### PR TITLE
feat(contact): redesign contact page on new DS (#113)

### DIFF
--- a/app/components/contact/contact-card.tsx
+++ b/app/components/contact/contact-card.tsx
@@ -84,7 +84,6 @@ const formScopedStyles = css({
     px: '6',
     bg: 'ocobo.dark',
     color: 'white',
-    fontFamily: 'display',
     fontWeight: 'bold',
     fontSize: 'base',
     borderRadius: 'md',

--- a/app/components/contact/contact-card.tsx
+++ b/app/components/contact/contact-card.tsx
@@ -6,6 +6,100 @@ import { card, text } from '@ocobo/styled-system/recipes';
 
 import { FrenchText } from '~/components/typography/french-text';
 
+const inputBaseStyles = {
+  width: 'full',
+  px: '4',
+  py: '4',
+  bg: 'gray.50',
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: 'gray.100',
+  borderRadius: 'md',
+  color: 'ocobo.dark',
+  fontSize: 'base',
+  fontFamily: 'body',
+  outline: 'none',
+  transition: 'background 0.2s, border-color 0.2s',
+  _focus: {
+    bg: 'white',
+    borderColor: 'ocobo.dark',
+  },
+  _placeholder: { color: 'gray.300' },
+} as const;
+
+const labelBaseStyles = {
+  display: 'block',
+  fontSize: 'xs',
+  fontWeight: 'bold',
+  textTransform: 'uppercase',
+  letterSpacing: '0.2em',
+  color: 'gray.500',
+  mb: '2',
+} as const;
+
+const formScopedStyles = css({
+  '& .hbspt-form input[type="text"]': inputBaseStyles,
+  '& .hbspt-form input[type="email"]': inputBaseStyles,
+  '& .hbspt-form input[type="tel"]': inputBaseStyles,
+  '& .hbspt-form input[type="number"]': inputBaseStyles,
+  '& .hbspt-form select': inputBaseStyles,
+  '& .hbspt-form textarea': { ...inputBaseStyles, minHeight: '32' },
+
+  '& .hbspt-form label': labelBaseStyles,
+  '& .hbspt-form .hs-form-required': {
+    color: 'ocobo.coral',
+    ml: '1',
+  },
+
+  '& .hbspt-form .hs-form-field': { mb: '6' },
+
+  '& .hbspt-form .hs-error-msgs': { listStyle: 'none', mt: '2', p: '0' },
+  '& .hbspt-form .hs-error-msgs label': {
+    fontSize: 'xs',
+    fontWeight: 'normal',
+    textTransform: 'none',
+    letterSpacing: 'normal',
+    color: 'red.500',
+  },
+  '& .hbspt-form .hs-error-msg': {
+    fontSize: 'xs',
+    color: 'red.500',
+    fontWeight: 'normal',
+    textTransform: 'none',
+    letterSpacing: 'normal',
+    mt: '1',
+  },
+
+  '& .hbspt-form .form-columns-2': {
+    md: { display: 'flex', gap: '4' },
+  },
+  '& .hbspt-form .form-columns-2 > .hs-form-field': {
+    md: { flex: '1', minWidth: '0' },
+  },
+
+  '& .hbspt-form .hs-submit': { pt: '6' },
+  '& .hbspt-form .hs-button': {
+    width: 'full',
+    py: '4',
+    px: '6',
+    bg: 'ocobo.dark',
+    color: 'white',
+    fontFamily: 'display',
+    fontWeight: 'bold',
+    fontSize: 'base',
+    borderRadius: 'md',
+    borderWidth: '0',
+    cursor: 'pointer',
+    boxShadow: 'xl',
+    transition: 'background 0.2s, box-shadow 0.2s, transform 0.2s',
+    _hover: {
+      bg: 'black',
+      boxShadow: '2xl',
+      transform: 'translateY(-1px)',
+    },
+  },
+});
+
 type ContactCardProps = {
   children: ReactNode;
 };
@@ -23,6 +117,7 @@ export const ContactCard = ({ children }: ContactCardProps) => {
           position: 'relative',
           overflow: 'hidden',
         }),
+        formScopedStyles,
       )}
     >
       <div

--- a/app/components/contact/contact-card.tsx
+++ b/app/components/contact/contact-card.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { css, cx } from '@ocobo/styled-system/css';
+import { card, text } from '@ocobo/styled-system/recipes';
+
+import { FrenchText } from '~/components/typography/french-text';
+
+type ContactCardProps = {
+  children: ReactNode;
+};
+
+export const ContactCard = ({ children }: ContactCardProps) => {
+  const { t } = useTranslation('contact');
+
+  return (
+    <div
+      className={cx(
+        card({ padding: 'lg', tone: 'white', border: true }),
+        css({
+          p: { base: '8', md: '12' },
+          shadow: 'card',
+          position: 'relative',
+          overflow: 'hidden',
+        }),
+      )}
+    >
+      <div
+        className={css({
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          w: 'full',
+          h: '1',
+          bgGradient: 'to-r',
+          gradientFrom: 'ocobo.yellow',
+          gradientVia: 'ocobo.coral',
+          gradientTo: 'ocobo.sky',
+        })}
+      />
+      <h2
+        className={cx(
+          text({ variant: 'display-md-bold', color: 'dark' }),
+          css({ mb: '8' }),
+        )}
+      >
+        <FrenchText>{t('card.heading')}</FrenchText>
+      </h2>
+      {children}
+      <p
+        className={css({
+          textAlign: 'center',
+          fontSize: 'xs',
+          color: 'gray.400',
+          mt: '4',
+        })}
+      >
+        <FrenchText>{t('consent')}</FrenchText>
+      </p>
+    </div>
+  );
+};

--- a/app/components/contact/contact-hero.tsx
+++ b/app/components/contact/contact-hero.tsx
@@ -1,0 +1,129 @@
+import { Calendar, Check, MessageSquare } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import { css, cx } from '@ocobo/styled-system/css';
+import { text } from '@ocobo/styled-system/recipes';
+
+import { FrenchText } from '~/components/typography/french-text';
+
+type BulletKey = 'audit' | 'clarity' | 'zero';
+
+type BulletColor = 'mint' | 'sky' | 'yellow';
+
+const bulletIconColorStyles: Record<BulletColor, string> = {
+  mint: css({ bg: 'ocobo.mint.light', color: 'ocobo.mint' }),
+  sky: css({ bg: 'ocobo.sky.light', color: 'ocobo.sky' }),
+  yellow: css({ bg: 'ocobo.yellow.light', color: 'ocobo.yellow' }),
+};
+
+const bullets: ReadonlyArray<{
+  key: BulletKey;
+  Icon: LucideIcon;
+  color: BulletColor;
+}> = [
+  { key: 'audit', Icon: Check, color: 'mint' },
+  { key: 'clarity', Icon: MessageSquare, color: 'sky' },
+  { key: 'zero', Icon: Calendar, color: 'yellow' },
+];
+
+export const ContactHero = () => {
+  const { t } = useTranslation('contact');
+
+  return (
+    <div
+      className={css({
+        pt: { base: '0', lg: '10' },
+        lg: { position: 'sticky', top: '32' },
+      })}
+    >
+      <span
+        className={cx(
+          text({ variant: 'display-label', color: 'coral' }),
+          css({ display: 'block', mb: '4' }),
+        )}
+      >
+        <FrenchText>{t('eyebrow')}</FrenchText>
+      </span>
+      <h1
+        className={cx(
+          text({ variant: 'display-xl', color: 'dark' }),
+          css({ mb: '8' }),
+        )}
+      >
+        <Trans
+          i18nKey="title"
+          t={t}
+          components={[
+            <span
+              key="muted"
+              className={css({ color: 'gray.400', display: 'block' })}
+            />,
+          ]}
+        />
+      </h1>
+      <p
+        className={cx(
+          text({ variant: 'subtitle' }),
+          css({ color: 'gray.600', mb: '12' }),
+        )}
+      >
+        <FrenchText>{t('lead')}</FrenchText>
+      </p>
+      <ul
+        className={css({
+          listStyle: 'none',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '8',
+        })}
+      >
+        {bullets.map(({ key, Icon, color }) => (
+          <li
+            key={key}
+            className={css({
+              display: 'flex',
+              gap: '6',
+              alignItems: 'flex-start',
+            })}
+          >
+            <div
+              className={cx(
+                css({
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                  w: '12',
+                  h: '12',
+                  rounded: 'xl',
+                }),
+                bulletIconColorStyles[color],
+              )}
+            >
+              <Icon strokeWidth={3} size={20} />
+            </div>
+            <div>
+              <h3
+                className={cx(
+                  text({ variant: 'display-card', color: 'dark' }),
+                  css({ mb: '1' }),
+                )}
+              >
+                <FrenchText>{t(`bullets.${key}.title`)}</FrenchText>
+              </h3>
+              <p
+                className={cx(
+                  text({ variant: 'body' }),
+                  css({ color: 'gray.600' }),
+                )}
+              >
+                <FrenchText>{t(`bullets.${key}.description`)}</FrenchText>
+              </p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/app/routes/_main.($lang).contact.tsx
+++ b/app/routes/_main.($lang).contact.tsx
@@ -1,13 +1,11 @@
 import { LoaderFunctionArgs, type MetaFunction } from 'react-router';
 
-import { css, cx } from '@ocobo/styled-system/css';
 import { Container, Grid, GridItem } from '@ocobo/styled-system/jsx';
 import { section } from '@ocobo/styled-system/recipes';
 
 import { ContactForm } from '~/components/ContactForm';
 import { ContactCard } from '~/components/contact/contact-card';
 import { ContactHero } from '~/components/contact/contact-hero';
-import { Illustration } from '~/components/ui/Illustration';
 import i18nServer from '~/localization/i18n.server';
 import { getLang } from '~/utils/lang';
 import { getMetaTags } from '~/utils/metatags';
@@ -38,67 +36,19 @@ export const meta: MetaFunction<typeof loader> = ({ data, params }) => {
 
 export default function Index() {
   return (
-    <div
-      className={cx(
-        section(),
-        css({
-          position: 'relative',
-        }),
-      )}
-    >
-      <div
-        className={css({
-          position: 'absolute',
-          top: { base: '340px', lg: '0' },
-          left: { base: 0, lg: '50%' },
-          right: 0,
-          bottom: 0,
-          bgColor: 'coral.light',
-        })}
-      >
-        <div
-          className={css({
-            w: '140px',
-            right: '10%',
-            transform: 'translateY(-50%)',
-            position: 'absolute',
-            hideFrom: 'lg',
-          })}
-        >
-          <Illustration name="contact" />
-        </div>
-      </div>
+    <section className={section()}>
       <Container>
         <Grid columns={{ base: 1, lg: 2 }} gap="5rem">
           <GridItem>
             <ContactHero />
           </GridItem>
           <GridItem>
-            <div
-              className={css({
-                width: { base: 'full', xl: '2/3' },
-                mx: 'auto',
-                position: 'relative',
-              })}
-            >
-              <ContactCard>
-                <ContactForm />
-              </ContactCard>
-            </div>
+            <ContactCard>
+              <ContactForm />
+            </ContactCard>
           </GridItem>
         </Grid>
       </Container>
-      <div
-        className={css({
-          w: '400px',
-          mx: 'auto',
-          transform: 'translate(-30%, -20%)',
-          hideBelow: 'lg',
-          position: 'relative',
-        })}
-      >
-        <Illustration name="contact" />
-      </div>
-    </div>
+    </section>
   );
 }

--- a/app/routes/_main.($lang).contact.tsx
+++ b/app/routes/_main.($lang).contact.tsx
@@ -1,4 +1,3 @@
-import { Trans, useTranslation } from 'react-i18next';
 import { LoaderFunctionArgs, type MetaFunction } from 'react-router';
 
 import { css, cx } from '@ocobo/styled-system/css';
@@ -6,6 +5,7 @@ import { Container, Grid, GridItem } from '@ocobo/styled-system/jsx';
 import { section } from '@ocobo/styled-system/recipes';
 
 import { ContactForm } from '~/components/ContactForm';
+import { ContactHero } from '~/components/contact/contact-hero';
 import { Illustration } from '~/components/ui/Illustration';
 import i18nServer from '~/localization/i18n.server';
 import { getLang } from '~/utils/lang';
@@ -35,30 +35,7 @@ export const meta: MetaFunction<typeof loader> = ({ data, params }) => {
   });
 };
 
-const Description: React.FunctionComponent<
-  React.HTMLAttributes<HTMLDivElement>
-> = (props) => {
-  const { t } = useTranslation('contact');
-
-  const description = t('description', { returnObjects: true });
-
-  return (
-    <div {...props}>
-      {Array.isArray(description) &&
-        description.map((d, i) => (
-          <p key={i}>
-            <Trans i18nKey={d} components={[<strong key="strong" />]} />
-          </p>
-        ))}
-    </div>
-  );
-};
-
 export default function Index() {
-  const { t } = useTranslation('contact');
-
-  const title = t('title');
-
   return (
     <div
       className={cx(
@@ -93,48 +70,9 @@ export default function Index() {
       <Container>
         <Grid columns={{ base: 1, lg: 2 }} gap="5rem">
           <GridItem>
-            <div
-              className={css({
-                width: '3/4',
-                mx: 'auto',
-                pb: { base: '16', lg: '0' },
-              })}
-            >
-              <h1
-                className={css({
-                  fontFamily: 'display',
-                  fontSize: { base: '2xl', md: '3xl', lg: '4xl' },
-                  fontWeight: 'bold',
-                  color: 'ocobo.dark',
-                  letterSpacing: 'tight',
-                })}
-              >
-                <Trans
-                  i18nKey={title}
-                  components={[
-                    <span
-                      key="em"
-                      className={css({ color: 'coral', display: 'block' })}
-                    />,
-                  ]}
-                />
-              </h1>
-              <p
-                className={css({
-                  textStyle: 'large',
-                  bleft: 'coral',
-                  fontWeight: 'bold',
-                  mb: '6',
-                })}
-              >
-                {t('subtitle')}
-              </p>
-              <Description
-                className={css({ textStyle: 'medium', hideBelow: 'lg' })}
-              />
-            </div>
+            <ContactHero />
           </GridItem>
-          <GridItem className={css({})}>
+          <GridItem>
             <div
               className={css({
                 width: { base: 'full', xl: '2/3' },
@@ -142,17 +80,7 @@ export default function Index() {
                 position: 'relative',
               })}
             >
-              <ContactForm>
-                <Description
-                  className={css({
-                    hideFrom: 'lg',
-                    textAlign: 'center',
-                    w: '2/3',
-                    mx: 'auto',
-                    my: '6',
-                  })}
-                />
-              </ContactForm>
+              <ContactForm />
             </div>
           </GridItem>
         </Grid>

--- a/app/routes/_main.($lang).contact.tsx
+++ b/app/routes/_main.($lang).contact.tsx
@@ -5,6 +5,7 @@ import { Container, Grid, GridItem } from '@ocobo/styled-system/jsx';
 import { section } from '@ocobo/styled-system/recipes';
 
 import { ContactForm } from '~/components/ContactForm';
+import { ContactCard } from '~/components/contact/contact-card';
 import { ContactHero } from '~/components/contact/contact-hero';
 import { Illustration } from '~/components/ui/Illustration';
 import i18nServer from '~/localization/i18n.server';
@@ -80,7 +81,9 @@ export default function Index() {
                 position: 'relative',
               })}
             >
-              <ContactForm />
+              <ContactCard>
+                <ContactForm />
+              </ContactCard>
             </div>
           </GridItem>
         </Grid>

--- a/docs/adr/0001-design-system-adoption-policy.md
+++ b/docs/adr/0001-design-system-adoption-policy.md
@@ -119,7 +119,6 @@ These component files were migrated in #86–#91 but retain a small number of in
 | `app/components/offer/symptoms-section.tsx` | 1 | Symptom card number |
 | `app/components/jobs/about-ocobo-section.tsx` | 1 | h5 at `fontSize: lg` — no `text` variant at this size |
 | `app/components/jobs/detail/scrollspy-toc.tsx` | 1 | Nav label at `fontSize: xs` — too small for display variants |
-| `app/routes/_main.($lang).contact.tsx` | 1 | Contact route heading |
 
 Running `grep -rn "fontFamily.*display" app/ --include="*.tsx"` should return only the files listed in the two tables above. Any hit outside these tables is a policy violation.
 

--- a/locales/en/contact.json
+++ b/locales/en/contact.json
@@ -1,12 +1,17 @@
 {
   "meta.title": "Contact us",
   "meta.description": "Contact page description",
-  "title": "Meet a real Revenue Operations specialist. <0>Not an SDR or a BDR.</0>",
-  "subtitle": "After filling in the form, you will be asked to choose an appointment time.",
-  "description": [
-    "During our <0>first exchange</0>, we determine if, and how, we can help you.",
-    "Then, we develop for you <0>a customized plan</0>, which we will execute to achieve your goals together."
-  ],
+
+  "eyebrow": "First consultation",
+  "title": "Talk to an architect. <0>Not to a salesperson.</0>",
+  "lead": "In 30 minutes, we assess the maturity of your revenue engine and identify your immediate growth levers.",
+
+  "bullets.audit.title": "Flash audit",
+  "bullets.audit.description": "Quick diagnostic of your current processes and stack.",
+  "bullets.clarity.title": "Radical clarity",
+  "bullets.clarity.description": "Immediate strategic recommendations, no jargon.",
+  "bullets.zero.title": "Zero commitment",
+  "bullets.zero.description": "A peer-to-peer conversation to assess if a collaboration makes sense.",
 
   "form.email": "Professional e-mail",
   "form.firstname": "First name",

--- a/locales/en/contact.json
+++ b/locales/en/contact.json
@@ -13,6 +13,9 @@
   "bullets.zero.title": "Zero commitment",
   "bullets.zero.description": "A peer-to-peer conversation to assess if a collaboration makes sense.",
 
+  "card.heading": "Tell us more about your challenges",
+  "consent": "By clicking, you agree to be contacted by the Ocobo team.",
+
   "form.email": "Professional e-mail",
   "form.firstname": "First name",
   "form.lastname": "Last name",

--- a/locales/fr/contact.json
+++ b/locales/fr/contact.json
@@ -13,6 +13,9 @@
   "bullets.zero.title": "Zéro engagement",
   "bullets.zero.description": "Un échange entre pairs pour valider la pertinence d'une collaboration.",
 
+  "card.heading": "Dites-nous en plus sur vos enjeux",
+  "consent": "En cliquant, vous acceptez d'être recontacté par l'équipe Ocobo.",
+
   "form.email": "E-mail professionnel",
   "form.firstname": "Prénom",
   "form.lastname": "Nom",

--- a/locales/fr/contact.json
+++ b/locales/fr/contact.json
@@ -1,12 +1,17 @@
 {
   "meta.title": "Contactez-nous",
   "meta.description": "Rencontrez un vrai spécialiste des Revenue Operations.",
-  "title": "Rencontrez un vrai spécialiste des Revenue Operations. <0>Pas un SDR ni un BDR.</0>",
-  "subtitle": "Après avoir rempli le formulaire, vous serez invité à choisir un horaire de rendez-vous.",
-  "description": [
-    "Lors de notre <0>premier échange</0>, nous déterminons si, et comment, nous pouvons vous aider.",
-    "Ensuite, nous élaborons pour vous <0>un plan sur mesure</0>, que nous exécuterons pour atteindre ensemble vos objectifs."
-  ],
+
+  "eyebrow": "Première consultation",
+  "title": "Parlez à un architecte. <0>Pas à un vendeur.</0>",
+  "lead": "En 30 minutes, nous analysons la maturité de votre machine revenue et identifions vos leviers de croissance immédiats.",
+
+  "bullets.audit.title": "Audit flash",
+  "bullets.audit.description": "Diagnostic rapide de vos processus actuels et de votre stack.",
+  "bullets.clarity.title": "Clarté radicale",
+  "bullets.clarity.description": "Recommandations stratégiques immédiates, sans jargon.",
+  "bullets.zero.title": "Zéro engagement",
+  "bullets.zero.description": "Un échange entre pairs pour valider la pertinence d'une collaboration.",
 
   "form.email": "E-mail professionnel",
   "form.firstname": "Prénom",

--- a/progress.txt
+++ b/progress.txt
@@ -820,3 +820,58 @@ Decisions:
   done. No script change needed.
 
 Checks: pnpm check ✅ pnpm typecheck ✅
+
+---
+
+## Feature: Contact page redesign (#113)
+
+Specs: github.com/ocobo-revops/website#113
+Slices: #114 → #115 → #116 → #117
+Branch: feat/contact-redesign
+Created: 2026-05-06
+
+Reference:
+- Prototype: prototype-seven-delta.vercel.app/#/contact
+- Source: ../prototype/pages/Contact.tsx
+
+Key decisions before code:
+- Form integration = option A: keep HubSpot embed + Distro untouched, restyle
+  via scoped CSS only (slices #115/#116/#117). Distro depends on the
+  hsForm_<formId> element, so .hbspt-form DOM tree must not be modified.
+- Tokens: ocobo.* already exist (preset/tokens/colors.ts) — no preset changes.
+- ADR-0001 occurrence in _main.($lang).contact.tsx resolved by slice #117.
+
+Resumption checklist:
+1. Read top-of-file Codebase Patterns
+2. Read #113 PRD + the next slice issue (#114/#115/#116/#117)
+3. One commit + log entry per slice + pause for feedback
+4. After #115/#116/#117: manual non-regression — submit form, verify Distro
+   inline calendar still appears
+
+### Slice #114 — 12acc62
+
+ContactHero left column + new i18n keys.
+
+Files:
+- app/components/contact/contact-hero.tsx (new)
+- app/routes/_main.($lang).contact.tsx (replaced left col block, dropped
+  inline Description component + obsolete title/subtitle/description handling)
+- locales/{fr,en}/contact.json (added eyebrow, lead, bullets.*, rewrote title
+  with <0> muted span; dropped obsolete subtitle + description array)
+
+Decisions / deviations:
+- iconBox recipe sizes (sm/md/xl/lg) don't include w-12/h-12 — used inline
+  css for the box layout, paired with static color maps (mint/sky/yellow) per
+  Panda CSS static-analysis memory note.
+- text() variants picked: display-label (eyebrow), display-xl (h1),
+  subtitle (lead), display-card (bullet titles), body (bullet descriptions).
+- FrenchText wraps eyebrow/lead/bullet strings; title goes through Trans for
+  the muted-span slot (no double punctuation in current copy → NBSP no-op,
+  but FrenchText future-proofs the strings).
+- ContactForm now rendered without children (mobile duplicate Description
+  was redundant with ContactHero stacking on mobile).
+
+Checks: pnpm typecheck ✅ pnpm check ✅ pnpm test 262 ✅
+
+Next ⏭️ slice: #115 (form chrome restyle)
+

--- a/progress.txt
+++ b/progress.txt
@@ -873,5 +873,32 @@ Decisions / deviations:
 
 Checks: pnpm typecheck ✅ pnpm check ✅ pnpm test 262 ✅
 
-Next ⏭️ slice: #115 (form chrome restyle)
+Next ⏭️ slice: #115 (ContactCard shell)
+
+### Slice #115 — 3c77eb6
+
+ContactCard shell wrapping HubSpot embed.
+
+Files:
+- app/components/contact/contact-card.tsx (new)
+- app/routes/_main.($lang).contact.tsx (wraps ContactForm in ContactCard)
+- locales/{fr,en}/contact.json (added card.heading, consent)
+
+Decisions / deviations:
+- card() recipe gives padding md and shadow sm by default; overrode with
+  responsive p:{base:8, md:12} + shadow:card to match prototype. The "no
+  inline rounded+border+shadow combo" rule is respected — recipe owns
+  rounded+border, only shadow is overridden.
+- Heading uses display-md-bold (display, 2xl, bold) to match the prototype
+  card heading (fontSize:2xl + display + bold).
+- overflow:hidden on the card so the gradient top bar respects the rounded
+  corners (1px h bar would otherwise sit flush on the card edges).
+- ContactForm component itself untouched — Distro contract on .hbspt-form
+  preserved.
+
+Checks: pnpm typecheck ✅ pnpm check ✅ pnpm test 262 ✅
+
+Manual non-regression pending: form submit → Distro inline calendar.
+
+Next ⏭️ slice: #116 (form chrome restyle)
 

--- a/progress.txt
+++ b/progress.txt
@@ -902,3 +902,33 @@ Manual non-regression pending: form submit → Distro inline calendar.
 
 Next ⏭️ slice: #116 (form chrome restyle)
 
+### Slice #116 — dfd3f08
+
+Scoped CSS restyle of HubSpot embed inputs.
+
+Files:
+- app/components/contact/contact-card.tsx (added formScopedStyles block)
+
+Decisions / deviations:
+- Used Panda nested selector keys (`'& .hbspt-form input[type="text"]'`,
+  etc.) on the card root via cx(). Each selector is a separate key —
+  comma-grouped selectors avoided to keep Panda parsing predictable.
+- Shared `inputBaseStyles` const reused across input/email/tel/number/
+  select/textarea (textarea adds minHeight:32). Pure object literal
+  (with `as const`), composed into the css() call — Panda extracts the
+  literal values at build time.
+- form-columns-2 flex layout applies at `md` breakpoint via Panda
+  nested responsive keys.
+- No `!important` was needed — HubSpot's injected styles lose to our
+  scoped declarations because our class is more specific (descendant
+  combinator + class on card root).
+- Submit button uses `font: display` to match the prototype CTA; non-DS
+  but matches the rest of the dark CTA family in the codebase.
+
+Checks: pnpm typecheck ✅ pnpm check ✅ pnpm test 262 ✅
+
+Manual non-regression pending: form submit → Distro inline calendar +
+field validation messages.
+
+Next ⏭️ slice: #117 (route ADR-0001 cleanup)
+

--- a/progress.txt
+++ b/progress.txt
@@ -932,3 +932,37 @@ field validation messages.
 
 Next ⏭️ slice: #117 (route ADR-0001 cleanup)
 
+### Slice #117 — (commit pending)
+
+Final route cleanup + ADR-0001 deferred occurrence closed.
+
+Files:
+- app/routes/_main.($lang).contact.tsx (rewritten — minimal, idiomatic)
+- app/components/contact/contact-card.tsx (drop fontFamily:'display' on
+  the .hs-button override; uses default sans + bold)
+- docs/adr/0001-design-system-adoption-policy.md (remove route row from
+  Deferred per-feature occurrences table)
+
+Decisions / deviations:
+- Dropped both Illustration placements (desktop + mobile) — prototype
+  doesn't include them; the right-column ContactCard already carries the
+  brand presence via the gradient bar.
+- Dropped the coral-tinted absolute bg div + blur child — same reason.
+- Dropped the inner xl:2/3 + mx:auto centering div around ContactCard;
+  prototype keeps the form col simple. GridItem owns the column width.
+- Outer wrapper now <section className={section()}> + <Container>; no
+  inline cx(section(), css({position:relative})) anymore.
+- Submit button override no longer carries inline fontFamily:'display'.
+  button() recipe convention is sans + semibold; my .hs-button uses
+  sans + bold (slightly heavier weight matching the prototype CTA).
+
+ADR-0001 invariant verified: contact route + contact-card.tsx no longer
+appear in `grep -rn 'fontFamily.*display' app/ --include='*.tsx'`.
+
+Checks: pnpm typecheck ✅ pnpm check ✅ pnpm test 262 ✅
+
+Manual non-regression pending: page renders fr/en, form submit →
+Distro inline calendar.
+
+Feature done — ready to push + open PR for #113.
+


### PR DESCRIPTION
## Summary

Migrates the contact page to the new design system, matching the prototype reference (https://prototype-seven-delta.vercel.app/#/contact). Closes the ADR-0001 deferred occurrence for this route.

Vertical-slice delivery — 4 atomic feature commits (one per child issue) plus 4 progress-log chores.

| Slice | Commit | Issue | What |
|-------|--------|-------|------|
| 1 | `12acc62` | #114 | `ContactHero` left column + new i18n keys |
| 2 | `3c77eb6` | #115 | `ContactCard` shell wrapping HubSpot embed |
| 3 | `dfd3f08` | #116 | Scoped CSS restyle of HubSpot embed inputs |
| 4 | `0a4ae1f` | #117 | Drop legacy decorations, adopt `section()` + close ADR-0001 deferred row |

## Changes

- **New components:** `app/components/contact/contact-hero.tsx`, `app/components/contact/contact-card.tsx`
- **Route:** `app/routes/_main.($lang).contact.tsx` — minimal `<section>` + `<Container>` shell, two-column grid, sticky hero on `lg+`. No inline `fontFamily:'display'`, no inline `maxW:'7xl'`/`mx:'auto'`, no inline `rounded`+`border`+`shadow` combos.
- **Locales:** `locales/{fr,en}/contact.json` — added `eyebrow`, `lead`, `bullets.{audit,clarity,zero}.*`, `card.heading`, `consent`; rewrote `title` with `<0>…</0>` muted span; dropped obsolete `subtitle` + `description`.
- **HubSpot embed:** untouched. Distro `hsForm_<formId>` hook preserved. Field/label/button styling applied via CSS descendant selectors scoped under `.hbspt-form` inside `ContactCard` — no global rules, no `!important`.
- **ADR-0001:** removed `app/routes/_main.($lang).contact.tsx` from the "Deferred per-feature occurrences" table.

## Test plan

- [ ] `pnpm typecheck` ✅ (verified locally)
- [ ] `pnpm check` ✅ (verified locally)
- [ ] `pnpm test --run` — 262/262 ✅ (verified locally)
- [ ] Load `/fr/contact` and `/en/contact` — hero renders, headline second line is muted, sticky hero on `lg+`, mobile stacks
- [ ] Form fields visually match prototype (gray-50 bg, dark border on focus, side-by-side first/last name on `md+`)
- [ ] Submit form → Distro inline calendar still appears
- [ ] Field validation messages still render in red
- [ ] `grep -rn "fontFamily.*display" app/ --include="*.tsx"` — contact route + `app/components/contact/` no longer present in output

Closes #114, closes #115, closes #116, closes #117. Closes #113.