### PR TITLE
test(language-switcher): add TDD tests for LanguageSwitcher

### DIFF
--- a/app/components/language-switcher.test.tsx
+++ b/app/components/language-switcher.test.tsx
@@ -7,6 +7,10 @@ import { LanguageSwitcher } from './LanguageSwitcher';
 
 const mockNavigate = vi.fn();
 
+// useParams and useNavigate are mocked so tests control params without
+// needing a route with a /:lang segment. useLocation is intentionally left
+// real — the memory router's initialEntries provides the pathname that the
+// component uses to build the converted path.
 vi.mock('react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router')>();
   return {
@@ -35,7 +39,7 @@ describe('LanguageSwitcher', () => {
     expect(screen.getByRole('combobox', { name: 'Lang' })).toBeInTheDocument();
   });
 
-  it('navigates to target language path on selection', async () => {
+  it('navigates en → fr preserving subpath', async () => {
     const user = userEvent.setup();
     vi.mocked(useParams).mockReturnValue({ lang: 'en' });
     render(<LanguageSwitcher />, {
@@ -44,8 +48,25 @@ describe('LanguageSwitcher', () => {
     });
 
     await user.click(screen.getByRole('combobox', { name: 'Lang' }));
-    await user.click(await screen.findByText('Français'));
+    await user.click(await screen.findByRole('option', { name: /français/i }));
 
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith('/fr/some-page');
+  });
+
+  it('navigates fr → en preserving subpath', async () => {
+    const user = userEvent.setup();
+    vi.mocked(useParams).mockReturnValue({ lang: 'fr' });
+    render(<LanguageSwitcher />, {
+      initialEntries: ['/fr/methode/discovery'],
+      i18nLang: 'fr',
+    });
+
+    await user.click(screen.getByRole('combobox', { name: 'Lang' }));
+    // In FR context, English option label is "Anglais"
+    await user.click(await screen.findByRole('option', { name: /anglais/i }));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/en/methode/discovery');
   });
 });

--- a/app/components/language-switcher.test.tsx
+++ b/app/components/language-switcher.test.tsx
@@ -1,0 +1,51 @@
+import { useNavigate, useParams } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen, userEvent } from '~/test/utils';
+
+import { LanguageSwitcher } from './LanguageSwitcher';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
+  return {
+    ...actual,
+    useParams: vi.fn(),
+    useNavigate: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(useParams).mockReturnValue({});
+  vi.mocked(useNavigate).mockReturnValue(mockNavigate);
+});
+
+describe('LanguageSwitcher', () => {
+  it('returns null when route has no lang param', () => {
+    render(<LanguageSwitcher />);
+    expect(
+      screen.queryByRole('combobox', { name: 'Lang' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders language trigger when lang param is present', () => {
+    vi.mocked(useParams).mockReturnValue({ lang: 'en' });
+    render(<LanguageSwitcher />);
+    expect(screen.getByRole('combobox', { name: 'Lang' })).toBeInTheDocument();
+  });
+
+  it('navigates to target language path on selection', async () => {
+    const user = userEvent.setup();
+    vi.mocked(useParams).mockReturnValue({ lang: 'en' });
+    render(<LanguageSwitcher />, {
+      initialEntries: ['/en/some-page'],
+      i18nLang: 'en',
+    });
+
+    await user.click(screen.getByRole('combobox', { name: 'Lang' }));
+    await user.click(await screen.findByText('Français'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/fr/some-page');
+  });
+});

--- a/app/test/setup.ts
+++ b/app/test/setup.ts
@@ -8,6 +8,29 @@ import { cleanup } from '@testing-library/react';
 import { toHaveNoViolations } from 'jest-axe';
 import { afterAll, afterEach, beforeAll, beforeEach, expect, vi } from 'vitest';
 
+// Ark UI / floating-ui require ResizeObserver and scrollTo which JSDOM omits
+if (typeof global.ResizeObserver === 'undefined') {
+  global.ResizeObserver = class {
+    observe(): void {
+      return;
+    }
+    unobserve(): void {
+      return;
+    }
+    disconnect(): void {
+      return;
+    }
+  };
+}
+if (
+  typeof HTMLElement !== 'undefined' &&
+  typeof HTMLElement.prototype.scrollTo === 'undefined'
+) {
+  HTMLElement.prototype.scrollTo = function (): void {
+    return;
+  };
+}
+
 import { server } from './msw/server';
 
 expect.extend(toHaveNoViolations);


### PR DESCRIPTION
## Summary

- Adds 3 TDD tests for `LanguageSwitcher` component (issue #136, part of PRD #121)
- Tests: returns null when no lang param · renders combobox trigger when lang present · navigates to correct path on language selection
- Adds JSDOM polyfills for `ResizeObserver` and `HTMLElement.scrollTo` in `app/test/setup.ts` — required by Ark UI / floating-ui when running Select component tests in JSDOM

## Test plan
- [ ] All 3 LanguageSwitcher tests pass
- [ ] Full suite (398 tests) stays green
- [ ] `pnpm check && pnpm typecheck` green