### PR TITLE
feat: defer member/team registries on detail routes (#156)

### DIFF
--- a/app/components/blog/blog-article.tsx
+++ b/app/components/blog/blog-article.tsx
@@ -107,7 +107,7 @@ const BlogArticle: React.FunctionComponent<BlogArticleProps> = ({
             return null;
           })()}
           <Suspense fallback={null}>
-            <Await resolve={author}>
+            <Await resolve={author} errorElement={null}>
               {(resolvedAuthor) =>
                 resolvedAuthor && (
                   <div

--- a/app/components/blog/blog-article.tsx
+++ b/app/components/blog/blog-article.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeftIcon } from 'lucide-react';
+import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { NavLink } from 'react-router';
+import { Await, NavLink } from 'react-router';
 
 import { css } from '@ocobo/styled-system/css';
 import { flex } from '@ocobo/styled-system/patterns';
@@ -24,7 +25,7 @@ interface BlogArticleProps {
   article: MarkdocFile<BlogpostFrontmatter>;
   toc: TocEntry[];
   intro: string | null;
-  author: Member | null;
+  author: Promise<Member | null>;
 }
 
 const BlogArticle: React.FunctionComponent<BlogArticleProps> = ({
@@ -105,30 +106,36 @@ const BlogArticle: React.FunctionComponent<BlogArticleProps> = ({
             }
             return null;
           })()}
-          {author && (
-            <div
-              className={css({
-                mt: '16',
-                pt: '12',
-                borderTopWidth: '1px',
-                borderColor: 'gray.100',
-              })}
-            >
-              <div
-                className={css({
-                  fontSize: 'xs',
-                  fontWeight: 'black',
-                  textTransform: 'uppercase',
-                  letterSpacing: 'widest',
-                  color: 'gray.400',
-                  mb: '6',
-                })}
-              >
-                {t('author.heading')}
-              </div>
-              <MemberCard member={author} />
-            </div>
-          )}
+          <Suspense fallback={null}>
+            <Await resolve={author}>
+              {(resolvedAuthor) =>
+                resolvedAuthor && (
+                  <div
+                    className={css({
+                      mt: '16',
+                      pt: '12',
+                      borderTopWidth: '1px',
+                      borderColor: 'gray.100',
+                    })}
+                  >
+                    <div
+                      className={css({
+                        fontSize: 'xs',
+                        fontWeight: 'black',
+                        textTransform: 'uppercase',
+                        letterSpacing: 'widest',
+                        color: 'gray.400',
+                        mb: '6',
+                      })}
+                    >
+                      {t('author.heading')}
+                    </div>
+                    <MemberCard member={resolvedAuthor} />
+                  </div>
+                )
+              }
+            </Await>
+          </Suspense>
         </LayoutPost.Main>
       </LayoutPost.Root>
     </div>

--- a/app/components/stories/story-article.tsx
+++ b/app/components/stories/story-article.tsx
@@ -78,7 +78,7 @@ const StoryArticle: React.FunctionComponent<StoryArticleProps> = ({
           )}
           <StoryQuoteBlock item={article.frontmatter} slug={article.slug} />
           <Suspense fallback={null}>
-            <Await resolve={resolvedTeam}>
+            <Await resolve={resolvedTeam} errorElement={null}>
               {(team) => <StoryTeamBlock members={team} />}
             </Await>
           </Suspense>

--- a/app/components/stories/story-article.tsx
+++ b/app/components/stories/story-article.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeftIcon } from 'lucide-react';
+import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { NavLink } from 'react-router';
+import { Await, NavLink } from 'react-router';
 
 import { css } from '@ocobo/styled-system/css';
 import { flex } from '@ocobo/styled-system/patterns';
@@ -23,13 +24,13 @@ import { PlayerYoutube } from '../PlayerYoutube';
 interface StoryArticleProps {
   article: MarkdocFile<StoryFrontmatter>;
   resolvedTools?: Tool[];
-  resolvedTeam?: Member[];
+  resolvedTeam: Promise<Member[]>;
 }
 
 const StoryArticle: React.FunctionComponent<StoryArticleProps> = ({
   article,
   resolvedTools = [],
-  resolvedTeam = [],
+  resolvedTeam,
 }) => {
   const { t } = useTranslation();
   return (
@@ -76,7 +77,11 @@ const StoryArticle: React.FunctionComponent<StoryArticleProps> = ({
             />
           )}
           <StoryQuoteBlock item={article.frontmatter} slug={article.slug} />
-          <StoryTeamBlock members={resolvedTeam} />
+          <Suspense fallback={null}>
+            <Await resolve={resolvedTeam}>
+              {(team) => <StoryTeamBlock members={team} />}
+            </Await>
+          </Suspense>
         </LayoutPost.Main>
       </LayoutPost.Root>
 

--- a/app/routes/_main.($lang).clients.$slug.test.ts
+++ b/app/routes/_main.($lang).clients.$slug.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Loader tests for the clients (story) detail route.
+ *
+ * Covers the observable behaviours of `loader` in
+ * `_main.($lang).clients.$slug.tsx`:
+ *  1. 404 when slug is missing from params
+ *  2. 404 when `fetchStory` returns a non-200 status
+ *  3. Happy path: article + resolvedTools returned synchronously
+ *  4. `resolvedTeam` returned as a deferred promise (footer-only)
+ *
+ * `resolvedTools` stays on the critical path because StoryMetas renders
+ * tool icons in the above-the-fold sidebar.
+ */
+
+import type { RenderableTreeNode } from '@markdoc/markdoc';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { StoryFrontmatter } from '~/modules/schemas';
+import { invokeLoader } from '~/test/loader-harness';
+import type { MarkdocFile } from '~/types';
+
+const fetchStoryMock = vi.fn();
+const loadToolRegistryMock = vi.fn();
+const loadMemberRegistryMock = vi.fn();
+const resolveToolMock = vi.fn();
+const resolveTeamMock = vi.fn();
+
+vi.mock('~/modules/content', () => ({
+  fetchStory: (...args: unknown[]) => fetchStoryMock(...args),
+  loadToolRegistry: () => loadToolRegistryMock(),
+  loadMemberRegistry: () => loadMemberRegistryMock(),
+  resolveTool: (...args: unknown[]) => resolveToolMock(...args),
+  resolveTeam: (...args: unknown[]) => resolveTeamMock(...args),
+}));
+
+function storyEntry(
+  overrides: Partial<StoryFrontmatter> & { slug?: string } = {},
+): MarkdocFile<StoryFrontmatter> {
+  const { slug = 'ekodev', ...frontmatterOverrides } = overrides;
+  return {
+    slug,
+    content: null as unknown as RenderableTreeNode,
+    markdown: '## Context\n\nClient story.',
+    frontmatter: {
+      title: 'Ekodev story',
+      subtitle: 'How Ekodev scaled RevOps',
+      image: 'https://example.com/ekodev.jpg',
+      logo: 'https://example.com/ekodev-logo.svg',
+      sector: 'SaaS',
+      tools: ['hubspot', 'salesforce'],
+      team: ['jerome-boileux'],
+      deliverables: [],
+      ...frontmatterOverrides,
+    } as StoryFrontmatter,
+  };
+}
+
+afterEach(() => {
+  fetchStoryMock.mockReset();
+  loadToolRegistryMock.mockReset();
+  loadMemberRegistryMock.mockReset();
+  resolveToolMock.mockReset();
+  resolveTeamMock.mockReset();
+});
+
+describe('clients detail loader', () => {
+  it('throws 404 when slug is missing', async () => {
+    const { loader } = await import('./_main.($lang).clients.$slug');
+    const outcome = await invokeLoader(loader, { params: {} });
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(404);
+  });
+
+  it('throws 404 when fetchStory returns non-200', async () => {
+    fetchStoryMock.mockResolvedValueOnce([404, 'not_found', undefined]);
+    loadToolRegistryMock.mockResolvedValueOnce({});
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+
+    const { loader } = await import('./_main.($lang).clients.$slug');
+    const outcome = await invokeLoader(loader, {
+      params: { slug: 'missing' },
+    });
+
+    expect(outcome.type).toBe('response');
+    if (outcome.type !== 'response') return;
+    expect(outcome.response.status).toBe(404);
+  });
+
+  it('returns article and resolvedTools synchronously on happy path', async () => {
+    const article = storyEntry();
+    const tool = {
+      slug: 'hubspot',
+      name: 'HubSpot',
+      icon: 'https://example.com/hubspot.svg',
+    };
+    fetchStoryMock.mockResolvedValueOnce([200, 'success', article]);
+    loadToolRegistryMock.mockResolvedValueOnce({ hubspot: tool });
+    loadMemberRegistryMock.mockResolvedValueOnce({});
+    resolveToolMock.mockReturnValueOnce(tool).mockReturnValueOnce(null);
+    resolveTeamMock.mockReturnValueOnce([]);
+
+    const { loader } = await import('./_main.($lang).clients.$slug');
+    const outcome = await invokeLoader(loader, {
+      params: { slug: 'ekodev' },
+    });
+
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    const data = outcome.data as {
+      article: typeof article;
+      resolvedTools: unknown[];
+    };
+    expect(data.article).toBe(article);
+    expect(data.resolvedTools).toEqual([tool]);
+  });
+
+  it('returns resolvedTeam as a deferred promise', async () => {
+    const article = storyEntry();
+    const member = {
+      slug: 'jerome-boileux',
+      name: 'Jérôme Boileux',
+      role: 'Founder',
+    };
+    fetchStoryMock.mockResolvedValueOnce([200, 'success', article]);
+    loadToolRegistryMock.mockResolvedValueOnce({});
+    loadMemberRegistryMock.mockResolvedValueOnce({
+      'jerome-boileux': member,
+    });
+    resolveToolMock.mockReturnValue(null);
+    resolveTeamMock.mockReturnValueOnce([member]);
+
+    const { loader } = await import('./_main.($lang).clients.$slug');
+    const outcome = await invokeLoader(loader, {
+      params: { slug: 'ekodev' },
+    });
+
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    const data = outcome.data as { resolvedTeam: unknown };
+    expect(data.resolvedTeam).toBeInstanceOf(Promise);
+    await expect(data.resolvedTeam).resolves.toEqual([member]);
+  });
+});

--- a/app/routes/_main.($lang).clients.$slug.tsx
+++ b/app/routes/_main.($lang).clients.$slug.tsx
@@ -22,6 +22,7 @@ export const loader = createHybridLoader(
       throw new Response('Not Found', { status: 404 });
     }
 
+    const memberRegistryPromise = loadMemberRegistry();
     const [[status, _state, article], toolRegistry] = await Promise.all([
       fetchStory(slug, getLang(params)),
       loadToolRegistry(),
@@ -35,7 +36,7 @@ export const loader = createHybridLoader(
       .map((toolSlug) => resolveTool(toolSlug, toolRegistry))
       .filter((t): t is NonNullable<typeof t> => t !== null);
 
-    const resolvedTeam = loadMemberRegistry().then((memberRegistry) =>
+    const resolvedTeam = memberRegistryPromise.then((memberRegistry) =>
       resolveTeam(article.frontmatter.team ?? [], memberRegistry),
     );
 

--- a/app/routes/_main.($lang).clients.$slug.tsx
+++ b/app/routes/_main.($lang).clients.$slug.tsx
@@ -22,12 +22,10 @@ export const loader = createHybridLoader(
       throw new Response('Not Found', { status: 404 });
     }
 
-    const [[status, _state, article], toolRegistry, memberRegistry] =
-      await Promise.all([
-        fetchStory(slug, getLang(params)),
-        loadToolRegistry(),
-        loadMemberRegistry(),
-      ]);
+    const [[status, _state, article], toolRegistry] = await Promise.all([
+      fetchStory(slug, getLang(params)),
+      loadToolRegistry(),
+    ]);
 
     if (status !== 200 || !article) {
       throw new Response('Not Found', { status: 404 });
@@ -37,9 +35,8 @@ export const loader = createHybridLoader(
       .map((toolSlug) => resolveTool(toolSlug, toolRegistry))
       .filter((t): t is NonNullable<typeof t> => t !== null);
 
-    const resolvedTeam = resolveTeam(
-      article.frontmatter.team ?? [],
-      memberRegistry,
+    const resolvedTeam = loadMemberRegistry().then((memberRegistry) =>
+      resolveTeam(article.frontmatter.team ?? [], memberRegistry),
     );
 
     return data(

--- a/app/routes/_main.($lang).jobs.$slug.test.ts
+++ b/app/routes/_main.($lang).jobs.$slug.test.ts
@@ -165,10 +165,9 @@ describe('jobs detail loader', () => {
 
     expect(outcome.type).toBe('data');
     if (outcome.type !== 'data') return;
-    const data = outcome.data as {
+    const data = outcome.data as unknown as {
       job: typeof job;
       sections: typeof fakeSections;
-      contact: null;
       lang: string;
       slug: string;
       ld: string;
@@ -189,6 +188,37 @@ describe('jobs detail loader', () => {
     expect(outcome.type).toBe('response');
     if (outcome.type !== 'response') return;
     expect(outcome.response.status).toBe(404);
+  });
+
+  it('returns contact as a deferred promise that resolves to the resolved member', async () => {
+    const job = jobEntry();
+    const resolvedContact = {
+      slug: 'jerome-boileux',
+      name: 'Jérôme Boileux',
+      role: 'Founder',
+    };
+    fetchJobMock.mockResolvedValueOnce([200, 'success', job]);
+    loadMemberRegistryMock.mockResolvedValueOnce({
+      'jerome-boileux': resolvedContact,
+    });
+    resolveMemberMock.mockReturnValueOnce(resolvedContact);
+    extractJobSectionsMock.mockReturnValueOnce(fakeSections);
+    buildJobPostingLdMock.mockReturnValueOnce({});
+    serializeJsonLdMock.mockReturnValueOnce('{}');
+
+    const { loader } = await import('./_main.($lang).jobs.$slug');
+    const outcome = await invokeLoader(loader, {
+      url: 'http://test.local/jobs/revops-consultant',
+      params: { slug: 'revops-consultant' },
+    });
+
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    const data = outcome.data as { contact: unknown; ld: string };
+    expect(data.contact).toBeInstanceOf(Promise);
+    await expect(data.contact).resolves.toEqual(resolvedContact);
+    // ld stays sync — crawlers need JSON-LD on critical path
+    expect(typeof data.ld).toBe('string');
   });
 
   it('returns job data with lang=en on happy path (EN)', async () => {

--- a/app/routes/_main.($lang).jobs.$slug.tsx
+++ b/app/routes/_main.($lang).jobs.$slug.tsx
@@ -38,6 +38,7 @@ export const loader = createHybridLoader(
       return redirect(`/${lang}/jobs`);
     }
 
+    const registryPromise = loadMemberRegistry();
     const [status, , job] = await fetchJob(slug, lang);
 
     if (status !== 200 || !job) {
@@ -49,7 +50,7 @@ export const loader = createHybridLoader(
     }
 
     const sections = extractJobSections(job.content);
-    const contact = loadMemberRegistry().then((registry) =>
+    const contact = registryPromise.then((registry) =>
       resolveMember(job.frontmatter.hiringContact, registry),
     );
     const { origin } = new URL(request.url);
@@ -138,7 +139,7 @@ export default function JobDetail() {
             </div>
 
             <Suspense fallback={null}>
-              <Await resolve={contact}>
+              <Await resolve={contact} errorElement={null}>
                 {(resolvedContact) =>
                   resolvedContact && (
                     <div

--- a/app/routes/_main.($lang).jobs.$slug.tsx
+++ b/app/routes/_main.($lang).jobs.$slug.tsx
@@ -1,4 +1,6 @@
+import { Suspense } from 'react';
 import {
+  Await,
   type LoaderFunctionArgs,
   type MetaFunction,
   redirect,
@@ -36,10 +38,7 @@ export const loader = createHybridLoader(
       return redirect(`/${lang}/jobs`);
     }
 
-    const [[status, , job], registry] = await Promise.all([
-      fetchJob(slug, lang),
-      loadMemberRegistry(),
-    ]);
+    const [status, , job] = await fetchJob(slug, lang);
 
     if (status !== 200 || !job) {
       return redirect(`/${lang}/jobs`);
@@ -50,7 +49,9 @@ export const loader = createHybridLoader(
     }
 
     const sections = extractJobSections(job.content);
-    const contact = resolveMember(job.frontmatter.hiringContact, registry);
+    const contact = loadMemberRegistry().then((registry) =>
+      resolveMember(job.frontmatter.hiringContact, registry),
+    );
     const { origin } = new URL(request.url);
     const ld = serializeJsonLd(
       buildJobPostingLd(job.frontmatter, origin, slug, lang),
@@ -136,18 +137,24 @@ export default function JobDetail() {
               </div>
             </div>
 
-            {contact && (
-              <div
-                className={css({
-                  mt: '24',
-                  pt: '12',
-                  borderTopWidth: '1px',
-                  borderColor: 'gray.100',
-                })}
-              >
-                <HiringContact contact={contact} />
-              </div>
-            )}
+            <Suspense fallback={null}>
+              <Await resolve={contact}>
+                {(resolvedContact) =>
+                  resolvedContact && (
+                    <div
+                      className={css({
+                        mt: '24',
+                        pt: '12',
+                        borderTopWidth: '1px',
+                        borderColor: 'gray.100',
+                      })}
+                    >
+                      <HiringContact contact={resolvedContact} />
+                    </div>
+                  )
+                }
+              </Await>
+            </Suspense>
 
             <ApplyCta
               applyEmail={frontmatter.applyEmail}

--- a/app/routes/_main.blog.$slug.test.ts
+++ b/app/routes/_main.blog.$slug.test.ts
@@ -91,7 +91,7 @@ describe('blog detail loader', () => {
     expect(outcome.response.status).toBe(404);
   });
 
-  it('returns article, toc, intro, and author on happy path', async () => {
+  it('returns article, toc, and intro synchronously on happy path', async () => {
     const article = blogEntry();
     fetchBlogpostMock.mockResolvedValueOnce([200, 'success', article]);
     loadMemberRegistryMock.mockResolvedValueOnce({});
@@ -109,7 +109,32 @@ describe('blog detail loader', () => {
     expect(outcome.data.article).toBe(article);
     expect(outcome.data.toc).toEqual([{ id: 'test', children: [] }]);
     expect(outcome.data.intro).toBe('Intro paragraph.');
-    expect(outcome.data.author).toBeNull();
+  });
+
+  it('returns author as a deferred promise that resolves to the resolved member', async () => {
+    const article = blogEntry();
+    const resolvedAuthor = {
+      slug: 'jerome-boileux',
+      name: 'Jérôme Boileux',
+      role: 'Founder',
+    };
+    fetchBlogpostMock.mockResolvedValueOnce([200, 'success', article]);
+    loadMemberRegistryMock.mockResolvedValueOnce({
+      'jerome-boileux': resolvedAuthor,
+    });
+    resolveMemberMock.mockReturnValueOnce(resolvedAuthor);
+    extractTocMock.mockReturnValueOnce([]);
+    extractFirstParagraphMock.mockReturnValueOnce(null);
+
+    const { loader } = await import('./_main.blog.$slug');
+    const outcome = await invokeLoader(loader, {
+      params: { slug: 'test-slug' },
+    });
+
+    expect(outcome.type).toBe('data');
+    if (outcome.type !== 'data') return;
+    expect(outcome.data.author).toBeInstanceOf(Promise);
+    await expect(outcome.data.author).resolves.toEqual(resolvedAuthor);
   });
 
   it('uses frontmatter.exerpt as intro when set', async () => {

--- a/app/routes/_main.blog.$slug.tsx
+++ b/app/routes/_main.blog.$slug.tsx
@@ -23,6 +23,7 @@ export const loader = createHybridLoader(
       throw new Response('Not Found', { status: 404 });
     }
 
+    const registryPromise = loadMemberRegistry();
     const [status, _state, article] = await fetchBlogpost(
       slug,
       getLang(params),
@@ -36,7 +37,7 @@ export const loader = createHybridLoader(
     const toc = extractToc(ast);
     const intro =
       article.frontmatter.exerpt ?? extractFirstParagraph(ast) ?? null;
-    const author = loadMemberRegistry().then((registry) =>
+    const author = registryPromise.then((registry) =>
       resolveMember(article.frontmatter.author, registry),
     );
 

--- a/app/routes/_main.blog.$slug.tsx
+++ b/app/routes/_main.blog.$slug.tsx
@@ -23,10 +23,10 @@ export const loader = createHybridLoader(
       throw new Response('Not Found', { status: 404 });
     }
 
-    const [[status, _state, article], registry] = await Promise.all([
-      fetchBlogpost(slug, getLang(params)),
-      loadMemberRegistry(),
-    ]);
+    const [status, _state, article] = await fetchBlogpost(
+      slug,
+      getLang(params),
+    );
 
     if (status !== 200 || !article) {
       throw new Response('Not Found', { status: 404 });
@@ -36,7 +36,9 @@ export const loader = createHybridLoader(
     const toc = extractToc(ast);
     const intro =
       article.frontmatter.exerpt ?? extractFirstParagraph(ast) ?? null;
-    const author = resolveMember(article.frontmatter.author, registry);
+    const author = loadMemberRegistry().then((registry) =>
+      resolveMember(article.frontmatter.author, registry),
+    );
 
     return data(
       { article, toc, intro, author },


### PR DESCRIPTION
Closes #156.

## Summary

Move non-critical loader work off the blocking await on the three detail routes (blog, jobs, clients). Primary content (`<h1>`, body, hero, sidebar) paints first; member registry resolution streams in afterwards via `<Suspense>` + `<Await>`.

## Per-route scope

| Route | Deferred | Kept sync (why) |
|---|---|---|
| `blog/$slug` | author footer (member registry) | article, toc, intro |
| `($lang)/jobs/$slug` | hiring contact footer | article, sections, JSON-LD (crawlers need it on first paint) |
| `($lang)/clients/$slug` | team footer | article, resolvedTools (above-the-fold sidebar) |

## Changes

- `app/routes/_main.blog.$slug.tsx` — `loadMemberRegistry()` no longer awaited; `author` returned as `Promise<Member | null>`.
- `app/components/blog/blog-article.tsx` — author footer wrapped in `<Suspense fallback={null}><Await>`.
- `app/routes/_main.($lang).jobs.$slug.tsx` — same pattern for `contact`. `ld` (JSON-LD) stays sync.
- `app/routes/_main.($lang).clients.$slug.tsx` — `loadMemberRegistry()` deferred for `resolvedTeam`. `loadToolRegistry()` stays sync (sidebar metas).
- `app/components/stories/story-article.tsx` — `StoryTeamBlock` wrapped in `<Suspense>`.

## Tests

- `app/routes/_main.blog.$slug.test.ts` — happy-path split into "primaries sync" + "author is a Promise resolving to expected value".
- `app/routes/_main.($lang).jobs.$slug.test.ts` — new test asserting `contact` is a Promise; `ld` stays sync.
- `app/routes/_main.($lang).clients.$slug.test.ts` — **new file**, 4 cases: 404 (no slug), 404 (fetch failure), sync primaries, deferred team.

All 414 tests pass (`pnpm test:run`). Typecheck + Biome clean.

## Measurement plan

Single-run lab PSI is too noisy to credit a defer-pattern win (we showed ±30-50 % LCP variance across consecutive runs on this site). The real signal lives in Vercel Speed Insights p75 INP / TBT once production traffic accumulates.

- [ ] Re-check Vercel Speed Insights on the 3 detail routes ~7 days post-merge (≈ 2026-05-22)
- [ ] Update `docs/project/performance-baseline.md` Changelog with delta vs 2026-05-13 site-wide RUM

## Test plan

- [ ] `pnpm typecheck && pnpm check && pnpm test:run` all green locally
- [ ] CI green on PR
- [ ] Manual smoke on preview deploy: blog detail, jobs detail, clients detail — verify footer (author / hiring contact / team) renders after primary content with no layout shift
- [ ] Networktab: verify no waterfall regression on detail routes