### PR TITLE
perf(home): parallelize EN→FR stories fallback (#153)

### DIFF
--- a/app/routes/_main.($lang)._index.test.tsx
+++ b/app/routes/_main.($lang)._index.test.tsx
@@ -3,10 +3,14 @@
  *
  * Covers the three observable behaviors of `loader` in
  * `_main.($lang)._index.tsx`:
- *  1. EN happy path — `fetchStories('en')` returns 200 → testimonials emitted.
- *  2. FR happy path — `fetchStories('fr')` returns 200 → testimonials emitted.
- *  3. EN → FR fallback — `fetchStories('en')` returns ≠ 200, `fetchStories('fr')`
- *     returns 200 → testimonials still emitted from the FR result.
+ *  1. EN happy path — `fetchStories('en')` returns 200 → EN testimonials emitted.
+ *     Note: the loader fires the FR fallback in parallel (perf #153), so two
+ *     `fetchStories` calls are expected even when EN succeeds.
+ *  2. FR happy path — `fetchStories('fr')` returns 200 → testimonials emitted,
+ *     no wasted fallback call.
+ *  3. EN → FR fallback — both fetches fire concurrently; `fetchStories('en')`
+ *     returns ≠ 200 → testimonials emitted from the FR result.
+ *  4. Parallelism — both fetches register before either resolves.
  *
  * Uses the `invokeLoader` harness (`app/test/loader-harness.ts`).
  */
@@ -64,7 +68,15 @@ afterEach(() => {
 
 describe('homepage loader', () => {
   it('returns testimonials and EN meta when fetchStories(en) succeeds', async () => {
-    fetchStoriesMock.mockResolvedValueOnce([200, 'success', [storyEntry()]]);
+    // Loader fires EN and FR in parallel (perf #153); EN result wins because
+    // its status is 200, so testimonials reflect the EN entry.
+    fetchStoriesMock
+      .mockResolvedValueOnce([200, 'success', [storyEntry()]])
+      .mockResolvedValueOnce([
+        200,
+        'success',
+        [storyEntry({ slug: 'fr-only', quotes: ['Ignored'] })],
+      ]);
 
     const { loader } = await import('./_main.($lang)._index');
     const outcome = await invokeLoader(loader, {
@@ -72,7 +84,9 @@ describe('homepage loader', () => {
       params: { lang: 'en' },
     });
 
-    expect(fetchStoriesMock).toHaveBeenCalledExactlyOnceWith('en');
+    expect(fetchStoriesMock).toHaveBeenCalledTimes(2);
+    expect(fetchStoriesMock).toHaveBeenNthCalledWith(1, 'en');
+    expect(fetchStoriesMock).toHaveBeenNthCalledWith(2, 'fr');
     expect(outcome.type).toBe('data');
     if (outcome.type !== 'data') return;
     expect(outcome.data.title).toBe('en:meta.title');
@@ -129,6 +143,41 @@ describe('homepage loader', () => {
     if (outcome.type !== 'data') return;
     expect(outcome.data.testimonials).toHaveLength(1);
     expect(outcome.data.testimonials[0].slug).toBe('fallback');
+  });
+
+  it('fires fetchStories(lang) and fetchStories("fr") in parallel for non-FR locales', async () => {
+    // Use deferred promises so we can observe both calls fire before either
+    // resolves — sequential `await fetchStories(lang); await fetchStories('fr')`
+    // would only register the second call after the first settles.
+    let resolveEn!: (value: [number, string, unknown]) => void;
+    let resolveFr!: (value: [number, string, unknown]) => void;
+    const enPromise = new Promise<[number, string, unknown]>((r) => {
+      resolveEn = r;
+    });
+    const frPromise = new Promise<[number, string, unknown]>((r) => {
+      resolveFr = r;
+    });
+
+    fetchStoriesMock
+      .mockReturnValueOnce(enPromise)
+      .mockReturnValueOnce(frPromise);
+
+    const { loader } = await import('./_main.($lang)._index');
+    const loaderPromise = invokeLoader(loader, {
+      url: 'http://test.local/en',
+      params: { lang: 'en' },
+    });
+
+    // Let the loader run up to its first await point.
+    await new Promise((r) => setImmediate(r));
+
+    expect(fetchStoriesMock).toHaveBeenCalledTimes(2);
+    expect(fetchStoriesMock).toHaveBeenNthCalledWith(1, 'en');
+    expect(fetchStoriesMock).toHaveBeenNthCalledWith(2, 'fr');
+
+    resolveEn([200, 'success', [storyEntry()]]);
+    resolveFr([200, 'success', [storyEntry({ slug: 'fr-only' })]]);
+    await loaderPromise;
   });
 
   it('does not fall back when fetchStories("fr") returns ≠ 200 (no infinite retry)', async () => {

--- a/app/routes/_main.($lang)._index.tsx
+++ b/app/routes/_main.($lang)._index.tsx
@@ -45,11 +45,16 @@ export const loader = createHybridLoader(async (args: LoaderFunctionArgs) => {
   const lang = getLang(args.params);
   const t = await i18nServer.getFixedT(lang, 'home');
 
-  let [status, _state, storiesData] = await fetchStories(lang);
+  // Stories only exist in French — fire the localized fetch and the FR
+  // fallback in parallel so the EN homepage doesn't pay a sequential RTT.
+  const [primary, fallback] = await Promise.all([
+    fetchStories(lang),
+    lang === 'fr' ? Promise.resolve(null) : fetchStories('fr'),
+  ]);
 
-  // Stories only exist in French — fall back to French quotes for other languages
-  if (status !== 200 && lang !== 'fr') {
-    [status, _state, storiesData] = await fetchStories('fr');
+  let [status, _state, storiesData] = primary;
+  if (status !== 200 && fallback) {
+    [status, _state, storiesData] = fallback;
   }
 
   let testimonials: Testimonial[] = [];

--- a/progress.txt
+++ b/progress.txt
@@ -1128,3 +1128,51 @@ Checks: pnpm check ✅ pnpm typecheck ✅ pnpm test:run 22 files / 306
 tests ✅
 
 Next ⏭️ open PR (#131) → after merge, pick #153 (homepage N+1).
+
+---
+
+## Feature: Homepage N+1 EN→FR parallel fallback (#153, PRD #120)
+
+Specs: gh issue #153 (PRD #120 — Performance)
+Branch: feat/perf-153-parallel-fallback
+Created: 2026-05-14
+Status: local lane, not yet pushed.
+
+Key decisions before code:
+- Keep the `fetchStories(lang)` → `fetchStories('fr')` fallback semantics
+  identical (status !== 200 ⇒ use FR). Only change is wire-level: fire
+  both fetches in parallel via `Promise.all`. FR locale skips the second
+  fetch (`Promise.resolve(null)`) to preserve the single-call contract
+  asserted by the no-infinite-retry test.
+- Reuse the existing loader test file from #131 rather than spinning up
+  a parallelism-specific spec. Added one deferred-promise test for the
+  parallelism contract; updated the EN happy-path expectation to two
+  calls with rationale in the file header (AC #3 allows it).
+
+Resumption checklist:
+- `but push`, open PR against main, link #153 + #120.
+- After merge: recheck Speed Insights EN homepage TTFB on 2026-05-16
+  for the -1s target (AC #4 ties back to #1 baseline).
+
+### Slice #153-1 — 3ae6fd4
+
+Parallel EN+FR fetch with status-based selection.
+
+Files:
+- app/routes/_main.($lang)._index.tsx (loader: `Promise.all` over
+  `fetchStories(lang)` + conditional FR fallback; primary result wins
+  on status 200, fallback used otherwise)
+- app/routes/_main.($lang)._index.test.tsx (new test: deferred
+  promises assert both fetches register before either resolves;
+  EN happy-path now expects two calls; file header rewritten)
+
+Decisions / deviations:
+- `lang === 'fr' ? Promise.resolve(null) : fetchStories('fr')` keeps the
+  FR-only call count at 1 — matches the no-infinite-retry test and
+  avoids a wasted refetch when the localized fetch is already FR.
+- Used `!`-suffix non-null assertions for the test's deferred
+  resolvers to satisfy Biome's `noEmptyBlockStatements` cleanly.
+
+Checks: pnpm check ✅ pnpm typecheck ✅ loader tests 5/5 ✅
+
+Next ⏭️ push lane + open PR linking #153 + #120.


### PR DESCRIPTION
## Summary
- Fires `fetchStories(lang)` and `fetchStories('fr')` concurrently via `Promise.all` so the EN homepage no longer pays a sequential RTT for the French fallback.
- Keeps existing semantics: primary result wins when status is 200; otherwise the FR result is used. FR locale skips the second fetch (single call).
- Adds a deferred-promise parallelism test; updates the EN happy-path test to expect two calls with rationale in the file header.

Closes #153 — parent PRD #120.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] `pnpm test:run` on `app/routes/_main.($lang)._index.test.tsx` (5/5 pass)
- [ ] Recheck EN homepage TTFB on Speed Insights after merge to confirm the -1s acceptance criterion