### PR TITLE
fix(cache): omit cache headers in locale content source

### DIFF
--- a/app/modules/cache.test.ts
+++ b/app/modules/cache.test.ts
@@ -73,15 +73,15 @@ describe('getCacheHeaders', () => {
   describe('locale content source', () => {
     beforeEach(() => mockEnv('locale'));
 
-    it('returns no-cache for all strategies', () => {
+    it('returns no headers — no CDN in locale mode', () => {
       const headers = getCacheHeaders('blogPost');
-      expect(headers['Cache-Control']).toBe('no-cache');
-      expect(headers['Vercel-CDN-Cache-Control']).toBe('no-cache');
+      expect(headers).toEqual({});
     });
 
-    it('does not include Vary header', () => {
-      const headers = getCacheHeaders('static');
-      expect(headers).not.toHaveProperty('Vary');
+    it('returns no headers for any strategy', () => {
+      expect(getCacheHeaders('static')).toEqual({});
+      expect(getCacheHeaders('story')).toEqual({});
+      expect(getCacheHeaders('job')).toEqual({});
     });
   });
 
@@ -113,9 +113,9 @@ describe('getCacheHeaders', () => {
       });
     });
 
-    it('falls back to no-cache (treats as locale source)', () => {
+    it('falls back to empty headers (treats as locale source)', () => {
       const headers = getCacheHeaders('static');
-      expect(headers['Cache-Control']).toBe('no-cache');
+      expect(headers).toEqual({});
     });
   });
 });

--- a/app/modules/cache.ts
+++ b/app/modules/cache.ts
@@ -1,9 +1,9 @@
 /**
  * Cache strategy for React Router loaders
  *
- * - Local filesystem: No caching
- * - GitHub content: Vercel Edge Cache
- * - Testing: ?refresh=1 bypasses cache
+ * - GitHub source: Vercel Edge Cache (s-maxage + SWR)
+ * - Locale source: no headers emitted — no CDN in front, browser defaults apply
+ * - ?refresh=1 bypasses cache (no-store) regardless of source
  */
 
 import type { LoaderFunctionArgs } from 'react-router';
@@ -52,10 +52,11 @@ function buildCacheControl(strategy: CacheStrategy): string {
   return `s-maxage=${maxAge}, stale-while-revalidate=${staleWhileRevalidate}`;
 }
 
-/**
- * Get cache headers for GitHub content or local filesystem
- */
-export function getCacheHeaders(strategy: CacheStrategy, bypassCache = false) {
+/** Returns cache headers to set on the response, or `{}` when no CDN headers are needed. */
+export function getCacheHeaders(
+  strategy: CacheStrategy,
+  bypassCache = false,
+): Record<string, string> {
   if (bypassCache) {
     return {
       'Cache-Control': 'no-cache, no-store, must-revalidate',

--- a/app/modules/cache.ts
+++ b/app/modules/cache.ts
@@ -74,11 +74,8 @@ export function getCacheHeaders(strategy: CacheStrategy, bypassCache = false) {
     };
   }
 
-  // Local filesystem: no caching
-  return {
-    'Cache-Control': 'no-cache',
-    'Vercel-CDN-Cache-Control': 'no-cache',
-  };
+  // Locale source: no CDN involved, emit no cache headers
+  return {};
 }
 
 /**


### PR DESCRIPTION
## Summary

- `getCacheHeaders()` previously returned `Cache-Control: no-cache` + `Vercel-CDN-Cache-Control: no-cache` in locale mode — useless without a CDN and misleading in dev
- Now returns `{}` in locale mode: no headers emitted, browser uses its own defaults
- GitHub mode and bypass (`?refresh=1`) unchanged

Closes #160

## Behaviour table

| Mode | Before | After |
|------|--------|-------|
| `CONTENT_SOURCE=locale` (default dev) | `Cache-Control: no-cache`, `Vercel-CDN-Cache-Control: no-cache` | *(no headers)* |
| `CONTENT_SOURCE=github` | full SWR headers + `Vary` | unchanged |
| `?refresh=1` (bypass) | `no-cache, no-store, must-revalidate` | unchanged |

## Test plan

- [x] Updated 2 existing locale-mode tests to assert `{}` — green
- [x] Updated throws-fallback test (same locale path) — green
- [x] Full suite: 392 tests passing