### PR TITLE
docs(perf): scaffold performance baseline doc (#150)

### DIFF
--- a/docs/project/performance-baseline.md
+++ b/docs/project/performance-baseline.md
@@ -29,53 +29,15 @@ Same URLs used for every re-measurement. If any of routes 3/5/6 disappears, repl
 
 ### PageSpeed Insights API (lab + CrUX in one call)
 
-Get an API key at https://developers.google.com/speed/docs/insights/v5/get-started, then export it:
+Get an API key at https://developers.google.com/speed/docs/insights/v5/get-started, export it, then run the committed scripts in `scripts/perf/`:
 
 ```bash
 export PSI_KEY=<your-key>
+bash scripts/perf/baseline-run.sh        # dumps /tmp/psi-*.json (6 files)
+bash scripts/perf/baseline-extract.sh    # prints metrics as JSON, one block per URL
 ```
 
-Run the baseline script (mobile profile):
-
-```bash
-for url in \
-  "https://www.ocobo.co/" \
-  "https://www.ocobo.co/blog" \
-  "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe" \
-  "https://www.ocobo.co/jobs" \
-  "https://www.ocobo.co/fr/jobs/revenue-operations-manager" \
-  "https://www.ocobo.co/clients/ekodev"; do
-  slug=$(echo "$url" | sed 's|https://www.ocobo.co||' | tr -c 'a-zA-Z0-9' '_' | sed 's|^_||;s|_$||')
-  [ -z "$slug" ] && slug="home"
-  curl -sG "https://www.googleapis.com/pagespeedonline/v5/runPagespeed" \
-    --data-urlencode "url=$url" \
-    --data-urlencode "strategy=mobile" \
-    --data-urlencode "category=performance" \
-    --data-urlencode "key=$PSI_KEY" \
-    -o "/tmp/psi-$slug.json"
-  echo "$slug → /tmp/psi-$slug.json"
-done
-```
-
-Extract the key metrics:
-
-```bash
-for f in /tmp/psi-*.json; do
-  echo "=== $f ==="
-  jq -r '{
-    score: .lighthouseResult.categories.performance.score,
-    lcp_ms: .lighthouseResult.audits["largest-contentful-paint"].numericValue,
-    cls: .lighthouseResult.audits["cumulative-layout-shift"].numericValue,
-    fcp_ms: .lighthouseResult.audits["first-contentful-paint"].numericValue,
-    ttfb_ms: .lighthouseResult.audits["server-response-time"].numericValue,
-    tbt_ms: .lighthouseResult.audits["total-blocking-time"].numericValue,
-    crux_lcp_p75: .loadingExperience.metrics.LARGEST_CONTENTFUL_PAINT_MS.percentile,
-    crux_cls_p75: .loadingExperience.metrics.CUMULATIVE_LAYOUT_SHIFT_SCORE.percentile,
-    crux_inp_p75: .loadingExperience.metrics.INTERACTION_TO_NEXT_PAINT.percentile,
-    crux_ttfb_p75: .loadingExperience.metrics.EXPERIENCE_FIRST_CONTENTFUL_PAINT_MS.percentile
-  }' "$f"
-done
-```
+See `scripts/perf/README.md` for details.
 
 ### Local Lighthouse CLI (alternative, no API key)
 

--- a/docs/project/performance-baseline.md
+++ b/docs/project/performance-baseline.md
@@ -1,0 +1,157 @@
+# Performance baseline — pre-refactor reference
+
+Reference numbers captured before any [PRD #120](../../README.md) perf slice lands. Every subsequent perf slice (#151–#162) compares itself against this document.
+
+**Status:** scaffolded, awaiting first run
+**Last updated:** _pending — fill in after first run_
+**Method:** PageSpeed Insights API (lab Lighthouse + CrUX p75) + Vercel Speed Insights dashboard
+
+---
+
+## URLs measured
+
+The 6 routes that #120 sub-issues will refactor or that anchor the site's UX:
+
+| # | Route | URL |
+|---|-------|-----|
+| 1 | Homepage | https://www.ocobo.co/ |
+| 2 | Blog index | https://www.ocobo.co/blog |
+| 3 | Blog detail | https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe |
+| 4 | Jobs index | https://www.ocobo.co/jobs |
+| 5 | Jobs detail | https://www.ocobo.co/fr/jobs/revenue-operations-manager |
+| 6 | Client story | https://www.ocobo.co/clients/ekodev |
+
+Same URLs used for every re-measurement. If any of routes 3/5/6 disappears, replace with a comparable peer and note the swap in the changelog at the bottom of this doc.
+
+---
+
+## How to re-run
+
+### PageSpeed Insights API (lab + CrUX in one call)
+
+Get an API key at https://developers.google.com/speed/docs/insights/v5/get-started, then export it:
+
+```bash
+export PSI_KEY=<your-key>
+```
+
+Run the baseline script (mobile profile):
+
+```bash
+for url in \
+  "https://www.ocobo.co/" \
+  "https://www.ocobo.co/blog" \
+  "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe" \
+  "https://www.ocobo.co/jobs" \
+  "https://www.ocobo.co/fr/jobs/revenue-operations-manager" \
+  "https://www.ocobo.co/clients/ekodev"; do
+  slug=$(echo "$url" | sed 's|https://www.ocobo.co||' | tr -c 'a-zA-Z0-9' '_' | sed 's|^_||;s|_$||')
+  [ -z "$slug" ] && slug="home"
+  curl -sG "https://www.googleapis.com/pagespeedonline/v5/runPagespeed" \
+    --data-urlencode "url=$url" \
+    --data-urlencode "strategy=mobile" \
+    --data-urlencode "category=performance" \
+    --data-urlencode "key=$PSI_KEY" \
+    -o "/tmp/psi-$slug.json"
+  echo "$slug → /tmp/psi-$slug.json"
+done
+```
+
+Extract the key metrics:
+
+```bash
+for f in /tmp/psi-*.json; do
+  echo "=== $f ==="
+  jq -r '{
+    score: .lighthouseResult.categories.performance.score,
+    lcp_ms: .lighthouseResult.audits["largest-contentful-paint"].numericValue,
+    cls: .lighthouseResult.audits["cumulative-layout-shift"].numericValue,
+    fcp_ms: .lighthouseResult.audits["first-contentful-paint"].numericValue,
+    ttfb_ms: .lighthouseResult.audits["server-response-time"].numericValue,
+    tbt_ms: .lighthouseResult.audits["total-blocking-time"].numericValue,
+    crux_lcp_p75: .loadingExperience.metrics.LARGEST_CONTENTFUL_PAINT_MS.percentile,
+    crux_cls_p75: .loadingExperience.metrics.CUMULATIVE_LAYOUT_SHIFT_SCORE.percentile,
+    crux_inp_p75: .loadingExperience.metrics.INTERACTION_TO_NEXT_PAINT.percentile,
+    crux_ttfb_p75: .loadingExperience.metrics.EXPERIENCE_FIRST_CONTENTFUL_PAINT_MS.percentile
+  }' "$f"
+done
+```
+
+### Local Lighthouse CLI (alternative, no API key)
+
+```bash
+pnpm dlx lighthouse \
+  https://www.ocobo.co/ \
+  --preset=desktop \
+  --form-factor=mobile \
+  --output=json --output=html \
+  --output-path=./lh-home \
+  --chrome-flags="--headless=new"
+```
+
+Repeat per URL. Slower (real Chrome run) but offline-friendly.
+
+### Vercel Speed Insights (real-user p75)
+
+Real-user p75 metrics live in the Vercel dashboard:
+
+https://vercel.com/wabdsgn/ocobo/speed-insights
+
+Filter: last 7 days, mobile. Capture LCP / CLS / INP / TTFB per route and paste into the **real-user** table below.
+
+---
+
+## Results
+
+### Lab metrics — PageSpeed Insights (mobile, performance category)
+
+| Route | Perf score | LCP (ms) | CLS | FCP (ms) | TTFB (ms) | TBT (ms) |
+|-------|-----------:|---------:|----:|---------:|----------:|---------:|
+| Homepage | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+| Blog index | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+| Blog detail | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+| Jobs index | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+| Jobs detail | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+| Client story | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+
+### Real-user p75 — CrUX (last 28 days, mobile)
+
+| Route | LCP p75 (ms) | CLS p75 | INP p75 (ms) | TTFB p75 (ms) |
+|-------|-------------:|--------:|-------------:|--------------:|
+| Homepage | _pending_ | _pending_ | _pending_ | _pending_ |
+| Blog index | _pending_ | _pending_ | _pending_ | _pending_ |
+| Blog detail | _pending_ | _pending_ | _pending_ | _pending_ |
+| Jobs index | _pending_ | _pending_ | _pending_ | _pending_ |
+| Jobs detail | _pending_ | _pending_ | _pending_ | _pending_ |
+| Client story | _pending_ | _pending_ | _pending_ | _pending_ |
+
+### Real-user p75 — Vercel Speed Insights (last 7 days, mobile)
+
+| Route | LCP p75 (ms) | CLS p75 | INP p75 (ms) | TTFB p75 (ms) |
+|-------|-------------:|--------:|-------------:|--------------:|
+| Homepage | _pending_ | _pending_ | _pending_ | _pending_ |
+| Blog index | _pending_ | _pending_ | _pending_ | _pending_ |
+| Blog detail | _pending_ | _pending_ | _pending_ | _pending_ |
+| Jobs index | _pending_ | _pending_ | _pending_ | _pending_ |
+| Jobs detail | _pending_ | _pending_ | _pending_ | _pending_ |
+| Client story | _pending_ | _pending_ | _pending_ | _pending_ |
+
+---
+
+## Targets (from PRD #120)
+
+| Metric | Current estimate | Target |
+|--------|-----------------:|-------:|
+| LCP p75 mobile | 3.5–4.2 s | < 2.5 s |
+| CLS p75 | 0.12–0.15 | < 0.1 |
+| INP p75 | 300–400 ms | < 200 ms |
+| TTFB p75 | 800–1 200 ms | < 600 ms |
+| Perf score (lab) | ~6.5 | 9+ |
+
+---
+
+## Changelog
+
+| Date | Author | Notes |
+|------|--------|-------|
+| 2026-05-13 | scaffold | Initial doc + URL list + commands. No data captured yet — #150 still open. |

--- a/docs/project/performance-baseline.md
+++ b/docs/project/performance-baseline.md
@@ -2,8 +2,8 @@
 
 Reference numbers captured before any [PRD #120](../../README.md) perf slice lands. Every subsequent perf slice (#151–#162) compares itself against this document.
 
-**Status:** scaffolded, awaiting first run
-**Last updated:** _pending — fill in after first run_
+**Status:** lab baseline captured 2026-05-13 ; Vercel Speed Insights pending
+**Last updated:** 2026-05-13
 **Method:** PageSpeed Insights API (lab Lighthouse + CrUX p75) + Vercel Speed Insights dashboard
 
 ---
@@ -67,25 +67,29 @@ Filter: last 7 days, mobile. Capture LCP / CLS / INP / TTFB per route and paste 
 
 ### Lab metrics — PageSpeed Insights (mobile, performance category)
 
+Captured 2026-05-13 via `scripts/perf/baseline-run.sh`.
+
 | Route | Perf score | LCP (ms) | CLS | FCP (ms) | TTFB (ms) | TBT (ms) |
-|-------|-----------:|---------:|----:|---------:|----------:|---------:|
-| Homepage | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
-| Blog index | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
-| Blog detail | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
-| Jobs index | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
-| Jobs detail | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
-| Client story | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+|-------|-----------:|---------:|------:|---------:|----------:|---------:|
+| Homepage | 54 | 8 185 | 0.009 | 3 971 | 12 | 296 |
+| Blog index | 37 | 6 826 | 0.000 | 3 933 | 47 | 2 153 |
+| Blog detail | 66 | 5 176 | 0.007 | 3 001 | 26 | 332 |
+| Jobs index | 64 | 3 901 | 0.002 | 2 551 | 45 | 668 |
+| Jobs detail | 71 | 3 301 | 0.016 | 2 701 | 6 | 572 |
+| Client story | 71 | 3 451 | 0.003 | 3 151 | 43 | 457 |
 
 ### Real-user p75 — CrUX (last 28 days, mobile)
 
 | Route | LCP p75 (ms) | CLS p75 | INP p75 (ms) | TTFB p75 (ms) |
 |-------|-------------:|--------:|-------------:|--------------:|
-| Homepage | _pending_ | _pending_ | _pending_ | _pending_ |
-| Blog index | _pending_ | _pending_ | _pending_ | _pending_ |
-| Blog detail | _pending_ | _pending_ | _pending_ | _pending_ |
-| Jobs index | _pending_ | _pending_ | _pending_ | _pending_ |
-| Jobs detail | _pending_ | _pending_ | _pending_ | _pending_ |
-| Client story | _pending_ | _pending_ | _pending_ | _pending_ |
+| Homepage | n/a | n/a | n/a | n/a |
+| Blog index | n/a | n/a | n/a | n/a |
+| Blog detail | n/a | n/a | n/a | n/a |
+| Jobs index | n/a | n/a | n/a | n/a |
+| Jobs detail | n/a | n/a | n/a | n/a |
+| Client story | n/a | n/a | n/a | n/a |
+
+**Note:** CrUX returned `null` for every metric on every route. The site does not have enough Chrome real-user traffic to surface in the public CrUX dataset. **Implication:** rely on Vercel Speed Insights for real-user data, and on the lab numbers above for repeatable before/after comparisons.
 
 ### Real-user p75 — Vercel Speed Insights (last 7 days, mobile)
 
@@ -102,13 +106,21 @@ Filter: last 7 days, mobile. Capture LCP / CLS / INP / TTFB per route and paste 
 
 ## Targets (from PRD #120)
 
-| Metric | Current estimate | Target |
-|--------|-----------------:|-------:|
-| LCP p75 mobile | 3.5–4.2 s | < 2.5 s |
-| CLS p75 | 0.12–0.15 | < 0.1 |
-| INP p75 | 300–400 ms | < 200 ms |
-| TTFB p75 | 800–1 200 ms | < 600 ms |
-| Perf score (lab) | ~6.5 | 9+ |
+| Metric | PRD estimate | Lab observed (worst page) | Target |
+|--------|-------------:|--------------------------:|-------:|
+| LCP mobile | 3.5–4.2 s | **8.2 s** (homepage) | < 2.5 s |
+| CLS | 0.12–0.15 | 0.016 (jobs detail) | < 0.1 |
+| INP (proxied by TBT lab) | 300–400 ms | **2 153 ms** TBT (blog index) | < 200 ms |
+| TTFB | 800–1 200 ms | 47 ms (worst lab) | < 600 ms |
+| Perf score | ~6.5 / 10 | **37 / 100** (blog index) | 90+ |
+
+## Key takeaways from baseline
+
+1. **LCP is dramatically worse than the PRD estimated** — homepage 8.2 s, blog index 6.8 s, all six pages above the 2.5 s target. Hero image + above-fold images are the dominant cost. → #151 (`<OptimizedImage>` + hero) and #161 (second wave) are the highest-leverage slices.
+2. **CLS is already in target everywhere** (worst 0.016 vs target < 0.1). The PRD over-estimated CLS risk. CLS-focused work can be deprioritised; image dimensions still matter for LCP, not for CLS.
+3. **TTFB is excellent in the lab** (6–47 ms). The PRD's 800–1 200 ms estimate must come from cold-start / real-user p75, not lab cold. → keep the data-fetching slices (#152, #153, #154, #155) but recalibrate expected gains downward for TTFB; their main upside is reduced bundle blocking + earlier LCP, not raw TTFB.
+4. **Blog index TBT 2.1 s is the INP outlier.** Likely script-heavy listing page (HubSpot + carousels). → #158 (HubSpot lazy) is more important than the PRD ranking suggested.
+5. **No CrUX data.** Cannot triangulate real-user perception. Vercel Speed Insights is the only real-user source. Worth checking whether Speed Insights has enough samples per route.
 
 ---
 
@@ -117,3 +129,4 @@ Filter: last 7 days, mobile. Capture LCP / CLS / INP / TTFB per route and paste 
 | Date | Author | Notes |
 |------|--------|-------|
 | 2026-05-13 | scaffold | Initial doc + URL list + commands. No data captured yet — #150 still open. |
+| 2026-05-13 | baseline | Lab metrics captured via PSI for all 6 URLs. CrUX null everywhere (insufficient traffic). Vercel Speed Insights still pending. Key finding: LCP much worse than PRD estimated (8.2 s on homepage); CLS already in target; TBT 2.1 s on blog index is the INP outlier. |

--- a/docs/project/performance-baseline.md
+++ b/docs/project/performance-baseline.md
@@ -2,9 +2,9 @@
 
 Reference numbers captured before any [PRD #120](../../README.md) perf slice lands. Every subsequent perf slice (#151–#162) compares itself against this document.
 
-**Status:** lab baseline captured 2026-05-13 ; Vercel Speed Insights pending
+**Status:** lab + real-user baselines captured 2026-05-13
 **Last updated:** 2026-05-13
-**Method:** PageSpeed Insights API (lab Lighthouse + CrUX p75) + Vercel Speed Insights dashboard
+**Method:** PageSpeed Insights API (lab Lighthouse + CrUX p75) + Vercel Speed Insights dashboard (site-wide, route patterns not configured)
 
 ---
 
@@ -91,36 +91,40 @@ Captured 2026-05-13 via `scripts/perf/baseline-run.sh`.
 
 **Note:** CrUX returned `null` for every metric on every route. The site does not have enough Chrome real-user traffic to surface in the public CrUX dataset. **Implication:** rely on Vercel Speed Insights for real-user data, and on the lab numbers above for repeatable before/after comparisons.
 
-### Real-user p75 — Vercel Speed Insights (last 7 days, mobile)
+### Real-user p75 — Vercel Speed Insights (last 7 days, mobile, site-wide)
 
-| Route | LCP p75 (ms) | CLS p75 | INP p75 (ms) | TTFB p75 (ms) |
-|-------|-------------:|--------:|-------------:|--------------:|
-| Homepage | _pending_ | _pending_ | _pending_ | _pending_ |
-| Blog index | _pending_ | _pending_ | _pending_ | _pending_ |
-| Blog detail | _pending_ | _pending_ | _pending_ | _pending_ |
-| Jobs index | _pending_ | _pending_ | _pending_ | _pending_ |
-| Jobs detail | _pending_ | _pending_ | _pending_ | _pending_ |
-| Client story | _pending_ | _pending_ | _pending_ | _pending_ |
+Captured 2026-05-13. Per-route breakdown unavailable — Vercel's Routes tab shows only `Unknown` because route patterns are not configured for this React Router v7 app. Numbers below are **site-wide aggregate** across all routes.
+
+| Scope | LCP p75 | CLS p75 | INP p75 | TTFB p75 | FCP p75 | FID p75 | RES |
+|-------|--------:|--------:|--------:|---------:|--------:|--------:|----:|
+| All routes (mobile) | 2 750 ms | 0 | 144 ms | 450 ms | 1 740 ms | 21 ms | 95 / Great |
+
+Geographic outlier: Algeria p75 in "Needs Improvement" band (74) — small sample, likely network-bound. Not actionable from code.
+
+**Follow-up needed:** configure Vercel route patterns so per-route p75 becomes visible. Tracked separately if/when this measurement gap hurts.
 
 ---
 
 ## Targets (from PRD #120)
 
-| Metric | PRD estimate | Lab observed (worst page) | Target |
-|--------|-------------:|--------------------------:|-------:|
-| LCP mobile | 3.5–4.2 s | **8.2 s** (homepage) | < 2.5 s |
-| CLS | 0.12–0.15 | 0.016 (jobs detail) | < 0.1 |
-| INP (proxied by TBT lab) | 300–400 ms | **2 153 ms** TBT (blog index) | < 200 ms |
-| TTFB | 800–1 200 ms | 47 ms (worst lab) | < 600 ms |
-| Perf score | ~6.5 / 10 | **37 / 100** (blog index) | 90+ |
+| Metric | PRD estimate | Lab observed (worst page) | Real-user p75 (site-wide) | Target |
+|--------|-------------:|--------------------------:|--------------------------:|-------:|
+| LCP mobile | 3.5–4.2 s | **8.2 s** (homepage) | 2.75 s | < 2.5 s |
+| CLS | 0.12–0.15 | 0.016 (jobs detail) | 0 | < 0.1 |
+| INP | 300–400 ms | 2 153 ms TBT proxy (blog index) | 144 ms | < 200 ms |
+| TTFB | 800–1 200 ms | 47 ms | 450 ms | < 600 ms |
+| Perf score (lab) | ~6.5 / 10 | **37 / 100** (blog index) | n/a | 90+ |
+| Real Experience Score | n/a | n/a | 95 / Great | > 90 |
 
 ## Key takeaways from baseline
 
-1. **LCP is dramatically worse than the PRD estimated** — homepage 8.2 s, blog index 6.8 s, all six pages above the 2.5 s target. Hero image + above-fold images are the dominant cost. → #151 (`<OptimizedImage>` + hero) and #161 (second wave) are the highest-leverage slices.
-2. **CLS is already in target everywhere** (worst 0.016 vs target < 0.1). The PRD over-estimated CLS risk. CLS-focused work can be deprioritised; image dimensions still matter for LCP, not for CLS.
-3. **TTFB is excellent in the lab** (6–47 ms). The PRD's 800–1 200 ms estimate must come from cold-start / real-user p75, not lab cold. → keep the data-fetching slices (#152, #153, #154, #155) but recalibrate expected gains downward for TTFB; their main upside is reduced bundle blocking + earlier LCP, not raw TTFB.
-4. **Blog index TBT 2.1 s is the INP outlier.** Likely script-heavy listing page (HubSpot + carousels). → #158 (HubSpot lazy) is more important than the PRD ranking suggested.
-5. **No CrUX data.** Cannot triangulate real-user perception. Vercel Speed Insights is the only real-user source. Worth checking whether Speed Insights has enough samples per route.
+1. **Real users are doing dramatically better than the lab suggests.** Lab homepage LCP 8.2 s vs site-wide real-user p75 LCP 2.75 s. Causes: Vercel CDN warm cache, faster real devices/networks, and CrUX/PSI's worst-case mobile throttling. **Trust real-user numbers for product decisions; trust lab numbers for repeatable before/after diffs.**
+2. **Real-user CWV are already mostly green.** INP 144 ms ✅, CLS 0 ✅, TTFB 450 ms ✅, RES 95 ✅. Only LCP (2.75 s) just barely misses < 2.5 s. → **PRD #120 may be overscoped.** Consider whether the full perf programme is justified or whether the LCP-focused slices alone deliver most of the value.
+3. **LCP is the only real-user metric still missing target** (2.75 s vs 2.5 s). The hero-image fix from #151 is likely sufficient to close this gap. #161 (second wave) is probably gravy.
+4. **Blog index TBT 2.1 s is a lab outlier**, but **real-user INP is 144 ms site-wide** — so the issue may be lab-only mobile throttling on HubSpot scripts, not actual user pain. **Verify against per-route real-user data before prioritising #158 (HubSpot lazy).**
+5. **TTFB lab (47 ms) vs real-user (450 ms)** — 10× gap likely from cold-start serverless on real-user traffic. Data-fetching slices (#152–#155) target the cold-start path, so they will matter at p99 even if p75 is fine. **Recalibrate expected gain: smaller absolute, but still real for tail latencies.**
+6. **Per-route real-user data is missing.** Vercel Routes tab shows only `Unknown` because RR v7 route patterns aren't registered. This blocks targeted measurement. Worth a small follow-up task before #151 if we want per-route validation of the LCP fix.
+7. **CrUX returned null** — site too small for the public dataset. Not a blocker; Vercel Speed Insights covers real-user.
 
 ---
 
@@ -130,3 +134,4 @@ Captured 2026-05-13 via `scripts/perf/baseline-run.sh`.
 |------|--------|-------|
 | 2026-05-13 | scaffold | Initial doc + URL list + commands. No data captured yet — #150 still open. |
 | 2026-05-13 | baseline | Lab metrics captured via PSI for all 6 URLs. CrUX null everywhere (insufficient traffic). Vercel Speed Insights still pending. Key finding: LCP much worse than PRD estimated (8.2 s on homepage); CLS already in target; TBT 2.1 s on blog index is the INP outlier. |
+| 2026-05-13 | vercel-rum | Site-wide real-user p75 captured from Vercel Speed Insights. Per-route unavailable (no route patterns configured). Numbers far better than lab: LCP 2.75 s (vs lab 8.2 s), INP 144 ms ✅, CLS 0 ✅, TTFB 450 ms ✅, RES 95. Reframes PRD #120 scope: only LCP still misses target by 250 ms; #151 alone may close the gap. |

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,32 @@
+# Perf measurement scripts
+
+Helpers for capturing CWV baselines and re-measurements against the URL set frozen in `docs/project/performance-baseline.md`.
+
+## Setup
+
+Get a PageSpeed Insights API key: https://developers.google.com/speed/docs/insights/v5/get-started
+
+```bash
+export PSI_KEY=<your-key>
+```
+
+## Run a measurement
+
+```bash
+bash scripts/perf/baseline-run.sh        # dumps 6 JSON files to /tmp/psi-*.json
+bash scripts/perf/baseline-extract.sh    # prints the key CWV metrics per URL
+```
+
+Override output directory via `PSI_OUT_DIR`:
+
+```bash
+PSI_OUT_DIR=./tmp/perf-$(date +%Y%m%d) bash scripts/perf/baseline-run.sh
+```
+
+## URLs measured
+
+Six routes, source of truth: `docs/project/performance-baseline.md`.
+
+## What to do with the output
+
+For the initial baseline (#150), paste the extract output into `docs/project/performance-baseline.md` tables. For re-measurements after each #120 slice, compare against that doc.

--- a/scripts/perf/baseline-extract.sh
+++ b/scripts/perf/baseline-extract.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Extract key CWV metrics from PSI JSON dumps produced by baseline-run.sh.
+# Prints one JSON object per URL — lab metrics + CrUX p75 fields.
+set -euo pipefail
+
+in_dir="${PSI_OUT_DIR:-/tmp}"
+
+shopt -s nullglob
+files=("$in_dir"/psi-*.json)
+if [ ${#files[@]} -eq 0 ]; then
+  echo "No psi-*.json files in $in_dir — run scripts/perf/baseline-run.sh first" >&2
+  exit 1
+fi
+
+for f in "${files[@]}"; do
+  echo "=== $(basename "$f" .json) ==="
+  jq '{
+    score: .lighthouseResult.categories.performance.score,
+    lcp_ms: .lighthouseResult.audits["largest-contentful-paint"].numericValue,
+    cls: .lighthouseResult.audits["cumulative-layout-shift"].numericValue,
+    fcp_ms: .lighthouseResult.audits["first-contentful-paint"].numericValue,
+    ttfb_ms: .lighthouseResult.audits["server-response-time"].numericValue,
+    tbt_ms: .lighthouseResult.audits["total-blocking-time"].numericValue,
+    crux_lcp_p75: .loadingExperience.metrics.LARGEST_CONTENTFUL_PAINT_MS.percentile,
+    crux_cls_p75: .loadingExperience.metrics.CUMULATIVE_LAYOUT_SHIFT_SCORE.percentile,
+    crux_inp_p75: .loadingExperience.metrics.INTERACTION_TO_NEXT_PAINT.percentile,
+    crux_ttfb_p75: .loadingExperience.metrics.EXPERIENCE_FIRST_CONTENTFUL_PAINT_MS.percentile
+  }' "$f"
+done

--- a/scripts/perf/baseline-run.sh
+++ b/scripts/perf/baseline-run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Run PageSpeed Insights against the 6 baseline URLs and dump raw JSON to /tmp.
+# Requires: PSI_KEY env var (get one at https://developers.google.com/speed/docs/insights/v5/get-started)
+set -euo pipefail
+
+: "${PSI_KEY:?Set PSI_KEY first — export PSI_KEY=<your-key>}"
+
+urls=(
+  "https://www.ocobo.co/"
+  "https://www.ocobo.co/blog"
+  "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+  "https://www.ocobo.co/jobs"
+  "https://www.ocobo.co/fr/jobs/revenue-operations-manager"
+  "https://www.ocobo.co/clients/ekodev"
+)
+
+out_dir="${PSI_OUT_DIR:-/tmp}"
+mkdir -p "$out_dir"
+
+for url in "${urls[@]}"; do
+  slug=$(echo "$url" | sed 's|https://www.ocobo.co||' | tr -c 'a-zA-Z0-9' '_' | sed 's|^_||;s|_$||')
+  [ -z "$slug" ] && slug="home"
+  curl -sG "https://www.googleapis.com/pagespeedonline/v5/runPagespeed" \
+    --data-urlencode "url=$url" \
+    --data-urlencode "strategy=mobile" \
+    --data-urlencode "category=performance" \
+    --data-urlencode "key=$PSI_KEY" \
+    -o "$out_dir/psi-$slug.json"
+  echo "✓ $slug → $out_dir/psi-$slug.json"
+done


### PR DESCRIPTION
## Summary

Scaffolds `docs/project/performance-baseline.md` — the reference point every perf slice from PRD #120 will compare against.

- 6 representative URLs frozen as the measurement set
- Runnable PSI API + Lighthouse CLI commands
- Vercel Speed Insights dashboard pointer
- Empty result tables (lab + CrUX + Vercel real-user)
- Targets pulled from PRD #120

## What this does NOT include

The actual baseline numbers. #150 is `ready-for-human`: collecting metrics needs a PSI API key + Vercel dashboard access. This PR lands the scaffold so the numbers slot in cleanly; #150 stays open until a follow-up commit fills the tables.

## Why land the scaffold first

Without a frozen reference, every later perf PR (#151–#162) would have to justify its own measurement methodology. One canonical doc + frozen URL set = unambiguous before/after deltas.

## Linked

- Closes #150 in 2 steps: (1) this PR lands scaffold, (2) follow-up PR fills numbers and closes the issue

## Test plan

- [ ] Doc renders correctly on GitHub
- [ ] PSI command in the doc runs end-to-end against the API once `PSI_KEY` is set
- [ ] Speed Insights URL resolves