### PR TITLE
🐛 fix responsive grid layout on story header

### DIFF
--- a/app/components/stories/StorySpeaker.tsx
+++ b/app/components/stories/StorySpeaker.tsx
@@ -18,10 +18,13 @@ const StorySpeaker: React.FunctionComponent<StorySpeakerProps> = ({
     <div
       className={css({
         display: 'grid',
-        gridTemplateColumns: 'auto 1fr',
         alignItems: 'center',
         gap: 8,
         py: 6,
+
+        md: {
+          gridTemplateColumns: 'auto 1fr',
+        },
       })}
     >
       <div>


### PR DESCRIPTION
Adds a responsive grid layout to the StorySpeaker component.
Previously, the grid template columns were set to a fixed
layout. This change adds a responsive layout that uses a
single column layout on small screens and switches to a
two-column layout on medium screens and larger.