### PR TITLE
perf(loaders): parallelize i18n + content fetches in root loaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ styled-system-studio
 
 ## QA temp files
 /qa
+
+## Playwright
+/playwright-report
+/test-results

--- a/app/routes/_main.($lang)._index.test.tsx
+++ b/app/routes/_main.($lang)._index.test.tsx
@@ -21,6 +21,9 @@ import { invokeLoader } from '~/test/loader-harness';
 import type { MarkdocFile, StoryFrontmatter } from '~/types';
 
 const fetchStoriesMock = vi.fn();
+const getFixedTMock = vi.fn(
+  async (lang: string, _ns?: string) => (key: string) => `${lang}:${key}`,
+);
 
 vi.mock('~/modules/content', () => ({
   fetchStories: (...args: unknown[]) => fetchStoriesMock(...args),
@@ -28,7 +31,7 @@ vi.mock('~/modules/content', () => ({
 
 vi.mock('~/localization/i18n.server', () => ({
   default: {
-    getFixedT: async (lang: string) => (key: string) => `${lang}:${key}`,
+    getFixedT: (lang: string, ns: string) => getFixedTMock(lang, ns),
   },
 }));
 
@@ -64,6 +67,7 @@ function storyEntry(
 
 afterEach(() => {
   fetchStoriesMock.mockReset();
+  getFixedTMock.mockClear();
 });
 
 describe('homepage loader', () => {
@@ -193,5 +197,31 @@ describe('homepage loader', () => {
     expect(outcome.type).toBe('data');
     if (outcome.type !== 'data') return;
     expect(outcome.data.testimonials).toEqual([]);
+  });
+
+  it('fires getFixedT in parallel with fetchStories calls', async () => {
+    // getFixedT and fetchStories are independent — they must start concurrently.
+    // If sequential, fetchStories would only be called after getFixedT resolves.
+    let resolveT!: (fn: (key: string) => string) => void;
+    const tPromise = new Promise<(key: string) => string>((r) => {
+      resolveT = r;
+    });
+
+    getFixedTMock.mockImplementationOnce(() => tPromise);
+    fetchStoriesMock.mockResolvedValue([200, 'success', []]);
+
+    const { loader } = await import('./_main.($lang)._index');
+    const loaderPromise = invokeLoader(loader, {
+      url: 'http://test.local/fr',
+      params: { lang: 'fr' },
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    // fetchStories must have fired even though getFixedT has not resolved yet.
+    expect(fetchStoriesMock).toHaveBeenCalledTimes(1);
+
+    resolveT((key: string) => `fr:${key}`);
+    await loaderPromise;
   });
 });

--- a/app/routes/_main.($lang)._index.tsx
+++ b/app/routes/_main.($lang)._index.tsx
@@ -43,13 +43,13 @@ function shuffleArray<T>(array: readonly T[]): T[] {
 export const loader = createHybridLoader(async (args: LoaderFunctionArgs) => {
   await redirectWithLocale(args);
   const lang = getLang(args.params);
-  const t = await i18nServer.getFixedT(lang, 'home');
-
-  // Stories only exist in French — fire the localized fetch and the FR
-  // fallback in parallel so the EN homepage doesn't pay a sequential RTT.
-  const [primary, fallback] = await Promise.all([
-    fetchStories(lang),
-    lang === 'fr' ? Promise.resolve(null) : fetchStories('fr'),
+  // All three are independent — i18n + both story fetches start in parallel.
+  const [t, [primary, fallback]] = await Promise.all([
+    i18nServer.getFixedT(lang, 'home'),
+    Promise.all([
+      fetchStories(lang),
+      lang === 'fr' ? Promise.resolve(null) : fetchStories('fr'),
+    ]),
   ]);
 
   let [status, _state, storiesData] = primary;

--- a/app/routes/_main.($lang).about-us.test.ts
+++ b/app/routes/_main.($lang).about-us.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Loader tests for the about-us route.
+ *
+ * Behaviors verified:
+ *  1. Returns correct data when i18n + member registry both succeed.
+ *  2. getFixedT and loadMemberRegistry fire in parallel (not sequentially).
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { invokeLoader } from '~/test/loader-harness';
+
+const getFixedTMock = vi.fn();
+const loadMemberRegistryMock = vi.fn();
+const getFeaturedAboutMembersMock = vi.fn();
+const getTrackColorMock = vi.fn();
+
+vi.mock('~/localization/i18n.server', () => ({
+  default: {
+    getFixedT: (...args: unknown[]) => getFixedTMock(...args),
+  },
+}));
+
+vi.mock('~/modules/content', async (importOriginal) => {
+  const original = await importOriginal<typeof import('~/modules/content')>();
+  return {
+    ...original,
+    loadMemberRegistry: () => loadMemberRegistryMock(),
+    getFeaturedAboutMembers: (...args: unknown[]) =>
+      getFeaturedAboutMembersMock(...args),
+    getTrackColor: (...args: unknown[]) => getTrackColorMock(...args),
+  };
+});
+
+vi.mock('~/modules/feature-flags', () => ({
+  isPageEnabled: () => true,
+}));
+
+vi.mock('~/utils/redirections', () => ({
+  redirectWithLocale: vi.fn().mockResolvedValue(undefined),
+}));
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('about-us loader', () => {
+  it('returns title, description and mapped members from parallel i18n + registry calls', async () => {
+    const fakeRegistry = {};
+    const fakeMember = {
+      slug: 'alice',
+      name: 'Alice',
+      role: { fr: 'Directrice', en: 'Director' },
+      bio: { fr: 'Bio FR', en: 'Bio EN' },
+      avatar: '/avatar.jpg',
+      linkedin: 'https://linkedin.com/in/alice',
+      color: 'ocobo.yellow' as const,
+      track: 'ops' as const,
+    };
+
+    getFixedTMock.mockResolvedValue((key: string) => `fr:${key}`);
+    loadMemberRegistryMock.mockResolvedValue(fakeRegistry);
+    getFeaturedAboutMembersMock.mockReturnValue([fakeMember]);
+
+    const { loader } = await import('./_main.($lang).about-us');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/about-us',
+      params: {},
+    });
+
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    expect(outcome.data.title).toBe('fr:meta.title');
+    expect(outcome.data.description).toBe('fr:meta.description');
+    expect(outcome.data.members).toHaveLength(1);
+    expect(outcome.data.members[0]).toMatchObject({
+      slug: 'alice',
+      name: 'Alice',
+      role: 'Directrice',
+      bio: 'Bio FR',
+    });
+    expect(getFeaturedAboutMembersMock).toHaveBeenCalledWith(fakeRegistry);
+  });
+
+  it('fires getFixedT and loadMemberRegistry in parallel', async () => {
+    let resolveT!: (fn: (key: string) => string) => void;
+    let resolveRegistry!: (registry: Record<string, unknown>) => void;
+    const tPromise = new Promise<(key: string) => string>((r) => {
+      resolveT = r;
+    });
+    const registryPromise = new Promise<Record<string, unknown>>((r) => {
+      resolveRegistry = r;
+    });
+
+    getFixedTMock.mockReturnValue(tPromise);
+    loadMemberRegistryMock.mockReturnValue(registryPromise);
+    getFeaturedAboutMembersMock.mockReturnValue([]);
+
+    const { loader } = await import('./_main.($lang).about-us');
+    const loaderPromise = invokeLoader(loader, {
+      url: 'http://test.local/about-us',
+      params: {},
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    expect(getFixedTMock).toHaveBeenCalledTimes(1);
+    expect(loadMemberRegistryMock).toHaveBeenCalledTimes(1);
+
+    resolveT((key: string) => `fr:${key}`);
+    resolveRegistry({});
+    await loaderPromise;
+  });
+});

--- a/app/routes/_main.($lang).about-us.tsx
+++ b/app/routes/_main.($lang).about-us.tsx
@@ -30,9 +30,10 @@ import { url, getImageOgFullPath } from '~/utils/url';
 export const loader = createHybridLoader(async (args: LoaderFunctionArgs) => {
   await redirectWithLocale(args);
   const lang = getLang(args.params);
-  const t = await i18nServer.getFixedT(lang, 'about');
-
-  const registry = await loadMemberRegistry();
+  const [t, registry] = await Promise.all([
+    i18nServer.getFixedT(lang, 'about'),
+    loadMemberRegistry(),
+  ]);
   const members: TeamSectionMember[] = getFeaturedAboutMembers(registry).map(
     (m) => ({
       slug: m.slug,

--- a/app/routes/_main.($lang).studio.test.ts
+++ b/app/routes/_main.($lang).studio.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Loader tests for the studio route.
+ *
+ * Behaviors verified:
+ *  1. Returns correct data when i18n + member registry both succeed.
+ *  2. getFixedT and loadMemberRegistry fire in parallel (not sequentially).
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { invokeLoader } from '~/test/loader-harness';
+
+const getFixedTMock = vi.fn();
+const loadMemberRegistryMock = vi.fn();
+const getActiveMembersMock = vi.fn();
+
+vi.mock('~/localization/i18n.server', () => ({
+  default: {
+    getFixedT: (...args: unknown[]) => getFixedTMock(...args),
+  },
+}));
+
+vi.mock('~/modules/content/members', () => ({
+  loadMemberRegistry: () => loadMemberRegistryMock(),
+  getActiveMembers: (...args: unknown[]) => getActiveMembersMock(...args),
+}));
+
+vi.mock('~/modules/feature-flags', () => ({
+  throwIfDisabled: vi.fn(),
+}));
+
+vi.mock('~/utils/redirections', () => ({
+  redirectWithLocale: vi.fn().mockResolvedValue(undefined),
+}));
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('studio loader', () => {
+  it('returns title, description and members from parallel i18n + registry calls', async () => {
+    const fakeRegistry = { alice: { slug: 'alice', name: 'Alice' } };
+    const fakeMembers = [{ slug: 'alice', name: 'Alice' }];
+
+    getFixedTMock.mockResolvedValue((key: string) => `fr:${key}`);
+    loadMemberRegistryMock.mockResolvedValue(fakeRegistry);
+    getActiveMembersMock.mockReturnValue(fakeMembers);
+
+    const { loader } = await import('./_main.($lang).studio');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/studio',
+      params: {},
+    });
+
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    expect(outcome.data.title).toBe('fr:meta.title');
+    expect(outcome.data.description).toBe('fr:meta.description');
+    expect(outcome.data.members).toBe(fakeMembers);
+    expect(outcome.data.lang).toBe('fr');
+    expect(getActiveMembersMock).toHaveBeenCalledWith(fakeRegistry);
+  });
+
+  it('fires getFixedT and loadMemberRegistry in parallel', async () => {
+    let resolveT!: (fn: (key: string) => string) => void;
+    let resolveRegistry!: (registry: Record<string, unknown>) => void;
+    const tPromise = new Promise<(key: string) => string>((r) => {
+      resolveT = r;
+    });
+    const registryPromise = new Promise<Record<string, unknown>>((r) => {
+      resolveRegistry = r;
+    });
+
+    getFixedTMock.mockReturnValue(tPromise);
+    loadMemberRegistryMock.mockReturnValue(registryPromise);
+    getActiveMembersMock.mockReturnValue([]);
+
+    const { loader } = await import('./_main.($lang).studio');
+    const loaderPromise = invokeLoader(loader, {
+      url: 'http://test.local/studio',
+      params: {},
+    });
+
+    // Let the loader run past its first await point.
+    await new Promise((r) => setImmediate(r));
+
+    // Both must be called before either resolves — sequential awaits would
+    // only call loadMemberRegistry after getFixedT settles.
+    expect(getFixedTMock).toHaveBeenCalledTimes(1);
+    expect(loadMemberRegistryMock).toHaveBeenCalledTimes(1);
+
+    resolveT((key: string) => `fr:${key}`);
+    resolveRegistry({});
+    await loaderPromise;
+  });
+});

--- a/app/routes/_main.($lang).studio.tsx
+++ b/app/routes/_main.($lang).studio.tsx
@@ -25,9 +25,10 @@ export const loader = createHybridLoader(async (args: LoaderFunctionArgs) => {
   await redirectWithLocale(args);
   throwIfDisabled('studio');
   const lang = getLang(args.params);
-  const t = await i18nServer.getFixedT(lang, 'studio');
-
-  const registry = await loadMemberRegistry();
+  const [t, registry] = await Promise.all([
+    i18nServer.getFixedT(lang, 'studio'),
+    loadMemberRegistry(),
+  ]);
 
   return {
     title: t('meta.title'),


### PR DESCRIPTION
## Summary

Closes #152.

Three root-level loaders had sequential `await` chains between independent async calls. Converted to `Promise.all` so i18n initialisation and content fetches start concurrently.

- **`studio.tsx`**: `getFixedT` + `loadMemberRegistry` now parallel (was sequential — one extra RTT per request)
- **`about-us.tsx`**: same pattern
- **`_index.tsx`**: `getFixedT` collapsed into the existing stories `Promise.all` (i18n + both story fetches now start in one shot)

Each change is covered by a parallelism test (deferred-promise pattern — verifies both calls fire before either resolves, not just that the result is correct).

## Test plan

- [ ] `pnpm test:run` → 397 tests pass
- [ ] `pnpm check && pnpm typecheck` → green
- [ ] Spot-check studio, about-us, and homepage in dev to confirm no regression