### PR TITLE
fix(typography): apply French NBSP to frontmatter strings

### DIFF
--- a/app/components/blog/blog-item.tsx
+++ b/app/components/blog/blog-item.tsx
@@ -12,6 +12,7 @@ import type { BlogpostFrontmatter, MarkdocFile } from '~/types';
 import { getTag } from '~/utils/labels';
 import { url } from '~/utils/url';
 
+import { FrenchText } from '../typography/french-text';
 import { Avatar } from '../ui/Avatar';
 import { Tag } from '../ui/Tag';
 
@@ -118,7 +119,7 @@ const BlogItem: React.FunctionComponent<BlogItemProps> = React.memo(
               css({ mb: '3' }),
             )}
           >
-            {item.title}
+            <FrenchText>{item.title}</FrenchText>
           </h2>
 
           <div
@@ -165,7 +166,7 @@ const BlogItem: React.FunctionComponent<BlogItemProps> = React.memo(
               lineHeight: 'relaxed',
             })}
           >
-            {item.description}
+            <FrenchText>{item.description}</FrenchText>
           </p>
         </div>
         <p

--- a/app/components/blog/blog-list.tsx
+++ b/app/components/blog/blog-list.tsx
@@ -12,6 +12,8 @@ import { url } from '~/utils/url';
 
 import { BlogItem } from './blog-item';
 
+import { FrenchText } from '../typography/french-text';
+
 type BlogListItem = MarkdocFile<BlogpostFrontmatter> & {
   resolvedAuthor: ResolvedAuthor;
 };
@@ -128,7 +130,7 @@ const BlogList: React.FunctionComponent<BlogListProps> = ({ items }) => {
               lineHeight: 'tight',
             })}
           >
-            {featured.frontmatter.title}
+            <FrenchText>{featured.frontmatter.title}</FrenchText>
           </h2>
           <p
             className={css({
@@ -138,7 +140,7 @@ const BlogList: React.FunctionComponent<BlogListProps> = ({ items }) => {
               fontSize: 'sm',
             })}
           >
-            {featured.frontmatter.description}
+            <FrenchText>{featured.frontmatter.description}</FrenchText>
           </p>
           <span
             className={`${flex({ align: 'center', gap: '2' })} ${css({

--- a/app/components/blog/post-header.tsx
+++ b/app/components/blog/post-header.tsx
@@ -8,6 +8,8 @@ import { badge, text } from '@ocobo/styled-system/recipes';
 import type { BlogpostFrontmatter } from '~/types';
 import { getTag } from '~/utils/labels';
 
+import { FrenchText } from '../typography/french-text';
+
 const formatDate = (date: string, locale: string) =>
   new Intl.DateTimeFormat(locale, {
     day: 'numeric',
@@ -53,7 +55,7 @@ const PostHeader: React.FunctionComponent<BlogpostHeaderProps> = ({ item }) => {
           }),
         )}
       >
-        {item.title}
+        <FrenchText>{item.title}</FrenchText>
       </h1>
 
       <div

--- a/app/components/stories/story-header.tsx
+++ b/app/components/stories/story-header.tsx
@@ -5,6 +5,8 @@ import { text } from '@ocobo/styled-system/recipes';
 import { ASSETS_BASE_URL } from '~/config/assets';
 import type { StoryFrontmatter } from '~/types';
 
+import { FrenchText } from '../typography/french-text';
+
 interface StoryHeaderProps {
   item: StoryFrontmatter;
   slug: string;
@@ -29,7 +31,7 @@ const StoryHeader: React.FunctionComponent<StoryHeaderProps> = ({
             }),
           )}
         >
-          {item.title}
+          <FrenchText>{item.title}</FrenchText>
         </h1>
       </div>
 

--- a/app/components/stories/story-item.tsx
+++ b/app/components/stories/story-item.tsx
@@ -11,6 +11,8 @@ import type { Tool } from '~/modules/content';
 import type { MarkdocFile, StoryFrontmatter } from '~/types';
 import { url } from '~/utils/url';
 
+import { FrenchText } from '../typography/french-text';
+
 interface StoryItemProps {
   item: MarkdocFile<StoryFrontmatter>['frontmatter'];
   slug: string;
@@ -163,7 +165,7 @@ const StoryItem: React.FunctionComponent<StoryItemProps> = React.memo(
                 _hover: { color: 'black' },
               })}
             >
-              {item.title}
+              <FrenchText>{item.title}</FrenchText>
             </NavLink>
           </h2>
 
@@ -223,7 +225,7 @@ const StoryItem: React.FunctionComponent<StoryItemProps> = React.memo(
                   color: 'gray.400',
                 })}
               >
-                {item.role}
+                <FrenchText>{item.role}</FrenchText>
               </span>
             </div>
           </div>

--- a/app/components/stories/story-quote-block.tsx
+++ b/app/components/stories/story-quote-block.tsx
@@ -4,6 +4,8 @@ import { flex } from '@ocobo/styled-system/patterns';
 import { ASSETS_BASE_URL } from '~/config/assets';
 import type { StoryFrontmatter } from '~/types';
 
+import { FrenchText } from '../typography/french-text';
+
 interface StoryQuoteBlockProps {
   item: StoryFrontmatter;
   slug: string;
@@ -73,7 +75,7 @@ const StoryQuoteBlock: React.FunctionComponent<StoryQuoteBlockProps> = ({
             mb: '4',
           })}
         >
-          {item.role}
+          <FrenchText>{item.role}</FrenchText>
         </p>
         <p
           className={css({
@@ -83,7 +85,9 @@ const StoryQuoteBlock: React.FunctionComponent<StoryQuoteBlockProps> = ({
             maxW: 'md',
           })}
         >
-          <q>{quote}</q>
+          <q>
+            <FrenchText>{quote}</FrenchText>
+          </q>
         </p>
       </div>
     </blockquote>

--- a/app/components/typography/french-text.tsx
+++ b/app/components/typography/french-text.tsx
@@ -1,10 +1,11 @@
 import { useFrenchText } from '~/hooks/use-french-text';
 
 type FrenchTextProps = {
-  children: string;
+  children: string | null | undefined;
 };
 
 export function FrenchText({ children }: FrenchTextProps) {
   const transform = useFrenchText();
+  if (!children) return null;
   return <>{transform(children)}</>;
 }

--- a/app/components/typography/french-text.tsx
+++ b/app/components/typography/french-text.tsx
@@ -1,0 +1,10 @@
+import { useFrenchText } from '~/hooks/use-french-text';
+
+type FrenchTextProps = {
+  children: string;
+};
+
+export function FrenchText({ children }: FrenchTextProps) {
+  const transform = useFrenchText();
+  return <>{transform(children)}</>;
+}

--- a/app/utils/metatags.ts
+++ b/app/utils/metatags.ts
@@ -1,6 +1,7 @@
 import type { MetaFunction } from 'react-router';
 
 import { Language } from '~/localization/resources';
+import { applyFrenchTypography } from './typography';
 
 type GetMetaTagsParams = {
   title?: string;
@@ -38,20 +39,20 @@ const getMetaTags: (params: GetMetaTagsParams) => ReturnType<MetaFunction> = ({
   type = 'website',
   locale = 'fr',
 }) => {
+  const localised = locale === 'fr' ? applyFrenchTypography : (s: string) => s;
+  const finalTitle = localised(
+    getTitle(standaloneTitle, useCatchPhraseInTitle, title),
+  );
+  const finalDescription = localised(description);
+
   const metaTags = [
-    { title: getTitle(standaloneTitle, useCatchPhraseInTitle, title) },
-    {
-      name: 'og:title',
-      content: getTitle(standaloneTitle, useCatchPhraseInTitle, title),
-    },
+    { title: finalTitle },
+    { name: 'og:title', content: finalTitle },
     { name: 'og:locale', content: locale },
-    {
-      name: 'twitter:title',
-      content: getTitle(standaloneTitle, useCatchPhraseInTitle, title),
-    },
-    { name: 'description', content: description },
-    { name: 'og:description', content: description },
-    { name: 'twitter:description', content: description },
+    { name: 'twitter:title', content: finalTitle },
+    { name: 'description', content: finalDescription },
+    { name: 'og:description', content: finalDescription },
+    { name: 'twitter:description', content: finalDescription },
     { name: 'twitter:card', content: 'summary_large_image' },
     // { name: 'twitter:site', content: '' },
     // { name: 'twitter:creator', content: '' },


### PR DESCRIPTION
## Summary

The colon in French blog/story titles was line-breaking on the index pages — e.g. \`Structurer la croissance pour libérer la vente : l'exemple de Surfe\` rendered with the \`:\` orphaned at the start of the next line. Reported by client on the deployed preview.

Root cause: the existing French typography transform (\`applyFrenchTypography\` via \`useFrenchText\`) was wired into the Markdoc text-node pipeline only. Frontmatter strings reach the DOM through plain JSX (\`{item.title}\`, \`{item.description}\`, etc.) and bypassed it, so the regular space before \`:\`/\`?\`/\`!\`/\`;\` was line-breakable.

Fix: introduce a tiny \`<FrenchText>\` wrapper that calls the existing hook, and apply it at every JSX leaf that renders user-authored frontmatter on the blog and stories realign surfaces (titles, descriptions, speaker roles, quotes). No new logic, no schema change, no loader change.

## Files touched

- \`app/components/typography/french-text.tsx\` — new wrapper
- \`app/components/blog/{blog-item,blog-list,post-header}.tsx\`
- \`app/components/stories/{story-header,story-item,story-quote-block}.tsx\`

## Test plan

- [ ] Verify \`/blog\` index: featured card title and three list cards render with non-breaking space before \`:\` (no orphan colon at line start, in FR locale).
- [ ] Verify a blog article view (e.g. \`/blog/structurer-la-croissance-…\`): \`<h1>\` title applies NBSP.
- [ ] Verify \`/clients\` index: any title containing \`:\`/\`?\`/\`!\` no longer breaks.
- [ ] Verify a story detail page: header title and quote-block role/quote apply NBSP.
- [ ] Switch to EN locale on stories: text passes through unchanged (transform is a no-op outside FR).
- [ ] No layout regression on cards (NBSP shouldn't affect width measurably).