### PR TITLE
test: RR v7 loader harness + homepage fallback coverage (#131)

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,3 +1,7 @@
 import { flatRoutes } from '@react-router/fs-routes';
 
-export default flatRoutes();
+// Co-located route tests (`*.test.ts(x)`) live next to their routes for
+// faster discovery; exclude them from the route scan.
+export default flatRoutes({
+  ignoredRouteFiles: ['**/*.test.{ts,tsx}'],
+});

--- a/app/routes/_main.($lang)._index.test.tsx
+++ b/app/routes/_main.($lang)._index.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Loader tests for the homepage route.
+ *
+ * Covers the three observable behaviors of `loader` in
+ * `_main.($lang)._index.tsx`:
+ *  1. EN happy path — `fetchStories('en')` returns 200 → testimonials emitted.
+ *  2. FR happy path — `fetchStories('fr')` returns 200 → testimonials emitted.
+ *  3. EN → FR fallback — `fetchStories('en')` returns ≠ 200, `fetchStories('fr')`
+ *     returns 200 → testimonials still emitted from the FR result.
+ *
+ * Uses the `invokeLoader` harness (`app/test/loader-harness.ts`).
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { invokeLoader } from '~/test/loader-harness';
+import type { MarkdocFile, StoryFrontmatter } from '~/types';
+
+const fetchStoriesMock = vi.fn();
+
+vi.mock('~/modules/content', () => ({
+  fetchStories: (...args: unknown[]) => fetchStoriesMock(...args),
+}));
+
+vi.mock('~/localization/i18n.server', () => ({
+  default: {
+    getFixedT: async (lang: string) => (key: string) => `${lang}:${key}`,
+  },
+}));
+
+vi.mock('~/modules/feature-flags', () => ({
+  isPageEnabled: () => true,
+}));
+
+function storyEntry(
+  overrides: Partial<StoryFrontmatter> & { slug?: string } = {},
+): MarkdocFile<StoryFrontmatter> {
+  const { slug = 'acme', ...frontmatterOverrides } = overrides;
+  return {
+    slug,
+    content: null,
+    markdown: '',
+    frontmatter: {
+      name: 'Acme',
+      date: '2024-01-01',
+      title: 'Acme story',
+      subtitle: 'sub',
+      description: 'desc',
+      speaker: 'Jane Doe',
+      role: 'CRO',
+      duration: '3 months',
+      scopes: [],
+      tools: [],
+      quotes: ['Game changer'],
+      deliverables: [],
+      ...frontmatterOverrides,
+    },
+  };
+}
+
+afterEach(() => {
+  fetchStoriesMock.mockReset();
+});
+
+describe('homepage loader', () => {
+  it('returns testimonials and EN meta when fetchStories(en) succeeds', async () => {
+    fetchStoriesMock.mockResolvedValueOnce([200, 'success', [storyEntry()]]);
+
+    const { loader } = await import('./_main.($lang)._index');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/en',
+      params: { lang: 'en' },
+    });
+
+    expect(fetchStoriesMock).toHaveBeenCalledExactlyOnceWith('en');
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    expect(outcome.data.title).toBe('en:meta.title');
+    expect(outcome.data.testimonials).toHaveLength(1);
+    expect(outcome.data.testimonials[0]).toMatchObject({
+      slug: 'acme',
+      quote: 'Game changer',
+    });
+  });
+
+  it('returns testimonials and FR meta when fetchStories(fr) succeeds', async () => {
+    fetchStoriesMock.mockResolvedValueOnce([
+      200,
+      'success',
+      [storyEntry({ slug: 'beta', quotes: ['Bouleversé'] })],
+    ]);
+
+    const { loader } = await import('./_main.($lang)._index');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/fr',
+      params: { lang: 'fr' },
+    });
+
+    expect(fetchStoriesMock).toHaveBeenCalledExactlyOnceWith('fr');
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    expect(outcome.data.title).toBe('fr:meta.title');
+    expect(outcome.data.testimonials).toHaveLength(1);
+    expect(outcome.data.testimonials[0]).toMatchObject({
+      slug: 'beta',
+      quote: 'Bouleversé',
+    });
+  });
+
+  it('falls back to fetchStories("fr") when fetchStories(lang) returns ≠ 200', async () => {
+    fetchStoriesMock
+      .mockResolvedValueOnce([500, 'source_error', undefined])
+      .mockResolvedValueOnce([
+        200,
+        'success',
+        [storyEntry({ slug: 'fallback' })],
+      ]);
+
+    const { loader } = await import('./_main.($lang)._index');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/en',
+      params: { lang: 'en' },
+    });
+
+    expect(fetchStoriesMock).toHaveBeenCalledTimes(2);
+    expect(fetchStoriesMock).toHaveBeenNthCalledWith(1, 'en');
+    expect(fetchStoriesMock).toHaveBeenNthCalledWith(2, 'fr');
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    expect(outcome.data.testimonials).toHaveLength(1);
+    expect(outcome.data.testimonials[0].slug).toBe('fallback');
+  });
+
+  it('does not fall back when fetchStories("fr") returns ≠ 200 (no infinite retry)', async () => {
+    fetchStoriesMock.mockResolvedValueOnce([500, 'source_error', undefined]);
+
+    const { loader } = await import('./_main.($lang)._index');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/fr',
+      params: { lang: 'fr' },
+    });
+
+    expect(fetchStoriesMock).toHaveBeenCalledExactlyOnceWith('fr');
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    expect(outcome.data.testimonials).toEqual([]);
+  });
+});

--- a/app/test/loader-harness.test.ts
+++ b/app/test/loader-harness.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the React Router v7 loader test harness.
+ *
+ * The harness lets unit tests invoke a route loader directly with a
+ * synthesized {@link LoaderFunctionArgs}, then inspect the loader's return
+ * value or any Response it returned/threw (redirects, 404s, …).
+ *
+ * Usage:
+ *
+ *     const outcome = await invokeLoader(loader, {
+ *       params: { lang: 'en' },
+ *       url: 'http://test.local/en',
+ *     });
+ *     if (outcome.type === 'data') expect(outcome.data).toEqual(...);
+ *     if (outcome.type === 'response') expect(outcome.response.status).toBe(301);
+ */
+
+import { type LoaderFunctionArgs, redirect } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { invokeLoader } from './loader-harness';
+
+describe('invokeLoader', () => {
+  it('returns the loader value as { type: "data" } for a plain return', async () => {
+    const loader = async (_args: LoaderFunctionArgs) => ({ hello: 'world' });
+
+    const outcome = await invokeLoader(loader);
+
+    expect(outcome).toEqual({ type: 'data', data: { hello: 'world' } });
+  });
+
+  it('captures a thrown Response (RR redirect) as { type: "response" }', async () => {
+    const loader = async (_args: LoaderFunctionArgs) => {
+      throw redirect('/fr', 301);
+    };
+
+    const outcome = await invokeLoader(loader);
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(301);
+    expect(outcome.response.headers.get('Location')).toBe('/fr');
+  });
+
+  it('captures a returned Response (e.g. data() error) as { type: "response" }', async () => {
+    const loader = async (_args: LoaderFunctionArgs) =>
+      new Response(null, { status: 404 });
+
+    const outcome = await invokeLoader(loader);
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(404);
+  });
+
+  it('rethrows non-Response errors so tests see real failures', async () => {
+    const loader = async (_args: LoaderFunctionArgs) => {
+      throw new Error('boom');
+    };
+
+    await expect(invokeLoader(loader)).rejects.toThrow('boom');
+  });
+
+  it('passes synthesized request and params through to the loader', async () => {
+    const loader = async ({ request, params }: LoaderFunctionArgs) => ({
+      url: request.url,
+      lang: params.lang,
+    });
+
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/en',
+      params: { lang: 'en' },
+    });
+
+    expect(outcome).toEqual({
+      type: 'data',
+      data: { url: 'http://test.local/en', lang: 'en' },
+    });
+  });
+});

--- a/app/test/loader-harness.ts
+++ b/app/test/loader-harness.ts
@@ -1,0 +1,55 @@
+/**
+ * React Router v7 loader test harness.
+ *
+ * Invokes a route loader with a synthesized {@link LoaderFunctionArgs} and
+ * normalises the result into a tagged union so tests can branch on data vs
+ * Response (redirects, 4xx, …) without try/catch boilerplate.
+ *
+ * See `loader-harness.test.ts` for examples.
+ */
+
+import type { LoaderFunctionArgs } from 'react-router';
+
+export type LoaderOutcome<T> =
+  | { type: 'data'; data: T }
+  | { type: 'response'; response: Response };
+
+export interface InvokeLoaderOptions {
+  /** Request URL. Defaults to `http://test.local/`. Ignored when `request` is set. */
+  url?: string;
+  /** Route params. Defaults to `{}`. */
+  params?: Record<string, string>;
+  /** Pre-built `Request`. Wins over `url`. */
+  request?: Request;
+}
+
+type AnyLoader<T> = (args: LoaderFunctionArgs) => Promise<T> | T;
+
+export async function invokeLoader<T>(
+  loader: AnyLoader<T>,
+  options: InvokeLoaderOptions = {},
+): Promise<LoaderOutcome<Awaited<T>>> {
+  const request =
+    options.request ?? new Request(options.url ?? 'http://test.local/');
+  const params = options.params ?? {};
+  const args: LoaderFunctionArgs = {
+    request,
+    params,
+    context: {} as LoaderFunctionArgs['context'],
+    // RR v7 internal field; not part of public route loader contract but
+    // required by the type. Loaders that reach for it are an anti-pattern.
+    unstable_pattern: options.url ?? '/',
+  };
+  try {
+    const result = await loader(args);
+    if (result instanceof Response) {
+      return { type: 'response', response: result };
+    }
+    return { type: 'data', data: result as Awaited<T> };
+  } catch (thrown) {
+    if (thrown instanceof Response) {
+      return { type: 'response', response: thrown };
+    }
+    throw thrown;
+  }
+}

--- a/progress.txt
+++ b/progress.txt
@@ -1052,4 +1052,79 @@ real URLs.
 PR done — merged 96ccda9, lane unapplied. Awaiting 1–2 days of RUM
 data before closing #165 (see resumption checklist above).
 
+---
 
+## Feature: Loader test harness + homepage coverage (#131, PRD #121)
+
+Specs: gh issue #131 (PRD #121 — Testing strategy)
+Branch: feat/loader-test-harness
+Created: 2026-05-14
+Status: PR not opened yet — local lane only.
+
+Key decisions before code:
+- Tagged-union outcome (`{ type: 'data' | 'response' }`) so tests can
+  branch on data vs Response without try/catch noise. Captures both
+  thrown Responses (RR redirects, getLang 404) and returned Responses.
+- Co-locate route tests next to the route (`*.test.tsx` beside route
+  file) rather than under `app/test/routes/`; exclude `*.test.ts(x)`
+  from `flatRoutes()` scan via `ignoredRouteFiles`.
+- Mock `~/modules/content` (`fetchStories`) + `~/localization/i18n.server`
+  (`getFixedT` stub) + `~/modules/feature-flags`. Single-entry mock
+  sidesteps `shuffleArray`/`Math.random` non-determinism (assert by slug).
+
+Resumption checklist:
+- `but push`, open PR against main, link #131 + #121.
+- After merge: #131 closed unblocks #153 (homepage N+1 EN→FR refactor).
+- Reuse harness for #145 (blog + jobs detail loader coverage) and #144
+  (sitemap loader coverage).
+
+### Slice #131-1 — 4a2a40b
+
+Loader harness + self-tests.
+
+Files:
+- app/test/loader-harness.ts (new — `invokeLoader<T>` + `LoaderOutcome<T>`)
+- app/test/loader-harness.test.ts (new — 5 cases: data, thrown Response,
+  returned Response, non-Response throw rethrow, args passthrough)
+
+Decisions / deviations:
+- `unstable_pattern` required on `LoaderFunctionArgs` in RR v7; populated
+  with the request URL. Tests don't and shouldn't read it.
+
+Checks: pnpm check ✅ pnpm typecheck ✅ harness tests 5/5 ✅
+
+### Slice #131-2 — 4a6d38c
+
+`flatRoutes({ ignoredRouteFiles: ['**/*.test.{ts,tsx}'] })`.
+
+Files:
+- app/routes.ts (add `ignoredRouteFiles` option)
+
+Decisions / deviations:
+- Without this, `react-router typegen` emits `+types/<route>.test.ts`
+  shims and `vitest` then fails to find suites in them.
+
+Checks: pnpm check ✅ pnpm typecheck ✅ pnpm test:run 22/22 ✅
+
+### Slice #131-3 — e804362
+
+Homepage loader: 4 cases via harness.
+
+Files:
+- app/routes/_main.($lang)._index.test.tsx (new — EN happy, FR happy,
+  EN→FR fallback when fetchStories(en) ≠ 200, no infinite retry when FR
+  itself ≠ 200)
+
+Decisions / deviations:
+- Dynamic `await import('./_main.($lang)._index')` so `vi.mock()` hoists
+  before the loader module evaluates its imports (top-level `import` is
+  still hoisted above `vi.mock`, but using the dynamic form is the
+  pattern Vitest docs recommend for module-scope mocks affecting the
+  unit under test).
+- Single-entry mock list — `shuffleArray` + `quotes[random]` collapse to
+  deterministic output; assert by slug + quote string.
+
+Checks: pnpm check ✅ pnpm typecheck ✅ pnpm test:run 22 files / 306
+tests ✅
+
+Next ⏭️ open PR (#131) → after merge, pick #153 (homepage N+1).


### PR DESCRIPTION
## Summary
- New `invokeLoader` test harness at `app/test/loader-harness.ts` — synthesises `LoaderFunctionArgs`, returns a tagged `LoaderOutcome` (`data` | `response`), captures both thrown and returned `Response`s.
- First consumer: homepage loader (`_main.($lang)._index.tsx`) — EN happy, FR happy, EN→FR fallback when `fetchStories(lang)` returns ≠ 200, plus a guard against infinite retry when FR itself ≠ 200.
- `flatRoutes()` now ignores `**/*.test.{ts,tsx}` so route tests can live next to the route they cover (otherwise `react-router typegen` emits `+types/*.test.ts` shims that vitest then fails on).

Closes #131. Unblocks #153 (homepage N+1 EN→FR refactor) per the `perf-safety-net` gate.

## Test plan
- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test:run` — 22 files / 306 tests ✅
- [x] CI green