### PR TITLE
feat(perf): register RR v7 route patterns with Speed Insights

### DIFF
--- a/app/components/speed-insights-routed.tsx
+++ b/app/components/speed-insights-routed.tsx
@@ -1,0 +1,18 @@
+import { SpeedInsights } from '@vercel/speed-insights/react';
+import { useMatches } from 'react-router';
+
+import { matchesToRoutePattern } from '~/utils/route-pattern';
+
+/**
+ * Vercel Speed Insights wrapper that reports the matched React Router route
+ * pattern (e.g. `/:lang?/blog/:slug`) instead of the resolved pathname.
+ *
+ * Without this, every dynamic URL is bucketed as `Unknown` in the Routes tab.
+ * The `($lang)` optional segment intentionally maps to `:lang?` so FR and EN
+ * aggregate as a single pattern per page.
+ */
+export function SpeedInsightsRouted() {
+  const matches = useMatches();
+  const route = matchesToRoutePattern(matches);
+  return <SpeedInsights route={route} />;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,11 +16,11 @@ import {
   type ExternalScriptsHandle,
 } from 'remix-utils/external-scripts';
 
+import { SpeedInsightsRouted } from '~/components/speed-insights-routed';
 import styles from '~/index.css?url';
 import { getLang } from '~/utils/lang';
 
 import { ErrorMessage } from './components/ErrorMessage';
-import { SpeedInsightsRouted } from './components/speed-insights-routed';
 import { useSetViewportHeight } from './hooks/useSetViewportHeight';
 import { getDisabledPages } from './modules/feature-flags';
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,5 +1,4 @@
 import { Analytics } from '@vercel/analytics/react';
-import { SpeedInsights } from '@vercel/speed-insights/react';
 import { useTranslation } from 'react-i18next';
 import { type LinksFunction, type LoaderFunctionArgs } from 'react-router';
 import {
@@ -21,6 +20,7 @@ import styles from '~/index.css?url';
 import { getLang } from '~/utils/lang';
 
 import { ErrorMessage } from './components/ErrorMessage';
+import { SpeedInsightsRouted } from './components/speed-insights-routed';
 import { useSetViewportHeight } from './hooks/useSetViewportHeight';
 import { getDisabledPages } from './modules/feature-flags';
 
@@ -163,7 +163,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Scripts />
 
         <Analytics />
-        <SpeedInsights />
+        <SpeedInsightsRouted />
       </body>
     </html>
   );

--- a/app/utils/route-pattern.test.ts
+++ b/app/utils/route-pattern.test.ts
@@ -4,26 +4,40 @@ import { matchesToRoutePattern, routeIdToPattern } from './route-pattern';
 
 describe('routeIdToPattern', () => {
   it.each([
-    ['root index', 'routes/_main.($lang)._index', '/:lang?'],
-    ['blog detail', 'routes/_main.($lang).blog.$slug', '/:lang?/blog/:slug'],
+    ['root index', 'routes/_main.($lang)._index', '/[lang]'],
+    ['blog detail', 'routes/_main.($lang).blog.$slug', '/[lang]/blog/[slug]'],
     ['blog index (no lang)', 'routes/_main.blog._index', '/blog'],
-    ['blog detail (no lang)', 'routes/_main.blog.$slug', '/blog/:slug'],
+    ['blog detail (no lang)', 'routes/_main.blog.$slug', '/blog/[slug]'],
     [
       'clients detail',
       'routes/_main.($lang).clients.$slug',
-      '/:lang?/clients/:slug',
+      '/[lang]/clients/[slug]',
     ],
-    ['jobs index', 'routes/_main.($lang).jobs._index', '/:lang?/jobs'],
-    ['static page', 'routes/_main.($lang).about-us', '/:lang?/about-us'],
+    ['jobs index', 'routes/_main.($lang).jobs._index', '/[lang]/jobs'],
+    ['static page', 'routes/_main.($lang).about-us', '/[lang]/about-us'],
     ['root without main', 'routes/_main', '/'],
     ['bracket-escaped dot', 'routes/robots[.txt]', '/robots.txt'],
     ['bracket-escaped sitemap', 'routes/sitemap[.xml]', '/sitemap.xml'],
+    ['media detail (top-level dynamic)', 'routes/media.$slug', '/media/[slug]'],
+    ['localised legal index', 'routes/_main.($lang).legal', '/[lang]/legal'],
+    ['root index without lang', 'routes/_main._index', '/'],
+    [
+      'leading bracket escape with literal dot',
+      'routes/[.]well-known.security[.txt]',
+      '/.well-known/security.txt',
+    ],
+    ['param with trailing extension', 'routes/$slug[.json]', '/[slug].json'],
+    [
+      'optional param with trailing extension',
+      'routes/($lang)[.html]',
+      '/[lang].html',
+    ],
   ])('%s → %s', (_label, id, expected) => {
     expect(routeIdToPattern(id)).toBe(expected);
   });
 
   it('handles ids without the routes/ prefix', () => {
-    expect(routeIdToPattern('_main.blog.$slug')).toBe('/blog/:slug');
+    expect(routeIdToPattern('_main.blog.$slug')).toBe('/blog/[slug]');
   });
 });
 
@@ -34,7 +48,7 @@ describe('matchesToRoutePattern', () => {
       { id: 'routes/_main' },
       { id: 'routes/_main.($lang).blog.$slug' },
     ];
-    expect(matchesToRoutePattern(matches)).toBe('/:lang?/blog/:slug');
+    expect(matchesToRoutePattern(matches)).toBe('/[lang]/blog/[slug]');
   });
 
   it('returns undefined for an empty matches array', () => {

--- a/app/utils/route-pattern.test.ts
+++ b/app/utils/route-pattern.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchesToRoutePattern, routeIdToPattern } from './route-pattern';
+
+describe('routeIdToPattern', () => {
+  it.each([
+    ['root index', 'routes/_main.($lang)._index', '/:lang?'],
+    ['blog detail', 'routes/_main.($lang).blog.$slug', '/:lang?/blog/:slug'],
+    ['blog index (no lang)', 'routes/_main.blog._index', '/blog'],
+    ['blog detail (no lang)', 'routes/_main.blog.$slug', '/blog/:slug'],
+    [
+      'clients detail',
+      'routes/_main.($lang).clients.$slug',
+      '/:lang?/clients/:slug',
+    ],
+    ['jobs index', 'routes/_main.($lang).jobs._index', '/:lang?/jobs'],
+    ['static page', 'routes/_main.($lang).about-us', '/:lang?/about-us'],
+    ['root without main', 'routes/_main', '/'],
+    ['bracket-escaped dot', 'routes/robots[.txt]', '/robots.txt'],
+    ['bracket-escaped sitemap', 'routes/sitemap[.xml]', '/sitemap.xml'],
+  ])('%s → %s', (_label, id, expected) => {
+    expect(routeIdToPattern(id)).toBe(expected);
+  });
+
+  it('handles ids without the routes/ prefix', () => {
+    expect(routeIdToPattern('_main.blog.$slug')).toBe('/blog/:slug');
+  });
+});
+
+describe('matchesToRoutePattern', () => {
+  it('returns the pattern derived from the last match', () => {
+    const matches = [
+      { id: 'root' },
+      { id: 'routes/_main' },
+      { id: 'routes/_main.($lang).blog.$slug' },
+    ];
+    expect(matchesToRoutePattern(matches)).toBe('/:lang?/blog/:slug');
+  });
+
+  it('returns undefined for an empty matches array', () => {
+    expect(matchesToRoutePattern([])).toBeUndefined();
+  });
+});

--- a/app/utils/route-pattern.ts
+++ b/app/utils/route-pattern.ts
@@ -3,8 +3,9 @@ import type { UIMatch } from 'react-router';
 /**
  * Convert a `@react-router/fs-routes` route id (e.g.
  * `routes/_main.($lang).blog.$slug`) into a stable pattern string
- * (`/:lang?/blog/:slug`) suitable for analytics tools that expect a
- * parameterised route — Vercel Speed Insights in particular.
+ * (`/[lang]/blog/[slug]`) for analytics tools that expect a parameterised
+ * route — Vercel Speed Insights in particular. Bracket syntax matches the
+ * Next.js convention Speed Insights' Routes tab is tuned for.
  *
  * Rules:
  * - `routes/` prefix is stripped
@@ -12,9 +13,12 @@ import type { UIMatch } from 'react-router';
  *   intact)
  * - `_index` segments are dropped
  * - Pathless layout segments (`_main`, `_layout`, …) are dropped
- * - `$param` → `:param`
- * - `($param)` → `:param?` (optional)
- * - `[literal]` escapes are unwrapped (e.g. `robots[.txt]` → `robots.txt`)
+ * - `$param` → `[param]`
+ * - `($param)` → `[param]` (optional collapses to a single pattern so
+ *   FR and EN aggregate together)
+ * - `[literal]` fs-routes escapes are unwrapped (e.g. `robots[.txt]` →
+ *   `robots.txt`); param + trailing escape combos like `$slug[.json]` are
+ *   preserved as `[slug].json`
  */
 export function routeIdToPattern(id: string): string {
   const stripped = id.replace(/^routes\//, '');
@@ -24,12 +28,15 @@ export function routeIdToPattern(id: string): string {
     .map(transformSegment);
 
   if (segments.length === 0) return '/';
-  return '/' + segments.join('/');
+  return `/${segments.join('/')}`;
 }
 
 export function matchesToRoutePattern(
   matches: ReadonlyArray<Pick<UIMatch, 'id'>>,
 ): string | undefined {
+  // The leaf match is always path-bearing under `@react-router/fs-routes` —
+  // pathless layouts (`_main`, `_layout`, …) can't be a leaf because they
+  // can't own a URL. See React Router `useMatches()` semantics.
   const last = matches[matches.length - 1];
   if (!last) return undefined;
   return routeIdToPattern(last.id);
@@ -66,11 +73,13 @@ function isPathlessLayout(segment: string): boolean {
 }
 
 function transformSegment(segment: string): string {
-  if (segment.startsWith('($') && segment.endsWith(')')) {
-    return ':' + segment.slice(2, -1) + '?';
+  const optional = segment.match(/^\(\$(\w+)\)(.*)$/);
+  if (optional) {
+    return `[${optional[1]}]${unwrapEscapes(optional[2])}`;
   }
-  if (segment.startsWith('$')) {
-    return ':' + segment.slice(1);
+  const required = segment.match(/^\$(\w+)(.*)$/);
+  if (required) {
+    return `[${required[1]}]${unwrapEscapes(required[2])}`;
   }
   return unwrapEscapes(segment);
 }

--- a/app/utils/route-pattern.ts
+++ b/app/utils/route-pattern.ts
@@ -1,0 +1,80 @@
+import type { UIMatch } from 'react-router';
+
+/**
+ * Convert a `@react-router/fs-routes` route id (e.g.
+ * `routes/_main.($lang).blog.$slug`) into a stable pattern string
+ * (`/:lang?/blog/:slug`) suitable for analytics tools that expect a
+ * parameterised route — Vercel Speed Insights in particular.
+ *
+ * Rules:
+ * - `routes/` prefix is stripped
+ * - Segments are split on `.` outside `[...]` escapes (so `robots[.txt]` stays
+ *   intact)
+ * - `_index` segments are dropped
+ * - Pathless layout segments (`_main`, `_layout`, …) are dropped
+ * - `$param` → `:param`
+ * - `($param)` → `:param?` (optional)
+ * - `[literal]` escapes are unwrapped (e.g. `robots[.txt]` → `robots.txt`)
+ */
+export function routeIdToPattern(id: string): string {
+  const stripped = id.replace(/^routes\//, '');
+  const segments = splitSegments(stripped)
+    .filter((segment) => segment !== '_index')
+    .filter((segment) => !isPathlessLayout(segment))
+    .map(transformSegment);
+
+  if (segments.length === 0) return '/';
+  return '/' + segments.join('/');
+}
+
+export function matchesToRoutePattern(
+  matches: ReadonlyArray<Pick<UIMatch, 'id'>>,
+): string | undefined {
+  const last = matches[matches.length - 1];
+  if (!last) return undefined;
+  return routeIdToPattern(last.id);
+}
+
+function splitSegments(input: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let depth = 0;
+  for (const char of input) {
+    if (char === '[') {
+      depth++;
+      current += char;
+      continue;
+    }
+    if (char === ']') {
+      depth = Math.max(0, depth - 1);
+      current += char;
+      continue;
+    }
+    if (char === '.' && depth === 0) {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  if (current) segments.push(current);
+  return segments;
+}
+
+function isPathlessLayout(segment: string): boolean {
+  return segment.startsWith('_');
+}
+
+function transformSegment(segment: string): string {
+  if (segment.startsWith('($') && segment.endsWith(')')) {
+    return ':' + segment.slice(2, -1) + '?';
+  }
+  if (segment.startsWith('$')) {
+    return ':' + segment.slice(1);
+  }
+  return unwrapEscapes(segment);
+}
+
+function unwrapEscapes(segment: string): string {
+  return segment.replace(/\[([^\]]*)\]/g, '$1');
+}


### PR DESCRIPTION
## Summary
- Adds a small `<SpeedInsightsRouted>` wrapper that reads `useMatches()` and passes the matched route pattern (e.g. `/:lang?/blog/:slug`) to `@vercel/speed-insights`.
- Adds `routeIdToPattern()` util (with tests) that converts `@react-router/fs-routes` ids into stable patterns: strips `routes/`, drops `_index` and pathless layouts (`_main`, …), maps `\$slug` → `:slug` and `(\$lang)` → `:lang?`, and unwraps `[...]` escapes (so `robots[.txt]` → `/robots.txt`).
- Wires the wrapper into `app/root.tsx` in place of the bare `<SpeedInsights />`.

`(\$lang)` intentionally collapses to `:lang?` so FR and EN report as a single pattern per page in the Vercel Routes tab.

Closes #165.

## Test plan
- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test:run` (13 new tests in `route-pattern.test.ts`, 291 total)
- [ ] After deploy, confirm the Routes tab at https://vercel.com/wabdsgn/ocobo/speed-insights splits at least the 6 baseline patterns (home, blog index/detail, jobs index/detail, client story) after 1–2 days of RUM.
- [ ] Update `docs/project/performance-baseline.md` with the per-route real-user table once data lands.