### PR TITLE
feat(ds): extend card recipe with shadow + xl padding variants

### DIFF
--- a/app/components/contact/contact-card.tsx
+++ b/app/components/contact/contact-card.tsx
@@ -87,7 +87,7 @@ const formScopedStyles = css({
     fontWeight: 'bold',
     fontSize: 'base',
     borderRadius: 'md',
-    borderWidth: '0',
+    border: 'none',
     cursor: 'pointer',
     boxShadow: 'xl',
     transition: 'background 0.2s, box-shadow 0.2s, transform 0.2s',
@@ -109,10 +109,8 @@ export const ContactCard = ({ children }: ContactCardProps) => {
   return (
     <div
       className={cx(
-        card({ padding: 'lg', tone: 'white', border: true }),
+        card({ padding: 'xl', shadow: 'card', tone: 'white', border: true }),
         css({
-          p: { base: '8', md: '12' },
-          shadow: 'card',
           position: 'relative',
           overflow: 'hidden',
         }),

--- a/preset/recipes/card.ts
+++ b/preset/recipes/card.ts
@@ -7,13 +7,13 @@ export const card = defineRecipe({
   base: {
     display: 'flex',
     flexDirection: 'column',
-    boxShadow: 'sm',
   },
   variants: {
     padding: {
       sm: { p: '4' },
       md: { p: '6' },
       lg: { p: '8' },
+      xl: { p: { base: '8', md: '12' } },
     },
     radius: {
       md: { borderRadius: '2xl' },
@@ -31,11 +31,18 @@ export const card = defineRecipe({
       },
       false: {},
     },
+    shadow: {
+      none: { boxShadow: 'none' },
+      sm: { boxShadow: 'sm' },
+      card: { boxShadow: 'card' },
+      elevated: { boxShadow: 'xl' },
+    },
   },
   defaultVariants: {
     padding: 'md',
     radius: 'md',
     tone: 'white',
     border: true,
+    shadow: 'sm',
   },
 });


### PR DESCRIPTION
## Summary
- Adds `shadow` variant (`none | sm | card | elevated`) and `padding.xl` (`{ base: '8', md: '12' }`) to the `card` Panda recipe so callers stop layering inline `css({ shadow, p })` next to `card()`.
- Migrates `app/components/contact/contact-card.tsx` as the canonical call site: `card({ padding: 'xl', shadow: 'card', tone: 'white', border: true })` with no surrounding `p`/`shadow` override — removes the soft ADR-0001 violation flagged in PR #118.
- Tiny readability rider in the same file: `borderWidth: '0'` → `border: 'none'` inside the `.hs-button` scoped styles.

Out of scope: sweeping the other `shadow:`-adjacent `card()` callers across home/offer/jobs. Tracked separately under DS-adoption follow-ups.

Closes #119.

## Test plan
- [x] `pnpm panda codegen && pnpm panda cssgen --clean` runs clean
- [x] `pnpm typecheck` green
- [x] `pnpm check` green
- [x] `pnpm test --run` — 265/265 passing
- [ ] Manual: `/contact` renders identically (padding + shadow + gradient bar)
- [ ] Manual: `app/routes/design-system.tsx` card showcase still renders without regression