### PR TITLE
feat(e2e): Playwright setup + homepage golden path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,3 +90,38 @@ jobs:
           name: coverage
           path: coverage/
           if-no-files-found: ignore
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Generate styled system
+        run: pnpm prepare
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Generate styled system
         run: pnpm prepare
@@ -47,7 +47,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Generate styled system
         run: pnpm prepare
@@ -71,7 +71,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Generate styled system
         run: pnpm prepare
@@ -93,6 +93,9 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    concurrency:
+      group: e2e-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -107,7 +110,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Generate styled system
         run: pnpm prepare
@@ -123,5 +126,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: playwright-report/
+          path: |
+            playwright-report/
+            test-results/
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ styled-system-studio
 ## Test coverage
 /coverage
 
+## Playwright
+/playwright-report
+/test-results
+
 ## Claude Code
 .claude
 

--- a/app/components/contact/contact-card.tsx
+++ b/app/components/contact/contact-card.tsx
@@ -131,6 +131,7 @@ export const ContactCard = ({ children }: ContactCardProps) => {
         })}
       />
       <h2
+        data-testid="form-card-heading"
         className={cx(
           text({ variant: 'display-md-bold', color: 'dark' }),
           css({ mb: '8' }),

--- a/app/components/contact/contact-hero.tsx
+++ b/app/components/contact/contact-hero.tsx
@@ -46,6 +46,7 @@ export const ContactHero = () => {
         <FrenchText>{t('eyebrow')}</FrenchText>
       </span>
       <h1
+        data-testid="contact-heading"
         className={cx(
           text({ variant: 'display-xl', color: 'dark' }),
           css({ mb: '8' }),

--- a/app/components/home/hero-section.tsx
+++ b/app/components/home/hero-section.tsx
@@ -125,6 +125,7 @@ export const HeroSection = () => {
                 to={getLocalizedPath(url.contact)}
                 variant="primary"
                 size="lg"
+                data-testid="hero-cta"
               >
                 {t('hero.cta')}
               </ButtonLink>

--- a/app/components/navbar/navbar.tsx
+++ b/app/components/navbar/navbar.tsx
@@ -185,6 +185,7 @@ export function Navbar() {
                   to={item.path!}
                   variant="solid"
                   size="sm"
+                  data-testid="nav-cta"
                   className={css({
                     display: 'none',
                     lg: { display: 'flex' },

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('homepage golden path', () => {
+  test('page loads with correct title', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/Ocobo/);
+  });
+
+  test('hero heading is visible', async ({ page }) => {
+    await page.goto('/');
+    await expect(
+      page.getByRole('heading', { name: /architecture/i }).first(),
+    ).toBeVisible();
+  });
+
+  test('primary CTA is visible', async ({ page }) => {
+    await page.goto('/');
+    await expect(
+      page.getByRole('link', { name: /rencontrer un architecte/i }),
+    ).toBeVisible();
+  });
+});
+
+test.describe('contact page', () => {
+  test('nav CTA navigates to /contact', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: /prendre rdv/i }).first().click();
+    await expect(page).toHaveURL(/\/contact/);
+  });
+
+  test('contact heading is visible', async ({ page }) => {
+    await page.goto('/contact');
+    await expect(
+      page.getByRole('heading', { name: /parlez à un architecte/i }),
+    ).toBeVisible();
+  });
+
+  test('form card heading is visible', async ({ page }) => {
+    await page.goto('/contact');
+    await expect(
+      page.getByRole('heading', { name: /dites-nous en plus/i }),
+    ).toBeVisible();
+  });
+
+  test('HubSpot form container is present in DOM', async ({ page }) => {
+    await page.goto('/contact');
+    // The .hbspt-form div is always rendered; HubSpot JS populates it
+    // asynchronously. Submission testing requires a live HubSpot portal
+    // and is excluded from automated E2E.
+    await expect(page.locator('.hbspt-form')).toBeAttached();
+  });
+});

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('homepage golden path', () => {
-  test('page loads with correct title', async ({ page }) => {
+  test('loads with Ocobo in the document title', async ({ page }) => {
     await page.goto('/');
     await expect(page).toHaveTitle(/Ocobo/);
   });
@@ -13,40 +13,50 @@ test.describe('homepage golden path', () => {
     ).toBeVisible();
   });
 
-  test('primary CTA is visible', async ({ page }) => {
+  test('primary CTA is visible and links to contact', async ({ page }) => {
     await page.goto('/');
-    await expect(
-      page.getByRole('link', { name: /rencontrer un architecte/i }),
-    ).toBeVisible();
+    const cta = page.getByTestId('hero-cta');
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute('href', /\/contact/);
   });
 });
 
 test.describe('contact page', () => {
   test('nav CTA navigates to /contact', async ({ page }) => {
     await page.goto('/');
-    await page.getByRole('link', { name: /prendre rdv/i }).first().click();
+    await page.getByTestId('nav-cta').click();
     await expect(page).toHaveURL(/\/contact/);
   });
 
   test('contact heading is visible', async ({ page }) => {
     await page.goto('/contact');
-    await expect(
-      page.getByRole('heading', { name: /parlez à un architecte/i }),
-    ).toBeVisible();
+    await expect(page.getByTestId('contact-heading')).toBeVisible();
   });
 
   test('form card heading is visible', async ({ page }) => {
     await page.goto('/contact');
-    await expect(
-      page.getByRole('heading', { name: /dites-nous en plus/i }),
-    ).toBeVisible();
+    await expect(page.getByTestId('form-card-heading')).toBeVisible();
   });
 
   test('HubSpot form container is present in DOM', async ({ page }) => {
     await page.goto('/contact');
-    // The .hbspt-form div is always rendered; HubSpot JS populates it
+    // The .hbspt-form div is rendered server-side; HubSpot JS populates it
     // asynchronously. Submission testing requires a live HubSpot portal
     // and is excluded from automated E2E.
     await expect(page.locator('.hbspt-form')).toBeAttached();
+  });
+});
+
+test.describe('english locale smoke test', () => {
+  test('/en/ loads with Ocobo in the document title', async ({ page }) => {
+    await page.goto('/en/');
+    await expect(page).toHaveTitle(/Ocobo/);
+  });
+
+  test('/en/ hero heading is visible', async ({ page }) => {
+    await page.goto('/en/');
+    await expect(
+      page.getByRole('heading', { name: /architecture/i }).first(),
+    ).toBeVisible();
   });
 });

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -22,7 +22,12 @@ test.describe('homepage golden path', () => {
 });
 
 test.describe('contact page', () => {
-  test('nav CTA navigates to /contact', async ({ page }) => {
+  test('nav CTA navigates to /contact', async ({ page }, testInfo) => {
+    // nav-cta is desktop-only (d_none lg:d_flex); mobile uses the hamburger menu
+    test.skip(
+      testInfo.project.name === 'mobile-chrome',
+      'Desktop nav CTA is hidden on mobile viewport',
+    );
     await page.goto('/');
     await page.getByTestId('nav-cta').click();
     await expect(page).toHaveURL(/\/contact/);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest --watch",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "typecheck": "react-router typegen && tsc"
   },
   "type": "module",
@@ -57,6 +59,7 @@
     "@pandacss/preset-base": "^1.8.1",
     "@pandacss/preset-panda": "^1.8.1",
     "@pandacss/types": "^1.8.1",
+    "@playwright/test": "^1.60.0",
     "@react-router/dev": "^7.8.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm dev:local',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    // Dummy GitHub credentials satisfy env.server.ts validation in locale mode.
+    // The filesystem source is used; these values are never sent to GitHub.
+    env: {
+      CONTENT_SOURCE: 'locale',
+      GITHUB_ACCOUNT: process.env.GITHUB_ACCOUNT ?? 'e2e-placeholder',
+      GITHUB_REPO: process.env.GITHUB_REPO ?? 'e2e-placeholder',
+      GITHUB_ACCESS_TOKEN:
+        process.env.GITHUB_ACCESS_TOKEN ?? 'e2e-placeholder',
+    },
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI ? 'github' : 'html',
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173',
@@ -15,6 +15,10 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 5'] },
     },
   ],
   webServer: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@pandacss/types':
         specifier: ^1.8.1
         version: 1.8.1
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@react-router/dev':
         specifier: ^7.8.1
         version: 7.13.0(@react-router/serve@7.13.0(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3))(@types/node@24.10.9)(lightningcss@1.30.2)(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.9)(lightningcss@1.30.2))
@@ -1025,6 +1028,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@react-router/dev@7.13.0':
     resolution: {integrity: sha512-0vRfTrS6wIXr9j0STu614Cv2ytMr21evnv1r+DXPv5cJ4q0V2x2kBAXC8TAqEXkpN5vdhbXBlbGQ821zwOfhvg==}
@@ -2197,6 +2205,11 @@ packages:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2849,6 +2862,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -4586,6 +4609,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@react-router/dev@7.13.0(@react-router/serve@7.13.0(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3))(@types/node@24.10.9)(lightningcss@1.30.2)(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.9)(lightningcss@1.30.2))':
     dependencies:
       '@babel/core': 7.29.0
@@ -6118,6 +6145,9 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6704,6 +6734,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       '**/node_modules/**',
       '**/dist/**',
       '**/cypress/**',
+      '**/e2e/**',
       '**/.{idea,git,cache,output,temp}/**',
       '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
       '**/build/**',


### PR DESCRIPTION
## Summary

- Bootstraps `@playwright/test` with `playwright.config.ts` at repo root
- Separate `e2e/` dir, excluded from Vitest via `vitest.config.ts`
- 7 E2E tests covering the homepage → contact golden path
- New `e2e` CI job in `test.yml`, separate from unit tests
- Playwright report uploaded as artifact on CI

Closes #134

## What's tested

| Test | Description |
|------|-------------|
| page loads with correct title | `/` title contains "Ocobo" |
| hero heading is visible | `h1` containing "architecture" |
| primary CTA is visible | "Rencontrer un architecte" link |
| nav CTA navigates to /contact | "Prendre RDV" → URL matches `/contact` |
| contact heading is visible | `h1` "Parlez à un architecte" |
| form card heading is visible | `h2` "Dites-nous en plus" |
| HubSpot form container is present | `.hbspt-form` attached to DOM |

## Why form submission is not tested

The contact form is HubSpot-embedded (external JS + iframe). Submission requires a live HubSpot portal and would create real CRM contacts — not appropriate for automated E2E. The test verifies the form container is present in the DOM.

## Running locally

```bash
# Start dev server separately (reuses existing server):
pnpm dev:local

# Run E2E tests:
pnpm test:e2e

# With UI mode:
pnpm test:e2e:ui
```

## CI behaviour

- Uses dummy GitHub credentials (`e2e-placeholder`) — locale filesystem source never calls GitHub API
- Missing content path returns empty stories; homepage renders without testimonials
- Retries: 2 on CI, 0 locally
- Trace on first retry for debugging failures