### PR TITLE
feat(blog): podcast ID frontmatter + Ausha player + filter (#110)

### DIFF
--- a/app/components/blog/blog-article.tsx
+++ b/app/components/blog/blog-article.tsx
@@ -10,11 +10,13 @@ import type { TocEntry } from '~/modules/content/toc';
 import type { BlogpostFrontmatter, MarkdocFile } from '~/types';
 import { url } from '~/utils/url';
 
+import { selectArticleFooter } from '~/modules/article-footer';
+
 import { BlogToc } from './blog-toc';
 import { PostHeader } from './post-header';
 
 import { LayoutPost } from '../LayoutPost';
-import { PageMarkdownContainer } from '../PageMarkdownContainer';
+import { AushaPlayer, PageMarkdownContainer } from '../PageMarkdownContainer';
 import { PlayerYoutube } from '../PlayerYoutube';
 import { MemberCard } from '../member/member-card';
 
@@ -81,9 +83,17 @@ const BlogArticle: React.FunctionComponent<BlogArticleProps> = ({
             </p>
           )}
           <PageMarkdownContainer content={article.content} />
-          {article.frontmatter.youtubeId && (
+          {selectArticleFooter(article.frontmatter) === 'youtube' && (
             <PlayerYoutube
-              id={article.frontmatter.youtubeId}
+              id={article.frontmatter.youtubeId!}
+              className={css({ mt: 8 })}
+            />
+          )}
+          {selectArticleFooter(article.frontmatter) === 'podcast' && (
+            <AushaPlayer
+              podcastId={article.frontmatter.podcastId}
+              showId={article.frontmatter.podcastShowId}
+              title={t('player.podcast.title')}
               className={css({ mt: 8 })}
             />
           )}

--- a/app/components/blog/blog-list.tsx
+++ b/app/components/blog/blog-list.tsx
@@ -1,10 +1,11 @@
 import { ArrowRight } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router';
 
 import { css, cx } from '@ocobo/styled-system/css';
 import { flex, grid } from '@ocobo/styled-system/patterns';
-import { text } from '@ocobo/styled-system/recipes';
+import { button, text } from '@ocobo/styled-system/recipes';
 
 import type { ResolvedAuthor } from '~/modules/content/members';
 import type { BlogpostFrontmatter, MarkdocFile } from '~/types';
@@ -24,6 +25,11 @@ interface BlogListProps {
 
 const BlogList: React.FunctionComponent<BlogListProps> = ({ items }) => {
   const { t } = useTranslation('blog');
+  const [podcastsOnly, setPodcastsOnly] = useState(false);
+
+  const filteredItems = podcastsOnly
+    ? items.filter((item) => Boolean(item.frontmatter.podcastId))
+    : items;
 
   if (items.length === 0) {
     return (
@@ -47,117 +53,151 @@ const BlogList: React.FunctionComponent<BlogListProps> = ({ items }) => {
     );
   }
 
-  const [featured, ...rest] = items;
+  const [featured, ...rest] = filteredItems;
 
   return (
     <div className={css({ py: { base: 8, lg: 16 } })}>
-      {/* Featured post */}
-      <NavLink
-        to={`${url.blog}/${featured.slug}`}
-        aria-label={featured.frontmatter.title}
-        className={`${grid({ columns: { base: 1, md: 2 } })} ${css({
-          rounded: '3xl',
-          overflow: 'hidden',
-          bg: 'ocobo.dark',
-          color: 'white',
-          shadow: '2xl',
-          mb: '16',
-          transition: 'transform',
-          _hover: { transform: 'translateY(-4px)' },
-        })}`}
+      {/* Filter toggle */}
+      <div
+        className={`${flex({ gap: '2', wrap: 'wrap' })} ${css({ mb: '10' })}`}
       >
-        {/* Image */}
-        <div
-          className={css({
-            position: 'relative',
-            overflow: 'hidden',
-            minH: { base: '56', md: 'auto' },
+        <button
+          type="button"
+          className={button({
+            variant: podcastsOnly ? 'outline' : 'solid',
+            size: 'sm',
           })}
+          onClick={() => setPodcastsOnly(false)}
         >
-          <img
-            src={featured.frontmatter.image}
-            alt=""
-            loading="eager"
-            decoding="async"
-            fetchPriority="high"
-            className={css({
-              position: 'absolute',
-              inset: 0,
-              w: 'full',
-              h: 'full',
-              objectFit: 'cover',
-              opacity: 0.8,
-            })}
-          />
+          {t('filter.all')}
+        </button>
+        <button
+          type="button"
+          className={button({
+            variant: podcastsOnly ? 'solid' : 'outline',
+            size: 'sm',
+          })}
+          onClick={() => setPodcastsOnly(true)}
+        >
+          {t('filter.podcastsOnly')}
+        </button>
+      </div>
+
+      {/* Posts */}
+      {filteredItems.length === 0 && (
+        <p className={css({ color: 'gray.500', fontSize: 'sm' })}>
+          {t('empty.subtitle')}
+        </p>
+      )}
+      {/* Featured post */}
+      {featured && (
+        <NavLink
+          to={`${url.blog}/${featured.slug}`}
+          aria-label={featured.frontmatter.title}
+          className={`${grid({ columns: { base: 1, md: 2 } })} ${css({
+            rounded: '3xl',
+            overflow: 'hidden',
+            bg: 'ocobo.dark',
+            color: 'white',
+            shadow: '2xl',
+            mb: '16',
+            transition: 'transform',
+            _hover: { transform: 'translateY(-4px)' },
+          })}`}
+        >
+          {/* Image */}
           <div
             className={css({
-              position: 'absolute',
-              inset: 0,
-              bgGradient: 'to-r',
-              gradientFrom: 'ocobo.dark/90',
-              gradientTo: 'transparent',
+              position: 'relative',
+              overflow: 'hidden',
+              minH: { base: '56', md: 'auto' },
             })}
-          />
-        </div>
+          >
+            <img
+              src={featured.frontmatter.image}
+              alt=""
+              loading="eager"
+              decoding="async"
+              fetchPriority="high"
+              className={css({
+                position: 'absolute',
+                inset: 0,
+                w: 'full',
+                h: 'full',
+                objectFit: 'cover',
+                opacity: 0.8,
+              })}
+            />
+            <div
+              className={css({
+                position: 'absolute',
+                inset: 0,
+                bgGradient: 'to-r',
+                gradientFrom: 'ocobo.dark/90',
+                gradientTo: 'transparent',
+              })}
+            />
+          </div>
 
-        {/* Content */}
-        <div
-          className={`${flex({ direction: 'column', justify: 'center', align: 'start', gap: '0' })} ${css({ p: { base: '10', md: '16' } })}`}
-        >
-          <span
-            className={css({
-              bg: 'ocobo.yellow',
-              color: 'ocobo.dark',
-              px: '3',
-              py: '1',
-              rounded: 'base',
-              fontSize: 'xs',
-              fontWeight: 'bold',
-              textTransform: 'uppercase',
-              letterSpacing: 'widest',
-              mb: '6',
-              display: 'inline-block',
-            })}
+          {/* Content */}
+          <div
+            className={`${flex({ direction: 'column', justify: 'center', align: 'start', gap: '0' })} ${css({ p: { base: '10', md: '16' } })}`}
           >
-            {t('featured.badge')}
-          </span>
-          <h2
-            className={css({
-              fontFamily: 'display',
-              fontSize: { base: '2xl', md: '3xl' },
-              fontWeight: 'bold',
-              mb: '4',
-              lineHeight: 'tight',
-            })}
-          >
-            <FrenchText>{featured.frontmatter.title}</FrenchText>
-          </h2>
-          <p
-            className={css({
-              color: 'gray.400',
-              mb: '8',
-              lineHeight: 'relaxed',
-              fontSize: 'sm',
-            })}
-          >
-            <FrenchText>{featured.frontmatter.description}</FrenchText>
-          </p>
-          <span
-            className={`${flex({ align: 'center', gap: '2' })} ${css({
-              bg: 'white',
-              color: 'ocobo.dark',
-              px: '6',
-              py: '3',
-              rounded: 'full',
-              fontSize: 'sm',
-              fontWeight: 'bold',
-            })}`}
-          >
-            {t('see_more', { ns: 'common' })}
-            <ArrowRight size={14} />
-          </span>
-        </div>
-      </NavLink>
+            <span
+              className={css({
+                bg: 'ocobo.yellow',
+                color: 'ocobo.dark',
+                px: '3',
+                py: '1',
+                rounded: 'base',
+                fontSize: 'xs',
+                fontWeight: 'bold',
+                textTransform: 'uppercase',
+                letterSpacing: 'widest',
+                mb: '6',
+                display: 'inline-block',
+              })}
+            >
+              {t('featured.badge')}
+            </span>
+            <h2
+              className={css({
+                fontFamily: 'display',
+                fontSize: { base: '2xl', md: '3xl' },
+                fontWeight: 'bold',
+                mb: '4',
+                lineHeight: 'tight',
+              })}
+            >
+              <FrenchText>{featured.frontmatter.title}</FrenchText>
+            </h2>
+            <p
+              className={css({
+                color: 'gray.400',
+                mb: '8',
+                lineHeight: 'relaxed',
+                fontSize: 'sm',
+              })}
+            >
+              <FrenchText>{featured.frontmatter.description}</FrenchText>
+            </p>
+            <span
+              className={`${flex({ align: 'center', gap: '2' })} ${css({
+                bg: 'white',
+                color: 'ocobo.dark',
+                px: '6',
+                py: '3',
+                rounded: 'full',
+                fontSize: 'sm',
+                fontWeight: 'bold',
+              })}`}
+            >
+              {t('see_more', { ns: 'common' })}
+              <ArrowRight size={14} />
+            </span>
+          </div>
+        </NavLink>
+      )}
 
       {/* Rest of posts */}
       {rest.length > 0 && (

--- a/app/modules/article-footer.test.ts
+++ b/app/modules/article-footer.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { selectArticleFooter } from './article-footer';
+
+describe('selectArticleFooter', () => {
+  it('returns podcast when podcastId is present', () => {
+    expect(
+      selectArticleFooter({
+        podcastId: '4Pg3gfj8z0gx',
+        youtubeId: 'dQw4w9WgXcQ',
+      }),
+    ).toBe('podcast');
+  });
+
+  it('returns youtube when only youtubeId is present', () => {
+    expect(selectArticleFooter({ youtubeId: 'dQw4w9WgXcQ' })).toBe('youtube');
+  });
+
+  it('returns none when neither is present', () => {
+    expect(selectArticleFooter({})).toBe('none');
+  });
+
+  it('returns podcast over youtube (priority)', () => {
+    expect(
+      selectArticleFooter({
+        podcastId: '4Pg3gfj8z0gx',
+        youtubeId: 'dQw4w9WgXcQ',
+      }),
+    ).toBe('podcast');
+  });
+});

--- a/app/modules/article-footer.ts
+++ b/app/modules/article-footer.ts
@@ -1,0 +1,14 @@
+type ArticleFooterType = 'podcast' | 'youtube' | 'none';
+
+type ArticleFooterInput = {
+  podcastId?: string;
+  youtubeId?: string;
+};
+
+export const selectArticleFooter = (
+  frontmatter: ArticleFooterInput,
+): ArticleFooterType => {
+  if (frontmatter.podcastId) return 'podcast';
+  if (frontmatter.youtubeId) return 'youtube';
+  return 'none';
+};

--- a/app/modules/podcast-embed-config.test.ts
+++ b/app/modules/podcast-embed-config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  REVENUE_ECHOES_SHOW_ID,
+  resolvePodcastEmbed,
+} from './podcast-embed-config';
+
+describe('podcast-embed-config', () => {
+  describe('REVENUE_ECHOES_SHOW_ID', () => {
+    it('is the expected constant', () => {
+      expect(REVENUE_ECHOES_SHOW_ID).toBe('wN6XqFGL519L');
+    });
+  });
+
+  describe('resolvePodcastEmbed', () => {
+    it('uses the default show ID when none provided', () => {
+      const result = resolvePodcastEmbed({ podcastId: '4Pg3gfj8z0gx' });
+      expect(result.showId).toBe(REVENUE_ECHOES_SHOW_ID);
+      expect(result.podcastId).toBe('4Pg3gfj8z0gx');
+    });
+
+    it('uses a custom show ID when provided', () => {
+      const result = resolvePodcastEmbed({
+        podcastId: '4Pg3gfj8z0gx',
+        showId: 'customShow123',
+      });
+      expect(result.showId).toBe('customShow123');
+    });
+
+    it('builds the correct Ausha embed src', () => {
+      const result = resolvePodcastEmbed({ podcastId: '4Pg3gfj8z0gx' });
+      expect(result.src).toBe(
+        `https://www.ausha.co/podcast/${REVENUE_ECHOES_SHOW_ID}/episode/4Pg3gfj8z0gx/embed`,
+      );
+    });
+  });
+});

--- a/app/modules/podcast-embed-config.ts
+++ b/app/modules/podcast-embed-config.ts
@@ -1,0 +1,19 @@
+export const REVENUE_ECHOES_SHOW_ID = 'wN6XqFGL519L';
+
+type PodcastEmbedConfig = {
+  podcastId: string;
+  showId: string;
+  src: string;
+};
+
+export const resolvePodcastEmbed = ({
+  podcastId,
+  showId = REVENUE_ECHOES_SHOW_ID,
+}: {
+  podcastId: string;
+  showId?: string;
+}): PodcastEmbedConfig => ({
+  podcastId,
+  showId,
+  src: `https://www.ausha.co/podcast/${showId}/episode/${podcastId}/embed`,
+});

--- a/app/modules/schemas.test.ts
+++ b/app/modules/schemas.test.ts
@@ -233,6 +233,43 @@ describe('Zod Schemas Validation', () => {
         }
       }
     });
+
+    it('should accept a valid 12-char alphanumeric podcastId', () => {
+      const result = BlogpostFrontmatterSchema.safeParse({
+        ...validBlogData,
+        podcastId: '4Pg3gfj8z0gx',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept a valid 12-char alphanumeric podcastShowId', () => {
+      const result = BlogpostFrontmatterSchema.safeParse({
+        ...validBlogData,
+        podcastShowId: 'wN6XqFGL519L',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject podcastId with wrong length', () => {
+      const result = BlogpostFrontmatterSchema.safeParse({
+        ...validBlogData,
+        podcastId: 'tooshort',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject podcastId with non-alphanumeric characters', () => {
+      const result = BlogpostFrontmatterSchema.safeParse({
+        ...validBlogData,
+        podcastId: '4Pg3gfj8z0g!',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should treat podcastId and podcastShowId as optional', () => {
+      const result = BlogpostFrontmatterSchema.safeParse(validBlogData);
+      expect(result.success).toBe(true);
+    });
   });
 
   describe('PageFrontmatterSchema', () => {

--- a/app/modules/schemas.ts
+++ b/app/modules/schemas.ts
@@ -34,6 +34,18 @@ const CommonSchemas = {
     .string()
     .regex(/^[a-zA-Z0-9_-]{11}$/, 'Must be a valid YouTube video ID')
     .optional(),
+
+  /** Optional Ausha podcast episode ID (12 characters alphanumeric) */
+  podcastId: z
+    .string()
+    .regex(/^[a-zA-Z0-9]{12}$/, 'Must be a valid Ausha podcast episode ID')
+    .optional(),
+
+  /** Optional Ausha podcast show ID (12 characters alphanumeric) */
+  podcastShowId: z
+    .string()
+    .regex(/^[a-zA-Z0-9]{12}$/, 'Must be a valid Ausha podcast show ID')
+    .optional(),
 } as const;
 
 /**
@@ -118,6 +130,12 @@ export const BlogpostFrontmatterSchema = z.object({
 
   /** Optional YouTube video ID for video content */
   youtubeId: CommonSchemas.youtubeId,
+
+  /** Optional Ausha podcast episode ID */
+  podcastId: CommonSchemas.podcastId,
+
+  /** Optional Ausha podcast show ID (overrides default Revenue Echoes show) */
+  podcastShowId: CommonSchemas.podcastShowId,
 });
 
 /**

--- a/locales/en/blog.json
+++ b/locales/en/blog.json
@@ -7,5 +7,6 @@
   "hero.description": "Articles, interviews and masterclasses to structure your growth.",
   "featured.badge": "Featured",
   "toc.label": "Table of contents",
-  "author.heading": "About the author"
+  "author.heading": "About the author",
+  "player.podcast.title": "Listen to the episode"
 }

--- a/locales/en/blog.json
+++ b/locales/en/blog.json
@@ -8,5 +8,7 @@
   "featured.badge": "Featured",
   "toc.label": "Table of contents",
   "author.heading": "About the author",
-  "player.podcast.title": "Listen to the episode"
+  "player.podcast.title": "Listen to the episode",
+  "filter.all": "All",
+  "filter.podcastsOnly": "Podcasts only"
 }

--- a/locales/fr/blog.json
+++ b/locales/fr/blog.json
@@ -8,5 +8,7 @@
   "featured.badge": "À la une",
   "toc.label": "Sommaire",
   "author.heading": "À propos de l'auteur",
-  "player.podcast.title": "Écouter l'épisode"
+  "player.podcast.title": "Écouter l'épisode",
+  "filter.all": "Tous",
+  "filter.podcastsOnly": "Podcasts uniquement"
 }

--- a/locales/fr/blog.json
+++ b/locales/fr/blog.json
@@ -7,5 +7,6 @@
   "hero.description": "Articles, interviews et masterclasses pour structurer votre croissance.",
   "featured.badge": "À la une",
   "toc.label": "Sommaire",
-  "author.heading": "À propos de l'auteur"
+  "author.heading": "À propos de l'auteur",
+  "player.podcast.title": "Écouter l'épisode"
 }


### PR DESCRIPTION
## Summary

- **Schema**: `podcastId` + `podcastShowId` fields added to `BlogpostFrontmatterSchema` (12-char alphanumeric, optional). Tests cover valid ID, wrong length, non-alphanumeric, genuinely optional.
- **Pure modules**: `podcast-embed-config.ts` (constant `REVENUE_ECHOES_SHOW_ID`, `resolvePodcastEmbed`) and `article-footer.ts` (`selectArticleFooter` — `podcast` wins over `youtube`), each with unit tests.
- **Article player**: `blog-article.tsx` uses selector-driven switch — renders `AushaPlayer` when `podcastId` present, `PlayerYoutube` when only `youtubeId` present, nothing otherwise. New i18n key `player.podcast.title`.
- **Blog filter**: `blog-list.tsx` — client-side `podcastsOnly` toggle above the featured post. Filters `items` by `frontmatter.podcastId` presence. New i18n keys `filter.all` / `filter.podcastsOnly`. Empty filtered state handled.

## Verification matrix

| Scenario | Expected |
|---|---|
| `podcastId` only | Ausha player renders |
| `youtubeId` only | YouTube player renders |
| `podcastId` + `youtubeId` | Ausha player renders (podcast wins) |
| Neither | No player |
| `podcastShowId` overrides default | Custom show ID used in Ausha embed |
| Filter active, no podcast posts | Empty subtitle shown, no crash |

## Notes

- Legacy `{% aushaPlayer %}` Markdoc tag stays registered (transition window).
- Content-repo migration (4 posts: lift `podcastId` frontmatter, drop inline tag + `podcast` tag) tracked separately and will follow this PR.

Closes #110