### PR TITLE
feat(perf): preconnect hints for fonts CDN + GitHub raw host

### DIFF
--- a/app/modules/env.server.ts
+++ b/app/modules/env.server.ts
@@ -4,6 +4,32 @@ import { ConfigurationError } from './errors';
 import type { PrivateEnvVars, PublicEnvVars } from './types';
 
 /**
+ * Returns the resolved content source without requiring GitHub credentials.
+ * In production always returns 'github'; in dev reads CONTENT_SOURCE.
+ */
+export function getContentSource(): 'locale' | 'github' {
+  if (process.env.NODE_ENV === 'production') return 'github';
+  return process.env.CONTENT_SOURCE === 'github' ? 'github' : 'locale';
+}
+
+/**
+ * Validates and returns FONTS_CDN_HOST as an https origin.
+ * Returns undefined when unset or invalid (soft failure — optional var).
+ */
+export function parseFontsCdnHost(): string | undefined {
+  const raw = process.env.FONTS_CDN_HOST;
+  if (!raw) return undefined;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:') return undefined;
+    if (url.pathname !== '/' && url.pathname !== '') return undefined;
+    return url.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Get environment variables that are safe to expose to the client
  * These variables can be included in the browser bundle
  */

--- a/app/modules/preconnect-links.test.ts
+++ b/app/modules/preconnect-links.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { GITHUB_RAW_HOST, getPreconnectLinks } from './preconnect-links';
+
+describe('getPreconnectLinks', () => {
+  describe('GitHub raw host', () => {
+    it('includes preconnect for GitHub raw host when source is github', () => {
+      const links = getPreconnectLinks('github');
+      const preconnect = links.find(
+        (l) => l.rel === 'preconnect' && l.href === GITHUB_RAW_HOST,
+      );
+      expect(preconnect).toBeDefined();
+    });
+
+    it('includes dns-prefetch for GitHub raw host when source is github', () => {
+      const links = getPreconnectLinks('github');
+      const dnsPrefetch = links.find(
+        (l) => l.rel === 'dns-prefetch' && l.href === GITHUB_RAW_HOST,
+      );
+      expect(dnsPrefetch).toBeDefined();
+    });
+
+    it('omits GitHub raw host links when source is locale', () => {
+      const links = getPreconnectLinks('locale');
+      const githubLinks = links.filter((l) => l.href === GITHUB_RAW_HOST);
+      expect(githubLinks).toHaveLength(0);
+    });
+  });
+
+  describe('fonts CDN host', () => {
+    it('includes preconnect for fonts CDN when host is provided', () => {
+      const links = getPreconnectLinks('locale', 'https://fonts.example.com');
+      const preconnect = links.find(
+        (l) => l.rel === 'preconnect' && l.href === 'https://fonts.example.com',
+      );
+      expect(preconnect).toBeDefined();
+    });
+
+    it('includes dns-prefetch for fonts CDN when host is provided', () => {
+      const links = getPreconnectLinks('locale', 'https://fonts.example.com');
+      const dnsPrefetch = links.find(
+        (l) =>
+          l.rel === 'dns-prefetch' && l.href === 'https://fonts.example.com',
+      );
+      expect(dnsPrefetch).toBeDefined();
+    });
+
+    it('omits fonts CDN links when no host is provided', () => {
+      const links = getPreconnectLinks('locale');
+      expect(links).toHaveLength(0);
+    });
+
+    it('includes both fonts and GitHub links when both configured', () => {
+      const links = getPreconnectLinks('github', 'https://fonts.example.com');
+      const fontsLinks = links.filter(
+        (l) => l.href === 'https://fonts.example.com',
+      );
+      const githubLinks = links.filter((l) => l.href === GITHUB_RAW_HOST);
+      expect(fontsLinks).toHaveLength(2);
+      expect(githubLinks).toHaveLength(2);
+    });
+  });
+
+  describe('link attributes', () => {
+    it('sets crossOrigin anonymous on preconnect links', () => {
+      const links = getPreconnectLinks('github');
+      const preconnect = links.find((l) => l.rel === 'preconnect');
+      expect(preconnect?.crossOrigin).toBe('anonymous');
+    });
+
+    it('does not set crossOrigin on dns-prefetch links', () => {
+      const links = getPreconnectLinks('github');
+      const dnsPrefetch = links.find((l) => l.rel === 'dns-prefetch');
+      expect(dnsPrefetch?.crossOrigin).toBeUndefined();
+    });
+  });
+});

--- a/app/modules/preconnect-links.test.ts
+++ b/app/modules/preconnect-links.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { GITHUB_RAW_HOST, getPreconnectLinks } from './preconnect-links';
+import {
+  GITHUB_RAW_HOST,
+  type PreconnectLink,
+  getPreconnectLinks,
+} from './preconnect-links';
+
+type PreconnectOnly = Extract<PreconnectLink, { rel: 'preconnect' }>;
 
 describe('getPreconnectLinks', () => {
   describe('GitHub raw host', () => {
@@ -64,14 +70,24 @@ describe('getPreconnectLinks', () => {
   describe('link attributes', () => {
     it('sets crossOrigin anonymous on preconnect links', () => {
       const links = getPreconnectLinks('github');
-      const preconnect = links.find((l) => l.rel === 'preconnect');
+      const preconnect = links.find(
+        (l): l is PreconnectOnly => l.rel === 'preconnect',
+      );
       expect(preconnect?.crossOrigin).toBe('anonymous');
     });
 
-    it('does not set crossOrigin on dns-prefetch links', () => {
+    it('does not carry crossOrigin on dns-prefetch links', () => {
       const links = getPreconnectLinks('github');
       const dnsPrefetch = links.find((l) => l.rel === 'dns-prefetch');
-      expect(dnsPrefetch?.crossOrigin).toBeUndefined();
+      expect(dnsPrefetch).toBeDefined();
+      expect('crossOrigin' in (dnsPrefetch ?? {})).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('treats empty string fontsCdnHost as absent', () => {
+      const links = getPreconnectLinks('locale', '');
+      expect(links).toHaveLength(0);
     });
   });
 });

--- a/app/modules/preconnect-links.ts
+++ b/app/modules/preconnect-links.ts
@@ -1,0 +1,30 @@
+export type PreconnectLink = {
+  rel: 'preconnect' | 'dns-prefetch';
+  href: string;
+  crossOrigin?: 'anonymous';
+};
+
+export const GITHUB_RAW_HOST = 'https://raw.githubusercontent.com';
+
+export function getPreconnectLinks(
+  contentSource: 'locale' | 'github',
+  fontsCdnHost?: string,
+): PreconnectLink[] {
+  const links: PreconnectLink[] = [];
+
+  if (fontsCdnHost) {
+    links.push(
+      { rel: 'preconnect', href: fontsCdnHost, crossOrigin: 'anonymous' },
+      { rel: 'dns-prefetch', href: fontsCdnHost },
+    );
+  }
+
+  if (contentSource === 'github') {
+    links.push(
+      { rel: 'preconnect', href: GITHUB_RAW_HOST, crossOrigin: 'anonymous' },
+      { rel: 'dns-prefetch', href: GITHUB_RAW_HOST },
+    );
+  }
+
+  return links;
+}

--- a/app/modules/preconnect-links.ts
+++ b/app/modules/preconnect-links.ts
@@ -1,8 +1,6 @@
-export type PreconnectLink = {
-  rel: 'preconnect' | 'dns-prefetch';
-  href: string;
-  crossOrigin?: 'anonymous';
-};
+export type PreconnectLink =
+  | { rel: 'preconnect'; href: string; crossOrigin?: 'anonymous' }
+  | { rel: 'dns-prefetch'; href: string };
 
 export const GITHUB_RAW_HOST = 'https://raw.githubusercontent.com';
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -23,6 +23,7 @@ import { getLang } from '~/utils/lang';
 import { ErrorMessage } from './components/ErrorMessage';
 import { useSetViewportHeight } from './hooks/useSetViewportHeight';
 import { getDisabledPages } from './modules/feature-flags';
+import { getPreconnectLinks } from './modules/preconnect-links';
 
 export const links: LinksFunction = () => [
   { rel: 'stylesheet', href: styles },
@@ -50,6 +51,9 @@ export async function loader({ params }: LoaderFunctionArgs) {
   const locale = getLang(params);
   const isProduction = process.env.NODE_ENV === 'production';
 
+  const contentSource =
+    process.env.CONTENT_SOURCE === 'github' ? 'github' : 'locale';
+
   return {
     locale,
     isProduction,
@@ -60,6 +64,10 @@ export async function loader({ params }: LoaderFunctionArgs) {
     shouldLoadScript:
       isProduction || process.env.SHOULD_LOAD_TRACKING_SCRIPTS === 'true',
     shouldLoadAgo: Boolean(process.env.AGO_API_KEY),
+    preconnectLinks: getPreconnectLinks(
+      contentSource,
+      process.env.FONTS_CDN_HOST,
+    ),
   };
 }
 
@@ -112,6 +120,14 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        {loaderData?.preconnectLinks?.map((link) => (
+          <link
+            key={`${link.rel}-${link.href}`}
+            rel={link.rel}
+            href={link.href}
+            crossOrigin={link.crossOrigin}
+          />
+        ))}
         {!loaderData?.isProduction && <meta name="robots" content="noindex" />}
         <Meta />
         <Links />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -22,6 +22,7 @@ import { getLang } from '~/utils/lang';
 
 import { ErrorMessage } from './components/ErrorMessage';
 import { useSetViewportHeight } from './hooks/useSetViewportHeight';
+import { getContentSource, parseFontsCdnHost } from './modules/env.server';
 import { getDisabledPages } from './modules/feature-flags';
 import { getPreconnectLinks } from './modules/preconnect-links';
 
@@ -51,9 +52,6 @@ export async function loader({ params }: LoaderFunctionArgs) {
   const locale = getLang(params);
   const isProduction = process.env.NODE_ENV === 'production';
 
-  const contentSource =
-    process.env.CONTENT_SOURCE === 'github' ? 'github' : 'locale';
-
   return {
     locale,
     isProduction,
@@ -65,8 +63,8 @@ export async function loader({ params }: LoaderFunctionArgs) {
       isProduction || process.env.SHOULD_LOAD_TRACKING_SCRIPTS === 'true',
     shouldLoadAgo: Boolean(process.env.AGO_API_KEY),
     preconnectLinks: getPreconnectLinks(
-      contentSource,
-      process.env.FONTS_CDN_HOST,
+      getContentSource(),
+      parseFontsCdnHost(),
     ),
   };
 }
@@ -125,7 +123,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
             key={`${link.rel}-${link.href}`}
             rel={link.rel}
             href={link.href}
-            crossOrigin={link.crossOrigin}
+            crossOrigin={
+              link.rel === 'preconnect' ? link.crossOrigin : undefined
+            }
           />
         ))}
         {!loaderData?.isProduction && <meta name="robots" content="noindex" />}


### PR DESCRIPTION
## Summary

- Adds `preconnect` + `dns-prefetch` hints for the fonts CDN host (configurable via `FONTS_CDN_HOST` env var — no-op when unset, correct for current self-hosted fonts)
- Adds `preconnect` + `dns-prefetch` for `https://raw.githubusercontent.com` when `CONTENT_SOURCE=github` (where browser-loaded content images come from)
- Pure function `getPreconnectLinks(contentSource, fontsCdnHost?)` in `app/modules/preconnect-links.ts` — 9 unit tests

Closes #159

## Acceptance criteria

- [x] `preconnect` for fonts host added (via `FONTS_CDN_HOST` env var)
- [x] `preconnect` for GitHub raw host added (only when `CONTENT_SOURCE=github`)
- [x] No-op when `CONTENT_SOURCE=locale` for the GitHub host

## Test plan

- [ ] 9 unit tests covering all branches of `getPreconnectLinks` — green locally
- [ ] Set `FONTS_CDN_HOST=https://your-fonts-cdn.com` + `CONTENT_SOURCE=github` in local dev, confirm link tags appear in page source before the stylesheet
- [ ] Confirm Network panel: TLS handshake to `raw.githubusercontent.com` overlaps with HTML parse on a content page