### PR TITLE
test(routes): blog + jobs detail loader safety-net (#145)

### DIFF
--- a/app/routes/_main.($lang).jobs.$slug.test.ts
+++ b/app/routes/_main.($lang).jobs.$slug.test.ts
@@ -1,7 +1,7 @@
 /**
  * Loader tests for the jobs detail route.
  *
- * Covers the observable behaviors of `loader` in `_main.($lang).jobs.$slug.tsx`:
+ * Covers the observable behaviours of `loader` in `_main.($lang).jobs.$slug.tsx`:
  *  1. Redirect to `/{lang}/jobs` when slug is missing (FR and EN)
  *  2. Redirect when `fetchJob` returns a non-200 status
  *  3. Redirect when job status is `draft`
@@ -178,6 +178,17 @@ describe('jobs detail loader', () => {
     expect(data.slug).toBe('revops-consultant');
     expect(data.sections).toBe(fakeSections);
     expect(data.ld).toBe('{}');
+  });
+
+  it('throws 404 when lang param is invalid', async () => {
+    const { loader } = await import('./_main.($lang).jobs.$slug');
+    const outcome = await invokeLoader(loader, {
+      params: { slug: 'test', lang: 'de' },
+    });
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(404);
   });
 
   it('returns job data with lang=en on happy path (EN)', async () => {

--- a/app/routes/_main.($lang).jobs.$slug.test.ts
+++ b/app/routes/_main.($lang).jobs.$slug.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Loader tests for the jobs detail route.
+ *
+ * Covers the observable behaviors of `loader` in `_main.($lang).jobs.$slug.tsx`:
+ *  1. Redirect to `/{lang}/jobs` when slug is missing (FR and EN)
+ *  2. Redirect when `fetchJob` returns a non-200 status
+ *  3. Redirect when job status is `draft`
+ *  4. Redirect when job status is `closed`
+ *  5. Happy path FR: returns job data with correct lang and slug
+ *  6. Happy path EN: same with lang param `en`
+ *
+ * Uses the `invokeLoader` harness (`app/test/loader-harness.ts`).
+ */
+
+import type { RenderableTreeNode } from '@markdoc/markdoc';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { JobFrontmatter } from '~/modules/schemas';
+import { invokeLoader } from '~/test/loader-harness';
+import type { MarkdocFile } from '~/types';
+
+const fetchJobMock = vi.fn();
+const loadMemberRegistryMock = vi.fn();
+const resolveMemberMock = vi.fn();
+const extractJobSectionsMock = vi.fn();
+const buildJobPostingLdMock = vi.fn();
+const serializeJsonLdMock = vi.fn();
+
+vi.mock('~/modules/content', () => ({
+  fetchJob: (...args: unknown[]) => fetchJobMock(...args),
+  loadMemberRegistry: () => loadMemberRegistryMock(),
+  resolveMember: (...args: unknown[]) => resolveMemberMock(...args),
+  extractJobSections: (...args: unknown[]) => extractJobSectionsMock(...args),
+  buildJobPostingLd: (...args: unknown[]) => buildJobPostingLdMock(...args),
+  serializeJsonLd: (...args: unknown[]) => serializeJsonLdMock(...args),
+}));
+
+function jobEntry(
+  overrides: Partial<JobFrontmatter> & { slug?: string } = {},
+): MarkdocFile<JobFrontmatter> {
+  const { slug = 'revops-consultant', ...frontmatterOverrides } = overrides;
+  return {
+    slug,
+    content: null as unknown as RenderableTreeNode,
+    markdown: '## Mission\n\nLead RevOps projects.',
+    frontmatter: {
+      title: 'RevOps Consultant',
+      icon: 'briefcase',
+      contractType: 'CDI',
+      seniority: 'Senior',
+      location: 'Paris',
+      hiringContact: 'jerome-boileux',
+      applyEmail: 'careers@ocobo.com',
+      status: 'published',
+      publishedAt: '2024-01-15',
+      intro: 'Join our growing RevOps team.',
+      ...frontmatterOverrides,
+    },
+  };
+}
+
+const fakeSections = {
+  mission: [],
+  responsabilites: [],
+  profil: [],
+};
+
+afterEach(() => {
+  fetchJobMock.mockReset();
+  loadMemberRegistryMock.mockReset();
+  resolveMemberMock.mockReset();
+  extractJobSectionsMock.mockReset();
+  buildJobPostingLdMock.mockReset();
+  serializeJsonLdMock.mockReset();
+});
+
+describe('jobs detail loader', () => {
+  it('redirects to /fr/jobs when slug is missing', async () => {
+    const { loader } = await import('./_main.($lang).jobs.$slug');
+    const outcome = await invokeLoader(loader, { params: {} });
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(302);
+    expect(outcome.response.headers.get('Location')).toBe('/fr/jobs');
+  });
+
+  it('redirects to /en/jobs when slug is missing and lang is en', async () => {
+    const { loader } = await import('./_main.($lang).jobs.$slug');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/en/jobs/missing',
+      params: { lang: 'en' },
+    });
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(302);
+    expect(outcome.response.headers.get('Location')).toBe('/en/jobs');
+  });
+
+  it('redirects to /fr/jobs when fetchJob returns non-200', async () => {
+    fetchJobMock.mockResolvedValueOnce([404, 'not_found', undefined]);
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+
+    const { loader } = await import('./_main.($lang).jobs.$slug');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/jobs/missing',
+      params: { slug: 'missing' },
+    });
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(302);
+    expect(outcome.response.headers.get('Location')).toBe('/fr/jobs');
+  });
+
+  it('redirects when job status is draft', async () => {
+    const job = jobEntry({ status: 'draft' });
+    fetchJobMock.mockResolvedValueOnce([200, 'success', job]);
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+
+    const { loader } = await import('./_main.($lang).jobs.$slug');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/jobs/revops-consultant',
+      params: { slug: 'revops-consultant' },
+    });
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(302);
+    expect(outcome.response.headers.get('Location')).toBe('/fr/jobs');
+  });
+
+  it('redirects when job status is closed', async () => {
+    const job = jobEntry({ status: 'closed' });
+    fetchJobMock.mockResolvedValueOnce([200, 'success', job]);
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+
+    const { loader } = await import('./_main.($lang).jobs.$slug');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/jobs/revops-consultant',
+      params: { slug: 'revops-consultant' },
+    });
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(302);
+    expect(outcome.response.headers.get('Location')).toBe('/fr/jobs');
+  });
+
+  it('returns job data with lang and slug on happy path (FR)', async () => {
+    const job = jobEntry();
+    fetchJobMock.mockResolvedValueOnce([200, 'success', job]);
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+    resolveMemberMock.mockReturnValueOnce(null);
+    extractJobSectionsMock.mockReturnValueOnce(fakeSections);
+    buildJobPostingLdMock.mockReturnValueOnce({});
+    serializeJsonLdMock.mockReturnValueOnce('{}');
+
+    const { loader } = await import('./_main.($lang).jobs.$slug');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/jobs/revops-consultant',
+      params: { slug: 'revops-consultant' },
+    });
+
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    const data = outcome.data as {
+      job: typeof job;
+      sections: typeof fakeSections;
+      contact: null;
+      lang: string;
+      slug: string;
+      ld: string;
+    };
+    expect(data.job).toBe(job);
+    expect(data.lang).toBe('fr');
+    expect(data.slug).toBe('revops-consultant');
+    expect(data.sections).toBe(fakeSections);
+    expect(data.ld).toBe('{}');
+  });
+
+  it('returns job data with lang=en on happy path (EN)', async () => {
+    const job = jobEntry();
+    fetchJobMock.mockResolvedValueOnce([200, 'success', job]);
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+    resolveMemberMock.mockReturnValueOnce(null);
+    extractJobSectionsMock.mockReturnValueOnce(fakeSections);
+    buildJobPostingLdMock.mockReturnValueOnce({});
+    serializeJsonLdMock.mockReturnValueOnce('{}');
+
+    const { loader } = await import('./_main.($lang).jobs.$slug');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/en/jobs/revops-consultant',
+      params: { lang: 'en', slug: 'revops-consultant' },
+    });
+
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    const data = outcome.data as { lang: string };
+    expect(data.lang).toBe('en');
+    expect(fetchJobMock).toHaveBeenCalledWith('revops-consultant', 'en');
+  });
+});

--- a/app/routes/_main.blog.$slug.test.ts
+++ b/app/routes/_main.blog.$slug.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Loader tests for the blog detail route.
+ *
+ * Covers the observable behaviors of `loader` in `_main.blog.$slug.tsx`:
+ *  1. 404 when slug is missing from params
+ *  2. 404 when `fetchBlogpost` returns a non-200 status
+ *  3. Happy path: article, toc, intro, and author returned
+ *  4. `intro` comes from `frontmatter.exerpt` when set (extractFirstParagraph not called)
+ *  5. `intro` falls back to `extractFirstParagraph` when no exerpt
+ *  6. `fetchBlogpost` is called with the correct lang (EN variant)
+ *
+ * Uses the `invokeLoader` harness (`app/test/loader-harness.ts`).
+ */
+
+import type { RenderableTreeNode } from '@markdoc/markdoc';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { BlogpostFrontmatter } from '~/modules/schemas';
+import { invokeLoader } from '~/test/loader-harness';
+import type { MarkdocFile } from '~/types';
+
+const fetchBlogpostMock = vi.fn();
+const loadMemberRegistryMock = vi.fn();
+const resolveMemberMock = vi.fn();
+const extractTocMock = vi.fn();
+const extractFirstParagraphMock = vi.fn();
+
+vi.mock('~/modules/content', () => ({
+  fetchBlogpost: (...args: unknown[]) => fetchBlogpostMock(...args),
+  loadMemberRegistry: () => loadMemberRegistryMock(),
+}));
+
+vi.mock('~/modules/content/members', () => ({
+  resolveMember: (...args: unknown[]) => resolveMemberMock(...args),
+}));
+
+vi.mock('~/modules/content/toc', () => ({
+  extractToc: (...args: unknown[]) => extractTocMock(...args),
+  extractFirstParagraph: (...args: unknown[]) =>
+    extractFirstParagraphMock(...args),
+}));
+
+function blogEntry(
+  overrides: Partial<BlogpostFrontmatter> & { slug?: string } = {},
+): MarkdocFile<BlogpostFrontmatter> {
+  const { slug = 'test-slug', ...frontmatterOverrides } = overrides;
+  return {
+    slug,
+    content: null as unknown as RenderableTreeNode,
+    markdown: '# Test\n\nIntro paragraph.',
+    frontmatter: {
+      title: 'Test Article',
+      description: 'Test description',
+      author: 'jerome-boileux',
+      image: 'https://example.com/image.jpg',
+      date: '2024-01-15',
+      tags: ['revops'],
+      read: '5 min',
+      ...frontmatterOverrides,
+    },
+  };
+}
+
+afterEach(() => {
+  fetchBlogpostMock.mockReset();
+  loadMemberRegistryMock.mockReset();
+  resolveMemberMock.mockReset();
+  extractTocMock.mockReset();
+  extractFirstParagraphMock.mockReset();
+});
+
+describe('blog detail loader', () => {
+  it('throws 404 when slug is missing', async () => {
+    const { loader } = await import('./_main.blog.$slug');
+    const outcome = await invokeLoader(loader, { params: {} });
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(404);
+  });
+
+  it('throws 404 when fetchBlogpost returns non-200', async () => {
+    fetchBlogpostMock.mockResolvedValueOnce([404, 'not_found', undefined]);
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+
+    const { loader } = await import('./_main.blog.$slug');
+    const outcome = await invokeLoader(loader, { params: { slug: 'missing' } });
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(404);
+  });
+
+  it('returns article, toc, intro, and author on happy path', async () => {
+    const article = blogEntry();
+    fetchBlogpostMock.mockResolvedValueOnce([200, 'success', article]);
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+    resolveMemberMock.mockReturnValueOnce(null);
+    extractTocMock.mockReturnValueOnce([{ id: 'test', children: [] }]);
+    extractFirstParagraphMock.mockReturnValueOnce('Intro paragraph.');
+
+    const { loader } = await import('./_main.blog.$slug');
+    const outcome = await invokeLoader(loader, {
+      params: { slug: 'test-slug' },
+    });
+
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    // loader returns data() wrapper — actual payload is at .data
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const payload = (outcome.data as any).data;
+    expect(payload.article).toBe(article);
+    expect(payload.toc).toEqual([{ id: 'test', children: [] }]);
+    expect(payload.intro).toBe('Intro paragraph.');
+    expect(payload.author).toBeNull();
+  });
+
+  it('uses frontmatter.exerpt as intro when set', async () => {
+    const article = blogEntry({ exerpt: 'Explicit excerpt text.' });
+    fetchBlogpostMock.mockResolvedValueOnce([200, 'success', article]);
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+    resolveMemberMock.mockReturnValueOnce(null);
+    extractTocMock.mockReturnValueOnce([]);
+
+    const { loader } = await import('./_main.blog.$slug');
+    const outcome = await invokeLoader(loader, {
+      params: { slug: 'test-slug' },
+    });
+
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const payload = (outcome.data as any).data;
+    expect(payload.intro).toBe('Explicit excerpt text.');
+    expect(extractFirstParagraphMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to extractFirstParagraph when no exerpt', async () => {
+    const article = blogEntry();
+    fetchBlogpostMock.mockResolvedValueOnce([200, 'success', article]);
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+    resolveMemberMock.mockReturnValueOnce(null);
+    extractTocMock.mockReturnValueOnce([]);
+    extractFirstParagraphMock.mockReturnValueOnce('Extracted paragraph.');
+
+    const { loader } = await import('./_main.blog.$slug');
+    const outcome = await invokeLoader(loader, {
+      params: { slug: 'test-slug' },
+    });
+
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const payload = (outcome.data as any).data;
+    expect(payload.intro).toBe('Extracted paragraph.');
+    expect(extractFirstParagraphMock).toHaveBeenCalledOnce();
+  });
+
+  it('calls fetchBlogpost with EN lang when lang param is en', async () => {
+    const article = blogEntry();
+    fetchBlogpostMock.mockResolvedValueOnce([200, 'success', article]);
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+    resolveMemberMock.mockReturnValueOnce(null);
+    extractTocMock.mockReturnValueOnce([]);
+    extractFirstParagraphMock.mockReturnValueOnce(null);
+
+    const { loader } = await import('./_main.blog.$slug');
+    await invokeLoader(loader, { params: { slug: 'en-post', lang: 'en' } });
+
+    expect(fetchBlogpostMock).toHaveBeenCalledWith('en-post', 'en');
+  });
+});

--- a/app/routes/_main.blog.$slug.test.ts
+++ b/app/routes/_main.blog.$slug.test.ts
@@ -1,7 +1,7 @@
 /**
  * Loader tests for the blog detail route.
  *
- * Covers the observable behaviors of `loader` in `_main.blog.$slug.tsx`:
+ * Covers the observable behaviours of `loader` in `_main.blog.$slug.tsx`:
  *  1. 404 when slug is missing from params
  *  2. 404 when `fetchBlogpost` returns a non-200 status
  *  3. Happy path: article, toc, intro, and author returned
@@ -106,13 +106,10 @@ describe('blog detail loader', () => {
 
     expect(outcome.type).toBe('data');
     if (outcome.type !== 'data') return;
-    // loader returns data() wrapper — actual payload is at .data
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const payload = (outcome.data as any).data;
-    expect(payload.article).toBe(article);
-    expect(payload.toc).toEqual([{ id: 'test', children: [] }]);
-    expect(payload.intro).toBe('Intro paragraph.');
-    expect(payload.author).toBeNull();
+    expect(outcome.data.article).toBe(article);
+    expect(outcome.data.toc).toEqual([{ id: 'test', children: [] }]);
+    expect(outcome.data.intro).toBe('Intro paragraph.');
+    expect(outcome.data.author).toBeNull();
   });
 
   it('uses frontmatter.exerpt as intro when set', async () => {
@@ -129,9 +126,7 @@ describe('blog detail loader', () => {
 
     expect(outcome.type).toBe('data');
     if (outcome.type !== 'data') return;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const payload = (outcome.data as any).data;
-    expect(payload.intro).toBe('Explicit excerpt text.');
+    expect(outcome.data.intro).toBe('Explicit excerpt text.');
     expect(extractFirstParagraphMock).not.toHaveBeenCalled();
   });
 
@@ -150,10 +145,19 @@ describe('blog detail loader', () => {
 
     expect(outcome.type).toBe('data');
     if (outcome.type !== 'data') return;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const payload = (outcome.data as any).data;
-    expect(payload.intro).toBe('Extracted paragraph.');
+    expect(outcome.data.intro).toBe('Extracted paragraph.');
     expect(extractFirstParagraphMock).toHaveBeenCalledOnce();
+  });
+
+  it('throws 404 when lang param is invalid', async () => {
+    const { loader } = await import('./_main.blog.$slug');
+    const outcome = await invokeLoader(loader, {
+      params: { slug: 'test', lang: 'de' },
+    });
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(404);
   });
 
   it('calls fetchBlogpost with EN lang when lang param is en', async () => {

--- a/app/test/loader-harness.ts
+++ b/app/test/loader-harness.ts
@@ -5,13 +5,36 @@
  * normalises the result into a tagged union so tests can branch on data vs
  * Response (redirects, 4xx, …) without try/catch boilerplate.
  *
+ * When the loader returns via react-router's `data(payload, init)` helper, the
+ * `DataWithResponseInit` wrapper is automatically unwrapped so `outcome.data`
+ * holds the payload directly — no `.data.data` double-access in tests.
+ *
  * See `loader-harness.test.ts` for examples.
  */
 
-import type { LoaderFunctionArgs } from 'react-router';
+import type {
+  LoaderFunctionArgs,
+  UNSAFE_DataWithResponseInit,
+} from 'react-router';
+
+// Strip the DataWithResponseInit wrapper produced by react-router's data() helper.
+type UnwrapLoaderData<T> = T extends UNSAFE_DataWithResponseInit<infer U>
+  ? U
+  : T;
+
+// Duck-type guard for DataWithResponseInit — the class is not a runtime export.
+function isDataWrapper(
+  value: unknown,
+): value is { type: 'DataWithResponseInit'; data: unknown } {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    (value as Record<string, unknown>).type === 'DataWithResponseInit'
+  );
+}
 
 export type LoaderOutcome<T> =
-  | { type: 'data'; data: T }
+  | { type: 'data'; data: UnwrapLoaderData<Awaited<T>> }
   | { type: 'response'; response: Response };
 
 export interface InvokeLoaderOptions {
@@ -28,7 +51,7 @@ type AnyLoader<T> = (args: LoaderFunctionArgs) => Promise<T> | T;
 export async function invokeLoader<T>(
   loader: AnyLoader<T>,
   options: InvokeLoaderOptions = {},
-): Promise<LoaderOutcome<Awaited<T>>> {
+): Promise<LoaderOutcome<T>> {
   const request =
     options.request ?? new Request(options.url ?? 'http://test.local/');
   const params = options.params ?? {};
@@ -45,7 +68,11 @@ export async function invokeLoader<T>(
     if (result instanceof Response) {
       return { type: 'response', response: result };
     }
-    return { type: 'data', data: result as Awaited<T> };
+    const payload = isDataWrapper(result) ? result.data : result;
+    return {
+      type: 'data',
+      data: payload as UnwrapLoaderData<Awaited<T>>,
+    };
   } catch (thrown) {
     if (thrown instanceof Response) {
       return { type: 'response', response: thrown };


### PR DESCRIPTION
## Summary

- Adds `_main.blog.$slug.test.ts` — 6 loader tests covering: 404 on missing slug, 404 on non-200 fetch, happy path data shape, `exerpt`-vs-`extractFirstParagraph` intro logic, EN lang variant
- Adds `_main.($lang).jobs.$slug.test.ts` — 7 loader tests covering: redirect on missing slug (FR + EN), redirect on non-200, redirect on draft/closed status, happy path FR + EN

Both files reuse the `invokeLoader` harness from #131 and follow the pattern established in the homepage loader test.

## Closes
Fixes #145

## Test plan
- [x] `pnpm test:run` — all 13 new tests pass, no regressions
- [x] `pnpm check && pnpm typecheck` — green