### PR TITLE
chore(perf): add PSI snapshots (2026-05-14 + 2026-05-15)

### DIFF
--- a/tmp/perf-20260514/psi-blog.json
+++ b/tmp/perf-20260514/psi-blog.json
@@ -1,0 +1,7065 @@
+{
+  "captchaResult": "CAPTCHA_NOT_NEEDED",
+  "kind": "pagespeedonline#result",
+  "id": "https://www.ocobo.co/blog",
+  "loadingExperience": {
+    "initial_url": "https://www.ocobo.co/blog"
+  },
+  "lighthouseResult": {
+    "requestedUrl": "https://www.ocobo.co/blog",
+    "finalUrl": "https://www.ocobo.co/blog",
+    "mainDocumentUrl": "https://www.ocobo.co/blog",
+    "finalDisplayedUrl": "https://www.ocobo.co/blog",
+    "lighthouseVersion": "13.0.1",
+    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+    "fetchTime": "2026-05-14T17:22:10.648Z",
+    "environment": {
+      "networkUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36",
+      "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+      "benchmarkIndex": 360.5
+    },
+    "runWarnings": [],
+    "configSettings": {
+      "emulatedFormFactor": "mobile",
+      "formFactor": "mobile",
+      "locale": "en-US",
+      "onlyCategories": [
+        "performance"
+      ],
+      "channel": "lr"
+    },
+    "audits": {
+      "viewport-insight": {
+        "id": "viewport-insight",
+        "title": "Optimize viewport for mobile",
+        "description": "Tap interactions may be [delayed by up to 300 ms](https://developer.chrome.com/docs/performance/insights/viewport) if the viewport is not optimized for mobile.",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "node": {
+                "boundingRect": {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0
+                },
+                "snippet": "\u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\"\u003e",
+                "path": "1,HTML,0,HEAD,2,META",
+                "lhId": "page-8-META",
+                "nodeLabel": "head \u003e meta",
+                "type": "node",
+                "selector": "head \u003e meta"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "lcp-discovery-insight": {
+        "id": "lcp-discovery-insight",
+        "title": "LCP request discovery",
+        "description": "[Optimize LCP](https://developer.chrome.com/docs/performance/insights/lcp-discovery) by making the LCP image discoverable from the HTML immediately, and avoiding lazy-loading",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "items": {
+                "priorityHinted": {
+                  "value": true,
+                  "label": "fetchpriority=high applied"
+                },
+                "eagerlyLoaded": {
+                  "label": "lazy load not applied",
+                  "value": true
+                },
+                "requestDiscoverable": {
+                  "label": "Request is discoverable in initial document",
+                  "value": true
+                }
+              },
+              "type": "checklist"
+            },
+            {
+              "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"pos_absolute inset_0 w_full h_full obj-f_cover op_0.8\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+              "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,1,A,0,DIV,0,IMG",
+              "lhId": "page-1-IMG",
+              "boundingRect": {
+                "width": 380,
+                "bottom": 892,
+                "height": 224,
+                "right": 396,
+                "top": 668,
+                "left": 16
+              },
+              "type": "node",
+              "nodeLabel": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute",
+              "selector": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute"
+            }
+          ]
+        }
+      },
+      "image-delivery-insight": {
+        "id": "image-delivery-insight",
+        "title": "Improve image delivery",
+        "description": "Reducing the download time of images can improve the perceived load time of the page and LCP. [Learn more about optimizing image size](https://developer.chrome.com/docs/performance/insights/image-delivery)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 2,432 KiB",
+        "metricSavings": {
+          "LCP": 700,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "reason"
+              },
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Resource Size",
+              "valueType": "bytes",
+              "key": "totalBytes"
+            },
+            {
+              "label": "Est Savings",
+              "subItemsHeading": {
+                "valueType": "bytes",
+                "key": "wastedBytes"
+              },
+              "valueType": "bytes",
+              "key": "wastedBytes"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 2490057,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "totalBytes": 2245492,
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,2,UL,5,LI,0,ARTICLE,1,DIV,1,DIV,0,IMG",
+                "lhId": "page-0-IMG",
+                "snippet": "\u003cimg class=\"d_flex ai_center jc_center flex_0_0_auto w_20px h_20px bdr_9999px\" alt=\"\" src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/ethel…\"\u003e",
+                "boundingRect": {
+                  "width": 20,
+                  "left": 41,
+                  "top": 4647,
+                  "right": 61,
+                  "bottom": 4667,
+                  "height": 20
+                },
+                "type": "node",
+                "nodeLabel": "article.d_flex \u003e div.px_6 \u003e div.d_flex \u003e img.d_flex",
+                "selector": "article.d_flex \u003e div.px_6 \u003e div.d_flex \u003e img.d_flex"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/ethel-gosset.jpeg",
+              "wastedBytes": 2245380,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 2245380,
+                    "reason": "This image file is larger than it needs to be (4284x5712) for its displayed dimensions (35x35). Use responsive images to reduce the image download size."
+                  }
+                ]
+              }
+            },
+            {
+              "node": {
+                "selector": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute",
+                "nodeLabel": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute",
+                "type": "node",
+                "boundingRect": {
+                  "width": 380,
+                  "left": 16,
+                  "right": 396,
+                  "top": 668,
+                  "height": 224,
+                  "bottom": 892
+                },
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"pos_absolute inset_0 w_full h_full obj-f_cover op_0.8\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,1,A,0,DIV,0,IMG",
+                "lhId": "page-1-IMG"
+              },
+              "totalBytes": 201358,
+              "subItems": {
+                "items": [
+                  {
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size.",
+                    "wastedBytes": 60256
+                  },
+                  {
+                    "wastedBytes": 131240,
+                    "reason": "This image file is larger than it needs to be (1200x706) for its displayed dimensions (665x443). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 152223,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png"
+            },
+            {
+              "wastedBytes": 66713,
+              "subItems": {
+                "items": [
+                  {
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size.",
+                    "wastedBytes": 25189
+                  },
+                  {
+                    "wastedBytes": 66590,
+                    "reason": "This image file is larger than it needs to be (512x489) for its displayed dimensions (35x35). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg",
+              "node": {
+                "selector": "article.d_flex \u003e div.px_6 \u003e div.d_flex \u003e img.d_flex",
+                "boundingRect": {
+                  "width": 20,
+                  "left": 41,
+                  "right": 61,
+                  "top": 7442,
+                  "height": 20,
+                  "bottom": 7462
+                },
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,2,UL,10,LI,0,ARTICLE,1,DIV,1,DIV,0,IMG",
+                "lhId": "page-2-IMG",
+                "snippet": "\u003cimg class=\"d_flex ai_center jc_center flex_0_0_auto w_20px h_20px bdr_9999px\" alt=\"\" src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benja…\"\u003e",
+                "nodeLabel": "article.d_flex \u003e div.px_6 \u003e div.d_flex \u003e img.d_flex",
+                "type": "node"
+              },
+              "totalBytes": 66917
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 10523,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 15421,
+                    "reason": "This image file is larger than it needs to be (192x192) for its displayed dimensions (53x53). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "wastedBytes": 16208,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "totalBytes": 16667,
+              "node": {
+                "selector": "body \u003e div#ago-wrapper \u003e button#ago-chat-button \u003e img#open-path",
+                "type": "node",
+                "nodeLabel": "Chat",
+                "snippet": "\u003cimg src=\"https://www.ocobo.co/android-chrome-192x192.png\" alt=\"Chat\" id=\"open-path\" style=\"width: 32px; height: 32px; object-fit: contain;\"\u003e",
+                "path": "1,HTML,1,BODY,12,DIV,1,BUTTON,0,IMG",
+                "lhId": "page-3-IMG",
+                "boundingRect": {
+                  "width": 30,
+                  "height": 32,
+                  "bottom": 792,
+                  "left": 350,
+                  "right": 380,
+                  "top": 760
+                }
+              }
+            },
+            {
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 6234,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 6709,
+                    "reason": "This image file is larger than it needs to be (348x104) for its displayed dimensions (234x70). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 9533,
+              "node": {
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "boundingRect": {
+                  "width": 134,
+                  "left": 33,
+                  "right": 167,
+                  "top": 37,
+                  "bottom": 77,
+                  "height": 40
+                },
+                "lhId": "page-4-IMG",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "nodeLabel": "Ocobo",
+                "type": "node"
+              },
+              "totalBytes": 12266
+            }
+          ]
+        }
+      },
+      "unused-css-rules": {
+        "id": "unused-css-rules",
+        "title": "Reduce unused CSS",
+        "description": "Reduce unused rules from stylesheets and defer CSS not used for above-the-fold content to decrease bytes consumed by network activity. [Learn how to reduce unused CSS](https://developer.chrome.com/docs/lighthouse/performance/unused-css-rules/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [],
+          "overallSavingsMs": 0,
+          "items": [],
+          "type": "opportunity",
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            }
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsBytes": 0
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "user-timings": {
+        "id": "user-timings",
+        "title": "User Timing marks and measures",
+        "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more about User Timing marks](https://developer.chrome.com/docs/lighthouse/performance/user-timings/).",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "details": {
+          "type": "table",
+          "headings": [
+            {
+              "label": "Name",
+              "valueType": "text",
+              "key": "name"
+            },
+            {
+              "label": "Type",
+              "valueType": "text",
+              "key": "timingType"
+            },
+            {
+              "label": "Start Time",
+              "key": "startTime",
+              "valueType": "ms",
+              "granularity": 0.01
+            },
+            {
+              "granularity": 0.01,
+              "valueType": "ms",
+              "key": "duration",
+              "label": "Duration"
+            }
+          ],
+          "items": []
+        }
+      },
+      "cumulative-layout-shift": {
+        "id": "cumulative-layout-shift",
+        "title": "Cumulative Layout Shift",
+        "description": "Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/articles/cls).",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "0.002",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "newEngineResultDiffered": false,
+              "cumulativeLayoutShiftMainFrame": 0.00213
+            }
+          ]
+        },
+        "numericValue": 0.00213,
+        "numericUnit": "unitless"
+      },
+      "max-potential-fid": {
+        "id": "max-potential-fid",
+        "title": "Max Potential First Input Delay",
+        "description": "The maximum potential First Input Delay that your users could experience is the duration of the longest task. [Learn more about the Maximum Potential First Input Delay metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-max-potential-fid/).",
+        "score": 0.42,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "280 ms",
+        "numericValue": 277,
+        "numericUnit": "millisecond"
+      },
+      "main-thread-tasks": {
+        "id": "main-thread-tasks",
+        "title": "Tasks",
+        "description": "Lists the toplevel main thread tasks that executed during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "headings": [
+            {
+              "valueType": "ms",
+              "key": "startTime",
+              "granularity": 1,
+              "label": "Start Time"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "duration",
+              "label": "End Time"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "duration": 49.226,
+              "startTime": 2749.206
+            },
+            {
+              "startTime": 2799.507,
+              "duration": 6.684
+            },
+            {
+              "startTime": 2806.201,
+              "duration": 6.235
+            },
+            {
+              "duration": 32.978,
+              "startTime": 2812.448
+            },
+            {
+              "startTime": 3129.636,
+              "duration": 9.551
+            },
+            {
+              "startTime": 3142.206,
+              "duration": 10.764
+            },
+            {
+              "startTime": 3152.986,
+              "duration": 98.705
+            },
+            {
+              "startTime": 3254.205,
+              "duration": 11.049
+            },
+            {
+              "startTime": 3275.517,
+              "duration": 38.83
+            },
+            {
+              "startTime": 3318.404,
+              "duration": 15.941
+            },
+            {
+              "startTime": 3335.578,
+              "duration": 7.124
+            },
+            {
+              "startTime": 3344.25,
+              "duration": 11.972
+            },
+            {
+              "startTime": 3357.976,
+              "duration": 32.181
+            },
+            {
+              "startTime": 3391.513,
+              "duration": 10.26
+            },
+            {
+              "startTime": 3401.976,
+              "duration": 29.713
+            },
+            {
+              "startTime": 3433.191,
+              "duration": 14.145
+            },
+            {
+              "startTime": 3463.713,
+              "duration": 18.861
+            },
+            {
+              "startTime": 3485.993,
+              "duration": 30.467
+            },
+            {
+              "startTime": 3526.012,
+              "duration": 81.72
+            },
+            {
+              "startTime": 3608.737,
+              "duration": 19.424
+            },
+            {
+              "startTime": 3629.872,
+              "duration": 22.678
+            },
+            {
+              "startTime": 3653.476,
+              "duration": 5.878
+            },
+            {
+              "startTime": 3659.56,
+              "duration": 85.359
+            },
+            {
+              "duration": 60.835,
+              "startTime": 3745.612
+            },
+            {
+              "duration": 7.169,
+              "startTime": 3820.677
+            },
+            {
+              "startTime": 3828.744,
+              "duration": 231.024
+            },
+            {
+              "startTime": 4061.798,
+              "duration": 6.938
+            },
+            {
+              "startTime": 4073.819,
+              "duration": 8.317
+            },
+            {
+              "startTime": 4084.032,
+              "duration": 5.731
+            },
+            {
+              "startTime": 4089.836,
+              "duration": 5.305
+            },
+            {
+              "startTime": 4095.185,
+              "duration": 11.816
+            },
+            {
+              "startTime": 4107.014,
+              "duration": 7.235
+            },
+            {
+              "startTime": 4114.26,
+              "duration": 5.286
+            },
+            {
+              "startTime": 4119.557,
+              "duration": 5.371
+            },
+            {
+              "startTime": 4124.943,
+              "duration": 5.394
+            },
+            {
+              "startTime": 4130.353,
+              "duration": 5.783
+            },
+            {
+              "startTime": 4136.149,
+              "duration": 8.138
+            },
+            {
+              "startTime": 4144.33,
+              "duration": 5.35
+            },
+            {
+              "startTime": 4149.701,
+              "duration": 10.42
+            },
+            {
+              "startTime": 4160.136,
+              "duration": 25.378
+            },
+            {
+              "duration": 24.214,
+              "startTime": 4185.532
+            },
+            {
+              "startTime": 4210.923,
+              "duration": 8.82
+            },
+            {
+              "startTime": 4221.143,
+              "duration": 5.523
+            },
+            {
+              "startTime": 4234.592,
+              "duration": 5.046
+            },
+            {
+              "duration": 5.271,
+              "startTime": 4240.968
+            },
+            {
+              "duration": 5.324,
+              "startTime": 4246.726
+            },
+            {
+              "startTime": 4252.065,
+              "duration": 5.365
+            },
+            {
+              "startTime": 4257.449,
+              "duration": 5.414
+            },
+            {
+              "startTime": 4262.879,
+              "duration": 5.481
+            },
+            {
+              "startTime": 4268.377,
+              "duration": 8.088
+            },
+            {
+              "startTime": 4277.35,
+              "duration": 11.535
+            },
+            {
+              "startTime": 4289.079,
+              "duration": 5.467
+            },
+            {
+              "startTime": 4297.118,
+              "duration": 5.147
+            },
+            {
+              "startTime": 4302.389,
+              "duration": 5.341
+            },
+            {
+              "startTime": 4307.77,
+              "duration": 5.235
+            },
+            {
+              "startTime": 4313.021,
+              "duration": 5.326
+            },
+            {
+              "startTime": 4318.477,
+              "duration": 19.96
+            },
+            {
+              "duration": 31.37,
+              "startTime": 4347.521
+            },
+            {
+              "startTime": 4382.031,
+              "duration": 6.624
+            },
+            {
+              "startTime": 4388.694,
+              "duration": 5.965
+            },
+            {
+              "startTime": 4394.896,
+              "duration": 15.103
+            },
+            {
+              "duration": 21.084,
+              "startTime": 4413.603
+            },
+            {
+              "startTime": 4443.536,
+              "duration": 6.818
+            },
+            {
+              "startTime": 4451.132,
+              "duration": 5.487
+            },
+            {
+              "startTime": 4456.688,
+              "duration": 5.249
+            },
+            {
+              "startTime": 4462.832,
+              "duration": 8.242
+            },
+            {
+              "startTime": 4472.031,
+              "duration": 5.52
+            },
+            {
+              "startTime": 4479.451,
+              "duration": 5.254
+            },
+            {
+              "duration": 5.755,
+              "startTime": 4486.094
+            },
+            {
+              "startTime": 4492.562,
+              "duration": 5.444
+            },
+            {
+              "startTime": 4499.577,
+              "duration": 5.427
+            },
+            {
+              "duration": 5.131,
+              "startTime": 4505.755
+            },
+            {
+              "startTime": 4510.97,
+              "duration": 5.207
+            },
+            {
+              "startTime": 4516.191,
+              "duration": 203.08
+            },
+            {
+              "startTime": 4722.563,
+              "duration": 6.532
+            },
+            {
+              "startTime": 4731.737,
+              "duration": 11.063
+            },
+            {
+              "startTime": 4742.915,
+              "duration": 22.428
+            },
+            {
+              "startTime": 4770.268,
+              "duration": 10.187
+            },
+            {
+              "startTime": 4780.66,
+              "duration": 47.703
+            },
+            {
+              "startTime": 4830.872,
+              "duration": 34.006
+            },
+            {
+              "startTime": 4866.096,
+              "duration": 83.224
+            },
+            {
+              "duration": 10.566,
+              "startTime": 4949.329
+            },
+            {
+              "startTime": 4959.904,
+              "duration": 10.25
+            },
+            {
+              "duration": 93.461,
+              "startTime": 4971.93
+            },
+            {
+              "startTime": 5074.207,
+              "duration": 120.639
+            },
+            {
+              "startTime": 5201.174,
+              "duration": 26.213
+            },
+            {
+              "startTime": 5288.724,
+              "duration": 16.624
+            },
+            {
+              "startTime": 5331.818,
+              "duration": 153.828
+            },
+            {
+              "startTime": 5487.023,
+              "duration": 6.567
+            },
+            {
+              "startTime": 5494.773,
+              "duration": 38.534
+            },
+            {
+              "startTime": 5536.01,
+              "duration": 27.838
+            },
+            {
+              "startTime": 5568.198,
+              "duration": 10.662
+            }
+          ]
+        }
+      },
+      "layout-shifts": {
+        "id": "layout-shifts",
+        "title": "Avoid large layout shifts",
+        "description": "These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "3 layout shifts found",
+        "metricSavings": {
+          "CLS": 0.002
+        },
+        "details": {
+          "items": [
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "type": "url",
+                      "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff"
+                    }
+                  }
+                ]
+              },
+              "score": 0.001897,
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,1,H1",
+                "lhId": "page-6-H1",
+                "snippet": "\u003ch1 class=\"ff_display fs_5xl fw_bold c_ocobo.dark mb_6\"\u003e",
+                "boundingRect": {
+                  "bottom": 437,
+                  "height": 187,
+                  "right": 396,
+                  "top": 250,
+                  "left": 16,
+                  "width": 380
+                },
+                "type": "node",
+                "nodeLabel": "Explorez la science du revenu.",
+                "selector": "section.pt_32 \u003e div.pb_12 \u003e div.max-w_2xl \u003e h1.ff_display"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "type": "url",
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf"
+                    }
+                  }
+                ],
+                "type": "subitems"
+              },
+              "score": 0.000233,
+              "node": {
+                "selector": "section.pt_32 \u003e div.pb_12 \u003e div.max-w_2xl \u003e p.fs_xl",
+                "boundingRect": {
+                  "width": 380,
+                  "right": 396,
+                  "top": 461,
+                  "left": 16,
+                  "height": 52,
+                  "bottom": 513
+                },
+                "snippet": "\u003cp class=\"fs_xl c_gray.600 fw_medium\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,2,P",
+                "lhId": "page-5-P",
+                "nodeLabel": "Articles, interviews et masterclasses pour structurer votre croissance.",
+                "type": "node"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "extra": {
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "type": "url",
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                    }
+                  }
+                ],
+                "type": "subitems"
+              },
+              "score": 0
+            }
+          ],
+          "headings": [
+            {
+              "subItemsHeading": {
+                "key": "extra"
+              },
+              "label": "Element",
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "key": "score",
+              "granularity": 0.001,
+              "label": "Layout shift score",
+              "valueType": "numeric",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "cause"
+              }
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "final-screenshot": {
+        "id": "final-screenshot",
+        "title": "Final Screenshot",
+        "description": "The last screenshot captured of the pageload.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "screenshot",
+          "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAMEBQYHCAIBCf/EAFUQAAEDAwIDAwgECgcEBQ0AAAEAAgMEBREGEhMhMQdBURQiUmFxgZGhCBUjMhY3VXJzlLGzwdEkMzRCYnXTGDaSshcnU3TjJlRWZoKDk5WipcLh8P/EABkBAQEBAQEBAAAAAAAAAAAAAAABAgMEBf/EAC0RAQABAwIDBgUFAAAAAAAAAAABAgMREjEEIUEFEzNRcaEUIjTR8DJCYZHB/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEXxzg1pc4gNAySegWPRa40rNcPIYtRWl9XnaIm1TCSfDr19SDIkQkAZJ5eKx0640s2v8iOorSKvO3heVs3Z8OvX1IMiRAQQCDkHvVqvOobXZXsbdaryRj8YmljcIh7ZMbR7yguqLAu2uq/6pL/U0c/I07XMlif1Bc3mCFdjq/T1mpKCmu98t1HVOhj+znqGtdzaOZBPJBk6KOmqIaqBk9NLHNDINzJI3BzXDxBHVWW76x03Z6sUt1vtspKnOOFNUsa4e0E8vegvyKKkqYKynZUUk0c8EgyySNwc1w8QR1UqAiIgIiICIiAiIgIiICIvj3bWkoBcG9SAvgkYejgrXcrjSW+A1FxqoaaHIbxJnhjcnoMlUFHqWx1tSyno7xb56iQ4ZHHUMc53sAKDJUUFO8nzT7lOgIiICIiDW/bhPM+z2O0NmfT0l4usFDVyMO08FxJc3PdnGFkdXoXTFRYXWh9loG0OwsDWwtBbyxuDsZDvX1VZq7TtDqqxT2u5tdwZMOa9hw+J45te09xBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHfjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fW0bcrbjNA6VbY/qkWK3+RbNmDC3d0xnd13evOV7m0TZJdEjSppiLS2IRNaD5zSDkPB9Ldzz4rGm6J1oyk+rm6/l+rQ3hhxt7DU7OmOLnrjvxlBZu0GqqdCdihp9O3iarMcraNlc54c+GNzyCNw72jzQeoWxdP6ctlv04y3RxCop5oQ2d8x4jqjI5ueT94nKjt2jbJRaPbpkUjZrTwzG+ObzjJk5LnH0ieefFUrtPXS2WUWfTFe2mptnDZUVr3VElO3phjeWcd25xwg0rTzy0/ZF2oWBsr5rdZq59PRvcc7Y+IPMz6sfNbn0TpSzUek6SM0tNXOq6dklTUzMEjqpzmglzieoOeQ7greOzOgp+zWu0lQVMkfloLp6yRu98khcCXuHLOcYSPR2o7TSeQaX1THRW0N2xw1VCKh1OO8Ru3Dl4B2cIMU0/VzaQ/6UbVZCXUFni8soYvvCB74nPcweoEZwsp7LNJWOHQ1tqX0dLXVVxp21NXVTxtkfO+QbnZJHMZPRXrRejqPTNnqqQyyV9TXSOmrqqoAL6l7upd6scgFjtFoLUOn2SUWkNW+Q2cuc6Kkq6JtSafJyQxxIOPAHKCDs+hjsHafqzTdrGyzMhgro4Actp5H5Dmt8AeuFtBYzojSMGl4ayR9XPcLpXScasrp/vzO7hgcg0DkAOiyZAREQEREBERAREQEREBeJxmIr2h5oMd1GKk20+RCuM24f2Lg8TH/AL3zcfNWKytu/wBaQeVDUXByd3lQoeH0P3uH5/wWbPhIPm8wvIieT91B9gH2gVUvEUYYPWvaAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiLHa6suDNQCGJ7m0oLMgx5GDjPPCxXXFERMutq1N2ZiJ2jLIkWP22qrai4VsMs0jQ0vEQMYAAzyOcfxVPQV12lpqyR4cXwxgNaYwNzs9enPksd/HlPX2dPhaufOOWPdlCLGbbX3OWgr3y7y6OLdG4x4O7HMAY5pHVXdllknnf9q5zeGdgJDT1yAP4KRfiYziVnhaomY1RvEf2yZFaKGpq5LBJPKX+Uhjy0lgByM45Kkpq+ukbacmTMjntnzHjOMY7uS130cuW7EcPVMzGY5faZ/xkSLGKK4XJ94qIZTJwGmTZmIY5Zxzwo6C5XP6urJahz3SBg4Q4WCCTjPTCzHEU+U9fZ0nhKojeOnv+c2VosYNwuQskziZPLIpQ3dwxkj2YwlTV3VlngqGSl04e5kgEfXwOMdyfER5TtlPhKttUb4/P4ZOiipWyMpo2zv4kob5zsAZPuUq7w808hEREEREBERAREQEREBERAREQEREBERARFFJUwRuLZJo2OHc5wBQSooPLKb/ziH/jCma4OaHNILTzBB6oPqIiAiLDu0TtFsugRQG+tq3eW8TheTxh/wBzbnOSMfeCDMUWLdn2ubTry3VNbY21TYaeXgv8ojDDuwDywTywVlKAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC4s+kz+N66foYP3TV2muLPpM/jeun6GD901Bidp0HqW70dPVW62OnhqP6otmjBdzxyBdnqt1xds1z7N7bbNL3rR7hV0NHCzc6v27xsGDjhn1jqeYK1ZpHWWlrBHbJ5tDtrbvRPbMK43WaPfI125ruGAWjGBy6clmX0l7/bL9DpGpiphFeJ7eyrn2v3cOOVrXMjJxzIO455fNEbA1h9IWjsdTb47fZfrFtTRRVb3eWcPhGQZ2EbHZIGOfrVBePpE1dofSx12jxHJUU7KlrTceYY/m3P2XeMH3rm2jY233igfeKWR9KHRTSRHkZITh3I+tvRbA+kZVUtb2iiqt7mPo5qCmkhcwYBYWZGPcg2zWfSStlPRWuSOyyT1FRG6SqijqRimO4gN3FvnEgZ7sZCwX6Q+tLVrnT+kbnZ3PDWvq45YZRh8T8QnB/mFgVHfNP0mgZ7VWaWbLfJyXw3R0xaQ0u5ED1YIwOR71jU1FUx2alrZA4Uk08scZPQuY1hdj/iag3/8AR51datF9mN+ul7mcyEXEMjjYMvlfwm4a0ePL2Kvd9J2k8r2t0xOaXP3zWAPx47dmM+9aKkpap/ZrT1MYcaOK7Sslx0D3Qx7M+5r1dYr3owdlr7XJYpzq0yEivyNuN+Qc7s/d83bj1oOjtQduFppNA0up7JROuLZKxtFLSyTcCSBxY9/nea70e7kc9eSxJn0l4JLRWznT4hro3Rtp4DWF4l3btxJ2DAaGjxyXBaIpaWqb2b3KqLXCifdaWNpI5OeIagnHsBHxC2n9FbT1nv8AV6kbe7ZSV4hZTmMVEQfsyZM4z0zgfBBsibt6tFBoq03a50UhulwY97KCnfu2ta9zdznHGAS3wJ+Cxyg+k5RPqWtrtNVEMBPN8VWJHAfmlrf2rW30krIyydovBpKSOktr6SJ1LHEzawN5hwAHL724+/1qx3S66NnobWwWysfLEz7cUrGUmDgci5xlMnPvO3+CDpHtC7a6HTNo09dLTbheKK8MlfG/yjg7OGWAgjY7nlxBHLGFhH+1Af8A0SH/AMx/8JY5eafQUvZZYai5uvlvMb6mSgt7J45Jpw8sDnklmGs3R8jgd/Vay0hW6coL2avUVtrbhRRndFSRzNaHc+QkdjmPUAM/JB3D2d6m/DHRtuvxpPI/LA88DicTZte5n3sDOduenesjVm0bXUtz0naK630jaOkqaWOWKnaABE1zQQ3ly5K8ooiIgIiICIiAiIgIiICIiAiIgLXusOyHSurb9Nd7xFVurJmta4xzljcNAA5ewLYSINR/7Pmhf+wuH60f5KoruwjRldOJaplykkEbIgTVHk1jQ1o6dzWge5bURBrrUfY3pDUFRSTV1LUtdTU0dJGIZiwcNgw3Picd65h7d9P0el9eG0Wx05o6eliEYmk3uaCCcZ8Oa7jVDWWa2VsxmrLdRVExGC+WBr3Y9pCDSnZT2c6b1p2W6Xq9QUb5pqZs7GuZI6Pc0zOOHY5kZz8Ss/1N2VaV1FbLVb6uifBRWwPFNFSycMN37d2fH7o5+1ZrS00FJA2Glhighb92ONga0ewBSoMN032a6Z0/p+uslNRGottbJxJ4ap3FDjgDv6dAscPYHoI1PF+r6oNznhCrft9nXPzW1UQYdqDs301e9MUmn56I01qpZhPFDSu4eHhrm5J7+Tj1X3QPZ3YdCSVr7BHUMdWBgl40pfnbnGPD7xWYIgsWrtI2PV9A2k1BQR1cbDljiS18Z8WuGCP4rCqDsH0HSVTZzbZ6jadwZPUvcz3jIz7CtpIgwTWXZTpfV1TRzXWmmYaSAU0LKaThMZGCSAAB61j3+z5oX/sLh+tH+S24iCisdrprLZ6K2UIcKWkhbBEHnJDWjAye9VqIgIiICIiAiIgIiICIiAiIgIiIC0P2r9t100VrarslJaaKphgZG4SSvcHHcwO7vat8Liz6TP43rp+hg/dNQdY9nl/m1Tou1XqphjgmrIjI6OMktb5xHLPsWRLk2XtfuOj+zvSti04yAVvkXFqKiVu/h7nu2ta3pnHPJz1CoK/t41sNO0cBk8kuYlLzW+TR4qIiOQ2ubgEHvb1HzDsFFpb6NmuNQa0g1A7UlcKt1K6AQ4hjj27hJn7jRn7o6qH6Q/ajd9FVdBadPtjhqqmAzvqpIw/a3cWgNB5Z5HOQe5Bu9Fxfa+1ftRnY+to66srKaN2JHCgZJGD1wSGcuqznVXbrfaLQ2n3UsVLFf7jFJNPNw/Nia2RzBtYSeZ2nrkDHRB0utcdtWvrnoO1UVRabMbg6pe5rpnhxjhxjG7bzycnHMdCucm9sHaXRNhrqi5VBppTljp6KMRSeoHYPkVm+q+2vUFZ2b2S8WaaK3XF9ZLSVrWQskY8tY1wIDwcAhwKDZ3Yj2h3bXtLcX3ezii8lLAyeMOEcuc5A3d4wO89Vs9c09nvbReabQupr1qadtynpJqeCihEUcIL5BIcHY0cvNyfYsKn7de0OtnlqaSphhp2c3Rw0THMYPWXAn5oOy0XMND28Xu6dn2oA7gUeo6GOGanqoYwWSMM0bH5Y7IBw/wBnPuwrPobtl7QrhXXCFpde5xRSPhgbTxMEbgW/auLWgkNG7lnmSEHWyLkns47eNR02oqaHVNYyutUpLZC6FjXx8uRaWgd+ORyrfd+2/XuoLvI2wSupISSYqSkpmyvDfWS0knx6D1IOxkXK/Zd246l/CygtGq3x1lLVTtpnPdC2OWFzjtB80AEZxkEZUeu/pAaiqr7UUekWw0dHHKY4pOCJZZsHGcOyAD3DHvQdWIuTtH/SA1Pbr1BT6tZFWUTnhkxMAhmjB/vDbgcuuCOfqXWDHNexr2HLXDIPiEH1ERAREQEREBERAREQEREBcWfSZ/G9dP0MH7pq7TVurbDaK6odPW2qgqZ3YBkmp2PccdOZGUHDWsdN19HYNOXwwSPt1dQsAmDSWskaXNLCe44APrz6lPrTVWq9W6atdRfmtdaqSQ09PM2BsYfJt58x1IAGccgu52UFIyiFGylgbSAbRAIwGAeG3oqeayWqelipp7ZQyU0RJjifAwsYT1wCMBEaB+hz/ZdV/n037JV9+k1qE27U1uoblYaK62d9G2Rrp2PY9ku94cGSsIIOAzI5jpyXQNutdvtgkFuoaWkEmN/AhbHux0zgc+pVRPDFURmOeJksZ6te0OB9xRX5+SX99JdxU6RbX2RpAAiirXSOLvzgGkjpyOVm/azZ9U3HTeltUX+jnMklCaaok4W0sLZXljngfdLmuByuvqWw2iknE1JaqCCYdJIqdjXfEBXFzQ5pa4AtPIg96JhwjUdqOq6iwWyy+XRijoA1sAbTs3Ya3a0Ekc8Dksk7R3ajm7JdNVWrHP8AKai4TPp2PhbE5sPDaBkNA6kE8+eCF13BY7TT1HHp7XQxT5zxGU7Gu+IGVLcLZQ3JjGXGipqtrDlonibIGn1ZHJBxZojTVfqbsr1XHaoX1FTRVtJV8Fgy57QyZpAHecOzj1LHtP6tq7BZrha2UcUoqHHPHklAjOMH7MPDHHl/eaf4LvS3WugtokFuoaWkEmN4gibHux0zgc+pUVRZLVU1HHqbZQzT9eJJTsc74kZQceUMl8uXZVqmvqrTbaW0RwwRsqorfHBJLIamLk1zQMgAHPd0VT9GX/fe7/5NUf8ANGuw6mipaqkNLVU0E1MQAYZIw5hwcjzTy5YCpaKx2mhldJQ2uhppHNLC6GnYwlp6gkDp6kH59aetr7xf7bbYSBJWVMdO0nuL3Bo/ar3p6+aj7NNT1EtLGaG6MY6nliqYQctJBIwfW0HI8F3NBpuxwTRzQWa2xyxuDmPZSsDmkdCCByKqq+2UFwDRX0VLVBvTjRNfj4hByJ2Vak1xqjtApWUVW6SOeqE9dIKaPYyPdl5J28sjIHyWG3S3XXs410W11JIJqSVxj3PkjbPGcgOa9ha7BB6g+o94XeVJSU9HEIqSnigjH9yJgaPgF5rqCkr4xHXUsFTGOYbNGHj4FBxTprUGoNT6xbHZbFaKmpqpG+ZLQNqRGOQ3Okk3PwOpLnLtyFpZExrsZDQDtGB7lBQ0FHQRllDSU9Mw9Wwxhg+ACqUUREQEREBERAREQEREBERAREcQ0EuIAHUlARag+kte6u3dnMFXYrnPSzfWMcZmo5yx2NkhLS5p9Q5LB/ovaqulxv17GoL7W1UDKZhYK2rc9rXF/duOAcIOl0VPFX0krXuiqoHtjG55bICGjxPgvkNwop5BHDV08kjujWSNJPuygqUUVRUQUzA6omjiaTgGRwaCfeqd92t0dPJO+vpGwR43yGZoa3PTJzgIK1FDBVU9RTNqKeeKWncNzZWPDmkeII5L5DW0s79kNTDI7wZICfkgnRU89dSU8myoqoIn4ztfIGn4FfTW0racTmphEBOBIXjaT7eiCdFBT1lNUlwpqiGYt5kRvDsfBfDXUjZeG6qgEnTYZBn4IKhFHUVENOwPqJo4mE4DnuDRn3qJlwo5I5Hsq6dzI27nuEgIaPE8+QQVKKlhuNDPTGohrKaSnb1lbK0tHvzheoK+kqH7IKqCV+M7WSBxx7kFQipGXOge9rGVtK57jgAStJJ8Oqq0BERAREQEREBERAREQEREBcq/Sn1jcpNVN01TVEsFupoWSSxscW8aRwz52OoAxgeOV1UtHdvvZFW6xuEN8046E3JsYhnp5XbBK0Z2uDum4Zxz7seCDQ180jqjT/ZtQ3OsqYPwfu80U7Kdk25wfscWOLcYBLSeh9qxek/3buX/AHmn/wCWVbMl7F+0OfTOKqGaR1NOI6a2mrY4BhBLpBl+1ozgYHM5PgqrTPYhq6psV+pLnbm0NQ5kUtIZZ43NkkY45adrjjLXO5nvwiKHsR/3P7Tv8jf/AMsitP0d/wAcmnfzp/3EiyjSHZD2i0NHqGAMNsp6mhkifE2WKQ1pwS2IcztBPVxI5Equ7F+y3WWnu0yy3S8WV1NQU5lMspqInbcwvaOTXk9SB0QZt9Lv/cK0/wCZt/dSLSPZToO9a/ob1QWi401JSwPp5ahk+7EjvtAw8genn/FdFfSP0petXaQt1Fp2iNZUxVzZnsEjGYZw3jOXEDqQrN9GfRGodHP1EdSW51EKoU/BzLG/ft4m77rjjG4dfFBpTtVrL3psUGg57gfJLRA0Ssp3Fsc0khMm49CcB7Rz6YKsztF6it8tBPbOLUTzeex9G2VpicMHm9zWtz62k+1b97fOx+46tu7L/pt0T650bYqimkds4m3kHNceWcYGDjoFqxnY32mXiamp7nTSMhhAjjfV1zHsib6gHOIHqAQVPbNZr9PojSmotT0r4ruwPt1W9zmuMgBLonu2kjJG7PsWGV+r31PZZa9LZOaW4S1DvzC0bB/xPk+AXTt17LWwdiFRpGheaqvjjNRHIcN4lQHb+WeQB+77CueGdiXaC57QdPOaCcEmqg5f/Wg901VctG9kdNVW+aSkqtTVcgdNEdr/ACaAAbQeoy956dwWM0GlLpcrE68UjxPh2BCxkr5TzxnIYWjn4uBXVfaN2TRai7ObRYrXNHT1tnjaKV7x5j8Nw5rvDdgHPiFocdj3adHTPtbKGb6vc/e6NtfGIXO9It3/AMEEOovwupux8UOqIKkW+O5wPopKiQOc37KYOZ1Jx0Iz05q0dntkuN50xrQ0V0dQ0tHQCrqYmsz5SGbiGE5GByJ7+7kth3LsL1Dbuzcw0sLbjqCqr4ZZYIZWtZDCxkowHPIBOXjPux4qv7K+zXVtk0zrylulodBPcrU6npGGeJ3FkLXjbkOIHUdcBBoCiudVR0VfSwTPbT1sYimjB814D2vGR6i0LZ/0X/xkzf5bP/8Aio9O9hetKu6sgutpNFSvjlBqH1ETmsfw3bMhricb9o5DvV40D2P9olp1UHx4s0RjfFLXMlilzGRgta3JJJ7sgY65CDWPZx+MPS/+a0v75q79dWUzaoUzqmEVBGREXjefd1XIGiex/XVu1nYK6tsL4qWmuFPNK/ymE7WNkaXHAfk4APRV937GO0Co7QJ6qMiRklWZm3U1LRtG7IcRncCB3AexB1ui+MBaxocckDBPivqKIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIixfU2o3Wu90FMyWmZCNslUJXAOLHvEbdvPxLnH1M9aDKEWK33UdbBTXn6toA51vIYZpZAGFxa13IYJPJ3qVTNepaWrnZUwympEUG2lje1zN8kj2tw4gHJ28yeQHTvyGQosdq7xVQ1FvNXA6iZxpGztJEjXsbC9+WuHdkDwPJRUWrY6iOSR9FMGCndUxiJwlc5ox5pA+67mOXPv58kGTorbYrq27QSyMYxvDdtOyZsoPLPVp5H1HCpK+8+Q1tUwRz1Lw+CNsILQAZCQMHr7cn2IL6ixSXUNxkuFBT0tBEHmpkpqmOSfGHNiLwGkNPLG0592FU0+qI57kKdlMTAZ3UwlEgLt7SQSWdQ3IIz8sc0GRIrBRakEwp5qmjkpaOcyNjmkeOZYCTkDoCGvIP+H1qmk1NHTtknmjqA58VO6OmeWgB0pfgZxkHzcnPTHL1hlCKw0OpI6gwtmpzCXTmnc7eHMDtm8EOxzBAIzy58sLxBqiGejjnipZ3Oc6UuhHORrGM37sesFmB/jCDIUVrsN4Zd4pXsjYzhkDzJmSdRnntPI+o/NW23aqbcJmNpaTdHOHGmfxQdxAJG8AZYDjkefrweSDJkVl05cqys09FXXGnijkdEJPs5N28YznoMezmqOm1LVVLqdkVnl4tTTeVwtdO0Ax8s7j3Hzm8ufX24DJkWNv1VCHUL2wf0epbC4OdM1rxxSA3DOpxkZ6erK9HUjpqmspaWlbx4RIGtlnaxxLOWSz7wae44OeXTKDIkWJ02qKmO02p9bSQ+XVsAnDRUBrC0NaS4kjkcuGG4PtVWNTsdwHNo5xE6mdVTSOIAhY0kOz4nI5YzlBkKLG6q81xtr5jQy0ZcI3xSF7Xgtc9oId4OwenP28lOdRMZemUEkAHEkdExzZmueXBhfzYOYBDTg9enJBfUWM0+rYpqKoqRSvxEGHYJWOe3ccDe3OWY6nPIAHwX2XVcYp6UxQRvnqOIWt8pZw9rCA47xkdXAAYzz7kGSosbm1ZCwUhFLI3jxiT7aRkQHnbS0Fxw52R0B6YOeYWSICIiAiIgK3VFloak1xqIRKa1uyUu5+bt24HgMZ6d5JVxViuF7qobhWU1JbvKRSQsnkeZgzLXbuTRg5d5p5HA9aCs+paM0ldTSNe+KtOZg55y47Gs69RyaOneon2Cie2QP473PjjjL3TOc8bHOc0hxOcguJzlUX4Sl7JKuCj32uKRkclQZcPBdt5hmOYG4Z5g9cAqpN9AhpZDT/19ZLSY39NnE87p38Pp6/UglhsVHG5j5DNPI2R0pfNIXlxLCw5z3bTjHReaTT9JS7tktW4cIwRh9Q48JhxyZz5dBz68hzXm2Xmas04LtLQSRh8PHjgY7iPe3bkdB1PgrRWalrp6KCS2QUbpPLYYJG+VZwHOHI+ZkE5wcgY6jKC+QWaKCpbPHUVPFMgklcZOcuGFoa7uwM5x4jKmntVLNUvne13Ec+N5Id3xklv7VbHagqWT1bH28BlLNDBJIJ8gvk4fJvm5IHE78dB48pKq/SMuU1BS0YmqmzNhjDpdjXZi4hLjg4AHLoUFTPYaGeV0j2zNkdUeVb45nMcH7AzkWkHG0YwvkVipIq0VDH1AaJHTCDjO4QeertvjzJ8MnPVUL7peHXq3U7KCCOKWGV0zJKjBBa9gyCGHIw7I6ZzzxhfZtTtitlFWGlJFTBNPs4n3eGwux055xhBXVVioaq0stszHGlYQ4DcQeRz19fMH1Eheq2y0dZJPJK14klEYL2vLS0xklhaR0ILirVU6mqonxQttTnVToRUPi4jjsjJIbzaw+ccHl05dVXUF6krroKWGikbCKeOofLK7Y5m/dhuzGc+bzQepNPUU1sqKGczzR1DxJLI+UmRzhjB3d2NoHLwU31NReWz1Yjc2aaHgOLXluG+rHQ8hzHPzR4Kmkvojq30ppz5Q2pEO3d/c2b+J06bQfeMKmjv9XLBC8W+OIVkLpaMuqM78N3APAb5p28+W7ogu1BbYaKaaZj5ZJ5g1r5JXbnENztHuyfiqeisVJR1TJonVBbHuMULpSY4t3Xa3oOp9meWFbLPfbnLQ2RtVQRSVVfAJS+OfzQ0NYS93mjGd3QA88DPeJbNqZ1zq4GtoJm0dTu4M43HkASC8bQGggcsE93RBdaC101DRyUtPxRA/Pmvlc8NB7m5J2j1DklPa6anlppI2uDqenNLHl3Rh2/PzAqSru9S2vqKehoPKm0oaZ3GYMI3DIDAR5xxz5kDmOap5NRTCSdrLeSG1PkcJdKBxZOvh5rQMkn1HkUEg0tb2w8KM1DIyIwWtlIBMYAY72jaPVy6KrbZqbyxlRI+eVzC9zGySFzWFwIcR7iR6s8sK3/Xb31lNT1EMtPVsqzBLFDIHsceC6Qcy3JaQPAHPzip9V8akqZfI/tIgxxhbJmRgccfaMxuZjqeRGAeqIrW6boo6anhp5KyDycFsUjKl5expABYCSfN5Dl05BVdPaKOANDIy5og8nw9xdlmc4OepOTzKtMmpz9XwVEENJI6UvGBWN2+b1DSAS48+m0dOeO/xNqp/CknpaAy0sVFFXyvfKGFsbw44AwcuAaeWQPWiq+LTlFG0tc+qlaGCNglnc7htDg4NbnpzaPXyC9fg9ReUMmDpwWVDqljRKdrXuzuIHr3O+JxheKe81FTUvdBQb6Bk7qd04lAeHNJa47CPuggjOc+pU9j1I+6VMANvlipqlhkhm848sZG8FoDcjpglBWMsVM175DNVumLBG2V0x3saDkAH29c5z35Xh2naPY0xyVMU4e+Q1EcpbI4vxuyfA4by6ch4K8ogtM1go5aVtMX1IpxFwXxiZxEjPB2epOTk9TnqrsiICIiAiIgKx1OnoKy7VtVVOkMdRFHFsjlezc1u7IdtIyPO/b4q+IgtjrHQOqDNwXNy5r3RtkcI3ObjaSwHaSMDu7h4L4bFQGpZOY5C5krp2N4rtrXuBDnBucDO53xKuiIKaKhp4baygja5tMyIQtaHHIaBgDPXp39VSOsNA+GaOVkshlcx73umeX5YctIdnIwemCroiCgNpozBVRGNxZUua+QmRxcXNa1oOc5BAY3n4jPVQfg9b/tDsm4r5BMZRO/ibw3bkOzkeby9iuyILayx0MbaYMjla6nc57HiZ4dlxy7c7OXZPMg5yoXabtrz58UjhtkY1pmftY2QYeGjOADnuV4RBbq+zUdc9j5hMx7WcLdDM+MlnoktIyPap6WgpqSZ8lPEI3OjZEcE42sztAHdjcVVIgpHW2lddBcXRZqxFwN+T9zOcY6e9QUVkoaOVr4Y3+Y0sja+Vz2xtPUNBOGjkOiuSILfQWaioOB5NG9oga5kQdK5+xrtuWjJOB5o5d2OS8UljoaSqZUQslDmFxjY6Z7mRl3XawnDe/oO9XNEFtr7JQ1875ahkm6RoZIGSvYJWjoHgEBw5nr44Uktpo5aeWF8R2SS8c4eQQ/OdwIOQeXcq5EFuistDHwyInOfHKZw98jnOc8sLCXEnJ80kc/V4Ly2x0bS539IMhaGCR1Q8va0HIAdnI5/FXNEFqFgt4c1wjlDxv3P4z9z9+N245552t6+ASKwW6KjmpWQu4M1O2keDI45ibuw3Oc8tzldUQWw2OhNX5QY5N3E43D4r+Hv9LZnbnvzjrz6rxT6foKdxMTZwOG6NjfKH4ia7qGDOGe7GO5XZEHmJgiiZG0uLWgNG4knl4k9V6REBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAXkh+eRbj2L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9IgIiICIuavpMdpdwpLodKWKpfSsjja+tmidte4uGRGCOgxgnHXOPaHQlRfbRTSuiqbrQQyt5FklQxpHuJUX4S2L8tWz9aj/muALRZbne3zC10U9Y+IbpOE3cWjnzPwKoHMc1xDmkEd2ER+iUF/s88jY4Ltb5JHHAaypYSfcCrkvzaIIwSCF0D9GvtLuDL9BpS9VL6mjqgRSSSuy6F4GdmT/dIBwO44x1QdSKkrbnQUBArq2lpieYE0rWZ+JUFznkfV09vpnmOWdrpJJAOccbcA47txLgB7z3I6G1WOjmqnsp6WFg3Szv6nuy5x5k9OZKK8fhHY/yzbf1pn80/COx/lm2/rTP5qsoqqkrqaOoo5YpoJM7HsIIODgr7FUUs0s0cUkT3wuDJGgglhIBAPuIPvQUX4R2P8s239aZ/NPwjsf5Ztv60z+auX2eCfM5dVFT1NLUcTgSxScN5iftIO1w6tPrQUX4R2P8s239aZ/NPwjsf5Ztv60z+auZDB1DVC6ogbUsgOeI9jpAQwluAQDl2MA8xyJyfcUFF+Edj/LNt/WmfzT8I7H+Wbb+tM/mrnhn+FfPs8A+ZgoLb+Edj/LNt/WmfzQajshOBeLbn/vTP5q5/Z/4fFQOqKTytlI6SHyiSN0jYiRucwEAkDwBI+KCeKRksbZIntexwyHNOQR7V6VorLeygjlrbTC2KdgL3wx+aycdSCOm49zuufVkK508zKiCOaJ26ORoe0+IIyEEiIiAiIgIiICIiAiIgIiIPmVxb9Ja0VNu7U6+qmY4U9wZHPC/ucAwNI9oLf2eK7PLsLGtdaPs2tbT5BfKfiNaS6KVh2yRO8Wn+HQoOErHdX2mpqJo42yGWmlpyHdAHsLSfdlZe7tLqJawTVFsgljLTujdM/73FjlG05y1gdE3DByALvFbTqvozQOmcaXVMkcWfNbJQh7gPWRIM/BRf7Mv/rb/APbv/FRGnNZ6zm1RRW+nnpGwmkLyHCQnO7HIDAA6deZ9eOSvHYDZqm8dqdlNO13CopfK5ngcmNZzGfacD3rZ8H0ZohK0z6qe+PPNrKANJHqJkP7FuTQGiLLoa2OpLJCd8mDNUSndJKR0yfDwA5IL1UONPqSmlePsqmB0Adno9p3Ae8F//CvepLVHfbJVW2aR8UdQA1z2dQAQeXwU9VFFVQOhnbujd1GcEeBBHMEdQR0VuNNdohspbnTuYOhqqUyPx7Wvbn4Iq1XXQNvraindBPNSRRRtjDYwC9uHufuY85c1zi47jnLh1VDR9m9PTMH9NY5/F4hHkUXCH2bGEiPoHYjBDu4l3ccLIuHfvyja/wBQk/1k4d+/KNr/AFCT/WQYzUdmkU9HdIH3Nx8vmjndmnaGtewvw7a0gEkP59x2jl3L1U9mlLJG9kVa2IGsFY1wpWbg7bg5xgO7yMggZ6FZJw79+UbX+oSf6ycO/flG1/qEn+sgtWrdDx6irpp33GamjmiDJI2RtdkiOVgcCeY5TO5eoKnrOzqjnMYiq3RRxSSPjh4LXRDe6JxaWHkW5i6f4iVfeHfvyja/1CT/AFk4d+/KNr/UJP8AWQYjRdmRltFLS3C5zxbY9sscAHN/DliDg7kR5snTpyVYzsxtn1fR0k075m0xJZxGBwBMzJTjJOAdm3r0cVkXDv35Rtf6hJ/rJw79+UbX+oSf6yDFj2VW/wAqfMK+qAdE+IM/utacgNAzgNAONuO7PqV4t2iKS33uguNNIwOpDUhsZgaQGTScQMaf7oaeQx3EjvVx4d+/KNr/AFCT/WTh378o2v8AUJP9ZBdblVso6GeokBIY0kNAyXHuaB3knAA9aisVK632S30bzl9PTxxE+Ja0D+CpqeikM7Z7hU+Uys5saGbI2HxDck59ZJ9WOauG9BPlMqDem9BPlMqDem9BPlMqDem9BPlMqDenEQT5TKgD19EnrQTZX3K8A5X3KCn5uOGjKGOTuHzVRG3a0BekFJwpfD5r5wpfD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpfD5r4Y5fD5qsK8nogpoo3cQB45e1Wax6kF4v12tIpWxSWw7Zn8UOBJJ2bQOZy0ZPTB5c1fzkEEdQqKG326ikNRSUUMU+HN3tZg+e7c7J78u5+1BVMcpdypYyp8oJ0REBERBDWTtpqZ8zuYaOnirLbL6aisbDMG5dyaGj5//AN4q+TwsnZskGW5zhWmj0/FS3BtS2Vxa3JazHT3r5nGRxvf26uHxoz833/Or02Zs6Koub9GO3jX7rfrR1hbQwy7ZqeInynEzhKPvNj28w3qeY5BV8naHpyOmfPJVysjG3YX0728VrnFoczI85uQRkcviFkFNbKWmuNdXRRkVNbs47i4kO2DDeXQclZG6EsbIZYmRVLWvaGNxUyfZsDi4Mbz5MySdvTp4BfTeZI7WtlFa2kbNO+pdEJGxtp3kkmMyBnT75aCQ3qvdBrC1VtlZdo3VDKF1SKUSSwuZ55eGd/8Ad3HGeipYtAWCE/0enqIAYBTkRVMjMtDCwE4PXacZ9ngFX0ulrXT6cmsQjnktkjDGYpp3vLW4xhpJy0DHLHTuQUkOubFNPBEyomPGLQJBA8sbveWMLnYw0OLTtz15HvCrLHqm03yiqqu31JfTU2eLK+NzGgAEk5I9R9igOjLJ5RSytpnsFOyGNsbJXNY4RHMe9oOHbTzGVNadK2q1mvNNC9xrmCOoM0rpC9oyA0kn/EfXzQUtv1xZa6oiggkqRLK5rWNlp3xk7o3yNPnAci1jjn2KFnaFpt7Q7y14YaYVW4wvwG8Li4zj72zztvVU9F2d2umq55HT1kkTjC6AGd++ExsczAfuyQWvIx4KspNCWKjfupYKiEcBtPtjqZGja2MRg8j97YAM+rPXmgoK/tFt0UEMtHBUVEUtHUVbZnRuZGBDtyCcE4O4cwCOniFXz67sNO6qbNUTNFOH7n8B+x5YQHhjsYcWkjICjHZ/YBT8EQThhE7X4neDIJg0SB2Dzzsb8ApptD2KeWpfLTSOE+8lhnfsYXkF5Y3OGlxAyR/EoPEevLE+ppafj1DKmomfAyF9O9rw9jgHAgjI5ub8c+Kq7zqWltN+tluqyWitOxr9j+TycMGQMcznvGOXioK7RNkrZjJUQTHdUOqXNE7w10hLSSRnHVrfh6yqi6aUtVzvUF1q4pHVkPD2ubK5o+zcXMyAcHBcfigteotYVVqq7xHT2ryqC2U4qJ5eOGYaYpHjljvcwN/9rPcpqTWcFRrFti8nLWui5VO/zTPtDzDjHXY4Oz7QrtW2C3VguoqIXO+s4WwVWHkb2AEADny5OPRUMOidPw1cdXHb421sdT5WKrJ42/n1f1LcHG3OMcsILtLdrdFI6OWvpGSNOHNdM0EH1jKt1/1B5FFbm2uGK4VVxqDT0zRMGRkhrnOc54BwAGO6AnPJXKS12+WR0ktDSPe45LnQtJJ9Zwqe6WG33KihpZoTFHBIJoXU7jE6J4z5zS3BB5n4lBZrVrejqC2mroJ4LoJpYJaaCN9RsMbg1ztzW/cy5vnEDr6iorh2hWiCmfJSceoeyaKMN4L28Rjp2wufGdvnhrndG5zy8VWt0TZWeTGKKpifCX5kZUyNfLvcHvEjs5flwBOfBRv0FYXsmaaefa8gtAqZBwcSiXEfPzBvaHcsdEAa8sJ4X9InG/O/NNJ9h9oY/teXmeeC3njmFNa9XUVbYGXeeGopKZ1UaX7aMgh3F4YJ9ROOfd7lE3Qlibwv6POdnN+ah54/2hk+15+f55LueeZKr49NW1ljrLQYpH2+rdI6SJ8jjjiElwaerRkkjHQ9EFBHrmxSzwxsqJiJS0CQQPMbdz3MYXOxhoc5p2568j0IUVRr7T9PSR1M1VI2KWGKdh4TubZXPazu6kxu+CqzoyycakkbTPYKaOGNsbZXBj2xHMe9ucO2nmMqmZoKxxwSRRx1TWPYyL+0yeaxjnOawc/ugvdy6c0GRU0zKqmiqIdxilYHtLmlpwRkZB5j3rzVDEDvd+1LZQU9st1NQ0TOHTU0bYomZJ2tAwBk81R6mrvq20SVRGWsfGHewvAPyKJM4jMpoSqjIVLAQQCCqnIRVUiIgIiIMO7RdSXLT0dv+rKWOXyhzw+SVhc1pa3LWciMFx5A8+nIE8lj1117eaKpvbTT0zIKMMNNI+CQiYukja9ue8x7yDj7xxjGCFtJQ1lLBW05gq4mTQkgljxkEggj4EA+5Bqp2qb5W11PKC90AxEH07HxxTgV9PHxQCcjLHP7zyz3KSk7RLs+smZPDShsQjkmiEEgfTNNW2J4eSeZbGS7IAHqx12uoPJKfy3yvgs8q4fC4uPO2Zztz4Z5oNc0Wu71U3u20rbfGKapmc3c6JwMjPKXx5aSeRaxrXnkc5/ujmrrfNSXui1LNT0lJDNQQzU0Wzhu4knFa8kh2cDBaO49e5ZwiDU1PrLUNebW574KeA1dMKmaOkkDW8Rsm+Bwcc7mua0Fw73Dp0NTR601KH6cZWUVIXXOGKofshe0Ye9oMYy7Ic1pLicHPLkBkraGEQa/1brO42jVtPbaOmZJTFjTKZIjnzmvO5rt3QFoB83HPrlWCm7SLvLQ0UsjrdGyofCHVZpZeHEXwySOjLd2XOYWNyQceeOi27IxskbmSNDmOBa4HvB7lTC20Qjo2Cli2UeDTjbyiw0tG3w80kexBruHWepZqKatlo6WipmmkjdxaeR5hMsbHvkdhwJa3JGOR5jJGCqii1nd6msoIKqCGiE8IcN1NK51UTI9mY8fcG1rX+cDgPGcdVsdEGn6LWmprbp+hZWQxVEz6ekeat8DvsxJHITxAXjcd0bRnLeb+njnj9QTSaSrK6mjiF1pqVsktO9ry2OUxh+04GSOY6LJF4ZFHG6R0bGtdIdzyBguOAMnxOAB7kGqZu0e7sobXIyia6aWVzZg6mIY9olazzHCQjo4nI3dO4AqebWupIaaeZ9LRYdE+SLML28PbU8IhxLsElvnDO0DvOOa2lhEGB3PV9bBpDT90aIKWa4VDIZn1NO8tiBY8l2wOzjLAeuMd/esei1ZqGouFvqnNdRwyy0nGhMT3NeHwznaMnzQ5zGDxy5uemDteopYKl0JqImSGF/FjLhnY7BG4evBI96mQapZqnUF0htE9HUUzagyvdMxtJMI4/6NI8xSAkbi1wAyCOeMjuVz1hqq602l7TUUkTKWW40UkskroXycKTghzY2hvMOcSQCem3oVsNEGvNHaqvNdqKK1VtIG07IG7nvYRIfsWO4pOeYc5xGNo9p5hRXbWWoaKa8xNtjMWyRsb5zE4seJZWiN7fOGQ2Iku59e8BbIRBrKLWOpJ5KZzaSkjhIpOIDA9xfxpnxlzTuwAA0Pxz69e9UWmNbagfVWSgrIo6p0zW+UTOgcxzyZHteB53IsDQTyOc/3eRW2kwgho6iKspIammdvgmYJGOwRlpGQcHmFj3aSP/I6u9sf/O1ZOsa7RsHSNaD3mP8A52rneuRat1XJ6RkmibnyR1VdAfsI/wA0fsVcrfQ/1Mf5oVwHRbjnA9UtUxzQ17g145c+9VBewHm5vxVknb1XHfbEP+tG/fpGfu2Kjt/iM9NvxTiM9NvxX56sypD3ImX6DcRnpt+KcRnpt+K/PxqmZla0pqd+8Rnpt+KcRnpt+K4CcPtPcvbev8VzmrE4daaMxl31xGem34pxGek34rgRnMuCqLY3zpfclM5nCVU6Yy7z4jPSb8U4jPSb8Vw80HKmaDhddDlrdub2+kPim9vpD4rjSkB4QVWwLEtRLsDe30h8U3t9IfFciZDGFzjgDmV9ZUMz92b/AOE7+SGXXW9vpD4pub6Q+K5JdM2RmxjJS5xA5xuA6+JCuDW5whl1Nub6Q+Kbm+kPiuYWNUzGlDLpjc30h8U3N8R8VzcxpU7GoZdFbm+I+Kbm+I+K58YxTsYhlvzcPEJuHiFolrVOxiGW78jxC+rTEG6N7XsJa5pyCOoKzm36sAtrvK2F1WwYbgcn+v1etFZZJIyNpdI5rWjqScLX/aRdo6q3spaV26MSgvcOjjg8gqGpqJq2pdPUOLnu+A9QVu1A3FA39IP2FeHtL6W56OtjxKWxaH+pj/NCrweXeqGhH2Mf5oVeOi9tO0OUqSZvJccdsgx2pX79Iz92xdlzDquNu2f8ad//AEjP3bEkYixSkcgoWdVOArDMvTBzUzQom4HM8kdVRsIAO4+pdIZSy7RsyQCTgetfQwnvVBVSudslwPs3ZA9XRV8LxJGHN5ZXG7GJeizPJ5awtfnccK4W9oEO4dXEkq0yyEy7ARlSUta6mdsAD2eHeCtWqJn5mL1f7WQMCnYFbaS5QTcidhzgZ71dYgHY2kHPeF2xh51dTACNvMKqZjxCoG08RPOJhJ/whTNp4f8Aso/+ELlMOmcKmrx5M/mO79oVewK3R08QcC2KMEd4aFVsCYNStYAp2AKhYFOxMGpXMaFOxoVCwKdgV0pqV7AFMxoVAwKdgTSa1cNrWlziAAMkq0ae1Tbb1cqyipJCZKd+G5BG9uBkjl45HuVwYF8pKKnppqiWCMMkqHh8hH94gAfsCaTWu7Gj1KdgHiFb2BQ3SvhtduqK2qdthgYXu/l7T0TBqXC5XKitVI6puNTFTwN6ukdj3DxPqWJT9rWmIJtjJKuYA43xw+b8yD8lo3VGoa3UVxfVVsh4YJ4UIPmxt8B/PvVoYySQOLI3ODRk4GcLLbrDTOs7DqB4jttfG6fGeDICx/wPX3ZV31Dg0Dfzx+wrjmCaSGZksL3RysIc1zTgtI7wVvzs61g/UlhdS17wblSObud3ysOcO9vcf/2vD2n9Jc9HWx4lLo6iH2Mf5oVaqOi5wx/mhVi9tO0Oco5Vxp2z/jTv/wCkZ+7Yuy5Vxp2z/jTv/wCkZ+7YgxBg5qdoULOqnaqy8VUbnNBbzA6hUwaOo9nuVzYo5aUO5x8j4LpTVhmYUmBkBwy3oVPSv4Ue0jIHTkvD43sOHNI/ivUZPDPPuwfWtTTFS01zTs8Y3Svec5IwAF9ZGN3TqvYHw7yqmmpZJiC1hwTknoAtxiGJ5qaKLLG4ByTyWUWaldTwZkJ3O57fBRUFAyna0vw+QDr3D2K6R9FiuvPKCITMHNTNChZ1U7VzWUzAp2BQMU7EROwKeMKGNTx9VRM0KZg5qJqmb1QTMCnYFCxTM6IidgUzQoY1O3qgmaFr/tnuUcGmmUTZQJ6iZuWd5YMkn4gLYLVj+vLIb7pqqpY2g1AHEhJ9NvMD38x70lY3c4QsEs8UbnBjXODS49Bk9VsTtRxorXJtOmY/q+O2NiMdTH/XTudGHF7n9SDuI2/d9S11LG6N7mSNLXtJBaRgg+CvjNTVU7qP67iZdo6NobBHU9zR0a57cPLR6O7Cw6sk7ZbfSQXHT90paeKlmvFpgr6mCJoaxsrgQ4taOgOM48cq39k80kWsYGMJ2yxva/2AZ/aArDqS+1+pLvLcrrIH1DwGgNaGtY0DDWtaOQAHcs97G7FKX1F7mYWwtHAhJH3ifvEezGPeV4+0JxwtzPlLrZ8Sn1deW/8As8fsCrVRW/8As8fsCrV66doc5RyrjTtn/Gnf/wBIz92xdlyrjTtn/Gnf/wBIz92xBiLOqnaoGdVO1VlOzuU7FAzuU7FUTM5jmvYhjPWNvwXiNTs7kR7ihjb92No9yqmKBinYqJ2KePooGqePogmZ1U7VAzqp2okpmKdigYvFZI6NjCxxBJRmZxGVyjU8fVYxfNSQWJlIJ4Zp5JwdoZgdOuSfavlHrW3SVEsdQyemEUDZ3vlZyAO3lgc8+cFctMvapm9VjQ1dZAHE1zcNYZCdjvug4z08V7drGyMkkjZWtkmZGZOG1py7Dd2AcYzjuTKYZSxTM6LEbfriy1FBFUzTupuJG6XhyMJIaHFpPLI6hVsesrAXyM+sYw6Nu9+WuAAxnPTwTJiWURqdvVYkzXWm+CyX6zjLXuc1vmOzkAEjGM94U101fS2vUFHQVLAymnpX1Tqpz8BjWgn7uOfRDDLmr3tyrJp/Ulpvz52WmsbUugDTJtaRt3Zx1HqKvzeiIwHW3Z3S32V9ZRPFJXu5uOPMkP8AiHcfWFrufsy1LHLsjpoZm5++yZoHzwV0OG5XtsYUw1FUw0xpjsjqJKhkuoKhjIRgmCA5c71F3d7srbstFBQWmGmpImxQRENYxowAMFXKNmFDdxijb+cP4rw9pxjhLno68PObtLZtEMQR/mhVapaT+pj/ADQqpeunaCUcq407Z/xp3/8ASM/dsREGGykiF5BwcL5bXOdv3OJ6dSiKsrmxTsRFUTRqdiIhKdqscdRN9chnFk2cbG3ccYyiIi6alcW2SctJB83mD/iCudqJNupSTkmNv7ERBXs6qdqIqkpmKKv/AKtntREliv8ASw7tKceFRMydhgkO3uyMc1iEjnCKoAcQHW6MEZ682IijpTtC89oZLa6k2kjNqjBx3+cqKzTysur4WSyNhcZC5gcQ0/ZHqEROqxstUsj/AKtpBvdgUkjRz7uIeXsWVUAB0hrTIBwyk/giISpdIyPk1Pp9sj3Pa2vIAcc481qyftk/3ki/yub9pRE6HVU9gMj5bjqF8r3PeW0+XOOSeT1ulvREWo2Yq3TsU0aIjKdiprx/ZG/nD+KIvD2p9Jc9HfhvFpbNpP6mP80KqRF6qdoV/9k=",
+          "timestamp": 6600967371,
+          "timing": 5980
+        }
+      },
+      "speed-index": {
+        "id": "speed-index",
+        "title": "Speed Index",
+        "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).",
+        "score": 0.26,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "7.6 s",
+        "numericValue": 7589.0857012338229,
+        "numericUnit": "millisecond"
+      },
+      "inp-breakdown-insight": {
+        "id": "inp-breakdown-insight",
+        "title": "INP breakdown",
+        "description": "Start investigating [how to improve INP](https://developer.chrome.com/docs/performance/insights/inp-breakdown) by looking at the longest subpart.",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "mainthread-work-breakdown": {
+        "id": "mainthread-work-breakdown",
+        "title": "Minimize main-thread work",
+        "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to minimize main-thread work](https://developer.chrome.com/docs/lighthouse/performance/mainthread-work-breakdown/)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "3.0 s",
+        "metricSavings": {
+          "TBT": 650
+        },
+        "details": {
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "groupLabel",
+              "label": "Category"
+            },
+            {
+              "granularity": 1,
+              "key": "duration",
+              "valueType": "ms",
+              "label": "Time Spent"
+            }
+          ],
+          "type": "table",
+          "sortedBy": [
+            "duration"
+          ],
+          "items": [
+            {
+              "group": "scriptEvaluation",
+              "groupLabel": "Script Evaluation",
+              "duration": 1373.673599999993
+            },
+            {
+              "group": "styleLayout",
+              "groupLabel": "Style & Layout",
+              "duration": 512.58119999999985
+            },
+            {
+              "duration": 483.3984,
+              "groupLabel": "Script Parsing & Compilation",
+              "group": "scriptParseCompile"
+            },
+            {
+              "group": "other",
+              "duration": 388.30799999999704,
+              "groupLabel": "Other"
+            },
+            {
+              "group": "garbageCollection",
+              "groupLabel": "Garbage Collection",
+              "duration": 125.16959999999993
+            },
+            {
+              "group": "parseHTML",
+              "duration": 85.783199999999979,
+              "groupLabel": "Parse HTML & CSS"
+            },
+            {
+              "group": "paintCompositeRender",
+              "duration": 77.974799999999931,
+              "groupLabel": "Rendering"
+            }
+          ]
+        },
+        "numericValue": 3046.8887999999893,
+        "numericUnit": "millisecond"
+      },
+      "network-rtt": {
+        "id": "network-rtt",
+        "title": "Network Round Trip Times",
+        "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "sortedBy": [
+            "rtt"
+          ],
+          "items": [
+            {
+              "rtt": 7.8534449999999989,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "rtt": 7.7142149999999985,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "rtt": 4.345695,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "origin": "https://js-eu1.hs-scripts.com",
+              "rtt": 2.0808
+            },
+            {
+              "origin": "https://useago.github.io",
+              "rtt": 2.051685
+            },
+            {
+              "origin": "https://www.google-analytics.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "origin": "https://forms-eu1.hsforms.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "origin": "https://fonts.googleapis.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "origin": "https://js-eu1.hs-banner.com",
+              "rtt": 0.0032435293073781193
+            },
+            {
+              "origin": "https://js-eu1.hubspot.com",
+              "rtt": 0.003132302594858295
+            },
+            {
+              "rtt": 0.0018671013606385285,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "rtt": 0.0015569661687088608,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.0013041150597027124,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com",
+              "rtt": 0.0011790031842973392
+            },
+            {
+              "rtt": 0.00095543022358362119,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "origin": "https://js-eu1.hsforms.net",
+              "rtt": 0.00093850321214365945
+            },
+            {
+              "origin": "https://images.unsplash.com",
+              "rtt": 0.00086458827217879308
+            },
+            {
+              "origin": "https://www.ocobo.co",
+              "rtt": 0.00084676039738510887
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "text",
+              "key": "origin"
+            },
+            {
+              "label": "Time Spent",
+              "key": "rtt",
+              "valueType": "ms",
+              "granularity": 1
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 7.8534449999999989,
+        "numericUnit": "millisecond"
+      },
+      "metrics": {
+        "id": "metrics",
+        "title": "Metrics",
+        "description": "Collects all available metrics.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "cumulativeLayoutShift": 0.00213,
+              "observedFirstVisualChangeTs": 6595322850,
+              "observedSpeedIndex": 3577,
+              "cumulativeLayoutShiftMainFrame": 0.00213,
+              "observedFirstContentfulPaintAllFramesTs": 6598285372,
+              "observedLargestContentfulPaintTs": 6598285372,
+              "lcpLoadDuration": 5945,
+              "lcpLoadDelay": 5453,
+              "observedSpeedIndexTs": 6598565050,
+              "totalBlockingTime": 655,
+              "observedFirstContentfulPaintAllFrames": 3298,
+              "observedTraceEnd": 7900,
+              "interactive": 13749,
+              "observedCumulativeLayoutShift": 0.00213,
+              "observedLoad": 5225,
+              "largestContentfulPaint": 6451,
+              "observedFirstPaint": 3298,
+              "observedLargestContentfulPaintAllFramesTs": 6598285372,
+              "observedLastVisualChange": 5979,
+              "observedLoadTs": 6600212756,
+              "observedCumulativeLayoutShiftMainFrame": 0.00213,
+              "maxPotentialFID": 277,
+              "observedFirstContentfulPaint": 3298,
+              "observedLargestContentfulPaintAllFrames": 3298,
+              "firstContentfulPaint": 3901,
+              "observedFirstPaintTs": 6598285372,
+              "observedDomContentLoaded": 3608,
+              "timeToFirstByte": 601,
+              "observedDomContentLoadedTs": 6598596076,
+              "observedNavigationStartTs": 6594987850,
+              "observedLargestContentfulPaint": 3298,
+              "observedFirstVisualChange": 335,
+              "observedTimeOrigin": 0,
+              "speedIndex": 7589,
+              "observedTraceEndTs": 6602887597,
+              "observedTimeOriginTs": 6594987850,
+              "observedLastVisualChangeTs": 6600966850,
+              "observedNavigationStart": 0,
+              "observedFirstContentfulPaintTs": 6598285372
+            },
+            {
+              "lcpInvalidated": false
+            }
+          ]
+        },
+        "numericValue": 13749,
+        "numericUnit": "millisecond"
+      },
+      "script-treemap-data": {
+        "id": "script-treemap-data",
+        "title": "Script Treemap Data",
+        "description": "Used for treemap app",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "nodes": [
+            {
+              "children": [
+                {
+                  "resourceBytes": 298,
+                  "name": "(inline) window.dataLaye…",
+                  "unusedBytes": 0
+                },
+                {
+                  "name": "(inline) window.AGO = {\n…",
+                  "resourceBytes": 631,
+                  "unusedBytes": 0
+                },
+                {
+                  "resourceBytes": 592,
+                  "name": "(inline) ((storageKey2, …",
+                  "unusedBytes": 0
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 520,
+                  "name": "(inline) window.__reactR…"
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "resourceBytes": 1619794,
+                  "unusedBytes": 0
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "resourceBytes": 53,
+                  "unusedBytes": 0
+                },
+                {
+                  "name": "(inline) ;\nimport * as r…",
+                  "resourceBytes": 6359,
+                  "unusedBytes": 0
+                }
+              ],
+              "encodedBytes": 305808,
+              "resourceBytes": 1628247,
+              "name": "https://www.ocobo.co/blog"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "encodedBytes": 3933,
+              "resourceBytes": 9792,
+              "unusedBytes": 749
+            },
+            {
+              "unusedBytes": 71258,
+              "name": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "encodedBytes": 43324,
+              "resourceBytes": 125385
+            },
+            {
+              "encodedBytes": 878,
+              "resourceBytes": 927,
+              "name": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 1084,
+              "name": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "encodedBytes": 1575,
+              "resourceBytes": 3192
+            },
+            {
+              "encodedBytes": 942,
+              "resourceBytes": 983,
+              "name": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "unusedBytes": 89
+            },
+            {
+              "name": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "encodedBytes": 82,
+              "resourceBytes": 141,
+              "unusedBytes": 6
+            },
+            {
+              "name": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "encodedBytes": 672,
+              "resourceBytes": 1284,
+              "unusedBytes": 467
+            },
+            {
+              "unusedBytes": 809,
+              "encodedBytes": 6245,
+              "resourceBytes": 15426,
+              "name": "https://www.ocobo.co/assets/cx-DiffRdtV.js"
+            },
+            {
+              "unusedBytes": 370,
+              "encodedBytes": 5628,
+              "resourceBytes": 17234,
+              "name": "https://www.ocobo.co/assets/factory-hx59odkt.js"
+            },
+            {
+              "encodedBytes": 1254,
+              "resourceBytes": 3070,
+              "name": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "unusedBytes": 519
+            },
+            {
+              "name": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "encodedBytes": 380,
+              "resourceBytes": 428,
+              "unusedBytes": 239
+            },
+            {
+              "encodedBytes": 347,
+              "resourceBytes": 410,
+              "name": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 65,
+              "name": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "encodedBytes": 450,
+              "resourceBytes": 525
+            },
+            {
+              "unusedBytes": 362,
+              "name": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "encodedBytes": 878,
+              "resourceBytes": 942
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 301,
+              "resourceBytes": 349,
+              "name": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js"
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "resourceBytes": 1866,
+              "encodedBytes": 777
+            },
+            {
+              "encodedBytes": 289,
+              "resourceBytes": 348,
+              "name": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 20672,
+              "resourceBytes": 67398,
+              "name": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "unusedBytes": 32058
+            },
+            {
+              "name": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "encodedBytes": 91,
+              "resourceBytes": 165,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 132,
+              "resourceBytes": 206,
+              "name": "https://www.ocobo.co/assets/lang-PH2TSE5M.js"
+            },
+            {
+              "encodedBytes": 33589,
+              "resourceBytes": 109016,
+              "name": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 605,
+              "encodedBytes": 541,
+              "name": "https://www.ocobo.co/assets/layers-CQ3InJLS.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "encodedBytes": 751,
+              "resourceBytes": 826,
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 330,
+              "resourceBytes": 404,
+              "name": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "encodedBytes": 426,
+              "resourceBytes": 490
+            },
+            {
+              "encodedBytes": 760,
+              "resourceBytes": 835,
+              "name": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "unusedBytes": 337
+            },
+            {
+              "encodedBytes": 25820,
+              "resourceBytes": 68826,
+              "name": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "unusedBytes": 47522
+            },
+            {
+              "encodedBytes": 44679,
+              "resourceBytes": 133936,
+              "name": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "unusedBytes": 31846
+            },
+            {
+              "resourceBytes": 473,
+              "encodedBytes": 410,
+              "name": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 290,
+              "resourceBytes": 338,
+              "name": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 361,
+              "resourceBytes": 435,
+              "name": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js"
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "resourceBytes": 312,
+              "encodedBytes": 249
+            },
+            {
+              "unusedBytes": 194,
+              "name": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "resourceBytes": 309,
+              "encodedBytes": 246
+            },
+            {
+              "unusedBytes": 46,
+              "name": "https://www.ocobo.co/assets/_main.blog._index-Ch2d6Qju.js",
+              "encodedBytes": 3561,
+              "resourceBytes": 9169
+            },
+            {
+              "resourceBytes": 717,
+              "encodedBytes": 642,
+              "name": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "unusedBytes": 65
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/optimized-image-BKBFj58i.js",
+              "encodedBytes": 224,
+              "resourceBytes": 272
+            },
+            {
+              "encodedBytes": 236,
+              "resourceBytes": 303,
+              "name": "https://www.ocobo.co/assets/labels-CtAnB7VF.js",
+              "unusedBytes": 0
+            },
+            {
+              "name": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js",
+              "encodedBytes": 239,
+              "resourceBytes": 302,
+              "unusedBytes": 4
+            },
+            {
+              "encodedBytes": 539,
+              "resourceBytes": 1208,
+              "name": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "unusedBytes": 4
+            },
+            {
+              "encodedBytes": 485,
+              "resourceBytes": 549,
+              "name": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "unusedBytes": 0
+            },
+            {
+              "name": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "resourceBytes": 69550,
+              "encodedBytes": 23527,
+              "unusedBytes": 28818
+            },
+            {
+              "encodedBytes": 156409,
+              "resourceBytes": 471493,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "unusedBytes": 204275
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "encodedBytes": 578,
+              "resourceBytes": 2125
+            },
+            {
+              "encodedBytes": 4215,
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "unusedBytes": 12049
+            },
+            {
+              "encodedBytes": 1242,
+              "resourceBytes": 2495,
+              "name": "https://www.ocobo.co/_vercel/insights/script.js",
+              "unusedBytes": 682
+            },
+            {
+              "unusedBytes": 6432,
+              "encodedBytes": 4673,
+              "resourceBytes": 12567,
+              "name": "https://www.ocobo.co/_vercel/speed-insights/script.js"
+            },
+            {
+              "unusedBytes": 56996,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "encodedBytes": 27531,
+              "resourceBytes": 97992
+            },
+            {
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "encodedBytes": 26369,
+              "resourceBytes": 78059,
+              "unusedBytes": 35974
+            },
+            {
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "encodedBytes": 42584,
+              "resourceBytes": 108995,
+              "unusedBytes": 46367
+            },
+            {
+              "encodedBytes": 25119,
+              "resourceBytes": 72608,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "unusedBytes": 36142
+            },
+            {
+              "unusedBytes": 335851,
+              "encodedBytes": 156409,
+              "resourceBytes": 471493,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "encodedBytes": 578,
+              "resourceBytes": 2125
+            },
+            {
+              "encodedBytes": 4215,
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "unusedBytes": 337253,
+              "encodedBytes": 202941,
+              "resourceBytes": 587832,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "resourceBytes": 587832,
+              "encodedBytes": 202941,
+              "unusedBytes": 248156
+            }
+          ],
+          "type": "treemap-data"
+        }
+      },
+      "total-byte-weight": {
+        "id": "total-byte-weight",
+        "title": "Avoid enormous network payloads",
+        "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn how to reduce payload sizes](https://developer.chrome.com/docs/lighthouse/performance/total-byte-weight/).",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Total size was 9,594 KiB",
+        "details": {
+          "sortedBy": [
+            "totalBytes"
+          ],
+          "items": [
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/corentin-guerin.jpeg",
+              "totalBytes": 2701533
+            },
+            {
+              "totalBytes": 2527840,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/aude-cadiot.jpg"
+            },
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/ethel-gosset.jpeg",
+              "totalBytes": 2246162
+            },
+            {
+              "totalBytes": 349067,
+              "url": "https://www.ocobo.co/blog"
+            },
+            {
+              "totalBytes": 204714,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "totalBytes": 202020,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png"
+            },
+            {
+              "url": "https://images.unsplash.com/photo-1566140967404-b8b3932483f5?w=1200&h=800&fit=crop",
+              "totalBytes": 179754
+            },
+            {
+              "url": "https://images.unsplash.com/photo-1612385763901-68857dd4c43c?w=1200&h=800&fit=crop",
+              "totalBytes": 159084
+            },
+            {
+              "totalBytes": 158840,
+              "url": "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=1200&h=800&fit=crop"
+            },
+            {
+              "totalBytes": 157097,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Transfer Size"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 9823861,
+        "numericUnit": "byte"
+      },
+      "non-composited-animations": {
+        "id": "non-composited-animations",
+        "title": "Avoid non-composited animations",
+        "description": "Animations which are not composited can be janky and increase CLS. [Learn how to avoid non-composited animations](https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/)",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "failureReason"
+              },
+              "label": "Element"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "forced-reflow-insight": {
+        "id": "forced-reflow-insight",
+        "title": "Forced reflow",
+        "description": "A forced reflow occurs when JavaScript queries geometric properties (such as offsetWidth) after styles have been invalidated by a change to the DOM state. This can result in poor performance. Learn more about [forced reflows](https://developer.chrome.com/docs/performance/insights/forced-reflow) and possible mitigations.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "details": {
+          "items": [
+            {
+              "headings": [
+                {
+                  "valueType": "source-location",
+                  "key": "source",
+                  "label": "Source"
+                },
+                {
+                  "label": "Total reflow time",
+                  "granularity": 1,
+                  "valueType": "ms",
+                  "key": "reflowTime"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "reflowTime": 2.394,
+                  "source": {
+                    "column": 85503,
+                    "urlProvider": "network",
+                    "type": "source-location",
+                    "line": 19,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+                  }
+                }
+              ]
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "duplicated-javascript-insight": {
+        "id": "duplicated-javascript-insight",
+        "title": "Duplicated JavaScript",
+        "description": "Remove large, [duplicate JavaScript modules](https://developer.chrome.com/docs/performance/insights/duplicated-javascript) from bundles to reduce unnecessary bytes consumed by network activity.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "label": "Source",
+              "valueType": "code",
+              "key": "source"
+            },
+            {
+              "label": "Duplicated bytes",
+              "key": "wastedBytes",
+              "granularity": 10,
+              "subItemsHeading": {
+                "key": "sourceTransferBytes"
+              },
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 0,
+            "type": "debugdata"
+          },
+          "items": []
+        }
+      },
+      "network-dependency-tree-insight": {
+        "id": "network-dependency-tree-insight",
+        "title": "Network dependency tree",
+        "description": "[Avoid chaining critical requests](https://developer.chrome.com/docs/performance/insights/network-dependency-tree) by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "type": "list-section",
+              "value": {
+                "chains": {
+                  "105D905F313F66AB9FA0331ECA6A657B": {
+                    "navStartToEndTime": 2844,
+                    "isLongest": true,
+                    "transferSize": 349067,
+                    "url": "https://www.ocobo.co/blog",
+                    "children": {
+                      "54.2": {
+                        "children": {
+                          "54.120": {
+                            "transferSize": 31974,
+                            "children": {},
+                            "navStartToEndTime": 3391,
+                            "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff"
+                          },
+                          "54.123": {
+                            "children": {},
+                            "navStartToEndTime": 3357,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                            "transferSize": 38778
+                          },
+                          "54.125": {
+                            "isLongest": true,
+                            "transferSize": 39126,
+                            "navStartToEndTime": 3433,
+                            "children": {},
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf"
+                          }
+                        },
+                        "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                        "navStartToEndTime": 3139,
+                        "isLongest": true,
+                        "transferSize": 24569
+                      }
+                    }
+                  }
+                },
+                "type": "network-tree",
+                "longestChain": {
+                  "duration": 3433
+                }
+              }
+            },
+            {
+              "description": "[preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints help the browser establish a connection earlier in the page load, saving time when the first request for that origin is made. The following are the origins that the page preconnected to.",
+              "title": "Preconnected origins",
+              "type": "list-section",
+              "value": {
+                "headings": [
+                  {
+                    "valueType": "text",
+                    "key": "origin",
+                    "subItemsHeading": {
+                      "key": "warning"
+                    },
+                    "label": "Origin"
+                  },
+                  {
+                    "label": "Source",
+                    "valueType": "node",
+                    "key": "source"
+                  }
+                ],
+                "type": "table",
+                "items": [
+                  {
+                    "subItems": {
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ],
+                      "type": "subitems"
+                    },
+                    "source": {
+                      "selector": "head \u003e link",
+                      "boundingRect": {
+                        "width": 0,
+                        "bottom": 0,
+                        "height": 0,
+                        "left": 0,
+                        "right": 0,
+                        "top": 0
+                      },
+                      "path": "1,HTML,0,HEAD,3,LINK",
+                      "lhId": "page-7-LINK",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "nodeLabel": "head \u003e link",
+                      "type": "node"
+                    },
+                    "origin": "https://raw.githubusercontent.com/"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "list-section",
+              "value": {
+                "type": "text",
+                "value": "No additional origins are good candidates for preconnecting"
+              },
+              "description": "Add [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints to your most important origins, but try to use no more than 4.",
+              "title": "Preconnect candidates"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "cls-culprits-insight": {
+        "id": "cls-culprits-insight",
+        "title": "Layout shift culprits",
+        "description": "Layout shifts occur when elements move absent any user interaction. [Investigate the causes of layout shifts](https://developer.chrome.com/docs/performance/insights/cls-culprit), such as elements being added, removed, or their fonts changing as the page loads.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "items": [
+                {
+                  "node": {
+                    "type": "text",
+                    "value": "Total"
+                  },
+                  "score": 0.00213
+                },
+                {
+                  "node": {
+                    "type": "node",
+                    "nodeLabel": "Explorez la science du revenu.",
+                    "snippet": "\u003ch1 class=\"ff_display fs_5xl fw_bold c_ocobo.dark mb_6\"\u003e",
+                    "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,1,H1",
+                    "lhId": "page-6-H1",
+                    "boundingRect": {
+                      "width": 380,
+                      "height": 187,
+                      "bottom": 437,
+                      "left": 16,
+                      "right": 396,
+                      "top": 250
+                    },
+                    "selector": "section.pt_32 \u003e div.pb_12 \u003e div.max-w_2xl \u003e h1.ff_display"
+                  },
+                  "subItems": {
+                    "type": "subitems",
+                    "items": [
+                      {
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      }
+                    ]
+                  },
+                  "score": 0.001897
+                },
+                {
+                  "node": {
+                    "type": "node",
+                    "nodeLabel": "Articles, interviews et masterclasses pour structurer votre croissance.",
+                    "snippet": "\u003cp class=\"fs_xl c_gray.600 fw_medium\"\u003e",
+                    "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,2,P",
+                    "lhId": "page-5-P",
+                    "boundingRect": {
+                      "height": 52,
+                      "bottom": 513,
+                      "left": 16,
+                      "top": 461,
+                      "right": 396,
+                      "width": 380
+                    },
+                    "selector": "section.pt_32 \u003e div.pb_12 \u003e div.max-w_2xl \u003e p.fs_xl"
+                  },
+                  "score": 0.000233,
+                  "subItems": {
+                    "items": [
+                      {
+                        "extra": {
+                          "type": "url",
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf"
+                        },
+                        "cause": "Web font"
+                      }
+                    ],
+                    "type": "subitems"
+                  }
+                }
+              ],
+              "type": "table",
+              "headings": [
+                {
+                  "key": "node",
+                  "valueType": "node",
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  }
+                },
+                {
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  },
+                  "valueType": "numeric",
+                  "label": "Layout shift score",
+                  "granularity": 0.001,
+                  "key": "score"
+                }
+              ]
+            },
+            {
+              "headings": [
+                {
+                  "valueType": "node",
+                  "key": "node",
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  }
+                },
+                {
+                  "valueType": "numeric",
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  },
+                  "granularity": 0.001,
+                  "key": "score",
+                  "label": "Layout shift score"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "node": {
+                    "type": "text",
+                    "value": "Total"
+                  },
+                  "score": 0
+                },
+                {
+                  "score": 0,
+                  "subItems": {
+                    "type": "subitems",
+                    "items": [
+                      {
+                        "extra": {
+                          "type": "url",
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "type": "url",
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                        }
+                      }
+                    ]
+                  },
+                  "node": {
+                    "selector": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "snippet": "\u003cinput type=\"submit\" class=\"hs-button primary large\" value=\"S'inscrire\"\u003e",
+                    "path": "0,HTML,1,BODY,1,DIV,0,FORM,1,DIV,1,DIV,0,INPUT",
+                    "lhId": "page-0-INPUT",
+                    "boundingRect": {
+                      "height": 38,
+                      "bottom": 117,
+                      "left": 270,
+                      "right": 380,
+                      "top": 79,
+                      "width": 110
+                    },
+                    "type": "node",
+                    "nodeLabel": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "resource-summary": {
+        "id": "resource-summary",
+        "title": "Resources Summary",
+        "description": "Aggregates all network requests and groups them by type",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "requestCount": 89,
+              "label": "Total",
+              "resourceType": "total",
+              "transferSize": 9823861
+            },
+            {
+              "resourceType": "image",
+              "requestCount": 18,
+              "label": "Image",
+              "transferSize": 8462709
+            },
+            {
+              "transferSize": 758023,
+              "label": "Script",
+              "resourceType": "script",
+              "requestCount": 54
+            },
+            {
+              "requestCount": 1,
+              "label": "Document",
+              "resourceType": "document",
+              "transferSize": 349067
+            },
+            {
+              "requestCount": 5,
+              "label": "Font",
+              "resourceType": "font",
+              "transferSize": 212550
+            },
+            {
+              "transferSize": 27828,
+              "requestCount": 3,
+              "label": "Stylesheet",
+              "resourceType": "stylesheet"
+            },
+            {
+              "transferSize": 13684,
+              "requestCount": 8,
+              "label": "Other",
+              "resourceType": "other"
+            },
+            {
+              "label": "Media",
+              "resourceType": "media",
+              "requestCount": 0,
+              "transferSize": 0
+            },
+            {
+              "requestCount": 35,
+              "label": "Third-party",
+              "resourceType": "third-party",
+              "transferSize": 9017436
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "label",
+              "label": "Resource Type"
+            },
+            {
+              "valueType": "numeric",
+              "key": "requestCount",
+              "label": "Requests"
+            },
+            {
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "key": "transferSize"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "first-contentful-paint": {
+        "id": "first-contentful-paint",
+        "title": "First Contentful Paint",
+        "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).",
+        "score": 0.25,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.9 s",
+        "numericValue": 3901,
+        "numericUnit": "millisecond"
+      },
+      "long-tasks": {
+        "id": "long-tasks",
+        "title": "Avoid long main-thread tasks",
+        "description": "Lists the longest tasks on the main thread, useful for identifying worst contributors to input delay. [Learn how to avoid long main-thread tasks](https://web.dev/articles/optimize-long-tasks)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "12 long tasks found",
+        "metricSavings": {
+          "TBT": 650
+        },
+        "details": {
+          "items": [
+            {
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "startTime": 7500.9999999999982,
+              "duration": 277
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "startTime": 16000.200212003247,
+              "duration": 185
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "startTime": 9900.9999999999964,
+              "duration": 145
+            },
+            {
+              "startTime": 7910.9999999999982,
+              "duration": 122,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "startTime": 8527.0040207835682,
+              "duration": 111.99999999999818
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "duration": 102,
+              "startTime": 8352.0040207835682
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "startTime": 5882.2551648332565,
+              "duration": 100
+            },
+            {
+              "url": "https://www.ocobo.co/blog",
+              "startTime": 2762,
+              "duration": 98
+            },
+            {
+              "startTime": 8454.0040207835682,
+              "duration": 73,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "startTime": 2401,
+              "duration": 59,
+              "url": "Unattributable"
+            },
+            {
+              "startTime": 2520,
+              "duration": 59,
+              "url": "https://www.ocobo.co/blog"
+            },
+            {
+              "startTime": 5784.2551648332565,
+              "duration": 57,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "startTime",
+              "label": "Start Time"
+            },
+            {
+              "label": "Duration",
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "duration"
+            }
+          ],
+          "debugData": {
+            "urls": [
+              "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "https://www.ocobo.co/blog",
+              "Unattributable"
+            ],
+            "type": "debugdata",
+            "tasks": [
+              {
+                "duration": 277,
+                "startTime": 7501,
+                "other": 277,
+                "urlIndex": 0
+              },
+              {
+                "scriptEvaluation": 0,
+                "urlIndex": 1,
+                "other": 185,
+                "duration": 185,
+                "startTime": 16000.2
+              },
+              {
+                "other": 145,
+                "urlIndex": 1,
+                "duration": 145,
+                "startTime": 9901,
+                "scriptEvaluation": 0
+              },
+              {
+                "scriptEvaluation": 0,
+                "other": 122,
+                "urlIndex": 2,
+                "duration": 122,
+                "startTime": 7911
+              },
+              {
+                "scriptEvaluation": 0,
+                "duration": 112,
+                "startTime": 8527,
+                "urlIndex": 3,
+                "other": 112
+              },
+              {
+                "scriptEvaluation": 0,
+                "duration": 102,
+                "startTime": 8352,
+                "other": 102,
+                "urlIndex": 3
+              },
+              {
+                "other": 100,
+                "urlIndex": 2,
+                "duration": 100,
+                "startTime": 5882.3
+              },
+              {
+                "urlIndex": 4,
+                "parseHTML": 0,
+                "other": 98,
+                "duration": 98,
+                "startTime": 2762
+              },
+              {
+                "scriptEvaluation": 0,
+                "duration": 73,
+                "startTime": 8454,
+                "urlIndex": 3,
+                "other": 73
+              },
+              {
+                "duration": 59,
+                "startTime": 2401,
+                "other": 59,
+                "urlIndex": 5,
+                "scriptEvaluation": 0
+              },
+              {
+                "scriptEvaluation": 0,
+                "paintCompositeRender": 0,
+                "other": 59,
+                "urlIndex": 4,
+                "duration": 59,
+                "startTime": 2520,
+                "styleLayout": 0
+              },
+              {
+                "other": 57,
+                "urlIndex": 2,
+                "duration": 57,
+                "startTime": 5784.3
+              }
+            ]
+          },
+          "sortedBy": [
+            "duration"
+          ],
+          "skipSumming": [
+            "startTime"
+          ],
+          "type": "table"
+        }
+      },
+      "total-blocking-time": {
+        "id": "total-blocking-time",
+        "title": "Total Blocking Time",
+        "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).",
+        "score": 0.45,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "660 ms",
+        "numericValue": 655.49999999999818,
+        "numericUnit": "millisecond"
+      },
+      "unsized-images": {
+        "id": "unsized-images",
+        "title": "Image elements have explicit `width` and `height`",
+        "description": "Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            }
+          ],
+          "type": "table",
+          "items": []
+        }
+      },
+      "network-requests": {
+        "id": "network-requests",
+        "title": "Network Requests",
+        "description": "Lists the network requests that were made during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "debugData": {
+            "networkStartTimeTs": 6594988080,
+            "type": "debugdata",
+            "initiators": [
+              {
+                "lineNumber": 0,
+                "type": "parser",
+                "columnNumber": 1354,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "columnNumber": 668,
+                "lineNumber": 21,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "lineNumber": 21,
+                "type": "parser",
+                "columnNumber": 16793,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 21,
+                "type": "parser",
+                "columnNumber": 30261
+              },
+              {
+                "lineNumber": 23,
+                "type": "parser",
+                "columnNumber": 1609,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "lineNumber": 23,
+                "type": "parser",
+                "columnNumber": 5225,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 50,
+                "type": "parser",
+                "columnNumber": 14492
+              },
+              {
+                "columnNumber": 13575,
+                "lineNumber": 60,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 141,
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 261,
+                "lineNumber": 75,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 360
+              },
+              {
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 460,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "columnNumber": 536,
+                "lineNumber": 75,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 602
+              },
+              {
+                "columnNumber": 671,
+                "lineNumber": 75,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "columnNumber": 731,
+                "lineNumber": 75,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 795,
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 857,
+                "lineNumber": 75,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "columnNumber": 916,
+                "type": "parser",
+                "lineNumber": 75,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 75,
+                "columnNumber": 985,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 1052
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 1119
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1176,
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1238,
+                "type": "parser",
+                "lineNumber": 75
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 1297
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1361,
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser",
+                "lineNumber": 75,
+                "columnNumber": 1427
+              },
+              {
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 1488,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 1556
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 1622
+              },
+              {
+                "type": "parser",
+                "lineNumber": 75,
+                "columnNumber": 1693,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1751,
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 1811,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 1886
+              },
+              {
+                "columnNumber": 1947,
+                "lineNumber": 75,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 2005,
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 2069
+              },
+              {
+                "columnNumber": 2129,
+                "lineNumber": 75,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 2188
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser",
+                "lineNumber": 75,
+                "columnNumber": 2250
+              },
+              {
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 2311,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 2374
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser",
+                "lineNumber": 75,
+                "columnNumber": 2430
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 2498,
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2565,
+                "type": "parser",
+                "lineNumber": 75,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "columnNumber": 2626,
+                "lineNumber": 75,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 75,
+                "columnNumber": 2698,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 75,
+                "columnNumber": 2757,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "columnNumber": 2827,
+                "lineNumber": 75,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "lineNumber": 75,
+                "type": "parser",
+                "columnNumber": 2888,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "columnNumber": 2954,
+                "lineNumber": 75,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 3018,
+                "type": "parser",
+                "lineNumber": 75
+              },
+              {
+                "columnNumber": 3081,
+                "lineNumber": 75,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "columnNumber": 14330,
+                "lineNumber": 25,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 14330,
+                "lineNumber": 25,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 25,
+                "columnNumber": 14330,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 25,
+                "type": "parser",
+                "columnNumber": 14330
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 14330,
+                "lineNumber": 25,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 257,
+                "type": "parser",
+                "columnNumber": 1619982,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "type": "parser",
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+              },
+              {
+                "type": "parser",
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+              }
+            ]
+          },
+          "items": [
+            {
+              "rendererStartTime": 0,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/blog",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Document",
+              "sessionTargetType": "page",
+              "transferSize": 349067,
+              "networkEndTime": 2742.554999999702,
+              "priority": "VeryHigh",
+              "resourceSize": 1856276,
+              "mimeType": "text/html",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2.0969999991357327
+            },
+            {
+              "networkRequestTime": 2786.80999999959,
+              "mimeType": "text/css",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 122090,
+              "transferSize": 24569,
+              "networkEndTime": 3126.4490000000224,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "resourceType": "Stylesheet",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2785.0069999992847
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "resourceSize": 12266,
+              "networkRequestTime": 2786.901999999769,
+              "resourceType": "Image",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "priority": "Medium",
+              "networkEndTime": 3093.3849999997765,
+              "transferSize": 12757,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "rendererStartTime": 2785.7680000001565,
+              "protocol": "h2"
+            },
+            {
+              "resourceType": "Image",
+              "url": "https://www.ocobo.co/images/partners/modern-revenue-club.png",
+              "statusCode": 200,
+              "finished": true,
+              "priority": "Medium",
+              "transferSize": 29545,
+              "networkEndTime": 3132.9879999998957,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "resourceSize": 29045,
+              "networkRequestTime": 2786.9699999997392,
+              "rendererStartTime": 2786.0180000001565,
+              "protocol": "h2",
+              "entity": "ocobo.co"
+            },
+            {
+              "entity": "vercel-storage.com",
+              "rendererStartTime": 2786.296999999322,
+              "protocol": "h2",
+              "resourceSize": 201358,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "networkRequestTime": 2787.1639999998733,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png",
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "Image",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "transferSize": 202020,
+              "networkEndTime": 3038.6890000002459
+            },
+            {
+              "rendererStartTime": 2786.5279999999329,
+              "protocol": "h2",
+              "entity": "vercel-storage.com",
+              "resourceType": "Image",
+              "statusCode": 200,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/ethel-gosset.jpeg",
+              "finished": true,
+              "transferSize": 2246162,
+              "networkEndTime": 3486.7330000000075,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "mimeType": "image/jpeg",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 2245492,
+              "networkRequestTime": 3144.79099999927
+            },
+            {
+              "entity": "vercel-storage.com",
+              "protocol": "h2",
+              "rendererStartTime": 2786.6979999998584,
+              "networkRequestTime": 3145.1080000000075,
+              "mimeType": "image/jpeg",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 66917,
+              "networkEndTime": 3320.5779999997467,
+              "transferSize": 67588,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "resourceType": "Image",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg"
+            },
+            {
+              "rendererStartTime": 2787.5539999995381,
+              "protocol": "h2",
+              "entity": "vercel-storage.com",
+              "resourceType": "Image",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/corentin-guerin.jpeg",
+              "finished": true,
+              "statusCode": 200,
+              "transferSize": 2701533,
+              "networkEndTime": 3434.4769999999553,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "mimeType": "image/jpeg",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 2700860,
+              "networkRequestTime": 3145.18200000003
+            },
+            {
+              "rendererStartTime": 2787.894999999553,
+              "protocol": "h2",
+              "entity": "vercel-storage.com",
+              "resourceType": "Image",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/aude-cadiot.jpg",
+              "statusCode": 200,
+              "finished": true,
+              "priority": "Low",
+              "transferSize": 2527840,
+              "networkEndTime": 3445.2089999997988,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/jpeg",
+              "resourceSize": 2527172,
+              "networkRequestTime": 3145.2910000002012
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 2788.1850000005215,
+              "entity": "Google Tag Manager",
+              "sessionTargetType": "page",
+              "transferSize": 157097,
+              "networkEndTime": 3243.4679999994114,
+              "priority": "Low",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "resourceType": "Script",
+              "networkRequestTime": 3145.4210000000894,
+              "resourceSize": 471493,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "entity": "Clearbit",
+              "rendererStartTime": 2788.2730000000447,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 0,
+              "networkRequestTime": 3145.5139999995008,
+              "resourceType": "Script",
+              "statusCode": 404,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "finished": true,
+              "networkEndTime": 3343.7059999993071,
+              "transferSize": 639,
+              "priority": "Low",
+              "sessionTargetType": "page"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 2125,
+              "networkRequestTime": 3145.5920000001788,
+              "resourceType": "Script",
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "statusCode": 200,
+              "finished": true,
+              "priority": "Low",
+              "transferSize": 1661,
+              "networkEndTime": 3191.8360000001267,
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "rendererStartTime": 2788.394999999553,
+              "protocol": "h2"
+            },
+            {
+              "rendererStartTime": 2788.4709999999031,
+              "protocol": "h2",
+              "entity": "GitHub",
+              "statusCode": 200,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "finished": true,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "transferSize": 5017,
+              "networkEndTime": 3191.2999999998137,
+              "priority": "Low",
+              "resourceSize": 17494,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 3145.69000000041
+            },
+            {
+              "resourceSize": 69556,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2789.60899999924,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "finished": true,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "transferSize": 24114,
+              "networkEndTime": 3201.6969999996945,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "rendererStartTime": 2788.5970000000671,
+              "protocol": "h2"
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 2788.7110000001267,
+              "entity": "ocobo.co",
+              "transferSize": 1454,
+              "networkEndTime": 3103.1639999998733,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "finished": true,
+              "networkRequestTime": 2789.820000000298,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 927
+            },
+            {
+              "rendererStartTime": 2788.7910000002012,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "statusCode": 200,
+              "priority": "High",
+              "transferSize": 43924,
+              "networkEndTime": 3144.046999999322,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 125397,
+              "networkRequestTime": 2790.1560000004247
+            },
+            {
+              "networkRequestTime": 2790.3240000000224,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceSize": 133936,
+              "priority": "High",
+              "transferSize": 45260,
+              "networkEndTime": 3115.7620000001043,
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "finished": true,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2788.9069999996573
+            },
+            {
+              "transferSize": 34184,
+              "networkEndTime": 3119.6650000000373,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "networkRequestTime": 2790.6469999998808,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 110060,
+              "protocol": "h2",
+              "rendererStartTime": 2789.0109999999404,
+              "entity": "ocobo.co"
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2789.0889999996871,
+              "networkRequestTime": 2790.8030000003055,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 991,
+              "networkEndTime": 3085.5829999996349,
+              "transferSize": 1514,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/context-HICI_8br.js"
+            },
+            {
+              "entity": "ocobo.co",
+              "rendererStartTime": 2789.1759999999776,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 9799,
+              "networkRequestTime": 2790.9449999993667,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "finished": true,
+              "transferSize": 4522,
+              "networkEndTime": 3116.4809999996796,
+              "priority": "High",
+              "sessionTargetType": "page"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceSize": 3192,
+              "networkRequestTime": 2791.1260000001639,
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "priority": "High",
+              "networkEndTime": 3232.8090000003576,
+              "transferSize": 2148,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "rendererStartTime": 2789.3080000001937,
+              "protocol": "h2"
+            },
+            {
+              "rendererStartTime": 2789.418000000529,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "statusCode": 200,
+              "transferSize": 669,
+              "networkEndTime": 3121.5159999998286,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 141,
+              "networkRequestTime": 2791.4629999995232
+            },
+            {
+              "resourceSize": 1284,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 2791.6459999997169,
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkEndTime": 3106.2319999998435,
+              "transferSize": 1269,
+              "entity": "ocobo.co",
+              "rendererStartTime": 2789.6140000000596,
+              "protocol": "h2"
+            },
+            {
+              "networkRequestTime": 2791.7680000001565,
+              "resourceSize": 15426,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "transferSize": 6806,
+              "networkEndTime": 3166.0140000004321,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2789.7690000003204
+            },
+            {
+              "networkRequestTime": 2791.9860000004992,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 17234,
+              "priority": "High",
+              "networkEndTime": 3120.3489999994636,
+              "transferSize": 6205,
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2789.8969999998808
+            },
+            {
+              "networkRequestTime": 2792.2900000000373,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 3070,
+              "transferSize": 1832,
+              "networkEndTime": 3137.0129999993369,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "finished": true,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2790.0300000002608
+            },
+            {
+              "entity": "ocobo.co",
+              "rendererStartTime": 2790.2180000003427,
+              "protocol": "h2",
+              "resourceSize": 428,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2792.5029999995604,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "statusCode": 200,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "networkEndTime": 3089.151999999769,
+              "transferSize": 953,
+              "priority": "High"
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkEndTime": 3108.2280000001192,
+              "transferSize": 937,
+              "resourceSize": 410,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 2792.6689999997616,
+              "rendererStartTime": 2790.3679999997839,
+              "protocol": "h2",
+              "entity": "ocobo.co"
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2790.7779999999329,
+              "networkRequestTime": 2792.80700000003,
+              "resourceSize": 525,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 3120.7750000003725,
+              "transferSize": 1047,
+              "priority": "High",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "statusCode": 200,
+              "resourceType": "Script"
+            },
+            {
+              "entity": "ocobo.co",
+              "rendererStartTime": 2790.9920000005513,
+              "protocol": "h2",
+              "resourceSize": 942,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2792.956999999471,
+              "url": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "transferSize": 1471,
+              "networkEndTime": 3149.4069999996573,
+              "priority": "High"
+            },
+            {
+              "rendererStartTime": 2791.1660000002012,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "transferSize": 876,
+              "networkEndTime": 3102.3889999995008,
+              "priority": "High",
+              "resourceSize": 349,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2793.2400000002235
+            },
+            {
+              "entity": "ocobo.co",
+              "rendererStartTime": 2791.3289999999106,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceSize": 1866,
+              "networkRequestTime": 2793.4490000000224,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "priority": "High",
+              "networkEndTime": 3091.7899999991059,
+              "transferSize": 1367,
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "ocobo.co",
+              "rendererStartTime": 2791.6560000004247,
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 348,
+              "networkRequestTime": 2793.5289999991655,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "transferSize": 867,
+              "networkEndTime": 3149.811999999918,
+              "priority": "High",
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "ocobo.co",
+              "rendererStartTime": 2791.9610000001267,
+              "protocol": "h2",
+              "resourceSize": 67398,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 2793.7130000004545,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "finished": true,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkEndTime": 3127.1650000000373,
+              "transferSize": 21252
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2792.1030000001192,
+              "networkRequestTime": 2793.9519999995828,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceSize": 165,
+              "priority": "High",
+              "transferSize": 701,
+              "networkEndTime": 3092.1109999995679,
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "finished": true,
+              "statusCode": 200
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 2792.276999999769,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "transferSize": 1127,
+              "networkEndTime": 3165.3889999995008,
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "resourceType": "Script",
+              "networkRequestTime": 2794.3749999990687,
+              "resourceSize": 605,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "entity": "ocobo.co",
+              "rendererStartTime": 2792.4519999995828,
+              "protocol": "h2",
+              "resourceSize": 826,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "networkRequestTime": 2794.4759999997914,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "statusCode": 200,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "transferSize": 1345,
+              "networkEndTime": 3114.8389999996871
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2792.6480000000447,
+              "networkRequestTime": 2794.7070000004023,
+              "resourceSize": 404,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "transferSize": 929,
+              "networkEndTime": 3101.4230000004172,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "finished": true,
+              "resourceType": "Script"
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2792.9550000000745,
+              "networkRequestTime": 2794.8129999991506,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 490,
+              "transferSize": 1011,
+              "networkEndTime": 3070.8240000000224,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "finished": true,
+              "statusCode": 200
+            },
+            {
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 206,
+              "networkRequestTime": 2795.054999999702,
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "statusCode": 200,
+              "networkEndTime": 3198.7570000002161,
+              "transferSize": 726,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "rendererStartTime": 2793.1349999997765,
+              "protocol": "h2"
+            },
+            {
+              "resourceSize": 835,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 2795.2470000004396,
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "transferSize": 1358,
+              "networkEndTime": 3086.2510000001639,
+              "entity": "ocobo.co",
+              "rendererStartTime": 2793.2779999999329,
+              "protocol": "h2"
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2793.4139999998733,
+              "networkRequestTime": 2795.3980000000447,
+              "resourceSize": 68826,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "transferSize": 26412,
+              "networkEndTime": 3151.81799999997,
+              "url": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script"
+            },
+            {
+              "entity": "ocobo.co",
+              "rendererStartTime": 2793.7039999999106,
+              "protocol": "h2",
+              "resourceSize": 473,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2795.7759999996051,
+              "url": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "networkEndTime": 3123.3810000000522,
+              "transferSize": 997,
+              "priority": "High"
+            },
+            {
+              "networkRequestTime": 2795.8849999997765,
+              "resourceSize": 338,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "transferSize": 855,
+              "networkEndTime": 3107.9249999998137,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "finished": true,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2793.8729999996722
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2794.026999999769,
+              "networkRequestTime": 2796.0609999997541,
+              "resourceSize": 435,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 3154.6990000000224,
+              "transferSize": 964,
+              "priority": "High",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "finished": true,
+              "resourceType": "Script"
+            },
+            {
+              "networkEndTime": 3089.546999999322,
+              "transferSize": 840,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "statusCode": 200,
+              "networkRequestTime": 2796.1669999994338,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 312,
+              "protocol": "h2",
+              "rendererStartTime": 2794.1909999996424,
+              "entity": "ocobo.co"
+            },
+            {
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkEndTime": 3125.296999999322,
+              "transferSize": 831,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "statusCode": 200,
+              "resourceType": "Script",
+              "networkRequestTime": 2796.2730000000447,
+              "resourceSize": 309,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "rendererStartTime": 2794.4270000001416,
+              "entity": "ocobo.co"
+            },
+            {
+              "rendererStartTime": 2794.6430000001565,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/_main.blog._index-Ch2d6Qju.js",
+              "priority": "High",
+              "networkEndTime": 3164.8810000000522,
+              "transferSize": 4152,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceSize": 9172,
+              "networkRequestTime": 2797.1030000001192
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 2794.8349999999627,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "transferSize": 1237,
+              "networkEndTime": 3123.7639999995008,
+              "url": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 2797.3720000004396,
+              "resourceSize": 717,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2794.9330000001937,
+              "networkRequestTime": 2797.5690000001341,
+              "resourceSize": 272,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 3180.1480000000447,
+              "transferSize": 803,
+              "priority": "High",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/optimized-image-BKBFj58i.js",
+              "statusCode": 200,
+              "resourceType": "Script"
+            },
+            {
+              "rendererStartTime": 2795.0940000005066,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/labels-CtAnB7VF.js",
+              "statusCode": 200,
+              "finished": true,
+              "priority": "High",
+              "transferSize": 832,
+              "networkEndTime": 3161.79099999927,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceSize": 310,
+              "networkRequestTime": 2799.3660000003874
+            },
+            {
+              "url": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "transferSize": 829,
+              "networkEndTime": 3095.7719999998808,
+              "priority": "High",
+              "resourceSize": 302,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2802.7400000002235,
+              "rendererStartTime": 2795.1990000000224,
+              "protocol": "h2",
+              "entity": "ocobo.co"
+            },
+            {
+              "resourceSize": 549,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2802.82600000035,
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "transferSize": 1074,
+              "networkEndTime": 3100.7029999997467,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "rendererStartTime": 2795.2790000000969,
+              "protocol": "h2"
+            },
+            {
+              "rendererStartTime": 2795.3989999992773,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "statusCode": 200,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "transferSize": 1132,
+              "networkEndTime": 3102.839999999851,
+              "resourceSize": 1217,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 2802.9199999999255
+            },
+            {
+              "resourceType": "Image",
+              "url": "data:image/svg+xml,%3Csvg width='28' height='9' viewBox='0 0 28 9' fill='currentColor' xmlns='http:…",
+              "finished": true,
+              "statusCode": 200,
+              "priority": "Low",
+              "networkEndTime": 3172.7800000002608,
+              "transferSize": 0,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/svg+xml",
+              "resourceSize": 515,
+              "networkRequestTime": 3172.5449999999255,
+              "rendererStartTime": 3172.5449999999255,
+              "protocol": "data"
+            },
+            {
+              "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Font",
+              "sessionTargetType": "page",
+              "priority": "VeryHigh",
+              "networkEndTime": 3375.6699999999255,
+              "transferSize": 31974,
+              "resourceSize": 31480,
+              "experimentalFromMainFrame": true,
+              "mimeType": "font/woff",
+              "networkRequestTime": 3176.7810000004247,
+              "rendererStartTime": 3175.6859999997541,
+              "protocol": "h2",
+              "entity": "ocobo.co"
+            },
+            {
+              "networkRequestTime": 3176.8859999999404,
+              "mimeType": "font/otf",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 57572,
+              "networkEndTime": 3349.9129999997094,
+              "transferSize": 38778,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "resourceType": "Font",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 3175.980000000447
+            },
+            {
+              "finished": true,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+              "statusCode": 200,
+              "resourceType": "Font",
+              "sessionTargetType": "page",
+              "priority": "VeryHigh",
+              "networkEndTime": 3406.2109999991953,
+              "transferSize": 39126,
+              "resourceSize": 58256,
+              "experimentalFromMainFrame": true,
+              "mimeType": "font/otf",
+              "networkRequestTime": 3176.9709999999031,
+              "rendererStartTime": 3176.0839999997988,
+              "protocol": "h2",
+              "entity": "ocobo.co"
+            },
+            {
+              "rendererStartTime": 3250.0060000000522,
+              "protocol": "h2",
+              "entity": "unsplash.com",
+              "resourceType": "Image",
+              "url": "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=1200&h=800&fit=crop",
+              "finished": true,
+              "statusCode": 200,
+              "transferSize": 158840,
+              "networkEndTime": 3274.6080000000075,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "mimeType": "image/jpeg",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 158261,
+              "networkRequestTime": 3250.9069999996573
+            },
+            {
+              "networkRequestTime": 3251.0219999998808,
+              "resourceSize": 92016,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "transferSize": 92677,
+              "networkEndTime": 3448.8389999996871,
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-13/cover-1.png",
+              "resourceType": "Image",
+              "entity": "vercel-storage.com",
+              "protocol": "h2",
+              "rendererStartTime": 3250.2869999995455
+            },
+            {
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "transferSize": 62130,
+              "networkEndTime": 3286.61699999962,
+              "url": "https://images.unsplash.com/photo-1493612276216-ee3925520721?ixlib=rb-4.0.3&q=85&fm=jpg&cs=srgb&w=1200&h=800&fit=crop",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Image",
+              "networkRequestTime": 3251.1370000001043,
+              "resourceSize": 61553,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/jpeg",
+              "protocol": "h2",
+              "rendererStartTime": 3250.4249999998137,
+              "entity": "unsplash.com"
+            },
+            {
+              "mimeType": "image/jpeg",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 158506,
+              "networkRequestTime": 3251.8569999998435,
+              "resourceType": "Image",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://images.unsplash.com/photo-1612385763901-68857dd4c43c?w=1200&h=800&fit=crop",
+              "transferSize": 159084,
+              "networkEndTime": 3306.3310000002384,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "entity": "unsplash.com",
+              "rendererStartTime": 3250.6320000002161,
+              "protocol": "h2"
+            },
+            {
+              "entity": "unsplash.com",
+              "rendererStartTime": 3250.86699999962,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/jpeg",
+              "resourceSize": 179176,
+              "networkRequestTime": 3253.4330000001937,
+              "resourceType": "Image",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://images.unsplash.com/photo-1566140967404-b8b3932483f5?w=1200&h=800&fit=crop",
+              "priority": "Low",
+              "transferSize": 179754,
+              "networkEndTime": 3287.5999999996275,
+              "sessionTargetType": "page"
+            },
+            {
+              "rendererStartTime": 3804.2319999998435,
+              "protocol": "h2",
+              "entity": "Google Analytics",
+              "resourceType": "Fetch",
+              "finished": true,
+              "statusCode": 204,
+              "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65c1v9100339653za200zd9100339653&_p=1778779333946&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1547864760.1778779335&frm=0&pscdl=noapi&rcb=11&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115938466~115938468~118012007&dp=%2Fblog&sid=1778779334&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fblog&dt=Ocobo%20%C2%B7%20Le%20blog%20des%20Revenue%20Operations&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=3803",
+              "priority": "High",
+              "transferSize": 796,
+              "networkEndTime": 4068.8229999998584,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/plain",
+              "resourceSize": 0,
+              "networkRequestTime": 3806.9519999995828
+            },
+            {
+              "networkRequestTime": 3811.6239999998361,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 97992,
+              "priority": "Low",
+              "transferSize": 29756,
+              "networkEndTime": 3858.7489999998361,
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "protocol": "h2",
+              "rendererStartTime": 3810.7199999997392
+            },
+            {
+              "entity": "Hubspot",
+              "protocol": "h2",
+              "rendererStartTime": 3811.179999999702,
+              "networkRequestTime": 3811.8899999996647,
+              "resourceSize": 78203,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "transferSize": 27954,
+              "networkEndTime": 3872.5530000003055,
+              "priority": "Low",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "resourceType": "Script"
+            },
+            {
+              "resourceSize": 109001,
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/javascript",
+              "networkRequestTime": 3813.3250000001863,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "transferSize": 43663,
+              "networkEndTime": 3872.1500000003725,
+              "entity": "Hubspot",
+              "rendererStartTime": 3811.4790000002831,
+              "protocol": "h2"
+            },
+            {
+              "entity": "Hubspot",
+              "rendererStartTime": 3812.0120000001043,
+              "protocol": "h2",
+              "resourceSize": 72678,
+              "mimeType": "text/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 3813.4189999997616,
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "transferSize": 27218,
+              "networkEndTime": 4021.738000000827,
+              "priority": "Low"
+            },
+            {
+              "rendererStartTime": 3815.0429999995977,
+              "protocol": "h2",
+              "entity": "GitHub",
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Stylesheet",
+              "sessionTargetType": "page",
+              "priority": "VeryHigh",
+              "networkEndTime": 3860.7130000004545,
+              "transferSize": 2000,
+              "resourceSize": 4371,
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/css",
+              "networkRequestTime": 3815.9319999990985
+            },
+            {
+              "resourceSize": 16667,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "networkRequestTime": 3817.6699999999255,
+              "finished": true,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "statusCode": 200,
+              "resourceType": "Image",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "transferSize": 17170,
+              "networkEndTime": 3967.7229999992996,
+              "entity": "ocobo.co",
+              "rendererStartTime": 3816.6890000002459,
+              "protocol": "h2"
+            },
+            {
+              "entity": "Clearbit",
+              "rendererStartTime": 4163.8970000008121,
+              "protocol": "h2",
+              "resourceSize": 0,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 4164.9599999999627,
+              "statusCode": 404,
+              "finished": true,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "transferSize": 639,
+              "networkEndTime": 4345.3519999999553
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 4166.5049999998882,
+              "entity": "ocobo.co",
+              "networkEndTime": 4198.5649999994785,
+              "transferSize": 1865,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/_vercel/insights/script.js",
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 4167.4729999993,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 2495
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 4167.5520000001416,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "transferSize": 5311,
+              "networkEndTime": 4214.4579999996349,
+              "url": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 4168.4419999998063,
+              "resourceSize": 12567,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 4170.0629999991506,
+              "entity": "ocobo.co",
+              "transferSize": 2482,
+              "networkEndTime": 4435.0060000000522,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "resourceType": "Fetch",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fblog%2Fagence-conseil-revenue-operations-business-partner%2C%2Fblog%2Fbusiness-ops-revenue-ops-definition%2C%2Fblog%2Fcomment-orchestrer-ses-talents-revops%2C%2Fblog%2Fcomment-partoo-repense-ae-kam%2C%2Fblog%2Fcomprendre-et-structurer-une-equipe-RevOps-modeles-stades-de-maturite%2C%2Fblog%2Fconception-plan-compensation-contenu%2C%2Fblog%2Fconception-plan-compensation-contours%2C%2Fblog%2Fconseils-astuces-maitriser-croissance-entreprise%2C%2Fblog%2Fconseils-optimiser-customer-journey-choisir-customer-success-platform%2C%2Fblog%2Fcontrole-depenses-logiciels-saas%2C%2Fblog%2Fcroissance-alan-culture-entreprise%2C%2Fblog%2Fcroissance-spendesk-co-fondateur-rodolphe-ardant%2C%2Fblog%2Fdeployer-business-model-internationa-cas-the-fork%2C%2Fblog%2Fetapes-choisir-nouvel-outil%2C%2Fblog%2Fexperience-utilisateur-revops-croissance-alan%2C%2Fblog%2Fia-vente-humain-commercial-IA%2C%2Fblog%2Flancer-business-unit-saas-performante%2C%2Fblog%2Flivestorm-les-grandes-etapes%2C%2Fblog%2Flivestorm-strategie-sales-led-self-service%2C%2Fblog%2Fmarketing-ops-maillon-indispensable-scaler%2C%2Fblog%2Fnet-retention-rate%2C%2Fblog%2Fparcours-carriere-revops-attirer-fideliser-faire-evoluer-talents%2C%2Fblog%2Fpartoo-evolution-organisationnelle%2C%2Fblog%2Fplans-compensation-ne-fonctionnent-pas%2C%2Fblog%2Fprincipes-plan-compensation-reussi%2C%2Fblog%2Fremuneration-variable-commerciale-qobra%2C%2Fblog%2Frepenser-la-remuneration-variable-pour-booster-la-performance%2C%2Fblog%2Freussir-implementation-hubspot%2C%2Fblog%2Frole-business-operations-engineer%2C%2Fblog%2Frole-business-ops-manager%2C%2Fblog%2Frole-cro-startup-hypercroissance%2C%2Fblog%2Froles-cles-en-revops%2C%2Fblog%2Fsales-marketing-comment-collaborer-efficacement%2C%2Fblog%2Fse-faire-un-nom-marche-concurrentiel-sellsy%2C%2Fblog%2Fstructurer-equipe-marketing-profils%2C%2Fblog%2Fstructurer-equipe-revenue-spendesk%2C%2Fblog%2Fstructurer-equipe-revops-90-jours%2C%2Fblog%2Fstructurer-equipes-vente-complexe%2C%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe%2C%2Fblog%2Ftarget-setting-guide%2C%2Fblog%2Fthe-most-comprehensive-report-on-sales-compensation-structures-in-europe%2C%2Fblog%2Ftransversalite-data-passer-a-lechelle%2C%2Fblog%2Fvirage-strategique-diffusely-tech-company%2C%2Fclients%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology&version=ba6d9b28",
+              "networkRequestTime": 4171.1679999995977,
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 16621
+            },
+            {
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 607831,
+              "networkRequestTime": 4184.6239999998361,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "networkEndTime": 4284.7620000001043,
+              "transferSize": 204714,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "rendererStartTime": 4183.3839999996126,
+              "protocol": "h2"
+            },
+            {
+              "rendererStartTime": 4229.12799999956,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "statusCode": 202,
+              "finished": true,
+              "url": "https://www.ocobo.co/_vercel/insights/view",
+              "resourceType": "Fetch",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkEndTime": 4270.609999999404,
+              "transferSize": 473,
+              "resourceSize": 48,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "networkRequestTime": 4230.2810000004247
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 4295.8390000006184,
+              "networkRequestTime": 4299.9399999994785,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "resourceSize": 16621,
+              "priority": "High",
+              "transferSize": 2482,
+              "networkEndTime": 4457.1299999998882,
+              "sessionTargetType": "page",
+              "resourceType": "Fetch",
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fblog%2Fagence-conseil-revenue-operations-business-partner%2C%2Fblog%2Fbusiness-ops-revenue-ops-definition%2C%2Fblog%2Fcomment-orchestrer-ses-talents-revops%2C%2Fblog%2Fcomment-partoo-repense-ae-kam%2C%2Fblog%2Fcomprendre-et-structurer-une-equipe-RevOps-modeles-stades-de-maturite%2C%2Fblog%2Fconception-plan-compensation-contenu%2C%2Fblog%2Fconception-plan-compensation-contours%2C%2Fblog%2Fconseils-astuces-maitriser-croissance-entreprise%2C%2Fblog%2Fconseils-optimiser-customer-journey-choisir-customer-success-platform%2C%2Fblog%2Fcontrole-depenses-logiciels-saas%2C%2Fblog%2Fcroissance-alan-culture-entreprise%2C%2Fblog%2Fcroissance-spendesk-co-fondateur-rodolphe-ardant%2C%2Fblog%2Fdeployer-business-model-internationa-cas-the-fork%2C%2Fblog%2Fetapes-choisir-nouvel-outil%2C%2Fblog%2Fexperience-utilisateur-revops-croissance-alan%2C%2Fblog%2Fia-vente-humain-commercial-IA%2C%2Fblog%2Flancer-business-unit-saas-performante%2C%2Fblog%2Flivestorm-les-grandes-etapes%2C%2Fblog%2Flivestorm-strategie-sales-led-self-service%2C%2Fblog%2Fmarketing-ops-maillon-indispensable-scaler%2C%2Fblog%2Fnet-retention-rate%2C%2Fblog%2Fparcours-carriere-revops-attirer-fideliser-faire-evoluer-talents%2C%2Fblog%2Fpartoo-evolution-organisationnelle%2C%2Fblog%2Fplans-compensation-ne-fonctionnent-pas%2C%2Fblog%2Fprincipes-plan-compensation-reussi%2C%2Fblog%2Fremuneration-variable-commerciale-qobra%2C%2Fblog%2Frepenser-la-remuneration-variable-pour-booster-la-performance%2C%2Fblog%2Freussir-implementation-hubspot%2C%2Fblog%2Frole-business-operations-engineer%2C%2Fblog%2Frole-business-ops-manager%2C%2Fblog%2Frole-cro-startup-hypercroissance%2C%2Fblog%2Froles-cles-en-revops%2C%2Fblog%2Fsales-marketing-comment-collaborer-efficacement%2C%2Fblog%2Fse-faire-un-nom-marche-concurrentiel-sellsy%2C%2Fblog%2Fstructurer-equipe-marketing-profils%2C%2Fblog%2Fstructurer-equipe-revenue-spendesk%2C%2Fblog%2Fstructurer-equipe-revops-90-jours%2C%2Fblog%2Fstructurer-equipes-vente-complexe%2C%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe%2C%2Fblog%2Ftarget-setting-guide%2C%2Fblog%2Fthe-most-comprehensive-report-on-sales-compensation-structures-in-europe%2C%2Fblog%2Ftransversalite-data-passer-a-lechelle%2C%2Fblog%2Fvirage-strategique-diffusely-tech-company%2C%2Fclients%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology&version=ba6d9b28",
+              "statusCode": 200,
+              "finished": true
+            },
+            {
+              "networkRequestTime": 4389.105000000447,
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 135,
+              "networkEndTime": 4426.9830000000075,
+              "transferSize": 1095,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "resourceType": "XHR",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+              "entity": "Hubspot",
+              "protocol": "h2",
+              "rendererStartTime": 4387.9129999997094
+            },
+            {
+              "resourceSize": 61,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "networkRequestTime": 4392.5,
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fblog&isMobile=true",
+              "resourceType": "Fetch",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "transferSize": 1718,
+              "networkEndTime": 4479.0230000000447,
+              "entity": "Hubspot",
+              "rendererStartTime": 4391.6320000002161,
+              "protocol": "h2"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 4458.9660000000149,
+              "transferSize": 558,
+              "priority": "High",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+              "resourceType": "Fetch",
+              "networkRequestTime": 4434.0039999997243,
+              "resourceSize": 5,
+              "mimeType": "text/plain",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "rendererStartTime": 4432.6480000000447,
+              "entity": "Hubspot"
+            },
+            {
+              "entity": "Hubspot",
+              "protocol": "http/1.1",
+              "rendererStartTime": 4498.8820000002161,
+              "networkRequestTime": 4499.7719999998808,
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 35,
+              "transferSize": 1020,
+              "networkEndTime": 4596.3769999993965,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "resourceType": "Image",
+              "finished": true,
+              "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+              "statusCode": 200
+            },
+            {
+              "rendererStartTime": 5193.9179999995977,
+              "protocol": "http/1.1",
+              "entity": "Hubspot",
+              "resourceType": "XHR",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953",
+              "priority": "High",
+              "networkEndTime": 5287.4679999994114,
+              "transferSize": 4080,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "resourceSize": 9346,
+              "networkRequestTime": 5194.9240000005811
+            },
+            {
+              "entity": "Hubspot",
+              "protocol": "h2",
+              "rendererStartTime": 5222.8629999998957,
+              "networkRequestTime": 5224.6189999999478,
+              "resourceSize": 45,
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 5396.05700000003,
+              "transferSize": 1520,
+              "priority": "Low",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog&t=Ocobo+%C2%B7+Le+blog+des+Revenue+Operations&cts=1778779336025&vi=0bd2c9deca31611a784a1c1c57aa132e&nc=true&u=242475741.0bd2c9deca31611a784a1c1c57aa132e.1778779336019.1778779336019.1778779336019.1&b=242475741.1.1778779336019&cc=15",
+              "resourceType": "Image"
+            },
+            {
+              "entity": "Hubspot",
+              "rendererStartTime": 5303.0910000000149,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "resourceSize": 607831,
+              "networkRequestTime": 5304.4759999997914,
+              "resourceType": "Script",
+              "statusCode": 304,
+              "finished": true,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "priority": "Low",
+              "transferSize": 1663,
+              "networkEndTime": 5329.48900000006,
+              "sessionTargetType": "page"
+            },
+            {
+              "rendererStartTime": 5484.5139999995008,
+              "protocol": "http/1.1",
+              "entity": "Hubspot",
+              "resourceType": "Image",
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+              "statusCode": 200,
+              "finished": true,
+              "priority": "Low",
+              "transferSize": 1024,
+              "networkEndTime": 5550.5290000000969,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/gif",
+              "resourceSize": 35,
+              "networkRequestTime": 5486.429999999702
+            },
+            {
+              "resourceSize": 3792,
+              "mimeType": "text/css",
+              "networkRequestTime": 5496.7269999999553,
+              "statusCode": 200,
+              "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+              "finished": true,
+              "resourceType": "Stylesheet",
+              "sessionTargetType": "page",
+              "networkEndTime": 5509.9069999996573,
+              "transferSize": 1259,
+              "priority": "VeryHigh",
+              "entity": "Google Fonts",
+              "rendererStartTime": 5495.6200000001118,
+              "protocol": "h2"
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 5538.1409999998286,
+              "entity": "Google Fonts",
+              "transferSize": 51336,
+              "networkEndTime": 5553.5579999992624,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "resourceType": "Font",
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 5539.50299999956,
+              "mimeType": "font/woff2",
+              "resourceSize": 50524
+            },
+            {
+              "networkRequestTime": 5547.4619999993593,
+              "mimeType": "font/woff2",
+              "resourceSize": 50524,
+              "transferSize": 51336,
+              "networkEndTime": 5559.0270000007,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "resourceType": "Font",
+              "finished": true,
+              "statusCode": 200,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "entity": "Google Fonts",
+              "protocol": "h2",
+              "rendererStartTime": 5545.1780000003055
+            },
+            {
+              "entity": "Hubspot",
+              "rendererStartTime": 5577.6419999999925,
+              "protocol": "h2",
+              "resourceSize": 45,
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 5579.3870000001043,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=b916c0ef-f2f0-4cb0-bcaf-2f09a3963e59&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog&t=Ocobo+%C2%B7+Le+blog+des+Revenue+Operations&cts=1778779336375&vi=0bd2c9deca31611a784a1c1c57aa132e&nc=true&u=242475741.0bd2c9deca31611a784a1c1c57aa132e.1778779336019.1778779336019.1778779336019.1&b=242475741.1.1778779336019&cc=15",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Image",
+              "sessionTargetType": "page",
+              "transferSize": 1022,
+              "networkEndTime": 5688.8470000000671,
+              "priority": "Low"
+            },
+            {
+              "protocol": "http/1.1",
+              "rendererStartTime": 5578.0849999999627,
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "networkEndTime": 5645.2429999997839,
+              "transferSize": 1023,
+              "priority": "Low",
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+              "resourceType": "Image",
+              "networkRequestTime": 5580.3889999995008,
+              "resourceSize": 35,
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "label": "Protocol",
+              "valueType": "text",
+              "key": "protocol"
+            },
+            {
+              "valueType": "ms",
+              "key": "networkRequestTime",
+              "granularity": 1,
+              "label": "Network Request Time"
+            },
+            {
+              "label": "Network End Time",
+              "key": "networkEndTime",
+              "valueType": "ms",
+              "granularity": 1
+            },
+            {
+              "valueType": "bytes",
+              "granularity": 1,
+              "key": "transferSize",
+              "label": "Transfer Size",
+              "displayUnit": "kb"
+            },
+            {
+              "displayUnit": "kb",
+              "label": "Resource Size",
+              "key": "resourceSize",
+              "granularity": 1,
+              "valueType": "bytes"
+            },
+            {
+              "valueType": "text",
+              "key": "statusCode",
+              "label": "Status Code"
+            },
+            {
+              "label": "MIME Type",
+              "valueType": "text",
+              "key": "mimeType"
+            },
+            {
+              "label": "Resource Type",
+              "valueType": "text",
+              "key": "resourceType"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "unminified-javascript": {
+        "id": "unminified-javascript",
+        "title": "Minify JavaScript",
+        "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn how to minify JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unminified-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [],
+          "overallSavingsMs": 0,
+          "items": [],
+          "type": "opportunity",
+          "overallSavingsBytes": 0,
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "FCP": 0,
+              "LCP": 0
+            }
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ]
+        },
+        "warnings": [],
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "unminified-css": {
+        "id": "unminified-css",
+        "title": "Minify CSS",
+        "description": "Minifying CSS files can reduce network payload sizes. [Learn how to minify CSS](https://developer.chrome.com/docs/lighthouse/performance/unminified-css/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [],
+          "overallSavingsMs": 0,
+          "items": [],
+          "type": "opportunity",
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            }
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsBytes": 0
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "interactive": {
+        "id": "interactive",
+        "title": "Time to Interactive",
+        "description": "Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).",
+        "score": 0.1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "13.7 s",
+        "numericValue": 13749.349510170716,
+        "numericUnit": "millisecond"
+      },
+      "largest-contentful-paint": {
+        "id": "largest-contentful-paint",
+        "title": "Largest Contentful Paint",
+        "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)",
+        "score": 0.09,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "6.5 s",
+        "numericValue": 6451,
+        "numericUnit": "millisecond"
+      },
+      "document-latency-insight": {
+        "id": "document-latency-insight",
+        "title": "Document request latency",
+        "description": "Your first network request is the most important. [Reduce its latency](https://developer.chrome.com/docs/performance/insights/document-latency) by avoiding redirects, ensuring a fast server response, and enabling text compression.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "checklist",
+          "debugData": {
+            "serverResponseTime": 107,
+            "uncompressedResponseBytes": 0,
+            "redirectDuration": 0,
+            "type": "debugdata",
+            "wastedBytes": 0
+          },
+          "items": {
+            "noRedirects": {
+              "value": true,
+              "label": "Avoids redirects"
+            },
+            "serverResponseIsFast": {
+              "value": true,
+              "label": "Server responds quickly (observed 107 ms)"
+            },
+            "usesCompression": {
+              "label": "Applies text compression",
+              "value": true
+            }
+          }
+        }
+      },
+      "dom-size-insight": {
+        "id": "dom-size-insight",
+        "title": "Optimize DOM size",
+        "description": "A large DOM can increase the duration of style calculations and layout reflows, impacting page responsiveness. A large DOM will also increase memory usage. [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/performance/insights/dom-size).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "debugData": {
+            "maxChildren": 59,
+            "totalElements": 1369,
+            "maxDepth": 14,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "statistic": "Total elements",
+              "value": {
+                "granularity": 1,
+                "value": 1369,
+                "type": "numeric"
+              }
+            },
+            {
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,2,UL,0,LI,0,ARTICLE,1,DIV,1,DIV,2,svg,0,circle",
+                "lhId": "page-10-circle",
+                "snippet": "\u003ccircle cx=\"12.1\" cy=\"12.1\" r=\"1\"\u003e",
+                "boundingRect": {
+                  "width": 1,
+                  "bottom": 1806,
+                  "height": 1,
+                  "top": 1805,
+                  "right": 167,
+                  "left": 165
+                },
+                "type": "node",
+                "nodeLabel": "div.px_6 \u003e div.d_flex \u003e svg.lucide \u003e circle",
+                "selector": "div.px_6 \u003e div.d_flex \u003e svg.lucide \u003e circle"
+              },
+              "statistic": "DOM depth",
+              "value": {
+                "granularity": 1,
+                "type": "numeric",
+                "value": 14
+              }
+            },
+            {
+              "value": {
+                "type": "numeric",
+                "value": 59,
+                "granularity": 1
+              },
+              "node": {
+                "lhId": "page-9-BODY",
+                "snippet": "\u003cbody\u003e",
+                "path": "1,HTML,1,BODY",
+                "boundingRect": {
+                  "bottom": 25905,
+                  "height": 25905,
+                  "top": 0,
+                  "right": 412,
+                  "left": 0,
+                  "width": 412
+                },
+                "type": "node",
+                "nodeLabel": "body",
+                "selector": "body"
+              },
+              "statistic": "Most children"
+            }
+          ],
+          "headings": [
+            {
+              "label": "Statistic",
+              "valueType": "text",
+              "key": "statistic"
+            },
+            {
+              "valueType": "node",
+              "key": "node",
+              "label": "Element"
+            },
+            {
+              "valueType": "numeric",
+              "key": "value",
+              "label": "Value"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 1369,
+        "numericUnit": "element"
+      },
+      "screenshot-thumbnails": {
+        "id": "screenshot-thumbnails",
+        "title": "Screenshot Thumbnails",
+        "description": "This is what the load of your site looked like.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "filmstrip",
+          "scale": 5979,
+          "items": [
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 6595735225,
+              "timing": 747
+            },
+            {
+              "timestamp": 6596482600,
+              "timing": 1495,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k="
+            },
+            {
+              "timing": 2242,
+              "timestamp": 6597229975,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k="
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 6597977350,
+              "timing": 2990
+            },
+            {
+              "timestamp": 6598724725,
+              "timing": 3737,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAMCBAUGBwgBCf/EAFoQAAEDAwIDAwUIDAsGAQ0AAAEAAgMEBREGEgchMRNBURQiYXGRCBUjMlJygZQWMzdFVXOTobGzwdE0NkJERnWS0tPh4hgkNVNisuMXJ1RWZnSDlaKlwsPw/8QAGAEBAQEBAQAAAAAAAAAAAAAAAAECAwT/xAAuEQEAAQIEAwYFBQAAAAAAAAAAAQIRAxIhMQQFQRQyMzRxoRMiJFHwQmGRwdH/2gAMAwEAAhEDEQA/APVKIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIvjnBrS5xAaBkk9Atei1xpWa4eQxaitL6vO0RNqmEk+HXr6EGxIhIAyTy8Vrp1xpZtf5EdRWkVedvZeVs3Z8OvX0INiRAQQCDkHvWKvOobXZXsbdaryRj8YmljcIh65MbR9JQZVFoXGuq/8ANJf6mjn5Gna5ksT+oLm8wQssdX6es1JQU13vluo6p0Mfwc9Q1rubRzIJ5INnRR01RDVQMnppY5oZBuZJG4Oa4eII6rC3fWOm7PVilut9tlJU5x2U1Sxrh6wTy+lBnkUVJUwVlOyopJo54JBlkkbg5rh4gjqpUBERAREQEREBERAREQERfHu2tJQC4N6kBfBIw9HBYu5XGkt8BqLjVQ00OQ3tJnhjcnoMlWFHqWx1tSyno7xb56iQ4ZHHUMc53qAKDZUUFO8nzT9CnQEREBERBzfjhPM+z2O0NmfT0l4usFDVyMO09i4kubnuzjC2Or0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3p6q81dp2h1VYp7Xc2u7GTDmvYcPieObXtPcQVp8ui9Z1NEbZVa8e62ub2b3st7G1LmdCO03dcd+MoNEN9uU/A+joXVspZJeBZHV7XYc+m7Ut359LRtyuuM0DpVtj96RYrf5Fs2YMLd3TGd3Xd6c5Vc2ibJLokaVNMRaWxCJrQfOaQch4Pyt3PPitabonWjKT3ubr+X3tDezDjb2Gp2dMdrnrjvxlBhuINVU6E4KGn07eJqsxyto2Vznhz4Y3PII3DvaPNB6hdF0/py2W/TjLdHEKinmhDZ3zHtHVGRzc8n4xOVHbtG2Si0e3TIpGzWnszG+ObzjJk5LnH5RPPPirV2nrpbLKLPpivbTU2zs2VFa91RJTt6YY3lnHduccIOK088tPwi4oWBsr5rdZq59PRvcc7Y+0HmZ9GPzrs+idKWaj0nSRmlpq51XTskqamZgkdVOc0EucT1BzyHcFjxwzoKfhrXaSoKmSPy0F09ZI3e+SQuBL3DlnOMJHo7UdppPINL6pjoraG7Y4aqhFQ6nHeI3bhy8A7OEGqafq5tIf+VG1WQl1BZ4vLKGL4wge+Jz3MHoBGcLaeFmkrHDoa21L6Olrqq407amrqp42yPnfINzskjmMnos1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93Uu9GOQC12i0FqHT7JKLSGrfIbOXOdFSVdE2pNPk5IY4kHHgDlBBw+hjsHE/Vmm7WNlmZDBXRwA5bTyPyHNb4A9cLqC1nRGkYNLw1kj6ue4XSuk7asrp/jzO7hgcg0DkAOi2ZAREQEREBERAREQEREBUTjMRVaHmg13UYqTbT5EK4zbh/Aux7TH/xfNx+dYKytu/vpB5UNRdjk7vKhQ9n0Pxuz8/2LdnwkHzeYVIieT8VB9gHwgV0qIowwelVoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICItdrqy4M1AIYnubSgsyDHkYOM88LFdcUREy64WFOLMxE7RdsSLX7bVVtRcK2GWaRoaXiIGMAAZ5HOP2q3oK67S01ZI8OL4YwGtMYG52evTnyWPjx9p6+zp2WrXWNLe7aEWs22vuctBXvl3l0cW6Nxjwd2OYAxzSOqu7LLJPO/4Vzm9mdgJDT1yAP2KRjxMXtKzwtUTMZo3iP5bMixFDU1clgknlL/ACkMeWksAORnHJWlNX10jbTkyZkc9s+Y8ZxjHdyWvjRppuxHD1TMxeNP8mf6bEi1iiuFyfeKiGUydg0ybMxDHLOOeFHQXK5+91ZLUOe6QMHZDssEEnGemFmOIp+09fZ0nhKojeOnv+atrRawbhchZJnEyeWRShu7sxkj1YwlTV3VlngqGSl04e5kgEfXwOMdydoj7TtdOyVbZo3t+fs2dFFStkZTRtnf2kob5zsAZP0KVd4eadBEREEREBERAREQEREBERAREQEREBERARFFJUwRuLZJo2OHc5wBQSooPLKb/wBIh/thTNcHNDmkFp5gg9UH1ERARFp3ETiLZdAigN9bVu8t7TsvJ4w/4m3OckY+MEG4otW4fa5tOvLdU1tjbVNhp5exf5RGGHdgHlgnlgraUBERAREQEREBERAREQEREBERAREQEREBERAREQF4s90z9166fiYP1TV7TXiz3TP3Xrp+Jg/VNQanadB6lu9HT1Vutjp4aj7UWzRgu545Auz1Xa4uM1z4b222aXvWj3CroaOFm51ft3jYMHHZn0jqeYK5ZpHWWlrBHbJ5tDtrbvRPbMK43WaPfI125ruzALRjA5dOS3L3S9/tl+h0jUxUwivE9vZVz7X7uzjla1zIyccyDuOeX50R0DWHuhaOx1Nvjt9l98W1NFFVvd5Z2fZGQZ2EbHZIGOfpVhePdE1dofSx12jxHJUU7KlrTceYY/m3PwXeMH6V5to2Nt94oH3ilkfSh0U0kR5GSE4dyPpb0XQPdGVVLW8RRVW9zH0c1BTSQuYMAsLMjH0IOs1nukrZT0Vrkjssk9RURukqoo6kYpjuIDdxb5xIGe7GQtF90PrS1a50/pG52dzw1r6uOWGUYfE/EJwf3haFR3zT9JoGe1Vmlmy3ycl8N0dMWkNLuRA9GCMDke9a1NRVMdmpa2QOFJNPLHGT0LmNYXY/tNQd/wDc86utWi+GN+ul7mcyEXEMjjYMvlf2TcNaPHl6lfu907SeV7W6YnNLn45rAH48duzGfpXCpKWqfw1p6mMONHFdpWS46B7oY9mfoa9ZWK96MHC19rksU51aZCRX5G3G/IOd2fi+btx6UHo7UHHC00mgaXU9konXFslY2ilpZJuwkgcWPf53mu+T3cjnryWpM90vBJaK2c6fENdG6NtPAawvEu7duJOwYDQ0eOS4LhFLS1TeG9yqi1won3WljaSOTniGoJx6gR7Qup+5W09Z7/V6kbe7ZSV4hZTmMVEQfsyZM4z0zgexB0ibj1aKDRVpu1zopDdLgx72UFO/dta17m7nOOMAlvgT7FrlB7pyifUtbXaaqIYCeb4qsSOA+aWt/Sube6SsjLJxF7GkpI6S2vpInUscTNrA3mHAAcvjbj9PpWDul10bPQ2tgtlY+WJnw4pWMpMHA5FzjKZOfedv7EHpHiFxrodM2jT10tNuF4orwyV8b/KOx2dmWAgjY7nlxBHLGFpH+1Af/VIf/Mf/AAlrl5p9BS8LLDUXN18t5jfUyUFvZPHJNOHlgc8ksw1m6PkcDv6rmWkK3TlBezV6ittbcKKM7oqSOZrQ7nyEjscx6ABn8yD3Dw71N9mOjbdfjSeR+WB57DtO02bXuZ8bAznbnp3rY1htG11Lc9J2iut9I2jpKmljlip2gARNc0EN5cuSzKKIiICIiAiIgIiICIiAiIgIiIC57rDhDpXVt+mu94iq3VkzWtcY5yxuGgAcvUF0JEHI/wDZ80L/AMi4fWj+5XFdwI0ZXTiWqZcpJBGyIE1R5NY0NaOnc1oH0LqiIOdaj4N6Q1BUUk1dS1LXU1NHSRiGYsHZsGG58TjvXmHjvp+j0vrw2i2OnNHT0sQjE0m9zQQTjPhzXuNWNZZrZWzGast1FUTEYL5YGvdj1kIOKcKeHOm9acLdL1eoKN801M2djXMkdHuaZnHDscyM59pW/wCpuFWldRWy1W+ronwUVsDxTRUsnZhu/buz4/FHP1rdaWmgpIGw0sMUELfixxsDWj1AKVBpum+GumdP6frrJTURqLbWydpPDVO7UOOAO/p0C1w8A9BGp7X3vqg3OeyFW/b6uufzrqqINO1Bw301e9MUmn56I01qpZhPFDSu7PDw1zck9/Jx6r7oHh3YdCSVr7BHUMdWBgl7aUvztzjHh8YrcEQYLV2kbHq+gbSagoI6uNhyxxJa+M+LXDBH7VpVBwH0HSVTZzbZ6jadwZPUvcz6RkZ9RXUkQaJrLhTpfV1TRzXWmmYaSAU0LKaTsmMjBJAAA9K17/Z80L/yLh9aP7l1xEFlY7XTWWz0VsoQ4UtJC2CIPOSGtGBk96vURAREQEREBERAREQEREBERAREQFwfivxuumitbVdkpLTRVMMDI3CSV7g47mB3d613heLPdM/deun4mD9U1B6x4eX+bVOi7VeqmGOCasiMjo4yS1vnEcs+pbEvJsvF+46P4d6VsWnGQCt8i7WoqJW7+z3Pdta1vTOOeTnqFYV/HjWw07RwGTyS5iUvNb5NHioiI5Da5uAQe9vUfnD2Ci4t7mzXGoNaQagdqSuFW6ldAIcQxx7dwkz8Roz8UdVD7ofijd9FVdBadPtjhqqmAzvqpIw/a3cWgNB5Z5HOQe5B29F4vtfFfijOx9bR11ZWU0bsSOFAySMHrgkM5dVvOquOt9otDafdSxUsV/uMUk083Z+bE1sjmDawk8ztPXIGOiD0uuccatfXPQdqoqi02Y3B1S9zXTPDjHDjGN23nk5OOY6Fecm8YOJdE2GuqLlUGmlOWOnooxFJ6Adg/MVu+q+NeoKzhvZLxZpordcX1ktJWtZCyRjy1jXAgPBwCHAoOncEeId217S3F93s4ovJSwMnjDhHLnOQN3eMDvPVdPXmnh7xovNNoXU161NO25T0k1PBRQiKOEF8gkODsaOXm5PqWlT8deIdbPLU0lTDDTs5ujhomOYwekuBP50HstF5hoePF7unD7UAd2FHqOhjhmp6qGMFkjDNGx+WOyAcP9XPuwsPobjLxCuFdcIWl17nFFI+GBtPEwRuBb8K4taCQ0buWeZIQetkXknhxx41HTaipodU1jK61SktkLoWNfHy5FpaB345HKx9343691Bd5G2CV1JCSTFSUlM2V4b6SWkk+PQehB7GReV+F3HHUv2WUFo1W+OspaqdtM57oWxywucdoPmgAjOMgjKj137oDUVVfaij0i2Gjo45THFJ2IllmwcZw7IAPcMfSg9WIvJ2j/dAant16gp9WsirKJzwyYmAQzRg/wAobcDl1wRz9C9YMc17GvYctcMg+IQfUREBERAREQEREBERAREQF4s90z9166fiYP1TV7TWOrbDaK6odPW2qgqZ3YBkmp2PccdOZGUHhrWOm6+jsGnL4YJH26uoWATBpLWSNLmlhPccAH059Cn1pqrVerdNWuovzWutVJIaenmbA2MPk28+Y6kADOOQXudlBSMohRspYG0gG0QCMBgHht6K3mslqnpYqae2UMlNESY4nwMLGE9cAjARHAfcc/wXVfz6b9Eq++6a1Cbdqa3UNysNFdbO+jbI107HseyXe8ODJWEEHAZkcx05L0DbrXb7YJBbqGlpBJjf2ELY92OmcDn1KuJ4YqiMxzxMljPVr2hwP0FFfn5Jf30l3FTpFtfZGkACKKtdI4u+cA0kdORyt34s2fVNx03pbVF/o5zJJQmmqJOy2lhbK8sc8D4pc1wOV6+pbDaKScTUlqoIJh0kip2Nd7QFkXNDmlrgC08iD3olnhGo4o6rqLBbLL5dGKOgDWwBtOzdhrdrQSRzwOS2TiO7Uc3CXTVVqxz/ACmouEz6dj4WxObD2bQMhoHUgnnzwQvXcFjtNPUdvT2uhinzntGU7Gu9oGVLcLZQ3JjGXGipqtrDlonibIGn0ZHJB4s0Rpqv1Nwr1XHaoX1FTRVtJV9iwZc9oZM0gDvOHZx6Fr2n9W1dgs1wtbKOKUVDjnt5JQIzjB+DDwxx5fymn9i96W610FtEgt1DS0gkxvEETY92OmcDn1KiqLJaqmo7eptlDNP17SSnY53tIyg8eUMl8uXCrVNfVWm20tojhgjZVRW+OCSWQ1MXJrmgZAAOe7orn3Mv8d7v/U1R/wB0a9h1NFS1VIaWqpoJqYgAwyRhzDg5HmnlywFa0VjtNDK6ShtdDTSOaWF0NOxhLT1BIHT0IPz609bX3i/222wkCSsqY6dpPcXuDR+lZvT181Hw01PUS0sZoboxjqeWKphBy0kEjB9LQcjwXuaDTdjgmjmgs1tjljcHMeylYHNI6EEDkVdV9soLgGivoqWqDenbRNfj2hB5E4Vak1xqjiBSsoqt0kc9UJ66QU0exke7LyTt5ZGQPzLTbpbrrw410W11JIJqSVxj3PkjbPGcgOa9ha7BB6g+g94XvKkpKejiEVJTxQRj+REwNHsCprqCkr4xHXUsFTGOYbNGHj2FB4p01qDUGp9YtjstitFTU1UjfMloG1IjHIbnSSbn4HUlzl7chaWRMa7GQ0A7RgfQoKGgo6CMsoaSnpmHq2GMMHsAVyiiIiAiIgIiICIiAiIgIiICIjiGglxAA6koCLkHulr3V27hzBV2K5z0s3vjHGZqOcsdjZIS0uafQOS0f3L2qrpcb9exqC+1tVAymYWCtq3Pa1xf3bjgHCD0uit4q+kla90VVA9sY3PLZAQ0eJ8F8huFFPII4aunkkd0ayRpJ+jKC5RRVFRBTMDqiaOJpOAZHBoJ+lW77tbo6eSd9fSNgjxvkMzQ1uemTnAQXqKGCqp6imbUU88UtO4bmyseHNI8QRyXyGtpZ37IamGR3gyQE/mQToreeupKeTZUVUET8Z2vkDT7CvpraVtOJzUwiAnAkLxtJ9fRBOigp6ymqS4U1RDMW8yI3h2PYvhrqRsvZuqoBJ02GQZ9iC4RR1FRDTsD6iaOJhOA57g0Z+lRMuFHJHI9lXTuZG3c9wkBDR4nnyCC5RWsNxoZ6Y1ENZTSU7esrZWlo+nOFVBX0lQ/ZBVQSvxnayQOOPoQXCK0Zc6B72sZW0rnuOABK0knw6q7QEREBERAREQEREBERAREQF5V91PrG5SaqbpqmqJYLdTQskljY4t7aRwz52OoAxgeOV6qXDuPvCKt1jcIb5px0JuTYxDPTyu2CVoztcHdNwzjn3Y8EHBr5pHVGn+G1Dc6ypg+x+7zRTsp2TbnB+xxY4txgEtJ6H1rV6T+Ldy/95p/+2VdMl4L8Q59M4qoZpHU04jpraatjgGEEukGX7WjOBgczk+CutM8ENXVNiv1Jc7c2hqHMilpDLPG5skjHHLTtccZa53M9+ERY8Ef4n8Tv6jf/wBsixPud/uyad+dP+okW0aQ4Q8RaGj1DAGG2U9TQyRPibLFIa04JbEOZ2gnq4kciVfcF+FustPcTLLdLxZXU1BTmUyymoidtzC9o5NeT1IHRBu3uu/4hWn+s2/qpFxHhToO9a/ob1QWi401JSwPp5ahk+7EjvhAw8genn+1eivdH6UvWrtIW6i07RGsqYq5sz2CRjMM7N4zlxA6kLDe5n0RqHRz9RHUludRCqFP2OZY379vabviuOMbh18UHFOKtZe9Nig0HPcD5JaIGiVlO4tjmkkJk3HoTgPaOfTBWGdovUVvloJ7Z2tRPN57H0bZWmJwweb3Na3PpaT6133j5wfuOrbuy/6bdE+udG2KoppHbO028g5rjyzjAwcdAuWM4N8TLxNTU9zppGQwgRxvq65j2RN9ADnED0AILnjNZr9PojSmotT0r4ruwPt1W9zmuMgBLonu2kjJG7PqWmV+r31PCy16Wyc0twlqHfMLRsH9p8nsC9O3Xha2DghUaRoXmqr44zURyHDe0qA7fyzyAPxfUV54ZwS4gue0HTzmgnBJqoOX/wBaCumqrlo3hHTVVvmkpKrU1XIHTRHa/wAmgAG0HqMveencFrNBpS6XKxOvFI8T4dgQsZK+U88ZyGFo5+LgV6r4jcJotRcObRYrXNHT1tnjaKV7x5j8Nw5rvDdgHPiFwccHuJ0dM+1soZve9z97o218Yhc75Rbv/Ygh1F9l1NwfFDqiCpFvjucD6KSokDnN+CmDmdScdCM9OaxHD2yXG86Y1oaK6OoaWjoBV1MTWZ8pDNxDCcjA5E9/dyXQ7lwL1DbuG5hpYW3HUFVXwyywQytayGFjJRgOeQCcvGfox4q/4V8NdW2TTOvKW6Wh0E9ytTqekYZ4ndrIWvG3IcQOo64CDgFFc6qjoq+lgme2nrYxFNGD5rwHteMj0FoXT/cv/dJm/q2f/wDFR6d4F60q7qyC62k0VK+OUGofUROax/Zu2ZDXE437RyHesxoHg/xEtOqg+PFmiMb4pa5ksUuYyMFrW5JJPdkDHXIQcx4cfdD0v/WtL+uavfrqymbVCmdUwioIyIi8bz9HVeQNE8H9dW7Wdgrq2wvipaa4U80r/KYTtY2RpccB+TgA9Ff3fgxxAqOIE9VGRIySrMzbqalo2jdkOIzuBA7gPUg9bovjAWsaHHJAwT4r6iiIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICItX1NqN1rvdBTMlpmQjbJVCVwDix7xG3bz8S5x9DPSg2hFqt91HWwU1597aAOdbyGGaWQBhcWtdyGCTyd6FczXqWlq52VMMpqRFBtpY3tczfJI9rcOIBydvMnkB078hsKLXau8VUNRbzVwOomdtI2dpIka9jYXvy1w7sgeB5KKi1bHURySPopgwU7qmMROErnNGPNIHxXcxy59/Pkg2dFjbFdW3aCWRjGN7N207Jmyg8s9WnkfQcK0r7z5DW1TBHPUvD4I2wgtABkJAwevryfUgzqLVJdQ3GS4UFPS0EQeamSmqY5J8Yc2IvAaQ08sbTn6MK5p9URz3IU7KYmAzuphKJAXb2kgks6huQRn82OaDYkWAotSCYU81TRyUtHOZGxzSPHMsBJyB0BDXkH/p9KtpNTR07ZJ5o6gOfFTujpnloAdKX4GcZB83Jz0xy9IbQiwNDqSOoMLZqcwl05p3O3hzA7ZvBDscwQCM8ufLCog1RDPRxzxUs7nOdKXQjnI1jGb92PSCzA/6wg2FFi7DeGXeKV7I2M7MgeZMyTqM89p5H0H86xtu1U24TMbS0m6OcONM/tQdxAJG8AZYDjkefpweSDZkWF05cqys09FXXGnijkdEJPg5N28YznoMermrOm1LVVLqdkVnl7WppvK4WunaAY+Wdx7j5zeXPr68BsyLW36qhDqF7YP93qWwuDnTNa8dqQG4Z1OMjPT0ZVR1I6aprKWlpW9vCJA1ss7WOJZyyWfGDT3HBzy6ZQbEi1Om1RUx2m1PraSHy6tgE4aKgNYWhrSXEkcjlww3B9auxqdjuwc2jnETqZ1VNI4gCFjSQ7PicjljOUGwotbqrzXG2vmNDLRlwjfFIXteC1z2gh3g7B6c/XyU51Exl6ZQSQAdpI6JjmzNc8uDC/mwcwCGnB69OSDOotZp9WxTUVRUilfiIMOwSsc9u44G9ucsx1OeQAPgvsuq4xT0pigjfPUdoWt8pZ2e1hAcd4yOrgAMZ59yDZUWtzashYKQilkb28Yk+GkZEB520tBccOdkdAemDnmFsiAiIgIiICx1RZaGpNcaiESmtbslLufm7duB4DGeneSVkVgrhe6qG4VlNSW7ykUkLJ5HmYMy127k0YOXeaeRwPSgvPeWjNJXU0jXvirTmYOecuOxrOvUcmjp3qJ9gontkD+3e58ccZe6ZznjY5zmkOJzkFxOcqy+yUvZJVwUe+1xSMjkqDLh4LtvMMxzA3DPMHrgFXJvoENLIaf7fWS0mN/TZ2nndO/s+np9CCWGxUcbmPkM08jZHSl80heXEsLDnPdtOMdFTSafpKXdslq3DsjBGH1Dj2TDjkzny6Dn15DmqbZeZqzTgu0tBJGHw9vHAx3aPe3bkdB1PgsRWalrp6KCS2QUbpPLYYJG+VZwHOHI+ZkE5wcgY6jKDOQWaKCpbPHUVPamQSSuMnOXDC0Nd3YGc48RlTT2qlmqXzva7tHPjeSHd8ZJb+lYx2oKlk9Wx9vAZSzQwSSCfIL5Oz5N83JA7Tvx0Hjykqr9Iy5TUFLRiaqbM2GMOl2NdmLtCXHBwAOXQoLmew0M8rpHtmbI6o8q3xzOY4P2BnItIONoxhfIrFSRVoqGPqA0SOmEHbO7IPPV23x5k+GTnqrF90vDr1bqdlBBHFLDK6ZklRggtewZBDDkYdkdM554wvs2p2xWyirDSkipgmn2dp8Xs2F2OnPOMIL6qsVDVWlltmY40rCHAbiDyOevp5g+gkKqtstHWSTySteJJRGC9ry0tMZJYWkdCC4rFVOpqqJ8ULbU51U6EVD4u0cdkZJDebWHzjg8unLqr6gvUlddBSw0UjYRTx1D5ZXbHM37sN2YznzeaCqTT1FNbKihnM80dQ8SSyPlJkc4Ywd3djaBy8FN7zUXls9WI3Nmmh7Bxa8tw30Y6HkOY5+aPBW0l9EdW+lNOfKG1Ih27v5Gzf2nTptB+kYVtHf6uWCF4t8cQrIXS0ZdUZ34buAeA3zTt58t3RBlqC2w0U00zHyyTzBrXySu3OIbnaPoyfareisVJR1TJonVBbHuMULpSY4t3Xa3oOp9WeWFjLPfbnLQ2RtVQRSVVfAJS+OfzQ0NYS93mjGd3QA88DPeJbNqZ1zq4GtoJm0dTu7GcbjyAJBeNoDQQOWCe7ogytBa6aho5KWn7UQPz5r5XPDQe5uSdo9A5JT2ump5aaSNrg6npzSx5d0Ydv5/MCtKu71La+op6Gg8qbShpncZgwjcMgMBHnHHPmQOY5q3k1FMJJ2st5IbU+Rwl0oHaydfDzWgZJPoPIoJBpa3th7KM1DIyIwWtlIBMYAY71jaPRy6K7bZqbyxlRI+eVzC9zGySFzWFwIcR9BI9GeWFj/ft76ymp6iGWnq2VZglihkD2OPYukHMtyWkDwBz+eKn1X21JUy+R/CRBjjC2TMjA44+EZjczHU8iMA9URet03RR01PDTyVkHk4LYpGVLy9jSACwEk+byHLpyCu6e0UcAaGRlzRB5Ph7i7LM5wc9ScnmViZNTn3vgqIIaSR0peMCsbt83qGkAlx59No6c8d9E2qn9lJPS0BlpYqKKvle+UMLY3hxwBg5cA08sgelFX8WnKKNpa59VK0MEbBLO53ZtDg4NbnpzaPTyCq+x6i8oZMHTgsqHVLGiU7WvdncQPTud7TjCop7zUVNS90FBvoGTup3TiUB4c0lrjsI+KCCM5z6Fb2PUj7pUwA2+WKmqWGSGbzjyxkbwWgNyOmCUF4yxUzXvkM1W6YsEbZXTHexoOQAfX1znPflUO07R7GmOSpinD3yGojlLZHF+N2T4HDeXTkPBZlEGJmsFHLStpi+pFOIuxfGJnESM8HZ6k5OT1OeqyyIgIiICIiAsHU6egrLtW1VU6Qx1EUcWyOV7NzW7sh20jI879Pis4iDGOsdA6oM3YublzXujbI4Ruc3G0lgO0kYHd3DwXw2KgNSycxyFzJXTsb2rtrXuBDnBucDO53tKyiILaKhp4baygja5tMyIQtaHHIaBgDPXp39VaOsNA+GaOVkshlcx73umeX5YctIdnIwemCsoiCwNpozBVRGNxZUua+QmRxcXNa1oOc5BAY3n4jPVQfY9b/AIQ7Ju1fIJjKJ39pvDduQ7OR5vL1LLIgxrLHQxtpgyOVrqdznseJnh2XHLtzs5dk8yDnKhdpu2vPnxSOG2RjWmZ+1jZBh4aM4AOe5ZhEGOr7NR1z2PmEzHtZ2W6GZ8ZLPkktIyPWp6WgpqSZ8lPEI3OjZEcE42sztAHdjcVdIgtHW2lddBcXRZqxF2G/J+JnOMdPpUFFZKGjla+GN/mNLI2vlc9sbT1DQTho5DoskiDH0FmoqDsPJo3tEDXMiDpXP2Ndty0ZJwPNHLuxyVFJY6GkqmVELJQ5hcY2Ome5kZd12sJw3v6DvWTRBja+yUNfO+WoZJukaGSBkr2CVo6B4BAcOZ6+OFJLaaOWnlhfEdkkvbnDyCH5zuBByDy7lfIgx0VloY+zIic58cpnD3yOc5zywsJcScnzSRz9HgqW2OjaXO/3gyFoYJHVDy9rQcgB2cjn7Vk0QYoWC3hzXCOUPG/c/tn7n78btxzzztb18AkVgt0VHNSshd2M1O2keDI45ibuw3Oc8tzllUQYw2OhNX5QY5N3adt2fav7Pf8AK2Z2578468+qop9P0FO4mJs4HZujY3yh+Imu6hgzhn0Yx3LLIgpiYIomRtLi1oDRuJJ5eJPVVIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKkh+eRbj1KpEFOH/Kb7Ew/wCU32KpEFOH/Kb7Ew/5TfYqkQU4f8pvsTD/AJTfYqkQU4f8pvsTD/lN9iqRBTh/ym+xMP8AlN9iqRBTh/ym+xMP+U32KpEFOH/Kb7Ew/wCU32KpEFOH/Kb7Ew/5TfYqkQU4f8pvsTD/AJTfYqkQU4f8pvsTD/lN9iqRBTh/ym+xMP8AlN9iqRBTh/ym+xMP+U32KpEFOH/Kb7Ew/wCU32KpEFOH/Kb7Ew/5TfYqkQEREBEXmr3THEu4Ul0OlLFUvpWRxtfWzRO2vcXDIjBHQYwTjrnHrD0JUX20U0roqm60EMreRZJUMaR9BKi+yWxfhq2fWo/3rwDZrLcL3JO23RNmfEwySbpmMw0AknziMgAEnwVi6CVpIMb84zyGeWcZ9WUR+hrdR2Nzg1t5tpJ6AVTP3rKNcHNDmkFp5gjvX5uPjewZexzRkjJGOY6hdU4GcS7jpTUlFbaypkmsVXK2GSGR2RAXHAezPTBPMdCEHtBW9ZXUlCwPraqCnYeQdNIGA+1Q3aqkp4oYqYA1VTIIYtwyGnBJcfQGhx9OMd6pht1DQB9U+Nr5g0ukqZRukIHM5d1x6ByHcAiovsjsf4Ztv1pn70+yOx/hm2/WmfvSzX203mF8tuqY5WMLQ7LSwjcMt5OAOCDkHvV0+to2VraR8sQqXRulDD12tIBP0Fzfagtfsjsf4Ztv1pn70+yOx/hm2/WmfvWRL4QSC6MEDJ5jkPFQMrqF9TNTsqIDPC1rpGBwy0OztJ9eDhBa/ZHY/wAM2360z96fZHY/wzbfrTP3rIuMTThxYD4HHjhQvq6Rj4mGRhdK7YzaN2TtLu7pyBPNBafZHY/wzbfrTP3p9kdj/DNt+tM/er8S05GRJER6x/8A3ePavpkgGMviGTjqOvggx/2R2P8ADNt+tM/evrdRWRxAbeLcSegFSz96yG+HA86PmCRzHMBW76ygNTFSOmp3Tztc6OLIJeG43YHfjIz60F2xzXtDmEOaRkEHIK+rCV1NFZYJK+3RCGGLz6iCNuGPZ1c4NHRw5nI64wc8sZsEOAIOQeYKAiIgIiICIiAiIgIiICIiAvFvulrPU23inX1UzHCnuDI54X9zgGBpHrBb+jxXtJa5rnRlm1taPe++U/aNad0UrDtkhd4tP7Oh70Hg2x3V9pnqZY42yGelmpSHHGBIwtJ+jK3OTidLLHFHNaonxCLZI3t3czmEjZnOxmYGeaOXN3ox1Sq9zDC6ZxpdVSRxZ81slCHuA9JEgz7FF/sv/wDtb/8Abv8AxURxzVWuJtQ2KG2zUUURjqn1Pah2SNzpHbRyzj4Q9SegxjnnD6Ps1TqDU9stdExzpqmdjPNGdoz5zvUBk/Qu+N9zANw3atJb3gW7H/7V1XhpwtsOgWvmoGyVVykbtfWT4L9vyWgcmj8/iUG0Xo9jUWyqcPgYajEh+SHMcwH+0W+oHPcshVwippZoCS0SsLCR3ZGFXIxskbmSNDmOGHNcMgjwWLNvuFOCy23FjYf5MdXAZtg8AQ5px6yT6UVq1bwwtctjo7fRymmMLdsszoxKZsxdmXHcThwHxSPinoqKnhnTy19XVNuBDpXF7A+nY/mZmS4kJ5yDLMYPccLauwv/AOEbX9Qk/wAZOwv/AOEbX9Qk/wAZBqVZwwhqqqonkuTsyUraUNFOGAACLuYWjGYgRgAjcefIYjreFdPU0Xk4ucgJigjMpi8/MTZGgggg9JOhz0Gc8wtx7C//AIRtf1CT/GTsL/8AhG1/UJP8ZBj75pIXS5UNV5fJEKdkUb29mHdqI5mSt58sedHz9BWFZwut7KNtMytmjZ2YjeY2NaXHspoi75xExOf+kLauwv8A+EbX9Qk/xk7C/wD4Rtf1CT/GQabbeG0sbXiouEUQFU+QCngDWvjMkEgAb0Yd0IHLPIlfYeE1uZQPpH1s0rD2u0yMDj58ewOOScuHXIxk45Bbj2F//CNr+oSf4ydhf/wja/qEn+Mg1V3C+g98GVMdbMwMEzWxtbhrBI+V2GgEAY7Yg8jkAdFf2HQNHZLxR19HOM0/afB9i0Ah8MMZwR0OYA7P/U5ZvsL/APhG1/UJP8ZfRBf887ja8eigk/xkE2oZTFZqsNbvlkjMUTPlvd5rR9JIV7TR9jTxRZzsaG58cBWlJb3tqBU1tQ6qqG/Ey3ayPlg7W/tJJ5nnjkr9AREQEREBERAREQEREBERAREQETKZQEXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzK+5QETKICIiBlQ1VTDSU8lRUyshgjaXPke7a1oHUkqQleafdL6zqJ72zS1FKWUdOxstUGn7ZIebWn0AYPrPoQbrqHj5p6gqHw2qkqrmWnBkaRFGfUTkn2LDN90RCf6NSfXR/cXnSNXDER6Hb7oSE/0ck+uD+4q2+6AhP9HZPrg/uLz7GpmHHVB39vHyI/0ef9cH9xSDjxEf6Pv+tj+4uACQDoMqVsp8AraUzO+jjpEfvA/62P7ikHHCI/eF/wBaH9xcFZMR1AV1FK09eSZZMzuY42Rn7xP+tD+4pG8aIz943/Wh/cXFGdynYors7eMkZ+8j/rP+lSN4wRn7yu+s/wClcbYpO1ax207icZw1pKDsg4uRn7zO+s/6Ui4uQyOe1toflh2u+H78A/J9K5CydvyZPyZ/cp6Xm6R2CA52RkY7gg683iow/eh31j/Sq28UGH71O/L/AOlcrZ0U7EHUW8TGH71u/L/6VWOJLD97Hfl/9K5lGrhiDpI4iNP3td+W/wBKrbxBafvc78t/pXOmKeNB0JuvWn73n8t/kqxrlp/mB/K/5LQWK4Yg3oa1af5ifyv+SkbrFp/mR/K/5LnN6paqttctPQ1jqOoePNma0Ej2rKU7XNia17y9wABcRjJ8UG6t1a0/zM/lP8lI3VLT/ND+U/yWoRqdiDbYtSsc/ElM5rPFr8n2YCzVJVQ1cXaQPDm9/iPWufsUvvo+0TU9QD8G6QMlHi0/u6ok1ZYvLoQK+5VDSCMjmFVlGkbivF3G4l3FnUGf+ZH+rYvZryvGPGvnxY1B+MZ+rYoNPjVwxW8auGKona4NC+hxPVQg5KkYtxDMyVFS2njy4jceg8VjKitmPR7hnnyOFc1EQnrBuGWsCm8ghfzc38651V62bow7xdZ097lj82Rof6+S2KgqY6qESRHl0I7wVin0EDWnaweCksA7GeaEHzfjBWiu82SvDtF2xQSFh8R4K/ErGsDnva1pOMk45rGsV1SuAcGuwQfHxXSqm+rnTPRfsmi/5jP7QUkDmvqHlrg4bW9D6SqWAeAVxGMdFzdFwxTsUDFOxBcM6KdigZ0U7EE8a+1M/YRbg3c4nDRnGTgn9hXyNSSRMmjLJBlp9OEFT2ztic7thkAnDWgfpyp4aXIaZZZnvA5kPLQT6hyULoZXRlgm5EYO5uf0YU8PlTGtBEUhAwXZLc/RgoLnsIy07txGOhecfpXFJ9W1sGuzFC4R0banyd0bGhuRu2l2euc8/wAy7U18wbzhB9DX/vAXO38O5Z9W++mHMg7UTGJ23m8c85BPLPPH0elBg+IWq6ug1JDHayyAQta9/mAlzvDJ545fn9S7ZpquNysdHWEEdtGH4JycEZGVzjV/D6XUN5gqoRJTMDQyTIadzQe7DuvM/R6ufT7RRst9vgpYgAyJoaAOg9CDIxqdigjU7EE7VjtT/wDDW/PH6Csi1WGpBm3s+eP0FceIxowMKrFq2hJw5xfkjq6bSu+Aj+aP0KfKtKU/Ax/NCuMrrGsNIZDyXjPjTz4rag/GM/VsXsqU8l404z/dVv8A+MZ+rYg1GNTZwFDGpT3LUMykZ0UrFEzopWLcMqCMTuOPBTRygu296pd9sHqVbcbv2rz1by9VHdh8fMDyyPpVVqG6te/HRmPzqiMAlw/Orq1AB83LwSjvQzi91lGKZihYpmdF6nkZSB25gPoVyxWlH9qCu2LlO7rGy4Yp2K23tYwuccNAyV9ZVx/Jm/JO/coq/Dg1hc4gNAySegX2KspjIyMVERe84a0PGScZ5exWbqhskexjJi5xA5xOA6+JCybAOXLognjVwxW8auGIFZTNrKOane+RjZWlpdG4tcM+BCu6WMQwsjaXODQAC5xcT6yeqjYp40E7FcMVuxXDEE7O5XDOit2dyuGdEE8alglZIXCN7XFjtrsHOD4H2qKNfKGipqN0zqWCOJ07+0kLBjc4959iC/YrDUn/AA9nzx+gq/arDUn/AA9nzx+grw8z8piejtw/iUujUh+Bj+aFc5VnRn4GP5oV1le2naHKUMvReNeM33VL/wDjGfq2L2VKvGnGf7qd/wDxjP1bEGpxqU9FAzqpm9FYZlKzopWKFpAHNfHVUbCADuPoXSGVzK5o2ZIDicAeKBpPeVjqqVztkvL4N2QPR0V/C8SRhzTjIXHFi03ejBnQa3a/JccLI25oEO4dXEkrDSyuMuwEZwpKSudTO2NAezw78rWFRM/MxjV/pbIxTMWLpLnBNyJ2HPLPespFh2MHIK77POyVKQIhkhXTHDxCxjYIi7nEwn0tCmbTw/8AKj/shcZh0vZe1bh5K7mOo7/SFkGEeKxMcETXAtijBHQhoV2xLGZkmEYVwwjxWNjU8fVWxmZJhHip2EeKxrVM3qmVMzKMI8VPGR4rFsUzOiZTOyge1rS5xAAGSVh9O6ttt7udbRUkhMlO/DcgjtG4GSOXjkfQruNfKSjp6aeolgjaySoeHyEfyiAB+gJlM7PMI5cwp2EY6hYlqmb0TKZ2XjI8QrhhHiFh2KaNMqZ2ZYR4qw1GR73s5/yx+gqhitrx/BG/OH7V4OaR9Jiejvw1V8Wl02j+0x/NCvFZ0n2mP5oV0vZTtDKOVeNOM/3U7/8AjGfq2L2XKvGnGf7qd/8AxjP1bEGos6qdqgZ1U7VWVFUxzmgt5gdQrYAd3q+hZNijlpQ7nHyPgulNVmZhacsjcMt6FXFK/so9pGQOnJRvjew4c0j9qqjJ7M8+7B9K1NMVLTXNOyj40r3nOSMABVMYN3TqqgPZ3lXNNSyTEFrDgnJPQBbi0MTqtoossbyOSeS2mzUr6eDMhO53Pae5Q0FAyna0vw+QDr3D1LKR9Fiuu+kEQmZ1U7VAzqp2rmspmKdigYp2Ii4Z1U8fVQRqePqqJ2qZvVQtUzeqCdimZ0ULFMzoiJ41O3qoI1O3qgnasPqPVNt086lZXy4fPI1gaOZa0nm8+gLMNUdZQU1c2EVcLZRDK2Zm4fFc3oUF9TSsnhZLE4PjeNzXDoQrmNQsU0aInYra8fwRvzh+1XLFbXj+CN+cP2rw808piejvw3i0um0n2mP5oV0rWk+0x/NCul6qdoVHKvGnGf7qd/8AxjP1bF7LlXjTjP8AdTv/AOMZ+rYg1FnVTtUDOqnaqynZ3KdigZ3KdiqJmcxzVYhjPWNvsVEanZ3IiuKGNvxY2j6FdMUDFOxUTsU8fRQNU8fRBMzqp2qBnVTtRJTMU7FAxUVkjo2MLHEElGZm0XZKNTx9VrF81JBYmUgnhmnknB2hmB065J9a+UetbdJUSx1DJ6YRQNne+VnIA7eWBzz5wVu029qmb1WtDV1kAcTXNw1hkJ2O+KDjPTxVbtY2RkkkbK1skzIzJ2bWnLsN3YBxjOO5LpZtLFMzotRt+uLLUUEVTNO6m7SN0vZyMJIaHFpPLI6hXsesrAXyM98Yw6Nu9+WuAAxnPTwS5aW0RqdvVakzXWm+xZL75xlr3Oa3zHZyACRjGe8Ka6avpbXqCjoKlgZTT0r6p1U5+AxrQT8XHPohZtzVM3osDp/Ulpvz52WmsbUugDTJtaRt3Zx1HoKzzeiJKdimjULFNGiJ2K2vH8Eb84ftVyxW14/gjfnD9q8PNPKYno78N4tLptJ9pj+aFdK1pPtMfzQrpeqnaFRyrxpxn+6nf/xjP1bERBpspIheQcHC+W1znb9zienUoirLJsU7ERVE0anYiISnasHHUTe/IZ2smztsbdxxjKIiMpqVxbZJy0kHzeYP/UFk7USbdSknJMbf0IiC/Z1U7URVJTMUVf8Aa2etESWK+607iU49lRMydhgkO3uyMc1qEjnCKoAcQHW6MEZ682IijpTtDM8QyW11JtJGbVGDjv8AOVlZp5WXV8LJZGwuMhcwOIafgj1CInVY2YqWR/vbSDe7ApJGjn3doeXqW1UAB0hrTIBwyk/YiIStdIyPk1Pp9sj3Pa2vIAcc481q2fjJ/GSL+q5v0lETodVzwBkfLcdQvle57y2ny5xyTyeu0t6Ii1GzFW6dimjREZTsVteP4I35w/aiLw808piejvw3i0um0n2mP5oV0iL1U7Qr/9k="
+            },
+            {
+              "timestamp": 6599472100,
+              "timing": 4484,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAMEBQYHCAIBCf/EAFgQAAEDAwIDAwYGDAoIAwkAAAEAAgMEBREGEgchMRNBURQiYXGBkQgVIzJSlBY3RVVyc5OhsbPB0TNCU2J1ktLT4eIYJDQ1NkRGshd04ydUVmaDlaKlwv/EABgBAQEBAQEAAAAAAAAAAAAAAAABAgME/8QALREBAAEDAgMGBQUAAAAAAAAAAAECAxESMQQhQQUyM1FxoRMUIjTwQmGRwdH/2gAMAwEAAhEDEQA/AOqUREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERARfHODWlziA0DJJ6BY9FrjSs1w8hi1FaX1edoibVMJJ8OvX0IMiRCQBknl4rHTrjSza/yI6itIq87ey8rZuz4devoQZEiAggEHIPerVedQ2uyvY261XkjH4xNLG4RD1yY2j2lBdUWBca6r/2SX+po5+Rp2uZLE/qC5vMEK7HV+nrNSUFNd75bqOqdDH8nPUNa7m0cyCeSDJ0UdNUQ1UDJ6aWOaGQbmSRuDmuHiCOqst31jpuz1YpbrfbZSVOcdlNUsa4esE8vagvyKKkqYKynZUUk0c8EgyySNwc1w8QR1UqAiIgIiICIiAiIgIiICIvj3bWkoBcG9SAvgkYejgrXcrjSW+A1FxqoaaHIb2kzwxuT0GSqCj1LY62pZT0d4t89RIcMjjqGOc71AFBkqKCneT5p9inQEREBERBrfjhPM+z2O0NmfT0l4usFDVyMO09i4kubnuzjCyOr0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3p6qs1dp2h1VYp7Xc2u7GTDmvYcPieObXtPcQVh8ui9Z1NEbZVa8e62ub2b3st7G1LmdCO03dcd+MoMEN9uU/A+joXVspZJeBZHV7XYc+m7Ut359LRtytuM0DpVtj+KRYrf5Fs2YMLd3TGd3Xd6c5XubRNkl0SNKmmItLYhE1oPnNIOQ8H6W7nnxWNN0TrRlJ8XN1/L8WhvZhxt7DU7OmO1z1x34ygs3EGqqdCcFDT6dvE1WY5W0bK5zw58MbnkEbh3tHmg9Qti6f05bLfpxlujiFRTzQhs75j2jqjI5ueT84nKjt2jbJRaPbpkUjZrT2ZjfHN5xkyclzj9InnnxVK7T10tllFn0xXtpqbZ2bKite6okp29MMbyzju3OOEGlaeeWn4RcULA2V81us1c+no3uOdsfaDzM+jH51ufROlLNR6TpIzS01c6rp2SVNTMwSOqnOaCXOJ6g55DuCt44Z0FPw1rtJUFTJH5aC6eskbvfJIXAl7hyznGEj0dqO00nkGl9Ux0VtDdscNVQiodTjvEbtw5eAdnCDFNP1c2kP/ABRtVkJdQWeLyyhi+cIHvic9zB6ARnCynhZpKxw6GttS+jpa6quNO2pq6qeNsj53yDc7JI5jJ6K9aL0dR6Zs9VSGWSvqa6R01dVVABfUvd1LvRjkAsdotBah0+ySi0hq3yGzlznRUlXRNqTT5OSGOJBx4A5QQcPoY7BxP1Zpu1jZZmQwV0cAOW08j8hzW+APXC2gsZ0RpGDS8NZI+rnuF0rpO2rK6f58zu4YHINA5ADosmQEREBERAREQEREBERAXicZiK9oeaDHdRipNtPkQrjNuH+xdj2mP/q+bj86sVlbd/jSDyoai7HJ3eVCh7Pofndn5/uWbPhIPm8wvIieT81B9gHygVUvEUYYPSvaAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiLHa6suDNQCGJ7m0oLMgx5GDjPPCxXXFERMutq1N2ZiJ2jLIkWP22qrai4VsMs0jQ0vEQMYAAzyOcftVPQV12lpqyR4cXwxgNaYwNzs9enPksfHjynr7OnytXPnHLHuyhFjNtr7nLQV75d5dHFujcY8HdjmAMc0jqruyyyTzv+Vc5vZnYCQ09cgD9ikX4mM4lZ4WqJmNUbxH8smRWihqauSwSTyl/lIY8tJYAcjOOSpKavrpG2nJkzI57Z8x4zjGO7ktfGjly3Yjh6pmYzHL/ACZ/pkSLGKK4XJ94qIZTJ2DTJszEMcs454UdBcrn8XVktQ57pAwdkOywQScZ6YWY4inynr7Ok8JVEbx09/zmytFjBuFyFkmcTJ5ZFKG7uzGSPVjCVNXdWWeCoZKXTh7mSAR9fA4x3J8xHlO2U+Uq21Rvj8/Zk6KKlbIymjbO/tJQ3znYAyfYpV3h5p5CIiIIiICIiAiIgIiICIiAiIgIiICIiAiKKSpgjcWyTRscO5zgCglRQeWU3/vEP9cKZrg5oc0gtPMEHqg+oiICIsO4icRbLoEUBvrat3lvadl5PGH/ADNuc5Ix84IMxRYtw+1zadeW6prbG2qbDTy9i/yiMMO7APLBPLBWUoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgLiz4TP23rp+Jg/VNXaa4s+Ez9t66fiYP1TUGJ2nQepbvR09VbrY6eGo/gi2aMF3PHIF2eq3XFxmufDe22zS960e4VdDRws3Or9u8bBg47M+kdTzBWrNI6y0tYI7ZPNodtbd6J7ZhXG6zR75Gu3Nd2YBaMYHLpyWZfCXv9sv0OkamKmEV4nt7Kufa/d2ccrWuZGTjmQdxzy/OiNgaw+ELR2Opt8dvsvxi2pooqt7vLOz7IyDOwjY7JAxz9KoLx8ImrtD6WOu0eI5KinZUtabjzDH825+S7xg+1c20bG2+8UD7xSyPpQ6KaSI8jJCcO5H0t6LYHwjKqlreIoqre5j6OagppIXMGAWFmRj2INs1nwkrZT0Vrkjssk9RURukqoo6kYpjuIDdxb5xIGe7GQsF+EPrS1a50/pG52dzw1r6uOWGUYfE/EJwf3hYFR3zT9JoGe1Vmlmy3ycl8N0dMWkNLuRA9GCMDke9Y1NRVMdmpa2QOFJNPLHGT0LmNYXY/rNQb/wDg86utWi+GN+ul7mcyEXEMjjYMvlf2TcNaPHl6lXu+E7SeV7W6YnNLn55rAH48duzGfatFSUtU/hrT1MYcaOK7Sslx0D3Qx7M+xr1dYr3owcLX2uSxTnVpkJFfkbcb8g53Z+b5u3HpQdHag44Wmk0DS6nslE64tkrG0UtLJN2EkDix7/O8130e7kc9eSxJnwl4JLRWznT4hro3Rtp4DWF4l3btxJ2DAaGjxyXBaIpaWqbw3uVUWuFE+60sbSRyc8Q1BOPUCPeFtP4K2nrPf6vUjb3bKSvELKcxioiD9mTJnGemcD3INkTcerRQaKtN2udFIbpcGPeygp37trWvc3c5xxgEt8CfcscoPhOUT6lra7TVRDATzfFViRwH4Ja39K1t8JKyMsnEXsaSkjpLa+kidSxxM2sDeYcABy+duPt9Ksd0uujZ6G1sFsrHyxM+XFKxlJg4HIucZTJz7zt/Yg6R4hca6HTNo09dLTbheKK8MlfG/wAo7HZ2ZYCCNjueXEEcsYWEf6UB/wDhIf8A3H/0ljl5p9BS8LLDUXN18t5jfUyUFvZPHJNOHlgc8ksw1m6PkcDv6rWWkK3TlBezV6ittbcKKM7oqSOZrQ7nyEjscx6ABn8yDuHh3qb7MdG26/Gk8j8sDz2Hadps2vcz52BnO3PTvWRqzaNrqW56TtFdb6RtHSVNLHLFTtAAia5oIby5cleUUREQEREBERAREQEREBERAREQFr3WHCHSurb9Nd7xFVurJmta4xzljcNAA5eoLYSINR/6Pmhf5C4fWj+5VFdwI0ZXTiWqZcpJBGyIE1R5NY0NaOnc1oHsW1EQa61Hwb0hqCopJq6lqWupqaOkjEMxYOzYMNz4nHeuYeO+n6PS+vDaLY6c0dPSxCMTSb3NBBOM+HNdxqhrLNbK2YzVluoqiYjBfLA17seshBpThTw503rThbper1BRvmmpmzsa5kjo9zTM44djmRnPvKz/AFNwq0rqK2Wq31dE+CitgeKaKlk7MN37d2fH5o5+tZrS00FJA2Glhighb82ONga0eoBSoMN03w10zp/T9dZKaiNRba2TtJ4ap3ahxwB39OgWOHgHoI1Pa/F9UG5z2Qq37fV1z+dbVRBh2oOG+mr3pik0/PRGmtVLMJ4oaV3Z4eGubknv5OPVfdA8O7DoSStfYI6hjqwMEvbSl+ducY8PnFZgiCxau0jY9X0DaTUFBHVxsOWOJLXxnxa4YI/asKoOA+g6SqbObbPUbTuDJ6l7me0ZGfUVtJEGCay4U6X1dU0c11ppmGkgFNCymk7JjIwSQAAPSse/0fNC/wAhcPrR/ctuIgorHa6ay2eitlCHClpIWwRB5yQ1owMnvVaiICIiAiIgIiICIiAiIgIiICIiAtD8V+N100VrarslJaaKphgZG4SSvcHHcwO7vWt8Liz4TP23rp+Jg/VNQdY8PL/NqnRdqvVTDHBNWRGR0cZJa3ziOWfUsiXJsvF+46P4d6VsWnGQCt8i7WoqJW7+z3Pdta1vTOOeTnqFQV/HjWw07RwGTyS5iUvNb5NHioiI5Da5uAQe9vUfnDsFFpb4NmuNQa0g1A7UlcKt1K6AQ4hjj27hJn5jRn5o6qH4Q/FG76Kq6C06fbHDVVMBnfVSRh+1u4tAaDyzyOcg9yDd6Li+18V+KM7H1tHXVlZTRuxI4UDJIweuCQzl1Wc6q4632i0Np91LFSxX+4xSTTzdn5sTWyOYNrCTzO09cgY6IOl1rjjVr656DtVFUWmzG4OqXua6Z4cY4cYxu288nJxzHQrnJvGDiXRNhrqi5VBppTljp6KMRSegHYPzFZvqvjXqCs4b2S8WaaK3XF9ZLSVrWQskY8tY1wIDwcAhwKDZ3BHiHdte0txfd7OKLyUsDJ4w4Ry5zkDd3jA7z1Wz1zTw940Xmm0Lqa9amnbcp6SangooRFHCC+QSHB2NHLzcn1LCp+OvEOtnlqaSphhp2c3Rw0THMYPSXAn86DstFzDQ8eL3dOH2oA7sKPUdDHDNT1UMYLJGGaNj8sdkA4f6ufdhWfQ3GXiFcK64QtLr3OKKR8MDaeJgjcC35Vxa0Eho3cs8yQg62Rck8OOPGo6bUVNDqmsZXWqUlshdCxr4+XItLQO/HI5Vvu/G/XuoLvI2wSupISSYqSkpmyvDfSS0knx6D0IOxkXK/C7jjqX7LKC0arfHWUtVO2mc90LY5YXOO0HzQARnGQRlR67+EBqKqvtRR6RbDR0ccpjik7ESyzYOM4dkAHuGPag6sRcnaP8AhAant16gp9WsirKJzwyYmAQzRg/xhtwOXXBHP0LrBjmvY17DlrhkHxCD6iIgIiICIiAiIgIiICIiAuLPhM/beun4mD9U1dpq3VthtFdUOnrbVQVM7sAyTU7HuOOnMjKDhrWOm6+jsGnL4YJH26uoWATBpLWSNLmlhPccAH059Cn1pqrVerdNWuovzWutVJIaenmbA2MPk28+Y6kADOOQXc7KCkZRCjZSwNpANogEYDAPDb0VPNZLVPSxU09soZKaIkxxPgYWMJ64BGAiNA/A5/2XVf4dN+iVffhNahNu1NbqG5WGiutnfRtka6dj2PZLveHBkrCCDgMyOY6cl0DbrXb7YJBbqGlpBJjf2ELY92OmcDn1KqJ4YqiMxzxMljPVr2hwPsKK/PyS/vpLuKnSLa+yNIAEUVa6Rxd+EA0kdORys34s2fVNx03pbVF/o5zJJQmmqJOy2lhbK8sc8D5pc1wOV19S2G0Uk4mpLVQQTDpJFTsa73gK4uaHNLXAFp5EHvRMOEajijquosFssvl0Yo6ANbAG07N2Gt2tBJHPA5LJOI7tRzcJdNVWrHP8pqLhM+nY+FsTmw9m0DIaB1IJ588ELruCx2mnqO3p7XQxT5z2jKdjXe8DKluFsobkxjLjRU1W1hy0TxNkDT6Mjkg4s0Rpqv1Nwr1XHaoX1FTRVtJV9iwZc9oZM0gDvOHZx6Fj2n9W1dgs1wtbKOKUVDjnt5JQIzjB+TDwxx5fxmn9i70t1roLaJBbqGlpBJjeIImx7sdM4HPqVFUWS1VNR29TbKGafr2klOxzveRlBx5QyXy5cKtU19VabbS2iOGCNlVFb44JJZDUxcmuaBkAA57uiqfgy/8AG93/AKGqP+6Ndh1NFS1VIaWqpoJqYgAwyRhzDg5HmnlywFS0VjtNDK6ShtdDTSOaWF0NOxhLT1BIHT0IPz609bX3i/222wkCSsqY6dpPcXuDR+lXvT181Hw01PUS0sZoboxjqeWKphBy0kEjB9LQcjwXc0Gm7HBNHNBZrbHLG4OY9lKwOaR0IIHIqqr7ZQXANFfRUtUG9O2ia/HvCDkThVqTXGqOIFKyiq3SRz1QnrpBTR7GR7svJO3lkZA/MsNuluuvDjXRbXUkgmpJXGPc+SNs8ZyA5r2FrsEHqD6D3hd5UlJT0cQipKeKCMfxImBo9wXmuoKSvjEddSwVMY5hs0YePcUHFOmtQag1PrFsdlsVoqamqkb5ktA2pEY5Dc6STc/A6kucu3IWlkTGuxkNAO0YHsUFDQUdBGWUNJT0zD1bDGGD3AKpRRERAREQEREBERAREQEREBERxDQS4gAdSUBFqD4S17q7dw5gq7Fc56Wb4xjjM1HOWOxskJaXNPoHJYP8F7VV0uN+vY1Bfa2qgZTMLBW1bnta4v7txwDhB0uip4q+kla90VVA9sY3PLZAQ0eJ8F8huFFPII4aunkkd0ayRpJ9mUFSiiqKiCmYHVE0cTScAyODQT7VTvu1ujp5J319I2CPG+QzNDW56ZOcBBWooYKqnqKZtRTzxS07hubKx4c0jxBHJfIa2lnfshqYZHeDJAT+ZBOip566kp5NlRVQRPxna+QNPuK+mtpW04nNTCICcCQvG0n19EE6KCnrKapLhTVEMxbzIjeHY9y+GupGy9m6qgEnTYZBn3IKhFHUVENOwPqJo4mE4DnuDRn2qJlwo5I5Hsq6dzI27nuEgIaPE8+QQVKKlhuNDPTGohrKaSnb1lbK0tHtzheoK+kqH7IKqCV+M7WSBxx7EFQipGXOge9rGVtK57jgAStJJ8Oqq0BERAREQEREBERAREQEREBcq/Cn1jcpNVN01TVEsFupoWSSxscW9tI4Z87HUAYwPHK6qWjuPvCKt1jcIb5px0JuTYxDPTyu2CVoztcHdNwzjn3Y8EGhr5pHVGn+G1Dc6ypg+x+7zRTsp2TbnB+xxY4txgEtJ6H1rF6T/hu5f+Zp/wDtlWzJeC/EOfTOKqGaR1NOI6a2mrY4BhBLpBl+1ozgYHM5PgqrTPBDV1TYr9SXO3NoahzIpaQyzxubJIxxy07XHGWudzPfhEUPBH/g/id/Qb/+2RWn4O/25NO/hT/qJFlGkOEPEWho9QwBhtlPU0MkT4myxSGtOCWxDmdoJ6uJHIlV3BfhbrLT3Eyy3S8WV1NQU5lMspqInbcwvaOTXk9SB0QZt8Lv/gK0/wBJt/VSLSPCnQd61/Q3qgtFxpqSlgfTy1DJ92JHfKBh5A9PP966K+EfpS9au0hbqLTtEaypirmzPYJGMwzs3jOXEDqQrN8GfRGodHP1EdSW51EKoU/Y5ljfv29pu+a44xuHXxQaU4q1l702KDQc9wPklogaJWU7i2OaSQmTcehOA9o59MFWZ2i9RW+Wgntna1E83nsfRtlaYnDB5vc1rc+lpPrW/ePnB+46tu7L/pt0T650bYqimkds7TbyDmuPLOMDBx0C1Yzg3xMvE1NT3OmkZDCBHG+rrmPZE30AOcQPQAgqeM1mv0+iNKai1PSviu7A+3Vb3Oa4yAEuie7aSMkbs+pYZX6vfU8LLXpbJzS3CWod+AWjYP6z5PcF07deFrYOCFRpGheaqvjjNRHIcN7SoDt/LPIA/N9RXPDOCXEFz2g6ec0E4JNVBy//ADQe6aquWjeEdNVW+aSkqtTVcgdNEdr/ACaAAbQeoy956dwWM0GlLpcrE68UjxPh2BCxkr5TzxnIYWjn4uBXVfEbhNFqLhzaLFa5o6ets8bRSvePMfhuHNd4bsA58QtDjg9xOjpn2tlDN8XufvdG2vjELnfSLd/7EEOovsupuD4odUQVIt8dzgfRSVEgc5vyUwczqTjoRnpzVo4e2S43nTGtDRXR1DS0dAKupiazPlIZuIYTkYHInv7uS2HcuBeobdw3MNLC246gqq+GWWCGVrWQwsZKMBzyATl4z7MeKr+FfDXVtk0zrylulodBPcrU6npGGeJ3ayFrxtyHEDqOuAg0BRXOqo6KvpYJntp62MRTRg+a8B7XjI9BaFs/4L/2yZv6Nn//AJUeneBetKu6sgutpNFSvjlBqH1ETmsf2btmQ1xON+0ch3q8aB4P8RLTqoPjxZojG+KWuZLFLmMjBa1uSST3ZAx1yEGseHH2w9L/ANK0v65q79dWUzaoUzqmEVBGREXjefZ1XIGieD+urdrOwV1bYXxUtNcKeaV/lMJ2sbI0uOA/JwAeir7vwY4gVHECeqjIkZJVmZt1NS0bRuyHEZ3AgdwHqQdbovjAWsaHHJAwT4r6iiIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIsX1NqN1rvdBTMlpmQjbJVCVwDix7xG3bz8S5x9DPSgyhFit91HWwU15+LaAOdbyGGaWQBhcWtdyGCTyd6FUzXqWlq52VMMpqRFBtpY3tczfJI9rcOIBydvMnkB078hkKLHau8VUNRbzVwOomdtI2dpIka9jYXvy1w7sgeB5KKi1bHURySPopgwU7qmMROErnNGPNIHzXcxy59/PkgydFbbFdW3aCWRjGN7N207Jmyg8s9WnkfQcKkr7z5DW1TBHPUvD4I2wgtABkJAwevryfUgvqLFJdQ3GS4UFPS0EQeamSmqY5J8Yc2IvAaQ08sbTn2YVTT6ojnuQp2UxMBndTCUSAu3tJBJZ1DcgjP5sc0GRIrBRakEwp5qmjkpaOcyNjmkeOZYCTkDoCGvIP830qmk1NHTtknmjqA58VO6OmeWgB0pfgZxkHzcnPTHL0hlCKw0OpI6gwtmpzCXTmnc7eHMDtm8EOxzBAIzy58sLxBqiGejjnipZ3Oc6UuhHORrGM37sekFmB/PCDIUVrsN4Zd4pXsjYzsyB5kzJOozz2nkfQfzq227VTbhMxtLSbo5w40z+1B3EAkbwBlgOOR5+nB5IMmRWXTlyrKzT0VdcaeKOR0Qk+Tk3bxjOegx6uao6bUtVUup2RWeXtamm8rha6doBj5Z3HuPnN5c+vrwGTIsbfqqEOoXtg/1epbC4OdM1rx2pAbhnU4yM9PRlejqR01TWUtLSt7eESBrZZ2scSzlks+cGnuODnl0ygyJFidNqipjtNqfW0kPl1bAJw0VAawtDWkuJI5HLhhuD61VjU7Hdg5tHOInUzqqaRxAELGkh2fE5HLGcoMhRY3VXmuNtfMaGWjLhG+KQva8FrntBDvB2D05+vkpzqJjL0ygkgA7SR0THNma55cGF/Ng5gENOD16ckF9RYzT6timoqipFK/EQYdglY57dxwN7c5Zjqc8gAfBfZdVxinpTFBG+eo7Qtb5Szs9rCA47xkdXAAYzz7kGSosbm1ZCwUhFLI3t4xJ8tIyIDztpaC44c7I6A9MHPMLJEBERAREQFbqiy0NSa41EIlNa3ZKXc/N27cDwGM9O8kq4qxXC91UNwrKakt3lIpIWTyPMwZlrt3Jowcu808jgelBWfEtGaSuppGvfFWnMwc85cdjWdeo5NHTvUT7BRPbIH9u9z444y90znPGxznNIcTnILic5VF9kpeySrgo99rikZHJUGXDwXbeYZjmBuGeYPXAKqTfQIaWQ0/8AD1ktJjf02dp53Tv7Pp6fQglhsVHG5j5DNPI2R0pfNIXlxLCw5z3bTjHReaTT9JS7tktW4dkYIw+oceyYccmc+XQc+vIc15tl5mrNOC7S0EkYfD28cDHdo97duR0HU+CtFZqWunooJLZBRuk8thgkb5VnAc4cj5mQTnByBjqMoL5BZooKls8dRU9qZBJK4yc5cMLQ13dgZzjxGVNPaqWapfO9ru0c+N5Id3xklv6VbHagqWT1bH28BlLNDBJIJ8gvk7Pk3zckDtO/HQePKSqv0jLlNQUtGJqpszYYw6XY12Yu0JccHAA5dCgqZ7DQzyuke2ZsjqjyrfHM5jg/YGci0g42jGF8isVJFWioY+oDRI6YQds7sg89XbfHmT4ZOeqoX3S8OvVup2UEEcUsMrpmSVGCC17BkEMORh2R0znnjC+zanbFbKKsNKSKmCafZ2nzezYXY6c84wgrqqxUNVaWW2ZjjSsIcBuIPI56+nmD6CQvVbZaOsknkla8SSiMF7XlpaYySwtI6EFxVqqdTVUT4oW2pzqp0IqHxdo47IySG82sPnHB5dOXVV1BepK66ClhopGwinjqHyyu2OZv3YbsxnPm80HqTT1FNbKihnM80dQ8SSyPlJkc4Ywd3djaBy8FN8TUXls9WI3Nmmh7Bxa8tw30Y6HkOY5+aPBU0l9EdW+lNOfKG1Ih27v4mzf2nTptB9owqaO/1csELxb44hWQuloy6ozvw3cA8Bvmnbz5buiC7UFthopppmPlknmDWvklducQ3O0ezJ96p6KxUlHVMmidUFse4xQulJji3ddreg6n1Z5YVss99uctDZG1VBFJVV8AlL45/NDQ1hL3eaMZ3dADzwM94ls2pnXOrga2gmbR1O7sZxuPIAkF42gNBA5YJ7uiC60FrpqGjkpaftRA/Pmvlc8NB7m5J2j0DklPa6anlppI2uDqenNLHl3Rh2/n8wKkq7vUtr6inoaDyptKGmdxmDCNwyAwEeccc+ZA5jmqeTUUwknay3khtT5HCXSgdrJ18PNaBkk+g8igkGlre2HsozUMjIjBa2UgExgBjvWNo9HLoqttmpvLGVEj55XML3MbJIXNYXAhxHsJHozywrf8dvfWU1PUQy09WyrMEsUMgexx7F0g5luS0geAOfzxU+q+2pKmXyP5SIMcYWyZkYHHHyjMbmY6nkRgHqiK1um6KOmp4aeSsg8nBbFIypeXsaQAWAknzeQ5dOQVXT2ijgDQyMuaIPJ8PcXZZnODnqTk8yrTJqc/F8FRBDSSOlLxgVjdvm9Q0gEuPPptHTnjv8Taqf2Uk9LQGWliooq+V75QwtjeHHAGDlwDTyyB6UVXxacoo2lrn1UrQwRsEs7ndm0ODg1uenNo9PIL19j1F5QyYOnBZUOqWNEp2te7O4genc73nGF4p7zUVNS90FBvoGTup3TiUB4c0lrjsI+aCCM5z6FT2PUj7pUwA2+WKmqWGSGbzjyxkbwWgNyOmCUFYyxUzXvkM1W6YsEbZXTHexoOQAfX1znPfleHado9jTHJUxTh75DURylsji/G7J8DhvLpyHgryiC0zWCjlpW0xfUinEXYvjEziJGeDs9ScnJ6nPVXZEQEREBERAVjqdPQVl2raqqdIY6iKOLZHK9m5rd2Q7aRked+nxV8RBbHWOgdUGbsXNy5r3RtkcI3ObjaSwHaSMDu7h4L4bFQGpZOY5C5krp2N7V21r3Ahzg3OBnc73lXREFNFQ08NtZQRtc2mZEIWtDjkNAwBnr07+qpHWGgfDNHKyWQyuY973TPL8sOWkOzkYPTBV0RBQG00ZgqojG4sqXNfITI4uLmta0HOcggMbz8RnqoPset/wAodk3avkExlE7+03hu3IdnI83l6ldkQW1ljoY20wZHK11O5z2PEzw7Ljl252cuyeZBzlQu03bXnz4pHDbIxrTM/axsgw8NGcAHPcrwiC3V9mo657HzCZj2s7LdDM+Mln0SWkZHrU9LQU1JM+SniEbnRsiOCcbWZ2gDuxuKqkQUjrbSuuguLos1Yi7Dfk/MznGOntUFFZKGjla+GN/mNLI2vlc9sbT1DQTho5DorkiC30FmoqDsPJo3tEDXMiDpXP2Ndty0ZJwPNHLuxyXiksdDSVTKiFkocwuMbHTPcyMu67WE4b39B3q5ogttfZKGvnfLUMk3SNDJAyV7BK0dA8AgOHM9fHCkltNHLTywviOySXtzh5BD853Ag5B5dyrkQW6Ky0MfZkROc+OUzh75HOc55YWEuJOT5pI5+jwXltjo2lzv9YMhaGCR1Q8va0HIAdnI5+9XNEFqFgt4c1wjlDxv3P7Z+5+/G7cc887W9fAJFYLdFRzUrIXdjNTtpHgyOOYm7sNznPLc5XVEFsNjoTV+UGOTd2nbdn2r+z3/AEtmdue/OOvPqvFPp+gp3ExNnA7N0bG+UPxE13UMGcM9mMdyuyIPMTBFEyNpcWtAaNxJPLxJ6r0iICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAvJD88i3HqXpEHnD/pN9yYf9JvuXpEHnD/pN9yYf9JvuXpEHnD/pN9yYf9JvuXpEHnD/AKTfcmH/AEm+5ekQecP+k33Jh/0m+5ekQecP+k33Jh/0m+5ekQecP+k33Jh/0m+5ekQecP8ApN9yYf8ASb7l6RB5w/6TfcmH/Sb7l6RB5w/6TfcmH/Sb7l6RB5w/6TfcmH/Sb7l6RB5w/wCk33Jh/wBJvuXpEHnD/pN9yYf9JvuXpEHnD/pN9yYf9JvuXpEBERARFzV8JjiXcKS6HSliqX0rI42vrZonbXuLhkRgjoMYJx1zj1h0JUX20U0roqm60EMreRZJUMaR7CVF9kti+/Vs+tR/vXAFostzvb5ha6KesfEN0nZN3Fo58z7iqBzHNcQ5pBHdhEfolBf7PPI2OC7W+SRxwGsqWEn2Aq5L82iCMEghdA/Br4l3Bl+g0peql9TR1QIpJJXZdC8DOzJ/ikA4HccY6oOpFSVtzoKAgV1bS0xPMCaVrM+8qC5zyPq6e30zzHLO10kkgHOONuAcd24lwA9p7kdDarHRzVT2U9LCwbpZ39T3Zc48yenMlFePsjsf35tv1pn70+yOx/fm2/WmfvVZRVVJXU0dRRyxTQSZ2PYQQcHBX2KopZpZo4pInvhcGSNBBLCQCAfYQfagovsjsf35tv1pn70+yOx/fm2/WmfvVy+TwT5nLqoqeppajtOwlik7N5iftIO1w6tPpQUX2R2P782360z96fZHY/vzbfrTP3q5kMHUNULqiBtSyA57R7HSAhhLcAgHLsYB5jkTk+woKL7I7H9+bb9aZ+9Psjsf35tv1pn71c8M/mr58ngHzMFBbfsjsf35tv1pn70Go7ITgXi25/8ANM/ern8n/N8VA6opPK2UjpIfKJI3SNiJG5zAQCQPAEj3oJ4pGSxtkie17HDIc05BHrXpWist7KCOWttMLYp2AvfDH5rJx1II6bj3O659GQrnTzMqII5onbo5Gh7T4gjIQSIiICIiAiIgIiICIiAiIgLi34S1nqbbxTr6qZjhT3Bkc8L+5wDA0j1gt/R4rtJY5rnRlm1taPi++U/aNad0UrDtkhd4tP7Oh70HBtjur7TU1E0cTJDNTS05DugD2FpPsysvfxLqJawTVFrgljLTujdM/wCd2sco2nOWsDom4YOQBd4rbFV8GGF0zjS6qkjiz5rZKEPcB6SJBn3KL/Rf/wDm3/8AXf8AqojS+s9ZTaoorfTz0jYTSF5DhITkOxyAwAOnXmfT3K88AbLU3ninZTTtd2VHL5XM8DkxrOYz6zge1bSg+DDGJWmfVb3x55tZQBpI9BMh/Qtz8P8AQlk0LbHUlkgdvkwZqiU7pJSPE+HgByQXSoJp9SU0rx8lUwOgDvB7TuA9oL/6q96ktMd9slVbZpHxR1ADXPZ1ABB5e5VtVTxVUDoZ27o3dRnBHgQRzBHUEdFbjR3eIBlLc6dzB0NVSmR+PDLXsB9yKsd10Bb62op3QTzUkUUbYw2MAvbh7n7mPOXNc4uO4584dVQ0fDWnpoxitjc/te0x5FH2Q+TYwkR9A7EYId3Eu7jhZR2F/wDvja/qEn98nYX/AO+Nr+oSf3yDFKjhnDPSXSB9zcfL5o53Zp2hrXsL8Ha0gEkP59x2jl3L1U8M6WWN7Iq1sQNYKxrhSs3B23BzjAd3kZBAz0KynsL/APfG1/UJP75Owv8A98bX9Qk/vkFl1boaPUVdNO+4zU0c0QZJGyNrskRysDgTzHKZ3L0BU9Zw5o5zGIqt0UcUkj44exa6Ib3ROLSw8i3MXT+cSsi7C/8A3xtf1CT++TsL/wDfG1/UJP75BhdFwxMtopaW4XOeLbHtljgA5u7OWIODuRHmydOnJVrOGFs+L6OkmnfM2lJLO0ZuAJmZKcZJwDs29ejisn7C/wD3xtf1CT++TsL/APfG1/UJP75BiJ4U2/yp8wr6oB0T4gz+K1pyA0DOA0A4247s+hXi3aHo7fe6C408rA6kNSGsMDSAyaTtAxp/ihp5DHcSO9XbsL/98bX9Qk/vk7C//fG1/UJP75BX3KqZR0M9RICQxpIaBkuPc0DvJOAB6VFYqR1vslvo3nL6enjiJ8S1oH7F4p7fKZ2z3Gp8qlZzY1rNkbD4huSc+kk+jHNXFAREQEREBERAREQEREBERAREQETKZQEXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzK+5QETKICIiBlQ1VTDSU8lRUyshgjaXPke7a1oHUkqQlc0/CX1nUT3tmlqKUso6djZaoNP8JIebWn0AYPrPoQZrqHj5p6gqHw2qkqrmWnBkaRFGfUTkn3KzN+ERCf+mpPro/sLnSNVDER0O34QkJ/6ck+uD+wvbfhAQn/p2T64P7C59jUzDjqg3+3j5Ef+nn/XB/YUg48RH/p9/wBbH9haAEgHQZUrZT4BXEpqb9HHSI/cB/1sf2FIOOER+4L/AK0P7C0KyYjqAqqKVp68k0yam8xxsjP3Cf8AWh/YUjeNEZ+4b/rQ/sLSjO5TsUVudvGSM/cR/wBZ/wAqkbxgjP3Fd9Z/yrTbFJ2rWO2ncTjOGtJQbkHFyM/cZ31n/KkXFyGRz2ttD8sO13y/fgH6PpWoWTt+jJ+TP7lPS83SOwQHOyMjHcEG3m8VGH7kO+sf5V7bxQYfuU78v/lWq2dFOxBtFvExh+5bvy/+VexxJYfuY78v/lWso1UMQbJHERp+5rvy3+Ve28QWn7nO/Lf5VrpinjQbCbr1p+55/Lf4L2NctP8AyB/K/wCCwFiqGIM6GtWn/kT+V/wUjdYtP/JH8r/gtc3qlqq21y09DWOo6h482ZrQSPerpTtc2JrXvL3AAFxGMnxQZq3VrT/yZ/Kf4KRuqWn/AJQ/lP8ABYhGp2IMti1Kxz8SUzms8WvyfdgK9UlVDVxdpA8Ob3+I9a1+xS/Gj7RNT1APybpAyUeLT+7qiTVpjMthAr7leGkEZHML1lGkbiuLuNxLuLOoM/ykf6ti7NeVxjxr58WNQfjGfq2KDD41UMVPGqhiqJ2uDQvocT1UIOSpGLcQzMlRUtp48uI3HoPFWyorZj0e4Z58jhVNREJ6wbhlrApvIIX83N/OudVfPDdFvMZUdPe5Y/NkaH+vksioKmOqhEkR5dCO8FWp9BA1p2sHgpLAOxnmhB835wVorzOErt4jLIoJCw+I8FXiVjWBz3ta0nGScc1bWKqpXAODXYIPj4rpVTnm50z0V7Jov5Rn9YKSBzX1Dy1wcNreh9JXlgHgFURjHRc3RUMU7FAxTsQVDOinYoGdFOxBPGvtTP2EW4N3OJw0Zxk4J/YV8jUkkTJoyyQZafThB6e2dsTndsMgE4a0D9OVPDS5DTLLM94HMh5aCfUOShdDK6MsE3IjB3Nz+jCnh8qY1oIikIGC7Jbn2YKCp7CMtO7cRjoXnH6VpSfVtbBrsxQuEdG2p8ndGxobkbtpdnrnPP8AMt1NfMG84QfQ1/7wFrt/DuWfVvxphzIO1Exidt5vHPOQTyzzx7PSgsfELVdXQakhjtZZAIWte/zAS53hk88cvz+pbs01XG5WOjrCCO2jD8E5OCMjK1xq/h9LqG8wVUIkpmBoZJkNO5oPdh3XmfZ6uez7RRst9vgpYgAyJoaAOg9CC4xqdigjU7EE7VbtT/7tb+GP0FXFqoNSDNvZ+GP0FceIvRYtVXatoSbc3fojq2bSu+Qj/BH6FPlUlKfkY/wQqjK6xzhpDIeS4z408+K2oPxjP1bF2VKeS404z/bVv/4xn6tiDEY1NnAUMalPctQzKRnRSsUTOilYtwy8EYncceCmjlBdt715d/CD1L23G79q89W8vVR3YfHzA8sj2r1ahurXvx0Zj868RgEuH51VWoAPm5eCUd6GbvdXRimYoWKZnRep5F0gduYD6FUsVJR/wQVWxcp3dY2VDFOxU29rGFzjhoGSvrKuP6M35J37lFV4cGsLnEBoGST0C+xVlMZGRioiL3nDWh4yTjPL3KjdUNkj2MZMXOIHOJwHXxIVzYBy5dEE8aqGKnjVQxArKZtZRzU73yMbK0tLo3FrhnwIVXSxiGFkbS5waAAXOLifWT1UbFPGgnYqhip2KoYgnZ3KoZ0VOzuVQzognjUsErJC4Rva4sdtdg5wfA+9RRr5Q0VNRumdSwRxOnf2khYMbnHvPuQV7FQak/3ez8MfoKr2qg1J/u9n4Y/QV4e0/tLno7cP4lLY1IfkY/wQqnKo6M/Ix/ghVWV7adocpQy9Fxrxm+2pf/xjP1bF2VKuNOM/207/APjGfq2IMTjUp6KBnVTN6KwzKVnRSsULSAOa+Oqo2EAHcfQukMqmVzRsyQHE4A8UDSe8q3VUrnbJeXybsgejoq+F4kjDmnGQuN2MTl6LM8hrdr8lxwrjbmgQ7h1cSSrNLK4y7ARnCkpK51M7Y0B7PDvytWqJn6mL1f6WSMUzFa6S5wTcidhzyz3q6RYdjByCu+zzrlSkCIZIVUxw8QrY2CIu5xMJ9LQpm08P8lH/AFQuMw6Zwratw8ldzHUd/pCuDCPFWmOCJrgWxRgjoQ0KrYmDUuTCMKoYR4q2xqePqrg1LkwjxU7CPFW1qmb1TSmpdGEeKnjI8Va2KZnRNJrXQPa1pc4gADJKs+ndW2293OtoqSQmSnfhuQR2jcDJHLxyPYquNfKSjp6aeolgjaySoeHyEfxiAB+gJpNa/MI5cwp2EY6hWlqp7pcIbXbqitqnbYYGF7v3es9Ewal3uV2obTSOqbjVRU0Df40jsZ9A8T6AsQn4v6Xgm2MkrJhnG+ODzfzkH8y0PqnUVbqK5Pqq2R3ZgnsoQfNjb4D9/erOxkkgcWRucGjJwM4WW3W+mNb2HULxFbbhG6oxnsZAWP8AcevsyrrqJwNvZz/jj9BXGkE0kMzJYXujlYQ5rmnBaR3grf3DrWMmpLC6luDwblSObud/Ks54d6+4+zxXh7T+0uejrY8Sl0fR/wADH+CFWKiojmGP8EKrXtp2hzlHKuNOM/207/8AjGfq2LsuVcacZ/tp3/8AGM/VsQYizqp2qBnVTtVZeKpjnNBbzA6hUwA7vV7Fc2KOWlDucfI+C6U1YZmFJyyNwy3oVUUr+yj2kZA6clG+N7DhzSP2r1GT2Z592D6VqaYqWmuadnj50r3nOSMABemMG7p1XoD3d5VTTUskxBaw4JyT0AW4xDE81NFFljeRyTyWU2alfTwZkJ3O57T3KGgoGU7Wl+HyAde4epXSPosV155QRCZnVTtUDOqnauaymYp2KBinYiKhnVTx9VBGp4+qonapm9VC1TN6oJ2KZnRQsUzOiInjU7eqgjU7eqCdq19xouTINNMomygT1Ezcs7ywZJPvAWwWrH9eWQ33TVVSxtBqAO0hJ+m3mB7eY9qSsbucIWCWeKNzgxrnBpcegyeq2JxRxorXJtOmY/i+O2NiMdTH/DTudGHF7n9SDuI2/N9C11LG6N7mSNLXtJBaRgg+CvjNTVU7qP47iZdo6NobBHU9zR0a57cPLR9HdhYdWScZbfSQXHT90paeKlmvFpgr6mCJoaxsrgQ4taOgOM48cq38J5pItYwMYTtlje1/qAz+kBWHUl9r9SXeW5XWQPqHgNAa0NaxoGGta0cgAO5Z7wbsUpfUXuZhbC0dhCSPnE/OI9WMe0rx9oTjhbmfKXWz4lPq68t/+zx+oKtVFb/9nj9QVavXTtDnKOVcacZ/tp3/APGM/VsXZcq404z/AG07/wDjGfq2IMRZ1U7VAzqp2qsp2dynYoGdynYqiZnMc17EMZ6xt9y8RqdnciPcUMbfmxtHsVUxQMU7FROxTx9FA1Tx9EEzOqnaoGdVO1ElMxTsUDF4rJHRsYWOIJKMzOIyuUanj6rGL5qSCxMpBPDNPJODtDMDp1yT618o9a26SoljqGT0wigbO98rOQB28sDnnzgrlpl7VM3qsaGrrIA4mubhrDITsd80HGenivbtY2RkkkbK1skzIzJ2bWnLsN3YBxjOO5MphlLFMzosRt+uLLUUEVTNO6m7SN0vZyMJIaHFpPLI6hVsesrAXyM+MYw6Nu9+WuAAxnPTwTJiWURqdvVYkzXWm+xZL8Zxlr3Oa3zHZyACRjGe8Ka6avpbXqCjoKlgZTT0r6p1U5+AxrQT83HPohhlzV725Vk0/qS03587LTWNqXQBpk2tI27s46j0FX5vREYDrbh3S32V9ZRPFJXu5uOPMkP84dx9IWu5+GWpY5dkdNDM3Pz2TNA/PgrocNyvbYwphqKphpjTHCOokqGS6gqGMhGCYIDlzvQXd3sytuy0UFBaYaakibFBEQ1jGjAAwVco2YUN3GKNv4Q/avD2nGOEuejrw85u0tm0QxBH+CFVqlpP4GP8EKqXrp2glHKuNOM/207/APjGfq2IiDDZSRC8g4OF8trnO37nE9OpRFWVzYp2IiqJo1OxEQlO1WOOom+OQztZNnbY27jjGUREXTUri2yTlpIPm8wf5wVztRJt1KSckxt/QiIK9nVTtRFUlMxRV/8ABs9aIksV91h3Epx7KiZk7DBIdvdkY5rEJHOEVQA4gOt0YIz15sRFHSnaF54hktrqTaSM2qMHHf5yorNPKy6vhZLI2FxkLmBxDT8keoRE6rGy1SyP+LaQb3YFJI0c+7tDy9SyqgAOkNaZAOGUn7ERCVLpGR8mp9Ptke57W15ADjnHmtWT8ZP+JIv6Lm/SUROh1VPAGR8tx1C+V7nvLafLnHJPJ63S3oiLUbMVbp2KaNERlOxU14/2Rv4Q/aiLw9qfaXPR34bxaWzaT+Bj/BCqkReqnaFf/9k="
+            },
+            {
+              "timestamp": 6600219475,
+              "timing": 5232,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAMEBQYHCAIBCf/EAFMQAAEDAwIDBQMFDAcFBAsAAAEAAgMEBREGEhMhMQdBUWGRFCJxCCMyUoEVFjdTVXKSlKGxs9EzNkJic8HTGCQ0dbInVnTjF0NUY4OTlaKlwuH/xAAZAQEBAQEBAQAAAAAAAAAAAAAAAQIDBAX/xAAtEQEAAQIFAQYGAwEAAAAAAAAAAQIRAwQSITFBBRMUUXGhIjIzNGHwQpHB0f/aAAwDAQACEQMRAD8A6pREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBF8c4NaXOIDQMknoFj0WuNKzXD2GLUVpfV52iJtUwknw69fJBkSISAMk8vFY6dcaWbX+xHUVpFXnbwva2bs+HXr5IMiRAQQCDkHvVqvOobXZXsbdar2Rj8YmljcIh8ZMbR9pQXVFgXbXVf9kl/qaOfkadrmSxP6gubzBCux1fp6zUlBTXe+W6jqnQx/Nz1DWu5tHMgnkgydFHTVENVAyemljmhkG5kkbg5rh4gjqrLd9Y6bs9WKW6322UlTnHCmqWNcPiCeX2oL8iipKmCsp2VFJNHPBIMskjcHNcPEEdVKgIiICIiAiIgIiICIiAiL4921pKAXBvUgL4JGHo4K13K40lvgNRcaqGmhyG8SZ4Y3J6DJVBR6lsdbUsp6O8W+eokOGRx1DHOd8ACgyVFBTvJ90/Yp0BERAREQa37cJ5n2ex2hsz6ekvF1goauRh2nguJLm57s4wsjq9C6YqLC60PstA2h2Fga2FoLeWNwdjId59VWau07Q6qsU9rubXcGTDmvYcPieObXtPcQVh8ui9Z1NEbZVa8e62ubw3vZb2NqXM6EcTd1x34ygwQ325T9h9HQurZSyS8CyOr2uw59NxS3fnzaNuVtxmgdKtsf3JFit/sWzZgwt3dMZ3dd3nnK9zaJskuiRpU0xFpbEImtB95pByHg/W3c8+KxpuidaMpPuc3X8v3NDeGHG3sNTs6Y4ueuO/GUFm7Qaqp0J2KGn07eJqsxyto2Vznhz4Y3PII3DvaPdB6hbF0/py2W/TjLdHEKinmhDZ3zHiOqMjm55P0icqO3aNslFo9umRSNmtPDMb45veMmTkucfrE88+KpXaeulssos+mK9tNTbOGyorXuqJKdvTDG8s47tzjhBpWnnlp+yLtQsDZXzW6zVz6eje452x8Qe5nyx+1bn0TpSzUek6SM0tNXOq6dklTUzMEjqpzmglzieoOeQ7greOzOgp+zWu0lQVMkftoLp6yRu98khcCXuHLOcYSPR2o7TSewaX1THRW0N2xw1VCKh1OO8Ru3Dl4B2cIMU0/VzaQ/wDSjarIS6gs8XtlDF9IQPfE57mDyBGcLKeyzSVjh0Nbal9HS11VcadtTV1U8bZHzvkG52SRzGT0V60Xo6j0zZ6qkMslfU10jpq6qqAC+pe7qXeWOQCx2i0FqHT7JKLSGrfYbOXOdFSVdE2pNPk5IY4kHHgDlBB2fQx2DtP1Zpu1jZZmQwV0cAOW08j8hzW+APXC2gsZ0RpGDS8NZI+rnuF0rpONWV0/05ndwwOQaByAHRZMgIiICIiAiIgIiICIiAvE4zEV7Q80GO6jFSbafYhXGbcP+C4PEx/8X3cftVisrbv91IPahqLg5O72oUPD6H6XD9/0WbPhIPu8wvIieT9FB9gHzgVUvEUYYPNe0BERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEWO11ZcGagEMT3NpQWZBjyMHGeeFiuuKIiZdcLCnFmYieIuyJFj9tqq2ouFbDLNI0NLxEDGAAM8jnH+ap6Cuu0tNWSPDi+GMBrTGBudnr058ljv48p6+zp4WrfeNre7KEWM22vuctBXvl3l0cW6Nxjwd2OYAxzSOqu7LLJPO/wCdc5vDOwEhp65AH+SkY8TF7Ss5WqJmNUcxH9smRWihqauSwSTyl/tIY8tJYAcjOOSpKavrpG2nJkzI57Z8x4zjGO7ktd9G23LEZeqZmLxt/wAmf8ZEixiiuFyfeKiGUycBpk2ZiGOWcc8KOguVz+51ZLUOe6QMHCHCwQScZ6YWYzFPlPX2dJylURzHT3/d2VosYNwuQskziZPbIpQ3dwxkj4YwlTV3VlngqGSl04e5kgEfXwOMdyeIjyni6eEq41Rzb9/DJ0UVK2RlNG2d/ElDfedgDJ+xSrvDzTsIiIgiIgIiICIiAiIgIiICIiAiIgIiICIopKmCNxbJNGxw7nOAKCVFB7ZTf+0Q/phTNcHNDmkFp5gg9UH1ERARFh3aJ2i2XQIoDfW1bvbeJwvZ4w/6G3OckY+kEGYosW7Ptc2nXluqa2xtqmw08vBf7RGGHdgHlgnlgrKUBERAREQEREBERAREQEREBERAREQEREBERAREQFxZ8pn8L10/wYP4TV2muLPlM/heun+DB/CagxO06D1Ld6OnqrdbHTw1H9EWzRgu545Auz1W64u2a59m9ttml71o9wq6GjhZudX7d42DBxwz5jqeYK1ZpHWWlrBHbJ5tDtrbvRPbMK43WaPfI125ruGAWjGBy6clmXyl7/bL9DpGpiphFeJ7eyrn2v3cOOVrXMjJxzIO455ftRGwNYfKFo7HU2+O32X7otqaKKre72zh8IyDOwjY7JAxz81QXj5RNXaH0sddo8RyVFOypa03HmGP5tz813jB+1c20bG2+8UD7xSyPpQ6KaSI8jJCcO5Hzb0WwPlGVVLW9ooqre5j6OagppIXMGAWFmRj7EG2az5SVsp6K1yR2WSeoqI3SVUUdSMUx3EBu4t94kDPdjIWC/KH1patc6f0jc7O54a19XHLDKMPifiE4P8AMLAqO+afpNAz2qs0s2W+Tkvhujpi0hpdyIHlgjA5HvWNTUVTHZqWtkDhSTTyxxk9C5jWF2P0moN//J51datF9mN+ul7mcyEXEMjjYMvlfwm4a0ePL4Kvd8p2k9r2t0xOaXP0zWAPx47dmM/atFSUtU/s1p6mMONHFdpWS46B7oY9mfsa9XWK96MHZa+1yWKc6tMhIr8jbjfkHO7P0fd2480HR2oO3C00mgaXU9konXFslY2ilpZJuBJA4se/3vdd9Xu5HPXksSZ8peCS0Vs50+Ia6N0baeA1heJd27cSdgwGho8clwWiKWlqm9m9yqi1won3WljaSOTniGoJx8AR6hbT+Stp6z3+r1I292ykrxCynMYqIg/ZkyZxnpnA9EGyJu3q0UGirTdrnRSG6XBj3soKd+7a1r3N3OccYBLfAn0WOUHynKJ9S1tdpqohgJ5viqxI4D80tb+9a2+UlZGWTtF4NJSR0ltfSROpY4mbWBvMOAA5fS3H7fNWO6XXRs9Da2C2Vj5YmfPilYykwcDkXOMpk5952/5IOke0LtrodM2jT10tNuF4orwyV8b/AGjg7OGWAgjY7nlxBHLGFhH+1Af+6Q/+o/8AlLHLzT6Cl7LLDUXN18t5jfUyUFvZPHJNOHlgc8ksw1m6PkcDv6rWWkK3TlBezV6ittbcKKM7oqSOZrQ7nyEjscx5ADP7EHcPZ3qb78dG26/Gk9j9sDzwOJxNm17mfSwM5256d6yNWbRtdS3PSdorrfSNo6SppY5YqdoAETXNBDeXLkryiiIiAiIgIiICIiAiIgIiICIiAte6w7IdK6tv013vEVW6sma1rjHOWNw0ADl8AthIg1H/ALPmhfxFw/Wj/JVFd2EaMrpxLVMuUkgjZECao8msaGtHTua0D7FtREGutR9jekNQVFJNXUtS11NTR0kYhmLBw2DDc+Jx3rmHt30/R6X14bRbHTmjp6WIRiaTe5oIJxnw5ruNUNZZrZWzGast1FUTEYL5YGvdj4kINKdlPZzpvWnZbper1BRvmmpmzsa5kjo9zTM44djmRnPqVn+puyrSuorZarfV0T4KK2B4poqWThhu/buz4/RHP4rNaWmgpIGw0sMUELfoxxsDWj4AKVBhum+zXTOn9P11kpqI1FtrZOJPDVO4occAd/ToFjh7A9BGp4v3Pqg3OeEKt+34dc/tW1UQYdqDs301e9MUmn56I01qpZhPFDSu4eHhrm5J7+Tj1X3QPZ3YdCSVr7BHUMdWBgl40pfnbnGPD6RWYIgsWrtI2PV9A2k1BQR1cbDljiS18Z8WuGCP81hVB2D6DpKps5ts9RtO4MnqXuZ9oyM/AraSIME1l2U6X1dU0c11ppmGkgFNCymk4TGRgkgAAeax7/Z80L+IuH60f5LbiIKKx2umstnorZQhwpaSFsEQeckNaMDJ71WoiAiIgIiICIiAiIgIiICIiAiIgLQ/av23XTRWtquyUlpoqmGBkbhJK9wcdzA7u+K3wuLPlM/heun+DB/Cag6x7PL/ADap0Xar1UwxwTVkRkdHGSWt94jln4LIlybL2v3HR/Z3pWxacZAK32Li1FRK3fw9z3bWtb0zjnk56hUFf28a2GnaOAyeyXMSl5rfZo8VERHIbXNwCD3t6j9odgotLfJs1xqDWkGoHakrhVupXQCHEMce3cJM/QaM/RHVQ/KH7UbvoqroLTp9scNVUwGd9VJGH7W7i0BoPLPI5yD3IN3ouL7X2r9qM7H1tHXVlZTRuxI4UDJIweuCQzl1Wc6q7db7RaG0+6lipYr/AHGKSaebh+7E1sjmDawk8ztPXIGOiDpda47atfXPQdqoqi02Y3B1S9zXTPDjHDjGN23nk5OOY6Fc5N7YO0uibDXVFyqDTSnLHT0UYik8gdg/YVm+q+2vUFZ2b2S8WaaK3XF9ZLSVrWQskY8tY1wIDwcAhwKDZ3Yj2h3bXtLcX3ezii9lLAyeMOEcuc5A3d4wO89Vs9c09nvbReabQupr1qadtynpJqeCihEUcIL5BIcHY0cvdyfgsKn7de0OtnlqaSphhp2c3Rw0THMYPMuBP7UHZaLmGh7eL3dOz7UAdwKPUdDHDNT1UMYLJGGaNj8sdkA4f8OfdhWfQ3bL2hXCuuELS69ziikfDA2niYI3At+dcWtBIaN3LPMkIOtkXJPZx28ajptRU0OqaxldapSWyF0LGvj5ci0tA78cjlW+79t+vdQXeRtgldSQkkxUlJTNleG+ZLSSfHoPJB2Mi5X7Lu3HUv32UFo1W+OspaqdtM57oWxywucdoPugAjOMgjKj138oDUVVfaij0i2Gjo45THFJwRLLNg4zh2QAe4Y+1B1Yi5O0f8oDU9uvUFPq1kVZROeGTEwCGaMH+0NuBy64I5+S6wY5r2New5a4ZB8Qg+oiICIiAiIgIiICIiAiIgLiz5TP4Xrp/gwfwmrtNW6tsNorqh09baqCpndgGSanY9xx05kZQcNax03X0dg05fDBI+3V1CwCYNJayRpc0sJ7jgA+efJT601VqvVumrXUX5rXWqkkNPTzNgbGHybefMdSABnHILudlBSMohRspYG0gG0QCMBgHht6KnmslqnpYqae2UMlNESY4nwMLGE9cAjARGgfkc/8Lqv8+m/dKvvymtQm3amt1DcrDRXWzvo2yNdOx7Hsl3vDgyVhBBwGZHMdOS6Bt1rt9sEgt1DS0gkxv4ELY92OmcDn1KqJ4YqiMxzxMljPVr2hwP2FFfn5Jf30l3FTpFtfZGkACKKtdI4u/OAaSOnI5Wb9rNn1TcdN6W1Rf6OcySUJpqiThbSwtleWOeB9Eua4HK6+pbDaKScTUlqoIJh0kip2Nd6gK4uaHNLXAFp5EHvRLOEajtR1XUWC2WX26MUdAGtgDadm7DW7WgkjngclknaO7Uc3ZLpqq1Y5/tNRcJn07Hwtic2HhtAyGgdSCefPBC67gsdpp6jj09roYp854jKdjXeoGVLcLZQ3JjGXGipqtrDlonibIGnyyOSDizRGmq/U3ZXquO1QvqKmiraSr4LBlz2hkzSAO84dnHkse0/q2rsFmuFrZRxSiocc8eSUCM4wfmw8MceX9pp/yXelutdBbRILdQ0tIJMbxBE2PdjpnA59SoqiyWqpqOPU2yhmn68SSnY53qRlBx5QyXy5dlWqa+qtNtpbRHDBGyqit8cEkshqYuTXNAyAAc93RVPyZf673f8A5NUf9Ua7DqaKlqqQ0tVTQTUxABhkjDmHByPdPLlgKlorHaaGV0lDa6Gmkc0sLoadjCWnqCQOnkg/PrT1tfeL/bbbCQJKypjp2k9xe4NH71e9PXzUfZpqeolpYzQ3RjHU8sVTCDlpIJGD5tByPBdzQabscE0c0Fmtscsbg5j2UrA5pHQggciqqvtlBcA0V9FS1Qb040TX49Qg5E7KtSa41R2gUrKKrdJHPVCeukFNHsZHuy8k7eWRkD9iw26W669nGui2upJBNSSuMe58kbZ4zkBzXsLXYIPUHyPeF3lSUlPRxCKkp4oIx/YiYGj0C811BSV8YjrqWCpjHMNmjDx6FBxTprUGoNT6xbHZbFaKmpqpG+5LQNqRGOQ3Okk3PwOpLnLtyFpZExrsZDQDtGB9igoaCjoIyyhpKemYerYYwwegCqUUREQEREBERAREQEREBERAREcQ0EuIAHUlARag+Ute6u3dnMFXYrnPSzfdGOMzUc5Y7GyQlpc0+Q5LB/kvaqulxv17GoL7W1UDKZhYK2rc9rXF/duOAcIOl0VPFX0krXuiqoHtjG55bICGjxPgvkNwop5BHDV08kjujWSNJP2ZQVKKKoqIKZgdUTRxNJwDI4NBP2qnfdrdHTyTvr6RsEeN8hmaGtz0yc4CCtRQwVVPUUzainnilp3Dc2Vjw5pHiCOS+Q1tLO/ZDUwyO8GSAn9iCdFTz11JTybKiqgifjO18gafQr6a2lbTic1MIgJwJC8bSfj0QTooKespqkuFNUQzFvMiN4dj0Xw11I2XhuqoBJ02GQZ9EFQijqKiGnYH1E0cTCcBz3Boz9qiZcKOSOR7KuncyNu57hICGjxPPkEFSipYbjQz0xqIaymkp29ZWytLR9ucL1BX0lQ/ZBVQSvxnayQOOPsQVCKkZc6B72sZW0rnuOABK0knw6qrQEREBERAREQEREBERAREQFyr8qfWNyk1U3TVNUSwW6mhZJLGxxbxpHDPvY6gDGB45XVS0d2+9kVbrG4Q3zTjoTcmxiGenldsErRna4O6bhnHPux4INDXzSOqNP8AZtQ3OsqYPvfu80U7Kdk25wfscWOLcYBLSeh+Kxek/q3cv/E0/wD0yrZkvYv2hz6ZxVQzSOppxHTW01bHAMIJdIMv2tGcDA5nJ8FVaZ7ENXVNiv1Jc7c2hqHMilpDLPG5skjHHLTtccZa53M9+ERQ9iP9T+07/kb/APpkVp+Tv+GTTv50/wDAkWUaQ7Ie0Who9QwBhtlPU0MkT4myxSGtOCWxDmdoJ6uJHIlV3Yv2W6y092mWW6XiyupqCnMpllNRE7bmF7Rya8nqQOiDNvld/wBQrT/zNv8ACkWkeynQd61/Q3qgtFxpqSlgfTy1DJ92JHfOBh5A9Pf9V0V8o/Sl61dpC3UWnaI1lTFXNmewSMZhnDeM5cQOpCs3yZ9Eah0c/UR1JbnUQqhT8HMsb9+3ibvouOMbh18UGlO1WsvemxQaDnuB9ktEDRKyncWxzSSEybj0JwHtHPpgqzO0XqK3y0E9s4tRPN77H0bZWmJwweb3Na3Pm0n4rfvb52P3HVt3Zf8ATbon1zo2xVFNI7ZxNvIOa48s4wMHHQLVjOxvtMvE1NT3OmkZDCBHG+rrmPZE3yAc4geQCCp7ZrNfp9EaU1FqelfFd2B9uq3uc1xkAJdE920kZI3Z+Cwyv1e+p7LLXpbJzS3CWod+YWjYP0nyegXTt17LWwdiFRpGheaqvjjNRHIcN4lQHb+WeQB+j8CueGdiXaC57QdPOaCcEmqg5f8A3oPdNVXLRvZHTVVvmkpKrU1XIHTRHa/2aAAbQeoy956dwWM0GlLpcrE68UjxPh2BCxkr5TzxnIYWjn4uBXVfaN2TRai7ObRYrXNHT1tnjaKV7x7j8Nw5rvDdgHPiFocdj3adHTPtbKGb7nufvdG2vjELnfWLd/8Akgh1F991N2Pih1RBUi3x3OB9FJUSBzm/NTBzOpOOhGenNWjs9slxvOmNaGiujqGlo6AVdTE1mfaQzcQwnIwORPf3clsO5dheobd2bmGlhbcdQVVfDLLBDK1rIYWMlGA55AJy8Z+zHiq/sr7NdW2TTOvKW6Wh0E9ytTqekYZ4ncWQteNuQ4gdR1wEGgKK51VHRV9LBM9tPWxiKaMH3XgPa8ZHkWhbP+S/+Emb/ls//wCqj072F60q7qyC62k0VK+OUGofUROax/DdsyGuJxv2jkO9XjQPY/2iWnVQfHizRGN8UtcyWKXMZGC1rckknuyBjrkINY9nH4Q9L/8ANaX+M1d+urKZtUKZ1TCKgjIiLxvP2dVyBonsf11btZ2CurbC+KlprhTzSv8AaYTtY2RpccB+TgA9FX3fsY7QKjtAnqoyJGSVZmbdTUtG0bshxGdwIHcB8EHW6L4wFrGhxyQME+K+ooiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiLF9Tajda73QUzJaZkI2yVQlcA4se8Rt28/EucfJnmgyhFit91HWwU15+5tAHOt5DDNLIAwuLWu5DBJ5O8lUzXqWlq52VMMpqRFBtpY3tczfJI9rcOIBydvMnkB078hkKLHau8VUNRbzVwOomcaRs7SRI17Gwvflrh3ZA8DyUVFq2OojkkfRTBgp3VMYicJXOaMe6QPou5jlz7+fJBk6K22K6tu0EsjGMbw3bTsmbKDyz1aeR8jhUlfefYa2qYI56l4fBG2EFoAMhIGD1+OT8EF9RYpLqG4yXCgp6WgiDzUyU1THJPjDmxF4DSGnljac/ZhVNPqiOe5CnZTEwGd1MJRIC7e0kElnUNyCM/sxzQZEisFFqQTCnmqaOSlo5zI2OaR45lgJOQOgIa8g/wB3zVNJqaOnbJPNHUBz4qd0dM8tADpS/AzjIPu5OemOXmGUIrDQ6kjqDC2anMJdOadzt4cwO2bwQ7HMEAjPLnywvEGqIZ6OOeKlnc5zpS6Ec5GsYzfux5gswP74QZCitdhvDLvFK9kbGcMge5MyTqM89p5HyP7VbbdqptwmY2lpN0c4caZ/FB3EAkbwBlgOOR5+eDyQZMisunLlWVmnoq6408UcjohJ83Ju3jGc9Bj4c1R02paqpdTsis8vFqab2uFrp2gGPlnce4+83lz6/HAZMixt+qoQ6he2D/d6lsLg50zWvHFIDcM6nGRnp5ZXo6kdNU1lLS0rePCJA1ss7WOJZyyWfSDT3HBzy6ZQZEixOm1RUx2m1PraSH26tgE4aKgNYWhrSXEkcjlww3B+KqxqdjuA5tHOInUzqqaRxAELGkh2fE5HLGcoMhRY3VXmuNtfMaGWjLhG+KQva8FrntBDvB2D05/HkpzqJjL0ygkgA4kjomObM1zy4ML+bBzAIacHr05IL6ixmn1bFNRVFSKV+Igw7BKxz27jgb25yzHU55AA+C+y6rjFPSmKCN89RxC1vtLOHtYQHHeMjq4ADGefcgyVFjc2rIWCkIpZG8eMSfPSMiA97aWguOHOyOgPTBzzCyRAREQEREBW6ostDUmuNRCJTWt2Sl3P3du3A8BjPTvJKuKsVwvdVDcKympLd7SKSFk8jzMGZa7dyaMHLvdPI4HmgrPuLRmkrqaRr3xVpzMHPOXHY1nXqOTR071E+wUT2yB/He58ccZe6ZznjY5zmkOJzkFxOcqi++UvZJVwUe+1xSMjkqDLh4LtvMMxzA3DPMHrgFVJvoENLIaf+nrJaTG/ps4nvdO/h9PPyQSw2Kjjcx8hmnkbI6UvmkLy4lhYc57tpxjovNJp+kpd2yWrcOEYIw+oceEw45M58ug59eQ5rzbLzNWacF2loJIw+HjxwMdxHvbtyOg6nwVorNS109FBJbIKN0ntsMEjfas4DnDkfcyCc4OQMdRlBfILNFBUtnjqKnimQSSuMnOXDC0Nd3YGc48RlTT2qlmqXzva7iOfG8kO74yS396tjtQVLJ6tj7eAylmhgkkE+QXycPk33ckDid+Og8eUlVfpGXKagpaMTVTZmwxh0uxrsxcQlxwcADl0KCpnsNDPK6R7ZmyOqPat8czmOD9gZyLSDjaMYXyKxUkVaKhj6gNEjphBxncIPPV23x5k+GTnqqF90vDr1bqdlBBHFLDK6ZklRggtewZBDDkYdkdM554wvs2p2xWyirDSkipgmn2cT6PDYXY6c84wgrqqxUNVaWW2ZjjSsIcBuIPI56+fMHyJC9Vtlo6ySeSVrxJKIwXteWlpjJLC0joQXFWqp1NVRPihbanOqnQiofFxHHZGSQ3m1h944PLpy6quoL1JXXQUsNFI2EU8dQ+WV2xzN+7DdmM593mg9SaeoprZUUM5nmjqHiSWR8pMjnDGDu7sbQOXgpvuNRe2z1Yjc2aaHgOLXluG+WOh5DmOfujwVNJfRHVvpTTn2htSIdu7+xs38Tp02g/aMKmjv9XLBC8W+OIVkLpaMuqM78N3APAb7p28+W7ogu1BbYaKaaZj5ZJ5g1r5JXbnENztH2ZPqqeisVJR1TJonVBbHuMULpSY4t3Xa3oOp+GeWFbLPfbnLQ2RtVQRSVVfAJS+Of3Q0NYS93ujGd3QA88DPeJbNqZ1zq4GtoJm0dTu4M43HkASC8bQGggcsE93RBdaC101DRyUtPxRA/Puvlc8NB7m5J2jyHJKe101PLTSRtcHU9OaWPLujDt/b7gVJV3epbX1FPQ0HtTaUNM7jMGEbhkBgI94458yBzHNU8mophJO1lvJDan2OEulA4snXw91oGST5HkUEg0tb2w8KM1DIyIwWtlIBMYAY74jaPLl0VW2zU3tjKiR88rmF7mNkkLmsLgQ4j7CR5Z5YVv+7b31lNT1EMtPVsqzBLFDIHsceC6Qcy3JaQPAHP7YqfVfGpKmX2P5yIMcYWyZkYHHHzjMbmY6nkRgHqiK1um6KOmp4aeSsg9nBbFIypeXsaQAWAkn3eQ5dOQVXT2ijgDQyMuaIPZ8PcXZZnODnqTk8yrTJqc/c+CoghpJHSl4wKxu33eoaQCXHn02jpzx3+JtVP4Uk9LQGWliooq+V75QwtjeHHAGDlwDTyyB5oqvi05RRtLXPqpWhgjYJZ3O4bQ4ODW56c2jz5BevveovaGTB04LKh1SxolO1r3Z3EDz3O9TjC8U95qKmpe6Cg30DJ3U7pxKA8OaS1x2EfRBBGc58lT2PUj7pUwA2+WKmqWGSGb3jyxkbwWgNyOmCUFYyxUzXvkM1W6YsEbZXTHexoOQAfj1znPfleHado9jTHJUxTh75DURylsji/G7J8DhvLpyHgryiC0zWCjlpW0xfUinEXBfGJnESM8HZ6k5OT1OequyIgIiICIiArHU6egrLtW1VU6Qx1EUcWyOV7NzW7sh20jI979/ir4iC2OsdA6oM3Bc3LmvdG2Rwjc5uNpLAdpIwO7uHgvhsVAalk5jkLmSunY3iu2te4EOcG5wM7nepV0RBTRUNPDbWUEbXNpmRCFrQ45DQMAZ69O/qqR1hoHwzRyslkMrmPe90zy/LDlpDs5GD0wVdEQUBtNGYKqIxuLKlzXyEyOLi5rWtBznIIDG8/EZ6qD73rf84dk3FfIJjKJ38TeG7ch2cj3eXwV2RBbWWOhjbTBkcrXU7nPY8TPDsuOXbnZy7J5kHOVC7TdteffikcNsjGtMz9rGyDDw0ZwAc9yvCILdX2ajrnsfMJmPazhboZnxks+qS0jI+KnpaCmpJnyU8Qjc6NkRwTjazO0Ad2NxVUiCkdbaV10FxdFmrEXA35P0M5xjp9qgorJQ0crXwxv9xpZG18rntjaeoaCcNHIdFckQW+gs1FQcD2aN7RA1zIg6Vz9jXbctGScD3Ry7scl4pLHQ0lUyohZKHMLjGx0z3MjLuu1hOG9/Qd6uaILbX2Shr53y1DJN0jQyQMlewStHQPAIDhzPXxwpJbTRy08sL4jskl45w8gh+c7gQcg8u5VyILdFZaGPhkROc+OUzh75HOc55YWEuJOT7pI5+XgvLbHRtLnf7wZC0MEjqh5e1oOQA7ORz9Vc0QWoWC3hzXCOUPG/c/jP3P343bjnnna3r4BIrBboqOalZC7gzU7aR4MjjmJu7Dc5zy3OV1RBbDY6E1ftBjk3cTjcPiv4e/62zO3PfnHXn1Xin0/QU7iYmzgcN0bG+0PxE13UMGcM+zGO5XZEHmJgiiZG0uLWgNG4knl4k9V6REBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAXkh+eRbj4L0iDzh/1m+iYf9ZvovSIPOH/Wb6Jh/wBZvovSIPOH/Wb6Jh/1m+i9Ig84f9ZvomH/AFm+i9Ig84f9ZvomH/Wb6L0iDzh/1m+iYf8AWb6L0iDzh/1m+iYf9ZvovSIPOH/Wb6Jh/wBZvovSIPOH/Wb6Jh/1m+i9Ig84f9ZvomH/AFm+i9Ig84f9ZvomH/Wb6L0iDzh/1m+iYf8AWb6L0iDzh/1m+iYf9ZvovSIPOH/Wb6Jh/wBZvovSICIiAiLmr5THaXcKS6HSliqX0rI42vrZonbXuLhkRgjoMYJx1zj4h0JUX20U0roqm60EMreRZJUMaR9hKi++Wxflq2frUf8ANcAWiy3O9vmFrop6x8Q3ScJu4tHPmfQqgcxzXEOaQR3YRH6JQX+zzyNjgu1vkkccBrKlhJ+wFXJfm0QRgkELoH5NfaXcGX6DSl6qX1NHVAikkldl0LwM7Mn+yQDgdxxjqg6kVJW3OgoCBXVtLTE8wJpWsz6lQXOeR9XT2+meY5Z2ukkkA5xxtwDju3EuAH2nuR0NqsdHNVPZT0sLBulnf1PdlzjzJ6cyUV4++Ox/lm2/rTP5p98dj/LNt/WmfzVZRVVJXU0dRRyxTQSZ2PYQQcHBX2KopZpZo4pInvhcGSNBBLCQCAfsIP2oKL747H+Wbb+tM/mn3x2P8s239aZ/NXL5vBPucuqip6mlqOJwJYpOG8xP2kHa4dWnzQUX3x2P8s239aZ/NPvjsf5Ztv60z+auZDB1DVC6ogbUsgOeI9jpAQwluAQDl2MA8xyJyfsKCi++Ox/lm2/rTP5p98dj/LNt/WmfzVzwz+6vnzeAfcwUFt++Ox/lm2/rTP5oNR2QnAvFtz/4pn81c/m/7vioHVFJ7WykdJD7RJG6RsRI3OYCASB4AkeqCeKRksbZIntexwyHNOQR8V6VorLeygjlrbTC2KdgL3wx+6ycdSCOm49zuufLIVzp5mVEEc0Tt0cjQ9p8QRkIJEREBERAREQEREBERAREQfMri35S1oqbd2p19VMxwp7gyOeF/c4BgaR8QW/u8V2eXLGtdaQs2tbT7BfKcyNaS6KVh2yRO8Wn/Loe9BwlY7q+01FRNHGyQy00tOQ7oA9haT9mVl7u0uolrBNUWyCWMtO6N0z/AKXFjlG05y1gdE3DByALvFbTqvkzQOmcaXVMkcWfdbJQh7gPMiQZ9FF/syj/AL2//jv/ADURpzWes5tUUVvp56RsJpC8hwkJzuxyAwAOnXmfPHJXjsBs1TeO1Oymna7hUUvtczwOTGs5jPxOB9q2fB8maIStM+qnvjzzayg2kjyJkP7luTQGiLJoa2OpLJC7fJgzVEp3SSkdMnw8AOSC9VDjT6kppXj5qpgdAHeD2ncB9oL/ANFe9SWqO+2Sqts0j4o6gBrns6gAg8vRT1UUVVA6Gdu6N3UZII8CCOYI6gjorcae7RDZS3OncwdDVUpkfj4te3PoirVddA2+tqKd0E81JFFG2MNjAL24e5+5jzlzXOLjuOcuHVUNH2b09Mwf76xz+LxCPYouEPm2MJEfQOxGCHdxLu44WRcO/flG1/qEn+snDv35Rtf6hJ/rIMZqOzSGejukD7m8+3zRzuzTtDWvYX4dtaQCSH8+47Ry7l6qezSlkjeyKtbEDWCsa4UrA4O24OcYDu8jIIGehWScO/flG1/qEn+snDv35Rtf6hJ/rILXq3Q8eoq6ad9xnpo5ogySNkbXZIjlYHAnmOUzuXkFTVnZ1RzmMRVboo4pJHxw8FrohvdE4tLDyLcxdP7xKvvDv35Rtf6hJ/rJw79+UbX+oSf6yDEaLsyMtnpaW4XOeLbHtljgA5v4csQcHciPdk6dOSrGdmNs+59HSTTvmbTElnEYHAEzMlOMk4B2bevRxWRcO/flG1/qEn+snDv35Rtf6hJ/rIMWPZVb/anzC4VQDonxBn9lrTkBoGcBoBxtx3Z8leLdoijt97oLjTSsDqQ1IbGYGkBk0nEDGn+yGnkMdxI71ceHfvyja/1CT/WTh378o2v9Qk/1kF1uVUyjoZ6iTJDGkhoGS49zQO8k4AHmorFSut9kt9G85fT08cRPiWtA/wAlS09FIZ2z3CpNTKzmxoZsjYfENyTnzJPljmrjvQT5TKg3pvQT5TKg3pvQT5TKg3pvQT5TKg3r7vQTZX3KiD16DkHtF8BX3KCmAc/oEMUnl6qpAAGAiCk4Mvl6pwZfL1VWiCk4Mvl6pwZfL1VWiCk4Mvl6pwZfL1VWiCk4Mvl6pwZfL1VWiCk4Mvl6pwZfL1VWiCk4Mvl6pwZfL1VWiCk4Mvl6pwZfL1VWiCk4Mvl6pwZfL1VWiCk4Mvl6pwZfL1VWiCk4Mvl6pwZfL1VWiCk4Mvl6pwZfL1VWiCk4Mvl6pwZfL1VWiCk4Mvl6r6IZPL1VUiCmEUg7h6oCQcFVKjqB7m7vCD41y95VOxymygkREQEREFHdaz2KkMg5uPJufFW+y3o1lRwJMF5yRgYwFdqqliqmbZm7hzCt1rscVBVunErnnGGgjGF8vMU53xVFWDMd31/D04c4PdVRX83Rig7RDHqirt09HCKOlqZIJpWSudJE1ke/iubtwG93Xqq6o7SLFTUwlqfbIXGRsfClgLH+83c12D3Ecx4/FZHFZaCKC4QNpwYq+R8tS1xJEjnANd6gBWZ+gbDJQyUskNS+OQgvc6qkL3gN2hpduyWhvIBfUeZ8fr2yi4VtFG6eWekY57wyPOduNwHPuDgT9vgqyLVdtfZLfdn8eGirpBHG+WMt27s7S4dwOOR8x4qlqdBafqGVcb6WVsVU3ZLHHUSMaR7ucAHkTtGfH7SrhPpq21OnnWSrjmqbe4YLJ53yOIByPfJLuRAxzQWsdoFkLosmrET2tJlNO7Yxzmb2sce5xbzA8x4qqtWsrRctOVd8gle2gpQ4yue3mA0ZPIZzyK91Gj7NUXAVklM8P93LGzPbGXNbta4tBxuDeQPXp4L1QaSs9Fa6+3xUznU1fn2kSSOe6T3dvMk56DCCji13aH8cSNq4JIGyvkjlhLXN4cYkdy/NcFTy9o+nopaqN08uaeEzOIjJyAGuIHmA4ft8CvNP2d2oOrhWPqqmOomdI3dPIHta6Jsb2l+7LgQO9XBuirIySofHTzR8ePhvDKiRoxgDIAPJ2Gjn15ILRVdo9F80aKknkikpDViZ4wwASiPBIz3nqOXTxVbN2gWSF8wkNVtjyGPEDtsxa8Ru4Z/tYc4AqWPQVgjjYxtLKGtY9h+ff74c8PO7nz94AqT7x7EZ5ZXUsjt7i4MdM8sjJeJHbG5w3LmgnHVBTRdoFkkrKCl3VLKiskfE2N8W0se1+xwd5h3hnxVbdtUU1r1NbbTUgt9t91j8H6ZPujzzg/Dl4rxPoqyTzRySU0hLJ3VO0Tv2mQv3klucH3uaqK/S1qr73DdqmF7q2Ixua4SuAywktJaDg4yfVBZdQaxrbZUXoU9rZUU1rbvmlM23AMW9vLHeeX7VPRa2gqdbusHCa1nDIbPxAd0wa17o9v5rs58iO5XqrsFuq47myeAubcmhtUN5G8AbR38uXgqSHR1hhniqI7fE2qiqDVNqBni8Qk5Jf1I5nkTjHJBWzags0Er4p7vbo5WHa5j6lgLT4EE8lQ33UYpoLaLMyC4VFxnMFORMBFkNc5zi8Z5ANPTPNXh9BRveXPpKdzickmMEn9ipLvYrfdaKKlqYS2OGQSxOgeYnRPGfea5uCDzPTxQWG266glk9krqKpZc455IJoKZhnDNhaC/IH0ffbzxnn05KO59oltp6aofSQ1E8kTmbA6JzROwzNic6M497Bd+5XBuh7E2OnaynmaYi4l7aiQPl3ODncR2cvyQCd2ei8nQlgcKgOpZS2b+yZ34jHEEmGc/cG8A8sdEEMnaDZI2Rud7WHe9xmcBxdTBr9hMn1Ru5KotesKSs0++71FPUUtMyrfSne3OCJTGHfDPXw5+C+P0JYXiEOppfc3Bx478zBz95Ehz74LufvZVwh07bYrRW2wQudQ1bpXyxOe4jMhJdjn7oySeXeUFr+/6ycaJjXVL2PcGmVsJLIwZDG1zj3Nc4EA9/VeaztAsdJRe1TST8Lh8UYj7uKYvs94Hqqp+irG6SicKRzW0kcUTI2SuDHNjOYw9oOHbTzGc81GNDWNonDIahvGG0ltTINo3l+G+97o3EnA8UF+tldDcrfT1tKXGCdgkYXDBwVLU8oHKC0W2ltFtgoaCPhU0LdrG5JwPiVFf6wUFqmqXjLGbd3wLgChM23eonclPnzVHA7IBCqcoKpERAREQYTrTUN6teobZR2ymY6lmaC5743OEji8NLAR9EhpJ7/QFY5Jrq+RsqPauDStFwjpYJX0UhEkDi8cYDPP6OMDwz0IW2VDU0sFUYvaImScKQSx7hna8dHDzQaoi1BqSasiq5KWpL3spHCna17GOOKnJA7t22MkHpkZU9o15d5J2ip4U8EclMKh8dHIwx8SOVzmlvM8nta3K2soY6WCOpmqI4mNnmDWyPA5uDc4z8Mn1Qa50xq7Ulxv8AaaauoWQU9RBG+VroXNJ3Rlzng92HYbg+vRT3PU+pKO8Vop6JlTSMnqIIYRA4OdspxI127PPLst6ftWxUQaik1ZqWV1HURzNfSxzyt4zKJ7GVJ9n3taWk5GH5bnvPwV0otS6obqGz0VZTwuhqYYZZHCnc0P37i4A5OCwADn178ZC2SiDWWrdbXm1X+609HTh1JS0szwZadwAc2AyNduB5gkY6DwVtl19fWtgbxKdscxl4dUaCXDy2Fr9gZnPJ52581tqqp4aumlp6mNssErCyRjhkOaRgg+S8GipnTU8pgjMlOC2F2ObARg48OQCDXcmqdTCiqKuoihooRVxUrt1I+Q0zXRNe6RwBy4Bx2cvHPcqZurdRVkT4quI0Ej6LfFE2jlc+dxY8l7XD6GCG8j0zz6hbVRBqGXVmrLbaooHQsmkY2DNW+meQA6DftcM8zuG3Pn0ys4ul9qRpK4VlvbH91aSICSJ7HubHLta4twBk4DvD496yZeWRsYXFjWtLjudgYyfEoNUnXl+9ksz20b+NMfn2voyGvbxgwlrg49G5PIefIcl9m1fquGhqJHQU+91MKiMmmeBH8+Yy08zk7QDk4HjyW10QYBdtWXCn0pp2vy2jnuErY53z0rnGMFjiTw2knq0d55Kxxah1NNcLbUyxy0YlkpTUQ8Jxa7fDIS3n9EFwaPIkZ6LatRSwVL4XzxMkdC/iRlwzsdgjI88EqZBqinv+pLqLO+GqEVVxnunYKCVjIT7NI4xPDj7+HADORzwrtqbUd6ZpayVNLF7LLX0rn1Ens75TFJwdzYw0cwXO5AnphbBRBrbRWo9Q1V+pLbcKbbStp2bjLG4SEcFjuLu6HLiRg49UvOqdUUlReaeC3NcLc4fP8FxbIyR7eG5ozz2sLy7zb3LZKINXwar1TIaWQ08HCDad0gFM/wCdElQ6MkHPu+4Gu7/RUdm1XqmKqtlHUNFRvneyWSWmc0v+fc1zAR9HawBw5d47ua24iCGjqYqymjqICTE8ZaS0tPoeas2vf6pXH8wf9QV/Vh13j71Lhn6g/wCoLni1xh0TXPSLmma/hjqkoD/u8f5oVflW6h/oI/zQrgOi3G8CaCoZI0e8A7vBX11TA1xa6aIOHUF4BVmnauPu2F7x2oX0BzgBIzln/wB2xUds+10/4+L9MJ7XT/j4v0wvz7ZJJ9d3qpTJJy993qiXd/8AtdP+Pi/TCe1U/wCPi/TC4Da9/wBd3qpWPf8AXd6rWlNTvf2qn/HxfphPaqf8fF+mFwS57+IPfd08V6bI/P03fHK5zVabOtNF4u709qp/x8X6YT2qn/HxfphcFMe4lw3u9VUWxz90vvO7u9KZvNkqp0xd3d7TB+Oi/SCe0wfjo/0guI2vf9Z3qpmuf9Z3quuhy1u1vaIPx0f6QX32iH8bH+kFxxSOfwx7zvVVbHP+sfVYlqJdee0Q/jY/0gnHh/Gx/pBckbyxhc55AAyea9Mqxn/1/wD8t/8AJC7rXjw/jY/0gvntEGQONHz/ALwXJzqjiM2ME5c4gf0bh3+JCuLdxxzPqhd1Dx4vxrP0gvvGi/GM/SC5kZu+sfVTs3fWPqhd0pxovxjP0gnGj/GM/SC5yZu8T6qZm7xKF3Q/Fj/GM/SCcWP8Yz1C5/YHeJU7A7xKF2+eLH+MZ6r7xGfXb6rRbAfEqdgPiUG7RIwnAe0n4r0tMxb2ua5rnBwOQQeizm16qaLc4VoLqlgw3A/pP5IrK3yMjGXua0eJOFgfaPeGTWsUlI/e10g4jh0PfgeioKyrmr6l09Q4knoO4DwCteoG/wC4M/xB+4rw9pTbK4lvJ1wN8SlsWh/oY/zQrgOgVBQj5iP80KvHRe2niHKVJM3kuOO2Qf8Aalfv8Rn8Ni7MmHVca9s/4U7/AP4jP4bEkYizqpSOQULOqnCsMy9MHNTNCibgcyjqqNhAB3HyXSGU0u0bMnBJwPNAwnvOFQVUrnbJcDMbsgeXRV8LxJGHN5ZXHFi0vRgzs8tZtdnccK4W9oEO4dXEkq1SyEy7ARnC90tc6mdsAD2eGeYK1hUTPxMY1f8AFkLApmNVtpLlBNyJ2HOBnvV1iw4DaQc94Xe1nnV1MAIxzCqmY8QqBtPETziYSf7oUzaeH8VH+iFxmHS9lTV49mfzHd+8KvYArdFTxNcC2KMEd4aFVsCWNStYAp2AdyomBTsCWNStY1TsaFRMCmYFdKalewBTsAVAwKZgTSa1cNrWlziAAMkq0ae1Tbr1cqyipJCZKd+G5BG9uBkjl45H2K4MC+UlFBTTVEsEbWSVDw+Qj+0cAfuCaTWu7GhTsAVAwKC618Nrt1RW1TtsMDC938vieiWNS43G5UVqpHVNxqYqeBvV0jsfYPE+SxGfta0xBNsZJVzNBxvjh939pB/YtG6p1DW6iuL6qtkPDyeFCD7sbfAfz71aGMkkDiyNzg0ZOBnCy26w0zrOw6geI7bXxunxngyAsf6Hr9iu+ocGgZj8YP3FccwTSQzMlhe6OVhDmuacFpHeCt+9nWsH6ksLqWveDcqRzdzu+VnPDvj3H/8Aq8Paf2mJ6OuB9Sl0bRD5mP8ANCrVR0X9DH+aFWL208Q5yjlXGnbP+FO//wCIz+GxdlyrjTtn/Cnf/wDEZ/DYgxFnVTNULOqnaqy8VUbnMBbzA6hUwaOv2fYrmxRy0odzj5HwXSmq3LMwpOWRuGW9Cp6V/Cj2kZA6cl4fG9hw5pH+a9Rk8M8+7B81qaYqWmuaeHj6Ur3nOSMABfWRjd06r2B6d5VTTUskxBaw4JyT0AW4tDE7qaKLLG4ByTyWUWaldTwZkJ3O57fBRUFAyna0vw+QDr3D4K6R9Fiuu+0ER1TM6qdoUDOqnauaymYp2KBinYiJ2dVOwc1DGp4+qomaFM3qomqZvVBMxTsULFMzoiJ4wpmqGNTt6oJmrX/bPco4NNMomygT1Ezcs7ywZJPqAtgtWP68shvumqqljaDUAcSEn67eYH28x9qSscucIWCWeKNzgxrnBpcegyeq2J2o40Vrk2nTMf3PjtjYjHUx/wBNO50YcXuf1IO4jb9HyWupY3RvcyRpa9pILSMEHwV8ZqaqndR/duJl2jo2hsEdT3NHRrntw8tH1d2Fh1ZJ2y2+kguOn7pS08VLNeLTBX1METQ1jZXAhxa0dAcZx45Vv7J5pItYwMYTtlje1/wAz+8BWHUl9r9SXeW5XWQPqHgNAa0NaxoGGta0cgAO5Z72N2KUvqL3MwthaOBCSPpE/SI+GMfaV4+0JtlcS/lLrg/Up9XXlv8A+Hj+AVaqK3/8PH8Aq1euniHOUcq407Z/wp3/APxGfw2LsuVcads/4U7/AP4jP4bEGIs6qdqgZ1U7VWU7O5TsUDO5TsVRMzmOa9iGM9Y2+i8RqdnciPcUMbfoxtH2KqYoGKdionYp4+igap4+iCZnVTtUDOqnaiSmYp2KBi8Vkjo2MLHEElGZm0XXKNTx9VjF81JBYmUgnhmnknB2hmB065J+K+UetbdJUSx1DJ6YRQNne+VnIA7eWBzz7wVu0y9qmb1WNDV1kAcTXNw1hkJ2O+iDjPTxXt2sbIySSNla2SZkZk4bWnLsN3YBxjOO5LpZlLFMzosRt+uLLUUEVTNO6m4kbpeHIwkhocWk8sjqFWx6ysBfIz7oxh0bd78tcABjOengly0sojU7eqxJmutN8Fkv3TjLXuc1vuOzkAEjGM94U101fS2vUFHQVLAymnpX1Tqpz8BjWgn6OOfRCzLmr3tyrJp/Ulpvz52WmsbUugDTJtaRt3Zx1HkVfm9ERgOtuzulvsr6yieKSvdzcce5If7w7j5ha7n7MtSxy7I6aGZufpsmaB+3BXQ4ble2xhSzUVTDTGmOyOokqGS6gqGMhGCYIDlzvIu7vsytuy0UFBaYaakibFBEQ1jGjAAwVco2YUN3GKNv5w/zXh7Ti2UxPR1y83xaWzaIYgj/ADQqtUtJ/Qx/mhVS9dPEEo5Vxp2z/hTv/wDiM/hsREGGykiF5BwcL5bXOdv3OJ6dSiKsrmxTsRFUTRqdiIhKdqscdRN92QziybONjbuOMZRERdNSuLbJOWkg+7zB/vBXO1Em3UpJyTG39yIgr2dVO1EVSUzFFX/0bPiiJLFfysO7SnHhUTMnYYJDt7sjHNYhI5wiqAHEB1ujBGevNiIo6U8QvPaGS2upNpIzaowcd/vKis08rLq+FksjYXGQuYHENPzR6hETqscLVLI/7m0g3uwKSRo593EPL4LKqAA6Q1pkA4ZSf5IiEqXSMj5NT6fbI9z2tryAHHOPdasn7ZP6yRf8rm/eUROh1VPYDI+W46hfK9z3ltPlzjknk9bpb0RFqOGKuU7FNGiIynYqa8f8I384f5oi8Pan2mJ6O+W+rS2bSf0Mf5oVUiL1U8Qr/9k="
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAMEBQYHCAIBCf/EAFUQAAEDAwIDAwgECgcEBQ0AAAEAAgMEBREGEhMhMQdBURQiUmFxgZGhCBUjMhY3VXJzlLGzwdEkMzRCYnXTGDaSshcnU3TjJlRWZoKDk5WipcLh8P/EABkBAQEBAQEBAAAAAAAAAAAAAAABAgMEBf/EAC0RAQABAwIDBgUFAAAAAAAAAAABAgMREjEEIUEFEzNRcaEUIjTR8DJCYZHB/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEXxzg1pc4gNAySegWPRa40rNcPIYtRWl9XnaIm1TCSfDr19SDIkQkAZJ5eKx0640s2v8iOorSKvO3heVs3Z8OvX1IMiRAQQCDkHvVqvOobXZXsbdaryRj8YmljcIh7ZMbR7yguqLAu2uq/6pL/U0c/I07XMlif1Bc3mCFdjq/T1mpKCmu98t1HVOhj+znqGtdzaOZBPJBk6KOmqIaqBk9NLHNDINzJI3BzXDxBHVWW76x03Z6sUt1vtspKnOOFNUsa4e0E8vegvyKKkqYKynZUUk0c8EgyySNwc1w8QR1UqAiIgIiICIiAiIgIiICIvj3bWkoBcG9SAvgkYejgrXcrjSW+A1FxqoaaHIbxJnhjcnoMlUFHqWx1tSyno7xb56iQ4ZHHUMc53sAKDJUUFO8nzT7lOgIiICIiDW/bhPM+z2O0NmfT0l4usFDVyMO08FxJc3PdnGFkdXoXTFRYXWh9loG0OwsDWwtBbyxuDsZDvX1VZq7TtDqqxT2u5tdwZMOa9hw+J45te09xBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHfjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fW0bcrbjNA6VbY/qkWK3+RbNmDC3d0xnd13evOV7m0TZJdEjSppiLS2IRNaD5zSDkPB9Ldzz4rGm6J1oyk+rm6/l+rQ3hhxt7DU7OmOLnrjvxlBZu0GqqdCdihp9O3iarMcraNlc54c+GNzyCNw72jzQeoWxdP6ctlv04y3RxCop5oQ2d8x4jqjI5ueT94nKjt2jbJRaPbpkUjZrTwzG+ObzjJk5LnH0ieefFUrtPXS2WUWfTFe2mptnDZUVr3VElO3phjeWcd25xwg0rTzy0/ZF2oWBsr5rdZq59PRvcc7Y+IPMz6sfNbn0TpSzUek6SM0tNXOq6dklTUzMEjqpzmglzieoOeQ7greOzOgp+zWu0lQVMkfloLp6yRu98khcCXuHLOcYSPR2o7TSeQaX1THRW0N2xw1VCKh1OO8Ru3Dl4B2cIMU0/VzaQ/6UbVZCXUFni8soYvvCB74nPcweoEZwsp7LNJWOHQ1tqX0dLXVVxp21NXVTxtkfO+QbnZJHMZPRXrRejqPTNnqqQyyV9TXSOmrqqoAL6l7upd6scgFjtFoLUOn2SUWkNW+Q2cuc6Kkq6JtSafJyQxxIOPAHKCDs+hjsHafqzTdrGyzMhgro4Actp5H5Dmt8AeuFtBYzojSMGl4ayR9XPcLpXScasrp/vzO7hgcg0DkAOiyZAREQEREBERAREQEREBeJxmIr2h5oMd1GKk20+RCuM24f2Lg8TH/AL3zcfNWKytu/wBaQeVDUXByd3lQoeH0P3uH5/wWbPhIPm8wvIieT91B9gH2gVUvEUYYPWvaAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiLHa6suDNQCGJ7m0oLMgx5GDjPPCxXXFERMutq1N2ZiJ2jLIkWP22qrai4VsMs0jQ0vEQMYAAzyOcfxVPQV12lpqyR4cXwxgNaYwNzs9enPksd/HlPX2dPhaufOOWPdlCLGbbX3OWgr3y7y6OLdG4x4O7HMAY5pHVXdllknnf9q5zeGdgJDT1yAP4KRfiYziVnhaomY1RvEf2yZFaKGpq5LBJPKX+Uhjy0lgByM45Kkpq+ukbacmTMjntnzHjOMY7uS130cuW7EcPVMzGY5faZ/xkSLGKK4XJ94qIZTJwGmTZmIY5Zxzwo6C5XP6urJahz3SBg4Q4WCCTjPTCzHEU+U9fZ0nhKojeOnv+c2VosYNwuQskziZPLIpQ3dwxkj2YwlTV3VlngqGSl04e5kgEfXwOMdyfER5TtlPhKttUb4/P4ZOiipWyMpo2zv4kob5zsAZPuUq7w808hEREEREBERAREQEREBERAREQEREBERARFFJUwRuLZJo2OHc5wBQSooPLKb/ziH/jCma4OaHNILTzBB6oPqIiAiLDu0TtFsugRQG+tq3eW8TheTxh/wBzbnOSMfeCDMUWLdn2ubTry3VNbY21TYaeXgv8ojDDuwDywTywVlKAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC4s+kz+N66foYP3TV2muLPpM/jeun6GD901Bidp0HqW70dPVW62OnhqP6otmjBdzxyBdnqt1xds1z7N7bbNL3rR7hV0NHCzc6v27xsGDjhn1jqeYK1ZpHWWlrBHbJ5tDtrbvRPbMK43WaPfI125ruGAWjGBy6clmX0l7/bL9DpGpiphFeJ7eyrn2v3cOOVrXMjJxzIO455fNEbA1h9IWjsdTb47fZfrFtTRRVb3eWcPhGQZ2EbHZIGOfrVBePpE1dofSx12jxHJUU7KlrTceYY/m3P2XeMH3rm2jY233igfeKWR9KHRTSRHkZITh3I+tvRbA+kZVUtb2iiqt7mPo5qCmkhcwYBYWZGPcg2zWfSStlPRWuSOyyT1FRG6SqijqRimO4gN3FvnEgZ7sZCwX6Q+tLVrnT+kbnZ3PDWvq45YZRh8T8QnB/mFgVHfNP0mgZ7VWaWbLfJyXw3R0xaQ0u5ED1YIwOR71jU1FUx2alrZA4Uk08scZPQuY1hdj/iag3/8AR51datF9mN+ul7mcyEXEMjjYMvlfwm4a0ePL2Kvd9J2k8r2t0xOaXP3zWAPx47dmM+9aKkpap/ZrT1MYcaOK7Sslx0D3Qx7M+5r1dYr3owdlr7XJYpzq0yEivyNuN+Qc7s/d83bj1oOjtQduFppNA0up7JROuLZKxtFLSyTcCSBxY9/nea70e7kc9eSxJn0l4JLRWznT4hro3Rtp4DWF4l3btxJ2DAaGjxyXBaIpaWqb2b3KqLXCifdaWNpI5OeIagnHsBHxC2n9FbT1nv8AV6kbe7ZSV4hZTmMVEQfsyZM4z0zgfBBsibt6tFBoq03a50UhulwY97KCnfu2ta9zdznHGAS3wJ+Cxyg+k5RPqWtrtNVEMBPN8VWJHAfmlrf2rW30krIyydovBpKSOktr6SJ1LHEzawN5hwAHL724+/1qx3S66NnobWwWysfLEz7cUrGUmDgci5xlMnPvO3+CDpHtC7a6HTNo09dLTbheKK8MlfG/yjg7OGWAgjY7nlxBHLGFhH+1Af8A0SH/AMx/8JY5eafQUvZZYai5uvlvMb6mSgt7J45Jpw8sDnklmGs3R8jgd/Vay0hW6coL2avUVtrbhRRndFSRzNaHc+QkdjmPUAM/JB3D2d6m/DHRtuvxpPI/LA88DicTZte5n3sDOduenesjVm0bXUtz0naK630jaOkqaWOWKnaABE1zQQ3ly5K8ooiIgIiICIiAiIgIiICIiAiIgLXusOyHSurb9Nd7xFVurJmta4xzljcNAA5ewLYSINR/7Pmhf+wuH60f5KoruwjRldOJaplykkEbIgTVHk1jQ1o6dzWge5bURBrrUfY3pDUFRSTV1LUtdTU0dJGIZiwcNgw3Picd65h7d9P0el9eG0Wx05o6eliEYmk3uaCCcZ8Oa7jVDWWa2VsxmrLdRVExGC+WBr3Y9pCDSnZT2c6b1p2W6Xq9QUb5pqZs7GuZI6Pc0zOOHY5kZz8Ss/1N2VaV1FbLVb6uifBRWwPFNFSycMN37d2fH7o5+1ZrS00FJA2Glhighb92ONga0ewBSoMN032a6Z0/p+uslNRGottbJxJ4ap3FDjgDv6dAscPYHoI1PF+r6oNznhCrft9nXPzW1UQYdqDs301e9MUmn56I01qpZhPFDSu4eHhrm5J7+Tj1X3QPZ3YdCSVr7BHUMdWBgl40pfnbnGPD7xWYIgsWrtI2PV9A2k1BQR1cbDljiS18Z8WuGCP4rCqDsH0HSVTZzbZ6jadwZPUvcz3jIz7CtpIgwTWXZTpfV1TRzXWmmYaSAU0LKaThMZGCSAAB61j3+z5oX/sLh+tH+S24iCisdrprLZ6K2UIcKWkhbBEHnJDWjAye9VqIgIiICIiAiIgIiICIiAiIgIiIC0P2r9t100VrarslJaaKphgZG4SSvcHHcwO7vat8Liz6TP43rp+hg/dNQdY9nl/m1Tou1XqphjgmrIjI6OMktb5xHLPsWRLk2XtfuOj+zvSti04yAVvkXFqKiVu/h7nu2ta3pnHPJz1CoK/t41sNO0cBk8kuYlLzW+TR4qIiOQ2ubgEHvb1HzDsFFpb6NmuNQa0g1A7UlcKt1K6AQ4hjj27hJn7jRn7o6qH6Q/ajd9FVdBadPtjhqqmAzvqpIw/a3cWgNB5Z5HOQe5Bu9Fxfa+1ftRnY+to66srKaN2JHCgZJGD1wSGcuqznVXbrfaLQ2n3UsVLFf7jFJNPNw/Nia2RzBtYSeZ2nrkDHRB0utcdtWvrnoO1UVRabMbg6pe5rpnhxjhxjG7bzycnHMdCucm9sHaXRNhrqi5VBppTljp6KMRSeoHYPkVm+q+2vUFZ2b2S8WaaK3XF9ZLSVrWQskY8tY1wIDwcAhwKDZ3Yj2h3bXtLcX3ezii8lLAyeMOEcuc5A3d4wO89Vs9c09nvbReabQupr1qadtynpJqeCihEUcIL5BIcHY0cvNyfYsKn7de0OtnlqaSphhp2c3Rw0THMYPWXAn5oOy0XMND28Xu6dn2oA7gUeo6GOGanqoYwWSMM0bH5Y7IBw/wBnPuwrPobtl7QrhXXCFpde5xRSPhgbTxMEbgW/auLWgkNG7lnmSEHWyLkns47eNR02oqaHVNYyutUpLZC6FjXx8uRaWgd+ORyrfd+2/XuoLvI2wSupISSYqSkpmyvDfWS0knx6D1IOxkXK/Zd246l/CygtGq3x1lLVTtpnPdC2OWFzjtB80AEZxkEZUeu/pAaiqr7UUekWw0dHHKY4pOCJZZsHGcOyAD3DHvQdWIuTtH/SA1Pbr1BT6tZFWUTnhkxMAhmjB/vDbgcuuCOfqXWDHNexr2HLXDIPiEH1ERAREQEREBERAREQEREBcWfSZ/G9dP0MH7pq7TVurbDaK6odPW2qgqZ3YBkmp2PccdOZGUHDWsdN19HYNOXwwSPt1dQsAmDSWskaXNLCe44APrz6lPrTVWq9W6atdRfmtdaqSQ09PM2BsYfJt58x1IAGccgu52UFIyiFGylgbSAbRAIwGAeG3oqeayWqelipp7ZQyU0RJjifAwsYT1wCMBEaB+hz/ZdV/n037JV9+k1qE27U1uoblYaK62d9G2Rrp2PY9ku94cGSsIIOAzI5jpyXQNutdvtgkFuoaWkEmN/AhbHux0zgc+pVRPDFURmOeJksZ6te0OB9xRX5+SX99JdxU6RbX2RpAAiirXSOLvzgGkjpyOVm/azZ9U3HTeltUX+jnMklCaaok4W0sLZXljngfdLmuByuvqWw2iknE1JaqCCYdJIqdjXfEBXFzQ5pa4AtPIg96JhwjUdqOq6iwWyy+XRijoA1sAbTs3Ya3a0Ekc8Dksk7R3ajm7JdNVWrHP8AKai4TPp2PhbE5sPDaBkNA6kE8+eCF13BY7TT1HHp7XQxT5zxGU7Gu+IGVLcLZQ3JjGXGipqtrDlonibIGn1ZHJBxZojTVfqbsr1XHaoX1FTRVtJV8Fgy57QyZpAHecOzj1LHtP6tq7BZrha2UcUoqHHPHklAjOMH7MPDHHl/eaf4LvS3WugtokFuoaWkEmN4gibHux0zgc+pUVRZLVU1HHqbZQzT9eJJTsc74kZQceUMl8uXZVqmvqrTbaW0RwwRsqorfHBJLIamLk1zQMgAHPd0VT9GX/fe7/5NUf8ANGuw6mipaqkNLVU0E1MQAYZIw5hwcjzTy5YCpaKx2mhldJQ2uhppHNLC6GnYwlp6gkDp6kH59aetr7xf7bbYSBJWVMdO0nuL3Bo/ar3p6+aj7NNT1EtLGaG6MY6nliqYQctJBIwfW0HI8F3NBpuxwTRzQWa2xyxuDmPZSsDmkdCCByKqq+2UFwDRX0VLVBvTjRNfj4hByJ2Vak1xqjtApWUVW6SOeqE9dIKaPYyPdl5J28sjIHyWG3S3XXs410W11JIJqSVxj3PkjbPGcgOa9ha7BB6g+o94XeVJSU9HEIqSnigjH9yJgaPgF5rqCkr4xHXUsFTGOYbNGHj4FBxTprUGoNT6xbHZbFaKmpqpG+ZLQNqRGOQ3Okk3PwOpLnLtyFpZExrsZDQDtGB7lBQ0FHQRllDSU9Mw9Wwxhg+ACqUUREQEREBERAREQEREBERAREcQ0EuIAHUlARag+kte6u3dnMFXYrnPSzfWMcZmo5yx2NkhLS5p9Q5LB/ovaqulxv17GoL7W1UDKZhYK2rc9rXF/duOAcIOl0VPFX0krXuiqoHtjG55bICGjxPgvkNwop5BHDV08kjujWSNJPuygqUUVRUQUzA6omjiaTgGRwaCfeqd92t0dPJO+vpGwR43yGZoa3PTJzgIK1FDBVU9RTNqKeeKWncNzZWPDmkeII5L5DW0s79kNTDI7wZICfkgnRU89dSU8myoqoIn4ztfIGn4FfTW0racTmphEBOBIXjaT7eiCdFBT1lNUlwpqiGYt5kRvDsfBfDXUjZeG6qgEnTYZBn4IKhFHUVENOwPqJo4mE4DnuDRn3qJlwo5I5Hsq6dzI27nuEgIaPE8+QQVKKlhuNDPTGohrKaSnb1lbK0tHvzheoK+kqH7IKqCV+M7WSBxx7kFQipGXOge9rGVtK57jgAStJJ8Oqq0BERAREQEREBERAREQEREBcq/Sn1jcpNVN01TVEsFupoWSSxscW8aRwz52OoAxgeOV1UtHdvvZFW6xuEN8046E3JsYhnp5XbBK0Z2uDum4Zxz7seCDQ180jqjT/ZtQ3OsqYPwfu80U7Kdk25wfscWOLcYBLSeh9qxek/3buX/AHmn/wCWVbMl7F+0OfTOKqGaR1NOI6a2mrY4BhBLpBl+1ozgYHM5PgqrTPYhq6psV+pLnbm0NQ5kUtIZZ43NkkY45adrjjLXO5nvwiKHsR/3P7Tv8jf/AMsitP0d/wAcmnfzp/3EiyjSHZD2i0NHqGAMNsp6mhkifE2WKQ1pwS2IcztBPVxI5Equ7F+y3WWnu0yy3S8WV1NQU5lMspqInbcwvaOTXk9SB0QZt9Lv/cK0/wCZt/dSLSPZToO9a/ob1QWi401JSwPp5ahk+7EjvtAw8genn/FdFfSP0petXaQt1Fp2iNZUxVzZnsEjGYZw3jOXEDqQrN9GfRGodHP1EdSW51EKoU/BzLG/ft4m77rjjG4dfFBpTtVrL3psUGg57gfJLRA0Ssp3Fsc0khMm49CcB7Rz6YKsztF6it8tBPbOLUTzeex9G2VpicMHm9zWtz62k+1b97fOx+46tu7L/pt0T650bYqimkds4m3kHNceWcYGDjoFqxnY32mXiamp7nTSMhhAjjfV1zHsib6gHOIHqAQVPbNZr9PojSmotT0r4ruwPt1W9zmuMgBLonu2kjJG7PsWGV+r31PZZa9LZOaW4S1DvzC0bB/xPk+AXTt17LWwdiFRpGheaqvjjNRHIcN4lQHb+WeQB+77CueGdiXaC57QdPOaCcEmqg5f/Wg901VctG9kdNVW+aSkqtTVcgdNEdr/ACaAAbQeoy956dwWM0GlLpcrE68UjxPh2BCxkr5TzxnIYWjn4uBXVfaN2TRai7ObRYrXNHT1tnjaKV7x5j8Nw5rvDdgHPiFocdj3adHTPtbKGb6vc/e6NtfGIXO9It3/AMEEOovwupux8UOqIKkW+O5wPopKiQOc37KYOZ1Jx0Iz05q0dntkuN50xrQ0V0dQ0tHQCrqYmsz5SGbiGE5GByJ7+7kth3LsL1Dbuzcw0sLbjqCqr4ZZYIZWtZDCxkowHPIBOXjPux4qv7K+zXVtk0zrylulodBPcrU6npGGeJ3FkLXjbkOIHUdcBBoCiudVR0VfSwTPbT1sYimjB814D2vGR6i0LZ/0X/xkzf5bP/8Aio9O9hetKu6sgutpNFSvjlBqH1ETmsfw3bMhricb9o5DvV40D2P9olp1UHx4s0RjfFLXMlilzGRgta3JJJ7sgY65CDWPZx+MPS/+a0v75q79dWUzaoUzqmEVBGREXjefd1XIGiex/XVu1nYK6tsL4qWmuFPNK/ymE7WNkaXHAfk4APRV937GO0Co7QJ6qMiRklWZm3U1LRtG7IcRncCB3AexB1ui+MBaxocckDBPivqKIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIixfU2o3Wu90FMyWmZCNslUJXAOLHvEbdvPxLnH1M9aDKEWK33UdbBTXn6toA51vIYZpZAGFxa13IYJPJ3qVTNepaWrnZUwympEUG2lje1zN8kj2tw4gHJ28yeQHTvyGQosdq7xVQ1FvNXA6iZxpGztJEjXsbC9+WuHdkDwPJRUWrY6iOSR9FMGCndUxiJwlc5ox5pA+67mOXPv58kGTorbYrq27QSyMYxvDdtOyZsoPLPVp5H1HCpK+8+Q1tUwRz1Lw+CNsILQAZCQMHr7cn2IL6ixSXUNxkuFBT0tBEHmpkpqmOSfGHNiLwGkNPLG0592FU0+qI57kKdlMTAZ3UwlEgLt7SQSWdQ3IIz8sc0GRIrBRakEwp5qmjkpaOcyNjmkeOZYCTkDoCGvIP+H1qmk1NHTtknmjqA58VO6OmeWgB0pfgZxkHzcnPTHL1hlCKw0OpI6gwtmpzCXTmnc7eHMDtm8EOxzBAIzy58sLxBqiGejjnipZ3Oc6UuhHORrGM37sesFmB/jCDIUVrsN4Zd4pXsjYzhkDzJmSdRnntPI+o/NW23aqbcJmNpaTdHOHGmfxQdxAJG8AZYDjkefrweSDJkVl05cqys09FXXGnijkdEJPs5N28YznoMezmqOm1LVVLqdkVnl4tTTeVwtdO0Ax8s7j3Hzm8ufX24DJkWNv1VCHUL2wf0epbC4OdM1rxxSA3DOpxkZ6erK9HUjpqmspaWlbx4RIGtlnaxxLOWSz7wae44OeXTKDIkWJ02qKmO02p9bSQ+XVsAnDRUBrC0NaS4kjkcuGG4PtVWNTsdwHNo5xE6mdVTSOIAhY0kOz4nI5YzlBkKLG6q81xtr5jQy0ZcI3xSF7Xgtc9oId4OwenP28lOdRMZemUEkAHEkdExzZmueXBhfzYOYBDTg9enJBfUWM0+rYpqKoqRSvxEGHYJWOe3ccDe3OWY6nPIAHwX2XVcYp6UxQRvnqOIWt8pZw9rCA47xkdXAAYzz7kGSosbm1ZCwUhFLI3jxiT7aRkQHnbS0Fxw52R0B6YOeYWSICIiAiIgK3VFloak1xqIRKa1uyUu5+bt24HgMZ6d5JVxViuF7qobhWU1JbvKRSQsnkeZgzLXbuTRg5d5p5HA9aCs+paM0ldTSNe+KtOZg55y47Gs69RyaOneon2Cie2QP473PjjjL3TOc8bHOc0hxOcguJzlUX4Sl7JKuCj32uKRkclQZcPBdt5hmOYG4Z5g9cAqpN9AhpZDT/19ZLSY39NnE87p38Pp6/UglhsVHG5j5DNPI2R0pfNIXlxLCw5z3bTjHReaTT9JS7tktW4cIwRh9Q48JhxyZz5dBz68hzXm2Xmas04LtLQSRh8PHjgY7iPe3bkdB1PgrRWalrp6KCS2QUbpPLYYJG+VZwHOHI+ZkE5wcgY6jKC+QWaKCpbPHUVPFMgklcZOcuGFoa7uwM5x4jKmntVLNUvne13Ec+N5Id3xklv7VbHagqWT1bH28BlLNDBJIJ8gvk4fJvm5IHE78dB48pKq/SMuU1BS0YmqmzNhjDpdjXZi4hLjg4AHLoUFTPYaGeV0j2zNkdUeVb45nMcH7AzkWkHG0YwvkVipIq0VDH1AaJHTCDjO4QeertvjzJ8MnPVUL7peHXq3U7KCCOKWGV0zJKjBBa9gyCGHIw7I6ZzzxhfZtTtitlFWGlJFTBNPs4n3eGwux055xhBXVVioaq0stszHGlYQ4DcQeRz19fMH1Eheq2y0dZJPJK14klEYL2vLS0xklhaR0ILirVU6mqonxQttTnVToRUPi4jjsjJIbzaw+ccHl05dVXUF6krroKWGikbCKeOofLK7Y5m/dhuzGc+bzQepNPUU1sqKGczzR1DxJLI+UmRzhjB3d2NoHLwU31NReWz1Yjc2aaHgOLXluG+rHQ8hzHPzR4Kmkvojq30ppz5Q2pEO3d/c2b+J06bQfeMKmjv9XLBC8W+OIVkLpaMuqM78N3APAb5p28+W7ogu1BbYaKaaZj5ZJ5g1r5JXbnENztHuyfiqeisVJR1TJonVBbHuMULpSY4t3Xa3oOp9meWFbLPfbnLQ2RtVQRSVVfAJS+OfzQ0NYS93mjGd3QA88DPeJbNqZ1zq4GtoJm0dTu4M43HkASC8bQGggcsE93RBdaC101DRyUtPxRA/Pmvlc8NB7m5J2j1DklPa6anlppI2uDqenNLHl3Rh2/PzAqSru9S2vqKehoPKm0oaZ3GYMI3DIDAR5xxz5kDmOap5NRTCSdrLeSG1PkcJdKBxZOvh5rQMkn1HkUEg0tb2w8KM1DIyIwWtlIBMYAY72jaPVy6KrbZqbyxlRI+eVzC9zGySFzWFwIcR7iR6s8sK3/Xb31lNT1EMtPVsqzBLFDIHsceC6Qcy3JaQPAHPzip9V8akqZfI/tIgxxhbJmRgccfaMxuZjqeRGAeqIrW6boo6anhp5KyDycFsUjKl5expABYCSfN5Dl05BVdPaKOANDIy5og8nw9xdlmc4OepOTzKtMmpz9XwVEENJI6UvGBWN2+b1DSAS48+m0dOeO/xNqp/CknpaAy0sVFFXyvfKGFsbw44AwcuAaeWQPWiq+LTlFG0tc+qlaGCNglnc7htDg4NbnpzaPXyC9fg9ReUMmDpwWVDqljRKdrXuzuIHr3O+JxheKe81FTUvdBQb6Bk7qd04lAeHNJa47CPuggjOc+pU9j1I+6VMANvlipqlhkhm848sZG8FoDcjpglBWMsVM175DNVumLBG2V0x3saDkAH29c5z35Xh2naPY0xyVMU4e+Q1EcpbI4vxuyfA4by6ch4K8ogtM1go5aVtMX1IpxFwXxiZxEjPB2epOTk9TnqrsiICIiAiIgKx1OnoKy7VtVVOkMdRFHFsjlezc1u7IdtIyPO/b4q+IgtjrHQOqDNwXNy5r3RtkcI3ObjaSwHaSMDu7h4L4bFQGpZOY5C5krp2N4rtrXuBDnBucDO53xKuiIKaKhp4baygja5tMyIQtaHHIaBgDPXp39VSOsNA+GaOVkshlcx73umeX5YctIdnIwemCroiCgNpozBVRGNxZUua+QmRxcXNa1oOc5BAY3n4jPVQfg9b/tDsm4r5BMZRO/ibw3bkOzkeby9iuyILayx0MbaYMjla6nc57HiZ4dlxy7c7OXZPMg5yoXabtrz58UjhtkY1pmftY2QYeGjOADnuV4RBbq+zUdc9j5hMx7WcLdDM+MlnoktIyPap6WgpqSZ8lPEI3OjZEcE42sztAHdjcVVIgpHW2lddBcXRZqxFwN+T9zOcY6e9QUVkoaOVr4Y3+Y0sja+Vz2xtPUNBOGjkOiuSILfQWaioOB5NG9oga5kQdK5+xrtuWjJOB5o5d2OS8UljoaSqZUQslDmFxjY6Z7mRl3XawnDe/oO9XNEFtr7JQ1875ahkm6RoZIGSvYJWjoHgEBw5nr44Uktpo5aeWF8R2SS8c4eQQ/OdwIOQeXcq5EFuistDHwyInOfHKZw98jnOc8sLCXEnJ80kc/V4Ly2x0bS539IMhaGCR1Q8va0HIAdnI5/FXNEFqFgt4c1wjlDxv3P4z9z9+N245552t6+ASKwW6KjmpWQu4M1O2keDI45ibuw3Oc8tzldUQWw2OhNX5QY5N3E43D4r+Hv9LZnbnvzjrz6rxT6foKdxMTZwOG6NjfKH4ia7qGDOGe7GO5XZEHmJgiiZG0uLWgNG4knl4k9V6REBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAXkh+eRbj2L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9IgIiICIuavpMdpdwpLodKWKpfSsjja+tmidte4uGRGCOgxgnHXOPaHQlRfbRTSuiqbrQQyt5FklQxpHuJUX4S2L8tWz9aj/muALRZbne3zC10U9Y+IbpOE3cWjnzPwKoHMc1xDmkEd2ER+iUF/s88jY4Ltb5JHHAaypYSfcCrkvzaIIwSCF0D9GvtLuDL9BpS9VL6mjqgRSSSuy6F4GdmT/dIBwO44x1QdSKkrbnQUBArq2lpieYE0rWZ+JUFznkfV09vpnmOWdrpJJAOccbcA47txLgB7z3I6G1WOjmqnsp6WFg3Szv6nuy5x5k9OZKK8fhHY/yzbf1pn80/COx/lm2/rTP5qsoqqkrqaOoo5YpoJM7HsIIODgr7FUUs0s0cUkT3wuDJGgglhIBAPuIPvQUX4R2P8s239aZ/NPwjsf5Ztv60z+auX2eCfM5dVFT1NLUcTgSxScN5iftIO1w6tPrQUX4R2P8s239aZ/NPwjsf5Ztv60z+auZDB1DVC6ogbUsgOeI9jpAQwluAQDl2MA8xyJyfcUFF+Edj/LNt/WmfzT8I7H+Wbb+tM/mrnhn+FfPs8A+ZgoLb+Edj/LNt/WmfzQajshOBeLbn/vTP5q5/Z/4fFQOqKTytlI6SHyiSN0jYiRucwEAkDwBI+KCeKRksbZIntexwyHNOQR7V6VorLeygjlrbTC2KdgL3wx+aycdSCOm49zuufVkK508zKiCOaJ26ORoe0+IIyEEiIiAiIgIiICIiAiIgIiIPmVxb9Ja0VNu7U6+qmY4U9wZHPC/ucAwNI9oLf2eK7PLsLGtdaPs2tbT5BfKfiNaS6KVh2yRO8Wn+HQoOErHdX2mpqJo42yGWmlpyHdAHsLSfdlZe7tLqJawTVFsgljLTujdM/73FjlG05y1gdE3DByALvFbTqvozQOmcaXVMkcWfNbJQh7gPWRIM/BRf7Mv/rb/APbv/FRGnNZ6zm1RRW+nnpGwmkLyHCQnO7HIDAA6deZ9eOSvHYDZqm8dqdlNO13CopfK5ngcmNZzGfacD3rZ8H0ZohK0z6qe+PPNrKANJHqJkP7FuTQGiLLoa2OpLJCd8mDNUSndJKR0yfDwA5IL1UONPqSmlePsqmB0Adno9p3Ae8F//CvepLVHfbJVW2aR8UdQA1z2dQAQeXwU9VFFVQOhnbujd1GcEeBBHMEdQR0VuNNdohspbnTuYOhqqUyPx7Wvbn4Iq1XXQNvraindBPNSRRRtjDYwC9uHufuY85c1zi47jnLh1VDR9m9PTMH9NY5/F4hHkUXCH2bGEiPoHYjBDu4l3ccLIuHfvyja/wBQk/1k4d+/KNr/AFCT/WQYzUdmkU9HdIH3Nx8vmjndmnaGtewvw7a0gEkP59x2jl3L1U9mlLJG9kVa2IGsFY1wpWbg7bg5xgO7yMggZ6FZJw79+UbX+oSf6ycO/flG1/qEn+sgtWrdDx6irpp33GamjmiDJI2RtdkiOVgcCeY5TO5eoKnrOzqjnMYiq3RRxSSPjh4LXRDe6JxaWHkW5i6f4iVfeHfvyja/1CT/AFk4d+/KNr/UJP8AWQYjRdmRltFLS3C5zxbY9sscAHN/DliDg7kR5snTpyVYzsxtn1fR0k075m0xJZxGBwBMzJTjJOAdm3r0cVkXDv35Rtf6hJ/rJw79+UbX+oSf6yDFj2VW/wAqfMK+qAdE+IM/utacgNAzgNAONuO7PqV4t2iKS33uguNNIwOpDUhsZgaQGTScQMaf7oaeQx3EjvVx4d+/KNr/AFCT/WTh378o2v8AUJP9ZBdblVso6GeokBIY0kNAyXHuaB3knAA9aisVK632S30bzl9PTxxE+Ja0D+CpqeikM7Z7hU+Uys5saGbI2HxDck59ZJ9WOauG9BPlMqDem9BPlMqDem9BPlMqDem9BPlMqDenEQT5TKgD19EnrQTZX3K8A5X3KCn5uOGjKGOTuHzVRG3a0BekFJwpfD5r5wpfD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpfD5r4Y5fD5qsK8nogpoo3cQB45e1Wax6kF4v12tIpWxSWw7Zn8UOBJJ2bQOZy0ZPTB5c1fzkEEdQqKG326ikNRSUUMU+HN3tZg+e7c7J78u5+1BVMcpdypYyp8oJ0REBERBDWTtpqZ8zuYaOnirLbL6aisbDMG5dyaGj5//AN4q+TwsnZskGW5zhWmj0/FS3BtS2Vxa3JazHT3r5nGRxvf26uHxoz833/Or02Zs6Koub9GO3jX7rfrR1hbQwy7ZqeInynEzhKPvNj28w3qeY5BV8naHpyOmfPJVysjG3YX0728VrnFoczI85uQRkcviFkFNbKWmuNdXRRkVNbs47i4kO2DDeXQclZG6EsbIZYmRVLWvaGNxUyfZsDi4Mbz5MySdvTp4BfTeZI7WtlFa2kbNO+pdEJGxtp3kkmMyBnT75aCQ3qvdBrC1VtlZdo3VDKF1SKUSSwuZ55eGd/8Ad3HGeipYtAWCE/0enqIAYBTkRVMjMtDCwE4PXacZ9ngFX0ulrXT6cmsQjnktkjDGYpp3vLW4xhpJy0DHLHTuQUkOubFNPBEyomPGLQJBA8sbveWMLnYw0OLTtz15HvCrLHqm03yiqqu31JfTU2eLK+NzGgAEk5I9R9igOjLJ5RSytpnsFOyGNsbJXNY4RHMe9oOHbTzGVNadK2q1mvNNC9xrmCOoM0rpC9oyA0kn/EfXzQUtv1xZa6oiggkqRLK5rWNlp3xk7o3yNPnAci1jjn2KFnaFpt7Q7y14YaYVW4wvwG8Li4zj72zztvVU9F2d2umq55HT1kkTjC6AGd++ExsczAfuyQWvIx4KspNCWKjfupYKiEcBtPtjqZGja2MRg8j97YAM+rPXmgoK/tFt0UEMtHBUVEUtHUVbZnRuZGBDtyCcE4O4cwCOniFXz67sNO6qbNUTNFOH7n8B+x5YQHhjsYcWkjICjHZ/YBT8EQThhE7X4neDIJg0SB2Dzzsb8ApptD2KeWpfLTSOE+8lhnfsYXkF5Y3OGlxAyR/EoPEevLE+ppafj1DKmomfAyF9O9rw9jgHAgjI5ub8c+Kq7zqWltN+tluqyWitOxr9j+TycMGQMcznvGOXioK7RNkrZjJUQTHdUOqXNE7w10hLSSRnHVrfh6yqi6aUtVzvUF1q4pHVkPD2ubK5o+zcXMyAcHBcfigteotYVVqq7xHT2ryqC2U4qJ5eOGYaYpHjljvcwN/9rPcpqTWcFRrFti8nLWui5VO/zTPtDzDjHXY4Oz7QrtW2C3VguoqIXO+s4WwVWHkb2AEADny5OPRUMOidPw1cdXHb421sdT5WKrJ42/n1f1LcHG3OMcsILtLdrdFI6OWvpGSNOHNdM0EH1jKt1/1B5FFbm2uGK4VVxqDT0zRMGRkhrnOc54BwAGO6AnPJXKS12+WR0ktDSPe45LnQtJJ9Zwqe6WG33KihpZoTFHBIJoXU7jE6J4z5zS3BB5n4lBZrVrejqC2mroJ4LoJpYJaaCN9RsMbg1ztzW/cy5vnEDr6iorh2hWiCmfJSceoeyaKMN4L28Rjp2wufGdvnhrndG5zy8VWt0TZWeTGKKpifCX5kZUyNfLvcHvEjs5flwBOfBRv0FYXsmaaefa8gtAqZBwcSiXEfPzBvaHcsdEAa8sJ4X9InG/O/NNJ9h9oY/teXmeeC3njmFNa9XUVbYGXeeGopKZ1UaX7aMgh3F4YJ9ROOfd7lE3Qlibwv6POdnN+ah54/2hk+15+f55LueeZKr49NW1ljrLQYpH2+rdI6SJ8jjjiElwaerRkkjHQ9EFBHrmxSzwxsqJiJS0CQQPMbdz3MYXOxhoc5p2568j0IUVRr7T9PSR1M1VI2KWGKdh4TubZXPazu6kxu+CqzoyycakkbTPYKaOGNsbZXBj2xHMe9ucO2nmMqmZoKxxwSRRx1TWPYyL+0yeaxjnOawc/ugvdy6c0GRU0zKqmiqIdxilYHtLmlpwRkZB5j3rzVDEDvd+1LZQU9st1NQ0TOHTU0bYomZJ2tAwBk81R6mrvq20SVRGWsfGHewvAPyKJM4jMpoSqjIVLAQQCCqnIRVUiIgIiIMO7RdSXLT0dv+rKWOXyhzw+SVhc1pa3LWciMFx5A8+nIE8lj1117eaKpvbTT0zIKMMNNI+CQiYukja9ue8x7yDj7xxjGCFtJQ1lLBW05gq4mTQkgljxkEggj4EA+5Bqp2qb5W11PKC90AxEH07HxxTgV9PHxQCcjLHP7zyz3KSk7RLs+smZPDShsQjkmiEEgfTNNW2J4eSeZbGS7IAHqx12uoPJKfy3yvgs8q4fC4uPO2Zztz4Z5oNc0Wu71U3u20rbfGKapmc3c6JwMjPKXx5aSeRaxrXnkc5/ujmrrfNSXui1LNT0lJDNQQzU0Wzhu4knFa8kh2cDBaO49e5ZwiDU1PrLUNebW574KeA1dMKmaOkkDW8Rsm+Bwcc7mua0Fw73Dp0NTR601KH6cZWUVIXXOGKofshe0Ye9oMYy7Ic1pLicHPLkBkraGEQa/1brO42jVtPbaOmZJTFjTKZIjnzmvO5rt3QFoB83HPrlWCm7SLvLQ0UsjrdGyofCHVZpZeHEXwySOjLd2XOYWNyQceeOi27IxskbmSNDmOBa4HvB7lTC20Qjo2Cli2UeDTjbyiw0tG3w80kexBruHWepZqKatlo6WipmmkjdxaeR5hMsbHvkdhwJa3JGOR5jJGCqii1nd6msoIKqCGiE8IcN1NK51UTI9mY8fcG1rX+cDgPGcdVsdEGn6LWmprbp+hZWQxVEz6ekeat8DvsxJHITxAXjcd0bRnLeb+njnj9QTSaSrK6mjiF1pqVsktO9ry2OUxh+04GSOY6LJF4ZFHG6R0bGtdIdzyBguOAMnxOAB7kGqZu0e7sobXIyia6aWVzZg6mIY9olazzHCQjo4nI3dO4AqebWupIaaeZ9LRYdE+SLML28PbU8IhxLsElvnDO0DvOOa2lhEGB3PV9bBpDT90aIKWa4VDIZn1NO8tiBY8l2wOzjLAeuMd/esei1ZqGouFvqnNdRwyy0nGhMT3NeHwznaMnzQ5zGDxy5uemDteopYKl0JqImSGF/FjLhnY7BG4evBI96mQapZqnUF0htE9HUUzagyvdMxtJMI4/6NI8xSAkbi1wAyCOeMjuVz1hqq602l7TUUkTKWW40UkskroXycKTghzY2hvMOcSQCem3oVsNEGvNHaqvNdqKK1VtIG07IG7nvYRIfsWO4pOeYc5xGNo9p5hRXbWWoaKa8xNtjMWyRsb5zE4seJZWiN7fOGQ2Iku59e8BbIRBrKLWOpJ5KZzaSkjhIpOIDA9xfxpnxlzTuwAA0Pxz69e9UWmNbagfVWSgrIo6p0zW+UTOgcxzyZHteB53IsDQTyOc/3eRW2kwgho6iKspIammdvgmYJGOwRlpGQcHmFj3aSP/I6u9sf/O1ZOsa7RsHSNaD3mP8A52rneuRat1XJ6RkmibnyR1VdAfsI/wA0fsVcrfQ/1Mf5oVwHRbjnA9UtUxzQ17g145c+9VBewHm5vxVknb1XHfbEP+tG/fpGfu2Kjt/iM9NvxTiM9NvxX56sypD3ImX6DcRnpt+KcRnpt+K/PxqmZla0pqd+8Rnpt+KcRnpt+K4CcPtPcvbev8VzmrE4daaMxl31xGem34pxGek34rgRnMuCqLY3zpfclM5nCVU6Yy7z4jPSb8U4jPSb8Vw80HKmaDhddDlrdub2+kPim9vpD4rjSkB4QVWwLEtRLsDe30h8U3t9IfFciZDGFzjgDmV9ZUMz92b/AOE7+SGXXW9vpD4pub6Q+K5JdM2RmxjJS5xA5xuA6+JCuDW5whl1Nub6Q+Kbm+kPiuYWNUzGlDLpjc30h8U3N8R8VzcxpU7GoZdFbm+I+Kbm+I+K58YxTsYhlvzcPEJuHiFolrVOxiGW78jxC+rTEG6N7XsJa5pyCOoKzm36sAtrvK2F1WwYbgcn+v1etFZZJIyNpdI5rWjqScLX/aRdo6q3spaV26MSgvcOjjg8gqGpqJq2pdPUOLnu+A9QVu1A3FA39IP2FeHtL6W56OtjxKWxaH+pj/NCrweXeqGhH2Mf5oVeOi9tO0OUqSZvJccdsgx2pX79Iz92xdlzDquNu2f8ad//AEjP3bEkYixSkcgoWdVOArDMvTBzUzQom4HM8kdVRsIAO4+pdIZSy7RsyQCTgetfQwnvVBVSudslwPs3ZA9XRV8LxJGHN5ZXG7GJeizPJ5awtfnccK4W9oEO4dXEkq0yyEy7ARlSUta6mdsAD2eHeCtWqJn5mL1f7WQMCnYFbaS5QTcidhzgZ71dYgHY2kHPeF2xh51dTACNvMKqZjxCoG08RPOJhJ/whTNp4f8Aso/+ELlMOmcKmrx5M/mO79oVewK3R08QcC2KMEd4aFVsCYNStYAp2AKhYFOxMGpXMaFOxoVCwKdgV0pqV7AFMxoVAwKdgTSa1cNrWlziAAMkq0ae1Tbb1cqyipJCZKd+G5BG9uBkjl45HuVwYF8pKKnppqiWCMMkqHh8hH94gAfsCaTWu7Gj1KdgHiFb2BQ3SvhtduqK2qdthgYXu/l7T0TBqXC5XKitVI6puNTFTwN6ukdj3DxPqWJT9rWmIJtjJKuYA43xw+b8yD8lo3VGoa3UVxfVVsh4YJ4UIPmxt8B/PvVoYySQOLI3ODRk4GcLLbrDTOs7DqB4jttfG6fGeDICx/wPX3ZV31Dg0Dfzx+wrjmCaSGZksL3RysIc1zTgtI7wVvzs61g/UlhdS17wblSObud3ysOcO9vcf/2vD2n9Jc9HWx4lLo6iH2Mf5oVaqOi5wx/mhVi9tO0Oco5Vxp2z/jTv/wCkZ+7Yuy5Vxp2z/jTv/wCkZ+7YgxBg5qdoULOqnaqy8VUbnNBbzA6hUwaOo9nuVzYo5aUO5x8j4LpTVhmYUmBkBwy3oVPSv4Ue0jIHTkvD43sOHNI/ivUZPDPPuwfWtTTFS01zTs8Y3Svec5IwAF9ZGN3TqvYHw7yqmmpZJiC1hwTknoAtxiGJ5qaKLLG4ByTyWUWaldTwZkJ3O57fBRUFAyna0vw+QDr3D2K6R9FiuvPKCITMHNTNChZ1U7VzWUzAp2BQMU7EROwKeMKGNTx9VRM0KZg5qJqmb1QTMCnYFCxTM6IidgUzQoY1O3qgmaFr/tnuUcGmmUTZQJ6iZuWd5YMkn4gLYLVj+vLIb7pqqpY2g1AHEhJ9NvMD38x70lY3c4QsEs8UbnBjXODS49Bk9VsTtRxorXJtOmY/q+O2NiMdTH/XTudGHF7n9SDuI2/d9S11LG6N7mSNLXtJBaRgg+CvjNTVU7qP67iZdo6NobBHU9zR0a57cPLR6O7Cw6sk7ZbfSQXHT90paeKlmvFpgr6mCJoaxsrgQ4taOgOM48cq39k80kWsYGMJ2yxva/2AZ/aArDqS+1+pLvLcrrIH1DwGgNaGtY0DDWtaOQAHcs97G7FKX1F7mYWwtHAhJH3ifvEezGPeV4+0JxwtzPlLrZ8Sn1deW/8As8fsCrVRW/8As8fsCrV66doc5RyrjTtn/Gnf/wBIz92xdlyrjTtn/Gnf/wBIz92xBiLOqnaoGdVO1VlOzuU7FAzuU7FUTM5jmvYhjPWNvwXiNTs7kR7ihjb92No9yqmKBinYqJ2KePooGqePogmZ1U7VAzqp2okpmKdigYvFZI6NjCxxBJRmZxGVyjU8fVYxfNSQWJlIJ4Zp5JwdoZgdOuSfavlHrW3SVEsdQyemEUDZ3vlZyAO3lgc8+cFctMvapm9VjQ1dZAHE1zcNYZCdjvug4z08V7drGyMkkjZWtkmZGZOG1py7Dd2AcYzjuTKYZSxTM6LEbfriy1FBFUzTupuJG6XhyMJIaHFpPLI6hVsesrAXyM+sYw6Nu9+WuAAxnPTwTJiWURqdvVYkzXWm+CyX6zjLXuc1vmOzkAEjGM94U101fS2vUFHQVLAymnpX1Tqpz8BjWgn7uOfRDDLmr3tyrJp/Ulpvz52WmsbUugDTJtaRt3Zx1HqKvzeiIwHW3Z3S32V9ZRPFJXu5uOPMkP8AiHcfWFrufsy1LHLsjpoZm5++yZoHzwV0OG5XtsYUw1FUw0xpjsjqJKhkuoKhjIRgmCA5c71F3d7srbstFBQWmGmpImxQRENYxowAMFXKNmFDdxijb+cP4rw9pxjhLno68PObtLZtEMQR/mhVapaT+pj/ADQqpeunaCUcq407Z/xp3/8ASM/dsREGGykiF5BwcL5bXOdv3OJ6dSiKsrmxTsRFUTRqdiIhKdqscdRN9chnFk2cbG3ccYyiIi6alcW2SctJB83mD/iCudqJNupSTkmNv7ERBXs6qdqIqkpmKKv/AKtntREliv8ASw7tKceFRMydhgkO3uyMc1iEjnCKoAcQHW6MEZ682IijpTtC89oZLa6k2kjNqjBx3+cqKzTysur4WSyNhcZC5gcQ0/ZHqEROqxstUsj/AKtpBvdgUkjRz7uIeXsWVUAB0hrTIBwyk/giISpdIyPk1Pp9sj3Pa2vIAcc481qyftk/3ki/yub9pRE6HVU9gMj5bjqF8r3PeW0+XOOSeT1ulvREWo2Yq3TsU0aIjKdiprx/ZG/nD+KIvD2p9Jc9HfhvFpbNpP6mP80KqRF6qdoV/9k=",
+              "timestamp": 6600966850,
+              "timing": 5979
+            }
+          ]
+        }
+      },
+      "bootup-time": {
+        "id": "bootup-time",
+        "title": "Reduce JavaScript execution time",
+        "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to reduce Javascript execution time](https://developer.chrome.com/docs/lighthouse/performance/bootup-time/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "1.7 s",
+        "metricSavings": {
+          "TBT": 550
+        },
+        "details": {
+          "items": [
+            {
+              "total": 658.26119999999776,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "scriptParseCompile": 13.5768,
+              "scripting": 525.2111999999978
+            },
+            {
+              "total": 554.65440000000024,
+              "url": "https://www.ocobo.co/blog",
+              "scriptParseCompile": 99.351599999999991,
+              "scripting": 14.5632
+            },
+            {
+              "scriptParseCompile": 10.446,
+              "scripting": 295.9752,
+              "total": 533.34719999999993,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "total": 448.80480000000023,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "scriptParseCompile": 164.35439999999994,
+              "scripting": 243.34320000000025
+            },
+            {
+              "scriptParseCompile": 0,
+              "scripting": 41.148000000000025,
+              "url": "Unattributable",
+              "total": 317.1467999999972
+            },
+            {
+              "scriptParseCompile": 123.12,
+              "scripting": 142.44120000000021,
+              "total": 294.97200000000021,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "total": 51.589200000000005,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "scriptParseCompile": 10.5456,
+              "scripting": 37.2792
+            }
+          ],
+          "summary": {
+            "wastedMs": 1721.3555999999983
+          },
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "granularity": 1,
+              "key": "total",
+              "valueType": "ms",
+              "label": "Total CPU Time"
+            },
+            {
+              "label": "Script Evaluation",
+              "valueType": "ms",
+              "key": "scripting",
+              "granularity": 1
+            },
+            {
+              "label": "Script Parse",
+              "granularity": 1,
+              "key": "scriptParseCompile",
+              "valueType": "ms"
+            }
+          ],
+          "sortedBy": [
+            "total"
+          ],
+          "type": "table"
+        },
+        "numericValue": 1721.3555999999983,
+        "numericUnit": "millisecond"
+      },
+      "cache-insight": {
+        "id": "cache-insight",
+        "title": "Use efficient cache lifetimes",
+        "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more about caching](https://developer.chrome.com/docs/performance/insights/cache).",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 319 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "totalBytes": 204714,
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 196184.25
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "totalBytes": 43663,
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 41843.708333333336
+            },
+            {
+              "cacheLifetimeMs": 600000,
+              "wastedBytes": 27276.333333333332,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "totalBytes": 29756
+            },
+            {
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 26789.25,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "totalBytes": 27954
+            },
+            {
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "totalBytes": 27218,
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 26083.916666666668
+            },
+            {
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "totalBytes": 5017,
+              "cacheLifetimeMs": 600000,
+              "wastedBytes": 4598.9166666666661
+            },
+            {
+              "wastedBytes": 1833.3333333333333,
+              "cacheLifetimeMs": 600000,
+              "totalBytes": 2000,
+              "url": "https://useago.github.io/widgetjs/frame.css"
+            },
+            {
+              "wastedBytes": 1661,
+              "cacheLifetimeMs": 0,
+              "totalBytes": 1661,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js"
+            }
+          ],
+          "headings": [
+            {
+              "label": "Request",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "valueType": "ms",
+              "key": "cacheLifetimeMs",
+              "displayUnit": "duration",
+              "label": "Cache TTL"
+            },
+            {
+              "label": "Transfer Size",
+              "displayUnit": "kb",
+              "granularity": 1,
+              "key": "totalBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "debugData": {
+            "wastedBytes": 326270.70833333337,
+            "type": "debugdata"
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "type": "table",
+          "skipSumming": [
+            "cacheLifetimeMs"
+          ]
+        }
+      },
+      "redirects": {
+        "id": "redirects",
+        "title": "Avoid multiple page redirects",
+        "description": "Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://developer.chrome.com/docs/lighthouse/performance/redirects/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 0,
+          "items": [],
+          "headings": [],
+          "type": "opportunity"
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "diagnostics": {
+        "id": "diagnostics",
+        "title": "Diagnostics",
+        "description": "Collection of useful page vitals.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "maxRtt": 7.8534449999999989,
+              "numStylesheets": 3,
+              "maxServerLatency": 42,
+              "totalByteWeight": 9823861,
+              "numTasksOver100ms": 4,
+              "numTasks": 1779,
+              "rtt": 0.00084676039738510887,
+              "numTasksOver500ms": 0,
+              "numFonts": 5,
+              "mainDocumentTransferSize": 349067,
+              "numTasksOver10ms": 46,
+              "numTasksOver25ms": 23,
+              "numRequests": 90,
+              "totalTaskTime": 2539.0739999999996,
+              "numScripts": 54,
+              "numTasksOver50ms": 10,
+              "throughput": 104330665370.65886
+            }
+          ]
+        }
+      },
+      "server-response-time": {
+        "id": "server-response-time",
+        "title": "Initial server response time was short",
+        "description": "Keep the server response time for the main document short because all other requests depend on it. [Learn more about the Time to First Byte metric](https://developer.chrome.com/docs/lighthouse/performance/time-to-first-byte/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Root document took 110 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 7,
+          "items": [
+            {
+              "responseTime": 107,
+              "url": "https://www.ocobo.co/blog"
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Time Spent",
+              "valueType": "timespanMs",
+              "key": "responseTime"
+            }
+          ],
+          "type": "opportunity"
+        },
+        "numericValue": 107,
+        "numericUnit": "millisecond"
+      },
+      "unused-javascript": {
+        "id": "unused-javascript",
+        "title": "Reduce unused JavaScript",
+        "description": "Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 390 KiB",
+        "metricSavings": {
+          "LCP": 150,
+          "FCP": 150
+        },
+        "details": {
+          "type": "opportunity",
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 150,
+              "FCP": 150
+            }
+          },
+          "overallSavingsBytes": 399250,
+          "headings": [
+            {
+              "label": "URL",
+              "subItemsHeading": {
+                "valueType": "code",
+                "key": "source"
+              },
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "subItemsHeading": {
+                "key": "sourceBytes"
+              },
+              "label": "Transfer Size",
+              "key": "totalBytes",
+              "valueType": "bytes"
+            },
+            {
+              "subItemsHeading": {
+                "key": "sourceWastedBytes"
+              },
+              "label": "Est Savings",
+              "valueType": "bytes",
+              "key": "wastedBytes"
+            }
+          ],
+          "overallSavingsMs": 150,
+          "items": [
+            {
+              "totalBytes": 196264,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedPercent": 57.372344479375059,
+              "wastedBytes": 112601
+            },
+            {
+              "wastedBytes": 111412,
+              "totalBytes": 156409,
+              "wastedPercent": 71.231386255999567,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedPercent": 42.2154629213789,
+              "totalBytes": 196264,
+              "wastedBytes": 82854
+            },
+            {
+              "wastedBytes": 67764,
+              "totalBytes": 156409,
+              "wastedPercent": 43.325139503661774,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "wastedBytes": 24619,
+              "totalBytes": 43320,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "wastedPercent": 56.831359413007931
+            }
+          ]
+        },
+        "numericValue": 150,
+        "numericUnit": "millisecond"
+      },
+      "font-display-insight": {
+        "id": "font-display-insight",
+        "title": "Font display",
+        "description": "Consider setting [font-display](https://developer.chrome.com/docs/performance/insights/font-display) to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with [font metric overrides](https://developer.chrome.com/blog/font-fallbacks).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [],
+          "skipSumming": [
+            "wastedMs"
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "ms",
+              "key": "wastedMs",
+              "label": "Est Savings"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "legacy-javascript-insight": {
+        "id": "legacy-javascript-insight",
+        "title": "Legacy JavaScript",
+        "description": "Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile [Baseline](https://web.dev/articles/baseline-and-polyfills) features, unless you know you must support older browsers. [Learn why most sites can deploy ES6+ code without transpiling](https://developer.chrome.com/docs/performance/insights/legacy-javascript)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 13 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL",
+              "subItemsHeading": {
+                "valueType": "source-location",
+                "key": "location"
+              }
+            },
+            {
+              "valueType": "code",
+              "key": null,
+              "subItemsHeading": {
+                "key": "signal"
+              }
+            },
+            {
+              "valueType": "bytes",
+              "key": "wastedBytes",
+              "label": "Wasted bytes"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 13769,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "signal": "Array.prototype.concat",
+                    "location": {
+                      "type": "source-location",
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 6239,
+                      "urlProvider": "network"
+                    }
+                  },
+                  {
+                    "location": {
+                      "column": 12925,
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "signal": "Object.assign",
+                    "location": {
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "type": "source-location",
+                      "urlProvider": "network",
+                      "column": 12813
+                    }
+                  },
+                  {
+                    "signal": "Object.create",
+                    "location": {
+                      "column": 10857,
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    }
+                  }
+                ]
+              },
+              "wastedBytes": 13769
+            }
+          ]
+        }
+      },
+      "network-server-latency": {
+        "id": "network-server-latency",
+        "title": "Server Backend Latencies",
+        "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "40 ms",
+        "details": {
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "text",
+              "key": "origin"
+            },
+            {
+              "label": "Time Spent",
+              "valueType": "ms",
+              "key": "serverResponseTime",
+              "granularity": 1
+            }
+          ],
+          "type": "table",
+          "sortedBy": [
+            "serverResponseTime"
+          ],
+          "items": [
+            {
+              "origin": "https://www.googletagmanager.com",
+              "serverResponseTime": 42
+            },
+            {
+              "serverResponseTime": 32.5,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "serverResponseTime": 26,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "origin": "https://images.unsplash.com",
+              "serverResponseTime": 2.5
+            },
+            {
+              "origin": "https://js-eu1.hubspot.com",
+              "serverResponseTime": 2
+            },
+            {
+              "origin": "https://js-eu1.hscollectedforms.net",
+              "serverResponseTime": 2
+            },
+            {
+              "origin": "https://js-eu1.hs-analytics.net",
+              "serverResponseTime": 2
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "origin": "https://track-eu1.hubspot.com",
+              "serverResponseTime": 1.5
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "origin": "https://js-eu1.hs-scripts.com",
+              "serverResponseTime": 1
+            },
+            {
+              "origin": "https://useago.github.io",
+              "serverResponseTime": 1
+            },
+            {
+              "origin": "https://forms-eu1.hscollectedforms.net",
+              "serverResponseTime": 1
+            },
+            {
+              "origin": "https://cta-eu1.hubspot.com",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "origin": "https://forms-eu1.hsforms.com",
+              "serverResponseTime": 1
+            },
+            {
+              "origin": "https://fonts.googleapis.com",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 0.5,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "serverResponseTime": 0.5,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "origin": "https://www.google-analytics.com",
+              "serverResponseTime": 0
+            }
+          ]
+        },
+        "numericValue": 42,
+        "numericUnit": "millisecond"
+      },
+      "lcp-breakdown-insight": {
+        "id": "lcp-breakdown-insight",
+        "title": "LCP breakdown",
+        "description": "Each [subpart has specific improvement strategies](https://developer.chrome.com/docs/performance/insights/lcp-breakdown). Ideally, most of the LCP time should be spent on loading the resources, not within delays.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "headings": [
+                {
+                  "label": "Subpart",
+                  "valueType": "text",
+                  "key": "label"
+                },
+                {
+                  "label": "Duration",
+                  "valueType": "ms",
+                  "key": "duration"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "duration": 1.3269999990463257,
+                  "label": "Time to first byte",
+                  "subpart": "timeToFirstByte"
+                },
+                {
+                  "duration": 2785.2000000009539,
+                  "label": "Resource load delay",
+                  "subpart": "resourceLoadDelay"
+                },
+                {
+                  "duration": 252.392,
+                  "label": "Resource load duration",
+                  "subpart": "resourceLoadDuration"
+                },
+                {
+                  "duration": 258.603,
+                  "label": "Element render delay",
+                  "subpart": "elementRenderDelay"
+                }
+              ]
+            },
+            {
+              "type": "node",
+              "nodeLabel": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute",
+              "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,1,A,0,DIV,0,IMG",
+              "lhId": "page-1-IMG",
+              "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"pos_absolute inset_0 w_full h_full obj-f_cover op_0.8\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+              "boundingRect": {
+                "width": 380,
+                "right": 396,
+                "top": 668,
+                "left": 16,
+                "height": 224,
+                "bottom": 892
+              },
+              "selector": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute"
+            }
+          ]
+        }
+      },
+      "third-parties-insight": {
+        "id": "third-parties-insight",
+        "title": "3rd parties",
+        "description": "3rd party code can significantly impact load performance. [Reduce and defer loading of 3rd party code](https://developer.chrome.com/docs/performance/insights/third-parties) to prioritize your page's content.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "headings": [
+            {
+              "label": "3rd party",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "valueType": "text",
+              "key": "entity"
+            },
+            {
+              "granularity": 1,
+              "key": "transferSize",
+              "label": "Transfer size",
+              "valueType": "bytes",
+              "subItemsHeading": {
+                "key": "transferSize"
+              }
+            },
+            {
+              "key": "mainThreadTime",
+              "granularity": 1,
+              "label": "Main thread time",
+              "valueType": "ms",
+              "subItemsHeading": {
+                "key": "mainThreadTime"
+              }
+            }
+          ],
+          "type": "table",
+          "isEntityGrouped": true,
+          "items": [
+            {
+              "mainThreadTime": 402.92199999745935,
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 206377,
+                    "mainThreadTime": 301.53799999691546,
+                    "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+                  },
+                  {
+                    "transferSize": 27954,
+                    "mainThreadTime": 31.238999999128282,
+                    "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                  },
+                  {
+                    "mainThreadTime": 29.773000001907349,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+                    "transferSize": 43663
+                  },
+                  {
+                    "transferSize": 29756,
+                    "mainThreadTime": 20.244999999180436,
+                    "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+                  },
+                  {
+                    "transferSize": 27218,
+                    "mainThreadTime": 16.072000000625849,
+                    "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+                  },
+                  {
+                    "transferSize": 1661,
+                    "mainThreadTime": 3.6119999997317791,
+                    "url": "https://js-eu1.hs-scripts.com/27107933.js"
+                  },
+                  {
+                    "mainThreadTime": 0.25499999988824129,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953",
+                    "transferSize": 4080
+                  },
+                  {
+                    "mainThreadTime": 0.18800000008195639,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+                    "transferSize": 1095
+                  },
+                  {
+                    "transferSize": 1718,
+                    "mainThreadTime": 0,
+                    "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fblog&isMobile=true"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog&t=Ocobo+%C2%B7+Le+blog+des+Revenue+Operations&cts=1778779336025&vi=0bd2c9deca31611a784a1c1c57aa132e&nc=true&u=242475741.0bd2c9deca31611a784a1c1c57aa132e.1778779336019.1778779336019.1778779336019.1&b=242475741.1.1778779336019&cc=15",
+                    "transferSize": 1520
+                  },
+                  {
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+                    "mainThreadTime": 0,
+                    "transferSize": 1024
+                  },
+                  {
+                    "transferSize": 1023,
+                    "mainThreadTime": 0,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1"
+                  },
+                  {
+                    "transferSize": 1022,
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=b916c0ef-f2f0-4cb0-bcaf-2f09a3963e59&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog&t=Ocobo+%C2%B7+Le+blog+des+Revenue+Operations&cts=1778779336375&vi=0bd2c9deca31611a784a1c1c57aa132e&nc=true&u=242475741.0bd2c9deca31611a784a1c1c57aa132e.1778779336019.1778779336019.1778779336019.1&b=242475741.1.1778779336019&cc=15"
+                  },
+                  {
+                    "transferSize": 1020,
+                    "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 558,
+                    "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "entity": "Hubspot",
+              "transferSize": 349689
+            },
+            {
+              "mainThreadTime": 222.68300000205636,
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 157097,
+                    "mainThreadTime": 222.68300000205636,
+                    "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "transferSize": 157097,
+              "entity": "Google Tag Manager"
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 6.6089999973773956,
+                    "url": "https://useago.github.io/widgetjs/frame.js",
+                    "transferSize": 5017
+                  },
+                  {
+                    "transferSize": 2000,
+                    "mainThreadTime": 0,
+                    "url": "https://useago.github.io/widgetjs/frame.css"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "transferSize": 7017,
+              "entity": "GitHub",
+              "mainThreadTime": 6.6089999973773956
+            },
+            {
+              "transferSize": 7837820,
+              "entity": "vercel-storage.com",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/corentin-guerin.jpeg",
+                    "transferSize": 2701533
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/aude-cadiot.jpg",
+                    "transferSize": 2527840
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/ethel-gosset.jpeg",
+                    "transferSize": 2246162
+                  },
+                  {
+                    "transferSize": 202020,
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png"
+                  },
+                  {
+                    "transferSize": 92677,
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-13/cover-1.png"
+                  },
+                  {
+                    "transferSize": 67588,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg",
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "mainThreadTime": 0
+            },
+            {
+              "transferSize": 559808,
+              "entity": "unsplash.com",
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 179754,
+                    "url": "https://images.unsplash.com/photo-1566140967404-b8b3932483f5?w=1200&h=800&fit=crop",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://images.unsplash.com/photo-1612385763901-68857dd4c43c?w=1200&h=800&fit=crop",
+                    "transferSize": 159084
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=1200&h=800&fit=crop",
+                    "transferSize": 158840
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://images.unsplash.com/photo-1493612276216-ee3925520721?ixlib=rb-4.0.3&q=85&fm=jpg&cs=srgb&w=1200&h=800&fit=crop",
+                    "transferSize": 62130
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 1278,
+                    "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "transferSize": 1278,
+              "entity": "Clearbit",
+              "mainThreadTime": 0
+            },
+            {
+              "transferSize": 796,
+              "entity": "Google Analytics",
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 796,
+                    "mainThreadTime": 0,
+                    "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65c1v9100339653za200zd9100339653&_p=1778779333946&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1547864760.1778779335&frm=0&pscdl=noapi&rcb=11&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115938466~115938468~118012007&dp=%2Fblog&sid=1778779334&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fblog&dt=Ocobo%20%C2%B7%20Le%20blog%20des%20Revenue%20Operations&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=3803"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0
+            },
+            {
+              "mainThreadTime": 0,
+              "entity": "Google Fonts",
+              "transferSize": 103931,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                    "transferSize": 102672
+                  },
+                  {
+                    "transferSize": 1259,
+                    "mainThreadTime": 0,
+                    "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "render-blocking-insight": {
+        "id": "render-blocking-insight",
+        "title": "Render blocking requests",
+        "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 160 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 150
+        },
+        "details": {
+          "items": [
+            {
+              "wastedMs": 165,
+              "totalBytes": 24569,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Transfer Size"
+            },
+            {
+              "valueType": "timespanMs",
+              "key": "wastedMs",
+              "label": "Duration"
+            }
+          ],
+          "type": "table"
+        }
+      }
+    },
+    "categories": {
+      "performance": {
+        "id": "performance",
+        "title": "Performance",
+        "score": 0.46,
+        "auditRefs": [
+          {
+            "id": "first-contentful-paint",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "FCP"
+          },
+          {
+            "id": "largest-contentful-paint",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "LCP"
+          },
+          {
+            "id": "total-blocking-time",
+            "weight": 30,
+            "group": "metrics",
+            "acronym": "TBT"
+          },
+          {
+            "id": "cumulative-layout-shift",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "CLS"
+          },
+          {
+            "id": "speed-index",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "SI"
+          },
+          {
+            "id": "cache-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "cls-culprits-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "document-latency-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "dom-size-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "duplicated-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "font-display-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "forced-reflow-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "image-delivery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "inp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-discovery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "legacy-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "network-dependency-tree-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "render-blocking-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "third-parties-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "viewport-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "interactive",
+            "weight": 0,
+            "group": "hidden",
+            "acronym": "TTI"
+          },
+          {
+            "id": "max-potential-fid",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "unminified-css",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unminified-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-css-rules",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "total-byte-weight",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "user-timings",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "bootup-time",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "mainthread-work-breakdown",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "long-tasks",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "non-composited-animations",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unsized-images",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "network-requests",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-rtt",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-server-latency",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "main-thread-tasks",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "diagnostics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "metrics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "screenshot-thumbnails",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "final-screenshot",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "script-treemap-data",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "resource-summary",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "redirects",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "server-response-time",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "layout-shifts",
+            "weight": 0,
+            "group": "hidden"
+          }
+        ]
+      }
+    },
+    "categoryGroups": {
+      "best-practices-browser-compat": {
+        "title": "Browser Compatibility"
+      },
+      "best-practices-general": {
+        "title": "General"
+      },
+      "best-practices-trust-safety": {
+        "title": "Trust and Safety"
+      },
+      "a11y-names-labels": {
+        "title": "Names and labels",
+        "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "a11y-best-practices": {
+        "title": "Best practices",
+        "description": "These items highlight common accessibility best practices."
+      },
+      "seo-content": {
+        "title": "Content Best Practices",
+        "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+      },
+      "seo-mobile": {
+        "title": "Mobile Friendly",
+        "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn how to make pages mobile-friendly](https://developers.google.com/search/mobile-sites/)."
+      },
+      "best-practices-ux": {
+        "title": "User Experience"
+      },
+      "a11y-language": {
+        "title": "Internationalization and localization",
+        "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      },
+      "seo-crawl": {
+        "title": "Crawling and Indexing",
+        "description": "To appear in search results, crawlers need access to your app."
+      },
+      "a11y-aria": {
+        "title": "ARIA",
+        "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "a11y-tables-lists": {
+        "title": "Tables and lists",
+        "description": "These are opportunities to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "description": "More information about the performance of your application. These numbers don't [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score."
+      },
+      "a11y-audio-video": {
+        "title": "Audio and video",
+        "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+      },
+      "insights": {
+        "title": "Insights",
+        "description": "These insights are also available in the Chrome DevTools Performance Panel - [record a trace](https://developer.chrome.com/docs/devtools/performance/reference) to view more detailed information."
+      },
+      "a11y-navigation": {
+        "title": "Navigation",
+        "description": "These are opportunities to improve keyboard navigation in your application."
+      },
+      "a11y-color-contrast": {
+        "title": "Contrast",
+        "description": "These are opportunities to improve the legibility of your content."
+      },
+      "metrics": {
+        "title": "Metrics"
+      }
+    },
+    "timing": {
+      "total": 27465.100000000002
+    },
+    "i18n": {
+      "rendererFormattedStrings": {
+        "varianceDisclaimer": "Values are estimated and may vary. The [performance score is calculated](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) directly from these metrics.",
+        "opportunityResourceColumnLabel": "Opportunity",
+        "opportunitySavingsColumnLabel": "Estimated Savings",
+        "errorMissingAuditInfo": "Report error: no audit information",
+        "errorLabel": "Error!",
+        "warningHeader": "Warnings: ",
+        "passedAuditsGroupTitle": "Passed audits",
+        "notApplicableAuditsGroupTitle": "Not applicable",
+        "manualAuditsGroupTitle": "Additional items to manually check",
+        "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+        "crcLongestDurationLabel": "Maximum critical path latency:",
+        "crcInitialNavigation": "Initial Navigation",
+        "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+        "labDataTitle": "Lab Data",
+        "warningAuditsGroupTitle": "Passed audits but with warnings",
+        "snippetExpandButtonLabel": "Expand snippet",
+        "snippetCollapseButtonLabel": "Collapse snippet",
+        "thirdPartyResourcesLabel": "Show 3rd-party resources",
+        "runtimeDesktopEmulation": "Emulated Desktop",
+        "runtimeMobileEmulation": "Emulated Moto G Power",
+        "runtimeNoEmulation": "No emulation",
+        "runtimeSettingsBenchmark": "Unthrottled CPU/Memory Power",
+        "runtimeSettingsCPUThrottling": "CPU throttling",
+        "runtimeSettingsDevice": "Device",
+        "runtimeSettingsNetworkThrottling": "Network throttling",
+        "runtimeSettingsUANetwork": "User agent (network)",
+        "runtimeUnknown": "Unknown",
+        "dropdownCopyJSON": "Copy JSON",
+        "dropdownDarkTheme": "Toggle Dark Theme",
+        "dropdownPrintExpanded": "Print Expanded",
+        "dropdownPrintSummary": "Print Summary",
+        "dropdownSaveGist": "Save as Gist",
+        "dropdownSaveHTML": "Save as HTML",
+        "dropdownSaveJSON": "Save as JSON",
+        "dropdownViewer": "Open in Viewer",
+        "footerIssue": "File an issue",
+        "throttlingProvided": "Provided by environment",
+        "calculatorLink": "See calculator.",
+        "runtimeSettingsAxeVersion": "Axe version",
+        "viewTreemapLabel": "View Treemap",
+        "showRelevantAudits": "Show audits relevant to:"
+      }
+    },
+    "entities": [
+      {
+        "name": "ocobo.co",
+        "isFirstParty": true,
+        "isUnrecognized": true,
+        "origins": [
+          "https://www.ocobo.co"
+        ]
+      },
+      {
+        "name": "vercel-storage.com",
+        "isUnrecognized": true,
+        "origins": [
+          "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+        ]
+      },
+      {
+        "name": "Google Tag Manager",
+        "homepage": "https://marketingplatform.google.com/about/tag-manager/",
+        "category": "tag-manager",
+        "origins": [
+          "https://www.googletagmanager.com"
+        ]
+      },
+      {
+        "name": "Clearbit",
+        "homepage": "https://clearbit.com/",
+        "category": "analytics",
+        "origins": [
+          "https://tag.clearbitscripts.com"
+        ]
+      },
+      {
+        "name": "Hubspot",
+        "homepage": "https://hubspot.com/",
+        "category": "marketing",
+        "origins": [
+          "https://js-eu1.hs-scripts.com",
+          "https://js-eu1.hubspot.com",
+          "https://js-eu1.hscollectedforms.net",
+          "https://js-eu1.hs-analytics.net",
+          "https://js-eu1.hs-banner.com",
+          "https://js-eu1.hsforms.net",
+          "https://forms-eu1.hscollectedforms.net",
+          "https://cta-eu1.hubspot.com",
+          "https://perf-eu1.hsforms.com",
+          "https://forms-eu1.hsforms.com",
+          "https://track-eu1.hubspot.com"
+        ]
+      },
+      {
+        "name": "GitHub",
+        "category": "utility",
+        "origins": [
+          "https://useago.github.io"
+        ]
+      },
+      {
+        "name": "unsplash.com",
+        "isUnrecognized": true,
+        "origins": [
+          "https://images.unsplash.com"
+        ]
+      },
+      {
+        "name": "Google Analytics",
+        "homepage": "https://marketingplatform.google.com/about/analytics/",
+        "category": "analytics",
+        "origins": [
+          "https://www.google-analytics.com"
+        ]
+      },
+      {
+        "name": "Google Fonts",
+        "homepage": "https://fonts.google.com/",
+        "category": "cdn",
+        "origins": [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com"
+        ]
+      }
+    ],
+    "fullPageScreenshot": {
+      "nodes": {
+        "1-54-IMG": {
+          "width": 20,
+          "height": 20,
+          "bottom": 15981,
+          "left": 41,
+          "right": 61,
+          "top": 15961
+        },
+        "1-75-IMG": {
+          "bottom": 21953,
+          "height": 213,
+          "left": 17,
+          "top": 21740,
+          "right": 395,
+          "width": 378
+        },
+        "1-5-IMG": {
+          "height": 213,
+          "bottom": 2227,
+          "right": 395,
+          "top": 2014,
+          "left": 17,
+          "width": 378
+        },
+        "page-5-P": {
+          "width": 380,
+          "height": 52,
+          "bottom": 513,
+          "right": 396,
+          "top": 461,
+          "left": 16
+        },
+        "page-4-IMG": {
+          "width": 134,
+          "top": 37,
+          "right": 167,
+          "left": 33,
+          "height": 40,
+          "bottom": 77
+        },
+        "page-3-IMG": {
+          "width": 30,
+          "right": 380,
+          "top": 16320,
+          "left": 350,
+          "id": "open-path",
+          "height": 32,
+          "bottom": 16352
+        },
+        "1-78-IMG": {
+          "width": 20,
+          "height": 20,
+          "bottom": 22591,
+          "top": 22571,
+          "right": 61,
+          "left": 41
+        },
+        "page-24-IMG": {
+          "height": 213,
+          "bottom": 3915,
+          "right": 395,
+          "top": 3703,
+          "left": 17,
+          "width": 378
+        },
+        "1-23-IMG": {
+          "width": 378,
+          "right": 395,
+          "top": 7108,
+          "left": 17,
+          "height": 213,
+          "bottom": 7320
+        },
+        "1-72-IMG": {
+          "height": 20,
+          "bottom": 20988,
+          "left": 41,
+          "top": 20968,
+          "right": 61,
+          "width": 20
+        },
+        "1-53-IMG": {
+          "width": 378,
+          "left": 17,
+          "top": 15655,
+          "right": 395,
+          "bottom": 15868,
+          "height": 213
+        },
+        "page-26-BUTTON": {
+          "width": 20,
+          "height": 26,
+          "bottom": 16219,
+          "top": 16193,
+          "right": 397,
+          "id": "ago-prompt-close",
+          "left": 377
+        },
+        "1-26-IMG": {
+          "top": 7995,
+          "right": 61,
+          "left": 41,
+          "bottom": 8015,
+          "height": 20,
+          "width": 20
+        },
+        "1-60-IMG": {
+          "bottom": 17641,
+          "height": 20,
+          "left": 41,
+          "right": 61,
+          "top": 17621,
+          "width": 20
+        },
+        "1-74-IMG": {
+          "width": 20,
+          "left": 41,
+          "right": 61,
+          "top": 21522,
+          "bottom": 21542,
+          "height": 20
+        },
+        "1-40-IMG": {
+          "width": 20,
+          "height": 20,
+          "bottom": 12051,
+          "right": 61,
+          "top": 12031,
+          "left": 41
+        },
+        "1-20-IMG": {
+          "width": 20,
+          "height": 20,
+          "bottom": 6327,
+          "right": 61,
+          "top": 6307,
+          "left": 41
+        },
+        "1-39-IMG": {
+          "height": 213,
+          "bottom": 11881,
+          "left": 17,
+          "right": 395,
+          "top": 11668,
+          "width": 378
+        },
+        "1-29-IMG": {
+          "height": 213,
+          "bottom": 8980,
+          "right": 395,
+          "top": 8767,
+          "left": 17,
+          "width": 378
+        },
+        "1-86-IMG": {
+          "width": 20,
+          "bottom": 24718,
+          "height": 20,
+          "left": 41,
+          "top": 24698,
+          "right": 61
+        },
+        "1-83-IMG": {
+          "width": 378,
+          "bottom": 24052,
+          "height": 213,
+          "left": 17,
+          "top": 23839,
+          "right": 395
+        },
+        "page-20-IMG": {
+          "height": 20,
+          "bottom": 4086,
+          "right": 61,
+          "top": 4066,
+          "left": 41,
+          "width": 20
+        },
+        "1-27-IMG": {
+          "bottom": 8427,
+          "height": 213,
+          "left": 17,
+          "right": 395,
+          "top": 8214,
+          "width": 378
+        },
+        "1-16-IMG": {
+          "width": 20,
+          "bottom": 5221,
+          "height": 20,
+          "right": 61,
+          "top": 5201,
+          "left": 41
+        },
+        "page-19-IMG": {
+          "width": 20,
+          "bottom": 3504,
+          "height": 20,
+          "top": 3484,
+          "right": 61,
+          "left": 41
+        },
+        "1-25-IMG": {
+          "right": 395,
+          "top": 7661,
+          "left": 17,
+          "height": 213,
+          "bottom": 7873,
+          "width": 378
+        },
+        "page-9-BODY": {
+          "width": 412,
+          "height": 25905,
+          "bottom": 25905,
+          "left": 0,
+          "top": 0,
+          "right": 412
+        },
+        "page-12-IMG": {
+          "width": 20,
+          "left": 41,
+          "right": 61,
+          "top": 2931,
+          "height": 20,
+          "bottom": 2951
+        },
+        "1-59-IMG": {
+          "width": 378,
+          "left": 17,
+          "right": 395,
+          "top": 17258,
+          "height": 213,
+          "bottom": 17470
+        },
+        "1-19-IMG": {
+          "height": 213,
+          "bottom": 6185,
+          "left": 17,
+          "top": 5973,
+          "right": 395,
+          "width": 378
+        },
+        "1-13-IMG": {
+          "width": 378,
+          "left": 17,
+          "top": 4284,
+          "right": 395,
+          "bottom": 4497,
+          "height": 213
+        },
+        "1-42-IMG": {
+          "width": 20,
+          "bottom": 12605,
+          "height": 20,
+          "left": 41,
+          "top": 12585,
+          "right": 61
+        },
+        "1-12-IMG": {
+          "width": 20,
+          "bottom": 4086,
+          "height": 20,
+          "left": 41,
+          "top": 4066,
+          "right": 61
+        },
+        "1-30-IMG": {
+          "width": 20,
+          "left": 41,
+          "right": 61,
+          "top": 9102,
+          "bottom": 9122,
+          "height": 20
+        },
+        "1-61-IMG": {
+          "width": 378,
+          "height": 213,
+          "bottom": 18052,
+          "right": 395,
+          "top": 17839,
+          "left": 17
+        },
+        "page-0-IMG": {
+          "left": 41,
+          "right": 61,
+          "top": 4647,
+          "height": 20,
+          "bottom": 4667,
+          "width": 20
+        },
+        "page-15-IMG": {
+          "width": 20,
+          "bottom": 6327,
+          "height": 20,
+          "right": 61,
+          "top": 6307,
+          "left": 41
+        },
+        "1-48-IMG": {
+          "right": 61,
+          "top": 14273,
+          "left": 41,
+          "height": 20,
+          "bottom": 14293,
+          "width": 20
+        },
+        "page-7-LINK": {
+          "height": 0,
+          "bottom": 0,
+          "top": 0,
+          "right": 0,
+          "left": 0,
+          "width": 0
+        },
+        "page-14-IMG": {
+          "top": 5754,
+          "right": 61,
+          "left": 41,
+          "bottom": 5774,
+          "height": 20,
+          "width": 20
+        },
+        "1-73-IMG": {
+          "width": 378,
+          "right": 395,
+          "top": 21187,
+          "left": 17,
+          "bottom": 21400,
+          "height": 213
+        },
+        "1-15-IMG": {
+          "top": 4866,
+          "right": 395,
+          "left": 17,
+          "bottom": 5079,
+          "height": 213,
+          "width": 378
+        },
+        "page-25-IMG": {
+          "width": 378,
+          "bottom": 19683,
+          "height": 213,
+          "right": 395,
+          "top": 19470,
+          "left": 17
+        },
+        "1-49-IMG": {
+          "width": 378,
+          "right": 395,
+          "top": 14492,
+          "left": 17,
+          "height": 213,
+          "bottom": 14704
+        },
+        "1-62-IMG": {
+          "width": 20,
+          "left": 41,
+          "right": 61,
+          "top": 18174,
+          "height": 20,
+          "bottom": 18194
+        },
+        "1-36-IMG": {
+          "width": 20,
+          "right": 61,
+          "top": 10868,
+          "left": 41,
+          "height": 20,
+          "bottom": 10888
+        },
+        "1-45-IMG": {
+          "height": 213,
+          "bottom": 13598,
+          "left": 17,
+          "right": 395,
+          "top": 13385,
+          "width": 378
+        },
+        "1-34-IMG": {
+          "width": 20,
+          "right": 61,
+          "top": 10286,
+          "left": 41,
+          "bottom": 10306,
+          "height": 20
+        },
+        "1-70-IMG": {
+          "width": 20,
+          "left": 41,
+          "top": 20415,
+          "right": 61,
+          "height": 20,
+          "bottom": 20435
+        },
+        "1-4-IMG": {
+          "width": 20,
+          "left": 41,
+          "right": 61,
+          "top": 1796,
+          "height": 20,
+          "bottom": 1816
+        },
+        "1-69-IMG": {
+          "top": 20052,
+          "right": 395,
+          "left": 17,
+          "height": 213,
+          "bottom": 20265,
+          "width": 378
+        },
+        "1-38-IMG": {
+          "width": 20,
+          "right": 61,
+          "top": 11450,
+          "left": 41,
+          "bottom": 11470,
+          "height": 20
+        },
+        "1-89-IMG": {
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "left": 0,
+          "width": 0
+        },
+        "1-52-IMG": {
+          "width": 20,
+          "height": 20,
+          "bottom": 15456,
+          "right": 61,
+          "top": 15436,
+          "left": 41
+        },
+        "1-88-IMG": {
+          "width": 0,
+          "top": 0,
+          "right": 0,
+          "left": 0,
+          "height": 0,
+          "bottom": 0
+        },
+        "1-77-IMG": {
+          "width": 378,
+          "left": 17,
+          "right": 395,
+          "top": 22265,
+          "bottom": 22478,
+          "height": 213
+        },
+        "1-58-IMG": {
+          "left": 41,
+          "top": 17039,
+          "right": 61,
+          "bottom": 17059,
+          "height": 20,
+          "width": 20
+        },
+        "1-80-IMG": {
+          "left": 41,
+          "right": 61,
+          "top": 23096,
+          "bottom": 23116,
+          "height": 20,
+          "width": 20
+        },
+        "page-11-IMG": {
+          "width": 20,
+          "height": 20,
+          "bottom": 2369,
+          "left": 41,
+          "top": 2349,
+          "right": 61
+        },
+        "1-43-IMG": {
+          "width": 378,
+          "height": 213,
+          "bottom": 13016,
+          "left": 17,
+          "right": 395,
+          "top": 12803
+        },
+        "page-17-IMG": {
+          "width": 378,
+          "left": 17,
+          "right": 395,
+          "top": 2014,
+          "height": 213,
+          "bottom": 2227
+        },
+        "1-10-IMG": {
+          "width": 20,
+          "bottom": 3504,
+          "height": 20,
+          "top": 3484,
+          "right": 61,
+          "left": 41
+        },
+        "1-46-IMG": {
+          "width": 20,
+          "height": 20,
+          "bottom": 13740,
+          "right": 61,
+          "top": 13720,
+          "left": 41
+        },
+        "1-81-IMG": {
+          "width": 378,
+          "bottom": 23527,
+          "height": 213,
+          "right": 395,
+          "top": 23314,
+          "left": 17
+        },
+        "1-41-IMG": {
+          "width": 378,
+          "bottom": 12463,
+          "height": 213,
+          "right": 395,
+          "top": 12250,
+          "left": 17
+        },
+        "1-63-IMG": {
+          "height": 213,
+          "bottom": 18605,
+          "left": 17,
+          "right": 395,
+          "top": 18393,
+          "width": 378
+        },
+        "1-67-IMG": {
+          "height": 213,
+          "bottom": 19683,
+          "right": 395,
+          "top": 19470,
+          "left": 17,
+          "width": 378
+        },
+        "1-14-IMG": {
+          "right": 61,
+          "top": 4647,
+          "left": 41,
+          "height": 20,
+          "bottom": 4667,
+          "width": 20
+        },
+        "1-44-IMG": {
+          "left": 41,
+          "top": 13166,
+          "right": 61,
+          "bottom": 13186,
+          "height": 20,
+          "width": 20
+        },
+        "page-8-META": {
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "left": 0,
+          "width": 0
+        },
+        "1-8-IMG": {
+          "left": 41,
+          "right": 61,
+          "top": 2931,
+          "height": 20,
+          "bottom": 2951,
+          "width": 20
+        },
+        "1-22-IMG": {
+          "width": 20,
+          "bottom": 6909,
+          "height": 20,
+          "left": 41,
+          "top": 6889,
+          "right": 61
+        },
+        "1-21-IMG": {
+          "bottom": 6738,
+          "height": 213,
+          "top": 6526,
+          "right": 395,
+          "left": 17,
+          "width": 378
+        },
+        "1-87-IMG": {
+          "height": 32,
+          "bottom": 16352,
+          "left": 350,
+          "id": "open-path",
+          "right": 380,
+          "top": 16320,
+          "width": 30
+        },
+        "1-50-IMG": {
+          "width": 20,
+          "height": 20,
+          "bottom": 14875,
+          "left": 41,
+          "right": 61,
+          "top": 14855
+        },
+        "1-71-IMG": {
+          "left": 17,
+          "right": 395,
+          "top": 20634,
+          "height": 213,
+          "bottom": 20847,
+          "width": 378
+        },
+        "1-85-IMG": {
+          "height": 213,
+          "bottom": 24605,
+          "top": 24392,
+          "right": 395,
+          "left": 17,
+          "width": 378
+        },
+        "page-13-IMG": {
+          "bottom": 5221,
+          "height": 20,
+          "left": 41,
+          "right": 61,
+          "top": 5201,
+          "width": 20
+        },
+        "1-6-IMG": {
+          "width": 20,
+          "height": 20,
+          "bottom": 2369,
+          "left": 41,
+          "right": 61,
+          "top": 2349
+        },
+        "page-6-H1": {
+          "left": 16,
+          "right": 396,
+          "top": 250,
+          "bottom": 437,
+          "height": 187,
+          "width": 380
+        },
+        "1-7-IMG": {
+          "top": 2568,
+          "right": 395,
+          "left": 17,
+          "bottom": 2780,
+          "height": 213,
+          "width": 378
+        },
+        "1-65-IMG": {
+          "top": 18917,
+          "right": 395,
+          "left": 17,
+          "bottom": 19130,
+          "height": 213,
+          "width": 378
+        },
+        "1-24-IMG": {
+          "width": 20,
+          "top": 7442,
+          "right": 61,
+          "left": 41,
+          "bottom": 7462,
+          "height": 20
+        },
+        "1-33-IMG": {
+          "right": 395,
+          "top": 9894,
+          "left": 17,
+          "height": 213,
+          "bottom": 10107,
+          "width": 378
+        },
+        "1-84-IMG": {
+          "bottom": 24193,
+          "height": 20,
+          "top": 24173,
+          "right": 61,
+          "left": 41,
+          "width": 20
+        },
+        "1-66-IMG": {
+          "width": 20,
+          "bottom": 19272,
+          "height": 20,
+          "left": 41,
+          "right": 61,
+          "top": 19252
+        },
+        "1-57-IMG": {
+          "right": 395,
+          "top": 16704,
+          "left": 17,
+          "bottom": 16917,
+          "height": 213,
+          "width": 378
+        },
+        "1-79-IMG": {
+          "width": 378,
+          "left": 17,
+          "top": 22790,
+          "right": 395,
+          "height": 213,
+          "bottom": 23002
+        },
+        "page-21-IMG": {
+          "right": 395,
+          "top": 1461,
+          "left": 17,
+          "bottom": 1674,
+          "height": 213,
+          "width": 378
+        },
+        "1-56-IMG": {
+          "width": 20,
+          "top": 16486,
+          "right": 61,
+          "left": 41,
+          "bottom": 16506,
+          "height": 20
+        },
+        "1-32-IMG": {
+          "bottom": 9696,
+          "height": 20,
+          "right": 61,
+          "top": 9676,
+          "left": 41,
+          "width": 20
+        },
+        "1-47-IMG": {
+          "left": 17,
+          "right": 395,
+          "top": 13938,
+          "height": 213,
+          "bottom": 14151,
+          "width": 378
+        },
+        "page-1-IMG": {
+          "bottom": 892,
+          "height": 224,
+          "top": 668,
+          "right": 396,
+          "left": 16,
+          "width": 380
+        },
+        "1-18-IMG": {
+          "left": 41,
+          "top": 5754,
+          "right": 61,
+          "bottom": 5774,
+          "height": 20,
+          "width": 20
+        },
+        "1-82-IMG": {
+          "bottom": 23640,
+          "height": 20,
+          "top": 23620,
+          "right": 61,
+          "left": 41,
+          "width": 20
+        },
+        "1-3-IMG": {
+          "width": 378,
+          "left": 17,
+          "right": 395,
+          "top": 1461,
+          "bottom": 1674,
+          "height": 213
+        },
+        "1-17-IMG": {
+          "width": 378,
+          "top": 5419,
+          "right": 395,
+          "left": 17,
+          "height": 213,
+          "bottom": 5632
+        },
+        "1-9-IMG": {
+          "width": 378,
+          "left": 17,
+          "top": 3149,
+          "right": 395,
+          "bottom": 3362,
+          "height": 213
+        },
+        "1-2-IMG": {
+          "width": 380,
+          "top": 668,
+          "right": 396,
+          "left": 16,
+          "bottom": 892,
+          "height": 224
+        },
+        "1-35-IMG": {
+          "width": 378,
+          "top": 10505,
+          "right": 395,
+          "left": 17,
+          "bottom": 10717,
+          "height": 213
+        },
+        "page-23-IMG": {
+          "top": 3149,
+          "right": 395,
+          "left": 17,
+          "height": 213,
+          "bottom": 3362,
+          "width": 378
+        },
+        "1-31-IMG": {
+          "right": 395,
+          "top": 9341,
+          "left": 17,
+          "height": 213,
+          "bottom": 9554,
+          "width": 378
+        },
+        "page-27-DIV": {
+          "width": 392,
+          "bottom": 16303,
+          "height": 125,
+          "id": "ago-prompt",
+          "left": 0,
+          "top": 16178,
+          "right": 392
+        },
+        "1-28-IMG": {
+          "height": 20,
+          "bottom": 8568,
+          "left": 41,
+          "right": 61,
+          "top": 8548,
+          "width": 20
+        },
+        "page-2-IMG": {
+          "left": 41,
+          "right": 61,
+          "top": 7442,
+          "bottom": 7462,
+          "height": 20,
+          "width": 20
+        },
+        "page-16-IMG": {
+          "width": 20,
+          "right": 61,
+          "top": 6889,
+          "left": 41,
+          "height": 20,
+          "bottom": 6909
+        },
+        "page-18-IMG": {
+          "width": 20,
+          "left": 41,
+          "top": 1796,
+          "right": 61,
+          "bottom": 1816,
+          "height": 20
+        },
+        "1-0-IMG": {
+          "width": 134,
+          "right": 167,
+          "top": 37,
+          "left": 33,
+          "height": 40,
+          "bottom": 77
+        },
+        "page-10-circle": {
+          "width": 1,
+          "bottom": 1806,
+          "height": 1,
+          "top": 1805,
+          "right": 167,
+          "left": 165
+        },
+        "1-55-IMG": {
+          "height": 213,
+          "bottom": 16392,
+          "left": 17,
+          "top": 16180,
+          "right": 395,
+          "width": 378
+        },
+        "page-22-IMG": {
+          "width": 378,
+          "left": 17,
+          "right": 395,
+          "top": 2568,
+          "bottom": 2780,
+          "height": 213
+        },
+        "1-51-IMG": {
+          "width": 378,
+          "left": 17,
+          "right": 395,
+          "top": 15073,
+          "bottom": 15286,
+          "height": 213
+        },
+        "1-1-IMG": {
+          "width": 0,
+          "bottom": 0,
+          "height": 0,
+          "left": 0,
+          "top": 0,
+          "right": 0
+        },
+        "1-37-IMG": {
+          "width": 378,
+          "height": 213,
+          "bottom": 11299,
+          "left": 17,
+          "right": 395,
+          "top": 11087
+        },
+        "1-11-IMG": {
+          "width": 378,
+          "left": 17,
+          "right": 395,
+          "top": 3703,
+          "bottom": 3915,
+          "height": 213
+        },
+        "1-68-IMG": {
+          "width": 20,
+          "bottom": 19853,
+          "height": 20,
+          "left": 41,
+          "top": 19833,
+          "right": 61
+        },
+        "1-64-IMG": {
+          "top": 18698,
+          "right": 61,
+          "left": 41,
+          "bottom": 18718,
+          "height": 20,
+          "width": 20
+        },
+        "1-76-IMG": {
+          "width": 20,
+          "height": 20,
+          "bottom": 22066,
+          "top": 22046,
+          "right": 61,
+          "left": 41
+        }
+      },
+      "screenshot": {
+        "width": 412,
+        "data": "data:image/webp;base64,UklGRpJqAgBXRUJQVlA4WAoAAAAgAAAAmwEA/j8ASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZWUDggpGgCABAGD50BKpwB/z8/EYa8WSwoOyohkgk7YCIJaW78RhFhKmVRxHabP1fHoKjVTZ57VjSx8S2G7K3Adqn/FNtP/05H9icnm9CdcJ3bN9M+3k51HTvd6YyIj4f/Sv8D/aP9H/wP7n///nz8u/Zf9J/ef2v/xPpz5YPiX75/pf+5/i/33+zf8t/0fB/6x/d//P/cf732V/nP4N/j/5H9//8t8zv5D/c/6f9//7X6L/LLUF/Pv6l/yP8X+//wSfWf/H/e/jP40m2/8D/4f8T2Bfcv7x+1H+i/fj37vj/+5/nf9r+7vwX+1/5//z/6D4Af6h/iv2a9wP+H+x3+A82/8d/x/3F+AP+Yf4D/3/5b84Pp0/0f/5/xPQZ+uf87///9n4Hf6z+/3/R/83t////4Wfn/71oioZhDMIZhDMIZhDMIZhDMIZhDMIZhDMIZhDMHqbKxJ+exALQzB+5jQfVBWYPrCCNXhLKBPB7/Whhd2Wrtm55P9cyvHxY7Cqe/an8ajozHdBrPBJRDUv5ZPa8BrMiiHJeOwT13ft27HyR3A/dZWnbdRB0+jNwexz9WvwGDvERzCPu6IyjKUZRlkd7qW9IOBIpAhjFehYr1B4gjFeiJM7YScAtDMIZmCMV6F7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7fiNLqAX/Q3niN0LGQ+8Of4jj32iGTSH68MJOOEpM35EWKKlPd8q4MBV050wa50rQOEgYtDMIZhDML8Gi+rAeSgCCiHFoZhDJ+Mqhi+PypE7gfezBdSvsQgI4K08VCrbkp9u/ECcfdM1+ddWyNKxfQq8E66OMgfakYaeln0aaD6cK7ZMMHWTi764FFjoglXrSVpkWZ1XwNdV/JxWStdXaXXxpEyILCQ7oEXFoZhDMHsgWmNN1AB3dwEEIODL86MHf8laQij2x6iDqPEIFYNEal96IoaR+PCgNub5iQBRDi0MwieGjI67m9CA9I/+diAWhlFJXzdUKQl9hiUoDPEsTxaJ22v+kJ436iyYKqDlmlmp02ChOsG2+i7tTj7pmvyDWSxekYgu9k0nBlZALHcuH/rG1tqUrBveseZvZ4nsbJep5KqvY1VdUI88OVPqE0C/eix9pos9Ofp21YC0WKsHqIFqZ0cVJ2O6t6eU4XpikzCGYQsPZneobPEia+JdVULK3SQe+pqtXEBTrEvnOjC3iLSa6dIkdZF3CQVU4TwPjwbMiibAqRbCGYQzCJ6d7mkwZtVLCGYQzB6W9XiGsyHd+iY9KWyjl8ZuFSdkW+oUTzCpG852Aq9iD9ARGNerYx90zXvZeWbSW2BElPbp0IjUsE+pG0qGhj5q+TLCqcmmj6ZWTAefAGSuTKf1ctfP0QdDYfDOAgfJ4WuIcaVNBxBALQyjMhe47WejI/AknD98XoLIhzTcKO58ixd/fOti/65sbssSn/9ZpWn8Cn3UCNxlmh2qD6QbPGYNiAWhmEPxiu5TnfWNGZ9wXuC9wXuC926mRRDi0Mv1V8Nba8rOrOVtWBsNZWdRJYV3l3KzHZlNU2QUZqHAvqSrvmnsjN0djZrYJCU4YjW1S3Ygd41Ax2ZAjK/aHG3nzAaQFAtvifP5EmEgWiV1FSkJ1K3+YQUboEwi8KTuQYpZZz1aSPLz+c51o2k4KAMlDbDSVC8tBUwdTuT1yrAUfvKv+/Jz9FDVXbPgXu52uYQmuLlJCHhlsn9HkJWF9zwy9tSzNXXN0lTcNZWYpGTTocqMjkt8mder5NKqMzbOKzSnivDLBkUgksC171CW+7TsIBALMp26vcCoZlx/PLBQZpOPd9COQntatYl/lJHYCwXQBdbQJDEFq3/zkTbCpfvBUhOfAwtrzyHACi6fwyAKIc4FfaRTI4jHWUNkVTIcWhmEMwhmEM8TdrtRLQzCGYQ5P3dX52IBaD//mdz1+Y3ZLlWAoSGu8l9mzIohxaQzGK9C9wiQ1Y9UoSApcf2MrGM+fpDp27tuhkd0lVmOddBvIHoQ3kEd+8Wj7+DX0BBmgjrNfnYgDp66lPHik0RCBQrbJ7JHkOUo3v3a/furLohWV9KD13lKBYuSqBCEoWR52zXITMn/+0giVx21IYAp+vgmwDIohxZ6rRLSRvGHSuD5RtdKhSk2tBOS6Ca6wA+FF7gvcF7gxEQ3gP0OLQzCGYPSlceKBa3Qp5mMRMw4iZQp5mMRMoU8iuQPu9IgGYH0zqzZv62Afd68Of3rHhgs0m6hH5eXOuti5V1G//fOJ4egGS9Tka8rta9FthlEwvtr+9PnDchCgsfo1JP5+ybXH6kJG7U/doxLFKubHF5A9UM/Q/HNi4TwSK4jJ7ige3dQogytAmwZyeOHQDWUIH8oiF9LD4P2UNqb3eUwxKjYrvQTyBexRBv3qBKvaz5f7Qhz0RiOcOpr2tw/I5fF8ZbNoHFzv0aczcWrtEl+QhK9j+hSHOKgy24pDVeBJhlBKxpa053Wl1wFro1OyI28fR3ypJ05YrPWkBeWN6INwq5vzdk6NLK5OKN+O7r+2rtEl727Uo3o2USozOKYJNplW8Bfgo98lk7UCxxS/hDmFlMEGiaF1X5z9JXzgGYlK4xoet5EQtxWNO7XxoVOyzeB5qZyTuzMtx+hpBxx5MB1Q+PbmpcgYGtAgX2pUbsFHZBeNWZi0bKbzWuk8yAN9vS5zCjKNrtCc/CVaDD7jA+dqCee1sdgqmppnyTNwBJ+mx+5C6waX7peXbR0mD34EdClhJoE7VlMp4qxIxfoljs/wcD/bOjP0C4wHnuZHVOiDOJhze96lH+DtWOa/+leE9vIrR5UUulwpehSA6eYbKbgiYP0sMlq7BagjQW71K31wcdf8Dn/nSOTqgFQ5TBpE9DDWLlwHXv/1QJvxn0ksqjHhyDQf7ebE9BC9TRvcwlz2fZuKBaZeN9XCjCbemzGkaTgbIJwWQTUg3/vtdjBo5HBMYjoqY2cc6RyXePhhVwYOyqvIgt5ZG8UPNeZ1wkMFbKWmfoZtltTwurBXThF5/cMmK9Aa8RTtktKTld/4E2h0mnBGB7c0BSiGJEw88Bj/0NzZyxQbSOACeKJoFuOZNIQ29BOwM8zFcmUNxVApTYiHDTOTFtDhJGt24XFXmMRqLjIbNM8vFOXrzkEnmwD4WrobcBxaGYQzESjiqH3CoE3WLPxwsBlq+kEZr9SQEuuc4QTjbdpf+amkUoaTgZgF0DU825JSUjKD0tE0xdHA12ILP6hD2VJmusx9UPdXDy9qTbV0L3BfxK8zVbL3BeFQp2ojqU70L2nsfRI4114LVEll2TaI00E2GfPGt7GHVYEOOUYU7rGvdX2Nx1xu2BGBTzwCrkmcUuG4LQO7MzUqbOQkYNqoBcZ8eaK+UPoCLyy+8QJcIIYAh3FSIrbIyUcbJNCeQPRWdoOdR5BgKOG5SG3hjOvDcUpinaxmJvT5a/YpLzb5zcjgTD3OZ/1gcpeh9kbyGE5hJWrPDdXF6Su0RzJkRAViWd/xv+ri2lFVUKl/YeeC9gb4eeXI+mTo47ABTDtEPTK+IP2P4pWm6WHgbAI/DZda2ZwAW2ksydcJQibTA04lgzaA2Xs/E7alSri9hjncOHGoCHHC3fa/ABkUfIskNQRP16c83fWjZyLcAxwx+jey3zyahUWt3jK829gIYeVESI89UFWMnskm07kYF8/K0lXf5x9wNUs0f/LRr0eBv76zxF1mU8q1mRQh+ZlTza6DRJsC2+LGt4xamXgTis9eT6tcI3cnXc2MFQS1WHcHoZA8MZgBuOA+0Vn5491uNiudkG8+4KulWBTpLn3KS2jlwK+faex9EpSavn3Be4L3Be09j6JGz91S+GrUXSo5wgWEcFzfeheLY40hRzDuA1SiAjDhFtSBy5ToGNWp4fHwXKCgQDh7MQB2YDzF01hUMqhPLaqkpHP0b2W98WRwH2WKh7W3lPejyh6u7ek8U4UL4fS8IM3Hbft1phxilyO+fQN3G/SvFZ21Pik3Wg7jNDk9uqxmhHJaDAI/pywHAbHUEPAktA5IdiL7bgKJSoQQLbmZzbnE658WKBO3Pgse2o0+6L/uH/w1lNKJBQ9JjI9LJzDwwDnd6VfXOL2otL+Xf1fwq4s+El1zkVjoe4c1hWyK9EMKIf+ifbRV0nC+pBZjnQkvFiMZ8AwELmnB8Hof1p4K4jYWhBN02EUDLlZLWLWHFdgsMEdswavV0Z0u+QSbGqlN9fxP/NwDfug0IEoDkTYo13gEqUdZch+Hv/vOrTwkinUljEpnGgFhISJg+El1zlR0FRoQAuJRNhQDYKDJbwvAjxwBBgtrI+tXITP/5/gye67EDCN+rnNsaP8wRXTngMQBwvb9pshDfMwSlfQoOf+dzAxq438pulEv7keeXI+iv0yJcgjuZhxCGAauAhuCIHV3AEhnyTxHm/vofJkIZGLVskqCh+g40BLp2Fu4LtX4sb4WJevpgOdCacMO+L20gvbe5eNhV10cTJnUa+1zlIbeGKuvsfSlKoR3OuQyRFDDHJPdmZX4IDkLF5YhYFYQvbiGXduLLFqQBT3ipwZ8zCfNI88uR9HC1l5/Hds4CbemYJsZxfz0yzpuVou9DgPXpmFNHcTEso03o55Swl7YvdxYnUMr9LHDv0G3btvGxFnmT59NYlRBaPcgpqkCJPJYzBXQOI8RehoMEQ7GInPh6IHh5c/0YOw0EfmN1t4PmRmhyyA/hbywhmEMwhl/3D/4qHFoZhDMIZhDL/uH/wz+W0e++yQhTzMYiZPXAsdlaB/wPBe4L2nsfRI4/X5VYhn9Tg/TYlzYI7Bduii713gNyIuwuVT9QOB6oGj1JjygLutkdm1RLQyk8uR9MP4ISuN4M+54ZbWghI93Dlvc4+QHfnYgDzy37yKBS/LMIZmCMV6F7flrjmrzTOW2RmShe4L3DbL3Be37Lw5CGiFPg+xlO+UTKFPMxiJlCnmYxEyhTzMYiZO0lozSgwx1gG+hrvJhWAoSGu8mBXD8CZ6Gu8mFYChIa7yYFjvHDWSUsBQkNd5MKwFBwdvJ0Kxpc/65VgKEhrvJJHCEBezCGYQzCGYQzCGYREx9HBaGYQzCGYQzCGizfdn3Be4L3Be4L3B5hvkiiHFoZhDMIZhETaYXz7gvcF7gvcF7jhE3dM1+diAWhmEMwpE5vuC9wXuC9wXuC+DMGj/52IBaGYQzCGZC/Av3Be4L3Be4L3Bg2zY5r87EAtDMIZhDRZvuz7gvcF7gvcF7g8w3yRRDi0MwhmEMwiJtNRrvJhWAoSGu8mFYChIDMAuLQzCGYQzCGYRE2k0p7Xz8wMoCLX13TnT8MxO3mMfyvMCUXAMM4uuinMRUx5bgRx2KiWhx4S6Z5pzLuNkUwNB8p5mgaBtQb9KF3MazRvlEdSXgpZO3fwkj8lWmRVXmqbDnEtZ/78tJa+cNtiID0e8pxgX3pjqp4e7G1KAGTjC6W9jXWAuhZz+J1o4XDIxQ441zSbWLcvCvY4NTPexjvD1cKq9KgPccX705TD5RDIgC3JycG2Z/V6Digolhe1Olg3coH9gi73uXkVMMRDOSEqCR8/b+95g70KgaGNyUwmhnjnd4FAJpO13wdGx0oyD5ucq/k1uZA2DeIu5HnV3L3lxKeKjW2OHOnBkldNSXZ8aTg6dNmqrSPJ/0vCSYSWmFUo4XYgcDVKi0KEl2o5kmyOmnIfMAlgxpLwFAkXkG6IOmjTn8rWcYmSRgZYDSphswhcARRVIiMDK+WTA+ql51/F6yIceGmsA6dJMQ78as3eDL6GUi21KZFR1i7Fn5BSCNL18QlRg1jj/fobClbUCS++vB8MIA5Cs4WVa8GqA/J3rwyFdJjwh91nMuKIGR1vc7s4ZTE5YPka5dUwcC6nvHZxzysuPUQPJXweneVovTMcIix4Sq+kYgGB8fb+J7aqgLbmTsvVNIV9CIhvAJyTgK5vVfP0pMnHKz0r/hA1hnT9HedcAJhEBS2RzZZ8SdGKGh8lulhSkhXwaJUTtiUzX525Q9JjODWCR+na/NUsaxN0H6PPVwXvW0RU5FF4LttAvFhwbLOs7s+4MG2bJgEW37gyi2yqcZxPx+NWZFEQY0y1HHsjmL0RkGff3kGSD1ohrBjG9+cX/fFCiViQgOjpBZ7mBwO4qDWCIgFoibTEErwp3oN6eIK/OxALUic33DbL3BfkazIohyub7s/lnJ0ejbL3Be4PMNsYI//RKD7chiij0T7gvcGDbM/zCHngdaykooYYpem7MsZ5QOmgUuoGnHo6hrCA2kYEvT7VO2KiQr+kFZLKFa8m2sFX3iD7gvcF7jhEq4K88uJNrQTkb3t7LZwC0MwhmQtrEP3a8MO3413kzFY0uf9cqwFAumSat560frzVpkhsFVYChIa7yYVesIZhDODWNfnYgFoZhDKkj/rqKxpc/65VgKEhrfk0fnBe7dTIohxaGYQtn5YLJmz9Di0MwhmEMyF+BfuG2XuC9wXuC9xwibumeexALQzCGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb21j/tmGpIa7yYVgKEhoKtWnCp73YVmvAyDk23U8FITzu5rNeC3elzHMF/VZyVcOrEltqy4wCUyvmwr3/qZnI5evjQ6aTzaMOnSHkUQXgIO/j8FMr0xlwuIOJBp1mByubSBU2orNx0EAJa7112WXQCTFNEJwlowRNhe1k7qbBZwQra5QgoTpwrDuVbcWbwR9fIvECe7bXpnZiZOa+13GE+Aa1BIcYF954VEFr9yizayojW6IEQ49Y/lcsiA9GTZs0c/B1Z23glZHQgFYLA6dTX7C9wXwZgpuKRkEctCjNrrL5+QUNVbLXsv8+6yt7gMVjffmFTBOpHtGTY5MqBXu0V8UG0YVetubMjFXS4m39gcitCSwiWOmqJaGizeq5KvW9k+CU0+t/V+RvoIH7p7Gok3P65eVp1/9xX6Drva8do1RuJW4aVgBWwpvWIHRltOQF3OlCqRynYSrqcxTsQFc3rEAqW3tGOUGvcRW8h+GXONj/vdLKuaIb8IfUMoldl9b46XpgOJAtX0X+iiGSq4mktJNB/sZgCZZQWf1VbtihmQvvckr0Msr+nqT44imRSlMipEUrBiCBqbxZOjjP6tErzE8UTUNQjCa+lIW9SvuYxygzIKQUbU+F4fs8fki9IoXpPyFE9dDMkgl6F8GYKxFqw0Dq4GAfxJy5Xvn3B5hvbgdNwdoaao3bMjHyQf8kOuAD9oyCHJGrHxmSnG1LRbcAV86wbzkSfkKQ6ZBsgy7wiJtMAWvt+4SwnYnYcaJxG5lUhltaCcNJ57jhE3waOTdr3TiDyAWhmQvwL9wXuC962lxaGYUic33cy3FoZhIn5kURBjSX4aMWK14GM6hg4mhRxcfEScvcdWzShxaGZC+9GgB2fdfpKbsCELcqkJ49xwIEwhxR/qY1/vjY8R9yX8Ay2NAFDFkwrnfUL3BfBlwxJIIPNL1fxJyWhmEMwfXfQDRPxaFc/Y3QVVgKEhrvJhWAoSFZypBRoZw73FuQW0vQ1JDXeTCsBM6+fyNZkUQ4tDMIZhC6qmd/7AUJDXeTCsBQkNYw5DcH3TkiiHFoZhDMIZhSJu7AUUQ4tDMIZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZv5QCBoakhrvJhWAoSGuaEY2Ga0ofkwrAUJDXeTCsBOixgOrYjdR8bb9S9oFL321DLYt4cH47/RlCTOahvSywcLcPrZQkNSEGj1Eeg5Rl6D8X3hgr989DWmuh6bqRM9vDJvEPKeuShd3Be44RKpaOSJTxO+YcEr0pBZvg7c9pJb15/7ohXXSdwJfyaPtCCykIE+a+nXAqzrVuwfSIqJzfu76yiyEHu4L3HCJU4EeHbb+xP988mX3vUrn3Cv+ct/lE0YGLWzH6o5BcamDd8CSZaNVcpqWdHRe3g/zCXnMIO5OSOKTyjBC6KMqKaFd3et8BznMLKi8An32GI231LwIkogcA3RGx+juLQCuppt30lfLcAY7vbtThUfA1BAKDX6FHETKhvi6D/Fjps3VINReTy03kf1QAzEqeEcacMK4FNv4uAvlWGAkAOOsh9hYwgjd5lTcLoDkgqXxdmGBKt7Qo0l/SQLT88/2K6NBAkV65GVKp1iXWYwQgtMDwGzqGBJ5wTIT3zlAaxh3/1n8lAPb9EKQjvH4bcu16sLUDc8HWepxwjYvxbk603LelygF4X4qnck1/L195NB7uLhQrLWP/VPkMjsDVSJtJgAoG74QuDxYSY0prqlShZWcsiq/iMjjIOzNsMAGmDlfq1MuWu5TNhZEnCKlQWNNSTXQZqkvkgCRw9B+RrXWvSDIE4BSzvKhm/DYeilOfFSKJb4GbIYWk7YZx24Dq7xoB08JNmztSo08ROw6+K9C9xwido0seWEMwhmEMwhos3qk/RRMAPqz5pqacma9ou9M3+GAw6oamhfAQNy77YNU/ZG+nv2vWpkOLUicmux5EuqwDU9BLwHoWBYoHB7+CDahgEbHDm6D9gcFAI37R/87F1+ZyMD8k5SwcCXqg6Ysfkp5x5QDZaSYU3wD7DsqXGBfgoUr50EyjTZTMCH7ej3a62qUC+8ezmXxtAdBcO7HbVV2q/sHUTlnAKLiASiP9QLfA9IwFdQ5XN+zqm3/OrEF3oN6/LWDk/xRN3TNfqXFoengVdxakTm+7dTJXxaGYQzCGizeqZy+AucYNp2LQzCHn6zk7J0KlM/Fi3HXfZkwItxDZQlRzWAv45Wz8em7FFNHRcRo/4CUtOikzMEffoBIQ4lZaBIyJXNn3Be4MG2Z+yHCE2HIJrxECka/OxALQ0WN0d7/pLwDJ3uLekDlBbS9DUkNd5KzwmjnDWMjwP+2YadBrvJhWAoSD3Wa/U+n3Be4L3Be4L2/2C97y5/1yrAUJDXeTB8YmkQI7GoHr8xutvCsaXP+uIWRDGnx90zX52IBaGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfygEDQ1JDXeTCsBQkNc0IxsI0PTQvNLE9TiDWEqIUhTCTbR2EvBbj0NA6qeaE6JUCtiVG5U4fvELZVkHKvp0mZQwmuZavS7PSW2CmVy86pXwZkL70YMQ7n+KJS1fotjVwi+uqpk17tvzrQdg8XvyEvFQ4pckGWuyRzlj50rxBw2lCNau36VVf2dtYUAVCWi9n9HEbllNq+qicipBd2CrQRBUp9+2pOR0z+nwbQtNGiaLIXLbX45/XoG2Z7NT47GOghI9gseHs/iufApi/x7TZRwiDLSdfFQHmBVmBDRoTI2RpQaG3/qiKG/FRDbcGQnXxX/Y7dN/MBIlsybW+yVwRugJh9EOHVPcSzN40ROTM2wXj+6re6Ku5G2iJ+n6rRjRgd5JeJN5ILunnMhMpS21k2ORDcP5t0q6dihCFXt2gpI9RAw0om2cLEGf/gQitYRoRs+bujhCFz8uQTlLBgiHaqB8SUeKy7zeqTwbsNWpNTsS+WlIxdWX3NQHOSIj1FVBdxaVdk1Lp3JjJ1RO82e6KO4g/2kd1ut6G7y3LEbzD590MIPr6Q+LvlYzAOlU8zKze11qILG2XmOgQokwlpq25Q9MXyXZ8PgQg0d/SO9hduYP5bLJe9Rh86Qjq1pVzgUW6QMDAsU7J+V84NVknN8+44RKgEX3elALfDT4jUAeXvBe4L4MwUL9eJDLgvpQr4HhDONCGampfTyIZAnSNxiwuD+vsESE+rEabdu1hDBdufA1RGoj+f4GAE0tApUfucL7gvcHmG9yjgFoamv8r3Be4PMN+ui0joBjz2/TUISUa5mgjaKc61h3Fm4tVMakIkoHiXj4wAgqLYv7Ze4L3B5hvawMMcMsmtlzM35DjvJq+fccIm+DQVw6QAIBaGYQzIX4F+7mW5Em6ckUQ4tSJzfcF7gvdupkUQ4tSJyWJjc33ksgDRq1ZfSxQvCp8S9MblOT3Efv+nBQQCPFJSavn3Bg2zP45do+o6WDSGLz18k5YPv2en5bswCXCYBPIPzKNt7ddd0tGQQUQ4tDMhevcCrt2r/KYkg86vzsQCz7AUJKSJrIIw08yrOsuf9cqwFCQ13krH4xCdfnYgFoZhDMIZhDMIZhDk/Fehe4L3Be4L2rZhhxpc/65VgKEhrvJXlA11N4QxRkvZsljZgxlWOVDzmJDMYr0L3Be4L3HCJu7AUUQ4tDMIZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvbWRWXoakhrvJhWAoSGuaBhMFVYChIa7yYVgKEhrmfYDlebVEKKeGhCQ0M3fgVYncH7ewqxSKBKxIy8Rj/ag+5H76kLV1hDVt9UF16W48ygIo9O/LE/s2S9OXRRAzF9dbFgGayYRcFiWJalGesaCkRodnp7LVLbeR0+dqPZ3cYL8f9jA+qMqg+GKAheBTHw/Dpl7ohiuryEbPKb+51KyywUMO2BJOgYgFhC82YMbD/IFVlV3EfkwQnu1bgjXQFbiFmQGaqCh50+Z3o0ViVNU0heoc9Nnpzff+8jk9PPfH1qzbdvNp+Nl2VgG0hpPGz8PfDqytAmhe7XHU/NOwT+psbfvTcQ84Lflto+GDZsLWk03vblD2ij31LXtb5rdDAJ7gZZi5SFFgFB9pQcTxTwy74r0L3HCJUrv3Rua+0u7grb66MsHcAWMrqBdC0cadFxpwWypyxa7uMApY4tWfDhPer1OMjVNz20o0/YVyMOlVfxOSCgmD99ljJuGPyg7zyKX8naO277T537qd6utELTaRjObJE85bumK9DBtmepio/aaLTJxQ+F2kI+kliR+tZn9mkEeR7GMUYFVhMkxevWjdl5br617Ey6kmUN7reS+hY0UxdPhCOmbu4+CKp3M7FirDRvYi/w1E+t0Ogja28xjLFdrXI6czJ87brmd/fq9YSRBMsBYFvPIHjgoEYakdvD+MVAlRnTF+oVVUmhxnIf6Oclh0ELiCQ3tGJBpCkLhFikHOuCYFe7f55DjAvwL9ypleeeYYXAr5+DMFKkhXf8G7Q/oyWGTP+P/yCh9Ns11+rsvEQxH0InY4OwkfE+VnlyGrFs41UJb9l6F7g8w21kt5Uc/u5KX3PDLbAKvfCXivF0IuhIS0MwiJtKXBL2T9N8VE3Or3ZKLjJobCUbWtIqTPKkt0tre6Zr87F1+VckKctj74gPL6DPSMOOnrcnzfjLBxDvCiAimsSfVcNqiWhmERNpn31pBbgBm2K9C9wXuOETd0zX55vCGYQzCGizfdpBGa/UuLQzCGYUiclYXia0UCBK6WkMxivQvgzBTav4A+TVDX6oMXfV/4ueEQXGj9ukjsPHoNpkxAWCyX6bYyoVXLBUdxpTZ4bMub1fPuC+DMFM8Jbw4iYtpaqvi4fzsQC0RM7j/rA5XxgSt0D1po3LvhWNLn/W08IuH9Mxg+/kiiHFoZhDMIZhDMIcn4r0L3Be4L3Be1W2YcaXP+uVYChIa7yV+6PA/n8zKtyC2l6GpIa7yYVgJoVljvJq+fcF7gvcGDbNjnnsQC0MwhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5+tuO56/MbrbwrGlz/qzy71ECGI1aA8PsWw0oRpcTTk3X7lL5nNlwLSbP6oGxta1oxS4sePG0J8vcF7gwbZn1G85aRTcrlIlKe1x1KT8HzSXMV4WL937qqAyfgalUScxwKTXqUPsi3/3VTAV+gE9moJWR1og6/OLOVpOOqX4v+2Oa/OxCY0l+Glnd5nSH5a4refXVdfVyvAA7Sd+abLMlaQWunyEymprBlxncwJjyVi/oZnjMqPtTw/n0f0fXqExBompu9kOVzetWezdPZ/vysDrajKpDiLcZhU2tIgRCPXqotgDRvHBjA5JXTTXZA8w2DIGN2Q61jWfeDoJ/5I4tPKjHjWovJMIMpZEEBXN61T4ghFmLu3hPvflrNzSxKEi+Z2KWZLMN3Mz7jYPr6z2qgPYlQZAzmYpW/AiJEj2m+f+Z/vJRBmdVw4oycDeOwKBXGfs3Orw7EBjqMtHrEZyf7Uc1ItDMKROS4hw3iDl8Ycbwuz/HeCL8y6D/EhrDo7OQAjyzgxgFbAHFBtiINwj7q0Tdfx7ld3BfBmCkVqzg+os87VEYfK96jaCz2ErFyEC1VyRYkXJvft0IqKcwutQMwMjwo0AMgsXfe16r+GX9EVMKNju9TgB/a60mkWl6xAmHnlG9H2jGmSqY66Mtra6GJoERzX6Ac7DK4iMsmJlEhEAtDMhfeeMhkSTS6w8tPB23WbCBAVpcXm6gL5W+nEGpKJaGYUicmyWix1KfNu4IjtQnWqTQbGmgEDMXshGJ2cEh0/h50FD4j9BZon1AF2yoXXgRFwxXoXwZgsAEFtzRXfKPgDU/+FQ3mAGu1znhE5LIx2BBLAwJAcls77gam7h+YWcA7hpDjcxMbwmJdaael0z20OMNmqQELTyUdSC7ydNTh8bNkdDvME6koir51RDxWDS/rnEAZMr4KIm7p8+03h11N8Pq+fet/wWmYQzCGYQ8/WZFErfmhmShe4L3Be4L3B5htqW7LSFFulqnqt6pr2jAng9hiecORMA1rGdoWDiWUDwSt8f9M+sjFNGqZmEufTQWC9wXuC+DMFIJOexoJsLNB41ZurCHy4IV759wXuDBsD99pvKbVCAfPuC9wXuC9wXtWSPczMmHt7bAUJDXeTCsBQkNd5KtBd9pG5/87EAtDMIZhDMIZvyavn3Be4L3Be4L5sFVYChIa7yYVgKEhgF8jhpMs1N+7L3Be4L3Be4MZaKYkMxivQvcF7gvcbRNID9Di0MwhmEMwiIS3ECVmRRDi0MwhmFGOSyV8WhmEMwhmEMyCA3dgKKIcWhmEMwhomGJAfocWhmEMwhmERCW4gSsyKIcWhmEMwoxyWSvi0MwhmEMwhmQQG7sBRRDi0MwhmENEwxID9Di0MwhmEMwiIS3ECVmRRDi0MwhmFGOWGit/ILaXoakhrvJhWANm4f70pUwAQ1scSz0FeqojbhHjrGsIiEgxNBno2QPbGlpJ9II4hzcWORYKIXo4tFLWkPwtnxnNbAGwhgmTOBLAkZF5NVoM4mn23SXvSREf26F7Rar1RKuZjE3qRz4Qa/ExWLYB4Qm5YIuNT0+cHRLOGf2wFDPnm602M6ZRcSVHWTaWTlUn82AS3JlGvuCYXHga6B7ec26QoHXcTXrd6zyy7Kl1A4yPG+6CjL35m0ueZv0I8vijkdGWrCbxyZJpJUMlwsbCjHFfNysmR6ZauYz97PEbD5zB9wCSVSIHhl7J8xEokw8AvyVbjS+blwKdi2g5YpwPLGQK9hu8uel5PbI69DQGhPi0ltP+JEbPShRw7YgFqMcVY+Icx2XQRePhsByAIxWKBjPp1oEYeefdgrdCbl7cvs8oZIOp32CCXHBQGG6iWoxxZs/2VRk8Fe+DFpDLiPe+7eCpDCawMsQiAXBKtMY8cg6omAWMR0pJ48gU9eNs0nc/lodXaTnuAbBLkEclreQYGfQBXg2tsiMwJkvDzdk0cMilCnu0gjNfnYgGQRivTaJSp1OABjVXt6TxGd1PZze7Z8JBdsfSfNsMfAW4eYtKxpybgDl08DACqUdsW2qJajHFk1zpIFev+1iRJcu4ubFPqxlV87EAwEBbVlwdmYkaV69vecE/6xzWBgPFWpfmSxHPSFT69ZdTDwJIMf1Zmex9pR4GRShT5IwK3dkc/OSsJQlqKwieSAdeGgE1PSjxBppbvOiUGpsoaR6uFWiK/ZzeNYq/SVtj5aZDlWGP4c/OW073+YNEPae0URBMtw+6Zr899QvdupkZIPG/gNpcWhmEiJ/cGDHRhBVZlgWxciHAFEbpfr/3SIZUmyV8xb1fPwTb/7eWBPcrhVcm0yolA/2wgfDCbVyM9DA76ybiBCGaEPfCe6N0MFGY25Ql+IvQ1DLLkvZhDMIZkEBU/x/5hF7zAC3kzoZhDMIZhRfXTDIfgPkfRSwNn1trS9DUkNd5Kzwi9gHgx0+hsFVYChIa7yYVgKENBe4cDXYgFoZhDMIZg+zl1FY0uf9cqwFCQ13iuEh/hJaQzGK9C9wXuC9wYNpJ3k1fPuC9wXuDBtmxzz2IBaGYQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic/W3Hc9fmN1t4VjS5/1xuqVSslLfuSs25gQfYbAuj/kklYPgsB2HpWGSkqAIg8Q6I65gaxFQC0MwpE5NM/klBcUr2HRyrq58JpEFA4/A2I8yUftqgX+orfis+oNs0If0M4c/H9l/aiML6GbY+A75Ytu2zoxJZxpG70TsQC0RNpMK1mETiHKNk/X2pblsO0Eo0iZEqDAmCN6gyz3eWnsLspFTY/e0eySUBh6nDKL0Jrcz4bv+WsTX/6IP/nblD0ypboTrMe3YteNRuGp0aup+BjOml2BEKnkd1wDKV1JB8BZ1Oqldtw4h8zQ3MDCdYQSxH2v8GxbUEOpzgjfnYuvyLyV1EDG/ow4bNKh1fy+K9JZuqQOEuBDptdKGZBEpogS0GVY3x7bDzaDVFW7/nJI93bg4ByLUWyGZR3ZG47+78M59Dcd/9pIYmrBxrtIQYrNVMw5wtjpb/EjqgU+ZPspnPh5rc516cIlVYGhVgtR/Z5yCV0N8SdiFjRgPlz0sEu95aEiOTR/qEp2/qHLP4QijUeRJ39i2YcKbOjIpSmREP24j4GH8qdXvR1LHcK8iyOVNf9AOdJwYh80xREMDpb1dZbCov9JczRFCB0tpLeIwZt0HhwRNKxfu9g/s1BUPsYic0YYsqQmecotDG451HZSxMaj7KIsKP9DMIibTD7pzCLMba7+rvJdcOZkL8DhfL33xIxL7fiPIgP7GGvzSBrMytAw5Dh499qm93C5TmHqS3cWF7d9q+tL/84u+L6lYbt+w8URtmK0K2r+8xqEf+7DzbiB6HDapsaWIJ93FBkx1nO4D9g+0MwpE5vuC9wi5Sp8gsRkUSt+aGMV6F7gvcF7htnmG+Uod5SfivRtm4dPIyqD3m/ytDGzb0uzI6l8dSqdNXeOy8lXPS4tG9gjhrpcB0OF+Dvg6hHMduqoCIgFqROTXsrApnlZ70e+oGpjLazDh0Cwd0Hq+Wn2HOGOutMWxlUIwzfk1fPwYlkAOhXV5v9v7TgOmbBN6vn2/0U5g9fZBngm3HOsuf9cqwFCQ13kwqg20716EYTZkUQ4tDMIZhDMIZvyavn3Be4L3Be4K5He8uf9cqwFCQ13kwqjem6ywAutxjFehe4L3Be4MG2WZaoloZhDMIZhDRZvu7svcF7gvcF7gvgzBpG9iAWhmEMwhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNpqOnyrAUJDXeTCsBQkNc0JPfk1fPuC9wXuC+DL2tQJWBLSPXNLiEWuR9VMgIAlSjSUHikMMBmkdfV0FdpDK8Wrap3wPwxgNAwJn2QzMvGSRt5/U+m9wXuC+DMFN0oAIs/5Lj0A9NxvPIAx8mWZYdJ2aOhz6sDLru07xu7Lk4tB0KgH/dM2FkSbCx7tzzVbdUcPkB4yDl5jJG6IuYFOIFVST9c7IXF3/NKIjIfDA4gadIbwS3Qn9PbKRMHIMRbqxpW9LBxaYPcYHiWBAim0SiAwQiA4vAnu7Ya2CSYQQRoeavVPkRlR/RRd0OmbCyJNmEZD3BE0lG/WbJR/iIVYaTNjeRH6kSq3cl/2+FM26XGcPYzWg6SVpuGwU0mygkYjahT+MP2HyyatSCyVNjSa2YE38gRSFCX0I4lk36JVns+haW7govEEfIXzmsRBneYAoJmES6Me8AWZuZAdVb1Kf3xYiYwL4HRqclCbP3ZWsBUMFUrjXoHrOaYtFavTX4gEGvdy34MzY3oABmMNTRfO3wPr9lhVj7LCuFhN/NeIez3HZoX4Gq3D1WVeaQr7Ve7RSlMiLuT5ZuBWfNQunJsYRKmSviTdKJE7BffmckKELLlD9cqMLf3jvX8GRRK35HV7CJdVgGp6CXgPQsCwkKvq54t4v/CTolOpXRfn0ymOq2JIHxmEMyF+BsSCba7IKbZupcI+6Zr9/gt4FM75MHAgReDqYBRhrfFoZhDMIaLN+zqm2hVpZEtDMIZhETaYX0ADRPuC9wXuC+DMGkB+hxaGYQzCGYRE2kvsFqkdq0dOH3n3Be4L3Bg2zP7pQfCAs8Jfhil59YHp+TYWffzqxcmHNC3luibkVVNGX3cJQJGmbKiWUXHGTeb4sePsqd3Be4L3HCJVwV55cmLYck2Hvb2UxALQzCGZC2sQ/dsAlWXxYCrcgtpehqSGu8mDtxihICTatd7gYX65VgKEhrvJhTywhmIxtmRRDi0MwhmELcHIKqwFCQ13kwrAUJDKkzUQ/Cb87EAtDMIZg/sZbePxRKczCGYQzCGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb+UAgaGpIa7yYVgKEhrmhLeiosIlA6aIRaT49kp0gxOZU9d5PKrs9gp1n0sdYJ7HGCIYHhSwIZhDMIs3RlI1CtFAoSR8KVuieEcp22xTU5bEko2ZGSShMaSB0z9kIjYmX22h6x7XByPtDSzqNT7WGnm9C9wXuNolH0lF2OJ8rPi8t9dROJ3R87Vv7dUQpJVBqAsYd5yV3oCi+JKcYWRphWJ/wflM1Gn6AKuUqMiLKMMgUkNXcb5foTmhEgIgKsLm6eyhO5ESjr+jTdiUhGQKrK5nzWbFMl2mGDPiHVkLAGCA5Ezql2mmYCIGnomXQNmy4DcxAXGA2LPt4/PC3kBRd5xuScQf1QyyIlsqzrAtEQllTW5jL41IgESiX3Gk73nhHuiFPJkOHpXmEvHvuXjkBe6zhu7j9/M7XP7VyLJoyh8fAzJThkBdU34iwhZ8zWCz5nnvO2e4H3wXKsLmIegPDVPyVLF9nOqsbE0/tsF4Wq7z/95nrgpw3kkufKKCM+YhvTr8i1/N5y6qLls6IweRO6uWeBtiHyffb/MVzPqLdVIghJllA+B72clJU+VisUikN0u/8jo3SDS/4wiufl7YsXm7qURK8iaCQgyLHYT2QlxHD1nD0Vhj5Ppg50OGUewCW/6bRcoSd7w/Q5LREJZnhltaF7zCE2FxJtaEhLQzCjHFU6nuhX3vza5QXQ86Ci0sS0MyCAqhSpb5QGiWn8ZyXUErIM8AeQHiZwZYxDIifVLrkOb4PSWL6XnW1UOx/Zh7GEzY0csIOLREJZu2BVUtlzI4w3w+r5+CbirjOTgbXXxPoLehlSGYGVYhrjPog5quP6EB0OVVfJFEOLQzCjHKnw1JBywfZoZhDMIiEtw+6Zr87EAtDMIaJhiP/sJ6F7gvcF7gwY6UrvIwhmEMwhmEMyCAqPRdA37nF1uRNWJAq3SIUp5qyBDYGFa2nBZp9xiWDdqalHd5sQC0MwiISyr6a530zHm0QliqfLBLz+6Zr87EAwB397aVvx3sAemYrGRlw+6Zr87DdB08Q24D39imtlDXeTCsBQkNd5MHfuRQd3BoIzX52IBaGYQzCGYSGYxXoXuC9wXuC8+iG6u9ILaXoakhrvJhV+dSimSvi0MwhmEMwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwee2YakhrvJhWAoSGu8i+c4aUyGZsS9wXkBWHXeq4Bkq/dQ86fzWzyQtxDUDjNAXx2zGbSyZ65fklOei3AlxQcBbQNYSLp5yzSkZ64qahkSSokRLiK4wMht3dv34cK+YXq5T2R6XLE1pO1aR8khvqbo16dMV6L6gt3vda8OntmklgALUicmsRKR+z3YRm7ZwF/AGPPiVTXSe99QYVHLFDQTXzpbzEhTryNeLsjGlJFeSfT6plh+SV3+QXcfFWU34BMe8VAOTN1UAxS13LoM4nB2LEIHoUnD0w5AH3wlAVal6+5otEpg2Tj9IY9/iJuIAjVF9poGCndHHA4H8Y3yDTK3t3tR2ZNfzEWn8nQ6k31cbB13eM5nPDloZALwjX4DqIh9Jecw78MJWFmKiW1WyrazQv7wjhqE3FQr3BodCIRKglTuRE3gqw3Q/wsXZSta+EcANwj/t5LjEFXE0906kpqBH28f+n6sqHXAqodXXCeJw9clY8lOS7uPillXi+yKqcVkD75UUnN2oDAtwKHa+9cBtNEKZ4I4tXZWfSgxnXirxipJAMdsjtYljR1eEb2IED5Tv4EDrvDR+ZAFHceNhZsBUYopIsQBVqaCoRsymADD3gjEMm+SA/T4V1/UDjfT5NMLN+zsJ6zQI+mr7Ve7RSlMiKzfYZhd/28cHElhF6V7KcF2E7T0GcY5xAwI5JCaAlUjyVLC8nfPJLskUt5HdxFhSNRREGNJq21WFRUzG7tolWL7+ZbWhIF2jNBPboXzsQFc3v/1qXeaGP+Uc7kJK1hCb3/n7CUVRc0LSNaStzyxTYG3BRgSm+YczdkfzQpFN/Ui4+RkL8E9zDZcAIxVRHduxp+HWip2glkuvBe3ehaqlMx6k2tshwD5sAAbTgYrjBfioTTi5QQRCQJVCf6NOXwZg39YoNILtu03Mmg3pQhmQvwL9wXuC/+OLQ5PxbizcPumbZyavn3rXYhMaS+wUu3oWNaMIZizqZr9/goT45VDhgeQ7suNDCB70v0r/bFPoMqaPyB6C9E4o7IW10kYKpLTopMzAVNK2bkl/AbKcoZfjZNXz7gvgzBTPBgDlueGW1jwDRnALQzCGZC2sQ5xO5Yck4zMBQkNd5MKwFCQ13iehZc8wzmK+u8mFXuBIa7yYVgJ8tBe4L3Be4L3Be4L3BeToVjS5/1yrAUJDXeTB8YmkQI7F6GpIa7yYVgKEhrulPmhjFehe4L3Be4L4MwaP/nYgFoZhDMIZkL8C/cF7gvcF7gvcGDbNjmvzsQC0MwhmENFm+7PuC9wXuC9wXuDzDfJFEOLQzCGYQzCIm0wvn3Be4L3Be4L3HCJu6Zr87EAtDMIZhSJzfcF7gvcF7gvcF8GYNH/zsQC0MwhmEMyF+BfuC9wXuC9wXuDBtmxzX52IBaGYQzCGizfyf9cqwFCQ13kwrAUJAZe1qAoXt1gkm+xbDSgpk/Xo0z4Ur10sRzYxVsf19GTXntFW6SAm74basCs9C5v9Fq+fccIlUo+a74aBNgGPg7cGQtIeiJQ4JSpe7MQa4HsW5d4SH2w+hu7UJO/SrlZkzuYulEYISqidpiiLX/YlZxlZ3blj7YaN4ummbMiiIMaS/DRKDxspFpEvC2rbfGdWR5e1/Do3jqDTuPGHkhP0i8X0OTwRDAFkgFZ29mpTE1NOv9rrgBKcMzJbWpDprTR/OxdfkcOC3wfyoyUbMsBFAPD+BQLMptWYJ8lM1f4Ojdct4jj2OWs4NW+0gomrj9Tm4GSCF6RiO1t1t18MV6HmG2Ytva7gWm4q//mcUNnK6/7QgI+41Ks5qgEZuHBh+cWjCc5+mV5SazypOh6xVZcNXgcmQHS/RcUdCGevKrAh3P5Kk5QJ5HNfoBzpJ6cdguuRI08U+Coysu55XUvJmHwmXBgvMieCV6EFMgkMpTXeWbMilKZEISw36hn0LWcH+2mV/z2IBgX3l9a+FP1TaPtM70rmwsEoN4jaYbjBvc3wIXqHCWTnVfzUo8rRKS2qIJHD0xdvy5YjDggBtMkBWEvl2lpvqP/nYhMaYYYctrAWHyHTyKIcWpE50iIm2q9dZjVvqKJnapqTk8N2lqymsvcF7gvcHmG9yoki2eTnuC9wXuDBtmxzX7Cj/90zX52ICub7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb1dQb/uc9JcvC7e7lVtUzPTJRnRjtGKkLseSy/VlBVcZA+hzGK9C9weYba3otrRl2v0REujY9chrYRDnJrifqDzUPnIHLrQ3c1dtziK7gveGThe4L3BfBiWQA6FqzI3u3UzWzAFoZhDKjkAsBhPq3txhs+wVVgKEhrvJhWAoRj+ph2+C9wXuC9wXuC9wXuC9waCM1+diAWhmEMwfZy6isaXP+uVYChIa7xgl78qDN3/xWNLn/XKsBQkNd5BXcZm/Jq+fcF7gvcGDbNjnnsQC0MwhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5T3NmGpIa7yYVgKEhrvIvzS76NL0NSQ13kwrAUJDQTrHDTb7RagW3CtLoQj0qlRQTSWUCVZRenEE2XoLPz4qnyNT0Rux4FYWNRpG/sjShszhDCJCiRoWaJsukFS9cvgFRw4x1No229/fqAeMMWG15dXswhos3rHpRerEDbNs4RyZxwWynVfIX88tCXa5NKJWh2tG2o8nEG2qDyZFdSA8E6X4Ce+V3hF6F8GYKaPBiZBDW6M+8qQ/hJhwx8rTDwo24Q9qubBOHRwHIJFBoFS0kMEic8rzbkdbVdLEE1FOP8qyupaxDEYLzgLtXyM5xJePJcrQ1feP/wvvX9EUj0zEQKGhHkmF1wQ7V/XGSZLt5X3B5htofGyyxycHfWXc0iSLO7NZFqZtzHuucFuS0NFm9bOtd9jC2QHWouXPf1jRxnHZk+z7aafkKNMicP3krBXsFZPRln/Mf37QQ+qIKQ0VQwTnu21u8XbJqRGdtjVIyRf8paGxvop52a7d59wXwZg0gI0Noi/WNLng+6Zr9/gn/G9ubjTYHzZkbLi9rG/jKCyZhKZVkWI5MP5XB+bECS72NYT0gSyocSk03nYgGBfemSYneS0e8HLGedjRBo5wLgZXrF1qWc7IbpeM78k3esB/H8Ng77l7g8w3z8MWjhSIrUs+5UysyKJW/Noz7BMlOXT2P45f5eWP2VBOCOqhqgfYZe4L3Be4PMOBcdeipoiJN+diAWhmQvwL9wX/xxaGYQzCGizfdn3Be4L3Be4L3B5hvkiRuH2X8+8+4L3Be4MG2Z8qyhLsL3PGwonowOwGQofJsDZks2j0eaGzulwtD7AuDFdPhxv3RZpBI7gqkNMn0xaeEMwhmFInJo6qhuJSDQRzVsfGYxXoXuDBs+QiI2J0RXAi9DToNd5MKwFCQ1eS+kj9XwEmFYChIP7yYVgKEhqAj/52IBaGYQzCGYQzB9nLlWAoSGu8mFYChIa35NH6a7yYVgKEhrvJhWAoR8cC4Yz7gvcF7gvcF7g8w3yRRDi0MwhmEMwiJtML59wXuC9wXuC9xwibuma/OxALQzCGYUic33Be4L3Be4L3BfBmDR/87EAtDMIZhDMhfgX7gvcF7gvcF7gwbZsc1+diAWhmEMwhos33Z9wXuC9wXuC9weYb5IohxaGYQzCGYRE2mF8+4L3Be4L3Be44RN3TNfnYgFoZhDMKROfraXoakhrvJhWAoSGswYXfxPXDTSkqKUSgDbYaa7TnfOruzGel7DqwLJ7g8w2yZG/srGaK/pfkY1FL2+tJaFOkfye3VuB1p6XsyNlfuoI4+c7tBdLQWKwLZHtqBXW+rz1BhR+ghL/po853j8tJ/iG0DWvvbXpBtUKn5/mGFlzgbz0RgpmxnR4JUIR6/vnLN+z7H2irGZ0Dg1Px74MyTscV7XCh4oAS9bXUbILd6Cw1Xhm5ZSekKegbG6RryhC4Z3myXbUnkuzVnxt7x7gSH+fMLJvI107ehNTX/f4KFZ75sY/e1khdMGIEtexeAt6Xn7CKqdoUtHVW5lWvsStkKACP1Cb9HtvjzD7nA631ugBDAeLXGGjjETwSvl/ZFRD13MX9WKCvqOdIZ98hmqsY+4PMNsZtPeYBaN2psBreNb3geKjUIcy8AaZ67dCrncYO+Ohahx5oMe8JZe5NHYwb8dCwy+S8TFp5FU3K5LySYT0gXOutJjPPmNiWYJal4UpTIiNQkeXUSdX0yFSgm5336fF0S8rFYDysL9Eu8fip+n9nrhmyJrf+nOFvml4rYHU90jMyTWgH3LETFXNs9pVSoIPP7rP8y5lad9aRwyIuG9PIgxpQp8hK4yOZcP4B8/6Ac6T7jKKU/sTlw596jdh21fPgwKPojvCb8621CnZNQ/wBmHRoBUOw9h/n52LCfhCBUy9MAKQXrTtJlKp66gIgIZhETaTGA0lGjihcWdTNfnYgGBffSM+rZJBxo3xwqKzxgfdLpwyPZG344CRnB/cvb+P4/IF/RqWaah2ZSmDfIwbH8MK5CPdCCYmiIXfHE6bGb8GBaRJc5erb0CVnc+Sq6yxPJCsteTU2LcWZRSKU5qg3bJkz8a6/pvK4t1dvI+Iqor9aL8njs2q2autMN0fCXMFUJhIpldtsvvY4Vs8sDyS5dxYW/NDGK9DbgYczCGYRE2mF+7L3Be7dTIohxgX3nfp0fdsStXobcBxaGYRE2k1IOVQ+VXyQ29SmBFHBjnzlf7Yp9BlTR+QPQXonMGS7+i7eDaCohut3hON/QDOxyqy0CRkSubPuC9wYNsz9kOEXvMITWsBNXz7gvcF8GSEYZ9ntHzWUNrEJ4akhrvJhV+MX6CoiEnzgYX65VgKEhrvJhWAnvvn3bqZFEOLQzCGYQypJAIGhqSGu8mFYChIawd0P5/MyrcgtpehqSGu8mFX/oX2KpkOLQzCGYQzCIm0wv3Ze4L3Be4L3Bg2zY557EAtDMIZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROfrbjuevzG628Kxpc/6s8u9RAiosIms+KXHZQoie5o4Ikvn9oFWLolMqe0mX8yijgjzhRiIGSZkqnmS8Hlxj/KqgMw4oQptM0l/sugYdnblD0YMKHzadsNUJO0eQDbt1X+OyyY6iwSB93bQki8G5dCUmCHeQbclgYmy4cSk/2D+vuQajKKyxTSUHk1+IQSdkHYZNnFyImKaAMwWSwGuo7RATSMhVBuNTsKkJvdYY5rCkTkvy2xkMd/zY45Gqp7uX6V8a4LqeAwiyRuWosk7t97dZr1+3KDFsgJLTESwU93OBlh35tUi810XuFy5Cjb3Jfn37QZI5Z/g5kvQmi0le4rAM/zWBtmfXFck3gSnxOOIseh8UZprUsMsHsfI5AL6eEQK9mEVMcFSMgVbZUTbKWW6H4OApFJ6KUxkRntpLhqDCdw1mgGdP15aqeS+Hmgq+gN+7c3gXC9ehfehBmmRMpM0T1N/rKVwshbZKeI+nuBwUIHDSQdPuk2rGyOowqGjp/BjMelNxC3a31Ng7wkWprubPDYS+xhVwl9mYsOKILbwayURSmzbnBhatMOfP9SszXLKCsT6O14veVdtKtJBZytmU7OIPCUyAA43FkFXjpVoi8DP1wOYGixWBxwkbDK9R8OSURk0vDn1GDovh15SUgZJ9eQ9N0mvvD+ECSFxkTBvBklZr87mKkiQR02tCYqEwcqGoukRjZx9ztU1dCU4BA5xEp0C7ZSREm2IEtsjf24BYwClDZS5qLlGLkZsA3IcOBVArTkJAxnMvppFDwp91xaIm0wF8IKIjptaUh90zYWRMHWzhh2daRnhCZJlsqEVACJtz0WPzNZL73cFkMpeIuzIcWhmENFm+9im2fu9nY5WQ4tDMIZkL8C/etdiAWhmEMwhos33aQRmwHji0MwhmFInN926mRYIiAWhmENFm9XUG/7nPSXLwu3u5VbVMz0yUZ0Y7Rf9n8d6nGWgquNDYAkIgFoZhETaTVmKDntggzSi7/UVky2hwthztBqgO650Zj4aLVWtD0PZf7C97A2h0RRDi0MwpB9qF86b4nAsf/yHodfPuC9v9Oz+QpbxUP6u4jDDjS5/1yrAUJDXeJw6YdvgvcF7gvcF7gvcF7gvcGgjNfnYgFoZhDMH2cuorGlz/rlWAoSGu8YJe/Kgzd/8VjS5/1yrAUJDXeQV3GZvyavn3Be4L3Bg2zY557EAtDMIZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROU9zZhqSGu8mFYChIa7yL80u+jS9DUkNd5MKwFCQ0E6xw1JUwxQqNRhjjCFzBKbtKQQCStyZ2smbu7Fk4xxabR+RFhIvlUFn/Bo6O4QHzwLHLFGVSyoMzw9+9xYI2CXnFpgi8DGolWz2QVlEBdC9weYba5LvFw87xuK9XZ6qACdeG7elDh0BOJYtfioZls7nNWXH0dMOZg42NLde+Z46dHHFS9mENFm9XUHugtk139uoh0DbNdMG9I3jX/5RjupOfardulI9AdyveI8dd79LNUm+kDzY7NRz1yfot5yvndWHBJe3lMdig6t9C8hzX52Lr8luJNiFNiQQqeXN8BW6TjDFRzt/YsLXfC3ST1J+se2e70JY/PpEri0NFm9XMvJqrc0GLb801SWnocXsB5Xdfb/0aUmAaAnSg5WprhQzmXa+iVZgAt+xPBSfEIOrc9Gn60T14uZYuGrZ+m+ME/6aLnphV0hUyO8WlKGJ3yAtpU18k8IZkL7zoLaFSz7axf0zGMIwDrxgLn9KZFIM25W7l0Rl3j/7CRxA/3p7TPL5/4QFiWhos3reGZSWwp6Lo3SGpsYGwIjsACCOLMCCS3FDeeLmgIjEwc0jLVr9v+c40QCbLrSuOZ0opf24kmwZWzZNfKBnauc+T4Wj2bwoWCwnnDpxY4Vn4L4lJpiSn2lRLRE2kv0dZUjBDlQS7tfxIWyCjmdcwXn7SeLmk8YpsFLXcYnRJA0Lf4Gut/h4pFobibpa/6LQtg6VDSbxJTdzHLogYm8lrsCeZr5O0I/FNF2qKub1UKXAYUSL+gXRl7MZe42Aby4QCAadALqwBgaXBRST/wBLbMzedocXUx5otnku0kg33VTFSW56WoDA4l1wnaWcGIi2539GpIhihlYgpIgDmaQvunLV9DhhLUicmydad+R+HcMt+eQvsR5ZbjbH8iKmx15y6WRC+/o9s+fZgeoRuNH0oh1rflBfSrEU8VFeVXE7XSiJNgmy0TrsaoRf5sWhmQvvQSb7ROoUOEUygHFoZhDMhffSM+rZJBxo3xuFRaxmkQF8g3vsF7thAqhkKcdl7gvcF7jhEwYGFkNxkglEo3Zu+lAszbA44c0EBEQC0Mwhos33ryJmlFgiIBaGYQ0Wb7s+4L3bqZFEOLQ0Wb7tIij9lrsQC0Mwhos3qtQv/fsh4ukKLsDedzc8Ln81zLihFF8OIu5kUQ4tDRZvWHYtHCi1e7HVvQ1BPIA/pZWIFcQV6z/VPY8WtsR6l1Qt/NLZVDKiBoLoANO3UXoXuC9xwhSVhtywt4RbIvQvcF7f6bc6SNli6xbXeXIFCQ13kwrAUJDV3l9ZGHxXsQC0MwhmEMwhmFrxXo2y9wXuC9wXuC9wXzYKqwFCQ13kwrAUJCyDJ87roqh0+VYChIa7yYVgKEfHCICwREAtDMIZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKRObcmgevzG628Kxpc/643cgy08oa7yYVgKEhrvJhRb5zhcsDQf9v+OUpni6PCjxzFwG8Zi9a9mnRJmhk0crKFmZQ25UQe2TF+yh2fe4zYxRNJNcbAjKNRpX3sGnzBDuJB31e1wOeDV6eEKbCCleohN/3TSebRIu4OJdWuZ8GIhR6/MrZ4pgHGwd0Ts5SPwB2uO4nAWS+p+CHGsaNZt+XoG0wj45CZAHs4Qa43ztThjSDtyc5m2bAImFaCvQwbZn7rf3pesmH7PP3GTGFmTLGzyHt/FusWTpkFx/5nwW+6jTXYHF+knWTOs5jTneDiUCk5a4WD+iiyU00tmAiVqO1wz1leX/9CisMBmDXk+XpmGcbhez8rWXzl4dgT19mQvvP2LZsIX1TlCVGaThbghobQJNmw4ELVSD9xwzTYqbQppRJhk0TGYAvJEnxjkdn+EqblKKcnZOYIjmMiMwCkSGGri5LGlHCPxlvdSkbQzmLsDSa7euqErF5ErTo4meq7SF7rjv+K1JONR9bMDtSgJ4Ss7shG1EZeX3W0awY0VPjU2NjpcISSofD0u/wDk/mT/UBWzErstHLb/WKoB71ZhA+RE4e6/tWjr2qwqxDswb0nA4LeZa0LpcuSCzOHIh3ef/C/s6bPT/Ej2ioMVxDZrmCiEyMc7XtKAO8Gyz57VDaqhCEL81yC3iymu330v61GU+mlQq73FLXNC09G6RbXs2CwApw6NidB0bDVrq6VmcgRVyqRDupETvHHRYORxb6QlSLXbdwgB52SovtH+WE2oYJVtyEqAmdgoib4J9JY2EUGnAdM1+/wT/je0i5QA0C4PSmLEEBFXPYC7mbImCrx5E7epIVIiR13FSI3DA+Gs7uC+DMFOACvjyUtpzW/7QSIXVkmxaJXLCuGouMBzrGpf6uRAsNMCzMYr04RN8tILpX+QXfs6AUXaGYRE2mRURRn5njWc3KZe3RIzkB6ik3LowMvJYm/3Be4L3Bg2zbw5ANUGj1WZFEOLQzIX4F+4L3DbL3Be4L3HCJu6Zr9hPQvcF7gvgzBo/7jjGEecw+6Zr87EAwL70LVwQze+ET+8lx6aEosCGqhTSwsyAv8ZFiAHAJ35nVYmZUhLPkCw0xQGGICKBfzKuKiWhmEMyF96T+hltaJjC2GMtbehe4L3BfBiWANMLshS4lLXLAkNdZMKwFCQ13kwdsUvcy6e5saXP+s5YChIa7yYU5LQzCGYQzCGYQzCGYQtwcd5MKwFCQ13kwrAUG3is5jJDXeTCsBQkNd5MKv/QsfiiAWhmEMwhmEMwpE5vuC9wXuC9wXuC+DMGj/52IBaGYQzCGZC/Av3Be4L3Be4L3Bg2zY5r87EAtDMIZhDRZvuz7gvcF7gvcF7g8w3yRRDi0MwhmEMwiJtML59wXuC9wXuC9xwibuma/OxALQzCGYUic33Be4L3Be4L3BfBmDR/87EAtDMIZhDMhfgX7gvcF7gvcF7gwbZozFMKwFCQ13kwrAUJDQVatPksScdZISPHM408Zl1mzUsVp4cCxCXaQnIVkY5nLhGGdXZKelW33Be44RKmiUBh9TG47AYJpiq+XNgyA9mJPodsfaq2P9brAxBVt0a4mURdxT2DiY66FZf6Pgxl53xcHEb0lRj7CGsBhUw1x8NwxB2LdK4tDRZvVORAJ+GhTzJSKo1NBfDpbyVLBjUTdJSY5p1shqVKwHPpmOUMZe6NpK80aY3WlbxpmHYfAV6hcEmKrznDoyqD5gNoJtET+PjQ2DuyDf/VyyNzo/uHWE/+rDxWbkrX8gaDY7rV6DebH9hvtOO3sk6s6eukOJ4GBAdccE5+n96MtlrtGAVkf514s35rs+NrfsJeq4X196BtmfGFJi9x8Egn2sK/3CC0SeDhA2xqF8apHyFPPPLf1AkgtREXd4a5fa0PAMlLX8vmOBncTMZgEolGcVlK4NTp8V3Mtb+Gwvb7Pkb2S/NJF7X/Hz3lHXJSmRT3MgJpVkM1/hsIRXWo3//0yym8irW7Ybd/235AWLZ3jmM15eXrExKR+sMMYsTTZ/Ykbf4DMf8FsjjrlF8cHXDXTtmNLO+/lddQ5qyO8IS36CuogZMzwK3KCRQqK2F1iykYep9B97N6zZ2h3hVjv+j7CMmJ1HdnPy5T1XDiB/NxW+NyOAWb3vbQVNTO9GoVRUEsKVzibIOgIXnkv4eQfFkbE/e2xG9llGfIcUOTe1uKuY+EBNSxKJiKxRvZDZos3rJPSKYn8koGU6ZAOZ2IZLa0X246HBLiJQsu6C8pECEdLgnBUxLClXgbg+EH9ETDXGTCkTksZhI3D+TK8PUsdo+FTzRLQzIX3pYkQVtgilwX2LWGvNvPhUV46PpTTebMH54CSHV/SOecIX724zp7nQaQFJojDHm1o9K8UUh2EiNEVpXZNX0DbNkhmabdAo77cyKIcWpE5w/OEJJEsIcFEx5EF+swa/NIGszUCrRvfpJ+X3uWlXz7gvccImPQo51aP+5kUQ4tDMIibTC+fcF7gvcF7gvccIm7pmv2E9C9wXuC+DMGkb2ZKGYQzCGYQzIX3n0UfwqwKJw7tW/8o239h8TDkOgELP1aWa0j+IDk3gejKJ9wbuGYoohxaGYUicmtYyOHP+4jBCyjTxM9vTYgFoZhDMhVu7218nHVE+wS5VesIZhDMIZg+ucmW+vbr2zJdn5jdbeFY0uf9cqwETqupb3z+RrMiiHFoZhDMIZhDk/Fehe4L3Be4L3AW+T/MJDXeTCsBQkNd5MHxzGQJWZFEOLQzCGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mo6fKsBQkNd5MKwFCQ1zQnXpivQvcF7gvcF8GXtagK2rpfB7/J1HICgC/vgPWeBICr9qVI20yqY+D1xgLcsEu6PntVfUWEcQ56qFFBLb3nom0+ojzAsoLTTg1GhFiSxs8tW84cjtpDT/0MdaZWCCZr9/goUlwNF8ebHhi5eucBgOd/Bl2RyEDKdn3BM+RwBFG1DuPqjPYKNymy3nZQmFBaCZr9/goIBMwGccl4/hL+QkPQ1T35VvDCbEuJUIRzSvEupjoNporki/Cj7AMiKl0Hyu5028pWZXsbJyKhW2VxwYQGUP4PkQshgPsVAPfP8i+mTr+ehCK2a20uH2NhyBpVHGugEDhCQr3S9CkOAqmCEgaQrOWiJtJevTCQ1YiooB0AaLJjMwXN1vNWk0mm+Ui9+l/cXvyRoGdTEkIUeL/kNeLUeM1jr3WhTA6kyu752ITGkzEWgDXuzCrLOgb9EouFvw4/nPHj6BRwFF0w9S7m/+caW3B2UMRA0A3aPbcPBV2YkM1ClraBwyB4mdo7iwv4I+veb/0hYgYNVvskALYkjLvlCyEzDz/m29mERNpMIV3aRTy4wIvhRJzVS/OD7uQCCUNoVts0fD0QXnjZ8bNjuvaOOeGV0rj9vEGBwVu/dM1+/wUGtgnbC51NTcbkJH00VEtJTjmnQCSTX/Ql8uJ0SA71yQHlT332gJnLgHwaruheYq5WLfpDpN7gvccIm12GyPpr7plZkUQ5XN6un+hkJhtK26QL+uiD5OFy7BfLHI6rKCd/MZ2DEpDmV7vggDyWvhscGiBJEgNAAOolUE3Gj52ICub1cho/9j93NWZXsi2tyWhmFInNp2mkPTS8f4lZSmZToANrocWhmEMwpE50rjjGgMRJTZcdo2bGYcIngM1RLQzCGZC/A1X68QUFDMIZhDMIibTC+fdupkUQ4tDMIibTDLe7BWQ4tDMIZhETaTBqBvsmXxqKws4aUldTyZT0GSsHf52IBaGizes5CQ5VN1HItNY3CXLQsiYCQqxf66nrFYtlSQnY4+X+3BG1z4C20b+DgCGK9C9wYNscCaQ9Mx55fdFm1RLQzCGYBxll8jSHLNdth3ll6OizaXP+uVYChIVkVa5NZ6Jr6CsaXP+uVYChIa7yB/OzJQzCGYQzCGYQzCGwML9cqwFCQ13kwrAUDHmTtDuJTmYQzCGYQzCGVwxKYWGNz/52IBaGYQzCIhLcVWa/OxALQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYZELKYHU3VbYPKhu5O7LiJBD1io6SPLypPQrx/mdFkdrnG1eLocqu1L2zS+kXiIHRByiiGLAMVfEd6vMjNQK02USEY+bUDxuj/n40MaKZjA9ZHQ+KQNtdRX1AgXWLr2YjyjlebudKYO5TvwoWpHM4cIpS9ZqIrPoXwgz5LAmPTsj800eI9WZ5YNfmEybxCNUlN/G+iaFA0kaFLP8o1tDE5Klxku7j4GH3DOaNL43LFi/nWMdSABuC2rltRsjGv0jz+I/sFAh2Pkmy+H943ciRgOxDZKeWOPl401hNqb+8Nt7fYvMUXAQl+sofFVe7hS+2QwMGWR6KP/W6CrI8mT3r7eqgMYL2C2X2ZUMC+9GIjh8Rj0ckF9kiHSsaNXWecj9SYYXuLGJGRTyYoBVqt/KMyfNAqbFEK0M4L2mHJFt6ZgEo6Ez7kqMZsGe6wHKcbcJb8i8kNA/AqUch/3+zP4ukSPPZ/Jc6tMHENhNCLZwT4bOi3iprBDuFfvtS6YkqA4andc1U6wF5vDVvDBetxkxu7Y00UQcX9jWVxZ9HcJt0wCRv/TcWwzMHwVWDimY2cnZQgC8Qy2tBNdB8r5McMtrQTYXGEQDAvvOuaak1+XYi5BIVMvqwX168C0MyF96HaN5qx8txDhfvs1DkQb8pggZlmghj2aEvM6dGc0EtPOlGSwciAlkjkH3Y0NgFgG4xYmqIZhSJynLC8HLV9iOvmV36zIpSmVeUDjbQ7eXx4YeBOY7VDln6LNPlKCXbmhniIBaGYQzIX38ros+uVWzvJq+fcF7jhE328mFXKpq+fcF7gwbZsc1+diAWhmEMwhos33eA2n0+4L3Be4L3HCJUeuoxjv6120l/NoqEtqOtCmlhZ3kxqeI9P4oSLkxOpimCf+il0wHBiARenonGlWj52IBaGZC+89F7aCclyqq0Jlb/3ZAJe4L3Be4PK6z4sRQP1PclDC76ZuLQzCGYPrRFka5TCiFgmeRQwv1yrAUJDXeTCr8gXtvPu5luLQzCGYQzCGYQzES1fPuC9wXuC9wXucCBoakhrvJhWAoSGu10IvRtl7gvcF7gvcF7jgXDHdl7gvcF7gvcF8GYNI3sQC0MwhmEMwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtNR0+VYChIa7yYVgKEhrmhJ78mr59wXuC9wXwZgpsrgEiO1bJ70iob72yH6EGukjJbjogy3RVzfQRLfKa7cJf7XRm+PebMFAaJZF5lBkyEiymRTggIDpq3N+cRGBKGgphP+LduB5P2WWH+IBaGizezoJsOQTXz+X74GpW3/ROJLmv9KsJ3aZrdS8r7PXu/bN6syKJW/Iu3jXmQ2O88/5aaytpT2kjiA5Dcz4lVw/vZV86CdSubGn7Hn2FiPZOC+jBWdwSkjUpzAPfuGLfqsLw4HlYzt+x0IyjcAR2Or8Od3xDyDw4UdYdYgn7ehUqUPRXB99XCgnhzBd0hMDYgK5vVKF5JCxwDMCYW75PEHSpXZo33rdNT15Z69yzskswUUMaSrJ9niKI6w8c3/voPXeEY2IbDFhmv3+CgaCNXUwLxVmsoMdkMe/BKa3UW8QXLGbC5wCxpWCDm5P9l+owlsXseCeMKvNLEsQCbrba7kHfxl+90EBrFF2+yCkUO76iDhh506berUBhoYU0GaihVNeuwV8Whos3qnKxM2PrXsV4sk98TWjHoMZ6eaeuFA/jQtKsmM0G/LjRgCmMnfzKrAjhSTxdguLWTduX5i72m1XRoYO0MyF96HD00DmWZAEXRRbwDGOOzYMGWf5q0DgiqpEpWcq/QCWiGgo0ZIySIeVKAyYPHk0ia0AkpnePBaMIZhSJymGWQ+JX6HEj6avn3HCJWDxlFKZMGKvFP5KEhBlls25i/kRU2OvOXSyIX39Htnz7MEpkSJRIsBw7X0wNqkTyd4MxqFRAzydQxO2xCVrL4qeRS0Q4tSJyXp/OtW6lstDMIZhDMIibTADzwwlg3NSJoGGWeoT0ELu5VXvLYFeEtS6wDkfZkxhFpXX6E8pXOOGeF/9EaAk1+Ydin0DPNsr3N1f6CqKXhIBS/RBjTIpsnzOGn/KFOxQzrkhdc0s+xp0x97gs8sL6GSUgeEZEeTDEmYiVlhtJDl4kJPYuvzSS5/+SXqM8KOxLjy1x2Yj/52Z5RKzIoh3kZC/AxBHJFEY46ma/UuMC+8+Bj1Lsm+ZKNJwmLjf7lOlokrqCgSQCpBUzX576hg2zPqWf7Q58BSKkBIS/V51X9LKxArkOWTXzHmPhinsnbSYkbyoSZBWaxSX2fvqiWRRDi0NFmtaObctjnLW1rsQC0MwfX8zQRSM05QqKs6y5/1yrAUJDXeTB18xt5KH4/vJhWAoSGu8mFYChIOUzZ+hxaGYQzCGYQzCGaIj65VgKEhrvJhWAoFan9kugCRWXoakhrvJhWAoSGuAecyJavn3Be4L3Be44RN4TfnYgFoZhDMIaLN93dl7gvcF7gvcF8GYNI3sQC0MwhmEMwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJsuXNGLT2Dp7YJ19bzxR7GGGNT8aKNJldlONuDNXrUCOXuP8nYctoXLBVddxh7lr1t41J6Bq6rv2Gpq5liuR4bcoJ4LrU6urzMk4TeWrH6KtXQcBo5EyQapYg2R2A/FlpAD/cOaFv/MDTBtT3aIGxDAn6xggEEMFAL8BYCDpZc1ugTgvSR0/4gETv19hxpZERVS68NP/5sQMS3gppMnjJQiExpMgsAUKMemftBDLmHwtdkQpLdaOXwx/CoxqwnBaJzqFkVFYC0eCMcKEFhlf4romk+rUY2dMgBmy8ZSsiYe10Tp5a5vbmhz2hiWSMwApOHAonDgBShUK7eLkOMC+9MW+G42CMn+uoBtoXS4nIJV001zGw7t+vcpBriuJpxBuI7RLAg5V9lHwwiIyj3DK2/sKeCArm9X6wIhQA7149C7222IxxpVWuZoREQxXy9hrP+VCV3OOtALsxYQZGPxqLMa4QqQM5pFIME1XXMJ4GBX9J71Yl4BoDSHzzX8urMYOF4O8St9Nm39hEk47ohZbS7iMdt26dwgfQlGfLPgZEEMtw1OdiKhGeQwOZEQY0z6o2BD2qiplgbJpv69NeK9OESoMRHrq2BtC+VBFSc4xOS/CBMsvduAFVTlIQcAO0IgFqROTYT3cjQLQ/22wtO7g+JljT/jboC7t27Cr7O6wI8sdjDPapJ9etMiE8sSa4t4Px3FnwuGdqcFEX+t7pm7uPtTuwO4hEfuu5U0fB3kYQ0Wb8ibgP0Noc2LmI/tq6mFOhAiRc6wFn7Wg2NvaPgNnRgBfmhei0kwX4xg8N+diArm+7bmB/C3mm1xL0L3B5hvkij2+OALTrsyUMwiJtML59wXuDbgOLQzCkTm+4L3Be4L3Be4L4MwU0dO54YQHy3+JtpTHd8c+WeFkeTAxAWkI0+VFa9nuX0smoDeVFJj33RqmZhLn00Fg24Di0MyF956Hv8km1oH/eVfW9c4UdzJoRRDi0MwpB9prH81M5Lli0MwhmEMwhmELbRICij03UGfU9fmN1t4VjS5/1yqfA3Ijb8mr59wXuC9wXuC9w2y9wXuC9wXuC9wXudWXoakhrvJhWAoSGtLxdgBGNHeKZDi0MwhmEMwhr0Ky3kYQzCGYQzCGYUY5LShxaGYQzCGYQzIIDeE352IBaGYQzCGiYYkb2IBaGYQzCGYREJbiqzX52IBaGYQzCjHJaUOLQzCGYQzCGZBAbwm/OxALQzCGYQ0TDEjexALQzCGYQzCIhLcVWa/OxALQzCGYUY5LShxaGYQzCGYQzIIDeE352IBaGYQzCGiYZJmKxpc/65VgKEhrvJhRb1QAdaP+ApgMSu9Aw5kSKasc2BcdMvTAP0lOAzfRBCCdA1Yi4VIgM33hxciO+T8Mz97qke3YoJOPsONSEqlEgI7ghClA0WSHoNnStk00PCJ+QKfmPLWJFqS9HN+9h7G0mmX22XeRnl8Jw2UhjmPlUZr57xK2Oq7IxLoiCEVTzJukyoJaia58ti6dwW9Xda1w4ttYSHyMJKBzjp1bgvBLt+jyG5XtrDnMqZmdVk9ox4v+o1EAXxG44/8qH1y/INNKJhXPhSlU/nUvSN92I8stCLBEkqSGYy/x1ShvUvF4sPGfGkCNnROeAle7X4WTsrZTXAjxC7vnznSJS7PlfiPSQMwXKKirHzBgdJSxaGZBAVLo4iIA6dnAvhXkJ27UewLjVfNid+Ps3j24X7bp9kW6yIv282zMoerrxXoYMdGTHzZoDm1v+Sjc0HYVz0iEg7d7psSpET6/lhBfVQyTjr9SRKskmOvyaqCf5m2B1LqixtgCEYESyBv9Szi1J+WMxbtUm4hDMIaJhiQCcGsJaGYQzCGZBAVQieWDh5jDfz8ZrHvELJq7+kDAjDKMpP43DlB5H8yO3+kiPzm9N68MwVN1e14Ld/9ABXuxeYbrZOvW9CfDrEfPbn32kJXFoZkEBbVmLQpxa+ZuBLqLIZIFxX6d/JBYCIBaGYUY5PfoiEj4yRtbHLa2xS9NlXF1wY6FqyYBRRDi0Mwoxyprs5dyuzNfnYgFoaJhiP/nYgFoZhDMIZkEBvCcB44tDMIZhDMKMcVQUuzEo4kUy7ZaGYQzCIhLKuB/trp1XpGiPswrDimDRNobj+BQzIHO+BoTKASHIn71S/vLwiL0NQyy5L2YQzCGZBAVbQr01kUzMfMXXWa/OxALREEaEfLvAqB01p/IJEXG6khrvJhV+NIarwWoGO9fPcF7gvcF7gvcF7g0EZr87EAtDMIZhC2hU+VYChIa7yYVgKEhZs7yn8/mbZ+QW0vQ1JDXeTCsBNCst5GEMwhmEMwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInP19BWNLn/XKsBQkNd5F+XeogRUWETNMlsjADYha4uLi9aJdPhZ0yxZvfaTF/Gna15jrsM2bc4SEWXUr16KdMcnNFQvew6oKdiAYF96LlgGq8RQr/881Q3E9Z4CsJU9v5+OMM7dk7flnyBh6pGyFb7HBaQUFWkgtOQs71Ibxn1srkeIQhXJ/y1l2HlVyQtkl7deRzIolb8iqRRZN6t4lDboOWDtubM9jVU8DevXdWdTtQFM3IaLxu0UjQElPu/LcqXezCGYQ0Wb1ksO3WspVml/heOGJ1CSB+bscy5O9o4WuIZ0an78JbnQxD4I4lPPB9k6QTMYr0L3HCJVwNPR/7g+YRbnARYKlJoP4ds9SiuTKd+LKIjlT/AvGu3W0e0G4L7rg35YdZfC8jIwPlN++uoN1hEq6k5khxeB81D8qZDD7szV/Yqb9MI7OxALUicmt4Wo7LY1oUhrJHXaWcr7/KAgKPbYwz5iR9uSiWtSCVOHAgJpeE4XQf/Oxdfkc7htkBX1da8RqLTyhsx4RFsG1wYlvIQhbDTVKA0ufg2hiBCcu6C7eF/W7oHsa6SMUTco2xPqxmNXAdmyKoeCAGo0zSZ6q6I7hRX/0J3C7x32GgAUQ4tETaZ6306qFOxyPBdu5hgI/+diAYF951fDpvuKtbIJCpmAAuEenzuZIuxYAbJ4k78EAtDRZvWz/pyzo96tuqcowFtIiaFUJBwXIQqgqMKh7RkY/GADlwOILbyM1oCmyTnsXBFs5SxaGizfew5bW4giTrVXzsQFc35FHyeIeILFh3l4KAWO/1uMYr0L3B5hvn4EJwTnb3TNfnYgGBfgX7gvcF7gvcF7gwbZsc1+ebwhmEMwhmFInN9wX/xxaGYQzCGZC+9KORhnMSaGj2ej1I+yqh5X0cOI1+WFHFfKpMNbqFXaTiFfdjwNEGnra2uXVv3BbZIQ6MTMIZhDMhfeeBjE2FxJtZOYP+WYQzCGYUh17+5icpljia14U7lhM/WbUjHUpPutaOYohx4YAxSCvcqJLLtA8gmvOmFJWM+QoSGu8mFYChIa7yP6jgdV+diAWhmEMwhmEMwhmEMwhmEMwhmEMwhmENgSGu8mFYChIa7yYVf0XY1g+j0oSGu8mFYChIa7yYVdY0EzX52IBaGYQzCIm0wvn3Be4L3Be4L3HCJu6Zr87EAtDMIZhSJzfcF7gvcF7gvcF8GYNH/zsQC0MwhmEMyF+BfuC9wXuC9wXuDBtmxzX52IBaGYQzCGizfdn3Be4L3Be4L3B5hvkiiHFoZhDMIZhETaYXz7gvcF7gvcF7jhE3dM1+diAWhmEMwpE5T3LlWAoSGu8mFYChIa5oQEOu9fnHTqLZ6X+AhAl4TFEOLQ0Wb1vblocWoZoh8WXOAXZ+MeSk0/JodmBrYdLSHbCdFoAr11wVaUgLsxuZUqWWdoNQqgP4u1iKrCilCvY0y69xGKVCrqJVk3svRCXf6y1SLjJw32Nc5Of5nzD1lvCePRWdSh8FiNhM7MQzIX3nX0wYc1Cov5mq7iR1MiE49ZV31+9VO2Miu0mM8i/pdKBzRkmT1mIf6iWpE5Nd2LtlZTTrWlB5s0a6+PQB0cIL7TQxOfywUrtvFGl2qYlcBi/DFA5qeglkQalDAAcIJS7gT8ECJEmAJ5nb+j+NNhgOA9Y7uPzwvlhD4VEq7F4+ZjnMoYX7g8w21omyKeSuaEZngepRvHrXrHYeFJIaHn1ul6nbJrA/IifcOG8iIujWTC2F0WcRBQMKV0SdFlN5uiUiWSIt133fcvccIlU7VcH6CJI4Xt1nh6bNn2TEIUAU5EaEbCU5mpYZ9QUZkaE8I1axOwjPi2uKHozCCaHOKL1k+xRrHSQH4w7pUorIvdcWpE5LZb91Xm26YLOj08hCgvkcP+mCO6i6gzgdmLTd8Ed7RBzZ+SNDwTRdyOKTYzvqoRLJWC4Ir9KEr9X/k1evaREze6/Q4uboJeh5htrkjET9+lN3IDbY+g7crgx91fq1Wr/rVFz1Id7+nhFE/z+8JId5J+vVl9tfEy3/ERRYdf7wiY3yf4WeboDYMG2Z6BH+1+Y3U8F1/KZr87F1+RgrOQpBjZx9zqa0KFSj62JmdvuaCW1rIkqSYeyLAk/fNhdg6xslR49j7CwbntHQCAOf/mROCzl7IAohyub7UlUzCGZgkNkUyKJW/NotnDDs60ip9XBQprUkbcQERx7I/85WW4LIY6XlU/Fehe4MG2bI6FvNDWxjuSKIcWhmFInN9wXuC/I1mRRDi1InN9279zCGYQzCGYRE2mF9IIzX52IBaGYRE2kvwz6x2dY0wBCac89+0nKnxL0xuU8Bt52h95hHOLHwnMMUyKIcWiJtJpsvtOGfKeZwO/0R9Iucdjxu8Zox8Gu9JSHnwdytB7ZyLbXCc3z7gvcHmDvQNzA3L+dpXuC9wXuC8mSVy+tmt6+b7M/86y5/1yrAUJDXeTB18kHIOPuwFFEOLQzCGYQzCGYSGYxXoXuC9wXuC80GW6TCQ13kwrAUJDXeSvKBrqaxlocl+TknuuC6UlI8ISeIlq+fcF7gvcF8GYNID9Di0MwhmEMwiJtML92XuC9wXuC9wYNs2OeexALQzCGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTn6247nr8xutvCsaXP+rPLvUbhvo0vQ1JDXeTCsBQkBmCkEC0vlGODamlV2+bnSXLgJiZmAZZuoxTMViNVJx9bfiIvh451IsumUbqLurPiTLvaq/QiaQPe7FWMt40ZVabUefnrJOvIRE39yVAsbC7wkYgs6V4kWIv2YKXTGNHLb/19g3wVCRk8TOzhoe9yEdH/LaQoVC1436aa+Jz+wLNQEnvqCMnoja+zWrwb7ks8hFgSTu23DNGRS/MuvCJBPOgW67cBtJkFcu9sga0WIT35wS5Idn0htjbEHNDA0QN1ruU3AQ7rHx5dclNzTadQ0eoW1TOdGQ/ubPKmae64sInYGu1PdbPXVQqzHjQAVvF44/yIIPJk4Jq4ZJQZ8iaNmpPE0uyamY3tGX+KQa7TFS9eJb2/S4iWQhNhccKG4j9SvgDPFIZVxJtZq/ocbcwGtJtaE+1QexasB61k5r7ICgupx4B4N1lMkNcA86fR4zkhBoh11gCF7JqeISsgpgRMicxCsWDLGIZET6pdchzfB6SxOF2Iv6+dPm+Dov6gjZWFEOVze2RxP5Ron+9LZ5QS0MyF+Cf72cn31w/ZSOYL2TdkXXvAjboU9dcZbFbqGYQzCGYUic4atvCqqJ+ZFEOLQ0Wb7s+4L3Be4L3Be4PMN8kUeifcF7gvcF7jhE3dgKKIcWhmEMwhos3qu93htwdllMEwsvpffskMi2UKt9YfuQ8MLI1XQZIL2MZoHC9c8+4L3Bg2zP7yJnCL3mAGHbqFkLfoKIcWhmEMyFW7vbXoH+pHkuU3OBXz7gvcFb9Qjj1+6dAxOqgQwvJhWAoSGu8mFYCKEEzwIYxp8fdM1+diAWhmEMwkMxivQvcF7gvcF7m/tmGpIa7yYVgKEhrt17jntCLt7zX5jdbeFY0uf9b3pVxcX8b/ENngAeOLQzCGYQzCFh00sBmoiS8YiLorGUTnm6yRLTzmAd4a/FZ0jPOmQBYuyAfzQmPGhkCAh6js3670k60lPDO8Wv1I6DQCJ19kRDTIypZoHzXQqMJ5RVB+0Z/5EheYRFialKhh/awqByqcX09P437Rs0RkN4AVjReTevT9iaLF4FfUw9AJIWavZeE7yBCFg1vlT6kLX2AisGtp9OZ4t0cCQ6sIY/flvDxQiitWS5gG6i5aUrzMbOYH1RFuNBLSU3B2rZyzIPMI5/10oXb4IFYBWYAbOe8ykP493xgIYpd+ki4d/t9JDjjOA+bP5CjLNgXjWuM3swVbZbROXIo2z55gFkfCqjykNpIxtCJ2r/IBteOV/lMSQNty03L+dpANC43J3HpIrobNyC2l6GpIa7yVp2v4es833BowFCQ13kwrAUJDV3mwGxFVmNlXKiGO8UTwQ8RUYChIa7yYVf8KBKrw7qTbQ1WubfSAVhYkIjaZb8mr59wXuDArcj074YqmQDhijPjDr1Inix28Kssd5NXz7gvcFZgiOhEzyCwwK4sjFVB/DGaGZKF7gvcF7gxEaPQAAD+/uPkAIr6Cd54fAsb0IYYKcAw7YY119YCju0s1WfzSXv6YSZDJT9Oa6MjcfvEKp+6+GGveRMaAV8zqivrIhLzySJqhmavSC8WQbLkEwZwrqPTnmql/NX+1uPO7WoJ2YUW4EZzQoe6MwD4OqzBH+bx4Z+QkOgUwiIT709H/BQbUVLvPZ7sRy1bavxKo/uc1i4TCwUJ7bPTSg+3Hh/lJy5LxIqJuj6vqNGFvqwNgaUFPNffZlgULXagHugICbBk7aMSXYTUNoKkdiu/J5h5g0u+bl4dcevZEnmMkRrwCBgnUTgwuwT7Tp3WQu5WkK/SMPidXyhIuYa6D4KCB1QBJTN/iHYLVhn0Um+ZbsP8BzTrKaGuka3nqr5rLYr3R5zR/PlBjR4H7O46Ka4LVszgtCD1NYndxEWVsLBCMkkO4WkaoY+vmIWSrVUN/tDxHafRkh1vfBzE3gzN3eFM7EYq1fkGUZlNg4Y9XGOjK5nGVasThDEvFXaeUMhtp7A4OAmVEZJtEmLXz4sM6zy6NZ6wwKg/iaifup3d3V4W/8dtI/1CYNj/qt+CoOXPlOyU3fFxf2OIk1ET0hnK2dkiNt5X4NTgUlreFbuodgZSfPeDd3+WpG24eFXhmCRzMD//nmwV3VdVW13ePbfVokD3g4t8mDIA/64eP9uHWE4iuuEOc5gSpSM01zodwTxGvQHLjwHaIxGySNrebMWv6aAjDoYTJAh2otGpw96o5cL2eLPzOR5TaQAGFW9L7x4Kv/DjXwzue0VKwRa7cAH/MmIawAAAAAAAAy5OW8d7oXWQw1+YyC0mgsVTT/up+yVG8/+RgW4HKuVgK2W3Y59YT9qp+O5WmL2QbCl/1IbbNnaAESCqOubjLCjjdWEMH7XFWyWqcT8M1CdrwHhk0/l0D2yl7f4BmYtxq6Mnndsp8EbOHoZOYTE9hM9KbVN85dwmy/oFhz7zrv9P3b1La+5YGOOabxhbVo1svJDpgeNO77cAT9e/0LdukNp+IkNjknfgkCkTJyrMpCbSUCdn7x8b8jNhtljreb/i2w3I1nFCkblaZN9JLzCrukjq8TK0pxqoUQ6v5F6We4Q5DA4UU5W9DBt5oBRFu4l1sLgnhR4aFDgUewJq7NbP+kkpIT7nBT5ssk9ePiTMCnbTwF+iCcAXghtTfiBKnG5HPWZoY0DxDguLkKH2wWG+xc/bqk7AJwPOrCtqIKap54mDLL/+zmkbX3HB0/O35yRJBh6laqwLBUkta/s5fTdZjNwUZUQasqydtuNiETgCjr4VYQEIGN4Kc9c1GSp8iCCFjVJa3XkO2mvtMsm3jDY8RmS/LfStjZKh3D9ICEH9ge4eWn6P7LBWnK2dXdrrhM14LEhsawNF3uRZw2+4KUpfiVQRwvUL9Tht2xRR5E9VF9Scem8RUb1yNJ28D0PCPqFpG/iajlUrHRkZ/U5c6EnFpdAVfuPy/2o3oLQ+fJN7ON77AYbygMGFq05+vlorFV7BBBsyol3W1016uwfAgjR3F7GMsI1KSHEK+cLtyJipZHFT3h7F8kU1SjEEa3eoOUQ0t2jNcpEqlVsLXa/lfo4QmJ3jp5A5an3RNlh2XWgNIAKJRSP38aJi3xWmj/0AGJ97Y6B9bnZjtOuQ1FbmgvUi48KNoXcSq/MBN4tu/jlWUeQuYQlrig6Bn97cfIRPgjJo4d8p/by7fPb0YspKWBy0HzNgB+7OkeaXaWpBMIaqEI2NnI0m50Cz2wFoClGtUQGQz+r5mHT0YINOYZKoBlECTA7BFbQE0ALVhP7F4xr7T/H4KsfJeMFOkrAXmzwed7ruXoPN64KfWtviuikSRGSYHTRD6fzm5Es3ZoDTVdqWd6JxiWg15kXQQtp6hcGpbvzChm5zqm+2tgs3Kf/xB1zZrzNYAdWrRhEwQekP4Rv7x8XjsKgea0TTfbEq45OoxLjqpZtie0dA34Pg2gpuXyCtbwKBVHi9pascnPWDi+FR1BQVsUkUgdzdQRHMuMcITiGNmGBcaI4bgUm8bswBH1Uuep+zojFiRmwR0DzljgCSBlubnaEjQEVYZL/AH1M5zHTLHI3W9pJ5oNAdkai9VOoPtl+LeUOKYATHsIL6OYZaez9DZ/gJT6EW9whKpS0EbmHtOZWeUY1am1XgeAPnQIljJ+g+Z8PfP20YxlF+UkFQagl9MJ591fa67drOCoQvl+wTTCw33BswXOn/jQLEbOd2un6JTq4qxgVq8N4IP4kgGora/Qkik/XLXhPc8Hi9EKbF0JKtSzxDx2NXq4kNopV+PJik/5IEdO0W7XzbLwb3Pyl4XyO3wGYW91Mhp6HBAzWcrVcLXF0nHdE9RF5PDZDxCjR3DaSwiQJcR8ehMp7/ahaUgy1FNy2VRQJCUGMs5m+/UZ2GgtcpPTGnCzHE2U5CyiAswnsaxdQvzpmLsCiARLICjaowk+ZB/vhjJurTojZyC94ry46C/jJQAmm2qltqQloMmCmxmz5jLXIhkJkTn75xxTk6VzUbq0Y5mGFotuXByYqEPOi5OJz21b2on2cofiXRFJQpC2rdtzk4dtaZ86qsHu3ONTJrGplOSLmduwfquf52VC+hBs0XI4lwrOisK5Zt4Eej0Djh0iiDp6yuKaMREKPT6nnkDu2GyN04MJrk/Kzl+ttNqzSIEu/t1wISk1w9hSGJATt5BiH/vms2aDmFN50HT/A7h1r8bA9YAaA+uyK+kjizcvEcbS2gPuyt1iUaW5Xi4jRdqiEaAJqW1rgLu2y3wikgaCUws0k2q+g2OZ3oPw5eZBdcsM/KQ2X9DqaD1zNp6YEFgtgwBCmZuqjBvtETgY+CZqN2Sr530hS2ebTQNHKcF8OfyUA27z0remCgdl4/gwn+bfkbTSj4vx3mN8BvQbIox2uTLxbCO5oav5ElvqS8lHf312ak2s6c+OOvnvcHDfDvb7qz5ufX7gidcb3OnXZ7Mg2Epaj/HhEoYHupLJAFeAaNPvXnnATcIBe8crw6oNIdxkmPAG4d+JQY58/kcd1NRZIREfqD8Aoe18kuwhYs3OYfa7kf+QPA/jAZCCWWCshdDKpnvzCLD2G+Q0amgUCdnGuXFkXrBG7nOBStiLjDq7b3WHFIQBZhBOu2/yjHQAcmAHlXXC9GA+WEABcB5172bLn8tYQEssdpEqMjwjqlsyUx0C3SJmGYnWr/8qG+34WjxuSeYAJRs7X/6QjyTa5fz0BJpbEyyuKpZoZQtRPk/On7H62FYYh2iZQS5xxtpoS3bnG4xhU9Q9HihSsj3ug6hFLvZyWAmwIWXliIpZy3YukxKWz60EfZnA1joSUVjJg3uaTj1SxY08O9sdX/a6EyihUjRZKl5N09gz3+it85JT/pALAcfbgyOBLhCZCpI3gl7+uIap35Fwbj3YcmjtM3fZu/Hz8YIE21xL7cc4F982l43FiGd67892NNpdMUk1OdxMYbpXzyidw41tbFr6migqjdP4zwYiBwBEqk2+wFkiOvRdEYuXImdmA/RWt0jPAxLHQUK3tS9CLzUQYasHzLisKyFwOkaJn0clZwS70hqAT61LCFf+GdEOG4L+vnorqw6z+ZgD2moTYo6PN54x9WzH8Iq35joWJTtPTo18UQL1el72msBFs5LesRTzyjGJOA9LKUiXN7fbyaAl6FUvZJV1Ynyz9J2CQ7jOyI5FqY6SBIDdQJu6e3kbJnBvto0UVgzIs5THPI0GrxxgJrnvXzdnqjsyGHtDLg4RCud8b9f0vrMlO9gPk/K1XNPBkvK1YUPzNVjaYQf4rZEdEcx19kXAzd2zj0xG6geDpAvEkAR2fTdgsQx5YvrofCFtYzP3W+7VU1ZpQcxbY6sRClwvB6gVypxJTBC3xgi/dTKavObXi33D+/19WNF0SUTTWWlAs8kRKbVns1q58Hyc3dqTkh5+acQqs418AmAO3Htk0GEd32lGsWwLQpgKSOvVod7/KEjT+uQn44HyCkI1rZzJct3TxorQRoluUkddDpl94HPrK3gZxDMlb+s0eKK+Y2LJM2D6eGU43N+MI3Fp/UqN69Y1sHwSAR9oKcsajCgaAB2Z9xkVOWWA3k5jAAZ13YtIMEeqAg6JJV7qSTLnv33yoIIOZauSsJFUKwkPgGzABAxC3IsU6zU0fgJyd+ACEFy5Sc+abq82yylT9M7/7oDWPk0FBohcKjVc5CGZz+PTQ0sNgH6Ih0Xsd7XVcoW4Dyh5NLrJK8FK7nqaK2mhi3ESRQc3tN8fUrCVG2oDRF4caa3C0Xly6euQ0XomAjkLXsWnmK0MSrfIHaO1nTG5jfacFt+R25p559qZShBKbxJ3wMCNrjVvUurx0K05HvBG9YT5oMeKI9ADlBfu5IX/Pje0xwbkINlCrTqZaOwuKTZIb46UY4IZ/U5fRW7/BTG2s1+GYHKCbyioiGIbnwbsM/3IV/3NzgSCWF56VNXlTm18uhjvwO+UP341BwobAjksSAgx6EL+7jfpgQ5QbdQRYEHEKRdutNcDi1YjeLQi8Gyv4E7XwmAN8X78gswRBIZ2Le2hIsUpIwRjzfc+g2ER5EW+8HQUAT9TgRGQ62rg5Mlq15Zu4ay+0dVy49+3VPc123ZD1GTIMwbBMIpgE/fijF8juHBKjIgBBUrJ6JNhb5I7qRIipdTfzZSxIBmMS/XrkOt6Mt4KHQV3pv6Q4GgDfvy2Ghyo7552vipv0pnofwJXOkLE5VqAu5sl4m4qGARz3BxsCK5y56so15BcCo980GPQnDOhBcr07LuAFEvdA9Pksnfv/y7LhiKrBTwPOHStJt3u3wgvIaf4GmGnmpR8uefBmLRYgqkX7JdHki+8bjWAUe6004kfMPx+63orXraCsU8snAJNyNUjALtKFg6iAAPt7BxuMq+KfQVeZwmb1w3kunPSeBoBEzCAaE1TUrLE0Bc/hxwxw7ylrb1sCCbD+gJStAdM16pP2YgVX4lQQUNu/VTgER7YjR36Ncpu5gXHYgHi8rz7hC2kNB+3Pt9ClzTQXmvFgNQrqxMkDq9GTCRWRDMEwDUn9Vwhbe2q9QGOWIIEX+IURJudHd/ZTyER+Ecd7XVcoWVRUPShhIFOjYTRBgWTXlR9Z+E5xJymti5P5EIS2hjsPucRYuQeit7h0AyHjZ7rhbe6A420ud40bYbwY45umw88CTVhVO/ilBhOPiii+fbg8e0q1essCbb6RtbAfSllbhURkWCf32trWeMd2+0BnUE+BOU/Q6I0yPS+B3PglTnUjHUvwQPVZ3iOG7C0vZO8poRiZwmb2eP/66e+4qVofHMWK1yHFzAAxe1IxoTNdZDslnWKiyAmessCbb6RtbAgnlgXero0cZ7S50IzdXSMyG5AONCO9aqgar0Jvi1OCQkJE8OJpuowv8TJg4gCuH1bS9sb9awr/GSckxb7nmdVunRYYVgj6SlOlyFSm/qnqnZsCaW4c8HWSCYlRm12Fa1RjmDx1K9FSIQiiGguXUCQhQ4nUjprn53eFexzhBBrVV+ki27mOn+PQAq1Q94g4WKSQsygs01DONfAGyn1XeagvCXYIdYA2Uch7OpzuHFBEzhRMVX7d9FGPjVNwIAt/npNaYodknl9v6nUs/g1cwUmV5XV9c4z5zRT1gCG8HktdMX2VK1ObNN3w6QOPAV7A7MhTr4CZaBNv+qfPVmz6+oPfx7S86IWdvRxhbOPVmU0FDdh7BYuv06cwwZBLU99RFfmzLJGOV7t3JITOMXLQo6ZsZhWOWRq2anXyhiFexIiXtJJHI80Ostkjxpj54fiHpmuzIWZId80nVBNIa5DT4QRr8Gk49VzEAE498Pt8qQhHLh25Pr0VvxGDpDS4yx9SJ6mFMcaXd15x5yZuKsNkJMGt8i3PCAKfXLWvgYXJ1iD/OTLcm3+7/+Js47PBBZe6FtlcjMxiPIU1pT1z1Z+W6eY+yJNt3ObLqsFWk09+JUrdsXnR+2c3Qp7zrCSuxLaryKXLMtQJQ28avLJcZjVfNIPAcbIRb41EwWrjRBD2S8YU0aJncu41L2YFSmoy6PduDFw7O8jphUreBZHa9E2B+gx+MVwRWprhB1qH4A5IILIRmsayV5FsPpfrgEOZMSR8/eVRsy7FtuWMuapAXJk0pI697SkkUUvRJ2eKL3+tDpBcZEqrB0JC8SSNM1nAVixTJl/cUqSRsi0sSIIzS/LzoWmFA4D8z+rw0s0cTgjEVfAu3+kGQ21DfwrKKG0fgQ7u9UoYoAWbngpnZ0uiCmIFVlqXbpWl9ZxcuX5UcXQEcl3d2mryt28fRNMMoOkYOseYC0BikkitgaD9gNiHcFnXjTSc35k6owfHQtmYKgGjVDtMDXz2TvvalajkVlsYHpVrDd7gg7iff6EMgY72BuYUx8AwRgTr9fZdAOEY5vAUXpLtU2wyyLxfrUKN3/Bwt89YMEmnxM14Jckxzb6cIHZz8AsFjp4LMWLtVjWNZzwfY66tEeU07smTWl/pK4XnsIIxWo+KaSLoIqSpfU5MlEK3ew8WrzXFZWLM2XnQXiR1CR7xfMHiIhpzkZ29fTCfYKda+Fa2NxzxXl4BEkoaxWka7WnJ5AEx/AuFQIhUn8WHSETUR4ugA1Ft5U1I+bFYnzeeNgKq55/mCbyv0/WCANYHMjSj5y2CoAGL7kEXjfBoVL0+nbYjrfbEhfbyAWIXvsCx1W9/dJblIG4lXlR0nh8OLc4JY+mbOG1p4GTavhAm4pRizFLAUZP/uTTi3Xfq+Ig7QZuljQnhDIqb9M48VNb0dH0gwATDbrHGyfl3FlQ++Q6yfhIHTdceqhufEaJZoCojYGTU+2tQ/Pt6Tzmd16ZRQVcKbiw135zNuG2kuK79t/MLH89HVQIIvC6SHD2J+dy9Ql9tdwhOeZSuwLzi7qiwuszviUDOkEYOpzQHlA53nf6RQ3+4R6lavLG0bEBuyVGZi5IWNpZ3GAjVeVwgsqEV8p+WTV30XWSCoqpNZOnNsOZemXqRf1K5Y5EzsDR1bKvKTqk51HKgCpbmdzgGo+wAkj6bbehpVQ1r5SijT2R2AWb1A0JG14TJShOhl5ceqnKyvhPcSq2XosMSVC/5xQLS1h4Y+mbSc37QV0Xz51b5FOQ/6R931Ck2LImDzpz4Kgtf32Z37J3j4eE5fSmyylJ7MVL6yuj1Rhrcl23zRBEgkvyG5vpgBWVxpZRthXxh83acmKuRpIxIjwnFFABzNfnbxbNY3j0wN3b3tB46g8AnnO1oOBjHSuz93wIua+2UNGRkqCMzsORkuxUMM1cKw4+U1z3HCmYHh8Tg3A3jQ55QQfcwQ8JB/9lYyE6HF4HoInPJ2ktTLXkC0IyxgP6jx0mGjr0a/930+8+pDLtuHeX1UcAJ3/mP+3ALp7gjFN2p1xc0uoMilevvCb90POw0IC2r/i+RNrHKnWS+kn8wwkohM0HesdIpr4gxb9pc0vi+BfPgoSfyMGrMNacuGdbjXIDQEKhKyKkwLs2THk8bH/Dgft9sXVVFaqxxFbcEM110ACJFPuugiqSR3hqj4isiR7ADp7KVkjZ79DKWnpg9FKZKrZpSylZebIZbAAXBX+5KlrypGrHbyp/Re0oNP+lIEAQt9annCaX9RR2wADlp0gjVBpJk47PWLYLJvBGPlIQS00+l9ZCoYxVZaNlcAZOTo+nyuL8tWeMzmt80UR027N9KlUi/WtKr2sLzqiTeYV48UdyrZoCZ1a+eq5lZ8aGGs6foV8jrXOq/8o5xgYo5RSZDq0uZRFhInRQOY7LmrSiPur8mjyVl6aunl016OnREibWu9c4xb70bnHmPK66vEusF2yQz+O21dbQTvYh9d2ARsNiUUjh6mqPB5EHW0RKIUz3F+6TntzgDnghDS7LodTTp03IvaCQIj6z1xDgZkuQs2JO9VM9s7GWyBCUDKpUpSETCKfBl9+bS0LTohdWmoo1i3gxeM8M/f46d+GjMDBNBLsbPV9JANK7v4MPmzkyXVOWYyKfr4O9a+FDmEaouvzX0JrqCQpLm5kzlod7HT1Yb3GFcGxFwKRUHPoL3TIICencnaPlUK2ePzB5zJkd61x4Ryn5hWqei/yGOGADP5uf1h3fmCQ+xAZTb+oBwIkZVJW3dvsK5smZk6/bKgiSf51nXeX+8RSm2iG+Dc+QhbqSeHg3JeY7hOYmGn5s6HPFfO9LpVoGCH6vpJb/vAwZuY275i/ZR9g8vAyHD+L7InCbFYVivdYPU/kQzB+Hxkk6R9YmBZrZRUVWsJSQ3by4FDVAx5Qq5+1Uqn2JJYC8vsoWeEX0hlZD/FKb/y88iW7rtjhZr5txSP6JrwtvMA+JR1DWBBsXfStx57bG+fauXdcZYyVRRliLQWPKENa5nLxfzcNyMrECecq1+a2zjs4Z9agPzABcUxz1i2qOdr5feRsExqXnHFBtDnyzGHp4SdtjjW1iAraw/wMVPC5Y9Rwzx7aB5XSg7ffVzsvTVV0WKqtk3mPEBS0wTWXDhEGmDrQD27Xw1eZDcR0/AveLLGuXTj4Br657CAkqtUavWlglMtxgP3LXnqGVEeaObxx7vAnBK1vu+sFBvlDDDgCnnvjqwNKN314xOQXk2HVwuhz7MZqiW4RmbcQimCgpKPSjNDoBtCG5L6q/AMJC462KEWHnUUjQUSRNhVRVJXLQTxhO+DXVvwRAiiGhjWfbRggViFFENkO7Yho32ZiOTD0VcQoZ0gh4wucUW+DFs3228doNxLGJoyAjzKYrexvGX6NzL+AVBa6hI3d1amIiuobtgPPsVpTVi01QkZMvQClapWl7xTv4hkZA7kBGsmty5A0iWnjnrxssKh9rbEjepAnMAIjOdlYJgDbkIdTvZW38hVMIqGUQfyU4WP9mu8riIaFX6AJhIq61Oa0z1C5mV5zhqKx2VgNJrAudALCl785vydpZgCpSqKa0UxaRw3PVkiNscHZhK6DWShC6PvRyGnwDWOfIX3la3dgov40GZbRd2yC1ZGTGYmU+SKfA/OZSzpL3ZzUsXly6g1rGwL+bOGm77JN7gwuc3gecnRh9DmcBHTnolxb8MSimruLcgwb1THDNBe7BCPPukzAa7vWbKRnrO0YTJOAf/v47MmXS2rQu9VbFCd5ayJozlfcO2qlBV5cypbXVgrYEGqnTIdGq5tjn2AygvupeSnqxZ2Mio56k1AqlUxM2v/QczCoH1U/Wq5+8SXTASGen51eNn77AlAaRlRK+OI63+99ie0O4SZTYHtwp65wvXgXe/wX8+H9bGrgnDscsvMn6apwi5GjTwo49gytsniXvhxgn7p2QRRmNoxkwFm78W3grzCqnHxgIqkxvtf5/MCyH40bRe4CDWKwkT0gowyXt28GJ//frYs6AkSSZUtnDuqw6B8CqLvA5uXmmdqY6wKvoKiSknOn8TJzVeD1ggdctWwVGJKAvBKJe8zp0UPp2czFtYdfYZ4DcicY7oNxYOn9mq0NUb8zZHREo34GEs8xaC44Zq5y1xe/fR/1jQ0CnbnQx9G0XPFPo+YyUvGapbDxvYcKD7lXjsQlRi9pF+9CwAKTni8FkCBCJ4aMKvTovxszYe73csNYkwaYcsDdLiQ3CFevU4JdzN++DT51iqG7S/q3oh7g1UjC2PhG9E4CzN+fRc07YZtUGP11kyb9vsxt5YXdPw6B5iCtubP0aRR976yStctDHqPprEpPqmVvaHYSaTVOwr7uDP50/ELR/IH/Hdt5D6GnfRhWVYk8Kv8Y0sUZshgidZEF54EdhB3KX+FEcNJ0nU3nfbxyC547jlQZ2gEh0cpVRO3KM6UDyP1mdOTXnO4bj78DqVRd5b8vps8d0DZA0WENN3w5TmOTKyyogTYcVltOe8W2ggI+RPyMMhaBTra5HwyQeGczpidof1GiyddEXzSIJvXG8LNCZWkmTAZdNGwiDE04aH8rg7MdSNsNkdmls7CuRSHSF0tJzqRwZrxc8EUDYuU+DyBt7qPyv9RkPLCp30Xb+82wbf9oBWLIoZ2e6He3kqxMxPUNGhfGBIDYORhSwpHMRD+Hgo8RxuUAjp9otg/l7OjaN7VPJsmaQKMsSeNIUr6Y+JAG9WVOuendLcfdJj88HV38bWvzE9XjmJklFKJVJjJaSt/S0ZmtJdn5X6BknzsIQB9/YvymVZjpM36HPS9IXhPdy/bJr7muA5570uDqOhH1DUwiDLIZwNnzpCnYeN/g0IFjzOm2zfIiv4VWmLShI/6EqJpT4mJzVKP9uN87oFSlTnb6xU6tB9qYfNyR0/XsXq21WpDAAa9sP6OFEvRLunmE42C3pcqkooOdsPO9//OxUaRX0B1g8gcZeDKMWuLzs/NNiUnCwqViRW/N8MhIypLC3VSDCvRq104+yi/uNlWLfvQD6xOeVJwBdpRXPwaAboDrKwWDm67O/E8w4/95iV+q05knDS4qske5+1jQU0Y7CJdhsJCnZQkkO6/sfAtGDbHbdUtpGGkzWocx7uXSxlMdlwC/MRPZdADOdZlBZjp0sSpJO1GAcyWDwLHN3tVA9byoxmDO+6zuJ6fVXMXQLkUOYZBtxGzMuegR+cBMGICUxuNdEHzzmj2ljcRsZEGjOgbvUqxNs6bVOdJrIOR3qW4BHMaZX10L8I6M0RJ+y7Pk2cX8CUmgvwPpJFMziW1sStgxEt1TNF8+cQfq50FZreSSDBBg5olQqMsfscxZcu3g0u2V0xKtQMBw8Yxgu1NOupwi5HrOjnD5T6sUVr7Yw3z2sjqsDDoGxE5q06VHa6YbRSxPpWKnuvAMjWEiQMjuWIWLa8fi4+F7mAWxrx018w3MScK8NNtbLrdkqTuK41cXMT0Mm5Iiz2N+pBGzsUBGyAcwSQ7765dMkHcZ7rP+sF3jKTY+QD10WuMqbzv0ZW7SnIalfM2xgNDHQ9DKH98FHU8ibogrQtSdujpMETyg1fPp5VQPcmCP/vX5Glsx8jAq/rjTCWY8OOKziJ7zNN2+ae6+6iPshWnIk1kaGDyCbBGofLA+kHqqHgO+6pcO59/Dq8akDSx/glP5jjr3vAINLyoJLRm/yAGQqaimOzkLJA4Mut9rGKz5mULe3wuqzNbsZdhANRh9YvrES5B1Jg5Os25L8rY74Eblz7j9XZzRaHxQzB6CGzCtXFpXwgGvk9Un7jNCcuzcsiDvpuVQ4KchYB6AGeHz0f2LeZ4Xw+GdrtQ8JcysQRxJlIYwBz9BlE1mbVy83uQtgWMq4VtQwknsXrVoZrVx/96/YkqjE4TtAHVnoZLGWWzZ2HWUPMKT55D4GTqd1tjjrNPW349lryURF/dD9KTHj5KWZxEOaDO2nJafVpWgz6KfloT9GZ6A7RuYxT21ZmdANQQsRQOK7lqRpZ8oS2jL2cHBfbU2F67xKZsVG7NQthzByWMf1ApFCf8Kwgg8VA86t9ThvE0x0Eczk5AQ76ZdW98cejrBqwok/HCzoUlt6f5Reu4Kv0Pk0gbVAjp/d4CSnWa/rjEpPAzwPS7kQZeNpAK0VWxHrV/Bb8aom4QWLHASkZqVc9qDal2DDWxvvjMHs4xMAjwZkIDW8nB5q3jsvMBY4ZgRQQ8NKAbHFardzNqfAjrrvaeGiSyvwpFxGJ1x0MLC5PDQQoxxqYGA7xK9KTNuPNcR/L3JiG3sOt+TS48I6AWubFCurQlHjlAv1crj4EVUP4nQZOYpDYWa+aBFEm6dNKqXUrCCH2rYBYNDqHMiIsjjS/jGE8ERnOQJREYEjmkZDo94rgHPbmEAXhKxuApWXHjxpE2l3L7P/56qCW0a0kPk4/f/0vmxb+b55e81+DiyM8VTPLFcMv44aUw33DtOhFPSvbewWboKb+9zCZx/i9SOkDu6Js1R3SUTJQuJQMX3lUErout7iaUrXVKhh/OesCfwaffT3crNXyHf3tHUP76HWK3BuDoLuvoAheB75NsU2QERRukYmv1512WoWjs4EWXnpKIq+UDTKwQUv4QUp3ndYNSXJichNQH6IgtW8JFEUC+1+p5NHkT0Oa2I4tu35G4x9rcbX/EpZOvKBmG6NWm8MtzG3ZwKSBl2Bvkh/HwfyRCpMuyNuvPZBVxDt/mV/v8bY/GjY7bDoEQiWeWf+/StcVSO2PwCMK1MA/OLpzNbnesW30wRFAk7a2U188wccXK8ye1hTo8lMwobfCyjpuZY3MbiJ9XKBuzH+IWGLF6OiXCMQxGuhSqm3wejbs/r8kOXGcn42s2ZIaYV6fzQxT4toynGezE+YH43x6UFS7TiDzxQ4+BQsTqz0MljLLZs2m7dgEEhHxeuF3QXQv/k4UUBeAc0GC5HXrWIlok7WmMFvQ5xg0H4Sz9WOBC6l2mTAZaRYcgHSSDqVu1O5cz32FLZQJODQbMbAS4KY2LQ++dU2kqUFuhJOZ3wC0Xfwl4EWPd6GK2MYza5/jyjWUwgnIDA90sPbde6kIgwNNDwTqPjB6Ol5/guMRuviA8waffX5JjkzH5HEzQjQQ5H5GkkVXzLedJk7gSIpbyUcZZSg/UIe4M9DIQ5ooDKm1SdDTkMljLLZHH/1TlRLZlhWLktE3OOu2eLOaYoUReEDmSrleEu5/cQCdnTEJpp/lnfL6Di4XCHvdCPyg0TBIrDorUWf+oxAkFskvYY73/dRYe+97QRsx9Jy0ezHqMCMTrzn8nzzoEEM7gCngDqiiLMJh8lSvemYA5u2CwQwgEDm6ZLDglVaOlEKNmMnAf80M0hpmLm4iRiTQMvFrY7TPsl/ZqZYfl/BAD/e4QleXE2x0dAOAgoxjJ1Bv2jLRpW+TvQPen4jsM93geXIcAGZ8Io/nzOLYf301yIZQdn8z3vtAGol/u1POs5+SLavmvkBi7fjUyaB+K8btcelo5CxAWp4ARI/7xJpULsL0WQauNuXFeZZOLT7eIxlEES+yTkgLjFQB3zIXecHGvTps47n41z62+0tdSB7x/AJ93Men1/UQ0HUbUFpe2wSYbYZj/U9PyaztiexN5wQ6tl5o2FPgWpdetnL7nMRvnFnEFMowIONhKsXGT9+3Rzi0dzHqMR1WwZXQN37xtQAoX7J9CUTdZA6ojBluHYqGELqR9rI2Bg9iIO8M01Bwmr39I6iYCRSDJ9VkS1Inij/LYl0FckpIo6YPhh0UgJZZZiXiLn5z+9ibc6oeTj8+aS7DfNJh4SnGfQStqtLn2Cm0GjtOJUWhAfEpHmeQ4+Swl8plqzuk3vTYFAMmIFDByWTDezeFLWRtzPqJwi0lUwbCH4Nt9KkjQ5KPfMOCjJTlfRrRmnIYeBMf4BbG8ceWModyaqWBJtHDML0OT3QlChzeRQk2dtTpjxFqtl/hxtLTcAVlAPwAIen573UGElxTaBLOSK7DO9gzF1jpSFmbCiLU8vysSGDX6FnT/Oq8lk3V3o+aU6C3hTc7XdjOTIy30x1xLWKdBhIMV2JdyZwl/HtUGo4SHPb1pFwCfvsMGuKWWFd00cwrDVNotYJqq776V44/kaFJWyADrnoRc4K9piARztrpuQvnUwBlqLecZ12eBuTWNEIV+lMeJSLR+i4uQz/s6JsmbbZN1TmqeJsrBEoKyzKcJQu7goFfrhjhWsuTRN75eH0qx7nXXBGINKPQasIahYejymT1GzYeUfKvOrcDTQ9ugmiMw+XQp3QR7Y2RumoFt1wwsYZe5G4XYX4wfBcTD9EjYhJk4DJ+TdVzHiB8fGgSw18EDogO7cBpRVWLa9sZa0UBrujQAMMPtVxYZNqehNHmGObb/eK0dxbR0LEZFTEHUbqVIT6h0mQLuTdDbg/AkC06sPm6TFA3+2KEsgPfO4Z8/KhCHgsnNgvEfgjNyYuiaz7tXfsTtK8YJM7WkHc1iWc2HQd8AxTt+4Bs0sas2XkFiYxKWyef8/Sr6jCHlbxgcwLYis/xEyZo4FtHQsRkTWjzMHFa4FDLraj6D/pwgkeSXUjssehik16N5FVMFjqTA3xiW/pzP+QwXnklagl+CZrmUUe6M/r3FfEK27VIG0wmRobpRIVhS+mkNCMmaQluysQ60GgCaOL0XOcqmYaWrsVFiA8sBu95ik8dY/d1U/rmAGeQA4pUY257locwK9bM/YqRZ/k4ulUfiM7IF6t76wIkHqvkaas+ta6OrJ8k404II93IDmaYA/TqoeGtqjjn+rZj6vQ5I/YG2kihQkC/JpJEek2wbAE/lvR6V+dqKW4jtsxquS+vfzS2BBHL9h/NoDH9zPKCOJ3g1VO455prlW2t7B3NPmfOlc4ajDY/iOQq30lb4oK3n+Fzs/n0M3NjqPDJrxv2YLpBQUM+EUAJzIefIjWyAGQisaZCJZUcu2c/2uudkln1/6z4inu0jBF59XlSYngwqLnaEUlLgFQVSSqIX6P8a01vmXplHZ0AAl4zTKxrPG2BbHDHd78JDRjcsVIDP3RzW7zHMh/kFQZF8hATB9X+gLo2UZGJyw91GkC4SIZQZSlynBNvClVYbhaC+JX8U3zWmlGoJeIN7Ardw72klXmUOxSMddHHPq+PoeHnuMjjEKGBnJYhwLiiPq3RbtGoeDCJa9yPtIUoxSZIY2l8f6A8cfT5AqlBd/cPqrA1tlMIXFf2Cyq5Dd6H0f12eT7j/JQ7sTNhm8m3GhrGpaBOEFU4NIaIbrCHNNu31AMxgTKjfyQI/gboyLYYBJ+k/QrCZok1QbKOdr7NBLJZdlLHS/OwFns5O/ec7u8EbDZZxJHbKKhfiX9RoM6KDvmPEJNmdSrRXblsUCUJEOIE4NJC7JHUXyga+MLFuc90bV9w6yjYYzJj07olx7SAfmGEER8KZVRDQNFdClybFUHd+KHNtPqfL6/4vLcu8aNQl/KxEec35sCswJf+oUTYyPSREZYt2pFTxiXSFa5S7HlS5+HkBkHt8aZ1McQv4kT6u75Ia2C/NBvIBxZsODjpE5YEcF70pkwjJkt0ZLRVfBKfw8Mtpn0IuSV2HnRXXqPBDB62vEnkHSubJ/oPrXX8TC4Y1R+m+6rCzC4m2fkflvkOIgkCXsDQsASJRZDRhaJ/fc2IWXs4w4Rq2KD5QtbULuJqpOU/+XcA2KKPVwr4j4ZonXXfe4swD8lsaa5kL+q9ZKXllK0fAJGpshhhLv872rjo+LlI/R7zv3FeauwT37oNpn+sdxZoxIkTDdbD/wCp1yNCz8LVfa192E+yzvoY6+z9LaIdvDvfBl92kSXyQoCoDtEBwt0ENIlq4vvGOh/UVqrYhLc8JQIDsfcK4/Gaa+dJ9WAr9kSRJcMwpBoMXJiuy4b7rBLUozkX3cQ/sYxs+aePR76uf+h7+i4C+42aR2O4uFF1ZRKr7mP0EMCtNERwMDH6E+r+8THISzNJZAhZIESJJfD2Ps5ZEMrZnSSqElqEuyaRwAGzBxSSYLwHlvMbN7yMokFSHjhKip+R1smMoob3sZ+Gd5Y4OeVIYCRCBNRKP1mlXLcUszSGkiXhOm/xbiQihQSG4Y3qM+5p+tKpOecb5wOymkZDLl2oMz9lxkD0nYjHyRN5tByo7JbETGw6MUUNf3VuKc394c9dx/LylNWBeDgsK/jd9ImGVpIqDNrVj2THUtTO3po/5T3GbFQu34xPt05zAiRucYG5lGO3kTbusPjizPh7dxlfkS8KTSoqObyQcpQBD2hQ3j6GjE13KJssijIhkf0Wuheyk8/lMJfepzqM7atElPhr6HclODA5z34ZeFKutwgBiknVCxS9N1+vENNJsNenOzVk/xfrcQTYxsi5PSK39jtHLZjqys6nuntzl69KiPm0MCYHQLGlNhRdAw0RZKjS5MtIpKjdlA59Sy8gqkwIv2g/A78edL5RcN8A56aVFtIO8u9aXkHvxxsFCwJ1HRNK3az50FiVXVu9UojhAoi3OoxSlj3bc+0N92LOvLKWXyW+5EX9x5S9I8moF5dHBVkh41Tighp+ddxbnFGWbfe4X88UOxLqe38vDkBNAOsR4+yQ9lyFwGIoSLo1mxdOetTqst70Yyg7vdOs1vfU+ndN1P0ZYnsSU5Stc48vXujlkvYY7Hd0lvZRZIobt6lj7tix8nDorxwtVqIB6Y7zakjxxlJ9JqlxXBD1KKg6FGDKkdlR3pCN7TMGj2uT8gDSMChv3nYJSMFWh9vJVv0ucgU5Yp0da50QXGEhr3lrDS8UYhnmuksTUv22/1nsdnzgIwdjGgUdBbtVcVRtQc9/veiFVinW3IJgKFOhlUor+tQHaeFtxTg7lSnRMRacQFl/dEHqN+M99A031LqrPSflHFORU8hCAx3SiTowGNoQ0iXS9KIwo/AVCGB4zH7m7xsZplY1njbAtjhju9+EhoxuWKkBn7ZNH++JmcA0uhcpY0RUgjftEwGL6SVc+r67HSOkWZ5TqEUqrDcLQXxK/qKOSbNDIo2oibx5K9+TkHQV7EPa5XS0iVQhWOBg5EbZo1mAEyq+RkJ7w+tH2BnjoNJBi7mTMTVHZZg727mPBTh7H3zkUACaoQHSksujyIdkgnNzZLtVWJb4etMLvhG6/KIjVQNwSFJ60FDJrVrveTqoINyziKJRPZL6zbIBCb5h9guG1uTPZm4oe8JZAJMikjM3sxgqBXrLLXmlrYbjcmSoUyvBU5H1d3XpWtyw3gCmkMbxMw4I8iGJwtrmU1gSwfUQrc5zojqmxpmbjnWsPhJ4M2QTAbM00Xvk3cEedVba7cOjXYjqUF3HRlqXpA9/qJomRUVOqwdtbk1jvC5JXcKImOGxXFuqL0iQpEIuxRRYEAV+TjGLUrssg0hohusrjZ9ZJ7p9Xik2prveW3AlUiaVihHbcbB/8pTewZjrjmpLnWxqmMmW1lNFU7puahFgF4BkondvZERwXegRTEVgoJNnHDZb7/FAVwZ91jir5hIL+xTaH20VsuV15dkFEZfq84eIBcG8tWq1Z6zngNy/OU6SNwHvIWiiFmgthdPmsOtjX/jubef2nzWlFGxNUynWLzhhAOCN62n1+bSlCMkc1MRV7P9A1WHJoINU0Ijrdt3Rla1LJ2tLNJlN87hcGWee8QUOOlL29h3+ikp93WuQhwuP36h8I+Zceo0GTy3o36FlnAnIqO1WifYjob1VD4mEV/z8nRVlgCaeL4om6Z1sFaERjdVizAzyZfNjczRA9l6RS/1pE36CnbZoXMmPL+DPiQpiv+18eUYjVp5/u/+LLCQ2hD5njOxjBWzGY31T23WYkkYR9J7Umif4xLA7psLPgqCC2KfywOsmxoJHsnr55UWDj7V+Wws0Af5mrRdJVP0ZmLVp3U71aIpM7b4Gb+4+cqPTl/jzJaGfTsdr/9bdKCQEQWLSHIvVwxq0yWbWmzcJcP/cCICRmnEDNQ6i4JT4SKw0QSmYsf+y29juFawFn47xli6GsqhO/v1/PEEltv292ONloR0VqL+yN+58Ag0s+HUVX+1czsulm/5JlWVCCKSuFOHcfsglMHr2EiqLTRabpEwC14k3k7ADasA6Cq236PulLtUX8rbteFSSSdc3Sxrb1MlPVhWDPgeMTFPrAmpappNtZPSQrj4AEiNlxOuC3QF3XbZYY4J3796jZeD8oyOIIJK9jXfayWA6u7kqjXqQh3ps81mQcE3NfuQZXrl2Rs04rn18VEWke3Wktk/sNioqCjHMt9dcutZ3TFwV+wGw/WQ1cfoUhhR7j1NMZtMt3mO2jJsKXWEUast3CEeHlzO7WAIkDKxmWzhoXS9OhqoKh6asxVLUfRpTJIpS4a6TvnRPPZGESZdR1eofu9y+16k7BItXy2d2TEoEMxWsVZeCYJdVRqestalRPqh24bw1xW6LEQ5pgk4TYMdIxCZifxSOM0jW/U0h1TWF31Zrl2nKqp2UV55aYmwP4Uk9TUMB9Uu1DAwvZDHBzhC9dKBxMtICRCI9xgXwl7waNEojUqJcNGNYjziE9N92+sTE7kZwvxBq40d72pdZAdudtTA9lVQeLkjorFlHNLyAjwwN+wo/rNtJBQuOH/MFUQ6qODgiunrNOGz0H5K+Jwh2u3kJWLr7km3a7Ebq9yyeB7cCiXyA66jki1El92M8edj/RHGt9mpARL7WU28txnv8QQBsx03hS62qZplL7+10mVl7e3/fBgB6SQWmaUt4zKGFrC/a+UGX4klc+6dbchwVxF+qIY2ule7qQsBZH/YQ7NdyzIyHXA2tzatRfSoI8J7GViZKPagk/atQ6mL9rGVIV7MIhvN5vbiHi2i+Uaxp36KXwcYTd6592/QjD8Fg2XVcZiSTabzJ4iwDQxgCb6cSriiNCMWhI+mqnBJ+HHQ1oPK2wUK5s7r0ShaQso01M7Qe2NyJ1FUGDZ99U0tF2X84JXJXUDgQelg84MyE2aoJNv2XHCrBXFS+FGYKnNEnDDfwkscVMnTFjUpLsIBw/mnzvuqnG+0Vjv+zed3svn7tOIegqKhaojFkxgx4Ebg5i9/wz4sxKjPZk/7+Q+M3TuHgEOJ0yTfmq+/wwBb8V5ciwc1mkmA1Z4D3lOWLQ8Fe0gnKQ+VSl1APNmuraees5SMwZIYRXeTglFKYndvLdezZHIhRgR7P0gwO4zvxRKsVb0ZgguY7LktgKTwACfVue0Pn0vVDWvBbRwEtLr829YV+mWlm2IsB7gnku7XinTb32S92uqiNk1JHvgjomgOZL+cT59jn/iGP7rHrbM9aieJ7I/rQyuQJIiohkV3QXm9AbgIWF14zxRd8LAenakitOTJPFRabfC5EFuSi5n+flzQGB0yYVKApiX7QqVB2g0uGmxDjdOcOEfyGFGnl2u3M9w/uQ+lYzQU7xs7VSmlROOVdYPxDRwSfYsYSrPU9Uij4npWAwXNui0vaZuA2PubgI5u872OyECc6jFNolG3C6qYbarW1niaQjgORCUUdZRiFu0JHL27kzovrzUwlU4xJ4DbCg6Syey/BoH1q4s4jHbyK5mFGWLCveLdNwuMu2dlY5x7l4ebJ7AshPk537nu9iCbFgVmS5uia+reEqs/VBu92f7tOdzAH6O+0UmNq4/fe6q1qpJCeMd8JOYn5L3Y72xJEhTfL6t5JvqSADbMBXU7vxHZJV7zx9iImv8cxjKDy5WGtKVeJAbgEuga0Sm7Qgdgh7CWsV1GN3V1jp5HuX3pni/MSJbuqdel+RZyj5D9xRBklQyy16MNZVB6BmaeuWrYcZ3Oa2cACOxGfUmSa9OpM1/buR1q22h/bq571XVFGGK6v7pLiJIcSRwY1ab0CFvXE+4Im82oRp215WGOBRsqkZNz/qqpQHgqvciX1pA76lH4S3hDrM2A7emJVt5EE2gv/UJa0bdcJm1Vb7o8leX1HvrXWpRzZPAsMCpyvQW/HW3Urun+eeCQaXu4z7ldXJ1DaHLS7UZYkoljGYccl2qljMBMJ1s4OSmWMa1Imw6dA+55XlkETM2L2YKXCo1+QFDHdn6I+sXweQaTSfUq6K5vvPL4T10MNgpD5cUQRmWf4WniYjHyh2/fUNOUKXTjMNx0dxBgQLtaMAs4GNdsrvHQiV5aXpFsDMFe7Ok71iSnB3tDEApwAl9+MgQXpIYf5DXvmgyNnW+Wc5RRvRgexxkhDeOtVQ1BcWDuyW9/ooOk2glCcyjw8hVFyczl5TDJSd69zC5MG0hGquwoFAak1TjJ/jmahhefCiJHAj8wBE7BGKI6AcAZmSDUtzF9B8c/l2aaRS9g784iwggOJV09dom6u2OAWAMEUQIxkZacff6zTSKBbUymxm06EGUIo3R37R9fZXrur9LI+toonYrqy4RCaaBXvJAChFkL671jjKMWXEwS/uZNmOUUS4E8cZYQYgBx9HVj/eiuakQL5WSCFO4ll5yRur9OKPdYGukJz/06Tva3PjYjev5JNDL9iQTxgJN17LABA0eIphKi7LtpRDWLPBYttjqiBcBWUXS9OvvP/mOIfua40LcipIz046uB8iphQbGm479BKOkumj2Hr9vvbswbwT7meybAt/7VhZrjJw1DlGYEu+Zwe+xXAVIEO+UmbHIhgXNT24qc+i6b+cHgfdNM6gKdHieFHPDa/DbFo/8AAvlu0GYqLApm4W7tprWYcN5deQMYUqaqaz08Ma8v7bSWBdDnlI9FXsLLUIylYCmscqPymFBlPDa7iTZjfAzkY+YvTdJJSUwqgSOJU2gG9TctPyxx0zukNipXubpFiw85+HUozta3Qzr8b0ube0hh/Y2aJhnWwAmzBfSN0MqpnsFT0KRi6F02uY9umcBEb0ts6RG+uL5NLH9yuRQrcYu2piXW25Z4rbhn7GugFW0VHmujTxJ4lz2x1EKxmft76YKhegl8kCQjAmdrmkQeIygQ94Fh+hS8QajA+sdIOZ1XYuF6xUEuKqnKANyCns3a52SfEm9A7bWfjc8q3qqYq3NLkuE3frzvsdU0nlommFTyzIg/OBR8fYHbuLcYehCf7Dpqi5/15S15V+unxkDRPo200C0hB09B0W+tkYM6r0rMbtZaAUYhD6m1KqWxEAzUyXr6nX1xuujfWXMlOQD3VOaplbpPiD9DgmnN8UTXB702DjHx1CUjPvFXx1AxfBGJlFDxtv1Ri1w2RMd7jW0m3eP21liTfHix1DlyKofQmy4CG0GW64RTtm4Fi6KOSR8dTsVdAXP7BJ35TKv1znEFa5s0elNCsG1ncZHp5zbH701gD7gxhctEn0F7+6jqnuCsSbi5sL6idhB6g+/bKFkiX95yLngUyzfnUDzjEAD7Vz8gL6OAVpeTj88a9tIxuwEXxno/ZwvB1XD8X9govDIZgjPiaDrNfJEnZJeKw+6uWHEdavXRYcBDfg2TiFL3/stRHLzKECGsAGD7oRvYwT+PhUAAAAAAAAAeltFsulPqIr86HxCsftxR6bYr4RFbKgZ4BP0iBpBSYhb1zj+g2xJf/RifmGISeyiavETyPh7KS847IoKYybpDqT4n1Ug8eRqh/zsrJSzaiK/HvFDzvwY5oJoI1ADPln+8iakQLWzO5S9gdj3oAUVmuWri43DIcUQcUXUwwg3juCW77tlZhi+6bP0e3Jng8B5QmlIKomFgAlGCdpDJKRTklU3ueDxeiFNnWfOMn5lATUwuBojyL+fr5QAva324i3D7h96Jy2JeHvJODu+o2ebzbiMb60x9+QycoUHefR3dvTV5a5K51q+GOnkCGoeXKxa/pvncqIHbzttoDv7V1v3DTfThfvVZwMxzpRbTqu0WGL14f9BIGzz5yXoldbbzC7J4wOJewOwtrMaFiMgz1vHj5nuqGOgDHmj/K0uKxzr2e5/jTPO4ymLUsMcSFfQOBYx0OS8Sahg+OceNR0ZQPuB0eKh8jh0sF4xjeTqRGmomZSY1iBuhEd9xRxf2Yfz8sS/j8hDNqWdLmveOJXnGwSHS6xvJiRqw4G3LtaXLkdjiIvI4F4Z5V00YrBZOeqMrkLMzeZq0gxQF0qkjV1HAufDUHSDxDTo/blV7xCz9iwbAAhPsEPoCBqMNfhzxZ07LglDNKIN+h4T0slgwyVyR7nywWiHTbUgTE+SO3MTVKxenT0vdYy8zeMGXFe+lDAT7CpWS+sx3CjK5UJRL/+JNSN3fnAA96sQ6ALUsnc7NAQJgj7F4I1AEYbp7zO8j2+xfXE5jZ6B7tubGC+QiM/tR2qkIJFgIQlM24daL322ls1XvPxB+r9u39UQ5k+PJST57uvRm2bciwn8MXyDpKI5GbchUknL9UTOvRyN/5SCJeEXtLUy9OFdKz2LGh0t8qGqUl7+9Re6DAAv5dWvC3/enk3E5bxyraPPNEpYb45qV6GpJOPKp6fNGFXigc/3UukvwqFZ4bXLJ104iimGx3RAc8IKTs4ZykvOtwBBWz2gTGw15Ou/n2l/gA1rnTpcZ0lE2CCYsDuEmVwElQNuH5yBCwtlzVForIJQIFDvpTRBIs5tiYovefAqrRh1f019IoChvgBWwlIAIB1+GV4O055vILofothnswaqmng5Rh/FUD9L1hiymHsxcrv51gZt1aGSXWnhwg+VDvz7d3sbhMsjsAFD8Qr0soB8n6L2o2ZSahFfmHncJY/9xfwQl8VUUaJ/T3/jx4lRDXXw/6SuPORT8UJtlPuWm5aFd48RmBygJSj4osPDXLc2FIi2Jl8Ssbfe+jFeGGquvKDVPanl+IEUlmgK3zpklkzJnkqvtTyZ2DZXMaYemBwLAS7+GYRW7OJL2NoWcWmIS0fWATpu9+oIzYhbbkh5VVJJ76RTcAlJHQD5QxNwvBXIGy2VUnRJPeN+54FT7sMwRQ93GiIWAlMpIZZIXMsQrktzudUubH0sAYMfI4JQXjATEW2ELyfn3sNEj/yKgmp3AbJN4VGS24dm7uBAWSgAJzteH3/W7yNxNFSzBEE2B6+EwV7l+FU+ugxOllzuowURnL90az2AJigA4fZVizuGvXc/16dcPeLd4hfcd5pZ0UCJp5/02O1noKe6wnsbv7b6+ZhDK2QS6PL6fIkSrMxyy+Rak1ZApv4bz2Yd3jgIYipmTcbCr5QOddem3i4zqZfR7Qnp6gz8q3WRpeS9scnWGuPMi3q3Q8/0H3aS9z1a7OaimQOo4do5SqrFkzKjaa0BjyGtRSWSYR2WqA4vdpwOOhKfbicR2gqf7YMb8wqMqp4t3q/PoMG4LDIBsj6hvqG+HWmIGe5kJhEFwUs1LGeu1dH5bILW00UP/rAicTU+4JEOWECKx1PuFoMZ4q0jHZ7QWus+dvS8x8U1CBKdMtY6CyhspCELPjTJrsPPV4jH8M1D2ZxJlmUjLrhYcPLmx0D6G+q8XCt8FYKHjW1zUepo2Bvj06kP3KHYZpUaCw4pl1410+XRSPDHgbZ7JqIdVt2JTy0FbhNSWDTU7rItRMrNbZl18k224WnZCCj8vT6fufCP7L+z4CSfccmf56fXjqyvlaCOCEqYg3pwKUVvGHRPv3h2uYyvnmGkbKo9upmeuVQ8J8C+ftkJtwsrB2KuSWVvzcrrJeF2NYGCBCDNDWtXgRgwb+yBFiiYB+8h6f+p15ZBI995HxQCaSU8DnpBSI+hB8SspWY49B71C5kWkX+cW1ZuQVYqMPAXO1d8fVeiSmp2nmhgqDxEi7ValVFJcGmKRZydMwxpdlo+uw7IC4A6mM9KRXw2YpcoziGsbvz8H+R/ZpF8LZ2y5EzM2Dz6cvS+irN25ij9dOiREmKEn89g66xxgYZGW8XZnrTlfSIQKy2ZHPUT0VpXjrzDGG47Lve83fh/2wMeV4Gg7mylyKTIadBaMEnZoZC9Jhp3Ydi14EzrbIsogaRtV4ALCxAxtnvdctLp1NdOqz/1Qjqi1XBqBwkjolgKKtuMoULLyBTu5TTpDQcccRkel/l1OJsPGZ2o/4wHmlJccRcvRpspr5pN5GyJRU4EEeWRChfzIiy//B8F9YMdJjo+xFUgMsbAu+LhIiZD8NnkM7sQFtL1H2vnvtMA4G/NJrvuALh3w4HgcRMMZMF00JD9sGF1SNmxNAJF/wYqN5MR2O3DbQzehhPY/fUYaj+S8Dzx1WBcNkEG6yoxn4Fxo8+6kfw+Qg/bCxe9X+YXNZ6iaaZ7gM8KyE3K0uI7ZoGooh9xpyAgl2yRm/sZLyajmmQsRsJcwNvPYuHE1Asy6BOsuIW0wn1ZiDv06qCtwgOwgYIfF7HNRqaY2SdMUiLYmYPUeW/PTbqL3Icndig0L5D+6DTLijQ2RduTsIBDwU+a8QVjZL760b3caf7SwzlBvproNsdgFjzVriMeJQLeIbalKfVH6TkaIBbrpXUD7vIoqn9lkE7o0Q9CpMkUj4URbuJEFeQXTRJ2Aqjkk3UdOy4p2OxHtYvth9ugY63VAQL6KOtBrPyuuwYwF8+rdBvKmpHzRGO4WavhjrPOB4SY2kuwJ86hUWpJ5T8lV+OFNyhfguADS52B3tSS3nGGylzgIQ4vHXfFwuLhi6F/6oxoibl76pzYUql48OL22ut23u+feKkgp5cd7iskWoRF0NARYq7rM8rLPtyH13f918AZYQjwfNROPEBi6AurRCmslAokGJ0KS1Kli6DTtW/AKJBKi5gt6HN+7S7Do8GMZN4c1OVZhofEKx8UE1DoXdRkv752eg9Qnym4hijnHW9LocA+DYPoO4M7m9Xr/4RbF13cDrDNlOhrGfvZLh9o81Ebe7bjk9jZm+7rk8w2Th55H+Y3lO5SphLjeLoG1KKmk9CEbl1QWDD8BQwGi/UCzHaGg17/hPZ0DNJeK4lIkqY4IjNa2eueaS/3VHvOZOleZg1mo7qyM/8Jf3sAG0l5JVtGR0kIb4EwCpwRUu5U7m8RjjvW5lEwJhgbI/6K2dlYXmruaEFVlJcYX37T0cKD/wM8b8qw7cgeOl4W0xmiapb6Kd+I9SrOFyCysMb1g7NJUxrfJFkJ1MdknPf5ZePL2ibAl/hBPnWBskgDTq0VHVF3inP+fF9xjVu3gYLyuqHYnr4Qwp7rZZW+ibuz8ugS7CkV5RjFiYwtFsO2pohDF3+eyN9XnTUNqItjF9IHXKSu8jwDyDFZQWzKXbYyuIQPYRhRG6+6MRb/U7T4U/321BaNZMD6an4fpP2k33x8xqjG6U448k7pWw8ezIHOhh4DNNHVNly7ULI6TffNae1oWglJMoon+6MEzBcSDp4DbOwdPYzvwAAGLen7AGpW5gH+nzVwmiLbpxkTIXPVDzaf1Qq10Bg6kcXNkfkCL2tQdxkgJ0jpk4yE4X59Tk4zm3a51apl5cyGZ/RQFxAMqKRVd5PNbDlLJzZVuFx2UbLrzm8cFfTVykOKsi65mR9eP3SIe+KE5takOcVolroVGL43J8XmverUbBqMpfCxu3abTOar9Tbeqgnynj5CWFA4oPNJGCsaiAEv/Vi2ohXxax0xwvPjiJz+APwg9tf/RmPNXc0ILSAumPZkDnQw8BmmjqPtADUuIip9b/uOmcY7Xj6UXE953AgfR7u/FTHQW3U1gicUnfw21czHyja2UoDHSpm8eekJ7qKKNo1X84w4r+y22qr1RljyPYnRnCZl0U6K+JD4TABATQWDjTCG4ATxNG509zRPXBWcm22i0Sdz72oqqPzjmI8gs8y5fkc+t0tqz/0d0/EbOoZ4vpgdJKeZcxsnta8XKm9zS9u8AJFiRB6HoixJFdhoyZPJTl93wnLg7ErvZHTWcaAdXnbnEFsT2cZEFrjNMAF/2C5E4dfTKpvAaUlxflAibpiwSM5sAWDQOEBOP1ClXdE/w5tFd0TnMt/mdTMb5nEhwzP4aLmTJm8KlLvg8DyIr0navxpSjeCIvcJAnKhPdhG4c7+//9ohB4XeYqml/68lStCgEz8uZwGfmPmkodAuSfmIy+dk4ehNs80OCvxtPy+gNX/lQK2rxj14jL3ln28fphNWVbczrXt9O+csIHS0unq+GQ325EEHpLuc1OpTGpcuWAgq6/8628M30LVcbpSj3WluDQ8HO2nhtDFWfgc+pmjOv6pKDuaNOj6EI0lRK438WZHrLjjM68i3TsH2KbvxAhdssnx6O1wcjIpBSF6JUbbZd4vpB6bPcUZIZ+AbmiBwQfjx4AK6KzAWMTfqBAhXdH0VIGwROgMbd85qRBmULSpqi9/dXoSeoYLl1ckEE/yVm5RDa9qQyojM7UtgHHWYBHgIL6ZdMAt5GGwuosR+SlBPIDIuzQhrqBxxCRqz41KRP0+V7O4/IYdTcgbKyYC/jzLc+AyRMIRLK8+h5CIKi6tpevHUhpKssof3tjTwrYVLpBa3j8NVUO3IY0sFkcq9e42N/Z7QFCdfSXaal4kyqfuF112n5p9AzKh6Ufe1RYvVgN6O66CUKBKuenv1iBgyEWMJW9Y+mCcIqtRn1EAbumW4E41geT1n5jDpGJVEZRehVuQp235D9zI936nkx4vuSelo3RyNzYIAmpbSsz0YkUoD6HYE3l6fj6T8gH9DeEq58smFN5OSfuVWceQAZBF/QMO8VmfapUceMPL/E3RgD1TB2rD1nsJLUhSOKo6UVRZvUY/kMjg3wtZKP0NXZHACVPbpevhcMHgBGGNtlklxG9Ntx0csOFWer96Upql86MWJw1TT5tvup2+3fbnTO2apBEKgarN6Pr9EqzNmjOPfzNDfcUBhjUeZl7W/QtQh30agmr9jyfRlC6xBM4Zh5mAQdgi9vFuL9v3iBE7qpTt0TnsE34jgFNBAwX3dsuU8LA8mBRjdLt5pCZzJQZCpa70vuPtjkPPrxwN1BrZtWRpn4Dpk6fqIhHEdUa1QLIGjiIsHKufUHdWlMjDJ/jATL/I8cuFK8DzwqMQDLCBF1IrySNeeEf76QOoeuS9vt6lIjvKkmnUGw7HGhIesrzQ5SZXMfzFEMFllIC/IJ8F4u0r/hO5fqGMre3dEns+AfYz74Yvpj8hfrs8bXQjnT0GltoHWUY8c2U+mVTsf0dVEWGu+yDLYVWqVxYwxmI8flFggMBTSEiNiKoCVAZeK2sVWNSHNI0N/drx/OXZ/Xo3k/Rzal8AMeN2UzvWzs9nTIFMD3zoYFOirQ3zFaJvV7SOjgZMDBgSH3XGu7DPdb5WozsvneEmF7USnPS86UDd35GFWttyqAtXYk82yji9NP6Pt4EBCzB5rDCV1P6gKE/P5ElNeyha1bFQbm35/fFh1mKLJXyK7Em/skTgHditisqjy32Jp/rOUVdTWLd6dWED73sirQMp1fBYyJQJQLQkcnvGX868qOi58qeH3KOXGg3MpUnFztZuGiG1VkBmW+bzOnfKvb3u2xTbx4BgRk9RKyQGNtXUAJEjDiKaeAjKo46fXsZEF+MbYAgChFEzVA07zpgtqGEg4W8AAAAAAAAADavXemIuWCxfd0o1Xt93YcCvqFf3HU2enixWi5ZeJ11a5McC/kshKcH2512PTze4UWHh9SgZ65aOUWiu6+7cUbMBdQxd0ghzRJsXSIuxE4XcWexbQ92FUYFAyFciogx/N8ilkc8Z5sRKc4GmuBfyWQlOD7c67Hp5vcKLDw+pQM7l5haT6PCIBo1nTmAXTjiJhOToNd2syzTxp+L9/+a+mg+pyjb2cN3PE479aFXcRU8t/xpAMqMa0xeRc9MlAPGSNsdv0JRNtIg9JQQBNaLndjMhFQKKOJwwMzKiT4ZJMdMscjex+wXse3+cj4kQikmNEgQDyiZs84yJIu7S0L1RxcLcR8sTfC25RjL5EmSO2kV07JEQN1pIZ21sGW9ccm20DcjUfZNAXVohTWSe08VW/aM3H9m2pirOhsMwYhGGW6+EwFYO76jZ5vKH8CNOxvZwFwcS4JgReJFQffmhmlDlszHQLP6qeBKpKMARXo/3r9fgXOoJrmhK92CE7b/7uapwHFDfIoPmAj3ZEYWB9EyxdyVwB7nFHCgSgKQZwryIdqaHwpZ42sN3qiR74tCc4Tf1rzkFjf9d6ohHvBuhrBYbiF00qsnrhij8heEKDZbLC73IDXFSJuhQTmPFSv3Cu3RlYMnHkfxOQBVQpwN58g+wE8U8CVSUYAitiAi5btGXD+xn+LvIRjQ0rrC9XZgYJ33c+kPCXGAfLdzWoNu8FaGFOT9drAZTTImsQga3NzBGY2Y7Alq/vEZozIaBj+HgNkW1/w2F9LJExLJ44TjFDyNQ9IHtgT780DqZwXGENnsVil9O0AumLjm8GpkXRzya+rVkzUpcbh5kq1rnZNZrUhCB/MimonncVeWNWRq7cSFa9Q/jpkkPTRFKi5bxSSXtRDQLcrU7fnnm/5tZA0d0WnbOBtYI/3uVDgat1OevliKKVV9L3rMQtiSN4ds5i3HT0/XjBj5p5/v4fEiencHy+thorD8j/v0IsIT+VqfNuNeSnBnJv5hWex0Iu10BIQnT6OyVcScQVnxG7tOEcLGOyRTa2e1Udce2hNAyQE38diN4W94nTcadZh2EeNSeYA3j35skZsRXNwnimrbgQ4Cj2JJG6rfIENOSjy6KolT93p7JhGnOVkz22MW0cxLKpDStDyQJ2kg4IAZHGYXMm5BqybE29qTOpTTBCGXuE0R9Pek3h9P73Wbss6xzVn3LlI3EnZvkE5lZyVDeyqwgVQ7e6+JiDrguKc7rBPK8YZa6Vz7PgE8U8d8FqlgQ0XJudbISvaYcdgUCkCVjrNxk7q007bRNtdT4a5HFMBkoBfgw2e3qAuTtFp34QXMbTnioBcpEWF+JIwGRKBXLcO5kMMhyLtgBdRWkhNE59HeauwQMRQ7inYIU5zh16KfMkHg7JCS/5q2mKoHxZag/RAEeQGjQN7U37/2i9DtQsdH9xH1IG2+gtOL+A4pOGTIYu0i9oZeNr6kZUYmMBYLagWDnw65o3Wo9ECrKd2WHJZ/se9O+k8OuNKkQUvDfPD6MV2vo7rswrPCscBMSS2J4KTb87uIY67dgoO4bTZyZ447wHx9JzCl2yqiZXvvw7lCvniVrcNnlq0cCvmQkLHciogyhVH9UbTMCFwQCZx+TvbRgFaeyySk/jOED+yuIUefKZ29c6hf9AazoRkNBw7WOS3DzbYIz1i/FKyjKDo61rcahSF5CpTXCUqISiAGRkAjAnPs3LcyoKlj7pKagzuvYImPAbOJSbPvr4uSKK8popkxWEeUHDMzdUy1Kn/K8uvQi3b+yVP9YET+uiegskbDzH9sTj00231hVAJTWtTnK+6Uq4YdKqrpSS+5fBKme9sB94/fkOJrh3kOdVe18j+ClUlnNo2grXau0x5EdkbbgTGdhCwAki/RzWTZXahDo4HpZm/4pqycCI/uiG+XFCVbGPaws6L/ddB4ALsCHXVubjHAXKTBeD6ZgOXCb1M1x/04ed75NvGeSGddAlwoacY445G9ROdlo8ZBtsU5bYis4sTCHx4jLkfVHTbZ3vw5RA+ZkGdMbraiv9PLizTbWPnTROjtucngITpxrIq2ywEXrAGUg446RMc0tNe3mhiTBx6JonPo7zV2CBiDGFvezzRgiAo7STaJ0QS8UWYZczVsV84pWoRGyqt0ApWkhDhlCFHlC9et0AriySAZrJpGI/E91+9vKHaLnalX045X9GTCpIkwtORxZnXAlLL0dz9cr8XTeeY+euha4JA6KuH0csGOsGcdcdtPeGy3IsW9BRu+S84012+TllHXwD2JrjJisAdTD2A4tV6iJFzHKlwHZk4tvlPfYXHI2VIvfPid+reRW9bxf82/ZHdPgjC5YF0wk/ebOAvPnp2wg9exFk4KeBGlWdfdaVhFhiSTTTriBrUB8n5oQcvH+psWM/rsvnm2ypX3ufKr9zgzyjJ/+7F2SeduU/HsfJ+UfcrMTXrQtVK8sGvHYJFnNsTFF7zxqTAm6I8L6dXjsd1qVRQaPmL8iu9Givk+JGYmSgKn2PndidhAn2TFmExcl040Vn8uFYwksbEQHZ3y84fAje+VWxc5IXuEsYaLC7YntaZE0I7uMy6og9UXEAvBlYX9Di2DEiLG8638yU/v2tQECz8vQaOdOpQ57q7Gt1TUoZHqo7fibDIf8xuImzwtakhUm1hOCitV6HjIjHXiXJKFQwUNnCukQHAb+EGF7ftGic710Yt1z+OKJy1YuXryVW+xI/m4S2Bykh7KgBWcG/V+nO+XE9kxRZktnMLvIqM4DycsoRnb6ut9mgChUqmFnYuhJFwdxGcOBXXpAgd20J1ifnS1+rw+DLOoC6cr0aGuPWOrsj6OCX4oqit6K64GIR43608CNWlEmMNK2bH67afIYFBeslfvmb9zrVaCPQKhznp2s8XMQA8jqlg71Len5y1LoIQWKiPUdnURJ/sDyASyO4sZuaRTsnoKWt/d1/gCRBL5JsxJWuvGwnPOYsJomRrXVBZdthNoOfzSd6UO/q1yvoLYn4PEIDowRgXZ74XXRxhewVfoQvJhZ2CfJhVni9tLJnUPT2h2TqsiA3Uh2RdDPo+NsGwuz7U5H1bZNNG90O8c/pmIVLBt3elRjvkPVUbbUQZGIB10gmmDZZSMlhETtzhw+IVHS+xMg+6lOvrfOt8YjIlrMY/YGK21G0oWbLVZiyDsR0M9/99jowJL9XNfvt1IFfEgcb+sci64HHz9PgVLt5yGUlTdkm8QW+u/yfcAa+fw9b43+op24HlZ5sKQ77tCP01w8u0wc/08hH1tvg5dDcxjbom2pU7EVyJGJTQwYkvf6yM524hXbLOLZyLct4r2HZI0tvbgu6GDW8KfTwmweMK//2f2qzv77RhyOWil7X8Du/bEo1l+vwBn6oScwlySpN8WJHioqW11xAOoXlnqfSri52VJjs342KSKdrRcXTSjSJ9PNkBg8ArVbVHjQnBxqKWq7SLimak1cElD1WKK6fEqKJaGB8JIa08M+TLztAhV9HlmEUCN+wjOlePEOTv03rU3uMYSYuTn4wK7y+LPEL1gFlUajhLkuo3kHlAyqwNxPx0lSiCpJZHMz2yt3TyTXh26AQv+iPV11SsXR+FHabi7cGKCAO6222GwdJdkhJysBEcpN0b39kzxrC3lR8eJlIUBa7It7gn7ZsEA4VOg+iRTg2dqK38zkpp0GU4MMjcLBUPEupRgcRW/nRgKnumyzP8V40SN+wv5LDH2vIx6ucAxWBEFfCnFDCgJhOwD7KQ+efNiPVSXfDoGURnRqoT/jDhFUJm5vbt3ZDeLK4Iy3Ps0v33Gzh9h//cqaLJCYUWAFTMy8LZVC6OOjBaMBAR3fFfbceyf++WExeYdBRKJpny7ZnZa7UGZvDOdwqvlguNrWFAgjPGXCBLD1XhGsqMSs1UpIh3HW92tvMUuwBytvWgqN8MJxEL/8G3ItBq11Lxdot6LJ/lWyXEaYHjAYp9qtuNGWjCUeHnLvXlE/Lxza5NR7x56uyKgdiNZU/+GUfpU4yIp2oX62G2pcXDvfij3vY+ZzAtlXBgLvsN7C9i+vWfNjzCW327Wz9lSZ4fP0TY3giyRXb3aKiKQPdL3HzOH4E1BtWacyIYa8QmiYqnxjdt8DiM3qsPJpJAGdsllkDKJ9yT0w/talSwRgGAYDaw86mmBvJ+YwMlNhmaWS/pOlvqgqCED3tWW7UxX0odFLTI5/kC4ep9+TDB8rHluubBhujjV4CN16Jo6bI3ajpR9YqoJlFv9IGXjfjJXnn0lnT15uLCnDmO//XD9hccBGO7NS8UkErDdSuuNuDQK1cC1gO0c0f++vv1i/KxevpVaEuxcb/+ewxP1vsj14JHLSPKFcksqnlLcAxXLs6mQkcVjtpr1XDT0z+eMkVbV6RrpYp4DMYBk5jdrrT2KJ9KHLq8micm8pHQAUTbY617PEVjq8DHNi59NkCVeRTZyU88TXd0MN0/QlJsPi4u023hA1DLgGRMWI3jwXli2WWeZh9UghOUxuoQpfEteJ1O67qJorHdTF51HiTpTaW9CESaPph9lJD/X2gNPjwR/HEtLuN+L2rFxBmEF/45ABMvsXSdPO/wUuRFdsU0yK9goBGk6jtSq6VhwNt0pDqKPpAn6OqdoyYr0eI9VnswiN64v3WMDHkmNXXzwAK+ns6to1MXJ59+5EpaaHJqFu72UGLzVEee6SIxB3OY8zo3YpvrFpwCQ9gYdkc09R27QCTfn6Vd4fWQKQdh7z6Vii8MXYcJzOUJtKmZTgRFROFfcbvNxOvBDTR3F+ORJgOaSoAA4mjFRKypqfXKwAWeEz2L0aE/AAAAAAAAAhVduYC/67UqWhaHRqKGlt835gy2wxx13tT6/m6OjmJOiQFuCGNk/U7LQVfKT0/R3JeVVHl8qbklKi5e5U7zxLah1WHbhSJaP3vVzdvJoIdadsBTxzE+VEnqGUkbfOIL6ZWa5sWJhD4vuyMIYPVoEnxl3WIUXeJNM9wmNwNbMAV6BSWJhd7OQ6FoX/4k8UD/Qs5kfeBql4koMFjb/WOEH47taKPW4+s1dc/c1ZE/4ZdIFIPNd3X9Ezkn3pPJQmgNoMvK3LqaoRaq0K2JoX9qJHcHoIad1xS3LgaS6vXR/joWOiayZ+GTlsizbV32WWT3uSFqhPAxXgejgH6tA+CiU5d8CniXU+j7McpD9Pj0L705n4Mknc8gXsURAi7u4OLJ+ccRGHm3gY6cuggVu21qC4ucnGCE44zN1wa0S/3AHPzNIjXzOf6zAOM4EW6AmeRn94XfoAT1WlRzaerT5gTA8Ngzqbmanzkq/tEfFzkAi2aPa+eD6MG3EQOYKmBG4yvvdZ5I+hUCHlWs82ya4WfJnLCP07SV4D3qcfzJbQswE0wmx3IlBshBmA2eVyLW2NaF3tubWpMhGaVekQzAr9zHNxXNGi0j+vT9YU/LXUWDxT6GwJc6ganvjp/QdRcFL00bkT/GeAAcYKb/AoLhBYNY+jf01ID4IizS7lvvlGdqVIoAGZHbYN7fHsrPLQ3IXkiJXLB9GD6xdfeFP0gh3q6TV95VefEWFnFkj0oEwVKOapyeALHU4ojoBszZzKSYsMz73riqRJ/aeDrJG/bzqYr/1CZy1odiNVNENt6XJYln1x0FtcDpM4TyJb3ZUo+298aYXjWmwXxLMEsgMa0p75KW6XNnoQ39eDiS7q5gu4J4ZqXkT42MONQLIK+dZ00lEdgA1bPtSQamO9Qt3i31e4A6WhCqwvjGic5+xR8lmOsIhjz1LLF7IwK+TssJsfZYoOblP0qFAARfJcsKpabvhLmRXkwDSglO+KiZAhysAHmcs9sWMzrCCqhWZVDexz9hS1mk3GkUv53G5DEi//jkvxCgNYygUb0Picib7vos9vZubHDtA6JnqdEfjhzsAmG5sfv5TATxwjWUxLLjcXrWhoqmO3x4unlUi5UNc8PiYDoMwdUDNgGKKRx4C1/mMJVrIIUHGfpA0mDiaeZxeAI4djemPnsffE17uT/b9qdROHr3dAxb46OAIIUtkEwynHTLXHFvv8NCmkVwipLgzT0ktQYH5RQIA+YYdsEJad+115hc/vNcDi6vHxLB6yLaDkw5KM/DUgo7JPlMwcvlL/Wa/cBhHgwaSCbmWUUpLJoCOgnOHJZMT913FVZr8LhkAyKsuQl4twUyi4zxFAGhi4u1biRjOGpg4yV0QgTc7ihSyvh4x0yBNON9TBl8URMiJOgJX+Gcs0ER4ILmwZSqxHL5jCuj9IdDMf4bW2KwegjGYOSuq0nMsLvVHthwUpL9rYpQab+68BTa+BTCRw+YAcvGAtg/hCDCFUqEr9bELr0P+u+9u7iHO9U9TxrNZELzDVrmJ53vGvznLkejjwtqmmlyoB57KfaI5PR9RAJfLQDScY72aHzEJOzAiIFAB2cT/8q6IDxBRqVIh9/Ilpzqx3/7LaeLB5xmhM6V7wP6biKIQnQZJ8gNPSRcUuqfe5/nVJDvJIs4pbW50yrr13gL+2MXu1BpQszIQEAhI9mJiS+RFpc1QW7EH7++0Vw2pqwW+2GqGY1xh5yfn1S79Eil1BasrkakGJI+yj+Xqvz3YF13V2DJKvLB68GUyT7c/ddxVWa85MDffhO/fJsbbM9+ZfMgSzddfHvd3NfBC4ZAMir8zKXeVMxvP+SweErkw0mPLY8nTJ3GorlXoupurdHVr8c9f9NRmt9Xzou9Ue2HEf7j8EaM4XUbdm1n56+bcbpIv6mDc6f5QKUAiKYw1b19jueyyW3UMjGdQljaQb/ZGCNjaf8zeHoCPRu8LOYRPdDdv7Tw9sv49wcqimd1TGxu3aeEXcRTcnYXdPweudlRfSSYfwtg1qNA1C1wS8yzFdGM00xcW8y4jLwJFRaXBCIBr4RB3Uyt5aqtzxQ6XmVcczR5E7SrFedYEekqs0MolsTpzhpDWbIqX/vxt19xUE33n4ChEoGpDRz5WSffPLtkD/xmG5n/8mIo6T0apjK4QLWrkdIDXWhYLWLfNpeO/Q0+zWKZhRn3q3EszsYpObT/YipN9VUvpv398FxrrjBzJd3cY9cpGq/9TCP3eK/1Cx4T9R7CdtP9L4n225YB1pIdVYY3lA9AmB0VaRs42vuNusoiA+KwN3RFSeGW2fQVoLCvBN0YThsKruQDANiDkAw1m2ndIgsMn3NGJkX7s4UEMbrIXDOxOmAAPiDwiNmxJb0erdioDpXyABTupLKrKDAE/xZ0f91m7FQ4c2it7Q//eZDlmjJCqOzuM+1XWieM/yp3DWQo7k0s/h0jJZ6kem8tH8X6nmOkZvu5dCo1EuMQ52FnMiWgxZLDqMfcKrF4TspQeGPhSAtdf7O0kCYeJuZokitvJCUs3UmhmfC1yXlEWyKdtyl4hsTvfPOKMAOk3YmcBrVPOag55Kbj2ybSBtJcb8FRdLBHXcLM6VWIOlooemYNAOzfY8qw7FsfuqLKey4K2n9s3jREgQMxIRBawd1DaAwpKFb1yqrEbOmo51tP/bSdL7ZtEoIj1Ut1TdsjwBmW/0C/MUCCazeNNE/ZpncAy5U0fc2lF4dO74cReB8SBQANHIPaJcg+GcmHDL2KeZS5pZEI6faXQ5+mTU0M5qIDXJ3ILrB4gPNCS2Nwx08o4V6FmdIZ/QXrMwNOROflxUtogb/S7zbzmrhahudLHwnUs+x7AggIu9m4J2asCksjt5UdDVBpWFGydZ6oWbX6lEAlS9boWXl4fKXjnjoCRtL0/J9hDJmi28bmPQxkjDgIjnoOk9qzAeES5MOe5kkJeYndtfyPsz5uX7vMz27Atrc6ZV167wGEw38bLwsP/3P5/TpFbjlLqEKgV4JujRCOyYaScN18QKE+b1xgtMRPor2eKIv+Cdv2jNw9mDVJeOKAUJn6tEIo4rZ4EJ25Yq12cfuJrZGa94McL0sfrna7mMIwf9crPebAtIYEynTV/IX9wDBXO1geONj7kWXwlvrtTt/JTbJHska9RGuMM9ffSfh2hTmqQqsXceKUqXE8m00rusTvbCXhH7dTaHOfkrQf891bRvqU8oCyYH8+oJCju+JT7syXqtBI3uqzZmLtHDQ+ykn11GZiJYFESxadVuqBoWDNwD6SQEeEGdG1eKpGjayjNBauhHRgo9MCaDdzHQWodLsTQ27Nre8KKK9AEw+fw2wfaJEeH/S2yfiSeeaOJGjxlgSSW5nRLQbYggESYPeFyV0V2+xXLKvW231XdcE946HfckWhpJnLw4/1c7bxJ4XJcfT8YdzdJXhWv5aOQSKT6fKUGWAMQ7ORU9/+hIn0L3ktMc1UD4jaAurRCmsk+xh43MvBE+i9/tTkUwFFZ621NEX4jF6j0zfxVzIIq8DPTDaR0rU5Fyn2qyoCAWG76rbcdDWK7vhEVvFno4abg3FK3CB0LmLF6fS+dLRpxjsxuDPiZBCiBiD5x4XyunXSbqngzU3OJ3imcOcJ06T2gJhQ/jh9ZvQH/kRxu0CGdvaQ9i2LuUNM+o1gbVf8eEfpICicepJEGqZGRf7quihEPzQcMHsxfoCqYO68uZiKWi3M+6JnacFfu7FPCVa9FPo/n45RcpZXokCmt1uAG821J1acNAp0nn6ROsaLkCH5OmYXKvLAhlRY70JJnimkQ5e+svbO6Cb2Rcwll9zXYmeEBuuRjKKTXtxPGHg6MlnP5/+igMbt5msnnXTZPTIj9F9azyoVl6VU4+zOUD0K6c5/k51mevK1Fb6JZWsp6BabkAlpo0Snio5hrZKSB3YeJZct4cSoDxXJvkQr3sxj8lYhUZ5kja5/2s9EMyJ13sIoFpHUlwmn0BYUKDxt7OxGik3XOHie+N0YIHe8PHmG/U0ga2LUoUYjLHwOK0ZF2tRYVyiUV87U8uBX+rTttieKUTnDOwFzRN7Qh3GWGs6JkRm3gg8W2VgJjvapnJoSwG7vth3z5LLDG9grj5KxfwX8ONkMYlQGGRA6QIv96ptZYAmGVB+HunE8fgSeTrewIrK+VoI4INckcIQY/P+QiDrgL9cg1GxwRa9dH+sQuJ46DMiFHleBn9ULUzzcpfE5t3dY+Nkp9QVo0Z5s/lihuwVP+6A5yl26OLgIM5fr/ztUX+SOsQHBQMOHpaPbiITZIhuUJ3F7nyxHMNbJSQO7DxLLlxKCYBwws0cZbP/BgAesv/EivT9P2o9RW1p3fuQbZY5B+fZkdS4CXfwpFXADITVD+SFONWhctcVzVtSG8guUCG0NxOPT1Ty8HgRkEAmtGeF0KIIA4Kf3CGk1ODqZ6VnUd6QToHagg672V3g+pfJNzH3C1fhMpKK27O+OGPLI8Y/hIE9V4qtC1zIK9MbVjbusmKvVPId4cSsmjfa8jaYXSBW8GSVEGvGnEaG4Zenp+FzUChw6AtmJg4QQ10RZQ7dMRLknzIZ60b0RJHKqOprGnFLJeYLlNTo0z3V8dPnuFdeKV33cEDacgG9MUd/qCs0g+2xRxdRoayx23TQBa6diCLtGLhOISp8Z5zF3AWhSAeossQY7luKRzqOYkVufKFGbcke9Fci6w0Bdavf3f1WDwNC9htnevQjMjtjACdHN0kFdFxIy05CNtD0MPvRK39dizLjEFLHx8YrBgn2BFH6T66Q17o2A1qq547acm+stWVMKx77/G3EObhv87gThHdrmC8ZWzHtfOaQF4lbIb8GwwIOy7kFqJlHodgblFzzEWy1IZYqiHSTTB3oduXeSO/qOzb0i8rdlWJm3LO5xflTkaKMlm6ZPexhQqFNtYpOiQAiVi60ChMcEEysna9sM1OTgQyI7+bZD7rqv88Yv+Ou9fVuAk5+kQ2wGFQSxjGh7o7skULQ/Y0S4m5xpSvtJM1PzJ4ReP2OmTpmGItQ7a3sspqEaEXAn1m8qkXxvUjftkUMhAXsstZqOeRq/oKDDrLUraXr2Wc86Ff3MTSoYasvjGLf+3jVliKGGEy0SR5EAc6PJk7u1BuXEp/f8kgGU6o+lELuRrduOeHaT9gMlHzuvBfOvp0r3tq5jELHd+ISjHr0mf3X7XfQrlJ8c3Jd/9JkI1H0eIVXd2mWeuw7B+ZAgMJrPKxDfE9XZBc5AO9IlaJp6Nk13PiMuFBhCxk1LoKKYeenzqDZ93Vn6HL7BHRDp3gIeCva2jpzhWG5gexmwr90HZ2NMdPPLx7UWd/9yxmxfUkZVhbQIyQg7pLB4t6A+n3qOfqCpcMpBT4aP85yndusIrCko5Rav6utJsAn7XjvT50uFGXDzPc0DW3k4qOI+gS2njbmPWl9wPXCrQaCC/HYlAEmr9lkCoNCfknbj6JVuf1XQCslOG9L6C410Q2EuwrrlvxpuCEyjEwDzPu2/XyRqsMtD64yUaQws27SGXHQoT9Kx06ygRUijPQLUmRsxqz/YCR0c79bybfHysF9RtGtICbn9aoxbvkiyenqqzEAyq5gR8H2HqJNTyNoFMLNyY02LmE3Mb+GpOT/L+VGhXCB7HAdPVuXRTsHjm/JWqaQ+4vLGir4ibkwH0lMA6wzkWa/yaZWItn1yHRaXO1XNpaF2aFiZKp27xh/rouLdLnQuWu4yPPOh15Ezp8Y9VKKYGahxerw1BGcc7ejBHcpSE+RahkXfXa9apaTZAUlh8RXJGAldIsXKIEKmkU51gx690+Lj4/EgKq56aJVPEne8yMu8tIUFYyPWHrFkGALgE1LoPUu4EJHxTSCfYrczYWB+gC5rRxfwMQj9cmgKAatf2CFdFlb1yQAEscFTIUiU1P3KwHUyaJqGXgiYCHWeEy7t4o6e4usDR3ibkHwMlFnViJ8Z49gST9xJNK6NI0quoI6GbYlW8Cb8l2fgrAmnuTVuCp+fMadHcjMA7qsXH+wEWhEhhq/7moo+21YEV81+HjWMzmhIaicFEoSbpyuoNlav9pCTkADvsY7ncGQ5ce9r4BU76itvVRvZwp2+F5YNJIwI9d56W7dHAE8+dmSTMCsk+IRGshr357AlsjrVrSuNIRxI1MElnxnxZ2z5gaHTMcm2ViUiUW5TNPHk0W9KMNH1lrkQhXY5jisyrjtq6WEJqz8kk0LB2XPnrA+9qyp8QQVuFEnAXDzyx4LWqD4O0hH8qt5cyMg5pZUFHGeKMHJj27YWHjLtncLqWtJvbiosokDWx0LqeHpFZsx1xVnYWnQqjJ2qUrdfmziA2uzRQ2Z0AYm6Tk6dwsQO52grVczEujQmRDDvLfeHfpBnMQycXLt2ZznjaCs9uj0RVErJAZPy+8nXVmoObrgDBFaeV284TpdFa2AMY0y6JUyxk0o4fXlsvGgAAAAAAAACt7gdXXW9wZKLn7dpjdsng2bdwzQBuJ9/aveu7RO8B3eYJB1WJJ95kQqiCtq4zRZAvTHAi0hqEwXzpqtZKD4nsUmy8Pe3wr4PgQSDn5qTKZbe203q5S7Yk+bMj7wzRdYxUJisoB9QiPUwrHQdZfaGXja+F2vosxCpOUrIkPsXCJZQVU8hfbqF/GWEoxj8gNflvaUTmYilotRAanJXR00RC8dmJKtwnSHF/7IYwWi8mFcSHR9RuGus4cdSPHdLUM+dkY6TyQcZLYVFnJ5fTDNbDXHD1gdIoUl6EMxXFFdTNBSXH/QnnROuGonZENVcB1aSsIOBFpDUJgab2+8UZBaIX+wCn+EuZnbhhqya8SRFXruHMCC0Us+XES79+ua1rlpkr4N9OHO0qUaPpFkG1ti3UY48UXep3IByHh4xoHHgb6i/N0ozAc9uLocBOmWiU0vwXXuZVmu7jMC8Sb2Tw/6llS2gXglnElcHZwoIY06uK+Iye1lo8QXQJ1sxv8kqSbwqMltw7N3cCAsk//pWs4oO45RV9RQmrD0tEdacOvW12Eu5glG2sYiU6kBMPKulcee6Kmh9MrXWkMiSJCkdA+e/Hztwx2oAz+OVFu1HkCCbhF9dlUXeUr1bhSMFRm5nBVm8PVhDPfwsCIGm/RxkpjPe3vMdRF3AJvPyQevG4O4L4K8P/tKMHT76vOhu5B1adPhpa4RelONg/SaIudZdPACHfdJoPWGxzfoC3Y2Rm8prZcAlBY4P6GReRCsnEv1qJoH+wLEPO+dVqrIldLOlg+nDNmdnSKmR/kpFnEDqmB+wRFijD2NtGw1YrKIzE9lMiq/LID30aJ3jJ6T0dmE/3XqqQuKOjQ6UOZqbtIauE9exzcoMDHFXbexs74MDju2l+3s5CG/ZdGd7XlTgDMJLgeAaLC1tD8q/pWhNE+8U1Fhc8TODaXQvzP8H/9ufGsjqzie2BgKW72dQZs2vBTUipwWWMTJEq6jRFnFNz+wxUVfLb7vTsSiXK1NUCJARg3HkZqEIj389aagye++PBwDjePEq2pxPHIR48v+s+vy+sRqpAFmoaNmg330ej/SWKGlnoBVx63HtZtzMIxjsuUh9rTePTq2IEvQLHkVXG4eooG6kZuBrHVJwxdsDu2s4TGpd+WcdXMGD1scxrjgwdI7EcIp+1jrLpsuAfYytxz/NpPoK28DoZ5lJDuVtjB6SyiA66JHRVjEjgR2lNfB9PVHbyl+Z75Cfv5djePVMWElqBW7mAnjTJayTQX/17JuAS0MWeyS4rBucT6KYAd6stlCqi9pqjq3Wd/VUWbrggp0RV6lbyaCY13V0Uql3gSN2z12Z1H8Yg3GtxOKH0nywo71kyMBEAQO65XwL5LkKfLCLR+ozjkGDWyz9QBoGY+5dkjB3TWql8ILyB0lsuwD4XDGpssvpusyAM/eKThlF0NWj2qqfxkEXRD3zC8khM9pwSTyp0VYAwMiO7MmZEc3rBzqoCdogJ65fTZudBP92VuiIDtLBtBCxsl5Or2z5dXHNTPmGXYYRhicipA2dOORhQ3lWBSP4v28ohBFiXjk1GYDkN1bDF0dff8XUoy37butQV5ongqtL62gkGQroMVwU6YfAZzY978qdTikPkV9o3FCMv8GAtqTiLT0DuMhMS6xZNMfcUUQfF5+0eAvtosSBXZ801iv53cQxBiwRe7WdKj83UED4/DbyPl8pmDN5z9qd59cxkd1uO9nUsYoqNEAsuBZ8fdbrsjW+zMkrt9PCVkMECFKNA0XZqc4CMH3qCle7mpixvh8nFLB+305tT5J3lQU8uO9xWSLSZP8gzi961GFvJjBwYZSGBHMNfKgWZSgw7uxBk17f7AudMK8iGmN5sc3IK0ZJiRglhdqhJR3E9zuSLAyzZCg525hLyHAq8uCTEgnQOhfeQJ6W3/kKb+fzQ+9wf9ZaTKjFjZVItFVEji/QMhFt7ne+SqChu/P/z66Nwb9KfykkB7chq5chiDOEsYZmN2DJFTDhxaRXxoFiNe5LNxLLdDxZludwz+ntD6w36dPfxJ4eOHzE9MFMzYgeswbBWGhc24GQ2dmJFiNmpOaOGMzBRIM0PwbCAVJ5rHQGBBdGCNFQaSz6MXNLJ3uKnS19oHL5rpS1yaczOYN8GUsDFdiRQdHYNGOcwOUYZX+sbrJOQPubeFON5ZEuergCwKOt+PxYSKcYpO7I3wZWT02xecVk+gUv6Re0MvG2EFki94eMVY1kLYEo8GFbHCKoW7HIiRVjYWUQhji4smxmByCUBeo1dIcp6Lhm4Pkfd6SfbpGuOMiJU2zSNgIRHg+JQHOsgXOqTFkfwbJF6tfAeBXHsTsjrFB+VuhFpoJ5jvfvm9bNZo0mr3qUMBMZ5Pz8nwM+73P0iZ56BN7eRN6N7OVoeD4ynasHCVrHn96fMTLSm+XX6Hp8sBX12pdXislc6R32IrUvmC+x5ZTpYnnD026EUVTrL+KuMdCoai0LRLF4GiMpTRccqgGXDLpvfBw1Z4ow9TQuTXyx6eTKLtKu5IXwdrcfpzHAuMg6uGz06ALNGZeOGRs4Gjwf9z8hkHQzJ+ssFwTbbP2tq0tvsnBA2vqTYjjzGxj4jWD7J/32D9q/wF+MyErBS3Fz2Lu8Vt9kE3l2+/NeVwY1HIWp/qbdxNvnVJiyQG6cOZCH347C/FKLjfily6aPynSuDGFPcXoZE4AkxzlFnihiewMd508WKZKZGYmB0nnIisxLhF7R67ZmI40p56eUhcreDdXNg3oLH7qsn/D7FxkOBRvTF6S4+ZXARsiIApFcM3Dw8U8WzXlY8B8+anD3e+MiITkMwfNFB+RlCOmbVdHIzleFzk28Y1LP+CbBqSuCJuKa8U9gw/ycDchMVUOrexYxW0Svvlw6fmr5Sq+SUO87D5AGmyW30fY5dv0Nl8+bygJ5Cjlxkx65MY9GBBMw99ATYtZ9UAvmoKlRw3j7Ga03qRAp7VWNdYZH3IU5kkEFEeerneDjyS42XpgwzxqYBxSFzdUAyUWyqsTSMPke6DbAEgWB077ngpMe0jsShxAd7b8x3tVo+uAFcgxLdjcUXK25cWlZN9op8d/VQGnJfNttlVEu2YIG3Cfenz+scdZ52LtPTlb0ezhQQyk658F9luAHp56qZBe+ImhmmkE6nyjfC0wen0y35pQLvOjZGAMKClrEhrmui7GDQEmIbI5aX2LpojHDWjHTT00Ajk7Qfj1zUZKpwaCbJwokdjXlgfCXW4B6taZ1AM5le2BOl5dwuXpal1aqGhpTjGFq+Aiedx/YDYp8Ye8T3RGW1/qr0MoTXDhKp4QZnwZ9Zy1JWBpC/p6ssIdrivXS/6zm7ecriVqEB3YDHrxGJHiPKkUzRzYpef0c0X0NiK2tN6kQGJCAFV8zzZKlSUMBe6B3AVkDRc09xehDP2dw5K7x3PYtfYvdD4tf6tY29rRyb1z9ukUQFPq4qkBP/So80nGbQCfGg9vWWwP4uQwo+1oNKbkDRoq0EVKXzAQRiVJTWvWXon6hPHvO/dl5vuyS+WLr9QQuxJo2uiIoaYeeJgpRVnZVIjhTudWRG9gPdPKpLbvuZXaU9ERQAKMvnVftuVcsW46Cj/Q4CJSaLDvGXPOsgsV015xVWrtN1UGoa8GgdmLvjvlo6hRf4c8sBt8LdXux++23NaMSocPqAOe79LbBcihLWEje7ZNhXoJdsDlnp7JacZZ/1xwVKDyEPKkliPjgUvPNmp9+ofhmpv5YgGmVBFyPTbVDklh0LDRussNK8eQ2d5TOTLCNJvb80KPN8sUZ5JnomEdQjkntUPUqgI18tkE9Slxq0P2OP0nwyTd1xAi1xgC62MV1VuJJ5lsM6APQGBY2jPKK5hNnDawcvXktYhw0d0c+R0BoLxbrgJqc8twsEwJIClcAL8ZyOBU0pSKXNE5MuEfonde0bNMZ+GUd3xTsC2Ko80THfH92tH45qJIArlX0am5763kFHqWZF6jdAfPM2e3vDRCg0cyYIXfDqbU/QIDTRDJPl0FaDjnb2MZlxAq0VBF33zDkfTDPMk81rxe5BDUarkfHdvYjdGd17qIW6DF3muLo17O7DcGgpaedgA0aS5b+LWiVG23AOVXfeZYEwl1W0w8efTxSL192nvHLDOoVuNLjB9FJp80LobszCTS7SHau/T9SzZ27z58DQ7XJUt525xBbE9nGRBa4zTABf9guROHX1H5NRuhjCHceNvvZosJaVlHH3jREgXR2SNZPQX3CziAM5RqDCI+mgh4lxUI78Mr/R0nUUNGPjXuMyqgIigUt3K344vWT0DKwPso0weaRSf4PAUsskrrSCjqJfECYnILlgmzqcSHiPfb5IHbaA7g/mGfSw46X73dHUV1JZlNc5KepvOcZA2INKSWfD3EyIB0jElxhMYI6H5j4D/mPDJAxBbSP3k3AZdAe5a29LCFYzuB/cdc5z3LC7CTUcCBWIoXEVNcGJO3Tqy+mbjXojBWdAgrSpejUjSyvOLo41CpANiR1+1xQvNExAszaHZGzbXgtYKQB9F/N1vs/rgV0IGd6nuJiFRt8ufPN8kbxPiFuG9kju0hJONA1bUpTPWsVet5NFfhQ55ifrvRtduOemMDJpu2xyjeoIinHqkNW7TN9slC/+BB2q+DsYjBZDMj2vBeFQQAX+QosVW9Y+mCcIqtRplkbEkaA+oajem6/LETpwMbX/YMUiWIx/z0PGF+mTSRpLIe/naxz7TH89xeZDGZRpLjZeFSs628xVif/ZypcqFV7skwd9RPrh/ZVDmhCrgsMo/48OktdIa7sHN1c8fWLtPNAyAc2P8X/rS+W99Mhjxixg7Vh6z2ElWZAkWdJaLRSpP3830HcZwvA6k1O328PTt9DBjVHw+o8aIXL0v15MLuZf+WLOQwEl4CJa0HRiyqt8tFp3lByWIC62pJKGtdy5BX92x1vijmIm6D1d36OK/AvugbonKia96k/5oHNrXBbmuUK1S1MqKZuDoCKsXnqIxlwf2CyrclDIGembA0f2MTOWce3NS2cJ1gfKOUdOsfMJmMoFSwi+4hoPPoM8mrT7zEtkSa6gShu35QldsI5vsqxEn1cl/V67PQ7R1bz+Qcfc5VS54CgrchlchphWdDKv/0eZmDz7T6iTm7gL1Q2HTR07dAryneLWY1JHzhq0nyVn817VE77R1iNcwUrzNx4RFHwyzUleRontm8hXfP6Mbg/TO0xMeETo1trC9XJY3faXqT3L0Shtb2F+vvwVljLotq63BkpR3v5FBXbfMs0iqznI70YoryFUhuzve8XlHRHPCHBMthVSCAIocFInFH636jme5h7lw0fvKXjqlJJoh78ZaCij4TKWLO411r1W52XSIlTO/JmX6iDsKMmdooZMrmx3QdkVIWW1oF7wBvgdEsOl2nNkWO7QbmUqTi52syB48KgJeuTd7j65QJUCiw59XW05HRcW9FeL7PbaGwRcjXW/v5XmUspXQuo7lEkhe3I59bbGyjQQViF8wRGSUoIGRjkvvh0U6FYyjuFVnmYY0JYX3HGpouyXHUGiUOVyDffwGY/LBk+Ju8/qvAVx3oO/Uqs1LOhkHctdpfTUx66ffxJAjNtZcU1kMzExqmq5mZxtR1aAJWH9PqdQ8FY4ZPfFZYIpVlJAJ58l7yQ8GJb8Erjgv7G/I5T9oZBPIBwB6tZfYQIDIBX/XoABNxdp5peaaeayfaE3TmXFbCtk+0JunMuK2FbJ9oTNMxXppyAA96x7F6PSqAAAAAAAAAWaOlb1Xe8Axva+pShTNZxd6vsGBRwbLE5waF813vUdlLMZ/57pKb80lSQtRpkG9SLBo3BkQcEkI7TkA87Q9IYdmMq2P/LmXftJJruHhjpfO35eEtJbKCRZzbExRe9AwZSLR614IHKCfmgEWpbVl0Vnrj8P7/aEoObZJB7IXPQwR3b2hBopO9PzL8vkg68f1rZ42sLun0NW0I36QvzsCJtwSb1wfixf5NAJ0lv/WNHHbmsx83Sr3IUrELMTKMqIPn3GAxmvYl8z3SnVPsT2ujD+dnBv2djbUHAXHywaTgCBoVpdfFRTJx3olnvgpIdXMqfLXA6vZlNTNDEmycZXhhpKnmfutzxVjk7jfB3XehfJDsu7RSn7LRu1xRfKorap7mG6JEV6TAw7XAMpso7alp60zLRDP1rU0ezxDxlJSBKWAZgtBv2FyqpqSOGhC6BMAZNBKy9boEwLSGbpUhWE9wF5qClmIVcX1c47MqAeetzKvapyUQ7+hy8NdfLrG6LteNXUkybwfrus6mh3SvZIzIuOAPWYOUXtXO9Jxkd20ixDa2CwMi4iOCXsumzABCXUN6TN5mDitcCjDPWIhgD8BXqbb43gi3MFjrFsYCkv/58F5uhyvoxf8gf6csDYwjL/w4cCyM92fJ1krkEvWw5Pw+EnV5g+kEIaQCCLFQXg77fW6vVx782xlY0nPTnVJJQP57B26DHWBeiCyOyTnv/83bfGGN96WHoYO4Z2NIRFpcwiDp0zQf5yx/1llGxyuFk/Uuwj427akrvdavKFI3jaKdcOhjRnL+HTbWEQWMMdmsyRVmpNlEwBj/o+ayY31/66MKS76RoDrQoEnoobCVj+PPUYnx39vwhd8yv3oBn9kA6sFmGMOjciCRDOV2ZJOLxY4LPy5ZOeXE+oedPVY9h3KlS6+PP9WLQBGrd7x9AAQIN0XQKhsIKeTi0Efm+WHP9eZV18wU3Y9Q6Tn5mfg/oi2WiJm9Jp1Xig4uIYtRTrVJHRYpGUKeS2zaRrX9BmUot0Yz10XKGhBnWTHGb3omzpCHuodQiJHa4xeqLDMH2Xbal9MI1DL5BH3bJGrF7CFVVfLJzPC9Bf8szAGWh2UKiLs7oCAdqXeBFIOqVB1/5sYbC5c+CsXheiOcLAQG1QLZugqRKJVrC+UJor1eAx7KsxrAQSK5HLuu+QVju51+HFd3NW2wKNlHxHCRafPhqwsEC9aOnYY9cQx16Tr5EZOHzr7UA+oAxSIaGrJos6gVzT1cq4VreBpQQJLXAFL2Uax+4GtNHxkyNImUaUPqUDSxRHX8KJC3T/5RECeZ15hZ9kML0osuSOg/pEZo2i7QNJbQVB1TtWra1Z1JQQnHrghy0Ba1Z2TEoFSuffaXmSnROmHv3Y/Y3KFu4NPctH8aOfOFhM5P2EhiZQPGmyR72gQRyZ6Ui+AokOwNFSu5Wf+DOhoEuFEqqpYgtftHbs3pwCRWqfOrclzzdYWHjvK53FMI2++UpYI2aqRqJM4uyvx68hDftgx3bCtAamQ6bPf+spExvPzGS5zL9IOgqq2WQpeDqGQsin7Z6yUXFOKemxNb1FvO1nky6tZo1jRGVDMJejV/eRO+QG95jfv5YnXCS173rMuD3QH7WQTEl+EG4niql04KVJA6pfXcK03txP/Mp/l6qbzScUYcjyh/XErZ458jPKefJtOzkAWEKv+m4jIfErEmrdfqc7IAH/xnzoF3Xa2OYer2mYlSYQg57GRhQ7o5Y/2Dib+NIn45z3V2bezebFYjIwpfdyeWSxMiONIcaRoPbmlFyzewAA31sgTkWd0EPsQwIIfI2ZTVDAoBl4oUPcsO16N7J8C11YY+QaqWJHMvb3TWetGVmLLBkaV/IFaB3ytNggEGafCItJiOha4kgRbj5W3Z7DQM9DoO5syoFwWhMTvj/SJeWBOMKxpgf7sDCwwSN/JP7O+KWHFC7JhLAn6lE5XekK85bYnfNiT+EpUlGl5p5SM3suC8mGDvaXJAEL+s2ZRJX9MoAloes95kiK6zo/zZcQCsPg8aixwoXrpjdOc5+cpYdnPD9CqIaR6Dg9SV0nlcNKpcSumJ8HitkPHXujrAYw/0cs2No+sDHpF2piRhhqL/437ex3XeaqqVG/f9ItACi7bYFUmTA54CJyJFNcPG8n66kzLwxXmc8TP/0CspJYdvVMsP/e4/le9UCYuUA6zzj52al3YiqnxkBGIvUUswmkfHa2J3zYk/hKVJP+WKU3L6xNCHEX6BDY5Pn5TBxEPqa7MYfUYMRIV/P1ycK5AEcPKnQFF1ipF3DmfLAOgUxhxWV7gtCYnd17h7xOh1y43RfAp6KJ+FS32OVh57hlcVUIwVHX4dRLLSoFk6/uXzMDJwUuuegvhX/mLnY2zH1Qc+WlvYj2PWgnENb11gpLtwwmOWDxpCxc6rhL/SbWEiECVOKFsnGcW/pwwQkqq6ACTU8Asy87fxftgx3bC+9hPJUrohw+xPBx6qgmx0AwI5t0euhThsM0j5FrT/uKmejaL+mF8Zo6PA1bWhDJb/e8kOly+WDwHrqtu+aHN2RheaMhjcSiL7UnaSuL6QAczxwRTihcZWa7oYvBJ+Vz5pKcX2wyb1tRgcJWHZAZKcEHgUy14sZSrE3oiFuqJCZGwA9dQ2AE/wF/G9nSftDTXU5leUaQjDIOfrgfR2w3cs9tLHxnyT8JBq2bsBnt31GRv7ECxUGGuhAbz5SBJ/yOhNPGUebccNVd0+vPLrom6ExMFXvB9TIWd2q02OqUMX/L3cZDYsID8L+b6rXAvAxcd4erkxCgsMxZ2iWbb0MpERNzA1cDFh4dV/TGLwZWdqXmy8ekHW9nO0s0D6mEVE7FnQQaz5h10+16dSF0ezOt45jluTn7MbKiKNH2mOISfgYJU1zAhVu5kXiI/T77SbCFrKr0OZi7+Bbn60imxdfJwRbFIdyWag6SB7/nL8/bfdqb9mspva80n82UCjrot+19RjpasBUPRJ4mLMtEAYkDm0KdizsU1O55ZLr6L0eeTQzJoJextpYkyceeG62hPqP05yng6tPEFFvRchudP8hQLT6otmON7b7LMlqwLCvA/rb0+0Fjf1/iTU5KwLVlrdVLruoEh4hbhqfliG6R/HGbr44olVGdbhgtrFKSNs+dAyIouFm7uNOa01PF2C3v8G5JL6wiwxJERB8gg1CJtTWmJylYS2zQ3+RY14ujj4lvMr+k936Ro9gMbBEQJ//VJm5kbbVRXo60ZLQQTX7QtznvIdaZTwKW1jpoWS4HQ018AWASWy6AAGq+3HOBdOxZpJtmmHDqNg5EAoOXjAaRLwH21vJxqL5Lba72x/BFipgt6HN/MtIK+MYOVWhcR1whH9uxXc+ibHBkHJLlXOgnRoL/zqEe97lJBfXwLd4ldsDQ8dnzGFvxYULiDaz8GxCh1odqJ5TLWpS5t/zRP6pyuSO50+wBmcU+XVLeY+t2l9ceEb+G6ChXMKKo6+uqbOlzbKR0+hTvhRnZCeBhOdU8pkzpB2hG2Kn62cO81gfyvBHIJbBhi2VVCIjGeLODFuoxvDvyvr1LAOGVUgvsZs4E7FnM2LhnPq1a3gaxywrVCR89GIPk5OKFcZUxgsv0ZdoVPeH8gmFozmz4NlpjJ9ecSUqEjWRvr0dhwJ4fdzXFdvS4IJIWivArbmZw/pVnq31T/HPYEiAYZI9/gd4UwUEspX5uV20NfYz1JIk4iXj4v/HR5+UDQAJ9M/kzGNBwyEeFSV1cC8+alQHnamPAdXREzICEEnoPOAME4elZ+tTsMVrJkktyKIPSACp0b/dStwj36Zvs3l+/DHTp1GLa0oBqAR1k6ljHafO3Chx95RnPK1pTeTnZooXPBHwSc6sZS5fBFhUSHxkPL3o/VWrpIz9K63FYSe9leCyVDfBJ4r5Lfi03rSmfpDO5cE7HuZ/KFw702Kl/8fDxykpLxdpP2MSRqesaHnKx+BjzQ9E7urqlY1k/4uqGf8M1ihZSNSEjGiVFPjZfBXXdHOxcpePXzBTyQ1kJasadHGmgb3dQluQVkBlTyE9I1dBVYIGDKjfp4ltAF4whtZpXL/R2DUZPdCHfu0alM5ZpRKF59jfQDmCS758nRP4ztWsnwgq7ZwXpywC1Gq6W9Dl4/6ugDC+spFeEJoVLnCNWkiWZwK3KyTtehAgyfXctWx0Gdl7i/b47rVRqr9BYxLbZ81cTwnn676DJWcu17pxyUlzN6iVoCbkg+3PIo64hpD76j+/MuSx/Pmh13JsjPYA2rhqV0m4cw1OodKWAZoPLQ0DOi0Zj39GcpQhvlO3JTK6XFuVHyhVrRccEQBhe+AkNnf+A1fdlWZs6lMOwWRSuF9Zwn03V0Chl+lVur7emh386v0WKOS1nQ6H9so4puDKykH8dY62pw0+Jl/gpwDABK1QtXJdrYzOhyobkTXjDm6xA4aJl/7Q8EclU4Phc12nmgypHGItIDkqN8p8jI19a3pEDYxg6bJmOFFF76CWUu8wLd7W/VChPrLyWDg94W/KV2M2Cq0fVmQJ5gEUuySJ31uT79/4tBIYJ1knYWKLBUTH4l6Q/LpgxKPYt/aGNiR+010EmGDS23p3dqtxxOj39z8cutnjwjqAQa7TFTS2eEbKf6EX/RUhZ7t+aTpatT8s6501Wo/Gg0cbpuZiUD33RagpOTIn3xQO+Lh/Bfs20f0ReHSJsk3QBe4Rw1d6F3kT+cw/SIlHmae9YCx/L4/F8NUtyvIBHeDVczsQlesg7KYgGK+r/IAM1C7G/+sdF78VUbNQa7swdd2UGgoUuUOWoYDR1Zoa29Wu0W8hhZWlyTUIxVSTk7pjAySlNuVEMM6/liqmSv0l8hrlASGU2sq4CcIkFzvQVgAXLvORzNczx5aoRS+zHoEetTcEppf8P9gyBh8AzSUgwcz/tcnOfx+zQ4etjyvKHJTc4MM4fvKfRdJoSiN0OM+Gwh3KNBLPJUtS4QgWF+gXB4NKmcm8P4MOk5JSgJ2HcPiyMsRZKS92S2trViB9Bn1EyUZKgYW9cjHgHkXxEjZWtBpFikFJd4slM3WyUyA0aFcCFiZ/NjU7t2n4z07rA3/wgtE531rqwbR+NqEP/A8tynsmj25X2mf4r/O09JrrDqf2T/ExoO1yjQBM7B4EeJBK7WsTczsGJFf2OjaTjPSw9p3ouOJY2i35Tvfu3LkxbaL3b9CLI7ITp9cwxaVndO9SMUzYhhR9gezw/aSgBQ1OwPDzDlcDfY/DOilqC/9Qf0+FO+P0PrQ3X18KdH4LKdXd2bwpfBzzof2svaH4KjQBeQMReFBbY8tKvJE3gC7IuzCkVIChDYuV1hPeJjo5na1AFfuYoWP/D86HnjJFbQf2xDBNKoJZ3MRshdHkR2k1mXJ9DBdrrT2KJ9KHLq8micm8pHQAUTbY617PEiVIv64v3WMDHkmNXXzwBixrSx12yNjtXR6mGqG6iDXi7rE0B8sAPz+H/f3BIFdoLM6/FYjUaph2/sb4BoKrnNIN45wL2VkDTFicj6muq0awWa8j0sSGMI9NGtCIWsdgAZc4rocBLICqZf3AYS0WUofCJ4b7oU32XC5LEfozoAg4pM4xhtZofYs0B9cYdf6Pj1lnXejg5iLCIQm6wDO9UAM9c/pfG8ObTNyosqommyg6vYACdjFhBhAAOx7zrygAAAAAAAAAD56IpG8vEET638S43Qf25WiodBH053HSIhmJrd9gr93GdD0487dwmivqtKJg4Sy6V8F4lBpyli0j5SUL+uwCZrxKkswew3bs7KouxUwLlj437e2Pm2wdcSfau9ukoZPzO5UNATtrVbXrowhlfsaysj8UNhD6A/hwwxgQSKLvX3MTOxqgzVijZNynifgPd6pIf6bhoHdBQZ7Ac9Z6/J9/Ou1v2VNCkuZfZVdTVIcY7SnPON+Ffgg2q3b+H51FKinHsylEeRS0nTDGpTkAYS6ndJXVmdBOfBW1vpAGZpCZ2FJe2DklyrnQTo0T7VMG9O5oybj5xfOiRKGMFqA5vI8sBl8r47fMNNOxHkjsUYTOyO4ssOIyj0LQHNhwjEFdT7ZQy2qczb37RXCsqr08uzWWzS+aGILko/AQvazAXYWoO+yqY1poVemdb2dBqvNjoSmVOXeTRtI40RDEB2YFdq8Gc/6mdPjNKbvibKbwtgViiQyYXfsXJc4x5B3UXgN9VHxjiIZtKwPHPVtI7EuoXpQRjBRnJK3s6DVd3Bkza4wpemL8VB4g1yhrpc3zqpGfC2MaSRAU98BmZmAvH8zSpq6cEKJG7urAt7elSiLLqxp8RvYp2CBzDESFXey3lcGzZCDLnV0pbhcDauCZaO1kcV104fid9RpkVG5geClVLI5irFhAhdhpZJaFx3WtlDS3aX554xSRnYC3EKasFAQgF4XMPlM35f5RkWRgLJq2GQG1C+Dz9la2RhLGyDZjEBvF9eRq+cHx1nI17NvPwnQFdKSStOG5EJF40ISbPW67Y4kiaA81rPc7V5sOKWV4vGw8IyWwDPxvX0hdGl/+yX/znntNYwN5vAPl7t7VJIm/LwwFnE5yp3FfXnX5FOzaxPPAiSxkYg0pf2/N5Z7Ful409JUT15UF4BhtecFVT5+ySJK6xnmrAa2uSujydiD7r4S7Bddb23qweX/SX8PJBwWcdC4xJWOvmCYlzS8zVDsC19XvEpG3uyctcvpusyBzTFvqJYgNyTk3Yurg/4xT7V2mzWpQYUhYNgTyQGvbiqU2UF6Yh4CBtlqqOuXpW4px0TMdwetIrAeOnaZoV8SlB4nMgHTFT9P6VJPAgYVy1GPZuwIrneIuf/WVVJG6KcBV4RJw4O7vVVQ+KS9kt1sfWDpdfCYIoZdiC1fJy0nEU9/PxQr0bWgKO5myLRIaYfi9EKbL17u6e8zvI9vsX1xC9ZZapdo9OZBW+iMHJey7sJXPf2La09EPuWYWpMD1TdMZUQasy/6Ng0afiHQ1RjsD/5Gp7ARazuBtCziokvchANFiaPjfA8WYwmgO4IMAPun7TUtbbS4FbkEWUXHnLMVU6f7m/Wr/7lak/QWRpFVBAlbcHDGn5tnAYRXPAdsL21LcEn/MGSpi7NehFWdRs83m6EW4fcPvI9vsX1xPRJFKeYzhX4cTK1pjkxtRpM1vdCsuoyIql+HkPNsM9nCMH6ienCyNCkcJYDQyDYgQI8OxitcNYoNRloZTlNEX4jF6k5Iq5femtN0ExpEzzyIvakBX45pXzQHshbCeRDHROdRBn3NW7uXGqysyrg1BL+jx9Va7M5J+sp/Mu674YIu/ueqzcMiVrfkXplEF+4pUwxVhpm3wpUoyXUMDodeA6ZMVBxQE39acAoBJBL3fAc5n9bMvAZtH3rztSd6e/5du5HDn2AuBqZQrf3t+sCloS1tDvsqcMBPtash183D+2z4cWC7Uu9rlPN+HIhtPtHaew1wMOwx1kMqOsT2bdYaiEZX1DiUQUMB1dC/jJ+8KZ2jkboBmESZKAFMBolqNDGjY5rSepav7T/q3szD6dukjiTek7n4V6CYRXOV+ULoEj+2y/7w45XqKGtlnt/1womDuwdltFwyksFHw9PXwhr40s+aMhGAyRA+LCe+iqXAgZag2PZhTRoBstee9AVB87SxJV3CxmcKXn0wAlVFvd1CkzwevxRqwmS2+b5M8x91gNxa2gzptFe5MQh6/OulkBN+8MYUwd8lG+16b5DVZE9FgbkpcTdgx6oPd33Jz9T/dEawv5YB+1QaJ99fO0De0BgyUXP27TG7ZPBeUen646J/JMh5ppy+N6NO4hE+aoYQgdaelqkKut7hHYvesRvSaiMZixeQxCz1T3GPGRJqnDb4CE1U3ySyWcnEIhW730xRKInJDXeyszqF8KQLqw1x5kW8ijuOcieO2L9Z2vpx2lwwjY7efo1iulaAx5DWopLJMG1mOhcQ4Nw+Kdw+kZcPwfc0GbEk0mmIfGJorsdjfkvv5kZrJL/nlnx3XP3Q+1D/dbEuYJP8lGnGw8UknqgUZuujb+zWWqQGApqEuPyr8iVNJD0iujf1/djdlTKd0HuOiKtvwgFekxFTG4sT0EY7FuED3+GroacCWUOwzSo0FhxTLrxrp8uikeGPFW4p+5ZpIj1kXpXEQodCBED3af+d5huCjcu69DjIygRpCZ1iKi05TDNoQEfLG896kwO+YV1ZkyliPfzCsFv/rAe4/TfZXrSJXmURZy0DSgP9GFCpZwNQzisG8bn+lLIdZrAoiWcLWylX5Oh1mr9C2nHheJwkNnwbCtVjjE2HjNODlUmtWNLllIe5uLlhqDc6v9/FDdTfvU2pbWzFo476rxNeYUqKJT1gWpTtPFjPoCZepiHI+al9SjQeNVcjHnXoeW78GV4ow4qeMDYX2VZ9dkJaXpJQTkLoWAgrERFoIl+avA0nkHWAqQ0gWF73UTG0/sV8hOdk05j/cCESBqf3LBlp2AhwSgvuwQm/c1J4RTkv2DXwl3geIb6cvX1MOR1jd9BB6fPpZXkdwCL2Vw5qAO+27Q3yA1p2PRkknDAlss25tLl8lyuO8+dVjXWBcyw83KtmAHq8rMqatxgJiLX9X4RmwK2uWC1VcegBqA7EJcp/hP7R1Rqn1DTcFekaXJisYEmJ9JEUnkZ00XmgNudu6AQ66FbPnF86JE8f58DiEn/yZ6aKyl8q+mGoxQreTEjkABDiaGDDcXAOjzk3ZHCcFhSFeqZky6yv1BuFwRkdFwRmMZ6ZqrUoOrZp0lYVPZhUfd+ImTYgKCrBsOsIVNuyokTZRm1yvPcYTs+Fx2gt0zXHkhNA+xAUAEIDfNT23NhhVVd+aB/LD8pvxQtrB44iJOs3mMvPZ1YkXCHamAhxpHg2AJqwbT7SQDeMrkOY2ADIQdGRPsLbFPKgvjRKsbpfgDR9PseOujpespCWDWu0drhxool2rBrF9vnyrlkiFCJgC+u04WO9PNca5/udC7c8lsqPzgbwHx9+SU8Zp8IT4g4ChaXwCsoo52toDNVDxhCM6bHXAhip7ZTfAiGthdbU+IkHxvBL5rtihprui8cZIiupQ3yZRUtreEYMYSpgdvi4a/UTKdgwvR9/cXjA3f4a0XRirCwBTj8ZkB3CPfK81c3pC9TVpFv0QN/YBviLnTTPAw9do7gWB+daTXXnP7EdMI9BCCLVYZYtzJWqg3B+WTTnDL/+3idI1hn2MEdKRpoDIvNPQY8id5hqoAqiuqAI01ia/Ii63Gbe/rfy+fhM0y4QD6+KOlNuBDDk4Gnn6oH06Tq561FivTzSpGyqNBRpuFUB2u/pX0+TCjR7F6pA9V54GjwDhgOsZIcllm6x7C9DZ1Gm94vDSJKhPBEgGxXl9ypgPHjeiiRLoIbMD5VE+917A/s4zypBc+1zVBmdgsbqHhXzvvnXOB8HSilkoKWsS9pJJOO23hm2ZqeNhLkA3HmYyYpqS8wRjLd6yEzmgs4Bymh4/jasTtUp62UTL5uRItZVe8IEJipYnz6PE2v+MPC3JF5sklXCCVOrUzaKK9nVOpv4TeF661QBHixfcIrHGN2CbihcYZhv/KIHsKRnGTKajw1ufWuO3l4eTnchRYY+/BImhAuFva87RD/UVYB3wCGNyNBR9gyc7FrPGH1MSEUzlUODneg+X/6x9goYrG3zUi5WtspI0fIRCMZNl+rdrdL+AxAEC4qs2CRVi0RqIoVRVlu75+7Kl+6wtMFLIRHhABwixDDhJn4KlNEIUeYLttozp4uQnsfCxITEjoUK6ZG57lUR/AjjbsNBJK8fyKhjV5t1A9+ftARPLtmzYp5XAiICaE/sTwfN3l+54jSxJR2uTdFL2HFQDRaJvJa4wFvSY+XN/G4/gjfiSZpWYzhXkluqTjy59Pd95QeCR9CE+5L3PgbuwN03roH5mugN93VBWFECTkHf6R30mXT8qCYA5EAdqO1sgrKt+HouiXVYjf0acmMQOwRkD8j0KilWZ2GLgAgWWr2ztMLfJGo0G71r2E3tB1/BfITxwUvfufMETqPeBhvCZimS4BTH1RRdXljF0VSFnUu9Kj+ul8fxCX2YoVj8D/ncTGAisULR7nEPigTbbruCIKVfHbWS+JQWncKZ03VHe1zMdy2JH4O39BK5i0xudQfFHPUlYIjac3i+cM7334BUB1ZVfds6aYo7tVyRgXYMPpCggRT+YokpjJrEuC+PiYVie6YcltbipnaLBYVZTnMkiQCW8CoFqRuiCgpg5GNx1EqxTKqCLjQP7z6NFCrPsgcm6YV6bJRlMRteY2aKZTCMUeRE1hwZUfXzyF0kERg3HBTJehQjq976emFqPY15Jmu9srlqpivbSXQ2K7PiJBvkxvu1rXXXmYEOVXrlkptppMgXwpCv/T2O6TsLGidDV92rM5tQpH2xiKtnuwQ0xXgSnDsdJv5qcDO4T6uUv0/QpIW5909u2/TgIZZkfatS7gTKxU0hMxkv469oO/VajyeC9NX17Vh+Rq+AJW0SJr9Ug0bzzV34bwujUJPNM3+LJAx4r85/0pTsGt7+YDXb84PpUmqxoVHi6+YXOuSdpG59JpIkcQZCIyCt6VjomKpv99ExMJMEO9Ya47MUxPwVCmoaCMAgGPoiw5ibyAMBXbzsUHB8mKgYycOjb/ImfiTAy1a9H39lHAG3tQF8K3iZZk9i8s5OASKVcoNDwBxNo1x8bi/AxI8oxhRvruZWq47cYTx/ER7eFSYazNU4qrXnKnlWbezrIt2E5I5AlFxyeo6QVAjc6YMs/rwDJAoY/W0p4f8v/UqzS8BJ7O5Fv6WZepUGjEAO04S5m5APbBvIsekaufJ0ddCrH1gaA8VbzhQS+dNg88AxtDdh8UFSvvzxcaYmN5HemvDSWskvP0nT6Xc+kBiR7aqaVOGLUIJktkjpeuCihXZ6XstY/7ux4IhaRdqkSDIL/8Ukd+kxVWy9HnimEwJjC28NIGYlEl6muEe2gR8RSFofvNzH81vCtyuyji+O76O+kIj407qzD/i122CRyW76XCZEzrXCXveZU4BHeVyG1Y/bFcwA3/2+ThUDcECrEObqt55/ppYO0bv0UgasK1mJY7+Cos+ofsEBKwgq3E55BWBriHQ+x33ONQ2HaWM2jeOt/0sIHFbv0S1EsHpX1Exj4/536AbxzEdRS2KenOGOZEyU9VEe9u5EtWy7vqHRDJ56/FWyqHgUc9hMbaXxWdRGPIqsUW6gFZj1gBzJ9aTInUiCbRgHCgLas1vEel+8iv1yk8M8/PdW1CsMnSsnB9c0qrWektDGMkUXi9vW5I0cULKelPNM9vZ7I8oxgmnPk6mOXLaj14PG5DbQ3OQU1nqURMDSQ4aeysY/AGwZfvVIYz9aQ+b9lR4wUlQ7z2jE4VA8LwDMJWsbKAk/27w4LqD9pEQPcA9yBe+Ei1c8f5UFVUN7sHoOHBkweUuvJqX0pYJRzEfELq3g7R1Uv0hwrDb1UrhBnhyfDLiKOUh3seR1c8GWtc37HeKzQzugK7+LcSh5wLJyWrhrKV44th3BfukYWYZcGik5Rv4Ke6Gi5aIr0w70NLWgU0PuDsk5Cxc4PoXtsE7d1Ehpv9CScZXoapqH8uAHkr+OxqNJqe1X2sEZBFXYH8Za2VnO6N8iKSsGOxFvE486srPmIdRPSkkEoxC+g6MQtTsps3+sU0/Q7y12mUdH74+BlEg5LT9MJ0Zrqrq3XGvB2whyF17kFuFI03ESmr798tBhEEYMn6/Cr8OWoce2rNgkNNsQAjan+I32SlNob4xLjWCjG1Zb02u+GdhrUYdED0EE3Np54OS38nhsc7qaBRlRTrblxxF6RqukBAr0NyYwgvSNmbOvnJme3/7UfjGpg/zMjLxledRD477MJvGfIsd2g3MpUnFztZvL3uwAQRNEK3+wUvc9zIiqmdzVhtYN1zt9O6e/bZQsx7GLEqKBLPvy84bACWmoN68DC+YujGVjTAeXDemBPYNmXaw/PIAAXXnM7SzoFYX06i2TggAAAAAAAAAj0dzmHyNzrSW9nCghjJYapSAi9ACMPXnvMHvVRJuEZs5VP+BIoY0BJ9UdLfnjtHB6l+XxgaehrFX+8mc0FUaFHY+NpAYRYbK9Rs83lERUuYgb+Zy7veIcj3/kaClCvkNR5tE4BPuaatyeO9Gpg4td+C/Y3+zTwkWjgDEsFlrWTNvUaYEfrQUciiBkbnQqXZtaOsJRZXjwcH2vPK7cQAiL1HM9RIZ5E7Vg1oZcSLuQxWrwOEQ1QaElqlFeDCN5LL1/2CovsneaVga0LFuka2dyGwuBbEwCzYe2VJMSmJL82KMz354xCgawvBFu/dJefSaXm7hyVpPct6KvIzZ0xiu0lixpJcoKEhMKO+iWBGfWcztvILyzOrFUvpQ3VQt6dhE03IpEDf63fRT5cTHAHFSxT4g4ChaXwCv2rGUdytRNNXFi+CDxpWpx+LFzy8kb9JHx5uevDcZmB6wW3atqCbz+La5ImYGYuSFCxxun+8x3zyF7HdmZvPiEYsw+WkIcieYEIS5VCpDziDwgBAZyTd/+RSrfNeygMUoIjNmDHvH21EmW/i/3BImEyoTCIevzE6iPnYztiv5oEzuf2TF0kzXsPch7W5dDg/nneuCXfy9y4YgltzvJIRZ8tZ8Ba5Cx2BqXuGKEGCHnqUiEg3uLe5GDttsGatOjB8dG0wi/fIWjhFanze3c9sgYuIG+Zbe/19kxY4GLa7z5eRc6UsZpHV83KZ+U6Qx0aUd5yJ5RO70StNhnTpYZ98eqvjudbnLO1Oka2YDdzQjXuWoj5Y3fA6m5tsMXyDpRzoAaifg2EC9EZIAnZcANKjvj9NwGdFoI/IuG42dAT8UyXiDtrqls8pkj52nNbEoLsWtuzbsjj6nzf6s/UH32wRX8XA0T3FwIGS8Uw1KYKFe8/dc4bEHxzUDpfYSLM1Y9xKdSfP+3b8IW9Tr8FZKueJEKDv8slbDoJfXhayPf2jAlPu2GcszPsf7VqVWzPG4MvgOXNhRHRRSNbOV7veLSMUUpaimBIVQ6omxw8ciUJaoSjyyNo7wBpYZnciKY768IvSqYCAiqGbUDubHrMHHE6dj7FP119be+spepDOS0WtM9UBscDok3tpZGA1r3o6ckv4W+Vi6lwwjX/BwaPh0LPpoxumhbOG2twFTnRS0Bymee8Iq/E74H1Pp62hRUrxijKGeo6hyB18G29hTfxI1mLu8owxTEUOwLihBNvMBnNjAyb85imil9N2XG3PMTdwJPLqkMAmefA+xJVrmrDeQknsadlwcXqOlhewp5xOH1wKKdNgrfGfY4ZRy+BYscWEJgnI7Scn7k5KKfdcwpVtvbTZq+usPH65VLyIsamQjH8m5sM62wU3GU9IIJxJGOZdUCtzEdRrApFbnTTzxMFlk9IbMMFJT3LuPIZ7/ecKuT0mDWzKUGHd2IMmvb/eno3PWuVdOHoHG48SGIpIH1H2c9IrNa03qQ9pAd7D9nCghjjlmfoFjpqOPom1aOJRtn2kBhFhsr1Gzzebl3fbjePFuDiIxv7cfV3szecx0yxyN7H5duhr+dE1HWSJ3T/o+sDImIl6ht8C8iuFQ+FhaN1qPRAtWENcrt+eeD+7WLuHTdZjDE6jKuJH+GEZEZrWitYhcfYYsph7MjE1W+AqjgByqMbF+A+CxVVEdD0q1L91wwlioXIdQ85uRvqovAekUo1BT96nz8rxWXH1FcLHMIDy8mu83GCtbwSxNwlraX+VXlK2lIZDRcfHy7wKcxLSF/VHWBTuMPDzsR+YCua84ru5q21/Y/vHMr+3q7toTa5pPC1v01TXv7TyP6pf80pOjDpVR5fQ6LmVpg1FtIH3QbafNqsZXj/gHxULrCJ+n8ge4LM3lr8E1LagHn9pBFDg5MlbEtg+MhFX82vM3aIc4Zv2pYxRUmtqDNvb7uwSk1/VSs7ZMTC+3Qa6awEDmIfvxW67OEsdokO12uElPDSYZNe8CHCsTkYsbZzjKspU07ljBuUHXREuBSkyYaTGFIRpIGo3wuvWi4pAI2DwZmGsXDLy74/XV67bgpBcszZTMUnhfcetptFj6pKykWDEzPjoVTv4+BfStLPCIYYGEkKYd4rvSSGt4LfqFRsPomZ7bneVrHWlP0cZJABtknPgEq3l0Xm5IGIgPkhuv6mWFPh95iHrMwRRiBALDm735CZzW5Luv8csKBjHiMnZjNXlDGTZYx3LKaJRjmBdZyAMECmhtPm6Q/GZ88h4aarrvQbLaDanGsapBmI93i60Ta+VGwwYDvUxxIkMemNDnDO12Uet/nA3eGYplLMoAdGYHX7UWJvfRB7wvCAOJW5uMcBcpL+o1WkAPXNRtP4Ixn5KhWyrornwJqHX8VZJ7odf5m/+QFKfSZXI+yEOkFO2z19KzqVT5rKeccROAPJNmiV7pug2jFTWXQRbHZOjS14SGQGdWeTDn3auts1OesTc2LWgYYRQN62uS0ijsb9/ATWHGj7x+GRvmm5STY6uGV0kV+TJxuIInQA54GS2rEuyhpjTCf38NhDQ+3dCKJQw+x8hVmbrli2bWW4YHsNUmvpSfeuyFj/iBVYX8dBRjCDDSVVDgQhbL0By6paOcjcxKJyu9IV5y2xFZxYmEPjtphNv/lT4TYOsagOkAR7VuCdw9ysaN3zYk/9ltqHOaJBMNUgF73R71fGkiI+gisLZw4qno+yolKfeW5v7/F9+YdzdJXhTsOjFzRmgStpqVpC/cquWX279CbmpO4P9m56GHyOnt+mYDlwm9TNcii7hwMKjTOY3+GLANTqFaEjAv/aENmG4uN1gKjbTTi2m0W/tb2FLORRuEnJFljvFqwzlndVDqM4x/jku1Akp0oxc0RPlrWHFT3hWwLOBbMoiBqMfeXXYysRXpo78Ns+IjenNCjpyWoB8Qn6V2CjAN04r/TMsQ+JneiyRbqYeCVLCG4QxuHyxQynJv3DJFUTjsqkhq4CuulsCTQCtV5a+QBNcId1FN6MxAkGlV9i69ziKz+g3mVrU6/jcULr0WYKDR8yFYiNgXOr9W9y2C2/8yd5byWkD1cLn3/GP4MrOagZsaH/0xutqH+0YNgV22l2an7jgYegtP0omnoGnLt1d3JnamcVFDLlZd9PTzBD3eRuhSI9E6Q+xpgD9NQHnKZbRNA0QZ/LJ7SbjUZ5BTjVEDXgv5WukbUNlLXCXyLtl6s3aQRhFe7YRlsZ6F7tAgcDeIi0oSQIjMZKs54BO1arx7qY/LRBiYnwX6Jokn4wTu2wQhlMjx0ujYEEdOQzN+72zUFBUieb7OnUPrp6lqHdU8dFW1zwAsMrA8C9XTW9ZIhZMqhCJMJqSyjcB16aDP16SxBf0yU78H+iwUP62R4RHAmaP0r0h7Tfd6uZgWJpFkQeIP3szXFe/LYAnmGkexGGpQlQDXAvQhoVpwejVBwJ9Y3nIZSVWbpU8mDNZzTeg4w9jgDB3Ot2hEbHGg4g5Rrr+FCUlaGysIyAizve5JOn5hVq/gB0Wsq+QVgCEd4BvrLP2/F5xgUazq7FWUf/jdYJQaqjzKmbUKnKibJU6Fl626lV7a+bB+nCfjB4faTNjPEgyOY58KTomIb58b5mVl8wMHI/pMnNhfodUCt6fllYsIEgTeRT81ZRS9r+B3ftiUay/X4Az9UJOYS5HzX31nUCXf10JndHu1hqQuf61/W+bb1WK3Dlw7C/YBfVyUYuuhp4URSwf2qKxVzJ6Fem2EeKZqTVwSoq6cNvj838jmUlVu4gNz+nr2pPs1UasdybSE4Xtq+tTe4xhJi5OfjArvL4s8QvWAa2Bh9LVNEbpeVwz+9mDgGNMGIbRH04ethc/78uBM+FUZN8pVu1eKXEj0+AFwANjTp0iinr/95DBno8sSxPhmSDATknFiQtJIUQDS3XupLaimugTyufSveHTc0MB1grTCJL9sZsU6ZhZb4UZoCddIJxzEjiiCGRbulQvi+cMgwWzj10JoCKM6TSK3PxH/rt7qQpT0m/ZJuLByeHuiuNN7Ny0qVJNWa4ezkLm3bQNn7h44aL143ADNj7Qi8ShwgPw8dRURURB4/tjDhB4WvcBTXdl34wfykZOswmaWujvS685jT3CHAGqszFAwEof6F2Leiyf5VslxGmB4wGKfamktC2bhgadkFjyHQy6eCNb/k7LaPBiNIuh2BpeegTJxp6mphPPTFjtQBYgAqTnwYdyvW5aeCKMqyaD5iH/2IjKPYbQ8Fi6LVpCtZmLzsv7wU1hPzvjoe2WyLRjJKkunePLtEpQ6GLdE5xDnCWoHrGs1WBcQEx5dLKYebp+dUBttOdPAHu8qOErwA2KzqmJ6mlNy6O6fOwYaIVK/zUd9w9rX/+T3ZAlATO+DZRBlIybokx/RILivOnGimMOCSEBHba9sQTUEitldoaGGvgksXHSLZLQyM3vysqZeDMrUgZHRWs4XWzcvc7It4cKPC7Sy65R0nGu+OtwopVnsOkKVNPPnAxs94e7SNd2dwkngIy33ykyii3cuPOC1c5PWoDRK822U28M4xu5cswhj+8vR3FyH6DrA320z8Pp9KdHWWoyiBbIKyTj8BlQtreN/Ko/tMs2NUhMHObXvYs2B+Z1q3d4+Nk7sak259uIf13FIkFg3Bgvwn817VE77R1iNcwUrzNx4RE2Rl+7sM9od6uMr6nnl3TQ3FUZxYx0PBnB5OItfPQB1U6lInPB4oTPjsLJMW0cNZrr6Az7+uJEr36/SciIEcOi5E04sRW0lh1Pg7CjJj8mxKS0ENKvsex8wbaXZq7DdWfBbyAwBJfrmta5aZKatcuD0uSIvQl8cLnQaSNg+c/Dbk2z62E9Q08jAYoCul6AqAV52zKbk0ZlQui5gJdeA5lJ/BTpdjZcSDpvyRW4F+6TFdGkAfT1ch+L4EUm44roztLANaZ0K75/RjpFYI/2+SEj6qxSlVTqTXmdZxLuQoQ93KBUqj22SHduq29asFBtOwlCHhzZREJalB/U5UbYCqNilbQkHhYOyn9XelS/TxPBoO/U5hOVrv2RcPH11V2k26kmAVhA4Qf9kKWurncVPIYdyufo1TEk5wmj5KGGI2dtBXyhNAvVlQYVnfFM73TfcaYxqFI1A0/LM09F4iuZMMSO0Cu9DTqXLTDGVumCCIBIAHXwSpvUJTF1vF6IXJ5QVBsHYpuOR+dSOHGx/Bp4JbXvg0yIAABgl4oGYi++CtAqU1WPXmAfiAAAAAAAAABU9wOyAYfUft2+SFoTG1M+rdGaDQzmkRhhtlFglIsTrowhlfsazD7t7OC6hD7ZUgLiuXoEViNqskV7RNhK8S9RYI5NvHlOB6OAOCekYuHt4swkYl52/i82n+xFTmdRk6Q0h4JysAHmcs9sWMzqXidAQ0KzJagSndcncDJQZ8oWMZUHou9Phuu93WYdZWyMTDLkaKIIt3qU2O6Fs4cVT0fZUSmWMO85ykONfV/4MRO4Rj16Kk30BoXLXQaQi7OTljvH1j2zYAys5slz/MYVypaeH4w7m6SvCtfyuYnhbnCkdJl79NNDpFAfkzP+P72Xl2Si2ykYuHx/pNVVubsB3Qjk0nuAWCYuXwcWHPnOccxJ0SBBLpU6G3aU5YhuDryUMtkPWhysw0MVdEderrY+KSfZYEW+bxVems5c4tr17PZBDSGY4nc8xC9KSaq4CpLOS7eui+tT+J9Kaux+VrS16zB4s2MbaMYc6Gs7YASt0620ixv3RYOxL/3maQwAwnb/sLyg/0tiGKlJikH3I/go9pRqnSkpahIc6q9NIZtNRBAzlS6IWWycMmhmRs4YE2Ocwsx6LKsv1RldE03PBODlgNPhToOyaS1Xgv79/2kw4ysNqIpO4kC2rELeN6kxfPuV1zIuhzsRDa9I5r3s6u5e2Wq85zC2kpI6YfQRAyTD2t1xvPLp+WpkKGbotdVFFWo8g7YsNwGHD1LBB/OpJvgngJUSvDNJmSo4IoehZ6MYPUyltIf8rQ2uiZmglSGo9aLF/z2hfP3vfrWeDTaEGJNBnOD1EdAfuFiBGEDqTomO1JT+2B2kOnz4JKaiNouae8XyWIVDFrtTw85DOvLMpFZ6qyBOee0ZKOHk45B9XSgfi3jtZiIrXyo4rOSp3hIAx+6UyIbtzYlOELTkKvLn+geMZpyf/8bgZbCUMn+9xlM+1IzsuwHbmwMSN09mcqyohbxU2y7sE6Xzi/P1LD198WjefMdAr+BogYeGJCgETfZzxQs8HPG0tXRnYWDo4qTWWBiw2Jkk6A3HvaQ1EHsWkbZMNmIZWiLtcq90DMLb871xBtpc65qPxKqxLGhTKw682ifkaqJWBGpShdDSpOFiNRXnvVhmoyA6FM9TVxc+jSWSOD78zqPwg3NDmj7PGgWI168dGcuXKeJ9aRVruD0OwJEcxGPIkZu5A9oqUoh2RdrToEQ/fX8wIfFTU5b1H+U0zUxOt22q6adSW+QBlWry5SHwk7Yxg0Wd+DaWslLOxNrAI1/d1EuIhHso8Np+aZRFlqZPeHZ7QpRXk668SywX3WHAouxGKVlPNKXXwvIFPaJ0tBpoZJfyDXdOpJtW9mC3YwajFT4dD02SiKM4rfVfor76bA1BRo/XXLz+XQZsax2mvEiBeO0q0T4AZpRcL7z4BiV/4r4LsZePSYyJYBijJu6YeUhw+zgCrWbnPaYJ2eRtwHnfOq5HUYWUVkBWusrO06hSZp9HXpALdTZY8UKIJw8A3+jxOxgeoiYF0vdcapLfNvXKfZr1WlTzXSsR4lBK4FdespIFq2XynMpDS9UDKTOqb5ThqAZj6WY2RA8gqWCzP6hQaOgeAVoXOjU5KANQnsj8vpfJA79FYKHp8P4TNfehjV8cG78Ywah6RkyUr8q0zOePTVputAKFEaU2yp2cZ+xh2KoSND4vgcmj08gj0k+df2eeyxmT0Ny++arjJ1xcSje0fE1CmjpPzcGi0+OhuSpV2gtFYveoCG3hig613fsk7t1v5iX1fQngJHzg6b9CSFuTMVhXcHpkmM5jY4TrIVFqVzTidHK5cqJTlo81HIsj5Asa4Ktk5Rgcx7WLW6C8hZO0fSH3IT2wJdUQkIcVuGJlk20450cgcV3+vLSH9IyOur2Vm3SXqEeEp65TDzk3FdyeQeeGBj47s4nUietmSTITqrGBGgIuNq53mVYWkFPQMXjjLPtu4gdb6cSh2gEp0rycOqofN7glO6Ts3mJUZD+z5a5USiukK5V7FXirIn7tkTj0WC+R5ZWNqExXrSllnKJSrb925ekuZwxqtQvsws8WB22ZZwDMohuQqeltYqT/WbZMyh17Uf2Kh9/ljcD3ueV7FdlvqlrakYmMKhFNsUJx1ON1kBXqHIPozbu/Ejp3a5CmfnhwL4B27GGTPmkO7iB3uy0B3hWQtbLgYOytP6t0ruzVFni9qLlFX+WqYb+9Q69c32Zz0UEYmHUdy4ytTbgLO/7NgwACT+lmxeofTkCLxRNzCGbPner+jIiuCGZiFZDRd5gWKfwJnCdhPkmO8dfsZguqxPbXkim8rgQCFzoKIVHMIeeNSw7XF8Q2IFOwGjA/3Jtrc+labE6XtBVg0OkU87npvJQ/MOWUCtKNJpAKxDYttRqKqcbZMZwrcDzJPdPecyXoL1tH/UTILyEcMYaEZ6V+wlVg7OItbeRew13dzyYgFocR71EPUkrMMYRtAgAMFUTmtCKeguJuObHykOJTppQmcFTWehP7rGxLm9ANpf449WJOFK/DvCK2MAc5d/roC561nr4ETRxif4w8GBqSf73be8rtanhqibzwafWHL/zD8sOJy8CdIemz+bSbie/gdzYbOgqLtq0p6v9jqRolooKVh1uqe5MO/sWh+1Wiz3GRwI2Jc2ta50B/SNTM7lHQPyjL6dcqd68/HGR+wOn71GwnlQRfwkdHWohIHBGIaY3X/ybyZDQCswGSbrFxoEAnD19JbBhUz5OTVn3log1dkUu/fTVNelCU4MAFIXi7cvQx6LVizuGvXcpCy/rYtSmMy9ISAhALwDUHaWWONVSX7Rtez14WuwFHXJa0WC/+RhIFQgWrYIKPug6MFTimXhw0GHCmLDbCQKtL/89SA94RcaqvJrDd3xtg3Qhiz9dPNoC9K7U3+aYZENsUFKe1/7TbPXBRGQJzpRvwlLGoINIJGPnmYDpOxJGuRbhI6/ANNwjS+Fd5sZkBjVmc/j6z4Obmz7f5UpqsgVsz0wjOrr0QwB4ejUVD2KYgQemE1WJMeIk7rvl1m584KcuichNl1diNX/gQ0HPBXGAoqWxGDVjirgiocMwbpaegmDKgPhgh56GSEgDad3xufcdJOeH8SbnfeVoChQVpPv/4rOvduWZRX9S3jLqRg8ny7qf24e7Y1UQf/wNTUMLJ2OuAzabiH3TIaYkvMB1Uh2w7crmwJO7knyOJ4AeIaH4ONMPCKK7tFlXgz11mFMMunTqzmui01W+ObNdbBY6qU2DxS85YS5B3IlQHA1RE7A4Y9zMaV1Gz9sAkjFAxlVm6OGkBCmntjLcasTSQ6b/hDZv2npDSzACYzzuCzu2J005q32kyJZb/Sm0OW0P1nceBP8XQsIfX0UFfNF8UsSZ2SkAqXQKYtto8Hbq5tQsy+Hlpt6NK1cCYjTpuBoOkEemirqFVGPIlw1RDLzazr+Zti6DDXLSoBe3pOVuBp87WjrxI1+VTkYvc4bZpY4B6wOROs5oQJl3+WepSBJ91n+vSrbs81mn5H3rayCT91HEpxesj1EAXTxbuV1Bnw8kX/DHtggeQ4Fk+vlsMfbvuE/jgXdjmiGRppPRGoR8B/KH0Tg2IOp4eIMJcrg5EDojUifDH0LmknZ0VNrukMb6oYW8aU0/FTtCaljgzcHwnOwq/afYsdY2GeEU5eBs6+sdBCLb//yklvyHbthOGx/WjiR6CgMtRTGhwCrszQ7uiSRh68v5OyH+/IF46yeDdFk8PxbMXCW7INPYZlX47tpgyALxkSNQ5oAvIx2uTy6p46msesY+YsS8LaXDYMHb0192CMpxEaVJhFhBOJV36uILZ4+o+sl2R0K0yok///TR/kkGW3l35WgmL+2/FbwYz83uvryADlVAMIQO6H45CSePwZJYjqwOXjDvN3EIDTuqRccRV/xiIkVpJS6DNgr0WG7MTvx93fi8LMvAbDN7bKG+1muQyTfG8WpYERxXsGIHuB0u/iNWi8hi1/1FDTlKxp14j4yw5QPHtHOO7PEcoIM78jIYAaWKAbUgl/DpKcGS6Nci1q1HGnNzpKBDDlVL/prBzw35EMQpnmpYYByaFNVGDv23ErTJCBxl61QpwZ3O9RbEV/53GXBS9UKPGOL9fXd3zmLVLtosfOV+3tgYMXszoK9Byv00+o7W9X+IbKokn/eBjq7zQLiEd7pOMLhiKdA3ArVifOe0hO267Dp0P6lTQ+eSwdfFEBp5Ett1AnWny1bldrhMNPU8hhrDJBaHDBljrAvI6/Wc1eaixh7gOTTbRvPsbKiT//+yMgxuF59/GJ0Ct3vlhqzaJ6RxIcOQ5Dad/Acjt8ujAQZ585WZAWsPfE0DwdXHYp3WT0SfwYipRDFtHh3ycFZsi969ldGqNVkfr4ZEtmw3oKOmL1sCahOEdRLJHPjI6MDSdY8usjOFVbOsXds62KXf6lC29FRj4AVcYq1KS5jffT6K5C4ZGIX2jx7oWPn+OJ3jBDsbp+iPEUMmqo+xWS48mtNS40d8O+1U/KTCGNcPLpVVx4AoMzeU9ff5RNx8M5v5zUxAh8EIa5V4Ww/baLZXbxzBdOvGh8xMHS6UYYrvnznYrgV1h2pLxBhEmoVWSgY9Kq3zZ3mSx/Q85923mfVIW09avP+vTQxPBDF7PMRf8t3uNFKBEdO0SAFa3+d5sjSlcGZSpbFiUL2FmpVBfSBCxHh4MhQ7iB/1AR1EVrseGJ8OuVNNVLJ5jY+AEYYHV68wJHH1mVuctG6WJorK8x0Y0Moenth4XSFJp4qhpmsRL0REOVP/3Lgr67PxH2HGpti09XnZULdEEdEBiO/6AkTQBtE0nwleAqvIQGkJ9vmnOx47cACm10v6k2gifDi0BcsiacAkaAOKC/SJc/tkTp9GfO72NgCvDH2482LtH6GQCDyRI2/yko4Dzd0GMCnPk+Mc3j2dPfawjqM0Jroqnm/ErJZSemjd3I/sKZmlVdgDrgXbBym4bEiaMXBSMH7SILoyzXMYqtYJX3Exn0p1H3zYdHQdrPuvp2mFoRUEvpzTgU7I+ksZg/svB8A0ByOGjUL5zU6vy4pAAA69efNg+cxQ0nbQ6uxgn9hKgAAAAAAAAFmjug/ipVisWkV8aBYjXG/yU3gsR11kXk3ee8sS20rsWDlBusiXXPPsiIkWGnKhlzWAQFZgMk3WLjPOb3Qzt7o7HjbTUU9dBtP/1lttOySsFG0D7HkBBPBJDuwiku2wd5/0Z4T9ps3zkgB35AwhMd70D1u6aJ1lMllfuntpkgw/yY1pnAx0PYDl614XOgAJQqvojaL1dCzjmvFYrUD//2BNfKskxgSh6gLyVS8tk5fKNCjtmrF5PzsU8sVG+yk+VhfnD9K7QTcvYWlMupW3ILPWNIZArDYWmhufqXeJAzaDk+UgUMqr060RMCCKq3ckjlyYwWX6eYIv9Rce16YKwNgSx3/jMd2NaZwMbd2Yq6cCZ3ar9iYFyjo03Ku1vxfhKK9kIJeIhJMAkxnPzlv2S4B93Kxj4lioXVnWtVLktiOZ55+W+dK0LLKLHQJ+YKbCr4zW1Ddv8jAOvZWkX2DFONDwY4oZVXqPENbXX2yX69c8wGB+SbJP2mlgbWTvezZTZf7lvj+Mu0Zad35vCIbO3BVO3R2FsUDTpS0bAp4KNRBOT2SNDjH8QyRom4mgbPIogOQhqWhj1eKbgUoL/fGZWu6oE1IWU6+MG67LKvzwJyDouPrE3dd9am3GqIRedgeDRPg413MSzuhAeOhW4QMqEFWOMSWXlAwMTJpNvzu4hjrt2Cg7ce8m6yJHBaCuzzkvHU4M/w1Q6nQ/qc4FK2ag16b4VeIp+CWr4TIgUt1tusyBzTFvqJOdcG7aqZGiPuJzmeA2SAEirl9N1mQOaYt9RJNh0IWkOXMZmHXF7IIiAuO7Aq1dGBhu/AYQJ9n+xm6vdEBzwgpgtpfAcpcj8VtiJDgUwuXCPJ1OMJ/BfXD3ZhtF6aWqrUlq9RFbKgksoXbJDCPBK5KgmxWeEWkqVvIN7epIMMT2yKpzOtKroJ5Qfg6iUnu/UT21zqNsV4KqQfO0V6gUHB5IHbjwfuN0XsbPOJ9MOLqJjb1QrJDXmotJSzcLYROeyQsIamWlHwjRcdcEVLo6fdmC4a58B9OU0SKSHvCPMTeuW78eG9s8f5wmo8zV0rVfAnrPCjou76AsFEJC+x+fECIqm8ICFpxMIaNOqyVEIbRhaFEi/UYH7GfcxrHvuSU+bBTY5f3rjgfJsdShtIbYIXvM7m8p2Xay1DwMYqMZZU5xuFl684U6rKWLNPKkU7EcZqBEYbCSr6Bi8Bd/iMZiO/n31twArfenA6KusDXnb+G49QZak/JBqjiQ1OuxDPcyEwiDrm1VRt2+6DgEHYjl498DVNU7kYeXiGyKglrd6pHcfOQEsiKSd5dNuHAI34iunUN3KYKSt095neR7fYvrieiSovATcke1HF7KcrerTljvfW5lX1cgWflFC6EpfPTIb7G9iUmgNMWoIr7730iBRKM4ska8KUCo0rXmTYcpI6uJiv4BMIp6xf/9THfQYaBMYI7OcsHQBRRbREKo5DIfehHA9NxwA8/AgGd79N4ukKUgZzUcEHVpAe+YKfaZrr3Tzgn1CbKOExrHeCCwos9eoXEa0S8uu2oS4OnVzorlhcxZ4dU4R45FSwdE5cr5B2vA5WmxD5InGHu69Gbrj34n2AGPDjld39a+toPb20WJ1tVQTT0EGVba/MjS0aLZ7ymNBo+CkdLJlHmgFmHippC0J6Gp5KPuNrWwPvpJNVFueup/M4tRg5BULnGt0RWhgAubUgLkBapWNI353vovtQtsq+6JOFCHp5PZIEJ2Dugd/QtSs/cb6DOoT/Dll7kpcTdgmpr61VxRuvlEi6Jfk7Pg0IB7Y9/XYkF928xM+xT7lrUTwr1oWEGuqVJbBHx26b14zl5edpA37kz2ZAhTn9vhf70dBzLlZT3t5Preqd7qHMluimvkAlKl68H/QFRTCo/yiNySgBsq1lX+Rn4bQSdUrQQ7QIyRhtpqA9iCeSaOF98rvbH8Bflt4fYuq5/RdN2GtLPC/rY9DCKgUWHPq7B8OeuGC0NBN/wTbF8rtXEKyQKKmizjhWNmquCynxDZ+oCxLcU0WW0tqf/4AYQyYSYJ4atWM18FXQsaGG3DWQ98VvXsG6qdB0/BE88gRK9jqlX2qg5za+UAe0nMxFLRjoyGiD2Duit3aIQH/XDeiOcT3UILDUO227aCFUpdGb02idWKpowUUpYihdi9K4iFDoP948oSZs+HkrVpsZtPuUYaMNFfRsHTkkdKZDQw2gaIH1aGxBhBa5sUkqnzVU26uhkcRJ1+USdvx73qWv+7h7um8/99nnwg2hJ/1fr8bxCjUfrlA3ifL5XWPyEHq1hPN2WiFNZJziq7BVGhTLU+ckqr9bCphzhORWL46vDPVn34YrG7+kBnPM70lqzAY8O4+IiUCC7VTCnuxcpCtAKJAHfzFmwECLkIUuyrJ5FeeZES6RE6MxLnUm+/4C4Bz8JxzUc5XxjLoJvUm0Ql9c3I909+PzasmsVMEXhX1BGHcefKplhFnfI7VZoFtazO5bmH4TDSmorY/pI+7ZvwJCtorVQQUOdN2LWoBzLbettyGuomt4Djm1CqJUeE/PY3fUTuezwDjGuElYMbe/YcjiWYrAyuXov9q4jqUDBzhC40oPgx1An3wn5E9j/p+u1oLniYa5CEuwNBZ+K+ooH4Ha4EXRwRMSQYib4tqmVkhSSTOH4UPjzsuS+WLIGMgdNMkVCMExiTIsWRRgFKlXUFJ75pk1UgjZrTdgzPdEZx0Xzg/LlMeR6hLz5k66fpSh35O+ojE1T1QwbggEIbo4kICiyVYq7zXOjUwKbN3NJpiHeJL11H6gYW3kEb3+j1SmKi0rPA2xjqIglQ72DY75hdgTeoIckMrXrxvO1XEC3BXjTnOWHolkIroC0iIAFXyEtGwCbcB2LI7JXRbjuAeIqK8pI2X0fKXA8mcouol6hkA2R8BF36iIKltvWBalOZfiPjMxiLQsUAIBkX76TsQsvoBJkAdMfa61k3KL09U5OFxGa/ZgmlOKNldA0gTkLzYsblKUrXKJQzYn9DUGlPFfE2FUyTzKfTTYRYmmA838euAQgSkbz987bPWuaLZkO2yvjk6l+JsN54VAa3qt7rzTDfa10BukdNbK+sL5tzq6H3rCmnT6WpTRZUVWJVIi7fxmXnNvuLS+twpUfwbzDSzUCu1+cUaRNKsARytc1sSilyFECPFB5SD4ipwBU6T/wyaF8fvPVeztl62L5fpQBE74g9x050Q9Mj1VwfajiS7e6r9hlIlXT5jJSEuq5jMbZShsmj+G867W1gTESb5ds+TsGLD2eP1qtWxQNN3cpfWZ+7cmBTBxtoQjArOGSIIiag8dqFlcL9LJ6FjvqlArt3UrkeLgcqefVPch3kupcBLv4UirgBkJqh/JCnGrQuWuK5q2pDeQXKBDaG4nItkJlOclmkgs7G/nfSIO4ILF3z8PsjfOgf6oKwMjOdnZSSiVfegwfaYTUrVAOqHvo/lHxuls7d0mwSXOk7UD1hMurMmdVEFgOV2SPS/JzrG/EGEtueZLMtVHreW1CmsdqARxRqzxzAd9uqHOTAubiF1LBiz2zN39/RPt0xEuSfMhnrRvREkcqo6msacUsl5guU1OjTPdXx0+e4V14pXfdwQNpyAa/ORWWo/DJcgbK7y3kQvg1/EiZsfFc3UKLGOf/hL8sr+XA1v+rAqGCken5Wk4zQN2/dhgFDbSneoeL5jUIOwjHzYrE0hcXeds07IE3CucL9bg2zvs7BzYLZ+Wusqg/h0hFnxC93txg1fKpELeQW2EdJRcMkiHl37fc6SPxSe6yK/8uviboXW7f91ZCr9xJc50JuNuYNLDLN5YU/OXijrcRjzIKHpMnzsWDW5ZbPBentQoepE3Y1CgvXZ5+gZFc5o47G+b1y04Y/juNONWxHkg8/WpMNupEVaDgfN9vxnpH3Km7QsqHWMsRMlqe+YBH25ocA+aHeNJ8yTgQvGkS2212oLTK9hBU1H0unhJ4KN4rioJYxjQ90d2SKFofsaJcTc40pX2kman5k8Iu38to9WHAaDc7S5hV7GarAC4aZHF+6qh3XMg1KWx6XDM7TeT4pFohgVA3BYMsgUZMSsbkkBeHB1RZ7G7YqNDF47pA/JI0NDuvyloHKl49YfZzoGSYqkAqv+bCaBDxGOg9avrot4oibDpR0E3kAYCu3nYoOD5MVAxk4dG3+QYfyQqxSj/A4vMS6rdY64hqXdndec8gfCq4z3w3TQ63dZMK6Y8mBWbPTnnZeih465HhkdbyvQSMMD6l7tMf90I+lCb8mOg8pq0Ivee8/xWsQEqeMRaxt6WFKyfSH56DQVeJuquMfdpVlNf1aW8UivMnoP6ZoevqA90ez5XZx5PR/LcVgbqKPGI6VUMaFukIciar9FfumWSYRoIkIC3Fv7gEbhEudseafYtLkINgmO94+n6ZcGE2IF2liBX6ocMqpyrAbBeEoueiIbeqa3CzcpiA8wAXz4qb2CapV1ilGUI6uMqaxCeHb9r48XHKR10NzBt1gmRjLZPRTaHoR80rD8F0f0KGup/OypJp1BsOxxoSHrK80OUmVzH8x/K6ubgFHHGbiEk27bPxv/Io/40VXlxIbktXDWUrxxbDuC/dIwswy4Aw0DaED4AI6mTli2JHLzzw8e11yiAnfkJ3oKgyh+RYwxmI8flFggMJHWkxw3oINfi/JYLjLWlkzCMVEIxRBrxq/wuzQ2A8xEsvbNXehes0BrUMlHsIPQ9Sf4yKcGOXMk/cHn5W5x2MGBxe/VT3MGQvWBbzlC67ACpffO9ADOuVc/N9SLMw8iRic7d2bTWChRkzS0x5wN4k+AHLirhFkoe08SGjUlF3MIV0svCwscPNlnTW0GfThJv9lweGbbUJ6cyhiEs0Vb7NtcPJhcqHSmbm/FH7yHSrGDVXaX8tqqG7Lp6SECKrznMMjRax0b1g80GT6A507hYgdztBWq5mJdGhMiPWRelcRCh1qaZ3mNSqJl/VolZIDGsDtrJJCUkoXdcH2AXeDIokLIDlkAFv/w2IS2mnedMFoAwCgAAAAAAAAA8LwrWM7sg0Db3YVWwJWhi9NAunjfPDgbHaAk3ShXe1YdSdCCXJjaIu40Byrl6qHVvFuYFVCjMEg6rLKc+YhpUX3/2XUIbNIOILkSDcyxCuS3O51S5oaQQkGuW7arNyfjnbNLOflvFAe2+zR/ycNpSItiZgjqqywxXnPo0b2pPfxoSsp4VO3mqgaBsrO59HNYJ6JdFsNEnwJ06ZXaldATZeTupFjEmjVQbsezTVCaeL0QptUzyBCnPycShSZV4TardvTYSaXWFlbRFhGXrjrLJJZXjah/Tr7ZmmdTNBSXH/QnyiD3JFvBuhEd9xLYVmwSl1jrw/TfnHqQEw8q6Vx57oqaH0ytdt6kYj0nFps4wExFt4hALpvaoe91+ubN6fIJnFQnvTJsQFANrwP0l9TpxMx2UvnEyI+fANRoLhxHSTUuObVYeAuNIjo55L7Mq37EuEVtojmKyo8MjWhwb5TuerJrIixzbE7lruiBYzAS9rJGMllGO7nTNR5KJVL7RZGM+VDgmm0tzsrzahSwqGR3wwPeQqn2Tgln/nXueWTtJTzC6f9wgnlNB1vvdu2tkfkM15B7Xwdo+iT+32cfw2/aFPwGEDiviL0azYjEI0+uHfJnP/dtG+ODB5WEOEI2B6hF2wijsTtNoNMWbdpFm3C7qploERUABk7wF9/o0Zxoe8BtsLMlz9sujvTUi25FgHm+gKJD2rFlkUzZwly+wCFprZ6Gr9nh9LzC2226MV6qx24beNLt3oLRh+pZ+UMbC5U9tghIH1aGxH4ohJZihGPES3VtLEmTjzw3W0J9R+nMZPeJUBLSdY7f8283UQ/ndtLqCgwjYx7GITuO26Ae59/s57tyQ0XA6vtDTTRT1TnzmxadJgCC2rLooruqQOvfpwUpY5JfEfZCHeTEarMGprCBuVDpMtfEQPwUXSTt7phyvUAhHtXhRQls/GchTZFk+ffccUYOCi5scyRxcAQ0wExopy7ougZEh0mWviIH5nISvnTXJNJsYOpyn+Vj1UUcA2916CAD71ive3wxr2scovU+M4B2imdc0NCrb3/NyVe1I1XHgf8CZ4iP9LyuVU5fMNp+a1Gz2vNUsXgTujCZrsGoT6rNqjSFewXQ4Nnc12X4W2WdhtBhHpZ9tI0PzWRyLX+XoZoE4hGjqpT4uL1kzMzMqlcPFfOQW5vD5A4kwUIdE/v4a+CpaLQS1V+j/xbubwPrIhnqMo/x6oCBSUaveJr9U3+UTz+hODlC68o7jBptjsPuGKHZ3MlfD4Ixx3a9yD+5aE5FU8XHsKHonj5UQuHxFidPXRXjs8lMRMGvoi6BtKBseR9NgKhUCdYHKBV9Y3NXD5ACTdDosjCDwSVPBeuVAWGneQp3xT/HZn0CdLnSgQF1ZlZt5daulocT1Ne+7XlxgdbIBrO83Db4OG8Yc5JHD5/Dz0QJlq0FKJEmPNAfAeECWJz9wIbZHAoTYuvcthRApRR9ZstKAypHUwVZAhZApwLE0bCN2YR6OXV652rQlaHMayovlHA4gm7QADdwOt8clv1cVV+0kERMMlnEJmAABJCFfyXs7FgBijNya81NgGgVpSwvSMn+RHvC6SX22utK/ZWB93kiP6dwXT43AzX54BtmXi8phxhceOpZlmO0iUcjzy8SbexlNBJUa8oxybhkp/zFkEjwf/xwUFm5U1srQIlm9Wpl3Gyxz7qMDXJEzg9g1sBtvZZtyAqiplaAxwOqOCt8ZgjgfBp9bGeYPXJzNNFb3DxHRXMPWcDlomKQV4WSTuMJgVF8Z0ZdljUnv8Or8Sfbjeph1gy+qCuOSIoHPb4gqRxhW/+K66CSb4wTQ3J4gBimVjyi7CmfuYrUMzLXq37XbtV/9605eRiVbx1/ZkcWYZiBq4mqDPXz6AslJ4TmBeaiJBeCXkpLb44XwcNJCTFrfl4m3WoZS9qdF+nJ+6sxB8tjdqBhgQQGs1AijIoDR4hIrqS/m51315QLHFHo+R3n6q9RtqYj1HmZRiOuw+YwGTGByjw38dW2tO3A77GrgDum0tsyu7/D6mKOGRM1w2wwO6Dk67ZfRQ+Z9ppkGVM8HuT59M39NBZKkO7XP29Zn0dpxwrFpUx+bVJ7fHqTgCovfhygi531fu5iqt0FO6jEfCvsDNnnRXmRNXNSucTZ2gNGZDzGQKTo5STA976+R/6BHXzqXYdr2KIgRsssN37GLGWum0yRtzd1nirsirW8YkRzbUdG6ghuNjtMTn8jPose6Tj3eF6WSzlkhcyxCuS3O51S5oRWPYZ3R6D5ZZ1AUmSx2Mh0BVhwlW8FkeZUET/cqSbvl2GAP0u69FjKLDmMzN7nYy57QshSlzeCdbL2WPJ7b5/D1w7Ybb9fWSQCefCanwTRnDEHAQfh4NsVH+tExbqxJnbK3C++QhMtmgPL1NZ0ZVnO19vlOGHFp/PzxXV+Ua+hmSdme1MXrNHl2aZd2TVJl8leubIeBfEwrtxMEaP1taqyHf8Rr8EtVJk4ACJeoCr53gCQXlCoBEimlnSe2GzxtLlF3uRDE4wFJl2KGK6j1Eh10GuGwZ9Z/0poJYhcSYb4PtWKqwDslg7Yb6qdlMX1iUpLjTQOFTGSdc8mWfgyeA58x//jEj7shTnOK/BSfYSe+y3tmSWIat209WnzApmk0/+wMBXN/hSu/ERh+OxEKphP7+GukayjH3x10cFzcUwXM3JuHQzEEfZNtUM55Wr3c0J5DdMNktrV4SWUH2DSFpuv3wa2NcheT18KNuFqr58cwMlzaj40/ypXQO8IamOIp4iTX9aW97vkZmcrMk2KmnkNA7u7q4amxutgqxQPHQJ9VyitqIYJiUXIGZ+NA+4YL4i7KYK0ShOKqOlxC5AwNhbyzayCMi5ErKMAFBIFoZBcCUhGp3KR/wiVwJmzv/C7cPwhVvowLNWDzNe8/LAeb9glwVlmNKo8THp+5+k2mqW9PzlnLHRED/tb5o3iYn9Si6f92IpOTE4fWf/S2MN9M9lQA9mv0vcCmBdi4a1o+fZV3/pluBN/MVQ5O+tqHJvFdTep7eojnomw7ZG0KCHZPzBEyT31jroZ4OO97dUtACk4V09t/DBTpZneNqO+z3NboRWsqhsg4f4rmOlpkdFrCcRDpkSb6YO1b+ygbVtALK0jQ1DLbQap0pKwc26XVtqlgyoOOfftlrWi3jVY/UJqvy3xRttXwkI1isTArQWzHmtYZbDbtj7oGsoUCKXQ/vejUsiucrqkwFp4DNdbQ1XGOOgF5YH/p2zcfjhlFpcgyWjTDNdbPrkNpWmGr/AnXpoqyEhLqbccqV2fGFKN+Izlzy5QY7OK1zftZVSqhziTOgxDXVK+GwGEdX1LrZhcsFG0Szh32ZyHbCE/ZAXe6jkTLthoDkOSVdITCIFalYCAzVhejVeXoAxT0HYJ5Jc5UMrfUwA9ZtfmihMoJIsxE/BVOwJ5HPt0nx6tbsW8cz4RHpH9zhDgCyY9Nbt1RtylmToUY1qqVIaUy3xMCsvuxOnMLsjYlHM92wIqGbTOXbbJY0BqmzdiuH8ykVw9vEGX6+GU4WfKXWgPCA5+h+GIhHNur7rV9e4L1qylfGlGCGh2GwQOuxX4bvDoWFqJVNXv03xFtECq/CaTHdyN6s97gkc7qkjgTbmEA41Ntxu7aE9c9ZfJIB7+DZcMMxspavkh0kAAuwYw4tb6L8VXz15Mu8K2oFV52WBekFasH1UkKW0TcLlk2OcIqkw6soT9Rw3+IZRluZFa4r5zuAggojlubxE24hYWLuaPb8TNWq8e6rHF4vBN64qHdWwYEQ/blERRpJ5v4vXCj4XoiWmnxgO//EUFU2coVOrjc/PbD3rVl0XKjy+oJU6aWwW1ND8zcQR6quSkx2nvx0CP9psGMEjQP3mXpj+sGsLflGMsk0ruetEsssXq2O6WudjimF6xicjwVRy7hTj3laXFTBCSROeRh+uJS9pI89R4RJg8bTGFbzDGCAmCfeHDbqZ+ifGRndPhm5wFMpzhoERFtSRhbCtBa7Kph5IRnDy+utCoY15s2kBzxWKGLnaOailI3VjKczkVyMGTx0Pd3A15dNRZBP2GfYk4uOjWNr73idN15aQMVtoyudSsaIdB/x0nCvQr6DIIaescYHRevijFuD1TfF9ocgDAEB7Dpa2B00Cb5ZIShiMZHColqSxmtEpNcPLtL4BrAhJbxtAcuhuYxt0TbUqdiK5EjEpoYMG0sRiAfU8uIp8fY3ysH+js1eYdIQRMAvUFN4cf+yu283DPA21rwYBFL2v4Hd+2JRrL9fgDP1Qk5hLknl3F1BpbwT9xqfA+zG+UzPfZiQnIg7Tolzh/zjAjOyKk1PNs6oJWkVt36BAarqVlv+PV97T1DJRPWnat14krv51kZVhzQzTpKdDcntL0RC2gtjTn5OxN2Y3vXGsVemfZ6Lo7voK22QW9uhtDWE2OF6Ihnhfu/R4RGaECTRZSjrxDJoIpxvpMX3C0ld12afFxA+OFuGXHCCAwm9BAdmU/vlUX4itCFQIsx/yoHavKOILpY9bKxJxMiFI1O1o102W+Oy0u6RlTmIWUnVBuaxvWJ9/UdPVwGoMGR0Z2ycX4FSc+IeXAUccOnPGB/jOJYJs8hhKmDYm9XuKzSlnARHKlV8X4+XpM+GRruG1qkLV9R0J+XaA0F2J+kq07ldJ8jnj9onfq+1YkediC72Ugn5roYHE9KGFLTYhGRzgZ+7L95Z8btJ39VTwEyKiRGvejYAQEcPDSAdieKsKOurARe3bu2c/gH4P2cwYvKD5VD7933+MO5ZN6exHqwRoFYEAjfHqBGO7NS8UkErDdSuuNuDQK1cC1gO0c0zz0bMwnTFGdDmqFXVc8BRHh7zpn3gtd8nHM9Eo326I3q3zcBXot1WHmxHcCZPtQUfYUZaLq9qqNI3rtXLaOu+7PsSooWyAr9zFCx/4fnQ88ZIraFmXCewr0II/XCf1XOWufBZVH5GIJcDuUJhp77NhO1iVaaztsG/6JiZJa/mRCpqWSqIJG/FiLnkATg9hfRqe2BiVt0v8UgQOGjl0oneyNlA5ru6GG6foSh8EJsQzPdPVXRP0jXcqiYu6b8/wV0XoS4QUJvcj2d7mRonU9P/QllAzcu1/tOhT7oDubxe8aAZutIQZLOOxyy92/utd7gMJaLIxv93v2ztMSXjD625fjYo4eJYxwlWQai/yam4N0W1pMnn9DPt9FEOtnyrZSpN/DCALf4esEGXRtqF83yvbHTvnlAIr05JH/Ao9Na9zYy1+C2DVIcwpx8Te7w+gAAFPS/pKy2lPrtYAMINA+wzsYJ/AAAAAAAAABCakhXafkFQooz7M3pZWtkcUrV5ftZUZoNJKQqtEo6Ebsxv7+fzQ+9qZIRbe53c1ELcmYrCu4PEwu1wKSRGb2tYhs5OYT6D1rSWBHCMw0Vv6J+rE8Bz5j/+U3E6Ha7QFVMOmnp/J0w+DlAE8dfcpKq9oht2trKFhLun9qQa2AjYAbllM8EBEkGATHIH3DBfEXadhOfw8FDTCeJl7+HLk5TKJ8eNcwOM0afrjbQnkSy3n+Ku4uzkaRmVFxgSGiFsSi5sJ1q5HYUWECfu1ynYLyyChlVvE4w0daHb78hHnnmPAprIoOaT5D/zKAi/kRDDOZDgejN3vEWkyggkYaJMc3uBRigFNBxv42EYhPV2SegVvW0huFM/SPwNXNJuZ8wAQmFSZb+ZEl++OQrk62xE8kUQRyho4H5KS9p+YReGQlf0ZHuTv5KykysDao/d9/AeAYwOcHW5kZCLi1CmnYHgvZk0E2+oZxU1FwqDCLrRAaeA2qlwYOxAeSqEMx0z9P/93d9Yg2HiafgDlRIfi4AG/ynIvYAISRZYwdzlz2/qNCi7CDOUfUPXKPDUEO7eAhW/K8PiNvH090ZCXatVfdH4uC4ceBa/CTS6wsrd51UlrPNuszRUQq3oKN3yXnEXM5eDxyE5fOt+YLNBE46t3Sukpb6ZWNwtuBI7eYvAUQaQ/dOuXXyvJHZA2EToKzl+9Yt5DC10pnFwCDjUWEG7FFFBu6kgU4qd1OBYC2as49ZsMLG9Y1FlV57cjNytCrSrEXoRjP2BqoYvF6PvVcgfyRV7rEmNOJUfvnIgwmDnyMnKoTWhXQk0gYk6Q3BJUvsoc7I7rjPD6vumL63Xj+d9u78SOndsj1vtYAsRrAhA8iE/TRGATxDlxvyAO30LnUrR4dGKbK+6u/eCECMxEgNQvDYM6m/9uJ0LDPNY6RcpKE4Sf+K+1/T8Eb1Te4ssnO80G6hKqXA+3QFNEUl0PXAhBPzvDfzR6uPq/NqwA7MQ6r4OOBg6bJisJguWBep3mg917OXxPHLgVH2oJS0CXWp/NPxptaRRFNC8aBYjWbW9Tr4vleabG2CXRLfqFRNXFd5nm2WlB8TC1YFVUa/Yc9o/wAbnrfqfpXuQVDDQlHr/jg0Jk+6SXrVL2myxO+Mejq8DVv1+UeVRqBI7CQQqRJZtHCuzazUIfQJuZX49H0yx5xjjg7BbTNHjvi4o+6jsADwvvD+qG6EMWfrhoIeYOUWkV8aBYjYOJA8O0gMbLCoFLvyH9WA6EW/ThLZ3ldhUJS9RpS0bAqRNcN4IfQvLh/amBUOKzFzcbc8FmlV86gua2G+UDv+/TfnUB7Q4WQIgo3G7+ys++1a3IFmWiRrUtyUKLKTqrEhBk5ihT8+EtphJ6V2sfEO4CJ05hii6Z5xDBfvX9vy32pAp62WilKJJOi1FG2pso0l0HC7VrDX0J/rOMtc+2y6gVG6XN4NVU6Vxhn+Ezxofu2Y2eiY5WA23NMahishMNzO9vt2WnaXPuUvGl5GiXwYZAmdd+h3jVj7zUZG80Z8lSXzkdQY6MMbvy7pSM4QIFaLjbxvspRFemwZaAKAM18vG7ErqfwOgAz4IMdaqE9ZJeQJ2N344dhwAFaOlVN0j16CLqRq+nQYScrwJBFXNBPdE9IGzzGYSzIG+kRcitD1ZfdAHxG9edYn6GGVuN8LyY8hHoSVjx+RmUrSQCFAdPYiI3U8WKNZlOwwQENLYwfFseFZ37mYyb8yDja8svjx9t7sjWBhcXprPDtOuKa17aC/DnacnKQitljeDumRP5Kly3ghwXXPKMGgd2ll7MHkg0xM93Qf98xTobu6Flfj8AdAdnbpnzUPX69TdsOjrM/AyHPsb1zlY34CAOIZgBRHAmpC4rVPEberHy/KGrAm79YJRgkAFde3aruvMOy1ttPCxEGRNOcmk64JeaVIFsHCzxe/UQu5+oSyoAc+RKFuhDSdIeH1ryuvTSt/5Od/iJtuRXho7r0vr4lCJf7GNKQxTZSu8hDcLE3LOnT0Zqjv/tS5tBdAYFgu3m37p2caFDmrYPw4Bp2yWyYaScMUY3/2HNhPPgpi0gW11F/Q5AdtaJdl8hcLbfcJxE8H83hfKoofbp6jVIIAzN4PvzrlKBv/bdAp2LQqx46UduQwdJYiJT3cGV5k/lzrNB2wS42qNbtjt7CouR8jgXUwVjMtwUw5dK/rWILxPJbcDovoVlc2u87jqh1Utzbj0CEsywdXAX7ENX3v7Tsu9j0BgmGNgHFWxDqEt/NcM1imfZZ4wnF5wCosDQjyG4QFnzFVu/rWc6U+yefxZ7ZTVzUGJ7tsB5xIkMpZRtktKUq8Wl2QA4PwuYHatCx0ynsYtjtP8FuSPldwSoS/gsiXZEnJyFeGfssIKT5cTQEzRsPhQRcFx/715jqpP+1lVUBnjxFQfccviJl+TDAr4WroK2389Umasn/xsZB6IXDIBkSNVNuqd+BkFSijiEmhJXR/Z2Oe7gehxLhemH4pVCTXNg6TVu1EB/0YNJUJiwp6ddCnkJ03CuG3Qys7dX1FBnQbs0H1giB2ysHs6depp8P5+MO5ukrwrX8qmta+nqR1WAKSmrdoRB7LOSqkwba3YlegUqPRW0Sfg0d0SGB1dhs+4frJswuvRlaa5/dh4C9KmU9QEuM/E3Fn07SYy1wTHpud31QhOtjhKrtKzfIkllsEA+kHrkE5wUMrp0faAjrGTsIkNexyWbPDiFQpCWZYlzH37iPpP+TVCdV7ZPAirDiVunUTsw7k9pAYZxyiMjhwFyRV/ymyirY9jT/1GzzeWZT7h2CY/T+BMT6rLdbAtlNcMfEaHB3WZUW7PftekTrfzC6Y7gk9cGXsn0sYBuFXxS+Y2sCmA8vnaXe3/MendHxtoRDnOw3SducAG0/wy6xrOJ76C/bU+bPdkpv9D6RF/iUMdw2MPlWpqMoUFTF6D1WmGKGkLelv1suhJc9xO5zdWbs24m4AppKGT86P8INDsMjhCZLMI/t2LBeVRxnPKzBWe3KDvsSfJ+c+1ySJr67IW7fy23GnFXD/BikTT0H8e+SsiJJqH/3f1cYbfvmlfe76TOdUh6vTYulWOinS2dN0z3hqjVWvie2raBkwvNaNq2sCMJZmVw9bJL9r1XUqjUcH0BeSWlXXnAc3n38+nsgq0ADVNNcsSwIAEoi1P90/JCuexW3+JaHxa/ubI+T/XEjtbUT5GiEufTE81bWGMK9lIRqWmk2Uj0h2C/0fsBVXpJFW+KYb5B249MnmpVUAddWB5TsmuOCadI3PM1TiUFw9U4pN2qNlJRXfcntECeydXrWSrI3ezG/IF0MJpyNbX8UdntMWfjyYEjnvvyGlUC0G8mgEDw5rORrt99dpkMcgO2tE5gLCAfNV8ElsqzAoFZdK0LqUCJtsbFohjPRHyd7kq+7+leVAK1YUhe/Jf+JqL52LLjqgygPO38OopINMUOmgxCON7GmTlLLN/tYdvRAH06XKEDBp5lR1fzF5H0Mcf0n2+q+FuQZOMCc4tX89UfKhG55uiO1W/ddNVuiOAG8we5zV+3yXj9jN4hCHv3f7b1s7P42EJQ37Dbvi7augEYpVnj6zX8c9gSIBEcqV5iTsqBbJfC7qfuDbj2BhIf0ltEz2PDATM/O7OeKFngn5KWRs7CbOV34SSD615XXppW4usBBqUxyh81/HPYEAZgsXSJrS/SCqllITDdHEZaJ2/eG4u/osHCqN3hytcY4AKetc+QzmuEUkQdINMTPd0H/a8ex5atJzPTW3kSTxEg6nTBHPjQ2l5HtqqoslbE54IRANrTMbneB27p+27c26LMt94ZtKuvTL+TdA4WAAM6EiSngvmS75fGbWqciSjY/1chjU0V1kwdKPygKulsRg0ufw3sqL+ewKt+yKi1Mt9xTOGZkZYMQYA4EyHzqvUHRMyqOr7xiQKQ+YWtfzqTYr8rcU9XMQM5AKorrQYMAtrwt8IBImcdfic9Hkz9MnsoB5PXYFaBM3GrFrwNjlDYj+ktp/FW2vyK4dFsoCYoLMiyihn9Zrh9c1aGf8xWSRCy++itk2SNg2rKvopo1Bh/cm6+CXBJlO+GxtuFFommYubIYspNzqftywSEXY0oVALqFVGPYspt4lpqCNBwURFdi4HykNEAq925bs8ouqL29JytwNPna0Z2ipx0W7A/4Lnq9bFYEOO6HXnmxME0WqFTkazYMwb9LBePqF4ILVRWpURzt8D9Hh9v/ho9jRGaN0HFxnYyGmDpjmQWxv380cqn9Aa3m/PZHw7wiPn4Jsi9+Gkus0T2ZFZbEIw7OCzKykCC41ywtBce0HSfkMploQPdyxyM4Zw9XQtCfRg0jI3by4p9skoRIIhhZOx1wGckgaLygkD7Fjq7pi6ve3RFPOo8H63Qxl/HFbbDx+7gqaEyXPEXkHkookt4LWSN4brLmXLHZG5IWIgMMz0ll/t0Pzd8Hz/CPvPphR27swoVekZT1ubWPFV1yATnhBZO+nJHhnzPUdXkH2v1e/Iz0XODqljGm9YnneG48coegysTsLbT6dyY4Fe+QSBCdDHbmwWR466dvJ1ce4goGkTygScFyysEk/rRH4NY9dl2Nc75PtcAx9u1LlWS+IgtSFion6wA6rtbLYczsLTjuMd9BDDGoPi64K1XTBZKzltXoNDiIeeg6VuBl8aN5dSMpDKDEfAMfcz1Vk4xavchFFpRdLXnupBjoFvxf9qYTJLJbBQROtFvRVk0MOMaDM+GQM6upvN/uI7QFX5HPanRoWGB5JhV0/fheWyqP7vLI5yZGp8C50K7HksaP+jyNz/8sKYEABz7DKTJt8ieCmDNZayf2h7KCPDStkaAedAEhP/MlWclI3RPvToU60AeUNOAEnreERTq2PdOR06sRzS4YKuRLLNGoIJWu3DUJS9ZzmfjPqE2WnwJgKOKMyDIcfe/vczCuZkmStb2SGRlrlOeB0Mxeqk7hSpRoIG9N2NQfbPkNBsl6dNXWV9XB2JC9l82UNAfpgzNTc2AtRb5Vdn1DaeTCXsL63EZpH/YNIWG2xdTOQz++tKR3+E+t947ixU0hE/jcxM6oifBLyJVcME2M7dNwT6UypCTQKJTrhjuv7Pm2X2hyHgpI7MGBuVhPsT5RPUr1/5UUoASt+Q9AiPvNOcIQWfrtdnTuil0s26GKBin+NVOUJ2oZNL9G2uwJXeXT2VXHpjxZno689PuOB0x+aAefSv6pfUNN04KRGZYTRZ5x6XjqJ3oYok1pICsArh+Iu20arsSeCdXhOjIPwtZUf/Be9zrb1YQINtQIitOkxE8SgY8kxI7PnBhaH0ybN+40nc9PY3sACyZGREnLzhyspoLdSzfv+D8/tkTp84Wy6c3dn6oI1sqJTyBZNCO+HfaqfnqXhKlyrLl2b9YOe4usDQ/gnvfnpmLOrET4zx7Akn7iSaV0aRpVdQR0M2fG6KTSY/FYavc20wMURz+ZNSX39JT5iDmYXO40vA38PGFKuF3/KHl6i4edEILF8jIPXJ3LXxGc44bjsn3wWGJ8AEXO1FKrIC0nW78+9ct+WVp0jBumGNjQRBuf11zV57gzKRDo1O8JdLYo49+PgOzGaY5ZmGA5rfkfEDV7Xa8oIQuq2NxPHsIQBvAJM2b7ijK3Dx8MuM7z84yrK0nuOxpdJ20YKKY1l0tjMsRilSvIvpI7fXG0M2j49WWuoIiUzKADD3iXKWjme7g1iQnjvWY/c8PHTg+pfGVhbDiQZswMF6B6nzXLCySbleWrgH9QUBoeJyQkoBdEOEYLRvgIXVjVd99t/pi70mGAQVV3DqmA6lIR6REMO8t94d+kGB1MbASapkUaCZqaolZIDJ+X3k66s08kxFaeV8tFDrwc+JACQXNhBhAHPwFHD68tl40AAAAAAAAAVvcDq6622mRbYWG4GsXowRc/7UDoLuOP3ZClLv4Fufr4HdF9Fox8T8i5jevk82e7JTf6Hd00TrKZLK1FgshjJzoB5NQ02QwtahD8NF0hQE/7FEZdx5E8WOEda44xRDB+Sp1710MDpz40G0dBRPqJyZ8qlAxfTX9xA5NKp0iK+4d71u8hyYrUNE6QTamNcNnBxfaAurRCmsk9p4qt+0Zt7bj7CSho4VB4q5hm/+s2yvIzTobw3LTU1uKSKLLSxtUOFmm8Y4SZAnN2R2PUr0e1vyVjGmltwESUJHxqnA7SHT58EmFJjDqk31rmiyzjCv9MVMU3+TEUdJ6PfZhl0lEmr0EmG3HtXvhrqqL+xTth9j4fYJ0wmbK04Fr2R3oqJKMbsilwbFfhJEG2IoDFEndQLFykw0J0p5omHdWJtFaNed4isUVJHUQrdnfoTu4KXekw7ygjjBVYu9zbWe5koAxrT9eL9AsszdptMSN9kFQghUkcOD7gkyNRMZ4QEgzLq6M7dcBx5zpVlIEMSUJ5gQjksE+G496DGvhcTdobmkeUnMUu/9WfaEbSrrzhiedq+JJU4+DPmLcy6Qwne9AAUAZsDYz/Cth1kuC3hkobjeyeMeM73J7Y6iwwqlu5LlCZ7qbHCvVgyjI/zeMmAusbFT68VHftBsC8lPiDrXoGfSYMrPnDXfwPfcc8TLTNAhvCv/PP3HtCc1nBJKAk/nupMWqoGiqj1FnvUuidDLQmXXeSH6TAe4Dmhfv0SLrHGoCTg05oY32nlQjfNgHaP1VDw8Eae7gIbW1j4lJtsKyhRpkJjaVI44VZGAwAUheLty9Eh/zcZnE+yCYU9L5Kwxus2qyVDxnmSf5EGuDu/QcAYVojqbjobuOBA4IriSgAkjldeusM0LZAIxsRWEjW73lLca/NUODMVKoxwDyAgHWzG/y5M13vjjzDso0S7SuVi7Wzd2lf14S2B4Mk8Qo1fIr5KwBA4JeF/ESkCUNkJLrMFpmquDiTe4ugpKZUorJNCQiOCCEx0CMaou4DZ4EJ/v9k+Cq0vq78b1Z7siLPOWSxDGL462jZkts3+yYQBca6GBdRZp7CwaxkXQua0LX9n4Zzyp22BHSvdA/HjnVdOF8xyS4OtPag68IlCAwrgkt33EMYcef3N0EYrUpn/gcMN6K29FUeRfQ5No5KWpyvt6z+7NeSa51kF928xNB9lJGfHXhvX+NL9gWg8h4CM28+1+3TjNkmo5zRJjtqQ2vXSHXmfh+90ONLZ+9tFTAVPXsJj+h9awa7ne7tSjz5y/tr2sYHWidnUwsRHJh3dzI/+2OmwRKbucLBQVN/t0x2ZoNB39Sr6G9ZmRLp0jb3v6NnTeonfxoFiNflbWU7LoWeHemqkGd/wGB9XH6fpgvRzELw9nGLPhxY2mfiek2Fjb4rUnKo+dkn1s14xFnIIO2bUHPa9zcVa4JNyJnTR6uMUEtNF+bYQ7g7I0zF71e6iVzMSushTwL+9nxz32Ln7dl2zBedTArRadTfVnqA9THuOkMB4PEz71rruqvOEQCwtusC8AzFDHBoD6CI2FqR+ssYHHqBKLk+xx8nHRUauTnYIKpL7NO+imr8zeWtlVwzYKqn0iKjjBU0NNmZYjHEvMQfQoXZOtjFJgGkQx0TnUQZ9zVu7lxqsrMq4NQSyaje468pHYQPZUc5zD8CEMXBKMGFA8x3BP9LuAH7+xZRZDCccH3N3xdSCpgRJaQQWXJAi3DV42BJK2dCEpqd6dWwnTiZYb7OsuFN40vd2aN//fVrNTXRpvE3RSJ41cXAGhQ1vA1bev75Zdh8JD5JODuC+CvGN3/eMBMRbf4F0tmwrAMXmJQ33Wzkpvl/BSHRJTSG4wrczR3tZC/e7q8gpAosTydccdUA8oTytgyZSx4va3BfYGFSYp13LHmk4ZgadEvvcUQu179SAmHlELoDWYYcF3S7iqaBAzdZRYas974DPEDeOKppinWnSwRtokALhvWKvJF921FJTTrnRc8tw227ObYqS5J7VW5IeXLmiTxI+IJXkrT/4kwmDXs3odmb9avU3lDvRQuexozQtKwmGJ2NEUF6+BPEI1ZQSWqw00Ik8QQLle6Bl5czxZhNI+O1sNQYmutoJYPFtrkNbveLORmZGG2JLnBVjhRqyKydonS6GxbeVNSPmtjpX3aS8pUksoE6K6hJJ5ErfwOzz3hDuN1Y+J0w3u7MH0GzfIZASgdWPcIz3xbfU6TB38dT2pOR+rEIPc5VcU13L+Bts3NQqK0qDYuCbDc2wc1V/ssxj0CNgU/UNzHg4hY4U5AmbDN69/fJXFzknKZruThA1FJ6d5WC/kQqloMZDDhCR+IBCg9p1iy1MsXxdd/E4yo90/rw/3zUBplEvDTx9JPw8GVxq/CHJ/MCG65fWP2FSmY+YiiElmKDja+uCpnFrWftTNqS8O9yFKxBEaGFg1VmH18VfrYQkLSiK5jxXAwoGRTJLtWekmQYLqkynxjc2Y0Z01zDOR93Laz6/KsS0IhF5PqmLeGB7A+NyRLlaOl/9VRxTCmSeFVrkQAc8lMFoD8dcAzF51PTLpolvd8ikEpTDy9XcB8QfugDYixPJU93nQ7Dw6po30T5Qec8xBHJGuBhVt+odUWebRFjC0Ey3FQ9t2EhGKtVxSlZcSscqOvuDZuvoOu4o/FU3FdlkjBt/O4LgqdjulcB9MxjC1Y/IhoMr4dkJzUUKmrXDEUnOF+UmHqve0OGgorhSafRKaw3fg1QrkFmCwVrMEIKDcIJY/DHJZx+m0MPBgLceodW01JydBSLFMUtaUKOCIzWtUhoqFqxYIXCM8H9LEa8GBq0eHdW8eMYhnva58DN+2tQcja/mv4Cb8oJl1VUWYKlAxTGIC62FS35RsStNl4qj9hh38QtN+nR1CX0n7IRTpSbMt2qtEy1fSp4gpN8lqkUd5/KCgWoVsqob2JH6nhVdMFKn4aMHYX5QWAn66UDwE37wxNvSvWDi9XBDqY5vy+YgMQhQGz7LKPcV+x6B7mfRPx4u7t7766TJclq0BJvihy2Q9IapGxeW6A33dUPH0wzzKPIzGGZALV+NN0ynXh9mfIsTUMs03sVDLNN4kjjBJSHk/5bCJy0YjxESoshVnCWd90lAZtw0HNa0mccndGHUAFcHhrTijVfzq0g9mNIlb3kvS/rRQ0p9TMBfrwLs1gr2g2SGUMqNPkSlcNIiD6WLJSqen2iBx3F7IuDDnIftOZTiEOZXDoZOtVdGx/jiKnK3pYymaRu84j5lkH5jbzbRGhvooSrX7ppNZuDg5E4eZHrm8NtaL/61FoatXBdC61zUN0Lfbvvj78UcyrE5w27yGw4LDd38P2/zPV0W0jHZTp2fmPLC8BjGAe3JYQ7VuKMP+bR0bQJm246nc+emvAZyvnLx/Pj2T06qVNpDnkADO7+0Wfnl3aLzS1um8ikztr5J0oe59CwBdPVoSXRFdAuy2/jrC/GJWg20TE087XB8UmddMSzPYJ15sDnc7V8fw9tYXevmEBBOutQanz2xCGKFr8JDa1ZE3Lu32EC4BFK4SS6i0LYvAKODCQJ23unIbXJO5BuAwEwIAwWedq5sZxQsufeVHXlfNMPi1bzpkfusn3Gx4kjHJoQUBeXcWGyF50Tn+4ScFlrukkEdSYahlqe7Z0NGG222PuLu2ON57arPmoHKP8B4ZT7xsYLUIqVw5azADysCt/1tuCEZFk2s6c8GhL1uSNHFCynpTzTPb50HNV6BCYZrG8fTc10sfevMrCqZ0LGoB1m8disa3M0b3+17TdJ8hgWNL3S5rgkl+9fNI/4gpDlkMk196dGcgfZ185p8BkSUFgXNZWTbgsqt7O0bGv7eXMkj+scnKf73ZYlFv0EM/LKIxzjk7mtX2DG/1LByH19eW8sTHRdBb4+t3Uign7Sam95jE2i3iN3ajujI7sEzgU6/B8J0lovEoPpKyU/UqdvVNbbN42yVX2iT96T7C5NjzFaWkxiX5rCGFTckQGHwl0BjPG85zWpJzfP2dadQUwvG0huMixmIrnRfPejfcLnGdHAPEuAsyDS+XrumKNKZLwdNC07X5CaLQ976tLE2pivm7XcZOUrh3cvK13lJ2QpG/YqcPLjT7ZQSAOL7/8Kwn0TLHRYTy95zbr55NOWp/pEiUUjyJ1/SyR4sbVE3SBBu+/vnKaXKq1x5/FUu0GH//d+yDLd/DW/5XRJbeTbXCGpQLm8DmT1Nee63zDJIkscyWkwlME4KRVmRaUWIP8XZ45yBHF/D7DIBRX76IY9/vddntrnzRQRdYOMQy1ltleY27U5E67cojrcbSa+1ShaI/eLKUP0tuuI8GT0h3uEDH2KSvJczr40Mix3aDcylScXO1mQs4H13cihIky17oC6tEKayT20d5E8oOF0V81h2N8V+01Em+ryGW+xEFSz0/q5qXu9EgDxuDFvyUdrZdp/V8FL2dhYUEww3LHpDYY1rI9AEDwPI++hsYDc7OG8Fx8U65eN81UTgusr1aM3i0KViyavflrBGsuTpKPJ3ixhypD7ZYuPWYrkV56Ubso1hb8JN2Yye8xHNtJeUnJGTr6wCq0WtAE+nR6W9QS50+4yIyEC0XRf8AAGo1s9s7yMewggdWetbY1Y9i9HpVAAAAAAAAALNHSTMoW1AMb2vqUoVHZ5BiuUe1NJEGvIR9Hozkn2GpCO8PRUF6+ZcdgBdgHkIa3inDZOYpU+xcm8h1UdghzB2KQDEAQL6YNDDE2dVKJgoQ8W9ER9F7eSy1GKHNMzHk3ystgKBnLu4PlSnDqVsPSiBl7oRXPFOzNMmmJloUg5uO3ijW6W/lbdezvaoELYNan1IDxwONJ/QSgpaxIa5rpJnfwNvdejZtcVO8Y+kL89kBarZtY9osfxwS4dZ5BGdXlvBfYMcLcjFiLttv4ZweSG5PLFtMK21acGklR6Nt3z2liQYnQpP6Jz3agTBRZNYoJ8+k2XiT8tYOfKvbomLHuDpf4isPa0CIxkSYxM3CoG0sWiQfIHtkVTC/aFDTET3f3yGQEoHVj3CD/jlXgPJBw0MGNlA0bWcXtf06MG6R0HP5dtLsyda5ih5r+NM6hXCiTFsGactLrhoYSIkXt4qbIUkcFIBBvC6VyqY98zpr1T11FSOkYj1PAGktslcmSNWnXP26eyPJ7iAEKvQqwaO05vbCoERGzh0d9fCrEVDi+43C9+qyLtjEVVnVYn4QiNYrjgA7/0AbBMRTjlMDeukdfM49tpetJb2cKCGVldv+NIuhT1roQpqugZcNV78aLV43mu+0YOnrbAR1dJsjvXKKOF8VQuStuBGpnm7tr7EAfZvLlropPG2yu3bZPJ/oIu3ke6ITJKh/VfatE/t5tYSIrMhInxhzrtVPVy5SKAHrM3xr54D4AkKOCIzWtUho3gillBAA25U1srQI43oEoGfp2Rt+qSgf8ikzaIDmV2PtScOtOF2qwhME5HaTk/cm7fnCJg+VZC7iDVoiXdIn7506VdG+1ZYuC13iiDwcZZDNy0y4QLsjHs3WmltlR/8BPOEill9FdJVXjN0h8tjzojqkpqHp5159K3zeZ075V7j/FVv2jNzBPgPkRKQfM5CgYC9R5IXCBIzKJW4veaBjUZnTDTuGsVeGlDCNV905J3G9gaQ50/Bg6nPhN70gTMP3RCJrTWV66GpefksrdqqcwG/TFZq++nbtfBsqLQZHe2V61ExfjPaL4euHfHXzwa57lLyQH2DU+s9EcU8F/c07YfG4zy7lkIATvqZqPoaQcFvUvDgUY7VHte1LmUxpng9yfPovIVu3v9Hy5R5K5gtlHutOQ/bJcsISh+5qOFM2tXsG1frIAoTreZBocZ26ZPknXk/vOY8ZZFsYG0hceknXABx3pgdyjIfCG+bwHuG2neIjOEtrgKTWJh0nI5Hy+2WWjhX64YOny9mVVyVNzmQlxegHADAngTG+lYHibuu81joSHa+tw4ZUQJRhY3bU5KjtNhAajPQwzpp+h41JjG3zfurkewtQ9Ylrc8yy5d/rksPLawVrWlIpnQOeoP0cRBCbBPtGdGXZY1J7/Dq4eQy2asFUGy1LDXNdG3O0Flq8aUSdUBl2VnvP/2i1Yq4SZ9Tw5DTkDNwrFY71xgI92szeWimz6Isxj0xXl9zvgkmc+Wjwkt2JqgKB+IrcofiSxCs7ZJjWVOsdhk/4db976oUouguJUB+7xQiiMGoNSJ+CeTR5FFxJA9p91nQ5VcWdWHdgmpkazabcBTHShBiKYhAB4nq5JRdhda43q3HYkV6BU1RrNHlkf4fbZoseF8TQJly9YVz0kg0p3j8Jwb1UGUc6aTdoEQ8KAUuvPKVCxaX20SRnpWdKTUTDpQa2VOQUAeLlKUsP8CBTdf+DTzVdM9j1ImpHfHESzQmShwcgqs+gLts8fzLsa7sx8MJwtwZoKlsa/7pY3Jn29oVWwAohezTvTrfrRiaAdVXXrA4odpmMotHnjjboXByZAGWI6YQRx9KqD8UPfRZ0lDxfenoSxTo8Shz1bhOtDwbjPgQDLZs4Swgd92EJAtbJSoOXCAo+CioZWD5wPJS/NqJeSAJ2Of2pQ582NGoRsO9Hu78VMdBb1WnrTXwcDK+jP3YtbbdZnEsFytWSt8INRoxRSVOW7V0qXkdoUxmB+u7sMm3wx5UKXASGbVZhaKrrca7AVneXXYhucYHPlV6LdzFiNxMTnDPZZ06wwmsobd1oMDhIMS7ct+nGFLAS+EXhupzacucAs2EqsKFo5DCENvGqRUEBY987T+RWIDhITfYp0s2KTFYAPM5Z7YsZnOoPB4mNqF+uu5WMWSFx4hn2/z2nE/Ccsm5tlRclC7jg2bfdVguN4FOGbgaZRIBg7PSEDLLUH5Fx+AQ3lFqCsP5UfDe4XkLWPihm30H0Rtt0a639W/4x36fPhGnodz+euh+U1+uz+mcxIjm2o6G0qGZBg70yjQRsbe9YmuY8oKrJpBP/Z1TmIanifFHu2t2/BhPNvcr5gimEZbxoyF8eOqXkR/hyRHHvP0KbGWQfwaV/0U8/pDCUSDHN6hI226oCzseIMA+T33/YUy6L+gDFqVTcLtl9e65fwAm9PqhsI1UXbLglhBfCaAeXQhTMtIccpszc2RSRCQzCoq2844iMPNv7W48+icDBOahggxTTptRRR7mcooQXrDjMDaOj6jsa3PZ3tuQwgwxE9koS0+VQZJrMF+UflBC2shIUKlujcHNjYO+o0j16tYd5qX3V/UeaZbx72HBHzBvgdgzvK6qXtwFInP0K1UdgKGWN26F3vzEzM5iCOpynYJoxAV8Btuoe02rmGKAh/IFzByutK+nqKctrHldUh8KgCa9rGUswvF7CqKBawWyqiZYnSnv4Nlwx6NnRf7KP2h/iPboI0y6m+yzF9015Z4YAKG1BxsFNsY5M5s3rIfiItKEYuTfieG3InNU2UVnoQQCLYAa6xqpuXfyFQpiJh1YvkkrjriOQgxCMZLd74bFLrtNUFUV6N8us3L2bLFB7dTEQZzoDsdf01MyyZtUx5cVGo9h2ShzfXDnvdsuAtf/tAf03B3Xa6ytPIJ55V5qH87jEZzFw7A6PvNiyXUcBOx2lJ6GyifQHh3UP9SrHFQqzELN3S0+YpJkAiYA9I1LoN1woHH2RLTAg/QKtZlfcXAljebQsue3CkftVLp8b7LOMuJ9F7U5Ryk+BoYsXbxyPrd7nhTgpx+IkpimHFLGXkvtXuglTql3m25FPF47V3muINhEpOmQQuhWMlo8kqMmliqTxorz8fJ3zRaaWmkINDdIF54LSPqgiYlW0x4QDAkcfifF9RwDc23auyzsnCHSCcTm1BTajoA58KQyR3vnyeT5PJBWlpA6FYGhXoiE/bNr5FC3cyDPNY9ig5JmahNYiIE0AI8FfViU4C17S58FMnMkWCb2y5o8HWdN5W08pmPhLoE0WjLTMRHrnwFT8yR3vGHCLDPh5a2cR9FQunE0YacRgzqlM/OIyqd/hoZo2jx3LksAMH81qYsZ7Ye3sAIZ5SxKYCKtirtLReMWoEDABlIhj9wzPlZAPHQzFbpZSuPz0HHkhLIjlrHfbCfb/TaMm3HxOKkJrG1Ai7MmQ34kX82a43604SCInhPfxIGxPJSjMwGyRVi77X+iPr5P2seAeOzI6Q/KTog8uOqKPZUF1pfBA9gGIvZdgvOVGkedfdAkW7PxqEGUG3HtUx/85RqwndC+b2d06PpvwA+e773dWwEOOtqxKVqjPksormi1ec1+BXcD6iAyBQDAqLbhcXtzz+hg7tZ5W0vXuAAW3CgIwNhUOx/1i/3Scw+YYMRhHPAmWDM9UMiNKmn/IWAfA5yHtuFl5KSW3TIERsa9Wd03fXp3MrG9hYbYj12yVqJNAU08/pjv0emAkCHdAfiJ8RE4rlTAZyoucD1dLLaoqSeZmGGmmg9llkGNMs+ePocP1i6Bb8zFc7E4JC85UnD29/Urcx1yXobRLkn4fLhrpGI4rLCtve8MeUWm3ghL77P0Qhe8NIcALP1n66E0BHxqSa5GrIi5/OPrDxSz3590Tm6cdFbF6/eyIPb/qjETwrIOsk5L2jPJRPmWr8ADsTpLDYWgTravAZPEb5OAW8+reN/Ko/tMs2NZuw3vsY1TlObtIgguTrPn27hLNGyb1WkaHXrmCSJjWwsa060KNakpc/8D+UseMcwx+vdu01ad3tnoJDNgyYkpUKtbI3HZx1lXLduUL1HvhM+tFc6f74BItYvftXaht2IYELwtwcZ8+Whdxkgsky/RLT1AGrGRNkvZVw1gfXi8XF4Y7y8mhyoLT1bYr5YrCibHvjTC/JtZX9gYeJtqnfVbzbP2Kxen3JR3DYTbDcxfsM5H3vHmb7TQ3FDVWIyJ4nUkDdiDM7A2EDLogXg4cs/VlETuRPnyqY0LKg4LtWT8d8gIasOmGQzkc7nw7GG+r634GdPXVrMX/17mdZZmRRTUdvsT780tYUOda1XKKoh8mlqnCs7Ytq3kkvDtobRnMuJvNxC4K2xUxcygod35ppCSQzHciMZLQYU98owexW6TfhWq6ZxNPxDD23zEVpZbBlKxzPLahSkAaYxqFIjCVeaIjrzPEz2L457uwmBJKX1lI99+SUNPrGanYooq5rWuWmSmrXMdXF6K8X2e20MPoxOkgE8+TApBpymJXSukAewybbXxoAV7PMQc5ebbAH4AVcDqWfW2Jaxw66GKAAAAAAAAAHzkPzwOMre0P/3mYNM3ApaHb/BORcDtgbDM+Zs6FrgkDoq4fRywX5IzH3LskYNplncTqM0+JuxorkDYh69CYgMe814yylgOwtnjDwiPkSDcyw3NWt7hKwuzrs1SRwdeMgAg7VPFY2C4YEXrXn/sS0wt94nySd9sR8Asqdb4HZPTf1YngOfMf/LoWvFqkYU9Izvix+g3mElt42JahZhNRzzZ0ZMu8rvWAzTNl/dudpE18Q7CoL+oqu1/DYgAMeb8+xDvW8qknmM3feJ6Xpch5Cqsk7wLMqEk8fOcniA4gCDrVZXvFPbkfxKdk61cPv63cLcc/MR7GAFLrnfES6kRHPNcOrU1rgfWKnYjFHqSsakb5CEF7o854EQA31sgTQxv20lRvspPgqRqfT+Ldu4NhkyDP7vNhystIdQZox7CTgLjaWi1Diw+Napdwn8OIAouVnu+vosibT96nAwLqIPgNt1JFgSB6fS6+6zhL6xap4QYxDT7NdwcjuL5wQGPNrhsTYrCHgNsY4LttOfHrd/mymwjV1ijh9bTouZrUs1IZV9dGBojIwy6IwICgyHJZ/se9O+k8OuNeqV2oJFY1krI2WRY0ngFQcc+/bLWlxubyTRh8NXR4bsF5GJdYrtqa9BcoInTTtwMnBdw4YYT6V81AV8VUyzktPj+PXYrc3XP/4vUgcfdoWrBkcVRWNb5MuuKdTf/OgTvFssVmlgKW03BBfy/ma7t2qn4aPkC2KpVzT9jzw54G8GXdccI9tpCY8ZniuG2bUxxcMLJ4p3G1LThD+2tTr0hnIDULagoPzIirntvxZy5F+1y0jeIFbvnltLgPk4JMdOntZnUqsujcWdITwmf2r2P0EtlcdVJbETpmi6tMmMT2MLpED2dbclhVQQ/RDIO/xwdObFiYQ+PG7r//8JzneF2RS1gPuZrULOwTdiZdkxDqR9y42TVXoP39uDcZDI0H5Ej3i2059UZvQVynUa0O0y5OM8YLve0hHtCDvFTy84qe+6voyPYnSM3MHlMvdUtjyNrl+DZadtsljP+T1U7N42eq/YJtnuL6z12h4NpfqKEHM90fsMHtIljRuWwoCRoDaDLyty6qVqb/e7cior9X/mi56zq5Ze+h7Kszzmx6aXPON+1Z0KfE+MNUwKaVJ+7aPWVVAdsKi8aL/yqEQ7x9Y9s2AMrObJc/zGFcqWfNYBcuehbWWy6Yn16r46ZQA7DzDQimHkX5faPvNa91Z1AHh/DGP6ONvC3DI7J7y+GsuwC5LMagFqO3X+e7XvXqSPwbLmLWXdcW58Zsb9u2SYt506A8yIlUXiSoMdAmQrKkhjgDlLEElpb/+5wqV1zHma0DV5+v39UYzBSTtJ2Sg4alGouQYJWtalHkhsOzoyFtmTrmhmNPfiBKocx5BXoRY8oW50n6iFQnh4mI/rM4tpJOndBD5qjZwflgDAQYB6DGd2wszxcTo0teEhk3+Q/6CzZ4qwIWIoxBMoWuc+1vO5lh3Xbsa3PZ3tuPd8LLb/Y95tQcZKsrZV6U3O70CqndEMJ/xv7cpQbQ7ndaRMmtbdQQvNhYvDS4LH15y741rofsmAegokKnIQI+nC8GVj1sqFrr1sOmwrBEK/K5u+nyKkuWde0lEo2Z8mqMIQa3hfFSSuMQNZl/SvGbc8VTJG9TZj4ZkumKeKMgmrXk9saEk8bCtmnIFnzYRe/9AX19vUYlB/HKQE3vpRszXem94VqT/7cPs0p2irLQVfRAQuyGKpkCvshaTs/iDwcyP56LDJCJiG1qvormYLOJDVbkQmqnm3kL2jEPh9bQsZ/GfIbyoaKYQcNegWVhECFz8cIiPdMYYmBLidRtSypEYhM9QFV0EkaHd1lzg3VH2JFzkARvGlqLTgT26Ufz8sy0u376AgPojQJ3jX9uByIfgs/E0yJdl2hNnDdZ+reC5K5ra3wne0GZXQZ5prLrf8s9RIsdJU/NG4M23icmluFEJbtzoeNvM8tSBhMDLS+zn8qR6pK5+7Y3FgJls8tvFmz8APe/aiQNaLWO8hVmpD3aR7AEKFj/pCXvw2bAQF6pNODgtS48G7pmi22NJ0Kk9iUst9iBlaqMIRVOy8M9uWrFTCJBE6ICh7d9KW7ViOdtAIn1gflOYLBp7zYeBkqYu9wLhBlKAfEJ8YgEAFNkDndvq3RNfHj3O+6xJtQmoK0DbvtPd5MpPp8hrTcq6cQgxmSXzdu/8vnGNv00nS4zArlSz6gfsy2/sMMpGnKWLSPlJQu6svCvpS/6Q/Jx7HItBx5rw9f6R8GnsRb5GTdX4p8nHIPq8yz89jozFCQBTWW7dis3ZguUVW1wRnLM6EbtIrt7OOsN5moyQkdUyFaBtTpYH4E4cbcPcrZ6ZXOn8YHub7AQGDC89NrsVmYA/AtMgf6/AshMMETXWcuMU6U1Bd56tdmnWkRik1bo7aW4MKb/eYN2ef9NXcGX2fFZ/FpPFZyWoxBXVo5agkxdsaCO8NDPFTmaQmdjZJ8/A0f5CUsGb6vNmJLSmrnvg7RAVsSc1q8dZVhl15A9iwbT55XnOZ/p9DE3T8BNBcLjznQnEjloODLM6CmD4rfGbqKJRj/viYDS7NET+pOs7ed93+y1T084+dq2dw4VMH7YehRP7fPMpvT5/6owjLuRNhpHm3rbtXJv8NxFFckTcbd0AmNiQ5EIGDK3blesZo2unOe8hZ4nbwB/lkewf7DH1nRwWXlVARj10VOCwPN0PuLmNl/BAhcjBJvR4Jxxv0u6dbo3xs3QdXbqDK5ul3srrXEQQmne3Pco93bFoulp2pDj3IMTOBdTB1AkeFCSv9T1d+6fJmPeD3iZZBXjlvhQ7HzFhbki1LLoYoakI9rDwyVXs52JoQxv25F+tI1e8TX6pv8orRYYB3/uQbPzUEy8wj8ffCj1OlgfgXkLQKmjIOWNYKMSPHCaWgAludI7DH2vRMXfSV1ZmMlVvNDaW3GUgEgraREl3rbnfd0mM4yiWpMkHcRaiHjd5jOwKY0ZXD1upovBtH/ZO9tBhNDINtDROiUIQJUujUSjallSHGC6GILlRwlqag86Z9NQEfNvTTIpbSrrzgZ3I5SkdRgeoO7YRMYjZ2+DNdC0ThtAuZqcnAqmj0xM7fmvxODYoKPWykBrqHVS1D8iQevsSOyrTIPyHN1JpTKkCbhAUjLA/JbeEAKz17FSsJCr45XeX+up71g+lsv69bkyZk4yYqa43LWNnZnZX7XDcf/wXzJDzJirr+WNUB2t6Ey19vghuTj3zm1u+aX29jPn7TkZDGVZd8zgmtNJhLP3Z4gQVyxsyqhsV3pUIjS2E5dcgHrN2zeHgRxv2GuC01C4UxEFrRZcqq56ZaADFtIj/QQsCByf87Yu+fCxo2BGKuKQF2uh5/ErMpBgkweCBR0dv5bbqItS+d5w2VADfxgbw2QndWozY/uLmdwt69TUBNIEMFSaFtG/BoijORXQ/9jIAJK0iFyJC/FDGJb4PniZdygWCUop2WFgiCdTcx3rw4yluSORYWcrXrvPXJLC7nTh54Up5hdfOpUKQEkZLQBmzFc1qWOKhHor+lbUUnwKliAkuV8cehIORb0QQhLiZqCcujuLuPsyLz5jMWY42MJ6/xwkyV4tXZg7og5KZ8Jrvx4+RP/mDxS85YTX1pLDr127W+EbaV1FHndJ/K/GCHYlOsLVY74PeYD3z/86afX1Bx3DT7o55/RZZ9afwXTx7z2kSLAd6IvQhK4fb/4kI/eawSsvB/d93Ecpshzfc0BRIeLYBjY8cMTIRKpI8cezrN1ro7/VM8YcsumCWUm51Zsk3QBe4Rw1d6F3kT+dr36lkw6adWccRgL29PGXVpr927G2LHrvGtBvMaHBIgTe/Qmo1qeHUt+mDxUBl/AsFBShg0HfUZ52YsoCGgaLLFGEWU6VLfr1mLKV/7JwXzI4p9MHYliEXazlnRhVYh0SL/hj224Pb4oJXRyqf0Breb89kfDvCI+fgmyL32L40wD+UPonBsOgHhy/Dn2c3feKquYQcuFbtsdhWN/MUp0aS8sVUwTSp6hJNRN3kRS3z3cqC3QElIf3UKLU+UR9CPc0WjGCD16DOY2oEN0+6DbZWw8jpUf0tiLxD+W6KKIrXNrcrBhXyullI0QreVQKrVyBC6QLKZOA2V5E+LvXR7y4Y+iGX19zkM4UlIc3DrIUXMMfIWgn+Np8XAuN0m+Bjt3RGanEQqY6KBl7UMoNhi813aHw77KXklnq0ZFbsRiHaIlPa2rNjICMkhOI73NfM2gptAdhdJs3Fp5lLZM4J0HIGJoOwkWpdaK+nzmyd2AnegrMIsKML+DB7OUAkrDVr1fzSYl/zD29rUpZIbxQwBNotBvyM56GHlUsmYMmqvsRy6aakRRujqIxctryZLa8fWZJOyCOrhN3UXwMhMOrPZZOIn8cYb0c5NTPzw2wd5SbAZ+CwMte0FGvTTv3leD2aQJezH5HHYITqsRdnhrKwUnRcwGoAr0rZ1eKpYo9EnCdhdxvkRy8UV5ijWepRl4skTzUtrLppCpr/esoZULgbOX4G6h9A4nq5JS3KDfqrkFqNqPMZbHdmemhf+DhXrVSRuSG8nRb0vtLrYlE70MIuy5ryWQ1t5l+90gdgfVtpQ3eu9mIGP5RP6w1nDs7S+/xXdNXqUr0+SdOjH4tq0gqNFM56lZAj4Hsqim7mqGsH6IsZARnU1J6+wMFjVrdCnZxMQkkkTEF/P1EmYJctuWH5POkLVhataUI9WUZGAyR7xdsIU9MWGKYiTr70XAx+PKGmyzeF5vp10YoHVSZx8BWYflzO7be2yhvtZreoMRexz53cHOAYmCdBKZbEzFP2LuahOAI6goyj9D4j2dwOqLJ7zCdXZ/JUvtmxGB2Z29nz1WJ51chYTfiiDSGobNaACFNqmObP8yCOfvrLIgnYYNDhUrJ7eZIqvRjZ7M8m+E6g16mWvXDTv12fYtw5lwGmmKE5LaM0aFfzdPWXOaxd8rD3Nta+UJQA4Ts0Re5z3YM2GykB+2oiYbTx3AQuPUthe5GNIL7WPLIUs1NRGjhsKjo1IOgTxgR9NWyseS1OhGOKFVrnwfYIELi+hp5kdwiwSHupxFSm/PwiA65eEmWnQ8sweV4VchMDPLeD3MqBlen07wBnP2r15l0z63sqlbA5GxWPMlXDvY566di2VHFe6dWoliJm6/U1ZayW8xFZ5oO0OU3sf5xsxpLAiNRofl6HirbBN2f4w4wiUuNHu7N2+UWHQZCr0mXLs3607doRc5ozGCu117TC6FqbJYfXDBSf5yZxEJkOil8rU+h95zJMILd4bSuVIX8UwNVNoysvAlsQvNkPFe2s1B77vKmQy2Sww3k+1qu9ESQirmxtgrHR93tsuuWNeqJvk0muMCjirrCuovvrRj+bw9VO1wVS7BM13El/Iq487tEpjiCW3z1mEcCkwRBQx+7zssoj+fGoPBF2uobI61a0rjSEyNOy/Z1SBMwRO9wByY0TCybMwEyjYq3Io9znLUeqELREOtB8VnUZq90PIQHmKmOZoG97+EzXL5tkxeFn3+2J+KmebOP1VR1BdaI1kBbzzWMg3S/Cbst7crvaZKFTEOjB+mjNdHSEqGXrmyevINx+RiTjZkkPoePHZXoedrOqMBE/6sD2mlmG//pfIxFluclRLCctO4WIHc7QVquZiXRoX3GHQLj0HcgyAEM0hjsuOi0UxsBJqmRRoAxpqJDUNAeVbrKdao/t+ODoO6CjOr7UnMKQAnY/YQYQBz8BRw+vLZeNAAAAAAAAAFb3A6uut7gyUXP27TG7ZPBgbv1jGpR3+X67wiW5HBGJwlRKw/xhzwyxEf4AojcY/4aEC6tEKayT2niq37RnAqMXyum1MrpiPlPCjt6oMyBNcfsGK7Eh/LenJPOQNlNeCq09ku0zu0MdHmm01xr6bshWMsZWYp9UqYz88/2c5By0zfTyASlPdECPtZK2CWzE/CUHO3x6qRftUx8nxpgJjRToPxhO6+1FwfsOk/UFd7dPTr7OikPpjFos4kVUhbPGHg+QjLUnZCkCvvwBD7hSV14A60b6FcUodV2v+V2ixGT2rB9E6XkJNx4AWvjA3UKiOlPCsVOSVWRFgDNtWdIL7t5iaFVE/p2sxY/BPIb5VNt8VZrBlkNVyqibz3aWIFaLnHMVLdh02Ww9/YJQ37VnG0KsZ52BJQ7Eu/RE8X3/+mWkuBREMptxyiSdWnlunRhF5gFAcBoQOdz1AeLJctDXqwuSKv+U2QYOIedJGHcAUcfeOUFd6e16ErxjQZdSag620W5MxWFdweJhc4plQT39nS3OmvWp2U4vVCleCU1KkYiU6kBMPKr4IRrvBcEIZHaOsqXQs2nISJcfDJl5qZXxQc4YfNvIId7yi0JGqgDFauxViNmWxJdS6EWnD7JJD5fQ66JaEL/hhfv/au7DkHVPiJwBP1jsLx+rWsw0uOMsVKekaj1jK1NwXbFpsYe/7ALpR8lEhJgWRloEmqxuTngOwIQ5qiK/3b7KpXVTp3qJzEDCSNbmrf82YUgrnPFlHAlc0YmHnXay4hEyW3zfJmlUHztBF1k9T8odZ59PN/L+l405/darJNADhz8IQZqp4IBGbB5RkqJaoL2rPyhd2vROgrwRoBvoCmZC1Dj8q7fZxAD1MrU7hkKwlIPyc6lQ/GMio+t8/M42fWdANN2VWZmL7tp60whKbQtC45PtzAuCEMjtHD40YgksC/pvTrh8YDSM9JAIH4jLZeYFUHfPgBfqY6IfcswmGW+6J4vHQurTgbNoayVli857xjtm5945g8vlkNPfWQvTZ1r9uj939aseo1eimslfc5bJQTbEREEZEJtIwWp8lZZHCrZJP43vm4rREk8gAko1WHMa4zAjQhlmbB59OLyFz3K8ku5+YRLl7mfE8/MTV4R1BdEWC6lYKSX5lm0FHwffF8CZEfsT85wxStIX+ebzz1IPzU/81pfzNW0TowVZ9Z/DLFYwJ5K8ENdyfvy2z/l7oGQfRzKzQ8AWKizMG/rUyOInR0TuXA3vaN/0KLBONNjx7dAUi0GhAqOwAUPyTwj4FqXrXpd8gH6E57nK1INTkVBt2DFdTY/WIa2IvezQfF2H5flHy2an1P6FvfTvWTIwEOfozQv87wJ/I484ooFlvtxwsjGe+uALrWjb6ay393Q7GHEOI9hcjrmPw6a7U04L6JPZ6VLGnekNVpnr48pBMzzZo4qLYOT28z/dN5PrOr//i1kZMnZKvchi+rT/2G75xlAj86Wphjmmq7x8JjW5OWfmqd36P4K+Gtka2pOrThoGRUGkY82bsUAiGSYK9l5HnaXNgCYptrvbH8EnAjZGYYWWiROqPlwBmAf9XC8di3OdRgRvcmvR3OLNa2s5HLrMNbfjbhOl1koG0fzLE3KAe5lpiV1HAwaYCOCsH2Rt9/M3XCCqjQoDlMQ297+jZy1TM03cpTvPlN9OTflFyKKHi+gyezDNxvpbIWRQKMCEuC7sa1l0NwjXInnpafxpGGf2an527eYktvQ0uJGImBLBRFhaDotiKSEHyQQcIdFUtkWSSEIXyIoae85Oq3K7Q346OHxRWSM/+w8f98xspvU9OL8x/dPDDtdui63G/Mb4lssEjaAxRVgdK3YiYg2EY8ddL1ylenMKCw1YUtwUgmvkJ220B1o4tDuWqLl9A5+NvV+LrPV8mvbxUqDtun/jQLEbKMiKul6yIsQg5jDuwll4kDGDf9fWcr9unGbcazhPMSBthDuDskoNK0tcb8W+cl7y1hXriE1duIvF2DPQ5EXvTby0yvCQMnshhtGTAXbYm8n2hqnBZzfLW4wmKoGv/8pcXgcMkeJ3bhrIe/lgD/Y8W7TSpCf/9+GKKCgMGzwIT/f9/jeSRW8KAx2+aGKno/9VHI+onkI+IR5ib1xfpbGLL0rI1uYSMsR1/L42caDgik+o68Kw/SbcupbZk0iIrgm6GOKkV6JC/tnCCISXK5SvTm2PluFobzqBrkM7fHostq+3AOfQIC9HpF5A5vzj1ICYeU1BVMVltm/uLW5vpFjQHkoxyhQlfiYt9uOFkYz31wRSVoubrENbb+1g/aIniFxr4UCgnS2OQLPg5GDPNUtZqkxPkjLPnw1LcZTjazuE3/fe1QExoO6S2QAiUEayT+k6xnDco65i9ZCyxyGRoAN1cJA5dmngw9L6awiAzTkhd+4OKpHSAjLM8N+uGeM1z47jr5FwDo8qDUm74SNYMbFxg/RtlqR2zBTi30+J2B0ewpW/UmXPhCboqtRyoWGdZxaU7VY9bmbRHOAtYRWBLo9LLR/keixmEwgaRAb2KufFQ0izonS8usUdCaILwNIIGSLRpUI6eE9kPmdWQLwhkpujAAjZnJeQbCCCqekAkg37ZBpKb1Rrv5HqT/niR4k15Zw/V2yuQumh4Up2aFTnrekF0UakEwHiBd29XZMKgcE3TiwrZvoqmNrfEwiVYRvqQEw8zpEhbzKIAnRKtgsWrPNQG+YZSc/RUrjZyOGgTv/JfLz5p3SBB8FrKeh5mBgLwX+WpAZD7egrEh6HqrDbnWWEfu7QXk7kaP40Oi3unfz+N7WIZzaXAvacLEgRIx1MgPvlccmoAyJMlAKKBQap1QsBCYR5d7xcn6SoI5N5uBZ0ZmON9uaCGMIInHDowf/ssiU5WP4p6mJKg2UlachytDg4BUwet4jQ2F30bTkVfQwfTrMSH7jK3oZszwe5Pn0XkK3b3+j5co8lcwWyj2etGSba5Pqv24XJdDDE2pvWb++2bEPwWy/CAPZUfuFsVmJKVxWD4TYPkwFRIieMWk/rsGoT6r3mX+4lsCCVbo/4pXWMDk3jJM0LySE0UF9P9IMbepYXgjdEgcSYEUR2Zwx77tQ1FiMfYE3wTL7A6Eq9BBx+RYDsxecU+IpxLNmaq418FzC+KyUDX/ujktzUtUnSjlZdO6OXFW6q/QgMfJkV33glHS4djNHDTl1SMgcRhCUglF1jlrjyGDtZp631gh4CKErpetJbpVYSpLk5kvdEnhRl+ke0nuBMaZdglZcaDCkqSuRbj6BrDekHb5fE2sGe7xJS9pJVqnwlU2VX3t3NG7dXr7md+pLwkS3SKDzHldgOH8iQRMAjzfK001mPqlunZFjDWvWXon6hPHvOJEQ5oQjiwLi4s9NSLyXpDrh8O19SlCWVP6Bn7zp0Ldtj4g7x6oCBcVWbBIqxaI1EPFmpMgX90VpiZE2/bQTbW6pTa+mECuiZ0zcLYYe8MITZB/+tfbMVUabGSY+YJKPG1WAWVLaiAE2fuS8c289UTz0NIs/0IIgYTTFQGv1D46Mq1FY321re12j8cmMKUYsjpFI1B4INlORqpkfDz+spAZ5n9XJixSK/WfTonbQvwGUjRzAy3TasfNwPn04dovD3gSmAMO0E9iLAXj7pEqmftx0Dbm0Y1wH72JSYe0frkUh1Sv4kwFOPtC0WRM+ursv4m1gqtQvDcPClSrVjcfssC/wrpedPjvq9bouMYRZ6Robni9wB7cviF6tYRulKb5ehgL0BeFdFzIeYTiSuMxeV6V/ou1jBTj8ZkErnMn1WbVMmV8AgXEheVuxexE8vex//aBWyg/Z4RMHl3sTX3avP+P7w/kvdgthwXfTWMcGDVwlrAEgwOjN+HUZbD88NTK78bzutg4dAc0pAdm3tiN0CakRKKuYdsTx10e1as7lGuBA35BPtgro0ORHrP9Yv77NzpRowj8NnX9zWGRcNWqgZCQe/G4hrdAM2oob+jRYMX2jm1saK7Ggby75ugYFSEXrhgdl4IjwfAo/RHe+Ky1UYCzPRUsDKEb7lICW7ZaoCrNQOY8HBCkKqkgy6v6NA/a0N89gzP15pnW5OxOuRWt8RLMb3LVmV+y8BVkxVZ0kuWOl27mGwIxzeKgg8busph7MjE1UFDRKL6U+ZAX1PptPoEUKXHhyKLOzwdjo9pLdsa3wOyj/R34ODi8bFHOHj8co3nL3FjjCGgoqJdYQaj5vGy/om4q1vKx01DAWKGocGwTb+fFg5ajcgCCbMdLbP9hqPqpc9VqazNmPn3SDsLtSMSi61eyCPqsRrdj/hZW8ClopWOw/xCWsY36Ab+skH9cbTzxMGlf1LMi9lZQQDOd6ynjoFkWoAmXwGLbYcR2YxkYorGSXEBnt1ClaN67ukWN1mNOu7wTFWv6z65dd13Rgfz6YTz4tn9L/WNHNW9j+1FH6/kepUXrg40QdzytK0+6u8O3nvI49uxka1diQY7hogRXTQUdWPefl69XJgmcaedAy8oHiamfmnI3gcMYSqIPYy0XO4m9BWzBrroEW2BZ4f0HggnCVzDO2/OV3W0+RusZCGDPcW+sGbJypu4cOBgeahiBTyPHFyGZRVE8q9jtuzM0bn0x6G92GZYRnLXUtrjAfVdkNTvA1W/rYcKbny5GWh5z9eWl9q9XLkIo6GeDDK5CzKIlM4Hr1iUD9OSBmlwxq/FSPrcBNVv6muVoXmFdzcQyb4PgNUOw1phzhFX3r6t7BxfRBgti+qGUYxtOBYjp/JWCPIYLJpoZjQ2BO74kXv+TLSj7rQdvPCml9kosZ5mCjyQZYexNMFboq14A7JL1pBsyaIh/Fsui0hWlpP1DPKsx3O0B7Gk8bzrWVbD5GufkmaqSznJ659tx4gBvcBmZYuFNjWKRMObQvugTcrUMK4TOsvnc7itMaNUhaEldWo0xKM8BBGQZxMQmzZf+cDFNNLCZwUaSK+M2a//zs9+PKIygCQzgUCursmcSj4RNiebMtDuM5jLKnN5LZb5qqtq5BLzKcj3VMf36VIshqZEnVnllyymOU3AaYKR0O32DxvzGJhRkP+VXNEtUWavK65mqW+2dEzAsCI8bXLw+cbdee72i+vKvlxN5z2qDEsx/ppyvp5AhjlLQBN5CixY61XxA1Sw7WEYsk539s/a98CByzY+dboLRPy0MYQos1Wr/t7Rk14aPEGLp4PcN3iw2xHrtohRX5h5kO3uqwIGtNXRChpP2gM07rdrLjc5Mf5yLTG3J1Mnxm7w0oh15slMQbESG9OvwD41myziWlFicEhgywZnqgf8lTmVm1VjX34qdJNYxU5GdifdDpPiJEFfRjliVylifWmhEHNgScXZenRnpezZG4DTyO6Po/0kCHy1yd3y0lGZ5z0reOHxT+rLB2ut6Y7tRS8JxSuFNVFhooRPJc4fsNlF5bqINPWWH7of37OfzMA/sdp5XCBNFixnOMP6luA3sP/aoSnckSh0eaVJBlGhibNBGdqjonHBRzg+JE9KyecsH6PE6pF4h03HA33AeGc3jG8WdW4kVDNxW8fVOo0bPcwsuJGVpjuWjxHqJ5Lns75xMjZMP8qpyc71M4QfUPOy/OkGE/6v6BVEpTvc4gsXBiJdDWHubF36+nsnGhMEI6egPNWG2EU4Tx4Y6UoNhIJ4eW+ab/r43yOLXqGf6/Ycr39XeHQYoSXJfNvGIjBm1WmW7+Gt/yufRO9pyvo47TBmANgaxfwKcIj9KopBCgeyiG5Uu3kCLhW88cR46NGARCn2ubT12ZKqQRsdh6zUSQsTlJNSP5+wZWM2BrpSkvYrgKQbOndYtfNxbvTyc2k+fKc0ed60sr4G/4PhcEBRHUBLoGLPD7kWO7QbmUqTi52syFnA+u7kUJEmWvdAXVohTWSe2jvInlBwuivmsOxviv2mok31eQy32IgqWen9XNS93okAeNwYt+SjtbLtP6vgpezsLCgmGG5Y9IbDGtZHoAgeB5H30NjAbnZw3guPinXLxvmqicF0uvsgq61TKbms3Haoe1HumcpRciLSxowgTRS+LTx62uL7XBO6vayDDgFI7vNQ+bGSr8VY39tdamIBiLrWgCfTo9LeoJc6fcZEZCBaLov+AADUa2e2d5GPYQQOrPWtsHsXo9KoAAAAAAAABZo6SZlC2oBjRlc7cibz0UgycTrWT8x1ZcfqiIJXt/NcyZ5sxrgyKbFOh3DyzIcwx3r2V+YiOmsahTrd6vwkClfyg8qy5eVsEgxOhSEt0y/W4OU2SSsFkTApQPqLMv29Ex31lGeS0Cx00tvExkkcXJwpO7e/yIo60eFPaK8GSxEOPdXvpFTf+DNp72AlKm1YJJyDtvMJaX0aN2j8B7ooPNmy53yzwVRYlrzL0lyQuquVUTeuP051GzzeXzMck5unMAlvL+6pwhrIOe5D1tOyQqABfxMTnEKGu5AEoHrhgUbyyKRacgGqdcJof0z6OaQcpFIQWMVMXuQO1UpcMPv9nMd2605013ChbKv4940A2ZIkKqU2PkG68y6lx76q1vLxiAx1ioElCUyK70m0PiYElSmisZAqhWDSjWzj8ktDQ1637rQm3KohEkxTztl3g1T8TBBMxeX8/K+kSGPTtDkCfOoxVLeK3Z1Q1XGivQDHqDCeB1I4ubI/GeJeppyr5/lco5QCJxiWMLUPDbptXK4GVOLV8m5tMEKJ89ealBIU8lEuINsPQZp3ncdCdR+iTs0Zgj8JIgEmjmdUe/A1ZXoUQUzBx59QBK8BeQl7lrK7P8aAawqymfy4gCBekXilGdwQQRPooKdRxih9zsjfjR3n+xZk6op7yCArBY3yjSHhVpCwCGzOIjEw61ob8nmXZ59VVyiKsNxG0brCWQBi6zQTfoyPbtRXt2kpikzXJJb2FGVudItSZv0RjsYC1txAZMUQFIkfhiWQtG5jAPonSiaJNCp93gF5I0CYfMFh/AggkVDsmj79GAE3ayobM98dR0BU0i9S06Yu/s7SPx6j0QLIXnZyRrSrlFrObIJl1n03DDSoNR3k4G5s0Cml6gNx8c4FxMgwXQ1vBI6KJNZW8Cgm3XRLT2JHrJQfD0te1fqItItbFLvOVj/+RkNRKZyYtYBr7GI3/7zYrjhq+htqXLjXotDbcdcR6uNHYD7h/vVRjC6fMNzHC3p2U050zQZk2/F+ZbbhcZNkJ7GLNPBc9SLawaiRdWiTuvaNmlfufmzzMtXcScfEmutCovCRp0fBYDcHavoSoKx+LR2m7g2AhKPt3dHgvQkoLtCJvVYA8uwpj6nzUSen6O5Lyqo8vlTcksXV3zpLgNSLceQXCFnNE4SklpO8oNK5+c7Zi37logGTiRwkUne64bEU3Kb92aOzOip7RO8aecUdYV60eeWdiwMTkPANeiJRdwNfE9/pITFBbTSgu97hzqUhZ3q0CpstrLbn0KVAYEM6gt7azYq/j6j56ZWNw4rjG68WzCmEZgheIA5Sojyjw+N16JiW9IKwMXk71ygNV+Z+fz2EPSoRTNEppp8DVBYGnInOmdx5LQGW82cO7wrhSJaP3vVzdvKU8arbhJzVmpVT7TAhNR3wZNH1OVH/8vHQw8U3fHYtPXDvMxkC2Of0qN/ftIn8auuCzVdmeLBOmqKRShMLDZBozt633o40Jz9Cpr3tGIJnWT8hvKzRbZSMW//q93djhr7raGxi7m6vOcvu3YInWD2J9htAReTun+HnXhf2w1D5/NquJnO5bdH8Xkuaf17FoTmNtdf4oIuATOXj05EP6CEN1O2qKSlIeChpibalfgKYqu04N2eNpMMF+DZMsy+DEheoRT1l4d4hRLJibcOFJcd2ghrUMbl70RK/i4ap4QXpu/nGfsCKm2NuhYCFX9+Ax6KIGbdIBQ4sMkiaMZaX+WZuknZt69+MBg/lQKLDn1djQigjoZiWvWlAxfinyccg+rzLMPTWxV0BtsMoUOvOZ7RJKct4A+qCRwIJaAsZhW0IZvi3vpSa6fye3C4ybKguoGE+8nzrAyHiQAzwmY5wbImTRRNWU3hTa+dOmswEbpC371bI1uDCmOEOlosT3/CUMT/BMXpbA9ExjZ662oQQQx5JHJcVbUpq2erNGvZHXY909MTzbSRqyp/bmP4jzqbVZ3P1BfYBa5stuznYGDIwTi9XgrLjtWh9QG+BQtlCkRwOAkOgR0cr6MAtvIG52ctsTVH+rgM6cyvrkaKIIt1/YOzZfvRbFdjMARsVcy0tQ6ziTqCp1/5sWZiEU2nbUSgSvnd/9KLswZgRpEghOvzlpfaVPNyhvYmPxS8X9M8sZlHqUbj+4tk3fxEUCduqG8uxpcYFxu86JEi+pEJOwTyhV2BFx0XwbvJxx5RLK1au4PyuEeyXzFipaSF+Fe4ijfsFG4f8U2hvKQZ1F6bk6ZhkKyN0eiqC39Airgp4cc7XjvqMWfQ3cViTGhhh0W99S0mObwAQFjHJBRaFar3W2kD8ktfl4mxjYiWLt9n4x2Fmg52MvKQIst9Fpi0JoSmBAxaqIjGLU04E2I0ArLRp/oUaVQN23pxArPuNkp54m3N5TXyJ+gHHBOF0ytdVgg8gXagrgoQsi0x3W/8s9vUCC19XiItKFUrvDnciPJVH2q+JwLwZG7nYORCoUxEw6sXySVxwMLQ7fMx5N0eGxU2Wj5ARug5n+FprrkElELvm8wIMYCbLddVfl8lvD59oJ0Ly6mPizcqh1wN95azgiLdJTzsghnevKnQdk0cbibolGZBphNR1pZl2q6s5UnHtUAs0KT8e53zoTvbNMh7eFByqnmqJpXfjPf9Tx5Ckk5vB/hvvgaph+HL1TLEre1GuIyGNDtbpf+gJibM2Z1UtQxjiwhMG0ajPmQVuV8GeIpJqTomO4MNCKs6jZ5vNIYJSVLM77wP3/cHQKZo2gNa66rw5ExauJM9TVxdA43AAPLZHFY+itKxZOu3ohVy04Uj1E7TNxrLeI08n4OdFEYeWWm9Aq3iGz+TH3q5qnO7MO4W/TBhFtTV6X2mRiNnMsR9kDDg4/r79wHnftXvXdooRhfsdFRVq97jl02RiDbzq5J236IuUc8bdNxegYbqrFv5oIvTfADZEOxPtoaG3uZw7lCz8SSy2B0lFvxLhOYllNoGeOt5XTYeRTV1VyMCg1VYla57dcpCHovqRf4lDHcQfFKn2FkfXWoqdpeQtUHA9Wj/cX8za6wgTJp3ILooWJYg3phvYBeeqHok8RxHfuSTWi4qQuiVSHhal0rzQPE2rZwUuiq9PBx/BC0JMfe6AlA0mTJ7JoZKMSItydbmfO1wzjnnDsnn5mhoD0ZvLj0J4RugsCqSWoedEC3KqR4HsHfPs00jrAFZLFhAhgsxuLTafNkQVxTcuA3xS9vW3cJ+BgeJ4xGhtCsunu4MOkGeSR5oRANpgXHECr6NmDh5KfJyO5t95ERo3dBi23rMtis+Qse/KDIZb4zV63jvYlPfL4K7vt6C+1rrAodnqK/PdnH76AjQRodmW91ElXwiMRQh213RcCx6A+S5a+H+urqPmDyIVv7/vndjgK3V6UCgunRZt2fEzbzgB3Ah7schK9/9eB4AXgjY0WVsxkQM/Zn9ajajdtfmkLc+j+Va8P+DENAG9y5FIhErkQdwr3ztqswWX6QuH0pmZqJjsE14BhCMksGDp+cKwzoSyXVZ0GTaaamwtF3LmEFeJ+KVrO//kMUPvXmd20PxsYW1u/84gj6eU2gXJFhGI5wvEDvo1xkqJK/poaFs7dYSE/NWaB8FsF4zGAqqUIqyXw1NeSl4u4sGF0OkEBOq4u6NA9vGsbz9Tuz+MfqPEZfY/3eg1UcJkoXVuQ7eraciYWB2lDimySPvV6BTHs9NGnbyC6wWT4bZ8fSX0qBbypN8HBVnd1BAzCglIhapVy3wEICCXGge/03ilaL1eKuH2cSo20Wzcc8aQGSTd9CaO+irbRHdeXaCyFwDtDYdmSfiolhtf4IHd2cuLkTEqnYUoN71NM3FTOBkG53plTGIzLbLeZd4bsyJdW65h4IQ/leVaxy5ZEMZWwYTnD1eHzPRq3h1jHQEJHhp8yJ/0g6R+jymYdKxU5JVIHidq42fOrK+mtR+XqLXgaOe3cBzxeV0Na6sc+OrEYum26eXn76k8htJ3+6itzNpodxHtkriWiQVZ7k2zLS7ggdQaitCvWb0BdWiFNZJ/UqbbOK0eoLPGfx46aF7P/vQU1NxrzN9RhazbLdIawVbBkmGR/QdT97HJI+2dtwICyUACaKwbxcAkvHaaRTl732SblXdvumUaTO4ZtYqMFKiHoO10wY+xytER7wpWYyOcAw2W2MRPv4U4QRQntBN7UKO6Yo0uQXMeqnUP+4SADl4D8WcxkUzR0nXBEnvtee0aecLK4YArck8D5EyO03+ImejJeYh8zeH9ypbIfm0BMqkgTz9p9QpM/Z8geLvbB41F5CDjU7eei2AkgR07R7lAuMg+kuCo4OCZG6IaVjXfWPp5vAbOqI5VUh7e6/Ww9HzfyYKP2d5S5XzPics3A1KxXEXuo/SMtMWF5lzYXA9e8XFnbkinr4QH2/Ys8PkQpqU3d0YxH6XvgR3ZnCAXp8DRzYGJG6hRuzbmyVkPv5NXWBRUOvbuwHJzTadJtaB+4G7E4/r73eqhlwBs3Nzd5fUyxVRZTJ5WX9cstgWFLaDuB6WiSP5BF63R5OOK46pTEoBSg/t7UBIHrpN4rtgo8qAfVUK/Q4+dm1WfK7NIraltuCFYkx9Go4ejRQHO4/bDeiK9k8UMJR17e6izNS5yrdSfrk9K7Ug7oQGv/Jh5NcmUjamfvHfVL3LAPbSHRGy5AQh4EyQwgBGEnpXapBHFOgFa6KpDzlI18c9azIhkt94tTCoDArlV5HlrBruEGEyWgCiOLWZz+PrPbdmlS7vN/0Sk9e74WPAOoM0T8OnbGJnOxBvcVTc85evosPEr1ICV4El0B7EwJ+TsU/UnZiQe+D0ik4v1tIBmOSjyYEhUFfY8F3Z2cdfxEsO6NbNfWOyQtC71BDxl1LbsZm4pfGXo/NSSXzbk/OlEoGrWLwY7hCLkS1hiVfqVyjZ9rj1k6rMohg2ouQlpV15wKSOIL8r8UIYgt7d6RLbSvotW0ocDg8uMsyYTmwAkYAOaWz5SKCymtYehBfbQYQ4382CRZLvkhYlRlaMV6Or+dq4EqmVvdXDV/0UW4KULaweOH0gaG55lhOZI1+7cDiLAOeR5dxne6KxZx2F254rBJci6MDqufrK8dpZmwX1DqcBlzFc1qWOKhHor9wwRBantRqU+x0lu9h6LktrvIh1LwsfxDhoUb28yLz5jMWY42MJ6/xwkyV4tXZgyhfh0wvOPSjlba5brAEN9u5/peqNrxBpem1TeVq94B4AjDUdIGTsSnWFqsd8HvMB75/+dNQKJVYSJ+46GXS5jBD7KMJ+R+ZSkEY35rWjnBoebUtslRTtTyS8RTa42t6FVJIbG+HU0IO1Usqu45+qvjZIvt8hbGCVqs7+vGEaL4xuTfSeRvj7QChVmrD59I3ysNPGN1gpp1Y1UvFdp0GZ58/Kj+bLI/WKD/VIa4JBOPj3ajBAc13a46sOG7B1gDzchR+JXV/ZbxG5qCmHb5GwR5NOgPmTHVw2dOEALeeYHEHg/23qysoLNZrsSgs3IP7bOOQqywCb7ODZ96OVT+gNbzfnsj4d4RHz8E2Re+xfGmAfyh9E4Nh0A8OX4c+zm77xVVzCDlwrdtjsKxv5ilOjSXliqmCaVPUJJqJu8iKW+e7lQW6AkpD+6hRanyiPoR7mi0YwQevQZzG1Ahun3QbbK2HkdKj+lsReIfy3RRRFa5tblYMK+V0spGiFbyqBVauQIXSBZTJwGyvInxd66PeXDH0Qy+vuchnCkpDm4dZCi5hj5C0E/O7a+TfAx27ojNTiIVMdFAy9qGUGwxea7tD4d9lLySz1aMit2KtLvRIe1tWbGQEZI6Nt0WVToIWefQSIau9gW5E0U5cDF3j+JUvg3z68gEgczQnoNfBQDOVMgxJTGqWY/ERs3heb5LZA2Yfl3FGAKX+LvRRmdTmbNQAA8D6mO6GS5X2UUKGSqtKUFeBus5LgNW5XRLsUUIh3gdR2nxXonzQTutnF2O4tdIAzdJmt2C1pN0AyDn5PEfqV4lHLGNdcnBkUEhRnwkUjTil0P+VdK8lsHks2Uc8SnoqE92EPdlE8HNTbDwNkiiMzEBX+n0aBZJZAgANTFtbvV8ns4/kC+anuBoN3I9+ZU2qxtPkweIoZNVR9islx5Naalxo7337uLcInxnj9/fztkEmQcrPsnojrHxg8VRwmyMzNWFsPA/ND6mQwLAly4MS2ZWOJ53MS+7bxrI9YesWQYAuATUzWRtCL3UA1GXoxIqqM+0AfBDPbErjTtx56wKD5R/1BWdnBXyla9UsQUI/ltrcyE3L/v921yEFV8qlNBdKVyJAXAsmyk5C1hNAqhfEnO4dw2BsGRqOARTTwGVe0z2867tivcYfAznK1NupB01GoQch2g3G16VXmrm9JTW0p6oW+UmEMHWB+my0PUCpZzaLFt0GeZkShLjDuYDYLz9KELXynHqrAqbeZb3uULTx6rFx/sBKc85rUBh+eOLUIrcDoEZyktix7G0jyJ8ge98bBVmftlmJffPC/c/plz5uoCOnih80SnUhSnfd33VCVabgmhLpXI2E+pbgortstKIudXBgYkQ7acFa+J9ID2OIDjsU4TIlKCopFXfck2zuWUCMb1bRO+f98/6JSpacmAPOqSQFNrpf1OSWiaL6Zf9jfpEL1kzGwFFK5X82ZbPF6l/2Z7zAEWmPNpLeCmttUf2/K5hAnb0pSCQJgAA0ji3ZQ1J9OKouxej0qgAAAAAAAAFlty+Zqwc3XXtyt6PZwoIY1Sr/J96OyZRvIuDHGG9FoeDa4h8Psxpcvw7xsstiTbbc/C6TIwkA9qYDoeLpTx+q1ngzyaJSn9hYT48rmAdEFC+jUhp3GW3FagvZ/96CtN6JUWG5buHYkUCX7lDbeYzJMMkFddW5x4zquP3R9WDN9FXd1o+WzELTX7hzDi0/mGLTR6+eszecuWXduV0ehMS1wjEebVBdw8+CCI090dFwRmMZ6ZqrUoOrZqLJdiYnyJGIFzr80fqjQykGYVpX4AI4RcY+15QfW17OnhfOERVzkFaFq8mht2Y2I4gmfBXIUsMyu+counzB1qPyOn0PqHi/0IYqsPIzhnKrXhKxkhOkTMNCNUXrR8TwigRrSTpWt7y7gUonEB0Swit314nLmn+18qyXkd4FQF8FovNBT57gpP77UA2inD4QAp3om4IoehaV2wUQFUIVZQfOu46vhm/olm9l/JXlTk0dusAI6AmWWa1hR7sa/OoNqdUxegwd325dArB78NbSsDCMUpG642NB3Q7F+eUcfQbmjOJA+cny2RGd75SLw7BiB1ujHl+uswC8wFbXSTifWkqnn4VwYgMi8IL18M6Anj3+kyg/pDCcD1yTOWt1upNmHwY0aji+ooJBasQ5WWvpRIHvAUbjMeUoWmPUaCxbl/K/HryDu421e5BqNdgTOHZHlqQ55+Ln8IrwLf5EueNosjfwSWbfWV+nW55shDJT/IPnhMKD2+TDOkqVSgt3K0tfvyRnoYvp5HIzVmZiade1iI01gtH+0IRa0QroET36Zvs3lm+Yz5mupqXi2kHN8xfX5ByYAse7rMBUMbnx8SwkM6Ymczwmn2lTWn5WUBnhsFFH2SMIMvpZxFgUdMxnLWP4VICHxGoOPQOfcErhZYN0llyraQ5p+Fb5rqJP9MA/cdwtziBoidh5KkGhfAs+z2YMRCdmkXhfkJAXSemeIu7Hs5UuXu3L9EpzsxGiiuDOmcLU70LhA6lYwZF6y7Qyk6FXlbVyTH9Nkbcw/spI+7rJNFvK8v79AeAfL2B1t3D067meMn3zKwt+HBN6TeuYcl1AeFdwloETmCl5+2h6bSBAL01lNSLYe9SOgNg2rQ1UTvvvDWtDFjj0nhjEE6DWV/71m4ivyFwIhhRtPfDVN5KHEMFNecbktPkLlSQKApWPXIdxFIhXgpnFv7EP65SwOTXXCoDh7X6B9QAGXM8HuT59M39NBZQ91SUSJ/JNNOfxrFpCLTZ9XB4WwYbKoGo7361TCj+dxEp2voXVLDMt5+ZRVjAg80tqPDyODiMjgqqdoRVnUbPN5uhFuH3D70TlsS8PeZ+KofZkMtXgoz5S75HBJIihslGLpX7jEzg4Q9GOFgEtq6VW5/YqBdoM6QiN112bPDS97iXSdk7VzCjarvKYLkBrYYrU/E783533HtQMXcI309krQ2BCkjSArFm4MKTqy9ACEq5Mg/EM0PDP/hAtQbApwu1/wBmbNCS5lqnRs0KluqGHdpcisLL6wjIgksaTefB/0SzSbx84nkArpMo1k5/5fEQe20gOdFpTIMbJL9OoKC1AlCc6pkP8ugHnW5NuqeVHnUJoAkcyCt9Eb3dvCPTgsVaoqPenRJdSc4YV/WnX2Ors3rWQqz5TvyovMZXQuAImWhJ7xR/Kuss0sGcD2VV3OVZ4595TP/eXkmuruf1sn5IaNp9khK/wP/ltd6cYRQYEKnsZujDM72HTj/PQWLOf3gJNbANR87+ik52OIYwXC8NpKyBizBsvicOkDoPZwoIZAxwU2ul0knoElZHGtOjJFU4plcL6csebQtJOuhR9AEJi0309r6BwLGct7uTeiqeU8cUVbwwDFPQ6w0eBqJU9SKMvDxD9YlqJq+bdYsjJxhQuFcLD5pEDSlOGMNCM9HWYLhgsq5PYzXZQlydKn9UUfD2Ul5x2RDgj6HDJ+Lz+8NlcQlrsOb1iRiLKw71luedZCxwSjF4SPuDERv3p4jHt/iFLzoJHAgkOMlSJLkK7frVG2uibgOOodCzAm2ZcQhHAlhsvfnl2cfHubJYW5aoxHPTju1eG/vDQv7jyjpQbIF0bUHrWUX8adVVwgiWweYlqyPjtaz/kIkjtg6SXlw7X2o8dxtEwIq3Nf89ZuepTWgKdzg9hz1XnWa2SXf6SbJj3JUCLsWSFBBKBowy+Wi3+GqYT0S6LW3o1NxwJpr0gBFBtkb9pl3xgJiLdHTsYjtcfnZnYw8CLL9YEntccmLNun8AyNSQbvCz1+lyZkJz7AfJPRPW3S5CnIP0SO9/+gp3Ezs/jGlyXGpSd01OVDE3RcdgIcRNEtdm34/2xPORMh0TB/XSY1oHjrKPJFQ/iQcixu65H/uX4d+UTadh6y++XYZiAsTFwgg+iPLRsGrbTpEFTQHqIpvGAmItqUaauiw5T2YVH3ezbceV4GfML7WknywbNRLPt5HB/LGTZjKmXGR5HCWSNKyAyanfQNBwoh0DXXwMuLLmK/cPHrsWbd3w3p+L9/+a3cCIC8MoCRyTDYw2lpNdfNJ0VwPSo5fDClBNFQ+Z6hDkYsfESvRKQXaETa3BMCLxIqD79Ysc4Djt9yawpW7uYPOTPxLYe1LgV7iOqv3Xry2/kZwSgZyic9fK+GWQB0OhxNfJAaFACOIw4K4PxGu/kvFtJcy9e8PMcHsIRrmItD7ctEhioEl6scWcjq24izsTN2zSPvMHTH07WMUwO5P6YYoRPs0CHGMJ+XJMyfcogGCnBQlhqWPpVaw0mI5a8KcbH1n+pF8mbpumByZq8oS4aN2DWK/P62VjMvQYjrWOVPD3NDSMDwXCc0vYlMtHOJM+wFONLhbh2uFGA8dk8SlkoZvkXUq8X8KbcAFe00v2mGP411AmkURo3vKxkYqW2IfdIL3Wuk9nzbbFPBQUALcdHLqMjGNvSpToVWwAohnkqrrt4S5+RuKFruMa6xFrmDlsGRY1K12jQgb+VAMpOkvWrbFNmv0Wsxd5wvtCwH3gSURsil7UDg0PpRN8ZpMS+lAvuZFxp3NZ+5SI+p8oVE7IdQt81X9A0DROOl1UDgZRdypOFz3pOOUeUz41POiGRM1915Ze8uP8barN9g93zcxNHp3u9cGkC9/OHAnpTjPj6FIQBOOUiSlY0SZMDdayWQkyzjrZCSijhfHhB9qeauXj76N71zAVMSg/85m3XGJHRrqo7LB2+9ocHmB3bVV95z5/sUpWOoZ7x9vq1dnm88UgIxTZ1nLmruqEeRPYSG7fffphx/dD9I2JZF2/xda9lF9JUL5qQLG8TZwOw/7yb6pA828niExb/IYG/Ej9ag0TK+MOxoriIxmtVxG+YVn1vxzRb4Pxx9l412J1FudAjxgO/JyRM/2eyNIlLZA5r7+vYKSRcgki2/R1CxU8hOgAyiS8S1bLOR/3R3YNwar/mzbpDJxDahvI34TLVkQHOgcQGJ7AqVLWXItjsybvrXOKSwlQKOJ/HrjObiUD9C+HOwGN5sNDR3NzW/XYN/ccZl5DgXIkPM3mBkxMTQUk5g+PTMf/OSV01SiclyYBavX6Cpgq2X8bIyZcUX9nS+DEbMqUcTdjxx1OLeSjn7kMbcCf+jKF+e/Q0u+4n/dHCY7Fa9AaC6agDNpT4/CZgfa3tFzBARUg7+9hdQKp3JwTSR2JdNxihfGSmPhMrmnyVMYhOD8xHTZI1UTtwKt507BsZyBKRV1XPETtVuLpJUhbFB/xVPgra30f8CMCR0f1mkTu7xM8iQU/uWhORVT5J4HtXb+4vfyVtX937ATjxQD3M9UMssVK3W6b/xTK2sbScMOuXLFt/qSgxffb6SJDIXspfx0Xqlb2QpAsWjkjBoUKEt732aE4jyvYWtq6+2pSzyU/KYFWM9uBXo6zkz7j8EaM4XUiS4QgTnaJEODzfZUsSC0nJGh3deUobZecw4XXggjTtJcIiJvlBYrxPzfFRTJBsFb/6AsZGSEOI9UiCvxvR4BgH109L+R7BZR+FYIG/NWAz1JFoWKooH+54JNyPLe6rvfj2KG0stdRQwKFGlAToVQI38PtKoZje87z9tqo16e5N5Kh3mDCE4yc02F0iCYtpslJT3HPEzNsp/oh1N+d3EMheR+fU5H25JZqSlf93GnTNrFiCzymfCIeDRJZsp1eAWWmMxoBT2ajQ+jxHADP7H+Q9CZKPlrPgKUFE+2WUILBidVzCMPzKNdvYXqm4Qywk4MGmdZyWKKOciLSLMCeRAO3ZrVsmF5+eqMbpUhRnSfg5kVDeeP2UGpkgdycJd49+OuydpMSzvhn0M82DcewYCsBRHrYEOVKy9nV/JM0kdKfuqRKmkJUEuzkUmZ+emCOLWUwSlMBdbdKA4TFzO5EGD1BDE4FkOGdH89dcgIPGS/N5VIwwh0P7Y3NPD8vwzf/Ut0YAPHoszlngwJTKjZQ1MJaN4hjBYhzx715Rl+kNOowl/wVkzZPOtKj1lZNM4Fj6nI4KEqHi5nicIONvUEWLAE5cHSylYHYSYZ941dELjvu6htPx9UT1sraOXhTRqlSjttNNXZE3qXNXcsezptOkY+EqFjEPCDgOP7mXdGbOAaAgoodZGn/YnnxC13jKcwpBypi111qTAAflm7neK/I3v/bpi1xQYbc1upLXf9lVnlEm9q9k9cLw6NESd6XPqOe+/PVoLtAu7syPUvqhBah2SvPzxjZnqGX9tL9PII5nMNVkeAxyyu9kWVIrsHTceDwFJpdddAdE9RRaBNDoyyQAU4gi573bMoZCtHLZiMhqsLf+/fwMeRQ8E1LY4sSBF8PsdLR3IZ8Ime9Z7xx+xr9tskIgJwijGMaa+QFRuRB6aQk/I0K0HFRqPYdkoc31w573bLgLX/7QH9Nwd12usrTyCeeVeah/O4xGcxcOwOj7zYsl1HATsdpSehson0B4d1D/UqxxUKsxCzd0tPmKSZAImAPSNS6DdcKBx9kS0wIP0CrWZX3FwJY3m0LLntwpH7VS6fG+yzjLifRe1IgBaZ/fuzDEGp9a3cUxQakyW+kwp8+iTtjh4eXKCQcHWuwDf/9nCg1FB2wargvQ/pWNHD8GGZBl0nJ+BP+Y522WCTU/8nuSq0ySZ9wPvBk5ImxENALAG8zh+YFgjdIpwIvA5cgmj3Fgwn9yKPnLi9BKr2pLQVr2smIigubGmohmphPPi2f2JxVXDaPk6Uo5VtPbmQKtEsUnIq3GfvAI8FfVYa0/O4Ftoc518FJpRfl2CXGpKREee4voe1WIbW9HHBzwlitZ0VJDd7FO1ncqteF4p0BW2LaF8AflxJ+RIdqagqHPmacwKfxkqeTaBcOM0aRq1nd0ISRE+YPFCqYcyc0kTtmxzPikPvLq4U1ub0lCDBoyk4GfrLo5N4MNwXtzd1ZNX6CVxwRqnIYJoDcwq9E9EJn2yeXIAd/ehMLirDScYK20M2cM8UafV//01P4utSYMqYv3McNVjKvNMgG8R+mCoxmZL7PVTNCV6zZMcr6I3EjoydPq2HOimqcdMnEaf2Nptmxl5/85RqwndA/J8UPfHfgcs2dhn+8QAONQ0QMF9dJgT/KMq9ceK+HgG4j+PSE8SCFGi4A/aIb4xWlwobXIYM+JWNv0nCgIwNhY/ecwDGgRHifYfTyWXsFJKYZA9n+RUr7ZM/7rJ6Sazn1qOlBvj/BjWILO6bvr07mVjewsNsR67ZK1EmgKaef0nY0bqiF+MHCgC4rvLuBMBnKi5wPV0stqipJ5mYYaUQ682S7dxSyU6wu2R7BNc5KNXOxOCQvOVJw9vf1K3Mdcl6G0S5J+Hy4a6RiOKywrb3vDHlFpt6GbXPhDJOWecMJRsRPQouiM/7Wmond+19AycAt6LoHz0345InTUfKsjOffS6ahQ3EomjFXipnF9pEuFVKsofQh+AAArH5ZFnme2NMNMEom4SG/l8rUWsGNivG/7uj2cZXTsCv+wx4VAS9cm73H1yPtlyQuesn/sZV/6GN0NjZKVz7d3gOorAMI8lBQLeein9z0N5byJASZ4Fnam4vO71BDiqPv4CDyIW2/AXeCAMHDcw1ZKiZ5F7u+eC09efNPgydNT3RZy6nuZIh+FteONQEOvAz9FwBe0RNpc+tAeGir7uP85HxIF5WbKvZo8PBdHGitHewmjyK1L6LLuoeeO82l9HxtHCKppMkvyY9PZajVLAIzXAo9pDrtYQzN5rrHKmOwvn8TQgKsP109UG07CUQD6nNf8LZvL+ytfP/ubCIBDVh0wyGcjnc+HYw31fW/Azp66tZi/+vczrLMyKKajt9iffmlrChzrWq5RVEPk0tU4VnbFtW8kl4dtDaM5lxN5uIXBW2KmLmUFDu/NNISSGY7kRjJaDCnvlGD2K3Sb8K1XTOJp+IYe2+YitLLYMpWOZ5bUKUgDf8HwuC6X+Q1nN7aywmpK8lzOvjQyjlxoNzKVJxc7WbhohtVAs3mYOK1wKGdyOi4t6K8X2e20MPoxOkgE8+TApBAiHQo5EWacTbXxoAV7PMQc5kgAH8AVcDqWfW2Jaxw66GKAAAAAAAAAHzeu9MRcpLgDU39yKuNxvRS1NdBRtI8zxdZcWBTk9VZHB4FEhyN6Ow0K51Pnp9Uivv1bRivyhxiZZG6mHCseYZw/B83rTLTsWbhJnjwn27Iax5uxlR3ahev1WW+poVzqiIKAKKgVWcU2HSSvggrqcwjqWY8qecfOzgMIdP1tO96Of4kGif7PCxPxY1/uJbAgl6IodHmnN4zJK7dTErZ8unY1LnuuXS9qU/s13T+9fP8VSBpCcbuXJb3N5Fz0yTtE04lFexiseaHH4sa/3B512DUJ9Vm0xUg2EwYXnpfcIm0k34A652QgRztgxHuM57XmVSqHTNgbBEcDAWLlhla5kTmWl5yXxqIS6s6v2q+zib4YfwK3dhPouCtuWUYeh5ixt4zgo/J0fvV0uqjuXSde70Q561kc+xiWyssTfaiu7S4BS+tau8sYSnUFbormZMn5JIHI3FSUVDDJPnpMAc+X7kiz+qNtiDEQCgPutAJ5SZn7L1PR+qngsDcar85TSAsX7B7UNwvc0xLf1hjzYUkZQvz36Gr6Tfq+vnuSPfZBP3aPPMsyruod3y7PAgUMaywsWgdsY4RGrwIAf1n/hHX+DWumnhsZBA0+4KmcWtYdcOegUveJFhXWUt9+Cho8IvIv6bMvcx0wEdKJnYML0gbT8crloErCWxI3QAATNodQYGYvT+8qv4fVA1wqcfCDOV4reUjCAIdnUPA7OBuzo7Qsy1Ic5T3ME9mZzOpVwbldn5ij70GzMJ1RSLjeLnbChpmR6rPctreJPEmSo/g7H2ts5uCAFfrBef/POtui8QEZo5DTHubbDa15egIxlBtLixXgboToOtyUdLw1N1JhWP6BUjaeO5lK9QFBMiflk2NkeoTQVp6HSxDqaVSYsbBma6r40MbMiOgqrAjvZ6ud7St1AvXx6ayt4GNngPAHSd2WWsVZSoqu6xCi7xJpmrYGiwo23SkulsGlyRwy4qcvh29UyxCuS3O51S5o5yYjjq3UQwlO2otHg5YaXBxNWzisP/omzpGFbEf/2GEinFXIytm8oXsj2G/j5BtVPj52TIQieobyxj3xaUmpBavkDIxFbE1UabPFWBCxFGIJlC1zn2t+n4w7m6SvC3HeD8fVUAE+sC5WK7FcgLqQEw8prfcprpwMBkavqwQbeZgUhwRpH3ATuEJ0MQiQn8XmagpvoCQ9UGWrKa+Jr1bdnPhXbsFMH38qzgra8A1B4Lcejl7PSZM0lYG6OMjATfdFaoMTXW0EsHi21yJlJw+jg1LIYF/S33L1cfqXk/TPJSBcplO55MyKYU89nN+5/5Ne/hmTOAPWv1nueuhVRDpKoCg/7MG37dv930UMDQb5AYOSDSJAibah2WV5XdnNjJLpsLqAvFPDF1uZ1s+BfWOFwlQi8rQOMXufQlE3bffsFCEgdS7uvXQUkwD6KrRmsPhiLW5BH2uJJMh9vlOG8FLn96sMw14jz+0AxtlJLBd2iZ9bqMMFO2kmYEjAoLJ1tntmKmlqp2VFKgT05pWOzQnWgaETn2xkF3aRlA68Xp+57QCniRfRAh+M04WGS0xQNtzi5deYhohTGJ7ILXrFQ4e6nMe9eCFYDvHvfg0+6TJ27QW7ov9LTINArKvf/jjloSvZh91lPn285wN7Z7lJHiSY7PVP6xKmloILhDJvUxKiPt7BA57O5xjGPRrGEaTEDch+bhFVVoTDr4kAvT19tYebP1zvGdnniMxqXaQktWbMHv+cb6utzRXso7V5XTv7n+loSpLXQrzMO9zZ8O7cq8Hg8oNcOy7lDSJlfTQmk1Phe6TppDsFmDWGaRQBqUTKdl2rapeO52nmd9R4GZ90C3S5aDHiftrMS6u+0VQUwySsN8QJuN7zV2RbA9NSfmY41RB8kAjpY0ZwMKjTPAAM54AfLkPH1q8yXoGgO2+U5I8OAbNe/sQ2dMdWyohGlPIQk9ZiyqYYt3ZIduB8IVWl1o2ESPmGvM9tcUd9Wf5SqlU9ekMkmRQ5g+hQy/d0Jx0+0ggDjh+hldbu2vKlKKQ/yGk/+ek8RjyFWf8vf5b9Ad4w+6kDaIfWEYFNpPvNP1Gtmwp28iJBpx7OinjcYv0v5+TzG9ujb/fmMBhN+4LlNGQFSdo8OpOkUGZGrqpe2+bYPNemy/T1vdvlel225vI+bwZfII+dsufTip3ZQC7fAhrZBz78hJCLW4cuYDonlVido6GGSKRgocARvNpPp/7bEZjlVwliGfR/yOhKepMvn5iNhmRfB1WWXFIwAJD3iBGN0uEtZE78Dnoi8aCEvqkpgj2WXzH+MfA+qSysA5bqrLIXuzDJ0AvaBafopfXp/RNhM8wsd9c9p2XPkhnqoPwIuJ0NVrEk9uCdS+qLivJTKG0O53KzkVSgHZ0Egk6UPI3R9JHPpr3vT/BK/bEnBl0FphEegPrHTWQ7SVLQa0hjPAlRnvZSLQw3sZzYVL6VWlPlojs+E+zD7D1ytAuma90bIQYZoHiond29qpzVw99c1GSqcSFRlwV86ydwvVEyvaxipgAHkmzRK+n4YZjZS1gvQLZNrYhavo20Yw4rLtpb/8IJP22v4JwQRfTNdRYKFeF6kJbLM2hy7Aa1j9scmoBCtbTH51K/xXSq3BypurQ/EDmYMgmDcRmiLlbRJ6KGG9u/P50aYfaN4s968EYLt2yY9IFFBL68LSS05cPyX/hfE0S67gBilsb3KGtAiQ6e7x9AIh9T30EHyXXU54UckaG3qCkSsTXcs7V0c/PgYwVprWoImLqigG4A95eBCgHMI1IRpWrqjYcTVAOA5LRxZH9ix1pR2A/7Tlnm/lbOSB9pFTA7JC0jopNf/g2XWA8a//eVSQfkZ3c1c0S21FrUS3/4QSekKXhN2rcXrCOFNoaSR3IuLfvFPvarMl5/ehc1t1UvMca2j1dWmHdcrDqJSLZp+WoxD1yzqk71YimRGnwuBMJhtxAewOo7RE6Uoqijw8ZxknZKompazLKJvtznvBOMXJD3DbFBd7ldQGXOECJ/yEnbSSqjwGDhqRTSAmcE7ls/t1GqLbU/encwwF7JxsZfkCjAL5vVqjPhW5V3JfO9cM6WW5T80RF6447dNqcwrzOYPiPCsc6VJ/uyKrTNyFXH4S8bG2C+Jacl4gm4siF4kw2fAQzFBmKBaPleVvOuGCrl6CSxXPzLz58Oe/T0gjk2+SKQMg7TmuLaHGcww0Zc73cifYUcO1UqDQtxMmih4rHNSyE1ohZ2CcxlcVdKLXZ/PlYpVtY/fFOjgEOo8X52Gfp3+wiGz+7Nf70tOXl6/aAsokA6BzFWE+qyolOWjzUcixmcPjKhvaZxOyKxSkqE2IevTSrv3NcPJqhuZQwaY4/OSNHtRn1eYZtlfmyrN4YIbwVyikcnk68fXZC3b+I+ePWScJ0zigJ29X+7QSikRl+We35msSC5NnzxVJrZEcd22xnLj1lBzO7CU6ZEc3Ah2+CaIb6iXuPwYoxMHkFalPoW9NtDIpAGWJ9esie/P7RV4I1JfvLyS7U3lYggNQ+ROXKjmPORFoNRXNT2A59czNOgkpza3xm6iiTHB8RuPeggO62fb9VB2t2LKx23tuT3jJjrcPAJ0Kze3nsYBaNMlb6iSwHJPOY2AF8Mv9qgq6wCdFFCsAIDLTO1+onPESuNZ0yYaFDMGdu13P1bw8eF7sHFVIIQR7lOuHs6G11F+/gted41PZg59Jhlk72nK+jvUfUaWXUdpLkN5FNlnpQIvFPR592rbkui2+49eH3IosdDNb7Ct0NWCH+dvcfCoRioHzh/TrS4KVr1/922ULRovI1qxMkYlQuaIGN4lz/Wekjq0+XrZ8d3m6fZlJ9j/VpZbsrgPy5eMcL0xfAKFJT13xpoBl9F0rnW1rvNCcrULLitwmJvkyPYwBsddBlCx/E7dm4jE94FrIjr2TufA6BMoT+Ir6tuI8cxUmWJeB7H58TNC1q0qp2TGIxPV4Us/VqHL7a1SHuBoXv3q7Z/VmjrIUgjnNI4MnSVpwQZ7D3jx6eb0DNnTwzDJxWmVdgTvXHEICYnACsEXrys3tq23s3NjPW9JzgP8LqPF+hTUwiYCEqNMUjSIHHR0d7URrGQN2yLkZFlT/nso7EA6RstKJkIl3H/Rq9ZOgqrMlrTa98yYbmarYTp9pnpq4iIaIY42ZpvFju1t72w6Jx1Hzp7dFOMJS0dH3qzocaYuIfC0OJjucAiPy4shv3BBMpGbmJ+0a5aHNE4TWQ1k2SLi6/ZYJbWG6nGCyrE5H9ePnDysU836IWysmwm4NTm3XJg5YCnimZkG5AoO+Rigz3VwjKch8ZaKNl7ScNVXgtbS6IJkpqCDL5OU8U2p6P5X4phZNrs81M6uvTsgJWzy6zds8GApQqHtRpPn/jjkvUZdtc6LSfMFAhr8kMFEb2UaB8Va4lmdkXh79F4Ng2fQOAF4QNPaQB+FKd8VQam8GzNcemMQkxdvUvGeK6oud2Gm1J2OTcop36IN/X0WYfLi9FeL7QLzMdonSRmGXjrekQ0sFqVF2UOYVZ0PVk/7CFAGakW8pANB8HRjKBQSprS0CZZ8nVkHBLl94qOIcPyYWKVTRlWOKyFiea3zz4xI4b+wSsJtSlXPuprUdU2qbzJzrcQ0MuUP7bGbHbMbSiXWyMqSNTbxYm5qK/qW8OYQ46qyCE0z0z+6BcQV2sJE/xwj7fgy730svaWdeLFg27PWZke0u0lGZ87wZ9a64JlU73PzAYAseVsFeRJLCH8a+JSpSz3I8c10Wmqzj0o5W2SxPGr8aRlPW5tXUBTIEcHzvblQ7F7uAsGt6pFrSzgiT/54IsDNfJ9APf1O2Ah9lXARsbyY8jVh+zX5lPk4tJNbUT+uOvZ5AtoC9KUOta3mCKuuRhgolCHbfIRE0BWxTeMTqYYmQiVR9XD9jnurHKs3fXd9WPOp5Zh0xhmKTdAGCShZPTsnXeRP5srKcFC4a753auWutE6YwEXQalr4p4XgDDwuxFI/Ns0kxM8gjYl1TGBXbOddGgwqRD50O/Wj8a4Q7fVme7cAH5jPFcdWATO23cKmj90J29QzKhFhPMPrBbjiQg6DTmBdK1b2G06+Wwx9u+4T+OBd2OaIZGmk9Es5tKRDP/xiu50fzoKoQRBw1Hb+nb8X1tqdAA9XfYzqw533Ax9dNkuM9nPGsptBQybAdtXZho9x/QGIf7OcHoty6ZersU+7hmSRI387FXwtoUBqBNGQ7uYaagf/vlXy/vT/aCFf98PwJWxEw4QQGbOga3UIg/35AWmSoKxw89S4gs4/SBjnSRe0VkWb/+qejvLySRkgDZQ7IylNF3+rWRnHw+eLaPVenpr7sEZTiI0qTCLCCcSrv1cQWzx9R9ZLsjoQiTth5/xjX7pNbeXflaCYv7b8VvBjPze6+vIAOVUAwfJo0/gxh5/6NUzICQF1hEGBRKRzfpQt6Zo29xVEdD5RNDSAuPVXm7VgZBbY2KaWcXgk4Jlyfre0p4Bc6vZxRQ6rVmlla1phsGapkYOymH+bEM3kEUUVA5g1Y7GDZgICEWLXKc8EV4zU6/4f6CapP8KAS0nWPJ+BUY+AfZchxOPWTiXQUqfsS2yjD5v7dGcop07doBN5iMd2al4pIJWGxRHeUAKJk6ERP5jIS+HizEZ2yo4sWKv/AGaMhRiwaUvLpjk0jxzMwo/0QrDeC5pLJVRrKgJ2PdylLuBMr0PRUcs+R21rAizwbBY0+UqqXkCH3IcA8C2U1dFNUkxVUeeMkVQpt4Ihgle34S7k1zH0wrxfLbp9LRaD4BMbaRi60JifrPW+yV9tg3/RMTJLX8yIVNSyVRBI33Q1RlQeK/mQt5U/wEwqxIcGmBBCkGamiyB2qZaLa6HYsfIGOTxyto4qa7YwINFhV1dix1hf1dSXkZdDx6zvYFeQpvt3ofqRj/+dJFrebOY8zo3YpvrFpwCRAhb0+YAFytQLGuV7cnz+i1hVuIT50qY95KsYp2/NvOVYDBAJ0ruRMwfzoIo78mDKB2iL8RBNDBwew3RK8JHHhRtqF83yvbTQhPKAZQCs7h+qM94Za/BbBqkOYU4+Jst86YAChpf0lZbSn12sAGEGgfYZ2ME/gAAAAAAAAAg0d0RWZUtIR7bp/40CxGuOB5Z9QFCfmphM1YO7dlDRXdSpJbfJH8ts9Ge+nNVBXA3xzwmwkwteSoY5hqZLkYyHApKNb48i++0iB8YZIwAlEjbsXdAVpIn+50oOxINH658CE3iE39NLL1sumkAnBV74Hmf3jdGjHzMYBrgfTXThNG4xRF7zn3BQqmxPwmAzNzHxliNISLL3YOlWJZlOwwQEVD0JqmJMJdridsWejFG+V+Sk/Wq4yA31Zxdghj1r5fujBmN3ow9OTPpby/Wzf4GByyAEzkHEf1odLYnsiW6VIdzjEjfv826L5o+n3cGPju0oXugZfOiZjqaykZmwVWuO52+sWVpWED5esmLWf/jGC6wgD06SFUxLkSobNN6dEJOQ741ApMz7ikADLS2dnH+P/wpOqQIyQZ/SLJe2Wyhrp/2YaHPV+3dvzzjfuKUDYg7vK3eRxLYynNODCxwZ7D1w0h/2xHRyT1NS72vV1w0qiyYubttTDGatIuT14/6bahxw95d89D/Y+6ECFLxteMqDGZrqWlfN08e0n3Zd+WnpyFaszapU2i+El1GxoPjK17yyo3a1NZo2T8STweurGrNrWohIEQt0DJytgW1DGcBqONl9t9ZwhUXIzPbOBkGWwkcEwJs6N4c6wvpZAFmRsR8hFOXCUT+0uC4ceBhawrzyDTGbf6NH6qPaGZ8LWxxZSYuehogSSykR4IyTktu3s46w3majJCR1kjcM641YQ9khPFZweR7SrxryqiFu78L0XIO87qGdcV4l5nF4AZn6Tf2QB2hkOFBg7SJfGQnvapwsMA1pSGiUw0KE9pShz5iFxw33yBLIpNvzu4hjrt2ChbMKIUwpYEFUKVX6JhK+mtZfTdZjMdR6cv/OLsTmAKJ1YTz+B8sB5SbDGGLRskpaO1xjS0aywkfzTPyywrbJ++yFWpuaSW205BHCUDf5JWQG0msc56IP2TECGGRW5XI+yEOdCD615XXn3DfdHc5Cs46WoGOXOJZGjY83kserl7h5QpzlY35STswSpt4X2BxpcpJylfzM7oRW072p1nHCeLPAgKJo0K7VaNL3xpgJjRToRt6G/kyuFZxqt3BujlqF0v26UfHh4DJhlt5qC0rfT2I3xrdvTYSaXWFlbHeml/+yX/znntNYwN5vAPl9AlmK5pFNSNab9QBjQBybBgLzWsPvRrIk4Wg97j4hFunV6PeetZI3sFUQw/m/eWmiQLn0EpOunwmukkiYhp76cQ1vECIqm8IvxtRsWtAg/liwE5QTxANbI5Ine/Ay7P4vvKxGgMwnKqPnioV60wGmgodLncJLANMElHGiVic5O6ClZTAp0CBWSGz+aOSF0D3BbsG5dfsfAerJUkQyaF8eGFAy93hC0e+nWnEx1dINwD0JkpUruxchYxZeOs85o68dlJbtFO40JVqE7CwMdO0+LEGbENkUz+3so3IMqfBKzTAjaGuudifzBXKCtvWL6Q2M+k83QNupcD0wYuRIP9TFibjNQIiTI18s8DI/N09actfqsuL/LP07G0Wlnh6Huc0gprDeSwfzLdMjRZpz/n4IGtz2nTmDd1WqLehzUkEqfQBqvMbC3HBFCvQeK7+aUbomu2pYofCovNiRj/hn0YGq4igrSi5Snf/RmS3mNKnv3y2hJx9xNE6b2amv7v8xjd0i1zbwP+PHojvp9CXqMfG1rhpvQnKtFdjI8xSBEcP9y7CY09SIDSnbl64hhUnhi9J7DTYpQNupe6FiEzk2Z0kxmQJyaibkmKtb1Ip8O29UQnsF1K8A/QJg7KlnWGbHXG4euLOvYNBXUMGW3nnevx3+tiB/6gtOFqroh9xKdt0fwrAhhDBa271TcTAXPrPI4XQIiOZyMmnHiKhB8oaNszvGxjnH8WlQ3oYBrMRSBHU0ELLCNBehy3Brf0DwXcxycFvz9FH0PGQyQ/GAwDJOHOlpN7RVxHjEUKZ67FDFErayFCGfxLp2kCxVbSRIjrjQ/LDcGCBobtVpKqek0ol2zpt1TF8h+sqnXqsrrDWfzT3k9PW1KMkFv9UfZD2Rpkug9wd771IbMTIpys7d2hPna7IqnD3zBTakjjfdf3ccgV3+GfA8d9NRv0Q0YSN8cXAh1X3CSX7e8VpaEeIsTeipJUaM+ghPp1/1AIJRN+twKlr75K3LVBhfN3+hxp8FB8gaBfONzaCcRCiqvyTcvWw4kOz+CnQxbHuP0ADslkXz7pK8K1/LRyBMpPp8pHfbJvfpcZoIWRwJYXJFX/KbIMHEPOkjDw63ZoDdAhO5TaK0RIoeBZYePRQeqlZee2iFDxbEZ3CxwQbVbt6bCTS6wsraI3BH9FLqP9CP4dZsUkF+u93ywJbrgLkvVqNwiC6pliEtLlzsSzaz6yzYTnGHj765qMlU71T2p5fhsfs624JpG4mHcHa/njCbAae1qLCWYydgJZTXPBJT1fSRLKdgryVPmdAlr7+2zI8fLp8J7LZQXBv3FliiRl3tVy4yt6YYrAB5nLPbEdnQ6WISSWubq716XLhLOHSbajwYI0kuVYWhJRgYLvA6FYXQflHggNZYmAx/MiJuKp8KA0OQA2Vayr/Iz8NoJOqzZWRxg1P7VE1Unbc0UJuF89GTL0FPqTB0STW+1qJzGI7/6uzhwHPM9Z/Ho0awLtLuIBrj/oT5RB7lPCBpPihXKMOmTUsEpdY7I8wfedc5h9fS4L4wyY2QRqPDvVpwpx2VZbqtDi3mwPd48RIEmvdkyabfctazo++CfW4zmEbED6g7QTsNYijr4OfXqATWQkOEqIHOWRqyHQud3BR+4vHr4jaWIFaLQbxYx4i/CNEsrv+/YChY36iWxUF3LHiGb2nA/GPUt/LH4+oyBj1Pzr8Rnafr0s0Q6TaW3cjMyd6bIvLm6KLOaPsRZt8zffi5JSOYPw2AImctFrRdi93qartoWC5AegEWAfBzj1y/APOOatX3CFjw68kFAdkaI6MaVe6NkF1NIxWH1QiTjBQ6pVg/blFtAQ0opHFLKESr1EUUzYXL8BYX6Yj/RNjYs8sUucYTnJT/0qd73R4u7zGpGxN3kiZ+rgzqbZjfcvQ7zgZdA8DLSzNfOoILDUFIJN8hPMxPRJBp+SD4uKUiXMqsb6sa7rHxss0TFoIZgyvm7IR0lQ1gTFOB3U1CjigbVuCfygnPc51DsIGOUV3meK6mx9GtO3lL9hcFz1U4jExb7ccLIxnvDbVwBfRmulWw2O7CV6r1qoywD2DrR293VNIt5E1divvAbfVslWl4d23ZdE6+OLS+KPVKKSltxF9UQIgLWfbi1AV3plhr8BDlAPkstw/bwiDyk3ln4hM2+KCp0i1Q3Rs04vfSUkCrqHUNva+px304+mHxg1Ursd6axbQLLm7sMwHlhPXjBCtIrJn5YuObgX0oBw3Z8UkMKoN9UtlghXg4o92s16oY/s13iERWwRg7HxtoRFg7p0nfsRI1mQVH1y/SQa2+0k9RYaaog6L8tDHeTbpPdju1GaIb5K58k994lmKi/1sfJNugacOUHNw5KIcuVoTNeO0zQZGQ3FdgFFfNDY69bjptFgfYCfM191h9Tz4iKaF40CxGwJiFEuunHyVtDkFsUrUGU2tTeVAG4Xsdwokh0N75ds6WSqtIviT1D0hPKzykuXdOzAZcw433em0yF09Artoy3K8TSxaMP85w4USk5AzI7Z1p7jIAaxxuJ/yC3FLJB+/GQi7F2BdYX4/5vo9O43lGM8tGDWRV+CH1OrwUCG7idEP4hc/Nh1gsoDFoocqa/Fq6jWWLfELEDSMFfWy78ZTqi/YK84IBPmZlrL5AQDn5nf/jx0bg36RsotQGJpKT+swxunbJCRcv5IakZ6+tUVFRSCf3Yw2u5GW0BsGHCsftadeOotdOpfcs0InVPXT4Ur24FJU43CFF493Q310cwPw7WNJz3Q02YHwWKrNjbu3MYAJRATCdjkifYH4hPHnMAPvp5JehHA9Zx2iY7sUNCVrMm37FxXHjNVe71A95RNOtqzuT4+UG+fnhwJTUwB8fD/4EpOwH5muuvAryb/ivnibSimtMxmzAVRcFkLaD60cBjOqOeXCs+C5Fg4uwZ/7sc4lqNtQYSIZy5KH1ebdxJ1IWuUvvhqeiPJfncqh+eYhHgY4XW9ftOy/WYiY/7lmAKLhtg7qYuJZM3RaoMDYKPxc8k/nmlDbE8VGuB3IJ32qiWBsPYxJZgCe/zowNj43/BXKmP26CalqsIvAPb57gXnP7UlbEcUeFxYsY0fMWyU7vjPzXIxpXqnVk/nU29jLqtgYrCCWSaB7XexFY0tkfUmCtD+Bla+geF0U56GCZmvGGTyXs85XZ26YEB/f7PgfEASy3FCpdufMsQOMZ+FyfwBy+oNZeaJToyOztN7/MYAM9Rw/HuXs3Cl5wDNu5WYKXAx9CQ5k6VQtUyAW+Nqg5Wyqh/M2MW/cmCWKsOohQDTz268QtsJ/wMhNUP5IU41aaEyA9tjIGZXS42z+lMag/83j7dqWM0iJiTgaHqEeDPMEF01KO/7MXsgSd6+LzkYM2HlAnZ2/P95SE4HLZGwOFFOApS+Ns+7gl6RrTOzofjVjylo1WBZdsLGdVoBTdEhrd1/lUYCotihv549KSQRN7iBKL+h2QWR3cv4htOMV9ho/oHXtPD/V8Nk1N8/CRyaQHxRvDkXrJq3aUcEsTPsVEeMj8QYcVBDYL4XVqYP77GsYxGBNfI3UFAWWu6SQR1LOmDmyitp9J8rTnStQKygn7qKufiVNfj7yxU5PO4Kz6K+NdhHh4HQq9HkTh53tggKiUwBSLRyU0lPMBwU34/AY69xk1TwpVC3pTm7G4c/KV/DrRux8qyGywgvn0/15TQf5wpDafsz9XkbUKMdFMzfW/eM6DvuNZF0TP22lO9Q2UBDiS4XT5ZDPHcaMdWtFppydpi8vLTNSSCTLhToeQ1o01o/Ml+yba/z47qn26BwZv/uuRakGfUd40ppfWd5lLCfySZR8ft9zZpDEZylyLcSILdmOUVvnw/dRmAjFb784tbQLkNTzItDA7sPlJaVWKzzCb96rGxHmQyqPncSXncIeWuoETLfaZd8NmhlHodgblHY9WuC/94GMQKm0R13W5IAEV2KbFoDjndhEJwVCN634J7H2myqL7oTGrQtp2//QBSBdDG58xEMSUpOrjaU9fPTZZunu7HsgVpUWyxXXFlXzY21EDlx4Z64fabKpiYx8f879AN472NlE9KwsjEuyUT+JCK9rAza9x6zBeyJ8ftjU9j7TZYkK4Qol4a+okbpn77uKR5rtR0arpZMaBGxpI/eGR2kDiJRTzip2GdpfonnqU/uiyUQVuOnzy8GGvpkOP3RrCcG6eiwK+DTv8i0Gb9iiF5ajKEn1oxzMSNnjdgmhjlw1nyc2icBWBpG9qLUjQbarGN+AkW4B4yLou56yQd+ABmzOEAgW8MFivPTbkOTp+ojcqr0n2FybHmK0tJjEvzWEMKm5IgMPvigy/Ep72lmvDBTcvqrEPO0q3KbY1M03FMV83a7jJylcO7l5Wu8pOyFI36TJkdDrCwvlsVjccblCmkSQzp2Qubc1TUvcEt+I2GBLDkHVbW3k21whqUC5vA5k9TXnut8wySJLHMlnIYRxfw+wyAUV++iGPf73XZ7a580UEXWDjEMtZbZXmiUUH+AxUNtcf1bk9cCG2yiyTDqcLC8AzCVrGyftenDO5ofJKFjE8qpZXnOa1JOb5+zsP+U1/fk2rryk+qTsb4r9pqJN9XkMtDFxnCqFkg3M/FSEp/T8C47DsYfWpOIf+hwkxA2QJw+HDmIFbci3x9k3phBO35Wf5EWGosSKx8fhiUbgC0Y7dIA8zpMzR1MPoJwSKRz/WbzIrNF0yAUVyJGVu2j162XThCRcZPaK3Dejei9SwHo4TjLLCyfRAH+pyDEv7WlhW5rWZdyj/Ow98Z0jgwWkz9CeM0m1oIMj2nK77q49wPwU1OBOrd0RZQxCWaK5yVvmvlhOjEAJk+Gc1Am1Jxh0SThZbWgX0ICdkuC28px+ethiRdGTBltUPfeEbqmZY0GCP1CgHiz++nwFfosl/3Z/Ucj0kXlNJvQNcu1suRaK7oAACAnFkc5RP1hRjQcSkMDJabKAAAAAAABkybBzC8BbK1cYk424uBeAUel4sX3dItphPS+BWEIUuFNcpcAEVIxCMqQ3LovhAeOKeqtkEC6KiGMXqtZzu7UGETXZay4zlcxisodpf4QFANhT75hhShyn+kOlliWubaGCi5wPC9lMcRpqpOA+7KZdexvT6fXdfwixjoNqLV2a5NOZnMG+B4JB7ARK18Fib0ubYjHX8e7i+5/BbANggpLmp+mok4sWqUdYp02Ct8Z29xV2pl/xK545oxMvkXChG4iFoJYJT3xQKLDn1dm16xEMAfgK9UTlHCYlZZojKs7qkNbHHvRAJTtj0OdutXNq93Xit+ejFTYJGoNAGzD/4oq90R/9nz+gu6SLOJ4/x8aF8fxT+wycpiP0Q0OHLqo0svS2/CptXTn7HUXpMj0qfvZpfm0NlkMQ9Pxp/6jZ5vNQLE3XK1a9CQACXp6xOLHCVRS+cjFmLul4DoyOOzv66SL4KaSifHdtf35tYPP6fx+IuVzaEoDnoevL3snqH/M4OwEorMDFzgLiwJ59Yg7Im9Ue8nqWn/lPRaGQuQtds1R0fj+6pqI+mwFPnleLrEhiBXPYuzoZWYqFfwFH54yRreVGTjpZzexHRHJ+60IOaO4esOvri8RBgYjv6EvKTRZlbWt7l7maaHLaGFV242MxGMMZpOu/4B9D+eK62mXKf3cRVCRz7AVg9fThU4YuNtvbGXDcbiMcSv6HChWHK5BUKC9MwHPA0kDu/3j6JE2/pJ9G0NQupB7hETunRP7+GtDDIhy+R23XpmeBNXrFSfWwK2rjlu4kQV5VEubf1ax9uithkYyZI7oQo1Feseln7M379qMmksC+Gz+LUBwismYjsWGZ1Vxle63nvhhkQ2+WaMF5KKyM4WuVlAZR2/bIziKCJ87roWBhVoaIM2/CFgwMsEPIlufaGTuv8JyvqQW9G4kAxSI69mxueIQ/8cMCKzIo2HbJltNW/e9nYwblBzDDtFvripc4LOqZwji/HdVOlWprfRSDGo5C3B7S1HrZNgZ2UhHs+iXQp9yhfiJ3YpM0yDBYb/0Qa/40AOi+KIElKkj7k9nsxPmBlGCOFfrhdtiu+lZRSX+nrgBC1WvN3UHrP0m2qZXYp4qRZGsd9sMbbyHFLZNcaGt+biL1f4D1CYUU4XYjfJ7m2fPT8KZA+jve3TYYSzo0YH2jsBlRlPGh0KPjFvhrnuP6bKrB56efZ6pu8ihgBalne2YqQcj5WMHceEhK68bDUppKOq2ts+GLla3gVKrhYnB9bopmjdy4umJyAdB+c+Hcp1SIUWYFRN7rCVRY+ayWEg4jrun08XHiZm+nR6eabH7G0X7UBFlAWYgLVTmieQgrBI8ICigT/7DFt3bTaLnhr8RONgz6Lc7MGu3N4MQf20SdvMFOodNxlwp/su6nBWt4JYm5AGhf2xSlqAdeCgH1S3gszbLmMuq4MajkqsDQHqPyl7GgKJW3UGngzC5xkl576tfJTG6ulhcFv9uD0fkp7u5A1hWD+4+WuqGcF/UaHoRZC7ZdfGzoSp6spxx/H24FVR3YIgkiAL8SUF2hE1+XxnfXsbnmBmhfLAN6d3NBKvk9YJkJh7MOGPaqPKZwMfP0J/m6SXGwn2tI/xd7SmHqm2NExY0bHm8lj1cvcPVhNwskD1+7MqYRVTFOXJocpHiJjJuTwB/oOMtRBLNmar+xzafUiFUPKngVoMZ6gclJyS4fnZaB0uRZy0cDHSPKObH0gSokWVKXalU/Z8AaT00c7kfoT/37OGyM0rixH5k1C71GWw/nn65J0rGX3LGeGmj3pLKDFhJgFdgVMbABCXUN6Xo5xUkJGBSrj6ihbdP/GgWI1xxIebm9XAbO5DlAQ2ev65CrO0dvjXVAEk69KCpiUIAw6useAs5zIHOhho7Zy4S7yEifGHOu1TZRBAAKormcj5p9aofbbloZk/ibSAztA+oAD1mb4188XV82J1QZnx+TOcGoxxvTIuQbEN2cr0yYOC6CY0ZMFhQ51SXTbuDCMHD3PD6V+j9oYf6tY3i5bcNCSwmW3y0Epsi4pLg/YBkDBoaSWZn2ZjkdIlz36pgIBytebQNrseV+5KBXvoxa8mJD63eoenF/TcVs+0gMHXe/mUcjOxVQES7LUxZuK6aTiZ4gvDGVU8k8l3RE5CWcJ4aHYcXEm6nUOPT+M3F9m7wrpT7HpdOswja0Lw7qYIZHsBJBioqDy7jYrc7PoRXCDGSJvJ/1l6s/fkn9pqR7ySUoDK1G9Kvwxut1Few2VtcHfdGY4XZ3+7IEKlseLfFLQ0uEpDsyR9+5gDDx2YCAR5hm7ZkICczgCsTyj/uZQbPjFzD3d6cA2DFUSt2vkElo00/95udoRl3Y3P58uncv6O7dh64nO0nBy7TU1xwZ8G+oG3uv3Q4odyC6p3tJkgVpeyS+pZQfBwed5a5IJRTj5Wu09T9DCljaGLwnNHvUldRiqyrc8Xey6bb8nNGGpzl4En321x2owqcvAdzzpVhM1NA+j68rcqPlK8CkOawnJG/H0O9OqjlQ2Oscoaz+rtAC3kxh8E00hfBB5gXaN8nWIgNXMq4yvdbz3wNx/IGBCF/RTnM0U3CifvcsewD/0i23DLLZMrz5UsYLeSmn/RNJaGud9iZK+GekIiNM55G4YcDBU4CVgTv+VRTnCS84sJTjY9o/7my1hKwsPUQGTRHQGxySuLN8dHXBrflkgojkZ2JLdGM9dhOjLIX+NyehWGdb2AlVo3EoAXbIQIhAcb0HNJcS49gXPsKCnPYwA2NfZx8cQDr9iXSPIXyOSaj6g+VdA0nmikU7b32Bzqkx+em3PFGdIutAhdzp2Kg2hQ4ASDKPHOoGFKQiuvihFK8evOr16QiPB8LueNwcxWcoCetI1wTg7zoxM+RSSrf6fis4BSkZQQd936R6m/JsDUZENWJhTJMbh3yOyoFlBjlnOf7EM4m34fsw/UYz5tcUtbvffkfeQbMhXl4xbnrZ/DbE6oOjVZ1VYK2Q1tiVPXOn7r1W8FT3SgC9jEMyYjExocaTykjPKoEWgZ9ltWbVa+OD71/ZsIC/hxxFX5xMtwjKh8iB75qFDGF/mj1Hdk1WLZIGAM2Z6kfHa2IrOLEwh8eIy5H1R0aq3DbTAPN8sBvvFPvarMlYuliRtCgj6/koSz/qR3ikRXvsp9w9emWycRIZO43bAMHnnjjv5aW9iVxbpaCPEBB9pIb8lZolgmx69QGPea8ZZTKzr0vSDC2Zr3smkF+FKNsksuiVcCpOPd4UjcNGXvpPHjPReLkrPkujCYkXzjupx7SfiYKHlsNolBdaVPSxTbeKg4SUt7hon6pHQ37s0U8iv0it16X7SLUprIVk9loGrl6am2w/5ogdTYziDtYxtP38t0i7alCO11c92q43HTZCmrL6/zUzDeVd5Qp1jBPVU6mEgVouyEIE8V4Laf3zwcQLHe+5DjjnwCABhyawkj9lOYiBWB/29lXhk5xsehomE7oUl7NYCX0MZBCyLTmd70i8ESVhyRixBCK3/YZ2smiIEFl2bXD1yLcoRv9rO7BeWQUMqt4nEh2Aj5fDMLc4KMISUrneEGPAXYtIDEhQc8EsYaF5Qf6d09UQNb31jJOUK5FMbFjJ7jAWJ6Ayy+DABZLu00KKAYlXDiU89XCdiKE5VtXDlhAJuTsYmAa06QP6Smfi6/IOLP/+S3Tc76YjeuvIHlR8SUhYZ57sw1EBSNuKGmy4kFXTCef0M428EXlUkH5Gd3NYTwVbcGNlZEa3Sho6KEG/UtJydMoTW0qrBAizgCCOOFPsT0+wzTLNsIvIihLwhqLnZG7vtgYKzr0OJoDsaPKfsSnEhAVTWpFgOYtjrMiFxDD/ElVGAVe8mljOSvWymlYP1Afap/BPaLicsh3iWSS73MZhf6gHbPshB3LtvL4AnSFJMp/Hert2TfTV3gXw9meNC4CpEnL5P4MKKuK9NkmlmWgYWBmpQDJNaK8FMIYQC/zyxNE1R4woo2B+9aahZGiyMemjcp/454iYXOWK1DqWmnxgHo1m9Y5WJPjkeczD3rVl0XKjy+oJU6aWwW1ND8zcQR6quR09J3izZN3qHlljT5va8zducWCpoPp7RwmiEAKokVJpOk7/4h0tpPGm6lvBU/PsEj/KigrcqXnc3eY5aJXYo6A6XhxkmkFsGjOxxkqMK6na2o2+MkvQ0FKyO8jC8I+HkAUamwSs7PTcoNxxAhs5acyPlQXM/AIrbF+rVFQT6sh6qjbaiDIxAOIzOHqByg9U9E6ZwxKwLeaVsGYZ9iThjZeMoUsNOb44gt4rAndE/bsR2i6Y60RzFaBe+Gr0w71jjA6L18nsx2xmlXsKbjdEHFn9taSnZr8TKmPNYuyyxKTmKPYoEzehkAqJrzyuO6paLCqs7qCKAP/xGVOzfoQH4KyTIto33/LoKaPhsl+3GP88khc0UkeaecAMoy/Q6oFb0/LKxYPqeOoTbidQNlZGF4L++dGzGZegdJhx2p2NmGGTXQRPfgpxN5hRfCPpgxUDnrB0bAOPNkBSxgMn1e+Naaap4Fglqu0ioDtF9Xd0osT0ZzLz52oMz8SaebZurfZqX4UELdNHLy/+Cb8JzHaHxQCaKrH8QZi5dxXalMEPLe5Ne39zKPWr0XRimi3Z0wCqH04oWu5vFpEEpXKT+aUg//l4PtEB2/UWadd0arRZCBgPsyceWUA1AXqhRgqM98qi//r2RcaOs/Uc614l0n+Yj3HCT01+LexkhhLHCrS3/G4i/inEPdixvN+Jk4mwQjgiRLg0rq+43lvcchtnHydB4eObBOqJbshu/vKJ+udMgnUficueTHK/48Bj7uYHn28HWyHtsFJQZ0JeYykULyRl6SyLKZw6E1SoKA/x+wWf/abTPqpp0GsMQW8aer1GsDX9557UQLL58VUZyn1RXrmOIzEJqaQiA+SLL33pmjlUZbgTG0BRXPm2HuqdPiFppOuDBvwMnuIaDz6DPJq0+8xLZEmuotR4VAS9cm73H1zgbcjJPT5mXmvNlxYDl23jdn4HjuI7xZsGpD8dGPOluEmSRhPH91EK2BN/AwPSgnvn5Y9AEueZtwtanA3Ufz0p/BAlrX6FrsdNeUzae/GI4EwBgCDG5p1K5kiH4WZVfYAMN0Nc33E1/quE7zUXDjW6KAClYFHXckt2+Hs0eHgujjRWjvYTR5Fal9Fl4e93cClOmsL7wZyfIaE+5GBqE1XxiCRf+AGCr9V3cMNgINVYjEbrrHKk/T4k/FDTHcT109UG07CUQD6nNfs9mLnEiYbBMbUVNBtcwiAwAvXvSFGfZnHGxNvuEamjEc0G4i6RFStHPvJ660I47KvzsXjowRTFJhDLHxor5NMMaDhxX4aalIMrzjVU7IpF1J6OsfrCrmFZJDMdyIxktBhT3yglOl9//W5Xxm9zD9qgjtOEc1lqmotHgmnltQpQQZDrLh/kmJ7jWc3zAQBaMoNfhFYx1Pg6PCWOvP2dNBWSsYYBhFQKLDn1dbTkdFxb0V4vs9toYpxn0NO3bki41iSdU+xJYkLJIBPPkwKgtiD8uRE566d++2mLwOr0lo5W5GhH0IBg/TkABFefZj6GKxK5z67WADB90vEaOXoDAAAAAAAAAAQ6O6DOSn1EGmE8/jT1KVA1Znz8YZcyv65XRcwvXpz/Y0H/bTqwuZfXrCK4UPoLHh4xv44+8geNnTJ1Ac5pOD7hBY1LhbAHIwiQQcirdtjzKr7xwdfXfMnohZ1AbDqzSsDQX3QKzpHyn+4r6En8OSf26h51+ALFqtLHPFMshZbDNiq4dvjbaeze7UJ/4l/+mEI6Tdcj44opZHwGT11Dm1mb7bf47o5DcSRG6f+0rMPwKNQ1GGGxmqoxBJOcPwZ+qONapdx8yHjsy7Cn8qOThKPXJvL9Lx0nRoUmNvJbW/8r+d+3x09YD+LiUBUJrDc6wsuYawBhvbh8ZpNiVg+0s47hqUxhxkByxbyJsRsNJyFoY7M57NuaphY63Fgrx1kRnfg3R0znfgpPsJO+euKNpxgTT/7AvUWqDfQ2qZJ+wmkv4PibMP3QzfLufYaW/IQOk1bNbESn/4otYhc7kAkQKXBo7wjzJDdR00QDfHz5W1EYTnw5DqhPWgwC3Wownt73Ly6+BwPS5OhOrI5wmL5Hbu/GM6JdeinzJB4OuqmTNhV9lonHKhv5MWYTUc82dGTLvK71gaRDdv5xW/REccVePz6X4YVKs646C2t8YQo2WlId+wXgyN3XMKyVq/hqzYjYaTkFKf/k5uZ8o3xDpM4PvGuVZvn6e5AHaUxFPuZUPpId99bulFHfsj9529DkC1UsMcd2jzFTUkq6bcl1k0wOAS+KYL0NiyIYuHeL4Aok0sWaeLLlebFxIcuMvUYl36HjVj4cmgAkpE1+z/70FmrzOuuhqFxOjA98JYLIXbAb1EDlVyqib1x+nOo2ebzdVianHXbpnePJAJGfhr13HaJK/64M5w4QPqoE43EgTEo6CMGkEWqgQw4pGFNDmtTw1ST8sFfCfBneuHpVdS1AC64AchAP+K9+a9cn3FNVDs1Xb1WoEP1+AanHlPedWYDqDO0ONJ2mEwkw5TDy3SwC3DpR4MJ3f0b1s0NdAJyH6xquAaG7f4xdVZZC92X6q8rhSZe7/fzYK+pe5yVixgENACxr4WMPeXCdyAjwcBtsBmXZvPPzlUxLPCXRLNNTFn7H3k9qpdbv+7jyJ4xoTFoDGc1ySNH7GrHrA+THHquDGS9+EhBPIvg5G/KS5dKmGGLmfNymYu9T/ovJk1jM4vwTuUJ3R1X9LFK0ymS3yPmiAFU/ZkmyZdYVHzdOLr7wwIm2xlCH4O+58XZFZrfTHgg3fggisB6J3OzaZwod4qkJrPbxKrxo0cKqBa2kEtLlyQSSVl4mNQK3cXp+lzS2PrK5uYk9nSziLA/HshlnI826vHbR65fPWRW7NthicDCaIRbqF9y6Izx7/gJIIt0rQuRSfXeLT2D/78mxRu/CBK+6HIMWAjQFRioU6+YNkFKMNgV8tPSUhzkzRlLp6M2btWGwBXACzPiNRALn4KnpXyZnuqvFV9MEIarWRJirLXBGUCZsBu5S9IImE2R1Te0XeCBMjT9yEDVHN9cbB0oHsvFvul2EMcdmFoJk9xjeXIKrKT0g88jIfoG2C7FbvaYgUEsl2KeTS/SXuMJLdjWmcDIN1IaahcMi9nUMmz7i/hTrHLahIBTvAsFUXNWCgIQAoTmNcLlBZLyez8X1dyQ/cFisN7gnP4tHmRU58IQUz8ED5rNYKsjjo3EfXD2QpgQSwesdHUgbTmm5mcF2tnTjsepZFMH4iDQ5WiLXcvvYWg8KplQLs2Hu0XP8RPWHGyn688uDIUN4Ikz6MAO+93zgaqKqxyQBxVR5B3xdyGnr6kxakz7S7ua8vj+DeUdqZfQ96pmrMEiOp+RDY78PJsm3soD0ECS9XQpCuRbcEDuLDAw4+ysR1PKm0sddzOeDxeiFNnhl3wJfnOa0QmDY0ThiUVLW5bz79S9aY/uEtrakt01Xj6KjiL9sz3H9fe8PoEaLV7/GJ40Hhbm3SPBfZjeMkmYEb/ggD4+1FwTPd2oZTsigNFKfoqWP1ODSY+XtKRhfMrRPnidmwsDfAR+hkSEnFKPJ7X2ZQSQNt36AqwN/CgRD99fzAh8VNTlvIAVstImmlwsmzHHwz5y94OSSBzXMT2/NqA5fEvDV/N7vR29S2CLz0d+cZ6LPI326l9+BmbX7pe1Pq3sa0K7x4jMLoTilKu5SxBt5AGEqZthzIv6D1uoW1cFIWRSWL2hXVGs2UAnBcB22G/Cm9aMZSuhI72R6uHePzeD7RW+lQrMck5ulCZEvi9EKbRUEef1GrFa/A1v4JMgDezaM7S/WlGVXQm0ceARw2FmH/TEIHFysYbiVSrnwBaCr9GxjK0o8j8IkJVOERJhVU3DoSGqPyRCznPIzfSbVbt9v12tQDKARdLELLf6WUOfGVjuH8QoehcR6qjJlJmX5iN7rEH43vE4H7WoLhZsDCyscgdRYbyzDRjxfwfn67vUWGiHQwXEon56qitvwpHWr7QU3zh+NW2yeon/ycXU8wVBZNuh+rFVjdCzhyVm/AA+D23Zy8DTw0/PWtmi+8qQExqxm8SdBMvWkcSxyMRBcyN0BXfasWDgReXineMOqQ7eGqBPjNBJIm3Dg6t1Ld2Ncy4GQQl/yITnwILXZzdEhUtfzgHaGw7FKbQGgSWs/ehdomT1hgpw0WcDmjOCIaT9Y+stsBHRzEK3enB6yA4PuXiTty1uHAC6B6RvJRLNLwXCI/LEqqIvKzQTVp8pVsjHgY5W1LbftyxBOE4lRHLeNf4yQrnNGcSB85Plr49Rxf9Ymc9Fd1EtpggeHOjVojgdpULmFbSXw7GHkY2CmYIXXTUwTRbFWydWG2L5lFWh2enV5eqdEJIgLGWjkO9FZmksScB4YL7ejkZ8QfJ4Rx/gUPdCC9krLuYnqvTF1tL0mAxraDpWzXKU/rzGrLpWobE4ZfVnlru8FScNE5GaT1eozp6j6JIRPsIZM0Hs9WShgMkoycYBdLujdUpCuwcC6yZSQAWXyV93FAZKcmLe++GN7ZTcWgrYF16RB1nPDzs49KAWRlTiNCu1JayWd8TW2NYp2A0YGT4qQE6qYCAs8GCfzEyTpYKYpIZpH8PWnZ13cK5Bgj6n/oLAdQmwFv8QkBCAXgh4IfBsIIFd3yEgutBf8V8K0igIm5Vsu+9E7NiscrV45rx5zdSpL4Yn/tm/A1U4XAkM9GYaqEwWfmXDp+JAaImsJWtyh+X93DqESmUp7vNU73DTjsouwSvxN5iEGU9A8bV4ynQpBX8MtYUZylggS1EMZ8GQCE+K6Y3cwafWJOi+PVR0zBEbtfeFXm2uJ5qDRtBaSf8lWloNS55mi4znFWkc3iDEPh8W1yjSVrQP0ZXuqKngjtM1kWyrIaeMv8iI7tQvX6rJueP7MP5+WJl3qettsd3i7km+zfvdSbu8imCnVu7n5PMbz/aTDr2TkgliC7GYqtYjdqta7W/FG3jWoWHkRkaq/elecJX9bIXZxuTfmaRTB/4L6eNmrRjM1HRd19nBOtmptwf60hUZcFfZ9w4VeqOsX9xNWhW9Y09idceXy14n3igi/YnlFI0R1ssSbV+/SHnybgWoai1hVEfSncQDyQ6+yxmNvGQ1gtjryHxzNxgzxMOULJlquOwp0V72xO/jQLEbBfRl+y/B72TEt7OFBDIuM3AkgntfX1nMt9oROapIRoE8uJTE6MeMbyR9ZvEzSiuF9OOcT6znyboyEZj4FTt0AvE/oXNwhEIhNIFoWSJZ40hvprPBwM9TCvdikJ6vU+eMAkryf/i7WqAzbKs9BkfPcMhHtDdXrhqOmgFHACeic4giV48HXyhW0uYkXYvRhms+DCq/pwLPP9Q9wpqraBtJYPWQxFT8NvBbSWjqqcluwfrHeMa66wlvTWsG21ALyNY5uC+RajQuSA560fZrfEkHOP25vBvI1nA831CgXANUlXR51hwFssLHWDBixdOMwtZAHOoS1mNk/+HZ5w4ZvY/N79/UqUe8w/ebDBGwILIQLCvOD3XmG0KozJDQ0CAsCMd13lmIJTLy2SoGtUjt0j322PL3LG3Cyr9W2jFWk7OVu2A8k7jj0hu5izoswrKdaEin82yOhonL3wVFlPwgz9xkEfh9ZukPA3k7gQxVdJjXSVXLMUiv3pLZs3HmuiRALqFq1VBNPQQGdyI1j2SzE0K+7nrxfc5ZLkSm+RjXtTfHqQEw8xW2pmrJ6kBMPKLk7hjLwsM92fhGUqbXNlHUVV+0VkcszBlQHH1NqqN78F3YgqL00ZKUkenBiPRvzSwiC1PajUp9jpLd7D0XJbXeRDpjbUE3zhPRApkXnzGYsxxsYT1/jhJkrxauzB3RByU0HDfecjOADAtKQKXnLCdm0TIZ+gaAKorpUvclKJQjpsOgpZDdhNbTXCjU3hFCl4GCbadDaC7ledDLpcxgh9lGE/I/MpSCMb81rRzg0PNqW2Sop2p5JeIptcbW9CqkkNjfDqaEHaqWVXcc/VXxskX2+QtjBK1Wd/XjCNF8Y3JvpPI3x9oBQqzVh8+kb5WGnjG6wU06saqXiu06DM8+flR/NlkfrFB/qkNcEgnHx7tRggOa7tcSEy5IHbELr5FiVy0IL6A4byqEld3AIuorr2i9rL65FkBXASDea1A3dm/XWoGeZ4eG6DFXrEeitdmHA6E/0JYCZ6Hz0cqn9Aa3m/PZHw7wiPn4Jsi99i+NMA/lD6JwbDoB4cvw59nN33iqrmEHLhW7bHYVjfzFKdGkvLFVME0qeoSTUTd5EUt893Kgt0BJSH91Ci1PlEfQj3NFoxgg9egzmNqBDdPug22VsPI6VH9LYi8Q/luiiiK1za3KwYV8rpZSNEK3lUCq1cgQukCymTgNleRPi710e8uGPohl9fc5DOFJErHi3GinGsn0gcu7z+Qmt2uksBGF8bbDfX4Lsc5iPVqG8T1zd38zaXWqREGvJcVaRz4HmVjeQCIEom2fEllxpuOidzFc1yhu93nTtZCxmzfDcojJHbf4WeUtRez0SF1xoLfQShm+OYRkQbmogHzSeCBZIDkKfkAGfebuQ6c5/W0Jl6UawYf8f7ueueA8W2WBwaBcLYIxrvNAmsuVzPgkeZSlAK/ngQWx9Fyraypkl0DKkeqSKeHYHa5SifujyAlUY/pcZ9mPTV4cc+QQqYDczZdxCySTUPmjyf4Ad3ltMsHdLoaoOgEDuNZSZvRf0GVieeGsX/nucMYMN1sdCH6SO8YYqJoIOc/j+4701J9OjsM+Ms0Bt2RjyFlxhtXaGboE48elZYw3Map37yvB7TVAJ7lHOcKmRe5yxN4Bz2AV0WqBKtu2zJflulrLzCZgiH2+l9aaRkYoUJHebiIohPPv3n8gaJf3D957kltgMVUX8xTQlpBINuTkk52OttU5Gog2j0zmgW4ihcv5YKYasw/Pw4nkeeNaQ0OpKqfL/l9C8FpKkEg4p68eyozynklFfHwho3ztge/k9/MadpANH14JsxIVl7aeBQxzeiT5wofvRZFdWSf2aB3guQuX7+2SMiSghyj5tQ+mAaWVevBOZJ2g0W3kBKb8/B6xLAX/kqIcb8nwEFtEaHufPc2v1Cjk1WONpyNjXDCCgAsRovTkUcmrHR/NQJm0QJ9EwyHboPPPiPc2sERU6HNBGHtN7jxWcs3+bNNVAroxB1BLui4FknOseXWKjSbIK9N2V4JdhBAeOjgEBVXPTRKp4lI4CYin3UVQLLMd2Bt2rEPGw6Z1lX0jscfpTG+wblLgaYG9QWc1NksQHaxHsTMsuczxWmjMb/bC4R4T0yA3KYwDz6H/I+/qmi+HsgEydA/9X4h5z7tvGsj1h6xZBgC4BNTNZG0IvdQDUZejEiqoz7QB8EM9sSuNO3Hny+nvUu4EJHxlgRRAkOVXXY+vp3YzvSrRmsTZ6dqnxxyoY5z3LmrxpBLJZtgOsJ4Hyk4pPtivbh9TlM3zRdU0OYPvjtPAztnDw7aOcgjff0CSMjvZvVeFKs1zM/76OgXHoO5BkAKsMCZe0fFIWrFABeqZmvi4QNCYoewamAbCfM3XHDA+rwuXN20HpBUmvxETL2r8EYA5SvSOmzFyKkOed8c0SvL2GIAP8ffHCbp8iujdn4eqnWTjrnkCTgox1cF3i4lOAyc1vyPiBrJ7im/7hImaay62QCMo9AyAFP1BuhTiSY8wxVBGwlNK7Mru6zhGx0/FIXLDItCa0wmuQcfADg/6rkoVMQo4kwmrLtncMj8sCD3BK5Y30kgKbXS/qxNROu3Z8AsC5OVv+xv0iF6yhVLksm/RshvBzzEPg3ziCG4EHnjAi+v5UzB/Z/aY82jkzOnNqj+35dYMx29KUgkCYAANA4t2UNSfTiqLsXo9KoAAAAAAAABZNzH7VxiTjbi4F4C2Vq4xSkCsn3mRCqIK2rpyCMT1DePYLE9CJ+JJyakvz5jNSTI739Ii3GZ2/hSZCpK+NrAvHe8qwld2cVjhpfkAlKe6IEfayVTAurLdXAJOb1gSLi4l+JJfRM5qnwXcmiSoC2fMPTrjIHGfG8H28NkGcjMx3XRcDPpRJ6qdsSyczj2VXERbC7aOwPbN5+e8vAvSZidmdlxPx6oCBfTBoYYmwG6elzYrtNmtSguhT5jacYmrL4N+hK7op3MtTkOKW6SmfkWZ6haQq5Rd8useaCMEmVo6Jrw3ZmY8sIEtanBJStNml0HgyUXP27TG7a2GFa8T+grESpYSH1oVHnni2vJxyCeBRi9k9itdLwUowIJaAsZhW1NQJDqzwx6xq2u3q/b9iw22eMfDUMhgKItPY8/J/5NzLkcq3In4oyld1wxsT1rM2akXktY+tPigKWHOshMP2JrADQ5ke002i0dreYt7L8d1QnWclTyU99awpeutkgA7TE41nCePoVKMTJLsnMu/AokUkh2MPlZWP2rKsDdJj8Hph25JiDNPPc9v3P5U5SUM3kIWToRF5+MEAuJk9dyhEtZI2i/fErpDj84OA36zfpK0ZqE8LqQYmREXdN8mGBePObqVJfDE/90AEk1fzKAnvLyJUHh1x4G+ovzdKMwHVu7SFRSh1Xa/2/M6aBvRWew7u43poxeQxFPIWa1tZyOZXDlYuLXcVWPw5rVtS0OD3eLzajEoBuVYHB64zLTdCxSQCKgwgcVc8ihktpdlVe3UoyqHBDT4ULP9JCUN51OuWeLAZ95ZiCUy8tkwgIzx/k62ow3+01bZyath68ViT+fABG2OR3TIfGxVnkX3YEFhGvG48IPMK6LKf39FqTyrwS2qictXxrtYJacYx69ob1wQLWyhISkJStGrOsPvsFHU+iYh+q9y5he9jsZ4gpbdhntchFYB79iGpj7JBqB3bBSNJ4oTlOVdUob6xgSoj1px+cPY6adWdzsZoSKPeztrxGF11J+LuMAhqpcCB09OfHtYJhBBRydczc98klRgB/XpXMebT9OR3MAa3RjBhccUWDS6hMVNnQ36PbsEVKCJUYfrmCVvLhH3lmy17WhJwAQCUxpOouxTarVwvXsZxqFauzgtrFx5tAyBGE2w+T+Ar/GLvqVSGyMF78izymfGNQGTRMcre6K4k3D/wwqkWpV9+ce+Pw/7XrCg29thDhdQAaZm7yeDMLKbDLpRPsAehpjE/lwoZiAnp64+ZjbTRYbTQa6QrXg3mlVFIAGfg7zMKtd6WKK9zEMwslIN9ROKuZjPvJwIcS8agfRZfJG2pnZYCWpF5ulojmaThhX9aOyJn307VmTU0WMxVSRqm0sm7CMf479VYaIgHKYQ4QJDHKdpLYwURe+PTDOYYHorhcKk7vCH87wJ+FC9GOnPwXG/s3ZhsY96TUuBQqyjXm/Icn7BJ8DGYiMBe5LjNxu35K+UW/xei9052DGT3JLQPKrWfBOMKEKZGgwlPRLYgmHCOVC0yftrEdd60GEsK998aiqTwGyR9+pIohw9M1Ss7vjC4rUe08KNu8NZBtSVyiqsnNtRzFRIoiWFQhtMpH2Aq2WdNkNNpnT1tmUbGoncTToEKCnCMZvX7BWn2/OjdTg/p2ujmD7znFmtbWcjl1mGtvxtwpKy42/nFkHCTb9X5ixVSV3iAtObDtCjl2KQ7M2bW55FDvbyQK1wOgBUBZvB5Rma9u4oNRtJ9RnsxrhyVUmpXpzYHc/84K1mp9uIltRwH62cGE81NfWqzdw665EplPKmcIwPpTMdxs/JAjp2kRjlRy2CkXI1CnjZnnbanhMy/CGz6vvG0LOyfgcjcKB06p3zPYnV/PxDfiwdYOFVJ0irqxucY79LQoNzr2V7ICh9OcQ1jeFQ/5RIv0xNvf7zzwvokIvmqzM47Ym5sAl8s0XHYwagIcxyiS29DS2w6oQziDmZDRbIvnzfrRuv140s08iKXYA3RLavUc1PXm49vty/mnn9/RkOReRNujFKyMUrSvqyq5PnwSfNbn8ulfn2LH3qmJV47Z8CLawOFpOs92Ouu2XlIQTtzxJa/NddZDgGEzYdrZhLzjSB14i14+4S/CqzOc2M2xDoR/FnH0T/zCr7hJL9X6jiQQtL/ctWh/JDv2YJrjKG/sfVklCxTKjx160XwdU+IO8phFoa5iid0ecO6yHkVvK9qJmD+p43SwiKMRx3sb7wWoXmqbhb0vz5h2rSnKRa6o2PEfKAMMBV9caBkfmGp8lZZXQePyjPjZ28l2Wdu29BSn4a+tG/8sqlIVqCvgwrkQCWy2ryvqQNFdLQMDdAcCEl/f2WU7Ajog2Pu4+Ii65fuhUiiLTPsG7/KyJkMM9mTwoEw1yRaX5KoIYIMOyFzoerlKheVNIXuPPTj7k9z8+Tq0fpzlTK9WXU4MRPZhUfd7s9Xbe6wEIk+qKA9weXndxPdyM9LW43H2er0GiOhltavcjRholOhVYZ01rZD4WUmF4/k7MQSmXlsq/8YGoevk7oesALZ4L2JOLoFgG3Ze3lRNRPZo6zXWvLLX/mTXK9msjvIK1vAyDRjR7CtcgT4zjsUS7RfIuRVjdyAQV8MQKVvKJkbZf3/8kIPpfb711+QG+xhFP3Y/sTyZ/kwGabNs8aq5Zrx4VpFi80/fQ++qsxRhrYeG3sZKjrlQK2E9FfTitnyrTK1nxgOno6QNJgYid1KRF+we73GePwqaodFxGnciU1bGRSXcr6MZHf2IpKGxc4X+Sdzl3qI4j6bPrcTxtCe31+8++a9ibST3Dq61h1YyrMJ2baiwOv/+WIufUbpdXmlq/CSIR5aKs4gZxxF7RkrwNE8r/Htq9dSka+RG44xsMCofS2ZoqsC31YCt6Xz64NOpFu9ldI53Fs96CO1sC+5IpI/tVSyqRDGzNUc+cYzwmHN+cdCke+Tt5dsEeTwt5OHdTBDFyCwR6+7WBQ4h+rvqJnSq8OujZKNs2HwsXn3O5LZUfLeT5QIzIZowWNw7pxAXVwc7Y1dxbRulIDujq3lJX8IeDYvHycjJag4U7KexTk9MaubsoslA3320R10EwoHIGAhMWrU3Sbc9KcHKh8/zacESrqlR9jFj3pzVOmGL6Qjt/iUU0ByttmJMsnk57Lzi15y9zNHsM5Hiu4MO9cwXjMhSUfA++PYkB3Lx4iPfbfppNN7X0hHfBfhGIxpSjD+2XZ1GNoI3o6rbypRYfo1mPp/PIb14eahukTrP1F2wtHi6dVadIO4ZSK7ypc8yrL39CLBMncCS9rPsMWAWYw/HvIBs5l6GzvNwuQh46IbbQNvsXiC6YcTv7dHIIr+WrUtvLzto2TD3IWfgPzxGDpYgUHRCrkq0WKpvb/S9XFDWaXAKX1rV3kPQB79idWszj+WGwaiVbonwBEvB3ByrgwIUwon1J58WYfabH8zS8QlWyvakgGq18ihyqUuYqzaYwV1JBw7MJeQR4SCcWrE/uF6i4QTLsXseey4EzcesmPdfhqJBROkvBKOcZ4ajNWJW+0Kepg1jjXJjeVDav1QpWsPXazderxVyq8U5b77d31zbfLI5S6DoMjOAulb7ZW1zW5eVmZeuxdz4rlyoWFq12+sTMNSNBNtDvE/2Op/duqTjfyRUVvzD/izxcKbdXUnlJdIxROKRWTidkBGiHn3GAxmvZPBZ15hOtgEolh0d9f9kCWDP3ns6NkQKRsPBNiUS6GgpYGDXQMCRthxuUbhML/wB97BurIyyJZ6KRfOMwRFXPfx3H7PKTP40MM4lt0YsqUEm9SfJbquRYDZoJO4okhBKVuk4XPS7qvEhBo6cOGJXhwLpI7Uaag6b/3uUXr1SJHXSeWl98dWZLNqTAAd8AGeoiKqcNefQIv3n0l0Pync9hxOjO2G0drglWnhsicSxzRed5HShjVdqwMKmX7lUjYK1FNwRI9JAMjneP0PKgPQRiTmMZTicO6WWkTH55UbkyXJZXCRRQqRHK6+uOUzDVQEpwFHnFrQsWUsaVDoKrTE1FpsKAH0IC/cIgcFsk2bsEnmISPo69hs0dCZXIUtEpVsFobqUwDJnAJl7/jRJxyxdHorpC5asynGbvJLTZ8c0cwkPr1HKxgi4dDN6NVFSwVfzU0ZEz7xCgbvW/VuZUO3xPpFI8/g313uhfmVotWNyPRHwW8DzaZm6AqmTYphqR9iKkBjNTvYZMVFEBlgOP7Z/o4k5oygw9OYBhARus4CisgCEDwye9U2OobNNUQvE0OSBcWmI4fLQJ7ZKF/8CDtgXM7hVYVIQI8dJDHW4G4lbrP1d1gPOO6rlqrU/17gEQwzbhTUfdV/2zFoF+Jx37cSyL7w+5Zqd/wERNhwCeUHCUHjIjYRRnNQ5TJcCB+LnUGsQNVHClk9+H9evr2jBW3FRWTW1XJ4w9r05qgtT/XzyhVGvoQAZnwObbt8n5qAdvfBD+0AxFS8u+YjO8HjXwUQQlZwVYbTqaHF+sgMLL3XXgg+nqM01nRV+nZa0FYZm4q/YlTLYG8z3QEqg8UKkM9Sd72Km6KfPok7Y0nXnpK6AUGWMRPfxTGi870RQMHlYH+Ef933qtF8Iq57t0dz6SbOjng8OdkqK0aWu67or8OPqrUOzFcrBkPJ5LvcHvCDuBFVxhqxXIXscD3CHXNViW7zFwEIA2r9WZenIcs4dOosxuQ5Ce+031F/hsrs9lNBrMIBdPcqz1jbfXC0cnzgadf/xBGxUnvlG5Hc7gwGE2frCEPxuPpg99tff2f3on1y7HTYyTX3fQ8PygM+721FP7OelvqstBlvLoGppL17JShbbuo1jqzwrimmF67nfq97g4DxANVBbzd6k5ckezPpMCaeC7kKhFzIOrLqGjZB11DjYxKHzsKdwsJxxSDDlRoHQCSv0B3lra0aPszmNIsgg+h2510F98x6jpnGVQ+NapD/SIAcUccDOhsOxFxdU7q2pLSXfLRaKWiDST/fPQ5ldzAb5QvtsulsToGY3oe7Qc5RuTdsXOqUGVgcFqdhGaOzjrZ4br0ayL0KtyFw6JnQfyPy7/DpRhthLP6YT1SYj38mDmnLNfduHRoB/SqBlqTN+8z3n7CHQp2zrYE6Ak9OCincs5D5YJ7zTxLd1XnxqaKnslWtHgHdxcQG7aMOcRT8Z0zhAIFvDBYrz025Dk6fqHaerTKz44cD67uRQkSZhQ2SjF0rfgQUlvOotXVf642wAKQ/EVfCn0p/jF8SqRXe3SRVpHohkio1YfRfHC5UCVS/SHCsNvVSuEGeHJ8MuIo5SHex5HVzwZa1zfsd4rNDO6Arv4txKHnAsnJauGspXji2HcF+6RhZhlwaKTlG/gp7oaLloivTDvQ0taBTQ+4OyTkLFzg+he2wTt3USGm/0JJxlehqmof13+OG1pJWhms3mRWaMbK2Z3JghIbkcSTzy4J1gvTPxxlTlPY5gbqRwPZcJeipaNzWVufcI6xYB3543l7itu6lzM7TegCKwb2UJTHmIfxr7u9qY8ythMHXkKTnLicIxKavv3y0GEQRgyfr8Kvw5ahx7as2CQ02xACNqf4jfZKU2hvjEuNYKMbVlvTa74Z2GtRh0QPQQTc2nng5LfyeGxzupoFGVFOtuXHEXpGq6QECvQ3JjCC9I2Zs6+cmZ7f/tR+MamD/MyMvGV51EPjvswm8Z8ix3aDcylScXO1m8ve7ABBE0Qrf7BS9z3MiKsXpudwIn+EJF/SNgAKXFL/60fpyfGEvENxyX/hnwLru10DzFwetQQAZMjNmBO6pmXaw/PIABld9yhUrN320aFPAVUAAAAAAAAADOtoqkvUDtKH6yQqR0LVGMwraF74a3fVxuBwsR+UcF0hZZo6LgjMYz0zVWpQdWzTo35jvYfs4UEMZPVrgY+se6kdwoD7pNvg0VLmIG5rgWVBfD10XKCl5e+2tFX1LFfUIicusIwFo9/jqET+VfYmWbRVjcMCvbxix17KpDbnFO6JpBgdeQiimUpd3rq+zZ1dL/9f89vcgWOJgHPawn7Ci3wM+yIGM3tfSELpAgDSQ0USEaSmoenn9MV1v/hEtujFmMHsFcMLl4RQ2oPmRoZLqyLbfJyuI4lY8TQpwci4VlvkuuGD4G4QXDQwkUsAoVyIH1H3EweIvxBy1lAklPpzC2LLhMUX7VdrypMGKUF9Z2rOxKhj1ts08nN9IblW81aqf4jsxtib9YGAAkb7Dk/MXmV+hRf05YYA+mhzsIACuDN+xEpugKsXzu0gNMxquH9swj2fERgNyoN1OX7K6nj04A3l1BTUcL4slB6IQ0edVxUm2tITQTT74zVwCg8dMi7WxJMgP5Sw6/MC5/6qwvmoWoLIe0eH43e4fTdRKnUamfE1K/NV/5n2a6QuPLhkb7H+axEc+H209DIotG5K1zeVb6o7shsBdXpDI/rr+QLdpr6W4mnBA7i6GAbUpcAhGB0vpqfRx49jDhzBoBOq6eXpZ4IAcSX9FirSOthRFpSY3zZMfFIVmDkiSaBxES/q4ice3VzTgyiZ0uWGFEbEjcX4hUS8yj/ubrfYbvnEYUHFKKScNtGKKUqeST+gIGT9SDgyrfgw+lD7ym7plOaSjosUbhKulcsalPPAE9Ru1Rr+Klm72aF1jc4eBWp1UICJgg8IsVl2R1bJ/5fXv5lrEk/xyl5dva4rQP8xgYT4yLCIk/tyGWu7hKzUZQc/Oh8QrH7cUigTU8Q4B46PXdKwlRvC+62vCVglyebAO+tA6cOPzY0jFNoHVoGMDUo2jN5ytQG0ZGBKwyThzWad7DQv9HQJRFjQQiaT5dulbTiod1swTKvTrlNvOjcnuBYNNxnGNV6OuRBvnYTGiGfRflehd9sXmY37LrH6THOY22ygFaYoaOiIFAQXqjMSOhg8BZNUOjHOfePERw5yvzYozPfqWtHRjPWHmT4v0aijOnUXUargX5ii70gg3sSXLH4UYt5OHcsu+nM3rK3okr4Xuacmx6+Yw/pgjs3aSdvZarKUNmzJkgmpoJi629NtT5NJ1S9Xggl8iwbzcQmBHEbjPuY1j3arIxXJW568NgE5ZnzYTEEpOH966C1zU6DVCA/9wdnxOqy1BxFZP9ZqWSv97j9hXpS2RPl+AgCjFYYsf0eAeFkWPaEogzKEsVFNL3KyaE6JAdt1R866rk6xdYpNE4pQY87OJLVf6Pi157vDf0SfoGKI/81Avy5nFoTFHumXfy6dP9OgGwtUni/Hqv7sImhvHCRFfcO96suL/9mW388WOTDV8ywidkMIdpW63+7N2I5i2d9QN9JsN0Ntx9iYl0kK3POB+0mK7G2RpubNewfwOk7sqybrqpxSJcSCAMpB4ASsmQ4dGVyh66hDTt0B201rtINDolIUbtHEirTWOWHvJCrNkNidooFtRYmrGZEX1BBfTPMzVtylnRsak4Sba7RqjnPfA5FwaESW+pz3Ba2qE1hudd29p8fSTvr6tvxV6JrIL5jivcPSIYCFIcClDc8viD6dIRNPYwfiVjppKHgjj5Ey5xzpb6TbLufd0BSLhRKBzltV9fwYbKPUo3H9z9VyvH5ZnBTYgkm6MVtCKj2CrsLMgVgnktNRXnqNMWWZ1U1hWj1zlZ347ndGTLvK71gNt9ZwvYYWWHdduy+PvYj27K3FOAjcPFOy6BAXgHdpUppdOQo6SvIqKGLmMi9iKUGrEXmFbOyi1q5P5EEVhVsaXUoOiywFwSwxMLFREES1QOv18MpXydTrKdmGdhIG8wTGcwwFt5ZhrkXHDIvhtuY16ZzhO1+iqxwIsuRCDzFznoxBXSL3q/jwcECLM6Myj1KNx/dzyL6NCxoTOx1zlb5BfBe5irkhXk2QuFEIufJ++/VG9Pq6wNJ5OD8Y9EmYj+SI9y3lmZ5sxBJZqrIBtxja6ySzq+7iDDkLghU97xq+d4Bvh8p+U0pJqrLF/IcT3odgYQcdUQpZR0jQ1oENS8Ca2QaBt7sKrYErbFINHyD8IJIeDBhS6WVFx9QAYjMXQ/4vPxXyAJachnAi1Q/3+b4F7HAbMmafYawYlBDQcK10d2uS4zp7Rj/Ev76FMOjRmzEt1W6Fvqm/a7TydEd6GnQviohRfVAH2mKPCOLzUarK2E4cjaBTfuZ938Lv+ewRF7NF3ZYJ3fKnLOpAArwU6YXP5i2Tt56//6kL36nLY103qANBdbr1Q/i1B0vSuRrx0+6ITGhz5cLFBC+mJ9NY3Q/q4GLDw6r+l9XzvAN8RcSfwlKkobe4YainvuFUbktA+BepWXjloRnFXPNHLTx4c0Tu1DH+qbXXe/pm2hrMy53kjuRUSQrERsC51frANrfmXHjYl6E7HE3EcQxebYL0q//b2IssB1aKPO+ZYQRnYoR2YnT/rf04uBLgMZBk+AgpFlpO3F0ir4szBogAhXaEte8nfMqVDN/pxGiRil3rUZLk1QQlGnjLTUSwMt0yIHs3dAmVV0dSEl5YylTFcW/3/r18tLexK44/NWBhUP60LcrbkZ2ZY22/QNQ0ez5iFClV/Q7cF30tudvMu5n/i971lUkI5AGwyNHVq7Zs9G1YuHDwU5APobPK3WfKWq56PVAeS7nqv1vOF1xelaGALb9AMdalp085hY2pgyNVEiWb+bWkBf+VA0ds6RrKsvfc969J/N4+kLlJxrLu/Gucty/RkkTQrfjWgRx2e1EvrQX4C5ErzuMtzZyHqTc4TrxUBpjIFtxZo/rVtFb//AIPk+v3fY1XxR3t8t57GxSXTH78ACOJezPN4aJpOk7/4h0tpPGm6lvBU/PsIbx0ujYEEdOQzN+72zUFBT6X97/G55f4eaF6/8N8NF8fsIj3PzzbIT127MY8S00+MB3/4igqMAkri1lgFtvWNl+nahIbXgoCG25AX0PyTjjTlYv5trmcgn1ZD1VG21EGRiAeAfQ2Fo/m/CJ1pZ6bSIIZdCLGodbxOUg7ss29awBO6IgInJPZJRrZ1kIOn37KB9FquO0QBeSrgpEydr7yznMZSrfZ2hyAMAQHsOlrYHTQPfXNYe9gCEd4BvrLP2/F5xgUazq7FWUf/jdYJQaqjzKmbUKnKibJU6Fl626lV7a+bB+nCfjB4faTNjPEgyOY58KTomIb58b5mVl8wMHI/pMnNhfodUCt6fllYsIEgTeRT81ZRS9r+B3ftiUay/X4Az9UJOYS5HzX31nUCXf10JndHu1hqQuf61/W+cxpbP3xn+68dZ1HkY1ixEKsLF3zI4xonAzpkeO0yCcxsRk4PySgJCknbWQ2xeOImwXYtolKzHFGuYgdWSX1eFFvdVKyVgG51gm0X3FWzKSjBMuum6ly2DQL2UFXw7uU5MLzABmqIZ4X7v0eERmhAk0WUo68Qyaz/5UUFblS87Nhh6aws0Pq3TWA0+1YbS10g5W2rXqEwhPwVmfRnMzx75Lpnl5LKwSlzz9bpaZJmC2JgzaDDyJxPwC0sQAcIiPbsTZl1nxeS4curx3hrO+BFKFiHYEVhNiMEBJhIDl3cySivs2913HFhFlSBldaCsVRJjwLWFEeiOcEihHShaYHm0i6HYEK22ddtyh7SPGR/NDVwrygMJfO7/H8SMnbP/QX17zmuwif39sDFr43syxvWJ9/UdPVPUKJGUPHE8s+A4NwqvlmBRL7Ef7mg/WsE3b6oSb6C2Jq/oTNINE2bRqfzrDItEAx12uxFkZVFen1FR7lHHLLoAEPfZBWSNGX2QVE/5n9cm00eT8YOqugpU/PFBmraqdT+BDub7zZBzUjK2aoDYdsPMg7hCf59D8Y4L3wt9lO7SzKeFFDHMd/+uH6vlJVZN9F1sTzbk4VueGk1GqlqgtYDtHNM89GzMJ0xRg5pYU6hmJng1Vv6+uhGcg4gEsq2np7EqCjvKHFDqm3Ka8GQm6HlQ5WINcFzeSZOdkiZ3RrA56wxhyyrwbLXw1DLpgNJpE5vyuVTR3nzxkitoP7YhgmlUEs7mI2QujyI7SazLk+hgu11p7FE+lDl1eTROTeUjoAKJtsda9niRKkX9cX7rGBjyTGrr54AxY1pY67ZGx2ro9TDVDdRBrxd1iaA+WAH5/D/v7gkCu0FmdfisRqNUw7f2N8A0FVzmkG8c4F7KyBpixOR9TXVaNYLNeR6WJDGEemjWhELWPcoLEn16Y9NoBpZP1SzXKTCOCoDQvkbP0qunNHGrNtJWojsOHyp8ROYiZoXyhwcYdf6Pj1lnXejg5iLCIQm6vnkpuOJt0gaWgmV1YH7JpsoOr2AA1WzLolTIGg9515QAAAAAAAAAB89EUjeXp30H0Rtt0a639O7G2MeQyEHRWiHFEve3FX4c31dI3K+QBLUPL65U6D17+0dci5Ict025V9oYf6tY6r1u0qZ1aOuuLyR9e/ovd0FSdkRc87MCRAYfXGlLCvQmZC15nRqygT6DSW/tzesyi8NonBSlR3CBEV/JrmO8DyMYFp3IBSjAgloCxmFbQhm98kLv/TpUfGHYPmxAp9y2aNuRFKnK1XvqUZYt4BA+UeddARmnP/cp0Md40j84qpRzlyb6xmchmDjTrpV5xCzfzPpI5EnbBkDJ02SLZq8Ul7ogywEn2huT5d9lkdkegANvIOTR9bIzNeqmqT6tIZwIJaAsZhW0PzOnp+f2YEJIVKlpcV4xlgYAQo4n3Xg5LRxejoTm/AVviMHL4NiLuu+fq5KUSkmjvyr2oUeuuSgdBLen/SyxgTkr1oUaIVXmQTqN4cJyDGog2CVfr0h1eMeLi7hVRajeCC/l+1yiffXxcl4A5ieNnJvzRjVvH7wNUvEm3EzlAz8deD9nhJVqnUmbBOD5vGoUNazKUBhFjEH5TIcjcC7qfqt3ATqBPaDRbLtEHfOzMKsjy3wSSk/oE4zgzigs5sL05jIW2xMOC6z1sBXHU+vuFThadOKYJ+anLLoZGbwGWDvmkF8nA8J1nbaJPhQ33dUf+YI3hSbEfpLVJ3d4I8ae1b/of4+cTC7LzhFzu7AykzHObo/2JdCDWAYdUbDQglDIRB42yNchZdNC5NvQoD8XOf+Jk5YvPJS5uEwFwxmIUP5mx8YrohUe2Eh0HZNHG4m6JRmQaYTUdaWZdqwVN3jXUHHX0x2ayiD0vcvzrC6W4VNmPhmiVlUbqNIs/aiy8H0tYMDWjb6ay393Q7GHF8A29tQv11909tMkGH+TGtM4GQbnemVMYjSgoIJZ8B/PVtYEYAxRgAEHAMY+QzMQrKIkWGzr3BsH9K15QFFL0vdTv6JhZ7NrQ1xJ6G7KWmyjjb5QMAHVYiKO8aB6O4egnOlOtJb2cKCGO6szVE+hief0gdD0gwzgapxZLIibC7ZrnNh503am9Qh2xj+bJ9umawmiQQ45DGkd9pmb0BGLVQ/qdCOAZotTjpfEZN0v3Fc0ZXGsenr+5ae/l2LghFDjAvMCq6eC6xYZe790f3LQnIqpUDqIwwygZ/GT5M6s4/jLtEgla2NM5SmMHyaiIbP7s1/vS05eXr/IC1qNwA5sVqMwx7240tqAv6Hn3XJbGB2p5xHL/bLJoKpFA+mLnIPADMGjyk74AzLfWLVSy5S1WbZbpDVnM0oUzQrtWNV80529x4hOAHof0DoU5bVcmTrbbUQS0usMSlfru4Aj2g48LupcXseUWog/XArr0uhkI6NcvwwAiThQ6Utmthg8apPhC7LT1nmH9ZPmdmuvMLr2DP/RtUYu6RxOsZK2P5EdG8dOoGUcXKV0EXE+qOIm3ndlBKJ08vwXOSrKao/PdlBx5ISOtAviwdaxgY1Hj0WecfgTwGjB3+DxAUfua4WJUZ8cBqtaxqvDMAtogxDnJeQk5bnpiCJt0a0mrZniAMNyHiVuUBnAkrII9DkV+oI0bs6U3s/wuFUIUOCQuDUdcz5RYO3ihGa6Fom14D4oTkF2hE1qXXwApkfpNoqNSIiRSSGyBEZfteUxjzQXLmP//KUED85jaSiRPhDahnEMj1XI64z4O+RkUDfsUn2kTS/F6pK3G1HViX/erLGOHov/4JIziRI3Mqr1OarmINri88nwllhfn9hpNaSvEBMOgRW+5Wv5fcIpfa0qldOhL0E7gajlcROf98nN1d7oEu7o3d/ZhyMAxA4nBqSH+m4f+xfhYJiiG2TKmP7hLaCfvFNZPR5v2ok/luk3YPdXPNT7jRCsWtjC4sidTIYkW4A+qZmX4HLawroRQDUx6+xMnKVqY/J8DiFrAsXc+Dt7BUKoDs0D7+QK+2tGP3ZP2CyJGMaB543Csnjhd+2q8LjoGJQaM5A1zbpA3PUIkqorgOAdD0gJB/x52BWNXAnvSYQKn3rJ1keaObdz7H6BR5pXKVrp+0AG4i253DrP6OSrtFvd79xoEeA4txjRkVgMqJFuiMYS8n0g3bxlFKsZJHeJlGZ/M2+6AhFZ4RlNzvvZedtm5YvIhfixqkDIyF3xf/nG8OK12qK95t8v9eDXlReFLrx9tZseckLNDm0ohWcIpVZhs6hHPdx49W2tROYvUiJoeRD93kGvDGGREIZVXRj3s1dfiGBG7YD/OD46QBP+ZdhJm3lY7kMYssgDUHt54A3RU9XA4czc0E4r95Ud0e3OApK8PfmI5cOIvDDPx4K+0uESOBY5hpcjD1zAf8s7xS+i5XkkbMv3dhO62PqBSYo6sAQ1v/HgcDGk1Fy4bzCetxJAT9tQsSxKYbWKSQtyZisK7g8TC5BTGAe7Skn40ScHMO96jrZPmtMNbMGjDssImOb1hemXfGAmIt1CAjPTSh3dSHNdObnYtNKSyMaVxvzpYQ5wbzlEcq2p8f0d2oXr9VhotftPIOWfucvnx/BoTmf2L9g3Obr+Pf+biqI+q9dW6W0q69KhR9s+gZfgq+6Uav9ER2RtHx1f0N4XGEq9pDmqgQu2vrWVYEbWiOeWvNRZp6AEz9KCcg7mC5sPKcXz0ebtjqZllncNeu8ul/nzWXQ0xA2bWXMkNXiVwuMksxUMJbV0lDEVpTFqmFuOCEr8lydOw9RzCH4ALk4Tktnri3mNO8DGT3ICVIY+9J8/EMlzkEyTZbkc5noW65wLHcRjZA0TNaUoNERxi6pmGdgYDa1NjvDmqH7N18JnwEC+xYLsdfFlsBdDmDwR/yjqnxbEztiQJW4zspuwZN1IA5qoD1bZB2yHCHijMy8NOqGC1NWwxkwXTQkb44uDWK26StLPnPy6zDpGaCZBA9YX2xhotH2qNJay6SY6pOGLtgdwk3vjp7WK0dZnhBM6JI6tNoUv+tU9TgwFCxUWdPb5Xt4V9FwqDCLra7zYsblKU58/T7/nYhRZa5CcTnz44swO7VE+Q4ksmGdvhMm5X4aC/6jYK4ndrEPVzYr2ViIR6HSiXPfmZor1JoTafA6FM43y1sOPsT7xmsQjNwAkofaRBZViNQrV6YpuUU3Jx+O4MgzwvBU4oUNmwI/sV8ila4UhabEPkh20Lf4AyvUcqtXGcS3BNxGKZrBE/HW0VzAXpFfgOaR0pSR2fYLuith0kw+aQBwwPZCCj7jWb+i9hrwMoQM4wWYae6U8M/tceP7sTwtQZMZkoNdHfJ8dJY63KM8KsYZNpYVZBir/oCDft28BSAJqolkhruzwh3MrcXzrNM7xfsxy6A+kttHn/nAGXLfIUe5srpcDUes18nZ6aNHMkAY/18t4rG0MTxw0vIf65Ve2UmLlx/KklRGxE2sGiTAQNa3M2EcyYXPS9MICShu4dFFoD1l/4kV6fp+1HqK2tZHud46oCXfwpFXADITVD+SFONWhctcYk9+ARMRaLzCa0Z4XQoggDgmBA7UEHXeyu8H1L5JuY+4Wr8KXIfY3qZfOGH1RXumNqxt3WTFXp8aftWAZDm4jQ3DL09PwuagUOHOdD+WpNEU8tyTn9PaWN1SxVlGuqdDXgcSw3t/819QW6QLFuMJBAlXPThJbN73YxAaO6iOtfzGbAXWr3939Vg8DQvYbZ3r0IzI7YwAnRzdJBXRcSMtOQjbRDLghZFHz4V36uqYzEC6NNiFHb/MoxguppHp8CHmE371W1CtZOMuXswibgOGCUtrJ4qEQsjI3dqFD1Im62xkDMrpccAfH+kZ9awZVqPvOV//eNJjKcbCKzWlObc4B4yYfNdn2RvnQP9UFYGRnQBrGmJGDBQMM/Fdt/VMl/HHjlrmefoVd1zxFG2tLusvq4UilwPuLEzcktT03hJnm1tRg/IiKYj+hvxwR1KNS1tWh9lhwe3XNnfoftmmr4brsjnzG9sEN5h/DgDSMmlx4BQDuv6Gp+P34867bBeh4FgMTkIQStoqaa3CzfHeB4LVIqdmCEUfEw/EW2yBLpjMroKff3aMgBbb6OAhd35ZNq7hwyMDbMS8Gxn9vesQ0CfEL3e3JTTJ0zDEWodtb2WU1CNCP+8MBWNzBbcY5qeXRhsJCXj0L5CyZp7To6UHnN9naOjfRwEOBCXwjtpU/FU2BsSRj2tYOWpbzY6b94Jul5nS8m59JpNJpH8ZiDIRGQVvSsdExVN/vomJhJgh3rDXHZimJ+CoU1DQRgEAx9EWrS8tWpDhdCt1M2d0+dRXaChHUJdqGCu4QRhzAbSdqD28JFweHeGtTWLS71oxlp3pZUtY9OmMMwHE2jXHxuL8DEjyjFqEVYGTaiDWUMBi4B3vvlob/a///3rqV0oQRmLWFpE9LrLCejTs+wDK1J+GH23BwtlIB+Po77FCYbCCtJcI4XAE6T7hRpWeOVwF6klTpbKI2B6INHPNliQrhCiXhr6iDBgnyL/E2tA8J5yZo9mP0WywF6nr1Z+Iw/AABBLjFWpSXMb76fRXIXDIxC+0ePdCx9GxEekRCRFTwqBNv1qD4uYiiTU/qY0SahvnD0cx6cbxGAfFnsegwHfF9vDbLdSonM7rr9gkD5BQZm8khvzvMdsp55IDZ31ro6NSzayEHy0Z00Iv4GUFvqP6hKOi7/ZyzAO6rGn5LZdOID3WAcuu4wLPUXDzohB9lAPxD6NPgGuu6/59WUsx3GyhbsNH0n4lmzuh9fTM/Z85c1iNnDspn6y+jcxCq8h07RIAVrf53myM+qcpYCzUJFN70jl06kORnWUhwNwJZflBzW/I+IGr2u3ljRvmlc+M+LOCAEwCavj681nZu+4n4owoXMM0M3YPc5y1G6T10+n/c7n0idsus21qvrEYpUryL6jBhfeF2+eBKqddYvUkV7c/yj6NKj4KOEVaK6UbDJcea8qvYGwlGjh90kuBTFGDkxLKyIW2i+KPmw6ExwYfRl5lSVhkMhrdVQXQwxjfJGrUYD+cjLzW+X6FmR07WW5yVEsJy1NOJk6iBQPlzO6AIwle8KXBimHxSRFH1Y2Ak1TIo0GmbXKbZIDJ+X3kgAAAAAYgAr82ezEgZoLu406SxgAAMWv+MQXe0p82c3uxgoieAAAAAAAAACE1DUAk0CBIuXdZIb/X3t9vZ7iMnD519qAfUAYpEL9h63r31EQBOIUw3SwKUYEERTWt8jclZrLmx5n2lNvQuweEeHgjoxHU1ecIkqlojMoTWiGaq0EfN1GWRGX7LYZyaxvdYKdmQb04miL+p+tGnNl+1JLD1jlyc6Mb64tOYdmhKSFgdl/p+sRQsYNJj+X7YMQ++JHaDQAD2BLqfyKyDeB/C3X9UQqSy64aqZ7wfvl/K/9IEHyFu9og3vSwrtiSukQJ7SrRwtb3nvKa0YRb9xgcj+A3mv778uVhHUkaySoH6xFJ3tcc+RWDKE688qdtgR0r3QPx450zkVR8KV6WYMlPofb+xb4CImdZmhk2ICioRyj6m90DxJPQNrp2Yx/iKjvDSaL5PZFdqAJW5dtJAs7O7b3Coyq7PxVKYwpHYnG/rR51tvJcG+4zneWJ/T6FkkIF4gLbQc8XRdbvq+UASPuPUkJxRWVeuaelXJ/G04hiApva383WMNXXjzs10F1SPu5Mi++tibOtnhmv19w1K+k0n7gyOeCkKAHWOnfNT6480cXz19+ch9vF6gzmsy8pz1+Jxb2HTjvIh5QHOR4HNlmCJgB0IBjY/zhNR5jyzjOancKoWuSEOtTFfEXwLPeiXAwim7REDst06vSUHOarbunL6ItcHJ8dX+PRlOgsgpNWfNNwfgK5D+gjKSLGnwhIX2PwWx2Y1DzFdk2g0ihJRUdyXFanH4q4BmoP/0q4N+Rex/2cZYIXvM7fX8TfDasiF6F0lUK4VLQBGFqv6Y3pL1pco5x7HrxfF1ve+pUr3z+1du6PMeWJuIkQin4oVUICcF4LAKuSbqu+rt4oRBeB5krl6VumkYMwqAoe1rUoI8cuF9Bl5xrK5uQPcqpI+Th9UgWTah5ABqg2l1f0EjCjCqrxTT8f9RZhGk6Y74AZjqcZ/+IBGkd7lJqUSpXdLD1gSlWxl9MiMKCIA3xYmqpGG81b924LiYy54/y2T9TNpfx4bwEEV8ZgRoQxxvaNTL/hybXoh6F9YjVSALuWw9JP4/gdjcDiQmENGnl/DhAbMeScHd9Rs83ldlakyJbHjimmlTkAeCdcNROyH5pw3Qx5SxkAg1BCZ77rbdZkAZ+8UnDI6NfI/XmVd+rk6FJ7jDnklRm3C4ybM3vCPvYOqaecXBcU+duGhya1g0d1qPRAtRWUFDd+f/qEh+0O+E8jt9Do3Bv3ArSHHRkuMmPXFSDo51gh2z7Xz+2jM5vIOqvpi+klonqffozB7HeEJAWlvSAqJuZMKC+0MvG2FCI79QyEkXyHgrDBfFQKLDn1djTy3l7h6v6pWsB2EBibrMl9pziAhvFkVfdlvS4vZa4aiP1dbTLlP7uIqgnCd1DV+Qv44lf0OFCfex+6VeIEFHrbVZvsYodk17f4LjDRRc2OZI4uALqEqia/IC/CdfAapDrutJNLosnMzcuAXRLCuEmobdqKOKYutvWaiucp7mCewUORMvueHojTSBEEwookmeZHUkuMCTs28WJNftMAia6WQX4XqLXW2GPEgvbQOOJ3rkdNrmPeg6btyeVtfiCRRbPmGJLDHLyh2rrGU5NRp2z9oZsD4dRaq2T+N/WtamaVVsMW6KOF1XgrxaryUK3BlAbzclGbhmsWTzaBZX8xYXNvvRjgbnVrr5ice1UOHtnWNZEqpLH5CmVKQUbTlXQmzZf1c1vxdIjq6IzUZv4BAWtun/ESNC2sxFb0iabGaGmsiZZTb6/sIfyT5C7cFhWnwtGhL8JWlNZq+N990qp6pVDd00lhmg60gzbTnsGU0CuOiTQJI2aKJyRk+wrEH2cq5UvuJypMSIe+ZNOZlMCNUR2uHjfFPUNBX0gkO7aXl6LhpvhRd/0wl66SdE66h8UxLBD+BPvG7ee32Kk46qpM2LlL5myage/PVRsKSCK1b202fsqzctxxI0FqHzcGvGbP3gCytPBK/ezsfyKrXW8u4ISiKxWS2yNNmqtuNYRK33OQ3ga9BLpCcqIMwpr8vv9QU4bB3DbleRAsXWdhG7GLlXmR8ry6idFhMN2VVG+WcpWChR8M/6tbeZV+lLcRaFx2MDYMSvirCOWhsecTq5lJ+xzhErACZY0Ln0rwpMe0lD23pWMKe1QIWwa1PqQHjgcaT+1kRNPDmyG7IxqLZhY2hdH9/xdW82gqpN4oHJlWQItBNRokeGchTmrsmL+2cXfOtEkxdODiGTs28TFhAgYas6kgWkhFaKj6r22g2yngFhgBMJdZNmby+gNg2suG4d5/fuuNCFILsUteSvCwRFAIMKsbarN7MU3jqNEZD67hsxXtdLD+0PxKGBO9t8T4A/taHt+jR6VyazYVML4Kr6cKCEwZJ0cWIwocljkZs0WIzRoD261CexoL7Qy8bXJjpuDvkegIiQIkORk0+i/K1A1JBBkuDlBskX/87AWLGJ/E2jcoU1Nw/AlT2yl+Yitiwu0EnP0Fnebhvb2g/tC3RRZfjPDcnzKfsDOTr3ypZi1vxcDCaVqMLvYmtDOBBLP/KMjrZgTincRFkwSE6w3kMe6dS0bF8AgWtslcBj7Cb1+faFOBWEhPcHVNCL5HNbFWb6wCS5Cu33LLAXsmFfjlZRX8hgHNApnmopXu5qidmE+8G47uQ8o7tXN6EdortYA8l9Bedr75U3EijGIVLSxAR2N+Lij6wmZCKf/ZYoACASWv3D/URz2d7bjRzr9SRRDh6ZqrUoOrZptRARniTlEisodpetTxeT6PY2t2pSd3ogjdiAvKfSWtwOlngYMO/PDNdzhvK/uBEgG700GAH5ToaWn/6cOBPjNrXNkfieW6RF/r1xhNxe4e84gGt822gXx//0SLce2kdmkL3RiLFjZ+cEz1w270fVYP8z8//fCBWanivBgDgyKaze8LF+TWoJAgsCL0ql7J7R2fP5VIabi44v3ZDoIcHNJAHo1fKVWImliiPO7HpJtvMANtfsPz/ddk3XkO2mvs4hRgyx7+Nq0WzOP/qzqNnm8ut2TC2Dt1Hlm+1vYoY4jUhwwaHNDHW/e/OG8OzVs68ZaPje6qTrzP/rUY0ISJ9z1kxddvAMVqich3Wou9RDUsbz8PlhJk+AoPx4TMgo0O82FldGALCIYva6o1W8ERoxZ7rSPTUEj1IG7h+qmIg0vIOw6dTcrskEp5Sav3L4owXPZ/bTHbjkd4NL84q1FwnlhcVe1UMRchHmjzR7cnpc1loIVB1gSfiwK8RtnYbL5+AkUleT2uDgOr58UpNFkyR/RyINafdgICuY9y7x6MEnwPmhPyfiZ1GcVLGNf07HspB5fXmXYgE8U8d8FqlnvBArlVZzDI6TM4LkqW0sk4HTJgm5IRmhBFlyX/Dzs25L271KdB2TRwt7z+/SiwC5c9C2z5tLx4Ir9B8tgL6whf10JGLEZzhW7OS8ItnZZBiNKakA6bEQrX5Fro1QrxhxAiaBDLGXrfQ/vREWj7ay5TaJOjW2wR2VvnIqqRWzyrdWIvcnCc1KQhGiqHurtYLXdEGkvDo/hEBDQat+cmQLHOeRdFInE5NBP/csz7ElaYvB9sKgOKhF2Ds6+jwEzsFi4qLpEaAuMj5IXDxwZ3cFzYoMzd95p/5DkajSqbTlNOGBHhn1Xrmta5aZKp6/HhGPMkYj/5mAJxY1EwRRQwRihzZ3Eiikro8tHYnyFXlpAX6Ul48Dm9+EfJweGzCOjsbPM3su3GqIGvBfytdIzwKmebPM22qAx7zXjLKWFbY1Yz9SxGObmIJmU3TLbklQk5MCLU5BIo7EZ4gl3nyD6tW5ty1mOA+AgOndsUlYLfRIdrmWix7P9egOtmptwf2uxvt/xE9J3UixLUWS2iwwVtm2p+DrVYd5qYagez/oZlBE7FD763AwkIadtntrOqJNnjETv44z7hw/f4YEd0APLQI7Jq4sfhm08OkM4EEtAWMwraEM3ro3JqjYjdvLzkomY335nZBoG3uwqtgStLeSfsykRKTNFRu4FjccgIseESKlnvt9uK7TDlk0Am3tOJ2lsdc9cfMXOSF1p9rrQKWSjkWzNOPEhHmVBE/JmS3O/PaOJtXU1gVNDuFo/Mc41us4XPA0pQ7a7GX3ChawcO1jkuqACwliUPqpliGxTTIuGuXFruGdj/z4GiYhgFMT9XkrGBOXpYhQDidtDw4CjSAtB2OoElmjl/ADtl7DnSYWqtPa5hSR/kpYXkvwM1VdaOwysvYyZn5PlWFmSISZeNpksollJSIO9kZ8DKTMdApbPp1IGrKWAji9fXoY7SjhScrLHDIodOEs++rvqrOBHHAySwXsEGyxL8XPP6IqHeUPQqwGvv3P02ya4nymzeFTJ1BxbNXJeGQL8wpI9V8CHiNAVBZi8uBvEOvs85jNyeT7xKNITvzbiJdd13TM5Yp9y0DQ8sszE+bRimc6A7HX9NTMsmbVMON/9C4cZo0jVrO7oQkwjI1q7Egx3DRAiumgo6se8/L16uTBM4Be5tUTgUhic3qBadrZzKBqiD2EuffvkAmmcw+34zz0YCU40ThqUKUyPGvzleXWnyH1ateM5kLqYtPdlogmhNsSw5shtqtUnw78s8HKHpLtjtuzM0bn0x6G92GZYRnLM2Czt6sB/3yBH97Icu6KFIRLP1TzzoVFl95yaqpSgqYVHOVrJmxAtvbZd3NZl94p0uIcNtkdJcjdwFEkwbues/+ZN8E3G6d+mkkOzeRInbPKusbwZUphqk5EK/N5Bc7PgO6mZmO1p+8fVrjI7D/WEo3WyWqr/UKPJ96hOAXtCJsE+D3FygaOIxIentHcV31oXguVrhdhrj9DwTa/UaiKijtaqabQtz56mWtd2LLfHSI2NjrAAkE0e0o08Yd82Ewqh3Kt4wkmGXkmau9Jgqgv0ildec0zq5qR3vnyd/eyfdfa62rmor4rg5/YIS53FB9QUoiGWE/w7RtaC6kSK+7uVYSGLuMahL643kqAa3VBMng1SwRDxslWY9VpcNovZZJZEUn6fTxwZSGym7YX8vpPzDUpC8KSXiiLoIzRRL0RHCo4y+vKrXheKdAVVJnyoR354MsOXUCMc55vc6pXEC/LbJhrQ0rGm76cHm2Jg1fx4cwTtAF9rjYXfosaPSQinHWQosWOtV8QNUsO1hGLJOd/bP2vfAgcs2PnW6C0T8tDGEKLNVq/7e0ZNbxSFTF1XanAoqS/j5mQQOmrRelgfFQ/PjVrA0NtOGncaPeIP2YwDU+AnYaxcGmxcEtSDP1khbPz5egMFcrvZmvvXYWhyptKLE4JC82eiKk9FiYa/kgm1mSUgiHo8PcOF8DznTFgqhMwekkaNS35h5vGkPToSMUKqYZit0be0oEwaJeOXRQt3tOqkZB1PIYPCNX76KzX/X46bOBS6thyTpRW8MijjA8CDFUVPh5lKDeRsNlGnvWkurlDJOTT9g6S3Qe2Y0GS0wWvwD9NZ9Bnk1afeYlsiTXUCUN2/KErthHN9lWIk+rkv6vXZ6HaOrefyDj7nabE5HWT700v/2S5CJr1c2GJM83jGpviRDMc8InAFtFT6PnCRh4pEtwxPz52uJ3z8T0r7xE6OiY2H2N/3Ttm4FBvxCYLwt9y7vujQqEHdqwHUJV6D48H5VMXIi/8AL7IvdrkuH2SRbuMQL1sg9N7ix91vufP+GVbFRUvP6gyrpE+jR2iet7SNBgukNg3MgqK3R/IpDG64oa8j32EHd35+XJyW/7j23XousMn8rBVLHw4fiXP4fydUiUTo9XUMMYkHZJDHmNjlvla9JbPysQPlc2O6DOdENZ6WNM8jmFfrFuc5C9Mv+wqyBDwk5XF4mOKTeV3kBgCS/XNa1y0yU1a5jq4vRXi+z22hsEXI11v7+V5lLKV0LdoyhwKIeodbuvLt+Z6MaQm47pLvVXHR01XhyV99UFtHzgDmbCS4W2w9C0hFEyGXAJ2Nh2VF7aRZeVnK1+L0BToQEPTcKmS8tdawoc63+5ZCVx80Z+hPXU6SXlp7GyepZwjQN6o/BnpFqkaJtlbKE0C9VBmj6CP59B2XbsFCElYKsUXhi7DhOYccL6zW6SphCOB4mLx3EAeAyAV/16AAXP2GrzTTzWT7Qm6cy4rYVsn2hN05lxWwrZPtCZpmK9NbAlABNVj2L0a0/AAAAAAAAAhVduYC/67Ve6xCi7xJpmrYFbBcF9l5BplyR9QrIPjoSe5DjlNGqQulF+5ARjW+TLrinU1OwZzNBvsjTGaHqXOQzEtHan3LoocV8+X/CdxyGtLYlqr+3MGDJRc/btMbtk8KxKaXUfv7xRRMSyFktmQfrDvXu4lnvXgi89/jjFaVbhcBsIF0Xq5JhKClrEiTC9yBnAceegbtXiBGHsjxABfXzPC+hiFvugSk/2gPJs1hv3rHQa7IDCY9MVuDsAse++hPnQu2MK+EPxLIK78yHuFcGnB/OhtEkIuja1/B8eJYQ77FPYHMYSWO2i13RKvKOTAJSk/GT+un90mQv3F96ebOwsFfSvuETdX3KIASdkhJf81bTD4zwzGPILwygIXcXsV5mG5wX2AkTrNxDBy+cpFQFp322uiC1s+ufpYfHixZ452HDbMnrEVMDVBYGnInOmdx5LQGWb6jx8t3jqTzdvKU8arbhJ1h8e+SKWVDoVbf6cpBedLsjQ5h3+XmQhBfU21if8jMztMBliNqgQ022yum0riiQVuNLWxwtxM75rmKAQlaks4bB0X3k2RGFiX0po0oKrMPr5ksNOvbr3Ido6ZXlkgAKUb+cOMRs29V6EJgY3vctZlJJ+lSEzqqE9rYZXFUU94SYxoEPnumjF+7qMSrga0oKWbHlo7Di1XXANS78zan8ViegznboVZRGBEOgP0e2bVtCJMFEe589wRAEU7wjSK6J0S+HbByvGwkDPJ1KcjChM7ADxcIjxvdWGAkOiHOqvee3pMNqh4iKYjP1LEZDVPuWLorRcTz4vFF2O2YczMXkatv12on6+G3LXMmGaLKtRZLaLIIZC3VboR5YRD7HuyGKpipWN3/vScjSSXKmcCGJBtGKmmMkVgWzT8tRiHrlnVJuw3+wei08Xlo9IzuR7xxAFVlhN0hDlzBfZwgql2MArvr+30AqItOZsEI81s+cQzlGBJWBujjIwE33RPcuIv1+gaugZO126EkjthmkyNHo1jAkWhgkHQCYBLPVLGzwZHYTHWO2qPc8koNp9HlXbGRb0pxweywmYudnuIycPnX2oU7It/jRqCVap9YRy+pWGaJ86ssV/8jtWKtqjG7T8SEsOmbhbOp22ZkxAhgwLpnBfzsS+WH2RYA4WqAGS3O0lx42Y65NPymyh9QHuY3bA0UOrbrqmTvImvot/tM3UJt9cewCRZbOu0D/CSolCOwToPt+XzmdePE12xoe6FChhHG94VjnSpP92RVXR37+fzQ+9up0/TYMP65VjJxLLf55MPVNmwH+K9i9SrRSz/a3Jlh/clw3wFJHpTgDX0WYPa84ASsmQ4dGacjxGeMNZeZKc6g1zQsmP2w5Q8nVYDcJ3h8jtkTgFXHDHX0QiZn77m/Fbnm7xWg5ySSw89vK7V2qDrXiBpbYBe+bpVdaHQHPSYx3D6Rrj5XEmlpnEmrKV8aPQgPifvXytptBL2+3sz3rp3FH0UUbFThuH12sIZpyoZR00D3TmkUvfN0OyWgWHbS4UagAgjCYB/bBsdMHeuJz0BYzJlJSgqXC/9PJw8FfQ1UdDnsZnmoEcP+8E18QPpDGrdljkNNwCkQbOd3UHqkohZ+SG4t5v387pbitj8KOCWrWaWny2g06hLIWNhNoyjTtjjfvQ70gGegPAsKabsY5bFsED7XFCR06rSREqWfaLGTNPoXP748jO6FmTkCOzhSP3JwdP5GObWXJOYrPU+m/E23RBbcPNLtKiwtljpSFxOYl03p5s/2W/mUcjDHr5RIMP8qLofHzbS92wcvmnj1V7XP29ZPAKE+0eDhYAjGnhn8nQiQCt2aXO8tCl1zy12HlbFCboA52OWAA3TcS43tu42jD+8rtuHyvtkj/HE3CKAVNlWYeYySDiRWYDGEPZZdgSr40sLpyLK6Du79WUi91F3nwZWjzM2/+5wHVcm2SN82g2hMFa1pJ/Lr6/5ItP9A6ztfwUnJlTx/crObR4cZEo8VnrLbiVTPd+QncgGelG2UIojDV+1lbTmu29YowvzI0SeAOqTo6LZ8rm04DK1h/3T8WoAxayg+OV6gfGXO4MKZoXKZk968Cg9LmYJo8oVbQwlsBTuQMnP83oIfXw4U+nhwK3r7Rw8HYNrlG+gEGICSEIigOoC9FWQdHRHR6EPUr6iBk9hCM49W5o2bfTD2jQ1I77IbVlYtf6wX5Pg9/ytngnYUwCbdnJpeE059PTLxFWkrAFqJxb8qSIAGqLtQMHEd7/kRDmqCuuoT0Aw2JmoXxlSsymgoubvs0Q/E4eSYQNZGKf8joSgwdOI76tFRwZdfYebFUhUfkWr9DQApAmi1Bc4Iu5PlUikN2pO2+4aLlW+ZfIyDJlg0++7JqkQOy4/5SlujbiBW755RIVkBtWokY87+84KmEjlxX9vq9hvYjpCavJGWxxI8ucrMAdSMLEwyT5L8fbzgqF7xwU3t+ow/1chmsApQXCscXjCijYH71pqFkaLIx6aNyn/jniJSJYrUOpaafGAejWb1jlYk+OR97Kz29IVwf5N2cPjV8kE0gKdqxC2t+aycftjTFGNN3gUGwFxfoW1rVmB8JIa08M+TLablGSTPdDOXV1O1RhkxVarDVE5H4ZKJK1145IliUjeebvMctErsUdAdLw4yTSC2DRnY4yVGFdTtbUbfGSXoaClZHeRdQjphagMBJf8OZbHft8GxEzJ4Wtaap/ap3LBFnQir8rqpP4VFE3gv9dDHtHx2Vi5Tak6hj1hoJuS6c4wLjtMurGYpVazim8qBoECFc1ncTDH7lqJ6IJtWEpsVXOkvfDV6Yd6xxgdF6+T2Y7YzSr2FNxuiDiz+2tJTs1+JlTHmsXZZYlJzFHsUCZvQyAVE155XHdUtFhVWd1BFAH/4jKnZv0ID8FZJkW0b7/l0FNHw2S/bjH+eSQuaKSPNPOAGUZfodUCt6fllYsH1PHUJtxOoGysjC8F/fOjZjMvQOkw47U7GzDDJroInvwU4m8wovhH0wYqBz1g6NgHHmyApYwGT6vfGtNNU8CwS1XaRUB2i+ru6UWJ6M5l587UGZ+JNPNs3Vvs1L8KCFumjl5f/BN+E5jtD4oBNFVj+IMxcu4rtSmCHlvcmvb+5lHrV6LoxTRbs6YBVD6cULXc3i0iCUrlJ/NKQf/y8H2iA7fqLKwts3ddmnxcLnC3DLjhGYzIY9F4eRs0kfuZMed17ck1N2fGsl5XQFFBL/cAiL8W9jJDCWOFWlv+NxF/FOIe7Fjeb8TJxNghHBEiXBpXV9xvLe45DbOPk6Dw8c2CdUS3ZDd/eUT9c6ZBOo/E5c8mOV/x4DH3cwPPt4OtkPbYKSgzoS8xlIoXkjL0lkWUzh0JqlQc0FssTsPcIKW24webSLodgQrbZ1zBh0g3fdZoxsQjI9vHiJJtOol4fvNLY9QaQUKor0+oqPco45ZdADpo78lRtK4QIIvbt3bOfwD8H7OYMXlB8qh9+77/GHiR0pvMJQNdN0m7jqNJ4t6hqpcnXvsRNKmvhufJjnoKxc70aZm3L33Y0dAwBiO6DrN5cdN7nOQEET+WanAJj/RCsN4Lmktgl7brWYy5noA8qHGEbTQ840wdHcsXsOX7GHLNvqdBMSc/iCUZBnW+lsvHRiW/njJFbQsy4T2FehBH64T+q5y1z4LKo/IxBLgdyhMNPfZsJ2sSrTWdtg3/RMTJKn8xOskqdTSYHe/8rL5AE4PY8Qwd5v6K/wEwqxOJRtQAXIz7XwRGM2VzfSs14u6xNAfLAD8/h/39wSBabGGjYu6b8/wV0XoS4QUJvcj2d7mRonU9P/QllAzcu1/tOhT7oDubxe8aAZ3W8Ezwch69eQE2GQjgbD3tinKqsOUJElGJLLOmZtcDYo4eJYxwlWQai/yam4N0W1pMnn9DPt9FEOtnyrZSpN/DCALf4esujkQArDcki+kztTFWYlfoAWt+s7h+nEseXWn+Db4R9eJvd5vKAAEIYcvNt4fjHEsSfSOkMsAFTju12oqlFBX6mfF4uyQ9l6qXDgJIr7dJ0R/kRaMw6PJq2iO8hk+W1f7NDZtuXssfYHdrtFnYcoXihVdktgLT9bVKuWPByR/fnofvk8ZkHn9VQFJ6sjZcHbtWJWfv+fbw9rQV//DbnCVfqi+xlXYPw+SdW+ONCA439QLSDSe09UUrC8HxRRZBSQNG+xlDIQpekcFgR3AVBRV5SF8kPwGrTxRw5gWx5zocRw833AY5JklkauorcM9a/1MP2ti+JXjbu0JtQ3FBZUYZVJIKS0+K0N0U8wZ+R30JGUYOiroJSICsrInWu7jYLCLisgOnEDjeheh4371SNN30Ho5QBK0sXIJSHyr2BooC4r8CClOqhpWGJ6Kt0vHEcnyC7LiqQ0wHSm6jDAVOR3lGmjbBlduuKAMU5hGmTR0I4023TkXu74xhKegstCNUrUYiVtfil5nB7ZWApprUVfcJdPeEkWQiNEY5/6Ce9tZw3rRS68xVTAtX4X6vIZ9Z2+IMwCuXwePVA89wXNCecn14rxeWHQIfjTlt3O/mJJEDUzfFNSaRBqL4jw9EM0jNwdJOpERQTJKdhj0qhEIlNUVf80ZY0D9tEfkZ6MKMl7i6NCAu3wU2Z1oDrdM1Sfg2z/7JBeE1UrkYQcg4vTYuUSerR0zeXftnZidmcNbJXM1SJJroNaWw1k3epeMbGyVK+BBrcaExj0cVyD2l8le9jdoRuvljfVe2FNdhkdMba9nf7vEh9oinTMNWgxX4c3+Jxfhee0mnWKx+5Hbz78VyWOyUqlLEb19wPT41mKrQplGNNBKFvN6NsLsjjjMlRSu7kYPR/euoad6oqm+4Y6UhHoszXXzPHU3x428Unoz1onFKri9tNvj6XZNHgqhMs6F8L3cYnzY2WuuMPjf5jXtYZo0OvUY3fFxKj+bYHTJ/8Za+xIfXLnnbajGUxd8Ngp8aUns9RqOxwggAJFg6DXt3HBU9XOUKAnYyFbybPstuougtTL9kZLVym+2g5k9xp66TPg9OwgrS7K0gAn1SR5X4vuntGMVz8JHpc8l3/+XbFoCStXg0CKSas2AmEi8VHSebAynGqhk9lMYWP8LqIbfp+yix/vvGvpMfCju+H4duh6IqCDERFanZr+2z6T0gx7AHDfB4n8RUy4GZi3ShP1uvpCfKcMbEit4QboBJg+FUyA3RTtREhgpW13K012M+XJg8PkQFH/OW/ej6cvtY4DV/4nIY8/UMUqY0ThwEx8CGsoiZTrFqIJBNfYpwwkWc63WaALps5ThSK1E6eiHnBqZAwwiyVaLTQBPt092KjiVrnC/51tZokULhBQGhKZG+FhxvWCh1SWRQqOQG3MdpbKGz7pDbAhd6i5jI8NU7UocKR/OLx1oheD4VMJIVMuWVrN0Bb4g/hD2VMhI+ijzpvLcgtlYfdZM/5To8SO9dQknHxYXfVf8kk7YEesRkgEtgwq53YN2q/QCwHYwfi4GXANMo3KycUIPb3bg9AOgzXGPQTSZg0A6elchtgICyjXPvezCCQgm6msuJ7wYG4IXn2qlS2DCrndg3arfwIXqwK3Cw3W53NyFBajd0lnp9pIDzag6VlGidMZibLOml9tyN08ad7gAFca0BkQ2CHeMw6uKvZi0deVFtE3LNr78Wd4b/WbdOEBDthWsgatajdqStzj4SV1L0IBrbkdXWIpPwBsSTi3W5cd0IzBSQXdkhfTn7FFta8pjz1GTsUk/GqKhuInzQckGoT+WO33nqAK7q4kujdhkBfz7KBdUT6ksDSsm4TbeasXBS4I5IiysJ35BgNW+RYf0QmJTk+pdnBXGcCCuxEPw7kLojkYBbfHcmlxjQv2acVfGLDW6GBCl/Ux/6E8lsl0lspfzrT8rY05UsDpGTbGsDnrinhwMO6PvvILgnfTSY9oaHUzCMlrA0lFG3KrZ5V34PEmoseAqtj4PGyXNbuhkGCXHTbS5xFYl8iSrjeAuCs8Saix4Nh2Op022z1ZU++6Su00snFCD280DtHypMXwAL/5KYgS3TwLMUuj4TpLvt5zXxFHAiV/soEHuSjgEJBsdB2mCOqx52BcAGvl1vZXpL6MGokrVbQOEophbdCryAnnEFGsqRfZW7EJBN2PJOATOHc71AyWMOJWxImwqoB0xGo9LIR34aBwrXW914NddGj3lpla6z6AihH6C62y0VxDOC/8TEEXQXrqPdeoFxHTQ+wSn8yh+N+5BOpRpvXwXzjUxD3Rwwb2qNN5yUW2be6UeK/W8pXKn3DfV+5RzruubSCxkURKpc7ohtxy8NRKm2OTt3TcHOFu9SUamdDDsA+WjyJHX0CsJfpfGiFlLvccVzDYNgwlldCtzhOPBBCmJ9F5o30owFHJn2YYanWKjtEbf8SLMFsXSY7alAd1/wKJ5Wm3a0+wU/2Epyjg/xVvAppeGSLxg3U5GschqUE3Yk/nyhZ2UNcJioCyQF34OgSaE5B26GaVlRsYTSZPIYYDMirBS9PHdwh2AIBuMUh3tf78zEIBo5F5dahUafy3cf91pJivoII8x6IVWfbwqLpzAKJi9ixHk6AMBG90xSoybo3dZy+fHb0Nq8nhuwaT1IpzvIW4oIok+wtpmq8kvTht6yDHEPW4Y8JOjmcNRTka3C/H7okhBymmhQpB/v/ku21NCYfgeqok/QDuin9EdrjYcvSasGMF3bin/5CoMa4uCwjmslQzXLvpRFquF1AVsNbKnbcS5cn/6jzfJD72YWWoX3fwWwqMvqllepWBdMglhCjd7rbeFAyaUdpUWIjQ8/Kiz9igeh3s0NhnGz9edGrUtp7nUlvZ5oyrp4L6g0JFxnI4hEdLgMSB+eBX2EEl5zVVzHyray2jwSPMASGfS5fg6CyVFolAGX4HatA7IAMadqofR4/Cel5V/gidmlCYAraDePrjMFEFq7yuzcZi2W/ImwxyAfVMPeBq8jmIA05+V5akmX7b0q9Efpv9Em8zXaDbPkEfDYN46TMQHXiJeI6lJ4oJUkKuDO3Htv8rFesT3LI4PU0He3fBC7n21Qzb/H/swJ2B/pTp6+561CDA4fbMh1tksby53UAJTr2/DfKeoHDL7AAAA==",
+        "height": 16383
+      }
+    }
+  },
+  "analysisUTCTimestamp": "2026-05-14T17:22:10.648Z"
+}

--- a/tmp/perf-20260514/psi-blog_structurer_la_croissance_pour_liberer_la_vente_exemple_surfe.json
+++ b/tmp/perf-20260514/psi-blog_structurer_la_croissance_pour_liberer_la_vente_exemple_surfe.json
@@ -1,0 +1,6582 @@
+{
+  "captchaResult": "CAPTCHA_NOT_NEEDED",
+  "kind": "pagespeedonline#result",
+  "id": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+  "loadingExperience": {
+    "initial_url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+  },
+  "lighthouseResult": {
+    "requestedUrl": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+    "finalUrl": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+    "mainDocumentUrl": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+    "finalDisplayedUrl": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+    "lighthouseVersion": "13.0.1",
+    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+    "fetchTime": "2026-05-14T17:22:41.423Z",
+    "environment": {
+      "networkUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36",
+      "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+      "benchmarkIndex": 595
+    },
+    "runWarnings": [],
+    "configSettings": {
+      "emulatedFormFactor": "mobile",
+      "formFactor": "mobile",
+      "locale": "en-US",
+      "onlyCategories": [
+        "performance"
+      ],
+      "channel": "lr"
+    },
+    "audits": {
+      "layout-shifts": {
+        "id": "layout-shifts",
+        "title": "Avoid large layout shifts",
+        "description": "These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "2 layout shifts found",
+        "metricSavings": {
+          "CLS": 0.007
+        },
+        "details": {
+          "items": [
+            {
+              "score": 0.007047,
+              "node": {
+                "snippet": "\u003cp class=\"font-style_italic fs_lg md:fs_xl c_gray.600 lh_relaxed mb_8\"\u003e",
+                "nodeLabel": "— Dans les scale-ups SaaS, la croissance peut vite devenir difficile à piloter …",
+                "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,DIV,2,ARTICLE,1,MAIN,0,P",
+                "lhId": "page-5-P",
+                "type": "node",
+                "selector": "div \u003e article.d_grid \u003e main.grid-area_main \u003e p.font-style_italic",
+                "boundingRect": {
+                  "width": 0,
+                  "left": 0,
+                  "bottom": 0,
+                  "height": 0,
+                  "right": 0,
+                  "top": 0
+                }
+              },
+              "subItems": {
+                "items": [
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                      "type": "url"
+                    }
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                      "type": "url"
+                    }
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                      "type": "url"
+                    }
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+                      "type": "url"
+                    }
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "extra": {
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "type": "url",
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                    }
+                  }
+                ],
+                "type": "subitems"
+              },
+              "score": 0
+            }
+          ],
+          "headings": [
+            {
+              "label": "Element",
+              "valueType": "node",
+              "key": "node",
+              "subItemsHeading": {
+                "key": "extra"
+              }
+            },
+            {
+              "valueType": "numeric",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "cause"
+              },
+              "label": "Layout shift score",
+              "key": "score",
+              "granularity": 0.001
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "metrics": {
+        "id": "metrics",
+        "title": "Metrics",
+        "description": "Collects all available metrics.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "observedFirstVisualChange": 1333,
+              "observedTraceEnd": 6437,
+              "observedLoad": 1845,
+              "observedLargestContentfulPaintTs": 107696654155,
+              "observedTraceEndTs": 107701758721,
+              "cumulativeLayoutShift": 0.007047,
+              "observedNavigationStartTs": 107695322010,
+              "observedFirstPaint": 1332,
+              "observedFirstPaintTs": 107696654155,
+              "largestContentfulPaint": 5626,
+              "observedTimeOriginTs": 107695322010,
+              "observedCumulativeLayoutShift": 0.007047,
+              "observedDomContentLoadedTs": 107696779442,
+              "observedLargestContentfulPaint": 1332,
+              "speedIndex": 4283,
+              "observedFirstContentfulPaint": 1332,
+              "observedLargestContentfulPaintAllFramesTs": 107696654155,
+              "observedLastVisualChangeTs": 107698586010,
+              "observedFirstContentfulPaintTs": 107696654155,
+              "observedLoadTs": 107697166835,
+              "observedSpeedIndex": 1358,
+              "observedTimeOrigin": 0,
+              "cumulativeLayoutShiftMainFrame": 0.007047,
+              "observedLargestContentfulPaintAllFrames": 1332,
+              "lcpLoadDuration": 2596,
+              "observedCumulativeLayoutShiftMainFrame": 0.007047,
+              "lcpLoadDelay": 2470,
+              "observedFirstVisualChangeTs": 107696655010,
+              "observedLastVisualChange": 3264,
+              "maxPotentialFID": 339,
+              "observedNavigationStart": 0,
+              "totalBlockingTime": 1455,
+              "interactive": 10876,
+              "observedDomContentLoaded": 1457,
+              "observedFirstContentfulPaintAllFrames": 1332,
+              "timeToFirstByte": 601,
+              "observedFirstContentfulPaintAllFramesTs": 107696654155,
+              "firstContentfulPaint": 3601,
+              "observedSpeedIndexTs": 107696679556
+            },
+            {
+              "lcpInvalidated": false
+            }
+          ]
+        },
+        "numericValue": 10876,
+        "numericUnit": "millisecond"
+      },
+      "network-requests": {
+        "id": "network-requests",
+        "title": "Network Requests",
+        "description": "Lists the network requests that were made during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 2.3900000005960464,
+              "resourceType": "Document",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 0,
+              "mimeType": "text/html",
+              "protocol": "h2",
+              "resourceSize": 117975,
+              "transferSize": 22074,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+              "priority": "VeryHigh",
+              "networkEndTime": 560.64800000190735
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 582.01200000941753,
+              "mimeType": "text/css",
+              "protocol": "h2",
+              "resourceSize": 122090,
+              "transferSize": 24570,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "priority": "VeryHigh",
+              "networkEndTime": 623.86300000548363,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 584.15399999916553,
+              "resourceType": "Stylesheet"
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "image/png",
+              "rendererStartTime": 582.55900001525879,
+              "experimentalFromMainFrame": true,
+              "priority": "Medium",
+              "networkEndTime": 622.32999999821186,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "transferSize": 12758,
+              "resourceSize": 12266,
+              "entity": "ocobo.co",
+              "resourceType": "Image",
+              "networkRequestTime": 584.26999999582767,
+              "finished": true,
+              "statusCode": 200
+            },
+            {
+              "resourceType": "Image",
+              "networkRequestTime": 584.35799999535084,
+              "statusCode": 200,
+              "finished": true,
+              "entity": "ocobo.co",
+              "priority": "Medium",
+              "networkEndTime": 738.9839999973774,
+              "url": "https://www.ocobo.co/images/partners/modern-revenue-club.png",
+              "sessionTargetType": "page",
+              "transferSize": 29545,
+              "resourceSize": 29045,
+              "protocol": "h2",
+              "rendererStartTime": 583.48800000548363,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "resourceSize": 201358,
+              "transferSize": 202020,
+              "sessionTargetType": "page",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png",
+              "networkEndTime": 614.48600001633167,
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 583.69900000095367,
+              "mimeType": "image/png",
+              "protocol": "h2",
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 584.53900000453,
+              "resourceType": "Image",
+              "entity": "vercel-storage.com"
+            },
+            {
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 649.81499999761581,
+              "resourceType": "Image",
+              "entity": "vercel-storage.com",
+              "resourceSize": 66917,
+              "transferSize": 67588,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "networkEndTime": 686.45100000500679,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/jpeg",
+              "rendererStartTime": 583.88100001215935,
+              "protocol": "h2"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 584.01800000667572,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "resourceSize": 471493,
+              "transferSize": 157034,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "networkEndTime": 758.58400000631809,
+              "entity": "Google Tag Manager",
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 650.162000015378,
+              "resourceType": "Script"
+            },
+            {
+              "mimeType": "application/javascript",
+              "rendererStartTime": 584.18299999833107,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 639,
+              "resourceSize": 0,
+              "priority": "Low",
+              "networkEndTime": 1333.2820000052452,
+              "sessionTargetType": "page",
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "entity": "Clearbit",
+              "finished": true,
+              "statusCode": 404,
+              "resourceType": "Script",
+              "networkRequestTime": 650.23400001227856
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 650.29900000989437,
+              "entity": "Hubspot",
+              "transferSize": 1672,
+              "resourceSize": 2125,
+              "networkEndTime": 686.09499999880791,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "rendererStartTime": 584.33600001037121,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "entity": "GitHub",
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "networkRequestTime": 650.3660000115633,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 584.45200000703335,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 5017,
+              "resourceSize": 17494,
+              "priority": "Low",
+              "networkEndTime": 674.06100000441074,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "sessionTargetType": "page"
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 650.43500000238419,
+              "entity": "ausha.co",
+              "transferSize": 1513,
+              "resourceSize": 2558,
+              "networkEndTime": 960.14400000870228,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "url": "https://player.ausha.co/ausha-player.js",
+              "rendererStartTime": 584.54800000786781,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 586.19699999690056,
+              "rendererStartTime": 584.65700000524521,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 24115,
+              "resourceSize": 69556,
+              "priority": "High",
+              "networkEndTime": 624.58600001037121,
+              "url": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "sessionTargetType": "page"
+            },
+            {
+              "resourceType": "Script",
+              "networkRequestTime": 586.98600000143051,
+              "finished": true,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "priority": "High",
+              "networkEndTime": 622.92200000584126,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "transferSize": 1455,
+              "resourceSize": 927,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 584.82500000298023,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "resourceType": "Script",
+              "networkRequestTime": 587.12500001490116,
+              "statusCode": 200,
+              "finished": true,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "networkEndTime": 761.6169999986887,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "sessionTargetType": "page",
+              "transferSize": 43924,
+              "resourceSize": 125397,
+              "protocol": "h2",
+              "rendererStartTime": 584.98000000417233,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 585.13799999654293,
+              "protocol": "h2",
+              "resourceSize": 133936,
+              "transferSize": 45261,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "networkEndTime": 628.43699999153614,
+              "priority": "High",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 587.22100000083447,
+              "resourceType": "Script"
+            },
+            {
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 585.25699999928474,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "networkEndTime": 627.24600000679493,
+              "priority": "High",
+              "resourceSize": 110060,
+              "transferSize": 34185,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "networkRequestTime": 587.52400000393391,
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200
+            },
+            {
+              "url": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkEndTime": 630.60300000011921,
+              "resourceSize": 991,
+              "transferSize": 1515,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 585.46400001645088,
+              "networkRequestTime": 587.85600000619888,
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "isLinkPreload": true
+            },
+            {
+              "priority": "High",
+              "networkEndTime": 623.28200000524521,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "transferSize": 4523,
+              "resourceSize": 9799,
+              "protocol": "h2",
+              "rendererStartTime": 585.597000002861,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "networkRequestTime": 588.08800001442432,
+              "statusCode": 200,
+              "finished": true,
+              "entity": "ocobo.co",
+              "isLinkPreload": true
+            },
+            {
+              "priority": "High",
+              "networkEndTime": 781.30800001323223,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "transferSize": 2148,
+              "resourceSize": 3192,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 585.69300000369549,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "networkRequestTime": 588.18900001049042,
+              "finished": true,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "isLinkPreload": true
+            },
+            {
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "networkRequestTime": 588.36300000548363,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 585.82900001108646,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 670,
+              "resourceSize": 141,
+              "networkEndTime": 629.66500000655651,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js"
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 588.97900000214577,
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "transferSize": 1270,
+              "resourceSize": 1284,
+              "networkEndTime": 625.06300000846386,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "rendererStartTime": 585.94099999964237,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "networkRequestTime": 589.35500000417233,
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 586.09000000357628,
+              "url": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 760.136000007391,
+              "priority": "High",
+              "resourceSize": 15426,
+              "transferSize": 6806
+            },
+            {
+              "networkRequestTime": 589.5869999974966,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "finished": true,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "priority": "High",
+              "networkEndTime": 634.07700000703335,
+              "resourceSize": 17234,
+              "transferSize": 6206,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 586.21100001037121,
+              "mimeType": "application/javascript"
+            },
+            {
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 590.58900000154972,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 586.34100000560284,
+              "protocol": "h2",
+              "resourceSize": 3070,
+              "transferSize": 1833,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "priority": "High",
+              "networkEndTime": 630.86599999666214
+            },
+            {
+              "resourceSize": 428,
+              "transferSize": 954,
+              "url": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkEndTime": 639.08599999547,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 586.48700000345707,
+              "protocol": "h2",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 590.93300001323223,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co"
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "networkEndTime": 634.73100000619888,
+              "priority": "High",
+              "resourceSize": 410,
+              "transferSize": 938,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 586.60900001227856,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 591.03900000453,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "finished": true,
+              "entity": "ocobo.co",
+              "isLinkPreload": true
+            },
+            {
+              "mimeType": "application/javascript",
+              "rendererStartTime": 586.74600000679493,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 1048,
+              "resourceSize": 525,
+              "priority": "High",
+              "networkEndTime": 638.26000000536442,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "networkRequestTime": 591.17700000107288
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 586.86200000345707,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "networkEndTime": 920.80700001120567,
+              "url": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "sessionTargetType": "page",
+              "transferSize": 1471,
+              "resourceSize": 942,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "networkRequestTime": 592.11200000345707,
+              "finished": true,
+              "statusCode": 200
+            },
+            {
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 592.31000000238419,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "resourceSize": 349,
+              "transferSize": 877,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "networkEndTime": 641.89699999988079,
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 587.18000000715256,
+              "protocol": "h2"
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 592.64000001549721,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "resourceSize": 1866,
+              "transferSize": 1368,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "priority": "High",
+              "networkEndTime": 634.50100000202656,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 587.32600000500679,
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "resourceSize": 348,
+              "transferSize": 867,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "priority": "High",
+              "networkEndTime": 745.56000000238419,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 587.429000005126,
+              "protocol": "h2",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 592.82100000977516,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co"
+            },
+            {
+              "resourceType": "Script",
+              "networkRequestTime": 592.97900000214577,
+              "finished": true,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "priority": "High",
+              "networkEndTime": 642.75699999928474,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "transferSize": 21253,
+              "resourceSize": 67398,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 587.761000007391,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 593.13400000333786,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "resourceSize": 165,
+              "transferSize": 702,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "networkEndTime": 630.33800001442432,
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 588.22900000214577,
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 588.49400000274181,
+              "protocol": "h2",
+              "resourceSize": 605,
+              "transferSize": 1127,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "networkEndTime": 787.73000000417233,
+              "priority": "High",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 593.787000015378,
+              "resourceType": "Script"
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 588.69099999964237,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "networkEndTime": 641.46299999952316,
+              "url": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "sessionTargetType": "page",
+              "transferSize": 1346,
+              "resourceSize": 826,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "networkRequestTime": 593.96299999952316,
+              "finished": true,
+              "statusCode": 200
+            },
+            {
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 594.38700000941753,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 588.82900001108646,
+              "protocol": "h2",
+              "resourceSize": 404,
+              "transferSize": 930,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "networkEndTime": 631.07299999892712,
+              "priority": "High"
+            },
+            {
+              "networkEndTime": 644.51800000667572,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "transferSize": 1012,
+              "resourceSize": 490,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 589.01700001955032,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "networkRequestTime": 594.9919999986887,
+              "finished": true,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "isLinkPreload": true
+            },
+            {
+              "transferSize": 726,
+              "resourceSize": 206,
+              "networkEndTime": 750.17000000178814,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 589.21000000834465,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "networkRequestTime": 595.11599999666214,
+              "isLinkPreload": true,
+              "entity": "ocobo.co"
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 595.25699999928474,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "resourceSize": 835,
+              "transferSize": 1359,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "networkEndTime": 636.44200000166893,
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 589.41500000655651,
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 595.38199999928474,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "resourceSize": 68826,
+              "transferSize": 26412,
+              "url": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkEndTime": 749.093000009656,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 589.62299999594688,
+              "protocol": "h2"
+            },
+            {
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 595.56700000166893,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 589.76800000667572,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "resourceSize": 473,
+              "transferSize": 998,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "priority": "High",
+              "networkEndTime": 633.60099999606609
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "priority": "High",
+              "networkEndTime": 635.78900000453,
+              "resourceSize": 338,
+              "transferSize": 856,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 589.8830000013113,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 598.6540000140667,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "finished": true,
+              "entity": "ocobo.co",
+              "isLinkPreload": true
+            },
+            {
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 598.792999997735,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "resourceSize": 435,
+              "transferSize": 964,
+              "url": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkEndTime": 772.9450000077486,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 589.99500000476837,
+              "protocol": "h2"
+            },
+            {
+              "mimeType": "application/javascript",
+              "rendererStartTime": 590.152999997139,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 841,
+              "resourceSize": 312,
+              "networkEndTime": 653.28299999237061,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "networkRequestTime": 599.98700000345707
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "networkEndTime": 636.20900000631809,
+              "priority": "High",
+              "resourceSize": 309,
+              "transferSize": 832,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 590.32200001180172,
+              "networkRequestTime": 600.05100001394749,
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "isLinkPreload": true
+            },
+            {
+              "transferSize": 3337,
+              "resourceSize": 6433,
+              "networkEndTime": 745.05200000107288,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/_main.blog._slug-CVkfQxlz.js",
+              "sessionTargetType": "page",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 590.48299999535084,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "networkRequestTime": 601.28499999642372,
+              "isLinkPreload": true,
+              "entity": "ocobo.co"
+            },
+            {
+              "transferSize": 1016,
+              "resourceSize": 495,
+              "priority": "High",
+              "networkEndTime": 763.65800000727177,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/badge-i9dgPBIb.js",
+              "rendererStartTime": 590.65200001001358,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 601.40899999439716,
+              "isLinkPreload": true,
+              "entity": "ocobo.co"
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 601.49200001358986,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "resourceSize": 717,
+              "transferSize": 1238,
+              "url": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkEndTime": 639.75699999928474,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 590.7660000026226,
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 590.86800000071526,
+              "protocol": "h2",
+              "resourceSize": 272,
+              "transferSize": 804,
+              "url": "https://www.ocobo.co/assets/optimized-image-BKBFj58i.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 637.91599999368191,
+              "priority": "High",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 601.58600001037121,
+              "resourceType": "Script"
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 602.06300000846386,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "resourceSize": 310,
+              "transferSize": 833,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/labels-CtAnB7VF.js",
+              "networkEndTime": 636.92400000989437,
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 591.027999997139,
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 602.109999999404,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "resourceSize": 302,
+              "transferSize": 830,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js",
+              "priority": "High",
+              "networkEndTime": 641.01800000667572,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 591.21099999547,
+              "protocol": "h2"
+            },
+            {
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 605.60199999809265,
+              "rendererStartTime": 591.38800001144409,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 1845,
+              "resourceSize": 2543,
+              "priority": "High",
+              "networkEndTime": 841.484999999404,
+              "url": "https://www.ocobo.co/assets/LayoutPost-BT26K59V.js",
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "networkRequestTime": 605.7660000026226,
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 591.52300000190735,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/PageMarkdownContainer-klsUvxsc.js",
+              "networkEndTime": 765.64100001752377,
+              "priority": "High",
+              "resourceSize": 3508,
+              "transferSize": 1934
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 605.85300000011921,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "resourceSize": 2533,
+              "transferSize": 1822,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/member-card-Bn7bfGBT.js",
+              "networkEndTime": 792.80100001394749,
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 591.667999997735,
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 591.7960000038147,
+              "url": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkEndTime": 643.41700001060963,
+              "resourceSize": 549,
+              "transferSize": 1075,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "networkRequestTime": 605.96500000357628,
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200
+            },
+            {
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "networkRequestTime": 606.04500000178814,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 591.91099999845028,
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "networkEndTime": 640.49400000274181,
+              "priority": "High",
+              "resourceSize": 1217,
+              "transferSize": 1133
+            },
+            {
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 606.11400000751019,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 592.07700000703335,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "resourceSize": 142638,
+              "transferSize": 51797,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "networkEndTime": 858.31599999964237,
+              "priority": "High"
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 606.17299999296665,
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "transferSize": 1125,
+              "resourceSize": 605,
+              "priority": "High",
+              "networkEndTime": 789.48800000548363,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "rendererStartTime": 592.18400000035763,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "resourceSize": 58256,
+              "transferSize": 39127,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+              "networkEndTime": 701.569000005722,
+              "priority": "VeryHigh",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 671.14399999380112,
+              "mimeType": "font/otf",
+              "protocol": "h2",
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 672.65500000119209,
+              "resourceType": "Font",
+              "entity": "ocobo.co"
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 671.48200000822544,
+              "mimeType": "font/woff",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 698.94600000977516,
+              "priority": "VeryHigh",
+              "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+              "sessionTargetType": "page",
+              "transferSize": 31975,
+              "resourceSize": 31480,
+              "entity": "ocobo.co",
+              "resourceType": "Font",
+              "networkRequestTime": 672.84499999880791,
+              "statusCode": 200,
+              "finished": true
+            },
+            {
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "Font",
+              "networkRequestTime": 672.9539999961853,
+              "entity": "ocobo.co",
+              "transferSize": 38778,
+              "resourceSize": 57572,
+              "priority": "VeryHigh",
+              "networkEndTime": 826.25400000810623,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+              "sessionTargetType": "page",
+              "mimeType": "font/otf",
+              "rendererStartTime": 671.68200001120567,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "entity": "ocobo.co",
+              "resourceType": "Font",
+              "networkRequestTime": 673.02800001204014,
+              "statusCode": 200,
+              "finished": true,
+              "protocol": "h2",
+              "rendererStartTime": 672.00700001418591,
+              "mimeType": "font/otf",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 865.917999997735,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+              "transferSize": 40710,
+              "resourceSize": 60228
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 1533.0209999978542,
+              "mimeType": "text/css",
+              "experimentalFromMainFrame": true,
+              "priority": "VeryHigh",
+              "networkEndTime": 1581.3780000060797,
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "sessionTargetType": "page",
+              "transferSize": 1998,
+              "resourceSize": 4371,
+              "entity": "GitHub",
+              "resourceType": "Stylesheet",
+              "networkRequestTime": 1537.4170000106096,
+              "statusCode": 200,
+              "finished": true
+            },
+            {
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Image",
+              "networkRequestTime": 1538.8920000046492,
+              "entity": "ocobo.co",
+              "transferSize": 17171,
+              "resourceSize": 16667,
+              "networkEndTime": 1566.4930000156164,
+              "priority": "Low",
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "sessionTargetType": "page",
+              "rendererStartTime": 1536.8139999955893,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "resourceSize": 97992,
+              "transferSize": 29757,
+              "sessionTargetType": "page",
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "priority": "Low",
+              "networkEndTime": 1576.5580000132322,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 1539.2950000017881,
+              "protocol": "h2",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 1540.5270000100136,
+              "resourceType": "Script",
+              "entity": "Hubspot"
+            },
+            {
+              "entity": "Hubspot",
+              "resourceType": "Script",
+              "networkRequestTime": 1540.6810000091791,
+              "finished": true,
+              "statusCode": 200,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 1539.7690000087023,
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "networkEndTime": 1570.9820000082254,
+              "sessionTargetType": "page",
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "transferSize": 27955,
+              "resourceSize": 78203
+            },
+            {
+              "resourceType": "Script",
+              "networkRequestTime": 1541.2460000067949,
+              "finished": true,
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "priority": "Low",
+              "networkEndTime": 1573.2360000014305,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "sessionTargetType": "page",
+              "transferSize": 43664,
+              "resourceSize": 109001,
+              "protocol": "h2",
+              "mimeType": "text/javascript",
+              "rendererStartTime": 1540.152999997139,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "rendererStartTime": 1540.5440000146627,
+              "mimeType": "text/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 27219,
+              "resourceSize": 72678,
+              "networkEndTime": 1572.5040000081062,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 1541.417999997735
+            },
+            {
+              "mimeType": "text/plain",
+              "rendererStartTime": 1700.2530000060797,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 796,
+              "resourceSize": 0,
+              "networkEndTime": 1745.7800000011921,
+              "priority": "High",
+              "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65c1h1v9100339653za200zd9100339653&_p=1778779362307&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1977217704.1778779363&frm=0&pscdl=noapi&rcb=15&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115938465~115938468~118128922~118228215&dp=%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&sid=1778779363&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&dt=Ocobo%20%C2%B7%20Structurer%20la%20croissance%20pour%20lib%C3%A9rer%20la%20vente%C2%A0%3A%20l%27exemple%20de%20Surfe&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1700",
+              "sessionTargetType": "page",
+              "entity": "Google Analytics",
+              "finished": true,
+              "statusCode": 204,
+              "resourceType": "Fetch",
+              "networkRequestTime": 1702.3640000075102
+            },
+            {
+              "mimeType": "application/json",
+              "rendererStartTime": 1754.9600000083447,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 1095,
+              "resourceSize": 135,
+              "networkEndTime": 1799.1480000168085,
+              "priority": "High",
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "XHR",
+              "networkRequestTime": 1758.7740000039339
+            },
+            {
+              "entity": "Hubspot",
+              "networkRequestTime": 1779.8510000109673,
+              "resourceType": "Fetch",
+              "finished": true,
+              "statusCode": 200,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/plain",
+              "rendererStartTime": 1776.734999999404,
+              "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+              "sessionTargetType": "page",
+              "networkEndTime": 1806.5450000017881,
+              "priority": "High",
+              "resourceSize": 5,
+              "transferSize": 558
+            },
+            {
+              "entity": "Hubspot",
+              "resourceType": "Image",
+              "networkRequestTime": 1846.0150000154972,
+              "finished": true,
+              "statusCode": 200,
+              "protocol": "h2",
+              "mimeType": "image/gif",
+              "rendererStartTime": 1844.2430000007153,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1918.5020000040531,
+              "priority": "Low",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778779363511&vi=5adaa0527fcfafeaf1991097a3e493da&nc=true&ce=false&cc=0",
+              "sessionTargetType": "page",
+              "transferSize": 1482,
+              "resourceSize": 45
+            },
+            {
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "Fetch",
+              "networkRequestTime": 1905.5380000025034,
+              "entity": "Hubspot",
+              "transferSize": 1724,
+              "resourceSize": 61,
+              "priority": "High",
+              "networkEndTime": 2020.5439999997616,
+              "sessionTargetType": "page",
+              "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&utk=5adaa0527fcfafeaf1991097a3e493da&__hstc=242475741.5adaa0527fcfafeaf1991097a3e493da.1778779363508.1778779363508.1778779363508.1&__hssc=242475741.1.1778779363508&isMobile=true",
+              "mimeType": "application/json",
+              "rendererStartTime": 1903.7960000038147,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "networkRequestTime": 2485.9610000103712,
+              "resourceType": "Image",
+              "finished": true,
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+              "networkEndTime": 2584.554000005126,
+              "priority": "Low",
+              "resourceSize": 35,
+              "transferSize": 1021,
+              "protocol": "http/1.1",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/gif",
+              "rendererStartTime": 2484.4660000056028
+            },
+            {
+              "networkRequestTime": 3262.7269999980927,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "finished": true,
+              "entity": "Hubspot",
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 3327.8110000044107,
+              "priority": "Low",
+              "resourceSize": 607831,
+              "transferSize": 204718,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 3260.5480000078678,
+              "mimeType": "application/javascript"
+            },
+            {
+              "transferSize": 639,
+              "resourceSize": 0,
+              "networkEndTime": 3464.2830000072718,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 3263.261000007391,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "statusCode": 404,
+              "resourceType": "Script",
+              "networkRequestTime": 3266.8270000070333,
+              "entity": "Clearbit"
+            },
+            {
+              "finished": true,
+              "statusCode": 304,
+              "networkRequestTime": 3267.0330000072718,
+              "resourceType": "Script",
+              "entity": "Hubspot",
+              "resourceSize": 2125,
+              "transferSize": 555,
+              "sessionTargetType": "page",
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "networkEndTime": 3298.2099999934435,
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 3264.2930000126362,
+              "protocol": "h2"
+            },
+            {
+              "priority": "Low",
+              "networkEndTime": 3564.2240000069141,
+              "url": "https://player.ausha.co/ausha-player.js",
+              "sessionTargetType": "page",
+              "transferSize": 705,
+              "resourceSize": 2558,
+              "protocol": "h2",
+              "rendererStartTime": 3265.5310000032187,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "networkRequestTime": 3267.0980000048876,
+              "statusCode": 304,
+              "finished": true,
+              "entity": "ausha.co"
+            },
+            {
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 3271.6539999991655,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "resourceSize": 2495,
+              "transferSize": 1865,
+              "url": "https://www.ocobo.co/_vercel/insights/script.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 3319.7140000015497,
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 3267.36400000751,
+              "protocol": "h2"
+            },
+            {
+              "entity": "ocobo.co",
+              "networkRequestTime": 3271.7710000127554,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 3269.0310000032187,
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 3303.5020000040531,
+              "priority": "Low",
+              "resourceSize": 12567,
+              "transferSize": 5310
+            },
+            {
+              "resourceSize": 16621,
+              "transferSize": 2482,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe%2C%2Fclients%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology&version=ba6d9b28",
+              "priority": "High",
+              "networkEndTime": 3336.7280000001192,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 3271.8349999934435,
+              "mimeType": "application/json",
+              "protocol": "h2",
+              "statusCode": 200,
+              "finished": true,
+              "networkRequestTime": 3273.4270000010729,
+              "resourceType": "Fetch",
+              "entity": "ocobo.co"
+            },
+            {
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "rendererStartTime": 3408.679000005126,
+              "url": "https://www.ocobo.co/_vercel/insights/view",
+              "sessionTargetType": "page",
+              "networkEndTime": 3598.5209999978542,
+              "priority": "High",
+              "resourceSize": 48,
+              "transferSize": 473,
+              "entity": "ocobo.co",
+              "networkRequestTime": 3413.8600000143051,
+              "resourceType": "Fetch",
+              "finished": true,
+              "statusCode": 202
+            },
+            {
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "XHR",
+              "networkRequestTime": 3626.8260000050068,
+              "rendererStartTime": 3622.8680000156164,
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "protocol": "http/1.1",
+              "transferSize": 4081,
+              "resourceSize": 9346,
+              "networkEndTime": 3714.2160000056028,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953&hutk=5adaa0527fcfafeaf1991097a3e493da"
+            },
+            {
+              "entity": "Hubspot",
+              "networkRequestTime": 3700.7940000146627,
+              "resourceType": "XHR",
+              "finished": true,
+              "statusCode": 200,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "rendererStartTime": 3698.8390000164509,
+              "sessionTargetType": "page",
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=5adaa0527fcfafeaf1991097a3e493da",
+              "priority": "High",
+              "networkEndTime": 3748.0450000017881,
+              "resourceSize": 135,
+              "transferSize": 1095
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "image/gif",
+              "rendererStartTime": 3718.3870000094175,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 3806.2709999978542,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778779365381&vi=5adaa0527fcfafeaf1991097a3e493da&nc=true&u=242475741.5adaa0527fcfafeaf1991097a3e493da.1778779363508.1778779363508.1778779363508.1&b=242475741.1.1778779363508&cc=15",
+              "transferSize": 1026,
+              "resourceSize": 45,
+              "entity": "Hubspot",
+              "resourceType": "Image",
+              "networkRequestTime": 3720.4360000044107,
+              "finished": true,
+              "statusCode": 200
+            },
+            {
+              "networkRequestTime": 3741.9110000133514,
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 304,
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "networkEndTime": 3764.4770000129938,
+              "priority": "Low",
+              "resourceSize": 607831,
+              "transferSize": 1657,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 3739.7570000141859
+            },
+            {
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "Image",
+              "networkRequestTime": 4260.8930000066757,
+              "entity": "Hubspot",
+              "transferSize": 1024,
+              "resourceSize": 35,
+              "priority": "Low",
+              "networkEndTime": 4324.2559999972582,
+              "sessionTargetType": "page",
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+              "mimeType": "image/gif",
+              "rendererStartTime": 4257.580000013113,
+              "experimentalFromMainFrame": true,
+              "protocol": "http/1.1"
+            },
+            {
+              "entity": "Google Fonts",
+              "finished": true,
+              "statusCode": 200,
+              "resourceType": "Stylesheet",
+              "networkRequestTime": 4273.1070000082254,
+              "mimeType": "text/css",
+              "rendererStartTime": 4270.7540000081062,
+              "protocol": "h2",
+              "transferSize": 1259,
+              "resourceSize": 3792,
+              "priority": "VeryHigh",
+              "networkEndTime": 4288.7150000035763,
+              "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "Google Fonts",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 4339.733000010252,
+              "resourceType": "Font",
+              "mimeType": "font/woff2",
+              "rendererStartTime": 4337.5120000094175,
+              "protocol": "h2",
+              "resourceSize": 50524,
+              "transferSize": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "sessionTargetType": "page",
+              "networkEndTime": 4353.5190000087023,
+              "priority": "VeryHigh"
+            },
+            {
+              "priority": "VeryHigh",
+              "networkEndTime": 4370.15600001812,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "sessionTargetType": "page",
+              "transferSize": 51336,
+              "resourceSize": 50524,
+              "protocol": "h2",
+              "rendererStartTime": 4353.1740000098944,
+              "mimeType": "font/woff2",
+              "resourceType": "Font",
+              "networkRequestTime": 4355.1150000095367,
+              "statusCode": 200,
+              "finished": true,
+              "entity": "Google Fonts"
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=99109eb4-c411-41a1-8fde-5425bcacc79c&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778779366081&vi=5adaa0527fcfafeaf1991097a3e493da&nc=true&u=242475741.5adaa0527fcfafeaf1991097a3e493da.1778779363508.1778779363508.1778779363508.1&b=242475741.1.1778779363508&cc=15",
+              "networkEndTime": 4532.1990000009537,
+              "priority": "Low",
+              "resourceSize": 45,
+              "transferSize": 1020,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/gif",
+              "rendererStartTime": 4422.66400000453,
+              "networkRequestTime": 4426.0490000098944,
+              "resourceType": "Image",
+              "finished": true,
+              "statusCode": 200,
+              "entity": "Hubspot"
+            },
+            {
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Image",
+              "networkRequestTime": 4427.4239999949932,
+              "rendererStartTime": 4423.5069999992847,
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "protocol": "http/1.1",
+              "transferSize": 1024,
+              "resourceSize": 35,
+              "networkEndTime": 4494.0349999964237,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1"
+            }
+          ],
+          "debugData": {
+            "initiators": [
+              {
+                "columnNumber": 1071,
+                "type": "parser",
+                "lineNumber": 6,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "columnNumber": 668,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 27,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 27,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 16793
+              },
+              {
+                "lineNumber": 27,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 31052
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 30,
+                "columnNumber": 18356
+              },
+              {
+                "columnNumber": 141,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 261,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 360
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 460
+              },
+              {
+                "columnNumber": 541,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45
+              },
+              {
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 617
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 683
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45,
+                "columnNumber": 752
+              },
+              {
+                "columnNumber": 812,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 876,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 938
+              },
+              {
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 997
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 1066
+              },
+              {
+                "columnNumber": 1133,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 1200
+              },
+              {
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 1257
+              },
+              {
+                "columnNumber": 1319,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1378,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 1442
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 1508
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 1569
+              },
+              {
+                "columnNumber": 1637,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1703,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "columnNumber": 1774,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45,
+                "columnNumber": 1832
+              },
+              {
+                "columnNumber": 1892,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 1967
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 2028
+              },
+              {
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 2086
+              },
+              {
+                "columnNumber": 2150,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "columnNumber": 2210,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45
+              },
+              {
+                "columnNumber": 2269,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 2331
+              },
+              {
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 2392
+              },
+              {
+                "columnNumber": 2455,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2511,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 2579
+              },
+              {
+                "columnNumber": 2646,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "columnNumber": 2707,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2778,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 2838
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45,
+                "columnNumber": 2897
+              },
+              {
+                "columnNumber": 2967,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 3028,
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45
+              },
+              {
+                "columnNumber": 3094,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 3159
+              },
+              {
+                "columnNumber": 3235,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "columnNumber": 3301,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45,
+                "columnNumber": 3365
+              },
+              {
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 3428
+              },
+              {
+                "columnNumber": 3501,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 3560,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "type": "parser",
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+              },
+              {
+                "type": "parser",
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+              }
+            ],
+            "networkStartTimeTs": 107695322218,
+            "type": "debugdata"
+          },
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Protocol",
+              "valueType": "text",
+              "key": "protocol"
+            },
+            {
+              "label": "Network Request Time",
+              "valueType": "ms",
+              "key": "networkRequestTime",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "networkEndTime",
+              "label": "Network End Time"
+            },
+            {
+              "valueType": "bytes",
+              "displayUnit": "kb",
+              "key": "transferSize",
+              "granularity": 1,
+              "label": "Transfer Size"
+            },
+            {
+              "valueType": "bytes",
+              "displayUnit": "kb",
+              "key": "resourceSize",
+              "granularity": 1,
+              "label": "Resource Size"
+            },
+            {
+              "valueType": "text",
+              "key": "statusCode",
+              "label": "Status Code"
+            },
+            {
+              "valueType": "text",
+              "key": "mimeType",
+              "label": "MIME Type"
+            },
+            {
+              "label": "Resource Type",
+              "valueType": "text",
+              "key": "resourceType"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "render-blocking-insight": {
+        "id": "render-blocking-insight",
+        "title": "Render blocking requests",
+        "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 900 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 900
+        },
+        "details": {
+          "items": [
+            {
+              "wastedMs": 151,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "totalBytes": 24570
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Transfer Size"
+            },
+            {
+              "label": "Duration",
+              "valueType": "timespanMs",
+              "key": "wastedMs"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "server-response-time": {
+        "id": "server-response-time",
+        "title": "Initial server response time was short",
+        "description": "Keep the server response time for the main document short because all other requests depend on it. [Learn more about the Time to First Byte metric](https://developer.chrome.com/docs/lighthouse/performance/time-to-first-byte/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Root document took 10 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+              "responseTime": 8
+            }
+          ],
+          "overallSavingsMs": 0,
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Time Spent",
+              "valueType": "timespanMs",
+              "key": "responseTime"
+            }
+          ],
+          "type": "opportunity"
+        },
+        "numericValue": 8,
+        "numericUnit": "millisecond"
+      },
+      "resource-summary": {
+        "id": "resource-summary",
+        "title": "Resources Summary",
+        "description": "Aggregates all network requests and groups them by type",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "table",
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "label",
+              "label": "Resource Type"
+            },
+            {
+              "label": "Requests",
+              "valueType": "numeric",
+              "key": "requestCount"
+            },
+            {
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "key": "transferSize"
+            }
+          ],
+          "items": [
+            {
+              "transferSize": 1470646,
+              "requestCount": 92,
+              "resourceType": "total",
+              "label": "Total"
+            },
+            {
+              "transferSize": 819500,
+              "requestCount": 63,
+              "resourceType": "script",
+              "label": "Script"
+            },
+            {
+              "label": "Image",
+              "transferSize": 335679,
+              "requestCount": 11,
+              "resourceType": "image"
+            },
+            {
+              "transferSize": 253262,
+              "requestCount": 6,
+              "resourceType": "font",
+              "label": "Font"
+            },
+            {
+              "resourceType": "stylesheet",
+              "transferSize": 27827,
+              "requestCount": 3,
+              "label": "Stylesheet"
+            },
+            {
+              "label": "Document",
+              "transferSize": 22074,
+              "requestCount": 1,
+              "resourceType": "document"
+            },
+            {
+              "transferSize": 12304,
+              "requestCount": 8,
+              "resourceType": "other",
+              "label": "Other"
+            },
+            {
+              "label": "Media",
+              "resourceType": "media",
+              "transferSize": 0,
+              "requestCount": 0
+            },
+            {
+              "label": "Third-party",
+              "transferSize": 894227,
+              "requestCount": 32,
+              "resourceType": "third-party"
+            }
+          ]
+        }
+      },
+      "viewport-insight": {
+        "id": "viewport-insight",
+        "title": "Optimize viewport for mobile",
+        "description": "Tap interactions may be [delayed by up to 300 ms](https://developer.chrome.com/docs/performance/insights/viewport) if the viewport is not optimized for mobile.",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "node": {
+                "snippet": "\u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\"\u003e",
+                "nodeLabel": "head \u003e meta",
+                "path": "0,HEAD,1,META",
+                "lhId": "page-11-META",
+                "type": "node",
+                "selector": "head \u003e meta",
+                "boundingRect": {
+                  "top": 0,
+                  "right": 0,
+                  "height": 0,
+                  "left": 0,
+                  "bottom": 0,
+                  "width": 0
+                }
+              }
+            }
+          ]
+        }
+      },
+      "user-timings": {
+        "id": "user-timings",
+        "title": "User Timing marks and measures",
+        "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more about User Timing marks](https://developer.chrome.com/docs/lighthouse/performance/user-timings/).",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "details": {
+          "headings": [
+            {
+              "label": "Name",
+              "key": "name",
+              "valueType": "text"
+            },
+            {
+              "label": "Type",
+              "valueType": "text",
+              "key": "timingType"
+            },
+            {
+              "valueType": "ms",
+              "key": "startTime",
+              "granularity": 0.01,
+              "label": "Start Time"
+            },
+            {
+              "granularity": 0.01,
+              "valueType": "ms",
+              "key": "duration",
+              "label": "Duration"
+            }
+          ],
+          "type": "table",
+          "items": []
+        }
+      },
+      "total-byte-weight": {
+        "id": "total-byte-weight",
+        "title": "Avoids enormous network payloads",
+        "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn how to reduce payload sizes](https://developer.chrome.com/docs/lighthouse/performance/total-byte-weight/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Total size was 1,436 KiB",
+        "details": {
+          "sortedBy": [
+            "totalBytes"
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Transfer Size"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "totalBytes": 204718
+            },
+            {
+              "totalBytes": 202020,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png"
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "totalBytes": 157034
+            },
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg",
+              "totalBytes": 67588
+            },
+            {
+              "totalBytes": 51797,
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js"
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "totalBytes": 45261
+            },
+            {
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "totalBytes": 43924
+            },
+            {
+              "totalBytes": 43664,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            }
+          ]
+        },
+        "numericValue": 1470646,
+        "numericUnit": "byte"
+      },
+      "redirects": {
+        "id": "redirects",
+        "title": "Avoid multiple page redirects",
+        "description": "Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://developer.chrome.com/docs/lighthouse/performance/redirects/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [],
+          "type": "opportunity",
+          "items": [],
+          "overallSavingsMs": 0
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "unminified-javascript": {
+        "id": "unminified-javascript",
+        "title": "Minify JavaScript",
+        "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn how to minify JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unminified-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [],
+          "overallSavingsMs": 0,
+          "headings": [],
+          "type": "opportunity",
+          "debugData": {
+            "metricSavings": {
+              "FCP": 0,
+              "LCP": 0
+            },
+            "type": "debugdata"
+          },
+          "overallSavingsBytes": 0
+        },
+        "warnings": [],
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "lcp-breakdown-insight": {
+        "id": "lcp-breakdown-insight",
+        "title": "LCP breakdown",
+        "description": "Each [subpart has specific improvement strategies](https://developer.chrome.com/docs/performance/insights/lcp-breakdown). Ideally, most of the LCP time should be spent on loading the resources, not within delays.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "headings": [
+                {
+                  "label": "Subpart",
+                  "valueType": "text",
+                  "key": "label"
+                },
+                {
+                  "valueType": "ms",
+                  "key": "duration",
+                  "label": "Duration"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "label": "Time to first byte",
+                  "duration": 1.598,
+                  "subpart": "timeToFirstByte"
+                },
+                {
+                  "label": "Resource load delay",
+                  "duration": 582.309,
+                  "subpart": "resourceLoadDelay"
+                },
+                {
+                  "duration": 30.787,
+                  "label": "Resource load duration",
+                  "subpart": "resourceLoadDuration"
+                },
+                {
+                  "subpart": "elementRenderDelay",
+                  "label": "Element render delay",
+                  "duration": 717.451
+                }
+              ]
+            },
+            {
+              "type": "node",
+              "boundingRect": {
+                "left": 0,
+                "bottom": 0,
+                "width": 0,
+                "top": 0,
+                "right": 0,
+                "height": 0
+              },
+              "selector": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block",
+              "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"d_block w_100% h_auto obj-f_cover bdr_2xl asp_16/7\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+              "lhId": "page-4-IMG",
+              "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,DIV,1,HEADER,3,IMG",
+              "nodeLabel": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "cumulative-layout-shift": {
+        "id": "cumulative-layout-shift",
+        "title": "Cumulative Layout Shift",
+        "description": "Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/articles/cls).",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "0.007",
+        "details": {
+          "items": [
+            {
+              "cumulativeLayoutShiftMainFrame": 0.007047,
+              "newEngineResultDiffered": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 0.007047,
+        "numericUnit": "unitless"
+      },
+      "speed-index": {
+        "id": "speed-index",
+        "title": "Speed Index",
+        "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).",
+        "score": 0.76,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "4.3 s",
+        "numericValue": 4282.766964607993,
+        "numericUnit": "millisecond"
+      },
+      "font-display-insight": {
+        "id": "font-display-insight",
+        "title": "Font display",
+        "description": "Consider setting [font-display](https://developer.chrome.com/docs/performance/insights/font-display) to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with [font metric overrides](https://developer.chrome.com/blog/font-fallbacks).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "valueType": "ms",
+              "key": "wastedMs",
+              "label": "Est Savings"
+            }
+          ],
+          "type": "table",
+          "items": [],
+          "skipSumming": [
+            "wastedMs"
+          ]
+        }
+      },
+      "legacy-javascript-insight": {
+        "id": "legacy-javascript-insight",
+        "title": "Legacy JavaScript",
+        "description": "Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile [Baseline](https://web.dev/articles/baseline-and-polyfills) features, unless you know you must support older browsers. [Learn why most sites can deploy ES6+ code without transpiling](https://developer.chrome.com/docs/performance/insights/legacy-javascript)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 13 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network",
+                      "column": 6239
+                    },
+                    "signal": "Array.prototype.concat"
+                  },
+                  {
+                    "location": {
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 12925,
+                      "line": 1,
+                      "type": "source-location"
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "line": 1,
+                      "column": 12813,
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    },
+                    "signal": "Object.assign"
+                  },
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "column": 10857,
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1
+                    },
+                    "signal": "Object.create"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 13770,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "wastedBytes": 13770,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "subItems": {
+                "items": [
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "column": 6239,
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1
+                    },
+                    "signal": "Array.prototype.concat"
+                  },
+                  {
+                    "location": {
+                      "line": 1,
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 12925,
+                      "type": "source-location"
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "line": 1,
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 12813
+                    },
+                    "signal": "Object.assign"
+                  },
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "line": 1,
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 10857
+                    },
+                    "signal": "Object.create"
+                  }
+                ],
+                "type": "subitems"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url",
+              "subItemsHeading": {
+                "valueType": "source-location",
+                "key": "location"
+              }
+            },
+            {
+              "key": null,
+              "valueType": "code",
+              "subItemsHeading": {
+                "key": "signal"
+              }
+            },
+            {
+              "label": "Wasted bytes",
+              "valueType": "bytes",
+              "key": "wastedBytes"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 13770,
+            "type": "debugdata"
+          }
+        }
+      },
+      "screenshot-thumbnails": {
+        "id": "screenshot-thumbnails",
+        "title": "Screenshot Thumbnails",
+        "description": "This is what the load of your site looked like.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "filmstrip",
+          "scale": 3264,
+          "items": [
+            {
+              "timing": 408,
+              "timestamp": 107695730010,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k="
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 107696138010,
+              "timing": 816
+            },
+            {
+              "timing": 1224,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 107696546010
+            },
+            {
+              "timing": 1632,
+              "timestamp": 107696954010,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAICAwEAAAAAAAAAAAAAAAUGBAcCAwgB/8QATBAAAQMDAwIDBAYIBQIDBQkAAQACAwQFEQYSIQcxE0FRFCJhcQgVFjKBkSMzUlRyk7HhNDZCocEXYiSC0TVVc5TTJSc4U3R1g7K0/8QAGgEBAAMBAQEAAAAAAAAAAAAAAAEDBAIFBv/EADERAQABAwEEBgoDAQAAAAAAAAABAgMRBBIhMXEFFDJBUbETFSMzUmFyocHRIjSBkf/aAAwDAQACEQMRAD8A9UoiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAi+OcGtLnEBoGST2Cr0WuNKzXD2GLUVpfV52iJtUwkn079/ggsSISAMk8eqrp1xpZtf7EdRWkVedvhe1s3Z9O/f4ILEiAggEHIPmoq86htdlext1qvZGPxiaWNwiHzkxtH4lBKoqF1rqv/ALpL/U0c/Bp2uZLE/uC5vIIUsdX6es1JQU13vluo6p0Mf6Oeoa13LRyQTwgs6LrpqiGqgZPTSxzQyDcySNwc1w9QR3ULd9Y6bs9WKW6322UlTnHhTVLGuHzBPH4oJ5F1UlTBWU7KikmjngkGWSRuDmuHqCO67UBERAREQEREBERAREQERfHu2tJQC4N7kBfBIw9nBRdyuNJb4DUXGqhpochviTPDG5PYZKwKPUtjrallPR3i3z1EhwyOOoY5zvkAUFlRdFO8n3T+C70BERAREQa364TzPs9jtDZn09JeLrBQ1cjDtPguJLm58s4wrHV6F0xUWF1ofZaBtDsLA1sLQW8Y3B2Mh3x7rM1dp2h1VYp7Xc2u8GTDmvYcPieOWvafIgqny6L1nU0RtlVrx7ra5vhvey3sbUuZ2I8Td3x54ygohvtyn6H0dC6tlLJLwLI6va7Dn03ilu/PxaNuVtxmgdKtsf1SLFb/AGLZswYW7u2M7u+745yuc2ibJLokaVNMRaWxCJrQfeaQch4P7W7nPqq03ROtGUn1c3X8v1aG+GHG3sNTs7Y8XPfHnjKCG6g1VToTooafTt4mqzHK2jZXOeHPhjc8gjcPNo90HuFsXT+nLZb9OMt0cQqKeaENnfMfEdUZHLnk/eJyuu3aNslFo9umRSNmtPhmN8c3vGTJyXOP7RPOfVYrtPXS2WUWfTFe2mptnhsqK17qiSnb2wxvGceW5xwg0rTzy0/SLqhYGyvmt1mrn09G9xztj8Qe5n4Y/wB1ufROlLNR6TpIzS01c6rp2SVNTMwSOqnOaCXOJ7g54HkFHjpnQU/TWu0lQVMkftoLp6yRu98khcCXuHGc4wkejtR2mk9g0vqmOitobtjhqqEVDqceYjduHHoHZwgqmn6ubSH/AFRtVkJdQWeL2yhi+8IHvic9zB8ARnCtPSzSVjh0Nbal9HS11VcadtTV1U8bZHzvkG52SRyMnsprRejqPTNnqqQyyV9TXSOmrqqoAL6l7u5d8McAKu0WgtQ6fZJRaQ1b7DZy5zoqSrom1Jp8nJDHEg49AcoOjp9DHYOp+rNN2sbLMyGCujgBy2nkfkOa30B74W0FWdEaRg0vDWSPq57hdK6Txqyun+/M7yGBwGgcADsrMgIiICIiAiIgIiICIiAuE4zEVzQ8oK7qMVJtp9iFcZtw/wAF4PiY/wD5fdx/uoKytu/1pB7UNReDk7vahQ+H2P3vD9/8ldnwkH3eQuIieT91B9gH6QLKXCKMMHxXNAREQERYdVcIqerjp3Z3uaXk4OGt9fzQZiL40hzQ4djyF0VFUIaqmhLRiYu97OMYGUGQij6CvfV1VTGYQyOJ7mB24kuIOPTH+6xBfXePURupwBFIGNO/736QMJ7eWcoJtFF1129mqXxtiY9kbWueTJtcQ4ke6Me92+C+0N09prTAY2sad+07iXHa7acjGB+ZQSaIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC4PiY97HuaC5hy0+YXNEBdU9PBUBoqIY5Q05G9odj812og6o6aCOZ0scMTJXfee1oBPzK4mipT4maaE+Icvywe/wCfPqu9EHSKSnHh4giHh/c9we78vRcmwQtldK2KMSO7vDRk/iuxEBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQRF5vsFteItplmIztBxj5lRH2wd+5D+b/AGUDe9/1tV+Lnd4h7+nl/tha/wBT0mopdX2ye1uqha2NjE/hTNDc+IS7LCRu93A/HjOMLy6tTcqrmInEPft6GzTapqqpmqZx497b32wd+5D+b/ZPtg79yH83+y1JQ099b1DuE1SyrdZHtb7O/wBpb4TT4YDsx5zy7POO66NPW/UsOta91yqJ32OMyPpnOmDhJvLcNLc590Z7hc+nu/H3Z7nfU9Pn3c8cd/8A3jwbi+2Dv3Ifzf7J9sHfuQ/m/wBlpfTlJqaO0ajjuLK1tc9knscklW14cTv27AD7hGW9/h6Lv09R6obp6+QXaaT6xkj2UchlB58IAOBBO07uT8clTN+7Gf5+RGk0849nO/n+24ftg79yH83+yfbB37kP5v8AZaUqKTVcmjLi1ntYu0lSx0MYqWiRsY2bhu3YGcO8/NXKxtnbZ6NtWyWOoETfEZNIJHh2OcuHc/Fc1ai7EZ2vJ1RotPVOPRzG75rz9sHfuQ/m/wBk+2Dv3Ifzf7LUel6e/Rarvb7tHWGhfJIaSR9U10QYXDa0Rgkg4zz6cLC0LSatgvUztROqXU5jduc+oY+Nz93u7GAZaMfEfJTN+7v/AJx9nMaTTzMR6Od+fHc3T9sHfuQ/m/2T7YO/ch/N/stNaao9Uxa0r5rq+c2Z0lQYGumDgAXt8PjceMZxxxz6rE0jR61i1dJLe5pHWwmXfulY5jv2NjQct/IcKfTXd/8AOPsiNLp93sp3zjv/AO8W8Ptg79yH83+yfbB37kP5v9lqXTlPfYtY3mS5x1htr3ONLI6pa6INy3DRHnIPfn5ro0jSalh1ZdZry+qdbHh/geJM0tyXjbtaCcYaO/Hfsom/d3/z8nUaPTzj2c75+bdtu1TBUTtiqIjBuOA7dkZ+PCsS1MtoW3f9X03i/rPDbuz64WnSX6rmYq7nn9I6SixNNVvvZKIi2vMEREBERAREQEREBERAREQEREERebFBcniTcYphxuAzn5hRH2Pd++j+V/dW5FRXprdc5mGq3rb9qnZpq3Kj9j3fvo/lf3T7Hu/fR/K/urci56pa8PNZ6x1PxfaP0qP2Pd++j+V/dPse799H8r+6tyJ1S14eZ6x1PxfaP0qP2Pd++j+V/dPse799H8r+6tyJ1S14eZ6x1PxfaP0qP2Pd++j+V/dPse799H8r+6tyJ1S14eZ6x1PxfaP0qP2Pd++j+V/dPse799H8r+6tyJ1S14eZ6x1PxfaP0qP2Pd++j+V/dPse799H8r+6tyJ1S14eZ6x1PxfaP0rlu0tBTztlqJTPt5DduBn48qxoiuot024xTDNdvV3p2rk5ERF2qEREBERAREQERUXrVq2u0XoOputqiZJWGVkMbpG7mx7j94jz7fmQgvSLydpnqd1Mr5aapp7rbbnHJIN9GBT+M1ucH9GNrz+GVLS9WNYQdbaiztdU1NqjuMlM22Mp497mDIBDtm7H+vv2Qem0Wjbn9Ia3W++3S2S2Gse+illhDmTA+I5ji3gY4Bx+C7bH1/orrfXWwWCqhe2GeUvdUNP6qJ8hGNvnsx+KDdqLS1j+kDZa6xXe6V1sqqOOgMLGxiRsj53yb8NbwAMbCclctIdf7JqG+QWuS111FPUu2QOe5r2vefutOOQSeBweSg3Oi8w9IererrtrqajvUlRcqDwJnmBkEbPZ9uCHuLWA4GNvPm4K2236QdDXWO8XJtgqWNtrYnOYahpL/Efs4O3jHdBvFFoKp+kjb4KajmOnaoipjMgHtLfdw9zf2f8AtUtP9IGw09mqK+a21zXCqdT00Axuna0AmQ5xtbyPU8oNzotLWP6QNjulBc3m2VlNW0dM6pbTyPbicN7ta4djjnkdk0n18t+o7vbLdBYqyKetqhTkmUObEDjDycepPHwQbpReYfpU3672rWVpitd1r6KJ9AHOZT1D42k+I8ZIaRyr1qLr3p+xX2stJo6yqfRse187CAx0rW/cHnyfd3eR+HKDciKg9JepNP1FprlNTW6WhFE9jCJJQ/duBPkBj7qqurfpBWGw3+qtdNba24eyyGKaeNzWM3A4Ibnvg8Z4QboRaTv30hLLb6C1VlDa6qthro3PIMrY3Qua7BY4YPPnwexCyP8Ar7YGWavuNRb62NkNQKemi431OQTuAONrRjnPqEG5EWj6HrpaNT2K/wBJDT19pucVuqJ4DuaS7ZG53uO8nADIyPJVbo51Rj09obUFz1LXXa5+DVwxQsmk8Rxc9ryGtLjxwwk5OOOB6h6ZRaQsP0irDcKsRV9puNDG5j3tmy2RuGtLjnsew8s8rFp/pKWSWr2usN0bS7g3xg5hIz6tzj/dBvlFpW+fSG07bbtcKGCgrasUoc0TtIaySQHG0dyB3974fHKjpfpHUEdopq86dqi2eeWAM9pbkFjY3Zzt8/EH5IN9otRaZ66WO96rorE63V9JLV+G2KaUDbvewODSODjJwDjng9ioy/fSL0/bbzUUVJa66uggkMbqljmta4g4JaD3GfXCDeCLU2pOuumrRYbTcaaGrrpLlGZYqdgDHMAcWneSePeBHGexUp0u6sWjqBVVNFS01TQ3CBnimCbB3MyAS1w9CRnOO6DYqIiAqR1htF+vWjnUul208lcJ2PdDUbTHNGAdzCHAtPccH0V3RB47Z0a17db9SvlsFFZWBzd9RBURhjMHO/a17jn+EDsrjqrpnre3dX/tRpemgrY3zidkz5WDwyW7XB7XEE+fbK9JrrkniicBLLGwnsHOAQee+m/TzVNo6411/udq8G0y1FY9s/jxOyHl207Q4u5yPJR2qOlGsouqd3vlipaSpo6w1MjJZJmgNE0T2uaWkg598geWcE8ZXpdr2vJDXNcRwcHOF88aPxNniM3/ALO4Z/JB5HsfRDWU+kr7SVtvZR1hmpqilZJURuE+wTNc3LXHBxIDzhXbROmOp9VqmxSaloLXRWy3NjjMj4KWSQxx8hrS3c4E+oIx3XoF08LZNjpY2vP+kuAP5Lj7VT8/p4uO/vjhB5s0d0u1vpPqZUz0dNTy2er8SnmrfEYR7O9wJ90kODuB5Kt03RvqBbbPqG3Q22kmhqmxNBbUMzNslDhsy4Y8yd2PQcr1yyoheQGSxuLu2HA5Wqr91ibaeqsWizZDKX1VPTe2e1bceKGHOzZ5b+2eceSIaKr+jGvpaG1RssBL4YXNkHtcHukyvd+36ELdX0genV41jHZ7hpzwn11uLgad7wzeCWkFrjxkFvmR3WNWdeDTUt7mfpKvjFtkawePN4Yky8N5O07Xc5xzxnlbA6ZazZrjStPefZBQGaSSMQGbxD7pxnOBn8kGk6Dp51DuNv1DUXq3W2nmno5IoqdrIHTzyFu0fpuXAY5yX/Dsr39G/SF80hp27U2o6D2OeeqEkbTKyTc3YBnLSfNX3WF/rLLBAy12ioulfUEiONj2xRtxjl8jjho5+JKmxUsbDG+ocyFz2g7XPHB8xnzRLQH0junuqNX6qttZp21msp4aIRPf48UeHb3HGHOB7EKFvfSrXtBqfVf2djpZbXeoZjJK58eXNcS/wsOOWuLvdz288r04yWN5IZIxxAycEHASOaKQkRyMcR3DXAoNN/Rr0Xf9HUF9j1JQGifUywuiBljk3Bodn7jjjuO6pFd066jaX1RqN+kaKjr7fd3PDpZDC79G5xcAWyEcjODwQV6YFVTkEieI45Pvjha/6w9Tm9OI7S82o3EV5lAxUeFs2bP+12c7/wDZBpbXfSbXt0t1hxbaSsrI4ZDUCk9np2REu4bgFoccAZIHn8Fs7rl06u2sLBYZbH4P1las/oJHBoeHBucE8ZBYO/HdbN03d2XrTlpuroxT/WFLFUiIv3bd7A7bnjOM47KQjnhkcWxyxvcPJrgSg8zx9MtfakvF51FqumpYK/6sqKenp4XxgzyOgdGxvunaB73cn+2BpnpXreh0JebfNYKKSpqK6mmFNWTRubLGxkodtc1/uuDnM5y04zz3XqcVEJeWCWMuHcBwyEZPDIHGOWNwb3LXA4QeXdJdNepUE9W11FSW22+BMGW6pqW1FOXOYQGtYXPxlxzkn1+SwrN0w6lQXqH6ttVNYKcub4zoa3dBLg93sMjy75Yx8F6wjljkBMcjHgd9pyuLaqBwJbPEccnDxwg8s3DpHr+1VeqbdYoaWos9zbuMhfGHTNa/cxgDjlrueew479lX6jo1r1+maCkbYSaiKsqZXs9rg4a5kAac78cljvyXpjqH1Hsegvq/68FW/wBtDzF7NGH/AHNuc5I/aH+6slpu1Jc7NRXOnk20tZCyeMyEA7XAEA/HlEPN8XTDWDerOn7wbORbaU20zTe0Re74UMLZON2TgscOBzjjKxafpt1M0jU3u2aZoKGutdweMzy+A8OY1xLctkPB55GCF6oa5r2gtIcD5g5UTLqayxX9ljkulI27vG5tIZB4hGM9vlyiWgdZ9JNZVFLpm8UBoKq+0MOyop4NlMxrhI6Ruzbtb/qIPbtlXLolpPV9rvNwu2rqa20QmY5rIIYITM5znAlzpGAkjjzcSc89luNEBERAREQF5R+l2S3XFlI4It4I/mvXq5aR679KL7r/AFFb6+zVNthhp6XwHCqke1xdvc7jax3GCEGn9HXGttnUCudoq6XG4mS11E9Q+Zjg503s7nO3NPciXGCfP186f4tu+zYvAvtw+1/tv6jDseHjPieJ+1n4/h5r3RZdOWmzz1FTbrbSU1XVHdUTRRgOld3JJ7nnlVm32zpvX6mf9XwaaqL4x7nujhMTpWvafeJaOxB7nCIebdcV1RF1f0tdNQEwTGG11NU94xghsZeT8iHfkqbFI2V+spIzuY+nLmn1BrIF7pvGmbHequnqrtaqKsqKcgxSzRBzmYORgnyz5KJ/6caOzUn7O2/NSNs36P743B3P/maD+CDS/wBGLQ9JcaGk1ZNW1YqrfWTRRU4I8LBjaCcYzk7vXyCr+vf/AMV1L/8Aulu//pCvUdgsVr09QmjslDBRUpeZDFC3DS4gAn/YfksGr0Zpyrv7b3U2ejluzXslFU5nvhzAA059RtH5Il4Rtf8AgNQ//pW//wCiJZsc9PTaes9VbbxXfaGGqe1tI1rg2CPO5rmO9S4ngf8AHPtKPpnouNkzWabtzWzN2yAR/eGQ7B/EA/gsuh0LpagmpJaSwW6OWkJMDxCCYyTngn48oh5G13US3bqRfm63rqijkgDhACXANIA2AANdwRz2Gc9wo3V8/i6C0xHHdKq408VTWNjdPAY/C92AljSXHcMnPwyvaN/0dp3UM7Z73ZqGtnaNokmiBdj0z3wuu5aH0xc6OipK6x0E1LRBwp4jEA2IOxu2gds4H5IPPWp9KT6N6ItvlkuFwlqL7DQ+3Fzh+iiMZOGkAENyWt+XCpfTv6sotY6ZntOoK2GulfF40cMDpt0hdh0Z4ZgEcf6uOcr1xRXbSdWfszSXCz1DomGlNtbNG9wawYLDHkngDBGOMLlZdE6Zslca202K30lXgjxYoQHDPfB8vwQeQuh2jKXXWqLjaq6sqqWnbROncacgF+2WMBpyDxzn5gLZf0vohBb9HwtJLY/aWAnzwIgt6af0ZpzTtZJV2Oz0lDUyMMTpIWYJaSDj5ZA/JR+vY9EVD6OLXMlmDmBzqZtwmYw4OA4tDiPQIPLuq6wT6l0XSakuVbbrHT2ShfDNTNLnR/8Ah2u3tA8/EGM/D4KY+ikd3VK4O3Odm2zHc7uf0sXJXpufSunLjT2vxrTQVMNAxgoi6IOETQBtDT6cD4L5YtG6dsNwkrrNZ6SjrJGFj5YmYcWkgkfmB+SDy11nZUaE6w3atoG7WXOkkkZ5Y8aN0bz+D9x/JRlfbblp/oXa6ym8aGG+XF8lU9mQTGxu2JhPoSJHfHheutRaR0/qSaGa/WmkrpYWlkbpmZLQTnAWY+x2uSystElvpn2tjBE2lfGHRho7DB9EHk7pALbQ9S7YywX+tIlZtfAyB0jZssJe15IZgDGc7TjHcrXmnKP2jT2qajx54zSUcUgZG/DZCamJmHDzHvE49QF7nsOj9O6fmlmstmoaKWQbXyQxAOI9M98fBYNP050fT09VBBp63shqmCOZgj4kaHBwB/8AM0H8EHjO/Gar6c6ZrKh0sr4qusoxI9xO2Nohexnw5kkP4/BZNyq7bX3OwW6eunptNQUMQaQ54a2Qs3TEZa48zmQZDT244wvW09t6eUFKdL1DNPwxSTeL9XSyRgmQgDIaTncRgKTn0FpSe209BNp+2vo6ckxRmAYZnk48xlBqr6K0sYpL5TUl3q66kjcxwhlpyxkLju5a4k5yAMjA7BSN3/6d/wDXym9s9vOq90eMf4bxtg2Z8923bjy7Lbdls9usdC2js9DT0VKDkRwMDBn147n4rHk01ZZL+y9yWukdd2Da2rMY8QDGO/y4RKXREQEREBERAREQF4v0hbKm9dVNZWygDTV1cFzhiDnbQXOLgMnyXtBak0N0gk0x1Hq9UuvTKls7p3ezCm2FviEn7249s+iCi3nWmpelmmtJ6KoKai+vXQOkmkmcHsaHzPDA05A9cknAVi0LrnqFqChv1vr7VHTXKnpny0Ve2nPgPkaR+jJyWu3eRB9VaurHSqm17V0NwhuU1rutG3YyojZvBbnIBGQcgkkEHzKh9JdGqjTlvvkkWpaiovtyp3Uza2SI7YWuI3ODd+S4+pdwiGr7b111tdnWu0UDaP66qKwwukdTja4O2Bgxngg78n5LMn62a6udyrW6bpaCaloSGlrogZZhnG7buySSCcNHCnYfo3GmpqF9HqbwbnT1DpjVCkPI93YA3fwWlrjnPO74LKuv0eDPXVM1r1RNb4KzBqadlOSxx7uAw8e7nJAOcepQVzXXW3WlrdZPDoYrVUVFCJaimqaY58TxZG7m7uQ0hrSB/Vd8XW3WsOtbzaJ7ZbpX04qg2mBx4JiY9xO/PvABhz6+WFP6n+jxDc22qO3X99NFQ0gp3Gen8Z8rt73l5O8Y+/jGOMLOf0Oldr27aj+v2Btcawin9kOWePHIz72/nb4me3OPJBr7/r7qubRs9SxtBHcaeuiiMrYctfG+OU4LSeCDH3HqpWz9btY0lfpyq1DbKT6juuI2yNbh8gDgx8jcHggnsR2/NVbql0rm6d6KBN0FyNfcIeGUxj2bI5v+52c7/wDZXPpL0bpbvb9Malud0qZKSOMTstrm+62QPJPvE8NJAJAH4oNfWW/s0t1z1Le5IjKKOpuUgjzje7MgaM+WSQrbZesvUiukp7hT2eiuNvllLfZqWEufgHkYa4ub8C4Y+autP0Ggfra73q5XgVNFcX1Tn0jabY5om3Yw/ceWlwOceSi6T6OXh1UEVRq2sktEUhkFKyEsd8cHeQCfUNQbC6ta+k0VoOO9U1IXVtU9kMEM4IDHuaXe+O/AB49V5h6x33VF9bp6fWNtjo6l1M6WnkjwGzxPIIO0E4I9Dz24XrPXmhrbrHSP1BVukp4Y9joJY+XROYMNPPfjIPwK1Fcvo3y1lNRsdq2eSWBpYXz05kAZn3WsG/3QB8+/kg6NXdW9T0mpINM6PpqEOpKWIPkqdu6R3htccFzg0DkDHcrZnRnV1/1XZKp+qbPLbq2neA2QwuiZO0g4LQ7zGOfmPVVvWnQ6O93qK8We/wBRaLiYWRTPjjLg8tYGbhhwLcgcjJVw6U9PqXp/Z6ilhrZq6pqXh808g2g4BADW5OAMnzPdEvJWpXXKXVddU63rLzTvfI50NTBF4rDycFmXtGzHbaeyu8nUu+6K0Np6LT18p7pHUS1W+eeNz3gNMe1pD+WkBx45HIwSrjXfR4rnxT0lHrWqjtkjy72WSnc5vfIyBIAefgpC4/R4ttRpK22qmvE0NZSSyzPqnQhzZXSBoPuZGANjcc+SIQ7ereqD1Ytlg8Wk+rqh1IHjwBu/SQxvdz83FQuiOrHU7V9ZVUNkp7fWVUcYlP6Nkfht3AE+84A98firna+g0tBra3X/AO0slQ2kfC8xzU5c9/hsa3G/f57eOOBgeSmOj3SCTp5fa24vvTbgKim9n8MU3hbfea7Odx/ZQef9NW6tuvXh8N1NNNVw3WeorC4uDHeE5z5NuOezHbfLOM8K6t63a+vVVWVmnbbb3UEMoa2mEfiSkE8cbt7j6lowPgtj6d6NutPVOq1fLeWVEU9RVTmj9mLeJg8bd+89t/pzhV6v+jm01tS206pq6K1VEge+kMJdwDkDIeAceRIQbn0bdqq+aYt9xuFBLbquePMtLK0tdG4EgjB5xxkfAhTKitLWOm03p+htFC6R1PSR7Gulduc7nJJPqSSVKokREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERARFFzT1ZnkERwxpAHuA/8hU3r0WoiZiZz4OqadpKIseOWR9C2VrWmVzA4NJwM49eVG227yVVXSwuMIdJAJXsGQWkjPGTz8sfHKtpmKoiYczuTSKFqrjWROuj2Mj8GladhLO52Ndyd3qfT8V1i61LRRsb4UxqTsY9o4Dg4ZzhxH3cnv5KRPIoCG71Tpqpr44g2OdsbTtIyDMWevPA78cr5PeKlklxazwC6nOGM25ceW8n3s+foPmgsCKIkukkdiZWyuijkdxy04znAGM8H4Z4/BdcN2mfUPa8Qta2MuIGTtw0HcT5tOSO3kgm0Vepr3NNLRN2xGOZxy9rc7huwMDdwccnvj0VhQERYlbJLuEcJLTsc/IAJOMcDPzSIyiZxGWWixqKVzw9r3btuMOIwSCM8j1WLa7hLV1tXFKwMETsNbjnGSMk588ZxgceqnBE53pNFAW+91FTW09O6AN3SPbI7BxgBxZj57Tn5Lpqr7VwwMlEDHtMLnuIB9127aOM9v8A1UJWVERAREQEREBERAREQEREBERAWO+jie9zzvBPJw8j/lZCLiuimuMVRlMTMcHxjGsY1jBhrRgBfURdxGN0IEREBERAREQEREBdc0LJgA8HI7EEgj8QuxEMZcIomRM2sGB3POSVzREBERAREQEREBERAREQERdJqYhVtpt36UtL8egUTOExEzwdyIilAiwLlXez4ZFgydznyWB9Z1Pq38lbTZqqjMK6rtNM4TyLUvUjqJdrDU0dvs1OyeuqfeyWZDR8vwKp126o63pv1UMTXAcg0mRn5qmuqKKtmZ3rrdFVynapjc9FovMJ6pdTMPkFLTCFozl1KBn5crZPSrqDcdWWWaS4MhjraeTY/Y3G4eR2+XmPwU25i5OzSi5E24zVDaqKB+s6n1b+SzPrCd9I19JTConD2tfGZAzAJ5dk+norKrVVMZlVTdpqnEJJFH+03D/3ez/5gf8Aou6jfVySSOqoo4Y8AMa1+455yScD4fkq1jKREQEREBEWDeaielpBLTt3bSd+GlxDdp5AHxx+GUGci6J52ikklieHbWFwLefJdzHB7GuaQWkZBHmg+ovjyQxxHfHC8uXDrJriDqPJYYzR+D9Y+zMj9mBcYy/A5z+yQcoPUiLzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiLqnnjgMfinHiO2A/FRMxEZkdqIikFW6FxdrKsye0eB+TVZFWbf/AJyrf4P+Gqi9xp5tOn7Nz6fzCzLrqJRDC97uzRldijr2/bTtaP8AU7laaKdqqIZK52aZlDSPdI9z3HLiclcUReiwKHW0PtGt6qpmaCYmNZH8AQMqfbCwNALQfwWNc4HNvE8jeHPY0jnuOyxoDWtqcP2eD6scTj818zqZ9vVzfX6GMaeiI74fL1A10DhtGCFXem8XsWsrlBGMRz0/inHk4OA/5WXWTVlQZMNYY2kjDnluV29OqV/11X1LsnbC2Mk+pOf+Fbop9vGGbpOM2J+TYS76Oc087Xjt2PyXQi+hmMxiXzUTicrYDkAosa2v8SiiJ7gY/JZK82YxOG+JzGRERQkRdNZMaemklDN5aOG5xk/NYsc9zNTC2Shp2wucRI8VJJYMHBA2c84Hcd8oJBERBF3VlqtlFVXKspYGxwRulkkbCC7AGT2GSuVHQ0cscVTSOqGRvaHMDZpGtAPb3CcD8lIuaHNLXAFpGCD5r6gxnUjj92qqG/Ig/wBQVV3dOrDJfxepYS+5AYbOWsBA9OG4+HrjjtwriiCo33p/ZL9cqauvERq56dwdGZGs908ejRnsODkK1wxMgiZFENrGDAC5ogIijrTcJ66WtZPbqmiFPMYmOmLSJhgHe3aTxz5oJFQeryRb4yO4kB/2U4oLWH/s2P8A+IP6Feb0x/Ru8l2m97TzTcZzG0nuQuS4w/qmfILkvRp4QpFWbf8A5yrf4P8Ahqsyq1JII9X1riCfc8vk1U3uNHNp0/ZufT+YWlRV9ziH05/4WZ7Yz9lywrrK2anG1pBac8rZa3Vww3JiaZiESiItzGhruxzK6OYj9G5nh5+OSVHS1jY3OcXN2t4DM4/FNZ3xturrLQmMPNfUOjL8/q8RucPzIwhEOHEgNcfPC+d19OxfnHfvfW9FV7emjPduQlPWRvqpmF7drzwzOcfFTWhIXt+sZj+rfK1rfiQOT/uFA3CaCmmLstL/AF9PirNoOugrLEzwuHtc7e09+TkH8Qrejrc1Xtvuhm6XuxTa2PGVjREXuvm0/Zxiib8z/VZqgKe7SU0QiFqrn7cjc0xYd8Rl+V2/Xkv/ALnuH5w//UXn176pluomIpiEhdal1Hb5p2AF7R7oPbJOBn4crr8O5fvVH/8ALO/+ooq43GevpHUzLXWRGRzRvkdFtaNwJJw8nsPIKa9sZ+y5c4lO1Dolpa6dojmq6bwyQXBlOQSAc4BLzj8lILG9sZ+y5PbGfsuTEm1DJRY3tjP2XJ7Yz9lyYk2oZKLG9sZ+y5PbGfsuTEm1DJRYklZ+jd4bMvx7occDPxVC0DcdZSan1G3U0FE22ipHgeE95Lf0bcCPI5bjGSce9uTEm1DZCLG9sZ+y5PbGfsuTEm1DJRY3tjP2XJ7Yz9lyYk2oZKgtYf8As2P/AOIP6FSntjP2XKF1VO2W3sABH6Qd/kV5nTET1G7yX6aqJu081hh/VM+QXJcYf1TPkFyXo08IVCqUf+bK7+D/AIaraqlH/myu/g/4aqrvao5tNjsXPp/MJdcXtDmkHsVyRa3mqpqS909ijzUB0krvuRM7u/8AQKg3TW90qqhraSNtLAGuc7by5wwcDJHBWytW6chv1HjhlVGD4cnzHY/DlaiuFtqKOb2esiMUu7c4EYAOfdA9ckL1NLVbrjfxZrlMxPyYF+jfXW6ZrBJJX72zxvLve3tON2T6D+quGl6590scE07Q+XbhwJAIcO+VWZWyR1DZojsla44yMjBAaePwysm2ianpJHQTtYHRh+CDhxJ8vj5rJ0loJ1OKqeMPV6L19OlzTXwlF3epEuo5aV4aY44zIY2uyO4Az69z+Sjoa2qbc3VFMZKd7QGhzHEEjPGf91nxwOAmc9wMk2BI/GScEnaD+Pb5riynPjNAxgO2nnOXE+vw2n81t0unp09vYph5+qvVai5NypL6f6g3amaPb2tq4S8ty4YcMdgD8fito6WvNNqCIyUwc0x48Rjh938exWqNOaeqrs2ngpYThx3vkP3WDkZP5Ldmn7PTWS3MpKVo45e/GC93mSq9VVRRGI4q7dMzPySS+oi81oEREBERAREQEREBERARFRepdTq6B9o+ylPSyROrYhOXvduxnkOAGAz1Oc/BQRGV6RdNIZzTRGrbG2o2jxBE4uaHeeCQDj8F3KQUVqL/AATP4x/QqVUVqL/BM/jH9CvL6a/o3eTTo/f081ph/VM+QXJcYf1TPkFyW6nhAKpR/wCbK7+D/hqtqqUf+bK7+D/hqqu9qjm02Oxc+n8wl0RFreaLAutqo7rD4dZC1+Puu7Ob8QVnokTMTmBru59P5fEkfQVTXNd2ZLwW8Y7+fKhotJXuKidEaMh4wxu2RrhtB79/j6eS26i006u5HzVzbiWoYtGXiV5JpWt5w3e8NDfU8fN35qfs/T1kRhdcarxBGQfDiGA48dz+B/NX9Eq1dyrdwTsQxqCiprfSsp6OFsULBgNaFkoizTOd8uxERARF0VNVDTNBneGA8DKhEzjfLvRcY3tkY17DlrhkFclKRERAREQEREBERAREQFFai/wTP4x/QqVUVqL/AATP4x/Qry+mv6N3k06P39PNaYf1TPkFyXGH9Uz5Bclup4QCqUf+bK7+D/hqtqqUf+bK7+D/AIaqrvao5tNjsXPp/MMq83SjstsqLhc5hBRwN3SSEE7RnHYAnzUVpvWmntSunbZbpDUugaHyN2uYWtPY4cBx8V19SbNV6h0PdrVb/D9qqYgyPxHbW53A8n8FpeHo5qplluFFvtolmggxOZpC+bZtzA49gwY4wP8AS1annREPQ4q6YhhFRCRJ9z3x73y9V8FZTFjXioh2uO1p3jBPoFoB/SDUjdJwCj+r6S9U9wNTBFFO8sjjc3DhudnnIbwBjhcL90WvhobFDbvYKtlPQ+BPDUTPY2Odzy58jdvfl2PXgJlOI8XoN1XTNeWOqIQ8ENLS8ZBPYL4KylLgBUwkl20DxB39PmvPN96OamrKi6SxOonyyupDBJ7Q4fq49rzzk98YySVyoekOq6e8UjnSUJpoLyK8zCY7yzLcnGO4x29UyYjxeiI54pJHsjlY57PvNa4Ej5hVdvUTSrtQfUguzPrTx/ZvA8KTPiZxtztx3+K130r6Yag0zrKO43M0HgQska+oimkdJUl2cEjIHmO4Pb15WND011XT9RLvdadlsFBX1UkgmkkJkia7dhzQOzhuz8wozJiG3dSaptWn7NV3OuqA+mpS0SiHEjmlzg0cD4lZ1rutHc7dFXUszDBJG2TJIBaHAOG70OCF5zg6L6qFprqX2a0QyugEImjqZS6pPih2XZO0cD08hx5qRl6P6obTXimopaOnpaqGkd7OJ3Bk8kbWh4fgZAJ3HPmmZMR4vQZqYGwiZ08QiPZ5eNp/FfJauniLBLUQsL/uBzwN3y9V54q+juqZNP00TX24hlbNUfVPjyezxte1oAa485GD5+ffuvl46O6lqG2ZrKe2zy0tO2Fz31chiaNziW7HAuONwwQ4fJTkxHi9HqC1X+og/iP9FNQtLIY2HGWtA47KF1X+og/iP9FFXBRf93LUH0hdW3vTVFptlmvMlsgmjkfOIWjxJdobtDXFpHmeMjKqNP1Z1jYq6uqrhVuq4W2Knq6Snr6QxiaRzog53uY5w5574W59cdQqDRdPZqWqtlZcqqtifJHDTNadrI2gucdxHYH/AGUbH1otMlVcmNst3NNbaaOrq6nw2bYWPi8RuRuzk8Nx6/DlF1HZjcqOsOsOr9KTRRXG3WR76i1C4wGGOZzS4yYDCS4dm8n4rEpOtGqrveqi009DbaaaSnkEUIinNSHez72zDgsLC7sDzj8zP1PWykuNVaIrdS19vnfcqemqKeopGSvfHK3czBEg2hwHcZPwXczr7ZnUFZW/Z29D2V7Y3t2Rb25JGXjflg4/1Y7hP9dY+SgWjrrqa1aXtwq20dxqnUE88k9TBIHmdszgIztLRwzaeB5jlWq2dXtX19s1Nc4LPaZ6WyQxSPhjbKJpDIzII5I2tOSf+0fipS4/SC09RUzJ32a7SYgbNJsEREe55a0E78HOM5GRjC7H/SB03BXy09VbLpDHHUTUzptjC3fG3J4Ds88eXmn+mPkrNm62atvNXY6Ght9hfUXKskpGVJZUCB2GtIIzg8F3Pf8ABS/VnWF90r1JtEtG6WpZFZKiploI3uEMsrQ7ktHcDv64ClIeulpNpNZJp+9RyOmghp6fZGXzmZrnMLcOx2aTz6hTF26tWi26GteqJ7dcTS19QKVsGxolY73u4Jxj3T2KH+I/oj1Kumvbjfae6U1BFHQR07on0jJWiTxA4knxOce7xwPx7rbK03P1909DTse203h87PFNVA2Jm6mbG4NcXe9g8nyJX2o6/adiqnQx2+5St9sFG2RoYA4kZDhl2cY/FTlExPg3GiqXTnWkWubMbpSWuvoaJ2PBkqg0CblwO3aT2LcHKtqORRWov8Ez+Mf0KlVFai/wTP4x/QrzOmv6N3k06P39PNaYf1TPkFyXGH9Uz5Bclup4QCqTP82Vv8H/AA1W1RVTbf8A7TNbF3czY9vr2wVxXRNU0zHdK23ciimuJ74x5IjVUNzqNPV0FilZDc5IyyCV7sBjjxuzg9hk9lRY7X1NiohGy828yMpGtBc1pLpg4AnJZ2LAXZx94+i2iWkdwfyXzB9D+S0MTXEtu6hVFmvUE9xoo62VsXsUkDw0RkOG/nZkZbnvnnyCwp7H1H8OllgvVOZ4XPaI5Hgt2FrACSIxufnfy4YBwcd1tTB9D+SYPofyQy1lqWya/rqihdbLvT0zRQNjqh4mA6fD9xADfPLcEYxjsouq051Ofdo6qG80TWQt2Rs8d+wgB2C5u3BPLck5yR6YC3Dg+h/JMH0P5IZVPRVLqyGapk1ZX087NrGwRQNbjO0bnOIaDnIPw5+StiYPofyTB9D+SIFBXvV2n7IS26Xejgl//K8QOkPyYMuP5L5rxlxfo28tswl+sDSv8Hw/v7sf6fj6fFa/oqnS1pkop7JNJSUTmRP8CloJHVsjwCHNkIZuJJ2nJPfKiZw6ppyslX1AdJG51l0/dKxgBLZ6lraKFwAySHSkEgDzDSo6ovWqbhR3CX6ytFripSzxI6CF9bUN3EYaC7azPOOxwVh0tJcquSd1s0pcZ/HdufPeqkUrHk4JLo273nJAOOPT4KcpdL6nme99TfKO0tkG17bTRDxXDOeZ5dzjyT5KN8u8UwhbpZqqloLpca7UGpKaopKaSohr6iqayESMJ2sMQaGEOG045PJHGObLJW1Fx0rZa2ti8GqqIGSyx4xtc5gJGFzpentjZVMq7jHV3esaQRPcqh9QQR2w1x2j8AFJanie6CAMY44cew+CTG5n1MxNucNZ9Y7rpunfpm26n03BeBUQTzRSyzmLwPDj3EZAzh3Gfl5qJ0Vr7QLr5c6Gus1usjbjR0kcsjp/FiqmujAZFt2gBrWnGeArD1RsGnbxXabGo6250k7KWqZB7LTuewtdFh5eQ04wO3bPxUZZehmlrjSUtdT3a81FBUQ07TGSI2zRxY2h42g8loJ7EY8lKyjGzGXGhq+kNHW19tbTWimp7POKwPbI9xdK07XOAH3g3IHc+fAHJ6iOhcVAIyLS2CslyCTLuJbxnd3a33seQ/JTDuglgzd2xXK7x09wa9vgNkbsi3ODiR7vPbjdnCkNRdGrLe57NO6tuVJNbqSOh30zmtMsTMY3ZacHjuMd0dZhhUNi6SanuhsdFbrXV11BE+n8CON7TG2N4LhuGP8AUe+cnJ5PKqulr50muVohvF9tFvs1TJV1EzIKiZ8xe5uA+THbntgjnGBlbc0Romi0g+8voJaiZ1zrH1shmwSxzu7QQO3zWq63ovpCjuFs0/JdL9HX1kNQxkkLfdljJ3lr3Bm0AHkA4z8UIWKrsvSSzWKnpKuhttPbb0z22HeyQ+MI2btwd3GGuOBkdz6qL1ZL0x1HZNPaWgvtLbKSKeKspaaCMgPBB2tO4YG7cTzyc/FW3WHSiz6p0bZdPV1RVxxWlrGwVMW3xSGs2YJIxgjGePIKuHprpOu6kSx0VXeKS4UNPTunpoWFkD2sYGMw8t54xlrXIQi73e+izdNxyRUNtuMFqjNTDS08JEm10gae+M+8RkOPxUju6PXW826etp7bDerqIaxkUm9jw+RoLA7adrXHI48+/OcrGreh+kbDZjLdLtc20MNE+hc523OHyl4d7rclwc7jjyWVpTpVpa43G36gs18vFR7IIYpCXbPGdC0NZuywOHu7QQMAhDc2FpyWx2OvZo+y0stL7HTe0sibE/wmsc85xIeCdxJxnPKsqgqyiFtu9bqKqudw9jjoyx9FndAwNO4yNYBnfgYWRpi+0mpLPFcra2oFNIXNb48LoncHB91wBUuUqorUX+CZ/GP6FSuD6H8l8ltxrfCEnuxteHHPn8Fi6Ss1ajS12qOMxhdpqoou01T3JWH9Uz5BckRaIjEYdCIikEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBdT52McWkSZHpG4/0C7UQYtXWMgoKmp94NhjdIdzSOACfP5KvQXCstroGVVW6slNCJZmSBo2zEtawDa3I3Eu4wT7vCtE8MdRBJDPG2SGRpY9jxkOB4II8wsZtqt7aZ9O2iphA9wc6MRjaSDkEj14CEoel1BU1b44KemjNQ6pfDucXMaGsYHOfgjPDnBuPVKTUM9RLQg0jI46hkZEjnO2uLuSGuDSMgdg4glTdNb6OmfupqWCJ3PLGAHnGe3rtH5BfIbbRQSMkhpKeN7AGtc2MAgAYAH4cfJBBXK9vo79PExsszS2KBjGse8Nfh73OLWAn7uzy8x27o3UlQ6lpZhRBjZQ7dJJvDAQ/aAcMJaHdwXAKemoKSbf41LC/e/xHbmA5djG4/HAAz6L4bdRl8bzSQb4wGsPhjLQOwHphBg3m7TUFVDEynaY3gEzPLtgcXABpLWnbn1OAscX2o2GqdBStoXGQRl0+JDtyAduPMjGBkjI+SmJaKllqGzy08T5m4xI5gLhjkcrpNotxM5NBS5nz4p8Jvv5OTnjnnlBXqzUMj6RxmD6cQVbBI6MPaS1kfjOGHAHs3Hxys+1ahfVTysqaOeJrYmy+7Ty7m5JG0gsBPzGR39FKxWyhhcTFR07CTklsYHONufy4+S7KSjpqNrhSU8UId3EbA3P5IIuS+bHEeE33q0UseXYLgGBznY+AD+PgsODUVa+kpZzQxSGqpHVUUMUu5/G3APHnv8AL5cqWr7NR1UdSWwQxVUzHN9obGN7S5pbuB9cHC5Q2e3QwuijoaZrHgB4EY97HIz688oMNlxqaux1U1OYI6rLoodxc0b+wDg9oIdnjBHp6rAivUlJBK10tRLUNlIkjq2tLoQ1gcT+iaQR7zefLdyfJWJ9DSPozSPpoXUp7xFgLTznt27rpNntpZGw0FKWR7to8JuG574488DKCG+08hFA5tKMT+ztezLiWPlIy3IbtBaCDyckeQXZaquqdeRHXVMwMolkhYzw3QSRBwDS0gbgQHMznuSVKts9ta9rxQUoe0tIPhNyC3Ab5eWBj5L4yzW1geI6Gmj3uDnbIw3JDtwzj/uGUQj73c5KS70zIjkNge8xknD3ucxrBgAk8bzgA9lzgvrnWOSudBmQTmnYwEtD3+J4be4y0F3fI4UnU0FJVEmppYZSduS9gd90kjv6EnHzKNt9G2kkpW0sAppCS+LwxsdnvkdkSiJLvcIp4aV9NSPqXylrjHOSxkYZuLj7ucgloxjnI5XS7UU7aVtS+mZ4E9FJWQiOTLw1oaWh2RgE7h8jxyp6moaSl2ezU0MWwEN2MDcA4zjHrgfkFwhtlDCyRsNHTsbJjeGxgB2DkZQQ4vlXFJPA6kL5YY3mNr3EPqNuAHNIbsOSRwDkZ7eS65tSvjo3ymOHxGb3ObiXLGNaCS5uzc3k45488+SnPqyg/Sf+Dp/0n3/0Y97nPP48rhJaLbI1gkoKVwY0taDE04B7jt2KCLff6jcXspYxBG+nil3PO4Pl25AGP9Ie0/FdZ1JPFQMuE9LEaOeISU7I5S6Z25zWsBaB57xnGcduVPMoqWNhYynha0ua/AYANzQAD8wGj8guqK02+FkzYqGlY2b9YGxNAf588coMK2Xo1FNcJqqF0TaM5c4xvYCNu48PaCCPl6eqj36oqKWnp5a2iZ/4imbOxkD3SFrnPYxrHYb5mQcgHseCpyptlPLa6ighYynhnY5jvDaB3GCcLlHa6CKKWOOipmxy48RojADsds+qCLtt/lqqlkElMWE1DoS5zXs90Rb9wa9oOc4GCPiuu13atul2pnQmGOiNMZnMPJcHSERuz/Cxx/H5KZdbKF0LInUdOYmO3tYYxhrvUD15XKOgpI5IZI6WBr4WeHE4MALG/sg+Q+CDJREQFgVd1gpZ5YZGyGSNkbg1oHv73FrQ3nvlqz1gz2unnutPcJA4zwMcxnPu8+ZHqOcfMoIpupD9ZeF7O59EyKWaWqaWtZG1r9oJy7OPdfkgeQxlSFqvVNcqiaGFsjJImtkw/b7zHZw4YJ9DwcEeYXSNN0AhER8Yxmm9ke3xCBIzn7wHc+845+KzLfbo6ISYklle/Ac6QjsOwwAAPy+aIRVVqaFklI5sckdLK57vaJGjY+JjHOc9uDnHA7gZzxlZEGpKOV7mFkzHiSJmHbTxI4tY7gngkY9R5hdcelqFrGRyS1M0McD6aKOST3Yo3beG4A7bRgnJ+K75bBTTW6opJ5aiRs5aXybw1+WkFuNoAbggdgEHRVapoKaJ0jhK9rWmR20NyIwSPE5Iy07TjGSQOAu91+phWmnEVQ5jZmwOnDR4bXuaHAZzk5Dh2Bx54XKexUclQ2VviQjw2xOZEQ1rmNztHbIxk9iFzms1NKza50o/TuqCQ4cvLS308gePkES67Reo7hI2OJkkhMbZjK1hbG1rhlgJJzkjHH9FhVmpo2OpnQxStp5XPcKiRnuPjYxznObg5x7o7gZzxlS9tttPb2zNpw7bKWkhxzjaxrAB8MNCjWaXo2xtjdPVvijgfTRRukBbFG7GWt49G4ycnHmgjarUd0i9tc23yOFO6KmbhseHzP24PMgIGXt4x8yPKShvhi3xzRT1NVv2Np4Ymh/DWlx++W4G8AnI5458876opiCD4hzUirOT3eMY/AYH5BY8lgp3SNlinqoJg+V5kieA4iRwc5p47ZA+IwOUQxq7ULYpKfwy2NjzG6QTMc10TS173F2e2GxnjyWdar1TXOolhhbIySNrZAH7feYc4cME+h4OCPRdUunaCYzeM2SRkuQ9r3k5BjEeM9/ug+fckrKobbHSNlAlmldIA1z3kZwOwGAAO/fGfVBj268Nq7nUUbo3sc3c+IkAbmAgHIySOT5gZHZcY9QU8lQ1ngVLYXTSQCoc0CPezdkd8/6TzjHxX202GC2TMlhmqJHMhEAEhbjaDkdgOfj5+eVh2/TTW25kVfUzySFjy5jZPcjkkB3uZxn/AFOxnOM8AIkodROmmeBE6pDmRmGOBmHvJYHuPvEAAB8ffHJ+IC5O1IHV1K2GkmdQvpnVM1Q4saIQCB7wLgRj3s8eXGecZLtP0wl8WnlqKebLv0kTgDtcGgt5BGMMZ8RjgrnLYKCUbCyQRGmNI6Jsjg18eCMEefc89+UQx2aooXRzuLJx4QY4N2hzpGvdtaWgEnvxg4PwWVWXmGkFMJoZxPUNLmQAN34GM+eMjI4ByvkVlgYza+WeU+IyQue4c7DlowABjPwyfMldtztcVxw2eWYRFu18TSNrx6HIOPmMH4ol0yXymjuTKOSOZhcS0SOADS4MLyMZ3dgecY8s5WNHqijdTiaWGpgY9kckXita3xGvOG4545/awvrtMUjpHPNRVculcBubhviAh2OM/wCo4JyR644WXPZ4ZJjLHNPA/wANkQMZGA1u7AwQQfvHuD2Hog5S3WKKgiqnwzgyu2RwBmZHu54AzjyJznGOc45WJV6jgpKIVNTSVsYAe6Rj2NaYw3uTk4Pw2kk+WVky2amdQU1LE+WAUzg+GSJ2HsdgjPII5BI5GOViVemaWqa8S1NZh8XgvzIHFwyXZJIJzlx7YHYYwAg+Xa/+BFM2ip5pJGyMp2zFmYmyvLQ1p5BPLhnAx5ZC+nU9H4e5kNQ4uLxE3DWmUMOHObucBgHHJxnIxldz7BTuqPENRVeH44qRDvGwSDndjGe/OM4zzhfHafpPZ6OKN80fs0PgNc1w3OZxkEkeeAcjB9CEQkqGqiraOCqpnboZmCRhxjIIyF3LjExsUbY2DDWgADOeFyRIiIgIiICxK25UNC9jK2rggc/7okeGk/n8wstRFXa6iW5VE8NRCIamJkUrJYd52tLuGnOMEOPBBQZouFGaz2UVUJqckeHvG7OM4x645WOb7ag0u+saXaGh5Pij7p8/lweVhMsU4DI3VUZihmlqIcRkO3v34LjnnG89sZ4X37PhkT44ZWsDbeKCH3Pud8u78593j4IJKe6UFPKI56ynjecDa6QA89vzXKnuFHUhngVMUm9xa3a4HJHcfMKNNga4SNdI0sfVQ1G3Z/pjawNb39WA5+K4PslS24OraerjbM58xO+IkDeGAEc92iMD45KCSN2t4fEw1tOHyhpYN4y4OOGkfMjAWaq9S6cNPRPgFQHPJpgHlnZkOz3e/mQ4/wDmU7TiUQRiocx8waN7mNLWk+eAScD8Sg7EREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERB//2Q=="
+            },
+            {
+              "timing": 2040,
+              "timestamp": 107697362010,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAUDBAYHCAIBCf/EAE0QAAEDAwMCAwQGCAUCAgcJAAEAAgMEBREGEiEHMRNBURQiYXEIFRYygZEjM1JUcpOx4TQ2QqHBF2IkgjVVc5Si0dMlJzhTdHWDsrT/xAAaAQEAAwEBAQAAAAAAAAAAAAAAAQMEAgUG/8QAMREBAAEDAQQGCgMBAAAAAAAAAAECAxEEEiExcQUUMkFRsRMVIzNSYXKhwdEiNIGR/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREA9lbK5PZWyC5REQEXxzg1pc4gNAySewWPRa40rNcPYYtRWl9XnaIm1TCSfTv3+CDIkQkAZJ49Vjp1xpZtf7EdRWkVedvhe1s3Z9O/f4IMiRAQQCDkHzUVedQ2uyvY261XsjH4xNLG4RD5yY2j8SglUWBda6r/7pL/U0c/Bp2uZLE/uC5vIIUsdX6es1JQU13vluo6p0Mf6Oeoa13LRyQTwgydFTpqiGqgZPTSxzQyDcySNwc1w9QR3ULd9Y6bs9WKW6322UlTnHhTVLGuHzBPH4oJ5FSpKmCsp2VFJNHPBIMskjcHNcPUEd1VQEREBERAREQEREBERARF8e7a0lALg3uQF8EjD2cFF3K40lvgNRcaqGmhyG+JM8Mbk9hkqwo9S2OtqWU9HeLfPUSHDI46hjnO+QBQZKioU7yfdP4KugHsrZXJ7K2QXKIiDW/XCeZ9nsdobM+npLxdYKGrkYdp8FxJc3PlnGFkdXoXTFRYXWh9loG0OwsDWwtBbxjcHYyHfHurzV2naHVVintdza7wZMOa9hw+J45a9p8iCsPl0XrOpojbKrXj3W1zfDe9lvY2pczsR4m7vjzxlBghvtyn6H0dC6tlLJLwLI6va7Dn03ilu/PxaNuVtxmgdKtsf1SLFb/YtmzBhbu7Yzu77vjnK9zaJskuiRpU0xFpbEImtB95pByHg/tbuc+qxpuidaMpPq5uv5fq0N8MONvYanZ2x4ue+PPGUEN1BqqnQnRQ0+nbxNVmOVtGyuc8OfDG55BG4ebR7oPcLYun9OWy36cZbo4hUU80IbO+Y+I6oyOXPJ+8TlU7do2yUWj26ZFI2a0+GY3xze8ZMnJc4/tE859Vau09dLZZRZ9MV7aam2eGyorXuqJKdvbDG8Zx5bnHCDStPPLT9IuqFgbK+a3WaufT0b3HO2PxB7mfhj/dbn0TpSzUek6SM0tNXOq6dklTUzMEjqpzmglzie4OeB5BR46Z0FP01rtJUFTJH7aC6eskbvfJIXAl7hxnOMJHo7UdppPYNL6pjoraG7Y4aqhFQ6nHmI3bhx6B2cIMU0/VzaQ/6o2qyEuoLPF7ZQxfeED3xOe5g+AIzhZT0s0lY4dDW2pfR0tdVXGnbU1dVPG2R875BudkkcjJ7Ka0Xo6j0zZ6qkMslfU10jpq6qqAC+pe7uXfDHACx2i0FqHT7JKLSGrfYbOXOdFSVdE2pNPk5IY4kHHoDlBQ6fQx2DqfqzTdrGyzMhgro4Actp5H5Dmt9Ae+FtBYzojSMGl4ayR9XPcLpXSeNWV0/35neQwOA0DgAdlkyAiIgIiICIiAiIgIiIC8TjMRXtDygx3UYqTbT7EK4zbh/gvB8TH/8vu4/3UFZW3f60g9qGovByd3tQofD7H73h+/+SzZ8JB93kLyInk/dQfYB+kCul4ijDB8V7QD2Vsrk9lb7T6FBcIis6q4RU9XHTuzvc0vJwcNb6/mgvEXxpDmhw7HkKhUVQhqqaEtGJi73s4xgZQXCKPoK99XVVMZhDI4nuYHbiS4g49Mf7q0F9d49RG6nAEUgY07/AL36QMJ7eWcoJtFF1129mqXxtiY9kbWueTJtcQ4ke6Me92+C+0N09prTAY2sad+07iXHa7acjGB+ZQSaIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8PiY97HuaC5hy0+YXtEBUp6eCoDRUQxyhpyN7Q7H5qqiClHTQRzOljhiZK77z2tAJ+ZXk0VKfEzTQnxDl+WD3/Pn1VdEFEUlOPDxBEPD+57g935ei9NghbK6VsUYkd3eGjJ/FVEQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERBEXm+wW14i2mWYjO0HGPmVEfbB37kP5v8AZQN73/W1X4ud3iHv6eX+2Fr/AFPSail1fbJ7W6qFrY2MT+FM0Nz4hLssJG73cD8eM4wvLq1NyquYicQ9+3obNNqmqqmapnHj3tvfbB37kP5v9k+2Dv3Ifzf7LUlDT31vUO4TVLKt1ke1vs7/AGlvhNPhgOzHnPLs847qhp636lh1rXuuVRO+xxmR9M50wcJN5bhpbnPujPcLn0934+7Pc76np8+7njjv/wC8eDcX2wd+5D+b/ZPtg79yH83+y0vpyk1NHaNRx3Fla2ueyT2OSSra8OJ37dgB9wjLe/w9FX09R6obp6+QXaaT6xkj2UchlB58IAOBBO07uT8clTN+7Gf5+RGk0849nO/n+24ftg79yH83+yfbB37kP5v9lpSopNVyaMuLWe1i7SVLHQxipaJGxjZuG7dgZw7z81mVjbO2z0batksdQIm+IyaQSPDsc5cO5+K5q1F2IzteTqjRaeqcejmN3zZz9sHfuQ/m/wBk+2Dv3Ifzf7LUel6e/Rarvb7tHWGhfJIaSR9U10QYXDa0Rgkg4zz6cKy0LSatgvUztROqXU5jduc+oY+Nz93u7GAZaMfEfJTN+7v/AJx9nMaTTzMR6Od+fHc3T9sHfuQ/m/2T7YO/ch/N/stNaao9Uxa0r5rq+c2Z0lQYGumDgAXt8PjceMZxxxz6q00jR61i1dJLe5pHWwmXfulY5jv2NjQct/IcKfTXd/8AOPsiNLp93sp3zjv/AO8W8Ptg79yH83+yfbB37kP5v9lqXTlPfYtY3mS5x1htr3ONLI6pa6INy3DRHnIPfn5qhpGk1LDqy6zXl9U62PD/AAPEmaW5Lxt2tBOMNHfjv2UTfu7/AOfk6jR6eceznfPzbtt2qYKidsVREYNxwHbsjPx4WRLUy2hbd/1fTeL+s8Nu7PrhadJfquZiruef0jpKLE01W+9coiLa8wREQEREBERAREQEREBERAREQRF5sUFyeJNximHG4DOfmFEfY9376P5X91lyKivTW65zMNVvW37VOzTVuYj9j3fvo/lf3T7Hu/fR/K/usuRc9UteHms9Y6n4vtH6Yj9j3fvo/lf3T7Hu/fR/K/usuROqWvDzPWOp+L7R+mI/Y9376P5X90+x7v30fyv7rLkTqlrw8z1jqfi+0fpiP2Pd++j+V/dPse799H8r+6y5E6pa8PM9Y6n4vtH6Yj9j3fvo/lf3T7Hu/fR/K/usuROqWvDzPWOp+L7R+mI/Y9376P5X90+x7v30fyv7rLkTqlrw8z1jqfi+0fpjlu0tBTztlqJTPt5DduBn48rI0RXUW6bcYphmu3q707VyciIi7VCIiAiIgIiICIsF61atrtF6DqbraomSVhlZDG6Ru5se4/eI8+35kIM6RcnaZ6ndTK+Wmqae6225xySDfRgU/jNbnB/Rja8/hlS0vVjWEHW2os7XVNTao7jJTNtjKePe5gyAQ7Zux/r79kHTaLRtz+kNbrffbpbJbDWPfRSywhzJgfEcxxbwMcA4/BVbH1/orrfXWwWCqhe2GeUvdUNP6qJ8hGNvnsx+KDdqLS1j+kDZa6xXe6V1sqqOOgMLGxiRsj53yb8NbwAMbCcletIdf7JqG+QWuS111FPUu2QOe5r2vefutOOQSeBweSg3Oi5h6Q9W9XXbXU1HepKi5UHgTPMDII2ez7cEPcWsBwMbefNwWW236QdDXWO8XJtgqWNtrYnOYahpL/Efs4O3jHdBvFFoKp+kjb4KajmOnaoipjMgHtLfdw9zf2f+1S0/0gbDT2aor5rbXNcKp1PTQDG6drQCZDnG1vI9Tyg3Oi0tY/pA2O6UFzebZWU1bR0zqltPI9uJw3u1rh2OOeR2TSfXy36ju9st0FirIp62qFOSZQ5sQOMPJx6k8fBBulFzD9Km/Xe1aytMVrutfRRPoA5zKeofG0nxHjJDSOVnWouven7Ffay0mjrKp9Gx7XzsIDHStb9wefJ93d5H4coNyIsB6S9SafqLTXKamt0tCKJ7GESSh+7cCfIDH3ViurfpBWGw3+qtdNba24eyyGKaeNzWM3A4Ibnvg8Z4QboRaTv30hLLb6C1VlDa6qthro3PIMrY3Qua7BY4YPPnwexCuP8Ar7YGWavuNRb62NkNQKemi431OQTuAONrRjnPqEG5EWj6HrpaNT2K/wBJDT19pucVuqJ4DuaS7ZG53uO8nADIyPJYt0c6ox6e0NqC56lrrtc/Bq4YoWTSeI4ue15DWlx44YScnHHA9Q6ZRaQsP0irDcKsRV9puNDG5j3tmy2RuGtLjnsew8s8q1p/pKWSWr2usN0bS7g3xg5hIz6tzj/dBvlFpW+fSG07bbtcKGCgrasUoc0TtIaySQHG0dyB3974fHKjpfpHUEdopq86dqi2eeWAM9pbkFjY3Zzt8/EH5IN9otRaZ66WO96rorE63V9JLV+G2KaUDbvewODSODjJwDjng9ioy/fSL0/bbzUUVJa66uggkMbqljmta4g4JaD3GfXCDeCLU2pOuumrRYbTcaaGrrpLlGZYqdgDHMAcWneSePeBHGexUp0u6sWjqBVVNFS01TQ3CBnimCbB3MyAS1w9CRnOO6DYqIiAsI6w2i/XrRzqXS7aeSuE7HuhqNpjmjAO5hDgWnuOD6LN0Qcds6Na9ut+pXy2CisrA5u+ogqIwxmDnfta9xz/AAgdlmOqumet7d1f+1Gl6aCtjfOJ2TPlYPDJbtcHtcQT59srpNU5J4onASyxsJ7BzgEHPfTfp5qm0dca6/3O1eDaZaise2fx4nZDy7adocXc5Hko7VHSjWUXVO73yxUtJU0dYamRkskzQGiaJ7XNLSQc++QPLOCeMrpdr2vJDXNcRwcHOF88aPxNniM3/s7hn8kHI9j6Iayn0lfaStt7KOsM1NUUrJKiNwn2CZrm5a44OJAecLNtE6Y6n1WqbFJqWgtdFbLc2OMyPgpZJDHHyGtLdzgT6gjHddAunhbJsdLG15/0lwB/Jefaqfn9PFx398cIObNHdLtb6T6mVM9HTU8tnq/Ep5q3xGEezvcCfdJDg7geSxum6N9QLbZ9Q26G20k0NU2JoLahmZtkocNmXDHmTux6DldcsqIXkBksbi7thwOVqq/dYm2nqrFos2Qyl9VT03tntW3Hihhzs2eW/tnnHkiGiq/oxr6WhtUbLAS+GFzZB7XB7pMr3ft+hC3V9IHp1eNYx2e4ac8J9dbi4Gne8M3glpBa48ZBb5kd1bVnXg01Le5n6Sr4xbZGsHjzeGJMvDeTtO13Occ8Z5WwOmWs2a40rT3n2QUBmkkjEBm8Q+6cZzgZ/JBpOg6edQ7jb9Q1F6t1tp5p6OSKKnayB088hbtH6blwGOcl/wAOyzv6N+kL5pDTt2ptR0Hsc89UJI2mVkm5uwDOWk+az3WF/rLLBAy12ioulfUEiONj2xRtxjl8jjho5+JKmxUsbDG+ocyFz2g7XPHB8xnzRLQH0junuqNX6qttZp21msp4aIRPf48UeHb3HGHOB7EKFvfSrXtBqfVf2djpZbXeoZjJK58eXNcS/wALDjlri73c9vPK6cZLG8kMkY4gZOCDgJHNFISI5GOI7hrgUGm/o16Lv+jqC+x6koDRPqZYXRAyxybg0Oz9xxx3HdYRXdOuo2l9UajfpGio6+33dzw6WQwu/RucXAFshHIzg8EFdMCqpyCRPEccn3xwtf8AWHqc3pxHaXm1G4ivMoGKjwtmzZ/2uznf/sg0trvpNr26W6w4ttJWVkcMhqBSez07IiXcNwC0OOAMkDz+C2d1y6dXbWFgsMtj8H6ytWf0Ejg0PDg3OCeMgsHfjutm6bu7L1py03V0Yp/rCliqREX7tu9gdtzxnGcdlIRzwyOLY5Y3uHk1wJQczx9MtfakvF51FqumpYK/6sqKenp4XxgzyOgdGxvunaB73cn+1hpnpXreh0JebfNYKKSpqK6mmFNWTRubLGxkodtc1/uuDnM5y04zz3XU4qIS8sEsZcO4DhkIyeGQOMcsbg3uWuBwg5d0l016lQT1bXUVJbbb4EwZbqmpbUU5c5hAa1hc/GXHOSfX5Kys3TDqVBeofq21U1gpy5vjOhrd0EuD3ewyPLvljHwXWEcscgJjkY8DvtOV5bVQOBLZ4jjk4eOEHLNw6R6/tVXqm3WKGlqLPc27jIXxh0zWv3MYA45a7nnsOO/ZY/UdGtev0zQUjbCTURVlTK9ntcHDXMgDTnfjksd+S6Y6h9R7HoL6v+vBVv8AbQ8xezRh/wBzbnOSP2h/usktN2pLnZqK508m2lrIWTxmQgHa4AgH48ohzfF0w1g3qzp+8GzkW2lNtM03tEXu+FDC2Tjdk4LHDgc44yrWn6bdTNI1N7tmmaChrrXcHjM8vgPDmNcS3LZDweeRghdUNc17QWkOB8wcqJl1NZYr+yxyXSkbd3jc2kMg8QjGe3y5RLQOs+kmsqil0zeKA0FVfaGHZUU8GymY1wkdI3Zt2t/1EHt2ysy6JaT1fa7zcLtq6mttEJmOayCGCEzOc5wJc6RgJI483EnPPZbjRAREQEREBco/S7JbriykcEW8EfzXrq5aR679KL7r/UVvr7NU22GGnpfAcKqR7XF29zuNrHcYIQaf0dca22dQK52irpcbiZLXUT1D5mODnTezuc7c09yJcYJ8/Xzw/wAW3fZsXgX24fa/239Rh2PDxnxPE/az8fw813RZdOWmzz1FTbrbSU1XVHdUTRRgOld3JJ7nnlYzb7Z03r9TP+r4NNVF8Y9z3RwmJ0rXtPvEtHYg9zhEObdcV1RF1f0tdNQEwTGG11NU94xghsZeT8iHfksNikbK/WUkZ3MfTlzT6g1kC7pvGmbHequnqrtaqKsqKcgxSzRBzmYORgnyz5KJ/wCnGjs1J+ztvzUjbN+j++Nwdz/5mg/gg0v9GLQ9JcaGk1ZNW1YqrfWTRRU4I8LBjaCcYzk7vXyCx/Xv/wCK6l//AHS3f/0hXUdgsVr09QmjslDBRUpeZDFC3DS4gAn/AGH5Kxq9Gacq7+291Nno5bs17JRVOZ74cwANOfUbR+SJcI2v/Aah/wD0rf8A/REr2OenptPWeqtt4rvtDDVPa2ka1wbBHnc1zHepcTwP+Oe0o+mei42TNZpu3NbM3bIBH94ZDsH8QD+Cu6HQulqCaklpLBbo5aQkwPEIJjJOeCfjyiHI2u6iW7dSL83W9dUUckAcIAS4BpAGwABruCOewznuFG6vn8XQWmI47pVXGniqaxsbp4DH4XuwEsaS47hk5+GV2jf9Had1DO2e92ahrZ2jaJJogXY9M98KnctD6YudHRUldY6Calog4U8RiAbEHY3bQO2cD8kHPWp9KT6N6ItvlkuFwlqL7DQ+3Fzh+iiMZOGkAENyWt+XCwvp39WUWsdMz2nUFbDXSvi8aOGB026Quw6M8MwCOP8AVxzldcUV20nVn7M0lws9Q6JhpTbWzRvcGsGCwx5J4AwRjjC9WXROmbJXGttNit9JV4I8WKEBwz3wfL8EHIXQ7RlLrrVFxtVdWVVLTtonTuNOQC/bLGA05B45z8wFsv6X0Qgt+j4WklsftLAT54EQW9NP6M05p2skq7HZ6ShqZGGJ0kLMEtJBx8sgfko/XseiKh9HFrmSzBzA51M24TMYcHAcWhxHoEHLuq6wT6l0XSakuVbbrHT2ShfDNTNLnR/+Ha7e0Dz8QYz8Pgpj6KR3dUrg7c52bbMdzu5/SxcldNz6V05cae1+NaaCphoGMFEXRBwiaANoafTgfBfLFo3TthuEldZrPSUdZIwsfLEzDi0kEj8wPyQctdZ2VGhOsN2raBu1lzpJJGeWPGjdG8/g/cfyUZX225af6F2uspvGhhvlxfJVPZkExsbtiYT6EiR3x4XXWotI6f1JNDNfrTSV0sLSyN0zMloJzgK8fY7XJZWWiS30z7WxgibSvjDow0dhg+iDk7pALbQ9S7YywX+tIlZtfAyB0jZssJe15IZgDGc7TjHcrXmnKP2jT2qajx54zSUcUgZG/DZCamJmHDzHvE49QF3PYdH6d0/NLNZbNQ0Usg2vkhiAcR6Z74+Csafpzo+np6qCDT1vZDVMEczBHxI0ODgD/wCZoP4IOM78ZqvpzpmsqHSyviq6yjEj3E7Y2iF7GfDmSQ/j8Fc3Krttfc7Bbp66em01BQxBpDnhrZCzdMRlrjzOZBkNPbjjC62ntvTygpTpeoZp+GKSbxfq6WSMEyEAZDSc7iMBSc+gtKT22noJtP219HTkmKMwDDM8nHmMoNVfRWljFJfKaku9XXUkbmOEMtOWMhcd3LXEnOQBkYHYKRu//Tv/AK+U3tnt51Xujxj/AA3jbBsz57tu3Hl2W27LZ7dY6FtHZ6GnoqUHIjgYGDPrx3PxVvJpqyyX9l7ktdI67sG1tWYx4gGMd/lwiUuiIgIiICIiAiIgLi/SFsqb11U1lbKANNXVwXOGIOdtBc4uAyfJdoLUmhukEmmOo9Xql16ZUtndO72YU2wt8Qk/e3Htn0QYLedaal6Waa0noqgpqL69dA6SaSZwexofM8MDTkD1yScBZFoXXPULUFDfrfX2qOmuVPTPloq9tOfAfI0j9GTktdu8iD6rKurHSqm17V0NwhuU1rutG3YyojZvBbnIBGQcgkkEHzKh9JdGqjTlvvkkWpaiovtyp3Uza2SI7YWuI3ODd+S4+pdwiGr7b111tdnWu0UDaP66qKwwukdTja4O2Bgxngg78n5K8n62a6udyrW6bpaCaloSGlrogZZhnG7buySSCcNHCnYfo3GmpqF9HqbwbnT1DpjVCkPI93YA3fwWlrjnPO74K6uv0eDPXVM1r1RNb4KzBqadlOSxx7uAw8e7nJAOcepQY5rrrbrS1usnh0MVqqKihEtRTVNMc+J4sjdzd3IaQ1pA/qq8XW3WsOtbzaJ7ZbpX04qg2mBx4JiY9xO/PvABhz6+WFP6n+jxDc22qO3X99NFQ0gp3Gen8Z8rt73l5O8Y+/jGOMK+f0Oldr27aj+v2Btcawin9kOWePHIz72/nb4me3OPJBr7/r7qubRs9SxtBHcaeuiiMrYctfG+OU4LSeCDH3HqpWz9btY0lfpyq1DbKT6juuI2yNbh8gDgx8jcHggnsR2/NYt1S6VzdO9FAm6C5GvuEPDKYx7Nkc3/AHOznf8A7LM+kvRulu9v0xqW53SpkpI4xOy2ub7rZA8k+8Tw0kAkAfig19Zb+zS3XPUt7kiMoo6m5SCPON7syBoz5ZJCy2y9ZepFdJT3Cns9FcbfLKW+zUsJc/APIw1xc34Fwx81mtP0Ggfra73q5XgVNFcX1Tn0jabY5om3Yw/ceWlwOceSi6T6OXh1UEVRq2sktEUhkFKyEsd8cHeQCfUNQbC6ta+k0VoOO9U1IXVtU9kMEM4IDHuaXe+O/AB49VzD1jvuqL63T0+sbbHR1LqZ0tPJHgNnieQQdoJwR6Hntwus9eaGtusdI/UFW6Snhj2Oglj5dE5gw089+Mg/ArUVy+jfLWU1Gx2rZ5JYGlhfPTmQBmfdawb/AHQB8+/kgoau6t6npNSQaZ0fTUIdSUsQfJU7d0jvDa44LnBoHIGO5WzOjOrr/quyVT9U2eW3VtO8BshhdEydpBwWh3mMc/MeqxvWnQ6O93qK8We/1FouJhZFM+OMuDy1gZuGHAtyByMlZh0p6fUvT+z1FLDWzV1TUvD5p5BtBwCAGtycAZPme6JclaldcpdV11TresvNO98jnQ1MEXisPJwWZe0bMdtp7LN5Opd90VobT0Wnr5T3SOolqt888bnvAaY9rSH8tIDjxyORglZjXfR4rnxT0lHrWqjtkjy72WSnc5vfIyBIAefgpC4/R4ttRpK22qmvE0NZSSyzPqnQhzZXSBoPuZGANjcc+SIQ7ereqD1Ytlg8Wk+rqh1IHjwBu/SQxvdz83FQuiOrHU7V9ZVUNkp7fWVUcYlP6Nkfht3AE+84A98fisztfQaWg1tbr/8AaWSobSPheY5qcue/w2Nbjfv89vHHAwPJTHR7pBJ08vtbcX3ptwFRTez+GKbwtvvNdnO4/soOf9NW6tuvXh8N1NNNVw3WeorC4uDHeE5z5NuOezHbfLOM8LNW9btfXqqrKzTttt7qCGUNbTCPxJSCeON29x9S0YHwWx9O9G3WnqnVavlvLKiKeoqpzR+zFvEweNu/ee2/05wser/o5tNbUttOqauitVRIHvpDCXcA5AyHgHHkSEG59G3aqvmmLfcbhQS26rnjzLSytLXRuBIIweccZHwIUyorS1jptN6fobRQukdT0kexrpXbnO5yST6kklSqJEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERRc09WZ5BEcMaQB7gP8AyFTevRaiJmJnPg6pp2koit45ZH0LZWtaZXMDg0nAzj15UbbbvJVVdLC4wh0kAlewZBaSM8ZPPyx8cq2mYqiJhzO5NIoWquNZE66PYyPwaVp2Es7nY13J3ep9PxVMXWpaKNjfCmNSdjHtHAcHDOcOI+7k9/JSJ5FAQ3eqdNVNfHEGxztjadpGQZiz154HfjlfJ7xUskuLWeAXU5wxm3Ljy3k+9nz9B80GQIoiS6SR2JlbK6KOR3HLTjOcAYzwfhnj8FThu0z6h7XiFrWxlxAyduGg7ifNpyR28kE2ix6mvc00tE3bEY5nHL2tzuG7AwN3Bxye+PRZCgIitK2SXcI4SWnY5+QAScY4GfmkRlEziMrtFbUUrnh7Xu3bcYcRgkEZ5HqrW13CWrrauKVgYInYa3HOMkZJz54zjA49VOCJzvSaKAt97qKmtp6d0Abuke2R2DjADizHz2nPyVGqvtXDAyUQMe0wue4gH3Xbto4z2/8AmoSyVERAREQEREBERAREQEREBERAVu+jie9zzvBPJw8j/lXCLiuimuMVRlMTMcHxjGsY1jBhrRgBfURdxGN0IEREBERAREQEREBU5oWTAB4OR2IJBH4hVEQxl4iiZEzawYHc85JXtEQEREBERAREQEREBERARFRNTEKttNu/Slpfj0CiZwmImeCsiIpQIrC5V3s+GRYMnc58lYfWdT6t/JW02aqozCuq7TTOE8i1L1I6iXaw1NHb7NTsnrqn3slmQ0fL8CsOu3VHW9N+qhia4DkGkyM/NU11RRVszO9dboquU7VMbnRaLmE9UupmHyClphC0Zy6lAz8uVsnpV1BuOrLLNJcGQx1tPJsfsbjcPI7fLzH4KbcxcnZpRcibcZqhtVFA/WdT6t/JXn1hO+ka+kphUTh7WvjMgZgE8uyfT0VlVqqmMyqpu01TiEkij/abh/6vZ/7wP/kq1G+rkkkdVRRwx4AY1r9xzzkk4Hw/JVrF0iIgIiICIrG81E9LSCWnbu2k78NLiG7TyAPjj8MoL5FQnnaKSSWJ4dtYXAt58lWY4PY1zSC0jII80H1F8eSGOI744XLlw6ya4g6jyWGM0fg/WPszI/ZgXGMvwOc/skHKDqRFzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiKlPPHAY/FOPEdsB+KiZiIzIqoiKQWN0Li7WVZk9o8D8mrJFjNv/wA5Vv8AB/w1UXuNPNp0/ZufT+YZMqdRKIYXvd2aMqoo69v207Wj/U7laaKdqqIZK52aZlDSPdI9z3HLicleUReiwMDraH2jW9VUzNBMTGsj+AIGVPthYGgFoP4K2ucDm3ieRvDnsaRz3HZW0BrW1OH7PB9WOJx+a+Z1M+3q5vr9DGNPREd8Pl6ga6Bw2jBCx3pvF7FrK5QRjEc9P4px5ODgP+Vd1k1ZUGTDWGNpIw55blVenVK/66r6l2TthbGSfUnP/Ct0U+3jDN0nGbE/JsJV6Oc087Xjt2PyVBF9DMZjEvmonE5ZYDkAora2v8SiiJ7gY/JXK82YxOG+JzGRERQkRUayY09NJKGby0cNzjJ+atY57mamFslDTthc4iR4qSSwYOCBs55wO475QSCIiCLurLVbKKquVZSwNjgjdLJI2EF2AMnsMleqOho5Y4qmkdUMje0OYGzSNaAe3uE4H5KRc0OaWuALSMEHzX1BbOpHH7tVUN+RB/qCsXd06sMl/F6lhL7kBhs5awED04bj4euOO3CzFEGI33p/ZL9cqauvERq56dwdGZGs908ejRnsODkLK4YmQRMiiG1jBgBe0QERR1puE9dLWsnt1TRCnmMTHTFpEwwDvbtJ4580EioPV5It8ZHcSA/7KcUFrD/0bH/7Qf0K83pj+jd5LtN72nmm4zmNpPchel5h/VM+QXpejTwhSLGbf/nKt/g/4asmWLUkgj1fWuIJ9zy+TVTe40c2nT9m59P5hlKir7nEPpz/AMK89sZ+y5WV1lbNTja0gtOeVstbq4YbkxNMxCJREW5jQ13Y5ldHMR+jczw8/HJKjpaxsbnOLm7W8Bmcfims7423V1loTGHmvqHRl+f1eI3OH5kYQiHDiQGuPnhfO6+nYvzjv3vreiq9vTRnu3ISnrI31UzC9u154ZnOPiprQkL2/WMx/Vvla1vxIHJ/3CgbhNBTTF2Wl/r6fFZNoOugrLEzwuHtc7e09+TkH8Qrejrc1Xtvuhm6XuxTa2PGWRoiL3Xzafs4xRN+Z/qr1QFPdpKaIRC1Vz9uRuaYsO+Iy/Kq/Xkv/qe4fnD/APUXn176pluomIpiEhdal1Hb5p2AF7R7oPbJOBn4cqn4dy/eqP8A92d/9RRVxuM9fSOpmWusiMjmjfI6La0bgSTh5PYeQU17Yz9ly5xKdqFCWlrp2iOarpvDJBcGU5BIBzgEvOPyUgrb2xn7Lk9sZ+y5MSbULlFbe2M/ZcntjP2XJiTahcorb2xn7Lk9sZ+y5MSbULlFaSVn6N3hsy/HuhxwM/FYFoG46yk1PqNupoKJttFSPA8J7yW/o24EeRy3GMk497cmJNqGyEVt7Yz9lye2M/ZcmJNqFyitvbGfsuT2xn7LkxJtQuVBaw/9Gx/+0H9CpT2xn7LlC6qnbLb2AAj9IO/yK8zpiJ6jd5L9NVE3aebIYf1TPkF6XmH9Uz5Bel6NPCFQsSj/AM2V38H/AA1ZasSj/wA2V38H/DVVd7VHNpsdi59P5hLry9oc0g9ivSLW81impL3T2KPNQHSSu+5Ezu7/AOQWA3TW90qqhraSNtLAGuc7by5wwcDJHBWytW6chv1HjhlVGD4cnzHY/DlaiuFtqKOb2esiMUu7c4EYAOfdA9ckL1NLVbrjfxZrlMxPyWF+jfXW6ZrBJJX72zxvLve3tON2T6D+qzDS9c+6WOCadofLtw4EgEOHfKxmVskdQ2aI7JWuOMjIwQGnj8Mq5tomp6SR0E7WB0Yfgg4cSfL4+aydJaCdTiqnjD1ei9fTpc018JRd3qRLqOWleGmOOMyGNrsjuAM+vc/ko6Gtqm3N1RTGSne0BocxxBIzxn/dX8cDgJnPcDJNgSPxknBJ2g/j2+a8spz4zQMYDtp5zlxPr8Np/NbdLp6dPb2KYefqr1WouTcqS+n+oN2pmj29rauEvLcuGHDHYA/H4raOlrzTagiMlMHNMePEY4fd/HsVqjTmnqq7Np4KWE4cd75D91g5GT+S3Zp+z01ktzKSlaOOXvxgvd5kqvVVUURiOKu3TMz8kkvqIvNaBERAREQEREBERAREQERYL1LqdXQPtH2Up6WSJ1bEJy97t2M8hwAwGepzn4KCIyzpFRpDOaaI1bY21G0eIInFzQ7zwSAcfgqykFFai/wTP4x/QqVUVqL/AATP4x/Qry+mv6N3k06P39PNlMP6pnyC9LzD+qZ8gvS3U8IBYlH/AJsrv4P+GrLViUf+bK7+D/hqqu9qjm02Oxc+n8wl0RFreaKwutqo7rD4dZC1+Puu7Ob8QVfokTMTmBru59P5fEkfQVTXNd2ZLwW8Y7+fKhotJXuKidEaMh4wxu2RrhtB79/j6eS26i006u5HzVzbiWoYtGXiV5JpWt5w3e8NDfU8fN35qfs/T1kRhdcarxBGQfDiGA48dz+B/NZ+iVau5Vu4J2IW1BRU1vpWU9HC2KFgwGtCuURZpnO+XYiIgIioVNVDTNBneGA8DKhEzjfKui8xvbIxr2HLXDIK9KUiIiAiIgIiICIiAiIgKK1F/gmfxj+hUqorUX+CZ/GP6FeX01/Ru8mnR+/p5sph/VM+QXpeYf1TPkF6W6nhALEo/wDNld/B/wANWWrEo/8ANld/B/w1VXe1RzabHYufT+YXV5ulHZbZUXC5zCCjgbukkIJ2jOOwBPmorTetNPaldO2y3SGpdA0Pkbtcwtaexw4Dj4qn1Js1XqHQ92tVv8P2qpiDI/EdtbncDyfwWl4ejmqmWW4UW+2iWaCDE5mkL5tm3MDj2DBjjA/0tWp50RDocVdMQwiohIk+574975eq+CspixrxUQ7XHa07xgn0C0A/pBqRuk4BR/V9Jeqe4GpgiineWRxubhw3OzzkN4AxwvF+6LXw0Niht3sFWynofAnhqJnsbHO55c+Ru3vy7HrwEynEeLoN1XTNeWOqIQ8ENLS8ZBPYL4KylLgBUwkl20DxB39Pmueb70c1NWVF0lidRPlldSGCT2hw/Vx7XnnJ74xkkr1Q9IdV094pHOkoTTQXkV5mEx3lmW5OMdxjt6pkxHi6IjnikkeyOVjns+81rgSPmFi7eomlXag+pBdmfWnj+zeB4UmfEzjbnbjv8VrvpX0w1BpnWUdxuZoPAhZI19RFNI6SpLs4JGQPMdwe3ryraHprqun6iXe607LYKCvqpJBNJITJE127DmgdnDdn5hRmTENu6k1TatP2aruddUB9NSlolEOJHNLnBo4HxKvrXdaO526KupZmGCSNsmSQC0OAcN3ocELnODovqoWmupfZrRDK6AQiaOplLqk+KHZdk7RwPTyHHmpGXo/qhtNeKailo6elqoaR3s4ncGTyRtaHh+BkAncc+aZkxHi6DNTA2ETOniER7PLxtP4r5LV08RYJaiFhf9wOeBu+XqueKvo7qmTT9NE19uIZWzVH1T48ns8bXtaAGuPORg+fn37r5eOjupahtmaynts8tLTthc99XIYmjc4luxwLjjcMEOHyU5MR4uj1Bar/AFEH8R/opqFpZDGw4y1oHHZQuq/1EH8R/ooq4KL/ALuWoPpC6tvemqLTbLNeZLZBNHI+cQtHiS7Q3aGuLSPM8ZGViNP1Z1jYq6uqrhVuq4W2Knq6Snr6QxiaRzog53uY5w5574W59cdQqDRdPZqWqtlZcqqtifJHDTNadrI2gucdxHYH/ZRsfWi0yVVyY2y3c01tpo6urqfDZthY+LxG5G7OTw3Hr8OUXUdmNzEdYdYdX6UmiiuNusj31FqFxgMMczmlxkwGElw7N5PxVpSdaNVXe9VFpp6G2000lPIIoRFOakO9n3tmHBYWF3YHnH5mfqetlJcaq0RW6lr7fO+5U9NUU9RSMle+OVu5mCJBtDgO4yfgqzOvtmdQVlb9nb0PZXtje3ZFvbkkZeN+WDj/AFY7hP8AXWPkwC0dddTWrS9uFW2juNU6gnnknqYJA8ztmcBGdpaOGbTwPMcrKrZ1e1fX2zU1zgs9pnpbJDFI+GNsomkMjMgjkja05J/7R+KlLj9ILT1FTMnfZrtJiBs0mwRER7nlrQTvwc4zkZGMKo/6QOm4K+WnqrZdIY46iamdNsYW7425PAdnnjy80/0x8mM2brZq281djoaG32F9RcqySkZUllQIHYa0gjODwXc9/wAFL9WdYX3SvUm0S0bpalkVkqKmWgje4QyytDuS0dwO/rgKUh66Wk2k1kmn71HI6aCGnp9kZfOZmucwtw7HZpPPqFMXbq1aLboa16ont1xNLX1ApWwbGiVjve7gnGPdPYof4j+iPUq6a9uN9p7pTUEUdBHTuifSMlaJPEDiSfE5x7vHA/HutsrTc/X3T0NOx7bTeHzs8U1UDYmbqZsbg1xd72DyfIlfajr9p2KqdDHb7lK32wUbZGhgDiRkOGXZxj8VOUTE+DcaLEunOtItc2Y3SktdfQ0TseDJVBoE3Lgdu0nsW4OVlqORRWov8Ez+Mf0KlVFai/wTP4x/QrzOmv6N3k06P39PNlMP6pnyC9LzD+qZ8gvS3U8IBYkz/Nlb/B/w1Zaoqptv/wBpmti7uZse317YK4romqaZjulbbuRRTXE98Y8kRqqG51Gnq6CxSshuckZZBK92Axx43ZwewyeywWO19TYqIRsvNvMjKRrQXNaS6YOAJyWdiwF2cfePotolpHcH8l8wfQ/ktDE1xLbuoVRZr1BPcaKOtlbF7FJA8NEZDhv52ZGW57558grKex9R/DpZYL1TmeFz2iOR4LdhawAkiMbn538uGAcHHdbUwfQ/kmD6H8kMtZalsmv66ooXWy709M0UDY6oeJgOnw/cQA3zy3BGMY7KLqtOdTn3aOqhvNE1kLdkbPHfsIAdgubtwTy3JOckemAtw4PofyTB9D+SGWJ6KpdWQzVMmrK+nnZtY2CKBrcZ2jc5xDQc5B+HPyWWJg+h/JMH0P5IgUFe9XafshLbpd6OCX/8rxA6Q/Jgy4/kvmvGXF+jby2zCX6wNK/wfD+/ux/p+Pp8Vr+iqdLWmSinsk0lJROZE/wKWgkdWyPAIc2Qhm4knack98qJnDqmnLJKvqA6SNzrLp+6VjACWz1LW0ULgBkkOlIJAHmGlR1RetU3CjuEv1laLXFSlniR0EL62obuIw0F21mecdjgqzpaS5Vck7rZpS4z+O7c+e9VIpWPJwSXRt3vOSAccenwU5S6X1PM976m+UdpbINr22miHiuGc8zy7nHknyUb5d4phC3SzVVLQXS412oNSU1RSU0lRDX1FU1kIkYTtYYg0MIcNpxyeSOMc5LJW1Fx0rZa2ti8GqqIGSyx4xtc5gJGF7pentjZVMq7jHV3esaQRPcqh9QQR2w1x2j8AFJanie6CAMY44cew+CTG5n1MxNucNZ9Y7rpunfpm26n03BeBUQTzRSyzmLwPDj3EZAzh3Gfl5qJ0Vr7QLr5c6Gus1usjbjR0kcsjp/FiqmujAZFt2gBrWnGeAsh6o2DTt4rtNjUdbc6SdlLVMg9lp3PYWuiw8vIacYHbtn4qMsvQzS1xpKWup7teaigqIadpjJEbZo4sbQ8bQeS0E9iMeSlZRjZjLzQ1fSGjra+2tprRTU9nnFYHtke4uladrnAD7wbkDufPgDk0iOhcVAIyLS2CslyCTLuJbxnd3a33seQ/JTDuglgzd2xXK7x09wa9vgNkbsi3ODiR7vPbjdnCkNRdGrLe57NO6tuVJNbqSOh30zmtMsTMY3ZacHjuMd0dZhZUNi6SanuhsdFbrXV11BE+n8CON7TG2N4LhuGP9R75ycnk8rFdLXzpNcrRDeL7aLfZqmSrqJmQVEz5i9zcB8mO3PbBHOMDK25ojRNFpB95fQS1EzrnWPrZDNgljnd2ggdvmtV1vRfSFHcLZp+S6X6OvrIahjJIW+7LGTvLXuDNoAPIBxn4oQyKrsvSSzWKnpKuhttPbb0z22HeyQ+MI2btwd3GGuOBkdz6qL1ZL0x1HZNPaWgvtLbKSKeKspaaCMgPBB2tO4YG7cTzyc/FZbrDpRZ9U6Nsunq6oq44rS1jYKmLb4pDWbMEkYwRjPHkFjh6a6TrupEsdFV3ikuFDT07p6aFhZA9rGBjMPLeeMZa1yEIu93vos3TcckVDbbjBaozUw0tPCRJtdIGnvjPvEZDj8VI7uj11vNunrae2w3q6iGsZFJvY8PkaCwO2na1xyOPPvznKtq3ofpGw2Yy3S7XNtDDRPoXOdtzh8peHe63JcHO448ldaU6VaWuNxt+oLNfLxUeyCGKQl2zxnQtDWbssDh7u0EDAIQ3Nhaclsdjr2aPstLLS+x03tLImxP8JrHPOcSHgncScZzyslUFWUQtt3rdRVVzuHscdGWPos7oGBp3GRrAM78DCuNMX2k1JZ4rlbW1AppC5rfHhdE7g4PuuAKlylVFai/wTP4x/QqVwfQ/kvktuNb4Qk92Nrw458/gsXSVmrUaWu1RxmMLtNVFF2mqe5Kw/qmfIL0iLREYjDoREUgiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKk+djHFpEmR6RuP8AQKqiC1q6xkFBU1PvBsMbpDuaRwAT5/JY9BcKy2ugZVVbqyU0IlmZIGjbMS1rANrcjcS7jBPu8LKJ4Y6iCSGeNskMjSx7HjIcDwQR5hWzbVb20z6dtFTCB7g50YjG0kHIJHrwEJQ9LqCpq3xwU9NGah1S+Hc4uY0NYwOc/BGeHODceqUmoZ6iWhBpGRx1DIyJHOdtcXckNcGkZA7BxBKm6a30dM/dTUsETueWMAPOM9vXaPyC+Q22igkZJDSU8b2ANa5sYBAAwAPw4+SCCuV7fR36eJjZZmlsUDGNY94a/D3ucWsBP3dnl5jt3RupKh1LSzCiDGyh26STeGAh+0A4YS0O7guAU9NQUk2/xqWF+9/iO3MBy7GNx+OABn0Xw26jL43mkg3xgNYfDGWgdgPTCCxvN2moKqGJlO0xvAJmeXbA4uADSWtO3PqcBW4vtRsNU6ClbQuMgjLp8SHbkA7ceZGMDJGR8lMS0VLLUNnlp4nzNxiRzAXDHI5VE2i3Ezk0FLmfPinwm+/k5OeOeeUGPVmoZH0jjMH04gq2CR0Ye0lrI/GcMOAPZuPjlX9q1C+qnlZU0c8TWxNl92nl3NySNpBYCfmMjv6KVitlDC4mKjp2EnJLYwOcbc/lx8lUpKOmo2uFJTxQh3cRsDc/kgi5L5scR4TferRSx5dguAYHOdj4AP4+Cs4NRVr6SlnNDFIaqkdVRQxS7n8bcA8ee/y+XKlq+zUdVHUlsEMVVMxzfaGxje0uaW7gfXBwvUNnt0MLoo6Gmax4AeBGPexyM+vPKCzZcamrsdVNTmCOqy6KHcXNG/sA4PaCHZ4wR6eqsIr1JSQStdLUS1DZSJI6trS6ENYHE/omkEe83ny3cnyWRPoaR9GaR9NC6lPeIsBaec9u3dUTZ7aWRsNBSlke7aPCbhue+OPPAyghvtPIRQObSjE/s7Xsy4lj5SMtyG7QWgg8nJHkFUtVXVOvIjrqmYGUSyQsZ4boJIg4BpaQNwIDmZz3JKlW2e2te14oKUPaWkHwm5BbgN8vLAx8l8ZZrawPEdDTR73BztkYbkh24Zx/3DKIR97uclJd6ZkRyGwPeYyTh73OY1gwASeN5wAey9wX1zrHJXOgzIJzTsYCWh7/ABPDb3GWgu75HCk6mgpKok1NLDKTtyXsDvukkd/Qk4+ZRtvo20klK2lgFNISXxeGNjs98jsiURJd7hFPDSvpqR9S+UtcY5yWMjDNxcfdzkEtGMc5HKou1FO2lbUvpmeBPRSVkIjky8NaGlodkYBO4fI8cqepqGkpdns1NDFsBDdjA3AOM4x64H5BeIbZQwskbDR07GyY3hsYAdg5GUEOL5VxSTwOpC+WGN5ja9xD6jbgBzSG7DkkcA5Ge3kqc2pXx0b5THD4jN7nNxLljGtBJc3Zubycc8eefJTn1ZQfpP8AwdP+k+/+jHvc55/HleJLRbZGsElBSuDGlrQYmnAPcduxQRb7/Ubi9lLGII308Uu553B8u3IAx/pD2n4qmdSTxUDLhPSxGjniElOyOUumduc1rAWgee8ZxnHblTzKKljYWMp4WtLmvwGADc0AA/MBo/IKlFabfCyZsVDSsbN+sDYmgP8APnjlBZWy9GoprhNVQuibRnLnGN7ARt3Hh7QQR8vT1Ue/VFRS09PLW0TP/EUzZ2Mge6Qtc57GNY7DfMyDkA9jwVOVNsp5bXUUELGU8M7HMd4bQO4wTheo7XQRRSxx0VM2OXHiNEYAdjtn1QRdtv8ALVVLIJKYsJqHQlzmvZ7oi37g17Qc5wMEfFU7Xdq26XamdCYY6I0xmcw8lwdIRG7P8LHH8fkpl1soXQsidR05iY7e1hjGGu9QPXleo6CkjkhkjpYGvhZ4cTgwAsb+yD5D4ILlERAVhV3WClnlhkbIZI2RuDWge/vcWtDee+Wq/VjPa6ee609wkDjPAxzGc+7z5keo5x8ygim6kP1l4Xs7n0TIpZpappa1kbWv2gnLs491+SB5DGVIWq9U1yqJoYWyMkia2TD9vvMdnDhgn0PBwR5hURpugEIiPjGM03sj2+IQJGc/eA7n3nHPxV5b7dHRCTEksr34DnSEdh2GAAB+XzRCKqtTQskpHNjkjpZXPd7RI0bHxMY5zntwc44HcDOeMq4g1JRyvcwsmY8SRMw7aeJHFrHcE8EjHqPMKnHpahaxkcktTNDHA+mijkk92KN23huAO20YJyfiq8tgpprdUUk8tRI2ctL5N4a/LSC3G0ANwQOwCChVapoKaJ0jhK9rWmR20NyIwSPE5Iy07TjGSQOAq7r9TCtNOIqhzGzNgdOGjw2vc0OAznJyHDsDjzwvU9io5KhsrfEhHhticyIhrXMbnaO2RjJ7EL3NZqaVm1zpR+ndUEhw5eWlvp5A8fIIlTtF6juEjY4mSSExtmMrWFsbWuGWAknOSMcf0VlWamjY6mdDFK2nlc9wqJGe4+NjHOc5uDnHujuBnPGVL22209vbM2nDtspaSHHONrGsAHww0KNZpejbG2N09W+KOB9NFG6QFsUbsZa3j0bjJyceaCNqtR3SL21zbfI4U7oqZuGx4fM/bg8yAgZe3jHzI8pKG+GLfHNFPU1W/Y2nhiaH8NaXH75bgbwCcjnjnzvvqimIIPiHNSKs5Pd4xj8BgfkFbyWCndI2WKeqgmD5XmSJ4DiJHBzmnjtkD4jA5RC2rtQtikp/DLY2PMbpBMxzXRNLXvcXZ7YbGePJX1qvVNc6iWGFsjJI2tkAft95hzhwwT6Hg4I9FSl07QTGbxmySMlyHte8nIMYjxnv90Hz7klXVDbY6RsoEs0rpAGue8jOB2AwAB374z6oLe3XhtXc6ijdG9jm7nxEgDcwEA5GSRyfMDI7LzHqCnkqGs8CpbC6aSAVDmgR72bsjvn/AEnnGPivtpsMFsmZLDNUSOZCIAJC3G0HI7Ac/Hz88qzt+mmttzIq+pnkkLHlzGye5HJIDvczjP8AqdjOcZ4ARJQ6idNM8CJ1SHMjMMcDMPeSwPcfeIAAD4++OT8QF6dqQOrqVsNJM6hfTOqZqhxY0QgED3gXAjHvZ48uM84uXafphL4tPLUU82XfpInAHa4NBbyCMYYz4jHBXuWwUEo2FkgiNMaR0TZHBr48EYI8+5578ohbs1RQujncWTjwgxwbtDnSNe7a0tAJPfjBwfgrqsvMNIKYTQzieoaXMgAbvwMZ88ZGRwDlfIrLAxm18s8p8Rkhc9w52HLRgADGfhk+ZKq3O1xXHDZ5ZhEW7XxNI2vHocg4+YwfiiVGS+U0dyZRyRzMLiWiRwAaXBheRjO7sDzjHlnKto9UUbqcTSw1MDHsjki8VrW+I15w3HPHP7WF9dpikdI55qKrl0rgNzcN8QEOxxn/AFHBOSPXHCu57PDJMZY5p4H+GyIGMjAa3dgYIIP3j3B7D0QepbrFFQRVT4ZwZXbI4AzMj3c8AZx5E5zjHOccq0q9RwUlEKmppK2MAPdIx7GtMYb3JycH4bSSfLKuZbNTOoKalifLAKZwfDJE7D2OwRnkEcgkcjHKtKvTNLVNeJamsw+LwX5kDi4ZLskkE5y49sDsMYAQfLtf/AimbRU80kjZGU7ZizMTZXloa08gnlwzgY8shfTqej8PcyGocXF4ibhrTKGHDnN3OAwDjk4zkYyqz7BTuqPENRVeH44qRDvGwSDndjGe/OM4zzhROp4bVp/Thr6uaaCmtdK5he1w3PjwPd5HckDkYOTwQiEncdT2e22SO73CvgpbfIwPbLM7bkEZAAPJPw7rXVb9ILRNPUmKOW4VLQceLFTe7/8AEQf9ly7rzWNy1jeH1lxleIGZbTUwcSyBnkB8cYye5WOMZJIHFkbnBoycDOES7y0f1J0vq2QQ2a6RPqiM+zygxyfg12M/hlZiDlfm/S1EtNURz00r4Z43BzJGOLXNI7EEdiuwvo/dRpdZWSWhu0gdeaAAPf2M0Z7Px6+R/A+aDb6IDkIgK0rblQ0L2MrauCBz/uiR4aT+fzCu1EVdrqJblUTw1EIhqYmRSslh3na0u4ac4wQ48EFBei4UZrPZRVQmpyR4e8bs4zjHrjlW5vtqDS76xpdoaHk+KPunz+XB5VkyxTgMjdVRmKGaWohxGQ7e/fguOecbz2xnhffs+GRPjhlawNt4oIfc+53y7vzn3ePggkp7pQU8ojnrKeN5wNrpADz2/Neqe4UdSGeBUxSb3Frdrgckdx8wo02BrhI10jSx9VDUbdn+mNrA1vf1YDn4rw+yVLbg6tp6uNsznzE74iQN4YARz3aIwPjkoJI3a3h8TDW04fKGlg3jLg44aR8yMBXqx6l04aeifAKgOeTTAPLOzIdnu9/Mhx/8ynacSiCMVDmPmDRvcxpa0nzwCTgfiUFRERAREQEREBERAREQEREBERAREQD2WmPpS1c1P01McJIZUVsUUmP2cOd/VoW5z2WBdY9NP1VoW5W6nANVtE0GfN7DkD8eR+KDhmFglnijc4Ma5waXHsMnutidUcaK1ybTpmP6vjtjYjHUx/rp3OjDi9z+5B3Ebfu/Ba7nikhlfFMx0crHFrmuGC0juCFNs1NVTuo/ruJl2jo2hsEdT5NHZrntw8tH7O7CIZJ1lt9JBcdP3Slp4qWa8WmCvqYImhrGyuBDi1o7A4zj1ypP6NNXNTdVKOKInZUU80cgH7IbuH+7QtfakvtfqS7y3K6yB9Q8BoDWhrWNAw1rWjgADyW7voraVnfc6zUtRGW07IzTUxcPvuJBc4fAAY/E+iJdQxHLQva8RDDQvaAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAqM0e4KshCDSXVTozQaqqJbla5G2+7O5e7bmOY/wDcB2PxH4grSlX0P1tBUGOKipqhmceJHUsDf/iIP+y7UfGHdwqRpm+gQcv6J+j7WS1cc+q6qOOnaQTTUri5z/g52MAfLP4LpOyWqltVBBR0MDIKWBoZHGwYDQFIMha3yVUDCD6BgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiD//2Q=="
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAUDBAYHCAIBCf/EAE0QAAEDAwMCAwQGCAUCAgcJAAEAAgMEBREGEiEHMRNBURQiYXEIFRYygZEjM1JUcpOx4TQ2QqHBF2IkgjVVc5Si0dMlJzhTdHWDsrT/xAAaAQEAAwEBAQAAAAAAAAAAAAAAAQMEAgUG/8QAMREBAAEDAQQGCgMBAAAAAAAAAAECAxEEEiExcQUUMkFRsRMVIzNSYXKhwdEiNIGR/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREA9lbK5PZWyC5REQEXxzg1pc4gNAySewWPRa40rNcPYYtRWl9XnaIm1TCSfTv3+CDIkQkAZJ49Vjp1xpZtf7EdRWkVedvhe1s3Z9O/f4IMiRAQQCDkHzUVedQ2uyvY261XsjH4xNLG4RD5yY2j8SglUWBda6r/7pL/U0c/Bp2uZLE/uC5vIIUsdX6es1JQU13vluo6p0Mf6Oeoa13LRyQTwgydFTpqiGqgZPTSxzQyDcySNwc1w9QR3ULd9Y6bs9WKW6322UlTnHhTVLGuHzBPH4oJ5FSpKmCsp2VFJNHPBIMskjcHNcPUEd1VQEREBERAREQEREBERARF8e7a0lALg3uQF8EjD2cFF3K40lvgNRcaqGmhyG+JM8Mbk9hkqwo9S2OtqWU9HeLfPUSHDI46hjnO+QBQZKioU7yfdP4KugHsrZXJ7K2QXKIiDW/XCeZ9nsdobM+npLxdYKGrkYdp8FxJc3PlnGFkdXoXTFRYXWh9loG0OwsDWwtBbxjcHYyHfHurzV2naHVVintdza7wZMOa9hw+J45a9p8iCsPl0XrOpojbKrXj3W1zfDe9lvY2pczsR4m7vjzxlBghvtyn6H0dC6tlLJLwLI6va7Dn03ilu/PxaNuVtxmgdKtsf1SLFb/YtmzBhbu7Yzu77vjnK9zaJskuiRpU0xFpbEImtB95pByHg/tbuc+qxpuidaMpPq5uv5fq0N8MONvYanZ2x4ue+PPGUEN1BqqnQnRQ0+nbxNVmOVtGyuc8OfDG55BG4ebR7oPcLYun9OWy36cZbo4hUU80IbO+Y+I6oyOXPJ+8TlU7do2yUWj26ZFI2a0+GY3xze8ZMnJc4/tE859Vau09dLZZRZ9MV7aam2eGyorXuqJKdvbDG8Zx5bnHCDStPPLT9IuqFgbK+a3WaufT0b3HO2PxB7mfhj/dbn0TpSzUek6SM0tNXOq6dklTUzMEjqpzmglzie4OeB5BR46Z0FP01rtJUFTJH7aC6eskbvfJIXAl7hxnOMJHo7UdppPYNL6pjoraG7Y4aqhFQ6nHmI3bhx6B2cIMU0/VzaQ/6o2qyEuoLPF7ZQxfeED3xOe5g+AIzhZT0s0lY4dDW2pfR0tdVXGnbU1dVPG2R875BudkkcjJ7Ka0Xo6j0zZ6qkMslfU10jpq6qqAC+pe7uXfDHACx2i0FqHT7JKLSGrfYbOXOdFSVdE2pNPk5IY4kHHoDlBQ6fQx2DqfqzTdrGyzMhgro4Actp5H5Dmt9Ae+FtBYzojSMGl4ayR9XPcLpXSeNWV0/35neQwOA0DgAdlkyAiIgIiICIiAiIgIiIC8TjMRXtDygx3UYqTbT7EK4zbh/gvB8TH/8vu4/3UFZW3f60g9qGovByd3tQofD7H73h+/+SzZ8JB93kLyInk/dQfYB+kCul4ijDB8V7QD2Vsrk9lb7T6FBcIis6q4RU9XHTuzvc0vJwcNb6/mgvEXxpDmhw7HkKhUVQhqqaEtGJi73s4xgZQXCKPoK99XVVMZhDI4nuYHbiS4g49Mf7q0F9d49RG6nAEUgY07/AL36QMJ7eWcoJtFF1129mqXxtiY9kbWueTJtcQ4ke6Me92+C+0N09prTAY2sad+07iXHa7acjGB+ZQSaIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8PiY97HuaC5hy0+YXtEBUp6eCoDRUQxyhpyN7Q7H5qqiClHTQRzOljhiZK77z2tAJ+ZXk0VKfEzTQnxDl+WD3/Pn1VdEFEUlOPDxBEPD+57g935ei9NghbK6VsUYkd3eGjJ/FVEQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERBEXm+wW14i2mWYjO0HGPmVEfbB37kP5v8AZQN73/W1X4ud3iHv6eX+2Fr/AFPSail1fbJ7W6qFrY2MT+FM0Nz4hLssJG73cD8eM4wvLq1NyquYicQ9+3obNNqmqqmapnHj3tvfbB37kP5v9k+2Dv3Ifzf7LUlDT31vUO4TVLKt1ke1vs7/AGlvhNPhgOzHnPLs847qhp636lh1rXuuVRO+xxmR9M50wcJN5bhpbnPujPcLn0934+7Pc76np8+7njjv/wC8eDcX2wd+5D+b/ZPtg79yH83+y0vpyk1NHaNRx3Fla2ueyT2OSSra8OJ37dgB9wjLe/w9FX09R6obp6+QXaaT6xkj2UchlB58IAOBBO07uT8clTN+7Gf5+RGk0849nO/n+24ftg79yH83+yfbB37kP5v9lpSopNVyaMuLWe1i7SVLHQxipaJGxjZuG7dgZw7z81mVjbO2z0batksdQIm+IyaQSPDsc5cO5+K5q1F2IzteTqjRaeqcejmN3zZz9sHfuQ/m/wBk+2Dv3Ifzf7LUel6e/Rarvb7tHWGhfJIaSR9U10QYXDa0Rgkg4zz6cKy0LSatgvUztROqXU5jduc+oY+Nz93u7GAZaMfEfJTN+7v/AJx9nMaTTzMR6Od+fHc3T9sHfuQ/m/2T7YO/ch/N/stNaao9Uxa0r5rq+c2Z0lQYGumDgAXt8PjceMZxxxz6q00jR61i1dJLe5pHWwmXfulY5jv2NjQct/IcKfTXd/8AOPsiNLp93sp3zjv/AO8W8Ptg79yH83+yfbB37kP5v9lqXTlPfYtY3mS5x1htr3ONLI6pa6INy3DRHnIPfn5qhpGk1LDqy6zXl9U62PD/AAPEmaW5Lxt2tBOMNHfjv2UTfu7/AOfk6jR6eceznfPzbtt2qYKidsVREYNxwHbsjPx4WRLUy2hbd/1fTeL+s8Nu7PrhadJfquZiruef0jpKLE01W+9coiLa8wREQEREBERAREQEREBERAREQRF5sUFyeJNximHG4DOfmFEfY9376P5X91lyKivTW65zMNVvW37VOzTVuYj9j3fvo/lf3T7Hu/fR/K/usuRc9UteHms9Y6n4vtH6Yj9j3fvo/lf3T7Hu/fR/K/usuROqWvDzPWOp+L7R+mI/Y9376P5X90+x7v30fyv7rLkTqlrw8z1jqfi+0fpiP2Pd++j+V/dPse799H8r+6y5E6pa8PM9Y6n4vtH6Yj9j3fvo/lf3T7Hu/fR/K/usuROqWvDzPWOp+L7R+mI/Y9376P5X90+x7v30fyv7rLkTqlrw8z1jqfi+0fpjlu0tBTztlqJTPt5DduBn48rI0RXUW6bcYphmu3q707VyciIi7VCIiAiIgIiICIsF61atrtF6DqbraomSVhlZDG6Ru5se4/eI8+35kIM6RcnaZ6ndTK+Wmqae6225xySDfRgU/jNbnB/Rja8/hlS0vVjWEHW2os7XVNTao7jJTNtjKePe5gyAQ7Zux/r79kHTaLRtz+kNbrffbpbJbDWPfRSywhzJgfEcxxbwMcA4/BVbH1/orrfXWwWCqhe2GeUvdUNP6qJ8hGNvnsx+KDdqLS1j+kDZa6xXe6V1sqqOOgMLGxiRsj53yb8NbwAMbCcletIdf7JqG+QWuS111FPUu2QOe5r2vefutOOQSeBweSg3Oi5h6Q9W9XXbXU1HepKi5UHgTPMDII2ez7cEPcWsBwMbefNwWW236QdDXWO8XJtgqWNtrYnOYahpL/Efs4O3jHdBvFFoKp+kjb4KajmOnaoipjMgHtLfdw9zf2f+1S0/0gbDT2aor5rbXNcKp1PTQDG6drQCZDnG1vI9Tyg3Oi0tY/pA2O6UFzebZWU1bR0zqltPI9uJw3u1rh2OOeR2TSfXy36ju9st0FirIp62qFOSZQ5sQOMPJx6k8fBBulFzD9Km/Xe1aytMVrutfRRPoA5zKeofG0nxHjJDSOVnWouven7Ffay0mjrKp9Gx7XzsIDHStb9wefJ93d5H4coNyIsB6S9SafqLTXKamt0tCKJ7GESSh+7cCfIDH3ViurfpBWGw3+qtdNba24eyyGKaeNzWM3A4Ibnvg8Z4QboRaTv30hLLb6C1VlDa6qthro3PIMrY3Qua7BY4YPPnwexCuP8Ar7YGWavuNRb62NkNQKemi431OQTuAONrRjnPqEG5EWj6HrpaNT2K/wBJDT19pucVuqJ4DuaS7ZG53uO8nADIyPJYt0c6ox6e0NqC56lrrtc/Bq4YoWTSeI4ue15DWlx44YScnHHA9Q6ZRaQsP0irDcKsRV9puNDG5j3tmy2RuGtLjnsew8s8q1p/pKWSWr2usN0bS7g3xg5hIz6tzj/dBvlFpW+fSG07bbtcKGCgrasUoc0TtIaySQHG0dyB3974fHKjpfpHUEdopq86dqi2eeWAM9pbkFjY3Zzt8/EH5IN9otRaZ66WO96rorE63V9JLV+G2KaUDbvewODSODjJwDjng9ioy/fSL0/bbzUUVJa66uggkMbqljmta4g4JaD3GfXCDeCLU2pOuumrRYbTcaaGrrpLlGZYqdgDHMAcWneSePeBHGexUp0u6sWjqBVVNFS01TQ3CBnimCbB3MyAS1w9CRnOO6DYqIiAsI6w2i/XrRzqXS7aeSuE7HuhqNpjmjAO5hDgWnuOD6LN0Qcds6Na9ut+pXy2CisrA5u+ogqIwxmDnfta9xz/AAgdlmOqumet7d1f+1Gl6aCtjfOJ2TPlYPDJbtcHtcQT59srpNU5J4onASyxsJ7BzgEHPfTfp5qm0dca6/3O1eDaZaise2fx4nZDy7adocXc5Hko7VHSjWUXVO73yxUtJU0dYamRkskzQGiaJ7XNLSQc++QPLOCeMrpdr2vJDXNcRwcHOF88aPxNniM3/s7hn8kHI9j6Iayn0lfaStt7KOsM1NUUrJKiNwn2CZrm5a44OJAecLNtE6Y6n1WqbFJqWgtdFbLc2OMyPgpZJDHHyGtLdzgT6gjHddAunhbJsdLG15/0lwB/Jefaqfn9PFx398cIObNHdLtb6T6mVM9HTU8tnq/Ep5q3xGEezvcCfdJDg7geSxum6N9QLbZ9Q26G20k0NU2JoLahmZtkocNmXDHmTux6DldcsqIXkBksbi7thwOVqq/dYm2nqrFos2Qyl9VT03tntW3Hihhzs2eW/tnnHkiGiq/oxr6WhtUbLAS+GFzZB7XB7pMr3ft+hC3V9IHp1eNYx2e4ac8J9dbi4Gne8M3glpBa48ZBb5kd1bVnXg01Le5n6Sr4xbZGsHjzeGJMvDeTtO13Occ8Z5WwOmWs2a40rT3n2QUBmkkjEBm8Q+6cZzgZ/JBpOg6edQ7jb9Q1F6t1tp5p6OSKKnayB088hbtH6blwGOcl/wAOyzv6N+kL5pDTt2ptR0Hsc89UJI2mVkm5uwDOWk+az3WF/rLLBAy12ioulfUEiONj2xRtxjl8jjho5+JKmxUsbDG+ocyFz2g7XPHB8xnzRLQH0junuqNX6qttZp21msp4aIRPf48UeHb3HGHOB7EKFvfSrXtBqfVf2djpZbXeoZjJK58eXNcS/wALDjlri73c9vPK6cZLG8kMkY4gZOCDgJHNFISI5GOI7hrgUGm/o16Lv+jqC+x6koDRPqZYXRAyxybg0Oz9xxx3HdYRXdOuo2l9UajfpGio6+33dzw6WQwu/RucXAFshHIzg8EFdMCqpyCRPEccn3xwtf8AWHqc3pxHaXm1G4ivMoGKjwtmzZ/2uznf/sg0trvpNr26W6w4ttJWVkcMhqBSez07IiXcNwC0OOAMkDz+C2d1y6dXbWFgsMtj8H6ytWf0Ejg0PDg3OCeMgsHfjutm6bu7L1py03V0Yp/rCliqREX7tu9gdtzxnGcdlIRzwyOLY5Y3uHk1wJQczx9MtfakvF51FqumpYK/6sqKenp4XxgzyOgdGxvunaB73cn+1hpnpXreh0JebfNYKKSpqK6mmFNWTRubLGxkodtc1/uuDnM5y04zz3XU4qIS8sEsZcO4DhkIyeGQOMcsbg3uWuBwg5d0l016lQT1bXUVJbbb4EwZbqmpbUU5c5hAa1hc/GXHOSfX5Kys3TDqVBeofq21U1gpy5vjOhrd0EuD3ewyPLvljHwXWEcscgJjkY8DvtOV5bVQOBLZ4jjk4eOEHLNw6R6/tVXqm3WKGlqLPc27jIXxh0zWv3MYA45a7nnsOO/ZY/UdGtev0zQUjbCTURVlTK9ntcHDXMgDTnfjksd+S6Y6h9R7HoL6v+vBVv8AbQ8xezRh/wBzbnOSP2h/usktN2pLnZqK508m2lrIWTxmQgHa4AgH48ohzfF0w1g3qzp+8GzkW2lNtM03tEXu+FDC2Tjdk4LHDgc44yrWn6bdTNI1N7tmmaChrrXcHjM8vgPDmNcS3LZDweeRghdUNc17QWkOB8wcqJl1NZYr+yxyXSkbd3jc2kMg8QjGe3y5RLQOs+kmsqil0zeKA0FVfaGHZUU8GymY1wkdI3Zt2t/1EHt2ysy6JaT1fa7zcLtq6mttEJmOayCGCEzOc5wJc6RgJI483EnPPZbjRAREQEREBco/S7JbriykcEW8EfzXrq5aR679KL7r/UVvr7NU22GGnpfAcKqR7XF29zuNrHcYIQaf0dca22dQK52irpcbiZLXUT1D5mODnTezuc7c09yJcYJ8/Xzw/wAW3fZsXgX24fa/239Rh2PDxnxPE/az8fw813RZdOWmzz1FTbrbSU1XVHdUTRRgOld3JJ7nnlYzb7Z03r9TP+r4NNVF8Y9z3RwmJ0rXtPvEtHYg9zhEObdcV1RF1f0tdNQEwTGG11NU94xghsZeT8iHfksNikbK/WUkZ3MfTlzT6g1kC7pvGmbHequnqrtaqKsqKcgxSzRBzmYORgnyz5KJ/wCnGjs1J+ztvzUjbN+j++Nwdz/5mg/gg0v9GLQ9JcaGk1ZNW1YqrfWTRRU4I8LBjaCcYzk7vXyCx/Xv/wCK6l//AHS3f/0hXUdgsVr09QmjslDBRUpeZDFC3DS4gAn/AGH5Kxq9Gacq7+291Nno5bs17JRVOZ74cwANOfUbR+SJcI2v/Aah/wD0rf8A/REr2OenptPWeqtt4rvtDDVPa2ka1wbBHnc1zHepcTwP+Oe0o+mei42TNZpu3NbM3bIBH94ZDsH8QD+Cu6HQulqCaklpLBbo5aQkwPEIJjJOeCfjyiHI2u6iW7dSL83W9dUUckAcIAS4BpAGwABruCOewznuFG6vn8XQWmI47pVXGniqaxsbp4DH4XuwEsaS47hk5+GV2jf9Had1DO2e92ahrZ2jaJJogXY9M98KnctD6YudHRUldY6Calog4U8RiAbEHY3bQO2cD8kHPWp9KT6N6ItvlkuFwlqL7DQ+3Fzh+iiMZOGkAENyWt+XCwvp39WUWsdMz2nUFbDXSvi8aOGB026Quw6M8MwCOP8AVxzldcUV20nVn7M0lws9Q6JhpTbWzRvcGsGCwx5J4AwRjjC9WXROmbJXGttNit9JV4I8WKEBwz3wfL8EHIXQ7RlLrrVFxtVdWVVLTtonTuNOQC/bLGA05B45z8wFsv6X0Qgt+j4WklsftLAT54EQW9NP6M05p2skq7HZ6ShqZGGJ0kLMEtJBx8sgfko/XseiKh9HFrmSzBzA51M24TMYcHAcWhxHoEHLuq6wT6l0XSakuVbbrHT2ShfDNTNLnR/+Ha7e0Dz8QYz8Pgpj6KR3dUrg7c52bbMdzu5/SxcldNz6V05cae1+NaaCphoGMFEXRBwiaANoafTgfBfLFo3TthuEldZrPSUdZIwsfLEzDi0kEj8wPyQctdZ2VGhOsN2raBu1lzpJJGeWPGjdG8/g/cfyUZX225af6F2uspvGhhvlxfJVPZkExsbtiYT6EiR3x4XXWotI6f1JNDNfrTSV0sLSyN0zMloJzgK8fY7XJZWWiS30z7WxgibSvjDow0dhg+iDk7pALbQ9S7YywX+tIlZtfAyB0jZssJe15IZgDGc7TjHcrXmnKP2jT2qajx54zSUcUgZG/DZCamJmHDzHvE49QF3PYdH6d0/NLNZbNQ0Usg2vkhiAcR6Z74+Csafpzo+np6qCDT1vZDVMEczBHxI0ODgD/wCZoP4IOM78ZqvpzpmsqHSyviq6yjEj3E7Y2iF7GfDmSQ/j8Fc3Krttfc7Bbp66em01BQxBpDnhrZCzdMRlrjzOZBkNPbjjC62ntvTygpTpeoZp+GKSbxfq6WSMEyEAZDSc7iMBSc+gtKT22noJtP219HTkmKMwDDM8nHmMoNVfRWljFJfKaku9XXUkbmOEMtOWMhcd3LXEnOQBkYHYKRu//Tv/AK+U3tnt51Xujxj/AA3jbBsz57tu3Hl2W27LZ7dY6FtHZ6GnoqUHIjgYGDPrx3PxVvJpqyyX9l7ktdI67sG1tWYx4gGMd/lwiUuiIgIiICIiAiIgLi/SFsqb11U1lbKANNXVwXOGIOdtBc4uAyfJdoLUmhukEmmOo9Xql16ZUtndO72YU2wt8Qk/e3Htn0QYLedaal6Waa0noqgpqL69dA6SaSZwexofM8MDTkD1yScBZFoXXPULUFDfrfX2qOmuVPTPloq9tOfAfI0j9GTktdu8iD6rKurHSqm17V0NwhuU1rutG3YyojZvBbnIBGQcgkkEHzKh9JdGqjTlvvkkWpaiovtyp3Uza2SI7YWuI3ODd+S4+pdwiGr7b111tdnWu0UDaP66qKwwukdTja4O2Bgxngg78n5K8n62a6udyrW6bpaCaloSGlrogZZhnG7buySSCcNHCnYfo3GmpqF9HqbwbnT1DpjVCkPI93YA3fwWlrjnPO74K6uv0eDPXVM1r1RNb4KzBqadlOSxx7uAw8e7nJAOcepQY5rrrbrS1usnh0MVqqKihEtRTVNMc+J4sjdzd3IaQ1pA/qq8XW3WsOtbzaJ7ZbpX04qg2mBx4JiY9xO/PvABhz6+WFP6n+jxDc22qO3X99NFQ0gp3Gen8Z8rt73l5O8Y+/jGOMK+f0Oldr27aj+v2Btcawin9kOWePHIz72/nb4me3OPJBr7/r7qubRs9SxtBHcaeuiiMrYctfG+OU4LSeCDH3HqpWz9btY0lfpyq1DbKT6juuI2yNbh8gDgx8jcHggnsR2/NYt1S6VzdO9FAm6C5GvuEPDKYx7Nkc3/AHOznf8A7LM+kvRulu9v0xqW53SpkpI4xOy2ub7rZA8k+8Tw0kAkAfig19Zb+zS3XPUt7kiMoo6m5SCPON7syBoz5ZJCy2y9ZepFdJT3Cns9FcbfLKW+zUsJc/APIw1xc34Fwx81mtP0Ggfra73q5XgVNFcX1Tn0jabY5om3Yw/ceWlwOceSi6T6OXh1UEVRq2sktEUhkFKyEsd8cHeQCfUNQbC6ta+k0VoOO9U1IXVtU9kMEM4IDHuaXe+O/AB49VzD1jvuqL63T0+sbbHR1LqZ0tPJHgNnieQQdoJwR6Hntwus9eaGtusdI/UFW6Snhj2Oglj5dE5gw089+Mg/ArUVy+jfLWU1Gx2rZ5JYGlhfPTmQBmfdawb/AHQB8+/kgoau6t6npNSQaZ0fTUIdSUsQfJU7d0jvDa44LnBoHIGO5WzOjOrr/quyVT9U2eW3VtO8BshhdEydpBwWh3mMc/MeqxvWnQ6O93qK8We/1FouJhZFM+OMuDy1gZuGHAtyByMlZh0p6fUvT+z1FLDWzV1TUvD5p5BtBwCAGtycAZPme6JclaldcpdV11TresvNO98jnQ1MEXisPJwWZe0bMdtp7LN5Opd90VobT0Wnr5T3SOolqt888bnvAaY9rSH8tIDjxyORglZjXfR4rnxT0lHrWqjtkjy72WSnc5vfIyBIAefgpC4/R4ttRpK22qmvE0NZSSyzPqnQhzZXSBoPuZGANjcc+SIQ7ereqD1Ytlg8Wk+rqh1IHjwBu/SQxvdz83FQuiOrHU7V9ZVUNkp7fWVUcYlP6Nkfht3AE+84A98fisztfQaWg1tbr/8AaWSobSPheY5qcue/w2Nbjfv89vHHAwPJTHR7pBJ08vtbcX3ptwFRTez+GKbwtvvNdnO4/soOf9NW6tuvXh8N1NNNVw3WeorC4uDHeE5z5NuOezHbfLOM8LNW9btfXqqrKzTttt7qCGUNbTCPxJSCeON29x9S0YHwWx9O9G3WnqnVavlvLKiKeoqpzR+zFvEweNu/ee2/05wser/o5tNbUttOqauitVRIHvpDCXcA5AyHgHHkSEG59G3aqvmmLfcbhQS26rnjzLSytLXRuBIIweccZHwIUyorS1jptN6fobRQukdT0kexrpXbnO5yST6kklSqJEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERRc09WZ5BEcMaQB7gP8AyFTevRaiJmJnPg6pp2koit45ZH0LZWtaZXMDg0nAzj15UbbbvJVVdLC4wh0kAlewZBaSM8ZPPyx8cq2mYqiJhzO5NIoWquNZE66PYyPwaVp2Es7nY13J3ep9PxVMXWpaKNjfCmNSdjHtHAcHDOcOI+7k9/JSJ5FAQ3eqdNVNfHEGxztjadpGQZiz154HfjlfJ7xUskuLWeAXU5wxm3Ljy3k+9nz9B80GQIoiS6SR2JlbK6KOR3HLTjOcAYzwfhnj8FThu0z6h7XiFrWxlxAyduGg7ifNpyR28kE2ix6mvc00tE3bEY5nHL2tzuG7AwN3Bxye+PRZCgIitK2SXcI4SWnY5+QAScY4GfmkRlEziMrtFbUUrnh7Xu3bcYcRgkEZ5HqrW13CWrrauKVgYInYa3HOMkZJz54zjA49VOCJzvSaKAt97qKmtp6d0Abuke2R2DjADizHz2nPyVGqvtXDAyUQMe0wue4gH3Xbto4z2/8AmoSyVERAREQEREBERAREQEREBERAVu+jie9zzvBPJw8j/lXCLiuimuMVRlMTMcHxjGsY1jBhrRgBfURdxGN0IEREBERAREQEREBU5oWTAB4OR2IJBH4hVEQxl4iiZEzawYHc85JXtEQEREBERAREQEREBERARFRNTEKttNu/Slpfj0CiZwmImeCsiIpQIrC5V3s+GRYMnc58lYfWdT6t/JW02aqozCuq7TTOE8i1L1I6iXaw1NHb7NTsnrqn3slmQ0fL8CsOu3VHW9N+qhia4DkGkyM/NU11RRVszO9dboquU7VMbnRaLmE9UupmHyClphC0Zy6lAz8uVsnpV1BuOrLLNJcGQx1tPJsfsbjcPI7fLzH4KbcxcnZpRcibcZqhtVFA/WdT6t/JXn1hO+ka+kphUTh7WvjMgZgE8uyfT0VlVqqmMyqpu01TiEkij/abh/6vZ/7wP/kq1G+rkkkdVRRwx4AY1r9xzzkk4Hw/JVrF0iIgIiICIrG81E9LSCWnbu2k78NLiG7TyAPjj8MoL5FQnnaKSSWJ4dtYXAt58lWY4PY1zSC0jII80H1F8eSGOI744XLlw6ya4g6jyWGM0fg/WPszI/ZgXGMvwOc/skHKDqRFzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiKlPPHAY/FOPEdsB+KiZiIzIqoiKQWN0Li7WVZk9o8D8mrJFjNv/wA5Vv8AB/w1UXuNPNp0/ZufT+YZMqdRKIYXvd2aMqoo69v207Wj/U7laaKdqqIZK52aZlDSPdI9z3HLicleUReiwMDraH2jW9VUzNBMTGsj+AIGVPthYGgFoP4K2ucDm3ieRvDnsaRz3HZW0BrW1OH7PB9WOJx+a+Z1M+3q5vr9DGNPREd8Pl6ga6Bw2jBCx3pvF7FrK5QRjEc9P4px5ODgP+Vd1k1ZUGTDWGNpIw55blVenVK/66r6l2TthbGSfUnP/Ct0U+3jDN0nGbE/JsJV6Oc087Xjt2PyVBF9DMZjEvmonE5ZYDkAora2v8SiiJ7gY/JXK82YxOG+JzGRERQkRUayY09NJKGby0cNzjJ+atY57mamFslDTthc4iR4qSSwYOCBs55wO475QSCIiCLurLVbKKquVZSwNjgjdLJI2EF2AMnsMleqOho5Y4qmkdUMje0OYGzSNaAe3uE4H5KRc0OaWuALSMEHzX1BbOpHH7tVUN+RB/qCsXd06sMl/F6lhL7kBhs5awED04bj4euOO3CzFEGI33p/ZL9cqauvERq56dwdGZGs908ejRnsODkLK4YmQRMiiG1jBgBe0QERR1puE9dLWsnt1TRCnmMTHTFpEwwDvbtJ4580EioPV5It8ZHcSA/7KcUFrD/0bH/7Qf0K83pj+jd5LtN72nmm4zmNpPchel5h/VM+QXpejTwhSLGbf/nKt/g/4asmWLUkgj1fWuIJ9zy+TVTe40c2nT9m59P5hlKir7nEPpz/AMK89sZ+y5WV1lbNTja0gtOeVstbq4YbkxNMxCJREW5jQ13Y5ldHMR+jczw8/HJKjpaxsbnOLm7W8Bmcfims7423V1loTGHmvqHRl+f1eI3OH5kYQiHDiQGuPnhfO6+nYvzjv3vreiq9vTRnu3ISnrI31UzC9u154ZnOPiprQkL2/WMx/Vvla1vxIHJ/3CgbhNBTTF2Wl/r6fFZNoOugrLEzwuHtc7e09+TkH8Qrejrc1Xtvuhm6XuxTa2PGWRoiL3Xzafs4xRN+Z/qr1QFPdpKaIRC1Vz9uRuaYsO+Iy/Kq/Xkv/qe4fnD/APUXn176pluomIpiEhdal1Hb5p2AF7R7oPbJOBn4cqn4dy/eqP8A92d/9RRVxuM9fSOpmWusiMjmjfI6La0bgSTh5PYeQU17Yz9ly5xKdqFCWlrp2iOarpvDJBcGU5BIBzgEvOPyUgrb2xn7Lk9sZ+y5MSbULlFbe2M/ZcntjP2XJiTahcorb2xn7Lk9sZ+y5MSbULlFaSVn6N3hsy/HuhxwM/FYFoG46yk1PqNupoKJttFSPA8J7yW/o24EeRy3GMk497cmJNqGyEVt7Yz9lye2M/ZcmJNqFyitvbGfsuT2xn7LkxJtQuVBaw/9Gx/+0H9CpT2xn7LlC6qnbLb2AAj9IO/yK8zpiJ6jd5L9NVE3aebIYf1TPkF6XmH9Uz5Bel6NPCFQsSj/AM2V38H/AA1ZasSj/wA2V38H/DVVd7VHNpsdi59P5hLry9oc0g9ivSLW81impL3T2KPNQHSSu+5Ezu7/AOQWA3TW90qqhraSNtLAGuc7by5wwcDJHBWytW6chv1HjhlVGD4cnzHY/DlaiuFtqKOb2esiMUu7c4EYAOfdA9ckL1NLVbrjfxZrlMxPyWF+jfXW6ZrBJJX72zxvLve3tON2T6D+qzDS9c+6WOCadofLtw4EgEOHfKxmVskdQ2aI7JWuOMjIwQGnj8Mq5tomp6SR0E7WB0Yfgg4cSfL4+aydJaCdTiqnjD1ei9fTpc018JRd3qRLqOWleGmOOMyGNrsjuAM+vc/ko6Gtqm3N1RTGSne0BocxxBIzxn/dX8cDgJnPcDJNgSPxknBJ2g/j2+a8spz4zQMYDtp5zlxPr8Np/NbdLp6dPb2KYefqr1WouTcqS+n+oN2pmj29rauEvLcuGHDHYA/H4raOlrzTagiMlMHNMePEY4fd/HsVqjTmnqq7Np4KWE4cd75D91g5GT+S3Zp+z01ktzKSlaOOXvxgvd5kqvVVUURiOKu3TMz8kkvqIvNaBERAREQEREBERAREQERYL1LqdXQPtH2Up6WSJ1bEJy97t2M8hwAwGepzn4KCIyzpFRpDOaaI1bY21G0eIInFzQ7zwSAcfgqykFFai/wTP4x/QqVUVqL/AATP4x/Qry+mv6N3k06P39PNlMP6pnyC9LzD+qZ8gvS3U8IBYlH/AJsrv4P+GrLViUf+bK7+D/hqqu9qjm02Oxc+n8wl0RFreaKwutqo7rD4dZC1+Puu7Ob8QVfokTMTmBru59P5fEkfQVTXNd2ZLwW8Y7+fKhotJXuKidEaMh4wxu2RrhtB79/j6eS26i006u5HzVzbiWoYtGXiV5JpWt5w3e8NDfU8fN35qfs/T1kRhdcarxBGQfDiGA48dz+B/NZ+iVau5Vu4J2IW1BRU1vpWU9HC2KFgwGtCuURZpnO+XYiIgIioVNVDTNBneGA8DKhEzjfKui8xvbIxr2HLXDIK9KUiIiAiIgIiICIiAiIgKK1F/gmfxj+hUqorUX+CZ/GP6FeX01/Ru8mnR+/p5sph/VM+QXpeYf1TPkF6W6nhALEo/wDNld/B/wANWWrEo/8ANld/B/w1VXe1RzabHYufT+YXV5ulHZbZUXC5zCCjgbukkIJ2jOOwBPmorTetNPaldO2y3SGpdA0Pkbtcwtaexw4Dj4qn1Js1XqHQ92tVv8P2qpiDI/EdtbncDyfwWl4ejmqmWW4UW+2iWaCDE5mkL5tm3MDj2DBjjA/0tWp50RDocVdMQwiohIk+574975eq+CspixrxUQ7XHa07xgn0C0A/pBqRuk4BR/V9Jeqe4GpgiineWRxubhw3OzzkN4AxwvF+6LXw0Niht3sFWynofAnhqJnsbHO55c+Ru3vy7HrwEynEeLoN1XTNeWOqIQ8ENLS8ZBPYL4KylLgBUwkl20DxB39Pmueb70c1NWVF0lidRPlldSGCT2hw/Vx7XnnJ74xkkr1Q9IdV094pHOkoTTQXkV5mEx3lmW5OMdxjt6pkxHi6IjnikkeyOVjns+81rgSPmFi7eomlXag+pBdmfWnj+zeB4UmfEzjbnbjv8VrvpX0w1BpnWUdxuZoPAhZI19RFNI6SpLs4JGQPMdwe3ryraHprqun6iXe607LYKCvqpJBNJITJE127DmgdnDdn5hRmTENu6k1TatP2aruddUB9NSlolEOJHNLnBo4HxKvrXdaO526KupZmGCSNsmSQC0OAcN3ocELnODovqoWmupfZrRDK6AQiaOplLqk+KHZdk7RwPTyHHmpGXo/qhtNeKailo6elqoaR3s4ncGTyRtaHh+BkAncc+aZkxHi6DNTA2ETOniER7PLxtP4r5LV08RYJaiFhf9wOeBu+XqueKvo7qmTT9NE19uIZWzVH1T48ns8bXtaAGuPORg+fn37r5eOjupahtmaynts8tLTthc99XIYmjc4luxwLjjcMEOHyU5MR4uj1Bar/AFEH8R/opqFpZDGw4y1oHHZQuq/1EH8R/ooq4KL/ALuWoPpC6tvemqLTbLNeZLZBNHI+cQtHiS7Q3aGuLSPM8ZGViNP1Z1jYq6uqrhVuq4W2Knq6Snr6QxiaRzog53uY5w5574W59cdQqDRdPZqWqtlZcqqtifJHDTNadrI2gucdxHYH/ZRsfWi0yVVyY2y3c01tpo6urqfDZthY+LxG5G7OTw3Hr8OUXUdmNzEdYdYdX6UmiiuNusj31FqFxgMMczmlxkwGElw7N5PxVpSdaNVXe9VFpp6G2000lPIIoRFOakO9n3tmHBYWF3YHnH5mfqetlJcaq0RW6lr7fO+5U9NUU9RSMle+OVu5mCJBtDgO4yfgqzOvtmdQVlb9nb0PZXtje3ZFvbkkZeN+WDj/AFY7hP8AXWPkwC0dddTWrS9uFW2juNU6gnnknqYJA8ztmcBGdpaOGbTwPMcrKrZ1e1fX2zU1zgs9pnpbJDFI+GNsomkMjMgjkja05J/7R+KlLj9ILT1FTMnfZrtJiBs0mwRER7nlrQTvwc4zkZGMKo/6QOm4K+WnqrZdIY46iamdNsYW7425PAdnnjy80/0x8mM2brZq281djoaG32F9RcqySkZUllQIHYa0gjODwXc9/wAFL9WdYX3SvUm0S0bpalkVkqKmWgje4QyytDuS0dwO/rgKUh66Wk2k1kmn71HI6aCGnp9kZfOZmucwtw7HZpPPqFMXbq1aLboa16ont1xNLX1ApWwbGiVjve7gnGPdPYof4j+iPUq6a9uN9p7pTUEUdBHTuifSMlaJPEDiSfE5x7vHA/HutsrTc/X3T0NOx7bTeHzs8U1UDYmbqZsbg1xd72DyfIlfajr9p2KqdDHb7lK32wUbZGhgDiRkOGXZxj8VOUTE+DcaLEunOtItc2Y3SktdfQ0TseDJVBoE3Lgdu0nsW4OVlqORRWov8Ez+Mf0KlVFai/wTP4x/QrzOmv6N3k06P39PNlMP6pnyC9LzD+qZ8gvS3U8IBYkz/Nlb/B/w1Zaoqptv/wBpmti7uZse317YK4romqaZjulbbuRRTXE98Y8kRqqG51Gnq6CxSshuckZZBK92Axx43ZwewyeywWO19TYqIRsvNvMjKRrQXNaS6YOAJyWdiwF2cfePotolpHcH8l8wfQ/ktDE1xLbuoVRZr1BPcaKOtlbF7FJA8NEZDhv52ZGW57558grKex9R/DpZYL1TmeFz2iOR4LdhawAkiMbn538uGAcHHdbUwfQ/kmD6H8kMtZalsmv66ooXWy709M0UDY6oeJgOnw/cQA3zy3BGMY7KLqtOdTn3aOqhvNE1kLdkbPHfsIAdgubtwTy3JOckemAtw4PofyTB9D+SGWJ6KpdWQzVMmrK+nnZtY2CKBrcZ2jc5xDQc5B+HPyWWJg+h/JMH0P5IgUFe9XafshLbpd6OCX/8rxA6Q/Jgy4/kvmvGXF+jby2zCX6wNK/wfD+/ux/p+Pp8Vr+iqdLWmSinsk0lJROZE/wKWgkdWyPAIc2Qhm4knack98qJnDqmnLJKvqA6SNzrLp+6VjACWz1LW0ULgBkkOlIJAHmGlR1RetU3CjuEv1laLXFSlniR0EL62obuIw0F21mecdjgqzpaS5Vck7rZpS4z+O7c+e9VIpWPJwSXRt3vOSAccenwU5S6X1PM976m+UdpbINr22miHiuGc8zy7nHknyUb5d4phC3SzVVLQXS412oNSU1RSU0lRDX1FU1kIkYTtYYg0MIcNpxyeSOMc5LJW1Fx0rZa2ti8GqqIGSyx4xtc5gJGF7pentjZVMq7jHV3esaQRPcqh9QQR2w1x2j8AFJanie6CAMY44cew+CTG5n1MxNucNZ9Y7rpunfpm26n03BeBUQTzRSyzmLwPDj3EZAzh3Gfl5qJ0Vr7QLr5c6Gus1usjbjR0kcsjp/FiqmujAZFt2gBrWnGeAsh6o2DTt4rtNjUdbc6SdlLVMg9lp3PYWuiw8vIacYHbtn4qMsvQzS1xpKWup7teaigqIadpjJEbZo4sbQ8bQeS0E9iMeSlZRjZjLzQ1fSGjra+2tprRTU9nnFYHtke4uladrnAD7wbkDufPgDk0iOhcVAIyLS2CslyCTLuJbxnd3a33seQ/JTDuglgzd2xXK7x09wa9vgNkbsi3ODiR7vPbjdnCkNRdGrLe57NO6tuVJNbqSOh30zmtMsTMY3ZacHjuMd0dZhZUNi6SanuhsdFbrXV11BE+n8CON7TG2N4LhuGP9R75ycnk8rFdLXzpNcrRDeL7aLfZqmSrqJmQVEz5i9zcB8mO3PbBHOMDK25ojRNFpB95fQS1EzrnWPrZDNgljnd2ggdvmtV1vRfSFHcLZp+S6X6OvrIahjJIW+7LGTvLXuDNoAPIBxn4oQyKrsvSSzWKnpKuhttPbb0z22HeyQ+MI2btwd3GGuOBkdz6qL1ZL0x1HZNPaWgvtLbKSKeKspaaCMgPBB2tO4YG7cTzyc/FZbrDpRZ9U6Nsunq6oq44rS1jYKmLb4pDWbMEkYwRjPHkFjh6a6TrupEsdFV3ikuFDT07p6aFhZA9rGBjMPLeeMZa1yEIu93vos3TcckVDbbjBaozUw0tPCRJtdIGnvjPvEZDj8VI7uj11vNunrae2w3q6iGsZFJvY8PkaCwO2na1xyOPPvznKtq3ofpGw2Yy3S7XNtDDRPoXOdtzh8peHe63JcHO448ldaU6VaWuNxt+oLNfLxUeyCGKQl2zxnQtDWbssDh7u0EDAIQ3Nhaclsdjr2aPstLLS+x03tLImxP8JrHPOcSHgncScZzyslUFWUQtt3rdRVVzuHscdGWPos7oGBp3GRrAM78DCuNMX2k1JZ4rlbW1AppC5rfHhdE7g4PuuAKlylVFai/wTP4x/QqVwfQ/kvktuNb4Qk92Nrw458/gsXSVmrUaWu1RxmMLtNVFF2mqe5Kw/qmfIL0iLREYjDoREUgiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKk+djHFpEmR6RuP8AQKqiC1q6xkFBU1PvBsMbpDuaRwAT5/JY9BcKy2ugZVVbqyU0IlmZIGjbMS1rANrcjcS7jBPu8LKJ4Y6iCSGeNskMjSx7HjIcDwQR5hWzbVb20z6dtFTCB7g50YjG0kHIJHrwEJQ9LqCpq3xwU9NGah1S+Hc4uY0NYwOc/BGeHODceqUmoZ6iWhBpGRx1DIyJHOdtcXckNcGkZA7BxBKm6a30dM/dTUsETueWMAPOM9vXaPyC+Q22igkZJDSU8b2ANa5sYBAAwAPw4+SCCuV7fR36eJjZZmlsUDGNY94a/D3ucWsBP3dnl5jt3RupKh1LSzCiDGyh26STeGAh+0A4YS0O7guAU9NQUk2/xqWF+9/iO3MBy7GNx+OABn0Xw26jL43mkg3xgNYfDGWgdgPTCCxvN2moKqGJlO0xvAJmeXbA4uADSWtO3PqcBW4vtRsNU6ClbQuMgjLp8SHbkA7ceZGMDJGR8lMS0VLLUNnlp4nzNxiRzAXDHI5VE2i3Ezk0FLmfPinwm+/k5OeOeeUGPVmoZH0jjMH04gq2CR0Ye0lrI/GcMOAPZuPjlX9q1C+qnlZU0c8TWxNl92nl3NySNpBYCfmMjv6KVitlDC4mKjp2EnJLYwOcbc/lx8lUpKOmo2uFJTxQh3cRsDc/kgi5L5scR4TferRSx5dguAYHOdj4AP4+Cs4NRVr6SlnNDFIaqkdVRQxS7n8bcA8ee/y+XKlq+zUdVHUlsEMVVMxzfaGxje0uaW7gfXBwvUNnt0MLoo6Gmax4AeBGPexyM+vPKCzZcamrsdVNTmCOqy6KHcXNG/sA4PaCHZ4wR6eqsIr1JSQStdLUS1DZSJI6trS6ENYHE/omkEe83ny3cnyWRPoaR9GaR9NC6lPeIsBaec9u3dUTZ7aWRsNBSlke7aPCbhue+OPPAyghvtPIRQObSjE/s7Xsy4lj5SMtyG7QWgg8nJHkFUtVXVOvIjrqmYGUSyQsZ4boJIg4BpaQNwIDmZz3JKlW2e2te14oKUPaWkHwm5BbgN8vLAx8l8ZZrawPEdDTR73BztkYbkh24Zx/3DKIR97uclJd6ZkRyGwPeYyTh73OY1gwASeN5wAey9wX1zrHJXOgzIJzTsYCWh7/ABPDb3GWgu75HCk6mgpKok1NLDKTtyXsDvukkd/Qk4+ZRtvo20klK2lgFNISXxeGNjs98jsiURJd7hFPDSvpqR9S+UtcY5yWMjDNxcfdzkEtGMc5HKou1FO2lbUvpmeBPRSVkIjky8NaGlodkYBO4fI8cqepqGkpdns1NDFsBDdjA3AOM4x64H5BeIbZQwskbDR07GyY3hsYAdg5GUEOL5VxSTwOpC+WGN5ja9xD6jbgBzSG7DkkcA5Ge3kqc2pXx0b5THD4jN7nNxLljGtBJc3Zubycc8eefJTn1ZQfpP8AwdP+k+/+jHvc55/HleJLRbZGsElBSuDGlrQYmnAPcduxQRb7/Ubi9lLGII308Uu553B8u3IAx/pD2n4qmdSTxUDLhPSxGjniElOyOUumduc1rAWgee8ZxnHblTzKKljYWMp4WtLmvwGADc0AA/MBo/IKlFabfCyZsVDSsbN+sDYmgP8APnjlBZWy9GoprhNVQuibRnLnGN7ARt3Hh7QQR8vT1Ue/VFRS09PLW0TP/EUzZ2Mge6Qtc57GNY7DfMyDkA9jwVOVNsp5bXUUELGU8M7HMd4bQO4wTheo7XQRRSxx0VM2OXHiNEYAdjtn1QRdtv8ALVVLIJKYsJqHQlzmvZ7oi37g17Qc5wMEfFU7Xdq26XamdCYY6I0xmcw8lwdIRG7P8LHH8fkpl1soXQsidR05iY7e1hjGGu9QPXleo6CkjkhkjpYGvhZ4cTgwAsb+yD5D4ILlERAVhV3WClnlhkbIZI2RuDWge/vcWtDee+Wq/VjPa6ee609wkDjPAxzGc+7z5keo5x8ygim6kP1l4Xs7n0TIpZpappa1kbWv2gnLs491+SB5DGVIWq9U1yqJoYWyMkia2TD9vvMdnDhgn0PBwR5hURpugEIiPjGM03sj2+IQJGc/eA7n3nHPxV5b7dHRCTEksr34DnSEdh2GAAB+XzRCKqtTQskpHNjkjpZXPd7RI0bHxMY5zntwc44HcDOeMq4g1JRyvcwsmY8SRMw7aeJHFrHcE8EjHqPMKnHpahaxkcktTNDHA+mijkk92KN23huAO20YJyfiq8tgpprdUUk8tRI2ctL5N4a/LSC3G0ANwQOwCChVapoKaJ0jhK9rWmR20NyIwSPE5Iy07TjGSQOAq7r9TCtNOIqhzGzNgdOGjw2vc0OAznJyHDsDjzwvU9io5KhsrfEhHhticyIhrXMbnaO2RjJ7EL3NZqaVm1zpR+ndUEhw5eWlvp5A8fIIlTtF6juEjY4mSSExtmMrWFsbWuGWAknOSMcf0VlWamjY6mdDFK2nlc9wqJGe4+NjHOc5uDnHujuBnPGVL22209vbM2nDtspaSHHONrGsAHww0KNZpejbG2N09W+KOB9NFG6QFsUbsZa3j0bjJyceaCNqtR3SL21zbfI4U7oqZuGx4fM/bg8yAgZe3jHzI8pKG+GLfHNFPU1W/Y2nhiaH8NaXH75bgbwCcjnjnzvvqimIIPiHNSKs5Pd4xj8BgfkFbyWCndI2WKeqgmD5XmSJ4DiJHBzmnjtkD4jA5RC2rtQtikp/DLY2PMbpBMxzXRNLXvcXZ7YbGePJX1qvVNc6iWGFsjJI2tkAft95hzhwwT6Hg4I9FSl07QTGbxmySMlyHte8nIMYjxnv90Hz7klXVDbY6RsoEs0rpAGue8jOB2AwAB374z6oLe3XhtXc6ijdG9jm7nxEgDcwEA5GSRyfMDI7LzHqCnkqGs8CpbC6aSAVDmgR72bsjvn/AEnnGPivtpsMFsmZLDNUSOZCIAJC3G0HI7Ac/Hz88qzt+mmttzIq+pnkkLHlzGye5HJIDvczjP8AqdjOcZ4ARJQ6idNM8CJ1SHMjMMcDMPeSwPcfeIAAD4++OT8QF6dqQOrqVsNJM6hfTOqZqhxY0QgED3gXAjHvZ48uM84uXafphL4tPLUU82XfpInAHa4NBbyCMYYz4jHBXuWwUEo2FkgiNMaR0TZHBr48EYI8+5578ohbs1RQujncWTjwgxwbtDnSNe7a0tAJPfjBwfgrqsvMNIKYTQzieoaXMgAbvwMZ88ZGRwDlfIrLAxm18s8p8Rkhc9w52HLRgADGfhk+ZKq3O1xXHDZ5ZhEW7XxNI2vHocg4+YwfiiVGS+U0dyZRyRzMLiWiRwAaXBheRjO7sDzjHlnKto9UUbqcTSw1MDHsjki8VrW+I15w3HPHP7WF9dpikdI55qKrl0rgNzcN8QEOxxn/AFHBOSPXHCu57PDJMZY5p4H+GyIGMjAa3dgYIIP3j3B7D0QepbrFFQRVT4ZwZXbI4AzMj3c8AZx5E5zjHOccq0q9RwUlEKmppK2MAPdIx7GtMYb3JycH4bSSfLKuZbNTOoKalifLAKZwfDJE7D2OwRnkEcgkcjHKtKvTNLVNeJamsw+LwX5kDi4ZLskkE5y49sDsMYAQfLtf/AimbRU80kjZGU7ZizMTZXloa08gnlwzgY8shfTqej8PcyGocXF4ibhrTKGHDnN3OAwDjk4zkYyqz7BTuqPENRVeH44qRDvGwSDndjGe/OM4zzhROp4bVp/Thr6uaaCmtdK5he1w3PjwPd5HckDkYOTwQiEncdT2e22SO73CvgpbfIwPbLM7bkEZAAPJPw7rXVb9ILRNPUmKOW4VLQceLFTe7/8AEQf9ly7rzWNy1jeH1lxleIGZbTUwcSyBnkB8cYye5WOMZJIHFkbnBoycDOES7y0f1J0vq2QQ2a6RPqiM+zygxyfg12M/hlZiDlfm/S1EtNURz00r4Z43BzJGOLXNI7EEdiuwvo/dRpdZWSWhu0gdeaAAPf2M0Z7Px6+R/A+aDb6IDkIgK0rblQ0L2MrauCBz/uiR4aT+fzCu1EVdrqJblUTw1EIhqYmRSslh3na0u4ac4wQ48EFBei4UZrPZRVQmpyR4e8bs4zjHrjlW5vtqDS76xpdoaHk+KPunz+XB5VkyxTgMjdVRmKGaWohxGQ7e/fguOecbz2xnhffs+GRPjhlawNt4oIfc+53y7vzn3ePggkp7pQU8ojnrKeN5wNrpADz2/Neqe4UdSGeBUxSb3Frdrgckdx8wo02BrhI10jSx9VDUbdn+mNrA1vf1YDn4rw+yVLbg6tp6uNsznzE74iQN4YARz3aIwPjkoJI3a3h8TDW04fKGlg3jLg44aR8yMBXqx6l04aeifAKgOeTTAPLOzIdnu9/Mhx/8ynacSiCMVDmPmDRvcxpa0nzwCTgfiUFRERAREQEREBERAREQEREBERAREQD2WmPpS1c1P01McJIZUVsUUmP2cOd/VoW5z2WBdY9NP1VoW5W6nANVtE0GfN7DkD8eR+KDhmFglnijc4Ma5waXHsMnutidUcaK1ybTpmP6vjtjYjHUx/rp3OjDi9z+5B3Ebfu/Ba7nikhlfFMx0crHFrmuGC0juCFNs1NVTuo/ruJl2jo2hsEdT5NHZrntw8tH7O7CIZJ1lt9JBcdP3Slp4qWa8WmCvqYImhrGyuBDi1o7A4zj1ypP6NNXNTdVKOKInZUU80cgH7IbuH+7QtfakvtfqS7y3K6yB9Q8BoDWhrWNAw1rWjgADyW7voraVnfc6zUtRGW07IzTUxcPvuJBc4fAAY/E+iJdQxHLQva8RDDQvaAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAqM0e4KshCDSXVTozQaqqJbla5G2+7O5e7bmOY/wDcB2PxH4grSlX0P1tBUGOKipqhmceJHUsDf/iIP+y7UfGHdwqRpm+gQcv6J+j7WS1cc+q6qOOnaQTTUri5z/g52MAfLP4LpOyWqltVBBR0MDIKWBoZHGwYDQFIMha3yVUDCD6BgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiD//2Q==",
+              "timestamp": 107697770010,
+              "timing": 2448
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAUDBAYHCAIBCf/EAE0QAAEDAwMCAwQGCAUCAgcJAAEAAgMEBREGEiEHMRNBURQiYXEIFRYygZEjM1JUcpOx4TQ2QqHBF2IkgjVVc5Si0dMlJzhTdHWDsrT/xAAaAQEAAwEBAQAAAAAAAAAAAAAAAQMEAgUG/8QAMREBAAEDAQQGCgMBAAAAAAAAAAECAxEEEiExcQUUMkFRsRMVIzNSYXKhwdEiNIGR/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREA9lbK5PZWyC5REQEXxzg1pc4gNAySewWPRa40rNcPYYtRWl9XnaIm1TCSfTv3+CDIkQkAZJ49Vjp1xpZtf7EdRWkVedvhe1s3Z9O/f4IMiRAQQCDkHzUVedQ2uyvY261XsjH4xNLG4RD5yY2j8SglUWBda6r/7pL/U0c/Bp2uZLE/uC5vIIUsdX6es1JQU13vluo6p0Mf6Oeoa13LRyQTwgydFTpqiGqgZPTSxzQyDcySNwc1w9QR3ULd9Y6bs9WKW6322UlTnHhTVLGuHzBPH4oJ5FSpKmCsp2VFJNHPBIMskjcHNcPUEd1VQEREBERAREQEREBERARF8e7a0lALg3uQF8EjD2cFF3K40lvgNRcaqGmhyG+JM8Mbk9hkqwo9S2OtqWU9HeLfPUSHDI46hjnO+QBQZKioU7yfdP4KugHsrZXJ7K2QXKIiDW/XCeZ9nsdobM+npLxdYKGrkYdp8FxJc3PlnGFkdXoXTFRYXWh9loG0OwsDWwtBbxjcHYyHfHurzV2naHVVintdza7wZMOa9hw+J45a9p8iCsPl0XrOpojbKrXj3W1zfDe9lvY2pczsR4m7vjzxlBghvtyn6H0dC6tlLJLwLI6va7Dn03ilu/PxaNuVtxmgdKtsf1SLFb/YtmzBhbu7Yzu77vjnK9zaJskuiRpU0xFpbEImtB95pByHg/tbuc+qxpuidaMpPq5uv5fq0N8MONvYanZ2x4ue+PPGUEN1BqqnQnRQ0+nbxNVmOVtGyuc8OfDG55BG4ebR7oPcLYun9OWy36cZbo4hUU80IbO+Y+I6oyOXPJ+8TlU7do2yUWj26ZFI2a0+GY3xze8ZMnJc4/tE859Vau09dLZZRZ9MV7aam2eGyorXuqJKdvbDG8Zx5bnHCDStPPLT9IuqFgbK+a3WaufT0b3HO2PxB7mfhj/dbn0TpSzUek6SM0tNXOq6dklTUzMEjqpzmglzie4OeB5BR46Z0FP01rtJUFTJH7aC6eskbvfJIXAl7hxnOMJHo7UdppPYNL6pjoraG7Y4aqhFQ6nHmI3bhx6B2cIMU0/VzaQ/6o2qyEuoLPF7ZQxfeED3xOe5g+AIzhZT0s0lY4dDW2pfR0tdVXGnbU1dVPG2R875BudkkcjJ7Ka0Xo6j0zZ6qkMslfU10jpq6qqAC+pe7uXfDHACx2i0FqHT7JKLSGrfYbOXOdFSVdE2pNPk5IY4kHHoDlBQ6fQx2DqfqzTdrGyzMhgro4Actp5H5Dmt9Ae+FtBYzojSMGl4ayR9XPcLpXSeNWV0/35neQwOA0DgAdlkyAiIgIiICIiAiIgIiIC8TjMRXtDygx3UYqTbT7EK4zbh/gvB8TH/8vu4/3UFZW3f60g9qGovByd3tQofD7H73h+/+SzZ8JB93kLyInk/dQfYB+kCul4ijDB8V7QD2Vsrk9lb7T6FBcIis6q4RU9XHTuzvc0vJwcNb6/mgvEXxpDmhw7HkKhUVQhqqaEtGJi73s4xgZQXCKPoK99XVVMZhDI4nuYHbiS4g49Mf7q0F9d49RG6nAEUgY07/AL36QMJ7eWcoJtFF1129mqXxtiY9kbWueTJtcQ4ke6Me92+C+0N09prTAY2sad+07iXHa7acjGB+ZQSaIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8PiY97HuaC5hy0+YXtEBUp6eCoDRUQxyhpyN7Q7H5qqiClHTQRzOljhiZK77z2tAJ+ZXk0VKfEzTQnxDl+WD3/Pn1VdEFEUlOPDxBEPD+57g935ei9NghbK6VsUYkd3eGjJ/FVEQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERBEXm+wW14i2mWYjO0HGPmVEfbB37kP5v8AZQN73/W1X4ud3iHv6eX+2Fr/AFPSail1fbJ7W6qFrY2MT+FM0Nz4hLssJG73cD8eM4wvLq1NyquYicQ9+3obNNqmqqmapnHj3tvfbB37kP5v9k+2Dv3Ifzf7LUlDT31vUO4TVLKt1ke1vs7/AGlvhNPhgOzHnPLs847qhp636lh1rXuuVRO+xxmR9M50wcJN5bhpbnPujPcLn0934+7Pc76np8+7njjv/wC8eDcX2wd+5D+b/ZPtg79yH83+y0vpyk1NHaNRx3Fla2ueyT2OSSra8OJ37dgB9wjLe/w9FX09R6obp6+QXaaT6xkj2UchlB58IAOBBO07uT8clTN+7Gf5+RGk0849nO/n+24ftg79yH83+yfbB37kP5v9lpSopNVyaMuLWe1i7SVLHQxipaJGxjZuG7dgZw7z81mVjbO2z0batksdQIm+IyaQSPDsc5cO5+K5q1F2IzteTqjRaeqcejmN3zZz9sHfuQ/m/wBk+2Dv3Ifzf7LUel6e/Rarvb7tHWGhfJIaSR9U10QYXDa0Rgkg4zz6cKy0LSatgvUztROqXU5jduc+oY+Nz93u7GAZaMfEfJTN+7v/AJx9nMaTTzMR6Od+fHc3T9sHfuQ/m/2T7YO/ch/N/stNaao9Uxa0r5rq+c2Z0lQYGumDgAXt8PjceMZxxxz6q00jR61i1dJLe5pHWwmXfulY5jv2NjQct/IcKfTXd/8AOPsiNLp93sp3zjv/AO8W8Ptg79yH83+yfbB37kP5v9lqXTlPfYtY3mS5x1htr3ONLI6pa6INy3DRHnIPfn5qhpGk1LDqy6zXl9U62PD/AAPEmaW5Lxt2tBOMNHfjv2UTfu7/AOfk6jR6eceznfPzbtt2qYKidsVREYNxwHbsjPx4WRLUy2hbd/1fTeL+s8Nu7PrhadJfquZiruef0jpKLE01W+9coiLa8wREQEREBERAREQEREBERAREQRF5sUFyeJNximHG4DOfmFEfY9376P5X91lyKivTW65zMNVvW37VOzTVuYj9j3fvo/lf3T7Hu/fR/K/usuRc9UteHms9Y6n4vtH6Yj9j3fvo/lf3T7Hu/fR/K/usuROqWvDzPWOp+L7R+mI/Y9376P5X90+x7v30fyv7rLkTqlrw8z1jqfi+0fpiP2Pd++j+V/dPse799H8r+6y5E6pa8PM9Y6n4vtH6Yj9j3fvo/lf3T7Hu/fR/K/usuROqWvDzPWOp+L7R+mI/Y9376P5X90+x7v30fyv7rLkTqlrw8z1jqfi+0fpjlu0tBTztlqJTPt5DduBn48rI0RXUW6bcYphmu3q707VyciIi7VCIiAiIgIiICIsF61atrtF6DqbraomSVhlZDG6Ru5se4/eI8+35kIM6RcnaZ6ndTK+Wmqae6225xySDfRgU/jNbnB/Rja8/hlS0vVjWEHW2os7XVNTao7jJTNtjKePe5gyAQ7Zux/r79kHTaLRtz+kNbrffbpbJbDWPfRSywhzJgfEcxxbwMcA4/BVbH1/orrfXWwWCqhe2GeUvdUNP6qJ8hGNvnsx+KDdqLS1j+kDZa6xXe6V1sqqOOgMLGxiRsj53yb8NbwAMbCcletIdf7JqG+QWuS111FPUu2QOe5r2vefutOOQSeBweSg3Oi5h6Q9W9XXbXU1HepKi5UHgTPMDII2ez7cEPcWsBwMbefNwWW236QdDXWO8XJtgqWNtrYnOYahpL/Efs4O3jHdBvFFoKp+kjb4KajmOnaoipjMgHtLfdw9zf2f+1S0/0gbDT2aor5rbXNcKp1PTQDG6drQCZDnG1vI9Tyg3Oi0tY/pA2O6UFzebZWU1bR0zqltPI9uJw3u1rh2OOeR2TSfXy36ju9st0FirIp62qFOSZQ5sQOMPJx6k8fBBulFzD9Km/Xe1aytMVrutfRRPoA5zKeofG0nxHjJDSOVnWouven7Ffay0mjrKp9Gx7XzsIDHStb9wefJ93d5H4coNyIsB6S9SafqLTXKamt0tCKJ7GESSh+7cCfIDH3ViurfpBWGw3+qtdNba24eyyGKaeNzWM3A4Ibnvg8Z4QboRaTv30hLLb6C1VlDa6qthro3PIMrY3Qua7BY4YPPnwexCuP8Ar7YGWavuNRb62NkNQKemi431OQTuAONrRjnPqEG5EWj6HrpaNT2K/wBJDT19pucVuqJ4DuaS7ZG53uO8nADIyPJYt0c6ox6e0NqC56lrrtc/Bq4YoWTSeI4ue15DWlx44YScnHHA9Q6ZRaQsP0irDcKsRV9puNDG5j3tmy2RuGtLjnsew8s8q1p/pKWSWr2usN0bS7g3xg5hIz6tzj/dBvlFpW+fSG07bbtcKGCgrasUoc0TtIaySQHG0dyB3974fHKjpfpHUEdopq86dqi2eeWAM9pbkFjY3Zzt8/EH5IN9otRaZ66WO96rorE63V9JLV+G2KaUDbvewODSODjJwDjng9ioy/fSL0/bbzUUVJa66uggkMbqljmta4g4JaD3GfXCDeCLU2pOuumrRYbTcaaGrrpLlGZYqdgDHMAcWneSePeBHGexUp0u6sWjqBVVNFS01TQ3CBnimCbB3MyAS1w9CRnOO6DYqIiAsI6w2i/XrRzqXS7aeSuE7HuhqNpjmjAO5hDgWnuOD6LN0Qcds6Na9ut+pXy2CisrA5u+ogqIwxmDnfta9xz/AAgdlmOqumet7d1f+1Gl6aCtjfOJ2TPlYPDJbtcHtcQT59srpNU5J4onASyxsJ7BzgEHPfTfp5qm0dca6/3O1eDaZaise2fx4nZDy7adocXc5Hko7VHSjWUXVO73yxUtJU0dYamRkskzQGiaJ7XNLSQc++QPLOCeMrpdr2vJDXNcRwcHOF88aPxNniM3/s7hn8kHI9j6Iayn0lfaStt7KOsM1NUUrJKiNwn2CZrm5a44OJAecLNtE6Y6n1WqbFJqWgtdFbLc2OMyPgpZJDHHyGtLdzgT6gjHddAunhbJsdLG15/0lwB/Jefaqfn9PFx398cIObNHdLtb6T6mVM9HTU8tnq/Ep5q3xGEezvcCfdJDg7geSxum6N9QLbZ9Q26G20k0NU2JoLahmZtkocNmXDHmTux6DldcsqIXkBksbi7thwOVqq/dYm2nqrFos2Qyl9VT03tntW3Hihhzs2eW/tnnHkiGiq/oxr6WhtUbLAS+GFzZB7XB7pMr3ft+hC3V9IHp1eNYx2e4ac8J9dbi4Gne8M3glpBa48ZBb5kd1bVnXg01Le5n6Sr4xbZGsHjzeGJMvDeTtO13Occ8Z5WwOmWs2a40rT3n2QUBmkkjEBm8Q+6cZzgZ/JBpOg6edQ7jb9Q1F6t1tp5p6OSKKnayB088hbtH6blwGOcl/wAOyzv6N+kL5pDTt2ptR0Hsc89UJI2mVkm5uwDOWk+az3WF/rLLBAy12ioulfUEiONj2xRtxjl8jjho5+JKmxUsbDG+ocyFz2g7XPHB8xnzRLQH0junuqNX6qttZp21msp4aIRPf48UeHb3HGHOB7EKFvfSrXtBqfVf2djpZbXeoZjJK58eXNcS/wALDjlri73c9vPK6cZLG8kMkY4gZOCDgJHNFISI5GOI7hrgUGm/o16Lv+jqC+x6koDRPqZYXRAyxybg0Oz9xxx3HdYRXdOuo2l9UajfpGio6+33dzw6WQwu/RucXAFshHIzg8EFdMCqpyCRPEccn3xwtf8AWHqc3pxHaXm1G4ivMoGKjwtmzZ/2uznf/sg0trvpNr26W6w4ttJWVkcMhqBSez07IiXcNwC0OOAMkDz+C2d1y6dXbWFgsMtj8H6ytWf0Ejg0PDg3OCeMgsHfjutm6bu7L1py03V0Yp/rCliqREX7tu9gdtzxnGcdlIRzwyOLY5Y3uHk1wJQczx9MtfakvF51FqumpYK/6sqKenp4XxgzyOgdGxvunaB73cn+1hpnpXreh0JebfNYKKSpqK6mmFNWTRubLGxkodtc1/uuDnM5y04zz3XU4qIS8sEsZcO4DhkIyeGQOMcsbg3uWuBwg5d0l016lQT1bXUVJbbb4EwZbqmpbUU5c5hAa1hc/GXHOSfX5Kys3TDqVBeofq21U1gpy5vjOhrd0EuD3ewyPLvljHwXWEcscgJjkY8DvtOV5bVQOBLZ4jjk4eOEHLNw6R6/tVXqm3WKGlqLPc27jIXxh0zWv3MYA45a7nnsOO/ZY/UdGtev0zQUjbCTURVlTK9ntcHDXMgDTnfjksd+S6Y6h9R7HoL6v+vBVv8AbQ8xezRh/wBzbnOSP2h/usktN2pLnZqK508m2lrIWTxmQgHa4AgH48ohzfF0w1g3qzp+8GzkW2lNtM03tEXu+FDC2Tjdk4LHDgc44yrWn6bdTNI1N7tmmaChrrXcHjM8vgPDmNcS3LZDweeRghdUNc17QWkOB8wcqJl1NZYr+yxyXSkbd3jc2kMg8QjGe3y5RLQOs+kmsqil0zeKA0FVfaGHZUU8GymY1wkdI3Zt2t/1EHt2ysy6JaT1fa7zcLtq6mttEJmOayCGCEzOc5wJc6RgJI483EnPPZbjRAREQEREBco/S7JbriykcEW8EfzXrq5aR679KL7r/UVvr7NU22GGnpfAcKqR7XF29zuNrHcYIQaf0dca22dQK52irpcbiZLXUT1D5mODnTezuc7c09yJcYJ8/Xzw/wAW3fZsXgX24fa/239Rh2PDxnxPE/az8fw813RZdOWmzz1FTbrbSU1XVHdUTRRgOld3JJ7nnlYzb7Z03r9TP+r4NNVF8Y9z3RwmJ0rXtPvEtHYg9zhEObdcV1RF1f0tdNQEwTGG11NU94xghsZeT8iHfksNikbK/WUkZ3MfTlzT6g1kC7pvGmbHequnqrtaqKsqKcgxSzRBzmYORgnyz5KJ/wCnGjs1J+ztvzUjbN+j++Nwdz/5mg/gg0v9GLQ9JcaGk1ZNW1YqrfWTRRU4I8LBjaCcYzk7vXyCx/Xv/wCK6l//AHS3f/0hXUdgsVr09QmjslDBRUpeZDFC3DS4gAn/AGH5Kxq9Gacq7+291Nno5bs17JRVOZ74cwANOfUbR+SJcI2v/Aah/wD0rf8A/REr2OenptPWeqtt4rvtDDVPa2ka1wbBHnc1zHepcTwP+Oe0o+mei42TNZpu3NbM3bIBH94ZDsH8QD+Cu6HQulqCaklpLBbo5aQkwPEIJjJOeCfjyiHI2u6iW7dSL83W9dUUckAcIAS4BpAGwABruCOewznuFG6vn8XQWmI47pVXGniqaxsbp4DH4XuwEsaS47hk5+GV2jf9Had1DO2e92ahrZ2jaJJogXY9M98KnctD6YudHRUldY6Calog4U8RiAbEHY3bQO2cD8kHPWp9KT6N6ItvlkuFwlqL7DQ+3Fzh+iiMZOGkAENyWt+XCwvp39WUWsdMz2nUFbDXSvi8aOGB026Quw6M8MwCOP8AVxzldcUV20nVn7M0lws9Q6JhpTbWzRvcGsGCwx5J4AwRjjC9WXROmbJXGttNit9JV4I8WKEBwz3wfL8EHIXQ7RlLrrVFxtVdWVVLTtonTuNOQC/bLGA05B45z8wFsv6X0Qgt+j4WklsftLAT54EQW9NP6M05p2skq7HZ6ShqZGGJ0kLMEtJBx8sgfko/XseiKh9HFrmSzBzA51M24TMYcHAcWhxHoEHLuq6wT6l0XSakuVbbrHT2ShfDNTNLnR/+Ha7e0Dz8QYz8Pgpj6KR3dUrg7c52bbMdzu5/SxcldNz6V05cae1+NaaCphoGMFEXRBwiaANoafTgfBfLFo3TthuEldZrPSUdZIwsfLEzDi0kEj8wPyQctdZ2VGhOsN2raBu1lzpJJGeWPGjdG8/g/cfyUZX225af6F2uspvGhhvlxfJVPZkExsbtiYT6EiR3x4XXWotI6f1JNDNfrTSV0sLSyN0zMloJzgK8fY7XJZWWiS30z7WxgibSvjDow0dhg+iDk7pALbQ9S7YywX+tIlZtfAyB0jZssJe15IZgDGc7TjHcrXmnKP2jT2qajx54zSUcUgZG/DZCamJmHDzHvE49QF3PYdH6d0/NLNZbNQ0Usg2vkhiAcR6Z74+Csafpzo+np6qCDT1vZDVMEczBHxI0ODgD/wCZoP4IOM78ZqvpzpmsqHSyviq6yjEj3E7Y2iF7GfDmSQ/j8Fc3Krttfc7Bbp66em01BQxBpDnhrZCzdMRlrjzOZBkNPbjjC62ntvTygpTpeoZp+GKSbxfq6WSMEyEAZDSc7iMBSc+gtKT22noJtP219HTkmKMwDDM8nHmMoNVfRWljFJfKaku9XXUkbmOEMtOWMhcd3LXEnOQBkYHYKRu//Tv/AK+U3tnt51Xujxj/AA3jbBsz57tu3Hl2W27LZ7dY6FtHZ6GnoqUHIjgYGDPrx3PxVvJpqyyX9l7ktdI67sG1tWYx4gGMd/lwiUuiIgIiICIiAiIgLi/SFsqb11U1lbKANNXVwXOGIOdtBc4uAyfJdoLUmhukEmmOo9Xql16ZUtndO72YU2wt8Qk/e3Htn0QYLedaal6Waa0noqgpqL69dA6SaSZwexofM8MDTkD1yScBZFoXXPULUFDfrfX2qOmuVPTPloq9tOfAfI0j9GTktdu8iD6rKurHSqm17V0NwhuU1rutG3YyojZvBbnIBGQcgkkEHzKh9JdGqjTlvvkkWpaiovtyp3Uza2SI7YWuI3ODd+S4+pdwiGr7b111tdnWu0UDaP66qKwwukdTja4O2Bgxngg78n5K8n62a6udyrW6bpaCaloSGlrogZZhnG7buySSCcNHCnYfo3GmpqF9HqbwbnT1DpjVCkPI93YA3fwWlrjnPO74K6uv0eDPXVM1r1RNb4KzBqadlOSxx7uAw8e7nJAOcepQY5rrrbrS1usnh0MVqqKihEtRTVNMc+J4sjdzd3IaQ1pA/qq8XW3WsOtbzaJ7ZbpX04qg2mBx4JiY9xO/PvABhz6+WFP6n+jxDc22qO3X99NFQ0gp3Gen8Z8rt73l5O8Y+/jGOMK+f0Oldr27aj+v2Btcawin9kOWePHIz72/nb4me3OPJBr7/r7qubRs9SxtBHcaeuiiMrYctfG+OU4LSeCDH3HqpWz9btY0lfpyq1DbKT6juuI2yNbh8gDgx8jcHggnsR2/NYt1S6VzdO9FAm6C5GvuEPDKYx7Nkc3/AHOznf8A7LM+kvRulu9v0xqW53SpkpI4xOy2ub7rZA8k+8Tw0kAkAfig19Zb+zS3XPUt7kiMoo6m5SCPON7syBoz5ZJCy2y9ZepFdJT3Cns9FcbfLKW+zUsJc/APIw1xc34Fwx81mtP0Ggfra73q5XgVNFcX1Tn0jabY5om3Yw/ceWlwOceSi6T6OXh1UEVRq2sktEUhkFKyEsd8cHeQCfUNQbC6ta+k0VoOO9U1IXVtU9kMEM4IDHuaXe+O/AB49VzD1jvuqL63T0+sbbHR1LqZ0tPJHgNnieQQdoJwR6Hntwus9eaGtusdI/UFW6Snhj2Oglj5dE5gw089+Mg/ArUVy+jfLWU1Gx2rZ5JYGlhfPTmQBmfdawb/AHQB8+/kgoau6t6npNSQaZ0fTUIdSUsQfJU7d0jvDa44LnBoHIGO5WzOjOrr/quyVT9U2eW3VtO8BshhdEydpBwWh3mMc/MeqxvWnQ6O93qK8We/1FouJhZFM+OMuDy1gZuGHAtyByMlZh0p6fUvT+z1FLDWzV1TUvD5p5BtBwCAGtycAZPme6JclaldcpdV11TresvNO98jnQ1MEXisPJwWZe0bMdtp7LN5Opd90VobT0Wnr5T3SOolqt888bnvAaY9rSH8tIDjxyORglZjXfR4rnxT0lHrWqjtkjy72WSnc5vfIyBIAefgpC4/R4ttRpK22qmvE0NZSSyzPqnQhzZXSBoPuZGANjcc+SIQ7ereqD1Ytlg8Wk+rqh1IHjwBu/SQxvdz83FQuiOrHU7V9ZVUNkp7fWVUcYlP6Nkfht3AE+84A98fisztfQaWg1tbr/8AaWSobSPheY5qcue/w2Nbjfv89vHHAwPJTHR7pBJ08vtbcX3ptwFRTez+GKbwtvvNdnO4/soOf9NW6tuvXh8N1NNNVw3WeorC4uDHeE5z5NuOezHbfLOM8LNW9btfXqqrKzTttt7qCGUNbTCPxJSCeON29x9S0YHwWx9O9G3WnqnVavlvLKiKeoqpzR+zFvEweNu/ee2/05wser/o5tNbUttOqauitVRIHvpDCXcA5AyHgHHkSEG59G3aqvmmLfcbhQS26rnjzLSytLXRuBIIweccZHwIUyorS1jptN6fobRQukdT0kexrpXbnO5yST6kklSqJEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERRc09WZ5BEcMaQB7gP8AyFTevRaiJmJnPg6pp2koit45ZH0LZWtaZXMDg0nAzj15UbbbvJVVdLC4wh0kAlewZBaSM8ZPPyx8cq2mYqiJhzO5NIoWquNZE66PYyPwaVp2Es7nY13J3ep9PxVMXWpaKNjfCmNSdjHtHAcHDOcOI+7k9/JSJ5FAQ3eqdNVNfHEGxztjadpGQZiz154HfjlfJ7xUskuLWeAXU5wxm3Ljy3k+9nz9B80GQIoiS6SR2JlbK6KOR3HLTjOcAYzwfhnj8FThu0z6h7XiFrWxlxAyduGg7ifNpyR28kE2ix6mvc00tE3bEY5nHL2tzuG7AwN3Bxye+PRZCgIitK2SXcI4SWnY5+QAScY4GfmkRlEziMrtFbUUrnh7Xu3bcYcRgkEZ5HqrW13CWrrauKVgYInYa3HOMkZJz54zjA49VOCJzvSaKAt97qKmtp6d0Abuke2R2DjADizHz2nPyVGqvtXDAyUQMe0wue4gH3Xbto4z2/8AmoSyVERAREQEREBERAREQEREBERAVu+jie9zzvBPJw8j/lXCLiuimuMVRlMTMcHxjGsY1jBhrRgBfURdxGN0IEREBERAREQEREBU5oWTAB4OR2IJBH4hVEQxl4iiZEzawYHc85JXtEQEREBERAREQEREBERARFRNTEKttNu/Slpfj0CiZwmImeCsiIpQIrC5V3s+GRYMnc58lYfWdT6t/JW02aqozCuq7TTOE8i1L1I6iXaw1NHb7NTsnrqn3slmQ0fL8CsOu3VHW9N+qhia4DkGkyM/NU11RRVszO9dboquU7VMbnRaLmE9UupmHyClphC0Zy6lAz8uVsnpV1BuOrLLNJcGQx1tPJsfsbjcPI7fLzH4KbcxcnZpRcibcZqhtVFA/WdT6t/JXn1hO+ka+kphUTh7WvjMgZgE8uyfT0VlVqqmMyqpu01TiEkij/abh/6vZ/7wP/kq1G+rkkkdVRRwx4AY1r9xzzkk4Hw/JVrF0iIgIiICIrG81E9LSCWnbu2k78NLiG7TyAPjj8MoL5FQnnaKSSWJ4dtYXAt58lWY4PY1zSC0jII80H1F8eSGOI744XLlw6ya4g6jyWGM0fg/WPszI/ZgXGMvwOc/skHKDqRFzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiKlPPHAY/FOPEdsB+KiZiIzIqoiKQWN0Li7WVZk9o8D8mrJFjNv/wA5Vv8AB/w1UXuNPNp0/ZufT+YZMqdRKIYXvd2aMqoo69v207Wj/U7laaKdqqIZK52aZlDSPdI9z3HLicleUReiwMDraH2jW9VUzNBMTGsj+AIGVPthYGgFoP4K2ucDm3ieRvDnsaRz3HZW0BrW1OH7PB9WOJx+a+Z1M+3q5vr9DGNPREd8Pl6ga6Bw2jBCx3pvF7FrK5QRjEc9P4px5ODgP+Vd1k1ZUGTDWGNpIw55blVenVK/66r6l2TthbGSfUnP/Ct0U+3jDN0nGbE/JsJV6Oc087Xjt2PyVBF9DMZjEvmonE5ZYDkAora2v8SiiJ7gY/JXK82YxOG+JzGRERQkRUayY09NJKGby0cNzjJ+atY57mamFslDTthc4iR4qSSwYOCBs55wO475QSCIiCLurLVbKKquVZSwNjgjdLJI2EF2AMnsMleqOho5Y4qmkdUMje0OYGzSNaAe3uE4H5KRc0OaWuALSMEHzX1BbOpHH7tVUN+RB/qCsXd06sMl/F6lhL7kBhs5awED04bj4euOO3CzFEGI33p/ZL9cqauvERq56dwdGZGs908ejRnsODkLK4YmQRMiiG1jBgBe0QERR1puE9dLWsnt1TRCnmMTHTFpEwwDvbtJ4580EioPV5It8ZHcSA/7KcUFrD/0bH/7Qf0K83pj+jd5LtN72nmm4zmNpPchel5h/VM+QXpejTwhSLGbf/nKt/g/4asmWLUkgj1fWuIJ9zy+TVTe40c2nT9m59P5hlKir7nEPpz/AMK89sZ+y5WV1lbNTja0gtOeVstbq4YbkxNMxCJREW5jQ13Y5ldHMR+jczw8/HJKjpaxsbnOLm7W8Bmcfims7423V1loTGHmvqHRl+f1eI3OH5kYQiHDiQGuPnhfO6+nYvzjv3vreiq9vTRnu3ISnrI31UzC9u154ZnOPiprQkL2/WMx/Vvla1vxIHJ/3CgbhNBTTF2Wl/r6fFZNoOugrLEzwuHtc7e09+TkH8Qrejrc1Xtvuhm6XuxTa2PGWRoiL3Xzafs4xRN+Z/qr1QFPdpKaIRC1Vz9uRuaYsO+Iy/Kq/Xkv/qe4fnD/APUXn176pluomIpiEhdal1Hb5p2AF7R7oPbJOBn4cqn4dy/eqP8A92d/9RRVxuM9fSOpmWusiMjmjfI6La0bgSTh5PYeQU17Yz9ly5xKdqFCWlrp2iOarpvDJBcGU5BIBzgEvOPyUgrb2xn7Lk9sZ+y5MSbULlFbe2M/ZcntjP2XJiTahcorb2xn7Lk9sZ+y5MSbULlFaSVn6N3hsy/HuhxwM/FYFoG46yk1PqNupoKJttFSPA8J7yW/o24EeRy3GMk497cmJNqGyEVt7Yz9lye2M/ZcmJNqFyitvbGfsuT2xn7LkxJtQuVBaw/9Gx/+0H9CpT2xn7LlC6qnbLb2AAj9IO/yK8zpiJ6jd5L9NVE3aebIYf1TPkF6XmH9Uz5Bel6NPCFQsSj/AM2V38H/AA1ZasSj/wA2V38H/DVVd7VHNpsdi59P5hLry9oc0g9ivSLW81impL3T2KPNQHSSu+5Ezu7/AOQWA3TW90qqhraSNtLAGuc7by5wwcDJHBWytW6chv1HjhlVGD4cnzHY/DlaiuFtqKOb2esiMUu7c4EYAOfdA9ckL1NLVbrjfxZrlMxPyWF+jfXW6ZrBJJX72zxvLve3tON2T6D+qzDS9c+6WOCadofLtw4EgEOHfKxmVskdQ2aI7JWuOMjIwQGnj8Mq5tomp6SR0E7WB0Yfgg4cSfL4+aydJaCdTiqnjD1ei9fTpc018JRd3qRLqOWleGmOOMyGNrsjuAM+vc/ko6Gtqm3N1RTGSne0BocxxBIzxn/dX8cDgJnPcDJNgSPxknBJ2g/j2+a8spz4zQMYDtp5zlxPr8Np/NbdLp6dPb2KYefqr1WouTcqS+n+oN2pmj29rauEvLcuGHDHYA/H4raOlrzTagiMlMHNMePEY4fd/HsVqjTmnqq7Np4KWE4cd75D91g5GT+S3Zp+z01ktzKSlaOOXvxgvd5kqvVVUURiOKu3TMz8kkvqIvNaBERAREQEREBERAREQERYL1LqdXQPtH2Up6WSJ1bEJy97t2M8hwAwGepzn4KCIyzpFRpDOaaI1bY21G0eIInFzQ7zwSAcfgqykFFai/wTP4x/QqVUVqL/AATP4x/Qry+mv6N3k06P39PNlMP6pnyC9LzD+qZ8gvS3U8IBYlH/AJsrv4P+GrLViUf+bK7+D/hqqu9qjm02Oxc+n8wl0RFreaKwutqo7rD4dZC1+Puu7Ob8QVfokTMTmBru59P5fEkfQVTXNd2ZLwW8Y7+fKhotJXuKidEaMh4wxu2RrhtB79/j6eS26i006u5HzVzbiWoYtGXiV5JpWt5w3e8NDfU8fN35qfs/T1kRhdcarxBGQfDiGA48dz+B/NZ+iVau5Vu4J2IW1BRU1vpWU9HC2KFgwGtCuURZpnO+XYiIgIioVNVDTNBneGA8DKhEzjfKui8xvbIxr2HLXDIK9KUiIiAiIgIiICIiAiIgKK1F/gmfxj+hUqorUX+CZ/GP6FeX01/Ru8mnR+/p5sph/VM+QXpeYf1TPkF6W6nhALEo/wDNld/B/wANWWrEo/8ANld/B/w1VXe1RzabHYufT+YXV5ulHZbZUXC5zCCjgbukkIJ2jOOwBPmorTetNPaldO2y3SGpdA0Pkbtcwtaexw4Dj4qn1Js1XqHQ92tVv8P2qpiDI/EdtbncDyfwWl4ejmqmWW4UW+2iWaCDE5mkL5tm3MDj2DBjjA/0tWp50RDocVdMQwiohIk+574975eq+CspixrxUQ7XHa07xgn0C0A/pBqRuk4BR/V9Jeqe4GpgiineWRxubhw3OzzkN4AxwvF+6LXw0Niht3sFWynofAnhqJnsbHO55c+Ru3vy7HrwEynEeLoN1XTNeWOqIQ8ENLS8ZBPYL4KylLgBUwkl20DxB39Pmueb70c1NWVF0lidRPlldSGCT2hw/Vx7XnnJ74xkkr1Q9IdV094pHOkoTTQXkV5mEx3lmW5OMdxjt6pkxHi6IjnikkeyOVjns+81rgSPmFi7eomlXag+pBdmfWnj+zeB4UmfEzjbnbjv8VrvpX0w1BpnWUdxuZoPAhZI19RFNI6SpLs4JGQPMdwe3ryraHprqun6iXe607LYKCvqpJBNJITJE127DmgdnDdn5hRmTENu6k1TatP2aruddUB9NSlolEOJHNLnBo4HxKvrXdaO526KupZmGCSNsmSQC0OAcN3ocELnODovqoWmupfZrRDK6AQiaOplLqk+KHZdk7RwPTyHHmpGXo/qhtNeKailo6elqoaR3s4ncGTyRtaHh+BkAncc+aZkxHi6DNTA2ETOniER7PLxtP4r5LV08RYJaiFhf9wOeBu+XqueKvo7qmTT9NE19uIZWzVH1T48ns8bXtaAGuPORg+fn37r5eOjupahtmaynts8tLTthc99XIYmjc4luxwLjjcMEOHyU5MR4uj1Bar/AFEH8R/opqFpZDGw4y1oHHZQuq/1EH8R/ooq4KL/ALuWoPpC6tvemqLTbLNeZLZBNHI+cQtHiS7Q3aGuLSPM8ZGViNP1Z1jYq6uqrhVuq4W2Knq6Snr6QxiaRzog53uY5w5574W59cdQqDRdPZqWqtlZcqqtifJHDTNadrI2gucdxHYH/ZRsfWi0yVVyY2y3c01tpo6urqfDZthY+LxG5G7OTw3Hr8OUXUdmNzEdYdYdX6UmiiuNusj31FqFxgMMczmlxkwGElw7N5PxVpSdaNVXe9VFpp6G2000lPIIoRFOakO9n3tmHBYWF3YHnH5mfqetlJcaq0RW6lr7fO+5U9NUU9RSMle+OVu5mCJBtDgO4yfgqzOvtmdQVlb9nb0PZXtje3ZFvbkkZeN+WDj/AFY7hP8AXWPkwC0dddTWrS9uFW2juNU6gnnknqYJA8ztmcBGdpaOGbTwPMcrKrZ1e1fX2zU1zgs9pnpbJDFI+GNsomkMjMgjkja05J/7R+KlLj9ILT1FTMnfZrtJiBs0mwRER7nlrQTvwc4zkZGMKo/6QOm4K+WnqrZdIY46iamdNsYW7425PAdnnjy80/0x8mM2brZq281djoaG32F9RcqySkZUllQIHYa0gjODwXc9/wAFL9WdYX3SvUm0S0bpalkVkqKmWgje4QyytDuS0dwO/rgKUh66Wk2k1kmn71HI6aCGnp9kZfOZmucwtw7HZpPPqFMXbq1aLboa16ont1xNLX1ApWwbGiVjve7gnGPdPYof4j+iPUq6a9uN9p7pTUEUdBHTuifSMlaJPEDiSfE5x7vHA/HutsrTc/X3T0NOx7bTeHzs8U1UDYmbqZsbg1xd72DyfIlfajr9p2KqdDHb7lK32wUbZGhgDiRkOGXZxj8VOUTE+DcaLEunOtItc2Y3SktdfQ0TseDJVBoE3Lgdu0nsW4OVlqORRWov8Ez+Mf0KlVFai/wTP4x/QrzOmv6N3k06P39PNlMP6pnyC9LzD+qZ8gvS3U8IBYkz/Nlb/B/w1Zaoqptv/wBpmti7uZse317YK4romqaZjulbbuRRTXE98Y8kRqqG51Gnq6CxSshuckZZBK92Axx43ZwewyeywWO19TYqIRsvNvMjKRrQXNaS6YOAJyWdiwF2cfePotolpHcH8l8wfQ/ktDE1xLbuoVRZr1BPcaKOtlbF7FJA8NEZDhv52ZGW57558grKex9R/DpZYL1TmeFz2iOR4LdhawAkiMbn538uGAcHHdbUwfQ/kmD6H8kMtZalsmv66ooXWy709M0UDY6oeJgOnw/cQA3zy3BGMY7KLqtOdTn3aOqhvNE1kLdkbPHfsIAdgubtwTy3JOckemAtw4PofyTB9D+SGWJ6KpdWQzVMmrK+nnZtY2CKBrcZ2jc5xDQc5B+HPyWWJg+h/JMH0P5IgUFe9XafshLbpd6OCX/8rxA6Q/Jgy4/kvmvGXF+jby2zCX6wNK/wfD+/ux/p+Pp8Vr+iqdLWmSinsk0lJROZE/wKWgkdWyPAIc2Qhm4knack98qJnDqmnLJKvqA6SNzrLp+6VjACWz1LW0ULgBkkOlIJAHmGlR1RetU3CjuEv1laLXFSlniR0EL62obuIw0F21mecdjgqzpaS5Vck7rZpS4z+O7c+e9VIpWPJwSXRt3vOSAccenwU5S6X1PM976m+UdpbINr22miHiuGc8zy7nHknyUb5d4phC3SzVVLQXS412oNSU1RSU0lRDX1FU1kIkYTtYYg0MIcNpxyeSOMc5LJW1Fx0rZa2ti8GqqIGSyx4xtc5gJGF7pentjZVMq7jHV3esaQRPcqh9QQR2w1x2j8AFJanie6CAMY44cew+CTG5n1MxNucNZ9Y7rpunfpm26n03BeBUQTzRSyzmLwPDj3EZAzh3Gfl5qJ0Vr7QLr5c6Gus1usjbjR0kcsjp/FiqmujAZFt2gBrWnGeAsh6o2DTt4rtNjUdbc6SdlLVMg9lp3PYWuiw8vIacYHbtn4qMsvQzS1xpKWup7teaigqIadpjJEbZo4sbQ8bQeS0E9iMeSlZRjZjLzQ1fSGjra+2tprRTU9nnFYHtke4uladrnAD7wbkDufPgDk0iOhcVAIyLS2CslyCTLuJbxnd3a33seQ/JTDuglgzd2xXK7x09wa9vgNkbsi3ODiR7vPbjdnCkNRdGrLe57NO6tuVJNbqSOh30zmtMsTMY3ZacHjuMd0dZhZUNi6SanuhsdFbrXV11BE+n8CON7TG2N4LhuGP9R75ycnk8rFdLXzpNcrRDeL7aLfZqmSrqJmQVEz5i9zcB8mO3PbBHOMDK25ojRNFpB95fQS1EzrnWPrZDNgljnd2ggdvmtV1vRfSFHcLZp+S6X6OvrIahjJIW+7LGTvLXuDNoAPIBxn4oQyKrsvSSzWKnpKuhttPbb0z22HeyQ+MI2btwd3GGuOBkdz6qL1ZL0x1HZNPaWgvtLbKSKeKspaaCMgPBB2tO4YG7cTzyc/FZbrDpRZ9U6Nsunq6oq44rS1jYKmLb4pDWbMEkYwRjPHkFjh6a6TrupEsdFV3ikuFDT07p6aFhZA9rGBjMPLeeMZa1yEIu93vos3TcckVDbbjBaozUw0tPCRJtdIGnvjPvEZDj8VI7uj11vNunrae2w3q6iGsZFJvY8PkaCwO2na1xyOPPvznKtq3ofpGw2Yy3S7XNtDDRPoXOdtzh8peHe63JcHO448ldaU6VaWuNxt+oLNfLxUeyCGKQl2zxnQtDWbssDh7u0EDAIQ3Nhaclsdjr2aPstLLS+x03tLImxP8JrHPOcSHgncScZzyslUFWUQtt3rdRVVzuHscdGWPos7oGBp3GRrAM78DCuNMX2k1JZ4rlbW1AppC5rfHhdE7g4PuuAKlylVFai/wTP4x/QqVwfQ/kvktuNb4Qk92Nrw458/gsXSVmrUaWu1RxmMLtNVFF2mqe5Kw/qmfIL0iLREYjDoREUgiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKk+djHFpEmR6RuP8AQKqiC1q6xkFBU1PvBsMbpDuaRwAT5/JY9BcKy2ugZVVbqyU0IlmZIGjbMS1rANrcjcS7jBPu8LKJ4Y6iCSGeNskMjSx7HjIcDwQR5hWzbVb20z6dtFTCB7g50YjG0kHIJHrwEJQ9LqCpq3xwU9NGah1S+Hc4uY0NYwOc/BGeHODceqUmoZ6iWhBpGRx1DIyJHOdtcXckNcGkZA7BxBKm6a30dM/dTUsETueWMAPOM9vXaPyC+Q22igkZJDSU8b2ANa5sYBAAwAPw4+SCCuV7fR36eJjZZmlsUDGNY94a/D3ucWsBP3dnl5jt3RupKh1LSzCiDGyh26STeGAh+0A4YS0O7guAU9NQUk2/xqWF+9/iO3MBy7GNx+OABn0Xw26jL43mkg3xgNYfDGWgdgPTCCxvN2moKqGJlO0xvAJmeXbA4uADSWtO3PqcBW4vtRsNU6ClbQuMgjLp8SHbkA7ceZGMDJGR8lMS0VLLUNnlp4nzNxiRzAXDHI5VE2i3Ezk0FLmfPinwm+/k5OeOeeUGPVmoZH0jjMH04gq2CR0Ye0lrI/GcMOAPZuPjlX9q1C+qnlZU0c8TWxNl92nl3NySNpBYCfmMjv6KVitlDC4mKjp2EnJLYwOcbc/lx8lUpKOmo2uFJTxQh3cRsDc/kgi5L5scR4TferRSx5dguAYHOdj4AP4+Cs4NRVr6SlnNDFIaqkdVRQxS7n8bcA8ee/y+XKlq+zUdVHUlsEMVVMxzfaGxje0uaW7gfXBwvUNnt0MLoo6Gmax4AeBGPexyM+vPKCzZcamrsdVNTmCOqy6KHcXNG/sA4PaCHZ4wR6eqsIr1JSQStdLUS1DZSJI6trS6ENYHE/omkEe83ny3cnyWRPoaR9GaR9NC6lPeIsBaec9u3dUTZ7aWRsNBSlke7aPCbhue+OPPAyghvtPIRQObSjE/s7Xsy4lj5SMtyG7QWgg8nJHkFUtVXVOvIjrqmYGUSyQsZ4boJIg4BpaQNwIDmZz3JKlW2e2te14oKUPaWkHwm5BbgN8vLAx8l8ZZrawPEdDTR73BztkYbkh24Zx/3DKIR97uclJd6ZkRyGwPeYyTh73OY1gwASeN5wAey9wX1zrHJXOgzIJzTsYCWh7/ABPDb3GWgu75HCk6mgpKok1NLDKTtyXsDvukkd/Qk4+ZRtvo20klK2lgFNISXxeGNjs98jsiURJd7hFPDSvpqR9S+UtcY5yWMjDNxcfdzkEtGMc5HKou1FO2lbUvpmeBPRSVkIjky8NaGlodkYBO4fI8cqepqGkpdns1NDFsBDdjA3AOM4x64H5BeIbZQwskbDR07GyY3hsYAdg5GUEOL5VxSTwOpC+WGN5ja9xD6jbgBzSG7DkkcA5Ge3kqc2pXx0b5THD4jN7nNxLljGtBJc3Zubycc8eefJTn1ZQfpP8AwdP+k+/+jHvc55/HleJLRbZGsElBSuDGlrQYmnAPcduxQRb7/Ubi9lLGII308Uu553B8u3IAx/pD2n4qmdSTxUDLhPSxGjniElOyOUumduc1rAWgee8ZxnHblTzKKljYWMp4WtLmvwGADc0AA/MBo/IKlFabfCyZsVDSsbN+sDYmgP8APnjlBZWy9GoprhNVQuibRnLnGN7ARt3Hh7QQR8vT1Ue/VFRS09PLW0TP/EUzZ2Mge6Qtc57GNY7DfMyDkA9jwVOVNsp5bXUUELGU8M7HMd4bQO4wTheo7XQRRSxx0VM2OXHiNEYAdjtn1QRdtv8ALVVLIJKYsJqHQlzmvZ7oi37g17Qc5wMEfFU7Xdq26XamdCYY6I0xmcw8lwdIRG7P8LHH8fkpl1soXQsidR05iY7e1hjGGu9QPXleo6CkjkhkjpYGvhZ4cTgwAsb+yD5D4ILlERAVhV3WClnlhkbIZI2RuDWge/vcWtDee+Wq/VjPa6ee609wkDjPAxzGc+7z5keo5x8ygim6kP1l4Xs7n0TIpZpappa1kbWv2gnLs491+SB5DGVIWq9U1yqJoYWyMkia2TD9vvMdnDhgn0PBwR5hURpugEIiPjGM03sj2+IQJGc/eA7n3nHPxV5b7dHRCTEksr34DnSEdh2GAAB+XzRCKqtTQskpHNjkjpZXPd7RI0bHxMY5zntwc44HcDOeMq4g1JRyvcwsmY8SRMw7aeJHFrHcE8EjHqPMKnHpahaxkcktTNDHA+mijkk92KN23huAO20YJyfiq8tgpprdUUk8tRI2ctL5N4a/LSC3G0ANwQOwCChVapoKaJ0jhK9rWmR20NyIwSPE5Iy07TjGSQOAq7r9TCtNOIqhzGzNgdOGjw2vc0OAznJyHDsDjzwvU9io5KhsrfEhHhticyIhrXMbnaO2RjJ7EL3NZqaVm1zpR+ndUEhw5eWlvp5A8fIIlTtF6juEjY4mSSExtmMrWFsbWuGWAknOSMcf0VlWamjY6mdDFK2nlc9wqJGe4+NjHOc5uDnHujuBnPGVL22209vbM2nDtspaSHHONrGsAHww0KNZpejbG2N09W+KOB9NFG6QFsUbsZa3j0bjJyceaCNqtR3SL21zbfI4U7oqZuGx4fM/bg8yAgZe3jHzI8pKG+GLfHNFPU1W/Y2nhiaH8NaXH75bgbwCcjnjnzvvqimIIPiHNSKs5Pd4xj8BgfkFbyWCndI2WKeqgmD5XmSJ4DiJHBzmnjtkD4jA5RC2rtQtikp/DLY2PMbpBMxzXRNLXvcXZ7YbGePJX1qvVNc6iWGFsjJI2tkAft95hzhwwT6Hg4I9FSl07QTGbxmySMlyHte8nIMYjxnv90Hz7klXVDbY6RsoEs0rpAGue8jOB2AwAB374z6oLe3XhtXc6ijdG9jm7nxEgDcwEA5GSRyfMDI7LzHqCnkqGs8CpbC6aSAVDmgR72bsjvn/AEnnGPivtpsMFsmZLDNUSOZCIAJC3G0HI7Ac/Hz88qzt+mmttzIq+pnkkLHlzGye5HJIDvczjP8AqdjOcZ4ARJQ6idNM8CJ1SHMjMMcDMPeSwPcfeIAAD4++OT8QF6dqQOrqVsNJM6hfTOqZqhxY0QgED3gXAjHvZ48uM84uXafphL4tPLUU82XfpInAHa4NBbyCMYYz4jHBXuWwUEo2FkgiNMaR0TZHBr48EYI8+5578ohbs1RQujncWTjwgxwbtDnSNe7a0tAJPfjBwfgrqsvMNIKYTQzieoaXMgAbvwMZ88ZGRwDlfIrLAxm18s8p8Rkhc9w52HLRgADGfhk+ZKq3O1xXHDZ5ZhEW7XxNI2vHocg4+YwfiiVGS+U0dyZRyRzMLiWiRwAaXBheRjO7sDzjHlnKto9UUbqcTSw1MDHsjki8VrW+I15w3HPHP7WF9dpikdI55qKrl0rgNzcN8QEOxxn/AFHBOSPXHCu57PDJMZY5p4H+GyIGMjAa3dgYIIP3j3B7D0QepbrFFQRVT4ZwZXbI4AzMj3c8AZx5E5zjHOccq0q9RwUlEKmppK2MAPdIx7GtMYb3JycH4bSSfLKuZbNTOoKalifLAKZwfDJE7D2OwRnkEcgkcjHKtKvTNLVNeJamsw+LwX5kDi4ZLskkE5y49sDsMYAQfLtf/AimbRU80kjZGU7ZizMTZXloa08gnlwzgY8shfTqej8PcyGocXF4ibhrTKGHDnN3OAwDjk4zkYyqz7BTuqPENRVeH44qRDvGwSDndjGe/OM4zzhROp4bVp/Thr6uaaCmtdK5he1w3PjwPd5HckDkYOTwQiEncdT2e22SO73CvgpbfIwPbLM7bkEZAAPJPw7rXVb9ILRNPUmKOW4VLQceLFTe7/8AEQf9ly7rzWNy1jeH1lxleIGZbTUwcSyBnkB8cYye5WOMZJIHFkbnBoycDOES7y0f1J0vq2QQ2a6RPqiM+zygxyfg12M/hlZiDlfm/S1EtNURz00r4Z43BzJGOLXNI7EEdiuwvo/dRpdZWSWhu0gdeaAAPf2M0Z7Px6+R/A+aDb6IDkIgK0rblQ0L2MrauCBz/uiR4aT+fzCu1EVdrqJblUTw1EIhqYmRSslh3na0u4ac4wQ48EFBei4UZrPZRVQmpyR4e8bs4zjHrjlW5vtqDS76xpdoaHk+KPunz+XB5VkyxTgMjdVRmKGaWohxGQ7e/fguOecbz2xnhffs+GRPjhlawNt4oIfc+53y7vzn3ePggkp7pQU8ojnrKeN5wNrpADz2/Neqe4UdSGeBUxSb3Frdrgckdx8wo02BrhI10jSx9VDUbdn+mNrA1vf1YDn4rw+yVLbg6tp6uNsznzE74iQN4YARz3aIwPjkoJI3a3h8TDW04fKGlg3jLg44aR8yMBXqx6l04aeifAKgOeTTAPLOzIdnu9/Mhx/8ynacSiCMVDmPmDRvcxpa0nzwCTgfiUFRERAREQEREBERAREQEREBERAREQD2WmPpS1c1P01McJIZUVsUUmP2cOd/VoW5z2WBdY9NP1VoW5W6nANVtE0GfN7DkD8eR+KDhmFglnijc4Ma5waXHsMnutidUcaK1ybTpmP6vjtjYjHUx/rp3OjDi9z+5B3Ebfu/Ba7nikhlfFMx0crHFrmuGC0juCFNs1NVTuo/ruJl2jo2hsEdT5NHZrntw8tH7O7CIZJ1lt9JBcdP3Slp4qWa8WmCvqYImhrGyuBDi1o7A4zj1ypP6NNXNTdVKOKInZUU80cgH7IbuH+7QtfakvtfqS7y3K6yB9Q8BoDWhrWNAw1rWjgADyW7voraVnfc6zUtRGW07IzTUxcPvuJBc4fAAY/E+iJdQxHLQva8RDDQvaAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAqM0e4KshCDSXVTozQaqqJbla5G2+7O5e7bmOY/wDcB2PxH4grSlX0P1tBUGOKipqhmceJHUsDf/iIP+y7UfGHdwqRpm+gQcv6J+j7WS1cc+q6qOOnaQTTUri5z/g52MAfLP4LpOyWqltVBBR0MDIKWBoZHGwYDQFIMha3yVUDCD6BgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiD//2Q==",
+              "timestamp": 107698178010,
+              "timing": 2856
+            },
+            {
+              "timing": 3264,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAICAwEAAAAAAAAAAAAAAAUGBAcCAwgB/8QATBAAAQMDAwIDBAYIBQICCAcAAQACAwQFEQYSIQcxE0FRFCJhcQgVFjKBkSMzUlRyk7HhNDZCocEXYiSCJSc1VXOU0dM4U3R1g7K0/8QAGgEBAAMBAQEAAAAAAAAAAAAAAAEDBAIFBv/EADERAQABAwEEBgoDAQAAAAAAAAABAgMRBBIhMXEFFDJBUbETFSMzUmFyocHRIjSBkf/aAAwDAQACEQMRAD8A9UoiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAi+OcGtLnEBoGST2Cr0WuNKzXD2GLUVpfV52iJtUwkn079/ggsSISAMk8eqrp1xpZtf7EdRWkVedvhe1s3Z9O/f4ILEiAggEHIPmoq86htdlext1qvZGPxiaWNwiHzkxtH4lBKoqF1rqv/AFSX+po5+DTtcyWJ/cFzeQQpY6v09ZqSgprvfLdR1ToY/wBHPUNa7lo5IJ4QWdF101RDVQMnppY5oZBuZJG4Oa4eoI7qFu+sdN2erFLdb7bKSpzjwpqljXD5gnj8UE8i6qSpgrKdlRSTRzwSDLJI3BzXD1BHddqAiIgIiICIiAiIgIiICIvj3bWkoBcG9yAvgkYezgou5XGkt8BqLjVQ00OQ3xJnhjcnsMlYFHqWx1tSyno7xb56iQ4ZHHUMc53yAKCyouineT7p/Bd6AiIgIiINb9cJ5n2ex2hsz6ekvF1goauRh2nwXElzc+WcYVjq9C6YqLC60PstA2h2Fga2FoLeMbg7GQ7491mau07Q6qsU9rubXeDJhzXsOHxPHLXtPkQVT5dF6zqaI2yq1491tc3w3vZb2NqXM7EeJu7488ZQUQ325T9D6OhdWylkl4FkdXtdhz6bxS3fn4tG3K24zQOlW2P6pFit/sWzZgwt3dsZ3d93xzlc5tE2SXRI0qaYi0tiETWg+80g5Dwf2t3OfVVpuidaMpPq5uv5fq0N8MONvYanZ2x4ue+PPGUEN1BqqnQnRQ0+nbxNVmOVtGyuc8OfDG55BG4ebR7oPcLYun9OWy36cZbo4hUU80IbO+Y+I6oyOXPJ+8Tlddu0bZKLR7dMikbNafDMb45veMmTkucf2iec+qxXaeulssos+mK9tNTbPDZUVr3VElO3thjeM48tzjhBpWnnlp+kXVCwNlfNbrNXPp6N7jnbH4g9zPwx/utz6J0pZqPSdJGaWmrnVdOySpqZmCR1U5zQS5xPcHPA8go8dM6Cn6a12kqCpkj9tBdPWSN3vkkLgS9w4znGEj0dqO00nsGl9Ux0VtDdscNVQiodTjzEbtw49A7OEFU0/VzaQ/6o2qyEuoLPF7ZQxfeED3xOe5g+AIzhWnpZpKxw6GttS+jpa6quNO2pq6qeNsj53yDc7JI5GT2U1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93cu+GOAFXaLQWodPskotIat9hs5c50VJV0Tak0+TkhjiQcegOUHR0+hjsHU/Vmm7WNlmZDBXRwA5bTyPyHNb6A98LaCrOiNIwaXhrJH1c9wuldJ41ZXT/fmd5DA4DQOAB2VmQEREBERAREQEREBERAXCcZiK5oeUFd1GKk20+xCuM24f4LwfEx/wDy+7j/AHUFZW3f60g9qGovByd3tQofD7H73h+/+Suz4SD7vIXERPJ+6g+wD9IFlLhFGGD4rmgIiICIsOquEVPVx07s73NLycHDW+v5oMxF8aQ5ocOx5C6KiqENVTQloxMXe9nGMDKDIRR9BXvq6qpjMIZHE9zA7cSXEHHpj/dYgvrvHqI3U4AikDGnf979IGE9vLOUE2ii667ezVL42xMeyNrXPJk2uIcSPdGPe7fBfaG6e01pgMbWNO/adxLjtdtORjA/MoJNERAREQEREBERAREQEREBERAREQEREBERAREQEREBcHxMe9j3NBcw5afMLmiAuqengqA0VEMcoacje0Ox+a7UQdUdNBHM6WOGJkrvvPa0An5lcTRUp8TNNCfEOX5YPf8APn1XeiDpFJTjw8QRDw/ue4Pd+XouTYIWyulbFGJHd3hoyfxXYiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIIi832C2vEW0yzEZ2g4x8yoj7YO/ch/N/soG97/rar8XO7xD39PL/bC1/qek1FLq+2T2t1ULWxsYn8KZobnxCXZYSN3u4H48ZxheXVqblVcxE4h79vQ2abVNVVM1TOPHvbe+2Dv3Ifzf7J9sHfuQ/m/2WpKGnvreodwmqWVbrI9rfZ3+0t8Jp8MB2Y855dnnHddGnrfqWHWte65VE77HGZH0znTBwk3luGluc+6M9wufT3fj7s9zvqenz7ueOO//ALx4NxfbB37kP5v9k+2Dv3Ifzf7LS+nKTU0do1HHcWVra57JPY5JKtrw4nft2AH3CMt7/D0Xfp6j1Q3T18gu00n1jJHso5DKDz4QAcCCdp3cn45Kmb92M/z8iNJp5x7Od/P9tw/bB37kP5v9k+2Dv3Ifzf7LSlRSark0ZcWs9rF2kqWOhjFS0SNjGzcN27Azh3n5q5WNs7bPRtq2Sx1Aib4jJpBI8Oxzlw7n4rmrUXYjO15OqNFp6px6OY3fNeftg79yH83+yfbB37kP5v8AZaj0vT36LVd7fdo6w0L5JDSSPqmuiDC4bWiMEkHGefThYWhaTVsF6mdqJ1S6nMbtzn1DHxufu93YwDLRj4j5KZv3d/8AOPs5jSaeZiPRzvz47m6ftg79yH83+yfbB37kP5v9lprTVHqmLWlfNdXzmzOkqDA10wcAC9vh8bjxjOOOOfVYmkaPWsWrpJb3NI62Ey790rHMd+xsaDlv5DhT6a7v/nH2RGl0+72U75x3/wDeLeH2wd+5D+b/AGT7YO/ch/N/stS6cp77FrG8yXOOsNte5xpZHVLXRBuW4aI85B78/NdGkaTUsOrLrNeX1TrY8P8AA8SZpbkvG3a0E4w0d+O/ZRN+7v8A5+TqNHp5x7Od8/Nu23apgqJ2xVERg3HAduyM/HhWJamW0Lbv+r6bxf1nht3Z9cLTpL9VzMVdzz+kdJRYmmq33slERbXmCIiAiIgIiICIiAiIgIiICIiCIvNiguTxJuMUw43AZz8woj7Hu/fR/K/urcior01uuczDVb1t+1Ts01blR+x7v30fyv7p9j3fvo/lf3VuRc9UteHms9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6Vy3aWgp52y1Epn28hu3Az8eVY0RXUW6bcYphmu3q707VyciIi7VCIiAiIgIiICIqL1q1bXaL0HU3W1RMkrDKyGN0jdzY9x+8R59vzIQXpF5O0z1O6mV8tNU091ttzjkkG+jAp/Ga3OD+jG15/DKlperGsIOttRZ2uqam1R3GSmbbGU8e9zBkAh2zdj/X37IPTaLRtz+kNbrffbpbJbDWPfRSywhzJgfEcxxbwMcA4/Bdtj6/0V1vrrYLBVQvbDPKXuqGn9VE+QjG3z2Y/FBu1Fpax/SBstdYrvdK62VVHHQGFjYxI2R875N+Gt4AGNhOSuWkOv9k1DfILXJa66inqXbIHPc17XvP3WnHIJPA4PJQbnReYekPVvV1211NR3qSouVB4EzzAyCNns+3BD3FrAcDG3nzcFbbb9IOhrrHeLk2wVLG21sTnMNQ0l/iP2cHbxjug3ii0FU/SRt8FNRzHTtURUxmQD2lvu4e5v7P/AGqWn+kDYaezVFfNba5rhVOp6aAY3TtaATIc42t5HqeUG50WlrH9IGx3SgubzbKymraOmdUtp5HtxOG92tcOxxzyOyaT6+W/Ud3tlugsVZFPW1QpyTKHNiBxh5OPUnj4IN0ovMP0qb9d7VrK0xWu619FE+gDnMp6h8bSfEeMkNI5V61F170/Yr7WWk0dZVPo2Pa+dhAY6VrfuDz5Pu7vI/DlBuRFQekvUmn6i01ymprdLQiiexhEkofu3AnyAx91VXVv0grDYb/VWumttbcPZZDFNPG5rGbgcENz3weM8IN0ItJ376Qllt9BaqyhtdVWw10bnkGVsboXNdgscMHnz4PYhZH/AF9sDLNX3Got9bGyGoFPTRcb6nIJ3AHG1oxzn1CDciLR9D10tGp7Ff6SGnr7Tc4rdUTwHc0l2yNzvcd5OAGRkeSq3RzqjHp7Q2oLnqWuu1z8GrhihZNJ4ji57XkNaXHjhhJycccD1D0yi0hYfpFWG4VYir7TcaGNzHvbNlsjcNaXHPY9h5Z5WLT/AElLJLV7XWG6Npdwb4wcwkZ9W5x/ug3yi0rfPpDadtt2uFDBQVtWKUOaJ2kNZJIDjaO5A7+98PjlR0v0jqCO0U1edO1RbPPLAGe0tyCxsbs52+fiD8kG+0WotM9dLHe9V0Vidbq+klq/DbFNKBt3vYHBpHBxk4BxzwexUZfvpF6ftt5qKKktddXQQSGN1SxzWtcQcEtB7jPrhBvBFqbUnXXTVosNpuNNDV10lyjMsVOwBjmAOLTvJPHvAjjPYqU6XdWLR1AqqmipaapobhAzxTBNg7mZAJa4ehIznHdBsVERAVI6w2i/XrRzqXS7aeSuE7HuhqNpjmjAO5hDgWnuOD6K7og8ds6Na9ut+pXy2CisrA5u+ogqIwxmDnfta9xz/CB2Vx1V0z1vbur/ANqNL00FbG+cTsmfKweGS3a4Pa4gnz7ZXpNdck8UTgJZY2E9g5wCDz3036eaptHXGuv9ztXg2mWorHtn8eJ2Q8u2naHF3OR5KO1R0o1lF1Tu98sVLSVNHWGpkZLJM0Bomie1zS0kHPvkDyzgnjK9Lte15Ia5riODg5wvnjR+Js8Rm/8AZ3DP5IPI9j6Iayn0lfaStt7KOsM1NUUrJKiNwn2CZrm5a44OJAecK7aJ0x1PqtU2KTUtBa6K2W5scZkfBSySGOPkNaW7nAn1BGO69AunhbJsdLG15/0lwB/Jcfaqfn9PFx398cIPNmjul2t9J9TKmejpqeWz1fiU81b4jCPZ3uBPukhwdwPJVum6N9QLbZ9Q26G20k0NU2JoLahmZtkocNmXDHmTux6DleuWVELyAyWNxd2w4HK1VfusTbT1Vi0WbIZS+qp6b2z2rbjxQw52bPLf2zzjyRDRVf0Y19LQ2qNlgJfDC5sg9rg90mV7v2/Qhbq+kD06vGsY7PcNOeE+utxcDTveGbwS0gtceMgt8yO6xqzrwaalvcz9JV8YtsjWDx5vDEmXhvJ2na7nOOeM8rYHTLWbNcaVp7z7IKAzSSRiAzeIfdOM5wM/kg0nQdPOodxt+oai9W620809HJFFTtZA6eeQt2j9Ny4DHOS/4dle/o36QvmkNO3am1HQexzz1QkjaZWSbm7AM5aT5q+6wv8AWWWCBlrtFRdK+oJEcbHtijbjHL5HHDRz8SVNipY2GN9Q5kLntB2ueOD5jPmiWgPpHdPdUav1VbazTtrNZTw0Qie/x4o8O3uOMOcD2IULe+lWvaDU+q/s7HSy2u9QzGSVz48ua4l/hYcctcXe7nt55XpxksbyQyRjiBk4IOAkc0UhIjkY4juGuBQab+jXou/6OoL7HqSgNE+plhdEDLHJuDQ7P3HHHcd1SK7p11G0vqjUb9I0VHX2+7ueHSyGF36Nzi4AtkI5GcHggr0wKqnIJE8RxyffHC1/1h6nN6cR2l5tRuIrzKBio8LZs2f9rs53/wCyDS2u+k2vbpbrDi20lZWRwyGoFJ7PTsiJdw3ALQ44AyQPP4LZ3XLp1dtYWCwy2PwfrK1Z/QSODQ8ODc4J4yCwd+O62bpu7svWnLTdXRin+sKWKpERfu272B23PGcZx2UhHPDI4tjlje4eTXAlB5nj6Za+1JeLzqLVdNSwV/1ZUU9PTwvjBnkdA6NjfdO0D3u5P9sDTPSvW9DoS82+awUUlTUV1NMKasmjc2WNjJQ7a5r/AHXBzmc5acZ57r1OKiEvLBLGXDuA4ZCMnhkDjHLG4N7lrgcIPLukumvUqCera6ipLbbfAmDLdU1LainLnMIDWsLn4y45yT6/JYVm6YdSoL1D9W2qmsFOXN8Z0Nbuglwe72GR5d8sY+C9YRyxyAmORjwO+05XFtVA4EtniOOTh44QeWbh0j1/aqvVNusUNLUWe5t3GQvjDpmtfuYwBxy13PPYcd+yr9R0a16/TNBSNsJNRFWVMr2e1wcNcyANOd+OSx35L0x1D6j2PQX1f9eCrf7aHmL2aMP+5tznJH7Q/wB1ZLTdqS52aiudPJtpayFk8ZkIB2uAIB+PKIeb4umGsG9WdP3g2ci20ptpmm9oi93woYWycbsnBY4cDnHGVi0/TbqZpGpvds0zQUNda7g8Znl8B4cxriW5bIeDzyMEL1Q1zXtBaQ4HzByomXU1liv7LHJdKRt3eNzaQyDxCMZ7fLlEtA6z6SayqKXTN4oDQVV9oYdlRTwbKZjXCR0jdm3a3/UQe3bKuXRLSer7XebhdtXU1tohMxzWQQwQmZznOBLnSMBJHHm4k557LcaICIiAiIgLyj9LsluuLKRwRbwR/NevVy0j136UX3X+orfX2aptsMNPS+A4VUj2uLt7ncbWO4wQg0/o641ts6gVztFXS43EyWuonqHzMcHOm9nc525p7kS4wT5+vnT/ABbd9mxeBfbh9r/bf1GHY8PGfE8T9rPx/DzXuiy6ctNnnqKm3W2kpquqO6omijAdK7uST3PPKrNvtnTev1M/6vg01UXxj3PdHCYnSte0+8S0diD3OEQ8264rqiLq/pa6agJgmMNrqap7xjBDYy8n5EO/JU2KRsr9ZSRncx9OXNPqDWQL3TeNM2O9VdPVXa1UVZUU5BilmiDnMwcjBPlnyUT/ANONHZqT9nbfmpG2b9H98bg7n/zNB/BBpf6MWh6S40NJqyatqxVW+smiipwR4WDG0E4xnJ3evkFX9e//AIrqX/8AdLd//SFeo7BYrXp6hNHZKGCipS8yGKFuGlxABP8AsPyWDV6M05V39t7qbPRy3Zr2Siqcz3w5gAac+o2j8kS8I2v/AAGof/0rf/8AREs2OenptPWeqtt4rvtDDVPa2ka1wbBHnc1zHepcTwP+OfaUfTPRcbJms03bmtmbtkAj+8Mh2D+IB/BZdDoXS1BNSS0lgt0ctISYHiEExknPBPx5RDyNruolu3Ui/N1vXVFHJAHCAEuAaQBsAAa7gjnsM57hRur5/F0FpiOO6VVxp4qmsbG6eAx+F7sBLGkuO4ZOfhle0b/o7TuoZ2z3uzUNbO0bRJNEC7Hpnvhddy0Ppi50dFSV1joJqWiDhTxGIBsQdjdtA7ZwPyQeetT6Un0b0RbfLJcLhLUX2Gh9uLnD9FEYycNIAIbktb8uFS+nf1ZRax0zPadQVsNdK+Lxo4YHTbpC7DozwzAI4/1cc5Xriiu2k6s/ZmkuFnqHRMNKba2aN7g1gwWGPJPAGCMcYXKy6J0zZK41tpsVvpKvBHixQgOGe+D5fgg8hdDtGUuutUXG1V1ZVUtO2idO405AL9ssYDTkHjnPzAWy/pfRCC36PhaSWx+0sBPngRBb00/ozTmnaySrsdnpKGpkYYnSQswS0kHHyyB+Sj9ex6IqH0cWuZLMHMDnUzbhMxhwcBxaHEegQeXdV1gn1Louk1Jcq23WOnslC+GamaXOj/8ADtdvaB5+IMZ+HwUx9FI7uqVwduc7NtmO53c/pYuSvTc+ldOXGntfjWmgqYaBjBRF0QcImgDaGn04HwXyxaN07YbhJXWaz0lHWSMLHyxMw4tJBI/MD8kHlrrOyo0J1hu1bQN2sudJJIzyx40bo3n8H7j+SjK+23LT/Qu11lN40MN8uL5Kp7MgmNjdsTCfQkSO+PC9dai0jp/Uk0M1+tNJXSwtLI3TMyWgnOAsx9jtcllZaJLfTPtbGCJtK+MOjDR2GD6IPJ3SAW2h6l2xlgv9aRKza+BkDpGzZYS9ryQzAGM52nGO5WvNOUftGntU1Hjzxmko4pAyN+GyE1MTMOHmPeJx6gL3PYdH6d0/NLNZbNQ0Usg2vkhiAcR6Z74+Cwafpzo+np6qCDT1vZDVMEczBHxI0ODgD/5mg/gg8Z34zVfTnTNZUOllfFV1lGJHuJ2xtEL2M+HMkh/H4LJuVXba+52C3T109NpqChiDSHPDWyFm6YjLXHmcyDIae3HGF62ntvTygpTpeoZp+GKSbxfq6WSMEyEAZDSc7iMBSc+gtKT22noJtP219HTkmKMwDDM8nHmMoNVfRWljFJfKaku9XXUkbmOEMtOWMhcd3LXEnOQBkYHYKRu//Tv/AK+U3tnt51Xujxj/AA3jbBsz57tu3Hl2W27LZ7dY6FtHZ6GnoqUHIjgYGDPrx3PxWPJpqyyX9l7ktdI67sG1tWYx4gGMd/lwiUuiIgIiICIiAiIgLxfpC2VN66qaytlAGmrq4LnDEHO2gucXAZPkvaC1JobpBJpjqPV6pdemVLZ3Tu9mFNsLfEJP3tx7Z9EFFvOtNS9LNNaT0VQU1F9eugdJNJM4PY0PmeGBpyB65JOArFoXXPULUFDfrfX2qOmuVPTPloq9tOfAfI0j9GTktdu8iD6q1dWOlVNr2robhDcprXdaNuxlRGzeC3OQCMg5BJIIPmVD6S6NVGnLffJItS1FRfblTupm1skR2wtcRucG78lx9S7hENX23rrra7OtdooG0f11UVhhdI6nG1wdsDBjPBB35PyWZP1s11c7lWt03S0E1LQkNLXRAyzDON23dkkkE4aOFOw/RuNNTUL6PU3g3OnqHTGqFIeR7uwBu/gtLXHOed3wWVdfo8GeuqZrXqia3wVmDU07Kcljj3cBh493OSAc49SgrmuututLW6yeHQxWqoqKES1FNU0xz4niyN3N3chpDWkD+q74ututYda3m0T2y3SvpxVBtMDjwTEx7id+feADDn18sKf1P9HiG5ttUduv76aKhpBTuM9P4z5Xb3vLyd4x9/GMcYWc/odK7Xt21H9fsDa41hFP7Ics8eORn3t/O3xM9uceSDX3/X3Vc2jZ6ljaCO409dFEZWw5a+N8cpwWk8EGPuPVStn63axpK/TlVqG2Un1HdcRtka3D5AHBj5G4PBBPYjt+aq3VLpXN070UCboLka+4Q8MpjHs2Rzf9zs53/wCyufSXo3S3e36Y1Lc7pUyUkcYnZbXN91sgeSfeJ4aSASAPxQa+st/ZpbrnqW9yRGUUdTcpBHnG92ZA0Z8skhW2y9ZepFdJT3Cns9FcbfLKW+zUsJc/APIw1xc34Fwx81dafoNA/W13vVyvAqaK4vqnPpG02xzRNuxh+48tLgc48lF0n0cvDqoIqjVtZJaIpDIKVkJY744O8gE+oag2F1a19JorQcd6pqQurap7IYIZwQGPc0u98d+ADx6rzD1jvuqL63T0+sbbHR1LqZ0tPJHgNnieQQdoJwR6HntwvWevNDW3WOkfqCrdJTwx7HQSx8uicwYaee/GQfgVqK5fRvlrKajY7Vs8ksDSwvnpzIAzPutYN/ugD59/JB0au6t6npNSQaZ0fTUIdSUsQfJU7d0jvDa44LnBoHIGO5WzOjOrr/quyVT9U2eW3VtO8BshhdEydpBwWh3mMc/MeqretOh0d7vUV4s9/qLRcTCyKZ8cZcHlrAzcMOBbkDkZKuHSnp9S9P7PUUsNbNXVNS8PmnkG0HAIAa3JwBk+Z7ol5K1K65S6rrqnW9Zead75HOhqYIvFYeTgsy9o2Y7bT2V3k6l33RWhtPRaevlPdI6iWq3zzxue8Bpj2tIfy0gOPHI5GCVca76PFc+Keko9a1UdskeXeyyU7nN75GQJADz8FIXH6PFtqNJW21U14mhrKSWWZ9U6EObK6QNB9zIwBsbjnyRCHb1b1QerFssHi0n1dUOpA8eAN36SGN7ufm4qF0R1Y6navrKqhslPb6yqjjEp/Rsj8Nu4An3nAHvj8Vc7X0GloNbW6/8A2lkqG0j4XmOanLnv8NjW437/AD28ccDA8lMdHukEnTy+1txfem3AVFN7P4YpvC2+812c7j+yg8/6at1bdevD4bqaaarhus9RWFxcGO8Jznybcc9mO2+WcZ4V1b1u19eqqsrNO223uoIZQ1tMI/ElIJ443b3H1LRgfBbH070bdaeqdVq+W8sqIp6iqnNH7MW8TB427957b/TnCr1f9HNpraltp1TV0VqqJA99IYS7gHIGQ8A48iQg3Po27VV80xb7jcKCW3Vc8eZaWVpa6NwJBGDzjjI+BCmVFaWsdNpvT9DaKF0jqekj2NdK7c53OSSfUkkqVRIiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiKMqp6r2mVkB2sZxwwOycA+ZHqqb16LNOZiZ5OqadqcJNF0U0kktI15aPEIPB4Gf91gUNwqZp6VksUTWStk3FriSC12MDjt8f8AYKyiqK6YqjvczGJwlkVfqLpWx01fPtibHDN4TCWcfrA3JO70J8guyO51JqaOAeFJ7Q0ObI0cYBO/OCR2xjnuV0JxFAQ3eqdNVNfHEGxztjadpGQZiz154HfjlcHXmq8KscwwOfDP4TWBm52PE25I35PHyQWJFFVNyfBZIqyR0Ucj2tPPvNyfIc/8rF+uphJL4ngMYyMvPBdsw1p3Eju0kkDCCfRQVDeJ6itpIXsjDJWbi5ozuPvdueMbRnvycKdQERYlbJLuEcJLTsc/IAJOMcDPzSIyiZxGWWixqKVzw9r3btuMOIwSCM8j1WLa7hLV1tXFKwMETsNbjnGSMk588ZxgceqnBE53pNFX6G+VFRVwQOga0mSRsjsHGAHFmPntOfkvhvVU19LmBhZNHTuL2g+66R2CCPTAOPioSsKIiAiIgIiICIiAiIgIiICIiAseWkilkL3bg498OIyshFzXRTXGKoymJmODjExsbAxgw0LkiKYiIjEIERFIIiICIiAiIgLrmhZMAHg5HYgkEfiF2IhjLhFEyJm1gwO55ySuaIgIiICIiAiIgIiICIiAiLpNTEKttNu/Slpfj0CiZwmImeDuREUoEWBcq72fDIsGTuc+SwPrOp9W/krabNVUZhXVdppnCeRal6kdRLtYamjt9mp2T11T72SzIaPl+BVOu3VHW9N+qhia4DkGkyM/NU11RRVszO9dboquU7VMbnotF5hPVLqZh8gpaYQtGcupQM/LlbJ6VdQbjqyyzSXBkMdbTybH7G43DyO3y8x+Cm3MXJ2aUXIm3GaobVRQP1nU+rfyWZ9YTvpGvpKYVE4e1r4zIGYBPLsn09FZVaqpjMqqbtNU4hJIo/2m4f8Au9n/AMwP/ou6jfVySSOqoo4Y8AMa1+455yScD4fkq1jKREQEREBEWDeaielpBLTt3bSd+GlxDdp5AHxx+GUGci6J52ikklieHbWFwLefJdzHB7GuaQWkZBHmg+ovjyQxxHfHC8uXDrJriDqPJYYzR+D9Y+zMj9mBcYy/A5z+yQcoPUiLzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiLqnnjgMfinHiO2A/FRMxEZkdqIikFW6FxdrKsye0eB+TVZFWbf/nKt/g/4aqL3Gnm06fs3Pp/MLMuuolEML3u7NGV2KOvb9tO1o/1O5WminaqiGSudmmZQ0j3SPc9xy4nJXFEXosCh1tD7RreqqZmgmJjWR/AEDKn2wsDQC0H8FjXOBzbxPI3hz2NI57jssaA1ranD9ng+rHE4/NfM6mfb1c31+hjGnoiO+Hy9QNdA4bRghV3pvF7FrK5QRjEc9P4px5ODgP8AlZdZNWVBkw1hjaSMOeW5Xb06pX/XVfUuydsLYyT6k5/4Vuin28YZuk4zYn5NhLvo5zTzteO3Y/JdCL6GYzGJfNROJytgOQCixra/xKKInuBj8lkrzZjE4b4nMZERFCRF01kxp6aSUM3lo4bnGT81ixz3M1MLZKGnbC5xEjxUklgwcEDZzzgdx3ygkEREEXdWWq2UVVcqylgbHBG6WSRsILsAZPYZK5UdDRyxxVNI6oZG9ocwNmka0A9vcJwPyUi5oc0tcAWkYIPmvqDGdSOP3aqob8iD/UFVd3TqwyX8XqWEvuQGGzlrAQPThuPh6447cK4ogqN96f2S/XKmrrxEauencHRmRrPdPHo0Z7Dg5CtcMTIImRRDaxgwAuaICIo603CeulrWT26pohTzGJjpi0iYYB3t2k8c+aCRUHq8kW+MjuJAf9lOKC1h/wCzY/8A4g/oV5vTH9G7yXab3tPNNxnMbSe5C5LjD+qZ8guS9GnhCkVZt/8AnKt/g/4arMqtSSCPV9a4gn3PL5NVN7jRzadP2bn0/mFpUVfc4h9Of+Fme2M/ZcsK6ytmpxtaQWnPK2Wt1cMNyYmmYhEoiLcxoa7scyujmI/RuZ4efjklR0tY2NznFzdreAzOPxTWd8bbq6y0JjDzX1Doy/P6vEbnD8yMIRDhxIDXHzwvndfTsX5x3731vRVe3poz3bkJT1kb6qZhe3a88MznHxU1oSF7frGY/q3yta34kDk/7hQNwmgppi7LS/19PirNoOugrLEzwuHtc7e09+TkH8Qrejrc1Xtvuhm6XuxTa2PGVjREXuvm0/Zxiib8z/VZqgKe7SU0QiFqrn7cjc0xYd8Rl+V2/Xkv/ue4fnD/APcXn176pluomIpiEhdal1Hb5p2AF7R7oPbJOBn4crr8O5fvVH/8s7/7iirjcZ6+kdTMtdZEZHNG+R0W1o3AknDyew8gpr2xn7LlziU7UOiWlrp2iOarpvDJBcGU5BIBzgEvOPyUgsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkosb2xn7Lk9sZ+y5MSbUMlFiSVn6N3hsy/HuhxwM/FULQNx1lJqfUbdTQUTbaKkeB4T3kt/RtwI8jluMZJx725MSbUNkIsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkqC1h/7Nj/8AiD+hUp7Yz9lyhdVTtlt7AAR+kHf5FeZ0xE9Ru8l+mqibtPNYYf1TPkFyXGH9Uz5Bcl6NPCFQqlH/AJsrv4P+Gq2qpR/5srv4P+Gqq72qObTY7Fz6fzCXXF7Q5pB7FckWt5qqakvdPYo81AdJK77kTO7v/oFQbpre6VVQ1tJG2lgDXOdt5c4YOBkjgrZWrdOQ36jxwyqjB8OT5jsfhytRXC21FHN7PWRGKXducCMAHPugeuSF6mlqt1xv4s1ymYn5MC/RvrrdM1gkkr97Z43l3vb2nG7J9B/VXDS9c+6WOCadofLtw4EgEOHfKrMrZI6hs0R2StccZGRggNPH4ZWTbRNT0kjoJ2sDow/BBw4k+Xx81k6S0E6nFVPGHq9F6+nS5pr4Si7vUiXUctK8NMccZkMbXZHcAZ9e5/JR0NbVNubqimMlO9oDQ5jiCRnjP+6z44HATOe4GSbAkfjJOCTtB/Ht81xZTnxmgYwHbTznLifX4bT+a26XT06e3sUw8/VXqtRcm5Ul9P8AUG7UzR7e1tXCXluXDDhjsAfj8VtHS15ptQRGSmDmmPHiMcPu/j2K1RpzT1Vdm08FLCcOO98h+6wcjJ/Jbs0/Z6ayW5lJStHHL34wXu8yVXqqqKIxHFXbpmZ+SSX1EXmtAiIgIiICIiAiIgIiICIqL1LqdXQPtH2Up6WSJ1bEJy97t2M8hwAwGepzn4KCIyvSLppDOaaI1bY21G0eIInFzQ7zwSAcfgu5SCitRf4Jn8Y/oVKqK1F/gmfxj+hXl9Nf0bvJp0fv6ea0w/qmfILkuMP6pnyC5LdTwgFUo/8ANld/B/w1W1VKP/Nld/B/w1VXe1RzabHYufT+YS6Ii1vNFgXW1Ud1h8Osha/H3XdnN+IKz0SJmJzA13c+n8viSPoKprmu7Ml4LeMd/PlQ0Wkr3FROiNGQ8YY3bI1w2g9+/wAfTyW3UWmnV3I+aubcS1DFoy8SvJNK1vOG73hob6nj5u/NT9n6esiMLrjVeIIyD4cQwHHjufwP5q/olWruVbuCdiGNQUVNb6VlPRwtihYMBrQslEWaZzvl2IiICIuipqoaZoM7wwHgZUImcb5d6LjG9sjGvYctcMgrkpSIiICIiAiIgIiICIiAorUX+CZ/GP6FSqitRf4Jn8Y/oV5fTX9G7yadH7+nmtMP6pnyC5LjD+qZ8guS3U8IBVKP/Nld/B/w1W1VKP8AzZXfwf8ADVVd7VHNpsdi59P5hlXm6UdltlRcLnMIKOBu6SQgnaM47AE+aitN6009qV07bLdIal0DQ+Ru1zC1p7HDgOPiuvqTZqvUOh7tarf4ftVTEGR+I7a3O4Hk/gtLw9HNVMstwot9tEs0EGJzNIXzbNuYHHsGDHGB/patTzoiHocVdMQwiohIk+574975eq+CspixrxUQ7XHa07xgn0C0A/pBqRuk4BR/V9Jeqe4GpgiineWRxubhw3OzzkN4AxwuF+6LXw0Niht3sFWynofAnhqJnsbHO55c+Ru3vy7HrwEynEeL0G6rpmvLHVEIeCGlpeMgnsF8FZSlwAqYSS7aB4g7+nzXnm+9HNTVlRdJYnUT5ZXUhgk9ocP1ce155ye+MZJK5UPSHVdPeKRzpKE00F5FeZhMd5ZluTjHcY7eqZMR4vREc8Ukj2Rysc9n3mtcCR8wqu3qJpV2oPqQXZn1p4/s3geFJnxM425247/Fa76V9MNQaZ1lHcbmaDwIWSNfURTSOkqS7OCRkDzHcHt68rGh6a6rp+ol3utOy2Cgr6qSQTSSEyRNduw5oHZw3Z+YUZkxDbupNU2rT9mq7nXVAfTUpaJRDiRzS5waOB8Ss613WjuduirqWZhgkjbJkkAtDgHDd6HBC85wdF9VC011L7NaIZXQCETR1MpdUnxQ7LsnaOB6eQ481Iy9H9UNprxTUUtHT0tVDSO9nE7gyeSNrQ8PwMgE7jnzTMmI8XoM1MDYRM6eIRHs8vG0/ivktXTxFglqIWF/3A54G75eq88VfR3VMmn6aJr7cQytmqPqnx5PZ42va0ANcecjB8/Pv3Xy8dHdS1DbM1lPbZ5aWnbC576uQxNG5xLdjgXHG4YIcPkpyYjxej1Bar/UQfxH+imoWlkMbDjLWgcdlC6r/UQfxH+iirgov+7lqD6Qurb3pqi02yzXmS2QTRyPnELR4ku0N2hri0jzPGRlVGn6s6xsVdXVVwq3VcLbFT1dJT19IYxNI50Qc73Mc4c898Lc+uOoVBouns1LVWysuVVWxPkjhpmtO1kbQXOO4jsD/so2PrRaZKq5MbZbuaa200dXV1Phs2wsfF4jcjdnJ4bj1+HKLqOzG5UdYdYdX6UmiiuNusj31FqFxgMMczmlxkwGElw7N5PxWJSdaNVXe9VFpp6G2000lPIIoRFOakO9n3tmHBYWF3YHnH5mfqetlJcaq0RW6lr7fO+5U9NUU9RSMle+OVu5mCJBtDgO4yfgu5nX2zOoKyt+zt6Hsr2xvbsi3tySMvG/LBx/qx3Cf66x8lAtHXXU1q0vbhVto7jVOoJ55J6mCQPM7ZnARnaWjhm08DzHKtVs6vavr7Zqa5wWe0z0tkhikfDG2UTSGRmQRyRtack/9o/FSlx+kFp6ipmTvs12kxA2aTYIiI9zy1oJ34OcZyMjGF2P+kDpuCvlp6q2XSGOOompnTbGFu+NuTwHZ548vNP9MfJWbN1s1beaux0NDb7C+ouVZJSMqSyoEDsNaQRnB4Lue/4KX6s6wvulepNolo3S1LIrJUVMtBG9whllaHclo7gd/XAUpD10tJtJrJNP3qOR00ENPT7Iy+czNc5hbh2OzSefUKYu3Vq0W3Q1r1RPbriaWvqBStg2NErHe93BOMe6exQ/xH9EepV017cb7T3SmoIo6COndE+kZK0SeIHEk+Jzj3eOB+PdbZWm5+vunoadj22m8PnZ4pqoGxM3UzY3Bri73sHk+RK+1HX7TsVU6GO33KVvtgo2yNDAHEjIcMuzjH4qcomJ8G40VS6c60i1zZjdKS119DROx4MlUGgTcuB27Sexbg5VtRyKK1F/gmfxj+hUqorUX+CZ/GP6FeZ01/Ru8mnR+/p5rTD+qZ8guS4w/qmfILkt1PCAVSZ/myt/g/4araoqptv/AKTNbF3czY9vr2wVxXRNU0zHdK23ciimuJ74x5IjVUNzqNPV0FilZDc5IyyCV7sBjjxuzg9hk9lRY7X1NiohGy828yMpGtBc1pLpg4AnJZ2LAXZx94+i2iWkdwfyXzB9D+S0MTXEtu6hVFmvUE9xoo62VsXsUkDw0RkOG/nZkZbnvnnyCwp7H1H8OllgvVOZ4XPaI5Hgt2FrACSIxufnfy4YBwcd1tTB9D+SYPofyQy1lqWya/rqihdbLvT0zRQNjqh4mA6fD9xADfPLcEYxjsouq051Ofdo6qG80TWQt2Rs8d+wgB2C5u3BPLck5yR6YC3Dg+h/JMH0P5IZVPRVLqyGapk1ZX087NrGwRQNbjO0bnOIaDnIPw5+StiYPofyTB9D+SIFBXvV2n7IS26Xejgl/wDyvEDpD8mDLj+S+a8ZcX6NvLbMJfrA0r/B8P7+7H+n4+nxWv6Kp0taZKKeyTSUlE5kT/ApaCR1bI8AhzZCGbiSdpyT3yomcOqacrJV9QHSRudZdP3SsYAS2epa2ihcAMkh0pBIA8w0qOqL1qm4Udwl+srRa4qUs8SOghfW1DdxGGgu2szzjscFYdLSXKrkndbNKXGfx3bnz3qpFKx5OCS6Nu95yQDjj0+CnKXS+p5nvfU3yjtLZBte200Q8VwznmeXc48k+SjfLvFMIW6WaqpaC6XGu1BqSmqKSmkqIa+oqmshEjCdrDEGhhDhtOOTyRxjmyyVtRcdK2WtrYvBqqiBksseMbXOYCRhc6Xp7Y2VTKu4x1d3rGkET3KofUEEdsNcdo/ABSWp4nuggDGOOHHsPgkxuZ9TMTbnDWfWO66bp36Ztup9NwXgVEE80Uss5i8Dw49xGQM4dxn5eaidFa+0C6+XOhrrNbrI240dJHLI6fxYqprowGRbdoAa1pxngKw9UbBp28V2mxqOtudJOylqmQey07nsLXRYeXkNOMDt2z8VGWXoZpa40lLXU92vNRQVENO0xkiNs0cWNoeNoPJaCexGPJSsoxsxlxoavpDR1tfbW01opqezzisD2yPcXStO1zgB94NyB3PnwByeojoXFQCMi0tgrJcgky7iW8Z3d2t97HkPyUw7oJYM3dsVyu8dPcGvb4DZG7Itzg4ke7z243ZwpDUXRqy3uezTurblSTW6kjod9M5rTLEzGN2WnB47jHdHWYYVDYukmp7obHRW611ddQRPp/Ajje0xtjeC4bhj/Ue+cnJ5PKqulr50muVohvF9tFvs1TJV1EzIKiZ8xe5uA+THbntgjnGBlbc0Romi0g+8voJaiZ1zrH1shmwSxzu7QQO3zWq63ovpCjuFs0/JdL9HX1kNQxkkLfdljJ3lr3Bm0AHkA4z8UIWKrsvSSzWKnpKuhttPbb0z22HeyQ+MI2btwd3GGuOBkdz6qL1ZL0x1HZNPaWgvtLbKSKeKspaaCMgPBB2tO4YG7cTzyc/FW3WHSiz6p0bZdPV1RVxxWlrGwVMW3xSGs2YJIxgjGePIKuHprpOu6kSx0VXeKS4UNPTunpoWFkD2sYGMw8t54xlrXIQi73e+izdNxyRUNtuMFqjNTDS08JEm10gae+M+8RkOPxUju6PXW826etp7bDerqIaxkUm9jw+RoLA7adrXHI48+/OcrGreh+kbDZjLdLtc20MNE+hc523OHyl4d7rclwc7jjyWVpTpVpa43G36gs18vFR7IIYpCXbPGdC0NZuywOHu7QQMAhDc2FpyWx2OvZo+y0stL7HTe0sibE/wmsc85xIeCdxJxnPKsqgqyiFtu9bqKqudw9jjoyx9FndAwNO4yNYBnfgYWRpi+0mpLPFcra2oFNIXNb48LoncHB91wBUuUqorUX+CZ/GP6FSuD6H8l8ltxrfCEnuxteHHPn8Fi6Ss1ajS12qOMxhdpqoou01T3JWH9Uz5BckRaIjEYdCIikEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBdT52McWkSZHpG4/wBAu1EGLV1jIKCpqfeDYY3SHc0jgAnz+Sr0FwrLa6BlVVurJTQiWZkgaNsxLWsA2tyNxLuME+7wrRPDHUQSQzxtkhkaWPY8ZDgeCCPMLGbare2mfTtoqYQPcHOjEY2kg5BI9eAhKHpdQVNW+OCnpozUOqXw7nFzGhrGBzn4Izw5wbj1Sk1DPUS0INIyOOoZGRI5ztri7khrg0jIHYOIJU3TW+jpn7qalgidzyxgB5xnt67R+QXyG20UEjJIaSnjewBrXNjAIAGAB+HHyQQVyvb6O/TxMbLM0tigYxrHvDX4e9zi1gJ+7s8vMdu6N1JUOpaWYUQY2UO3SSbwwEP2gHDCWh3cFwCnpqCkm3+NSwv3v8R25gOXYxuPxwAM+i+G3UZfG80kG+MBrD4Yy0DsB6YQYN5u01BVQxMp2mN4BMzy7YHFwAaS1p259TgLHF9qNhqnQUraFxkEZdPiQ7cgHbjzIxgZIyPkpiWipZahs8tPE+ZuMSOYC4Y5HK6TaLcTOTQUuZ8+KfCb7+Tk54555QV6s1DI+kcZg+nEFWwSOjD2ktZH4zhhwB7Nx8crPtWoX1U8rKmjnia2Jsvu08u5uSRtILAT8xkd/RSsVsoYXExUdOwk5JbGBzjbn8uPkuyko6aja4UlPFCHdxGwNz+SCLkvmxxHhN96tFLHl2C4Bgc52PgA/j4LDg1FWvpKWc0MUhqqR1VFDFLufxtwDx57/L5cqWr7NR1UdSWwQxVUzHN9obGN7S5pbuB9cHC5Q2e3QwuijoaZrHgB4EY97HIz688oMNlxqaux1U1OYI6rLoodxc0b+wDg9oIdnjBHp6rAivUlJBK10tRLUNlIkjq2tLoQ1gcT+iaQR7zefLdyfJWJ9DSPozSPpoXUp7xFgLTznt27rpNntpZGw0FKWR7to8JuG574488DKCG+08hFA5tKMT+ztezLiWPlIy3IbtBaCDyckeQXZaquqdeRHXVMwMolkhYzw3QSRBwDS0gbgQHMznuSVKts9ta9rxQUoe0tIPhNyC3Ab5eWBj5L4yzW1geI6Gmj3uDnbIw3JDtwzj/uGUQj73c5KS70zIjkNge8xknD3ucxrBgAk8bzgA9lzgvrnWOSudBmQTmnYwEtD3+J4be4y0F3fI4UnU0FJVEmppYZSduS9gd90kjv6EnHzKNt9G2kkpW0sAppCS+LwxsdnvkdkSiJLvcIp4aV9NSPqXylrjHOSxkYZuLj7ucgloxjnI5XS7UU7aVtS+mZ4E9FJWQiOTLw1oaWh2RgE7h8jxyp6moaSl2ezU0MWwEN2MDcA4zjHrgfkFwhtlDCyRsNHTsbJjeGxgB2DkZQQ4vlXFJPA6kL5YY3mNr3EPqNuAHNIbsOSRwDkZ7eS65tSvjo3ymOHxGb3ObiXLGNaCS5uzc3k45488+SnPqyg/Sf+Dp/0n3/ANGPe5zz+PK4SWi2yNYJKClcGNLWgxNOAe47digi33+o3F7KWMQRvp4pdzzuD5duQBj/AEh7T8V1nUk8VAy4T0sRo54hJTsjlLpnbnNawFoHnvGcZx25U8yipY2FjKeFrS5r8BgA3NAAPzAaPyC6orTb4WTNioaVjZv1gbE0B/nzxygwrZejUU1wmqoXRNozlzjG9gI27jw9oII+Xp6qPfqiopaenlraJn/iKZs7GQPdIWuc9jGsdhvmZByAex4KnKm2U8trqKCFjKeGdjmO8NoHcYJwuUdroIopY46KmbHLjxGiMAOx2z6oIu23+WqqWQSUxYTUOhLnNez3RFv3Br2g5zgYI+K67Xdq26XamdCYY6I0xmcw8lwdIRG7P8LHH8fkpl1soXQsidR05iY7e1hjGGu9QPXlco6CkjkhkjpYGvhZ4cTgwAsb+yD5D4IMlERAWBV3WClnlhkbIZI2RuDWge/vcWtDee+WrPWDPa6ee609wkDjPAxzGc+7z5keo5x8ygim6kP1l4Xs7n0TIpZpappa1kbWv2gnLs491+SB5DGVIWq9U1yqJoYWyMkia2TD9vvMdnDhgn0PBwR5hdI03QCERHxjGab2R7fEIEjOfvAdz7zjn4rMt9ujohJiSWV78BzpCOw7DAAA/L5ohFVWpoWSUjmxyR0srnu9okaNj4mMc5z24OccDuBnPGVkQako5XuYWTMeJImYdtPEji1juCeCRj1HmF1x6WoWsZHJLUzQxwPpoo5JPdijdt4bgDttGCcn4rvlsFNNbqiknlqJGzlpfJvDX5aQW42gBuCB2AQdFVqmgponSOEr2taZHbQ3IjBI8TkjLTtOMZJA4C73X6mFaacRVDmNmbA6cNHhte5ocBnOTkOHYHHnhcp7FRyVDZW+JCPDbE5kRDWuY3O0dsjGT2IXOazU0rNrnSj9O6oJDhy8tLfTyB4+QRLrtF6juEjY4mSSExtmMrWFsbWuGWAknOSMcf0WFWamjY6mdDFK2nlc9wqJGe4+NjHOc5uDnHujuBnPGVL22209vbM2nDtspaSHHONrGsAHww0KNZpejbG2N09W+KOB9NFG6QFsUbsZa3j0bjJyceaCNqtR3SL21zbfI4U7oqZuGx4fM/bg8yAgZe3jHzI8pKG+GLfHNFPU1W/Y2nhiaH8NaXH75bgbwCcjnjnzzvqimIIPiHNSKs5Pd4xj8BgfkFjyWCndI2WKeqgmD5XmSJ4DiJHBzmnjtkD4jA5RDGrtQtikp/DLY2PMbpBMxzXRNLXvcXZ7YbGePJZ1qvVNc6iWGFsjJI2tkAft95hzhwwT6Hg4I9F1S6doJjN4zZJGS5D2veTkGMR4z3+6D59ySsqhtsdI2UCWaV0gDXPeRnA7AYAA798Z9UGPbrw2rudRRujexzdz4iQBuYCAcjJI5PmBkdlxj1BTyVDWeBUthdNJAKhzQI97N2R3z/pPOMfFfbTYYLZMyWGaokcyEQASFuNoOR2A5+Pn55WHb9NNbbmRV9TPJIWPLmNk9yOSQHe5nGf9TsZzjPACJKHUTppngROqQ5kZhjgZh7yWB7j7xAAAfH3xyfiAuTtSB1dSthpJnUL6Z1TNUOLGiEAge8C4EY97PHlxnnGS7T9MJfFp5ainmy79JE4A7XBoLeQRjDGfEY4K5y2CglGwskERpjSOibI4NfHgjBHn3PPflEMdmqKF0c7iyceEGODdoc6Rr3bWloBJ78YOD8FlVl5hpBTCaGcT1DS5kADd+BjPnjIyOAcr5FZYGM2vlnlPiMkLnuHOw5aMAAYz8MnzJXbc7XFccNnlmERbtfE0ja8ehyDj5jB+KJdMl8po7kyjkjmYXEtEjgA0uDC8jGd3YHnGPLOVjR6oo3U4mlhqYGPZHJF4rWt8RrzhuOeOf2sL67TFI6RzzUVXLpXAbm4b4gIdjjP+o4JyR644WXPZ4ZJjLHNPA/w2RAxkYDW7sDBBB+8e4PYeiDlLdYoqCKqfDODK7ZHAGZke7ngDOPInOcY5zjlYlXqOCkohU1NJWxgB7pGPY1pjDe5OTg/DaST5ZWTLZqZ1BTUsT5YBTOD4ZInYex2CM8gjkEjkY5WJV6ZpaprxLU1mHxeC/MgcXDJdkkgnOXHtgdhjACD5dr/4EUzaKnmkkbIynbMWZibK8tDWnkE8uGcDHlkL6dT0fh7mQ1Di4vETcNaZQw4c5u5wGAccnGcjGV3PsFO6o8Q1FV4fjipEO8bBIOd2MZ784zjPOF8dp+k9no4o3zR+zQ+A1zXDc5nGQSR54ByMH0IRCSoaqKto4KqmduhmYJGHGMgjIXcuMTGxRtjYMNaAAM54XJEiIiAiIgLErblQ0L2MrauCBz/uiR4aT+fzCy1EVdrqJblUTw1EIhqYmRSslh3na0u4ac4wQ48EFBmi4UZrPZRVQmpyR4e8bs4zjHrjlY5vtqDS76xpdoaHk+KPunz+XB5WEyxTgMjdVRmKGaWohxGQ7e/fguOecbz2xnhffs+GRPjhlawNt4oIfc+53y7vzn3ePggkp7pQU8ojnrKeN5wNrpADz2/Ncqe4UdSGeBUxSb3Frdrgckdx8wo02BrhI10jSx9VDUbdn+mNrA1vf1YDn4rg+yVLbg6tp6uNsznzE74iQN4YARz3aIwPjkoJI3a3h8TDW04fKGlg3jLg44aR8yMBZqr1Lpw09E+AVAc8mmAeWdmQ7Pd7+ZDj/wCZTtOJRBGKhzHzBo3uY0taT54BJwPxKDsREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREH//2Q==",
+              "timestamp": 107698586010
+            }
+          ]
+        }
+      },
+      "network-dependency-tree-insight": {
+        "id": "network-dependency-tree-insight",
+        "title": "Network dependency tree",
+        "description": "[Avoid chaining critical requests](https://developer.chrome.com/docs/performance/insights/network-dependency-tree) by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "value": {
+                "longestChain": {
+                  "duration": 1299
+                },
+                "type": "network-tree",
+                "chains": {
+                  "94FC32A618EB10287E3C168CE49C0C9A": {
+                    "isLongest": true,
+                    "transferSize": 22074,
+                    "navStartToEndTime": 599,
+                    "children": {
+                      "51.2": {
+                        "isLongest": true,
+                        "transferSize": 24570,
+                        "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                        "children": {
+                          "51.73": {
+                            "children": {},
+                            "transferSize": 39127,
+                            "navStartToEndTime": 1295,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf"
+                          },
+                          "51.72": {
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+                            "children": {},
+                            "navStartToEndTime": 1299,
+                            "isLongest": true,
+                            "transferSize": 40710
+                          },
+                          "51.68": {
+                            "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                            "children": {},
+                            "transferSize": 31975,
+                            "navStartToEndTime": 1293
+                          },
+                          "51.71": {
+                            "children": {},
+                            "transferSize": 38778,
+                            "navStartToEndTime": 1297,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf"
+                          }
+                        },
+                        "navStartToEndTime": 631
+                      }
+                    },
+                    "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+                  }
+                }
+              },
+              "type": "list-section"
+            },
+            {
+              "description": "[preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints help the browser establish a connection earlier in the page load, saving time when the first request for that origin is made. The following are the origins that the page preconnected to.",
+              "type": "list-section",
+              "value": {
+                "items": [
+                  {
+                    "origin": "https://raw.githubusercontent.com/",
+                    "subItems": {
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ],
+                      "type": "subitems"
+                    },
+                    "source": {
+                      "path": "0,HEAD,2,LINK",
+                      "nodeLabel": "head \u003e link",
+                      "lhId": "page-9-LINK",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "selector": "head \u003e link",
+                      "boundingRect": {
+                        "bottom": 0,
+                        "left": 0,
+                        "width": 0,
+                        "right": 0,
+                        "top": 0,
+                        "height": 0
+                      },
+                      "type": "node"
+                    }
+                  },
+                  {
+                    "subItems": {
+                      "type": "subitems",
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ]
+                    },
+                    "source": {
+                      "lhId": "page-10-LINK",
+                      "nodeLabel": "head \u003e link",
+                      "path": "2,HTML,0,HEAD,3,LINK",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "boundingRect": {
+                        "left": 0,
+                        "bottom": 0,
+                        "width": 0,
+                        "top": 0,
+                        "right": 0,
+                        "height": 0
+                      },
+                      "selector": "head \u003e link",
+                      "type": "node"
+                    }
+                  }
+                ],
+                "headings": [
+                  {
+                    "subItemsHeading": {
+                      "key": "warning"
+                    },
+                    "key": "origin",
+                    "valueType": "text",
+                    "label": "Origin"
+                  },
+                  {
+                    "key": "source",
+                    "valueType": "node",
+                    "label": "Source"
+                  }
+                ],
+                "type": "table"
+              },
+              "title": "Preconnected origins"
+            },
+            {
+              "description": "Add [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints to your most important origins, but try to use no more than 4.",
+              "value": {
+                "items": [
+                  {
+                    "wastedMs": 488,
+                    "origin": "https://player.ausha.co"
+                  }
+                ],
+                "headings": [
+                  {
+                    "label": "Origin",
+                    "valueType": "text",
+                    "key": "origin"
+                  },
+                  {
+                    "valueType": "ms",
+                    "key": "wastedMs",
+                    "label": "Est LCP savings"
+                  }
+                ],
+                "type": "table"
+              },
+              "title": "Preconnect candidates",
+              "type": "list-section"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "cache-insight": {
+        "id": "cache-insight",
+        "title": "Use efficient cache lifetimes",
+        "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more about caching](https://developer.chrome.com/docs/performance/insights/cache).",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 320 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "Request",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "valueType": "ms",
+              "key": "cacheLifetimeMs",
+              "displayUnit": "duration",
+              "label": "Cache TTL"
+            },
+            {
+              "label": "Transfer Size",
+              "granularity": 1,
+              "key": "totalBytes",
+              "displayUnit": "kb",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 327497.9,
+            "type": "debugdata"
+          },
+          "skipSumming": [
+            "cacheLifetimeMs"
+          ],
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [
+            {
+              "wastedBytes": 196188.08333333334,
+              "totalBytes": 204718,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 41844.666666666672,
+              "totalBytes": 43664
+            },
+            {
+              "wastedBytes": 27277.25,
+              "totalBytes": 29757,
+              "cacheLifetimeMs": 600000,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            },
+            {
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "totalBytes": 27955,
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 26790.208333333336
+            },
+            {
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "totalBytes": 27219,
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 26084.875
+            },
+            {
+              "cacheLifetimeMs": 600000,
+              "wastedBytes": 4598.9166666666661,
+              "totalBytes": 5017,
+              "url": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "totalBytes": 1998,
+              "cacheLifetimeMs": 600000,
+              "wastedBytes": 1831.5
+            },
+            {
+              "wastedBytes": 1672,
+              "totalBytes": 1672,
+              "cacheLifetimeMs": 0,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js"
+            },
+            {
+              "url": "https://player.ausha.co/ausha-player.js",
+              "wastedBytes": 1210.4,
+              "totalBytes": 1513,
+              "cacheLifetimeMs": 3600000
+            }
+          ]
+        }
+      },
+      "duplicated-javascript-insight": {
+        "id": "duplicated-javascript-insight",
+        "title": "Duplicated JavaScript",
+        "description": "Remove large, [duplicate JavaScript modules](https://developer.chrome.com/docs/performance/insights/duplicated-javascript) from bundles to reduce unnecessary bytes consumed by network activity.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 0,
+            "type": "debugdata"
+          },
+          "headings": [
+            {
+              "valueType": "code",
+              "key": "source",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "label": "Source"
+            },
+            {
+              "label": "Duplicated bytes",
+              "key": "wastedBytes",
+              "granularity": 10,
+              "valueType": "bytes",
+              "subItemsHeading": {
+                "key": "sourceTransferBytes"
+              }
+            }
+          ],
+          "type": "table",
+          "items": []
+        }
+      },
+      "diagnostics": {
+        "id": "diagnostics",
+        "title": "Diagnostics",
+        "description": "Collection of useful page vitals.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "totalByteWeight": 1470646,
+              "maxRtt": 13.936364999999999,
+              "numScripts": 63,
+              "numStylesheets": 3,
+              "totalTaskTime": 4408.6019999999971,
+              "maxServerLatency": 41,
+              "rtt": 0.00070740282062719813,
+              "numTasksOver10ms": 52,
+              "numTasksOver100ms": 9,
+              "mainDocumentTransferSize": 22074,
+              "numTasksOver25ms": 27,
+              "numRequests": 92,
+              "numTasksOver50ms": 15,
+              "numTasksOver500ms": 1,
+              "throughput": 15468654462.217491,
+              "numFonts": 6,
+              "numTasks": 1858
+            }
+          ],
+          "type": "debugdata"
+        }
+      },
+      "main-thread-tasks": {
+        "id": "main-thread-tasks",
+        "title": "Tasks",
+        "description": "Lists the toplevel main thread tasks that executed during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "startTime": 565.311,
+              "duration": 29.59
+            },
+            {
+              "startTime": 625.618,
+              "duration": 5.926
+            },
+            {
+              "startTime": 646.799,
+              "duration": 10.255
+            },
+            {
+              "startTime": 657.089,
+              "duration": 634.709
+            },
+            {
+              "startTime": 1308.219,
+              "duration": 13.616
+            },
+            {
+              "startTime": 1336.223,
+              "duration": 19.128
+            },
+            {
+              "startTime": 1355.365,
+              "duration": 6.942
+            },
+            {
+              "startTime": 1362.905,
+              "duration": 15.872
+            },
+            {
+              "startTime": 1380.623,
+              "duration": 12.483
+            },
+            {
+              "startTime": 1394.591,
+              "duration": 10.611
+            },
+            {
+              "startTime": 1406.023,
+              "duration": 10.453
+            },
+            {
+              "startTime": 1419.489,
+              "duration": 10.661
+            },
+            {
+              "startTime": 1431.331,
+              "duration": 25.063
+            },
+            {
+              "startTime": 1458.067,
+              "duration": 31.978
+            },
+            {
+              "startTime": 1491.357,
+              "duration": 31.198
+            },
+            {
+              "startTime": 1523.506,
+              "duration": 6.503
+            },
+            {
+              "startTime": 1530.205,
+              "duration": 7.673
+            },
+            {
+              "startTime": 1543.742,
+              "duration": 94.462
+            },
+            {
+              "startTime": 1645.2,
+              "duration": 57.486
+            },
+            {
+              "startTime": 1713.066,
+              "duration": 29.812
+            },
+            {
+              "startTime": 1746.124,
+              "duration": 9.667
+            },
+            {
+              "startTime": 1755.966,
+              "duration": 21.952
+            },
+            {
+              "startTime": 1777.971,
+              "duration": 21.302
+            },
+            {
+              "startTime": 1799.45,
+              "duration": 26.593
+            },
+            {
+              "startTime": 1832.503,
+              "duration": 13.184
+            },
+            {
+              "startTime": 1850.912,
+              "duration": 9.625
+            },
+            {
+              "startTime": 1865.886,
+              "duration": 9.821
+            },
+            {
+              "startTime": 1875.843,
+              "duration": 14.215
+            },
+            {
+              "startTime": 1890.677,
+              "duration": 9.747
+            },
+            {
+              "startTime": 1900.448,
+              "duration": 7.665
+            },
+            {
+              "startTime": 1908.175,
+              "duration": 5.802
+            },
+            {
+              "startTime": 1913.991,
+              "duration": 478.561
+            },
+            {
+              "startTime": 2395.776,
+              "duration": 5.536
+            },
+            {
+              "duration": 39.287,
+              "startTime": 2401.587
+            },
+            {
+              "startTime": 2443.818,
+              "duration": 5.234
+            },
+            {
+              "startTime": 2449.383,
+              "duration": 13.89
+            },
+            {
+              "startTime": 2464.197,
+              "duration": 18.552
+            },
+            {
+              "startTime": 2486.58,
+              "duration": 5.791
+            },
+            {
+              "startTime": 2492.382,
+              "duration": 20.19
+            },
+            {
+              "startTime": 2512.78,
+              "duration": 8.156
+            },
+            {
+              "startTime": 2521.148,
+              "duration": 8.372
+            },
+            {
+              "startTime": 2529.534,
+              "duration": 6.187
+            },
+            {
+              "duration": 9.676,
+              "startTime": 2535.739
+            },
+            {
+              "duration": 5.444,
+              "startTime": 2545.437
+            },
+            {
+              "startTime": 2550.988,
+              "duration": 46.673
+            },
+            {
+              "startTime": 2600.36,
+              "duration": 6.287
+            },
+            {
+              "duration": 36.572,
+              "startTime": 2606.658
+            },
+            {
+              "duration": 280.403,
+              "startTime": 2643.378
+            },
+            {
+              "startTime": 2924.572,
+              "duration": 6.151
+            },
+            {
+              "startTime": 2931.049,
+              "duration": 12.922
+            },
+            {
+              "startTime": 2948.704,
+              "duration": 19.24
+            },
+            {
+              "startTime": 2968.027,
+              "duration": 6.457
+            },
+            {
+              "duration": 5.648,
+              "startTime": 2976.112
+            },
+            {
+              "startTime": 2982.993,
+              "duration": 5.531
+            },
+            {
+              "startTime": 2989.46,
+              "duration": 5.408
+            },
+            {
+              "startTime": 2994.956,
+              "duration": 7.027
+            },
+            {
+              "startTime": 3001.996,
+              "duration": 5.983
+            },
+            {
+              "startTime": 3009.024,
+              "duration": 5.702
+            },
+            {
+              "startTime": 3014.791,
+              "duration": 5.605
+            },
+            {
+              "startTime": 3020.431,
+              "duration": 6.558
+            },
+            {
+              "startTime": 3027.903,
+              "duration": 5.85
+            },
+            {
+              "startTime": 3033.821,
+              "duration": 6.194
+            },
+            {
+              "startTime": 3041.068,
+              "duration": 6.123
+            },
+            {
+              "startTime": 3047.242,
+              "duration": 168.647
+            },
+            {
+              "startTime": 3215.965,
+              "duration": 32.938
+            },
+            {
+              "startTime": 3255.616,
+              "duration": 17.8
+            },
+            {
+              "startTime": 3273.526,
+              "duration": 11.327
+            },
+            {
+              "startTime": 3287.265,
+              "duration": 97.915
+            },
+            {
+              "startTime": 3387.419,
+              "duration": 9.316
+            },
+            {
+              "duration": 7.243,
+              "startTime": 3397.81
+            },
+            {
+              "startTime": 3405.126,
+              "duration": 5.084
+            },
+            {
+              "startTime": 3420.685,
+              "duration": 6.279
+            },
+            {
+              "startTime": 3427.039,
+              "duration": 6.847
+            },
+            {
+              "startTime": 3433.914,
+              "duration": 5.474
+            },
+            {
+              "startTime": 3439.697,
+              "duration": 6.256
+            },
+            {
+              "startTime": 3445.975,
+              "duration": 5.477
+            },
+            {
+              "startTime": 3451.576,
+              "duration": 5.187
+            },
+            {
+              "startTime": 3456.992,
+              "duration": 6.831
+            },
+            {
+              "startTime": 3465.123,
+              "duration": 5.716
+            },
+            {
+              "startTime": 3471.419,
+              "duration": 6.484
+            },
+            {
+              "startTime": 3477.96,
+              "duration": 8.492
+            },
+            {
+              "startTime": 3486.755,
+              "duration": 9.264
+            },
+            {
+              "startTime": 3503.331,
+              "duration": 120.636
+            },
+            {
+              "duration": 24.995,
+              "startTime": 3628.624
+            },
+            {
+              "startTime": 3656.515,
+              "duration": 35.515
+            },
+            {
+              "startTime": 3693.907,
+              "duration": 5.822
+            },
+            {
+              "startTime": 3700.096,
+              "duration": 22.55
+            },
+            {
+              "startTime": 3722.682,
+              "duration": 18.922
+            },
+            {
+              "startTime": 3745.302,
+              "duration": 15.166
+            },
+            {
+              "startTime": 3764.271,
+              "duration": 294.051
+            },
+            {
+              "startTime": 4064.988,
+              "duration": 7.192
+            },
+            {
+              "startTime": 4072.715,
+              "duration": 186.601
+            },
+            {
+              "startTime": 4269.018,
+              "duration": 60.989
+            },
+            {
+              "startTime": 4334.435,
+              "duration": 54.885
+            },
+            {
+              "startTime": 4393.503,
+              "duration": 8.038
+            },
+            {
+              "startTime": 4406.616,
+              "duration": 17.661
+            },
+            {
+              "startTime": 4430.242,
+              "duration": 55.258
+            },
+            {
+              "startTime": 4485.74,
+              "duration": 282.402
+            },
+            {
+              "startTime": 4770.069,
+              "duration": 10.914
+            },
+            {
+              "duration": 36.423,
+              "startTime": 4781.51
+            },
+            {
+              "startTime": 6165.405,
+              "duration": 162.534
+            },
+            {
+              "duration": 7.854,
+              "startTime": 6328.228
+            }
+          ],
+          "headings": [
+            {
+              "label": "Start Time",
+              "valueType": "ms",
+              "key": "startTime",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "duration",
+              "label": "End Time"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "network-server-latency": {
+        "id": "network-server-latency",
+        "title": "Server Backend Latencies",
+        "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "40 ms",
+        "details": {
+          "items": [
+            {
+              "origin": "https://www.googletagmanager.com",
+              "serverResponseTime": 41
+            },
+            {
+              "serverResponseTime": 4.5,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://useago.github.io"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "serverResponseTime": 0.5,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "serverResponseTime": 0.5,
+              "origin": "https://player.ausha.co"
+            },
+            {
+              "serverResponseTime": 0.5,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "serverResponseTime": 0.5,
+              "origin": "https://fonts.gstatic.com"
+            }
+          ],
+          "sortedBy": [
+            "serverResponseTime"
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "text",
+              "key": "origin"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "serverResponseTime",
+              "label": "Time Spent"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 41,
+        "numericUnit": "millisecond"
+      },
+      "lcp-discovery-insight": {
+        "id": "lcp-discovery-insight",
+        "title": "LCP request discovery",
+        "description": "[Optimize LCP](https://developer.chrome.com/docs/performance/insights/lcp-discovery) by making the LCP image discoverable from the HTML immediately, and avoiding lazy-loading",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "items": {
+                "priorityHinted": {
+                  "value": true,
+                  "label": "fetchpriority=high applied"
+                },
+                "requestDiscoverable": {
+                  "value": true,
+                  "label": "Request is discoverable in initial document"
+                },
+                "eagerlyLoaded": {
+                  "value": true,
+                  "label": "lazy load not applied"
+                }
+              },
+              "type": "checklist"
+            },
+            {
+              "type": "node",
+              "selector": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block",
+              "boundingRect": {
+                "height": 0,
+                "right": 0,
+                "top": 0,
+                "width": 0,
+                "left": 0,
+                "bottom": 0
+              },
+              "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"d_block w_100% h_auto obj-f_cover bdr_2xl asp_16/7\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+              "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,DIV,1,HEADER,3,IMG",
+              "nodeLabel": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block",
+              "lhId": "page-4-IMG"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "unsized-images": {
+        "id": "unsized-images",
+        "title": "Image elements do not have explicit `width` and `height`",
+        "description": "Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "node": {
+                "nodeLabel": "Ocobo",
+                "path": "2,HTML,1,BODY,0,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "lhId": "1-0-IMG",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "boundingRect": {
+                  "height": 40,
+                  "right": 167,
+                  "top": 37,
+                  "width": 134,
+                  "left": 33,
+                  "bottom": 77
+                },
+                "type": "node"
+              }
+            }
+          ]
+        }
+      },
+      "script-treemap-data": {
+        "id": "script-treemap-data",
+        "title": "Script Treemap Data",
+        "description": "Used for treemap app",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "nodes": [
+            {
+              "name": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+              "resourceBytes": 45561,
+              "encodedBytes": 8364,
+              "children": [
+                {
+                  "name": "(inline) window.dataLaye…",
+                  "resourceBytes": 298,
+                  "unusedBytes": 0
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 631,
+                  "name": "(inline) window.AGO = {\n…"
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 592,
+                  "name": "(inline) ((storageKey2, …"
+                },
+                {
+                  "resourceBytes": 520,
+                  "name": "(inline) window.__reactR…",
+                  "unusedBytes": 0
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 35393,
+                  "name": "(inline) window.__reactR…"
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 53,
+                  "name": "(inline) window.__reactR…"
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 8074,
+                  "name": "(inline) ;\nimport * as r…"
+                }
+              ]
+            },
+            {
+              "unusedBytes": 754,
+              "encodedBytes": 3946,
+              "resourceBytes": 9792,
+              "name": "https://www.ocobo.co/assets/root-HtXVBFii.js"
+            },
+            {
+              "resourceBytes": 125385,
+              "name": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "encodedBytes": 43335,
+              "unusedBytes": 70219
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 865,
+              "resourceBytes": 927,
+              "name": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js"
+            },
+            {
+              "unusedBytes": 1084,
+              "resourceBytes": 3192,
+              "name": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "encodedBytes": 1560
+            },
+            {
+              "encodedBytes": 944,
+              "name": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "resourceBytes": 983,
+              "unusedBytes": 89
+            },
+            {
+              "resourceBytes": 141,
+              "name": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "encodedBytes": 95,
+              "unusedBytes": 6
+            },
+            {
+              "resourceBytes": 1284,
+              "name": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "encodedBytes": 700,
+              "unusedBytes": 467
+            },
+            {
+              "resourceBytes": 15426,
+              "name": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "encodedBytes": 6230,
+              "unusedBytes": 809
+            },
+            {
+              "resourceBytes": 17234,
+              "name": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "encodedBytes": 5626,
+              "unusedBytes": 370
+            },
+            {
+              "unusedBytes": 519,
+              "encodedBytes": 1271,
+              "resourceBytes": 3070,
+              "name": "https://www.ocobo.co/assets/grid-DIis54sB.js"
+            },
+            {
+              "encodedBytes": 367,
+              "resourceBytes": 428,
+              "name": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "unusedBytes": 239
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 349,
+              "resourceBytes": 410,
+              "name": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "resourceBytes": 525,
+              "encodedBytes": 463,
+              "unusedBytes": 65
+            },
+            {
+              "encodedBytes": 878,
+              "resourceBytes": 942,
+              "name": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "unusedBytes": 362
+            },
+            {
+              "resourceBytes": 349,
+              "name": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "encodedBytes": 288,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 1866,
+              "name": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "encodedBytes": 779
+            },
+            {
+              "encodedBytes": 285,
+              "resourceBytes": 348,
+              "name": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 20674,
+              "resourceBytes": 67398,
+              "name": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "unusedBytes": 32006
+            },
+            {
+              "resourceBytes": 165,
+              "name": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "encodedBytes": 119,
+              "unusedBytes": 0
+            },
+            {
+              "resourceBytes": 206,
+              "name": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "encodedBytes": 158,
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 33602,
+              "resourceBytes": 109016,
+              "name": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 605,
+              "name": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "encodedBytes": 541
+            },
+            {
+              "encodedBytes": 764,
+              "resourceBytes": 826,
+              "name": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 358,
+              "resourceBytes": 404,
+              "name": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js"
+            },
+            {
+              "resourceBytes": 490,
+              "name": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "encodedBytes": 428,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 337,
+              "encodedBytes": 788,
+              "resourceBytes": 835,
+              "name": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js"
+            },
+            {
+              "unusedBytes": 47528,
+              "encodedBytes": 25831,
+              "resourceBytes": 68826,
+              "name": "https://www.ocobo.co/assets/portal-Clm-6X_X.js"
+            },
+            {
+              "resourceBytes": 133936,
+              "name": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "encodedBytes": 44682,
+              "unusedBytes": 30785
+            },
+            {
+              "encodedBytes": 412,
+              "resourceBytes": 473,
+              "name": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "unusedBytes": 0
+            },
+            {
+              "resourceBytes": 338,
+              "name": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "encodedBytes": 277,
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 372,
+              "resourceBytes": 435,
+              "name": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 251,
+              "resourceBytes": 312,
+              "name": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js"
+            },
+            {
+              "unusedBytes": 194,
+              "name": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "resourceBytes": 309,
+              "encodedBytes": 263
+            },
+            {
+              "unusedBytes": 18,
+              "encodedBytes": 2747,
+              "resourceBytes": 6431,
+              "name": "https://www.ocobo.co/assets/_main.blog._slug-CVkfQxlz.js"
+            },
+            {
+              "encodedBytes": 431,
+              "resourceBytes": 495,
+              "name": "https://www.ocobo.co/assets/badge-i9dgPBIb.js",
+              "unusedBytes": 65
+            },
+            {
+              "resourceBytes": 717,
+              "name": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "encodedBytes": 655,
+              "unusedBytes": 65
+            },
+            {
+              "encodedBytes": 211,
+              "resourceBytes": 272,
+              "name": "https://www.ocobo.co/assets/optimized-image-BKBFj58i.js",
+              "unusedBytes": 0
+            },
+            {
+              "resourceBytes": 303,
+              "name": "https://www.ocobo.co/assets/labels-CtAnB7VF.js",
+              "encodedBytes": 249,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 4,
+              "name": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js",
+              "resourceBytes": 302,
+              "encodedBytes": 256
+            },
+            {
+              "resourceBytes": 1208,
+              "name": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "encodedBytes": 552,
+              "unusedBytes": 4
+            },
+            {
+              "encodedBytes": 1276,
+              "resourceBytes": 2543,
+              "name": "https://www.ocobo.co/assets/LayoutPost-BT26K59V.js",
+              "unusedBytes": 483
+            },
+            {
+              "unusedBytes": 721,
+              "encodedBytes": 1339,
+              "name": "https://www.ocobo.co/assets/PageMarkdownContainer-klsUvxsc.js",
+              "resourceBytes": 3506
+            },
+            {
+              "unusedBytes": 83667,
+              "resourceBytes": 138685,
+              "name": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "encodedBytes": 51203
+            },
+            {
+              "unusedBytes": 9,
+              "encodedBytes": 1252,
+              "resourceBytes": 2533,
+              "name": "https://www.ocobo.co/assets/member-card-Bn7bfGBT.js"
+            },
+            {
+              "unusedBytes": 65,
+              "resourceBytes": 605,
+              "name": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "encodedBytes": 541
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 549,
+              "name": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "encodedBytes": 502
+            },
+            {
+              "encodedBytes": 23529,
+              "name": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "resourceBytes": 69550,
+              "unusedBytes": 28818
+            },
+            {
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "encodedBytes": 4226,
+              "unusedBytes": 12049
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 595,
+              "resourceBytes": 2125,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js"
+            },
+            {
+              "unusedBytes": 203872,
+              "encodedBytes": 156346,
+              "resourceBytes": 471493,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "name": "https://player.ausha.co/ausha-player.js",
+              "resourceBytes": 2558,
+              "encodedBytes": 682,
+              "unusedBytes": 1760
+            },
+            {
+              "encodedBytes": 26373,
+              "resourceBytes": 78059,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "unusedBytes": 35974
+            },
+            {
+              "unusedBytes": 36099,
+              "resourceBytes": 72608,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "encodedBytes": 25123
+            },
+            {
+              "unusedBytes": 46367,
+              "encodedBytes": 42586,
+              "resourceBytes": 108995,
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "unusedBytes": 57100,
+              "encodedBytes": 27533,
+              "resourceBytes": 97992,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            },
+            {
+              "unusedBytes": 335885,
+              "resourceBytes": 471493,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "encodedBytes": 156346
+            },
+            {
+              "encodedBytes": 4673,
+              "resourceBytes": 12567,
+              "name": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "unusedBytes": 6501
+            },
+            {
+              "unusedBytes": 682,
+              "resourceBytes": 2495,
+              "name": "https://www.ocobo.co/_vercel/insights/script.js",
+              "encodedBytes": 1227
+            },
+            {
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "encodedBytes": 4226
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 595,
+              "resourceBytes": 2125,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js"
+            },
+            {
+              "resourceBytes": 587832,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "encodedBytes": 202931,
+              "unusedBytes": 337253
+            },
+            {
+              "unusedBytes": 2149,
+              "encodedBytes": 682,
+              "resourceBytes": 2558,
+              "name": "https://player.ausha.co/ausha-player.js"
+            },
+            {
+              "unusedBytes": 73621,
+              "resourceBytes": 97992,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "encodedBytes": 27533
+            },
+            {
+              "unusedBytes": 36205,
+              "resourceBytes": 78059,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "encodedBytes": 26373
+            },
+            {
+              "resourceBytes": 108995,
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "encodedBytes": 42586,
+              "unusedBytes": 68120
+            },
+            {
+              "unusedBytes": 49494,
+              "resourceBytes": 72608,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "encodedBytes": 25123
+            },
+            {
+              "encodedBytes": 202931,
+              "resourceBytes": 587832,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "unusedBytes": 248156
+            }
+          ],
+          "type": "treemap-data"
+        }
+      },
+      "third-parties-insight": {
+        "id": "third-parties-insight",
+        "title": "3rd parties",
+        "description": "3rd party code can significantly impact load performance. [Reduce and defer loading of 3rd party code](https://developer.chrome.com/docs/performance/insights/third-parties) to prioritize your page's content.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "entity": "Hubspot",
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 206375,
+                    "mainThreadTime": 370.65099999308586,
+                    "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+                  },
+                  {
+                    "transferSize": 27955,
+                    "mainThreadTime": 65.99099999666214,
+                    "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                  },
+                  {
+                    "transferSize": 43664,
+                    "mainThreadTime": 57.739999920129776,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+                  },
+                  {
+                    "transferSize": 29757,
+                    "mainThreadTime": 52.096000015735626,
+                    "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+                  },
+                  {
+                    "transferSize": 27219,
+                    "mainThreadTime": 31.402000024914742,
+                    "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+                  },
+                  {
+                    "transferSize": 2227,
+                    "mainThreadTime": 5.0070000141859055,
+                    "url": "https://js-eu1.hs-scripts.com/27107933.js"
+                  },
+                  {
+                    "transferSize": 4081,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953&hutk=5adaa0527fcfafeaf1991097a3e493da",
+                    "mainThreadTime": 0.30599997937679291
+                  },
+                  {
+                    "mainThreadTime": 0.22599996626377106,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+                    "transferSize": 1095
+                  },
+                  {
+                    "mainThreadTime": 0.1549999862909317,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=5adaa0527fcfafeaf1991097a3e493da",
+                    "transferSize": 1095
+                  },
+                  {
+                    "transferSize": 1724,
+                    "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&utk=5adaa0527fcfafeaf1991097a3e493da&__hstc=242475741.5adaa0527fcfafeaf1991097a3e493da.1778779363508.1778779363508.1778779363508.1&__hssc=242475741.1.1778779363508&isMobile=true",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1482,
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778779363511&vi=5adaa0527fcfafeaf1991097a3e493da&nc=true&ce=false&cc=0"
+                  },
+                  {
+                    "transferSize": 1026,
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778779365381&vi=5adaa0527fcfafeaf1991097a3e493da&nc=true&u=242475741.5adaa0527fcfafeaf1991097a3e493da.1778779363508.1778779363508.1778779363508.1&b=242475741.1.1778779363508&cc=15"
+                  },
+                  {
+                    "transferSize": 1024,
+                    "mainThreadTime": 0,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1"
+                  },
+                  {
+                    "transferSize": 1024,
+                    "mainThreadTime": 0,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1"
+                  },
+                  {
+                    "transferSize": 1021,
+                    "mainThreadTime": 0,
+                    "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1"
+                  },
+                  {
+                    "transferSize": 1020,
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=99109eb4-c411-41a1-8fde-5425bcacc79c&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778779366081&vi=5adaa0527fcfafeaf1991097a3e493da&nc=true&u=242475741.5adaa0527fcfafeaf1991097a3e493da.1778779363508.1778779363508.1778779363508.1&b=242475741.1.1778779363508&cc=15"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+                    "transferSize": 558
+                  }
+                ],
+                "type": "subitems"
+              },
+              "transferSize": 352347,
+              "mainThreadTime": 583.57399989664555
+            },
+            {
+              "transferSize": 157034,
+              "entity": "Google Tag Manager",
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 157034,
+                    "mainThreadTime": 256.01399993896484,
+                    "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 256.01399993896484
+            },
+            {
+              "mainThreadTime": 10.237999990582466,
+              "transferSize": 7015,
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 10.237999990582466,
+                    "url": "https://useago.github.io/widgetjs/frame.js",
+                    "transferSize": 5017
+                  },
+                  {
+                    "transferSize": 1998,
+                    "mainThreadTime": 0,
+                    "url": "https://useago.github.io/widgetjs/frame.css"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "entity": "GitHub"
+            },
+            {
+              "transferSize": 2218,
+              "entity": "ausha.co",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "transferSize": 2218,
+                    "mainThreadTime": 1.5990000069141388,
+                    "url": "https://player.ausha.co/ausha-player.js"
+                  }
+                ]
+              },
+              "mainThreadTime": 1.5990000069141388
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 202020,
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg",
+                    "transferSize": 67588
+                  }
+                ],
+                "type": "subitems"
+              },
+              "entity": "vercel-storage.com",
+              "transferSize": 269608,
+              "mainThreadTime": 0
+            },
+            {
+              "transferSize": 1278,
+              "entity": "Clearbit",
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+                    "transferSize": 1278
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0
+            },
+            {
+              "mainThreadTime": 0,
+              "transferSize": 796,
+              "entity": "Google Analytics",
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 796,
+                    "mainThreadTime": 0,
+                    "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65c1h1v9100339653za200zd9100339653&_p=1778779362307&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1977217704.1778779363&frm=0&pscdl=noapi&rcb=15&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115938465~115938468~118128922~118228215&dp=%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&sid=1778779363&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&dt=Ocobo%20%C2%B7%20Structurer%20la%20croissance%20pour%20lib%C3%A9rer%20la%20vente%C2%A0%3A%20l%27exemple%20de%20Surfe&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1700"
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 102672,
+                    "mainThreadTime": 0,
+                    "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                  },
+                  {
+                    "transferSize": 1259,
+                    "mainThreadTime": 0,
+                    "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "entity": "Google Fonts",
+              "transferSize": 103931,
+              "mainThreadTime": 0
+            }
+          ],
+          "isEntityGrouped": true,
+          "headings": [
+            {
+              "key": "entity",
+              "valueType": "text",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "label": "3rd party"
+            },
+            {
+              "valueType": "bytes",
+              "subItemsHeading": {
+                "key": "transferSize"
+              },
+              "label": "Transfer size",
+              "key": "transferSize",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "key": "mainThreadTime",
+              "label": "Main thread time",
+              "subItemsHeading": {
+                "key": "mainThreadTime"
+              },
+              "valueType": "ms"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "total-blocking-time": {
+        "id": "total-blocking-time",
+        "title": "Total Blocking Time",
+        "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).",
+        "score": 0.15,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "1,450 ms",
+        "numericValue": 1454.5000000000032,
+        "numericUnit": "millisecond"
+      },
+      "interactive": {
+        "id": "interactive",
+        "title": "Time to Interactive",
+        "description": "Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).",
+        "score": 0.21,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "10.9 s",
+        "numericValue": 10875.515130618125,
+        "numericUnit": "millisecond"
+      },
+      "inp-breakdown-insight": {
+        "id": "inp-breakdown-insight",
+        "title": "INP breakdown",
+        "description": "Start investigating [how to improve INP](https://developer.chrome.com/docs/performance/insights/inp-breakdown) by looking at the longest subpart.",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "image-delivery-insight": {
+        "id": "image-delivery-insight",
+        "title": "Improve image delivery",
+        "description": "Reducing the download time of images can improve the perceived load time of the page and LCP. [Learn more about optimizing image size](https://developer.chrome.com/docs/performance/insights/image-delivery)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 234 KiB",
+        "metricSavings": {
+          "LCP": 600,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "node": {
+                "lhId": "page-0-IMG",
+                "nodeLabel": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block",
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,0,DIV,0,DIV,1,HEADER,3,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"d_block w_100% h_auto obj-f_cover bdr_2xl asp_16/7\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+                "boundingRect": {
+                  "height": 166,
+                  "top": 414,
+                  "right": 396,
+                  "width": 380,
+                  "left": 16,
+                  "bottom": 581
+                },
+                "selector": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block",
+                "type": "node"
+              },
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size.",
+                    "wastedBytes": 95745
+                  },
+                  {
+                    "reason": "This image file is larger than it needs to be (1200x528) for its displayed dimensions (665x443). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 107678
+                  }
+                ]
+              },
+              "wastedBytes": 152223,
+              "totalBytes": 201358,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png"
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 26794,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 58004,
+                    "reason": "This image file is larger than it needs to be (492x489) for its displayed dimensions (183x175). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg",
+              "wastedBytes": 61573,
+              "totalBytes": 66917,
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benja…\" alt=\"Benjamin Boileux\" width=\"100\" height=\"100\" class=\"d_flex ai_center jc_center flex_0_0_auto w_100px h_100px bdr_9999px obj-f_…\"\u003e",
+                "nodeLabel": "Benjamin Boileux",
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,0,DIV,0,DIV,2,ARTICLE,1,MAIN,3,DIV,1,DIV,0,DIV,0,DIV,1,IMG",
+                "lhId": "page-1-IMG",
+                "type": "node",
+                "selector": "div.card \u003e div.d_flex \u003e div.group \u003e img.d_flex",
+                "boundingRect": {
+                  "width": 100,
+                  "left": 49,
+                  "bottom": 6734,
+                  "height": 100,
+                  "top": 6634,
+                  "right": 149
+                }
+              }
+            },
+            {
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "wastedBytes": 16208,
+              "totalBytes": 16667,
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 10523,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "reason": "This image file is larger than it needs to be (192x192) for its displayed dimensions (53x53). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 15421
+                  }
+                ],
+                "type": "subitems"
+              },
+              "node": {
+                "selector": "body \u003e div#ago-wrapper \u003e button#ago-chat-button \u003e img#open-path",
+                "boundingRect": {
+                  "top": 0,
+                  "right": 0,
+                  "height": 0,
+                  "left": 0,
+                  "bottom": 0,
+                  "width": 0
+                },
+                "type": "node",
+                "path": "1,BODY,62,DIV,1,BUTTON,0,IMG",
+                "nodeLabel": "Chat",
+                "lhId": "page-2-IMG",
+                "snippet": "\u003cimg src=\"https://www.ocobo.co/android-chrome-192x192.png\" alt=\"Chat\" id=\"open-path\" style=\"width: 32px; height: 32px; object-fit: contain;\"\u003e"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 6234,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 6709,
+                    "reason": "This image file is larger than it needs to be (348x104) for its displayed dimensions (234x70). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 9533,
+              "totalBytes": 12266,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "node": {
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "nodeLabel": "Ocobo",
+                "path": "2,HTML,1,BODY,0,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "lhId": "page-3-IMG",
+                "type": "node",
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "boundingRect": {
+                  "width": 134,
+                  "left": 33,
+                  "bottom": 77,
+                  "height": 40,
+                  "right": 167,
+                  "top": 37
+                }
+              }
+            }
+          ],
+          "headings": [
+            {
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "label": "URL",
+              "subItemsHeading": {
+                "key": "reason",
+                "valueType": "text"
+              },
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Resource Size"
+            },
+            {
+              "valueType": "bytes",
+              "key": "wastedBytes",
+              "subItemsHeading": {
+                "valueType": "bytes",
+                "key": "wastedBytes"
+              },
+              "label": "Est Savings"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 239537,
+            "type": "debugdata"
+          }
+        }
+      },
+      "cls-culprits-insight": {
+        "id": "cls-culprits-insight",
+        "title": "Layout shift culprits",
+        "description": "Layout shifts occur when elements move absent any user interaction. [Investigate the causes of layout shifts](https://developer.chrome.com/docs/performance/insights/cls-culprit), such as elements being added, removed, or their fonts changing as the page loads.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [
+            {
+              "headings": [
+                {
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "key": "node",
+                  "valueType": "node"
+                },
+                {
+                  "valueType": "numeric",
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  },
+                  "key": "score",
+                  "granularity": 0.001,
+                  "label": "Layout shift score"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  },
+                  "score": 0.007047
+                },
+                {
+                  "score": 0.007047,
+                  "subItems": {
+                    "items": [
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                          "type": "url"
+                        }
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                          "type": "url"
+                        }
+                      },
+                      {
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+                          "type": "url"
+                        }
+                      }
+                    ],
+                    "type": "subitems"
+                  },
+                  "node": {
+                    "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,DIV,2,ARTICLE,1,MAIN,0,P",
+                    "nodeLabel": "— Dans les scale-ups SaaS, la croissance peut vite devenir difficile à piloter …",
+                    "lhId": "page-5-P",
+                    "snippet": "\u003cp class=\"font-style_italic fs_lg md:fs_xl c_gray.600 lh_relaxed mb_8\"\u003e",
+                    "selector": "div \u003e article.d_grid \u003e main.grid-area_main \u003e p.font-style_italic",
+                    "boundingRect": {
+                      "right": 0,
+                      "top": 0,
+                      "height": 0,
+                      "left": 0,
+                      "bottom": 0,
+                      "width": 0
+                    },
+                    "type": "node"
+                  }
+                }
+              ]
+            },
+            {
+              "headings": [
+                {
+                  "label": "Element",
+                  "valueType": "node",
+                  "key": "node",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  }
+                },
+                {
+                  "label": "Layout shift score",
+                  "granularity": 0.001,
+                  "key": "score",
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  },
+                  "valueType": "numeric"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  },
+                  "score": 0
+                },
+                {
+                  "score": 0,
+                  "node": {
+                    "nodeLabel": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "path": "0,HTML,1,BODY,1,DIV,0,FORM,1,DIV,1,DIV,0,INPUT",
+                    "lhId": "page-0-INPUT",
+                    "snippet": "\u003cinput type=\"submit\" class=\"hs-button primary large\" value=\"S'inscrire\"\u003e",
+                    "selector": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "boundingRect": {
+                      "width": 110,
+                      "left": 270,
+                      "bottom": 117,
+                      "height": 38,
+                      "top": 79,
+                      "right": 380
+                    },
+                    "type": "node"
+                  },
+                  "subItems": {
+                    "items": [
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "type": "url",
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                        }
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        }
+                      }
+                    ],
+                    "type": "subitems"
+                  }
+                }
+              ]
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "unused-javascript": {
+        "id": "unused-javascript",
+        "title": "Reduce unused JavaScript",
+        "description": "Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 465 KiB",
+        "metricSavings": {
+          "LCP": 300,
+          "FCP": 300
+        },
+        "details": {
+          "overallSavingsMs": 300,
+          "items": [
+            {
+              "wastedPercent": 57.372344479375059,
+              "wastedBytes": 112596,
+              "totalBytes": 196254,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "wastedPercent": 71.238597391689808,
+              "wastedBytes": 111379,
+              "totalBytes": 156346,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedPercent": 42.2154629213789,
+              "wastedBytes": 82850,
+              "totalBytes": 196254
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedPercent": 43.239666336509771,
+              "wastedBytes": 67603,
+              "totalBytes": 156346
+            },
+            {
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "wastedPercent": 60.328802682337667,
+              "wastedBytes": 30034,
+              "totalBytes": 49784
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "wastedBytes": 26614,
+              "totalBytes": 42584,
+              "wastedPercent": 62.498279737602644
+            },
+            {
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "wastedPercent": 56.002711648123778,
+              "wastedBytes": 24266,
+              "totalBytes": 43331
+            },
+            {
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "wastedPercent": 75.1296024165238,
+              "wastedBytes": 20685,
+              "totalBytes": 27533
+            }
+          ],
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsBytes": 476027,
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "FCP": 300,
+              "LCP": 300
+            }
+          },
+          "headings": [
+            {
+              "label": "URL",
+              "subItemsHeading": {
+                "valueType": "code",
+                "key": "source"
+              },
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "subItemsHeading": {
+                "key": "sourceBytes"
+              }
+            },
+            {
+              "valueType": "bytes",
+              "key": "wastedBytes",
+              "subItemsHeading": {
+                "key": "sourceWastedBytes"
+              },
+              "label": "Est Savings"
+            }
+          ],
+          "type": "opportunity"
+        },
+        "numericValue": 300,
+        "numericUnit": "millisecond"
+      },
+      "final-screenshot": {
+        "id": "final-screenshot",
+        "title": "Final Screenshot",
+        "description": "The last screenshot captured of the pageload.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "timing": 4402,
+          "type": "screenshot",
+          "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAICAwEAAAAAAAAAAAAAAAUGBAcCAwgB/8QATBAAAQMDAwIDBAYIBQICCAcAAQACAwQFEQYSIQcxE0FRFCJhcQgVFjKBkSMzUlRyk7HhNDZCocEXYiSCJSc1VXOU0dM4U3R1g7K0/8QAGgEBAAMBAQEAAAAAAAAAAAAAAAEDBAIFBv/EADERAQABAwEEBgoDAQAAAAAAAAABAgMRBBIhMXEFFDJBUbETFSMzUmFyocHRIjSBkf/aAAwDAQACEQMRAD8A9UoiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAi+OcGtLnEBoGST2Cr0WuNKzXD2GLUVpfV52iJtUwkn079/ggsSISAMk8eqrp1xpZtf7EdRWkVedvhe1s3Z9O/f4ILEiAggEHIPmoq86htdlext1qvZGPxiaWNwiHzkxtH4lBKoqF1rqv/AFSX+po5+DTtcyWJ/cFzeQQpY6v09ZqSgprvfLdR1ToY/wBHPUNa7lo5IJ4QWdF101RDVQMnppY5oZBuZJG4Oa4eoI7qFu+sdN2erFLdb7bKSpzjwpqljXD5gnj8UE8i6qSpgrKdlRSTRzwSDLJI3BzXD1BHddqAiIgIiICIiAiIgIiICIvj3bWkoBcG9yAvgkYezgou5XGkt8BqLjVQ00OQ3xJnhjcnsMlYFHqWx1tSyno7xb56iQ4ZHHUMc53yAKCyouineT7p/Bd6AiIgIiINb9cJ5n2ex2hsz6ekvF1goauRh2nwXElzc+WcYVjq9C6YqLC60PstA2h2Fga2FoLeMbg7GQ7491mau07Q6qsU9rubXeDJhzXsOHxPHLXtPkQVT5dF6zqaI2yq1491tc3w3vZb2NqXM7EeJu7488ZQUQ325T9D6OhdWylkl4FkdXtdhz6bxS3fn4tG3K24zQOlW2P6pFit/sWzZgwt3dsZ3d93xzlc5tE2SXRI0qaYi0tiETWg+80g5Dwf2t3OfVVpuidaMpPq5uv5fq0N8MONvYanZ2x4ue+PPGUEN1BqqnQnRQ0+nbxNVmOVtGyuc8OfDG55BG4ebR7oPcLYun9OWy36cZbo4hUU80IbO+Y+I6oyOXPJ+8Tlddu0bZKLR7dMikbNafDMb45veMmTkucf2iec+qxXaeulssos+mK9tNTbPDZUVr3VElO3thjeM48tzjhBpWnnlp+kXVCwNlfNbrNXPp6N7jnbH4g9zPwx/utz6J0pZqPSdJGaWmrnVdOySpqZmCR1U5zQS5xPcHPA8go8dM6Cn6a12kqCpkj9tBdPWSN3vkkLgS9w4znGEj0dqO00nsGl9Ux0VtDdscNVQiodTjzEbtw49A7OEFU0/VzaQ/6o2qyEuoLPF7ZQxfeED3xOe5g+AIzhWnpZpKxw6GttS+jpa6quNO2pq6qeNsj53yDc7JI5GT2U1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93cu+GOAFXaLQWodPskotIat9hs5c50VJV0Tak0+TkhjiQcegOUHR0+hjsHU/Vmm7WNlmZDBXRwA5bTyPyHNb6A98LaCrOiNIwaXhrJH1c9wuldJ41ZXT/fmd5DA4DQOAB2VmQEREBERAREQEREBERAXCcZiK5oeUFd1GKk20+xCuM24f4LwfEx/wDy+7j/AHUFZW3f60g9qGovByd3tQofD7H73h+/+Suz4SD7vIXERPJ+6g+wD9IFlLhFGGD4rmgIiICIsOquEVPVx07s73NLycHDW+v5oMxF8aQ5ocOx5C6KiqENVTQloxMXe9nGMDKDIRR9BXvq6qpjMIZHE9zA7cSXEHHpj/dYgvrvHqI3U4AikDGnf979IGE9vLOUE2ii667ezVL42xMeyNrXPJk2uIcSPdGPe7fBfaG6e01pgMbWNO/adxLjtdtORjA/MoJNERAREQEREBERAREQEREBERAREQEREBERAREQEREBcHxMe9j3NBcw5afMLmiAuqengqA0VEMcoacje0Ox+a7UQdUdNBHM6WOGJkrvvPa0An5lcTRUp8TNNCfEOX5YPf8APn1XeiDpFJTjw8QRDw/ue4Pd+XouTYIWyulbFGJHd3hoyfxXYiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIIi832C2vEW0yzEZ2g4x8yoj7YO/ch/N/soG97/rar8XO7xD39PL/bC1/qek1FLq+2T2t1ULWxsYn8KZobnxCXZYSN3u4H48ZxheXVqblVcxE4h79vQ2abVNVVM1TOPHvbe+2Dv3Ifzf7J9sHfuQ/m/2WpKGnvreodwmqWVbrI9rfZ3+0t8Jp8MB2Y855dnnHddGnrfqWHWte65VE77HGZH0znTBwk3luGluc+6M9wufT3fj7s9zvqenz7ueOO//ALx4NxfbB37kP5v9k+2Dv3Ifzf7LS+nKTU0do1HHcWVra57JPY5JKtrw4nft2AH3CMt7/D0Xfp6j1Q3T18gu00n1jJHso5DKDz4QAcCCdp3cn45Kmb92M/z8iNJp5x7Od/P9tw/bB37kP5v9k+2Dv3Ifzf7LSlRSark0ZcWs9rF2kqWOhjFS0SNjGzcN27Azh3n5q5WNs7bPRtq2Sx1Aib4jJpBI8Oxzlw7n4rmrUXYjO15OqNFp6px6OY3fNeftg79yH83+yfbB37kP5v8AZaj0vT36LVd7fdo6w0L5JDSSPqmuiDC4bWiMEkHGefThYWhaTVsF6mdqJ1S6nMbtzn1DHxufu93YwDLRj4j5KZv3d/8AOPs5jSaeZiPRzvz47m6ftg79yH83+yfbB37kP5v9lprTVHqmLWlfNdXzmzOkqDA10wcAC9vh8bjxjOOOOfVYmkaPWsWrpJb3NI62Ey790rHMd+xsaDlv5DhT6a7v/nH2RGl0+72U75x3/wDeLeH2wd+5D+b/AGT7YO/ch/N/stS6cp77FrG8yXOOsNte5xpZHVLXRBuW4aI85B78/NdGkaTUsOrLrNeX1TrY8P8AA8SZpbkvG3a0E4w0d+O/ZRN+7v8A5+TqNHp5x7Od8/Nu23apgqJ2xVERg3HAduyM/HhWJamW0Lbv+r6bxf1nht3Z9cLTpL9VzMVdzz+kdJRYmmq33slERbXmCIiAiIgIiICIiAiIgIiICIiCIvNiguTxJuMUw43AZz8woj7Hu/fR/K/urcior01uuczDVb1t+1Ts01blR+x7v30fyv7p9j3fvo/lf3VuRc9UteHms9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6Vy3aWgp52y1Epn28hu3Az8eVY0RXUW6bcYphmu3q707VyciIi7VCIiAiIgIiICIqL1q1bXaL0HU3W1RMkrDKyGN0jdzY9x+8R59vzIQXpF5O0z1O6mV8tNU091ttzjkkG+jAp/Ga3OD+jG15/DKlperGsIOttRZ2uqam1R3GSmbbGU8e9zBkAh2zdj/X37IPTaLRtz+kNbrffbpbJbDWPfRSywhzJgfEcxxbwMcA4/Bdtj6/0V1vrrYLBVQvbDPKXuqGn9VE+QjG3z2Y/FBu1Fpax/SBstdYrvdK62VVHHQGFjYxI2R875N+Gt4AGNhOSuWkOv9k1DfILXJa66inqXbIHPc17XvP3WnHIJPA4PJQbnReYekPVvV1211NR3qSouVB4EzzAyCNns+3BD3FrAcDG3nzcFbbb9IOhrrHeLk2wVLG21sTnMNQ0l/iP2cHbxjug3ii0FU/SRt8FNRzHTtURUxmQD2lvu4e5v7P/AGqWn+kDYaezVFfNba5rhVOp6aAY3TtaATIc42t5HqeUG50WlrH9IGx3SgubzbKymraOmdUtp5HtxOG92tcOxxzyOyaT6+W/Ud3tlugsVZFPW1QpyTKHNiBxh5OPUnj4IN0ovMP0qb9d7VrK0xWu619FE+gDnMp6h8bSfEeMkNI5V61F170/Yr7WWk0dZVPo2Pa+dhAY6VrfuDz5Pu7vI/DlBuRFQekvUmn6i01ymprdLQiiexhEkofu3AnyAx91VXVv0grDYb/VWumttbcPZZDFNPG5rGbgcENz3weM8IN0ItJ376Qllt9BaqyhtdVWw10bnkGVsboXNdgscMHnz4PYhZH/AF9sDLNX3Got9bGyGoFPTRcb6nIJ3AHG1oxzn1CDciLR9D10tGp7Ff6SGnr7Tc4rdUTwHc0l2yNzvcd5OAGRkeSq3RzqjHp7Q2oLnqWuu1z8GrhihZNJ4ji57XkNaXHjhhJycccD1D0yi0hYfpFWG4VYir7TcaGNzHvbNlsjcNaXHPY9h5Z5WLT/AElLJLV7XWG6Npdwb4wcwkZ9W5x/ug3yi0rfPpDadtt2uFDBQVtWKUOaJ2kNZJIDjaO5A7+98PjlR0v0jqCO0U1edO1RbPPLAGe0tyCxsbs52+fiD8kG+0WotM9dLHe9V0Vidbq+klq/DbFNKBt3vYHBpHBxk4BxzwexUZfvpF6ftt5qKKktddXQQSGN1SxzWtcQcEtB7jPrhBvBFqbUnXXTVosNpuNNDV10lyjMsVOwBjmAOLTvJPHvAjjPYqU6XdWLR1AqqmipaapobhAzxTBNg7mZAJa4ehIznHdBsVERAVI6w2i/XrRzqXS7aeSuE7HuhqNpjmjAO5hDgWnuOD6K7og8ds6Na9ut+pXy2CisrA5u+ogqIwxmDnfta9xz/CB2Vx1V0z1vbur/ANqNL00FbG+cTsmfKweGS3a4Pa4gnz7ZXpNdck8UTgJZY2E9g5wCDz3036eaptHXGuv9ztXg2mWorHtn8eJ2Q8u2naHF3OR5KO1R0o1lF1Tu98sVLSVNHWGpkZLJM0Bomie1zS0kHPvkDyzgnjK9Lte15Ia5riODg5wvnjR+Js8Rm/8AZ3DP5IPI9j6Iayn0lfaStt7KOsM1NUUrJKiNwn2CZrm5a44OJAecK7aJ0x1PqtU2KTUtBa6K2W5scZkfBSySGOPkNaW7nAn1BGO69AunhbJsdLG15/0lwB/Jcfaqfn9PFx398cIPNmjul2t9J9TKmejpqeWz1fiU81b4jCPZ3uBPukhwdwPJVum6N9QLbZ9Q26G20k0NU2JoLahmZtkocNmXDHmTux6DleuWVELyAyWNxd2w4HK1VfusTbT1Vi0WbIZS+qp6b2z2rbjxQw52bPLf2zzjyRDRVf0Y19LQ2qNlgJfDC5sg9rg90mV7v2/Qhbq+kD06vGsY7PcNOeE+utxcDTveGbwS0gtceMgt8yO6xqzrwaalvcz9JV8YtsjWDx5vDEmXhvJ2na7nOOeM8rYHTLWbNcaVp7z7IKAzSSRiAzeIfdOM5wM/kg0nQdPOodxt+oai9W620809HJFFTtZA6eeQt2j9Ny4DHOS/4dle/o36QvmkNO3am1HQexzz1QkjaZWSbm7AM5aT5q+6wv8AWWWCBlrtFRdK+oJEcbHtijbjHL5HHDRz8SVNipY2GN9Q5kLntB2ueOD5jPmiWgPpHdPdUav1VbazTtrNZTw0Qie/x4o8O3uOMOcD2IULe+lWvaDU+q/s7HSy2u9QzGSVz48ua4l/hYcctcXe7nt55XpxksbyQyRjiBk4IOAkc0UhIjkY4juGuBQab+jXou/6OoL7HqSgNE+plhdEDLHJuDQ7P3HHHcd1SK7p11G0vqjUb9I0VHX2+7ueHSyGF36Nzi4AtkI5GcHggr0wKqnIJE8RxyffHC1/1h6nN6cR2l5tRuIrzKBio8LZs2f9rs53/wCyDS2u+k2vbpbrDi20lZWRwyGoFJ7PTsiJdw3ALQ44AyQPP4LZ3XLp1dtYWCwy2PwfrK1Z/QSODQ8ODc4J4yCwd+O62bpu7svWnLTdXRin+sKWKpERfu272B23PGcZx2UhHPDI4tjlje4eTXAlB5nj6Za+1JeLzqLVdNSwV/1ZUU9PTwvjBnkdA6NjfdO0D3u5P9sDTPSvW9DoS82+awUUlTUV1NMKasmjc2WNjJQ7a5r/AHXBzmc5acZ57r1OKiEvLBLGXDuA4ZCMnhkDjHLG4N7lrgcIPLukumvUqCera6ipLbbfAmDLdU1LainLnMIDWsLn4y45yT6/JYVm6YdSoL1D9W2qmsFOXN8Z0Nbuglwe72GR5d8sY+C9YRyxyAmORjwO+05XFtVA4EtniOOTh44QeWbh0j1/aqvVNusUNLUWe5t3GQvjDpmtfuYwBxy13PPYcd+yr9R0a16/TNBSNsJNRFWVMr2e1wcNcyANOd+OSx35L0x1D6j2PQX1f9eCrf7aHmL2aMP+5tznJH7Q/wB1ZLTdqS52aiudPJtpayFk8ZkIB2uAIB+PKIeb4umGsG9WdP3g2ci20ptpmm9oi93woYWycbsnBY4cDnHGVi0/TbqZpGpvds0zQUNda7g8Znl8B4cxriW5bIeDzyMEL1Q1zXtBaQ4HzByomXU1liv7LHJdKRt3eNzaQyDxCMZ7fLlEtA6z6SayqKXTN4oDQVV9oYdlRTwbKZjXCR0jdm3a3/UQe3bKuXRLSer7XebhdtXU1tohMxzWQQwQmZznOBLnSMBJHHm4k557LcaICIiAiIgLyj9LsluuLKRwRbwR/NevVy0j136UX3X+orfX2aptsMNPS+A4VUj2uLt7ncbWO4wQg0/o641ts6gVztFXS43EyWuonqHzMcHOm9nc525p7kS4wT5+vnT/ABbd9mxeBfbh9r/bf1GHY8PGfE8T9rPx/DzXuiy6ctNnnqKm3W2kpquqO6omijAdK7uST3PPKrNvtnTev1M/6vg01UXxj3PdHCYnSte0+8S0diD3OEQ8264rqiLq/pa6agJgmMNrqap7xjBDYy8n5EO/JU2KRsr9ZSRncx9OXNPqDWQL3TeNM2O9VdPVXa1UVZUU5BilmiDnMwcjBPlnyUT/ANONHZqT9nbfmpG2b9H98bg7n/zNB/BBpf6MWh6S40NJqyatqxVW+smiipwR4WDG0E4xnJ3evkFX9e//AIrqX/8AdLd//SFeo7BYrXp6hNHZKGCipS8yGKFuGlxABP8AsPyWDV6M05V39t7qbPRy3Zr2Siqcz3w5gAac+o2j8kS8I2v/AAGof/0rf/8AREs2OenptPWeqtt4rvtDDVPa2ka1wbBHnc1zHepcTwP+OfaUfTPRcbJms03bmtmbtkAj+8Mh2D+IB/BZdDoXS1BNSS0lgt0ctISYHiEExknPBPx5RDyNruolu3Ui/N1vXVFHJAHCAEuAaQBsAAa7gjnsM57hRur5/F0FpiOO6VVxp4qmsbG6eAx+F7sBLGkuO4ZOfhle0b/o7TuoZ2z3uzUNbO0bRJNEC7Hpnvhddy0Ppi50dFSV1joJqWiDhTxGIBsQdjdtA7ZwPyQeetT6Un0b0RbfLJcLhLUX2Gh9uLnD9FEYycNIAIbktb8uFS+nf1ZRax0zPadQVsNdK+Lxo4YHTbpC7DozwzAI4/1cc5Xriiu2k6s/ZmkuFnqHRMNKba2aN7g1gwWGPJPAGCMcYXKy6J0zZK41tpsVvpKvBHixQgOGe+D5fgg8hdDtGUuutUXG1V1ZVUtO2idO405AL9ssYDTkHjnPzAWy/pfRCC36PhaSWx+0sBPngRBb00/ozTmnaySrsdnpKGpkYYnSQswS0kHHyyB+Sj9ex6IqH0cWuZLMHMDnUzbhMxhwcBxaHEegQeXdV1gn1Louk1Jcq23WOnslC+GamaXOj/8ADtdvaB5+IMZ+HwUx9FI7uqVwduc7NtmO53c/pYuSvTc+ldOXGntfjWmgqYaBjBRF0QcImgDaGn04HwXyxaN07YbhJXWaz0lHWSMLHyxMw4tJBI/MD8kHlrrOyo0J1hu1bQN2sudJJIzyx40bo3n8H7j+SjK+23LT/Qu11lN40MN8uL5Kp7MgmNjdsTCfQkSO+PC9dai0jp/Uk0M1+tNJXSwtLI3TMyWgnOAsx9jtcllZaJLfTPtbGCJtK+MOjDR2GD6IPJ3SAW2h6l2xlgv9aRKza+BkDpGzZYS9ryQzAGM52nGO5WvNOUftGntU1Hjzxmko4pAyN+GyE1MTMOHmPeJx6gL3PYdH6d0/NLNZbNQ0Usg2vkhiAcR6Z74+Cwafpzo+np6qCDT1vZDVMEczBHxI0ODgD/5mg/gg8Z34zVfTnTNZUOllfFV1lGJHuJ2xtEL2M+HMkh/H4LJuVXba+52C3T109NpqChiDSHPDWyFm6YjLXHmcyDIae3HGF62ntvTygpTpeoZp+GKSbxfq6WSMEyEAZDSc7iMBSc+gtKT22noJtP219HTkmKMwDDM8nHmMoNVfRWljFJfKaku9XXUkbmOEMtOWMhcd3LXEnOQBkYHYKRu//Tv/AK+U3tnt51Xujxj/AA3jbBsz57tu3Hl2W27LZ7dY6FtHZ6GnoqUHIjgYGDPrx3PxWPJpqyyX9l7ktdI67sG1tWYx4gGMd/lwiUuiIgIiICIiAiIgLxfpC2VN66qaytlAGmrq4LnDEHO2gucXAZPkvaC1JobpBJpjqPV6pdemVLZ3Tu9mFNsLfEJP3tx7Z9EFFvOtNS9LNNaT0VQU1F9eugdJNJM4PY0PmeGBpyB65JOArFoXXPULUFDfrfX2qOmuVPTPloq9tOfAfI0j9GTktdu8iD6q1dWOlVNr2robhDcprXdaNuxlRGzeC3OQCMg5BJIIPmVD6S6NVGnLffJItS1FRfblTupm1skR2wtcRucG78lx9S7hENX23rrra7OtdooG0f11UVhhdI6nG1wdsDBjPBB35PyWZP1s11c7lWt03S0E1LQkNLXRAyzDON23dkkkE4aOFOw/RuNNTUL6PU3g3OnqHTGqFIeR7uwBu/gtLXHOed3wWVdfo8GeuqZrXqia3wVmDU07Kcljj3cBh493OSAc49SgrmuututLW6yeHQxWqoqKES1FNU0xz4niyN3N3chpDWkD+q74ututYda3m0T2y3SvpxVBtMDjwTEx7id+feADDn18sKf1P9HiG5ttUduv76aKhpBTuM9P4z5Xb3vLyd4x9/GMcYWc/odK7Xt21H9fsDa41hFP7Ics8eORn3t/O3xM9uceSDX3/X3Vc2jZ6ljaCO409dFEZWw5a+N8cpwWk8EGPuPVStn63axpK/TlVqG2Un1HdcRtka3D5AHBj5G4PBBPYjt+aq3VLpXN070UCboLka+4Q8MpjHs2Rzf9zs53/wCyufSXo3S3e36Y1Lc7pUyUkcYnZbXN91sgeSfeJ4aSASAPxQa+st/ZpbrnqW9yRGUUdTcpBHnG92ZA0Z8skhW2y9ZepFdJT3Cns9FcbfLKW+zUsJc/APIw1xc34Fwx81dafoNA/W13vVyvAqaK4vqnPpG02xzRNuxh+48tLgc48lF0n0cvDqoIqjVtZJaIpDIKVkJY744O8gE+oag2F1a19JorQcd6pqQurap7IYIZwQGPc0u98d+ADx6rzD1jvuqL63T0+sbbHR1LqZ0tPJHgNnieQQdoJwR6HntwvWevNDW3WOkfqCrdJTwx7HQSx8uicwYaee/GQfgVqK5fRvlrKajY7Vs8ksDSwvnpzIAzPutYN/ugD59/JB0au6t6npNSQaZ0fTUIdSUsQfJU7d0jvDa44LnBoHIGO5WzOjOrr/quyVT9U2eW3VtO8BshhdEydpBwWh3mMc/MeqretOh0d7vUV4s9/qLRcTCyKZ8cZcHlrAzcMOBbkDkZKuHSnp9S9P7PUUsNbNXVNS8PmnkG0HAIAa3JwBk+Z7ol5K1K65S6rrqnW9Zead75HOhqYIvFYeTgsy9o2Y7bT2V3k6l33RWhtPRaevlPdI6iWq3zzxue8Bpj2tIfy0gOPHI5GCVca76PFc+Keko9a1UdskeXeyyU7nN75GQJADz8FIXH6PFtqNJW21U14mhrKSWWZ9U6EObK6QNB9zIwBsbjnyRCHb1b1QerFssHi0n1dUOpA8eAN36SGN7ufm4qF0R1Y6navrKqhslPb6yqjjEp/Rsj8Nu4An3nAHvj8Vc7X0GloNbW6/8A2lkqG0j4XmOanLnv8NjW437/AD28ccDA8lMdHukEnTy+1txfem3AVFN7P4YpvC2+812c7j+yg8/6at1bdevD4bqaaarhus9RWFxcGO8Jznybcc9mO2+WcZ4V1b1u19eqqsrNO223uoIZQ1tMI/ElIJ443b3H1LRgfBbH070bdaeqdVq+W8sqIp6iqnNH7MW8TB427957b/TnCr1f9HNpraltp1TV0VqqJA99IYS7gHIGQ8A48iQg3Po27VV80xb7jcKCW3Vc8eZaWVpa6NwJBGDzjjI+BCmVFaWsdNpvT9DaKF0jqekj2NdK7c53OSSfUkkqVRIiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiKMqp6r2mVkB2sZxwwOycA+ZHqqb16LNOZiZ5OqadqcJNF0U0kktI15aPEIPB4Gf91gUNwqZp6VksUTWStk3FriSC12MDjt8f8AYKyiqK6YqjvczGJwlkVfqLpWx01fPtibHDN4TCWcfrA3JO70J8guyO51JqaOAeFJ7Q0ObI0cYBO/OCR2xjnuV0JxFAQ3eqdNVNfHEGxztjadpGQZiz154HfjlcHXmq8KscwwOfDP4TWBm52PE25I35PHyQWJFFVNyfBZIqyR0Ucj2tPPvNyfIc/8rF+uphJL4ngMYyMvPBdsw1p3Eju0kkDCCfRQVDeJ6itpIXsjDJWbi5ozuPvdueMbRnvycKdQERYlbJLuEcJLTsc/IAJOMcDPzSIyiZxGWWixqKVzw9r3btuMOIwSCM8j1WLa7hLV1tXFKwMETsNbjnGSMk588ZxgceqnBE53pNFX6G+VFRVwQOga0mSRsjsHGAHFmPntOfkvhvVU19LmBhZNHTuL2g+66R2CCPTAOPioSsKIiAiIgIiICIiAiIgIiICIiAseWkilkL3bg498OIyshFzXRTXGKoymJmODjExsbAxgw0LkiKYiIjEIERFIIiICIiAiIgLrmhZMAHg5HYgkEfiF2IhjLhFEyJm1gwO55ySuaIgIiICIiAiIgIiICIiAiLpNTEKttNu/Slpfj0CiZwmImeDuREUoEWBcq72fDIsGTuc+SwPrOp9W/krabNVUZhXVdppnCeRal6kdRLtYamjt9mp2T11T72SzIaPl+BVOu3VHW9N+qhia4DkGkyM/NU11RRVszO9dboquU7VMbnotF5hPVLqZh8gpaYQtGcupQM/LlbJ6VdQbjqyyzSXBkMdbTybH7G43DyO3y8x+Cm3MXJ2aUXIm3GaobVRQP1nU+rfyWZ9YTvpGvpKYVE4e1r4zIGYBPLsn09FZVaqpjMqqbtNU4hJIo/2m4f8Au9n/AMwP/ou6jfVySSOqoo4Y8AMa1+455yScD4fkq1jKREQEREBEWDeaielpBLTt3bSd+GlxDdp5AHxx+GUGci6J52ikklieHbWFwLefJdzHB7GuaQWkZBHmg+ovjyQxxHfHC8uXDrJriDqPJYYzR+D9Y+zMj9mBcYy/A5z+yQcoPUiLzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiLqnnjgMfinHiO2A/FRMxEZkdqIikFW6FxdrKsye0eB+TVZFWbf/nKt/g/4aqL3Gnm06fs3Pp/MLMuuolEML3u7NGV2KOvb9tO1o/1O5WminaqiGSudmmZQ0j3SPc9xy4nJXFEXosCh1tD7RreqqZmgmJjWR/AEDKn2wsDQC0H8FjXOBzbxPI3hz2NI57jssaA1ranD9ng+rHE4/NfM6mfb1c31+hjGnoiO+Hy9QNdA4bRghV3pvF7FrK5QRjEc9P4px5ODgP8AlZdZNWVBkw1hjaSMOeW5Xb06pX/XVfUuydsLYyT6k5/4Vuin28YZuk4zYn5NhLvo5zTzteO3Y/JdCL6GYzGJfNROJytgOQCixra/xKKInuBj8lkrzZjE4b4nMZERFCRF01kxp6aSUM3lo4bnGT81ixz3M1MLZKGnbC5xEjxUklgwcEDZzzgdx3ygkEREEXdWWq2UVVcqylgbHBG6WSRsILsAZPYZK5UdDRyxxVNI6oZG9ocwNmka0A9vcJwPyUi5oc0tcAWkYIPmvqDGdSOP3aqob8iD/UFVd3TqwyX8XqWEvuQGGzlrAQPThuPh6447cK4ogqN96f2S/XKmrrxEauencHRmRrPdPHo0Z7Dg5CtcMTIImRRDaxgwAuaICIo603CeulrWT26pohTzGJjpi0iYYB3t2k8c+aCRUHq8kW+MjuJAf9lOKC1h/wCzY/8A4g/oV5vTH9G7yXab3tPNNxnMbSe5C5LjD+qZ8guS9GnhCkVZt/8AnKt/g/4arMqtSSCPV9a4gn3PL5NVN7jRzadP2bn0/mFpUVfc4h9Of+Fme2M/ZcsK6ytmpxtaQWnPK2Wt1cMNyYmmYhEoiLcxoa7scyujmI/RuZ4efjklR0tY2NznFzdreAzOPxTWd8bbq6y0JjDzX1Doy/P6vEbnD8yMIRDhxIDXHzwvndfTsX5x3731vRVe3poz3bkJT1kb6qZhe3a88MznHxU1oSF7frGY/q3yta34kDk/7hQNwmgppi7LS/19PirNoOugrLEzwuHtc7e09+TkH8Qrejrc1Xtvuhm6XuxTa2PGVjREXuvm0/Zxiib8z/VZqgKe7SU0QiFqrn7cjc0xYd8Rl+V2/Xkv/ue4fnD/APcXn176pluomIpiEhdal1Hb5p2AF7R7oPbJOBn4crr8O5fvVH/8s7/7iirjcZ6+kdTMtdZEZHNG+R0W1o3AknDyew8gpr2xn7LlziU7UOiWlrp2iOarpvDJBcGU5BIBzgEvOPyUgsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkosb2xn7Lk9sZ+y5MSbUMlFiSVn6N3hsy/HuhxwM/FULQNx1lJqfUbdTQUTbaKkeB4T3kt/RtwI8jluMZJx725MSbUNkIsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkqC1h/7Nj/8AiD+hUp7Yz9lyhdVTtlt7AAR+kHf5FeZ0xE9Ru8l+mqibtPNYYf1TPkFyXGH9Uz5Bcl6NPCFQqlH/AJsrv4P+Gq2qpR/5srv4P+Gqq72qObTY7Fz6fzCXXF7Q5pB7FckWt5qqakvdPYo81AdJK77kTO7v/oFQbpre6VVQ1tJG2lgDXOdt5c4YOBkjgrZWrdOQ36jxwyqjB8OT5jsfhytRXC21FHN7PWRGKXducCMAHPugeuSF6mlqt1xv4s1ymYn5MC/RvrrdM1gkkr97Z43l3vb2nG7J9B/VXDS9c+6WOCadofLtw4EgEOHfKrMrZI6hs0R2StccZGRggNPH4ZWTbRNT0kjoJ2sDow/BBw4k+Xx81k6S0E6nFVPGHq9F6+nS5pr4Si7vUiXUctK8NMccZkMbXZHcAZ9e5/JR0NbVNubqimMlO9oDQ5jiCRnjP+6z44HATOe4GSbAkfjJOCTtB/Ht81xZTnxmgYwHbTznLifX4bT+a26XT06e3sUw8/VXqtRcm5Ul9P8AUG7UzR7e1tXCXluXDDhjsAfj8VtHS15ptQRGSmDmmPHiMcPu/j2K1RpzT1Vdm08FLCcOO98h+6wcjJ/Jbs0/Z6ayW5lJStHHL34wXu8yVXqqqKIxHFXbpmZ+SSX1EXmtAiIgIiICIiAiIgIiICIqL1LqdXQPtH2Up6WSJ1bEJy97t2M8hwAwGepzn4KCIyvSLppDOaaI1bY21G0eIInFzQ7zwSAcfgu5SCitRf4Jn8Y/oVKqK1F/gmfxj+hXl9Nf0bvJp0fv6ea0w/qmfILkuMP6pnyC5LdTwgFUo/8ANld/B/w1W1VKP/Nld/B/w1VXe1RzabHYufT+YS6Ii1vNFgXW1Ud1h8Osha/H3XdnN+IKz0SJmJzA13c+n8viSPoKprmu7Ml4LeMd/PlQ0Wkr3FROiNGQ8YY3bI1w2g9+/wAfTyW3UWmnV3I+aubcS1DFoy8SvJNK1vOG73hob6nj5u/NT9n6esiMLrjVeIIyD4cQwHHjufwP5q/olWruVbuCdiGNQUVNb6VlPRwtihYMBrQslEWaZzvl2IiICIuipqoaZoM7wwHgZUImcb5d6LjG9sjGvYctcMgrkpSIiICIiAiIgIiICIiAorUX+CZ/GP6FSqitRf4Jn8Y/oV5fTX9G7yadH7+nmtMP6pnyC5LjD+qZ8guS3U8IBVKP/Nld/B/w1W1VKP8AzZXfwf8ADVVd7VHNpsdi59P5hlXm6UdltlRcLnMIKOBu6SQgnaM47AE+aitN6009qV07bLdIal0DQ+Ru1zC1p7HDgOPiuvqTZqvUOh7tarf4ftVTEGR+I7a3O4Hk/gtLw9HNVMstwot9tEs0EGJzNIXzbNuYHHsGDHGB/patTzoiHocVdMQwiohIk+574975eq+CspixrxUQ7XHa07xgn0C0A/pBqRuk4BR/V9Jeqe4GpgiineWRxubhw3OzzkN4AxwuF+6LXw0Niht3sFWynofAnhqJnsbHO55c+Ru3vy7HrwEynEeL0G6rpmvLHVEIeCGlpeMgnsF8FZSlwAqYSS7aB4g7+nzXnm+9HNTVlRdJYnUT5ZXUhgk9ocP1ce155ye+MZJK5UPSHVdPeKRzpKE00F5FeZhMd5ZluTjHcY7eqZMR4vREc8Ukj2Rysc9n3mtcCR8wqu3qJpV2oPqQXZn1p4/s3geFJnxM425247/Fa76V9MNQaZ1lHcbmaDwIWSNfURTSOkqS7OCRkDzHcHt68rGh6a6rp+ol3utOy2Cgr6qSQTSSEyRNduw5oHZw3Z+YUZkxDbupNU2rT9mq7nXVAfTUpaJRDiRzS5waOB8Ss613WjuduirqWZhgkjbJkkAtDgHDd6HBC85wdF9VC011L7NaIZXQCETR1MpdUnxQ7LsnaOB6eQ481Iy9H9UNprxTUUtHT0tVDSO9nE7gyeSNrQ8PwMgE7jnzTMmI8XoM1MDYRM6eIRHs8vG0/ivktXTxFglqIWF/3A54G75eq88VfR3VMmn6aJr7cQytmqPqnx5PZ42va0ANcecjB8/Pv3Xy8dHdS1DbM1lPbZ5aWnbC576uQxNG5xLdjgXHG4YIcPkpyYjxej1Bar/UQfxH+imoWlkMbDjLWgcdlC6r/UQfxH+iirgov+7lqD6Qurb3pqi02yzXmS2QTRyPnELR4ku0N2hri0jzPGRlVGn6s6xsVdXVVwq3VcLbFT1dJT19IYxNI50Qc73Mc4c898Lc+uOoVBouns1LVWysuVVWxPkjhpmtO1kbQXOO4jsD/so2PrRaZKq5MbZbuaa200dXV1Phs2wsfF4jcjdnJ4bj1+HKLqOzG5UdYdYdX6UmiiuNusj31FqFxgMMczmlxkwGElw7N5PxWJSdaNVXe9VFpp6G2000lPIIoRFOakO9n3tmHBYWF3YHnH5mfqetlJcaq0RW6lr7fO+5U9NUU9RSMle+OVu5mCJBtDgO4yfgu5nX2zOoKyt+zt6Hsr2xvbsi3tySMvG/LBx/qx3Cf66x8lAtHXXU1q0vbhVto7jVOoJ55J6mCQPM7ZnARnaWjhm08DzHKtVs6vavr7Zqa5wWe0z0tkhikfDG2UTSGRmQRyRtack/9o/FSlx+kFp6ipmTvs12kxA2aTYIiI9zy1oJ34OcZyMjGF2P+kDpuCvlp6q2XSGOOompnTbGFu+NuTwHZ548vNP9MfJWbN1s1beaux0NDb7C+ouVZJSMqSyoEDsNaQRnB4Lue/4KX6s6wvulepNolo3S1LIrJUVMtBG9whllaHclo7gd/XAUpD10tJtJrJNP3qOR00ENPT7Iy+czNc5hbh2OzSefUKYu3Vq0W3Q1r1RPbriaWvqBStg2NErHe93BOMe6exQ/xH9EepV017cb7T3SmoIo6COndE+kZK0SeIHEk+Jzj3eOB+PdbZWm5+vunoadj22m8PnZ4pqoGxM3UzY3Bri73sHk+RK+1HX7TsVU6GO33KVvtgo2yNDAHEjIcMuzjH4qcomJ8G40VS6c60i1zZjdKS119DROx4MlUGgTcuB27Sexbg5VtRyKK1F/gmfxj+hUqorUX+CZ/GP6FeZ01/Ru8mnR+/p5rTD+qZ8guS4w/qmfILkt1PCAVSZ/myt/g/4araoqptv/AKTNbF3czY9vr2wVxXRNU0zHdK23ciimuJ74x5IjVUNzqNPV0FilZDc5IyyCV7sBjjxuzg9hk9lRY7X1NiohGy828yMpGtBc1pLpg4AnJZ2LAXZx94+i2iWkdwfyXzB9D+S0MTXEtu6hVFmvUE9xoo62VsXsUkDw0RkOG/nZkZbnvnnyCwp7H1H8OllgvVOZ4XPaI5Hgt2FrACSIxufnfy4YBwcd1tTB9D+SYPofyQy1lqWya/rqihdbLvT0zRQNjqh4mA6fD9xADfPLcEYxjsouq051Ofdo6qG80TWQt2Rs8d+wgB2C5u3BPLck5yR6YC3Dg+h/JMH0P5IZVPRVLqyGapk1ZX087NrGwRQNbjO0bnOIaDnIPw5+StiYPofyTB9D+SIFBXvV2n7IS26Xejgl/wDyvEDpD8mDLj+S+a8ZcX6NvLbMJfrA0r/B8P7+7H+n4+nxWv6Kp0taZKKeyTSUlE5kT/ApaCR1bI8AhzZCGbiSdpyT3yomcOqacrJV9QHSRudZdP3SsYAS2epa2ihcAMkh0pBIA8w0qOqL1qm4Udwl+srRa4qUs8SOghfW1DdxGGgu2szzjscFYdLSXKrkndbNKXGfx3bnz3qpFKx5OCS6Nu95yQDjj0+CnKXS+p5nvfU3yjtLZBte200Q8VwznmeXc48k+SjfLvFMIW6WaqpaC6XGu1BqSmqKSmkqIa+oqmshEjCdrDEGhhDhtOOTyRxjmyyVtRcdK2WtrYvBqqiBksseMbXOYCRhc6Xp7Y2VTKu4x1d3rGkET3KofUEEdsNcdo/ABSWp4nuggDGOOHHsPgkxuZ9TMTbnDWfWO66bp36Ztup9NwXgVEE80Uss5i8Dw49xGQM4dxn5eaidFa+0C6+XOhrrNbrI240dJHLI6fxYqprowGRbdoAa1pxngKw9UbBp28V2mxqOtudJOylqmQey07nsLXRYeXkNOMDt2z8VGWXoZpa40lLXU92vNRQVENO0xkiNs0cWNoeNoPJaCexGPJSsoxsxlxoavpDR1tfbW01opqezzisD2yPcXStO1zgB94NyB3PnwByeojoXFQCMi0tgrJcgky7iW8Z3d2t97HkPyUw7oJYM3dsVyu8dPcGvb4DZG7Itzg4ke7z243ZwpDUXRqy3uezTurblSTW6kjod9M5rTLEzGN2WnB47jHdHWYYVDYukmp7obHRW611ddQRPp/Ajje0xtjeC4bhj/Ue+cnJ5PKqulr50muVohvF9tFvs1TJV1EzIKiZ8xe5uA+THbntgjnGBlbc0Romi0g+8voJaiZ1zrH1shmwSxzu7QQO3zWq63ovpCjuFs0/JdL9HX1kNQxkkLfdljJ3lr3Bm0AHkA4z8UIWKrsvSSzWKnpKuhttPbb0z22HeyQ+MI2btwd3GGuOBkdz6qL1ZL0x1HZNPaWgvtLbKSKeKspaaCMgPBB2tO4YG7cTzyc/FW3WHSiz6p0bZdPV1RVxxWlrGwVMW3xSGs2YJIxgjGePIKuHprpOu6kSx0VXeKS4UNPTunpoWFkD2sYGMw8t54xlrXIQi73e+izdNxyRUNtuMFqjNTDS08JEm10gae+M+8RkOPxUju6PXW826etp7bDerqIaxkUm9jw+RoLA7adrXHI48+/OcrGreh+kbDZjLdLtc20MNE+hc523OHyl4d7rclwc7jjyWVpTpVpa43G36gs18vFR7IIYpCXbPGdC0NZuywOHu7QQMAhDc2FpyWx2OvZo+y0stL7HTe0sibE/wmsc85xIeCdxJxnPKsqgqyiFtu9bqKqudw9jjoyx9FndAwNO4yNYBnfgYWRpi+0mpLPFcra2oFNIXNb48LoncHB91wBUuUqorUX+CZ/GP6FSuD6H8l8ltxrfCEnuxteHHPn8Fi6Ss1ajS12qOMxhdpqoou01T3JWH9Uz5BckRaIjEYdCIikEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBdT52McWkSZHpG4/wBAu1EGLV1jIKCpqfeDYY3SHc0jgAnz+Sr0FwrLa6BlVVurJTQiWZkgaNsxLWsA2tyNxLuME+7wrRPDHUQSQzxtkhkaWPY8ZDgeCCPMLGbare2mfTtoqYQPcHOjEY2kg5BI9eAhKHpdQVNW+OCnpozUOqXw7nFzGhrGBzn4Izw5wbj1Sk1DPUS0INIyOOoZGRI5ztri7khrg0jIHYOIJU3TW+jpn7qalgidzyxgB5xnt67R+QXyG20UEjJIaSnjewBrXNjAIAGAB+HHyQQVyvb6O/TxMbLM0tigYxrHvDX4e9zi1gJ+7s8vMdu6N1JUOpaWYUQY2UO3SSbwwEP2gHDCWh3cFwCnpqCkm3+NSwv3v8R25gOXYxuPxwAM+i+G3UZfG80kG+MBrD4Yy0DsB6YQYN5u01BVQxMp2mN4BMzy7YHFwAaS1p259TgLHF9qNhqnQUraFxkEZdPiQ7cgHbjzIxgZIyPkpiWipZahs8tPE+ZuMSOYC4Y5HK6TaLcTOTQUuZ8+KfCb7+Tk54555QV6s1DI+kcZg+nEFWwSOjD2ktZH4zhhwB7Nx8crPtWoX1U8rKmjnia2Jsvu08u5uSRtILAT8xkd/RSsVsoYXExUdOwk5JbGBzjbn8uPkuyko6aja4UlPFCHdxGwNz+SCLkvmxxHhN96tFLHl2C4Bgc52PgA/j4LDg1FWvpKWc0MUhqqR1VFDFLufxtwDx57/L5cqWr7NR1UdSWwQxVUzHN9obGN7S5pbuB9cHC5Q2e3QwuijoaZrHgB4EY97HIz688oMNlxqaux1U1OYI6rLoodxc0b+wDg9oIdnjBHp6rAivUlJBK10tRLUNlIkjq2tLoQ1gcT+iaQR7zefLdyfJWJ9DSPozSPpoXUp7xFgLTznt27rpNntpZGw0FKWR7to8JuG574488DKCG+08hFA5tKMT+ztezLiWPlIy3IbtBaCDyckeQXZaquqdeRHXVMwMolkhYzw3QSRBwDS0gbgQHMznuSVKts9ta9rxQUoe0tIPhNyC3Ab5eWBj5L4yzW1geI6Gmj3uDnbIw3JDtwzj/uGUQj73c5KS70zIjkNge8xknD3ucxrBgAk8bzgA9lzgvrnWOSudBmQTmnYwEtD3+J4be4y0F3fI4UnU0FJVEmppYZSduS9gd90kjv6EnHzKNt9G2kkpW0sAppCS+LwxsdnvkdkSiJLvcIp4aV9NSPqXylrjHOSxkYZuLj7ucgloxjnI5XS7UU7aVtS+mZ4E9FJWQiOTLw1oaWh2RgE7h8jxyp6moaSl2ezU0MWwEN2MDcA4zjHrgfkFwhtlDCyRsNHTsbJjeGxgB2DkZQQ4vlXFJPA6kL5YY3mNr3EPqNuAHNIbsOSRwDkZ7eS65tSvjo3ymOHxGb3ObiXLGNaCS5uzc3k45488+SnPqyg/Sf+Dp/0n3/ANGPe5zz+PK4SWi2yNYJKClcGNLWgxNOAe47digi33+o3F7KWMQRvp4pdzzuD5duQBj/AEh7T8V1nUk8VAy4T0sRo54hJTsjlLpnbnNawFoHnvGcZx25U8yipY2FjKeFrS5r8BgA3NAAPzAaPyC6orTb4WTNioaVjZv1gbE0B/nzxygwrZejUU1wmqoXRNozlzjG9gI27jw9oII+Xp6qPfqiopaenlraJn/iKZs7GQPdIWuc9jGsdhvmZByAex4KnKm2U8trqKCFjKeGdjmO8NoHcYJwuUdroIopY46KmbHLjxGiMAOx2z6oIu23+WqqWQSUxYTUOhLnNez3RFv3Br2g5zgYI+K67Xdq26XamdCYY6I0xmcw8lwdIRG7P8LHH8fkpl1soXQsidR05iY7e1hjGGu9QPXlco6CkjkhkjpYGvhZ4cTgwAsb+yD5D4IMlERAWBV3WClnlhkbIZI2RuDWge/vcWtDee+WrPWDPa6ee609wkDjPAxzGc+7z5keo5x8ygim6kP1l4Xs7n0TIpZpappa1kbWv2gnLs491+SB5DGVIWq9U1yqJoYWyMkia2TD9vvMdnDhgn0PBwR5hdI03QCERHxjGab2R7fEIEjOfvAdz7zjn4rMt9ujohJiSWV78BzpCOw7DAAA/L5ohFVWpoWSUjmxyR0srnu9okaNj4mMc5z24OccDuBnPGVkQako5XuYWTMeJImYdtPEji1juCeCRj1HmF1x6WoWsZHJLUzQxwPpoo5JPdijdt4bgDttGCcn4rvlsFNNbqiknlqJGzlpfJvDX5aQW42gBuCB2AQdFVqmgponSOEr2taZHbQ3IjBI8TkjLTtOMZJA4C73X6mFaacRVDmNmbA6cNHhte5ocBnOTkOHYHHnhcp7FRyVDZW+JCPDbE5kRDWuY3O0dsjGT2IXOazU0rNrnSj9O6oJDhy8tLfTyB4+QRLrtF6juEjY4mSSExtmMrWFsbWuGWAknOSMcf0WFWamjY6mdDFK2nlc9wqJGe4+NjHOc5uDnHujuBnPGVL22209vbM2nDtspaSHHONrGsAHww0KNZpejbG2N09W+KOB9NFG6QFsUbsZa3j0bjJyceaCNqtR3SL21zbfI4U7oqZuGx4fM/bg8yAgZe3jHzI8pKG+GLfHNFPU1W/Y2nhiaH8NaXH75bgbwCcjnjnzzvqimIIPiHNSKs5Pd4xj8BgfkFjyWCndI2WKeqgmD5XmSJ4DiJHBzmnjtkD4jA5RDGrtQtikp/DLY2PMbpBMxzXRNLXvcXZ7YbGePJZ1qvVNc6iWGFsjJI2tkAft95hzhwwT6Hg4I9F1S6doJjN4zZJGS5D2veTkGMR4z3+6D59ySsqhtsdI2UCWaV0gDXPeRnA7AYAA798Z9UGPbrw2rudRRujexzdz4iQBuYCAcjJI5PmBkdlxj1BTyVDWeBUthdNJAKhzQI97N2R3z/pPOMfFfbTYYLZMyWGaokcyEQASFuNoOR2A5+Pn55WHb9NNbbmRV9TPJIWPLmNk9yOSQHe5nGf9TsZzjPACJKHUTppngROqQ5kZhjgZh7yWB7j7xAAAfH3xyfiAuTtSB1dSthpJnUL6Z1TNUOLGiEAge8C4EY97PHlxnnGS7T9MJfFp5ainmy79JE4A7XBoLeQRjDGfEY4K5y2CglGwskERpjSOibI4NfHgjBHn3PPflEMdmqKF0c7iyceEGODdoc6Rr3bWloBJ78YOD8FlVl5hpBTCaGcT1DS5kADd+BjPnjIyOAcr5FZYGM2vlnlPiMkLnuHOw5aMAAYz8MnzJXbc7XFccNnlmERbtfE0ja8ehyDj5jB+KJdMl8po7kyjkjmYXEtEjgA0uDC8jGd3YHnGPLOVjR6oo3U4mlhqYGPZHJF4rWt8RrzhuOeOf2sL67TFI6RzzUVXLpXAbm4b4gIdjjP+o4JyR644WXPZ4ZJjLHNPA/w2RAxkYDW7sDBBB+8e4PYeiDlLdYoqCKqfDODK7ZHAGZke7ngDOPInOcY5zjlYlXqOCkohU1NJWxgB7pGPY1pjDe5OTg/DaST5ZWTLZqZ1BTUsT5YBTOD4ZInYex2CM8gjkEjkY5WJV6ZpaprxLU1mHxeC/MgcXDJdkkgnOXHtgdhjACD5dr/4EUzaKnmkkbIynbMWZibK8tDWnkE8uGcDHlkL6dT0fh7mQ1Di4vETcNaZQw4c5u5wGAccnGcjGV3PsFO6o8Q1FV4fjipEO8bBIOd2MZ784zjPOF8dp+k9no4o3zR+zQ+A1zXDc5nGQSR54ByMH0IRCSoaqKto4KqmduhmYJGHGMgjIXcuMTGxRtjYMNaAAM54XJEiIiAiIgLErblQ0L2MrauCBz/uiR4aT+fzCy1EVdrqJblUTw1EIhqYmRSslh3na0u4ac4wQ48EFBmi4UZrPZRVQmpyR4e8bs4zjHrjlY5vtqDS76xpdoaHk+KPunz+XB5WEyxTgMjdVRmKGaWohxGQ7e/fguOecbz2xnhffs+GRPjhlawNt4oIfc+53y7vzn3ePggkp7pQU8ojnrKeN5wNrpADz2/Ncqe4UdSGeBUxSb3Frdrgckdx8wo02BrhI10jSx9VDUbdn+mNrA1vf1YDn4rg+yVLbg6tp6uNsznzE74iQN4YARz3aIwPjkoJI3a3h8TDW04fKGlg3jLg44aR8yMBZqr1Lpw09E+AVAc8mmAeWdmQ7Pd7+ZDj/wCZTtOJRBGKhzHzBo3uY0taT54BJwPxKDsREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREH//2Q==",
+          "timestamp": 107699724451
+        }
+      },
+      "unused-css-rules": {
+        "id": "unused-css-rules",
+        "title": "Reduce unused CSS",
+        "description": "Reduce unused rules from stylesheets and defer CSS not used for above-the-fold content to decrease bytes consumed by network activity. [Learn how to reduce unused CSS](https://developer.chrome.com/docs/lighthouse/performance/unused-css-rules/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [],
+          "type": "opportunity",
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "FCP": 0,
+              "LCP": 0
+            }
+          },
+          "overallSavingsBytes": 0,
+          "items": [],
+          "overallSavingsMs": 0,
+          "sortedBy": [
+            "wastedBytes"
+          ]
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "mainthread-work-breakdown": {
+        "id": "mainthread-work-breakdown",
+        "title": "Minimize main-thread work",
+        "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to minimize main-thread work](https://developer.chrome.com/docs/lighthouse/performance/mainthread-work-breakdown/)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "5.3 s",
+        "metricSavings": {
+          "TBT": 1450
+        },
+        "details": {
+          "items": [
+            {
+              "group": "scriptEvaluation",
+              "duration": 2423.0483999999828,
+              "groupLabel": "Script Evaluation"
+            },
+            {
+              "group": "styleLayout",
+              "duration": 1823.2416,
+              "groupLabel": "Style & Layout"
+            },
+            {
+              "group": "scriptParseCompile",
+              "duration": 543.8412,
+              "groupLabel": "Script Parsing & Compilation"
+            },
+            {
+              "duration": 346.16879999999588,
+              "groupLabel": "Other",
+              "group": "other"
+            },
+            {
+              "group": "garbageCollection",
+              "duration": 62.85840000000001,
+              "groupLabel": "Garbage Collection"
+            },
+            {
+              "duration": 57.451200000000014,
+              "groupLabel": "Parse HTML & CSS",
+              "group": "parseHTML"
+            },
+            {
+              "group": "paintCompositeRender",
+              "groupLabel": "Rendering",
+              "duration": 33.712799999999987
+            }
+          ],
+          "sortedBy": [
+            "duration"
+          ],
+          "headings": [
+            {
+              "label": "Category",
+              "valueType": "text",
+              "key": "groupLabel"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "duration",
+              "label": "Time Spent"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 5290.3223999999782,
+        "numericUnit": "millisecond"
+      },
+      "max-potential-fid": {
+        "id": "max-potential-fid",
+        "title": "Max Potential First Input Delay",
+        "description": "The maximum potential First Input Delay that your users could experience is the duration of the longest task. [Learn more about the Maximum Potential First Input Delay metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-max-potential-fid/).",
+        "score": 0.27,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "340 ms",
+        "numericValue": 339,
+        "numericUnit": "millisecond"
+      },
+      "network-rtt": {
+        "id": "network-rtt",
+        "title": "Network Round Trip Times",
+        "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "items": [
+            {
+              "origin": "https://player.ausha.co",
+              "rtt": 13.936364999999999
+            },
+            {
+              "origin": "https://tag.clearbitscripts.com",
+              "rtt": 7.86051
+            },
+            {
+              "rtt": 4.436235,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "rtt": 3.2615099999999995,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "origin": "https://js-eu1.hs-scripts.com",
+              "rtt": 1.6103249999999998
+            },
+            {
+              "rtt": 1.0658249999999998,
+              "origin": "https://useago.github.io"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "origin": "https://forms-eu1.hsforms.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "origin": "https://fonts.googleapis.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "origin": "https://www.ocobo.co",
+              "rtt": 0.0038541497395246172
+            },
+            {
+              "rtt": 0.0034251413550519172,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.0032433464596178935,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "origin": "https://js-eu1.hsforms.net",
+              "rtt": 0.00297190542624014
+            },
+            {
+              "origin": "https://js-eu1.hubspot.com",
+              "rtt": 0.0025626760154601825
+            },
+            {
+              "rtt": 0.0016301436327293536,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "rtt": 0.0011202367576397232,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "rtt": 0.0010424614482917958,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com",
+              "rtt": 0.00070740282062719813
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "text",
+              "key": "origin"
+            },
+            {
+              "valueType": "ms",
+              "key": "rtt",
+              "granularity": 1,
+              "label": "Time Spent"
+            }
+          ],
+          "type": "table",
+          "sortedBy": [
+            "rtt"
+          ]
+        },
+        "numericValue": 13.936364999999999,
+        "numericUnit": "millisecond"
+      },
+      "first-contentful-paint": {
+        "id": "first-contentful-paint",
+        "title": "First Contentful Paint",
+        "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).",
+        "score": 0.32,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.6 s",
+        "numericValue": 3601.0692284322158,
+        "numericUnit": "millisecond"
+      },
+      "bootup-time": {
+        "id": "bootup-time",
+        "title": "Reduce JavaScript execution time",
+        "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to reduce Javascript execution time](https://developer.chrome.com/docs/lighthouse/performance/bootup-time/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "2.7 s",
+        "metricSavings": {
+          "TBT": 1200
+        },
+        "details": {
+          "items": [
+            {
+              "scriptParseCompile": 30.1416,
+              "scripting": 1031.000399999999,
+              "total": 1956.2495999999987,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+              "scriptParseCompile": 7.970399999999997,
+              "scripting": 7.489199999999995,
+              "total": 994.41000000000065
+            },
+            {
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "total": 565.05839999999989,
+              "scriptParseCompile": 13.9992,
+              "scripting": 513.11399999999992
+            },
+            {
+              "scriptParseCompile": 188.7792,
+              "scripting": 292.51559999999961,
+              "total": 554.87639999999965,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "url": "Unattributable",
+              "scriptParseCompile": 0,
+              "scripting": 51.284400000000112,
+              "total": 315.00719999999677
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "scriptParseCompile": 151.51319999999998,
+              "scripting": 154.31040000000016,
+              "total": 309.0372000000001
+            },
+            {
+              "scriptParseCompile": 23.7084,
+              "scripting": 78.859199999999987,
+              "total": 108.03959999999998,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "scriptParseCompile": 27.506399999999996,
+              "scripting": 48.845999999999989,
+              "total": 78.7164,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            },
+            {
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "scriptParseCompile": 18.289199999999997,
+              "scripting": 30.877200000000006,
+              "total": 55.974000000000004
+            }
+          ],
+          "sortedBy": [
+            "total"
+          ],
+          "summary": {
+            "wastedMs": 2670.2039999999988
+          },
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "ms",
+              "key": "total",
+              "granularity": 1,
+              "label": "Total CPU Time"
+            },
+            {
+              "label": "Script Evaluation",
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "scripting"
+            },
+            {
+              "label": "Script Parse",
+              "valueType": "ms",
+              "key": "scriptParseCompile",
+              "granularity": 1
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 2670.2039999999988,
+        "numericUnit": "millisecond"
+      },
+      "dom-size-insight": {
+        "id": "dom-size-insight",
+        "title": "Optimize DOM size",
+        "description": "A large DOM can increase the duration of style calculations and layout reflows, impacting page responsiveness. A large DOM will also increase memory usage. [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/performance/insights/dom-size).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "statistic": "Total elements",
+              "value": {
+                "granularity": 1,
+                "value": 601,
+                "type": "numeric"
+              }
+            },
+            {
+              "node": {
+                "snippet": "\u003cpath d=\"M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 …\"\u003e",
+                "lhId": "page-13-path",
+                "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,DIV,2,ARTICLE,1,MAIN,3,DIV,1,DIV,0,DIV,1,DIV,3,DIV,0,A,0,svg,0,path",
+                "nodeLabel": "div.d_flex \u003e a.c_gray.400 \u003e svg.lucide \u003e path",
+                "type": "node",
+                "boundingRect": {
+                  "width": 0,
+                  "left": 0,
+                  "bottom": 0,
+                  "height": 0,
+                  "top": 0,
+                  "right": 0
+                },
+                "selector": "div.d_flex \u003e a.c_gray.400 \u003e svg.lucide \u003e path"
+              },
+              "statistic": "DOM depth",
+              "value": {
+                "value": 17,
+                "type": "numeric",
+                "granularity": 1
+              }
+            },
+            {
+              "node": {
+                "path": "1,BODY",
+                "nodeLabel": "body",
+                "lhId": "page-12-BODY",
+                "snippet": "\u003cbody\u003e",
+                "selector": "body",
+                "boundingRect": {
+                  "right": 0,
+                  "top": 0,
+                  "height": 0,
+                  "bottom": 0,
+                  "left": 0,
+                  "width": 0
+                },
+                "type": "node"
+              },
+              "statistic": "Most children",
+              "value": {
+                "granularity": 1,
+                "value": 64,
+                "type": "numeric"
+              }
+            }
+          ],
+          "debugData": {
+            "type": "debugdata",
+            "maxChildren": 64,
+            "maxDepth": 17,
+            "totalElements": 601
+          },
+          "headings": [
+            {
+              "label": "Statistic",
+              "valueType": "text",
+              "key": "statistic"
+            },
+            {
+              "label": "Element",
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "valueType": "numeric",
+              "key": "value",
+              "label": "Value"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 601,
+        "numericUnit": "element"
+      },
+      "long-tasks": {
+        "id": "long-tasks",
+        "title": "Avoid long main-thread tasks",
+        "description": "Lists the longest tasks on the main thread, useful for identifying worst contributors to input delay. [Learn how to avoid long main-thread tasks](https://web.dev/articles/optimize-long-tasks)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "15 long tasks found",
+        "metricSavings": {
+          "TBT": 1450
+        },
+        "details": {
+          "items": [
+            {
+              "startTime": 951.0125869876756,
+              "duration": 381,
+              "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+            },
+            {
+              "startTime": 4367.3463937864581,
+              "duration": 339,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "startTime": 3949.3463937864576,
+              "duration": 336.00000000000045,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "startTime": 7368.1478971051883,
+              "duration": 287,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "startTime": 11313.377477933207,
+              "duration": 224,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "startTime": 8277.14789710519,
+              "duration": 202.00000000000182,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "startTime": 1637.0125869876756,
+              "duration": 195,
+              "url": "_lighthouse-eval.js"
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "startTime": 7935.1478971051883,
+              "duration": 176
+            },
+            {
+              "startTime": 8132.1478971051883,
+              "duration": 145.00000000000091,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "startTime": 7700.1478971051883,
+              "duration": 117
+            },
+            {
+              "startTime": 5628.0223036878779,
+              "duration": 113,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "startTime": 11537.377477933207,
+              "duration": 73
+            },
+            {
+              "duration": 69,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "startTime": 5741.0223036878779
+            },
+            {
+              "startTime": 4301.3463937864581,
+              "duration": 66,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "duration": 56,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "startTime": 3893.3463937864576
+            }
+          ],
+          "sortedBy": [
+            "duration"
+          ],
+          "skipSumming": [
+            "startTime"
+          ],
+          "debugData": {
+            "urls": [
+              "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+              "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "_lighthouse-eval.js",
+              "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            ],
+            "tasks": [
+              {
+                "other": 381,
+                "urlIndex": 0,
+                "paintCompositeRender": 0,
+                "styleLayout": 0,
+                "duration": 381,
+                "startTime": 951,
+                "scriptEvaluation": 0
+              },
+              {
+                "urlIndex": 1,
+                "duration": 339,
+                "startTime": 4367.3,
+                "other": 339
+              },
+              {
+                "urlIndex": 1,
+                "other": 336,
+                "duration": 336,
+                "startTime": 3949.3
+              },
+              {
+                "duration": 287,
+                "startTime": 7368.1,
+                "scriptEvaluation": 0,
+                "other": 287,
+                "urlIndex": 1
+              },
+              {
+                "duration": 224,
+                "startTime": 11313.4,
+                "scriptEvaluation": 0,
+                "other": 224,
+                "urlIndex": 2
+              },
+              {
+                "urlIndex": 3,
+                "other": 202,
+                "duration": 202,
+                "startTime": 8277.1
+              },
+              {
+                "duration": 195,
+                "startTime": 1637,
+                "scriptEvaluation": 0,
+                "other": 195,
+                "urlIndex": 4
+              },
+              {
+                "urlIndex": 1,
+                "other": 176,
+                "scriptEvaluation": 0,
+                "startTime": 7935.1,
+                "duration": 176
+              },
+              {
+                "other": 145,
+                "urlIndex": 2,
+                "duration": 145,
+                "startTime": 8132.1,
+                "scriptEvaluation": 0
+              },
+              {
+                "duration": 117,
+                "startTime": 7700.1,
+                "scriptEvaluation": 0,
+                "other": 117,
+                "urlIndex": 5
+              },
+              {
+                "urlIndex": 5,
+                "other": 113,
+                "scriptEvaluation": 0,
+                "startTime": 5628,
+                "duration": 113
+              },
+              {
+                "other": 73,
+                "duration": 73,
+                "startTime": 11537.4,
+                "urlIndex": 2
+              },
+              {
+                "duration": 69,
+                "startTime": 5741,
+                "scriptEvaluation": 0,
+                "other": 69,
+                "urlIndex": 5
+              },
+              {
+                "urlIndex": 1,
+                "other": 66,
+                "duration": 66,
+                "startTime": 4301.3
+              },
+              {
+                "urlIndex": 1,
+                "other": 56,
+                "duration": 56,
+                "startTime": 3893.3
+              }
+            ],
+            "type": "debugdata"
+          },
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "label": "Start Time",
+              "valueType": "ms",
+              "key": "startTime",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "duration",
+              "label": "Duration"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "document-latency-insight": {
+        "id": "document-latency-insight",
+        "title": "Document request latency",
+        "description": "Your first network request is the most important. [Reduce its latency](https://developer.chrome.com/docs/performance/insights/document-latency) by avoiding redirects, ensuring a fast server response, and enabling text compression.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "checklist",
+          "debugData": {
+            "serverResponseTime": 8,
+            "redirectDuration": 0,
+            "uncompressedResponseBytes": 0,
+            "wastedBytes": 0,
+            "type": "debugdata"
+          },
+          "items": {
+            "usesCompression": {
+              "label": "Applies text compression",
+              "value": true
+            },
+            "noRedirects": {
+              "value": true,
+              "label": "Avoids redirects"
+            },
+            "serverResponseIsFast": {
+              "value": true,
+              "label": "Server responds quickly (observed 8 ms)"
+            }
+          }
+        }
+      },
+      "unminified-css": {
+        "id": "unminified-css",
+        "title": "Minify CSS",
+        "description": "Minifying CSS files can reduce network payload sizes. [Learn how to minify CSS](https://developer.chrome.com/docs/lighthouse/performance/unminified-css/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [],
+          "type": "opportunity",
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "FCP": 0,
+              "LCP": 0
+            }
+          },
+          "overallSavingsBytes": 0,
+          "items": [],
+          "overallSavingsMs": 0,
+          "sortedBy": [
+            "wastedBytes"
+          ]
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "forced-reflow-insight": {
+        "id": "forced-reflow-insight",
+        "title": "Forced reflow",
+        "description": "A forced reflow occurs when JavaScript queries geometric properties (such as offsetWidth) after styles have been invalidated by a change to the DOM state. This can result in poor performance. Learn more about [forced reflows](https://developer.chrome.com/docs/performance/insights/forced-reflow) and possible mitigations.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "details": {
+          "items": [
+            {
+              "type": "table",
+              "headings": [
+                {
+                  "valueType": "source-location",
+                  "key": "source",
+                  "label": "Source"
+                },
+                {
+                  "label": "Total reflow time",
+                  "valueType": "ms",
+                  "key": "reflowTime",
+                  "granularity": 1
+                }
+              ],
+              "items": [
+                {
+                  "reflowTime": 627.185,
+                  "source": {
+                    "value": "[unattributed]",
+                    "type": "text"
+                  }
+                },
+                {
+                  "source": {
+                    "column": 85503,
+                    "urlProvider": "network",
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+                    "line": 19,
+                    "type": "source-location"
+                  },
+                  "reflowTime": 1.085
+                },
+                {
+                  "source": {
+                    "line": 19,
+                    "column": 85503,
+                    "urlProvider": "network",
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+                    "type": "source-location"
+                  },
+                  "reflowTime": 0.802
+                }
+              ]
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "largest-contentful-paint": {
+        "id": "largest-contentful-paint",
+        "title": "Largest Contentful Paint",
+        "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)",
+        "score": 0.17,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "5.6 s",
+        "numericValue": 5626.1117095156205,
+        "numericUnit": "millisecond"
+      },
+      "non-composited-animations": {
+        "id": "non-composited-animations",
+        "title": "Avoid non-composited animations",
+        "description": "Animations which are not composited can be janky and increase CLS. [Learn how to avoid non-composited animations](https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/)",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "failureReason"
+              },
+              "valueType": "node",
+              "key": "node",
+              "label": "Element"
+            }
+          ],
+          "type": "table"
+        }
+      }
+    },
+    "categories": {
+      "performance": {
+        "id": "performance",
+        "title": "Performance",
+        "score": 0.45,
+        "auditRefs": [
+          {
+            "id": "first-contentful-paint",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "FCP"
+          },
+          {
+            "id": "largest-contentful-paint",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "LCP"
+          },
+          {
+            "id": "total-blocking-time",
+            "weight": 30,
+            "group": "metrics",
+            "acronym": "TBT"
+          },
+          {
+            "id": "cumulative-layout-shift",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "CLS"
+          },
+          {
+            "id": "speed-index",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "SI"
+          },
+          {
+            "id": "cache-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "cls-culprits-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "document-latency-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "dom-size-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "duplicated-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "font-display-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "forced-reflow-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "image-delivery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "inp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-discovery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "legacy-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "network-dependency-tree-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "render-blocking-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "third-parties-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "viewport-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "interactive",
+            "weight": 0,
+            "group": "hidden",
+            "acronym": "TTI"
+          },
+          {
+            "id": "max-potential-fid",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "unminified-css",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unminified-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-css-rules",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "total-byte-weight",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "user-timings",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "bootup-time",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "mainthread-work-breakdown",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "long-tasks",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "non-composited-animations",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unsized-images",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "network-requests",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-rtt",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-server-latency",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "main-thread-tasks",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "diagnostics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "metrics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "screenshot-thumbnails",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "final-screenshot",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "script-treemap-data",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "resource-summary",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "redirects",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "server-response-time",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "layout-shifts",
+            "weight": 0,
+            "group": "hidden"
+          }
+        ]
+      }
+    },
+    "categoryGroups": {
+      "a11y-tables-lists": {
+        "title": "Tables and lists",
+        "description": "These are opportunities to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+      },
+      "insights": {
+        "title": "Insights",
+        "description": "These insights are also available in the Chrome DevTools Performance Panel - [record a trace](https://developer.chrome.com/docs/devtools/performance/reference) to view more detailed information."
+      },
+      "seo-mobile": {
+        "title": "Mobile Friendly",
+        "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn how to make pages mobile-friendly](https://developers.google.com/search/mobile-sites/)."
+      },
+      "a11y-audio-video": {
+        "title": "Audio and video",
+        "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "description": "More information about the performance of your application. These numbers don't [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score."
+      },
+      "a11y-names-labels": {
+        "title": "Names and labels",
+        "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "a11y-color-contrast": {
+        "title": "Contrast",
+        "description": "These are opportunities to improve the legibility of your content."
+      },
+      "best-practices-ux": {
+        "title": "User Experience"
+      },
+      "seo-crawl": {
+        "title": "Crawling and Indexing",
+        "description": "To appear in search results, crawlers need access to your app."
+      },
+      "seo-content": {
+        "title": "Content Best Practices",
+        "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+      },
+      "a11y-aria": {
+        "title": "ARIA",
+        "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "best-practices-general": {
+        "title": "General"
+      },
+      "best-practices-trust-safety": {
+        "title": "Trust and Safety"
+      },
+      "best-practices-browser-compat": {
+        "title": "Browser Compatibility"
+      },
+      "a11y-language": {
+        "title": "Internationalization and localization",
+        "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      },
+      "a11y-best-practices": {
+        "title": "Best practices",
+        "description": "These items highlight common accessibility best practices."
+      },
+      "a11y-navigation": {
+        "title": "Navigation",
+        "description": "These are opportunities to improve keyboard navigation in your application."
+      },
+      "metrics": {
+        "title": "Metrics"
+      }
+    },
+    "timing": {
+      "total": 21716.3
+    },
+    "i18n": {
+      "rendererFormattedStrings": {
+        "varianceDisclaimer": "Values are estimated and may vary. The [performance score is calculated](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) directly from these metrics.",
+        "opportunityResourceColumnLabel": "Opportunity",
+        "opportunitySavingsColumnLabel": "Estimated Savings",
+        "errorMissingAuditInfo": "Report error: no audit information",
+        "errorLabel": "Error!",
+        "warningHeader": "Warnings: ",
+        "passedAuditsGroupTitle": "Passed audits",
+        "notApplicableAuditsGroupTitle": "Not applicable",
+        "manualAuditsGroupTitle": "Additional items to manually check",
+        "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+        "crcLongestDurationLabel": "Maximum critical path latency:",
+        "crcInitialNavigation": "Initial Navigation",
+        "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+        "labDataTitle": "Lab Data",
+        "warningAuditsGroupTitle": "Passed audits but with warnings",
+        "snippetExpandButtonLabel": "Expand snippet",
+        "snippetCollapseButtonLabel": "Collapse snippet",
+        "thirdPartyResourcesLabel": "Show 3rd-party resources",
+        "runtimeDesktopEmulation": "Emulated Desktop",
+        "runtimeMobileEmulation": "Emulated Moto G Power",
+        "runtimeNoEmulation": "No emulation",
+        "runtimeSettingsBenchmark": "Unthrottled CPU/Memory Power",
+        "runtimeSettingsCPUThrottling": "CPU throttling",
+        "runtimeSettingsDevice": "Device",
+        "runtimeSettingsNetworkThrottling": "Network throttling",
+        "runtimeSettingsUANetwork": "User agent (network)",
+        "runtimeUnknown": "Unknown",
+        "dropdownCopyJSON": "Copy JSON",
+        "dropdownDarkTheme": "Toggle Dark Theme",
+        "dropdownPrintExpanded": "Print Expanded",
+        "dropdownPrintSummary": "Print Summary",
+        "dropdownSaveGist": "Save as Gist",
+        "dropdownSaveHTML": "Save as HTML",
+        "dropdownSaveJSON": "Save as JSON",
+        "dropdownViewer": "Open in Viewer",
+        "footerIssue": "File an issue",
+        "throttlingProvided": "Provided by environment",
+        "calculatorLink": "See calculator.",
+        "runtimeSettingsAxeVersion": "Axe version",
+        "viewTreemapLabel": "View Treemap",
+        "showRelevantAudits": "Show audits relevant to:"
+      }
+    },
+    "entities": [
+      {
+        "name": "ocobo.co",
+        "isFirstParty": true,
+        "isUnrecognized": true,
+        "origins": [
+          "https://www.ocobo.co"
+        ]
+      },
+      {
+        "name": "vercel-storage.com",
+        "isUnrecognized": true,
+        "origins": [
+          "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+        ]
+      },
+      {
+        "name": "Google Tag Manager",
+        "homepage": "https://marketingplatform.google.com/about/tag-manager/",
+        "category": "tag-manager",
+        "origins": [
+          "https://www.googletagmanager.com"
+        ]
+      },
+      {
+        "name": "Clearbit",
+        "homepage": "https://clearbit.com/",
+        "category": "analytics",
+        "origins": [
+          "https://tag.clearbitscripts.com"
+        ]
+      },
+      {
+        "name": "Hubspot",
+        "homepage": "https://hubspot.com/",
+        "category": "marketing",
+        "origins": [
+          "https://js-eu1.hs-scripts.com",
+          "https://js-eu1.hubspot.com",
+          "https://js-eu1.hscollectedforms.net",
+          "https://js-eu1.hs-analytics.net",
+          "https://js-eu1.hs-banner.com",
+          "https://forms-eu1.hscollectedforms.net",
+          "https://track-eu1.hubspot.com",
+          "https://cta-eu1.hubspot.com",
+          "https://perf-eu1.hsforms.com",
+          "https://js-eu1.hsforms.net",
+          "https://forms-eu1.hsforms.com"
+        ]
+      },
+      {
+        "name": "GitHub",
+        "category": "utility",
+        "origins": [
+          "https://useago.github.io"
+        ]
+      },
+      {
+        "name": "ausha.co",
+        "isUnrecognized": true,
+        "origins": [
+          "https://player.ausha.co"
+        ]
+      },
+      {
+        "name": "Google Analytics",
+        "homepage": "https://marketingplatform.google.com/about/analytics/",
+        "category": "analytics",
+        "origins": [
+          "https://www.google-analytics.com"
+        ]
+      },
+      {
+        "name": "Google Fonts",
+        "homepage": "https://fonts.google.com/",
+        "category": "cdn",
+        "origins": [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com"
+        ]
+      }
+    ],
+    "fullPageScreenshot": {
+      "screenshot": {
+        "height": 8802,
+        "data": "data:image/webp;base64,UklGRpA3BABXRUJQVlA4WAoAAAAgAAAAmwEAYSIASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZWUDggojUEADC7Dp0BKpwBYiI/EYK5Viwopikk0ds5gCIJaW78XbOUGAKHch1Xfjc1oSmkWVzSYlq26pzm7H/pc2+fmA84D0n/4jpofVt9ADpdv8TkvXwn+Vf5X+yf3n9hf///3fsR8n/Uf8x/cv8v+wf7xez/kT+Jfvf+c/7X+U+QT6+/3v8j4R/Sf6D/y/67/iex381/BX9H/E/6T//f8b5k/tv/N/zH+W/bz0L/Pf3b/vf6D/Z+4L+f/07/z/4z/b////n/H58t/zP8n/o/388VfVP9B/zf81/q/3O+QX2n+zfst/ofVi98/5H+G/0fsR+nf43/uf4r/N/ID/U/8D/3P8Z+bvzV/vf24/3Xmp/j/93+1//l+QP+d/4T/0/5b/V/vV9Mf93/+f9p5+vrj9wPgM/YT/9/6r/lfvh9AH/x////8+Dn8A/9X////fw+/ux////+XB3gOWOA5Y4DljgOWOA5Y4DljgOWOA5Y4DljgOWOA5Yv5R0JKbZEptkSlkpIN7cPyYayBAdSEU4n0/DiuMN8sqI0x1mXPA1gBe/1VBBRmO1BH7bbGePVWM5PnDSTnyuJ39ui/25zhcbGWG1K6QR7cOO4sj5HLRjQZ6NTv8YE4NauoZLJXDKLaZJQGxtDvr3IAonz3ODhCluFV27/bov9orOJq2Nh8X+3RqWfEBPTbIlNsiU2yI2xPL7ooY72y0LqB41qvWIM0lhsaYI6X5aPdZd5/ycByxwHLHAcss/aiE+/26L/bov9ui/26L/bov9ui/26L/bov9ui/26L/bov9ui/26L/bov9ui6nZxYnNRECrpvz7ulepWtxVx6kiU9r4tCMjocyZPcHALJ8cc2oRD88LBY49rGi/26L+e7e/ihwYUB8HFXNAp/3TXofX0gxDcUNtLMJ/IDAa2lqZJCQOK0z82aj77ipvSyrkTZVUOlM4WyJTbIlNhuqa8dIwjdV1oxWwegOWOA5Y4DljgOWOA5Y4DljgJ8/iN1Z9eiyy6zmFJMtqDOxxDwka8OWt7KqfjZ8JXuHH9wCQfe7A9QE+sxEnvrx3Pl75uaQ9IJid4KS1JGs7oWNXXxqz7TZ6N/LgDbOmvVJEIyg7TxYKix6Yk0JWzC4LqNWxXDKayBHP3RPqbdb+f/Y881SPdXPcDloFKy6mHcZ3eqfkzwqnyTDospUSEKbuvFOJ4xMmn5Jpn77o2hAlb5NQ5NkiL/ZjU4ggN7K2ULegFTrfgpqC3HayIdJvk+etvafSkQJRPGVHdTY/fRTE4azH4UlldN9NvJCAmLnk65xaoYaKyJBYwOOxrOVnajam/iOBXG+JYzVj2OYtPTGoVizZbcoxgklUSdw+TQ49sOXoSlLfXF0UcCzouO4oTpcST4BqKH3Vn5dF2Jlh+LOZSV4K2KSQY4xpme09yXj9qnhwmA28r85Fx+7FAqQM9/C9ExG1X0KLKHCV3cvtWZ3cIhtTSx/5naXgo0E1JyiUw75TEmZ0yfugKnLnZyyd0YeqitGNS1DK3cvXYffDtQzBaIZUH80JGa/hLO/aI+98+kc4izeUdyBm0eSmoLHsd/kDOl+HOWXt4OhfNalT6U6quRsfajiAJw9ksFIkfi6XYTVWxYSbOyfBgAPN4o5KjK6FofBG3Dr2vJqptAcscBR3GfS+mEqcqN+tNUr9uXC9kIh5AvXw2wMG34OycaOT6CIwucpM3gmRhSCk4Sw/MtAt+cw0YkJxEcd5Jc5XiDjrF5fcxwHLHBDQd2boP7XmeZqlt4DljgOWOA5Y4DljgOWOA5Y4DiBUK0kbBUY4OoP7fbXs5ldORSKtfrYHgXukm04Nh8S3MABSdQLGWNF/sd3v5X05SVm3BZyJPvmqq7NDfBbiUXDYcwZWGhmlyHO5+5jgOWOA5ZmVlt5mzLC2V5Y4DljPa35brqvqmXw8Wu9gACbUh7hONfbI5VuWOAohWYr0IUqW2qYFv/MVZpu7vpff7KT6PcrsI3K4+aI8GVnMzZj0YEX/HNovXM4j7VbtohPW7Wyri3eRTXl/bdZuAuSVYv9fZbJIDd0793nkQxXvOWDX27VtNne4JkbTCljerwYkLYpiALvz1Y5SGk0Nyk7vcI4oBgvo6Au6qkX1VFrLbwHGtx+CgCmj2tdlxZGAdBMqlCagKGeKps7pNyAWRYZ6fICn+x0cxTrbueAjDdpnqSpc0QjejY3/SquvzOYpugkGkvope9AgDetcnFATqXlZjumCSOfUPJuCZaZbXGgMMIwz9ka4B7ipAd2a3UL0AyJCK0ggqcorP3sP0eAhTFVaTex9WOqZMf5OA5cbk+SbdjRSDoIj9oh2tA1Hn49/eHjC+0X+3Rf2dBEazaGTkmTnmOqZxdJAgBAnB5C+Bjy3qulL3telL4wBjcH/YHgzUse8jaP5esLeTufqbaTKj1mvddTPJq/o5/kFJBEnzXiuEjgjkXvXl5ml5PdvnJKgURc9hN2awrKMPR23bWMRJJF/UW4dLe8aeuGI7K8PzgJDpVmnnTivk5YpQEZn6hR4djoh3IPh1HE4Ji2UdrSiMU7oGpdJDsX5zCQ9mrE0LAWpWDsW4y2BOHN7HJcx/FfNKi6eB/Px0v1UerT1VwILRsvs6p7A+tOg/lA15pRzCON6GjEUncH3ByaUO8f3i//tfdjqyo+jSua3abqr6CNea6Z3NeQhlHeHN0705/usPFxoIJrBvvz7nLOOmpr0Yq4U9o2IB8cGjf/gnq2mSwHEd8LrecBYNSrQzly+8p84FiN5musT29d7neAND4akIIaGTv8nia3IbDUE4eYoaWZ/rhoQrOjZ7U/t4K0qVtx0Ff6npfUpPgaSDZBchcuvkxhcTccx/5nh8XY0YH1IFjLGi/26L/b0UWZyO0pNyxwHLHAcuN2ujALSBZCXAcscByxwHLHAcshZ9uwOWOA5Y4DljgOWOA5Y4DljgOWOA5Y4DljgOWOA5Y4DljgOWOA5Y4DljgOWN6eRCBX8bbfthITFdsb0li+uLfzNL36myA3H0X1NzijIAtdGDUqQdfmDGxXxIkn5jvmQgbaEzevNwzO2G6nbM78t4GC8NWgrdJQG9IZXsG9BI5b/YKvGkScllb1yLix5a5SyffU4Aki+RermcZdastQS0dR9iu5y0U4miWeizmH3Up/cTDkUIejyPwJB/qXl0LfxJzsa7bx0MIdhOLl9WAJuK7Y6/Zfz/zvt8reBQsK5LXlTLL+onORZMQmKWH6XiTchRZwahqWusYh8c8FZWVlhYdMrBDITs5qxNAGR0/ckB5FxUwN95QlJBgmLBZa6pIOJxdDgYrUh7zGslTCXUEbU0tnyaxTGsMpf29sQetjKG/zT2zjBpavwCwelx9GdhhQ7vWno3q7ZPQyEhGbMeTvzXq07tlMx5mqXi4HMfzf8nAUbPhbkUdszKC6qEUda6Sxov9ui/26L/bowC1Ovv9ui/26L/bov9uiKPycByxwHLHAcscByxvJGIOWi4DmFIg0QnL1pv0G22A1je1UF1bP2DFBNsOPibR6jOwF6U3lTJtYgILYiriOmn8aJgiWZtsp0CXD5NgfG2yk9In0pPipK9vE1xZP80aezwWUP4uKXGA7MX5jLy1DTZCJAto3peHSySh7S0w5ftCQjPYdlBPbXGa5jq/h3SbXk3IIa/Ow5HG8YxAvZcdENw9C+w0ybQEWn/sl9Fc4x0qYpLhjO8mckaCkj76qH4nwKHpkBOIJAWNycb2xcdXUy4+JcuZFtLYoNGYbFAp/rvnKZ7QbJ0IstgcmH9nIakFcRCY3qUdJFa8QWzLhpLHQ1naHNT9QjXHGj1XK0JWXrQLkhg6OvDM8LKioDmmFikMrc5Gr+GSV5k7nHjLbtTBPAjsSDR6g88LH/vKUFCA8otrnw07sEs+vgSvr/OeenX3eznSSh3FhWf2269dXFHerIvqWJdtOdOdyszUdK5bjL164no9KvvmGszfO00pQCfIpXSiTmnlfz2Bja2lhFmzrFZtpGKIeP6TCcYj4EC/hKzXKO16Dsge3RXQYuUrk9uxCfk99qVt4n/kfruMz4e/o1ZXS+/kcJF8bg1/KKdCqy48XesnFKhEl8Yx4J97IVcXXpDXaLjjyZUQnW9n9n9XjzM7bm6rlez25frha8Bd3XmRGPYPkPsFrFjpvz4otlBy+WnOxjeyzZ59hM0HhCLhABqi3GgsxtB4T+U3eJ8peSZrlC4/2kmIyR7jbEG6QI5Al05WMJA9/W6GEcxrOMsNyxDq8VKY2gDb//vsZUeWYtQk8pKEvJ0nmIutLlTOxv7lGXlUWZTx5ONapDBOTCDOXEPOHF4zhf5ZcnH94VlW0VYUXTba+3sR+U8akmuNkgwF89niNF/twOZbb+TqiU6jibHsnJBz1AoOV1UGqKqGd/owuaMoMqBdWx/H3l+rh2exXaCp6RPJbJnhN4DljgOWWN/ycEM8sb/k4DljgOWOA5Y4DljgOWOA5Y4CJXWyOmgL0MonsU2wBObO+Uh6AtDAsEYs7LTQBn4ZqsUgCAG+bXz3xA4GHP0MVo3Y6ICMdJhBDnRW1wiACEqUZTNrkdxI/AvVzJtCEoifMm6R5dwHvFSiku9LyWECvaiGGYl8+RYfEVGex4i/uhg0TIZaHAn9hYreoPb80HPdOGIKkv1jYntu7cUJWIR2EcZenAe5riDmbZ7RkTqylyrAlXO4daK1wLGEcM+Br0cdV/XXa+SluM4xt3r/LXJpSy8rr2OeJ2eJ7hG8Y5fWf+q1gDKh9frwvsrcyxtdLucNQ0kHtIgrOmQLkS2rx/nH4OeeAxKpsl+yO715wremovpNvUo3CoM2Tz8c9LfF+JSR5KIo0SX5bYtKl4eR/qz4mEyssHcpKP/VWem1z/XgHPX0BeVZWi9/CliQSaWwicVdr+XmujUSN697TtfVA83ptZ6Qd9xgykOoiQHdsW4gBLlscBFaihFtY8Pk1OBdPWH0/dG+4ZDYPPaqPrbkJa2H9TuEenrGx2uSYnA9YQWSFUDmAlZBy+JDJRLYZ9B6uniV+LaUJs8LARgIWpxtCvQ/Ibd8lZryphzo8NdncTAsouXmhZwkPKGJxuapVTBzVJiJJto0F8XCD6ABRTirtxgvztpMDl66SRuw2iEVQ/fPwU+qzjaZXxNKHMywWI3u/njuxfqZBMsXMNsZ9o+nCAd/4tVoz3fB2AAlz5Z+O9L/TVx/97YnuKNSW3mbnljptgLQikfK3X20gD5B0FGRcByxwHLHAcscBLcrknR7O0FHgabimMrdvGbfsmTzQb8tlujx84lAgd1KZOFB7NfqmdmzGrkcADU6KRvjLsMTQMWiJuk5no4gc5wDas/9ibcSitR+nn+ov1eG/B2bzIpbK+Ytcl1JAlMecctBgUsofjIN2UdUMNr5E6wY07BoUGjZHcEjdeJTfxPjT46XEgs2EiCgl768dhiVKGPTr8zg697SuekgFAI1nYLyWVZjoMKzb4l5yOet2DXHFoHsUTmO26fdageLn3TPCNumRj5qETnxQGTd/9gjfd22/cY6Awm7HLgyhosVKsfDEJAfCp4ShkNV9DhVRs0mhlbXRf7dF/t0X+3Rf7bo9YdUn2r4OJvVgpV0/IuekthP3C2lPisyN0rVBHsmJqocx2zD0if7hHzgm2MQOXcEJiT8p2BrvzVopOWYypoi9IZMcdjKZ/tC0DdyBg7BsjaWxaJ4DBiWQ0ujDkdTOMPGjqYPgQbVquY3NZNSPAmKFNxHAsoZIiuoPOJYxBKpNoiy/BW7amfqzXVmttgE0h5nJ936PiasqIp5U6AtbhpqTLVrhFuTRH9N4FjP5I56UL72A/SeAKh1EoWGffAjJH4+FgRvTyLhVmry2cAzuovrc7pTufJQ1ve5asnI8mrYyQ1TWL699lQXTdyXamRTfkma/37UGR/8MidfJ5Rdyo8W6xbZ/k69FoW6Ul+nWqXgRFUaRlAt1vQo2COEmFtsV7OKmm96UXnAtBnLKiTfWB6IAVFdkQoQbgbl0XXnJjUIrvcSUymZkWSGgsudMKBgd9r9Mi069fhOn5q7OUkkscVYLD0IQQHiQKexn7YfldidXXsZLidboRFFB4wdn7N7Gui/kGJZLoVPf4glCZ6A0WtESvALlbl+Y5HLCImt2pcRqG+N646QP+2r7Z+Fg3avJ0cx3A5Y4DzyzXmeY3/JwHLHAcscBwe5IpOnp4hCyz7upPT3B3z2Uc2ZSluJ+naK/4X9G48y/jN4sBFesOT3AlfkLsp/VvPN1mr9LmRU6JuXKvPvAVNGQ18WNdWDv83X1FV+Cp5cYd9kSLWutrYVqJID6xv/fxfdH57z0/WeR5xliy5Gma8hZ4b6W0m9CnTohNAXOkIOP/DGtx4lN5aV+OEW46WLFq9YAmc+BgWMZcOeJrNKDBHVNPD126sJGit8ESJ7zAQe3lgNoiPOyN4b2deExPYdo9Z3dYffLSOA2ZH95xnHjLG0LcEp4iqtAwCgr9MOliQXy78WeYoqsk27HbdQud3tBMA3XkHCUmOxRZ85G4VncGMtmjQaFjd9ISgLNjyRN52+O7Til4sQtF4V2pn1yBMioITkSDX2u2b0xwOqnwkrqNei4962AtKa076ICv2n6OXxWgYhdUGUber+L+k0gly25l64DFJtnWKX5E7HN+YA6HQlPVDXVikmMnxq0VLxshNtFOpDkN+mSStzPvRbiGFccRP7910tu92fBprMQ2SNZXs2T9xtupzGui/26nMa6mlo41JuzvAcscByxwHLF7HZLEipMCj0PxSvqQy8zy9RCC4O0OnAkXw0nYY934haBs4c76dudj9lO268DBy6Ln4ckDtWc89DCDukbiRe4K2NR1/xf7yN4lAWZLGziodBN9XCAoeBkQMEx05FvAHrav88UjO5+M5rfkdkDUrsGisD/W3e6yHqB9v5nwLSaHPR/OQaGp/H+rLgE/fQFKnN4fS9X/d46ZITa42VbAWzqo2oGsFwWwxX40aivP0YnjzxnGyMz82Bf0lS6YkQon8UNrKgQ0YcC9Vt9GA2zXhKFobCzk0wgf/yME0KrbI//VcfYYpsNLJyMDN/MP4YuMeBIwBLXDofZVITYmULB8GdpnErdsL8y0eiYMZVJ4AQVkpFWtagIb9j3Pxga+NuWSw4VEofc3Ly7ggXPiOIvGcsWeJ+XmaDPaMfoAce+KFf/U2yzp2rygSZ5Y6X4+b/k4DlYmBLlc2QL2Vm7f6R6dQ2H+0PwZsd6Ra8VHoqr0UtbcTBq+7ZxGxRyIB0mv97scJEZ1b25NvWtC5Q9hQ0GjtmXhM4+PqE+AYDdEYlC/SV6kKpec3Geqf47UI9jmMWY0n3Ioyc9IyHQGpCNLClh/9IA6UtxkdOzgxPaVZYNnZ5uiOF8VCeJbtU5reLTZO+u5rLk6lABmRPWe9OfqgpkxRMnaWzvAL/ZYcPoTIrunnni6egn6BVDsDwxexjGIW3ZMrwpiY27xgX41PnLkzu95n3HLCfnAgFo1JvCgeBj8je1FgqkkQy1xcZp0hrGRqYkohYNtkWqhoP5v+TghnljgZXgOWL7eK5N4Ir1kTMnAeRqK3hgOq9eOxrsqF3muwqJkhC9oPfV5MWn/RtbJbA39HR6afOGBgGqHCGFg0/qCJtdF/twf8BQP9a1c263vPRX2w46zDUpfBmX/xKg6hMX2CeWWr2T3xKmt1/zlCGH/M3ULqKJIprrAcHuVn/4kDkEeibv9ui/jQ2rrcvqo8gwlMd0k6/LmzZSWfVJrqrLxNwZDOSsyWoEjp+O8IzXNSdCcXGNXPKfoWc/p3O4vYDZzQSmezwWEp5EIKv2+JWqhlNsiUjTlcM9xEyCUVUyFBSG4tAF9+xyO0YBAg30JRkt0tl+fDPExnqdtQdJhf7yHzWkMra6Lm1OrO1yB00LB51HxgZjDn2c7qYTw6dcWNodHGAiGz/IvNpEO7LpVMxNPVt4HB3w3jPkBw9DRWzZT3NBdS5SCGFcIeusfXi9An9w9nbstCcGrPXp8ra6L/bqcx3QdnZnmP5v+TgOWOAlvXNSWXgQyg4eRSGPM9acSJisNHDUVIsvAobbpVTNbBd9E+IFuUUmmJA9Teu4yClE91uO9KVZfv1uBAaLpKJZX2HIJws3qvgGR61TozDgIEE8CgkI7O7b31OfBK+jTIGtn+kvjIKLXomrXYoqhF1iEogc5J4X34HockqpLkkj/3HTP/w3APbWQmZH+AfVn+vCfpGxppFatERA6s/mndd+P789aXC9AlxoPNIVD8ISVO++bSDwp6Emytya9cMW1rBIP5X4qqD44Savp7CC9ixKiN7swznf2hlNocef03ezdDH+c3D/Sd4fhq4LmRnrJu7n59KZ7mWcK3MPoP0Grft/Pk6hrDL2J29oR6fkFJ+wHKHH+LOkfWl0dyDXTXT8veIUVPXpxhND3/gQrA4QYo/4EZ4xYQbqEHAU5liv7/pVTH4GW3YtYyBkmso8E5I1x+gzrTvuCwcVAUizGJ76lxpSq0ZQO3oEn6fFUuyfFtei984QA8lmEsvJgec27qmc0KdBLneGtMqYnt5BUViUP2yyINaCB9gqfeqpYKJ/gE4CB3kuVqYZwLgPwvT1dJG7+4TA3/mPi7iOr9204WpSTxQCEFseArAzLNAuKtrFMLLuoBQak3bzZAzZibjwVvz8KPKtya8Hpn6+54Mnn8DASt5L8rrKv11G7RAX/Xv+lWNqrU82Za955H93+H6W+TIZaSZxhLmDerv6Xlp7JQAkPCR9PrDO04uW0HMR7szFfbcBl/Rbrks+BpMhoEPWKohE6cEL7qknu7gmGtf9A7oVvkJIqH+OA3ju+f91K9/9gIMJmfuFf4/HcJxslobWjuFRm21gezlDSINPDFIDACRyNOWDsscQyquc49kFKP50MXDh+dhC4jdcnb2y7ickeYwJ0qFrmGkDxSSJqeN3odzBADCT0cXIUcC4JRwrWQHs3rE4zSIdomZJl5fZ/z6cjVxf7HV8+wHWywqgzlv4fgiaE4nwmY9g/Ns28VRp1M+4miUneTZzKkMsYQHR8zJnoQUtPJgPmdRwcOlg/F7t7On1XYvcCFZGWjtwwBGmnRVJHMeOMGGN+Qtws9GX4qQ2H4yzKJYN+lHzs+cDRd6E8BKQAnJJd2BsuWOA48NUpPKaDLFlyPoDo/xuJlH4fv4TouXrRS+ZyxHol/Fikf0lFqj0tg7n0vUH3vmZP/LsgIWdiSt9UvyTPod41CccTjY9L0aGEvjIhlAUpfaidtsvV5nD5k79pUL/IShk//8i4wzd/FDNwNOZMt3QkPvdMMe4jsJZOSKzHzu3iFirBfclFSu8Q/6ZJoff+Rq/xRJYms4B56capsVPVjSlwcW4O+NQOsF/rpaQnG6nie6a1cNOtMNfOjM6NjNtztcrzztp7hfGdp3ZAguatSGpOCNdFVTmCLkbSejkNo3zEwMrK0bfU/vR130eBXCgOvYXS9zKbNjpurFoaFR4KtDkFXJSsGyyzXmd3trM8jHfTNDhmUNYkx6IIx5pAIAXx06J5knO3pMwFjLGi/26L/YsSPBp0oa8u6DyDoeKZG1cyyZWZoLbDlKb8z7GXn7DxLJhJ7tRu0RvgPR1Bk+aIlK0mi6jZ9iOMGNkdUCYNGzFoR6+hAAtk7rPdw1MwNn59c2BWu5ZKYEENU11lIsOMlvD8YyPi8fhajsGMAd7zXsXAflH9jZg89tq7KFZDQVATbJa/ftiWEM8WHmhZp7J77uNYU9fabq384xSAy2LhWIbEsudX8mEpEXC98UBfw1Y6vMw/X5jPsnU5jk40n4dR/sWg/etGL3A/XJkSrYPvsKLI6eVcBCvxisDrsSScPRnk0C0hOHJiQ48Q+eP0tFFF8EseVYo4TthqecA1oucLbGOkakSS2Pp5WYnDAvfUwDYd1o2NC9zlZegXNnXkNlc4+9psBYw+UVldSitsX7sug6YytrkIo0pMP5d9Lu7aSN/+TiYTu6MARdc8ZSSRN1BhpnbVlB2+QNtS8ftt9uFPs78gsQv115Qbpy+DDpZI3vb6T1nZ1TYkPqpCpj5WpVWcxt7AGtZNNxonvjtsBMZqlKeX2Q+af355eEC8y4Z7vJcC9Q9Q3A9dJQuCbeAitYANlId7VymRs4TEo7RK03bd91SjyREFHgRRjEFAKl3uAwYecu+qCAdY6ME+6SUuVte9LdYkcvmAKQRb79xPFDDwqJzn1YCayBw+OCvPS1Gv5ChAvU/Y3mKt8xgrpMU7qBIUtDLKBVMtc2HQY/Bsa0vCHPKBUhcNbUHxPxfsmLK+V1QfCoH1V0Ys8j6gKVN5/uoXQ/dZ2lGtrCFr9JJHLw9aEos7o+wKmshr5y3fouAMglb1z0kE5rZROLp0RD5poOEL3AhukF4xl7EBPTbLSqhLLG/7/nS9bOkNwKN6qBER+Bomqh627o5Wuql9jgXkSfLjapFEEgByzJk5NeMX3yNS/S8Lc5iMkkjpSnIEH3rSGeXVeiML8uAZjCqvmR3wIKMxP8nMJuLWZDl/p9yijN39CWSDkel9f6vQp//h/1KWlGmsaAWHhpKqRDTLebCD9G7LG8LOYpoHA9cBrKNt+JeRi899RIDn6gsUzNyJ7Z+FX/ksRqOH0yJp5KOqkQLhXqrYB/t7KRTcEBYh0wGbVEz1CwMoKRuJrGd62GReQrYTKaJIESdMz8AluO77BVSsTRRNV6lj5hJquipZIrqTyAdwgLGP2Tmlaz/DUYN12fuI/fkoL2g59O4GQ1o+S0Jav4SRJeKngyMPPtxnW56AUOSFEe7Yu/iSLm6mGeCUz8qB1DmltpQsB220l54r6J8o/5DeMBnCF7Wq7+v6H/c63CCnvvjsueMZfav+Vsn8UEudlFDKo6bPfd5NdqVrZFz7jHvZY3OlATB42sESch5x9G4OV5oD2uLFkL60MgXCvdfsAVbNmgsntNYFPuR4E8GYInMO8dbFsSg0ixrAfwDDg3N1JhrCTSI582i5Q0hDUCi9fjw249O6vwV9Zb9owduOa8V3MtJsPXvoUP3Xv7Nm0NSt/+V9vsFMGgVJCNMsHV4Ssr2d915P8A/2/uj3KM5YaL1dNpe4j7WgA0JwfmpZN8olIxz6ZPvuR2clUYcaA1fHMvw6fXkqmdXUZ8rOMD+Ni7Z1u4oEhibwJnHYX65ujF/MJPo9/KmL+Gn8x2DDINWFu7xSnDrgQRiiEFmTgOWWOBpSQeo21jLGjUNdF/tu89kLu8dDV2R3QaW0skTEKer5PZXp8PicjzEys4whWQw0I1viKMn48xc+xlq9Q6Th0NxiDIoCWmRkfX+GjO5B9I///SEYXnzXbNPRnihj+Y3QULe/dOu3OYc0gY6pCWJkrtjd4bgNXiJTa9gV8oezUr7zc+Zm3LuPet0jDvqrswFj7mXIGdWBMUEpOfNw+ZoR6YCPBGc7pm1Qk5sfIbA4Mkkiv9CqYgOIed67tSAMKyAWxZnsRPFou2qcVFFuiO36yk5ACRlOTcTBO4kBmEhL7ry7snQ3zH0CvyT8pR/uFgYVFqeuYKUIAyrxgNT8QrtTXgRpvXvnBFzbvO66FMWFiUPjx31fxO0h4oO/KPHxMsvD415FD4LiBQGmmWByxwElGQ44/HS/zlJZXHn+RRzK0LFrvh5n5DTv7xOL6aBO20ou5lnzI3FKGRKbZEUQoxuPtq8UaUTKsJ/ynDXi1DI05tv/ZtmyAwBUrzJbzgS2Nk0d7I/eC0bH8C/WpCGwLZGFG/vaCHfx01WrDyQACX7v9ui/26MDSGWlr0HZ2XleptkSm2RGPlgV7EKNjKpV9ggmjtsvcXygCjmSpfhi2HAZ7fwN+OuSvoOsTdQHT1glpU5moFPhUn5SSGtxUJFYIEME//QOCXYljRIkwNSq/2FBZuRyWeXWk1LtjTH4Uhf9TusTXBF1b8zJIe+jHilDbx4+yqd6EK9ZlUoWdxpx+CIzLFKCAmrj1dNluOx2ZevCKqhvgGpfo5RomcSWKIJKFTVVB4PoBPM5bZcpJWqTp7XrQto/aVPBB1IOD/5yFdY2UM6VJZwAq6hUne+HpjlpPydMSpgGDDnWWJChTg9IvQzh01bgDNHBO2fsCrMaVrmuMM4ZuHG1lAcuxnYnwQ2kNV20AhgI0zHHT0/mZuMzUdv8aTLG5TWk5w/T+jNjVwtBqK89Xtd3gGjmmqxFJ/CsjVmNujRka8X/klGKfpRcWgOoUyqNUB7bkwR36J0jDr+31UgXsbQi/9cM0y6l8arB3dbMQqGp09uByZH47BeiIpYw39151VKF/Y7hKA+PcyWAOII2OID9weuoI0DvvAwkO52EVE1ptZua4LRVjpAlqKSMJFWxI/4iC0PyUAVMEWkgH3st+WgnIz/25Nwn6ejIfGu88p+hvvWigo8yVu0iDmDkgtJPhes5pS2KuoVfh9T5ZrrRln1YypCj+e7KvopeQBracxHv9YBD6SeJeklHa3Ch0+mdfCnsQXZE7KmUrOw4w4o6w4IrpFT/0knYyuIifMcqq/N5lGdCBfTwpFDmh166mMJnMmFmd5NQke5RVwuSFBPn0T3b2piE7rWSm5y1BSUuLpooDFWGPuI/bo3FDo1LPh/9TcUqm2WdNsiU2x+hx7Td7zO0V+ejXRQ0XrZeu9XRjWpdM7a4+H2HmceSks0oD29mwEjNdpc1rPiSvi16nc8vxqpBHJG18lvGoM6x2ag8gu4NtdpmAB6epRatkvP886AYXhQ/IFZRlJFXEMraGs7scWFYdZLON3fydgn2MlCp7512KEZDwu8D0HUWWM/FUJtRFESvHsK6jKJeSvMwvreMulmfbudu/0itCSMDrvnzn2Fz3/P0Pfgh+px1LcVhPseIjfi8ponYyC4Es9Sqr65jywSNkOOkjWZZCi0uuKaflaavwGcXna6jkL0U/BLcLdyuSPqyoctznoyhNA/GJ1XUoOeYGE7/24cZie/Lvg1+YAJGhfASY0UKHhXTs5oebHniFQxw3mjidTsd4WQNWvMOtIVOWbPd27ewlfTgkdEY+LEiJnK9ltJiV97C5CRuQ0S2yHdGTSqekS64k16dptmd4DmP5027sWlr4ZZ2XscG2yIzDRMkM2AkrPWfDH3IsxTo+y4uGORHhqCOHvgfW9/t8mihoZyoRK+ql8KLNhsCIfZ2ikQkbrNcDo9jYyWmpXxSsOqT2LR1s/boacABgJW/xP99uEJv8mQk7H6wycj8lY5SQOLV48zwJP4s7UnJpkUcbBuPXaGmm4ioyMgreElhpJ6Y2DAw7ckxnCqaqEOn4j/krXu6avo/TeN8hZZNxSlY6LKSg5Rk6N/vsbm80N6jZYBKbE3x1xzFGL+k/F7eKO8XMFj+Rou8kFhPnA3PqE+UIsTc3hEc+zvk0BehFEEzRDOMnPxT4Wa0OwD72ycrT+KeNeh+AQKIH0xJC2AaQl1xJlWosommwQ9xWul7rC0pAtwUzDPzXTDnGY+hsjwUDG4dYCFb+n17+Vcy01wEccluPrefn3dsA8SYuhVT7kLfdBI19UmPs4biPVwFL8cr+82vrQatnubGSda8L+FNN+YZBrwtDH9gzTJ6HqnjaXq+YQ0o0EuoEqCG/ATY7ra+lzhqdWozSq1B+wqaEZZ8SU8yiNeecSkeZwXfYSSiRP/f83/Jl4MpNqYerPkcm/26L/bov9iif2z0yhZUV/l1C6O53QXwfwyY3WGkLLEYkzmR7Q1UVmi1+4/85duffJx8VfN3mqN71k0LsGpA57PJ2LSKVsD1yLFlc8cBgvQxhJSbCSZTYCZG1rdBg3eOj4R8h8CyOcj1bODHfx01SHJOdG7jGCqrB1Jd7+eKqcxU7xo7DSs1JeOeN6tDzFuUyPMNfKdPXqIRrGoMy3wCmfUjGbwMx5jLAMhtPGfB1aj8RBgYAXksIboSR2kUAiuMiYgSYA2RJbKm7jSwH6foWSrSYokCq3D8Ptq+Q3jlwOoCRQNQ6MNaFakpxKmSYNOtVGuAwEGOGI2t+mf2EOw19aSDg0eAHJQttvj/86klBv6GuojP71IoyadYM/sIlSpjijTORreBAgo8Dr87Kbw94pbicMX7LC18hOiHFGFpjMponfuyVQJDiOhkELU5jvsNGyu5M2BITYVeb5LClmfQdwhnlmRJGAPPQZnzyzXmouzZY4Dh026sSz1+NoahA81e2VxsrV5rZoFkwamXbhQaZl0hWhjzjWMjMj+/tC+0kjqz7RB0nBrLGMWTD/ymyyb0+VN0HH5qPPHy/YK7olhldmXDDb8CuC2PK6XLnSB6JoU834Hj5+V2TV7i6Uc0h4hTwd5bhX5+X3kQJpQkfwZdSOb50k6Y8BQ58GKri+KhYyVEDv9Ud2CzzmjXfqB7pPEOlDga9+/3fwiit1c+6xwwQVSRrHQpq4lcbt+MJ53qzHx8YWynCfWoP2begkbcH1hMTe9oZEptj4BWhrOjQuF/Sw7SMRxqh87jGXMeB9PZPd3i1VfIJdEBUIk8zRZnzHjMcgcscBzH84GguByxwHLHAcscBysBqKUAkra++MAi6dls03yXrpNupappKcjImd4AnZq9lOhXzCTRLRmfaaL28se4ufSP2XKdGUc+LEVsctF6tlfDlvxHqHebmTi7BJR8GPHuAP23kpWAfjBlHrFTlZGxJiyPYXtUvg+wzLYckFqP7oGfpZExqQ/eMC47PaZQs9W8PBsDG+TUO8i64SatMeYk7eE7Kt4xzXFZiV1Fp6a+j6YuS9OCDkbHfIYyyb2RiRdyBaPkHmO31ZjJg5/s46HOHCmTl0iw7F+mQHBRJtTA9hg1t5YY0KgjA+d42tdaWbNagm0iCi+ATEBhamge4z1g6grfQ+ozM1+HMGW18aCMhRwKlQdnvGKsHAPpW0+OGztffYbGq2NB3CEhgx+6hIMYe+KnHRU+fBZev5mpQ7BUeBGHY2QpPi55qxUl9km8y/a7GKw2oojLKm5w9X9FWw5QvTcgkKHeA5Y4Ici5pOZBf0DzP6B3gIc0AeNLAXH1SSpWRoujAVi9QSPJnSAlyJ90Sqos/A/ceDVamrLs0pbHGmvL2JyPjPUUOk3g7RxE88UZFKuhxZsQYk6V+Gy2YQBBJqu0bcM4FNyWiWEF+7ZMdZNC93U83fdnv5xMIHvwl/yTI4620taR4if20cBNnJpJ/kErEceQAt7QTXC+5/qkrVeh/zkEboguyUU4LRglGbzdRqR+ot92ACwQyTUqZuZilc7kpRy8tr4uw3u1iruWfpr8OzLAwU/eISXmQKYymSNx509UlKFjXs5hGNFa40cEmaT7mN5VOLk0BqI/35OWdxVVnf/Oep0JebqkKiO0cIVD+EQS2ilkuJyhwJYTuQ6lSckB31H4YItI244SPDm+/AS0ElIcJ30xrEqDcOlzW869cgocjSp/gw/YKfM5tH3vs9jUyoQ+FP4pV0G6aHN4tE/BiUo/0RDJIO7FxlfX8xmH+hsMuaw6mjuGWjt0aliGWjt0X+3Rf7dF/t0XThzQwK0NFrsU5FNrfvvhWvf7dF/tw8cVuahwfbFVBAkyb+HGJRrzAOjeONVoGslHdzEeRtMCMI/36UHnnJu3sLeFkumfdDKbxbRviuaV6S/CCidUAvqtCq/hTT/dxU2H1iLgBURX3iSfTL0irUyA4+Uk2ZNw56KTHMANiDALGWNF06XMLxWlGz3z2D8gj8o5X9QDvg2tuKm/1KedcZgn1b3I7vsTGui/26GNNCAJpyn15YJIqPW4QGptZvxXxFwlhdQdQ4lUEIQspRwMFD9kdb3gV4nr9r0G9Mb1DRyI/NJhi26L/bov9ujA0hlzWeg7Om2RKbZEpq0a+p/E6zQUiQ9rSNKZhTSrYuS5SvySdASyDvLK9UgPFd9taxXLnjClU7+y4qc4mO5iWnCfh6rnAfxblGkr7IU5fD6XD02m8iYL9blwhnrRqTRViwp2mwO5/xHDQebMDg+D0Z0lW/RiMSH1ySAr2Vsr/m7fRZnAv1WbmzBAeab/GUKVaeZP5fgZTSo1lo4SAlSLCluui/qdvGrR7bB1Ri/5/MnN/4IrHfqV6dWu/w1FLx0L8RyvXUxSC1ybR50KsFkolRuKli2ui7qytBd/4j7GE5J5SYXEQkSl2QGL7R2y17vCV8H3J71MwfRDDZtuKQCUFeptkSm2PyeQq/AK8IUjeusrvqEZY0X+3QfViBt6s0AVPML/cfTSrr/7rcteIQuyr18EcnpqgxKHz5FVMYyIkG2Orv2FVbf1LpOg6w7Yd5M0FL4VZC6ES/V38Uqn7uL+lQ2dDSrnaEP0JOM6b5cXmx00/1HltsKTU1li0Yp2ExY7tqTkX23zCNG5yVk9cXW/KOHsXGO4IwDOpakBsZRQdNRVKWmjajTbg3XLpRxFX5vyw4Ynea09JtH2LorCBSit8ja4jRGEAMK5A9x7AgJjMzAl/ql6nK12R7FLC5ntWu4LmrK90a2JO7xxwpKW5gmTBvOIH4g+/nFbFnlcB2NlFaNGUv4qo+6yCAntyN6/sbM52i/MzA0M4bbVyDy269WVLQ84gG34y93qW1RehrxGz7U4opryfhS4YIAvAbDdoLyDJQEgpt8/LzdtXNq1okL10TzdzPyK/XlDzIqk7bfjUmocBB8zRDW5ez51oFTdze5e0sfq88FNkrVBLa8oL7MMZhmLzvrqwFMsGXK5grtbdURa+F6mb8g8/wL4u7vAC6AW31Wtg/Z+EDH/LifNT419vl5iuoZvrmq5BEJYnDsuwnaxWck3ocMei+kxWhcOERpCUAZ0FqvwDpVGNX6/P6E/zcT8Cd9dXUoctulqLRv8JxqnJzx/7oenW+23n0cw/cgYsi6pk3RpULwBUtN97gyUoiejtYTAXTl6Vk25kNogLhMn+fRzYRDpXjiBJr+sZbCVLzIW1rDFArfrgAM6CIWofOxj0PQgCJRwHbfpmJWEVVOuVOmgCCn+yUhPa1Knq5hbmSYXeZxUBjuT1Ds7M+g7gcNKxblEnXZiiQYW9C8BSFE8OCuaE5tFMah8ujGSoz1qwQWfM773DBQi9F/t0X84UJLz5sxF2LjGe3D440u+kQsY8nU/7sFX9XmRAG8li+Ye2X7TeExal7wxPywkczY3ZHNFADp3UjF/785C5IGjAP2pEL9SbBihEiK+MD7SS8wRb6RjyHXViw8BLOVgVDCb/4D2HnmKHNudxT4kZOvNeJSM/oWfDjRwmnbj+crKElxCUfdtL52AbUdJfeewGa0M4uOdsdfgXr6TUP8+IedlCIeacydLSMb5xuSSvT0ylqZ951UT70LIbukrrEIgiOfEjK6A4Xhd/aAXgaMVzy49WDUT7ouoUziGSYgljp5UDhpYO5B4qHRK0kvyQU1I0wr9e1Mu5tCQ8o+k17HNYp2vTAVfZKrEQhniDkLYLerU32/rB4lMckgEko+sptno8FpTQ0I5qktigGbTDHiA3M7XuOsFTcKinq017j5h8PY5VnSavqfOr/26WT8CgJFFfzf0R8VLMfn3NNAFjQn6ncgEF7wUTrzsmk6a7/0qpC3fJdF9kp9vaDNAWxYdGCNIXFGMIl0wVTcTWFuPBN6gCrTtxw/W6rsYLQ7K3wlTaHAc1AchmlRSzNu9Fq9cI6gDW6T+QVq2FFl7gW/Skk1TSyi5LhTlVgmU2DhbHvW6NS0bXViWv4YSD38U5QhixCssAulLdYKLTCwBqztkSaeyQDxRLSybww6JVI+FMaK1AdD5aYVy1TIdDbKyIYjitLqgaQihl7M5luUs0XW2cPkG3HpceiFnehLXGGD1jLjGH+/DewPdGHX88JvGx6kMpgnJOFtR6xbCKgZf/l5iT+g35B3MqUUDww7L8NqZCjrqW1K/A0CMs6oXpXE00r/BC/T7s4mz2RjKERkrCWdqUFBJxBp28S/Po1LRan4IJg0u7QSZHGlTMJhJRQ0W0JfL70yJTt0cTVRwrAdAeg7geeOZssXz3HsUGsZBq7bozjwZW10X+3Rc4ELb4Mv52c0Qz1gvStBmjqFafbrOjnE7W0SaR8+dj34vW2P3/XZ9taVa4E5Ek2UtMOR4fnMsC9dR72MG8a0h9DhhqBcirb9TljgOWOA5YvQ/43dcVE+uYioVooxXDByRetuXg6elS9KzGWSvUbLov9ui/2VWKqnzBmUFvieMm/9YGVOdfF/fgHp/XNE+a3MYVpfoojv3S3A0sSKNABXj8pIolBUIDmVLYku+5ef8nAcscEJZY3/JwQzxwHLHAcscBQyfI+UYzwLaViCkXH1xxbUc96SU09+Ucx8ErZXNDomeSeE79KU34VSvu/8H5V7Pt9jTBGqS0Oosw88XcS8WZtmN1m2ctTesllAqqVlqIRieWpeRp826bPSdqGfaRgbkptkYT8UIKVqwCxljRqcXzIjTpyBzsucBy0/88/RpU5hDR3qJfjArlhyuXv8kj+RyFaVmtd/+Js2zEBDe7HVH50Vg7xykqMof5vMM4uFOCyUGLNIkDiDbTDfXjMKgtyeBRQ6eBB8H/p7eWzWDN0n5R9eX/6Bq5KNWCqctgbv9DGcX8ANdhe53cXJ+WHhJAPolSfic4tVjTKYC86lvgsuP65YoA2sJHnbloI1VDLYGJhJl+YAlX3MJ3yZSA2BCvmr2I2idY0XLv9MRZ/qx80Z7KAYQXZ91TFgkprajdEyjfW6T1CVoeDrGSsUHxgBqfd2n6eXAI+gyeqt4ONEx45j+3YG8WnAjkm+RTOgLt6xrQLwJ7G8I5uw0kxEoC1VF2h9zvqDtpucVA3doOSB9ceoV0dL+U6pJvIleVm1zgaXghBJpVacBJ4xHd6ZguzRg1GUGYr1Y/MW5weAWYQCuVjoNa9Wnp07vu21h+m2NrsBk82xs7ZgxGsMsis9kVKds3QdwOWWOBoLtJLLNdJRU4GlgLGWNF/t0X+3RfzZI31qYtqiTHBqEb02mUEg91aBYW0R5cUWr0dp3vjiNCdkuvqm6QuM/y3vclE96o+hz9mKzQpOqt5sCPOcANZlxSX2ekslH1wEvwDQuw4nV6JZ10bfSxdcgJSeQeggWajSV4KksEd2tFxeYVDNAPQVhGBLHjzNA5lEBCN+/IdSuoCk/mHmOLG+X8EZaZy4luLKqLR50fsyKU6yPgRzm7oUNhxvNuWw2PJWHUWLj8SWcqKDjd4IM1Q1hRvvS1o654E/i5VgEmvAddIuY1aD6QN0QtGhkCAq2ft7TvjJefczaf4DxYpfJYHaoz5dDZRyOKTkw1+QjF+vviH9tj60IVs3P5pA7/22OgFYAhWbfRqLXZlaWUpYO9wGJ/SIIQ+jFtAqbKY1v0iVBOM9VRMaIdW5RzifheffAcubIiyhSYE9r53NldyVbvcszF4cVO/At3rbRiMAzhTCempQYl7JsCgGftxyIyGRJxsGFIJeCj+2xs0TxkHI6g7EC2dc4YZt9LDbvan1lfVD74HV+VeZ2xgmBVInJtLJ1ubjxIB9CxsBw4D9HRVni5vzpaVskEgCZqtng/sSh7FawK8ICSm9VlrDYkW0GmpFHgkluitpa1lwx+zCbsrK5qM3HDUpUZqjZCayxFHK/bD2ecCeXUJ9wdRoovAUBUxwDbdi4W3yef4vEoEnLftUvFwOWWOm2Asb/KL/bov9ui5qXgz139PToAsR0mWHCu+d0Vs1ZvXtZoRJPjL/2biAk29/NVQ4QEnjeiKNdLH9oRtdkOLag+Dde8S4BoT6QwyMEmOOn0nIoSBBjq+YYvSgjeA/sZeAHLJtTJYmNzyQIzOBAxov5tyPYj2wiazx6EpQT23+/bjAtKlRBg7NUJ0hfOW2tb1aRo6gdOiHFmQ8N3gYqOhl/plzZFFJGJVq+8NksITQnnnJY9byYl7IJo9mmeTNrp+foRg+bfA1U/CVuJWtH4CgNBqgvcQqyxImfYrxQa76p4hQVEy5AcV76QUvXrEpg/+UcH3IdOQHAbyt94fGAmBnfj96iM8Sr8k/+Btm4FDyGfNsyDc1wCoMZ6KrygwB7QVRzbpCeHMi75RkFu9OxlwK+L9G4aaEiU+WCzRKmNpBE4KcyXTdT4JrwnpHrBXHtLERjJesKoHKIKdacxIjtxdvcXb+ysRx9ByveBCpkHfj8IdtEYxahJr3eb5Eglm29JIdccw+is6PtU5LNKSzHcqH6ushXNCj5YaKB4sFZBCYMrYFMS5t29zWyxMXNV6sbAWFaFRCYp4o9jlsvbsUZqy84/xKA41bCk2KCE03DxTI+/jgUvwfo1SPKjaKlIPVkToHIPNNCti0Zq2tTVCf3a7T4+pxAPfZBu/G+xKhz6zqjLtXHaIVDRYLbc15ECKfJkNIik/7wyKD1abXcIpuCB5OmBvxZYaOi/2HiwYVKod8iLGlQYOqI0NG6yVYZS77u2aUXWJ68268x0juK2ETunhJPvVGSLlLoUsHCUAkKTFSdOp1o0Byxveyzfv5DfnvRD4hNlDB9IDQYKtQY7g61cQKUHvSUnBNo7yiwZo3aWld11tSDMkTBSbXRf7dGpafP/6qjI2f0DvAcscBTbOJpWzlBpORmdGbtGhR2JJrde4FaXwd58LXMU3n7EIKhJCI3yv7x3wGQE5ZVK3InTWg80kykqnuN3GptdGxQTMf3z92dyNjYTIjeKqCtIs5OGsa0mSRoBpRM4cdrcedmouujBsLCE908pGRakZ1JRpV+tHZlNLiVMO5qWArXBlJtTD1Z8AGQGz0W4ZeTFGvplrNrIXPVT1cX91l1meKvyatnBV8Y0x0TabncB6RbnUjUoy3xwa2Ols/uRL1IvMsfy+Z4CxkCWuPO4gfPZfBRMWqV/dgLmLcApyU9F+zBx6qWqZSPbjYtwgACIuzkmIbgpMSiIzISydtuaudAosXrI4RAjl8Td6Y9X7gD7Nrd2NsEwJ5zC2RKyc5O5AExHeQ7fzI47GgyQGKzy0d/WSimsBIfpRiwvgEsTVMAQwSJSafh2hBPbdn6/cJgtwjI7mjpRk7kwvR6M2GW5UdzfrjJmboQwHuZqN+o4JtL74cKgwsCo//Y8OkurLlYtewzTVaO++3VlUHZo0cp7wEgIQg7i0cRvy3Haby1slOQ4MJ3FBRizv2poGdSR5QJJY3oSo5k6JBnFa/ykmbDaAHiUYv6Oee+bsvOJNbflllL0FOCckjMXtk+rU0yvTFcgLiROraVYPg/3NyW1Jm247wEVqkvhomG96pQZAQW1I8Grhe80nVyRauJjCK0ZJCPwij6+D2pGwxFWEQ3POjjZknR9AAHSsdN2qyAfJekB64wVVGJwH7q158N7PGW54JtdCkZVwKgG3PxTJjRGwLz9ZhSf+Vs+VWdptc2pKVDuZ5l+oBir2f0tP/Lcmjvbo0WM4dxnDeMAHFQX2h99v40WUeNkMP42I4ILCWPgYPKXhSwLrgbhP55VH2aFLr4I1kR2oBIRcnYXAh/cN1jXT+0aCYdRz5tPVICfp1RoeyGeYB8TpZsasQLbaoj/uOi5LxOwXJt7IvCEUA38MFLeUCFY3FNTahxXgLlBibK2F+WQSN5DeCIaEx9S5/DmX+NQ4TqATN4oUnwww6JtyHo2AhNtClICjdAebma/dw2BrlgqtiKVMLP5Gy6PXlj4eKgOOd3y2FjUCTLScv8oJ7B9hltCG2HtbYr3u/a6RAuFgwBsmAYNLebN9It+H0cToL+WhWSJKYdAw1AJPblYaEFLnifJ/DgJBc6DiUjlKwYfDFY9XmrNrqYu7JWrWVIRrLZgSGgW5Y4OnZOIRYJzQJagznRpNQMvFMw+fkgt1xVg4Ntj800F6bbyphOdZFOyln1guFQ3PPrLHATgJFL4bOUATXKNYLo4ppE64gzvNR0YapPJ+dYoT/iXJqtFtR5UshhukmrN4mhQm0D1g6tM+ufRCjKYbMhwBrmQ/bxvyHsNaB4/OVJTug2zAK7a4q1W4mFFOG9mYk88ra3R6w5z52+GEFERcTmQFfLB83wnRpVoFG1ozpfeIUKGcuoTuuBSo6ax0rNTMbcEZo4EkOAPAdWEjnJ3t4Wro8qEP37Fqfj5G41q12BNSG1O6evYMDr5DqP4IswirMmKioXbwV5X0vGshIFH6qX8KDV1NzeLE4PbBkbUV9W9YdUluc/ITFCNrFKooffWFjEgHMGhfBW1aPGAHKCwWHj0z1y1PUn6L6IO+xWQyw5qNiCMPzzqKeCOqKhC3EtRYq7iCxltAA7dwoK0zHH8xeGJgW9GZ2r91KwXZ2mulIGvKxMsuJSQ7bF6ctH13d1hitBdMb7QO/VIacz/DmtxDLQhj1tFJyDWi6qUWd4eSnt5bjZHOTh/YERlsnBhIAOTKhwMfXkZGUCy85ylRf89Ci2FCg7gcscB544DljgOWN9rrGWNF/tu1dRgxv+4SBEJFw4P0aiD5uOD+IchVtVagIFV//K+GL0SQv2nXp31dFQffFm5clE9vgAexVAA3Q2kBTvsuYwnUVwAkgmPIrGPcGMc3mg1eoaHtRoPThy2alEWsbKN1Q28tuICVyI39sEfO7d92bpxv1KPio0sL1RzHdm6DuByxvoVKj5LBJDIlNsiU2yJTbH47hrZk26P302Lag6GLYR3cDn4/TPKigt1ldLP7hDsOia+hShY4fZi9N25rWMsYa2hdVGOSAfPVa8IYcQK80+aU1AItJVmH4NxDBkHyoEhKEhuxvSvd4HLUzdoKgGIbNFYXCjuMi7/42neXZcTWJhwQp8RhLRQyBd9eZ4d6Qabn3GpjHmNwtnvAug4mA+1DJUhq2u098ciZagQZvDqihCyw9ZgPCOGhymge5ycr9vINuhuOwVaDF/Z17CR/iOwl7e6q8+w+OIVIeOAPTueBcpBiDZ9ShIew4nRhT+MseRnvFfayjkQs6XVLpSG0RPWT4DEQrjWMT3U+4qqKbeopoR0cXDSPsFM83WyoSGx2ivsmjwtWBSyBNmhrPQjouY2C6JRQRMmvNf1mtYUnwooxA4TPaeM/CidpVHLHM2Y/tVLCPTg5fbnk6OWOA5Y4Dh7P6oWuwOACbjAO0NPxmRJdLQCbyEocgYk/jWu7FKvyQt+i22RLAeV15t38Q+5B23o+Zp8/GZcEWcdzVgZhpRY1viL6QOj6TCbtoknd8FQbw/ZG1F7LcSF0KGZfjtxCGuU+rlhfrT5SF0kGbbLrAowTaL7npZe5QwKXUoY/luxuR0hOJB6qdqC8WoNgVhjqdN9UcaOMOmMgaH9IK3KFDBELR8lloi4mgtALLFe/gY0hE5b7Dfj3RcH7JtrFZb1H6AwPumq74wK2QTprXadbtcroawC9dO+c7X2VCMgNtY1G0p51bbMhaMONGTmQX9LLshdBgHZ8zhEtU6tavYs27l6+fwokWPJlzZ0+UvOaNDWaXdZM2CNZdwjwwExcychBfKN1VUnYs+RUKgyjaxUlL2fQk/p9rIMuBBRq/Uowhc50S4HvOIKdEP7UUuLe4kGcetOhMsDljgKpUnByRKYXPGBLRC0IUjlaYpPaa1FSP4RoZh1T2iuArCIUsBFIQ96/T961oUzFg4NtkSmutWrjgLiamtuuTxOikEkOx///yXP0fSPEDZaIPx3LFjN+e6XuUlP/r8FcUOadVT1/OaoF4lceITFbKBa9JwiCKQXbR6pJlB+9bXXa1X2UL3+3Rf7dTR26nNZ58ra6L/bov9uhT0i4L8UBcd85Fd3RudAfKzt9rbES8nwo7B3utGaFGUvvNQCF9tuqlNGA08AQ1Y+FphIlKgUqQP26TxQpvIl/3J7ojKA4thRihPQe5DjRGH6Gn8MoTx0CogHkM+pNfP7/aclVNwtgGzOX7C24dT2athXRvnvEd1B25NLD+qXy6gGVY6gEJ97FjXSHHnQP6ue2GB2Os1ec7EKFnajP9aVgD1qXAPBpLgGQSAgfLS7axl6fQAcGUbmKaCLYGnLIAhw5cscBx/8KGVtI2/Gpn9zytbIYAJGG1cNWoKnsNkWmJmYyI/+EAYVRh3Ipxd0XqnIK189/R8BfPHEV4IVJhpLoKU+gqqFMOW++5ROwWUiDSsKxt+8Hn/57fysnD5+txmiKMebeLAII91S//0rHy+qSSf+dPReowuv5mwMBUjCr1DQAT4akMXJjhoioJ6tOqZAzU1KVd67J1Rrx2ZyoesEhUinBqwKHgIhsMjgffFvUK6E9mgdokNFQHS7i10KSALSBuwTW/CipvoAdxr70ESiwmyGacY0XSWNYOP2qtird6GRgD2VhwJqzkbbSFd8iuydAkWGDPJjvRLXm/O84ua/UCjfDibQHK1Z0/27jaJ8iDpoy3ZVSAY0Fr9f6B386wpDbid3RcyUYuWMdprZJ3dHCNGzuakoVUQM9FgxZzCxHz72k6Xw/me10KRlHsdzU9WlUI9WACbXRdJfIbXQuG0VbjNyJv0euOAwCFP+WcSb/kaWvVf+uGW4YfgEuJ5ZYwOnXLTvDDVkNOyYaOOToRhmnoNidYHj45SKjxiA9/xBlk1Z5Ls3giMa1Kn8RSij+gzVVPWirT4EUKEwTLRbht6O8pHC0Cya+cbFdUOQ4KYxNyvjDK1X/oPJ/dtp2+Rr7u/poMV/+FBpYiZNGjWurdYuq8Y5oMw7HsXxrDGpJswH8AzrnwyYvuq5htWWHGTPPu5DP6laWc7wU2Y41+RF21mX0irdv1hZmQlucCjfBBtBrtUGIlPJp5aoBfTEeytYBlRRMOYE0WmzlOXU7irpjVSi+qfWLsT6ADN7LOuA3Uh8QDLoEzWd2p5vJz3POrSBhdUfx75OYaHt0MU1nXTNljgKmuAnXkhEtQyzwRThutb0vfdlCk+Osn3KkKP7Gug7S2no5EetE6tBY4DljgOIIDa1suFB6jeW5uMA7Q0/GYkqioP0S+nL6o5tC0C5Qc/3U6l72ZEa6kXzm64ZvYCx3bs4LhHKK8AaIaTCqRWpQe7cGUoYM2fodiNTlLdmtz8jePWrBLh3juuKAsowBbopCmj8CWzUEHzG2J2HukYBhS414ZnPSSFqdSEtXRngmB14/LJ9ZSgUqpHo2H29f90fJg2b3mNUC9Fw6knTH6qo2TW+ZnJgcu3Hr7gr1lsspbwf9wO1FV63Cvfj+YZBq8hY5yaPVEh0SRV2Dw54RF7JpaQXGDL4CdSZ5k8YF6NZudLk79YrTmium3RmDwz4vlt4KCxwHLHBQWOBm5KSFoLrCxIseTJh/4USLHky5s6fRpU1HdHzUz/rLG1iKYC1nTturkqqSODvlWX8SM03p6E2pXdKAzqCOoWQuIGNq3A8fHdEz9dKOGckEmLpLquV7zRoVCU9bBpw6t15+0uKcwG3zrYzb74A4DBThhoIn/9r8jDVbBjDRN5adXFag0yOloTgWb2WYnX9p6NtkB5KfaSeBJkADHZ8GVgEAvk+tW1u3xXClLUFqXqW2e39Dj6RhH0fafK/omuZmOHKoY4m35X8UdplcuVCmUC3ZhWduGFZf7JUee5MldYxQ4UThb3rwHBGOdJes8UaNf8aLfNhbGxySvee6VVnPblZARzxBbWvuEfMvz2KTiDA8bb5gGABgNUvsEze+kZY9lNMgt3PU9gChN9phwv3JNjKVcvS/zodZEb+Bo7vYWkkgkVAsKXl2pnDpfz74J4MoL+uym0/SeJdY7ErlNRIVRelWv68T90CLvyUgzf/rNESlOA2LpyZFsS1fBYkfGLDglhYKNoV0wBZ7nERqL/bowC0igo4x3gPkXAcscBysgjzVUtmp5kGi8rYFHtzhkTKdJ9u/F4mUqcyQGoftIy7CX7W/G8Ox/8kiQH2UAsArVGNPlGI+8dMg1u2HDmM/ojmlBiMPFU4iTeAuA27ywxXg868n18hxaWtVpWRCRyhdkZOkaC9unpzAGYWF3pPdMA4STtQy/o7FGqT4M05JmhkDnga6VUUKAhjVowDPg0JXpyMVV3QnEDZ1Bogv/g6NEsx0OpHjAWWJDkwnCQdgy7nt0Y+lAzrAyamGSW5jE/xLlQcB+gR9Jv4UmmmHAY8Kl/hB5BAHMuyHgPg4ccsmsvC3lr60czpiBLsqoK/rtwhmkRKe+ApHW/XzOxeYD2Tldp37/uFNWyz2yXiMmXdYHLHAcscB6D+dL8fa9RtrGWNF/t0Kxctgt+A2bYfeEMqRZXkCqDLO3G60FjZ1lASVBIvwsTvfv851oQxzS/SNZY4DljDte6WZjfHOtv/F/ljZWDpTJm7A+IynsOu55y+MdJTzxBYAE2CpRma2ybsxYtX99xbNHXi8sV595EcVP/bf1sqLn1SUjy1JVvfihURB3J1ljgOWL/DdZfN2xDbadQcUJUHmlJQ7crU2EnTfLHMbMpfD5xmDSLphUrD+d7/lOzueCc6tiW3zIJnMxyWeioAnAcscBEU6jgZB5DaQEMA7H+2O9sWXEyCMMkjddodvQdoYxbb+4U0rw3zGu+AbWiWhfgX/HwH5K+WpKzZEry/Xaq7AfTKNbFvjGWNF/sBBcPmgz0QX4yBM0Eu6qL+oMheJdOpC/YmtW5GkGd/7ALcEaI1MFMwwcObIs1gTKC5HeEALI8nUsxG5rqP+UBLQEyJ6FslgJ1U1GPLh3AfD39ui/24XdVHwtOOdSiosdpN4yo5Mtfj/pba65uGiQi1m7tt3m8Jj9vQ382FLhnuIs0Ifk4DljgPPLNeo3Yuaz4f/U2yJTbH+D6B2QIe7OVXA5XGPuqeHuj3SVDmatJuGZu77ttG5v8qWOXNZ6b6ToEW8Soder5QFUgdjnv47djpiRXHD8bDJPyOunDqbWNrubwILX4RiNtyRpROv7JLhtTjN9m36OyQMgrfiEREKsBFBbp8FAsRoiYPOtayahhb2+3J9wkPbK61T77dUEncEDXy8tERNYTw7oBQwktgBMUND6rvBDI7T+ustecrDGTXrSGTB3gBb/FWZd34D9Heo+nBN4AdCqXrsSMYSvnK6xP9IcqyegLGQGgttPJWUhsclA3vjJbkNCvQB33PP2acSI/8kkATzDX4D2a0APOee273JVAE2BIqJhI25TD3Y2qlUR6Wq8OMFLORf7vCob0M3Fbc+KLq65bYLt+mt6/BRI24Orgj4Un8htUsMJYBo+Pp5rMZNVeYnR8Ai6vfNiqepcp3SluurOOqzzhW6Tr1/QOCe1KT0lb58WVTU/Qe1o/Y8vrSPDVlv2XZc+clqbw9iNXTn9pcRe0BaNYcjHEbNELhHtkUUITe2PXNxgGHGn4zIkuln1Yx/WXeNVwPyJ/Fix3gOWOA5Y4DljgJLiXIoPTEGWFXZFQwJo8MrGp5rcgSp7QL0K/67Q2KAKxJoTCV6QoxAoWdNm+X0gFI2rQDyGz9HoS9aZx7nadJiE5q2YFcVk7QP+bgIAZqA2BN3bV2KoXa4BgilrqYk9otpsTusdhsIdI00TEy/fy6DYqpB5Df4AQciAuCLoUI3txFHwi5iVhwrO7kKvGKpgsKChv0hQrIgzAHiuFkzxbssg8+jyZnIM+Qf194HWlA85BAlRyPn3vAYO8rApjzR0mCAQcsi0sDEymGKIqFFgU90sJ4NuhHUmPTXcDR2Bk7JzDrkAIMWCbPiRbJMLwLOOUujg9kQc4RJSYWYoYMCmrnxGe+nW1ulWceiyW5UYP0Ww3Dq/zxNl2cjrG0cy5rDov9wvqWCUgtBMdwOWOA5Y4CodpDN1i1PAhpiop3JHctyXfcl7sqF7D7X096fidy7jXvOruTmK2zJ+2/3cNkABTMEnx8ITR8xIaE58D8E+/6mUz7Py9N2jNj4bV+mskZGEcT+KL2qWBZKzPJfaxHcSMb7kWIpW/hWDkQ5ljlr2FkgntEj3DioVEvU/9Lc2Ra4usAYhs7SziJN4t+yOmmWJB9cR4T+a9K8hM2OtwukHvJCQ2VeoJPeMK3GMbWgpfl8YWRxUEZpdeUO7y6TDXCM18xrzQ4eciZdjf8mZT/pv0psexROMqUxQtdOZJrPI5ZBVbLDvSo0VZdWLZuMiGoj2dwfBSO7a4AsY0mjMLTG/faMbOYzQvYXoGA7NG9C6SdvyUBsszBS28BUOkyzLwWTjpWCGgKH0BOM0uw6DYVKiL4Ul/v2b8CwEV0Y1R0vOx9Am7wK4c3FiGvuzwz51LNn/e1mEqr9BFD7NhJWMshBvBmwvkKO+YZ5H4sCAydALT9Ev2sn0WzKLg87x4cmCaTY/6OrDwzhIEKiS0R7m8W11vJb+cfGYv/a+U2CVRZ4PMUqjQ6LWWLd9SqGXQeYmuAHkTwbKHpn9A9YjeklNGQgsxNkq8h/aeLFIlsReILjuAQKoe60pp9VlHsxAZQjkgpRiAzaDzYS+K4dS2M+aLmpe3NjK4c2ZLxg6AA+qrv+SvFv+3nCWqK0OSpk1gNrG69aWla04j++mtCVnbMe6scW+A7r7cNrgjR8OFKCv2EkscByxwQ5kSD1EBy5Y0X+3Rf7AQ4U4pFYhtBdS/MKaWMcDv8XyDQZa85CQl0aEmxz6/tkDWIF2dHaimu6MrVU7XDnhVruATWd08GzIrHiWuzo61D8vRAJXAathnEUX+VBvSWEphwQOnaiMHh1L82+WdbUKVUQeyFM5utPILdQ28fjmMjW0/MaOFkZ3WyuMnpb5kele2nb1skAO2/dC9Hoh0YgkYlTwGbhzCLL4qUjDYwnk3wr6yN6/xc4BGZ4lo37MWf1fmngWUvqqbTDcb1GlXZbT0rxsQ8QtkjHlLezJ4ebiWgDscsmix/ejEKFN3/yrL3I8JdYxPbvmdxF7gcZs1IsGk77sSD3YbbSjSfqjr5c4RNzAbazb4IfC/tXnV0d0qShyquZCTKjRJohNzFo8TDwQEEccCYbRaNwHC40asANZLEPe0EDUC3L803xuDB46BZvKYQbyzhw6mxbmyu9yVYeF0FV9TcFgdrHaYFhUlcuhFjH7qVy2gwKh+Vjc8oSuGtstf5Fzv+WWa5w+ru8yQwVqfSRfSb2qr6WXRCaJX6/dLX0G7FIkHm1MzrYKEOfIlkZaWvhkSm2WlVDPLNeogLGWNF/t0X+xOI4ByyyAmtiq8P6/C8C/NxlvMljyk3y4/Q9Oile+H0fAsW3Rf7cOlskqAN2dkjQGVq7xbCRV5VBP29FvpzAgb2ly2hJew27Ob84XXeYLA9w0Zo1h8geCJJh+K/8xa26U3PVHXBlRfQXBtVjw8lnL0gC63Ed/XaBYD/gvDL5KP1LaqoQfmOjN+ZO4ZXfWhVFU0bJPl4dyuVPjV6Hr4iQ/ll1FQFqwnv/39qVuMI9hvV0xjCpgDT4A8y+s3+3HI0XxMcOuiYgl7JPjgi+RUYZ1+npp6lBZ1qjMpz+DvyhcZJNQYNYhf5F3L0E20elh0rAC7Bty5i50FYukbeBOQ4fWRWR6t8s70tl0WGuneCcKg4M6Nr4fclf1ap0z+Ad78NVsoqNOfKW6HWxHCOubiQ33elTPgmZna/67UKyqp/i0UVoOA9ogOJYqFPGG0EEpXdi5rPQcWqhlXuxcx3h/9Rzj3ltvDYTIBUh8qyYft0X+3RfyH+8suv6B8MR7HkrhwSWpAe5hQeowM7frs7VUIVBN8pNCIuDv43kqAkCZC7lNVSTIMGIVvoNhN6oyKO2RVgFcc/K/9Y92IZjsz5ks5B0jAu/g1sDCmsPoEq8Tw+2RKPp7VQWht//Ep8LRsBUB+BQO6G4HYZkLSaxVb6xov9iF2kH7BtOrmsbJ/wjJ3KlXsqgRFzfil9dKlvd2eO3FDwKQPmBglcqw7Y7M9wes4FDptWQffMtXbMDK9RxpTdov5D9njGoHTeMDp0I/GJzd4t8hVyS81gL9VES6lU9knvxQ59kGFOrZ61eiQ17sSDPsVPd3zxZfBJZamVPAQ9NrP2Pwc3Ea7YAxxoPLRGW/8vXKYSsDoFU8Sf7HIgGPtQbrcjl1mR3Ul3JgjCOy36O3G3f8E0c7s7cLZEquHDOm3dfqHeGWdmfPHAcqwG4Gx7GmKdn2F4pBw4M2aA5mIF3+P9KwYgYt1PCN2uDy0IpeTHIqwsCHA20vxbAfNOTeBZIeNTaIHwnpc8tzv3G1SZQ/lhKUb/Bxr5F2yYF+iiDP6wvLyRZKyGkpWOnuX7Kxo56JbUxhAhTRnUiZ72eyK0cGutjWP1XXO0iB9jER0Spew4UCH24WKJXlf9cbhX0VZbaNXCnlg8asSMYy0d91mU8zynqmgv7m5FInE9pCUZv5kilzNdcJAjPYy8rWU01g6Iw6HodFCEldlDSagb1dviafKPKHt7lqjzpmFXIbnPkopG80GwQXVhdIza/5Tys1MwkyL8aQbMqjASsQWBkCiMfs8utaK8a9+a4r6gKW5mvNZlqBY4Dljghnljf8nAcscByxwHEbS1GjWhLklvsbgZDyyan5hDbWe9AqImdzxvGWuho6kt5Jd0PSi2FEzUMEuSShqWrRsaVls4BzfmdkE4njsEh75R2Xcu6WVp23sh5QM8EezsX511RTomLQWE4lIN29tVbSF2xqEyX1THHwq8tgRulAZF7468Cn2EL0J7jV9lE6lkPOpc4LmNjWTCJjaicY2VGuX/sUbipYtreIuNjWMl34w90FvQ3Sor2NldvOJdSJnF+dF5X9mMnYlfjIR9E5KEiyEVkq5o78wnHLX+1lPJwnkfyDCNi7AZ09bEMd3K2ui/om2MaJopctMX5s8saXYPn0hHwdQebYZZ55XkTNGLFgzFaJnHhu3R6PM7v7Z8Y8loX5U/tzkn877TtKvrlEoOrWi25JE3+7DoH/O7PERTenbJVdT7bjCkm4DiYmcsOzIyRfhUTuI+WYrKpmZk9IDsnZRkvzpye9pUOzaa/VaEon5y02CvIqG2fHCVmYIKhA1khpepvKRP8JPAF1ZgNIyWTtSvL9WLUhAL1EKDHwkMYA2LHLzSNI3cHIXifH9ukgMHixJSYdwMToYgb2CQINQOTYDTeuCvBWdAqxzN/E1n7H4q7Bmej6Klx0yT/CnrMi5aDnDbgePIdNAHsIMM7//f+NLzO1L8wcoMEVB3aF7pIujkMA334apmiDBr3stOZwybRknQaZk/qClQqAhxms6TeORQbEzJM9V/wroi67Oh2UIwxooWhwyQTuyJCVaey4PYk7xP6wKBG7fQn+zpfCr7gPFa6EeodYu4PtpHOfQN94jqQMKJKai8AdhlRVzIU1L3KGCOJoRc1fGMwZr9GnPgCZ0/Ii6Ij1qVesToorJiLQKvpAPoR5QLCQkNUGBO62kGUA7nidvIRu48cqPefBYksXZewYTUktMQUa8qcVIOwqjLL/alDNzN/kaKYDXd85YSkfYn1XJGjKD1hP5oOiN6r5sdIjP/hRhj0p5U5r0XsCNXNMv37Ef13EHL1ekfq8JEYE/6+J4dv9FJo/P4YDYB8PXkawI8sY6NcnCfTUx4D3Ij7ZK9sEeZ9IFizZTru8zuep/exeAtsZpbvxRjtbysgpRquYgEap/e1BTELTTTywW+qZOTAxWm8bEkODE4Ag0cgRiHIXeBde6TRkAFxAStXTigbpe40KYWzcE2gqOmJYzzPhRxdfLWDbbMI5vZqYa2juFbC+83z8U7wcatNzvLJiFB4HrzL88dsC0uwlrcpNkTDBwaJWvVcgDX25EbSAOvYM84m0WN2+0uHn9Qqa78aGE0TVLGT5VII/hOBRkAWZbauGxt2KagMCdP2xE9EDggR6LKBRGBqUmcBQRfC0xShp8ot+36Xs8a/JUqS5RRe97IuotL4Fy0bif5AAdl/99J/UwjBIqtGRBlhYR7g9wHNVjNc+plFFhQbVEYQfHsrrFfpO4I4I5GVpHoJmeL93WFSWE9wnmPaGqrF4SBnMiqClNt+1PjYtvnwKNH68GX+EamCbgSdqkUG+9Fq7wmFhECanVmwJit28twAOdpu20MOFien3TkGcAA4EoN9rS3Fkdx5CHtT90p4xsurOsq/Vpd6sgT2UjhFrh507ATNqnkZsPIOWn0m+7dFxlsbkKH/F9J2jsxKW2DvmOA+Pxfl1nudbaHba92TueBpFmC5iQFF8iNF2d324JNwOCdpkGJwPsRSXFznW49L18oEbstv8CAXcx+BBMP1hZBqJ+VGl3PXvGJXjPcSVm2ZG7A15fAggSo9lci0mbMIjgoF+Luc+S9j1YAalOW+B+aPXFgrEkAuLWOhEMZqw1GjNRr0028QbBrcNkL30aW8x71oD9+KtyqfxV4meCfk4LuCkwPAKjiVdL8+PbzeLHLLzyxwMsxwNBdmyuZCJUbiuw10X+3Rf7dF/sZAORSueu2RI6oWXYp2LPkrydcz7uvxyqTGU+pT93cvkd5e3lkm4mY6vBUoJ58tg7vBYw8F4Dx6O5bEDPII+JzRlI8zr9j4Groqk2T7rDZYF1gtC9v/2CU32/khwsSFbqxXeoIm3/WYFBZUYjTVE/h0Be3OM14ER28ENgmLsuwO248X5W2iGKfYlZBCgd9EMxZsJAdA/Khmi2EB4DC9lOhjHfChtQcNmgbIBPc/JRwVOnjphVLKlG5WLs1KhyeXTEVx/EgqznEZwWSHwqQ08RnZTh2reXhMC9nOII1cn+DqZBFx6GcNmThpE349O/SLTbYQgkrF4nIBnxwOhtJrIebb3APWdCXeEm90h/erKq45ZdxM1ZwBhgq4HOzW+mUU/QQP1xbwEQw1bb6X5PIDR8OWGIsZ8NnXllfBuAcQ4sEqtNLizAi/u+4R6nirwIj3q2yB89ckTsMORFa/oAK9AvJFfGxraOjvey1XkH8ourhyo7SEeBVF8r+cRN0oVpfEEcJJzFL2q2SsQDlFsyxT2spBo2M0D4aG+zFG8XtUooCf8JiQD9RZj231eyYU+o2O3vQpzN8hCQiDHGvdeLUMxhhySHe1YEDumqRAOTZ8yYyjB+YA/EEOSHIzfiFX3eAsY5oWrWPZcKNRRxRAMjLTiGIZW1utC5FUf7IQP8hpYn/j8gM5eZlpujFAJMcRBrS/6saZs8YUxwa7keTp7omEi+kedcLwLGF6m2R0Rpay0PVh0TFQzAD1Iz9if7g22PdVCkjlwNzVmBlWY6Jv19d7wPkdunL3mSQYurkHIB3JzTem5xysKO98AInMaNIj/6jdP7Fm13dHnLJ5jOiD7UYQE90TWzjHwjMTFEK1AcYGMWegvMZzDd+3s/yuexvAcrAr7XVlY2jEggKORw6/VcbRpUELXXA51WFaDxjZ2HoaXZwYijuIL7LSwJIQslb4HUg/Va2CybM7wHLGIAMmEoKX551X9zfTzNk0OuwjwTnQjQZhqY/xGXhbweDbZEprE9cIb8QfXcLX1hYO0R79e28UUA2GskO3gqNYqOoiOoCg+39DyYwBo1Er44PsbgEj6jEda92bMo656ZTf/mt1kFcA3LyWBa8QJmDRWDz4qp+QOarP1ZiHpBjPWGIPqeqocsDRymLclkgwwrSt0sH/mMcDIwE2W4AGBhyvUz6fiAdhIFwZd/umyfoDlS5eEfa3ao86omIh3p0GqqwS2RNzlWMhMiIHKqcUgd6TwA1Abmso7epLnN08MBvQheh6ZAKIgJh7g9EDcLD2ZLZpStb0RMwfhUHcsUrG8fN6T+7OHxALNLJjBf6gEMgCmvLcXz0dgW9MtFUgCdjiBhsP2UjEBmcUUzWzqNYykeaWPTnBd9QL3A06bane52+9JzQrZ9I/mzLWLqff5QK0KUSu6WVfk9vbJHMKv25I5jfnaEVea2hxX5R0GeN9CpUfJYA0udBF4qVHyWArXBmkSm10EK91G8u9uoDziFt2VyykVfKBoJGMbalH9PBqaRMTyT4DgbAvUeku591zGhWTIrNrtQaEeWMIOagExV+fWxwsvoeCEFv86IJEabHANgR91s+BzXJu2XUxuHbMo/KdBFa/IGcCA2FczS7ZS39UifIZCFNcPdfWZIG+j0+UKbdDLaaw8CmfKDsJiBC1btSZPmBsCOx+lDr/vNtfRC0YO69oAl6qIv0HTvQN6K2mY7oM12GmtWVxEpG8UTwIOuLhNowEju1lcsdXavWit/noqVu/AsLqMauD04X7N2vbPtaNsAgY/98Sh/hABUzyHGRJ/1+jw/PPx44XCF5e8YsGkmCBnbwqKMLpQ3/oAxDOOlQE4s8CzMj9+FA0qKPBiQZcRNusn04UMrIRtB4SKopFJjYrLtVAN6scQcNb1v8Nr3pJwdE4rPyqBHhciWjyyZQh43bwj+t4ssDw6ouAfh3xft8B4cNrHCfzRVNIpQ/6QxueGRaqEx/apbeA5Y4Dlljf8nAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscBxBxk/70uhkXVGxrT+2vsNPRY1rcx5bhFF9L/BA0cOT4qHJ5ov6xGU2yJTbIlNsiU2yJTcBPTbIlNsiU2yJT03MsuloBgugwDtDT8ZkPQrbmP11ZhlNsiU2yJTbIlNsiQ88dlSL8di0siRvya1tJ341Xy28ByxwHLHAdyka8hw9JI8fQErLF/3DSKoGZEptkSm2RKcyrUIKNBdBqUtpGvzPLC4UHzII5e6g7aFG5WH/mKui/26L/bpxMFZnak51dZ8Hed7lddZagJijDZjZI0JUZoQV2/YTlhFOuCAhX0Qpn/McByxwHLHIFYAHCntak5HkX8MXo2AbU+M66XR/UR98C9YGfwcnNvxqsFFY7C5XJZuvwJa8/5OA5Y4DuUjXluSwv00W519utZGs+N86D0i9zRwRlQ5hz0rFty1ZPdqqSBx4XqbZEptkSnMq1DY4jVKDy+RHCM1syvKYcerpddo+mTgOWOA5Y4DuUjYHBljPPlbXRf7dF/t/MYkew+dvFBdt6ma6u3gOWOA5fh8ICoE+sRc5dp2ZH9F7qG0PDLD9NxuZyVgzWJT7G5KbJBbEAJEET6jaeaZT6nK+ePYMt8pCP3yvpmFT8iShLztDqwOWOBnwlAruShMwuDyB+0QEb8IHao3FSpHBtsiU5lWoLtcEc/qC1OLUHKeibK1DUITsxuwDtDT8ZFwHLHAz4ShKbf/U2yJTbIlNsiVyNlK+DxdqJJvHUMPVZ/a0IJl7XAfej0ovpJ15SMfKsMXsn0oqI9lSClydwmQ9f54BE+d8Nf12hmKfjcdLniS7CqS2cQ4tDWNQPR6Jqfn6xCJeuRP8FEkPg/i+6piqS48zZGbtfsODBIL2BdcI6kB7A0WSc/XygMUrAMGDSE4cLkcUAxm0Bg3aosx/vw1uG2LZ09GkdrgV0faKDq+HJrbjDSBNp1J/cCmCWGyAOgt/zkBwUpAyrLngmcJLvh2xU2B89BRIwQCWQPvcl+DSMvCoXa/ibfKzgS13IqsJRd4IcM15obvaK3UVptCBnTZoLc01ACuHFVLsER3B18IJDaxiKYNs5KX2VAaK5pNXtiIdSWTbF6jzFb1DL4gdw6wkiwCovjiozgVC7IY788PNQReiQ9McZHzZxC4ayOASoJM5ehJOjruOA/g3OVbzQ8gVbTXy81GB3Afrh8H4DAW2WnAGfP27/oWYVgrRkxvAn1xd1f2wks/4SQvHgFwaHqA4K7oRHY6lnxFns5lWoS32ql21jLGi/26L/b+YxHnvmfI+FUX+3Rf7dF/t0YDmJfzcwcNKK/+Y4DljgOWOA5Y5AqyWF2PBtsiU2yJTbIlNshACM+6rE2nYgmNhxmRJdLQDBdBgHaGn4u5yP3TwRR+L0tAMF0GAdoafjMiBcKq9RMd2Ga5CBh0xvcJ/6+OHd97K5KuJwljA4mG6xcyAdWqY41R7PrB03Nr1goOSh5/8Z+fR3XZE5QmI6HpAYaeJAgMnsp2XcIDPD4btzu8/iNX1NfVLUnBYkbY5svxvNKU41g5gtgresm5iSCkMsYhlo7dF/zw/+ptIuPZDQdwOWOA5Y4DljgOWON4pIbbHuSEYKKYl+kyOOzze9aS1mCq2nb9nBSf8r4NdV6NHkktR17EcKFUgh5gRrxByjUUcsj3TUOGiJJ+cXrYH02Yh4wm3/oPTDX7IEzkWDZmKX3Yq15cE04AWs+5Jl0kj85PoWv158I/yvg22eY6ee2A16Ls3tLEpQ7g4bcNt68d40H5OA9B/N/ys1S2q8KHSXqGGU2yJTbIlNsiU2CY9ctH77xYhTj8d3doVKaduLuA0+WyBKRHPNcW4voZdFfhZrNsiU2yJTW3v5QsO5qWAJacOawdiKlSODbZEptkSKIWcdkHKIwLmAUwToz6qvBtAcscdhOfd2C+Zfu8byKU5/Zgs+o2WDV1mJLCPX5aNp2WaYyFh4HLbpjf57K1kKDsMx7XSHR9xD8m+yLAaDu0meWN/ysdNsBYyxl5eeGGgWXkFw6Uxmm0GfcvoWIb2gXbD1/+waKq7N2kKj7RMO3Rf7cwfDIv7NABcbMWnk40aliF7/bov9uTZDhnJxRszPS+q0QRKbZEptkU60VP4uFDmCXswUaiheEakela3o8bGMO9NorNhe53M3J4iU2yJTbIlmfQdwOWOaSWOA5Y4DkXtvmVg2ow7ETrun82mXv03/kfbD9qnPxoZqR14OD2icYOmRWSMsAHjB7um8WEf9ttQcEA7ONSR1dyxv34dTS0G4YpZnzthnRB+LWzKq8G2w+rMv7RVxO/Mlj9klKHD7hE/+SW4Gx+TgOxZ9awO480O2yeFj1iOkFsX711oAVfxxAMniAG4Yi640SBLf+YBi3d/+lIh6cRDwoCisXGWNGSdWI6G5WtuWR1SzjUKkK6bJTgz03VRLpPRNLImxLgoGMOkmXisXSLJtNJLLG/5OAzrSNPyc0mg7gcscByxwHLGq2Q86elo4MLbY5u14Tj5+fH5GEc2kLo8x/uY4DljgM5G/lpjQNK0J28xBR6oKJobMMhmzKKDMq3to+tmNGuDGowhwXXWkMra6L/CDqE4wcH7RDWricSHBpv8EK8QQ9cI7fLIOjdeQYt7uyUoV4tUjGhPoHpTreOttARC8cLnyvrBPKUw7bUPOxd+jLfnfAsyaPv1yjac3/eRmg8Q7CmmdBJyXqeh8nRyxzNlljf8nAcscByxwHLHAcscByxwHLHAS/3EGAaVRupCc2xq19iM3MDbhO2iR1WraK5e4Cfm9XRgFy6+TGGNJWdH/RL025EZiL9vrCFhRoHaGn4LJdQRP99qfs+uOmSqAVzVpFRfnvOqhLFYt9bqsFQphg9+Xw66Tseg+ptX4oS73511E2GPdkkSixvsoSKSDdugqexuMUVBai3SJ5vDHErmWOO1a+1j7PwBHuhnT+f7he51CJ0k4VhvyJRkngbfd3yuEQ9+sA6AEwiEF+ft4+qiw0Kf+1XuO50BjZWgf9DTIzPdqshd6Mn1GHs+X+hf0hOjcf3vtDjAyq44MghlqONCCduUPzxpRb9bqQpFYFsJKOnjRHo3gOiI+tQDPmfnwT+ikPmOQOO2s2APb5KDoff23q0CYEtEjwrWTW6M5mWH+mIEOSvLNsMqBcGAW+1/IiPC8jx7SjzlaxbKhbGEZ/Q+2dlUbMfMomzbZgWrLMW4XvPjY3SjYPx2nfpURN0u60LSwJDozMIIIihucICxtUM8PoCna3jLVLOzPnlmqW3gOWOJGaSOyvlPHGCse1R/YghN4u75YppOP2qPutvyKHp9LNgd9gnxwpQtiYMXTk1l06C0UF8VlVM6kAq1/ZGDnYj8ma2TQFH7LwLHkhS3gDNg574MgYHxv5ertAVIKz2lQGSafCUzz6yEc+b0mdLnorDH0Hwl6hXAUHyXs7dk2MFRAKZ6/ZU6o/nmvHSMI3VdaMV7VH4IQNe4N777hqSuqXXBtUGZEl0tAMF0GAdf1ALpN2rWcLWg1bSI/eVMLBgGlUbqQnNsavF74/ELkByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscBxU46DbynjXK+siP3lTCwYBpVG6kJzbKMl31LImwvcuvkxhcPq76lkTYXtIFjLGi/26L/bov9ui/26L/bov9ui/26L/bov9ui/26L/bov9ui/26L/bov9uhS+sX+3Rf7dF/t0X+yNiZm0Mt024MeDHVzh9TcqRaBEKcBQstsMa/o9M73GUVEZsZ0iSNxb6aZXTVdui/26L/bov9k+u685uKJ7tYkRKsMqdF6Cm+LjCZFWUlZX87474l4UJ/fX0X8G/xs9zSpa8/5OA5Y4DljgOY/teai4HLHAcscByxvTo+RG6SFvK+f8nAcscByxwHK0i0Iw14NDCvkOuct2grKrULXT3X8oSG6L/bov9ui/26MAuYVgNKui/26L/bov9ui9LH4vPLhS5Z+39ui/26L/boYBP42sCga78/8voKm9o0vSNXEOhUVlRVCP2TOZrIlNsiU2yI180WAKFlXBKjQveFyO5rtjUQueQkxijglx4Lu+Aba7HAgAVzbdF/t0X+3RevTh8OUgTGPMKSa4GJNHveA5Y4DljgOY7gc0Emzy0ByxwHLHAcscByxxIwytrov9ui/26L+ep7miSqRCg/qmh1+MxwHLHAcscByxwHK06It5b9Byh/kbcb72FhFTn0eDbZEptkSm2RKbZEt+ixwHLHAcscByxwHKsBvTLscNemrOwllRIBQIEV5Q0a1zwtFZ/ycByxwHLHAcx/a9RtrGWNF/t0X+3Rf6/LxouCFizBNf18WzrdJ114yiWQape7AGNDgwltlZVgoDljgOWOA5Y4DljghMfzf8nAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscBPb3rLbO3IVIVG+1xkC9lK9FEVNF5qYqu3PXy28ByxwHLHAcssdNu2sZY0X+3Rf7dF/tvt5iC2Vd4f6ki6LOLzLHAcscByxhRXr02uEVKXJCw0/SeuLnZu6dC6LaBAfSS/ORqnsnPUJqzCK/9rYzICQg+uhF2v0BfPdo9IIskeqbZEptkRk6D/5ecZeoPEyzljgOWOA4qmj00S2nnGNA2ZYlE9un+NF/t0X+3Rf7dCVFVu004KPZA7+gFEvaxov9ui/26L+pxbh0Q4Ai40jz2FjlDohjokFSniMhicAv9ui/26L/bov99xosLljgOWOA5Y4DljgOXG7XRf7dF/t0X+3RfzggRzglaZBJ16Y/W2+fpYQ+oX2U5O3CUmhVKOjrKsRjmZrLbwHFTupQk14cDOcy8w/bKMfI5u3TiA7W3s6ZwzHc4GndbJXBUsENa96jaFyFj4JYmqb8NpxDn9NMMwxHCWgt2Y1fZlT8ByxwQzyzm/uWjVq76pk7jEqLLbwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcrSD+rZW3Bq2Zhg0lbkT7VUAnNmMmEvHjXKIPFYm6o20jADLKz7GRjsOd1z2dScayyvzidHY575YB2EdiSwTtr/u6Mg+bA+2HzPYXh+Mxb9LMPxuFcxnkplvcKkLgChUFDKjqh1/jKDdyONnXcPvTtjN6+iPksNG6wYBpTb/n+uTTeBO39AAcKJFjyZc2dPo0qdWtXsWbdyf5Qs3Rf7dF/t0XScQ0LBUVu6iVA/PgUR2Mgm10X+3Rf7dF/S2iYNBfAHajVIoosElTwZI2U83sdui/26L/bov9jiqmWCGK9mhRVtL4UgoFeHDt4m7ov9ui/26L/boWFYjbN2LPOWk1A5Y4DljgOWOA5oIwuF/ibXRf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+w+o1ub98SlVBoAXywFrx9y23GJWvSVlVK8dwZI2Xh7Zazj8RZqgekIztgyf1X7b86JodWNlMfaO1Ialc9YBse2K1L+ebZBqukL4Gvh/9TXWlyT1AlwuRRpmMA+Bc9zpHrsM0mKjqweh5TQwjEz/azRTdHytrov9ui/3C+BpDQms8+VtdF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3RcgAA/v5eTAAZeKb/o6Y43BOAwIOA3wgIGpoKvb81xiuRIRmSwOWu41zPygevCIRgw522bzGovoYd4PiVA4rR4SQ25AkBJR8Gq/vTdJfqxkxsgaJ1PFNGjUM++Wc4l+rJJ28VCFu3jcff9dWDpKm5DcRSav9EsI7bajA1zaQKkFSOmyrWA9Vqv4L2gQ7gdlQCKDYRveom33p/5tIf1gBRG5BuCm/Lv19R39l5cne98TlElrJJvmvP01YGxmQbz1s1AqiKPri1hK/e0v1QK5Qkj0sBzJkCouBDiAERrMeZqaMPrS6Pv8WI5izD1XhZflYh5WNUXNsQinDrGzuMTR+sQXAzNULW6O10m6ZT5Jf3LRcUzfvD8p46IkerWJxO9Wyn9C0PVoMd5WVpaXldANE0k+dQY10r3kW6LFcgyDMX6bu2W9MTffCk8W1vKdu0lbpowdKF34Avb0wG4/CZU30Da4WALUqqwMh4x8h94LxF5d6rVUJ3r+7pGGjyQ7QF2DQDIgQqlpk39CQDHrJyPitnySZia40A2IgOOazkB4ujlZiI7lXqt5K2PLy00IogPA2pjAdj4eZq/m9HGLJmQKIe3LJheh7SLhvLcWonOxKgtCbGopQ/vZmr3NuREqgiYY9STN6VKx65Mz6SA5T74vOlSUwh74S+OFhrQAwpJ2VTX30OGYZc1ipPGFqzGQhxXdmzaOmngE/7KJvcJxpNaAokjhxhpassNNT0OQvB/dIa6E+sU7Juc47KZmOW/5bt+njiiCXbJqFiDVRsChYf3IIHvz/DiF9dYe/dyonULC1dcsGzbx66F+Y5vAQIY9wi4oMmHuz6JaszbF6TGDz2wNI+G2c8SYD8FaK25k9BrCpIZoE58q6YFFNR4l/KzP3HXk4Osnlebz4QtmDsKfZealjup34/N7pRvduMJcXuDyTa0EOhORe89lUj6+mZv6057B6F6XMFkMY1ycf8M1S1cNghr5kBc/BMwbC2Tw3XPZvTAG/le4x90dZpf24OuLThvBQ5QtzVnS2VL+pp1Udo1AAAAABWbVdGCPGsrp4hX2EpBF779jtEbhIdSAu8vDL9vgL7TMsQNavN9rZiBzEfUth2EBUv8lLYMbsQLxAq1rg6t7VqFwjnFJpUc2667Z2QwDf0qFkKQ5gVrpCveRLTeD3GsUMUmjvswbjf1KvkodzY4wKQGm6vzhANbtxB1Ba8h8tq5s9zoGoo9HEX56cgDCFPOSVysfiecBQ3dkP1gwexndpOaFCXkErNuf6HFqEdaybswZA1EtufivK/Z9zgA5v5ssToTEsW2VQRublz5zPMgZ80d3KUlxMshdx287pMVrHgt4/HXKVsxa4+k5U7GB2EMTBODFYzALbwNQHX9TpWuH4A3K3jKRAiFJqfKnUm20ecljpWEGxQbkCgDVBbw708JGyQAIpuDw7hecj4Wdx8Ns+ZFXwvU93NlNGRXwro7TSOTivBf7EPIq+n9mrr4RjThIlIxQ/ZzSapMVK40WBoe+YpJyhtqq7T1zeSwTvRpRlO2UPmWYEzmtZqD5y2sTCC691/Abo94U5DQgshhJtcb7c6fWTboG9hcJ0daj4wRxTSi82+5u3CvhqwMsQbwQyfZkxFjTtcAPcWc1HocYFgp+03xTEU3zZOJOs6mk+jkfgokO7TUormYYqeDSy4eOXJ7wJdgL5iXiTFuMYlIudOjOVEafeRNSvKY6sCKcZSwVhsaWKtD32cvDVl8Z3OOy9SXG5ksJZHHq3PzQw2vCOEd9WXrajICmovIpHD/8bAOMsveDbzD87CPByJDC0sslWZUAhB/KfY1S7gpV123FOOiRk9rO2pJuTIwSTzGsHTjVX+CvQRwTESg9PF9boSRhFT+STURrY9c38j7/+GygKWAAAAAL54nuDn6Mv4OLm+VIRNfnpEa6oVhWhkj22/yN17N9Xspl6FYa2tpLnvwCLk10k42yajjsaPiWoyDYQ8HmUC23piwHbT4BFyaqPzg/SMy/uCXiIRElUHWzjGMx+NxZsu95VFJnFJSVHkcQVb+YbKfyB/nXo4gRzfuLD8A/5Zq3IqsXq1kpeyKdx6kPE+r9q/mQ8bJ+ARcpTSUjMawLeYAB1B4c4ERcQWJugSyZ/zgEXJa/uLDCRzfsDDfpH/VLFrfrn43FnCS/AIuShvPhDXK6IYO6Fdffy9rJX16TB5EqOQgCDvOxmVbdz7IdpfODzbIjmfRMABSYu00rpB7XQB/ulb3TdbGc1I0sonIweFAGoFYBMuus1hs5vRyjMyONXeXq/qDo/vlY3escvAmpfXTdyqjCajUUMPP/yT4P8mfLeQLGKR8rrjrZ3iz5ebMrx79EmJ4ZSQnOTi9yoZz0ux8tktus1hTwXDJ67O5nQS+lckpfRhrT59D8xqRxwQGHdNewV788mfpJpx9qvwQLJD2E4DbVFLrQ7XVHe0HLwtRHtHfR9aguz0NXxagbevkGVF8uy7YLl0+HY0l1Gs9vJAUfSs5fpDl5i/9qBaHHMzTQ48gyvn7mJ3cRz7ZS5yV+9U4QZbqMabR069anh/aLWrsbNpgpM1YUn0P/wQcuxf1TPgGBmA2fSfPHUcFBiV0Gevf1qLc8tlRrGhbhCVCswYDMWpu6JaMrOG9GbKs1n17+tRbnluPIcDWL1SWSqcKv9Wpf8jaEYw9x7bpiBTZGpL5QyUdx9Rkdo4y+WkaSCMJSDgNbCdFnuZJ2doo7byVly2KH0IPhn7FbwglvKNQgWiPBk8xmb64x0etMmZNKvrOsXC+sgJi4cMntO6DylVkzFDhYoc/yKSST0GPRffp/r3K7MKpT1Ir746esHLu+EL1NbpAyOLKNaua9nbtG6RZGXOTm/j7shAEexIyK60gfNvG3ISxChIwm8LuUdi7+99gyMsWFv2wlnuu6/2I+JmesDrYpMvCZPIOvp44HNWgybhWBd/hZS6g5FR7ifD0qZXZ1s6/ZATGLDX4GKxul4lOk/s9gDL/Pm+ZvJzjlXNNf2C8Ug0Vo6Sjum+aGxGW8+T0rhOyRpweB9QH02pMGl3P5oz9o0mzveB26GqAzS4YwrwAzzQLaSkejXG83Sm/tmOGhWY5L5rciPNnv59Nc7JT9oG43A7dBBAx0OV+jaQDDhm5bcwBYxAJYeUt5WZ70WW5OtJM65gMwnGwJ+Trg91uvWbZ4kjo28gcG3D5Kv3Vtz919EsHeIaU4z+yCrFQlu8x0ww3QcfhV04UnUK8+MC4pXO9YrqCfOvfgq5L25E9R9wZxU2DbLH1CC5KorGC1NnlWQ3mDVvR5JBWa79Yz4ZRqQmG91kWCJJPSVoRJxIeBeSFEJ8rS2aEmkqn7aiBXS7DqpuNpJdQNHrd8SK330kwQojBGSkphnGNMtpCEiFP3l4rcs6bsq+hdUYXphjeeqvM/wg8lMA+/dxYduhviVjTXkYE8l9jGFstNUo2rKhEKcGWpDDL/GXSrJ1Nl+ZnSVFT89T4Z7XBLIiBkWZUYNPLGtw4OOVkohXzU/0zkN57oC5SMBM1MNuEBRUBb8ySzjZ73bTdlgc49bkbHhS8i5cGgpH4e7Zaz8l7dkWE+LZuE2zocX2vgTrj2Cv53B8P12+k1qwHPce3v5DkWB4Ew2e9RUs9EomhEvUvveyHfXarJJ+GjxhUhNcky8ahQ2/oZx4DHEknOgmecAGgXmo5Uk0KwrbqMFe6TFDCiTZjbIeVF8/Vpdg+i9A7tuR7LMwPJYbfDgjS2pSIiSyKhyUObh/derrxScJi0Z6e3ZCFGHT+Z7I32zstVPkSRlgHg1Lwifwt+fKwTRlzw6SC9TK5qKr1SqgHbRCal6g59diUMhJRKiTbSHgBZNCpKQRSzxaVIfV6R/gEX4ogmqvMIPD/aL3x/aoWnIi4dQBjqvcUtGs3CSgVID7kmsQXthjaP6f9sL1qIEXXJ02ePpMc3+s8k9obEGCMAjypSqB3INSvE4H6Z8qv/dVH7PZWhDORk2jZXCoeYZ1/MtSG1G9UhE9RAlYml/isjBEWNHuVAVAOy2kywra1gmk0IemhnL0OKo9g0tIkVmPSedoAWKBHTH9C+qFLyUlHjPGM4Wkx6aSKR1v6V7LGpHBGo+ka6yW+HMZok2rG4aDXnej3KTIgwO6UlDCOf0BjO+3WOJKwpTMv/LQbH1kV8TnQMllHXjbNmNmswcu0EKuO/xYlF3oBfb01thsqPif9Mk1sNp34g02fyLc2Th6MJnyVrcMoxmcICBOJ5kQ34wbj9J1IMufqTESLGzisAj7rlXSbBG0QbOTHny52JoahbJSEGT9yTWdLLiJRI6xKarQw4Cg8aCyEfYll7ch7NIBuuLMR+EzCL6xYCiRcEKv+XWpnb+LWWZt7Y1JLvNUNApya/ZY3hCNIpSv3EuCFoCNEW1RvLc0mRT60JrkuKVyz0nppm/+0ioKG4l4rZVNUeSqjQfGOVk671nk8vrcW7Ka0GhGkUqos25IFl8iGqoaKF9CtYFMyB7GbwSlPO0+PL5QWUoxBs+STEOR1LNghYBQGNf0oAADsPYRD5KbrYmDU5Sx40Gif193KHGZG4314jd3DHTTiIaQ8uM1bWTICi92wAJL2FvAjj5mCtV7KW6KsjFWddXZvQFQ5OQiJZoBFWI/l4mTeLyg08Xpq6l2GB2VvsLc2136lEKxYZGKSKp1TJor3LsQsF5akAq+u/0rHKaIbCCy262V/Ite7kET9yDbh8lSwW2y7ASljRujwN/gH52uQJ1wdENU/w9y6Rl0HuvTUPk+bYxNtmTgmJCZCgerMsGq0dycuL9CxeeH7IYmqz7qYCKmlaj8X7+NilnvoHjF9SEHnG8w07noJucIp8atz5yLIK/2U73sJMI3xJbGbV60Sbwqr7JfQlfhhBf1t3vxIncQZApdHsDDe7VXDsHoY/TCUMperATlpCkDKuBP0nM8BJYAiEolaZOW/eyuVRp70n1spBsyXWSThhV5lSzAYRq+Ae0WnCqNOIoCChZqXuZC6OJ3yZfqWefrlfEYNinPgfdCrnQG/cvnhpJ7D/dnHvSe/M8qT/KISpXpI8P1IDfLIkyiz+nqspkTbSyVV2KfETVKQ4039Nc1rCACKFwMNtMvhKkgOmi619HJTS2otGENPRYp1aCQg1H4tI9eq+idJqvx0FId+Fhv6aOdf577chsDXYS13yLprMKbovuHTzjSXIZxWoypEiPyeJc/SzaQCpNiNTTt8WrkdChYzCzMO0vymdasvej2ht9KkroXh1bZoQ7UEkX15vMHNxJqjWEAMWqdvY4pZsEMiK9Aa62nORo6/hAWrShHarfHWTW33Mp5IKYvD3QH/L6sowGp+lXa3Z/gOe8vh312YYgI00p0nmIrTQ3zJc2MHdUmyn2ZHn2TWwKdruPYIf1DGV4fUnvkSngT+w2DcxOovOVXnFfF9igwi9hTeWzIcf8chNrC7I+kqL5+GMXXFb6+WBiK7Z6sF/eqjkoq6qOdkrlE9vgxGKjaV8Hn4QqkTtVi9w7WQKmMkS36/ydZhRYN6xfebpVB6K2zCRyTvKPR3gN9hU9HiUYuaiHZBCL+phqrtiSCfjhHC+VLqDxauj58ISuB182ZLAo0LzoKxlicPRFDA5Ai6mt1rDQloocxG6d+gajzlWp3YjrWmj2lqilGTll0An/iUEf/mEpDfjYsMq4720q+222iAn39k6ZMRShxA0GIzAg0e3cT6WBt2qYNWRrvhahCxwlscWIlNxnPOq9bK0vZu1IbQIwLsxoNKqdsOppaG0RClWe35YUVj+1Ouyzl73shPs7QzoWT5XuPVihThmLvb6dnoIPH5LNSGHCwEvPGV1aBiGf+J/Zgd3gCBtQzO+Oq+rMFwSvqJ2nx3JUskFkKbbWr5220j/XJHoaUL2WPLWuj55YMHnp9S7bhYnYlGfmKaMZ9aiSpLxd3+e5TbyXvXKEz1xK7iDaYT4Nwcv5YViTlOdu5OkrIUDZ8bdguVYe9fKoxr9WD4JVYPhddipdmELsgcJVsp6AeZ8ag6UjMtZbMipJkF7d768mwmV8UntNAplGdfOek6Xkp5GdIBXQhmhKI1Qk7Zf1CXB+1qIgz6nx7wlwVxf44iKc3sHT9qGlWmB5xTwk6vPe+mplVqm5bCeR2uF0aB/NHOH9S2FaCsScpGPl0dBFEkMsSwnxBkNg3uv3pyBpk7FS7O64SKboj38X4f7Zyu/wVEa/Mfrc8NP15Fubduz1gh1nsY0byJoPWG1lDcCi41xIFrrZyvPqI4MeLFfAuInmx6SeWiID7cO7H9sng2XOsBXraN2p92jDZrmIv/l0/fgKwiL9Q1I/MDrLF4gl6xvmYUfdxfQuhKZoF9VtDPWUJxCA3xSzIdBhye76Mlt7cMYbBbEPRNuTfrZUNsisSaKy5Z/a3Fklw4HiF1m9xSAQHl/xpmRoVQQyPmPt4ucCbWACh5Lc0tlfsRLAAAJUScqfgS8QcX2nTiyH6kmsruAoIv/5PshwKw1Dbuf/kX7DM2v5HDJtQmfIg9WgLvy/U5z+ED0cJVyPcublMrOfIRQ6NieLsMS//aB4lAQugxFY2VzsPAyAc+Z3UeC6RLnNnsIyOs6wSpoJF6y8mNSgLC0zLP24KKeOsbHETdoSmNEPwkaFWMRwlJ48iArQkoXJL3Yths/1mRCa5QrAZHT04S1/BK+X8B4YV/7RInxa9iKyXVzm+J2+xf1CR97GixOnFWrLtGPaiI2vGUKh/WaVgq8V33ELXl6A+92ApAUc/Ymp+viB92w4iRLos1jIHy0kyzY4i6PZ6dzT/BkMJWDYZ1Qs88K8sUc1p2hK6kndGFvHYW6kD2kMDdnigdvKupJo8B3oyDLx/TFaihXR5OSsYdAtjBaJP5U4VAmqqsukBlLWrDtDkX3wUbARwVANPn1IfMneh0ALG3cmg/j8Lg6lflCbqHXBtz3TVo9vm9CJdxYCpMGfJUaJu1Gkt8CvXwjRheLhhzAcsWiChdKNZ/cgk2+XfQxuTApK7GqplEBCfbmj7WXDATHzLY8ETg09IsB00PHqTQAgbSi1gMGPYYIqebVmmeJro8L+s4f1J3h1XX6jM31OHngr/EnrpTsMEVPOdV40+IZ4ScRm4G0yHmtyGyF+4T6qXd1BRXkHZSC7KIugsIgb4TAPF3kBOibNMxRq/KvkCEbDeu90JW2dff306Sc0Sv9VY8ZZCyHjqr4DqwZ8H4Fp+bsB0tNw35QfU3cTfqK2OJ/NkCVn1M6xvDMAyprja3MYQsNDs/PmCsOys7isKbIx2f9TsPlPt1ZatHbj3kpfSAPNyXaEszIpjKLE7jYA7tnLmg9BveZ3kX9SPIvAf0MBzqJZy3B6nrCzw1fzD6twwQKLh7oUSgGbXV5tjXPQ6e0xmWRazbI2SOPjbvkA2jBVyd08h3I/xMiz25nmjzG64A5Z+97vzlle0sikVuvtCVuQiqpLNcSbeYicFEvXOUTa15KFcTJq7l1zDdc/M6qZDI5SmXP9uuOao+9WVBdYx9NwZ0RlFaRPbA/Rx6CJjDQpg4Gbx37dyJClR8QvwWmoojheLLOb/2kpW4RtW7wD6tndEMbN2iu4YqjZInovmb1LwEU1xT/Db/FvcEAm7wrWBFwNGw5R1V8P89rDOUf5NuknVXl+S/Qy+6EoyN1Bo3lFycLcyLIb81mFUKYYLXFHrvE0yAt0GPpGYsEJEwA2e6ob2JYUTMFg2zs69aLpkaobx3/MaTb+QeJFAENgVqok6pW3+lg0UTxghuqIhhtlVkIxk4JVoz9SSxTEdgENQF41Q1BT6R3tfMLW+nMC7amvNPTBwCssdmhRBR3hiUdDn6uBNRshC2hFqhrtWf0CgkHcuiydH/BS2ESsU/JRGvJOg/nMEO8mbvbqLkYiW9Hmsb5khX8xIzVm8IFOvUBk61cQM3UFa09/gJwoQn1chI18eb4tGk1zXZuIN8/3BvZ0x6ksCroEGtsjRgO72aErYVlcHYWDQNIOsDUQGyG/JYccbPyAPcX0EXAZYpMhC2tqMa03wy5kJDCHTG2G9t9YYKJo3Vhs+Nyaux1y/RayoxFf29zvdySptogxjP3/o0EgxShAG7ODlaGzOKG0W+osAq9wokR8Og2GjO1GHwXR0oIZH/F+OO7H3dg6vAXOxBML7RS3I8nnEUvyeLAq8av3+nStXfogOd4abVsE/gZj6Q31tyMtxMKDj0DHSRSVH6+1qL83tFXu7iUuok2T8uIOdEimyo7tOxDrss7GweVVV41nb/ntGIRfOOT+6NghINZqoAABK/SQbC9AwIZ71stRLW8xffxcF09bG3Ns2w5205d/FWdg30rbrUUE9bJgAaihaNeqm6OKXuSVA/0mRCZvKyINqkgARJuDbCnWRCbqFMjBbFEVyJ+KuaBOxfpQ3R2sYvVOKGIUBPTsoj0J3Njr1mBqxZAayN6EZ8WZZiCk4CSSqA6R8fQ0OguFAeRcy9aTEKUyxNXc5SnECiNwMUIZPxHpeiGnhYrO2G4GzfuxymmKTEsgSZtkwh5rlfrEiaeBOgdJwncKHpJUjwDyeMhGyWonhZT+z6A1XRD5JJ0ugDo9hkBgEi/Ckl79ITBBZ4cCjzR7NUcz0lcgvzFECiQx2/Ra7pSDYWbQ2pIabkQ32U7WIPRV25OKkLGW5YfHQv2Mf1ByaZZFhpJATf8BMOLvqzSq6CiZwyPhTgQxx/9uNm3vms59AoRAaCqFPZhgRkC/VFp5L6FmZSwLVyo+TRwis22sDjNljHPJfSKUYIfqUtStGbXm51Djy0mtQGquTMmzEdRnlrlWXIQI0XpaluUw9X3urf6NPXEyUc9ixwID97rF0Y9HzbKtw7QwpbVMp4PPAvBi2iPZzluFCuQBKAwFMhDn9aqJLFC0Tz8uu9ilD/Kh9y6VQ7+whMfPAhZMNMgG6CrYnr1zT0+5BJmE1sBToTZ6CIo1Uy5jqhNFYX3AEzGQdEaJMreKx2tlGdzg+UTxrSqwuQhWWCypsjGYPqDa2qQawBc/d+i+kDV5HQF+/dqYGgTXT5uQDvLohBdcLf6U8gfc29GAFpe2ZO4/IG+iK37llKVxvbcQcniuuV57+EYdDzh2+wFYyacN4KkSxUvmMhFXh2eYSzkzJwfMVj7oURhPaAnmRi3lowunl0O2DRJavdC7u8lMF4q/8+XpcYyyIZkUw8SfjIqcrd1+MDJq8/mI0z7wT5AMhPcPgdQ9+c9Qt4iIolR5DhNq2Nj3JIZZv99hv460qx0ehd2utApVUTaZfH0R+PCFDawfkPXxtUyxdUK0T8DitwGxyXITEfXdgrEYns6Fz+jB9gFRrmVyK2veuZ5gMlwVY8f0g9q9sCU+EoiebeXwKLtbwg5CJ2aeastruK2EzfO8vUOVhR2ikeTytjS6nnhWrrxfGtdzvMsmYtEZsg6mhteYfmgTm1KIhfCjwUf+lUBWrHEu+EjrmnV1lzH9TZSyr7U4Hteok4hBnyDFmgEYl2O66imtc6l8ljqTBjqtnDO8LxRIUR97QdnkahNBkl3wQv9z19wWYLZFHfPJfR0Gf0NUoD6duEK1wNI8womZHpKF1AuEXDj2pExp7gF6XxSxXyKFHQmejfj1Nsadxeb6nLhgmmbaSS38ffsQix76O0y+e/mz6Fv9//82aWNzRIV1Sh/goq6d6MMG0iDaSpIPje0BVCA0dmkoxu8m+kZGFNG7BXS3Os1ANWyxH0wY8DLxEzp5U16UCCQDYNSJtA6RQukDeJeb03FBCBg9oKZNRr9/GgXAW2UPAYfcsMBaVyEJVregxTj7oYU22fEd9OGeuYu+97nwG4z8RMFQ+Mn01E996uZp+d+2oLhc0w4gHa2nMsRxPqA0nqvRg2cymbPfa01AwPdRmXLB8bzwXS/vtHydn2+5m/M4a8EavwQy8UPIAVZEjBnZfy4lhqugzCUw+TWbU9MP0yRRR3UlJAXRNsdIpytOQUWIjRpYgi2JEI8nJWMnxDAoIS2jgM3CF3mCTbErkL0JOeTSuhC5bwI7Ws1ryrG3Kx02HMAGCzq46H5WPD5stYU8dLj7Lf/lfWdD2oolCYakidVziKYAyFVK9qeHRRm5mYVWx7R/CdsphqBEH+xrZdrqZzYaUrMt/CknHFT9qOoPKCkL2vU9dd8zHmE+PpCVDSoNhtQEoIjPKdWua/8/kizxh1SQQy5GbVLasQpWIUmWBqNaziUWMuZqrWlkmN6jUBlWKLD2ZAEwpMRd9oQLeO7GjYwGk0HjohcWDP2jnAN0FrBz5ETW9JPFjvzNnL4f8T7M9UDO7K7UtXAa+DU6Rn8xBzG5pzcE8YVfRuZSERAwRRQtFqGDSliUAC7LVaf6LDYOff2+GURD7T5atqZDYGLHxGTK7AHVxU4yLVEMTtWmzLhpE2eDBkqJL/YxbvuYDg3WPvQfqiZ1PArthCROyqAyBP4azR8InIqjKSEZggg/rh+p8tEYAzly8JCP7Ew56sr1BsYxpqPOb+9tvtz7eE+HlREfpu5h/cvVEevlvReVBKoHN3zM7tGRpFK/qoHc+S4C+bRGsUKuyGcQqv0h5ufCqd7AbN3AyzJWorXpDZZEBLPix42SJsPvtoj+6MO/OfymnEAhtbDaNF6s16c4aM4qT5QUNlKo2Bf5raOYvWo+IdMTTHZxAJ+aNKEArWkOmFAosQ2kfvl5mpaqx+my6rwk81HTPHyXnKn/XIxbKUyTBLEDKQ2nZCPSFhnnNrHiU6KgjxXvprh64g44LoiOwf8s7pKgq6XWNGQW25UqeDtc4hP9GFM/razawbPpTQx2EHpumkVYWjLp/q5Q5xkEw0r8kJBibVHj9nIU19k/oTAkN5kBE7D+KiNd7DeW0GfsHE9vAaLyXSt0rQQpW8brH8HBap6uBJ1D1KSBApshJ3HIpHK852HvK4gmHM18u+w0piOnt37Jlf0gxznzjpEkWic595gh4+BqL+cvIv1l/eYC4TMrZ5r0m2rvhYxadRz5GkpYg1AXhG5JGYQrgb1nVGCrQQnF/VIvAJK8Pa8hoBxhGOHJr6ykEmkbJWpH2nt5pXNI8bxjhoz1rcEJxQxrnDLeuGI4zaYssoAl7ZfRcpIIaLv/EEXHtdXzDWETiYysRNPLGcDHmmKgoUVNUqRQpr+l85PKUbkKqrOwEV4QVR5rZBOVGDeSSytZrj5ojvcKFJLmkTi3oFXS5Lb6aVau3QeGoARfmAKKibPR4PfCWbxX3o7wBhJR4Treof8UAa3aDA5cb2xXrn6SoCc09n44eHM8X0QndYcIhYlF5qbCUyQ2Q7QT4rMuqMAlyK4koWlGTmM4THKbzNhy1oX2ioOxIbzAAes0/mZKHe2lHaKkF9VmY2Y2/jddLB+ljg2kuyWjbGS1sCmWbVYSGgL1foyqH+gaV66THdSbOfIYktqpPHsKtQKJgG4d9+LRvaeU81DV8hlwlRV4W1X1SVpEVed7l/HUnXtTnHu2ZFhQYMMN5Q9hGhpXSE2aymXEknczOmHQDgpjrSfMOaXgXApOHJeI/yb0QgYsiwlg2gztalAhDsCmPmaHJim0gAdIO82fh3PWfNF+obw947AVfkqtvSaBRnNM7MhnIWRVlOlwso+CkIQdNVRC4dj0N8oC4Ck6AxjL2+1XvEj/KRrV7D50xk0yTFFhxNuD6m6IGObhyMmsaxa4bF4Hj+pOqSe9NXtYYFF73k35b1TR2e/wnHjIeFrMYWW3RnpuCkqylEAUP4ac1UEdKz0HSN1XogNkf4kbzQSTWzd/ZU8SbBxxHqXNjk2HUJuu2Mu7usvV+wIf8mz0q6ZxgDmYFz98dtU2lIOq0EmAUvVA1AHjmXpXGbZbIIh3QQFtN5nbgxxXPDglEw7X6vqu90qSkg1+M+47SIgVigzbPSVSuTwIDSvyIo2iHqQ8eA6LsVnFYYrShxHcL6c17ZGm/XKCdU1ki53RN8gZBwayq4tXY1Ms/3czzp1lxOwReKMXx1gU7urVcQrBnH1FLc7WdpBcAIi7t5EOtaMUzXcLo2cKdT+SZfZuyeCJndA9KyfIdiGcFX4mloHAl0UZruUWlwKgAfXQDPHP/1H+BNl/gQXtSQPy9jfhENV/RWLe/t/AJg0YBsiolHOjJlocwwINWrXxRDgQAAABzjg5liQ6bzj73RodG7TDPX9ymoKv0TEpvnUuivkoRGnDFuU5qMpZFYQ7OtOastlhuJGXlw6CZ5ZMfrXUz5pH2ZBf3X71/KgO0211PKzTzFPzI/cddcN9hFAGcKCN0NmuVEqU8ZI2WUpIQsowoxlWsU11/S0xwgUO7ErQby43zW37UC7ueG9oq3/ckfNUJka2muM/5INnLhv73vKGiGnHRoiIyh6eP1Uaq+2QE10XmxBUUYmVvNSGxg1zPiAxHrQ1i083LW9MU2fMmt8N0XypZtEZXO/ElxrQC/tL0UATT9/g7TAY5/s9sEO+YxEQzaFmT6GWDK12pALezdvd34qU9yLYWcIW7EAlJBKDiu1w7F3KHSPwCcpAPO8qy5GgQKsyo611Bn8wWfZNuVJKK6ZSwnPOgGCqXqVdZYSK9925ry0yJV4/tga48gjkoK3fwWEKisIsksOlYSiOEg0hPhB4DNLIpBPiTgv+jvv3dhg10C7+VZlypZZfbGFkaUy2W38zIfxXdfdNYxM0trufV/Kz8ygmtcbFUf4uZgox3J37rZsKL/yQ0jwPuhM5Y4SUh0mqlOwS2Kh60HE866N9uHEtw6V3fEV9QBxM3TxoxztDRuoN3D4o2YwWJFOZuF1Kd4DXkF0UBvQ7XJQvjDaotQ0TJhcKpEQlJHZJFi0aEVI27vA2YjEnPpkEbFEqjF8QebrB4b8LUhxSkESLUNRDHvURB7GS/fTCyoaNIOP/X0aQ8x9YhoSRBLFOZPgcajsJt8i5QuXSuynDk/3XeppvQ+lcB4I5Jrm8C+AhAQll4odSk+4yfS+BxOmj1RFnakiPl2KhSlk5p7St7qyp6QmgFAqEx7WqEwo361au7TBixFR0tw3Txegvxx9Wux7ftL0bx1N6hgwO5r3Mh4z1UTndyrRMRR+Dzc7AovSBBlruQRpdf31pPtm3mcl8tVTxuIgfcLChBMOvmMydOKGUKjaCqwkNQeYhdi99EpdjBmD9EXM0YTcdxvc3Dlc7VFR5KoE1mnbX5dhV/3vsGNCibQJnkmzuVcGLCstUoEXg0IryrWd956q3uqw90vRaSucp3McbQgFhxtjg/6FsEykwPFjzxHqMaK2GT4gKR3nZXc3HntN9TuZaqcIe6bgNrZqDBpwOoDQdnNQHWNrTqpKHCfDdPpcioaA82f2ox9PERthHL0GbjpCpS+nmnte/016nKaiu6qC7oIF1plHMSf3ZyfEHnz1weriFx5S8th8FqVUUPw5coKDusFzeRNqZIgwWf5dax0qoxZAgtRe+AOlCqiiWtM+9nWqC1Bm1HQQd0JnLHCSkF7Cteq2w9L98jCKqan02dEwbKPQDAS9el6JSVsO+FvU7urrzbdjg6V0Lz1KPW732qK6GiVSLKDbAy5XIHkxsNzFhNLYxCIxd/2BMtZ/OXJ8xaHOydB4lbMQpmiZqmbbTZKvPtHNQ15BdFAby7AHeohzwj1ysquqQsJRMpyfd+cP+uSxg74eSnz2y16Ah8BBCtLxAQavkyPxX3Z/fX+b0jVq2gRpWKZXDQxoUdwydTmygVsRu3qLWGHPe++O0BtvvUNbm5wXNJbuscsOTVYtE5fU5ZglnPU7oZySPisy5X8oo6hKfme1Q2ZXmpMxoy4qZaYElbP8kVDlJjghbA+cDlr7TouMULhaw/Z0mo+6DSUyDOsmWdWTmf+Q1nAFp0lG+0g7Tsogea1szsf2w1Q9VGD316ZE5ug7U0n17U+vd8O6UuEax+ePzGn7Oz6a30jeOcrFqY4Z1ec6MgBEI/NAgwRRHvkYSZVWd7VJQ3Jwq4X6HdVC1q+hrpIW+6uOeSSsTWTXBOemQi3SOBX5BqC8J2ASCcZl3OLw74LRC9EUfMEmVRk3LZgsabgAqQGSlL0ujfpRgFa+HwfGMl2m9xRywp0U+gffOrwlhKVVzLhs08bEhD/Bv1+RnVFGz6ZJXDRmYz8tMxr/kgVkfyjsHT63HpnNlCRcGYYhuc6t6I6P/qQfDMjjG5zG4u80VlXWIcELYHzc5yyByb22MtnbC24UD6Iw2RVtYZLQKms4z+8ehWAj7WeaQ4PFGG9EuaWStAS6nfzafZNX0LKhu28lsDMWJlhnPrJlyYAcD5c2puo7cIcCRIf0Ne1yXhAA2jIcM/sgKXe3yMBAW5BcHHSdVG8QZETBE5ug7WVKH1bWz2WsvUTwkJnSjs9ipaoJrF46xUcFr5s/RfXWQ8BqJp8+1yG0OWtsl6n0JpUxYv7eN5DxBoe6xNbc0tovLD6LkobZh6tiiolUFj7nh0Qi7C/y2BvtVHSAIISZk+8tgPKmjDr/JMZAj2lO+K05ukuWYTUMz/bcmcXqD0B954yoxrGu+5bBWu2GJ3/VTBnYmEc3HN8eK0Dkb+PH348iUNTGIbY9Ml7k5VQE5rVUSbYM7EwkM9vCgZa1pSySnn2SlGF6SocLUQ33cNhbp62M6boB72A4RvY/46QxhX0Y/wst1ADG62IE1SZingst4cqEFZysjmuWrhNxds74oLfdMEL4xBijMOkx/+fd8Okgo/sBg30R/kcT1oC/gIfxd2xFipKy9sOPGmqfQN5A2ppT47ficB1cch+bYyh1t0OlXKzc9WXrtMEDbaooFNgRPowhMvOkorFldXGkl+e4qJoFKGL3VGcMi5HkoW8EZLYck11xUkiKhI1A3jwEzh5jaDiIMUGzq9+ilpIEaB/JyEI+oA4IMzWSZM4BDBFDliQQwdKoMCloyHuuBljVuENcg8JvXds4rRxLBnRHddf4EAE3Yx2qPmILVFeE3ysKGMfl15v6o62evO6WP6rpYBC8RRUD+AbOFeXj016w5Vwa/fqblXPS4VHhlP4hC9vQfOf+necGlkB1L2U1gMX/rtqeKUfYxlDN7N9ZHKb9hBOrVjM1Uh7ha5piTR+IxF5F+57BAoYSS3AYRbQ4/BxXDO9ikEh6Dvoei4/4hDFtHlmRrFzJnQw6MKSi30Dkj9i6DJwPhCfCOlClLcoz0HXPp+MRisBh4f17mUOmr0Xuo+P29q8M5C0VEjnoQXIvnSz/0T1Wz2sG6umcU0mwZhqIwdmO8l6DHuhn9yVJO7C3B+6DAqCY6gPFwNrCLL0XiU1kKLYdaTc0IC359Pxpc87aDyn4bNhKBqY9iFGcNcAPmm1QPVhgHhO1Lt+2x5b+NfORtN6RwbW7+68xBktiSIBpq40urxQGo6kEIkrBMv51csoYqKbYH4+7KU7LrphZZsqy8UhB2s5OsPwlinV+oIeEW1JvPsg8wkzLEjxf/n8Cy7g/feggn8D9LRPKyFa3Q+/1q/y7u0hr7WD+VtTZDLEdG4pXXhW3uaHLvzR0ca93/C7AGXgaHOc1oXWM86LdYGHjd1BWEOMNL8Barwo2LcpCKzdAKzAX1uPJVDxz5FfduOxQcYp9gdFd8JPPTIXKWZQv7gdj+q8w7mCQAAHtmr/AaQWZMdoUbCvzDON6cb45lzZ7jt0EKY0SyUo1obOueuLV7ORWstWPiDPdhNlJV8oY//s3zgfqdorfrtb0XT2zg5IuI6JfsVgwoefKuOxvNfVwBAxyEqUHiHQOoJmZw2xNmcWZH2YoiOLk3KAJiTvG3Aa/4b1RcFtztTpAmt1avqJHPQiBNAnV55yriI//fAz6YNU5MGeRyq6SHRweuIoL0R7NqgeReAAjkgHvYyWjhCj+pEQqd6CDeSmJTm/Za2jwRXW0JC0LLy831GbpFsjvThRVqHzPy70GlLkyqUvjrYahZmB/ZF6WsgRXpXoj9/TOuyvSADH2CvlpZ4YWD1hIlFV6IaW7A47o72ovcHICHVUPUv+GvZZsdSL1qJWuLPmuuTOG1/UetrtCVu4DgD/PcnqVg3vY0FpsKW4OMnPMgwejFG0I+II3IEZmCgaF64HEdzVOQrkFCaxkb/mnRf0eeeOKlw3Wh1NaR9U8wa7QaHbV/ibcQghAY974HvbkkZQ/8aX1EgbghUKqR7Jp/zxaxhgcRxqhfju3MtL/rfEiTNXBEBMTi0E8jUY0dj8TTyECFFkXnFLP1B31adk0opSpKe5N5YSVOt19Gfvbbq01+QZGvuhd2gbEsrhmxMF+E6xi+NfgqAsE5dqADCJVs4vT9PvQWW5A+s1I6kdOfT+4XAaIldAYz9tEzIMJu+9IycW+03d+xz3ymDzR7WgYqNhqrn/pOC5iJvZQzbB16YcM+J2EGVrLgBCOKT+m6f6vpAFzDHfUsm8d17a13w+gmid7JVtUExgKy/63eilrKnUVnlzhV5ToG0VzdU/1lV6wiRwxzRDU+ceSXYfRdc1VXjIMzPihG6kYv4OHZPKQJHvYpuO3GUV1i43408CLly/hk3ExwIBVl8FG+OIJT8car2e3WqYcrAdyyuhCBWNvJdYzOT+niG331CR2Y1d39jIGz4ZC+mDlsNmq+uhMpBlGSUtglljgwWT2N3G+tEn7ofdARje1uYC1e9iiIhh1czUlcodHQrvTJXL7MAK/5/6Is2l4mamhD3suB1O47SVuK6FXR8AGDdpIjdTk7R/HbqpJqU8FDvbZg9/kk1trmYSc2fM0lgtmfpLhP+s5fLx1JAcBGxSctmJ3YAu74I3x3Z618qbis/F7pv67nHHcctwisJJBWieqMPmpTeiOzNjUciFhYzjN739Cll/mDwwCXXVDknbQqtq6L4fNrU/1ZkmYpM9cXIHNtatUJZSLQ0AIsYSO+KMx1FfRGXLC4PL9vOVFhZRD2o1AQWcC29bqmu+BbOvrPiNKiautRqF9boDNvZehpw+hQPj2hCmjiWanQnAgOP3pRxtPWIL+1rpwBUXH/Y0Am4AzETwKHxbXhGofjCGjb25yOr3J+QwZZEfCHz2k60XHQ87vxUEn5cDZ3xLjn0gWGbdi5Vso8VEVRGIoadOeypGMte6C7HCPscH36MODZWn5C67duSFwW6l5R10CEG5w+GfNCK0nEaxWW1Ob7dfTCYPV2kWYAa2vrmzA2pQL0Acj5AUoxzJwdjjRGtvAg9u/Vp/8o3W6ODmmCmzIFfZX7YoYEm64Xfe+reiHvHy0C4Td5vQa/km9ykBgJ0flK315krZkmUlfCEmfCDaiisY+KoOhtG6foVnH6r2FK/vkbaWaYal+k9bnyaQj+05vwKemixw3CPOVM0Jhb7aLliP871+yMoccnABeVK6LkKGJ0TFyNDvEip7ae609h8Xhv3are2OZM7qERWRgZZCLPetHk84rZMn83StKYhudfvLsESFH4+ME5j3pUmridadZ/z4ALJQqGS2OMJ+B8aRnMaJWue1z4JfaxibZQKHVZCF02N0JQsvdCzri3f0xgrMgSDtly+xuJSkONZFmR+CsObSrfc3QOujSSRT5gKeVdjSeE7EbYN2PJ2IYIDdGGgaNRdz0S+f+q0CHepNr+taruC9mZ9HJoMUuKl2u3zhoElSIPBkqaWZan4RYL9wAZgQuDl4kuN1X1xMLMVRDSE48KFRC5rlFSY0t4QnI6bk1lE1altI9pzr7SuvwNt6QT8uDweSTicNv3Xayx0O5eQ6Z5DUNkyWrPfkqTbC7ajk1ExT14XiRvHFNrFxIdoXdDx7XD550RdkdjVHEIDloDoygwdEjCg2FJs0eCrGfoiMGe3pz2DNYhhmFd2YYhnBs3SxiqUs6eI4DvwWxwhYan3LV8IU0Vo2bwRs9cVvn6Eczs4AZ0aWyGO7h4aVltB2XDzThqhqEMNMrosxf54H2vkiflR+zjRi6oovAYAg4ZAh1kpxK5akgA4Q+HBSB/g89IllTL7hgYPkWA0HTsvHV0DekuQUfcu/lS+NLT2HzXeQ3Abrpiwg9XBaT1nkc7DZs/YlCxQZ88Y+TtmW7FjXjUBZmS0AXE18K7Siw2yXt0WDTDZBPZUnkyyeEZV/M/o0pXyj2XQXi59W0QwxbBGYbcFnsqAD9IfGDPP5Gsy9GLxg7ZzU3u2NwDKpZ9Jx1fJ6byc5NN1dggUVSzSNuoSzyY0S2RfPbXTkR38SEcH8pFR6Oo3E6CIZmJfRBNIA/MUS777QJsqAQZ44TKeLvYHeaO+d79HG/PeO2/MhkD+WyefsoJXQ4jYUmzRm15eMo1iMqm+zUyw4asS5xha2PKw08REpoqZuQpTklOz+zZhyk3jNDsf3paodbFjS8yPoCQIKzxCgWcsA0fG8D0wW65oUGLn2kF5bZ6KN3HKOhb9F08K8Gz50o05hYVDK/aZdTknPALwGd1HJbpQasrQL7und4IUtqAtzYYnAH4v3KqZobk5ncmvMXdcD9ki+TsArelmsgavW0edwh91j1mL8T/LTf9VrHXc/96IqmfHBt8DDmDTkTghDgFE7lMcT3gDxdrc6z6vRXxxfiA42zqJLezsSEKZ8v+6oJP+mFH40TBHx5xnScSXgbegKDG4uM7MR9al+tAFk1t5aE9UkGyl8Ms44I/KLJSgvIWy/TSyLbYMY9HuKCeJqAnUyFN2irJCyPUllT9Bf3e77pUQmaPxCof/NC99mTuPZxHnYKr42iNHRWqqk2sFT5Eho9H8+8hXf7zi06chNYS/ldfdAqBLEDohg2uaBWhRWXsplKE6O+3qOhAfYIqex+D1cQuqgx+Cv2Sg0WPxThB35ICtKNpNaq2e37LtX6hj4fm5qAW8GlBsmomTV9BAo585DjB2IuX4ZRguOs3M0q8bj+MsmniNeUPfY1zfOyftez7iewz60+681DCtSP+hYIkhLsS8oAjV2kJ3yP0V2gxsAiY8C5zDEglF+LbMSsqsHcg09pz9RfX8Jjhz7OEG45Z/iJTCLDBwC/cuKEamfIKpHydjyHiuvsGVWuxJ9sBVVyYzE43GlLjHZNnY6c6catMdzbukdKXXYWZiZu3W2aZ0DEfxG5bkAu3dzyLtL9o9qBM7BKp+ysC66rLXCHjAO1Ajt1dkpd2AkuX5sxIC8jAwjzzs3RLt4BF5z2mamtlP3w05wVtbfk+Iwu4RuUD1gZDnquBqqXK+qpHTdC0IHVetF1rNNnGYWU+OMqCXXatbWxxpGlcEkRzeWy3tPl6rznJTUGthYk1IlSWF9yq2DiB35afQ7wQRDyn8wYKCPV4cJzmTyAWyBeHUw6gSShQVUdkWljxWdOPBMLd0ExP/kmAIuCbIM/RKmyKjM1xjZ1GuiXxJoY4WgIJEFNz++0fUuHP1fW6588VsRBVQmkofg/VZ5Z652fIF7TnzPDyCgY4Yg88toI5D2sdOcZ9aXhop/8VxhVz0ZbgyTatHLB5UzjQDRbjXlPA2cG6gsi+r7iT3O1FzgwgpmuuUhTIfCSE7NAL9vPahddA2IZbaThBI00QDqrDHpaMVrmHhsZXoViuMxaOkxxpEVNiEXEVY8rzLmjRyFMmBg+wBdLmYd49iFQXQ1I9QZ5IeFTFeRWIsvt8ri1Dmp3mp9QdyT8ovBJdoQECkUy++rTOnb+2n/wW8tNpsZzxVe+oUR92vR39+UPw8aINxt73JmOqbdjKaJ6uRyBdFeR7K3fPqNT0nl7cWx8q+A3fW3UNCbJR29BI2tk2We+A1YD+1mSBg2e4Jr3bWMri43UbVhjr11viPYub3PjfT+GZVmwZRvRXULxICi9Y7BLx12RUMGw3HaSnlQSuRzOBvfUDq1DpSY+dGrNR4q/oNpe2/Tes4/PFC8B8q6xCTIkJaP5WyvFtjwiqz4FvROQX483DsklRMV1gGaBQVnPHMMqqEpfammHsUbxez/XjyIjP06xPxGADbx9reN2/MT+TeJkWH0Y5MK0kF+pP5401EbapnA0Qe0uTMstnkaiGZJB3U0NreMxRCUt8aEUHhKFUI199Gs8Vcdxs+nGwCR5cs2l4+iE1/qrdZHKht9gzQ/qn+zAjY6A9RnAHARJGZHHctMCcBVdh7PXDud+NbAQsWkXk8iISkJWO691j9GZZRkN2CJmd6pK+I4L1nUjPCmlDwMVknpfWw+Fy5lumOStnDSgGkgp7he6J8Q79/7kDQpFF5Gq++Cq2p8NXsiZV6T/tzyuO+un328R6C3YM3dzROScRk+MzygsDZTdRFvCCnoAplxSbdCEHEUAfef8RphkQHhKaIdLCZiFZrQmsfGcDUwhOYNF1AwYOrHVibm6flPxSvPWXeF9PLQnFygMhj2oetE3OTJBaGuLo0ymiN51qdzmn5a1B2We5VHz/vDeq34dlRsFi+AQHhVePPXUYA1X7SWMRBCWfM+wxgbSoTtDjwF3LYq5dbzSGZkb+/OO+OE5S4JDO8qkRzG6NxqDMgB/M7UwBLFdUm7akvONM/CkT/GoUMJctKD3sEKCJ9V00H0M/QUrj3/sL20LF++jPot52t/gdG+CuLN9sPSSC6qd5Fy5j17i+jbxd/WapW83VFcE2XP8ahQPSnZJqI84irw3Kil3ko4P5mxs8uyUERMYoZWakkAEKBlVQavWK+SEnn6e/0injOVjJBIzBH+NzRdBPv42y3WR1dA+isT2JXOED0xHc1i27b5rC7BhvEM0aBbCpc4K7fKgPOQh9G6s/0H0XelS2Lky3wlkIZFMsS3j0ZWs7hNvy/C6KSTFo5N2/mAvFgzgVWkDs0ssb0UCT11Qp/rHMwIZYQ2FHcOUlcb+piULAakGE5B5Sn18SNUtccerkKjNwcBAMD53TP47CG263z3ZTv5ymq6mfNJAPYqd/B/8/tnHms/XGeCU+F5eqpSP3HXfRTFfQbPP53u5oMo2BQZZAgk5g1fiDit1EqnpumBwK0VWvjaCPGFPtnXC7glscROjlHpDJ4AvYh16u0C8ycrg6N1si3QEXkyRUck0gTxlpLleLxklu5jP4Jy3jVZ/Gy5SAsq1jCvT5XmbCc/zFKd8HsBwJ9J0he9qTb0wLJQ8VBR9AnUGR4noagt6JnqVUZwMpNr4s2gKQH07XC0cvJl2FO9C4ULmo6Ei77J7fOuiWkvCBvrwOSKk45+R3X0gQYDlj0iZnOZD8XwPYT48/kd4vLlSQ3HU/CsTGxlnyS/iBTUrX+CAmcM6alQzMNsWsw+3PYwvCEawP3N4YqwMBWHWEJnJQ5jTKQKHtSrj0SQJkBL124ENefA/wqaZz9mzdz+Hu3f0SCMZpxmogPa6MSHOYrcuADMUZCWxHKzJYe76dP/piDIPNC1eFNKzJJMZ22LQUNLVLRuFw7NDTUL7mSe8SJh4qVlqpXHXhHAPEnS28l7FXy1Z98RJS1XMjnSmOGP75VEe7C/4mpuxLccu2OVHKadCkeiGnQsxxyo4my99JweMRLoCAiaDBZbeIo5vxiaSTxTuOD5u/GPqUoStuFZkB6Dp7gitBldpClknLwtVH+jTKn78nsUD7+W+8VkCaS1CWXtxJGWbPOaTmqr3JfCzTLEnUr1UgUh/Lxt7lKlFaI3DZZeWNveObtnv4dl7OJh05treOSWfqax3pZU4Ps2A/2A352KDzH63ZlXJKPgcJXX9qLxxWeiF3A4RGI1cuMhbVqv/TGwuEqY1q+NULdslJJBftNShoP/ojPHeHf0xmGV3wUe0BAY1JQCm4pFVv/gJhrZnF/EsRvRUqv9ClA4nfgUlcY9lTkKDCF9lhZwPluIGsp+W6dC+KzxdlkjXmWnLroQewgdt3K7E4rB74YeLhK/ySHzPRZJYiGR+THM7rB8KXjPSnaGTHlgArtvOHUvr4jo0mI0HtMO3zLzdrB7i3SYMGkKfTeKheYVuntLKe8Wnt16O8nH4AaefIZb67eLFvV6Mq/hfGrM85oIkeWnCBT31LUgZzFkYZ6LHKMXwVNHZUF5HBbkdurYFOKfykfVE6L6WV6gIpEM3ZCy+2DAVg0wFDvBxbYe7SW9H3ExD/Izl2QAaYB0SPWCWc3E3rakB805C0htiYp9B2TkcPRMZLIRN6cOgO2lqZ+RvPCU730ThIjqa8MueFlcjnqHw/Fd/+gYzDIVXh/Fi730W6uPmJ4gPnvJePF0gFR3Hgol5JrHdiDNCaSPTNSolUjBRVSaLn71hp0wRbqBRAgMhYRUYXpmmsGJvxGwtrbs0r6kg5BXZK6XZM7g8+vy5LJjKuQbHViH2Lp24b0EZyoipxc2vRAm5NNufRzj4YBucGjEpQd+YqSo23dmy7cBXb9Nt8QzzM1PawdRUa/NEdptx8R8bpANXlROSejcmUp+gQ0uKaPJD7CamflYdPEsxoyPJ33OfBJhp8WqcszGBckbzsSEUQ8S4dQIrXneYp5tyxuwygwGxlXBGpD5A2oBA3vcdSyfroEFZTXgNg6uFWJsbHYvsaCzAdGhug1PZwG/ReOxzlfOKGarnhUZg0cMbrrcxXtXhV1dVsN1Fr8C2uO9Z1wDR2YbsAE+G+V28HefamxPjzCluGYlb7JvYG/yasxMIcLfYcD056LdX78LrHDd/ROmajlccPhpNkEdhD90eli77t7CQhBgN7UjUu77Dv/wKRc+06phODyyqRyWVIeg7HFphU4XcbRltTS/tyYZ5zsp7v5GlBaHsVIEpnFmHTQOAHXzonxJ36rP3yNUgFFpn1LdFfoDfHzH8SZyRTT7dpkf58kJYhKLHLzgLPk6CHLEwa/H/YW5+M89zkC2M3NzClAHB8A0XK57a4YjlIH7qxL1Z5NIJlVFBa6981ps+Tr/ErPmZlQc3AKpqnEmcgJby8ImVOUF+ayuSKSpRPjfezL0Ei5zIf1yRGaatKHpP2UtPwhhUbgBVIfeg4b+qrliSAtwq/Cy1JLP7hb5i7dve3QoMuOBjCTh9FkA2tZuBVFZ6Ar3CL1e9EsLgTzgVWgFItk4e/XJGo2YmmPgst2PKa+NHGksFE5k2x4Wv4tXu29vuToCp/5c9gIovFndVk3rO21jp5iOTplSOIRQgikMIzTFiflfvvq+1RjwqQuNbihYjXCvyqWI+Z16+9uNc0QRuCjtavbozpXvm8y67gvLT1pk/Dq1XeR13Yd9xoKC4pgWKK6TLqI4zTsVCZeKr8asF3XklsuM0OFzEi719ekEKUNzlIqGFeo4sI1wr8qliPmdevu/b/Sq/CWNJUnPzZYeoW+3CA7pTypnH5glvmkqs/rHpzHBCHK0b4QKdhEXABbxPic8MTpaWTW6Bg7c/hXd6vVtGzU/AqSODnsAAALLHaf7Nbzld8wsY09C135ptbXGXtXCGzjuT9nJg6WqaXDDaZdkOKr6/DVN8/2HrdTDxUip4KigORhgzwK97/a50o1P8D3iGLr0orbMKVVV2BwLMF2+F+N25px94+vR+gAeNZgBFKSmmTWoKLFZlrkqBfyYdF+xLQ/VxzWaKN20N+AuYXy/2JVRz2OjBAx2GyOH8VhFAzGe6vkfugTXo6Q+7bmurytWnQScdKRhUeyW9tf2+LGUeHPZEzDzUv1yrErbc2PBPcDutml4h0TSIwni8dydGDKPtD56C2yEKzI0P6ozVVMORZ887oII3uvYcleyzFFRCW5t8x9XSDX6BPWbpcis5azZG3AcNzlzI0a1qegVTEzmeme8EdAcXxCuY9t8UzBAXEJ85da+/IxtEDpJDY8wiGkpxf08Umu7R3snmKNq0yGOKKRG5vFXpUe+O4KZZB18WvjZMSHTD58S9DvU7uJwib0X404s80soZdLLZMfZx9tUJqL819TXWo5w2StY5hHg0uUmfobSoIEShSFBZoi/xUtPz6HauEFj8sJJMcOs5nixTzeVe2rFlpcII7dIRM3zRFWHNYWvPSZbolaiUIweVEkN53pb46BY6fCCUCjJ1S8DKaBDHqiRpQogZJKygq6b8XbvcRVimeWYvg+4EtXT+/4gO17y07bXFPCdg76unoyrDMKzMfSFCWZjzAPHGRzOHOnPZFJyToi/PNuyoAxKqp06xNI+TMp39OJy96V+CWMEZOzVcq0wz4cJR12Z4BnXYkc6rLKZUlFdQlrSQvfFr9sTDima7Tx7mdrqB7QjWEpTF6Onxng8ZDMbsloNMeCvqL3uVvIr6MEE45FwN8ksWuPbLNwBhPxKLZ44cN7ePwynsK98gRXscDdp62umuKcjcbmPdgZLUbiaWP7Qv/Jytbepr0DI8EsGZSoKtM+aQ3xGVF3OCdMafEfcQOLCtZFUo6+/erRZoAV8Jj6WPe6L9vtZCffPooEMUcc+uMBW4OLzw1ySJUKpPZA8jNf1E2TiA+782WeV/rKK+79NRAL8Y6VJeoXovrbCvDp+JaebML2I1X+jhdszEUbdGHo85dYLxAdr4Jt8vzAhltz5zMHs6WIko4v+fMZRdi03OKKkL4DjhTlFRxdWtJ3oCLbQ6oHFrZdSMACDP7shCsx09YJqZ29UnqTr7Eq+m6aKcNPvTIS2zvaihzp5nRlVaHrpi6Spp1Ro8+azPjpyhxa66yk8UN1nLIXgkBd2fZiEbKCJFmzndEHwjKHDbsCOC91oAPazZ3QtvagQhP/cdN2DVzLh8vZcCobkZ/9F+PNeK/xksuasW90ubBWdvv1Wdl+K95aHM1ReE55hXDyP7EfYolSj4rWSvu1aZEZK80AF125qxJIuaJGvqEXeYT7PaKJoVxmTezz1/1qXM8YjVUcJSFh0KNGZD8EcD7nmcI8aB5Ni0aFoEe16JeOZmICmShuZ7dg38I1NNlgZQ+Km7YY8EwtvxZaJzkrtNcZ7Q6k00NS8NH8UPehPoGBb11oLki5FHysCBs371fGYFFvF/Kjv0tHbZbPxQsUnxJ0tce2WaFeEFnD2SfqWRDizRfsbsZFPL/5qC/tZlQnznAZtXqkV/9S+3mJ/IsLFCReVvi0mGdWK1v7P5RorKUxwB27m4g6aF3K4qFObT1WljyPtrH8ilhHTmDqI8KJkTOddYcLp15rT5mFzN//yoiVQKNvFsTuPE8ix7E/IQYWoHbZxV2jgMylWQw3sXGZ5yJlU4g+cHAvXpGLmUmeXS17DxU7K1OosYQFp6diOpsiVViwVjqBVfT2fWu5jTSDmz93BL14wBE/QsNRJYGqDOMkHQBF2JrKGNgrjY+Ak5AYW2aWbPxJ/4BuyYsU5LDu0fnetujkh6FqsuU/tZd3f7wB2DHa6daEKuA0U7UHS840nUR015K6xozpHbUFlocVLPJOcBbta1Gs6ikQNtG06oZa8PSeFGatLA+16uwX5JTg4/U6C0JwnBKh6BnFyHstxmNsol5roM+Dmo43wLDC+ccwg7ZtxzfrO2Of60tb70kMErmgRPmboXeNYSWEF5g4mA7Uo6RelR5dF/4DT7+5GYWfjr1Xjdmnl7+vaG99sBRov8mvaiyJfBToJmgxzNuxN9Z0mWEkAnlM5QCFVunLau3ayLjcnZb57Xs+5PkrvOtof5rNkClaqtN6P8jODIhU47glsqOPnNUET1G4zj/f3aP//Z99sB6RAg2+jMXCSV6hTzUQqGFugcjiH+AvZk1t6jMBxU7a662xc0WCwjU4ymYIy/pw4qa9u9R+FO9iYNcYyciCypyBd3J02gZtmcwTzQHJxmVVlpg0lMaVP2cbGYTNrj8WlcW/t5117IlyVlZO5tM0OpTNBo52p0LB6zkTUJJn1TPCb7AiUZRn5fHkjr0tqIdGSWe5bEFmSgpTSrHSCS11K5aryFIjCNbxMrvjuvxf4ZYZVsiAzKpb1NNZu6gHoQI4w20/H2bn4g0tywu94P9PsuUd4g8mpye3Ist5o5ZgcXWwI0C5uQZqj+yp5z5DQVZKw2ePfQxdiohn2OvjUFpRXXCKcQrDycaIt/ToVofrak1RsdpTqdXy0ud40uPpG1MiUwkpP2H6GgXjDIzJk9Ojh1zACvwdfdS9wcK4PC3Hoq1H0TvWCeo3loum2vZxjd1SnpzAS5uuvGFOM+lLmj4xAvS9JZc1Bw89CcBb9AU0qXvNs2zE3q/XU++vBAn9nkIhjTnbM5HCZsJAVbMJC1ZwHW1X27isfVMSXEp2dVKL4tDDfzifvTo8nJMBxf71QUEAHIBlrjcMZw7kUm0kD4gZLRKlBSX3z/7ZRsjQdLlKzY5tWR3wmQu+ugcWiCAdd/By9m8HtxZM6VaTXXEk3R9MSAm3T2CqT+e4J8KbQfY9cN0G+pmEu/ieRbcuAvueDx8u7G2VyUTqr3bLkyEWA/ZLNMZpF4tEDdi2LhGD2zYYVxROYZeFgUzQv97rf6yQblgFIhWbXveOEdrSjOH7L9r+YE8M4/LsdFWXPkzMbX+CTfeo+2hvzPazsDdg2gbV4B0YSjM/u0YCzti9W0H/QNob2EA8jovw3Jr8gyrkLdIu3+ZBZiH7R5DiLzfUpzBJdZpd+IRpFL3Mx+EC6ntdZaZDZ4Uw8JZJ9ag1mImu5xPLDHXrNy8vurpE28IvKtjdNH6kyDAep+PzfMO9lbTfrcVe27TCi0L0mJGl+ze3ws0wBOCqvVbrepkTvj7DHjHVWpd+7aVxfRc0vZerfL/dqsvhNfs8OL4VIm0yBKJeHjIeIq1ZyMwTGRl0QMDYhpXywvJd9pRe59D70/E7+Ca9/SREdPnqqT7SoVlu1JJoCr5d6JL1Ll1OAeB8zAqw2GaqZdct0fbN7tnsEJ4ZU1mkgPMohNAtEcO0tsrnfeCDGyypYWnTFZkj2cob+5AH2qTWQ4jwA0l8+3rxfOSr5wxp0FXAvnHWgcnFm0+ozgHQVDE2Fhegtx5n3H90QarEytRbt5rRXwe9V/Tv6KaQLxjeyb+dKjfUsRNcdBjT71qGkQQDhSF1pRaNfqbJAkVN1wAK4+H5gaY1i7PmZupSOACa8BKCbFh8q3owQ+uQ0oqUxopgcBKSCX2Z1ukYZ4r5T5g69fhW+O46qRmxMbr8oEQGY5teWRvW8WjLbJYldreG5Blw0WVXvECPN6ugh4Dfd+Ke/Mj0VmCKBBCXT267kKEdVHe0CfJkUDRwqdvNpcNHaGLfHVlHxQwhxBR63VnLujK2/BhN9ispY5H2JFsIB3iilxEWPf5k1MJ8Hy+grg7aCgZAkWXDi+w1nwBD4meknRcHV45HzOSQ1ktpExIfeO3QA6p9yWNoarmoiEhU85T/NrU92m4L3VtVCUU2fo+K81K0f25z+bmxPFyAUu+cknPVlzP1bqSha/30NrjszRpGxzAIWVlpUtTn1ZdX/NuhoQFNawwTj0Hukt1g7pKdXmCVQBSRoIRgLEF9DywLYt/9tpYJ6SxwYXZz2XLq8K4P3lQdpr1zprtVtxUJuGIWwMTpIY52kG810W8WPLxjeyf3KH7Gz6rIbWvqcE/N9Ai882s3EsxEc8wOJKqlPUuOYVhDKbNAuj4bLvks02LDUIOrfbfFIv8djH7Yp55DzQ+hIlp01j+xMjF180S/GslDozdD41iqU/LKUz3OFsLf9umRJsMhoOmoYfbB1xhfytJJ0q7mjN7ZzT207r6I7cllOL9AappRNshf7TOJv7cwANM9p1+Bej+xfBvtOXymuA/8L5h8UjsESfbV650CweY7Dhs/k18MwDodjHsUW+hZPGjZxkIIl8P6+/nqrQxu6b3u5TUZc3cDRB5g/xi3qMsYAO7Fr7yLzxPeG0Ei1s8bUUVUvKj3ok5SzrTGTA1Lxyr+LdLRtLcQshJ7IYfgDqC6IwHBffFCXOQF0cWc5uyQAZIsCwk+Nes6r2TXFPmfyUmE1TLjLnINH+2LRQCfsC/6kU76q7CPlnXRaoHjNPSgzAhQ3XMmbJh42YI1qQ7ahSAvQI3Gsj+wxMUEcVhmUDInPgJ9UCyq3TVhUGJ71+ygWsB6Z1qc2627jF0cWYTU4JEK7v6nUUnSHKR5b4IzYb3JbTsmQLgA/5cPIQBdPC1rLN5rAQ8JuOignMm4yyB65naBO04jMHxdamzpXhPEeLPsrNxSKOxd58FYosaZM4hqLrGbAhXzlTTaM0Xly/KgWS3vueBq3zIyGg/n4oPvPJIyVStkMEyanIOQbR5kA0zJoZZGMjiIFXV1XSnwKGJXb/ggvILMz+Co+ZiSRShSH6IdtBJpqMgpbVkAsVuyQAZIrQ/YgkmeYmb8wyZFajo1fmXAgJ7FXEYp1gdonmq8t2HQFIjKyST0BYhjPyfWw7LNZdpll/0t+slRFZv4Yvig3p8tdSNVKzx0F9WYKVZBjDkxBEe8Vd1Ee0f4ZSSXy4v3oTUxn+SIN0nenC7YaB+g1ulDUIz6Nq49MRL3RNxCA5hGDehDwLlCArv233aOeiCY+1wPsj4j/m1n3qap/JeVDINSQAPqLieYscoTQfg2IjpqTYHyVHufNLQQKMJGUpj4eFW6149pzqRVyv3Zcv6Tbw6btO5Ef/cYqemYFS2jyHTmkvxB4UqP2GO9xteSCXp6BHFP+QrnEdcevLgj+u88V4oy4tAsMPwRoamvnX3qBNUPzWugRxTTyB1GiUoOpikys2Zgn3l7gYkOeaABu2OgzZu1H/yIczMeAvvyo3MbhtaQV8wNcOusekncraAuTySetxwHzfjfW+LOJR1qjy+Sw+gWIvF+ktZvxoO44NdwyDPa7gEQh3FWaXbgvWeufPzG5I/JTIntwu7P6BL5YTW35OeVVN/dfyRfAt7pQECGhisSbLZumB0qmr9vZyiUWhFJor3Uu2ERRuRIJ75TNENO59mjsZxz4qtShwdmuAEJKNB/6bbSGms4gQo8mu7iwg/D2cqro3NrJQyla9gxEEQkeMoYBKjicQjSvMJDFaxuWTC2uDeoQcN1FiRZdYzcIuWnEPU4T+kmNq2lOSWpuoqCdPKeCeYPeQaQWU4okwOf8z2P7K7H15zzQwQlz/DZ1JkgycVnHZyRk2uTBdiolEE9N6GBQgNkoKp0c30KXhpQC8AvhB5gBNFHPmfpv5UhjfaK5i7vR4duEo7MElof5MYWHHMWXrxDeSCIe/YGHDgLcKVT4YTYo8EC+D0ryziU3fuRrSQtOsrKX7mVHJeVKVzxF7MwA+yFyfaXfMuqw2C35wTDJRa4cLYTLmV/YDUETQeiyLiXhn+e4MFa6kZUT0fFQ9JE2cPcMRHG9FevDMR0mJvJragsGV0YoKRQ7jTBrn5jcYR6P1iT94AMUOFLBhoRHizOH83yyQ7s6XQzbbU80LwPCmTGXGhO9sFP4pKwBLHCNstXlsBER4Y3oqPwuyJKXnWuQ+ovJhOAYw9y4AoHde08JfimCtaXP4BAehyM0CtrqzusQZxeEAuCVI6OW0j3Iz9ThHRCecz1xd2glUz2hAIEqo7dxeoc6hf3iuszPOsnGWLgLYybBOmt/UvUjOKqrpYNcWHLFGj24g7R3Tc2oGxZr/STl+w9mXjFXjwLLaaRmHwLF+158c6xzhjSpF/1/0c+BEJXXzKR6A1UDbVLD/Js88Kvv9/mai7RL8s50wik8BdsqmxqUH0rKEnW2eL/n6Jf1O8GE2DE4bpccP1JdwCvfyaYCpfRFpkivsjP2RDcbD0xikmjuyF0Yi8YjHgQBMV0kpxRJgc/5nsf2Xi5GJXt6IBihDEWN+NVyoadKzKjDvPj1IF7iNBOLXP5uLkEF57uDXIhkwczv2Exw5OY0hKBrR5/Ad2JUSM3OwWbhiQ9qyULzWS2mFjyoPM/3jZgqcdib7rZd0D2PAuUxYr3G8N2yj7FKUaeiDQ8JAqj1iAwicERe4jH9t9y+xnjNOmRes9NSJfH9xMRJZhFpbTl4hG9sR9LzSCAEr7WluSIpUhYJC21huWsKp3XcEp3/X5XE3ZImF8yYX4d+g4u9PDEZSkbddENk+PB5d9LzPXBWjHQS2zf57Tv8JEN8bM394PmnErCi65nre6oXOPaQnFcSCW7e8xRgQJG+RGUEJXXHsyBU5jnjzmyPOW349QkW7pD/P/xQo4/PeMXm1JaXpHJFO53yigAqg5CNrUpC7aY6IHxaDU3xX9t/YaaNpT4K4C1qJOkghCrsgDrUazC52zIhJJQw4yTAbyygRC7L1aRZIgFhs4Zyork9qUODrw4RmlZelXcJ+PqHHIq3cHChUPqDjdnMitN36a7zw5vKhI8AVwxBYvJ3+d8bstbHT1P4QATcId0DQAn0OsFBCVd4hSsk5hV9U36Cads8MpcPun5E4+1LOOMUKD59K8deUZoxT7ib95ou43EbVCi7Gphab50x7byDsUnGYncVll6Gq5/tpcri8gUk58KSrMIfbmdWEEimWRzS+/8Y62S7SMConY4iLgaEKHUORNCATTxVgX/1rxhZQb8zSxLVrvx4yB0pzUto8SopNMcRsnNhzBIqNpxrUwBEKawTEzv0um7RQzZr2Iwy1WTaE1pb3RFALw0KFrAhvZIkmEXMNoQHM12a36b5eciuOzKdsbdP/2BNpvWv6lqbk+FvjtoIkvE0e1QTVVAzI+LmjPeDNmjEmeKsVsEq4ZDmX8E6XeQvWX1kf3M7T6BBTx8iZCVV+Y2+1z5mDjCMHXO1UkXcveL1OGriSxsToCo9GQdqSZcecnJQO/DOK/az8yUDpZEJWeUxL/uTQv3sUnWqsj0dDkEmF+Kd/aMMTEmp/6uzglQV3p2bN5UacF6gUOtAjljJBkxAwVl72a3AHj9vdbEx7ALdGdDVS8hIlnbFvrQDX3VPr1rI7uxGG2RNg/BbuWdtK2rMnKWA8Z3RjiWhoT0CK/0DD2aEu3syFORG88hb8QmCdzftNL449Egf4oHeSlHI6dwvgOOgVO1JQKAbDy6SGYfZ2A4WSGeXI+GznwYlsxjFyWAwxdBqbmU0kwMo9P4ytBKNmRtz68wu1m4Rb4FZt/d3dpCPv2BkSgURk2RIy75bUIFMM9sTUcINdTUceQV9En5evbdALsm2Y8CahsTysMDoJ07aaa426cL6puuciD+850MrnSwDRIxd+vLELa3lx+58U5XwUMmCqX43RuB7zmO2+wDfpemuXZV9HMuvsyYWDFfKX2KScwmpvdrfFhru4K3d17vr8RSlS1Qt+8eC9L2ufEV/BIdMBSvxTK6QFk+JNd/cSAAPZIaK7+U0AzSFW6mZoa0I0gAIuZa+D/oMkabda6OqTT2c4iV/+CsGOuDAy6+TePa1v+ShVkGi4uUmNbeyen/I5rmGosoRemtUh6odfgNtqqK3ODecsYSUZNaF4kKwtnk0eWYn11yGgH7wVINV6pOf9Fi467zHZ88A8AIbkjcVMuBhbifnudVtNai4gc/QRyUauNr60qpq5e20K+2PkhDfFMZIlogxs+NvIQedxheIMq4S42YyLfm2J/uZ2JQT0MCzGMd3dgy55cRuGkhFCJHbckpy1OduuQWfU2JAoAhfUB+f6WwyC/xn9Du6fGokSOMkHRbfLK+ebIAk4QfAcd6f2YQCjMSV6zvPN2YXXUcockXPwxHUcgBrNSUytlknVpDxQby4X4ygm6nQWjJKq90BWn/p6MkcynmfbVDoYcHjNvwXLbYs5/M49fwyRxS/ouxTvGlhvxuRWPVlnbF1Z+JcOB374pYy2zkQrpyjKapChT4cKE9XrGxXY/edChVoIsaRXjAfbycQDlCN0ZeIMxKeSmuJQM4fxyKoSwP96K6GmihUKOOUlkmwPAy5guDtsYnpc6Bcxvno/YLWJUz9VF7oN+CZwhRjrRNCOcm5FOIS5HU9XGKalkZomc2c5Y2T5DADfsBNu8YCjvQaSvecB2JR7hfiQI33Ohya04MHXUva2k0A0Jeoyg4wU19tRoFJRbG3OGuubzdjOASbSuVYEzsguY6hHOP2D7tmDbaZhR+voZdm9RH6unNJxW59RM14H54FNRcPQFAr5gPA/P4hwEeCrP+UT/hYBLAs0BMfYQ623GxKUVxCdb3i3YoZC1qp9sjIWh9kDdVa6NktwLBVYYXgwGYtaj6KiyeiRnDrsPZgBuhoHaKjCf26P3Cbav4otl0DD2GM5U0exC9/KTq0+guYIlSTiKdnH4S3UdJinTRTM8uVYoywRtlpg73AbqT8udqhXqNfKFXrsvOa5dW5hc67LmENaFPNHwHQgO+S+zZdgqNxKoAoT1TsHl6ddKDNpr32hzIfbcc4yhnTo3Jhl76+QaNGGL+Ysj1XUBIvEm+XpPaH1izvG0dXIlEAzF3NwY+Iyiibn+2516DMr965etdtj7vGSaiSxGGXI2s0PT2b2D3Si8gSI21gsMkA4+ZeC7T5d7ZI9HLgFlmPECGQ+RWZWNqJvZFnSSB4mpOKbEsTG7vERJPClmQ4H+zhnhTd+RVFk+qpwCxS55Oqi+3NEaUc6kwd9KXRvflaN8iqc0w+PPfEnOY+yvkABfutwEbFJ9GFc/XSIYOw8/zmhuKBzL1EKdOlFEuDQI1CFrhMb5l1uKg2xEv0K+eveirLMOGcFvu1kq0MN47/LxehOHoI92nkQFSHBWFUAtrhAsms5lqr/Nb67QjHimGw10oqpYUPFWgjZgZOygkcHL5ssOjxczVilosCKLQ8iAaWU/fu59ScVyiowRWAIbUxMLTsuoJAQCzQFlo3xNRrJ1WdK+W4CCT1wWN981FMEQY3XtbjLlkjMly6pGtTEG6519pdobDsak6X1/F5TCgeXea3eVTXSrJWbecrERz7+YDyyeftMMfVY8yVIqcX5GPWoybZJBPA0E4V4xrptM9fPrrcispSJGmzdr+hL/JLe5++XluVqZEJBDQ3kbe3L2lCOBL0NHVLbIPBvX7Ceer6T2h4/v7ia7w7Dx0BpIswnEB1sEtKwGqyykXNeXOnL8wnP0c771oKg2PY5ToOryKxB/mte8NH2394eOt9Wh9RR8p1OUCyCAPM6EFdtTETD9LwetIMnZ1pzk5nwBysh5vuSkh/bwbWukl5ws1qedKegeXZWGMajTjBBDpV6nten6MvXgHk6WWbDa6VKlcoKb9YRxQFqD0Ix1azxh2+PpqNtZZzRxCBBuMeRuR3BkxC6SkV/njQ/76zucn8DafXCyWcibp9itgn+TPbqaPsdL35FElnv1WBBXMuVHtTC5Qwg963gvP5A0zyEe0tdsdUjUnONbe27Hb1B12lN+8XooXmiGP9dkXyklUHdcFK3xrHOVDwzZcnAOtCrkHbkfssvN6thtzVRTKv3w73CMv8wM+bV/eSkzsJgtk280LeDCAfHCeZ10dBFKKUPAft0Q5ou4KDhl120KiqdPv0ovd3tpU4sQccPFAYunF3bphCfV/TBakRWxLrUHunkwpRwsH+beCVkrMN7KZsZZaqN1DxRyfdTdWR0O6LvqBIEwmsBFHmyyMAqF26Qjbk0WK6enEthY1ys+9X0JVjFDi/WfIAk83kzAkVmwmpcLT/yPNrTkZ/8hYOkg3xpe/zYP/7Px8NbOBKuJm6VbhKGCa8QACRI9AjblA9JMdVkFxWkgTto8JFruQqoTmtEx9SblXsACyjXOCu9T/0LCkCp6sJ57zlE3a0mKPu08B2iOMxm/4E94QBll4vgA7cYvkHBk+m+gQrP7b4vAygr7dMCCVKNDyEI1IIxSb76GkVMhEh+IsYvvYUeCCNmBk7KCRxBz3l+1yMAKRJTPlryiUc3UaUBrduiFjDuyLRAq49TXoYYMYmLJ2JsLotmoyT0Obft9aMie89qDVdqucF3adc7cMsvo2C2dS6PU/MjZOIA3l1q4BJPRh3Ez30Qdpwp+r5qSqh+QYRonZ2mqjKR8u8kl4T1iv1Cbv3VE202mbvSSqx5kqRU4vyMetaI4eY7ZSkKDbHXaYnooyH/KWfTh9pYWYQNZEd6/bw3JlVVDerOkpQt9HCSBPy02EaaCVxuPBEfr7mvcpZdrSvj8HfL3cO3CJYt6Bov+zXPceyKGbwprla+MnIziliuW9zEWfIYALcXw22otleqrD/zrzDMXsZfsos9rxZ2bsbX3zytccwP+5YEkJw+5Gg0HHIM+x06HNe/z1TzaNqwwL5wolsCmHp70GPCq1zJX1XPnweMJjwI13QJ0v1QsT+r7kZnEOpPS1r3Isil+ifdAEcZcLqI7/05YgPluKFKYwq2jkfOgsyvVytMGaP/warb6BUidtce45YnuLUjreZWccoq+4pt8O94zIu3Gkg9yUO/VHo+xgt/Sj0W3VxhcX0UDfZ4nFYIJlZMo12yDlwPiBzSCKkL/Sg5zX+efxvSUhg9d+jA9R6BTqDAjSdrzrX+y+kzXdHu+DjW/sI8Z7VQMBoO099WMtnl04svvXuFv/GVUTeDwZ1JefqsE3Y4GJsQ004Kcz2ctblgL0zWhWHzViLbHHAjhAQVSW5hYHi+0JxoEzT37a8H0dg3RHbVlFmJZqmOeVOvSIb+JqlnubXPlX5ATlLf7YgG2e+Eg+hSMWjPb6ks/Zp5l4CD4EVkkUwa+DI+fLRz050FyNd6eYpAQqn2GiHGf07tNn0zT45NNwf9AF4pA7SffSEQ62zWiNWEaphKpg8e3VgXofaUkFaIkzoGzbD9Ff0z1eQiEuRN2//oTHCZlv3b3vFZ30g7EW/9LwsTQiMgG1mtt5B4cdbKF0pRpTK5srOVlWO47qevZh+/KpaNtjpXLB2ycU74V1CosVO3gK2RpCLPvlcRASkWIf7s7VyKym1y54MQl3aHRb7ESYTBb9e3nCxsnmO4yBS5ej+q1pjhkpXT70xwxT67ivVISNf++9tQYgruuAVKuZi8JM+eBUwY+7QZjJbJTU04upEdalUJM64n6tfCPr5DGWfg5Qpmgx873WEhzqjqDS2IwslOStAtTlejyHF2i49ooi3des3X79Guf9OcS+id7cuTK96pQLMcqyZMoVXKwuj5FZhWoZwCua4pmM0hSsD/ey40vK1c8ZLA8j5c+7DPROkVArYzKpXPu5vOHvaQ8ri2Ur4aS14z/9yhZpmHiiGLz4kvm2CFD4e+EyztwFnswtF9lMpcoWm28b1Oc4oBhqeSMPelfMqXD68b6yySiIbjsr0VNIFS/+MCTSNzocMyoNe/XF4RHrSsJvV9g3B+9l/Hd6TpuNh6bgwxF4WqK62g5Q3V10WHsuLwiHkCMn/pm4zO50zw86fzWLz16Xav9AK4YLwAT/fpyAhRAlDimYfM2R3vmY368sYMLq9BFEOrzmWczL/v9qQ4OMTdNaRmnyrG1fx8xuqA9tRPRX3A6+/MkYN8Tfy9WibKrgQ7De74Bjl3wb/mmzHn+z4QqpVxhV0re69yBNgXKjhWOA2bbTlnsFLWJHJKdjG1rRu4zWgo3B7Ucy14NuVcA5ovP+7bu5kLklSSrmxNLiyS1vAnXVhY6EmwzAL228jQiepeiWyf0Ks5Acu6IzEZaR2HdxYGssQrRw1kad6TKVUUoDVBlxGeFZozqqKS5zTEe0L+X2pHrhaD4nQjurC0QiR4ULmdauLUsV5tpDosEreMSyNGKUpkTZs2kRlwr94uQahQ6J8i83qLYaBgCwatRgzcpdx8xRd+Aj5qUqDB1WUu/95olKoz0A3rebMS0iXAuihaY8X/XdS5lr2HAT1vd7vJ+BO4sxLJO+3jcRETf08VvAd8vtsSQX16OtPkslVQ+eh5DQhpPP5zyqKGztz9vVhVNXml2qVNf3AnbrJlNn8KorSH1sjLlx76f5Ct+yixUWx0Ni++IRE5ajU+xTAlhBr+HNs4NyMrEQ9yxbTsBLdYR8IZUr0muoDEfZBjRbZJdqO1jqF95mRL8lmk0aQmMs0m9Es/kHtq3zrHdN2Wy+nCeGk16VsqaSgb+ib/ojWQSr6jU+9t3DQrKDd3DZffmsdq1839GT1RU0rMhzS0CUhoa5m0gRKFB4XBx5vveynrjv76VT7O0rru6loMyPQrIsoRy716EaSxbx9Lj6phr7GMR/2yiVTV1ipdj3Kz6ohw8EqRZHw3jPFPms1pi1wrNEeTWcqpWe9RME5MoyqDfVEXWVlm99+5wbHsCEKjGJUmWNFV3SAuywyUsmopRIMlrTM3HkqaAwiA4xVXAZkxcpQqDya62hgByNrunnFwtGG70XfA2FH7JfXtXvkP2GPkRWHaYHRrYPpvjII8IkTaYnItIOfi5wdJwOhTInVGGh+QZVTR/JwqvqRo/2BLRYpIRaYkLqd/6VDBj9c7cwzu890VSyDcACS/GFWPnZQkyiwJvyoaQvxtnVHHlhh4r2tiTepkhKdxZAOV7myWby+f1zZ8qmRbKlZKOLUuP5UXX7UOunGvH5B3W66QTHJTVUDTwzLhCHRNBELnXaktJjhv6/Uv6qCGGNmlbtwF42uUVhK2nfzYqaFSRBeNOCnM9nLWzXfD7HQyfwJM4DMmPyczAegaJfd9R5rY6dT26Vk0AQ+zBhmR69ddVNkG9VX1SXiX9432l6KTu7BNVouwcxlPYN7AncAJHRfFEEGfs9Vgn1c7IM+wXUmme7qavL+lUKFMKVkL3ierYToceLSqyB9gY32+aGHcolb0XuOhp8GRJrT+D3xpEE/h+9MJzWOyOaLcu+bHW+UIBv01SHkUHr+MDjSZ0TqMR6pSg/cxRDTcdmeSvaRyM2nqIGjiISyqabg8dIKz9EWdeTSLXrLDIkfFfeT5krtHfMWa45BQ9tEtp84D4JoIhc67zbqa2Xrcam0sPVfQdaHJbwkZBDM9YUEGSf1xRmnV8qZfPOCeWjPJqEkLw1F/qEbhzTaiLEanq3agg3vIlT2B/Ieb6iEzoHPlQDw+I1T1gcFQq4trex3/hFJAczV3Edj+TYqTSuE7JdFT/zmRYHbDf/l/DrqKkFYtJmuG14OygAIUqdmNLicjOgKJ39zEYCqFmc/04iy2WFTFrOyUEWBFozXDFZrU7pyRKvIGaR9szXSko3AJ0t2bOAucJyaAb5CcvJiM1gIa0L7A2eRLn6Q1b88APYkyJlovNmb2ChXPY3c31kQgPTj5gCu14EQ44WUF2YydvNuFenz1VT4nxsx2nwLWIHxXnuCAQ2EJEjxIiD8vgP78AziaRNU413AwlMqxikUo+k94dXrb7vM7HYEdmADNXW7sWBj2PP7HC7OPaB3IvUeQb23OzIrt2bDYc0Yn72M8NyW3D8XMHVJGSGL9/aXlebI281TgFoeWaIsAXvOoxTWxk0PltCfihrcnoNw9qNvtmLT/NGR1urS7NRjx+anh8ZcQ1nvNTs8esWdKO7i9mrjXT+Wm6+3zBtyjeu7EZC4OHPq6sjSi1jCygmJxylTk65P3nuhlbvujP1Z8YQ+XXv32HKxP/b9VjwXpB72ET+9Ta257On4U5TsEetAgDT9o3Jv2KIobDg/bcyrf8AyS2l+pCx/JxBxDo7izqbPM/GxguzhtbjRghY8x40k9/labPdmcrtAiWE14uOS3cyh16yX6diLdYRH67ey9BLdeQtjUTbfYT6YcoJBkWIZ+y1qGDDQeVyOjbYO0E4NqQs5sm0s1Z5MRNBd3p4X5n8rtTSh+kL+bLjPWdpIlCqSwmaOGe65aGCFEKOJMktlI6D7V+sbmBdU9qsK5/hpAhpEqs8WBfeJQBjaJx85xBF7d+rTldlu1jlzuoGISGmMjBeP4u8ynjKDLnmLha4PS6vL6Sc6KriDfJTwtiuIrnbEKvH7vB1OIPuURzbo6fJITZSqHAjgcRj9iFsxZ0LJosql2dSE1WbXC6+X/TeuoEGuUouxacxIKyOeZfKpJdFSwWgzsZ/F/amwDqBf4ZF+ctowaFflhMJFmg3vhIQqarrQZ7M1X9EMbLqGHnbw/4N0fGseRBfYzLZ7kXOaGPXPFRECdBuH580LyS4oGpMJXq72y10m/HqetdcqG3LsRTcNOCrtiVaDSHBjIFnxY4G7qun0aCIXzaJeDSXY/S5w2mVny5Gk6rrTSljncygHxoaHSIqu+60YFQ9rzgTKlh+rJvHSnRUBM3lSu7TdIUPBjS5tEwezm5JC/FVyMr7KP0JEYF3bdOgQsS6P8ueLifJfDK9XhKMMOqQVNbsxZMdchdii9NnewHdFGAcJHdo2iGWpB/SZpoIgjblQS445yquVoi8q5ZJDaRe06C7NnTapkZRrHfo5sRKbp+sLeNjNSXV3VdPo0EQK5X21GJVjOdt49r9e8mxd308BQQEXyaHfidMdRp2lC9BJLCXqrZoHivP3JetXeKyE596S6nLGxmk3PxlZpKGP2h8z4I61e4nyJpoqjdm5Vpf4ffpjv0RmPHltZViNPihpSgdZd5n0N5BKLJi5j7NwGABCZtPVrCRx51sXZQWRgIAtm71IwXUauIc8eM2lzeZpqhVZ/ZXbymJHjBKrDnMrN/e83pdrTVx2DALC8eFbeMscZl/Dd4hPfKruUBq4ZOPn1SsdumclDxxpXU1904h11Sh8NOlb4a91QJ9kRWq5Dz5S2wpHHfvEZVnmgPyNwIPHNhsCukXfiC2M5cZPO26zCYaxZy7OTwamegHOK5FJE59rCzEx2YVLSxM+kz/CKNbZiazymQkX6+ZdV/NWQD00kzDcixcmX9n+v8bZ2VmHNEe17tBJp3o9V7J/gc0b6jA4ARl5FUqYEhVpo3IN+5r8CDHJwv1UjNRnMyFtoBrv7EZyRjG09HgAp4SFadVCmiW5FvMDLZZ973EHw8IfzuU8JAb0sD23DAUr+IggTJp2wtc9MaWWK5qE303+U8ufTOqXsts8GqOUWN/fSsFiPUweRY33Csa4Yfckpxm18WTr/8KXdUCt6R9+eT0C0kbAXwXWZNRO9zo4HGqfi48E2fSX8ShEU5XcX/cJBjXIyqVV9s+zamUTgC1I6l/uZSKWcEGT4TkYedIIrCGocUEGArgLu3OiD5TgmAwEyfmaw3p9tpuHnonNCwkaFrIyKQySQAMf2LIEiy0MCjAbs6vZF3HWA2MwhSq2pk6cN8mi9T9O5awqND1e4aUZKk/dcKspwcYAHFqD166kw50DptfiVBz2tI+lbUPU1HNfES9bIJYpSKfG/AEYpXhuaz60FmhYu+pVAv5yAJwCd/QgQx7y1OAXr4cYSONMSYGErXxsqYkAhpW8TommSuNkJWh2oGyAqb33W5WNFKXsxJYJeJCQ5pow1m76ZHOXdhtjhiU4huFxrK7G2bMKw/h4pGXeOZUJDxdb3uk/dwS9eL+1RitmKPVmwRe2ojz14TgMo2vky8bsVEBOaMdATkN6W5zCHKv++sXaIe1q5A2E54ACi5DC9Iv3nc+NwF7b9LKVQYXKkMuicKgI+ZUU+Mv2XNPDEAJ5TOUAhfO8DSJ9CCoKovZSrwhQ4C50mtU/2zjQH7qvgZRolchyso5RcPld87mi/UY6oaaihdy/Pd27Ui/bm1F+l+0OD/91oKEIN8o0fmbsBk2ClrOGhYkd1MbnUDFT2kpvCpDqxBO3+SajmLQLOu7Vj710+KMJ70V0Fn5DUZBaf5fMuaMqAg873uWxcS0J+wGc3/r0NUhsyUELY+GdeSEOtLQT0huUPmXgGlsalJO4TWdQKVdQfDjtbPidsdoD/dbJhZGozBtHUScwWYOKJvH02rXd2n8aE4UM0xMalxK3dvBw4MeC7ssMA6dzaZodSs14fMUQdLjzHSbcEw8Js3WONIz/TpzQopGpsOHaN/gL8jf/Kt5POWQ36eCaLXEfPbfBoEO9vZHcGTC0dvT4oj3mvSoG9hifgznkfycgg/fhvv7+s4cnunyrKKe3YaqA7oLNVXAKt06JjY7uo0eFGJ8QJbKpzQtwOdtgUkabcvPXMg1dNGIApB6H/w1Qze+M/h/eoKWAV0GPAclZkvjKTksY4k2zM4gMjyb/d5xxyiYXkpKfhA4Dk4DWA87xH2YxEX4XtlHYiMdEFhjv8H4d9mtdJyTQ5Fp3Po6tRHmiF9Ji3vCbqBGn06SXS+RrCg8k6d89jVyqUsxFoPdPJhSjicUr95dsUIVDg+7ZgzwPWl+o0sXeCOAWuZ7FVaJ5VWU3uPEzuWmCLMzu2bOVRdzPZUWbC1dLPd91uYQ5sevfP2CFxUC/g8Ca8P90p6+poiPkyUEItPnawj/Xgt6hb133/qczu69GDyEjpRktybu9yKPc61QZ+x3lmzcdyyt+c7ZoxH6+5r3NIeL42ywpl+mEi/4YsRqpVP7b3Y2yuSidVe7ZcmREodAhOEimbWmYTgb4wbfIa4eUN41wyGnCgzXdfXYz2qx5PgVmq/CInpALRCtK08gMA2rABNGlnoGY/X5AgQ7xK1t06g9aIey2dHTfzsJjgDt3NuWXwEVBxxvcfCXkft0JF1PV1kjgY7dh20RA4r6Gr+McEIkzllEh8vtEuVwM2YKH+LLG4P+lCl/OMZuXnw+FL9I2vGxQZ40sHRxCBBvDk4kVZrlV7+7kbAaqF06xyQFomeKFweGIHa6CM0GT+BIn+vqI1W9HUbFZZ5JWVBSLSkYZ4t5wIp0Kp4fEYkmi1C/gQzPa0FY2mioGQJFl0Us28LIbNCnc/M0CfqmkNsknWamWXvgfiqI3bv0g/VBozLms83bxIgSjcbg5FjcwWoDjRasSnSS/z1Aa16FEk+uAaqGa1CXdWPdFt2HwSMfmuaVPalGb4GmAeUNKV7uKXYbVSz+KdTTKDU51dNvIosoz0KhGAqX73Et3jaHCRylLII5htt8an6Is/xi+wCkJhw7YCb7jtTJeB1gu6WIHgFFbW9cdqMsOeGIHa6CM0GT+BInXLSUCuEPskeojVb0dRsVlnklZVjv25nB+TtpDbwGt7mgO26cLch0QOcSLaaVh1kwuzr7bz3rHwE5w4fLgYEuN4x+abcFs1UBxMRYBJszxeGcItJJd7igJ+4a0+nlU/Di+FSJtMgSiXh4yHisU80MtwZToCoCCTWoo5GCOgiw8E6UW11ylk/mhpNuueuk2y+ZsoSikV6SUoEppRAtx2LZa+iOwXOP9Q+09nkt8HUydzhhZ61LRMpMBqF1DN4avDu6FdhVSgwyu2Ogiw770FZ1D9phFcOzJbWwg0RX6DKmOObETdVZn0MGbgYF303s9g0IbsuRnEnTKnEUWtJDnzbd2U3o3UKvGjKzO2edFahbZq2RHYijau4zTYsNQ0uI3s0ttsi2sgejw90BwoG75ruxDO4jvtLY7wCh7emdv5t2FZfdWzrMwC6gToscfYF3jxNAtEb1RnW0450GI4czM927YF1hI3cZSAOvCMqoyoQKAMK9eTZLORaq3F7M8qEvL1/PtjmskHxEV0qhpNiz9cDaWz8CBIVTfDMTeLz+43QtyJ72CH162C6yRPx1mal4N6oiFVG4aziCtPYA+sYbgZoDJDEj6GNMIiVtiGTfmRAML2oGkznY+OVxGC8/NV6GWxNiYKqzWatGeDLvktKtPzWnOzz5pHQI4p3H7HTeZD6fQGiFrMGoO7UKnCNl3BKBxNCZcsFfJQRWgXJZderhMY/xT22NPkiNX4Z85oRZljSC+jcz97Cbz8RLKOxVqZZaFRZ4hBfkHYi25fY1YD3pksC0FB/Kfprp63AWQWVl9loT/ixwWuK7IzbapCRCmYEcvMqRRnyKF75MN7g0k60q7mfZhDFb6/51cfKzRgmWt0L5G/3RM9yY+Bj1qwRVFAgCbnSo9k7LF52XAqDkD8KnG1D/5y3NaIqMtfAKbMeOVxFyYF1oWHtVFnrShsI9voqi2WrYtC3apo/ekdoB5IGh8lWGnGvm2jt2lZJ3eX/maFIZAK1pxMWPBkAfyPE0cMGf6g5hLbZksyYVJ6USvSugV8wo6KHp5QGjPlEs9SnsH7NvlGkzrHLzu4it/+fcVB0VH8G04M9EBlavI8uMUX27ZsQbn7ji2vtvhkAhDVX7D2ebeEQlrOGs9cJfyK35KCW+BUErv2fp7cbhSLG8myC20Xf4SCueDvWlDep0XnQvpE0NIKf3yF+656eNU4QS9IGIpC6Cdu3QEbbd/EVLNOV1g8v/GE8zJAwIV1aSuXytkgahHkogPCeH/DsQsJF/9v1miSZsMWaxGZKV3PvJUmAa+5PFBdqtBK1Hig+l7lSwFaUN+kN2EkKrjt4f5XJzViL6VYM++18dKSYNiTi+TcpcctSbU9kP8ghKtGBZENKHIhDXngFvT42ZF4bCQ5unUayNuxqDGp/jCTPa2+SsmmuKcd/YljSnaSKOiTgJQ9x3jjmssdyju+sqhRO10oWAMYSde2dYz6q243K6r+vT7pH2C9infkgHiHZkfp9ED4vDzHWwgfwTnQS9LcldSlCcuMuvchjeMe2KIF2+HOPUYOsenbhaGciN302EFcTcg1fic98kcWzCq6yQ3Q/cQpY3z1+2Hjrga1QhSTNltj6XVkeCcZuAC3/zmlYIoeDtoMwRQtUIDrdiuP4cYFJYEIwKd0z40sFRKg8zm/w2+BNrE6DdSg0PixZYIWRSs0Myke+DW/iEYRuIihKzkKcgWvCguee9Q3fPZJKIY8ZtywyszC07woByS+mme1mYNPQ75yd+WCeqyxFFJwAgighaWH8fIpbUMI18xt8HYlF6t86fcUoBikeJjli9LtQgZpvwWt+4WkTq47V+dRoqEdK5ucTZqaaxdduxXkn+EHncv8Dg6gSVTsRs7/sHGo1MFC+ciiAImqWaJ4v/a6tHuDGLWCQhNryW2/PXIkOKtH4MnJvE2jiRKC070eKy03UEEWouF0+2AIwZ43NOVsyLv+u/IxZTJx2aFsHgJNu8kcy5Z0gf5+WoGvBfeEw9tIDabWycHFPttVLUOkMm0L5yKIAiapZqmBm7Mb6iQylXE8mn/FpsvrojqTN3PN99gbAZoAJUcTiwV3Jo3S44rYKkXd0+0QGKfTE/4MT+xV8baz1EkXz8PPd8mdKFU+7QGp4s5E+3ovDkGM+F8v5bkcR50l3kwLuZCL4S8fZLgpGR3Hk/5Fy2dV/daEu8oIaj19/c3D5nrOvuexRi87c2mElVaEs/mpKX6hv2EjQTXo6fygxMqcHTIZioAjEp0bqLd7LHd2AVCwPVzIj/p9ghHi8z6AsGqGZjT9NdRQ7ovMf4pfb1QlT52SptuTVkerPkODYTY9gBRtjPxf4jCoGlHX515GzGFlSC9A/NOqq9DxGfTipiBdTjIWBicyBwSYylLcTz+pykmdMH33Figo5W3uAfkIROVbtxXYJGQEy5wjg2FwssR9sKH5jOpSIUEfmHceT/kXLZ1X91m+dor+dvJN2+HKtoa9UHzwEJBIFs0cg7cLw1rkeYxdfQMF2RsEPwisX0omIv/qhOR36aBPczieNS/uyXZk7Gd7zNdF5iMte95NVHPT8jDyPsYGuyeeG1QC9oVvuey98HvVRuotQ2VmFm3ZBCAmxmPJKAXTNRXnQ3wN7AHgUz73trSOHNoSirHjt792P5NmKAttWVckvYv391i7M3cgKhqapyDtIDDuU4YKCB1i0MzN1rXA2DLIVscKNDbBtA5hXfPvFZo9PN6UwoqWIzwUq7+oeodx3gwMvLn+Eo2dXHa+OI3bgGXdr//ebzahM8QuKI/Heu45L0Mb4qx0o7wim5aT5xzhEV+6ds/4pfb1OLwhAGYhjxm3Mz0Td9Jd5jwmv1lq9n+nnKFn3R3rmdX+FoeqVa5K/Ru0CBttrF2VYfs1slZSyjE00bhS/K6UmSorfjlst1ZxEklyXUJ2gG0xFa72iSQRhr+bSflA8XVmV81XCcOfoKunq32tU2n7ngDnhSTlp9MO3IQP7jFJIN2HlARf7LhV8oil1zkJV6H99TeLJTsg1f4rFtfr/Li4/D7BOMkjSct+v5PK79WCdf2qnPSQvix0eM04OQRhDLBy3Scr8WjvJaWyng2s4rTlE16urrsIP2RPLfnqpxN3xc5E/bl48hMwqKvmts28oEvfacFlgzaJxi5485sj4D7CCtK2VPljPpyBEfq3E11NATk3Os8adA5gE16eTy4iHnXkj5UlmJnbTHRNF7OUPjjiYr9BlS+42PqpPp+sjsMTFNHDVlPg5kezVuW8wSDqzBSrIQY8dVosbncIAZg/Id+xriG8a7wtJVBWbolJvzjpvE14GsCr8qSxtLkIfLbwv+a51ZsyVJDPbjBO+dz0BP/ZB/ayUoykv9kuGPZk98thhtIkDtx6qpMbbDtE0Qp7Wl1cm7E3mnBBRqHpiaoI7g4ETTElA1tR06fvKXaVwAp9hxQQ1JzXXgJPyEWtJx09lnq2/5WYu6hfRVr8mlws4ygrSAitVnrdd10HURdFgdF2Ug5MPPr84VsrlEUZXxffPucnxLn2cPPctw49frMBTpuynM3RlT9K2qs+NA4KRvRk0MEMUyKHLbXmznXZr1i1iDObsSk/MJopEVNnRSb7hkQ902KUwJOCZA8tqiw0bLWXTEKdcHla3S0gRqDI8LorXKm3PAdrd5HnEXnAYz7xTPFL5ZnPsMYJqZPV31+kfMgYF71UGsMEv09TYPpDVNuPokxmWCgu84DexruCJxJ//8N+C/Hwh2DgyHv/6txakiGO8ggACVeTV22bdK9qwjNkZJx06+l6mb4xRP0Wk4TgUgQLIO+i+AQY/Efd80b4BUoGiSVjuzKtJmDEDsXVXJ2O7z7rL7ZqYC+OhFdk3zEis3JHT/aSlH4bqboIbfDkG9i6Opunp5kACSh1+bRZb8dGUDK+/K+eWbL+pgmuVb/iCWNvyN8hHlf1uqA/VoKySHP8qwhILs6uaHvfWNmN9A7Ob8Op8epRaxrTQgScRDlFOKgTF0uq0phI83EiPjch4ZjMuAjZUYNBl8Q4yHrQ+DExsjVb7kabj0bOogqKxszB32zjOSPzihsiBdTZELIPsMdxheJn5sIzKsgz4odjJW5UBmT39keMmU/CYKKl+JwL08GPxbB2I65Y/3OHPMdnzwSi8jDPl2F1SY/MIuMfXhVnUgIqccTfq/xY45qLN6Eitiu1V0vEWXdDAl96Y6Kj4ATw/olaZhA/1xvG3h9BcBhx0xH7q+JkCzK5O92Lryg/+ZyP+sDyOjo5KjI5jtyaE7idSz+f1E6Ow4ChVdn2qIrj3XlnrQQQCEhQXigvq+W6jitMTnTBt99qqCvU6ZuDKd9GX3dfSLsCNT4g0MDIJI8xkwHbzSvAl+WOkAnLawJzUdKHloj9PvITJR9Wuy6G63vqij+x+DZnWd0RsRDm1L/sZ8RLRCPdQ6E9D+FkLQjpRzv8bVlF/TlLl7//88ULOo5jVfrckU50blf1KrLfgq7XOrz9fpWwrFLzU4QsQGWt29AgiOcZUEfBU4teG2MqxNIyc4rmfv8vy6005Oxgy8qqi6NPo8gBdFol0ENZTTns1lLH86eozZdu2qpxoInWA8UdApdIKHnbutFU4AClRCxdWwmU0x12/xZ7AywcIC5uH0gp4q2QZR4jvUVyvpDnt9/T6NmzHxB48+MSy+aZV51Xa+Z096ciFdOUZTWGTp3X4+KxYfHdQL4kq1uS9EFuUs43iMNyqEssoGXe4BcYaHuwkDeHukwQWDoFs+TVRu4Nic1zZZAeErH3AlcgC9O+UZP2nigYx+TGukVeAivJerIcKIOkZmWh2bP0ExZOmJ9E9ipRSVhGiEs7d68zGaCrX29P/aLGCBzKG2mLnLH+eY7Png+kGnzw6iVx4lX+M6+JMMuPGIKPHGGmiUO3CwXqeJFtgEcsH35aFnTc9v4EPLQ93DD+54qHM3sg8qwzOsDCq90fR85ZFNKxZJHsnTTogevAM5Ir09NpQBiu9/3N4mcDaGQ8cCstXtwxDS8MoBYMZQt2CrpjCnzHT0KoDES/f4dPYhwRZmJRv7oG3NBNCiMiXmEJWEiJ0Cyg3rMva99O58+PhHsSXWnBELjwHKGdJw2GA4NJj9+u7ihQGVfLYAdkdgFpTE08jVn9gEoZ4RuNn32uFpGC83Uju0svkiixfTQBjb5cv0siWnJ/YiI/pSPeXicTqEipKz3dXTfVs2scsHT4RFuel96pkPqiDwsQPGbjDed19OOD2K07wV3HSsgcpJUjskyl1L1TJygZxHActJ1afQXE1TffO6cL0cTbTkkd1PnmwIxKIW1LVe3H1y5dNmnuA8/BO3gMf5Pi1ewj/vaMSIEb3+q0gAt0Sx8dAVyWOOPAqFifBUNCrRMcat+TFnriLP7HYOuU5WcjFBk+eWo13wkPH3snt+eYcDlNJvnBF4FUrYQOTJVMX8z04eEYpC2jqMYwm3qME8W99sOK74GaKxs7gA8Y/fIQ8BOzFC2/ekToH0KU2sotzH2yvxFGC7yZO7thQWnjaJ5DTxKbeWsI8TEkMbHyUwoXVPbd91tG0Tnmj61Ue00MlKKHMEC0HzESss+IiY0PZzlIFe/RaPfGkwR8Jek+1EktzK6BZz5dq/uVIvFAsWFDSzPZaLRdDdT7FcTSDr6maMhn4dI2srALinbXVTJrcwsj9mYYsgpDKwj4IsJEegio++JSU55qDiAxQF6Y1zjpYXpKdPLipgGtr+x0uXA6TfV5FUN20z0M9/ENoTdX3lNPppNo9/KVJ/Eafmvfh55TjH5fVXZfHZnv9g8R15cTH6Gu1ha0k5f0vmTfrfjOggFyHFACIFuNwxtIpgywwgGXI2tIByEnic/A52bgKKKq0LF2znXxsmbSfBGheDsBp9VjyaVHZisdY7Tdlnh5F3HPuMDf3IVztlDoNRcPEMTBX6TC3vIi91XYAlt78QFA4wv1ovMXIyde+5JLjYaQbt9B0DMQYdF/5dRHnrwnAZRtfIwIRe2ojyuWuGQYC/OAncFjE4Uy3/DutVC848rTi/aestbLv05KIBnLVA8KCfZdqVDJYzgY1mY8F7UM26xNkh/RPOCAKhtsCjP869iazpzh1tJBSCjuL4Qod97mnRZ3w9uDxXsMkpMgCY8lgdZAHqX0dQlRhMrP7bT0tiK+3S8zeAYWh3QF251iV/ZRfgnVAOjbg2TbKGh1Ce3NjNO0AxSWFMtiLcxlMb52m9bYGcHCebuaGdtKakMOr9856UooayZe8poxcYqgL2dR6GasQuwWJard6SgDEuYQE8WsC7olUjhzRwhxDpWakZOjnfetBUGx7HKdB1eRWCOqLMwezKH8LeVNyxEx72wNtLaexdwGrI/Tmq5tBjSjBMgf0J6lGzlhh2Fo93xl6awNvCLy0oqV8tfMoad2NsrkonVXu2XJkGDps1bCQ4oMPZKGwgQBE9UN6s6SlDIUoBbXC/CI/m+5KSH6NnGRoYEjvf1NQaUkiN0Io9Ed+em1x+LSt7eqj4dEsoodFGiYWnO+wyBVaZa+SX6iqET/yqjn4OwGn1WPMlSKnF+RjwBsv+ymXUPTo2e8XUxahag5z3qFfg1Wr2kjZhANgbFbTo4y1D+YQNKQnFpPZsU8BMXj/wc79db8wHM9/aD3TyYUo3ywm0fSHJOoOj9z97G9eoayZe8poEiXG25/vD3B1ZF3SPCyfLqGIPOCgoHi1gB1pyDWVFDHkSL9f9bilBap4GpzCzMUQdLj5Guf98t1365Y0BEhp9+pccwrHE/YxWsEzxL/+QT6LZqSkt6cFVR7JUgftDnLFlrjo/k1Ey4GGMX38Zsr7A0LHZme6C3FuAJrHF606FFp/WjZQUy8etokyK/oQSVIIHEShP9eI0fq0+oX2cMrb6cN4AummZg9yOYNMUWSk0IJne5Ob2ijUrsz6D9ylr68Bt+Z7f/L6x44/AWc8naNpbkRw15kVklcXJGGvlXAG7C9QRob21KOk/m+moFRf51JxHsscEq6gQHC5jM7ig4IViWa5EHjIMTPOZn8COwjmJOzozdJpL2lQdXJ4ez+ZsTIHdok6sd9YpsupXrYdgFQbXABkXcMI5Cd0BdudYlf2UFV3M6hkAymbJGVIPbeUbdHKmMD8Y27Lnfkm/NL/pU5U+phROYhfDsg7cZWCwuiQrx9cvHTeZ+NMJb5E9KkOM4g1/xBF+p1qSEg2FSoY1Cu6q+PZlNWXN1My8ADdYQLp6HYJzpwz/l9YIUQZmN4Oa7HTDq1LRp2I2EYQTdkX7Si3xXSCXLGvEDSD5yEuy0gTeTl1NPxvzYoSEHbrlox/E4K6lM/C2Qe+zzOiU9VCEbPqogFQ7pRG/2fREcE/XsBum6lqfch45s+tSN0a0G1JVD0/l6MdXGCTUyW80HK6tddd9qGx9DRrjmV5Hi0uwqWuMTUhMs8xRJqFOyxOrAiQby3aQugXKeZxPZ3wxfFCpKHuINXCLqz0PSPMFEzn4d/l5zEV6PWYVU39ILS6apKyZsBSMLbmLHCvoPQUdxi5pB9zVKYWSyUklAeUzW8bxdrPZfTy5eucQY4NYIT0/r7554DShYdgEgXNm+jdcPXsiLB4OlrPlaTO+YqPFigo4TI0hq21CNFxGidXL6eufzbdcYkpWZXEgiTuZYf9NkFAITMea0ctRFyPNXSgjiUA92FYSemBy+yOCVw5mrIACoRd15rYuCYWMW/AsudNg0ESZOahWpV4cEP1ArEpAmID58QsXXi06Sz65owV4UKwl6hwDnT2U8Gzl6pq4O4xpzXA5mw8BfxGatowOZvxxqUGldfYvPMBfE5ue+APbyd1pUYmLdfRmsi+Q0kJOI+E12ocUa/2Rwr1zrpFvsGvYd+AHIC1KKovqaa+OoHsroSZ5c2SmPE/0Nk6GcRuh3xREgkqs6U/T9V0hRiaeRNmR6Iq3MWtziYH5p8+C7At4JaaDE4gPaarEnVBnvFwsdc8Ge4BEDepyiHnIFiVxftZmM1kdaY5th6ZmEoahvQMu/vfjItPXXsDtX/YFCjkpqfspBEOt/YjW7F19AwXYVGkvMXCJNf2MmKVb58TYL1mo2/TDfyfZrXbKGpc6WUcvWLhwIA9JONYh8QC0yhUXSn+0xHqIvScvepOER/ler1f8vV44ue54xTYfVGbRj0eMm5GxBQCtHiNgY28gYVFqG80Z+Qa9QqL6QwIeIga9pG6/s0lvrX64kHqDC25czHF5Amc421xMLyroUJtd+35FMxop6Z+3OoxLjRhtoGC7BR3/PY6slQUvDi9Zhza+eNNrFxHUbvwojhAJfdjHDtIteFZg5ehLofn7lfcDq5r4KGmUXB00ljFfhCXIRfz8M1l5jmaHKPIXEXHdRXPNQJrVNscw0xDj3BvRURxlGmBuVuMkpufDzmhZC6MRe9xlBSEg+2AIxIgDxK/ADL5VfzpCTn5L00p8EexwAOGBZoWV8jahbIc1Am/K+KYRnC8VlmMLRoXeQxF8lmh37MVRfOySH5DwTke2v1Ma9gAS5+woqBkCRZdEa9yvefXJQOAY3GdVg/UMNIOEC+9nB+P2Nvmnol8Pc2wTqxQexCA0UrBjMXGzqvk2dyu4Th9joKtm1r18f4SOn5trRm7u7fOuCN7mjKLH575JAFcnVmMYNCqag6iLLptXZ97Jyz8TOXcG8YxE99cTZ7u8E4gVI2fnX/FCBvgum0WD9QDCEgem2oz618rwZPgxaHri6Qzd01hl/jg8KQx86Tq0MI/kUtTXnHeihBX1pKL+pMnuROgcmCFJSEIbmFzcl0XuFyWpOgdYhrwglL+VAy7aawODg6iXe3x3vCrbr/rZKCoYmwrJ16imXPGF70o5aZuWMShc4EEGJmDH5rIsMkeAqn8xIyjViJuovorFbH1fLCwlbsycflpVVFSyui1oKxxOT27m8YOWHX0GnbOkxJnYcG3KzGMGQla2smLcSM1VoMwWLVhOpUI3rTO+FRXHpFinICGtL+8J+VyWGMT04fQ1jjGdDtl0q7HDtmEmBetMZInRhOvoNO2dJTI8HmwtVQV0Mecu9ASPWZeEOa0tAMZg1yWPoaxxjOh2y6U6acK8/+RFIxop8JZc4HSdwm+Mf+rEjkKSDat5rRNjMeUOlUGBm4G4yeIzNEBiVklkqvuaW2F528m0vJUACQE3c8woJW9TAahf6nc1jkdGjBOdtp9fiOXD5z0iSROO21jze2+QFeY+0rqMpj6pCBcpjmmMPEBiiyPaZmEIDtNtMNClO+ac14dUq/0Bm6tTaaEqtdvflg6+Ijy+LMjB/toNUGE/YeZ0ZbOsfkJ2paAhRJvgROjGZHqrOSh3SKGZSlBIDftzOD8nmsI8FkorO/U1bVhN6deTRZclG/4ECYR5VglXJooJGI5iDTzHAECiZqdcOpWDeur0Sx5YOq+vrc2mMw0FAoNM3v+hEpieyqWSulbt5VIpItXOhF+j1fRv28VQIpdd3QbruYbv3e8DkDwGFjEbVadTnnIt0a2m1AIbBbJQYLoh0bsBI3QkCNCFF9Yk68jp4Ng+Vns/oEi1yPb9fRdwIykkD/yu2ETNQeDE42CnpplciU2/sn6mS7umBz73dXjFLi+jKr2Z7hHZWqWyIZ2yAO3oGOGkX/IOJ2bg8o3n1lf+QSKmhthMIWieCq3QC9IWaGZSVGFgnox+tEzZn2F0wV/Fezo6JtJZcfBkxQRhQwglxCRhhEZtwT0gHnPeZhLsenkx9hhct/VkByeSUGChplAnyagJ1QwbNcar3r0K6ItnwI5QJZbxlEv16uB6h9O0Ym/GETQVuB82GJmrPxtUmsHInPM3VvfhssFCWW/fOwIz1MZLyOY/OvJEKTWqkntBw8uNRysNOOlt2RVqZqQNNusJZ4Nrg//zH/ttdp/XC1/8ZNXqVBuebedFz58AChDCPPU3FAjOzXT+WmkF6yN0S0wxofhaPu8BjPvFM8UvlmQrn5TMkNm7Hl3tl8XRYfBre2J8LNp/eVtw4BPN2aIBJL6Xc/Gd1O2YgkYKRG9jSEyMWkz+fI7OfjM2CLCntbLCMJQN8Ec5b0IhVAieI4Nk+pbHD3eubbNpc04WVylL/Dm8H4uZhiDQdbxQdZAaBhFajExbq0hZqTQRzKRQCBEWpahkdbubV/VVwJGQ288CU60C8EvMLAwj8O6CuhCrGd6tOasXntX6yrRlXu3Pizj2i6d/Wh3g95F2AOfmNxhfI2aNMzCbobfePEpvqJYfhPtlC9d4XczJDvUXQ3M8Zpz7RasbY4uCjkPjcsVINcrT6FQMeBEcew+lrOqFs7x+lkTb7/VH2t1l9veSSyUqqoitCDxS6fAy1UksaVL/QRgrTJCui5ZI3QnAN5HNIC9T4fWgfDwsSozQ7gPCfeDpYJ6BG7IlO+JLBifxgYN93N4ciY35A3JobwWCErDt6pjvAqJJKcuH7kjbiLXKUjWQttl5JLYs8YUA4+SFlQlplI0yskM0CLm2RfHGBFIHVQIOG6s4WbKsGRYIX4KCpav0pwGimNSntRh5YVv5g9STQjZUNvIcTt9nRSAxYZUY3OwqAVj9PxL9hoiUhU8q0QTnw/9RTGV6ALpCR421CnnTc2DclVkRohxVmSmWvcK9ULhfNYDUydSAVEq+TAD8DPwPQ3hqHF0dJCs24vLDqLwpDoDesSm7mgjQJfX3FHzPtjg6WmiXT//ESk4Gndo50beQfyM+VoIhWmdBVDmBDbly4B1LpTXxAMOoXRW+iv5gFKxIa6spbYSbKAaqhP9JofSaXYzbwOGDoP00jo+3+AT+dpp0UqYpLc+iPbWYESa7e2v4fSZlVh8vkTrxGiAF1vQQCj5MZ6B1g7eog0GRxau5gCpCItCniybUFbI1mXqjbor/QObr4wYu19GmxQp2dMoTVCjHh/F9vhs4ZcytmLZgxqciN/PW/J4zETzYYOEpz9Q9kzJq9owbrfvVd415gXghaUM+CwDzjC+XzBPle3L6HFi2rRNb+kDKX3mNmYP7IzRIgavAsOrazC3q5xlITTh01NzvV95yRef/n9HzqTYEKjRkRdl0D/o8X/k0HtAaVgrcGcnqtwdue1dMChpGIGDumbJ5XggXbq6GXmL/WyZp1lVhwXiCTAQNLFjIs1UKvbTFpF6oWbAp9sLvG3DqS7j+06TPffIn7pMhyqzv401s0F9MIgduEKm6JQFieeEeQlpK5ukkE9ukNkpMqFYlHzJgOJOqA3wuM/OpCclffQiDSTAI5knhV7eblFqkJ3YaxnHGLBZv3FilEjPrMK3k/83fH7a4jPsEeyXqYEgCj0Nk6ZGWmXtw3vorulfzNFyKD3WHnDwnObe9It6JF4CR4L8gRQ9aWPjqLVcXEHnJGje0/OEaKzuJwXvCeyqm+n4mnT3czAFdZSztUv6QIIYxOfilJEda/WanGY2kScLJ8dQP3i2O2hoVxEH6sVeUCUev1dI+1OH1tRbHCs6xbqmnrcRonXOko887Lk+K7+QjiqxrejgMkVOCR4jxLkYwhXqUjtH7zrRSrUHCDFpWim1EPtC46BFF8iB8qUJKu8QVgkKxZASxOn8HwnZuhmRbgiTWDY9wroNJya7gB9YASqbVf2jBBgNauYXzThu9UgYb2Q2NQkuXjco4G8QsXst88e9yoSfc2hvv3wOs0LDe5wwoCZVJj0jIsGSgIL/QdrRD3evhlWuFZgrykmy5pQHyVXC/VwAvAnBiDL4F0L8g6/Ty3XWSZFL04PKbvQrs0sMJEKbs0aeViuybnsyQI82EkbaNKpmeDoLlQWjpK3/XPqM7n/Hp2HpF1kcIHOab75c8qAcGLkIURO1NnXdpNeqfFZzOxEboU5J6RW6rsx+zj22UZmqngVI3RWnDam82/0AZROppZTmVw1qxujs1dJ6mpmbCCparZaM63i42UstLJ/s+6TXE8q3Onf1JRgv2hNW75xukFHprbObmweHLLqq5aTJbSpNz+Hpj7GescZBYO9ODCG2HEpnBzWiN5AW7wagiaiMp38gOIjYVenD5fv8AL32g23i7t0UWAtfRsBGnuYmYHQ/lTV2giLt5Cak0IgH3IR5uzgbSMYddOMqWqm5k11ZMra6e+QJde4eH0IuoRiXBoG7P67ZKSM+q+CVnnVrgposBe/rXfSYugSIw4YF4IU730skBKxNJ+zhfq5sWSv2ai6ZZ8AexGY+9NRYf3qXs4LoxpGU0Ybl34F+IWh72fVsohwERtqrZVXXRLz+uquQZbFnsVb87rt6vQ80nQCumPSR/fKIZ9UJlggMryz0f8WZci1NxszRNRjb32khl1GooYg81JwRF/mkBn2wzQdgDM4BmjpU+BHkUrYe3RyNLHTLcoGJbu4r20lqSJepWaOz4uf5WesA/GDPzUKxMzYUnomeE5SD9R8vWn3zyAs1ICOhJeBj0rYLs39vNixXSVSYk2S1C0WMU/MZkiTVl02vlSY4JhmYVrtnRlr00eH2oD42XpoYaA/C5b9jciVkXoEqqw+SjJtvDeHRp6t/EJWJ7Meft/tVsSbYFRAC6/hyXy8nHqNtKTMaXsC5xk1gGxc9oz5ktgL0SsfKWaAwDek7ljRNx0XCUAEqGOns4md2NnfTMjvv40AR3Rt3ey0a2OvtjE9Ab+vMpkaXO7kGta9vfgQOnHiLb9kT6pBn+/ts4Q9kAWlC4vUByFHcfqB34rdnZgDgp1BFr82hJr795LB1pFBGawDsZZstQeVQtaIiaC82ZPZ91e282sz1vMAp7aRIW6/QA7v6tz1xRpsBVaadR+AixBC8IDq0vex4exRvaYjOpBQkr0x/pHmiyCVjd83ZJzSB1032GCItBxUqkpO367xsvTQA/J7oQK8cYQ8SsGQAIcjqBQL7hk/wPO4W2sxdGEiewVgocKa60ol1RrmgD2Vg8hikKub9ueJTkzvPtVLLb1KIu/b4cWXCLhOdpaMbpVlP4+nqROaALzwDyh0g7ER+OS7AT/RU0UYVP2qR4Ie8n0/hVWLFL5LkXC3hY4uW7Sy0F4vfYsoQelbrZvuAFh8afG8Ec4Qf0PumNwADWlqQuyktp7FkGAlG93XnvTh4Cg+Uu0gFocm9KZT0bBLs3BVUGQy93WicCjBrEHONrTnQ5uSQYkGKV8WccHiS33TpMUvYkGWhW76XZOgUvOT6YOri7R7CZ9Tgfobl1xX84YBGJ/j567zaj2VNFbt/toQekn/Hzr7H2r4dN+agSZoDDrQikkGvztT4bYgShtU80APib82o9lSdvlcS2w5NVmtGlM9mkDvqYL9SJLISwqyW4KA3zjWFDCbyKcimJOaIOOH+f0jMdQudwkdJajNUz2m73B91EbgKX0WpNXNGTKchvMtHseFdBxrMDJd6flbqJ0pHASjwnXxzTbsoKgY9j/vRArCYqc6uzjBvzaFhjJLHohLggl1cB1B5Weu4WiRSDocvJaTdewOceJKXk00ifEKPiFaP4DX4fOPKEfPXIg8kd9u2xvqxSrACuXHAZfkw5/fUZ9R4pku291pM/N94qVcuLVvbH+Y4j5HKxablB7fyRQbkVB30lVbuaV17Ux3sMtJmCYNTYTZnNLW74v9VRNiPPdashGagez5ItmuUKIDilNTZAYQAur97Nbf3Zs+aCAmWNbeJDHRgC/sIbIKnR3GUO/IZBvLUkwj0gIvZHA/jkjX4Xe7cO0Uqf3AHGkAN18JWywK31GNyMq7Tj7yUCAAOA5jG5NWQoC+nTnzaREpf3e0lklE0a/qamV1vvJbx2VSiXusvCwSnJMwc3owmmSL/WGFU+YGxYmXdzd/tJzgM22hWuAFwVN1MmlzxlK7JC/TOiwWV+2XhlXvsQr7lqntvomA072WsdbEgxUGrOjgsX7A1Q9EaLAeMb8o6bQxbbW3Pm8F6SlxmSQXLTDoIzhmBxpbhmoqfqFmc/mveVnrmiaVKN95tkaJSwhrHAuR9ePeDulUXXsKwjcn/U89cuH9CPtCFnYf1lk1uOYM4Cd8hFMZa1yvHlO52rKk3sRo7If8KpnE6GNEaEM7T33E7gDkx/z7AfItqVpaMHiSev3Nzdq+0LfQTCFz6nHu0EZEhVHHgyrZkWN9kMv8ALhsfWtimbwbE1MlRMNd+TpZf/dwO3IjGmTZXBWF61svksYuAifpsSuvtlgwSydeWCZ60z1wET8LjZRaYyNsw0DqtTjuabbCBaD/YjZaeNqA/UlfP4f0V+H2baAjJ9YyrDi4GCB6c9vk7knKjTlnUFZEy5xBrhbJdGsVKwxzqwTCYQzIEdt2pZbhVGJHtliHXl8RryxTDusYpXZjqGlVEIxYvnYRE+AgbPXG137JfA3V7l7a43AqW9ZSzjlv6quroh1yPk0GmmPYbMJpgcRUrEYm/vl/sJMSo0bgpl+guqZULNRyWHGdqZB76L8C0NCmU7dLtFKb++5NDnRhsLTQthCB2I4AcRpa8lbdiupaTHdSXdwIcjPJmbKbOtNv8QEhv5+wmKl1qgGXqsVTarpPbU9njTUR5TLXZInPe0rHGlhQWy0DK7beM/UwCd15HOdR2gAdPoZmUDiHt58Aj32joKpRb/gFFdYUN+CByBVHBdb+W0f1niED1liBzlQVClWd0mgfjmlrvwq/jJ0NDt+wZgTQx8qrQSWKfpWN9FBc0966hbgrmyvXjx4O5fvMah8holaz2jAQoTMbpq3UiguLMF/t5XA8w7EbL+vuLPrOl07dpM9dTlb90HTqpm0FoFwjyK5ZKT+TAsM9OR3WsbyC7Tt8qpbuIrfnybTiIAuqGKXz2vS48hilqmSUMo8LoCPbqPnXCYQnZfAIDfUWPCnp3SjkauUGZxiAw4Fdh9SL5mATGZKSHZ3zXuJMo/DmckyQy+NNzjRh1qsc5JSTaNuFdzPRT4/CRrFKjSX5HBsPak9OdiBc9mWaxLIYCC+a6gPBdrjFcQ2HTI6RDfncvp/TMkpm53BSdNjh8fN05+6rY4TCLexX/Ptlyb2toRBNAgxl/XZQGCDtQEP1MwMoI65nLL/ji+kvAbcgGn7++GyucXGyCrsmKi2XzkG2kEqo+ccyPxDeeHTJaiPnWozR09CNW/9H9eET6EFMaGLXZlOpWKzIvoTKVnHVIUBWSqejGr3/j7+QlDw+ELfDgDqHLq6pmJLrgbV66k39KfH5ruEkEmhjryDcL0N6u/Y3ZxrrNX6VQdJGYZ9VpJ62JXhmKRYUwx+c9rdWNfwP0yTLNUE88wTF+hindT7rdJM8ZkY1FBMXbG9QQsGbca5ZNHHeV+lKctVuu24FfrWtwZkbiKUSt2bAf8E6VpOwIPbeXH6zRTNKFXOYD/ysRIIaPnTFXoQFbxn0DDgd8Ah4g76lw6/RM8npVujwv/8PKox+TLM5BfOBok4wRMt+pnfMcXPBbRNZQUdrnTeKvE75gmPQURbhzFAs8CxuvGyJFgr40JVwf1cHkNNvGky9yL8gDIOIrdWzs5lTPFNJ2t7G8c2YmpmdKvX3bPAcJbV0gtxwxFMImidOTcWkQqljPDpLTi2Pc9JIbY3b0Ruza6U6Jbr/8v/acElkxXFYpCdGu+8ANJRZc3D6PkzRQX/G+emHuuiGkhE8o6Zw6jS+uQLwBqMRPK3AmkipR+CTMOzTh8vui0SoXky4Vuty7FWKDGDYKNdORRWN2/F4hVb7BTn3esl5gS3KZsoXaRKc7s/r1K13w1lGuTxdQm3cQvbF76gI2SWEXV5rSWlBk+O3UT6bpUCqtTNX1ij/PyOq6884JoQHrNmQK36A3KH6ZqJS/T1MleqsU7XOUgZF8Ftti4q26oYwyc39BL8VyZYTKVXH3qNpP1PHdwCCARPru7QErA2ycMkvbO2UsZYBYBjwjFqX2JzLf3ML0Yt+NLrfT8nlR4Doyb84HES6/edkXBjRlGFRi2kpivyQrTln65LUlYqFrF6cqdnb3HzyrGrAtNnrEUi11kF3+s9oLtlhgXWjKHNm0p9pE7Ccg7AX83lMf3tCsM+h0f9pNVPPBiPhYbi5dZl1vzM/5ds7MOj6yGcjqZKhSWAwuFRx2YLOeWy4AYPft5DUbNMIOsD8xYrYiEqGGTOFuFG5tGw08kWhbsnY1jlvdb0U8NtUdk43g2igP7t5dHeLwhxjKdXhv+s9dDtG7xCuQCjwdKP6dsYLh1cj1Pab2wuZQa8qNmPXzWNVCRVYZ5J+flv//z2SbmDn2kVu1Fsrh1vzum1/K0SCdaul8uHUQjwTt5WVg9q4uglVoiurfgLQYVdVuve0gHrWO56YCEd6MMpprRMjjA+VTJkftMdTx2YpF5kwd3KXafaG+B72t0awgmIeDkKLnm+qaFo2UYBm2Szy9fcagfIOYcKAHDopHSCVQPFU7MJkeJSoZJ8a7IZiqr9RySKDGgjpDX/X54yCsPBged7+javWW42v88aA+4Nn3vQW5jASkMHS6fOq9LfgVWx1TzJWEIeAHkDqR+yXrPTEwpOynE1d30tlZmD1gTxawhGW4C+BapGnANcsr+UOQP4Z6A0fv+krKZnmlyMN1kj7NQaeZL7v5NWJ0N5ADuSwlep5QeWbAlVieTGvNrLFEnHfjqCkj/AVoU8A6lTpBuJ9pmSAu2wcNt1aERW1ekOdrnB/z7RC1NHaLPETsqRbWIZzZQ7yqh5AcFr878EXdr1sMl5War2sdCZsBUuX0LY2h9Dn3KQbqImufYsigYiV/ic2FjC7JRCaUV+W0tnJVhM+c1m+OO8yNN8evm2ACOhzfpkwMeBzRvqMEn8U7EOA+wP419yRwgjZzi0K2j6DCmbAkcmCSQ3HbaGq0DjkH+dR+/s2zGrDQ9qT/gykfuu6TZYdCJ3tlrTMBWdHnyGqT/T9mTfR0i2eKn2XqfBQvw4ffdm//CIvezaYGhOHGLzvQyhRDLrjuElfbzCwM/XqucOlAFiBmEK80hpd2IZEbHhC2yyZzdBjV6MavtbnLcw9XSUyJNgjDgB2Rs/dmgp/vFtXE8ACm1a1JutxIylvQ56FebbtxCmoAQ3cqOWIaXg0K+U2DE5kkWoCGknK28FvEaiBg1woqtuVguZHhT8EcsrgODWDTPiKeXZ27FfR3m+V2IO3nZzr56+TQrZT4ibRijjprT5rYf9IqmKakt05KvJMv6byo9EQZr74AGh2FKJW23gVxmnV+QRacSxov6JZExntXV4f+14Q2JOK6EYZXF4SSBw+Eh2+6BiNqm3DHdUrBKc3ZuMoNYsGw30y7cRgziw8YGJIvqskN1kfJ8TvbMuMrrLOIc8VvJmxNFC5iwWYyPas3Z+iW670c7xE8P/L7ywheH70OPHqt3uj0KFPN63lSqPBkSM6Ht3cxEnjW+uPQ+af29KicQOhYJZp246Q2Qr6myLwQ2AcZHLIxW7vlts6lsauqbP400ahVhgApXsLg9nm0rFuVWJAhCqKzhO0X7BnpPZsX/BjRLOD/cBSnDb38chIqm7eiaVLEUGrve0e9oN/yOIEUJZ+Z3d1fMdf0htW1F1YCY+J3NXgRl4rU2KmlvUdldKM7CXjxLCMXM9G1v3qcIuU/fd/NYeYeEc6FxYs5F8tsoj2W3fybLAzICFrIskVEha2sOJ6+HADQad7Xem/hKbxQ7AQCvcK7XnVVE8HA4rQCXBDyNH/Vw+qB2IzJp4v9GoewZHcgnkELV1XH4XLBIImcPRzcvDYRUZOaPuXYjJSnK8hG2G4rMMmqbOImPrKhlxDZZbim9XypPxwVth4qELgCmpC0cPtVXQwRKELp+q5B5qTWR8Hx2hZKovWPgjd4bzDYleGb5ZlFrJAkVRLjlSpDNUs/Bai2VwTyzFWuNXI9rYSQqVpWhTc3qV2zqoOxpaWrvCXXjMxphrjXgDoGa7gjXQfi1jfJR7OhPdHc105U8rrHVTZEQvR+VmYFHrcBvHUeQ5jwjZIOLTkLFbOUnhRqEnldLDx/v1bJZ8TZZ8YknyTaR6e27ifK5y8zGqj+jCJs45YRwYLOFhQJlLIWr4Ad47LzsJxbF0tbOURuZO29Cd49jbgZ3MxuJMeyA+wrCTPLZOIpWdDIqw4a8kpqq2FHbckqnI9PYRskiBJ3lzVnhD3FO2Z5zlQ/oFytJ5zzRxXy8XCEnFhEI1ur62ZjNTmkdxq6I6iT7dXUiZOweuX4NemZX/AJd5iMMwQPgBH10NTQHPD4hI9NJr8iPqm2tVSrjkTA0mnToOFxLAp8IrwumpsGwus7jzSHMXVFOZuStid/CImCcd7dJRLt5fzb3b4fj54fJCx/A03uJ+G34Dsx4FzLqpSqRWMArMxsougsGX2IiLBtvyFo7mx7udhv2tKYLsM6eHLQRIrNNcdXFLGbD5C4VV42f4bbxG/6xs9vJHbyDsk8+KlMi3vUhJ8szmGmMPKk6FAEZk08X+jUPYMjuQRK0Ljru5uOfYbgqkiL/mYT5/W+IjrjjQQbXhpF6f1/mWtrY1m8wgaW7GpvnzCaAMZL/GP2h47SnJxYSxABG6ePpnxcfex4JhTVoeBGNiER99qzEGvdSc3SRAvhwDRvFLSaMw0RTo5ejSXKZdMKMkM0RuVh6kVuJCo+rTJhcDdajkhO4s/Zc+5J6Qr/1PIoYGqqjnuIPa/ntZ9FObZLeFX4rLPoXdd1ZbLNKos7qGeoj/DSABAinrBYl+OrM5XLIzTWfzpwsyRrHdn43SRfITLFzKgS8Ii2KL0e218tY34tObsj3IAt3tpahnQgPhuI/9LmOv6Q2rai6sAaRs9jqDR1PBGzIKV6A0TdETi2+NN9/3kZwqYeyWFRtD9qhRVI4f38WVL17RYvfU6d8Dy3W5IXXldYC0L02937Jrnm+0mlInC08xdrKwL+oyYm+329Xo6lF1JlPbb005MrrcTZyqtMdWBlK5Bk3xfvBAnyhrB/Tx5EuSxcz1rtFcHSyftdW+TqS3u+ET5SdRRAzh3TYn1nMDt1D9ZepbhHFbVkrYJI6B0M2JVmMxFG+qhxvPtCVFWMtQSZuww42wQBXJbiUG7vUsX1okt4LBHkL4xFUsbKcWJy4OkpGvd3HhC3qNRl2OcK1Nulatlnb+p7XQbCMd4eyqC7AghMtaQw038+9xVxPVAVH9tEC7ck3c2EI36bq6NglG1PF61XlkNTmH5iNg9jf+6DsHYoCgKleub4hnhWrY73UA88eD/EycYSSRJJ47OV1DjXMmyu6AnVu8+iMxR27Y6Z7sIGpZooFTu7+V7ofvxdP6OvdtmK0TefIcmN4F2x0Q90G/iSZSz8+DaVIC9ImM3Hv3mrjyGbzXiXno9yCX89i2or/d6JKS738z4TFOg2ek5X7fIAxUe0Bj/i7MJSRCLHZqwbkjWD4pBcbc/jBConzb6M8NJTEpEZUVUOR1MJC2WkdS52IGO95oBBbsuJ7FiqoSwjd30YmnPje8XCEqlBXprFe5xVQHxpbSMUee1rrlp1nR0K4hFwuO8r/MRWK8jxZ1aBq9F5kDsVSIzJp4v8fC7L/gxGNPfkBXe3F8iaaSzd9EslRhkAEDq0cO0Uu5KZsSQiCxeSTvQg5223hYnYuoXot7yrcq5jNczXpspfUe2EWH/N9AuVpPOebyr3vxcIQ0CtYvCpA0VILOWWoyAR7mhY2FOXktO7xE8IkZ8OTZJ83EqtLpoSNYydUnvClRlX5l3WuHzRKdYTwxB0V3PSQpXS4w/1Ec1dy5Dr2EEMpxjYoHQ9j1gf2j1kk/3ll8WlTzrvZo65SuWBGDJrvqwYmNMbX5FTIinvodwJX+Zkr6FX1kaVoSuvgYFP5u9Ywl15s95VUzaHl8nLYa0N9ReOWINfhPPwWmqcN4Jd86FOyO47EOpGvrm+b5nd8Lxdgux6BCSzSp96NnmDCNi1w4V605EuLKJMjhx1pSigmYsDFWms/oGb/tBgC1+8Kk376FzmGWa0/lsTfdFc9g8hZWheBp14RWwvYnIN6xDY5ATngUdN/Nv6vrQiC+FQByT+CjDPLdHZzhy+bq+d29S/u26Gv0z/gUNCsBONfYK5w8KeN3YoDpabr8wBYbEyv3xcSOWkw0iQEl26pmtEwT+4/kaiKUVLT3wBMYxFEU6PUaQFHkqqRsPybJOgANwI/r4WWOA9aOQS4s8lGKrHYs9uwJpKpR+JZedTQm4FjQYsyzDEEqdGMkTDQN+77/rHgrw2hssv8lpq4G2r4wOwDAb1fB0ED5yblVtXmM00QTFfncCy5JgFheRAk1ZYwl/zH5zh8EZGxNxHUpAT0MK8IZ+468pQ8RGIJMnvICiE4m0JWFKtpGQ85HoIyPHsNbFpGUaBBeTqCqf9M7gtafRAehguuciTk4mfhGeEPdXGLEolU1F45mfyJDNbnm/HQdkPoRIbtHHg/6i8KFe/D7Hu0ZlxtJYPIDn5mIatlmqzOdrwpR6dB7N/tluVmeyccIJ7kkXVnUprwigO530ExPH3MEp1MumHb6quudhiuB2nFdpxc5Zbe3k2A1iaj6+65HxfugytTV+3ahWvLjIJg9w9x8J7Tf/a3uZEFgT6oquHPZyDb3wMirhHvftQH+UdoOgMcecD6HAR6V1XrCBSpU4CqNJKAZh+DbnY9HLYLj5eoPvfokfueCjysjRPitJVMn8o7AUxs/YT8afCrlaNGxEMbu4Ybq8s2lSC2anx0IvvHu/+cXbJjeNDIr4HPXhcnBNejqFt/npP66UOKU7Kjyv3i9fZvHLSyiyPn4FZa2Ar2g2YZTjiIZ72yJtvE9xwmC3adMM6Od/hXLve/qgUIoMm+uBCQnR3DYPQWgJcNfFweDuNnGzqIFWkq7qkFkpbKybQyE15RQg6eMT87UFTHMpox2p5+Z0Td5H9g9kPypzbssSrNi85rKBRn9L7J7ljAFlyViubCo79n8YJlSxNMVUa3MOtajdkoX1A8e9sT/szI4aCw10/Rz843bopnl/WgD+qYhZU1um43Bd5ZZuJytkP7QVqIl7cbICEDBYO8kSM1hP7xu24KzRLpmgE+wiUIbRiPq3HBdsfnuC4dqmV6jaZduM5UhwQEZWVO2lMSlQC4dbmMe9n1n9ce0fd2YUseuiBI2s3OVinyiUTDuJVkBAK0DRc0JVysjZEf4JNv9qcieQ7peKY43y2Nwh6dJs4mIJiXeC5Dbxsg8bmzTbJZkwwgIkOVFv2ZOMsfbm9piIa0qvKMC92imWFI6Vz6qnXoVINKbPsI3jP2rweCl+Memlobt4By1CrVx+a7g9Q1FiQepumFrWUPXj1H/Qs6Pj5MmLNWiA5GDVBSd35AjTknaSkOV2K3gktVkOJ6gdOZdgrFf3ky9KD9XnFR0WQNetu4X2QJAyih2gS+HuIfWyRZAUSidtm89aGd+1ApURXVKRVJGJ6dstQCv5ZAgZLzGxI1vDEVYqnqSzCFabY1PmaGCDOR03O/w1jM7jf7EY44vAMfxGBAUrdiVJpI0bA463o70vhA9b9ejeeZKHal/SL8K5UGRSe5hYSAu/P1JQBDe4CCt3V1cM/VYPAvHkPf8B5s/sgVLwyR7nBAw8b7dF2YQ0HDrLfiOQuVZh2akzp30Mr3144c9xA/O+c1MAkq3ilfTMdacJ2PJBI7bUTJa4aYEHNUe2twLWXgFmdL1HvKH8L4S0gzrygFbvc2mylSpPgTy7mJyJiZSDdcK2CbUbU3EjT4pPDunNbNrpCYndKuQmP3OUvlbjmmrbfa5Wq8I+vW3+4N/PaGu6Yltpd85qdpq2n04btc9T8FRygCOHT/lZV5rmMNcgiwnryPcSwXD8BDA5nnofn9LLjZSgIz6Ja866xkr7YFEPBSkAKGvEoVzz1SQ4MIf4+HKthZIvC0x0DYkkgyW8WuxJEepqrdrjN/1pMRldGRmNoABkBrqIiL1k0tbOyRBr670bGNpgTvfROrm0l4R5yt5Lq1oW5AZ6caNiEZaNeg1MaaQl5MTNpYxl4wkPc0Jw8dymP5Frthv69RdBbH+uQa2jDnFJPXznFWwP6f63oJj0TrLLYqi4VelZtb4buXUdTGyNywVQcPhJhHUQdGdC9IiZ4BLw4pK5R3+WsiibXQmBIRg2ddjyEsQYj0Dkirae+TNKG4GU97PZrFqDxryPMPcGhG+8ZqgtnauFSWYWPrXOUKg7esvyAFOhVRJnNE7TOQKhErXdJUQ1p00K0llH9Rw2xh+idZJiIBlkqMSxXWIYjV1b11Z5WJLkceRbHgpbLNRY6c0R5JggidaA+UhVfc+UHrVyVhfMuueA5DjTIaWLlW/PlErlj3NneNKkrzb5YVdj6qDlqexk932/+SBQKl/mFhUaemSrgs/Gh8a8PK2sQ3juv3pAsVly+JBL3fzSUxjo4pAmYECNgkkwQrkmY+hWMzQ1xDWkw2UdY1F4i3wzqxRc6N74bPcJQmHdS0NlojAARTnJ8Dv5SjPbpjJm8eNN64LxLPW8EBrdgIBUYbQBbSbq2ASOB3uaraBbK2lwsoDPUVsI3mrSTpxMyzzZT5nh+GbXPfA7AzScmZ0D9CO4mBryELdC2N+9Gn+uSwwoy9yInGDImjn06mvxlrOHrMB5yxFlCuQVzJC30DtezqEnF2TrqXEpgBUL4loVIx7qHAygTmKLE8lVuqezbLlqGgW+ESf7CuOSlXj5xPLVpaSuzBBoY9JJxZ56XFxhi0lpIiIsix5gWs6ZTWWaPpkXEWIG6Fd5vASLGZEDg/qC6EVsBt1NNVuhDUDgyw69DoJe1Q7SCZrv5zS3ijggGESRmrCRmloEIXaGwMvaF7V/ava+jGFeGaz4XdRByxfflVUfgk0ldemvGY1hOd2cZTPNGW75iWjjQuFoI+w3Xv5YWFyLPtmg/oF9XlNLvTZTapgbp6Gw0B0Pe7AorUZ0XsJM7l6XljGzldGetpSul9dezd3lW4IDTO/UY2RL1hG95A0B4rTpepdogT6NontGRMMHY/U+lOeq6hweboIvoKflkjbGs9dagLY8BIOIk7Z48A/UtsBJSpjIyQkiFyyqdSWz1q/nzI/tJ+iKpqpinBy8TizehpDOYNIoCp5IFrrH9PKtd/x9FvD24CoSgsUAIekUwcM+llae3SQcPSUHVpKMpWTgr82EBvITkfn+sm3HHIdPpXUcbWi8TRFuo0gRXqYoIFp04hEirm89JBW2Pqciv+sUbLk9NtGG07kaHzjnL9FdNOqpkFG7leg0QHI9RTnJL3ioBOXgWgsa6jHE50VIDg8zpZpv/MwLNxQuYkMvNMwzyPxBj4AqvNmhSCveidxDtle+D99QlGDhnrvErusgfInCM5fuRr1ufDoD3vfDjXnPPUHfKdO0Fhzs6nrWm8fbGL2v8n/4Qb+0YkM3abEq2pzBRUmSWhIvLo2zLuY+TeLGe/Vecd3I0+qzq/0be7r8XRpBVQhu4Vi8HBSy9wx65VTL5xQb0S06hFMx0I33OmjaRZ7Lq86HfPWznuCq5uRQO5TXgLnBCmK1U2ruimht2tfVbl9Cok5p3ICUVsfFeG1NDPZgv1+7RykWQ+UJl2UzBceWMztEC+pVZb8FXa4fjA1x3Okw4VvXaggPy1dCTDPcxNbqdcOgmBfAUNaesAx0dv/LL4WO2Q3lNgPpDwYzzNlsoci8GQXMKGZYlgW8LYIPzzWPotM863elxO/myOTC+ffVbt45d6MDPtX18AFv+f76k+0Z31cu/tiAVGpL9ZmeWw/Sv8/IHAraxRYeoA7R8ygEeRYH0jQEFR2B9Smg455PHVwyDeU2sJhQo9Are2fWMkwtZQdIFJRYkn55QZoVZVUeCnRhHtXuk9t6GP81V26EZ9qOUMDSDBzi3caEJD9hSX3EYoof7TJ7SCTJW0Y426K6s7lC/ZmaUGCpqNweY4BhZ/xp2jG8q7FESh9HB1srZxna6xU/1W+2plOGXN/vz83dDpQCw6yeWyy8nVJLkD9nmM50CkxJ11rZysuaPPO5YY3L9zaom787ue2+JrFqlk7lDkftMdT1XUOndXRRuRp9Vns6PyhvOefGsFMiJK0qVbjIRe1/k//CHPtfEgwLGJbWMmtQO94k7NQNb+hjCWMOabMud9whf/hD8p4353s+39dmBsmQgHn1cO5ASuqtfDVHmle8K7JfYSvBLrmrYELfFAy+ucZaqr8BxC04qmRPzuTlfE9F7jrydpdChGYLM7PfLBp9mFUw/McqtQaXwcDD3DHB8v8Qa7XHWTnNMB+p2Ansnvdu1lK4LgaEZrykD3H0jXg3+jLnjKdDLzdqTqAFx9MCo3y6G3XbY1VKjoSUK3RYkJXYr3/1jpZ1ERGrSP87ixn+UpWGYsC9NvSm9lWbMvYtrI7EZFyST78HjCuXnUpuC4NB3y8DaTBpbK5Yi+FNq2NATT66KuroUUNo/Pvb9fB7Q34udrTZzL1xJJbG27cT7IPgnTSDDZBwU3Ii77kDIoy+SLAvZHD2TGxmK4yGKFQz5FFPdiSqzELt/ylH5RL2oNs8V8HiLlzt64Khq/g028xeTxG/v6BikOBYz13eD23djxmPlBLT+uRPOVCVx4tutKlW4zBbo0G2sVxFV7pLbpnxD5tagSCvQ0McYUh1BX5LBuYmL995ULBD4MS7QL4xLMDMjlfO5FdW0xa7N+E5zVdDr8C4lcAlQLoU+W2vIbQ2i8t0ZMbH42BCUusz5+vk0eGWah5GyOKJMo6pVevsvd6XGwutt4w2s18wF90r8/ekIXzvB+ZTfeBDwzyyJ1dNzdTygy/RbfRUKnqUizMlnl4pXyWHPnHrau50c1yMcsOwJKPtd+K9MZ8pjOGgKJfqK2ymE76CMff0nVUnsgsvAKNebNkV5n4MviCD1f3FVLj+36GtgfQ42DVAbXNAXKNzRafUJ9Vu74++g5k2NASiOcP6+rWX7skyIvzLfpS5Fz9W/zqlQNQN9gkZmKXNsi/UJuMu/VWq+e4wNgXXy0Jkb4Rf8V2fghdkNDdPbJ9aIWtUgpwtCSlAZB0VLK+orMHYkMff1rNWEEFFQ2pPPo1ukSpDf87DkS/SCDt0TVxe/yut3srp+k/dMFl8GHxfTIhyB/XkWTm69wMhvctHM0xw1kKrjMmnndng2vigiOnuWYmbi2ICpECDwJF3WCj5dm+X1RZqYtpZv6Jox4RgnqXXKgZ+iYe+LGLgZCutcLUyeStWmz3EIZqp/GSbp/VDSuQmrHBR9/JXjIxCft3AEo0txCv72tHVeGGHNvHrTklW7E8O5nn8k1xlL7GkW64WC0Oi0nyxMiEFai6yEX9Q5ezyrk/EMqbmvY+0cRxLEGMVyqCkGbnUhlUzpyAF7N07cjrIzLMjvKkcOBEjFNWSk2HYKDCX9Mt7cVXhb2J3R3bRSnyyt5RwIiXMXPgIs2sTJXUYBhJpUXNqKVLo12ENLndBuZQ4uHCm4klEu23TF8EVAgjkn6Pa3vsulL7h9qpV71Pq45puFZhngpT3s28dstw6OJq9l7/Bkn7QKuGXXKgaa3mkzSpemupMW0XDmcTTH9Uk/jJN0/rsNEKpcUmhvJ9z0XIini6OfQIcN2rwcRBQPxvzzp3/S1WCueNad7dVryMiwDeAnC4TELqfJuCtcqYiwWoBE4M7KTe/ywQ0Dyfe1CbM8Vh7zTnOHVkJSIFzW3GoNZHW9xc5Y3/3pnhDPCT58vI/1znkIyXOYEQQ8nzfkm6kf/lsRL23YdWiMK2i5AoF3ADYWguBinopnbA1+XLXyU1uUH/eZNqFJ+V3sn267XIQ9dYsU9zAT22AWxi1Hy+c8CvxPPpIZhLwYMCsWJYg7PPumAsBsts0FX2rozdd8sBT+Lm6loWrQlAVkE8UfpxzS/T+JiZMNqY7Ln2RAD9V8xalMGp7WpaAEACwqU1G9b2UvLWGz6qpIQIWNyYw2TRFpBGI84JlO5lIotmjYsN0iwb0MR9aHM4yA20owkqi3k1q3Q6xmr2vNkcIedwRoHk+jqoLVpUSro/48pY1+cM5HqDcsJrMPl4kDJnlatUII/A/1SDuN3eCuEOS6OE8jhM+L1gurPBSmk2k8MO5ckTB5Ysl+91+ZOU1Cw8mFay+ZQ+y9/ghe1Jl8xlUjVPfAsaT7XvX+qpiUmd+LjGJj1eTkyviU/UZmY/1kPESmJsCvSYH9ojX4qLizBObOZ9KoK13GuxR1CJ2UA7SQRWkJ6YjE2WujNX4H8I6yVn4kFAWH7z/Ycsxld9DaxNFL2ydeWUxYLefPSwRczdHkKlICw+jv4XnItc37MT3f2N5xchn+dFba9lhi65g59SNgigzv+wnrZCkK9QotrSXLs9Bx2bcBS0H9Kb3EOFNmbUZqc5AYDAwFF0MxlXta9ahFqCXlU3l2GfeYBETUaefF5gp8RzBeDNuhrHcgV6q5wXzIgI1F3oPEQ2/I1kqRgu7VYMMHL3O4fen+awXhXEHLP1/wv6SDdH8a2G8o27SF1k6KaWZ399e2xh3Qbwbw6I7ZTW4t3J1e3fqcKgI+Z1iTGN6LZSPQDCM//MJ8Xudute9wRO3S7+cNI7MuiCm1Fz5lDFFQzh7UiyoLGwfsIOnziXIzBu9n1AxCPBXFxruFOtNdC+6Hk+ibhYZYrfgqoge9zJSFdMYdFWhHCKBcOT9uYFV2GjoZXsn9VKwDhdEZAeRt7hUd76lWs3IFAs3BKlAXPiNVFWSrlbRCm8x8CS9D3hH0aVxCT1skAyiwujJJZ7sfU17v0LhHwU9TjA6hFwp9yfJMCHFKDjJigAzQ6y2PGeGwSbusrLGas2Z/T+Ipye1CJSNmx19dW1NIfqVMMn2iPMRNxW9ggW6DCpLX4yKvFzxVOHa/aPvzQUcy1n8TMOuc8XKJgUbCVJPUWK9l1MHtmOD5q7IuzHcj3xcAQ0QpNN+mDPDIYGP28rjRxw4PSBSW8B4DYGCnUp4Kt314updCKPRHfnptcfi0rg9OHpYzx+dskzLSUBxbi+FmStEm5YWfk7oSJkMY8F3ZYYbrvm4AFDLOk/j06x2c0y/KFmrYMGm/4YmbVKPVoOGyM0j/YMZkRwYLBg38CxWv14A9FORAbNT4y/Zc0425NyuQAQhHREnGZVWWmDSilvjN/WMaJ7gg8HweZ/TGLPj3uAOpfzmj2jDmWpzW0Dvrdp/tnGJE0Lwf54tBJwMlxNhCJ2k0aCIXqgQQ5vWwUZQvlFZ0wfUrofJydqSsrjg5sINTavMZ92iDTCOG1nAY7YmRthAkE+AlHRgogUYUNBJ15MPyslPjOvmR5fPXvdyu5w7t+tDBoBMbLuMScA0Bk5cYO9e03MRNd1C80wFMWG4De1mVc05PYtpDn9DQU8PwWRqjARNXe0OQwgPca7uXzfrDTsrmuAVc0tsETYHXGNigREgxoXE3p/HcilfX2Kvv+2phbRNjE09P27//qlmPuFS0ICWmmLvtZE0tn43zc8jsvjNqeAYj9fc17mnVMWzNgY4/0QEtzClLFrLIIRL2uwcj/twLyNsraYfI8gnUnhq5Na4A+eTMbI1I3o5rUBWcAs+QcGT6JTBdz62CZeHMG6edvqlaF+iU7g1c50362JxvkbBdhycGnGCw4MN+QuXnJ7LY/k6PLxsTkqeL0Nr3O6Bov+zXXvVljiS5AZNDDrWjvYBPJl7ymlfpwO6kiJy39tMPkeU5WgtYtciClWTAOB1BzxxslyBrGFHGZT7IqyiyUm/jpxNIHd0Qqt05bV27YEL51fP0pkRZj7ep+E80bPwsfNgvi75pUaX9nt5VKUtkr5enB3E6k0xElEnvfsUe02YDgE3vxeqFoHX9SMt2of5nhXQedJ2eiRkQvv7rlTv7/Bgt1b5pv0N2c4E9Elp7PZbyZ4RfctveFhN85usDwva4limLAX5oU1ohsfiWYabaWFzv+/+Fi8XWjaX2Yl44YbdlKtMtcLrkcpdMgYMrEcd+3//kD2BYbS7ScQNuKm/eoBakYP71n9OQvBZYD14Ied3xRHCcepyOpWBeMuCeFPhnFg63GrEokWMeQqjaMESkfQE2vND/cLr5wQusfdlsf+3BXlsRAkJl55ihUEDTtlYV0s/+dhGLSCXu0Bx1OXWSX+hQbmk294qrDP/4J1Pd0d16g9z9C0Gw595ijp3MhmKgCMSnRupR6S8SEu8axRjPRltWkYiq8mg9sFA20U7CEfRPlVfuOzRLMMs3ay2bzQhdupwW9YDzUjzcPeVGKS5wC76fQDNWesDPxD/KMI1GB3u4uK8bxhlAopWQHBHZ01sSivmObVwSwJEn0lT82XS+kZo7/YD8Uqi48DKOR/YxCej6ejDCdwjKkWSivYUOd8wYo2E0KE7UfQ7octTE02UK1UIgJeBzC2ZtTIuzSYX/kkRVVypUSBF1MmYBvOPch9p+D6id3Qn362yjR/tsaBKnshKHvJzL3zM+dqScRSfb8GEBUNTRlJoojnWNHE5TO3j55QTkQ0oZyMASo4nE42cZKUj/foRwegIzQ3w9pFkiBQgvhZ42KTOl76WmIh/TBTw19h67iZcsG35h0o7Iawsz8TzdzMZESRWPGEHGgGKaascfaZBXXRYfQLQxCGemuy6iZ9mVRiL75n3zzeezk9QLxh3ZkNlkSCZZDBERk4akybcSv6nQWHl7VnHHISNVOHmx4eu0bgio9/8I5elA+Hhbe4YhTVGnlI26DWF1andp43H0wzMk7xxAHRXKzPRw19FYn2X1svw7Tz+amZHn+1ixk2hfOQTjPoX/8vRUlKuQpEO3eGdu4H/kqEtk9l2LpwXZMy2TX0Qtqi+Aa6NNtdbwSorUew7UiT+WR4Meb4iUIlmfc/jGpkqRi6QwVjre3g0NJrR/hTbPXuTnPC5B7mYrtg+PInj1Sw/5h7XL6C0IWZ8/nt08MDPLkEIYBQS0fOEjzNlDOXrPcuwqmAA2M/hneIRIyBBN9pLPs/uwlxKFP/I5ZxczUcTavABrV/Nk7JErAht+q3kH9WnZXTJSvWP/WPK0NUewFzyAUe9Ai1G7PZJsITkkvNfLgCh4Jooji+QuL507VDd6/bievlogNQAkySgPKZroJTJl8C72l4LFkOANDjCGvf+bRe+qMxrQ1VZlxBO5JfNNuWIFyILxvPjcazJC+42Imi0u393oS1B+xg+/2T+VuNOQcPYYTYMThulxw/Ul3ALD2Q+J6zyUmd8xHGqUYmvXlMxEIARnYAe+JmSHeouhuZ4zTlbtwXrmgqJKwCVNhlNxckZjWXPRnAfGV1pga782EGNyy8T+SQsjk5MDtvzaWG2UWc4QpKQt2niPJ68dVoENdGxjqvhV8X+PxIUWfQ98Offv0xzdTGyKqJiGhi6A8DpyGu0oWS8mVJTeGPJXnS4J1uyQaHAfRVMyssChFyFnPL5Z6hOLiBMPOkgoumWUONtQm7OXbShy56T0WBdS8i1TQPni9V/N93lVuoLl7UDzjfMpg6sezALSls63clAOXyVQddPFnwz3p+Kk4EKdnVsy6XOsSjtVRU3s9aIoI1Zkfyt1xHDLIeXZEx7gTEnr7wdHV+dzMQYwdzL0KMW0ujWe03NpHSBsisY5U/LiWT6Kc8rJfp3//i39SAQqyoqerZgCDHZB8//bp4E1SY/Lwr+CvddeVa13xzcmG1S3bWHAPynS4090XkQ0o+r1HcvWJLt08L/Th1TiaSsJ7vMN+jAYsygVzFTqPV3aA7WVDJjthbVnCN2Usz8TcR6bfR/txHSpPKETNgirxgtvzRjXZJhaFpZT4gOhOWFeK1kJOaiVSGJ2JXXMkYQBWnwt5cxdSrq2xyxcFHA8hNe+hVCDCEZM03i+GuEk0iMuG3+1Xo9NlRtpbTyHQl8FAe8vnSeiKgBl2KzuhituWgkQFFP074VF3Z66MTHDMX25rKDbb3LEM8vauaRX/ZxAIAhsOA6lmaFDy2VNw6nwMkjOxdpz1kLh7eWTujQMWYCUfrWRpJ6rUyRByDWjKMx8Ps1fM4sW43HuBSA05T4Ivqvv+4w0m+xqrC1AT3hzj39MDJj2PGmgyLBlREwJYawYPjVPK7sjr50LHUWhyAxhEZiEe+QMFp3q6v6PJykoHfGcMvCFY+2CpuJsd3y7PM3jEDkxTlqNvJmlA89cajmp/xEZvyEg2AdUBnVKGglb2+TfA9FtnAbn9cX+A9OG4qa3XYRbVxAo15T13l560hESGA4qkPU6u/5YxrDc1BAGvSd6A9ZSvvXN3riktuuhhhZkH3zrOUCXOVjeICSc2NjvsFUnZBwZV0xl3ulnPMoJ54rnrfqxfvDN+WFWg/Cow9Z4FsW/3MyHO3qCAlLUcopT5ZEx8Wft/rX3gcOogNKp/q1NBnVnt6irb4LaJrKF4MyKcFOJ4zGSftEhHQvfXDH8OihfZI+mzyCRE3onLoOL1IJM4q4JMW82oe5g9AEAblpvfgce5f1awXqiAUywB4R3YjWAyhdyw0A+TpNQC4UuY6OVd859dFhnuX9S3WnkCX8K8Tn+9dSoS/tgrg6BQ3FrexPJsTJlbz7Kg7s4ZLhYkUMJ2IraRB5GMIUHSRmGfIqFA9l5Z60EGQPmwgUXUiRCLf7Q0tpzesTnOy+tm2nol2EB2C4nufP435bOG/0+AoMcp1oBHCXNP54GnQNHJxOHH6QTgA72Qu5YaAfKUe30MghZ8mGRM8UUwCCJ208g5glweFOrQLt5zg/zWTwoNG7Wrh8wdKQiFRhHoqhS3hsMg9g80r3hX4d0IfLRnvGaZ+dNcUNrakWU2J9JSUL+HkahZeExm+XNf3krMLGrhllgfjwQ9GzuKSRADjd8RJ0u8HlW/1lFFE98SI3LCK+WjzQaPMi8wkTNHnzdsthq3b/IDEeIFFai364LKO3guvH2Z5UvWODneJqcthe5Sofltc+iYVx6F5Thj79QALBvxKoBjLC9L7iKwF4ZMau0k9uoCV18hsUg+HnSk1gL4/2Ee1Uzx6mikJ+jU/md+gU96TR3VUYaDM5Ltp9sJzmrQmIGLD1Ahe9iQIs577CxYJGwLgN6GI+G2WxopmqEPb3oRqPblEmgNIpXgLOdgjIGh+w9aoPH3OODihHVECsgufcpWIqlCELKfntkQekvuXTQzLAw0dJQ3xSi8i6B3purjTY7THob2ZOXui7rsKTLMhx752V3HXQZsU5LyF6QG4JAsricFOn/N6ZUBldeU6Xj0B0Eb34syj8uzHHK4aODs08flZkcNss1zKcf7uVQVqEhjHyzcLIaG//jwLyDXdKn/54finGvqdBjQ3UFl5ggO/Ksxk07uuoLIrwevhbM8TCWhYLq68AmE7ic+gbn+gMqJDE4c1w9SHxZKOu5lqGkUaQ1lrLNZhglqHZ5N+9ZwQGuPWp7RnrFnnUHiWsmzMayrBAEcF00Cn8uGaHKjz6iR6iOEiXS0xAAiNhKhUpbRaMSuvq5tGyWyGKhEYkCCVj2dB86Nb2k5iomhQCC1gYuEQVwLwYu2qrdPOo517qRWHl5P4i76FLEI5iAUcq56YAa5KOzTi2aioXia6RhkTS+J465cG4pv+oWQmJhF32+KCjiWIMYrlUFk87bg6wIPIwiCNxwiPQNuqSGg1g6bpGarGypTnJtUl4BLD85AnuMqpJvj9KE8iOQBLsOAd/tdxoNnyDlF7sakjBPk71qEAIxIL1pJ729Af3382MbMKsjRUQ4swu2gI3+3b5crR0fMvmqFg1cRgCMWQ7x4rl8c5iZyz3vmefw7JT5y2OuKYs5/1hMd4ChrT1rr/AzmX6Zmf9ldT1xezbBsANbWxDpG4l5VIVjI2oCQv+Lvcam5VFYpQ7U/gKZiu4AhPjdgscHQMJyV2Pchn4rQ9VgBt4uEIQEHpXOO2pmUcKxivwsBtUdPbETZw5IBlmfy4ZjdcPAj4Wz/9I4j59vGtkvQyWz+gdaZl8ox390v6EDXB0Q66F6Yke8oWqfTCWqjntTiUl7ojRVKmK03MZWxYK8MQ3D5Wt77wUkc52+AR3jbOvsZ4BaI2dM3P821cP0TPMEqpoVytWDpJW89VcfRKqtVwj07XhIio1QZ+lNJO6pUCRg0GQhlrgtzcL882GhWoWa390te3ii9aXEvep0l2ZV7OgWeGPYCJKx2e67v9PotnedHUqJA66evRvLyA8C0KvfOz+5MdeW0mFatOgCOqs31soCk2yOJIrFRzyr0TA43P7F+qm46BkKACRVfGdc8FiH/Xpo3QfiJRmax5/YaRl0uU35vzIOk7geSwyJeiYpmY6R9b+qmBPpdFR5X7xlmyLiSnoz+z/5MCtlHRZo0t4GBKty2uKi/qDY8JJej1/PAUBY9hsv0PFysQiAMM/nC3eholhIqj8trElF6cCgdDlsNSRc4rNV6bZ/+8yC/A4eiWHxOTiYuwj2SC6fLCFetnEoC+6BYEv/DjESffDtqza0ebPpV17HwJfdxWjAx4M/PJyfRZx1/pjiO6IBKUlVDLIbVQFLAVGrTB4Bzq+wix+awE5JXkrOGgFYGlFYn5VXGhE8DE1GWuNLWRkR/uRsIq1smgCHyYGgxQHO/zFwc1BmqXk1gigXhi1zktFJeCElzLUzzLWl/utQevHvez2ItiNDAJD4y1MQoTFDdZ1K2IjRSR59lAt1wQDkFj5gGT+sBtsS60neJY8YvI2M7K7DJqO/316OjqwHeGCooHz8HgjuHa5Y1FEGkjkGjsqYn7lKVCY/nTmUBPIwYL6T0d6tQzBeqGRDXfTsiKI4Sq52miFIt9n7McIFok9UX2aKFVisImtyp9Gm4JB3yn3bGgJRHN+oZGWuXed/Z4mbmQpxd+IuQiDEwg4/IU/HHpSYD/7pOCnLnK3j55WSSJgp59Wsu9+rSdq52uqi0ipFPEm8qhVNsJtAPLBmdubm/vI1s9JlTAMZYXpcWSffWA/eF5GdT1avn5ZABoTWz8oci8FnFOE35sAFovxniy4/g/TD0tRZbmvud1Bz+7Fe0Q2xnqSSgH019wXlR56KS/k0EAWheOjULO1pVRuEPcY6i8ziPJcZlLYcrw5NkqfMaURBx4eLg0A2HNL71VyYme8FWdaluHNSy5sPwC4SDYx7nzsKM/NEA80wXoAXNjUTxRrQYYlyoU6CvsEz39hP8nVAjALGTSY3GH6NKzuVf7mn7GqLB7fmyPMn9LOnIDUHqYfKffkPor58Pj7OXkp6blc/KCBjjZceGFvX8qWpWK4PTYbzSHts5KBdK/y/bTgjlV6wsa7kL0M+34NcLI6np8EAzlfLgC1jATsW397/oPz8MQgIywqn0o71qZ/mKJlCtShs85tSbvxZp9SFh4aY9dU+diXeqxvO80YlODHhGW85fc7Ukk4ZIUdsRQrJc3FucKKGdOkK6uOeRiWzG1G+yFM3yuHgR/Jtqbvq1TJV4T3SYd5MxBMW/QU6Kui3cJwM/3kEg0+RoYzCaLaA25zvVwOxcLoDlkHRPm7FNITcMlumn1GVIcWSs8sDSo7M50CafXRyoKEyPfbu8vL2nbf3UTNMMHmYvSM7/3Jsiy1bn2Sr+BROt9vyU/3zQYRVADFq58em4qzzAMyhLGfcsfNOYuKqIhJxkBd+9p3H8KOjtWQO2uvNnkZR2NZwyQAiNT6lYgz0U7vPXChP5vV+MuzMeWqXXez8jw/NkZlfjA5n/7LjNLuROooTniFXfeK1a/zu2Hph0EA1mpyl6rK/ngadA0bvtJNYC4NQBXuLbKbh6nJ4Ubqlv6wFqw7WXBeGh8AoU6cAM/TZCbJfbIy7HOFbP7Hzp+0Ts0Pv2TMkmbDiYhSjXIVH+5K3qH7IEZhC6g8QLQLXcdeGTZur9ebq5n9YQfsj8bc5pHt9eIQjc7QOIZyCl7QenbXucTmX0IZOfVqvGC13sin2GzCTnFFS/0xmlvMKE7ByT4DmEZCN7EYbaw/qSvs2wlZ2vRgqpfujeWf57I4mHjTR45eJgVkmoehG3g3Jl2X2eKkHBbHSBiEwEDWcw+fxgpxfDqj/gF9ry6WOzYxq3wIFuYiNc76nO5sek9dHeYWIlY1OQlsvsQs9iUok18hsc4obih2m07/Dkv0gf9jI1t9VwjHrJmsQ6jPcGR2VjcShlYy4uPg0fDjVoHV/f8imzSXvBsOIv+C2sL+Sb/WKyV9T/0s2fruddBmP5jPgO94or4C9UUAuDXycI39/r6mBlJVtHdD9KlxxS+FfkIiu/slNnQ0QSMgP9s3G0zG2pk8pAXMxUqI96eGHPIkPDGjzMfAf1e7t3zecaAvfZP+tTM+cBBk9GktpvQvjQHYXXEGowlgexXt/lRg8fE64cenTaAvQJxvf+9tNQW8KpY0UEzNBwQRsGwus7jzSHMmi2HAZUFjqQqpsyxr6czVSjV/DlksnzCyin3TAm44HIMeQ154X4IQ1H1z0ITZA+a9CyzcxxeCLYVL79mt9bhPGXyvvWGm0aWzVadfaQH8pug3b+kZRKI2yxEOMkaQL90/LJnOIDQ16KlG5ZgEQc7K+jzpO610eRNn/LEO1Js3FVel0oT5c9p/hqSq8Lw4vaab/9c/NgZ5Ouz9/YP5DOxOVoNcHr3T9HadQH4XBJa5YmCXxg5ITRD4a3A3lOWBXCHLAY/3meuF34r4oiXqaGU/uEEcVZ6v/LeIuPvY8EwpmF4lxcfEAskEa0TIGj899Ou9IoLBD9vaRKrNcWl8hoF9DF4UDKxSIYsrRP2+dFF7wOOREZgk/bsuvG0O8uk7rXR5E21xtpgS5pO5hFhyGhXB1E1NB+mYQploTGTrjsQTRZMZcp5fL8oufHQWkzwKMzbMALnZsQLZ/qYF0nTS+BU9RTC+cGe5F3J/kUh7jilX1Si06WUCHk56tWiOq8FGI1zwCPJaPJvw0r8iVphoX0zbve7HVIYq4DFdCG2/w5jOgLbKnh7CpL++qtIqNTKFR09X7i7x+DAHZqtrizD8uGT2qtTsk1wR13XRk9NMujrzzTyP6/toVlWACbAiSWsKaQkGpQeTGUzohlE2q4Wlv/daoZPnuuh4aQ+TampVFxoFS8PJU5q+ffg/UqiG9s4wI0ILDUmaiHhClpWaZJ8XlwL2JrKukQ9cgZ4HQ63I/Z/aYdw0/egQENl0aRsSSAlh9X+nHv/TTWF4xsYXb7E7PEJtdTfodONTeMhasGWdbt7UijyVVI2v1+aCjaWQCQsslM/Td5ZUswEnMUFMzfBfTnV1u0Ik9g/4Bb2BwPcCMBGanSxSPzSNa9T3OWI62y1cg5LMEWb8BpFVUenw42QCYf4+pFOD+W66yWA0GuqQsmQ6nDtB5Los778qk7+TSdSoOaoo/Y6BDnAdLI6V2issamZ5qhuKwGAxrNR2dGwqabSTpipliBkaeoKA14eAAg5JXXoMQdj/IznE5+rQ+4XUs7EjlrUPh5Pv/DDfm6hWKYb3/BOiLVPgCiS7AGKpI7njzNwA+95iur6pMV4UGjcHb11UbpG1yPJp4gFtt9pbqY8yB+fQSFV8MNYYNhMoCfRPbXSudcs+6OhRkVA/bcaadboAtQ70yWLFmZmy8DSiDmSqnZJDbiCEhsQAwK/cHYs9uw5P00jUNnJ5rfI2or1nYsQvALSFTcJUvwHD1ZOCcIM2umr0XuMvZvQmU1owkTnRssEQDefQ5W7+/FUejO6Q7Zy+IwSbH4O9j5cRnhWagRyDb3wMirhHvftQH+UdoOgMcecD6HAR6V1XrCBSpVqANZtsBgFG7igii5NM4g3vzbApmlK60tlFGM/+huLEpryjwMUU6T8h6QSDnaBengQVQuSz1JwUAYdWY7M92ksycXg9L3FnTHRzzCkAlXGCFSUju5y0p6vKf3Axb86eU8RnSeNopghfS7c2yQ13zf6fSrl/gPlqyXAoIfbxXY+5wkvaZPdQqccG2OHy4AeBnaM5AFBqM0r+68K53sqC1KOnPrpD0idGKlRNUFnXl52Nl9I06FuPxzeIvS/u7z1EUAGnitHsnZKRC3EYp1axgY98AAEWIe0GqfYj+M7LNqjJe2FoZCzK7ct/eEYMobpmT3hoUFMlQ6oPSgRQynjif5p60/1fGk3nuMSl6bmeHlPFbbuqw7nRuHYwAEWpVzoE3B2gRy7vJkfR3ip/qfqHCmzgRxcLUGgC3FIoiGE37E9/pBwKuYE6/UcLu24lV61lgdH9fgJkJ+9M6zTrNPL0KXdKVmU/dAesRxxHRV/zYa4uN6H6aTlcl4hr/SiIjbtY0GoNzITbl16AndMgTgYV4wqQg+QvqZoeuuOzQ5LzFWrcL1fRCOspymn/2bJDSKMF5fFRHNgyQxaGzYhSMWugcbxqtJHg6WSfR5Zj4dRc5To0s2HIW+C8oicQCqcQgqwF1poj6Ube0tL15nkwsMmzaT1alo4p9Y3TEooTFWrYuBTshLzEPCVaaNOUGgijvOoxm4WWCnZeQTuPJIyjWkdp7wNdD/soOnjcI6BuA/rjEd7CW807fSQXxbuIz2/1utEPCTBwad31mflCDfydpjHaXrZywV41GCyC6cSzUX6eIt/p5QJYaelWCHg9Z33DCcQzjCuPGjDVuylocPvfsGwfJP1X/r9X+mBjI88ZESSgsQTEIVEAW0gK7lbTC64eYTEh/YCbcF8CtvxvrO2KskOdAPQzysIKpQZfA4Fy+/cMdIJaP3TlWe0mqr5oW1Vwta5rQrNwkAdIFssgceHiZe7Ngp6Ep28TyyMLmFQO+jE0Yd8MZvcUqB0ivaNuXbg4JQGz629tWzAW7dWLiJaXUCxClGSBc5RhIu74Y1b2dH5VbpekVXd7yDsBiQFy6sxZxFwH5mc6Jg5UyLibDfXeeY0HFUAzRaNndjQcIAzNbyYdwdu7h2rktFT8R84zYlLhAkIjRfMiXJ6NB7sU6VyIQlOCti5b0rIFL85At6eIJiEKiALaLrSj2OwlJDWAoNqgrodABDjitA4xKRQ2oII0197Z6JIjl4QoNXMU7g4IEYEiadzbmVtyv8BL+s6K+tQSMepljwWaeyC0QzruJww+TsPj7DiLINHS4n6PzJaOKPHSttJd/r0HsVa/IuQ+1nAThAykvKO2Q0sjpbJDXVxjR+w2uSpXkEmu+GDxp+zReJSS3wYWOx7irvRyCKBCreHoWeR4S0tU3R42WfwspgtdGOWJi9/G3k87w4haWZABUMXlYgxsjx6zlDoNqY785HsWYvqS0w4muQNO/JOEiDjeNGbtBpsdR3VhcMayJjInqPNhsrj+FF+ySx2/VBxjyPVI+ZdR2ViQ6CMdkUQ9AN4LhoVbADNBtUF60VRFEj0IvoOKkvZSEXH3fn7L/Td2KxQWMRwCwW11IRIEYyZ2NfBBmfNPcp+jaqC2wWQ0dUiFriJJC3JmBHUUb6YBpUieaiWl61biN0aqgV6F0N7fnM4we4m/iNel98yu2dhTWgRLeJs6XG8825W+223/WMmbPPnx65Jf/vOhx6NIPz1MgxjHEJtpz6PtbqJTQIHem34UsblGsYPllyNzs439hHPnZzGlvVfXAy438UFijvLfyJ8G25TqDZwuIwtgkor7GIWbHfmBnoYA3V5U6OrQ4UOOYk12d2TtcH8nfj5izALILmq1WBrHyQGeLKndgsDFh3Nmcr9F5RuNEfwlOYwgge0xUEH8gzyqiS6fTxsoImnpgKhTxoNUwPAwLD+s3hPVHYdrEsFOUqs1yp9o/m6WxexNd2W8xIwhfCmyEhQbpj8ppR8LdNKgGbxw3d+m8UGnnoljaCQohTPFVcbT4/sEotcglW+T780Q8qQ4Ze/aWFwuPJSlx8g+ZOTvnes+9HJG38yYwchoiq6KieyB88fgAvbHm46QZfzKlVNZs13wzQSrVrXq6vVQF4C2WtGDmZBtxNLYGjm+BYTdiikDL9U3RrZrH1vD6of248CWUt91p8A+mmbUnH3cBp0wl2qxcMeV85/tW0yBTBKBbmWA4dGfIkOlciDVJOcXh1g4CzfUSeLrZtIc92jWZhwbYbpx8wx/BhLqLBpBNT4Bhzm3KkVDzUixKKVwSHxiBvBaFeInjVvJ6d0Gc5Y2doZp+21SeDJWJCeI6MNOKe401nnBCqep8NZZympoFuQtH0pz4ThLemy8mB3Aleg3Z2JWJBJakQHk7zr3MvbVa2hik6NOAhdHaBwmmtm8eg2Hq0TOfkZgCarmxX/b96YcLaxu6YmAKsVmItUIutXAmHjkKBdeKGwhcerIUiXzh4C5V1sJJ4zPUdNyZ7+lz/XauQjj1HxzZM+DN1VLzAnufY4gpLG+VUAFB8gPhlm7GreT3qdhsMYQuXl8oOtVx9MnXoo5xMM6YGZwL6lbfWeyCol2pHKmQJttuRbiIlUDIu0gwmsSayDdIYm2JMi9cgrF2xxAYO/fl0lBWy346IdOdQOe1AiQkwSOE9eaWgyK/TnWiZxRq9ZOsDKiEJSiGmYD/Fw8ajcTtzHGoRhYP1QMm3Of+1LXQV3YMsPCImd+9egCvJISpwX97uvPgN+UV8ja89wtDv+OfGm4HdN6mpeM4rpFGQj3w5Z6/e/zJClx4oeYzbpSjw5h/7CKSa6bBfDr8e7O8CKirmPUX0bNP4Uaui9YuqIMFauGYulaVXWHaz8vqnZ+Ov2yLlDMzWn+ehk1EuO5/EgcoriXlbsEbyyZx5pzZ3HXBS+9xGbicU2EFLjcrfy5Jaoqyf7AGi70/Qv/wxneAQMeVt0QM9Z/8X7KdR+D5AJmc1RGog/jSE4wdgKKCBrHyQA7Qa3f55YO8G9NH8ZWdxIbNBVJ20NC7Si8RD1fezbk0ZiKfvMxbmO3t3vzW9+52n0Fz4gj71xhCLk7p2ipb+YRg/N5FqhXSgz0TZ7CpTeWHVsrS9YxroHIiAYooJiBlm4d+48znyIzLEk+XHNXLFiG2Bhgg7zBDNcfYzrJ+WbotYaMHIZH0BcXNw5p7K5FDc26+aSULV1aYJ5RYiE+nbxVmhkGq/W5UbEkhAYu9DtbU+eEasRhoO7XNtGp/DbjoUyt2LolQqljyox9LLQ9/bDr/cTCnrWWrcOjNCdMRDP6LUGjvQnYbihzNKKhr/j7q7UN1A1N8nm49qz7V7HZCMYtrsiScvaV8oKuJ6YaYSOee3HcyDpO4HksMiXo8gT+wosFIDjZBeEw6FwCULfK+gTj/yOFBW62H/4nSRlad+PYjsMMEUy7tRFzKA82LXKgaa3mky/1rbfAal83nf3afbCc5q0JiBkRH+g5mC1Y8zUMu9281OXm1fZnpzNRXdvKSbdIzCJAFDV2lco08Xo7mJhcUBmdcpx5Kolbp7EApKsJPSZKX7010AjLpwCyshhezvtMxhLVnsbO1prMCJXQGEES02bd6tNj9DWHYf6FAy+zdfhwAvtb8cXydlYk0gw8veBsQSU7UbI2DSUfUaEIj/kE3mmH4bH9tUg/Y5PtlMDZu4rYRo4eL+ROwYbs9k9V+/wVLkNE+lEXS5oVZl1idXAlVIqgHlwIoQfDz1HLsXpyp2dvcfPKsL96KnEkaQCe/b+3/pTBQf/xXDgh43Qj8sKtCKvJgvmiLmKLoXv1FdeC7+6m4muV2wV4zWcMlFm+qyYPMl2HgpM0IsD+rFHGxWEs/407RjfVXTiCl5V6AX5XybJMkkkna0BW2wRAas5pRQSmHYElH2fGgnWAd/v47uTWPgSrF+lCeRHIAl2G8GoxPJtzxXQkhEg2+yasUnpqVYxNByC+yL4mhAcE9wA+z64ZSD+7mIwbvURuDHRISnTickCjnEtKspIrvQv3C3LRnjC03xkoOhmf68nT5E0AvlJSHEpcaJSOQu1vsT5oDv/93tg5QduhWZ2oH3CU4lLfx+dNQFwFue1srM5UI9JTVrmzbKSceLCjGv7ubUdr9atHAU1/OKB3kQapdQqbCbPIJETeidQtWC6Kx5xkMnlQ1KAx+m8Gs4Svd1A/G/POoWtGU2t+VYK0Q35UDAzXj9hA76Gv4v/MflgtrqoWto0uNK0agO3elLnxT/JRp6UpcDAlPyykj/gU1s3g1DPgGVDArF4ruz5SOEXMCcF8z2yrA9P/VpU7F1cFVkIjTJMs1nG9VhW5/7ekgjc8m1R9DQICEe4ww3jDalkW9xyTqQ+JwASdj7ESnbMTMRFi3aH6bI63+dov3D53HUv1OzZsmy3rjLUHZUBAxXh4xtyNkbfokaqqO7DQfj0iE68ecNNSxUsN4uN1hM1pHW/1W/AV1D9Xlp2Bj6LyEtdTIiTcmgStjLZ/2J9R8aWMhVkd1I0vKN2hOS31OvRfi66F0yOQOsKQCp8LuQUIqXKdTHygHDMHhCOolbWIr2/6m4mHLmpHOSxoxEhvPVerw9p90DxL1dK1g6QpztGTr79KyC3QU3RcwJDn6fd0zMdkRtZsAYpHicwVt/Wf/pIKic5sg8f19CmAtXsTpg2qvz0qrl12Zhix6ZxziSRrI+b+Trvm/0/4Ov2n+buZASh2VjN3XBEF2WUVi1LKm/M2xlqEPYMG15utq4gUbJyZBkmR/3qyiaoWL2Yh78hhnQIg+xe8LBPoPiF/QA/oV4nP96/aO7EN0HpRpFU0ZaOctNC5kg/HK+WvIRDaVZ8INY50dVgk7Uk9uGnL76GP1HyyyxY2HGbvSnCD/M8Stnaaa0Qp4h60xjZku7gfmyO81ZQAYwSrt6YjnFhrkkacUgkfjvv0mLB0puFEy0bIA3IOq5LzD3e20ZFw/o2nT/QvYWNdZxeg1/m3W8Zy4ltC536M2rpwZHogYm4UxePlhzN+lCJwVgZViQyxYLCHmzXAJoP4refuMEj9X3Owv+CtsvKW7dwi/Xxrz6SGx09f+xrVhCrziK3yzknIob6/1VMSk0qVr+ranxAn8cNy8CsSiYEbeJIcZUA/bdPWgISuk2KHzYo9pyIQxVzFs29vJsBg+VVVE7VngQYCHJf/VDP9kUliSG6m5iaGks33aVcJqx/MT7YUkkIkG32v3k0f2jPrk3iYZmUCwjhh3LiAV1PWKCpBmDG6BR/fpgGvYJ5LQ389uLAUmP6LR5/o3Vr7nG5EK21lFhgBzjntlz7UXYqxRCpHwiWMbW21/CfvT+L+DWCjmEjbZZ+1ToF9Bbt7NI0yqYlzCu7Z8jYPatWzR+1rFhM6PuQCZ5bW6GY55v5AREMLlRL6yXSKWk4SOQeP06x+EMgAkfTFs/gm0cS2Oh2O1eA8Kgtf74FD4k2J1Vo2lMyYnGjsXXijTJrHkOnX64GInLOyFJxlCD6lkWdegzQ4KK4WKIMVvhI04BrllfyCTxMlqWG3COwbE2dESYhkavqNySXOxUKqKax6139jqpXMAY42lo/4OUUSjdrtdgIQBh0ACMe6MxSHEUngTbJwtdbfzLUhtRvCFeYibGnrdtc0By4AOcBWRLNksjnJXY2ocw6PenbVh2suC8NDz5c7w1ZVzt3pX6NiKtP710rHHVytbWYxQJ/D7dG3AIfTHz8voyp9oA8RR8t0zeOJR3HDYyi3SStEIkMgjPqIAJ4domA7A/A/R82x6WXb9CxkqLOXbX2W566YIV7Bb12I0EbDoaIBeK1hTkKaJe5jm5oOyDJzUOUkyLHlquiTGW2Sr9XPtYeHKXn3XnOEKd+GolTrAkKWUA/0peIfgbFDzYqJdK2R52Vr9QmWHEC5Ihhr6mBlJVt6ir3Yq/gxY3GqGbNzz0v/ZPMN0g8ZkOyGdnytA6+/cifq//IoP0RNm3rFLVYTsbAHrL5dDUw6wESgLfYZ2JdiZwvk0vE601cxisJ+G+2GePzK4r12ytkushm3pIAj23Hg1s4ubaS5CXYcko31XeJ1REzxFEDIEifBWW2jsRhW4dc/F8+ymREI+x69pIZyvQ2DL+BNGkNuxRo0QyOfWgvJrDcTk/V6yybFOA/7/gy+OgE9E5c8m6dTOER/GxG4c1IRPFcjoo7RmmJbh7yN3GRdFI4c2aXu7MQ2LenPaoCw2g3JRpo8cvEwKyTUPQj7E72Ct1cugeW+YYauYxoLJ98HwHccIOP+13ZwjKzTJqVX9vgHI54uEH6P1UMwLqKCC10VzIGdyb5fRJFvNaQ39jE5xX5Q1/Mv/bEiJSDSwPGwSIg4L33ENWgRG2z9e8X7vPU/rt6WoZ0LLhAAVatmrIxMCEeJ4qG+tA1COpkBN27WE/dhZRAxd+tz0swo7/kJj06PQuf5brqzkc6Sbtb1mSUkS/qJ12N1uceTBZnbUPA0HmaohK6DbFRjDI55PVZnAI7YFRNBy1FKjlHuRoh5JMMYjXPALINX7oup1HzMfImOih3V5EnEaB0pr1MRhfoQWf8q9vWjXaVm9UeDyfIRZwAORfDuJldy5Ph5J9EXBelqIp4412lXC+7tdijOuACx8NH2GTPXNBoSwkrxCKcLtfUHbPD9RzrQLx3kb2fQFB4S64lNlCBBJjQXK0+3SboTwxpVxKQQ5jX3X93Sy/d0ihqAS+kxL9OXktO7xE8IsTwLUPHJ4GByTEJ9VjJ97DJfTBBS2nG75ENibaivG/o5sdaoC4waIdZuD0EZmh8n6MEEuvbu2eaoQnBDIBIR6Arsk85LSLg710Zn/4TYyaCOTxJBZZew3xD348E2lP1AG0fTh9gJtKU8dA1o240fAF03gnxQJQhVeQ6gtJSMRdrO44uOjfTl4nuMKQCHF6by5rBM8gmNuHUEpUDRaeMe57KSE/Kd7jnFwhHvSHowwLIMCdCPRfDJXHvqCCsPp2UIfSWd8eJwtC2CQWgP1zMTQvfNETRjNwsw8jlXGt9KkQGq+RmjnpxurroydY3zYGaywy/IBmMFF0sR6cxX+LcnO704kVOj0aciHqHxcaIQ00393A9hYQM+q+Udyui6dK7ueOVcjVoeBDhcKd+9AM4IeTkXJF9jtPadBo+BST/XnI2IvXhfJM42ANOJZackHXzQKjoSvZjYm0c9GUvS5sSF28Kk+OPvc7NCn0BAH0xw3z40lK/YJO5B57ZaPaMhsE5WK4B/w4WTEW0fqPLJssJaPZPtfQlv1k8HN6Tnmec2m3lJuQUM+hcfIvyIjPrm+qivzrjaQapU/YdWfjdgjN1hHKs/o948wdTtHURmBdfZQ+xyqYDnaSugpS5zWvp5L18nfztkxkV+iHWs6huZ4zTjnzrLxuzCkUmdPrlrkOiPwx+pKd3A6sIqMayJVP1LlIFy6yAl5FKeq2cW+rv2kUg7flcARGzefIhD8cacY8WmiXNidEOdzsttthoFLP0kKYI+fb5nLY8BBqyIKuMfARyXWK7JYO94XAGSAfNFU8YdEzcqOS3Xrd2IzCdenyUYc28zMko5zIs8aCUOGZUGvb6b7C/JKL/SoS/10rJ5LE5+gJcj8U7+Ts3dKPm8FZr0E1c8ic6jHUvlfBrWI29cSjsYMrt0l4+MVGlJVL36ShmoA64vLlQmUuCXLFTE3b1HpNMcyk7xDpruNZrLaV+f1pnYK6T80aOBE6NB0AoZc4f+OgV/PM5+HKoNiY2p9M69Q0jEnb8uBiLoxciQ81APRhUGlJHeVSiToLAvCRJYMwk125da2ge/6ROIFZTvJ2lB5Y4c/Ng9CzJLkYYUic256sP+S/GpUsE2HV50O1ewNCZBSymsC57KmHpzn7ccLAracGJT6SvXJ3u1wM7lrXDIiREbPe5q/P3DISlI8m6SPHUQ08U/6Z8GijHs5l1Lk20vqGjDbQMF2FCa7xoGONPHGGSIlcNHpVk3YmpG99+kmqsyV7xR50MgeVWlFoIJr63iMvt1ZeW4QdpD3EUO9btTf7hS98pqct9at+7FYu4UCrbW6XWqxdAF7VMcxTR2mAcWnpS053LmYxdfQMFXxtj0n9XsCW7urmOaiLTFIkAs6NDdyujwMfqToOzMjC9Ynt0WdjDq9y7WNpywqFok+IX7c9lTD05z9p9QdRF0V/vVWB6dTHP6KRTuSUUwXbmSEgAPUSiYcH7DGfkzblXGM/yPCbRzvSm1e0QPudpOYHabRsq6d4iraPT8GHlUe8rSTl1nzJGzQRoZawYuQEAHVz41iM/8SmBzgSlaQamPM5YhdA0CPSuq9nfO2GjPxsqtSYHwpQfoarvrWarlP9bsqEM7fBoUuFBlLmCQCODYVzoNPWEZpNQRj0+D34S/xRr8CkJNV1oP1tYlvJCFG4cxnAHR7UAmNVk4Yf/FAhU7GC5oCb69qBHpXVggIaG2H43Pc5GHrexciuLYZKb+MyvHPwCkdp+0+ynRmouHxFDFqEaqFe6GaR+XyE9cuUjE2vtM0IFxXwdTbvBXq17TwY/vJzylE+X/bY5/NuKasyyb81UT/ONinVqqUBjA9XXQrnjwEHF0z5c6EdrIrZoFKc5/Tdwj1kkEKgUCTGzusOlbn0NufrorB0pCFRwlcMqJCEvXLkU+hF0txyS+Wm7VY1ZjTSLXDtz6zJ3edBmaM8TXUhN8HFrKuLXXLUieITwLrawqhz2SsOEFncEkUdz4d22x7kWHxzoa/jxW4ZpX0LNcr4RXr9rj9yEZBNvTzrKGZATgt80sGKD9QD/JkCU52VMLzuvCHDi5mvKHM2rpGunHIbjhbz6gSguWtGoQh154HOo7jjK24J2s6/8is0hF5pMCQLTWf4TRG2eoGkZo5/lsKRNKeBJJFccQn/fxM0hfmVSTeX6EuzZrDQOOUFKJF/nYlTRVVAttxLZCqnqoCS363O5FBjyiHS0Yx+kEs5ubfNmAV49zrfgmiJAZKnJ2Se4imlmnoK1C0bhw9dTe17WZCVSFX9UHlx+HHKTLBFyJ6YPGYbi4QY4LIB7kQGWnVgIBCysyvSkiq5PhqEXee/0PDwX08aTZsUUK1kCVJPpCpma7ViDbTLiivMRmhg5YXlBh7I7IYQaDdok/+I3AxS+9W+JoUtZ4Gzwef0HWyaoQcGvxN0DKtty4sM+1X1jMofRG2QdkzL71eTJgLwv0u3kv5A9aqAkkyq7BrSM3/6g5+U5WmOQxJ6xZUYPO7h258OYBkaVxX3b7XkRfBKsRjsovxuksmQH3H0YB1GpHVzxa7eCRavgtaCdsDyIweDV+CukFOjgSC50cIylMpjG47ra75kV77Q1xDsDXdP/+O8Ed7pUD7pVsj7ESkNrKAR5vpy6RANGF0WAGkvTZRGgX+ChThDYJ4wgX0PrujzL2uuPeINyHe2lYXzcfnwHH7uk0gcoewUUWffgjf6i+Ig3u0IHpdWCJq/QnlDmQjZJF+22n0P8kj5j3tkP7UMxQG26IPmoqatp98T/2iCWoVh3ln9UCGZYenE5eHkvH3AiH2xDRl3nlazIEcwCQBq1pLviaDcDpuHppQZopL6MM3wqLBZ0BPj5qg3uUrr0+EfyDIXcbU7amRz9IgYX2IjuO9vL8r24Q4pfRDygn9ThVxt3vM2YJEm7H0L3zvIOXVuKHooJN1mrU8fNHE0VbWsXZGiRmu7IulGX4Fkb2iAdciBd2CTJ05qlTF+j1avrREt6jIQyv9LkcdQdNCr/oiP/piYZpGPBCVNYWyQcI3qTjSXtyNYNeEZJtcjaqzKw0CbWi+m99qA+7R6PTJhaOgGyWJo+YnD4N37VrU5qFyXx4AYu265jV8cSnxQRBOQJnLRI1PoT9GzjlQJiACliNbgpgARyKU39LuF1YSVbHXvTBZY2Nl0gKzgoWEgUzFoZVWdrwrGGkqzH7OcaV7dDs+ozrWvEHe84sIzAiIgz7madxIC5ccn7NjrYvB2BtHHZZ0lukvE/Dn3JpfmaM0OfEcYmZWTqDbXfY9F1+YFN3Jyb1LrSbxaVCKJN/6skZANYngGuWsnTfxxlgem5ZnefK2oAAx6MEP7KbDo0YSEN0/q++AvjvJeZ7A6gfsqASxetyzjeAgdCRW4LhTfY93MEH9gE6K5dnL8zZH5Jb71Y4NiFSXjWbG/y/g8ldFni+c90CJvEjOFgAcoj/jN2I3BhK7OxMcxX8wVVfJ5yAt3g2Zomoxt8IltspeKks5KTPtU2yaYGHZrlBxv62Pd+N5ZfgcTNXFvnGVsRLnGxi5lsdh45PLY84h/mrVpY2ph6B82LpdsKhT9qOpT/odX4MXksbOnFlnDmNYNreHccm7Krkn6/wJcqxbH56i9l857gRWgtuHWCmAB3OHsjT98v+REN4p0boez08KGGwuU2VX7EeMaOmICyl02Ka0ER6erkfCjpxT2HRmEhIQ4Qtc+NOx36o6f8SINwJbPfHkuSAVKSRjgZ5mUyYa91ybkEDSgm3/O5Lm+DiZsSwCJef01nx9MRTqZO66hImj6e5wUYl1y+pcOxRUHv6dfM7XdxeK99tcOs6FJzogf9cjkzcbBE71eK/qqw/UfVNNOC9Yj0R5ab7Z2x+ydhnWGqKBNPWoix+eHA5Jw+0Q5EHq/AmHeh1092yjJHbPgUFBkMRLwzJcjl0wnKJ+k/9zrIUZ6Vcu3p4PYLZAXa1Sb1+WqGnkiA37ng8ww1bl65CWB7QXqdaAgcoELEofapz5lo9BvRNHjeffAk+jxq834vX886FyDpqDLyLikg8QGMKeY6MpANq5mnhvTcMQyaw/UhXTDTiXDjk4RM6g5StSMEX3jhpEi3a9uiA1psdyYoAYqEZ1lNILY6DO0ip9dIki+64wEYzhK28vje8TGdgB6StVN2nSL+vRQiqnjxdnUq1F5GbNnJXjC/3R3TIV4f6edZNafJffQqX34Qf1C4K41XgS5CE9iVb515IF7MzayoCs2ivA24KP4tqLquz0AjGCp44GT86vZBt8eJ81GO7Q9NXUZhbsdgtUzRFgeEmo1GXxtdfQDgl2k8aEBy1gZXHMWQ61McYpP6/Y34L1+IMB+NyL8lK5HwpSm26evp4s91s1SSRmRAElsEC3of0J+gT/w1s6QlFQxQnWZqsOTzsFIwuQFu8HWSjm9FkDOljSMpowyCRIGqIQy06k8p5ZVjyRKO801Qev0w+GTsYV4QVRIhZd/StCxAbIctylJVm2kAutREFh3tij2a6LYsuoRu7IZfXhGXjZemphdfirXj+e/xHqjUXP+wmCKRZp6wPcCMBGgyYylLErHAYtWfjPlS+5zmHmLDawb5fQYYJq1N+quu4xOwPvLbxALbce03RMEpD/OQUfoAHGCUiOpAxyKPPskeH3QyKPk1AEQxeJzckON/Ga/qhQTGKpE1xNaWAoRvc1G3kg73rDZFnq2ktHcjR7nHBAsbvCqNcl3Ow6TcYRZnTL/7iuIAZyzyPFUKXWESM3+fhx2wdrFoEkeD0Mmfp6m38i250hqM19dmzTejVd4gWa/J1mM36ioGnGdqNOadV+p0kCrWzfvqFYCFaUwM9m0NSIrloSGp4zmieMunUM3Jxsj4xrUJZu3sD1StKtRHaAbUCaZnaSxOFSjBEWhIZPG9hCh/v6o1zSSIyg90/IHWmiqg2aLm/0cXOy7sZzBSDo01tmxl3IytSMw2a1zKNisILs+Gf35FTbr9cJB73L4gRBWmiv9nwUPyAxnkSJfX3Eb8oJmeORQDNdqkRM043WYPxWNdtmE2JLXWWIqT+Gz2S18Brlh1BNqe/RtZvgoYoBNXK0gM3Bg2bmAUPg6c+KxEEA2OuIQLemU5DYYaYS4+OMMiUdtr8g+mIrjYqK9oZqmwBzziGICXmQpaLGgozV9+VN5zbFZy70rv9G4ylCHPqqd3M4mHGQer+LA8tScuBPH/+x2t0HiwE8ncjHDSWdXsabZEEY9jAjGGMhGjC6dmg67fqn6mPTJY8/KTtA/DvO3OA1+l1EFyXJVxirzR2iTbSLScUZRSRiznGlOXssNXNYIS/icY7EAw2Uv6zEkpL1v52eXmZxQUfqAVee06kJ/YabyhB/nXDQwW0899TNyMGUfqbjHo6xlI7QzSVcdZtzsnhiRXUBgIg39Yn05DbPoHMLgEZW06MERJoIlGPGgoZv/dUCsSEwEql/E2vqr4TbDbr/PUZXvCc+ZPO7TG/4ck+tXHXGMetZTkh9hYciiMmyLi1ubASv1gHxjy1tQjSYvIdxtfjZST0a4hRsyicEdSmA+WJov9sBMVbuv7vBwLgbS3kSCvCVB0ypYHgXEz7SND+MzsuB9CsBorwsAbrtTkhcjlcQHnFc+1EVwzTKpaS9I2z8B6N+u3I7gM/Xu8rneqGY4dco+f1NWcmViIUDYdjNpEB+UVLuzVDezWX7HxhQ9GP6CV96FeJOu/XUxiUcZ9wqAwCocYqXEIAsk/NrO6pBryUZcxmkxXSLsG+AkGa7mEPfMJ4wamHpPEjHOVtHjMpSJP2k67e3+xU6F/ogTv7NB3LBtOfB3j17C7AWEYsu9zYzDFPIoLgwuJkFX+CUjs3hoVXKD3Seqr/SWr6091Bb/GNm0m0lFW/R9qqvJoFrDKv/SjasvilY284CPYK1BY4SnJqeVsxX2TGMPFPXrdtuKg2dMr3tc7S8lpnnKbFkLaCZu9QaltA0XEDBMjM39bIf72JgClF9z8OxRQ9m609h4/t4wH9vwS6O5atDPcQR5POQFu8HTxRY0A0mfvo+KxUT5teDFgfNeid36D+hSkWn3QC3NMao1zQSPbuMvT8k09P41dcoAwAXMp/sPJgYzfFCY8CGEfvozJFHbJS5jkOH5EBHklI/jbU6k1DtRFobqKOYSR1qvUmCYSRmulMD+/fuZJtod25XqEs7giTmphmDCKuHTC2/tPxlRKsd5ADFG0juBwl30qdVFJxCZo/GhaBlQwyvm2TasO7AUxV/Fk0BD/rqUjvW3ypDLqNRQxteAa/8AnYrOLMdO6Y/wtkIt8G2l9EjnTH6Ax9WENjZyTTMIYOvX4OnxrezyKO/RL6c4BHMBCItWLW0BfbnKq47CswTfopysTMU80CgMAeGhKMsYrq+/hhbgm6nARP/qSjBfsLvz04wydFgQOv2mu3CTyAt3eYuUW3VejXkqrpPbgFiI21gS09IrIas0VxRFEZyUodVQlY2ELdYEQWFcnakqqAO3UHZn9GBaQWUdgn/IdC9B+4/Xyl9tKR7gfDbCOa9HS4HmB+Ia/QxnEk4Sv4kYh9Q8UMNX8+F2OZYBheGobnU6iCaz7tHvpGIaptla2yNuYq4IaVsTk7pJfaETJEIxmPYhO1H4daTd/CJi7b6SNreOftIdwIlYtAeHPU99wmBhqwo8P2dKEWUp7TrEXewM3UPasXdzMus4Y3zaR0gB94Q5ZbSaxL3POq6mip8h+miPoly69tGZTmvFs5xiAzoEMYFzxaGiXhRJvCdf1JzJxt3GKyKgG+8FT7qaLfyLEzftll81GUESCPlgzNGQ4+hmkQyJOSS9B7Ggz+FMe/vYsrWmboogAaTbK/xfF1fRX8XDyqZyOguvzzSUhC3VeY6i2wmgERV7UV8yGjQExRhOc9rEgcOE2CefFF1pLRVxcXt/kbzy+SKCTknMnPZVW6BOuPQf4jMExyMqy8iXlvvZ0fsPzmpWkIRRgSUa2WrmMM4UIGLjyugqXK2T5m3cwV57Q7PyUOe4pYn8nbNIX0tbIHsdf1HUZK5tziDRgWrq0RZeLzWdTtAZ4gynBCWfdDnOjXe4yxA0quIxCg5QlRq08gYkt4qePJpuQTuUU9+E6il3htLi0k+7tJhSkb9V0vr2444BOUTzHmZkSNFb3pGgnMmDTveJ0pDlOcb21pXg7sV4aOvyt7c9EI0BPUXdWMjetGotrARsOWsjbJ4Aw7lhmtxZ74/T1bjueykgAsA6eRupH5FzH+s3CB6QFII69ccTzYW/FdvKNqkvd//l3aiyM+nLbNeU0AwHzwUf9vol8aZ9jKh7wSJWVglffNdEkfZoy0tLfLO3MwyEvXmJsmJcLcPTeKl1CanbKRC/W6jn1SHTeIE5XaJnVa/NyBD6MvOJX4g1J3v5Nl39+g7M7qB7wOLn44ADBe6OI9vk3d9g2t94q2lICRhw6NTU7IZ5/G1T6A3P6bQThzPpbe+xEzFGx655RY9l6KNJX1cSsXnvRyQYpovhkw6wDn8fDbWcSJDTA7gSvQbs7E8PCzO6fSuo418ur9phdwxNsogZK+agXC0Oi8188KcFly1eW75IL+BMLL1BZPeqEeLBgIareVLchDpk7ebBAUMSWGQTaKFhc+AZUY/WLcidfWRsk3ZYt2g9UK/hvzgkaM2ZkDHujrQq0f1ot8ulxkwhd2nNkgO57BASjBwz13FslRrhgFeap0/y6CkjlRKwqa0ERysajiWqE3ghoMxTwdYJNgTb30XR78EUE18mW+Iji+rs4RK3ZP5kmdJ1tkKqekpRlDLBqsjkgxTRbNXcHKM1O9zyOL4qNS+CGpsB+qsBSklr1hHj1okdsiHT7tXQHo4Z6RPFenWMVNqvsG2ym1cQDRDtpPnXWqw0kdNAFv5Ct0VgyC68UM3IFzkuNL9VDeHDCVMlSU1Ei29hEfyDTu+sz+TT79srdELwGOde05GqsYNs5+boa86w9KpHaGY1S4blaK/Bd8K6SQSNJY7gpE911fI6SI+d1jWLg4zfCxXwQzWRzTiS+MqBr8xTSF+z5GCMHWHStz6G3P11t17L8O846Ja0QvfnEqXRCh7BEZnWgmQgLSqJrRSUPDCikAjmx9/oNXMUawjyq3aOByHie7yohQOv+DD/k/xfX4cA4s+OdySDQRyRvsQvAkP1jHgyq5ozwQzM/OebPmG9WlYR2IG+Czt1y8cyL8drRhg2RCsj5kUOgbeD1VxyMT2nWXHAN3hZ+R4htHbktO3NB9OHuQ85Zr7k+m4PVYOsTwmYaWMvX3JIa+vZpmyeheogNBQ6Ko/KJ0X1T8HEm0jrPtpGvBdZsSlC/EoOZDB9S8PBfTxpNmdXKj7UJW4An2MYRSoxRyUGFPEAo+5iMEvUJGVQObgo9ptRkheGgPJT1aoJjGn3v5y4Lg2me9mfp79/0WybHxAWzJNa3TeZGluOheNWXl/mZ0GgsXWIkR+PWQK4wjKi4KunHV9ZKTwU3ugeU4zLhmGc4yyi6VwJWUkf8a0clcZxC9rJOGOOezTHPDBz3R5BavrrpqGo87Mo2iGr9Uq4lIfqmPSNQKVBcdt1Ydj/ye5B6Y5uinHsLqiDGPIlYJOTzo0HiwHWUySv2TiDkfdvfqkpnMYL2xqCdjridxyjEw12/oYtmhUMtkDcfg5sg8f7ZO33CFMsgUPRlSgS0Hy+zrOjky/MDqbcnclIK7PE4yT9xqz938yejUMIl2nUk2KJ6Zx3AMhWgxgPzl0IZ7l/VVd7U+0kXBL1ugUuLyw6+Ey3j8VcSKGANu0uKDOv2n+EEl40RIM8wP/bhi2833ELepZmCqDXfIEWK2x1XANwmEY4CtiSH2UWwEhi3X8XEWl3q3zl0XXy3f4W+9qiglaFcBp3980A6UUrK4PnswqtRBLchZsLtd7Hs5Fa4CDFT5ojH26lgQg9vkzNCBSO3WomgXhKup8fwbo+hgzcoQCg5zGU+OrYOevsRSDpCssm328cSnVPL81gJyHhmL40GxzKytcHe97Nndo2xFSnD5GCKOvlFrWp/9sgjvZZHq2JNGqUhuGZuhc2MRQg0EVMfgTJA1ybrR5X1ENJnkv2vasD3salLyKNm1KzNuN60PApqQ6pk4EkytXVWnsgsapn8IBKGmMvZ96Rltr3QYwKXDxsW00rl7VdfCtATlma5KPO/liOyjVBn6UjZcqsF89ncCsaQEZDzdzsPuP4paF68kbLHuSQDqy242jfuOP8J5TL2hSUmmrNyeog+i2Yr2r5Tm5tN9//hvEI630lvOgtpS4lV17Ht8mZJauqI4BQiCLzR8ju133gBpMcbmDVxue7mQjeCBXjijD9NdwPozpTIzvd8MlyJNDxcPoNMX1ZWFjC3mrkBZ2UDFYkV9pSwO45hRE0anqKiNHptnUvfsumyOVXaR9+9GbguS38lmkiZQRmmIIxcVfTaVf5aXLykp1EodJjEAUP+8y42K3sYVwnQFmrNgluQxjwu/6knkvRpcxf9fAD12rktFUxVXpY7oGOFyBfyRTepfB5Q9KUBdCTk/aUkGlh4swoK/mu9iPC9hy/t9/Lmh87JUwRbq7unrX036ss9aB+GeA8WppruI7YCm418qkgR2SLsqIbxj29esodiUe5mIEvTTADECneJsNWJIH7KRq5BHBvPjEFXn9SMleRn+DthRJZfzuH00RxWI4tOgDIG+ExE6Q+RL0Za62xj1Q8Qt9IRrR/+n4sZuStJTzwigZKXBYLnueqcQGjAspdbEeojRAqZXJlC/LJQ4CElGGBsVHC5H16Dym7l/Q5RJqLixqpHO+0zGEtWexs7WwCs62fhcnvPqHYv1iuzVL4KEmyPWpSSfS25g3a7XYTJInAD42/ADgYnVDS6Vz3R4yLFpYOrr7IZpxIGCa2s5n3TY7fkTCzaxtabN5801j6YJE2f1Ftj1R9pR2Caz+rC5XvTkJdfjFLmca4qz8LVZ7ryzOsvRZ5GGVwANooD+7baDEIWL00oDFGm5VuugBfbSxh779UxNlf1bU+INK7eUNJxIkCjE8m3PE0j4or+8dnJWi3EQR932FukuFI/ryi3SDZfivYywpjbU6PLJcb4lKPW5je30Gpr9odTxdg4jzFPZ+huIfGh0o9lq6t3LagIJuJ2WLaQDBDKgxDxrws2GSUtLG0VJsvcMeuU/O+rdtZ755sNO0gVXStxjvt6Z2p2OfmytmjkrhWXAi6k5izepfbKwxDLaLJn2Sxd4DUDuvas52tLvkA8QhmrIpSOnzXkO7bCOqDPs79Ow0oJZQyj3E+muPLzavsnW28YbWC9Tbbt0rnucuqDb3a29AWW2p2pfOZAEpeMtNI3laReYPUr7lrIdfbKU1/mITMbS6jgFqK/2lm7wtOuHXp01cOeCaVN2A4+SQiBCuTqWYkCRYvWGqCBhYNsuS7FCmgUEvRd6tP9khcB+9NVqsiv0vJq+snetA6f1SSXvjoN3laa4I+Gc4I0k7hiFCQnLhw9qISePbh+mrAxKEC+acE0DSDgUoCYfXOwrgp2pREm4DIfltc+i4U+IIk3dJYfO4Pb21VGSAQ9kO1/4lloJwRP/KB7EQ5uocxkOmG6Eud1w1SpJnXxOeTSpzgTb0kKk9m6wxsPx3YqeqrpQjlwAzLV47Mw4O5HoEQiYWk3vIokxJSxkPEZPNyYQSSaKG5tDsUvhP80LjsoKta1/A2TcpL9ZmeWxLcB19xdFI0uT7KuSkuMlvDuDR2q1MOpMOmJC3YLJUVget3F2GcgFIvaPeup6cCVbCNCk99NXO4j9goGZ85vPyg+uueU1F+BZzWAP/oxwKSV/im5tPq0bUqdVtqHiOaAkDadVfvVfNt7nEu9sraVgLZ2QY1fxGKv8I9PZ1nv+g93FlGqEQ0t1VZ0CsUGEcXsWkrNJbkSDv0wDXsFUbqC8tzyjtwbCkfoGyX37JNcGrjQ3eu03pfekh+tETby6Gph1gIlAW+ys86g5hlEKjDlZ8DbGG8uawTPIJjbgYUrmJsXICgAjxcIR70h6MMGASMetgh0/dvuG5KNNHjmLntAXcjSSFYGNpbb09STfuPqMTXAo++D4DuQcGIF/26fGh1znOMlTC2Ud9wbvs/CEL9ikY7alcE9F9s39xqPZQp18qumAceLyXElweZNR48W6TF/QLrqrQehb/dYKNxvZOBFlRuPfa7gRTPw43VZUCJ0jQ+oRCbQLpGf5CAarJtXsXs9SJ/cZ0y6q5jKyz/mp3pkvSIRZdNzNL7cTi53ch7xDXZWyXPfb3pRrj/0z1f8ChnbRTWOIoYbt+9l+v4mbvEHDJbH/V09LtsxxlTa4LjXzTH4Dqo8+aMAgr+jJDgICOD9RdkoUpTOSms+/Hito/ytT41v+rZSaOVku8xpFtLAf8EmtAXKyszfLN8V/rOpBJeFOAUEkaAR6dX4kMZuPlucspDk446AmhbDR8NEwiEpbnt8Sixoawao9uaKsdQmY0cu07sPTC+EMaiD5GUnVen3uZFyblFpiQfcJSKXGOty4NimDgjBZGJOCX453L3F+eE7CslaSDt7ueK+Q+qrM2UfD8yxLzOfnE7/7htngmrm23iwkR6uocBnbaIkcVrKEoLeitmoPIivE1pSGXGzigkkZ4FFaBX2RuRDzrdVM1NI3fsgQomlbrA56mAr/izDJq3TvwYSci8aRcFFlBqzqBIXyKG0su36LoYbEYJj6YAshE8VyOifbca3GpsaLHfTrYWjUZ8jwHfcenjJc0HnbGQwciErxOxnfYICSHNTfMdf0htW1F1YCeNAa9ouRhRQ46OrFQsHYA9GeMeyUQI0PwC6q10ZStS2SGNVgfUqBPRMLq0c3wFwKK2Tl4Ad3J71yPgC6b2EBrOjTLjm29RKxy2P2zUE/xJPEbm4Bv5LPvc6ioRk7A+Lj8+7MqtYiJKkspvVqbErxcIStaLsYqKSUI0G9o7LubJbyw9hiebmg0IGiUVwaBUhBrg7WjuEk0vLV363QxDaYIGirB4B8ewxf3o6KfdtellhN5KwL/wCzPakosWCXt3HJA+qf8U8TgCIw8h1nijBU0RS8xcGvgGYRsPMYD7Hcw30fWcKsFh8dnQRx/+iViATUJHZQnZXG0ZIKiqF7Qeb4YOjWzcUVONQEUIgUsF/+DKLhaMM692A5cgpcR7rTL9RTMKeRaJv24d2kySqnjdAHTzO4n/lbt1hG9j9aztZEqxfRo9Jl8wCtZP0wTRMdo/0ZII083N5t8P3SplkhRdI2daryx4kwz8oKkA9RBIw+U5iIHH0zVqpkCcbcRi3+OdMzlV/tsFy8aQ+ySwEwPI0dZ9fP7rUTKJ/JFF6yvegUwYFJ+JRR2hjehYOX6JHsNxyJvZZnkEgdxhQTYpXKNLAh8LmRKSGNvciHtwOVi2iVjbPU9cA/4TKce7Q9+Iar6TImWd7Crruk6r2doVU0gQImgl9dmAEWmoMhUg1piLO76R7mMLXKA4jsg2iDSS9w9+BaZ9P7zl76ggrD6dlCH0lnfJj4w9gEsq2aVhqN5lcj7gb6LOoR+RP0iorIqJJRIz7Y2UxnWTIt79TsvPBMngmxRKMJCRnoXo8+efyeUQmPSlaSM6BDp1tScx+ntqk8PzL2kQVf62dNsWUrxLJtZG2jh1GvRuyVVO2vpe/iZUGO6RT5Dfo6HilV/psokd22USCRkQhEyjnOWel/GBiJ/3fIyUiuUN64GXrW3HxZDTgOwL3T7kSZt9vXoiTdDadzUIENHLZDIm+JE6d8li6RLjMQRIyMr0PiiK8tyIyhoDkYARc3D8y1qUp713vg5nE2XfxjWui235jNCPdJR6dcp9pmGnlo0uC+OLucx08OwdpUlmQKBcHO8o35aY5cRUKVQfcrK3e0HMuWXIjYM/zgguXLj8Xi4KgVWFOJqlaoLoQRvrj5O4Ffu8yEr3AS+nEg0iDBVhiTTKzHUrWF0C3HfbTkqC5MjrWztj2UZyrO8umGtJepzbLRqv/a9oOL8IBmYPyPfWoO7yz0Wk6biO5JA6zcP/qWGeHi+Wh8INMRxZAV43yIlt9ocDvUzA+rkv/ENqRHmJzEaTODvMGEocML1cvILPWRhob3gCeuoDXud4zgMNUyGdN5JVDOD/j8goWtwWZ+kMSwdJwOj4k2iv9LKdO3GncTEU+Il/YkbxwHFYnZaBMkO/mXN9KkX5KFYzfk6sUxkuy2PIrU6Jk8vV0HkPXuPHGCy4pYJHEy8QZtJMpJBey3O8ETbSheV7yUgj/Usc//llEWZwwJ9RWPvPPSipOlvjsd4xfAQ3VNLl9aDm9zKp0ftCapDuBa73i/f8xgJqssZr/eOqVOgphem7SHiq5jyDCr7m2Iqwy7nnFwtGFnD0S3CcVlbLCjnkXpVQ2PkvEBMZVfuxxdGcEY7JHOKwmkQyJy3CfnXYyMwsp40zGQeegFEsTWRpDXtOEc4cLCEEf7KOijWRKI9eRZtBi0kZbqaK7uvtHmnWybVbG34LcjbGpqpU64uBJHO3gZJPElKJo5owZEouf5K7MQc5iiS9KrpaJWVVR025BBKZj4gIKgUypcXbCpQHDJXQpl5PAqp4upOPoCNfbRLafRFtiZmQeLP+MZ6CwWr82myMUGjvVsKwHCcVyC9OANmdK0D4rhK6l2j2s4bcMaHH0Lob3BdyuuSxMcWI63WG0537oKhFGQjRhKpvkNw3S0DqC5GgUlkOJZ49ghXNZcYBwzsv+QTE8eUZZ0vVPgAEIFsx5SbJkuzJPBiyvawKk8p0X59lEUHixpxWVp+6j7UJwQoczgCGAaDn3T+H3AKkiCr/WvDR7T4+Ls9vOhF57+w7hP5tcNNqgeh7y5AxxJ06UMi0w9bavB1q8LzAQEM89xwEUvYnfVqMOUF6lm6lvZQ5m1dI1043rZPcJGFX9hOrj6bm5mgVX3PnXRJYmZagFxSu8JFhiAeBgpCJA+UYBiYMNbXrPM5nm9G5gkKvWgtSpPD9yzKQaFJ+oXgRD64gFLdDdOo1CtTLqKN9kN8z2su7LKTa7mN8zJMXnwx6UOjUBiATYrI551XWiUGk4GKRfdK67RI74Fb2QqqQg6YjT/2uXt425SYY5UL5JjBJCxVWu9D2m9CcvAvjkYJfdBUC0U4+i7WEHwFYtiZGRLOxkjWYNQd2wWWXgbsvvBdZsSirOiwJRIpvUgPyrirokXJOp/ph8WEN2fVLJwx/NPzhu45JHojE2bvA2A1azA5FkMOUiV9GgQkie+lKhHhhcdZuzbfKj9OEfdlkQ6gHAL48923OLZhKdpBfeUoFE8UNsYMGuByWr/TJXiQ9VyFZyeLTuh+IcwiHWFaVhv8t0KRxj2Kx4STlLTY3l/XmWOCet6w8D7QAw9Pc7OW+Zj4OSh/sVVw19Oh5dZ+n82n4+ZZcQxN+NJAEP1GJ6iVPcPk1HpZ3v6iU67x33kMmVl7EoMpNk+yFKD2Wjv4aHIYGPeYJrGTdI6UnlN3f/o9J/fU7gVhReG/Hr4mFl/kIBAKzkJIOKXQSREZ03cZy7GCFjB297RhttpY9KVAQ14cW/isakOvsVeLUmiXjfuvvgJ7PKLMj3LDuPznWrQiouf8yeWIH6rZyQ5ak46YBwfQD928i41I6X58G+EJanaC84M2hmKWrC9JDRgzAZeWd+0SpZkfv/ttOOkDYrLSl5at2xt8pbiIufBQZ4+5k1qqcHysDPtzyTODr/+tggQ5wvRiTnSLriGignPA/EmBUloXNOiot58nYFr36K+e+OXPA51HccZW3CjBm2sTVghaisLupnIlYJ1tqVNHPuQxOIBe04JekppM4OA58wNtqooOEsxz76iv7mxj1FNf9AYrRDBerdIsCVfPrSSODDaecpe3uZB1Vv7q89FqZnQhxmWq6yPNYr1w6RUxBPPSTad/xbhXwi5HWPdRLKxgq61ifNiH+keENSzzjbmas6s1ycMiEKH1TbyjQUAiZGF3UzkSrheCK0LRD76ufYQRXDf+OC41gnsaE1QYxDhD7upD7jSc++oprdHg8d9FKCGpcOwr2YFqbnMy1+4Z2FDJJYQG0sfs5Nqkaom7pcijCfsKV1+tvPbyjuUcn4iBEBVOAGdIvQhaJmNItp0PSUw04RveIcNAqPOEnc+z+eYTMykvles4FQglhJ1+wPsBWe8HI6x7qJZbfRrnpCQPFhi7VfV0yq4t1MAW6PvQ+xyOvuup4PshSUadlfZVCsBgayJOV65jWtRlq4DKPy/pwhwrfyXYtakRR91GwMutCus9vR8ZB8C9ajiy7Wv0oF71ZFl/SAdy5WKvZ/fH5t81RDch2udBCB+P3003Ipc+9qgjDdPBQpV4MPEbODIylmj9LRP+C4yAC/yreZXRai0xkkBqTH+RrcaOMQIkiww4Eyz7qFIKrUQmhiIeZC/4gLUzdAkuy7lzduX001VSbOciwS3qtdigyS98F0MYR/ffT5ZX3Kkhn6KUPq3f7Wn0aQS7U+ELooovsjtIqIWllS2aJR4uCZCwqCBqedAOCiChvhKxhPCvjBZgNL/3GVhYLxiXmtKlzaPsnuXdSBzHoH6nfnYPZ7Aw4EUsW9TgwjSpMr09uJiIvwKlaYsFmcvWpdBI4CNpIvmKeXTqFIA2BPpNaDM+GYOygd6ggLP2l3Nn1erz0z8Bl7BCH6i2CAfMfoxox+lWtAnZo0LxV+wIgdO4r8ZPsv+ARcsl8dghkCP/oAg97SLTGx40laPv1jTy5L3IAjjPXEo+/Af4t88ggAKhIEMZnlUPxuLNPnrBOIym7RRekn+UkfbYuaLODJLtCQEbnXDA0t0TcNLXaVct3Sf55xT8m2z0SKgnHWsULX37W3mMDkysyRkJSD85wSY7BDv89DtxvKVoiETEhVBR6gSQZ6toE4tuZ7dSjOm51A81jrwEv2/apFPJFSfipUxkGuSSFkbvuW/l1DSW/Fi0hrADuThpHjWt/2d4un940CcnFkfCvjB6ah4TO8/39laMcFTTBh/tpN/Ft07ZMhnhCUn/rDSZ7cf63LRGxaEwrGpplcOF0hTuA/3eyViAmG10A5POH93c4ihw1K1FnCgQ4orY3bhLecSuT1xd9IhagW3aTMW2uOuIl43HZZGqnhGoJyQAYj63It+vu5IlYMRebfgEXLOFyePcgm6CuEeFpK0O2lstFtfFhfLzGDRQUH9xGo02MoFAQH8pb9ImGJM1/jLu3ORVELHfTnjN03WxnZnuLDDX96BtJErGCsNHaTnZ4Al9sTkiOjFgc8k0WNvKv2u1Yqnr+SUr22EBEzWhM8RI44Gvu/e6i+dOE8Y40Wad1FMJt2hUzxP/8PGybdsEdIiv++J4xDpebCQIzCE679vKv2vK/Iq97mo28kNxc+27sJfefiA5sVwhqI+1f6hbMUDGDjIAInkQDBaILybFZMYrLYloNKG2tKa4CRBRCQ6LcHO2G3WnN9HGRnZFATTefGQrwlNzzsDs8JD+Qo/SZauNl6aJdNvcBLIDoSYOpWCb5al4owpKlfh+Mu4GO36OwEl36WmRkpQs1hFnuAcJq7Tw3+7rsZ5bQI3/zPU54mhlCMDtNZtXb/VDYU2KLJue3220J5fqjZWlHbmVp8L6OwNXK2bMt4vx9g0QCMHZD7m31kgdEOhkBAXZ3FDVPQaAI7Qe1an0BLWLm/bnhv5aazQUYQpDU9JuVeyeGULGrjZemwQqIKD7/wi5H+IgswJg7VjWjBvKTYRiJxsvTQ9eSH0QusTRS9snXllMWC3nz0sEaJne468pEGfh6vbxQZnhtIUM4NJw2QbnYFIYm74gEPknyIRtTVpYroyNjYbYg4okrr8+ZpGTojosLehZOiOiwt704EYUKHXj/1yslrwOZZQQVrqDRgRsOAlp0CzKPkStU4mKRDhSd8adKwpVrbQsTMRdD1IrBhg5e53D70/zWC8K4g5Z+v+F/SQbo/jWpIev0bGUSwhMvM/9feUkoBxAzQdkfq2i9/rSy7/zfApjQ6hPbmxjmFaWN6L7B9iUK4Hqb0EHGF+wOR/24F5G2VtMPkeYPUT8Hcm/V83FgO7hwExcm5TWqIg8UXbCjHtuKRGg60DKRzXwuQmmyhesidFLeHamsK/+itMXmathRIjlDYeNWg5zN8ilRQEf82ySCeBoJwrxjXTaZ7iQmilMpbjU/rR0LRXx6wFb1bs9tu09JIXTeJvZkcibQ7aISnfv7hwjyBJ3uulPMOdOhtK6k2cT9QBWj7GKEJE0Jm01n1HFYIPL5DE7g6e7rXbM3+m8rA9KUBJ9HZ2g8hNmnDNVUHsIAc3YQH3nzuEELF+2/mZOljM3eRIyE23FZ6lTDMb7TF7BAhS4Gv+ro4hAgwgQTR++uix49LrQriZPtKLcZI8Jcx1PaVyySPjeVGMHqb0LyXEKBW1wvPMbi5kejcI0o/nuwotzsfonspi9i/Lu+p6KdrTX1lZAsI1JEGknuQfk9z96XGYPSyOeFS9Y/YxjoyZMAu6ffFwASrCYBOLMIoU2p0PZjTb9ipfoHHU00gJ9qWhrMkZRtbKyiSKUdRrXs86Y4YMY6TEGHggrtqAIoki9ZxDMDenP5qXnoTdX6DDpd533o6mwXivS1nfeWXXBoFZL51fP0nZpgtsUc757iPIJpxSSAjuw2xwxKcQ3C41ldjbNkRVb9U2qbzeSxi3uB+2kBuva3GYagTEn8enWOzmmi1XYPago3mPE5EPQeI+1z/UXi14aj+H98NAHWMNQOnIH31MwxBFlL0CckLib0/juRSvr7Ffj0LWeO2IuuLijwrfBuKzAs0kdBznbW1ImhpgIcxcF0+H2d4jnwllkg/tbPbH1cr8PJyIDCCTGOKMsoVyoJaI69Zl0mbgrWbYMuvOLKVEu+Go1g4cGPBd2WF/gsr9SBu2boVBWVP1G1Kh20CQriNGlnGgFxdumdQkj5Az9Yuk8smaoz+ApMiaJheSkp+EDgOTgK+0oucvwRBpJCOLs40IYacDY829jM5gjm83f81aNVslDYQIAieqG9WdJShXkbdrZ8b7Rgd2qoqHgp+KwE2Xe/ot2TEkx8s3aWOniJO55UWkFrHiINFtC4oZOKD3Qcb1I/aKIyoaXO/RSgBIEuFL7YV6j2mklQXu4GiuBi16BL7gey6wC6tHnfam16Zefds0bdHKmml9f4432/qtwa/tHt1laDGq+44s6vegNSlJl5G1PpK1SFZCGOilVuypBoKoLDuc3ym7nd1hQehjPjbLCmX7cIMHbYcp2RfW2BnBwojHr1g6xKhUw+tfFx723GVxIIk7mWH/TZBQGV/vgJ/qesx/wF/IbrllPhz3hJqABf4h6BdM3HMksnvsbSUgRqkiffeKzSBWAz0KgUZSV39YfJo8U+thR6+AImvkzAYxcHVDx2z8G8P0VSIqYI9f/DRYavhMarfjUJnBZVe8QBM7HISTvKfWLg55urDtrTQg3AdXb9JdOb6Ih8wyZDE6yBcjB15pXWIm0JAmmkQVEtsK+iTi5zVuUkvScbx7xfS+XszHUtWYYIHKar7a4Kl0DE/yAqYwEAu4CEgkC2aZ7/2KpPXjQSeNeLSUh4JE6B1SD7Y9DqzGpmnmeLgfaVuwRiva8IvUgNiQ7JL+QJnONtcS7mGhCLlnn7n1s/+xVQKTna3xPrIYZzyXcAr7VRiQr5ewEcGpSvLpBmBINFU4ZfUA51Jdfc/QlNCVdpQuaUvhB7e4gy+lbbNHqmijFZ1Bu03SW/qhvUHBXUEBTvxeqFrpc6rKtPSWnq971REJ9UVXBVSxA0vmcT4VLRJG9CfCNgv8uLj8PqHEZ3bmqvj8xI9rUK0CoaZUOsn2x9fWUlINWCtIZGZKnhO04jNAdCmFssxnLrAfEj9mY6lfOOC+0sFUnTywXsCUILriFdQHIVYf7BsZcCkfxhPHt8KcxaTfrDR6gbAoGVUjAuQAEvevAVKciYsFua7BtnfaBo1kMnRjGDdcdu3i1MDjZM/DFUFEvkdRYYk6C993/zVYLQMndF1ayUI3LhwNYr7rGjrTgqaFgsctPmZ2C9L58SNmoXqnfP5g+YlqCXHFngasH8lEb+K13m4Pk8RNZHV3me7Ubc/QE5DFe8YVUrJsyPp3+rj0ggY4kjPp34T3plWvWIaTrbZJUyLHmVUft5gUPpygK4A0+OYaX5iDJP8WiU9sKSDAki1sDQsKWLiyQaD9EYh15CPqmsJ170lkYmMG6XOax5Y+FnfcwH6Fz5AAxQO6Z73PR5xAH336wxtzhnVaR9i6rDYL0qJDeRX9NQo1lpHt1a1I7esdWA5QKiIKNJerSLJEAsNflfqGOD5wnB57jIXl10iPFcvCK9Yl8Vk0RMYN0uke3w4hIBdi6YHPR2XXVqIgZL66ioNCwps1UCH81Ix7oDUDYg33X7vjpCFkk+wdrQstdkYj6prCjUmQARiflpKRa6E2PtrUuSxwS6y1KH+FqgcEcn5vVMyy2mAGHUBiQYL47aNupNemTFDJfRsYkKOFh0O59ms1WW8WBbFv/px9sfkUeGcJuCxJzdTE/EJcCwWCtaUuO0UZoJCRByrZIPAB5AuyRGf9C7LbhZwaCd7hZ9XTK07dsEAABjmOTCq6zeBh5yIZSZdnRw4A2gU42kjDl5uAqAln8+HGEs8M7Uq9wuB6qITFFIIpxQWUCWep/hdaLYv9Q93C/X6Gccc+HsOQsGMwgQe3OrYmqzHib0ackiBL2dZeE+nTxw/jWi+0pJ/3U7WMx3aFv2MzdezKFwlDjncUJcD5jOFvPqaRhD0JzxuWPw9C3nVnQtd/KlNW40XWG2xKF1KaVXZa0rxLCAHmsuu9sfoONGu/mRAe9FCxtOn4jWQhmt3AWPglDa9XnZUHvL2RAWg8tj1u0v8s+bNonorZfguNeY8XrGGcLDAgQM4jwCPsEgWa8ocwoAOgSr6qw485jWquBMbszVnVa/DjZYPfiBRiqbWdf+NkseQaE33lnNkmrp6BT8zdfoEPJ7h6a3ZkbGQ+H8iTpNUwA/mBG5y30dWX4VcSf/xAWiOYdXeApbQ36l044zPQvR50Y0lxvRlKW9uT4Ld1omb8+Upb25TEhk88e3KHM50OAcWe9+LzWhtXyObbybCHE6ESXbLWZhpYy9fckg4m0R/KS+NaSX/WLwsvyknmFj4PhmxcMhPgpw7B7LRD6JufWOv+NvwOtb/uUtVv6uS50XPDRR0gHXZ3bp/FzEPtE/nCN63Xc85LumQqnADfX6JMWKD9QD/OHj9eWetbPK8u1oVK9lxZ04QPVWY8hAZq30KVs9iQxiQa7LJnjiATRdHlFa9MpivIlvpccWh0ej7GEu/tMfXkL9Jp3i7eNRrgWiwHYUOMfan+KGLGaTNV/N3XxrOgCjw8V6iTRQxjEsfqrAUpJh0Qotg/NIgdur7mO+jbouRVh6m1uKKQX8QQXgY4XIMB5R+KGZf7IyMf16+RPfo4Q1EI2Fh2S5ieMHeGXFiTrDcd9rs6OHNxx6Y6SMI7njRJFToQXWGzZD//CohvT2IjLS0UFnlhK78gzLOVF8U8RU9Baw9zq1xdw9IYXGVKkD/BHjoL5teo88FrMNJoQm37rP/L25ZgIZMPyczXVclTPqcJLCKSK3+ZmgOgnrfnbziiMskz8sBAzw/s6LBU9Fa4aDMc1bKle+0Ndx4Kwl3P5mASGRA+4373QOFodIRelXcGuDJ1lv5vy/qT4XCW+mei9MHHk2gxB9Qjut3LWx+SLx6XLYw4grVbAIsgsRBnrtnMBg2MyOd/+xo8pn6d+cG3W6pHQkjnYAfcfRgHUiuLkSEecp+R4Diwg1foTyhzNq6RrpxxReOMW9DiuDw3Hjl9omdVzvfQaVwp63TOFvPqBKC5aztH8qU1cZpZYQANEwOj4pOgRPLdE09l1e54wizEdHvnx849bV3OjmuRkfk1S5S5g76P/wp41BZyN/fowqAZwJbLt39x2rPuiZXj5XfVI0T2PA86WUAO7CAFRHTAFaW8PevUuFWGmDuueLIrwXof2PidiIx+KLHFhY/8bQg2IXvVjqKz6kFKW677cYcldOBvh2/WB4CnGcaZ6EOjAy6J7Lvy1cijQHB5lDbynXy7m9bjm9gSABI0EIFmCETi2+o6rm8N8/4aRReSCOIr10YPhz4py2VJitmHWRcE+WY2aqA8t0KSWMEWpNwUa1lQ6XMiVbg+GDrS/UH8n20r3z5K6iAI6jtfme7GX4qUdaQl1fNi4y4HpvTVlkK55KmwVO06qjbQlMwmuua2G7YVObu17MPsAu+5PbdEv6LPfjP2iCUFrmm/+T2hbjy5n7xQYpepZ1+n3B88cjppqzbdBprVqFlSeXPZyx5l9TkCUmbvbbmVQExPs4MXxgh686luANDK8qVbyEGIKppEmZp5SafzfEsOc7sEoa5lwX/sOeU4RFC30Xq0913+JOgx7BExd3z5TZTialfSjhlyhZfodHnOUbCzH4iwO+hQ7rCMQQNO4Qvx3IoKEzW0I7sQ+8MUXQvo0241ygEE+DH6NJvKrI634XChvusIIZCkIKM8jgWUqCSAIdHhNjI62KbmK8nzzrn+MYThEXiMDVHRgur3LZ9jnAUZfvBry0Zru1Nr/gMvoo7MW3waMKPPeoqM+UtP9rYYkAI/15ZdSq/TFVoLELcoUeZZFEEkXXzmhZYZ27WKjnTBUU2L+N+CAYMAq7+s1jV697zRO/HN8XSbN0xUAQb1XoKvsf70FNc9nDtnINRK2nkva3i/mw/fKrwKcsmode9evcUPhTOkXGxXBV2uHyMeQF6XA6E38K8pioUHliKrgTN1mLcZVfc9n7FTnYW298vqg1BrHv2FykgO7I1Ngi0qbO/DRpXwh/BW75PHp1/lZEBtA0xf77R09ZUO2wAqCLI2Ws1t5ikPUUFsFTu7hGG/ePvoUp4l+VHUmgo9tf6UbIM8SEcnbOUe+r82Q8hJMOTaKa0ZJlF/Wvl6T8pNzG8933F8zR5czA2Wa0fjYKu96tQQ5IaUtkSWxieTbx0WJ0bVOzODwTOnzOVfXPiozr9IgkzadBDdKmiaRSc+UYoVbsIEVCWSwoTI+M10VU7sxRSlnXy0IAHQ8am2cRBbs94Y3ArBdvGxOWJfoZneKZdywapQByxgATL1vEEi11jlyluk7AcRKz0Wt5ARBkQfSAlBvy2Er+icGi+DzOzO3PTAQjvRhjCDpMUntT4ix1HOlfwf4yjCoxbRv8QHtU3WPl3RxUjTbTEQnRjJag0cP4zqFqnQUfbrtdL/DUzE514+GqRXAF7AkX7Yo19emEpncL9sphAkk63fyymmz2it+mv01Q1wle9gZJjRtRaEliwGuS0XfvI4yPADlSikN7vhZIpXgC0+1/JRfC7BAdnEZ56P2AGFUcpyIe8VNk9RBN6Q0k2nY0g5og4NU0ss/ZHAQkowwNio41K5etuzOZjx8BpuafV9cEFGdqLN2uDKb6B0eLddpRoCcC/haEqlaPlZHD4gouTtXc0uFHR27FKJXb9a1WJcVjMIr/gO767TJR0GhvKFCEIuV7od5YDOyOgcsWzM7k7Fxi+Souze4ni0KrjJwtZAhMZJS0sbRUmy9wx65VfqeUYSk8UwS4yXyqq0Ly1PZ+2iWr1P1JcKYAtQZUxizeyM8/knMN5n23aCgBw6TiM8h10exinA7o8bFRt+07w5/VHxIKOcMXwUbYQlU4BEYRXnrPhaTnZ0m5fq+pXUwFSWQRPlBhP6c9/x0aIXJD1beJhmZQLR8+CG1xz3uRfZdN80RQQVknKpcnsc08RvfjfXVv6NrB5YMztywxuX7n8K4oAoYjvIZXEUvFHOlfwf5Cv6jI8xWl4MNqMSDioMUGpVg5dnBQJm0QnVYwdEA0i1LDc7LHagEjV+tvVeD0X2KjekU6qtCfld5uGqyZQwjX8f0+X1sMWCdJQCCkzcurMZyR9fWz5YhRAjNm5HwxTHJmuOhDk+ripFcqkafjxJzJ/pM8EkxlipB+5yvh8GCZXXBVXKfJNc8Yzz+S8Uwzx37fDYf0w70/eVOPPO+rgLvJolCx4QYVGRT21UnkNDpCjXN4Svkvw/h3oGXHVV3DT+QR9lJAlcpZRXsC0ienkhmF/9hyAtCUwFFM3hz/ol2jgzQ+9l/iD3DeDbFmF3lVLgPMgYUqa2DThVg2fVT7pl67aVLfaz9e5OvkSwSTusAS4b0hDAy2VZF0oY3HEcquiQTacj0zjmz4RovRw/LNlbLoSs4kiuf/qUEQ86DAJw4n/N4/BykCTHJNcR3k0KlKv8XhhBIYVVxjp6b8Pv0xNHxl/plgJVJUzo/kbgcewxf3to2T4ouqaFrb6lQ/iDoBL23nFq6ysC/qLf7dJBvF0yzBX6DEcaG6QycFlVaY3zXGunOXt74Yn/+oOTD7CWRBmrCw8k4Z98xM8a2YkvZrOr7i2sGMazTFCgHhXd49YuRUa8SEWaodSqyom8Iiugj4fyl4iUd84NUtREpjaRQp5JS0gHcBJil2h2/RQE7y1KbB48hzzlvUr17DaMQsCJ3GaKv3lj0037fr9YMBCJgGkauBC22PSG3xdZuFX0USI2GRaXhlc5ljx1eeh6iJs29Ypa+htjDeXNLco0oijgpL6tI85Oz75S4MvgdbwNe9+LhCJIWsv63x1LdbTT7B9O1lSausWB53qJJ5RMpj18E/jUkRbuDmiFY1uewfdQcT0L8KInpPNmVT4RsUIZOaGu05E9GpoeK6Ocb1x/DwMN057xd2wMRhR2R0kTpb5QnVBHLMOJ5zyUxZzqv1l7m3jlhmvX88nf/+xR0dbF2po0qII2GvfHMFRJl2OGgHfjVUckfkSanofsD9lGr2F23H99JRZXE29f0S+q/tLM/ThwvIX6QI3IJ28Mio4VMDITuN9Zcgymm9ndB/o8lWNON8nRy7TuxF701xHLREAT7bM5WA+HuN006fwAv186aAXitYU/KOLBXAhnX1K2U5xE8IsTwLUPFzHvupEyZxmTJrfctH3xyKtO612iuDozI0+uzYtBNAsEe9PWRMmVD+y+LqTCw/573R6fE/xfkM5lp42C7ysAxnrEd3DCAZEi4F9ruQF1nfcnyP/N/39PpfxFiUcs324bj7bUrNCvquzUp20dSFVNsINEhcp6qYdF10g0XwVsu8jzOc3XV4oAQLwo2x8M9ykZEQ5uJqThyDIGavmDzqEwQZNNJdOBhy7H5+gPwwdqiwjWUh2qNMw6dHugqSx4gZ0LixZyVVK2vasq6Ce153TXGua9jRvuBI7VvuczcguglxryCTJ4h7bcm6eNoxEOz9Pxg+oVZw1AOPIVbUy1P3SPcjRELFCWI6ZXmWWbeYZTJqOI9+9D1jGLvJp0idvsbogd1ByaXtj0SzHxnbe+GJ//qDkw+wlkQZx0N1QFjJyILRA7qDk7L31dPx2tFJKB8dFWyjJUNbpRL8ThN1HGT/gmFNgs7NMyVEPFj3dKM7CXnEobSy7fot2htcUYQuRfioeN58QykkMmXTRLdoJ/t37bUvSRkGvqZex4KMmgUy7ijZjCnibMA2WLOzRoSTbCYVsYwNt+a+e2gqMJb/ZhOzMblclyMD/4iqYHYI96kJPlkiEhZgOzNINPO9G87JCn/8CzaJRsPZLCo2h+1QoqkcP79sF05xnTBCvYG58KuqUdt2LYh+UTtMDOfCgX7B/fN+Q0RXia0o7DxmKCh7o08DciHm2ZYQ2kJcV5G4ujlVha38yNA9h6n3YgfN6LnaZbdhA6OOQWG7KgS0TYyh6xkyvWjYjOSftd8p5Uq/UInV0boJj7LWlVoPo+bBQIWMzjuMXIhGk6EfUabY6MQnwHmimTCzbcTckawfFH6Wt9gSboU7YgoZxgRN146jjaB+saCABQqEBYDId2pHkrn9icJZ20Y+RXNL8HHJ+rt2JwD9iMpangkxwIkTB1Z4OyaLCIZDq39RdECbw1didTqhzABRHhmemVGd/v2tJvoQUjhfO9aRNqEjskxdqBOoqsDfG5zud7uj5U/9Mtbw89sS5pSp/wUqHW0Gy5TJTgQ9Qd8D/4hrSuzXEMVAqGio+yh5DJLddC9qa5jbzTpZa1Ww+zKZTa8Xv7B5qWDGagZwMGzZjNI5mBp9dmyP+OYG8q1AlGsyI5w8WHsMTzgmhK4aiGXqTpAZYyqPsJCZEhaIvrXYGLfF/LMAiMxtQmWHNwcfw7ApPIkWQFzs7yHzUOPfNrIh/2Slvhbt9wo/a6612iuDozI0+uzZIUixZ1kTJlQ/svi6kwsP+e90fz2MQUkWbzBETTgT9lf+vIWlgBwib3CsJGi4bAP/6FNS6j5kc3rDFq3JM4WkMsWOAsTecaqvi4B/u3YGF8NhBBWC+pqVpMTywjQkIWmtRDMIvyN+9M7A5PAfBwTbVM4L9+PULcuOn1YoWsOeMgZ+RKQmSqysnnx0VpxMRe7iiatst2QmZjer4OghbDTWXhTWHcIVbrXj3u/z2ix/GZ0HmHEeV1Nx7YC50z2t9OpsOyuyMZSfl0P8ojh5tI5w3EEu2guYoiJt7kQ9t6WdGeovugFMrO6VB6H4elqWDLYStUghV11m9B2xcSvuPMOZ/FI8kK+fSojeuKhddrJCFc8ctVdoA6s0GSx5zb3RbYTOEr6DeS8chCCgWsciSXoM1rNFMpRstxYmwA4HHKdapm/PoxS4EpUBD/kFmR7JncyPmxAE9DorTs1d/ye7nALPINTF/3eMrJrmI9QlKpz5dCSNrTEWd30j3WwkRfkudMyVmzuRfjvwC1ZEZNCp+Q6OY5ZYvUnQEAkhYI8WITGdGm06m1BRsfduSOhVnm232aCHaujie5dwzBffZnbSXwgHTWwC5xCmQ+NaDrNMkZ8qiwKZV4OKrw0lE+kB3JEnfdumvMpPuRlIqEMKEZGHfaEqkzLjPEETxowG9XwdA/WUr4Tm8P8SXEeMO6SVm8Noo4HAiMJCya1mo57Jm7xKFWPoOI79kc/Sb9lHsf6bblRFuVjAluLpS0W6gB/n10k6NQ5NFkrmdv16WjVHqAFtuUP2MZAZdrJCFonBQy+bW56CisrZGopvlV9LEUOxeZ12UrIvBYAufNDVlesBKcqfH0/9vqyZSoCH/ILMj2TO5ig2l1/XebfLtoLh9QeLjP+eX/kyuUE0J3B9g7DOt6PM3Uy9QvDG8GKw0JRB5eaUPl1amu567yek++L8O7LB5GAqZ4be4PEX3uydtLwm32W0X0KXUmUdegoDWJVlreBOuoKgRqWkh+DaAJomycjLxNtjhiD7YRUKKLhoHcfTn6jGbhZZ3JSWkVJMO/Y+b+18/XVN4Qxkl/ojfkdEbuGg590/h8aAUN+l6LbfVyOn8Fj2HfFcC/VamoYZdWxEVte5Z7E4sjhoG6YhdxIa8vvNNmusIwsDoU0LL5VxV2LUcPk9pfnOlKHkooGL8cLZNBQ9fmljMw5dHLtVYQ61fFLyKvv+ATs+VF7QEweMdBzBaGfLiBq58yUjL1wAPTosutOCFDhOnbsWqRdVG9b5gg+1zpSN/uj05uMEn8Cvx3ruOSiFugOxWCQudQQbZRWIwjOomOp7EN4pN32WEX018wtt7O7R1CKFl5ALnp3UfJlqWqnXiqXkqsNyXNfp4i3+nlAlqYwEXQMwWVMnU66fuEJVas/UXqSnuxhY6RAkdn7F5IE1J6P1kwyOLD5KTo9G0SasdI5ZJocdfY250Isv0po+PtuydE6nRNWJEZ7RUTyha5g0E36DlCsEtF6/vY2x5bBjLW+afEbogl+IY23Q7c+WT/1GSXYGChEkmbdztDtdUFnIbVVgUHhwpmZgutFaVEoSSoH64gSnPw3p45pkOK57vB+tXfoxOticOE2Q/RBGhy7qNEUh7aqbpEgcYwk6+iroEL/NO4YRZbHM1raL8VlJb+spmBWmO8kKIrBWVAu2fYq1a7DXNtHOQ2H+H+4wrh9ryBWdgBFFB0O93eUEU/4R8zwrztANqINwIyUdjKOz+0uFcQeDjHBt2CKywDNnC65qFvJjAY7VHyDtRgheQ3ddo24iBKiJfYfEKZ/TQ3R6QtJozaS7DAHnXXAE2Leu46n+dsLEgV8dGGYqtvF5pOXSEvxV+TwC7vNZzGKi0k8Oy7f9MHhDAuXoGQQriCNSDQ/fLkHmSfcLl7oxhHoY3bOh722Z8JZuwpEojnIRPw4jp8XVPqSuVFReexyL6jVvJ3y/S0Zu4vFdfZ7Bi1td9wiLikdbfYi2JE8Er+Nca13uwh4Y0Jfs33nsfka4fdIdfyNgeCA/EwRkxLuajolYBB2YQO1hXd0x0j34mVlnx/H8rsNVq2kvSPrNHueAXi+0+n+eraMw0KtgCgdEIJmIBg3VAj9+7bu5rxcJY2XqQLGI4BYLa9fpzf5rgx82Wdos6uBId44I6fs99mj5kA/bdKMyuRPUHEyiBDgllLfSpnJ7uMA3Lu68bSP2IaLhPvCxeY5EKFEXuIx/cusnmsc/T7Eag4a/q6x9BBcltP4uT/TvqBUZVUkxumgZF0QmTF1KHoK6TBICVJOdk0qe0GVMiwY950nVYWxb0TCgt0n/nQEuwbjI47xqyILVOOwsV9IA191GDu0QIra0QZxGoQ58HlOjdmmzclQNYowUMLD2rvvpZ9rncauoWxh+idZKY3ff8ltLlbSvDtwV39w2Y/vq3YzzMSoYsN0GOr/BsdjlJ4vRaF12lkjbK0nEiQ0wO4ErlNvysRe//vyXiFv1yR7Hz1x7xlOEwWYWcfa0lz5IiIfhRG36AbJ79Nx2g0DRNIScNccYXMkI1Qqnr4mf7PPnx7d74LFdT+GXwmA8nLk2+1UNmJtc5YQtHp6pRGLvYCSMFdmh1HulfwCEdk/+YkflfoOxpiG+hu2J6ZW+95fJXwhnVXjNDeSIhyCk2k0vAhiDX2RbcYtkG12fxpF1xTMIZtLlzJlE9MyuTSoBm7VXALNkjyOmdd1mAMeco9gN8ey9MvmeiL7e4GTabij3KuV5f3GrEk/Sa37eQlMEknJ1ckxPai3zuoLTIb+fycE0N+VDWVl9yEfZ7Bi1tz92cpVpVuSuSm6nhpIwHOgT2TpPoiuMHIaIquiontcPifSq3Mvuf0E3TiV6fMgfkAHNyXLrvbH6DkAzq25AXgJ0HcGuL4NC/+IA1b/x4i+aGAWF1jZGG3Yf5OgJDXQUnu7NKR4dWVfVRRblegeH4QlKDOKwAcDYa6WIT/WCgs8ltcrrA7WUds4x+uHmDCjlT9xiSzhGi2SHT+46cnwfoCUdG1Bpp5T6DtsN04+SWXbgVagWHkBOgegnPK1GwCRoxrzo+znsb/ieKGHNBREpcpTWxiDUdAtUfL7y8BHWgm11oqSPe93oLGVMChqESkGlcrOI+M7LcjegOCE9ckF9Mn9IkTKZgenT/uHZcplNZZo+ofIohNvrhmG45PFIPAbZjkY2zFhqqO/bXZnDT9My2aPAv8ROD+/78MzdmY9Lpi+qkRkUcuY3J18pB8J58wUnyaNP7vSy5Rg9+bhg6KgLN12UtwTt+2CeQUsCTfNvxP8NDquUYPCUOSTj9st42lthVTgVBVdr3fYvZ+SWJu/K41Ws+YiFmvJ7e823cqcbQOlR2dxHY21ub+Fk6T9Rm3fwLoe5lY6raTFkPm4QR5WGLXSQGM9RQfyPczmWw6laqwVxzvkzs4yFdQQQZweyyByACqVqk+uXrHs3V9Dn88JvSdkiEiIFL85At6eIJkv/fPkZZkEWLv2QkPMJiRBKWsVNkBPVYOcsMgrwJWeCy1EhAOrumNv3rO7kYmTX8Yn2QzqVgX5UIwDbQzLpX2sTbdSWxGD1DfgduTd4Jv9Tv837nwqvfOz+5MdeW3fZjFk5T1xmSRaA+N6h9jG55jesnKJzAlGFJ0baOVwpJkffU9PpJQimoesrVTtaFXT5bGITObfdxAk2WLuWk6RphQzu8SdmoA8gqJm3NxXeohIgQNY96dhmL7eq8x/boNqzwEojN0zr+BNdtFR1N4ZJqNz13B9e6niC1f4fQ4hhjPEjH267FulHewWW/yxdsCn6GngQ8xWVo+rd6oA7jDV95kCH4YBjJRZy8zkp5mcCwRJJRCne6Npw8TifIh6EUlPYWc4POPOvsOG2k0NV6zRx5tPPSAwojL9ip/tBV5mKXsGzPy7niLR5ZuHytb39ZWsNP9UrVKqIBOauUDHnKmbIqVdok7tJeBD9LH3+ZN7DsaDj6LLl/B/j89vVhUOZpRUNUq4kEDWtUcs/+uAsZrEz532XYhbSdsrYVlIEePx6o0BMADwz+aFR2Srq86DPZnAHnFchmbWlCuLhtqUVHinq6p3DH2jXqiKYVE1M0bS9Okxql2Vv/ZdSwJusz/uhb0pmYOTyPxsVhLP6ZH121fDK8kHtmQdkHUgzEJZElzJY+7x9Qy8kn5Ka0GF8mCbZYo8wag9AGmchLIgsgiWTz4Ls0o/jXSzyErmbY6YtPFW73mYi/paAr6fUzcPieowd/tgZkJ64QqCyO8PgaFkfIpw7KmtLGZaUyhEWRwo2xrzaybB4/l7sPvxJ/8dILMiLGmGscLsI0lNshD8Sp1d9oAMwJ+LEYx+NDKPvDSPkrPom+GUz8eQL/vIQzjYocJJN3Lo/9LkR4+NdbNw5RzICO0przGr5xloimOjWdPuhVn/i+MSzAzI5Xb43+hR46/qA4CCr/KXRs4iAqFWSicoaZUuAaArFBQBQmVApQSJYh6uWX31UNJUn04tf8NiQPZ9/ygV98/VwsOir9g5awDw/TyTfmdBOHOh34ncSkSsQ2Lc2naN73KI9b3OEyXcUJ7A7/Uqspeao3tWwcY8igwDGGNPGApLbiXj6qp23MjbdvHywwjEFIFXTqGZTkyFuBmiGxpj3Pp5Mm7kN5Kem5XZBREj8eBmFeO7Ly7QXMCUzOhauvDeKnQoh2xCX1SfkUz0W7wP+YgEV3a/59n+6gPxCj1JztFBrISW7pJph4cQP7KNS5DT7gFQa+LAx0r6XnTuArrubBmMcdTFHAsN27oA1F3yu8TqMjqXa/ne22MBsYmTYg+xBI3y1Hnt+q2PHOmsD9OUCW2duiBd378Wy0Yl6HS3kI+/tM2jAfnz44+rqDdio/kVaZfJ0ph+R11BufIAWCj8Bc/tYhBaiwY+FnZBuREzLrhojoArlDMrzS7tovNKV5f4Q5gAojwzPSORrwx5z3zRhUGTgd/SqHbj+AB3KL4Gi9G499rYok5buDmiMEgntZqTpCLBHfxCJvnkEoTRC1NAtZj+vPJx0EzDAeqU+vwc2Cy0GgbFQ7Ypi2F1EK8tzllIWiC/LX+hw/cesaAbT7FupezL92rsuzQqHD2Vu527twxsSxN3burkUbgQKb/3MXol+3tvl3l62XObdmhidYSzO6hrIp6KKMcbReJZcC+J+tEym5pu6ANRd6voPqM2aXTNfargV9De+vUHHuRNIRKpTpcVYsjs0f/UHK4NhSP0DZL79kmtM/OcE2vldLcqhzTBKOuJR+trETVHhxF7Cj1qmKX1XuwA0e9SNgg1qqD3k+RXLhiVmmfrpSVF42fyBR80Gqibtt2aOht2HF4UtzyM2CAHpRQswA329aPJEMteLTmLVT+Ir0DwnWPK+bdkuak9kLRxpUl5ydfXHrhQbDBFFOYHOVLhBE/tmxSUMOHlucspDk446AmhbDxKOwUvUzLcRPosfh9f2LCawpigH7BYvQjGtbaLgaSNXAIZaQVsLr4A4N2Vslt4CcmdmotrYZu10BxMYCq0mGxTR0/mjlk73iDYeUxJB4bD2KgCb9D+uzV2h93OlTXCINGuWG/3KeIxnP3oesYRqZHh5j3qJM2r+2gb4hxLIuvYOWHfBoOKZDoRcL51r11V9s3G0zKGYJVHi2fzfge4GQlqEd+KFvW7eLSlA1sxJezWZwl38y1IbUbzcz1CCQtsMuzwUUHwTeXbL82XsXU+EsQC5a/WE0Z4n5Rt+dYA7x5le+qelEnatV6QkE4qjs4tSWAjiAIDB6WrrdcxWNM7RO2dKgeE7GbJo0H6XlekUtJwkctJko8918xrWhAZahrI/HVmcr6hpj5pdwEDRLQa6AIyzRy7Tuw83LI6H91CQcpFLQLlaTznkYYiefK3rjsaSRp/acHSJpK8HrssB/2iCcGdmKtaXUKj9Fheri29S6UJ8s64pevJhj7rIVGfo/CB1xd6wMkWEAQXwta6T+nay6WSOfEKRKitP9zKuD0pP55e/Vey8coBuqT2KaG7HaCDAyp19LUc80fYCKEZgzqZEY57PBCSgBgCr5RicSIJG2QuSEHYx7G27B6PsQJbiM5wyUfegtEGHjU3kyCAYtUJAUKyVEGXeai91OAxOv1giZtMdMi3RcQDfA4omhtEtJi/jzjfnw6kwsP+1eC80nzVxNwzQLCT5Y/Q+9Az7rznCFP9altkDPpm23MChgym/SoYt+iGcD4tPq1uqTOKFK8i877HJfKkHmvwTVEOBcE3pHBDYRK4bpP03AZ+GVNWmRAnCt7alJJkH6wdg2ZB361R7k87ao4kJKJ3HsRMP/H96PhCbCm5JuoKJwmRmGFdeI47HTY4F8NPwkglRBT0dfZkEbdw9tJVXMiW10eRNn/LEO1JspUcog/+RXMWGf70Uw7ZHoJb1VFdRYde55Jmurr3Cuc75GBD3lVUJblBtZm7k7pEsjHiF/Lnxv4N7lNVr8azmV+7OsWlL4e3vju5ljStHlHjOn4ZLIofICDsSi06WTaEtHuRohk7Zw1N8x1//bGpS6G6dmzNeRe2LpQPdD65SF+Ld066PlGCD2hNtZcF4aH9EFfDrVlXKRTt1p5jwOVEjPzyVIDpcQ8Co08Lr6gQ2UsTEXp47g+bdZUmrh7zHk/E23JDw6gV8GlmHEdTCPZwA+IEEdQoG7SLt4Jh1ubej1wL7XcgLrPqicWd92fjdCj/m27FGjRDF+xL8dWZyvqGmPml3AP7pCqZDx+5OrqG8zkbcAMu/V6yyZvWXziKSf7Mb7Kj88lAlfG2XWI8HS2odDAYaAkiBYW8Raavo9L3H4c3oNXMZ0LPxA4rQyrhylwZfA63ga978XCEQYAyotKQVg+ufkfJJ75Qft1c+i0M0eOXiYFZJqHoR1c+OVYGp3XuSIkslYP74PgO5BwYgX/bp7wkxtbejnPen9uX60DUIgdOS2I2YClWpvdnluXTKM7e8gCeyXJA6wABT2mm//XPi/cI+q9ioBCRugmPs5qzPxcA17MLTd5HpSfDHxGVeH2n9QVY34BHJT3kjt5B5zedVhGyI0EgvNivIHPRGZNPF/a3YFg9Bg0kAI2YtiiqHvAyZSdV6fe5hpxyFYcKNuqW5iIlLdrIU6N6fDL6MEKZ2XtjoxCe+TneOUIP8hNvdvh+6VMskKPDikFDOMDZ/wPOfbR0cxdlp8duljjPOE0jYBHPddDwqeojVNxLBM1Sj06EeJDbaTYkcLL+ZMN4ZFE2gyPGS3GpFgT2bREX3C6+hOrSHINvfB4CEuQ+CebD840uxpJ19icqCQFfTcwQwFlEiqp3eIm1zir5uZu4kRZiYZs4dxLSqjwetndbPOoV+vs5cszjNXtVEx2/6OtvO2Kv2/YvJAbwvY1qExY3ziQc8F8dFgcS4IpFVohFyi5nkoNZQX0bursOym3zCvjsV5yF5xFtk1SWzvIdpJ+ODW++KUozB56+cfMmHWoraaUXruk0jIsHyW4V1WpqF4XtFlaGgflwIdhvd8BdZU4VtMkzgWLzjcosPpjkY/SXhNvsvX+CToxSWcLQJ7HVAaxKkAZyEAq0OfMZ364GTUC4BgFWhZVHtkF27hLdF/K4ywH1sH07yd2NhGaOwdD0C8qEXSlez+BOyM14NefYlNFH+uE1dcx4wvfnkQLeMk43x8UKt0EQlfDkp24iJC1ExVqg8MfnhaiEe/VUqg5YpretoXiIhgYddgA7T0h/xterVIeQG8r065b2Yw71LRCUd2EnNMri5fp5+qWIxUCAi1UrCzVFogfZgqarCMIwDs2X5v0N+8J44KaGRJXRV76DSuFPrBjQaQwlekM3OkqX8NtTe8flRFfFgohgHAh+QlNdYTar04nLypLcsZvY+PLIce9unoRoUe9laY/JmXuadGFu2U2b2GSahcV4XrWLfgodwPifnHipEy3Y4LPR5Dc/N+qEo/7nVvXuYZ1uMZMKrXVb8ZWh561fd1Nlc5vnuz7Z+ZdjDzmWBGdFzH9ZckrMsS7qFl4g2nxy54HOo7jjK24J2s6/8MnU1LqE3KHsQvRS4Ht5+RFbhc/VXrHp3TkbGrl72b/++QvKTrDsSkYYkoAKefvKmTKPVJ3bQ7BQgw65ndhQMdyxqBw5mcKZTa2A+S15AhFEBfP/OutVhy/It1eR1z45mbMsXM0cl6PQownpx2SeKWjTthskzn24Let/GnBi7wnTyoBswwMfezmVCEe182T5JvWJ2s3MkBYfWLcidWtV2rZVtPsWHl5DP9FH8u4emt2ZGxkPrfOylHbyczBycYC9MG22Xm4Eurpvdft5T5m0EwpAgT90j7ESkMvb+pbXzWeydaYT+aW+S2nmjTqa4O0XqAQQvHYWwHYu3zNC/L8dKVf1wqJEg87/9Z/1yk/6rpgTlqqJGxF5FVuZmXrd0bUf5ruw/x+bznjRFXNr4o9glfw9o1cK8nS3/zUv6xUV/7DhGjAer/RJ8fzuz+91nCpXdPf3i7PbzoRee+2jTCeNRjWZhTnS39HSzT5x7GjXAkdamvivodLCX2e5wpo91/HYxb2INM4UAguv0Hw+1jrkhT2QWbbRvBMH/Zjj26cbcSHoD2neei2XMyqNX7uQo8AIO9IgJKsjZnt6YnILwEWqh4+knVgIA+0cHKk4EnS7eduQmH2qtzSKl6QzPqCfS3ZnoN5d/5hjvq6rHHwbKz/02pq27HQZfaWLfvvR94qcxTtKaAHxdsaaxE1ALfG6Cba9S4hEN56dxXZ3bp/V2IXetb5L011ANlUyOdMzp6BILtKQEjDc77pYWIvL2rQLZkT83BjsoZXue8F0XSyjlmPrkhi3e55G/DtQYNnfii/DieeQiy2WepUk2OuraPdBtsFj3yjvgPV9k89FSBWT3lrZeYfnaLMPuDb1jOWusRIj8esgVxhbAySXG4QvpWMF8OvimpFOzv8++OgrTLgrejpZALDu5fxdLjaxR24vYvvVkSp7x+UIMjopMnbFDHq5f86UhkxTVXbpOv83lkwOKhySIRcyJVmkZ1IZVK48KQrhrKHKXHJQWgqlyKSLvO/MOYkB5C6ihTmf8P4budFlRh9g8vPMSlDEMA8eF4aUmQAGmHq4/RWic6/954dE3jb8GckS0kXNG8B+uD2rqL7RTh59HrbPLN/yNOXZi3Hjcgz/CuzJqbMA0F8BrBsDf61zHpe/JI0Xi/yoh/ATXM8/utryb+iTOy/pGeRIIXf8eHNlI0kBkI0lli8jIoBrlrJ0xLJ3X1+CkzfXJXVPgVKzZ9Oj17n3EnDCKRYktYSZIZjNyOAv35D5XroI3J3h+aKBxG+f1PmH797r2jHUl2sRNPXdT/fPUhLHFeU18c6pXCdk3DumSd8hgqF2WdpCy+DM+jJ7M7TjSL8RLMj2uCJ5T+VOYQU0eV2KZ4oaV+j7luuyLceiIuFpJp63k+R0m+RJguZ6GZzaNh/TCqb4p3ew9rdyJLeW4o0hsE/2YG6kQ7wmZWTpiWTuvr8FJm+uSu0bUIL5q6zsPOYbUDFaqBhsRdsUgovfBocRiswsKm9g5cLfCGfB3xD6rNKQQOlaXL/4HJAulhiq1HJnl89try+wFnEPYueAvt3rHAEiQJO+x8JEmI3EHj8bBbxYwRSBQGZzZNVIpZJQDIiLSqZjKlVZUGvB+YF3f+/Mqe+oc9yPfTl+X5SX99MpDkOxfkLWbiv+PEXxOA8QYWhZIUSEwyOWSF9KOg+wilPH73WGLWc3N8iv0j2QwpS7HB8wakykkN6mw/Pu7ll4LKlx4hiIgZfvOdXLGw4J+i7Glb9oV7wvmD85Dlh47uZ1Y4UUuSKcyunGq3CX5ATUZKzGKt6qtwJuE+GSbvy5WCtKuaslNinf2O1SaHomHqDdICs4KFf3pNVXBSKkvdhmJmif3BO7dfsJGG4VajjNbePfZoHsIOZ8jS3h695bfmdQIlMnt/XSO4KOaBKkOIjZPNfaJ/S5ftDtQQp3ygiC6lgDHezwf8IQ5dJeXN7sUWJUvGD/c85+mSBk+Oq+g1MjXfaHjMmFEiINNlGVVrgnSNHpN+WEG1lUXkR/q33F8zR5cqzMGhQCKtNk1kUVLPJLqtuA8sui6tZdCVGGoWnXYO+0am79B2/iF94f4QfxG5EsQlImTSk3Vh2IbY2Ie4dGKd5eq2tGG5dfi72swGjqxk1PHFaHJndBtM1mf9bey6zQRMNvDG3LjXKsHYMckmyMEMfFdbHjvxRuacG6VXMEAfxEImQXz0gm3nAAX6Ba0rBCAeeOf9Wv541bfcoIXWOmOY/17dlB2GL6f/0DXOAwlS8mlZ37omgJ7phqPdk5n2xzA/ZDX3WfV9vGLjaaWv9fl1C4xKlcFEmaWNrK6Mvv+e4udZ8LZ5ewPMxzirKtviPTEdQNzt+BSDYty45FP/ASs0THGHMR0Wjz/E2UcGg+K9z8Uae2S9tMK7hF9J9O0gx3CGPhEBvqZOrRkltrlIEqofi809b4VGem6vCO3c+8hRZ0gty2bcnMvkzkmx0+f8tUZVC+qrjnsxXQqG74fYh1W3vG/4oqhSh9iBLy9D/7bVDW2qYxhQKPQegUBbaP0VNCuT98LorJ5qETC3BcnY8GaZygxiQ4tgNLEIiJ024TKLrwoln8hYk7wZatKtycE4bhEY8Ff7zu/gTJg+TWg4VWf64J6cq0a0ULzIDLzJpjeYaN9RgQ5zpiJwIg+n7huq+gEqZZ1STPt2uVQtP8x52pdEEY9qq39aKTVCugFlHiWQv50AmgZL8E6O4tWTfcGJzE3nLuw4nk2bAO1gKcC51l1FA1dLy+l7DnzKTFCVjUUJGQia8V094KC3pNldhHPwSU9SdzKy5zyH0DX78XfqHsj6kgba5r5mKB0PkHv7H159s4jKP1hBEmlhzN4NaING8ll/b9H/kIRBj0444p8roK74Sgpb3iRuNjNz2FND4jFXGtRjZ9MY+ZYrN8exw8XYodHot6UPw3TBy2JZG/kC/fTMG1uTseLrQdCbegWoElLTiEM3//pp+oq8qJrPStjQH2qToLluM+trLiZ8Ekaf0btbARe2MxEuPzan3YNLyyVPktTAVdLEk/16r4gqLAgPqwVT319ibq9kH6w0qXnO8vY3WQNkWE+FVUbLAsei57U3c+HpY37Eb6Zx9hPTLGAKPTUmWfb7U8Bh9TWESx8NAwyd7QeW8XMHmGFhor7ehjEfyx9fxIGkX8mDUN6bc8QxldBdK08BhXzsOb1V2orKXMpjz2Lto2NAUnRTnfwRI86pkB5uN5xO0QBUn9KtYcbF60smdnV5k6wlRuS2I2aseR5NWtlC1UQ4a99bXHYztggVNITHp0ehdQTrTYq5qIkWNqHMOj39oj6nN27NA44XlKdiQpQ7iVD//rwCOKjK4HUIE87E1GPe1YkuYp8L/TKaqfqkRA7VaXFUNe8HkktBGO+mKQ3VWuCB98P9DFArGFSYwhIEwkbdOHi4iJTWSt4Itskvih5DAOdw7UnAUMga69LeVboygSPEV+qUqysbh1R/vwlHxyDUD57b0kVTQ4le8XTrYuDE8I673IjqLGTy7nOLsTT3MYa30bJgLCM3ojLaNsdGITkyoaQtQwc/09U+1DwOjCexKUXiVaKZANX3oVdFGHnHAAd0F2NMuUeifOA45kORbRRg5mUO/LZWq5x8A984zHmZAoBknmxbJImUBTsipa0LUygyP0Owu9bV+M7htUv7JdmFZBsNe+OYKiTLscM74Nhrq07mn8nR1zwgnx9HZ6Btw+kosribev6JfVf2lmfpw4XkL9IEbkE7eGRUcKmBkJ3G+suQZTTezug/0eSrGnG+To5dp3Yi96a4jloiAJ9tmcrAfD3G6adP4AX6+dNALxWsKflHFgrgQzr6lbKc4ieEWJ4FqHi5j33UiZM4zJk1vuWj745EEi7rrrA3+m1VJuKcBUukcWzPaMKHONAlfMA2rVekJBOKnNEkT3yGcy08bBd5WAYz1iO7hhAMiQtlmlUWd1DHtXeofxAZ8fx1ZnKv/nFU+Os3Ck9FFGONo17MvXHOe9PpNxxmHUfxqAcEWfb8yB1DRVRsDW6mNeUAT5xUj0+sedY2iFV/tDcTzZ3KxuvzhvvETVlySF2s8UCC8T72aScvg2OBEB2bvRBe3moYzR7GdC4sWcma99gqMANBbZmupmBoqAG1wJGV6aAIcyPDeN3R6sW5jeAr6ad9TZVmx2vMJFhX0/AraIevGEmlctRSgwPFETOUp0Asj4+fVA0UKjWkSLL+e1GDkT9PwdL0gDWn0CcxhxaUjraXvQnBXyZlHSUodpLDYPwD/e8As5rlVy8j8RaUxqDk7L31dPx2tIF2H+evK7e1/Ab7omgUQQgXtZmGp3rk3PmUCZxKSK5uk+cxResWpg2gK0oWaKoCXs4r9GjXR1s/ih/Y53rUDPpoWfdHQmIAAWvCrglkUBvxkt4arLjnTm02PEv0cPi6dbFwYnpRTH0CB8KK9WXetMUR2ZJjT3eu+QsGFe7lYzQCYsKckhzim5bhSDVTAX1vmcQ5dwXtAcuMIBSq7lj4Cu9Zkht13grTIJW2V0wfFLRcB9LsnnRwYnm8VZoBMWFS3NyWohDqTFgRKTmyGLk17+4YGrV3b0kBdZkoRDxqfU1psB5MmJHBukV7v0j46szlbdzzpx6Cl5n0me02suC8NDz5c7w1ZV1bgxAv+3T4BscdXK1tZjFAn8PtzOb4ZOmuNc17HTY4F8NPwkYGG00Zpb5OpF7tLRXuhlLH3mxGylm+vSZK3/MnnIlRyCKL42el0F+fe8aLtKVqaaKWC0Dbrv7bC1tu2VmAAX5fpVCjp7yXbT0UqxnCbqOMn/BMKZmr/4ZbHEN5qQaCMHzHaDsUPufgw/2WwpgZSVbeoq92LUynlOEl3ZkpDCY0Rz3gn6qmkgX9Ex1SAezjO0qtpj2DEVcttbpl9W8Z6RkcTbLWRgpsaL34V5ZPgg8u2JuQ6QnTXGua9jpscC+GpcMkyGqBnderqHAZ4jEP4l0EFsjWnl+43kM4sZLEGJp3AGOJS+j6f2eiTTl23IyPaXCouYvhYfHZzzkjWG3/Bi4cLnTXV8qT9DOuqkeN3YPlamNLvMER8L74K57KMlwCKqSwqpCmf9E3GeHeguLHbteQjqqtGRCAuyUKUpnJTWffly9s7lM+oUpWu7hJHgOqJpEPgp0vcgjr7Mgjb8wGs6NMuOboEEqhPLmsEzyCY2yfDOoHueykhPxMKtji4Qj3ove7t1qTJ3BOMPkdQDqZ5H9KoUdPeW8+uxp0Ya7i0PWZ/CqGyjeIAyWSOOa4+mj+ZyoIILFYa9vK51F7XTJVokOHbZOVz3TiEi46LezRjbZGm4i81Q4SajQxOsJZndQ1M5s14VcEsjnPqnn9x6tHfZ4qQcETjm02PEv3a6Wy7rKjh9hClcwBHNC2s8Zin3FVzUC6+zII2+z4CBQxnwQJXzFig9sW64cqASVFiUrCnkj7bkvomye6w4SsOvPN6O0TdM1jA/Od9DLW+lOL63xE5HNG00vh75NRRY7Hlss0qizuoayKeiijHG0XBQ53L0WEp+l/EWKskh6irVfm9SIM7HOREGflOg8afeDGcYQceV5hTCKVpOGF7bLUWVNgtaGxH9s2TYgqb/5hB4Db89keWs278sDH9uLUNoh6YOerBRstyLNTG3cQw6Q5ExiaJNgF8/ezo2mX9W/aLTxozSezvHdQPoOPwRDr5UNy76A+J8gBh9DixlvyvifZOXD2VwuMu6lykR8hCvwg5wCTUIP1M81/CP8Vk6xWMUCvJS/PFB9wry2Hq+2y3in4/RT+UJPdrxyF10bqmPiaq5fGiCiQ29LAz/ZRVVpZTb5fQMaZG70dzrK8R6N+U1+p+gKWDdd3Hp0BqkLRs857ksr4wQWtRVOkDYhCETApy9eZyxXb/PxnU232KOJwyNO0fhKAZSfl0/NuvPxO/ljsc+T1Mnlzr8luV/JhpIloi8Jgy9CZG9oXkBGALRIAvJjWLtv6Glbnmz3lVpCMnE5K96wjF0nP+RmYGBrY2M08Ecz+yVWtSaQkGrPFVeJueFrVA/Of7TmQEzZFNjogsEp+cKlCUR+4Jq5AtF4A20ldui0EP+NSMhYs9CFb8sAhXBeSiBYYtWSU7JVpBt3WrWZyhgj7mpBoOmV1/KzeoJjDbYMXOBWQ+qGZekEJ5fpBLAsV4asBvV8HQP1lK+E5vD+eMdQC01BK4GYLjF6+fv3kYsf+Y/OcPgjI2JuI6lOwPNO/IzN5lI2Wv8/UBOVDeghSIknEEUvTIhRBfvRnrpqu42N6V/yus3HpLdDDYpHnoL5PuSPDELZIvrI0rQ3edToo0cesIOAXEF9BWzevnn9ggPSYVUCze2PK32ZWAz7OZTcGnWHOsibTRjjq7n2vJ3YeLaBiclLG6L6qV2BEkXE5xt83oTKa0YSJzo2WCICdCvlCN9FGLMRyBd3NR83daQqWLEAWPuBvos6k4gHsW1Z/O6UoEtN+xQIPdDiEG9CqEVIMW3ramf5OKlkudqARvakdyKgkOHZ5VuLOIqeJyXDD4Ul3hcyQdGOm1UMqGCPn2+EBcM2d3sPtL0YwbL1iLIomedqA/BkAPNjZOglTQZhR8E9Kti+RYTk6rak/W4DpkUqGVD4Zc9XPoaf1G2RyJJugUL80LmIPMKzvCJtiz0aVoeRxZqeeFd9QCYie5ES5uGB/RNtOAxVmw7QDabpFPoo6Cj9ISGZ2fxdo/EsWli5mISWw9ihdQMpbM5LZwIcPZ+XWk/zs/ta5fR5xz2qFklcdjTfk2cgaICYdjYgScPdrkbgNzTnFgfzCkAlXGCDakuNjWhX3nowG1whsaZfoMGKOiUOmp9smfoNjz4gw6onR4I3J2VkpQWBXJ+8IrSIpywOlUHJR3cBG9gueo5rnMgXgVMGU5q31XJL9VUa8W+ncKiD4Mk40bVsIqda3RxTrcJnIIVaxmCzIK1dpRaLrzthOJZ49fvb0N+DRtAfP9eEd0HmIsKPU6O2yglE+kmOHN61tfISMxtO9AZlZjxc2OihvPbRlnZXJ6pygV+smGEBylvT1EwVXLwgmyPZZGMjAHoGxhPSuyS8GITdcRtuVqagK5ujKLb8g1pFXiQDYBcFH+S2YHLPGNAPIJ+GgmJGizlxuuqMDs9rr3PgSJnYkG/Cw3BJryn/s2hMcOD61dCigKrAqMa0uUztpydTD3dQ2XXofP4jaEl0MM0aFYwsqrP7G4fEvtoqeFP2xRpDYDW1AHP+fNeuzkjrzLIp1uRK7LoQFhR1iVCi8Q5yIcBpaBtAoYx2l63cLw17DfG+Dhd9U+7FvC5POkfOf7fNDzFjnN/eydIm3djCy8IFSLEMuRZ26VIPFT3O2B7fcx9QKKzhr3m0vPjpUUfYShgz0gIsVtbX4JtN1tA6+z1ofsXeHsTPpZRixoVyl/di0B8YTuS2W8zVsjvDuZT/Ssb6YPhJcFNRXdVh81v5wbXJldmWA6aW4mSLuIcYOPlprcWrdwRogElcZ7ESm//XINbRmmkBYU6mfmp+DQOmaM0J1mCuIkcLs7+gZxrVRV4Qn7qDB/BYkFecvEjfLWONxthTd+CZEnB33QpASah0y5cxik/pYYiycNgr5LtABwBaXK2k0NkyoML1j2bq+h7aIOjFTSOkEF1bWwyMiJJQWIUDsLX0axhASBjZS850EmUJSkPUUQuorEAJqsOpeOQXTMg2ieVKEqbIgEuDAKB0QgmgWwL0eewPIpfn72g2BWHM9ONBXxv1bk6KchrIumkpHIX4Si1kQuSs0fBrlVURPlfyNNhMoWb2DOTH763ItuIwkBkRJGwsu3d+ufGEgCxE3wAK/U3UR6xksPeGRQ8yNwY+8mcxiNdY4CxTdjy8Hg1YFNfX39UshIReEzKOKuETNjLdbMrrAu7lQZfIB9OSM69MdB8Dgxu8anr9CHDLsMHXkMoxlucDqCvvbvr25Fu5rhF4T7Jjv1jIn+beGMYJq27HQfKB1p7ZwrjnYji9FyK7vuGdl7duMxpsclpEoLSnOYJtyEsgNnrAJj79IPsqQzFhRB6jEH7Z5W/p9KoK8JODzl3AIfuagP3AYwnabmhC6nSsL+t6yeK6peA0cSEpin2MOg/pzZM3lWDyACb2HDHwqD2EQUkzT4qayFs7L2oCBWnS9OrnWlla+kFp7bQUNYCg2qCuhyaoaTK0H41pgkS4xA92/sQ0PtGVoeLG0UQqIAtneQ6v0Ohe2AS0cUxXoOJ4qcq7OWn+AUryyZQIwONFzWOfpsCNf8cv4QX8RhP2uaf+mRsfGvm0qOQ21w+OIlzNyYBBX2l7t3V4OX+MEyXvcE8YQL6e/ZngnZWKR0x7R5uOWi9tm6itELAdnEDNy/yHX37NjrwOcQR7efBLQeyB9XqByWOAufGvkbRGoXvcA20aTHtdaTmDxIHDjPmLRn44QI8FsJTYXkFdxbmw7RZtQ/wTVEbDRzWwc4QoS/le7/dqTu0tPzhT74g3OF6z6hGTnUqrfKlLX3uASzHaKBirRyReFS5kKjfAODzDq0ywiaEd93HoC3nqGXQt6HmG3Gg4604pGNf3pu6eTT3Wh/srJkmrceOZHRbiAy+FvF2vCw6mRSBI27mTsFmPXlhxtje0aRu4TZRJR4s1HQG9zXY6U0RGs27Xo0ruFEB5HBKmkhT6VK6a63fqbNLs7IdQMoG1sFARqcbPXjSlxryhSK0wQg49rwOrWVyNj1vXEyrQvFFMMdQyMVkFTRDyCYBnSMfO5srXxZVP7LiX3qaLr7mAqhOLU4zoTRT6tjQE8sE4OFjHgqogGGACKFxieIJe0POekF8MQt0bo9Iaf5cqimevQjpfktoDMRK0SF7NHN1pqqgpBROzFgJyIClvGrisnPWcSk8uD+V3DNHgB6ga6EJZj8W98ltqMGiVkih8M6HJnJo8AFRh8ScMbWlPdiIClvGtdOafPaQRFsgVcww7PUAAs1tOA4RycnH2LisMCmwo4h/T3iRuNjNz2FVgMYnklBNGv/NZh+WLZalCQAFIuaOqXOWsgeh9+O/sekiYLKBMD64aOJgATV2XQvSgtvHIkMw+DnWT+7gEpns3D+ArSsq/+jhIZoqeZxX0AA3/Ndwj2Mi1Bkn5UEzp+fR5OxPhvhJibCELYV+9z7nN83yrj3qY13bbmBx1l0uTvvMbXIC3eCOqgfaychrpIEIxEoit8HqZZZodMqo7Np+XsezZ0EHSsluZYuJT611Pfeu3875BYlctNn5P0kEWteb1S+3R0+6fcGTh8Z0rKGcU7tbT9C9XcRqHIov0HeXOYVCEbaEkeU/4TYZ0HF1gu80lcg0xVpYtRmtvTk7+maUqZhVEIMpegr4bB/qCZtVVd8CxyLO773AC9dKON/10LnfOYp7frUEf5vjhOVD0vSjOheaRIIUEt3xvgc2sNBuBqbEOAv1P4cRVE5mhYkRRy2hYwkZh9bip+TmXI4+vLxw30hBKZLLCrL3Ba2/j6Em8pyyysqEwtls0H1ZmlNba7ejlXX8Y9nMZKkOxJwnTpM8o9KOJRh/bfWDFt04d9N0oNvVCiXlUr2s9IyLBkocuPCZqOVJNKV+gFdMQnZ4oTxfIc4PVuk7RzDDJdo1hrgfw+/8Rq09bo7d/aF5xyvgnGoUNv3Vd2x48q227y6IvmhcWMmCJvEDehGRWax8Q7BO+Kbue3PnF0ByAOJTFlB19pr9+cQ7rFw80QmSob2rYLqDb4dUVTEj0cEkeaqjpiDiO6/wt0xfgBvMER9AK6ZMY4jO3uKujDAv+kPkSHgo/bMvxj4PksgJxAZfodZSkpXOjpNKgUbuecgTFLJDQlyLdNtZjvDyq6nhJOejCEQ/QCh/JINeVLjU18ThDwxFcTWCvaa/fnGMaEyW06ST8ZybT4hBV43hOTIrgCcj/WXAJ4gJGt9MjomoSSfSTnc+z94vu7qphfsvs158PdFfkmLKR57ran2SAUCgtAnYsdQMiaLz8e0wJ1gbYqxPkMiXXpC1YSmOGlZz4pdx+txIjs9+x5kj4SKgRjJUacfS48R4/izpoq6JgtDhdUNzIRy1SG9IyLBkoYF/l5hjixxwlv8a7I46FWgtXM8krqrRh0BzkPksioktLpbRiWR2oqdt1eEE/ZIIIK2dTnf7ueGLXJM0A0vy0W6/N4BDsaLaSyBYSDWm9XQGOUy2uooVeg+fxTyadHWg4vuiaKaEC/jO1dwFepfgU1Lt8oQIL5p4t9Obaz61TzWekEb0k+R+VHRkhbKqAJkzApsnSoKIYFzEqBU1JkBHXDA0b3qli1v9c7tPiZWIUnassQ9kROJgsZ80zZ72CVeq3nGbPVBoSfflYWOt7ZF84P0gZ/WrSveKFFHwLJvYAHWhNaXMOq4LlMpWH1q8PKrrdwrl6XxMUM1UEnaZKZ6wJjh2Rc1zqslvDvcd6M7glZ9J4zGK0xmLjHZSu39H6sEV8+zESXoeD/Op+81UEaj6Bt5jcJfyp32aneryDUDsn4zee6AuUyrzg/SciyjeluKxOYi+RlhMpAZZp2O2zQESdPxro+9ZczZr7yPXFCTcJ++8wddDH4DOesuZ84DQQJAF190yowI6hNysJy1h5+t3YPic9rAfeFQzE8tv/AIuWS+OwQ2Denp8/fEtgZreCGo+r76/SjIxhm60ouMvfF+BRRaBf4oEbIXPnnpkfw2SO6thw29Mx/rhZUp0Lt5V+2EY3BVU3xUj7yAjEKjtD+xKpPL+uLaKTBE62ZOPEOGdBT3EpgK9Iq9QlvQ7mv+MHKls0i/PCvjB8WrWWfRIpV+6lnXXwRaU2uRc8m0HaompQCcuu1z7EG1uVsNLqH/RDlJhQwQGPtFWaJ+HeIy2YoW+0jvPFNOGCtIpNmcXwx8UfSn2QRZGfDVmpjpMx0yqfBGIwWbzfKpS2eQRcAPaxXjdXwxpznLE0pcTTdS2hdsAELCuPMdfI8F1MFIF1pNeLuJbv42XpoBGYXOpbnrLoAoTLihH+INqBH7nEy8AwBXh7zB+RScNlQ6RLbKrU629kTIabMCmR9CVGxejoq/iRQ0mtwuA11ZEtRaDYKrkUIqmiNyotqMMFBm6nDE5ogcOSIzpikqtAMGCeaEtPKVbiUwFk90LC/BOdiLtNs6wv6AY1ypFLkc0zuoJDoLJOd+0C1n9LZykae55koa/IscApNDu2iVHU6On1RrmkkLjrl8rBIIXekLxdeTxjCmhuKOQEgOPTxYJ+yL0+bl7GbiUwGvJZ/zquOZp3LXJfBdnnGJvJco2njlFdTNakABUERP2RLPWFwLwaJ3L6QRWqcTFIhNyEzFZLiSIMz2HWNv/P7efmtdanowcvc7h96f5rBeFcQcs/X/C/pIN0fxsSLbqyMVaNBmdkH8W73iRyN6nTthNzO2IvpzUepr77iQvWHKAEueHs05XfJdaIhSlWrhnL9CHD4UeMNO4CQbjYd57trPZ0tpjGepYxA5HZAiqE7QPvw9L1OvaL/cZpiQh8c69UhzYTheHUyJCR9TO+zUm7s4k98FKfzllqqZ0MMIDtOC1dJiXbHaWWbDa6WY7oy7Rl7xNHU/IHAcnAaqY9Ry9iJ5FISBdsZGC5p9Il0fWhaR9DGfoPlfgjS00KE6y5XO4ApeJ04abBdWZb6xiE5409GE/U3/whxH0q+UmxRjKPj/IYQHuNd3L5v1hSOOHB6QKTSKW5zID6atVJcNOumGDr/6THLFJQe+jq4EXSvhqSi3Yk1byX58XOK3B6K9rjuQx/4G4Fn+yl0I/QU9HyHj/zTmrc8wQ52QdazTGnF6jg2TdNokjQHkCJJJp+uZBNPuNi8NlbAby1vEMnrmrrRezbEyDdCGP0xe/DRkUGPhU98yUow3ZofgRVgkfHVgnZFIYGuu06JysWcNQJAzIeKURgL7YptNqYEcJLGLe4H7StmATlAsjc9HVqI89eE4DKNr5E0XfGUhKZutOo3ljqF2stj3nny3EDZPuu5Mc2WMdEZcU6qzuZNLh3AElBfyTU5wZPKSK6mmqnTyvxGOSr+tidfc17mnVMWzNgY5B3PkVrYgbbuWdej62wM4OFEY9esHWJtqSAhLkIxqgNT2ReiopBXZg1xCLUAlEu9l/9c56FY6xwjk+DbxRr9lh/N+uEMa3Ai+24RrmUXm4G/Ar54JYefuq+Bk/ZYxIpUV9R5/UTnfo7/vp7+SuhwQBdlYYxkA/y5tBmcqftoJCCedcj+godFGiYVJL+J64h2/rJGX7LmnhSUX5CuLTdynSM5R+cJMNjCgBIDDvFboUZDx1B+MMTfKpUQiiw0ajr8DGr9FnF0J6KO2aWB1HS81B2MGG2rme3L/MOd8yMSyFoqf0iBXXgGqUQbr4x2kc5mZJXC7ANp+YQzqTPX3/y84sZapO9sxYbvPAVplIRKbVarpt8feT9GqTC3cSR+3E1Ot67chC52boINJtwp/xFULNAJDNgJdGdhQI5PmFVH8RQb2UVCzhxzz1NSdyt5dKZfka2wKgmfKjNoACb18QcqGVE3Ak/v3pc/3dU3GBi5aCy7N5ReKrv9lwsuGdViLHIdd/+O5y04Hz5n3ZEIkqmMycgTENzxJhh0vRSfw0s2q4Km6wALJkAFc4yQLAY/pLGLe4H7StmATlAsnqZuJTFgxs6hBW0vl1pvbs7UTAxyDufIoj0vW2BnBwnm7mhnbSmvvBIC1CxX9cQYl5j4TtM3G9PsDtLO4S9C1jr01XfWWvf1csnc7dzq20t5H2yjq9/LYIVXlM0qQGIAASxjv10WXQVD7eDOJEgNkMf+gPV6yz2BTSsiC+lFPxrcD0Iths50W37bk2ECQT4GVyevitjxWOgJyHXn2xbsej0nLj4XBQJLlK5PtDOPxEBZN0T89Gwi2hlhRgwx15uiDo1qJpmwkGX6JzHp0Oqv/PcIiqWhGipyJ9NxBpCnZIA6PuWrPv1ja1kkQln8yRVN0kD62kFCS2Amm4foRLJqwfq/kCYLvzewoIeEyM81UBmATWoCO+YvSP3FhflIOrJr+RzNFLc5kCI9W4bt19mryIcPM1Ma0OPq5MYFgBNxCBpff0C1ljMBReG7dAKReCjexbypKTfEm29OgRFPcVbTYmdDwMEfpXXZ+5+9ngDqlpdPIvjPx3qvSyOrjZHPWLWenzq4uQ+yEwGCqg5ohRGpB3WQoiqAqfbjRf8xb507BE7u6ndeYGtSx3Zi43tDAN9DFDXb2leehBoIJ/+2SXrThUjIuA+YbYMdKPUtWEadRgoSzkl5HUgwPG+UckJ9vNB50xgv+NLkCsqMqYcz46OD3iFGgH7GiM+xYv1+l+0OD+6xA23TmazZvdjbK5J4pVHIO+Z4sLMTyr66IJ55YUy/TCRfN4HCuDzJFZr6oXDKqr3bLkyIlHcZbHNLqA+uJxNhdbX3IPye5z/B/F6OZaE3Tk9i2haGwlrgtLf743cjnyC9acx3ZQMH3dy+b9ZJ6WUbn+Y1BHWw2YvXOlSluGus40+zKqtZ/73LYBvfu9Hqf3u5GV3DVWMw3iZ5NsySxi27adZ5KxlZeTiz0kvjM1A2UWPLWShvtQmZ4z+HV7P2YyIW2HeRx4iZPi1DuWjQnAzGhYjwWck4+a8SNigNWZYr7/3gUcqABMLg9JQJfKpjkAJ2c/3XHAfvnK/BGk7Vtyjwrj5wnc8qLSC3ScYIIdKvk94i7Jhdd/j2r7+lGA6bKQBWIsel/v5gNP33Szr+qu4PAGAS297cp+vy22CD//e+qgi3DcDMSQ6ruRSmNdFrQCc+hhd0M7AzZWjlZhRoq4Z+wdBqBrKrYEHXvNsyklLJP6Te24pEaDuQLwOdtgURJhgB7ptxjBqn1tR8hLEu83IF/KWRd0nwuQ9bii9zvAXNwUnqoO0L7voKrJXzqumCJS0HPL2OLvsiamWl5m+IaHY2Lz79ARCD5CRPRfYPsSglTovgnZ2+C0/W2BnBwojHr1g6xNtQVokD29YpFU8QbLd5Tv/VCFjXBrNT9QZIWY4xcGvCE0kBj02KdpsyMPxikq+B0jBRkzoSRtMTVkD0eHugNNUlb1hY+bS6nXnu8+CiAHj3Mh6XyKI8x6V2mV0WtBWOMEvjzMO2d/2FxU0y/2ucr/A/2BzMxQmxkiBrBezocLAyBSmR4PNhaqf/b1FVPyF4AR26H8TSmhNdTGdTlCT3eKTurJ+3hMUq12SPBrlTfvw7/p/nxhsRHhG+upfAKhjPCnCohAXo98hO/GWxZ3su96sC/qidVUMCQc8hvz4sAJs1Vd9H3hiN8AcjQEahPfAVsefBZq9K6uCL84D2zrtxiomZ0lx5IY/aHjVoKXH3UJdXqTadEZyTOUXmQiLl5V3o6c0UDO3DrvXE4K/8jWIrY2E9HQ50ZwGaxZ98/TTRNw9k+XZXZLvBJ2Qk5FcvVsS0uO64k4qzeUyVWFlh5gvF+sw/OIGZ48ppaovyEAlz9iovT6ijWnPa7PqidDIZwF5XN4wh+x+NMC+vGEi1JITkMS31QvSovvvRefJVt9B6ahgLGLr55APgILZoe/wS/RPQp1fZhGZKZMlteap0Co2n6bCkkkuS4KY81iOIduabS3fiQhRNA75k3V9gO7LjlzcSHybW9aWC9/SzzjAc8f2Kfsy0Ud2adQLvDCvXoLZXYF2SfR5Q8DhEcrja+pFb82y+w5/hNYs8vjvS8t6MWBEFqQEYifgMnMOADZJXeAysPPZdQFIwUYhpv2PCLv+pBSu7wy/XVM3ekU76q7QmeDqU6S1Y39sognjHhgL6hDay6xxCaEu9Ovg42buHdi3AAbUaxt/xCt8kJJXDUY167M0D67JaLkTMYybNQaQoaxtzMtmH91BVX4D+eM47bK+M3XqzWatQBIBCYb4oLzJZ5424t7PdSIg3ZnfqwTr+w0ExxS1rj7aEqhp0NrNFwTUxSQ7k03h9gG9L3odUo7s/O+BXCF8AQBp8sH6IH+fBisq14IjAQxsdM4hG1k9MaqfdlDDp4PLlZNR2+X6Dgp7rXgREak0/apuIiPxS8i/Kq7hc5XLyuT9iVXc+ttxUeEWZOHIu/G9MZAketQxH2o3p6eo3mlmWs54PLMD4O5u+91AXBoZKKTsDjSXQGyuN+xxXLv57x91WKlSVMBdi5OUdSpelT3ERa+Ko9pRVfBax9zTxCJn92fIs9FpwpdgsDBD/kALD0k83WNR2Wj6lntHe326mf2Vb/RCE2YnBOnvITD7VZQEipetWULmLyC0QhfXaXVc2t6WE8amEpAvpUAKW8Tq7OUOcm/nsuUkeHksSOPADlgR7rdRSdCi1r7janPqD+DUZ8/CcFr8t3c7BdXSYlMMYzI53/66H2hmKPim9y5CYfarKAkVL6azDs3JXxnwpXJoRcsY2oV2/omK84EUOJcTnrKSOgkJTe/7Lyv05/HE3C3KfWmsL4fgbPmvivSWVkFQSIk806VtbXCBQAwRcQvWfFKgWTlmEeT3So0uGmbrbcXwGz629GgQXZU07chZPyp5jdlzcISb8qfEtjdI3MFfjm8m9ZORND3mU3IKXEDQ/lD+F71ManP8HtIvDNGupXtuZDiT2uwNTY4ulHLYqGVToVI6l7Khkcs7MaHxXzsW5kAMbSdsmFkDKPtrvhuZ/CCWc85Mzbc3CBA9b+bzhTlQoFAigbHuKu9G+H4n6PxrW1+p2QijwWtfdvy3J/MTYCNdrvhCkZsnKw0vU7f8HMAPl2XmszmFErNG3Fqv6h6ROt0kRQEk0AS3uM8t8U0lOWVYDD/CfR1wT92ejjq1oTCzgmyaq0Oh4BO+D2jVPXTvl73HAduXuk1L38qpK8hsEuPhIkxdNPDC1w/QSFukIcX7narxauqAjTopwg45QBNyVA1ii/kfxH8taTGg4qgGaLBUgD8PsfRI25V8IZ2VjRVcyHXRRryjByzJojTit6nI3kzDBSskjBLEnIkLuNK/xCJe5ZJiwaT9qBDH57cCMfd/PsF1/wf2mLEw+SAzRC0uRWZIg0rkBJJZhFk1bOon9uQe0eZf6yQBHr8qoKKcyyEGap8/Ij/Lh7K1+q+v3X3wE9nlFmR74soMVrYKSlaj73g/04W7hI6ZrMhSa4d3mjYPG8pZp1JqdrPCv3DitjYGn2f6vXTfeSz/aMk1EenlYou+t+GiDGbxs09w+uAcMKK6YK4eR0FsRsITS8tz6sQAc7Ht5oSKh2O+aj6VnqqOUO2cR+umR59OZhHdXqYfVSaXUy610ULfygE2Re/lR0xDS+DbBWWFb+AfDvt8btLjWuoMyikLEk5MyvzUQy9zgmyaq0Oh4BO7oDBg3JoFOYYNKIIU/iwsndvAqXoS13/ogbdaK4SurSCfjgXiPWoRJ2NUIKH/z+BZdpm01G/d8WCqjFUFFgs/ePx7vs5Nnzb3w4zAs4nCezaLFyirfZ+9KacK9enG+2mIq3QdPfvaEPnSpo47OOrNWWRb3HJBSE3tCaYnYJxOdXHidEmO/yxB4077DzBZ8U/os9LPgoX3WYd7bV19GZNQlNGWnc8kHVu3xgxDVAMj7OL0sIZ6MXX/FI8g4Vs9CLCZmIAQ8BYKosWmYsoT16oQaDUlRWEnyN04eQ0JT1fTV42zRWeeOYuraUS4NdWJmTXvmLEylh1X43fLUSh/+gBTTRbbj7igscPej9O1FCFWCzlwL81pT3YiApbxrJqCdj77PK5TYL42Axb0owzM35inUsl3CpvyQgMHsfWZ39/bV4tCLG1TlynFeOSKPuCKfKqACgtDqV7p/o2XHhSFcOQGvgNw2IA8oe/Y59W/IVG8REFxLh/yC9sr/sESJsMBFccgT+wtl/Y/9+892Bpqvy8cX8Pu7xGpHMQs9CY61XMTEM1Mm8RFlyzBRnl2ZFC6uzugN1SobXGX12enZMRjlTRRgWDeq4ttyqHb7IIFti0QB8SrOj567lKtPnP9OrG+CrGslAGARc6jzUGn6b73wVUQDC1LRMns7Kg6b1MTTvS5KZAIEZmqv2zi43IR33puSkLsvLd1VThh4dqbKhqSZfdl0UX9z9dHPPZEiYH11EJT1MD/LWq5rmskmDpv+MBhDxHBuLPpdlT/vrYq37C9XxrlPr031jT9GwVMiqawYMf3URvxSeQI/J4xhcT6rJA+9+YTOIA+7JvdOKspnr2jSlx7t17mVHTzNZh8uK/Mgx55ltijNj1gT/C79EC0ikW1/LCZB7hZc1kgi/DHWGZCg/+WbxApqNPvS+s2vzQBsPQrWQ51dD+YyjqTV1G1T4/CBsJzKbR4bV5TSr8rRI98qHID8CW14dj81StHGkW7JFCKE33DvWlX2/BwSdqa1Hz6cYBtoZt5q/2qCG242XUUDDneKzKeCuR5/CnsQCkqwk9JkpgegxmdDA/llACMVjMIsup+tivV4UfoqRE7osWbFOl1bGgJTZF/Ff7fYUgfsqVMTIwMp1SAE7y1qaDflErZmGWWR8ykAcmq0X06YFhs7MI52wURELeT2Ph1ULVaUS6Ec4rtnBwIEb00wN5vzMycBaxXZqMTVkePLQn7JmAqlkkR2OC8vhJ6IviNOhoLCTYM9rLrZGFh8BSSIDaBIWNSKG55tjJzSTTHsTV0+DTVFWFpXaR/RBsg2oOHUgqSVU6jBEaBrvaLCxzStN/TAMm3PBf7QYXnhfkErjKm/uQN0BVp2IgKW8at7gcm9Bqs9ZTeTyQLn7ixV1X0hUT60yCsUGCY+bxvSDxznwuNI9LcNNuwpusemowvWFVjNDgTLM9A8/s4Az3a3nWjDMd4MYr4TE2zcCwsWqfLMuOfzn4iV5QW+cle8Vpf2Equ8JRvRd4yUgPQTpnoOYZyxUPq0lfFXKdSVG408DKSA0dGud2ww1+m/RwwH9BsLHL2Zs4XO4T8OARFVQ0v9Mibup5qOtO6jRXB8+IjTt+RuhoAwvIRtxVs0tkzTgw5fIGW7sVAlWc/iucLrvVSUu9vTaI5gNW2VF5vxCbq901FakHFr5ceAA1hIKyS+ruybcGhiHPEC1n2ZOQ7wrgXAvfpcPwDm2nuUusZsV/0wVDyG+0r5SQUwmcfS7Kn+b4vhhSFA7hoJLN87+x2qTPjmviJeuiYFZihv3F9k2JJWtYYuPmOMo3tv/bzV399rmPj+JGCq/3JJ2SgL2ago89IPUjPEgTAtYP6ePIlyICuFU1MUQF3UeBisPGitztRriy4KLKIca12Bi3wkZnsdeeTjoKdBK8+dFkJaqo8jeT7aka4Wn4KBEYfWtHn01lnSI04QblTULKTnf35urQXIKkdf4K6U0v3XcCKZ+HG6rYXaHzoXFizklKjy4wAz6baS+yz26n2W8OKQL3nb/LmI0P/9ofb3ONMvlIc+1A1J0faxqFA2Bm9SZfsUNORWrrhvXOGmoII2DYXWdx5pDl//l9VzS6/Z7HZ8tXlRAd0MW+LX3npdPLMb2STSuWopUco9yNEMnw+/JwzNHjj0hHAOFnfdn43gWQYD5DxL+GW2xtip4WcQ4VunClKs7kigNRhxmwDBSiqko4jZ84ZmjxyaYAiDc3mSXzpl8a9GGFMpOq9S7wZjEmhbObb77nbd+kywJV0KY9gxFXK5xT6PdJS1BmpSBzFZOBQlucMnEvXHbU9zrz4DLbOF9QlkcHdMo1d29JAXWX0yMCrpHV3uRHUWdoLGm8ApeaL2L8u6ANRd6voPqM2aXlGUVxBtTxCdUBMkcGoHxaQy9lE9PxI5CchgUz7bMJFbHtu3L+SPc2KDuguxplyj0T5v+IAZCkqqqjGpsv+rL1W+6ykjGY89fXpJJZ3Dup3ODQ1rb9vPSageuKrhHQa/v2VdIx+VPVIpKCoJJ8vkKkEqIKejr7MgjbHvXo7aXAWrqdX/rMMrDsSQD2ziRXuqtdZpwc1c6uSpUkYdI1/WI8mcR/6XMdf0htW1F1YCLXhoJhmct4Obc78EckBCVxKqMaip9A8oeR+o2GcKCFEeb2aX4k19fsYurVFG5onNi3tSOoKVHmdi/5mE+f1viI6zfQrTg7ufFC6UbUE0sjrIj0WrVekJtySSRbhT2LuCH7e0jcVY4Sb5GZh3KyW3kvjiWXtcz0aUiCviwUQwCmLSmNQcnZe+rp+O1o8wKTy0KsnVyvC3mVX3wtN9Pt5fjl/+EaiaxxFDCMjRXnLOAzgTsbcXaIjt2YpqUDeniGMroILEC50xZOOLjRzj8agvYao1NfqOCwudTXXW4sWyMNDvbK4i0uJ9AAsuP9FUP+Ksxdlp8cqex98P4bFgeQ5pd74LTy+m1CR2SYu1AnUVWCEsH98HwHabTSp+zCunVyTbJGHAb22ROLaPvQb9L38zQJHrSXgU/ZoeOQym0KUImIaT+1+BYn2eKkHBbHSBiEwEDlTM3eGLm6ZuURoUvzFpK71ZdQz9rsO32AH352lo/4OYV36PZEGj8VHfrq4FlUd0uYOQcs+i0Dyc+ZV4OUJU7C5R0XVchbICYib7Kat4jv0j46szlXzBiKOHtE17bInFtH3nEb5cCjInBH5Fj7K2SgNQ6xNY4dOjCexKUXiVaKZANYulR/Iq0y+TpTD8jruG7FCAsZRuwn4bfgXDocvCo5d+E82FIfEzRcA5yjWdKttkTzJ3EKo7OsQ7UmylRaEt2/auPGHObRk3+4tNHU8EbMgpXoDRHLa+OO/z44dtP+5ULd6txxd3yrfCt18MKrbWbdaBoPMKZkzfHYmQ9B9tPlEbwXMIWeBAoGr7Mt8ww1cxl4XAjFo+SeYIs9Zh6TZY9NsLr4A4N2VslUuOkwE8cd64kFOp8929QWhTnGyCFvd8Inyfgz9yfuVs9g0exYaNOymQkc48hVtTLVB5OerVohie5Kk2czhncCNMnE40k33M2RJBz7Q1DrnVNWN3HgUXQaaaWmGxtip4xrMdikuvFgp5uQroj+x8/INMChP4iokm88MJHPqlFp0sj0TXnrQBphO/7sWoWpNON59j4b3EGw5LvJz1atEdQAU9ppv/1z4v3CPqvYc0ZQOA5thtYg//v6XJi8DBKzGk5YV4Dhrk+Ad2bgI4qMrgecWxWUgkB4zIddHLnkqw4pmuCLlfdGt/1bKcoFdZKhGgTHd+i/ZO+geUtNnTxid2y7y8dtkN6YXNzXRzYlCB+If1TKcleMfclDtdFn5I6MMWJOu4JXIOCtycbwxthO2iTn91Eq1XcFqqT+cxMjKZi2PMJqwYBQthQCFnBJuYBeXvHFkAUGCgXd3IXIbdsQZp0uQ1Te6auaL4Me3y/avG/JIspkatBVcn6O7G4nvUpmEBFUZLBl9XYiQVuaoE9wXvjiX4W7fcKPRuN111gb0WbJlVZc5Dj0znl0N1L74lFjQ1gjCG2Qbb09JQVPUqF9Pp3l8K7ef2r7CPcZOs7iFKzVyyQr6M6Jxo1O0dFOj2uo4icxHB4DnxXKICT+ktxffpTmSp8Ft9tDw85Jd5hWNrmtESHr0zs+JlhrtrTwZjlkzBouBBgF0BdZ97UrNCvquzUp0Q+q89HOEFbkl08F0ixL8dWZyvx+ObTY8S/S3a1+FCAs3eNGXGtOMHBCpqGNMpLzQHb4kx2EP6I/zzQII9ZW8trlTYSiPD2NgDkqOahI7GeXOWvzrrmaUzC3clymFeRxwzqhxkjJDNEbn7SZoYM9Aw4GasKjqR3xUEnsTsw8JpS9PkbwaYSsGPhZ2QbkRMy64b9lrfctH3xyQpYfeMKxyYu1AnUVWDyfp+suqcfxBQn7rrrA39QM83uqmW4jZNZzA7dRTpW5sgU2kiBfDgGjd3WD8rSiXRRsW1p4szgKusdN5q0mXFXYbEVQVZ3Gy2zN5twLxoK8L5BoS9qk/5m65cKiPrL/m+geEl5uvAWYpsMpkHc2hvnKebsDORn2INP93R0zNWCzDW5b/eblMNn+g0c6jfePF4rJOjOnkbFsCUndAatladlEIOEbMs2GtqkumJeQxK+T1xq5vwssyIi4BZYSO+X2jhcbmW6eYKjq3uqyRBWNmc4WnewaYVVPiCXjscYKGVQWWnsWpF+8keb3EF60KKxBgxFy67VMWwQLb0JD3ZYShannTMruchK0VNlKSsrCb09W4clfc8c01U1Xt4fX/hJ6t48OYMyu4XVHvSErYkxkRHZnX9B94c4MQA8rV1hqRerVr5URLNy3S7lEBHoMyp4MNjwLHLmuykReuyDR4IV+g68kRUcbIylsIGxdqb/cKXvlNTlvrVv3Yq3qdBOr+mwN/zrGYvJ3ujxKGb6tPHxYvNrwm3sj/f5wOIBZg4wTnQS81fFXRLW+8TaElvN2yw5bXKwGNNus9KCJemsaDpAg5X4pc9JZ9i/fwsS6XxzJXd8qnWkYvJtvAMhVNbyo4VO25fY0pGAM3V/PtzhOevV6WD/9rGDJH7TWzPjetU+2FxPsN1qMb1WpqFvWTNA3z64n37IduKXdE+INLMAmI+NGDNqcncZ4qlpQmB1M6v8C2mvbo++ejf5tsI9ngNovSVGQ8qDiclp/2eavChScSUutrWgzUzSYJqfoN948WRZTcKhxnB3Dc6aXelvBTRUjp1KJGxlBn4CFAqzSvHfDojdBJXFxV3wuB0+XFAKuNcpjvXGTCIvyw5cIDmiqds+NpKPvlpIMAwW4+u2YYZHvHXALy0kK4FypqLlC034XNDFGcVO30nm3RYAKdGkdCbUvijFSomjES83w2JgSRGNLuBpceWq5wuRpNntj3xCFBGPcLdPb2TMVSw9AX65hr4R5X5uQw07jCwYo6LGBV8/MXedBOEAsw4VKz8wZxs4Vv5bNXlh+OHFwxdZZCjD8SXqB4dtUW6BO/ib1WpqFvWTNA6B164sw6JXQKIej3onZSOLDpvjZIXZ01zjsG7wPtVyPet5Q1zz92LG2F1mBedifTbKQeOj+z1xl5IyaewcHKmDeJA81q2bPv5TFCHnnGa3Ogjt2L0xyxnDiEcu5wyXn0BWD5sB/mKQiTQJFVqJ793ODj4c1R3DLqT9T5ItKwS0Ej+DoK6vhqobcw1e0YBhzXtab75Xzn/BPnQDGRCutXv57KJVrzBy6HInBsAgETGWFGuPmj9fUOnsdEwkwrzPUDD8M966Zt89m1feW5czBPj3YMsY/R6XBl90DE1ey4vJz742h9Ay2mltMO68FS6sOzstN9gEV+JPsed8oyp1Aq58Itb52zHmT05+Srmtz3GZUJaUqGt9Mhn0RcPB+THR5GlOiCagFHAxO7zxiNHOU1Z2QHuRfP0g231cjp/BY9h3xW7lYFa31YeQxK7aB1phTNDkQ7M+zFJLVCZo71LNJIxshYbD+R2Za23VJjJmPWOQbTB1tweUqeDiWy8LqCAvFW39vVhZSQ3XZa0rxLCAHmsuu9sfoO7qwzs5pizcB++Jqg7mrAfxgOX7hzI+yzMVcxhhmDQ6CAlCOUIC1ry5obB1xMK2gch15l/0EKS+kGU69w7Qa27EzNylCNGY28tCNoLXExs8C8o0Ovjz4+avxpzqdP8LGMT9VGdIGI043k2eF5w4OyDCl0AA1lnVtyAvIXmElHgTVJj8vdC704YPJobnNCWcMFInJHIlTAEK7ONN3+7VA4owgFhr9iiuccqtEaylZPu1ffTu7hCmqXWpXT9xNYbUgeG9TwxErpI/0XVIReEzKOR4AQd6I+H7t6h8Xxcg0HaN2ZMSmGMZkc7/9onzRfVPvggvRxWoEmNndYdK3PhS7QhQP4vAhkWdMdqbqyvbV8D7xFpFqNPG/fJKzg7WCUkVKGCByuUQxqsqe6umts+pR2wZLtRIsvPq9vjZ9grNi5MeCT8ixW8cDepOvl2svB7J+evA3z4vrCvCxoAko08N63uOsTuJZWhpigTLswStVNI4Z+tDiDqwIRVl1zrGIfUrODJxK7kE1ck7iIKm4mS3ffVmsjGML5wNLv+7fxCqxRCI3zTkus6S9CMoa8iIkBkqcnZOoSGq16CdWmrKuRu6eUKVqrMd7SSoPHtUk68mU3PERciemDxeQz/2iCSnbGF2MzuSyS1e9AT/2Qf3jRruU/4+ftsxI0uI8+rLbF/bE7HIaqkTPidDNV3tTZfjPqe1HDBceC0VpN+mjUXGWbEVWQ3Ph3JyW1Sli0ElO1gbEIVQzbSXqrqZbFOEfrVm78AmWLKu3da2ZAVL1CNhbLOxVQbgNavu83Qe5jx6ctziWwbWeVO6uwXQyVHo+KF6sGvreegbL+FpBMRJtcb3qsv8dCutoU4c08nJsRXa6GIGX7znVyxsN+CXAMO7k5/AhI+I09uO7Uy1VuBNwnwU91J3E6zeI0A23HnsJn6bJuGNsR94WvW2rZO+JUc98BWyu9VxZd+1a+VXjyVcstjdAvJFqc2nW1rRyGQFKclDPFGsghp5YKDq3hpHm+t/4CH6Gs+R32lftyjNouETuEKk6qzKw0T0EvnWQDAOxXxO88Z3CfDJN35crBaY539EMAQCNUE3ISYnWxJyW1aMHvKZLh/M2yGx1jaL+MBLieGpb2qA76aTcJn/MJlXFE+eQBkHETVIN+mveJqAmesXJfN+GUpFUuLRTc63V9eQjNICrX4PKrMwVoCBnG1CUnKj0EsOH2ngMTEaXBqABc/m2UDjH/VdytAGDNBZ8Zomk1w/7iXvzeNdGVYaj2xcZfXZ6dkxGOQX2RfE0IDWr1H2gpJ54oo/RpaEr4RN6eWlHze0sRc1gr8f30jv43co9EKz96gGFeMKkSDCCAbEaBVz9SEnkEsMxqOwFLrgQszIPXHWgPI9uMKkp21Yq1N7Os7pFQsfdjOFCsitGnbZLcVUkt/YgTJnsq/RSJn0VH8wASvKMYWJfdGf/pQ4dmh7BT+HD5T/5cNS2ZsqRknl3ee5CKVyidG7pWYixSyYsfSEhmaYNVc/Mnn3qxdxqD6HRcIDvj3br8JrnTwL2N+fNMwYWgovECVIb7ipmPi1j4kpyctsgRRITArWucj1ofHokFLOPUjmLfXo6CJFriRCv7K1/DKg0+v/MaKe1Fh+5YXDttDObZacgq0x/WGsiUanAdPG+gH7fnurg843k2L1oL3zSg1+ry8bfMUKKU2Uy45yFF3m32t1ps6+ssNkm3FKcxogRnVzUQfP92kuCuwf9LVohPCmGeO/b4aQfx0R0pqI6QAbpVc7nm93FBBqtTDqMie9XpiO3gfMCslvGpGeE6rqPE9XH9KBxYIxGDb3KyixIj6TroixOvIcM8m2Tha5p4A28bAYk0BpFK8vzzbrjU6OI48vvol/2BqCZl4qoKUigf2X1wR6P6soDPSXWD7AXspd4AkSHmhVsQMqH3bLSdm4mmfQS17ddvNRdGuG6M1+cMcXt04fTNk672BWULjsex+wn1UReZIqyORaIxAdhFzz+tzULNVNi1MCcxXqkGrYDpMmLdxS6h/TcM9ZV2xILUBFVgQt8UDL65xlqqvs+4gztWeYhZsw9xVRJawiyLB9+GZxqN5DbDDWudbecwUjm2hwG7mxeABVdllqqT/unAX/E1DdE+DLTetux34O3NduWsZeZTw7PPpIZhLwYMCsWLkyiU1fsoEXpq5LwLMdjRp7gn6cu2n2xc/8nQ9ngXWMlr0e0QrdAD4DKhBcgnpGyMDH5jn6iD/sfVvLBrO2V+SMrkXMHZiE5Je2s8b8JqykywXa5G8A+iASE3EhTX8+oetTmZ98CiIVpqsCATPJ8t7UcORdYFaV/GAPTMc7Qca1CEiRy/3zYbpNnjWkuwpnYSJgcgufblvZuwr8JjPD4ZewOc+2y5jcTiXnpzjcQ9gLnSy0zHkxo1W6zfWT7CPIVuqa6ZpLVg/F1hpRu4vocpLcm08+cU5MdgJryukyI2DS1mpA/6+Gem7DFG6xaO3PkV5wHMXDmcTTH9Uk/jJN0/qG5lij1upToROYgZ8ywHl5tX2W93Ye0GNSDVkjRdy1Q1a5LwLMb/j/iTBnX/YFwZgJ9k43YhUrRAeJ3+HxGuGEiT2WgJ7i2Dm34Rr08vLCAu+bJ8q7qF1oGxuLVzpxEgyPBFVmrwt4PUwzcsfL+4B7hb2tyOp16lcI6nxevzMcbDvvgR0MbJouB+yGvuswX25AREYEu78V/L8dyKesMkeQzym1RG/hsIkNBL7Cqpii8hMJSUJFYUJ7DHH28O93/Twvh1D1PvVvqp/f72gdXHYmh8DwR3Du8iQZvE+OxjHG8OZ58WNrn0abxH2bDleDBeRdA664uFTKGVUzkC9L6/V17FE4+Fsi4mjtn65LUlYojTGjl2ndh689HqNc+sxJlfQfUZs0sZYaaBY8VAAw/QVfdA59f7KtbhyPZ4r12ytkmWjga+oUQKBVg5+9WGah7dPKRs68QcZjhr2XaMliB6wY9u3izIJAsmNDmD7HoWqfTI3e1R8nmcFFC/kLQsElgKZjwqDvdRtodP13kkVvc40zIXOUhNAy3z3/FEci6p3T/YRs5rZmhnZ/NzJWRvKvbsVox+YC464ssbv/e/rwCOKjK4Hnue56fjwJ7rsWrnWAM3aiYlpxQeKDYtC8DL/JhI6+0TnD7LQJBeZXf/Y14EgEcwFQ5RupWjCbUKCNcP2HzpYbDy3p5C1LHTHU/weRZ0W9uLtZYTM0/Fj/HXueSZrq67wVn+JvitBOGD2JhrKY10xKDbfbBk+6F3JQUNFmWaTeZb9DUVCMnXpVjTcwbX+DssV8vFwhK1hWrp1elbO0g1efvAHi3wu+HvP28GFCD+0E+bY/lucspDQkzbLuKZFnhQWmYyB26N0ixYIG0+suqcf8SaZEw7yKlmE//nyrhTAxWfvIjWDESGiAzWo+aoonLVqvSEpBL1bmlUjpRWz3BDK3Wy8nnKyWZneLa7hmpiecwc8VUtAkzAEE+ej0cazHRQ7q8ML4PVzHH2BBgF0BdZ97UrNCvquzNSVcqDNyxlNTr+l/EWKskh6irVfm+BeXBiU62j/JiGaPnU85d++oit7ZYFFscfV1CDIHysdLKkxlVf2RqbyWP9iVQD/FBVxefNiol7brrJBrFsR5m3zqL2umSpd2hinmpk8Bl3XiSPGea7/m0y9s8znOgbS/6VpTXyX0aZohm9SD3ZnwJJ/MVpwetvPQDBBlbV76jdo+qdtdw8Au680TNPCWyCGNxl6PLWbZypAI536o3ZIN7u/D4ihlN2LJxy30tAK6C+IaK4Sb4OnsnJhFzE/G9xIInbOlQPCdjNk0bZHvsSnB+sDii3bM12EqPFqXDw5ZqRlpAot8/BEA3/okS5+o3aPqDSTbDeZMIDTz1dowb7o782STRCwU4iWbCGOlBHirEO3JDVVnq60G60UKmZRU/tUyVnzug+vjefKt8K8N4X8CJKSSaflOn7wZwqTL8v08Sb+2Tq3yTm8hCLHJgAEv2AKYjLWscG3cXhGQhM46hks6FhJtNWuYaDy3qBSmAwVfwxseJ6iPKHF35pwUtnbiegoH6jZ7TqVfhTejdmIqQqeB2IzJp4v67Ry1NsatlbCxOpkwsu9NCvHHJYp4D3he59ApJFdAFHYOdEYSeVlyNGW2O+14IOBtoU1ugV6y7+mZJR3Xpt4WJ2LqF6Le8q3KuYyslGu2QOHrzXr/B9gON8jP3NwDfyjeoAjxcIQlYQr43+puyXKBlHe2lqGeE+Ob4TiRgx5nfTpQuCB0ZPEBFx3sLZGGp3U6n/Cstum1/fzd3Y2NbAa4AQjZODdLmTqrgcfLc5ZSHJxx0BNC2HeapP9gR61YMSr29vCig9Qvaqye9SYWH/UT1jYfpo0d/mtJZM47s+3CssW3IO+oDGmFm+975jyUGUPOsy7xViJ2glTC0Ql4Ike00f8W2kSfzE5xkRLQrefuMEtykJ65su2LQCORPAppsSDY09pAW1OaR3GnxH4/vR8IQLUl5zphSThgFe4MQNPTI4vR5Tu9Tr4hFjr7DjURSDK41uRNpedTUjxa/H9D1fg02LQ+LhOCOG2pCaspSQqIri0KHG89SqqVp9YXzHPScjuOa/EneZ2J0Zdzo4MTzeKs0AmLCnJIgvP0S+F8gPugWSlATenrzhmaPHJpgCINzeZKI+pfjqzOV+PxzabHiX7AojWebdykjwfjNdlsIPtt4WJ2LqF6Iff6U8A8AoVVta0T/T082WPTbC6ToS/PO6Lfu5g15c1zpRWdEDC/95T1H6JPs+YmIgy0b3i4QkfmH5DOA9PC5KFPi0Y9ZLy9TPsIUrl/rqygw4gEGOFyidzWDsTpiWPZ76C0ZtIdZuUnTMKY+FnXHYGrVGWK0NvsSVvN93F822bpyWxGzUZDfFQhcConyni6JCF7iugE2NBPe/xhWOwY6XpAGtPkPsUBpL5QZbBUGTgd/SqHbj+AB3L1eCGZWR/3X+R8ag5Oy99XT8drRp4sw+PFk7cNgKt+fULBKTjBKjAJzcU9Y2KhHPeJ6a6DAnf2IUi4/4QnyNhFpu/BwYAxDyVU0SkzbQU8s4mA1STqz/foQJo0+90u62nnI9ZUiKn+pJHs58SphMT33R35t7b4HnPto63VXOPgHiMc9CZfrOzaCGzbZunJbEbNWPI8mrWyhaU/oeGfVS6Ge89oRllb4VwPnzzEWepdSSmLOdV+xAdEdFM/5HKknc/JLeWoPTFGlQfKhWpHEk8VdvWPjpKrTNqTdhbpx1I/2uqBFlRK6P1xIUk5N7CrTV/XyrwBDyk27TuLNJAB+/XRi6e/fE1Q8rwEgO52/Q1vww+hdDe3tBc1jthE01SJxx7PRau6K3sW1eJwvyN+z2FGcMgkYNb+9RBINt8Myy0LfIB6NNrKYIuXUir6Iq+j3SUtPkUyKxPtszlYD4e43Tx3xo6K/c2+j4/vR8IWv+QbiklCZwbacFv4xjLO4rrxAt7u2Axj/tg2sCj9l1w1W+LEzPUhOgTMDIuQpAA3BIR9k2UQXmV4CZ6KX5pYtJP5ggpjNUAWyrGWyIZN50adLhBwrcDnGN0u+qf06yj/ySw2qOKQCOAsogM++j7GDdRGcIjr3vskgnFzT6116HDgdkaVVkCeLZkWg7bi2+AUli6ukVm2yFrEpAMLjx3uCpB82lPGpGtqLrKlWS315CFfdf8iZ+uLO71xrtL63Z9z1kbDCYI5Yhm3s6grOFZpamwIqhJCIpMeUGyEprdJ2dDPtRf2e2JuMDeTUCdB6wFbKsgq7BB+3m0RmMC8pTow+jQiUDXbqInpETvh/gGYK7pX8oeeVmBhzzE7qmWVtxSLH1WXbAZNKVht513XpJ4Jbo4eQ+q31sLx6XH1uQdxyknOTkIJbH0vvb89G1+o5LWBtEEw+5HnY7leNaZtMXZgHFYZBZXYJWkldsRDiNK2Pqsu1oLyxS2hMDYDkTGJok2AXz97OjaZf1b9pU5HAyRNhl0uUhksdeAM5A6xQIY15zTGa+ceLRnk09lsGagZpFzV00REDutR9UWF9JcRZU30G/J10+e66HhrS6aE3zohNPBZW7xPfNnQV33qAWmQG2IOKIYAFBYUupM/+U+GOFmNBPWoPxLLzqaE3AtUXAZblLT6orNRzM1JVn0Ux5VFBK5qNRIGJ1hm95wr0sdhGhHp1TaSU7Y1p5ifX3vE69zy3B9SEGm/lYi9clGNVrncL8K7bcdm8uKgZjnBhXF5ymqSSaB2VvcwjYoKDExpja/IqZEU99CLeMQcWGY65SMtYzxobJ8+qrBtOK3ALkA8PoOapZawj2EgCJmKgzgl+qbUePZ+66M3s3hL3b0tAZE40/bNzc4JT/EoRCpzHgtF+p0soec21JCkHfJf31SngkQXYWUD7IzFDduc9SfDlZYo2v1SLDjKsTeu6JE6TMMSMp7yFpEAlGx5PYK1VYwmcfU/a2dmqzGvt1yyqFzrLzXOk6Zs4/9cHvyUFWJMHcAOyuv9D5ZFWdDJgm8TWIifuahQ4BSEhtjG/Gp75RCCX8THcBXO14fs/oXzJXtrw5g6aXMJvRxSmxVoRGVY4bmSZ/qaXo5mVAuFewHtTwb2m/ZGOT+1gK/zT2/O3WWbyF3/PR5KNHRiM6biORxxXkR2mM1m/eeOkFNFL+kyo3OY0VIqxCeK/G60OqwFE6S39ZUD6F5ki3Y/TCu1hyJbgQcEKU/6AbMl0dVXMGgm/QcoVg0netLR36eIt/p5QJYawGKcjJk842S5RFxjNUHMDRIuOFGhxjCTr4D8wMvyhEphLt79AnMsCg8OoqYZu+OEmUmR/A9im/72L9EdoAlermMXXz2hmRStia1gqFuAJg9OREwcwVFdpGmnpc0Q8663+a9rwnIeCcwZonL9ZMMIDlLekUKG94L3jxFx0kuqMCu980gFavg9rQkAeOXtTwb2nNsR6lyF81x0fjJtbec3ZIAMkCfpQuVZl78JbkC/hhV5q2fLkKlDqCXLYoonLxisLpR914mMciiy9EVla6NMAbWMKhdpqk8sNUECHy6kBkRR77sO4kQpXEl47hBlMxtj0i4lX7jmzndOggvnLFJ3OMDK5q1/zbl4BbVfNTI38g7wjAFdtPTGuFgcmV4yNVjNE88/8xmPT+kWES+tspHTqTVV0lPhk7au8AGjvygIoWEeosH/6ytOJnwMRmD5vSkjWy8iGIkqmaAT6wcz6vL5xEgzun49Uy2BXXUwX8KxLjy4Vq5O7Q2h/Qj7e1NgM7bNascC2fAs+Zw4MI1c7/8I+4zj408Y69VMNNH8gBFJ9+dpMxMQnNjQ4J5deBf3VAU2myzP4wrf3d4WVrXOwLs/AViI3qD/aksl3hj2foBkOGLP2gLIjRF5hUECEoAMAHrB2TKCKFuetMlI7VDXoDOUML0ur38/mYHA4P3DsuUymss0fUPkUQm31wzDccn79k0KkvX/STZy7ZDvufpQt8j5kiuVhPquhdY/WS7RGGNvBTUBvuhWU0XHMNvbe0YXd7vBWCULji9yKa/Nr++ag/AZHeo8sGn+xWFLOaWZhsXFna++St+DSJYJ9Xl5yAGGzityAuqxxSEV7NOO9l8Kap6ZvnV5vBzPPzxjuMai53iz+jO8fSlw25kRLBi/LwGHD1qnJrZTtzSMPA6tNE6bC8Xlik75D0NVR6etP9wYg4RMj1LjoXqjr+RsDwQH4mCMiQMHL2Zde9fRifSr3xUv/LAOAtkwM9OMxrwAshu2Id4NFs5kMyuKOc5lwRl6FBJf15lvq5ZG7ImnMVwjoA08PJimazEUWLBaRndc1LalNRU62hqn4sjTFW5qk6kNdmzil+gzmGwUZ1EDPxtmtmcBopRkjrhvU1FbM3sOFvF0N3uD+2IP4lvaaW4mSLuIcYO4nk0d4kQoaXZhydVpxCGfbVrJlodCrYBbwd1BmfGh/njYVhl0WJw4mHdqq52OuDhBzQPdouy1dNKoS7fHhCO1NJCVTwnnzBSfJo0/u9JN9Cph9FCV2tUwdA5xnCe06IfzMg5B3MNl/XdhgY+xwUlXYODMtPrWvpcuMSpNxaA1bc80A29IuT3saPYO2K2D8Rm6ip2QuvbeSG8Yr/RxJO8zlUjHmf9us2zl8bNrKHPA6ataBKEt8DZ81D0CsWcWt1CskzNtzdUkD1Io+E00QWv8pLVKZkRsYtTUhKGxURApfnIFvTxBMl/758jMJzG3GsD+JF/fbPuuAhLSTqwEAhZWZXpSQgt8WAg8xuyPDwX08aTZsUUK1kE11wxMmv4xPshnUrAwEDgb/8EajO4VwA0+g/XZ+SIiH4TyrLllJXye3WFQMERyeK8nPXLTJP4qFaACFv3X3wE9nlFmR76csaCAMhgIcDeJvY4AMHGgLbK4HfheBLwoC4znc9muq3l9cmUvuh9QdiY4kf9ddGue8mgylTLiy6Oj1kMCwEntXr3+8vuFBzV8LscvvP1Ozf2YaFq9fI3Ek9Nj2WYIQrDiee/aKOwfJ9PnPilYLLs/PhkOs/Fg8UhPb04JBgnh4Ia58dNKe2KPf6072f78sKQKB1HsT2Nl9l+QJ2rlS+4qqxlDkiLnpUExKzFio067w4MhclJ3XvDH7attH3ewFkZkiqqUqvK8zsOeDD23pYaNK9QcJXCeVHBm4qnXXiQSTZmQYOXsAQUU5lkIM1T5+My2fNUvMqbiqFFPg5L/950RAmjz79L0UO9JmaPoP5kRSm+hWMzQ1xDWkw2EtJFsLg9UL1yjhHyFSx8M2D3z5VOvBaK1rliV/UADUlxbuprNFzu5MxO3hPqiocqC/NljggRgU3hs/OD+ceC8acrf0dnaHm6H4JtN1qGJ63QQsHdANWxShPKMYT4JXjzfeM9DpzW/tfcf1/lW+tLwsVauLL4EreHM9uq7c2TwHvlrNborzh4IJTiYnBDrpAB5peKN0iajguVfzNNkrPWNHMCvpn4wg3tn5MUvta5ThCIQCZIOpNQpVw4RmCeCRsRL2RkAOAJBDOJ4essR1o/c59Bbc7YCDmQ+1yKC9FwUGowFLn2QnEKgRBt9t+x/AizGORpCjfwyrn70zQ0qw7MYD2Ve5v+bht8HnmdEmHrftQF0/CXD+b854doZT3y2fns/D/TjDoLnZpzlmsD7Zt9KZOgbG5n0x4lobX5y8qxChFnhIupP4bczVJ3v4JE8WuX11ifsSdiT1RpSM6nNUtpE1Zkb8LRrWlP86mL7/ZLIDsdw+GaTjNJduuG6CXbSPkHVdtQDSBkYN+VSfZwX+zzmvu9lchmfyTyAOzgQRHGjNanmUfBLpxAPaPjhj7snw1IWlxviUpYJ5nv5Nqo/mN+dKrc24uKY2OTw0pxpouJO5b0O8kKtXh+LW1KziRi4DNw8ium4J/7XKXqIJbfpNkAj3+2kYdkT6IL8L4NvNo+o1oAo322lI3sJB+TXMNX6fDSX1r4lp6cD7Ljsn+L73ngET2rEYaDt+8vZnAHnD8UvhtdLurz7238oCO71yeSGrDzwPLA9aofvOX7owRVqvbVTcy9HD876C3v66VKRNQka4LDYtp8wg6OwxwmU2YlGqKFSZH7IUkaLuXHyaPDc0p7sSV5KziOuCCTVb56XcVArbBtv5n5D2aSkAQQ7VB2xdy2JMnY1yT5UJqC2FqxIImpJcc+m1sESYFoccJzRwyjjtebfYfNZ31ey/BuJpT1QLdUTQoAwGpvuCSVvIupCEVlkEZXT8JPxL0L/GjTnNpxPFhn/VxaJ8+tCtOYdDgKIibqf+f8uEK9xXKY+xxJ1RPpKShewjKbsLY8tGw8EySuEgPJbbmZvncO22OBstfhd9uiz4UaqJqQMahAt8FpRoiDO6jYVH23b8mVFUhh+1KQFIA0rY4I+HpY46qac+CLXc1T9Ath30QPP9FntYzk8ucGnt3zyn/LKXFZBtsTJr5zXUqDZWTS3SUyScNI67EqQ7hY7MyIqaZJGoLY2ktMNJeQ3J5nOVhC9sgoziOxXZOwopB5rBTcVVrhjUOw6rOjCBYmzzmvu76DKMqNacYLdsDMhPXHKH7bxxNbMojKO6GF8zgxSgxTXnscpPDXq7QhN09uU6VosqPpbz+MIpzAXdlB2vzJAdBCuLKs7M7dAwHCHTC7mpdH+Uuj249vQMljVN6cQ7gUEMfpAcCxnxjwf5Q3oX+NGnObTi10ws/D2/gGPdVJwa0AUb7y0m9z3FKmVKJ8dCkD2xCEcbhrkoowvXlxTY0HvkJ5X2UkXZqmx6Kt0mUINVaMFVpF2UpNpRoCcAfK0TqLDNJ3wqwfE1JYWZxvo4rnbg5yJwhCndg429eAREz7dvQWM00wvgPlwGuHLy34b+PpJcvPEXLnpejvLs9ISkmrif5zLjgsXXYecP6+rWXf0Ojzv1LELKRYHKwW3Ndns8U9Ft6J/D5dmxn1/zTdIwqjPOwfFo1YAkDuAhvp0LMBVjrQ1N2lEhGzdmjspjFcluOY0wRL5f78/wZ7eiXkSAZFY8p300vWra1HNPJbUPCX3BlkOKa6cTzdFrIvh+gf0BIRh61WnMOhwEJKMMDYqOeCzaoWrMa1rWVgvi2zmYwlqz2NnZhalu5fWRCSHt7X+qN92J/i0sPzACVTar+0YIMI9Df2AQLPPW7sRqrZHr24nWDvXqQSjJpGLNVKE5IOZUxP4mlNA8DqcDRvNYA1Pns38scF63Oy7GX7FpGPI4MetMZW4WV++LftTOGey2UKZVbo4MuEZX1sCCDTlCtWAV+P3pFAT8417rIh0xhHyxL8X1pf3BjaWjc/g+vvBQBuNEFIdsl3b6lbmnHuMS1j0jno7s83x01y+iH2lTaBeGLKT03a9XlDco4jwCluOSWfitD++L1Qe5aped49mJlpee/+3/XaxXscD2MW5yXDUpuLXMH225dXPBLp6eMl4sW4zWqZn3mnuecofWY5gKW7/ishToBVoBeTGxV50SY2IoM2LsSyaLwIIE0yM22Li/sjx8nKzUSfEzrApJ71IKUiqKxdpAFLlzbY9fkhHCm+oDD2Te0JlOehHmorZsKeWR8HRuDLFJlLrSnJKWhYQ6ZA+VQGQUrtxUJdiiwR6B02r+WhvPHMLPnZ4gdUApZIND7Z3BCx1UOYrxZoQprbgH5DRFeJrSkb0eGOUy2uonu9KVr2wpv+GgumcyVrwa3AsyKPemMNjmV9mu9Blm1UtCZoC6AV0zmRgRUIZbyOzvMQIHeHnaF3B5kZfTNFAnVp7m2GQEkF2nIoH4/34QE67gpf3pcOF4nrenPLEW72pS2tu7OOI10Js92Q1DRKdcu3IP/58cOLpWmnYeYtzL4+2oYAQY7w7KJoJlRHfDEdgQYbwLjwXBB4A8avkKPJw+o/FsUfTb9jwwlbyh3mfL6jN2vADYeha5f7xgRqmiJLGnlyZjPG4s0y5936K1dWAVeeogGeRm5U+6yjZ72Ca7++TwRwTZzX94X02VzzeSi2MaNP0kZ1Z//PuI1DfGcmnDrtkqQs5tkscIDZO7E+qElhQpIRLBXZ0kTWGwXbo1TdsMiM3VVOTUb52F/AIuWS+OwQyBH/L6/GuaHQF46SlhFn4LwGyexd9NLk/Hq3cIn+grg5HtZm45V8zdnW5sGQPwQLA8QUORangX83YTyCdgrhO8Dfo00s6D/Yxm51tAHUakL53b4tNgJB7InBeW6ZhZAJ5WE5aw8+852OhNNva4/gAFyuj+3evedyuiG1q/GUbvU27x/CbhTPi7ALL2UgTL/18BZyJTroFUH3aFlVNPfaLr+QmdftRdsWH4JuK/y2jemwvK4Tg2ig6VNVtYDaUh38Mar+q4jlxi7xtlzdSAhUzGiVMDIeIIPv+iaCZDU4B+gE/oa7MxIJDo06/fbvILNSAoFJHrF7mF7jE7p5caJB1RzTLmoabt1mkxN0oWJFKB/McTm7Z+30cQ288P4G+HWwEyZgiJxsvTT+gn64d6AY7EkG/biWnZ/BxfrEmLIeMW1c5YSw2qR0YnvADPb0ku0/isMcyBC3EijpKfmqLVon4yK5Lk1HarM4gashkQBF0YRlvrZAWakg0MXghMsCEZCw5GZFoctxtbMJAMBlWQczs19UAmACKU/FbypA0QRZs4FwUJrosOQ8nBqwg+YnQjvcCcNysmQpEvuW4Sw2Ih0LXM8sAHcV84XUc5ebqrgtsk3mMzAjErpgocyW//6cRcjl6ub9ue6cimlWYXwCYBhWIdVWaaUbXPMW7/hlTFpHKxeMmFLKXgBfXYCAES0MmK+JaU7d2n7isN8QQ9l/vZISB/tHOmnEew5b+A1tvVNXM5wZLpAuIASEhYhU98W8wAx/0Rsxi36yWWselhemHmtKBsXfd56lL6TTmHA+fsURa0uyH2NcMZIjYZFpeDFM6jt1Uy3FLLsHOkmMON3yWg0DQ4Hi6+LJjKRqQFLT52L54KAxo1EHDmMCvzs7YEGAXQF1n3tSs0K+q7NSnRD6rz0c4QVuSXTwXSLEvx1ZnK/H45tNjxL9LdrX4UICzd40Zca04zbV5HpAEMlt7y01fR6XuU8tdaauYw/hpuYNr/BoUuWb7kgsiQ84Ek1yG5g9ucMnE6PFZjD5yvK00wLcvOxGKsS07vETwjxo6wZoAsU5QMnpiDhYGndDD4SF/HjkBuwiLanu/uAHxDn7BMfm54pXmM8SaJrvo1yALTqusbmHyZScCKZUI/Q7SGCMZPz76d4RNexNule/ao/zzQIBIikABm4QwSRfgK76MSmXndgh5A9pmRD/kEOetEQamlUXXsKwhQMG6m80eHVjDJs3V+9c9dZXbHP5sX8ga3DT3aJ9fBVRoHDGRjkaIEBjgcbtTv/+GasCuoq2cJmMjRM8ttvHwJ8q6x5uGhSqgCScaagw+adsGRaZy/vzBSx5W2oc324aIAIiF7G4P5zPOx3A2nk57Myr4Gq+lJUnnz3EyBIsJAv836LLqqyOuHslYWjAREH8yXO08t8LiYV2uAqOZMX7lfcttWeNuKL0e217nAspfPiIOkvbDbG1wWXWl2DiOICFUDwxFMRrZOsQUkWbzHqEY8QM+685whTLp3dAnyjxBrVaERc62SnbyMzbKr9yO268m2SY093pSTPXEgp1uzmb4vj4Th4Z77M7mAw0FxpyNC/gCBn9LW0ZEIC7JQpSmclNZ9+Xq2efeu07uYE3Al7vKInZKYu5fHkrz8EBI6gcfUGdqbVTSQL+4Mnh5mtSDXRsZRTafrPiLsfc8YEV5bAS1Qnff07vlnW7eLSkyfP1LEJ3tpahnbwwPsJZEGasW3Tgi6PZRkaw3VAgeU+unxdYfnhRyKjsoxhtMAWI9hfCGNRBLPYGfrMMrDsEPClOwFkV3W6G+I3B6LrfM6sisF3l6VnL+q8GX6ZruBohisbLlZLcBdZ8dP/tVC/xWTohNAydb8dWZyvqGmPml3APsX3vFw3W3asQ8PrMMrDsWMEsSIbQ3o3KgsX3TLYqrBN28kq3e0CQPHaZo8cwdH/tVC/xWOgnazvXV79v0j46szlfUNMfNLuAgDQSRmMTHUyeUgLmafEtao8a42bTQt4arLmklvDKnjjDPdSXifs+UPxg0h+JWwYnm8VZoBMWFTeVtmwgjFkwFhGb0RltG2OjEJ9h2PPdkSFKiH5efUxh5UnQoAjMmni/z6IP7z0QwBxbREB5BJhmCue3W8DqyY+hzK6k+NZmvRZK01gsK4W+AAM65xVLbs9V/evUhH4+fPM5lCWKkl4Jbj0oeKZl2lAq6AC+1JB50xg5e53D70/zWC8K4g5Z+v+F/SQbo/j1PxUPG8+rRVqqKnXcnqFeLRkccpM4aEDgyG2By287K/qPcdlg/ARaELlrm4U7sUeLR980hyILZAnx0qu/iiXyTj2AM98nDWzH9TqQx/6fgd3P107Qvtgg//333t54h4qql74z+H96gUm4Fn+wQuyJ7KYpNgCbkLm30PpZtEDBxW1MIEAJkMY8F3ZYY91ouSv+VrvmAPcC4PTeRZ041FKp6bWteyxooY6H/8O9PYofi/Hu8DqN4dCz3t4Ap6kEhLI7F3V241OsgJqxL+9vszUWLpJjcsTABYTd+rihrrQhrJVee2Jrl3GwqIIpPc2reC15KQnQAszFEHS477M1n8x1VsbsMo6Cb/3k+0++fplOiv/3h7LhXjPW+LE3ZKubK+HOn1FNiJcmhaC+gnBEGZY0aWRz7wMik7YkPj1R1Ir+ulFv00n4se9ur7tTUwguW4ObzlE4FrnlkcpfS1OxbT520rV/smkl4MBGWkjp0Aavl76G4Eq0oryAux3MSyiZjkgZm7xtEWSehzb9v10C67747DVEXPeEt+q5wXdp1ztuNMmIN7LE8pXhdRmryLlbZjMadVDueNv6cf3Q9YWUQcqk8qOzFY6o+8LcQwp6LMQV99S87a0bHWNvlOA1a0CZEqCP4nec3mEwYgE+MyevedB7LShJvCFFtjiCEXtqI89eE4DKNr5KRDVHWKY+Wn94k6Oo5fcf42J19zXuadUxbM2Bjjo/y9ji77a0dF8E7O3wWn62wM4OE83c0M7aU1myhbBNXps3yYKrNaEeGRL8iVlnnm4KZ4dx4iNkC0deEuN1KNihWXSOooSA1We2uygVjv7V2sQxtDP93pNnVKmGSWbLt1T1Oc6klIYyhXJJtsd2nEsePS63ak2ECQT4FuoRoR4ZEv7jZfw/VvSRxvacCW8nBNM96XCG4CRcwUNBTLJB7YvTPu0QfGIGQa5lHntcP5Ubi7lpvkTl9FqDHUPKEaNujB2+8ZCyC03eB7G58+0ajN8AP9BWHfxWy6anPfWv9f3V5wNZOtBmx4rt0DCua7beFzA3uQXo405MW4XRhcRiHWqMVsxR6q1pU/ZxsX4BCwrzKh3j6LeDNFflaxNjTi0z+FEuhWvNh5Dj+uCWH7aXopTCrG0SxGVDS6K15cO0Peq3reC8/kDTQIev5ZkiV9jhE36AGvtD2dP4yycEGyf8YjEio1bBxBzBcy7rOJmhijWFERqr5KldVaNptbMkhIujlNy6A2XgUpc47pj52BLwfQQenNSGw5LlNi77a0dF8E7O3sjDhgHXTtK5TkUUbBLhbGSIbqomK+CPlcXfbWjovgnZ2/RdExHzxEcN1tyWETuC2Mxp1UPcP9CzdJa8K4WAzyTzT79vYqi7qsqNT0YfF9UDfbDuWLEffP/j19/0LafrIlSEb75Krz0AhZwEAf7ZjNBRYRphHX6w2LroMb9RIdUctuDVdZ8AQ2FtRlHHCzCUWHhwqY5KytU7KktMgAYziE1r6DKWW2/sFrhL/FxaaT6gMAXRaJRNm6f8ljFf3FpO+SY3D+0n+G4sUbBxSIdoZ+3Zj5bZA3v/UHIvfiPOYMp0ly/gLQ8v+ECGTwi26xZ13P+lcb0BAMlIqz1vlp2IaG7LTVoUH74AtfcElmULrHHOJKmjJRH77Xm2v/MxC/fZ+Blwlc+drMd+FYjyYABc0trdndtszyU62pLKugOk7taeS/yl2SX69vPVAuuE/GZUsNAf75UmJ3eevwt93ggcYqQ4U2Y0ykDo5FwQGKs1NnmrEUwGHhMxH+O0BK1yTX/OAcs+cQO9oOfWBX+tgOldJ1LPgm3CHwI0DPImZeZFSEOgbIC3pt3MKLr5zdib0KvOp6ajOwJr4pJhY8r36/svtkC81TCzQvxLM8royoq+0nnjJchrf7lhtZR5Fk+rHJpKACn6z6gTnHJB2Hh7DC5cFbKuZ6m6WrNSUyeV+RdaSTG3Y8/6FZVnHFM3fdHCDSd8kxuH9pP0bVo6aH0oqQyATMwTggEV3IYVrrzYd2gpCaaz3AdkSGqwqORuJ0vxiGLalo5EDlHhE3/zitxaMO7ohyPfWlK2oepuVVisvLglZmknCfVdd6fBoLDuYeSmvecoLZxFtVsOP+Z9xOjtu/VcGGqfoK7xW9F90MK8zMJptWOhNiIUHon++QFRcWoKoRxL0fLQnctGlKRopNAWjD8YpKvgdD/X+VQHjq/n2YYqx0S/fPEJgw5QyaVsqcl5SqCH6Qt89LiOBGbbszujRyZ+YvFHhnCbgsSc3UxKg74Ux33u3qJPOIT8iymVlrvCxvnUwI4rkUTsEvADQ6Y64C8t+dQLwmBp4MmhqpwUJCUvKWewhHFg6e8YhAiOmJ0Eq0i7i0jS1C2WtPPjM23TgEVk9QoJzha4dd/cMJIyJEfv94gr2jT2mRKM8jePxlLVr/MNpbTKHrudlqwLioZuWfTL6ymdPRm6HzCTfSt5Hwcewvm3hWSS4BpTkP7cLvgHB1OIRz7nJS0OkftpX0GUsttZQIrHOCmT37bfPuUXGrKcfZPxK884GNJqhb0AskwbVTu7hGd/50kfl7zwTLRMubpzE5RTk7MR6US2gTbGmEAi7mWTAEEfQSodMQj8iIdBZ1HLhDr4PlzQ2iRK6EFYwHACh64sdPMvUhmRh0MipftUccXekygng4rHYefg6+q8Nv5QyON+mu7S9j3NsZZxEP5gXmLnuWgsWMq3dX2DlIa4NsIGik22HPAvB3iN+j60QtHVBfCK5FpFe1utAyAXRCsHksglhxwUgv4hVD8iJFdetmhvbSXSSYYHpabNObMuNGqtoJVdqpaUgjqP0ocX5zWZLqPPlFvlTF+OUF0gmlXeX9W42KPlpCpD8ZA19jB5F3lbxK6KJZubNi4uKbph54DqG7xj/VTdi3BDwE0Q/I6G6jbs1I5Xn6C8Bqp5tDVeSKx/mnu1p6EMlGKsmLP23ulT1SEDw+76Ig2pzaKXi+QJmNDUbWQ403gUiBAkaQkeaqWYK3dTULaXnT4XeVQiU4/Xy9VLwUGDNUaxsMTpyTMph9dWMBKzIx1bM5uyP/ubi/pO9/INHRqJY+yO7sqmnw1MEKMDr74LnHN68FnvSOFcwQhl0wdwQvpJ5K0G35mtsC8E1NYLUpUM6RuVMTV/WDCerHSVsFVUxvistwO7XBEw6svvXkAGGplCQ8NRs+hW9fIumpj/aQMiEd2s+YTOqhG16E2Kud6rLrA7YAjkXDffEcjaXW7SLBru7AsdKbV+jhZQrhThztpjomMLR7t12DsAqeqmpRhf7WcN1y5bLgLYKHOLYqXoUu+SThxxBffvsA7Nv9p5Y8O9CGaHUEdZgzdM2Sb9DA0QZ6br3zvMJnsV1EmK1fz0C3VGT8a7soT9Wm/SU8HmxhA5rzAOmhVcGE88zrxbxCvA8G3X7cjH0g7u68fXcFv8jBpjv80SJCONgt3cetfP3drV1hYuSYYQhFJc/9G0/JVoGshlq+odq1vhc9LMpMF61Zu61yrTSGw2wY2avGJhhFhJBH+z+UpTZvelpLCCnH95YpnCVHVU9yUJFA+t+wuP41h5xf62ATH56HXj8QG/jUbXGZIrhgYaD4GZv+nnYgAtFbi0a0TRyG6J6nZD/AZBJudpDVmKF6xpYwcmOSXDLnjium2adP0h9HXjOZwnQxAFAgfNmciaGHjjw+VJQSCUjdAAV6N22L9TfrEw82+0N+X0OP2jtJisYK7tY5cjteIVmhlrZ1HLB7Qo9BSrhhKvwTfSl3I2sBlLHHzmZsItdJvlZyqtbbp+uKlGEzKVwN/LHedHoO/cdrT7D8ZHByUL47GN4iL7SqEN+5uJQBuXcDl6nm7CcErhr0MwxWUmTy5FOhEDx/pXdl8FuaiP4/EO13Du4oUxzSfEpk6wAsrkyTGQBJ1U4YcxDTnJyTDCEImHwPvEWkWPYUaJCKy2T63jUYrwed8jNI/k70I2AQrrBAoPEz0xVBy0xFQqOfhqDa8zj/ybsEWXJb34K5GRmrCM2RoqVC1IoQw7f2WnBnXW5wA+mh7bDVyqhDR/UqnO0Gc0ZrUiNCuH5nSdDQUOiqPeYSX2UprdQV7Wcb8xl6tX87Gq/W0iE185CevTjn2yYnb0tqOWevXnwr3AteGe2jlsgj5mjwBGIZ3TKNBNO1eNezfkZvcfnrKrmmHAsA8X267euEIEPeoa+7RKFczRQmiNQDj4QS+Bkcg875GaR/J/bJVcyktNTED9NBnHTSJ6Ij60c/lO7xlfE6ZRAazvyTdIhQJkF7It5wRruhplrT2pyOWDkaTUwXmEMdT3dAob/qQIh/VQy/UziyBQbe+1sY04Dgv/R+BbSn4NQya9aR0Om+kaPS0xdHBu2iitmS+k64d4sQnfOyJASigyieIwnLLyNFfPyx6oZ9+mwjkQxIxMAuxI+Hw2IfbkoQp8xJI5esROZVRfFK5cCEDjO0MpRfPQ/0rlAW3mscE85OWJ977Vw+uH4d2mzqAf1lDuCKR3WMIAt0XUEjYhq0Qn9NEmJKEYLPLE/bG/KCYb60xJW1zTArSKDZdc/suJsUjrZKY404fhfov7O5aBv35+p++0SYCbgpBlGVzJDeMM1jWohOsDrLTYlng62FKOmmJMDCP0NMFUIQM9tLPHxn9szRitsABUwhSZU6ZAJbZUh8eu1LVzr9EZG4gklN45ssXLPTZo0wMsIxvxNcAvU7J4napdOzoEtoRQFYbegA6VEC1xIKjnpsvP1MKFMXAk3vydujeOZFhjy+WXNvPcxbBkeXL1UlXf2mRdCPJQ/J/1++JP7+ANiuviHc1QhfqB9WDIBX1jxOqSOCd38qSRH6cS0jYGElIgGDcPSZmGYX4j97FbPDS/Iq5s1hzLe4S6g8ZiIvGYtbYwXKO8jl5e774aUtiF7rwLZcWE3Bubc5uTlqx3bKA6W1hTw8r1iRaYb8V6KWgTFbuyAWSramHxHn0L/RCxf39R+shv4IkwKWYRxHCZlSwjiWKgsphAUYDZbGiHbn6OFFwAZETJQWgovEDiwraWyVEjDGKyODvcJi4bK57vKSaU/So90dFeMadDH6KxAvgVcGs3R/Ug1+gTdrNSdsRcYwTobUd3N9Br5dmpAtCP08ddmoF1QxHR3C7eDHKdIfWnGrw30IXaeoN9HbZOis6eB0sZvuX8L+XMDv/tdHE3Co9kxhbrwWOFmx/DDBz9YQJd3McWhPyLqiXJyrcYgU0X1Kii853gGYsC8ZGyIE15CAE91S1di49b0KVxENPBxE6m7+OFRNZcmRY6rqX7ftWpWDbaH/UEW31ZHqkaK/XOZLleiXb9XUau30KHHiMx8dpWZQ5Yi8zifQr567XLZ8RbUndc9BkEUl02SnuqJtGhQY5yMMcnxutayX3v2LdGpAIlTTEhen7KN2MwBByl92i4ld17E2Q9czNPSI50T9R0R2LOy14x8hM5uuxdwucrG8QElBfi7t6nMCd/LrMIxe2ePB1FylmLibCSiThLIZVMGFPP27YlK9R0DauBBQv3x5CN9Z8KyzM+FjnfQRj7+lCeRHIAl2G8BeQU+eJJTVkngt4sYIx169K2h10DFTBg871Ahe9iQI4T2NTY3Yysi+cr283QryK/udr25hhrwfmBdg9qFBzx/ex9rC9fKojjcRqOY6RcSaCSPHSO63gKIGjidbzEXMSH+H//4Dp9B/lrwEIkBYiKHoRFLOUiA7hNR15Z60EGQPmwgjezi1OhNu/uyK0QYd+ql2HHtngOEtqoHJa4Exjat64xV63s/C4k/AUvYmexbP2cnyy3LRnjryz1oH9yymT2pD5SUhr/ErCvi6tJDIX9zJalzHpvPjgC49NZBuEr/PKm1rtC8gcAIdNa6hVHtDhnd115m1i13P4L1FBY/bBt/B6OSLXEiFf2Vr+GU4t5JvFKGm0I24ij7cw+FdVw9e1+/gqvhb8qyGiaGVJsGD1jtnTiNNsdQSzwC6rfCdbf8GA7CcQw5H3o+VBTXYF6BO99DC8rCSzKPQzpY++d1AtcNS2ZtlUSvH9XFrSlOe6N/g2yBRsHfn3KvZ6GLxA1gPg8dJ7vuGYsLIUtDogO+ovs9F8R1uXdKAj5e0h70U7v/ShatmpF75vgRhAxV7SlFHT8WM3LEmPCWK8JZE11HOyGezn6W/ZItcSKE88E1HGH1YV5kdNlkSax25m5Wj30og3D17X7+CGMVBp9f+Y0u0KqOpGqhiTBnX/YFwZgKXV+O9+laUxHiNtlIyCpaqAUNlQ9Q/0dMznUOyftsH6K2OCyhx31Fiyi2ZFIEvPF5lP0I0F1UcTnawkGEEA2IwrlqHqb9EvF8cIPQCwR/5vYTwxKkyD+pGILlVruHPPkSWZR6GdLGOycvgc6RxAl/fWCoLhF9u+nY8G2cEPDO1YN7yLQ5gigpD6BDhu1eDiS7K1DaE+MsUwDWFQ/HW9fGuW440R73+1d60taeXCp9GxM92vXlhg3xipkj/iZCPqOAYUhoeE/Ay+mRSd1ZAu3aODND72X/4gez1fhQ7UtUunaVx0KJW062Pa2FeAHyIUcqkrL0MIeHGVIitPHGhxEN5hPN/C9x45zhCUa6ffhPkVBYGvl9n+TSkMpEwO+ebEqzWJhJzLBIR3N5L50DlqbY1bKvumtBZwApGDRIFZ2EDIK9A4YWp4NJ4jyspCrDKGJ+NltV0Csd3b0ZxYdEKiC5Z3iNKOalbaV1+yfLEFWueCZYRjDW/Hyn+uw3U3MTPIwtWjU9f7wwj/cu/TbwL2LIaZazmf+9ounVy45FPx3o1cLAkLfTdrDpZCi23VnCWngSqoChCFICvRn99p5xsc+dHZzQR459JDMHAfIc0u98FmqxGBWLOsJulKzBVdFiaazY22CIyV0UTOWS8qyWlUQRehQq/cbO+WHrWWTpaaoj52lo/4OTis5NxjTcUS7y8Klh5jeRWyW5ddj2BCiGtcpjwE/eHMRkJKoDL7v5UIuhcdd3Nx1yMpxYnG4R2wXHh+5X3VxQLKVnXHFj6JFi54ivhD+n4XyA+6BbBeMR5RymsgCFdP8J2NRlPUPBupIME+eixUv6zH/5evwjHbDPccW756lE4rGKjlirWFCr92DZq1LVSJrzA6MbCx9++PqYvb8obW+5Z3D7mLkc0+qOyycl6XpLL0OSY9qOoE4A/7mS+LceURdCx347oYY3BYovLMdQP/Ic0u98FggFZBOB9249+/m0m9wX4g2OrnKGK4emDR2q1MOp8hvk5wjvXWm8mWoUPct5oWi84fRxgwzKsYq9eQisw/uOmSZsrYmtFJaE9CBkoog8lYWov37YiypS0B/5IynJJ8yulQNcuMlvDuFoOGwSzPlexdBnoDQkKr3TLUKHuW+OqLLay4Lw0PPlzvDVlXQUi4jhnVDkSxNgzzjBHY+dP2idmh9+yZkjg1ssbKMRCWujyJsoEQUc/24fxWNWOxiOqgqdNUP5MsGBpYm9KxoMDRqhcU7zFgI/Un3S1LRV9cvuCGLl8JCsH6IQNXedP13oa98pEBFUaorewVhxhepY1VHJWBCQX+k03t5MT+mL95GygVfRwX7oI74wcRUyNtqSXoqTTDrTbGkNzLu8xxl6PLWbe2+B5z7aOt1Vzj4B9oBMWc7WzPMqtTPxmqHygFW2D1wAyrKwDiUGehFiK3aK5liKEEFag4HmtvixKJvOncFZsKwW2dWfPk7euQo8yfAp7dCJ2hD1iqF8f3o+EIFqS8fvI59uetcDO6KvHA9fzuqewXddwhO1BklAgj01LeYL8zr/hM9kWNUH9/XsoZvWq8se3uNwAt51Q9fq+N12uVEopCyRf3u7jLc3DAWSocf+BilKEJv3HuFeuQSxqFA2Bm9SZfsUNORW7aVVR9dXgLn3DiNqYeeTMoBx9lxhk7+ar7oDX7/k0iZxv+CG/Faph+aqaiGQ0cufecbC1RmrDTHVBPJd9GIyvp42vAIUH/x0qmaJECk7uWj745FWnda7RXBgz2rYA0c4vLdP2UabCzKmYvF16IrzFxzMRnq+lr3TdxL34ZLIofH1y/kk0rlqKVHKPcjRDySYYxGueAWQav3RdTqPmY+RMdFDvlNabFXNRFSg+Ei/Qgs/5V7exsNwmyxE87EmjDDngzJJpXLT9xg7GPFXnlmgApxVzX57P3d083kX2FKlRHvTwwznnai4KNaJGxRA0Gel/UQgUarOOhuEgfLaxYd1ZRj0aROPIXo7w0zsJxbF0t+CAM8aeAS4xaRYdANqU+pDfPfZk6Ee/M6uu3RDgHgN3qz3zkrQ+dQBdLyK4NuFi8beXSRtjDRA4U2fAfGExgG1fVk7Hc4IQ2DSH3qvvGy++NsGyCFvd8Inyk3yRdBv1uFplbLssBwXZNiSbEcz3FInQMXUDdzH6wINrZQrjWhCKtjIgqocmDinL0HoQJo1jdQwEWkmpIE1BYUAR2YSAorr3L5/QrUvcWuX7CEkGBqi9m1ikUmCedSnzV/+DKNcul83dEy/Khx03Ns9zhOahcyd2WOkWIlFuYiNPL/U5pHca9xZL0C9uk3XcsqJYrckf1CcOVF7XxSChnGBE3XjqONnqWTbl7NeZrvnoeyB59VnOXC8uaf2n0aanUMVI++liTqpcqWhPdOsfoibNvWKWvobYw3lzW7s17we7uxRT03MG1/g28p4veVvXw+1d5xzpcVG6U2t7cc0D07vETwixq/YKWsSKwni9R5PjGHFtr0WWQgF+aC3uCMzN/RYSVZVXr3omJj4MD/2tarnleSv17z2k51L5Ls5M7aYgeNvbphgSOi7hLdHYrakrLbZ3ZxPEU7KieAY/kZr45fGZ58BKUJUcQPT177eZ29xhd7MtgODf0e3hK+oBXXayQhZw/bUPFE/uk/sVgD4PxZP9zE17sq60Tj8FzktoEeQKCMZT1RhuGEMSvwMd0gtKJb7ZSa6nwr+us+V7ziKnaUWd113a7xaO0KVgEGxkuNfkCeaHVkRRolKeFQbzRnzqveEliaKBnXanAQM3s9Aympe+U1OW+tW/ditGr58r0Pc6FggYCiQ9iZrPoiCH0GzSZE4IT1NA20DBWrCqd134bkUVFEZqxPj7mimUWVoaB+XAh162a0NvW5gKUdLPUycfqu3xelrCx2it4hoyufxkNOhtNRhjQ6jedEemlzQVhKPhDx00Bz8jJ/IqfZqFcwJuTp06VBqDIfnNXm5L8D5kJrHuNv89KAvEdj+XWFH9aAkbn2ZQ9zEqF7866ReAT3C3xO4BlNprbR2wPCtBirXWNJ5MHLQgnsirTpdIDyW2stCTNdJ7HSDiu0IEg1QVGw4lVoytH5nebxZfqTGJVrdAou6sNWfu+0MkG0R4h55pvH1yjYnN+oViXMHLTUwYzzeBywRcG9qgIT2W4cJAW2HpKKdRJ0vv+DhHU7/2WYSmXQxzdkf/c38Mex7PNlzhELxLNEKHyHlcVyrdWXr24JgxLU3W+6twyzUNRujwgZqKzCth0x2v7kvK7TJPKJGYCiqYoqOhE6iVTAfhjPyjle5Cquwya1Vlwh/UVXVxq/MfT1XmfaT8EE+4Dw6M/UlXUfyqZajV10WHsuP9dc0Nw2jIBdxwHN8bHuCCEIG7NP0Mu5TNCW1ZNdX+41Z9GVapctofBJ64hheKXJOJlDWqu58LuPWB7Ev44RUjY5AviIds47tPf0jmtInisCRLVhph1Npn+8mYIsLDjFpVpP2oTp4jtEtWtevs3t6XNlcyeLwmmhIpY8ArbgpC1Excrw+fDs9cdfqTv0k/yIm3k2GhS9padn+hXAS5iL+Fc4Q+6QER4UmZFXsYhVMGY8vHPQAPQPTAbEQ+jZ1M1AwxgJ//1vE1W8xu1a2bFXT/j4PBIfYfjpSCjDhd99Gqz9nqeF1q7wuwwcZLb7RFNskX3q2q1xGW9/z0JUNaESfbUZzQIg3Y1GB1m44LR5aDysCJ41oyDV+rje1mYyB+rbvz5ffWJaDT6Wj/7+GBxzq8PsqQZZKP6S0Bgb/qHfTnD7X86+O7D51LjRafGLXdyGZhdwcZKTVHBtgCe8+vYR5VbtQvpCQtRrpC1qMPDMs6eaSR0zZQg7WpPr4U+2aaud/+D80oXOwc5e27hisL1w3WZAx7o60KtH9Z5U2CP4Q1upavMv3rQbxu8YzcEWbSSNL3FnTHKpLxRkwhdBxsGNhi2SVQdMNYW8LdtsKjctqvOeWwDpxnAInmtu7FuLOJXX0uOt1hvKmyEiDZbA5TIZ1WMTsQIOER9893iC2cIkRoahtC7tfKWhptFzRWdEQ336b4CGwqD6QjcZJIK1zSvhOuAb71HrSRPfhahlHN7IXuG+tMfyciGnsZF4SF/CbxL6+Sd5AsDUwggxZL6dfTG3V8i/9Dx9gPy575evwnlA0gDqLuuJSEzBukSN0isBWANZKDgc9BNCBi8wgEZ4rpqXhJUxXMnhx+/0yOeKVfMq1n35ueC8Okyp6rE/b/VMex5keZ5btRjSmFv0E+qtmFRRzXU1QjX3o/ZIpBM2hz/nP57fryThhIsFcmQo12pPizGSLdQOYF939fs9amdgQYE+txB+eRq31437DZO0Hvo76mVnUnRKI8sPNoc2XkwO4Bj9+CXVdwXPvG7k4CU8io10lIq9aRcFCWPtBUAyLF8JPU9WqCYxp97kh/LX8C+w3QY6rmG5ZnPqYVUGdc/i1xmOjDbpnw7AfqrAUpJagXtDGWxMZgL6BaCNu/VpyDbNb/iEIRbTvAtCVNOlCf6c4lgKa1sIftPqNErX4PTpQloabRGfkTuSyS1emlgGRVHVVC/i1c/X2dkGFLoABHbYv7YnY5L2S31quUULGJne83KlWmCqtJ7RkoIPhOGe9VfdMKk+VS7iyPWtR/Y+hYlm3IQk974+u34SE+vMWXpwWmGupXiQBuFRf/trhm5PKyQGIR0kstHgL5HpWE4JPitAGElBMWT6g/2r8quRUyhJ0Rka8ZGJfY82L9DCLYHaE1iayySD6ZcUKBQRPWMtu6ICgj213snA5awJHlkj2b0IuFi6sG168ES8V9+bYqJSqywz+vJD0s1sUyhzIRski/fbKwhWpll7jAIlAFNT45c9QV+k3Z7EERHOhq4BXY6RjKP/zXcIsKmk/j+Kcs3Y8vB4NX54D0vNQL8aWTh3p6UIvCZlHI8AIO9JLuHRk32ji2KK9FSBWT3l68NWzj8idyWSWrvkLOLQOr8mQmbZh9qrc0ipjT6Hgvp4z1r28S4CaBrTEy8DBlfUswDEN9QVZ0djzoLDqkYNPnxnU5MhbgKEB+NaBVJ20M281f7VAHqjgCJs8H8xawa8z6x9w9qkPFyPRfjaax6t0TxNxwYdqhSyFsomiT6DXwSWXH45wL9UjhzzTXr8IjkyDJM7anK7BrInuv5jXjF8X3xvUt6uzEV7Jbv82PsNumw+Y350vnFROR/ueDN1qzjIKARn1fSJzbFh/pU56VQvgv/PTeWIFuwfRwQSdZy65Itwbj1Fc02Naf8aZxKXy0ZHtWn5v9PhMraDrY+E1sl4EeG5KzFeTvOvcy3y/iVt8T1QgseA6uJrbNVF6ki5tVRg3ieTpJGY3wHj05bp4GLRQTAI1uKvfHWuM+Hzjdzwu3PIpfq5oeznl2WOanNFKDIKZITK/qW9K7wd0l0K201Qzenzd8QJDogb38MXoc5BvRHL/JuGm3oYPDKl2s3ESdqSTD2+hkCAEDDLshSI+rZNg5dbS7vamy/HvNPKVHDMS1RjQDbcZgAhLLeUw4i1iPKqNbVyBk7fct8uUnx/Sw666ErgXWEDiYlznhUJ21U0a24wwrqTag8XzXdy/1EtcwoKFlF3WMfoNHBlXeLCv0HUYojXhIzSqx8iLUiA8n0fBuAaUFEEBGGjqXcIQC7uNLDxLIkYFStqc/FecFa9T5hiY1hC63M03krog3ZjgCRIEndYAmKYU36MbqdCWAxluZ5ErBJyedGg8a5oAbFAgl3v7HPjHL7q4pCb7LZD17y2/M5wbe3Bfqk5HmUnQYYB4zXAO6zyp3V2Bh80GIMyH7NhVBbIw882N0xza5h8vaz9tY/xfJTACPAl4UzL+8YPxzx6vl/9ZiGUIqsc2HgLs3OrMoOt9tSv61UTqgpGuOJEOGqwDKimnykJIQXXtKMkDceoDOJWta/gbJuUl+szPLYgXC/Ei0EYCTsI1KefPw/X0ZwLAG1Q/pUsPSr6WBF0T2KHyI4V+XiKvRX8tR5G3lTI5C+FywHXTphzDOgUM+3XDrZTk4nfrG+UvcNOCxYChkH8zo2Q3fjc8re+BGVn7gIJcmFkn3UB02tnGeNL4yWCZTeCiaTW7spwCh/zQLwi2abB+js8SmxwRy3FE4f11xp0xzBA767qOi2ufRJ6xk9DSFmXDlLa5MRrNTe/BfYUlMwm1K63xBC5tcaY3fZvMEUoKL0wZfz+EJe0GtRhk1UFQsjlwajPWw8u8HuZAzsCqT5hNxYnxjflBspntYGw0b73Z+mlVNmOzW2DeBYg98lMow96hg5c60bTFDE7FGhG0ZpZrl0QCWOXy6WBvV36epoV9QZTYqWG8XG6wmc+AwWn3NjJFWIP79rUzjZchUZp5AXOcc+u9IhWfHGcDOpW1TUDT0RpMLg6u/74ZTvS4L/jcj5u2HJERNt5hkq3fndz24Uc5t4hE1kzK9XepdofGkWI3nAsZ6UP8aalN/9i6DPfOhnFpsimkajesFTSIwkyrehtOF6qGnwSoee8eiMpmPA36SxmkI8ZTb3ra87EgimuezhxK2ygSAE1pn8jQJTnZwS6/TdAkPVuyqTHs4D0Y7av/K5rcajIY7Qo43b5mlFbfcGwKdGEe1e6StQpitvw/7HuSWSOpGwxBxfQHd4gnvw1ogRbI16NxMAY/Q/JIpIEQcC42dPrkrWoL0H9rXcZhZEWJIB9U3ccRZgrFYSwy5VDF3egyE1kUV5jvI4SgbuLd2qD5CbS6nzdF7MjG3NxmOv1DRXyp2jGHY1Z4mgCEU4q7ZFDvecAFW4MfQp/D4xXmll6Ifkn4dhhyYaQjFrEnjmgFmDLoQiOBA8EgAusRd24XzxPDiU6peb1xpIk0nwCZKGE8LSRPpEg5nkEYyHrAsmE0BJITQpCLhoI7zo6lFpM0BMLuSvgGk05T78h9ExF2TYRTmNsskJ5sHAKdCfUpkD/EziPE9whz5kiOlhvs8pShJx3YHJQBqwjnR4ijq4ZRV4IKr4XMW9fc0Xhty1RJcpMtohxd0AdoXyyYrsigoP/VrMi32LDfCTyOmFnagFupMGfhMkorqGw5yNHrsJPUDXtDoQ6mRTSwj1W0JGt9Nr9Nh4Me/IzvNrkvfuswJi78e0TyKeClJEpC/lFs+/ozppO96wVvv9Dx2megeIfTkDRwo1FrxS8BYOW36FjE4cTBGOX5jR1K9EfqID8LDlMoR6l+vY+BMCoSO4+zTE0Knes9irdVt6aNs0XPm0ChvYHJoar6jNd9ZpM4hpEV+gJaXXcdkVeBWrwZ4aSblhSvBR19NgZ8/qEfQJx/5GolLZ/Kwrx5Iu48gGqEgWIJZhk18uuvm0gZGnXiHJI9WHubbSDehf4y48FvS5LwxF1SMm7bEqiAJCNZZnUWvS0OwLUwWpohCSLXRCtdL6kdOM5Yy83FbmyWgir9FqhXSgz0TZ7Xeocc1zbBMOzKWgLOFJW1w1lJwbAymxIl8beW6eWx8QgdKGdQiDgLuajBUx1eJk1azP5VNyQ36QO8lPTcrsgoiR+PK2QiJcdiXuuYEQklTP+NRAkCwLlsQx1V7jrWzpxGlJkYIyzZs1I1XzONKoSbfsGvZcPjwelVGDaWvxjeH+rSUG786SExegtOsgwxE9pA4W+KoT8MJl100D8m4aJaulm/AZwEhlUK/Px8bN84St2QDKjI2cCStDp9o9qsVioLlMyXOEKPC34kg00fmtFoahUUY3gatYxPKKidPjvS1tomOvbBBtFAf3by6O8XhDilk9xHE5NGdiKQyPMeiyqU9FS00mfvqj5dm+X1RZqYtpZv6Jox6IxFo1+YZlK+nWPwaSBAMmQkZi2CeSkvjxd3uQT9OXbT7YTnNWhMQMTeOhE5iBnzdwBVwKmrjsj7y1LAiNdZjUsxk6GvxgjizwUZl6HfcmdAcIXuP8FJJJCupbd/9uku0ke3igDlup2jhgorqLDcR/6XMdf0htW1F1YAKt08fa6NmAPRnjHslECND8Auqs5aem1/QigrileIC2pH3JXUvV/hNbrVxwbCtx/XYPpx4tUcOEl8WOM6f55FKHo4pDKjKgMPOebCzAf3lpXvtkQFDTLoSuhcx1/SG1bUXVgBwU5F18GD73D54eQWlh/LLluOnoEBJobzgOKA11Nh8tOhCHcpEm1tiD9Tkrmsj0qIG00wbzbcFcuAPZBxMMc2cyE+F9Jj7Cq+GqNvtkObAKVZjoob7yGY5ESJ4jwlNtaqlrMgNgp9mIbKQxSND6hAFzK9XNydio5VXonS8JCSSMumhuafA1owa+cycPEETF4y7892CZtE+T7i+85DlTMPqT4bjCC4L3xyOqcv9+1pPsB04MpQ7SWGwfgH+93wC96H8xTiel8r52Yz9mjSSB0bHp1JHT46K6OXEvDz4irQGgLrPqicWd92fjd6MEH6NkNjlDT98HwHccIOP+13Zw8s+2YX9j0m8+eXReM7jKzAdTbVjz2hjb1vQMqNwIFN/7mwpun6mWMCkrMTrMQVOQOkGMvRgvQ+HxkvdrOZF7DPTCOmV5le9jcgU5pf1s1RE4STDTXxaUoGtmJL2azq+4trBjGyPsaTbM/Ml/AtWQ3JtrY6pAPZxnaVW0x7BiKuW2t0y+reM9IyOJtnHLqRr3zhq0fb+j3SUtQZriPDTTCU3ih2AgFe4f5Y3+nwVky/8f3o+EEExuzlBZkIaDkvrNUAVg0tkKzTRJunsHNMsVU18h4aZz6H6zDKw7EkA9s4kVzT49O9JjovjtqtItOY422TKSQgeRfxKomfm+CvMshzRcUcltd7vYAizAzVt1Bydl76un47WjCndyOubScGqrOEOf/qgcY+/YWAPmfk8u99NvjEf7a7+qUnipsW+ZKmtjbj+q0oSbgGNiM9puyyx3qnJO+rpiUns2zv1nA+65WkG0eOyUk90YoA93tPaWg0++dvEuyjxfaOJuTMAnmXq6UrF+eWJhNM/rweRtBWp8XB2s6wrz5OjF9rZcLckngaIM+IsEIa+oYiOCN572XAESPx4wg0gdD6uphH7duNdCASGl5kW6Gn6fiKqOTknlUdtUbB1ZOPXTdatY/cT5UEkXQIukpu/ZchlBPmFuw6zb0xHSm62XvadVzHc/EkCzpjfMEsVK+it0o0B57rU7H32kShfOoSfiIn7TlaUIxoJVC9nzbU321ByEGhi75qF2cvQ82J7vq98ieV3vhRIGPRYPUJ9EvuzbAhN1fqyDzZCJBhXCEl2cdcEVkX1McUc2hWMVLQ+6ll6g6fv29cCEu1yGOdiaOuIs1nK9gMdvRzZLrtPuRyjtY3fegK7uXsGe/R1KsW0zKyeh0IUGE/YPVerGC+fvn9nDs4KcWcSGcY8vLfKcYIJ6L0obZleOrbSw0dys7o5uE2sPlvzqbvuWkPQB9QC0vboxDgmFjzPRPrbKsEE83PTDuDOu719bIZyD1yuq4Eyk5LCHCxC4XLqrMGacPgeJcSSic/kfvreb78fiOefhXMZuTFm3bUMJgN4kmk6n5mYTc3xwsYBKlfVS8suZbzjyk3tDJzTWJ5a/F+TE/okb9WOrlPX2V7wunEBDD++F28o526D7hcLNLliLZ6ciQGkZWXjjbMXtYqrgMyY/JzMB6Cq5BJJ+mK427GiIPufg9LItAZk3NBkYwz117SivUCWZCbFxMbBG1AYJIGil7+dzVlz5V55+tJTDfBNDuElcvq1zik9O5ZTSP8Ns9R1I2J46rx7QL2YjE4JJLOwLHFspyOSgcOk3+R8Se8UUxGOHat2+TPGVMteQOuvFwqk+FZofWCAhL6PLCddO5sPmdBEudaQiUU2m/hnIK8FE1BF6ol4/rmUrcTKdFf8fNIXw+Zpr3FqmfKz9Es7WVvJpm5ixaeNc8AJJ19HH6zgCZNTca0KnxSdxRUZniql6l+V3H/ZrcdhbD3qGYwX5PBGJjS7DwgCwVYuf5ybiIfHnWMvPeuL63wLCV7aOrmGKIz7Li7LRj9OAQbFGIh4nzKvC0eedqei5wDjTCoG18niCduidaMAEK7kVSgxAlMxqQGMdizEdFfi/MkoApI+vtLAQBDbGACTlrwdXg2ewuUsLToqmsZsQcUQv9mMglampT/cEfY0VkwR/iXfkrAP2JbPut5mGP5mV68rQS+klRm+nEePnHHHr7rkfAW58OVhQ+fSCGb3nC0V9PvtxrffX+cyCanMGfwgsLZVSJ4AEEADKfQANHVHZXXmBJpYC2rQAO/cJS2abMjfOuIORm68cg+x6z9CKVH6W6dcDBHhLXmWj5oRmHarQ4flibFr4eaQrGjbhlCoecXFnoSTHnScffIM9MWxFcDcoLPUqSrnQZgRpWZ72syzbHN0bMpJ3ZrNPykuEDqUERhCEGCX9DxRhgmayPznkdwYl1UrWR9TRvdm5ZGUSc6gUPi3ofwZ2DP0Gx58QYaZbWYqmBW9fAggLLgSnU1/Gjkvi2YSnaVzW0fC2l1eK3aEGBxHXyZZTbiwzlKVpBtnlSvkMfPvw+9pMPmpT1u4RU/4l9N02r/xmEWiCEbgnmQt/yfEQu9gnUy040iFgkZJCUYYooW7gtyzLRKVwO2Gtjr7VflVV5bUCHbE6mac3qzE08QN7CMfeEvnZS8MBbEiu5lPhpJgjQ+BQMNi7UOmUTgdekzGFEHwbLYO51CQ/UXsvbSyR3vlRhR+YIsVnjEstswNslRx8csEBWOlhC7nV4GafUzTbvLh936Fnlx2rtitvSJFjJff7zW2wlHRRgmqQ4j58d8dz3j2byJyZIoc2G1YA+/UbIC4C6Ji1/Sl2mlLP1Ej/Yu72E0yOM5PsxQs0vWPaimDrG3Ad4WF3DG2Y1sFA6+KzDnb1Dvr+/G/lhoiUsCpUdVpil58xEo5PkoaeY7W9ykQ26oXyAMuuCsr+AdPu1cvIRs0NN3WtbzVe5sz1XVTbOnhItcjJyokAjn7OC+3mn0r2qAmW1+ZGOzLV9j+Pmqfzjox6fDryZEh1hAEOXqRvMJT47aEdveEMiSy1KVgz6/w5qdsMql5oSC0aKRpbir2oVg5CikSjt6Tajoh3akzlnTFNYbdMPStiHH2JNhIEAsPOZBB0YyrJ5xFqtQ/ckH66pngpmheLkCEfvEYp1d8lBdwzU9H0kRApekmw+Gw9wBcsNS8Iw0xSHu/ZHZzlrQfnJnmw1kawHFpKIwq7tCq66K2heNqS0hQEC4STeIN/SbCJKSlzZKAO9dSc6QriYgs30ABdVr8WO6B4o9sWLS3yzt0nGp3yrlJes0TGDUutuuHSu2yeKw4jjl6sfsn2FvxEUiIgJ4lkzDaFJ1fJ5UxGwS7zSmnsMvYdAb42uhuehCurK/swdbCV6ClFXHNVgBeJaiAJZCh6UwHwxkqgr0g06NwHIZg0XXUl1QCgg9SO8O5lP9Kxvpg+FJ48UnxQQTWcdSa7rXsecNV1sIrTyQpPOX4Oq1QA2dgt/09xIdmy3Eyq2nf1vruYss9qlA1vIG4TCKbvs1on6qdslm/O1poKDnzpQpOWsBaIRAwTywbs3j3h/BG8Gd5zTbog0wJ/ztyZre4lgOaoUN3DGs0ggSG8n8HLZZTFLmCwZPR9jCXf2mPryGaRjxQxYzSNLd6ZyEbxl43QjYyaHNl5MDuAZ7A5yN4gDcI+M7Lcin/0F4NGdTdiihMWknzb+ZIWkGej22Li288G54M9VCpjNQ5JJXsXOhM6r4et6Kz12sRNPcDtbabJRxIvqY13TIg4BqaBbkLR9Kc+E4OqvqA97vQWMqXesZSnSq83GDvcLL1YFqwqAfbFgXWUC+mQ937I7OctaD9E/rm392sCOf9+nCmLSURhV3aFV10VofCfJBADFMf5uxlRzAqCOvkL1KDyqovxaPhxPmO3IO9U8S9ZaZmBEcJejQPIMHm2Ah2zeCk1FuHJfi7xY0p63tgSv8WjKHUv5/qcRJwuW0ZSVWWILC9xnSm74bPuZ2DVT5P3/FZAzRZyfvTuyEswg5iZu7Z2h5uh+CbTda7AgznSv32z2En37TwwjFQLRj69juOj9+7kVFSoa/9h0F9JHS6YSj8b4dSlgxZ8tlH8zuruHmDCjDEOQ1tqdljaOtKhAjIX0pxTIa6ZobpzzI/LFQygbdAYTRnZ9QbFJuCFI0mAbh/2RX1JWb+w94jhpn5mt0HiUWdr9DWoiMCOStz4L4+xR+yLSgKZdKGHl7U4Y2r+WAhsnaiPHK/eqVmaOluCxXSwNDKmQVnR5xdrO9zS0O+gQZpO/H6HdscFZv4i8oKqloNscFmn00qAJADPFm5GufuYARUri2Je0NPzhu45JHojE1s+2c+F1cER4rHg1DRMxD3JYya8QcAgphWvubSHdFiWwNXW5DwMy3o3izz7KQvG1JaQn/wAg35Y3PHanpqfAIZ/nVrPWs08IDmvaEz5BhdySL2wAzQbVBjBo6SqqnnZXgFsjRKOA6FDE7mPKxy/TUads5QImDKFaXwLIAPlXYarVs+Yi9sYJzuQvjEayF/Pj6CSR0MNLH327szeeP9KWwvGJsCRTBp8nPI/vy0hYl/5OI6bwFu9PPOZNPnh3evmipWp6UOWHHqkbmVy9jJChFkKxbMZMTW7p7UKAo2iSbGmmAFgqteg49RduHkWmuLCAinyRaH3q67Z3tsQBTstL0w0Abwtpn243KpSjNoM/TOplFOTkkaCblRsSSEBiD9sPrIJf7Ok3MA0qMPCOJ6tC/8gPCqHE3vEqZVOZsjMr8d8Nw2UNg02jp/cf9pz9rau49QvZQAW4gfGg3OTBqFkzyGuPdrCB52S136HGlXHfW2CyFUcXuN0UCSazUqLv3WvrvNySscrEmHOu+2K9W9a98nPn8cZ8/N+c8O0Mp77L8tZzwPvMSuI34Y6xfYCy2zXvc1FELTiqY9Q4dx25nfMcGfmcI5k2NATT66NHiLaRW03e2EM3cFLBULQ5/cvvauu92shPhDfn264219W8LmUELr4axPQmVOK2+i3D6GsFuAq4IgST0nBt4lhSkZ9DBgM421jwBTCrkCsF/6QQdrK0laGkl8/8xAQkKvBUqQdKWWYbAeWrp8+IMRZD6g/nuLpb3GSFC5qZoGGIaalSoXzH3dE6v18BSnuzoFzD5BnwjxtINrEX6L6R+hwyOumalQXWWgotpYTe0GKhBs/85M+XA0RZhqdvd15uY38WCKemFJuFJfZcSKp2+8DhLa3Ctbazym1RHAKw85vofC1yoeuYk3npt47fgUg2LcuORT61uEejwD7a0lu/6PjG3xHUxrtTaKhMLmsp8M8EShqHVUOKSGH8n2B2Afk6M9FIFiZYHVHmSPk7Hf6JejOZKADlHzC4cAL1awSkD1VRuE6Df1ZuaK15CiQAyKx5TxLQKjjboTYry+Pa5kNqrH2ec1933BB1cTVvNfzDAQVqpS2c1ArteBRwtrVAR1zod89bOe5CehJPWMGIH8ogO+dOh5Mo+hXYeCkYwV5ZL4WnaML5giGQSPHfFe7uHFkP99FQRn/3m8cWSV4pqqY8WL9b/h+ZmVdPaIIVsJ0baOVwo7vmhMg5p8LoE/rx8d1dthxS9WsY0eKxmnEgy0Eq/gCtKJu7hE3mMjHszjRYS2XNSSBE8mGoL1+EEp67y8rHKueMZ5/JeKYZ479vhfky6/XnZFBwEaCdmEGq1MOo/k430ORy4D25Q5Rtmbye0KIcCzr0kNGcZJFJnocv34Vw5+9lp3CvIMGc5XV/xwWCOq1cbe4YU8EC2SX1CXB6GP5nhnUMDbmPkFgozali9uCxZu7cPeLJoQr0aqEgHdKIzgHBx5rg11Kv+jmVsFoFoGsquExncjR63K+pya09KqV2EXVwBqrtTwWDo9kISBuPxr+IRAVqtgISAhJ3I7KpXJYFByyHt968zg1Tx4fHXgIDih5pmihqnkQdSMkQh10lW1eBrFiRQZNnomih3anADHPxaS/mui9rxWVxF3FPgc0KyaD6ybNA9hB0i07BBh4DRSth8cageUN14GNiEQ4M4mmP6pJ/GSbp/a/gu5wsBYQOqj3FRNZq20IewDw+I7me4pWVwXrRWZO59Exo+dY9vbdD1i00zlsxgh5LN9jbvGY2HFjdemdPTUVrk9nr5PTLirGHXmIhsJhYZuIk7UkmHt9DIbhLecffSnLnF/TMosdqVfng13EM9NxmzokkJIOPDsrdYlKABUNVEactWXcbRAiiHtB+VkY+/pPp2kGO4Qx8YB6TWABrNp1jpFdqF1LQaVmz6dHsUr3bWeU2qI4Bi4fwbkhSAFqAPvOuprp0f7cJxD+DvXUp8ynT4zTCanOhyyRhv4HJAuqltAsiTKGe5f1VXe1PtK8zOx2ophOtymoZM5/VWA/GIM5ayknq/CxQ1hP8Lp+mjmHKqfiH45UX5zTOAAgYog3ukhWOQjDW5vvnkqEeZonWDpYzdfy/LfEY5HfrbgeI6/342Zp4NmOlq/1XgmxTxiKgAmvsR87eYbh+NFH46U7HOwtZ8Bz9ktgY8HKr9tkbC9Oiidm0bJn0E0D3eVWIVXa4fG2LorJloNdC73+kytaJvpS/gWMPLLa9QUdUghuKaD8Hz7dKX9ohsnorZx4dldkk2zn0Qul+678jHqUyfl5z6UAlpBjuEMe2h/CGsi7H3rG7lPfqouVFVUYAhmvbtbTpWIEEg3zfhfegBHzjIg+EzgpxRpQJe3+kA+k/fwkYFHETVIN+mxBGzSWEmblfv8P7o8mkNZbi2tJH/5bDxwhfgzAzHZg7CwFnzQHmWgRw5ZSM7iIHx4PSqYEqclBEJ01Ok3GBYvgUr6SH/PQrzV3WENQ7QGB78OLg0IMgu1IWAyj47q3yEQnALH73uBG409VaKLZo2LDdIsG9DEeWTq1wplm+KfIVAAa383ZWR+GWYvaErZ6XULJGowu8AeBtFPJUggGGvADtuind0csofP/JxNxmkf0DSc16FWdoLY4i5UDl16ubRsmX5p0pwq+vbjBg6/P9VuEoUjATh1GkywlUiccglOPW+FRnpu2dNE6Lak1PG3FzRq8d9Z8ip9qZn/vaLp1cuORT4LnFP/UQmE6z3PnrT3IplGtnoY5wBCqnVrPDllLyD6WV7eJiPVDNVnxIf0qWEquz0iuefw7z5t3u4cRQwfT7PVLWrVyfoc4CTjTZO8PiCPQdrrzn2buhJN69ks+1krTQIS8kYfEgV5U26hZwZjeIAaR2f4FfUv6t+bC3wg7iqJlv3C+xTCtOp4IVPjkJeYpXH1ENQSGfEMnxy8XrpJTsBZV3tqkPoWVSp3MpoZZY57+QQ56BbLzN0zRpEPxt2zmQgFndjowA5MuLARdQCxn4NFYIsRXyzrtktQAHlsY+vCrKvIMullS24AlQZDAwMH8+ob957RGcXE984uDgx6otBUFl96htYGk3k0O1PTaq1K7X5hoBZQPNOTcWj4URXWwxNoNumxAmKZcxApoDnYDditN5oXxN5hGnMMcV9Kf6sSO9TgvNaYFpeHMG8MA00DNqHQZ/SfLjpt1ZBGbhf4O25IIKTSJYmjcFEEUEhbShOUQaViCTJjl8ptGlZCoMhVV8mlwckR/8On/QNG/SwAt3BBuT0fYwnXGryxhFZGSs3N6GAEx1imS3vkLvpGNotQvygqdlSVotDRnzNf68fwxUkBi2sbEwCTtPkjUaihjbbn2ApioQLTjre4qdXSjnkmwyTsohLgfw+/8Rq8/tUDqJDwL8BMvRXuEjUguuDbWLgM4Y2ausEpSLnm2RxlMV//rHnIEbLTPyX6WdwHLJraIR4WCDyfswSRfeVJc4XjoyVBeHqH1d9yBk4NqsTW3W5NEcxsTaBeVadgKYp/odABVyPbeUUEe22RikKia0iSJH+7qphfsvsoJtwoeKKCpyYXDAQuA2GCKLPuyzDVzZVDq72qujp4MCs4cyvMq5IIIK2dNUdpUKV+5aFQWuhDsdVQzRcNBbiYSZcbAt5mCgSLZc6DFD53jnwjIl/6IyfjIOMViM/6P39+LfaHH57TC73ejuDW9gVEQxaB3TJo718ybmJ4ohSzr3/k4xHgAtPAU/gVmeF3zODInVHlI+LVUi/V5nDGz2P85ZVhVAKFVEAwnf/jueSlPOkbSrQD8Oa2rM0prbXb0csqE+KsXAHOCnXjIq6UrNjUcSjEyIDRPNCtBL0iCeLIRtoucMs9GrsDuvhpsUZN63UYTUaihjXfxhbq16G3bPMgYdg1h5US6KerJKC2bpbg2JTH3BUQEtUTHU+DaGebLGOCGx4knJiNy15z16fagFxSXPu9KM3ByW1Mbr5Abrx69qa9MNRKRne9HbfPKEspZ2d4abw7aAq26/R8YqyH3jLvN0hgtDdXes12wEQoudq/1RxafJy/bH3Iue3QERre2ZBeIgChuBgZw2EyFGysfGVSURU7NzS1e/IsqGoQlLKiG8hfW/5OXFSNMEXTCnuhScbsxzMLRCqObxk6XSdKHJ4vJ11T81+Kjb34PFWO0GpShEStepf8uyCrrBxx4NZxg6Ay24qMbn+S4AiOZusUmyExidjBZ3+zE6815PTf3HMkmsxMJvtyzgyjQ8IIIUXw/xIdB6OvK5/FRpPAwypKfAl7h1fAjgVCbqvkkHCaBSa4GPpm1KtH8Dtfip+Q6pOCBKD54U1bfBVRAMJ4TxtuLkQ1QMYlvnIQN7tquJyfp7R1oxaRDE5dFD+r6QA3kh4owutcAGYT9zL8QCwsQV/JeQA7E0OxemzfcRM0FtmndJVpZgv8/3UZCqljLupX36SMc73EXEGaxSyEIuxWPMyIEgS/dDSQV464oM1lIX7fKLfingBfMXWn4hTCXBl06XzwDYcVH+PAM/eTL6MsS13vVsP7eyG1GkghEnqSyEjF5lCMAwzFR87/+IadgsVCJpfK0yptV1QhkwYhRAFK8zabxQKXuM0W3g71DidNlUHTDV3nn5y+QXZXi4jNDBy7HCkfIbQ0QtS+IWbv9GLiqAaWOwq9fPh1U6B3nMeAFQh0azBqDu4HpQ5sb+vkneQKz8/FdS95Y1NM8skFxOeqoyj6bqnfGkjpns47PnI+OpWNfFDLhdHZJCA/ZshZkE5kK4r06xkis9IzfwAcJYOonIgo12Z5Teu2yNNGR3lcRxskKXSKWLIF6X4piK6Mp85kOR45ffLpxOg1uauW1YTZTsoe4emlBmimMGyJFNVFdImi8bkrElt2o/LuI0L6MbTtbc50w1jG91rwftqWovXtZleGRu4R9lEGlvQ9mULhKDBEzry+MlHlC4SiFTK1xaup5UK2e2WsIZdGT6XMGFtiLJBAOAsfBKG16vOyoPeXm2HfJ9D9i6Z9NkGgqgJpFT3yu/ABm+JqAnUwFUfYD1XD07grVKFaRCcso2A38IV+WXJKzmwMiuUGKM0Ie3Mr/a530yHkjbx3z14+IWb0syplVnB9GNxybTS6R9iJSC73qzyKqqlIhmVA9R5PaekSDDgtaorO3+MNi5nWJGiTDL3rjFpHPho5cFuqyYoIuigFarhRstaV4lhADxt/4hfUejnTbEPOAMYGluamJByFd0sdqKBXhmywIRZ2SxG8bkkGHoA/gbO6na/BD3z9WTIBj50TVmGP84tLDHGB8onbR4o6a/uHvUEGm5jSW3s7RsjX/us1MeijJpUMKlh2tmlu//SM5DqiaUuk5jIsUEaCYxp9/eJlXTRTaSS2j3Qk+YD4mkDx6MvswxbqTWFyKV9gEbqRUnVBQvg1qJJ39zd4QYHK+NXO5yIb0LwZnyxO7pc0N/E4BKXaXCaDe0p320WqOM5FeaDyqvBRBqY2mdpidlJfIslBYoAQkuCmorZm9TgYMrkTzrRtxVavhDOysaKrmQhPzbOWWleXYcTl7+SmEI+sdfwSeerVBMY0+iEVWEZdl/m57ws41G6LusgZO33LfLlE2N6oELLw+Iuajtr4ate4OuY0fyR9iRh2EkiEXMiVbkjmsWoLu7rbN2Y1wzUTkhnGpbxxK80LguDi6sSqK/KnXtWV7pZQA7YpZyesx5h4UC/eObQdLVjU2s6/8Qs3GaVvD4sJGUX+1gLay8YEeeTuSumjF9r3czY358ojcmStAqEuNAG57lbRVUKHe2F+2C7ec/ud6zRbUcWJLzi2CbQq5exy2oyiZ1+G36JbVFwuDO8LwibUCAVOH3c8AxDTQLsI4wWkzMtpKVFuzqZemDba+Ipb3Bj1mwLrJobv14hl6Uzi5kSrckc8VfqhVoCKWVyHjztZ1/5OKA6njdMo4tn3x285VR+opcfK7rbo0XgCQ02/ogZns8ibg06fe1xSxFU8OgG9epLkSTZ86JeGpHH9/MivfaGsXRoR0UufzMAkNJWJAXMIYyjWy/VBLZcNCX16EKGRmwGmPWOQYYiHXaJRfnUwB1LJ+/XLrXdbgWxbbmMDT0MPNrE8PtI3iY+ipf4M7EW+I+ORaSWiYO5emjUXGWbEVWP73GGewNmaTZypFEfGJO7zot5LoY/tPRR9JIhwQuT+CuxON4eIyJfQl/Q50kdgTAbizj4p0UzkJh9qsoCRUwNLy1okg+hJrYJQdHAgbqhn2ekbzsSCKa4SfVibZ+l3XTx17Bc5Ri+C/Djznlg1UvUDLBrTqSfcherob35nk6++yIUu2PVJKZCFT2JZg+AY48t289cUjn/zu1A49SX5lOLFAyIXN/GU9vjrN42CSXgL6nw05sRX/qGuJIv4JmFkqucxELx0M44u7fibyL23C+eJ4jzNdJGdRbxMtXeO2Z/ltz92Hg0koNnqAfC3MiTapWfqbBd0bEPA0NeC059HkfwzLWBaJ7K+Q0oEdSBLPOjpzsS5sM4b8dl/SubNvGw9MKW7frFEuHOoeN0B9vOvalMqSQFfnvmkSp9cJK62r7P8eDsLF/6v8CEJqWjPvIHOcopTpjcQBUSG19emEpnTLFyACNHCcYj0nAUoaop1GwoLKDTqgtYfHkjzqt5j7VCPH78BIwaDKDAfEQ+F0eZCRuGGip4WX2nAHtvE4VTGHFFP4EUxNvNOJL1YvVcYAmz8NsWPQCNax2HtlRs8upaOBFdKiSYOejOlBuNg/RJ8dE2793k3e3fsV4A1pqbysD0d50dSkiynmoFsb7VbUE/hQ1YYQEhM/OBTzwPV5c7IXmw4I1g5uNl+A0YdvLv9YZYWdL10H0exuchpmN16F/jKV7rXvg67bznQS7WRuaRsK+mxCruH0cWICHxcuu0AZcRJv1SmeDvByJ7gvA5PLYgpLZ+ez8P5F5CnesqVwVmWBGx8WxXu/pK9VgN0NRtWDpJXEAJhkZP9FlCMtyeXJXTS4yJOReCYTsGfuMSgosAd1oKcXkouNIPEEmEjnntyvp2qU6CnOvVgILJY07RjevTcwRJ7+9lte/boPSX9gjCY519oH8CgympU8OjxNabU1mxeQg/2VZcabW0jpi5WEAVNMO1QpZDgW8oLcbXH3ekcvujai645/r+Lv6wCDY0p4yTpZRZFA57QKYAv1xGO5DaHdjovn/OL797e2HhQ5A0xnGPWcYCEaz/XsuspOsuWwdirrlposCQrzpc1pn8kHrerUxX6YQg674DqeMjnfaZGQPlF13P/1dXFe3Dh5E8++vCIC1x+3DWsMTRF4ZiK/RlV7KU5bLlvrQ19hmpM0BMHI+Ozf3KwKsy62/ODE2Cjdod3TCd/bRVKmVL1HcWzDlsSZOxrknyoTUFsLViQRNSS459NrYIDmh9QfyH2Cqub6KxA2JAQyX54L5khQezd9jjU6Y0L966cKeypQK356UYKdhSyxBf+GSfFX+JUnQQaH5bX9RG3ZGzga4lQZkAqnZ8CfT50/JukBqZk26cEPg3MCVh64/GGSuLbmXOynJkLcDSexLL5plYGMNz1OZyXT8zwvOfizNWsul3bVRXksfxlGlMerocCxnua0HZkSsvXQ/Wgx+TXOgSozgHBpk73wsx/GlC0YNPy4z/BJwk2G5UFtdz9PIK2624LqXVwBqq8Y4sICKlfTq+WE7Rad90AOrH37wDCUlzQQA2iXXShnp/eFjafXXtF8nsJ7NDZxcGBlhd4efQxpt6BksapSMbOAoGQcw4j8N3iY0F60k98vChnbx7rfUsKe5LyVcqDNyxmtIC8/nDnD/97bmwD6mFdqHFIVYHEA8Dw4FwuajNm9DRtqUia4pw8RXaAGfrkyCBhwO4kfAnXgEocoQsHDwfaQlidJZaffNrvNgfAe2E+6OcQ/KK8PElCn/NrzOHxvlAS802O48ziimy+97tgkjoHFUoSwBNaHKb/Q8wep3Iq4nIlZzSVm+j1i8UyvR2hrhSKHUNA1fZlvmGGrmMeAXMAmuOLZZdiZwvo5PsE+VvXwZDcw6urZkHft75ATAbxsOZqdsrFT/KSlIddviHpikMZ7Jq1TlpsEqLCDVTYGrqrQehcgAtzMLsdr8DjtC3wfy8XFeIm7iZtOYuNr8ZoO18E64CBui0Q2g9SxbyjQAN7jiipxqAihEClgv/wZRwLOgy8AbVolJj85ugMLNEybyAYqr8zVz4WWHJOqLQPM1vel6OD7yhgAY//6RLlg5iSdi9jyeKZd1vWMoptP3EtASyIMzC5Tjwag5Oy99XT8drRdqzBBgF0BdZ97UrNCvquzUd6O2lwF1PTij725122nOn46szlfj8c2mx4l/EV63npr+NELU0C1mCuhkop1bbZPOfmBEPXlC7m08/LC5Te7W+ccljGBSB/h7DnkSLIC51mpIf4GGcYMUMZ7Da1/Gf6p99Q9tG2OjEJ6fknxC2Dd+ZLWMVtsS2xBQzjA2/TFSC3owAnjd+Na00S29PjyRXolppz1atEkUOjpKUO0lhsH4B/veX+1bsor/Xovb8Yj6Ey7H5c9QcnZe+rp+O1o39SQQCRBXpL9YcUwwfaaPHLxMCsk1D0I+RWsEU8XaBjyzv7PFSDgtjpAxCYCCHPJZatYqJZsGpZjJ0NfjBHFnZcElIqBspcdTRKluFVA6RvGYK9aSPbxgAn2tj+Nl7F1PhqZ72gUXBOeM7JdsMEvZN7alJJkGmBlBCZMvd2qRKHQaW2FSe+9XUOAzyJT6hLh9UBnRptjoxCerKx7nN7XWDtvtvh+6VMskKPDikFDOMA/foQPcPttSn4bfgUH+HV45lr70d90VCGaz7MOs6rXu0USGyZbN+BhWx/npI6HxwmYqDOCZGQifQFGtUoI+Ls76lSUk/zsslz/F/4/cn7pIW7/xm+8vhSO8OY2jrF3AQbUMfVh4z1F9sEF+jR7nENJxwtLf+7+1+6HGAaBfwYvZpbbY7TC0VTNIOE+5I8MQtdlvdcdFmR3MMfzMr2Z66kpQAtTuwKs81hocUEhsE7LajUE4gyDH2OfdmTLzG/LAIVwQjI+z4wpR6dCNw5ptRFhb4WdyFONVXxcA/4Bs1nNObesYGubGhLNuUy/UreizmrnOTy0dt0QeTerrJ281n9AzeQMsoSjYBiPCEmGVEfOb+AS49dWA2JDNP6iTEp14fVWiY9QqzMb1fB0ELYaay8Kaw4GCx5epe9y2cym4NOcyIGTTdsOMqWVN8IGqbQtFE60ZoSmHn9k0dhBmER0+7DzbQQskpY+U7ftyafkp+rVuODE9U6jmchPcfDUgSW+E/6Kke6lVfSpA+RJFuBwfyzQPvqkbsCeeN65QbHIg6v9OnmFYd9lQWaQzF12kwgQAJ+hS5PXrHGz7J2W39tu2/9uqNWK7Rwg9lhJqizhqi9C+1er2XChmcUONEPn9tVrst7rjos+geeqcBrN+Plof6B23qqdutbTBnsOnMirhKxCh3cE7DoUa0HWeg6Gel+Sxe8F0RaYdtC3Vyb5RYO0MGUW0SRs3xCelNeN4yYG9R0t7uNpUHxKvLPcu6vUUBc7TT27UK15cZBMHu0DovhraUSgLuZEFgT6oquHPZyDb2AZXVQi/Kx6ZldugU3oe1CH6R3+4yxvbnC1HJqqJf+zzh3ZMXnAY5CpCWdvQJAkIedddIgUH/5lWkqmTdh2ApjDSJQSC0T21vdWNOg6TmluQJJti8vQX2UQUZMnymtUbW1qP6egTcdjk7XhcnBNejqFt/npQHy5iTMQPWqAYW2cLNTc6oDcQhzoR3cv2aaJaewz3Pz2R/tnY+GNmrgXdnovH2Znd7m7n7CcziXW3knv/hF26mVxPDEMBqcpFu+hWfH/NxLT5483jLPiUG5qPcWJTXlco9ZvorDjQ+YZIGjmi5+PeMfmBl+ZFph62wue5+eyfQok7wMvgYFh2qxKjsVJaDBXxBx+IWCVmV3iOUK3WQL7v2fhdfOERwwzo7dZGmhP25IcjH8or1FamfFeToTkfRvTSagbg0d8xblNenV8XoBLDfW0XVmkJvBVfRBFGWkXJSLty93HrQC45/dFy+LzAsQ9oT1QvQzBiJNZsF3lpLsBsPcAXLLA1PPSFYa4kGtgYvFSwxjYz3xUyuxkNCArQyDINHkDCMAorsgCW5vu1AtBuoIy1jtaHCIuf9IrUGUxp4Prdr/ccsiTCTv5VK+QPTbWPKpwNCrMlCxB2aKdrDkReJc0ixc7LOHN1ket58BukZvB81FzmhCs8dLsbXt9Jeemwk5LR0z2s4bLQ2MrO2nQJljDMD2fozLVBLaknPuD6pNTz87YWJBA80Yzj+K/t14Sslyg1FC2nQMcZ1l+hhAXwZe5ylOODLSHB3POe/DV+QMS8x+0DQvcDaWr7/rMOWKu+RoUZKnxX7vU8+a6z1y1g8PQGUIuFoToQERQdjNNfKeNjLKUq/rRlhZKI+hFxXxPsnChKpLVMqDrPSd2LZZDmZk+L12MQPnTBaCHgnDXHR4qNDwF4Nx2d6PUNmwpl8rJTjfzu3+s/INP+ByGLuqCIwaQ3Z/m3/fZ4+z8h15qj3jC/ozqIMKiBMlbIxfioxyyF/3+1IcGm2w7uPOfp/0WEldYd62E3H7eukacu3+z4QqpnBaF+32X7SUQT1Cz0T8Z347TRIS7HEHigXjATdXazXzI7yBEzhj1raePJ+Nx1yerdB9VyEnIARGBX8FbXOMsr8yKBFe3yeLR9aKv3CthNSjwLBZ7rc3pVMnvUTHl2r5xS6vBEh1Xb4vS1lK9cSFahR+DhAOUIZSq43m9QRMIzXDO9W4bzmBAdDy+MVImSGmHqoVyo5g6Q8lUML1HhMmqLwvwmo9AljsMFwZJ1D/m+h8mzyDO3JCtEoNBWLYwbe9bnpvYPkgH470DI3CL7U2LU1msib7/PRM8atv8mpnZKR31wbnliIaqP1h2JcdRcLVUVgY1afySj3KKIG7LlyU6RkhnMt+ay8vVLO6JW0S+xpnPu7J0Tzaiop0YGxAOCg+fdZ+Qaf8EP92pOgABygFHUdBUU0drxxGVr95FnsuzUXrjCc6CXpeSYwKSFdTvZt6pIFFF2kOrdIx8dJVQAhxD+Erd0XK0+DbXT8lhnJ7g5wQWNLciQmkRVAUkn3kMw+55uo9CAFTZZKTDtBRSV2xEOI0rY+qy7XA3CEW2hfYjZjkFrz8AYV54kJ6NP8FbWAXbL3s37P7tEezBTTBwVsNVZJ9moV3i8oezOGVe2+3zzWmocIJAIV4bitBdv89KAvEdj+TCEmhv1kHgbW81CHQtsQ4MsaEwB4nWEjTHpByvDL5wfUsv0Yp8aJkCJvkYvAfRfmdlJUmK7FPoRxtgwOjISiW47fzUXsb0+C6ypwraZAHoXYhXxMZy5Hn/I/1/H9Mgf8ebSGYeCtptdC7o3Q7C1VqjkgyILCQzm+vnUY6l2CFw0HDzzKaTRwRIdV4AZyEAqrwKsNm0kqNDKVWoufiAUCjHvHouxK2IACnC8C1l/aOz3Qtc9ELhSCqkaQamkLW/5t6dDV7Zi2+cSjrViuVVvNT9ZndjnwgyaxHq1Bqkkc4lsmzWc/tvBwFKduH0km0fITEauapQRoQi5HKeKTZCK4WucnRwbmEn15lXhn2+c85EUA6SPa3xE64YzS3I42ip6mEHFJ1rRvBt+yy53LQShthRDo/L7ttdlavuc99fds+wpgH3eSnm44RhD2SIWd1Dbx45AdH6mDNerrOXm8Z0LHBNkQAlfCd/0IB8CAujv0NvM4H7xTl6WlkdX4HyieeTgLNDBlykIgk/6VFUN2ZtGbGZueCSX4PdS0y3O8rLNHnrr8/WKsHxpU9jv8w7vduED5sZzgn0Uh27BcXmeHHSo+kwZzh5kPLlS+2VP1nxwX8euTE8wdwdAglQR5Fv67xzM2pNbqVqaYuen4R/TsiNlmM5dYDcA1lBfRuLnK3pSQTuFhRWLV3/UH2Q0YefPIGASk93tOpkGvQs3noO44yKyigtqvWit5VHioUxyYMv4hw1lALTaJnQl+WYqH6lNyXDz0B+o43QgNhoWHp649MHozEOVaztt9PsRo5rBBNZ1+eVFY9sLujq0qopuQUuIG1Wi1VezkxcRhbBzGdS7hTCEAqoy4yPMrbU7LGzNV7c1aCO4hddazL4fFSX+Ca+k26AwBChCPX/SBluG6DyMk+iUA+tr48F4Vw0XB28gbq/BqpwO5KFyrMcrRoIl1b43PSToPV2ksqsDLfnUFh1ycYUmQlUEnla0EXfK7VVJA8PMGmG17ahcxIx8i+cr3NUuOPbpxtizgJShKjT0EJ74QMu0sfU/okxYoP1AP8wuETbBBTDbtqgQnooJN1mLcOUg/z1cGdTq18RSL+zFWnPo2eNIddDF26gC3RKOA5DjTIaWLlW/PlEriEr7ocaJ7mCTvnuJX7SazNzEiTcdeToGlpoXn+rtj0X1yVcdyxRjKhOTm4ksroTFhG9Jj8LyxDAlDIlLcdXr26VF/9vmBCrtp65YN0PmpqLZ6unaduz9+/kdOJBg8aBKsb5+3AB/BhLogXlq4cqrTptew+OksRtz5nCdCT4wN8uVTq14Is9U/s3mZS0KJKhIsk8CPOop/p91K+msQ9lhL7yF5RKm32rXt19o8P/lnH96FLdrWqVnVrbrdb9xi+uzXHaQnH2IVJZkbxgeteiyIsL4NAL2wLoMhoOjKXfWoYtpioAg3qvQVfY/7d4iS43xmav0IcMvkWJv6A/vFzNUX2VbrBqjVEi660+WtfvRyFnoGIczOR7hBEJbf/xvFvAcQFyono3izz7JMA8CcyNUka13UmfLjycmhUj3f51az1rNPCA5sL7l6kCxswJ/YR+g4aI6YvAOSvms9NefoWy4geId6BwdlAffW9Ls25WQUThbda45tr233Vz33LZ+YQgFVHAB8GeFFtbwqHewWprXRMn7cma2Zh+cWFuwkWwEDcl3QfA0KFmHN6b7AS3uU55hdYMLj1/wNC9zAvR8R4pUsHZf1I9kgO542D9HWI+kU1opINie3Uq9x9PvJWv3CEJs1LhDDFysAG7a+37ms54PLL+7ezqRNBozkdqOxC1hjuMG7MS//edKP0bS0hm14wxRIDKym2+zdNk7RfqjD5lBkn7pHJqmvdV0j/yzNyK916NTpKfM6b7yWf7Rkmoj0tk7wgmx0+M2KctxQ0BlyJh71FiwW0HNDCJIuwJZSyUwhm0uXMmUT0zK5NKgGbtbXtj0NNJUJevGuxxiJBYIHs40UHixpxVkyLZRaIloro3VSAGF59KABiJ961wNWHUU8SlC261xzS3OubFa8TsmJ2bJjdykALEt57dIyHyXGLy6/5LiO2TsYI/iQwb1Q5otXDPRnLRJdaZQPmCXoqrGeQvigKG5ZpIxynwb1Z+owyOVBXpBp0bgOQzBpFOG/lqYgaXCSmUwLijnI0Dw4Hokn70JzvP9oAWVnUur/GIDHl6RGVxtqkQGofwI/OslUllWQGsIgp86d2X05S2VkLuLZ93Z+/IKKqWvaqBDt+UyULFjGvMSH5xuYzvPe+58uigM8CYbwdY8iAINs4qKPQx/ynTbqfoKKuM1Jmq7PCYTRnZ9dDXvphT6JNas2Luc6k5eSCOIrr8aiB5BOnGISnbY6PhsncX4HW/gAt/2ydvuEKZZhljNz/dCA3w014nG24yHdPAuqBrF/Rfy2Gia8ORQlM3c9T0uly/Xl4+9obndcITVocit1wgHUwszTfvc3u1EEW4PKh/Jz6jv4X+iG+hd85asu56aFT7M4G+Q+Y6JKi7kbm6ItxARte4FQsoCbqxKvDSv2ZahgnuSjXOlPd7mlJkIe5rSLFhftiPw0ZYv4QZfnLoPdY2k6vTX9mSEXzM7HaimE63Kac63ZQX8C9I0jSoJU68zWBVmv1oYO8b2uSna8c+JhbNn3gyxi2ki57h9maOFD137nJDVn/SmxkYsWs2ASwLY4xD24WXWe02I8V0ZfZqHykIShgQwi3+cR1M7fuqFFcLmu2WCVSY/C4Awy0lu3GEG6Z0CYLIWKiEY0L1cExXLUPU5reaT6Nn68F9KHlEP8qCRQfRu93eXtI4YlO0fE1MVgopcA0XnRDmykNcrwPdE19yv6gBVqmUlYg1Vvp9kIJxKVMD47L/us6y7Yq9NZLDg4Wvy8YAjs1nmL7tPthQ+Vs+e855C2XvoVx30SR9ROyR/NnyiGeUFqyEHL42UYDOXGFl7XmORIPqWQ9vvQBWcA4Sb8aHkw1tXECjZOTIMkzLKWt4J/Jk4pet3RsH5s3bEfxQmmsxvWMSguCsTIhBWAsCqCbpg+VEG06Svqha6CH/WjVru2c7UJvDXbl3/L8t8RjkbXvKFqn0yqQtgwjjgfZp9PRsqGa++uEDuT67vcgDQAYn/z133dS1YdF3TGMRQ2bXQbU5FD8HvCRWW6bT7Gw/ryrPNYi/htiB5MNbVxAo0GtV1j3xhmRmZ+W24k3v7wzTPBGozh0nK95+3nrgDEjOw82yPsDAEQaMH1RKfEmEkHEF7UVVGs09/IjOAcHC02mHxjDY8nzByfIS+R81TDvCJOLpc6MbKZ/DEAzePQ+mj5MNNjnoj7zFhd6FtFUNA9UAiJGeCVarpZb+aRR4rxXDhCtrCbJe/dtWQ86ksFNivAgQ1WBAJnk+W2QBPHFuPMYF3daZitqW0VCIxIQD12s+3fRpjDTp0xaY+N50I9n47oYAMdtCUj9ZRSbp32mh/H+layAzHCNeXpVtov56QFHBql6/tU2i/81evXx6Czl2xPr2hDDEJI9P4gLXwUuctQtLTs3/V1rBlDVARuJm7XHOrTkgcoZd7t5qcvNq+yIsEsApZD8YQquZ3v+cxboXZczTaRp5QA6A2vG8JudDMPevYGf3kM/QIWUNAiCwVOVMQD0/o4esadMc2nm3hdqTAP9XInUa4m9u6Wf2/M/rpo9V+t7KXgqYkMlPnxg3xkEDX9Rdccdm7v3xB/w9wyAzqY2ygBia5wGRZfMJuLE+Mb8oNlM8slWJzB0NyzdR0SmoETLd9npmABEKZeg1B5f3SntSIbqm4tysOPBad0FT9/Qz+Q3abKcM0riAIkPKoi77LfI3wfKWdiaqU8sOREKZgXZ5dMvIPM9aBsihfWzq+/pdpDYSB2YahhLn/B+4lHX/f/vYt50DnOY+x4S8ENyFgpxEs1v7vciOosCFgDgNX5aaS6pCaJqokF+Fme7J5a05bBmfzXK8C7PzjLGJ2hWtQsuZJ3I7/vi/xIAoSDz8/kpXuUaWaRExtWBehc6mhqSPXQESQWgXH8CO47/u07RKEk1glCbwQmdai3M197GMld8mja3+AFsPelq/XXekIr0S0056tWiSKf2owLBMXKkD27cHcoiI9+9D1jGLvJp0idvuz2lMag5Oy99XT8drRRA816ZXpijS3HuAW0/XsSc6CCn4oep98TrhC4sTIaTOHdyPzHgxoxEqlOlxVuIKDIbfg554mtkd0A4QYABrWwfOMCYYt4qu/R3ZblavfP8Ck457g5TpIyDXJwCTr3eypzOyiv9c45lDMblQ2Pc7EzwiclQM5JqvmPsaatGp0cvY8LK8z7LHdPEwHbB7xzDT0OHey/X71DrFNLidGO/g9xXwR/1LyRn6Bs3XY0y/WoisYX1gDqRUtPCkUOoaBq+zLfMMNXMZu+bHAiA7NqMyQGqNZmsuCn4HW8DXvfi4Qfk/9GonUo9ZbzehaK0s73vZfr+C8BMNRF7vZelsHWlkRd5cMXl9oKg4n9OOpkTdiwEPapDNJ2UZKC0ZtIdZuUnTMKY+DVAqasIHqeLtHxP6trPJ7p2uLQocbz1KqpWn1hYu3t2vIR1fRx3paneiS3RdgKK8mE8L1YvJnPA8mZ2Zfe5sKmjTfGw2JR9PHkS5FQUA7a+efsdE44vBTM7juYrh+BL8hhoWny+s8iltG+zShR8K9yjt6y3EZIUq5AIk4PZc12rVekIxoaOqu+fGFPF0SEMadk+WjAwME2AibENJc8CG5kRhVSJB/1/7McsFFRqn7t/P5abYu0XjbKp5sqKqHI9nivXbK2S4C7HaEEFBTSe2joVxCOPyDVWcNCevDidaFw5N3EGoMRSi4e08afengyGZvSjshuL9nW4cDaYRJeLvQFoAb8nru9A+lkCwNy+SuitY91VG8LZAGX6tB2k2k7uaukOVn93/EfpEkv+T5/fsXUL0W95VuVcxhGRsmtZcFPwOt4Gve/Fwg/m3z1JTTE7jqhUHe6jazXdHuyjXn4SQzj7UCV3aMrWxe9iMJOSXqEDEkVcEGh4nVjbnu3Br9rcInto6FcQkGZDvMfmbGPtfrIj8YxLg0O8umGGBkk3Ulk+Fyk5rY3J76qEJwQx6yFYf14qfD61o8+msrhZHlhP5LbnZl6asGl0M1bdQcmnnYDyFvd/yUszG2UZLgEVUlhVSEvvmMspZgSHapmSoh4se7pRnYS8blsr8gFgoIixO7khlTtsiPMq4yNxVC0HS7BdE3CfDeR7oDM8nQu9XCTbwI4FO85Ztdpl9pu/0fWf6T4Q0k4aAdmFtt5jCrCxDwO1/TgQXm9Q424uHnGPtZCTo4ym+FoDJ7zb3ENPL4+KcCe6wb3PCdwlZB/in5n/ScGNMmB1x3jVPQyPzulvUBgClpQQq1ZiADakk3dh/ilTc0jHlzSxV2YbY/ZnT5kTfFOH2MAyy7DzfaGDlOfRXU1vxnh+mKZXMPmpT1u4R2q82jWLEV/VawnPFsHOwhj8yfCAsTcLBLessY/RaD+nveWK9sLsD1JcYAwH8RhUtzKrdZKzHCxoc+lzuZH957Ok/Ve43qZhwClWqVhKgP+YT52vj8zsHhmsqfoo6aEXFCwYqpYgVHUzIfRQGzGJUoD2tyL1Ln+obtxmZyiCx/AzOK8Jutai1i4hF7smCKYbzEZMAvIp8N+UWq2gmkbSg86QZcBO4KF6Uvsmz9OHqK7llo1DN1B9EeVZLggPasxxjKjY7vL+duGmS3KelGU6JjZVbPDsZvYQwb3qczWbxj6SWuUpCAJ8xizR8UeJ4AwQJ0RIMw9JYyFQtjJnGjKXHZz69VWymBEQfuOwk9zVCJvDrc3Gtl9nTQej56x4x4b35xUjxvFGbP+bvqZ6dFRZBWRdI+zO67nv93F9RBW+byS9NbC3Fi9c7eycZfLYZPN9sH67ce+XYhAg2JCi+gYd7NL2zxAn+z06XDa64gQjWDK5HrVOetdfzCtZnZDr0tPrZ2ZtQbBbSynU0SMn30e1506pRADHtJQ0zgG1lsNsuYSYJDw42pokhSZKBIoCxwjl+zZieUvL10G1aF7Mz4WSR4O+NGGSUyYqHz+wGqE6t3y6klJTo9pRyVFCdI/CPiKiv2RLnOyCO1CZOBk+3LRgjHZKaF53HgnWcETfBrInaiw1bHd3m72gaaC387yX7RV80hgJWqc9a7AWUupzd9NRiNvjEEC9VMg2CzKypcPjmwcrrsr/rBsDS0N4i0DB9B27IhPZlZSp1yiGMUsIjhcbBijQJi+y4+yTc7oF4SxtUMLzGwTFiqhiUUz5Hmorwro3WXcRFDRydf7sSNLiZPL1dB1q+CcqnqjMH/yfbCjFwnGo4f4Lq8eXWLBZ2HcQStseFbeW8637ETGQl/M3xEDqjotVw/beeU8jFOJBUvUoiUyZF8SOR0ZBjTTPpibvFs1t41yp+/8DRST9cF+nv0CXgq9WlbQ/Yb7GHrehDiW5TZPLwddZiwy9zcEpWgf7/zlAPgBBeY5rOR6XF6lVygFJAnnMeB5VpOW2lYbylpvCbuzuMWGclblbfHArsyWqK62+H/uwC+y3Nmp/N8n/za3CrkjrjXMb6nim2vRdr6VbxmCdlZgARSZAU2giM6OfRaTjZsd53M7yeJselCEMEk9KtYa2nQ2eeDkk0et4sq3pch0wHnFBZS+aAzCaqlEEP3xr0fBvhFLObluHQxyq1ZDW3RBaNuLh6XWOP1NXDFs2CmGPFPMDSn2/9a3y7WNQjVQr3NuEWmJxMVhD9oagBJklAeUzW6sO61fnDN+qIzAu+0fFnVwGnRydzjpBlHwN9nbcmSCb5JyW+rGXFYv1OIz1T6deOVysmNiL14XyDOvhQPlDBEOKnhHdb+mju9cl3JUrGSRcvkjchg5je5Mnf5ZPy9V+CGBmq+QemSIlEN+CnQOFHkOuLnTcbxldoc/joKVGJBhwWtTgX4C+BX5NG83AEr6mqVKvkMe8QEQVAdB454h2U7mHhMsifxEyN6G+ROihnBaPsv3snYtw5o+0tgijNV4uRvhsvV6mOFLMYQTjDmLuGanjFdAFKaRfxP+NSMhYtBWeY6UBFc6NolBQKDom2Hcg1cbL39EPhR2urBlwhWefi8ZdIvWePIzeDVqOJ38z23bVcwIiLZZi3NIhluYjKm3xIDxmWxByBWEK23LUnrvEeipDOhIhfNX5+4ZCVsvORnxPMQ5JlKTaObM03xFWDNE/ILWtM5qaZWZz0AXMuO0ypijnTaGuWyCm4tNg3MnRd7AFIqPTOOmkdTUDiSl1uI6RlOy8g5vT1ZSiRg/S2zVFKbgrSlfCc3iEBj+CX9BTomB98lglnEDTjssuXGAKq1AlPindjc6d7vDbcn3e1umSftb707eT0YGw6r4Zi9TFvYIJvGqMzN0d/v7lcDS03xD+B59bCkbNkYHp7tCjAv60TASvu4aOHT48zcAPveaYATB9hE4FkNpDgt+ebZzzsBUGr8SEUUPBMUb2D/gFwi6Idf5CNWv5zGHO5WTDNjqAC6azroYUi9Ue0T2rroGs+eomxjvVSAwdBFD0b+c0JmcVwQwRrZAREwJ7RzbeiimzkZ9iDT/d/rH4CG6tdDnxBwZhp0jUxBRFHhIbJOtzmwW5BYQx20ZfFK2waKRvlV5d5JrPnnmF+YbDt+k8W9aENQ0yAKLkQvEW42ksHkBz8zENWyzVZnIfFJzeJt4YirFmH5Ga2WTgJaDhP4/s1AJn8vLO5/Qo5n9kqtak0hINWSmgHcTRRVGMMxyPmrmicel8aub+65Nwkh9Lh1oxXl0GluzQn8+3ZPXLkj0KZ+IkMGDlsVLAp6jAFWoEPWdeUwfAZHZ5w4E7YRWZWnSmnTp7FyK1gLGFZHKUVQYjE8i0lT10lTqJVO8bQcyhdVUIjr2TmljQT1qD8SyiDQMQYwQOFPIFO9z15RXiQ6EUm1QySXVmNL8WyYT1VLDmEVyQrflgEK4MAD4OiBDRztjxYR+/qLogTeIxiyZkwny7+lf7PFPbX8VIIiqTWQ5Fcrs+JfvCjt4aYBWFOv0m/ZR7WgMNQY0xtfErdOQ/YzofHeyV5wnQSy4va480cbR7/HaKKAy8IcMhwjKjp/ULVkzpWccaVzcL3Dj+u/TdezRZyykiiXF73pXEaWVOwxLN8+1ZOJtC0lPx7uuR7ule/aruQZh5rjbO09qqgUPM8kxNPxkS0kVAMetM4Iz97+wbWJIKs0ysc78Sc+DY6n1PNuXjwKuAI2ALGc7eoKyD5Y1/v4QERfZwTZNVaHQ8AnbXBjpB2ncJvT1JBX+6OR2S9kxsmrwBajPHnfWTnkz7hv2sLqWvpgvG7KUPLCVU+P8roo3F/umQDf7P+fFTQ+0gVQtCQEvXI/u5uEEctXONc4RMZZSH/io+Hyjoeibg3VaqW51Y2DGfawJXVs2qfcDmPsHsvmZOowhJ191aDiBw6SbrwuubWeqoH5dqPFWLgruK1M+KQpcDCwSEFRjCTr6Kue48DsG37F5ilGy9BTEPDZ9lyyvqvenGHCEUjFHZz8ZhwTvdglA8YkwaAiKdvWClFfjLCrIqXFb29XMBdDuruzB9pVUekK5+0EZbAjExrBA+yoJjLwAR0uMhjo7oBjI5UOm5g8NOKODDFrkbUtagkxKneigYG65QSabxrSGYUvnMuGIpjlAH2DT58Un0ZK1maEue4WwS8cdu+iSO0KpKP0Vo34BEbtMcHuVcQucgOl4ccs0DEDaUsW6H3hLPRZLC12ztiBRYVa4wjP6D88ezWrWZoIlX/edmIt/rboIiIeddb/JIRTSiqqCchU0qYyDHPDu4VH8GMZF+V9lnyXdxbrAzWmxZwaus7lfdFFFsmRcAZcIkZJKIJ6WDF2z9pwIpe+YP+0SqFKBBNlwW2lQa1sbOH73igal7RdDWrYj33NdAnm/uC0G/z8G5cG441Dy4LI0xVu5mnyaqrBXoVexa8VgIPmID0xQY4UzFdDNUguabdEGl4WKtXFl7y6OmTOpJ5gwzTig0QQxY4+MiiAycAwGfzr1IfCETjdlLD1KtDpdZZ2kGlMAEIaFbDgyJbjbtqSmbfHwNGestJTz81rqKWbOOyuI1SAWzhWMH+oVonGy9Fv9t8m1BGUShK3OH6c1aHwWfmsuSs1tD1JwJzQBQBXyPC+QkqIbCcvG2IyEGapHLiJsHpRIJUvpeUmLMzKYUkst0LevBhKfaRLkP5QYIzl4dpdzV1S1nCD8GoQhzhuEw17jLz705xOogoWWOS6NDq/85f4n5UCNzGF7d/dgWsH01ZIlfApa+KEoh3SyqyhHlJHTYc2qU05CQhvPM7bfzIwDkx7B2XBAOQRcbGFmvfFb3rhU3qJ9+ZpOJldmVbfFOhX+FxWGK4czozPSe0JOb8pgIe6OzKp1cnl82O6bh8rWlrwVC2rP2S3jiwyJVWh0htSc9y+Q0KsS9tEIppyMljTlPoka3AeONo5QHbVyhODAWOtBl2/ynZVI4GrseISuVndWiG0vQu0fNBhEKhqcrD44pztj/k5s7G4p3WR4UyZC8gXjoqVwoxU4QRaFKbvGNgpAZTiHVqlORU17p7u7BRqoWp7E0GqTzM7rcF8DQuInG+TGKKiFyQu30MhulFJUQLCyJ03JOhNeezsTcfovcli3tnwQKbzbDhCuuYRka9vM1nFIkTbskUEZ5+jjy38RjOqc/73LpEBtAcO4a152f0SKFZA8DAhznATOqNjBt4h3stb+gZZzahyf0Q592Qd4NE+hsdh/clM0cX9ffHlYKNU0oS7enlFwLT1N0EEb3XsOQFD9aX7YqPkL7302TCJ9YRx310mq4oC1r1XhD+R73I6WIk39G3igdfMRup3I+eGisC/1uW8Zv4zeDZHD2CfZnrx5YPi7SkgQ3z8LXlJ5EqgJ7ns/MAEsBreL8gd7K41bFFQEgrAdJvEBq9R7P+OsizC3c0yrdO0Lmv8qwOjkHh1TytyDZZpx8CiqsmVYMyPx+KYJidGM+q85J47AX6H/Wy4ePIJ0AqPEZO+xGuvVPj6ceLWqlUwgs/SZWsRmmmWA2NxCb+8O+hnc5kItVyHtAlK8jtr+X5n9O95atczOkTen3K9OtBtfn1sl5W2o56VJ575/6R7HGxnKtzh1jknmZnEzOR/udvssF3XgagKLlWQW48bp52aghILnQCL+BATvkh6FJKfixRmyxCPOuJtgsAFZEMMo5pX7O3KVSqZg+aIfhjjScpc+Lu9g0vy/l/cgWky4vMvnL1fSlx3V7Xyi58uqz0LCDCm5MD52AsGKgUr1e/k0Fhnon41H4IPwyHj71fkhWnEAEG2X16kP1BnkjPvKTR2omRvrfJqCPSnoZVgJDify2wNAop8P2X67hFosrGwlj5R5T9LhVYEGiNeqa0eGIQ+sgU/3sM6xhIV0rdUXqTWsgGp2De2fXQZsWDFHWC0dQfa5m0yXVImrqyJ7z2qBN89ZMs5+6tzzCrhFczIw97hergBdks0+aLuCuYVYWw82064w1BJoBq0dqcqBTinwZQ80oWkER09wSr/49zW3IieHx79uarSbe4qbrCDZ289AxqYEVM6ky8ImBPk/nktbG9kWWL9bO7zgqCia5YwQQehjPjbLCmX7PBfuwsJE9+bpZoDXdjbK5KJBMTDLepfbhbMJFbIHDbS7i95ZzegqrwB5tnnOIZzKR/z8HqZPoqq5bPjgrgJR5taPDm7riDgJLsArkhsCkZxDZ48n8iKb0uq/nXsTVnxo50gnNOLa9nM1A9cn58sowNNXg+D7iX+LNlEJoF1mPt7O/L4nBpXNnPuTUNGYyUBfrh7Q/ro6tRHnrwnAZRtfIwIRe2ojz14TgMo2vkpRk4rmNACxDkg6EiiS5B3PkT7ZfW2BnBwnm7mhnbSmsTsrzux0ZeehGFdwJa4EHuQXRhwxAGy7n1TgKGdGAAVife2hoK507zU3qp3IPh34+lb7Ml5Aybf3YqXy3jv2rbOAC0/vnSG3uRD23/EZjVJL8igrs2Kjz6KYaGDuqeXkFoXXWUbFbDYvNfbxXWejCQjs9UmR9StqIMrf0aNaE4UBGALRIIRm+XS3n7BmGTgKtNEyxUwtYtOXqFRIHM4PDUX+oR4k1w+KktX+UV/oaP9i14S929P98SJTRSJzPINTF/3P/xpgwC5bkK73XQ8NPcj715/VlVPJI6CmThxf5ciPWuaD9jwkCOXEVClUHmE9pF1DOIq8HV4NnsLlLC06MvvSuADMQDxXTgeDOAiy9YPCT292q2a3QjJVtOry+ufrEeswNXz28ZMDeo6W92HkjtJ7nosO3CyyU8pCGqtiU0TeTifPPEzKX5McqT20KHX/yGMjaRJQQZ94Thu1sZF34gN7Vx4G9vZ0RqL/UI3Dmm1EWKRBQCgvHFboFfcT9xsGakqWAtp5qtIa2DnI4ZV97Of30wqBtc15xPZqZpxL9s3S5mqzOdrwpR6dB2vxjejEPBcA6WR4k675RIdkPeEvduoGiOau5ch17CCGU4xsVOIquwPqfpS9FeGDxRE2CDknnQrexSMOAGLyJHiw5atYB6OymvANCIbKSpV8htp+jXi5xf6cdf6ce/79LqAVPiIg0ijvC3wvNjm/NSKIIA9Y4a8eEdqRsRevKkUlI0ksc1Vj5p5mqEzrxosMmr6MIhQQ35dvu9Y2UCucEI8u56ia/ApCTVaqWcQ9/3rxPYpzBbAm8lkiV9N96dUOiBdBeDrZcZ4SD/r1vIY03/rx5H+SeE87zo2ync0BDGzVycMMJu7gnl66tBCaDQHb3SyNV4crPxXiXY73fj0qRKrJ4Clbs5hnEXOhPBcWqK61AfV6eyRKDeTkOdGhnFq0sMuEv8Mcj1TK9RixIAs54HmKjvj5CqvExEef+VrjCbE42Krmc14N7hKxYSP+Jdz4mFooSmgPI9vTWCXTbcSvNNQGLWyOKOzs+H6bggJZ/9tiNIhFNR6xOyda6+zEs2GJaKhz0kJ9/oi+4XXzg2JSXQyXUGfQ/2xspjOcux97JELnbpL8K1EQ7exJA3wop5o7sgkxizr7fqLlQ/emk1A6aK7ngqvWLGMJOvbs+eXnZrTojm1ZMX5Nhea5D7zdx2Xb/pg9wtKXPqQSeWcAFp/fNZaDHhRJu5RsmdA58qAe6YazRExaL4gLRjIdW0mjZq4lKKQzlQ7wVn/3IkQIWAJ6M83lHI5sKTskvHzv/eQ4R5pAEeWYKWQpHUljZrzteH7P4k0Ht3481LwAdNSk8Rc6E75atlCT1jEkGHv6tHEvSMzbMRIRHuO1zlGfxQGkKw6EOyyu8T1Uon3ClMEMmIpjAI9K6r1hApU03ul7ummZ/6J69cWYcPC+VvGJXF6y0gg7/CZUspyvUemWdr9Jf36N7/4Gij8CHJpEiGU9hAw5C63PT7FMY2fPjsvL4smELHtpc+Zw4DHJpf3f7YixEWwgt/8NAcdtoDIel+ZzKbg1IQJo0803jwOh1uR+KnibUnK4xMEI45hcatSqQr6hQKs0rx3w0UrU5fPgfoL0cm/nDie03/2t7mRBYE+qKrhz2cg298DPOQMhIWT02dBoBAdJhn+nZ26JaIqqOqgP2VR/jGI0TIo4hF9JTK1zaC+B+hoZRbH5PYeqt5pwIC06ePjUl+/onzj/KoA8IbD9qmUHGrMM5E9rVRCMDhh9v+SH5GpGTVSCG+cp5uwM5GfYg0/3uCfw5PSehHRkb6sx6Fn2Fd14OOWmWDDSk8IA0Sbqaot+K1c91BzJGE8pVIyk5EzqeRzsPBay2ipa3sCUucRVAPrG3AUGCilVilCR45w6RyBbEYZ/rg2znbqy6vizUASEny4L0LpYwBpwRWVJSIkNtyYhe29pLBCzFjI7pApRH+p4+lbeLsXUF1KulFNdRZBI0qXtneWyIo3O41Hg31UVKQwXOD6J560BfyQ/I1I68AvvlJWD31vsF2ubU8RP3zWfaMesTli+aBD9xzwRKqMavvLc1Wg1iWHWNF+BpQ5jQvIOQK/wvkWTB5R+ldGg+J0I3I+NrYXI8Z6Jlt0ZUtPopMGcJPrMUzMPhD7aP8jNtOZXrYrWf0Ns4opnXxiXCdeQdz2lyTuFBcu1XHX3n6iJlITjxhp48kRGbiBHk9q137BWGPzMyLcRinVv4WRVk2zNCHMaav0/5weusLf6nBv+u2ZVtfq/SyOr8D3GCgzN5ICnrvt8iAfVb0zfWYORL0RF0O4+asBfw4rMy6UuZ8Rw83rfBrxiBgR6QYUhpqRPL6vmJVEVN+ntulcYVAV/61otEsCgQA+pZcT3orYz0yHy3tcXgHxUo/hPG23PWR+nLTgY3Kq8fb4DEk8gA9f8Ipmfw3ooqYLoiJHr0DrRoHNGmJVAuSpw2yauHwKexFA0P7OG6ojSmWC0yRt5VjLtlMwiGxCzdicT2E1KPAsFjn2/bPFSyXwGgCMKVNkjzs+EKqRr2zGOY20lV17pdTBPcXFpBRKC4yZNRtCGoluDEDv2SF2dNdPLJSuCEp+tBmidDpJoEHcRFpCvyUwAyZFiKHPxDnIhwGluLeopVRccRdne3Dd4mGtcQMvtjFuPcR4UuxcyfMVFmNKs5sbwp4B83ELLFV5SrvXlOQMItjg76E0iPTstA7g9S+QejC4V0lpolzQuUZZXgyKRgj59vx8/22KQrCK3v5zRm6J+YHMGOV4G7anx/UIDJQ2EzKAYfNzbDIuNfjugxqvDuEICWdRCDm0WpRHN3phcC8FGdYgjFNt/J6+bLi84i76reK+/hF9CFUnrQgo+H6CJFNWPDlIj5Bn55dUGLI1YfLShZi4HR06gBa6V5MeVzSwnK1KTSUEsY2QCa1ihemcsEnD1mCCeBu0AxYQZ0mgkUPLSjZsRvYFSC75gXngLZ1Z+a1/DIm06zzA02KpSls0mQa9/oct0jdrMbrr533AsiEIG7NdH4Bvm4IiRfiSL1B1vfcjObMFp6nmw1ZDVkHQB+cKihqkWdJXF9TNRKcsMr50UnmYHkhPbkcJWCZ06uQ+HNbKhQJ5lyb70JlNaMJGbTHXE5t1VlInZmgnuM1zVEItOy1WvNfsE2gh8qtKuVjvqZg30v43zM4JqC/TIe65Zeon9hJ0iVvXCrOGPKOzvr20+x/Ql7Xvnfen1lKV6syLjKnkG96zFjYyudtdhc3EnRNWKZHKCoeZvFeJpfcbW2i+1ZODB9v7yrqAt8MEubGlxzmCZAvNATmcjyH6mclrvdOXv1v6pC5iCiXlfsAuY5LwaM6m7FFCYtJPm38yPnh6RImrXzVw432ZHjWhjUmxNFTqTXda9jzhquzHRq6imC7iHGDrmbPMSeM0e/9dNi3oz+zB0EfO2z6a9Y9lTvWaxdm7dEGl7PtGL/T5JQItWoO1CqhfzEACwvmOtW5OW4yF83PbC1+fkY6H/Wriy9wkpVw69TTEFSzouadODmZ8kWU1ygtuQoDEahqhEh4LS5zG46sz3AEguhJODJMQ7a30LHJJ9L03nxvhGLaVEBTVWGrxBUXCJlqkfaZq1/eidm+fhcftaD49sG8Tey5LP9cPB8nWY0cFmHh/Foupv7nvcT+e58TvA2jcmUA49cgsMiiPxWgx95NOVD4oaCdlVZGmjIyH6/gTHPFc1fSwWsBGUg8Kp892XgF2qsm6qr/n+d165D6FBaCzUFkXGc5PAsWnFAp3AksGyXvzST4VU7u/TgDkA2eDCezPNHcu28heUSpt9q+DgGOkfgaqcDvLsZfsRPrzP8jlZervQ+Do+nwpnnVQHr5M1TR0tjllq3yTZbA7WFd3AtjGcJKe+FVfo4L4QzvVNkJjhOAPMXXhj+cIojwtz0bG1Rpybm/gvDmtdSLqLDdIDKAMc1NAvShC76qYuHwjVFjk1TVMQAdKfMrlQ7WoB6+MUO1rMm9UWprPEqI52ALFLTjbnHEO5KzUo+FumzMzkJ9uKeq166Q8kD/TOyLgVBHXt+qtHeJDp3C4KP+xO3V5O0fCndHx2eH/6R7LG2JBP6BBRj3oPzx24FtXiD4zIx7Jnufqdffz2ktPlmmwmOdW6xUz90Dbnap71T3iHvVPeqe9U96p71T3qnvVPeqe9U96p71T3qnvVPeqe+FRIkkvcq6qSl+ZI+gJ9Cw57laOPSFxRKmYsLjhUcWZD2V0Xq1ABOsZrGG5IVe9FFLJ8LjuV7gDuM59Q3n0dO5RGVlwL09bG64aVUFFPxwel+WW/EDzgrDIC3eKF3Y5dm4BBxv0no11PqkewqcFJo/eJT8bKqZ+zK8h/xeVhJxNTM2pkjlsuoHKdsRQD+dLsBe8K51tW9HNGgA4R7X/RfocXbS090GyABadoRbb5gsJHbMoOt9tZDBfn527REdEHFIlbOZpaLlRTbBJ05cQENFfcGzXVxHTu3MTeGX5hLq6BWWXR7pRnGrjq2nPcYCHMTuOOpacd3K8+5tVtCipXDSNUffLodYPjStJWO/YT71jC3l/zQxxPr6O3mqHzmPzUL4ewzzNG5FoiVI0PZdnIODXcbH03ioR88d7ke9Hhr2jDeKPHpaMzouEBGPb5ekGZgPLUSkBTAmwW9kIgYe44CxrnSnvIs0SrWYtm0mNeCdX8BDXbus8AZx1V1hl9lmL1IfCpVx3ZWXDU08frE3XZWBTIoCeHkVF/yradYuJ7eWTepc6Cu0BmJEqjLl9+tFoqpD5qA3dZBISYhdYUqpGh5b8ShmkzRhpk8qFh5TgSqDtaBL3YiqQb4ck8sVI3WSo/F8ICbxoiQVRlzqRkT0+1vGXiKfS8/DyNlYaV7mSK6iHG9DYF/jNHZp2mf6+2oLgTRZAjqnfFb6bi2WnJSWZmaXH2cDx2Lce3D9NU2Flj3LsPD635Rt3Gt+tTuaL0B8EHz7nCKauGYuN+PUFufut5B9AaKD4l0v3pdHtx9EVg0OUDuFGUP0fcrVps9YikM+p3jCOJM/eC8xnZRQNFbFOcIR+bVLc6urZiREhdiAPvBteGFSuwVD9yx2ND4/nduGASbOSzWKhRmqels3ytRJG22i+7sNtiMYD+T6hosztrpeH9nVpwPTa6s0lNlmOcCg+7lF1Hg1SWVdDx76qwf6joZDO7L1OcQ5WMWpsyBDWA4jr7UgP/JGU45ZrUZDty2JQugOPBoIktWX64jDP0OawsoKET65VmkUyLg1MtiBzlHD1F40wl2J+yAtsxPUQ//CCywaeLowL5L0KNSWLaNdoQxNgQNUzGigakpET0Jj0AnAB9zgfnKk7m4c7gBHQ1rCI3Nukhx6UlhJfriMW0XAIZQbDZ21cz/S4V1YxbtlxO2kuwTe5r6K5ke4BaelNYGQiO41bzfl4Y3LjFrdwOOn2UjBTF5h5q+tt4O9tArwz7UyNOKQmS34mOfWphwBpXnlN/kV0ilpOEjfEVZiHEqWqc7nSec5m5UcMPzMWuQXf2gKgiaEgNctHPN2MQJI3HCHasCMzdQx2b1kUkSzQTPm/Fsb1+KI1aCAX6olwggpx1FNY+WLvCuD1upHUDfQJHQb+EbIwwoL+oFxZ4rugB8BlP3VY2YhQxIEpVzrnKHzFX+tnV9/SvpIiH9mApMyxKD2KZDHaSmIN8kXQb9bWTDU3tQv0xTTDQwRfaZ+R7eTGZ+q2BVv3/Yyd/ZdixQ6bP/YlyChF666hgFLBnPa6S0RPhUexBNVLGUap8N2qvO1l+KneUM3pzcdgGINeokpQmsrcP+PVU2PyVUjcU2TeCVkQNNvfNxaeCfOxjTVjwbs2/Z3n47eWJ4E67aX8Oy+3E4ud255OG4nmzS55j0w7i2mB80SByUePpR9bUyOwKi5IbXOZYybnEoalFaq1NRhXb+C2BVFjj+5JoYk+gH6eLqdwAWyweWvuRJlJF+ngUEGhpnutPdLQM7ewu9K7CzA01ogLMUwVAIGRnnwx4QTfAgIQTE6L+d51tKvRuw3jOGTsA4SixsFfUAeos1DR/pytNrLgvDQ8+XO8NWVb5Tr+l/EWKpf7dyZHWiRKpT5S/S+higPfJ5FFR+ATq22lIjU2rS+qWCNLAasyvlucspCphYk+2hcEwsgs1/j2zUx6XilkdZVBr8PMWa6PBUYK6EdcDrG8g7q6OI4QFxcMq6eFbVqvSEgm+OIkp5TBHDqk3ESWkwJkiu9lxq4jBjzOP6nQEUQ1FmQf2F+JaSK5G+X9lkTt3uCv+Q+nUQEXbYEMimgtcsU/TFqH6DBrkgnVrLzgk6FrpDRueh5qrEcCUAL3kU28A4sMR6M1do0rqTUY8OA8Pxvu3nQ1LU53KAngd2uVIwi3bO1Tp7i0hl7KJ6fiRyE5DAsWihEKVzC4sPoLUSSAUPRWFSGIOS+s1PT2ekZTTGdGRTHfUZdTdvWT/2pg5x8A9D7+/A+KnpxDPwC+LJx9IVn4BWnYXO3WVOpirpKpVKjExEKKBvY9gZTclwZZJTEs4bWWLPPSDhhB8do+690vMvTcoMJHmtuzD36vwyVyWUmTGOLt4lv7h9gv4335DGcj+5TNCPMMCWKxAjUUqkMsuOb3Le3hxZFrctaN/GjqVKdPq5dT0kJwNd1fY0lpdjsE178eeHxXOKArDJTdkpTcHVK1EyJrfy4QKHD4q1SFl42dELd8l5gDN6YnJBzKK+IY51WX7zPj0wMhIvMJJEjJOak1tGRLgynjoHFKj6yekR8xoj4+CbX5LJqlrW70I6VyC6lpfpl1rmTsCO5ym2EMPupDeC/JEiHLmBE87k4PA3HkjZE28s2vXjZd0cOxEoyNk7WVDT0qJRpLtkQuwWh2YImlVNMR9tn/dDdxfR1XaYDX3HaNRWjhOVzVQrRSn0odW2s5La4wUlntzYT4f3toY+yYuCxcgtMEJbwWP9xpM/NO4uKeeV3TJsC+DnrNqpt5y0X9lWoNr/zW+x3+QbD3HbqOb5ipM0BLjhc7hGiq+ZQ1cwyh4ZIDlv9bZUQTYMjUUyNZvm2jli/rPV1a7VvhdKw92Vl6QSZAf1O12YJHPZuuTsR4egU1GxJKK3V9hgNV8FEpzHtLyHb84QfRHkM6Ut8u9eT99ZKRuJew+nnMGFUOhd3Xc7Vgn9MDTAzFwo1m4+okZvbRk66sAAWkk1c9jdApEY57MPvVLz0DYhoCsisKD0ajZL5BX2d7rq99sgler2pwjK4kt0sjqUm39SywPFndZWXaEC0ISgJmSG7ticgU/5Advpd8ITNC3t8k4qNir9hSPwq4sEY+YYGljJgN2uLSPoo1bcDoH1ZDQjG5N9Qt+uCFmY4vJ/xHx/H0jX4eVyO3wOpPcpJQHjSz/jY+dYLFFIb3Wmcm7EF2qjCTn520EEvI5YCADLukJ3HPujoUDeeMQ8reHySssjY4DRacp42qq7BmlCe7VVLEgE4bGKeNQobgZOkbdQMOaKT5QFD5aWrsB1PYMeJKN3O573RcKDVpA9XWqmyUfLRWqPPXIJw6yGTwwzHCRDAp9RmDIrDwipc7IqXsj244nBpQ6Etttn6OBw90yWd3L4/RYT6rZ6MMbQpyDEuME0p5n9t0GPxmTcEYoaV1ooI1WTsZWeyOvFxs7mKEOVuJ4zZD7mS6cKUrFCbCj1HKUQgFPM4BK1vFh3lwiv8z6iDcRGwNiIwr4rJuNolBK3KbRnWZaRz/1TSu4jrhF05rXTdRRBpiSoTUcKu9Tw3FPKd78aRXKtzIvGJjr6JkS8Aegrp0qZ1eda5BLSELhRL2CKSpBLtcdEc2sB+rTXF0VqKVwYbntKdV+HOt1fuc4F3goR6ErckKvhTb/hMS50mVjMw+xtnQ9MoZUN9huWkE9dMSgR02sEtjVWcRamPWwmpK8vBvcBPYe/xbtlxO1uZtjzuzgrnqgS+OWTQ5plhIfOmoj2JVtzyz0dskO0LlBp8fz5XyhA0/2AvjJktVBvdeGxsMNhz+VP78HfHfpzmmv5YdiszJ73PYsNAHbFJAYhk5MqNTSvFvRU3HepwK4X4xAzpipo1Q2WNmdTPT6/LeJPrOE23af0NIw3lwcj3qjgFVQlL9jopVn39uyCuxCNIkrO3NHtH4YiHiDgk+PDVqo/dB36boNrzUnK4EH5vpwg+Tg72awpJX9yV96aqI+yE3znr6FsXL5yteYKw9+bv0ISn+SEeWHaLGWPN2dootolQzRoDm6xORZkZsDx7FEU3QYUfI2BMEi3ym89RN3+6N0Gp6eGhLocqwtwUPF/hLKk+4izr+AC7nXu+rG7cDbhbCPA/1qfkvnjU/6Q8pgowxi9Py5Qq7RDxBx/VPcF9+s/3CH4f7aMxGnUk1WDWt+c4+UIGnoweNHtkvMg6ONhgZyCFc2yCfwbBQ9JXX688rmzvc9i9SHNG+C00IpUemWxvtrZuWCQQGmjKVngivy+mehprRKPdwshjTynHcF/JbhdiHtfGJ2GgKFzRQp9bfOM3L/UEXHvxAfcU/UWCQkriVKuwIk69EpWw3idA0FbarytmRZuDf2sVT6NmhqSvM1T/8qQNi48EK1nuO5T1Kq1/g85aDgmp0Beu6OYbTaG5V/6d2jDlgMlg5JuScqksO0vcdSRc1k+WUcAbQSjw+7jXmCPe450zfnV31CfdMzHMCdQ2A8TKHxWlUcW13YCyCK6VBnL9nIN61GsYJsCkulby4232Z9l1qUec/HdNlH0g1V9Ya1Fhe6/k4FPxMfYqSibmSg3a5CtsfnAAdqYQYR//mai+q6M0dXO/HD/K+RHVBQuVTIYB1TU3T2ibJ5LE7WWQKTvk1PKjeCWv367p0raDckxKbxwhZ1ZqbWTKWKJS9/Hw0hnQpMcafLt/nFKBYLk0R2Cl6FSOnzT9HZmIyvtuuG/nZPt01zvnVAePnBFT0CRv3jvHhKmN+73podDtFVAtvoIcSsECRCx48geM25TscOxPpgaFWzIVGd/UvsV46K5Weubpj4jOOFg9W4XtJX5XwJS1pF3Mz47/A+fz7IWA3sd9nShakjBZ3ebzOD4DGIE78EA6rYsvx0rHpy/GInRPFMU5yV17ymoDEDqXDNZecNIof+yT7oAHgeqIjuzioITqOB/11AOXaN3emEuWPRGSk2+A10A1f5Sb2UBP6YUVN12Shchu6tsvVvA79csNKcK05HhH5V4fNmtLo+AGJgmiOEkCkTJjh/3JVYd6apowa2zb05N6ZaPXPcChucrNAuj4bLvks02LDUKWSYY7kIVa1K+H2NifRsezTqBd4Xp24JgtNMiqTMuPFC/thdxTHw4u2cSrBNWx5B/hk9+jAtEugt5BQl+KOyGHEtuobSXdgdmAI48S8mtmrZEdiKbGlmmxYbECiLKt8I7zfpb5Iv9LOBV01OJPaVQgVT+YkZRqxFXs7jXz54zZ1dXEBAzK+LCt2Z0dPxm4RJkXPa6GoI1mP51UtNAZI0VddIwP02w8t1yXVT3j+EVNUDt6hhpFhnbNuvM3cWwmFYAFw4Y/N8w7dkYI5UY/MEEWQkLTpKCDATNtiKWDhJcVZcZxz3VvbZn/Hn/QrK0immAJwVV6NcZGcZrheUZS8mdtwsoQtl4TnwYll8ijJd58PtRcfLjvyliMXtdaECqbp6FGtd9jwLb1O038Olpms+TZ/XDl2uD4ibqMmtF8Rff+Ysr6Zd1lxulYkD29YpFU8QbLd5TGHb8aKVBoAHzBeL9O09s5ma6dZAL8tf3NyjDwyTfotLsLFwpMmdCqjh7n23KWMnYo1lEqphSmUw/iL1DqCh+2J/VI3kT9pIjbctQSRggoqMbzAM4hoEEdiR5eJvbnEjM+xNcToBUJcEqhG3/fKVHIhDREZRleagsgSaLQXTNePUCDLC5PLqdBgeF5ZmsMv8cHhQDlAUi1Sp6KQraB2NusOjpqQ7OiR4E1AD2JN9H9Nnkt9pzIQwPwALw5IZiSxw51N+WouM8aIqyFne7JFD+82vp4w13m8iRPkRj3L9/q+SeDV3NjRRUma4DHSW33BzY3xR/k+D9Fs0jAC9QfllRwC52FRcznp2MjPPAD2YA2CMK2wP2zh0SwezrTLEWZhZu4R4WcyP9YP7H++3aZYGbj+aGk3XFeplnEIUzWkubCAR13Iq/xxGLxAaeuQ+cn5eopfvraE92Irr6AdBiKtdg7f8vW9oqWCF3cFvVsiIKFPyhXmcTk8xyXZliGc/XvQRiiOmA3pGUeyBqme/YmoiVKnc4o/VlLHI+xIpzISeLUFwP6pPQ77FSOVe5EA/wyQcqzWWjnaUboIRD2XxH0n05YHap97n2vnGTrqCJe7qX1oqsfor7gdetLs5tSlwDW4CR7ay1PD1z3cGuQ6KIRZxLjJAblZXsyjWh2D8a7R8zoRmkCY3GSH4mDYUChdCH07fAxUs9jnFsr2ZSsAUanKT9IU0KeA3vyGy3s6gybXSlhprW1FRXRZYHbx3yXnw34LMtR5MVA38+9Pulk8ev8JfL3CjWUJtonVyww5ecZlZK39M5oRExGYBXmPnipmqlKx+ZuJaLUYewUYl1nvH3jZwaDCSCv+AWSfR5Q8DN1Zvk3UQdFams7uGCdu/NCD5QBspVANtxVfgaUPAgAMImgrOj07EgGJLmaRhCvzoc+i8+hddeYeEwD+1RxFaEHil0+JI5dAnYL6rOfGshiJtlgXQ0PWRYU8AydwEqyck1hJ6bNTo5Z5wWANni81vKlPoo8zabbrMVgcWaHAbXV4BMYzcLLC8nzYYuUaxD4plFHjgb3CViw23vB4QmYG2in8id1miZAFaOjjno1SojXV0zkpajfZocAjVVr5tEzNnO/MEfTQHA/RSOvuMN8CIrk6PHp2Ax/K9Sihd80wlPwgknZfMBXoLBuDVzRaW2OcogCHNuXqtTULoHF1AlqwGTll3PthbNBO+EhpjjB1kDAeTp9Dwn/AsWpVM61omi2WJBdwr1QuF81hSYlZKgGYmb8wyYrhQbIm0PHBZPNBFZUlIji1lBRaqFs5OWJbUjh8sLpOZ+gh9bQHEjqkMrtRL1Kjm6GGKXQ89dcoGVu1oEplHuUVGB7A2z5iO3AAcIX6ugtpy0MNxKGrBwmmsohMlaaEjDaDGPyjMdX2R7mkvXyF2hLyMtPV8Ky2FVHdZ2v0l/EXZ2bBzQhEoRVg7pkd+9AKn4eHjgZdgckhsnlUnN4dRZrHjEFlj2HZpXWIm1mjWvG0hVifU9nLgA2qjx8b5cT+C+TEXq/vx89bTElwDl3slhscMRhAAuOaWR4Md3FUmZcZ4Pnie5F6LKQU2NDKYhhPUiaa1v1XN3Jq3ZIGEDODyi1M6zeBh5yIZSZdnRw4A2gU42kjGFtWpiUA8O93TOHGrIFd0Y8YlsFQWPXbxEB07y55OizSgWT448Z2nMotnEbu2VJPOURBfhBtF/ZFG6zN8Ub7ODLD/skXyacVWrArEyu7x8PZWUD2pjFBkBwLXqXRbmVAmJnbCHCo0HtN4xgAvyFPmwyLH32YIZVy0lR0EUN9//YK+Gal/ZxUu8WA9W8bQSdp30ptpidlJfIslBYoAREuLATrP8pgIpQAmla7/zhqu5bdBSdY3k7k/Zh59dAxqia8LaaE/6P8gMcQC67gwFr0YUTfXjowgkQC26mrkxACwBTOViUgGhgCPURUHW75Z3bckA5ZzrUZp5stbi2TVt6DjK7LhfLxSwETDGoAcC8Nu7iq5kIQhzpX77Z7CUWuFmFz0BnvSeDTXXhWzz97QbArCGz8tpm0TRHMj1MtQuudjrg4Qc2c4nk0WOgXC6c6NOwpNdHPkjRNlkPgDcryJW5sPfCFpGYA39svvkYJldEzCGRDutl2MBaVzXa+vuS+GPz24EHlsrXL64pMg3UlZhodYPywR6r/SuZsZdxr1TaXmGyFmZ6Q5QKMVtj39KK+IR9vs1e2WqmBcryD8bio067w4MhclJ3XvcIr1H9j6FimBMjdbQTM4RMAEJZZahhXJdhJ7XwPUXlS0E7pTbacb+VdZowMXKKCZHbRc0mZqLFIejTSoVvXC71mmowNUdGDA5JuhE31pjTMDh8YNM0JcHjLx/xeY4TJGlNesFF9VueltzaTsyjL02/8RFN4B3JdjXtuHfXZyeO4UQ7wleP7zcA4NNjAHw7I1Sv8L5PFbq04c+ODDyu80c8tBPUOOllIVyzkU+MOCNhQtTtBecGbNtqbsscaYgosFZCBYLjx0EMMF/oAG3f0vjKjSVIaY+i2Yv4qryMcAd3r+VFY+ZSmvfQotLNvkzBRij9qjkqBPPGYititnYu4peEcTI0zbAAX0dRh6+UM18F0NBPfrbevBK/jXKAEoRmIdTU/tcQ+jFKjd9zik93tOpk++l40znHRdlNMjCOzCB2sK7umOke/Ex0I7NKoibUCAVOcAcOnzGLb/iug9B+gFRhsva5SfYo9zjRgCGMArVUTQhB/ASSMqGGtli1NVNG/Rt8pbiIq07rFhZo/fAVE3/G7DG7L5Ogg2nrmmY//uRk8EsV/pT9hG3QGE0Z2fatQdqFLaJP49J8efdLyQRxFdYN+htSy+YDPYxbQo8R2puqQQ7r1hlCzhZQhSvMi0oCoAh5dn89QdQGaSfSz/UaWg3x9198BNzjxpWbRYHZyfXFfgLHSiCnRplLbImUC3qYRWERt5tM6AbMj4hlFxqRhsg5u55h4zH5N5ivdE1aRqqz3v+RsDwQH4mCMkr4o4SkZSyGbS5cybWPYQKjMeB0DtpCCygcumPOjalICzVAGYqfoj8p6gK5x+nAIZtUGKjouF3mW38RvOxH/fWvi0RpxucpXkGEg1rv4UmZo2//uhhK38aIYFPYgFKfox7vjNuZFSIi4SwUg0+r63vVrG+X1fDor3LDViUFSR/vjeX1cSn/nur1YbNnjq4ZBu1if1fc0e+E2coBNxZfsB7WM1gX8Z8ytbzwwkmYIKgFeEseLCjGv7ubUdr9hovVZDFVwhpomYMmzELrs3dAXMeASURDEGf5SlYZiwLvHjq9NMB62eeJbhyAzIT1xFP5egWYJFcgXS35a88Z6hWopwPOC3wSHGpEH33gKGtPiiO86OpE9JpM2+DvVS6PJsgDRktyE4fHWpieIjEmkydh+ufmDjfF1gv3ckcTgSTJ85hgW2PmBEJShvHXgN34BArQWjhHnM855YNVL1AywdD7okrntlB4s1odsHfaK3FRsPBMkjyvt9u9ks3ldNuYP3yVl1i7WbF3jFBevmBntnDUJZtQYsQFp6m5YZ8buli8WQApyvFDfklqo9KYHdpKkK6rpPbjM7lQlHKqSfCoelGfBNlT/vVFMkMvuRXqk25IQ6xt0GdpgyVG/57Uh7fmyPNMMHRhheVAEbYo6LbkB+WrdJopaavQueCx/4uilhkS89tDIXktTvQvrW7jryaiXEOLwkW4JbYS1gH+EwzvrV9fWr7b9tnaV7dszLTcnrGUHqNEe4WKQ9aeUz2PbOLOaUO/V0eG8fsjMVPuABMMQO/7vsLdJhkAau5pcfZwMwgfJ88e5c1N/kM4J+gS48aOCQNEvr1ONwV7GHwmtoKr8mmJlELHH9hM8lsmaOWgEcMiSPM7MKwMJp4lqmUlWrIXel5kFO/H7Gy4hOY1mHfz7JgiSJ9G97Dh77PoV0oAFB/39SpbSVkUZ4Mz6vZ0RcYkP41lcNKbrtnu1nAVcikUp5nRrdSgP90WuZAUBqDzrF6cqdnb3HzyrFktWD8XY+2BesneQd3KXafbmOEaNnEme6UvuH2Zo4UPfmlNOhWkhxrz87ck95JMrGu/UAHn6rd0be9y+ZApQjPwxB6PgS3IX2W1ekzA1n91ExypRmthvHUKB5QkAtXCeoLvVJJHC6sknfS2p3xMUGJP7sE1BEm9YSF9sCAMl1Iv/wpqaSfEuJ/lRV135lMYrktw8zsQzY2fatm3jYaD9D0gNAM+blpjQNUxxHdEDLJB5kVYmi8ppGidMcpLp2ELj2Tz4ravllKao5iyUgyda8e+0DAFp6m6BgOEOmF3YeYcvE/76Eidjj1quENzpD3e/aen8fWrjbTHmtyO/bpii62D4eBuM5T96Tz4l4d/BkyKAUseYuJsMj9LAqi9R+zpzkoJyyoHPVpmP5GprlvyAt/hRzMl+eC+ZIUHs3fY41OnGVUxV0n4Fus31k+Zgb6mUHWLzfevqqhoXwuFjl7M4A84K2yyf2IS6ILTZ6xFItdZBd/rPV3sJfKq/I1lKCW9JgAQqyS2ltJTS/gKjmTGnTQN3KBeGNOq96tTDUIpOTg15c0bL9zxnO8jRDk62qAa4eflMIfMvMsgCQ/EKRYpPC5o8cwdH/tVC/xWbYbwxFMRrYiVaokt0GFev5lqQ2o3kGYcH1gNXjjz+GrUC8wwVUQnirbiO1kCkfk7euQo/lRVxR11+epzbSXIS39JIkvox7LltNrf4tWztqVwT4s52tmeZVamfjNUPlAKtr5RIhtbvmJWHo53LVSznQ097y3JYps2afVSeYCj9gEKCjXxfMxhR+bxqiOvRH+/C1YFzpyNC/gCFNaP58ym2PDtcAFnxK3wmmWyP1oHWHtvzI/nRuHVpB7OvkB7pbA5gP7yz6fvckp9SflH5Fik8Lmjxv+Y0yXQ4Qv6ii5OZuStifZH3JflK9+ewmQQuLC4tolXJpqfLV363Q7PuNCJk+XOWBjXWcXoVnVxIRyqZB++9RAP0ggFitdaX4A/PuzKrVWU+D1UMbJuHr0yXfllwN7XiTVxbItXRwRoI2HP9/hVAfQXikwlWzrVkNybpFSElhMioKE6uSpUkYdI1/WI8mwAcKHr4J/xIxCIDwv05a03EDbEIqQGjKrgjKcQZ6gAD3/CIUOPce2Qw/v3dG+kpSHXndycPvNUJ2TNIejL6DEukpq0yIE4VvbUpJMg0wMoITJl8Mus6OhXEHimmg8QnZjRBIu22Ll/JClczfHYmQ9B9tPlEb2jLy1KrYXXwBwbsrZH1ghS85CqfJSLTnsghZcEuhNLJ98HwHccIOP+13Zwz/l6fArCAtkcIvqMykgJjAdaom6rFk10RQPzn+wdWvH96PhAgKiLPTlNtvlmBegTjfQapo9AbeM1Fe9QAzT+9wTSCBPQhfQBO43oqFMCK8tgJaeGhSHCF96QLpn2DNSIv5aujFHwtBTXQp9Wt1SZ/J1MExCTCbcXtkiCTzzg4bKLdk+TpsCBg3nQ2Bu2MmgjjimPfbRVzpsPFZ7P3wfAdpJq2KL0e218/X0gQ9Ynsnv15GXs7hZfiywZCGVYqc6nZhRJunf0ZKyIk4AUV5MJ79ifsCqWLhEF+P0ja7T+7vnE9T7hr9lJYGHWAobIMBNCQirI4QYJ3G9FQpgRXlsBLV0e7Yo704RwASu/LnsFiekyitrIzYbfFwP3MoNXwHedepA3JsieuosNLDDT8dhBcO35dizKOwMXfwI8cbYd/Prh8SMp7yFjBKAMysGlshWYcqdo13JTNiQGABE00ZNZYOGRQd9UKUbVC/0e5kOagKma2pNc/yAfLcUKUr0us+AIHOtCGobexorq1eOvIfXQO+1xJdRlZruZ7UWgzrwL56ejmM9RfdAamE7F6qkvJ7BkTMeQkAkbQBVjPhuFq0GJXt/zEP0G/UxFu/tRUHKjj/Rky1zqByXHV/9RhatIW2ysdiprg53HpEADyeLp92JxUmGmywlo9k+19CW/w/0JsEt22ljCimuosgkaVL8WJauYa9jvtG5PuP3zNXdHglHNdanFbJBBl1CZqL3BLa5LCMTErEz4w6ASF160ucigoiFRhO1wuMpjl2LxnY8wBgOfGI4BSghjEsSvQuQuWAuFEZmkRgMTIQhwEQiuYrENve2nERqBj3TugqtvD09CHazSpf8DRSWB8OvmlFdgIsbY6dll7cps9L2JBQGw+/6zImDjE3r/YATzlcB+jXfIyEd23wmZhBAWunNHGEBqAEmXuhf6IlWCUQT0yjZQiJEZqxHqHCSmWq/s9yrIR5XFFYLy+2uoht8ROuHxUuFZmHjVT1MOhj0vK88Ftoe0v1c5tyWKizuGLbcjVtrPFwYHPe2VETrxFB/D9Jlw62Igv/EI5gvLDzmkVQcHWnor7gdHJS21qhl0zjFQG5hLTHgL4FeUQNBOZ2tGlColNkOd3w4bsFro4+2SOiEpHVPpoPCWfZ/dhLjDZb+ZKWFtJ2OeXsLOCSbh/ZDDZyK3C2kWOhhA4P/dO43t2B9OtWyiVa8vuTa8VlWNzJ1sGa/tFnUi2/tb2S29Md1IinttV1VUk3eN0GWwZSorRTfodPfFv/JUL9VkptenRu0wLmpC5OhLj8sT6EUlxqoAPbblu2bruwu8LUexZAASCBOTIZSt80yLxq1Ktz8EmsLQfE6EbkfG1svEFnlp9KByCnQiT4fGTilzgxrPg+pGXDAFYiN6g/2l4T5NInkfFYm8IgzbEODLGhMAeJ1hI3T7U4DBlMxtj0i4lX6TNnUR+OlQH0X5nZSVJiuxT6EcbYMCViErAzx9jdAZIBySJsFnaCs3iukm34fquK3l3yXEZ4VlIsgNqDw18QTAL2DlxFQpVB96wUZM6fm3Xn4nfyx2OfXM4FcFYK9Ex5fUL9GjWcHdULb+GLXZi3SqQr6hQKs0rx3w6I3QSVyZX3OWvIuqmK77Q9vx1Pvr1UB+xk/2Vfi1quLYQ997OOArGjx8v3jz7qa636GvZEap5rnpcUUNdkW6bSxK/+ZGTnV4+/VzJYNVG3tiP6eGoKGmVYofGWt8v6/cK7bW+qYGrycs4I5pMg17uKW6RfXWiveQQjoUuFBRKThK9/7wtOTJaorrUxleVpJyCaRrZOk0gC4I4Ca4opLavGm/jiSsh91PNPTW3SQf2aUU59dIekToxUqJuOA2kUHO3ZHXv0VaXNLKEUUoinRhFT50X540yXLDragoM4XQmR/A9im86COl4uP1RdDc0hZ7ZB2An8q2p9PR5KNHRZRAze3b3Rm60gHQLG7lUYmJUDW5txOzRMQ4k8Xw7RpMSdsds5Bhk/QugSQnpOsSA4oiFzlF+yb/DFIxI2ybQDZcW6aeZpEYEKVZU3A2daJLJ7OLen0cw9jhd8NLyEQoNkEtFau3ulfeJJ9gNmiGxu0n80UdBojahuUfeCVQT9IXENduz5niwiSLrRIiGyR+H/NYNcaEKfZ+UWoARjUx44ALVdyN6TvBQohurt0fG7eU8jFOI/PubL9eXpfrPQSR2Y4FkghX5N7yOoQXuRv/A0Ufm1/VOX3HVYFwa9ySXCzOvt5wbkBOqDINlzW+leWTq9c6zLSg1YAMdSDc+ycPP1KRQm8E7Cx2/3AchH4uDJuycnjxmYKXQNGY+SkUevoOIgup9sG3NpLvKUdOp3xfTE6xR4UkuzkztpiBLPt+4oUKCncziFKBHiaK5qifpA0wBC6t6khBFSlgWQyV+1xMv3sAR7Hxg7AbF2pwEDN7PQMpqXvlNTlvrVv3YrRq+fK9D3OhYIGDWtY9uxToXmbf+JFLTxan1H3P0JTQESV9wOndL8cFUg4/sab3QGifi42MrBgOg/qoHFI/8+Be1ehPNOx4A4umbKBWr0Y5HvNivhcx78b6ys3gfb9+1O2pa1E1Ipq+27b/Y26MYaglysKNW1Rclzsiv/rx3ynl/5roT7VaYrs7K1/2lqvo7jYN6HglbbaDjhm7/YzJwx5Urom4TQ4XjOUGu1TUvv/kTKHrUK5FGqc0DeGPtlyU0Cbrh5GooFz7QUwvTdpDy2KACPnFntCYVWExome6RaUfJoJK+TEQOrjmlcrF+7AxNvuKOIln1TO3GDGsTi0vAknx9NDpXlg+e9p3wTdMLWkb+YHLp1mzG8jXqOGzE8woPjP9fKTMFcfuO/AUsku9PsntQSSvQ/ZRh+zQ+l9siziIOuXLdrgXo1BIt7WiWHX+mPGSklOUJLfDXNtjVWJd2T+4n98tXMST2pmfmpm6mqLpkrkcq4yTFopTbuaUQ2YPK/2CVn+9V6BV32WiSbOKQ0tTS695rvdF6amROuYas0rXvTRwAl8wPRZxKt2Ux8onYtO8yNGDudQG22Olcp2bJ4NMu4AljSEx0N9erD4OxpOhX7DkcZCXgtZPzcLrY8JNLQu7uFmJWy94zI4R/H05vdxCQOBdwlS8bdCloEFBFOp0gxJgN1ynWXNpD/giQ8+nwppr61mTeI6M1Dkt07+LsIWVXfxSLQT9GPgS3QXqgwaVcMgQslPvxeuws70fOXb+PkvgqB9y+B1D36Q8w1wvGfVYIacYbnBo6L00CwOuogV61eMnVXZQSBZodGP+exNhguDLt+g4dowITV2qnCeohQC5fIHRwXlFGPfpDIynYVhE+AyA4ul6q2HUGXyIm2CAhiNR6SY0jJlyuxvdywCei6+lmVWUl1KMfU1ebo/9uqxgIbxE2v+Eg97vhkrhxFoNgrLC4JKAs0OjH5MO1YYGBhaJbJ/2uuopN7Qyc01ieWvxYgi1ivpY3HWyP3jL7tceQAhdyWLKFAZSqo3+BdEoYGCfQnWpJbtahdq0akNhs5vRy8FC6RxnFzF/q0SXYP2+BYeGQUqmqRFasQ9BuINGBIYjpl2JvvOLxTYmNwC0x4O8+9E5XsxhkWLCXht+r/fe6AU6eyqHcPocKBpgpqsuCVJE/y+/x3uYlgp4GlsnDYQYJBP+EjsVMoR5kgdsyRDl0m2IHWab7wfXiL6Ws0eForMXg/wSEY37jjee5HIFLe3BZU0T5nw1ZAgsn1OAu7A7uFyF6+sXQFrxXcXZOd4CBv14TQ4vbumkNUxnJhUUF5igf5LP6H5AwL7ECeOfEAuBtLer0VuRCJ9ZHShI2MaCKBfyrMaO+8l8CEBQbdjkxK7ehyiDu20qy6g9YZIxOgVXVKysoR+7o2mQD50Y4Z+DP/pv9P7AKYSNef6rb4ydnAxYpD3lkaUWsYWUExOowm9cWSvG8HwFt2xUMoftBENN1XNSiFnN8PrMmaYyPdIxBP8nysMu4sDM1KSjts85owk4S5+TsT+EREv4VuyJ6ohsWPiwtGXTk9dI1TEHAXQbkF2kWLzIpS1aTOWn1fUBPqIMMWJGvNu7ElBp++I+96hz/3BkjHsQj+2plV4a75tJTL2kNKCJmVfduo050umGuhLWGjRyyr5f+rTbyeMwmfRXMratjkD+tUlDVLjI52WgrirOivPYW5s6V52+AqwVBKajyHNnhToA3Hol8Z10b/HaUYNKcWb3X9FUr2F3yDXqS3eXmzMAk+mL+60zuPFAlDK4VyYDPKZnGOf4z4AKWzVqusBRYCheHCXcIpGKut9jOJK33UJ1qnO3LGyGQtatzQhQOiJ6Q98PLIRfWzq5u78Fc2yOSrZw0Ol3PhOQsCc/MCukW1LfhJafYW0SHiDpAWnf3HdtwC9KJ1RjiHtOBmc1imXB0TM2sOY4i5Si7Fp4LVK37CF3dKBw1v1/6r14/+Wgm5NKnUb57AwVoqqoJRS4aLZtQFJE009abnJTMqUDWV0S4oCXLFryyoyb7DGfFrimZ3+U/4KIEl+I+xgCJRBIrKnwncJ1aKGwei+B9BW8VFURehUN93PhoQ2iloZ8rh0UKR218ru3cawJSezHT16m5I9JBvxNETPk6Hg0HJELySv1F/xXfumV6PyMIf/dDWeq46PK4kLiQuJC1yVw1XEhcSFxIXEhcCAyGdXl3q/qWo2VcX5m0XtldLBGJWTFXrgqNXaYQU+G9sOitO+BKY7IU5Uz1WAnGcfV1SEOX3MlSpDUori90gfQNTaVmeRjAYvrMUY9B/xCrpCozgJrkfHTWXYVXXTQqYKZvIkQh2i6CMy+VRXWeEGta46W79XGo1kHiHA2MlO4jqtUedQ/k+C8PiffzHgno2XHhRO1jjF8sb8DTlNMuiQv5UDAzBfBqHqIBRyx/5+plQ04Xedq0c4+bgp2qDBNSie7ME6cNfeUGPASN2a1fQNja9dMzN5DwaQ+xziNrk1rRrLIm1LkLDMjkzGhWZgz7o2POUxxdnbXGvBnBD80gJ8ChepyLstXArqwMjnJBwSrguSWp2FKsY3jy9pwB+lBLZQBk9xjDPHOs1bskDCAGNE7DMXbsXIK7bWIUC+A1g19UrhRcv4QXU7q1kOXlVS0TJbH048q3O8a1a2S2tCLkuRR1UGB71/8RKPDLF++PIRvjwKHcM+GkPu1Kh/iALwuok6KW892pVfPBzG9z7n4z7Rl5byQuQejQcGH0PnfukoPJ7GsGYVVGF4Tx0dJUzhK1jEWshnTFCcmEEm89VpySH+dRwN5R0okJhqWtMcw3UfcecgPvXBjSEtTqzXcniN2MPgu0lzd8+FWI5jul9kZQpzqoPMaxRWWQfzJX6yN93mSpbcVaYUFJSxMOwuCEX/QUYchEavvxCeRIWyh1mkqnSfNfQ52hQEus3M/iDldg1YqBJ2piDhqk4G8dJf1Z2M943oIrXpUDg7apjGFAo8qxDQy2y/41qgMHjyar/8WKAOt0mc8K++FyBY8pCwW7eFslXMlUX7aoDE0RqbZ6nISn0zm6gFtt7cXrv2p01c/V7J+qsUMinm3q5gkb9o4R4nNpwZ9lISeBIiP/J4uwjXTDgfT+JRyj9GpAcCJcTaPijHd9P/cFSp70Y7mSXCuhwSYjfuAyZIDADXepZDShnHy2bgA/gJdhxUbQd/LrD7IxDK4Kh+LzT1vhUZ6UShQEnilBLEDAhxGJ1zjI35TPZidPmMUbnFqywImyQRnFBO8HLGmK6vNXhMS0BOHdaWMjagJC/4rPafT7EHXRJPwadMyiotuiwSMuJVHdyMg0rpMS8Ub9O1SVldbLKy7xCOYZmfoCkb+5YAxx8XNAhn4OWi8jB2Ysu3i0Q3kepuiTjj9JmflaGTRNDktLtpR/vNJxmkvChjz/fuqMP22zMgrNNGyQkQy3+3wzfittNPMskcI0hXEFdkvsJWrNg/fdratY7aiPfI235RjFLECRweegniN+GGTaGXkf4Cs+QMUJ2apidI7f5qFop8TE0md/SQbGZUzWSWfnu5hJnptGfwUUE5IzXuwa9U2Jx0XX7JOU37054KTbI4kisB0Le1kDQG81rvabSoFhNTZC8TsQx78HKnnLtaI+2TZYgKvsWgzrpWPrnjUtYRorkl6i4WlqfHXU2v+rhljb60vWvEEIQQeZvo7Qky4bEKaFcrVg6SVv01+lfEhCNHVJTFdmhZ17lIWNACO/BCvxoUjSCOQg12IwYEWQsQNEI5Iy+V4cK3ApOj5ZdlAM2tFSap2r+LOolW+ExwY58oxtDDgY7oxt40o2IKq0cpGZHgXTGPy0bBpoVEpRCR8Ft9hIHKy5JSru7FoHl9QTShyVtaAJX5S20dAi4++D4Er6Bqlptqq5eB8S16COmweznV/WgagbUed8ddwapPt1s2YB96hE5z+ryz+MKxnMDF9xAXx0mTrhzzRRac5c6CMjGrCkYC5YsZKasEDYSZIEbabsNSw4zs1zHMQ6nZB8G+j/6g7dzrrYZf57hF0dWDchX/3n6KHEh2a+LSfjDmJL2L9YkO1TMlRDxrt6TWE4ajVm/t6D2bKBQFtsOqQMyz3Gp2E4ti6WldU+AwzV3PHOcfRJaMNOqwdS+qhZhX0/Aad6faAiPDM9Mp31ZLkgc/ZT0DlZ63mVFlb4VxzjPxTzRAbhhUpmkXQvc9lxp5d8IyEN8wiXaeVKGFZvkHdXRmEbfZ4qQcETjl/o7s4XitrZ0lxYUn+eywv04geRIHJR+SRhMPun9b6wIVdYgsP0InBMcYQH1bkWcZTYcYIiojYz8xn5qsgIJg+A5f87Dtr916XmWAIElCdG+xb7tkSm+yAK/di90uYOQcs+i0CrFrnAVMUGlQ6EJKdg9WuUDOl0C/OZlXwNV8SeW4cIHfC+WU7IgcqYfz9TYqTa6C08bWPMxKLU6wyOJB8rpe4xs+Jgw6KfgT5V1jbl6CeZe8/AM6PqTVkC+dG9RwkCkd3qMUs1/2eKkG/fB3h5ztrcriFkbnEBHwJxIjcpFN1yATFoBS2j71QTLqEKUAdP4XpWPN2i1a9Go05tWDdHCavlrX8qNh5nh/LLluOnoEBJobzgELjsQYE3W6ZLFYbcTO1CP4f/0NmR09jYbhNliKEwP5IWsFhPOIx0wY7/oHR/WPbYC/jlucLk4Ab9zqmrG89LpUVjfOomClsrfM2B5vhIPfkbhGYBZS+fEQdJe0WDLIoUD3PZSQntfSa6YygW2lUJ5c0dImob7aGf/kKBp0s+S2V+tEaF4AWcaukwpBCo3udqxizrl2RWKxWKxWKxWKxWKxWKxWKkcuBtXrXkAqL+LesZ9hvf8umuIKa3gNzBPLw35q/OmLvVKeiCqEALFglVqa3oxEUCYaRLrjweVRH0/NOiDFa9X2H4SsFIpfdoEd7MQ1hibCDEkcBXvkBW7c/Yc2qYgOQBz1i9AigcSUutxlx/OQ3xoxDGsesD+q9J2MuprExP5R2ApjGpr1SXCGxh594FIOav4I1bJwTQMQknAvX7IPw9fB0ELvSmUN4xPjICAwCwnD3mX+mWVt1tHnWcXjxIJKEvGAGNa6La/T9IbylGjF69sgJmVeP87nUaXrzyAt2vdWFFMI9BY8EX/GWMH/zmaDKMjBMJ+agyInoRw82kc4bhy8m+O/VUmeds+JQZQmkqtbBWksq0IIw+xOnYZ95fk2+c058VJbY4QWXv4fGnSze0zDLZzihRVjtXpme690k7JsoxcENLTcc+lkXeLtXv4612mJ2d/Rf5CLEn73dWdqopbrkj3uQ7b7QVPzq7eKSCVOjGSJhoG/dOqij40jVMDeFqKe4jG5nhHRD8tC4qd3f2dMAu+LaNA9djcofsYyAy7WSEKy1nHbYcTL9Ec6YyU8miY0Od4eI5JHpnVrkYNZ0ksaLlizBvuEz+WiVa//oAi+tz60rKQNczlP+wqXGIleZ4YdTsR3SKfIcA8vnflX0T689da+AgDHn3mp+sztWTak5WqVaxxgnoF1+LGFzW+f8WzylR5oifIm5NbKC0LaQWt1qtNobO/j4gsfHCZioInLpYcXqlD9vtuxSOInqfF8IXWRBpFFvyozkMimAEl1R7VpETYSI0cjJ3f9No7DWlVpFw8btUfARDc5tRABaXLT5RKJjA3f+8JcmH+SpdkDqBlZxlR353mfxIjKMQj5/IqbwI1G42PPNTOgvaspVFM++ESWTTCreE7hPq+3VAvKw37QqSwAm4LBJvukgYoQPZKB/DFhq6d35nWfO1vfHpX4mPJDVuS0PLH+XngfrU97PSAuUBrFzyGlu6upnBL9U2rjvCVkwjDtcFIBQ2og1o1Y6H3KctT3an0KSSTANvGF74yB//TyEZ9iYCv6FVL8e2BWhb6aap5nA2RquEVfdDpOnd2TYaGTBXVayJxrNajCwr6TKFt2NjP5H3rzsM+8vybZ20FUSM3Lgy+V/4Olo1R6gCqrOUjW+JpQCyu7RQBQ6oWMkvbC0Og+nJIXtXXOZBdGdue7FY5kzlP+zy6SJNomQ4lu1BBIMTI93+Z7GKbLgO+gnBoK+AuztDH05WO1+llHidYSNMjI61R0OOWdtcEC/iwxxfjgez20TpEvh8jYcMioIR3FoAVzC9Yyr2WTJtIYLj6V5vUn+FxOD6IQUZW8xNQCjdod9hjzbmCsw5kCR9jJrW6e6V0fHwu49YJpMwppo5hk0QaGM3RmvBrz7EeLRtFt5EILs23454wG8O8kJDCZfYcFgea0nuKuwDd3DBwHGCKxMsH4pe3EYmgXJkda2djrDVU7DEs3gqWyijGf/Q3FhGFRsOiiaz5G1Fes80eEZkzqePpHUzgjP7bJ3zJUKN3gX91XX2j3ey/9d/vWNbtK3NGQrh+gC3SnKFTFKtZwNd7DelVdYNbEd2zaz5RrENLYCu0NldZNFPYhXERUDC//0J+SSb8kx4pgY85FMgg6PPV+Im+vpZTOFvB3HWAeqZhVBiEwL5VVNGfsI9M0etCiS4p+kkZi4w8iY6M1ezOr6VUSARwEYN9ilMyFklsJQEm8eOqwAmcRrADcCLyCtXKf64EHSuZCZGcC/1Gvon7BrMZBMFWQ4wRtk8HN6Tnj/mn6HmKpI2QQrMqVnXe6u5yErnRX3A7JvecpopzID7IZ6wFX48hw/5XULSpb320xGoKsr9s4Z10+5WbtsigvCvebRY+nU8aanwslLRuHxlDhrd9r/FhSEwmfaD9lrVSzyMycuKCBxAedNZ6ufYOUyPMdP51hqND1lcTSeIBaxJB44x9OgANqwk8jpK1wqjgEN39mh61hXYpym80ZYaXhdsH3fvcdVEl1n+dKBm/d4FPMPKuhuZ4zTbmJZjlrt6rh6U57m5clEro4IvM+2OEoLtfOox1LypPeMQdg+5aquTBCf9DE4GFfr7OXT2JudmOLTv5XzgK3YgzOZEx3BkNWRfdeD5df8UH6MFyqOqNCCfFpQ9ljYMgpLMlzerRNlVwIdetmtyYjVjdt1Moi2F7U193WrVE989Q7pfARFAy99QQVh9KG2WVBm+NHiFvYd1KXAcsRao4XevqR9e14DPH2N0BljkauZq4emeX+MVXfWAxCq9vborI8dAuKzaKWDFBgBjxpLqe1rxcw1X4pfjvRc9TEK8USqqHljp6ASH8IBJ2giOEIGdAKXv67o+DgvaQqSrCvLJ/YxJ2/LgYi6MXIILY8oMUunxRIu9Mce1BHIuWBBxs4Zbiq/Mk2Nzoay/CXrB35q9l8Fz5J7XGED+O/7nZK+g4jv2TzNFwvrHEDPhHqCwGMiwKdfm3b5rvddDw0cjr9wBSgu5A1gFXl1yBm4utaZYtTHw15Gbd/wEYxoWDsFL5p89SQRDvP77dItavoa6H4xr3RgHU2hGDaXhePpDagaA1wNh/NF2T6z93s8W6L56h0U1RWqfw8clc09peF0PtR2Etyvlaboov2nW/8cMXM1jWqEaq8jj9wYvwypp/3BALHGWt7AnU7bfkjEhmB+0EZEyUTYg6yu7fpRch6z+njVdza/hzfNdWVWxCQ+OWUW0O/N5fv4slCNAGu8Fb8Myo2UPBfL/UaT9wIxH2z+01c8PB39kamEDhl+cQMU4eXALlCTc2YCYBrraBkBpBo3/+cti4xIT/HDQA6ggX+rX/UYVl1LFOcUMXYZbAbK2/8sGuHAjq/gXE02Upygl2WOGw6F1MwzyjL6Sr3G7TocjzIShKmF77RCm+PzN9xWiiH7c+d7UnbsesICmRz3daBtzISxRViR40yXTmEqrctVNeGqag0UsOwwWMf9FLuQWiJ7kfqf8p/5VxpdDQZ3QJLSi7N7j2KvZZQC4vi6Thdae/C24l7OjphpHQnBker74iIluIRLpYx2mggiayphrcZEyUXuH8KgBjUfPd+L13thcb3HIg4q3H45vEW8O+fCPtml1WS4Ey1xZocBtdWbTIqAygi8y4pZZslLDgIYtAZegSvU/8sgkiDuwZuunyQZMH0gH2dbqGZi5nzytqaBiDcvmV7ut/2taUR4SjEdheJEc3V35R88/yEAX5S/BocTDZQLMnqnSoP93IDBR0oF14cnWVY0du+WKCs8MeTti/P/o52PvNbLMpMLxslGmOWrO4u1eZ5kYjpv1ocQUkUR76FMhZNOc3Qs4yiK9DjmYV2+oHDZOY+1sGZrFKwPQFgPVJvrq4DpXXJAutsuf8Fi8pJbnKbt4axwwK3oKIU27Knc0IDO/bDYyZT2OkbxGAL4bo7Xx7PtB8hchVyRThuon+BjmtzV4vcLZxfNnAji4WoQ50I7t/0VS/u/2GH4RrDTRs30/jBQQA8Jsui8QEt0Ujiqr4SGWlZ3UaIMRTSiqp5YToofSqiKgZDgoRIimiOpT+EqNb5kBv3lVAMR2G1zufNCvZzFpQJfR84n/uWs4w6uUTlNTgCDn0l/eLJfi7GvMHuR6/NH8F0CAm7QSE06TMNQJb67NUv8F/KzXh9M5qMcSLn7YRR11fZsQxdVlQqJtNjIGl4iMMKTgNmRbo41YgQY/B2ynkwozHBA7GNTiHPnIJDaiyY3hawbBKfnTmiOS0Oiv0gJhCRZfCSwHgRydmDG/ikSUgClDq94CfIQNsmbLHSEEb6e9fqlROQ1+9LVtEr41AIYH1whGnTXyK7OMGbseC9IvCrnx8MWOEvRFiS/olGGwtZJzBxu9bJ7u8OeOaSRPDo7j5V0s9ZHrG7JMwZC0HYFMZx7pgcLLNAXwcCSIfh1mrvRyYOZa/fCJF5AUXvK6+6JnLo2Po/w5ugaF3CO2Jy7qAAMDBlKZ7Ri6s36LANVMsXRK7OCkKTAngklhMz1p1yTEH0CBTdDcOOry10HbhmAsnQbFpwS4qAg/JwSJqigRMGi2fLvR+jCVolPxMw3GKe2k1G4etqucbEzrJC6sbrPwEnLFD8uzysSWhP1jcdkdhHgXo3rWLK/i0Mj0k3ce0xdBOx7ZgHjFnwUtPMCpDTRb0a6Tlx/RIafBhGxU0LBeHGMHQn1mSN6tJzvDrgg6Os2Wz8lFSDFv0Wl4bRlCTJQAgmmPiGwDyPHnCFUdHXURwAOVMrNaVVlnzfLlJ49gBR2LQcVxh2YQCs33GpeNmQyWt/aEJXQe7Eql1fSH9WvWZ/eySCG+0CTvujcF94+FEU722fP3yMJ48dtBeLibKRqXDgA4xpFudorCWtLcjk0Kx8mHyjYhERdjXqzhC5TuW6qNxi68f0bg3eEUPPX3Ei/K2t0UggshSRwxRw/ZpzZnS3DJ0g2mbIyPOWzKtCGfDWT/UlXBeMUesioh/Z35CAvR7F/r1G2pRwpJidaBvXQsiwlylHknzbFujST/WfAUuvPM/swM42PCjrz0N3t+x7zRQKZn6MKiV9jLBDWlFokvFBDEYDyxwYsU13tklAb0GVdDm1iXyl53F430gPXCjsZC27WhzZBhuYZ9HeCKNDrA9nO9WlCFuB5ZZyPVKlpd5geqFhfTP5jJl9g4toFgdjkhsPLafmATSkU4ADQt2+JhW7S5wKiSXrcbtjHyDAXgcmzlRJyu0iPJYW1yPh1+HxgJsgk6SE6c8o49OZMv0OzxfWMAvJOFe2v7Oizz3WgJweqQhtro0NCrSJ3yS72sqeJATO9bLjX77AMByhFN37HZVFJ+q7K1ApVV+ONbO55yfwmErcO9+mxzcpJxJYMgW6UVEWftAIUmyDhxw67FbHi/p6yhXDBGxyVFbIcV0JyQpZwf8cdRUeR2VmMNuj2kVXO7GIdYI6z1bva+jcVEHXWbWFHqIsvih4jUAaJZUvPO0aWLmed16HpO2ilPli2Ggq4dzwnKgYxT4OZd6GA9E+3ewIcEc1Jz8UIrEK9+C/LsHXRwbHqKc1m9mWwKtH0Tgqaaow6cJb5FBH8Mm+WiyHffzAFqhMRZ7bd/dh9yIkGznzpBt0WAAI8S9o8Rq0aPl/9/F8vmcrHCVQFCZvJEEbOikN0DFlXN1gUCh0PxksudWGRKq0OkNqTnxfdCAoQ0bCRphy6C63WfzDjTZ/8kYDS6/0fcVjZmD3oMPnY9mB1srWDxwqRpN4B5FCmed+5kkVNsMPMdIv8rA4H0oQnv32zjN+tTw8PEyRBHg3VhwZ8i023BlpD9p2Dkg8OJlvlNr3g5S9Vt+yKRxvPOXeaflKz5Rl61BnnaUCmkBAwsidNhSA43R7DXittL9pc6i8uFMuqLJOwe9+zY4m0JUhj5vn5Bz7TvkkPz9A7yNQM3AAjr0wYuTuXu/GvyqLo4BO5tP70bIyQ1e5YdwZGnuxlRntYwbIeNh1gYYeWsLBXhALL5ljTguwvcGKfB4W/dhnPmMYP5N2/DEdRyAGs1JTK2WSdWkPFBvLhfjJILKk9GfOrI7BUtFRhM/RBID7OhU6O29ZG/BH7DBmzTtazLgUJ32WVHIlZJX0UVDdDoxugWk6N1n/49IT7Bllos+fWSlXSe23/h4tPzEkadiOXAF5EhxVivXLzOhEOZuOPNjTFvv2tLcC8Wtv1iTxwe9T6XoIUd+cAFp/fO1atHTQ2cKSa5Qa/wqWFtSi034REeDkCWJmVARvRG94DtKugR9aXPh29pR5USVlPt48qKjfxXTbjT9CQ3YXsWBM3P/Yn5sQfYecYwc8iV2CvV5tvOyRyJt+1AQDiDdyy8HtTP+I/pz78oB8xSNQ+oTJeRzZsftmBM4fvsdGaIFxAlRa+a7VFM6Mq9l1wgwiUIinBNjFContBRu9qYKEBvrSGzkUBw2c408dJ5FLyBhGe7Arja2fEq2CFZSAs/F1Ds3FG/lO0IUhVW+zO4XIlAaqSJHoyd+QYuuPKvWNzIXtSQ5KFFnf2k/8sO3aqKJae6BbJIopKC1fMxYOHIuOq6X3r2joym6RYLBVk4MlDfahMzxn8Or3oULEeCzCA4GPHtsT5MfRyX27NNFQYdyrDTOBkEkVhDbAJxvv/PkRlGKByifUji4TioeQUwYlcA/as+KN9J800cGoxrfmbFhknoc2/cEADeRzDO5W+WR4cgK/Vly3BzfKwOqG4r8Gvu4zy1lLjMvJv8cKqiQoAZ72ohXe5bFxLDetSp15ovJLspijs9GfYpx7Ftzp9mwJqDAiUofnUMx761IiMK2LVqFx50ONX+ALuEfusE9HEqziQnPgYI/Su6uxRKF7cRTDv8jMExkexmrCfscDrEqfqAu0NwTUt2VINBVBYdk0DKMOD3iFGgIcdqPWWp09iM5goFOKQyl3CH3dBvqvGCiBRhQoPiVI3TA58PLupaJeqJFZRZKTfuhH6Cno+Q8f+ac1bnmCDJYBaKORtZsF6g6KMNk6jJai/lb8ISYFSV4fV1XQHwqN3sQe5RqCuT68k6iHt+/Fxs3BjfQXgy9COL/mATYz9ZMDv7QMSWeT/V/JbzwW+AVTUtPnbGo+J3xtIyLZRyNkkE8DQThXjGum0zwXEMCKYBVynrW4cBGMazokdupzp/TPWgb7HeI6CbnExumR6XdXbjU22rXMo89rr5m4CiiqtCxds518c0ajEwhYVy0rQkzrU8xK9Wd7BAhS4Gv+ro4hAg1eeInrQ3uGjGv8KkZQAYDJp1Pbxrf2MLjHjIJLNHG9pwJaUvM26nzIl1Zre7w70HUvuVXU7KzVpRhO9GP36cNJGDlXCP86cKlUbhzGKk2dvUW6OIzpbiPDaWvsak+KE1FOCLsKu4GDVv8zBUtsAeLfeePGQzAeN00tlxakWCPIeELVkV9sOaAtEzxQrpbk9n8CcWuXCS09cL1s1OcWfcguCyatIBaO/8NQ0O43YdN6tDRSOgDP/VJfIHJs7pMQV8OQ7Qxc0Zt6K+IOAtErM6PoctiECbD6NdWfIfYRCk1iAy7iRU4bopZMoUrMwb3zYiu9ngPfCyZiZV3ZLOh3XQEa08iDmUxjLpvJ8cYTfaiFAUvRXKzPaU/N7J0Xqt6yPI5HziLsUV5vNwq3HjL4S3SLFUeK+1sP9vrDhNHzvvkvbtWYLyapVf2qlldygaFBoTPHGTR/AuvLAPG1sKb8CSPD3HJxwXvqZKiwkuIBXw21zdLnnf0vaJliNkCxYlCkPi60Al4eAInYk93EpwZHwyWdH7nVrRdiMBen9twX4SVU7j8ZbdynuxtlclEnYmAA+RWHdaSxjYu21kC1tssJe5mshtoX6eyY37HdmLjez2/PQgmI0Z6+7lYxs73LnpHQGuZ5OA/Zx/n0f7qx5ZeJdxTL0ydttAg1t6Bov+zb1vmhVBD1I1VSJVn0qdO9d9CTKJ3UycW+LsHpr3T3lkrocAriQkD0nWhvEDRlNCx2Yxfmz2e8nF/jMSEhyTapw/RjRR/yS3ufvl5blamRCjLzWnzMLmb//lRERLrSTLHJRDUORFJbOb97Ul05vZCVpBvzy6RSOFuIYX93HQCVutrQx+Br/jfWti49J2KnBLBseYzMLmc3jMbZRMPfQTGXnAnfcY+jVfD6uA7EIktg7unYIneElCDSQ8t2sg0NUQefpXqdGhDIDBEoeDKhh09mwnNShpKB4QtWRX3FY5mUqolhSVIEGwM0e3MeFt5PdSvYVO56np5Bj7BqA6GFl9KxKbr7c3IuZfUGr/FYtRUAYV6xiiC4IMsblegWcMmPXRIiowuLfIcExIyNIattDRNNWVnretUDX2V4QjxfSjg+gMYNWn0dDr9vPbZOiIQnBXyZSItT1Y+VH2OYrWxhRc6a3fhXmnG2RsVkSy/Hjn8QM9gH3CPDZda114wKx7WmEaNTMPO5zlChjjMqCTzcyu8TbNTPH6sbvXJWkTzP+HVYhEAH9o/6q/U/Cx/bmAx7i42Q5oOpPzpcbHLGnx81I2bPxI52iZyoV6X4oEmSKHNK+/eTlz9x1QuPpLeGm34Glt2tO//Lv+ZBblFolCyUYqEREepP0si4ni1TEvT+j8GGJOGYjg6TkxwtMYeIDFFqNQ8eKZ8Fkao4axE1qPRQQDTEtu8/OiwTGkdPKeIzo+b4Yc3+niCytjsQcYUB4wo6eMnDUWK7mwUL0etHyvvxGpwbHs4+pfOieTS008YeCWj9F25RWN7zfbB3Td60q1T1/G2pLnXnTkCI+6/MfE8le3QdHw69sSuEkqHPq1w0KaNr+6UCzuaGjXHM8W6IKkOcWY8QFFALEW9ZpRRYfleABb3jKr5BveBGT3UOXyb5AzkdiRLV3e+FBJibFI2lV5Gz8QHXN2txbouxIbcpCl6Upp1V3N2A43ekvwXkMCE/RLxBMuuDy4Gta00ajbg85wluGoU5Z/2J8okVlhd/7F9ErTUhANkDREPcdW0zuLhqEKfFRQqx0aqWwN6okJGkDjkdqzUgoHUcAoimaqUrv4ODAWL77TjWRS/MYLAC2kOzoI9BlvXHTE1gQqSkX8745N0DkCUpMrR9lXTlI+zLINXkVzrJpONwv3zgYBIYmwmHx/KcSvTAOdSaCKBoQSduJbbeF1q8Wvy0uZ1tNEM1XSYQTrvzzm1hvBcohSgGfkngPVSSDnJDkz6QVwwysM+MpD8hO6FTHKTOzpLFq1V97IG+t/j0/DkTF7ODMRjNdFP0XOo9h1oPLNkpwb2mjjfBduzTDU2C+PY8sp81vCPm3vp8hjW/8/TwkRH/PWcK8Z9z4iQ+aJMasb+zveTB5i10wc5gkcc+8f1jPnyTio2KX6AKXCOZHgl8dghgutkfVG6ed/N9LCUnfxC8m1PVMeF9nSjVJesvjKZ4gvUpWYNjwl3qPI0FITawuyPpKj1I/3qtZb881KK7UIOkGhk0EYTv9tZNYlH7U3S/BGJyUl4dZJ8BHx+bCAuebn+NUh+GIn8XVKpHafsDhPA4yUZg8Js3NYzTfMoFYHgwxtEnbWeiXn1AqXC6fGWW90GJ77Fg81NiJVykPe7lzPTw4IM/Q6kuhEz9wwNEBu50soC2yrVBNVn9VjAHwmPVU/IwxfwHx9A1M92VzB2FRlajUNDEz+Shqp/2v1U+/1uq7cKDCANMEV3yhjPoFELtZPfYsHmpsGGI2xP0QqxSRWpj1igA+uqjz0N4dEKTVPt5EhjEIbfLpMs04qx5cZf6Cjj2qOANOz7gnxfuB3PeVHzIHRV5sryAwvzYGSBzjkExco1/RkdBhmBJh9/QWYGzEEhwwsUZoMDu1nOVTTsqu/l0/WlqU0AJ8cPjeVME/m4moeRgOgZuzwXcw45l+gV62voy2gYTJeqPA4JJaB1Yuy/IOXHlqK5IiS+feoIriR6i/XcRGc8x8+e8rH3XG/kE5zJ8tmpsY0xElCBo6SUG12pedSy3Loa2JoacEaA6kDllxhd/cnTXHDWrIgxvSFx9mFdd1aTEArlYGG8kfsMizTXyTnsUjSpJ5ofVbszcJzdeNSa2iAzgwgMTJYunivEuaNcoFWJMu2hPHTGzxvRWkHxxfUQ5DHgtjA10Qlz9nw8f1m29OcexUFjw53eN5Cmpc3SzULk0imb0mKxEhZfwnOKY3jIdoDVDtBgd2yBxfTrYzt6h8jJkwVQoBlnS+ZTBIgbIUE2AwpzVUUrh1z6wrC7lyyOtwfOMAgjVMgn1wZR51zXUO6nVFwMLsBnoBYAo1jyRCj6HWUZuLd/MoWQv5gxfjXSCIq0EEYTSFUW9RhFWZZV/H5HcQgN+ATtTwMEoSEa35Q2kXma68C48FwQeAMYe49vcpujGc0Ec0KWuP4XaSEfhya9OEaONlvMWiX2JRaHfPSy6O9ZC6s5iGxzvq5iKu/ylm2ZXwZFXOu67mnuiLkSdtBDNhXjZDhIypm0aCBArLmW4qQnQfwzh+oUxFiJXijVBvMiLUghP5EKhprnwowd7ZuNp1esHWeF4tvoVmn/Ohtgt7OflCGT9mtrY+oPiwoUNqTYcjDkwM5Ymcc4YURHxqyDL4yQgGUyZ4ja6Txy8sqoDlds2wQHzZ3DX652NphhFhzPymRC4V797NAZ7V5lxVwyS8mwbGRNXYQEBNLaup2suTyIxV1wvYDpmNy5XEc+awDdw01nR7Xced4YsYo1RQjV78TnunN0811Iy8TLdspKUNEANJ/9SwdCrd/0BnH3gEXLOtd438oFm2TPnR0CWgsD25M3CZxkZtHT2hBNHd/K6ocaqXaQIqQAqYSgqhZ9KrE9ZkzUAhunUNVDIAVlr2A7MKyY0y1agRu6O0yL7/o3SkF2PV9qWruKDAgLXtg0VwWkBXoaQ93Gd/c5zFXTt2BxcEW/fzMtxR8dNOe5Nn/srhlpu3zhgOXOU/i8ztgzHG4zhMCK2BIiv+182PLsUqvQ/RUUCCW30KzU5zwmi0J2O4rPup2krQW/uigHS0L5FPBoLG7Vc31AZyh7HYjrnr2dcyUg0IdRpjEHhnmpoHn4sIrArk9QRbsCC1DgguhrGlUHjDWI837J9zqTDucsnGPh2Qqr1CEIdx+oPIqn283KMNl+oQvbpDHp/TXInViKm/AEVid8WKLkZA+dbTUBL09kekspwE+/2qqXeFrZopff0DUBJhH6nqHHPuEGF3MdOTnFtnL7Or8iy9VXmjcquJk6rsGLpNja2DsinTqAs4gOBJ4DGnbThDhuYYwFaxeGZvKQbfsJj1k0svu384NoGPyF3LFyAUPYr19VKHkfW6l8p62ohfv77WQgIzrG/GRfyQZgeKt9nVMYszHd+GXaKKHjZDxoXnoQO1t9vDFlNJ3xpAwm3JfT4xZVi0mo+w7ruKngIFLKSEKhRhwTH2dicYk16UvbefkES6ILP0QM0nKDMCxsBgqEDQQxC94b8lJAuTBjY+jfPY593CdUgTzTjPz2MJcaxEl1Hn/uiBRb/QSSJAHYqzSbi9d3k6i/XaHdtJgeRHngD3sDOKrQem0twFTuoiGGgE7CI+oWbIbr9yfucFKH2WWTPqY4sWTd2RCex/GE20K+2KH2mCrVvxxIUsB3ljUdlHtQ4e11Q9qHsAuskdV4r7xuHpAi3M4O1CDzOUE3F7buF9KPYi85ZMyWjWGV2aSPNhVJ3Umw9y1sBLRs1tVMVSFZN3NhinqGfyUAzSaoF9cI/qPqZzsyZHhrYzfgzvO96BeWUbJ8bcji7y/3wPn1rxmwCy9lIEy//43K2xJmSrTB6Y8mFwXyiZaPcWxUj8zmcB2XKaTiXgwhumX54RRgAZoiYGyXke56yu/zpSnQQxkQnjTjUCXQP2yfNHqXYTgXNwgIPtiqDZUY/3vbYu+jr7+kHlS6k2SRjPDoV5K6rIbfou+Xkhl1GooY2259gKYqyPp5TpCghTdCwS+DCpWUxK+C6E0DY2NcqZEdlafClkuntAB+1Rz38FDi9nCXF8Gso9c9S8ugsmC+619w0lBMZVdOQZulg+2ZdtQLekQXroY/Ial6d50vEj1iXC04hTwweqxKQcrBARVRKJq4QQmrlZzdznnYcFu8QL/aMiWuLUaWiL6x0PJqDnPmeF9SYsaLl+b/Bs94qj+u+bf9fSdZAoHp/TB/6CePjBUhNvm99HsGHDiq3gLLfEKBVoR9W+TNku3LlowzC4hpwVGpvN4hn1QnUXatjshiV7V4SEs6qAC1PSaWZe+H3yHY4b5r9otaBFL8ci48nozGiFqaBazK4wj2nHYRLzo/1d0GbUT8MjbIhEptBGfRUyT9f4EuVYtj7RjG8NPJPrJcZNOoQB+Sv9LLVfKlc6PgwmvUbohtAj2bf3gfesc8u6R2EYke5gxApE3TjRK1Fv2bvHAZfe2zqsn/VwOgCbKSvf0ozErFUZAbUQDDTHVgWfZscPZOLivu3L4gv5+LNID9oNSjYBds/7tGAv9K3xAEQejrDs/u107acbeGmOqEwTV2tCPr4ctX/wVwM9nTX7/HzHQGPrGAmyowPA3zt1/CIgRJgcbXv9NwAAjWVvT9suvRcN9q3e/Owj0WkT0ZH6ETXKKFjzivSXke7YcVBeSdIujvitWEEmrDYqRsVUrF4MKw4pt5WSb2GQ93DlTnDYxH00sg1Iz3FqpSbQzRiACZ8ZR3wlxF6r0IBqbvaO0Y5irg9NpMBNBZnl/omgmQ1OxHAQpL0zTsdfQgAaYVIDs51oNXs6Gnvug+gMD+J+nb8zoQibL9Q6olph6ni6OoPpXvTO2i4Lsp5eNl6aLoDnS92YZ+NZeuHd28Pgo0Dds5hftLm97OzCmDxlzFUCqD7iye6XmxIdvUEUJwc1iAxVVuam+GTQ7gehKU4mgZMd2BjlwahibfQ5CP+t4etllP3L9v6Xts+wExegIPMCisCAXoCnxn5BXsGn+pai1HTY3B+9gUvq32Ip5qF4aGzWyAAjfNM2e9rwWsdOqEnrDMYXOBYEADL10acGiWbuM3zJseMy5O1L2IAmEM7fS+X65rlIqHTman2sysPdTwAS2GjHJX7g1j8H311eSXTkCStjyTOpz6HQ+4O96GQGxdj9QAJGcc/HglezgTCnEiFXH9E25cXUQ5khuZJ4aAbktxn70ND8rUrX0D9PpUvHZLZd1WvHpa38MOTI4hALLLIQV60UAJBp47HbJ7O2zPNCuBKDNkQ3V7IMIg8OLDegHAr9KOFuTlT3scRBCzI7B7CLD/vrgpDXQwAgqcLLoTqnfXzT36qgUKl/71oI8qIP6ElMef9atB9cueGhbN9o6d5BKOTS5zMLIAWgbJYo8ca2z/uhu4vo6ropVu2+EyzhYjnIQjg158ATEcZL7Gp/npxhk6LAgdftOuKEdcNETF/cRf2gySffHFJf9DZwRntld0OknCVs9qfBSLSbZpmADgIDKde3xC0NLuN5P9rbMpveDVbt0Hy/ebB3c2YBDeiO7WXSimJrQKPXwc5zd/JbfDRbs6Nl80QEDF6wsduBYA81SrVsaAluEXJIVaiQByu3wRQpEY57P57dt5lEQGgpcT9Q4kki/KEalI5M5x1n0FrguXLRllQz0MDEIfmQb4Rb8hG+ldFGhl3R0aHJlPFZCs6anFhxMh0WRCQULRcskdkf02RnfgvGA+EJC09VtYYKsg6QsZsulg5JiYMuqlhH+8Vyziq4zqZgiEcx3wiSxemzj6p5ZDKUiqXGy6u097CzKilNW4ClGHtdbVIvfx6Oaskf7S7JjjCAsnr4L83uHGFoxacLKSnDNMsi8DIBc1kig0ef3mxSv2WR/UuXOz4kI5oIfZ8+ScVGxjL4aPfB1UX6h4cP8BzQzYZmFh9q1Cvy1QuwgoOntdfqowH1jlA8TX6V5Ta09jjZhGwbTZ+WQ/3MGhsWKSdb5SQeWFeQf7vb0oSoOAFhUHHPFbTTH1uZeP0za6npPhdITrOSvfCJTAnZtpwspKfbUlJznmmjqXG9vE1DlWCje+v+hhFZS+TMFfjoKTjR3EuinW30Hqi0f00YEpNR6BKxLMxoY0zNjZDalNKqxsgajVokjaph+pqsJ5V2agehJJTBlo3Ug9cfXy8r7g4DhRD2ZEVX4clfRB8IhrkiS+FL3kVYqLSuttTSfRAdJ+3GXEJlk7xQW8KTOoRI2QPqgydBFaAwMD2rawiCRusQwJ/IYA8jmYaHPDyoTMT2TBxVM1nS//LE5pxbyO/KwZXd0DFVFkTsZKEyE2ucLjBYUhg/FoNr16wx2q40lB2SL+KgRIK86xMmHbtxOGK8+HL3mEDLomvzHzg51E5QJk0CKZU7WBaWGxMYOciG4ivgB4ImSM7j342qP6WNTq8Emm4ISvCSOEpC2wyfY9C3Q+nIZcA1SI5k6KJg7b+3MMdm/iFOsHysTQQKRRHX0TIO8yhvySD5HAAhiYyb5tBtlQQ94UJhLXOtRFe4vmv1B5cyG8iiOvomL54LbfOQQgLAvbC9enWjE/YGAVV6llwU8Q1NS7WcN5B149KCFXhhxvcO6tfdQoNARf1wNaoQbFkS0NDHYIm6ZQCJUpqqIKzdmMWgMI9Q459xYgq/3lySsuq4sBQoMccb2PvbqMwZFAyjwTi86chy+4pkSkgOocurqmYkud7IXcsNAPlEwiRqqNYJOljN/A/R7W93GzzIgd3t2tqDTHEdvPZtyV5kmFBifWB7gRgIpsquUqANGl8ILsaxr9xlbn74gCMQ93svlfk0kZvcMO9dS+EnjX93NqO1+kHGh5MJJt2MlyYyOT+5uJ4alvaoDvjJHcrMlOx1X6i+43Fb0gvByvCce5LFnrRm0Rhbblk64bnBRqNGpqJj5Kh0GVaLu2oKOY9O/ZD4xk1q8deaFctQ9TfomHwZjH20+E0UGn8Vc0igybPRNGb8ff33T/iAavvjpI8mgmLtjeoNXAHtnlRzleE49xFhsW09crzI0e6Pywq0F42P8I4818FZ9j6nIokwyRssdr1Vm626rdaUfN5W42Ukzxlh1XPryzmVEJMRIa/9XVPTLrKLpTsWXyuf4uMWq/Bup/AcKQfmBeCDNdct1PhXGLG1ldGX3pRyAIPSnDvpXOT+lv2S9DJbP6B1pmXxrcxfUJEtOEFV/RYFMp+LV7hhHVZBRie/Hdo/Bi6qsVTscjacSkvdEaK5UTR/XqlnNCcVjHpih5Y3R+8mnpWRm0Duj1wzd7dNraRSDowppTu4lz4LKJiBBXPw3DD6QSgjm9tkehfH+xtHAkNUf9LVohOxiwSEdzeS+4dA8QUVFPL9NHQOIuWFHKY4OgchOOh2A4F7EFmufKORNCXUfJbmEsTCydgbLiyNieKZGhW+fYl8wRDJUy3tUHu2MQ+r9MuQwm6ZW/PV+yY0GBPh/qxkf7BQfuJBVz19IFeIWPOynWXORtygQ9R+Px9bcLVUWf2M7Rf19485UoJZLX6EsMqfssKGm6SUxp2ozpwKPMXE2GR/Jsa08VZoVBCniS6iWvASbYFByyHt968zg1Tx4fHXgIDiY0JYJlN4KJzaXMDjIfaU1ixp2eJ+z1b0VzRDqniWenbmCrdw/QrZLcn2Rvwy1Ni43gLvYXFQJZQC1vHK+OFXQXqESYeV8+FgRwQl4HY7lnM/97VRpcsIFvUXp4TkwqMv4YbJyGWDXDJ5/M+5u0e7ciy1jf9ecg3IVoLyAn9BniHRyUZWkyKedF1GZ78OH/8mTmJruhRUHPSEISRdoZuJV/D1bLw1JrJ15dGECrFQDWhavZHiYzOH/EZv/HYBPYuN0X3OfKfzGytl0beMNBmcl20+2Ln/k6Hs7/XiYknaYV3qpPvxQLJoELKGguNBYt6vu84UT+PuRnGJ8WU+H5ZwkRfmrbea1zpYpFf+ko6LYT1AbSHhJJx3CXOiYfghGKQexPzIWEPfo+hoEBHAjaCYoveLBc9zz3bysqfT48usYaIPeBEvWWtYlOc3ymI8RtswtVgHILK9OE8INgn1xnk+tunelQ/rl6B4jn5EEcIWE1/fVugddcXCplCxuciOXQJUiG8B5NAqYSExA37Y81UDdAfbzr2pQep3QOTOTvHDUJeWWlUx/iDaiMZlCtyYDd8O2WW1+XGTbQDR6AkYwtVGT/D/CD+I6vl4w9cCVNFPgT6UJ5EcgCXYbzYGXMjFyOm+5NV+3rxSempVisl5w/RshtHTyKppZhvyaRJztUPmDdWCD5/RkrIiTgBRXkwnv16n9u30fefrrRBYsgvRpLlMukxNU4RdRf3c3+7eH+fFyIXef8S90arwrJ4hVxaSLYRjw1pZ06FrF49D8cjwjnYWn5HNZbMVV+Zq58c19vc40zD46n/6InBgCd+TvqXGjawzsRGiJxbfEOljOrc6iImFlNnTNMeQGw6sTKGCufmJqYkl9BnkafT3aL0yHoCmq9kHdo3WWhaWB48wkuiyw5J1RaB5eusqzHogVzHqDwQSgKSYOXMUFCyHTyzNoF3sfDaO+ka9OFCis7R1ZCNsKx4qLRs1s2RKHA7FialIOMx5TBABPcurbbNK45nbE0/EnClQHiegbpxyiEGsDRcOZDXG7qtTIbSBTdpkuSoKz5rYW/TGA6mbwyP880CPcfNCrCEdJSzMbZRkuARVSWFVIj1zvHvS+/G/YNiNw59xHVaZvNDY93SjOwl47Lc5ye5qVulNSwYgqtwrml+DjPYQnGOpVqgCkxFXsmWKHnKeatIWSGPQ7zl2rftrU2f4jq+Io/vGphqEUnJwa8uajPHted01xrgv/ZVrcOR7PFeu2Vsl1mlmpXd60D5HIDaB12Lgmf6RkF+f6lrQqEQWjcEIFSdKGa/efQaGtvkLp9/Bc3j3mGydG91VRh9gti0YUPXwT/rq7fbiRFnl8y+u0+WXvqaTveGb/NaPC7r8Cyl8+Ig6S9sNsbXBffnaWj/g5XSSjEA6K3sF55jApBLmtVaAVbYUnR3JYy1lJiVtHw8l6z2b80PFBDd9HmF8PR7tijvYbTt8zSZYLe1+RGmYwOnMYVuMesr/UbPae1bTTdhmnFyeEy1zar34HdWgDG3HSRp6ZHHD7InwfGKVits8e+qsJGvGrqlIB8OlF66+/bz0YyN1XbpaLyZCp1DDJOE1s6f5Np3Fh0bKPMOFbpwpSrHVqfGtCgA9xIpcY63QFL6iPpQ8eM8ehUbEIj8kiYup7DsYSnVNp7MrUmVfKqS+qAAzZk9WMhxnrfF5LOYeZPMdbuc0ZzPCUOIxYV6sNCcGac/YJj6vja2ozxCq4gnJGsNvXyDZakKfs0QEbZ1Pm4U0RyTcoxRNvt8ri3sh+YR7SuU0pY/zD2dWD+VXyUCZwRZICdyO/75EcL5j9i6hehf78wDiM5IC4vQUi1yIwRZ6y0kRlRVQ5Hs8V67ZWyVUPxeAxaJu9YKHqYKHvT7IA0VLLV7u5hvo+s2HDZQoar/5YQ4ZiyZJSAyFtELvLIYqj/uFtg6j7czGXVmeXWngdybDNEYG76Zf0CgFTBi43e5Jv32APDySNZ7WhAFoP6edtRymwgqNaRIssVAi+PJFeiWmnPVq0SRT+1GBYJi5ecob0N/RvvtRg5E/T8HS9IA1p9AnMYcWlKBrZiS9mszgdQD6ekVv5bNXlh+OHFxAIQsXYFY6nbY1kj4TdIAQyVwNJ+vCxJ/AikfT57S3HVdKq54/DavHpbWABeRdN1yisQ6EaD4B+L436es2PYQpml9+SgpnHFeFjDryG67F5Kqh5Cp2ZKbSoE/PD52tUWen4akRV2HTso49pEzEN5gBxnFENsYAKdzBtpQFnuomax2nP4djFJtgcuaFHn6gLhQEIbTjvGYjrknmMdkC5MZiB47pBaSg2Gxjf8ipav0pCUtoV6SUiAMJfR4inf0rGgrBu2dBxULZWkyGSPZq8ZqfBAfi/a7LfylSZQ9b4vGpPWlzJPSzyY1xl8ARQopKDrvesTXt4vWAM0gk0do2j14o1kQTpG3Ta2T5olOiWE2ldfVvqW8TpRJt6/khuP5CbQx2xxzLLk7Epm5BRAI4VCzQsr5k8XeMGfrT4TYljg/1DySMlEMYAuWCDSXggRi0zeRC+Bv6cL3jAreOu5yhzWgdK/43yg2JBMtL1NzVljN6P1vcdY6P1Hpp03QRhgOUOZgfl8sIqwM3qBzAZV2WssfkNH7+e7cpAD6WIF8CyW11ppPUvlM0WWTI5t8slpkryhP0dA4fswd4QPg8rPuslxrX/9p3fWZ/4bXb2tUrsaO6enjeB0apeSdsN8cs3VEHEcWrev13bnVozo2dSC4SY2Ssju7W7bqi8dUNP8kb0AKSgB5ZgIZMPyczXVclSxr12+ZoX5fjpSr+sWuIUgX8f8NTyyN1fe/QY6vf6067w4MnWW/m/L+pO3bpUnDmKoeNSEh6b0sCTHQOzvwTptTVtKsvLmP04R92VhdEFEc6BICUoLw/IjLjAMgDJKjn2U8QJwU9/QW3dWnZI7JIQH7LL/qkP1603PWiN9D8zLh8YNRrUzOEdI0DdxySPRGJt2fapsXTlXU2hvH0DKAR5vpy6RANGF0WAPV7M/LAQNKj4TnoHL3e17izpjn0B7doQe6txjp2wPIjB4NX4K6QU6OBILnRwm9hfz/rlItC6XupIoAwF/eiE64b0CQDKN93F0dd7HwmUd4QdPiOIET+dVoDCwfIE9FbSNJSDtMwms7onlwrBavALcKtyRtHlQxl8OVzoJ+1GcOJegJM3fYy2t2BrJUYHhUXqrHKeenyz/yDXwSVZXSHr3gq6cRYvhAy7Sx41nfTZHC8uIp9b6gLbyWrZDYmlSShqAyOOdRMNPoKEkASsp/StEYFCHXnk2YNhGDZeVDakF/Yvbjc0SbHWTqHPhTDbxovkfYiUg2SrUD/84Ek2gyoefMGSnPsI6dCuTksLfVEzPPgo0A23HKs45IICwzbXw1a9wYSmK6a5DsjiTgZnk1zNZOma3CVDon/LJAUoux2C9lsorzlRSxgci6HY21CExwwOSrkJMtq9chJlts8EU3bM4NFgQiueISdHiFZkrQd2fFhmeoFViogbF1L3d4hzuuAYT5u57cVQMh33rEO0Al2Y8rvoRyyx6Bym4uN4h1W33rZWU1U45xU1m3B9zo2V2si2zBxWY/0PgFbYdb8Ckopx02zW51eZo0xlpaYLkNqZ3DT/z1EcIXhEuSgLW0hV/Na76BT4E+ChYzSjMRJk1NM0w8wEABIxOB5Yo35gz9yZy8DDTZVf8FNvRCJrVZ3bg94oDLzXOIA0DUjQwT83J6Esyk0Er1EYdzexGhMT1WKtEDKgINC9X7PRn/9X5AU23yyxXfb+vJX0WD6X2PqVc+MHkZJgHZqphfCmRqoCJ3lTO1DxSIfwMjBrtLt+syGgzwQFzi3E3n7hodQX5yH4ohaXxPOeJHIXCNskbS4b1Ai5qQ6IgaaBD1I1lSj1pInvwpLKQ2X0hnFXzAHjbDSBoWSPY+eaQE7W5te+QiQFwkGViGGP0H2LLTUlNRvKrTpmXfV8NvUMbpYQorYY0hQkm50STN00fkj5CHqXAa0sam7AZW+oH3GrEqx5KEP4/rVJQ06YZZHKF5qCAUemt6m5X0Ync1KDlIXUTxZUIjEVrfYNUA9qEHzeCa1/fPufYqhYuZW1bBLAB/nRsd+F7vnal8tQNmk14v1L53s/ZaWcBLWbpszM5Cfbin01MR/LlKSzeGFhC76qYt+L+Phz4+9kWQLi60xGiBK6sYZktALYuaKjufaHv03Hq5+tUIZrPhd1EHLFZEngR520l8RMXcikmVIz5+VbI0JMu4Y/6QZwNilceZiu3QdVJh9ioFWjkE2t7lImIQYYzm5VTFD8L89D6q3EhAjjLTmeXPUSajT5asnrAqFQqPyLWVmp74oScPxvQJllO8Qjy3hefXFet0juDwMHDKOwGxB5REamXaI6qSYsx0QQrjd//wnSGE2wvt4DTV/ojtQRZVHioUxyYMv4hw1lANFbcdMvveeF+c/FFiaVEIZL+YitFaMdVdJPO1pcBDQfiN6wCSSzA5WU8aDQ6HWozT1L4EdklJehq3wBBArzKVVPoYPcRpnlW9OGdkpUekuzprXdBonxd4rE9BGMbrOL3WzYqdwi5NBKh9lPKkelN3qcG2qzezwKyijzl7XHDZ7fWCjhEJEx9nie6ULIFBQX0zXF9VIoATJrsZxYT5Y01uOef3eomD/G+BP8GLAl/AO2G0yhKCzEVoYDx2Hipz7KibLtog5a66T+Rx+9PrKXEExCFRAFtISktvM4cS1ZTCSSf8bYPhKyJwT1HAhZ76a+xssODX2QHWs361ZE4VMImIfN/sN4gRn0xInAoVlPg4q83AOkZJIA7X96gYxhEOL0DV9oeLHSily/Ysqgl9zTTG80T8fUpnfKwLxTcUlTUp+CGIgll6krj7Kh3r63Sq00qFfoSFS0Eje/fbqIGzfJFa+X92KKESOstZm1freBL75R9Um35qb+AfF1oK36+dTmV+cG2MgIT92+B6tAN01rN+tWUtzsVk/LIwuYVA76MTRrLHWUORmvRaV7+5+mgZFzSu1iJp7flaIdzHp1rvKQTuOVuA+rNnNnJOt7h1dWmkgkxnr+Rqx2gvASnguqLxsKw5npxoK+IaM7Ioz1br59FnvzH/9XhCsjqRUBAQ2DD8EC92LJAzIsoJeGWzWzMqtr6EYP17ubhfY7xptBFXGRKfO2l0Kqw1srmKcx2ha5jm1NjjamWJa7lIrXAeZ15tkbBZ5HMwimSM5vLVDHIpUdJDOn0QgRsdMRFPFLLFd6In6dKXnXo+WEgjzAvDdmLzsTtFYr7a3bhf8Lz2ZC6mRzI+SiMgeHmyEaqHEoHBz5kJAYdRAaFJUoaGKAG5QDOAtrCTKkKiiHJpwtKL+vBuOMIQvXBfKo4p+PWZ+vtss1zyiC07iflxHbQ2Z4Rozbl0yL1s6zlGl90rtyZ6EL5Wmjou5DPuFWCFWZp5LCwHsMhFQbeqfIX5GWwmiIb5nSOThEDoTjTR3Vq7zNFivD6Zyj4XnpEjU2gF5AUzO+Z7Fn54ImEzDX5zIqMFjDRfUSiMgaS27KHZ4GV1gCk/IE5EHLIdn5ZplrmZgDCc9S9T233J0tAkvK1T0H6vZ2yFiOmUNVaJtzRVxz5Oy+7CYqu1cVUu5Es5HXSyb/jaY0HHVgK0kO0Wv5Mf40d5mMV2GQTOClHVtpkCzfuROIDMloMxPf/LnkOKDYaPwOQDFackGehC+V5qXfuQ+3C8zpKAEbf11c+2tZLFn3EDW3xCm0DMZzoEqM4Bwj5bxQueo57dHGLGuAZJRujBH9CsEyKt3k4gDLuDpjQSY3MyzvWF/3+WXDKJ+zOWN4SrHBeinJafSkk8+MkUqAfqZNlVeEH5w0Phwoh4vTQ//bJrUOCHHpksBh+0gjNhl2sibifMjMJfkkSikRn4Fjdey87BMzL5vh/W0xnKWGeIKb0X8L2piRgcfuri9FHv+6dQIdaAyiDk3eeKXFsGRhmNErurbhTZinf0MDvlabJaMo9czdvg3z8ZSeP7DiFP5l4HvKRDuvtPA7ycymHtsyUsf4y/Nck7aGOiXih6mKF3Bd/+szpP19eg3UNyqlLYUVzUYhIcK7HY1EMXNwS7LxOQopjoCi643yzdp0DPmRhL9fkk+dDbn+FCW7i0wdb2W6ZfAXPfBnBwyyDC3CRlBnrtclSFipKx2u8G7U3bs2tJgU+/jfFNjR+aTTC/J5vcQCnbx2DI7tf5IkgRAvrtq1SId17C/T1OSzL76m4VAcJ29PcNNULovY9iCbgGdFgyWoe4U9YxCFXBXPvOZpFIl9zpuTVlo10dMGKO15iSRE6W5DAnXQsUqT2ANM7Rse3a8k2VMOs/ei1R83h01sgUqUbUfCSaFZJVHeIiskvf9Ax4+BSvufil8BpKaZpS7Mdlgvw8CGRSNWfu+0Ty5UU+IFsxFUTm72mQ4QuH9RglA7c5xB+qXgrMwLgdkvZ5fcV47DbE5SSsg+Bsc8zZv61Y+NilUHj1HHx2sccs4GPLNn/iUIHL5sin69PtUIQA9GQfjxkS0kVOzIzz7Hl+Cv+pW/kR9U21qqVSsSpKcJ64VqcZy7YEgZgaugr7Bfd3Ulou1UO58bekxIT7EO+zGtR+J78w2Ljnaa7kPeIa7K2S6yGBfhQTcM6ociWICYDeOmL67vZr8+fHH1dQc01zChOwfQXlmD6wJMfB+gwUsnAqab0AKEXb67RjmX48+pUF3UTlSiYs0DlWTrkmkoXeo24wjvKMkzmizO9PkMv49KRaF+WXA4G09AUcoZPbjqgb5MmPwMU9UN5pN2EK2cT1TgFOd/6DPUGwu7vnE9ToS+UAbfRpCauYOl6pMe70nIzSztphH/5A7b5hNlshJaHrkyL9f4gvd1SWZJVP1DDATfQnlnOgXnu76CudR+8sTwJ15CcoAlrRMBIfUT0BmopOdqMOtxKSIx7nspIT8TCrY4uEH7PLSSIkdAB2qzr6dKFwQOjJ5UGSLRxNDDqL1P+HfmqD+O29k9ou4tlmpocr8cQLGPmSuUeOIuL13eel02QS8Y8EmbptZSHao0zDqp5V1a3N42ULgxgAEuwwJXKdKQ4QcxX8+yY0iH307wicfiugaLDTOZiaobi8p8lv207stHkHnagleo0Kc3TtNf1jptxo+ALpvYQGs6NMuObcjLaeVcxkdMoc/HDntAc2VFVDkezxXrtlbJNdGpQ18etG0+x1iwJXeaAQW7LiexYmgGzjUiHM815mQ769dwZsCSAWHOHYW1drET4U5gsCM9Cn7qvgZdUe9Zp7NEgclH1rqv1B64szS/93gRe510P3o/nuozXFi22F+JfBemSCLNYvytTGl3mW6YzF2qMXdZ2M7jSqLO6hrIp6KKMcbRme6AEkGlLWNKP46szlfj8c2mx4l+RvUTGiw2CtY8fj433g9ftJvyhodSLkyitZuM7qGpnNmvCrgllINUI3dnMsu0eJpg3McDmsT7PFSDgicc2mx4l+lu1r8KEBZu8alqeCSvdwW81AnsilOrBN1xZNK79/NPD7FlPAG7r7AJ7QiILPiUSGC+m30eE2MmgjjbqPHklp+OzSmYW7kuU3u1vnHJYxwQ9vJHbyBaAP0wr62NdeaJmnhLZBDG4y9HlrNk/FTdpAF+r9I1GfI8BT80KsIR0lLMxtlGSrRvoXdB9fG8+Vb4V4O5GwbEbhz53yMEWSsEno11Nh8tPssqebWZapuXLKeNzzof+QtSwNYeC7vtyXn02XcznJPpfrywjGqFr4DQJsrWhGkbtoxEm1FH2fGBagySgQS1fShe0yZPwJkeNc10TcKVbT7MiN3BU0Fp7BFjOkEMEUarNTcGxRs8as332sswXBUAqEpSuJ/0VI91JyACvpCc8+GgsJ7U/AAu4keGanbLOZTcGo1AGNdAKYJdsj370Mj2DrxSdx+Kvh01MtWN4DHzPNZiz8f5OHY3btr2GoYIKNj7tyRQ21R8BEfbnCc9er0sH/7WMGSRkMSRREcgJj6sWq0tn1hUKkHCaQ2Jsvf0Q+FHa6sGcNwK6r4b+jmKCmZv6hNlZKkVWZ2a06I5t2xlohiZtKLeLR7S2KvuS/37uzd86xk/ER89004lek3Wi6KfUc2O8oDT78dOlVDbk1SIiiG61knMOg/W9tpY/XBdlj4fJ4ZXDNgpc7EZYzK3zSAafAgZZzmnzEj71oXwBK73MB+K/h0YGIn/d7rJE0AuN5o32WIpBZfy6rdKkScnCw40PmGSBo5l3CBjYyt+GF9bDT1DU4ihy2OKNUQV1nbJv7TMMtnOKFFVu/o0gkS4GeLNBPcZrsPBnj4/zD30454xl3/Dq6V7OJH7bC+Ub46FiJhIUMIXVHNRCWBXpT1VbwwiJTOamQVexgB/gSZwGZMfk5mA9BONTooM+NWswEE+I2VtibaULyveSkEf6ljn/8OpPsak0QWMlY1hEmh43n0igJP4QIdqv14QHFvPVTvBFTKzC2S8sz8x9hEMf4qHjefVFwhwhfRrVqVuRXi08wm1XY/xNyHwbuXYcSOhsDoRzumERjGqnXDLY/h7AufyF7Lkiq4heHndpThG2kM0KxLUeGOSqIqK2Mn2EdtOQNaBxSKC2c7vfS1XAQa4Sne2U2owqpqJ5aX0wvW5mpmKDRIHdaUkSzVMc8qdekQ39XcMj7gpoI2+braX2275tH+AVaW7q3jOOeM2DBQYdb9IEl54cGzNXivUP9kcoRIWUto9PK+FpNH2Lhs08APFhKGGk6ufdQvE44kbBvm8tvSnjWMYNf3Gkyj8nLwzPWFBBkn9cUZp1fKmYB0hJH+G2eo8G3fJbMoturHFfSFzw/DlSpTgof6To/j2RUPHl79YnZkpvHXZBqdE8IT2VK05B4rpGyQJRYiOJ9M6X/jA8l2RlJPvN8JjDI5l9QF8C+1UHTizef3f355Z0vFcsgCNRIYWZPqPZNCxhlkk145ffMpBuXt72KTIQzcSTj49WWhpN4ZpxIwhYIYg6FSq84XhSmrBHVXbef++iSAEEuTo+Q4FacLVLWqM03M2IOvQUrBpdWo+TaITF/LGgm8OrKrYhIfGQoiJWplBvyLeLJfi7F7GKVK6Z+TiQ1LwR2CIe3UR06Ug9jyEGtasf3LToDXUTeImuCX9ltIfq3IhE92khowbAD36qlUK/zTHX8gZ4WMG3ZtAE7wx6yGjxvSfO+T5uB7qzPah4UyabN10/GEtrbAjWJN9Z9KlsRP1R/zqcyLRJL+6sGy9jOMb4WzOHlCjoy1vSxo+PWS91Bvh797aHiQaViGhKQ29BkV22CJa/uT+tWtwCxRAxp0iEbMZ9Pd9PQQbfYXf7Z/xMH2CSRBqws5L7RqEHvrJvVGG7fJPTB7B8E00W2Ghi0cJDHgxp8XUnjQAF9xtCkVd8VkTSevEVtJeM4LyXvurWI2mXFNhlUNFGmb3/O4BUfWpF5BiMJT6opmxZ5ixS4V9iLmf0P3VRAXmkUwIXmShtvtzbezvBEuFFa2oa2Ouq174T9fTwu+tqtjfGLCbKcAQIQqYbcUbshbLdl1ULWbVWnML2Hth4l9p53/MRentvE2b6kkBLf8YsDhGeymO7uBNeH3glp7VLhoXNCYOnIWP4F2Ht4+M1b+tdJMm8lkN/sjsLEqiTCVEONMdcCwjLCinEJKP83o+GZd79MRcnXZ021RaazZyvfyC2nx9SlDv1f8Gfd1PyNU51mxtzUUEgl+szlvdbZXsos4JWDCO4nrBVi5TZOuSnxo6AKozUqRDDxS7FkiW0s8a3JL/qd4ghlVZKEWF1kMAIr0MnOTR56iOCGp42WqCIcfYsBYLeYEhGil3tj9BtxDydC49FoPSQuhXF9OXe2fUo7UzH80/OG7jkkeiMTYeVJ18v3MQ3zQBwRHiseDUNEyxgGIcCAZI5aWlyk+xR7qV5KWzzhsLu+dfiPnuUl7Hmp6UdRzMBA0ckg1+TIWYvJJ32azFIzMQm/IMkryRZBBR4K4AJAI/TFXa4XHO6WPx46BclSaJ2OOJ+3GWbnw7uEOjkpC6YL0JM9TTbsDUgGLfuQjIK3yUpCAmcTgCOcl5GGGIMEl9eAtwjsL0TIvdhoeHD1d+MB8cAoVuN5wh1lywIL9K1/vRacSsFPG2j+9J2cjRFC4nSb4dIfvdHdcnZGjVmQf8xdajK4/Wpfa3LnDlX69T+Vs9vDwIhtIWXh8Rc1HbQRPoRlHFhwDiz453JIM8MR4Jazo1JZIUryFylr80HP11tsUGEebqblUB24YTBWtloVC6EjKP8kU8wCwNo8kFPDodk7V09H2THx2tyO/FVygOI4uLoo3F/umRDKmTKPUg2bttIft8G/cGbTDjlHhrgvMJdvUnp230c3cnzYbkwqKSTCE8ks50A/GEYdiFYS06282uLmrYSMlEdiqt4MmcQH7OEPrPOwKMbJzr+OcGc7be8k+MKSAF+D8rv68kvAtDyy5M9AvnLlYgexh5jOm+rSH+bmB1sK4SjgXCosFnQE/5wCavsdUirEdQ8XZ7edCLz3vjzaHWxjh30X4LgFD1nSZvKDItZosHSkIR/+CJm69inWTjAAwgx21mO9pJUHj5fWZO7zr30PHD+OG1LwN1OJsdi+0r3njXYm23ZhMUmZts0LCI2zwg9M894293yeD6Vvnpt4gKICdrT1WPLweDV1tDO5HBwefnPWvNpztldD98r21k55QTSLIwnPhPAZixYNjHo1PkvTBtttjMq0g1LACueYcnsFcZ92/irzdtdbLvsdk2imCxODOfR/oMw2Kbh6a3ZkbGQ+t87KUdt4+1wUziuZemDbbLzcCXV03uv28p8zJ1Zaej457IQ3aMTmD5Z51oJcMj5MUDUtmr9kEukZsFvFjBEhPJB9Mt1i9yTl7mTGUauVDEv7Xj7xFhauvK5GDvSljdkvKLqVYqc7C23vmJUZZVhrM7wfFRi7pd0sLNLEUZPA54Z25n08D/kE3mmH3ydeUYwsS+/YDhFAxqRxISsSN7peWHlEYvSLqqU1Ri4+vn+UHb7Obg4l3yZkvocLAijVSt3qE3NulFLgIMAM2vX4OiBfxwdgeWcHlixtiA0X6+isnWmQqC3uzUdKHhntDouEBGlSLEzPsBLjTld4fC3I4Oo//XpMmx0Gg3BLSedyp35JTsSgPSs8Zw0/8oLZcT/l+rFRtT0gHfutYBjSJdukZHiJelW3O+WVLOW3lvzt5WDXdrllJ0GA+av2io9HJkPMI0qQQLthdR09ewW7EF+IDSAEev5G6dCISsYBx/J9ludE8z/Wxe4/97wZY8JTTNxKV0VUCmYtxdDzHhpka36esshZEXQAjb+upx++QLASb1P+DONKEywlMZfGPK9uIrBR0j3Sh/ATXM8/utrz4+mgQzurx/DQD923GWTE2IirF2MhLuSTzuSpsE2tTYP6mM2ixCjxoCtkBXmYGSjWnGBQPX5IUf7wHnN53vLBpo1ymafF6MIhkRWfdiRGUw07bvSQZJmgJSyfKOi7HPeq+jGNa6KeEdP8fUeZJtbnh++BzJaPPdIKltOJdkmwOn3cKY8epY2ihgl8b0Ry/ybgI5AzQvAgYtHRWgv1+IRAVqtgIScPhdueNMw+zjET2ca6x5wk6i7+FgaSeszL+RPZ65/G7tk/cpSoTH86cyStUE7S6tZ1jFG4mPLqor9QbIDjaUUlC8iJisx9d52JC3ungZjPmg76pt9NO/UCnFagYf5K6DZyWJVFWz1K08QlC/hfdwdvvKKSGTDbEU7ZhnVuwLjiz6mW2RxPakSgqWG8Hmle8LAWQ8SljOuy01G3blKgQ31zakbHq+X/t7SjJ9ZmXy/WDaYZe3jpf0Q1LfBlm4d6EtTaQKl3kqg6XGs+i6InN8a6KD6Mv3UP0O7AiSK9MZ7tIPsRp25T/B7nB5nZnbnK6amLn0hzjLSArK43LqNV+ftMdUSpIwtrGaYwNfjVB/RRHczBuNtmFqoYAWOXSC+4EVC5qWGd676EwcQSlBG/jQ1NeA4xaefOyq8tp9Xj2wo+rhKAuZtu+yamutwXjSrJN9xGgwcOIzn+GTJQc1fyLtyvEuW9T3um4vukC0SesMcuFlQglJuANbP9EpWvC1E0cgF90En4MgWeTczcrR76T6dpBjuEMfHDX/3O/fQBiWlLGcbd033J6kT5QP+vhniBHInq0ZNR3XBl8Lm3rUvpX0Qd+DTI8UynviAb6PGySIGxMEF9V8m19emEEZalElssljRkYizxw4D2jEBgHn/kp/Oz0v/7q+7wy5A5FH5922Yt1bg7HhnyipdKEP/EZw9YLddzqC2Ebx7oHDzvXfQl2WaH05rG4vuBgzFxGirtX5feleUVo/qoleP6uLWlKc90b/Btp1z3S/b++WZrVuh2RQcBGgmqsqVDmLVjnWq8UhCh5g4D6YMJMF/yaFdk8MVRCO1WPvFtv9vOnvLMhZoFRcsd36uw5Ya4ZH6U4kfUpNZVra1caggGDq5tGyNs0TgB8bzXUP84Q2gkFQYybDXZ71pChIal0IBFEQWqarOUReWSqGqboK5wD62ItM7Y6o+v+dEOjbmfHcIgnI1GUjeuWznW7ArcVNGr4yfy/PbDFWKPDOhSXaGMypK1ndkqUpe6k5ZJ1ML6BLFhb6orMzxKYA9zvZHhDVQcSBh3LiAh/CaEGxTBUa2FnaDTmfu6Lo8joUa80FWJvRbBDerIMb3+21/jhQzkjIrH0T1NzQjvXOPAbQW2Y8SGshVVzSGf3oPVF9mihm8kC1qVOJjaiXTySOghxuj4P7ah7U9rjQg5QVHatdgNzbr5R8DWOGxEDYfSV9Cf5NM6BL5T435VZOWuINkWJVrgEEbVvVyYx/IUk4XhmRj5I5F1fIZbvVuFKkSLb71Qw6QhVl07N/1dvgyi0edS64micIIBRWYeyd0D1HtDzOF7x4jGX8dRN5fa8eKoPv00WPhCmWgv6501xJ25+kmm1wrZlpbDnMFkUKr36ShCLQdXHzT3PdI8HVLg+Gu3Z94Btn3NSxccOBuLaGyXuYzFjjF1aoxW2N8EcsP6qA3Z+lCXlD2/gSzqj0nGEW/UwgaW7FfsU70+dax7OAN3KBdAu1xaFDjecfsCs9+qHF6ag+aslZDZ5Rr++7rvBknnsJkELiwuLaJVoy6BMiHrpD8IanKJI+xpgQ/dBSG/FBzRy/Z0MQbBUZWey5py4OFCJu5kRhVSeYw6cq5jFP8/DKSRGVFVDkdQm0Lzyt6wJBxegpFsloJaFw0KiWD2dDEGwVGVnsuacuC0CQiw0LuGakWIUNFmWaTeZb9DUVCMnYHjV5+8AeLc/N8uBRkTgS0e27K2S6zsEuWoa/9EApC+u392730WQT2uUGhN5sf8CymuwoZ2jNmL1HgST8sLk4xOxmyaNZC4lgUWnE9aaZFCKc8JDLMnrmOo/E/ugwhIMfglijMOHcLYuMdBcEgo/qow07QQlTO8FmfFgLAixFNv6MZNBHJtIQe9Osb4sA7c8ObtcRnL4MuAe+nMMGbykIbfp6GwWEnj12Hxx9vnNF+jeq+8Si1m7N4RZe+NSG6Tej7suPmhX6wAoZdtJ+ihaQBTMHb6xxY+wVrLgTcOkJm/18GJQGnIIM1YJJACZAtDyFt4i32QSUJek9CSeGYE1poCvBwS8Qs6ycizP3+iM9lWYF6rCxjyeFiVe+GxAA5G1aLW2i4ty8TrCRu4sbTCjciL680F+YKM7wFMCbRaG+a9NdDZ9izdI/fCQtC/2XFSaTNt7ebNFao2pnoTYNNBLBCqCOvmr88yGMqo10EdrVfQhOr196fINgq8dJGAzbZe1Q18Wh5dVzA0uaV9ZywNp43CAGG4VnKVqYrh6LRJTTfOgX65xHeOjtwKqgqxI2MGEJ71Uk2RjThCj2yC7dwluiVFG1Mef7zD7tHmzckduilgfv78kQ4SBONtIWCK5A+crvQF0lnihsNNArmz2yLCRmC6qxbYMh3JO7rGzMT6ysorqPekOQ+tMRX32sR5g8WthkvNymGz/RHsVx4jVnZaV39YCwhTU6bdDVxvxg933de1lEfsSGR1qjoccqmI8FPtRilrfq3WPbROkS+HyNdg59L7Q1NLe+31kokCFI0sjwYp8yCBd//TpoIsk4wyWhnyAZfHZ/6Bi2jQPXN+QOKayjYLn05kWHHtDy3B8JtE2Xnyq4iwyK3h/WwXyugJL1pD4hX/gM1ucRZaxTbEu6V2rfPdeh/6l8FyjhSC7vYNNatst5Vw71hsglGYrc34fhFz+RZ+qQZCrwi81RO997SFnICMcz2Svv3vinmtYiT4XjM6JIZWl5s+g2VyR5LAR6+WcmiLdqw5Z9x2b+4VK+zp7AZbTkL+MDET/u+P1LexX0usYWI0Rh7/JShA5zOwRtiwRW/yqcH0JdUQMU82UDa64MPXBGgHCr5U+Iz8r2s1Ob6MTgOhMVrlzehMprRhIzaY64nNze43tOsEZq2R3XKRxTNEYEqq39Qu9VLDAhdH4OrlBreEbgeIm3AAhoZOihuA5PeWmhy8STRfp2Pef5JYw+NooLvp6U2jzae6I2eMpcNqzY49iGU1Dz48mTsMsBfPq8aCfOZWGfeX5N4n5DKekUDXAtk3OvRh+TOaHzJQ6KOBnubE01XhVWLDZ9aoR08r4EVd/J0h5Ws822+rDfhdtCeZ8++LP0br0NLmCso7kgVJ+O/zlme8QDnPEth7kHPxac9EjisEMiuqNqEpiE/35fUTxGQ5lXaiJw76+E87zo2DbpIvNs552ApdonxRhcxBB48zcAPveaYATB9hE9J9T/LePXo6SZeeL8SWXKwYw/iH8DgEGdmzPHAbxuxz69X9EoDPciT2v1y5NfwzvoQPB0L7g7pva2zNJu4fei1Q9Sq0SUCuEZK7nLFMbxKGYkEcbTeKUmcrKPih0e6pX3w96tYJbwpQ5cj8lSAy6ZxxXh0G8mMycIIlkfXvb8uz98SNI02/LI2ffxvirodkSOF4LuswoiWdUR5qKQI4Uk9posFAFulOBKMAHcgue39B14fQkI8eyq5dX0y+u1Opb320mlvbcPP1998nW8KPY55588L+qpj4CuWXgyuqfQdW0+6dlRMuVt/F5SqW5Y0zwasHp8iwl17LjyyIW8LTvX8oMIX2WD5My9+QzmJ5U51wse+EUsoqdrncH4LUtzOljlg4WgT2Oh2RRuLhPyqgZ5d6Ecq4RiJINYqnUO8mNetHtZmCr2wv0MJ5jV5/EUeycG8ynYTFaEzogvhyhsjZeYKlXVVSL5aKYoyHlPEZmdVy0lbRPuz1cas/d9osf+WIhpUsq69P2/MBM60rMRCSYYb3m01xrVx/rcrSFEGqNvhn5wAWn981HMzUlWfRTHlUUErmo1EgYsM9uldBsxfJ9x++Zq7ndMpK9JX/ASiTPuptM/3kzLv3FrEbfoZuBIYKlGF8N3IrSnTUtHyeZv8hA2QyEhUT5C0wFGii2TiHRVtQz9bWbFPIEGBHeBHZwrnZg9gP3T8VblsSKsqvZ2ovIxF+/TYbCbH5JyUq7MgFTIMOfM5tzsv2q/qmIWVNcL8XW8Pxw4uIBCFi7ArHUnGE6Kv1rrmmupy2UGCim3Lp/GnHQfo6pqBkCRZcl1nAX5OqCWuwL/IDthlZqUxbqnZlq4BbbmI0fGM37sP/Q9mk23FNeZYOwoRnVbanJMpSbRzZmf+plgglm/hUHu0mYpIMu3GfZKRCw5bSPOsc+EGTWI9WoNUkLzjYrLXPGfIXoM6+Ic0RLVkJRqnJPLrBqjmLRxmh5/uT72PXsbd1qhEgwO60Mr6nVhumiKmwYk9bDTGo8e/lRnOmgdKYUzQ5DeyIqCUAj5HUx85pVtAeUpiI667UQPdSVPiHG7cHNBIrAVgvsZmC805KkFAcb1aJsmMt3P2s6uN7dSwSqxe0SqmWdmDSt1b/UPTZP+dFtfYYCDrDoNApW+eq8nW8mxRWkwDQgFSDMF4hzkI7CQ5/dQkCYw/hQ5NsggHDuY4zw/nXxGdLVntbtTAebnR4l19z9CFYHKd5A0yMjrVHQ45eUAueY9GSUgvlJbzVEQtxGKdWt3AtEyvHe5l8sSFLaDkzRZyZCi+9uXBH5/UQ4yHdD4Hes6uVdEoXDT3jgWN5AAUWzZoptmQn+k5yOVc6h9v+6z4AgYNdM1+4tvL94NczlP+wpsXPbz8lPGofy5crVvkhPsUjJnSmi5gdBje3HQqIPahr43NgAQHVYn4ia5Fph62mPKda2vRSQFocb2sUgmXRm2HwUnhJfbMxi7cZ9kjHO1cuFRJNZ6EVg1Im7F+rSsILKM2ZZJqrPAiZfUyphHFGe2XQ6X3FLNAhpEPolEjjr5QqKx8e5KbyC85AbVftCq4azVhz7UkN1VuKDfc4MnawjoeP4nMtc47n04a9uMBOE+J0raT15AYB+FFcIm02865KDhXRF0zqYGuARGyno/kxTmDp4D9eQJ8nyFapZ2pjq8TBcQnmtfdi/y0hz0rtPuwpRUNOAaOk6umUPTZCNYRdGVG2VumCXQlE/jWo/aZRALDzmkVQcHWhJoJEcxIiqcN4vMCxD2ouPcQHJZUFbAxMYyhaAAe2mMOZd3nPtvy7b0Cv4UfpgqvWLGMJOvb6K4G3KsFM5euvt7/qFr1kuhvoAIdY+rMqJU/P5jvOgO6J66cnyyD1L44e6PCXGgPErd/+G9FWmjPa7cO3kDdX4NVOBvpNNoDwFTYmOZrc6Bon8Sr4RUQE9tJgudPKeIzo/yBgF6mE5dIIpJoILSk/v7JQ/hkTIP7PLwgiK11ZOj3TkJiyCbXZzNy8kXaK+SkjEm3BkT3yjoitnwkhwFb0E0rqBRUOxUXDpw1/BYa33HFeBdU4bvFhbKO+qbMlZsPOp4YQxkgwP5yyZMr8Hldc53VT5cz55f3EVrKgBUdmW0j6fYFXHI4gay1SKx8iF0jObvY8XeADff64LW8VQSoj1LupBR7HnLmJybNkcNnA3EIc7ZW72jzjeD7LUbYO3BgNtB8hchZt/72OXBJdpy0LLxp8Lj8q8Orr+SViGqJnJaWrLIXjg6g3uJASR08dNPa4hr3nbSD5yjBEn6WnWnRrM6aj7cn0YjpMY9pSee3nChkLQhnjVdq8SYByu18+BcohlHM88CWyGoUy7eHEYgsta4KbAlsGt/eFptgXCYYZcBMEhZ/tvj0oKBof1PSnvZ/csVnL7tr+KyHS6/anpZ+DK9WgQu7h2rktFUuqia+jOiCPLDTnrp10BIuC1mWCLo3TbhaJtfT0UssXROvheQqWPGa6hbANerTP8NUlw1gjG7s0te08uYTZAUZibAtLaL2gqAJDwXt4kqRiCwdCMTEK0WM0wJ/ztyZroKYrjdKEJvT7rGctrk0bAZJC5TNNY2xzoU0G7/5YX8tNIkNMDuBK5TbEMg5eD3JHsfPXgGQrQosurpy3OzhlyXjfH9nsl5SAsYR1HiRH1AMrjzXz/tRrmugTAVvxV6gxNcTI5nKBSXel44raL+5u8CiiRfe/pPut3PyoX3iI8aZuwE1weep8G80ur32wQuzSwKkjXJZoD2uTqRkhI2aQgZrPhd1EHKx0OI3iKhcN/djHZ2x4+dIrlYOh3E+en7xMnqJsoeKPf6072gcBcoUgUDqPzisHfm5P0azmfGTx9Ku809G+4t/7jyRyQYpotmruDlGOKoBpfS/Il2Bej6Vkm/6oKmmW0lwI5I0qkiK4I9Obf+A+KXhE/HAQjK5MxO3hPk43fDRdySL2wA8aWWdnnFmMzUS46P37uRVxSFVzJJ2rktFUxVXpZoPTSSXhOHQzEjrcB5EvqfilDOxauJLI7uoSdKCAz2iIDcctEl1nIVROgYpTV+ebJiJ5BpmadVZt/ksxtjQzsJdO9YNHgKgIqnzlcVRbEx7J5LHuTF3gXRDhxvsyMgRfO0CpG3Vwp/endpSVeEJ+7PGCr+3uxwmGk/Q7fX16PKT9vhkK8Jd5kaO0Ijai9C5CU+EWeq3jSP/LM2/SnHPaQza8YYoeC2fHxG8E6/hdxpaow+ZQZiv18lZhaMwfzmj13HDU8ORS3I2WUMbei/pcjQtptjTPx05XQ/3My4A2GCKPwUuwbjJ0gMRS1papujxwAvTcekruU27Ja0r913fQHeVP90mXWxUk1S+Q1TOvmid76yZuSa1guaKqk3FpLVqnkXrOFj0xqSre3Em+hUw+kcClcpY0qIgrfrGJyD47sX0F0iKTyHgIMCNITWwwRR+Cl2DcZhmbzx+Sq6EgG5uHehUDCDvz++2fB3nuVWp/BCf0WgyIn5v+/ejLwrbmwOJG7G6TmCTc5m7rQfo1ELmkNRwJCCX6pJhA7WFd277kYBOShnTEpLlLovuOI9BgCV8fEl73AWUN4pcS2VpL3awvJbArmnyqYFuwmTOjetOnAcxTHyK6z9M3GxoSy9SP0Ot9x1EIGKbaCDo8m3vxWhYUnyiZY8dtGzeBBvyxueLpmNoOxSmNNcmrmwDnsmg4M/9FhFh32R7GF1YnqFZAfnK3/KiP9mkFimp1bAAa5WKGJ4nFV73QeunP/Ww3ROuCj+eSafwoyYVg1WVike9bARLFesxAR9MBFyljQuZS2sjwTsbg/Za2byIdiMyz/XsuspOsxrukrvxpvQfnCJlUShEDCD0U7yAlkT/VAF+6I/Cd6bGava1sekq89w9yMsTJQWg3VeV8keGtYwfYAoChSvUTRvc35gNaAZRYefRBaIUgeiH4HgjuHd5EgzeLUHxrvTzfN3l/rUooHcpqkwfG+1eAEzDD+b3dKpv1K3T1rK1VgrFCCsA8xyqGC08CQL77/VdSXI5m6LWlGi0cfheweaV7wryoEYLaegXvJTed1vhFr9AFw0gs7766cl0JeuIzWv9sKm9aiYsEnakw0kMkIvJFXBUXJDxuUxNvOPvpTiR9Sk1lWtrVxqBWqm7CvwlsGZEStbXS1JMczASzQWwjMMqMB4ZRWhXFLBrv32UnWY8SdJzY2kCz8ymZkzZLWc/BkmMX4jiiCw6aU8GPcBR8DiuadsvLxhLYx3JTN4XZKd8mnXYSekyUvnHl2lwzvc3lcZdB5vWt6UmBzduNRkMRrdqiI5IHXvxdP6kEm//i+xmaevGD5ShrbR+0x2qIlkgecNbljUCMoR/X3r9FEervYWENbqLYgQhqrV+sk9/xYV3KamCNvzHKObL/bV1Rc64TvCdaJ8DPm68SzwIcNcczs/mEYdNjQe+l0g7gXzgQUH5KD2CMieg/YnnXZcVIeu2RFtbR6onWZrLL1MHsABQM1JjEDraq5DRUF4spExH6+MFdT9cnhC+HRiim3P/f296Tf47hfDI/c79kTg4HzkAAwM6qbCHklU4kEo1n5Plp7AID4iFDE3ZTc2xclftHjkQWyBPjo2Z+zMCMjuu9h+XdZ27M5JwrRecFarndGP36cNJGDlXCP9ern9ROd+jkWkzz+WO6FuB1Q3Ffg1XQSYo2LCLn7WOfVWPFs8MQc1PZVrzdEHRt2LL3XgzGfFC3CvMqHePl+ULNWwf1ufXvq7OTxPI1Rn71N5JyoMg5npp1j/lAas/lub4oiUZdhXtdEANkNYWtJpXip8G6jKSXTi7t0v1szqGOBvoOuHCwZKYfwLWyPBJApejtCOBL0MJbzAx7XsEXPgJ3qolik9yD8nufvS4zB6WUolu6Ha6yRQV4L7mGg2xBxRJXXxupF2pWXM97Bek7d8prw9ZwmzrrS+RWR8MSP6uIRaUKP1dV/sSJhGuxetu2Pl4T/0DmrjXQmU0x13BWVGVMOWnb22Lkr9o8ciC2QJ8dKzd0KTPkpLzy2JFWevEj1odx5LwkEVeT4shIPwP93KffAq2W1HZ3vi04U+5PicdSLAvQkbuPGTbWEDpOtX3LDoSA1We2uRCSb4ept9h/uedIex3G1voJJatiYvI82yh4pmXaT7ca8Kv0xOyM9Mr1QJnoQtUmshxH63t3SSX8jlMB1ZNzOKS3mCamNaxKzwa4nclMeZe1dh93AAMdrytKxNuPRsU5RiUoZORI06lCuVR7JU0OhK30gZEFnyrx1vq0PqFdKW8L+coCtOnzuBrDQx7pvUnNtZs0pN0pDnapHZ2K7OZTcFAK3RLnLuunBfKi1Ice7wUDgK/tFX83bL5V2E71FZBp0X7h+q/t6xYGuYC34XIR2PRXAAXTcRaDXTv0DCO0UiFd+pC+5VNFKjdnbA2RcoC7l/ViCymt8MYeVCJFnIWaDdEqR5v7UEjQow5R1dLx6j80FHMtZ/CEdyPfFwBDNxtHm7/aVb8rA/bysfN4+t6Cw0ZkwlGzhhAwUCJIksxeEUbe1i2mTWPZkCsjs/0kbL54IE/s8hETufH6TnPunGMLrHHF8P3gbGTZ3K7gAYmteLMLLm2HAJtxjBqn1v5l9Nz0G1JwUkegPkcmqQZq8bCsZ22/KhFzenC4AxRokmhUhJ6v3EueTos1b1LYGgFNJDG19cNc4bMlA/AkpeRiP2ui1oBye/C+oCZGYpil5TnF53lQ5dDIRdYHahniGwEAQ+wkw5T8//1UNmeHVbFNksZ32GQKrT6WqEjxI9QIPo4HG1k6TUBNNG2D9Axlo38s/jM5Dg11nG6laIrXiiGDROig8SUlxsY2jsn+rAIVQ7bp+c+2OayQfCL23ncly0lItdCa/q4UKi2cGJmF+1aOVDX489AN3NsDOsuv63E+lv1vW9kwEPGE2sL7+6H705L+cq0n0GrE9ZWyrse4pZXT57jKcdoqsQwpZWTaF85BiG0eKnNq97sUYIp7ZFdoMM1JkDlfnI/q3on2dM9rOG2VTbJXIO8nWkoLWnOg57p+xdpoFi3GJEIiIv0TJaxaFdwoWHlq4RlcWld59AcqHuuVVOco3YEhYLL+uqBrYfAtcMSI4kwOf8z2P7LuCh8X49O2OsG4gE/5waTCBCZfyXTQce7IegEtwXrTXIiKQTcjd2somvFHS1Y0jSRZt2f4jpOTG2KCjNGvTkPHim3cozVG9yiwMrrB/odEIqr2cFCqu5n2lwlSXHmLoB15Q1piZciUpFMxoqTR6YpjJ2RwbYOizK1Af6s1HGlAqG5ovFdPLTyL4/qzDM8XD/KgHzkj0/7uDF9gt/KFEQYbbbVoun1f0kcJ6QN7KgtShoRb1mmbeuLAhttEf8aqs+BVIAXb5h2SbERTl4WdnH8EqvualoWYttGPijApzPVPGg9O94eg8+KdoacQ4xW4bYeGPhj5/8hrJcWkHS+NELh0MMD0awqCQdSnbK85rMZtt3EQifOdcA0SRlYWdIzVjOHqbP1H3kM4wbikW95EldnD0dTD9y4ebuL8b+YImMQh09I6RNljJqIO5IHkFWlZWMOMN9JYM4WoBlXiJCZpUFLw4vWYc2vniEKg2h3ahVYPULfPgDvzIiFQjiLBLS2ISHybATtOIzKh2rBXL+k+unZLwP/KUJ1c0Nxa3JcHYz05FOkCtWJ25KOwRqi1dmGpMdeNdXJXUsgZAUjOFzp5TxGZFQPnz1n/CUZXR3yipMOMKMpqSRaUaT+LAGBzrnzCLy5ou52n1WwQCOWYSljpR3hFNy0nzjnCIr907Z/xS+3qcXhB7ajlspY4/ibqRCSiDhTGi/NXqhwOS7aHVTC9diJxmQ1i0p8e3eN46BerRNkxlu57HyfpJG9CfBNSjLaMnPAUAIjbxtILFnU2Na6qBuXLK9WazVsXuJ1j7/3ufFLMKtyubCDgztbhoT958UcPB0tZ8rSZ3w/oFT5tHWIARDgI4Ynjwmyo5iNs+TmKM8VfKoUlywDQVVtPbSltQwjPRr7o84YzwhWru6HDQEFdrScEiPNATiy7a0usfp3Rua3C3cG5mbFROrAbXPGgGQod7em0vVRpf+t0U4inLGsOqosx/p+Vs4bsh87WoNAQBPgjQhF2RDq7tVWJt19PcffdnhWUd5Z9AsorqPTwD/mOg8jxE8AzMXshZySFrTfGfu8/jzyhNSKi9+OhEqyKhp0NrLwh5+UxmlHujac9w/rby3xSSS+J7CFPsPEmBmNwC+vONVIh6zQrZqGRbjVlrYOdtNly1ZCYHAAhWWef8OQt8WziYyf5Zt1Jrz1GL76xpHoMIaP9Liv2CwqMRnInGVc9qocH6WQXpLvJ79HLqxu9USFOsodQb4rLNC7s/8JuKJ/ZzUdwY4aI6kC73mLwR2MwkrA+3yIbJVUITcqi6MlKR/vUYnJ0PAMzdJVxr2BqrbKfuo9xEPOvJH0BNxTbemdz7QLjryBNaFI2SFS1htT/S8ZBV3cjof0AXlykumSKUHblyK6sEtOXWSzRLCHYyzWyZwM3cOmBqy+dPKeIzMmyuK6vS9RS/fhzWe54k3WwC0zKhRsXvK7tRkRAp+3JqaBYtNt32QsSLGQHmr1Q4FgPDoz6ObUvv9XggZglHNXxMQjffG6no1VUFGmxZUrbl8BNavGLO3nehV0kNEscsNuKm/TgbF3f2Di4OGvbLIu7Q1RQEwoqyOiV1dSYAgighc0efb70+D5PS8YJvo4VyhNWh8vEv70MrcAC2lR8yUjLhdwpIKZaCthgphe+omeODrEDn+GXmLdYfYUTPAN1/MuC3TS96h9Q0xNlVSJzD5eYYOPfz5g4BvD7AtHOGMvIi6OF1ycGc1fExCN98bqejVVQUabFXQa5/lMsIT6GjWzM/3lpLwnq3afHe+I1hZFIKnVkCa1PHQZaavuH2aJZhhKnzslT0WMj8rLKvJoPDPeKLYM75KjCw9YlpUOhiBUns4G++NRoVGjX77ClVnKK/F1Lphtu6AyrnfX5Noa2m0dXiPdpC984CsMo9YgMInAgJ54z6W5dSZSBTmLwSQr4U6IByfVqzvztJppmGUbO5EWdscj+d4NxhDSe6qbmIpB5jiOhBykecd7V9d9QCMxRpQx8Vi1/yYl2CDKnyxn04qYfnCSypn/B7OInvD8UbXsYNMQ3b1o9rOG3DOSfdp+M7siVMLcXrTxVweHXxt4L9XDQ626eWIzJaxDvPGdNI7dMAiy4wyK4c1ekxcPVHndo5jtccgFp0KPO/R2S1ecSg/fUry+fans5bcOByGFuSehJ+ulzqsq09JdhdmdEFKaMJ/JbBB4kUwHUJ9xlSlPivIYpJaCIXDtEZ9OKmIF1OMhYGKOZii3ey8FIZS/xvWrl6J80V3SqDAywsABlwwQeGGHy5eS0HVs6eufz7VfUYXnrttPrrQOayWQXpvfk+XziUdao8+UDPIQCHbkY9PMCQ88cG1lm81gIDBK+0ioHtXNe+cd3Ysjj5Fe3qzWatRmhwZ6iRGB2BG8rX4suDobLTKcXfNkmQt3QafMSora0gJMsGT/EgdqoDCJtt8cZVHoK1Mm6M5v6dMWvFkNNUr12TthfcAzbfurcsFUUb/V861gUFviUfPVJwDHsH4Qe1Xa+AgHf7YV7C2j7CbErzz/C1NTAEKLNRqkBZV4GZRXUengH/MdB5HiLYwZGIHKfuUd31lRVF4X5yXZsUqJG8LPPGP91pS4iu+VpHAquGi1GC/52EVhjAnbNFvEmHZtiPTZEpsRQx91ebYBVUzO8Nv9G8Ks4igUc4n44q0Z1PTEsmx8Vi06IPM4HVMYlsV1KJpRWG1uXaTB07vdqJke8e6d+kU+0eFLU/8Z31Zysi2z8gonV+DpOo6zin+k4mpCZVMpMdYcmjK9pPADPy4xUXWM3xzzj1GiJBTMyI0HUEN3XhrszKqMg0AR6Ecc6uqPmU51uG/jgZeqVIrhZcWwq1ZZxHPuq9JxXW1BkjIqdM1AapvP4b0bVuchK3XgMrAg9q+3T5Trf6rfSbThH2aP3moMfBAHH2otqsmO4wMAAIGPNVR0xBxHdy1ByRP3/Jrj7R8vVLFrR1XH0L5dxb7QqAFDHvEp+BDIQcXlvd4xVLIpPDFhxtowuqw2HQfyTNBQ32Lv/M1Ibs22edTzcytGZXEFNNiAkm6sdNwOqRlEtXvA5XeWKddTG6qSHrFM9g7TPzXVJM7NRWaatvnEogpbSEOCvB1WJqm6pHUnRy1mXU70E2yOrOAbgQVy70qSGPDLTDlVnBGxRu1RgHPveGSJtuw05/M8/o5NJJxdZwbl8o1qgbWb2BbfvFRKu2/6qH12O0OMOo9DgJ5awgmSVVDqJF/wFKEwROLADDZygKoKXIS+OS11IbG9BMFk1vMx/6KCHSKuGOCTwmY5rHeqUqziZMNIHg1uSvBsViR6rSxHix64NIiEL+8el0gByEg0v68Kmy/uOEsB+RuGojxZXu8eDZJdmdy+lTVBUrE5H9bvTSl5hZBZX/nq0ijBV3Vr3l0jkf4Odf2VnotBwuTAMWpVOTWsHvSFcDZS5nk3ToCuKKeR4Av10HsrzzWEi5o4RlyrMChqcoconT4/2vlT084Gv7c9a5ZTOzXdA1QL1EMN15pL4yd9YZTVbQy4kGKeR9QtoZrmcn7XJdpg5GHNxzrHInCsp7UulG4dXhF5zyMEvtu9q3ikSP2MHmFJTPraBHv6JtGCde82OfmN7O5ufHPwLsMMFRO+JDvSFoWzcvbWBglFKVn3wMdu6pJ1UPxZ/sR05qBO08sr3JpmbtwldGiDVHUQIN3sAY8ZVTgVx11nfZ3f/8teSmMundbzQO0oSd5sNNk6coPpPRw7BPBK/KKlYGMb8WQ/mb0b9a96+k8IT9RW22GKg7cWtigSDx30R10d+VZMMmC7N+f5X3JeLXFdMs6xmEnksN8jTqrUo8T6Q7MDUI9LaLWK+hWf5N0X3gWP913ymwEIrYDnCJSQM/szq4b50T617Oa7/RadHYl5E0OY0+mh2srzNx3GkpP3SlPOHmyQXPdXUY9Q/u8G0gO4EHSfiZ9vtsxFJXi8EHEAW2+NnkkGCc9tE+wb2+tRPEiQabwq4M+aq46He2aSEs8/Jkwspn3wOt1UlhWWKzW7gTYOKrw0b6eqdF+OnQzYRvzHuV6wfEcDrI09bYGT/+PM72iyKQI9s8xLFzKoS2kV4Yw8uikYvHQxzk70ecKthw1efn7kaAZ/110J11CKb3yAyMlWVCggwH62ndQaqxItnpEyHinBahV/Vj+hGx9Eeb/4zWt34RdK/bJ31Z+6nSDibg/3cdKdVMtaFlpA6psbfgdmp+yxazYOdVXWVkwMcz7KUgTO6rtlEpHCwfztrbv8RcGyNk1xlEJesRwK4vjSQAgbHnT9uC7HECPRv4OZ+FbgBeuh8izDOq4xNPOm1wlEIuSZg5vRhSNBGlL3t1WZTSiIGTS0dDR6VYxELMRU7XsWZSCX5tyDR6YfE3n8Q2Qon/WVtlQ1mGUKyRIzPTtmYgUe2bZpbjqi+irUmYOQ3Q8Q4VunClKxQmxaaq4TImQ/WGKB4pfDBMocni8nXVUyA/+tmM4yxtyDztmB5O+b/W4HNvH8AcvFfxaB3G+NYUIVD1W0W6UJvuaGh8tuPiOWaYB5kiP6U6erthMJk2UwA92fASyQ0BMSEb2RLfrv9j/K20g5hu796Qwyd83/gJq3fON0go7FmKTaYBdmDwPWv7tIRmlxD+nW216P2JsfaTM3MyclVz+eujYaE7XLUmMRmynD6iBEr7EbWUDFUrQkza0ex2DSx/cms3HcStn1iDfQFd3LUrz5CIqwt8WB9N5cPfSQErE0v8XC/VwAvXOLi5PWV31mBT5Jzjm90s67aVSIdD/9wNCyOBMuJI5OYr7Igj9Q6X0R1tdwb0lD83tWhGVylAOuatXnAm+3mW/aJgUt7b0fbNZXpPKJGYB6+43qWMoAufPMwe6jLSJ/Xi2+UhPP0r18VZxPyAwg1oa/xCYVDmQkL3LrcUEKwIy5JQ5tguQmGGzdS/RRh1MTOXQ8EKV9t+tM/X8gssTIRW2vmkjMzE+EeTrLKN7Wl/FMblsOfg+RxNb3uAmRG53MOLtSsNlgWifV98eXwsXJwmaAoIDWh7LLbmjWTmRFW2Cg22j8WM2rlvnxwQxP4Bet6pOnHaDvXjRHU6BHsFW/vKAZEowivmvxTRdwVcFFsZVH5xubAFpj5SWZyn+QFp7rgJMv/trhQdNCTf6vKB4S00SZ5H+QjHG/yfg8Y5x116Ma4sLUvIrsbHBMGLcVy8vYCH2bH1GgBUkhMN2RU23fCrWSEhk/S5wzDt+FFsZ7QPg9vXe00rPlVWBU7InSJhUHFJYO+eqjSixs4sU5ejj+uIN68Z+r7/L6JVEFOypa+HQHXSQJ/nhDFt8r+/fDZSCy1yj1PU5h+RsUEJoK76Z6g6qGXj+yZlJYLINqjm+ux+SEn5oZ0SH3Dt6QbDx+b6b92UxgMccvznZLfYq0wLPs0uoPEss+PyeqC69Myq/Qn3BZa916cwMaUp00res19XJ8D4bS/ZVLt2dTa/aC8O2LFKrNFOVq6pBh5tBfaCunlAugwEdGAWYYu/Lt/KNUGPmRXxPpbqphjxdJrKqo1rJRROSF2kL3XRC9yV7bI1JRuuk2qiBzu68LYNAnt9wfV9t28vGnjp2pCVcJzuYY9Ua5oyUQZbQ89BhNALTT0zh2UjBwiwocN1n2AOHVOquaOhh931Jo9cqVVFx+mP+HeY9ufYCmKbaW22DiO2wd393EpgLBy2wxjaZc3mhNm7Dt+WS5JM2VkzL0AjZMHSiWEN8hcHLu3Vt7Fv4uvtnQ7jYxj1Dc/RiNhJowaxSxDi8YXGJopdT8te0PR/Gm8JBU/ZMVg3IIbYD+2yXg4lykbFa/8od6zuIQeE7UJ3/ombx1DpgRX1JxMol+nE3CEETeLFhiAlKA+hFsOkbHPKBwe29mV7qKzD97zkqobQoUcot2Sh0gE4ZEj+pzpUHa7rfU1Nd/Y6C/PIRhJDTghMGcaQGXUs+vaENGhHK6I93DtUuR5QSHw5JBDoNkqPKkdV127gGbQRtT8dLLLiPr63VWQmUSjVmA9PIuRn6uNsmZLXTKvGoAAJpuxkuXBDP5XMJQZoTgoctIqr03+mj1E0w/t2LLYoITekN5W/WV1/o6tkQILQpr9tL0ownC1WfilSNFG0Ll9bEDgv617ujxbsyBQLTDWQy/UL8Xk45r+bv+iS7LqEXLhgDSBFt+Y0bsZ73y7ckX3PyUMiJG+YDW1hn1jl4lFv3R/HRGUkDh+ulR/8eETaS6bn9a/Kyk47MdgquxaZJ1PmQLb1hoDgrCn3O/NrINcVSTRjSKkmHZJWkhvjRp1YIDHWuFKrLfo2V6ybAuFHlj4sgQX2JZ3yNCjIfaM0xadHjf/b4PLFI/M2O06pi9Lhc+GTn4Ne36dVr3aKJDZMtm/AwrZAVsZ/XeW2DRSN8qvMWH6bBFmMTJx9cvbbjnWJP4GBT+bvWMJftRppKDb8PXTcCx6fhP+WzlE55u7iqwJKNaR3DhgEYBg60tdEhFbZe9sSriv8lsvTTaWABjMQatG2vXmOT/aSM9rlQTiF0SyUpjC9sSsT7XojMLsV/brwlZz+GdTKmFvWXUNNxlkLrQ9J14F89PRzGeovugLIgqvS6T9T7eHEqz2Ra65BFFFVYCUe3StCd9Qj8hZ7qCsU6Wb2mYZbOcUKKrpp3erOYCFY29c74g148I7Vz5kmR3OszB87NFesyUaUq7MgSXuaKIaYzlttyWJ+WgNhKvZ/EoR9+qREiaKJ5KmFPkJsIili5VD7eLkXQTt3QDmcE4e8bzCIpZv6ivBjUfttrxGHty587NJbzTk3Fo3PS/NaPlNovILhq+dtO7LqDLGJB3dqQYKn+sk3rVeZvvzoWvffXgbvpNWi4af2hqaW99vrJRIEKJ6G8vNLsrfXU9QMCUWazA+L3mckLFBvUqa0HeHdc1onkWastLC3j7DmDt+w430M2O35zvr3UpHY9WOgYn7xCLY7MJ7A4XCyOwIWAFqyaGbetNOMA0PYXWEjdxKD2Az33fidmq2uL2uPLGHXkN12LS8Kolt/V1dZs7kX13IBNT2lTgvMXqAuE/OJ+g0zgonGCHsOOKhXTiu04uhki3GURzaG754evg6B4U25oA9zo3BaRWo7TjgaYLKm8BXjrcPSAs48noF2Qe2/Qr3JYb2GGe9WQfROrd0OLKEXJ0PHLd5XUkIjuhnuYoCArKm6HyBxpbKjpAg5bN+r9BFurCjGeoD7JDIfyt+72R21Z04og4saTtamQpR/HcJ2u6tnLEdd5YLLIl+jkHu5tvrKtRW3hS/Blb5WDwqqeK93LT6yU15nqIEHgNsGHiCus7ZN/aZhWrWebbfZTprh9r9JSkJxGx4jc3S9bzDZZ2hm11tY2nl9QkMTnaKQdlvNw+CjyvH00vce8J2AMAEVSLcLD9lrSvEsIAeQz8oqh1XOS3CaUFmR1YccigjH9O2EPcLMhEx/j6cpzii9wdtp04iPGmZ+BKjhWqNDp3sLHuj/9BeDRmTJe9Gn+rue45ZKdG+xir1szkspEpntzB4vwBvMUBGS7rLBQfBNReFbPbLWEGXXBXyRSQUzKSUd9XVY5UFe9wuhqGys/83zRfVPwcSbSOs+wTr3DyFxr48+E8oyJzIcgOgsxmwI9ISrWffm54LtRw5FPoQSeBmAzkyIkdn7F2YveUCEEKmnVri7h6aUGaKds164h07vr+k4W1fYuvoGC7IdKIJ6mxK882daLgZNVbM9Csk9P6Uc7gN1lLQckvFT2J8LV0L7GrAe9MkKvebGj0CFoocSjXTHiB/Gasu9Vuuc7//pMQWssQWF7jAZpG/T4+jtE6cu9Ir7lLVLj+JGmvgvXOrBC2PSJC16dsAZFOhtNXqi6G5njNNt+2IPTYJbpJF5tmOiCFcbv/+E6QuzQOrYiK11ZOjyrUbNfKVRf5toRSlbVUVXlB+E55uAxzOr/CwPSWgoP+j/tBMLGpO+TU8oO19ZSTRGn/q5R+5hOPsXm2PDJB50scGBkC80fySblC+QvmgMP7Nht9x4RcR4DHhfilNYIAB65tSd+7+gANUg2hKkCcldeLzh30MXeZUbYjf87ubdiihMWknzb+ZGzOKTI5wzCnuG104lIwRUADGpBxCvFv5YBnBKpv3JDvqBwqstbwJ11Ifx6Z0h4WFjRcDx+Yd0YYhFauuqIMDyLrrcATA1LRwvpnqmkA1m30tpwrOqXxbVDDsO0oXpz10QV5n5KVaMQrQVOdPUTPwOX2R+t3hGUL9CzBPTau/O8J/ICTAXSKtIEZNTQ9u3XHtXJVf2p+xISD0ZO7YaQi0Qq/2LBDvJvc6RNbQEGbJkze5EpmK7wWnAgt1q79HXna6y7HcKmT3Q8663+t1oh4SYAsRL9tm6tmNUhb4ftBGU11ZAqCcyqxlDU5p2It8SO9pTJr3z9ccHBGer8dynxKwMs4NMzZxPJmOCeGEQb+eVzMV0RdVUCqUrkMZIErAbbim3Fy38FWBasKgDDRhrLnqNGxavqwuu6qaNbfUC+jaEsmh1Xh8TZrTXrKkLA8x8hf8Q22qig4UxAIJWK6Ecaz3nm/jly9jphH9ttdTI2Y+wcOmOQaQuXP+C8O8H0QykvKO3ERpRXP0u84Et2SIFXbgghEG6RR7QeLMTvhF0bWwEBy4cYULAYqQEyxCAhyheYopcav8YWJTpzwDdsw4EQB1RHKdYkkQi5kSrbvJVOirOyjrqSrqkUZIzjAoLWOEpsCNGVv461EIdeeg2DmzgR4QkJ3J/5W5+Wo1VWPSsnRLFiOfkGWnu1aM3z/zrrVYzVvPXEHLl7JUocMDDhQAFFZC0VPL533JJf0iq/C0llY528UjvdvZV1xDN0bDjsFvDiLRZGukEOS0a//1X5xtz9kvnez9luVCMAnJRFQD/NY1/XSugmYY4fZAzPkg3peb23oEFVhtEvyq7UhHzrAYErTd3pWi5lmhT+4K8sXL8w8KBfvf2Y0MZldzadWKzy69o7hC4qCPrTVTYu4OOoOmhV/0QFCvQjKGvIoj+cO1dqKpFkT/IM8BD+QIjILSmYmBLnPDRXIPfs+KC5xtkSZp/4RAd1lcvRGlhkl6vxzfAqfG/rmZO33LfLlE1vyF/6EePurjSrHrjMX9azW9rpd3fGC6R+4LUZRSy+snGmclayt4SxL6H+GeVZ76Ahtf43avkEE580Ey9G148uIFJSkI8RQ2in6fYL3JCi5u1oaUyDFy39OZeIvn5OMpEQFKPYj7wq5fTDN+3XjHtzbsrQOIHCxzZ28TrMTAeprOJnZSchiYruXXepEuj4fbMz9jnKQSSrOvWYMDrTE7KS+RZKCxQAh6RS+1Crv5RKbT8JOEmAwpUWvec3bYOzOW9dkHhPBqBSGx9QRSOiH91fgqyPtX2q0+mBNQ5UdNvLf63HAFBW1egF+V8myQtffxQhjGu1ZA7aFZ653Bfvfk0hBfgRODmU6KQDpPoLmikrNJbk++vGUCCoKO50H9C0cckVPDwfc3sUis416Ndt/QB1R50F6aMGlq2B9s6CtVxuXiXNxKYuPJoKRc5eYDK2uKjJh8DJVZR559M6lXFq1thfi2cq9na4gqQvHRUrhlaiYaVbgx+aeRk/mLU8cEe+Rt5auhJhnuZUlD6wxFSkbapTjceOfTa2CLPRf5vElX+LyIF+WrMOuI2Lx25x7T/Zu87Lx0AwsyWfvJOg1M36JJkhh/J9gdgH5RUC+ygXtBQ/cq6qIS3EF0jdsKxQloQ1Y+LnmPKX68cI3/64+y6y13ZGcI6M0X7PMIlCIpQrF0joYNy3foaslwqGcMd9BvrqKMZ9zyM1mTQWUDxcdJvJr8wzDwq77SlxVvJ00+9RETbu39gZFZxR3MTL8YITINtzbi9LwraPxA+GBVsAnQ7AgTLN3RNuQeiBrvOUp32mYwlqz2NncCAjAnlmAv3wtHAlYu+Ifp9eEL1PTVgvWLpZRfTuzNUSRZj3FCdzN2vSg9BM0tIKQDuq5qMtMrZoq9dKRjTYCgCCpEZdixHtkUk1AqfQSOIP770gePhkSURDeKe1T5BW0p4eMYAcAenkQDZh0dDYkWJdneksbCzAvyPQ5jrA23UPlBvfshpT0QjP6e61ztB048QvD0Pkh+fIFGz+1fcejN3UqrKPuwGk5K5hX9GeQrKNKksd2EUMo5wa7No9ljXtv3unIZ07LJfhIeLkDIMbYsz/7nj21TPMzSiPJB0QmRbtIMcjMSz0X1LK4cPICbZ/+DXvuH4il0E3nzME/IIThrBRHprFexmFl51nOJHfA8NIB9SlweBD7IPh0rlaj7kGdTUH6Os0R4Gs6h0QmkTT/I2kUNGMkHzRvwFUwhqzeb1osHCTr/3DNmhCY7c7L5fQYBEVtz6mfBS/BEVhs3WlEysQDhpVrXJOu8HtDiRDOdR5FZUTC3QMw+ks5WUdT5RJnzeogPdeC2P7e/bv0L2RVEyKkhuuP3nD3VDVziJmOxWbWQrSCv0txqQdv2HG96Kp0dEOT/HQXy+sqNyjM76D10jZgR3OlGUkXd3sXfvgeyhNoZIT9R1D+VkvQ7Hk1K6kwp4SLohXX3fVpJWC146xSCEmSj0CmTw2TONxFnIAVRDLNMFClio/TLtxGDOLDxgYlt1xSDZykCTsoLMLysw345A3cnab2lmRRDjVQ/8IzuWC9r21F+gpdT0CLp2f1zsuiIJyNheuUUC+YU1i8WTRpcYROEk1WLniieDDnMNoQTIwlK0DL0fWOZmQCHHc+p3WxmFl51tbW5rggDobHNfK5OP1QExFEfYpnpSMY5Fn2M5/8/lNhQ1A7fXHofNPHg3KH+DPspAxDsPUorm9ROU5V3jafsA9XuoBV25/VhaGAiKHOdTAvpCcV96vmKuO61UWLbFrdyeb5WsxBiDU/uN4yXBgfjj9ZSUqTWJEgKm1TurJd5cb+bVFG/JGT8SA34eKqkVL3XnSgVvglj/KXQes1sUuX1xbyPG2fRnBhJRL9U7U+d51mPrytvZIBCRoefAhy/NiPHC/DRosF9WwKIlJIdnIUwtBw7txuJoaCCTcoilznpcGWvvqQGQYBuxO+RBWMjvKxQGRaAVduf1YVK/lbhp3rpFt6T0Vkq1pG+LLZ1kMeNTQDtM9VtL1mKYAgc8inLmAzCNpRO36H4NCv43ezOlV3U9GuHnTVoZ8z0IPOrcZtcL7EQG86wBAL1iX5uMpHmxPdY29vqyN6w/c3iZjI8KFszsu4s6zb69J61IBeyUJhlQT3D/PT5YooWcNeSlJSFfP5Okdg7EKdqsVnsFt7qUnwyM+KcDrfw+08hlhYHJeQbZyOSyNw+evsW1yeH0r7BwH2GOVGcz007yZRIzUVeD1ba5+Bnz7CGk9oEyDK9K0aP4vomd1ZLvLjfzaolNqLMZWNj32af5JuN1eRFz7whJm8zwhLdt6cK8hAg4p7YEVKq40lH9Ckyi0KAmYETs/oE+llMZd7zn7rvG1dHYbf/9MM8DEU9rKBFtA0V3EPyRXp7TDr6/8WUXBGYOgvkQqvsCHFYZODGceUPwC5SxyI5eUsRAaDflaFZc7h3PGUs5QL9Dga3dY4b4bm2xJBfXo60+SyVVD56HkNCGk8/Z0yUyQEL2XeoXdW4/jNWvdNe/3JJKXXUKSQhrzTlX7bxiRFOrbdaGStCr2n0QdGMDH0YJ0wRkXHox4Hi4/jk8Tv3W1wxcosJUMogG36VJhgLfPgnGoUNvS9GO4TRRRFNc5anIY9Gyv/mMOU9wlwaLti02UiRA1l8msMgX1vEo3YC70O0pgj1EiVQH0/2gphem7SHjvOsj04UowT+SxHyd1Ov8klzGndG3AVfvbbAFPdjyh+AzI7sDr8gMvs5lUhEh8X0N2v+E7rdHlp9JlCCrgSFQDcMChjvtCZUqKWoyAW0HD4+l1lT2b4Emby0krLME5HLM+YNeUIRYcVWUdyIJtCp0WHHeRlBo8L/OGpu3pLnH5wyE+CXYnz2ZfxWizEs1THPKnXpEN/sU6uFpFdA2MBsoeIpkxK+jIm/tNdVhg54PqyybVbQZYBy0hSaD4srDYeZ5qVyMV1anFdYc2SbRCJrziNf9uLUtKb2sdFHutqQ7CR55lddEkd0PRES1qUm3m3Cv+yOR+VXR6rQV6jeMf6dbGAhtDIu21QmQaufEjO1dtT28zaxF0GHDUsKTZyxQRQ+XI9StPepYFqvtKkz87ZmulsQQG9J/nxxuQ7qwvKcYcGS5fDjj5TsY2NhPH/FTfMPQfSSFmoY0yU5MTlp5GLw+3cjj3e1AjjWl6YFy+mSxfHTQD61LnQ7AaraJHoL4HvCkRkMtxWm7fJIGZycroS7tdNIVKvilJSSxYO1OVT60XkzccQUaF+xBgMQ3MNxOdRGmLGbZTwuNV3rR2rcBCFZM+XNdfYTKBmLgmO8i542zGz3/zv6XQUhAl/vBjFXI2ZLNzFbAXvSmC5xm+Qh8HVYDhOK5BenAGzOl2oopLlvVrrVdIKBk2ujpodqccff8x+fA3KQnd8rLiqvt68nSvAx/c2r2is+HGlIas85cvAhgJAGTqYK1ClfLALddDAZpb2N8jRjjvy02ZZIB84A6FuGrPTUE4LC0+XiOI/U+gREIz0JFjoBmyDsbYeig49VIjmUkBoKx2qKj/XV2vPzr01DEM4IUOHMCywD5raLRHIphjxwF2fBe05YWqzGz7mrM8/Nh5EJ80IvsBawO8CxTfDW7y2gljq/xN+b5TlJ8Ygc6MPBZ0MRCw6USTAAIH/2nf+ap9YylbqiwaosAvwrZ0WBIdQ+naL4mwLQ433R5OqfkfTq4fxuP2syAkZdYUTFJjR5P0Ngcg/NKZQPm0G39VyHzk+/TTnYyGbFfhItJbI57E2lvdFzy9pOOjUB2kFn3sspQdRC3g1St7GBry9LHMNAADy+O7cFnV723k2eWHG5ki2Otmbu33tuGUnyE8gQEyk6AfG2NOttOvUeU1dgi6jps6UOpIPyEsaO4BylXEji+aGv+P2t5unmbKM94V6MR1EV0gmOSpYfFhMoQD6T6oSjoo88PT5NLUrei/A+Pncv4Y7EHmemNEzuvpnqiog6RuM6fVCd+c2IYYKawU+g326mBrm6h6zs5fF7XfZGY8EOYt29kAgNVu7jFFJqxtDfd0PjNlHbEsyyT6r4T0Ez1OGPHHmV09ugKYy5Lcn7vtnPH2SaSDIT2ofQcXIlZcAG1zae3mxs6yInZsbWcjWralw4CsPV4RhuVE1g3NnTdMQxV0XOV4WJGTJ69wuB2xIczbfn3fTlXam4doIzqq6LHo4mVuCzSzxEgescMUbbV13sizk02ogON7QAK6pHqnuIHNjlOgnb73zCXEomXvRihpyZGMtNqdAm1j4imTEr6MhgmDatrkxmpOWXWvJO0khWD7UhI5G8XFc7lLUEO9kbKZNbCA2/1yUk47ZPMgB6OSArGW4Q7huewRk01J9btOwfJOtqxmf25g4oWDFQ2iiJHFIXigmLIUzUvVPcQObHLz3c7JtVs9lvA2jX5h/IarGq8jFUHRP6/vUglcCM4CPkTRmCcJ7PE7O6QrEByEEOl1NDJQTaaNu5ReI4KTeyYKcz2ctavIm3k6QfAkzgMyY/IZJrnc+q0DaH/k+2FKyPMoi6xvnkeKZEybS6ETWVs9PKMsy3CqVZaVLvX1shjJMlb4/3TfnzKqizQrPQs1HMZXfIBgBnBGH+gMHwnorl6uDZQnOGud1NvyE3WIbzn7dD0VrqrbYSCnPYzAJ/8khZMDRdWn93jTG+LrAePaBezEYpoo3KrZturldlYOVHVjGMlgAzDiT48YbOuNJFbts0rUBv3DKvCOAfBYIHvwzabPbUMJfOblHGHG/ud/p0m7yfgTuLMTr1myQ+hSeslmYZJ9Nc5u40wA8QuEfRa7f1F9CKBt5HvrUHd5Z6LSdJxrebiEW7QI7FnzY6dZeFXM7FQs9zsHfBDbDRlkZ7NSLAJYNTrKLgq2gfwbkqx91c3W5m229IoRnvGqgQMGZzYH46TfrNlktw47rlJ79ceAIjEFa6rVOasAytT2ZjqNeMbjbnjRJbJnr4UojX746Q4fQ4QiLgYtnF2nUAYczOxPJR3l07Jvz03nWP76WXUkry9Atd9SwAopYqPNy02l9DoNb7bSCaK2wLlUCa0Lx7UTbN4GIB0NMy2lxathiObC6YEam/aG7k3lvKSDQyTV+lfRL37euaVYC8ho88HTQTQZnhGRyFHZOC/ZnzgC9tWbmqefoKFVEAwoJZx5ws4EH0wtpdVFWOSWvNyuNumx5751jb9+EMkh0/6Y8jak6fTbShnG3t5K+oL50btqp/5iCLfjMMlbjWC6nNEYlbbUqUARzEaA9Z8BGO5+dC7+kxnT4/SmviD/IdFdQLbOiGnLmJYp/g69xPdcclY09QHjxN5oR3Kbu/GrJWJxxqWy20yRPEJFIPW4YvvhmF5sBwSmU5N5D34Qyqh4M9XA2sIn2Pqch8l7M06XmoXsGjxX8uUnhRqPN1AXBJdaeOL2VBL4lYOBU78H869NQtsCJEei4RopEK4tdfHSlFKx+ZJk/rvePtLOr9+94X+cIUe9ZTt8GJr6N+Kk0ga1Mk+jTLygiET0mTp1chKqdC1IuTF4m7ctqRFLX3rXLRtEbMAnR0TDHq63UY7V92w8t9GPbZVqAABUKMC8h6tLN+F3wEliKRJC3a8WuU+sn6iICoIokgUBkovwa/N06w61Sz6PP/22D33NWYJdv0H8FG0Qu4Gw6aKnYIi2qrvkGvUlu8vVYEHj0+OyArOlNjaleP/jQfM90mT17ZhFhKZmIcohigTDjLGYYVC4jYhq0VeaDCURWeuvfVjZICmqxQ23Q4ed3jIIlIkLfBSHc2oqclleQqgRjGdloHrN6oybZVCV3lbYDBHQlhXDqqg2gKCaphHj8XrqQZRVbHLDWBaZ8QHwsk5RRit58ixeX2augsa8lIbC+8QphdcFCbhEJHlHr4abQvtxDX6vo5hWYOxiksPNx8D1aD9DTsA2Eea8UEcEchKGGNrFppLZ3r/uK+gHFnN5JIM2EHxwsXL2RY1a2z/9KMcsdR4uXApzxnhG2pY+cYeBDManRUQG0a9g4lOr6wqiJ0dCYMB3dt+AVgugAO+BcMCTSNw3uxyZd2nYinDszMggRIxKbWkR/5+8XS854KteZVsCE/RjmxzkNDxZ9mlBOV198nOmSoBSqqieINJKyl0EdY99At9kAoNGkQiiGqK16OuBEbz+jgLDv9Q0/nt6mS8JmeklzRY28q/bFcpbt6dgd8ungvZoRlsNPrb5YEUKPr7tgknEEtPapTTluFGf+gk3JuzsI1HAY9FoXQ3iYI8V0eI3eJGJAmpG5au4TIVF0Z8auRVOsNY2RWDepflGAH5haRj2Ia9qA4EHp9OFP9Q3yPmFGlnU2WUmPkWqJ5v/ZOYfht1uQahTkEClCVqPzJqXhZWExBjKWWz7OXmCdNjwqWpL5tmjmzIXQXlpm272kikH08Zmq0hVclDW0yasWSqACyPET75zRpUauNPw1Ljmw2BXSLalO41JN4FNTphvA7i+ln8APIqxY1AjvM2NNWok+OChQoBkYICn5AyM7YA+XUP3Z9hVj9IDm8zTVCU9LnWrRcNfL/pvXT8JCFLdT3h6QElvXO/+ab0D+abq0SzMUcjVeWMrYlQnN7eMfw93MzRny6QkQl1pOdGTGVuvg2wRBHHTCIgRncE3vnIfCmPcrY5UpB7sFWPEtlJHUbKuGOozmr6pxdv194ApuSiRc3maaoVvxbqe+erTD2LIUVO2hqiGOR9Aks176lOUfSrdTVSpcMrOO+Derkc730z+R1D4uWFn7/D9QuSQyQAKm8CITy3O4Dc/QOYOcUFS91Rk7rvOJLIC7aDTUUJUk8GM5ToUTSE5uyr1CByA88k9hT7b4kAGtvVy22A4r6rIArsMr7hJZTvo5fx8+rnpXI822yyhdHT0hyhDxSgEITiUqlD37RL6RuIS4lXPt9VYka4kcK1/Kh+v+mjtMaOIPKc6lP55FNP9SbaygkxUSzzyHUamvYoAyQzAp+6WAYZCcWje0O+BBCFcdWBUbTEFJbz97kXfKln1OixSvDudTNPHPDuHmsQX4ByaL0NEsnSRmRcg9vSOpw2qjrHQIyiH43UPJWZ5uhvFG9g44zcyCmojGjvi7oik+ZtT+Yoew8sgpo/tJ43oMpnJ+l6XYaNP7o8bemQCKyN6T+eVcc06NR64roH0sMk6Kuu/T68SF0fBImzCNOPGrJN1dbpj77KAixSddrPZPihlzzAb2kxOio2mPYpLUpd0d+gjUm5na6qbWNOxv2qE1fhNSHI/ztBGWGo9sGsi+Abe8S9HFdRphOqvn8RWHyP+fPeTChoIPRAJjS64HKRTWGiWzVuot+MxOjQxjsUujouQeRWQu53oHhs/fX9RQkAhR19prq+yBFCORyHPUfcP2U/yDXd6uuai/OfKPFy9Prxdix2hj4Z78hFpkmWaIZ7OfnU5tTI2Htry8D5a1jiDbtlT3S0/gLkxiE+P2hfZoOPCrt2zPnzXzTE0zh6ExR1HoRZRb7g72pkvYVagFgo3+v3AxW8vsYqNI5fKXyeb6mmzb1YADGUfEc3wBAwo+F4pCzXz8Mj/A3BV8I6GsxDC4/gWNYcU2I0w2+tE7wJDlissoKMH3FMfCYbJe+uS1rA0oKY0g5YzTFx4gzuoMJvvfgPueE/XsX4+2JWoJ1K2p6fntSUIf8+o9Wrqr3xM5Gm3o6f22c9MhEPK9OGD2er98eaxeiAjTf3GQt8HSCXxvZ4QdRw/9P2JPdUCPz3NRQaKJD/5pQCwLqERvh20n4rUvsOOUvjbcuv91NA7/vfcIEzv694x7iN6F2VfBNSz3XcnnxvwBGKV4bms5h6of/CSiq4H5/FiVXHNbf99BXjIIRf9fvAzN9oONxyIwjW5TCAhaivmpz+p+8+yPaiFS578QT+3GUR8lX1ltMHYULQ6alX5BMXlNGr7w/N7ckBt3Dgew+SCcY7PE7L2y9NVgDVS4N2uXvmSFqALxxbcyvKSflx3uGd/T7SkWgE6bgTZm/9J7O15SioCfkfV8X9eHdRqKgCUHg/3RC37IrFHG9zRWcbhTk7BLUlUpZPvRs5gvIC+YZ94pHsN+20/sIiaf3FTzWTbP9FLXm3Y+HV/kUyqWkMpYFbHfGRx+bozFimoz9DVzB12aqq04APSeQW48sfLEaYFBtmGqQTujt4GskLaGJFe9W6ToZTFJOiaO568nfhSCQ/bVyialFcXukJRa0Pzh0JKh6h5L2H7nIsQmtE4ugFoJ5hoKdHDwvbK8+N58VYr7ihtfpY44LYynIG/8udzLj8QS33RZcwTUv5brUVYuzSgZJ5d3iyMyG0peGYk1dnBpWIub7ruTz43nxVivuLxbk+ztpMMpRXg64HGzAvGbzVzWoTyFhz/YD/FOKscyjnla5PkDZF5Vsf25jIMXigbHxH5T6cduVw03LcV+/0DVdyrJ9eCKRmpz8RjAayIf8IscvFpncnul0Bklc+6L1bfCWaZy2UbIQpqmkPQSr9Bps9eV877F4Z0wxl86x24uV8G1ZuFj4lcKquYxYV25lMCX4bLIKLHKQL+T/dAroVsflo0cogKCgUm45WiOVukJrSk3hSFBrB7C0zdrYfEwZyaaqYJETSjcNxMvK48uqX1rJbjOWErQnOYI3IcxIgc2zzTeNviCsyNmreqL37tmn8KNPAUjkfZ39L6gZe9lO5737SnI66xKOAnYLmQ8rd3EYYA3APyg9eP4PL5Q6oMQex58m1gHz6hVmxck3Myaywz/TPpAV+8F17PbWyYWH4JjvnZF+TQK2pbuFwzkATex2RGuYBb23/t5q7++kndMs1DZ5L8636KoD9uo3qT2atp/8m0qsXxSXIZYk8KI+x7hRsSuhxlZWSfC5zgc5/xIQxSUD/c0Qq32J5NqVOjyxFTJElsJlpo1uSDh7eyYkfyezTJA6pQv05/VW59Be2SvCzdpuiTAC7YQGrUKCxZcfk9RXhTru5vOuPlZKhFjU0dkAcT16O3z6ZUMs48sX6bNJ0P1ygC9xuo8jyQsB5HES9w//MsKFuBISjWjL04vPxoft5VfGH8IVOiA3fa5O3P3gb2cFzRg3BrMLmehY/oiMJYJofMCco+0paRIncjUpUTBZwbQ+hmPP8Z7FDnqNeWfupK3aR4rX6cE7UBTtLmHdrBLLZxtjXUmWkSJ3I1KVfgPG6zVWJL8Ih/sK+SPu9sGvLynvO8FT0KOdyJtka8esb54k9pk2j6+AC9fmU7tBjUzZj6FB04/4x6Gl+92sVdWN5d/Y1jaBN/sw1ylppMDSxDuVnIxznTeBKyy5PwQDN0m4Y3nPlbhp3qxErJVEwmcg0ZDowT86ezTUef2+2kuYApxExPi346UvdVOPVYFWkFuqOe9S173vM3AQtgegWW5/sxJ09eKsYwUGSlIt/Y+o0OWfKvODNsnLuLSXcK3spikEGcLjoFJUx56q9EthWQb3k1tT6pRHr8y7zSaXf9maxkTv4Xf2cTJihswzkaHBnBCQetv4/mEk+CYsPhMFhqy36EP3NLeg5lKG6wvIRvWH7oULgJUv6/iyMkP3GHMc3fhxeCPXleXdss4BI4lQigRL1F500dVGC6qWj0UhjXcDZXaQzAKmgKwxlK+3mfArvSHjeq9YTK0jBqMQF7vXrYtXZh5halrid9Bp0tyJLLK+gFQ05h5AF7aAEfo8Ryy4aiPyRgtp53Y43/2xGnFLyv279C9kVRMqoRyfsuRZT6z1SievyzRpNOtUOqwQDA41OKWaoU4W8dqt7Sv7rGLpJtXhhngsb65X2gITQH/tvD81wQB0J1wZ5SvShCfTA2VlaCD8WMywtHfaRQ0YxRnquUB3Ti7qpF1PNyds3vNnfvdoEYraEh4WO+owoKgtAig6jK501nCGu4hiz+ZccEIGQn5iRv8RelYgA7YKZG3FkmS4pQIvdz3FW7XRlcow8HknovC06WAmZw4+if4uefqycdr+ttd71DAC8YfoTB9/Q5F5hbsOs29Q94+YjtsKntDoCXvfUupvTrP9dWIJDQMiim+jZl7a5PBIPeyOw47JfDrhHW/5LcKMpb5MiiTBXbwzUbvuBe2dwyB8ET2pIlZ/FCGq6QgK2gAbUcg1xFPcyq+O8SPVQIocAT0lIxghk3ht9TO9r8/mfSCj05oLiNeCp9iUg8TjLfTY0SrgOxKr18mhWynvNrC/X25lumWyfPcVRCvz0uvbiPvw+daovmmcglLukcKCQOh9XUwj+BY8AQ5eggb/EgrXdojg8rIVwyC1sHeJ+ifcJQPKaVQjYQETloPC6m90BkuKohuMQkqfuEVWAm18HoYF56xgrl0/+kb7I6mSsukyvQwqMsQFoWPaNa0BoUT7da7KAiG8GYZyldld8pUc8JvNQbTY63j6aBQk2UtUNDJrlyTS4Rwtr7Myazhth6UB5JLpQAQtPkYnV407qLII3MMHNVeLZdrFLQBVnR1BQg/V2mFo85/tPpttPc+vmcD5AP5dUJmGSTuCF45bvQI52lXOuX+gK7uahurdJvGeF53tccLvdOCesd6JhFs36fO2+YbvN6gMER+2O9577ZFliUjzobI61TlwjKbZ2V5QcNDmUlMYWqMGsqltm02rOEQEn8IEKbBcv9wWSoO/Ctg6Z1k6PYuObm8OmldEyeXq6CYYypTz7g+eAn8yfP6fvt/gh9gUmyqeJY8VpJG8H9pslFXGZAEuR0kFcGxb+93wCR4BNfvAo+2Muq6TGn78el1izf6purvchQZUs1L6OFGCVjMhvKitjQAmd6HmgA6HCPXTXggqUdS9RfrRk4n5hmsni4glz3SDw7S3S8OT+D4OZnbX/Cd1yFG1SxAEBzLt3rSiWH1cWaqIqYs6uJB9WllWNH1AcJXAeoI9l4/mSMZ41fyElunRqnx4S4i6oj7eV2+VsNHvzt2TGbwadFq42cMjcD2j19UUICixBL1EtB3rJ/s6+0RSFNAHPOmuc3caYAeIXCPotdv8MrZ1nZxnFsMAdXZLSmTeQzXdNcrLJVUPnYRz9U8Wg09KHiKZMSvov7Dsak0QAfFQOxAE29eZADWAdmmHEU2Ki9r5cYaacHM69qLUCyrR1kAX2gSpX1UvMu0I3ml5JbxvTt9xwuBkCftKthWzbdXQTDGVKefcDDHxa2xqWIYCUXteKPT3xwz4fxQXEmMMR+foSvjCUnsx+LfRDkjy3ZwCwr6ovEjDbxxaIjEogt0BYJqWAeafOZmF2yRByh4iyQJMvkgtYvOBYpbBDvmuskxPjradc7I9p8K6EWsFTL0WSA8gz2oY+MTaTvLfwRJ15OH/8PYhKSti8GDnlnBqUYV8tl6Pw9NdQOEl3EZPwisv1XMJPMGtG2Wn/BL6OrnIR0UiSEwJGUCxM9dk2yRZPvXLC51Xrdw7wAbB9Wv0EbA+31psIteyipKa7FNG9j32lkV5mw9cFQFaTkrtM5Fq6jbthka8kI/G39SSr0PTnf8UbvRBRyZ1gUn4J7aqpGYvvDTI1wiK6qL1nAmtrUN48//HTqzNY/NsDr8ORTLpGOdt6xD+bzWmxCMwiDEufsJ4dCQ5yWN+mfI2zOKf+iJWlpwjnDhXkXOZ4IvEyrHiDfKX7EhzNtz95vndY8cx8vgcHlZSxpDsoxU40oKDrT9hsxVxcGW40gKLxufg2AzGNY/NlNdXUWFCCP6JdUkAvuLlE3sn4jqzLdVVxbZwqnXhC8g+LPUP9F6UO3r9PTe7dl2BHt6Mj1KGAC80pDyzmHHyscGdPUBTi98m6GWTisKC7EnLAtgNYJeMpaYPyZuFkI3U+I4Mj/9WNrOK0xXm9HDD1DHs9rvun6Gg5j46PomKJ7x3vFjfKZvdxBg0w5gUVsvol++iMbF/Ykw7nZxIVcSd5o+0kWW9az5gFua0J3uP0nWksAkHO4dDJ2oBP08qOJiw8W2sk37Ab1DkfBCIBdIzDitC7cM9Vf+x5wn+1OHtD2/sQFaTjM+JGDWs5bcs1eGYz85msY5HZnTHRIZcqbmPEmbVHAlo8mNRw1VR8S7kUXOWX20u9GeqJgqP2kjNjX/f3Dx1nuAwlVjqmE2c/bJ2hWD8VDxvPpEgW6T/yNz8U3xbI67npOnPfzV1ViwusF3XxmJtttUnHjfP4satNi4Gc7UW3LQs93X3OxromQH7+i6kLF8Dqcw8tDpH9U0bpnWKJWn/3sx3286916Pz+4r06df+szUOxPsdtti6EN9xq/VkJH2tpcPh33/HiSMnuFCsC2/z8SuFoSG6gi2rKShTwzFgEyyYlfRcbGTfvzeuxKevcBh1JbJFmMooBMKy65w4SjUHrmVdZl/geR2TBzst2H9/KCkyilgFnFRtS43EURsfd1hCodm96Gn64b8Y59k6Rn4B0UTDzWVY4aiNkfO18vdJBZvtTEppR4omQfCO789khz9kt1INx3K62sLIdxCsYjV+p5fTzrf8KCh1fi+rlhKvpsNf945GN+YhsGmpVbZ55SYEmNeBnIM0epPImyCl1k+3uJIezSHYUicaKHo4fGlTz0ZHkm17aeEYil/4zc271VSe227qop9pqFdMaFQDfbjjTUJNFaazP7Kt4z6nA/pusbnHWIqYDlJ9gRLENmPvBxrglEgvED4s2ilIWhQNl9cT2PotRvLBK/k1XEoIcEjLrgrDtTAmyhyw8qEgjZ39Ly+x6hkbLjJgxAzec8NX+mUXHpI/5dCD8gPSY5/MiKBPFUQqHJ842nJNN+yfStlzZOsulQhd+woNRZM7pBloPVG80N4pabA97LuAxpaKGASfk7jbXZD2H3XnEq9WdKfqXMpaO42ymJuiZGID3iq1D5sYTbTUXxYW9HbdTDUSwqJJSG68kDhFIy8H5lcuBZQ+pwUEE6bYDIDo2+hlh3A5Q6z8Aky7Izi1gPT69aofiGIKStsznmNdQDLs7XzRg4yrEAiaMzVU8Li1j8dYE1mrCiPtg0pcMDP6Ub2uDjEegvJMrb04SyuVEK8HxxYvEgkxPicADWEoqEiWEvVneZGJdQiPOWEfCGSqFvoADESnESxMoZ8Z9cvHB339hWhlShm8rccXsapqe2qaLHS3oslMumgfU1zQ1MHHcudG2HfjVyAVmkkAK1vbMzcvvDyOoUdk7yG81EysCP8UmR0IWD2tomovzNPd9wZgEMKgIuxXxYNSSWWCWQUOqz4xNGKI4NtiRLjSHTs2mkPyp+1azRJSKsLyYMbPs8wlo8kpQhYUCGmjPBc+4JAOUsJRILmxmLhMwMThDf8q7LEon7tNHcZjDMof4NVllmZMEiNZtlers+ec5DOEEw01x2ztnUOv1TYiTJlfOwaDmCgE/pa+8nKV3Qvecyd2apAwZPTp7pxTRpXX+v5nYe18PulguBRz2oyqH+peZ/0nBjTJgdcd41MfY6LX3uWAdvUN6XqKtzTxeXKK/4keKkGF8LrifdOTg6nMik+LJ3/GE6oVKNtz3018eWIo30ePAwVDjf7o4dEG+DZLXzx4snb/u4PIuYBJ4U/RUKeAdAld4LstjX5OuzMT4oaoon/1gvGfKFmYjGJJ4T7rJUJDCY+hCnlubT33pfU3tANkr/3uQsPnkXWtEPTsSBhdICRxT4oPgNpD5EgLV7e0wpXI9+4TL8BfgvjMFRx9ED9gNU/hfqGyn7Wjwr/u+C6M3YGPsMTGLmXVEnvIK9tmKPV5BvccjdJ/kxW5BfFb3U/cmoygDGceOSm/nrN/TPhYOrT1P1fw0xDXAVCajNDKhY2Ag/Xilv3cWZnshYT5O62Yp/S+hSrB/LH59WyMOaqNgsajyBI8JqCGUSDi28yf5w5jUZX+b4Zp2oc4LLA4P8Yauei3JYPM7cN4QTLrPDZYML+8I3iGcxxAsynQnux3Fbz8BjL6dxRvyE0IIHT/RT9Kwxrxa5AVVEHegfc15uMSGBA8r+BmUngXlhqzRUJ8iST5g9xQzupTPxXM+w9aeywfbl3ou5RfrDsJ/qRciki/s8/TO7qAlhdcrNhhRk3qoQHuWwZ91jjo3W8Rni43Id1Hb35GCJIgg0B1XbwkxG4jIQxofsgtC8FoEGm0m7nF+Q48mjheEcTIsAuC9kH0NfcMefAdh4UUsWQmwMQJvZAzGquirChmHDXncV0VIBYQt5LlR0CfmzuXBKiH0Jg0o1Mjp9SRC2xTqo5bS9H+I1d3got7vG3mQr65znZSxeJXVLd2a/S0gADglO0SbB28e/nEMe1MyK42fwNq9t9ulyVewypGpavQ4hii9Cxu+9AV3ctliG7YjB6o93rEd0sFiCYT0Y6I01ivEVMU4Dt6vuI2tODoYL6wihd3Pm/gH//p6t5v3jU2DbgDKZNbI5bCXap5GkhmrDBHqRck0iTj6rFj/zWy4i+V/HZdX+RHRhx8nYaB0xfgBvKwaP4J0XgmoMy6GjglDtfbZyWfbHV5GKhCmICpXl6AccIkNhf0UXxEG75kvjgVDM4SI75FUiDGajg67GiqdGOJyntu/zn2AU/RTdk4yNFrYpUVLmKCMhso6vgX3hcJC657kUpZIMaQ65bQIrvsy/eg70tHfgpfKMz8eyUmFkM2H1QiOzzz7thqNkkHMO95IvCM7L/UtW8EgPluKFKXvm1vJQ63GXKjoFAqv24JOK2H+UC5mwm7ARlZu0duWIWr/zSumY6TGf3XIH5yHyDVFOVJNNvSmty0JPksL3Ja6GS7x+WMggqO+mPA8yJGc8oixP3YW2oHB4DLJsyJ75ViEdr75veI7S18xARu3XN+pODQ4sqxNoS/nh9GEXmVH1j6f+gyD4OesGCEoMji0a3D4DAHlrDw2BwXRSD4vkAH3ver5zZDHq0rxP8mZLKEHrWOyWul+Cw1AuSjLWK4Y8N2QC+phDTXYU5pSK2wy9mZVbdwHWyDtlSZXJRUMz4V2YQlD7y3bU77Uz1uyDlpZEOrny30os5HwubzNNUKajFqkSrNMup2ykhiydnQNNkgTeJBuzWcxWSR0+GBsvqX+YIms839XuZUREdG4G0507uDVxSwefwYHbFiNHW3pWv487U6KSA6RxFY47uAPIUWDyiSWm3qOyUOrzB3vaU8U66uumbDIi5Pp4qdW7JAwfqgInFlfA9Ub+4HsukXzWgB8NDEUNuda/Y9cXRSlFuto1yinQl2pmhR71wGdwSuUg6BrnI9lZGr6dPhZ3tY5NBcB5fnosYVK4RxLz5LAxVVka+FkdToIIc9InxttBc7Z70ycPfuw18rlfL28Sr1Du3OCPpw32fBCmdQ3+4JhdWux9PpXcyBeaJcaNV54ICF0ms6wyy8UzYHJGRL9/zwgdxc0ihaD0HWULo6ekOH6C38GT77V3SCalrDl9F4GVcjzYIansYQcwu6bVHrnchF714ed7xsIHbjbXrr/s8CyZacbFnUwKy9uyVWOsJqt2Tm8xmSDJbCU8DQEhdKFNfydX+KD3fdub0Pwrk0cySBdvTerpgLMCnJlCCJm43Obevp+Mw3zD1DpFw7tnBXh3sbmqzQwi2umb0MgGOfEd0kGJJrcw2SXRu9H1Psq8p2PAOA5izGL2RTITL/LjftZlp/CDD+FLWObbClvkz8ncLvMV+bmu+0BKcOZGIclHyYUDPPseU9DR4tzlWykInUTY7Z2o9e0bA6+1YsckkfBdduNlNjsS7WLFA8vit0nfQsMu39O9rVS7MX3zMnxU7FVunNW0dQgdEQ466s6NAdrfcQexJT1KGV3X7EOcSq/JB6DgX3UvzfHq83GgLjPRUP7TTMccm4XzZYVqCPeZCV1/bOG3ddhdBDU75AduWfvyEEd+R/WsEoZNL+bZW2/gXImNQMIhdUUhnK9XywYxf7NtFL8YJGSfdLEy6sZIJi9Bf7m0JdBOKWJRvRd4yUgPQTqONR6HT4rIOtdDWh5vbxErDrpohA3zxfuaaBDSBQlZmabxQS4BJpcfUedTkVW6PDdVTTdDCWOACpFeRjM+b3oiuu/oNI+XrImPlEsWgDPl6AryHBhNZcm8qQxu0TOPzaSuXbiVOFchYFCagJm8rGq/FPc+adwxl0kwy9mz5iZ5JZKTyka7/GJaRpNsd+lDKYCV2wKmh5HCXhPCmGwhcerIUiXzjOROhkbPvre3zRDX7pSf56uzjcv8YPF06L30eQYkUHIB1g3+b/kJ/23UklTYn5e3b0Fp1kGGHoTok3NxzHJjcJIUOOp1kGk51Srqb8W27ODkNiz1nXvJLAtQWyF2+hkNrSnuxFC6GH8/ebuR7RB6vAQCost3sqaauJ1ljYbUU35e37pIeWIR2gTQAygMWC53CGFqnceEqYqTjzP15+rKJGegiXwgP9kDcmoyGRNmdirT94pw8CBEZHyPF7dvQWnWQYYkT6qL/8YKh5DfcD8CTy4P5XcM0eAHnThhSFBbHLLG3o6tPnP9O29d3R6yTLBDsmWLU8stdTaQ7C3hUbhDTyl9urtAu0bW/nnAqONQsqcA7O/9HJUCYmJQtxEOuHAneZYaFz7J7oAyIXBETSSbfmVPR5dAFurE/Rm0NN2kzMetQpQVZAZfdbOfjriINbs6XQnW+ANhDhOUx0p5B8TlULT+9W8SEPydiUzmuKvWPsqGTVBO1AQH35SGA+s+Z2M9zuPSN5gxqbrt5OCOYxgtiT97NYBccUG7yMP4WR33QPA9i5sXGaSjwQgjBJFDgxHjjK6PatTf7s6xdKo4O9R+weXhWyG4AhPl418sWABOVIgIIC/rX+iqXVroWwteElxRsTrBcdcIAeucd+3Lr615z4n3QD7ToORCpwdvs9sYGyJ0fT5l/VOkQnpU98tOxJtga1ieHdVaeHvBjBMkelx2KD/0fuhe95OAf01cZHgDJ8euTZRicA+Hf9d9QeIpqhUIQuk2w9kNohON8qVOk9U3/l9Kon7f+L7oUE/lNCaiAXYbJgDwxFjMuOqmEVcj/DT6x/ME2ZQFxfpq5vWEKvP9LI0q75R4nGvRxoJcw51ZJQ4lFvbT4BKd9bTOfN76wERn2wW8Sm/r5/0xAP0Gh5Z5nFRq9XGIML+YvITSBnt925jcd1v97vJa+TU/OGgYWlTlIR/5XRYjNyhiTyog1EMEpv57zvKvPVv+ZV6YqtdNgvh1mg1Pg/ClSrFkq+jgxB/4y7Mx3pHG9kcshYOK36O5d3AZ5yifleUJkiHqciztR4i/QiZ0FtnEI1f8lotAoj6WHkN+hveCoFUyolRRKW047rb9yllivk6vOVWA7hNqu28/9+jVGqHgzr/BkH6dChWszb7e82eyx4qCaNmgq+xV1xMv6zEKL72+0Gix5wcwEaXbSSfgtD41gCYH2NdZu5HtD5/RmiP6N3tR4JC/ziLy7Zwzerc/7F6+cGO6/PUKWhYTcQr09qdBrXwdB3jmmAdHvoJli6fumfMdeW9wjNP5Cl/gz3/FJ33PdnCgixSDBKj2Jy3V7fgrEiz8N/lEltuJDEktnUiHni4YPyMifefSI4YYXum543YKYaTY5+CycX93M0ldjo/TXznKpkch0hRcrp1uJQFLpeLE5ETDHaPwFDR9kxQ2YZyldld8pUdJoNeszq0nC6Bk5fGMTZ9OJ/FfD41W6XDioZ9ndHbpj/jOef772tYV+F1x6dYUxbag2BrfCMH5SUr0PDrhdlPGxt5EgyJkoZRMop0gvgyrc9ZRTX+csx8bnevtmUARvUAra5+ARcs5F9CYpOf53CaWCs43TbrDL9FD7BFSWE+vK8zzlmcB/SViKNY50A1ys0HEUF4WVXiIPuGAIJMMkgHMMIh7fBnOFsrbGfBrBO/p12cjic7GJQOZlzbIQfdmAh649/CZ0cldAjqwFvmj5Be5BkCJfQNaImiHCzckFXHRg59+bc6sBwdwBJSQdRpvekFCo0pnq90M50MgVneh2wX6PTxP4aggR++s6kPK+ECM3NX/o2df3D+Z5+ucEPfe1bicX0cokzz3B16/Cue3wFIenfwVGLqZiOYGSTIY2yOdCk8MmzttfyhTPHy/iR6uBPDX8mqa4f5ZQN0e2gH7reB5JV61EHMQ5jIVOCRVk23dPsNG20G4yvEgw5uIRa6D19C7+ob6PGa2I/pbGggdKa9imUnRE7MFQn34p78ya6yqkwwtwMbbQbjR4gzt7A5fMTbwFPlvnuusctmQ2m+SMCcUNQZQCxHyT+3asqbbvJxLxxtYKZ9dlY8LgWhE5zf52GyTGpAV8Z+7vkY0VrYRguhmHUFlUyp+yzhwJNbJFLIOCwdO/govvkn5tTrumDqlB24tODKJcnjVMJy4PX8U66+nwsSfkee7NT4x9fsOdPlrbvziwJYjSDIzR9NhQ+6Y6ViJRBX2ciV2c0UiiBkJflj68SJwQsl4uCylRJgUzr1vnU0qglGzXrwr0DJsk5XGOb4SlyxwznkEi4J4qqfO8EiWsCkZ78sVIPrI5I3WbeXnf8mcCjBiodLno9kqCHZjfvI5NUr6ZE/2dYzK3iWBHpJTBhGkvh333s4g0lpNrLGDO4r1y7y13UywuDvkjiFb0KvPPdfdlbNu0274ddpImBY/BI9ESCr0PldwdNOJl5YwuWi9zvs8OL4VIm0yBKJeHjIeK0q/rK+LM4EXVVV6tH9TKr/z/xqZA6Zbu/BRmNreLRlun10pO28T3UXo/24jyi0qG3eBZog5QE3WOuRANzFaJseY7bR49tRNAJmBefoJi25dHht+CCNqcFB/LRSg/+xPYKM53rU4xumiSZsQIJgh7t4tSF/DBhREaiaI96E2Q18zbYgi1lepMFkCTSr3NwsWW5r79yDcd6Wt/Lqt5IvYkReGlehbtewHnpB5KbHcxXd8tXG86hA1i1VhcwjlrPpnUX9SDwEvY1tc751vo1nT+cHUhkZqsD2yWiRH8RvyN09q0Ot5rOmXRJcR/xL2x4MdMxPY1JyZug1HlRqahCXqG+hlAEuS85eoIlzojSiYiJafDuhaiTGHvkl3zLxrjB1j64hm5p49EdsXZi95QHaGr1buH1u5uuAs51jEhpPftuF9AZIyJov0nkUzCBdfQMF2Dz1O68DGCc5+Kq6dTL8x6/AYum8inhF6v+9+5oTNIyO02bHJEOrDvjs+fQFHgl4HQYvi1QWkiN8uKego1TRYK/1PynvtL2GySrKfKPnqlIpeq02L/FrP4gRgSGgFVrdeKsYI12KHxFXXl5QkBBD+ibRJXJZP9AZuoDxj/dakxRhtoGC615pcj3+xMYoa7pSXRFBq1IAjGoJwAdoRiaxq0eSOImFt+cFiiJqAkHUbdQvAIBNWqR6LxT41T3Ue5rozfTR82O4LaYlUl8xnk/YqEbHuddTIy8NPKXPa2oKL6MRzY1R4hrLYLCHmZ8xZAWiZ4oVDazv0A6esXqThn2zt6CZ29hNEGsoL6On8eigbaIqJ32xL+EAUvII24LzAsYeaONOo72Z9iMgQmqzIP86y9t+oEATZjqtG1HCcqGHCRNBAZWvjxMgy8zC1rEQqEceXk603VBrrL0pS8uWp90HR6iwJho0/ss9qbH2ELreN6O4weeMNIof+0wUBjJi/r+3elEctWSkMYN78iC7d+kDlzuSAlqGybJO11v58WLEBAvShCf0ch0HhN1qOMLMhOJ7Xhff3MbkcUOKYwZtL2hZlFQOSJbuLNyfC7U3Qbh7pOzcSrCGOSf5GHaMDFNsMJnBl1gTVSnSl4xuEijnFkW9KBLXWKKzeaoJ08qFmE84kUzGilm9ZH1yc9DUu/JG0JLMFutc183PTmE+/K8quE3S19Y0EbnJFXuIgsWkaK9ZPofwWWT/ucrruQBYwl3bmbs3urYTrAxYAVPb7Q2alWwZ5Dz3JeFj+ztUsGSjBLCltquf0ov7GdtFObharrB5DFsSQsEX+B931wGQNGtxIM9hUBqbAntee38ZJ0idmYzJXJ4xACbXUMFk13GSi+jyzHw68ZzjSkFyV/9mUIozd4vSeDMFZil5RWG/H9YX9gkMInZmMyVzCykc+2XUByFWH+m82uJnmTHw8Q3JwTjXVlVsQkPimWI6u0BD5ZF1+sNi66C5Uza+1c2gcoLpBMs8KwFV4GoWSddoj51Gz6GoiKOXWTHRE3eh+rPdKBZgm9DeVt5R3U3M6r2M+4Z8TzfV5Ygf0sKFlUM7ilCk1s18k+YIZnNopT8AmRN5ouL4XdEaThht25rEg2DT1XglYRMh118w/MLreEzlxJaF9rgZ/VQOMNa1TiafrC7aY6IPGLG6wj/epPPI98HvHQyr0s3jKobu4sJ2tl77YhwaiZQZ2dTPIvZyicyN2nGsBxlQrx6kRsbdNBr5uNISga0efwHdhrFFgq1C6cLJLKAwsZGO4wUj9cMXNvTGCNgMBWgFX4U+Y9MuQz5YaM7M4VcMhs6CdpbUnXx5H8x44Edx10fs7glbb6DjueEL+0fy5PuP23GPHV4EQuQ4E1o1+oMf8Bh1fX9sOxZUK3rP3OaYJYRRriaibmX95lFGufPzG42n+9LAHPMDSpqXtWYBA98bwrAjSBtNo13MqY/AQJnHM3fR8All1q9bmtcpZCaxrML27gKSY0i5aHgP70Qtp+siVIRm1QClbj12nhMT8nIRmjrppRL2IHVKRT6tPGkJrRLWjp9ZgCWZIpbjf2+bQ35iR7WpLCs3hpxcwCB7yDR41GBX0Omcahr1QfPAQkEgWzRnuBkdNA20DBdaKtaJBEncyw/6bIKAil8HL/hSqfYJmaURd0APofafg+aYpN7SLXNjtds65EFaY+tsYWpYGme1nDbSnOwuRagV28XajWiKxxPVOJxwoHzuPm7oCoppfEaSQkW4QPOWtPiMYtTVGDyUi10Jr+rhQqLWwpl0kbNBpA5waWQDFZpo6ETPVIC9McmRfb18RpJBNEsMtFA0QeY0y8pEhZRuasrgUPRuVGCRtt2Cv+f+NT/PrUx7egmoj+OVe2sh9uGJEFHUvk41QXdL03hJdHI/12+oNKPm8okWN1IAu7pYUOx7bXKBCRbFVN6GNjoyRaBnE4pY0E14C6B7/9s/4caQ9bOvag8ZUAYZY0TADruSckAtmlDkoiexFhuinNph2mnEpmm2BZ8erWvGHFP5x8FtW8LJUzNPkogY05zo0RabVayc8Wk/XfUDYtZ2l8vH2I4zILZnXtNkP3KH8zteXZREWfo3Nba9vKfJdJSdBaZxEoovPhsFdPnuMpx2iqxDBDBuuBsd+DWAYpQI8CHCCxuSw4V22LF4VLBkowSwpbbLWoKex5zcNY5WlU+wTM0onPYglleIFdsz4x87sEKe4UynsV2po0vTuw0SxKvJPXLkZQsAdMvBmYDr+3C/dJFT0h3fsaS9WkWQzzwYxvG/g6tbyaLJh4+HOsxJZZhfmJ2CWTB6TFDJfLZ8Im7zXRP2rhcKsYyMDOxqoTIb/ngWFZNAl7v6k6w0rQeKGy85MQC5yW4bU6E0y4DpaqB4Fa8OrehwJsWaBi8ZRSAf5Xx2sVsTzP4P3KX0BOHdSpYXMYk+fPrgjRLvy9HbO/iG+Sgd58ZApocg/SKrMcl443eNfAH+kCAow2DHU3Mo/ZxnZlzv7diqMzkUkz2q8JIXVYY796E1X9vkbHvprdsPKzeVYJUaMkiXAOJFKlQXrCIBfnxKXh89/vGEH1Pp/CpuCd8kSzww+hyo1lQZyQWXOWxh+0yDOx062M7y921uxlkKmdl5UuOLQNw2jgt0ZziOGpP+V3EEk/CclnomP3HNIBL+FZJI7wpd0C6HipG5EpbX5UXgmxlux3a3wk2FQfLat0Im4QNNH27wz8472k4qF5hI3+zG746bmy1kQgOC5cUuSTC1kVeBYNZY00DFH95CIOkMLFes1fgFuk/lada1iyIEZGc3WoKYa5Gm93n3cYQ4dKZ0HUhThEHdTfZ20vhvGVKzHYDlIU8Fd1EwPhVdSnHbq3B2U6oR4sGBN0G7v2rnm45oPOrJ2LgPLk0R2w/ZKSGxRRga2TgAAf3qFlmorleTJcPdm6b754Xc9EW3KBoZFj5pl+e4it+gpa0M057deViLSVj5ByE6saVbgYaD4GaXp8OxNQikrDfiucHfnbOtorDD67W7xUXnJRh09G/m6WD6VKjNNmIKrLFcSvc1pBRxa+QQOSLUvM6MKeTMzMAAfgWnzjtGpU3ghnJR+LClgVL4SRKi+yyq0Zu5ar+bAJMEVcJ8Jm6ksDFS2XfaMfQAO/24qrMtV04EUGb37eK15Q9Q0GV1wHxGnxW50GTD/kC5UdFHlrTkX/+Cmpq34Y0GaRrAHRss/02SOAwW3eEIr5vNQ0uR096gDomecliNupi3pAho8yTvt5KdixAAfZ9otO8KnsN0w3pRd3f9WLyyyqHLtamSowy1YM5EVdGPH21KVpf4RgsNCLur+zvNEKLlCYyFPywCECZcUoEr/mZKvASA2Cqvvc1e2ALNyYefP+G00WBndFkzoEJN4oEDnBKdXe9qXvdEUAv25rLR+AZJiPGUQPPp3ahSDSLA6o47Hjq6r8GxADVcmvPO1c1C1Rp5rgM7BSGKHVDkb6Pwp6lvIDCcQ7RsK3L2yyvgLWZvllpVR40pY3Y8GVztHGK0Zu80ODVbDigNlikr0+ZBRGDRfwF2iTr96wKfDFbYACpg8TXCli/+RCSu1O/NKJiOqVZJLdUM32zFgvLkoyO9WldNxTppK9ruWpilophpk+uoF14g3xouH5i4GqJZoByp5VLHKJyQO/kpSSNRnCECHvHNdeAk/PsDEtJmzof3atza965jKxsB+ueIv81+gpa0M057deWjqmGY9YleWkdrFGnhe/DFcLpdzpaP9cXmcJtRAJQtl6E9IienfBB6CiuswOWfm6sO1iHHYdbsyYrsIvAANw2ch+tpVLb152PXZ+Y6CUn89UbsTUIpKw34rbtJYiceFf5u//UKqL7Tk1HqsXyhaxE9edqgBZSVhs341swtjJfN0WsgfakVKkDw3CX9V2lNNs9rmRGzeGQ42eHc/om89pDY6Uihzz46M8iWTX1S6Qx88x2fPBzCanCFiAy2Q9pRLVoO0vBtNnIknwqLpVpSMRjkF9m1Ei+InmAZsWYQeNXh28+9LcXQeBb5BWIRN8KlCHj4J7UaXmUUXz4AMus9az23geKop94oeszNGdMdRp07ombPemP45Rn0wzD75PRuX8bzNN/hk6YR5YluIccDUjYrfMyIaGzIvqpeKS0FQhLeKa+fkHmuJsff0l4lyVrqDUgLqnaA91IwZBq8B1YRgXVXwNWrwqKKTQxLNkRc1mtedigMGYOMI8ZmbOlEi7l7xepxFDpQGmu8ziZ7JM0aXoaGGhfeB1CzTrMjdUv31Um84hsyuoSI9Mr8QfVPorIe0I0PfbFPdCVfzM8vQC7JrBbzOHumBmGdZOYbg0GNsletq1h/uwZ60p+L+qje80G4kHEbV0gLIXNVVyjHYMCfIM7QQIoZZuQ1J2fFLZudPhd5VrSeyzx9LJwsZc6fvw5v5U3s09TqdWR8Ym1l86kCOrNXyieD/F+Sx9DMPGaHYJzpwz/l9TCkn++GHWS7xJdvBY8myKpIqkDOh4UH38A8VzuEtwChWq8FdQ7QL1JVIsEEnjJAgxc1oRRQpXXi12YHENY0pdO+9ht/0FW+rruNpVBG6OJAZr2DIVA3/CSTGrQFaf+aZU6R7+vcyiJ/x0GgNI92PDiAabpu47MqRIbuIH2mjKpMf+iY7fwIeWhgq4hchcczD082fMLRrc+Y/8WxB8Y4Rb4FOxOvoNxIOH//2ulmof3Xnjc/vI7KvzFUXnj+5GC9cfwmjkiyoTRSmVgyel0utzA3+tc+nZWrwX7HwsjwKYblIBAAXY4hFw4r9SOoqSO14gl33/gJmsMpPEAAA69a98oCDANK79qnxQuWIPQYv9PoMeDgkNjUUou955mLTN5GoqnQWjJLD7naxHIuYK7fcRWpSvyLsMjP27qKLLDon5PGbFucaunLh1P9GmcwaFR4RZxOeuUaxmwclaoVmXOFi95Lkm9LcEbxN5Y+6mAHuPcA1YU/eiC+zaiRe/CkS+ebm4IpEP3cnoH4j3mPiffge88hcgwVe5GXyYi1plRvZ6cDpmMPcmQeLmibD5PcQpC8YXW9n7QtzLj1x7rW1hsDLGkkkddhVMvRtN87u5bwra9QlfdJE+aYBOOQyDIkgjOURcOr9JyPK7gsgG90Z44KegwZYJVHPkWJB9m1iMxFZVyhZZj1py2UlnkJCEF/XeFp9O9RG6UCO03HLhKujREqf0GhRMxnxImCT1abvPIn5M6Bzk3Ip7XW8NKhEBmcjyu4LICiPZxTAuXyKn1g0BQ/7ATkq/EFHxH/kQ7B2Hn4DbwK5l+8FXdQqitkfvJ6d8orbXZlAxfCV3pP3SlCm06ZaBDCOLo+fc+WcrmjFEDIjK02e2AcRw5y0dGa+PW7KopC2IUDCAccuaHS1wCToHDtLsXCIcvMNpWVg5v8c+tXXtz6iqS3uwFo0Itp6cGutn0SX0+fV2qf4/iGaReBnGuWQskRj2u9r0RpTTNepokq+F4MrXv+x82gftAoOejPnYoBSLxihWdt5xNXioz3Leul8MT3CrCZr4KNhcFM3e2iRnffr74Jjf/qLTzzYYi5EMHYef5zQ3FA5n0h1nuiYzOuw1mqnWCYmUequxYncYK9o54CkIOuqYZvLexwGYFSbI8CR7wREMu5T+o8NUj22BOhUSNVvwyve8NobRKWKA3QK6dOlyHCfjqDjl496feTf44VVEhQAz3eGtf7IBlBg5bREDivoav4xwQMKMmSqYv5nQdhn3mARE28pCMWP1cpECTVocQUXSVrqDRgWdsdEQzL+wBsQOWX1SjePRtmNsMe7eiUm/JqzHym3mHaBjZQh9Ft4cZBelZ3RVdATfayl47oGKUClXT7DpqztL0P4yi42rqv/OOIr3sTjWG7I2gdiY3beXSmX5GtsCsPJzBRxpGkcahMhjHgu7LDDdd83AAoZbYOGg6GVtA6UlR4L+P6yWZRgPN+iRY2j1+Cn4rATZd7+i3ZMSL2r318618kv4Xt8G/TcB8wLsrDGLvjdD/nzcL1mXSZuCoA5faIa8pP9MiPBFWsFpj1emVJ3sGk5mj2jDaOMaTMlf7UHnGKKhjPTmt5qY4h7vDoVTO9OZ7cRKo6yC9PJR9wBw/mYKgZjtaAwVUGrd4LV2mUlskhbBW4837K3hErxdYxapvNv9MtG22esCr/z3CIqr5m3U+ZEvNXreC8/kDTNkCRQ7D3fuhSHpCAEjrj768JRBA3grY9QWd15BJcBzuaZNhpMOBjj/NrIrqyKzsMDu1VFQ93ToGi/7N01pKDCoJ9wfggD7sRK8SLWqWCqC8krTI1om+onxP/NIMW/Rwqm/j7xwMjaZ/DjJXJjjBmYC38Ub3NjMYbssRDsXSlWWCJ2IBF8c0E++qiOiJrYbXoRj4UxjrN2DDZR9E7Enu4lMS7WEv9amxopgFeZCzsyZUOSR+LLeLl2YlJr2+e+yrRJpvofSzafCII8tn6MHJfoWxdan2AU46xwjk+DbxRr+qD4PAmvD/WZ9t0WtKqV2hXO2UUzcuD0DKT6KvKSwVLYR4tYyGEESL9f9b0pN7hp6eiXawuztRMDHHit7yQe9eSmDeDIGX0DRf9m6sHVhTglXrFL+G7oD2GXsyurYat1NrpUUsQTbpFYVaNPiT82mlFu8RLa3FwBDMdmLQpxgXkBGEFcHJVjJPgaIq4sQccPEl9ecGY5/DFtyvhed3mL3Yudgh1mS9cvbpfTV03VEPQe4f6Fm6S1ZyrjefqsTbW/ItPyDjFLkbPxHkGbWFNlxwRAkQzOxZYbkIwyCv+k7HUXHgBiH4gi+lujcbrZyrCVJGJqENbHixUqWkFzV/pnDiZNN5e6dpY7Wz4nbHaA/3WyYW7bRNDHbov5di4B+tPUShzujgrWbYMuvOpihbIHZMDiJulX89y5FK+vsWHZfkuY9jfRlnKQ6oGIeFMgIyTpYfwlwM5jZ3ftp+YF7S9fQi9b4dAxBtlx2Q4iMQrWdfB92ilDKK6j074wNUVddlxKBIF9o5PVGjicpnb13seVvEQ0fqBYAnacRpJQS3wKhj63W5K8QLIo+0I0de1Z1KRCghxo8UJaazvmNsLajNGFw2r5Qn+8/47Hdm6aH1Oa2idsKxFd8sO8rK5ohQljUjfZQojuJ6zLxkQAXLtn0GvsZauzDUmOgTVjcQq0cDHzXQ3M8ZlL3uG9FWnI5FRbHvOSh2gWhCR5PXPGEWJ0/MeZMnHBqsSQzFk0VQ28p5eH92w+oAxdGLKXPy8bsEQOXf6MBKjidAlfMJDFbX35Fc4UIN/Y4T5RIlyqE5Od/w5aoPJmG/A6jgdRDZgMEEl/nHQgSxhWvtKu8zlEMAg85q8OCRJY5VqEaUrM8OajUyOJ278YVlZqQWlZI0cIYIAXl1Mcme1KlYnwP8IkMsGykONSnS3/eLYKuiFmf3SICQJPsHfnmA0Ta+zPC/czDpev9PnG+FqITv3ZTVA7Ik8nZeiCuCgDOx/v+2KGz5QkS3lauSv89w6LUuxZmh0Lo9wO4IuHZTFlb7MsAn0023E8EeBGzoZ1WK1IwfJQayhPjJo50wO4XdVf5eNhfYgboOx0L9SH10UY1VG2UeozN6lxZzHp1jj54aKv1XlmwyVPQ4nglLnAyNo2qNdBAE7n0tdub8abbcq+bkSKODWNRtqkpIQlu7R1TL9+50wLD/Cy8LHXPCcPV6I2GwK0aV2sI+U0oP2PsRiYtN2s9mRlAwJ4slme2UTn35T72LsN7FaDtn/zFHTuZzS2ZtTJvRgHL97qA5CrD/YpunBzMIp6ZvQ8iNtvsEaskV2a6G5qwHvTJcYFRdFc6imoDEETmaIHoB59BI31rzRId8arz2Pu4gop8+v35Ha/Ra/bsI+JjMOuDUReAtaNpk4aiIIXwES+dHb1fWdcal9/Sxhn7sk5KG+HA+ejJI0ppTkpYJlpO8L9b8jwbyZKU58UsrJtC+ciiMOeacwMDoIn5eUzaA9xkHZZKn1TGkxgKHq5Z5pPZ7XL9S6B2gCU/6+hAbNnqYlqNBzV5uRjdUt52tEyxjQUOPloh35ZSXTJGG9Qj8cmqm6laJmIQBK7fHn3yFvipG7yFKLPvOTUzslIK+eek8lu+RYRwWDCt8036G7OcC3HpsDPmL2z3a/atFLWB+23u98DklQK7nIStSm7NwRtSToRIB6ahgjEcAafHMNL2oYaymNuukqwTUW5X2VXlnpUrAavx6OTeRChPw65HE+rbYVU1X9CeLzWuAWgV76yg9femP0LmcQSIl1YetW8xc+/Kj4C+UgvtEybi66Fivxh7auGhQM75bo6txL+DbNpu4lWEMcpGXbjPslIcfcboETBY7BRhjta9KI6a3s+hzcATS3INbuv8RJAqTRq1foc74UVdlMICtEge3rFIqniDZbvKfe3fNqpdb2a9hb6oRFLCZLAPh3QtRJjD3yGh/TjgcP5DDPew2D5ySivE3H4mByZ+hauKVRQSJ5RSGPPVUKrxcJDY9j6oIbUiDRryvM6BIO4ufaqm/CafoGsmZrDL/HB2UHQ0/id9ycS7NsRZjauB1oVZL5Ozf0vRyAMcskjyUtoLEiGq/rDjLuHD5cHrPFSKEFc9xtbxaMt5VUdg6ewCMs2F2kZ9au46bqXZXE2smMsjDJuGK262j68tlK6Wf/OwePxYwz8VI0KLcuq4PZGjCuNIdb+x9NNpt7EHMHK+bme26qoYEgoaCPtNt66nQYHheU+LJNwOgsMtm5Lvc9SZjdLJVyuE3ktUNJYZv4oKcDh4flejl3cfTjmAXQMhgAMFAlOgyXgfDRf5zLxlkT2IQKI4ilxz8qQGLAPkx4hvLBAXSevt1SAl/hFiUAIWaCzLFoialzS6L2Dh5BdVY7pmXX7kYtq/VWKhSEUkxeez2zUhsni5WFaJ6r19DYo9j/CZsJDGoxl/jg8KRMmOH/clWWp7oE/J96mR/rF7MVoB0aPXLzTODtMVQt2Jntfqzj5HofV4T41I4gzR2y+nSdy3n23lInTVIZS/xvOErTOi9ndxrczOY9aPBlGXWzmj7LShCkXvkhjNYZTmadaV5r8GCYJZwU+IreFF1F9tVyrgLaurd/m9k6p5/yiO6Ri01IQDc3/jgsIxtv/Jr14e0vfoWohOyZ6ht+Ucdsyik8plbofU2GM0f30NrjszRpGxzAPBXdTuZgHxaSNZ8Qt9vaGeXYYmKCM4OwHYxkg2XgKRTKvXNwbFVDGvXMTFgnGm5JPRhwtcdBjT71jAFy0XuchA3XIoXcj/fZM96hJzX6Z4fyVfuHdMNpbiFj8wBLjR1WhcCYgcEqne72mHjMQruOJbhvp7p+J1ReYO2Qask3QVYHcun0///1wmRlN04IUOZpz2uz6onQyGcBeUUd4Ll8KKt1H1BmIxUMO0NotBgQaAbe4zcJZ29AkB0NXZL9cs6EM3NN0iRH8DHZNnIXg29fw43RSTTVYS+QQcOciq5jP26zAPxFul4ioARqmLnIhd23LAEWRgJu/HhbaFw9DIPAg5rU/7R7Vj7aMKYSQ4EeDHXSaRrWsn2cqq2+MX1WdWC9rRfH1SF/XnH0dxGVbalsh0mgT3wKE/uLxc9b32r5mQYwKS/Oyl5tn9af/uGPEncduCU+WaS+w0G+HEgiUQydodxo5BD2VBL0NotCIOd/BkbhL67MZvfOIZnbKcFPiR+LPAfF2Yhq358jRgJ+P2FEgzNeXigOqQWEH7ZCBxqvFD+jqkUKo3EP8JG0MJlmmmXNBqxYHsCEqvtTFwShfvrrloTgEM5rR8KplUS938d5n0rwvKeE2H6eqt7of7A744AqZIyce8UQdwtK+R5Uruv+z/TD8xSvUqDc829V7THWfsZhrZ2ZSy3cYXzq33znl7qW1YypLJeqdRvWnkjiT/Fsnl081XDjXLiIawsLzOoNnb5PXxIm885agbVF3Sc+mIjtqWKvsXmie5AgD01O3gTMqdn5GMjLY90IEb1v7YHMMnpbnkKIbKhOwF757AK+RC7Xc03cPUQS/IF0rNn8BFZVb0cACsWzKXQ4Rf7IKUE+T1tMXG9mDu+ekkcBxqlCvJ9eRKU1OTQeY9DMdr+fupP+UOXr9a1uDFpWxLH75CxXz2avzHtBQn6JJZPtZGj6A1EJLpLWbgCu99jVfD3mz1mKd8HG0d1qMHX/qa61EYoyrQT/3bEfJsuRT94jZdZrdQOt5Wn0N9O8iyy98ldBJTIw9X87jq+vn2UegTMROthkgBwTlFSaetE9ZW/Jot5suaZFyj6Du/87LErPTD9EOkeI1P7sSYEu1fU6srlPafq9BmlGXCjz02YueShDCPPWQ6xhWEEsRwLzk+HnecOZ2CekYofCfm1i10lK7xA1ahTy0w5BX0woc8490IEb1v7YHMMnpbnkKIbKhOv+/t1lefa1QD4DExdqtGP4k+c1BlLBAvPHQWdrkLqp7IN7zmBDoSreLAj0M5Sk9HXhOFvvD0cdz6rTDCKqJJTOSefABFKPaXro2IRcn+AZhFrvclHSZ/RVfQhYbMIkoGH/huc69OUwo9P9DEEPk1kKCt2PWT46kDtuMUgY3pQVtcoxX/myCXarEy3PZ247Renrd/01J+gNkDqbsAF/fwNHOkiZndyFRlJ2QCKHuAO4eGB3h1lABxhs2XT0NEdVhNeQdMIJcVZgqwn5X/Pqfe5cXjPpYunBxM3JkRb2vhi1OhdwafQ0oJtFcyVEFw3zZ++ceQvG/kFxIw5gh56lC5VmHVr9UAmDM6BjQSKBQjYn4xmDxyukS5StvlQFXS85LNmf+GDiwNJTXaNA8G79tk35EkmAlCWnwXtzP0IGWnjGmQSwrVodIhqgsRwhxJDWHjrHyJCCXN8ot9Vlx+enS3YnXBIqIqB++d0GcjJGnPbrzDzuHsXa1etCZTh50WnnrbxznYhOnnKzy1xUrmrVJrJSdRhy/IV5PmdG+KRxHoRVOKQ6DjStRiwa79LSgZFOjXQYhx1LOl8wyYPSNdijeMWfBSsfKipuc02hNQ3eXUSAkWJzp01qxMrUzdr3laEp37i8EU4PaI1dsZxmIxYZdKviN6eQ5rEftjUzm9DhATsBYsnWRXPi3bxCrqE1a0FUJ2x81iGIsr3gYcczPuQ0iYeCi23qTeDQRSb8Gq3ageJCVqYaJxxpiYjsrP+KZql4WQEhcizMoLADoFQOyomJRVN9PxugFvUZEtoCbGzOHKkjrX2cV/yG9zncbz2rjGHSi4ic4KfzJVl73K9oTxPBDL750irie6AeTZBwnrgg9P6rXAfSEFFfoIzJnu1s4Qnr5o4c2UaSvpfy57jLhHRB/Ke0ulNeOIeJ7FSmWTwQvIyz3hLxT0oa6o6/7QJJe7QN2Z6zSaeJl+qGYeo+UTiNoS5wQsF1VvoacX6GzK1Yr49mYqHqS5ZKw8Iwfg2hW6p1aFq31k215QFb+OW1Ug7KRHiJhEr6ukQdmu4ODnhj2I818xJuksV+3p8irTF9yJaniRLy/pzq3n51k2kAskkx3IjynYH7hTUJFw9uwdQmrmNTqPq2bJW+hSBvGhP4Wkf2BBuKCQqzbzptHu2qTKuzfR34tdYI6Tk13ooytHYuhpbOx29MJBMF9CdIlRpyH0fkag1YeYe30MitTefx8li1/CZ0dx/nNS08S/EmLZp3U/igZhxixvF8OHNtvm2M+m1sE2YUshLqQGHisfMAy+AGtofrQuCyuw6M/UPeOfAbQRMpqPSBL6UM47nJASX+V0ZrW77ImdaX+87IuDGW+0tZvX7C5KILykwgLyIhkAKzMrKNbNd+rtsBPIkrSB/WLrrHiMB34hdJSjkeaWBNNdYZ9ohRs5zrBlSWSRjsETNZeFH5H42yx1emmA8wUMD5YCgsvJC9RNG9zfYfNZ54D7jMCVaRyT35hVjVkSdjgbd9bZvEosem1MuDCYQpmD+w2iONG9N+Q/nTtJNoghWcz1ZDMYVBr+2qD7nlohDPplxbpMCqBYtv0m3E9Z9916Wo/kb5t5xX1zAX4tQceEqgvfMgWKizFiI7BcAxxwED8ho/Wlpxh4YD5eqhapEs/WVAZppw9xzaIoYEXrp7e0k7SYQDPZSYoSkxpTdds/K7QML8dYloRU01quwuNEBaepui1zICgNQbE8P8IP50BtSdX/edkXBjRlGFRi2isGmD63yPQEyiE/myGoPUu5Ce7c+ddcXCplC9cXl/A8uf3QHtU3dMWm7K7kDdc7Ct9IJpvO2emlM4TxrgUWParWehdwfRUqCpil96vsohpMhd/MLUvRD7T1N9Xx/mJhC6fPzAuAWHA1eU1YuilhkrpPpjTphGggKdtWKtQrjHsFOzhBTBRnnIOd3g7WOCpvIbO761OR6TWkD2Pc/gfdzneuGUo95Ig7Hs5n53sl2Ptc28ibQ23lHn3nTzV3gkQdLSMa3tXrGk3MiO+J4tD2g3NVl1BvzyX6iQEBU9kJ8GSRJzr6I34xLGGivUClVfC6Qs1EZzJ+25aokuWKB9HHY+yX1YVnNWcwggSH9WsyLfSSPQ/0EcC4e2VubckLbBrGg9oIkRyBS4bH/pguGYpI/whAMpQFPNohfQSPmJ4JFN/LOYAfMArdm1o82nvQO5TVodQ7kQKiOlu5SvUpLZJtMEjCSDQiHx8k5oOr82JYkJRl2BGj1hPZlyg1VvuRCrPKTbpRS4CC6JB2kBuGaiH7JvAS9jBrgzXTAsDdXyiI/pStZnFW3cdYDbBZEEbl0tTnKBBUdq12A3NuvmS+g7RiRVVSjQzOr8Bm+TAOE5IkB9pXOtlWGqJ0jbXkLWKcLG+npG3/+9HedHU16u03waMjQhvV3NRc7ernkd/OLdzmiJNtn47y9J7trXf9nSVnPQFKasQspDtHxz9ChU8fFa/Vq+20IZXXL7BjNRJQzx3P5CSh9Scv8cXxjomCZou9BnszgDzh+KlHVcCx0tWVV8Er409JILF/AB0J1Lc1DHCrdUDu/+TGmXZYAowTXtXmc8VhFh9UkyNmHeo++o8cDYJBn6qByuIlWe+jIGnCLMY5GtPCK0fiB8PUYaIZpcj40h/M46nCn9zzeiIWnFUyIR21l9EjdujCB0zRjPUN6JpJeulhjeSBmBkae2pV+HbALorVsB+BQ0noG84aUUkPpTBQf8854boPsUeKXFsGQhvHE/NI0TpjmIIbc2TM9c5EcugSpEN5zODXTRFqLL8AfTiomV6e0+sEv5iSDLkmULa6D7ieEbMEG43Tjnz3KIZaUWq6YUwIDoudDaQk4NfzYOEJeUGl1Ojmz6wlRQCof7xU37GntIq+Q9iQUltFMfLg6+Jpd0GkhUlhLzh+jZDaOnkVTSzDfk3igm7QFK1hySUMRa6VeNS6neiS3gsEeQvjEVijXcK9A3Zuw1TS4YDNGbMs0m40pOTg15c1NI3HSv5EPlg7WzlEbMrNlRVQ5Hs8V67ZWyXPff0JXtadCUGXLFN7N1eNW0FkljlMnO8A3qyQ1fZwiWm1VdO+rJA81ocjRy+7eIfFGic2sn31BR3Meftjv9DeBAESFQxZH2EgkCoy5VHjOXt7n21gUpg+b+8KBlYo/QGbMwpfWpoHRyLpCeIiTyHtnjtzlhJp/hSBzede/4YnZYw6Np+QPW3RtAcWTCKRxpNkLlUR36nKghIu0UPwOCI0O7ib3pIV7sjkZQiXsp7xW25xUo69QFRg/FBwpeVeqedbpxGwdoeLEn+6j5WZgUettgkyGe+m9y8HwKIw8CeXaUamvpT6UR4ZnplRnf79rSeWh/uKWtaNuJUoX/f8d/vf4wrG1DkaAxt6jhEYxN3wrhGSy9kQ6RvATUdwEjHF4hP3s37ghYKcRLNXqAaRHoQGjI2QyXf6H3e/mV7XVzGYVOtsSgwPjwjWsuCn4HW9+qSXsrZJqk+e2lL/84s1C6hPjz+nmdxP/LEv3Fy2EUUEJScu2okWaYys3Qjja8uXx8SxBWVyP0Iyp8P9DZDVl9tiq+oiHhHPuvOcIVAMmrA+ruz0dmwP8yUT29tfaUHujvLYtqexqgf4wYcKNsTwYpFUZcZgYEC2BaJ85hW+BtOH04jyzBS6PjH1Cgrc+IYghtrkPMRGpm4/LUr0d1287S/bG4dUf8BXesyQ267waq3rNwKabEg2NPa04ebZux6Tg3JGvqeuOawemsj+k2eeshQQ0v9TmkdxrZ2zoApKMICZW8VS+LOdrZnucbYd/PrV8fGaxWn2Aruy0+OZckuCt3ravvj8OkVt79ww7ckNVWeud/gix3NEn6StFXVT5Z4LXSfA6LlWG+LXFhO9DuTwwfKj2+3Eh9g0EzbPv9D7vWIQSDWo/G/madQXjdbLy41naXA9ljmNckb3i4Qhs9bXZvTiupn9suQUm1w7aIUjUqupA2ImU4UDY/SvhcdvfsGpLYJ4TfIO3YeIoT5Q3RouR2NuD8QQDtC/OS6TkjgEv7gls5PeuR8AXTdZaVPQxtqc9Q+wSWf2Fn+Jip1lkU3iAhQIRnGH0vHSGnBbM1qH9upLbAPtWcoDWHbFrkx2QqTOG4RgC83viv9czXVSPG7fw2+KcPkgJMEpv5AHSRQAwRXkI31ujSksIN1EI+zJuGISI16xKdHr3m6UbarjMud+K6mM6nKEnsn2yfymdufOHD5cD3rNmeMi61Nw/I5PadVvQq88+ykn3sMxet/LEGW+PuEJq0+hvEI5/ciJAhIg5lXODiN1FizPP5RmLWadSUCuEPtU4YgdroIzQZP4Eif6+ojVb0dRsVlnklZUxYE/sKSxQ20eXq2JaXHVhUaJHRZ8HRebeghH1Mn0QQviAawm2lACLEVpVOnvpEfBINjHrMLj6wEibnrC69y/5gENnkzG9UOTP2YEyLxrqz3kcmq+D5eZD7yhftvzrYDtaEH0Ep7na4j1QECLGDv/Hv1iV2kProzZoF0fDZd8lmmxYahSlLbgzL6rQyUcpZ5MxvVBRIaGxhlUvXIjnIcQ96K3Tkvgcb6wJ9dOTuTa+1zGK17ZTk4Tdd1GCNxsxqy79MwQd3nW5Q/Y2eIsi65L9yd8qQnDW1ybNAuj4bKlpwCT3VjtYbMAKqtSYN89LyZ23Dc3AqrdFO+I7BciIiGPpUtS7TefsKOJY7mREi2IKhibCx1j5NTxva/VNIbZJOs1MsvfA+/9vNRjwySk2JOTESvpNSS6TF3woIZA4O/OEY8QHML5+xUg+sjkjdZt5ed7+oqwCgXT38yP6dvlplp1PkphduUVb675qb07F8O9ehwEpIJfZnW6Rhni3d9euYEfD4rBqefVCjLTogOS++XomN6WaHfsxVMaFdmIi/8HXr8K50dcyypD/1D+U/trLu7zFLu51y/Y4Ip7TPeii40gKQjubWO5TUfNdHcSoXqE7S3oqzQPhov00qxzgKN8ztoXySgQFswH0mxdVnf+Ec0N2GUD9oqXJCCLc9cWYzsEfqoPG4hBlP/yTE9Jm+fO84TtANp5FOXSpWB6ChpzzKeDwOkAM9ONm3EU3EO3flbATBrWy6FKxKfMVCdbskpjT3WuYvXg48Kl3WgYt1BErPMAMfQCKERNkqNwy/jhs88UX0eWY+HiG62sazC9pjArz/5EQaAlqP4ZKNTAk15qN4Q2Ia1spnRlWWHVTFeH8KmhxvK+D6bZR8XJmV8wNcOu9a5tTMT2NScmboNR5UXGLwuoPo/ebsm2/GQ6RWxO4jYZ99pcy4URXSZPLJJf12VJSItAjS6MjBkBKcdY67j6+6eyF6U5Y1h1VWK7ymOk/djmGBmDF19AwXX4lTQhAFcLwC7Fa+PEx+v/YMGVZFkosO/Gg7jg4/tgwPbA5kj3SLPn/ky1cVuo7sNyJIK+YGuHXe75Si3xtyONKXkTLpE8HYfR8OvZ6LztzaYR3ptRMmhFpB5VGaIomUCaSV9wOnkR5Srw5ZALEN7PAESQv/QK/Ccy+Jo/KsNjxahvnFjh7L/3TZUNlYiJT4M1eX8JjhzfDLnFQnGuu3wNSt8CZ9R3fWVfZe6To2pJyceKy3VlunPoaxxjNwTOl0M23JEgAeQVcpmDgvAJZu5Vpx/HtTHlcAZnHZlVD0/15YWG6vQgJzrwgiwr1QuF81vJhYZNmRMNWJ+iZWZUBxe0Nz6Ah9kWpwJzOrrEAZSvoTF2S0HVw8IFxhA0jjorbpkKG3iFoBFWNjGhfuEkMQDanmLkfTwDWUF9HUTLEw4uFA8mgtWlcw5bOsfkMNGbDXKFGpgS6+jhEyR2gG02tk4OJxdkpYTFf7V5poGHeERXzA1w66v6qA5j7yOzn40tHjwsD0GdOlpw3ZOFPBX8hhnTguNUS+I8w8k1yFdmn8VLabgoIES81Ys2vDALhR4apG/ABJZer+0iYtO2IAf0hhLFIHZ+hZmthymicu4qWJw6jGAwQbAxmG4lDUv/MjyFcJDfVMYjDNLSJgBwArj34bn6l+6pMy48TIHFHhumuVGX0rbZkyey1NmfDfD2kWRRgJ0cyhqXKVlsiUmjZJQA9LEVJ9s2lDFUXlN710xQyq+yf3+C5ATcNY5U7FS79ShuRP7rF2QoctKLAeGrWQxlxIr3q0w8Vrh97vvv9/R7rKpXK9xpiXAHPzF5HHzTkNn1a6t7WwRa5g+fjwsO0/QAbOMGrT6Oq+RBv4yTpE7MxmStTsYWj3brsHYBDlAW+J9ZC/kdAfUX3uB5eAdcRvwBQW+JS6xgIBdka8ympavUDQ1aZvICanOF6Lr6BgrCFAdI/ebm2PiwojYI/g9B1jRdyIx28QdyoTgWyDNRp5jwuLX+1o8twzDxqs1mrTgljQTW9Rmt92Y+AUdsAPgmRT65NJ0XoApqSVBSLwdETKja0JkrhNjmi4hCwOGN8blh8/sA+0M4jSotb6Y4MNVhXjJIEaknXRDLfBrx9YxW+WxDYKAkXiKU3gZXHS1j9XAvxonmeijeXtWgYyMe5aD/5HOEx3q59cOsR3TOHdWYziGE6Nt9TxLllGOCEEQErxZehvDcX9CTv+M85799x5Ln4OvrdzkJXXI84pwtzywGyerCWugXYz+QW2zhhpiLB5E2Ljre4kAdG3RakRBReS6F/jZhAinY4k1CmkdXvK7tSty2RNkJhcnuAwxOXTqdgK6fVSp5UPjodCNH2wwHqr3HLg3UYBngwmsdcDx+iE1V1dym1j2EvN5ucp5uo2QQiwJFrpJDv5v+Hf+5HMVma3RFJQvdWqrLonIcKb61nRtSv7iO301ore5pMRzq9+Uw4NroliEgsJ4j3qYE+dzRbVvF0/XFbo8xe2BzrsZuyGpaFsom3bTbS1ePwXrFrD0mxIjXG5AzgAROOnOi5ELwkbS/4zFVh9wMNQLuEKpD2m6JvyLybcRFuBlKrR6INZQX0dQIUsZYn15W4sDLY3E2ITxP6JybEZ7aHyL8eu1/FRvLwBy6SIvVq0vQRoQi5Z5+61C+STh4/M5+GfTkCI/oRrJNGL5YWPXQDbFthR76bIfYZDz9cB9vgFbZz/RDOa2DWJjEAG1zg7hSQUzKL4QUyAVGfNljBRBYLVPKgqXlnGtddWXF7aSc8ljuqLpol3w069IJBlUvRNQCjgYo6VPC61f2LGBxdHm8V3x6JkoKnLdb8EqfDdTcTZY4RukR2K7mO2MWUkLHYqzhfLJb7HAtFUf8Tb+J3dpc5IMMmIrvkMdsxmp4DsbqMe6YI9RyFCmfM5E9OmAnZSxEy+tPDUsqgKt6UQ564vLlQmtX1DIkUcGsKdJPsOmSR8w3nDkm63tb9KIJdyprt22XKatP8g2sbeSEytWp/4zvo9FA20DBdbyR+z76GfTM9j+y+LES0B/ROTYjPbQ9/okHsQfAXkR1ZaRn5cxdyiUQT03oYFB9eYdk73TVYqxusDJGL39pSDO1qSPCJTXq6uusYSKfaJibSa+laNmdXwoiROZkh3m+7ngeIpvSiqlF2nC9i/f3WLszdyAqGprfJu59eeTsH0mZMqO9EUlWrXpMYCh6uWfxWLQTp8yPD2Iq0YfUL4iMv9Snue6Zy8C7NKbQ6BAQRzfXuafIauDtvzWwjeYvbA512M3YtyTnIHKRwmi4auuL02GKgxQQuOydcIX2FPdMM3CE7/15xNelS9r3Kz8Ed50FuqGSZgQRFasD8ZV36uKeKzBknirvAg4cp/t4dexaRVToMAlGBjwfyR5rX5DBKeggYYkPTNYVrmvIcSBKk3+YdpC4+qENDYcGX18mvaspDMPtY6MLi3TJ7m3Gpwhg19lpsAWyWbRN7iOx+yFecjy/bw+JaaeuMpGFTKoIdXE/vY3ndfFCVExmhedkBIg7XyORY0k/kBuevg3LMlNqK63bfMP8U5PPT5tE6DQnZ19EAEcsuOxa99ptQi66YXTo7OCWndCT2VxQRA8qLZNFViVJt5LuscqmT+QWzd14YwOZmnOTDI+ocfXAVY94a3Lc15UepcGrRQig6JlDFsZvOiXgY3G2GG0j74oSBKLgwnksQnfO5/RwuwY7/+8bxr+17JrfyRzs6woO5ANUss09tnzOPHy60e66p6plWuQcBKck9AjmUiXcBDmM8rEAj74BOvOcvP+jf3GYQfYDMesGcOYR8RV0bRepH8PUshE35U8JLtNSZhX8+SYWGJdKNEheP1i0nQ68enRbnsmRnymJKBy7t8D/5dlOmQD17yMUBvMKqZj705WXQveEgX9TgbDfVKaKYjg/oOky0PpRrqa0ojjp34DjnKlXXEZig2P6VL1NAgwAjT8vRp+/xparwKVqxC3ZB+QMEvtQvANy09XmiSGDDpe9vTBMJxl8YSaSnPjeqZjtul2h5ZIPGADOtT2Oi4liz0L0mnZ0uCGFumhxJDaQiASmCX+GN2e2wswLRrI+7U4iXH+LUErl2UDWQy2P0/Iu3L5kTLOBQseCtaFmxvqPm3KlP6dG9I21PTvjYPLTotgTnLSrfHZ3K6RY1mje1ZzHLmuv1F9L5hPOkjC/rqCaGtW1UqVJ9SKZFPmOCSUYr/4TpEgJ7WUgyn1dxamF0OwZVJpGqxc18Ic4iD/BNE8DILXWdRlzEU29bBu/9FApkTY0IIWYVdLv7ibXsW8MVdYx5NLkLTHlOc+YA2E5qWBLvcgSlfgKRl5z7a507HZHYmZBCJHEhEA4pSw7cm4T60OlzQ5YwAzWfMakgKODaofVCgG2v1BTVWfjzXrRB3hS76YAOIttIchYWHafS1K/QW3aUBflS3rVBzyUWDeaZTintfysP/7AKqdBf1AUU/SRdWXnTOP2mkdkIDCYsPHw6xYhahIpTlqMRJ2/gZYCo+CFx/KxO6P7rvE6icaU8Wz67xOSZeUvLiXtnKV2WmjiNu/6rSYELvuaNG9o+ae8UTT2PCyI//PIRE4l6P6kK6hjBfDIvXOOlkGNhu4kZRkLBoAawQhDCmtk5Fha4OD6t5g2wZR9PjPB+DYCRUbTjOjjDuvOoGN9IbUzv56hSVz7eaMReaMK4tHe8Z7+a9UC9NSwL+FMMkx007otasdCJuEDaW/9HJfJyPwaM2Nu+MLx3d8eJ2dPsGnT7X8MPCj7ISjWmjQhpKY3cclA6o80uxrcScIsuyS/Sbwy7fQOvlDxP2P/WNb14P7A8gCTS5j76EPAH7lDUNJswncP8EPEUit5guHUSVd4EG4Mx2LEyXA5F3SNZL6h5mI5Ckde5kX1W9bUw+I8+tey2w+8U7ym2FbqOhwEAH3vw5u7LUvX9GmCU1hMS+ifd4ZqYMslbBIglbSl2ohMC54+SzpaCzxCX+HRpnOgBTBH1UJqyZbIguIRgiNcuZebtYPfH5ruD8xdFZyz27FEUVnCXhi7dpgDWXIKnv9YCfwPCYuO6B2tK4wRhcAJgHSeux1jlq2qhmkM5haHfeaTigEowHq54hIR00snuXNwsx1Nibb27tvvXGekPvyTViDvzlsDbt198sOuNNvMa4ntaKM84R+CIhV8o4CFLunnfMwE1IAAAAAAAAAAAAAAAAAAAAAAAABCaN2EMlcSrKz2bVI6HBQHutCoGXE4NeMPLRZQjh6JwzX87kZ8DCCbLA06ebkZ2AQHbkA0uBC3i3zDYmFg4jrLjXQDx8cvQwlJ1aopl38Vc+wU+ePEQlHBHVJV683f4yHyZ+nF83582eDtjYJN75Q8Hze5wPkoSaoudR0KRoInkhXPHLuNLZ4XHzwzre67gmf/cjOiI6tVa21LvionUTelkih0PTT2Bpr6NXMWusK0n5SV2B3+n+ZSi6Q7JWCUBBIGoRKGmhlxFnORxs4elo83apnwojPeqH+lGsfRPHfkeq8w0P05rrtmI+eR0J1ilZ+8GldXA5Z5NMj8cxnfKzhVXRZCB5VVAAAfbAbMA3dh5+CS4cczdKAPuXgmCmQ27TRS+B76raeAk+TqnU3JHoSHM5VWb+BtyGX8y5CuNcL2CZTtFTUM5AqHchHi/T/uG4xGSStttPswRC/RUZQ6+6hc/D+OT6PYt/i7qs2fQJOmImZ6+HpEuoU6ABQ49FOb8su4MXxeIx9HmZji2k1+homogasdSN+zsqAIoWc09F6GtJ6syJmHLWsJt/Cq6yI6wzHLKZqHRNEGV6TbfY5xj0CyDfHkq6sLID/w4/L+MFmNjyZrMh8I73LasqSJbvIKgay/cQe5bo0MLLU7AxIOlIoiOqVDFEDPn4NWfnvoA7Nl1ISRfvM+qEe31PNkINc7KT9q2dtzsM1p+hUZqinonQKcXPwFwJ4eIwylAL2o1lDSDfYMkJJERSm4Y0eDrx4kPn2P+288rxfWy8kyM2KS8NIboIZTh1MdyIDyiRoLz6euvvoE0joENZXDr0ykUKNIM4JzZxVd7aunBj5+rGgdL3pAFJIY8kMZhSNil7q2FcDZE5XMEgFpKIs8g3psL+TS4O8EVoTr3Ea/qSmEc9XLR7oEUqefbXr1I2Gf2AdD1PdbTWcQUbjt5oNoqcQXWQD7GPC0qL4Y2uEJ+yEXc9JoxfNPdyStzJQo42kMdIdAv2nubcXzLdnU4g2JvhpBx07E1YIwVL1IeJUxo8astfAOXv+bO5cXNZU/d4uTpGH05aJ4lmOIM2VRsK5SJ0kwvSz4xhjjWfBZcGAf1B+5MaPy4+vjLM0wuTXgQ0A/dYQPXVvfOacWsqVkI4zkXUQBMJLlA/RrvgNj6mdbVEa/4RwzAMhFzrs842QDsGlW5mZR7wKrF09BAdDbkqFKgYQcWu9IwVnwJESHKxMVudCL5hedzKDIO9tLjmVKF8k3wwqhRTwafzO9SIRZlFsKew70X3v1Loxir6NrdDJbK+C34XuhuwWxy6t1PNhVxYQAC5/uHqbn1pBpTiLgNo9NawxyV5HfeMwW3GzkX3c0qjDXiKRSgPiGCqb6kva4be2T3mnfnYpAoQ7pNIBX5IPG423Cgn90+beynwg4A6/MZnRICOvP6ElBDSABBW/gQ8tBH7+mY30DvxOKc1z8iQy8vzpsNpYwK7XghxVeLecN72oOKZBxjcbatEcae0dmDPsh2+q5/qrsu+yHuwLozBV4gGGC6pAzSpFm+X2PmmUGwdJKzlOFJmCz6PNW8btR9hfwcefAIuSRxoqhqyCyjx+rImid79ZmIvKyAeWVJsqKiwxDp5CXq6hy16TWIj6QfekJbbGuNyHD24StVu+dygIgNnJtufPC2KpGznSveTuDBZgJl2xcqRanTzQItA1UDQ8raEW9d/EzQhaXQ5LsZKx4BeJp9csChJNxwQVUlfCvyICIxEgZ5KYlr7eI7vLdGdZ1X51ryX4kmLgM++t6MOiKDIHm9uwRI4XM8F84l02MjhdHTY7yVH1GL9pzkaOv4QFrq6xtztaseyPp+Fl7fC30qd7JFCgNjvNAf/KTBuzwL7fnxWyIZJLy7jk0LNOcJZpn6a4eK6F6mZ0pWkl71G+5MA78WUMoOjzVchdd/EqNoBAcJ0dIc5zUXt4bTW1PsiICeDiuBClRp9SCZqCaLsXr8iwm8+flYR+xcX0sM8HaQjvaBlj0p611IIrzUrlULx9dbKlIhEoi3HWef3/1LiozQj9jsaJq2G7dbH+FX+SNpRDrj8u+aSGvKn2SEQIDjymweB1iCGrhbTVk0CRFLd9313pa5B3DDAide1P6RV73iAYz8eiCCzv6e53OeaqtQLkx1VRKRsZQLp5t8VKGX4kfaCK0gK9LKQigg1+xExU7FxmoihveKRUWZqIxK9hjvHM/ZgnZ2Vaz57LKuKc0o0uNQpdgtacfFrWd6Ce1I2Z1ooO93MtywDsGn3EhxZ4fC6dn4WzwX/4YRv4gkC/BOgtHp6XF1arbmgyOm83Q5rab3VWyI4VXKfKsTI049KHsAAnmclm8/+tD/4VOkuZpJpnLJKoqIMMUqykZ2ZJkULJgMF9QwNeqPBTxFNzb+e2vZFkLOKpm3YyXN8H4qx+qTDNVXyXz/WAQaHJjP9T1iiMh8J2dK1HibX9Q3WnMcuJ7q/DE3UxC+93HnqJBLlA8wFzPyIWeYbs+rwbNwY4jPzXPdKKSVzAfnkcw072+gqosw9k5t/9gomnYUCcAZEloWXgC3cHTkhKflEB3yXEvehafOgBgNBoLWx+84mZ7Q+1LOgDlGX/zqCCR/OB3GjVH1NeorZB4JxcW0I9AGdTwZ/ElTklSd0ZeN58NqgaNjcaMusnuyA1izCkqxLR1iPAQGz81z1P7JLBQ+pV1lMjlW/bcJqseHnxiLhvwyU3pXQQwVcDqtu1LjuQ+wlFTNXt6QxgiuQzOSb2JIQ+MZ/UL0BfI6u26up0f0seNW/9rJJfD4xrVWLNidQtOFZ2/sYXG6QbU/Ez4uW7hg0BKtwka0L9YhvodoHv1tg+kOMWO6ws/EgQPKgrtHvVLbYzxjZkscBO5uTpblGpeFn0zu44lmdK5OAs25NPxXi4W9Toyu7YNJckh0n2rjYbvS7yDdzKs9zSu/3dGjTmygkifFIZI9kVBWdnU6qZamKsPxUXGo1F0GY/kbUUkrmBjEFuECG/CjWlHTCAdhrDq5j4OHyMhyBNtiKb15a0DzIxRwzAEUJlbXYPcanUuAMKLTxCDDc0vI87qIUeoOc8XtQEMx01m+QiIzL9Z6Y3jcC1xKw7vF8bPT/d2NyO8tROPmXo+kn2cGKCA/VLA/Vx2eaPP2VH5ox7YYqSn8Q8ZTjZ+t8xMFc2ac2nHWQbS/dzIc4PQ7/pZU2hk/3233lzDGuIvcCclstkAg9b6HqJ3RYs2KaKWEW9fi2e4U9ryAU/LOq9kwDLrJy/yKxKDLOVE9SQvlQhEnKcxUdJzYGC3GI8o//LuZ1RBPwdkHf8K/QDn5+IDUPcFIXfhZekPx/irJva/XCEJ07SdohVAes5WD/osuRwrNBjJQdq9k3JJ/d1t04maGVDZw8jsrKECJol8Hr2yUJ3eZzsgREIroe8TQZYZgV3yGX8u89mdVAXru8RyYDUbBuHS3z2YQubhFpFE1V43ti5JXsg7wEEdsPOET5eYroq81CSEaDGowNh1XwzFtXPypBJgpLOdd+NQ9adwXNv+XwId7HVkZjT6L1YC+oFJkBj3F3k5kcWtp4sbhtLpe13SEQVf612QLQ8sV7JPLh6WWBvamkhCxs8Ogd9rgfU2zPGRaAwDrC2nEuyUV+lx9bewenC6W0nFfNfTI1B6wyRg8pflaxS2xvdcPJ/vcZNkRYbmF6XLTaAVGEVZ+rxpCOz6Ilc7eF0XzKH+KxTu4XOKRHyK1dMmvS2hSAylspjeDxcquwkDwG9A7JLc3CGPslzxhdMSJHxwpLpLkteYpiYDtrKeXWpdz2RHoE74zSDNnXzNV7oKND8PgUhMtHvUgpHAltZbTT9oV6qEcNOmGdfy5sxm0EyKOVN7sZNAeZr/rKp42+cWhgy+WLhzXtZfpXbtMxbRoEX8feCzmUxBgcywFJfnIn/JfLZa3OI6DLdH38WvoOuTEOnpdYYOnVb0ExjLWQRx8AswV/KI9CW1EKOuOuGL8d7ve4PSeO4sLEadCYLr5Adgkg1S8yCUcElHRG2EF8pMGV0Eyq8VOBDJUfmUrodewFKtMV2bw/pceWvWxIeOIZBfRNQUcKfvrkoqB8OGgQkTDL0UlJPus52KZkbBQR4+7X7pU8vWSkjlZS9Z4pf0jddzQby/B8GgDTou3SS6dPIHBtzGvssm1Dkt2WcBgMgaFQtW+u/MNY4wKNO4506MU6148hU/C679Ep1+FjU5v/jIuX1VYIgx0Vmi0+qtmv7lLCdi8fvxkBIZESKLYKMOs0ZZEVkp9gFdzkJV7oTSt+xvqhQGSzQ+B9sPZlODPTMhiSlN+Y9cNdw7iaRWfQCMas2vmtoQJWCJRYK02Pib/pKpBZlbEOcF2yxIsoT5r2f8jlzI1jD6LPR5uhVtUoe+wXKHsnKZ6C/XeQwXeGECPlQHRdoLZZYZTpPMvj2HU7vO0/Pw6I6R+02k/PChyrTjpGsRhLpEDNCW+loqwHXgxbQWL2NSXCtZZsdgXfxaLcgv5krfWLGbJ0rP2sJSXZ+2nTjEJwOcSR8KkHLmf7qeMTZJnVCiAeSlKYL1SwHgBCj3fAHZKv2zM/0CDfkgdSShaA/8ABPCBdcsR0cRyUPo1x6LTBvmK7MsmPPVDGRYOqy51RmKEPf2LpxSmVVTHVbuER6cvXDFYZ+oVtR4hs4gJS47Fe+PaZGEBM36GFgakwLQjc7fZ0LFTYs0wFEGTVIl+DnkV8BS6ptbo0LovsYPwFf9RE+puzJ7QlJV+ippKVlbrKSDAf4QdbNn7TThACCDnpkyxCXr1IH80e9vtrZcQZsDV6F0gCYx9o8Sz8tlkCFv8kr2eOxtFoXuA2b2V/KMefELy6/VufawpoBHXiE+bdUt6TI4hv0KVMmlNTyx1HCrZ2wMi/HACHR7KaFjAqmdOgCA9Q34Wytb3xRw2Y8kdhb0jkDcsRLQhgE+jTaFfUMq+jyP8c1fp+Cz28tiF7WePVwg7RKAPBzupq8d46DeroqVP5zRNSrG490GElbHam8NaMpzhbqbIJOfPc3m89m9hTW0eo6s8p9uamaolOWIyke/YGRhQ/d3YHODf2E64/svxEyd/46VxG9ipRbgBJveZb3UtNKZw6S7XlZODSm2dto4HNvLbmXLQrGkTh7FGwzrdckSWec1pByjezr5vhOYxZs+63KY9iOGe4uwrW7OJ122Jot7bknWrF7iys4oioWkDNjUZVP+8LkHXb742AiJfSlKdWAjfFpuT+kplRN3KOwCn0XVdJ7alcSeMRDoVKJt9pxpK5cLK2sJLQd6+T4Vq9qib9cr5ytbw54VHHK2hjmDHKy3kL81cYfWvfJz5/HGr6Fdh4KRjBXIX9ks+YBdko8D7zRTCb3rnSiQd/OG+92u29/TigzQEGUwQWPxTcmO4TIRFBhiFNwLAKjZQ43yrYL3gpeZcYhn4OpVKC0JntvNYlcP+gxpVJatly1v09ZZCyIuvbNzUIkFk2G96UWTZv2RSKh7PcxJ8J4GMAXIRurmIMFo+pXeZX5v3Pq8Tl23viBSz/140pv0lXaR6ByJH67F/E31ywf4UKWZHyZ0kwAjJ7AsAiCqr6chhOCyu0UEXYQVquNy8S5uJTFijPL14MkKRiE7ARQ7MYHR/KO3PyXA/qa1jqmg6+qnRM99FwnO2dF5HfxO04Dv2WklE56/jDUUKvA51exVGbQkFk56BNPcyJqIeziIDx7+cxHSz9D8VMjoD2gr4bD3zsruQ0xuf2L9c0eDVcB4i7kjrsI8iAcxH2hiXhfjYXZAFcaGlZGLCxxG0xMFdhjQ1xaM/hYQgekKhiQbyQAfGTW39njhhMwO6EYtYuF+IgGJFCZmjQObmd0m6FtMwWLLFT1z4QzEH89TnqqFkaOkwZc4wUOik+Wt5W6QFMwL/Qmiqg6AMRqDZ/jhgBcVbb31aNqVOb0L4VvXIaZuXpMRAQZvbd8BqMM0Gh3769p9lv8OW8vU6WKCosCA9ioAVSfczVlAouzuKjBnTeJtvcBJyScxSMKPTaD2B2khPs5logpVhoEp2bN96XkO5T9lKsGXziWkS+Gb2vLLAWHfh1GGUomgxNo/j1YUp+6aTTyW0wOisY+ZcWrWHF7h62SjICOX2LqIQDgiv1rKwok3D2iOPyQSZUC9vwFkiGCZTtWCNfIXb9egHNp0EtaCff4GkXOn6WMTsQkfn9xVZhStgpcxPgewwDU3XSXxHb+iFushFtpUrKLcTZZf04g8886S/q2fSphCyKL/8Sepo/Y0C/dgkXeM7sY2I5O47QKAE6Z31FANj8PzQ4j759XjR+0w5mxpydB7cITMU2TaXI3Pmx8taW+2ICjvb894f6QvCz+15AJInQYzxmzUiPS10jIOLH7wF29y1l9WDYU7/zkeBvLZb127oTA3F7ymRaorgK3YgzOZEx7iAYm+0xyHc4KwUpx+DzSaHDoucHweFqIR79VSqqu3BetGrwVG/W8kwuHZieAAhl0RNXXNKQPKAEns81yGHhGcgAqvGYYpzQu0J43h4v+FqPEoWCsldiZdWAUCdqX4zRA6ydU0lX/tXiCdN3/NRytvmCOlIFTzMyQIGTQMxpHD5MoYj7Vg4BOJ0yUBpkz20Kxcz3SNQ+nNewe8Ak+Az8g0YUDxUJPUQFN4zMNw/Ez8lqXgWAtC7XjSWPd93pPEhCfILi5aUWc4ePt7mky8tVaUvKYrT9ynWmA+w/xJ3Af1G/cp9t+AKNffLZYf65pXwPfF0X3wNjRREcdB9juB/3BD5U8LC0wIc4IrJqGpvYJFfIIMaZHUNL6fyf6ZBE1QsddrPnovZMVHLyAKuq5wbEoSYTjpLTvjsTlOCrrpnZTpO/hhtTI4JXvXLOeIBNBj+iNJ8LNuGkkQ2yrKZB2X3n7z+Q3mfRzeaULwX3bImjEVMPwbmSkT3TJvFPco0NjV/NRfoczaRYnUeqw+RDMfVLAL3F2E3fyiTGuela8O2IOC2luaGUOrJ9EFthoQ48SL5KdD4kkYNKDBvixh7Dht5wP+iSizCWqr19BLbjtqeU5alaOKm67fHHZckWsn8ZOnhsad0PKG0NAYJGVZs/uaapbYDddWuK4w7NOa4mSZFXFKDI1/o4USBg0Gyt4iy6V8bTHQJL4wUBgUK9GYyDUmmlyT3ZEXHij7nDH4pDYxs4kXY9nOGS6+e7sQzxixHXXyz/hfSPTdPXa6RCRiq2Jp9o/2z8P4tKYQSgkE+o+GQ8nawaJjhBCuFmRqLO6AHA2nQdIHsjdN/cNikEcSmxc33YffhpFZMZhjaYkoWd//SxkDih8YpnTnWj9ikOqGrRma6OAje2vBHD9R8sKeji7s9YPSJTWm8P2xhjajZ2r50w+4RSNctWkcKpxIZUWejWepvavcEPQ6m14OxfNGTs4WASVAvolIeehnPyzNqPjsuqSYzb0VeYujS6t7JErvQJDD74pYrPm+WbGxdZ+9iwLKcshoXytVCMTIoYQWyK9fmKewgMy/kWGP+u8FN+uN3K82sA1gdaCtUzd9F/tD1m7MMjyF9/JLbUunnQtTpF801TIAeH+fsASlLVBQTN+Px4jDkNjy8QvSLYaCgxYoLZEnB/u58PjDFvAQFxwY8Ub+2G1DdBCA5mj+W7F+gR2NpXr5IIe0YY8t/18b7X9ig7BWeYr1MskcMnW6pgvSBYVAe8cMH+oBhTWAJ+WcLCZZAG+FtgBE62EEXNS3iroe9DI9cwSuY7RQEzF7lLSd/wi6JVdSbRsYV6+sVsERVEuf2syI+LRMl861t+OruXGQbdaHatOWyNLItVBQTgIVMs2W1ajES9bcbe8Yyu2qaH/3aEnh3PlL1ywO44fAW9M1BCVTaKC6/vsDbG56QairpUHfTRq7qu4hw1GxqnJpMKblaJlynJycSeOP38f23RK1HERe1J9jK606es6HZJYsozIKLQ4eGuxjK/qcIAAPgicwHHYxm8I8fCy6vDjrQRgl428zg9wttPl3qezBg8YHTdCtz3mVvD4JN2Hp/eLcaSUHZdJbJjdfJ/eZvJmH87RW9ICL5IwjNXyjUHr3SrRzNA1JYsQx4TofEM3Rn0aSx5yXApf905phHcdFF8VyE0591RySI/etDBoPWxJ/iISBHVoJ+K1F/KjL5pGdyYPKC6xCW+nak8x7sCCPX2zT7JC5y8kY2a4WLv7OURePpf8NR/mL4R4RgEhO9btzx8WKV/LlmDCP5e7DluEq6uu3e5NfVN9OMRLh300HpPW6AQ7afuA7lU/OoMPPceplaLt56PLHZZfGPEkHCUWIfLeKPcgvqf/th6U50ofYM+Rss7bCd30o+FFwJFEoZlbajgnMkNDhnsJ2i/nRi7SYdwmlHVhSav4ufzr4JW24jDOKwxONyadxKOAiphxl2nhWP+PxxFIiO8XoD+uV2L6HfT7fQWuyuZJBrlTAIPwFo+Fn06lv6YstbjWBEpZKks7B5VuC9OMwifLG3cPkWm6zsfVMnRgWQ6YOSM0rukAtWPdey06s3VC6kzCa0J/lr2j8YQG6w4DRL8aw9/vjN49QzF2z3XVMiQOYH+6/LdR3uDT/5plQmD+6cnTNgYCb3IXuEfq+iBMD3nTJB7Hd+Qan5/SPd74imXIgFOEBFJqwVn1ixPRo/DKy/uvwVn1ivXYRB+LLlH5IwC5iC2UHAY4cWL/19zCh5d6qwSFMhLQAVDT8OMLvA71ZHlLF4BAzosmod2967heSBXB9KOwphBJ/GXkYSHPcpZEvnrQgCWofUDeQXQIs1bTGjGIGGLa9aTDtR2e6m/DQ6t9DJ4OyFHJO5AWhLtVyKMaZZ7Z1Eaxg8odEogQ3wqKHqQkyYjrPENfInmdcDKYSHVmCXNWmG4kAWJI7ofOFJnlUj3RtgJcypGt6BGEtVAPtllck3UYVTd61HrQGgqSZm4fuP+u0W2oC2G397O/heK13F0KQf7eedIypOjCD4UII8yY2EjcijhBlzZR6S+DoY20xo5WUK8mvgB2LhUoZ65TOOa7aKsAILXr0AnxSHrot0OS10rtY/oHhJiONDQBfrQ7rt1VYhg43POLFmq5ryG+StQHoVUoEJ95mdk0YZiZvG2pmkmCQJrBbES44jAktv64EWikc0IZTi2Xwv00kDQWH/lE27AAAvb6ZdoddcukhRIQZYoLCr8ue4wbteeSiNd3Ifyo1kAnKLVFh0xYff2Au5f43qOVyNGouEH5NEzabQ4nXbsusS0o2y4fL22LIXO6vwv7fpYhOm0L76HWRi3T77wx26h2CZNmLZflxgeGLsaQqhvKaU8nyZ8rKDw+yoYWBv4Cr3IlNwBGKj8qtjIV1u1okDIDIoxEhDfOe1308HOkGxq2LCq0LvzdYtRvnlJKkgExBSQHIVmNoKrCtr8tecyFfCbrbXtyYF6JSZCDOdZz+x2mXVVuk/8oNY2miE13aAFS1jh2RPojcVC4dnqWOPcj7MPCW2xxdCz55qS1MsJ784ZhJgzGADA6X1j5Pmt+hu5xDPq81oPQz7BkbOXid6VOi8E69PDcuS6LcCQj2jIR2IrIc6OG35gh3rgxqXYtinZZEiWPfQwA6zQVfnrGjpHdX822AFd8hHg++GIyBvuDcYDx4DX+nyqZCD7t+MJ+v3iLGAkBb+Exz0EQq9aQ8dt4xjKSjh+ZZaFsKRe8c7SluqfoxDQ/a6rpC5jZg4ra/Gwkf81lzB+mV9noalTa5sEEHdZ72N/tw3xG6cgw2iIJ08L25553j0f9P5yrNp/LoOVPHOlKqCuo2aYjeYBU1CxHYgrjzLuxgVh2OD1CAyMf9ARx9dn3A6/k1gn1cp5EgrKGNbJVlk6fKRP1Qv7CEdQl5n8XX1tbLHQvD/YRVy/i8q8cahygA3sXDg4wJneBbbsPSDjTQqkcr7FsUTLxi6YXhS6UHDxH1tThD1nDD8YB0AgdoTIxK8uyHBUE5cpwABdVCnuWlFnHNSvbAYoI/NaAYVVboM7XRtUwTQfbOQVKoBSXZaEHmr/OdoOpZ4pdeWw41wA9HcJVoxZIBXLo2qYJn+IzwWiQxBqscWD3gBOV4RbxVTvktqcOSY/CQhwBFBmLt5UhU+dOD5hQtwq6wNd1TuBSUrAyNZLCCGKVPpVuaQ3F3+mnr/5rHCP2G3VCh2JcLskOjxrQsGbeeS01Lnp6S75bYCarpgXZpMVlLhG2NxjPhWKI3WxdtKKpRq6mkHCJ1EXjihJjY5AJsKlueJ1AW+NNQwcDx6YS+cTsbWUN7HNNTRn7TKw9ZVsl6yw0MF7q2BZE7lIdQBUU6va0IWMyMZ8dONDxpg/BbfLlgp+b8t0fwPMq7RDMIuBFqTtdaYE4I47vU1HpaNMcKnt9Nv+xzEoFcWM2xuNs14AAq9Pgys0tbdGL6dGaPFBK7QNnB88UGmpAbMjy5zHoBje/AsTSQczum9ck1tu3zPUyN96B+s4lBpBRWBQvQImBKF0oqMWDfLJp+pgmiNbXL7tVcMuIA/zJgkH4v1WInM4qEZT37YQFMZkS7Umomq5H7lNs0Gke2SxPPvRBFotaqfXXeBq/H4rkR+rFnEGRWzNDYLA5r/9k+Jw/zoAyUksSRGbvqZ4AKJzmbbb0lq2aFlsmxGT1h1ur60tAz1AnaZJp2RAxxnNP0cunx3jScRDEXw8yOCZUWnxkD4QSCGhBuC7SyADCj40ZyrXbobOTNpcAHyqv7BDOZSOMZLA4d2MqNtQzq0+CKSTWXIs+zqAtmdinkiSiqPLJDdS81Qyi89s9NWxXG6bL0qfDCiBhZmV6aVGWhZYVEy9+CAyK3aprgsBJx6blpRXD/Zw2jeXbNGeEoa7DlDdfAO3NTmrBbBld68wS7qa/RlhnEgYGUceWIPf6H5uida/9CPKO06exxUHXf+sI+5kkuVwoTDOywEXcb0ig9FWUXqdqlAowl74sYQ6PSmWVSrdgTp1Anmt4RnViFEBibUziZKCh42PKlX8QGwL+hDWzL6pfblx8OgwdLQsBhS1RetOL+dCNPywNml/TQqxTafTQMWPsdeogImBHga7+ncxSJLYixCUnO+mBJL5JcvrbPOnzf37wDM81tMfDPGb+GUtzRO+VGyagK9yS7QRGd5eXgPGR62qxsmmu5ZMnbTfkjeRNUrjSQc4vHDacxLSJ8Dvq0vw+l/QeUycc+FZSyoby4CgEZO2m/JG8iapM//pTCfdCcJl2oQi7G4kxi1d/Gti6p3XEhSNJtjkpZ9sTSIEfrlpvs2FyPsZKzHeM8/JhS8es2gjKbjlKiCu59twCZnG4TJfvir5PkuYBd8TuLoqRYzMDc6fVGKONqdNVGyJkcfmgBL3ml0Il9h0FixKxGkzZisI5yGffqjHwk1s3axOpAtFu1IORDAoT4MrNAkPtAg6wQYzGGQWMmMlZyLQip5p1v65r2A1/setXVfsmo/ebC0JEWW9xeZ8L7ANmo0poACmSJo5GohKQxpY7TvUHXnfIhds2X66T23o7R3CVaYI7jooqTojMzc47BVsWTHCbsZKldagcWL2pSJ5dWw4xiXPatR4Wg6/8saAgnTABwuIp7YBIfcdguPC4McE/uyZk2Zza9DwgoCKftJxP1Y901WVeYfBBAieYsdkgbsfdp/PPBNfo+zPT5Z+a0z+6M4zc48zAUl0AFeONO5wzzXOLFvvmgah/IF4mh8EyuFHMjZWzQsrg9xebK2H3wedM4LAKuJGzC8WRVA7Q/3QL7w9oftkobBd71T9mcSP4KiyTVFH9Qq6jZWfQZKDOjS5qr9USSLnVE4Sio2c08LRDn6hrnEm3K/T/CNxNiY7GWe5LL9sEps5z835bn34izNiyvHrHfXIuE+S5YgBDpZ0CNCICtHb7lKh3QC7F+uvwjKDkh6Mp7r5EFZblRvjYsDQw89aaxxKot7eW1YWFBeSQCwOa//ZPjHG/ZNNuzBSgiC9hS8ZM82w/8nBkgmX9jmUyvD3uD0Wr41PmcAqmfiuSGiwKD3IOJLL4AAgAnvA25rCjR3BVjT9g/ZaFGfngxFdAIWIGTjkqa6BkDhQHty83tumgZscX7sJhGuhjZOiwTdPyAECcWUSikqdqs9jsAAVCRI0QcS00zJY35icHB5PZ2TJR5i8Vca2cNm5lqm6xT7c1lZdl0EG0iqNifhcnG+I/niL4v7XsmLvhr5L0lZcP3IDheuaHDGUBf/8DcEsnFyB7NTf6L8g+kHZP5rW+u3HplNuUcl9NSKAkbpyhAbxEOuFPsK3jDg6QYFbG7KAU74xIGRHJI0Jbb0XTXpG5XyfdxkKEAoQ6KJGYTCnvYPqjh/p2xYEB8pJghnPTRJIlL6VO4H/tRz5tmoy8NL1bFhvhxb1Z+aGAhjZLiQCDlKXUNXHXOAcbayqe0TlYifCKp41WEFAQQDb4zgjvvsWznW/RVLV2uNVn4BlRoZbBumnLvX/Y3hr4hP1U7zhmBhFQDqGvyvPao4M6u65RCbJTZj1MsaYv5JhRAv/aGFjgErXB/zyDcYskw5hXfxMyRtWVVMHc9dyTHMhP3GIeED8CDPclR52IeU7x09vCBIWQOxZn0vv+Zm1vBnY9KeJOI41RMLnRhy+VQa88/rhdw6ptnVZzEr6Q//eVvcGJJcJmSDho4hn+pigQzNKVgIM7Gv6OGEG8o1kaRQTU9tKOw9+mtbDLzMP440mVL0cTajqOkNBPiDisoysiKpO0g4gd2YChBuOgJidiRCeIkFgGbwwvyDqVtFqzyMBn/0pk1Rw2zHSWs/DNGi9ANYpA7wm8Rx9aWUE+SYdyhTtP1N4k+VbxQ9AxkwfhMn5g+p4p/RQLWpcs1g19yNwpyckNx6gTvTcbxwUG3uwYeQglpZ3/6dV8arqeV1LFdCmdySRWcqZEm3d7sZKWJNRwa90B6G1QGgoZE40r7NQzGtixG2TJXdu/FKDSKL71BYFAD6oqbji2DAhz7jT+qwZOqS08MxHbp+e0IwAuByHfDmQ6KVILiqP1pOszRHipAZQ6QUYOeGoo+o8ZphVj5/YRg/isH3acTzEzp8NIyJjJIBQtxGUxbV0BmM0tOovey6CLm36CFGtFug6Pz/asgeQhadRAU7cWEHpyEvorgG2rHR5DAQPl1xsaB92VdIc2yhPVltEc4jnCdvE15Mi1knbiuhMf+X4Bi/llK4B7KqgZIMGsEheIPIcrB+Wj+oaB13lzTN+1rw3DDMPvTwxQr9OOjHTrqBmNvrbnw6IAWdA9h74gTccZmIStvTuqbHKZerEp6LlhscOaKeQPkZ78m7OdJ9aRQ//3QcJFs/W8dAZg7a2y4pEr29udCFlKwcNVAe/hKKFK6x+/HZphH3k7DuZ86y5R+BMfX70pdBkZYiLALjXga+AWg1MHZEU1+AZEmhnX28mia/N4zJkTqIbLPkQLyi+KEu7Wob6wReCOfH9XbWIugXJ1WgXq3hMV6A9Req5mDl1dfNNod6tvzVk+4z8IGobDqJHBcDsbPloV1KkYOwUcUoo7sk8xE58DO9VHiDWueeb0g4ipkflLMEV/Xjka+4nppkBO536YwSxZGESHyBwCnEZoXTmuFxYzcNKyj+nGM1a1MwtYGykAes5onoXJpAMXpvldpKwHGsFls3IrwZJYVW2rCUgBEVn6dSdcRaOJ2Hmcunkz8xeZJdtnBqV2RLSmnusAWZrVvqlDe58Xvx9pz67jeY5jXEA+BP/pxjNQA+d7I2ltZwzQIW7NPvQ9SY23drCtskMojwkG5cBa09akvsOUMlCHLNwTTtQQfrXU0UiEVFukMNRn8Gs94ajaKd/4dYAidiVnJyEyoxFeSPbUZIT0iUt0ljQhhUk+2SqbJN8TMy/LSRjHX5GyQjVc27SG+s2eqUgyJlFhF0i3JGFwsfIttD+zukgKdD1yvq8uMCY/g7RwLFi4NyVRBX1i9mwYKTRAOmKVRL0PWil0sliLiApHt6dt4Vj7isR0hC+lJFHqWL2iAj3oBvtsxqQVlAjX9uPJGOmxk4jdOm9XFvc/EDeFyGNKztGVf8QQ08G1HnpNkkipYQEIXGiZ4NRONlZ2wKSqn+MeI4NmBoPcXSjXc8CAJhDcAQUwNNMkwV1oitOze9MNFujku7ZAn+EeuRDZAnDXWg+XcCK8QxNacdL0+g2w+Y9orNpWA3p5jMVg18HfGJh8YO+A8lcIHSfjaOcGuCVr89xdE/NuN0QvT2lBHBK23EYZxywbfEtRuTAZWspKa/RGD/1dyUfTpRiFXwv92wZ6M5UeUmW+2PQzH9MV+J2oY/ua/YB8OV7wnjgM6g9nZ8qXoQSygbTisnvxDlgqPvCvHtl7UAAQvyFD60vgDMLovQbzfhLB43Y6yYdisprrNh3H519N1N4ZE08rl9H88F5j3X+qv3sUkctlhbmtpwl8UbbwHjXv0UjD65EupIS8V+/rQf0uLu1y6fndAiilFfn6CmnHYOSFgKOjViWX4Kqaf+aHlgVqZ/9Xwo94NzvsHMLeBU4jTTmgQg8SCfjxhTutDZV+ieeTeuQcqiKttVI5XIKreDtEv8qg46LQscxSk8s8nPoCvdmfkqHguXI9mvzev8e/yd/G7eHfocoHCiyQynPKEgy0do4BHL4QALdzK+8keKiDUZ+CcNa/1V+9iiduNfi9YhGjT3GqS4Eh8P6ea/6Ovgi5xbnIiQXggofgMsaebDOjGDyyJQjKcuyGlluAAk5ziESP5rnOWLZPxMuwNEZVb/ijw1ZuCNJKPKM1nBdWVK9QKUDc5YMHNm1xak90bi42WREPx02TG/rbUzs0CDvy0dVF4hFLx1siAo0ezxD0Jwn+WqlGIFSGRlYBFVvMB5eRtHPz+OAq1c8o3theI4TukNniI9whiIxoD8RsalXsd7U165kzDa0gHA8ya0W/0oMMOKPU/X2wOF8oKAy5CR4R+2tb3mCXSXNWl40287XFJ8wdYFlQOd8NcNwhFMRHU/ddw5ZUfo+1mCIok+BSWdeGemujC2aOyVJdThLozdRaJ5hTSKMTSYFRZSJbdCFFgNCwqVmytc9Y/H2KyDpWwLWfby2eaXKE36ejxfZ49eTwH5clMCWnV/17DI3+44bl9QwITFgKxVMEqqR/RY5WUK7xFr6jRytBloYrRAgOucMqPjRrhRabSFm1N4GKFGVdcn4nWQuI03Ll0NdhP5m1yp5TKeLF4EpYs0TqhO7eIDX65LgJjLDrd2Bu3nEEqky0t0ucjTKpHnX5yUQjevQCfBrH9V5fXzMmB6y/UISUx4MONwwB18PPRsnFnNMzkmByX58fEVbqHOHwpfD9JXE6yksqAqoydNgTIhc/JQLMdfrVuFoA0K57ID4W8KT7zM7JowzEzeNtOddHrB4IVYi3R4u8y3zR6HfgFLDh7CML/nBIcVBS4t/CBTuF2WaFlRFOnjZnEBqnaxa5Bn/Eqmc7p+KIEUmBGIE+dywtgkwgQIZM3wuC94nbkXYap4OD5zw3hh0VN3VKOTEGuymO6ZI2tfHUFpBrgbEjswVjJ/6K5N6Fql8zDOlEckYE5cnrh8m7wAikslb63yGFnzu5t0FTFhntykoBT6666z0j8d7qpeoGGOWeqr9uZ9HTE/jY9ARW3qeD93wFOdP/i48363QejJiXo9nM3f75g0hMhn++C6dzj6+dxz+YnDHSwNJ3UNYLAg67xH05oc51kfhBxdrNiYDfsMQtXOF9RCHfjc4DQp1vrUHYFcB/98IdnyRUW2TXJq7xlwxRNTXKGdYygjlrS9WzsCZ7DIQDIkpcDnyrYKowTj90ZroWuqLIR63ZamXYtmM6l552dQaFPbvaG71fVnMqgV/Gitw8+dxEiQLORpkXTQKhX/X5a/UABtEtyT0REsOAOpJ+7VOfVe5YSZZ3C4eHwBnYHcRMFp2tmYlMq81g9HUm89ajfpJzUIMvRSWwLH7uPVpwBDAAAbaX8dwmOoPK1gESMFDhjlM/hJMjB+LSGDU0PlmvyiBzsvPL8TQI1krzgCZulHHYnvUCeBjFYp7MaKezEt41D5Isf1zE3Qg2Pdqq4CJdhAZc2iBcfCrEJc8afLSkncQITPvDSDgyfcweyFPgItTL/sSil0qZ9AH0ZD/cpQUebYHHwlFF04HxXlw7LQHDsQuI6Tu6hoHFdhsctdZfeRH5cIbaadX/lRZI26cjG8N5vU7ugre0G/oJU6X1KmdoGWMfbZV+2d9qxPY6oSu2YoPEFQQfgHakR6mUZ7V8s+0bhXHZZppkqBPGcvQwsgEnh+Nm0HY1RBhgQ/5KUNTc5udTL63qA48dtRc0EyZoPW+Oi6ZquaOvOotrMWCTP+IQfo+0xbvWtdNEN0YsWEEwBg5w7bjKHOibANlX/R0bXFBRLcR5qhhGCca51IvxKSqWJp/wqEaB4J8mPYNI65aj/9bw+w334HKQhOLDreWFPYvOfwLQuf0HRWBOmx78t/UMUo3m3+MpCQuVwHocZydu4PSdtmE34jlBp47SeBqKQpjVegZtx/D8M191Gy48GVnAVGgBjcs4+wp7GDzDeUTc8Dk72RJdA7+4WNTA8hZtXxTBXOzzbxSKtmIgBKIFDun817yEaESmjLIe0CLus6imOWeENBGw9t6LpKKpEoC6EKJ2ZymvV/bMDVUX1mvjA03mDmF0bD/JW7gJNk8LZGjH/UcEDJUvCQvGosz1Qdm3re4PZCexE1oKNm/Ii0yM48pIWKzXJPRjEtBPC7ndI8bAxaqV0CgEOPsJkp+GH6tZHjhPqsTPWQEPtxqZ/3JRkc2Ac8RYWwApepV4vPithjCthE/C/YEKVUxN6AkqdWPVndQ64uDA3aR/Z5biF5nCrdAFVCjcfyQtVmyBdj0QAyPdhiogkFgzTYDK9iTWZjpzWfSHS3CewCVqgz9fRM8pmn+W7337vyF9HmWOj24BEviiOxFUh5Pyy6XgGX0DVygegd07sTJI18VVpHa6NlaUSK33GKlXRYFXg5q8J4FuciSoIRm9UvoiFksp46S7MYNk7JwRs3SfSyhgtB+seB6ArIAVspZKhxinG7zqUJbK2+qEKPEm5FD88fawhQZt3lL78SwCVrc90Jny+/K+dasobZx+nBhNzNBWT8XMfLpH5FjFhthXWNRFE6omfELVjtpgPSZay0riRy4LclfrM0RW/QiaZLcG1SkXA0xS4GLetWGth0S02xK41PjZ8ArhbrL1z4gAlnEHFqqLCVhFcy+ZvpOBSKplshezTOpCH8G1XFwPF7UqwVQ2tX6wrxFX2axx+rTwulFeL4dy4GD+gk1Inv39saAe57X5TN1863e56O8PACtqf9wS8UyjnaqmylyZy6vm+RuZpBbR7PdqSN4UtfHFr8Y/falLEGPHvF2azKBbT01/u8ogNU0/TRkR7TM9JsFRW1/+a100QuRQFs27VHPZwx1Q4Pf0VYOsn3a/CxZUOjgMS5tJenVAfK/kIBxkCq6lKrr1uDGooAi5sBYQ+2iKENqPV+tGwSw8YRjTtj2JtasTyfjTxGKii7eGBYjHto+loZnkipGpikk5qyB0e0zkWuHvLbYCI7m1rBSY8WUOZkGLFHSh33pCwtaARs9Egz+PvKBTWfMBcXd6TWbXkx2qTcCVHQVQctvD5v9DVCfSCczZn+RELszV+a2LE1htuaDfz/nOmDvKML+5gIjOSYM/tuN+g0cDCZSmWkTjMVHP4XtRSZnDhSeeigFlO7hSXZvCdtFB+9QAwr/oEfw+Z8B0Vr3NX7T1hjqpsOFWKSc+V/HdNqsvXPUl9i0fAVsUe/LLrA2Ulj8X6EIvtMt0a2vyQbT8qavdOIWVTWIpbQoCMUuIv9+FQaMpC1e5k7HLQZOe80NiS0zCQC7/YG8/5hIHF7rYmVzIOJkYeJrwAvXTVC2BpfdHtEqWn50iiwR2zW16d+DNIwhvY11/2OKGnhcZIpkfq422W2Aun/ozOxw2JUJ8Ibr06ysMaPRFEDXx/OcHVf4FDeuxJjrwXtOafWKeRoHgLXlr510r9HnCLbe+kKMxxEMu6z1obkqsiPfxb3UzgkaZMaWds3JA4pHGCQLLv6Vm/8JxgwVkqW8lgq8/H3GO0nIQyWeHoIIb8I91pjmYTJNUkfY9zVuYuSfmhBh5yJu6GePm+DuWo2/ZNLwlE9l7v+PJBFULa9smTrQ/L64CMKYYREsyVJUtlfWX+HNPaUCYYX3VEVOxgmkYavm036rbORJrFbqhq9zq/SunHZJuihJX4cUmB8Mgd7Nj/CfrPto3AgiK8waNHTDbE6GMu44ov2KlLYNGXwFz4UJPeeQ5gSrn3Kvz+xww9IkzVxWcbI4T3aiLCVLP1Cr+4O9nokdGwPurljXtfmh9Y+mFcMMr9w5Agvm+XUKwzt7k5s3cnafNgZC0LH9sLtsM7dw1xB5JMNwDfFuaavvnpScAaQyiD/RBCkKEaL3en4aJIwvqoz+PbXHlUvLd/j4bQ5PfIH2EbbUTPi79Op0sjvFSgTOZb43xysCHLLWs4Ibag2t44LsZEo/gEhegszs53jLU1pcXFwfX95S0sVOG3igkfm5xNCPnIkdDRoYzw+hltGSmnOgKYcLDl2PBvsogoBHwHvAfOtoSWfSaK1b9O1KvDmMCnj+cHNOcyyS6wU2VaDxaxJChpmI1sjYosfs/TAgHF/rs0KtUKQ7KUoRhBHPS87ShO0pRlqTo+ToljS2hjn4sU0bOgmw1YesKHRHjUTq06hB+9Si6fUhDEt//r6zVa0uZNU16f3iS1heIxql33rHxNdLmm3yR/LDdFroIbIQULhkgHWQ1QApWWZVaxCym8MEZTrBMpP48TnhcOqhRE29esZ1qM/nximcQG9tsYuFyUrhZmD+QlTZ3d49/2jygxZpDjjWbpqeTRB0c+IMwIjf/UrfK0NkVaQwmc2aTaB0nFVN9JJ8r6qY4FZ6nzhAPyqIH8xP9R2Myz5yICkaxXPIF0PvTXzbsneGHQz5rt8dqd0t2JtnvSyxNR4ZC2W8XS0CWWJkIBkt1nY3iBT8ln6ci0TKbwSTtRqrssCNISgB3e2+kcxkRmkkZaviZbTI/CH1TbpUEOrlXBZJJdlCY37raxlXsBIg9YDxZ5HgJCCOW5sI706PyZ+dlVR+7s0iyy8gFOJEtF+HnL2ys3VKWQ2YIQti58X6rMPR5uylygmaniuCjPSnY+9a+Q+q7fuBUUMH99gN0fHOXZahhjlffxTjQtrloekGwYVSr0rfSLJfGq1/+c3y/npF4aWR2uGPQVnK/wvHhyPi5mKLRA3cYMrYQ8uIBODIQWxfmNW8A92Psjgm2kQ5nW+Tsh3Y8qmmyoO3fCdvFepZIwXcFsgviAbNuO+43iTX7KD1y14l5Hk3yESoXCpi05hWFxMGGZe+JxySD0KR273IrdZfwOr0SWuFwpnYY3u1+dXQ1WiH7VYAjK8kEf0qjbS4PO8oE2Wch9l1u77F80BIHR53VqyGNbCOTygVUChHjm5WfhuMOKgHQCSPyKo3XaZb5pRWzKqJCRpB0bbQ5smvQ9Kj4Xq3+jqZi/OANZv3KLETl7SdQIdrFhgjgV2incT/51vwEHIjwp4YpW7/ZP6cFoYWFOh5uoqfYZ38NRZYGPjP7mnreLgbieBAjzW3qb/9vHoNWAkcIxFWzrBEkJZVRoLVXi3X/h82VuRpq5vfSfFimeJzRlb/XGhZrLb1geTVWWmYCrsOF//NclL0Ns6ZvayPGszBQgFXHe4s/II4X0OiZ+Ke9pfQYfpU3mhuBeDSYMFZP7pScl33Vb9DO0JKZ9bU7JELxzf42xgzPzOhY7uA53dUdu4jfPycO71I0rHO4lsWVOMFkZ4OrNIoxtUyeziZrP7nPq8FCJoYnO5uMLZUTPURi9XgUXEERZM0KmnFSTPK//ld+A6yi9NleSUp9jpVbFO1QMD1JNNOfMLe+I8XJ62H6jwgorR9fqRExQTqux6nVpSXocMDdKrZN4O/qk9YnV1JLH0ZQp0HHH+A1FUyoGMrBjAHmtDyEGdXpEcgI+pJH3qxIMKaQinjqvPvbh7FX+OioBqkQ+OxDi5u4jj4wAoYtXtxPrSV4DwUszdxUutn+x6gH8dgS2/yi3CUszJbfd0px2W3o5c6E4+S4beI4L4O0bNDQ5ucQhOjgcD2QNSUUflLXFWxhAnBkbzSgDScYLxBVdUdQY6Rjab7JYxPvGswTFIlwt81I+jUyILvRQA53A3nph8O0LGMZpAyNu216NyrES4yXZ9xAEZFzB/kxDKv3AtmsTZd1KJXDLNkWCOmseRjSuJuDk+ZjIEL1dH90nAEEBUpxiRgMEC+InVRfL0lnZeogxWTxbVuhzT6oWyQpd6BVoN87yaZE1+RWRrqxgjB/WSvCPQcbwYGoOKyzhYhHKV8Sj5LyaeAd4qVYefNeK4dpzvtTFon9+Xa9QkWR4tx2Nw4WpOFZilXsYFemy0EsSuKkTcILTksU2vZAlSKXoQNXeblUCww/7VHfMSBftVxKVXWUK7tuWf/X1yokt3pGlbg7KZvYJvmW/j5SUxRLWqT3K12E12E12E12BIJCiSMgoBYL7YL7PIR/YTXYTEu1yEVW9ZQ8n7FFMZAFVaJdM1GWdI4VDYOEnZZfmnHH8Qzvztl+wVSiWR1nECb2dQf1qmd/Cs48rXFPkaLQbTKm/HjoI/FW4oNXt5whFcJwiGEO0KclSO1SZgzN1FmwAAAAPWNptGggCKB7PetoEAAAAYiedshQEOR+e7y5aoM8navgLtnwAO7y/mXLicgHArbg0apvff6e2DrkPuc+nxuGALAkL5BL/luW0bbMsVnNozQc0L+IMWZq9LQoGktovfEY+234+2+RFFGQN7FZJURxWsfMMbPndSYFmmZAUn93bsOZhRBMid+FRlISukJ3BNmokCxh80YrNTh6bPVJ5yieOEDdsvB3miXDlzBz1pmF4fbyA9qug7U7KNQ8qMHQC24ARc+TvCiWAjEMVHeU7UjgCSGTWj69Aro5RmXkSBQh0MN/PmD01ttllcP+ZxVXg/WX2srH6O+1k9rBy5WAB3CRjUX19ZNTR/glZzFu8u5AdgJsWVWg7Hsq6/MdCQIWTug2ZVCsPTg6I1VPlIAeO3a6e9xwdH7MiynBieu1VI1V8AwzHNdOSXJRKY+i34j8qnSWrYGbFtE1zPDFH8VqEwEkXIlYRiGXF3yCgeUpsuxndksycV9dFrbMbmEL/WG+Qk4ublVl72XpDj6C1gb54m/gcVEUxv+ma6VvOj6x9se++MvcVwE/GoQ6P2E80rzZv8NQ9DnhfQZsPID7xGVDFHKO4Ohk5dFz7wZ57IQ1AnI0onMAxW2bVs+Zht3I5VCWLfoJ1y2+VDb3aYRqOxjadEr0fDyV4pgQZN+eEfAvaI5CGlC77Ki8tXs4Qvb5cWhAHeR2NEqCJyVOwaf2oh8MT6UDEqWhNDxYBskz+m4K3N8PH/PPdF9jeFOB8olaqBw7aRB0dlz0VFqIBJMOb7tdPzKlkPCK/9Z5wUCy/5GR7MIo/9c35TgAAEEo2i3yt2BlX4qL1YuwQnuuuqzLj5M3aQfX1/Nf7RqJGWIjCIUf+leFNvpOmg2gvNFgGQjweKefO08ridPSUutmiVzvn8te4l3MXD30cSfchvmeO6ls4tujB6lps+UB7u4icekXgaYtyDCI5mex49Lu27exGCsSvYeKCoKZLh1m7ICTKceFP3QBpficmhU3FQOHYfHyGITpXtQF7dl3pFT9BP7xvUn701U+AUWgHP9kGS5qMrTByffQJMB5213P4fzaXEaduf0jIplxrOcApkCvpiav0NOXIjq2thmNaJCtcVna1jIFZZSs97fOsdZzt3zAlSdm2p1JpGIZQd95dpKsYfKNblEee7GRxjK+bICy7lq+wy6wdt5grVk9Sp5LVACzIOBYhlB33ltUvh26QE0QhFVVmlfn26ojW8S6Rmb9JzNTvpl5q6/lrgYRsg1PDuUWt/t4tiP7Jf4OvjRmNyN79YsEt6xwTBdGm4RQJucpAAALY39tRcGiuJUk/Cl/EJJVCO2ACbvgAFdF7B7Q+non/Qx8AI4SbsoRceQ7D3lydnidNO3nPWQqauHVUacLpVebVP/03radtkQx0l0EOAkHxAwh/UKMyf0LJCTBKvdhuibPsiHo8HmCG6BpbVXfxrY2FRTrRJhQ+Yznu18RxLO7QV9uYZ0l0bbwYJbv4BC5N+PM+XAfvC8pEoCVZf+Y6CmiOEwgJUahHVUJyP+1mPo2F3J3ubh8VKacWezbQS7Y8yV19HjiX1dEkcsNkDOslEpb+aODEB5Rd1NVIlfKw/TR5pcFYy6QLrLtOnXpZFywqq5FgpqlBb8N+vpGfEkKjcoQAYe3M5HbnFXunCW3vSfP+MGUbbuMCXgDFme8TzrsGoU87p1qAAP8CAZl1ZSzfY6FMx4P6IOeHcAztJ2Mgy0Z3ix9wlJXBEtizrEOuYJeX7BKun0PcP9seq007U01jDcLp7ClsNjy1UTPnq1aAxyC3G2V1LseJSABb0XT2DQ+ocs6Hfj1pRvriSAUDAVTUvHcz+zm94o1NEqP7TFHX2sy+dwkK/2Z4VxVwm7pNIzW8FkG8jIleIgoZtpj9VADbjR0Uw6GaxGCgCYC6xraIT983j1JQUkge4/rjbqpBnoA3N93exqArJ77uERlp05EAYEkMZEA9ZAg696bwSzcTaTjSRNd/LKRG12r7RukFk5XM4M9Mf/3FZNxLVnK57/E0hTjsLSCXublFYoxBizc+cQ8FaPTkLIt+GZf6uzMARpjxO0GAbJBpUIkcNsj/Up/5oNVwWTzc7SzQqkxETiLX97uDafoCygwLgSKIbccSGjzYRKZ9AKyN5xZ/TnDz16/I34ZJpEKZ9XGv/jem9VSrRmth+MbqooUBf1JjqAl1ycKNghEQ/uvVB0ww/aJQNkfTOuBQR/62xlA6jKYNEZGSJUZzvjnKdXUgeQ/CYiJxFvCVNkev2jH/30PUdiig4xVt/XWLs9Qj5nLsLOL2B6/Msor9MRE3BGQ0wnaXcX/l8MJsPmV05JlKCC2m6bvqvZOVmXLqqDSVQOASH6bgrNRr5FMNUEoZapFjW4LRx9pESD7gAdS3mbURh3db/LpTsIHmXYTRz92iHU03RovGeRgyisVFje2X6COta7cWrNVlhooi9zBYZfIeVR3aSRz7SHKyEBPu8NSu2AP/ZM5lBdheThgK8igjJMeX5rNBzRauTASrmeV4fyEYYPXGndU3SijqgUqVjNuHkdKN11pQ3dzwQogq95djlUG9cETIrJSjhm/xZbIlU8cZbOJjLm0X36gjMUupUOMIljA3xukl44NvgNdXaB+XuGvX0kRVynUH2ELACT6UNUaPwSbVZknCN0xaaa3qd4M5NK5BU4qW9oIuYf3yZfO+HVODywsL+jYAs3yn4UhIY5BliTU2Sl6AAAAAgQ6hH23l1y9xRQwV8MCeQ6BO6lK1O2YF8ZejxrfyDav1jDmcJ8rxGyunOSV7IqaAlq+MYIgzg5b1gRH8Y6HNrFOc5waswnvtIbctNOqKzGPafLbSAvjXVTlHHotr0zvUddYp8UseGOWKhBV4FP1ZO/RHNHmv4iugME/uYoRaZkLZEuuYWJSBuBQjvOHSbtjFc5aqp0d3Vwtj6Rvj4QlsSWaQB0WdRUDBmZEJ25L4wxNih63eLtRs5Q1aAeFYRzsTjM2OTl1kdo5HoTcij4JpcbUTke6B34MDXy9MHZMow0cnIBW6B4g/PepGzmpNzorqE3w5cBV/uSyJx5+iC7946/FtPw6HFbZQ/rDknT8aGhXuu05wSLkB816xSc04LW0eYTQajWL3dVZHPbhBBRJTL69D13YncrDp9l5xspHK1wYtuIBdx0yZiB/PKErQEjHQliwl2m3sO3T2YKh2GgUcJn2uKdrrHaXnmR7Ktumfjt/zQASlKhEeybNIX/BL3oh561tuIyKNXx7+5fGFXB414L/NLvxp6nUT/29aQyGeWhxqkbHtCMkyFLGLumhK4vKZvx30vZixou/vpDnorbEwDJGpM7N6qE+VH38IQVdB1D0irczCg89dLflnHSg/lj79cJaAg0Flx9H5LEgI9TGOw65Vh9TxjoN5+KYxQsg3PDRcQtX6vKjpGRfAQM2PwXoZkiCi1i9vPX1ZKDGLz8zUhunSHPzRILHyGMB9zSkX2U04bM8Yqws/XQCPXQQ5AF6Hx0VkMkGH+WCXsAWAgfeRkUTxh/IRisGMB9z1lvv1h/ulp6dPFc1MWx+n2GzgCTwL+/ZH9aJmtmN1TT5DYbSiEI1xehzfNQtWysFfdsjEPOGg+ag/xh8ZYy1+46kyh5UPE48OABQLRyt5YEaKZrf2CzsNJRLOFR8GWm6IEZ53ntfkV0jeBOQCBGLdUvhm8z9W78pHRD86BL9C1D+jJS798QAW9D13YncrNOkCwws78JuTU5x6dtYkbn2Qk8NpA9ThX9KLr+QqVN5WRl5wXZrvn204qt40deSWHIwoLpMVqcNXpKB+kVY8pPIqDgFJWZarzhOEAr2JZEv8XVQtdnIIzp8BGEpmn7NY2x2WKJWm9EXwTZTJAlE6/gFnfWhMNrh8T1cMHTzq/xghFFOWHhPO8hKH3z0MgM4sDwAEacK5LPcfL3w3LrvtU0etnVljTic+kXy7pXk1xYzQHUt3zcqDM7BUzC1u3eJ0pNYneeolG53lOxkESd2fTwKidfSqW2IkK9A6z0N1eOPCCkWghwuC4+FkTB18igsAH0Kwb66L2PnVcCj9BVNZQ9xV+jvoaPrDmi/Z2RGq1Vk3tT32pb0Q3OzEldHQdfJpB6HSul3HkMmqy1M0aMEnouM/g9JY2UyuiJVmBvnESIB2tWrsZ23IwWM3sxfrZIuG6f8be6Wo0Dp4f5Lr3Qc/2PUkN5uJqjeekJBlxJ+pv16Jr+jtSILbh6KH6k/l2fkMiB8S+tesnE8QiDeyWcduBP0qs1EzJNMDjypTdwiFZAfaQhyK0helM6oMpbN+C9Nyk7kIX/ftNkA3045irDeHf3xopSZBGNphhriX6cYcFduESna4z4/h/FT1k8ERr1oIuaTFS4Y9esSaJ6xT7t6/2m4qLXv5f8l+rZn8CYoTYmxTy6htfyw47k3OKt+s3Y81alYNEAMRGekwWhA5erpZnJxK6dm3NWv6LxMvEyq5KMLm2Bl9XjINTvx9dzKkD5GKmzrGLu0h12BLxjBHDB+SUxDWid9RNDwZ5UQUfrRmwaUArahfKg7J8df64BvP1xPk/a8JCx8QeXN4VVPHnYiQOCLemE7AK3UxJFdRlWlnJLYWf32sZgUR6iPIXfUCMQ4EAGO1x5y5a0Z1wu1Fi4Sxlt3x2BlqcY+KfP/hddikAuZ9y4zTEiurhN7r+Av3jqDsjDE3Wlh/dT/BZYwkeEYin752ooWqN11bMX2CjYnOenywVsGWd+WCKUvO4iEKP1ULxYriGUpLiZZNYq9Z8pI3QBFb21ZYgGi/JMqnAAYLVBlYBScRsO511YLujWYz68UiYbpBTVvOPVfg0eOEPK7YkFfnPl8SzJbINNydgjupfvBY53wYQCZ6ojeZYF4UqqG3ZK0IP8ms0sn4pt3oV/AV/RhP8Aj+rJFQp0E7wcCCN1OEc8klz0+WCtgyzvyysnDj4PhL40TOHPDbd1Aw4OtGLcUVFoYPxyp9HI5Py7/a4p3g0otbVyQ2570QP1F5SsmvhfigiWS06zjE/pqatkn/uBFOSrwECyRP3BDeAt+tF5sAUI1yGbQuWvRrCsNoAzxgJxrHjjwsLrL3BnUQMMvxVGk+3//f5h2OTV7hDFQskP0brFT3g6ySkm6cPkp9VNRVHOW9edCqPKq4Yuw7Mcur1xhrUDYSGIsiBZ+oCpirobB3ghXBmRg7w2sr9Xr32bWWMwzX8rkhhGKUJyq60sVVY0hEaJ2UG+iiN8PZJzPuCxbpv0E1Wf47atUmMxsv+eoqP/JevYOTknY3Mx3waDr/8NAvJa4I2gF6OY8VZNeJZgUOfFwmorLe7XipfXcK5EOeewZdJtNs0FImjNzEbnZDdQX8J8ggmA+khgu+3imU4z9yHfjb2ys4EqT0S+1nkGPR5ZluhTBvzaXPiDiFqXnv3kUNE8MmXQWu1aSq7UpKnqLv9tJvSnkccX416TQj3HRUFvmO7pF5ZPwG7dovKcJudyD/5imjs1Xz8d83Yl9WpTWkSKEGdnAXw6ZCz9aNIaEHO+nZ2Bgun3tq8q5b/simrzuALMc+OpTfaX990OMwQCQMd6fwBfy1VwHmpNi+5e1GbYvauTzXG7cyjIKL1+60UyJdsdgVJffQB0c3R/TSdlUAAABOwAt84+bbv0mGlTIRz5HOtGBRYKx8zhMMtppdJ5JBdoOu483CntPnuAk7M+JZ+Q1RUkuWLflsYctpvzkq0RITZHHyNxhGuXViLuCe5D3eCWK349YUNswQBOBtAx8ClU6oF8v6Dkxc0bCugwZXfPYoELN2iGxONEiHZ0a7VXpQ0B5wYbQyMglFRDeCQu8okM+sISBWiI4nJgHuK8hSu/tkq0qAleqzcqT131lEWn7GOmEutpnXuO6fauykQmOdWlX9+PlSSSn438xh7smTXHzbfwigSFDi/ldcirOYGSJrgrr1xi9XKut19W6DAIT7+S2I1CPyVq8ati+hcR2XAplr0D3p2XPgRQaD6GcOBTNn/6SSMX/mwrSxuybd8hc8q5qT8Bo1c3Sj1uIujavfoSySIOCDVMOxBbwj4KAri4t4kkRb+U0TuLm3P4VG1vQHma/EnZEjm6uhXhp73bOLDFYOMQH2nHfyypKTUasSeGw+AGd9cNKyY6OSv3EG6MnxcBFWw25DQP2KL6eFWt8mXv8pVxp8esOEyR7mQ3LjoKxGFWfP1M52xGIrNsw029ACq4i43gYgbc5r03b93W8FeK4HqcsngBTO3vvNEy+nnbEsJTU6jnwlVjuEToo5ixVADHTIpiMX3XBbz/AaFeKj0/vsTo5x7U6BAQgq8j1oy/DLsD3sn9j/orCIMYaSQMNcp5iheL+IvqCAvGgPwhb+Fgf9d3ixRaMNoP92BEptArkCY0A38n1QLJMugg7m5CTtV+oq8T7SuQzFdf2vgdH8WKIlXA4Tzz7wAqEn5tkt/11Yg07zKjaL2sCul0jgv3nnsjJUWI15gXJB4OexXi5mVBOJ0+5CzzqjNIipJtVsZ9VGImJZIU+c1LeAYWmL8G13uUKwIYdcfGD7YBzO4pRj5sb941xfIywBtAMKWRnjhgIQgAu+kyxpAVXGGBiMcdHEtwMUkC6E3kAI77X/eh0YbQOFMVclOockRuGo2zM5MdPPMZlfD1APChNzINdOhNYgPoFrpiuacgBsPXpS3iCphiD15Z2x3MC/30bTBAdQPQukL+xSrlT/H4xJaG9IRgG2hoIg152pQBljIEg39ZElSJfhkIT4EAAAAAAAAA9KkiwPKZwt40PliZfY1yvPZe9bj0XGsAtFAZktPT8RSMbrreaPUjdKQzhMeR1xI6bFzhuF9bKYUCXhWTD4A5+sO5lG2SyqCWyfmQYsxgEdMRT9te9kEGRLpXVVb0BU7aEfxYA9IAWlI1maNs9i9yjZRzspN4A20RCj3aPq1g2GCyf8jhJAbXMLW2DcTwLPA/rkQVLPszgOiAw6z5guIXfbh7uuPTC7Nkax/2KDllWNQYa+VA0kS4jHRpzSRx4r8kB1beXqfXrEOjwSx73mFF/TQXSwMWm3q5yI89P8zQ+0+AF5uC6jCjfdapQDhAgdBQMqbdaMIkYhIhcRAIrf24pe3m2AEo14sWmereK4HOp3t09/0Qlju8yO6jJLoCJr9u+6vkjqBIolnmapN45Wmk67c9jWtsa0miFcAoMYD2eZncAB0ModKLpZOnQf4q7qi5i4tzZhhOsEbZEDsNcZ32KGeJByOxu8tCrIJ5Iclh3lDwdT1sgRCV28RpFz9A6txKBr/LvMRhRI/u/s89fZ8ANRo5PquIl9JgnOwdxyV+WaGDgZipfN4vfkWWl+9WHzrvFX1S0bhvwgfvP5yZvaRsNvfvVm5uwe+qYB/ZNd7VjzS39uZpQFswlhxV/xRx+EW7UKcRPmNqfD/B4+eS82fsfeUJfSxfOnyY+rBGB3ugm3oDmomO6XLHv2UUHTis8x7+LfpQO3OogAXM5RJgjuXMRUK7FfJ0PTPlBNIT8LoQ0jHudPvL0p33PgCHiymds+nGqpni3yYysbAQkyK8tJjkFFly1NqndG8EBMUMI8EAS1+Z9vUzsQ9M7SuVyvFGOeRvhI4WGbhIrAAZVXpEApIwWjgfslhCpuIfSndPEjVfxJjoAAx5cBiwTxfpEk4eJJXo6mWCn4DODA8dv4RIGFmoABdO/b6nZBBZP0GESSIqunqDOb/bcoURJTD0GNk0FoMlXcLLDANhDZCRlUDDr8pOfQ9OQ+AarfJ6mWEk5L7x9VwfL95Wn50PQnk4tPWH36Rj9tv1VGi0edICyNiuw7vt2fY3ETqdVZYGN5njp4/E8+1ZsTo+HBolTIL6uSLiofJ0K05jQrTj1Sllke+5ojP4gnWOHPNPNj9t98bx3BqhXfp5/jStKkVKX1GGrKVoJ8pILX77vG3F1I3ZWXM57ClhN26Ea0rN4ZgVUlWyEkqIKyFIyluqtP6cwnzFHG/6ejSj99iRvTz/T5WxeCkb6336rHknhafzdtmCSkgqoLSrozrTgif3DWL7TZS4HOzUzfmhiNmLezip38mfiX3A8nIio66Vke/cKNxTn1toOah4NVi0U2hPpCMY07W2rcjWuHkIvU7Z7CuQWGz2uq9Z4DwZ/8BJQfGRqORwrD99tCSoa24542bHPh03qTulgqseCBKcCJai6X8AUAAAAAAAAA==",
+        "width": 412
+      },
+      "nodes": {
+        "page-15-IMG": {
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "width": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "page-12-BODY": {
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "width": 0,
+          "left": 0,
+          "bottom": 0
+        },
+        "1-1-IMG": {
+          "width": 0,
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0
+        },
+        "page-1-IMG": {
+          "height": 100,
+          "top": 6634,
+          "right": 149,
+          "width": 100,
+          "left": 49,
+          "bottom": 6734
+        },
+        "page-11-META": {
+          "width": 0,
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0
+        },
+        "page-8-SPAN": {
+          "height": 0,
+          "right": 0,
+          "top": 0,
+          "width": 0,
+          "left": 0,
+          "bottom": 0
+        },
+        "page-17-DIV": {
+          "left": 0,
+          "bottom": 0,
+          "width": 0,
+          "right": 0,
+          "id": "ago-prompt",
+          "top": 0,
+          "height": 0
+        },
+        "1-2-IMG": {
+          "right": 396,
+          "top": 414,
+          "height": 166,
+          "left": 16,
+          "bottom": 581,
+          "width": 380
+        },
+        "page-13-path": {
+          "left": 0,
+          "bottom": 0,
+          "width": 0,
+          "top": 0,
+          "right": 0,
+          "height": 0
+        },
+        "page-7-SPAN": {
+          "width": 0,
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0
+        },
+        "page-14-IMG": {
+          "width": 0,
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "right": 0,
+          "top": 0
+        },
+        "1-0-IMG": {
+          "bottom": 77,
+          "left": 33,
+          "width": 134,
+          "right": 167,
+          "top": 37,
+          "height": 40
+        },
+        "1-4-IMG": {
+          "left": 0,
+          "bottom": 0,
+          "width": 0,
+          "top": 0,
+          "right": 0,
+          "height": 0
+        },
+        "page-0-IMG": {
+          "left": 16,
+          "bottom": 581,
+          "width": 380,
+          "top": 414,
+          "right": 396,
+          "height": 166
+        },
+        "page-6-H1": {
+          "right": 0,
+          "top": 0,
+          "height": 0,
+          "left": 0,
+          "bottom": 0,
+          "width": 0
+        },
+        "1-5-IMG": {
+          "width": 0,
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "right": 0,
+          "top": 0
+        },
+        "1-3-IMG": {
+          "right": 149,
+          "top": 6634,
+          "height": 100,
+          "bottom": 6734,
+          "left": 49,
+          "width": 100
+        },
+        "page-16-BUTTON": {
+          "width": 0,
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "id": "ago-prompt-close",
+          "right": 0
+        },
+        "page-2-IMG": {
+          "top": 0,
+          "id": "open-path",
+          "right": 0,
+          "height": 0,
+          "bottom": 0,
+          "left": 0,
+          "width": 0
+        },
+        "page-9-LINK": {
+          "right": 0,
+          "top": 0,
+          "height": 0,
+          "left": 0,
+          "bottom": 0,
+          "width": 0
+        },
+        "page-5-P": {
+          "width": 0,
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0
+        },
+        "page-4-IMG": {
+          "width": 0,
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0
+        },
+        "page-10-LINK": {
+          "width": 0,
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0
+        },
+        "page-3-IMG": {
+          "height": 40,
+          "right": 167,
+          "top": 37,
+          "width": 134,
+          "bottom": 77,
+          "left": 33
+        }
+      }
+    }
+  },
+  "analysisUTCTimestamp": "2026-05-14T17:22:41.423Z"
+}

--- a/tmp/perf-20260514/psi-clients_ekodev.json
+++ b/tmp/perf-20260514/psi-clients_ekodev.json
@@ -1,0 +1,6135 @@
+{
+  "captchaResult": "CAPTCHA_NOT_NEEDED",
+  "kind": "pagespeedonline#result",
+  "id": "https://www.ocobo.co/clients/ekodev",
+  "loadingExperience": {
+    "initial_url": "https://www.ocobo.co/clients/ekodev"
+  },
+  "lighthouseResult": {
+    "requestedUrl": "https://www.ocobo.co/clients/ekodev",
+    "finalUrl": "https://www.ocobo.co/clients/ekodev",
+    "mainDocumentUrl": "https://www.ocobo.co/clients/ekodev",
+    "finalDisplayedUrl": "https://www.ocobo.co/clients/ekodev",
+    "lighthouseVersion": "13.0.1",
+    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+    "fetchTime": "2026-05-14T17:23:52.354Z",
+    "environment": {
+      "networkUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36",
+      "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+      "benchmarkIndex": 782.5
+    },
+    "runWarnings": [],
+    "configSettings": {
+      "emulatedFormFactor": "mobile",
+      "formFactor": "mobile",
+      "locale": "en-US",
+      "onlyCategories": [
+        "performance"
+      ],
+      "channel": "lr"
+    },
+    "audits": {
+      "interactive": {
+        "id": "interactive",
+        "title": "Time to Interactive",
+        "description": "Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).",
+        "score": 0.23,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "10.5 s",
+        "numericValue": 10484.721498701396,
+        "numericUnit": "millisecond"
+      },
+      "total-byte-weight": {
+        "id": "total-byte-weight",
+        "title": "Avoids enormous network payloads",
+        "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn how to reduce payload sizes](https://developer.chrome.com/docs/lighthouse/performance/total-byte-weight/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Total size was 1,525 KiB",
+        "details": {
+          "sortedBy": [
+            "totalBytes"
+          ],
+          "items": [
+            {
+              "totalBytes": 354683,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-avatar.png"
+            },
+            {
+              "totalBytes": 204723,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "totalBytes": 157097,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "totalBytes": 51797,
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js"
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "totalBytes": 51335,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "totalBytes": 45260,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "totalBytes": 43924,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            },
+            {
+              "totalBytes": 43655,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "totalBytes": 40710,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "label": "Transfer Size",
+              "key": "totalBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 1561233,
+        "numericUnit": "byte"
+      },
+      "metrics": {
+        "id": "metrics",
+        "title": "Metrics",
+        "description": "Collects all available metrics.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "cumulativeLayoutShift": 0.002315,
+              "observedTimeOriginTs": 3524285901,
+              "observedSpeedIndex": 1963,
+              "observedTraceEnd": 5908,
+              "totalBlockingTime": 695,
+              "observedFirstContentfulPaintTs": 3525820647,
+              "observedLastVisualChange": 4485,
+              "maxPotentialFID": 439,
+              "observedLoad": 3498,
+              "cumulativeLayoutShiftMainFrame": 0.002315,
+              "observedFirstVisualChange": 344,
+              "observedFirstVisualChangeTs": 3524629901,
+              "observedFirstContentfulPaintAllFrames": 1535,
+              "observedCumulativeLayoutShift": 0.002315,
+              "observedFirstPaint": 1535,
+              "observedSpeedIndexTs": 3526249145,
+              "largestContentfulPaint": 3901,
+              "observedLastVisualChangeTs": 3528770901,
+              "observedLargestContentfulPaintTs": 3525820647,
+              "timeToFirstByte": 601,
+              "interactive": 10485,
+              "observedDomContentLoadedTs": 3525913638,
+              "observedDomContentLoaded": 1628,
+              "observedNavigationStart": 0,
+              "observedFirstContentfulPaint": 1535,
+              "observedCumulativeLayoutShiftMainFrame": 0.002315,
+              "observedFirstPaintTs": 3525820647,
+              "observedTimeOrigin": 0,
+              "observedTraceEndTs": 3530193811,
+              "firstContentfulPaint": 3001,
+              "observedFirstContentfulPaintAllFramesTs": 3525820647,
+              "speedIndex": 4881,
+              "observedLargestContentfulPaintAllFrames": 1535,
+              "observedLargestContentfulPaint": 1535,
+              "observedLoadTs": 3527784299,
+              "observedLargestContentfulPaintAllFramesTs": 3525820647,
+              "observedNavigationStartTs": 3524285901
+            },
+            {
+              "lcpInvalidated": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 10485,
+        "numericUnit": "millisecond"
+      },
+      "duplicated-javascript-insight": {
+        "id": "duplicated-javascript-insight",
+        "title": "Duplicated JavaScript",
+        "description": "Remove large, [duplicate JavaScript modules](https://developer.chrome.com/docs/performance/insights/duplicated-javascript) from bundles to reduce unnecessary bytes consumed by network activity.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 0,
+            "type": "debugdata"
+          },
+          "type": "table",
+          "items": [],
+          "headings": [
+            {
+              "key": "source",
+              "label": "Source",
+              "valueType": "code",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              }
+            },
+            {
+              "key": "wastedBytes",
+              "granularity": 10,
+              "label": "Duplicated bytes",
+              "subItemsHeading": {
+                "key": "sourceTransferBytes"
+              },
+              "valueType": "bytes"
+            }
+          ]
+        }
+      },
+      "server-response-time": {
+        "id": "server-response-time",
+        "title": "Initial server response time was short",
+        "description": "Keep the server response time for the main document short because all other requests depend on it. [Learn more about the Time to First Byte metric](https://developer.chrome.com/docs/lighthouse/performance/time-to-first-byte/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Root document took 10 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "opportunity",
+          "overallSavingsMs": 0,
+          "items": [
+            {
+              "responseTime": 14,
+              "url": "https://www.ocobo.co/clients/ekodev"
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "label": "Time Spent",
+              "key": "responseTime",
+              "valueType": "timespanMs"
+            }
+          ]
+        },
+        "numericValue": 14,
+        "numericUnit": "millisecond"
+      },
+      "cache-insight": {
+        "id": "cache-insight",
+        "title": "Use efficient cache lifetimes",
+        "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more about caching](https://developer.chrome.com/docs/performance/insights/cache).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 319 KiB",
+        "metricSavings": {
+          "LCP": 150,
+          "FCP": 0
+        },
+        "details": {
+          "skipSumming": [
+            "cacheLifetimeMs"
+          ],
+          "debugData": {
+            "type": "debugdata",
+            "wastedBytes": 326264.91666666669
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "type": "table",
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "Request"
+            },
+            {
+              "label": "Cache TTL",
+              "key": "cacheLifetimeMs",
+              "displayUnit": "duration",
+              "valueType": "ms"
+            },
+            {
+              "displayUnit": "kb",
+              "key": "totalBytes",
+              "valueType": "bytes",
+              "label": "Transfer Size",
+              "granularity": 1
+            }
+          ],
+          "items": [
+            {
+              "totalBytes": 204723,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedBytes": 196192.875
+            },
+            {
+              "totalBytes": 43655,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "wastedBytes": 41836.041666666672
+            },
+            {
+              "wastedBytes": 27267.166666666664,
+              "cacheLifetimeMs": 600000,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "totalBytes": 29746
+            },
+            {
+              "wastedBytes": 26789.25,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "totalBytes": 27954
+            },
+            {
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "wastedBytes": 26076.25,
+              "totalBytes": 27210
+            },
+            {
+              "wastedBytes": 4598.9166666666661,
+              "cacheLifetimeMs": 600000,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "totalBytes": 5017
+            },
+            {
+              "totalBytes": 1999,
+              "wastedBytes": 1832.4166666666665,
+              "cacheLifetimeMs": 600000,
+              "url": "https://useago.github.io/widgetjs/frame.css"
+            },
+            {
+              "cacheLifetimeMs": 0,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "wastedBytes": 1672,
+              "totalBytes": 1672
+            }
+          ]
+        }
+      },
+      "lcp-breakdown-insight": {
+        "id": "lcp-breakdown-insight",
+        "title": "LCP breakdown",
+        "description": "Each [subpart has specific improvement strategies](https://developer.chrome.com/docs/performance/insights/lcp-breakdown). Ideally, most of the LCP time should be spent on loading the resources, not within delays.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "type": "table",
+              "items": [
+                {
+                  "subpart": "timeToFirstByte",
+                  "label": "Time to first byte",
+                  "duration": 0.948
+                },
+                {
+                  "label": "Element render delay",
+                  "subpart": "elementRenderDelay",
+                  "duration": 1533.798
+                }
+              ],
+              "headings": [
+                {
+                  "valueType": "text",
+                  "label": "Subpart",
+                  "key": "label"
+                },
+                {
+                  "valueType": "ms",
+                  "label": "Duration",
+                  "key": "duration"
+                }
+              ]
+            },
+            {
+              "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark fs_4xl md:fs_5xl lg:fs_6xl …\"\u003e",
+              "boundingRect": {
+                "height": 274,
+                "left": 16,
+                "right": 396,
+                "bottom": 438,
+                "width": 380,
+                "top": 165
+              },
+              "selector": "div \u003e header.d_flex \u003e div.lg:w_2/3 \u003e h1.text",
+              "nodeLabel": "Accompagner la création d'une business unit durabilité : comment ekodev a struc…",
+              "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,1,HEADER,0,DIV,0,H1",
+              "lhId": "page-4-H1",
+              "type": "node"
+            }
+          ]
+        }
+      },
+      "largest-contentful-paint": {
+        "id": "largest-contentful-paint",
+        "title": "Largest Contentful Paint",
+        "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)",
+        "score": 0.52,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.9 s",
+        "numericValue": 3901.2933981229003,
+        "numericUnit": "millisecond"
+      },
+      "image-delivery-insight": {
+        "id": "image-delivery-insight",
+        "title": "Improve image delivery",
+        "description": "Reducing the download time of images can improve the perceived load time of the page and LCP. [Learn more about optimizing image size](https://developer.chrome.com/docs/performance/insights/image-delivery)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 373 KiB",
+        "metricSavings": {
+          "LCP": 150,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 381442,
+            "type": "debugdata"
+          },
+          "type": "table",
+          "headings": [
+            {
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "reason"
+              },
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Resource Size"
+            },
+            {
+              "subItemsHeading": {
+                "valueType": "bytes",
+                "key": "wastedBytes"
+              },
+              "valueType": "bytes",
+              "label": "Est Savings",
+              "key": "wastedBytes"
+            }
+          ],
+          "items": [
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-avatar.png",
+              "wastedBytes": 346663,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 247346,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 329619,
+                    "reason": "This image file is larger than it needs to be (800x800) for its displayed dimensions (210x210). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "node": {
+                "type": "node",
+                "lhId": "page-0-IMG",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,2,ARTICLE,1,MAIN,1,BLOCKQUOTE,0,DIV,0,IMG",
+                "nodeLabel": "Benjamin DEKESTER",
+                "selector": "main.grid-area_main \u003e blockquote.d_flex \u003e div.w_32 \u003e img.w_full",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"Benjamin DEKESTER\" loading=\"lazy\" decoding=\"async\" class=\"w_full h_full obj-f_cover\"\u003e",
+                "boundingRect": {
+                  "width": 126,
+                  "top": 2981,
+                  "right": 269,
+                  "bottom": 3107,
+                  "left": 143,
+                  "height": 126
+                }
+              },
+              "totalBytes": 354013
+            },
+            {
+              "totalBytes": 16667,
+              "node": {
+                "lhId": "page-1-IMG",
+                "path": "1,HTML,1,BODY,12,DIV,1,BUTTON,0,IMG",
+                "nodeLabel": "Chat",
+                "type": "node",
+                "selector": "body \u003e div#ago-wrapper \u003e button#ago-chat-button \u003e img#open-path",
+                "boundingRect": {
+                  "width": 30,
+                  "top": 760,
+                  "right": 380,
+                  "bottom": 792,
+                  "left": 350,
+                  "height": 32
+                },
+                "snippet": "\u003cimg src=\"https://www.ocobo.co/android-chrome-192x192.png\" alt=\"Chat\" id=\"open-path\" style=\"width: 32px; height: 32px; object-fit: contain;\"\u003e"
+              },
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 10523,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 15421,
+                    "reason": "This image file is larger than it needs to be (192x192) for its displayed dimensions (53x53). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "wastedBytes": 16208,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png"
+            },
+            {
+              "wastedBytes": 9533,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 6234,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 6709,
+                    "reason": "This image file is larger than it needs to be (348x104) for its displayed dimensions (234x70). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "node": {
+                "nodeLabel": "Ocobo",
+                "path": "1,HTML,1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "lhId": "page-2-IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "boundingRect": {
+                  "bottom": 77,
+                  "right": 167,
+                  "top": 37,
+                  "width": 134,
+                  "height": 40,
+                  "left": 33
+                },
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all"
+              },
+              "totalBytes": 12266
+            },
+            {
+              "totalBytes": 11321,
+              "node": {
+                "selector": "header.d_flex \u003e div.d_flex \u003e div.bg_ocobo.dark \u003e img.h_10",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"ekodev\" loading=\"eager\" decoding=\"async\" fetchpriority=\"high\" class=\"h_10 w_auto obj-f_contain d_block\"\u003e",
+                "boundingRect": {
+                  "width": 113,
+                  "top": 532,
+                  "right": 161,
+                  "bottom": 576,
+                  "left": 47,
+                  "height": 44
+                },
+                "lhId": "page-3-IMG",
+                "nodeLabel": "ekodev",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,1,HEADER,1,DIV,0,DIV,0,IMG",
+                "type": "node"
+              },
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 8610,
+                    "reason": "This image file is larger than it needs to be (400x143) for its displayed dimensions (196x70). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png",
+              "wastedBytes": 9038
+            }
+          ]
+        }
+      },
+      "resource-summary": {
+        "id": "resource-summary",
+        "title": "Resources Summary",
+        "description": "Aggregates all network requests and groups them by type",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "resourceType": "total",
+              "label": "Total",
+              "requestCount": 88,
+              "transferSize": 1561233
+            },
+            {
+              "transferSize": 820955,
+              "requestCount": 61,
+              "label": "Script",
+              "resourceType": "script"
+            },
+            {
+              "resourceType": "image",
+              "label": "Image",
+              "requestCount": 10,
+              "transferSize": 431709
+            },
+            {
+              "transferSize": 253259,
+              "requestCount": 6,
+              "label": "Font",
+              "resourceType": "font"
+            },
+            {
+              "label": "Stylesheet",
+              "resourceType": "stylesheet",
+              "requestCount": 3,
+              "transferSize": 27827
+            },
+            {
+              "label": "Document",
+              "resourceType": "document",
+              "transferSize": 16292,
+              "requestCount": 1
+            },
+            {
+              "resourceType": "other",
+              "label": "Other",
+              "requestCount": 7,
+              "transferSize": 11191
+            },
+            {
+              "requestCount": 0,
+              "transferSize": 0,
+              "label": "Media",
+              "resourceType": "media"
+            },
+            {
+              "label": "Third-party",
+              "resourceType": "third-party",
+              "transferSize": 986433,
+              "requestCount": 27
+            }
+          ],
+          "headings": [
+            {
+              "label": "Resource Type",
+              "key": "label",
+              "valueType": "text"
+            },
+            {
+              "key": "requestCount",
+              "label": "Requests",
+              "valueType": "numeric"
+            },
+            {
+              "key": "transferSize",
+              "label": "Transfer Size",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "screenshot-thumbnails": {
+        "id": "screenshot-thumbnails",
+        "title": "Screenshot Thumbnails",
+        "description": "This is what the load of your site looked like.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "scale": 4485,
+          "type": "filmstrip",
+          "items": [
+            {
+              "timestamp": 3524846526,
+              "timing": 561,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k="
+            },
+            {
+              "timing": 1121,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 3525407151
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAEwQAAEDAwMCBAQEAgcEBgkFAAECAwQABREGEiEHMRMUQVEIImFxFTKBkSOhFjNCUnKxwRdidNEmNDWChOEkJSeSo7KztMM2Q0WDwv/EABUBAQEAAAAAAAAAAAAAAAAAAAAB/8QAFREBAQAAAAAAAAAAAAAAAAAAABH/2gAMAwEAAhEDEQA/AJU0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUr4pQSkqUQEgZJPYVrzWuNKvXDyLWorSuXnaGkykEk+3fv9KDYqUJAGSePetdOuNLJn+SOorSJedvhebRuz7d+/0oNipQEEAg5B9axV51Da7KtCbrK8oheMPOtqDQ+7mNo/U0GVpWhda5X/skv8mG/wAGOlSHWl9wVJ5BFZY6v09ZokCNd75bocpTLf8ADfkJSrlI5IJ4oNnpVONIZlMIfjOtvMuDchxtQUlQ9wR3rC3fWOm7PLEW6322RJOceE9JQlQ+4J4/Wgz1KpRJLEyOiREebfYcGUONqCkqHuCO9VaBSlKBSlKBSlKBSlKBSlKBSlfFq2pJoBUE9yBXwOIPZQrF3K4xLewZFxlMxmchPiPLCE5PYZNWEPUtjmyUR4d4t78hw4Q23IQpSvsAaDZaVQjrJ+U/pVegUpSgUpSg5v1wfeXZ7HaEvLjxLxdWIMtxB2nwVElSc+mcYrY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvr3q81dp2DqqxP2u5pV4LmFJWg4W0scpWk+hBrT3dF6zkwjbJWvFqtqk+GtaLehMlSOxHibu+PXGaDRDfbk/0PhwVTXShy8CyKnpVhS43ilO/P1SNua64jQOlU2P8ACRYrf5LZswWU7u2M7u+765zXt7RNkd0SNKmMRaUtBpKQfmSQchYP97dzn3rWk6J1oiJ+HJ1+7+GhPhhRt6DJ2dseLnvj1xmgw3UGVJ0J0UMfTt4ellt1MNE5SwpbLalkEbh6pHyg9xXRdP6ctlv04i3NtCRHeZCX1vHxFSMjlSyfzE5qnbtG2SFo9OmRES9afDLa23vmLmTkqUf7xPOferVWnrpbLKLPpiemNG2eGiRNWqQ5HT2whPGcem5RxQcVjvux+kXVCwJdW9brNOXHhrUc7W/EHyZ+mP512fROlLND0nEbMWNOVLjockyXkBxUpSkglSie4OeB6CseOmcCP01naSgSXG/OgqfmOJ3rccKgStQ4znGKN6O1HaYnkNL6pbhW0J2tsyoIkKjj1Datw49grOKDVNPy3tIf7UbVZCVQLO15yC1+YMLW0pakD6AjOK2npZpKxs6GtslcOLOlXGOmTLlPtpcW+twblZJHIye1ZrRejoembPKiF1yfJnOKenSpABXJWruVfTHAFa7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNBQ6fMt2DqfqzTdrGyzIZYnNsA5THcXkKSn2B74rqFazojSLGl2Zji5b9wuk5zxpk5/87yvQYHASBwAO1bNQKUpQKUpQKUpQKUpQKUpQK8PjLRr3Q80Gu6jEk20+SE4vbh/1LwfEx//AG/Lj+dYKypu/wCKMeaGovByd3mhB8PsfzeH8/7Vuy2SD8vIryGlk/loPrA/iCrqvDTYQPrXugUpSgUpVnKuDUeW3HVnepJWTg4Sn3/egvKV8SQpIUOx5FY683M27y+1nxS6opxuI/0Pf9KDJUrD/iz6kTlNxUFMYrHzOEbtvf8As0k3d1hpBWwzv8EvrBewNvskkcn9qDMUrGN3ULfS2G8EulvBVyAG9+cfyrza7uJlsemOteChsZPJII2gnuB747elBlaViYl5S/EivKbSguvFlY35DZAUe+Oew/eqf42d9vT4CczBlP8AE/Lzznj27e54oM1SsdcLiYkyOz4aShwgFalEYyQB2B9/XAqiL0nw1LLOQhlx5QSrJGxWMfr/AKUGXpWJN2cS2kFqOXVuBtO2QCgZSVcqxx29vaibq4uVHZQwg+I2HFKDm4DkjggYPb6UGWpWB/H1+VLvlkBYXtKC4flGCcn5fp6Aj61e3O5GHFaebbS4F9zuIAGM54BP8qDI0rEvXV5l2TuYaLLTSXQtLpyoKJA/s8duTmreTflx2lboyFupd8MhtwqSfk3DB29/TsKDPUrEzLutha0IjhakvIZGVHncjdngH7VUjXJbtyMRxpLfy5Ct5O44BOOMevvnjtQZKlKUClKUClKUClKUClKUClKUCvC2kLWhakgqQcpPqK90oFeHWm3ceK2heO24Zr3SgoiJHS44tMdoLcBC1BAyoHvk+tenI7LuzxGm17DlO5IO37e1VKUFPwGvGLvhI8UjBXtGce2aCOyltTYabCFd0hIweMdvsBVSlBTXHZcStK2W1JWcqBSCFH3Pv2r4YzCu7LZ4A5SOw5A/SqtKCm4wy44hbjTa1o5SpSQSn7H0ohhlClqQ0hKl8rISAVff3qpSgoCHGDKmRHZDSjko2DaT9q+qiRlKbUqOyVNgBBKBlOO2Paq1KC38jE8Mt+VY2FW4p8MYJ98e9VHmGX0BD7TbiQcgLSCAf1qpSg8lpslRKE5UNpOO49j+5qmIkcNhsMNBsZwkIGBnvxValBRdix3gQ6w0sKIUQpAOSBgH9q+txmG3PEbZaS5t27kpAOPbPtVWlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArFal1DatM2w3G+zEQ4YWEFxSSr5j2GACaytR1+L697LfYrI2rl1xct0fRI2p/+ZX7UHXtM9RdJ6nuf4fYry1LmFBcDQbWklI7n5kgetbZUGOn7zuh+qunHpaihJMdbhPGG5DSSc/YOfyroOqdZ6+1p1QuemtI3FcFuI8602004Gcho4UpS+5yR2+vaiJTUqM9m171H0tojUMjU8V17wEJRCmSkpOx0uBBBx+YYUSM/3e9azarr1guVnjaott1nSosiQWkIQ4hWVAnP8LGAnII7UVL6lRi6i9TdcSbjYdLW1Bs96ksMiYE7QtT6zgAK5CU9jxzz9KwsfqFrvRt6vWmNU3F2U6YT6QsuBbjDhYUptxDg577eD/KglvSoWaU1zr6ZYtTvxtRyVohw0uurkvKWtCS4lP8AC7gKOe/tV7bOpPUGb05vj7d5CmLfIjByUs4kpDhUAlJA5BKRknn96CY1Khze+purJvTKyS/xuYzObuMmK4+wvw1PIS20pO7bjON5Fe39YdT42jLTqtN3dbtDavKoUXUrU8sKVlTiVZ3ZII59APvQTDpUS9WdYtWapk6ftenJP4U/KZaS8WlBBcfUoj85/Knt6+pzmsJqnW3UC3a7FtvN+kx5bLjDTzUOSQ0flTzhJxkjk/UngUEz6VFhrXvUPX/UGY1o2UmNFt6lPNxCtLaFNoVj+JnlRVxkdufStCjdR9YvvXda9RXVGGVrSgSlYbO9Pbn0yRQTkpULLXrjXzugrzcmtSSTHiy46HHHHVKfyoLwEE9k8c+/FZid1t1X/s5tjDMwJursl5l6dsT4hbQlspxxgH+JycZ4FBLulRU0VqHqnbNWW9tx+bfoLpQt9vPjNltR5wsjgjnkHH3rWtJar6hag1m5Z7LqKa5LfD7baJMpWxICVZPOcEAEj2OKCZM+UiDBky3QotsNqdUE9yEgk4+vFaF066t2HXt6ftlni3JmQzHMlSpTaEpKQpKcDasnOVD0q609Avdr6SPxNVSlSry3DleO8XS4VZLhT8x7/KUj9KiZ0r1TK0c7qO624I86LYWmVLGQlSn2Rux64GT96CdtKhrI1h1Lb0Au/P31xVrnSw2h5MgJfbWnOQkJwUpODkfQHFdv+GW93O/aBmSr1PkzpKbi42l2Q4VqCQ22QMn0yT+9B1ulKUClKUClKUClKUCuDdYej+o9ea0VdY1xtjMFDLbDLby3AtKRknOEEfmKvWu81rurda6e0ihpWobozDU6CW0EFS1AeoSkE4+uKDieufh5mTryxI0tcYzEVLCELE591bniJyMg7VcY24GeMVW1X0DvE+9G9WW+xodxkgOSUErSEvFP8QoWkZ2k5OCB3rqll6oaOvUWa/br006mGwuS8gtrStLaBlSgggE4A9AaxrPWrQTsWRIRfP4TG3eVRXgfmOAACnJ7Ht7URp+kfh+jW/Tt7iXu6mRNuTIZDjCMJYwsLBGeVHclPtwMfWtVR8OGoStMN3U0T8KS5vACXCQfVQb/AC5x9a6l1M6hW2DZIKLfqqDZ356EPh5yMt91LC05C0NpGQo8Y3D39qyXTvVmnn9Jq8tqv8YRbmyqVMmHw3Ep5O5YIBA9Mn270Vo2uugbFzt9nOm7kIdwt0dEbe+DteCTkLJTylWSeQD6e1Y7Tfw/TY/4pP1BeWZ11eiPsxgCsoS6ttSAta1DccZ7Yro/+2HQvkpMtN+aUzHWltzay4VZVnBCduSOO4GK0nqV14gwLFBlaFlRZ0l6QptxMqK6EhCU5JGdvOSn96IxOk+hWoLPYtUQZFxtS3LrCTGZUhbmEqDiVZVlHbA9M19snQvUEDQWprG7cbUqTdHYi2lpU5sSGlKKt3yZ53DGAav3+pF11N0LkX2JeYdnvMWSGZrqGHAhsFZCUp4WckKbORn17emb6Ma2QjpzMumrtUxpzcaWWjKWlaNg2pIQSpKStXOeAe9BxLqnoW4aA0FZbZdZMWQ8/c5MlKoxUUhJaZTg7gOcpNZrQ/RWdrLR1huMe/GJbJKFuPx3Ape1xLq07kJyE8pA7/XvXbI2t+m2vZ8e2uyLXdJKVHwGp0Q/mPfZ4icZOPTvXuy9TOn0SadP2u4RoSoxdT5dERbDTWzcpfO0JHZR+v60Gl9Qfh+jXhm2q0zObgvQ4yIqkSEkpeCc4WSOQrk54OfpWsSPhvvEe8x3bXd7euG0WlEyCtLilAAr4CSAN2cc9sV3nSGu9N6vceb09dGpbrI3Lb2qQsDtnaoAkfWrvVWq7HpSIiTqC4swmnDhG/JUsjvtSMk/oKKiNr+Npq3dRrwu23i5WtKZbiJUdtg7sbvnDS0qwQecBWMfWsP0s0bcNb3e62+07Gh5RRLz5OxHzpwFEA8nB9PSs38RN4tl41tGnWFyI9AlQWng6y0kFaipYJUcbs8AEHtiul6L6hI091KvGmU22z2vTVvEl11yLFUHSlpBVuUQTuOB7Zoila+hWoInT6+WFy42oyp8qO+24lbmxIb3ZB+TOfmGOK+x/h6lPaC/C59ziN3pia7Jjvs7lNFC0NpKF5APdvOR2+tdPgdWtGXC03O5RLspcK2pbVKc8q6PDC1bU8FOTk8cZqyPW3QIipkG9L8FSy2FeTf/ADAAkfk9iKK53pL4fbqjUUO4auvrMuPEUhSWmFOOKcCTkJKlgbU/bP6VkOmHRe+aT6jR9QTp9seiNl4ltlSys70KSO6QP7Q9a6Avq7oZHkfEv7CPOI8Rrc2sYTkjKvl+Tkf2se/aslqvqFpbSimkXy7sR3XUhaG0hTiyk9lbUgnH1oM9eYq51nnRGlJS4+w40kq7AqSQM/vUe9G/DzcIYvEfUNygqjToJjtriFaltueI2tKsKSAR8hzz6127SOttPavQ8dPXNmYpnBcQApC0g+pSoA4+tbFQRdPw0XRMCXtvcJyZ4iRHyFob2f2ivgnd2wBx9a7D0R0RP0DpKTarpIiyH3Zi5IVGKikJKEJx8wBz8proNKBSlKBSlKBSlKBSlKBURviMQiP1piyNQMyHrMpqOrY2cFbI/OlJ987v3qXNc915qzp23cvwXWb0F2YztUGJMRbuzcARghBAyCOxoI3Q39FTL5fF6Vtl/jK/D5io4W+gttp8svduGCrb3/tHuKvvht0hY9X328R9RQRMZYjJcbSXFo2qKsZ+Uj0qVFu0fpy2xJUa32S3xmJTZZfS0wlPioIwUq9xg9q9af0nYNOvOvWO0Q4DrqQhxTDYSVDOcGiIfdSIMSxdYp8e/RHDaWlpS02QtY8uGwlrGFpKgAAPzDt3rEtx7bKsOoHNNRr2XWmwuQslIYEfxU8KSMqHO04Kj27nGam1f9MWPUPhfjlphTy1+QvtBZT9iaqWfT1nssJyJabZDiRnf6xtllKUr9Pm9/1oIHPS7C5otiLHs0lN/afK37j45LamznCdnYen7d6z70FC+g8acmMhTzeoHG1PhA3JQY6Pl3d8Zxx71JN+d0pZvr2knI1nTNkSEpdipi4Qp4cJSVBO3cMkYzwTjvW8wdK2GDZ3rVEtEFq2PqK3IoZHhrUcclPYngfsKCL9qvFsl/DFfbXCYLdxgPMLmueGEhwuSSUHcOVEJSBz2wBXPHWZqumER5tKzb0Xd9LpH5Q4WWdmf0C6m0xobS7Ftl29mw25uFLKVPspYAS6UnKdw9cHkVcQNJafgWqRbIdmgtW6Qre9GSynw1qwBkp7E8D9qEQov67Dc7rp1jp7brjFuHhttvB1e5TknIwpHJxz68DtwKzHT21xbx10/D7ww3Kjuy5vitrHyqIQ6f8AMA1Luy6M01Y5Qk2ix26HJAIDrTCQofY9xXmDorTUC7/ikOxwGLjuUvzCGgF5UCFHP1BP70EX/hRUR1PdAPBt7uR7/Misx8VrLrev7DKuDby7QqKlOEHGdrhLgSewVgp/lUibHozTdhmmZZrJBhSigo8VhoJVtOMjPtwKyN5s9tvcTyt4gxpsfO7w32wsA+/PrQQL1+9p6TqFT2j4EuDaFtJ8NqUSVFXZRGSeMj3PY/apd690ZYmdI6ovEG0R03p+2SSqShJ3qKmlA/vWwzdAaSnFgy9O2x3wGgy3uYT8iBnCR9OT+9bNtTs24G3GMemKKgZpK8Q4WgdcW19axKuDMTwEhBIOx8KVkjgcEd6wDv8A+mY3/GO//I3U8E6F0qlmY0jT9sQ3LAS+lMdIDgCgoA4HbIB/QVpGqEdItMXBmz3yBZo0hRDgZ8qVBG7A3KwCE5wO/tREaNdW2HC0roiRFjttPS7e44+tI5cUHlgE/XHFfL7tjaxtkjVDLr0J2BDdwpKlb2zGQEkAKSSAfZQ7Gpd3KwdPnUQ4VyiafIithEdl5TYLaFHcAkE8A5z+tZq56Q09dIUSJcbLAkxoiA3HQ6yFBpIAASn2GAOPpQR3+G5Nid6iSHLJHvPjJZdKnFFCY6WiRgKT8yhzjAKjyO5xUpaxlisFpsEdbFktsSA0s5UmO0Ebj9cd6ydFKUpQKUpQKUpQKUpQKUpQKhf8SKijrLcFAbiluOcD1/hpqaFRk629LdYan6lTLrZLWH4DqGUoe8y0jlKEg8KUDwR7UFa39btWwNbptmq7Q1CjTFgNMrZKHWEr4bVk/mGcZyPft2q36b9YtXX46nFxkxVeQsUqextjpTh1vbtJ9xyeKubT0f1nfOobN01zPafiQlpCZPiJUqQhHKAlI7DPJzjue9YOw9GNf2KffW4AhpjybdJiF4OoV5hChw2kEgpKiEjJwBzzRFXTvXnVadP3ydcG4055gstRwGQhDSlleVr28kfLjHuRVOxdZOp9xQqZAt8a5RkKwtDUMqx+iTuFU9JdJuo9ptN1REiMQJTq2VBL0hlxEhtIc3IIBUk8qScKGOPpVo10Z6iXO/tSXoFvs60EYksOtMoSR/aCWec/YCg8aru4j/ECwtu2W9t5U6GoqLRyFOJbUokZxuyo8kZrI6S626+ubl1ShqJcFR7e9JCfCQ2GgjBLh/vADPy+pIrK6r6Waxm9Y273Ht/mramXEcVLMhpJWltLYWraVbu6VcYqx6ZdJ9aWSTqJdzs4ZTLscuGyfNMq3OrSAlPCzjPueKDP6A673GVpXUs3UUSO/KtbKHmSwPDDpWsICVDnHzFPI9M1qh66dQ0st3dUKCLW66UIHlT4aiO6QrO4/vWS6c9FtS/heqLbqOGm2ouEJDcd4vNujxUuJWnIQonGU1h7b0o6q28ptsBtuHES9vEpmU0jn+9vSfFx9P5UGz9Q+vV8hR7OmxW1uCuXDTKdXLbKlBRKklKQcDAKTye/0q40f1W6goddf1HY0ybWmG/ID7UZSNxQ2paQFpJTyRjtXrXHTvqKfIs2+RF1HFbiIbd/ES08rxuStQ8YcAk8EHOAKw3Tno/1As8i4zvMtWZ5yI822yiSCXHFJIRnZlIAJBzn07UGNt3W/qNfLg6LNFhPFPzeWZjbiB9Mncf0qRGiL9drx09Yu16hiDdS06XWPDUgJUkqA+VXIzgH9ajdeekXUm8SGW5lmtSVJVzLYMZnd9VFGFK/YmpJ9P8AT1wsnT+DZL1N83NbZW248FFQAUTgAnkhIIH6UHDem/WLV19OqPxGTFX5CxSp7G2OlOHW9u0n3HJ4rX2Ouut12CbLVLh+M1JYaSfKpxtWl0nj/uJq9sPRjqBYp99bgiGmPJt0mIXg4hXmEKHDaQSCkqISMnAHPNYWP0W18jT06KqxgPuymHEJ84xylKXgo5347rT+9BnJfXDXkXStnuSo8ENyHnkGUttJD5QR8oQCNoAUOfXP0rX+surW77dNNXv8Jt/jTbS3Id3oJ/iB11BB5GU/JxnPFbHe+k2tJPTHTNoYs4VcIcuW6+15pkbEr2bTnfg5wexrH6p6O65nW3TLUWyhbkO2eXfHm2Bsc8w+vHK+flWk5HHNBpvVdd2d6ly3Ln4HnVqZUz4QASGyhJaGB/ubc1OCxicLLAF3LZuXl2/NFv8AL4u0b8fTdmo7dXuj2p7xqCLe9PNMyXFxWEPMKeQhbbjaEp4KiEkfKPX3rvmim7w1pW2o1KsOXkNDzSgUkFeT/d49u1FZqlKUClKUClKUClKUClKUClKUCrW43CFbI5fuMuPEYBx4j7gbT+5NXVRM+JB5c3rBAt9+lvRbGhpgJcSnIbbUf4iwPU5z79hQbZ1M6z6h051HesloRa3raDHLbjjSlqUHEIUTuCwD+Y44rtkLV2m50oxoV/tMiSApRaamNrXhIJUcA54AJPtioOajYtUXXYj6euT1ztTTzKGJLwIUpICeOw4ByBwOBWZ6VzI1s6kvvXB9uM0licgrdUEgKLLgAyfUniiJho1xpNxDim9TWRSW07lkT2iEjIGT83AyQPuRVZnV+m3m2Vs6gtDiHnfAaUmY2Qtzj5EnPKvmTwOeR71Ayyf9l6h/4JH/ANyzXZfh76b23VlhF8nzZ7ci23QlhlpaQ3lKWl5IIPJOAcHsBQScdvFsZuKIDtxhonLGUx1PJDihjPCc5PFaJ1I6m2206Iuly0pebLcbpFDSkMokIe+VTqEKJShWcYV398VFKxSLVO1Hd5+s7tdIM4Bx9l6Ijc4ZO7OCe45+33FYiw/9lak/4BH/AN1HoJZdF+p7uqNNzbjq6VaretuYIzJCvASv5ArHzqOTye1XHXLWeoNK2u1yNLm17JS1hx6W82nsAUhAUoA5yckZ7VFO0RLDI0VeHrleJDF4juJVAgJSS27uwFqPHfA9x2Hetg1BJmSOhulxMWtbbV0ktxys5/hhCeB9AoqoN71N141faXbc0hmwrW9EQ86WwXk7ypQOFJcx6ducHI9K2y39TtVJ6rO2i7L07HsjclxpwKmNJU22nPzZ8TO7jkY/QVGe8/8AU7F/wZ/+u7W9ORGLh8RkmHLR4kaRfnWXUZI3JU4oEZHI4J7UHadH9eo2oddxtPu2hmHHfecZROVPCkkgK2YGwA7iAAM91DvW19R9T3SDPj2qx3LT1qW6ne7Ouk1CS3z+VDROVE98nior6BFmtXV2Ob0UsWyFLeUkrUrCFthZa7cnCwj7+tYm3IhXu5XmRqm5OR5qkrdQ46tXzO5Od2EKJ+3H3FBPmA+mTCZeQ+zIC0A+KycoWfUp5PH61rl06g6YtWp2dPT7q0zdnSkJZKFEAq/KCoDAJyOCfUVzz4W0xmNOXaPBva7nHQ8hfhmMtpMdSgcgFX5s4Hbtj61caxidMHOrcNy/SVo1PvZPhAr8JTnHh+JgYzjb6jjGaK7LWGXqvTzczyjl9tSZWceCZbYXn225zWv9b5kyD0q1FItylokBgJ3I7hKlpSsj/ulVREsdn0hL0g5Lu2o5EG++a2JjJjF1PhYHzcdz35z6dqCdsybFgxVSZslmPHSMl11YQkfqeKtrTe7VeErVaLnCnBH5jGfS7t++0moadRpq3bboq1Kvcmdp5uJlEpTKm8/x1pUdhOSUpSkD6D61X08Lfp3rXYWun12k3KC5IYbLqklJWFkBxB4GRjPOOP0zQS5g6u03PkmPB1BaJMgJUotMzG1qwkZJwDnAAyauYd/s86G9LhXWBIisp3OvNSELQge6lA4A+9Qf6b2hi+awlwpbj6GTDmOHwV7CSlpagCfbIGR6186cWtN1iavQ5JksojWN+XtZc2h1Ta2ylKx6pyc4oibb2qLAxb0T3r5a24K1+GiQuW2G1LxnaFZwTgE4r5/SrT/lY8n8dtflpKill3zbex0g4ISc4JB74qCEV5w6DubBWfCTcoiwnPAJakAn+QrJ6ks7EXpvo66pdfXImrmtrStzKEJbcTtCB6fmUT7k0E5ZV6tcN6OzLuUJh2SMsocfSlTo90gnnuO1fbrebZZ2kuXa4w4LavyqkvpbB+xURUGdd24QrHo2WJMl52ZbPEUHnNwbw6tISj+6nA7Vc6jmr1BrqF/S2Y+iMYkZJcUsp2oLCFAg7VYBJyTtPcmgmynUNlVbHbkm72829rHiShJR4SMnAyvOByR6+tW7OrtNvxHZbOoLQ5FaUlDjyZjZQhSvygqzgE4OB9KhpAj26DpzVrdr1GqR4kYJVCRHc2rQH28LLhCRkcc7R39M1jrTaGJPTC/3Rxb3jw50VttAWQjCwvJKfU8Dmgll1W6oQtCWa3zozMa7OTXdqGUSw2S3tJ8QYCspyAO2Oe9ZjpfrVjXmlWbu0y1FeK1odipfDqmSFEDccDGQAeQODURJkRqR0Ot9xdSpcuLfXYTThUfkZUyHCnGcfm57V3/4VXLN/QBbNvcQbsHS5cEBSiUkqWGyQeBlKfT2oO00pSilatrjQOntbNsJ1BC8ZxjPhvIWULSD3GR6fQ1tNc26p9XbP0/lMwXoz0+5uN+L4DSgkISTgFSj2zg8YNBRl9DdEPz2pYhSGFNJbCUMvlKBsAAOPfjJPqcmr5/pDoqRqF28qtYMt1S3FpDhLZWrOVbO2cnP3rQx1us+tdKamtDkF+2XB20yyylaw4hwhlZICgBg4BPI9K5b0J1gzodrVF6kMeaLcZlCGA5sLilOgYBwfTJ7elEd6jdB9FR2ZTTbE/ZJbDTmZJ/KFpXxx7oFbloXRtp0RanrdYkPIjOvGQoOubzuKUp7/ZIrnts68WxzRj2obva3oSPMmLFjNvB5yQoJClEfKkADI5NWekviJsl5vLMC52uRa0vrDbb5dDqAScDdwCkfXmit3l9J9GytSi+u2hHnisuqSFHwlrP9oo7Z9fvzWEi9CdEx2ZbLTU7bKaDLgMoklIWlfHHuhNWmruvWndPanVZ0xZU3wHfClSGiAho5+bHqoj17dq4P0ZukSJ1pYukl8NwGzNkLdVnAQGXTn9qIkQ30L0Mm3piKt77iEveMFqfVvzgAp3DB28Dis5qbplpnUVjttolw1s2+3EmO1GcLYTkYP3rmcv4mbQ3PU3FsE16GDgPKeShRHvswf86zur+ucKy2Ox3i2Wdy5226Ic2uGQGVNOIICm1J2q5596KvpHQbRT7cZDjE/bHb8JGJJ/LuUr291Gsq30j0sjWH9JktS/xTzZm7vHOzxCrd+X2z6VqGp+v0SzqsyIdicnruMFqWUplBBaUskeH+Q5Ix34rqepNSxNM6Vevl9BjsstpU42g71bzgBCe2Tk49P0oNYvvRzRl7vi7tLtq0S3HPFd8F5SEuK9ykHGT9MVS1J0W0XqC7PXGXb3WZLytzvlni2lavVRT2yfpWkL+Je0mBIdbsUrzKHUpaYW+E+Ig5yrcEnBHHH1710zpRrlPUDTTt3RAMANyVR/CL3iZ2pSc5wP73bHpQZvSumrTpW0ottihoixUncUgklSj3Uonkn71hLz0z0xedXMalnwVLubSkL3BwhC1IxtKk+pGB+wrnepPiPs9su78O22aTcGmVlsvl4NJUQcEpGCSPvisF1C60vaj6cOyNMQ7rbZAlIaflNulPl+yh8yO4VyOcfrQSPlxmZkV2NKaQ9HdSUONrGUqSRggj2rmS+g2glSy/+GSEpJz4IlL2fbvn+dcz6VdW7tY+nV8uN9jXC9+VnNhEmTKV83iJA8MKUlWNu3dj/f8AT12Wz/EXDucm1xUafdRKmTBGUjzWQ0klASvOznJUrjj8vfmg6bqPp3pfUFiiWi4WtoQ4adsYM5bUwP8AdI/n7+tWWi+lek9Hz/PWi3qM0ApS++4XFIB77c8D7gZrStG9emtSu3dCdPLjfh9tfuJJmBe/wgDs/IMZz39PavulfiBtd2hXeZdLS7bY1vZS7lMgPKdUpQSEJG1PPPvQbPp/o3pOw3Rdwt7MwSVtOskrkFQ2uJKVcfYmvlh6NaSsSLmmAzMAuMNcF/fIKstLIKsccH5RzWixfiZtC5wRJ0/NaiFWPGS8lagPfZgf51pfXzqLfDrdpOnrndbbbBCZUytiQ42iUlY3+KAMf3tnryg/YEdhR0I0Ui3vwksT/AedbeUPMnO5AWE849nFVez+jWkp1gtVmfZmGFbVPKjgSCFAukFWTjnkCtUu3Wx7SukdJyblp6S/KuURS1pelFtaS2rZuOUEnd+bP19e9VdY9eW9NGybtPLk/idrYuQxMCPDDm75PyHONvfj7UVst36M6Su0K1xJjMws21gxo+2QQQjcVc8cnJNXOoukekdQRbczcILm+DHRFaeadKHC2hISkKI/NgD1rRJHxGQomopdtmafdbZjPOtKfTK3E7N2MJ2epAHf1q4uHXW0SenirhNiT4Eyc49FYjw30qeTtSnLgWUgJ/MOcHn3oNutnSfRUSw3WyQYh8OZsbmOB8qewlSVpSVf2eQk44qnF6M6SjadnWVpmZ5GY82+6DIJUVIztwccfmNc66LdT9HRLwLRGs021yrm6lK5kiUZJfd7J8RRwQST6DGTUjaDR7b0t0rB0lJ00IS5FqkPmSpD7pUoOYSNyVDBHCR2+vvV5oPp/YdCiaNPsPNmYUF4uulZO3dtAz2xuP71tlKBSlKBUWfiP03ebd1Fj6riwXZluWlk7kI3pbWjjarg4zgEE+9SmpQQ50yi76iXqW5NaQhMxBbpbjs55p1TjZ8BYAQtSsFZOOw9TXP7VpadcLJeZyGH0qtyGnCgtn50qXsOPqMg/vX6DUokQabs141F0zitW+3yHXLDLeU8020d5afCSF4xlWFNqBx2BHpV7JY1B1TvdigwdNtQPKMoirfjx1IQEgjK3FHgY9B+3epsUoIfOWjUnTvq1PWxpz8a86463EL7KltupcVkKCuwV6H9fvWo6G01dLzrV+1oiqjypDExtIKClAX4DmE57AZ4qd9KCB8Fy8WKDN05M0y5IkOSEqLT7TmQoY42pwVduOcc8V2TWGjp8v4d21zbJEtdzhP+fTDhNKTsQTtO4Ek7ik7jz6D2qRlKKhH0Q01L1B1MsrU5h/ykI+ZWXEnAS38yU8+hUQP1qS/X3T0/UvTWdDtDSn5jbjb6WU/mcCTyB7nBJx9K6LSgglMVqd3p8m0P2Btm126WCqSYZRI8Ve47Co8n19PQZ9KkP8KTLjPTWWl5tbavxJ04Wkg48NuuzUoINakXKhXmVKa0tc7JfQ8opdjLWhnJPJ8JSCcEZ4Csc9sV0K32PV+oeh2pG59j8OcuSw+xsiJYflIScqJSkDdgdjjJ578VI/VN6a07p6fd5DLz7UNouqbZTuWrHoBWodJup8XqILgI1skwVw9u4uKC0qCs4woevHaiIu22ddmul180w7Z5CGEy0Ty+ppYUHMto8PGMdgT78V3L4Wbak9OLl5mIkP8A4k7sLrfzD+E1jGR713OlFQd0dbtQ6XvOpYbmn5rz7lomw3QpBQGkFHLmSMEDbx75GO9WGj9JXe/2DUTFuhyHJMdtmSGQg7nQlRBCR6nCs4+lTxrR9N9VNJaj1A3ZbRcHXriveEtmO4gHaCVckY7A0RF+23y+vWS0aZa0JCmvwHFEF+3uKccKifzAEe/J+g9q2b4htJX3Zpe5C0BDDNpaiSG4LRLUZ1KlKKcDOE/Pgc+ldb0l1ogak16dMs2aewsrcQl9zHBQCTuT3SOPf2rq9BD3qk3ftWaB0ZezZZLbcVl2E4lptStgSUhKiMZAUEk57VqnUY3e5DS5mWaVD8vY40ZoKBUXUIKwHMY+XPPB9MH1qdtKKhjoWA8v4gmC/EcUwbs+SVtnaRlfuMVv/wAUujbjIk2m+2eCp+FGZLL7bDefDO7cFFI9Dkgn6DNSPpQRB6fv3jVfUC2vx9HQnQhbQflS2nVhlKTkr3bgkHHYY9sCpfUpQKUpQKUpQKjT8Rt31yxqrwbM/cWLEyyghdvUoALIyrxCjkH2B9MEVJauQdRejkjVOrn9QWvUsm0yn20IWlDZP5UhIwUqSewoOT9PtVajsi7ldkaubv0OHAedXEXKdUoL24QSh1IJAURkpz96wTNx6g3vS911sNVyERoMgNuNCattRUSPytp+XHzDjj1rtGgugNt0/NkS71c3Lq48w7HLYa8JG1xJSonkknBPrx3rXJPwyIM5fldTLbglWUtri7lgexIUAT9cURyvWXUvU17j2OSq7T4shuGWXzFfWyl5SXV4WUpIGSCAftWT1PrDWeltX2p57UkuSoxIknw0rUGihTaTsUgkg8cEnk966tq34eI1zTaWbLd0wI0GJ5ch2P4q3V71LU4SFDk7u2PSvWtugr+pbrDmI1A1HEeFHibDEKtxaQE7s7x3x2oN763armaO6fTLla8CctaGGXCMhsqP5seuADj64qM79w6gWzSdu1wrVclUaXJLSGvOrWsKBV+Zs/Lj5Txz6cVLvWWm4GrdOS7NdUqMaQkDcg4UhQOQpP1BFcKjfDIkTE+Z1MtcIKzsRF2rI9slRAP1xQc+6r6/v9zm6fuMa6T4Bl2hlx1mLJW0gub3EqUEg+pT/lW/ald170z01etQXe+tT5N3cbjRg2644iIpW5ZUlCxtHypwMfSth6hdBW9S3OA7ars1bIUKC3Cajqjlw4QVHO7cO+6tw63tWxvpZche4r0qG0GshhQS4k70pC0k5GRnOD37etBG+7TtfW3pxDv8rVDzttvEkBCUzlmQ2tO/9gcHIB9siref1F1QjRmnbPFvc1lcjxX35SpCvEXl5SEguE5CRtPr6/StNuosLUAt2l+5SpKnQpK5LKWUtIwcjCVq3KJ288Yx6547xpXoqjV3SnT67hIetV2b8VxtZb3ZaWsqSFJyD9Rz60HMeoN/1jZbtFt03V65i48RCUv2y4LUhSSVEbyCMrGcEkZwBWTsd91XcOsSrXb9ST2Fu3F9lrxn1utNjK8fwyrBwOw7dq6BcfhmbcTEFv1CGShgJfLsYr8R3colQwobRgpGPp35rP6d6Gv2jqO1qhV+adQiY5K8uIpBO4q+Xdu/3u+KDj/T/XWpxK1LbZl7nymnbRPILr6lFtxDK1pWgk5Scp9PerfQepNaL01qRNhuNwkzCY6SC8pxxKCXCotgkndwM45xk+ldXsPw+SLXc58s6iadEqJKjBIiEbfGaWjOd/ON2ceuKoW74cVsWqbEf1N87zrTzbjUXbsUgLHOV8g7z2x2oOS2e76vXJCXdbyrbc/E2iJcJchpRPpypOwfqRW0am1drDU/VRyyQtSCyphulhsuyvAYCmh8ylEfmKlJJ5z3A7VuLfw4PS7g27fdXSZrKAE4DB8TaP7IUpZwO/pWZ1v8Ptr1BqEXKBdHbc25s8djwg4FYABKTkYJA9c880HGtL3zVF+6pJtMzU89Kpsp+OtyLLWplKlBY3NpCgNoJynGOw7VZdEbY9N6xWeM3OdjrYkreU6jOXA2CpSDyOFBJSfoT3rtmlegY05r2Jfol7SqFFlKeaiKjncEc7Ule7kgEc49Ko3H4d46tWG62q+rhxTI8x5dTG8o+bJSFBQ4+47UHMrfrC72nrXeZK7hOfjQ5Vxd8suQstqS2h5SUlOcY+UcVaxLp1A1bZr9qxvVLzDFrIW8yJime/OEIT8uPvjP1NdltfQzy3UeRqWZeGpMR+TJechGMRuQ8Fgo3bvZffHpWv3D4Zml3B1Vu1ItiAtWUtOxt60j23BQB++KDn2rOpOo730705Icuk2PPjy5UV5+M8povpShlSSraRkjeR/P1qz1FqbWdpsekrgdU3AplxFuMoQ6oFAS6ofOc/OSfU+nHpXbNUdBIlw0rYrJZrr5JFuW86688x4ipDjgQCo4Ix+QD7Y9qtdSdBH7xYdN25OoGmjaIzkcuGIVeLucK8438d8etB2HR9wdu+krJcpGPGmQmZC8DA3LbCj/ADNZesZpe2GyaatNqU6HlQYjUYuBO3fsQE5x6Zx2rJ0UpSlApSlApSlArUdddRdN6I8JF+mlEl1O5uO0grcUntnA7D6nFbdUSfiNYNu6yRLneoTkuzutsLDe4pDraOFoCvQ5z/731oO+aH6q6V1nNMK0zXETQkrEeQ2W1KA7kehx9DWJvPXTQ9rua4Sp0iSpCtq3YzBW2k+vzcZ/TNcN0g9YtTa3ntaM0nOhzHo0jyryZ5CIpLKkhRQE9iT/AHu5rSLJPslnsWo7ZqKwOyL28nw4j6lFBiLGQcj6HB+uMURLXUnWLSVit1qnuSZEyHckuKYciNhY+QpCgoEgg/MODVpI656Hjuwm3p748yyh4lLJWGQoZCV7c4VjuBnFRNvVtnwdEaeenIcbYlyZbsZKxjKNrAKh9CQf2rLdU4UWFG0UYkdpgv6ejPO+GgJ8RZW5lSsdyfeglY91e0a1qdmxG6Bcp0oSl1CCpncrskrHY8j6DPfvWMh9dNGSLw5b3HpkVbfib3ZDIS2nYCTyFE87SAMckgVGfqtCjWzW8Jq3x2ozfkYTm1pISNxZQSePUnnNX3S+FFuPWby0+O1JjqXOKm3UBSSQ06RkH2IBoJKWbrVom6w50hu5OR/JtF5xuQ0UKUkED5fRRyQMA55q+snU/R+otO3K5tz0IgQgBLTKbKSgK7ZSc5z2GM57VE3pPb4dwc1d56M1I8vp2bIa8RIVscSE7Vj2IycGsbp23z7ho7U34ehxxMdUaRIQgEktgrBOPYFST+lBIq2dS+j67ygM2uHFeK8JlrtSUpz6HcBkfcgVtmr+smltKXw2q5eeXIDaHAuO0laClYyCDuHoaiZGuOnHbXaor9klSJrSiHvLOhgvZPHzELKj+gx6VmOtUfy+tYUcxXIgRbYSPLOueItrDSfkUrAyR2ziglJbOrmkZ7F8kJnLZiWhaEPyHUYQsqKgnw8ZKs7D6ZrE23r1oadcERfOyo+9W1Lz8cpbJ+4zgfUgVqHxFaGttk6dpe0tZ2ojQmtOTPLpPKAhYSVfQFf86403e9Gv2axQv6Hy5FzYSUSnGZpaMlZIx2Son7YGO3NB0fqLqO5W7rqGRq64sxW5MciOylRQhC0oVsCQdqgQrufeux3Pq9o226nFik3TEsOeE44EHwml+yl9hzx649cVGPqY0WOsrDRYXHKBbk+Cte9TeGGRtKvUjtn1rF2xSdPa2u0HUmmfx6c4tyMmM44ttQeUrhYwCVZ9PfPBoO29Qet1mv8Aoa9xNKyLtDuyGm3G3wnwSkB5sKwpKsjIJH61b9AOoHkdH6hu2t79KejsSWm23Jby3lZKVHagHJycdh7VHezf9TvX/Bj/AOs1WRYt06T08kTIyFrhRLiBI2jISVN/Io/ThQz9frQSysHXLRN6ubUBubIivPLCG1SmShClHsN2SB+uK6PcJsa3QX5k59uPFYQXHHXDhKUjuSagzCmacudwssaPpudLlbEMrZiPiP4rmR2+ValffI/SpVdc7bNuPSG8Rbcy4uQlppZaR8yilC0qUPrwDRWLHX7QhneX85M8Pdt8x5VXh/f+9j9K1Hrr1huNhvFsh6MuDaUrj+YecLKHEOJXgtlJOfTdXBINxsCdPMQ59pffnofKlOMLDSlo9ishX2wEgVv3Wu1qjaD6fyGLTJt0YRn0lp5zxVt7lJUhKl4GSRkgYGO3pRElulOpzq7QdqurilLkraDchSkBG55PCyAOMbs4rba5x8P2oIl/6a25MOO4x+GpRAd3gDe4htBUoY9Du9ea6PRSlKUClKUClKUClKUCrafAh3FgsXCJHlMn/wDbfbC0/saua4L1t6o6itOs4uk9GNoTPWG97pbSta3HPyoSFfKBgjkj19MUG53LqDoPQ9+dsCktW6akoC2osEpTlQBTylOOxFZHX9w0Xp7ZctTQLc/PXwwgxEPSXiOwQMZP37D3qI/UCXfJvUsu6riJiXoLjNyG0kEEpQgBQwSOQAeOOa3nU/VvV2odXzVaXMCHHgFwMKcbY8TwwcE73fVWB8qf54oiTjtrsmpIMKVcLRElteGFspmxEqU2lQBxtWMp7DI+lJeldPTAwJditT4YbDLQdhtq8NA7JTkcJGTwOOajdceruvW+m/mpSHrdcW7gy23PMNKUyGlNukpwtJTkFCTkD/zs2eqfVJ/Rzd+jKCrXBdLUqcphk+KtShgFOBgDKR8o7nk+xXaOoGo+m+mb2zE1XbbebguOh1BVbA8fDyUp+bae2wgD0xW5WvT2nUONXK32S2MvuJ8RL7cRCHMLHPIGeQTn71DLq/q5et7jYrw+ylmSq1pafQj8u9LzwJH0PB/WulXrqjra86oZ0r09bQ2uI0GchttTjqkI+ckufKkAgj9PriiJDRNK6ehF4w7Fao/jNqZd8KG2je2r8yFYHKT6g8VWten7NaFOqtVpt8FTo2uGNGQ2Vj2O0DIqN1l6ta2uVg1LaJL4jajtTKpbchDDe4hpYDza0EFOQCTkAflNYT/bnqn+gnhC7/8ASAXDJkeXaz5fw/y7du383rjNFSdlWrSunEPXl+3Wa2hkFa5nlm2yn/vAZyf51jNPOaR6gsvXhqxRZe1zwRInW5IU6EjhSSpOSnHb/SuBam6q6wY07YLI87GlXW4sImPvyYzR4cWS0gJICBhISokjufTFbN0k6i69ka0Ys+pIyrnbnFeC5JjsIUlg4yFeI0NhHYH/AMqI7vfr9ZbKhpN+ucCAh/cGxLfQ2HMYzjcecZGfvWvM3bp3bFsXBmZpWIuQCtqShbDZcAJSSlQ78gj7iuS/GP8A1Wk/8Ur/APFXBb3d2J2n9OwGkOpdtzDzTqlAbVFby3Bt59lDvjmgnYmy6Yvy27wm2We4rfCXETfLtuleOAQvBzjAwc+lXtyjWxgru82JHU9DbU55hTIU42kAk7TjPbPaog2fqZq6yTrDZLXdyxa0NQ0JY8u0rAWhBUNxSTyVH19azut+pmrkdTLxp5N4Is/nXInl/Ltf1ROCndt3dvXOaDsGh7z0x1jcpNu07Z7W7ISwXXUqtSWwWwpI5JQAeSnit9j2ix2WBJTHt9tt8JwZfDbKGm1DHdeAAePeoU9IZ2qoN5uh0NF8xdXIC0qVhJLLYWhSlgK4J+UDHP5u1bTeNeao6j9MLhb5LZky7fLZffXGRtU8wUrHKB32qCScDtzjjNBIy0XXpzAmKVZ5mlIso8FUVcdC/tlPNbmy62+0lxlaHGljKVJOQoe4Nfn1bGtOOQw1dnbtDnZILzTaHWhzxlBKVD68n7VvkjqRqvRdwt1ksd9RJs8RiMWkMx2yl1Cm0rIBUjcM7j35GcelBLVOl7Amd51NjtYmbt/jiI34m733YzmsjMiR5sdTEyO1IYVwpt1AWk/cHio0R+rHUDS+vIUPXMVpEOctK/K+GgFtpasAoUn29lEnjn3qhO6rdQ9aaluTHT9sNQYYU4lttptSy0k43KLmck+w/nRUkD+DaXtLjhFvtFsaIK1YQw0gkgAnsBkkD9q92W+2m+tOOWW5wrg20QlaoryXQk+xKScVFq+dRb9r/o3fI812M1Itj8dyatKNvmo6l7UgDBwoObCcY4H6HZPhAZuWL6+JDf4QNqFMY+cv8EK7dtuR39e1BJKlKUClKUClKUClKUCuJ9a+klz1VqKJqLS01qNdGkpQ4lxam8lJylaVDOFDt+grtlKCKl16E63k6kbnv3CLcllTTj0mRIVvUoBO4cgkgHIHuAO1ZLU3Q3Vdu1XOuGhrmyzElKWpP/pCmHGgo5KMgcj2OakzSgiL1M0DddFdJ2V6guq506VdWR4SXVLaZSGnuBu7k55OPQVZ6F6Zap1foKKuwXkNWqU+4JcOQ+tDQWhQ2r2gHdkY9O4/aV+p9N2jVEBuFf4Lc2K24HktrJACwCAeCPRR/eqmnbDbNN21NvskRESGlRWGkEkAnueSTQRx1t8P98cVZo+nHIb8eJASy86+74alvF1xaiBg8fOMVktXdEtTsamRftEXNqLJeQFOjx1MracKcL2qA5STk+nepH0oOLdGuj0nS0u53TVMpmZcZzK45bbUVpCFnKypRHKjj/Pvmo43PRMmF1N/oiHW3nlTURgto5G1ZGCfqEkE+3NT3rU4vTzTEXVKtRs20C8lxTxkKdWo71AgnBOOxPpQc66y9GpepJttumk5DEaZEYbjFh1RQnaj8ikqAOCO36D9bbpf0q1hb9YM3zWF+ccQwd4YalrcLygMJ3k4G0e3PbFd6pQce+Ibp7e9et2EWERcwi+XfHd2fn8PGODn8prmt66D6rlWDT0WK1a0yojDyJKvGxuUp5ak87eflIH8qlXSgi3eOgWqHXLNMt0u3olNRmUSErcP8N1sBO5J24UMBJ/ek/ofrR/XD12elQZja5ReVIW7sW7zkq2AYGfapSUoIn6e6E69ti5r8S5xrbJMcobVHlKHi5UkFtRAGAU5PryB96zkXoDfIGii3BusVvUS5jcorQtaEIQhC0hCVgZ3ZcJzgD0+tSUpQRQn9EOo9/lRxfrrEfS18qXpEtTpQknnHy5NaN1R08zZOp34A08tbUdEON4vZSv4LYKvpySanRWqXnp5pS83td3ulmYkXJZSpT6lrBJSAE9jjgAftRHH7H0O1HL1xFuWsb6mfb4LoLSlvLceeQhWUJ+YYSD6jPv96sb70N1daNST5WhLu1HgTNwwJCmHEIUcltWB8wH+lSZpRXDNI9DFW3p1qGz3Ge0bteUNhTrQJbZ8NW9A55PzDk/8q+dDOmmrdC6llLus2KbM40oFmO+pQccyNqtpA7AH967pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpmvmaD7SsJftU2LT+0Xq7wYKlDKUPPJSoj3Ce5rBI6raGX21Nbx91Ef5ig3jNM1p7fUrRjn5dT2r9ZCR/nVy3r3STn5dT2X9ZrY/zNBs+aZrBtar089/VX61L/wAMxs/61eNXe3Pf1VwiL/wvJP8ArQZDNKoJlMK/K82fsoV7DqD2Wk/rQVKV5zTNB6pXzNM0H2lM0oFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJrlHX3qQ5oeyMxLSpP41PB8JRGQygd149+cD9fauqqOKhr8TsxyV1VktLUSiLGZaQM9gU7z/NRoOX3CbKuMx2XPkOyJLqipx11RUpRPqSat6UohSlKBSlKD0lxaPyrUn7HFVUzZSPyyX0/ZwiqFKC/bvN0a/qrlNR/hfUP9au2tV6ia/qr9dkf4Zjg/1rC0oNla17q5rGzVF749DOcI/mqt00V121XYpSE3WR+MwMje3Ix4gHrtWOc/fIrk1KD9DNJait+qrDFu9od8SK+nOD+ZCvVKh6EGsyKi78It7fReb1ZFLJjOMCWhB7JUlQSSPuFD9hUoQaK9Ur4K+0ClKUClKUClKUClKUClKUClKUClKUFus1Cn4iF7+rd5+gZH/wk1NNw1CPr0vf1Z1B9HGx/wDCRQaBSldE6FRYT+s5EickrVBt0iZHQloOqU6hPy7UHhSgCVAe6RRGgyIsiNs8yw6z4idyPEQU7h7jPcVlNRaefscSyyH3m3BdIaZraUZyhJUpIBz6/Ka6fN1JbLxo7Usa4X3UWoUFjxWTMt4xDf3DYvxAs7Ek/KRwOayztujOQbDKittXDUtv0tGet9tdRlC/mWVuYxhakg5CPXGecYoOX6YiaLbtXndU3G6uyitSU263MpSoAdlKcXxg+w5q7nQdBXK1yXbLcrrabiw2pxMa5oS62+QM7UrbGUq+4rIaPkosuhr1rBMGNcL2bgiG2uU0HERQpJWp3Z2yT8oJ4FVb3PTrTppcr/d4cKPebZNZZRLjMpZ80hwKyhQSMFSdu7PtQcwrJX2yTrG7EbuLaW1yorcxoJUFZbcGUnjtx6V0fWV1i6BnxtNW2wWmSyzFZcnPz4odcmLWhK1fMeUpGQBtxjB5rZrtY7VqjqfETMYSxabVpdiaYr7xQNqGklLa19wBvTk+wNBwCldm1Ba7PdNJXd6cjRVvuMNkPwXLLMwXtp+ZpbZUdxKc4PfIqwkaKtdx6gaXFvZTH07doLVxdAcO1ltCSZAKiSRgoV3PGaDlFKurq5GductyAz4ENTqyy1uJ2IydoyeTgYq1oO3fCYn/AKe3Nf8Adtyh+7jf/KpZoNRT+EpP/Sy9L9oQH7rH/KpUoNFVhXqvIr0KBSlKBSlKBSlKBSlKBSlKBSlKBSlKCxdPFQb6zueL1S1Gr2lFP7JA/wBKnG72qCPVRZc6k6mJ9Lg8P2WR/pRGrVdWq4zLTcWJ9tkORpjCt7brZwpJq1pQbRqLXuotQW7yFynJMRSgpbTLDbIcUOxXsA3frVkvVV4XdLVcfOKTMtjTbERxCQktob/KOBz3Pfv61hKUHWtGxtZPMS9Q6X/Cbum5qULlaEJQsfmOPEjnAweSCn3PbmvOvbZre46cXJ1BbbdpyxwP4jNvbSiIhxw4B2NZKlrxk8/XHtXKWnXGlbmlqQr3ScGvTsh55SVPOrcKe29RVj96Dp8jUE+PBZj3Ww2O/S7Sy2w1LkZLrOEghtaUrAc2nIAIP5Tn1r5CumsrnqqXqxm3x5TrDPkZjSloLclKGQlxG3dlZKU7iE5wT9q0pjU89svOrXvlL3FL2AkhShtUs4HzKx2J5B5qnbNTXW2WmTbYkhIhyCVKQtpK9qinaVJJBKSRxkew9hQdBv8AbLiq1u2yw6Fh2o3DaZD4miU4gJT4uNylYZSR83OMgd6pRdQ3my9MpEB7T4cLCZEBq7CQFeXbecHiJ2jPcoUkKyByf1w03qfeHbx52GxEith0PBlDeNyg34aSpadqlEJJAOfU+5qwu2v7xdbBItMpEQR5DhccU22UKUfEU52B2/mUeducYGeBQalSlKDvnwko/wDXeoF+0dpP7qP/ACqUDZqM/wAI6MydSr9kx0/uXP8AlUl2/SirhPavYqmntVQUClKUClKUClKUClKUClKUClKUClKUFg72qHHxD6afsnUCXO8M+SuZ8w0sDjfgBafvnn9RUyXBxWuaw01bNU2hy3XmOHo6uQRwptXopJ9DQQJpXb9RfD5do8harFcosqOSdqZOW3APbgEH78fated6I6xR2YhK/wAMgf6iiOY0robnRzWaO1uZV/hko/1NWznSbWqP/wCFKh/uyGj/AP6oNFpW4OdM9Yt/msMk/wCFSFf5GrZzQGrG/wA2n7j+jJP+VBrFKz69F6mR+aw3Mf8Ahl/8qoL0tf0fmslzH/hV/wDKgw9KyDljuzf9Za5yP8UdY/0q2chymv6yM8j/ABIIoKFK+7Ff3VftW+6A6W6g1bMaJiuwbZkFyW+gpG3/AHAeVH7cfWg678JttcZsF7uK0kIlSG2kE+vhpJJ/df8AKpAN1hNL2SHp6yRLVbG/DixkbUA8k+pJ9yTkn71nECiq6e1exXhPavYoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLZYq2cTV6pNUVJoMe43VstqsmtuqSm/pQYtTNUyz9Kyha+lePB+lBjSz9K+eD9KyXg/Sng/Sgxng/Sng/SskWfpXzwfpQWAZ+lVEs/Sr0NfSvSWvpQWqI6CoKKE598c1eNIr2huqyEUHptNXCBXhCarJFB6FehXwV9oFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJFeCmqmK+YoKJTXgoq5xXnaKC2LdfC2KuttfNlBa+HTw6udlNlBa+HTw6utlNlBa+HX0N1c7KbKCiEV7CaqhNfQKDylNewKYr7ig+ilKUClKUClKUClKUClKUClKUClKUClKUClKUDFfMV9pQfMUxX2lB8xTFfaUHzFMV9pQfMUxX2lB8xTFfaUDFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFct1P1fjWHqTH0gu0PPOvPR2RJD4SkeLtwduPTd7+ldSqHvXa4iz9f8A8TLReEJyHJLYVt37EoVjPpnHeg751a6pw+nTttaft7k96YFq2NuhGxKcDJyD3J/kayfSvXsbqDYX7jFiLhqYfLC2VuBZHAIOQB3z/Koz6z1K91L6s2J6Fa1yEhqOlFvDyQV8eKtG9WB6kZOO1bR8KNzctusr/p6UC0p5rxA0o/lcaUUkffCj/wC7RHSNZ9a4GldeK03LtTzgQtpLkoPhKUBYSc7cegV7181D1tgWfqH/AEVFqdkLElqMqUl8BIUvb/Zx6bvf0rhPVqErUfxAXC2oXtVLmx4iVexKG0VrOpLfc9PamtMu++Km6SEtz30ujC0kuqxn64SD+tBJK29e7S/erxDn2qREj21t1xx8Ohe/YsIACcDlRIA59axDHxMWRUnD9huSI+eHEuIUrH+Hgfzrh0NcZOptZqnRXZcYtvhbbK9q8GS38wODyPzdscVafjzlsEaFpm53CbCWTugT4iC2FE9g3uWlWfcAGglF1F622bRlzbtogyrhOU0h5aG1BCWwoZSCTnnGDgD1rGQ/iAtMzTV1ukezTvFt3hFxhxxICg4vaMKGex9xXJurMyCNdiVdBdbBfm4cRanoSA4grMdBIAKkqSUklGQTnb6c51yHfLzd9Baq/EG0yYyER909TIDu/wAdG1CnAMqyCo/MSRigkN/t5sLOjIl9nQZTT0t5xpmC2tLi1bMZUTwAOR/51Yac+IvT9zujMS5W2ZbEPKCEyFrS4hOTwVYwQPrzUcrrZJ69B2K9NsuOW8KfjLWlJKW1hwq59shX8qur/LXrifpW32C3SVzIlrj21TYQMuOoKsqGPT5hycduaCScTrhAe6hvaVctLzSm5bsMSvHBSpSCoA7cf2ikDv61m+kfU5jqP+K+XtjsDyHhZ3uhzfv3+wGMbP51FeRb5Y6sXpiMsmbBlTZCFD1WwHHB+5RXWfg476t/8J/+agknSlKKUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVaSLZAkul2TBivOnutxpKif1Iq7pQWbNrt7DqXWIMVt1PZaGUpI+xAr01boTMgyGYcZt8kkuJaSFc9+cZq6pQWhtsFUnzBhRjI3bvFLSd2ffOM5r7Jt0GU74kqHGecxjc40lRx9yKuqUFqzbYLLqnGYUZtxQIKktJBIPfJxXlu1W9p5LrcCIh1JyFpZSFA/fFXlKC3lQosvHm4zD+O3iNhWP3ryLdCEYxhDjCOTkteEnaT74xirqlBRZiRmGCwzHZbZPdtCAEn9O1eY0KLFJMWMwyT3LbYTn9quKUFoLbBTIU+mFGD6iSXA0ncc9+cZ5ya9xIMSHv8pFYY343eE2E5x2zirilApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlB//2Q==",
+              "timing": 1682,
+              "timestamp": 3525967776
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAE0QAAEDAwMCBAQEAgcEBQsFAAECAwQABREGEiEHMRMUQVEIImFxFTKBkSOhFjNCUnKxwRdidNEmNIKE4SQlJzWSoqOys7TDNkNFg8L/xAAVAQEBAAAAAAAAAAAAAAAAAAAAAf/EABURAQEAAAAAAAAAAAAAAAAAAAAR/9oADAMBAAIRAxEAPwCVNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFK+KUEpKlEBIGST2Fa81rjSr1w8i1qK0rl52hpMpBJPt37/Sg2KlCQBknj3rXTrjSyZ/kjqK0iXnb4Xm0bs+3fv9KDYqUBBAIOQfWsVedQ2uyrQm6yvKIXjDzrag0Pu5jaP1NBlaVoXWuV/6JL/Jhv8ABjpUh1pfcFSeQRWWOr9PWaJAjXe+W6HKUy3/AA35CUq5SOSCeKDZ6VTjSGZTCH4zrbzLg3IcbUFJUPcEd6wt31jpuzyxFut9tkSTnHhPSUJUPuCeP1oM9SqUSSxMjokRHm32HBlDjagpKh7gjvVWgUpSgUpSgUpSgUpSgUpSgUpXxatqSaAVBPcgV8DiD2UKxdyuMS3sGRcZTMZnIT4jywhOT2GTVhD1LY5slEeHeLe/IcOENtyEKUr7AGg2WlUI6yflP6VXoFKUoFKUoOb9cH3l2ex2hLy48S8XViDLcQdp8FRJUnPpnGK2OXoXTEiwqtC7LATB2FASllIKeMbgrGQr696vNXadg6qsT9ruaVeC5hSVoOFtLHKVpPoQa093Res5MI2yVrxarapPhrWi3oTJUjsR4m7vj1xmg0Q325P9D4cFU10ocvAsip6VYUuN4pTvz9UjbmuuI0DpVNj/AAkWK3+S2bMFlO7tjO7vu+uc17e0TZHdEjSpjEWlLQaSkH5kkHIWD/e3c5961pOidaIifhydfu/hoT4YUbegydnbHi5749cZoMN1BlSdCdFDH07eHpZbdTDROUsKWy2pZBG4eqR8oPcV0XT+nLZb9OItzbQkR3mQl9bx8RUjI5Usn8xOap27RtkhaPTpkREvWnwy2tt75i5k5KlH+8Tzn3q1Vp66Wyyiz6YnpjRtnhokTVqkOR09sITxnHpuUcUHFY77sfpF1QsCXVvW6zTlx4a1HO1vxB8mfpj+ddn0TpSzQ9JxGzFjTlS46HJMl5AcVKUpIJUonuDngegrHjpnAj9NZ2koElxvzoKn5jid63HCoErUOM5xijejtR2mJ5DS+qW4VtCdrbMqCJCo49Q2rcOPYKzig1TT8t7SH+1G1WQlUCztecgtfmDC1tKWpA+gIzitp6WaSsbOhrbJXDizpVxjpky5T7aXFvrcG5WSRyMntWa0Xo6HpmzyohdcnyZzinp0qQAVyVq7lX0xwBWuwtBah0+hyFpDVvkbOVKU1ElwkyTHyckIUSDj2BzQUOnzLdg6n6s03axssyGWJzbAOUx3F5Ckp9ge+K6hWs6I0ixpdmY4uW/cLpOc8aZOf/O8r0GBwEgcADtWzUClKUClKUClKUClKUClKUCvD4y0a90PNBruoxJNtPkhOL24f9S8HxMf/wBvy4/nWCsqbv8AijHmhqLwcnd5oQfD7H83h/P+1bstkg/LyK8hpZP5aD6wP4gq6rw02ED617oFKUoFKVZyrg1Hltx1Z3qSVk4OEp9/3oLylfEkKSFDseRWOvNzNu8vtZ8UuqKcbiP9D3/SgyVKw/4s+pE5TcVBTGKx8zhG7b3/ALNJN3dYaQVsM7/BL6wXsDb7JJHJ/agzFKxjd1C30thvBLpbwVcgBvfnH8q82u7iZbHpjrXgobGTySCNoJ7ge+O3pQZWlYmJeUvxIrym0oLrxZWN+Q2QFHvjnsP3qn+Nnfb0+AnMwZT/ABPy88549u3ueKDNUrHXC4mJMjs+GkocIBWpRGMkAdgff1wKoi9J8NSyzkIZceUEqyRsVjH6/wClBl6ViTdnEtpBajl1bgbTtkAoGUlXKscdvb2om6uLlR2UMIPiNhxSg5uA5I4IGD2+lBlqVgfx9flS75ZAWF7SguH5RgnJ+X6egI+tXtzuRhxWnm20uBfc7iABjOeAT/KgyNKxL11eZdk7mGiy00l0LS6cqCiQP7PHbk5q3k35cdpW6MhbqXfDIbcKkn5Nwwdvf07Cgz1KxMy7rYWtCI4WpLyGRlR53I3Z4B+1VI1yW7cjEcaS38uQreTuOATjjHr7547UGSpSlApSlApSlApSlApSlApSlArwtpC1oWpIKkHKT6ivdKBXh1pt3HitoXjtuGa90oKIiR0uOLTHaC3AQtQQMqB75PrXpyOy7s8Rptew5TuSDt+3tVSlBT8Brxi74SPFIwV7RnHtmgjspbU2GmwhXdISMHjHb7AVUpQU1x2XErStltSVnKgUghR9z79q+GMwruy2eAOUjsOQP0qrSgpuMMuOIW402taOUqUkEp+x9KIYZQpakNISpfKyEgFX396qUoKAhxgypkR2Q0o5KNg2k/avqokZSm1KjslTYAQSgZTjtj2qtSgt/IxPDLflWNhVuKfDGCffHvVR5hl9AQ+024kHIC0ggH9aqUoPJabJUShOVDaTjuPY/uapiJHDYbDDQbGcJCBgZ78VWpQUXYsd4EOsNLCiFEKQDkgYB/avrcZhtzxG2Wkubdu5KQDj2z7VVpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKxWpdQ2rTNsNxvsxEOGFhBcUkq+Y9hgAmsrUdfi+vey32KyNq5dcXLdH0SNqf/mV+1B17TPUXSep7n+H2K8tS5hQXA0G1pJSO5+ZIHrW2VBjp+87ofqrpx6WooSTHW4TxhuQ0knP2Dn8q6DqnWevtadULnprSNxXBbiPOtNtNOBnIaOFKUvuckdvr2oiU1KjPZte9R9LaI1DI1PFde8BCUQpkpKTsdLgQQcfmGFEjP93vWs2q69YLlZ42qLbdZ0qLIkFpCEOIVlQJz/CxgJyCO1FS+pUYuovU3XEm42HS1tQbPepLDImBO0LU+s4ACuQlPY8c8/SsLH6ha70ber1pjVNxdlOmE+kLLgW4w4WFKbcQ4Oe+3g/yoJb0qFmlNc6+mWLU78bUclaIcNLrq5LylrQkuJT/AAu4Cjnv7Ve2zqT1Bm9Ob4+3eQpi3yIwclLOJKQ4VAJSQOQSkZJ5/egmNSoc3vqbqyb0yskv8bmMzm7jJiuPsL8NTyEttKTu24zjeRXt/WHU+Noy06rTd3W7Q2ryqFF1K1PLClZU4lWd2SCOfQD70Ew6VEvVnWLVmqZOn7XpyT+FPymWkvFpQQXH1KI/Ofyp7evqc5rCap1t1At2uxbbzfpMeWy4w081DkkNH5U84ScZI5P1J4FBM+lRYa171D1/1BmNaNlJjRbepTzcQrS2hTaFY/iZ5UVcZHbn0rQo3UfWL713WvUV1Rhla0oEpWGzvT259MkUE5KVCy164187oK83JrUkkx4suOhxxx1Sn8qC8BBPZPHPvxWYndbdV/7ObYwzMCbq7JeZenbE+IW0JbKccYB/icnGeBQS7pUVNFah6p2zVlvbcfm36C6ULfbz4zZbUecLI4I55Bx961rSWq+oWoNZuWey6imuS3w+22iTKVsSAlWTznBABI9jigmTPlIgwZMt0KLbDanVBPchIJOPrxWhdOurdh17en7ZZ4tyZkMxzJUqU2hKSkKSnA2rJzlQ9KutPQL3a+kj8TVUpUq8tw5XjvF0uFWS4U/Me/ylI/SomdK9UytHO6jutuCPOi2FplSxkJUp9kbseuBk/egnbSoayNYdS29ALvz99cVa50sNoeTICX21pzkJCcFKTg5H0BxXb/hlvdzv2gZkq9T5M6Sm4uNpdkOFagkNtkDJ9Mk/vQdbpSlApSlApSlApSlArg3WHo/qPXmtFXWNcbYzBQy2wy28twLSkZJzhBH5ir1rvNa7q3WuntIoaVqG6Mw1OgltBBUtQHqEpBOPrig4nrn4eZk68sSNLXGMxFSwhCxOfdW54icjIO1XGNuBnjFVtV9A7xPvRvVlvsaHcZIDklBK0hLxT/EKFpGdpOTggd66pZeqGjr1Fmv269NOphsLkvILa0rS2gZUoIIBOAPQGsaz1q0E7FkSEXz+Ext3lUV4H5jgAApyex7e1EafpH4fo1v07e4l7upkTbkyGQ4wjCWMLCwRnlR3JT7cDH1rVUfDhqErTDd1NE/CkubwAlwkH1UG/wAucfWupdTOoVtg2SCi36qg2d+ehD4ecjLfdSwtOQtDaRkKPGNw9/asl071Zp5/SavLar/GEW5sqlTJh8NxKeTuWCAQPTJ9u9FaNrroGxc7fZzpu5CHcLdHRG3vg7Xgk5CyU8pVknkA+ntWO038P02P+KT9QXlmddXoj7MYArKEurbUgLWtQ3HGe2K6P/th0L5KTLTfmlMx1pbc2suFWVZwQnbkjjuBitJ6ldeIMCxQZWhZUWdJekKbcTKiuhIQlOSRnbzkp/eiMTpPoVqCz2LVEGRcbUty6wkxmVIW5hKg4lWVZR2wPTNfbJ0L1BA0Fqaxu3G1Kk3R2ItpaVObEhpSird8medwxgGr9/qRddTdC5F9iXmHZ7zFkhma6hhwIbBWQlKeFnJCmzkZ9e3pm+jGtkI6czLpq7VMac3GlloylpWjYNqSEEqSkrVzngHvQcS6p6FuGgNBWW2XWTFkPP3OTJSqMVFISWmU4O4DnKTWa0P0Vnay0dYbjHvxiWyShbj8dwKXtcS6tO5CchPKQO/1712yNrfptr2fHtrsi13SSlR8BqdEP5j32eInGTj0717svUzp9EmnT9ruEaEqMXU+XREWw01s3KXztCR2Ufr+tBpfUH4fo14ZtqtMzm4L0OMiKpEhJKXgnOFkjkK5OeDn6VrEj4b7xHvMd213e3rhtFpRMgrS4pQAK+AkgDdnHPbFd50hrvTer3Hm9PXRqW6yNy29qkLA7Z2qAJH1q71Vqux6UiIk6guLMJpw4RvyVLI77UjJP6Cioja/jaat3Ua8Ltt4uVrSmW4iVHbYO7G75w0tKsEHnAVjH1rD9LNG3DW93utvtOxoeUUS8+TsR86cBRAPJwfT0rN/ETeLZeNbRp1hciPQJUFp4OstJBWoqWCVHG7PABB7Yrpei+oSNPdSrxplNts9r01bxJddcixVB0paQVblEE7jge2aIpWvoVqCJ0+vlhcuNqMqfKjvtuJW5sSG92Qfkzn5hjivsf4epT2gvwufc4jd6YmuyY77O5TRQtDaSheQD3bzkdvrXT4HVrRlwtNzuUS7KXCtqW1SnPKujwwtW1PBTk5PHGasj1t0CIqZBvS/BUsthXk3/wAwAJH5PYiiud6S+H26o1FDuGrr6zLjxFIUlphTjinAk5CSpYG1P2z+lZDph0Xvmk+o0fUE6fbHojZeJbZUsrO9CkjukD+0PWugL6u6GR5HxL+wjziPEa3NrGE5Iyr5fk5H9rHv2rJar6haW0oppF8u7Ed11IWhtIU4spPZW1IJx9aDPXmKudZ50RpSUuPsONJKuwKkkDP71HvRvw83CGLxH1DcoKo06CY7a4hWpbbniNrSrCkgEfIc8+tdu0jrbT2r0PHT1zZmKZwXEAKQtIPqUqAOPrWxUEXT8NF0TAl7b3CcmeIkR8haG9n9or4J3dsAcfWuw9EdET9A6Sk2q6SIsh92YuSFRiopCShCcfMAc/Ka6DSgUpSgUpSgUpSgUpSgVEb4jEIj9aYsjUDMh6zKajq2NnBWyPzpSffO796lzXPdeas6dt3L8F1m9BdmM7VBiTEW7s3AEYIQQMgjsaCN0N/RUy+XxelbZf4yvw+YqOFvoLbafLL3bhgq29/7R7ir74bdIWPV99vEfUUETGWIyXG0lxaNqirGflI9KlRbtH6ctsSVGt9kt8ZiU2WX0tMJT4qCMFKvcYPavWn9J2DTrzr1jtEOA66kIcUw2ElQznBoiH3UiDEsXWKfHv0Rw2lpaUtNkLWPLhsJaxhaSoAAD8w7d6xLce2yrDqBzTUa9l1psLkLJSGBH8VPCkjKhztOCo9u5xmptX/TFj1D4X45aYU8tfkL7QWU/Ymqln09Z7LCciWm2Q4kZ3+sbZZSlK/T5vf9aCBz0uwuaLYix7NJTf2nyt+4+OS2ps5wnZ2Hp+3es+9BQvoPGnJjIU83qBxtT4QNyUGOj5d3fGcce9STfndKWb69pJyNZ0zZEhKXYqYuEKeHCUlQTt3DJGM8E471vMHSthg2d61RLRBatj6ityKGR4a1HHJT2J4H7Cgi/arxbJfwxX21wmC3cYDzC5rnhhIcLkklB3DlRCUgc9sAVzx1marphEebSs29F3fS6R+UOFlnZn9AuptMaG0uxbZdvZsNubhSylT7KWAEulJyncPXB5FXEDSWn4FqkWyHZoLVukK3vRksp8NasAZKexPA/ahEKL+uw3O66dY6e264xbh4bbbwdXuU5JyMKRycc+vA7cCsx09tcW8ddPw+8MNyo7sub4rax8qiEOn/ADANS7sujNNWOUJNosduhyQCA60wkKH2PcV5g6K01Au/4pDscBi47lL8whoBeVAhRz9QT+9BF/4UVEdT3QDwbe7ke/zIrMfFay63r+wyrg28u0KipThBxna4S4EnsFYKf5VImx6M03YZpmWayQYUooKPFYaCVbTjIz7cCsjebPbb3E8reIMabHzu8N9sLAPvz60EC9fvaek6hU9o+BLg2hbSfDalElRV2URknjI9z2P2qXevdGWJnSOqLxBtEdN6ftkkqkoSd6ippQP71sM3QGkpxYMvTtsd8BoMt7mE/IgZwkfTk/vWzbU7NuBtxjHpiioGaSvEOFoHXFtfWsSrgzE8BIQSDsfClZI4HBHesA7/APpmN/xjv/yN1PBOhdKpZmNI0/bENywEvpTHSA4AoKAOB2yAf0FaRqhHSLTFwZs98gWaNIUQ4GfKlQRuwNysAhOcDv7URGjXVthwtK6IkRY7bT0u3uOPrSOXFB5YBP1xxXy+7Y2sbZI1Qy69CdgQ3cKSpW9sxkBJACkkgH2UOxqXdysHT51EOFcomnyIrYRHZeU2C2hR3AJBPAOc/rWauekNPXSFEiXGywJMaIgNx0OshQaSAAEp9hgDj6UEd/huTYneokhyyR7z4yWXSpxRQmOlokYCk/Moc4wCo8jucVKWsZYrBabBHWxZLbEgNLOVJjtBG4/XHesnRSlKUClKUClKUClKUClKUCoX/Eioo6y3BQG4pbjnA9f4aamhUZOtvS3WGp+pUy62S1h+A6hlKHvMtI5ShIPClA8Ee1BWt/W7VsDW6bZqu0NQo0xYDTK2Sh1hK+G1ZP5hnGcj37dqt+m/WLV1+OpxcZMVXkLFKnsbY6U4db27Sfccnirm09H9Z3zqGzdNcz2n4kJaQmT4iVKkIRygJSOwzyc47nvWDsPRjX9in31uAIaY8m3SYheDqFeYQocNpBIKSohIycAc80RV07151WnT98nXBuNOeYLLUcBkIQ0pZXla9vJHy4x7kVTsXWTqfcUKmQLfGuUZCsLQ1DKsfok7hVPSXSbqPabTdURIjECU6tlQS9IZcRIbSHNyCAVJPKknChjj6VaNdGeolzv7Ul6Bb7OtBGJLDrTKEkf2glnnP2AoPGq7uI/xAsLbtlvbeVOhqKi0chTiW1KJGcbsqPJGayOkutuvrm5dUoaiXBUe3vSQnwkNhoIwS4f7wAz8vqSKyuq+lmsZvWNu9x7f5q2plxHFSzIaSVpbS2Fq2lW7ulXGKsemXSfWlkk6iXc7OGUy7HLhsnzTKtzq0gJTws4z7nigz+gOu9xlaV1LN1FEjvyrWyh5ksDww6VrCAlQ5x8xTyPTNaoeunUNLLd3VCgi1uulCB5U+GojukKzuP71kunPRbUv4Xqi26jhptqLhCQ3HeLzbo8VLiVpyEKJxlNYe29KOqtvKbbAbbhxEvbxKZlNI5/vb0nxcfT+VBs/UPr1fIUezpsVtbgrlw0ynVy2ypQUSpJSkHAwCk8nv9KuNH9VuoKHXX9R2NMm1phvyA+1GUjcUNqWkBaSU8kY7V61x076inyLNvkRdRxW4iG3fxEtPK8bkrUPGHAJPBBzgCsN056P9QLPIuM7zLVmeciPNtsokglxxSSEZ2ZSACQc59O1Bjbd1v6jXy4OizRYTxT83lmY24gfTJ3H9KkRoi/Xa8dPWLteoYg3UtOl1jw1ICVJKgPlVyM4B/Wo3XnpF1JvEhluZZrUlSVcy2DGZ3fVRRhSv2JqSfT/AE9cLJ0/g2S9TfNzW2VtuPBRUAFE4AJ5ISCB+lBw3pv1i1dfTqj8RkxV+QsUqextjpTh1vbtJ9xyeK19jrrrddgmy1S4fjNSWGknyqcbVpdJ4/7CavbD0Y6gWKffW4IhpjybdJiF4OIV5hChw2kEgpKiEjJwBzzWFj9FtfI09OiqsYD7sphxCfOMcpSl4KOd+O60/vQZyX1w15F0rZ7kqPBDch55BlLbSQ+UEfKEAjaAFDn1z9K1/rLq1u+3TTV7/Cbf4020tyHd6Cf4gddQQeRlPycZzxWx3vpNrST0x0zaGLOFXCHLluvteaZGxK9m0534OcHsax+qejuuZ1t0y1FsoW5Dtnl3x5tgbHPMPrxyvn5VpORxzQab1XXdnepcty5+B51amVM+EAEhsoSWhgf7m3NTgsYnCywBdy2bl5dvzRb/AC+LtG/H03ZqO3V7o9qe8agi3vTzTMlxcVhDzCnkIW242hKeCohJHyj19675opu8NaVtqNSrDl5DQ80oFJBXk/3ePbtRWapSlApSlApSlApSlApSlApSlAq1uNwhWyOX7jLjxGAceI+4G0/uTV1UTPiQeXN6wQLffpb0WxoaYCXEpyG21H+IsD1Oc+/YUG2dTOs+odOdR3rJaEWt62gxy2440palBxCFE7gsA/mOOK7ZC1dpudKMaFf7TIkgKUWmpja14SCVHAOeACT7YqDmo2LVF12I+nrk9c7U08yhiS8CFKSAnjsOAcgcDgVmelcyNbOpL71wfbjNJYnIK3VBICiy4AMn1J4oiYaNcaTcQ4pvU1kUltO5ZE9ohIyBk/NwMkD7kVWZ1fpt5tlbOoLQ4h53wGlJmNkLc4+RJzyr5k8Dnke9QMsn/qvUP/BI/wDuWa7L8PfTe26ssIvk+bPbkW26EsMtLSG8pS0vJBB5JwDg9gKCTjt4tjNxRAduMNE5YymOp5IcUMZ4TnJ4rROpHU222nRF0uWlLzZbjdIoaUhlEhD3yqdQhRKUKzjCu/viopWKRap2o7vP1ndrpBnAOPsvREbnDJ3ZwT3HP2+4rEWH/wBVak/4BH/3Uegll0X6nu6o03NuOrpVqt625gjMkK8BK/kCsfOo5PJ7VcdctZ6g0ra7XI0ubXslLWHHpbzaewBSEBSgDnJyRntUU7REsMjRV4euV4kMXiO4lUCAlJLbu7AWo8d8D3HYd62DUEmZI6G6XExa1ttXSS3HKzn+GEJ4H0Ciqg3vU3XjV9pdtzSGbCtb0RDzpbBeTvKlA4UlzHp25wcj0rbLf1O1Unqs7aLsvTseyNyXGnAqY0lTbac/NnxM7uORj9BUZ7z/ANTsX/Bn/wCu7W9ORGLh8RkmHLR4kaRfnWXUZI3JU4oEZHI4J7UHadH9eo2oddxtPu2hmHHfecZROVPCkkgK2YGwA7iAAM91DvW19R9T3SDPj2qx3LT1qW6ne7Ouk1CS3z+VDROVE98nior6BFmtXV2Ob0UsWyFLeUkrUrCFthZa7cnCwj7+tYm3IhXu5XmRqm5OR5qkrdQ46tXzO5Od2EKJ+3H3FBPmA+mTCZeQ+zIC0A+KycoWfUp5PH61rl06g6YtWp2dPT7q0zdnSkJZKFEAq/KCoDAJyOCfUVzz4W0xmNOXaPBva7nHQ8hfhmMtpMdSgcgFX5s4Hbtj61caxidMHOrcNy/SVo1PvZPhAr8JTnHh+JgYzjb6jjGaK7LWGXqvTzczyjl9tSZWceCZbYXn225zWv8AW+ZMg9KtRSLcpaJAYCdyO4SpaUrI/wCyVVESx2fSEvSDku7ajkQb75rYmMmMXU+FgfNx3PfnPp2oJ2zJsWDFVJmyWY8dIyXXVhCR+p4q2tN7tV4StVoucKcEfmMZ9Lu377Sahp1GmrdtuirUq9yZ2nm4mUSlMqbz/HWlR2E5JSlKQPoPrVfTwt+netdha6fXaTcoLkhhsuqSUlYWQHEHgZGM844/TNBLmDq7Tc+SY8HUFokyAlSi0zMbWrCRknAOcADJq5h3+zzob0uFdYEiKync681IQtCB7qUDgD71B/pvaGL5rCXCluPoZMOY4fBXsJKWlqAJ9sgZHrXzpxa03WJq9DkmSyiNY35e1lzaHVNrbKUrHqnJziiJtvaosDFvRPevlrbgrX4aJC5bYbUvGdoVnBOATivn9KtP+Vjyfx21+WkqKWXfNt7HSDghJzgkHvioIRXnDoO5sFZ8JNyiLCc8AlqQCf5CsnqSzsRem+jrql19ciaua2tK3MoQltxO0IHp+ZRPuTQTllXq1w3o7Mu5QmHZIyyhx9KVOj3SCee47V9ut5tlnaS5drjDgtq/KqS+lsH7FRFQZ13bhCsejZYkyXnZls8RQec3BvDq0hKP7qcDtVzqOavUGuoX9LZj6IxiRklxSynagsIUCDtVgEnJO09yaCbKdQ2VVsduSbvbzb2seJKElHhIycDK84HJHr61bs6u02/Edls6gtDkVpSUOPJmNlCFK/KCrOATg4H0qGkCPboOnNWt2vUapHiRglUJEdzatAfbwsuEJGRxztHf0zWOtNoYk9ML/dHFvePDnRW20BZCMLC8kp9TwOaCWXVbqhC0JZrfOjMxrs5Nd2oZRLDZLe0nxBgKynIA7Y571mOl+tWNeaVZu7TLUV4rWh2Kl8OqZIUQNxwMZAB5A4NREmRGpHQ633F1Kly4t9dhNOFR+RlTIcKcZx+bntXf/hVcs39AFs29xBuwdLlwQFKJSSpYbJB4GUp9Pag7TSlKKVq2uNA6e1s2wnUELxnGM+G8hZQtIPcZHp9DW01zbqn1ds/T+UzBejPT7m434vgNKCQhJOAVKPbODxg0FGX0N0Q/PaliFIYU0lsJQy+UoGwAA49+Mk+pyavn+kOipGoXbyq1gy3VLcWkOEtlas5Vs7Zyc/etDHW6z610pqa0OQX7ZcHbTLLKVrDiHCGVkgKAGDgE8j0rlvQnWDOh2tUXqQx5otxmUIYDmwuKU6BgHB9Mnt6UR3qN0H0VHZlNNsT9klsNOZkn8oWlfHHugVuWhdG2nRFqet1iQ8iM68ZCg65vO4pSnv8AZIrnts68WxzRj2obva3oSPMmLFjNvB5yQoJClEfKkADI5NWekviJsl5vLMC52uRa0vrDbb5dDqAScDdwCkfXmit3l9J9GytSi+u2hHnisuqSFHwlrP8AaKO2fX781hIvQnRMdmWy01O2ymgy4DKJJSFpXxx7oTVpq7r1p3T2p1WdMWVN8B3wpUhogIaOfmx6qI9e3auD9GbpEidaWLpJfDcBszZC3VZwEBl05/aiJEN9C9DJt6Yire+4hL3jBan1b84AKdwwdvA4rOam6ZaZ1FY7baJcNbNvtxJjtRnC2E5GD965nL+Jm0Nz1NxbBNehg4DynkoUR77MH/Os7q/rnCstjsd4tlncudtuiHNrhkBlTTiCAptSdquefeir6R0G0U+3GQ4xP2x2/CRiSfy7lK9vdRrKt9I9LI1h/SZLUv8AFPNmbu8c7PEKt35fbPpWoan6/RLOqzIh2Jyeu4wWpZSmUEFpSyR4f5DkjHfiup6k1LE0zpV6+X0GOyy2lTjaDvVvOAEJ7ZOTj0/Sg1i+9HNGXu+Lu0u2rRLcc8V3wXlIS4r3KQcZP0xVLUnRbReoLs9cZdvdZkvK3O+WeLaVq9VFPbJ+laQv4l7SYEh1uxSvModSlphb4T4iDnKtwScEccfXvXTOlGuU9QNNO3dEAwA3JVH8IveJnalJznA/vdselBm9K6atOlbSi22KGiLFSdxSCSVKPdSieSfvWEvPTPTF51cxqWfBUu5tKQvcHCELUjG0qT6kYH7Cud6k+I+z2y7vw7bZpNwaZWWy+Xg0lRBwSkYJI++KwXULrS9qPpw7I0xDuttkCUhp+U26U+X7KHzI7hXI5x+tBI+XGZmRXY0ppD0d1JQ42sZSpJGCCPauZL6DaCVLL/4ZISknPgiUvZ9u+f51zPpV1bu1j6dXy432NcL35Wc2ESZMpXzeIkDwwpSVY27d2P8Af9PXZbP8RcO5ybXFRp91EqZMEZSPNZDSSUBK87OclSuOPy9+aDpuo+nel9QWKJaLha2hDhp2xgzltTA/3SP5+/rVlovpXpPR8/z1ot6jNAKUvvuFxSAe+3PA+4Ga0rRvXprUrt3QnTy434fbX7iSZgXv8IA7PyDGc9/T2r7pX4gbXdoV3mXS0u22Nb2Uu5TIDynVKUEhCRtTzz70Gz6f6N6TsN0XcLezMElbTrJK5BUNriSlXH2Jr5YejWkrEi5pgMzALjDXBf3yCrLSyCrHHB+Uc1osX4mbQucESdPzWohVjxkvJWoD32YH+daX186i3w63aTp653W22wQmVMrYkONolJWN/igDH97Z68oP2BHYUdCNFIt78JLE/wAB51t5Q8yc7kBYTzj2cVV7P6NaSnWC1WZ9mYYVtU8qOBIIUC6QVZOOeQK1S7dbHtK6R0nJuWnpL8q5RFLWl6UW1pLatm45QSd35s/X171V1j15b00bJu08uT+J2ti5DEwI8MObvk/Ic429+PtRWy3fozpK7QrXEmMzCzbWDGj7ZBBCNxVzxyck1c6i6R6R1BFtzNwgub4MdEVp5p0ocLaEhKQoj82APWtEkfEZCiail22Zp91tmM860p9MrcTs3YwnZ6kAd/Wri4ddbRJ6eKuE2JPgTJzj0ViPDfSp5O1KcuBZSAn8w5wefeg262dJ9FRLDdbJBiHw5mxuY4Hyp7CVJWlJV/Z5CTjiqcXozpKNp2dZWmZnkZjzb7oMglRUjO3Bxx+Y1zrot1P0dEvAtEazTbXKubqUrmSJRkl93snxFHBBJPoMZNSNoNHtvS3SsHSUnTQhLkWqQ+ZKkPulSg5hI3JUMEcJHb6+9Xmg+n9h0KJo0+w82ZhQXi66Vk7d20DPbG4/vW2UoFKUoFRZ+I/Td5t3UWPquLBdmW5aWTuQjeltaONquDjOAQT71KalBDnTKLvqJepbk1pCEzEFuluOznmnVONnwFgBC1KwVk47D1Nc/tWlp1wsl5nIYfSq3IacKC2fnSpew4+oyD+9foNSiRBpuzXjUXTOK1b7fIdcsMt5TzTbR3lp8JIXjGVYU2oHHYEelXsljUHVO92KDB021A8oyiKt+PHUhASCMrcUeBj0H7d6mxSgh85aNSdO+rU9bGnPxrzrjrcQvsqW26lxWQoK7BXof1+9ajobTV0vOtX7WiKqPKkMTG0goKUBfgOYTnsBnip30oIHwXLxYoM3TkzTLkiQ5ISotPtOZChjjanBV245xzxXZNYaOny/h3bXNskS13OE/wCfTDhNKTsQTtO4Ek7ik7jz6D2qRlKKhH0Q01L1B1MsrU5h/wApCPmVlxJwEt/MlPPoVED9akv1909P1L01nQ7Q0p+Y242+llP5nAk8ge5wScfSui0oIJTFand6fJtD9gbZtdulgqkmGUSPFXuOwqPJ9fT0GfSpD/Cky4z01lpebW2r8SdOFpIOPDbrs1KCDWpFyoV5lSmtLXOyX0PKKXYy1oZyTyfCUgnBGeArHPbFdCt9j1fqHodqRufY/DnLksPsbIiWH5SEnKiUpA3YHY4yee/FSP1TemtO6en3eQy8+1DaLqm2U7lqx6AVqHSbqfF6iC4CNbJMFcPbuLigtKgrOMKHrx2oiLttnXZrpdfNMO2eQhhMtE8vqaWFBzLaPDxjHYE+/Fdy+Fm2pPTi5eZiJD/4k7sLrfzD+E1jGR713OlFQd0dbtQ6XvOpYbmn5rz7lomw3QpBQGkFHLmSMEDbx75GO9WGj9JXe/2DUTFuhyHJMdtmSGQg7nQlRBCR6nCs4+lTxrR9N9VNJaj1A3ZbRcHXriveEtmO4gHaCVckY7A0RF+23y+vWS0aZa0JCmvwHFEF+3uKccKifzAEe/J+g9q2b4htJX3Zpe5C0BDDNpaiSG4LRLUZ1KlKKcDOE/Pgc+ldb0l1ogak16dMs2aewsrcQl9zHBQCTuT3SOPf2rq9BD3qk3ftWaB0ZezZZLbcVl2E4lptStgSUhKiMZAUEk57VqnUY3e5DS5mWaVD8vY40ZoKBUXUIKwHMY+XPPB9MH1qdtKKhjoWA8v4gmC/EcUwbs+SVtnaRlfuMVv/AMUujbjIk2m+2eCp+FGZLL7bDefDO7cFFI9Dkgn6DNSPpQRB6fv3jVfUC2vx9HQnQhbQflS2nVhlKTkr3bgkHHYY9sCpfUpQKUpQKUpQKjT8Rt31yxqrwbM/cWLEyyghdvUoALIyrxCjkH2B9MEVJauQdRejkjVOrn9QWvUsm0yn20IWlDZP5UhIwUqSewoOT9PtVajsi7ldkaubv0OHAedXEXKdUoL24QSh1IJAURkpz96wTNx6g3vS911sNVyERoMgNuNCattRUSPytp+XHzDjj1rtGgugNt0/NkS71c3Lq48w7HLYa8JG1xJSonkknBPrx3rXJPwyIM5fldTLbglWUtri7lgexIUAT9cURyvWXUvU17j2OSq7T4shuGWXzFfWyl5SXV4WUpIGSCAftWT1PrDWeltX2p57UkuSoxIknw0rUGihTaTsUgkg8cEnk966tq34eI1zTaWbLd0wI0GJ5ch2P4q3V71LU4SFDk7u2PSvWtugr+pbrDmI1A1HEeFHibDEKtxaQE7s7x3x2oN763armaO6fTLla8CctaGGXCMhsqP5seuADj64qM79w6gWzSdu1wrVclUaXJLSGvOrWsKBV+Zs/Lj5Txz6cVLvWWm4GrdOS7NdUqMaQkDcg4UhQOQpP1BFcKjfDIkTE+Z1MtcIKzsRF2rI9slRAP1xQc+6r6/v9zm6fuMa6T4Bl2hlx1mLJW0gub3EqUEg+pT/AJVv2pXde9M9NXrUF3vrU+Td3G40YNuuOIiKVuWVJQsbR8qcDH0rYeoXQVvUtzgO2q7NWyFCgtwmo6o5cOEFRzu3DvurcOt7Vsb6WXIXuK9KhtBrIYUEuJO9KQtJORkZzg9+3rQRvu07X1t6cQ7/ACtUPO228SQEJTOWZDa07/2BwcgH2yKt5/UXVCNGads8W9zWVyPFfflKkK8ReXlISC4TkJG0+vr9K026iwtQC3aX7lKkqdCkrkspZS0jByMJWrconbzxjHrnjvGleiqNXdKdPruEh61XZvxXG1lvdlpaypIUnIP1HPrQcx6g3/WNlu0W3TdXrmLjxEJS/bLgtSFJJURvIIysZwSRnAFZOx33Vdw6xKtdv1JPYW7cX2WvGfW602Mrx/DKsHA7Dt2roFx+GZtxMQW/UIZKGAl8uxivxHdyiVDChtGCkY+nfms/p3oa/aOo7WqFX5p1CJjkry4ikE7ir5d27/e74oOP9P8AXWpxK1LbZl7nymnbRPILr6lFtxDK1pWgk5Scp9PerfQepNaL01qRNhuNwkzCY6SC8pxxKCXCotgkndwM45xk+ldXsPw+SLXc58s6iadEqJKjBIiEbfGaWjOd/ON2ceuKoW74cVsWqbEf1N87zrTzbjUXbsUgLHOV8g7z2x2oOS2e76vXJCXdbyrbc/E2iJcJchpRPpypOwfqRW0am1drDU/VRyyQtSCyphulhsuyvAYCmh8ylEfmKlJJ5z3A7VuLfw4PS7g27fdXSZrKAE4DB8TaP7IUpZwO/pWZ1v8AD7a9QahFygXR23NubPHY8IOBWAASk5GCQPXPPNBxrS981RfuqSbTM1PPSqbKfjrciy1qZSpQWNzaQoDaCcpxjsO1WXRG2PTesVnjNznY62JK3lOozlwNgqUg8jhQSUn6E967ZpXoGNOa9iX6Je0qhRZSnmoio53BHO1JXu5IBHOPSqNx+HeOrVhutqvq4cUyPMeXUxvKPmyUhQUOPuO1BzK36wu9p613mSu4Tn40OVcXfLLkLLaktoeUlJTnGPlHFWsS6dQNW2a/asb1S8wxayFvMiYpnvzhCE/Lj74z9TXZbX0M8t1HkalmXhqTEfkyXnIRjEbkPBYKN272X3x6Vr9w+GZpdwdVbtSLYgLVlLTsbetI9twUAfvig59qzqTqO99O9OSHLpNjz48uVFefjPKaL6UoZUkq2kZI3kfz9as9Ram1nabHpK4HVNwKZcRbjKEOqBQEuqHznPzkn1Ppx6V2zVHQSJcNK2KyWa6+SRblvOuvPMeIqQ44EAqOCMfkA+2ParXUnQR+8WHTduTqBpo2iM5HLhiFXi7nCvON/HfHrQdh0fcHbvpKyXKRjxpkJmQvAwNy2wo/zNZesZpe2GyaatNqU6HlQYjUYuBO3fsQE5x6Zx2rJ0UpSlApSlApSlArUdddRdN6I8JF+mlEl1O5uO0grcUntnA7D6nFbdUSfiNYNu6yRLneoTkuzutsLDe4pDraOFoCvQ5z/wC19aDvmh+quldZzTCtM1xE0JKxHkNltSgO5HocfQ1ibz100Pa7muEqdIkqQrat2MwVtpPr83Gf0zXDdIPWLU2t57WjNJzocx6NI8q8meQiKSypIUUBPYk/3u5rSLJPslnsWo7ZqKwOyL28nw4j6lFBiLGQcj6HB+uMURLXUnWLSVit1qnuSZEyHckuKYciNhY+QpCgoEgg/MODVpI656Hjuwm3p748yyh4lLJWGQoZCV7c4VjuBnFRNvVtnwdEaeenIcbYlyZbsZKxjKNrAKh9CQf2rLdU4UWFG0UYkdpgv6ejPO+GgJ8RZW5lSsdyfeglY91e0a1qdmxG6Bcp0oSl1CCpncrskrHY8j6DPfvWMh9dNGSLw5b3HpkVbfib3ZDIS2nYCTyFE87SAMckgVGfqtCjWzW8Jq3x2ozfkYTm1pISNxZQSePUnnNX3S+FFuPWby0+O1JjqXOKm3UBSSQ06RkH2IBoJKWbrVom6w50hu5OR/JtF5xuQ0UKUkED5fRRyQMA55q+snU/R+otO3K5tz0IgQgBLTKbKSgK7ZSc5z2GM57VE3pPb4dwc1d56M1I8vp2bIa8RIVscSE7Vj2IycGsbp23z7ho7U34ehxxMdUaRIQgEktgrBOPYFST+lBIq2dS+j67ygM2uHFeK8JlrtSUpz6HcBkfcgVtmr+smltKXw2q5eeXIDaHAuO0laClYyCDuHoaiZGuOnHbXaor9klSJrSiHvLOhgvZPHzELKj+gx6VmOtUfy+tYUcxXIgRbYSPLOueItrDSfkUrAyR2ziglJbOrmkZ7F8kJnLZiWhaEPyHUYQsqKgnw8ZKs7D6ZrE23r1oadcERfOyo+9W1Lz8cpbJ+4zgfUgVqHxFaGttk6dpe0tZ2ojQmtOTPLpPKAhYSVfQFf8AOuNN3vRr9msUL+h8uRc2ElEpxmaWjJWSMdkqJ+2BjtzQdH6i6juVu66hkauuLMVuTHIjspUUIQtKFbAkHaoEK7n3rsdz6vaNtupxYpN0xLDnhOOBB8JpfspfYc8euPXFRj6mNFjrKw0WFxygW5PgrXvU3hhkbSr1I7Z9axdsUnT2trtB1Jpn8enOLcjJjOOLbUHlK4WMAlWfT3zwaDtvUHrdZr/oa9xNKyLtDuyGm3G3wnwSkB5sKwpKsjIJH61b9AOoHkdH6hu2t79KejsSWm23Jby3lZKVHagHJycdh7VHezf9TvX/AAY/+s1WRYt06T08kTIyFrhRLiBI2jISVN/Io/ThQz9frQSysHXLRN6ubUBubIivPLCG1SmShClHsN2SB+uK6PcJsa3QX5k59uPFYQXHHXDhKUjuSagzCmacudwssaPpudLlbEMrZiPiP4rmR2+ValffI/SpVdc7bNuPSG8Rbcy4uQlppZaR8yilC0qUPrwDRWLHX7QhneX85M8Pdt8x5VXh/f8AvY/StR669YbjYbxbIejLg2lK4/mHnCyhxDiV4LZSTn03VwSDcbAnTzEOfaX356HypTjCw0paPYrIV9sBIFb91rtao2g+n8hi0ybdGEZ9Jaec8Vbe5SVISpeBkkZIGBjt6URJbpTqc6u0Harq4pS5K2g3IUpARueTwsgDjG7OK22ucfD9qCJf+mtuTDjuMfhqUQHd4A3uIbQVKGPQ7vXmuj0UpSlApSlApSlApSlAq2nwIdxYLFwiR5TJ/wD232wtP7GrmuC9beqOorTrOLpPRjaEz1hve6W0rWtxz8qEhXygYI5I9fTFBudy6g6D0PfnbApLVumpKAtqLBKU5UAU8pTjsRWR1/cNF6e2XLU0C3Pz18MIMRD0l4jsEDGT9+w96iP1Al3yb1LLuq4iYl6C4zchtJBBKUIAUMEjkAHjjmt51P1b1dqHV81WlzAhx4BcDCnG2PE8MHBO931VgfKn+eKIk47a7JqSDClXC0RJbXhhbKZsRKlNpUAcbVjKewyPpSXpXT0wMCXYrU+GGwy0HYbavDQOyU5HCRk8Djmo3XHq7r1vpv5qUh63XFu4MttzzDSlMhpTbpKcLSU5BQk5A/8AGzZ6p9Un9HN36MoKtcF0tSpymGT4q1KGAU4GAMpHyjueT7Fdo6gaj6b6ZvbMTVdtt5uC46HUFVsDx8PJSn5tp7bCAPTFbla9PadQ41crfZLYy+4nxEvtxEIcwsc8gZ5BOfvUMur+rl63uNivD7KWZKrWlp9CPy70vPAkfQ8H9a6VeuqOtrzqhnSvT1tDa4jQZyG21OOqQj5yS58qQCCP0+uKIkNE0rp6EXjDsVqj+M2pl3wobaN7avzIVgcpPqDxVa16fs1oU6q1Wm3wVOja4Y0ZDZWPY7QMio3WXq1ra5WDUtokviNqO1MqltyEMN7iGlgPNrQQU5AJOQB+U1hP9ueqf6CeELv/ANIBcMmR5drPl/D/AC7du383rjNFSdlWrSunEPXl+3Wa2hkFa5nlm2yn/tAZyf51jNPOaR6gsvXhqxRZe1zwRInW5IU6EjhSSpOSnHb/AErgWpuqusGNO2CyPOxpV1uLCJj78mM0eHFktICSAgYSEqJI7n0xWzdJOouvZGtGLPqSMq525xXguSY7CFJYOMhXiNDYR2B/8KI7vfr9ZbKhpN+ucCAh/cGxLfQ2HMYzjcecZGfvWvM3bp3bFsXBmZpWIuQCtqShbDZcAJSSlQ78gj7iuS/GP/VaT/xSv/xVwW93didp/TsBpDqXbcw806pQG1RW8twbefZQ745oJ2JsumL8tu8JtlnuK3wlxE3y7bpXjgELwc4wMHPpV7co1sYK7vNiR1PQ21OeYUyFONpAJO04z2z2qINn6mausk6w2S13csWtDUNCWPLtKwFoQVDcUk8lR9fWs7rfqZq5HUy8aeTeCLP51yJ5fy7X9UTgp3bd3b1zmg7Boe89MdY3KTbtO2e1uyEsF11KrUlsFsKSOSUAHkp4rfY9osdlgSUx7fbbfCcGXw2yhptQx3XgAHj3qFPSGdqqDebodDRfMXVyAtKlYSSy2FoUpYCuCflAxz+btW03jXmqOo/TC4W+S2ZMu3y2X31xkbVPMFKxygd9qgknA7c44zQSMtF16cwJilWeZpSLKPBVFXHQv7ZTzW5sutvtJcZWhxpYylSTkKHuDX59WxrTjkMNXZ27Q52SC802h1oc8ZQSlQ+vJ+1b5I6kar0XcLdZLHfUSbPEYjFpDMdspdQptKyAVI3DO49+RnHpQS1TpewJnedTY7WJm7f44iN+Ju992M5rIzIkebHUxMjtSGFcKbdQFpP3B4qNEfqx1A0vryFD1zFaRDnLSvyvhoBbaWrAKFJ9vZRJ4596oTuq3UPWmpbkx0/bDUGGFOJbbabUstJONyi5nJPsP50VJA/g2l7S44Rb7RbGiCtWEMNIJIAJ7AZJA/avdlvtpvrTjllucK4NtEJWqK8l0JPsSknFRavnUW/a/wCjd8jzXYzUi2Px3Jq0o2+ajqXtSAMHCg5sJxjgfodk+EBm5Yvr4kN/hA2oUxj5y/wQrt225Hf17UEkqUpQKUpQKUpQKUpQK4n1r6SXPVWoomotLTWo10aSlDiXFqbyUnKVpUM4UO36Cu2UoIqXXoTreTqRue/cItyWVNOPSZEhW9SgE7hyCSAcge4A7VktTdDdV27Vc64aGubLMSUpak/+UKYcaCjkoyByPY5qTNKCIvUzQN10V0nZXqC6rnTpV1ZHhJdUtplIae4G7uTnk49BVnoXplqnV+goq7BeQ1apT7glw5D60NBaFDavaAd2Rj07j9pX6n03aNUQG4V/gtzYrbgeS2skALAIB4I9FH96qadsNs03bU2+yRERIaVFYaQSQCe55JNBHHW3w/3xxVmj6cchvx4kBLLzr7vhqW8XXFqIGDx84xWS1d0S1OxqZF+0Rc2osl5AU6PHUytpwpwvaoDlJOT6d6kfSg4t0a6PSdLS7ndNUymZlxnMrjlttRWkIWcrKlEcqOP8++ajjc9EyYXU3+iIdbeeVNRGC2jkbVkYJ+oSQT7c1PetTi9PNMRdUq1GzbQLyXFPGQp1ajvUCCcE47E+lBzrrL0al6km226aTkMRpkRhuMWHVFCdqPyKSoA4I7foP1tul/SrWFv1gzfNYX5xxDB3hhqWtwvKAwneTgbR7c9sV3qlBx74hunt7163YRYRFzCL5d8d3Z+fw8Y4Ofymua3roPquVYNPRYrVrTKiMPIkq8bG5SnlqTzt5+UgfyqVdKCLd46Baodcs0y3S7eiU1GZRIStw/w3WwE7knbhQwEn96T+h+tH9cPXZ6VBmNrlF5UhbuxbvOSrYBgZ9qlJSgifp7oTr22LmvxLnGtskxyhtUeUoeLlSQW1EAYBTk+vIH3rORegN8gaKLcG6xW9RLmNyitC1oQhCELSEJWBndlwnOAPT61JSlBFCf0Q6j3+VHF+usR9LXypekS1OlCSecfLk1o3VHTzNk6nfgDTy1tR0Q43i9lK/gtgq+nJJqdFapeenmlLze13e6WZiRcllKlPqWsElIAT2OOAB+1EcfsfQ7UcvXEW5axvqZ9vgugtKW8tx55CFZQn5hhIPqM+/wB6sb70N1daNST5WhLu1HgTNwwJCmHEIUcltWB8wH+lSZpRXDNI9DFW3p1qGz3Ge0bteUNhTrQJbZ8NW9A55PzDk/8AKvnQzppq3QupZS7rNimzONKBZjvqUHHMjaraQOwB/eu6UoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKZr5mg+0rCX7VNi0/tF6u8GCpQylDzyUqI9wnuawSOq2hl9tTW8fdRH+YoN4zTNae31K0Y5+XU9q/WQkf51ct690k5+XU9l/Wa2P8zQbPmmawbWq9PPf1V+tS/wDDMbP+tXjV3tz39VcIi/8AC8k/60GQzSqCZTCvyvNn7KFew6g9lpP60FSlec0zQeqV8zTNB9pTNKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKDya5R196kOaHsjMS0qT+NTwfCURkMoHdePfnA/X2rqqjioa/E7McldVZLS1EoixmWkDPYFO8/zUaDl9wmyrjMdlz5DsiS6oqcddUVKUT6kmrelKIUpSgUpSg9JcWj8q1J+xxVVM2Uj8sl9P2cIqhSgv27zdGv6q5TUf4X1D/WrtrVeomv6q/XZH+GY4P8AWsLSg2VrXurmsbNUXvj0M5wj+aq3TRXXbVdilITdZH4zAyN7cjHiAeu1Y5z98iuTUoP0M0lqK36qsMW72h3xIr6c4P5kK9UqHoQazIqLvwi3t9F5vVkUsmM4wJaEHslSVBJI+4UP2FShBor1Svgr7QKUpQKUpQKUpQKUpQKUpQKUpQKUpQW6zUKfiIXv6t3n6Bkf/CTU03DUI+vS9/VnUH0cbH/wkUGgUpXROhUWE/rORInJK1QbdImR0JaDqlOoT8u1B4UoAlQHukURoMiLIjbPMsOs+IncjxEFO4e4z3FZTUWnn7HEssh95twXSGma2lGcoSVKSAc+vymunzdSWy8aO1LGuF91FqFBY8VkzLeMQ39w2L8QLOxJPykcDmss7bozkGwyorbVw1Lb9LRnrfbXUZQv5llbmMYWpIOQj1xnnGKDl+mImi27V53VNxursorUlNutzKUqAHZSnF8YPsOau50HQVytcl2y3K62m4sNqcTGuaEutvkDO1K2xlKvuKyGj5KLLoa9awTBjXC9m4IhtrlNBxEUKSVqd2dsk/KCeBVW9z0606aXK/3eHCj3m2TWWUS4zKWfNIcCsoUEjBUnbuz7UHMKyV9sk6xuxG7i2ltcqK3MaCVBWW3BlJ47celdH1ldYugZ8bTVtsFpkssxWXJz8+KHXJi1oStXzHlKRkAbcYwea2a7WO1ao6nxEzGEsWm1aXYmmK+8UDahpJS2tfcAb05PsDQcApXZtQWuz3TSV3enI0Vb7jDZD8FyyzMF7afmaW2VHcSnOD3yKsJGirXceoGlxb2Ux9O3aC1cXQHDtZbQkmQCokkYKFdzxmg5RSrq6uRnbnLcgM+BDU6sstbidiMnaMnk4GKtaDt3wmJ/6e3Nf923KH7uN/8AKpZoNRT+EpP/AEsvS/aEB+6x/wAqlSg0VWFeq8ivQoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLF08VBvrO54vVLUavaUU/skD/Spxu9qgj1UWXOpOpifS4PD9lkf6URq1XVquMy03FifbZDkaYwre262cKSataUG0ai17qLUFu8hcpyTEUoKW0yw2yHFDsV7AN361ZL1VeF3S1XHzikzLY02xEcQkJLaG/yjgc9z37+tYSlB1rRsbWTzEvUOl/wm7pualC5WhCULH5jjxI5wMHkgp9z25rzr22a3uOnFydQW23acscD+Izb20oiIccOAdjWSpa8ZPP1x7Vylp1xpW5pakK90nBr07IeeUlTzq3CntvUVY/eg6fI1BPjwWY91sNjv0u0stsNS5GS6zhIIbWlKwHNpyACD+U59a+QrprK56ql6sZt8eU6wz5GY0paC3JShkJcRt3ZWSlO4hOcE/atKY1PPbLzq175S9xS9gJIUobVLOB8ysdieQeap2zU11tlpk22JISIcglSkLaSvaop2lSSQSkkcZHsPYUHQb/bLiq1u2yw6Fh2o3DaZD4miU4gJT4uNylYZSR83OMgd6pRdQ3my9MpEB7T4cLCZEBq7CQFeXbecHiJ2jPcoUkKyByf1w03qfeHbx52GxEith0PBlDeNyg34aSpadqlEJJAOfU+5qwu2v7xdbBItMpEQR5DhccU22UKUfEU52B2/mUeducYGeBQalSlKDvnwko/896gX7R2k/uo/wDKpQNmoz/COjMnUq/ZMdP7lz/lUl2/SirhPavYqmntVQUClKUClKUClKUClKUClKUClKUClKUFg72qHHxD6afsnUCXO8M+SuZ8w0sDjfgBafvnn9RUyXBxWuaw01bNU2hy3XmOHo6uQRwptXopJ9DQQJpXb9RfD5do8harFcosqOSdqZOW3APbgEH78fated6I6xR2YhK/wyB/qKI5jSuhudHNZo7W5lX+GSj/AFNWznSbWqP/AOFKh/uyGj//AKoNFpW4OdM9Yt/msMk/4VIV/katnNAasb/Np+4/oyT/AJUGsUrPr0XqZH5rDcx/3Zf/ACqgvS1/R+ayXMf91X/yoMPSsg5Y7s3/AFlrnI/xR1j/AEq2chymv6yM8j/EgigoUr7sV/dV+1b7oDpbqDVsxomK7BtmQXJb6Ckbf9wHlR+3H1oOu/CbbXGbBe7itJCJUhtpBPr4aSSf3X/KpAN1hNL2SHp6yRLVbG/DixkbUA8k+pJ9yTkn71nECiq6e1exXhPavYoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLZYq2cTV6pNUVJoMe43VstqsmtuqSm/pQYtTNUyz9Kyha+lePB+lBjSz9K+eD9KyXg/Sng/Sgxng/Sng/SskWfpXzwfpQWAZ+lVEs/Sr0NfSvSWvpQWqI6CoKKE598c1eNIr2huqyEUHptNXCBXhCarJFB6FehXwV9oFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJFeCmqmK+YoKJTXgoq5xXnaKC2LdfC2KuttfNlBa+HTw6udlNlBa+HTw6utlNlBa+HX0N1c7KbKCiEV7CaqhNfQKDylNewKYr7ig+ilKUClKUClKUClKUClKUClKUClKUClKUClKUDFfMV9pQfMUxX2lB8xTFfaUHzFMV9pQfMUxX2lB8xTFfaUDFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFCaVidTXqLp+xzbpPXsjRWi4s++OwH1JwB96D1f79bLBAXNvE1iHGT3W6rbk+w9z9BXNJvxBaJjyS027cJKQceK1G+X/3iD/Kov8AUDWl01rfHZ90eV4QUfAjBXyMI9gPf3PrWtIQ44FFDalBIycDOKCeWj+pOl9WuBmzXRpcojPl3QW3P0SrGf0zW4g5r834sh2NIbfjOrZfbUFIcQopUkjsQR2NTC+H7qM7rKyOwbs4FXmAAFr7F5s9l49/Q/ofWg6/SgORSgVy3U/V+NYepMfSC7Q88689HZEkPhKR4u3B249N3v6V1Koe9driLP1//Ey0XhCchyS2Fbd+xKFYz6Zx3oO+dWuqcPp07bWn7e5PemBatjboRsSnAycg9yf5Gsn0r17G6g2F+4xYi4amHywtlbgWRwCDkAd8/wAqjPrPUr3UvqzYnoVrXISGo6UW8PJBXx4q0b1YHqRk47VtHwo3Ny26yv8Ap6UC0p5rxA0o/lcaUUkffCj/AOzRHSNZ9a4GldeK03LtTzgQtpLkoPhKUBYSc7cegV7181D1tgWfqH/RUWp2QsSWoypSXwEhS9v9nHpu9/SuE9WoStR/EBcLahe1UubHiJV7EobRWs6kt9z09qa0y774qbpIS3PfS6MLSS6rGfrhIP60Ekrb17tL96vEOfapESPbW3XHHw6F79iwgAJwOVEgDn1rEMfExZFScP2G5Ij54cS4hSsf4eB/OuHQ1xk6m1mqdFdlxi2+Ftsr2rwZLfzA4PI/N2xxVp+POWwRoWmbncJsJZO6BPiILYUT2De5aVZ9wAaCUXUXrbZtGXNu2iDKuE5TSHlobUEJbChlIJOecYOAPWsZD+IC0zNNXW6R7NO8W3eEXGHHEgKDi9owoZ7H3Fcm6szII12JV0F1sF+bhxFqehIDiCsx0EgAqSpJSSUZBOdvpznXId8vN30Fqr8QbTJjIRH3T1MgO7/HRtQpwDKsgqPzEkYoJDf7ebCzoyJfZ0GU09LecaZgtrS4tWzGVE8ADkf+NWGnPiL0/c7ozEuVtmWxDyghMha0uITk8FWMED681HK62SevQdivTbLjlvCn4y1pSSltYcKufbIV/Krq/wAteuJ+lbfYLdJXMiWuPbVNhAy46gqyoY9PmHJx25oJJxOuEB7qG9pVy0vNKbluwxK8cFKlIKgDtx/aKQO/rWb6R9TmOo/4r5e2OwPIeFne6HN+/f7AYxs/nUV5FvljqxemIyyZsGVNkIUPVbAccH7lFdZ+Djvq3/un/wCagknSlKKUpSgUpSgUpSgUpSgHtXGPillvR+mpbZJCJE1ppzH93Clf5pFdnPatC6x6aXqrQtyt0cAytoeYz6rQcgfryP1oIMsoDr7TalBCVKCSo9hk966J1RxorXJtOmW/w9u2JaLclv8Arn1KbCitS+5B3Ebfy/SudvtOMuraeQpt1CilSVDBSR3BFZtGppT6of420i7Nw0hLDcn0SOyVLThZSP7u7FEbJ1lt8Ri46fukWO1FevFpYnyWGkhKEuqBCilI7A4zj3zWT+GmW9G6qQ2midkiO824B/dCdw/mkVz7Ul9n6ku7tyurgXIWAkBKQlKEgYSlKRwAB6V274VtKvruczUshspjobMaMVD86iQVKH0AGP1PtRUoWjlIr3XhoYSK90CrSRbIEl0uyYMV5091uNJUT+pFXdKCzZtdvYdS6xBitup7LQylJH2IFemrdCZkGQzDjNvkklxLSQrnvzjNXVKC0Ntgqk+YMKMZG7d4paTuz75xnNfZNugynfElQ4zzmMbnGkqOPuRV1SgtWbbBZdU4zCjNuKBBUlpIJB75OK8t2q3tPJdbgREOpOQtLKQoH74q8pQW8qFFl483GYfx28RsKx+9eRboQjGMIcYRyclrwk7SffGMVdUoKLMSMwwWGY7LbJ7toQAk/p2rzGhRYpJixmGSe5bbCc/tVxSgtBbYKZCn0wowfUSS4Gk7jnvzjPOTXuJBiQ9/lIrDG/G7wmwnOO2cVcUoFKUoFKUoFKUoFKUoFKUoFUXm9wqtQig4l1U6MwNVSHbla3E2+7K5Wrblt4/7wHY/UfqDXFJfQ/WzEgttQo0hGceI3JQE/wDvEH+VTUW2FdxVIxk+woIv6J+H2Y7Lbf1XKbbjpIJjRVFSl/RSsYA+2f0qSdktUW1QGIcFhDEVhIQ22gYCQKyCGUp9KqgYoPoGBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKD//Z",
+              "timing": 2243,
+              "timestamp": 3526528401
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAE0QAAEDAwMCBAQEAgcEBQsFAAECAwQABREGEiEHMRMUQVEIImFxFTKBkSOhFjNCUnKxwRdidNEmNIKE4SQlJzWSoqOys7TDNkNFg8L/xAAVAQEBAAAAAAAAAAAAAAAAAAAAAf/EABURAQEAAAAAAAAAAAAAAAAAAAAR/9oADAMBAAIRAxEAPwCVNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFK+KUEpKlEBIGST2Fa81rjSr1w8i1qK0rl52hpMpBJPt37/Sg2KlCQBknj3rXTrjSyZ/kjqK0iXnb4Xm0bs+3fv9KDYqUBBAIOQfWsVedQ2uyrQm6yvKIXjDzrag0Pu5jaP1NBlaVoXWuV/6JL/Jhv8ABjpUh1pfcFSeQRWWOr9PWaJAjXe+W6HKUy3/AA35CUq5SOSCeKDZ6VTjSGZTCH4zrbzLg3IcbUFJUPcEd6wt31jpuzyxFut9tkSTnHhPSUJUPuCeP1oM9SqUSSxMjokRHm32HBlDjagpKh7gjvVWgUpSgUpSgUpSgUpSgUpSgUpXxatqSaAVBPcgV8DiD2UKxdyuMS3sGRcZTMZnIT4jywhOT2GTVhD1LY5slEeHeLe/IcOENtyEKUr7AGg2WlUI6yflP6VXoFKUoFKUoOb9cH3l2ex2hLy48S8XViDLcQdp8FRJUnPpnGK2OXoXTEiwqtC7LATB2FASllIKeMbgrGQr696vNXadg6qsT9ruaVeC5hSVoOFtLHKVpPoQa093Res5MI2yVrxarapPhrWi3oTJUjsR4m7vj1xmg0Q325P9D4cFU10ocvAsip6VYUuN4pTvz9UjbmuuI0DpVNj/AAkWK3+S2bMFlO7tjO7vu+uc17e0TZHdEjSpjEWlLQaSkH5kkHIWD/e3c5961pOidaIifhydfu/hoT4YUbegydnbHi5749cZoMN1BlSdCdFDH07eHpZbdTDROUsKWy2pZBG4eqR8oPcV0XT+nLZb9OItzbQkR3mQl9bx8RUjI5Usn8xOap27RtkhaPTpkREvWnwy2tt75i5k5KlH+8Tzn3q1Vp66Wyyiz6YnpjRtnhokTVqkOR09sITxnHpuUcUHFY77sfpF1QsCXVvW6zTlx4a1HO1vxB8mfpj+ddn0TpSzQ9JxGzFjTlS46HJMl5AcVKUpIJUonuDngegrHjpnAj9NZ2koElxvzoKn5jid63HCoErUOM5xijejtR2mJ5DS+qW4VtCdrbMqCJCo49Q2rcOPYKzig1TT8t7SH+1G1WQlUCztecgtfmDC1tKWpA+gIzitp6WaSsbOhrbJXDizpVxjpky5T7aXFvrcG5WSRyMntWa0Xo6HpmzyohdcnyZzinp0qQAVyVq7lX0xwBWuwtBah0+hyFpDVvkbOVKU1ElwkyTHyckIUSDj2BzQUOnzLdg6n6s03axssyGWJzbAOUx3F5Ckp9ge+K6hWs6I0ixpdmY4uW/cLpOc8aZOf/O8r0GBwEgcADtWzUClKUClKUClKUClKUClKUCvD4y0a90PNBruoxJNtPkhOL24f9S8HxMf/wBvy4/nWCsqbv8AijHmhqLwcnd5oQfD7H83h/P+1bstkg/LyK8hpZP5aD6wP4gq6rw02ED617oFKUoFKVZyrg1Hltx1Z3qSVk4OEp9/3oLylfEkKSFDseRWOvNzNu8vtZ8UuqKcbiP9D3/SgyVKw/4s+pE5TcVBTGKx8zhG7b3/ALNJN3dYaQVsM7/BL6wXsDb7JJHJ/agzFKxjd1C30thvBLpbwVcgBvfnH8q82u7iZbHpjrXgobGTySCNoJ7ge+O3pQZWlYmJeUvxIrym0oLrxZWN+Q2QFHvjnsP3qn+Nnfb0+AnMwZT/ABPy88549u3ueKDNUrHXC4mJMjs+GkocIBWpRGMkAdgff1wKoi9J8NSyzkIZceUEqyRsVjH6/wClBl6ViTdnEtpBajl1bgbTtkAoGUlXKscdvb2om6uLlR2UMIPiNhxSg5uA5I4IGD2+lBlqVgfx9flS75ZAWF7SguH5RgnJ+X6egI+tXtzuRhxWnm20uBfc7iABjOeAT/KgyNKxL11eZdk7mGiy00l0LS6cqCiQP7PHbk5q3k35cdpW6MhbqXfDIbcKkn5Nwwdvf07Cgz1KxMy7rYWtCI4WpLyGRlR53I3Z4B+1VI1yW7cjEcaS38uQreTuOATjjHr7547UGSpSlApSlApSlApSlApSlApSlArwtpC1oWpIKkHKT6ivdKBXh1pt3HitoXjtuGa90oKIiR0uOLTHaC3AQtQQMqB75PrXpyOy7s8Rptew5TuSDt+3tVSlBT8Brxi74SPFIwV7RnHtmgjspbU2GmwhXdISMHjHb7AVUpQU1x2XErStltSVnKgUghR9z79q+GMwruy2eAOUjsOQP0qrSgpuMMuOIW402taOUqUkEp+x9KIYZQpakNISpfKyEgFX396qUoKAhxgypkR2Q0o5KNg2k/avqokZSm1KjslTYAQSgZTjtj2qtSgt/IxPDLflWNhVuKfDGCffHvVR5hl9AQ+024kHIC0ggH9aqUoPJabJUShOVDaTjuPY/uapiJHDYbDDQbGcJCBgZ78VWpQUXYsd4EOsNLCiFEKQDkgYB/avrcZhtzxG2Wkubdu5KQDj2z7VVpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKxWpdQ2rTNsNxvsxEOGFhBcUkq+Y9hgAmsrUdfi+vey32KyNq5dcXLdH0SNqf/mV+1B17TPUXSep7n+H2K8tS5hQXA0G1pJSO5+ZIHrW2VBjp+87ofqrpx6WooSTHW4TxhuQ0knP2Dn8q6DqnWevtadULnprSNxXBbiPOtNtNOBnIaOFKUvuckdvr2oiU1KjPZte9R9LaI1DI1PFde8BCUQpkpKTsdLgQQcfmGFEjP93vWs2q69YLlZ42qLbdZ0qLIkFpCEOIVlQJz/CxgJyCO1FS+pUYuovU3XEm42HS1tQbPepLDImBO0LU+s4ACuQlPY8c8/SsLH6ha70ber1pjVNxdlOmE+kLLgW4w4WFKbcQ4Oe+3g/yoJb0qFmlNc6+mWLU78bUclaIcNLrq5LylrQkuJT/AAu4Cjnv7Ve2zqT1Bm9Ob4+3eQpi3yIwclLOJKQ4VAJSQOQSkZJ5/egmNSoc3vqbqyb0yskv8bmMzm7jJiuPsL8NTyEttKTu24zjeRXt/WHU+Noy06rTd3W7Q2ryqFF1K1PLClZU4lWd2SCOfQD70Ew6VEvVnWLVmqZOn7XpyT+FPymWkvFpQQXH1KI/Ofyp7evqc5rCap1t1At2uxbbzfpMeWy4w081DkkNH5U84ScZI5P1J4FBM+lRYa171D1/1BmNaNlJjRbepTzcQrS2hTaFY/iZ5UVcZHbn0rQo3UfWL713WvUV1Rhla0oEpWGzvT259MkUE5KVCy164187oK83JrUkkx4suOhxxx1Sn8qC8BBPZPHPvxWYndbdV/7ObYwzMCbq7JeZenbE+IW0JbKccYB/icnGeBQS7pUVNFah6p2zVlvbcfm36C6ULfbz4zZbUecLI4I55Bx961rSWq+oWoNZuWey6imuS3w+22iTKVsSAlWTznBABI9jigmTPlIgwZMt0KLbDanVBPchIJOPrxWhdOurdh17en7ZZ4tyZkMxzJUqU2hKSkKSnA2rJzlQ9KutPQL3a+kj8TVUpUq8tw5XjvF0uFWS4U/Me/ylI/SomdK9UytHO6jutuCPOi2FplSxkJUp9kbseuBk/egnbSoayNYdS29ALvz99cVa50sNoeTICX21pzkJCcFKTg5H0BxXb/hlvdzv2gZkq9T5M6Sm4uNpdkOFagkNtkDJ9Mk/vQdbpSlApSlApSlApSlArg3WHo/qPXmtFXWNcbYzBQy2wy28twLSkZJzhBH5ir1rvNa7q3WuntIoaVqG6Mw1OgltBBUtQHqEpBOPrig4nrn4eZk68sSNLXGMxFSwhCxOfdW54icjIO1XGNuBnjFVtV9A7xPvRvVlvsaHcZIDklBK0hLxT/EKFpGdpOTggd66pZeqGjr1Fmv269NOphsLkvILa0rS2gZUoIIBOAPQGsaz1q0E7FkSEXz+Ext3lUV4H5jgAApyex7e1EafpH4fo1v07e4l7upkTbkyGQ4wjCWMLCwRnlR3JT7cDH1rVUfDhqErTDd1NE/CkubwAlwkH1UG/wAucfWupdTOoVtg2SCi36qg2d+ehD4ecjLfdSwtOQtDaRkKPGNw9/asl071Zp5/SavLar/GEW5sqlTJh8NxKeTuWCAQPTJ9u9FaNrroGxc7fZzpu5CHcLdHRG3vg7Xgk5CyU8pVknkA+ntWO038P02P+KT9QXlmddXoj7MYArKEurbUgLWtQ3HGe2K6P/th0L5KTLTfmlMx1pbc2suFWVZwQnbkjjuBitJ6ldeIMCxQZWhZUWdJekKbcTKiuhIQlOSRnbzkp/eiMTpPoVqCz2LVEGRcbUty6wkxmVIW5hKg4lWVZR2wPTNfbJ0L1BA0Fqaxu3G1Kk3R2ItpaVObEhpSird8medwxgGr9/qRddTdC5F9iXmHZ7zFkhma6hhwIbBWQlKeFnJCmzkZ9e3pm+jGtkI6czLpq7VMac3GlloylpWjYNqSEEqSkrVzngHvQcS6p6FuGgNBWW2XWTFkPP3OTJSqMVFISWmU4O4DnKTWa0P0Vnay0dYbjHvxiWyShbj8dwKXtcS6tO5CchPKQO/1712yNrfptr2fHtrsi13SSlR8BqdEP5j32eInGTj0717svUzp9EmnT9ruEaEqMXU+XREWw01s3KXztCR2Ufr+tBpfUH4fo14ZtqtMzm4L0OMiKpEhJKXgnOFkjkK5OeDn6VrEj4b7xHvMd213e3rhtFpRMgrS4pQAK+AkgDdnHPbFd50hrvTer3Hm9PXRqW6yNy29qkLA7Z2qAJH1q71Vqux6UiIk6guLMJpw4RvyVLI77UjJP6Cioja/jaat3Ua8Ltt4uVrSmW4iVHbYO7G75w0tKsEHnAVjH1rD9LNG3DW93utvtOxoeUUS8+TsR86cBRAPJwfT0rN/ETeLZeNbRp1hciPQJUFp4OstJBWoqWCVHG7PABB7Yrpei+oSNPdSrxplNts9r01bxJddcixVB0paQVblEE7jge2aIpWvoVqCJ0+vlhcuNqMqfKjvtuJW5sSG92Qfkzn5hjivsf4epT2gvwufc4jd6YmuyY77O5TRQtDaSheQD3bzkdvrXT4HVrRlwtNzuUS7KXCtqW1SnPKujwwtW1PBTk5PHGasj1t0CIqZBvS/BUsthXk3/wAwAJH5PYiiud6S+H26o1FDuGrr6zLjxFIUlphTjinAk5CSpYG1P2z+lZDph0Xvmk+o0fUE6fbHojZeJbZUsrO9CkjukD+0PWugL6u6GR5HxL+wjziPEa3NrGE5Iyr5fk5H9rHv2rJar6haW0oppF8u7Ed11IWhtIU4spPZW1IJx9aDPXmKudZ50RpSUuPsONJKuwKkkDP71HvRvw83CGLxH1DcoKo06CY7a4hWpbbniNrSrCkgEfIc8+tdu0jrbT2r0PHT1zZmKZwXEAKQtIPqUqAOPrWxUEXT8NF0TAl7b3CcmeIkR8haG9n9or4J3dsAcfWuw9EdET9A6Sk2q6SIsh92YuSFRiopCShCcfMAc/Ka6DSgUpSgUpSgUpSgUpSgVEb4jEIj9aYsjUDMh6zKajq2NnBWyPzpSffO796lzXPdeas6dt3L8F1m9BdmM7VBiTEW7s3AEYIQQMgjsaCN0N/RUy+XxelbZf4yvw+YqOFvoLbafLL3bhgq29/7R7ir74bdIWPV99vEfUUETGWIyXG0lxaNqirGflI9KlRbtH6ctsSVGt9kt8ZiU2WX0tMJT4qCMFKvcYPavWn9J2DTrzr1jtEOA66kIcUw2ElQznBoiH3UiDEsXWKfHv0Rw2lpaUtNkLWPLhsJaxhaSoAAD8w7d6xLce2yrDqBzTUa9l1psLkLJSGBH8VPCkjKhztOCo9u5xmptX/TFj1D4X45aYU8tfkL7QWU/Ymqln09Z7LCciWm2Q4kZ3+sbZZSlK/T5vf9aCBz0uwuaLYix7NJTf2nyt+4+OS2ps5wnZ2Hp+3es+9BQvoPGnJjIU83qBxtT4QNyUGOj5d3fGcce9STfndKWb69pJyNZ0zZEhKXYqYuEKeHCUlQTt3DJGM8E471vMHSthg2d61RLRBatj6ityKGR4a1HHJT2J4H7Cgi/arxbJfwxX21wmC3cYDzC5rnhhIcLkklB3DlRCUgc9sAVzx1marphEebSs29F3fS6R+UOFlnZn9AuptMaG0uxbZdvZsNubhSylT7KWAEulJyncPXB5FXEDSWn4FqkWyHZoLVukK3vRksp8NasAZKexPA/ahEKL+uw3O66dY6e264xbh4bbbwdXuU5JyMKRycc+vA7cCsx09tcW8ddPw+8MNyo7sub4rax8qiEOn/ADANS7sujNNWOUJNosduhyQCA60wkKH2PcV5g6K01Au/4pDscBi47lL8whoBeVAhRz9QT+9BF/4UVEdT3QDwbe7ke/zIrMfFay63r+wyrg28u0KipThBxna4S4EnsFYKf5VImx6M03YZpmWayQYUooKPFYaCVbTjIz7cCsjebPbb3E8reIMabHzu8N9sLAPvz60EC9fvaek6hU9o+BLg2hbSfDalElRV2URknjI9z2P2qXevdGWJnSOqLxBtEdN6ftkkqkoSd6ippQP71sM3QGkpxYMvTtsd8BoMt7mE/IgZwkfTk/vWzbU7NuBtxjHpiioGaSvEOFoHXFtfWsSrgzE8BIQSDsfClZI4HBHesA7/APpmN/xjv/yN1PBOhdKpZmNI0/bENywEvpTHSA4AoKAOB2yAf0FaRqhHSLTFwZs98gWaNIUQ4GfKlQRuwNysAhOcDv7URGjXVthwtK6IkRY7bT0u3uOPrSOXFB5YBP1xxXy+7Y2sbZI1Qy69CdgQ3cKSpW9sxkBJACkkgH2UOxqXdysHT51EOFcomnyIrYRHZeU2C2hR3AJBPAOc/rWauekNPXSFEiXGywJMaIgNx0OshQaSAAEp9hgDj6UEd/huTYneokhyyR7z4yWXSpxRQmOlokYCk/Moc4wCo8jucVKWsZYrBabBHWxZLbEgNLOVJjtBG4/XHesnRSlKUClKUClKUClKUClKUCoX/Eioo6y3BQG4pbjnA9f4aamhUZOtvS3WGp+pUy62S1h+A6hlKHvMtI5ShIPClA8Ee1BWt/W7VsDW6bZqu0NQo0xYDTK2Sh1hK+G1ZP5hnGcj37dqt+m/WLV1+OpxcZMVXkLFKnsbY6U4db27Sfccnirm09H9Z3zqGzdNcz2n4kJaQmT4iVKkIRygJSOwzyc47nvWDsPRjX9in31uAIaY8m3SYheDqFeYQocNpBIKSohIycAc80RV07151WnT98nXBuNOeYLLUcBkIQ0pZXla9vJHy4x7kVTsXWTqfcUKmQLfGuUZCsLQ1DKsfok7hVPSXSbqPabTdURIjECU6tlQS9IZcRIbSHNyCAVJPKknChjj6VaNdGeolzv7Ul6Bb7OtBGJLDrTKEkf2glnnP2AoPGq7uI/xAsLbtlvbeVOhqKi0chTiW1KJGcbsqPJGayOkutuvrm5dUoaiXBUe3vSQnwkNhoIwS4f7wAz8vqSKyuq+lmsZvWNu9x7f5q2plxHFSzIaSVpbS2Fq2lW7ulXGKsemXSfWlkk6iXc7OGUy7HLhsnzTKtzq0gJTws4z7nigz+gOu9xlaV1LN1FEjvyrWyh5ksDww6VrCAlQ5x8xTyPTNaoeunUNLLd3VCgi1uulCB5U+GojukKzuP71kunPRbUv4Xqi26jhptqLhCQ3HeLzbo8VLiVpyEKJxlNYe29KOqtvKbbAbbhxEvbxKZlNI5/vb0nxcfT+VBs/UPr1fIUezpsVtbgrlw0ynVy2ypQUSpJSkHAwCk8nv9KuNH9VuoKHXX9R2NMm1phvyA+1GUjcUNqWkBaSU8kY7V61x076inyLNvkRdRxW4iG3fxEtPK8bkrUPGHAJPBBzgCsN056P9QLPIuM7zLVmeciPNtsokglxxSSEZ2ZSACQc59O1Bjbd1v6jXy4OizRYTxT83lmY24gfTJ3H9KkRoi/Xa8dPWLteoYg3UtOl1jw1ICVJKgPlVyM4B/Wo3XnpF1JvEhluZZrUlSVcy2DGZ3fVRRhSv2JqSfT/AE9cLJ0/g2S9TfNzW2VtuPBRUAFE4AJ5ISCB+lBw3pv1i1dfTqj8RkxV+QsUqextjpTh1vbtJ9xyeK19jrrrddgmy1S4fjNSWGknyqcbVpdJ4/7CavbD0Y6gWKffW4IhpjybdJiF4OIV5hChw2kEgpKiEjJwBzzWFj9FtfI09OiqsYD7sphxCfOMcpSl4KOd+O60/vQZyX1w15F0rZ7kqPBDch55BlLbSQ+UEfKEAjaAFDn1z9K1/rLq1u+3TTV7/Cbf4020tyHd6Cf4gddQQeRlPycZzxWx3vpNrST0x0zaGLOFXCHLluvteaZGxK9m0534OcHsax+qejuuZ1t0y1FsoW5Dtnl3x5tgbHPMPrxyvn5VpORxzQab1XXdnepcty5+B51amVM+EAEhsoSWhgf7m3NTgsYnCywBdy2bl5dvzRb/AC+LtG/H03ZqO3V7o9qe8agi3vTzTMlxcVhDzCnkIW242hKeCohJHyj19675opu8NaVtqNSrDl5DQ80oFJBXk/3ePbtRWapSlApSlApSlApSlApSlApSlAq1uNwhWyOX7jLjxGAceI+4G0/uTV1UTPiQeXN6wQLffpb0WxoaYCXEpyG21H+IsD1Oc+/YUG2dTOs+odOdR3rJaEWt62gxy2440palBxCFE7gsA/mOOK7ZC1dpudKMaFf7TIkgKUWmpja14SCVHAOeACT7YqDmo2LVF12I+nrk9c7U08yhiS8CFKSAnjsOAcgcDgVmelcyNbOpL71wfbjNJYnIK3VBICiy4AMn1J4oiYaNcaTcQ4pvU1kUltO5ZE9ohIyBk/NwMkD7kVWZ1fpt5tlbOoLQ4h53wGlJmNkLc4+RJzyr5k8Dnke9QMsn/qvUP/BI/wDuWa7L8PfTe26ssIvk+bPbkW26EsMtLSG8pS0vJBB5JwDg9gKCTjt4tjNxRAduMNE5YymOp5IcUMZ4TnJ4rROpHU222nRF0uWlLzZbjdIoaUhlEhD3yqdQhRKUKzjCu/viopWKRap2o7vP1ndrpBnAOPsvREbnDJ3ZwT3HP2+4rEWH/wBVak/4BH/3Uegll0X6nu6o03NuOrpVqt625gjMkK8BK/kCsfOo5PJ7VcdctZ6g0ra7XI0ubXslLWHHpbzaewBSEBSgDnJyRntUU7REsMjRV4euV4kMXiO4lUCAlJLbu7AWo8d8D3HYd62DUEmZI6G6XExa1ttXSS3HKzn+GEJ4H0Ciqg3vU3XjV9pdtzSGbCtb0RDzpbBeTvKlA4UlzHp25wcj0rbLf1O1Unqs7aLsvTseyNyXGnAqY0lTbac/NnxM7uORj9BUZ7z/ANTsX/Bn/wCu7W9ORGLh8RkmHLR4kaRfnWXUZI3JU4oEZHI4J7UHadH9eo2oddxtPu2hmHHfecZROVPCkkgK2YGwA7iAAM91DvW19R9T3SDPj2qx3LT1qW6ne7Ouk1CS3z+VDROVE98nior6BFmtXV2Ob0UsWyFLeUkrUrCFthZa7cnCwj7+tYm3IhXu5XmRqm5OR5qkrdQ46tXzO5Od2EKJ+3H3FBPmA+mTCZeQ+zIC0A+KycoWfUp5PH61rl06g6YtWp2dPT7q0zdnSkJZKFEAq/KCoDAJyOCfUVzz4W0xmNOXaPBva7nHQ8hfhmMtpMdSgcgFX5s4Hbtj61caxidMHOrcNy/SVo1PvZPhAr8JTnHh+JgYzjb6jjGaK7LWGXqvTzczyjl9tSZWceCZbYXn225zWv8AW+ZMg9KtRSLcpaJAYCdyO4SpaUrI/wCyVVESx2fSEvSDku7ajkQb75rYmMmMXU+FgfNx3PfnPp2oJ2zJsWDFVJmyWY8dIyXXVhCR+p4q2tN7tV4StVoucKcEfmMZ9Lu377Sahp1GmrdtuirUq9yZ2nm4mUSlMqbz/HWlR2E5JSlKQPoPrVfTwt+netdha6fXaTcoLkhhsuqSUlYWQHEHgZGM844/TNBLmDq7Tc+SY8HUFokyAlSi0zMbWrCRknAOcADJq5h3+zzob0uFdYEiKync681IQtCB7qUDgD71B/pvaGL5rCXCluPoZMOY4fBXsJKWlqAJ9sgZHrXzpxa03WJq9DkmSyiNY35e1lzaHVNrbKUrHqnJziiJtvaosDFvRPevlrbgrX4aJC5bYbUvGdoVnBOATivn9KtP+Vjyfx21+WkqKWXfNt7HSDghJzgkHvioIRXnDoO5sFZ8JNyiLCc8AlqQCf5CsnqSzsRem+jrql19ciaua2tK3MoQltxO0IHp+ZRPuTQTllXq1w3o7Mu5QmHZIyyhx9KVOj3SCee47V9ut5tlnaS5drjDgtq/KqS+lsH7FRFQZ13bhCsejZYkyXnZls8RQec3BvDq0hKP7qcDtVzqOavUGuoX9LZj6IxiRklxSynagsIUCDtVgEnJO09yaCbKdQ2VVsduSbvbzb2seJKElHhIycDK84HJHr61bs6u02/Edls6gtDkVpSUOPJmNlCFK/KCrOATg4H0qGkCPboOnNWt2vUapHiRglUJEdzatAfbwsuEJGRxztHf0zWOtNoYk9ML/dHFvePDnRW20BZCMLC8kp9TwOaCWXVbqhC0JZrfOjMxrs5Nd2oZRLDZLe0nxBgKynIA7Y571mOl+tWNeaVZu7TLUV4rWh2Kl8OqZIUQNxwMZAB5A4NREmRGpHQ633F1Kly4t9dhNOFR+RlTIcKcZx+bntXf/hVcs39AFs29xBuwdLlwQFKJSSpYbJB4GUp9Pag7TSlKKVq2uNA6e1s2wnUELxnGM+G8hZQtIPcZHp9DW01zbqn1ds/T+UzBejPT7m434vgNKCQhJOAVKPbODxg0FGX0N0Q/PaliFIYU0lsJQy+UoGwAA49+Mk+pyavn+kOipGoXbyq1gy3VLcWkOEtlas5Vs7Zyc/etDHW6z610pqa0OQX7ZcHbTLLKVrDiHCGVkgKAGDgE8j0rlvQnWDOh2tUXqQx5otxmUIYDmwuKU6BgHB9Mnt6UR3qN0H0VHZlNNsT9klsNOZkn8oWlfHHugVuWhdG2nRFqet1iQ8iM68ZCg65vO4pSnv8AZIrnts68WxzRj2obva3oSPMmLFjNvB5yQoJClEfKkADI5NWekviJsl5vLMC52uRa0vrDbb5dDqAScDdwCkfXmit3l9J9GytSi+u2hHnisuqSFHwlrP8AaKO2fX781hIvQnRMdmWy01O2ymgy4DKJJSFpXxx7oTVpq7r1p3T2p1WdMWVN8B3wpUhogIaOfmx6qI9e3auD9GbpEidaWLpJfDcBszZC3VZwEBl05/aiJEN9C9DJt6Yire+4hL3jBan1b84AKdwwdvA4rOam6ZaZ1FY7baJcNbNvtxJjtRnC2E5GD965nL+Jm0Nz1NxbBNehg4DynkoUR77MH/Os7q/rnCstjsd4tlncudtuiHNrhkBlTTiCAptSdquefeir6R0G0U+3GQ4xP2x2/CRiSfy7lK9vdRrKt9I9LI1h/SZLUv8AFPNmbu8c7PEKt35fbPpWoan6/RLOqzIh2Jyeu4wWpZSmUEFpSyR4f5DkjHfiup6k1LE0zpV6+X0GOyy2lTjaDvVvOAEJ7ZOTj0/Sg1i+9HNGXu+Lu0u2rRLcc8V3wXlIS4r3KQcZP0xVLUnRbReoLs9cZdvdZkvK3O+WeLaVq9VFPbJ+laQv4l7SYEh1uxSvModSlphb4T4iDnKtwScEccfXvXTOlGuU9QNNO3dEAwA3JVH8IveJnalJznA/vdselBm9K6atOlbSi22KGiLFSdxSCSVKPdSieSfvWEvPTPTF51cxqWfBUu5tKQvcHCELUjG0qT6kYH7Cud6k+I+z2y7vw7bZpNwaZWWy+Xg0lRBwSkYJI++KwXULrS9qPpw7I0xDuttkCUhp+U26U+X7KHzI7hXI5x+tBI+XGZmRXY0ppD0d1JQ42sZSpJGCCPauZL6DaCVLL/4ZISknPgiUvZ9u+f51zPpV1bu1j6dXy432NcL35Wc2ESZMpXzeIkDwwpSVY27d2P8Af9PXZbP8RcO5ybXFRp91EqZMEZSPNZDSSUBK87OclSuOPy9+aDpuo+nel9QWKJaLha2hDhp2xgzltTA/3SP5+/rVlovpXpPR8/z1ot6jNAKUvvuFxSAe+3PA+4Ga0rRvXprUrt3QnTy434fbX7iSZgXv8IA7PyDGc9/T2r7pX4gbXdoV3mXS0u22Nb2Uu5TIDynVKUEhCRtTzz70Gz6f6N6TsN0XcLezMElbTrJK5BUNriSlXH2Jr5YejWkrEi5pgMzALjDXBf3yCrLSyCrHHB+Uc1osX4mbQucESdPzWohVjxkvJWoD32YH+daX186i3w63aTp653W22wQmVMrYkONolJWN/igDH97Z68oP2BHYUdCNFIt78JLE/wAB51t5Q8yc7kBYTzj2cVV7P6NaSnWC1WZ9mYYVtU8qOBIIUC6QVZOOeQK1S7dbHtK6R0nJuWnpL8q5RFLWl6UW1pLatm45QSd35s/X171V1j15b00bJu08uT+J2ti5DEwI8MObvk/Ic429+PtRWy3fozpK7QrXEmMzCzbWDGj7ZBBCNxVzxyck1c6i6R6R1BFtzNwgub4MdEVp5p0ocLaEhKQoj82APWtEkfEZCiail22Zp91tmM860p9MrcTs3YwnZ6kAd/Wri4ddbRJ6eKuE2JPgTJzj0ViPDfSp5O1KcuBZSAn8w5wefeg262dJ9FRLDdbJBiHw5mxuY4Hyp7CVJWlJV/Z5CTjiqcXozpKNp2dZWmZnkZjzb7oMglRUjO3Bxx+Y1zrot1P0dEvAtEazTbXKubqUrmSJRkl93snxFHBBJPoMZNSNoNHtvS3SsHSUnTQhLkWqQ+ZKkPulSg5hI3JUMEcJHb6+9Xmg+n9h0KJo0+w82ZhQXi66Vk7d20DPbG4/vW2UoFKUoFRZ+I/Td5t3UWPquLBdmW5aWTuQjeltaONquDjOAQT71KalBDnTKLvqJepbk1pCEzEFuluOznmnVONnwFgBC1KwVk47D1Nc/tWlp1wsl5nIYfSq3IacKC2fnSpew4+oyD+9foNSiRBpuzXjUXTOK1b7fIdcsMt5TzTbR3lp8JIXjGVYU2oHHYEelXsljUHVO92KDB021A8oyiKt+PHUhASCMrcUeBj0H7d6mxSgh85aNSdO+rU9bGnPxrzrjrcQvsqW26lxWQoK7BXof1+9ajobTV0vOtX7WiKqPKkMTG0goKUBfgOYTnsBnip30oIHwXLxYoM3TkzTLkiQ5ISotPtOZChjjanBV245xzxXZNYaOny/h3bXNskS13OE/wCfTDhNKTsQTtO4Ek7ik7jz6D2qRlKKhH0Q01L1B1MsrU5h/wApCPmVlxJwEt/MlPPoVED9akv1909P1L01nQ7Q0p+Y242+llP5nAk8ge5wScfSui0oIJTFand6fJtD9gbZtdulgqkmGUSPFXuOwqPJ9fT0GfSpD/Cky4z01lpebW2r8SdOFpIOPDbrs1KCDWpFyoV5lSmtLXOyX0PKKXYy1oZyTyfCUgnBGeArHPbFdCt9j1fqHodqRufY/DnLksPsbIiWH5SEnKiUpA3YHY4yee/FSP1TemtO6en3eQy8+1DaLqm2U7lqx6AVqHSbqfF6iC4CNbJMFcPbuLigtKgrOMKHrx2oiLttnXZrpdfNMO2eQhhMtE8vqaWFBzLaPDxjHYE+/Fdy+Fm2pPTi5eZiJD/4k7sLrfzD+E1jGR713OlFQd0dbtQ6XvOpYbmn5rz7lomw3QpBQGkFHLmSMEDbx75GO9WGj9JXe/2DUTFuhyHJMdtmSGQg7nQlRBCR6nCs4+lTxrR9N9VNJaj1A3ZbRcHXriveEtmO4gHaCVckY7A0RF+23y+vWS0aZa0JCmvwHFEF+3uKccKifzAEe/J+g9q2b4htJX3Zpe5C0BDDNpaiSG4LRLUZ1KlKKcDOE/Pgc+ldb0l1ogak16dMs2aewsrcQl9zHBQCTuT3SOPf2rq9BD3qk3ftWaB0ZezZZLbcVl2E4lptStgSUhKiMZAUEk57VqnUY3e5DS5mWaVD8vY40ZoKBUXUIKwHMY+XPPB9MH1qdtKKhjoWA8v4gmC/EcUwbs+SVtnaRlfuMVv/AMUujbjIk2m+2eCp+FGZLL7bDefDO7cFFI9Dkgn6DNSPpQRB6fv3jVfUC2vx9HQnQhbQflS2nVhlKTkr3bgkHHYY9sCpfUpQKUpQKUpQKjT8Rt31yxqrwbM/cWLEyyghdvUoALIyrxCjkH2B9MEVJauQdRejkjVOrn9QWvUsm0yn20IWlDZP5UhIwUqSewoOT9PtVajsi7ldkaubv0OHAedXEXKdUoL24QSh1IJAURkpz96wTNx6g3vS911sNVyERoMgNuNCattRUSPytp+XHzDjj1rtGgugNt0/NkS71c3Lq48w7HLYa8JG1xJSonkknBPrx3rXJPwyIM5fldTLbglWUtri7lgexIUAT9cURyvWXUvU17j2OSq7T4shuGWXzFfWyl5SXV4WUpIGSCAftWT1PrDWeltX2p57UkuSoxIknw0rUGihTaTsUgkg8cEnk966tq34eI1zTaWbLd0wI0GJ5ch2P4q3V71LU4SFDk7u2PSvWtugr+pbrDmI1A1HEeFHibDEKtxaQE7s7x3x2oN763armaO6fTLla8CctaGGXCMhsqP5seuADj64qM79w6gWzSdu1wrVclUaXJLSGvOrWsKBV+Zs/Lj5Txz6cVLvWWm4GrdOS7NdUqMaQkDcg4UhQOQpP1BFcKjfDIkTE+Z1MtcIKzsRF2rI9slRAP1xQc+6r6/v9zm6fuMa6T4Bl2hlx1mLJW0gub3EqUEg+pT/AJVv2pXde9M9NXrUF3vrU+Td3G40YNuuOIiKVuWVJQsbR8qcDH0rYeoXQVvUtzgO2q7NWyFCgtwmo6o5cOEFRzu3DvurcOt7Vsb6WXIXuK9KhtBrIYUEuJO9KQtJORkZzg9+3rQRvu07X1t6cQ7/ACtUPO228SQEJTOWZDa07/2BwcgH2yKt5/UXVCNGads8W9zWVyPFfflKkK8ReXlISC4TkJG0+vr9K026iwtQC3aX7lKkqdCkrkspZS0jByMJWrconbzxjHrnjvGleiqNXdKdPruEh61XZvxXG1lvdlpaypIUnIP1HPrQcx6g3/WNlu0W3TdXrmLjxEJS/bLgtSFJJURvIIysZwSRnAFZOx33Vdw6xKtdv1JPYW7cX2WvGfW602Mrx/DKsHA7Dt2roFx+GZtxMQW/UIZKGAl8uxivxHdyiVDChtGCkY+nfms/p3oa/aOo7WqFX5p1CJjkry4ikE7ir5d27/e74oOP9P8AXWpxK1LbZl7nymnbRPILr6lFtxDK1pWgk5Scp9PerfQepNaL01qRNhuNwkzCY6SC8pxxKCXCotgkndwM45xk+ldXsPw+SLXc58s6iadEqJKjBIiEbfGaWjOd/ON2ceuKoW74cVsWqbEf1N87zrTzbjUXbsUgLHOV8g7z2x2oOS2e76vXJCXdbyrbc/E2iJcJchpRPpypOwfqRW0am1drDU/VRyyQtSCyphulhsuyvAYCmh8ylEfmKlJJ5z3A7VuLfw4PS7g27fdXSZrKAE4DB8TaP7IUpZwO/pWZ1v8AD7a9QahFygXR23NubPHY8IOBWAASk5GCQPXPPNBxrS981RfuqSbTM1PPSqbKfjrciy1qZSpQWNzaQoDaCcpxjsO1WXRG2PTesVnjNznY62JK3lOozlwNgqUg8jhQSUn6E967ZpXoGNOa9iX6Je0qhRZSnmoio53BHO1JXu5IBHOPSqNx+HeOrVhutqvq4cUyPMeXUxvKPmyUhQUOPuO1BzK36wu9p613mSu4Tn40OVcXfLLkLLaktoeUlJTnGPlHFWsS6dQNW2a/asb1S8wxayFvMiYpnvzhCE/Lj74z9TXZbX0M8t1HkalmXhqTEfkyXnIRjEbkPBYKN272X3x6Vr9w+GZpdwdVbtSLYgLVlLTsbetI9twUAfvig59qzqTqO99O9OSHLpNjz48uVFefjPKaL6UoZUkq2kZI3kfz9as9Ram1nabHpK4HVNwKZcRbjKEOqBQEuqHznPzkn1Ppx6V2zVHQSJcNK2KyWa6+SRblvOuvPMeIqQ44EAqOCMfkA+2ParXUnQR+8WHTduTqBpo2iM5HLhiFXi7nCvON/HfHrQdh0fcHbvpKyXKRjxpkJmQvAwNy2wo/zNZesZpe2GyaatNqU6HlQYjUYuBO3fsQE5x6Zx2rJ0UpSlApSlApSlArUdddRdN6I8JF+mlEl1O5uO0grcUntnA7D6nFbdUSfiNYNu6yRLneoTkuzutsLDe4pDraOFoCvQ5z/wC19aDvmh+quldZzTCtM1xE0JKxHkNltSgO5HocfQ1ibz100Pa7muEqdIkqQrat2MwVtpPr83Gf0zXDdIPWLU2t57WjNJzocx6NI8q8meQiKSypIUUBPYk/3u5rSLJPslnsWo7ZqKwOyL28nw4j6lFBiLGQcj6HB+uMURLXUnWLSVit1qnuSZEyHckuKYciNhY+QpCgoEgg/MODVpI656Hjuwm3p748yyh4lLJWGQoZCV7c4VjuBnFRNvVtnwdEaeenIcbYlyZbsZKxjKNrAKh9CQf2rLdU4UWFG0UYkdpgv6ejPO+GgJ8RZW5lSsdyfeglY91e0a1qdmxG6Bcp0oSl1CCpncrskrHY8j6DPfvWMh9dNGSLw5b3HpkVbfib3ZDIS2nYCTyFE87SAMckgVGfqtCjWzW8Jq3x2ozfkYTm1pISNxZQSePUnnNX3S+FFuPWby0+O1JjqXOKm3UBSSQ06RkH2IBoJKWbrVom6w50hu5OR/JtF5xuQ0UKUkED5fRRyQMA55q+snU/R+otO3K5tz0IgQgBLTKbKSgK7ZSc5z2GM57VE3pPb4dwc1d56M1I8vp2bIa8RIVscSE7Vj2IycGsbp23z7ho7U34ehxxMdUaRIQgEktgrBOPYFST+lBIq2dS+j67ygM2uHFeK8JlrtSUpz6HcBkfcgVtmr+smltKXw2q5eeXIDaHAuO0laClYyCDuHoaiZGuOnHbXaor9klSJrSiHvLOhgvZPHzELKj+gx6VmOtUfy+tYUcxXIgRbYSPLOueItrDSfkUrAyR2ziglJbOrmkZ7F8kJnLZiWhaEPyHUYQsqKgnw8ZKs7D6ZrE23r1oadcERfOyo+9W1Lz8cpbJ+4zgfUgVqHxFaGttk6dpe0tZ2ojQmtOTPLpPKAhYSVfQFf8AOuNN3vRr9msUL+h8uRc2ElEpxmaWjJWSMdkqJ+2BjtzQdH6i6juVu66hkauuLMVuTHIjspUUIQtKFbAkHaoEK7n3rsdz6vaNtupxYpN0xLDnhOOBB8JpfspfYc8euPXFRj6mNFjrKw0WFxygW5PgrXvU3hhkbSr1I7Z9axdsUnT2trtB1Jpn8enOLcjJjOOLbUHlK4WMAlWfT3zwaDtvUHrdZr/oa9xNKyLtDuyGm3G3wnwSkB5sKwpKsjIJH61b9AOoHkdH6hu2t79KejsSWm23Jby3lZKVHagHJycdh7VHezf9TvX/AAY/+s1WRYt06T08kTIyFrhRLiBI2jISVN/Io/ThQz9frQSysHXLRN6ubUBubIivPLCG1SmShClHsN2SB+uK6PcJsa3QX5k59uPFYQXHHXDhKUjuSagzCmacudwssaPpudLlbEMrZiPiP4rmR2+ValffI/SpVdc7bNuPSG8Rbcy4uQlppZaR8yilC0qUPrwDRWLHX7QhneX85M8Pdt8x5VXh/f8AvY/StR669YbjYbxbIejLg2lK4/mHnCyhxDiV4LZSTn03VwSDcbAnTzEOfaX356HypTjCw0paPYrIV9sBIFb91rtao2g+n8hi0ybdGEZ9Jaec8Vbe5SVISpeBkkZIGBjt6URJbpTqc6u0Harq4pS5K2g3IUpARueTwsgDjG7OK22ucfD9qCJf+mtuTDjuMfhqUQHd4A3uIbQVKGPQ7vXmuj0UpSlApSlApSlApSlAq2nwIdxYLFwiR5TJ/wD232wtP7GrmuC9beqOorTrOLpPRjaEz1hve6W0rWtxz8qEhXygYI5I9fTFBudy6g6D0PfnbApLVumpKAtqLBKU5UAU8pTjsRWR1/cNF6e2XLU0C3Pz18MIMRD0l4jsEDGT9+w96iP1Al3yb1LLuq4iYl6C4zchtJBBKUIAUMEjkAHjjmt51P1b1dqHV81WlzAhx4BcDCnG2PE8MHBO931VgfKn+eKIk47a7JqSDClXC0RJbXhhbKZsRKlNpUAcbVjKewyPpSXpXT0wMCXYrU+GGwy0HYbavDQOyU5HCRk8Djmo3XHq7r1vpv5qUh63XFu4MttzzDSlMhpTbpKcLSU5BQk5A/8AGzZ6p9Un9HN36MoKtcF0tSpymGT4q1KGAU4GAMpHyjueT7Fdo6gaj6b6ZvbMTVdtt5uC46HUFVsDx8PJSn5tp7bCAPTFbla9PadQ41crfZLYy+4nxEvtxEIcwsc8gZ5BOfvUMur+rl63uNivD7KWZKrWlp9CPy70vPAkfQ8H9a6VeuqOtrzqhnSvT1tDa4jQZyG21OOqQj5yS58qQCCP0+uKIkNE0rp6EXjDsVqj+M2pl3wobaN7avzIVgcpPqDxVa16fs1oU6q1Wm3wVOja4Y0ZDZWPY7QMio3WXq1ra5WDUtokviNqO1MqltyEMN7iGlgPNrQQU5AJOQB+U1hP9ueqf6CeELv/ANIBcMmR5drPl/D/AC7du383rjNFSdlWrSunEPXl+3Wa2hkFa5nlm2yn/tAZyf51jNPOaR6gsvXhqxRZe1zwRInW5IU6EjhSSpOSnHb/AErgWpuqusGNO2CyPOxpV1uLCJj78mM0eHFktICSAgYSEqJI7n0xWzdJOouvZGtGLPqSMq525xXguSY7CFJYOMhXiNDYR2B/8KI7vfr9ZbKhpN+ucCAh/cGxLfQ2HMYzjcecZGfvWvM3bp3bFsXBmZpWIuQCtqShbDZcAJSSlQ78gj7iuS/GP/VaT/xSv/xVwW93didp/TsBpDqXbcw806pQG1RW8twbefZQ745oJ2JsumL8tu8JtlnuK3wlxE3y7bpXjgELwc4wMHPpV7co1sYK7vNiR1PQ21OeYUyFONpAJO04z2z2qINn6mausk6w2S13csWtDUNCWPLtKwFoQVDcUk8lR9fWs7rfqZq5HUy8aeTeCLP51yJ5fy7X9UTgp3bd3b1zmg7Boe89MdY3KTbtO2e1uyEsF11KrUlsFsKSOSUAHkp4rfY9osdlgSUx7fbbfCcGXw2yhptQx3XgAHj3qFPSGdqqDebodDRfMXVyAtKlYSSy2FoUpYCuCflAxz+btW03jXmqOo/TC4W+S2ZMu3y2X31xkbVPMFKxygd9qgknA7c44zQSMtF16cwJilWeZpSLKPBVFXHQv7ZTzW5sutvtJcZWhxpYylSTkKHuDX59WxrTjkMNXZ27Q52SC802h1oc8ZQSlQ+vJ+1b5I6kar0XcLdZLHfUSbPEYjFpDMdspdQptKyAVI3DO49+RnHpQS1TpewJnedTY7WJm7f44iN+Ju992M5rIzIkebHUxMjtSGFcKbdQFpP3B4qNEfqx1A0vryFD1zFaRDnLSvyvhoBbaWrAKFJ9vZRJ4596oTuq3UPWmpbkx0/bDUGGFOJbbabUstJONyi5nJPsP50VJA/g2l7S44Rb7RbGiCtWEMNIJIAJ7AZJA/avdlvtpvrTjllucK4NtEJWqK8l0JPsSknFRavnUW/a/wCjd8jzXYzUi2Px3Jq0o2+ajqXtSAMHCg5sJxjgfodk+EBm5Yvr4kN/hA2oUxj5y/wQrt225Hf17UEkqUpQKUpQKUpQKUpQK4n1r6SXPVWoomotLTWo10aSlDiXFqbyUnKVpUM4UO36Cu2UoIqXXoTreTqRue/cItyWVNOPSZEhW9SgE7hyCSAcge4A7VktTdDdV27Vc64aGubLMSUpak/+UKYcaCjkoyByPY5qTNKCIvUzQN10V0nZXqC6rnTpV1ZHhJdUtplIae4G7uTnk49BVnoXplqnV+goq7BeQ1apT7glw5D60NBaFDavaAd2Rj07j9pX6n03aNUQG4V/gtzYrbgeS2skALAIB4I9FH96qadsNs03bU2+yRERIaVFYaQSQCe55JNBHHW3w/3xxVmj6cchvx4kBLLzr7vhqW8XXFqIGDx84xWS1d0S1OxqZF+0Rc2osl5AU6PHUytpwpwvaoDlJOT6d6kfSg4t0a6PSdLS7ndNUymZlxnMrjlttRWkIWcrKlEcqOP8++ajjc9EyYXU3+iIdbeeVNRGC2jkbVkYJ+oSQT7c1PetTi9PNMRdUq1GzbQLyXFPGQp1ajvUCCcE47E+lBzrrL0al6km226aTkMRpkRhuMWHVFCdqPyKSoA4I7foP1tul/SrWFv1gzfNYX5xxDB3hhqWtwvKAwneTgbR7c9sV3qlBx74hunt7163YRYRFzCL5d8d3Z+fw8Y4Ofymua3roPquVYNPRYrVrTKiMPIkq8bG5SnlqTzt5+UgfyqVdKCLd46Baodcs0y3S7eiU1GZRIStw/w3WwE7knbhQwEn96T+h+tH9cPXZ6VBmNrlF5UhbuxbvOSrYBgZ9qlJSgifp7oTr22LmvxLnGtskxyhtUeUoeLlSQW1EAYBTk+vIH3rORegN8gaKLcG6xW9RLmNyitC1oQhCELSEJWBndlwnOAPT61JSlBFCf0Q6j3+VHF+usR9LXypekS1OlCSecfLk1o3VHTzNk6nfgDTy1tR0Q43i9lK/gtgq+nJJqdFapeenmlLze13e6WZiRcllKlPqWsElIAT2OOAB+1EcfsfQ7UcvXEW5axvqZ9vgugtKW8tx55CFZQn5hhIPqM+/wB6sb70N1daNST5WhLu1HgTNwwJCmHEIUcltWB8wH+lSZpRXDNI9DFW3p1qGz3Ge0bteUNhTrQJbZ8NW9A55PzDk/8AKvnQzppq3QupZS7rNimzONKBZjvqUHHMjaraQOwB/eu6UoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKZr5mg+0rCX7VNi0/tF6u8GCpQylDzyUqI9wnuawSOq2hl9tTW8fdRH+YoN4zTNae31K0Y5+XU9q/WQkf51ct690k5+XU9l/Wa2P8zQbPmmawbWq9PPf1V+tS/wDDMbP+tXjV3tz39VcIi/8AC8k/60GQzSqCZTCvyvNn7KFew6g9lpP60FSlec0zQeqV8zTNB9pTNKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKDya5R196kOaHsjMS0qT+NTwfCURkMoHdePfnA/X2rqqjioa/E7McldVZLS1EoixmWkDPYFO8/zUaDl9wmyrjMdlz5DsiS6oqcddUVKUT6kmrelKIUpSgUpSg9JcWj8q1J+xxVVM2Uj8sl9P2cIqhSgv27zdGv6q5TUf4X1D/WrtrVeomv6q/XZH+GY4P8AWsLSg2VrXurmsbNUXvj0M5wj+aq3TRXXbVdilITdZH4zAyN7cjHiAeu1Y5z98iuTUoP0M0lqK36qsMW72h3xIr6c4P5kK9UqHoQazIqLvwi3t9F5vVkUsmM4wJaEHslSVBJI+4UP2FShBor1Svgr7QKUpQKUpQKUpQKUpQKUpQKUpQKUpQW6zUKfiIXv6t3n6Bkf/CTU03DUI+vS9/VnUH0cbH/wkUGgUpXROhUWE/rORInJK1QbdImR0JaDqlOoT8u1B4UoAlQHukURoMiLIjbPMsOs+IncjxEFO4e4z3FZTUWnn7HEssh95twXSGma2lGcoSVKSAc+vymunzdSWy8aO1LGuF91FqFBY8VkzLeMQ39w2L8QLOxJPykcDmss7bozkGwyorbVw1Lb9LRnrfbXUZQv5llbmMYWpIOQj1xnnGKDl+mImi27V53VNxursorUlNutzKUqAHZSnF8YPsOau50HQVytcl2y3K62m4sNqcTGuaEutvkDO1K2xlKvuKyGj5KLLoa9awTBjXC9m4IhtrlNBxEUKSVqd2dsk/KCeBVW9z0606aXK/3eHCj3m2TWWUS4zKWfNIcCsoUEjBUnbuz7UHMKyV9sk6xuxG7i2ltcqK3MaCVBWW3BlJ47celdH1ldYugZ8bTVtsFpkssxWXJz8+KHXJi1oStXzHlKRkAbcYwea2a7WO1ao6nxEzGEsWm1aXYmmK+8UDahpJS2tfcAb05PsDQcApXZtQWuz3TSV3enI0Vb7jDZD8FyyzMF7afmaW2VHcSnOD3yKsJGirXceoGlxb2Ux9O3aC1cXQHDtZbQkmQCokkYKFdzxmg5RSrq6uRnbnLcgM+BDU6sstbidiMnaMnk4GKtaDt3wmJ/6e3Nf923KH7uN/8AKpZoNRT+EpP/AEsvS/aEB+6x/wAqlSg0VWFeq8ivQoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLF08VBvrO54vVLUavaUU/skD/Spxu9qgj1UWXOpOpifS4PD9lkf6URq1XVquMy03FifbZDkaYwre262cKSataUG0ai17qLUFu8hcpyTEUoKW0yw2yHFDsV7AN361ZL1VeF3S1XHzikzLY02xEcQkJLaG/yjgc9z37+tYSlB1rRsbWTzEvUOl/wm7pualC5WhCULH5jjxI5wMHkgp9z25rzr22a3uOnFydQW23acscD+Izb20oiIccOAdjWSpa8ZPP1x7Vylp1xpW5pakK90nBr07IeeUlTzq3CntvUVY/eg6fI1BPjwWY91sNjv0u0stsNS5GS6zhIIbWlKwHNpyACD+U59a+QrprK56ql6sZt8eU6wz5GY0paC3JShkJcRt3ZWSlO4hOcE/atKY1PPbLzq175S9xS9gJIUobVLOB8ysdieQeap2zU11tlpk22JISIcglSkLaSvaop2lSSQSkkcZHsPYUHQb/bLiq1u2yw6Fh2o3DaZD4miU4gJT4uNylYZSR83OMgd6pRdQ3my9MpEB7T4cLCZEBq7CQFeXbecHiJ2jPcoUkKyByf1w03qfeHbx52GxEith0PBlDeNyg34aSpadqlEJJAOfU+5qwu2v7xdbBItMpEQR5DhccU22UKUfEU52B2/mUeducYGeBQalSlKDvnwko/896gX7R2k/uo/wDKpQNmoz/COjMnUq/ZMdP7lz/lUl2/SirhPavYqmntVQUClKUClKUClKUClKUClKUClKUClKUFg72qHHxD6afsnUCXO8M+SuZ8w0sDjfgBafvnn9RUyXBxWuaw01bNU2hy3XmOHo6uQRwptXopJ9DQQJpXb9RfD5do8harFcosqOSdqZOW3APbgEH78fated6I6xR2YhK/wyB/qKI5jSuhudHNZo7W5lX+GSj/AFNWznSbWqP/AOFKh/uyGj//AKoNFpW4OdM9Yt/msMk/4VIV/katnNAasb/Np+4/oyT/AJUGsUrPr0XqZH5rDcx/3Zf/ACqgvS1/R+ayXMf91X/yoMPSsg5Y7s3/AFlrnI/xR1j/AEq2chymv6yM8j/EgigoUr7sV/dV+1b7oDpbqDVsxomK7BtmQXJb6Ckbf9wHlR+3H1oOu/CbbXGbBe7itJCJUhtpBPr4aSSf3X/KpAN1hNL2SHp6yRLVbG/DixkbUA8k+pJ9yTkn71nECiq6e1exXhPavYoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLZYq2cTV6pNUVJoMe43VstqsmtuqSm/pQYtTNUyz9Kyha+lePB+lBjSz9K+eD9KyXg/Sng/Sgxng/Sng/SskWfpXzwfpQWAZ+lVEs/Sr0NfSvSWvpQWqI6CoKKE598c1eNIr2huqyEUHptNXCBXhCarJFB6FehXwV9oFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJFeCmqmK+YoKJTXgoq5xXnaKC2LdfC2KuttfNlBa+HTw6udlNlBa+HTw6utlNlBa+HX0N1c7KbKCiEV7CaqhNfQKDylNewKYr7ig+ilKUClKUClKUClKUClKUClKUClKUClKUClKUDFfMV9pQfMUxX2lB8xTFfaUHzFMV9pQfMUxX2lB8xTFfaUDFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFCaVidTXqLp+xzbpPXsjRWi4s++OwH1JwB96D1f79bLBAXNvE1iHGT3W6rbk+w9z9BXNJvxBaJjyS027cJKQceK1G+X/3iD/Kov8AUDWl01rfHZ90eV4QUfAjBXyMI9gPf3PrWtIQ44FFDalBIycDOKCeWj+pOl9WuBmzXRpcojPl3QW3P0SrGf0zW4g5r834sh2NIbfjOrZfbUFIcQopUkjsQR2NTC+H7qM7rKyOwbs4FXmAAFr7F5s9l49/Q/ofWg6/SgORSgVy3U/V+NYepMfSC7Q88689HZEkPhKR4u3B249N3v6V1Koe9driLP1//Ey0XhCchyS2Fbd+xKFYz6Zx3oO+dWuqcPp07bWn7e5PemBatjboRsSnAycg9yf5Gsn0r17G6g2F+4xYi4amHywtlbgWRwCDkAd8/wAqjPrPUr3UvqzYnoVrXISGo6UW8PJBXx4q0b1YHqRk47VtHwo3Ny26yv8Ap6UC0p5rxA0o/lcaUUkffCj/AOzRHSNZ9a4GldeK03LtTzgQtpLkoPhKUBYSc7cegV7181D1tgWfqH/RUWp2QsSWoypSXwEhS9v9nHpu9/SuE9WoStR/EBcLahe1UubHiJV7EobRWs6kt9z09qa0y774qbpIS3PfS6MLSS6rGfrhIP60Ekrb17tL96vEOfapESPbW3XHHw6F79iwgAJwOVEgDn1rEMfExZFScP2G5Ij54cS4hSsf4eB/OuHQ1xk6m1mqdFdlxi2+Ftsr2rwZLfzA4PI/N2xxVp+POWwRoWmbncJsJZO6BPiILYUT2De5aVZ9wAaCUXUXrbZtGXNu2iDKuE5TSHlobUEJbChlIJOecYOAPWsZD+IC0zNNXW6R7NO8W3eEXGHHEgKDi9owoZ7H3Fcm6szII12JV0F1sF+bhxFqehIDiCsx0EgAqSpJSSUZBOdvpznXId8vN30Fqr8QbTJjIRH3T1MgO7/HRtQpwDKsgqPzEkYoJDf7ebCzoyJfZ0GU09LecaZgtrS4tWzGVE8ADkf+NWGnPiL0/c7ozEuVtmWxDyghMha0uITk8FWMED681HK62SevQdivTbLjlvCn4y1pSSltYcKufbIV/Krq/wAteuJ+lbfYLdJXMiWuPbVNhAy46gqyoY9PmHJx25oJJxOuEB7qG9pVy0vNKbluwxK8cFKlIKgDtx/aKQO/rWb6R9TmOo/4r5e2OwPIeFne6HN+/f7AYxs/nUV5FvljqxemIyyZsGVNkIUPVbAccH7lFdZ+Djvq3/un/wCagknSlKKUpSgUpSgUpSgUpSgHtXGPillvR+mpbZJCJE1ppzH93Clf5pFdnPatC6x6aXqrQtyt0cAytoeYz6rQcgfryP1oIMsoDr7TalBCVKCSo9hk966J1RxorXJtOmW/w9u2JaLclv8Arn1KbCitS+5B3Ebfy/SudvtOMuraeQpt1CilSVDBSR3BFZtGppT6of420i7Nw0hLDcn0SOyVLThZSP7u7FEbJ1lt8Ri46fukWO1FevFpYnyWGkhKEuqBCilI7A4zj3zWT+GmW9G6qQ2midkiO824B/dCdw/mkVz7Ul9n6ku7tyurgXIWAkBKQlKEgYSlKRwAB6V274VtKvruczUshspjobMaMVD86iQVKH0AGP1PtRUoWjlIr3XhoYSK90CrSRbIEl0uyYMV5091uNJUT+pFXdKCzZtdvYdS6xBitup7LQylJH2IFemrdCZkGQzDjNvkklxLSQrnvzjNXVKC0Ntgqk+YMKMZG7d4paTuz75xnNfZNugynfElQ4zzmMbnGkqOPuRV1SgtWbbBZdU4zCjNuKBBUlpIJB75OK8t2q3tPJdbgREOpOQtLKQoH74q8pQW8qFFl483GYfx28RsKx+9eRboQjGMIcYRyclrwk7SffGMVdUoKLMSMwwWGY7LbJ7toQAk/p2rzGhRYpJixmGSe5bbCc/tVxSgtBbYKZCn0wowfUSS4Gk7jnvzjPOTXuJBiQ9/lIrDG/G7wmwnOO2cVcUoFKUoFKUoFKUoFKUoFKUoFUXm9wqtQig4l1U6MwNVSHbla3E2+7K5Wrblt4/7wHY/UfqDXFJfQ/WzEgttQo0hGceI3JQE/wDvEH+VTUW2FdxVIxk+woIv6J+H2Y7Lbf1XKbbjpIJjRVFSl/RSsYA+2f0qSdktUW1QGIcFhDEVhIQ22gYCQKyCGUp9KqgYoPoGBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKD//Z",
+              "timing": 2803,
+              "timestamp": 3527089026
+            },
+            {
+              "timestamp": 3527649651,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAE0QAAEDAwMCBAQEAgcEBQsFAAECAwQABREGEiEHMRMUQVEIImFxFTKBkSOhFjNCUnKxwRdidNEmNIKE4SQlJzWSoqOys7TDNkNFg8L/xAAVAQEBAAAAAAAAAAAAAAAAAAAAAf/EABURAQEAAAAAAAAAAAAAAAAAAAAR/9oADAMBAAIRAxEAPwCVNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFK+KUEpKlEBIGST2Fa81rjSr1w8i1qK0rl52hpMpBJPt37/Sg2KlCQBknj3rXTrjSyZ/kjqK0iXnb4Xm0bs+3fv9KDYqUBBAIOQfWsVedQ2uyrQm6yvKIXjDzrag0Pu5jaP1NBlaVoXWuV/6JL/Jhv8ABjpUh1pfcFSeQRWWOr9PWaJAjXe+W6HKUy3/AA35CUq5SOSCeKDZ6VTjSGZTCH4zrbzLg3IcbUFJUPcEd6wt31jpuzyxFut9tkSTnHhPSUJUPuCeP1oM9SqUSSxMjokRHm32HBlDjagpKh7gjvVWgUpSgUpSgUpSgUpSgUpSgUpXxatqSaAVBPcgV8DiD2UKxdyuMS3sGRcZTMZnIT4jywhOT2GTVhD1LY5slEeHeLe/IcOENtyEKUr7AGg2WlUI6yflP6VXoFKUoFKUoOb9cH3l2ex2hLy48S8XViDLcQdp8FRJUnPpnGK2OXoXTEiwqtC7LATB2FASllIKeMbgrGQr696vNXadg6qsT9ruaVeC5hSVoOFtLHKVpPoQa093Res5MI2yVrxarapPhrWi3oTJUjsR4m7vj1xmg0Q325P9D4cFU10ocvAsip6VYUuN4pTvz9UjbmuuI0DpVNj/AAkWK3+S2bMFlO7tjO7vu+uc17e0TZHdEjSpjEWlLQaSkH5kkHIWD/e3c5961pOidaIifhydfu/hoT4YUbegydnbHi5749cZoMN1BlSdCdFDH07eHpZbdTDROUsKWy2pZBG4eqR8oPcV0XT+nLZb9OItzbQkR3mQl9bx8RUjI5Usn8xOap27RtkhaPTpkREvWnwy2tt75i5k5KlH+8Tzn3q1Vp66Wyyiz6YnpjRtnhokTVqkOR09sITxnHpuUcUHFY77sfpF1QsCXVvW6zTlx4a1HO1vxB8mfpj+ddn0TpSzQ9JxGzFjTlS46HJMl5AcVKUpIJUonuDngegrHjpnAj9NZ2koElxvzoKn5jid63HCoErUOM5xijejtR2mJ5DS+qW4VtCdrbMqCJCo49Q2rcOPYKzig1TT8t7SH+1G1WQlUCztecgtfmDC1tKWpA+gIzitp6WaSsbOhrbJXDizpVxjpky5T7aXFvrcG5WSRyMntWa0Xo6HpmzyohdcnyZzinp0qQAVyVq7lX0xwBWuwtBah0+hyFpDVvkbOVKU1ElwkyTHyckIUSDj2BzQUOnzLdg6n6s03axssyGWJzbAOUx3F5Ckp9ge+K6hWs6I0ixpdmY4uW/cLpOc8aZOf/O8r0GBwEgcADtWzUClKUClKUClKUClKUClKUCvD4y0a90PNBruoxJNtPkhOL24f9S8HxMf/wBvy4/nWCsqbv8AijHmhqLwcnd5oQfD7H83h/P+1bstkg/LyK8hpZP5aD6wP4gq6rw02ED617oFKUoFKVZyrg1Hltx1Z3qSVk4OEp9/3oLylfEkKSFDseRWOvNzNu8vtZ8UuqKcbiP9D3/SgyVKw/4s+pE5TcVBTGKx8zhG7b3/ALNJN3dYaQVsM7/BL6wXsDb7JJHJ/agzFKxjd1C30thvBLpbwVcgBvfnH8q82u7iZbHpjrXgobGTySCNoJ7ge+O3pQZWlYmJeUvxIrym0oLrxZWN+Q2QFHvjnsP3qn+Nnfb0+AnMwZT/ABPy88549u3ueKDNUrHXC4mJMjs+GkocIBWpRGMkAdgff1wKoi9J8NSyzkIZceUEqyRsVjH6/wClBl6ViTdnEtpBajl1bgbTtkAoGUlXKscdvb2om6uLlR2UMIPiNhxSg5uA5I4IGD2+lBlqVgfx9flS75ZAWF7SguH5RgnJ+X6egI+tXtzuRhxWnm20uBfc7iABjOeAT/KgyNKxL11eZdk7mGiy00l0LS6cqCiQP7PHbk5q3k35cdpW6MhbqXfDIbcKkn5Nwwdvf07Cgz1KxMy7rYWtCI4WpLyGRlR53I3Z4B+1VI1yW7cjEcaS38uQreTuOATjjHr7547UGSpSlApSlApSlApSlApSlApSlArwtpC1oWpIKkHKT6ivdKBXh1pt3HitoXjtuGa90oKIiR0uOLTHaC3AQtQQMqB75PrXpyOy7s8Rptew5TuSDt+3tVSlBT8Brxi74SPFIwV7RnHtmgjspbU2GmwhXdISMHjHb7AVUpQU1x2XErStltSVnKgUghR9z79q+GMwruy2eAOUjsOQP0qrSgpuMMuOIW402taOUqUkEp+x9KIYZQpakNISpfKyEgFX396qUoKAhxgypkR2Q0o5KNg2k/avqokZSm1KjslTYAQSgZTjtj2qtSgt/IxPDLflWNhVuKfDGCffHvVR5hl9AQ+024kHIC0ggH9aqUoPJabJUShOVDaTjuPY/uapiJHDYbDDQbGcJCBgZ78VWpQUXYsd4EOsNLCiFEKQDkgYB/avrcZhtzxG2Wkubdu5KQDj2z7VVpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKxWpdQ2rTNsNxvsxEOGFhBcUkq+Y9hgAmsrUdfi+vey32KyNq5dcXLdH0SNqf/mV+1B17TPUXSep7n+H2K8tS5hQXA0G1pJSO5+ZIHrW2VBjp+87ofqrpx6WooSTHW4TxhuQ0knP2Dn8q6DqnWevtadULnprSNxXBbiPOtNtNOBnIaOFKUvuckdvr2oiU1KjPZte9R9LaI1DI1PFde8BCUQpkpKTsdLgQQcfmGFEjP93vWs2q69YLlZ42qLbdZ0qLIkFpCEOIVlQJz/CxgJyCO1FS+pUYuovU3XEm42HS1tQbPepLDImBO0LU+s4ACuQlPY8c8/SsLH6ha70ber1pjVNxdlOmE+kLLgW4w4WFKbcQ4Oe+3g/yoJb0qFmlNc6+mWLU78bUclaIcNLrq5LylrQkuJT/AAu4Cjnv7Ve2zqT1Bm9Ob4+3eQpi3yIwclLOJKQ4VAJSQOQSkZJ5/egmNSoc3vqbqyb0yskv8bmMzm7jJiuPsL8NTyEttKTu24zjeRXt/WHU+Noy06rTd3W7Q2ryqFF1K1PLClZU4lWd2SCOfQD70Ew6VEvVnWLVmqZOn7XpyT+FPymWkvFpQQXH1KI/Ofyp7evqc5rCap1t1At2uxbbzfpMeWy4w081DkkNH5U84ScZI5P1J4FBM+lRYa171D1/1BmNaNlJjRbepTzcQrS2hTaFY/iZ5UVcZHbn0rQo3UfWL713WvUV1Rhla0oEpWGzvT259MkUE5KVCy164187oK83JrUkkx4suOhxxx1Sn8qC8BBPZPHPvxWYndbdV/7ObYwzMCbq7JeZenbE+IW0JbKccYB/icnGeBQS7pUVNFah6p2zVlvbcfm36C6ULfbz4zZbUecLI4I55Bx961rSWq+oWoNZuWey6imuS3w+22iTKVsSAlWTznBABI9jigmTPlIgwZMt0KLbDanVBPchIJOPrxWhdOurdh17en7ZZ4tyZkMxzJUqU2hKSkKSnA2rJzlQ9KutPQL3a+kj8TVUpUq8tw5XjvF0uFWS4U/Me/ylI/SomdK9UytHO6jutuCPOi2FplSxkJUp9kbseuBk/egnbSoayNYdS29ALvz99cVa50sNoeTICX21pzkJCcFKTg5H0BxXb/hlvdzv2gZkq9T5M6Sm4uNpdkOFagkNtkDJ9Mk/vQdbpSlApSlApSlApSlArg3WHo/qPXmtFXWNcbYzBQy2wy28twLSkZJzhBH5ir1rvNa7q3WuntIoaVqG6Mw1OgltBBUtQHqEpBOPrig4nrn4eZk68sSNLXGMxFSwhCxOfdW54icjIO1XGNuBnjFVtV9A7xPvRvVlvsaHcZIDklBK0hLxT/EKFpGdpOTggd66pZeqGjr1Fmv269NOphsLkvILa0rS2gZUoIIBOAPQGsaz1q0E7FkSEXz+Ext3lUV4H5jgAApyex7e1EafpH4fo1v07e4l7upkTbkyGQ4wjCWMLCwRnlR3JT7cDH1rVUfDhqErTDd1NE/CkubwAlwkH1UG/wAucfWupdTOoVtg2SCi36qg2d+ehD4ecjLfdSwtOQtDaRkKPGNw9/asl071Zp5/SavLar/GEW5sqlTJh8NxKeTuWCAQPTJ9u9FaNrroGxc7fZzpu5CHcLdHRG3vg7Xgk5CyU8pVknkA+ntWO038P02P+KT9QXlmddXoj7MYArKEurbUgLWtQ3HGe2K6P/th0L5KTLTfmlMx1pbc2suFWVZwQnbkjjuBitJ6ldeIMCxQZWhZUWdJekKbcTKiuhIQlOSRnbzkp/eiMTpPoVqCz2LVEGRcbUty6wkxmVIW5hKg4lWVZR2wPTNfbJ0L1BA0Fqaxu3G1Kk3R2ItpaVObEhpSird8medwxgGr9/qRddTdC5F9iXmHZ7zFkhma6hhwIbBWQlKeFnJCmzkZ9e3pm+jGtkI6czLpq7VMac3GlloylpWjYNqSEEqSkrVzngHvQcS6p6FuGgNBWW2XWTFkPP3OTJSqMVFISWmU4O4DnKTWa0P0Vnay0dYbjHvxiWyShbj8dwKXtcS6tO5CchPKQO/1712yNrfptr2fHtrsi13SSlR8BqdEP5j32eInGTj0717svUzp9EmnT9ruEaEqMXU+XREWw01s3KXztCR2Ufr+tBpfUH4fo14ZtqtMzm4L0OMiKpEhJKXgnOFkjkK5OeDn6VrEj4b7xHvMd213e3rhtFpRMgrS4pQAK+AkgDdnHPbFd50hrvTer3Hm9PXRqW6yNy29qkLA7Z2qAJH1q71Vqux6UiIk6guLMJpw4RvyVLI77UjJP6Cioja/jaat3Ua8Ltt4uVrSmW4iVHbYO7G75w0tKsEHnAVjH1rD9LNG3DW93utvtOxoeUUS8+TsR86cBRAPJwfT0rN/ETeLZeNbRp1hciPQJUFp4OstJBWoqWCVHG7PABB7Yrpei+oSNPdSrxplNts9r01bxJddcixVB0paQVblEE7jge2aIpWvoVqCJ0+vlhcuNqMqfKjvtuJW5sSG92Qfkzn5hjivsf4epT2gvwufc4jd6YmuyY77O5TRQtDaSheQD3bzkdvrXT4HVrRlwtNzuUS7KXCtqW1SnPKujwwtW1PBTk5PHGasj1t0CIqZBvS/BUsthXk3/wAwAJH5PYiiud6S+H26o1FDuGrr6zLjxFIUlphTjinAk5CSpYG1P2z+lZDph0Xvmk+o0fUE6fbHojZeJbZUsrO9CkjukD+0PWugL6u6GR5HxL+wjziPEa3NrGE5Iyr5fk5H9rHv2rJar6haW0oppF8u7Ed11IWhtIU4spPZW1IJx9aDPXmKudZ50RpSUuPsONJKuwKkkDP71HvRvw83CGLxH1DcoKo06CY7a4hWpbbniNrSrCkgEfIc8+tdu0jrbT2r0PHT1zZmKZwXEAKQtIPqUqAOPrWxUEXT8NF0TAl7b3CcmeIkR8haG9n9or4J3dsAcfWuw9EdET9A6Sk2q6SIsh92YuSFRiopCShCcfMAc/Ka6DSgUpSgUpSgUpSgUpSgVEb4jEIj9aYsjUDMh6zKajq2NnBWyPzpSffO796lzXPdeas6dt3L8F1m9BdmM7VBiTEW7s3AEYIQQMgjsaCN0N/RUy+XxelbZf4yvw+YqOFvoLbafLL3bhgq29/7R7ir74bdIWPV99vEfUUETGWIyXG0lxaNqirGflI9KlRbtH6ctsSVGt9kt8ZiU2WX0tMJT4qCMFKvcYPavWn9J2DTrzr1jtEOA66kIcUw2ElQznBoiH3UiDEsXWKfHv0Rw2lpaUtNkLWPLhsJaxhaSoAAD8w7d6xLce2yrDqBzTUa9l1psLkLJSGBH8VPCkjKhztOCo9u5xmptX/TFj1D4X45aYU8tfkL7QWU/Ymqln09Z7LCciWm2Q4kZ3+sbZZSlK/T5vf9aCBz0uwuaLYix7NJTf2nyt+4+OS2ps5wnZ2Hp+3es+9BQvoPGnJjIU83qBxtT4QNyUGOj5d3fGcce9STfndKWb69pJyNZ0zZEhKXYqYuEKeHCUlQTt3DJGM8E471vMHSthg2d61RLRBatj6ityKGR4a1HHJT2J4H7Cgi/arxbJfwxX21wmC3cYDzC5rnhhIcLkklB3DlRCUgc9sAVzx1marphEebSs29F3fS6R+UOFlnZn9AuptMaG0uxbZdvZsNubhSylT7KWAEulJyncPXB5FXEDSWn4FqkWyHZoLVukK3vRksp8NasAZKexPA/ahEKL+uw3O66dY6e264xbh4bbbwdXuU5JyMKRycc+vA7cCsx09tcW8ddPw+8MNyo7sub4rax8qiEOn/ADANS7sujNNWOUJNosduhyQCA60wkKH2PcV5g6K01Au/4pDscBi47lL8whoBeVAhRz9QT+9BF/4UVEdT3QDwbe7ke/zIrMfFay63r+wyrg28u0KipThBxna4S4EnsFYKf5VImx6M03YZpmWayQYUooKPFYaCVbTjIz7cCsjebPbb3E8reIMabHzu8N9sLAPvz60EC9fvaek6hU9o+BLg2hbSfDalElRV2URknjI9z2P2qXevdGWJnSOqLxBtEdN6ftkkqkoSd6ippQP71sM3QGkpxYMvTtsd8BoMt7mE/IgZwkfTk/vWzbU7NuBtxjHpiioGaSvEOFoHXFtfWsSrgzE8BIQSDsfClZI4HBHesA7/APpmN/xjv/yN1PBOhdKpZmNI0/bENywEvpTHSA4AoKAOB2yAf0FaRqhHSLTFwZs98gWaNIUQ4GfKlQRuwNysAhOcDv7URGjXVthwtK6IkRY7bT0u3uOPrSOXFB5YBP1xxXy+7Y2sbZI1Qy69CdgQ3cKSpW9sxkBJACkkgH2UOxqXdysHT51EOFcomnyIrYRHZeU2C2hR3AJBPAOc/rWauekNPXSFEiXGywJMaIgNx0OshQaSAAEp9hgDj6UEd/huTYneokhyyR7z4yWXSpxRQmOlokYCk/Moc4wCo8jucVKWsZYrBabBHWxZLbEgNLOVJjtBG4/XHesnRSlKUClKUClKUClKUClKUCoX/Eioo6y3BQG4pbjnA9f4aamhUZOtvS3WGp+pUy62S1h+A6hlKHvMtI5ShIPClA8Ee1BWt/W7VsDW6bZqu0NQo0xYDTK2Sh1hK+G1ZP5hnGcj37dqt+m/WLV1+OpxcZMVXkLFKnsbY6U4db27Sfccnirm09H9Z3zqGzdNcz2n4kJaQmT4iVKkIRygJSOwzyc47nvWDsPRjX9in31uAIaY8m3SYheDqFeYQocNpBIKSohIycAc80RV07151WnT98nXBuNOeYLLUcBkIQ0pZXla9vJHy4x7kVTsXWTqfcUKmQLfGuUZCsLQ1DKsfok7hVPSXSbqPabTdURIjECU6tlQS9IZcRIbSHNyCAVJPKknChjj6VaNdGeolzv7Ul6Bb7OtBGJLDrTKEkf2glnnP2AoPGq7uI/xAsLbtlvbeVOhqKi0chTiW1KJGcbsqPJGayOkutuvrm5dUoaiXBUe3vSQnwkNhoIwS4f7wAz8vqSKyuq+lmsZvWNu9x7f5q2plxHFSzIaSVpbS2Fq2lW7ulXGKsemXSfWlkk6iXc7OGUy7HLhsnzTKtzq0gJTws4z7nigz+gOu9xlaV1LN1FEjvyrWyh5ksDww6VrCAlQ5x8xTyPTNaoeunUNLLd3VCgi1uulCB5U+GojukKzuP71kunPRbUv4Xqi26jhptqLhCQ3HeLzbo8VLiVpyEKJxlNYe29KOqtvKbbAbbhxEvbxKZlNI5/vb0nxcfT+VBs/UPr1fIUezpsVtbgrlw0ynVy2ypQUSpJSkHAwCk8nv9KuNH9VuoKHXX9R2NMm1phvyA+1GUjcUNqWkBaSU8kY7V61x076inyLNvkRdRxW4iG3fxEtPK8bkrUPGHAJPBBzgCsN056P9QLPIuM7zLVmeciPNtsokglxxSSEZ2ZSACQc59O1Bjbd1v6jXy4OizRYTxT83lmY24gfTJ3H9KkRoi/Xa8dPWLteoYg3UtOl1jw1ICVJKgPlVyM4B/Wo3XnpF1JvEhluZZrUlSVcy2DGZ3fVRRhSv2JqSfT/AE9cLJ0/g2S9TfNzW2VtuPBRUAFE4AJ5ISCB+lBw3pv1i1dfTqj8RkxV+QsUqextjpTh1vbtJ9xyeK19jrrrddgmy1S4fjNSWGknyqcbVpdJ4/7CavbD0Y6gWKffW4IhpjybdJiF4OIV5hChw2kEgpKiEjJwBzzWFj9FtfI09OiqsYD7sphxCfOMcpSl4KOd+O60/vQZyX1w15F0rZ7kqPBDch55BlLbSQ+UEfKEAjaAFDn1z9K1/rLq1u+3TTV7/Cbf4020tyHd6Cf4gddQQeRlPycZzxWx3vpNrST0x0zaGLOFXCHLluvteaZGxK9m0534OcHsax+qejuuZ1t0y1FsoW5Dtnl3x5tgbHPMPrxyvn5VpORxzQab1XXdnepcty5+B51amVM+EAEhsoSWhgf7m3NTgsYnCywBdy2bl5dvzRb/AC+LtG/H03ZqO3V7o9qe8agi3vTzTMlxcVhDzCnkIW242hKeCohJHyj19675opu8NaVtqNSrDl5DQ80oFJBXk/3ePbtRWapSlApSlApSlApSlApSlApSlAq1uNwhWyOX7jLjxGAceI+4G0/uTV1UTPiQeXN6wQLffpb0WxoaYCXEpyG21H+IsD1Oc+/YUG2dTOs+odOdR3rJaEWt62gxy2440palBxCFE7gsA/mOOK7ZC1dpudKMaFf7TIkgKUWmpja14SCVHAOeACT7YqDmo2LVF12I+nrk9c7U08yhiS8CFKSAnjsOAcgcDgVmelcyNbOpL71wfbjNJYnIK3VBICiy4AMn1J4oiYaNcaTcQ4pvU1kUltO5ZE9ohIyBk/NwMkD7kVWZ1fpt5tlbOoLQ4h53wGlJmNkLc4+RJzyr5k8Dnke9QMsn/qvUP/BI/wDuWa7L8PfTe26ssIvk+bPbkW26EsMtLSG8pS0vJBB5JwDg9gKCTjt4tjNxRAduMNE5YymOp5IcUMZ4TnJ4rROpHU222nRF0uWlLzZbjdIoaUhlEhD3yqdQhRKUKzjCu/viopWKRap2o7vP1ndrpBnAOPsvREbnDJ3ZwT3HP2+4rEWH/wBVak/4BH/3Uegll0X6nu6o03NuOrpVqt625gjMkK8BK/kCsfOo5PJ7VcdctZ6g0ra7XI0ubXslLWHHpbzaewBSEBSgDnJyRntUU7REsMjRV4euV4kMXiO4lUCAlJLbu7AWo8d8D3HYd62DUEmZI6G6XExa1ttXSS3HKzn+GEJ4H0Ciqg3vU3XjV9pdtzSGbCtb0RDzpbBeTvKlA4UlzHp25wcj0rbLf1O1Unqs7aLsvTseyNyXGnAqY0lTbac/NnxM7uORj9BUZ7z/ANTsX/Bn/wCu7W9ORGLh8RkmHLR4kaRfnWXUZI3JU4oEZHI4J7UHadH9eo2oddxtPu2hmHHfecZROVPCkkgK2YGwA7iAAM91DvW19R9T3SDPj2qx3LT1qW6ne7Ouk1CS3z+VDROVE98nior6BFmtXV2Ob0UsWyFLeUkrUrCFthZa7cnCwj7+tYm3IhXu5XmRqm5OR5qkrdQ46tXzO5Od2EKJ+3H3FBPmA+mTCZeQ+zIC0A+KycoWfUp5PH61rl06g6YtWp2dPT7q0zdnSkJZKFEAq/KCoDAJyOCfUVzz4W0xmNOXaPBva7nHQ8hfhmMtpMdSgcgFX5s4Hbtj61caxidMHOrcNy/SVo1PvZPhAr8JTnHh+JgYzjb6jjGaK7LWGXqvTzczyjl9tSZWceCZbYXn225zWv8AW+ZMg9KtRSLcpaJAYCdyO4SpaUrI/wCyVVESx2fSEvSDku7ajkQb75rYmMmMXU+FgfNx3PfnPp2oJ2zJsWDFVJmyWY8dIyXXVhCR+p4q2tN7tV4StVoucKcEfmMZ9Lu377Sahp1GmrdtuirUq9yZ2nm4mUSlMqbz/HWlR2E5JSlKQPoPrVfTwt+netdha6fXaTcoLkhhsuqSUlYWQHEHgZGM844/TNBLmDq7Tc+SY8HUFokyAlSi0zMbWrCRknAOcADJq5h3+zzob0uFdYEiKync681IQtCB7qUDgD71B/pvaGL5rCXCluPoZMOY4fBXsJKWlqAJ9sgZHrXzpxa03WJq9DkmSyiNY35e1lzaHVNrbKUrHqnJziiJtvaosDFvRPevlrbgrX4aJC5bYbUvGdoVnBOATivn9KtP+Vjyfx21+WkqKWXfNt7HSDghJzgkHvioIRXnDoO5sFZ8JNyiLCc8AlqQCf5CsnqSzsRem+jrql19ciaua2tK3MoQltxO0IHp+ZRPuTQTllXq1w3o7Mu5QmHZIyyhx9KVOj3SCee47V9ut5tlnaS5drjDgtq/KqS+lsH7FRFQZ13bhCsejZYkyXnZls8RQec3BvDq0hKP7qcDtVzqOavUGuoX9LZj6IxiRklxSynagsIUCDtVgEnJO09yaCbKdQ2VVsduSbvbzb2seJKElHhIycDK84HJHr61bs6u02/Edls6gtDkVpSUOPJmNlCFK/KCrOATg4H0qGkCPboOnNWt2vUapHiRglUJEdzatAfbwsuEJGRxztHf0zWOtNoYk9ML/dHFvePDnRW20BZCMLC8kp9TwOaCWXVbqhC0JZrfOjMxrs5Nd2oZRLDZLe0nxBgKynIA7Y571mOl+tWNeaVZu7TLUV4rWh2Kl8OqZIUQNxwMZAB5A4NREmRGpHQ633F1Kly4t9dhNOFR+RlTIcKcZx+bntXf/hVcs39AFs29xBuwdLlwQFKJSSpYbJB4GUp9Pag7TSlKKVq2uNA6e1s2wnUELxnGM+G8hZQtIPcZHp9DW01zbqn1ds/T+UzBejPT7m434vgNKCQhJOAVKPbODxg0FGX0N0Q/PaliFIYU0lsJQy+UoGwAA49+Mk+pyavn+kOipGoXbyq1gy3VLcWkOEtlas5Vs7Zyc/etDHW6z610pqa0OQX7ZcHbTLLKVrDiHCGVkgKAGDgE8j0rlvQnWDOh2tUXqQx5otxmUIYDmwuKU6BgHB9Mnt6UR3qN0H0VHZlNNsT9klsNOZkn8oWlfHHugVuWhdG2nRFqet1iQ8iM68ZCg65vO4pSnv8AZIrnts68WxzRj2obva3oSPMmLFjNvB5yQoJClEfKkADI5NWekviJsl5vLMC52uRa0vrDbb5dDqAScDdwCkfXmit3l9J9GytSi+u2hHnisuqSFHwlrP8AaKO2fX781hIvQnRMdmWy01O2ymgy4DKJJSFpXxx7oTVpq7r1p3T2p1WdMWVN8B3wpUhogIaOfmx6qI9e3auD9GbpEidaWLpJfDcBszZC3VZwEBl05/aiJEN9C9DJt6Yire+4hL3jBan1b84AKdwwdvA4rOam6ZaZ1FY7baJcNbNvtxJjtRnC2E5GD965nL+Jm0Nz1NxbBNehg4DynkoUR77MH/Os7q/rnCstjsd4tlncudtuiHNrhkBlTTiCAptSdquefeir6R0G0U+3GQ4xP2x2/CRiSfy7lK9vdRrKt9I9LI1h/SZLUv8AFPNmbu8c7PEKt35fbPpWoan6/RLOqzIh2Jyeu4wWpZSmUEFpSyR4f5DkjHfiup6k1LE0zpV6+X0GOyy2lTjaDvVvOAEJ7ZOTj0/Sg1i+9HNGXu+Lu0u2rRLcc8V3wXlIS4r3KQcZP0xVLUnRbReoLs9cZdvdZkvK3O+WeLaVq9VFPbJ+laQv4l7SYEh1uxSvModSlphb4T4iDnKtwScEccfXvXTOlGuU9QNNO3dEAwA3JVH8IveJnalJznA/vdselBm9K6atOlbSi22KGiLFSdxSCSVKPdSieSfvWEvPTPTF51cxqWfBUu5tKQvcHCELUjG0qT6kYH7Cud6k+I+z2y7vw7bZpNwaZWWy+Xg0lRBwSkYJI++KwXULrS9qPpw7I0xDuttkCUhp+U26U+X7KHzI7hXI5x+tBI+XGZmRXY0ppD0d1JQ42sZSpJGCCPauZL6DaCVLL/4ZISknPgiUvZ9u+f51zPpV1bu1j6dXy432NcL35Wc2ESZMpXzeIkDwwpSVY27d2P8Af9PXZbP8RcO5ybXFRp91EqZMEZSPNZDSSUBK87OclSuOPy9+aDpuo+nel9QWKJaLha2hDhp2xgzltTA/3SP5+/rVlovpXpPR8/z1ot6jNAKUvvuFxSAe+3PA+4Ga0rRvXprUrt3QnTy434fbX7iSZgXv8IA7PyDGc9/T2r7pX4gbXdoV3mXS0u22Nb2Uu5TIDynVKUEhCRtTzz70Gz6f6N6TsN0XcLezMElbTrJK5BUNriSlXH2Jr5YejWkrEi5pgMzALjDXBf3yCrLSyCrHHB+Uc1osX4mbQucESdPzWohVjxkvJWoD32YH+daX186i3w63aTp653W22wQmVMrYkONolJWN/igDH97Z68oP2BHYUdCNFIt78JLE/wAB51t5Q8yc7kBYTzj2cVV7P6NaSnWC1WZ9mYYVtU8qOBIIUC6QVZOOeQK1S7dbHtK6R0nJuWnpL8q5RFLWl6UW1pLatm45QSd35s/X171V1j15b00bJu08uT+J2ti5DEwI8MObvk/Ic429+PtRWy3fozpK7QrXEmMzCzbWDGj7ZBBCNxVzxyck1c6i6R6R1BFtzNwgub4MdEVp5p0ocLaEhKQoj82APWtEkfEZCiail22Zp91tmM860p9MrcTs3YwnZ6kAd/Wri4ddbRJ6eKuE2JPgTJzj0ViPDfSp5O1KcuBZSAn8w5wefeg262dJ9FRLDdbJBiHw5mxuY4Hyp7CVJWlJV/Z5CTjiqcXozpKNp2dZWmZnkZjzb7oMglRUjO3Bxx+Y1zrot1P0dEvAtEazTbXKubqUrmSJRkl93snxFHBBJPoMZNSNoNHtvS3SsHSUnTQhLkWqQ+ZKkPulSg5hI3JUMEcJHb6+9Xmg+n9h0KJo0+w82ZhQXi66Vk7d20DPbG4/vW2UoFKUoFRZ+I/Td5t3UWPquLBdmW5aWTuQjeltaONquDjOAQT71KalBDnTKLvqJepbk1pCEzEFuluOznmnVONnwFgBC1KwVk47D1Nc/tWlp1wsl5nIYfSq3IacKC2fnSpew4+oyD+9foNSiRBpuzXjUXTOK1b7fIdcsMt5TzTbR3lp8JIXjGVYU2oHHYEelXsljUHVO92KDB021A8oyiKt+PHUhASCMrcUeBj0H7d6mxSgh85aNSdO+rU9bGnPxrzrjrcQvsqW26lxWQoK7BXof1+9ajobTV0vOtX7WiKqPKkMTG0goKUBfgOYTnsBnip30oIHwXLxYoM3TkzTLkiQ5ISotPtOZChjjanBV245xzxXZNYaOny/h3bXNskS13OE/wCfTDhNKTsQTtO4Ek7ik7jz6D2qRlKKhH0Q01L1B1MsrU5h/wApCPmVlxJwEt/MlPPoVED9akv1909P1L01nQ7Q0p+Y242+llP5nAk8ge5wScfSui0oIJTFand6fJtD9gbZtdulgqkmGUSPFXuOwqPJ9fT0GfSpD/Cky4z01lpebW2r8SdOFpIOPDbrs1KCDWpFyoV5lSmtLXOyX0PKKXYy1oZyTyfCUgnBGeArHPbFdCt9j1fqHodqRufY/DnLksPsbIiWH5SEnKiUpA3YHY4yee/FSP1TemtO6en3eQy8+1DaLqm2U7lqx6AVqHSbqfF6iC4CNbJMFcPbuLigtKgrOMKHrx2oiLttnXZrpdfNMO2eQhhMtE8vqaWFBzLaPDxjHYE+/Fdy+Fm2pPTi5eZiJD/4k7sLrfzD+E1jGR713OlFQd0dbtQ6XvOpYbmn5rz7lomw3QpBQGkFHLmSMEDbx75GO9WGj9JXe/2DUTFuhyHJMdtmSGQg7nQlRBCR6nCs4+lTxrR9N9VNJaj1A3ZbRcHXriveEtmO4gHaCVckY7A0RF+23y+vWS0aZa0JCmvwHFEF+3uKccKifzAEe/J+g9q2b4htJX3Zpe5C0BDDNpaiSG4LRLUZ1KlKKcDOE/Pgc+ldb0l1ogak16dMs2aewsrcQl9zHBQCTuT3SOPf2rq9BD3qk3ftWaB0ZezZZLbcVl2E4lptStgSUhKiMZAUEk57VqnUY3e5DS5mWaVD8vY40ZoKBUXUIKwHMY+XPPB9MH1qdtKKhjoWA8v4gmC/EcUwbs+SVtnaRlfuMVv/AMUujbjIk2m+2eCp+FGZLL7bDefDO7cFFI9Dkgn6DNSPpQRB6fv3jVfUC2vx9HQnQhbQflS2nVhlKTkr3bgkHHYY9sCpfUpQKUpQKUpQKjT8Rt31yxqrwbM/cWLEyyghdvUoALIyrxCjkH2B9MEVJauQdRejkjVOrn9QWvUsm0yn20IWlDZP5UhIwUqSewoOT9PtVajsi7ldkaubv0OHAedXEXKdUoL24QSh1IJAURkpz96wTNx6g3vS911sNVyERoMgNuNCattRUSPytp+XHzDjj1rtGgugNt0/NkS71c3Lq48w7HLYa8JG1xJSonkknBPrx3rXJPwyIM5fldTLbglWUtri7lgexIUAT9cURyvWXUvU17j2OSq7T4shuGWXzFfWyl5SXV4WUpIGSCAftWT1PrDWeltX2p57UkuSoxIknw0rUGihTaTsUgkg8cEnk966tq34eI1zTaWbLd0wI0GJ5ch2P4q3V71LU4SFDk7u2PSvWtugr+pbrDmI1A1HEeFHibDEKtxaQE7s7x3x2oN763armaO6fTLla8CctaGGXCMhsqP5seuADj64qM79w6gWzSdu1wrVclUaXJLSGvOrWsKBV+Zs/Lj5Txz6cVLvWWm4GrdOS7NdUqMaQkDcg4UhQOQpP1BFcKjfDIkTE+Z1MtcIKzsRF2rI9slRAP1xQc+6r6/v9zm6fuMa6T4Bl2hlx1mLJW0gub3EqUEg+pT/AJVv2pXde9M9NXrUF3vrU+Td3G40YNuuOIiKVuWVJQsbR8qcDH0rYeoXQVvUtzgO2q7NWyFCgtwmo6o5cOEFRzu3DvurcOt7Vsb6WXIXuK9KhtBrIYUEuJO9KQtJORkZzg9+3rQRvu07X1t6cQ7/ACtUPO228SQEJTOWZDa07/2BwcgH2yKt5/UXVCNGads8W9zWVyPFfflKkK8ReXlISC4TkJG0+vr9K026iwtQC3aX7lKkqdCkrkspZS0jByMJWrconbzxjHrnjvGleiqNXdKdPruEh61XZvxXG1lvdlpaypIUnIP1HPrQcx6g3/WNlu0W3TdXrmLjxEJS/bLgtSFJJURvIIysZwSRnAFZOx33Vdw6xKtdv1JPYW7cX2WvGfW602Mrx/DKsHA7Dt2roFx+GZtxMQW/UIZKGAl8uxivxHdyiVDChtGCkY+nfms/p3oa/aOo7WqFX5p1CJjkry4ikE7ir5d27/e74oOP9P8AXWpxK1LbZl7nymnbRPILr6lFtxDK1pWgk5Scp9PerfQepNaL01qRNhuNwkzCY6SC8pxxKCXCotgkndwM45xk+ldXsPw+SLXc58s6iadEqJKjBIiEbfGaWjOd/ON2ceuKoW74cVsWqbEf1N87zrTzbjUXbsUgLHOV8g7z2x2oOS2e76vXJCXdbyrbc/E2iJcJchpRPpypOwfqRW0am1drDU/VRyyQtSCyphulhsuyvAYCmh8ylEfmKlJJ5z3A7VuLfw4PS7g27fdXSZrKAE4DB8TaP7IUpZwO/pWZ1v8AD7a9QahFygXR23NubPHY8IOBWAASk5GCQPXPPNBxrS981RfuqSbTM1PPSqbKfjrciy1qZSpQWNzaQoDaCcpxjsO1WXRG2PTesVnjNznY62JK3lOozlwNgqUg8jhQSUn6E967ZpXoGNOa9iX6Je0qhRZSnmoio53BHO1JXu5IBHOPSqNx+HeOrVhutqvq4cUyPMeXUxvKPmyUhQUOPuO1BzK36wu9p613mSu4Tn40OVcXfLLkLLaktoeUlJTnGPlHFWsS6dQNW2a/asb1S8wxayFvMiYpnvzhCE/Lj74z9TXZbX0M8t1HkalmXhqTEfkyXnIRjEbkPBYKN272X3x6Vr9w+GZpdwdVbtSLYgLVlLTsbetI9twUAfvig59qzqTqO99O9OSHLpNjz48uVFefjPKaL6UoZUkq2kZI3kfz9as9Ram1nabHpK4HVNwKZcRbjKEOqBQEuqHznPzkn1Ppx6V2zVHQSJcNK2KyWa6+SRblvOuvPMeIqQ44EAqOCMfkA+2ParXUnQR+8WHTduTqBpo2iM5HLhiFXi7nCvON/HfHrQdh0fcHbvpKyXKRjxpkJmQvAwNy2wo/zNZesZpe2GyaatNqU6HlQYjUYuBO3fsQE5x6Zx2rJ0UpSlApSlApSlArUdddRdN6I8JF+mlEl1O5uO0grcUntnA7D6nFbdUSfiNYNu6yRLneoTkuzutsLDe4pDraOFoCvQ5z/wC19aDvmh+quldZzTCtM1xE0JKxHkNltSgO5HocfQ1ibz100Pa7muEqdIkqQrat2MwVtpPr83Gf0zXDdIPWLU2t57WjNJzocx6NI8q8meQiKSypIUUBPYk/3u5rSLJPslnsWo7ZqKwOyL28nw4j6lFBiLGQcj6HB+uMURLXUnWLSVit1qnuSZEyHckuKYciNhY+QpCgoEgg/MODVpI656Hjuwm3p748yyh4lLJWGQoZCV7c4VjuBnFRNvVtnwdEaeenIcbYlyZbsZKxjKNrAKh9CQf2rLdU4UWFG0UYkdpgv6ejPO+GgJ8RZW5lSsdyfeglY91e0a1qdmxG6Bcp0oSl1CCpncrskrHY8j6DPfvWMh9dNGSLw5b3HpkVbfib3ZDIS2nYCTyFE87SAMckgVGfqtCjWzW8Jq3x2ozfkYTm1pISNxZQSePUnnNX3S+FFuPWby0+O1JjqXOKm3UBSSQ06RkH2IBoJKWbrVom6w50hu5OR/JtF5xuQ0UKUkED5fRRyQMA55q+snU/R+otO3K5tz0IgQgBLTKbKSgK7ZSc5z2GM57VE3pPb4dwc1d56M1I8vp2bIa8RIVscSE7Vj2IycGsbp23z7ho7U34ehxxMdUaRIQgEktgrBOPYFST+lBIq2dS+j67ygM2uHFeK8JlrtSUpz6HcBkfcgVtmr+smltKXw2q5eeXIDaHAuO0laClYyCDuHoaiZGuOnHbXaor9klSJrSiHvLOhgvZPHzELKj+gx6VmOtUfy+tYUcxXIgRbYSPLOueItrDSfkUrAyR2ziglJbOrmkZ7F8kJnLZiWhaEPyHUYQsqKgnw8ZKs7D6ZrE23r1oadcERfOyo+9W1Lz8cpbJ+4zgfUgVqHxFaGttk6dpe0tZ2ojQmtOTPLpPKAhYSVfQFf8AOuNN3vRr9msUL+h8uRc2ElEpxmaWjJWSMdkqJ+2BjtzQdH6i6juVu66hkauuLMVuTHIjspUUIQtKFbAkHaoEK7n3rsdz6vaNtupxYpN0xLDnhOOBB8JpfspfYc8euPXFRj6mNFjrKw0WFxygW5PgrXvU3hhkbSr1I7Z9axdsUnT2trtB1Jpn8enOLcjJjOOLbUHlK4WMAlWfT3zwaDtvUHrdZr/oa9xNKyLtDuyGm3G3wnwSkB5sKwpKsjIJH61b9AOoHkdH6hu2t79KejsSWm23Jby3lZKVHagHJycdh7VHezf9TvX/AAY/+s1WRYt06T08kTIyFrhRLiBI2jISVN/Io/ThQz9frQSysHXLRN6ubUBubIivPLCG1SmShClHsN2SB+uK6PcJsa3QX5k59uPFYQXHHXDhKUjuSagzCmacudwssaPpudLlbEMrZiPiP4rmR2+ValffI/SpVdc7bNuPSG8Rbcy4uQlppZaR8yilC0qUPrwDRWLHX7QhneX85M8Pdt8x5VXh/f8AvY/StR669YbjYbxbIejLg2lK4/mHnCyhxDiV4LZSTn03VwSDcbAnTzEOfaX356HypTjCw0paPYrIV9sBIFb91rtao2g+n8hi0ybdGEZ9Jaec8Vbe5SVISpeBkkZIGBjt6URJbpTqc6u0Harq4pS5K2g3IUpARueTwsgDjG7OK22ucfD9qCJf+mtuTDjuMfhqUQHd4A3uIbQVKGPQ7vXmuj0UpSlApSlApSlApSlAq2nwIdxYLFwiR5TJ/wD232wtP7GrmuC9beqOorTrOLpPRjaEz1hve6W0rWtxz8qEhXygYI5I9fTFBudy6g6D0PfnbApLVumpKAtqLBKU5UAU8pTjsRWR1/cNF6e2XLU0C3Pz18MIMRD0l4jsEDGT9+w96iP1Al3yb1LLuq4iYl6C4zchtJBBKUIAUMEjkAHjjmt51P1b1dqHV81WlzAhx4BcDCnG2PE8MHBO931VgfKn+eKIk47a7JqSDClXC0RJbXhhbKZsRKlNpUAcbVjKewyPpSXpXT0wMCXYrU+GGwy0HYbavDQOyU5HCRk8Djmo3XHq7r1vpv5qUh63XFu4MttzzDSlMhpTbpKcLSU5BQk5A/8AGzZ6p9Un9HN36MoKtcF0tSpymGT4q1KGAU4GAMpHyjueT7Fdo6gaj6b6ZvbMTVdtt5uC46HUFVsDx8PJSn5tp7bCAPTFbla9PadQ41crfZLYy+4nxEvtxEIcwsc8gZ5BOfvUMur+rl63uNivD7KWZKrWlp9CPy70vPAkfQ8H9a6VeuqOtrzqhnSvT1tDa4jQZyG21OOqQj5yS58qQCCP0+uKIkNE0rp6EXjDsVqj+M2pl3wobaN7avzIVgcpPqDxVa16fs1oU6q1Wm3wVOja4Y0ZDZWPY7QMio3WXq1ra5WDUtokviNqO1MqltyEMN7iGlgPNrQQU5AJOQB+U1hP9ueqf6CeELv/ANIBcMmR5drPl/D/AC7du383rjNFSdlWrSunEPXl+3Wa2hkFa5nlm2yn/tAZyf51jNPOaR6gsvXhqxRZe1zwRInW5IU6EjhSSpOSnHb/AErgWpuqusGNO2CyPOxpV1uLCJj78mM0eHFktICSAgYSEqJI7n0xWzdJOouvZGtGLPqSMq525xXguSY7CFJYOMhXiNDYR2B/8KI7vfr9ZbKhpN+ucCAh/cGxLfQ2HMYzjcecZGfvWvM3bp3bFsXBmZpWIuQCtqShbDZcAJSSlQ78gj7iuS/GP/VaT/xSv/xVwW93didp/TsBpDqXbcw806pQG1RW8twbefZQ745oJ2JsumL8tu8JtlnuK3wlxE3y7bpXjgELwc4wMHPpV7co1sYK7vNiR1PQ21OeYUyFONpAJO04z2z2qINn6mausk6w2S13csWtDUNCWPLtKwFoQVDcUk8lR9fWs7rfqZq5HUy8aeTeCLP51yJ5fy7X9UTgp3bd3b1zmg7Boe89MdY3KTbtO2e1uyEsF11KrUlsFsKSOSUAHkp4rfY9osdlgSUx7fbbfCcGXw2yhptQx3XgAHj3qFPSGdqqDebodDRfMXVyAtKlYSSy2FoUpYCuCflAxz+btW03jXmqOo/TC4W+S2ZMu3y2X31xkbVPMFKxygd9qgknA7c44zQSMtF16cwJilWeZpSLKPBVFXHQv7ZTzW5sutvtJcZWhxpYylSTkKHuDX59WxrTjkMNXZ27Q52SC802h1oc8ZQSlQ+vJ+1b5I6kar0XcLdZLHfUSbPEYjFpDMdspdQptKyAVI3DO49+RnHpQS1TpewJnedTY7WJm7f44iN+Ju992M5rIzIkebHUxMjtSGFcKbdQFpP3B4qNEfqx1A0vryFD1zFaRDnLSvyvhoBbaWrAKFJ9vZRJ4596oTuq3UPWmpbkx0/bDUGGFOJbbabUstJONyi5nJPsP50VJA/g2l7S44Rb7RbGiCtWEMNIJIAJ7AZJA/avdlvtpvrTjllucK4NtEJWqK8l0JPsSknFRavnUW/a/wCjd8jzXYzUi2Px3Jq0o2+ajqXtSAMHCg5sJxjgfodk+EBm5Yvr4kN/hA2oUxj5y/wQrt225Hf17UEkqUpQKUpQKUpQKUpQK4n1r6SXPVWoomotLTWo10aSlDiXFqbyUnKVpUM4UO36Cu2UoIqXXoTreTqRue/cItyWVNOPSZEhW9SgE7hyCSAcge4A7VktTdDdV27Vc64aGubLMSUpak/+UKYcaCjkoyByPY5qTNKCIvUzQN10V0nZXqC6rnTpV1ZHhJdUtplIae4G7uTnk49BVnoXplqnV+goq7BeQ1apT7glw5D60NBaFDavaAd2Rj07j9pX6n03aNUQG4V/gtzYrbgeS2skALAIB4I9FH96qadsNs03bU2+yRERIaVFYaQSQCe55JNBHHW3w/3xxVmj6cchvx4kBLLzr7vhqW8XXFqIGDx84xWS1d0S1OxqZF+0Rc2osl5AU6PHUytpwpwvaoDlJOT6d6kfSg4t0a6PSdLS7ndNUymZlxnMrjlttRWkIWcrKlEcqOP8++ajjc9EyYXU3+iIdbeeVNRGC2jkbVkYJ+oSQT7c1PetTi9PNMRdUq1GzbQLyXFPGQp1ajvUCCcE47E+lBzrrL0al6km226aTkMRpkRhuMWHVFCdqPyKSoA4I7foP1tul/SrWFv1gzfNYX5xxDB3hhqWtwvKAwneTgbR7c9sV3qlBx74hunt7163YRYRFzCL5d8d3Z+fw8Y4Ofymua3roPquVYNPRYrVrTKiMPIkq8bG5SnlqTzt5+UgfyqVdKCLd46Baodcs0y3S7eiU1GZRIStw/w3WwE7knbhQwEn96T+h+tH9cPXZ6VBmNrlF5UhbuxbvOSrYBgZ9qlJSgifp7oTr22LmvxLnGtskxyhtUeUoeLlSQW1EAYBTk+vIH3rORegN8gaKLcG6xW9RLmNyitC1oQhCELSEJWBndlwnOAPT61JSlBFCf0Q6j3+VHF+usR9LXypekS1OlCSecfLk1o3VHTzNk6nfgDTy1tR0Q43i9lK/gtgq+nJJqdFapeenmlLze13e6WZiRcllKlPqWsElIAT2OOAB+1EcfsfQ7UcvXEW5axvqZ9vgugtKW8tx55CFZQn5hhIPqM+/wB6sb70N1daNST5WhLu1HgTNwwJCmHEIUcltWB8wH+lSZpRXDNI9DFW3p1qGz3Ge0bteUNhTrQJbZ8NW9A55PzDk/8AKvnQzppq3QupZS7rNimzONKBZjvqUHHMjaraQOwB/eu6UoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKZr5mg+0rCX7VNi0/tF6u8GCpQylDzyUqI9wnuawSOq2hl9tTW8fdRH+YoN4zTNae31K0Y5+XU9q/WQkf51ct690k5+XU9l/Wa2P8zQbPmmawbWq9PPf1V+tS/wDDMbP+tXjV3tz39VcIi/8AC8k/60GQzSqCZTCvyvNn7KFew6g9lpP60FSlec0zQeqV8zTNB9pTNKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKDya5R196kOaHsjMS0qT+NTwfCURkMoHdePfnA/X2rqqjioa/E7McldVZLS1EoixmWkDPYFO8/zUaDl9wmyrjMdlz5DsiS6oqcddUVKUT6kmrelKIUpSgUpSg9JcWj8q1J+xxVVM2Uj8sl9P2cIqhSgv27zdGv6q5TUf4X1D/WrtrVeomv6q/XZH+GY4P8AWsLSg2VrXurmsbNUXvj0M5wj+aq3TRXXbVdilITdZH4zAyN7cjHiAeu1Y5z98iuTUoP0M0lqK36qsMW72h3xIr6c4P5kK9UqHoQazIqLvwi3t9F5vVkUsmM4wJaEHslSVBJI+4UP2FShBor1Svgr7QKUpQKUpQKUpQKUpQKUpQKUpQKUpQW6zUKfiIXv6t3n6Bkf/CTU03DUI+vS9/VnUH0cbH/wkUGgUpXROhUWE/rORInJK1QbdImR0JaDqlOoT8u1B4UoAlQHukURoMiLIjbPMsOs+IncjxEFO4e4z3FZTUWnn7HEssh95twXSGma2lGcoSVKSAc+vymunzdSWy8aO1LGuF91FqFBY8VkzLeMQ39w2L8QLOxJPykcDmss7bozkGwyorbVw1Lb9LRnrfbXUZQv5llbmMYWpIOQj1xnnGKDl+mImi27V53VNxursorUlNutzKUqAHZSnF8YPsOau50HQVytcl2y3K62m4sNqcTGuaEutvkDO1K2xlKvuKyGj5KLLoa9awTBjXC9m4IhtrlNBxEUKSVqd2dsk/KCeBVW9z0606aXK/3eHCj3m2TWWUS4zKWfNIcCsoUEjBUnbuz7UHMKyV9sk6xuxG7i2ltcqK3MaCVBWW3BlJ47celdH1ldYugZ8bTVtsFpkssxWXJz8+KHXJi1oStXzHlKRkAbcYwea2a7WO1ao6nxEzGEsWm1aXYmmK+8UDahpJS2tfcAb05PsDQcApXZtQWuz3TSV3enI0Vb7jDZD8FyyzMF7afmaW2VHcSnOD3yKsJGirXceoGlxb2Ux9O3aC1cXQHDtZbQkmQCokkYKFdzxmg5RSrq6uRnbnLcgM+BDU6sstbidiMnaMnk4GKtaDt3wmJ/6e3Nf923KH7uN/8AKpZoNRT+EpP/AEsvS/aEB+6x/wAqlSg0VWFeq8ivQoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLF08VBvrO54vVLUavaUU/skD/Spxu9qgj1UWXOpOpifS4PD9lkf6URq1XVquMy03FifbZDkaYwre262cKSataUG0ai17qLUFu8hcpyTEUoKW0yw2yHFDsV7AN361ZL1VeF3S1XHzikzLY02xEcQkJLaG/yjgc9z37+tYSlB1rRsbWTzEvUOl/wm7pualC5WhCULH5jjxI5wMHkgp9z25rzr22a3uOnFydQW23acscD+Izb20oiIccOAdjWSpa8ZPP1x7Vylp1xpW5pakK90nBr07IeeUlTzq3CntvUVY/eg6fI1BPjwWY91sNjv0u0stsNS5GS6zhIIbWlKwHNpyACD+U59a+QrprK56ql6sZt8eU6wz5GY0paC3JShkJcRt3ZWSlO4hOcE/atKY1PPbLzq175S9xS9gJIUobVLOB8ysdieQeap2zU11tlpk22JISIcglSkLaSvaop2lSSQSkkcZHsPYUHQb/bLiq1u2yw6Fh2o3DaZD4miU4gJT4uNylYZSR83OMgd6pRdQ3my9MpEB7T4cLCZEBq7CQFeXbecHiJ2jPcoUkKyByf1w03qfeHbx52GxEith0PBlDeNyg34aSpadqlEJJAOfU+5qwu2v7xdbBItMpEQR5DhccU22UKUfEU52B2/mUeducYGeBQalSlKDvnwko/896gX7R2k/uo/wDKpQNmoz/COjMnUq/ZMdP7lz/lUl2/SirhPavYqmntVQUClKUClKUClKUClKUClKUClKUClKUFg72qHHxD6afsnUCXO8M+SuZ8w0sDjfgBafvnn9RUyXBxWuaw01bNU2hy3XmOHo6uQRwptXopJ9DQQJpXb9RfD5do8harFcosqOSdqZOW3APbgEH78fated6I6xR2YhK/wyB/qKI5jSuhudHNZo7W5lX+GSj/AFNWznSbWqP/AOFKh/uyGj//AKoNFpW4OdM9Yt/msMk/4VIV/katnNAasb/Np+4/oyT/AJUGsUrPr0XqZH5rDcx/3Zf/ACqgvS1/R+ayXMf91X/yoMPSsg5Y7s3/AFlrnI/xR1j/AEq2chymv6yM8j/EgigoUr7sV/dV+1b7oDpbqDVsxomK7BtmQXJb6Ckbf9wHlR+3H1oOu/CbbXGbBe7itJCJUhtpBPr4aSSf3X/KpAN1hNL2SHp6yRLVbG/DixkbUA8k+pJ9yTkn71nECiq6e1exXhPavYoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLZYq2cTV6pNUVJoMe43VstqsmtuqSm/pQYtTNUyz9Kyha+lePB+lBjSz9K+eD9KyXg/Sng/Sgxng/Sng/SskWfpXzwfpQWAZ+lVEs/Sr0NfSvSWvpQWqI6CoKKE598c1eNIr2huqyEUHptNXCBXhCarJFB6FehXwV9oFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJFeCmqmK+YoKJTXgoq5xXnaKC2LdfC2KuttfNlBa+HTw6udlNlBa+HTw6utlNlBa+HX0N1c7KbKCiEV7CaqhNfQKDylNewKYr7ig+ilKUClKUClKUClKUClKUClKUClKUClKUClKUDFfMV9pQfMUxX2lB8xTFfaUHzFMV9pQfMUxX2lB8xTFfaUDFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFCaVidTXqLp+xzbpPXsjRWi4s++OwH1JwB96D1f79bLBAXNvE1iHGT3W6rbk+w9z9BXNJvxBaJjyS027cJKQceK1G+X/3iD/Kov8AUDWl01rfHZ90eV4QUfAjBXyMI9gPf3PrWtIQ44FFDalBIycDOKCeWj+pOl9WuBmzXRpcojPl3QW3P0SrGf0zW4g5r834sh2NIbfjOrZfbUFIcQopUkjsQR2NTC+H7qM7rKyOwbs4FXmAAFr7F5s9l49/Q/ofWg6/SgORSgVy3U/V+NYepMfSC7Q88689HZEkPhKR4u3B249N3v6V1Koe9driLP1//Ey0XhCchyS2Fbd+xKFYz6Zx3oO+dWuqcPp07bWn7e5PemBatjboRsSnAycg9yf5Gsn0r17G6g2F+4xYi4amHywtlbgWRwCDkAd8/wAqjPrPUr3UvqzYnoVrXISGo6UW8PJBXx4q0b1YHqRk47VtHwo3Ny26yv8Ap6UC0p5rxA0o/lcaUUkffCj/AOzRHSNZ9a4GldeK03LtTzgQtpLkoPhKUBYSc7cegV7181D1tgWfqH/RUWp2QsSWoypSXwEhS9v9nHpu9/SuE9WoStR/EBcLahe1UubHiJV7EobRWs6kt9z09qa0y774qbpIS3PfS6MLSS6rGfrhIP60Ekrb17tL96vEOfapESPbW3XHHw6F79iwgAJwOVEgDn1rEMfExZFScP2G5Ij54cS4hSsf4eB/OuHQ1xk6m1mqdFdlxi2+Ftsr2rwZLfzA4PI/N2xxVp+POWwRoWmbncJsJZO6BPiILYUT2De5aVZ9wAaCUXUXrbZtGXNu2iDKuE5TSHlobUEJbChlIJOecYOAPWsZD+IC0zNNXW6R7NO8W3eEXGHHEgKDi9owoZ7H3Fcm6szII12JV0F1sF+bhxFqehIDiCsx0EgAqSpJSSUZBOdvpznXId8vN30Fqr8QbTJjIRH3T1MgO7/HRtQpwDKsgqPzEkYoJDf7ebCzoyJfZ0GU09LecaZgtrS4tWzGVE8ADkf+NWGnPiL0/c7ozEuVtmWxDyghMha0uITk8FWMED681HK62SevQdivTbLjlvCn4y1pSSltYcKufbIV/Krq/wAteuJ+lbfYLdJXMiWuPbVNhAy46gqyoY9PmHJx25oJJxOuEB7qG9pVy0vNKbluwxK8cFKlIKgDtx/aKQO/rWb6R9TmOo/4r5e2OwPIeFne6HN+/f7AYxs/nUV5FvljqxemIyyZsGVNkIUPVbAccH7lFdZ+Djvq3/un/wCagknSlKKUpSgUpSgUpSgUpSgHtXGPillvR+mpbZJCJE1ppzH93Clf5pFdnPatC6x6aXqrQtyt0cAytoeYz6rQcgfryP1oIMsoDr7TalBCVKCSo9hk966J1RxorXJtOmW/w9u2JaLclv8Arn1KbCitS+5B3Ebfy/SudvtOMuraeQpt1CilSVDBSR3BFZtGppT6of420i7Nw0hLDcn0SOyVLThZSP7u7FEbJ1lt8Ri46fukWO1FevFpYnyWGkhKEuqBCilI7A4zj3zWT+GmW9G6qQ2midkiO824B/dCdw/mkVz7Ul9n6ku7tyurgXIWAkBKQlKEgYSlKRwAB6V274VtKvruczUshspjobMaMVD86iQVKH0AGP1PtRUoWjlIr3XhoYSK90CrSRbIEl0uyYMV5091uNJUT+pFXdKCzZtdvYdS6xBitup7LQylJH2IFemrdCZkGQzDjNvkklxLSQrnvzjNXVKC0Ntgqk+YMKMZG7d4paTuz75xnNfZNugynfElQ4zzmMbnGkqOPuRV1SgtWbbBZdU4zCjNuKBBUlpIJB75OK8t2q3tPJdbgREOpOQtLKQoH74q8pQW8qFFl483GYfx28RsKx+9eRboQjGMIcYRyclrwk7SffGMVdUoKLMSMwwWGY7LbJ7toQAk/p2rzGhRYpJixmGSe5bbCc/tVxSgtBbYKZCn0wowfUSS4Gk7jnvzjPOTXuJBiQ9/lIrDG/G7wmwnOO2cVcUoFKUoFKUoFKUoFKUoFKUoFUXm9wqtQig4l1U6MwNVSHbla3E2+7K5Wrblt4/7wHY/UfqDXFJfQ/WzEgttQo0hGceI3JQE/wDvEH+VTUW2FdxVIxk+woIv6J+H2Y7Lbf1XKbbjpIJjRVFSl/RSsYA+2f0qSdktUW1QGIcFhDEVhIQ22gYCQKyCGUp9KqgYoPoGBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKD//Z",
+              "timing": 3364
+            },
+            {
+              "timestamp": 3528210276,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAFAQAAEDAwIEBAUDAQQFBwgLAAECAwQABREGEgcTITEUIkFRCDJhcZEVUoGhIzNCwRZicrHRFyY0dIKE4TWSoqOys7TDJCUnNkNFVYOVwtP/xAAYAQEBAQEBAAAAAAAAAAAAAAAAAQQFAv/EABwRAQADAQADAQAAAAAAAAAAAAABAhEDBAUSMf/aAAwDAQACEQMRAD8AlTSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSvilBKSpRASBkk9hWvNa40q9cPAtaitK5edoaTKQST7d+/0oNipQkAZJ6e9a6dcaWTP8EdRWkS87eV4tG7Pt37/Sg2KlAQQCDkH1rFXnUNrsq0JusrwiF4w862oND7uY2j+TQZWlaFxrlf/ZJf5MN/oY6VIdaX3BUnqCKyx1fp6zRIEa73y3Q5SmW/7N+QlKuqR1IJ6UGz0qnGkMymEPxnW3mXBuQ42oKSoe4I71hbvrHTdnliLdb7bIknOOU9JQlQ+4J6fzQZ6lUokliZHRIiPNvsODKHG1BSVD3BHeqtApSlApSlApSlApSlApSlApSvi1bUk0AqCe5Ar4HEHsoVi7lcYlvYMi4ymYzOQnmPLCE5PYZNWEPUtjmyUR4d4t78hw4Q23IQpSvsAaDZaVQjrJ8p/iq9ApSlApSlBzfjg+8uz2O0JeXHiXi6sQZbiDtPJUSVJz6Zxitjl6F0xIsKrQuywEwdhQEpZSCnpjcFYyFfXvV5q7TsHVViftdzSrkuYUlaDhbSx1StJ9CDWnu6L1nJhG2SteLVbVJ5a1ot6EyVI7Eczd3x64zQaIb7cn+B8OCqa6UOXgWRU9KsKXG5pTvz9UjbmuuI0DpVNj/SRYrf4LZswWU7u2M7u+765zXt7RNkd0SNKmMRaUtBpKQfMkg5Cwf3buufetaTonWiIn6cnX7v6aE8sKNvQZOztjm5749cZoMNxBlSdCcFDH07eHpZbdTDROUsKWy2pZBG4eqR5Qe4roun9OWy36cRbm2hIjvMhL63jzFSMjqpZPzE5qnbtG2SFo9OmRES9aeWW1tveYuZOSpR/cT1z71aq09dLZZRZ9MT0xo2zlokTVqkOR09sIT0zj03KOKDisd92Pwi4oWBLq3rdZpy48Najna3zB5M/TH9a7PonSlmh6TiNmLGnKlx0OSZLyA4qUpSQSpRPcHPQegrHjhnAj8NZ2koElxvxoKn5jid63HCoErUOmc4xRvR2o7TE8BpfVLcK2hO1tmVBEhUceobVuHT2Cs4oNU0/Le0h/yo2qyEqgWdrxkFr5gwtbSlqQPoCM4raeFmkrGzoa2yVw4s6VcY6ZMuU+2lxb63BuVkkdRk9qzWi9HQ9M2eVELrk+TOcU9OlSACuStXcq+mOgFa7C0FqHT6HIWkNW+Bs5UpTUSXCTJMfJyQhRIOPYHNBQ4fMt2DifqzTdrGyzIZYnNsA5THcXkKSn2B74rqFazojSLGl2Zji5b9wuk5znTJz/zvK9BgdAkDoAO1bNQKUpQKUpQKUpQKUpQKUpQK8PjLRr3Q9aDXdRiSbafBCcXtw/6FyeZj/wDd8uP61grKm7/qjHihqLk5O7xQg8vsfm5fn/Fbstkg+XqK8hpZPy0H1gf2gq6rw02ED617oFKUoFKVZyrg1Hltx1Z3qSVk4OEp9/zQXlK+JIUkKHY9RWOvNzNu8PtZ5pdUU43Ef5Hv/FBkqVh/1Z9SJym4qCmMVjzOEbtvf/DSTd3WGkFbDO/kl9YL2Bt9kkjqfxQZilYxu6hb6Ww3gl0t4KuoAb35x/SvNru4mWx6Y61yUNjJ6kgjaCe4Hvjt6UGVpWJiXlL8SK8ptKC68WVjfkNkBR7469h+ap/rZ329PITmYMp/tPl69c9Pbt7npQZqlY64XExJkdnlpKHCAVqURjJAHYH39cCqIvSeWpZZyEMuPKCVZI2Kxj+f8qDL0rEm7OJbSC1HLq3A2nbIBQMpKuqsdO3t7UTdXFyo7KGEHmNhxSg5uA6kdCBg9vpQZalYH9fX4Uu+GQFhe0oLh8owTk+X6egI+tXtzuRhxWnm20uBfc7iABjOegJ/pQZGlYl66vMuydzDRZaaS6FpdOVBRIH+Hp26nNW8m/LjtK3RkLdS7yyG3CpJ8m4YO3v6dhQZ6lYmZd1sLWhEcLUl5DIyo9dyN2egP2qpGuS3bkYjjSW/LkK3k7jgE46Y9ffPTtQZKlKUClKUClKUClKUClKUClKUCvC2kLWhakgqQcpPqK90oFeHWm3cc1tC8dtwzXulBRESOlxxaY7QW4CFqCBlQPfJ9a9OR2XdnMabXsOU7kg7ft7VUpQU+Q1zi7ykc0jBXtGce2aCOyltTYabCFd0hIwemO32AqpSgprjsuJWlbLakrOVApBCj7n37V8MZhXdls9AOqR2HUD+Kq0oKbjDLjiFuNNrWjqlSkglP2PpRDDKFLUhpCVL6rISAVff3qpSgoCHGDKmRHZDSjko2DaT9q+qiRlKbUqOyVNgBBKBlOO2Paq1KC38DE5Zb8KxsKtxTyxgn3x71UeYZfQEPtNuJByAtIIB/mqlKDyWmyVEoTlQ2k47j2P5NUxEjhsNhhoNjOEhAwM9+lVqUFF2LHeBDrDSwohRCkA5IGAfxX1uMw25zG2Wkubdu5KQDj2z7VVpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKxWpdQ2rTNsNxvsxEOGFhBcUkq8x7DABNZWo6/F9e9lvsVkbV1dcXLdH0SNqf8A2lfig69pniLpPU9z/T7FeWpcwoLgaDa0kpHc+ZIHrW2VBjh+87ofirpx6WooSTHW4T0w3IaSTn7Bz+ldB1TrPX2tOKFz01pG4rgtxHnWm2mnAzkNHClKX3OSO317URKalRns2veI+ltEahkaniuvchCUQpkpKTsdLgQQcfMMKJGf2961m1XXjBcrPG1RbbrOlRZEgtIQhxCsqBOf7LGAnII7UVL6lRi4i8TdcSbjYdLW1Bs96ksMiYE7QtT6zgAK6hKex6dev0rCx+IWu9G3q9aY1TcXZTphPpCy4FuMOFhSm3EODr329D/SglvSoWaU1zr6ZYtTvxtRyVohw0uurkvKWtCS4lP9l3AUc9/ar22cSeIM3hzfH27yFMW+RGDkpZxJSHCoBKSB1BKRknr+aCY1Khze+JurJvDKyS/1uYzObuMmK4+wvlqeQltpSd23GcbyK9v6w4nxtGWnVabu63aG1eFQoupWp5YUrKnEqzuyQR19APvQTDpUS9WcYtWapk6ftenJP6U/KZaS8WlBBcfUoj5z8qe3r6nOawmqdbcQLdrsW2836THlsuMNPNQ5JDR8qeuEnGSOp+pPQUEz6VFhrXvEPX/EGY1o2UmNFt6lPNxCtLaFNoVj+0z1UVdMjt19K0KNxH1i+9d1r1FdUYZWtKBKVhs709uvpkignJSoWWvXGvndBXm5NakkmPFlx0OOOOqU/lQXgIJ7J6dffpWYncbdV/8AJzbGGZgTdXZLzL07YnmFtCWynHTAP9p1OM9BQS7pUVNFah4p2zVlvbcfm36C6ULfbzzmy2o9cLI6EdeoOPvWtaS1XxC1BrNyz2XUU1yW+H220SZStiQEqyeucEAEj2OKCZM+UiDBky3QotsNqdUE9yEgk4+vStC4dcW7Dr29P2yzxbkzIZjmSpUptCUlIUlOBtWTnKh6VdaegXu18JH4mqpSpV5bhyue8XS4VZLhT5j38pSP4qJnCvVMrRzuo7rbgjxothaZUsZCVKfZG7HrgZP3oJ20qGsjWHEtvQC78/fXFWudLDaHkyAl9tac5CQnBSk4OR9AcV2/4Zb3c79oGZKvU+TOkpuLjaXZDhWoJDbZAyfTJP5oOt0pSgUpSgUpSgUpSgVwbjDwf1HrzWirrGuNsZgoZbYZbeW4FpSMk5wgj5ir1rvNa7q3WuntIoaVqG6Mw1OgltBBUtQHqEpBOPrig4nrn4eZk68sSNLXGMxFSwhCxOfdW5zE5GQdqumNuBnpiq2q+Ad4n3o3qy32NDuMkBySglaQl4p/tChaRnaTk4IHeuqWXiho69RZr9uvTTqYbC5LyC2tK0toGVKCCATgD0BrGs8atBOxZEhF8/smNu8qivA+Y4AAKcnse3tRGn6R+H6Nb9O3uJe7qZE25MhkOMIwljCwsEZ6qO5KfboMfWtVR8OGoStMN3U0T9KS5vACXCQfVQb+XOPrXUuJnEK2wbJBRb9VQbO/PQh8PORlvupYWnIWhtIyFHpjcPf2rJcO9Waef0mrw2q/1hFubKpUyYeW4lPU7lggED0yfbvRWja64BsXO32c6buQh3C3R0Rt74O14JOQslPVKsk9QD6e1Y7Tfw/TY/6pP1BeWZ11eiPsxgCsoS6ttSAta1DccZ7Yro//ACw6F8FJlpvzSmY60tubWXCrKs4ITtyR07gYrSeJXHiDAsUGVoWVFnSXpCm3EyoroSEJTkkZ29clP5ojE6T4Fags9i1RBkXG1LcusJMZlSFuYSoOJVlWUdsD0zX2ycC9QQNBamsbtxtSpN0diLaWlTmxIaUoq3eTPXcMYBq/f4kXXU3AuRfYl5h2e8xZIZmuoYcCGwVkJSnos5IU2cjPr29M3wY1shHDmZdNXapjTm40stGUtK0bBtSQglSUlauuegPeg4lxT0LcNAaCstsusmLIefucmSlUYqKQktMpwdwHXKTWa0PwVnay0dYbjHvxiWyShbj8dwKXtcS6tO5CchPVIHf6967ZG1vw217Pj212Ra7pJSo8hqdEPzHvs5icZOPTvXuy8TOH0SadP2u4RoSoxdT4dERbDTWzcpfXaEjso/X+aDS+IPw/RrwzbVaZnNwXocZEVSJCSUvBOcLJHUK6nPQ5+laxI+G+8R7zHdtd3t64bRaUTIK0uKUACvoEkAbs469sV3nSGu9N6vceb09dGpbrI3Lb2qQsDtnaoAkfWrvVWq7HpSIiTqC4swmnDhG/JUsjvtSMk/wKKiNr+Npq3cRrwu23i5WtKZbiJUdtg7sbvOGlpVgg9cBWMfWsPws0bcNb3e62+07Gh4RRLz5OxHnTgKIB6nB9PSs38RN4tl41tGnWFyI9AlQWng6y0kFaipYJUcbs9ACD2xXS9F8Qkae4lXjTKbbZ7Xpq3iS665FiqDpS0gq3KIJ3HA9s0RStfArUETh9fLC5cbUZU+VHfbcStzYkN7sg+TOfMMdK+x/h6lPaC/S59ziN3pia7Jjvs7lNFC0NpKF5APdvOR2+tdPgcWtGXC03O5RLspcK2pbVKc8K6OWFq2p6FOTk9Omasjxt0CIqZBvS+SpZbCvBv/MACR8nsRRXO9JfD7dUaih3DV19Zlx4ikKS0wpxxTgSchJUsDan7Z/ishww4L3zSfEaPqCdPtj0RsvEtsqWVnehSR3SB/iHrXQF8XdDI8DzL+wjxiOY1ubWMJyRlXl8nUf4se/aslqviFpbSimkXy7sR3XUhaG0hTiyk9lbUgnH1oM9eYq51nnRGlJS4+w40kq7AqSQM/mo96N+Hm4QxeI+oblBVGnQTHbXEK1Lbc5ja0qwpIBHkOevrXbtI6209q9Dx09c2ZimcFxACkLSD6lKgDj61sVBF0/DRdEwJe29wnJnMSI+QtDez/EV9Cd3bAHT612HgjoifoHSUm1XSRFkPuzFyQqMVFISUITjzAHPlNdBpQKUpQKUpQKUpQKUpQKiN8RiER+NMWRqBmQ9ZlNR1bGzgrZHzpSffO781Lmue681Zw7buX6LrN6C7MZ2qDEmIt3ZuAIwQggZBHY0Ebob+ipl8vi9K2y/xlfp8xUcLfQW20+GXu3DBVt7/wCI9xV98NukLHq++3iPqKCJjLEZLjaS4tG1RVjPlI9KlRbtH6ctsSVGt9kt8ZiU2WX0tMJTzUEYKVe4we1etP6TsGnXnXrHaIcB11IQ4phsJKhnODREPuJEGJYuMU+PfojhtLS0pabIWseHDYS1jC0lQAAHzDt3rEtx7bKsOoHNNRr2XWmwuQslIYEfmp6KSMqHXacFR7dzjNTav+mLHqHlfrlphTy18hfaCyn7E1Us+nrPZYTkS02yHEjO/wB42yylKV+nm9/5oIHPS7C5otiLHs0lN/afK37jzyW1NnOE7Ow9Px3rPvQUL4DxpyYyFPN6gcbU+EDclBjo8u7vjOOnvUk353Clm+vaScjWdM2RISl2KmLhCnh0SkqCdu4ZIxnoTjvW8wdK2GDZ3rVEtEFq2PqK3IoZHLWo46lPYnoPwKCL9qvFsl/DFfbXCYLdxgPMLmucsJDhckkoO4dVEJSB17YArnjrM1XDCI82lZt6Lu+l0j5Q4WWdmf4C6m0xobS7Ftl29mw25uFLKVPspYAS6UnKdw9cHqKuIGktPwLVItkOzQWrdIVvejJZTy1qwBkp7E9B+KGIUX9dhud106xw9t1xi3DlttvB1e5TknIwpHU46+vQdugrMcPbXFvHHT9PvDDcqO7Lm81tY8qiEOn/AHgGpd2XRmmrHKEm0WO3Q5IBAdaYSFD7HuK8wdFaagXf9Uh2OAxcdyl+IQ0AvKgQo5+oJ/NBF/4UVEcT3QD0NvdyPfzIrMfFay63r+wyrg28u0KipThBxna4S4EnsFYKf6VImx6M03YZpmWayQYUooKOaw0Eq2nGRn26CsjebPbb3E8LeIMabHzu5b7YWAffr60EC9fvaek6hU9o+BLg2hbSeW1KJKirsojJPTI9z2P2qXevdGWJnSOqLxBtEdN6ftkkqkoSd6ippQP5rYZugNJTiwZenbY7yGgy3uYT5EDOEj6dT+a2banZtwNuMY9MUVAzSV4hwtA64tr61iVcGYnISEEg7HwpWSOg6Ed6wDv/AN2Y3/XHf/YbqeCdC6VSzMaRp+2IblgJfSmOkBwBQUAcDtkA/wACtI1QjhFpi4M2e+QLNGkKIcDPhSoI3YG5WAQnOB39qIjRrq2w4WldESIsdtp6Xb3HH1pHVxQeWAT9cdK+X3bG1jbJGqGXXoTsCG7hSVK3tmMgJIAUkkA+yh2NS7uVg4fOohwrlE0+RFbCI7LymwW0KO4BIJ6A5z/NZq56Q09dIUSJcbLAkxoiA3HQ6yFBpIAASn2GAOn0oI7/AA3JsTvESQ5ZI955yWXSpxRQmOlokYCk+ZQ64wCo9R3OKlLWMsVgtNgjrYsltiQGlnKkx2gjcfrjvWTopSlKBSlKBSlKBSlKBSlKBUL/AIkVFHGW4KA3FLcc4Hr/AGaamhUZONvC3WGp+JUy62S1h+A6hlKHvEtI6pQkHopQPQj2oK1v43atga3TbNV2hqFGmLAaZWyUOsJX0bVk/MM4zke/btVvw34xauvx1OLjJiq8BYpU9jbHSnDre3aT7jqelXNp4P6zvnENm6a5ntPxIS0hMnmJUqQhHVASkdhnqc47nvWDsPBjX9in31uAIaY8m3SYheDqFeIQodG0gkFJUQkZOAOvWiKunePOq06fvk64NxpzzBZajgMhCGlLK8rXt6keXGPciqdi4ycT7ihUyBb41yjIVhaGoZVj+EncKp6S4TcR7TabqiJEYgSnVsqCXpDLiJDaQ5uQQCpJ6qScKGOn0q0a4M8RLnf2pL0C32daCMSWHWmUJI/xBLPXP2AoPGq7uI/xAsLbtlvbeVOhqKi0chTiW1KJGcbsqPUjNZHSXG3X1zcuqUNRLgqPb3pITykNhoIwS4f3ADPl9SRWV1Xws1jN4xt3uPb/ABVtTLiOKlmQ0krS2lsLVtKt3dKumKseGXCfWlkk6iXc7OGUy7HLhsnxTKtzq0gJT0WcZ9z0oM/oDjvcZWldSzdRRI78q1soeZLA5YdK1hASodceYp6j0zWqHjpxDSy3d1QoItbrpQgeFPLUR3SFZ3H81kuHPBbUv6Xqi26jhptqLhCQ3HeLzbo5qXErTkIUTjKaw9t4UcVbeU22A23DiJe3iUzKaR1/dvSebj6f0oNn4h8er5Cj2dNitrcFcuGmU6uW2VKCiVJKUg4GAUnqe/0q40fxW4goddf1HY0ybWmG/ID7UZSNxQ2paQFpJT1Ix2r1rjh3xFPgWbfIi6jitxENu/qJaeVzupWoc4dASehBzgCsNw54P8QLPIuM7xLVmeciPNtsokglxxSSEZ2ZSACQc59O1Bjbdxv4jXy4OizRYTxT5vDMxtxA+mTuP8VIjRF+u144esXa9QxBupadLrHLUgJUkqA8quozgH+ajdeeEXEm8SGW5lmtSVJV1lsGMzu+qijClfgmpJ8P9PXCycP4NkvU3xc1tlbbjwUVABROACepCQQP4oOG8N+MWrr6dUfqMmKvwFilT2NsdKcOt7dpPuOp6Vr7HHXW67BNlqlw+c1JYaSfCpxtWl0np/2E1e2HgxxAsU++twRDTHk26TELwcQrxCFDo2kEgpKiEjJwB161hY/BbXyNPToqrGA+7KYcQnxjHVKUvBRzvx3Wn80Gcl8cNeRdK2e5KjwQ3IeeQZS20kPlBHlCARtACh19c/Stf4y6tbvt001e/wBJt/Om2luQ7vQT/aB11BB6jKfJ0znpWx3vhNrSTwx0zaGLOFXCHLluvteKZGxK9m0534OcHsax+qeDuuZ1t0y1FsoW5Dtnh3x4tgbHPEPrx1X18q0nI6daDTeK67s7xLluXPkeNWplTPKACQ2UJLQwP9TbmpwWMThZYAu5bNy8O34ot/Lzdo34+m7NR24vcHtT3jUEW96eaZkuLisIeYU8hC23G0JT0KiEkeUevvXfNFN3hrSttRqVYcvIaHilApIK8n9vT27UVmqUpQKUpQKUpQKUpQKUpQKUpQKtbjcIVsjl+4y48RgHHMfcDafyTV1UTPiQeXN4wQLffpb0WxoaYCXEpyG21H+0WB6nOffsKDbOJnGfUOnOI71ktCLW9bQY5bccaUtSg4hCidwWAfmOOldshau03OlGNCv9pkSQFKLTUxta8JBKjgHPQAk+2Kg5qNi1RddiPp65PXO1NPMoYkvAhSkgJ6dh0ByB0HQVmeFcyNbOJL71wfbjNJYnIK3VBICiy4AMn1J6URMNGuNJuIcU3qayKS2ncsie0QkZAyfN0GSB9yKrM6v0282ytnUFocQ87yGlJmNkLc6eRJz1V5k9B16j3qBlk/8AJeof+pI/+JZrsvw98N7bqywi+T5s9uRbboSwy0tIbylLS8kEHqTgHB7AUEnHbxbGbiiA7cYaJyxlMdTyQ4oYz0TnJ6VonEjibbbToi6XLSl5stxukUNKQyiQh7yqdQhRKUKzjCu/viopWKRap2o7vP1ndrpBnAOPsvREbnDJ3ZwT3HX7fcViLD/5K1J/1BH/AMVHoJZcF+J7uqNNzbjq6VaretuYIzJCuQlfkCsedRyep7VccctZ6g0ra7XI0ubXslLWHHpbzaewBSEBSgDnJyRntUU7REsMjRV4euV4kMXiO4lUCAlJLbu7AWo9O+B7jsO9bBqCTMkcDdLiYta22rpJbjlZz/ZhCeg+gUVUG96m48avtLtuaQzYVreiIedLYLyd5UoHCkuY9O3XByPStst/E7VSeKztouy9Ox7I3JcacCpjSVNtpz5s8zO7p1GP4FRnvP8A0Oxf9TP/AL92t6ciMXD4jJMOWjmRpF+dZdRkjclTigRkdR0J7UHadH8eo2oddxtPu2hmHHfecZROVPCkkgK2YGwA7iAAM91DvW18R9T3SDPj2qx3LT1qW6ne7Ouk1CS31+VDROVE98npUV9AizWri7HN6KWLZClvKSVqVhC2wstdupwsI+/rWJtyIV7uV5kapuTkeapK3UOOrV5ncnO7CFE/bp9xQT5gPpkwmXkPsyAtAPNZOULPqU9T0/mtcunEHTFq1Ozp6fdWmbs6UhLJQogFXygqAwCcjoT6iuefC2mMxpy7R4N7Xc46HkL5ZjLaTHUoHIBV82cDt2x9auNYxOGDnFuG5fpK0an3snlAr5SnOnL5mBjONvqOmM0V2WsMvVenm5nhHL7akys45JlthefbbnNa/wAb5kyDwq1FItylokBgJ3I7hKlpSsj/ALJVURLHZ9IS9IOS7tqORBvvitiYyYxdTysDzdO579c+nagnbMmxYMVUmbJZjx0jJddWEJH8npVtab3arwlarRc4U4I+Yxn0u7fvtJqGnEaat226KtSr3JnaebiZRKUypvP9utKjsJySlKUgfQfWq+nhb9O8a7C1w+u0m5QXJDDZdUkpKwsgOIPQZGM9cdP4zQS5g6u03PkmPB1BaJMgJUotMzG1qwkZJwDnAAyauYd/s86G9LhXWBIisp3OvNSELQge6lA4A+9Qf4b2hi+awlwpbj6GTDmOHkr2ElLS1AE+2QMj1r5w4tabrE1ehyTJZRGsb8vay5tDqm1tlKVj1Tk5xRE23tUWBi3onvXy1twVr5aJC5bYbUvGdoVnBOATivn+lWn/AAseT+u2vw0lRSy74tvY6QcEJOcEg98VBCK84dB3NgrPKTcoiwnPQEtSAT/QVk9SWdiLw30ddUuvrkTVzW1pW5lCEtuJ2hA9PmUT7k0E5ZV6tcN6OzLuUJh2SMsocfSlTo90gnr3Havt1vNss7SXLtcYcFtXyqkvpbB+xURUGdd24QrHo2WJMl52ZbOYoPObg3h1aQlH7U4HarnUc1eoNdQv9LZj6IxiRklxSynagsIUCDtVgEnJO09yaCbKdQ2VVsduSbvbzb2scyUJKOUjJwMrzgdSPX1q3Z1dpt+I7LZ1BaHIrSkoceTMbKEKV8oKs4BODgfSoaQI9ug6c1a3a9RqkcyMEqhIjubVoD7eFlwhIyOnXaO/pmsdabQxJ4YX+6OLe58OdFbbQFkIwsLySn1PQdaCWXFbihC0JZrfOjMxrs5Nd2oZRLDZLe0nmDAVlOQB2x171mOF+tWNeaVZu7TLUV4rWh2Kl8OqZIUQNxwMZAB6gdDURJkRqRwOt9xdSpcuLfXYTThUfIypkOFOM4+br2rv/wAKrlm/0AWzb3EG7B0uXBAUolJKlhskHoMpT6e1B2mlKUUrVtcaB09rZthOoIXOcYzy3kLKFpB7jI9Poa2mubcU+Ltn4fymYL0Z6fc3G+byGlBIQknAKlHtnB6YNBRl8DdEPz2pYhSGFNJbCUMvlKBsAAOPfpkn1OTV8/wh0VI1C7eVWsGW6pbi0hwlsrVnKtnbOTn71oY43WfWulNTWhyC/bLg7aZZZStYcQ4QyskBQAwcAnqPSuW8CdYM6Ha1RepDHii3GZQhgObC4pToGAcH0ye3pRHeo3AfRUdmU02xP2SWw05mSflC0r6dPdArctC6NtOiLU9brEh5EZ14yFB1zedxSlPf7JFc9tnHi2OaMe1Dd7W9CR4kxYsZt4POSFBIUojypAAyOpqz0l8RNkvN5ZgXO1yLWl9YbbfLodQCTgbugKR9etFbvL4T6NlalF9dtCPHFZdUkKPKWs/4ijtn1+/WsJF4E6Jjsy2Wmp22U0GXAZRJKQtK+nT3QmrTV3HrTuntTqs6YsqbyHeVKkNEBDRz5seqiPXt2rg/Bm6RInGli6SXw3AbM2Qt1WcBAZdOfxREiG+Behk29MRVvfcQl7nBan1b84AKdwwdvQdKzmpuGWmdRWO22iXDWzb7cSY7UZwthORg/euZy/iZtDc9TcWwTXoYOA8p5KFEe+zB/wB9Z3V/HOFZbHY7xbLO5c7bdEObXDIDKmnEEBTak7VdevvRV9I4DaKfbjIcYn7Y7fKRiSfl3KV7e6jWVb4R6WRrD/SZLUv9U8WZu7nnZzCrd8vtn0rUNT8folnVZkQ7E5PXcYLUspTKCC0pZI5fyHJGO/Sup6k1LE0zpV6+X0GOyy2lTjaDvVvOAEJ7ZOTj0/ig1i+8HNGXu+Lu0u2rRLcc5rvJeUhLivcpBxk/TFUtScFtF6guz1xl291mS8rc74Z4tpWr1UU9sn6VpC/iXtJgSHW7FK8Sh1KWmFvhPMQc5VuCTgjp0+veumcKNcp4gaadu6IBgBuSqPyi9zM7UpOc4H7u2PSgzeldNWnStpRbbFDRFipO4pBJKlHupRPUn71hLzwz0xedXMalnwVLubSkL3BwhC1IxtKk+pGB+BXO9SfEfZ7Zd34dts0m4NMrLZfLwaSog4JSMEkffFYLiFxpe1Hw4dkaYh3W2yBKQ0/KbdKfD9lDzI7hXUdcfzQSPlxmZkV2NKaQ9HdSUONrGUqSRggj2rmS+A2glSy/+mSEpJzyRKXs+3fP9a5nwq4t3ax8Or5cb7GuF78LObCJMmUrzcxIHLClJVjbt3Y/1/T12Wz/ABFw7nJtcVGn3USpkwRlI8VkNJJQErzs65KldOny9+tB03UfDvS+oLFEtFwtbQhw07YwZy2pgf6pH9ff1qy0Xwr0no+f460W9RmgFKX33C4pAPfbnoPuBmtK0bx6a1K7d0J08uN+n21+4kmYF7+UAdnyDGc9/T2r7pX4gbXdoV3mXS0u22Nb2Uu5TIDynVKUEhCRtT16+9Bs+n+Dek7DdF3C3szBJW06ySuQVDa4kpV0+xNfLDwa0lYkXNMBmYBcYa4L++QVZaWQVY6dD5R1rRYvxM2hc4Ik6fmtRCrHOS8lagPfZgf760vj5xFvh1u0nT1zutttghMqZWxIcbRKSsb+aAMfu2evVB+wI7CjgRopFvfhJYn8h51t5Q8Sc7kBYT1x7OKq9n8GtJTrBarM+zMMK2qeVHAkEKBdIKsnHXqBWqXbjY9pXSOk5Ny09JflXKIpa0vSi2tJbVs3HKCTu+bP19e9VdY8eW9NGybtPLk/qdrYuQxMCOWHN3k+Q5xt79PtRWy3fgzpK7QrXEmMzCzbWDGj7ZBBCNxV16dTkmrnUXCPSOoItuZuEFzfBjoitPNOlDhbQkJSFEfNgD1rRJHxGQomopdtmafdbZjPOtKfTK3E7N2MJ2epAHf1q4uHHW0SeHirhNiT4Eyc49FYjw30qeTtSnLgWUgJ+YdcHr70G3WzhPoqJYbrZIMQ8uZsbmOB8qewlSVpSVf4eoScdKpxeDOko2nZ1laZmeBmPNvugyCVFSM7cHHT5jXOuC3E/R0S8C0RrNNtcq5upSuZIlGSX3eyeYo4IJJ9BjJqRtBo9t4W6Vg6Sk6aEJci1SHzJUh90qUHMJG5Khgjokdvr71eaD4f2HQomjT7DzZmFBeLrpWTt3bQM9sbj+a2ylApSlAqLPxH6bvNu4ix9VxYLsy3LSydyEb0trR02q6HGcAgn3qU1KCHOmUXfUS9S3JrSEJmILdLcdnPNOqcbPIWAELUrBWTjsPU1z+1aWnXCyXmchh9KrchpwoLZ86VL2HH1GQfzX6DUomINN2a8ai4ZxWrfb5DrlhlvKeabaO8tPhJC8YyrCm1A47Aj0q9ksag4p3uxQYOm2oHhGURVvx46kICQRlbij0GPQfjvU2KUEPnLRqTh3xanrY05+teNcdbiF9lS23UuKyFBXYK9D/P3rUdDaaul51q/a0RVR5UhiY2kFBSgL5DmE57AZ6VO+lBA+C5eLFBm6cmaZckSHJCVFp9pzIUMdNqcFXbp1x16V2TWGjp8v4d21zbJEtdzhP+PTDhNKTsQTtO4Ek7ik7j19B7VIylFQj4Iaal6g4mWVqcw/4SEfErLiTgJb8yU9fQqIH81Jfj7p6fqXhrOh2hpT8xtxt9LKfmcCT1A9zgk4+ldFpQQSmK1O7w+TaH7A2za7dLBVJMMokc1e47Co9T6+noM+lSH+FJlxnhrLS82ttX6k6cLSQcctuuzUoINakXKhXmVKa0tc7JfQ8opdjLWhnJPU8pSCcEZ6BWOvbFdCt9j1fqHgdqRufY+XOXJYfY2REsPykJOVEpSBuwOxxk9e/SpH6pvTWndPT7vIZefahtF1TbKdy1Y9AK1DhNxPi8RBcBGtkmCuHt3FxQWlQVnGFD16dqIi7bZ12a4XXzTDtnkIYTLRPL6mlhQcy2jl4xjsCffpXcvhZtqTw4uXiYiQ/+pO7C635h/ZNYxke9dzpRUHdHW7UOl7zqWG5p+a8+5aJsN0KQUBpBR1cyRggbenvkY71YaP0ld7/YNRMW6HIckx22ZIZCDudCVEEJHqcKzj6VPGtH03xU0lqPUDdltFwdeuK94S2Y7iAdoJV1Ix2BoiL9tvl9eslo0y1oSFNfgOKIL9vcU44VE/MAR79T9B7Vs3xDaSvuzS9yFoCGGbS1EkNwWiWozqVKUU4GcJ8+B19K63pLjRA1Jr06ZZs09hZW4hL7mOhQCTuT3SOnv7V1egh7xSbv2rNA6MvZssltuKy7CcS02pWwJKQlRGMgKCSc9q1TiMbvchpczLNKh+HscaM0FAqLqEFYDmMeXPXofTB9anbSioY6FgPL+IJgvxHFMG7PklbZ2kZX7jFb/wDFLo24yJNpvtngqfhRmSy+2w3nlnduCikehyQT9BmpH0oIg8P37xqviBbX4+joToQtoPypbTqwylJyV7twSDjsMe2BUvqUoFKUoFKUoFRp+I2765Y1VybM/cWLEyyghdvUoALIyrmFHUH2B9MEVJauQcReDkjVOrn9QWvUsm0yn20IWlDZPypCRgpUk9hQcn4faq1HZF3K7I1c3focOA86uIuU6pQXtwglDqQSAojJTn71gmbjxBvel7rrYarkIjQZAbcaE1baiokfK2ny48w6dPWu0aC4A23T82RLvVzcurjzDscthrlI2uJKVE9SScE+vTvWuSfhkQZy/C6mW3BKspbXF3LA9iQoAn64ojlesuJepr3HsclV2nxZDcMsvmK+tlLykurwspSQMkEA/asnqfWGs9LavtTz2pJclRiRJPLStQaKFNpOxSCSD06Enqe9dW1b8PEa5ptLNlu6YEaDE8OQ7H5q3V71LU4SFDqd3bHpXrW3AV/Ut1hzEagajiPCjxNhiFW4tICd2d4747UG98btVzNHcPplyteBOWtDDLhGQ2VH5seuADj64qM79w4gWzSdu1wrVclUaXJLSGvGrWsKBV8zZ8uPKenX06VLvWWm4GrdOS7NdUqMaQkDcg4UhQOQpP1BFcKjfDIkTE+J1MtcIKzsRF2rI9slRAP1xQc+4r6/v9zm6fuMa6T4Bl2hlx1mLJW0gub3EqUEg+pT/urftSu694Z6avWoLvfWp8m7uNxowbdccREUrcsqShY2jypwMfSth4hcBW9S3OA7ars1bIUKC3Cajqjlw4QVHO7cO+6tw43tWxvhZche4r0qG0GshhQS4k70pC0k5GRnOD37etBG+7TtfW3hxDv8rVDzttvEkBCUzlmQ2tO/8A4OQD7ZFW8/iLqhGjNO2eLe5rK5HNfflKkK5i8vKQkFwnISNp9fX6Vpt1FhagFu0v3KVJU6FJXJZSylpGDkYStW5RO3r0xj1z07xpXgqjV3CnT67hIetV2b5rjay3uy0tZUkKTkH6jr60HMeIN/1jZbtFt03V65i48RCUv2y4LUhSSVEbyCMrGcEkZwBWTsd91XcOMSrXb9ST2Fu3F9lrnPrdabGV4/syrBwOw7dq6BcfhmbcTEFv1CGShgJfLsYr5ju5RKhhQ2jBSMfTv1rP6d4Gv2jiO1qhV+adQiY5K8OIpBO4q8u7d/rd8UHH+H+utTiVqW2zL3PlNO2ieQXX1KLbiGVrStBJyk5T6e9W+g9Sa0XprUibDcbhJmEx0kF5TjiUEuFRbBJO7oM464yfSur2H4fJFruc+WdRNOiVElRgkRCNvOaWjOd/XG7OPXFULd8OK2LVNiP6m87zrTzbjUXbsUgLHXK+oO89sdqDktnu+r1yQl3W8q23PmbREuEuQ0on06qTsH8kVtGptXaw1PxUcskLUgsqYbpYbLsrkMBTQ8ylEfMVKST1z3A7VuLfw4PS7g27fdXSZrKAE4DB5m0f4QpSzgd/Sszrf4fbXqDUIuUC6O25tzZz2OUHArAAJScjBIHrnr1oONaXvmqL9xSTaZmp56VTZT8dbkWWtTKVKCxubSFAbQTlOMdh2qy4I2x6bxis8Zuc7HWxJW8p1GcuBsFSkHqOigkpP0J712zSvAMac17Ev0S9pVCiylPNRFRzuCOu1JXu6kAjrj0qjcfh3jq1Ybrar6uHFMjxHh1MbyjzZKQoKHT7jtQcyt+sLvaeNd5kruE5+NDlXF3wy5Cy2pLaHlJSU5xjyjpVrEunEDVtmv2rG9UvMMWshbzImKZ79cIQny4++M/U12W18DPDcR5GpZl4akxH5Ml5yEYxG5DwWCjdu9l98ela/cPhmaXcHVW7Ui2IC1ZS07G3rSPbcFAH74oOfas4k6jvfDvTkhy6TY8+PLlRXn4zymi+lKGVJKtpGSN5H9fWrPUWptZ2mx6SuB1TcCmXEW4yhDqgUBLqh5znzkn1Pp09K7ZqjgJEuGlbFZLNdfBIty3nXXnmOYqQ44EAqOCMfIB9se1WupOAj94sOm7cnUDTRtEZyOXDEKubucK8439O+PWg7Do+4O3fSVkuUjHOmQmZC8DA3LbCj/AFNZesZpe2GyaatNqU6HlQYjUYuBO3fsQE5x6Zx2rJ0UpSlApSlApSlArUddcRdN6I5SL9NKJLqdzcdpBW4pPbOB2H1OK26ok/EawbdxkiXO9QnJdndbYWG9xSHW0dFoCvQ5z/531oO+aH4q6V1nNMK0zXETQkrEeQ2W1KA7kehx9DWJvPHTQ9rua4Sp0iSpCtq3YzBW2k+vm6Z/jNcN0g9YtTa3ntaM0nOhzHo0jwryZ5CIpLKkhRQE9iT+7ua0iyT7JZ7FqO2aisDsi9vJ5cR9SigxFjIOR9Dg/XGKIlrqTjFpKxW61T3JMiZDuSXFMORGwseQpCgoEgg+YdDVpI456Hjuwm3p748Syh4lLJWGQoZCV7c4VjuBnFRNvVtnwdEaeenIcbYlyZbsZKxjKNrAKh9CQfxWW4pwosKNooxI7TBf09Ged5aAnmLK3MqVjuT70ErHuL2jWtTs2I3QLlOlCUuoQVM7ldklY7HqPoM9+9YyHx00ZIvDlvcemRVt8ze7IZCW07ASeoUT12kAY6kgVGfitCjWzW8Jq3x2ozfgYTm1pISNxZQSenqT1zV9wvhRbjxm8NPjtSY6lzipt1AUkkNOkZB9iAaCSlm41aJusOdIbuTkfwbRecbkNFClJBA8voo5IGAc9avrJxP0fqLTtyubc9CIEIAS0ymykoCu2UnOc9hjOe1RN4T2+HcHNXeOjNSPD6dmyGuYkK2OJCdqx7EZODWN07b59w0dqb9PQ44mOqNIkIQCSWwVgnHsCpJ/igkVbOJfB9d5QGbXDivFeEy12pKU59DuAyPuQK2zV/GTS2lL4bVcvHLkBtDgXHaStBSsZBB3D0NRMjXHTjtrtUV+ySpE1pRD3hnQwXsnp5iFlR/gY9KzHGqP4fWsKOYrkQItsJHhnXOYtrDSfIpWBkjtnFBKS2cXNIz2L5ITOWzEtC0IfkOowhZUVBPLxkqzsPpmsTbePWhp1wRF8bKj71bUvPxylsn7jOB9SBWofEVoa22Th2l7S1naiNCa05M8Ok9UBCwkq+gK/wCtcabvejX7NYoX+h8uRc2ElEpxmaWjJWSMdkqJ+2Bjt1oOj8RdR3K3cdQyNXXFmK3JjkR2UqKEIWlCtgSDtUCFdz712O58XtG23U4sUm6YlhzlOOBB5TS/ZS+w69PXHriox8TGixxlYaLC45QLcnkrXvU3hhkbSr1I7Z9axdsUnT2trtB1Jpn9enOLcjJjOOLbUHlK6LGASrPp756Gg7bxB43Wa/6GvcTSsi7Q7shptxt8J5JSA82FYUlWRkEj+at+AHEDwOj9Q3bW9+lPR2JLTbbkt5byslKjtQDk5OOw9qjvZv8Aod6/6mP/AHzVZFi3TpPDyRMjIWuFEuIEjaMhJU35FH6dFDP1+tBLKwcctE3q5tQG5siK88sIbVKZKEKUew3ZIH84ro9wmxrdBfmTn248VhBccdcOEpSO5JqDMKZpy53Cyxo+m50uVsQytmI+I/NcyO3lWpX3yP4qVXHO2zbjwhvEW3MuLkJaaWWkeZRShaVKH16A0Vixx+0IZ3h/GTOXu2+I8Krl/f8Adj+K1HjrxhuNhvFsh6MuDaUrj+IecLKHEOJXgtlJOfTdXBINxsCdPMQ59pffnofKlOMLDSlo9ishX2wEgVv3Gu1qjaD4fyGLTJt0YRn0lp5zmrb3KSpCVLwMkjJAwMdvSiJLcKdTnV2g7VdXFKXJW0G5ClICNzyeiyAOmN2cVttc4+H7UES/8NbcmHHcY/TUogO7wBvcQ2gqUMeh3evWuj0UpSlApSlApSlApSlAq2nwIdxYLFwiR5TJ/wDw32wtP4NXNcF428UdRWnWcXSejG0JnrDe90tpWtbjnyoSFeUDBHUj19MUG53LiDoPQ9+dsCktW6akoC2osEpTlQBT1SnHYisjr+4aL09suWpoFufnr6MIMRD0l4jsEDGT9+w96iPxAl3ybxLLuq4iYl6C4zchtJBBKUIAUMEjqAD06da3nU/FvV2odXzVaXMCHHgFwMKcbY5nLBwTvd9VYHlT/XFEScdtdk1JBhSrhaIktrlhbKZsRKlNpUAcbVjKewyPpSXpXT0wMCXYrU+GGwy0HYbauWgdkpyOiRk9B061G648Xdet8N/FSkPW64t3BltueYaUpkNKbdJThaSnIKEnIH/jZs8U+KT+jm79GUFWuC6WpU5TDJ5q1KGAU4GAMpHlHc9T7Fdo4gaj4b6ZvbMTVdtt5uC46HUFVsDx5eSlPm2ntsIA9MVuVr09p1DjVyt9ktjL7ieYl9uIhDmFjr1Az1BOfvUMuL+rl63uNivD7KWZKrWlp9CPl3peeBI+h6H+a6VeuKOtrzqhnSvD1tDa4jQZyG21OOqQjzklzypAII/j64oiQ0TSunoReMOxWqPzm1Mu8qG2je2r5kKwOqT6g9KrWvT9mtCnVWq02+Cp0bXDGjIbKx7HaBkVG6y8WtbXKwaltEl8RtR2plUtuQhhvcQ0sB5taCCnIBJyAPlNYT/lz1T/AKCcoXf/AJwC4ZMjw7WfD8v5du3b83rjNFSdlWrSunEPXl+3Wa2hkFa5nhm2yn/tAZyf61jNPOaR4gsvXhqxRZe1zkiROtyQp0JHRSSpOSnHb/KuBam4q6wY07YLI87GlXW4sImPvyYzR6OLJaQEkBAwkJUSR3Ppitm4ScRdeyNaMWfUkZVztziuS5JjsIUlg4yFcxobCOwP/hRHd79frLZUNJv1zgQEP7g2Jb6Gw5jGcbj1xkZ+9a8zduHdsWxcGZmlYi5AK2pKFsNlwAlJKVDv1BH3Fcl+Mf8AutJ/7Ur/AOVXBb3d2J2n9OwGkOpdtzDzTqlAbVFby3Bt6+yh3x1oJ2JsumL8tu8JtlnuK3wlxE3w7bpXjoCF4OcYGDn0q9uUa2MFd3mxI6nobanPEKZCnG0gEnacZ7Z7VEGz8TNXWSdYbJa7uWLWhqGhLHh2lYC0IKhuKSepUfX1rO634mauRxMvGnk3giz+NcieH8O1/dE4Kd23d29c5oOwaHvPDHWNyk27TtntbshLBddSq1JbBbCkjqSgA9SnpW+x7RY7LAkpj2+22+E4MvhtlDTahjuvAAPT3qFPCGdqqDebodDRfEXVyAtKlYSSy2FoUpYCuhPlAx1+btW03jXmqOI/DC4W+S2ZMu3y2X31xkbVPMFKx1QO+1QSTgduuOmaCRlouvDmBMUqzzNKRZR6FUVcdC/tlPWtzZdbfaS4ytDjSxlKknIUPcGvz6tjWnHIYauzt2hzskF5ptDrQ69MoJSofXqftW+SOJGq9F3C3WSx31EmzxGIxaQzHbKXUKbSsgFSNwzuPfqM49KCWqdL2BM7xqbHaxM3b+eIjfM3e+7Gc1kZkSPNjqYmR2pDCuim3UBaT9welRoj8WOIGl9eQoeuYrSIc5aV+F5aAW2lqwChSfb2USenX3qhO4rcQ9aaluTHD9sNQYYU4lttptSy0k43KLmck+w/rRUkD+jaXtLjhFvtFsaIK1YQw0gkgAnsBkkD8V7st9tN9accstzhXBtohK1RXkuhJ9iUk4qLV84i37X/AAbvkea7GakWx+O5NWlG3xUdS9qQBg4UHNhOMdB/B2T4QGbli+viQ3+kDahTGPOX+hCu3bbkd/XtQSSpSlApSlApSlApSlArifGvhJc9Vaiiai0tNajXRpKUOJcWpvJScpWlQzhQ7fwK7ZSgipdeBOt5OpG579wi3JZU049JkSFb1KATuHUEkA5A9wB2rJam4G6rt2q51w0Nc2WYkpS1J/8ApCmHGgo5KMgdR7HNSZpQRF4maBuuiuE7K9QXVc6dKurI5SXVLaZSGnug3dyc9Tj0FWeheGWqdX6CirsF5DVqlPuCXDkPrQ0FoUNq9oB3ZGPTuPxK/U+m7RqiA3Cv8FubFbcDyW1kgBYBAPQj0UfzVTTthtmm7am32SIiJDSorDSCSAT3PUk0EcdbfD/fHFWaPpxyG/HiQEsvOvu8tS3i64tRAwennGKyWruCWp2NTIv2iLm1FkvICnRz1MracKcL2qA6pJyfTvUj6UHFuDXB6TpaXc7pqmUzMuM5lccttqK0hCzlZUojqo4/3981HG56JkwuJv8AoiHW3nlTURgto5G1ZGCfqEkE+3Wp71qcXh5piLqlWo2baBeS4p4yFOrUd6gQTgnHYn0oOdcZeDUvUk223TSchiNMiMNxiw6ooTtR8ikqAOCO38D+bbhfwq1hb9YM3zWF+ccQwd4YalrcLygMJ3k4G0e3Xtiu9UoOPfENw9vevW7CLCIuYRfLvPd2fPy8Y6HPymua3rgPquVYNPRYrVrTKiMPIkq52NylPLUnrt6+Ugf0qVdKCLd44Baodcs0y3S7eiU1GZRIStw/2brYCdyTtwoYCT+aT+B+tH9cPXZ6VBmNrlF5UhbuxbvXJVsAwM+1SkpQRP09wJ17bFzX4lzjW2SY5Q2qPKUOblSQW1EAYBTk+vUD71nIvAG+QNFFuDdYreolzG5RWha0IQhCFpCErAzuy4TnAHp9akpSgihP4IcR7/Kji/XWI+lrypekS1OlCSeuPLk1o3FHTzNk4nfoDTy1tR0Q43N7KV/Ytgq+nUk1OitUvPDzSl5va7vdLMxIuSylSn1LWCSkAJ7HHQAfiiOP2PgdqOXriLctY31M+3wXQWlLeW488hCsoT5hhIPqM+/3qxvvA3V1o1JPlaEu7UeBM3DAkKYcQhRyW1YHmA/yqTNKK4ZpHgYq28OtQ2e4z2jdryhsKdaBLbPLVvQOvU+YdT/wr5wM4aat0LqWUu6zYpszjSgWY76lBxzI2q2kDsAfzXdKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClM18zQfaVhL9qmxaf2i9XeDBUoZSh55KVEe4T3NYJHFbQy+2prePuoj/eKDeM0zWnt8StGOfLqe1fzISP99XLevdJOfLqey/zNbH+80Gz5pmsG1qvTz391frUv/ZmNn/Orxq7257+6uERf+y8k/wCdBkM0qgmUwr5Xmz9lCvYdQey0n+aCpSvOaZoPVK+Zpmg+0pmlApSlApSlApSlApSlApSlApSlApSlApSlB5Nco4+8SHND2RmJaVJ/Wp4PKURkMoHdePfrgfz7V1VRxUNfidmOSuKslpaiURYzLSBnsCnef6qNBy+4TZVxmOy58h2RJdUVOOuqKlKJ9STVvSlEKUpQKUpQekuLR8q1J+xxVVM2Uj5ZL6fs4RVClBft3m6Nf3Vymo/2X1D/ADq7a1XqJr+6v12R/szHB/nWFpQbK1r3VzWNmqL309DOcI/qqt00Vx21XYpSE3WR+swMje3IxzAPXasdc/fIrk1KD9DNJait+qrDFu9od5kV9OcH5kK9UqHoQazIqLvwi3t9F5vVkUsmM4wJaEHslSVBJI+4UPwKlCDRXqlfBX2gUpSgUpSgUpSgUpSgUpSgUpSgUpSgt1moU/EQvfxbvP0DI/8AVJqabhqEfHpe/izqD6ONj/1SKDQKUronAqLCf1nIkTklaoNukTI6EtB1SnUJ8u1B6KUASoD3SKI0GRFkRtniWHWeYncjmIKdw9xnuKymotPP2OJZZD7zbgukNM1tKM5QkqUkA59fKa6fN1JbLxo7Usa4X3UWoUFjmsmZbxiG/uGxfMCzsST5SOg61lnbdGcg2GVFbauGpbfpaM9b7a6jKF+ZZW5jGFqSDkI9cZ64xQcv0xE0W3avG6puN1dlFakpt1uZSlQA7KU4vpg+w61dzoOgrla5LtluV1tNxYbU4mNc0JdbfIGdqVtjKVfcVkNHyUWXQ161gmDGuF7NwRDbXKaDiIoUkrU7s7ZJ8oJ6Cqt7np1pw0uV/u8OFHvNsmssolxmUs+KQ4FZQoJGCpO3dn2oOYVkr7ZJ1jdiN3FtLa5UVuY0EqCstuDKT07dPSuj6yusXQM+Npq22C0yWWYrLk5+fFDrkxa0JWrzHqlIyANuMYPWtmu1jtWqOJ8RMxhLFptWl2JpivvFA2oaSUtrX3AG9OT7A0HAKV2bUFrs900ld3pyNFW+4w2Q/BcsszBe2nzNLbKjuJTnB75FWEjRVruPEDS4t7KY+nbtBauLoDh2stoSTIBUSSMFCu56ZoOUUq6urkZ25y3IDPIhqdWWWtxOxGTtGT1OBirWg7d8Jif+ftzX+23KH5cb/wCFSzQain8JSf8AnZel+0ID8rH/AAqVKDRVYV6ryK9CgUpSgUpSgUpSgUpSgUpSgUpSgUpSgsXT0qDfGdzm8UtRq9pRT+Egf5VON3tUEeKiy5xJ1MT6XB4fhZH+VEatV1arjMtNxYn22Q5GmMK3tutnCkmrWlBtGote6i1BbvAXKckxFKCltMsNshxQ7FewDd/NWS9VXhd0tVx8YpMy2NNsRHEJCS2hv5R0HXue/f1rCUoOtaNjayeYl6h0v+k3dNzUoXK0IShY+Y45kc4GD1IKfc9utede2zW9x04uTqC227Tljgf2jNvbSiIhxw4B2NZKlrxk9frj2rlLTrjStzS1IV7pODXp2Q88pKnnVuFPbeoqx+aDp8jUE+PBZj3Ww2O/S7Sy2w1LkZLrOEghtaUrAc2nIAIPynPrXyFdNZXPVUvVjNvjynWGfAzGlLQW5KUMhLiNu7KyUp3EJzgn7VpTGp57ZedWvfKXuKXsBJClDapZwPMrHYnqD1qnbNTXW2WmTbYkhIhyCVKQtpK9qinaVJJBKSR0yPYewoOg3+2XFVrdtlh0LDtRuG0yHxNEpxASnm43KVhlJHm64yB3qlF1DebLwykQHtPhwsJkQGrsJAV4dt5wcxO0Z7lCkhWQOp/nDTeJ94dvHjYbESK2HQ8GUN43KDfLSVLTtUohJIBz6n3NWF21/eLrYJFplIiCPIcLjim2yhSjzFOdgdvzKPXbnGBnoKDUqUpQd8+ElH/13qBftHaT+VH/AIVKBs1Gf4R0Zk6lX7Jjp/Jc/wCFSXb9KKuE9q9iqae1VBQKUpQKUpQKUpQKUpQKUpQKUpQKUpQWDvaocfEPpp+ycQJc7lnwVzPiGlgdN+AFp++ev8ipkOdq1zWGm7Zqm0OW28xw9HX1SR0U2r0Uk+hoIFUrt2ovh9u0eQpViucWVHJO1EnLbg9hkAg/fp9q113gjrFHZmEr7SB/mKI5nSuhOcHdZo7W9lX+zJR/matnOE+tUf8A5MVD/VkNH/8AtQaNStvc4aaxb+axST/sqQr/AHGrZzQOrG/m0/cf4ZJ/3UGs0rPL0ZqZHzWG5j/uyv8AhVBel9QI+ayXMf8AdV/8KDEUq/csl2b/ALy2Tkf7UdY/yq2chymv7yO8j/aQRQUaU2r/AGq/Fb7oDhdqDVsxomK7BtmQXJb6Ckbf9QHqo/0+tB174Tba4zYL3cVpIRKkNtIJ9eWkkn8r/pUgG6wel7LD09ZIlrtjfLixkbEA9SfUk+5JyT96ziKKuE9q9iqaTXsGg+0r5mmaD7SvmaZoPtK+Zpmg+0r5mmaD7SvmaZoPtK+Zr7mgUpSgsHDVu52qopVUVqoLdwVbLRmrtdUVCgtFIrwW6uimvJRQWpbpy6udlNlBacunLq62U2UFuG6qJR9KqhFekpoPKGUbgooSVe+KvWh0qgmq6D0oLpurhB6VZoVVZK6C6Cq9hVWocr7zKC53031bcynMoLnfTfVtzKcygud9N9W3MpzKC53031bcynMoLrfTfVrzK+hygut1fQoVbBdegqguM19zVJKq95oPWxP7R+K+bE/tH4r1Sg88tH7U/inLR+xP4r1VJUhlK9inEhXbBNSZiP0e+Wj9ifxTlo/Yn8V6JA7mgOe1UeeUj9ifxTlN/sT+K9UoPPKb/Yn8U5Tf7E/ivVKDzym/2J/FOWj9ifxXqlB55aP2J/FOWj9qfxXqlB82J/aPxTYn9o/FfaUHzan9optT+0V9pkYznpQfNqf2im1P7RX3I9xSg+bU/tFNqf2ivtCQO9B82p/aKbU/tFfaUHzan9optT+0V9pQfNqf2im1P7RX2lB82p9hXxSEkdhXqlBaqBQrBr1ur5KOFp+1ec0F3SlKDy4opbUoAkgdhWh3B2THmlSxheQRu9RW/VSejsvKSXm0LKexUM4rl+09ffzaVjnf5tWd1p8bvHG0zaNiWkcQYk+46QtbMNpT8hybH3pO7aU7uu/b12+9a9Oj6k0fbmIEWY/y3fESULiRFyUpdyOXHG7cQjv1P5FdXlyWIcVyRKdQyw0kqWtZwEgepNfIkyNM5nhX23eWrYvYrO1WAcH+CK6POvxWK7uM8zs65W7qHWrV8ntpiPPHwi1ssIjEIbcDQIBJT182RkKOe2KsndR6sFriJVIubb7svYJDdsW4ENbUlRcTyskg5A2gZ9+ma7RSvaNL1rO1BC/TV2BDklExJiqHJyWXFY2vKGOgA3ZB+la5Lverm7vNYYVIU62qQ2WVQCWm2koJaeCwPMpRx5RnuenSur14U80l5DSnEB1YJSgnqQO5AoNC0pedRydC3eRJjvu3eOHBGLrW3nEIynA2pJGenyj2rA2bVl9M9SVyZ02HGlRkSFKt5Q4ELZWVZQE7sb9oziuvVRaix2pL0hpltD72OYsJwpeBgZPrig5PB1BrV64WZLzL7TbjbalpXEVh0lagsKwg7SEgY6p/mrEXbV0+C+3OdubZYnRll9iIUjYXCFJCSgK6DBIwr7mu2U6UHHHbtqmBDQ1GbmRvNIcYCIKnTJe55CW19PIkp656d+/SsgbrrJMl54qfCXHZjKWTD3IaCG9zawQMnKun1rqdUG5cdyW9FbebVIaCVONhXmSFZwSPrg0Gj6OvV8kaLu0m6sTHZ0bfyiWPM9hGRsSUo3demCB7dax2kn7xK0HqWLLZkgtIcTCyypC1pU0FdBtTnzEjoPpXUKUHJ5EObp1+zXKDFuUp1VvfeeawteHy02lKcenUdj9avuFjV/syrlarzCk71tpmMOPO8xKlkYcTvGQnKhkD0BrpVKDXP1DU/wD+g2//APkj/wD5VhNfoeef0+7eIstdmClm4MQ97u1ZR5N2wblJBz6e1b9Vs3cIbr6mW5LKnUuFooCxkLAyU498daDkttnaht0WK00btDtC3pDkU+CVJeKd6eU0sK6pBBUeuOmOoxX293bVc39ZibJqitqW2uImGUpZQlP9ktDgHmUrp0BPf0xXW5EuPHdYbfebbW+vY0lSsFasZwPc4BNV6DkEa96oYtwaL1wTbw+y2ueq3HnsgtEqAa2+YBYSndg9/XvWX0BIv8rU7z2oHJrfPtrKkMqZKWtwUsE9sJVjaSM5830roMOXHmsB6I8280VFO9CsjIOCP4IIqvQctkXjWbTN0Stp5CLetMcvpjby8FO9X0Jx5trWOg9c+1Wx1LqqNALim5z7So81EV4QFb3nElPIUpAT5SRv7gA4rrdU1PNJeQ0pxAdWCUoJ6qA74FBzrTt61K5rwQ7imS5bXG+wjFCWvIk5USgeuRkKPtgV0mlKC0m/Oj7VTzXud86PtVLNBkaUpQYLXMG43HS82LZneXNWE7SF7CoBQKkhXpkZGfrXP3NLaq8PZwwJQRHcW5JaVP2l1kuAhgEKPUAE5J7eXPWuu0oOJxbDqG9sXhUZqSlC1XBhS35hKXwVkNthBOE7SM57Y+9Xl909qSOxMkFuS/EQt9xLLE3lKSSygNuZB7JKV+X69q7BSg5La7TquQzAWwXjHfVCleIXJxsSmOErSUE5J3dSOx+9Zvh1Yb9ao9yF5ceLjraUgLf5gW4M7nE+YkZyPb7Ct/pQcjY0lqiJa0ttOSllyFG8W0Z53POpcJdSlRV5SUYGRgVbP6L1GoNSEMv8/wALMZYT47K4gWQWklRV5sDIz1xke1dlpQcyGk77G1bbnoz8n9NaSyQrxalcvGS6lQUrzbifY/xiq+qbTqOTreNOgNrRb2FtEutySNzeDvBQV49R0CeuO/pXRqUHAo0HUY0tEuARcW2n0xmnEqnLK5Sy8DuHXLY2+U9u/wBM1tlq0nqFUllcl6RGYbYlqjNKmqX4dxSwWUrwfPtGe+R6V1HFKDj8bS2qRFVuZlpihTBkwVXMqXLUndzFpc3eQKJT0yM49Kuv9D74bibi009GlJEANgTyspShZ5oUrI3+U46jr6V1alBzTSNt1Jp6bMlXRuTMLq0sqSl/el1Snf70Ak4CUnr0T0GMdM1d6wst/la1tVxtHNXFa2BxKpJS0kBRKiUhSTnH+0D2IroFKDjydMavfmz1OpejsyFt7ktzjg4fCiUkrJGW8+3tgdK93TSeqmzEFvMlxMaY+WULmkoDRcBb3+cK6Jz1ySO2K69Sg5nxHiXW46lhQ7a1KdW5bXsBmWphDbu5IS4SCAdp64qzk6P1C5emJq9zzzUt5SHhIxsC46UJcxnsFgnHf6V1ilByeHo26y2rSxPgSGGo8pLklS7mp1Th5KkqWnrlIKiOgOT6gVmpVkvrug7HCfLz82M42ZrKZWxb6E5ynmZ79j364rfqUHGrXozVURdnRudZYZUTtalZ5CjIUsqV5hv3IIHZR+g71uWrbDeJ+oIDtrlONW+QEtXAB0pKUIVvCkDPc9UnHoa3OlByCPpHVnLuCJEiSXHXm960y8B4B8KKk+bKcN5H+H2waS9FaiExt2HzQ60iexGeVMJLCHCksk5VkjooepGR7V1+lBpfD633mzw/D3GO8W3nlKw7ICzHSEj/AFlEhSgTjJxn07VulKUFpO+dH2qliqszqtH2rxtoL3cn3H5puT7j81iS3Xzl0GX3J9x+abk+4/NYjl05dBl9yfcfmm5PuPzWI5dOXQZfcn3H5puT7j81iOXTl0GX3J9x+abk+4/NYjl05dBl9yfcfmm5PuPzWI5dOXQZfcn3H5puT7j81iOXTl0GX3J9x+abk+4/NYjl05dBl9yfcfmm5PuPzWI5dOXQZfcn3H5puT7j81iOXTl0GX3J9x+abk+4/NYjl05dBl9yfcfmm5PuPzWI5dOXQZfcn3H5puT7j81iOXTl0GX3J9x+a+g57Vh+XVxGWpo47pPpQZCvC3EJGSoVQkPFQ2oPT1NUEooPalFxzca94ohNVNtBSKPpTZVxtFNtBb7KbKuNoptFBb7KbKuNoptFBb7KbKuNoptFBb7KbKuNoptFBb7KbKuNoptFBb7KbKuNoptFBb7KbKuNoptFBb7KbKuNoptFBb7KbKuNoptFBb7KbKuNoptFBb7KbKuNoptFBb7K+bBVztFYnU14i2CyTbpPXsjRWi4s++OwH1JwB96ClfrzbbDBXMvE1iHGT3W6rGT7D3P0Fc2mce9FR5BabdnyUg45jUby/wDpEH+lRo1/rO6a0vbs+5vK5QUeRGCvIwj2A9/c+ta0hDjgUUNqUEjJwM4oJ06Q4iaY1W4GrPdGlySM+HdBbc/hKu/8ZrckjNfnPGkOxpDb8Z1bL7agpC0KKVJI7EEdjUwPh+4iu6xsjsG7OBV4gABa+xebPZePf0P8H1oOuJTXrFfR1r1igYrlmp+L0aw8SY+kF2h55156OyJIfCUjm7cHbj03e/pXU6h7x2uIs/H/APUy0XhCchyS2Fbd+xKFYz6Zx3oO98WuKcPh07bWn4Dk96YFq2NuhGxKcDJyD3J/oayfCvXsbiDYX7jFiLhqYfLC2VuBZHQEHIA75/pUaNZ6le4l8WbE9Cta5CQ1HSi3h5IK+nNWjerA9SMnHato+FG5uW3WV/09KBaU81zA0o/K40opI++FH/zaI6RrPjXA0rrxWm5dqecCFtJclB8JSgLCTnbj0CvevOoeNkCz8Q/9FRanZCxJajKlJfASFL2/4cem739K4VxahK1H8QFwtqF7VS5seIlXsShtFazqS33PT2prTLvvNTdJCW576XRhaSXVYz9cJB/mgkjbePdpfvV4hz7XIiR7a2644+HQvfsWEABOB1USAOvrWIY+JiyKk4fsNyRHz0cS4hSsf7PQf1rh8NcZOptZqnRXZcYtvhbbK9q8GS35gcHqPm7Y6VafrzlsEaFpm53CbCWTugT4iC2FE9g3uWlWfcAGglDxF42WbRlzbtogyrhOU0h5aG1BCWwoZSCTnrjBwB61jYfH+0zNNXW6R7NO5tu5RcYcWkBQcXtGFDPY+4rk3FmZBGuxKugutgvzcOItT0JAcQVmOgkAFSVJKSSjIJzt9Oudch3y83fQWqv1BtMmMhEfdPUyA7v56NqFOAZVkFR8xJGKCQv/AC8WFnRkS+zoUpp6W840zBbUlxatmMqJ6ADqP/GrDTnxFafud0ZiXK2zLYh5QQmQtaXEJyehVjBA+vWo53WyT16DsV6bZcct4U/GWtKSUtrDhV19shX9Kur/AC164n6Vt9gt0lcyJa49tU2EDLjqCrKhj08w6nHbrQSTicb4D3EN7SrlpeaU3LdhiVzwUqUgqAO3H+IpA7+tZrhHxOY4j/qvh7Y7A8Bys73Q5v37/YDGNn9aixIt8scWL0xGWTNgypshCh6rYDjg/JRXWfg476t/7p/86gknimKUopimKUoGKYpSgYpilKBimKUoPhHSuM/FLLej8NS2ySESJrTTmP24Ur/ekV2c9q0LjHppeqtC3K3RwDK2h5jPqtByB/PUfzQQZZQHX2m1KCEqUElR7DJ710TijjRWuTadMt/p7dsS0W5Lf98+pTYUVqX3IO4jb8v0rnb7TjLq2nkKbdQopUlQwUkdwRWbRqaU+qH+ttIuzcNISw3J9EjslS04WUj9u7FEbJxlt8Ri46fukWO1FevFpYnyWGkhKEuqBCilI7A4zj3zWT+GmW9G4qQ2midkiO824B+0J3D+qRXPtSX2fqS7u3K6uBchYCQEpCUoSBhKUpHQAD0rt3wraVfXc5mpZDZTHQ2Y0YqHzqJBUofQAY/k+1FShaOUivdeGhhIr3QKtJFsgSXS7JgxXnT3W40lRP8AJFXdKCzZtdvYdS6xBitup7LQylJH2IFemrdCZkGQzDjNvkklxLSQrr364zV1SgtDbYKpPiDCjGRu3c0tJ3Z984zmvsm3QZTvMlQ4zzmMbnGkqOPuRV1SgtWbbBZdU4zCjNuKBBUlpIJB75OK8t2q3tPJdbgREOpOQtLKQoH74q8pQW8qFFl48XGYfx25jYVj815FuhCMYwhxhHJyWuUnaT74xirqlBRZiRmGCwzHZbZPdtCAEn+O1eY0KLFJMWMwyT3LbYTn8VcUoLQW2CmQp9MKMH1EkuBpO4579cZ65Ne4kGJD3+EisMb8buU2E5x2zirilApSlApSlApSlApSlApSlAqi83uFVqEUHEuKnBmBqqQ7crW4m33ZXVatuW3j/rAdj9R/INcUl8D9bMSC21CjSEZxzG5KAn/0iD/SpqLbCu4qkYyfYUEX9E/D7Mdltv6rlNtx0kExoqipS/opWMAfbP8AFSTslqi2qAxDgsIYisJCG20DASBWQQylPpVUDFB9AwKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQf/2Q==",
+              "timing": 3924
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAE4QAAEDAwIEBAQEAwQGBggHAAECAwQABREGEgcTITEUIkFRCDJhcRWBkaEjQlIzcrHBFhckYnTRJjQ1goThJZKio7KztMMnNkNFg8Lw/8QAFwEBAQEBAAAAAAAAAAAAAAAAAAEEBf/EACARAQABAwMFAAAAAAAAAAAAAAADAQQRAhJBEyIx0fD/2gAMAwEAAhEDEQA/AJU0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUr4pQSkqUQEgZJPYVrzWuNKvXDwLWorSuXnaGkykEk+3fv9KDYqUJAGSenvWunXGlkz/BHUVpEvO3leLRuz7d+/0oNipQEEAg5B9axV51Da7KtCbrK8IheMPOtqDQ+7mNo/M0GVpWhca5X/4SX+TDf6GOlSHWl9wVJ6gissdX6es0SBGu98t0OUplv+G/ISlXVI6kE9KDZ6VTjSGZTCH4zrbzLg3IcbUFJUPcEd6wt31jpuzyxFut9tkSTnHKekoSofcE9PzoM9SqUSSxMjokRHm32HBlDjagpKh7gjvVWgUpSgUpSgUpSgUpSgUpSgUpXxatqSaAVBPcgV8DiD2UKxdyuMS3sGRcZTMZnITzHlhCcnsMmrCHqWxzZKI8O8W9+Q4cIbbkIUpX2ANBstKoR1k+U/lVegUpSgUpSg5vxwfeXZ7HaEvLjxLxdWIMtxB2nkqJKk59M4xWxy9C6YkWFVoXZYCYOwoCUspBT0xuCsZCvr3q81dp2DqqxP2u5pVyXMKStBwtpY6pWk+hBrT3dF6zkwjbJWvFqtqk8ta0W9CZKkdiOZu749cZoNEN9uT/AAPhwVTXShy8CyKnpVhS43NKd+fqkbc11xGgdKpsf4SLFb/BbNmCynd2xnd33fXOa9vaJsjuiRpUxiLSloNJSD5kkHIWD/Vu65961pOidaIifhydfu/hoTywo29Bk7O2Obnvj1xmgw3EGVJ0JwUMfTt4ellt1MNE5SwpbLalkEbh6pHlB7iui6f05bLfpxFubaEiO8yEvrePMVIyOqlk/MTmqdu0bZIWj06ZERL1p5ZbW295i5k5KlH+onrn3q1Vp66Wyyiz6YnpjRtnLRImrVIcjp7YQnpnHpuUcUHFY77sfhFxQsCXVvW6zTlx4a1HO1vmDyZ+mP3rs+idKWaHpOI2YsacqXHQ5JkvIDipSlJBKlE9wc9B6CseOGcCPw1naSgSXG/GgqfmOJ3rccKgStQ6ZzjFG9HajtMTwGl9UtwraE7W2ZUESFRx6htW4dPYKzig1TT8t7SH+tG1WQlUCzteMgtfMGFraUtSB9ARnFbTws0lY2dDW2SuHFnSrjHTJlyn20uLfW4NyskjqMntWa0Xo6HpmzyohdcnyZzinp0qQAVyVq7lX0x0ArXYWgtQ6fQ5C0hq3wNnKlKaiS4SZJj5OSEKJBx7A5oKHD5luwcT9WabtY2WZDLE5tgHKY7i8hSU+wPfFdQrWdEaRY0uzMcXLfuF0nOc6ZOf+d5XoMDoEgdAB2rZqBSlKBSlKBSlKBSlKBSlKBXh8ZaNe6HrQa7qMSTbT4ITi9uH/UuTzMf/AMvlx+9YKypu/wCKMeKGouTk7vFCDy+x+bl+f9K3ZbJB8vUV5DSyfloPrA/iCrqvDTYQPrXugUpSgUpVnKuDUeW3HVnepJWTg4Sn3/WgvKV8SQpIUOx6isdebmbd4fazzS6opxuI/wAj3/KgyVKw/wCLPqROU3FQUxiseZwjdt7/AMtJN3dYaQVsM7+SX1gvYG32SSOp/SgzFKxjd1C30thvBLpbwVdQA3vzj9q82u7iZbHpjrXJQ2MnqSCNoJ7ge+O3pQZWlYmJeUvxIrym0oLrxZWN+Q2QFHvjr2H61T/Gzvt6eQnMwZT/ABPl69c9Pbt7npQZqlY64XExJkdnlpKHCAVqURjJAHYH39cCqIvSeWpZZyEMuPKCVZI2Kxj8/wDKgy9KxJuziW0gtRy6twNp2yAUDKSrqrHTt7e1E3VxcqOyhhB5jYcUoObgOpHQgYPb6UGWpWB/H1+FLvhkBYXtKC4fKME5Pl+noCPrV7c7kYcVp5ttLgX3O4gAYznoCf2oMjSsS9dXmXZO5hostNJdC0unKgokD+Xp26nNW8m/LjtK3RkLdS7yyG3CpJ8m4YO3v6dhQZ6lYmZd1sLWhEcLUl5DIyo9dyN2egP2qpGuS3bkYjjSW/LkK3k7jgE46Y9ffPTtQZKlKUClKUClKUClKUClKUClKUCvC2kLWhakgqQcpPqK90oFeHWm3cc1tC8dtwzXulBRESOlxxaY7QW4CFqCBlQPfJ9a9OR2XdnMabXsOU7kg7ft7VUpQU+Q1zi7ykc0jBXtGce2aCOyltTYabCFd0hIwemO32AqpSgprjsuJWlbLakrOVApBCj7n37V8MZhXdls9AOqR2HUD8qq0oKbjDLjiFuNNrWjqlSkglP2PpRDDKFLUhpCVL6rISAVff3qpSgoCHGDKmRHZDSjko2DaT9q+qiRlKbUqOyVNgBBKBlOO2Paq1KC38DE5Zb8KxsKtxTyxgn3x71UeYZfQEPtNuJByAtIIB/OqlKDyWmyVEoTlQ2k47j2P6mqYiRw2Gww0GxnCQgYGe/Sq1KCi7FjvAh1hpYUQohSAckDAP6V9bjMNucxtlpLm3buSkA49s+1VaUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUCsVqXUNq0zbDcb7MRDhhYQXFJKvMewwATWVqOvxfXvZb7FZG1dXXFy3R9Ejan/wCJX6UHXtM8RdJ6nuf4fYry1LmFBcDQbWklI7nzJA9a2yoMcP3ndD8VdOPS1FCSY63CemG5DSSc/YOftXQdU6z19rTihc9NaRuK4LcR51ptppwM5DRwpSl9zkjt9e1ESmpUZ7Nr3iPpbRGoZGp4rr3IQlEKZKSk7HS4EEHHzDCiRn+nvWs2q68YLlZ42qLbdZ0qLIkFpCEOIVlQJz/CxgJyCO1FS+pUYuIvE3XEm42HS1tQbPepLDImBO0LU+s4ACuoSnsenXr9KwsfiFrvRt6vWmNU3F2U6YT6QsuBbjDhYUptxDg699vQ/tQS3pULNKa519MsWp342o5K0Q4aXXVyXlLWhJcSn+F3AUc9/ar22cSeIM3hzfH27yFMW+RGDkpZxJSHCoBKSB1BKRknr+tBMalQ5vfE3Vk3hlZJf43MZnN3GTFcfYXy1PIS20pO7bjON5Fe39YcT42jLTqtN3dbtDavCoUXUrU8sKVlTiVZ3ZII6+gH3oJh0qJerOMWrNUydP2vTkn8KflMtJeLSgguPqUR85+VPb19TnNYTVOtuIFu12Lbeb9Jjy2XGGnmockho+VPXCTjJHU/UnoKCZ9Kiw1r3iHr/iDMa0bKTGi29Snm4hWltCm0Kx/Ez1UVdMjt19K0KNxH1i+9d1r1FdUYZWtKBKVhs709uvpkignJSoWWvXGvndBXm5NakkmPFlx0OOOOqU/lQXgIJ7J6dffpWYncbdV/6ubYwzMCbq7JeZenbE8wtoS2U46YB/idTjPQUEu6VFTRWoeKds1Zb23H5t+gulC32885stqPXCyOhHXqDj71rWktV8QtQazcs9l1FNclvh9ttEmUrYkBKsnrnBABI9jigmTPlIgwZMt0KLbDanVBPchIJOPr0rQuHXFuw69vT9ss8W5MyGY5kqVKbQlJSFJTgbVk5yoelXWnoF7tfCR+JqqUqVeW4crnvF0uFWS4U+Y9/KUj8qiZwr1TK0c7qO624I8aLYWmVLGQlSn2Rux64GT96CdtKhrI1hxLb0Au/P31xVrnSw2h5MgJfbWnOQkJwUpODkfQHFdv+GW93O/aBmSr1PkzpKbi42l2Q4VqCQ22QMn0yT+tB1ulKUClKUClKUClKUCuDcYeD+o9ea0VdY1xtjMFDLbDLby3AtKRknOEEfMVetd5rXdW6109pFDStQ3RmGp0EtoIKlqA9QlIJx9cUHE9c/DzMnXliRpa4xmIqWEIWJz7q3OYnIyDtV0xtwM9MVW1XwDvE+9G9WW+xodxkgOSUErSEvFP8QoWkZ2k5OCB3rqll4oaOvUWa/br006mGwuS8gtrStLaBlSgggE4A9AaxrPGrQTsWRIRfP4TG3eVRXgfMcAAFOT2Pb2ojT9I/D9Gt+nb3Evd1MibcmQyHGEYSxhYWCM9VHclPt0GPrWqo+HDUJWmG7qaJ+FJc3gBLhIPqoN/LnH1rqXEziFbYNkgot+qoNnfnoQ+HnIy33UsLTkLQ2kZCj0xuHv7VkuHerNPP6TV4bVf4wi3NlUqZMPLcSnqdywQCB6ZPt3orRtdcA2Lnb7OdN3IQ7hbo6I298Ha8EnIWSnqlWSeoB9Pasdpv4fpsf8AFJ+oLyzOur0R9mMAVlCXVtqQFrWobjjPbFdH/wBcOhfBSZab80pmOtLbm1lwqyrOCE7ckdO4GK0niVx4gwLFBlaFlRZ0l6QptxMqK6EhCU5JGdvXJT+tEYnSfArUFnsWqIMi42pbl1hJjMqQtzCVBxKsqyjtgema+2TgXqCBoLU1jduNqVJujsRbS0qc2JDSlFW7yZ67hjANX7/Ei66m4FyL7EvMOz3mLJDM11DDgQ2CshKU9FnJCmzkZ9e3pm+DGtkI4czLpq7VMac3GlloylpWjYNqSEEqSkrV1z0B70HEuKehbhoDQVltl1kxZDz9zkyUqjFRSElplODuA65SazWh+Cs7WWjrDcY9+MS2SULcfjuBS9riXVp3ITkJ6pA7/XvXbI2t+G2vZ8e2uyLXdJKVHkNToh+Y99nMTjJx6d692XiZw+iTTp+13CNCVGLqfDoiLYaa2blL67QkdlH6/nQaXxB+H6NeGbarTM5uC9DjIiqRISSl4JzhZI6hXU56HP0rWJHw33iPeY7tru9vXDaLSiZBWlxSgAV9AkgDdnHXtiu86Q13pvV7jzenro1LdZG5be1SFgds7VAEj61d6q1XY9KRESdQXFmE04cI35Klkd9qRkn8hRURtfxtNW7iNeF228XK1pTLcRKjtsHdjd5w0tKsEHrgKxj61h+Fmjbhre73W32nY0PCKJefJ2I86cBRAPU4Pp6Vm/iJvFsvGto06wuRHoEqC08HWWkgrUVLBKjjdnoAQe2K6XoviEjT3Eq8aZTbbPa9NW8SXXXIsVQdKWkFW5RBO44HtmiKVr4FagicPr5YXLjajKnyo77biVubEhvdkHyZz5hjpX2P8PUp7QX4XPucRu9MTXZMd9ncpooWhtJQvIB7t5yO31rp8Di1oy4Wm53KJdlLhW1LapTnhXRywtW1PQpycnp0zVkeNugRFTIN6XyVLLYV4N/5gASPk9iKK53pL4fbqjUUO4auvrMuPEUhSWmFOOKcCTkJKlgbU/bP5VkOGHBe+aT4jR9QTp9seiNl4ltlSys70KSO6QP5h610BfF3QyPA8y/sI8YjmNbm1jCckZV5fJ1H82PftWS1XxC0tpRTSL5d2I7rqQtDaQpxZSeytqQTj60GevMVc6zzojSkpcfYcaSVdgVJIGf1qPejfh5uEMXiPqG5QVRp0Ex21xCtS23OY2tKsKSAR5Dnr6127SOttPavQ8dPXNmYpnBcQApC0g+pSoA4+tbFQRdPw0XRMCXtvcJyZzEiPkLQ3s/mK+hO7tgDp9a7DwR0RP0DpKTarpIiyH3Zi5IVGKikJKEJx5gDnymug0oFKUoFKUoFKUoFKUoFRG+IxCI/GmLI1AzIesymo6tjZwVsj50pPvnd+tS5rnuvNWcO27l+C6zeguzGdqgxJiLd2bgCMEIIGQR2NBG6G/oqZfL4vStsv8ZX4fMVHC30FttPhl7twwVbe/8AMe4q++G3SFj1ffbxH1FBExliMlxtJcWjaoqxnykelSot2j9OW2JKjW+yW+MxKbLL6WmEp5qCMFKvcYPavWn9J2DTrzr1jtEOA66kIcUw2ElQznBoiH3EiDEsXGKfHv0Rw2lpaUtNkLWPDhsJaxhaSoAAD5h271iW49tlWHUDmmo17LrTYXIWSkMCPzU9FJGVDrtOCo9u5xmptX/TFj1Dyvxy0wp5a+QvtBZT9iaqWfT1nssJyJabZDiRnf7RtllKUr9PN7/nQQOel2FzRbEWPZpKb+0+Vv3HnktqbOcJ2dh6fp3rPvQUL4DxpyYyFPN6gcbU+EDclBjo8u7vjOOnvUk353Clm+vaScjWdM2RISl2KmLhCnh0SkqCdu4ZIxnoTjvW8wdK2GDZ3rVEtEFq2PqK3IoZHLWo46lPYnoP0FBF+1Xi2S/hivtrhMFu4wHmFzXOWEhwuSSUHcOqiEpA69sAVzx1marhhEebSs29F3fS6R8ocLLOzP5BdTaY0Npdi2y7ezYbc3CllKn2UsAJdKTlO4euD1FXEDSWn4FqkWyHZoLVukK3vRksp5a1YAyU9ieg/ShhCi/rsNzuunWOHtuuMW4cttt4Or3Kck5GFI6nHX16Dt0FZjh7a4t446fh94YblR3Zc3mtrHlUQh0/4gGpd2XRmmrHKEm0WO3Q5IBAdaYSFD7HuK8wdFaagXf8Uh2OAxcdyl+IQ0AvKgQo5+oJ/Wgi/wDCiojie6Aeht7uR7+ZFZj4rWXW9f2GVcG3l2hUVKcIOM7XCXAk9grBT+1SJsejNN2GaZlmskGFKKCjmsNBKtpxkZ9ugrI3mz229xPC3iDGmx87uW+2FgH36+tBAvX72npOoVPaPgS4NoW0nltSiSoq7KIyT0yPc9j9ql3r3RliZ0jqi8QbRHTen7ZJKpKEneoqaUD+tbDN0BpKcWDL07bHeQ0GW9zCfIgZwkfTqf1rZtqdm3A24xj0xRUDNJXiHC0Dri2vrWJVwZichIQSDsfClZI6DoR3rAO//lmN/wAY7/8AA3U8E6F0qlmY0jT9sQ3LAS+lMdIDgCgoA4HbIB/IVpGqEcItMXBmz3yBZo0hRDgZ8KVBG7A3KwCE5wO/tREaNdW2HC0roiRFjttPS7e44+tI6uKDywCfrjpXy+7Y2sbZI1Qy69CdgQ3cKSpW9sxkBJACkkgH2UOxqXdysHD51EOFcomnyIrYRHZeU2C2hR3AJBPQHOfzrNXPSGnrpCiRLjZYEmNEQG46HWQoNJAACU+wwB0+lBHf4bk2J3iJIcske885LLpU4ooTHS0SMBSfModcYBUeo7nFSlrGWKwWmwR1sWS2xIDSzlSY7QRuP1x3rJ0UpSlApSlApSlApSlApSlAqF/xIqKOMtwUBuKW45wPX+GmpoVGTjbwt1hqfiVMutktYfgOoZSh7xLSOqUJB6KUD0I9qCtb+N2rYGt02zVdoahRpiwGmVslDrCV9G1ZPzDOM5Hv27Vb8N+MWrr8dTi4yYqvAWKVPY2x0pw63t2k+46npVzaeD+s75xDZumuZ7T8SEtITJ5iVKkIR1QEpHYZ6nOO571g7DwY1/Yp99bgCGmPJt0mIXg6hXiEKHRtIJBSVEJGTgDr1oirp3jzqtOn75OuDcac8wWWo4DIQhpSyvK17epHlxj3IqnYuMnE+4oVMgW+NcoyFYWhqGVY/JJ3CqekuE3Ee02m6oiRGIEp1bKgl6Qy4iQ2kObkEAqSeqknChjp9KtGuDPES539qS9At9nWgjElh1plCSP5glnrn7AUHjVd3Ef4gWFt2y3tvKnQ1FRaOQpxLalEjON2VHqRmsjpLjbr65uXVKGolwVHt70kJ5SGw0EYJcP9QAz5fUkVldV8LNYzeMbd7j2/xVtTLiOKlmQ0krS2lsLVtKt3dKumKseGXCfWlkk6iXc7OGUy7HLhsnxTKtzq0gJT0WcZ9z0oM/oDjvcZWldSzdRRI78q1soeZLA5YdK1hASodceYp6j0zWqHjpxDSy3d1QoItbrpQgeFPLUR3SFZ3H9ayXDngtqX8L1RbdRw021FwhIbjvF5t0c1LiVpyEKJxlNYe28KOKtvKbbAbbhxEvbxKZlNI6/1b0nm4+n7UGz8Q+PV8hR7OmxW1uCuXDTKdXLbKlBRKklKQcDAKT1Pf6VcaP4rcQUOuv6jsaZNrTDfkB9qMpG4obUtIC0kp6kY7V61xw74inwLNvkRdRxW4iG3fxEtPK53UrUOcOgJPQg5wBWG4c8H+IFnkXGd4lqzPORHm22USQS44pJCM7MpABIOc+nagxtu438Rr5cHRZosJ4p83hmY24gfTJ3H8qkRoi/Xa8cPWLteoYg3UtOl1jlqQEqSVAeVXUZwD+dRuvPCLiTeJDLcyzWpKkq6y2DGZ3fVRRhSv0JqSfD/AE9cLJw/g2S9TfFzW2VtuPBRUAFE4AJ6kJBA/Kg4bw34xauvp1R+IyYq/AWKVPY2x0pw63t2k+46npWvscddbrsE2WqXD5zUlhpJ8KnG1aXSen/cTV7YeDHECxT763BENMeTbpMQvBxCvEIUOjaQSCkqISMnAHXrWFj8FtfI09OiqsYD7sphxCfGMdUpS8FHO/Hdaf1oM5L44a8i6Vs9yVHghuQ88gyltpIfKCPKEAjaAFDr65+la/xl1a3fbppq9/hNv5020tyHd6Cf4gddQQeoynydM56Vsd74Ta0k8MdM2hizhVwhy5br7XimRsSvZtOd+DnB7Gsfqng7rmdbdMtRbKFuQ7Z4d8eLYGxzxD68dV9fKtJyOnWg03iuu7O8S5blz5HjVqZUzygAkNlCS0MD/c25qcFjE4WWALuWzcvDt+KLfy83aN+PpuzUduL3B7U941BFvenmmZLi4rCHmFPIQttxtCU9CohJHlHr713zRTd4a0rbUalWHLyGh4pQKSCvJ/p6e3ais1SlKBSlKBSlKBSlKBSlKBSlKBVrcbhCtkcv3GXHiMA45j7gbT+pNXVRM+JB5c3jBAt9+lvRbGhpgJcSnIbbUf4iwPU5z79hQbZxM4z6h05xHesloRa3raDHLbjjSlqUHEIUTuCwD8xx0rtkLV2m50oxoV/tMiSApRaamNrXhIJUcA56AEn2xUHNRsWqLrsR9PXJ652pp5lDEl4EKUkBPTsOgOQOg6CszwrmRrZxJfeuD7cZpLE5BW6oJAUWXABk+pPSiJho1xpNxDim9TWRSW07lkT2iEjIGT5ugyQPuRVZnV+m3m2Vs6gtDiHneQ0pMxshbnTyJOeqvMnoOvUe9QMsn/Zeof8Agkf/AFLNdl+HvhvbdWWEXyfNntyLbdCWGWlpDeUpaXkgg9ScA4PYCgk47eLYzcUQHbjDROWMpjqeSHFDGeic5PStE4kcTbbadEXS5aUvNluN0ihpSGUSEPeVTqEKJShWcYV398VFKxSLVO1Hd5+s7tdIM4Bx9l6Ijc4ZO7OCe46/b7isRYf+ytSf8Aj/AOqj0EsuC/E93VGm5tx1dKtVvW3MEZkhXISvyBWPOo5PU9quOOWs9QaVtdrkaXNr2SlrDj0t5tPYApCApQBzk5Iz2qKdoiWGRoq8PXK8SGLxHcSqBASklt3dgLUenfA9x2Hetg1BJmSOBulxMWtbbV0ktxys5/hhCeg+gUVUG96m48avtLtuaQzYVreiIedLYLyd5UoHCkuY9O3XByPStst/E7VSeKztouy9Ox7I3JcacCpjSVNtpz5s8zO7p1GPyFRnvP8A1Oxf8Gf/AJ7tb05EYuHxGSYctHMjSL86y6jJG5KnFAjI6joT2oO06P49RtQ67jafdtDMOO+84yicqeFJJAVswNgB3EAAZ7qHetr4j6nukGfHtVjuWnrUt1O92ddJqElvr8qGicqJ75PSor6BFmtXF2Ob0UsWyFLeUkrUrCFthZa7dThYR9/WsTbkQr3crzI1TcnI81SVuocdWrzO5Od2EKJ+3T7ignzAfTJhMvIfZkBaAeaycoWfUp6np+da5dOIOmLVqdnT0+6tM3Z0pCWShRAKvlBUBgE5HQn1Fc8+FtMZjTl2jwb2u5x0PIXyzGW0mOpQOQCr5s4Hbtj61caxicMHOLcNy/SVo1PvZPKBXylOdOXzMDGcbfUdMZorstYZeq9PNzPCOX21JlZxyTLbC8+23Oa1/jfMmQeFWopFuUtEgMBO5HcJUtKVkf8AdKqiJY7PpCXpByXdtRyIN98VsTGTGLqeVgebp3Pfrn07UE7Zk2LBiqkzZLMeOkZLrqwhI/M9KtrTe7VeErVaLnCnBHzGM+l3b99pNQ04jTVu23RVqVe5M7TzcTKJSmVN5/jrSo7CckpSlIH0H1qvp4W/TvGuwtcPrtJuUFyQw2XVJKSsLIDiD0GRjPXHT8s0EuYOrtNz5JjwdQWiTICVKLTMxtasJGScA5wAMmrmHf7POhvS4V1gSIrKdzrzUhC0IHupQOAPvUH+G9oYvmsJcKW4+hkw5jh5K9hJS0tQBPtkDI9a+cOLWm6xNXockyWURrG/L2subQ6ptbZSlY9U5OcURNt7VFgYt6J718tbcFa+WiQuW2G1LxnaFZwTgE4r5/pVp/wseT+O2vw0lRSy74tvY6QcEJOcEg98VBCK84dB3NgrPKTcoiwnPQEtSAT+wrJ6ks7EXhvo66pdfXImrmtrStzKEJbcTtCB6fMon3JoJyyr1a4b0dmXcoTDskZZQ4+lKnR7pBPXuO1fbrebZZ2kuXa4w4LavlVJfS2D9ioioM67twhWPRssSZLzsy2cxQec3BvDq0hKP6U4HarnUc1eoNdQv9LZj6IxiRklxSynagsIUCDtVgEnJO09yaCbKdQ2VVsduSbvbzb2scyUJKOUjJwMrzgdSPX1q3Z1dpt+I7LZ1BaHIrSkoceTMbKEKV8oKs4BODgfSoaQI9ug6c1a3a9RqkcyMEqhIjubVoD7eFlwhIyOnXaO/pmsdabQxJ4YX+6OLe58OdFbbQFkIwsLySn1PQdaCWXFbihC0JZrfOjMxrs5Nd2oZRLDZLe0nmDAVlOQB2x171mOF+tWNeaVZu7TLUV4rWh2Kl8OqZIUQNxwMZAB6gdDURJkRqRwOt9xdSpcuLfXYTThUfIypkOFOM4+br2rv/wquWb/AEAWzb3EG7B0uXBAUolJKlhskHoMpT6e1B2mlKUUrVtcaB09rZthOoIXOcYzy3kLKFpB7jI9Poa2mubcU+Ltn4fymYL0Z6fc3G+byGlBIQknAKlHtnB6YNBRl8DdEPz2pYhSGFNJbCUMvlKBsAAOPfpkn1OTV8/wh0VI1C7eVWsGW6pbi0hwlsrVnKtnbOTn71oY43WfWulNTWhyC/bLg7aZZZStYcQ4QyskBQAwcAnqPSuW8CdYM6Ha1RepDHii3GZQhgObC4pToGAcH0ye3pRHeo3AfRUdmU02xP2SWw05mSflC0r6dPdArctC6NtOiLU9brEh5EZ14yFB1zedxSlPf7JFc9tnHi2OaMe1Dd7W9CR4kxYsZt4POSFBIUojypAAyOpqz0l8RNkvN5ZgXO1yLWl9YbbfLodQCTgbugKR9etFbvL4T6NlalF9dtCPHFZdUkKPKWs/zFHbPr9+tYSLwJ0THZlstNTtspoMuAyiSUhaV9OnuhNWmruPWndPanVZ0xZU3kO8qVIaICGjnzY9VEevbtXB+DN0iRONLF0kvhuA2Zshbqs4CAy6c/pREiG+Behk29MRVvfcQl7nBan1b84AKdwwdvQdKzmpuGWmdRWO22iXDWzb7cSY7UZwthORg/euZy/iZtDc9TcWwTXoYOA8p5KFEe+zB/xrO6v45wrLY7HeLZZ3Lnbbohza4ZAZU04ggKbUnarr196KvpHAbRT7cZDjE/bHb5SMST8u5Svb3UayrfCPSyNYf6TJal/inizN3c87OYVbvl9s+lahqfj9Es6rMiHYnJ67jBallKZQQWlLJHL+Q5Ix36V1PUmpYmmdKvXy+gx2WW0qcbQd6t5wAhPbJycen5UGsX3g5oy93xd2l21aJbjnNd5LykJcV7lIOMn6YqlqTgtovUF2euMu3usyXlbnfDPFtK1eqintk/StIX8S9pMCQ63YpXiUOpS0wt8J5iDnKtwScEdOn1710zhRrlPEDTTt3RAMANyVR+UXuZnalJznA/q7Y9KDN6V01adK2lFtsUNEWKk7ikEkqUe6lE9SfvWEvPDPTF51cxqWfBUu5tKQvcHCELUjG0qT6kYH6Cud6k+I+z2y7vw7bZpNwaZWWy+Xg0lRBwSkYJI++KwXELjS9qPhw7I0xDuttkCUhp+U26U+H7KHmR3Cuo64/OgkfLjMzIrsaU0h6O6kocbWMpUkjBBHtXMl8BtBKll/8MkJSTnkiUvZ9u+f3rmfCri3drHw6vlxvsa4Xvws5sIkyZSvNzEgcsKUlWNu3dj/AH/T12Wz/EXDucm1xUafdRKmTBGUjxWQ0klASvOzrkqV06fL360HTdR8O9L6gsUS0XC1tCHDTtjBnLamB/ukfv7+tWWi+Fek9Hz/AB1ot6jNAKUvvuFxSAe+3PQfcDNaVo3j01qV27oTp5cb8Ptr9xJMwL38oA7PkGM57+ntX3SvxA2u7QrvMulpdtsa3spdymQHlOqUoJCEjanr196DZ9P8G9J2G6LuFvZmCStp1klcgqG1xJSrp9ia+WHg1pKxIuaYDMwC4w1wX98gqy0sgqx06HyjrWixfiZtC5wRJ0/NaiFWOcl5K1Ae+zA/xrS+PnEW+HW7SdPXO6222CEyplbEhxtEpKxv5oAx/Vs9eqD9gR2FHAjRSLe/CSxP5Dzrbyh4k53ICwnrj2cVV7P4NaSnWC1WZ9mYYVtU8qOBIIUC6QVZOOvUCtUu3Gx7SukdJyblp6S/KuURS1pelFtaS2rZuOUEnd82fr696q6x48t6aNk3aeXJ/E7WxchiYEcsObvJ8hzjb36faitlu/BnSV2hWuJMZmFm2sGNH2yCCEbirr06nJNXOouEekdQRbczcILm+DHRFaeadKHC2hISkKI+bAHrWiSPiMhRNRS7bM0+62zGedaU+mVuJ2bsYTs9SAO/rVxcOOtok8PFXCbEnwJk5x6KxHhvpU8nalOXAspAT8w64PX3oNutnCfRUSw3WyQYh5czY3McD5U9hKkrSkq/l6hJx0qnF4M6SjadnWVpmZ4GY82+6DIJUVIztwcdPmNc64LcT9HRLwLRGs021yrm6lK5kiUZJfd7J5ijggkn0GMmpG0Gj23hbpWDpKTpoQlyLVIfMlSH3SpQcwkbkqGCOiR2+vvV5oPh/YdCiaNPsPNmYUF4uulZO3dtAz2xuP61tlKBSlKBUWfiP03ebdxFj6riwXZluWlk7kI3pbWjptV0OM4BBPvUpqUEOdMou+ol6luTWkITMQW6W47OeadU42eQsAIWpWCsnHYeprn9q0tOuFkvM5DD6VW5DThQWz50qXsOPqMg/rX6DUomEGm7NeNRcM4rVvt8h1ywy3lPNNtHeWnwkheMZVhTagcdgR6VeyWNQcU73YoMHTbUDwjKIq348dSEBIIytxR6DHoP071NilBD5y0ak4d8Wp62NOfjXjXHW4hfZUtt1LishQV2CvQ/n961HQ2mrpedav2tEVUeVIYmNpBQUoC+Q5hOewGelTvpQQPguXixQZunJmmXJEhyQlRafacyFDHTanBV26dcdeldk1ho6fL+Hdtc2yRLXc4T/j0w4TSk7EE7TuBJO4pO49fQe1SMpRUI+CGmpeoOJllanMP+EhHxKy4k4CW/MlPX0KiB+dSX4+6en6l4azodoaU/MbcbfSyn5nAk9QPc4JOPpXRaUEEpitTu8Pk2h+wNs2u3SwVSTDKJHNXuOwqPU+vp6DPpUh/hSZcZ4ay0vNrbV+JOnC0kHHLbrs1KCDWpFyoV5lSmtLXOyX0PKKXYy1oZyT1PKUgnBGegVjr2xXQrfY9X6h4Hakbn2PlzlyWH2NkRLD8pCTlRKUgbsDscZPXv0qR+qb01p3T0+7yGXn2obRdU2ynctWPQCtQ4TcT4vEQXARrZJgrh7dxcUFpUFZxhQ9enaiIu22ddmuF180w7Z5CGEy0Ty+ppYUHMto5eMY7An36V3L4Wbak8OLl4mIkP/iTuwut+YfwmsYyPeu50oqDujrdqHS951LDc0/NefctE2G6FIKA0go6uZIwQNvT3yMd6sNH6Su9/sGomLdDkOSY7bMkMhB3OhKiCEj1OFZx9KnjWj6b4qaS1HqBuy2i4OvXFe8JbMdxAO0Eq6kY7A0RF+23y+vWS0aZa0JCmvwHFEF+3uKccKifmAI9+p+g9q2b4htJX3Zpe5C0BDDNpaiSG4LRLUZ1KlKKcDOE+fA6+ldb0lxogak16dMs2aewsrcQl9zHQoBJ3J7pHT39q6vQQ94pN37VmgdGXs2WS23FZdhOJabUrYElISojGQFBJOe1apxGN3uQ0uZlmlQ/D2ONGaCgVF1CCsBzGPLnr0Ppg+tTtpRUMdCwHl/EEwX4jimDdnySts7SMr9xit/8Ail0bcZEm032zwVPwozJZfbYbzyzu3BRSPQ5IJ+gzUj6UEQeH7941XxAtr8fR0J0IW0H5Utp1YZSk5K924JBx2GPbAqX1KUClKUClKUCo0/Ebd9csaq5NmfuLFiZZQQu3qUAFkZVzCjqD7A+mCKktXIOIvByRqnVz+oLXqWTaZT7aELShsn5UhIwUqSewoOT8PtVajsi7ldkaubv0OHAedXEXKdUoL24QSh1IJAURkpz96wTNx4g3vS911sNVyERoMgNuNCattRUSPlbT5ceYdOnrXaNBcAbbp+bIl3q5uXVx5h2OWw1ykbXElKiepJOCfXp3rXJPwyIM5fhdTLbglWUtri7lgexIUAT9cURyvWXEvU17j2OSq7T4shuGWXzFfWyl5SXV4WUpIGSCAftWT1PrDWeltX2p57UkuSoxIknlpWoNFCm0nYpBJB6dCT1Peurat+HiNc02lmy3dMCNBieHIdj81bq96lqcJCh1O7tj0r1rbgK/qW6w5iNQNRxHhR4mwxCrcWkBO7O8d8dqDe+N2q5mjuH0y5WvAnLWhhlwjIbKj82PXABx9cVGd+4cQLZpO3a4VquSqNLklpDXjVrWFAq+Zs+XHlPTr6dKl3rLTcDVunJdmuqVGNISBuQcKQoHIUn6giuFRvhkSJifE6mWuEFZ2Ii7Vke2SogH64oOfcV9f3+5zdP3GNdJ8Ay7Qy46zFkraQXN7iVKCQfUp/wrftSu694Z6avWoLvfWp8m7uNxowbdccREUrcsqShY2jypwMfSth4hcBW9S3OA7ars1bIUKC3Cajqjlw4QVHO7cO+6tw43tWxvhZche4r0qG0GshhQS4k70pC0k5GRnOD37etBG+7TtfW3hxDv8rVDzttvEkBCUzlmQ2tO/wDQHByAfbIq3n8RdUI0Zp2zxb3NZXI5r78pUhXMXl5SEguE5CRtPr6/StNuosLUAt2l+5SpKnQpK5LKWUtIwcjCVq3KJ29emMeueneNK8FUau4U6fXcJD1quzfNcbWW92WlrKkhScg/UdfWg5jxBv8ArGy3aLbpur1zFx4iEpftlwWpCkkqI3kEZWM4JIzgCsnY77qu4cYlWu36knsLduL7LXOfW602Mrx/DKsHA7Dt2roFx+GZtxMQW/UIZKGAl8uxivmO7lEqGFDaMFIx9O/Ws/p3ga/aOI7WqFX5p1CJjkrw4ikE7iry7t3+93xQcf4f661OJWpbbMvc+U07aJ5BdfUotuIZWtK0EnKTlPp71b6D1JrRemtSJsNxuEmYTHSQXlOOJQS4VFsEk7ugzjrjJ9K6vYfh8kWu5z5Z1E06JUSVGCREI285paM539cbs49cVQt3w4rYtU2I/qbzvOtPNuNRduxSAsdcr6g7z2x2oOS2e76vXJCXdbyrbc+ZtES4S5DSifTqpOwfmRW0am1drDU/FRyyQtSCyphulhsuyuQwFNDzKUR8xUpJPXPcDtW4t/Dg9LuDbt91dJmsoATgMHmbR/KFKWcDv6Vmdb/D7a9QahFygXR23NubOexyg4FYABKTkYJA9c9etBxrS981RfuKSbTM1PPSqbKfjrciy1qZSpQWNzaQoDaCcpxjsO1WXBG2PTeMVnjNznY62JK3lOozlwNgqUg9R0UElJ+hPeu2aV4BjTmvYl+iXtKoUWUp5qIqOdwR12pK93UgEdcelUbj8O8dWrDdbVfVw4pkeI8OpjeUebJSFBQ6fcdqDmVv1hd7TxrvMldwnPxocq4u+GXIWW1JbQ8pKSnOMeUdKtYl04gats1+1Y3ql5hi1kLeZExTPfrhCE+XH3xn6muy2vgZ4biPI1LMvDUmI/JkvOQjGI3IeCwUbt3svvj0rX7h8MzS7g6q3akWxAWrKWnY29aR7bgoA/fFBz7VnEnUd74d6ckOXSbHnx5cqK8/GeU0X0pQypJVtIyRvI/f1qz1FqbWdpsekrgdU3AplxFuMoQ6oFAS6oec585J9T6dPSu2ao4CRLhpWxWSzXXwSLct51155jmKkOOBAKjgjHyAfbHtVrqTgI/eLDpu3J1A00bRGcjlwxCrm7nCvON/Tvj1oOw6PuDt30lZLlIxzpkJmQvAwNy2wo/uay9YzS9sNk01abUp0PKgxGoxcCdu/YgJzj0zjtWTopSlKBSlKBSlKBWo664i6b0RykX6aUSXU7m47SCtxSe2cDsPqcVt1RJ+I1g27jJEud6hOS7O62wsN7ikOto6LQFehzn/ANb60HfND8VdK6zmmFaZriJoSViPIbLalAdyPQ4+hrE3njpoe13NcJU6RJUhW1bsZgrbSfXzdM/lmuG6QesWptbz2tGaTnQ5j0aR4V5M8hEUllSQooCexJ/q7mtIsk+yWexajtmorA7IvbyeXEfUooMRYyDkfQ4P1xiiJa6k4xaSsVutU9yTImQ7klxTDkRsLHkKQoKBIIPmHQ1aSOOeh47sJt6e+PEsoeJSyVhkKGQle3OFY7gZxUTb1bZ8HRGnnpyHG2JcmW7GSsYyjawCofQkH9Ky3FOFFhRtFGJHaYL+nozzvLQE8xZW5lSsdyfeglY9xe0a1qdmxG6Bcp0oSl1CCpncrskrHY9R9Bnv3rGQ+OmjJF4ct7j0yKtvmb3ZDIS2nYCT1Cieu0gDHUkCoz8VoUa2a3hNW+O1Gb8DCc2tJCRuLKCT09SeuavuF8KLceM3hp8dqTHUucVNuoCkkhp0jIPsQDQSUs3GrRN1hzpDdycj+DaLzjchooUpIIHl9FHJAwDnrV9ZOJ+j9RaduVzbnoRAhACWmU2UlAV2yk5znsMZz2qJvCe3w7g5q7x0ZqR4fTs2Q1zEhWxxITtWPYjJwaxunbfPuGjtTfh6HHEx1RpEhCASS2CsE49gVJP5UEirZxL4PrvKAza4cV4rwmWu1JSnPodwGR9yBW2av4yaW0pfDarl45cgNocC47SVoKVjIIO4ehqJka46cdtdqiv2SVImtKIe8M6GC9k9PMQsqP5DHpWY41R/D61hRzFciBFthI8M65zFtYaT5FKwMkds4oJSWzi5pGexfJCZy2YloWhD8h1GELKioJ5eMlWdh9M1ibbx60NOuCIvjZUferal5+OUtk/cZwPqQK1D4itDW2ycO0vaWs7URoTWnJnh0nqgIWElX0BX+9cabvejX7NYoX+h8uRc2ElEpxmaWjJWSMdkqJ+2Bjt1oOj8RdR3K3cdQyNXXFmK3JjkR2UqKEIWlCtgSDtUCFdz712O58XtG23U4sUm6YlhzlOOBB5TS/ZS+w69PXHriox8TGixxlYaLC45QLcnkrXvU3hhkbSr1I7Z9axdsUnT2trtB1Jpn8enOLcjJjOOLbUHlK6LGASrPp756Gg7bxB43Wa/6GvcTSsi7Q7shptxt8J5JSA82FYUlWRkEj86t+AHEDwOj9Q3bW9+lPR2JLTbbkt5byslKjtQDk5OOw9qjvZv+p3r/gx/85qsixbp0nh5ImRkLXCiXECRtGQkqb8ij9Oihn6/WgllYOOWib1c2oDc2RFeeWENqlMlCFKPYbskD88V0e4TY1ugvzJz7ceKwguOOuHCUpHck1BmFM05c7hZY0fTc6XK2IZWzEfEfmuZHbyrUr75H5VKrjnbZtx4Q3iLbmXFyEtNLLSPMopQtKlD69AaKxY4/aEM7w/jJnL3bfEeFVy/v/Vj8q1HjrxhuNhvFsh6MuDaUrj+IecLKHEOJXgtlJOfTdXBINxsCdPMQ59pffnofKlOMLDSlo9ishX2wEgVv3Gu1qjaD4fyGLTJt0YRn0lp5zmrb3KSpCVLwMkjJAwMdvSiJLcKdTnV2g7VdXFKXJW0G5ClICNzyeiyAOmN2cVttc4+H7UES/8ADW3Jhx3GPw1KIDu8Ab3ENoKlDHod3r1ro9FKUpQKUpQKUpQKUpQKtp8CHcWCxcIkeUyf/wBN9sLT+hq5rgvG3ijqK06zi6T0Y2hM9Yb3ultK1rcc+VCQrygYI6kevpig3O5cQdB6HvztgUlq3TUlAW1FglKcqAKeqU47EVkdf3DRently1NAtz89fRhBiIekvEdggYyfv2HvUR+IEu+TeJZd1XETEvQXGbkNpIIJShAChgkdQAenTrW86n4t6u1Dq+arS5gQ48AuBhTjbHM5YOCd7vqrA8qf3xREnHbXZNSQYUq4WiJLa5YWymbESpTaVAHG1YynsMj6Ul6V09MDAl2K1PhhsMtB2G2rloHZKcjokZPQdOtRuuPF3XrfDfxUpD1uuLdwZbbnmGlKZDSm3SU4WkpyChJyB/52bPFPik/o5u/RlBVrgulqVOUwyeatShgFOBgDKR5R3PU+xXaOIGo+G+mb2zE1XbbebguOh1BVbA8eXkpT5tp7bCAPTFbla9PadQ41crfZLYy+4nmJfbiIQ5hY69QM9QTn71DLi/q5et7jYrw+ylmSq1pafQj5d6XngSPoeh/OulXrijra86oZ0rw9bQ2uI0GchttTjqkI85Jc8qQCCPy+uKIkNE0rp6EXjDsVqj85tTLvKhto3tq+ZCsDqk+oPSq1r0/ZrQp1VqtNvgqdG1wxoyGysex2gZFRusvFrW1ysGpbRJfEbUdqZVLbkIYb3ENLAebWggpyAScgD5TWE/156p/0E5Qu/wD0gFwyZHh2s+H5fy7du35vXGaKk7KtWldOIevL9us1tDIK1zPDNtlP/eAzk/vWM085pHiCy9eGrFFl7XOSJE63JCnQkdFJKk5Kcdv8q4FqbirrBjTtgsjzsaVdbiwiY+/JjNHo4slpASQEDCQlRJHc+mK2bhJxF17I1oxZ9SRlXO3OK5LkmOwhSWDjIVzGhsI7A/8AlRHd79frLZUNJv1zgQEP7g2Jb6Gw5jGcbj1xkZ+9a8zduHdsWxcGZmlYi5AK2pKFsNlwAlJKVDv1BH3Fcl+Mf+y0n/elf/argt7u7E7T+nYDSHUu25h5p1SgNqit5bg29fZQ7460E7E2XTF+W3eE2yz3Fb4S4ib4dt0rx0BC8HOMDBz6Ve3KNbGCu7zYkdT0NtTniFMhTjaQCTtOM9s9qiDZ+JmrrJOsNktd3LFrQ1DQljw7SsBaEFQ3FJPUqPr61ndb8TNXI4mXjTybwRZ/GuRPD+Ha/sicFO7bu7euc0HYND3nhjrG5Sbdp2z2t2QlguupVaktgthSR1JQAepT0rfY9osdlgSUx7fbbfCcGXw2yhptQx3XgAHp71CnhDO1VBvN0OhoviLq5AWlSsJJZbC0KUsBXQnygY6/N2rabxrzVHEfhhcLfJbMmXb5bL764yNqnmClY6oHfaoJJwO3XHTNBIy0XXhzAmKVZ5mlIso9CqKuOhf2ynrW5sutvtJcZWhxpYylSTkKHuDX59WxrTjkMNXZ27Q52SC802h1odemUEpUPr1P2rfJHEjVei7hbrJY76iTZ4jEYtIZjtlLqFNpWQCpG4Z3Hv1GcelBLVOl7Amd41NjtYmbt/PERvmbvfdjOayMyJHmx1MTI7UhhXRTbqAtJ+4PSo0R+LHEDS+vIUPXMVpEOctK/C8tALbS1YBQpPt7KJPTr71QncVuIetNS3Jjh+2GoMMKcS2202pZaScblFzOSfYfvRUkD+DaXtLjhFvtFsaIK1YQw0gkgAnsBkkD9K92W+2m+tOOWW5wrg20QlaoryXQk+xKScVFq+cRb9r/AIN3yPNdjNSLY/HcmrSjb4qOpe1IAwcKDmwnGOg/I7J8IDNyxfXxIb/CBtQpjHnL/QhXbttyO/r2oJJUpSgUpSgUpSgUpSgVxPjXwkueqtRRNRaWmtRro0lKHEuLU3kpOUrSoZwodvyFdspQRUuvAnW8nUjc9+4RbksqacekyJCt6lAJ3DqCSAcge4A7VktTcDdV27Vc64aGubLMSUpak/7QphxoKOSjIHUexzUmaUEReJmgbrorhOyvUF1XOnSrqyOUl1S2mUhp7oN3cnPU49BVnoXhlqnV+goq7BeQ1apT7glw5D60NBaFDavaAd2Rj07j9JX6n03aNUQG4V/gtzYrbgeS2skALAIB6Eeij+tVNO2G2abtqbfZIiIkNKisNIJIBPc9STQRx1t8P98cVZo+nHIb8eJASy86+7y1LeLri1EDB6ecYrJau4JanY1Mi/aIubUWS8gKdHPUytpwpwvaoDqknJ9O9SPpQcW4NcHpOlpdzumqZTMy4zmVxy22orSELOVlSiOqjj/Hvmo43PRMmFxN/wBEQ6288qaiMFtHI2rIwT9Qkgn261PetTi8PNMRdUq1GzbQLyXFPGQp1ajvUCCcE47E+lBzrjLwal6km226aTkMRpkRhuMWHVFCdqPkUlQBwR2/IfnbcL+FWsLfrBm+awvzjiGDvDDUtbheUBhO8nA2j269sV3qlBx74huHt7163YRYRFzCL5d57uz5+XjHQ5+U1zW9cB9VyrBp6LFataZURh5ElXOxuUp5ak9dvXykD9qlXSgi3eOAWqHXLNMt0u3olNRmUSErcP8ADdbATuSduFDASf1pP4H60f1w9dnpUGY2uUXlSFu7Fu9clWwDAz7VKSlBE/T3AnXtsXNfiXONbZJjlDao8pQ5uVJBbUQBgFOT69QPvWci8Ab5A0UW4N1it6iXMblFaFrQhCEIWkISsDO7LhOcAen1qSlKCKE/ghxHv8qOL9dYj6WvKl6RLU6UJJ648uTWjcUdPM2Tid+ANPLW1HRDjc3spX8FsFX06kmp0Vql54eaUvN7Xd7pZmJFyWUqU+pawSUgBPY46AD9KI4/Y+B2o5euIty1jfUz7fBdBaUt5bjzyEKyhPmGEg+oz7/erG+8DdXWjUk+VoS7tR4EzcMCQphxCFHJbVgeYD/KpM0orhmkeBirbw61DZ7jPaN2vKGwp1oEts8tW9A69T5h1P8Ayr5wM4aat0LqWUu6zYpszjSgWY76lBxzI2q2kDsAf1rulKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSma+ZoPtKwl+1TYtP7RervBgqUMpQ88lKiPcJ7msEjitoZfbU1vH3UR/iKDeM0zWnt8StGOfLqe1fnISP8auW9e6Sc+XU9l/Oa2P8TQbPmmawbWq9PPf2V+tS/wC7MbP+dXjV3tz39lcIi/7ryT/nQZDNKoJlMK+V5s/ZQr2HUHstJ/OgqUrzmmaD1SvmaZoPtKZpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQeTXKOPvEhzQ9kZiWlSfxqeDylEZDKB3Xj364H5+1dVUcVDX4nZjkrirJaWolEWMy0gZ7Ap3n91Gg5fcJsq4zHZc+Q7IkuqKnHXVFSlE+pJq3pSiFKUoFKUoPSXFo+Vak/Y4qqmbKR8sl9P2cIqhSgv27zdGv7K5TUf3X1D/ADq7a1XqJr+yv12R/dmOD/OsLSg2VrXurmsbNUXvp6Gc4R+6q3TRXHbVdilITdZH4zAyN7cjHMA9dqx1z98iuTUoP0M0lqK36qsMW72h3mRX05wfmQr1SoehBrMiou/CLe30Xm9WRSyYzjAloQeyVJUEkj7hQ/QVKEGivVK+CvtApSlApSlApSlApSlApSlApSlApSlBbrNQp+Ihe/i3efoGR/7pNTTcNQj49L38WdQfRxsf+6RQaBSldE4FRYT+s5EickrVBt0iZHQloOqU6hPl2oPRSgCVAe6RRGgyIsiNs8Sw6zzE7kcxBTuHuM9xWU1Fp5+xxLLIfebcF0hpmtpRnKElSkgHPr5TXT5upLZeNHaljXC+6i1Cgsc1kzLeMQ39w2L5gWdiSfKR0HWss7bozkGwyorbVw1Lb9LRnrfbXUZQvzLK3MYwtSQchHrjPXGKDl+mImi27V43VNxursorUlNutzKUqAHZSnF9MH2HWrudB0FcrXJdstyutpuLDanExrmhLrb5AztStsZSr7isho+Siy6GvWsEwY1wvZuCIba5TQcRFCklandnbJPlBPQVVvc9OtOGlyv93hwo95tk1llEuMylnxSHArKFBIwVJ27s+1BzCslfbJOsbsRu4tpbXKitzGglQVltwZSenbp6V0fWV1i6BnxtNW2wWmSyzFZcnPz4odcmLWhK1eY9UpGQBtxjB61s12sdq1RxPiJmMJYtNq0uxNMV94oG1DSSlta+4A3pyfYGg4BSuzagtdnumkru9ORoq33GGyH4LllmYL20+ZpbZUdxKc4PfIqwkaKtdx4gaXFvZTH07doLVxdAcO1ltCSZAKiSRgoV3PTNByilXV1cjO3OW5AZ5ENTqyy1uJ2IydoyepwMVa0HbvhMT/09ua/6bcofq43/AMqlmg1FP4Sk/wDSy9L9oQH6rH/KpUoNFVhXqvIr0KBSlKBSlKBSlKBSlKBSlKBSlKBSlKCxdPSoN8Z3ObxS1Gr2lFP6JA/yqcbvaoI8VFlziTqYn0uDw/RZH+VEatV1arjMtNxYn22Q5GmMK3tutnCkmrWlBtGote6i1BbvAXKckxFKCltMsNshxQ7FewDd+dWS9VXhd0tVx8YpMy2NNsRHEJCS2hv5R0HXue/f1rCUoOtaNjayeYl6h0v+E3dNzUoXK0IShY+Y45kc4GD1IKfc9utede2zW9x04uTqC227TljgfxGbe2lERDjhwDsayVLXjJ6/XHtXKWnXGlbmlqQr3ScGvTsh55SVPOrcKe29RVj9aDp8jUE+PBZj3Ww2O/S7Sy2w1LkZLrOEghtaUrAc2nIAIPynPrXyFdNZXPVUvVjNvjynWGfAzGlLQW5KUMhLiNu7KyUp3EJzgn7VpTGp57ZedWvfKXuKXsBJClDapZwPMrHYnqD1qnbNTXW2WmTbYkhIhyCVKQtpK9qinaVJJBKSR0yPYewoOg3+2XFVrdtlh0LDtRuG0yHxNEpxASnm43KVhlJHm64yB3qlF1DebLwykQHtPhwsJkQGrsJAV4dt5wcxO0Z7lCkhWQOp/PDTeJ94dvHjYbESK2HQ8GUN43KDfLSVLTtUohJIBz6n3NWF21/eLrYJFplIiCPIcLjim2yhSjzFOdgdvzKPXbnGBnoKDUqUpQd8+ElH/pvUC/aO0n9VH/lUoGzUZ/hHRmTqVfsmOn9S5/yqS7fpRVwntXsVTT2qoKBSlKBSlKBSlKBSlKBSlKBSlKBSlKCwd7VDj4h9NP2TiBLncs+CuZ8Q0sDpvwAtP3z1/MVMlwdK1zWGmrZqm0OW68xw9HV1BHRTavRST6GggTSu36i+Hy7R5C1WK5RZUck7UyctuAe3QEH79PtWvO8EdYo7MQlf3ZA/zFEcxpXQ3ODms0drcyr+7JR/matnOE2tUf8A7KVD/dkNH/8AtQaLStwc4Z6xb+awyT/dUhX+Bq2c0Bqxv5tP3H8mSf8ACg1ilZ9ei9TI+aw3Mf8Ahl/8qoL0tf0fNZLmP/Cr/wCVBh6VkHLHdm/7S1zkf3o6x/lVs5DlNf2kZ5H95BFBQpX3Yr+lX6VvugOFuoNWzGiYrsG2ZBclvoKRt/3Aeqj9un1oOu/CbbXGbBe7itJCJUhtpBPry0kk/qv9qkA3WE0vZIenrJEtVsb5cWMjagHqT6kn3JOSfvWcQKKrp7V7FeE9q9igUpSgUpSgUpSgUpSgUpSgUpSgUpSgtVirZwVcqqgugs3E1bLbq+WKoqTQWKm68Fr6VeqRXkooLItV85VXmymygsuV9Kcr6VebKbKC1DX0qolv6VXCa9JTQU0MIKgooST7461etJrwkYqsigrt1cIq2SarJVQXCTXoGqAVX3fQV80zVDfTfQV80zVDfTfQV80zVDfTfQV80zVDfTfQV80zVDfTmUFfNM1QC6+hz60FbNfc14BzX3NBa4Uo4SMmvKmHT/L+9XjaQhIAr1QY1UV4/wAo/WvBhv8A9I/UVlaUGJ8E/wD0j9RXwwX/AOgfqKy9KDD+Bf8A6B+or54F/wDoH6iszSgw3gX/AOgfqKeAf/oH6iszSgw3gX/6B+or0IT/APQP1FZelBihDf8A6R+or0Irw/lH61k6UGPEd4fyj9a9Bh3+n96vqUFkGXfb96+8p72/erylBZ8p72/enKe9v3q8pQWfKe9v3pynvb96vKUFnynvb96cp72/erylBZ8p72/enKe9v3q8pQWfKd9v3r4W3fb96vDXk9qC2abVzAFjp96w1j1ILxfrtaRFS05bDteXzQoEknZtA6nKRk9sHp1rPnIII7irJm326E4ZESEy0/hSd6UYPnVuVk+uVdfvQXSFVV3Vatmq+aCvSlKBSlKCjMfTGjLeV1CR296wtsvpkTEsvBOVdEhI/f8A/wB71nH2UPo2ODKc5xWJh6fai3BMlLqilOSlGO351zLyl7149VvjZnu9/ctMNYdmqknnhrt41+q360VYUwWXdr0donxOHlB0fMlvb1Ce56joKv3OIenG4y33JbqGxt2FcdaealSikKRkeZOQRkdP1FbBGtkWNcZ05psiTN2c9RUSFbBhPTsOlYROhLGhl1pDUlKVpCE4kufw0BRUEJ69EZJO3t29hXTZlRWtbKJqYiXn1yVNBxLaY6ySS2XAjt85SCQnvXuBrC1TbKi7NqkIgqkiKHHWVI85WEev8u44z2q1a0BYGT/s8eQwCwI5DUlxGUhBQCcHvtOM/b2FX8XS1rj6cesQbfctjiC2Wnn1rKU4xhJJykDHTHb0oLRnXNiefYaRIePOKQHAwsoTvWUIKlYwkKKTtz36H1FXlj1Tab5ClS7fJK40bPNdW2pCQACSckfQ/aqB0ZZPERXUxloEdDLaW0OqShQaOW96QcK2nqM1WtOlbVazPMZlajOQG5BedU4VpGQEkk/7x+vWgtbfriyzpDTDDkkOuqSlCXY62ydza3EnzAdClCjn7VRRxC02tIV41YQYwlbiyvATyubjOPm2ebb3q3hcO7XGlvuKfmONKLKmAX172S2hSMBe7JBSsjHtV5E0JYoa90ViQyOQmPtbkuJG1LYbB6H5tgAz9M9+tBYT+ItuaYZdhsSJDTsORLS8ptSGwGduQTgnB3DqAR29xV+/ruwx1SkvSHkiOF7l8hexZQQFhCsYUUkjIFUxw/sAj8kMPhBD6V4fWC4HgkOBWD1zsT+gqs9oexPuyVuxnFB/eSgvr2IKyCsoTnCSogZI/wAzQeG9eWJcmLH58hEmQ8thDK460rC0KAUCCMjqpP6596u7zqWLab9bLdLJSJp2JXsX0WThAyBjqc+ox096oTtE2Sa8XJDDx3SFSVJD6wlThKSSRnHdKf0+pq4umlLVc70xdZbTipjPL2qS6pI/hqKkZAODgqP60GL1FrCVapd4bj2rxTFsjiQ+7zwjCS04sdMeqkBP/ez6VWiazYkaxTYvDlKVNdJO/wApf2hZZxjvsUFZ+4rLTbBbpguokMqV+JspYlYWRvQAQAOvToo9qsWdE6fZlty27e2ma3J8WJWTzt/XuvuU4ONucY6YoMs7drc04pt2fEQ4k4UlTyQQfqM1jr/qDwTVuTa2WrhKuMgx4yQ8ENkhKlKUpYBwAEK7AnPSsk5a7e64px2DEWtRyVKZSST9Tire6WG33KEzFeZLTbDgeZVHUWlNLGfMkpwQep/U0GGtWt4cgpjTmH2LoHnWHYzDa5GwtqCVK3JT8mVJ8xA7/Q1SuHEK0MRluROfIWh5psJ5K08xCn0sqW2dvnCVK7Jznp71ep0TZUeGLTUlpbJXlxElxK3d6gtYcVnK8qAJz7VTXoKwrQ8kx39qyCkCS4OTh0O4b6+Qb0hXTHagDXlhPK/2h8b878xnP4H8Qt/xenk84KeuOoqta9XQptgRd32ZESMqUYv8ZsghXN5YJ+hOOvp+VUk6EsSeV/s752dV5kLPP/iFz+L18/nJV1z1Jq/b01bUWOZaC04u3y1OKcaW4o45hJUEnukZJIx2PagsG9c2J19ltEh4h0pAcDCy2nctSEFSsYSFKSdue/Q9iKpSNfafjxG5L0pxLTrLT6DyldUuqWlHp3JbV+lXZ0ZZOdEcTGWgRm2W0tpdUELS0ct705wraeozVsjQVjbYcabblJQtCGv+sueVCFKUlA6/KCtXTt1oNijPIlRmpDO4tOoC0lSSk4IyMg9R+dfJIwyfyr5bIEe2W6NBhI5caM2lppGSdqQMAZPWvcsfwFfl/jQW7VXGat2quKC4pSlApSlBp3EXUly083b/AMMitu+IUsLcdQVJSUpylHQjBUegPXt0BPSteuuvbzCk3tJjxkMQwgxnFsOEPFTjaVpz6lveQcfMcYxgiupVRmRWJscsS2kPMkglCxkEggj9CAfyoOVK1TfJs6O6CtTAw0Fx0LbafAnx2+aATkZQpfqemfSqkTiJdlzHkPsxQloNuPNBhwLjJMtLSwsk9SlslWQAPpjv1eqHhI/jfF8lHiuXyubjzbM5259s9aDnMLXd6k3u2xU29sRpLyk7lNKBcR4lbeUknoUoSlZ6HOf5R1rK3zUl7halejxIjL0Bl6M1s5auY5zUrJIVnAwUj0Pf0reKUHJo+stQzza1LWxHYMuMJLzcRwJTzEub2FBRzuSpKQVD1UO3Y3MPWmpQvTiJkKIVXNlqQvYytIwtaQWxlWQpKSVE4OenQDJrqGKUHP8AVus7jaNWx7bDjIcjFCS6XGjnzJWdyVbuwKQD5cde+awEbiRd3YMJ1xVubRIWyFSzFd5bRWy44psp3ZUpBQnJBx5x2rrriEuNqQ4kKQoFKgfUH0q2FthBuGgRWtkPBjjb0awkpG328pI+1BztnWepXoT012HFhRkmI2rmx3FlkutoWtxWFAlKckY6HqMkYNXELWd3kzIDEphmEH2QobozqlSiXFoy3j5BtSlfmBwFjOO9dHpQcfha01NbdPwUTGWpDy48RZlrYV/DDjbhPMBWNx3NpGcp6r7e++L1A85pKZOjNtC6xoqXHY60rKW3S2F7TgZI6jtWyV4Q022pxTaEpU4dyyBgqOAMn3OAB+VByl7iPd0QbW4iElTzrqkvBUYhC0h1KPIoOEdlE5G7t6AGq72tdSMxn3lxYWFNLcayytPL2yeUQolWCSnzDO0D1OOtdSxSg0O56vmsaQ0/dEhiK9cJCGXlyY6yloFCyVbArOMoB74x6+ta81qzUMi4W+UpKobLrsTnMlpakrC2XztGT5QpSED3ypOe2D1eRFYkqZMhpDhZXzWyoZ2KwRuH1wSPzqtQcpRqnUF0ZtD8ORGTILq1PITEeDbf+zOLLTgJG4pUAMgjrjI9KyesNVXWNpe0yIjSIrtxhOOuOqZW5ynOSFJbSE9QpRJAJ7bexrodKDnmjtVXmdqJq1TYgTHQwnctaCHD/BQrmk56hSlEY2j7nqKpXbWWoYT15aTbEYtjiW1vlpRQsOupDa0+YZCWiSrr39QK6RSg5k1rHUj7kZSYkRtkiJzAWFqK+c8tsqSd2AAEheOvfv61ZaY1tqBcqyQJjTcpTyU+IeUwpClkuLSsDzdCgJBPQ5z/AC9DXWqYoKMOQ1MiMyYyt7DyA4hWCMpIyDg9RSX/AGCvy/xqtVKX/YK/L/GgtGqr4qk0Kr4oPrDwUkJUcKHv61WyKsFoqkpugymaZrEFuvnLoMxmmaw/Lpy6DMZpmsPy6cugzGaZrD8unLoMxmmaw/Lpy6DMZpmsPy6cugzGaZrD8unLoMxmmaw/Lpy6DMZpmsPy6cugzGaZrD8unLoMxmmaw/Lpy6DMZpmsPy6cugzGaVhw2Qcjoavm5J5fmGVj96C6JA7nFWkh0OYSnqB3NUSFLUVK6mqiEYoPTYqriviE1UxQU1IrwUVcYr5toLYo+lOXVztr5tFBb8unLq42im0UFvy6curjaKbRQW/Lpy6uNoptFBb8unLq42im0UFvy6curjaKbRQW/Lpy6uNoptFBb8unLq42im0UFvy6curjaKbRQW/Lpy6uNoptFBb8unLq42im0UFvy6bKuNorFamvEXT9km3SevZGitFxZ98dgPqTgD70FG/Xm2WGCuZeJrEOMnut1WMn2HufoK5tM496KjyC027PkJBxzGo3l/8AaIP7VGjX+s7prS9uz7m8rlBR5EYK8jCPYD39z61rSEOOBRQ2pQSMnAzignVo/iLpfVjgZs90aXJIz4dwFtz8kqxn8s1uaADX5yxZDsaQ2/GdWy+2oKQ4hRSpJHYgjsamD8P3EV3WNkdg3ZwKvMAALX2LzZ6BePf0P5H1oOugV6xQdq+0CuWan4vxrDxJj6QXaHnnXno7Ikh8JSObtwduPTd7+ldTqHvHa4iz8f8A8TLReEJyHJLYVt37EoVjPpnHeg73xb4pw+HTttaft7k96YFq2NuhGxKcDJyD3J/Y1k+FevYvEGwv3GLEXDUw+WFsrcCyOgIOQB3z+1Ro1nqV7iXxZsT0K1rkJDUdKLeHkgr6c1aN6sD1Iycdq2j4Ubm5bdZX/T0oFpTzXMDSj8rjSikj74Uf/VojpGs+NcDSuvFabl2p5wIW0lyUHwlKAsJOduPQK9686h42W+z8Q/8ARUWp6QsSWoypSXwEhS9v8uPTd7+lcK4tQlaj+IC4W1C9qpc2PESr2JQ2itZ1Jb7np7U1pl33mpukhLc99LowtJLqsZ+uEg/nQSRtvHu0v3q8Q59qkRI9tbdccfDoXv2LCAAnA6qJAHX1rEMfExZFScP2G5Ij56OJcQpWP7vQfvXD4a4ydTazVOiuy4xbfC22V7V4MlvzA4PUfN2x0q0/HnLYI0LTNzuE2EsndAnxEFsKJ7BvctKs+4ANBKLiLxssujLm3bRBlXCcppDy0NqCEthQykEnPXGDgD1rGQ+P9omaaut0j2adzbdyi4w44gBQcXtGFDPY+4rk3FmZBGuxKugutgvzcOItT0JAcQVmOgkAFSVJKSSjIJzt9Oudch3y83fQWqvxBtMmMhEfdPUyA7v56NqFOAZVkFR8xJGKCQv+vmws6MiX2dBlNPS3nGmYLa0uLVsxlRPQAdR/51Yac+IvT1zujMS5W2ZbEPKCEyFrS4hOT0KsYIH161HO62SevQdivTbLjlvCn4y1pSSltYcKuvtkK/arq/y164n6Vt9gt0lcyJa49tU2EDLjqCrKhj08w6nHbrQSTicb4D3EN7SrlpeaU3LdhiVzwUqUgqAO3H8xSB39azfCPidH4j/ivh7Y7A8Bys73g5v37/YDGNn71FeRb5Y4sXpiMsmbBlTZCFD1WwHHB+pRXWfg476t/wDCf/eoJJ4pilKKYpilKBimKUoGKYpSgYpilKD4R0rjPxSy3o/DUtskhEia005j+nClf4pFdnPatC4x6aXqrQtyt0cAytoeYz6rQcgfn1H50EGWUB19ptSghKlBJUewye9dE4o40Vrk2nTLf4e3bEtFuS3/AGz6lNhRWpfcg7iNvy/SudvtOMuraeQpt1CilSVDBSR3BFZtGppT6of420i7Nw0hLDcn0SOyVLThZSP6d2KI2TjLb4jFx0/dIsdqK9eLSxPksNJCUJdUCFFKR2BxnHvmsn8NMt6NxUhtNE7JEd5twD+kJ3D90iufakvs/Ul3duV1cC5CwEgJSEpQkDCUpSOgAHpXbvhW0q+u5zNSyGymOhsxoxUPnUSCpQ+gAx+Z9qKlC0cpFe68NDCRXugVaSLZAkul2TBivOnutxpKifzIq7pQWbNrt7DqXWIMVt1PZaGUpI+xAr01boTMgyGYcZt8kkuJaSFde/XGauqUFobbBVJ8QYUYyN27mlpO7PvnGc19k26DKd5kqHGecxjc40lRx9yKuqUFqzbYLLqnGYUZtxQIKktJBIPfJxXlu1W9p5LrcCIh1JyFpZSFA/fFXlKC3lQosvHi4zD+O3MbCsfrXkW6EIxjCHGEcnJa5SdpPvjGKuqUFFmJGYYLDMdltk920IASfy7V5jQosUkxYzDJPctthOf0q4pQWgtsFMhT6YUYPqJJcDSdxz364z1ya9xIMSHv8JFYY343cpsJzjtnFXFKBSlKBSlKBSlKBSlKBSlKBVF5vcKrUIoOJcVODMDVUh25WtxNvuyuq1bctvH/AHgOx+o/MGuKS+B+tmJBbahRpCM45jclAT/7RB/apqLbCu4qkYyfYUEX9E/D7Mdltv6rlNtx0kExoqipS/opWMAfbP5VJOyWqLaoDEOCwhiKwkIbbQMBIFZBDKU+lVQMUH0DApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlB//Z",
+              "timing": 4485,
+              "timestamp": 3528770901
+            }
+          ]
+        }
+      },
+      "unminified-css": {
+        "id": "unminified-css",
+        "title": "Minify CSS",
+        "description": "Minifying CSS files can reduce network payload sizes. [Learn how to minify CSS](https://developer.chrome.com/docs/lighthouse/performance/unminified-css/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsBytes": 0,
+          "overallSavingsMs": 0,
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "FCP": 0,
+              "LCP": 0
+            }
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "type": "opportunity",
+          "headings": [],
+          "items": []
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "third-parties-insight": {
+        "id": "third-parties-insight",
+        "title": "3rd parties",
+        "description": "3rd party code can significantly impact load performance. [Reduce and defer loading of 3rd party code](https://developer.chrome.com/docs/performance/insights/third-parties) to prioritize your page's content.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "headings": [
+            {
+              "valueType": "text",
+              "subItemsHeading": {
+                "key": "url",
+                "valueType": "url"
+              },
+              "key": "entity",
+              "label": "3rd party"
+            },
+            {
+              "key": "transferSize",
+              "label": "Transfer size",
+              "granularity": 1,
+              "subItemsHeading": {
+                "key": "transferSize"
+              },
+              "valueType": "bytes"
+            },
+            {
+              "granularity": 1,
+              "label": "Main thread time",
+              "subItemsHeading": {
+                "key": "mainThreadTime"
+              },
+              "valueType": "ms",
+              "key": "mainThreadTime"
+            }
+          ],
+          "items": [
+            {
+              "mainThreadTime": 331.7679999996908,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 228.96400000154972,
+                    "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+                    "transferSize": 206382
+                  },
+                  {
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+                    "mainThreadTime": 31.947999999392778,
+                    "transferSize": 43655
+                  },
+                  {
+                    "mainThreadTime": 26.824000000022352,
+                    "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+                    "transferSize": 29746
+                  },
+                  {
+                    "mainThreadTime": 23.862999999430031,
+                    "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                    "transferSize": 27954
+                  },
+                  {
+                    "transferSize": 27210,
+                    "mainThreadTime": 16.202999999281019,
+                    "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+                  },
+                  {
+                    "transferSize": 1672,
+                    "mainThreadTime": 3.6580000002868474,
+                    "url": "https://js-eu1.hs-scripts.com/27107933.js"
+                  },
+                  {
+                    "transferSize": 4082,
+                    "mainThreadTime": 0.16200000001117587,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953"
+                  },
+                  {
+                    "transferSize": 1095,
+                    "mainThreadTime": 0.14599999971687794,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk="
+                  },
+                  {
+                    "transferSize": 1724,
+                    "mainThreadTime": 0,
+                    "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&isMobile=true"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&t=Ocobo+%C2%B7+Accompagner+la+cr%C3%A9ation+d%27une+business+unit+durabilit%C3%A9%C2%A0%3A+comment+ekodev+a+structur%C3%A9+son+organisation+commerciale+et+d%C3%A9ploy%C3%A9+HubSpot&cts=1778779435991&vi=522bb937e1deac1b4040bccdca012966&nc=true&u=242475741.522bb937e1deac1b4040bccdca012966.1778779435984.1778779435984.1778779435984.1&b=242475741.1.1778779435984&cc=15",
+                    "transferSize": 1474
+                  },
+                  {
+                    "transferSize": 1024,
+                    "mainThreadTime": 0,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1"
+                  },
+                  {
+                    "transferSize": 1024,
+                    "mainThreadTime": 0,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1"
+                  },
+                  {
+                    "transferSize": 1022,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=57c7f575-9393-4ca6-9159-53c362155363&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&t=Ocobo+%C2%B7+Accompagner+la+cr%C3%A9ation+d%27une+business+unit+durabilit%C3%A9%C2%A0%3A+comment+ekodev+a+structur%C3%A9+son+organisation+commerciale+et+d%C3%A9ploy%C3%A9+HubSpot&cts=1778779436333&vi=522bb937e1deac1b4040bccdca012966&nc=true&u=242475741.522bb937e1deac1b4040bccdca012966.1778779435984.1778779435984.1778779435984.1&b=242475741.1.1778779435984&cc=15",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+                    "transferSize": 1021
+                  },
+                  {
+                    "transferSize": 559,
+                    "mainThreadTime": 0,
+                    "url": "https://js-eu1.hs-banner.com/v2/cf-location"
+                  }
+                ]
+              },
+              "transferSize": 349644,
+              "entity": "Hubspot"
+            },
+            {
+              "mainThreadTime": 210.93599999928847,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "transferSize": 157097,
+                    "mainThreadTime": 210.93599999928847,
+                    "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+                  }
+                ]
+              },
+              "transferSize": 157097,
+              "entity": "Google Tag Manager"
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 6.6249999990686774,
+                    "url": "https://useago.github.io/widgetjs/frame.js",
+                    "transferSize": 5017
+                  },
+                  {
+                    "transferSize": 1999,
+                    "mainThreadTime": 0,
+                    "url": "https://useago.github.io/widgetjs/frame.css"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "transferSize": 7016,
+              "entity": "GitHub",
+              "mainThreadTime": 6.6249999990686774
+            },
+            {
+              "mainThreadTime": 0,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-avatar.png",
+                    "mainThreadTime": 0,
+                    "transferSize": 354683
+                  },
+                  {
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png",
+                    "mainThreadTime": 0,
+                    "transferSize": 11989
+                  }
+                ]
+              },
+              "transferSize": 366672,
+              "entity": "vercel-storage.com"
+            },
+            {
+              "mainThreadTime": 0,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+                    "transferSize": 1278
+                  }
+                ]
+              },
+              "transferSize": 1278,
+              "entity": "Clearbit"
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 796,
+                    "mainThreadTime": 0,
+                    "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65c1v9100339653za200zd9100339653&_p=1778779433853&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1674557540.1778779434&frm=0&pscdl=noapi&rcb=0&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616985~115938466~115938468~118128922&dp=%2Fclients%2Fekodev&sid=1778779434&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&dt=Ocobo%20%C2%B7%20Accompagner%20la%20cr%C3%A9ation%20d%27une%20business%20unit%20durabilit%C3%A9%C2%A0%3A%20comment%20ekodev%20a%20structur%C3%A9%20son%20organisation%20commerciale%20et%20d%C3%A9ploy%C3%A9%20HubSpot&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1823"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "transferSize": 796,
+              "entity": "Google Analytics",
+              "mainThreadTime": 0
+            },
+            {
+              "mainThreadTime": 0,
+              "entity": "Google Fonts",
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 102671,
+                    "mainThreadTime": 0,
+                    "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                    "transferSize": 1259
+                  }
+                ],
+                "type": "subitems"
+              },
+              "transferSize": 103930
+            }
+          ],
+          "type": "table",
+          "isEntityGrouped": true
+        }
+      },
+      "network-server-latency": {
+        "id": "network-server-latency",
+        "title": "Server Backend Latencies",
+        "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "sortedBy": [
+            "serverResponseTime"
+          ],
+          "type": "table",
+          "headings": [
+            {
+              "label": "URL",
+              "key": "origin",
+              "valueType": "text"
+            },
+            {
+              "granularity": 1,
+              "key": "serverResponseTime",
+              "label": "Time Spent",
+              "valueType": "ms"
+            }
+          ],
+          "items": [
+            {
+              "serverResponseTime": 9,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "serverResponseTime": 8,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "serverResponseTime": 3.5,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://useago.github.io"
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "serverResponseTime": 0.5,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://perf-eu1.hsforms.com"
+            }
+          ]
+        },
+        "numericValue": 9,
+        "numericUnit": "millisecond"
+      },
+      "lcp-discovery-insight": {
+        "id": "lcp-discovery-insight",
+        "title": "LCP request discovery",
+        "description": "[Optimize LCP](https://developer.chrome.com/docs/performance/insights/lcp-discovery) by making the LCP image discoverable from the HTML immediately, and avoiding lazy-loading",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "total-blocking-time": {
+        "id": "total-blocking-time",
+        "title": "Total Blocking Time",
+        "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).",
+        "score": 0.43,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "690 ms",
+        "numericValue": 694.5,
+        "numericUnit": "millisecond"
+      },
+      "cls-culprits-insight": {
+        "id": "cls-culprits-insight",
+        "title": "Layout shift culprits",
+        "description": "Layout shifts occur when elements move absent any user interaction. [Investigate the causes of layout shifts](https://developer.chrome.com/docs/performance/insights/cls-culprit), such as elements being added, removed, or their fonts changing as the page loads.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [
+            {
+              "items": [
+                {
+                  "node": {
+                    "type": "text",
+                    "value": "Total"
+                  },
+                  "score": 0.002315
+                },
+                {
+                  "subItems": {
+                    "type": "subitems",
+                    "items": [
+                      {
+                        "cause": "Unsized image element",
+                        "extra": {
+                          "type": "node",
+                          "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,1,HEADER,1,DIV,0,DIV,0,IMG",
+                          "nodeLabel": "ekodev",
+                          "lhId": "page-3-IMG",
+                          "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"ekodev\" loading=\"eager\" decoding=\"async\" fetchpriority=\"high\" class=\"h_10 w_auto obj-f_contain d_block\"\u003e",
+                          "boundingRect": {
+                            "top": 532,
+                            "width": 113,
+                            "bottom": 576,
+                            "right": 161,
+                            "left": 47,
+                            "height": 44
+                          },
+                          "selector": "header.d_flex \u003e div.d_flex \u003e div.bg_ocobo.dark \u003e img.h_10"
+                        }
+                      },
+                      {
+                        "extra": {
+                          "type": "url",
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                          "type": "url"
+                        }
+                      },
+                      {
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      }
+                    ]
+                  },
+                  "score": 0.002315,
+                  "node": {
+                    "selector": "div \u003e header.d_flex \u003e div.lg:w_2/3 \u003e h1.text",
+                    "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark fs_4xl md:fs_5xl lg:fs_6xl …\"\u003e",
+                    "boundingRect": {
+                      "right": 396,
+                      "bottom": 438,
+                      "width": 380,
+                      "top": 165,
+                      "height": 274,
+                      "left": 16
+                    },
+                    "type": "node",
+                    "lhId": "page-4-H1",
+                    "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,1,HEADER,0,DIV,0,H1",
+                    "nodeLabel": "Accompagner la création d'une business unit durabilité : comment ekodev a struc…"
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "valueType": "node",
+                  "label": "Element",
+                  "key": "node"
+                },
+                {
+                  "label": "Layout shift score",
+                  "granularity": 0.001,
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  },
+                  "valueType": "numeric",
+                  "key": "score"
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "type": "table",
+              "items": [
+                {
+                  "score": 0,
+                  "node": {
+                    "type": "text",
+                    "value": "Total"
+                  }
+                },
+                {
+                  "subItems": {
+                    "type": "subitems",
+                    "items": [
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        }
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        }
+                      }
+                    ]
+                  },
+                  "score": 0,
+                  "node": {
+                    "type": "node",
+                    "lhId": "page-0-INPUT",
+                    "nodeLabel": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "path": "0,HTML,1,BODY,1,DIV,0,FORM,1,DIV,1,DIV,0,INPUT",
+                    "selector": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "snippet": "\u003cinput type=\"submit\" class=\"hs-button primary large\" value=\"S'inscrire\"\u003e",
+                    "boundingRect": {
+                      "right": 380,
+                      "bottom": 117,
+                      "width": 110,
+                      "top": 79,
+                      "height": 38,
+                      "left": 270
+                    }
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "key": "node",
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "valueType": "node"
+                },
+                {
+                  "granularity": 0.001,
+                  "label": "Layout shift score",
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  },
+                  "valueType": "numeric",
+                  "key": "score"
+                }
+              ]
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "main-thread-tasks": {
+        "id": "main-thread-tasks",
+        "title": "Tasks",
+        "description": "Lists the toplevel main thread tasks that executed during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "startTime": 1050.217,
+              "duration": 20.236
+            },
+            {
+              "startTime": 1348.175,
+              "duration": 6.552
+            },
+            {
+              "startTime": 1357.864,
+              "duration": 13.407
+            },
+            {
+              "startTime": 1371.285,
+              "duration": 148.853
+            },
+            {
+              "duration": 18.845,
+              "startTime": 1521.793
+            },
+            {
+              "startTime": 1550.581,
+              "duration": 18.919
+            },
+            {
+              "startTime": 1569.835,
+              "duration": 10.117
+            },
+            {
+              "duration": 14.449,
+              "startTime": 1582.181
+            },
+            {
+              "duration": 8.432,
+              "startTime": 1600.391
+            },
+            {
+              "startTime": 1608.954,
+              "duration": 12.324
+            },
+            {
+              "startTime": 1622.013,
+              "duration": 5.066
+            },
+            {
+              "startTime": 1628.258,
+              "duration": 24.558
+            },
+            {
+              "startTime": 1653.762,
+              "duration": 23.598
+            },
+            {
+              "duration": 5.69,
+              "startTime": 1678.024
+            },
+            {
+              "startTime": 1688.321,
+              "duration": 75.294
+            },
+            {
+              "startTime": 1768.657,
+              "duration": 57.606
+            },
+            {
+              "startTime": 1833.661,
+              "duration": 51.447
+            },
+            {
+              "startTime": 1886.474,
+              "duration": 16.977
+            },
+            {
+              "startTime": 1905.13,
+              "duration": 48.032
+            },
+            {
+              "startTime": 1961.745,
+              "duration": 16.376
+            },
+            {
+              "startTime": 1978.244,
+              "duration": 19.334
+            },
+            {
+              "startTime": 1997.697,
+              "duration": 6.631
+            },
+            {
+              "startTime": 2004.404,
+              "duration": 5.663
+            },
+            {
+              "startTime": 2010.11,
+              "duration": 5.632
+            },
+            {
+              "startTime": 2015.763,
+              "duration": 18.305
+            },
+            {
+              "startTime": 2034.106,
+              "duration": 9.603
+            },
+            {
+              "startTime": 2043.738,
+              "duration": 5.624
+            },
+            {
+              "startTime": 2049.373,
+              "duration": 5.541
+            },
+            {
+              "duration": 5.196,
+              "startTime": 2054.933
+            },
+            {
+              "startTime": 2060.21,
+              "duration": 10.427
+            },
+            {
+              "startTime": 2070.667,
+              "duration": 11.395
+            },
+            {
+              "startTime": 2082.118,
+              "duration": 6.603
+            },
+            {
+              "startTime": 2088.732,
+              "duration": 8.712
+            },
+            {
+              "duration": 5.328,
+              "startTime": 2097.474
+            },
+            {
+              "startTime": 2102.814,
+              "duration": 7.984
+            },
+            {
+              "startTime": 2110.846,
+              "duration": 5.404
+            },
+            {
+              "startTime": 2116.27,
+              "duration": 5.933
+            },
+            {
+              "startTime": 2122.22,
+              "duration": 7.633
+            },
+            {
+              "startTime": 2129.879,
+              "duration": 37.465
+            },
+            {
+              "startTime": 2167.385,
+              "duration": 16.678
+            },
+            {
+              "startTime": 2185.233,
+              "duration": 10.582
+            },
+            {
+              "duration": 7.034,
+              "startTime": 2197.789
+            },
+            {
+              "startTime": 2204.851,
+              "duration": 10.195
+            },
+            {
+              "startTime": 2219.627,
+              "duration": 7.118
+            },
+            {
+              "startTime": 2230.773,
+              "duration": 5.333
+            },
+            {
+              "startTime": 2236.632,
+              "duration": 12.613
+            },
+            {
+              "startTime": 2249.362,
+              "duration": 6.802
+            },
+            {
+              "startTime": 2256.202,
+              "duration": 5.452
+            },
+            {
+              "startTime": 2261.667,
+              "duration": 7.08
+            },
+            {
+              "startTime": 2268.771,
+              "duration": 5.49
+            },
+            {
+              "startTime": 2275.679,
+              "duration": 5.427
+            },
+            {
+              "startTime": 2281.38,
+              "duration": 5.943
+            },
+            {
+              "startTime": 2287.335,
+              "duration": 6.397
+            },
+            {
+              "startTime": 2293.742,
+              "duration": 5.377
+            },
+            {
+              "startTime": 2299.134,
+              "duration": 6.415
+            },
+            {
+              "startTime": 2305.565,
+              "duration": 5.66
+            },
+            {
+              "startTime": 2311.24,
+              "duration": 5.442
+            },
+            {
+              "startTime": 2317.61,
+              "duration": 19.111
+            },
+            {
+              "duration": 6.034,
+              "startTime": 2336.822
+            },
+            {
+              "startTime": 2343.022,
+              "duration": 7.335
+            },
+            {
+              "startTime": 2350.693,
+              "duration": 5.398
+            },
+            {
+              "duration": 5.306,
+              "startTime": 2356.123
+            },
+            {
+              "startTime": 2361.445,
+              "duration": 5.2
+            },
+            {
+              "startTime": 2366.656,
+              "duration": 9.819
+            },
+            {
+              "startTime": 2376.956,
+              "duration": 27.739
+            },
+            {
+              "startTime": 2406.326,
+              "duration": 7.392
+            },
+            {
+              "startTime": 2413.856,
+              "duration": 26.496
+            },
+            {
+              "startTime": 2445.684,
+              "duration": 17.201
+            },
+            {
+              "startTime": 2465.748,
+              "duration": 20.055
+            },
+            {
+              "duration": 7.891,
+              "startTime": 2490.392
+            },
+            {
+              "startTime": 2500.653,
+              "duration": 72.39
+            },
+            {
+              "startTime": 2574.418,
+              "duration": 731.513
+            },
+            {
+              "startTime": 3310.796,
+              "duration": 23.785
+            },
+            {
+              "startTime": 3341.854,
+              "duration": 113.654
+            },
+            {
+              "startTime": 3455.527,
+              "duration": 12.878
+            },
+            {
+              "startTime": 3468.971,
+              "duration": 8.949
+            },
+            {
+              "startTime": 3478.257,
+              "duration": 21.319
+            },
+            {
+              "startTime": 3507.937,
+              "duration": 12.948
+            },
+            {
+              "startTime": 3521.918,
+              "duration": 31.567
+            },
+            {
+              "startTime": 3553.597,
+              "duration": 11.947
+            },
+            {
+              "startTime": 3566.177,
+              "duration": 111.427
+            },
+            {
+              "startTime": 3683.833,
+              "duration": 8.03
+            },
+            {
+              "startTime": 3692.892,
+              "duration": 93.833
+            },
+            {
+              "startTime": 3790.268,
+              "duration": 25.65
+            },
+            {
+              "startTime": 3816.729,
+              "duration": 16.385
+            },
+            {
+              "startTime": 3835.379,
+              "duration": 6.739
+            }
+          ],
+          "headings": [
+            {
+              "granularity": 1,
+              "key": "startTime",
+              "label": "Start Time",
+              "valueType": "ms"
+            },
+            {
+              "valueType": "ms",
+              "label": "End Time",
+              "key": "duration",
+              "granularity": 1
+            }
+          ]
+        }
+      },
+      "user-timings": {
+        "id": "user-timings",
+        "title": "User Timing marks and measures",
+        "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more about User Timing marks](https://developer.chrome.com/docs/lighthouse/performance/user-timings/).",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "details": {
+          "headings": [
+            {
+              "label": "Name",
+              "key": "name",
+              "valueType": "text"
+            },
+            {
+              "label": "Type",
+              "key": "timingType",
+              "valueType": "text"
+            },
+            {
+              "valueType": "ms",
+              "label": "Start Time",
+              "key": "startTime",
+              "granularity": 0.01
+            },
+            {
+              "valueType": "ms",
+              "key": "duration",
+              "label": "Duration",
+              "granularity": 0.01
+            }
+          ],
+          "items": [],
+          "type": "table"
+        }
+      },
+      "document-latency-insight": {
+        "id": "document-latency-insight",
+        "title": "Document request latency",
+        "description": "Your first network request is the most important. [Reduce its latency](https://developer.chrome.com/docs/performance/insights/document-latency) by avoiding redirects, ensuring a fast server response, and enabling text compression.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": {
+            "usesCompression": {
+              "value": true,
+              "label": "Applies text compression"
+            },
+            "serverResponseIsFast": {
+              "value": true,
+              "label": "Server responds quickly (observed 14 ms)"
+            },
+            "noRedirects": {
+              "value": true,
+              "label": "Avoids redirects"
+            }
+          },
+          "type": "checklist",
+          "debugData": {
+            "uncompressedResponseBytes": 0,
+            "redirectDuration": 0,
+            "wastedBytes": 0,
+            "serverResponseTime": 14,
+            "type": "debugdata"
+          }
+        }
+      },
+      "script-treemap-data": {
+        "id": "script-treemap-data",
+        "title": "Script Treemap Data",
+        "description": "Used for treemap app",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "treemap-data",
+          "nodes": [
+            {
+              "children": [
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 298,
+                  "name": "(inline) window.dataLaye…"
+                },
+                {
+                  "name": "(inline) window.AGO = {\n…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 631
+                },
+                {
+                  "resourceBytes": 592,
+                  "unusedBytes": 0,
+                  "name": "(inline) ((storageKey2, …"
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 520
+                },
+                {
+                  "resourceBytes": 16537,
+                  "unusedBytes": 0,
+                  "name": "(inline) window.__reactR…"
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 53
+                },
+                {
+                  "resourceBytes": 8723,
+                  "unusedBytes": 0,
+                  "name": "(inline) ;\nimport * as r…"
+                }
+              ],
+              "resourceBytes": 27354,
+              "name": "https://www.ocobo.co/clients/ekodev",
+              "encodedBytes": 4869
+            },
+            {
+              "encodedBytes": 3959,
+              "name": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "resourceBytes": 9792,
+              "unusedBytes": 749
+            },
+            {
+              "resourceBytes": 125385,
+              "unusedBytes": 72151,
+              "encodedBytes": 43335,
+              "name": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            },
+            {
+              "resourceBytes": 927,
+              "unusedBytes": 0,
+              "encodedBytes": 863,
+              "name": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js"
+            },
+            {
+              "unusedBytes": 1084,
+              "resourceBytes": 3192,
+              "encodedBytes": 1575,
+              "name": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "encodedBytes": 942,
+              "unusedBytes": 89,
+              "resourceBytes": 983
+            },
+            {
+              "unusedBytes": 6,
+              "resourceBytes": 141,
+              "name": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "encodedBytes": 78
+            },
+            {
+              "encodedBytes": 683,
+              "name": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "unusedBytes": 467,
+              "resourceBytes": 1284
+            },
+            {
+              "resourceBytes": 15426,
+              "unusedBytes": 809,
+              "encodedBytes": 6219,
+              "name": "https://www.ocobo.co/assets/cx-DiffRdtV.js"
+            },
+            {
+              "unusedBytes": 370,
+              "resourceBytes": 17234,
+              "encodedBytes": 5613,
+              "name": "https://www.ocobo.co/assets/factory-hx59odkt.js"
+            },
+            {
+              "encodedBytes": 1258,
+              "name": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "resourceBytes": 3070,
+              "unusedBytes": 738
+            },
+            {
+              "encodedBytes": 380,
+              "name": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "unusedBytes": 239,
+              "resourceBytes": 428
+            },
+            {
+              "resourceBytes": 410,
+              "unusedBytes": 0,
+              "encodedBytes": 362,
+              "name": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js"
+            },
+            {
+              "encodedBytes": 461,
+              "name": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "unusedBytes": 65,
+              "resourceBytes": 525
+            },
+            {
+              "encodedBytes": 878,
+              "name": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "unusedBytes": 362,
+              "resourceBytes": 942
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 349,
+              "encodedBytes": 301,
+              "name": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js"
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 1866,
+              "encodedBytes": 781,
+              "name": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js"
+            },
+            {
+              "encodedBytes": 285,
+              "name": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "unusedBytes": 0,
+              "resourceBytes": 348
+            },
+            {
+              "encodedBytes": 20672,
+              "name": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "resourceBytes": 67398,
+              "unusedBytes": 32058
+            },
+            {
+              "encodedBytes": 91,
+              "name": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "unusedBytes": 0,
+              "resourceBytes": 165
+            },
+            {
+              "resourceBytes": 206,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "encodedBytes": 158
+            },
+            {
+              "encodedBytes": 33600,
+              "name": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "resourceBytes": 109016,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 605,
+              "encodedBytes": 541,
+              "name": "https://www.ocobo.co/assets/layers-CQ3InJLS.js"
+            },
+            {
+              "encodedBytes": 751,
+              "name": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "unusedBytes": 0,
+              "resourceBytes": 826
+            },
+            {
+              "resourceBytes": 404,
+              "unusedBytes": 0,
+              "encodedBytes": 341,
+              "name": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js"
+            },
+            {
+              "encodedBytes": 426,
+              "name": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "unusedBytes": 0,
+              "resourceBytes": 490
+            },
+            {
+              "encodedBytes": 786,
+              "name": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "unusedBytes": 337,
+              "resourceBytes": 835
+            },
+            {
+              "resourceBytes": 68826,
+              "unusedBytes": 47522,
+              "encodedBytes": 25820,
+              "name": "https://www.ocobo.co/assets/portal-Clm-6X_X.js"
+            },
+            {
+              "unusedBytes": 31280,
+              "resourceBytes": 133936,
+              "encodedBytes": 44669,
+              "name": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "encodedBytes": 425,
+              "resourceBytes": 473,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 338,
+              "encodedBytes": 275,
+              "name": "https://www.ocobo.co/assets/x-B1I3g_bH.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "encodedBytes": 387,
+              "unusedBytes": 0,
+              "resourceBytes": 435
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 312,
+              "encodedBytes": 264,
+              "name": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js"
+            },
+            {
+              "encodedBytes": 250,
+              "name": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "resourceBytes": 309,
+              "unusedBytes": 194
+            },
+            {
+              "encodedBytes": 645,
+              "name": "https://www.ocobo.co/assets/_main.(_lang).clients._slug-Cr9mkmTq.js",
+              "unusedBytes": 0,
+              "resourceBytes": 1400
+            },
+            {
+              "encodedBytes": 6369,
+              "name": "https://www.ocobo.co/assets/story-article--3yoMqOg.js",
+              "resourceBytes": 24633,
+              "unusedBytes": 11379
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 656,
+              "encodedBytes": 581,
+              "name": "https://www.ocobo.co/assets/star-BI6vQnwF.js"
+            },
+            {
+              "resourceBytes": 446,
+              "unusedBytes": 0,
+              "encodedBytes": 383,
+              "name": "https://www.ocobo.co/assets/zap-C3uzvT7-.js"
+            },
+            {
+              "encodedBytes": 372,
+              "name": "https://www.ocobo.co/assets/chart-column-CxnbmN-k.js",
+              "unusedBytes": 0,
+              "resourceBytes": 435
+            },
+            {
+              "resourceBytes": 717,
+              "unusedBytes": 65,
+              "name": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "encodedBytes": 653
+            },
+            {
+              "resourceBytes": 302,
+              "unusedBytes": 4,
+              "name": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js",
+              "encodedBytes": 228
+            },
+            {
+              "unusedBytes": 4,
+              "resourceBytes": 1208,
+              "name": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "encodedBytes": 550
+            },
+            {
+              "name": "https://www.ocobo.co/assets/check-D95Zi0fi.js",
+              "encodedBytes": 240,
+              "resourceBytes": 303,
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 1276,
+              "name": "https://www.ocobo.co/assets/LayoutPost-BT26K59V.js",
+              "resourceBytes": 2543,
+              "unusedBytes": 483
+            },
+            {
+              "unusedBytes": 83667,
+              "resourceBytes": 138685,
+              "encodedBytes": 51204,
+              "name": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js"
+            },
+            {
+              "unusedBytes": 1829,
+              "resourceBytes": 2533,
+              "encodedBytes": 1226,
+              "name": "https://www.ocobo.co/assets/member-card-Bn7bfGBT.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "encodedBytes": 556,
+              "resourceBytes": 605,
+              "unusedBytes": 65
+            },
+            {
+              "name": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "encodedBytes": 500,
+              "unusedBytes": 0,
+              "resourceBytes": 549
+            },
+            {
+              "encodedBytes": 23527,
+              "name": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "unusedBytes": 28818,
+              "resourceBytes": 69550
+            },
+            {
+              "resourceBytes": 17494,
+              "unusedBytes": 12049,
+              "encodedBytes": 4217,
+              "name": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "encodedBytes": 156410,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "resourceBytes": 471493,
+              "unusedBytes": 202490
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 2125,
+              "encodedBytes": 580,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js"
+            },
+            {
+              "unusedBytes": 6432,
+              "resourceBytes": 12567,
+              "name": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "encodedBytes": 4673
+            },
+            {
+              "name": "https://www.ocobo.co/_vercel/insights/script.js",
+              "encodedBytes": 1227,
+              "unusedBytes": 682,
+              "resourceBytes": 2495
+            },
+            {
+              "encodedBytes": 26371,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "unusedBytes": 35974,
+              "resourceBytes": 78059
+            },
+            {
+              "resourceBytes": 97992,
+              "unusedBytes": 56996,
+              "encodedBytes": 27531,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            },
+            {
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "encodedBytes": 42584,
+              "resourceBytes": 108995,
+              "unusedBytes": 46367
+            },
+            {
+              "unusedBytes": 36142,
+              "resourceBytes": 72608,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "encodedBytes": 25121
+            },
+            {
+              "resourceBytes": 471493,
+              "unusedBytes": 335851,
+              "encodedBytes": 156410,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "encodedBytes": 580,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "resourceBytes": 2125,
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 4217,
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "resourceBytes": 17494
+            },
+            {
+              "encodedBytes": 202942,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "resourceBytes": 587832,
+              "unusedBytes": 337253
+            },
+            {
+              "unusedBytes": 248156,
+              "resourceBytes": 587832,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "encodedBytes": 202942
+            }
+          ]
+        }
+      },
+      "viewport-insight": {
+        "id": "viewport-insight",
+        "title": "Optimize viewport for mobile",
+        "description": "Tap interactions may be [delayed by up to 300 ms](https://developer.chrome.com/docs/performance/insights/viewport) if the viewport is not optimized for mobile.",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "node": {
+                "type": "node",
+                "nodeLabel": "head \u003e meta",
+                "path": "1,HTML,0,HEAD,2,META",
+                "lhId": "page-7-META",
+                "snippet": "\u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\"\u003e",
+                "boundingRect": {
+                  "top": 0,
+                  "width": 0,
+                  "right": 0,
+                  "bottom": 0,
+                  "left": 0,
+                  "height": 0
+                },
+                "selector": "head \u003e meta"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "key": "node",
+              "valueType": "node"
+            }
+          ]
+        }
+      },
+      "render-blocking-insight": {
+        "id": "render-blocking-insight",
+        "title": "Render blocking requests",
+        "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 660 ms",
+        "metricSavings": {
+          "LCP": 650,
+          "FCP": 650
+        },
+        "details": {
+          "type": "table",
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "valueType": "bytes",
+              "label": "Transfer Size",
+              "key": "totalBytes"
+            },
+            {
+              "valueType": "timespanMs",
+              "label": "Duration",
+              "key": "wastedMs"
+            }
+          ],
+          "items": [
+            {
+              "totalBytes": 24569,
+              "wastedMs": 164,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+            }
+          ]
+        }
+      },
+      "inp-breakdown-insight": {
+        "id": "inp-breakdown-insight",
+        "title": "INP breakdown",
+        "description": "Start investigating [how to improve INP](https://developer.chrome.com/docs/performance/insights/inp-breakdown) by looking at the longest subpart.",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "mainthread-work-breakdown": {
+        "id": "mainthread-work-breakdown",
+        "title": "Minimize main-thread work",
+        "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to minimize main-thread work](https://developer.chrome.com/docs/lighthouse/performance/mainthread-work-breakdown/)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "3.1 s",
+        "metricSavings": {
+          "TBT": 700
+        },
+        "details": {
+          "sortedBy": [
+            "duration"
+          ],
+          "items": [
+            {
+              "groupLabel": "Script Evaluation",
+              "group": "scriptEvaluation",
+              "duration": 1240.8587999999856
+            },
+            {
+              "duration": 1118.3484000000005,
+              "groupLabel": "Style & Layout",
+              "group": "styleLayout"
+            },
+            {
+              "duration": 364.13879999999995,
+              "groupLabel": "Script Parsing & Compilation",
+              "group": "scriptParseCompile"
+            },
+            {
+              "duration": 300.89279999999815,
+              "groupLabel": "Other",
+              "group": "other"
+            },
+            {
+              "duration": 36.924,
+              "groupLabel": "Parse HTML & CSS",
+              "group": "parseHTML"
+            },
+            {
+              "duration": 25.347600000000003,
+              "group": "paintCompositeRender",
+              "groupLabel": "Rendering"
+            },
+            {
+              "groupLabel": "Garbage Collection",
+              "group": "garbageCollection",
+              "duration": 17.832
+            }
+          ],
+          "headings": [
+            {
+              "label": "Category",
+              "key": "groupLabel",
+              "valueType": "text"
+            },
+            {
+              "valueType": "ms",
+              "label": "Time Spent",
+              "key": "duration",
+              "granularity": 1
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 3104.3423999999841,
+        "numericUnit": "millisecond"
+      },
+      "final-screenshot": {
+        "id": "final-screenshot",
+        "title": "Final Screenshot",
+        "description": "The last screenshot captured of the pageload.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "timestamp": 3528771776,
+          "type": "screenshot",
+          "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAE4QAAEDAwIEBAQEAwQGBggHAAECAwQABREGEgcTITEUIkFRCDJhcRWBkaEjQlIzcrHBFhckYnTRJjQ1goThJZKio7KztMMnNkNFg8Lw/8QAFwEBAQEBAAAAAAAAAAAAAAAAAAEEBf/EACARAQABAwMFAAAAAAAAAAAAAAADAQQRAhJBEyIx0fD/2gAMAwEAAhEDEQA/AJU0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUr4pQSkqUQEgZJPYVrzWuNKvXDwLWorSuXnaGkykEk+3fv9KDYqUJAGSenvWunXGlkz/BHUVpEvO3leLRuz7d+/0oNipQEEAg5B9axV51Da7KtCbrK8IheMPOtqDQ+7mNo/M0GVpWhca5X/4SX+TDf6GOlSHWl9wVJ6gissdX6es0SBGu98t0OUplv+G/ISlXVI6kE9KDZ6VTjSGZTCH4zrbzLg3IcbUFJUPcEd6wt31jpuzyxFut9tkSTnHKekoSofcE9PzoM9SqUSSxMjokRHm32HBlDjagpKh7gjvVWgUpSgUpSgUpSgUpSgUpSgUpXxatqSaAVBPcgV8DiD2UKxdyuMS3sGRcZTMZnITzHlhCcnsMmrCHqWxzZKI8O8W9+Q4cIbbkIUpX2ANBstKoR1k+U/lVegUpSgUpSg5vxwfeXZ7HaEvLjxLxdWIMtxB2nkqJKk59M4xWxy9C6YkWFVoXZYCYOwoCUspBT0xuCsZCvr3q81dp2DqqxP2u5pVyXMKStBwtpY6pWk+hBrT3dF6zkwjbJWvFqtqk8ta0W9CZKkdiOZu749cZoNEN9uT/AAPhwVTXShy8CyKnpVhS43NKd+fqkbc11xGgdKpsf4SLFb/BbNmCynd2xnd33fXOa9vaJsjuiRpUxiLSloNJSD5kkHIWD/Vu65961pOidaIifhydfu/hoTywo29Bk7O2Obnvj1xmgw3EGVJ0JwUMfTt4ellt1MNE5SwpbLalkEbh6pHlB7iui6f05bLfpxFubaEiO8yEvrePMVIyOqlk/MTmqdu0bZIWj06ZERL1p5ZbW295i5k5KlH+onrn3q1Vp66Wyyiz6YnpjRtnLRImrVIcjp7YQnpnHpuUcUHFY77sfhFxQsCXVvW6zTlx4a1HO1vmDyZ+mP3rs+idKWaHpOI2YsacqXHQ5JkvIDipSlJBKlE9wc9B6CseOGcCPw1naSgSXG/GgqfmOJ3rccKgStQ6ZzjFG9HajtMTwGl9UtwraE7W2ZUESFRx6htW4dPYKzig1TT8t7SH+tG1WQlUCzteMgtfMGFraUtSB9ARnFbTws0lY2dDW2SuHFnSrjHTJlyn20uLfW4NyskjqMntWa0Xo6HpmzyohdcnyZzinp0qQAVyVq7lX0x0ArXYWgtQ6fQ5C0hq3wNnKlKaiS4SZJj5OSEKJBx7A5oKHD5luwcT9WabtY2WZDLE5tgHKY7i8hSU+wPfFdQrWdEaRY0uzMcXLfuF0nOc6ZOf+d5XoMDoEgdAB2rZqBSlKBSlKBSlKBSlKBSlKBXh8ZaNe6HrQa7qMSTbT4ITi9uH/UuTzMf/AMvlx+9YKypu/wCKMeKGouTk7vFCDy+x+bl+f9K3ZbJB8vUV5DSyfloPrA/iCrqvDTYQPrXugUpSgUpVnKuDUeW3HVnepJWTg4Sn3/WgvKV8SQpIUOx6isdebmbd4fazzS6opxuI/wAj3/KgyVKw/wCLPqROU3FQUxiseZwjdt7/AMtJN3dYaQVsM7+SX1gvYG32SSOp/SgzFKxjd1C30thvBLpbwVdQA3vzj9q82u7iZbHpjrXJQ2MnqSCNoJ7ge+O3pQZWlYmJeUvxIrym0oLrxZWN+Q2QFHvjr2H61T/Gzvt6eQnMwZT/ABPl69c9Pbt7npQZqlY64XExJkdnlpKHCAVqURjJAHYH39cCqIvSeWpZZyEMuPKCVZI2Kxj8/wDKgy9KxJuziW0gtRy6twNp2yAUDKSrqrHTt7e1E3VxcqOyhhB5jYcUoObgOpHQgYPb6UGWpWB/H1+FLvhkBYXtKC4fKME5Pl+noCPrV7c7kYcVp5ttLgX3O4gAYznoCf2oMjSsS9dXmXZO5hostNJdC0unKgokD+Xp26nNW8m/LjtK3RkLdS7yyG3CpJ8m4YO3v6dhQZ6lYmZd1sLWhEcLUl5DIyo9dyN2egP2qpGuS3bkYjjSW/LkK3k7jgE46Y9ffPTtQZKlKUClKUClKUClKUClKUClKUCvC2kLWhakgqQcpPqK90oFeHWm3cc1tC8dtwzXulBRESOlxxaY7QW4CFqCBlQPfJ9a9OR2XdnMabXsOU7kg7ft7VUpQU+Q1zi7ykc0jBXtGce2aCOyltTYabCFd0hIwemO32AqpSgprjsuJWlbLakrOVApBCj7n37V8MZhXdls9AOqR2HUD8qq0oKbjDLjiFuNNrWjqlSkglP2PpRDDKFLUhpCVL6rISAVff3qpSgoCHGDKmRHZDSjko2DaT9q+qiRlKbUqOyVNgBBKBlOO2Paq1KC38DE5Zb8KxsKtxTyxgn3x71UeYZfQEPtNuJByAtIIB/OqlKDyWmyVEoTlQ2k47j2P6mqYiRw2Gww0GxnCQgYGe/Sq1KCi7FjvAh1hpYUQohSAckDAP6V9bjMNucxtlpLm3buSkA49s+1VaUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUCsVqXUNq0zbDcb7MRDhhYQXFJKvMewwATWVqOvxfXvZb7FZG1dXXFy3R9Ejan/wCJX6UHXtM8RdJ6nuf4fYry1LmFBcDQbWklI7nzJA9a2yoMcP3ndD8VdOPS1FCSY63CemG5DSSc/YOftXQdU6z19rTihc9NaRuK4LcR51ptppwM5DRwpSl9zkjt9e1ESmpUZ7Nr3iPpbRGoZGp4rr3IQlEKZKSk7HS4EEHHzDCiRn+nvWs2q68YLlZ42qLbdZ0qLIkFpCEOIVlQJz/CxgJyCO1FS+pUYuIvE3XEm42HS1tQbPepLDImBO0LU+s4ACuoSnsenXr9KwsfiFrvRt6vWmNU3F2U6YT6QsuBbjDhYUptxDg699vQ/tQS3pULNKa519MsWp342o5K0Q4aXXVyXlLWhJcSn+F3AUc9/ar22cSeIM3hzfH27yFMW+RGDkpZxJSHCoBKSB1BKRknr+tBMalQ5vfE3Vk3hlZJf43MZnN3GTFcfYXy1PIS20pO7bjON5Fe39YcT42jLTqtN3dbtDavCoUXUrU8sKVlTiVZ3ZII6+gH3oJh0qJerOMWrNUydP2vTkn8KflMtJeLSgguPqUR85+VPb19TnNYTVOtuIFu12Lbeb9Jjy2XGGnmockho+VPXCTjJHU/UnoKCZ9Kiw1r3iHr/iDMa0bKTGi29Snm4hWltCm0Kx/Ez1UVdMjt19K0KNxH1i+9d1r1FdUYZWtKBKVhs709uvpkignJSoWWvXGvndBXm5NakkmPFlx0OOOOqU/lQXgIJ7J6dffpWYncbdV/6ubYwzMCbq7JeZenbE8wtoS2U46YB/idTjPQUEu6VFTRWoeKds1Zb23H5t+gulC32885stqPXCyOhHXqDj71rWktV8QtQazcs9l1FNclvh9ttEmUrYkBKsnrnBABI9jigmTPlIgwZMt0KLbDanVBPchIJOPr0rQuHXFuw69vT9ss8W5MyGY5kqVKbQlJSFJTgbVk5yoelXWnoF7tfCR+JqqUqVeW4crnvF0uFWS4U+Y9/KUj8qiZwr1TK0c7qO624I8aLYWmVLGQlSn2Rux64GT96CdtKhrI1hxLb0Au/P31xVrnSw2h5MgJfbWnOQkJwUpODkfQHFdv+GW93O/aBmSr1PkzpKbi42l2Q4VqCQ22QMn0yT+tB1ulKUClKUClKUClKUCuDcYeD+o9ea0VdY1xtjMFDLbDLby3AtKRknOEEfMVetd5rXdW6109pFDStQ3RmGp0EtoIKlqA9QlIJx9cUHE9c/DzMnXliRpa4xmIqWEIWJz7q3OYnIyDtV0xtwM9MVW1XwDvE+9G9WW+xodxkgOSUErSEvFP8QoWkZ2k5OCB3rqll4oaOvUWa/br006mGwuS8gtrStLaBlSgggE4A9AaxrPGrQTsWRIRfP4TG3eVRXgfMcAAFOT2Pb2ojT9I/D9Gt+nb3Evd1MibcmQyHGEYSxhYWCM9VHclPt0GPrWqo+HDUJWmG7qaJ+FJc3gBLhIPqoN/LnH1rqXEziFbYNkgot+qoNnfnoQ+HnIy33UsLTkLQ2kZCj0xuHv7VkuHerNPP6TV4bVf4wi3NlUqZMPLcSnqdywQCB6ZPt3orRtdcA2Lnb7OdN3IQ7hbo6I298Ha8EnIWSnqlWSeoB9Pasdpv4fpsf8AFJ+oLyzOur0R9mMAVlCXVtqQFrWobjjPbFdH/wBcOhfBSZab80pmOtLbm1lwqyrOCE7ckdO4GK0niVx4gwLFBlaFlRZ0l6QptxMqK6EhCU5JGdvXJT+tEYnSfArUFnsWqIMi42pbl1hJjMqQtzCVBxKsqyjtgema+2TgXqCBoLU1jduNqVJujsRbS0qc2JDSlFW7yZ67hjANX7/Ei66m4FyL7EvMOz3mLJDM11DDgQ2CshKU9FnJCmzkZ9e3pm+DGtkI4czLpq7VMac3GlloylpWjYNqSEEqSkrV1z0B70HEuKehbhoDQVltl1kxZDz9zkyUqjFRSElplODuA65SazWh+Cs7WWjrDcY9+MS2SULcfjuBS9riXVp3ITkJ6pA7/XvXbI2t+G2vZ8e2uyLXdJKVHkNToh+Y99nMTjJx6d692XiZw+iTTp+13CNCVGLqfDoiLYaa2blL67QkdlH6/nQaXxB+H6NeGbarTM5uC9DjIiqRISSl4JzhZI6hXU56HP0rWJHw33iPeY7tru9vXDaLSiZBWlxSgAV9AkgDdnHXtiu86Q13pvV7jzenro1LdZG5be1SFgds7VAEj61d6q1XY9KRESdQXFmE04cI35Klkd9qRkn8hRURtfxtNW7iNeF228XK1pTLcRKjtsHdjd5w0tKsEHrgKxj61h+Fmjbhre73W32nY0PCKJefJ2I86cBRAPU4Pp6Vm/iJvFsvGto06wuRHoEqC08HWWkgrUVLBKjjdnoAQe2K6XoviEjT3Eq8aZTbbPa9NW8SXXXIsVQdKWkFW5RBO44HtmiKVr4FagicPr5YXLjajKnyo77biVubEhvdkHyZz5hjpX2P8PUp7QX4XPucRu9MTXZMd9ncpooWhtJQvIB7t5yO31rp8Di1oy4Wm53KJdlLhW1LapTnhXRywtW1PQpycnp0zVkeNugRFTIN6XyVLLYV4N/5gASPk9iKK53pL4fbqjUUO4auvrMuPEUhSWmFOOKcCTkJKlgbU/bP5VkOGHBe+aT4jR9QTp9seiNl4ltlSys70KSO6QP5h610BfF3QyPA8y/sI8YjmNbm1jCckZV5fJ1H82PftWS1XxC0tpRTSL5d2I7rqQtDaQpxZSeytqQTj60GevMVc6zzojSkpcfYcaSVdgVJIGf1qPejfh5uEMXiPqG5QVRp0Ex21xCtS23OY2tKsKSAR5Dnr6127SOttPavQ8dPXNmYpnBcQApC0g+pSoA4+tbFQRdPw0XRMCXtvcJyZzEiPkLQ3s/mK+hO7tgDp9a7DwR0RP0DpKTarpIiyH3Zi5IVGKikJKEJx5gDnymug0oFKUoFKUoFKUoFKUoFRG+IxCI/GmLI1AzIesymo6tjZwVsj50pPvnd+tS5rnuvNWcO27l+C6zeguzGdqgxJiLd2bgCMEIIGQR2NBG6G/oqZfL4vStsv8ZX4fMVHC30FttPhl7twwVbe/8AMe4q++G3SFj1ffbxH1FBExliMlxtJcWjaoqxnykelSot2j9OW2JKjW+yW+MxKbLL6WmEp5qCMFKvcYPavWn9J2DTrzr1jtEOA66kIcUw2ElQznBoiH3EiDEsXGKfHv0Rw2lpaUtNkLWPDhsJaxhaSoAAD5h271iW49tlWHUDmmo17LrTYXIWSkMCPzU9FJGVDrtOCo9u5xmptX/TFj1Dyvxy0wp5a+QvtBZT9iaqWfT1nssJyJabZDiRnf7RtllKUr9PN7/nQQOel2FzRbEWPZpKb+0+Vv3HnktqbOcJ2dh6fp3rPvQUL4DxpyYyFPN6gcbU+EDclBjo8u7vjOOnvUk353Clm+vaScjWdM2RISl2KmLhCnh0SkqCdu4ZIxnoTjvW8wdK2GDZ3rVEtEFq2PqK3IoZHLWo46lPYnoP0FBF+1Xi2S/hivtrhMFu4wHmFzXOWEhwuSSUHcOqiEpA69sAVzx1marhhEebSs29F3fS6R8ocLLOzP5BdTaY0Npdi2y7ezYbc3CllKn2UsAJdKTlO4euD1FXEDSWn4FqkWyHZoLVukK3vRksp5a1YAyU9ieg/ShhCi/rsNzuunWOHtuuMW4cttt4Or3Kck5GFI6nHX16Dt0FZjh7a4t446fh94YblR3Zc3mtrHlUQh0/4gGpd2XRmmrHKEm0WO3Q5IBAdaYSFD7HuK8wdFaagXf8Uh2OAxcdyl+IQ0AvKgQo5+oJ/Wgi/wDCiojie6Aeht7uR7+ZFZj4rWXW9f2GVcG3l2hUVKcIOM7XCXAk9grBT+1SJsejNN2GaZlmskGFKKCjmsNBKtpxkZ9ugrI3mz229xPC3iDGmx87uW+2FgH36+tBAvX72npOoVPaPgS4NoW0nltSiSoq7KIyT0yPc9j9ql3r3RliZ0jqi8QbRHTen7ZJKpKEneoqaUD+tbDN0BpKcWDL07bHeQ0GW9zCfIgZwkfTqf1rZtqdm3A24xj0xRUDNJXiHC0Dri2vrWJVwZichIQSDsfClZI6DoR3rAO//lmN/wAY7/8AA3U8E6F0qlmY0jT9sQ3LAS+lMdIDgCgoA4HbIB/IVpGqEcItMXBmz3yBZo0hRDgZ8KVBG7A3KwCE5wO/tREaNdW2HC0roiRFjttPS7e44+tI6uKDywCfrjpXy+7Y2sbZI1Qy69CdgQ3cKSpW9sxkBJACkkgH2UOxqXdysHD51EOFcomnyIrYRHZeU2C2hR3AJBPQHOfzrNXPSGnrpCiRLjZYEmNEQG46HWQoNJAACU+wwB0+lBHf4bk2J3iJIcske885LLpU4ooTHS0SMBSfModcYBUeo7nFSlrGWKwWmwR1sWS2xIDSzlSY7QRuP1x3rJ0UpSlApSlApSlApSlApSlAqF/xIqKOMtwUBuKW45wPX+GmpoVGTjbwt1hqfiVMutktYfgOoZSh7xLSOqUJB6KUD0I9qCtb+N2rYGt02zVdoahRpiwGmVslDrCV9G1ZPzDOM5Hv27Vb8N+MWrr8dTi4yYqvAWKVPY2x0pw63t2k+46npVzaeD+s75xDZumuZ7T8SEtITJ5iVKkIR1QEpHYZ6nOO571g7DwY1/Yp99bgCGmPJt0mIXg6hXiEKHRtIJBSVEJGTgDr1oirp3jzqtOn75OuDcac8wWWo4DIQhpSyvK17epHlxj3IqnYuMnE+4oVMgW+NcoyFYWhqGVY/JJ3CqekuE3Ee02m6oiRGIEp1bKgl6Qy4iQ2kObkEAqSeqknChjp9KtGuDPES539qS9At9nWgjElh1plCSP5glnrn7AUHjVd3Ef4gWFt2y3tvKnQ1FRaOQpxLalEjON2VHqRmsjpLjbr65uXVKGolwVHt70kJ5SGw0EYJcP9QAz5fUkVldV8LNYzeMbd7j2/xVtTLiOKlmQ0krS2lsLVtKt3dKumKseGXCfWlkk6iXc7OGUy7HLhsnxTKtzq0gJT0WcZ9z0oM/oDjvcZWldSzdRRI78q1soeZLA5YdK1hASodceYp6j0zWqHjpxDSy3d1QoItbrpQgeFPLUR3SFZ3H9ayXDngtqX8L1RbdRw021FwhIbjvF5t0c1LiVpyEKJxlNYe28KOKtvKbbAbbhxEvbxKZlNI6/1b0nm4+n7UGz8Q+PV8hR7OmxW1uCuXDTKdXLbKlBRKklKQcDAKT1Pf6VcaP4rcQUOuv6jsaZNrTDfkB9qMpG4obUtIC0kp6kY7V61xw74inwLNvkRdRxW4iG3fxEtPK53UrUOcOgJPQg5wBWG4c8H+IFnkXGd4lqzPORHm22USQS44pJCM7MpABIOc+nagxtu438Rr5cHRZosJ4p83hmY24gfTJ3H8qkRoi/Xa8cPWLteoYg3UtOl1jlqQEqSVAeVXUZwD+dRuvPCLiTeJDLcyzWpKkq6y2DGZ3fVRRhSv0JqSfD/AE9cLJw/g2S9TfFzW2VtuPBRUAFE4AJ6kJBA/Kg4bw34xauvp1R+IyYq/AWKVPY2x0pw63t2k+46npWvscddbrsE2WqXD5zUlhpJ8KnG1aXSen/cTV7YeDHECxT763BENMeTbpMQvBxCvEIUOjaQSCkqISMnAHXrWFj8FtfI09OiqsYD7sphxCfGMdUpS8FHO/Hdaf1oM5L44a8i6Vs9yVHghuQ88gyltpIfKCPKEAjaAFDr65+la/xl1a3fbppq9/hNv5020tyHd6Cf4gddQQeoynydM56Vsd74Ta0k8MdM2hizhVwhy5br7XimRsSvZtOd+DnB7Gsfqng7rmdbdMtRbKFuQ7Z4d8eLYGxzxD68dV9fKtJyOnWg03iuu7O8S5blz5HjVqZUzygAkNlCS0MD/c25qcFjE4WWALuWzcvDt+KLfy83aN+PpuzUduL3B7U941BFvenmmZLi4rCHmFPIQttxtCU9CohJHlHr713zRTd4a0rbUalWHLyGh4pQKSCvJ/p6e3ais1SlKBSlKBSlKBSlKBSlKBSlKBVrcbhCtkcv3GXHiMA45j7gbT+pNXVRM+JB5c3jBAt9+lvRbGhpgJcSnIbbUf4iwPU5z79hQbZxM4z6h05xHesloRa3raDHLbjjSlqUHEIUTuCwD8xx0rtkLV2m50oxoV/tMiSApRaamNrXhIJUcA56AEn2xUHNRsWqLrsR9PXJ652pp5lDEl4EKUkBPTsOgOQOg6CszwrmRrZxJfeuD7cZpLE5BW6oJAUWXABk+pPSiJho1xpNxDim9TWRSW07lkT2iEjIGT5ugyQPuRVZnV+m3m2Vs6gtDiHneQ0pMxshbnTyJOeqvMnoOvUe9QMsn/Zeof8Agkf/AFLNdl+HvhvbdWWEXyfNntyLbdCWGWlpDeUpaXkgg9ScA4PYCgk47eLYzcUQHbjDROWMpjqeSHFDGeic5PStE4kcTbbadEXS5aUvNluN0ihpSGUSEPeVTqEKJShWcYV398VFKxSLVO1Hd5+s7tdIM4Bx9l6Ijc4ZO7OCe46/b7isRYf+ytSf8Aj/AOqj0EsuC/E93VGm5tx1dKtVvW3MEZkhXISvyBWPOo5PU9quOOWs9QaVtdrkaXNr2SlrDj0t5tPYApCApQBzk5Iz2qKdoiWGRoq8PXK8SGLxHcSqBASklt3dgLUenfA9x2Hetg1BJmSOBulxMWtbbV0ktxys5/hhCeg+gUVUG96m48avtLtuaQzYVreiIedLYLyd5UoHCkuY9O3XByPStst/E7VSeKztouy9Ox7I3JcacCpjSVNtpz5s8zO7p1GPyFRnvP8A1Oxf8Gf/AJ7tb05EYuHxGSYctHMjSL86y6jJG5KnFAjI6joT2oO06P49RtQ67jafdtDMOO+84yicqeFJJAVswNgB3EAAZ7qHetr4j6nukGfHtVjuWnrUt1O92ddJqElvr8qGicqJ75PSor6BFmtXF2Ob0UsWyFLeUkrUrCFthZa7dThYR9/WsTbkQr3crzI1TcnI81SVuocdWrzO5Od2EKJ+3T7ignzAfTJhMvIfZkBaAeaycoWfUp6np+da5dOIOmLVqdnT0+6tM3Z0pCWShRAKvlBUBgE5HQn1Fc8+FtMZjTl2jwb2u5x0PIXyzGW0mOpQOQCr5s4Hbtj61caxicMHOLcNy/SVo1PvZPKBXylOdOXzMDGcbfUdMZorstYZeq9PNzPCOX21JlZxyTLbC8+23Oa1/jfMmQeFWopFuUtEgMBO5HcJUtKVkf8AdKqiJY7PpCXpByXdtRyIN98VsTGTGLqeVgebp3Pfrn07UE7Zk2LBiqkzZLMeOkZLrqwhI/M9KtrTe7VeErVaLnCnBHzGM+l3b99pNQ04jTVu23RVqVe5M7TzcTKJSmVN5/jrSo7CckpSlIH0H1qvp4W/TvGuwtcPrtJuUFyQw2XVJKSsLIDiD0GRjPXHT8s0EuYOrtNz5JjwdQWiTICVKLTMxtasJGScA5wAMmrmHf7POhvS4V1gSIrKdzrzUhC0IHupQOAPvUH+G9oYvmsJcKW4+hkw5jh5K9hJS0tQBPtkDI9a+cOLWm6xNXockyWURrG/L2subQ6ptbZSlY9U5OcURNt7VFgYt6J718tbcFa+WiQuW2G1LxnaFZwTgE4r5/pVp/wseT+O2vw0lRSy74tvY6QcEJOcEg98VBCK84dB3NgrPKTcoiwnPQEtSAT+wrJ6ks7EXhvo66pdfXImrmtrStzKEJbcTtCB6fMon3JoJyyr1a4b0dmXcoTDskZZQ4+lKnR7pBPXuO1fbrebZZ2kuXa4w4LavlVJfS2D9ioioM67twhWPRssSZLzsy2cxQec3BvDq0hKP6U4HarnUc1eoNdQv9LZj6IxiRklxSynagsIUCDtVgEnJO09yaCbKdQ2VVsduSbvbzb2scyUJKOUjJwMrzgdSPX1q3Z1dpt+I7LZ1BaHIrSkoceTMbKEKV8oKs4BODgfSoaQI9ug6c1a3a9RqkcyMEqhIjubVoD7eFlwhIyOnXaO/pmsdabQxJ4YX+6OLe58OdFbbQFkIwsLySn1PQdaCWXFbihC0JZrfOjMxrs5Nd2oZRLDZLe0nmDAVlOQB2x171mOF+tWNeaVZu7TLUV4rWh2Kl8OqZIUQNxwMZAB6gdDURJkRqRwOt9xdSpcuLfXYTThUfIypkOFOM4+br2rv/wquWb/AEAWzb3EG7B0uXBAUolJKlhskHoMpT6e1B2mlKUUrVtcaB09rZthOoIXOcYzy3kLKFpB7jI9Poa2mubcU+Ltn4fymYL0Z6fc3G+byGlBIQknAKlHtnB6YNBRl8DdEPz2pYhSGFNJbCUMvlKBsAAOPfpkn1OTV8/wh0VI1C7eVWsGW6pbi0hwlsrVnKtnbOTn71oY43WfWulNTWhyC/bLg7aZZZStYcQ4QyskBQAwcAnqPSuW8CdYM6Ha1RepDHii3GZQhgObC4pToGAcH0ye3pRHeo3AfRUdmU02xP2SWw05mSflC0r6dPdArctC6NtOiLU9brEh5EZ14yFB1zedxSlPf7JFc9tnHi2OaMe1Dd7W9CR4kxYsZt4POSFBIUojypAAyOpqz0l8RNkvN5ZgXO1yLWl9YbbfLodQCTgbugKR9etFbvL4T6NlalF9dtCPHFZdUkKPKWs/zFHbPr9+tYSLwJ0THZlstNTtspoMuAyiSUhaV9OnuhNWmruPWndPanVZ0xZU3kO8qVIaICGjnzY9VEevbtXB+DN0iRONLF0kvhuA2Zshbqs4CAy6c/pREiG+Behk29MRVvfcQl7nBan1b84AKdwwdvQdKzmpuGWmdRWO22iXDWzb7cSY7UZwthORg/euZy/iZtDc9TcWwTXoYOA8p5KFEe+zB/xrO6v45wrLY7HeLZZ3Lnbbohza4ZAZU04ggKbUnarr196KvpHAbRT7cZDjE/bHb5SMST8u5Svb3UayrfCPSyNYf6TJal/inizN3c87OYVbvl9s+lahqfj9Es6rMiHYnJ67jBallKZQQWlLJHL+Q5Ix36V1PUmpYmmdKvXy+gx2WW0qcbQd6t5wAhPbJycen5UGsX3g5oy93xd2l21aJbjnNd5LykJcV7lIOMn6YqlqTgtovUF2euMu3usyXlbnfDPFtK1eqintk/StIX8S9pMCQ63YpXiUOpS0wt8J5iDnKtwScEdOn1710zhRrlPEDTTt3RAMANyVR+UXuZnalJznA/q7Y9KDN6V01adK2lFtsUNEWKk7ikEkqUe6lE9SfvWEvPDPTF51cxqWfBUu5tKQvcHCELUjG0qT6kYH6Cud6k+I+z2y7vw7bZpNwaZWWy+Xg0lRBwSkYJI++KwXELjS9qPhw7I0xDuttkCUhp+U26U+H7KHmR3Cuo64/OgkfLjMzIrsaU0h6O6kocbWMpUkjBBHtXMl8BtBKll/8MkJSTnkiUvZ9u+f3rmfCri3drHw6vlxvsa4Xvws5sIkyZSvNzEgcsKUlWNu3dj/AH/T12Wz/EXDucm1xUafdRKmTBGUjxWQ0klASvOzrkqV06fL360HTdR8O9L6gsUS0XC1tCHDTtjBnLamB/ukfv7+tWWi+Fek9Hz/AB1ot6jNAKUvvuFxSAe+3PQfcDNaVo3j01qV27oTp5cb8Ptr9xJMwL38oA7PkGM57+ntX3SvxA2u7QrvMulpdtsa3spdymQHlOqUoJCEjanr196DZ9P8G9J2G6LuFvZmCStp1klcgqG1xJSrp9ia+WHg1pKxIuaYDMwC4w1wX98gqy0sgqx06HyjrWixfiZtC5wRJ0/NaiFWOcl5K1Ae+zA/xrS+PnEW+HW7SdPXO6222CEyplbEhxtEpKxv5oAx/Vs9eqD9gR2FHAjRSLe/CSxP5Dzrbyh4k53ICwnrj2cVV7P4NaSnWC1WZ9mYYVtU8qOBIIUC6QVZOOvUCtUu3Gx7SukdJyblp6S/KuURS1pelFtaS2rZuOUEnd82fr696q6x48t6aNk3aeXJ/E7WxchiYEcsObvJ8hzjb36faitlu/BnSV2hWuJMZmFm2sGNH2yCCEbirr06nJNXOouEekdQRbczcILm+DHRFaeadKHC2hISkKI+bAHrWiSPiMhRNRS7bM0+62zGedaU+mVuJ2bsYTs9SAO/rVxcOOtok8PFXCbEnwJk5x6KxHhvpU8nalOXAspAT8w64PX3oNutnCfRUSw3WyQYh5czY3McD5U9hKkrSkq/l6hJx0qnF4M6SjadnWVpmZ4GY82+6DIJUVIztwcdPmNc64LcT9HRLwLRGs021yrm6lK5kiUZJfd7J5ijggkn0GMmpG0Gj23hbpWDpKTpoQlyLVIfMlSH3SpQcwkbkqGCOiR2+vvV5oPh/YdCiaNPsPNmYUF4uulZO3dtAz2xuP61tlKBSlKBUWfiP03ebdxFj6riwXZluWlk7kI3pbWjptV0OM4BBPvUpqUEOdMou+ol6luTWkITMQW6W47OeadU42eQsAIWpWCsnHYeprn9q0tOuFkvM5DD6VW5DThQWz50qXsOPqMg/rX6DUomEGm7NeNRcM4rVvt8h1ywy3lPNNtHeWnwkheMZVhTagcdgR6VeyWNQcU73YoMHTbUDwjKIq348dSEBIIytxR6DHoP071NilBD5y0ak4d8Wp62NOfjXjXHW4hfZUtt1LishQV2CvQ/n961HQ2mrpedav2tEVUeVIYmNpBQUoC+Q5hOewGelTvpQQPguXixQZunJmmXJEhyQlRafacyFDHTanBV26dcdeldk1ho6fL+Hdtc2yRLXc4T/j0w4TSk7EE7TuBJO4pO49fQe1SMpRUI+CGmpeoOJllanMP+EhHxKy4k4CW/MlPX0KiB+dSX4+6en6l4azodoaU/MbcbfSyn5nAk9QPc4JOPpXRaUEEpitTu8Pk2h+wNs2u3SwVSTDKJHNXuOwqPU+vp6DPpUh/hSZcZ4ay0vNrbV+JOnC0kHHLbrs1KCDWpFyoV5lSmtLXOyX0PKKXYy1oZyT1PKUgnBGegVjr2xXQrfY9X6h4Hakbn2PlzlyWH2NkRLD8pCTlRKUgbsDscZPXv0qR+qb01p3T0+7yGXn2obRdU2ynctWPQCtQ4TcT4vEQXARrZJgrh7dxcUFpUFZxhQ9enaiIu22ddmuF180w7Z5CGEy0Ty+ppYUHMto5eMY7An36V3L4Wbak8OLl4mIkP/iTuwut+YfwmsYyPeu50oqDujrdqHS951LDc0/NefctE2G6FIKA0go6uZIwQNvT3yMd6sNH6Su9/sGomLdDkOSY7bMkMhB3OhKiCEj1OFZx9KnjWj6b4qaS1HqBuy2i4OvXFe8JbMdxAO0Eq6kY7A0RF+23y+vWS0aZa0JCmvwHFEF+3uKccKifmAI9+p+g9q2b4htJX3Zpe5C0BDDNpaiSG4LRLUZ1KlKKcDOE+fA6+ldb0lxogak16dMs2aewsrcQl9zHQoBJ3J7pHT39q6vQQ94pN37VmgdGXs2WS23FZdhOJabUrYElISojGQFBJOe1apxGN3uQ0uZlmlQ/D2ONGaCgVF1CCsBzGPLnr0Ppg+tTtpRUMdCwHl/EEwX4jimDdnySts7SMr9xit/8Ail0bcZEm032zwVPwozJZfbYbzyzu3BRSPQ5IJ+gzUj6UEQeH7941XxAtr8fR0J0IW0H5Utp1YZSk5K924JBx2GPbAqX1KUClKUClKUCo0/Ebd9csaq5NmfuLFiZZQQu3qUAFkZVzCjqD7A+mCKktXIOIvByRqnVz+oLXqWTaZT7aELShsn5UhIwUqSewoOT8PtVajsi7ldkaubv0OHAedXEXKdUoL24QSh1IJAURkpz96wTNx4g3vS911sNVyERoMgNuNCattRUSPlbT5ceYdOnrXaNBcAbbp+bIl3q5uXVx5h2OWw1ykbXElKiepJOCfXp3rXJPwyIM5fhdTLbglWUtri7lgexIUAT9cURyvWXEvU17j2OSq7T4shuGWXzFfWyl5SXV4WUpIGSCAftWT1PrDWeltX2p57UkuSoxIknlpWoNFCm0nYpBJB6dCT1Peurat+HiNc02lmy3dMCNBieHIdj81bq96lqcJCh1O7tj0r1rbgK/qW6w5iNQNRxHhR4mwxCrcWkBO7O8d8dqDe+N2q5mjuH0y5WvAnLWhhlwjIbKj82PXABx9cVGd+4cQLZpO3a4VquSqNLklpDXjVrWFAq+Zs+XHlPTr6dKl3rLTcDVunJdmuqVGNISBuQcKQoHIUn6giuFRvhkSJifE6mWuEFZ2Ii7Vke2SogH64oOfcV9f3+5zdP3GNdJ8Ay7Qy46zFkraQXN7iVKCQfUp/wrftSu694Z6avWoLvfWp8m7uNxowbdccREUrcsqShY2jypwMfSth4hcBW9S3OA7ars1bIUKC3Cajqjlw4QVHO7cO+6tw43tWxvhZche4r0qG0GshhQS4k70pC0k5GRnOD37etBG+7TtfW3hxDv8rVDzttvEkBCUzlmQ2tO/wDQHByAfbIq3n8RdUI0Zp2zxb3NZXI5r78pUhXMXl5SEguE5CRtPr6/StNuosLUAt2l+5SpKnQpK5LKWUtIwcjCVq3KJ29emMeueneNK8FUau4U6fXcJD1quzfNcbWW92WlrKkhScg/UdfWg5jxBv8ArGy3aLbpur1zFx4iEpftlwWpCkkqI3kEZWM4JIzgCsnY77qu4cYlWu36knsLduL7LXOfW602Mrx/DKsHA7Dt2roFx+GZtxMQW/UIZKGAl8uxivmO7lEqGFDaMFIx9O/Ws/p3ga/aOI7WqFX5p1CJjkrw4ikE7iry7t3+93xQcf4f661OJWpbbMvc+U07aJ5BdfUotuIZWtK0EnKTlPp71b6D1JrRemtSJsNxuEmYTHSQXlOOJQS4VFsEk7ugzjrjJ9K6vYfh8kWu5z5Z1E06JUSVGCREI285paM539cbs49cVQt3w4rYtU2I/qbzvOtPNuNRduxSAsdcr6g7z2x2oOS2e76vXJCXdbyrbc+ZtES4S5DSifTqpOwfmRW0am1drDU/FRyyQtSCyphulhsuyuQwFNDzKUR8xUpJPXPcDtW4t/Dg9LuDbt91dJmsoATgMHmbR/KFKWcDv6Vmdb/D7a9QahFygXR23NubOexyg4FYABKTkYJA9c9etBxrS981RfuKSbTM1PPSqbKfjrciy1qZSpQWNzaQoDaCcpxjsO1WXBG2PTeMVnjNznY62JK3lOozlwNgqUg9R0UElJ+hPeu2aV4BjTmvYl+iXtKoUWUp5qIqOdwR12pK93UgEdcelUbj8O8dWrDdbVfVw4pkeI8OpjeUebJSFBQ6fcdqDmVv1hd7TxrvMldwnPxocq4u+GXIWW1JbQ8pKSnOMeUdKtYl04gats1+1Y3ql5hi1kLeZExTPfrhCE+XH3xn6muy2vgZ4biPI1LMvDUmI/JkvOQjGI3IeCwUbt3svvj0rX7h8MzS7g6q3akWxAWrKWnY29aR7bgoA/fFBz7VnEnUd74d6ckOXSbHnx5cqK8/GeU0X0pQypJVtIyRvI/f1qz1FqbWdpsekrgdU3AplxFuMoQ6oFAS6oec585J9T6dPSu2ao4CRLhpWxWSzXXwSLct51155jmKkOOBAKjgjHyAfbHtVrqTgI/eLDpu3J1A00bRGcjlwxCrm7nCvON/Tvj1oOw6PuDt30lZLlIxzpkJmQvAwNy2wo/uay9YzS9sNk01abUp0PKgxGoxcCdu/YgJzj0zjtWTopSlKBSlKBSlKBWo664i6b0RykX6aUSXU7m47SCtxSe2cDsPqcVt1RJ+I1g27jJEud6hOS7O62wsN7ikOto6LQFehzn/ANb60HfND8VdK6zmmFaZriJoSViPIbLalAdyPQ4+hrE3njpoe13NcJU6RJUhW1bsZgrbSfXzdM/lmuG6QesWptbz2tGaTnQ5j0aR4V5M8hEUllSQooCexJ/q7mtIsk+yWexajtmorA7IvbyeXEfUooMRYyDkfQ4P1xiiJa6k4xaSsVutU9yTImQ7klxTDkRsLHkKQoKBIIPmHQ1aSOOeh47sJt6e+PEsoeJSyVhkKGQle3OFY7gZxUTb1bZ8HRGnnpyHG2JcmW7GSsYyjawCofQkH9Ky3FOFFhRtFGJHaYL+nozzvLQE8xZW5lSsdyfeglY9xe0a1qdmxG6Bcp0oSl1CCpncrskrHY9R9Bnv3rGQ+OmjJF4ct7j0yKtvmb3ZDIS2nYCT1Cieu0gDHUkCoz8VoUa2a3hNW+O1Gb8DCc2tJCRuLKCT09SeuavuF8KLceM3hp8dqTHUucVNuoCkkhp0jIPsQDQSUs3GrRN1hzpDdycj+DaLzjchooUpIIHl9FHJAwDnrV9ZOJ+j9RaduVzbnoRAhACWmU2UlAV2yk5znsMZz2qJvCe3w7g5q7x0ZqR4fTs2Q1zEhWxxITtWPYjJwaxunbfPuGjtTfh6HHEx1RpEhCASS2CsE49gVJP5UEirZxL4PrvKAza4cV4rwmWu1JSnPodwGR9yBW2av4yaW0pfDarl45cgNocC47SVoKVjIIO4ehqJka46cdtdqiv2SVImtKIe8M6GC9k9PMQsqP5DHpWY41R/D61hRzFciBFthI8M65zFtYaT5FKwMkds4oJSWzi5pGexfJCZy2YloWhD8h1GELKioJ5eMlWdh9M1ibbx60NOuCIvjZUferal5+OUtk/cZwPqQK1D4itDW2ycO0vaWs7URoTWnJnh0nqgIWElX0BX+9cabvejX7NYoX+h8uRc2ElEpxmaWjJWSMdkqJ+2Bjt1oOj8RdR3K3cdQyNXXFmK3JjkR2UqKEIWlCtgSDtUCFdz712O58XtG23U4sUm6YlhzlOOBB5TS/ZS+w69PXHriox8TGixxlYaLC45QLcnkrXvU3hhkbSr1I7Z9axdsUnT2trtB1Jpn8enOLcjJjOOLbUHlK6LGASrPp756Gg7bxB43Wa/6GvcTSsi7Q7shptxt8J5JSA82FYUlWRkEj86t+AHEDwOj9Q3bW9+lPR2JLTbbkt5byslKjtQDk5OOw9qjvZv+p3r/gx/85qsixbp0nh5ImRkLXCiXECRtGQkqb8ij9Oihn6/WgllYOOWib1c2oDc2RFeeWENqlMlCFKPYbskD88V0e4TY1ugvzJz7ceKwguOOuHCUpHck1BmFM05c7hZY0fTc6XK2IZWzEfEfmuZHbyrUr75H5VKrjnbZtx4Q3iLbmXFyEtNLLSPMopQtKlD69AaKxY4/aEM7w/jJnL3bfEeFVy/v/Vj8q1HjrxhuNhvFsh6MuDaUrj+IecLKHEOJXgtlJOfTdXBINxsCdPMQ59pffnofKlOMLDSlo9ishX2wEgVv3Gu1qjaD4fyGLTJt0YRn0lp5zmrb3KSpCVLwMkjJAwMdvSiJLcKdTnV2g7VdXFKXJW0G5ClICNzyeiyAOmN2cVttc4+H7UES/8ADW3Jhx3GPw1KIDu8Ab3ENoKlDHod3r1ro9FKUpQKUpQKUpQKUpQKtp8CHcWCxcIkeUyf/wBN9sLT+hq5rgvG3ijqK06zi6T0Y2hM9Yb3ultK1rcc+VCQrygYI6kevpig3O5cQdB6HvztgUlq3TUlAW1FglKcqAKeqU47EVkdf3DRently1NAtz89fRhBiIekvEdggYyfv2HvUR+IEu+TeJZd1XETEvQXGbkNpIIJShAChgkdQAenTrW86n4t6u1Dq+arS5gQ48AuBhTjbHM5YOCd7vqrA8qf3xREnHbXZNSQYUq4WiJLa5YWymbESpTaVAHG1YynsMj6Ul6V09MDAl2K1PhhsMtB2G2rloHZKcjokZPQdOtRuuPF3XrfDfxUpD1uuLdwZbbnmGlKZDSm3SU4WkpyChJyB/52bPFPik/o5u/RlBVrgulqVOUwyeatShgFOBgDKR5R3PU+xXaOIGo+G+mb2zE1XbbebguOh1BVbA8eXkpT5tp7bCAPTFbla9PadQ41crfZLYy+4nmJfbiIQ5hY69QM9QTn71DLi/q5et7jYrw+ylmSq1pafQj5d6XngSPoeh/OulXrijra86oZ0rw9bQ2uI0GchttTjqkI85Jc8qQCCPy+uKIkNE0rp6EXjDsVqj85tTLvKhto3tq+ZCsDqk+oPSq1r0/ZrQp1VqtNvgqdG1wxoyGysex2gZFRusvFrW1ysGpbRJfEbUdqZVLbkIYb3ENLAebWggpyAScgD5TWE/156p/0E5Qu/wD0gFwyZHh2s+H5fy7du35vXGaKk7KtWldOIevL9us1tDIK1zPDNtlP/eAzk/vWM085pHiCy9eGrFFl7XOSJE63JCnQkdFJKk5Kcdv8q4FqbirrBjTtgsjzsaVdbiwiY+/JjNHo4slpASQEDCQlRJHc+mK2bhJxF17I1oxZ9SRlXO3OK5LkmOwhSWDjIVzGhsI7A/8AlRHd79frLZUNJv1zgQEP7g2Jb6Gw5jGcbj1xkZ+9a8zduHdsWxcGZmlYi5AK2pKFsNlwAlJKVDv1BH3Fcl+Mf+y0n/elf/argt7u7E7T+nYDSHUu25h5p1SgNqit5bg29fZQ7460E7E2XTF+W3eE2yz3Fb4S4ib4dt0rx0BC8HOMDBz6Ve3KNbGCu7zYkdT0NtTniFMhTjaQCTtOM9s9qiDZ+JmrrJOsNktd3LFrQ1DQljw7SsBaEFQ3FJPUqPr61ndb8TNXI4mXjTybwRZ/GuRPD+Ha/sicFO7bu7euc0HYND3nhjrG5Sbdp2z2t2QlguupVaktgthSR1JQAepT0rfY9osdlgSUx7fbbfCcGXw2yhptQx3XgAHp71CnhDO1VBvN0OhoviLq5AWlSsJJZbC0KUsBXQnygY6/N2rabxrzVHEfhhcLfJbMmXb5bL764yNqnmClY6oHfaoJJwO3XHTNBIy0XXhzAmKVZ5mlIso9CqKuOhf2ynrW5sutvtJcZWhxpYylSTkKHuDX59WxrTjkMNXZ27Q52SC802h1odemUEpUPr1P2rfJHEjVei7hbrJY76iTZ4jEYtIZjtlLqFNpWQCpG4Z3Hv1GcelBLVOl7Amd41NjtYmbt/PERvmbvfdjOayMyJHmx1MTI7UhhXRTbqAtJ+4PSo0R+LHEDS+vIUPXMVpEOctK/C8tALbS1YBQpPt7KJPTr71QncVuIetNS3Jjh+2GoMMKcS2202pZaScblFzOSfYfvRUkD+DaXtLjhFvtFsaIK1YQw0gkgAnsBkkD9K92W+2m+tOOWW5wrg20QlaoryXQk+xKScVFq+cRb9r/AIN3yPNdjNSLY/HcmrSjb4qOpe1IAwcKDmwnGOg/I7J8IDNyxfXxIb/CBtQpjHnL/QhXbttyO/r2oJJUpSgUpSgUpSgUpSgVxPjXwkueqtRRNRaWmtRro0lKHEuLU3kpOUrSoZwodvyFdspQRUuvAnW8nUjc9+4RbksqacekyJCt6lAJ3DqCSAcge4A7VktTcDdV27Vc64aGubLMSUpak/7QphxoKOSjIHUexzUmaUEReJmgbrorhOyvUF1XOnSrqyOUl1S2mUhp7oN3cnPU49BVnoXhlqnV+goq7BeQ1apT7glw5D60NBaFDavaAd2Rj07j9JX6n03aNUQG4V/gtzYrbgeS2skALAIB6Eeij+tVNO2G2abtqbfZIiIkNKisNIJIBPc9STQRx1t8P98cVZo+nHIb8eJASy86+7y1LeLri1EDB6ecYrJau4JanY1Mi/aIubUWS8gKdHPUytpwpwvaoDqknJ9O9SPpQcW4NcHpOlpdzumqZTMy4zmVxy22orSELOVlSiOqjj/Hvmo43PRMmFxN/wBEQ6288qaiMFtHI2rIwT9Qkgn261PetTi8PNMRdUq1GzbQLyXFPGQp1ajvUCCcE47E+lBzrjLwal6km226aTkMRpkRhuMWHVFCdqPkUlQBwR2/IfnbcL+FWsLfrBm+awvzjiGDvDDUtbheUBhO8nA2j269sV3qlBx74huHt7163YRYRFzCL5d57uz5+XjHQ5+U1zW9cB9VyrBp6LFataZURh5ElXOxuUp5ak9dvXykD9qlXSgi3eOAWqHXLNMt0u3olNRmUSErcP8ADdbATuSduFDASf1pP4H60f1w9dnpUGY2uUXlSFu7Fu9clWwDAz7VKSlBE/T3AnXtsXNfiXONbZJjlDao8pQ5uVJBbUQBgFOT69QPvWci8Ab5A0UW4N1it6iXMblFaFrQhCEIWkISsDO7LhOcAen1qSlKCKE/ghxHv8qOL9dYj6WvKl6RLU6UJJ648uTWjcUdPM2Tid+ANPLW1HRDjc3spX8FsFX06kmp0Vql54eaUvN7Xd7pZmJFyWUqU+pawSUgBPY46AD9KI4/Y+B2o5euIty1jfUz7fBdBaUt5bjzyEKyhPmGEg+oz7/erG+8DdXWjUk+VoS7tR4EzcMCQphxCFHJbVgeYD/KpM0orhmkeBirbw61DZ7jPaN2vKGwp1oEts8tW9A69T5h1P8Ayr5wM4aat0LqWUu6zYpszjSgWY76lBxzI2q2kDsAf1rulKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSma+ZoPtKwl+1TYtP7RervBgqUMpQ88lKiPcJ7msEjitoZfbU1vH3UR/iKDeM0zWnt8StGOfLqe1fnISP8auW9e6Sc+XU9l/Oa2P8TQbPmmawbWq9PPf2V+tS/wC7MbP+dXjV3tz39lcIi/7ryT/nQZDNKoJlMK+V5s/ZQr2HUHstJ/OgqUrzmmaD1SvmaZoPtKZpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQeTXKOPvEhzQ9kZiWlSfxqeDylEZDKB3Xj364H5+1dVUcVDX4nZjkrirJaWolEWMy0gZ7Ap3n91Gg5fcJsq4zHZc+Q7IkuqKnHXVFSlE+pJq3pSiFKUoFKUoPSXFo+Vak/Y4qqmbKR8sl9P2cIqhSgv27zdGv7K5TUf3X1D/ADq7a1XqJr+yv12R/dmOD/OsLSg2VrXurmsbNUXvp6Gc4R+6q3TRXHbVdilITdZH4zAyN7cjHMA9dqx1z98iuTUoP0M0lqK36qsMW72h3mRX05wfmQr1SoehBrMiou/CLe30Xm9WRSyYzjAloQeyVJUEkj7hQ/QVKEGivVK+CvtApSlApSlApSlApSlApSlApSlApSlBbrNQp+Ihe/i3efoGR/7pNTTcNQj49L38WdQfRxsf+6RQaBSldE4FRYT+s5EickrVBt0iZHQloOqU6hPl2oPRSgCVAe6RRGgyIsiNs8Sw6zzE7kcxBTuHuM9xWU1Fp5+xxLLIfebcF0hpmtpRnKElSkgHPr5TXT5upLZeNHaljXC+6i1Cgsc1kzLeMQ39w2L5gWdiSfKR0HWss7bozkGwyorbVw1Lb9LRnrfbXUZQvzLK3MYwtSQchHrjPXGKDl+mImi27V43VNxursorUlNutzKUqAHZSnF9MH2HWrudB0FcrXJdstyutpuLDanExrmhLrb5AztStsZSr7isho+Siy6GvWsEwY1wvZuCIba5TQcRFCklandnbJPlBPQVVvc9OtOGlyv93hwo95tk1llEuMylnxSHArKFBIwVJ27s+1BzCslfbJOsbsRu4tpbXKitzGglQVltwZSenbp6V0fWV1i6BnxtNW2wWmSyzFZcnPz4odcmLWhK1eY9UpGQBtxjB61s12sdq1RxPiJmMJYtNq0uxNMV94oG1DSSlta+4A3pyfYGg4BSuzagtdnumkru9ORoq33GGyH4LllmYL20+ZpbZUdxKc4PfIqwkaKtdx4gaXFvZTH07doLVxdAcO1ltCSZAKiSRgoV3PTNByilXV1cjO3OW5AZ5ENTqyy1uJ2IydoyepwMVa0HbvhMT/09ua/6bcofq43/AMqlmg1FP4Sk/wDSy9L9oQH6rH/KpUoNFVhXqvIr0KBSlKBSlKBSlKBSlKBSlKBSlKBSlKCxdPSoN8Z3ObxS1Gr2lFP6JA/yqcbvaoI8VFlziTqYn0uDw/RZH+VEatV1arjMtNxYn22Q5GmMK3tutnCkmrWlBtGote6i1BbvAXKckxFKCltMsNshxQ7FewDd+dWS9VXhd0tVx8YpMy2NNsRHEJCS2hv5R0HXue/f1rCUoOtaNjayeYl6h0v+E3dNzUoXK0IShY+Y45kc4GD1IKfc9utede2zW9x04uTqC227TljgfxGbe2lERDjhwDsayVLXjJ6/XHtXKWnXGlbmlqQr3ScGvTsh55SVPOrcKe29RVj9aDp8jUE+PBZj3Ww2O/S7Sy2w1LkZLrOEghtaUrAc2nIAIPynPrXyFdNZXPVUvVjNvjynWGfAzGlLQW5KUMhLiNu7KyUp3EJzgn7VpTGp57ZedWvfKXuKXsBJClDapZwPMrHYnqD1qnbNTXW2WmTbYkhIhyCVKQtpK9qinaVJJBKSR0yPYewoOg3+2XFVrdtlh0LDtRuG0yHxNEpxASnm43KVhlJHm64yB3qlF1DebLwykQHtPhwsJkQGrsJAV4dt5wcxO0Z7lCkhWQOp/PDTeJ94dvHjYbESK2HQ8GUN43KDfLSVLTtUohJIBz6n3NWF21/eLrYJFplIiCPIcLjim2yhSjzFOdgdvzKPXbnGBnoKDUqUpQd8+ElH/pvUC/aO0n9VH/lUoGzUZ/hHRmTqVfsmOn9S5/yqS7fpRVwntXsVTT2qoKBSlKBSlKBSlKBSlKBSlKBSlKBSlKCwd7VDj4h9NP2TiBLncs+CuZ8Q0sDpvwAtP3z1/MVMlwdK1zWGmrZqm0OW68xw9HV1BHRTavRST6GggTSu36i+Hy7R5C1WK5RZUck7UyctuAe3QEH79PtWvO8EdYo7MQlf3ZA/zFEcxpXQ3ODms0drcyr+7JR/matnOE2tUf8A7KVD/dkNH/8AtQaLStwc4Z6xb+awyT/dUhX+Bq2c0Bqxv5tP3H8mSf8ACg1ilZ9ei9TI+aw3Mf8Ahl/8qoL0tf0fNZLmP/Cr/wCVBh6VkHLHdm/7S1zkf3o6x/lVs5DlNf2kZ5H95BFBQpX3Yr+lX6VvugOFuoNWzGiYrsG2ZBclvoKRt/3Aeqj9un1oOu/CbbXGbBe7itJCJUhtpBPry0kk/qv9qkA3WE0vZIenrJEtVsb5cWMjagHqT6kn3JOSfvWcQKKrp7V7FeE9q9igUpSgUpSgUpSgUpSgUpSgUpSgUpSgtVirZwVcqqgugs3E1bLbq+WKoqTQWKm68Fr6VeqRXkooLItV85VXmymygsuV9Kcr6VebKbKC1DX0qolv6VXCa9JTQU0MIKgooST7461etJrwkYqsigrt1cIq2SarJVQXCTXoGqAVX3fQV80zVDfTfQV80zVDfTfQV80zVDfTfQV80zVDfTfQV80zVDfTmUFfNM1QC6+hz60FbNfc14BzX3NBa4Uo4SMmvKmHT/L+9XjaQhIAr1QY1UV4/wAo/WvBhv8A9I/UVlaUGJ8E/wD0j9RXwwX/AOgfqKy9KDD+Bf8A6B+or54F/wDoH6iszSgw3gX/AOgfqKeAf/oH6iszSgw3gX/6B+or0IT/APQP1FZelBihDf8A6R+or0Irw/lH61k6UGPEd4fyj9a9Bh3+n96vqUFkGXfb96+8p72/erylBZ8p72/enKe9v3q8pQWfKe9v3pynvb96vKUFnynvb96cp72/erylBZ8p72/enKe9v3q8pQWfKd9v3r4W3fb96vDXk9qC2abVzAFjp96w1j1ILxfrtaRFS05bDteXzQoEknZtA6nKRk9sHp1rPnIII7irJm326E4ZESEy0/hSd6UYPnVuVk+uVdfvQXSFVV3Vatmq+aCvSlKBSlKCjMfTGjLeV1CR296wtsvpkTEsvBOVdEhI/f8A/wB71nH2UPo2ODKc5xWJh6fai3BMlLqilOSlGO351zLyl7149VvjZnu9/ctMNYdmqknnhrt41+q360VYUwWXdr0donxOHlB0fMlvb1Ce56joKv3OIenG4y33JbqGxt2FcdaealSikKRkeZOQRkdP1FbBGtkWNcZ05psiTN2c9RUSFbBhPTsOlYROhLGhl1pDUlKVpCE4kufw0BRUEJ69EZJO3t29hXTZlRWtbKJqYiXn1yVNBxLaY6ySS2XAjt85SCQnvXuBrC1TbKi7NqkIgqkiKHHWVI85WEev8u44z2q1a0BYGT/s8eQwCwI5DUlxGUhBQCcHvtOM/b2FX8XS1rj6cesQbfctjiC2Wnn1rKU4xhJJykDHTHb0oLRnXNiefYaRIePOKQHAwsoTvWUIKlYwkKKTtz36H1FXlj1Tab5ClS7fJK40bPNdW2pCQACSckfQ/aqB0ZZPERXUxloEdDLaW0OqShQaOW96QcK2nqM1WtOlbVazPMZlajOQG5BedU4VpGQEkk/7x+vWgtbfriyzpDTDDkkOuqSlCXY62ydza3EnzAdClCjn7VRRxC02tIV41YQYwlbiyvATyubjOPm2ebb3q3hcO7XGlvuKfmONKLKmAX172S2hSMBe7JBSsjHtV5E0JYoa90ViQyOQmPtbkuJG1LYbB6H5tgAz9M9+tBYT+ItuaYZdhsSJDTsORLS8ptSGwGduQTgnB3DqAR29xV+/ruwx1SkvSHkiOF7l8hexZQQFhCsYUUkjIFUxw/sAj8kMPhBD6V4fWC4HgkOBWD1zsT+gqs9oexPuyVuxnFB/eSgvr2IKyCsoTnCSogZI/wAzQeG9eWJcmLH58hEmQ8thDK460rC0KAUCCMjqpP6596u7zqWLab9bLdLJSJp2JXsX0WThAyBjqc+ox096oTtE2Sa8XJDDx3SFSVJD6wlThKSSRnHdKf0+pq4umlLVc70xdZbTipjPL2qS6pI/hqKkZAODgqP60GL1FrCVapd4bj2rxTFsjiQ+7zwjCS04sdMeqkBP/ez6VWiazYkaxTYvDlKVNdJO/wApf2hZZxjvsUFZ+4rLTbBbpguokMqV+JspYlYWRvQAQAOvToo9qsWdE6fZlty27e2ma3J8WJWTzt/XuvuU4ONucY6YoMs7drc04pt2fEQ4k4UlTyQQfqM1jr/qDwTVuTa2WrhKuMgx4yQ8ENkhKlKUpYBwAEK7AnPSsk5a7e64px2DEWtRyVKZSST9Tire6WG33KEzFeZLTbDgeZVHUWlNLGfMkpwQep/U0GGtWt4cgpjTmH2LoHnWHYzDa5GwtqCVK3JT8mVJ8xA7/Q1SuHEK0MRluROfIWh5psJ5K08xCn0sqW2dvnCVK7Jznp71ep0TZUeGLTUlpbJXlxElxK3d6gtYcVnK8qAJz7VTXoKwrQ8kx39qyCkCS4OTh0O4b6+Qb0hXTHagDXlhPK/2h8b878xnP4H8Qt/xenk84KeuOoqta9XQptgRd32ZESMqUYv8ZsghXN5YJ+hOOvp+VUk6EsSeV/s752dV5kLPP/iFz+L18/nJV1z1Jq/b01bUWOZaC04u3y1OKcaW4o45hJUEnukZJIx2PagsG9c2J19ltEh4h0pAcDCy2nctSEFSsYSFKSdue/Q9iKpSNfafjxG5L0pxLTrLT6DyldUuqWlHp3JbV+lXZ0ZZOdEcTGWgRm2W0tpdUELS0ct705wraeozVsjQVjbYcabblJQtCGv+sueVCFKUlA6/KCtXTt1oNijPIlRmpDO4tOoC0lSSk4IyMg9R+dfJIwyfyr5bIEe2W6NBhI5caM2lppGSdqQMAZPWvcsfwFfl/jQW7VXGat2quKC4pSlApSlBp3EXUly083b/AMMitu+IUsLcdQVJSUpylHQjBUegPXt0BPSteuuvbzCk3tJjxkMQwgxnFsOEPFTjaVpz6lveQcfMcYxgiupVRmRWJscsS2kPMkglCxkEggj9CAfyoOVK1TfJs6O6CtTAw0Fx0LbafAnx2+aATkZQpfqemfSqkTiJdlzHkPsxQloNuPNBhwLjJMtLSwsk9SlslWQAPpjv1eqHhI/jfF8lHiuXyubjzbM5259s9aDnMLXd6k3u2xU29sRpLyk7lNKBcR4lbeUknoUoSlZ6HOf5R1rK3zUl7halejxIjL0Bl6M1s5auY5zUrJIVnAwUj0Pf0reKUHJo+stQzza1LWxHYMuMJLzcRwJTzEub2FBRzuSpKQVD1UO3Y3MPWmpQvTiJkKIVXNlqQvYytIwtaQWxlWQpKSVE4OenQDJrqGKUHP8AVus7jaNWx7bDjIcjFCS6XGjnzJWdyVbuwKQD5cde+awEbiRd3YMJ1xVubRIWyFSzFd5bRWy44psp3ZUpBQnJBx5x2rrriEuNqQ4kKQoFKgfUH0q2FthBuGgRWtkPBjjb0awkpG328pI+1BztnWepXoT012HFhRkmI2rmx3FlkutoWtxWFAlKckY6HqMkYNXELWd3kzIDEphmEH2QobozqlSiXFoy3j5BtSlfmBwFjOO9dHpQcfha01NbdPwUTGWpDy48RZlrYV/DDjbhPMBWNx3NpGcp6r7e++L1A85pKZOjNtC6xoqXHY60rKW3S2F7TgZI6jtWyV4Q022pxTaEpU4dyyBgqOAMn3OAB+VByl7iPd0QbW4iElTzrqkvBUYhC0h1KPIoOEdlE5G7t6AGq72tdSMxn3lxYWFNLcayytPL2yeUQolWCSnzDO0D1OOtdSxSg0O56vmsaQ0/dEhiK9cJCGXlyY6yloFCyVbArOMoB74x6+ta81qzUMi4W+UpKobLrsTnMlpakrC2XztGT5QpSED3ypOe2D1eRFYkqZMhpDhZXzWyoZ2KwRuH1wSPzqtQcpRqnUF0ZtD8ORGTILq1PITEeDbf+zOLLTgJG4pUAMgjrjI9KyesNVXWNpe0yIjSIrtxhOOuOqZW5ynOSFJbSE9QpRJAJ7bexrodKDnmjtVXmdqJq1TYgTHQwnctaCHD/BQrmk56hSlEY2j7nqKpXbWWoYT15aTbEYtjiW1vlpRQsOupDa0+YZCWiSrr39QK6RSg5k1rHUj7kZSYkRtkiJzAWFqK+c8tsqSd2AAEheOvfv61ZaY1tqBcqyQJjTcpTyU+IeUwpClkuLSsDzdCgJBPQ5z/AC9DXWqYoKMOQ1MiMyYyt7DyA4hWCMpIyDg9RSX/AGCvy/xqtVKX/YK/L/GgtGqr4qk0Kr4oPrDwUkJUcKHv61WyKsFoqkpugymaZrEFuvnLoMxmmaw/Lpy6DMZpmsPy6cugzGaZrD8unLoMxmmaw/Lpy6DMZpmsPy6cugzGaZrD8unLoMxmmaw/Lpy6DMZpmsPy6cugzGaZrD8unLoMxmmaw/Lpy6DMZpmsPy6cugzGaVhw2Qcjoavm5J5fmGVj96C6JA7nFWkh0OYSnqB3NUSFLUVK6mqiEYoPTYqriviE1UxQU1IrwUVcYr5toLYo+lOXVztr5tFBb8unLq42im0UFvy6curjaKbRQW/Lpy6uNoptFBb8unLq42im0UFvy6curjaKbRQW/Lpy6uNoptFBb8unLq42im0UFvy6curjaKbRQW/Lpy6uNoptFBb8unLq42im0UFvy6bKuNorFamvEXT9km3SevZGitFxZ98dgPqTgD70FG/Xm2WGCuZeJrEOMnut1WMn2HufoK5tM496KjyC027PkJBxzGo3l/8AaIP7VGjX+s7prS9uz7m8rlBR5EYK8jCPYD39z61rSEOOBRQ2pQSMnAzignVo/iLpfVjgZs90aXJIz4dwFtz8kqxn8s1uaADX5yxZDsaQ2/GdWy+2oKQ4hRSpJHYgjsamD8P3EV3WNkdg3ZwKvMAALX2LzZ6BePf0P5H1oOugV6xQdq+0CuWan4vxrDxJj6QXaHnnXno7Ikh8JSObtwduPTd7+ldTqHvHa4iz8f8A8TLReEJyHJLYVt37EoVjPpnHeg73xb4pw+HTttaft7k96YFq2NuhGxKcDJyD3J/Y1k+FevYvEGwv3GLEXDUw+WFsrcCyOgIOQB3z+1Ro1nqV7iXxZsT0K1rkJDUdKLeHkgr6c1aN6sD1Iycdq2j4Ubm5bdZX/T0oFpTzXMDSj8rjSikj74Uf/VojpGs+NcDSuvFabl2p5wIW0lyUHwlKAsJOduPQK9686h42W+z8Q/8ARUWp6QsSWoypSXwEhS9v8uPTd7+lcK4tQlaj+IC4W1C9qpc2PESr2JQ2itZ1Jb7np7U1pl33mpukhLc99LowtJLqsZ+uEg/nQSRtvHu0v3q8Q59qkRI9tbdccfDoXv2LCAAnA6qJAHX1rEMfExZFScP2G5Ij56OJcQpWP7vQfvXD4a4ydTazVOiuy4xbfC22V7V4MlvzA4PUfN2x0q0/HnLYI0LTNzuE2EsndAnxEFsKJ7BvctKs+4ANBKLiLxssujLm3bRBlXCcppDy0NqCEthQykEnPXGDgD1rGQ+P9omaaut0j2adzbdyi4w44gBQcXtGFDPY+4rk3FmZBGuxKugutgvzcOItT0JAcQVmOgkAFSVJKSSjIJzt9Oudch3y83fQWqvxBtMmMhEfdPUyA7v56NqFOAZVkFR8xJGKCQv+vmws6MiX2dBlNPS3nGmYLa0uLVsxlRPQAdR/51Yac+IvT1zujMS5W2ZbEPKCEyFrS4hOT0KsYIH161HO62SevQdivTbLjlvCn4y1pSSltYcKuvtkK/arq/y164n6Vt9gt0lcyJa49tU2EDLjqCrKhj08w6nHbrQSTicb4D3EN7SrlpeaU3LdhiVzwUqUgqAO3H8xSB39azfCPidH4j/ivh7Y7A8Bys73g5v37/YDGNn71FeRb5Y4sXpiMsmbBlTZCFD1WwHHB+pRXWfg476t/wDCf/eoJJ4pilKKYpilKBimKUoGKYpSgYpilKD4R0rjPxSy3o/DUtskhEia005j+nClf4pFdnPatC4x6aXqrQtyt0cAytoeYz6rQcgfn1H50EGWUB19ptSghKlBJUewye9dE4o40Vrk2nTLf4e3bEtFuS3/AGz6lNhRWpfcg7iNvy/SudvtOMuraeQpt1CilSVDBSR3BFZtGppT6of420i7Nw0hLDcn0SOyVLThZSP6d2KI2TjLb4jFx0/dIsdqK9eLSxPksNJCUJdUCFFKR2BxnHvmsn8NMt6NxUhtNE7JEd5twD+kJ3D90iufakvs/Ul3duV1cC5CwEgJSEpQkDCUpSOgAHpXbvhW0q+u5zNSyGymOhsxoxUPnUSCpQ+gAx+Z9qKlC0cpFe68NDCRXugVaSLZAkul2TBivOnutxpKifzIq7pQWbNrt7DqXWIMVt1PZaGUpI+xAr01boTMgyGYcZt8kkuJaSFde/XGauqUFobbBVJ8QYUYyN27mlpO7PvnGc19k26DKd5kqHGecxjc40lRx9yKuqUFqzbYLLqnGYUZtxQIKktJBIPfJxXlu1W9p5LrcCIh1JyFpZSFA/fFXlKC3lQosvHi4zD+O3MbCsfrXkW6EIxjCHGEcnJa5SdpPvjGKuqUFFmJGYYLDMdltk920IASfy7V5jQosUkxYzDJPctthOf0q4pQWgtsFMhT6YUYPqJJcDSdxz364z1ya9xIMSHv8JFYY343cpsJzjtnFXFKBSlKBSlKBSlKBSlKBSlKBVF5vcKrUIoOJcVODMDVUh25WtxNvuyuq1bctvH/AHgOx+o/MGuKS+B+tmJBbahRpCM45jclAT/7RB/apqLbCu4qkYyfYUEX9E/D7Mdltv6rlNtx0kExoqipS/opWMAfbP5VJOyWqLaoDEOCwhiKwkIbbQMBIFZBDKU+lVQMUH0DApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlB//Z",
+          "timing": 4486
+        }
+      },
+      "unused-css-rules": {
+        "id": "unused-css-rules",
+        "title": "Reduce unused CSS",
+        "description": "Reduce unused rules from stylesheets and defer CSS not used for above-the-fold content to decrease bytes consumed by network activity. [Learn how to reduce unused CSS](https://developer.chrome.com/docs/lighthouse/performance/unused-css-rules/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 0,
+          "overallSavingsBytes": 0,
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [],
+          "headings": [],
+          "type": "opportunity"
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "long-tasks": {
+        "id": "long-tasks",
+        "title": "Avoid long main-thread tasks",
+        "description": "Lists the longest tasks on the main thread, useful for identifying worst contributors to input delay. [Learn how to avoid long main-thread tasks](https://web.dev/articles/optimize-long-tasks)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 long tasks found",
+        "metricSavings": {
+          "TBT": 700
+        },
+        "details": {
+          "debugData": {
+            "urls": [
+              "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "https://www.ocobo.co/clients/ekodev",
+              "_lighthouse-eval.js",
+              "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            ],
+            "type": "debugdata",
+            "tasks": [
+              {
+                "duration": 439,
+                "startTime": 5920.4,
+                "urlIndex": 0,
+                "other": 439,
+                "scriptEvaluation": 0
+              },
+              {
+                "other": 136,
+                "duration": 136,
+                "startTime": 6911.5,
+                "urlIndex": 1,
+                "scriptEvaluation": 0
+              },
+              {
+                "other": 134,
+                "duration": 134,
+                "startTime": 3839.2,
+                "urlIndex": 0
+              },
+              {
+                "other": 113,
+                "startTime": 11046.8,
+                "urlIndex": 1,
+                "duration": 113,
+                "scriptEvaluation": 0
+              },
+              {
+                "scriptEvaluation": 0,
+                "other": 90,
+                "duration": 90,
+                "startTime": 5609.4,
+                "urlIndex": 2
+              },
+              {
+                "urlIndex": 3,
+                "duration": 89,
+                "startTime": 943,
+                "styleLayout": 0,
+                "other": 89,
+                "scriptEvaluation": 0,
+                "paintCompositeRender": 0
+              },
+              {
+                "scriptEvaluation": 0,
+                "duration": 87,
+                "startTime": 5833.4,
+                "urlIndex": 2,
+                "other": 87
+              },
+              {
+                "scriptEvaluation": 0,
+                "other": 69,
+                "duration": 69,
+                "startTime": 5699.4,
+                "urlIndex": 2
+              },
+              {
+                "scriptEvaluation": 0,
+                "duration": 62,
+                "startTime": 1167,
+                "urlIndex": 4,
+                "other": 62
+              },
+              {
+                "duration": 58,
+                "startTime": 5401.4,
+                "urlIndex": 5,
+                "other": 58
+              }
+            ]
+          },
+          "sortedBy": [
+            "duration"
+          ],
+          "skipSumming": [
+            "startTime"
+          ],
+          "items": [
+            {
+              "duration": 439,
+              "startTime": 5920.4156473407756,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "startTime": 6911.5378965586506,
+              "duration": 136,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "startTime": 3839.2325678550619,
+              "duration": 134,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "startTime": 11046.760007687446,
+              "duration": 113
+            },
+            {
+              "startTime": 5609.4156473407756,
+              "duration": 90,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "url": "https://www.ocobo.co/clients/ekodev",
+              "startTime": 943.04889968715,
+              "duration": 89
+            },
+            {
+              "startTime": 5833.4156473407756,
+              "duration": 87,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "startTime": 5699.4156473407756,
+              "duration": 69
+            },
+            {
+              "url": "_lighthouse-eval.js",
+              "duration": 62,
+              "startTime": 1167.04889968715
+            },
+            {
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "startTime": 5401.4156473407756,
+              "duration": 58
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "valueType": "ms",
+              "granularity": 1,
+              "label": "Start Time",
+              "key": "startTime"
+            },
+            {
+              "label": "Duration",
+              "key": "duration",
+              "granularity": 1,
+              "valueType": "ms"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "unsized-images": {
+        "id": "unsized-images",
+        "title": "Image elements do not have explicit `width` and `height`",
+        "description": "Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png",
+              "node": {
+                "selector": "header.d_flex \u003e div.d_flex \u003e div.bg_ocobo.dark \u003e img.h_10",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"ekodev\" loading=\"eager\" decoding=\"async\" fetchpriority=\"high\" class=\"h_10 w_auto obj-f_contain d_block\"\u003e",
+                "boundingRect": {
+                  "left": 47,
+                  "height": 44,
+                  "width": 113,
+                  "top": 532,
+                  "right": 161,
+                  "bottom": 576
+                },
+                "type": "node",
+                "lhId": "1-2-IMG",
+                "nodeLabel": "ekodev",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,1,HEADER,1,DIV,0,DIV,0,IMG"
+              }
+            },
+            {
+              "node": {
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "boundingRect": {
+                  "height": 40,
+                  "left": 33,
+                  "bottom": 77,
+                  "right": 167,
+                  "top": 37,
+                  "width": 134
+                },
+                "type": "node",
+                "lhId": "1-0-IMG",
+                "path": "1,HTML,1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "nodeLabel": "Ocobo"
+              },
+              "url": "https://www.ocobo.co/logo-ocobo.png"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "layout-shifts": {
+        "id": "layout-shifts",
+        "title": "Avoid large layout shifts",
+        "description": "These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "2 layout shifts found",
+        "metricSavings": {
+          "CLS": 0.002
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,1,HEADER,0,DIV,0,H1",
+                "nodeLabel": "Accompagner la création d'une business unit durabilité : comment ekodev a struc…",
+                "lhId": "page-4-H1",
+                "type": "node",
+                "boundingRect": {
+                  "height": 274,
+                  "left": 16,
+                  "bottom": 438,
+                  "right": 396,
+                  "top": 165,
+                  "width": 380
+                },
+                "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark fs_4xl md:fs_5xl lg:fs_6xl …\"\u003e",
+                "selector": "div \u003e header.d_flex \u003e div.lg:w_2/3 \u003e h1.text"
+              },
+              "score": 0.002315,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "extra": {
+                      "type": "node",
+                      "lhId": "page-3-IMG",
+                      "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,1,HEADER,1,DIV,0,DIV,0,IMG",
+                      "nodeLabel": "ekodev",
+                      "selector": "header.d_flex \u003e div.d_flex \u003e div.bg_ocobo.dark \u003e img.h_10",
+                      "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"ekodev\" loading=\"eager\" decoding=\"async\" fetchpriority=\"high\" class=\"h_10 w_auto obj-f_contain d_block\"\u003e",
+                      "boundingRect": {
+                        "height": 44,
+                        "left": 47,
+                        "right": 161,
+                        "bottom": 576,
+                        "width": 113,
+                        "top": 532
+                      }
+                    },
+                    "cause": "Media element lacking an explicit size"
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "type": "url",
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf"
+                    }
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "type": "url",
+                      "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff"
+                    }
+                  },
+                  {
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  }
+                ]
+              }
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "extra": {
+                      "type": "url",
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                    },
+                    "cause": "Web font loaded"
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                      "type": "url"
+                    }
+                  }
+                ]
+              },
+              "score": 0
+            }
+          ],
+          "headings": [
+            {
+              "key": "node",
+              "label": "Element",
+              "subItemsHeading": {
+                "key": "extra"
+              },
+              "valueType": "node"
+            },
+            {
+              "granularity": 0.001,
+              "label": "Layout shift score",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "cause"
+              },
+              "valueType": "numeric",
+              "key": "score"
+            }
+          ]
+        }
+      },
+      "font-display-insight": {
+        "id": "font-display-insight",
+        "title": "Font display",
+        "description": "Consider setting [font-display](https://developer.chrome.com/docs/performance/insights/font-display) to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with [font metric overrides](https://developer.chrome.com/blog/font-fallbacks).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "label": "Est Savings",
+              "key": "wastedMs",
+              "valueType": "ms"
+            }
+          ],
+          "type": "table",
+          "skipSumming": [
+            "wastedMs"
+          ]
+        }
+      },
+      "speed-index": {
+        "id": "speed-index",
+        "title": "Speed Index",
+        "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).",
+        "score": 0.65,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "4.9 s",
+        "numericValue": 4880.9209480425488,
+        "numericUnit": "millisecond"
+      },
+      "non-composited-animations": {
+        "id": "non-composited-animations",
+        "title": "Avoid non-composited animations",
+        "description": "Animations which are not composited can be janky and increase CLS. [Learn how to avoid non-composited animations](https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/)",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "type": "table",
+          "items": [],
+          "headings": [
+            {
+              "key": "node",
+              "label": "Element",
+              "valueType": "node",
+              "subItemsHeading": {
+                "key": "failureReason",
+                "valueType": "text"
+              }
+            }
+          ]
+        }
+      },
+      "network-dependency-tree-insight": {
+        "id": "network-dependency-tree-insight",
+        "title": "Network dependency tree",
+        "description": "[Avoid chaining critical requests](https://developer.chrome.com/docs/performance/insights/network-dependency-tree) by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "value": {
+                "chains": {
+                  "C3AC0B9036C5731FFD7A93C335555A97": {
+                    "children": {
+                      "51.2": {
+                        "children": {
+                          "51.75": {
+                            "navStartToEndTime": 1599,
+                            "children": {},
+                            "transferSize": 38778,
+                            "isLongest": true,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf"
+                          },
+                          "51.76": {
+                            "children": {},
+                            "navStartToEndTime": 1542,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+                            "transferSize": 40710
+                          },
+                          "51.77": {
+                            "transferSize": 39126,
+                            "children": {},
+                            "navStartToEndTime": 1543,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf"
+                          },
+                          "51.72": {
+                            "transferSize": 31974,
+                            "navStartToEndTime": 1541,
+                            "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                            "children": {}
+                          }
+                        },
+                        "navStartToEndTime": 1354,
+                        "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                        "isLongest": true,
+                        "transferSize": 24569
+                      }
+                    },
+                    "navStartToEndTime": 1073,
+                    "isLongest": true,
+                    "url": "https://www.ocobo.co/clients/ekodev",
+                    "transferSize": 16292
+                  }
+                },
+                "longestChain": {
+                  "duration": 1599
+                },
+                "type": "network-tree"
+              },
+              "type": "list-section"
+            },
+            {
+              "description": "[preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints help the browser establish a connection earlier in the page load, saving time when the first request for that origin is made. The following are the origins that the page preconnected to.",
+              "title": "Preconnected origins",
+              "type": "list-section",
+              "value": {
+                "type": "table",
+                "items": [
+                  {
+                    "subItems": {
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ],
+                      "type": "subitems"
+                    },
+                    "origin": "https://raw.githubusercontent.com/",
+                    "source": {
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "boundingRect": {
+                        "height": 0,
+                        "left": 0,
+                        "right": 0,
+                        "bottom": 0,
+                        "width": 0,
+                        "top": 0
+                      },
+                      "selector": "head \u003e link",
+                      "type": "node",
+                      "path": "1,HTML,0,HEAD,3,LINK",
+                      "nodeLabel": "head \u003e link",
+                      "lhId": "page-6-LINK"
+                    }
+                  }
+                ],
+                "headings": [
+                  {
+                    "label": "Origin",
+                    "key": "origin",
+                    "subItemsHeading": {
+                      "key": "warning"
+                    },
+                    "valueType": "text"
+                  },
+                  {
+                    "key": "source",
+                    "label": "Source",
+                    "valueType": "node"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Add [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints to your most important origins, but try to use no more than 4.",
+              "title": "Preconnect candidates",
+              "type": "list-section",
+              "value": {
+                "value": "No additional origins are good candidates for preconnecting",
+                "type": "text"
+              }
+            }
+          ]
+        }
+      },
+      "cumulative-layout-shift": {
+        "id": "cumulative-layout-shift",
+        "title": "Cumulative Layout Shift",
+        "description": "Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/articles/cls).",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "0.002",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "cumulativeLayoutShiftMainFrame": 0.002315,
+              "newEngineResultDiffered": false
+            }
+          ]
+        },
+        "numericValue": 0.002315,
+        "numericUnit": "unitless"
+      },
+      "first-contentful-paint": {
+        "id": "first-contentful-paint",
+        "title": "First Contentful Paint",
+        "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).",
+        "score": 0.49,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.0 s",
+        "numericValue": 3001.2200485921749,
+        "numericUnit": "millisecond"
+      },
+      "unminified-javascript": {
+        "id": "unminified-javascript",
+        "title": "Minify JavaScript",
+        "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn how to minify JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unminified-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 0,
+          "overallSavingsBytes": 0,
+          "items": [],
+          "headings": [],
+          "type": "opportunity",
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ]
+        },
+        "warnings": [],
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "network-rtt": {
+        "id": "network-rtt",
+        "title": "Network Round Trip Times",
+        "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "rtt": 8.9322299999999988,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "origin": "https://perf-eu1.hsforms.com",
+              "rtt": 5.254154999999999
+            },
+            {
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com",
+              "rtt": 2.6433
+            },
+            {
+              "rtt": 2.4421049999999997,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "origin": "https://js-eu1.hs-scripts.com",
+              "rtt": 1.3909949999999998
+            },
+            {
+              "origin": "https://useago.github.io",
+              "rtt": 0.91458
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "origin": "https://forms-eu1.hscollectedforms.net",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "origin": "https://fonts.googleapis.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "origin": "https://www.ocobo.co",
+              "rtt": 0.013006637473868906
+            },
+            {
+              "origin": "https://js-eu1.hs-banner.com",
+              "rtt": 0.0038940203036076731
+            },
+            {
+              "rtt": 0.0034253250220037915,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.0028488591339393579,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "origin": "https://js-eu1.hs-analytics.net",
+              "rtt": 0.0018674086006078318
+            },
+            {
+              "rtt": 0.0011411007598294211,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "rtt": 0.00078207303516692449,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "rtt": 0.000781715686307039,
+              "origin": "https://www.googletagmanager.com"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "label": "URL",
+              "key": "origin"
+            },
+            {
+              "key": "rtt",
+              "label": "Time Spent",
+              "granularity": 1,
+              "valueType": "ms"
+            }
+          ],
+          "sortedBy": [
+            "rtt"
+          ]
+        },
+        "numericValue": 8.9322299999999988,
+        "numericUnit": "millisecond"
+      },
+      "max-potential-fid": {
+        "id": "max-potential-fid",
+        "title": "Max Potential First Input Delay",
+        "description": "The maximum potential First Input Delay that your users could experience is the duration of the longest task. [Learn more about the Maximum Potential First Input Delay metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-max-potential-fid/).",
+        "score": 0.13,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "440 ms",
+        "numericValue": 439,
+        "numericUnit": "millisecond"
+      },
+      "redirects": {
+        "id": "redirects",
+        "title": "Avoid multiple page redirects",
+        "description": "Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://developer.chrome.com/docs/lighthouse/performance/redirects/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "opportunity",
+          "items": [],
+          "headings": [],
+          "overallSavingsMs": 0
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "dom-size-insight": {
+        "id": "dom-size-insight",
+        "title": "Optimize DOM size",
+        "description": "A large DOM can increase the duration of style calculations and layout reflows, impacting page responsiveness. A large DOM will also increase memory usage. [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/performance/insights/dom-size).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "debugData": {
+            "maxDepth": 15,
+            "totalElements": 515,
+            "maxChildren": 61,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "value": {
+                "granularity": 1,
+                "type": "numeric",
+                "value": 515
+              },
+              "statistic": "Total elements"
+            },
+            {
+              "statistic": "DOM depth",
+              "value": {
+                "type": "numeric",
+                "granularity": 1,
+                "value": 15
+              },
+              "node": {
+                "snippet": "\u003cpath d=\"M12 6v6l4 2\"\u003e",
+                "boundingRect": {
+                  "right": 0,
+                  "bottom": 0,
+                  "top": 0,
+                  "width": 0,
+                  "height": 0,
+                  "left": 0
+                },
+                "selector": "div.d_flex \u003e div.d_flex \u003e svg.lucide \u003e path",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,2,ARTICLE,0,ASIDE,0,DIV,0,DIV,1,DIV,0,DIV,0,DIV,0,svg,0,path",
+                "nodeLabel": "div.d_flex \u003e div.d_flex \u003e svg.lucide \u003e path",
+                "lhId": "page-9-path",
+                "type": "node"
+              }
+            },
+            {
+              "statistic": "Most children",
+              "value": {
+                "type": "numeric",
+                "granularity": 1,
+                "value": 61
+              },
+              "node": {
+                "type": "node",
+                "nodeLabel": "body",
+                "path": "1,HTML,1,BODY",
+                "lhId": "page-8-BODY",
+                "snippet": "\u003cbody\u003e",
+                "boundingRect": {
+                  "left": 0,
+                  "height": 5842,
+                  "width": 412,
+                  "top": 0,
+                  "right": 412,
+                  "bottom": 5842
+                },
+                "selector": "body"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "label": "Statistic",
+              "key": "statistic",
+              "valueType": "text"
+            },
+            {
+              "label": "Element",
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "label": "Value",
+              "key": "value",
+              "valueType": "numeric"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 515,
+        "numericUnit": "element"
+      },
+      "forced-reflow-insight": {
+        "id": "forced-reflow-insight",
+        "title": "Forced reflow",
+        "description": "A forced reflow occurs when JavaScript queries geometric properties (such as offsetWidth) after styles have been invalidated by a change to the DOM state. This can result in poor performance. Learn more about [forced reflows](https://developer.chrome.com/docs/performance/insights/forced-reflow) and possible mitigations.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "details": {
+          "items": [
+            {
+              "type": "table",
+              "items": [
+                {
+                  "reflowTime": 142.712,
+                  "source": {
+                    "value": "[unattributed]",
+                    "type": "text"
+                  }
+                },
+                {
+                  "source": {
+                    "line": 19,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+                    "column": 85503,
+                    "urlProvider": "network",
+                    "type": "source-location"
+                  },
+                  "reflowTime": 0.803
+                }
+              ],
+              "headings": [
+                {
+                  "valueType": "source-location",
+                  "label": "Source",
+                  "key": "source"
+                },
+                {
+                  "granularity": 1,
+                  "key": "reflowTime",
+                  "label": "Total reflow time",
+                  "valueType": "ms"
+                }
+              ]
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "diagnostics": {
+        "id": "diagnostics",
+        "title": "Diagnostics",
+        "description": "Collection of useful page vitals.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "numTasksOver500ms": 1,
+              "totalByteWeight": 1561233,
+              "numTasksOver100ms": 4,
+              "rtt": 0.000781715686307039,
+              "numRequests": 88,
+              "numTasksOver50ms": 9,
+              "numTasksOver25ms": 15,
+              "maxServerLatency": 9,
+              "maxRtt": 8.9322299999999988,
+              "numTasksOver10ms": 43,
+              "numTasks": 1608,
+              "totalTaskTime": 2586.9520000000025,
+              "throughput": 19169230703.634834,
+              "numScripts": 61,
+              "numFonts": 6,
+              "mainDocumentTransferSize": 16292,
+              "numStylesheets": 3
+            }
+          ]
+        }
+      },
+      "legacy-javascript-insight": {
+        "id": "legacy-javascript-insight",
+        "title": "Legacy JavaScript",
+        "description": "Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile [Baseline](https://web.dev/articles/baseline-and-polyfills) features, unless you know you must support older browsers. [Learn why most sites can deploy ES6+ code without transpiling](https://developer.chrome.com/docs/performance/insights/legacy-javascript)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 13 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "wastedBytes": 13769,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "location": {
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 6239,
+                      "urlProvider": "network",
+                      "type": "source-location"
+                    },
+                    "signal": "Array.prototype.concat"
+                  },
+                  {
+                    "location": {
+                      "column": 12925,
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "signal": "Object.assign",
+                    "location": {
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "type": "source-location",
+                      "urlProvider": "network",
+                      "column": 12813
+                    }
+                  },
+                  {
+                    "location": {
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "column": 10857,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1
+                    },
+                    "signal": "Object.create"
+                  }
+                ]
+              }
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "subItemsHeading": {
+                "valueType": "source-location",
+                "key": "location"
+              },
+              "valueType": "url"
+            },
+            {
+              "key": null,
+              "subItemsHeading": {
+                "key": "signal"
+              },
+              "valueType": "code"
+            },
+            {
+              "valueType": "bytes",
+              "label": "Wasted bytes",
+              "key": "wastedBytes"
+            }
+          ],
+          "debugData": {
+            "wastedBytes": 13769,
+            "type": "debugdata"
+          }
+        }
+      },
+      "unused-javascript": {
+        "id": "unused-javascript",
+        "title": "Reduce unused JavaScript",
+        "description": "Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 419 KiB",
+        "metricSavings": {
+          "LCP": 300,
+          "FCP": 150
+        },
+        "details": {
+          "overallSavingsMs": 300,
+          "overallSavingsBytes": 429011,
+          "items": [
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedBytes": 112602,
+              "totalBytes": 196265,
+              "wastedPercent": 57.372344479375059
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedBytes": 111413,
+              "totalBytes": 156410,
+              "wastedPercent": 71.231386255999567
+            },
+            {
+              "wastedBytes": 82854,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedPercent": 42.2154629213789,
+              "totalBytes": 196265
+            },
+            {
+              "wastedPercent": 42.946554879923987,
+              "totalBytes": 156410,
+              "wastedBytes": 67173,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "wastedBytes": 30035,
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "wastedPercent": 60.328802682337667,
+              "totalBytes": 49785
+            },
+            {
+              "wastedBytes": 24934,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "wastedPercent": 57.543565817282769,
+              "totalBytes": 43331
+            }
+          ],
+          "headings": [
+            {
+              "subItemsHeading": {
+                "key": "source",
+                "valueType": "code"
+              },
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "label": "Transfer Size",
+              "key": "totalBytes",
+              "subItemsHeading": {
+                "key": "sourceBytes"
+              },
+              "valueType": "bytes"
+            },
+            {
+              "valueType": "bytes",
+              "subItemsHeading": {
+                "key": "sourceWastedBytes"
+              },
+              "key": "wastedBytes",
+              "label": "Est Savings"
+            }
+          ],
+          "type": "opportunity",
+          "debugData": {
+            "metricSavings": {
+              "LCP": 300,
+              "FCP": 150
+            },
+            "type": "debugdata"
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ]
+        },
+        "numericValue": 300,
+        "numericUnit": "millisecond"
+      },
+      "network-requests": {
+        "id": "network-requests",
+        "title": "Network Requests",
+        "description": "Lists the network requests that were made during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "debugData": {
+            "type": "debugdata",
+            "initiators": [
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "type": "parser",
+                "columnNumber": 1600,
+                "lineNumber": 0
+              },
+              {
+                "type": "parser",
+                "columnNumber": 668,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 21
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 16793,
+                "type": "parser",
+                "lineNumber": 21
+              },
+              {
+                "columnNumber": 30105,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 21
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 141,
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 261,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "type": "parser",
+                "columnNumber": 360,
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 460,
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 536,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "columnNumber": 602,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 671,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "columnNumber": 731,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "type": "parser",
+                "columnNumber": 795,
+                "lineNumber": 36
+              },
+              {
+                "columnNumber": 857,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "type": "parser",
+                "columnNumber": 916,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "columnNumber": 985,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 1052,
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 1119,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 1176,
+                "type": "parser",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 1238,
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "type": "parser",
+                "columnNumber": 1297,
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 1361,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1427,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 1488,
+                "type": "parser",
+                "lineNumber": 36
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1556,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "columnNumber": 1622,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "type": "parser",
+                "columnNumber": 1693,
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 1751,
+                "type": "parser",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "columnNumber": 1811,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "type": "parser",
+                "columnNumber": 1886,
+                "lineNumber": 36
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1947,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "columnNumber": 2005,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "type": "parser",
+                "columnNumber": 2069,
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "type": "parser",
+                "columnNumber": 2129
+              },
+              {
+                "columnNumber": 2188,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2250,
+                "type": "parser",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "columnNumber": 2311,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 2374,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "type": "parser",
+                "columnNumber": 2430,
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "type": "parser",
+                "columnNumber": 2498
+              },
+              {
+                "lineNumber": 36,
+                "columnNumber": 2565,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2626,
+                "type": "parser",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "columnNumber": 2708,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 2776,
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2840,
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2903,
+                "type": "parser",
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2962,
+                "type": "parser",
+                "lineNumber": 36
+              },
+              {
+                "type": "parser",
+                "columnNumber": 3020,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 3087,
+                "type": "parser",
+                "lineNumber": 36
+              },
+              {
+                "columnNumber": 3146,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "type": "parser",
+                "columnNumber": 3212
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 3272,
+                "type": "parser",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 3337,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 3410,
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 3476,
+                "type": "parser",
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 3535,
+                "type": "parser",
+                "lineNumber": 36
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 536,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36
+              },
+              {
+                "type": "parser",
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+              },
+              {
+                "type": "parser",
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+              }
+            ],
+            "networkStartTimeTs": 3524286094
+          },
+          "items": [
+            {
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/clients/ekodev",
+              "rendererStartTime": 0,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1046.9010000000708,
+              "transferSize": 16292,
+              "resourceSize": 89117,
+              "mimeType": "text/html",
+              "priority": "VeryHigh",
+              "networkRequestTime": 1.7549999998882413,
+              "entity": "ocobo.co",
+              "resourceType": "Document",
+              "protocol": "h2",
+              "finished": true
+            },
+            {
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "networkEndTime": 1347.2050000000745,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1063.6959999999963,
+              "transferSize": 24569,
+              "resourceSize": 122090,
+              "priority": "VeryHigh",
+              "mimeType": "text/css",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1065.0109999999404,
+              "resourceType": "Stylesheet",
+              "protocol": "h2",
+              "finished": true
+            },
+            {
+              "transferSize": 12757,
+              "resourceSize": 12266,
+              "mimeType": "image/png",
+              "priority": "Medium",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1064.2010000003502,
+              "networkEndTime": 1336.1009999997914,
+              "finished": true,
+              "networkRequestTime": 1065.0839999997988,
+              "entity": "ocobo.co",
+              "resourceType": "Image",
+              "protocol": "h2"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1338.7020000000484,
+              "rendererStartTime": 1064.3789999997243,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/images/partners/modern-revenue-club.png",
+              "resourceSize": 29045,
+              "mimeType": "image/png",
+              "priority": "Medium",
+              "transferSize": 29545,
+              "protocol": "h2",
+              "networkRequestTime": 1065.1229999996722,
+              "entity": "ocobo.co",
+              "resourceType": "Image",
+              "finished": true
+            },
+            {
+              "networkEndTime": 1123.9399999999441,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1064.4870000001974,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png",
+              "resourceSize": 11321,
+              "priority": "High",
+              "mimeType": "image/png",
+              "transferSize": 11989,
+              "protocol": "h2",
+              "entity": "vercel-storage.com",
+              "networkRequestTime": 1065.191000000108,
+              "resourceType": "Image",
+              "finished": true
+            },
+            {
+              "resourceSize": 471493,
+              "priority": "Low",
+              "mimeType": "application/javascript",
+              "transferSize": 157097,
+              "networkEndTime": 1388.9420000002719,
+              "rendererStartTime": 1064.589999999851,
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "finished": true,
+              "protocol": "h2",
+              "entity": "Google Tag Manager",
+              "networkRequestTime": 1358.9590000002645,
+              "resourceType": "Script"
+            },
+            {
+              "transferSize": 639,
+              "resourceSize": 0,
+              "priority": "Low",
+              "mimeType": "application/javascript",
+              "statusCode": 404,
+              "sessionTargetType": "page",
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1064.6669999998994,
+              "networkEndTime": 1580.7889999998733,
+              "finished": true,
+              "entity": "Clearbit",
+              "networkRequestTime": 1359.066000000108,
+              "resourceType": "Script",
+              "protocol": "h2"
+            },
+            {
+              "networkRequestTime": 1359.1450000000186,
+              "entity": "Hubspot",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1390.0610000002198,
+              "rendererStartTime": 1064.74599999981,
+              "transferSize": 1672,
+              "resourceSize": 2125,
+              "mimeType": "application/javascript",
+              "priority": "Low"
+            },
+            {
+              "finished": true,
+              "entity": "GitHub",
+              "networkRequestTime": 1359.2199999997392,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 5017,
+              "resourceSize": 17494,
+              "priority": "Low",
+              "mimeType": "application/javascript",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "rendererStartTime": 1064.8139999997802,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1379.5639999997802
+            },
+            {
+              "transferSize": 24114,
+              "resourceSize": 69556,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "rendererStartTime": 1064.9210000000894,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1344.4309999998659,
+              "isLinkPreload": true,
+              "finished": true,
+              "networkRequestTime": 1066.1529999999329,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "protocol": "h2"
+            },
+            {
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "resourceSize": 927,
+              "transferSize": 1454,
+              "networkEndTime": 1423.1289999997243,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1065.0240000002086,
+              "url": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "finished": true,
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1066.3129999996163
+            },
+            {
+              "transferSize": 43924,
+              "resourceSize": 125397,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1065.101000000257,
+              "networkEndTime": 1367.3680000002496,
+              "isLinkPreload": true,
+              "finished": true,
+              "networkRequestTime": 1066.441000000108,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "protocol": "h2"
+            },
+            {
+              "transferSize": 45260,
+              "resourceSize": 133936,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1258.4709999999031,
+              "rendererStartTime": 1065.2009999998845,
+              "isLinkPreload": true,
+              "finished": true,
+              "entity": "ocobo.co",
+              "networkRequestTime": 1066.589999999851,
+              "resourceType": "Script",
+              "protocol": "h2"
+            },
+            {
+              "resourceSize": 110060,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "transferSize": 34184,
+              "rendererStartTime": 1065.2900000000373,
+              "networkEndTime": 1409.8159999996424,
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "isLinkPreload": true,
+              "finished": true,
+              "protocol": "h2",
+              "networkRequestTime": 1066.7399999997579,
+              "entity": "ocobo.co",
+              "resourceType": "Script"
+            },
+            {
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1066.8470000000671,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1065.3410000000149,
+              "networkEndTime": 1337.8059999998659,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "resourceSize": 991,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "transferSize": 1514
+            },
+            {
+              "finished": true,
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1066.9159999997355,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "resourceSize": 9799,
+              "transferSize": 4522,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1353.6790000000037,
+              "rendererStartTime": 1065.4070000001229,
+              "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "statusCode": 200,
+              "sessionTargetType": "page"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1350.0519999996759,
+              "rendererStartTime": 1065.5279999999329,
+              "url": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "resourceSize": 3192,
+              "transferSize": 2148,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1067.0910000000149,
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1067.186999999918,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true,
+              "networkEndTime": 1270.9780000001192,
+              "rendererStartTime": 1065.6149999997579,
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "resourceSize": 141,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "transferSize": 669
+            },
+            {
+              "protocol": "h2",
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1067.3390000001527,
+              "finished": true,
+              "isLinkPreload": true,
+              "networkEndTime": 1217.9989999998361,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1065.7059999997728,
+              "url": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "resourceSize": 1284,
+              "transferSize": 1269
+            },
+            {
+              "isLinkPreload": true,
+              "finished": true,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1067.410000000149,
+              "resourceType": "Script",
+              "resourceSize": 15426,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "transferSize": 6806,
+              "networkEndTime": 1305.9660000000149,
+              "rendererStartTime": 1065.7860000003129,
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/cx-DiffRdtV.js"
+            },
+            {
+              "rendererStartTime": 1065.8429999998771,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1363.3780000000261,
+              "url": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "resourceSize": 17234,
+              "transferSize": 6205,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1067.6699999999255,
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "url": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1065.9429999999702,
+              "networkEndTime": 1338.3620000001974,
+              "transferSize": 1832,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 3070,
+              "resourceType": "Script",
+              "networkRequestTime": 1067.8459999999031,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "networkEndTime": 1339.313000000082,
+              "rendererStartTime": 1066.0509999999776,
+              "experimentalFromMainFrame": true,
+              "transferSize": 953,
+              "resourceSize": 428,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "networkRequestTime": 1067.9209999996237,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "finished": true
+            },
+            {
+              "isLinkPreload": true,
+              "finished": true,
+              "entity": "ocobo.co",
+              "networkRequestTime": 1068.2889999998733,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 937,
+              "resourceSize": 410,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "networkEndTime": 1342.5099999997765,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1066.1070000003092
+            },
+            {
+              "resourceType": "Script",
+              "networkRequestTime": 1068.4989999998361,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "finished": true,
+              "isLinkPreload": true,
+              "url": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "rendererStartTime": 1066.1829999997281,
+              "networkEndTime": 1346.1529999999329,
+              "experimentalFromMainFrame": true,
+              "transferSize": 1047,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 525
+            },
+            {
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "rendererStartTime": 1066.2420000000857,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1346.9300000001676,
+              "transferSize": 1471,
+              "resourceSize": 942,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1068.6259999996983,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "finished": true
+            },
+            {
+              "isLinkPreload": true,
+              "finished": true,
+              "entity": "ocobo.co",
+              "networkRequestTime": 1068.7349999998696,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 876,
+              "resourceSize": 349,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1066.3309999997728,
+              "networkEndTime": 1380.5379999997094
+            },
+            {
+              "finished": true,
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "networkRequestTime": 1068.8509999997914,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 1866,
+              "transferSize": 1367,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1066.3900000001304,
+              "networkEndTime": 1335.0740000000224,
+              "url": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "sessionTargetType": "page",
+              "statusCode": 200
+            },
+            {
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1069.2160000000149,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true,
+              "rendererStartTime": 1066.4419999998063,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1343.5910000000149,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "resourceSize": 348,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "transferSize": 867
+            },
+            {
+              "protocol": "h2",
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1069.37900000019,
+              "finished": true,
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1066.5290000000969,
+              "networkEndTime": 1271.523999999743,
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "resourceSize": 67398,
+              "transferSize": 21252
+            },
+            {
+              "isLinkPreload": true,
+              "finished": true,
+              "entity": "ocobo.co",
+              "networkRequestTime": 1069.4530000002123,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 701,
+              "resourceSize": 165,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "rendererStartTime": 1066.6000000000931,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1334.3670000000857
+            },
+            {
+              "protocol": "h2",
+              "networkRequestTime": 1069.7080000001006,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1066.6650000000373,
+              "networkEndTime": 1257.3760000001639,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "resourceSize": 605,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "transferSize": 1127
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1345.1899999999441,
+              "rendererStartTime": 1066.7680000001565,
+              "url": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 826,
+              "transferSize": 1345,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "networkRequestTime": 1069.7690000003204,
+              "entity": "ocobo.co",
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "networkRequestTime": 1069.9849999998696,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "finished": true,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1339.8849999997765,
+              "rendererStartTime": 1066.8470000000671,
+              "transferSize": 929,
+              "resourceSize": 404,
+              "mimeType": "application/javascript",
+              "priority": "High"
+            },
+            {
+              "url": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 1352.476000000257,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1066.938000000082,
+              "transferSize": 1011,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 490,
+              "resourceType": "Script",
+              "networkRequestTime": 1070.0919999997132,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "finished": true,
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "networkRequestTime": 1070.4449999998324,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 206,
+              "transferSize": 726,
+              "networkEndTime": 1366.2859999998473,
+              "rendererStartTime": 1067.0120000001043,
+              "experimentalFromMainFrame": true,
+              "url": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "sessionTargetType": "page",
+              "statusCode": 200
+            },
+            {
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "rendererStartTime": 1067.0690000001341,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1339.1159999999218,
+              "transferSize": 1358,
+              "resourceSize": 835,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1071.9849999998696,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "finished": true
+            },
+            {
+              "finished": true,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "networkRequestTime": 1072.0570000000298,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "transferSize": 26412,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 68826,
+              "url": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1341.0139999999665,
+              "rendererStartTime": 1067.1320000002161
+            },
+            {
+              "entity": "ocobo.co",
+              "networkRequestTime": 1072.4449999998324,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "finished": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "networkEndTime": 1334.8179999999702,
+              "rendererStartTime": 1067.2790000000969,
+              "experimentalFromMainFrame": true,
+              "transferSize": 997,
+              "resourceSize": 473,
+              "priority": "High",
+              "mimeType": "application/javascript"
+            },
+            {
+              "url": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1067.3349999999627,
+              "networkEndTime": 1326.5919999997132,
+              "transferSize": 855,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 338,
+              "resourceType": "Script",
+              "networkRequestTime": 1073.214999999851,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "resourceSize": 435,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "transferSize": 964,
+              "networkEndTime": 1327.1349999997765,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1067.4239999996498,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "isLinkPreload": true,
+              "finished": true,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1074.3969999998808,
+              "resourceType": "Script"
+            },
+            {
+              "networkRequestTime": 1074.4869999997318,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "finished": true,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "rendererStartTime": 1067.4890000000596,
+              "networkEndTime": 1432.0460000000894,
+              "experimentalFromMainFrame": true,
+              "transferSize": 840,
+              "resourceSize": 312,
+              "mimeType": "application/javascript",
+              "priority": "High"
+            },
+            {
+              "url": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1338.1740000001155,
+              "rendererStartTime": 1067.5509999999776,
+              "transferSize": 831,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 309,
+              "resourceType": "Script",
+              "networkRequestTime": 1078.7710000001825,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "rendererStartTime": 1067.6060000001453,
+              "networkEndTime": 1301.1099999998696,
+              "experimentalFromMainFrame": true,
+              "url": "https://www.ocobo.co/assets/_main.(_lang).clients._slug-Cr9mkmTq.js",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "resourceSize": 1400,
+              "transferSize": 1246,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1078.9120000000112,
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "entity": "ocobo.co",
+              "networkRequestTime": 1079.0299999997951,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "finished": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/story-article--3yoMqOg.js",
+              "networkEndTime": 1352.839999999851,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1067.6740000001155,
+              "transferSize": 6967,
+              "resourceSize": 24635,
+              "priority": "High",
+              "mimeType": "application/javascript"
+            },
+            {
+              "protocol": "h2",
+              "networkRequestTime": 1079.1419999999925,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1333.1709999996237,
+              "rendererStartTime": 1067.7689999998547,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "resourceSize": 549,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "transferSize": 1074
+            },
+            {
+              "url": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 1345.5559999998659,
+              "rendererStartTime": 1067.8259999998845,
+              "experimentalFromMainFrame": true,
+              "transferSize": 1132,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "resourceSize": 1217,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1079.2450000001118,
+              "protocol": "h2",
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "networkRequestTime": 1079.3109999997541,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "finished": true,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/star-BI6vQnwF.js",
+              "networkEndTime": 1335.2900000000373,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1067.9249999998137,
+              "transferSize": 1176,
+              "resourceSize": 656,
+              "mimeType": "application/javascript",
+              "priority": "High"
+            },
+            {
+              "networkEndTime": 1333.780999999959,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1068.030999999959,
+              "url": "https://www.ocobo.co/assets/zap-C3uzvT7-.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 446,
+              "transferSize": 965,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "networkRequestTime": 1079.3760000001639,
+              "entity": "ocobo.co",
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "protocol": "h2",
+              "networkRequestTime": 1079.4569999999367,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true,
+              "rendererStartTime": 1068.0939999995753,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1409.3229999998584,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/chart-column-CxnbmN-k.js",
+              "resourceSize": 435,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "transferSize": 963
+            },
+            {
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "rendererStartTime": 1068.1879999996163,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1328.0919999997132,
+              "transferSize": 1237,
+              "resourceSize": 717,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1079.8489999999292,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "finished": true
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1327.5109999999404,
+              "rendererStartTime": 1068.2510000001639,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js",
+              "resourceSize": 302,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "transferSize": 829,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1080.0279999999329,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true
+            },
+            {
+              "resourceSize": 303,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "transferSize": 824,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1372.8829999999143,
+              "rendererStartTime": 1068.2990000001155,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/check-D95Zi0fi.js",
+              "isLinkPreload": true,
+              "finished": true,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1080.1809999998659,
+              "resourceType": "Script"
+            },
+            {
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/LayoutPost-BT26K59V.js",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1346.3610000000335,
+              "rendererStartTime": 1068.436999999918,
+              "transferSize": 1845,
+              "resourceSize": 2543,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "networkRequestTime": 1080.2599999997765,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "finished": true
+            },
+            {
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1080.3299999996088,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1423.8959999997169,
+              "rendererStartTime": 1068.5049999998882,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "resourceSize": 142638,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "transferSize": 51797
+            },
+            {
+              "resourceSize": 2533,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "transferSize": 1822,
+              "rendererStartTime": 1068.5699999998324,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1433.4960000002757,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/member-card-Bn7bfGBT.js",
+              "isLinkPreload": true,
+              "finished": true,
+              "protocol": "h2",
+              "networkRequestTime": 1080.8859999999404,
+              "entity": "ocobo.co",
+              "resourceType": "Script"
+            },
+            {
+              "finished": true,
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1080.9490000000224,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "resourceSize": 605,
+              "transferSize": 1125,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1340.4789999998175,
+              "rendererStartTime": 1068.6569999996573,
+              "url": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "statusCode": 200,
+              "sessionTargetType": "page"
+            },
+            {
+              "finished": true,
+              "protocol": "h2",
+              "networkRequestTime": 1383.1999999997206,
+              "entity": "ocobo.co",
+              "resourceType": "Font",
+              "resourceSize": 58256,
+              "mimeType": "font/otf",
+              "priority": "VeryHigh",
+              "transferSize": 39126,
+              "networkEndTime": 1532.6049999999814,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1382.4930000002496,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf"
+            },
+            {
+              "transferSize": 31974,
+              "resourceSize": 31480,
+              "mimeType": "font/woff",
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+              "rendererStartTime": 1382.7080000001006,
+              "networkEndTime": 1521.5540000000037,
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "networkRequestTime": 1383.3009999999776,
+              "entity": "ocobo.co",
+              "resourceType": "Font",
+              "protocol": "h2"
+            },
+            {
+              "finished": true,
+              "resourceType": "Font",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1383.3379999999888,
+              "protocol": "h2",
+              "transferSize": 38778,
+              "priority": "VeryHigh",
+              "mimeType": "font/otf",
+              "resourceSize": 57572,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 1583.8530000001192,
+              "rendererStartTime": 1382.9010000000708,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "priority": "VeryHigh",
+              "mimeType": "font/otf",
+              "resourceSize": 60228,
+              "transferSize": 40710,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1531.8730000001378,
+              "rendererStartTime": 1383.0520000001416,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Font",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1383.3820000002161
+            },
+            {
+              "networkEndTime": 1581.6669999998994,
+              "rendererStartTime": 1519.4900000002235,
+              "experimentalFromMainFrame": true,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-avatar.png",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "mimeType": "image/png",
+              "resourceSize": 354013,
+              "transferSize": 354683,
+              "protocol": "h2",
+              "resourceType": "Image",
+              "entity": "vercel-storage.com",
+              "networkRequestTime": 1521.0509999999776,
+              "finished": true
+            },
+            {
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Stylesheet",
+              "networkRequestTime": 1686.9479999998584,
+              "entity": "GitHub",
+              "mimeType": "text/css",
+              "priority": "VeryHigh",
+              "resourceSize": 4371,
+              "transferSize": 1999,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1706.5069999997504,
+              "rendererStartTime": 1686.1499999999069,
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "sessionTargetType": "page",
+              "statusCode": 200
+            },
+            {
+              "transferSize": 17170,
+              "mimeType": "image/png",
+              "priority": "High",
+              "resourceSize": 16667,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1878.5460000000894,
+              "rendererStartTime": 1687.6419999999925,
+              "finished": true,
+              "resourceType": "Image",
+              "networkRequestTime": 1688.2089999997988,
+              "entity": "ocobo.co",
+              "protocol": "h2"
+            },
+            {
+              "entity": "Google Analytics",
+              "networkRequestTime": 1826.0329999998212,
+              "resourceType": "Fetch",
+              "protocol": "h2",
+              "finished": true,
+              "statusCode": 204,
+              "sessionTargetType": "page",
+              "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65c1v9100339653za200zd9100339653&_p=1778779433853&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1674557540.1778779434&frm=0&pscdl=noapi&rcb=0&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616985~115938466~115938468~118128922&dp=%2Fclients%2Fekodev&sid=1778779434&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&dt=Ocobo%20%C2%B7%20Accompagner%20la%20cr%C3%A9ation%20d%27une%20business%20unit%20durabilit%C3%A9%C2%A0%3A%20comment%20ekodev%20a%20structur%C3%A9%20son%20organisation%20commerciale%20et%20d%C3%A9ploy%C3%A9%20HubSpot&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1823",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1956.9550000000745,
+              "rendererStartTime": 1824.1450000000186,
+              "transferSize": 796,
+              "resourceSize": 0,
+              "priority": "High",
+              "mimeType": "text/plain"
+            },
+            {
+              "finished": true,
+              "networkRequestTime": 1835.0449999999255,
+              "entity": "Hubspot",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 29746,
+              "resourceSize": 97992,
+              "mimeType": "application/javascript",
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "rendererStartTime": 1831.4950000001118,
+              "networkEndTime": 1926.6170000000857,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1831.9989999998361,
+              "networkEndTime": 1902.3539999998175,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "priority": "Low",
+              "resourceSize": 78203,
+              "transferSize": 27954,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "networkRequestTime": 1835.2340000001714,
+              "entity": "Hubspot",
+              "finished": true
+            },
+            {
+              "protocol": "h2",
+              "resourceType": "Script",
+              "entity": "Hubspot",
+              "networkRequestTime": 1835.2949999999255,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1832.276999999769,
+              "networkEndTime": 1923.1740000001155,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "mimeType": "text/javascript",
+              "resourceSize": 109001,
+              "transferSize": 43655
+            },
+            {
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 1856.5490000001155,
+              "entity": "Hubspot",
+              "protocol": "h2",
+              "transferSize": 27210,
+              "mimeType": "text/javascript",
+              "priority": "Low",
+              "resourceSize": 72678,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1936.7170000001788,
+              "rendererStartTime": 1832.7080000001006
+            },
+            {
+              "finished": true,
+              "protocol": "h2",
+              "networkRequestTime": 2136.1229999996722,
+              "entity": "Clearbit",
+              "resourceType": "Script",
+              "resourceSize": 0,
+              "mimeType": "application/javascript",
+              "priority": "Low",
+              "transferSize": 639,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2317.0919999997132,
+              "rendererStartTime": 2134.6119999997318,
+              "sessionTargetType": "page",
+              "statusCode": 404,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js"
+            },
+            {
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2138.2559999995865,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/_vercel/insights/script.js",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2137.0139999999665,
+              "networkEndTime": 2171.4599999999627,
+              "experimentalFromMainFrame": true,
+              "transferSize": 1865,
+              "priority": "Low",
+              "mimeType": "application/javascript",
+              "resourceSize": 2495
+            },
+            {
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2139.4750000000931,
+              "resourceType": "Script",
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2166.9229999999516,
+              "rendererStartTime": 2138.2409999999218,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "resourceSize": 12567,
+              "priority": "Low",
+              "mimeType": "application/javascript",
+              "transferSize": 5310
+            },
+            {
+              "finished": true,
+              "entity": "ocobo.co",
+              "networkRequestTime": 2142.2689999998547,
+              "resourceType": "Fetch",
+              "protocol": "h2",
+              "transferSize": 2462,
+              "resourceSize": 16638,
+              "priority": "High",
+              "mimeType": "application/json",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fclients%2C%2Fclients%2Fekodev%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology&version=ba6d9b28",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2189.1329999999143,
+              "rendererStartTime": 2140.7249999996275
+            },
+            {
+              "protocol": "h2",
+              "networkRequestTime": 2172.1529999999329,
+              "entity": "Hubspot",
+              "resourceType": "Script",
+              "finished": true,
+              "networkEndTime": 2219.7929999995977,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 2165.1229999996722,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "resourceSize": 607831,
+              "mimeType": "application/javascript",
+              "priority": "Low",
+              "transferSize": 204723
+            },
+            {
+              "transferSize": 473,
+              "resourceSize": 48,
+              "mimeType": "application/json",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "statusCode": 202,
+              "url": "https://www.ocobo.co/_vercel/insights/view",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2272.3820000002161,
+              "rendererStartTime": 2217.2319999998435,
+              "finished": true,
+              "networkRequestTime": 2220.24599999981,
+              "entity": "ocobo.co",
+              "resourceType": "Fetch",
+              "protocol": "h2"
+            },
+            {
+              "finished": true,
+              "networkRequestTime": 2414.8900000001304,
+              "entity": "Hubspot",
+              "resourceType": "XHR",
+              "protocol": "h2",
+              "transferSize": 1095,
+              "resourceSize": 135,
+              "mimeType": "application/json",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+              "networkEndTime": 2469.4969999999739,
+              "rendererStartTime": 2412.8569999998435,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "transferSize": 559,
+              "mimeType": "text/plain",
+              "priority": "High",
+              "resourceSize": 6,
+              "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "rendererStartTime": 2484.311999999918,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2501.0709999999963,
+              "finished": true,
+              "resourceType": "Fetch",
+              "networkRequestTime": 2486.6759999999776,
+              "entity": "Hubspot",
+              "protocol": "h2"
+            },
+            {
+              "finished": true,
+              "protocol": "h2",
+              "entity": "Hubspot",
+              "networkRequestTime": 2496.9270000001416,
+              "resourceType": "Fetch",
+              "resourceSize": 61,
+              "priority": "High",
+              "mimeType": "application/json",
+              "transferSize": 1724,
+              "rendererStartTime": 2494.4210000000894,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2581.3689999999478,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&isMobile=true"
+            },
+            {
+              "protocol": "http/1.1",
+              "entity": "Hubspot",
+              "networkRequestTime": 3456.1080000000075,
+              "resourceType": "XHR",
+              "finished": true,
+              "rendererStartTime": 3454.2910000002012,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 3545.9199999999255,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953",
+              "resourceSize": 9346,
+              "priority": "High",
+              "mimeType": "application/json",
+              "transferSize": 4082
+            },
+            {
+              "transferSize": 1474,
+              "resourceSize": 45,
+              "mimeType": "image/gif",
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&t=Ocobo+%C2%B7+Accompagner+la+cr%C3%A9ation+d%27une+business+unit+durabilit%C3%A9%C2%A0%3A+comment+ekodev+a+structur%C3%A9+son+organisation+commerciale+et+d%C3%A9ploy%C3%A9+HubSpot&cts=1778779435991&vi=522bb937e1deac1b4040bccdca012966&nc=true&u=242475741.522bb937e1deac1b4040bccdca012966.1778779435984.1778779435984.1778779435984.1&b=242475741.1.1778779435984&cc=15",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 3496.92799999984,
+              "networkEndTime": 3552.4420000002719,
+              "finished": true,
+              "networkRequestTime": 3498.1669999998994,
+              "entity": "Hubspot",
+              "resourceType": "Image",
+              "protocol": "h2"
+            },
+            {
+              "networkRequestTime": 3502.3569999998435,
+              "entity": "Hubspot",
+              "resourceType": "Image",
+              "protocol": "http/1.1",
+              "finished": true,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 3501.2649999996647,
+              "networkEndTime": 3619.1230000001378,
+              "transferSize": 1021,
+              "resourceSize": 35,
+              "mimeType": "image/gif",
+              "priority": "Low"
+            },
+            {
+              "sessionTargetType": "page",
+              "statusCode": 304,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "rendererStartTime": 3564.1400000001304,
+              "networkEndTime": 3587.344000000041,
+              "transferSize": 1659,
+              "resourceSize": 607831,
+              "mimeType": "application/javascript",
+              "priority": "Low",
+              "networkRequestTime": 3565.7139999996871,
+              "entity": "Hubspot",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true
+            },
+            {
+              "resourceType": "Image",
+              "networkRequestTime": 3787.5989999999292,
+              "entity": "Hubspot",
+              "protocol": "http/1.1",
+              "finished": true,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 3785.9490000000224,
+              "networkEndTime": 3880.4529999997467,
+              "transferSize": 1024,
+              "mimeType": "image/gif",
+              "priority": "Low",
+              "resourceSize": 35
+            },
+            {
+              "finished": true,
+              "entity": "Google Fonts",
+              "networkRequestTime": 3791.523999999743,
+              "resourceType": "Stylesheet",
+              "protocol": "h2",
+              "transferSize": 1259,
+              "resourceSize": 3792,
+              "priority": "VeryHigh",
+              "mimeType": "text/css",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+              "rendererStartTime": 3790.7119999998249,
+              "networkEndTime": 3798.9199999999255
+            },
+            {
+              "mimeType": "font/woff2",
+              "priority": "VeryHigh",
+              "resourceSize": 50524,
+              "transferSize": 51336,
+              "rendererStartTime": 3817.9719999996014,
+              "networkEndTime": 3824.05700000003,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Font",
+              "networkRequestTime": 3818.7429999997839,
+              "entity": "Google Fonts"
+            },
+            {
+              "networkEndTime": 3830.530999999959,
+              "rendererStartTime": 3822.62099999981,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "resourceSize": 50524,
+              "mimeType": "font/woff2",
+              "priority": "VeryHigh",
+              "transferSize": 51335,
+              "protocol": "h2",
+              "networkRequestTime": 3823.4419999998063,
+              "entity": "Google Fonts",
+              "resourceType": "Font",
+              "finished": true
+            },
+            {
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=57c7f575-9393-4ca6-9159-53c362155363&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&t=Ocobo+%C2%B7+Accompagner+la+cr%C3%A9ation+d%27une+business+unit+durabilit%C3%A9%C2%A0%3A+comment+ekodev+a+structur%C3%A9+son+organisation+commerciale+et+d%C3%A9ploy%C3%A9+HubSpot&cts=1778779436333&vi=522bb937e1deac1b4040bccdca012966&nc=true&u=242475741.522bb937e1deac1b4040bccdca012966.1778779435984.1778779435984.1778779435984.1&b=242475741.1.1778779435984&cc=15",
+              "networkEndTime": 3900.8889999999665,
+              "rendererStartTime": 3841.313000000082,
+              "experimentalFromMainFrame": true,
+              "transferSize": 1022,
+              "resourceSize": 45,
+              "mimeType": "image/gif",
+              "priority": "Low",
+              "networkRequestTime": 3842.683999999892,
+              "entity": "Hubspot",
+              "resourceType": "Image",
+              "protocol": "h2",
+              "finished": true
+            },
+            {
+              "resourceType": "Image",
+              "entity": "Hubspot",
+              "networkRequestTime": 3842.929999999702,
+              "protocol": "http/1.1",
+              "finished": true,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3904.6219999999739,
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 3841.5819999999367,
+              "transferSize": 1024,
+              "priority": "Low",
+              "mimeType": "image/gif",
+              "resourceSize": 35
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "valueType": "text",
+              "label": "Protocol",
+              "key": "protocol"
+            },
+            {
+              "granularity": 1,
+              "label": "Network Request Time",
+              "key": "networkRequestTime",
+              "valueType": "ms"
+            },
+            {
+              "key": "networkEndTime",
+              "label": "Network End Time",
+              "granularity": 1,
+              "valueType": "ms"
+            },
+            {
+              "key": "transferSize",
+              "displayUnit": "kb",
+              "granularity": 1,
+              "label": "Transfer Size",
+              "valueType": "bytes"
+            },
+            {
+              "key": "resourceSize",
+              "displayUnit": "kb",
+              "label": "Resource Size",
+              "granularity": 1,
+              "valueType": "bytes"
+            },
+            {
+              "valueType": "text",
+              "label": "Status Code",
+              "key": "statusCode"
+            },
+            {
+              "valueType": "text",
+              "key": "mimeType",
+              "label": "MIME Type"
+            },
+            {
+              "label": "Resource Type",
+              "key": "resourceType",
+              "valueType": "text"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "bootup-time": {
+        "id": "bootup-time",
+        "title": "Reduce JavaScript execution time",
+        "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to reduce Javascript execution time](https://developer.chrome.com/docs/lighthouse/performance/bootup-time/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "1.4 s",
+        "metricSavings": {
+          "TBT": 350
+        },
+        "details": {
+          "sortedBy": [
+            "total"
+          ],
+          "summary": {
+            "wastedMs": 1351.340400000001
+          },
+          "type": "table",
+          "items": [
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "scriptParseCompile": 11.654399999999999,
+              "total": 1153.3956,
+              "scripting": 277.80239999999992
+            },
+            {
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "scriptParseCompile": 10.1436,
+              "total": 500.26799999999963,
+              "scripting": 448.62359999999967
+            },
+            {
+              "scriptParseCompile": 135.1524,
+              "total": 322.66800000000086,
+              "scripting": 164.36760000000083,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "scripting": 7.807199999999999,
+              "scriptParseCompile": 3.558,
+              "total": 321.63719999999995,
+              "url": "https://www.ocobo.co/clients/ekodev"
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "scriptParseCompile": 114.906,
+              "total": 253.12200000000041,
+              "scripting": 136.68480000000039
+            },
+            {
+              "scripting": 40.640400000000049,
+              "scriptParseCompile": 0,
+              "total": 252.7559999999992,
+              "url": "Unattributable"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "ms",
+              "label": "Total CPU Time",
+              "key": "total",
+              "granularity": 1
+            },
+            {
+              "valueType": "ms",
+              "granularity": 1,
+              "label": "Script Evaluation",
+              "key": "scripting"
+            },
+            {
+              "label": "Script Parse",
+              "key": "scriptParseCompile",
+              "granularity": 1,
+              "valueType": "ms"
+            }
+          ]
+        },
+        "numericValue": 1351.340400000001,
+        "numericUnit": "millisecond"
+      }
+    },
+    "categories": {
+      "performance": {
+        "id": "performance",
+        "title": "Performance",
+        "score": 0.62,
+        "auditRefs": [
+          {
+            "id": "first-contentful-paint",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "FCP"
+          },
+          {
+            "id": "largest-contentful-paint",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "LCP"
+          },
+          {
+            "id": "total-blocking-time",
+            "weight": 30,
+            "group": "metrics",
+            "acronym": "TBT"
+          },
+          {
+            "id": "cumulative-layout-shift",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "CLS"
+          },
+          {
+            "id": "speed-index",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "SI"
+          },
+          {
+            "id": "cache-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "cls-culprits-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "document-latency-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "dom-size-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "duplicated-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "font-display-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "forced-reflow-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "image-delivery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "inp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-discovery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "legacy-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "network-dependency-tree-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "render-blocking-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "third-parties-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "viewport-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "interactive",
+            "weight": 0,
+            "group": "hidden",
+            "acronym": "TTI"
+          },
+          {
+            "id": "max-potential-fid",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "unminified-css",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unminified-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-css-rules",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "total-byte-weight",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "user-timings",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "bootup-time",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "mainthread-work-breakdown",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "long-tasks",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "non-composited-animations",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unsized-images",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "network-requests",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-rtt",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-server-latency",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "main-thread-tasks",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "diagnostics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "metrics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "screenshot-thumbnails",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "final-screenshot",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "script-treemap-data",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "resource-summary",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "redirects",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "server-response-time",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "layout-shifts",
+            "weight": 0,
+            "group": "hidden"
+          }
+        ]
+      }
+    },
+    "categoryGroups": {
+      "seo-content": {
+        "title": "Content Best Practices",
+        "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+      },
+      "a11y-names-labels": {
+        "title": "Names and labels",
+        "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "best-practices-ux": {
+        "title": "User Experience"
+      },
+      "a11y-audio-video": {
+        "title": "Audio and video",
+        "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+      },
+      "seo-mobile": {
+        "title": "Mobile Friendly",
+        "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn how to make pages mobile-friendly](https://developers.google.com/search/mobile-sites/)."
+      },
+      "metrics": {
+        "title": "Metrics"
+      },
+      "best-practices-trust-safety": {
+        "title": "Trust and Safety"
+      },
+      "seo-crawl": {
+        "title": "Crawling and Indexing",
+        "description": "To appear in search results, crawlers need access to your app."
+      },
+      "a11y-navigation": {
+        "title": "Navigation",
+        "description": "These are opportunities to improve keyboard navigation in your application."
+      },
+      "a11y-tables-lists": {
+        "title": "Tables and lists",
+        "description": "These are opportunities to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+      },
+      "a11y-best-practices": {
+        "title": "Best practices",
+        "description": "These items highlight common accessibility best practices."
+      },
+      "a11y-language": {
+        "title": "Internationalization and localization",
+        "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      },
+      "a11y-aria": {
+        "title": "ARIA",
+        "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "insights": {
+        "title": "Insights",
+        "description": "These insights are also available in the Chrome DevTools Performance Panel - [record a trace](https://developer.chrome.com/docs/devtools/performance/reference) to view more detailed information."
+      },
+      "best-practices-general": {
+        "title": "General"
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "description": "More information about the performance of your application. These numbers don't [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score."
+      },
+      "best-practices-browser-compat": {
+        "title": "Browser Compatibility"
+      },
+      "a11y-color-contrast": {
+        "title": "Contrast",
+        "description": "These are opportunities to improve the legibility of your content."
+      }
+    },
+    "timing": {
+      "total": 16086
+    },
+    "i18n": {
+      "rendererFormattedStrings": {
+        "varianceDisclaimer": "Values are estimated and may vary. The [performance score is calculated](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) directly from these metrics.",
+        "opportunityResourceColumnLabel": "Opportunity",
+        "opportunitySavingsColumnLabel": "Estimated Savings",
+        "errorMissingAuditInfo": "Report error: no audit information",
+        "errorLabel": "Error!",
+        "warningHeader": "Warnings: ",
+        "passedAuditsGroupTitle": "Passed audits",
+        "notApplicableAuditsGroupTitle": "Not applicable",
+        "manualAuditsGroupTitle": "Additional items to manually check",
+        "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+        "crcLongestDurationLabel": "Maximum critical path latency:",
+        "crcInitialNavigation": "Initial Navigation",
+        "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+        "labDataTitle": "Lab Data",
+        "warningAuditsGroupTitle": "Passed audits but with warnings",
+        "snippetExpandButtonLabel": "Expand snippet",
+        "snippetCollapseButtonLabel": "Collapse snippet",
+        "thirdPartyResourcesLabel": "Show 3rd-party resources",
+        "runtimeDesktopEmulation": "Emulated Desktop",
+        "runtimeMobileEmulation": "Emulated Moto G Power",
+        "runtimeNoEmulation": "No emulation",
+        "runtimeSettingsBenchmark": "Unthrottled CPU/Memory Power",
+        "runtimeSettingsCPUThrottling": "CPU throttling",
+        "runtimeSettingsDevice": "Device",
+        "runtimeSettingsNetworkThrottling": "Network throttling",
+        "runtimeSettingsUANetwork": "User agent (network)",
+        "runtimeUnknown": "Unknown",
+        "dropdownCopyJSON": "Copy JSON",
+        "dropdownDarkTheme": "Toggle Dark Theme",
+        "dropdownPrintExpanded": "Print Expanded",
+        "dropdownPrintSummary": "Print Summary",
+        "dropdownSaveGist": "Save as Gist",
+        "dropdownSaveHTML": "Save as HTML",
+        "dropdownSaveJSON": "Save as JSON",
+        "dropdownViewer": "Open in Viewer",
+        "footerIssue": "File an issue",
+        "throttlingProvided": "Provided by environment",
+        "calculatorLink": "See calculator.",
+        "runtimeSettingsAxeVersion": "Axe version",
+        "viewTreemapLabel": "View Treemap",
+        "showRelevantAudits": "Show audits relevant to:"
+      }
+    },
+    "entities": [
+      {
+        "name": "ocobo.co",
+        "isFirstParty": true,
+        "isUnrecognized": true,
+        "origins": [
+          "https://www.ocobo.co"
+        ]
+      },
+      {
+        "name": "vercel-storage.com",
+        "isUnrecognized": true,
+        "origins": [
+          "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+        ]
+      },
+      {
+        "name": "Google Tag Manager",
+        "homepage": "https://marketingplatform.google.com/about/tag-manager/",
+        "category": "tag-manager",
+        "origins": [
+          "https://www.googletagmanager.com"
+        ]
+      },
+      {
+        "name": "Clearbit",
+        "homepage": "https://clearbit.com/",
+        "category": "analytics",
+        "origins": [
+          "https://tag.clearbitscripts.com"
+        ]
+      },
+      {
+        "name": "Hubspot",
+        "homepage": "https://hubspot.com/",
+        "category": "marketing",
+        "origins": [
+          "https://js-eu1.hs-scripts.com",
+          "https://js-eu1.hubspot.com",
+          "https://js-eu1.hscollectedforms.net",
+          "https://js-eu1.hs-analytics.net",
+          "https://js-eu1.hs-banner.com",
+          "https://js-eu1.hsforms.net",
+          "https://forms-eu1.hscollectedforms.net",
+          "https://cta-eu1.hubspot.com",
+          "https://forms-eu1.hsforms.com",
+          "https://track-eu1.hubspot.com",
+          "https://perf-eu1.hsforms.com"
+        ]
+      },
+      {
+        "name": "GitHub",
+        "category": "utility",
+        "origins": [
+          "https://useago.github.io"
+        ]
+      },
+      {
+        "name": "Google Analytics",
+        "homepage": "https://marketingplatform.google.com/about/analytics/",
+        "category": "analytics",
+        "origins": [
+          "https://www.google-analytics.com"
+        ]
+      },
+      {
+        "name": "Google Fonts",
+        "homepage": "https://fonts.google.com/",
+        "category": "cdn",
+        "origins": [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com"
+        ]
+      }
+    ],
+    "fullPageScreenshot": {
+      "nodes": {
+        "page-6-LINK": {
+          "height": 0,
+          "left": 0,
+          "right": 0,
+          "bottom": 0,
+          "width": 0,
+          "top": 0
+        },
+        "page-9-path": {
+          "height": 0,
+          "left": 0,
+          "right": 0,
+          "bottom": 0,
+          "width": 0,
+          "top": 0
+        },
+        "page-8-BODY": {
+          "right": 412,
+          "bottom": 5842,
+          "width": 412,
+          "top": 0,
+          "height": 5842,
+          "left": 0
+        },
+        "1-2-IMG": {
+          "bottom": 576,
+          "right": 161,
+          "top": 532,
+          "width": 113,
+          "height": 44,
+          "left": 47
+        },
+        "1-4-IMG": {
+          "right": 380,
+          "bottom": 5811,
+          "id": "open-path",
+          "width": 30,
+          "top": 5779,
+          "height": 32,
+          "left": 350
+        },
+        "page-2-IMG": {
+          "height": 40,
+          "left": 33,
+          "right": 167,
+          "bottom": 77,
+          "top": 37,
+          "width": 134
+        },
+        "page-10-DIV": {
+          "width": 392,
+          "top": 5637,
+          "right": 392,
+          "bottom": 5762,
+          "id": "ago-prompt",
+          "left": 0,
+          "height": 125
+        },
+        "page-4-H1": {
+          "height": 274,
+          "left": 16,
+          "right": 396,
+          "bottom": 438,
+          "top": 165,
+          "width": 380
+        },
+        "page-1-IMG": {
+          "right": 380,
+          "bottom": 5811,
+          "id": "open-path",
+          "width": 30,
+          "top": 5779,
+          "height": 32,
+          "left": 350
+        },
+        "1-3-IMG": {
+          "top": 2981,
+          "width": 126,
+          "right": 269,
+          "bottom": 3107,
+          "left": 143,
+          "height": 126
+        },
+        "1-5-IMG": {
+          "left": 0,
+          "height": 0,
+          "top": 0,
+          "width": 0,
+          "bottom": 0,
+          "right": 0
+        },
+        "page-0-IMG": {
+          "left": 143,
+          "height": 126,
+          "width": 126,
+          "top": 2981,
+          "right": 269,
+          "bottom": 3107
+        },
+        "page-7-META": {
+          "height": 0,
+          "left": 0,
+          "right": 0,
+          "bottom": 0,
+          "top": 0,
+          "width": 0
+        },
+        "1-0-IMG": {
+          "height": 40,
+          "left": 33,
+          "right": 167,
+          "bottom": 77,
+          "width": 134,
+          "top": 37
+        },
+        "page-5-H2": {
+          "left": 16,
+          "height": 39,
+          "top": 766,
+          "width": 380,
+          "right": 396,
+          "bottom": 805,
+          "id": "la-mission"
+        },
+        "page-3-IMG": {
+          "right": 161,
+          "bottom": 576,
+          "width": 113,
+          "top": 532,
+          "height": 44,
+          "left": 47
+        },
+        "1-1-IMG": {
+          "left": 0,
+          "height": 0,
+          "width": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0
+        },
+        "page-11-BUTTON": {
+          "id": "ago-prompt-close",
+          "right": 397,
+          "bottom": 5678,
+          "top": 5652,
+          "width": 20,
+          "height": 26,
+          "left": 377
+        },
+        "1-6-IMG": {
+          "left": 0,
+          "height": 0,
+          "top": 0,
+          "width": 0,
+          "right": 0,
+          "bottom": 0
+        }
+      },
+      "screenshot": {
+        "data": "data:image/webp;base64,UklGRnLuAQBXRUJQVlA4WAoAAAAgAAAAmwEA0RYASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZWUDgghOwBANAzCJ0BKpwB0hY/EYS6VqwoLLKj8grSUCIJaW7/1GxFFYDMe+/ziodZj/O9Hk/+p/hvTq5F8K/j0rh390n5y/+D+ynvB/qfqCeOv6zfMR+4vq3ekz+7b6v+7XsAfwD/X9cN/eMl68e/5v+3/4j/i+a39c/0P95/zH/a/xPpv5Pfjf71/pf/F/lf33+yL7l/1fvW9Bvqn9b/8P9b/vfZD+b/hn+r/iv9H///+J8z/4L/lf5f/Pf+v/aehvyR/6f9H7Av5//V//F+f/wSfRf+D/Wf6bvbdk/3H/l/1fsC+5f3v9nvTB+L/7H+V/2H7zfBX6v/jf/L/gv9j8gP9U/w3/m/yPt3/vf238mH8n/yP2p+AP+cf3//5/6H/hfu/9Nv+P//P+F5/fsT6/fsS/ZD//f7r/s+/r////z8JP3y////9+I/97v////ygbD/5BhXP0R4dwMGbec285t5zbzm3nNvObec285t5sPemv8SDCufojwz5X8KftbRO0Suv6m8+RgSTtbfWT5UgOJWYqCUDT7qv55cobTC1XIGwCh2RqHuubgUBpNahRIMK5+b9NGv77H6L94fHCV/pSIYxA+1g4yiDp9GcYdE7nTi1WGs4o3BY3Ry2JMzUChZR4XOFUrAq1Tbzm3m9UoxxHiGubekOzD5D4rn6I8O4GDNqbSg2IYHjQF3XT2kGgG85lQ2WKqpWC2vFjrVjarm2KzVCmNcAHBV+4GJg5qAdUtsFQx+ngEsbkbXM4UsnIiG/XjvSKDp+nFwHIQW5UvnGMuT646Fc/RHh3ZBrhWADJ+imYM285t5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzYPP5wuSspehF/tgn0jS9Kc7sU/l3MUc2zpuRNCl8hVboQh13RSu0Gofx9U8qDCto7WhH8r9AzZ6HXQY6ObGwReWcYRGcvxoD63Lo/RaPpnqbbhEO7+IH38lXGl1+6ttSTQiSapQFk7J9gJZw/SBUzXHeJrJfJ31YWRYR4zFZDXMxVmPdXsfDE5/Fk2c3d8//8gvrz5R6LS0zmgvYsAbbFZxISaESfgSRqdMM47T8iv6r4fyUtzzqKWFPa7yJ0t8+z/eo53H2lcPog3EsPSN1WR4dwLx/927JE5m1pu566NJJmBT/MKiJ1qyHuVrcbnMLBHzDOh/2ULQKufseTq40dD2MvZDxhdVDXetPVyt6+ZPRW9q+dUfHDEZ9tpEeIbgB2tfbnsw0KLPemxBkmDAVOoT9LGfDNqkXVfy8OfxByJs1z5is0wotyRRM7fmec5d6sxt7++u/JEec5IZzBGr12vXqzQaTJ61zm3mzdtwEty0MyZrk73mxfRVH4LbDZFsHBcrjzqvIwkdqdV4qn1U9rqYeG1tlb4UfJ3rgiVQN20wqoflpvKFZ3PAODJ8su//XdjrHkbz8vPIkDw7gYLMOi7Cz+7iMMpcO/6pIHQLTPJtLBJYjP6MIdBtr+VrLcXSf5w8Bob9lVYRZ7hEdFOnqxMYRc2N4KEY345uDiEa6I8KkQgP3qrNovgBj1i9KtUbnshoCxRf9U3AVulY6mNuI9cNuuZruDU0xRco8z9zvswvsUbYn8HjHUDsaSRl5+8dl65YaFqief1StI411mhoqQyUdyMIm4cW64Iqhb+aBFJABcPToJ29dWQ5Cn4ApXwqF/L1XFBpYeG2Dgo+d9dxVM+WcZE7L+vIniIr4OmQ5iT38wanw2KJjat6x+MyGZJoBmmJ/L3w+3uOnoaQ3ULDptwwSlBvfUsUfuWxsLzmhGFcd+ZTAgTy08rHkb59TeFCJF6z5+EAafwnvB4lh7ncTf8l40p3H/v2a0ix4LdJoPDQmbnjjLB4K9tV2kJAZ9b1re2rIj8ok5kOjJVf1xcvv4qverZGz6oAFWTb6lQ5kmeS59JsDcYLiuW/7f9Gb28wvOR1zrG/CmPfCV2kJe447y4WZcWT+pNxZaBDHFctaRU0XzmO9QsUBoLSUGT1+IpzbSJiF02S+VVGPTi8F+kYu/zrpNwM/1xgZtYmOmUbJmcrpoEhfRTaW7Txs8G8I1GwnZt59ROkMFh9KiKQtG1dqQf581NJPEmAbpVQBWb53jOuw+znLE7iFFW678jrvID7olxPiW3qw0f7mfpoXVYrikd3eY+sTZb2BWYXcv5QxFmsoeUVhJAX7HGDx/qz7P0QAMeSVEVxbh9CN6H4sfnklQZjLlAG1TAb1O8FPp3Qi2D9bbdy8FR9ksGgqCmpIXjVl5EcLqNZbbTy04RX5+tHrOi81K+qkpmF7rWWioiAHjFIhHDspARE2BAj6ZOApaDXOYSP6c9y8dc1Bw1sLM3VPL5AVGGsQ+gqCVJLIV4my8FGZ7t93rgff0sOsFj2YF8QHrYlNMI1/tm54o9Q3Q2x9LBCy1WuZ5S9RFKwZt5y+VPT7suTUHYafb8BoqEnSJ9LPzr80WW2ELlHBatW0fAy5DSxXRcokN3/uVUNWv7fhIAAD32kEZ/bAxAy+/G9l0j+ks31lCw+GxtJgET4T9zN7rDOvBVrbtUd2RPKirec27vLXk9OBgq5iZAV+kK4JkKRstGjdNO18vpGfc1Jg34CmoyDUFO4bSGpSw7Egj9jw1fnIuCfOz1nQthH1E7ec27g+svMkdjWnVeUES92imQPSPx54OtTwEfA8AEuFP/AjJwpqRh92GirLUV8nxXri0WGyOuofqAAfYNsPw9PMFDz0dqlucRvMMdD1O1M5rB1nlb3XuUnCne9aPEZsudVWNYz3I92IU0Ra72eXIRrS5za8PT2GbnAu24DXnFNGqfWjtcmPels7ERqeiPmznUmPFpw/+QYVz9EeHcDBm3nNvObec285t5zbzm3nNvObec285uFrYf/IMK5+iPDuBepVIQ6D/1zN0wBkRa/rVCO07u1wfveV3cc3MQBj/5BhXP0R4XCj9NYAarClA9CGv/zfr/yDCufoLf+qoRuUP44RQ5mRbRRkKQQzOVYghox36I8O4GDKdoqOy5wY7VBWWDjKKZ4FGGUA2xG76ERgoQ14NwgTHQAPsYNgrIpF2qh78Bnkj0UjAw+qAguqJ1/yeBtA3kZD0YJ8M285t31/T9Tv6UA2btlWnkju6qUelSi4MirfcLZCrRZq7ekgB9kvmFr/P2waPuer9EeHcC9sPK57MfpgH7WM5j+p0DqU7SDCufpXOB76WTHh649Lq9kBXhX+P4Dalt+agbptOqW6//5BhXP0TvYvar67fXsbEWzLGnaQYVz9EdwPQnASA6nsv2RhXP0R4dvX0P5LgUEq0kjv0R4dwMGcJZY1EycpBAS/HyDCufojw7sokBycfIMK5+iPDuBgzbzm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzm3myaHAZXsYZq8Zj11eU+WElzJPzPLrulpIGd/zB8vXo/Cx5Dtl60aufb7NFA4Zt5zbzm3mzkdufqMkff6OHmQJ3QapiYXc6THtMDoS/0CuL0/aSmEP5dJ3qcls2lETlhJAoTQAXX3fr/yDCufqQ4+uflth/8gwrn6I8O4GDNvObec285t5zbzm1EzSObXNBjam1fqWh4cXzdE/nTGX73rw4lbETInrwHCPBSMmDDmabxkSqGKdREJ99qgvtlUKdvWkKx2KGYnsBciaHd8EUAC498mGw/+QYV6EbhnLxpmU8xgqlIrn6I8OozNDzVQx6IXdDn4hdKHGb6Y+I7NXTG32f1+zOrne8FEeRXZXYO6OWFHdUh2Gl1rDcz64gprNIypqWf0EcuSwCYAhPpqXpkyiuFmlY+VttXGWS+UCZgYuiS+TvBmw77CrYBpJYMToicrlJl7OMkhJmj7C8UuuaxJJWZOfOa0F1ph5eC6ZuKDu75HhXSGcENO0RpfhCUtqJWq06E/QgJv8OxvuW7Yy1trQnzPRXLn1Gs1q59UDXJhYyTD1YbFP3r6kDaE8d0jCcQjVwsxC0NANRANH8wJ+ZovGnyA/7/qIy2+4VhnA/1rDdPKW+Z2ntGjw7dZRNgi8BQEEwiXePXMYndy2gsHWabF32sTHavG5XRHh28u/LELLxqvObec285t5zHWTu2IUFIM0V8UaztBACE2bMB2Q9Tb2IWt7bM4OVJrP0mK1RoCFkGRIaHfVfIttixjcCbUfC+SRCyHNj9iYxiLJrplAvio9VTsPK8O6jgyN4hwnMaC4UjHaMMVcvR3aTwEE8I9aozvocPKpq4PRHjmMhrUx6d3THH2GXqOIFyNpn3eYPMKFbzJucERkimBjNUMikDONReEth3AVh7TV0hLm6+eljVWmiONvVn0nYv3YhvHC36W+va+zPR0zZoeQMTBH14Lq6svckMFXEnafMP/6SouNutj4BnfU0dIsJrNZzUs6cl43OLBHI823x+5ZTUDj04fUFLuJ2VWy1h3NqUS2OC+Qh4DtGTfB7ywd1Lo3Q3tqrRK/zJRaFgLotjiXYcKd/guFE6LC2sIauyEGCLH7bGRMGEb3glGNSDaLsFW1dCThLaomNAHyh0aZA8pNqbqpqzpDgm5mHeQxm+fTGs5C44F6TLGRUpsSPAbLp0+rkTjzE6bRAXj9zAA5wuOLC3KGPT657wL0uSjZeErIvX7bBCox0eQV/trFtBkXSxQTMEcnQKl1cMIeNb9EeHdkHc52yuCbYf/IMK5+iJLaoijI3hoey5EJbXo0z8XRs75e40hGFuoV6ifIGgH+KE8b74eR/XqD+7j357u/TKUgafiHubZ0Rqs9y2hxo3vNsGbV6f50lNsWk3GTeVZTl0k8UGVCLw6BYX3SmmxTvb40TrG7NwxQEO6YNLKm3x6JsVjIp8M4PvY/HyDTKQoRZGVYjaPCqpx/P+r/oCIZ24sFZiOfMw/HyyITQMEUdRAfRKR+82sZoA8WtDlb1PusMausB2W5w7AEeYwDpZlxG7fgwiI8O3a5tb4FCqUwRcj2eEPR1CiXh+0l9jJB8FdQCOW89wUeyRhEHidJKPVwwPk2YgvB0Fl3QTa2hm3nNu++ZN5/UzrZ/mgfgcXsK+yNAHywmLRs7DFprKt8zMuFF9IWVd9HeqabnEr23i5e4iboMvoy6oR4CAQ8alV6xJ4fOM/GMj2fWvSrJD/rBLp8Y6l7VJnYib1RhuFlhdRh3aWdAH/r28OMBKT4VztRYLcjL0hoPkBB3ee9FL9eQ04+fGG3GcR7nA16ZVUqDrO+UNoqfQ9VV1z8090UAbGGLaLODaba9+TzbuDUGt0EAG/ke8lIavZmGh6pPrGBH95G9tAYFgfQMQISYZZpPMzkia6hD3bgYJIikCFbW2iWhzR9DAvtG1SEFSrbiIZYJbZr+y1PTLA9cQlkODO+a+uc9IUoApd9rEICUFp1AnSxpGE9gEo6q/aCp6tlzrNeiUiFfp2gRxw0eXh0FluChYWlXhJ2kGlhaGk0NIjxnJ+6rw02LJAwZtFsUQsAJmyI8buLKEmjw7gYM285t5zbuC1k+d2uJXWohiyzqXOaYR3HlUkYPMxumK6tzUhAtdJ1qDrC6+RU2QnAtna/X/kGFc/RHh3IoP/20fIMK5+iPDuBgtW1no94Z1kLi8pyFTPoa/iwecbAfZudGy0x35nhMTpNAYoO7EcEGZ+5D1bHnM1p0r/7ILcmIKxGGykwMsDfj6/ET+rk+Lk3cBxsaxDrvV853AwMAMPTwwdfgYH0eoowL0uEDN7F5LN99LyQqmLVze/2a9aXq0tGs9+DEaJLSZOxLf9JoNMfLvywqVX77s0YNFfRT3R/nf362RHqpGe59MSKyrUXfTO2dOhNmM/f1Na129xsF0gofH7ztNv+AhWNpFYMW92KM6UviYwZdftOooZc7AqYCOGL6sszpmmbXSM8Yr1yS1oHayTvVrONjqUmYh/rRirGulHPMu7hV7cNH8WBvqtoZqyI/4RlxENWaHjfDM5yVvQsJgIatFqKN0xsHA9gzFrY1xGx4ilSn3y32a5qz5kLUjygtLkJOHbDZTwNfiLmMb0il4HqnwRUNPTEFWYG5MNCUDqS+y3QWua+USee4isWEMLMOZydcMoIY40MadeLjQRoQ5sF4DBc0CvCJH2O+rZHpB95QBlTbGfDNq50li3pJn1zdaVQt54Q0VZpiIRninCOIUgi25MQGq5KkrAFGmjPDaDBMuS6QOzpI1og2wzHDfQbC/RUpK50EUp2Em4xu8dErsimerQjMBIUEfBfBes0Pj3qlqDc8josAyk+yA3HNEh8/RMi791VBSEsMPuu/0qw0Ue89DorTdVei77MG9n1eeCxxSo8exhWwDy4zeXs5Bf6hVG5Q7h5zNxL2hJfe7XKAMzXP4V8yNec2mGqy9KpWMdwkbY1N6HbJB0O85/EWIYoRV09/LUXxevoqeUyco4dwMd787bec286hBlwgwrn4HRWQRgMI4UmRHP6zkSUcj3cmMBLTngyex71iMqt3Bl4RV55llM7cpl9K/K60XVhmoGNU/IFcLg7bLYk4mDSjojw7gPD8XGMdaFF0JivyB3Tu9sYcMMAFOIHJ5emneRM7LWYamwwdjUgic9baAGFj0SEy7NPWr2HBDtX0Wk510DPhm3nMW9jo/gpmPp8VTjPyZor5qzIDm2LyRaRcf4uLuVJbDFdu4VG2oF9URwObW+CshSc9a71UZVLADRcw2H/yC/UdZffxTjrTFOzXnvZj1mre37v12YWc9n21mLEihzGHjrPnzkFCfqthgixpGLo/WJOTuv/IMK5yz+B/bZ2poffPYx5g9VmmPgf/kKO9G2XRV4gWnVuRJlCGfDemdvDiwSc0ArnseoixAIsEYdzXwitreHFKxwhvIM/qMgJ63GQUU7Nea0VUPCQWw5ghiqrTFLE+9wdcbxNQs0kXfh/8cMfWDHE0ulADT8KVqeIBbJg2Ic9cF2VCg/QGAlMYFf5YABX2H9RwYdoB3+kni0Yb2XwYCpt5rgg4hXP3jn4QaaqymrmLokF7HTs0U+MWQWXdk870gEbirkORcMJ/uAqrMk5gVaq/ETd8gJvGTaOzGLUZIL2Mq5YzCufojw7gYM2+WYK6Zt2kGFc/RHh3AvgB2w3kMN6YTYw1J8vFVldoLdB3kOkzLM8NUKvPwOaZv29h0Lt203RfJ5QRzi3ShsWWvPd44AYEf5HeJWWnES4N2adaHrnCWDs5G+3QVlOfBz/NFH1BPHUZAMJM6opeL0TgQdtEfofC5FbHmdQGbV2JIzG14xT/QQUsiSkNQdLgZCr7Gbo4bv2g5FwFO7bgrArn8PCDJG5l1jR5Qg4RJJMLqxNc0P+OmZenhdxDmAjMcMZINkQAiIRDtP6o9S8MEkWNjrpRQgHndP1ZEvWeviSQgb3+/f/1hGb2VRT2aJXrR+9ehLORnJQvtNPOgbsw9CTCVWyQIu18ndZl08JHd8WBOXuE75wV0rBqDCgbmrdeFOqxbaq3Pi6YKsTGV6ssL3gsp9ySiBa+lyeW3Vl/qrNFJ2zlJs/z96TZ1//RNxfsXAi49iKTs6NBWPturH50xQiD3TNufJ7oPV4uSpD/m0y4QWvSu2dlj9SkW60Q23GadIvOEFVCuHzN5TQpn4G2uPbClABabWOmUwbh8kTzvD+XPExr7Y4m6INIvwowFSCdmWq/8RXBt8+CfSPfa3nnfsU7SDCxV0QUeeqJLEwP7NzPK+eBLpOCqpBvAJ8DPzjjflnGFjxhOD46v7HLtUMxVWTxsDVssH7Y9MemZLHOmnX2IKHQAScA/NLxRKyA3tlu7PIBbAXdDWsV/dIBD/uUKuIQ6C9HW4nW9w3Az+nmTCFBJ0GHUyv2IWGof/M4YMcD54DWUbR8B72GWmbLxJMPe+2Su3q1p4sFpjGplD6c0FRWv1OUAfDBzrWEATQgcaS+aAQkEW5qRtWi/8euQeQoj+345Ilefojx/hgGDxuaz51JM285t5zbzm3nNvObeb/k0gwrn6ImcDqKp1m+0nNIJ7ROCgs74tCBRyomKdNHRYw6qo21/hcpSokok3yCi/KS5OstU5HRfrhSfiGf8TufINbIre06l3LH4CqMZRug5Ykgc/DzmmPE/IMauk/BZMoPQSqK1iq7TcJGqQyY907CKRYKU00Z8U6cXVDRSr6+UvjJwhx3IXeKGzneQ3lMfVZAmATNwBVPCyy6FG7OktJfZNpNj8+4M/2UhW2yqqhA1YTpTDxoc688FGGGqKNhDSPAUCTTVd+QatZ858M285t5zbzm3nNvObec285t5zbzm3nNvObec274EeOZai9MtxWnY9fmNRWIeul/8kB9FfC0iqmTYxBTUH8QwoRDGwDVjVUV+UUNnkI3AYo6q36ArDVUed2FuXxg3TlmUJQc4NV4FkR6KWJQsnm8SRvYjK0e6ShaiTtcAps/dM+w75ZppANuJfEv2IRHJ1UYJO10VCQIlFvmHmDVqgLl4V8Iy7bhH9BPhsvFFDK8abAYtUsChxI4I78D515rBnTb2Ll7QtzewMHSfwPTUGg4JiA9Pr9qAHqfZFNX/iUD7/AJZvLWQhKaOPb47PcbqoR9+pgMxnoIFjZo6vZNiIW1ievrQtu+sKODkMvRS0285fHq+fbqkSODeRfYKQVLLg2DRBLPVOA0i/kDjQHPlH26pEjGUIQeORgM1Bs7DKdt4dVu0xvZ6qbxrIKwXOfDW4ebP9xIGLM+MdWeQoQC/IMK5+inAmnyhgh+ZXwJm3nNu4L2OTd4wLFtFu/95PIcUZt7ryQN1QeY+yJZT1aivsH5S7EzDoDj2v6J+3WF3793uPtqLbxF0/+Qt5bZsCG9wsUWY8Xs21zwpkAYqauMWg5p0rUTnZU+P3zntzeesBd7QE1fR2fAsOL0B3bYNpnKgTJHZCOikllzG6wsskkCordH9RttbwDqe3Hq74gHCCzcw33UQ91Wk55OwizIhu25BhQz8+KsRwRMAFA1eS5gYDufQFnWNCMLPED/G7VKtQjfpP+kDwhxj5IDavXBSU9hHSpSwL/rMftCl6Q91alqKF/ITVAGPHM0j9ljpf2G7VY/Tx+Te6l+xRRiekVe5VVuXqxYxVeddJtZieUPo+EEHIaQvXPVU1AtMTC0GmwByf5XdVXz+OvoHzxuLmoewIfGkGnsVgJ1KAy7Mp3sgqwciBXno8jXc6KxjGOpx429116x3pKor1joZNRj7hi0CHy714FrSDcI+UML+MG/wand4Uj6gUntBNkBov0m3cVuSF56UosBmIL6daxww7W6o2RtO4C6XA65ckX+GIGEGdQLiGStg7SgNHY83ozjGIWoUOw3fsKQ4Gd+x0OE3H1WgoGnBzYGUODDHB3h1g4LX99v7X8BoTN940JF1Z2KgXFeZitFe6Gn7FY0lh7Y24DZ/hOI/4lv0TNsLVCI1jVV9zD5R+oFjrn0k/6Z6UK4nocsZr9peeVm7grK8pPv4j5VVt+XMP0Yz9q80KqW0m/wfpXTO2bECUms9Rn3qYO5MvTo9xnayGlDTUWgNCVmpU7RYuH0bt+PvAC5S48b3HbiQvVNU6ZY8ENlzcMxTdsv/8xx8rQykOAy+VEEqUyxLbE4C0MWCvAUCorHddE2Wufc58IJjrfGX9kJjkM0CZZCU04COQufUQ4Gb+kOSVGzi/ke0esQOv9xlqLyGYa+4mkyINzErrLGH3/PniuaU1zs2/ZFPvAmdR3x1kfBw6VuhjE2vo0BeLKekPHoaZCRMYstqtdRuzAf5crj3z9mBvPn2u3mae+Y+FEr2t2M52IlMMLoBEnTngH9t7tNr2Q3/cCYm7Iiyl1U7Zx+rXtFTpZ/Np1q2WXC56xdvUktjkdjk1gcybU6ZNiecXjCWA73RJAxY6UqYYOrhGlztb+MZRMvCKjqRXAV/OOi5hHTuQUy+tlN/CmddxcYwml5e85TXbgvKLIQAQ0RhVnQFjVnBffR0wFwmlg7kgZtILlQYTvyC3dYTCyRZK1msz3KwENDEg2B49x4DiLep6n4yuZiJeY81GaqjZPIaZp+CgMelttIHl0RGHXqcIKkM4wt7OXVzF6ZLDy5/wjWq7v8mdxqvfOnXlvasFSWfAO3spYC8I8h0Kz0nMe4+e+ny0oLresV5nhTBpOA5XX+MVrKC4GAGIB6AW05tGJl4NytruNuYJN1J3dTyMd8IKbP1lHyDTLEoRl7cDBm3nNvObd5dr5zb4O/Q2kEtfRhtOFoLsJ5W+ge4cw2H/yDCerzIAWaTE5q5xTLwuzHmv6d4qyPZ/OR1Zr9SL51ourgtUUJfuWvCAlU5BTfH6CwiftqePhpQeV+o4ufTgVFfMkihpPkt6gBT6dmBug0oIWuexMeH5wk+VryjP5sZehC+M8G793NvObebEl5yvvAaaj3gYVF8aRJUuTb+kVOhsGGHgLBeDxcK9qQ44hq4WbBq5P7Ai52C7CgHqX7G1QGpmsvZfThvltHYsEb+yVGcc/LbNyYW0ajZ6hq5BviPBGP0NoMRf4I5WKi54W/XAKmQOyUqkTOuMJTsZJDkgD5dNSzfzPSeFkbdB/8bSUNpgQm3dWLIRSIiKFAwGrTFfxyvb+o2FT6I/BduE8tqC/jcTsP+jLWZPVLCptEDPRHYEN3FZf+gd3dvWNEo9enmG1e0Nrn+lRbEW+a0auuZN591twAeuUVeZ04xd9kCQwwGFQ5IDFDt8Yb5+xbkvRzp4LLFx1lHUvAkY6ttEVgWTKc1BnVnkp4AvomBeMzkeF2hKZXTTH++uMm2HabEGrWW+S5A8HrqJ7YkpQ2tup8ELECacsFrHXNq/vy0vYFIiU4J5kvzIOMBkBCDCShaN2sULqPBXI9DC9c8u0sg7GuAja66X6JCAMfHVe/kJfNvXIGDNvNQmQgwkbMl34+8O3HC/0bKtSDsRkatuSRYvlSHvMWTcaf+3qCRo/wWdsmZvKIr/miEhnn7j3xo4eEvIRsrk+BsBa5xqDJsDfDYrXDlpxlL+c+3MHe6GS2IKKmkQbTED6ymN3rDCm8rdIOBLm6NTE4tuxs020fAU3vEd+Gj0n+DcX3b8idjJ0nuiHgdFGXiyv5RPW0AcV2w7sG5+BFJOem8ECAf0Rekc4EhCpLIwUDUHlwlawzQ5YKpuaySo8vTrM6TBmw8s8VE1p7XVC1VmNw0iqnSaIqm7D3EbMuDi4e+ve/r7Tc8qL7z5iwxWLtx8/TgP/gmyYMIK7PNUy2/tdw5SEQmdzS6D+o07uvPlhkgadcwOKyIG9U8M2Cb3VnUVQB3Z18bMRdExDbs+QPPrOwI1+2QnDcF2EYDCNnzMnkc2LGtW8XxkCgM0R1PuB3Gjd1ZmjxL3O0yhXMZARh0MNgwGsuFfkdU38kH6BFeAcvkEEX+olRdiJXZUkxQYvYvhBo9S5VbahNOnhuR5gkJCYlSyxO6qCi3CA3BGThrKAcDOnLeZPxneHtY5OedL7WSVdKSr3CAAWDs8aXXETCf/8+sHw/esezSE8Hi1bukSpGvIww/RgK2T+7dRWH5oH7ivrCnl9ZNljvi2GgSqPS7Yebm8N+ntKXIf/ofs8k5aPW5D/ENAcPUMUE8CgzL5hDvNzfJvW5L4SlWzQT1EaOeVI96XfbsvA7QZiQQJ3Hy8HhKEybr1fBxl3nooNHbhPyENnONeWEsh/S6NezpcgP4WEXqdUMK8lbb6eHBLk60ninKKfZfTS4XdtwMbvH7JWzgnKbFbCb9wR3YZzD97W1PLdFoDYB25Ie0M03oVig5Csnoa+us4u0s1tG2Z+N9EH+PyqTuOiY0aU8EbuBxNEp/WPFsTSzyOrnQDfLeSyeBcqorugJS8mkhkJZOLbubuJOY0ssjcu2Sp3pHXWNcdGQT2bELHpBvJqZCNSUYVXLuXBaYAYy4H3AYdJHMw4DWq4vGxGMl5C81s8MglOMEylYXFdjQpjC6D48W/DiF79rADXb44NVrdq1Eje4s06S3EAksnWfe2Lq3fUILS3ApZ2Gd1/41TM9/SN/Mko569Xhqy2iixabPl89mRB5euOrzjWLuRcdN9wtvy3oi9849BGDEYFwvJhzOqmyXcBkr91rQoeOWm0+viEGnyjfTGnj6JF/XbKkrXQOqEr5nTMmwFoz7YKKaz1Ti+juwy8yGkNgxfblwEjMvWKceCt1h/db4dIAU8QSFqjnNJrXErcaFqx6a0BzstYoTmyuGBuia+I5TpemvjUPewVoCyEdiofuACw3+xJPvjMfWaSx1MY30Jcwj0mwH9GhAPtYFPBagrfrCBpA4BKmgq1gQUPsMEGfVjky2cy3V9aa0oV/FBXdlcwXbfko+VRqJF7+rmCbjfctKc1hWigI5Cz8S8skoJAHds/ZdklkNjJWjb0gQbULNvi+ZB5JVLnETqClZy9O+UWK+Xpye/5HsGHvq0rD/7rokEgDXl7FNOgClOhhH7tqvAeHVXuSlI0j2UXYw0HngiF2srOi8++cz3ur8Ys7Q9GJfvaoeBoPq2XG7p/nAJ3ee9JRGLemZCsGL/RP8Yzqbr/yDCudl+40E0QFjsuV07yHuTxHcSDRz72kFMNWdAey/+L4gWczMaQDuQ825UfQMVgoH5WVP7EnkxAlDBcyia/Xsa6KOiPDuBgqid8iwjjvgMqR8oBqEuC0qocCVthFNFSg85nlnWdAP9xRVTwrb4D3oBB80T+ulARBNc6/k5/ciTH9GbgKXik05OzxrOJ8Q2JwAAVda2jw7gYLWfYE72PlpjcIS7JbyBRym8oqrtHiEW4Cx43uSMYbPyk+xn+x7+zY3osqBBbSNpC9IIwrn6I8f4njwS4kmmq78fIMK5+iHhkJxZ/IptQn/XzLUDNyIilmLBaBOWCl0GAIlo6vaR2KqwxzN8u84aXHvKPCvCBu0Xdf5d1BLaJEJCibbKLqKdKxlnGdWGISauNOsNZpfaUPHl+FsBJBXV/Xv6b3mDCk0C504U7HMLK5TuGipNXI6QvHQPLJNb8mUYWuyLocB9Bnq85G3gZYOFSYTpcA1pQyml+kR5UvMuskhlQ42dYbmFNwBnOucFT4OV8gHTYAAjsYgz3zO2hf4Q4FZsQrn/z5kg9LiglANiaQKSqPwCdVgRgZroF5HZWwFlNSGIu5qwRGN5vg0ixFQFywIBVX4gBnde9kDfBDx6BzmVCal/IIS2tC03cedfYXnOkWRAgLHE++qhLB34y5dp11LdNiPZHYwaoq7AMTfdGpqP/hEeA/Ug0LvMoWVmj9k5UiSdE7EKXTjvC5f6EKXhKNp9DeScpppTo4nQdccA4z7cA765q4uRGYf/IL3rkChXAq51ZQTx7Kgr+ZMWRkkBKLyAzVpfIgElLqJmSzFg7GK0JesApX108ODqCzT07EI82t2zcJ+ISHgSAqiOvMwXaCRlQXzCQO02hTzIGZPSC2fyyMsB69PfMKeZEBFPDBF7DYQfFuQrrH38OjFcyz+Hvs1vU7d3zTsK3pJWUo5zFmcHDrSY1Yyc/INfy9ERfy16j7tDATyd1o2B9hjmEJtx8M13oxnWxlFz+STHS0T2+TlRCC8dqvdw4OR4P3vJpWLLx2111KV6r3kefRMShQltlc8AJ9wmVZf6oYdT7AJP8S6KNj4KGmDKbwtrHxpEHfFB0Ax/sMO9ca9yqbnmK+5+Q/61sh/3H3AbXAqWYjzI3NzmeJhFvGPJB+nXOtRxiaLm3EBhyAZ/x0NF5fCDVHCXDkGGpJ0At6LNfN5JJ4mjluZGj+ru5gDEmv+pIrWqbvwoecVvb5CdiQe4dG92DXSrn8GUD0prN/sAkVsDAB1y1kX45Ae97A3Uuke/th05lH0B1wKQ8rtpmasNbATIPwNMCla1Ygh+d1N1OgRdiCBn9LHvQagAhGLCM2sP7nYQNEo+TG/grZXUnBMEGPXj0A/sIp5Cha+dpVrfJ6wbQedtfnY4i0YdQ9z0WyLvcQoN9r43Il1MbwrZYRYNf7IDXrbGAfPl/5/Qg5NnlknJrW9BxvBpb9nPdiVNlTgmGa3f1h2ih5S0R8XVAohnykRYNnd9Y1/F4lQKf6YGSXhVJDmDDZCOLtRA0E4RP0FoO27ejUUE4JW4LIrOsDA2g6DVI9j1tQ2H/yH5lHeSy1TKm5Mep6FB/8gwwHt5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvObec285t5zOgyVeArFl477MCXPQCQHJx8h/KLASA7JGUWAkB2SMVn6ZUGFc/RHh3AwZt5ze6EUGuc283mHfAGkaL9BrnNv33O66I8Oo2a7MIaB86dExNcQp88xkCq6Mq0uc2/fc7rojw9H3wzjWFJTAIdRH6ssw7YCrB6kT511lu56Tm8j686DNv33O66I8Wl2ELA3YRP6PHR8KwiYUdYzJ4LGdytBL/mCTTrD66jbD/5cAI2w/+Vk/GrLsHG3RdiC5QQKGfpxVhfc2X9ZG22DNv33O66I8Wh8L7LXn+GNAHVhYLtHKczRtYhtTwqG7K1mFbw2MzYzaQYZ2S8PkGGcwylpi7EenmGFWNt0k9squ/1XMgLAePcsmSJt50W2X7gYMcBHPbWHxr2eG3aetXKbIVYI90R3vwqZqVNvOb3Qig1zm8gCCVnzK6i3zRSsnrXgGst3xXOCjfJmaPDuDB0yoMK4SNUtLfZgQCPDuDB0yoMK3BzjvMBIPFcn3fr/yF4gH63mH9x1PXp8inhsKmRZo4hsQQ/VGdzjuTR7nS76La4xl0N2/O3865Mi1liyPceAIIGmZT/RQEQQ4WO4hRBpxsTFIdR0PIBMqt7bQ1HAtq5c//BJM4z0BZ6O+99P3esBd7PsHvS8Nv33O66I66ff2yZ234MuHTNR1Q/erDuy4ae0L7n1KdpC8QD9f+OlBx8UtX4+KW0nojw9lcrfRUn3fFNYwcQKHR8SCvS5p6LTIsdGVR+UM7Co+w9ruLqxZntyTAUYfA/hyGtR1emB1QNPSDsVgad/QoOOecCIaP7q3nv+n8hAsfehrVqDl6AoNmB8o+VDeBwMageKFiMMQP4VWCcLVXJA0l+EAahkR0nOMluisfJYt0/kMXRjh0JPihwGX6l6wTzLdmX7AYC2sOboQFLtTDlzto3FUc80quiuPn4S/AfaV9IQNKJI4jCGROPp+8AuZiYItbDaI1UZYUj2RMjpIrIoQbRik7qULYDnqg9C0wg1rAEcV7cr9MLwjX/jG2hyDjb+03EkQ32MZ7EGymF4cSfkPc5uFtl78MZCQtcf8D6o2wrPqH1sRTfxcz3C4YXzSejvnkKuEUVUkpSteFjA7toczEveKuxIW1sP+PZfHaiaM2wB4K2nvNN5DgEPOw4YpfJJKmsJXV7hIWM+M2ypeJKU8YnyBRyAZZyXttGYB8EYY4CsdFhs58fwig44jK37aeNcb0f/JG43lj36ADIqSez666NpqbhL/bMFkWqJMMxN7fFyxAlUAXqbjki9C1vbNCn6uVPEF+BF8K5FXl3ghUESHucAvN0R3pJpKfVuRtqf6axii5VQkWuYbFfm1ABxpM0PvOouKmMeZHpqS/W7WecI0iULB/lJ1m//O1NY/+LtkrmwDKVDnq9zq36S/1AK6LQh+UwHi8GloMMVGZEzUl88DYNJ0yiXwC5mFu2kSKFtXOXEmzuokCutgvT8xhyUFMgmQ9jVoqCwtgWODGNtDB0hqA46Ai3uWEoELJDQA7gZH+U1ZL2HVbA9ileZBH1Tmsl0/CKANDRCAnNDnFtWXOhQeHYDBgZnz4YmqRf94tOobANYUV+k7jeo3n8d/KXgpDszsoJg254K1D4XJE6ltH8A3evuaSs0He1CpEfxgLlxGgDuLnz6/c7pAdm4n9eMwBK+D1XYg0MXWRMV1YqaIqedOpF0ScVpv6fwp1QW/VEt++LoYD9Nzt/9mxbE9KQ/au22dn2D3pbNzXH8seilrRdaGOPju3sqnmAMGkS8QD9f+Ouyov4SxrSKsawZOaxLLfqg1gjIR/G5GMd9iGYuW//5BhYq6k80tsP/kLxAP1/5BhXP0R4dwMGb3PxELO03AoJ+ytpuBQT9lbSa4DNLc/GpNkW7iAlDh7TsFawLb0urIt0x4MOCerrW6h3Uw7gmB12VlTcmPU9cqYR1phEOx5F/bw+Fc/RHh3h/rfD+5wUF62bgUaIMDNvY1GQiFWdIy6y56AUQYL24PhNY0yLA9PpESRgLibYzBxfm1NTuPWnyL8NlD+Dw0pdbX9fYsd/tUe/PvgFQ4pJHfok7T4ZvMH4whqt5zbzm3nOqgkGGSrN0td21SVlnwXsMHOUDeR6xISrzYxM4MuqqNb5Q1sMfIvnJALMybMoEr7IwYCifkiaFJ5WDLLdFgtASFh/89j9A6dY4Y4OdAnDnLiTBdWQZkMHweQ+r71NmIngvmyAS+fL4VRBj27OvkvrGDFVrCuiF+ZCRsqLZOAh+0tE8raINDaR83cOoksp5Oko3yh1JntFIefPgsjRXqza/X5Qx2bCE5gj+zhy+B+oyvxjSUOd6WDUhs2JGAuscIRLjDYgAypW4Qh/yRdln5HqzWnTq/Wj4EaiFv98u1cV2CYyP6pvtIYkMvQ/OmA68fR+m40QFytWIBAoMyV/9cabrSp7R8jKYPaJL/jw9j9A6Yd27kbU9GSsBWNnCuT3mVb4FkmrqIrsYo+jF1/zy18XZ2S72VAAWB4iD4pqzFafm9TeBWLxmckyDCufqQ4X9V5Z4eYhLk4m13IMIfGMj1rQiBYjyEZKgFbSOVIKdAnvf1HLkjVmKuf2zgW7bvqATXfiRN1JyyC/ZOJ56nim7Vdh+tRCsjezgG6JXYKGxy/1uTBmro7YdANVlDiLUDQpKo79YQ1i4meHpQufgByTqB3ll5XhrviuilDTiRFfTQ3B6DxjwAzjOEJinrPO5bldxNg+KijMdtaND+5r5a+JL/8/rIDFFzErYpYQV/df8B1iFnpmMQqbyGI1lmivpobiJqY6TxVuUB4MxNERiXXwB7xtck5TXgBI7pjGDjYrMgrzJGTbfS4ImfcsiRpn+gdPtpqWwaflJAGukOzDNI3S13bVJWWfBfzgG8TJocOCApH0D2O2wC3mQYLXWzdHq/uWF/A6javS4N/9+uAgtDOxIUavW6cKFbKgJRSTtII0Q4Raxwxwc6BOGuvg7ZIc5XWXPBip5b8mSvB0WYB+0lAARQBSBv4IKCc+yxZvWOHvrwgdbkpaQ5xi9mAtiH4Ib23ZrbSPhGMORw7hBrbZh827ZBuFERleKzsPAxkjid30ITx/b0gtu1zusCMHtnNSSW9t3KvzjPWl4sfDoFnCYUiS8/aXFMuUFTxOZVnTaoVkL99TtX8xAxG/bQ6TyId2nWIiLZ7Xezyf2J+bGoKrk/8NPYtnw5RGtF+7Ee/7yAtspjSUt67d65AwXKOEcxfootnGVrPoI6O+ILsw+QYVz8WyvLQ0M285xdd+v/IMK39tDpSdGj0AkB2SMosBIDsjXnDZXlovEB2SMosBIDskZRYBWLzEETO0gwrn6I8O4GDNrlw1/1uWx1G746BUKVvKbhhqCRfD1AZ7BiZ+FE5Deulg6cy6L/pPZRG2YBzWTqBh92dkkVH3ieOGQjgbuts2GqGbecyo05j5UAXXSWfesBd7PsHvuwVnpRryNxbK8s2LZMZd05GuP7K2m4FBP2VsWQi8qk/jxQ220Ok9O1G8BpMFb0h1SCWqDw0ULoU5hlr7pQT/2CLM/usPabwcTKWIrUMlR07s+P1jF6r+sPD1JczO+wQYUXxtO27WNOY5TgFulRibek+GdWq3AwWCtV3pzSc+B0R6qfLXLC3zA/GPR7zJflZvEoT01W5eC/2kZKD4MzQqoto82wqbkx6noYkmeweZxg1ksjutWq/3+Jo46nfZ95kvys3iUOHtOwVrD+MP0f7PAa2EETxoeLn6Z1eArFl477MCXO9g4/R855WLLx32YEuegEdcp6Kcs477MCXPQCQHZIyiwCtsP9WeNEgOyRlFgJAdkjKIwK3w/+QYVz9EeHcDBm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvObec285thoTfC9d5AG++8gDffeQBvvvIA333j+8mVCnb1U4OSkkW4r921Xq0Z0mI/dtV6tGbxdIfFaFqXmgtFnZGFc/RHh3AwZuBZiLFIJ3hjZXP0c3gYM28T61p8LmaRz+mQLtHD3hTwQag7de3RqVkSY28sf6FYvmzq+6DZmVzsihNh6pYmUEdeKuUjpmgagKT35zITNcPWk6JqdGRMDLihdKyfPr/m6zprqAJi+91/5BhXuTzmVpqN/HJGRtVHmdUT5zutnK79/klFJ5s3ky7/Rvhz8pJhYYwnaXJbEfkIoSPISf5ScFz18OMju+z85CiO0LGSGAUI438mpQOAxFRV05bC8H/PUIaHdM/1rh2nWF1pauOaK6KG/dq7wu2jrZzXXRD2BNeEGjZo57PP5hRLHg7Ne1yQXzunQx/4flaIKNJvyyRGI3vzkKO0hD40rncvbREv8DGo0wV/uaXzxlwvN8i84p9CweFuxwjiH/IWM9lGVHKISSdtTDSvSMnEYyvmUki3TI6xa65DyJs8Wa2tla/KkDt7Ivyy/o9zCnUkItvcwxFiHhCPDrl9aP5igGhvcWXZFeoIaoHycctd8X3D82FigmsPn3PrDq2P9WDOx4YD5r5vM97/vUrH16RZ7SOBdY4672iMzOQ/9rxsI8Z2kGrIVfXtZDNiPDt5Mj3EmhEf7q4JkrWsj1OP3bBFJJJquDhs4EgSFkDroBA8I1eRUWEquU8QQ1dueo2jodhGIBV//teNhHhrudS86nPN9N5R6J/PKQcDqZmQaqkmkGHc2Ygj5ESVnv/qcssrPzQa3SC9cECkHQ2rGn+5laTW0djStXzyokp5yN+u8LmaScZxR12R5AdZCEeMPeQCNJ5nFCB3rxsI8ZyYemfI+Je5FrSoyiMqH6JKabbEnSF1yBzaWBMEpxPfWA9YeBKYP2+HYFWZO4eyeNZvvFZmddTYAh4Lx5lEawT/3BAEKwz/zdZ010+6BfCMLP9uphX1HaHAfx1sPSGgjp36a3wgAn6YA+YEKfLdblAVIXuR8jAF5l4J7Um+TozOe5/+ErELLOKiLhQiu2+yMM+beYOHpt5r0pAvJXUV9//HV/1TAoGmspErClKRaPGdpBexaaHYxGv7Iwbt4lXfK0jBBL9ATvy65LjT9GaYA4p7hn+u6niMkZ2n45xJuiiOQYT1HWdX7o0jG4YaPC9OAMNoNsplY8fnQgPYMyrRycXO8RGDNrpfP5RFPhm4Kq79JkGFc/F4jfOxjCufojw7gYM285laajfyC+4sIqN31Q1EOKoaiHFUNRCQEPyq/NUe73sSTjNx67Iy7wBqZwiT1sivYCQGZZS/6OBynFcE1unoZqe0eh4a0fqxAZhW1mbIdXEhLDE18sLW1kmXWU7gT+7OUgd7MaEnWggIY6kGwkOIJzD3OGCbO3jaYllt6z4FSKJob8sAoEO6okfYa0VauwJ1booqKWLP/pJVaUkKOdg9k0DML0ZlVS/Qao2fPk0/HwN8PWfggYhpqDrNn6PyPcPWk6MSfi6JXCunh0S51kXaFWq6O/REWAh4+mdiGSuP+TTBZJZR4jYxg7GnT4xog+CWcaol4XLXrfvGVGu+yPgNG+dFz/rS0DcLfu2qr94kc0ERt2/uOw0DmRfe1P0rLf82TEb8zkIMPTdAhPdQArc8Ejbr3jQso0up9UNRDiqGohxVDUKYp8eWUSlUv+lXRXP0R4eV7Zj2KaaZWVNyY7jm3n00gwrn6I8O4GDNvObec285t5zbzm3nNvOew8cQCa+Vm8Shw9p2CtYgJQ4e07BWsQU5TcmPU9DDLKm5Mep6GGWVNyY7jm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzm3nNvOYcvM5vObec285t5zbzVU6JqS4FhLrnaYlf4TzyF53qdcQOUM3K87FLQqpmzn7PXq6TvP2MGxPFElfnMMGbec285t5zG1nq70W0xenzcr5ACXW1U9+rEnKaRYS0EUHHEjpn6RpAXxLnXD1r/FF4TstOTEr/yDCufojw7sNNV4L9bfojw7gYM2817Oz0PqXJ4w/+QYVz9EeHcBxz+shzXaNeQWd+bfPZt6jPqSBW/bBm3nNvObec285+pvfW+c285t5zbzm3nNsM94uMJP6ReAL/yDCufojw6tWvmnjF1ho5DL4FVBTY+xidmbJHlWUEXWrgzbzm3nNvNkv7BlPGBWEpBosp/LxkK+WIN+6GiBFwDEcPCZu6ttRUmiQYVz9EeGxxYggR6Xir8nIPq1R33nwzbzm3nNwTbD/5BhXP0R4dwMGbec285t5zbzm3nNvObecw49iUpd2ti4sTArcPhm3nNvObec285tPNUItpuWoWy02nDbzm3nNvObec285uCqVX/kGFc/RHh3AwZe/CtpNX6dCIBmnPGc6QAq6eQI9O9tNPFsECyAw2H/yDCufojx/RgFVfVUSDCufojw7gXhto9fo5E2XTEQ7ma5xTFQQK12aVTVpdlZXHaoV5Eh1VrwQ+QYVz9EeHcDBm3pDxDSO/RHh3AwZt5zbzm3nNvObec285t5zbzm3nNvObec285t5zbzm1JgL8vbZQazJg2odUZxkf24bDSRqNhzNfr/yDCufojw7hBtrQ/HyDCufojw7gYM2m51TKuoxo2wQdcW9Bw/+QYVz9ET5qiCVKrD1WZY+jBlJZ1PMyIaJLvy+iiDiPgOIqaWxnNUwp4XW5/oMvjwJ4FJTNbt/mCRLFRehlL7/X1uPe3+DVgoqAa5zbzXsh4sF1jNOZbO4FnHmgKTsabec285tXcCzCdmxAm+G6tjx9RX//IMK5+iPDuBgr+sJlQ1KYLUaFlWSAcsPoU+Gbec285t5zGQ/ZRowcGDTrImiqrQc0l6dXMXkiTBcw2H/yDCufojyJe4QGadj/XRHh3AwZt5zbzm3nNzWp2kGFc/RHhVAA48ENLzZwbVXenmthIpx0+X0/ck9YUDf4OuKsdJXU77+kGFc7PprFRyD11lV8TPlMyNfYAGDhFpvKgRLvMK1u4nlIDCtL/bhAEby3DA26HJaI4wSGHSwFL9CnHDGuSpVOmWZGU+GbgnDCNJ5nItqgiV9TpnItDw7gYM285t5zbzm3nNvObec285t5zbzm3nNvObec279abeAQGETXKbpXRqC2yLdUiHY8rN3zkwoqzPxVcQEoW3pbsMxVWN7qCgykShAnmWxvw8xsKRML4bQZSCQNgi9jIvhVbWh/s5e+aZrfu1rhqB2s/GowWMuqKUGI7KFj/rSwPW+kZPm35S21HCg7Cz7uZL8rNuz7B77ltaxAShw9MKtnAHt45lLKGRgz9TKm5Mep6GGWVNyY7jn5eLcc285t5zDD5tSVn3DleFWtrO79f+QYVz9EeFmbSLsFxrfcOm9nA+J6M53pb8YSQf/IMK5+iPDt2QPpG0zPDBZUDOCSbU4dtVxG0eHcDBm3nNu9l5PLvaELe9foly8d9mBLnoBIDskZRYCQIT6HWRcS3PvMl+Vm8Shw9p2CtYgI6IKyvP4boBk7H/OWwvNB2SMosBIDskZRYCK9iLxzaagmnqB7jPAAeg2UuvhqxFVpgcx4GGFJjmVjFta5I4RwA18Zm0g70FcTSndaQcNKkRoYP4Bqzh6nu0P1F39P347IQRS6D9854IijkRqPACsbN47abMMWorw86Rli3loiB2HDHlNuryVv2gO3olzz/A+QElzzqzfbodIPDMHDKn6HdmjDz+VhNy3JY2M53V0uQY8GUthCgbb1ptj1Yap1hCGWKLAxqAXBDJm+r+hYAsiKhD2C66A3wWCWKHDqzkFfnTlJuikqGJLj7uwN4dQcvrsiMUCjsYA971/vaA43roEGukDz2BvTHyB4YKDAxTSmetCV5hYP52sFpvv63hjcOedxgzRXJGDASsSnV2AqAidR1GDZprzdC0jj+c+GcH7SIvmIS1DaRbQpgY0xufnYhw9p2CtYgJQ4e066nQ0Mgyrx3sByopgausIDQ+Vy8iKO1XcPCFnxzUgGBzsm0cvF+HG1wq9eHK5pnwTVHdC9Oo4sZ1i3u/pK6MNgG3QXXvVG59NHNMLJtbDgT3MMzNrdOl4A8Ze5L6EKE7sQEcJsb2hzSt2F6d4mej6ZMUiiINkCoOxuiRlHHgkehO+swNDd1K6kTM0yjjXqkr+T31pQh9o5CsxTsFF3GiCQYOqQfh/DXVMg9R4jF1H3YYNPlDBD8rz9EeA6fg6OJynfOCx0Gbec285t5zbzm4Kz+mxNvObec285t5zbzm3pCgAA/v4eJMINAJZWFfMlN3PaeaMb508cDCfoTeo2t9Cmbi9QpG6cal1ppDjndIJV2JjeIQCgXii8zkltHi4KZF6PWfEyAYZcAoG3kPkjB9DUa90+yFx/7Ozo/iNZnlZnTV2yUOcOybGdWw7KAuLMoCVF+So2hx7nINsSdsujIMQVOYxb8rGwpDqOjo3KJr7pYqqP0cY0i9w7Z9428bQzDP3uG3/AyRvCCSgwZ9PBeed96AVYCSWybPEVsnJPKmsLI2oNpgdcJJjhebrY0i6aOI/+3F5QGHoquP9pX2aCXQsFCwKsupDM9sJ9k9MTZidD+03ZtTSaF9TtIJBk68GAzWpwhYwQ0vbv1wBzAQaUXmXQrptX5AYxf9fiM3//4EkP82btUxUg2HMGpLUO6fzxyaPT+Bkd0+EVmUccgupsvhwPOdjWXCno0binJLetT4k5R+8IYJbb/cjPqadYyGD1//3fDPEJYOBP8GvFNvMa+hMvCjm+AX37CthJ47vx1g492+DqQSBIASDxQ153d1kHJuW31yE9mC+Kbg2GMx9pIMZArCqLOvLVS4at4q57IE5Okn0yHMqoIe/sKmvAbnxvQxgd7m8kErCY1kxH73IjAHgr4arNTxPv+MKtOVG4TJkauzcKlR5ZtU2RuVEe9Nhdt9vNbTu7yjOxw2g/P5wp8W5GfS0S4CAo4jld8d4TCdTBXhFCZWsYkN2JS/QNp7sUARWDiRSevh5P1L5osswHlT+tAEAxEvefQDyWT+BUDEkd3h3q84FI+rF6Hbey0KJsiMZ5tvGPd7BB3xZiGZGluqAmLrUn3TgCt81Bj7FDDVAtH700mnmtHdVTueaPTZ1OlS+5kFBnhBD6mxVJ3oeSoYmITxE1S+rLjlkKKZrkwVRqqh/+mHG2YiHVH4YeIU5OztT4VEuEqRbWr8Mqs8uwwrHkTX+IwgcxLghyGCOnrrz+FGez5XDptwtAHtRdfHMiz+3xlJ9ikkpUY4I/+xkaqiVO1b3gAT9+SMabrrovO47DP797ZxMrtqBMz/lmPBit67BdJOEQytyGtcLslkjiKrgT0xU5M3G5P0qqp3gVV1e7JVsYRDo2zyw1BcrqWc/hB+bObFsfb2XrKshC/CkTLpcwswKyvlnHY7H09ms5riGIXNug4vh8/xuzh2yzqKcaCJABuG45kY15nfKBx0ztO0SNS/J00tsIyTjDcNu3g8fH43SYBM+EGZO5xqmJlOMOLmMUKIiy81AOJLac2BgSJdMpOiRdTg23oOiRyQylJWtFWKweFr48iEbEPjTnPM6urJiifCpoVAsTNluAhA+MZDe1JzLm5bDQ2DyvWC7wUn5LPyT1KINHIg9Q2U86qMWODuBTj1ee5auNndeUTBZEJjZrFpuy/L8JZyu4pYIKpETz6yfSWOY3S87zAAAAATYFIgAFQW93gWf/nlM82zkKwMhIObzO/kshw7Fd8lRxS9jMQc3rzyUNtQmdsDKgdN1So8xaZA9+HRdbewK9FEC0wsnnQqN5GS2CrlQ2rVOAIeieY7cQFEsTPgqKTD1bPjtedNvEa7P+ygGmfibniBIgVFrVdC4umwtEM1Ml83fyPUMjfysMPD2DKgfmYk56qcS0RmGSiu8D3mRGs7pD7WPIjulQTo+I2/k8CUMMcQ/X75YE2RE/M1nDSOP0wLBYQCTqPf+nxVDuNWH4A9AfeO+4DksRzteJOmk+dv0/KIqPz/LTwQM29AkGy/P/j36iNuJRXnMBva2i091z1BPE+ifYsQGZZ8XKMjRqnsRRxoVeMPmwefMT44MnLShfWU/09qNU8J77d9UrH83OtVzA6vhZe8BYjBFZuaxUqTahbXwLLjo1TMdIxgtokV4Hez2/fDenVxhhBXnmlPdw85nyg08gZiDNuECsGS8fvW40MqJKs6Ewt5Zn5JahiKq8x91QejA9sljEvFSGwk7Fv2N+CNK1kMYl9FUOweYKBqC2CvqbHtOXIS/FGLGS/0BkcJzYzHN3CsH9RW1kpLOdxO+bCFIn4XRJi5/RAldKKHVisSGbkcZGUOSVdedRjjSd4HRiQvczMSzX/kT1MhHMZUsaxfCn6u0kgKM8EpE2cWKpwcI259lKWGokbCjsXTcm8cAuQ8iGAJCGapKusr9TShYV7nI63vnw9l22ca4OtCEcZ6VAtXhX1SRkDWIimlHAZsyxfQRhJkeR6Kossnb1uInj13/PiE+tnD1ucBhQaJHiOKQu4zNaxUes3uk5IiBmsSCQqu8+3r/ZwWx/r760vuHRBGl9l7bVlkH9goswr4E30LLeMYkcZnpkSwoBSDfsR84dcolJbOHYSymaXuv+FH2Q1iPChGytIwCvh8AV4J+4uE4t4HaE6KjulKIfb2OMVlHCvT27FCJ9wFao7uGwtNOjGMd7IwTRg4frXCwGIRfbr0rNOtd46KAGnGNWZQOWCGgRIBwyF1uFRe/U+ikYm8HclZfKGmcrzrk4j6iR5nDkz6sL6Eo/x2l+GygFIvEVXnzTKNw7O58vfBEqRdV5KEQiljw+3quP/vrDPsvioBi8gsDz6ttSinBc/maj4lb+sRIAmRxqIZmKVH+oztAQs6oS9bzDiBTHbRivb0nzGord1uUKR98X8OyZ1fmsBp4qsaqTfDT6dyEmVHz2CsMFhy+9dBMCsFzAxZseF39zWMWy7QzvDeC/yBw56NUeVxjY1OHYCCsK98oqv7mKwREYw/A8sfgvZ8up84QLY4ISwxVPBIkhC9BX5KNvAfpE4kcWJz4czIRwuZ2bJ+0fKaQ20aSS9UN9KBOLUJPCuTpbQO5keostPhYJgJlMvvQKooAChT6gBfdbsAuHtjD7+c6mx5owIyKD43+jufeKJMQAcuBTyglEPwRC095QHst5bUqUsAKe331CubJin4Plcy7eyCdGO1kfdM/mdAYbFE4Qjk+RQSOkFeeAFXNPhHDLSrn6NbNYJYsOdmPWrmtdIF1vb+hk1UbDavUm01+lDf6IvAySJZNk4JVmFgNQgviIMoiV88fH5UC8G1vSWwCVeCfGhcYO9RZBpEEAgDriboaypGot7isMKM5zzix8jkkK5/2ETcARvzz1hlC7HeqTjjkPcbts776d6sTuLn4hwH0BED83lQs0GL7HR9YmjKCyj9Jl0wRYsaDQhKcCuW+0NEDc+CHtrv0NRP0Fc6AzlinFEcECvd8YeI1AyK74b1kveSrNggPitE6Exhvx+ycZzOEO1iCQW+VS5VbuGeHlmdHdJdGY9KHjq3vfmrVe+AC9Pj84fCsxJKPLya+y9H5j0/gzhQFom2AN6wnhz7ldXurxY+P+0eBQzZ1fb77afV6ric1r/WPHaD5zULlGxjpr/HnvCq74IdYO6IOXNYg4N7qVuoskZgHCGxXLxgU55vSmnFgZdvm8aFh69rHLSikgoiWw/6xeNZwToO/29D5nl4kMw/BI9a/Q+zhLvWjNJzQwMlnwcojpDgPagPvHNC67cQFlm9ZdODhyoB3hGivnEYOF+m2ou7IZhBjDdE4gC0savBpsw1FHLi/JMW7dOu31TVh/17Fu3QswHyi9kpUJC1p2DVtIPk5GdFMt5dPMGiaWb5uhjM3q+vNuXEOgD2ermTX1Z/JPSe3jX4l0ICarDoPsoWv47TxClP6tV/wf1eNM0ZZru2q5DsKwJJiegBMdH4bxT1JkCPy3gh9als3ZaYKI6M4D0LgJK/eHDz7y4q0MbeogKxQlxxWCtc5mByS8cKm1iTXnxBvAU6yp6cdGwplShMewhI6DdxKyKY86KJ4ADA0W45CPEEWniMlb1PjtcELHmuWWWisVlYBTSK2S3feF53hfNnMTHGD+21MlOUnfXPKKnl2/KM4Srbpa2gmkh6ORTQK7cRi3d1VHXpH4SDt0xrxqEWS3EhfU9Ce52dyvpR4lSS50xvgV2XtxVAVYDjPJ/hvnKGpIcYpgTCPuZ5Mdn4RMCvnfEDiASUh5hnHv10WEYvSjW2bLEB3LgDrFHiRgnzK0grIzWOqIE9B8QxMMWIDS86S1lg67ARZ3FB182aoP14Wzbn0QQAiEAUWF3lcvNMcjgWGPrvUNJdOzuU820uDAPc7OHzMc+0txm0MI4/lGss8NMA229qmwn6xPOqJDfAcFXYww9OoHwvQstS8ElAHdD+1gFmdBXkpfMXnR1AmgDGxq5IeWnQ0AYwKOmJmH+rgG50h8P2gjya9zVMqF/ZRqSxMKzeFASi7lecrqhy5z3exagGK0z4rYx+lX4wFggwbN8A0zieduk6FqL0theAkmS7grzC7V6fRQDuU6h9aD6FB5qxi78rAirr3GAe8FBCgO1JdPwSdHsaj9oNObde1r+542s1k4okDmR88cRsdhXZ8LeIWi7ei/MaCAmKApjMHwbiD2FLLuJKc7lpIjuTMaD68KpmfIgyU1ETJLpbrZLhwptYT4TUeUs5VrNrF1ZV0xpCk+W7DIxBQ37xVm0jA4gX/oZFoh9K/tUNdG0HAcCKGowLYojM/J16VA25/gC2vIVlEun7bYnoUdHsSD60HB4Bk3yyGindsN+/2fv3bsaKk8bQRnMHY/hOoEc03NSM7qVohlcIVmIRv0JZfRRQlIfgo9ZWWYqv7ae+bnMctaV7wm+BcNAPNR09UjJral4lIJ8mJrlRWAt+3d+YPhabpIFHgPiKM1/AEPRNc/FZ8nYOpqSHbmB4vVHpVziVFptpQrS6f7nF/ZWv2EKeciY6riKb/4ooudecyrAVbKYsERtF6coECOoam515+w1LuZAFLeJXkLRxKf3yuIB6/T5+xocNJILUPZev/M8nWmXBxWKYoFIGUDGqiYzVeH403zzVMe7DjvmFoJalVKEQmwnpXnkzM5kYyXphNO2NQT/V1++ndgmeF8+xKc4uMkl7agpRkYb9E6ukZA6yDayiLpQG/iBp2RU0aKJyNg4PtbUpPC6zLNAsW5A1S00qTLaBusQDZ3dcF7Fh9tx+KePGKPoqiGYUeRIjpjXXYMfQZ/OHRxUDxKhsZYo2O8PxtAAtcsG4syicHQSXqrfuSdqVCUgv2N1V3RbxrXyO0/PHqkg7qnJRWdWCeNtyUqv1MFPKYFE6KVWTCqpbyEtWh+IkV1aZLPoWMabKSV2/MzDCPWF9YcxFeaMVwyZhBhV+yP+Ts21aUuG/nhrzuBTtKxwbnFssmaNWsqchKQI0aiNGcByLRUXPTBilCEkuVsv2siRR3acH21yjiGPH22savbW65rM4loJGtDItvUThCACpCDVZXVTwhwhcLLzOb9Cb+Zm7FD54xgYnDLnKMYTHZE15OM5Bl2VDCmpt8hcADYk72aof06qTMo8Q/PSxZT9R3/F7wiLV3zXlS5/POEaeUhXDHWy9T8ZNW0kj8LAMMyPU4fnqB3y/gU9T8Hih46t73yJ8GPZdQI3XbDgKc89N9U1YXpD9thGtsAwTBJl5XwBLG5Sd8tesmHVfo7yc1EDsYb77FclEFD82WK/lc3Tphi0wSTXrxXJWznHpmOOz71XbaF3UPwDZTikPScW1CBVhW/IUoInTsQEIPhA1tbEqxkkW8eVYQwX8Z2J6Q0fym6VzIwuSFMRv2GFahKVFo+hSRQR7FQTPEoGtxUtoSJr8CvZa7EfQGbDFPuj8GwStj28dJ5peaOgLu/KEdH8G4nxu7bLKiM3m0N0cRyD1bnE3DcSNoCDdnMVrMahd8h14W5qNqk5PQAQ3ZnEHfi4EfpMSAXEyPTwD9LrDFTn4b9yuqSunDtxdkg+N0Fasmyhui3Hj2HyWavWuINzjsMLkIvfptVr8JcxKlgaDIq1woN+xZ/9C/pxGmIB0bA9IUyEj/NiYbq3z/9yDnkSBHWdYObq1/KKPZM0VJdV3e7gLlRwMkvgWlQeRt6cs4W2cs1I0sUSWi2feRebZFUVAcRhcj+ThSY4PXZOU3qFC59RDjM/iqW6YhtJ3yYDuYGaIpRlq01StFH3PVd5nUZUKoTqpDgGduTz5G2c8O47m9YDJOBe8h+Wi5zvsRE7GkRRGoAD/ALuuQU9H8pXMV/NN+H6S+ps3a27MdgNRmot/NTkV8zdAbnMucnCM3rxejQg4CYveivk808LyADlMfZNd7WwUisQ5t4S7cjd1nY+9Xr14WHUgT/BG5rnfTVbASF5+OV6hivOT0jJhQYauy1QYaLbFGf/AwxDOCnSDGH67Aw7g0mIrQTM8ut0GF1mgdt94YNvu29XWEcmZpXyXqYXEaSM1BClsoysS9d4TPuNh/fNYMgx+ZXWQwMQ9PfFunvYljEJmzZugIymuQyTHCsrnvjyWW1fiFB0wNnbVqDppDFdG//664av0PkLbFgNvNpgbdfZxXOo7gpb2aBzcOS4xUMFB3ruij0Ih7RD1fRrIi38klpq9NfqjkTV10TLIppFbJbvvC8gbebnBwdkBzN9PIObgULQ+NtSzlkjtpEZfFaL1gjm32BOpl8chy/pCI9Tdgiyw3fYmJJQvJO7lIwIWOtzqXgUTn4pBpMHe/Kk7fbG29nJY8xjjf1DNw6PZnYIlxBmcy6XpeTGEjQBJIBHI1AFsSXLY9Ta4eAx+CJ4pcFuG+fYMhrRiWIABPyPl1Wgq4b8NUJo71IWoSEyt0eY3GnLSFmSchNZ+fLLDQbZU7l5/sMnfDuT9zyGD8oTwY6+NjHdAY9xfq240JHKKvILB/jawjmzmVzxhgkbEapJ6oP43WuHQkgkXYMdvBdHdcFmTuT3DCOzhGNEo4IkMAZJF4y6a6KC+295jPavAZgFhkV1hWI9a5EarMpQA55jFhXrbM0Rdc6/bu6zyQ81gAhvoKWHm+x9j6L0SKTSV2MmyFY6ZK1YGZiPQiIWI7mCc/gBOVHmLcD9PKyFMG1XqjcM+2vUtgusxSJ/Zo7mjYsJQoLqi0zHffsn+AXdc5BoHcOnE64BSKc1pdKsv+t1d5LYNGJIkVgtJHx/7x0xc+FHei2fZThgCd14RXsUexK2yb7PH/VBfQ+f8X+MGYYKN4C1/J6ZDyXAsC61rs8UP2F5+4rzmemKUYMvEVg8BsPP5ATRS17Jix9qm8yr0J9UIdgsULGGxM60OIdMEhdMp9uJDzllCkiOvVNWEtRM+zPEZcfzvt5ruWgdd/93leGFGEgBylVv4KRgzZfzGVNODyLy6P66ui+E3MaX4umnhRFaPbKRB0yckTEFTwgjcGEzg+67iJ7tYISMz6KDJ1ZhlakNCVsRn9aQ5UdRwphlS08JCZapcsDYt9Dc0iFkjwkfwVSCLB9XamOr87S29CRynDP+SCG9Q2c16H19rFzKX0QEQgRePcLSN1OHCyirSK2Lpt363GAxeZKAYTow8AFtTftWgLBFrVJZzLDi5/tkGDpSCJf4Tb5revKC950Xl5FhqRZMDUqngJmQkrUXcGKQQAmcgHDwLHPxENGPQyhc9NbfnCATEWFH7Tblr4VEI65hk6Fard6wcTSG6VC8k2EnCElUQBi5IzRKBxHkGCfJEBOEC2oN8T6p3ZZnghemb9B11JXuSKu51FrrCtN7LQmhgJTpjvs/rLD7F5l1Sr3Phx38JO1+f2rAXPnvJVD18T/1dZ7BA5p61Htep+HsziNdwumLhSaetiY2yCpkNOhXJ8ZaMDxlZABkOriO2KdmbuWLccZe58bTpPQo/T+Vv0O934aPIxLLx2v28FB4ipJcm7SGDP+AN459MUlr+iRkUtGwiPUUJbeL2rE1pa02KoorJ3s8ynEpxydOIaTs1Pu4P6tLp3Wu9LFC6yVZg7KrePC5182L6VHYYmMwBOU5D0axbvWlVEtvkhi2N6GDs6cH6yfTxRs8+QBmsxcKA+unK5r1eMpzjviadt0btQj6orwH2PHTNI2oLEs9IwZrio1/rrlBXqLwQnuucJg7HCqjkobRwIc1FOU26shWTKIdCU4xhT7ORfKWhLUZAypghm1jn3bZohFzksUjKMg8yGV0A7ffZgXuW7d29tCRNRgAQVyeSubq1gT1KIZHAwHuNIjDMgpzX/k10HmyWCvW49iaMZCA74tHI3oWz+rLDoMksAo566mj2MDsXK1kTkSDLdy8Gud0ergGVpo49B9uEycyzETrNqDXUNBjoextsqKgQZpkzuBiAaQvwGKtiR9YCpR7KthOS3F6ZbgmnGKVwlDo7nZeBHd9XuNVwt0exBBQP305jO3wQpTzFB37JyTPGYQWIFMDsPvhJMDNp+kyaWJQmQyxD4si6RVE7v91CHwKRKrVFT0z6z+YbpqAzmFda1L/ntIlwJGdHU8iJ5wQt7HeqL2peZklVHiZ344cEbQ7ogbqKvs6IYcyX2YnwJrGbYU2TyQW0O2EgvgQDmCCI8tv4kU6vCDU/yBT73MuOlhS5xVIszD2fCehQxpZI0Jsmy9oYnRgGTOh7fYxVDhzLeUgN+uiaf6Zl8jAKfasCbu9aiR8m0n6GfjB/EcgF0G4L9fJA1thD4u6MmdzkxQS91bW4zSCHqgyKVlGbs6zrCeMe6AiwNZrlxYrgQgiNQtsgiDp+sy1l+lyzPDur3vHb5bGP5FTc3S0qznkBkoZDfDFke5WlkgVHAji8FHbOhnTegwNJe+o5dokoqPbXTL9sNJGkQ8cmMA1s6jTybfGyQsklwNOt+KfsEcOam0JSSR1cycJ6TLdmXTbiI+K8hauzsT0hbBvj9OfPRo/YtafFWZIJWjejeDd1ggHM3FLkO3PRxPn4JJkWHiNx5kg4dMWbOID8y/pwaxuOIzUGakYqT0qjvtsi3QpkRn0Ub0qY0e/c7h7JML1D+S+2ssL7s4hKUcgpzcthuwXub33yI/WmyhHO+UHhP5/KsfegrKMh7X0d/+R0x7Mw+uARDMC7XaJNjwJjzX2YD4yEcKUJ+Ks9X8O9d2WUBxAzdeUW9+wfaz16iHZrzeiNn1gZ4KxG4dtYimn34ZNNuwfhiJob/D4Cv14y7UcJ3qGM1YTW5RJpT8L0F6cOkvH7RRzWmY1Pwc8BOtWHYbu4cg9ACacO/S3wQ5/3qmLLFOZOaU0gUZ5S65j4TuEwM5ngVg9JuvRZZXCpesVA59XbNKA4qSL4mEzMvQi0d1fNCO2LLHT12FqbLTlWH4rNhhJ5OKQSgPkTmpansbGKOlSpS/eGWMkRmx+kNT1S/d0Kd1cIK12oHBqAj6Rpmrt3BRkeeNtBDTe2Cn3+p4XQf1+a6duIR1PuqkNADgsNMCp4VfzVw8xEw5/D/l0qGTqdee1QSU8vrAavcDkCPQmvngefhU9HqrT0tYUjg+BfX3Z3ZV1CqF8hboHltg/e2qba9Nev4rqZDET/yvnQ0EzeUGZy2cEJrLYHYwzSjEGkgCC3cN9cPMHpB3yfBsWIepIG08aFU/WiAvqtzmGInBttDiKVYDP2Gtt/pY7sZPUHtHeqwDcZdKIujIsmZJZXonzQgE+6u7vIJRz9XtwK7mUgQNC+X9Jaoh2KpyWgsPy4nxxxF0wXIcP3/wQFnAMuKJMO38gqUTphTP5HGmsTH7zqtgttjKHJCd2lNsxyNLiBZeXmOF2bVQYRWQF2ZMrGoG9vYIOtHef3ZiMAId/JLZXmi/C2ScFpg0akLET6koDkn4CqC29D9NVE2GmNp4VmrCZ9TpvvHciOUIMeNmI+06RKjMu6r4HXeUuycKk2ixskkfFyr36vqj4yHAHZGfojvQz2ITFK6L495LgsoxlMEDuinon0mQbZDLyTTSvUWko9nfarsnEUGEY8ugHzXOYsloChRCrtnHTgyXwP7Io30WQFMYvMpAfNLe1+tAsbChW38VsjdY+NVMY2Y5wdjMTfx8Tk02AIw+SYqqGYQzyqRP6/8Hj8IoZL6SSWFQgtfS7KZuv3z+cSu228nLnd3S1EgKWnZAKOJuz+QxXysdeLJnX6sAog7PeoQT7ldRuEyo0qNqZzTGmdylQZvj7T7cVJYRMdkEJz2BSYYAoVt4uj825PI4HwPg/V5xasZnT3smzuZjT0zhZz0sbgqPXV3cY5u9bZ2Xt4q7sxfkQtLY59ACIanm7pHByTB1HHmcGFvY6V+kLNoKIKWZJKHJyAqAvADCmpt8hh7E/M1qoGCEIho2j828psqrjkB16+IJP9a9LzOQGBDzEaRma6Ep95HyT0FiVwa6AKXXo3ER12WiCCDDZjDS4CWqfatSn+1NW2JN3gJz29rO7CANLOh0zAHAyiiQZCkEanO/w26u78Id4C3Un5QoqkauikUKVnmTtlR2GPeBPV1615NCLoN5tcGb2wehZGQ/fRLwToud5+4Enx0gU+2P9ghTkgPOfYs7ZsQtQ3BdpiDeoLQEbO1tjW0PJZOlPIAM2H326FtAkK5goQN+1TbYuukIuSkj+Y2HZBLdSfoHehkSpzGIogKMTjau607NH8gR9VmeJZ2JRF/+lWHbbVEFxkPcYGgEc2kFOsNCqnTed23wrHHVeI5SIsILcGzTb/CtYbvMKq4NYlJSCjlnpT0wV74GxV8YHn1wQ+PxPQxer9UoutyI5w6Kz/+iTMyZJb0Dha8xrn1aTpL/LD1WhOn9uDpRtcWMEcNYee5rDNkYOHrU+lLL4iePFy98L8I8T+EQ2m9mQMQ9DH7cnmR+PM2byFcJKzsmXJtGry0yyCIgffbkSnt0SEVI1Xlbfws3w3a726HSDVbF3Y5I6eLgVKtfdinPg+i9bxIPgh5+8KE1OhAoGIYwQe9kmonx/z+llSOnsYIOZEcGHmioTHQ9BWsialRQ2yy0JQRUalkFCYLN1Blr3cpJ4yr5Zn9TMSVT7YosFoCvvltMwdFXY1OkufeDpMaJwoOIkQEA3GgA4Eu4bLHlOd+RZpCZrtBf+S1xMpuU2vMAgk5mIG9DHTNk+QvHMA99KissOpd6OjT7xzARHhUendwfyDmXokxrwEh9XTUvX9NnKjFr8MSFDzX0wjsWKIVhAGhadUbUSCjElLWsKRp78fzTqZTRYm5rvSLX2/RFixt1+fAYSQtH9tqLRLdqz8j9F9XTDnonCCoPrcYJuw++z5KoTm8UEqZ8Wm5sGDwpdM342eCBJrkntssLnR5r57iSPK73I8vMYHdU/sifut0J7p9faxcylvuIvUlb7Yz9SOFJQ7qUoJLKKemRWd0UJr932WxIpZ8ou2mBqZqGka7iRw0oJbe8NAZfirBJH24xGpEcVbcbC+4pKNoQQ5PkY2J0WAUc9dTR7rRM2LtUk5M39q9Sz+AggwvOh78HF2dv6dbgocJi4ee4fb3fFILVjvao43v3fBMb27FHVr6awC/rbPq/JttexBU61hbedMZbzs5aQUGt61rO7dFKjp0QMLn1hSsucVt/bgeqpJFDiAiksZzI6tnEUOpxvYZvRQdYIHEX6qBQkYsQz5isqlSl09I/YJ/3Z/WWHcKG0BTxBfSv7slwPo6MaxrOxO0x5dcvhAsGg+NDZf5p/a7RUa/oFlAYWH7zvXCItYpJNPh5IS7JH7z78gybO/KzoZ0f89sJcDyessi75pNM05bpmy7+eKHxgMHcb9/fr13M6/dJ9VST94uFyUqezMaa0GnNNNuBGUhJdA6HuQy8Lf9QvIOP/LFCyM8VJl/iLpxn9FGhM6obrNm1csKHjvKfNUJTi/KB6GgavMTDqlDMfPAgmZuVOf8hTVPjUA9l1ES77RVtRqQtOSWVrymONPJpmtpE4ZDvc459VXseybp5W35tE2dYr5o41Eg2g81TFu3TtyBk6Fg/6fSf7m4gjNNfZgPjJmjAI2b+9k+vEH8baZ5tpA5gHecR8jpf72yg3+6OYXFqWyXipbORtTIlkH+E4M4GeXu9B9LXePa9aSpVOzUVpt7mJA2AVkYgSmPvqoShTH9Vqbd4Q+ilX3kzAeUN93QDeO7r0kOynpk6/sQRQ7TMmLqnewkLuoAJ7nmutzbts4rMvnw/1tlmh2c8wvNHH/XfjWZ1l57Tt+oAujBW+Yx1WtLpDvDuCZKBvfSINapb5liZ1S1pkQQJzL6uwXs9M2y//tevM7MBEpaCXVYXMPPyUrZO7qN7az4GPKJtL70kAGWP1PZ0TetBjJpPQp908no8L9R+icP/zvmUjgaUZpeWNEj4VTTAnGyp0RMQ309d1CsZq0p4zKLK2Lp9LhDnN00uqyH26P/Y2LgyDDtwEZQedbVTd1H00T547rDCQEyDGR6lx17WHCiS7FjR1RJltLFZ8AMqjRAN9P9dw060uuInDcv7+K/qyRVOaiUJJmusHRCPXlNGZTeoTIY1qCK+EsIFcgoomENQ4reNS+twWXL4t6aIrxj+w+oPIJNFznUhPdySw85fDRFvnEuD2YP5W99KfM5SkZTHqbAYZKBbAvPOFKVgGCwjHQYyaT0KfcE+jF99tFF+ynW4eEbr8EF52k5MX9hUkNZhA2U0kJ/F43q/NL+UxoQnfZxc7Ih4BVcKQM+zdERkFntcmUVT96OUMcfgGybOZQNs5kp6usfcR2dGG+7td5EfILktcKLh2BqlADhJv1BZsJTjXB8EI3CzUgIh0lpBSeCPkpbkgBVfjMclo77TvrTSrIuDQXowwRM0waB4qTe0OVde0xyXyh7ATTfgoWpPAqfZErPDDN4VHFvH+32TF9b5L1DswDTwRz780lsWIqVWkaO8d8mmQfXB628AyF+55gZ5b3vAOzIa3DDxEepjM6+EPj8OOv1hACwJEMthKd6VBzp7m4yPYFCw4kGgvb1FI2HUxQA+gbwkwOWPdb6BoknZ3SPM//HEUH802G7eYguMDNj09wi01DtNQYxA9cBQ38Vu6KNuhnvawb9incj8L55g9OGoFFHcf38hstxctPCtx7P6+J70N4bzk/XeSFBXrtZHXy1c9u9TpAyKwxBG0lWnwAACYrav95gmEcdWvzzoGZpViJcHetdpwvk4tHBoyNLpMIQt4CDbndexbobcOc/fAE6oIzY4LAFE4woiqAncN0eboxGBPUfcUY1ALoK/vh5sWxPRZCof05+dNtQwWol/Gh62m03pIKvQ4Nxcq0ZW7S7cCF3yGQT257tDBeKhcxAZerPpG2u0qIdYMV2F2QH9/YqU7n+tr9+oe0cEM5sFjY0Z1WOqjmrbwPz5HB6AoJ6NA4cjGQ2sogx1rNNJWbfGj/s+0o+JmNNdb0qaxRjOy8j2WYPGEkevv8T2zTUTOTzs1kH/xVHk2KKw0mIrmuB+yL1YXSiBq9hM3+nFYvJJpXmYDQDa/Ba3Rol0tA1QpjDsQUOnAHczVEWSxleZHMkKctiTZeUgtaACzcg6dg6dBogTbf6fkE9QCbA1c4zeMNd/LopG1aHmoR5GviiKMe9pQ+4QfMuaK4WPZARwNVFtjUUJytHnk3BWGSon6kkkargXdv2QnFyw4VlbFTBmiI5pXIrWoMyLyeI9iqx8lFK/G1lZfA0nxieGSv1SKIl86vwc4tM3CYxPv5TXp4ueLeDvgxpItVrnWqz+hMwJwiHHEJwI2c5jQx2HTiYvB5Ojr+GuNmwhaC/4D0s+Cgz9vIO6Z6Y1cE7+Zt9bLmBGo+KrUk6q60kZdeHJjtWnzARv7X7xFJ7k4+FHu9JBH+qgw1b7sTSRLt3LssDxhq9Pb5CZFku8nFjTQxRtSVBG9MwTgMrL5XUhy5o13lluKN/LW/3nuBsODdEOG0rnkllBT3kyt3Say4Zx6YlGpo6BecKGvhJ3dColRBrh0XXF/uwFJdab42HP5/Zsx9v9MkTBD6mN7r2EADFA9plngw1AlgtA/t665y62lSISKdImtH+zsc6ua61iLeFmNUbz6TZmSfK4Cgjle4WQ8Ek0a9GHFpmHlYgc7d0XZMpmFpDk+aIQNcciFw5bdiqPJ/GR2bBak3AR2tGXO2BTR7nFMrET8Hf0htxW0iH6nGEQbnA6NiMZb9Imzi/IyGlmWkbJKhgVww4JTZjpXGjTjrA1q/iOKPWpSQWaTdaH+hMI8/McLZho3R1kFP/9WBrMNzwyLaX4BrPa5p/E0kKTKpIFQLUe51hovv/XB6htu80wqmyDFLBUzGVOq2Bkjv5K6efSj8BAi+QVvdMs7PGgnSmzt8+Frw1GtjmFf6pJ9EimLr/cILZVl3pqcfxDD2syPagIGzrFO6Ho0mxGsIxmhXa6Vb1KUCdkEUvZTtccqtKNBFhv/ZXap+LJ0jEuGKkMwdSvWdUb1gp0yA3xwypk46S4yqKKu2yOJfg5PU8cONTkPqql+RuTGUdNsGGJj10mYSKeUG2a4ePwiWdcW8Ll//skc16/l4vD44COKRCP9qItYQ/oDBPojGo8xEwwycYTLmkH+27GZUU45fK/NPLhYfCy7Os6QsPwwS1AvOeZMV8jA0X5XDfeCmYGPgN0GDBhWIh7bn8cI4B4DtRdpiwKlKj5RdQDogDOgAAAAAAAPbpCiTAZgPpBvGiSpKpQKSDWQtCL+DZp0cc79Tx830ObIGQFwtM3uvklF5TIi3M0kcVu7FE58Qu9N5u9gImtdUBjoXIHhIEZva01tCBrVYCeulzoGvsKZfn7D0yv0KCJ5LXgSe0peThCEehiVYN2UL0R7Xeu7zYyhRMW99Ds5WwBhciaJY22Z17qZHLdXk2evCGq72h0+w6isoAR48kPuk3k6RHK5n1WUktIsuqCimwl5uQD94osrcIGmc2loJd8Jy9biC+QmQx1KRdKNm1bhhekQKzKy6oKKbrGXcT7crOOElY9wfyb9BOyhip/M8fdkickXLV/X4KMQWBVn2082Zc4ED4Qm7+vhEse1u5Jyscti7joB0vjSSQU65spUUKHUGULU4KgchcTDGrf/cYyCrwk5B18iF25nQD6AfM1r0hFCUPcOK6RgaSHDCa/4aXwi+elZItFdzRFW6T0v7P/iVDJgOg88fJ1KEHXj8y/HqfitATh3I1jGmLUNeYsvmmuW/hjIDTDOA4SGfhGyDW1NNXtgf4UEoVZq96xucPfVWdVzeM3KimHN+eG+rALDBQxGqLjtTavuwzSSe6W1tkvhFIjDvxtDusn8WyhVz5gGbP5StMHhVzfAkGeGKG8euWY64S6Hk7/7wxk+404+VGwjqwj5smR3xurLIbX20CDcAYGiFvEtZs/j0S7YFkibhG4/00Wb/dAvlr0B1IAkvUR6wCczNGNBobvrXrHG0O6xialKQcQBdFPP/3jAKnI4FUErSnPwnZMiTrJDIi5Ci5m1w82SmNGJ8y5T2nbFM42h3Tos98e4zUCFboAAABNFDpLD3BgidkSfLJOQI9lGAUDiwVgoN3659czKuENlIKFtZ+t/oLaSrVZUZa7xs3dRSR2av1ABU+GxkwtZBxbPTkV7kAkDtBLl5vSnjEW9u/+QvuEc1SVVA7gPGasekrzNU6uNgKISc+5iW6MnJpT7pZotHfnRoIyms+N5xrYY1vzjcUXu8+w1+myIbQusula29AbdKW7yyK/lag+OVhJ8bSHpD+JxW1vba1rMgyQnxdh2FqhukjGHKsC59zCNPryN1FvyvT0omjO+1xnadiuLSu7euySGaJhAWaH3VQUw+reI21w0CTc55di0Qj+Eq1C68PJHldrbqJmD3YIg/6duGyJR+OfC4gVWoEYouhgIMZr3+bqQk+0BTl1dzsr+UcElAcs4EIGDJbomLOvDjWloaHZizbW27ORClfbFp1uFzUvkyTP7VYFNAPLlATZYLSUfeSps8xfE7gMyBtvWXwEsZ5fCTo0KKiqmlaefMKYn5DdWtRfOXHwPcjEyVltsGXH2262+AAMID3xV59qqcyeIw+4Ps5+tUlPd/huLMVvNCr+Cgn+Jr0sCc7a90t8W+o6z7ms9ap1OHZ0VwI7INO6jy8Iqroc7Z3KZk8e2G4jdppU2Rw0Z4dapzskT5tK6H0AiWA21UcwoIzbMZcwRNasOzwP2eeDLvIjTT9oAts0K1Q4bPkakXL9B2ZPa8vwnng7D+4QiMKxdDkruzrEWh/hvFBV49r0l+37JH1pMjQd2wOx83vsK2OWgR/kvjCjSJyhYm67rSvy81kEw3UpXgIuuWC/paaNIDUGVXfBD/k9SAGSz2gn3ELPnCel3QzQjRqWZZjmr+QHutVZ/o90Fu3Wfowuxpzvo3ut51JfpsldUmqRsSriAOYAR6WsLPoXtBdqo3q5oD7lE327ewHhB9/CPHMyORVPcA5V4pLaAFZkb0/ZXfRVwrNAD0csycJ7LZGREk1GUI0A7AYrPaQ+JEu61bNPMspRPVe4RrWpadrqW0XrBWu52HDNUxD1T/P2aUY+PyHFO5TV1Fm0iWUoiOwW4hYS8ri+/JBb33TjyJh3nQs2hrqlJXYXx3PjX71QlhmrccFIgBh0Ba9M1U3H22mje9xv2p4nfKWwZbmSpVW6yBwyOq1Jzz491EfjMRmn6P8957H/0V5WTK4PyuJpUojgDUYncT8+O0+plF0FgstnDLKFp0SEPrDQNbXUy0t/OB/jHO2Z7oG0XRa6JcDsm+QnOmzxGs34MDhcpB2TA9tDNlUPnM8RD8OYTGfgdJSO/OE+T9ih1UVE7F1nHI0lxrBYOw4WWy6UpSC+HoDaavzGOIvQlosejDyO+l3ck67wcgZ2xreeWBvV+Q1r4bi5ywJ5tfdovyoHELiNpKaeR7OjVI9uzED0kZN2YTRHBJ650TyFYQ2i4ftUN/lVgODpeWmZyS0gMbqoItK05H3dSrXTcFtweEVh90IV+MHTU7Llo/E5ZKGygo/cd6P/XqgkXYmSE5a6mGrOO1MRAP5y9Qt4TI+MUyrEHk1PHpf1ikwmOqpOM028hlm3JvQnE5Z3MBX5jOxLhLMgr2irIGWEFwOeKaBUKjey3pYEq7tALQ2hnFJ0saQJNc7DaGrry/cVOQT8yDzgCpuMSJLey399gMisLgcob9e/qaJLNymxDEauarF+jY8NGTJZEKktzOzem7HIG+I0b3nhuQiTcBvCIiXsnN59P5BXrV8lFLCF3PVdwhUNpLoKFI03GO7N1iv86BK5AlUfgvj5u7lRvvKEAF3ARhpRhNYpLzmL3dl0NIFOcxyyChD2os5zK+DwdhvpvKoltq+Gs7KnNZijDR/P43OfHaSf654M8FwdstLXfifA2Exp49hNbVyKOoVbGV917R8P9T1W89o5En9hgcQPv18gQ+UMjXW4ar37RBsUGiMFv1wwE79v/zOmF57vEyfkO4CyQ6Y5oqSn2zu9MzeJ1sNYmvRIYAB5t6tDA5LPd7yCuqwThiExcR8F8LLka+UxiK82CSuh3w8INp/bp6bSAPGorHp4G3SgLb9GWeMO5njR17h7FuXXh4Fc81PUgiuSvTWmOyDJlkw5IpsMECUiNDvTHK6gv4qsivNJMu3+bkQbdxGSfLNM1pSj11MiNhbGrJBAKG0ZKiKZFV1/yF9eG40gaTV4E1wjhD/pEiO7RfqouGd5OQNqLUBtkdXq8yfclSDism+f98Zz5T4UY4MkXmjEd27CYPBjR1sW/8Nc3JQFPjAI7pTnZmBII4fprHO4MUk878sU1ODNw44fe6KfO7M9f2qT+Ain5ktwq55RHEk3TdoOd0qnrs7GTt4a+LicP2UFg6F0VL1rAJAdqz3M0Z/ZeppOxfAZi7Kl5CYkQ6LFiLM5C+E+bdKQJOVDeyIjsspM/fRcNByRf07Sfxo944i+/ZzDV2iz/k3eQIUvtn6nVujExAWHMGx9PJNeyiuV/ycdJrsDUToYsDCHUUKLYG4xD4Q1kptyqoyi+Oye1ee1khe31968S+TneFY3k05AjU5I2rm7BdzCxCGYmuzlTgJnv0TfTEFZeAjvEfnGGZySQGA7DvJWrY8DifNinvG/5w9J8PhFBUs7aL9qaGECYMmuX77Mt+C2YRiHyVuvyT2gxCr31Agtkx8mNi1YUqMYiTcCnPkTJdwVd5Ns1G42qyRMUfFI50YTfuhJDEFsTMJnNJub5GBjAM75anHd927d9jjyOe45Cqd/3InSVhwHdKCuaIwULpAkJHN3sV2d/8qIN+mt1hdyykTa6VWQfbUM66A12jr8/sZStSaW6HJIz1+GRsMS1STtOqtzRVm062voGSLsysykSft1/ciEcBVI1na1R/squzJ3AmNW99MrJ9ek2XGJrl97KnpCq76RzyOaJQ4HLc/CB/M42nRtsAle5BNPxQg0/c7Fo5NTvtgxIarnuym9jekA7keKjVosdCsclSJQFWTyztTElN3/Yy5nvDNmPRDYiN32pHTzmT+TZx0TRNnWSVw8NynOz3+IbL65aPdZxh1VWHsSKXbva+LkmT8l3rLCklNdWyyVJ7Pscw0VGWjPBbbQtKY0XoH4vTX1+Q+f21OHgJ9Mk/eVKXD9o9KJ9Q/oatf6OEmbFhdH0mFn0IX2BaldeltgC9KNBUI3rJACGWF/0AbABwvLYKH7ajOwygEApl8s0d7eQPsGeN3M1V8X6bMRKkNvUfjjZ7DJjf9L3NiynXAlJPLXcwavAKHoDHDmfNMOhwVxAtwBNkxDpzS7bzFi+DLjDWTBd4BEtP+FMeTQHT2P4feTUoMyhtXls/bFDTqfYTw3MZsl3gZXLKLOzZZ5Vk9lxd6w8CUAJupTfUO/yduseK51KOSlUb5f7BlFfvHmloiq5GI/SIohSScgpLOuvRma3S3yCNC8zEOZ2AH0ztU3uoOpqxTECkK5XrTgEz0yc96FFj4oLBOwsfZwOUjelVERjb8G4il/pKoG+mt1myg/zy+tZdrK+fMKElLePBmIllT1iqGrw8vOrJHsp/vZpMchsa2Y9EyBhXSgRyp38Hj03fCvQFmKpPkjSvKCs19Wfs1z+WkU8AFxA2Dy7UjOptwVETmJaI5dRkSUqlMPGCaBzzvpc6Gw7DdNE2XjGxRfcispCsWnhQ+vlp3J+nWh/xMnTyvZjXiL4kuwtK0WLCHj+Tubx6fNetSFW9RxJGFEH2UjxnP00OD7ABGXv+z+wvK8a/8jj7Vaj5MsQtlfnniQHf/hDqjtez9lYfIc2qtZciVYDUM+PNDzloNLM0Pd9qqYWPv8VVRcYjNg8vobAxZiHuTpGxdDss81EZBFF1VqhFnKM3fVCi9kh6xaiJVyOz4NryfJV25WUNSISw6xrAB7mP6WNqFs7JYOMCu+ulbJVhJ5XxZQPw2bSYwL2NZ6mD0tF5WRt7df1RA/YyKRtjzeKXaWJ4S+FNTu+msrTbW2vC3nullHJB/KL5qTXRl0TTUX7dy9ZnTp45j02K3nmkHZqAX8P8SMlUNcrpBGDeeRnsUI5QiKc65tOjZAUL5BbmdtP4AewlWk4ozIX6sLWN70uxaHPV2T0FK4lc+sRBovBbwxcz1J4VmDeXy62N5uNTqIcY8DWcoKDRHU8zQOXl46jUGgMPcl4Tn7yCq4Ddbx2YmR0Vo1yOyNFRQ2O3XLerDhyBhqha9N4hzRrwontW+pz94t59ZAsZij8jCtESNmxU6HOzMhZKQ4nFCN7yFiUbV8q0NJ2dwhmsiHFAAcdtVPySOb5uiqjNCosbAlF77shr8N0k0lYXee/+Zp4cTgC+LiDf4EFLosXbj5O7L1awPaT9yzvMVtv722BOoz3xvUtaEfAohp3bDSE0Cdv4o0l6evaXbe+SDYIjwNbSRxLKZrEwqBeh4MBvx6ahQPiy5P4u+3O/1jRpFT/OIF3VTgQj2lHYvIcOwWt/7QglfzTm0gQpcxmn4D7rgeKUPyL713o66I0pTDwT+iKasd9frWL4BHf2ZBiTQcy2xMqGcAoRejvwndI1z8SgqTT42OdRUMCPW7boBgDK+1tLDtOjE20GJrX1y5uhWBl0UV/NeW5VxTUGV22EiMhF1yJ9iOO7lpz7l/jOzpcdew/5hsKoQfzYkYmEoubDl9p0R36LLElcp8VSBQRgupn+DS5smBfiBa6MUcO3ekegF3KEwQqGW3ymO+Ut0cenmHG6N/wmHP8QxUBFarqN/lsH/fozhBSP+8FT8YtbRV+hZm+AyTECRcQYhRC7YlCFkTCUjZ2GhtTZIhoo7QrELNiOWC6GhQKXx2AQoJoc+NA0FdxRp2OhCSDE6Q3PLs/It3yiMrpAKiqM10vk9budQ4XIRofpgS6/fv3/TJ/q39j81r8UMLdJBfB/mwwhDvIduuVcgP5x8Au7MC4f4j8R+IVO7Ax/WAKn58tLvkYuw/yBuc/mgQPqAHEyM+ZA1grjZ9oWlCgElA6wl3VNgMJ5Iecdlq5OUIhF82sgTHjsGPpBG5tqDQibZ7jh49YAX9Qgo+iFT//KK4OlhH9ZJ8KxgYBdOkdvcg4hwE6U/S7TVjkS7d4cj/YiVd0steuOrbgDqcbcl05LnWb1KQhbOZ73i+26xE2x8MZLh8u/DDfDsgmtf7oEAIKpMjNBUg4fWaJ31DuqtH7AOAYOm4ePH67z+I3Q9Ow05gcLMpDkGY+ufRO2JqBrRfnggsDxO9E3Zfj3r0iwaEynHQbD+9PERCQ2D1Jfxl6Zx6q6im26T6TRpE/dfJaSbJlA9l88NJ0oO/PjuAm4cq8Gq5TWLf+lsfNgJahpQfi5YO/j9lI66Mx2y+wxOjSemgOvJsRHG+DzKw8kWjZLhjJsQ4IPE0mlt1A994zcat4nXUa/6AuHHrx5oj7O3ngT3nqWGMEbckU2RtJ0mCMCBi1O+y4SPFOZF6xQs8T47H+itMb3prlVDbNZVIkzB29aBfk/3ZcT43uaYwWTPrzSkKPmfLRNsfDGRPZC+QQa6DviNlfnocVmRZdf3Qfa302yPjyFyJJ+qV/g8BjfgNRMs5q0hq8xZM5JCx/HkSt6S/e1arwidfL0dQ1Z55ImMK5zGhHILrpaXQqpYd2gUtfuWeuogFddVu385L8nOwX1qJzm1oRVt8C1j94Duot948Q9erxAcKwBxT3wBD+QfVu8Amhnfr071z7TLQNLAguj6zZ9RzXDJbpWIBgPR201f1KqVzQDCTkCabUmZHeu9sa7l22EHsZFjOtBlaiQLOY1b2M5o57a0Mak6YTaJGxeaAsbjXIE8M6SRbbH4j8Qr7Gy7xm5o5Ueh9/DyUGQEeXmtZEUjH8Jw7JCOrW3uqGuHSxgXE2iKTizsKNhmywTulRf+2vjSW7uT83GqdEum8m/Ls3mlPcmRGsYc0OUoMKN7jCt+8jvBAuVDrP9GybaUd9MA2LufAUR9FDirg9GtcDvIqaN4FkoY0k3ZBihrtLNuL89ryV+FsOB64hte0ak/X8goeOAKQ7lK3j9TNFobp4CxxtNsQ3O6/damWuZjyFSZv2SHaLHLbsVlooyMfMRvDz4uMOiEJ2tCg5Etl3WbUtgnS/dLmyEoU2+mm+ut9hT6Zk8Ef972e74MQffe3/mnUjNvz+stiVTLG6EOPMdtkMwCemtkJG0gN4kPwMCqK8hUyloXRwfQ/Y+34XTUuehTNp61njpoVLRgo5MgvLNKdNK8qDcIWxZ1tMdKMK8ZuzfeORTvGYsRIoCiWa47Pp8R8UEKv+5k41+GuHLVzXPcbt/dCIvBB50DglJLVxuaxzgdJ3sjb02mDQjc+JlrbslXhIGCoj7F4unSIOZ4b1PRIJFUJYT5+KP0MPEKweODJlEIuaWTSatFON1gGeyexQxzIjhomn+l2mBOUQxLkbgFajF8zywV49y63vwOPazthPmjYJ9/E/ZkcSGl3v9eP/9Gw/kp6hzUSkOtBXTahsy06ZV8FT/CaWoxzGQT0WgeLma5wIDMifDBXHlLzed2Yh3PXciRWb8+QKj5wafFgNDG+C0XdNNLD328OJLo8OQ0mLNbzexse84QJYuoUxvzLElyXyKVCe+W77+kNW2Cj3aR7jmTShEa1YHmfHe0XdzZRwPxuAWl7lEBsCgyaAUAR/C8p5F9MyGa+N09Xx8d6dNXaIEb31gDhUKU7Wq123atCt5jDgamsSGOZRYA9Ir97Ryzilx1nsTQfjot+/NGgjC6KIdut2+MXh00O4aPseYNkglhLZFIL5mXgfOsTPKzdnzvA3GEOuW/+ngtM7BCBocOwZhhTDuIl3oFHWjm3pY+ZqjKGX58hUmzMilqAXE5sogiHdNsLfdlesJEpeU4Mseu/Uj6CpgbTGCk05Iuo0Q1DYX1B7U03Aj4IdH/IjjTIVXDcBRXCmMeldlPLHlZY3CZI6hQkGWLE8Ei6/FP8zNc8vUlY2LLiDAgXxvOxTqPB9mX5qYncDmNuuSo0SUroZRTNKZowjhYb4nRxHTo9jJ6UKbK8aNL04rV2gjBFee5MjNmYjiehA7RhDVVOAuiaxCkyFsA377QV5xorY9EILbbpwTGG99kBc/LoKree53CJtZrDa0nCp/lsfS0b97K4Yjgp7USkzdOzrNNqAodkbE2/aJpc8IcDIE1LKqUhAW2B5Fm9c8b09p2awx7OhUcjANNtUxXvDB0MH8YnnO4SQHKhOIBrJg2Po5nAwvQp4gWGMOydYOOJuFUx4EEnmGHN9yXybYlg2415cT43uM08vy5XvDyFfcfzsmlBiF1zgKVznd3OxpJ2H8qySxdevRf6Vq+6VA1x5KDQTc4ektvxFbmcs2ttNVX1HkkDY2nolLzirCZiC2PoAiOOdqoKx4IBcpUoTeDWq571ic8IjDa4w0G16d1BpwBQDN6rxwvNx/g8/a65ccic63Ic9b1LqKFZCgojky2QSk3g7ZfwbvKMoQb+4F4NI5yUz7lyIzQD00SmzZa8NHNOVqbCxIvzfsmI5RbEUOnlqxlxv4fSGUG5BzGKQo1GTnB+E68dkLGM3oijTwMjTdk/IuTr13vm1vujTD9bL37lG556c8yJbrv25cVNqkLN+wJY6ttRIJexiUsEi81z06qZVDvjIa0cH85G1XyI2Oh92EhlujSdGvwBUypjoVekY/nZ5MRZ0i2gDDe3agWxb2ZNUuJmT9x9XEV7DmXnYiYc3xS8YXfpmFe7MSy2WOp4JGm3H09AkExsv3W10pR2Dp+lDrUN0ZlwLoLXo58a3+EOGBGXXrfVCb055x3j7qcEnDjf+hBtQBDb4Ur4q3pZKA59xw0Sr0t+0nzA1vyoEFzADjMwNw9DUNGwRIM0I2ONsyXpvgzTZwovMfSGdZDGmNTRz1gmgoAbHYnLXdxwNmRF/h3r5QvTN0IVsbd5SwJAzQUxXxgBnATX7nGg55o1sRRz1PXZcQ/PbGs8e+M1iy9NRW6uV3g4QMDF/QCs+w247IdC7Ojioh6dm3YSL7HiAi013HtncAxW/a8jhTZ6dswJMiVhML/6ap+pzz5ocHR6LZWLh+55Ld5a8pkLBtzPXE7z87KXsYN2mOao0erah2qmNfcmS6KGBR1GBGucdU0f5Ce8nG8rtSKAKCO2vxBJ0Qu/Ky3tJ28z6LHO56oEaBt2go02Fb4DvgbMEmq52FDvlRFn2zHiXRBn1Q5YGhh1fRhDI5CX6YUUfJwbycyxC64X4w0p2J0GRJqfcPx33HYDcJB2gidUvvodiOjl9iQWJNtfyRjSTHnSXxO55X8yQlRdQ09oIxRAJklEf2gT+ygm+jD556/OL+CGS0+62af1sLqrylgGnuME/7p9HeCoqeVoXDEcXEND9//2n9htc/weTK2GBACWtTUSYrvMns0odG98eaSSwiCviMBkDeVqeCmpqo8x4K+DkWYL+xnhLvU7V7sQVYg2JompknHmYxIswjbyFGoRmA6XpjYmdKCe1lK/aQDjcrYwmdNaqq4mpNxTw+ehQrfhvBgeMHrktfkJTAhs+XjIYN/g45dJZgXZzRacvxGDHNZz1IrHj3NgauOHVYcACYU148ubkvwJ6z3pPKkcRoUqYmX4lD86+NgbKn629hUNV44QU9/cTEsmsbbcZpDlxnUNl9xZckT0H7Qs3Msk2bxAWedH0bcj76Ud1IOrIqwT4SkfRhHBpHG6swsNLVLjc1r10UlFe4FZFhqYh3Wy5Z6iv4ELGs/dcCOVgjgxvU+clQ+b6zcz4aforFFEI/8MmgcTjOlUvTtwKr0tCZPij6GzNlC0h/rQYgoKdR8oAM2t0SHdxvH5W6Z5yszzLrP8bQSSsE4ynyWpFqdeThHGLxG0VqwZXcl0Sc7m3Fe+XbyNTgfQDnPz5Vzlt10dKl9JcvIdvX8/AIPvYr7raxaunUP12EhHCyPN6+1IJrNUAfzJX9ODHzU4eWo/D1aMNHseOByC/P5L9gf6W33HvWZSwiEjs1cCymcMPXnBmDduF4KyOaPD0Pc0B/RLxbBSutFWktJvuDranD/tY7t3leVQiPbkgF3bwFTe51QrtERbFiGzlw32Z5YRh3sBJUmF41xWpx93P+RtUNZv3WM5Wz2hKrr2S8zuWtK9/pGA40gAyHk2F2ynFf9ZX5mh75O/tvWEkiP0VOZ4nTe+GnUH0HjkCBP04jg8msXUJhGM5Cf1n2tuuXDXKRfivMZUYkkqZoRK+wRuAWYlNSdEaV5Ur2l7upvnZwiN4bpnFhO7LTKkCeGZ4r2wpBtgOWRBCozVHMp/lTjau+dQ3uEcbbxRrCvEz5JxLlNCYKGkz+79TX9C8bBsoE1c7eYRaxK0oe9v3IHexVLRvINnlWCuVhgCh21xC8zwSmYc3H1A4c1XmhV7rAC0w0vdoAPTQ2gKO8NAqb75+csdvOu5ICxTla/cnAJ1p0gwIsjV3U6D3GpMcXlOtM4p2sv3u47pnl0vKclMG90mHsxpNfF7Ppan/DJhxR83gWgjJQa2f0mUVU0y70WWi4GUH0ofkL8WOkzHoPdKdXjmeVeCp4wX7m8e24hCJGB12NYsMqTSt9eNQki0iIN87AW+yfsqo4OaLgenAx7oBYFiFjPmc3gNwVO0/5Bzui/47s3c8PkjP57hPX4Ho5JqGjBy8NwFz8LLCOO1tnoUobjeB81+WICIsIRAU7U5OQbz7ir1KY+zQKLBqXgU89QTi5FtJDQKaGrpv9KIMp6gnd3GQ1OPZzwKHeGpnx0jf48G/LtUWj07ZEZIVv1YJuAC3NfhRNrlFrvZRArHyhqPhmlCmlVHwI7ATIIQ5E0IdDZZiphRHNupfd/ofY6NlWJtOAcXpkRGTBkO3LxHFuXpkhzH6CBStf6hgCV12HWSeKQkav5lYCkeZXo2GrdtmHyIQeyfb9cQt+EdpgUDH7kuwBOEdhOWd5b+YD0DkO1WrEYEDQC6R7RMjr2AHUM1TA/h87DAtADDiiUnTJVqkjWvHtfdlxfPTMEoBhn7QS2kCmAjtEp9CTtJ+tEZW9Jm89pjtq5hw9ytFNYlaxrkucbwxd0lLtJa4fYIMWaKV5h4laPQRNiROaXtThpF1xrj/XOeChI2tqCeSbZFC79gXwnY6UXeZrlrTV8okWXUe2YEJRadluOU9SWe2lPLOzIM6tlIu6I4uKcUkYgC+vuMiStahghtWN5TxcphpTNCF1PDHprPr2Skpf2l3ylga6sEbiyCdmaKNDdE52ghdIjp4pqOSowI+eKVk4wri1wPCeV1Z32+oyGWK169p2XMEEwRLmHckeRsk5QedioO7ZvIMZo8CmTIA+0oGwJjrMAmjWiNKOpywjVJ8/FSsBSrWOkBZvbRECIdCosCtUgd35kEWY1JH6eDMzxqBXlnBRa6Hv/CZnb32z8WYQojEVOrXHSpxj7JHLGq+AegZFFjcdBmv1L2yk//ZL5fAEu6RGwixzh2CbFyiPAqrO2dILh36iwozJFb0/mvzEcqnpKTt5tOpJdcmp3W9wiLAfP7h0fdIXeRaVNVelpRPAaXlGuNn0/BmlAUZbC6+7SiER+Aarq6x6qImiOj7u+TmxcJEPWurGPCXHDmLppZIatrgYaw++Ny4ybJ4JwNJj0tVIV40BO/DdLugt75BUwgAp60yvA6eJVpNcmkmrQ08SjctJV/l5aFnK1uMiyRCb1cPCJkoRdL3Mg1u+YxunvWiJZW34DAKud4l7LmL1yk6ETT0DwGGIw/nRCmgI07x4O7w6SOaroogGHGt0BEUag3ngkyL6guAA8nZlPzc8ukkChiYUGxgdRob3Qs7zY9m7ApwDq6iR7frouNGqOiMKa4FEeX/ANGrgCI9I2IvmFqrytzLuVi8H7xewnfUje9WqShxqgdu5KJQVcB83miJkUDaXRsnZKxkMXdrLKX4zSPMXkveYdQ2gKfH8py55vn7l+zY2SI7nJoTyB+NTsTi9w9PXJz7wml+3NBGogg+RIdpMLW1m3EYVXHYRjpiQpYiHQukvzmILBvCG7NWpld0/1xm+RuYGAHZPISiMSPYcgNFZjW1OnlT97+u2MBk+dqe9RJeGwiycSVbzwlAMYREPnHJjKtAGEl0cu9ropTeCccirL9p+HEaS32SJOF3J7TAqV71H9lFyXuy5pvTyLDu1/H7inQsInaqRaSyQ8+tB+rwOpd3Ruec/n1isaI0grMZrsNDbBWLreGB2oq//Wus6iLBwcyDWrwzGiE77TKiUiQcwfCQQqJDeBDO3qysgXZXHcorHbucT0mN4kivgC+hykYroCD4P5Vv0J8aeq5Wiu63VZyfxo1f5EjQ4LA8s4tuZBAVK1iElYc5qvnQFOWrkukvDHJxJE8G4s4FJ+L2Cmr3QNK00DeeVz9iCc80yCVLo2hMFaWYTS7jyb+yRMd+1pVmMPRfM/hCb8OOvY2AqJ4f9YrbaPz4iO+wAq0VHvZzIbl0RSibrl4bMZywK4eSYv+7hLLyZWJUiKXz8Ji52HvdP7yY8yTvgPk//fIDn8USF69mPyQwRgz7onuGvutGz00mrfbxQa+Y9P8zH/hGRfYEjhesRt4o4ASR0WE2208GKwnKjMQcVcwkkoXTGw0F657AyxXWgio9TVoSthXgcX0/7bVXATXDKvZAY7uZk7crTCXTQfbfgRYlr9f6dyXLQ49zaakztMFB2NHym1NmCExTXx2sKJOqAs0Rv+aUIDt6icI6x4gAOeQbIn7X9RNcLcwhpXldtlly0bTDuIJ+D43YSv0ONp5AaIJJ083EY5swK4ehyhGMif5gH3K7yQr+gBNbBCb9qJ8hBqRah93abWeOFF0gXp9CkIoEfm0TZ1ltkddHJyY6AdL5IrvbmhhsmNV8zfFYJ6DZ0vLLRyihxldqZ1d9k87JLaj4AkDip5afHAnh6/D4CJ+WfJzoOXGx9akoiHXvovIW/hUaw5J48K7Spk0rQihBGTD00M801U9NtbEnkZoWTGOfPw9tBLMqrCvoZqaCkQmTBouKzzWnZzbZgZAxL9I9wJN18Dbah7eRqC2ZOmG9tDwBdayTiuhgmFxOq5eg3mQwiyDXJnfPOvcS6+qSugbgFR1lroaeiob/uxs4e4WI7aXSoqmlsHf1Fm9h2TLP/BMDfhRk/fJio0kgh3C/qQHK3myjw5OJ2VuiFNKUnlj1JPFUrHhwBA/lJwim5IFyn21SgsndoecnEiGNwn4IvlIrpGW5SCqDXY46exp5XebLI/ScXXMW0XO/Hg3NZHMVsBUIznmX8gcnXi/0gWXBUAtM2PE4HkAsJxFGxJYvRfcCPTLOEsNmVhZ4TI1uQu+jUVZlZAntF0IABqXda1WBdyy658r849xKt2YpOeqSUbF5BECEsxQ6fTpoO7Sh7aX4bz4N1HjPujl3TEVEomSec8fW1FbYEBmgpYH3/jJC0uhNkt7imb2Fi2CUlpkj3pq0tcZ4pxW0Zm7sQBzZgqmjQeLnFDoX9A6OecxBt9eM4tP8szN3W4tzp2twjcBg9Ohjwigbh4Hd0BjHhOghJXzwhpfl9Tk/IVXBaWex5XNtmbVkJqiYBVeg1z81IVQUUUvYqs0rwl8NEG8c5tfmcHa0Rx8Ch08baYcVD2ek3Ls2g2S90KJE17t82GgiYnRE3U1FloB0Dn3qjV6UpR/VerEFpIm1H0Zjk5VKj1m+lirdKiVVUICRf11IDxUAUPWhOie7H887QfoiuoMzQhlViXdj0n8lcF1t1QcJG/5rPB39C7if3jPfyj/hRD2wX28GxttmPb6dyhvhZlDd6viGeLf/nxeavjyKQ9WedAEt4LUk8H+2urVoAnSO8xCnl3TdmzfaDACRsXf+gsFfUNZ5VFwYCjFvpxR7Sn10Vofjlk+JB08SJoMg36hOkh9A0Tdef5L85+/ZzgrIpXeGa7Rk/kBNFrZ1dlG1mXt/aYMal0ZVEz8jDHzcAJuGqT30wSfJ+e3heiT144Jb1wdG67duTGlfhrT48iM+lagX9AKEFjGsARbxNWdBE/mogTVSczW6dhcYYoJ7tadnsAeuT0NYGAlSnm3InYQQohdZYpaJxO2jRS47386f1PUEWRNaVYJkF5Pv54iFabTQjBi8p521hVa+jGuuJjWT6UdmvHHwIokzKvNdnjU4UXxi3xZUZ9CcGv92MuqJAXjQU2RSqFBs36FGo9uQl96XkIJKF/Bq7jIiRfdiK8ylvAcuzEb71sbLUiihI7od69elyCxvFCJnCXP+FkAkvA1++wNAjLXZBWjlLOVH1AuCghrr6r5m+A2qpy7u9HAeZ/BOVHFwD6Ryx2VChGLOgyIqv7mczFWwd/DGwYch49zxJ7lM5Vi+JNgEiy72imacPI1ahAMtzs1GalZMBEjDxpmbumfi9r9t6h/LieHxZpBdMxU0Fk0nuUzlWJJbxxYa0l78sEJAXCOSydO8Tms3P1yImNi76bL4NmM4f0q4KigzCKMyAWX0XZE/GEgeorGP4hBngbooqHxBLIeE+pzLZDMXhf6GMq0etzfy0oUdL4EME4kG5CblvKTIOqrT8IIVGgnFfpsQ2ijz7uT45nFVXXchjnkx8uL8epV45Vi929uikt5aD5MiJ5SsMFX2x5OLHXjkHh/KKKkTqsMlKBE0/NmazrY8ehAFD5M+pr8yOLmkDLScekjL98VxvUYfwFkbQkjwhhZBe7ZYzeMJq7/4l20jwYqTyWz+F30aWUiY1wmW7NINQm1aEQC7TJ96Dzhinr9/C54ypD7ztCOR/AnOdwLkg5oyvdWP2zjc3YM7FKo8m2RXkmNs4sM7VeVyj8Hia0wvhqNrcoRkvf188N5+8LI/zuUcEjypjrgAcxEIbjse0QXRy71fPnYHIzcwyJmn0cFhoEd5GGaMTwPwcr/TSFItEDok9rX0DNhio8/HiPYe4XKsSFjjqrECraGCpPJbeggpHrgMvnWVg/2Y8Jokm4GdJmjSrch9mSeEK5SO7X9v/iz5ww5QgpibN1lEloYMtz1h1GFjYnj9ozkwneJCRTUYOB59qjlLDpfAMmsDLcGuQNV0i2L8w5n3eyArt4KntsEttMlFoL4fXjs/sheE73AilsCQi6DZKE64cERyhNI0uM1fjAn+cucwJZyb+Uz675vUw2kbv8HI2tfzonsYor0RciRTYV4oR8SLGLM7bEDlWqbJxzI4CQ/ep43s5NdwFadCWlrmy0rwvLB/qIWXyNb2TRdZElMoHPAuFvQUbyrvMEhuq6RYCuQKgRjOphsTOJC5eM18TWNuBCL44f7CUBxGS1jaWzdtaP4KXvGYBUki+YAQjf+xob4YwrpCm0pjEjhSw/6ETrLUdgZ0fYkgh8bonG0+H5VozN1ZGUaypf+XuVFPTRwuShNmhaeXe36Z/ACMuceUGKRZo8PVENK0cB4FWuDm62tDe8RZ+kZ0JxMrXpOID3tyWivHRRiuoWkTL5O90/uwp+qyBWb0CIO7l/ehNBYtLGtnsC9tuhFRAvjQL5Xcs2MrzSug7kNLLFaCuc/zSCb5auSsQt/Np2xmqmIhd/BdxhCkaZI3oWvDTES9hGEZAvsnSAaNm9kp5YuWRAMNNGfWd4ydNEzzPK5U8VpLRCVw1J7ogJifiUhQDFjd8AjmZ4nJ13J39goCID9hV5+AJfgEEax0OxZKHLOQo3G18JiKtzeYlsqN26q7JL8HLStoHYDUUdAbCLv8DWV4sD4ls8Vhr0FBsmD7BgZ1ctvar9DNKM7ZWgE18Abf9vYD/Sbu6NbQlg1AqRpp4r/HxZB8liMIFv8CnwAMBSIU9Hm8CXidBOcUBqTxVUACaDx9FtPJbhGlM73flGxxgOQCxcxJtXc+dG95jl3PicEXKNLagBaLwcXYghW/x2TNRfaYeqFOn7HAn/h3MQoddxf09+XDFMaD3alI1iXN7zNLhVtvON69A8wB6IWaJ4ZbzC1ym9mFaifBL63WxYULMo7V9PvEqAXsAZHTlOT+eHH9K1j320eo0tuYyEqUgNU3qi8RYeJpa2nETDfHT3o4mFEZF8GWQRVXrfHxY8Cpg3rZhsxvkD+DtIhdUaGzvFaEjHuBAcQIsbMp3gKP2cnNrnHfgRfdPyFptrjtW/4FZ/eF3wyLNBQPnlEGGJMoLcpnsMkxWD4kkvR/kleJKXXyzlg3PU04nv2TUNRn0x0ROGoOV6hCdy+YXHyl6OWbUQpnh4bs4i7WMPNfiQ8ZbwtWo542nK7Fs5QVlBZLXtmtrZOaynzswKBRHTC5GXmr8mGhj7s0wq/RyT1KjzegM/5d9DsjYugTQFGdDaihSBcBFDReGTnbNewqLxXuMUJBlaSunAXiyNDY4LXdgpfsMF1iVOCiYWbH12zT22eBAWzpKOiSAVEwV0kL+HVBU1cR2yRRHHeUIZN1NXDIgBHt6EZqEsYkL4GnfgkMRF+aT+DUztqNA5IPbQuDMOwiLhjhz623NYkOLXfIPCpthkm2qfjgcw9fddu+0ab/i7mJAnZFw52ZkKWwlxbgPd7oBdfUhMjezFhbvTfgVHj8wGFAgS5tOjZAadWPEW3UYZHtRSOkI3QWLBxrcfC8RFmE571xYo9RjXUb7hoIcrT0qVnnmkHZF62ObAQzxVqObllauRR82iiNAohrpcpln0gFajBHzYl1x2JmEkJ65hC4CT1ksAX3jm3yq+aUS1R5BaYAdFum0XXZAvLYOuvB/fxxZkE2PMIPMipsaGS1CAQQRlf55jXJ9kWsoBJsM5XbDMgdDNFE4D14IPh5yYzoHajzL4oUiqzPq/mx+Ql1T3qofxB44hbvjx8LTr52oGWvIwnuO+VSVrR/S6B3i78tJqaiVqTHOHhxkJRipLPvUTaCqAEy2K4BCdOu3MBC7g0n13Gy5YYfaLiFOGa0xrSXd9ehRbeRLPndpgvgTA/yxKmNTtfDQwkhVrz5izFIZnSWCW+CK5dvBVRvY72DgsT6NOKIK3xebqjzAFEj6vRpzs6Z+p8W2G8n9qmcQguwIF6INqPV0LeUBEbeGWZe5K965jWfyJBRu6bk+hUiQ8ZjF9NAZfupB6R9rgNDlA1hlr2yvRj61KP7bBHighS6vfo8hfk4Hn7xYygXv/Dn4i6OAIuWbpQVHyCl+cGVdhpXxLPV7MMiucUWv4nWgNIPomM40lKoO8cSoon2W/0HBBWNNau5LN4i7bHVgIydTsPx5T6HyYwAxzknbB3jPPcFaMBvJaef2WYXn+V2lYq/1qGDQJQp5BUwMLeTwr+oboWlSKK6CJZ/km7aShWMo+HaL/v7reQpgbO0dJnfrDdkX/6LkbNkEX+9whUrs/N8ISGEX47PpJG0/6psfVyxrgFTArKgqHI9uMDLGp18piNCVhA8v1Sg2yC5CcYMrlJavGo/lIfljdHXPODFUpuLaoLwK5Dx1dHxjHkftUunCddh/wTqYKdQHc+7oxZKE6afgWS0BdxAVjElUixQgCJ3qGLMuiX0lVleI796KvVL51yypHlsjXKHXdjn1qv1pFbThRvAnJKgTuK4PQ1O/kMzt+a3j6wDKSJOnYL3zFlBNCrAiLFylBuUbrAGXQncDVJcey5M/P/7D/FMUwZyrsU7FQ9rELRgQnQOuBw1p0hOMCcOj4mBhTLDtrKT3AH7iro0+vZNdxMxNFgeV9R8hJVmXUsMv6JOstO02X57n3YwKCvjttSksKxNjPfs3eaywMSOzW57HBbCm12WxTE0G2ZEIe29kNCmx7rY+OuChh8TisLv1huyHamZBcAHp+PJKR8oGB/tNcnQAmU/9iEgPG+Cg4OJWWB3h49q4FeXW7SjEPXMr5BbmdtP4B5jCSErOW+fdsvPLO/S8aSEEkD/cfXsxzG0Cg4sSTkpUqwMWnfConMiyDkANj+2S98PNUMwh3Pl8uvecYH6L0+OB3yI0Cpf0eykYZgObdRT+0/f+0ItpbKijmhCUdmFcogs91+3O/P+IIROvYt7tmwJ7q9YyiGfkW9B1vpPM+o4VZpFsvy6yK87k/pXlDTLbXSjYL0+To8XGIwn8OHtE1RJAQSy+zdrQ5Zqfd5Zo/JL4WzUEmPeuwReWrVr5XaHhfle5G0np3ARqxCsmAjEsP3Wk9wIUuKfDDckzRdQKiEgaunXhneXAB3eWaPyS+Fs1BJhXu/t1CuoRbq9jvXRxSeJuO66epzAlepJqRSMYfxK2ZPlHqph1rNpAiUrtQBmDh12KN83tAHV79vxFelNBhO4C6tpLzt77tkavmuh+GNf0eykYZlTt3V3afwDBsxOSs5b3JzU7urq1kOQHdhteA3v5wrOTvHgCfxmWLqiwFXZNEp/OJXQAoNPPD3Nloav37R6d7PQxHmKDF6FKnTZSkHTzr18gEbKa71dXd9C8x9GnmIO7DubjwjvDSvxMw/QqJLvfsmjjiFmCF7blRAErpXBDLmIqVGG693Mzx6OmF0Al9igPmuSDH7E/PaJLA3SemcEszl82DeNu07jzLdylvJRnxzT4Nslaj5eq4zkel/JU7O00ySOodK8WmPJDPyJbt0MiiqggKKlp6w+lE8bdp2Qa3SAonyShIwLPnYjYomgEv/x49uzEm/RRAHp//RSBy0xpvN+Vb+4DPRi4ZXooedROIpK3d9C8x/kk5rsO5uPCO8NK/EjsTI/ONxTgE0oTei5CRQA3baqfkkc3zdFVIgRYIldhtweIPmyAo8zbS+lxskZI6tPr8JZLGzsSq6/GzpeC18XVrtfk0Q1f0vDSTYEx4ho8C4+ri4cRLOKujyb3jj9Fd77JKUUYmEUsXet1yKUGLHuRICGYKtWa5xr/40Ig27vWClde8iRQsNjr1BzjlerNmcqcYPwOqPJas0Oub8sH+TFRvDvKloDjTaDb6PgUQQLYonchiaHWVyY67T11zCQQ0UKTvq4WNwztQOekjJ0YCtYketbgTyr3mBr+Yvxjnd7hzV+hDi99tYHBydkM6jIOFqTrumlG2eU9Hsu2q0k5QecAyJmUpZAdI2nFkDOtbsaiGcA9K6PiICERx/3K9XG0c5xH8R59DgLn1CCoxLdy6pGtIqpbV38TrD6lqu0KW0fHVNUM5toE2fb+Z4Yfbv0Wfrqslc/iujZb8tG0LQ6nVyFDWt2dcJxxDHl5cKp6ZZAnSRZa+5N23gL/vsDXfnglkkhjXI9mvL0DVmWN6g8KnWz66oa/dGAEQ0wYPKpnwRmju2dFCFlxMjpRf1zl6M/SLZ0NISO2hRLOsiwdmmjPFnDGTYWc37oIkhyT5nL/TUuAxXSQE6RQLs0BEJfy4g6PYmsVYZBIpA2idqXbkXGIquTeGcRAKVloo7yDCeyFBzsOoxQto71VW/LsjBcGi0pBd4Q3+uSV59uGuogjvHS6sNd3o4sRZ32EtRHv49tF4Rt/zQdU0tAKldHDjOelrG9KZt0USELPR3XzVQNCuRW1o9hYZO6i4pH/BQLtsNPWNIgbnEFsgmt6TVTTd07s932ce8s6FgNpdxZgMgeJPEi/lEf4knXTpPgFj5LXntvVHATsQvWfCk2nuQ1frmwrjlILn2f8PlvSvOjkoyVAX+SZi3DH4tZcP4alGVlLMnHB8EZsuYFe6da1YpSfv5VDxzf8L8WGmyzapcCLJKe4mK1yT8Dhq0si9bIgr38HOKgt595LbZxbyzasjrqan3caLPEtn9iLDPTe5S53VDXDpXzvvzRHFbsRhb54sSARMVJv2rtWhAdBHPAZVBP42NBAy1bi1kS+KXdCNAUcI6eAQXz38PybOvQlTO7zjGQE3ms3Y0QEmiFw5kJGFQZ8MdJ+A3kpKxmu22ub8Jzvza606OG/8+zfUfCbdUXbCnqQ235ZF1X/IIQ1fNEyjXbkWTbRw9VlrIyXd5OWp5usQ9Yx0F5vnNZ+eAdgjMIv3EgzgT/s8Hr9YtKdq1/sz65HrQeYp1UDxPI2R40fibaIVPlor2rEDXT1qMcItM/1cXcCpvPr5hQb+THWGspirwMGf/fKhNkxmoU1WYV3zE3+qpjVMo97EnHPt4iTtivMZR1oL6FhN/1yWFAinwq/Y065GTh5M/7hW04pnIsDDKClsWWikCbO03zlmQg1F6k5zEsLHmXfJCkiGOST7UD+/QwWzIx42F9NiO8ugzTdJNSUHc4KQ54Q8nOmcnSnzCa54AoOBP/NNZuhpXTFOCcnnNVfJlUi5RyiHPnYSd3zZfwvPujTJtTwxM14xJtIPndKePpR5giycvgkMaBGw7p861q7VBx0Kru0w9F0/YZnaDZcKXZIfwUge9gUuly2m0NoPXAtkfwyJTAkN2GzvGXCh2rhgR/aLjEnh5W3Lggr7kyXgQMQKYDW//4Citu6RxbD6vFmml28QkF94tiqe8qftL9fGVSYQrwM/SSnNeFKKtHpt1Bz6B1dlfyzGEn7zzVbe0gpujgQ3RO9DPLWXaG/Fc2H1sUGwCvNRMXNBlW1mxE/atqJgFAtoLH9MVkGFACvNDaICYc9ALykYHwld22xNnMwSXlpahKsIMLX5fQzVAhYkds0QZEE+vzqkup162P5Ama2yHlDSUQQ3bEJtGlCihLeMdLd5PknWBsh4+N4LQGMlNYHguMLwOE0QmoDOoXo8NBjzxbLoT+4JtChW/DdSf/8+q6KzEbIqm/fpxnJg4cQdJPdgktzXpaGWti/4DaJhtbxiOLx9Efgca81JTCRXDbJY4cZn9wJoGLSeIkcZLaFz6xw4zDbTawDOXSJA2I1eMTCS712LfKkHFZNk1UVLnDIb+nzPI4haDiz/oJh2G8U3MSvohAHWpY802RWsRtXZHga7W7LvGlifpAS82qDASEEM8CxWh2MLu6b60GX230/j4K4QdPQW4NJrxsBMBNuKgyZBg3eQk9Xi2G4+X0v2+SWZO6n/P21jSUU3Vm/x+jlyb5iBp2ZJMQOlJlpnZf+/cT15wVhM2i6BqIZATeHFlLs590tN4ttePtk47R6cPvBFBGrjBoeAXSIAjbWP4xv38GY3V9+nfuyD3i2z9HGWR7T3nNti/80gax0DI27rhSoqPb4MXq3/65hqhAKOopsaCV2N7cLOEF3X4shtj/Oy8c+yniBZaX3zOjImrSnHZjSM0E2cBagAfxBi0R2l9unmlkp7kp6jxxZWuudXCEltZaMJfIchKZE1aNb17sh4vwJ15XrFO2/b95OfdCVQQmHGf5PZblzbiww5MRDcBC382xZKMQ5Y7HEBpXQXRwopl7vYK1EyJUvjeotD3epIPK0uTJYiLsehLuSsfnblok/taYI88R4NbL0HK88ARyoVBi3Z/+V1WWtq9ruwpZvhUQk0TCgdpv+1GtIU9WzT0RaSh5ddAt4KozzSntCxl6S7K6MFUWl29UpBCNwC1OlNuWohcMGdwi7zlXBSnAZQ6VsBPn0wgkoEBxR21QPfdLZ2yAZ0298qHLoHNDrlvsV7dUlHVwJm/hqXTpWGnu4Ns0BFOM+ZtKFiYRKQhggd7SMUjt5xSzSKVF/A5NwlajgD5uYkU3aLyjaxt7igdUMlj8Nyo2JhjUc+4teNAJ+H/IR7WOgvVzdMvEHacYJIH9Pmi9jie90D9Eoj7J+TPeyeVNlLyMsrU2eQn8SDxA2vhkPCY7gf6xKyAR8KLwE63uxVZQi4K/HvNeZtzrWDxroa/6HLnTBGbaNKYKxaFSYcsul/6LsxAndGR4/K2HX4edLZu9RdFR287Jv7KBKKXH6eO0idQuoyhXHgcByg1CuoYdBu/XstfDIeEx3UnIrsT1dDKLQAggrQk8RM8xKfgzpiYtjslxsYbybS2XNfpgJIr31YLrux3h/Oe/j2yWdOi7xVh4aBWi88LHJexmA+XsROHto1ymxRT495WxbG8KZE0uB0mkL/iKFdqGjB0F2xAPVHzoLa63KydYccJkuM2PFFQ1ae3rRvCYPSb6zuNo0w96oQIQXbcCdvBEeo46fAwG/6BpA6vnYgBzOxqNDYHNBDF4FMtFNFfEJVxGokBnDGLWViOAkaQt6FLpO+0eJY5UdFTis0O+1+/DffTGnS1SshfZwIeyOrKEsHxPNo1q9V0S5tglS+N6i1XQtR8/H57nb11mHtdRcbdNJPU9/05bB1KubqeqavMJatVYt5BGJO5An7Qud7bTQVe3qwNuVXIB/w4K9GNQbgCKJcSAt+gzDmVpSCJO2v6SZ1GBENbe4qSoXCD94fuL85GeOQXV+oMvuhqaZcVXL7eviwJ+zKGZtbS7Amjy1O6fHVyPXb8mawg4MtV9vOxZBG3ASm9XVjn5rYE5IgzmpCJ9vQ7/Em5JiPTp1ygv6e1ZMb7fKHeUqYRPTqlw2jahlNI6EG9BMoF339veNeBX2kHhRe715GWePwajKwLJeIWHSemjgjbjiBErWOJmkD/pVpvkUJfTROA5CVumaDViKhjtzEywpb86lqyQJ+Il5Gna6FCNKiQmv6HoYUlJ286bRunqJZyBu041QqDqpkTNxTlb49+RKdt71QLP3vOw0CyzJiuwsuOv1odB3X3pT44XG5tK8m1fuk9R3XvXeAl+DJyG0T0QRf44P28ygxvdwDzVDBy3EpuiZMZVzASC+98eBWhgREBoqN0T5wHN/7qhEvFA7m9nLLc+PdlN7G8VEVKLshYlC2sI+2wO1tIk0eTUndq5Df+J/+OD9vMqR/HNUxDxUiNQlQnD1am6rwH4W79+H2iN4NtDSHirJ2/pwF9dy4siuTfl9j7NnrRiFxbzAf9fUCH63gmr6iLazwM4u7gxhRcrc2nWGVAubgSf5v5z7fyQxck00zyv9Ykt6lS6+3W3DSe+n+Eg7sBdib/Y3v0S0/0C87SG4G4GBjamuMsMBtMfEWe9aOCUfWLw32M5pBJ6wqNnsOZ8vCM+qKmKqv9N+ApHR4Un0XU4CuEMmi71OVWggFdTHDqxIYO6dmo4JUv0bqAh+xXVKsGsWX2ukLbgCSEzv/paPu0iXj0uo5AY4ofJqJkkyv+X7fdfGRuqbi2bhbF1u0oxD1zK+QW5nbT9/iZzsrK3XzzqUIjX2CXVrtmbJ5atuvX1bllaoUw+TrDL47Qb+LGCWH/KQjuZhlrtw1xQKnwxePXHU7U74Qu7iYQWaYGxrK5y0a62OINCCsntd4w1DqUa+bvJKXGcy1pt6N3HnYQ3a1oRJ+eQstM3t9OjHwgT4aiKLc0SsmIXSoY44Z+xGME7y98XtRW925g4sQRZDIZwn2SpwfyGWdILII65tHLrSmq9DuCS9Ewe6/Hk1clmWPS1NE6+zCz/TRP/c7wyMYOw2e/l1afsEokFR4eCv1qi5QOjWI60PaKJ1bCkMVATH4RzVLTDwcrafv2E01HQCjYydvS7Foc9XZPQUriVz4v3eserMdJJwbBm1voGwkPy+XWxu9Q4ihmBfOEu8PCAqEDVXR0+8SIDdnXUpyiyndJfGEvsdHan8xv5GBjXRImXn71IFeHD9jaQ++7ldp16BtrnsQfAF3716P3JwdJid8OvQY7DJeZ8eLFMnvJ5zxV9vHDEOPWE7qc/eMB2H1g6YgMstIcQswQvbcl8X2DTDODmRRG6suYHtVTAgb7wPn3uusWnj5ex2+BORzG3A6TsxAs2n7+YxW9IGbS//s0ihHi54mokHErn//YDSWEsL6GHtkdUXhzAgpKSbbZiLIzV7+tT7DiEQLqTIzvB9pS5P0Y5JNijfuOqU7nSmga0/Bk4VpZ/Ia0qKLMNpAr3iZcoP2DdJYmnnRChRDGSWklkqjZ27nsxzZTdmfxo4gFjlqpvl6HCCeMVy1wkw5bqd/0p/UALV1lOLASA5FLf2dC8b1/MiA/JH8vfGgPFL39xrsIrNag7SoLX1VRs6hy2MzufAlANBfsrKYwTe/HkLDZsP+AgXvKexIVQpNteIAzWJYw8m6rdVdY5s+bhGIuPMmL2SiWWBX4rOOgwQb1c2+qsPgcmMjF3fciH+fZniMy6imjMuJ4IpezZ4ALbokkrsl3teshOD8hdvUU5sGavcL2oVKv7Iq6jNFbwkQe1LFhQ2u4Q+7bh2nc5febmjjIrZhqc/Rv2LmQRhl3tf68eJYOTpLJmOhlHXvR3pb8QwZZ72Dcwzt55qdc/UmiGRbjUB938cdTUsfwxo7Og6qy7fkwIzFVk3xqhEjjItCwjkJyox6pywJRCqt7gCQ7aA+vtFywweqi4U/eYcOcvkw8moMC1bApj6udx0A6X5DPIG8CIPEnykSxWOYM/s10w35NMIU9f8hM76yvD6kb8TpqvWjeEvTSjQOVeB4q2ptxVbJ02Z2CvHGbHnYyYxxvUlg74zLA9OOvuJM6pSCgOx2fNWYNjqp1ZYxPmtweZcXMyZ4KYepogCrhhW/l8qYsTaoHkVDH6jHzN0tJhCknZ1m1nDjEahmtDctYbvMjUcH9Ka8DWa5P15aP3/i+mfDj4tY6fp3y1P5v+8CXSsczOU8Rnv30AndQPLwkKuwQk957I2mytIDbV98sbBkft1mnPAgQ2jJCdt4vVf0IrygQRcU6PupajhCKSpZUUTUdPHKtt3C/UM5fR7jvtQzVFewKAjmYEbSHDi3m2UIgOR4OlY9bgIWQdI3hpDvhaJumDgkTj0P4Zoo4WMFKdwwhjY6ro7t1koE8TRVc1DhYEmjRs1HqmwiXJFo1kaSbe2HW/tJVW+fNmfFp5Dp+i7IfVd+/TdvbXq1lH2LZA0r8Yver2C+AdYnAzlak1HAxup01SS/rKRvR0CwvSTYeqsS1muwepeFmhI5RV5eSvVAFAoZZodtsUWIe4pfuZbcc8Z/ZDWAd7PtKW935VpIacPgaSUy3oUvKvfdC9y0U8SQyaRUc6xykAGM2+rhcayvgJhLZlDWS9eOl9V7BZIFOl6DOWRyO1I6bVAMDcqG0PFrBpNxa31ErCcAFKAG8hfTav/A+cOAhCpZTStA8SRkCWG8VW81dZRYxWyt7n7L8S+bxvRGodQlsSnvfj7a0cBchXVB7U19EZthApuVth54tW3XU1/MrwE1fcMHAfCQtaFk7y1SfSu/gCjhf4JBcQSQ2SY0HjI0hz3NMxqXhYeLhlSW16AK0Dy814EulYjlY/r+Bln2pgrAx6l+oG/eWJVVkEwpSJZREuieYXnUTqQXUgmjUNCHy1ekyhjGvqIx7UUQzEc3YpJ3n4e25U2f1qr3TutAX/s5kpR6g0yLaiAX/unFWOQOh15H7+FMBgMzg9IzqZrHEoBR8B4N8h0BDR1cWr5Y3dyDayC2RtFJ2q3hLK0vuQoBWvMuvF1aKU5lj4R/9j0BLprlsZnoRoO3gRO/laIIar/LRhc3A+AgCwA27LaJ8Ryx2VCeqWFBjU4r2xGZ0zBaQpOo3ONy1izzIdrhdMx2JIn0II67+rER1FU3jtm+aLDy6IvCj5/dqYASb2AFO8zUgn9WVr93lnMh5VPYrpIxfm2CwpU31UaiY9lc6UmdNAaLvH9KOGSGRDSceS5c27X9C2eKyw6tZsoc3hwqIvfQT77YkzSPzAjN0fGvGFY4SSlHIGvPPG2lVCT+5BtDhuIqJXJ9nOBCUc3nrfl1xJdmLyw3/QVJzGrUuC/6jAqUtchzB6h8k0rDLNZhX4UHbfl3KYl74Ft8TwcIfBAPaLs0WHl0Op0SIWPGNrmapeOssUAjfFVAVNaGNaM5PNMEeihb2MpMYqwmcPYnl/GVrEytZiqWDIP6JHVt6gr3mu1kzM3gAxrM+CYFF0B8XT+CeTDnWsxU+gqMlrHEV/zB1KLxgTXIFI9VX8G+neXErW+ncaattEw7ovAf+AFVLZbP6GQQqY/1ChrI0LkewF8+V+t+wB1Yb38GT62C4YGM0aqFwsTU701FyV5ueS2MT4pN+RrZK8pOgV0n+d/8idHP485/5/0EwF7JNW8ZGb6UDPxdgMBe8P5Z08HbMo/M1WSSmRS9U8kxiNNdn13ia9nqihzm1xKgoMm4yxP4Vsw+qVZGPTENEYhRbjuIjVOWbQCxQVeqed4VFbcZT4OJ4M58YpeGwvzwdgOPK5Cpr4nye39xpaueMRJLCtzo+iMj/l0XOAoerimZq2yNDK1qQIWGMK59MWamlTMdGcN7Kk6JL0xcRmfQA7zlN0Y2GCFnqToZBTgqsJawmof2/6R8Nx3YMOj/4cnCGXpajmqDg8CJogEGTEUI/vesJGCKJRcE4sJkLxRQJ9mV8Au61qxGOsZgR7b+K+9putCZ9sRP0rKb2pAO/aotWEYq/CDx2AQ+Kx4Tnc4ZWfGfzadV0s0qInp0PRbF7RPpUd35RNYMRhsW7CfQF+h/vdw2ySfavoVCrQMPAilp5qX6th9JVkHh1n4+61zob1xHwNvSPxPD3kWinBD4iN9Vhg+hlZkgQsXboIlMfbf8mBoBl9uMdaEGIIGnvp6XqRvxOziS1VN7/X/ubrdHQz9bu+9tZTcazOapPkHCgQIbbdo1bNnV/AfRD+29exKjvxVrkXIZbmZIDG0L5+kILyF308ljdJ80SBaPOi+uAprcddvWxkFmR+PLB7q8BYMyQjHsJVn1r3B17yuZrc2fI1LcGTtKx37Qxn8pvQxziYgUxc2jXB2HtBWRk+5Yq6CBCFvO5NxqMpvzfT3Kt7AoMLrf4SkmFMTje9eQ1YT8KTvUH/+zn0EJ5sJjF5FM3kySBo0A3zwyRvdn/IWw/tuAtL6nmsNWkJ33CCoHcPXHMSMdb8UqDImzNrynxO0ebnbbL9t0Nt7hibmldiipCF3sHHKq9MKwNUWrL7Gjw5+preIO1TmvSR+FJP9zzf7VGsOXdNuBK1rNJnJ9Eg/yYxYBq38ZNfugAlXAxKKpyrQsnuwzivgviKf62XonPxpAH/cnChBgs1u7hWYHi9mq8PqRvxO/t9/UMiFzymirF/+pRktvlURFrT0p2qEmbqReA/ZWgMFbtNrVW5FT6q9pOPNEu/7u5Svy0us746rdpgiktPvuMqXUbk+CoTwvuLM+9PV5UCpmD9PkyWHuWKVW6EtQVs36xqnBCMY4F0fbLHIF/r9YET8s92ZgOoMP3KKYy/XtVV5fvtSASYknFGcwwbklPlga+9D575wKOBfG1NGhzow7XrHd+IoHD3De4fBvtp3KkEmXFi5kMUNiv7VFIMLxMRPTYYcs3VmveAw9G+qESx+QJ14FN9Bx0VupHlOIV3x3A36euNRHbiarnZD4+WyHk7icndu1s6/25V2cZbyrxJi58n6CDdSdHEtYBL8CAG60flm0xy2/Da5K0XxTgX39zFCfP6wGGZ1rmQzjLEuDa9Vi5Q7zxp+4f8kNC3/hwQMhMEQ8GLTeWc2RJu21v8QdmHJTmlVn/nmAsRp/WrmsjDCde0++Mj142KLZo6QV66kDrpXHSIRXSAlAO4U+9I8YWwcl0M3VyNwBnJVxoh+AGVlOBff3MQ1wY6l6TM2kBn8nBNnXQOUER/m+STYnKFLS5TC0vYoHrqx/N7lwUTZuo075w1Fncobl038WWgXPgCO4COeCB2GjtFtLlvjxG4W/67ZqCVAcZ05aAPFKGdKchaC93LW1qabNGpiLdxrxV1Rw2TY1MRb/m7KP+qX8o19CJ2Ks/p+JwxjxoozjYdmSzG4vRMuV+cIGCqMCMOTJUwmUkxFvq1HQrPEHTHDLTZBaMvuQNvmRwDHCvU+qD0SEJBgKa3JzNCHIwOrM5qEuOmUaZ2EYa07qfN5t0BkNAnruSD8bXFG5yR9WE3DdGGYFJIufvDYRIMulVbMIehToEY/CPYqObdC9BCNCeZ812LVrLgm3vJ8Y8fAxuOZlIzdQt3wcqR/0rk91lB/rxEPbSwrLgEuA0B33F8yfcxYZqZlqp38Xh3mWglZL8AVFFI5DWm7owBG7OLJqaJ6OaMKZ4MyDMrsHqdPnipwyPEYN72vhREL211dCS1Zmc/tXCfuhrgSgZzR+qNML50D+Ufk13VrSL7ZbaaAdTAFvxWA1NS7aZlvQXACRQC4NLCoIK6UuT/RORgB5KEaNtYIo0WXBTwWwV6GDxNkOGvvAZT74F9311EzWKQswz+mP7zoGZbwUdsfhZwC4fy34FnNusYAKYoAKK2/LTL8SH96CeCq/+Ksk1dt3zUU99s2qmLHWsY2FQUZlLRNOex6YQkE9Y3MzvaIJhrxdzK0O+VCLNruD6ZZ3BgwanMDuYXA60vXjUla+yK9Jvt2VD49JpMrp+PqyTX0otf8hKd6glhmDWcNbT0f6I4essIVsc/A8BNHadK9Lww9gmuC091HxPRKcO25/wNYKPBDXRkakCMVJLfIdjILnHReaj94mhT8OvPd8mVQI1BSVAf5stuXPQdRZyon+pqdIgROhWg9tGk4wNNyen7SG6lnisXBXmjLFANSj1b97+AQW8scRAyn5eXJoxbeWwL7BG9X3P59nFSQBnWBbviQsYoS0Q3HUZMlvLSscajE8rOx9o8qrVectKg4yWfaT+1RJ6gH2MJjIMQt77px7R3EteDn1dxOgHefeWZz6gW+sWwROxgFj4Q9N9sMyg104Lehh2b0MIuV2uvSsmW+DQfWj0Q0F8p5OuK8hFGzbf2mnOGaHxTpU0dvqrFwQ7aC+K1NVEWqebDkSAkluFuFazflUjsotj8JHl/q6F6R1Aa1rviDC4exw4Pv6VfNMILSM1Vsy3AJ7GHkZa5nLPUZLfFkQJ+HvFQ8eZd1SMTLt/qNhXu34Qfplew+k1jhsnj9vU5reCt0e3oNlCcb6PBPApbYaBKP0BRuJ5nYcXEpBviLCyeA1vMZjhjUc1v9iOT/FuoQhGentXj2VBxePLL1fLxvd8mVQI1BSVAZCx5gKzguO3z3mtk5PRBwp9k67TXVjM0DBfGdtRy5jr3PFoSbkiGTLr8ysC7U1I6BW7A3uI6ENKZSKsGA0AjSR5cDrTCNgYFG3XQsTFjfIESmDslRBwgzDfE6O76vLXxWL5j6DUbru3fOjOfmNRdJI9aSFXNgSZTp/xm9KIx2RKGjUt8hKGxjKn1Vi4FVSqc8qF51YypOEUAEdlg2PEnpS/8YwHXDDPF7OiA2OWLHT1HPr2BqUaL37uON7tnyTC8RJZUN3y8Cx0/2GMWQfqUMGg53PK7XBHb0rs7efrgdFII1HPvhAAaNugzOvDv/1esywkglPY8iNmF6ffIa5LKyAddMHj/gjL/C7dcaKXz9mKrD0tvmw/pMTRPo/0myxjflcnoFpDYBxS39+ULvMQ7gT4u0ZDBbzSVJTA27yitVEggDRSpIeLhNT47y++cCB6zHZ7OAqFM5dSo0j+pU8rb8OQ3exwJvOY8+h/fY9J3ytKKjguOeJK4vWc1+osRjICF6ySulfWS7vYiRYYVa1LU9vFUfbfdoIu4WnaxtOHtDLSe+sx83+55lym9hCRXaFjdTu5I4jN/iY3fwffd4jmLVMS6lObgIM7kysaFErXr0l5QRjK9oL22H2t8mHOM4AT+Us1SsVY8ai6Q5CWWsFmnStFIB4XBFA0EL4wflzLu6jhQvlzDHjknl7fkcnyz0iI6bbLYpBg+UzvIL4nLeQG4kF0B65aqBfqN3ChRcAOj1m6Vt+3OVST3HXzxXJRmauNfsWwPwrihwV+xTx4zDIc1NOWJxgABuG64kAwtAsiUpoJh6SU7mdmOU4Q9XE83TdX1JZBpovcskjv23dE4KaXa+Ex05ZlJwp0+bH2lS1x9gDsZ4q7/P5o/7bmu1ZajZbNQd4cbZvNPmNwma3K4+dhXJXepBAJkt+XxyOJQ3qxbx/iAUf0xlulB7RI+d1Wd5UXdoLaJqEGZC+dBUv8bVbl0b9fnh8PAmHwAhw+mWV4+II4OFXsFYGmZOinGpmqlSjdG02hEZAaCtSbrg+07yC0kPRx4Ckb/0cp0gFPnsg4xMmxfT/cCmbZVfqHQlpAujB0SvoEssKmfYsVFjxfuSPGwt5dsYjBf6ZZYBxN/WjEbTkp5cL82oGNG9FanAarjPdirZMTEksddkAtMesQERJU50CoR9uNGaFrJq/zDaThI0YLx9MXNdLFAmlXRTQiychF13Wud8J22PgB0G8BTuf8w97qhMwZXwoBXOl1/H/nszxJl063+2vIGWTDHWjURXj1SriS3pqYV1H8RI1/Nosg6D3fiqWNZWBu+IyNazcfa+Cn8U3tJ4ptGokZuNmM3zceqlm2CIsVz3+LevokD8hXkxode/gjZhUNHYk9lPWYNGFqWba1mA2Le0j4lDb3FAGRCnD6jxxRyzLQCCYiB3TygMgIif3aArVU+5SpIjgoKzQ2z+HpWgybSJF3SDN+1BDUE5PYKyWfJwQKNAwnqrhFaMMwreVouFmyU8UpqY1RBk09euouEDbmicXpVPQoUAtjYA0d5jiQ4rl1xglo3vXq0/cHzhVFkW6Gm5EPef0PMDvGUXh/ToKyeXPN5YA0FticvYTkQJwPKWfv7svPMk1XXCbWyiYW5/pBT4d4jpoDS1qYCr1LZufT19IyA/uFxjaqWi9qtXgIAr69Xv8VLghR+ja/EL67jURNbp/sElQzQW6Izbx6yy9623l3+TMg77GCJfNofalSwIVGuoAEGhqYgPZG30wYdexO8PS/txaFHKakSahzdtM1uztTmEyAHVdxoKC7q8lpyS8ntLLvAzLg/Nel7OT8NfYa+vpdPQseh3kudL3Dxxz+FoqO6Q6yiCQgMCDL9L9UjBRk6iJ1qsMrxM+t8uV3vng4fjP+bRUwG1xqjWfTql2YroHd1QOJbVp+IU0zrt/rSejwlPkZqzV8POls3eouipVbbRpRyeT0GsyzxBvXvyy2ycEuHlL/uwhaf4ATkrluka0ar8Fnjfiwhjih9LBp1vggiIxp457YbzJk1gR90hdqMC+6kGAL3aN6+PWECvfi36bWhmGKoW2ACwkGyWb8MQQKVQvVanuZKNGoz63PpMNi3lAepDaZ9BbFzc2K/Qx4fUD6ucd5fAlgRcWux0sirarcfd8dG7R6XA7F4t2x935pTZX5M9uPGwYAeoy7ZtUAv95wS6AuNsFbuCvYDDNlNnUm581zbsdKeSwYKyceYYnro1///M44TbIE1I+8Nv64DT3OUM+8y01tRjCCsY/EeyaSKHGiJIQqutaBclSdzMLoAGhgOxPcWeSTDRJVegJBZpuPpzYjmxNppMj0D8A/40vMdSiXL6KT0rsWufoVKYLtB4G7UNA8IsB2nuu9Zs5aFUiJmnoYwrC1TA7rrEmtASvXqVE2ZnyunGJK7Bw3hVTR+PsJlzdjVYoWoi0ftnJwMd3lcdppUWXIdseMDVUuyS2ILvMhzcS55b7nOrAVY9Yk7EkXcYWNumIfKNN8tgOuQx+brMO+gaERoggTeqlNlK9qtGaBgD/uLtW+ezm74q3RwIRNp/AD2Eq0nE5HLhMDWkRu6WC+nR0HuTqwb0aE5aSFClyOweDs9EIRvFMS4F8GjdSN7j5HAPlUObfnKtVPPhP6k8UluIDZMqM4A8gSeslgDFkSIpkicvJKfuQ4olmaJb49LQCCCMrAJKXBiqRhfJb6IopMN1c4BfJ3sy5UawMzveqRvYNeqZwn8vl17zlBKt5JlZcXALe0Gcm5sIi6ZX2l67zPCpzi5lMhSzz3SVq9jVNHkDeeXzb5EmA9e3lHqANv0XryKiCAsOUnqm1NKK5Z8jsluBjPYnylIRIabea82FWj5JpqCN4piXAwZF5n0+qzIh1IVxy/5tlsQ6oxYPl4tfZDqI+hi1ByGKIep1TRvkeIICyl2bBzkAhyZhx9qgzZRIendcUT7JU4Pa02OsiIIzcCFLioM34mHErvBuRLPndpgvm38P/qzR+Q7o3q6E5oQVO9v/Vmj8j6kAtb/Q+YPq8LBuLnpdbFsvy6yKqFyWcv58375Qx+li1LnMvgJDqw7MQC7iZiYw26Ck7csQvJ5snTiwBWDEpva2ixNIXeKf6zdqgddprCZwTzViat3LBGB4y6W4Z4eKbIrVpB8nUskBvPQSP4PdzRmK0ryqFxdXmIbi4xL+6Zdrt/weyZUZwBY6ej68llId+4q6NOr8dy9x3yqSvP55Ec1GnMUOEpTqq52K9OP7Swka3DTAuMZpjZeqmZPlWc4dq8hDYuLJjukTC38QIkZgZhQpOepkfyulWBSVRx/0bHMeA5nyHADSyOZ43qPJXZUyJypy4x8LHEu4ncgdjJ9Y8P4lc+sQuB1jHgEMsSxcLMoDP4dMdxO93oyMqdMnXwRfOTkI6wwGfzipvuyJb4p7oiSRW9/Fxi5dMQwCl1PZSKG1IKDgj94Sluv9ah6Upv9QwcIdlC9HmXQANzQBnTg/khxOKEiMQz0RqGEyb+rndoc9RboO54SoSTA50N5yU+wTgcnhlYs3VH1Vr1RiAoMt2WhA42Ga7oLef4X9BfbJprXaNOHgK9uvfK2R6CgOvJETf7bBA8pomCeHlP29ZRg4cU28MjJZmIXpyKeYXJb2698spM4XUBtEhTzFgEZjlH7qZljQWw56xK7ak8ozf2NYlB8TTUXIXhJjr1xRqjycAS8j6vTYUlXhKYeqPMAqOSBCuaWCIIkKxcXsmAIQzvCS3QGnQkJbJudPR0rmN5ZskOlmyyJY1JVn427TuPMt3KW8id5eF5n//iUAU28xoWviNgjGG6vPq5XVLAz6oqmbq7YEd/InGXaxfiOrXMSDsBw38hXd3R7jgue+2gDgC/HDt+x9QfajJCF2TZ/N2NfkDVaiHFnyWT33fpCzqBJiTQDVeJ+p9VTSpleXBgx2Og0cKblHbcxy5ns5twQKHfCi5ktrzfQv9c418Gwi8Lw7ynePT0JHofoU3Dc+9pRegTn9Dy9IvarebIi15s6aLmuCZwG2zWUrPfVtRw6MW0eBji7qowEVRBkQ+Kngmd4+tOPE/lMgQQpy6jTBppyZ4jf7M4wNyuA36SfaVNIu+KdXkp0WfmnssMY7l/MvRwTIGpSrAwZtlwWHbKZEqh2JDz+lbBIDtUeXdgDk4hlncPZe4YVZfchFNaxcGRiYP+D1QJ8MenAzlb7Yrfif8tnCuzWHUVprivR1TBrpHy723UEPPjvjEl9lxgA33gWjG4pB+0zjQjYu8z0r4hHcBAQSLwPkuJRep5w1nyu86O01hNx1rocaO5IdZF/O6cvm327vUBCCk5ZlSg7NvruPnynVjuhramAXkRTBIhc1vI4VAFH5KdVg2H/7nqNJ/IpyMVhpaUKhlAdRmp6lIoVUsTaeNSu1c7E7O4TBQVqOKEpthnSzK1gYb2a2BqkAkj7N4zyE+EbidFfgSVMKzrPbwhECxwNiHWxo5QxmdHJg6oAIQaXEovU8368hBv0jpEBBG1Sql71so3keSvCSh2hahll4i50i1RpMgcyRovyQxVrRpHrleq6VfHlJ9RQgCgpQPF+xtPVZ4dyvTLmjg2y7s9UQqQG2jmWqxf2NSVEkUWnVGp6KEaAE3oXfwAQZ9z84NyBv3+DIlImKpSgvt2oDH0Edxlcxfx5bZLewSNVRf18v8HzBxk7rJiZC6M7tM4JFrXhJTNevhQU0H2+AXLQNDg/9VYklMYRaJaooxwt8mAAFkzAQFYUP9tOo/Yo9KX1fXJBaA1W+2YChQLy8S+D91ORGQ7eMdw0zIHvoxdjkx8hqXpcg4mAh5ZmbUazIECRMcOCxRAnbrLrbf2haHU6uQoa1uzrhMLu+ToiVhOZUosBfmGkSlt+IxDChZBVggg7Tm3V0rosb9JysrvGLJzXDO+BuFCmN+ZYaLca1suMhf2kNFNv0yJjdrxQQgpVyMGXTDEDIZguDnZs3zLpcg4mAp3K010GBStLxyEDYHFh8ot0EVjNHiX/rpkkjC+nWYdGrR0lF/qRuKj23I7AG39GwXdrd1yyRz5gDlAxmmI7V3c1GgBoHDRYTUPoSduUDdHjK1xVSv6dmgmDAeLy8wlpktvk4c+jCP9YTjjpBP5a6npMnocJycYVeL2kLXgPjso5yRILsSvqUbuxT5HVSWDC9UpXkFsToAAIszn41WuzOfawILtVNkfQ7VQFpJdgvxrDqGbZW3wLFWnXPQpbR8Y55nNhd2JYjffPGHs5GC1jIliyEnPUFFLda9YtpLCXqGNQ7iIfi/jpjrrVadJR9LujGbDGdJ6m3ELKSmkDGuJjFQpt/sVNMnSJS2/Do15rSKWQGL/ViqDOPWe3f77Xaxs2/4P7GqWR33jOeDYRxd7bGUBL3JQHx2Sm8mTzOKVbiDhrgrNU6QJ0ow3FpP1aOBjWVhAhaYdcvacVZvnl6NnekFSc5jakrcomTz2GQFk1ZqEyn5eBdyCSoBZcfwyqCoHBe4Yj2n8vJYgOzgd1zSBdX2bwlP9WSVCy+2yiZIstcvgLK6QQOTpdHv/g+nptFKaeOgoM32NN8TfTvDaJ77tHlCND9PlVRcK/NS9gDnrBM+lpSDL7ncRcIuOoJw2WXMADToqrtnlZjmXmsVhhlu8BHOwO9xYnVveolCpCIncaocRkp1DMGb2tpYBX/hOLoxfNAB4soZuFwtHmMP2t4Ow3QZYNOs52+WaM+ObCuOUgufZ/w+WFrG2rilHwCOQMtBIOs8rUVi/953ydjSKAcr5FB3pEi/r4QL0210/ITjObFtZHClKnvPQXGLgOvkBI9lZelykjIQgH2UBu+E0DodR5o/v51SfN5bx0z395p5ir/L/0Zyo9Gkqw5uheKdJD5UcNc/blszkzG5QCE+OC+80WHjThBPKgYw3FJ3jHKTwZWA2wkJd8kAEm797EYNmg2t/mRV+Njv55H8JZHcLtgCDyPtuAgQOO8EJ376a2Xqtvr/b73UGMZXEQpqx2zDVQyvDjasTMFNU8OSSN9cBN731kvUONE0Q89+krmolenBab79Nh5OJiGdIzluxjkWta2DyHcoUKPHlUi7lBDNkJ3MSETRMLfLZItACPD5yrdZEzZEYeWUY+qRcjGfl6oem0NaPmJKJr3yMNRcKFuXsY01RJjLTjBUFSBlyTfxaFRqb2nPVX19IJWNK6qBaca3K2GKnM7r39TRIeZuysDoC6bXCVhAsa4atVucOE4gr1nv87OpxYrF9ZHPnYh+xb/aebKFVuckt3XJjMl7bVMIvjpCLUR43yBEpg7JURNcTIRxS72LOwqSUdYVTcF/s7FszqrpQepdtqcwan+y/032jDghFPWNN6rxv9MoJWiyI8Vv7DlqKc+bU//mynixIoOnEz5e75RldGJAKtt3kMiMcrdUfmTh0OLhuR311flQXUiPgrTxC4jPb6qyidPFWLrssprGI3vrdQwxbT7rcqWOcJnnWhr/7hiUH/Oam6vrLWM+U6ltEHVmvPm1PVadXBgGgu84N5eZQloSivE2HJF/o+ocrr1IpWdOyladigAiz4OOUXCSyAYF21RifZLcM+gPEjQl3bk5JOmxRBD5GvztNy5F4lsb6NcEPHdAJ7sBPDwGAdMuB/XxZL9uL2Bt35RRzLkUr2DyBl0DFtR9a+kOgcRDorwYwKRs6gJy8RsD7Wlw0iu2qw0XtA8RP3xmWcB8jpfcc5oa/fiXGdVtpGeku80ClrSkS21FRz96A5UpD5MgnLIGhPHa5MN6ewZ4VUb9v5LfZ6UNNrSVrheT/SvMAo0gD7YKnoh/jRGTzDs7hjNiVzPwwHu47j86s4Tl0UtCo6jN8p3RG8/Jv6g0LZbps2fLxjadvmWm/AZZLtWj2ATcmk8Td8V7yOGb9NTfQ11EEr+EFDugzPQiwDTMM5SjHjOMlNJmjUpo4IgKriNyx6k4CE3yEnUXSHDhOIK9Z9PygLd/osF5FGRt7bpuXp7ZajWcfkioh/O4DhXww1GWL2mXSEsiwZm9n1Q3yBTC2GKDLnY9GMJGzmOXrvbghe3VexTHqOnTKoOa8YZw9xK6hkRb3r6js9CVbVlVAN6yGlL/7AAA3DjDnaK86lUcolco6JilkAD0NqokCc+dL9s6uw8yICK/OY44kdLO54G+dFafXo2qgbYnLzDGZYCGY01oNOat/RrO2iFQUe+iOVXNyoasMIz/dn9ZYcHODIZGsse2cjAhHoiDuMK+f/jdyi7KXUQYODfDX7i8ljCTMt89ReNRbVWRLNncjbBbECLu3WcWBMiD6+KJRR6BgagtXrtHTBpoGJ5dcaUiYl7glphRZpsHqLesVIJtrh2rE7Tq1FSo5NgqaCorWlo+zQcmMhWCpW/qNqhKJr9Xd5h69ABCBW/wmMeJOW26VNGlx9XtdZPqVG6ABQcSUmVK2ERprQac2xBN5X3fcb//Cnj4W048pHmxGxJO+vS1FQ2Y4/YRVbl3dG55z+fWDbf/cYyCr11R+0GnNKzdkWY5iKouDa3hvwnJYWYPRCLBUR15+DOoHclyceM7le8rxhWLnlqocboSFrWIhSxsSJO+twbWD/lMmn26IvKeR2NZOl+CHE5xWL4agNDDyT6mCSNsKrneOVjNXdkOHxppnm1wvMz68ZQKpGU/2CFwldje96Z/ASGNt9OW8q0EzPj2Xw/VDIpNFU5luuQ+eGjBT1QcjGWWlEiJqkcVAM7JL2L28ambN5pQaoL4OlOj71TrJWdHyuN6P1lZDFuXPs70ZJEzBHrRqVkac78kbOWeNtM83jvhGVXFXyLJJq5NEL1/uKyr8x8Nzqcx46lULqfy7RhaUOlUlDDiiWJyTiQTpDjg/X9Aq7yLQZV+4M5eY6r54p+s9hPBDBfnVGlFKjEdbmiPf0DwF6a8WSHmkcEsBbHlFdD9d2XhUj2CV1y8gPtyjuA9fLm/6CX5hwXpw9U3mky/fLAmyG6jdLsxWN5gYijp+nS4qR1+yvb4Qn1f1W4sobjSNw/jWIQjafQ6/0jipeQA5e5gzmhFwKvmAhvCj1phdZTJK+a2n3VYzKwDfccGoz9kd6Lef92/hXTvYb5zL18Hm93JeYjCvYaw3zsri1Sbx5tne2tsPvnaSb8Um+2JDBWx1gkfDLwJ5FrRpPGxAgRQ768VloaRTvqUSqp/Hz4R6GF1sbLtXdHV8Hrh1s2rQFVsFisFzcR0BI3ljrCPZnH4Q4g0K67TXsbRno5oEWO73LbHxL/86tQY0T06z3qsSbOulzLUpA2QUV+ut1ecXOolBaF5JqohXBNyF0+nG0O6EWHNTXUV3aQreMC1+f2WFFHic7vgHdZhmKbJeb//g5jwJGkcxZ5qE8UaZYWEZBK8HvTn3vleBcy/oc1Xy9s5XEFlczY4fIdWNWMDv6CUN2h1S9huGoiDbI45sRfhP8LegakW43X5LnGc/P5YidVqR8CMmw94r7mHht7OpWhIpMqJXbPD0V89dHEfoOC3/IYJ8SoomAqXJvplKgj02uMERGYXCSP3T1MTsH8T+LruOWoIxWJu5PMbPRFJU65LhOii/iZRpN90bh+dXLor5mIUnYLJbcalPtZfDSdoS6Nycw8XjzXEmoj54gvtOZoKkwKk7+lG74XjTwB0kv8rt/F2hgIb3S3AlOj/I+EeeQty4HCcdagVni3KxFmJyoB6sBf71LA4/g57PKe87XYYQ0m/9kDiJJCk3kgLqADQ2AAAAAo0fgx9ggIbQKxEU3vDNPukOHO15XymB30EGloc3Ln4YOEbWOpaJ00VsjF0BBrD0pca4hkiHLH0zr6uv/BZLViI6iqd6hkQueU0VVIEFXFS1Ynfz64le4OEFnphUHAj0iuaTvkOx84a3YECvmw0wn0Yy4As6cssw3S/d7E1anLHKCNqap541oZQ7FN04uB+SW/lIqxAJ2U3eM5iCbp5WKcQjeBAAtal9a1HmgvvmS+61bO2ct3eWkW23aTEKUznfeMsYNZTb+43w4wEz4PDkEAW75TeU1GF3dG55z+fWPWCVtxKK7wycXzaBYd0Hh4V7S/n9gsZB4LCBQ2kinjCjAd3N9s2N106C2VnMbx1daj3XeSQSG8onWh6X6Soxa5g1KoSM6s3/73VH7YTN9EX80VBkBJqrCO92/LWsr2OZwOshahqpHiGUG80lZc9t6rxSx5BlZ98VWcz+4sLlBjUEWhpI53dh+6jC1wJN0pFWYHnmS0Uzawat/u/fF9ml8EdACvd9Qa+jIg8+BNKWxc3teath3gstD4GclR95KR73VpP1QprAsoHi0uD5Wi8gMB+NMc/5WoIuVLhwAiuIT4Aix75KftuC5KrpV8vLzSBr1M+DREjlhjaA85+hmpSvzm+Nu5phxMcQQqsGlhwRz/6Z4bhnw0eFLBT1AWj6UE2Yu15GmLZ97cNZ1kFJidogujtaA2CSMKqwUV9AMD280xhdNgCyne+ceSTjFr9GfHwFieC4VLcNU5UGRNohahtrlhdAstpWXxKP8sRa/T5CEMjbRwp1n4+Ib1oqv7mVRfKHb1E4RON/eQjmpGbGaL++FdrawAmIojdGnAuDIOLblf8ZPf+LFmh/d3LNlj7Rn9qPtUQl8Zl7e5dXompbS2EjVTVJvQYfKN6LT1wBRy/oRayTRwAycvOy3K1b4pZCWWObYNfP9WeWbpb+q09DhfPWYWs0QV5r+oCUDpbpPzcRX+k+zl9hEviYSW60iPUQPXNlIedrORYlQeIyKT73RihTqX68PuJALEuymHWoLJXKtcmkW8/bxmGype6YEH/JS7fCvvCuGhHNvrxZdy4YSAC3WdyGvjaSmMW3L69KJ/XKuS9qp7Wvi4DaKYL6vzMIeED9GdxeouPmT1YJvCstAj1ZUueRcdwO/UxKw3y7jrjnV0xIVhL1euDl0Yu9StCRTze4i/vzbTSp7K1WiFGErXYdnT3csDfJXOelwSLOrOOfvoURAK9VRgbEUqZGXgvwcyvSTcT/pka4lxBjfqDhjMo2FvEB/RbAUV9z9aNg4xHxiUCQ2YQ4tC6UtGw5cbXNK44w2SaY1RVf3M5hXQNGsMnP38428UbVp1XcyApGBQ0EhhfYFzvXFbzVzPYGXVAtONbXGkCXwrMVlR+/PLITyX2HDZphzYrEeMcry+/775it4UDU2lcPyofK5PZ9q0PMXn8QizmUBX/BEuLknbzabSZTh+wRgUmPgPyfa6ZS87JG9hHNEClyT1TPwSqthMChAXrJ0grJft9OW7wGAfhFD+BqmTg34fm0alvYSQFcvifzqLaAARQPJzrmGYSQK/E9rEpgduqOT61b4l8VU6bppEJOBNxs8Nw6wTwTewr2vZJiq0ptNEjOeSO3yg645KqiqyEUEUgp346ZOqned0rs4UQvYMV7oCb7PRSxhCaar1CSjgxVf2BpDB/3/ZBZLy5p94IjvxZf2hjU1jDF0P4cyh8cx1uJLG7hH65d0gLkfvLIB+4y01qEjcidYffP8hpVEjNiSyA+3N9PS9SN+J3v0vr05+GZMU/cG+1aKJRzNaF4gzoWFaUTchfIfUoYMY1ZXs34PahDml5PSnRKtSRJmb50uxt6C5NNUKiqkgSAfTQZ9qfW7sbkJFCdZEQ/2SbI0yaTXo+FhnCe6rpbgWYpwiEo2BS0hOvcfZ5eaTGyxZFQA8lK21iXEhMYTM5F5ecjXxPQ5ryBGX3wjLgjKr5lRci63Q2GlundZT1lZ4wso3naccpihgG2KqKKILe4sHwc8Mk1Ud6lfHV9CHkOc13lW6ZLCwl6mn4Dz13C17HVujZmUoC+a4aPPP9cnpP0+SRFxhPBMGnUcHCvE4tcRkbadLtCQop6/HlTFpk3VoqBtLxU2/XLGBQ9TjpCUUVOEZCo0piHKHju+iBwdRCT49Y1ISTCRSAPMUuc9dbquaX+tGKzLTme6BeBM68xOFqFIS2zuIVc7u7OoxEjNzPe/DURn6IR5eQHNTGTN4s/2N3/HMLfCifHvVD5UIw160eyWTNxcjgMiQVmylcLt/4SA7ucSmB1DUVs0Kg5oeL/fhwvD2e6lqcOf7MEjBuY2iiLZaK2VQxGJR85yg31nQZnpt3CmAXcBWQwERXBewealh68g6aVE6hrNULIcPOOS2ekvyRTFwJH5hVH9qvuNTaf9GzONghofQSe5h2fU8RGT2zY024eEVgmLzNHA8uDOXGWJ5qjeV7EmsnODcXMtoXBw21CgQ9WrOWKlDrDFiDUbZhaB896xK2VZFR6UP4+fVjBNbYBBjSA1rrwYkXn6ORW6N1oRtDurk0+urZsrgduUHksQQPjnlhrUiOKynAvwVfV1R6TRmFCCkjJE3MEDmyjcZ8K3iwxc4hPBKhxswGXRV+oJIFdfMJOYPSNREXgXW1Uu1dwGcuXAh16Wj4xdAqFHwi9g3MqQZxymBuZK0ZiCivtLx6jQf4Lsv8/G8Nb+RZaHwcEM/TCrUbR+fceofCItfb7q6A6PhElYffGCblz+UyclJDmD8KDBBj2GOUmXCeZVpd7Ta6nA/EFHuIeiBfq2CoB8SM4gwpQ4g4pNytuxRe5MIqD8OfE8/3Hs3d6BgZX9F1WGB0fTyEKR+CErNaZXFx3lez6ofNMOk8MW9NpmGI6oxSTFvg6CbZmHSUMjgLa5JKsoM4GW/nwUCG+4Ip/nvOWKN97zlj/IRKstzXf61RToLUNO0lWB3aVaqjTuYA5VRp5QzagxamwiUrdHx8IMgX58aqm72IYurSOKAUGQWdni90apa03c7UjoRqNrrs506gW9BinYSUdku9e0vPRHnG7ZiqC48ADXQGBFExb84x6jnn60bvE40tT7OttLXCVGfQihtp+sfGs2/Z492ditMrjDNBbjC2MXrVdp24pz4f0SJp2KabZqNneAWR9Oo6ZBJDBy6d71hf6ra97MGprnhRF6r1wPVp5bzfR/9ZXGerBkecmUZBu9153BTwMxXsDrcSpr5D3zMwHrSw5uA5Fkz7i3+8wDGKZ5yGJM/nfUhT/PZcTVkrbO6tRtS8iGgj4J6f3DXYMkAGBvSnMDP0sgsYtOY214qG+Mcs0eadzWgslrQVgW9f5G88PNaqFHkrTJNnTN9R+IXgJRIDq6wDyKNaSvz5Yk3Y6IkZxarVIUuEG9erufviRyV3q2w488J9CuSo4jNYNK2Y3DUwKQuBVS6qi9X3kzIG1tWxgClpgsc/u6bB5AlxAKXxpTJ1x6mJz7A251vVztUfcvoQhZ+ZGfsunkI9Xm4aaQuRF7mtCRxo4KbBeNEvrn7QN2e22nIfzLyVT6/1zNHjZl9tFsWm1fGd5TRqf3PEvfBvlEelUBFJjhLKO9a/Kln135q276Y96025KoTBHYG94qpeBI8szHz6RxMUaVLhNir5KGKVwbJQ1oYlXPsyFYcX/sTLxcLLMqTc73s9KE6jmBv8XJnWnRGKzFO1UIxqSWyAQVCqwvNP/HWdkUi9UT0hPFRd//wM8mn6BVaEom/mBIe2RCKWT4s2+Nhj6vQrRc5C2TDLB7MKiAFlYeKr6F7KJ5J1j1+YqKIrfpEa16SGz9Bzh9nxzTnLobAkBQSemiwqVuOSkUwjabfIziHs2FWShAkhDIEPHLP98w5/4oCZRX4LeQtiomhOWwOM+aTLBAeP+jvIoNuEHHru2RcF8+0E3rbsUhL+d9w5hBY1xzLgsudRSof4gkT2B51ZHbfNkD+h0d9k4TJztTIMbGSwCK03SqvSHHiZDDqpVbbmefVBXdlsvdieyggmtSVyKlYlCKKdC4UGQWdLUqgV3E1FQsITQ7sfnPHQ5f6mJ0EMuvXDaVNuBIuU7ojzfrQRSswPkQ6JkzHNATl1x1a9huoSNIhVodFWV3hVQo8laZJs6aOX5v3NmMWq8Bsk8jZABa7U9lQ15+6lppf0yZbbuTAdDNZkA1kMNJ9v2pp141Tu1sxh6dctTAvFcRUDkCwdto/Fb3qFtvjC8ytiCa9TxvVbZUxbgueMc0HcJ0tlnvWYP/sXpZRPe6dKKJ2TMcfSgzV80EY4qSq4pK/m7UW2hcOzkOxs/peeU8y4hnBCj+pKWo3Pl8BqaN8rVX4SmjfK1V+GmcYb1q7iIKQ0WyEAJDcfmSK7nJNbd7fEbYkNqIAFJ6JohqRPbXmErXG4X1UaIaivj8G/ExauI2YO6vYYeps4LAmQsIQouo6UP9Q1THyr/Uq7ObDijNNTT/OJo6lP9OHKrewHFqeSPUS7s3NbAmtVQ4L22ash8lL2YgBH3WD95Xfo1Qt87jYLSzG/vtEr+mgwH6Knrx6vIAqtKlFO4kk1YzM2o151qFN8pPXydT+YjhpWJQg6Tm4FjKSuaq52MvI1PVTuagRlz/kqzRYZYJCAjyOuXx15BTkan9k0PlIekHk3MuzY56p1M9XPic04Db64RuoO0jGoF0oxyfjnjxrhCZ4Mn/jFXv5Mfm+clk9IrJemsSNSY2KNQyh7NlDAulL3N3ZP04tzvqfElcvHf1VM/uyMr0NM4F41t7GfDfl6rOsxRqiNAsH0OD6jI7isQyZI6sk5PfQ3yydrgMJSz9fapj58pBWRI1mYrEFs16nnnllKI50Asr4XFQq9nceHf//kbq4v0YB28q15w+/IuOVF7g+E0sva0wYFpky9uxEmkFYQlt63Dj5AFHgivtdzYW0vJ9RFCDGUysPPAr2NsBfKYakZ1TI4U6FZIYbYTWkVPD8jP9kHns/trgtG8yYS+c081CbkuYatPjJQ+nBEdJm0Fo3Tulmc0HNwmfFMuI90z+tJ7eeoMKCXDu7JASCV1jGc/jJvkZ2Jsg0AHElk008SFjZcdW9vdAvjySoYr/XKGsm1jhiGVGDbC7YFsh7PTWaombx9Vdll1T2GjghIFRkW8vnp2Wo+Kx1HYabhESP+HE3NGQYwk7uIQspW/gd7odhvk+X80L/z9p/PqydS2sqw/9lfZLetxMjO891FDaA20LhClVyhsGo0i9H8JCrgDW8kxrWFnJOf4JHJBahYWAHiEK8hBOa2D5669sRwO+aQo4xrZXqmp9K11F4jMbCJpMRjQeLFwO5LrYMjQ5cvwd/p+uB2cI5yVKvR5rSjNYYw5jNGWjhHNZVqOBI4U6EeWnPI8fNCm84JVJUzpvOIjfw26hIppK9mU+v0Efl2Vmc9McYyRcFow5vG2C65tMyX0u2NegJ4ScrkL6pAgyDuQThpgV0iUWsfNO2AfByxX6V5NWQfl4gvj8IZWyN5M+yvm1UqIbkl62f43ftV8cS3ZasCEkmalSTLZKw7prNAG/IhSR/Qt714MH9bpy1BD8h5R9HWCq4G9dWIQCBl/x0qaQJvSVvdE0LxAM7M7MQlJpGo8TIv13tEsOW+bbM7aMK8cjRsTwvCyzi0p64iGNgIDdzLwQvX5oGs2A8WZj/6/tSvcqsMLKSQIT/sUpKuJVVHGE3g/9xDHUAHv4ojBMefpVfTdEnrJ3DIk+nA+3HkiuornP1wkzDESUDCVo86ol2y78tQQ/OzRbgSfNTz3b6gMJVuGlgamVq4TPUV2I3kvkoEHJjRZfxOivdDgZa0uZqqD0qUJu/+Q3PfdRQXsqYDYlefy5hsvVEQjtkJI9uL7iRvSKIdiN5AzGBiwx2rSl1PSlIGntHMT2lPpY5vhFuynsgFoLiEb1hOYmEX9KQd6BZB6Lj6iBu+tzC6r4HmUvn8chxBoAzjZZcYntu+9h5bnMF+z0iKgBiXfeknDco4JorVIESd8Mnr5G5fvMLHY/ITtrif1S3KkAOUwvU6mypy8u148xx5EFbUoCOtiNEzqlbnN9uCSqDQF3u0vV13dL2J+CxxSSfAuOnAPi3ptTfRufdWops9ZxbJXNKFs+/mLVP7XQVlXJ176jNu1w69pvacM0L3+Xapdo5XJKT8gD9aOclEkhvI5O5SGtDLJ5u/6l9k82jqW9GA7KNKVCFX7P9FhgFIDf9BzHaWUgQRUazff/cqxkA4pn6eIrphGJKHKAGt2YkbbYDoZXhdA2R6qKoU9uv6BbbTZMJTw+XZHzNLvsF5+ZJFx7ZHcUJHVz0CDN5PHVL+X+6d7aBbbTZL2IlA1A6xsxP4f/OaU2pCP1cxxp0SbU9av1WE5ZOjsXTQMCAGEBC7uDw1ppxp/uis9SaPNTwn2R25MEUH+8SMRDFGVRXZOHNJivYg2Wbqs12z6umAARXAxz5zH67QEhHgYoseMUkF7/HutUmwzsjJeAQWgPYuUhwLXkgdfZeId24Hctw+VrReKwH0tc2XUF+jlbCJjyXn8pwP1a2ZcIE0Ym/2Kg/upAkUCW9/XjCif6Q3aZI4w7oWuI0oFz/YfsazxdSv7igIUYkjK42BIcrsJOIXp+mjRtzqNqXkQiQ1AZCSqPk2nc4LixR5xLsebKW95qfsonjGXe7EZaKo4kTq4up6NHUt6MC4RpSoQo3RdISscM1UZwuu3I5KPkBjyZATevSN8BFVMGqJMtzB/aAIiUxg0BebwvqV70CcNzTQMIteZn9FHmSxbAACsR1sipzBtBQP5nUmdcyIjHwvddyjqEH93xpfG1XDSFYJLXkV4CG/uDTO3CA1qR1uEHCRtW4eIkqh/e6fmdz5Kla3HHyfpXSEQ4x0Qc2L4fWNUg79NoMGx80xVZggoqxc8nJjCM5uamhn3Ivo1KZEXOmGk4q9vj9fOIrjA7/MXm9+fWYFq/44rcHuFy4hydy/0xq3HinezEBMl25VgccYh1gcTc05onQLnbKt7Ys3jHcL16guWMK9cu1UsbktRyupMPFXqD2m+avSkDbBOIrDEUSxFbhLHAMHiYQaULXWlVWT2jq/cY0ejF2oSpW9Kwf1Y8w2epVsA7Qg1Laq2nkfeFL9CjEdgMdnWOdqoXrdIyyKtCXvFAPMGPA7AcFA9cKc5zyScezDLTg7q031K2jMdF1VGSIkhqNZFKBewnxj+hSf9p51p/eDRrVZDFCn3kn19gGtFZtYDZHhw44+DAiONWBw052gm8qzL8Oh0/WgVMRmuraJ3sxASktK1Qx2oCOMtREDOGXVZV6vSwHABqb6cdWVq61IzZUrQYcWYRNNXyBx1mUC4xXLnGeweahtVKIFFoFQcTSycZm3udy8BOCwd+WKHo+f61+La5fCyQaNtnfgqsanlVt50pHQUIPKYLx7+D0cuESRCJ+3khprl6oFqNOwC/Je8zvM7KhpokN81QoAZ+/owoCtVXphYfmHJ3RXq4fN6H1ecIRLqQaxvnv/HgHkEF0G9Ho3JkNaAuSkrPwlgG/y97B0YYBEbmqpezpAT3b/fjgTdWC2YfkBmOZiOrCi9AEnzRSuseCxVE75s6/ZvFCudemOTRMbIDqG3lcoA6Cz4UZqkIwLa2ecfAdrZI+t3h0mM5wVLSuH4EeCqa4jXuls0i6Umb9G4fnV8k0tvvFQCnl+F7rcGQptVtZg8/OVRBpa6WgA7n7lY+ZZI1ubdxAIB6zzg+X4+2+ILASGWduEZJrE90drL3z1dUvTrshiFCogUSsZUgwIBge/tiyG2KnDwPLRmfgIXAOD3FJXxbAa6xWCLYdXy49V9iHQc+QrGjGp/oRD41IfUaPBxRQNHQuyqOpA856dYnjYursjNVCC9B8IyM8cuvKUO4f5kACkpnoXW+L3NVRiwyn3JKa7GDQZGG3oVDW5WKS6uilJ52hgforTfGH0bVqOmj+iNshWJ/G6/ZNnsZktUSEUHNRAahLpOU/gebbSaSZRD2+PGlHztNX6GqPQEqbD7jRlTZWeagJd3Upkm5SuBOWoz0VVdl97fxMl6XZU7eZG8GAWHbaXvqnlxE6MV7tb+n7VqtaZBsGHFsiWowaSy9m9GEwdUEv/tWxs8MD8WZxULned4kMvYhS1kSS/8eiLzgLHUwmkprt5ifzx8uP4Mu4ffxrJFF0bIzWq5p9C5bkxfouobANgl7c7cJuvOmhRKPaN6lWofO5yAARr+UX0XnuowVmJ7ZA4QeIjHcokUH7V2rS1LBvC4d92w8mi2qwP0WAczDjn5gjqvPudhwETE+Vw1a1ILVD34iF9jIgwGgLy4r1iT3WKY0DlT2xCawNSF1+Sk/gy4a0yxFay53WVYAsgWjDJKJPhoBgsAlA/4WdrpoWik+2QA8LqNja4Vz5WY5psIDpJ37Ka8QKJZEf5WPskDsK2aXtdj9o+ieb+yMXl9g6DT6SqViNvGCamkGIgGnwsWihytcYY3LwQsfK/g1SZ7sv3vOn+QrtgmBMkeXE3TPUqjBiGFjLoty3QHzn2JFccWPOF8W5hCJ62Byx8xIQ+R7Pc0mNFkVIIT3I/zu9476sDodZliB0tRbCaC2zHfS6h/8qSKd1/2DmkoEW3Ohs2NRX5k0nc1lBu9wmBe5x1Lf+Vq909hXUAwTw0hyIBZLguaGAro0vjhJNo458lWf3w0X//ZeHF8vHwVITQCbmKnYtjKUXq7BzJHlni1/sG0mA1wAkKkipHLwKr/pJuS+CjgmiojoOraKybIWwCor9KzSgCAwwhEcpVm4HLCNeUgPQ4JAkdMKKFxlbtPc4RUS8XjZArNplcd2sKDGaaIxh0ocSXBMgWW0PrueSRxhskkpuWJREOnBy88WXBFl6vPVulZGVfmblxe7XqJ8bimO1ddr3PqvFuX9pl00pX99biu9o6L6TT+ZKZcVQivNL9lc5RbrORUdNXwcDBpICIKY7hYqmzvHsmreBIKt2eGkpbD1ff9S4Vi7w+Hzf9gznlGmgJH+2+TVhoXpDNnWzp4ns+oWA61A9VXufVTW61Ttu3ocgPVOMwxVCy1M6+/oYZhfvLt5ITDbIassET/OD43nVagokAWl8xIl9hGnas9N2IkJjYWSMuxVKeeoXXocLsK0vUskhH3UGGQKeTCoJv/+WFaLnE1c0oPfKDy0HKvCQ4+oppsnOd6Tty2G3lHY2D69jOdJZKrBMAFJDWDNfd8U0ZGZXA4aqPPId9K9Xx1dYOT1My0f85Kgl0khssSdKQzx00YYzeIgIyeTaSuq1EY2A9CDc2OHpY6WXOjYv4Zt5IzT6cVZu9NigpUTCv+xA5Ac5CZ4hGSBxvf5c4052kUUDxDl7PJddijPYnOYJx2EnfrgacwU8S5PH23yv6PyMjRSi/1UC6/4hXJrv7cIil48IyZ86EzDHDos5KbjDGHGBD3/RxMmkxWd4LKjT/6tMvBajWkflUSGYEbg+wEHnLSTABYjTJuyDWJYUiSTOQFbn73pF7x4ANX15R4W3j1RtEIk5TWTo30CPxgDvYJ7AYMtWk5SKXJF7io3d7GGGjIOWqgkmD78i2BtFPiDXB8F+rmONLZooIzXy3oWFpKwzOgVooqZHfMi2NOsgk/FA8VezhF+WI+I14tONcBb1IOnypdRKOAdaItb9OmbF/RF2vXnJSeCllNRDzE7QaIic4hn9iWUgaNsCY52X/F3UYTG3wApS2P5dw//vo2r7wT08bE3cOfUbR02EU5y1uNImPgnnfsrW0LlMaZ+Nkxcvy9HE0uEtidvNPy2Fwy4AdyKZ20JuhpiV+1O2PmBcZM5+jqnzvw8vTHyDY1n9UHVUpeYdnzp86m0fk48yG8BxzRp4t8C8cl1bsHC2a6KhNyfkgxjuV03fGvsAJSyHxdJvw4WE5ZOlEbKG8WmJm83bRvBQ4Coky3MH9hAWEEEa7PuIGv8RPSpYyE/zcjLVmuplVdtAqPtIQnsrxOHm86G1WdM8r1Wb2H1qoguC3wL3wh7ztFKTrg8W29aCJYl/apJdkCE4Iz/PVig+RyOHl7wsU6MuJ3R/JIARnhXL2QpRA1+HB9/vARpdBgef2hYiSXFskLlGFWwVfkuwC5Ojoz/CE0K57a/NVAf/nzVXnzl0yu6DjpOyeUp3nAGE+t7akHIQ9ycw+ja9EDwhKb8K4qmWtWJf9NBCsQimkHavb1JhtufnDIunuqp1yElSi0ysY+fsfC6KbfKorIEBq6z1cw/kSXMMCDzUvhikE7WJYQRVqik2CSNB4prfrN+S77o0Y4TD/DzXaHgcULmpgtrZ5x8B2tkj63Wz/QI7LC2gSRzka3bAdLQk0p476mqYFxlTB1PTgqbnauHxHnukoJuFId+qEeR5bcXBIGnHrtmQfxzufUm1EZ+3jAkHH0v3uJ8Z3Lizjo3KHvTRhZofo389McCmLuG7LdiMafx/edsDB7U4g38pGeG9RxytShjKkvP8ImwN3BZGu60xg5Kj+p8SFdTpg2k4X8ywdqRJ/uuJKB8oRehXYWdke5+78iOMl82kGKHo+f8Fe3aZHNfQVE7qMog/Df6SEKBR1+5N/YeOYzQGSNUtX2kX4OI8zbLehV3ZwGoBA3JY1PwzDZOn/iSoO7E1/blDjFzPUJunROnHgPccBZ5gUcZGmo1mdXfe9/qwPnrmTvBhGbS/E+XH94UX+Q4es+Aq8Zr2cYlhj8qqcvg+4HcTTcuxBoKyOkXvhAwij0lXNDKqdd1MLXRHDXkNicPO4wHcjZPVOEIbQdcqPGLiJhgzPWjDPaBwVI1wXXGk5t7Rx4phk85UhpPL98XQidCd+84CBncNrbRTooqg0zb/ZVX6W3ktcRI4i+BtosZyJuWIFjL4qVidYFMnj9FCu1b5Yd1akq/fAohFDH4hb3vVSV5JscAq5cr+UBhYJFzlIU2jra0QedQD4+qUh6n2XtRis6n7yu/UikYQ0vcNTY9TzrbUJros8/GGHJS+SNmV1E0lBtvUVN86BLIhBAdjgSABQUuyL8HEeZtlvQq7s4CSfpj4zTGO7hBYVF6pdShWxw1MhKYbO4UxnMz48An7YFKvbHj+Q5HPp5ybaGrMBN7FkzY/UjHsyLU1UCYZ1HCsdNHsIAQCf/sWFi3Psw/yEn+3R0zNbutor6/FP0nhqL69EcYNJ0HxXCm/TY+1amXi8BJRzZI6p9l7UYZ/9sO0tSNgFbKPo9Kss9lKHrXn+PJ+AVgAK6HvDxzwTzK59l0AgAqPUiq2xKXVuujdKVUb9AGjWFwGrQZhc34c7dhzql/dfsgPpwHJx2oVDzKx9RKO6SzGxUaMy2lTHvUhefWimyoePQeKnKfPOOtnWOkbhTSENIUGsY2p9+FvtqZPIQutLgxSGj1iol97f5UPEobcY/CrxpJEvdlaEKO6gc/YyJnlzDXSIGG6cvpmuPIx2GQPqXrjeNiWxs8r70z5dML2a/Vf0ROPsCnrrMhDrK9G5XTy8Dhr13ggdgUHZ5/xiXYKl4OzYjYAvk7KmrJocyScaS5S2bKJ+lwxxeCxaU/qHGjvPK7g1tnm/81mA70wV3qCi02TUZryoIg+pTjb2uBnPlBdWeP1Puxm8uO2N5ZkInnCQgbXXRknkkrd2T7HxyTfOQK/9asYGVJZPKsdj2X32nougipsXlp1HSh78MjGxKmAAzVSwnOaQCo+QAX81HH5mLJyajtTs6SZbOnuZmo8q4ADwRcaWP8oLX6i5E4gI9XNIgGrhatHTCuVWTqDG+7YYOVvB/SQllgCD23zfwoWzoseAJWhloy2E6dl+3h0mnJhg9DmebIWfTGIOLqox45nIjboMAXgtLwdSSstjKia3Sw7l3mRJm4ZvBD9KhfGI3yyCHwrT9ENUsxhLZA0aaAvTA/fBxVljMiD75uAO3+SbE/mm3j2S7HuTkDMHP37tnJMgiSaw3+t1lYoPEYLiaEQLwCjNj2OeLpr4ITbVNdW4nqR9JNYM/Vf2wrhbjDyvQ5IZlc5o8QPsdMEsc7BvopQRn6FXgiiGnNgbVcdSBMdUZRzuoxoHNnjG6TyQG2wteV/r/PODgXz6oAv4fLvtvjDLgrU4iUzbGnN/Jqn+5rptkmSitT1sQXRtk/1NKbjFHyI6UUTc4EEdZDDrdqwJFsvpO9J0vYwqH330aDYnu4PNsDDH9Yhkgs6DlqkKhonk0psmDVNbw6ojN49yfESfTsk64KaphUBl/xAlUkkVFIeZMRkieqVT8O5CmMVda6ZIsAjPTE+SPW7bMxrFXL9MKvUORkiKfFpMo8UznR51I3j2yQbtKng/zOcatQvotraKSVghL0obuCZ6YcOD3+R+1B3Tam1KFPKV/DuM6K2/pF6x96/R3hrdxQBchyBeKDfxomY9E6BVSrPZEnCmOGnngXtlEZva2L2RNQjlVAcvGgF9Mqo2cNl5xSQ0yNXog3td8ashH4xM3e+OhXZGu2tjbehayTJ6gP9FH+/fvQNLzmePH5jmzjE7JmB4kD1IyNXI2wi15jC46vyqYeFaB/N/xd8YBqaXQwPkn6qSxvAwkZwH2WJYgI3jxdRy0EltK7Ie+j1IsBDszXczlnI6VzR1ieGa9D/MFlo47yP/msgBMWL/btX+URA2LyDOCk2z/aZpkSU5re/uPZ/06IRU9HVz0CDN5q7kwvWwlWQ6x+nJPRRmWFBUY/+VwDYB3EYXpXIpnT560nGfEbKep4BDDvOg2S7Ox6/0SQnzmRNR7w3q0cfZMwuAiMOSSSH9oWwymKJZ0yF608iWMN8DtCa0kgf2V8jDT5bDg16xo+P8IiSqFMIm+WaYiMXSvVUQSSlkuhmrr8acOTgMgbHQDB77rmgbV5nqu44TIF+emFRo7qMRfKEO0iKl8q1v+BM2nMfL03Yp7z51No/JstojjCLKMBEE92zFKx17r+F4I8hNZFLjENnWHWSn7S1VfXkNrpKxWERCTIPQ4uOlXJCGL1k3x8azcLpTqudwvPg7dzrROMOfVrLYVIkHQpcRxrviY7CSI9gPheowmNvgBSlsfy7h//o5btVXF7J/z2Jdoz7D6bCKc5a3GkTHwZmp2l16uY89KKVlS/L1kAMvkHAbVUdCgzOuYWd5KxLJOLLgwNqFR13b6zzjTqdLIeHl6Y+QbGs/qgbdW1VPSBqaTOtJD9fSJ0Zk03AbmLwY4v7yj+PiNnMDu2zcwAPJDPS//Z3OxRibeTeLpl2dVVVoqHGcfmjVdKgIvszwApLiGnRPcNCb138n9S8FgOPhqtskbYmajO5l9LYvd8DilhJl/E1hRgyS3E5cbDs4bxjTlcHjjeFBfjDpVeY8btjc6m2PMipRHnflO5EOKevp0AAancAd30X//1fL0dlvyyuxgnlYp5jPsQ3AYisOjDNbsDIH6ln3Nl7eZQmPbJpbWBXi/Jdj2MzCBzBGENSFYtvp1gUlHxQbt5om9LBm8nU6j5QJOQAXfFhGCzq0buYvBTWV1tSrjZNE8CMBoM+R1TXSK097bX74j8Ph61XL3okYJnZb1dxTR2g8Ha4i+U22nH6/fYJOjOYFPH9+OKx8mMljOae26SakOnZ8T2eNmRVGKpvFpwgHioaa33irLP8tHRf5Dh6z0tLPio+3N7jpl6+O0ex/9FeZp5DfaO7JC7ZKM12JVQ/OtSNFJfUNDIrBR9Vh7CuEAjLUKBGVvTZZjHIiuy6Mlqx+2p6CY2ERd80yoFM2c7XTJkCYHzvqMraASQbAN6Up7J9UFWSIRmyHVZ+JzoXJrRGfsVpYfTyhLBPQM8Dxa6L49vN3VVjq9QzneHW3amNYPRaZAEMkR/aSoSR8Frmvl8ugh0wzqfvMaVdLKhGbGw0bN1F7oVUnTEMDoC2K3UzOaGoMxj5du7ciwCuUMzv9+Fa9+ujJj/OqHf6kGe0kU7mfVXFHpgza8PZwk+Ak1TbCl/bxt3V4bB1DOdI216/7JR5qDtp1qU72JaK6vv+RHqfZe1GGhuy3ab5Px8oUVvFnzMb+39NHo2V1yPl8n1/VQMFyIpYiL8/hpaLuBLFveb+1U09fn68wIAk8gwKSA2Le5/czo8XIA73+nkA5yH3gcRoG73s+uGA3q14dcSAVESqV4+zvt6NRDX/HL7heZQrbiM17UvQy2leDb/CaWl3/u6+5goGF4cc324KJiuV11VsSGSMeLtPsegzMGj60tpqjaOkFKKUQPvgcZNLrwQlYYq8BKgW87r2wjMo3LaWcGjM/BUlHTNu9BTyAvPLgFdkB9ngcxfUbDb0ngNDtrDCWs0pgkv76Xf8CsN/w3H85c1Ov5tC21EBAqNwMd9XR90gpTURgWVj5opOl5XfdLh59RLOY6CyO8yUbX5P/agPh0JoiwUuua0cvZ33KdY8dEDzOgTeqndE4CdQ1dF5k4zI9Ibsx6l/N2goSF8egVCYFo1d8/Dpg5HfmdH9kPbJDs/ojB8/1FOxi5m4oef/DvjyojHK/SAvL43ipJdJF74PqCWFtAV/aHjw0IUczaigldkcWbHusArvz1ebzcaqQ9pk0jmvcpL1uf7hMC0aGG2DqPA/8mpmesDz6SGURNCW81bECySobbyuZZy3zHFj+Z/DvxlgOnVFhydxL2nYQD8CDbuvCzK6mDq60UpZcQCnkN12BhDHlTBMR3zk4We0aqPnak551iZLMSDyX/1pytTyjkhIh/TWk03OGkUIVVbKOiCGZpjOoVzE0DcOVqufrNLJKdl9jC0UWy5we3rHfZsb8LUxarS9E/8GRO1tcbDbtpYgWNlTca88HP66duTZVNliFWbdIsjlC0KS6FRhXp+k31UmdeskuwwX2m8QDesFSr0s2KjG0wF7e4rI2wiMq36oUxTL0vuTQAgMjBq+WVgCH9qmt/31KpJy8SZ6jT73xcxNVGnTHNLceeLe3d6IXBGlmYkGVjSBfozG0Tu8p1UONco4mqmJFTWnWEDQ4hvo0/l3R1KMv1dlRh1Vzme4mRg3meZUYkhPiSDRjrpnjcso64LVehSSPymNjLa83KdSPuCxyjvhSSvYfMc5XnNE9UT0hPFRd/vTe71MYnwTkGIhVv3mTa10Hha1yYI63zQRvAN8JZ5He8Gi8oWyy5oL7A5ngBJr00RjDpQ4kuCZAsumefXLWtcXBmJZ6mbLU/9mLPRkWBli+q/yRLYer76nFTnIQHs5u1rrROMq64yZeDuha4jScP6ZMYWhVt0x8fJfaSedMKG+9jLLKYJ/uMXjy7kf0nly7UJo7vGnFOv6I1j90HEZCK/FD+sr1c0cv3v1S3Ah9m0mrfGCbUC5tBzKEyv7zIJRnWaKP7YDCS48D+TuMAt1kD9Z51BhBCHJ1PNgmHwIiHVE0h3nGvD8VfV1NByVjjg3iS0OfHZnMbNqWNHRLAxpRnwpxaWo3mS4vT5ZmjN26VdP7svpH1HkpCt3ng9eqwn+yVePNNrZeG5j/m5XJxVIl3a/6N67NV8181wVS40mlizo/lUWo/Egn7ukAQ1hS7htq12ImsEYj5eUPmaeBoq5edXyVFEz3gSOKKwf79O3j73f3htAkTE6n9kDQOpBwOMfdgYcOSfsE+ZSR0+/OEAGhxp0z4zpT21WwKIuKwEL/uFrAGQJbSPChmJF6dQOkLsKtle48UaAwjC0C+pr58berPozgyO+BjvQ0qVyylmQcAsSgC9O6qmkKaGEFtTq5YaeYO1N4DcE7CkMFrn+FwWaSSXDPPifCFxESE2umB9i0oY1g5weJ0wwS0s0PLyyeoY3wVTcCEJaRhoa6ukBJJ4hekMJaVLCIB08KuGb7qwD137d8IYMmJzgEH7t+YP6t2bmUNA/othZAv54WeoWd5eic3LQvQRj93yyMKSC0WYXZgGtSvc+miLiMmirhfekM7hEIb/GNHTvQgmCKRfRZhToMPpQlFyf2NmMVIbIwvfCGYnPQFoMuyR35BoK7qtBnXg3rUTpXEoEPMkI8Fp1aU1raFymNM/GyYuX5esgBl8g4Da52w8D+ixeTuNaaEau0ebH8fuUfx0VKU2VZKtwQpxYZ5oCGr5oS55OnrF1bytfhDseKQ1HM7uDEBvgq5yWjn3FgwFhY9ya9NEXH1HuxuzEbwp+nQ2XO/QHsXKQ4fc23+1aB87vv0HJRW/CjetugtPnIVbTRfPZ8I06XxbVtgOUOMXyjJh4l/dFR81MkvkWbvd9OVrP7Q95cDFw1xXXM1cW5abk2qZkg/ewnq1cLW4Vm0z1GRvaqaIleiMt0nZmeGzTUXpX2BDuBgr5mC16T9369JcHwnwhULFGHIABovnvDotGTvsI2V5hyX5kCeuxxALcvQP1GFAUboBLrQfOkpuxeCudDX5qee7RXQUga0NUoswIwsvVwfj9Euef/ahXk3BisMtLaMdwjsHy7/22BJaNhVMDIRC+/KKxti6hwsPw6Zl58eCgC/M7nUXODqqRCUwFj1MF+LERgT0FlVj9U1DaqUSsHWI6tbAHyd7ZbPP+lXB/MCm/tJFakBZ4QivKdcIkYyMXAEt046R6ugC8Gv7uSdjYxsabXGhMF2gIj2k+bkDKcdctZQNkQsaT/YDNDw+YVvBejiSJ57fIGBcZ/zVrQ9dX6wMAT3CWkD8CuKBPrt+qXNdzf+xINIbhb8roXgEEH39MoNpKGJnxoUt55EKCO8YFPEy++5M/BgROs3+J1/R2I6eo3z7h5nCICHWcakXUP1hhIN93TJ99DHmiPtFmzNkEg/6g3wSIMlLFXwkd6pbvtIuQv4psthGk8A4sblg93sl+89lHZKV4dx7SaocAiLOfmHrafSM9l4wNGUaXZugPNJfCz6JaXDWAhYxENbxDIIcH1GHtxe4cn9nH7zG2GtQ4/VZ5r+k0j2yvwDzWxlJjsblDN0S8CScNFdQHE/y3Enf15oWZBnzSUZ7NiGoRty29zBDNo1z/E6HV3YA5rtuM5ahcsrLOp76S2lbLx2VuiR2KqVRh3JEUviAdmlnSSSstjI9bCJsCH2iiifsC4Jx+wDuaYKx8dUczlKiuAvSZBdQKa1RPH+6yUDmLrqOeKu7MX5ELaM1b79eWq/L6NjjRsXrmAXnTwXhvw23LDs3JpC4rF3axcBY/rlVGLIxNfkCXv2OAoGCJP8SQc1PLmMSiqbx2zfNFh5dJgwlG9M7mNT+dvjBSaj5mxvp7h3HxdVT6zfvXbh993aNNu3HSGOezRM7PVftVc7bHUwczAuKuv/kgxbt1VdhNnRVTqs/DFEvganmuVU4h6c1owzRDdC9VnTu39glMd6GpF/lUlETLx/xEXfshOykR7t1ZQI0vXc/KKjZ2k/CEWyyw59dsA2DB0m1TlZAZZqFyYtgJI0PbtrM2EpU2mf1rIcnK2+YwBPv/o67AZiozSDFhk8b7I4I4Cxqx5AgMAzENT1aNGnXLG4ffAwa6Qp8xUDvxGfJ+JPn6LTEBXOAk1kHgqjnnYyBdkJyHIodlS0W5Z/JB4QhR+tzbqLQgGmdbzT+8ZwpD2+m0ml1pm3WZBu7WUWqspaHv1CoxjrcIxRze5fqqospSPUQPb9TNGcZNV5Az1gCFg1OCDr4x598li9myVkCp+flG/DvmJCTNvSaxhfrBY8OmqFNoKH/4Bd1zE13PNLr9kfDC1msrIKequfMFHVkC35q4Q4AeKBylYMgxiBPYASrN0ZerfLh4whF441yVm7g+CsxN+PHY48SCfj9zuot5bRanwHFQuJv4H9wlglgX5lBHmxOCbbopvY4Cu2wwHeu/bQ6GByHIIpwvXiNlR8oLEs/gWGEGyGS+TkaIG3Pz32Tf95T4yjHFKAHXSs2CGrYq3sH1WrXvIF7msokrWNMkiGkoAaoAteWNRr+id25kLT2K5TXVuHdxiSmMJGH8sTt/mkcGsnwBn67hy4rVItM1cjJHx/T5AEBWiEOy+8E0pFPAas0ZAO/l7MMzozQGApPbbZcFpwbOqspmbbDMwvVTIrxn6VuO4kA+tfvSppCak7CERAyHudfEj5TysKZf4e8xjwjALzVMnsdFvJfVojdu4M6kTLLxohRGB5hse0k4QWEYURWyeG52HKueuFyN6XeqbSqoErNOB40/AeYLZjWR/c+wM5nyUojTAoBUNp/FWwN/R5LC0j3bpCiTAZgPpDiaR/2SbI2yNpaXXKN/oPnzXySp/6jw34bRqOChKHVNK/NOQZpU5o1goQhM2B955dDPyww02gjVISVLPijNwX78pDgiQ9Q+s19GOFBfMpSQx7QDZlICFE0bJHHC/6AWsQ8kFs/nCqN4O6HWLfDn12AH0fT/p/v4ZfaJk6c/HJ2XK5f3VvxIk0158TQvhgrTT2Qv/9Dt6icIOIdzY3s+Nr67Ko1QdZp1doI3X8e4ycGkyWtAnX3SChkbYXbMWjIgqi9tPwNSzqSLGq5Ul3rvE6kYjRzzM5ORLJnFFnsZX2PXC5JPpJNNNoEHLe1RojqKp1cNOfPLmCNNouzRYeXQcYkNg8baZ5xuHcsTx0MQKUU4nxTBJVYImC8MEAwTml0s/CA9y4JKIOZwZBoBSXjRW7cyUrWdjIDW+xDhc9Z0a+4pXFk1ZZYW9tCmTKpZ2ekuomurc0BIvWRI90Dpfx3ije9zovAI5MjraVaErg9tFnUEcTLBMAgMElHnofy7GiOfsDdNTdqPjaE3gGFL4zuFwybxW1occBKtACrG1QPIyzQvvi/YMHMtj/hPzBPsAxq09D46pW46T3NSHZJJheMZp4v75MjhL0I7WUVePFEUmS1odAyffo8BHvj6fVvbXDDdizUXG3+SNztGC1eOrsK3qU29WVdqqa6cLFaeLCvHTlR5bo4mBjOori98rSYqzKLxC8FQz948LlW2GWt0W23gr6WoMkiAsQqwkKTAny9DdCyJH6KFu5g6iXznU2htrAlUyMmIanvY0flE0sXaaNkomz2k8HjPOeekd1nUh6r0rl0Y3VS4ZTWww38ij14CGoSD+AzGTXCFdndB3vnibt96IS/rVzWda7z582LgSfj8WCROsDc0HubFWjpcVtiVUcRCK7m1FG1OZxRC2jiLyJhmIMv8q37daIgB4MrdzeyD7YSJa9n0b5P0qDH43yCzsNQpTCpr5cT6xCpqNE4zyGcmQxSgmzbLIUlvN2jd3qAhCAUZqlNbMwoXo8H77yQji88KPNE4NV/NT3zFo6+S9uCwCK+bTHMTGeZzXvDvNDbWaKNpwQlqnXbBfb04SN6kDND0rd3kQmh7rxbYe0OKWhwowocVsXQXP7wQfrDbz5Kw3iklroosia061tJcGTphB+DU3kVj5LnNcYsNhUIByXkvebKAdJJaIF9elFAdyi820kn8tYkibGtrja4tvxahoWlA89kwqgW3A+y0G+6bu8ZcC4X7b/q5rZlajpCYjW7fW+35OjK1xqWrG9I3+ap2vWJfOK7GSh3f4yJ/ukL08zES2FYMe4dxBdIkoDyJsAVDNx8bbzXBd6iF4TNNKHUURmD681a4rJpVaYW4YmvsuiC+Dhfj8Nlk22Ldqs0Xz3gLxmpCuS4p/LGRa99IY4Y7k/EJtb3wMUiOQZxb0VZ05ZZhul+72Jq1OWOUEbVLaQYVFgwkICvVs5dI0sxg2JTRlqlyli82Osr21YD81slAp332JosNEOB54pnveQXI9IP7xZKfOnCgdcRxlYwoAztAEmofJVs3PLb3m+oA00cxMZdEkqGA3tKu3utQUB5s4Ckue02khjlkH9md6R8ng1KOf+ZAI+8wh44VmB4vZqvD6kb8TqpJKJS7qpoXkofLgjCLRRrWJiBaix0RmgZlPlm2R10cnJjoB0vkiu9+b+4Z2FoNV8zfFFhBUUGxCDhkvDPUyWAL05orIoqktAm9gu5EZdK1xZvhos+ILv0CF4l74GxV8YIwSaVsuAcW/D/Q/frXGau/wVrEuKbGwlI405faQWSazWK1wvXRrgn9YRVi4m16yyWNWix8+l+0ynInT2KTewXcbt5Z1h883fuKLZZ7UmU+WbZHXRt8DWRtMg7eGRtPs7FH3PxV3BcztFWll37L/dFudHdhOmitkYuQyVzwDWo3iEbhUwYUhk1oqq++3QTogmmQ7sFyB13IVFnqASgQtZdAZWwvG4JMd8rQGsKYbhoBJwOyLcK2uENLYoyF7KSu6aGinrW1w62yTOFmExDNfnSfBo2WX5N1f1YMMIJE/imrTFhfx0EiIyNgdqPhkElPME/3FSCsxnwp0Q009Sfmb6XwnaVlbVf7K3r1HhWmB828NUti5vlP8PjTZWWOAhcTdrM4L0AZjRFRoTwqkaz/sv4b3vO7F235v8VaMl2b+Z3Wairs/iQP46+oteG9Xenl5xNvjNvKnv8TU//JsgmHmu1dGtYCM2hxNaVbxDZnwi2sVa5b1JVmoBJwQrCULuvPdPf0U9qbz2z082rswjtUKwLi4tX6l6fWF0QG8JJZRPSY9o8eVYNJe+Mr+8xUTHW8TfVPvucG8YB0iLE4n20RYtC3vnISAolxlQjRQ8aFwaRQoCxbeaGgU9AEzh9JRLUs67GVkwYLlXQjXOyTpxyQGwN8QXfCpBKwFXZXn0BcIoBsAvtn4sK8rX3f9KToDt6icHCU8OEKXIAS203zwA37/L9f8mpDwhQUK2baNPzRwZBunr3qf80a3qcrQ3Cufdf+SJ7QCPXaRgvWp8ZlywPbYr5m+BVIKOPrRYg6oO8U7KPe8Uvcm7CRcU7Hmz1CSawB65PQ1gNLMgDwReVDePFToDeW9AWFcT4126K5or5m+AbTaZzRqrf91PbD9uiPCXPfi/9JHO8PxtPdZP5jel660dF6EsmZax+oCxz9+fEAaXK0z3YKHPtf+TEMIF69x4RTe0NtOQ0xzM5I1/oFb3schG1c/cgLoW0p3YH86eCBVZ/53dzhiS2mw+upBLK9nsmLD41Z8D7/NxfqMsmmB1OHThNDVnUdxUmjut7y4LaljhPYxFX3SVPzGlrlWYOyq/KQdIE5XSnEyzHByeg2yiwPHwsAChua/qABdSCzneMrlf9A2fxCVmo9DvWncjtCvYDfuUkOB2s5t03sFcRCTctJQkrivbPfGoY2S2fsZBTVeGaOkFeVk5niiZoGIlL+kTmtBVXuqe4y1HV12rzyteWIULzLAgUmgSwzx7NRwj8E3RXcWhoeYmtaCqOvlqBoZvG7Yfjxj1Jx4QbY6I0b2+vjWxBZEWmABtpjJKqtN86BC0tcJUZ9CKG2n6x8azb9ni8Nl/Y+xxHth6GOk7eNj3dqcQZ35WqwNfodetHNEGJ29bFrObbhg/LQ3AyyuT/OEYqK+xJA0XpotFPpDVtl5ejILizgcGoBrqj6KFOApgvCqfvonh6E5HlfveXtNyC0SMZUPwWRE9nox/Uli7YYij4O5uHisO4LrNkVruW2MafyZQTPZ2QFvzn8QPlhOdJY2gS8myVqUlc99M+5B5YCOc2fjswUikUMXPLNyOan3d2Y5omaRnru0tNF/mWH7OvrSH40qh3MY7RVxlv+9gOq4RyWynPp+gh8KEjf/sKBaa0y3FjRekNg01suG4Gux0uu1OfmA7NkHqy5KzeiGto4qJet0NS6apmPXXhL3ukMn4wnasBm6CyVXQD2b3Cp/vJRwDfNedx587/vQHE1bN3JKycIGpQpWXkuTQmSkDiSTdV5ppQZ32q9Hp0XkpsUBT/ApGNIdsgf8jEPYkvmdqI6p+dPnU2j8ncyfkgxjuVNYAsLO505ab6uWcKah+iQrZ5Ux2SHFkMsD1UVA/fX4B0489Ql010txCDSzEGw7gOchh00Atrlun4JEPuC2+1EiLreEcVIoT5+GiTv92aSFZh6LlsLJGXYBb2knI2W4Jq0zwgc4osKL6UME3q2J3obsaOumjByJ3UJw/NKSlWh7mfgZg7/ysIfzO3coh0rwWsSy076nFTnIe+L8yMxBvI08HFie906LUvMj2vsCrhNhHbsiAZNjYZocY6Iv+Pb34agfgSayApvctU+x+MuISpmrJry7nOVszFexBss2xoPaZlekE08Q1VV33zlv4uUUjWdWbPgdW0Vk2PM9tbyVvjC0i2anHsvZpKn4JhGyZEaDt6mJw3dUxP3waZ3NlBOuavfvMqCib/0dFiq2b1ZM8QJtWQ96b8V7Y9SzxlqyxHvlF1KakgWfxsw3zn5DSujeyL00RcRjS60flTYJ33VGwUkU7TxXEVLFk6CnMIyu4M580RBTHcLFVC9/j3WqTYZ2RkvAILQHsXKQ4fTWGlHzPr8/xKBDzJCPBadWvnbKt7HMSOKp3T2J5arYKgdx+aomH4dTCTYyq7osuzJpjoUL1ukZZFWbD8Yfm2IWhv8t+z5ODoAThKPF2g4Yz/OXBzk99REKtO38eP1sIx6fiN6qfVTmhyH/gQCqUPAlWp3VU0ve+HOe4U9bB8grTDZgueanO90M7pGnWDIx6R+7A/P5w5KM5OoEuqROwHNWDdQeSk0wVefp1blr3bOEXhXt3QNFFQxFJxFgvzDWOHDjj4MGo1oNCUxiZ8aQhzmo/RZ2uLDF2jeE6E+4vn8+ymRLfOgSy3YSsP2vb1XcTtlBe2XTSt3mhRD8i58AXw87ayM7Ga577GLv2tCNXp6bQjgk12gm767KN3ux/cGM7ilOOao4EFCaaQVkAtFo2Q6SyeB3LURwDgWofdpjmCSZf0OvAWhTJ8PUVKdTcsO3xDMcywevX4L34MB+dCM2NvXjMa+vkoUHVc1zEjMJthWJ+9oUTSRO7a/haboE4JNVJQ8RC+xkQYDQF5cV6xG3j8y1L5l9RylttrjMvDi2RJYrZe34+ZeoCX2jDEUc2Op0/mwJVsT2Q5OlV6wVp4aovFK+/Pgf1tjPnwnUuluKTfYkssJOHZvuzz2lSriUWbK1JN9hVinRMUvOD5ffCCC7btAt9skOz+iMHz/UEsqBLeOmDWNdUt362okbaUkJCtszidqPEsuGS6sjwm2O121j3pvaV3a2lIdMoStH5VnIuxXK66q2JDJGPF3nAFA3y+FbxhWVpbTVG0dIKUUqeyBkDWmlpmvL9sQpbic4gg1JSlgFjqYLsmAQcLkkoJxC9N/ynJUR8XJdf7p7hkhqPtK2jaZ45Yzt9/Sg8v4DwrSK8UWpM1Do/EnJjI9lPJXWOJHngaqJVKIVPcXmjZ5hg4Cto1aLre/r5KyzBXRX8YkZheo9I8EySJwfTpfJ6QbCSN4T3Vanqx+rb44V4yFY7pMl6RVBS+I5WAqM4Du1uML6rf3gsOR/5dDJ3+ZNR76jJ5EmkFYQlt7A4PD5JxDUdKDFaJyWZDo3OfLly1uLFqjSSBe6Mn3X7neocEUwpHroqqV4PXGuamGoxIYkLZfVLzkaZhUmQKsV+ld/rBv17voJjrjXK3zNN83Bkyzaib/w53MpY33iRDL4iGdqhgV6l5wUKGEjIgGdoFdvq55poU/yoyyPzTdsouEQxGIgHmiZ4jeTGHfT+8XQfSFgHR2Y9kY9dEcifxxG0WqfXoUYzF4gcH513YkO12p7fNxqsEGAkKIJ+r+OW37TLjyfsvBlfFnELdxhDyUVLdsebha5L8sMdf3dDt1OmfpdvB0DoaZrO7ZD2yQ7P6IwfOdQ0ScgAYQWsZqd3+1EfXcU0R+IKp4RuGnb86HszZLomR0Yjpk0sUsZ2I1hWwVpPaiPGF0OC4Tp7lLkq0vM450PzeNLexKXi4qm1bFH6XALn6CpvX0/jLSwpWQrH2aL9NQD9HSGDPRE2o/DBX9SMmQUZbjoT8HxEGXHMabq4/UQlI8em9pYGBXDIekkFrAAnGGHNRJ180uEyJM68U7rVKrRJB8RxnvvDY1aLC2VjGaWKM3RhQ6Dnyj5FvKJT47xuSXrdAdS8S8/QiAbNIPyUQ5lby4B0cTL8Dm8yMx491C3PCdWZj4N15VOO2KUUL9KALymKTDvrOyt79TX69oWImWVPQy//5pX80BljGwaMjdM2j2Z84cXBcZtiZpdTnN666SJt5TaHdmV/cUHW9LZPr1lgU7VQjFZMzC7MA1qy3I4eJQVQqKNUlimVfS9iGqHfPlERjNjDQKdJ0WS/+bvQaHpG7MW67NmArewcN2NICISk3RhGLZ9cr3JzH9ShpLVSse4M6k67UuvUetNFGX0dknt/wTkjrwEKQ6fvEBxK+18kxQdn3L/dq0URCMdeMg2FOE8UbGCrenCZ9rYcUrqc/Fgs8fPF7MRe/bSuzX0DS85YUMC74KvMmuVjZZgWgliflx5GBublxmhe/y7VLtHK5JSIOywHDvLhUmsrwDwvCogxncfkDNKlkPbumeTZ5MWBgJ4o2XQPRwAIJjK9nGrn+0YEVyUE6I2AQ/YeDi6OqqAPaoeT9fD6esMvHGFIkOGlrHtxIpsj/W4GEquOLxwrhZrk+E+EKhX0duLNQzN1detYMJ6WMGc+UeD6cvzYVzLCXF3TkhA8ez1bpWRlX5m5cXpbZRW/JW8MqBD6LIUlOiXz1HNQstFI5kR/wt/yPLNHmnc1oLJa6BH4ail0rEEl9p2IeLdK7cdspXwYeOk1D0FlZ7HiqtXiPNzgdICLyppN8hZTXHkl9A9hmnmhS04BJH/2yDMcgSNHSToZwZaeT05gomLhjGQv/8dPDfXzxKREpplBaa/nJld0HHSdk8pTvS1RyNTh5mX7QwrhH+WqKF595iZLdmVcG+8IVGWbnwDb54MlEPNOD8drZs92CrFhkDsOWlBLpJDZf4kSIPVzq/SCZyXqQP3M1SOijZ0CYLhLi0tXJfwrcY1zVkV109CiEHMwle9AnDc00DCLXmfGdtv8IMXD5DaOF0EzK+dFSDtSCFx1nYRFlvM8Y3SJzMK9TjTadJZWNbo8kTNQFaxs46IYF02IkU72DondC/bsf9I+JJj+3W64ssqWs4cIu5eYg0ETWN+YoOmobgcd35du1UL9gOixxhUmIr89GYHcQACOIWxQk+pHrfiBqyEwK4QtlPJ18QreL8CMOZUVFun/WUIBd4D86zApoq7Ocomj51ke83Hc6RJ4gwn1vaQ6d8VN9YUJH1ZLTXRjo1x//Nj0ulqihSS07g7f3beJsHBfIoAHIpK7BDuDHqX+PDsQefGpDtjjRjExMBPqtPzuhe1HC7smro9NuByuJYZchfAhcuIYJqRt/m3nr9CkrFHQ7VLCzQLJXtK4bSkI2OB+kDbFaFi20TQ2JmGuBaVPqxWDi+eslmYNgoajT/xzUNcZqXmuXZCH422X11yx6UD9xvkHoDrJT+h9Vs/uvOnoisAi/jRxppXjWVb70ZB5uptYGFq3LGAO6Nr0Qby69iFwa76siqqFbspFZNwOK9lzGqcQDh71NKBPyYSFTs3A4NCJ40CEVVyIPNSgGM9mYm/P3jxCIBKtV31+72ytBBrZH3StPjQdepXbqnd4g+jGtMbJRW7TnvQZReAxdcPBR90JCy5cjOVqaeoBoR/2vGgynRx9VRW88KcN3dJ7nXDwufN9c2BXxl1NPcYHkx+N3AmwZpvNNtAhQfQgcnCzoZOwcnPD4MKSJzY9YX0A9UneMhsYyPEu8+JEtuTHv0s2ApRLpQYH1sY6/1FgiSByZJ3/0g3uZ3HcmDgSFvP0CJCEIdpjZR7Tbzc3jvkzZQLwXr29LbJejlW7RVbOYmT0HXVOhUT4N1i0gb+uL5qGXCv5DpDO/iVeZRuc+QqKThAQtNsqfrJAfeoD5vUi9cGWdsXndzrcarniMfOfymiWjxATGjXfWjeSAD0wAQ2PeF/nvBPMQZYcX7RQYrAgi/PmVCXBHnS6kMJ2to+wOxoMLrn9knhVeDwU887ggrkerkHuqX1s+znef5QuIe99NdQaxW3uXOTYbZLDQeXs8tnkBeex503m6Tf5kPE6sjMgBANqWh4PERzo5rS9oAUm8IMcl4mdhT8bV74LJLjNUScj0PzuTLOJkng0UU2HoxbAoOrewqSMBj3JmYt28Mre4cqS/qsIvmVpes4RQHGzSOWlHK7xoB8qorWcYRQN4w9L4yvT0b/6J1tCyXw05nh+FTxTxQ6DnyFY0Y1c2CLGyft1xZsYd1jDdWR/5RB3MNLinHw4EVS0HxLdS5+BeUGmFge6wxm6mpYBASXoF4ZZsgfXp3woJjrjXK5V0h2uz0RKo8golXoaC5LokYfJbWNB2Y9AVR3FSWIEyM5bqlUcLs9Glb83y6iVJODNb98HJEeeCHHUXHwS0f6QtgmHs0nKR+DfiYtXEbMHd527vn5S7NGJzIdDTNVlacB5LR0y4LRijUohYlYqtSGck22mHCoBTpryGsygvZlJJERfmHJ3BuSQszayaNnoZL3PGG7vWKXRRduKrHnow+vztweQp1Mm1YOZW8uAdHEy+dvMirsxsh1kXFmSFE2vtM5Bm412zHCmvy+9vLpEoJ38Q5W1yAsHZY7qbYRAcYQ/n8zW+focHqcut2fZhXGoAaBxtVk0bPQyXueMN6J+M5z4j1RDckvW6A6l4c43bFvj/i2eb6elN+jiZgIM9U/Rkhw3yvjZU7D9xgVP1xOrY0125nFC4CkkxZhE01bHj3Ur5664RGY4EsoEe6FHMqXpwyMC8V1b6Q6itGw/kTZ4Zj2dZTtNjjEzTfOBGZw3ecH9YztX7eg0k1gIqCcuSek+CGhRbXEcV5VjP4fUF3aW5unTtKqAYDHxdDF5GW8kapV43TJSo8Xd/SeSojmqP7YL6pAhGwuQ0Pg9d54a6udgw61Ftpdt+fSYy/l1TlMe8Y+0Sv+783rAkLnyMuouMVDinuTnWtJfIBiWxUmOpR1OyBD4YpclVkZrVc0+hTLGKUlDtiXwRbp6/MFQ6W8mQ8QExxu0bWHN8Fbic4xw0DXgHAVj3uV63TOMoSV41l096uk9DzfKGErMpLp7VdOBwh1a3DwY7NvF7DljrJc/7yXfv0uPjOkxr1pCgkPZ7R9yuJC81UZr6aLiPtFRu5Yb7W2U2mcPJ1cB8cIXtIguWZ0O47Em4Rx286gDQPUUOLEkgfAR//hhws8w2KJwREnRHJQ4023TSwtKH89fb2nICmbCMWuivUKZKMBLgowKub0Aw37esowgDjuMSYOLGZ/KKNhuEDcDlhGvJQZ+YlIOkgeuNgaqvXHtgzLbjahq17yEtZ8ab6oDRaAHad4ISrkbakRdC0I2Is9I5lbEeSwbV7xyJUo87pyfrwZFp8bDri50NFUBvQIVjn7GeU5Hbzy+yx07xhaeYpdgbjZkUzmQyrJPYcY+lkNZwGPG3TISJhk9jog8HYoljEx7mzexqLf8fd/p6tfiFEgOrdBVJAxDCQehW+U/5PKViN/sg0dXnN120NlGqJHyJjGAoYM25/ck06Y+QbGs/qg6qlLzDs0xqQyMyZUYnHf4HHNGni3wLxyXVuwcLZr5S2VAe4XsGvAO6Ld8IizgtAMS8dHF6rMowKYlmbgIZGv99jMC4yf8Hm2BzRaz2ciajSHzZ0RtF7zgprF6ydxw5uZacKocHJsBbqNsh3SBppSPqxmowoBOKulXXmIsWjMIyWknAJZLzne1q2VqEGthr2YiPw7RrlhSGA6zrucOb7SOujKbVf/4b1zLtUu0crklI0KaDiVpdjGKXQASDy8KM0jxIfbnZorLM+ZButapmleO/Wir45+HD9rrV4L6AbB3Fv+1z7ePH4qJapm69D+jpfLGMDDLy8KZnoAxN850iSAjTY8QQA5tsbhXEoFRpq6RdchPnKJo+d8fFZQZqLE/BRFbzm0GBR+diBwnBFVJOQ+VlHMufpsIpzplwnmWzx85rITHcVASuECu6JML1sJVTLQWGBM/rYK2e93r65SvzNIrJuBxckgHTdpkgYMgDIf5eYkUwaXixVzzJAcaw0dNntm6qlyF8qlYaP6gQ3P1pbdKCmk5TB45Q+RtKL6ttTVkIiWQxaS1t/OQH66lmMlR0Pv6gjWsuxPLVbBUAiV7Gc63q/mEe/En8ukEAd2FdyjqEH9nY+wrT/EoWELVMyQfvYT1auFrXOkjj/gh5GaUVNLWdC5Y+cKhtYsx8UEU4+kl31n/bU8jOBgffBkOBjzOmwj61Dx05bVj6sFZa+RlXk+cx/2r8qspjueRuJ9hMZa5So5uSNGHthLT2r0Lp3yCJ1k5AXF20cZNop/Y6yN0zxPTVNPLWbZdNTUuuStHpRYdn1nt0d+pjNqxlXzuH4G3q4A7jeLNuTfg2F4yXyAEmdw757ZuOpFYjLOtTxaxzlg21gQQx7ckSt08BZni5Z92c33TtBPVGhPVvOMgSVfFdqXrSRgzXZ8j0eeYgTIr6qWN0a+tdLCYPZ/cohc0L/GIs2pbP4jHUq8Am81ECViA4HGP0PGhI15GqpqhmaWygzJnRZGNOVhG+MlRsHES0LsjAHe2NqvuOcJjUstrF/vVWXjm8P/pMZDRo7nKi3M3zXb+CXQzXaJorZ5mhqLn4xdv6y3Xt1nIqOm4AM1llUAzaeW3j9/PG4BXILKaWOujorW5Bgnci8fOKB9RhMbfAClLY/mqSZWVQ3L+04Wy5GgHcC2C2syob8j9T+6lVys9zEYbkuABoehqZfXQ8J8aZQ4aaBCzZIBe7FyCHiIX2ix2oj0S93OKjEI8kWwPt/WHRK0/deLQ9hbF6KBPolWyXUsUkSloQE0VFnBdNAvRcJwHEG+zyH2tsz9m+C0NguP1OCgy+bCLdQfXP6iDHy0TG24RZS+Y1DOXgIa13iL1KBiGcB6IYJnGCYqFMjHiuV7WVzPatZH/FTaYIYgfjUEymynMFRDmcclHAsDsK88fiTDrdHiP5pIauVvSnDpDVHUAevVqhI8WRsJQgQU4fr6rZ9e4CcVZTkOIo3lEIBahif0N1AtblXUQNtCweAoJqEpN3viFl1JVr9ksjRu1hGQEI9YHLmau5kfxTbOQsMZmZvsheeQQh8magpp9PgMDZtoHIGZ/cTFYoI1AXqoEXM+6o582UD2sEY8sr0KkznufixPgxV4m5mdVYhzVPI+UvF8z7ZfxotGdD16ykOuVFwnlgruv40c9W6I7OIXuOHmRXAdulx3bFOUV3x4GBVHpDruJp3r8L/HymWnZZjcUkPbSxgn/XesFp0qxSob4Rh9MyY5HndysvA0wsFXpNLG3NatOggF+v42p3i2eBKTMy+Q2YpKbIkHSEMCinYiyyK+lE8j43wmUN362722V7HE9CBZNPkFSnQYcoXmyXJXqZ7dQZMfYTOPgF1S2oYD1yiFbgcVy5zUVkHH04Q/7FeE4DiDfZ5D7W2Z+zfBaGwXH6n6HKG128m4HOJR5LSEXP0J2KFeqbazzoTquIFlcCkSRPncC4qC04IttuXKg/oRgaYWB7r6NplK7EJnuIzBa7CeHi9fwTqIFb1Js5k/O3U8Je33Oapze58WoXp5AyF9pF2q6n6Er6Q1657Qop0ZSyvlzIoxvP3DUrxjeTU2t7xFLvzt4dPTiw9vtP4T2WACi5XqyOP8KW+ll3uBZKm0JaJmK1e6gP2bZLHg09SCzKty68UZ6kO5peBwfSWqpdFNd1tKG2s5A6nrTv9cpsl0F8RvpxHKnsAlA/O8t+3C3lbnKAXAvbAZgb3yzjK051AI/df5TY0WLE2ulhLDTR1SaZkxmaZ127oDihwo8hFTMq0NpGWMkmwmdIKjfJ7pgOkI9K7SKAN3eCwn2nAUFbLm9DtZTZ+R0VC++HAhTv+8ocXCmx/DClLjvZ2AN4n/mVIiWGcSybTzTCILXvfVOAhJ4V6Nw9dNpJ6wUwX9b4HGDrbl7becWC69stQ5AGcct5ruKhX5jitfQIXivsCF0AYtFMTt6wVw1xu33a1RfbAisaGUvRrmt3RFZ/IWvkFO9VEJNnR3dgAo9JU0+3eQlqUDdfB6pH0k1gyE02TNnA6tf4w88UWVEZGj3lWo/SkPsdVn8GIcfWaYGXqrW8/ixwCYFsS9d5ljLWRG+37Kt/K4gna5JdOmFUFMzNa1PlpY43nLUdN1MqJH8LFjPYVFSBNFGMuPc15oox+7L3dwodRzYmB//jmfVWA6CatkmFdutLNCXybzIdUbytg92J5I1v92munGSSYDT13QoqyfFqZ2T28xbO9/MyjRWfdViWmYndIQqWRXjR73fOjG6TrPaXNC4hGnENxv5y0y82lkHQ6IPIO0lt3SEX5bGFWVqxbMHoPW6azLV3r0NNSM5Ezymi9Ur3vUVNaWs6JUyaw43qSVq/2k99GZWRY1HpV3uom+pFy1LA34aVhYcBpTvr2IjiZLVAOZ/iVtqUQPV0Gr9qHZWEQQvWc/W/ZihegWVkanRWT5Ribng25Q49mqARTYl/YMcM1UV0vJ8D4mMSZMnJm/woCZiIJNmlu7mlEEF54QdE+0Dc7GgRMPM6UkJPyus9yQHbLCWEMgT+yKPyd+iQuB3couD5w4uC4gsKkzrSRWOkICuuDQz0v/2dzAYrS4sUnnTOD4FPdBVG4oGIom9uWMDVD1V952pxFpav13j+sg3RE3Eqjyi6WuzwgTvb4RYkUvzkBiBY+pSQwWaNVPlhIoB1VzmgpIkgq/Pq6xqwAuSEjQqdl7o3tHmoMMJ/IwnijXVl92lOS7IqywKLbpmnpoWFgFjFqBEHlw87ADhoygOnf5tJZRtnOmWTJaIiShq7wqoUeLHb70nSpVJdRyOajj0Y/XNNIU4QRXYCEcTgAIspqi0mFygruzJ1Nn+auGMH9KNywSFEXW8IrZJJFu5e52/FjVwehKuclJz6Cg5hTi2Fy+9PVw3b2LTl7ck7VF6fxSMLc4FgDEbHrSnuibq+X2Dv9HJ5f2yOB6i4Ur8M2xOOMHDOu8HG86rUFi+IprS39dC6e9R2Zzgb2fJhSYgVVhPucTBgzTFyz0Byhbfl6uXiSBBq7iXIrwEX3qlhsUKQaYfZNmtTnOJQ7x/s2QMK8nwnwhUKrjnSPdw6p0V7vdKGIaWrLEMwXYp4kqiGGqeFXnh2j8J2rPE1psJgh+wCpdIb0VzefkDLW6WqcCKAb30IlVYzgnDfUCzDd1aFp6Vjb7Ce/2oLebUhH6uY5DPfJaXPpDQWL7FHTMW8pEx9dug+kZJkcNo4lSEZ+NW99Zpt9mMv6TLiXBHdNU3hukSvT06aIf2ovkPd8Uj0bcoA6U/FFTErCkYX0DjZgIXBUx71ptyVQmAz86ftMUAsKMDErZ+2HtVI/UGhiD5m4Dr5qZWHXl+l3syFTLIkvBy1rXFwZiWepmzI0Is6itdycbj78DoGJBX0jHrS1uxuMJhbx5A/35NZte1ZMzRCcK1ArqpP3wr0WX32PIUwbmsFYbqtABd+bbsxKKVdR4yaJ+UDKPZ8I06XxbVtgOUOMVzsAYGRs0N/lv2eLbN02Vyof2dm/tuXGaF7/L19YZouF1sCXMl74oG3epVTO+8QyashOfOmDi3qjmC57Kgl4Sc/EEg/dv6AUFIw72tWzQof5zUSE7Rq2hLZglOlawbsYdJJ10gneqDG8QknXeRyqjKM6Qv4wBDX6nQpm+6ynadJzt22RrnS9xi7frEHzkRuEKQMdsN2a7u3f3gXoCCVGUR2FvBLlAxl/kdFFGuGHGNJ7j9A4PWkd6Z4nprhB3ARbVj2se4UlpFMTmo1/z5DJxNwY5tC9ggeqZ5QIv1r5uqqeAevkRGppzvVf/BWBX+FEd8vvbAKZIggkvWmbJy5Mhjmh4IeFMzo8ocntmU1bv2uNwPXKIVuBg7M1KkjYBeXb6yYL6tbkWGvIYjRqyfG6/lAZAWr8qRcJtBl82I+FFt9mIWvLxELC7FliFUm1cy7rqP2IVwvx1cmo5YxSC7ULf8K+bjXN3SXYepj5/IS10xUghAKDMpnPbNadCViyHhPxnms2Gu/57SZ5X43ZbtNuZkouUNX7jeCSpOzySFiNpJ3XyBAybEh/9NdGuhGaSIfLXLC1EfLiIVoTDOmSrc6tXywphs7jMYLbNlXxt3TR0C6acjeQ1TR5ZXoVRafa3wh/RDwQ8K05f4qxDJPf/MNaZb1du2kfS/fC7FSS9uUtmtDSe2uetbDtKDs2A90m5hKSzS/ebLF4oqVrSi8VZO4EgOIsuZdw6ljZHOG6aBLt8yZGogyB+2HqWyH328OE1G9/PO7laXSG3MF0WMegaK7NEMPRb24tOvRr/M9nUI3jCbFGoZQ9mxukR9ijgW92LGKbxANZXXvU1SaAOSiFoSWhsnjQ3epG7M6dxPlasVtPjeusXdPElAx0RWnyrU/+MA38xqIcrq1PJ843IYLWaF0CNROdsJOWY32PHlpU+PmhD0vwC/xp/9W43ir70sX+/W5rScwDFR5eEscbXcmxhQdVzXMSMwsdwwRqQx2FfxBU2BR8oPbYZz/HctiH9G0JaikyUesEfW7YLxPugfF0J0OU2jMIlSvj8er4wPEAC14F6iUA4EfVLHkPtAKnMRH+6BJw4NYChgTH/vl6uey91RBDo1r+alIA+YaWL25ttKeTUvQCwBeAea2MsYnkFb5dFksIxdKtsyZwcV6HjHlC6deUmWJk2KSHDY/zixhxHiMPi7a8w3LP2zNcR/jCfCLYrQe2R9H2hNGQCJ4cpC+3YvosGvVni6i2UMVWmUIslKjMnAy/79RRgIR4oWoSFANsxA3n4/RjPLhTa+CFP4b8Bb76dAlZxPL5GFLE8Mhj2+KLsw3k32qQEp/W/pIVSC6Iy4epGFit6C2O6O8aW9bi4p0GcF6Jfar1KzV3iSLO9QnRvcJwZKRXLq7i2jVlOxtAdzk1gmQr4xqcNGldQo68aNOWkdNqTHinWITspP05Kv3j4EBTPmXWVfpF+6NgRHWiMxz3B+sESjGfA9nprOIek9kH/mBvUCEa5veaKWPjMfwoUfN6GRFZJS2e8LLXJHy8SQ8taVAZzu7FwTp6gmJpA7bmAZwRNs2Wtz/cJu9NK7xVLDpIQLDhN6IZi2Rlu3fjGbxTmdecMvOTCJNl6BRlwWjCq5VVpeif+Cc/cJANTH2okQzM61HRjfX+uUNU+lCWfr5OaHFSGwwgSyrUPnaZsTS8015Jw7YwsDznZ5AU8GYhL/NfgE0iSjW8bu+5DAgas/SSIfIhugEut8jUAn5Kh5Fj5wqG18SQfHwzTqJrHmZzQhQ5F8QJSS8jdNEXEZAdVA2tnqBXnxiix4xSLe4pSKV6hQnSf2psEcitYcrntTmDD7VUn17xXbj6UpbH8u4f/5FUsv/yyDdkq3iOKICw+mwinON8FC1TtEv0KMxaV63W5Wv3Fkh1z627+rnCoNzoQ/1B/eHFgEaXKQey/5qw05ErfEGdd6Daht2YR1CgchFBIg1CDckOGDkXTRGMOk4NrgahmFm+3+L/1GwDf2NdbRBWIF/OD+or7TleEXCX3rxHo0Ufv2hoNeSr4PuvlWjkMYg5k4vfmbb2rjLPdn9qL3gexaDoQqsgKDBCcQHw4iIViEXkeBSlibz22y+3QXDGtnYM6tIt0d444qr2t7UwLxXEVA5AsHbaPxW96s6VaYAhf1S4WXYJZakQhZ6D1btStT8lc68dBxAIoWcPAmjXyQjTtr/dusifej32IPqAtP5WUHzFgDI601JV6MCdMNLrqkER+pHhUgE97m6+/WJSX6KuDTp/HV0PrwSzcSfhzw22Z7VKZx83GhhrYZLmUr8rOFDFn5Z18UdsPhWoAYGAaOZ8LTIWCEEdjljX0El9+GBM2fjpnRb1Lw9FSRApm1wqfVo6FE4i4cRu5SSYxJZOUvX8bMoYyk1rNn9H3FbPHpm2j/hv82yiE8HeS31x+yYP5gkzWjpdiUFRxFyDatVTYxsT6Kk0CVnVGx3wcdZpDeeaYO4fkOIMmey5stcDTFmfSvYZWrnOXqIjO9ONAnLrjq17DdcPSRkiOmD/Bi3L2vrVJmBNlJB6H7jAklLJdDNGq/1QnQbWLldVqxbCWUepLMykAQ1hdiysLiozaa/45PdTbDvhjUYO1URzKnraL1iGDl06iq7rqq7t3BPX5yV5iLFoy7qflelIQrEsHXI3CoapAE5CVxePRdeOiI2vjr5TgF1V50nvSqNdaJ4ehVew+vnOjtnFDpiBipxs+2MPH5fj352mrJXfdhKLyTkK1YhRhCtopfwyc7R9l7y365MdkiTxBhPre3APhdPGHgVqw60HrQL7z2qg2S7OwMh2bvMrA+JPneLmiliLmMD3fCTeD7Ej+94VgnqOGbyjlLxvpotPrRzy1vy4ehaa8itFUsNtHUuIMnzdAPnPm/9a3zwrUdi6Eb/8L8YvNeQ92PA0x4ppWXhZ2pk6G1tzhAkfPb+5AUkro5e+Isu4tMCTkz1bgVgmRJlDZBv7ZhL20V1ZKIha+f0U7+iRmKY3xVhZaaXf+2wJLRsKeW/iIO6JD0v/YLQyuG45jCQcNItB9GBQDNDTCwPdylUgvT02hJ9F3Ln4441IdWHe4cqcz6VCe99MxfBCvldXFql+u1AZL56Q8lBR9WthDfm9jo0pWHbDiema6ucVfxRCrri1o5k5LrVmALSMCqAziWxNZlAKlmFd+SifdZ0Xv7EwXGNlxCMo3bQRkyHdFsInygFYinFn2HxSUjKK2XUMqVambYDWzg/SW/pogFiJhi7LJJK+uuHSwtZ/SKrqNmOd8KwGaZ16WlLm+/Z2bkYQMGfmgV1JWEqWpnCICD6NU+8QOulRQYWI7qhP+ISgT8Peoc8UDrj6ZWZ1YZnQecI01kcqR43vPuitBG8RaZRjc80qLR8tMmRzF8+mCgnEBEp8KmtB3UL6SbdlvXWzCKkNWjQ5LGm0XPPluCtO+xhVTgVw73ooAPHC0PxUgV4/zz4+tnsjDh6MYnB9Ol8mMXzzaP96H7VrK0HsQ44fH+1mqJI4aR4gvn8E28vIhboiEdsibpU0lYgAfT+ri28hOt+gdAyvT6PQRXs40Yjpk0tXIFmfyCHwuR4/3MTGjVvyqubYK9M1IXcjxluiaz28+Yw20XJzqoWAyzke2XEvpVPjF8amoreyWMH4Xc+dAzXUWU2twsxIzClVc8SfzLvUYYHGmtZh6QZ1mzEY7HFkHrwFK799NvJRmIr/IUGapC/fCm/4TWmxT29XOr4RkuOyDMqoCN6uBEOFvoTKPV1Sw9Ua7AOM3FXsQZ1SB68g3TGK77i4E8Rdesf7fXuz7x/rmBt58CeuQfQUQ1WZdP1oSxHXTz3Urz+9K+a4FYIbtFavwSPZNsEQef8fgbdRWdy0Yz7bSnkbYRGVntNFwNhta1TNjWLPO07VNwonB6y2r5pTPJpTLOTDC3bXovtd/E1cMwznNvyXnoIBwXmOqd8+vsH82gzrNfYhhw1XCw01ApP011pNzHYFth6jB1N3wbWMhiY2SjMRYkx8ijJb8p7sYpRHJ13F+toiUesKSDV+KfKvYGoCP3uCzSlRylLSAoTZyGc2eaGvpNikPrhkoSKkL3gXnu63SDWHk4jBtLfntvwhQ2cqgOSpgLaAkvpdS1SIh8R3VdOsZfzOWKr31yS1qOA0N8bW0F4b7C89o8XbU0RN2vnPeWy26kMxBdYDhAh8rylGTideO3VVrA09/iBrb1lpASz8jWkkaaf1xhmPT31y7HpkoK73t/anTRDsChKR2Bwf997N3/jdf0hk4iy3mYRgekpbk89s5lJjUJXzrNOBcN25LS5Bg7RfTdQSpg+hqH+qMRHga0tUOo8ZYE4Aau9pWI7lqI4B2L4/a5P6bPxqLD0WsaW4zUjSLm604u8VtmfUtIdvirHG7IjGEaX54iw4mwcjUgvdWlW7PG+s83O4vILdV3bjoGBNLRserKcQpHrwf6I6Pvht+SWGyqgXkNslik2suazoVM78ob1FoPw0XzsQTF1o8ldrpi80hGZoUtlS30NoeWHps8XN+Ppf/Tedd6kkvjRWlqYIB4glIdKZY8EkXBVY89GH1+duDwnej8sSHMreXAOjiZeKVR4CQu6lGLjh83jjP80RNaC0ZKVA6p9rKpAebZtjS71iJM2jV1BhL6A8DGBevh3nXib8dK3suLE0psUwiYQHF/GgpL4xVK2nqjPk0jU2xvlru9Vc/xJqyJR+A7EP2KZvuz6Q0AOs7IQB2QKLOHw+ghWVgzIjd7TW5C6TJybcUekWyto8JjISZ4AFN8EPAxtnmhS04BJH/2yDMj+TSbqgMnkP+c3iBSab8Tdl+b0qeEcackbGw2HiVkaQgiU5I+MZLomL12Hx8B2jKIzqc6P/5nIM4qjQApYz5HOsevzFRl3zHu2LH1DiTWxMrvtCmYdmaU4gOCSgKUVSxg/ctILAnBBZT+AEZ340eY7djfFGBxVESpKVbfsR1Ms/suvjwkjjyjSVGyqzLHQrZEDCQNe5/KqaxLLqMmI3Kiuyv8jO5o5RfIimxZQ7ek2Ll8Ltmi55Z8TaOPiPNzgceWx3DBDOXTPPrlrWuLgzEs9TNlcGqy9sPflw0z0epzIiQVt17QsMgdhyy27vTRg5F6V2AzUo0xMgHWIO1ttVQFzG+bYMnEsOl8Wl7OJlXy/NqetuiCyMKR9k1Se0Vo9sxAQu7g8NaacagfGY6XmV1b+mhXu+g5E1R8iNMQDEUVLYm77UuUbZ34eHps5702bLJCSI9gPheowmNvgBSkvdayo7JcC6apmPWlPdE3V8vsHf6OTmodcdv4rAfLm3OFbmhZgsd95wasXuq99q46gvMgnrcUFzF4CgvZaY5HXBohFDURaVuZYh/o9CwcH0j58eJpk6x6/MVInMNbttcWrENUrfopR8UXt5PUUVekZ36doOkJMQl+9aScnrbMVhf+7yQp0RsobxaYPuzgwInsC4yaXqNZ3Di8xbr9p7stXrwRFlCxr6ME+WsOWYlBpAyS9rOHJ9+6cEbbmn4rVIX+Ho18nfCB7cc8OVhAfXeTk2nhW3DSFQdeD0tMq1ZVbvthwEnJL4E29NFlDPFoQYUeKvxOYCc+w8eC9MUtlyNAO0pWAAaSfpsIpzjok96GTBGgpNzF31HXKTYMvszXczlh3TmGnD1Byf00WFSumAomBzNtoNd9XJcukMkpYo1rOQg0LR3NQzILk2knlRRVpK6i3L+0y6aUr++aBrgSR50gHkWiOO5BtY/wbdSdY+NzjgvJuWyrfBwA6C1lWUWo7BGgcEIWvFg4RHijr5qnljjsxm8gQacoUKj4UIZdeyQ5uyfFQM0HSkMtnGu1UsbktRyupMPFXqD2m+a5zWNjgKRc0NP8qzWSUUqjfEfVU34XwmNnrT7AbDnIiIPMNYWDOvBvWoFgOtQPU24tJ+5G3rboPpGvbWMxwgnu8HG86rUEktILV+LFH6fizY1iJZ+FRxD+YTUCcJZR3XYZtm7zKoBaw6jcHwXpZsUifttHOZxi6Ww9X31OKnOQw6aAW1ymd8ANgXCHYJcKxt7LnZlIrXP9oQlVi62TeD8JWiq8GhCqSaqnvt08D4O1kFTmrn9eRHbAcwUvpGjxtpnm2j5OTIFnRCPqI24lFgBnpwHqKxbEaaTKB1JVEn7g9ufZ4kh5EBZwYootUy4EloAL9nNosAlobZ8VhDgDH2iOWHDLxwMgVrT9H0Q04CN2k3mIP0o+fuydxaiUBc1yNobCdiuE5Z+FJ4bwmfI+YWei4KioGQa9vyGyAAxZGVGVmLk3ljqx0Hg+Dk9c5qT97segTeJqHTXQQ2wXgTOvMTk/X75YE2RE1ga0eovCuyqaJqy/Msajvr9br7vT9NxgAxXdbS4KpyegL8HcMK0gPmYbVT0yyeuxpy0JS9txnWf25JvBFT55yNc1BLt/P3fEEcTEEkXIWNoFMBYK0mjAVg1iCenFEfQh092gouFP1w9tsXbR7agtctWcWmXeh/o3YDbqrxghPz/Hz3ZdMMs1YIVWeeK5UcXvEKGrYkZAVw8O8o8X4Bf/akF2Xdks02kX2mJ8/qMgIWjg+OLwKHP8EfKLeV5vnsBhgYAGKuI1XzQCNnAC2uQlvnNWg4m+ZNnk9BLA2JIKZbftcvu2vldAzGvEFHkvUlVEug9PMVkAxNfmJS0jBGRikR7j2z6KPmqwYQj3azc1DqHnMFS4MwoH0Rvws64nWvmIzYaolMkdtpOMjSFSMUzqFivwOp3CwymN2crIiDLnXo5lyUslEptr447GI/MtW7XoVwBixAF3hRYrpRqkHxwWLEcUsZA6nTxNIiLVGg3c9h8cSFX9fP/joWLTk5Rmp/b2bfVyyjUQmDOM7uYckWH+KSYQmCtydzxing6qOtnEg+7AB9jsFK5HDoo8FjMNlOYVCNuki2RcfgWq3sY54BvGxoON7vMQVlksb2M5WHbN4AX9L4BgN2eNJFtlafCATO68g/JcYGu5b9kQ5lyWFbemRtBr48Y1FMducHNGPyr6mQR33WPMvaS1e+oLNs26XwBtVV3oAVSdBE8WB7QJwUMQ7z68y7aQt/VtCTGHQkrIpwOt1ZiDmtAnzNKE7zqgP6YTswNY496f6doyCYXhqQDe1fSy8TeYjTNJYx7N9Iul4P+hhdw1Wihgu4pMzOyTgDY4VMMPvTUpwL8PLNHKy6yWg6Vw5KFud+5vUmRNekUf5hHka3xTtDssbh6xtVDvgxWfxPAYRrPq/SOkjMOWOWWb6j9MiLsPWaTjDKrmx9VhRCZ+9JgNl2BE9PCRmY7SEzn/7SzEN0vMejvkBqT5qe07IlDjxfcAl3KOgGyPtVPPyvqdy/3tYcJ1v0ZLU5E3G42jBDt3eLjerrWcoKeBiP03y8E5jTFdT+2WF6Rz05d+f3V5oxtp11S/TCKBgPbJswWO6Ne5zUq6QLZE0bnZpZZnlWrs9uxQwlq0+iqzpLZJEQOOCRhTIp/DA0kq4tyKCnFxKmEdKLHI0laRZk2NOyrgte12DTK2FTdq+7Xr/5Myef2AkdNskmxGlsFi9HLjWYxkSbYJ4Pb9g8+4edOpnao0dL+KMoESax5lRG5tmQDC9bxnH5W/krJ5Nc/Pmcc5MGw6BGy0wJZcLQH70cwhcTQqG0aQQ5biT7HgiTesKyAUR+CVDB+lswGtd/j1cdDX+TPFzc60exCIqvboPn0jltotPsU1ctuq8lLJ1JzLF98a4ZYWFKZ5RDqvscX5/IiLRqBctraGfelNNhYjI4rU1aPBV25s9YIWhlp9xuupi4E04Yj6tONgHCEu3v6dikr/Rlq0+iqzpLZGuz7RqVsWqnqL7TK5ZIKZXpuDCGv+hfYiSHZvm+nwMQliVtfrf2gnpCpXm/Jw3fDAqhHvrOEvjO7o+V4a329mDU497e2FWHlIaebRtuR3IUdY6BjKTKNXEuyIreWMKIs5q0+i1pkoD0IbhqGUdsAOm9nbggNN0walzlJBa/tSiqprit5TGg3yAxqQWu7RRWHZxdABzYaax208S4ssPofHLo6xPx6H/3k/nGjYkMjwacDf3aUeV7fV52KAsQbbQXcvIbxuydtZYyk0WXm3BQjOfRPoJXvj54ci0IptxaPQCZS4nMcp7diErlWTNVqzFmKCWP/BmhL67RmBg0HRApUWLAavuOXS8u47i7fNa3fAqWKTw3+WGUKi2Fwih9jiY38nwAvkEndsbxEKGVy+D2ASCSK5Q7zVv7j2GP4/i0Ig4G6WOqJEmpig/jmoMQ/XSjuIpDeJ5sRBWfYlvzHzKeqShFsyh4eM5qE5BxtEVjyfVaIw5PzO1rt6pTGogYQOZsPDvfj0U55LV1adkVYrF0ziyxZafkE6gKyW2TaoEmhqLz88qDByBt6d0PGRxa6r9C8dPZ1/g0mEtc9ge8HW735OoNQAEpIU+kVSfH76TDM1EdiDwgAOW5WxLFjKWYSVmRAUYJA+BWEFN6+l9RuklPq3SAJUHDboNpe+Aw2EKTfk4Kj9fuT09Cegl2DSnBSJJVXFCO0RDfVo/iyCpqBw0D9MUMX/4d1+mGLf+D/1q7bEE1XlOrisiU+INKEjxK/6nquI1q2zF3rFw66C0j7pv+egcKHDn+lEeoQWz0NtmEfRZlECytOUBmTgC1RHJJCqINU4eRENOq9Y1dNq1tdmDxKMh56V7Mx6E6kMrDBeZlDScRovzhTM9j1SHFytJ6ctkCcR0bjItsY4Zk9Rlo3N7J1wJLpYvvX/Oz6/hoNI51GkY7cTvz3i54uurJqSDKH0ZgMgeYM0xZ1MWgJ1c7OPzbTWJELHfDKoHQ7Qv3y6QL487LWUaCruLwpmNs47u0Dz3nYObidIdBr14Z/12iaAy4sg8KWLur4fboJdzHXl3dsQ9LPycWNL54lxgtBBKlAiosNZWW+mnRhG9dn/Fw1C9JX78X16YofF9WptYCXUZ3hynWpyiO1WbO4X0ZwPNmlIspmOiuEe12Cs3euGXcqv83lIvYqfZ2e6FO0Otbmpg/XDfwUZGOc8YPI4AzMfSSVZaEmU3VxJg3VIccMRDDPVAhHGQQ8+TW/YC0lUTDNv+X6Wvcc3VDAh0QC7aUtL1F6Shup8wROkg1e9NqzadfraGul6sBM/H7RdYbB89qVpQtcUmbONUjZ9rNm0rsiz8E0bHSj4seKuURsQrAviDjQHu9+Tjmvuc1oOFn1zlufaFTPFRLq2mdkPeadz2gGn98pqP2ETI3tcVmBGw8VUbXpf4JBlUPS4nr6KixD9meWObXBueqv7fsCZE6K1LP37poTKAH6XBtqpMQM9z1D8/4UoLnSwaoH62qppV1/1LgDFJje8ShpgXW+uCv89GktE7P0fR25IYK9iSJafdhjINHGdHr3kg3mx4isoitsrzS/dHaPClsqh3rzO4Zslhg5l7enJc3AKBiM37nhWGSYV/zJpz+M4o+L7WVu/LV6Z2t4r5bayWdZt0mmyTHvB34lBZTUQR8nTpeRUVUhAlwreAeUoz9u+VNUHHsbw5fyJ0nZ1PTlPAxOAMO2G9mZdMbGpDOWd3WhXw/QTdU0FmYSK4po3b9b4ehT1RIx/BWLhUT/5+ymQhacdH9ZLk8ysWAJMYE+cdI/uGLF4+zEWRJP2cWZhbSLsiYBnW94IGgxQpHIdg/FcNSv6BPEsBq02lO2qWHd/L8y/xyGYujZMh5mOazeDwyShZ16PuX10+G4i5IaUIpoBs+uKWHMz+ARHRGToEnmUw0lPjihDzhVrYe+wf9lpYyPhoFPf+5tt5PBpIExSsepxGzCNSI7AFT0i799RgtbMuzudBAquCPqxC0ehTVEi50EOwv0i+hmgNHhRUDzmAhDlh8baj720ymyl96b8GjrLl3NewhJDui2t4stWQwv9OdUpJRe1Y8GkeddDzgoVxoa/8HowX+mWRVEXdG9IQNrCLvKCnnp/wqVDll3Agbgdw+B8EM6wXc0rowX+ovHYLbgTCXXwFZZXPUZWFJ7atuwS+eRGLri7QvsTg23WvEsS2q/rOYIY55LFSa0A/Kpa+ngHcs7Zf+00FC7Buj2Q8m7zjG4WbAf2HGAHwf3tVBA1rGsrBHBk19WBftPhZSlFYRZ1hHvY0Pk+VtHlxJ34YKXpgXcmIr8K6afGYAZF2Lg6pwerjNLpHxW+iDeJK1bHdXsT0tpqgo+K0qVUXIaqzmkSbJfm7ltOGcqOIW+t+Euv+/n3t8JOPuVJ1vpsndhWPIaoNcJbltimzEWhx6uGzObgkfTvZY3hz/bFaYl3gC/0yyAVsOnxEnopnD2+BD4swm4PzA8IqRw/2bvT/GThGCTcZSDssFhDx/KB5US5tlRp6lSvSMd81Nhr3PGNBaqevVzJCP2O5o5ugadiujSC4qxp+ueyLgyKVuPn7E0GS8LI4b43vnXZZhj7cKhxSv+VqPTZELAgATlE9tNnXXe2yPR8l6buOyGumNN66jwF9lHjrwV3hpIsDBB1sKDkTno9jSCQjjL2bdyLjKrL3Di3SjUYY3FIXRik7AJ058nnP7edKXOJZF0wc7NcP4cnEC6N8uVEJ8XFhR2hSXtz0ftUNScB8r/jpD/LxVwt365zW/4rY44DGB0A79dg9w61YHdxZmbFnA4/Z9TYF93k9sDYbRYgGv7TDsp4GNeq2sVdL3jt5N6LN8IDNFUO9qZvlZdhL48TiILhq5qe6bJmSDDOG7CQBORQropVpLQsFVIuEL2SmnjEhZpNQYU58qE+nTjIG9PWUDWNyCI6f4QxL+Mx4ECknc8hjO86/tn28egjB64yxQLExTES8TjRzuEJituO9aU0XF1aSZisJhgJ42g0KBEnYjs6xUYqcMI6pgQZUZPMvkwrPRC8bdutBn1aBurUTQ5mVRJdk5A7rFoH5ZLC/YM+ZBBrkiQC6qOTb8TQJO46N3/rTiC/fa8y4qJl/bvd7GWz60qluCWjxie1pxSZDScdJbDEL5SajOHS5RrPJjynQskfMjeQdIURXkbfB5ekHYX1qMP43f/Lu2evxHUOULKTvWF+zDyyg53efZELt8oUsne/S8bGn44xszz/ifwmHPjUrIrS/jlYeMDwsdHi9UFnSFoYOx+5S9RbTH1sk2c/SzGEDiFgha60PVV/Oj3iJdEZ+bJXEaE+oxev0o65Cci8qvn5p+cjbXeBTYh97KDc6jSbYbWKIAvUYKoCrfHWZa70fq2Z77u4sjmsOvJl1QA2GAWvNRGq3s1zSB6DBr0YhWXN/S7qdfCk0JoYGbz0RKLCCiSHXU68xz3JWVugMXOkHEsLYg4xKIUa2iK58JYgQdLzwbD5OhRfAdppLBrK9eIOpnsh/sp1/ydM4jry+C4cyeslIR0W4WbJeQ2zpZpMeXFu3bIzIJM5XQDfa3ITG/pk5nW3jMJFeZy8AqMMOhTqdC9dczeGkC7h1tRVnsupckR3RHKy9l7TdSluNhB1Wub0y7Ws6xLPKtPApL/5RqPJ/LvloHRVjcM/Q/vhBNnQeMkybhkh0YkWE5BMn6xpFckPdF0dNI0VFhm7F84Hj+L2FMB2XrL4riguZTXR8INiJGvZGtnHEcC6lWBNAnDIHZrdR5R2lArz/8jSpxrAOAWN0jWqDZFv8o44yr6lj94WVIV5+L3iSs8yrJ3nCoLr+vAG1A8T3FEk1h84BxINGGo+KGsTbR6cTyWSk5rflwq14SiHVNDD1H/PPw1pCcals6o3Q5e8wUYbNYRilJjwrVaHGXAhVti9YXhZH5P/G1g313A094J0pzaGTkPhbAYav5oo7Oh9gFcq1ikwbChGLBQzccF/FSaJlDo9yLD7EU+QOH7CtabEPxlvchw3Bq/b/R9ZFq4URwl/P8SdTzVIG6+jcIGaQ5/Wya/bY6zPh3rHLRCx2XMc7NHc+ZtOO+KXLLIaYzZzqwfqme7ltRf3EqMYKsu+h+JW/i+WmKM0HDrI7p8jGADZAVj9ioRb7fHcrxQdUoj8Jv0gIjk56n/8XcN/fyRELNoT5Jl4OhRAwRHin0hbuitZf99hUeo5U8Y3ewxTnbjyjfm2fZzjJV2y2XOuww4oWqHdx9Top0B0CuIB+MtDR68PR3W3C109IG8nQ8FY3VvlvpgDfIwNM9X60WX7w7fdW3K3Y2Vlz/PN1T9BLuY68u7tiHv0ZOUsD3hwTE1w+cGnB39yDovvotcOx7qyQL2y1T2qx0d8Pv4/YB81YXIgo1xWEn1QaEeT0D38s3zUXRmue07pNkcxoDvuyDPlKxx0KzGStUGP+ddfI36pi22GD8VEyAskgLLyWQzv5SWGSSmfgo3Rtps62Yp6hK8K7YO/zaLPafMO7PcKJaJ73IOBI0gP1SVZcUGSGyibXd5slokumKVb2SS1G9c5UIoS5O+RtMTKCJyt9wKljsB91wRrMbviUQLcGQVglWd/2zn4atKDLsouy1cojD46ljNfx9gkfCSgzSJ5Ul39C4WP9dnEbvCxZ+r6iwtzByFulHPX+HsZOrYD2pRfF9nfuWI7/QQ+OFJkJF3xoFO6LQ/0sfaWXB4+vNxp0W2mO5aSI6Q4/2dODr58Yn+j/M+GGdlzOHLZrTAancxMlhsmiQ/fm5dweypd+rBWtYJzJhvYjY4yrxzXe1fszsX8P3RBpsTIIk74oTRen4iYOggPXwRDmbl324Yw/bPzWAAzpKqbDvMp/ppFOaNFswjTSKCLhe3O5vVnG4NjvMj+xTZb0TLvOUy4WnePTU5VLBIuyTjTBx71DwI7/UVgehG2ibUfgCRhQB003Biqi48sGOG9qhcKY5JY04BjL1qFXOraDrK+Mru05bYlP9meQa46XN395nx7XT2xg+3PBA4wid2+np64aY23aPYwwNh1RokZ3QTgIoKPoC0VEnI0pbvccgPlzrxazm4HBBowR3H9oi7u8/8+1z/ZbmSbEjWgp2S5KtdymlKZIOzNe7ereGTKDIHjlIM61DXifiAVz0yR+IaBfLME5B0WNLI/tVgUxC1xfeqty3xVOb3Lz2PImYiEM5bkExI5DtmXS0sPE9H9MV4LeZTknXdTZc65pOOEyueGzwIqQx+R5uS9kxyfIGLThpehhXNMONB2aiersrMeBeuLnx9mbvt5yiGFXMyCsDoL7HLK2gZT5SFgXzLjfg5rt18/eRaB+LaE/cTQKM2KD3aE9m1vN89psfKXAqZ0jANt/ngz9zDAyyclPLrIbmywv5ErlgnNUO5/GdZmagnXHQ32t5+BjY5deLciEGThhlQLjxvNUgUuTMKSrN2leUWpGlm9Y02HEWP2VINHPYiY8t6nKCRfAn7r0RGqh3JZD5KzkRry2eNNGlKattcZLpkxses5+Stzi5bUHXKOx9I1fMQIqiHCHqOF5VBuoeqBCOCITxq/9OwSqMsWwmxwiJPQJpsmAXmqfbQog0k58J3f11PW9lE5e+XOjciBmL1TScYVM++U0duB1sIXv9y3ecPDjDrQERU2PjtTHXLy1RCPahbyqqFe9VjGFHLda2WN0BhGmV8LO2BLUOboFJi0DqHqo5iCL5r3iQfIEKo7cJRGvyja5N/+rHyZwdciIV4JVZXbcIQUCfy9Ao5IEzDghVMCU5ngcjVoI4jFWHHdA1oSllfK0Ri8/84bqycaOUUKYbV29hfKSz4T/VreXBTacEfOzDrORGDKzfOVQbmbgRnL+Bdt4wucN07eUoOznbdsTEPWoogTvRYS9CCmDtMhMLEQFy3EUpuI/vE/ut3AKm5/Y/HUlnNH1wuHt2dmJ0NN4N49yjHhFBWtj+GihUdnOib2fsZhbinKIm0J+4jXnkOlUHGX2Nvhu4xvQ7wPF6DuBtSrlQvQaksWYBnYgJRjwPgrRYLuawaT0x+13OzaDb5e2Y2Ql0khE4aUDBoBlZBYydjLtUFKE96PKomDc+5VUMxqGCqOcQHhqhaKB++OJGMH5A2BNjtiSIk+ELcIGauKNwztixrFsLjJ3dFxVbSANOgdvTksCneJOq4hONRS8CbAdux0ND9Lu4oe26L8VOO1I+A8Uhyd/CMojsNrwswoHrNR/ByzErAvNtcPo9I/Vgoq4TxxQEgSj8OFsDnExRF4Rs++4aQRCk6py/iENE+WO1PmM5Lh3nZ/6PE+ShT87dlHCzRdjoIlQjFxW8vWt8zroMsD99oaDXEDxXy4efWgKIW3k9tkVPu9Wqa26KMOLGegMfEySpt8DALXoz+MLOrrfQW7ZAVwOCH0X4UkmFLVxxm/bAs9Jr5myssCc5ia1L48CGvzpwEKx1KqbNokLYeooHoltfuqr5rlhiYNDfP3pC5CfWg/uDdvfllQjvDa3X1U6wKUx8rpVp17fFljWEkzSWfSQvZvbMpWtpxFGA62FbyByqsLVkgN6VDm2RU+9qx4491Q5ugUyA8Vd09757yWeS7E9IASgnBwe9sPQq1jGsyjOffJ77lWToJe1yAgOOzKfUtb3CJUESMe+0roGoeJIEJTql2ycr6CueXL5esy+pvccWsJhgJ42g0KBE0zHfO75NRmyNhfM7or0J/Pg6sSNM4uNhBhP4kkDu+3jFA2PyXPN9BuBJ2dtcfKD0lrB87XDsJLL3b86Fvg2bSclIro4sxSUoxN1Y0iA6NuFrp6VqMV1aP44P6HFhvSqMw2BngU/esoU3eKbSZmR+dMjJYc9djiitv4tgznrCk07dC0EJMQoIMkqXq1I4RdO3wmHW2Y5ygsL5GDOwFL44uMBeng4eE4yD2gpccAneQaLaenFwsPiEJUFHIqszn/lrsC9ddx+veJMkYdHLLLRMRc5WNPpxvQb9BvQIkDPmBdSrAmgThkDs1uqgB7h2Ell8be9RKxinSgY4XrheULixDD6hNo0oU1uSWbZe3RmlhPIcBfGMEpGKse79J1tLaLZzNt7f98Ww2gxE4TlOX9IKDUTdpilE81HTBevy3egPiI9f6CRMgEEHIj9c+YqIKkKhFA2LRyUCiIB1E/KkoTmd5rS+OLWB0+Ph0pSOwdNimNn0mo5jZ4q3uaqg2Mbg1zSpgK2RCphz4CJTW36MfTG9dubZ74EfBpxPvzXISnkCxwTT4DvisAC8nS3D/UEYUczd6fVoCHbfsrq/1dPeoUzk9HU3jQq1axeXe3vevJpieBGiZHe6Vp8bAuN6W1wz8GSVadWJM0bfvcC1PIFjppHZKD79qeu78/sXwuGyS29rsaZt6J118jetCVUYCozYhBBv+DVLJQPvLpZ7RZnitQ65JIs9IMvMISKYG+sF6ic3ZTwcRn7jWRLzfcttpCRhzgAl7zyRZ6QZeZn9aDp63npXmV4+ZAkk7FvubRYDfMca3fTg17ldPbAzvm+1RCt4o0bm/GfJvRBXm6wY7QfdcQDLe2PHOmG0R/Dpzlo+CrEHPX+w0ozsh7zR9efR+sk67ByAF+6glBFkFrwgNI0NcgvFcCCHoBHWaR3Z6jLx2x7bJZeLboaqW3f3SHRqCGn2qlyoD+OowKKyNig+ezV2BVV6NUSjolTO18R87ZlgM7dAtqydOrimVCVICWARAQ3+dYB7YJsSgczoz3SawsEBHAkCBu9m/hLba1eqFXJd0WeWdqywjLNbOSmLt0jgNli34wygzT7e6yVEgpaaz6dGCL/dS/sWlRtVjT24UcjM8LfmRZhSvyIZEAeLLgHY+T5eOyuyWEIfXW0OpDp1f4pNkqnlx2R/4qN7XESfFsnyTFO4M7FjHhP7Dzr5qntBDaFqLe5Vkci7R1CQRaDsnHhAaFXE5rQcbibLX119j/UHy6d1SBNzsVQ38ChPuAFGJgkeBAJBPVlCFsQNVhPMnVll4AC9slwnO8tqmNDU3I0pbCL4ByhRr9CmaX2mnPwybaD9PE52MWdLHA8GugPRNnwaqgkZJ6dPV+JopuOfcpqG40rAmgb80sGqf7nQpSG75XNziH4isa4/1IxAtbK8RlCr4y+cL15HlnIEqA7Kn7V6Pqm3Qb+085T5pIy8zAn/ZSFLhgZrYjPDnOqCDLWQ5NOVsUAQtXKDv9IxRhbK+hJjibcgmPwk1beRA9LSETYg4oqntcy45YHZHJEV2saYGokoBca/gKFCGjmRCk6AUJBV6LGQ2H+DcMxxoSbLnmanGsTopNZkQqVvfBvPMT8S+p8jdQXbpwfUlWd/2gGzHQgdAfVDK51jdP2GZQ+1snusWaffO+HLfJokFKjQwPOx7hnJZ1gUiHwvXBXq5mujJwco+IhYP779dMViySvhNCurD+cenoE57pnYcDJ1SNfAd+LVGFHwtjIqOCSGVa/+Ivm0eTwL2OZIrXOD+yQByiX99pCkpMzQc+tWe0oioMweYwjSHjhvjdsxe2Mcdm7mDumXc6PuY0VlisSZKbW6RH+66yyyhUOouA2sGVk7hTlqq1qT/GaSA55RkzsG6QEsstF44w0AjWAvz0l5uG9e1FDom48tLk0IVpNdMTRKGr9CujuYpNPFDDSWTjQXEiyJsA8To6Cy41rjOh2cmyb87+ScBTZjJm4rFkAWaXnRcHoEI7CT6qTrQAXpmeFf6hOHwgMExj+9QXJXYxQeFjo7Wr5vfQLjzCD7J7h4+Ed09mgseP1YP1OHj490xb1/Fiz1KrWkOGnBUPJgFjQo7lmSW9MafwR5/il0Y4Qu5TDYlknK3C4KkSm7GyLb8hrQee2VYMBNfInkHv+IWgT6nhYPn3yfbUddoPYIRV7r1IvllpqaQepzD1jHStHik6Zs3c8kttku5ZdOl4kcogkqnPCD1QIkWliAjxSbm4u5xxsWGb6klkTsZN7ZTPOfUEutfnlnLHaqTnWQkQTKwuR2RtPPjqNFF4Rw5oYTdBSnAcj5NHi/jpl1sJdLePgmFQgAIiisFEKcg2sHFAr76dTGVjJ5ZsFv42TEBcrCJFt+b+n/amzpkYmTEB8bnn8eEUs92PeN2z+x0v1rpMz1TL8bhPGk4qhiNAPS56hTV4781BKSk1nVlQfZPyF/3Fs38Re5xpQ1wZtLx+E9I3VXlFkGg/9FaKUtSKiDtfg6FJIbchHkYWp+8z+4ciFtc0VCmyFXrBUz1NJOWudkVZCeMnIrFfZXqmk4woKj2DbATXewDcI0teeDP3MMkDevbII3/vKPKhh3jGOXgIHoIVHMQRfNe8SBykYjfu0EZQgslVlSw9MMkUSNVrKvHiNxGrMuzueeSHZaXC3HPy383lRey9b3V20y0p0SMGTCzSXEPoLOKz7Ili6AJY7Ysz5rmpGdpnHjV2mkBnWHO1z0EgtPDR2v3WIJEFlk3wmw6s7lS3aLcUF9aB3PfmzIYcDNl2mQKOM27N36UAWlGsrmM+OKuMdFGlBF2S0ekxlV/0jHaYA+FZ1QKei3Z1g0gdr7mZMN7uqlvAS5en51/GMkzIU3FzG33syHGJN3yj0XZsilSuzW8ODYLF97TETSgRu4lahlMszB3TLuew3STSNkEQBFJ/dY2SCf+I87v0CLPcYqNycWptV+we8mTdWD37ouIKcc8BLSG73+9gW8lSBdydEWdGCQqpFWQjZm2mw60SQt6+K6m0dRHKO71d0gSgr5SajOHS5RrPdugvksqlHxTXPtmS6giowPIuiF7CbBCOdAHXpN4S1eGXQdR/j+YuSm6bXZ/RoREYUTOM+4XJ0WxUj7EalpPKHKKjQc3REX590Np2kBqGAqDQ/UdMFFYU4OsmZ5dF4Ve4WtYagcFF4+FIS7NqSgOOcvSf1m24NErLVNTGcS0DZnZm8ajGe4tECC6ZkTLJ+F3DPHghjj/rmOJMXUrTjyv4lWTB8vxEd7uo4KcJoWn3c4FYXPPl/WbcpGO4tR5VuaiUNacfIoXWA+QFNelkR+O2DDnXFppXS1mu6cHN2E3M0LQNzuoOuGasHCZao2Qb+t43LLib/SrFF8gLnEQGqdbdobsBSwQeIw0GmKXiiTdSbV8sMZRmyISyaS0l60vBUEt6fPhomJI/CuOTKy5OvVivbiL2Rp3wAIKtq0ocTZENxKsI4AbVx9/vk0BeNgIYSeIESaer/+NjG9qSu5vY0lRx2+2u++o4z1PHi1kAZ9Tvdbefk+Gn+ANW8P3RjSnj/FfeFLxnopaDjcTZUZlMgv+GOQArXQdkOu+hIZm0KmLT70VYr6KwdnT9w3fGoExmOF1qeR3bTNrmgHE1UEGhU4rZa4Fv3vKzVesdf0XozBny6u5kZIjR42OY6/dlZxNvm2jk4aDmlcDJfJ+Vap+dzxNHNJiKSb6usJmtyg5rWCohNMOjq1g1T5Ub11LZ81e7V2lTwEk7KhGVstt6UkzJ/kH2HBQSnFV2wUSgjbxVsMp8cd184nfPBX600Gos0lUiO5A7qP8wr1TKFbDu5XAtv79ZvzrVvkqibPAui+YR8Dv1r2dfTL4EjTmrs7D4kd98kx1b6rPmUc0mA3sSDyjB7m1N1HRhENwHTUrxkT3X7ov7hOwBnXDoMZB7S/20qj80opZV55rP1ZyaRaU+FRqKn8NT43f0KqWHc+HOIo7Yauyz0e5cBNTEOvr7yELKsIILeeQdcN3zakZj+4CVe6xFfIwjJ4CLBQfEbFbt0NR8UNYm2hKpMtT5iQlCdyTvtOtzmhVzh8A0R2Cvvt53IgTLi3Z7tTSgqj15vXUqUKRnF+CAda1N2BUhLK6Rt9MP+3wOtcazWmiZxmsN4r+ilY0MsxuSooQQmMI+EKC63xZbCQAEwGeeyR5nzyhhHOiXXK1P2ntUFPsAkJZ7STBvquaL2A8sg5KpkC1DLM7PUi6cHBJFVgLobBbpRBBRkuOUX6U/bIWb8N+H9ero5SPq134AcNalP3faX9m6t7c7lTW2c5mP/uSdVcmqvfSl0nQa3sIcvir3AVMXFOmiI5sFfC85rEqfYeSqCHvwVwIcz2FOP1YUZZ+bTrLXEUbSomLk0CnzFtSeG2cbF5FR7KP1rSS4Ob/CxFIOWb55ApvAvQeR/4/68wdXvuTbHF//mzbYy2K4djFNCjVcyB2QJJNjeOVdOJ0fxT6u+iR8+hdTAuZvoZfrTBBXK30cHd1uJEBz05Osgb/xVarXtgfdNCFdFT3wxaPEEL03azxe3Y6qAh4SRLIkMtDhMW9iBuzMbSiZCx/coAHNNpuQiwdND0u/S+uL5iT6daaLFMTUi5fFpGGLyq52ExRkkCC+nY4e2HMqwiuLJnwM7Fx7gjBQATALSqbdNm0bD4J4VGoRsae+1T30lcVWod6/wHpG0tCxZv4uTCnv/dOCVg8UsXX7yuto82Fdf4XlAjRDh/HwXBeuEoJGppzl7gD5TVYhaUTYt180BMj1NOdA2kJyZw3d7v580kIHdN2GJVcpqYoN8pKWTRqwAVqJnw5jamL3lRJEu7IXZ5uw3LlwGSnv2LuTNaXXsGQZ5xtWE3cqSwGBTZLe40QrHCw0cL3V5bfyUQu08rHgNVySYijp4yNFNIpYuv3lcy7UghFRCHxP8aRsa2eAMbC1QxlGJGjtN/1FiMZofCPqszw8E43Zs95Rr4wYNvLZljrqcW2o9UGoXD3nL+0n2XOewmeakrKbkB5YVa0fspOqGcApXUMVoWidFo0B/py59tsMJ4iTJLlaJzSVBTbyf8+eTW2wKXkWl9lVGjEwyTsgrjnlnwvHXh1gF2NpMV2JYGGN/t3m8cnoDUddcmE32vw02ns20AOg1YBXN0jq+Ia94uZmkcjBiT3fckP47RuCcKRWD/oGuJodUyAGA0fGNkP4kg5cWltDXN3ZAv9TbPmDAuxDqmEtFDbYDq3zPr7PH1+5Y3XdiFgOesUkO54wfLLpui3WLSUgYR1lSVluqNjAjvaAYQjHRQBK0JuwI3i9pNQNoE4RpYkNXz/bDEFKQEOiiEqhXatXyFIGNN7WC8a7JXDxzc22+6dhyuoSXbmb4t3gF1N2JsaMl9dhIa2SkJht+FA2d4cDZNdyKAu30o81Ia5GUqyDIM843vRZKJeFPZopp0hrmkecXcToW9iAkJ8KE/Jp6g16SI/ZxvYTbSqW5z2EzzVpRi6wpdEGB7JbdKm87zpzmopqovAVsWK2dR2nyhxJjX9avKimucoYrixAe5++bfZligHQWews6Fw8KdQ9H/FWn3uLRCJmUS998HHorzywWdZ6wYPWqOMNfIYkUfZo4N8NvSkyFPRFVyPmi+ltwj9LBjyW6kHXo6c1Ag4ogS1sqGMiFs0BANu19lcIcKgfUV4O+lQIXju/n9MGQdfkKeu8PxEeXtmQrmwctU4o2/AXpatErn2Mxhme7Q/S77EWyqcmfJ9wDZ/7FniEbxYhX3W0xy050zfwQwdVAZPYGIReCYYPsrZxRN6/FrBXBBYIxmkTL1q1b8uyL7yqUUIdT0DFc0pEoatU0umNb1B0tG6J+n445xKzCuTyR34RCZbsTMd4wynMh9H2QqbZeUfv3ObEsGV+9d+bGrBaz6Q/Rovtw8VPuIoVA+az0h5Ry3DOSbWhX0D9Mlvp3fxuZd35a/bhled4G3bDG1SHC5eHkSFJP7Pk8bJ9UWOyIJUrtdRr3YoB54I0CRgIGIM1TfXmhk2IGWBUthBzzgUH6aXNcJ8P9Vv06fcgEgZVud0s5uCBpj0R1XBEeDIQpFG3N3qq707QnuB5ASUc/2hAAAAAAG6djOQpPyvMTD01rQS9b5WP0UQ2KCOcjFwjpPxcU/YJI4aWMstUib8zGwWvnhTnZIumsO9hmawo8ejLZMMRrrCih6sR6Hhj/tq0mjhmV62Ev9UB6w7h1Zuee8F7ywpHxcrls+/xiZzHQncZVcXxWE2hlvpTDIafAqQAg791YCL6hDx3V9ABLgg4wdAzisQRzuP/KzskMT1leWEMFTHdgIHNM+IsTBj/0ivL87lDfmp9K8U5LkFuaO6+GMwHIidS+octBfgJoKzDxerUdarOTkcqcwBbzvsqJXi0S7A0w9Jk2CopKK2MR0jmChKnTRsDKqpz+KJHp88BLYKU41K0SwL0em/3uEORXMAnBvf5AQT/z8bMDCmVVFlFvY2ZcULHtNt2G+UJrB4K/Rq0Xe+JZnv8Qabg+oAu6aEdFDPxq2XUAXyqWYE9u7nibzSIyzgLNmU6fUOLBsGKw6zviLa4WeF1lRsssZ3vYEHcNaf0FCUyABy4BCN+HC7VOs5Y+DLQ5+qMpXgsl7Q74QLoG7HOpqFr8N0kqE27alIeHIPHq+RZUJlKUHFClciDc3GN6f4I0l05F8MIhIK2FswENcspIfOWQd1DLWhI/1zxRNSLZ2DS6C04v+VtCOU88Rp7VxBXk29tGrVcx6BTU/JICIhQMH1RpXKkdIvmDzq0EDAQB9fI9SkEkh7obmYRYDBscoXJ9Icxb/m6mpn2OCgo4TwRNHcoAWB4X2LBnFXPK9805zoXmkX1APfyu7eFOGHhvxzmi3BX+1TnEyIBTVLjlVTYpOZp8RSHgO5UxFv3U5dUWBygKZX6ArPaoyI6BD8A1kPGmRT7CMmbK5sA74FjoAbc7gzEuXQcgVBb+iA63FPnDN1Vgh6NNA1jCmPhQOoBprL7wkC6o1ZCX0X7iUTJM6JH49DER4n7E3vxNPHrXF0Uh4Ekk7ARwRFvQW7PzJbOi1cVV8XleQDgwFzaoac7X4wP/4amxeUs5imUiqNi+9d3YMpLrhB+V6QSp1lD/SZBPiArSE4XJWAYpCZgCArbaKsc3BkZDqzVbU/vVYGNP8GOWrA1MJzd+TCWNAMo9fAkvfc3w3714AnrQ16fSXiSuBrGUwffWykEyG/e1RzztOd4ePhuW8RlcYFAjUgQluL+smAVulUnTVX+wI38aykGfhiZSQp3vI6NGrkBDlNZwmrUiTspoTx7h6NyISZRdlk6LLuUZL9t2oZOhcPPjzVMnm1VE3psdXuOcah1Ei9q9tcXT6bdG8X6yL/0ajANeBSBRZ7AyCRJeTbm58496eS8fvd0y7AGNNWVnTAWUaqvW32JsnEBI9xg6LVYtCnT+DYz+1hYnOOnH1dAyalw/SGuHWrMA7FrWxcPNrfG/rhoVlG6Y2etRf3dYV9bYwOaAl5mUWpdu9CydGmnGD6QC35bTVP75oBGzf+eX+sdq9dvB1xbhtAL+WLsJkLnkPtjbimSHCN+csv66md3vu3NAFS1jNHyU/pgPOcYMYqCsd8uH4OE4i5eX04RYxncJMFAxOAJoP2GFHTEPz5Gbqw05ZFIK70l5rGZdUJV27xRSO/ucKErAOJCI7Fl3kk+VejwSz9ydZSCt+2fef7kuOMBsxxwlDKWB59YTc+GaxxXkxFFLKVtRXfpedTwlelhuLfULpzNLYk8lgfBb2Vlj78SER0+NYJ5nvsfsH2//SE7/O5G9tpLSqroTHLGgU8zuLoen6gSrgYlFU0EmLXkh7H6HyQtMhc8h9sOtMRqBQrdvJlZMbFKLJ8CShnllNLM/3YCABS+G2OgFShlTHbC86a1GT/hnT5H5yCPnseQiibs1Tz+widyXisxpaS68tbeVrh0ZNOKxQK8UxnDodAcV8ida/Pa26kAABi2vciL7LNDy9ajGdSHduUj9Zq91i4jBExNbYHB+8hcIs73f2kwJqrwKs7TYoDRD67OUJQPLqPpB/EZaAzIL8zejq22zM3ONiWfUHzDoQRGUixCe/isLyINxCZ2Wz2adsqO+azbLtUHk22s2mpLWO16vnFVJFAPcDI2wej4Fpll3iC68xsBR3pcF2t5lrFitYTfnWf7QfXKHTgAAeQRjf6mWrPNAvChp3qWL4ftmEFemLW+3IFTTbtGI17cocnCJZK6bJ3gK1rTFtykFcP5G5bJ4mZHiqcipaNuAWCq9+6SxdoHd3CM7MjkuF5JW+vxA4hVsdzOYcIlfo5X+Sd0GuIJKC0AhCAeOiJVdAXDaHGNTx5NahG0yA/iFJqzmPPsHW67hdWXeql89/T293xohW9YXgCrjRAVz2xZU8t7ULihOzI/2jO8kppBHbM5wT2pT+J3zb3CYRIvix98ijY1r8bGJowMBdc0/jhzLO0151bPU8RbrCheJR98n4eS36UerP8Jf7OQjNvx1okB2/qbg3SYZSP+dnqo/a6Sv2/hv21Jh/STrgYcdzCIxBMH2TG+kX0PErvZxp2Vw/kblsniZkegHyi0pOijvE8vL61wwxm/zaqimeexUHkH0mgAwcvwUzDesLwBVxogK57YsqeXDyqU6MaZrHMZiOs4q2VW+ju5qP50/PdlvxVBfEqvK/1jeGQ1K/wodkSLqUbWAjV3qqEZXtGJprfsXDrahGYI0csiwujb2W6esvq7BycXaUuOcqovWYtz+1fDqf0ljy+numCqoeyyw+A4aJgiR3MyHmTPmEPHhglGFC3/CgLcZB6UYvtS3HMH54tGMqsgy92rY5S3iB9CM8yJFlaoyGAenqHjBXOIT/GW5FkdsKZPcXEQdR7MRAp5TIc0amAiwUJ3qGd/D2HFHOkzMaql9nKf73AaGRNKq+Jau7gCA5xBzXrMY0gAi0DcJwu2F5TYAV4ZL49fsoEen9Uu7ISraS/m+rYANQUy5WSfRmXTW8cyb1UN31YujmZ5jBQNAwoayE0HdR8+lboRT7hNnm7f1t0/eTtf8IF67mDYGCNAhODE892BB+ANwEca/JnpZhD0auXDIAUJ1SS80MhqZCzRRISCDgXqCx9L/e6Q0xZKY8zCD2Zq6cVXyyDw6XmLeIN+sCH0COHJWVVuZVuuMxGhdrrhOkRqxcB74KybPYe0sup5rssFodVAgMSMj6bLhOYViJ8kHJcpzaDYTz8coxWd+7w/RgOo30XIkb8imNZcty8AdUs4gAEU10qquuJqQ0iIrLAN/8j9r6kPij1xGomVomiv1B3G1kiaSAUxlGrMyf75r+cNwMhAjHEggcRb3pRgSG437Yijxkc8Z1aGw6DSBinAvY0O5H64VUkBGCJKEO4nJyGBSIaSxFniqgs5rG/5DQxLhBucj1oG+y33BT/7vhzmag+3EGKupagNcRS4YQETXrZYJC7THkKBIgRULSPLgz0fjUzGgJ7xT43iYOLRJhyPiDciAZpqsGwrvfEsvBhfqP+SYM3mBCheDldGttQu9F65uZaxM2X+aAbzfZYgcSAxbdoAuP08UwOXQd4CxNBgxNpYXRcMPJYpZe+NLjE7vmqPhX+TbrcIjtLDhXD+iVob1taP68oBZC1FS6HSnunnjYYNj7IyMpmlDirFRQ3EMeAl/czo6YHBaUM/+L4L16M04E4u9WUsYA6xzOoP0GBJT7UPsXTdbMnde+hXcQGk7tIhFW6jQU+PzhWjPrbs4cOOdwLup3NsbPYGF7nlAEOsyj5BzHP8WyG3UHyJbuuLTj+e0R4ldnPvxpbHjPcF7NrwlGIgTp/N/4Trf5Ei6b2MjYjt3IYL9XQEWAJE+hYjGrWv/js9APnn8V3//qF72vC2/Ym+OrGWBqYdCi0qx4VXw12PzKR1CD5Wkg7AAO2P0jXmniG4P0Oac1GQNeqVUEh1iwWHWrPYH4cxhFVi6dOmAA+5NHNuV+BExray2k+UNvxXyG6uGCPiB8PQuDPtDZiIm6y2bpkENxCxrWsxBUFkK9seVdAHriI3psjsRS0CmciXuTEJyNOaiFKR2dVHwFEJXnZFj35IxWI2FKucFkk6II//3hoGuz+Ya2SD6gyH+Qe7+dV8i1cwUhXv63PtgU+2a+Rqt5s6TrHTrqZwX9z9ihTX5cOOBuGgKCjkcRog/6pY8JyHQe1m6SU64wLxJdN3flPcA7Q8JRX7By6rzptaK/2cWdrSEVSXLHXRWV5Fjbuyq+rzuTzTiCN9VSXHHJu5Q0G7BOvQI3HLxflQrl7XZ5yBCNX7wP9AkSMEOQ+LeT4GRdChV2bOaFqdNApuFahOswvDLtj283jufLEyeAuYuJl7gFXOBvbk+cW6zzWyYu9325vJR95/Sb+aGX8HLoIfLqy6McYk0Sq+H62OuDekFdIKth8UwnJTZ89PtE8G8zfioHz+PCdA354jpg5Ba+QhPvGPX4JJSjuDLtRBEL2IuDwZ1/5SM2yOmYk0Sqfrdlp2+FCAFC0UwDE1GV27nIj99dFinHVf0BuKclls8S1LIIaVpg9GQLu74/rasHeEj1PEBYKjmQlyI+2k5EovqMUXsbfeF4XoJ+Eou9CbklvSKFE4lzuoLjipGcYk+F2fJQdsdYta6kmSyscSUmCGjoSsjv6WabcVWxirIqC9kpRLfVBR7SLtHRdbBmJtAAiCtRqY8FlFH6IENf88vnUOFAlbD0M1AGNAPhHLeJebGQC7EtfnOy9FcNAhpOpmwbqzAA3iFh31gmPLkn9skJxnUstqnzlsp5JfebnahsYmpgGVRHMTVivuImOG0xwAjkYQbaOXERzzQ70NW2O0eyPpAkgMjv2P2iZA75MGiDYP7TePTXHUo+X3nAmV1gz0w/aTDqzAVPqmU+oez3Ue6FU2GXZWsdE4FnnK70GDPywavhPQBgPfR4JsPTb+WAjc2gaBgNZgCP2QpFZ8P0aNwsFC8Sj9MDOob1BRylNIHtAyEEcMZssLILAw0jaANAyspKr+zjs+i7mB4E1tluEyxEhAOU93gX4Kd+5iYbfykhnDAg2SEKjOhbOPuwjbkuk7+F3oGSWEW0n97fIZPejtlniD3q95F3+mPKSsggqRzFTc+jsPWf78EUX/D8hEPRc4EXyfZj7fHFQQ7Zk6GNtpV8CvYy2NhoqYJdqSZ7GYAWKhK3tMVp2A3Aqd8rpDVIC6NQKfTgCM0Gk+3L8kfwmDZxUAAsS88NF05yolLEe+fsJ1nAoIQDLRjbnI3kI43U1rPzcv26viS0gfuxYClQBHJcu8LYAO5baKA7CuMQPMm2V4JLM4RXShVlwsmndMJCiw/TNekSC691hua4MmlQKJnoLgWyZfU4s7UxmlGN4FOvGhYY5kSA9I9Lrl87L3TBHkCk6wWMxbhRMIMke+U2Nntc9jLe3LCEuyKqXfvq3NJER/7pzzChRdVC0WqRc+dtm4tI7oMnJzTgjxRYnSFr/4fxetWyjhg2FOA06oO6M4JLObJR/paZpH+oZIOUo2Wl7KEnEkEeQVn9o9/wy3Q1GV20XhBzdvroXFII6ksDchZUPxOhyM4UChiL9iukm3wS8rIVqFk53m+99fXk5EIOt4HCIXc2N9EyfwOYIVPaNAltNbfsUBuY8wttUbNKvcB1KVDeF9R05992U9kwFqWXYdckg/k6wXwC4nDL8z6YQdetzMnBg8N5eKaLep5XtP2u4y2DMmYXbWYwK6OOumMsroBo/hB5NxlO2wxMq2CI4AvyIeTiJ6BEVV8diY3f5MxXrB71SS+ChcTDRP5HNuV+joUOTqRKMLt0SxR1AWQ6ps9Fl3clxWW4014QMq+rpLjaxkb94FfDbolkYY1NreT6O7DosufTIZprwgZobsAyy7jHt8yUWG3ksUumgZ57ZcIGcojdNB06FxcIklrG+ZSF9URYDfWi/o8913RYRs43/+wPzGkaazarjnvoHjhBb5dh4ACKVEi1Yt5qolHafcgk49JrTXVbHG0/h7wn0avAguDlLkhxvdZrzv+Z0AaekAi8duG+vXP0SS3eRW+BjEWFecAQuV3gAQGPssE11J56+ksbjihx4c41YDecxYriAe+ZuEcP4trwlGIgThLgNPEKkTP9TSxGo2znWUChQCu2ZLpxlHKbyMSn056sPrsXV4MAvSC/GqLDVnR/q38i8x194QdHsB2WGND2o4haiqu/5KGzGQ8ejqRjoQbkXYD9q8s9s/UtBNG+2Rgzx/cM3PiXamoOax0/XG1rQ8pn6Lj2/NSV3AbYw0CGRcf/OE3YxrUNboaC7g6ABJHKWRpMCt52RUp6fh8iIWXPDilFhqJiHTXwfLamC1iDJM7krKVlT7an82PS5V6EhMdyuo5CuoTylX/vHfrqOWFUBR0RtLsv1ETPo6AC7Dy5Bk1yBQudnbZfxoYGiR2W7B9NRzZMERAh42zjgObaaxN2hCFAXkBgKjrRV1zPaNWShl3hqaxK11U/vwfo1+1+/67mQeiwvd6paT1Ra4IBWtik72uv4h/iVaPGGncEg0NwfltPAoZXX/t6sdK+gyKt8h2+yU3jP3zA4x+leV62fnlG6zlkjx2gQlBcGcVzwXiMj7Xs0fi9XmSK51Bcg+dGjqDzy5fNE6VWoN+b7baSXsSfJgyOmNDDq4Fl8C0YC2vTfculxDQjvX8ebhBl0uUJrrJrdk/ZeSk3F3lDEO6YSyGtWHvChdyhtYJb8qvjUJAVUaCmQ6obFoO4lkOLOOGyT1vFd5UXIIxH3Cmz9TqDdVPyoBsM61Xs1I68YhkEVmsx2ghRNvagcyelFEU5OKMGrKEyNF4Xiznrvw9TxngurI64rRXnuLEyzz4qs1iW1IA1uaXZq/mWK4YhtQfho5w7k8JM+t4EtPUHnMbv4IcBd32O7L1oUZICzwg9TWyQxxemzqdHhUvBdK2KqQmllyMnOTKYbJlAWW9qDI/nHeJLsvYX8+EbRtOujZCrflyVkG8A1wiXkwBAmdSQ4MiZljJtmdjLus/xCDObyxUQQ24V43ULYo39FcOe9+5I4Mdh60YjOfUFXuxaRpDXIbm8cHoohOdZexoJEh0tb+dUW8ebA4a2Mtl3EmrsztgVsiZalcRAOrzf0LFPeCtv9eKo+sUcDK/DYSQlXCBtf1B6Q6DEQNRZVm9pCM5gHZdAh9E/VML9qUPfrvJ1b9ihTX4Z8NFyu1kcBqVG0dIeGoXoWfQ0n3Ih/mXS40BJeY61ZTOlsDkW9jkKER+/QC7KrrlEUC9+F1vheGVY7Ziej3SroBj2JZI54zW15bJtYjkHA9mghROMoGQBWIV4s51hSx4erpFv36GGASAklzs5PI9X2QO5uE+T7D0b68sS7Vzt2DuBa7r5pz4swl8WZ0P3q3NcM5wFJCxFaVT3jqFzChGDMq5xe31fTex5UFfaSp1uhxjM3A/1AF11mLdQQbiImBqEKHkk5pUJIvHt90z1rzqQO+j7vGuoc0QzFCVAUCAAm9uTsrvkhXOOkoqmuY60+EgORRDrs7STslRNIKb8Ok69cQnUySl67ZZRDpopZoIvU3koKH4+Aa0tKNoDngKfCPTwqCZMILTYpMocotUnkAVs4LCkCFbLs+enap7r/m+MK9DPLdd5EBg05Va1+2SE4FVubnBGVs8o1PdfQ5sRhCV5+0pOBSMvJps0CI0EQZOImfM7l/2KQwGcYHVyBcKuGFCsm6b+i1bmHPp8b+FL5wHzjOi0Bp8ykPk00s7ZFJmGcyyH7W9BOSXxXzR3QteOj8PrQIX9AbblXrRkLdRMnbcdReZE8JBMnLep5Dt/204MCDhw4n+mkonAVQZ/yHsFmOAVT8JPqBytHb4arFt0CLpMaJ/GVHPVO18VaX/FzqSkK3btaOZdRLGjOlyxqZWuPHrWqTCZg+OWpX7ZBPkbt/jxiM9KNOnb9f4xGriAa1XPqyWZ3/HwHzA5Fa4CcVZlQcFkoewfjl+JrizBjnW1kZfGk2QX1aYQj6zaKfGo52+kEcKEHRTcvLtIWz2HcYu54xwfDDktatO2Xpect7AOSWoer9LLtkDREiXiM1Np23UuBuqXRC7mWSEVAX0Bi0hCkDSX7fqqLy00jMd753crNP+qJ2YCN+kJs2Zj+559KOyhqpdqeYmvmYoapGKuqmOBXDPN/GSP1bkzah1CB3tMfBr4JruXlJdG57H0HGqd1cYrAYe1e8LrqgSZXHC38HSCaavuuh7pXnlr9nsi7neMYtdjX8Z1vRSp7uqxlLY3ubtyXIZ/Umt+4CHYbSNw0Gk+3Osda8kRp512m616UmesdGJRHrAdzuhFYwD7zGzdTFC1MMlWIVSZQg7kt31tO57bQ61vwyB9vQwOLwfgUBjJ8OJblNy5uoljRnS5Y1MrXHj1rv4/zdyGT6mzD2EMzXQx5jq0nEhsJbyA4juRm3RYYH58c7YiAAC5UrqpEjsC9iMIJ8sWFYjJY8xJig86TcBuj1zWA9VCAP/6M2+f+QpGb7CjQFSdLDk7szwv7ALkzKrTL05zvvPU4iPbxDBAOncDbolhw1u9+U1PWXzzjKH165r6ukuSugIjdNQPVjB/Dj6rUNEjiOBiphaiIp22rfma7PUmVBE/JXyjti886GdJQjgWYgBtDdeMiqzBk7ujHdwoDP60mTIzY5STiMLiBMWpWjwGmqOP+WXUimVl+JAA4yIX1VZ49NeKBkm19b9HNN6dSzAgS/vgHPuDIwJ1s6nO5tj8iJ8F6xM8J0f+y+Ve4bqCY0oX5bk7I5Eh457LFfHhkcxE9V6HGyA4eTMHSqrQxA1aMwCHy5vD9m6gNZngj9ImTV18FLjhht6Sz5bRCMZBYLI6wSqg1TOodRPKukUxcGuIJQ6wjze7dqqtwdESbTXy12wPiJtFvAj0PUYaCG5wHdW1P0zGG4iWWQxkTNsQGgtQFl00TUvB3p/cu+EOmNe3wBrvzA4EyFy+xtK9MS9AOLGSUPGnYeZUl9osMLnaGAl5+2/62jf0RW3yb+87OlgNHgIy9NLRjYPv18TNQ7U8vjyZg/+WSh7m09Jd+BZ/WZ26GW+YlPoPUC0GmlgS3qrKTqrbhwHjrpy3foNf3FV74u38QKOi5WZ8A+E3hWu1bO2ct8JFTT2P1p9SMPMwBCccH+nHhxq/GSeT1EdhKWtMLZgmYN6SSBg2Nui014f/J+7P57g6IkGwTd8L7xuA0+CZeMwXGEkbNVk2rEfiIxvPycE2gSZzhTfsuyLaB0lEZ/qfjrRHp6aNDWiwj6/QB7Yp5vqfLGb9NGnFPx1b8nrL4DnYloyLAjnXckfljm9zPevD2O0fzbGQV2OeftKfTAKGw3RoMQ7daMF54X4YiDwQREP1uBdafjhLSz4eB+AsEIcfoqDnpDgrkrUD965L2kl0ryLOIXOAwVZXde6KbJ9sm1Q2ug10cXQ3FE596P8BL7nqrmE8VTVN+zSC9nlfZBhGypo9AmNCGqpm0iusOFymy54BOM8aHGi5LeWKPGZAfA3wjKwTAyBoSpkmB6oxJtUJF8FBFaTcvdM89to1HzYdzn8m9dtoTmznLB3ocdVspFHDCoswwz2FWt63rMfa9f6dLsNwUioPjA28IO5ZjhWrBmCBPmNf7/5L7BiCgG5p1DrFdFDtHspsml28kv1JSE23Vfa74z4hZlkRnmRE0cpcqcAm7VQUI4ukMZQPHPXuPgZMsVw8XZaGVWLyjHw6Y6C2dE63cbqpsd+v8bd2jYs3/zrvOXkO6r9iEXBun95FYlDo5F9htbEP17srLwck0eXKjQOUgqghPPyb4ICv7HVRiRfE1TYt8i9hXAlAhGTi6+vNrhVqfOY+36YdJBVWZm8qc/A1n55gizrhUWibAC1B714thAN+pcs8EWtZai0KTtErH8uh02T3/h44Atca0E7jHOuulvOKlnAt/BY5Qb8+usTOr+4su4vppMepNbvIIq814YNNpvplTedRwoU0nms87zIR90tW/xAacfN1cwLMW90Jviw2I6UNTXUZ/++KysXQh/fPK2TF0HnqJPp57LJgtFIW98QPBMaki77oZFtdYKHGKNa45cCJB1HcVLE+n1YC3qWE03Yj8hbSApMr+3lRTwoeG19a+5Uqxz19roXsHWgq/7mKYe7fqr4V4A/fyTRR1r/i3b/IOSqpOmyb2yLZ3FEH3L85hPgrByYSz1pmyhezqg4tXqW2e8bWj5KGP28KOYZ4JeTvwLEdJzzKAPeIJIXc3sMqAOZbGG7/ztGcTTnZz11k0/3iMzJg27jV7GwEuT508kowgbRXJPhj8KrcCmWxIELP1Xyum2jHN5T6gzPEHq3zgvbxS3KRVBoLXjxcacPv5wGbjjoTS7B6pStTRX4ZIL/+6xAAS3H7iK7+5VCkZjFHOKvF1OdlLiFyVn37/Tcj0RsZmFCuaBP3l05zKVoqL1h1MWB/feoy/V6v90YbcE7MlUbLlNX87TCIO2Izh71ij3zIxfw61imWFTGKHKCHe707Tp2wAbR40xonkEo4k9SQFYp1XjHZjuvIuaBl1mCF7LMtdTXU+8c4Kppe5CUgpb6mCGaUzMVkHnmbrjU8E8XK3fNivjrgVitA7VJx13CFRQDhj5ez7efYVfe0LCvRnzZ5YvVP/EK2AaAiOjMxWFXQjh34aa3+M0rRbDbp5+rrLwg4JFA0xOHJqP5V3U91LV8Rg0S/xm+a2rhQRu4G+rptiCY6mW0eXRCA2A/tVwxfgqflx+yfYUlCBYokxVsrwSWchtn/cXSCV0/aVEqXjFOffBHO4fuufsJr2AHzknGwvAHp9DvKWjLTidkgKF93kiGrcnfKh2kVIFTY7R0Rn79QWkTnoF/91gEF8YGUpUrHwDXZEINbSsiDDmA84/rFbqEN896fqR8DdoyhuOgy6Te2JZdML8k/XxNuSgOh2SB0YaISORUPgu6RJY0wRi4q3XIm7aKBpP7JuIneRImOSuuIL9OSEYyre+GjGFHdsdNmrYZTKukm5Uo8S1Ms+TKJO3wUWbBtts5f+bAP9qCD7u1VjyaHG0lIqHg5u3Obsa9szMOByj4+PaEm1oacRWspwtNLPqsHPKjnbBJs2eGA8tp3uHPBCjl73fl0PR4D69IXSyQkRf8s2F+txxvxoizKrHQoIV72+YLO62snychRjELz3/FD3HCmBjQjCK0KrppqglHikb64k6mtZF1uVU7eU4QA+RDSzQbfv2ov97CgqhN8C6mHbiJ0ha/+H8XrVspFP2MWprJ8r6jWqnp/syw/GwpaanRX/9wfqZrpnbdKFbdgyDv/LF4MUiZgXT1eFEGTwBFJEInnZioouebAgAAqySYo5V+Tr3g4SfAOwABEqK9oZQvXzCaf1589RF5I7YnxrfkTOE4i/bxCTamMuUMokgrVG3ZDNKHlnondOkDueBUUnqbFvcxhMFiuTUVw2SjHQvcIHqGffa/9h2fwx/LI0iSqAbCqMTHZb00YSAGeuIDggCvhPn2watmyjcUGhxkqhBrNjoGi0iCqnY69rl2aOK+qOC4dsElmGHTymAmcwFxiaIzzU8S+FoMzWIihS0bKz6k+Tzmteuc1MV8eUPnlhTc0kra0ZOVcGrlUbw71oPul1AMHRKp9vMQUQZRkc3PI540HsxsYhWbTqIkE42xbAA/NpLQkgfXETa+cp3rLJ1L+SPm5FCqZFexEQAdT8GXLDOU7wtGE6vjEHDQf5uzyPVz6in+jXGrv3FjHDhWQKAAADGenh/vRhSBM9EA6iU7BlzDd6Xwd/jRrFNHwAG6GaRtlTi0agDTy9//kVcpkDhD/kNXzyGyqydOmFyQU16jC9HC1h5BRsL48UymUoeXd02QA/SEHzMSYySTLXVdysqYzQBBbn/Fwcj0T4/5QegHnqnDlNJkcUeifkuIz3/3JZrF9o9sDIFeStvp3A0gouadGYg1eVrPQ59FiV30FuRn6Co/XS0JxUDQLnMwZvrUDarvrFZ7a529gKNAWIwslHcPdbsLKXPEggejfP39YXtefTf5gOLPnc2xrevuvKBdyNPaln/xMWkjt0PihIsk4kpj9heKpkWwX5BvZGp+OxMIb6BAYQv8ZDYTSFZcrGAtA1GQw+gtiUO0nz+IDAu5eighIru7s0qAdYSxcJFwXmW2KBEkLG5OWpagwinsHSZ8+vn+0dTNCmSfuMjEnpAF9YsaLTOmwDtks0qHc5HkXGfk69VXCwUqqxyfyG2vyg/KWMS8CeDrqi3Cbh+rsDcQvTq91T224KJ24Cg06JJqbp5K/W9QrExsAThV7b/SW7mYzNlTSOv9OzGLyibGw/JsX3VAYieAZmqKszG2vGeoERCgxZL+garFSJPgvOQKJCmJc6INO3n2U2SPsCs4nvrYF03q4t6UXMzaABaRYGNNrUK6XGMBpEqI4kC1jJ8+xoRUU7c9yl3CA2cmRamxy3p9A73LnKZdejXji1kb/RruTnvvbYVk+f3GV1o4LX+fNqaSnADqko5XxA9NcDuU9Fe4uAWaRTICQO2lcN/G+tG3SoXNXoPzGjhsf2f8llEXyPO7YNvRwFBZJ9nA1QTi6Bohn72SHqWShstCGMdCUz/0+YTAe8mH6Iv6vRjDTe3WHHKoWTIq/FVokupf0XCDXHg7ZF1xW3g2xIfxSq66USCnVSdrDHEfq9N+NHH+EuVMm2XvP6VhclE9KukaaX2wb9eWdD0OgX5gI504VzUcATCBDzXgCGC32qyv091hfj8vXm0RsLjB9yNudhr/h+M2MIaj/xfrLWOtzR37CR9i4buMawOOIJryZ/0dP2mwDDiiQStITB5gLts9ILMCWrAn1GzSvseGG7NUQXwntBwy/FJT/1O/0B2V6RJIfg+qkjVF5GIuOQDedtj1hgtMVOIbGrwf2qrJ87hlhgXrZjy3uSSXNOK6r4vq9MBbDp9z4+XsOIgIKto38tIpTW2AhmeKK4+FUvwaV03IiAb3x3dK5Btkw4wZk9SEvYl1iIDhfBxhwXqjkbU3GsGo5hI/awiZB4YxYEzvhcf+umcl9sX6AQJI9EyAH/SMJDgnDMT1e2jFJG0PYtqik5oxPORtmVtqGsbJcZEQl5z4Nc4O6WK7Pq5qgyKGI5pPSd86poFI6UiuBnEl3M829CW5U12D2LmP0AHhVHOb7n7Ymg+DVMYdWnhqYagoHIMZyk7/JcADuZS9CR2MBvqwxqWPcBA2cccx7YkSQ0C4SMu0erLwaq06LTqQ3AgeDGqfylXKeJSAEpSHrSzCYTKiJM3Sm6VM4sknx02fxIaiGWddx/+BHijk/VvQf5/uMq7AoYSnLTH3oR7V6OVoZRAtsnh1cMXKqh7hQdz3/l+XBVKIsyP4Mb4h7m5X9DrmTfsOExnbu4QHyhNzEmnJOJ/1VE9huVfPung3u2X8TKccHbthHx2j2P/PZvcqY6O6PbXNFEzsxG7vzBwFAVucQza+pyqBjFmcdaVMtIOzDPfSw6/z6V8+YW0kPt1HpL/EWX4JcFthvIKBG9kfjigFFcTMB1eqyHuor6vcfhaozG9Tv561C0yEGwDIo5ejBMRaCv2zvaslGSMmZQlKjBp3RS4urGIjBmGBfrtkyGJezJf6zwdCVbBDHz22JHqGLfCRoSVVxTw8dkmALrZzL3AnZB73TJlA2PbrTq3UVvDtiwFYD5w05MqIb6XnBIt0oGsGkX2epdzbEhJU3cwsknlzRJzmUN7hfBck8xImLq43Mog5AnObw3dGOFdHhUIPoaphdUL0sJLrpt0wViE2KGqZJqYU1KXXb0mv7BTQyPTdkOxBjR+ZG66gRtntoC3SKkW048heSqKFXQnTy0gHOObIr23YXrpAdVixFy5dgzIELcZI1mCtQRuW5HY1J4p7nJIgf8m/cyqf0u0LG5N/c7Xf1DsU1xkIZV6uP2/Fv9n3+oXSJvbuLvP/iCJ2bOQhMSpUHhrFfD++lESTLvYfms//9uONSljh5qT5EovSdD/TTpV64ynE+mZYZfTTnCpx3UPaVJ/SrOp7rBIunhIQlRY5Dek5nfU8qaTUP6jt2FFHzIgZOkKwgLKB61Ira+iAl68OxqbDPg2LinwcTi8C/ee1xm00qkr2BbGNOAwdxrJvO2yRIgZKwbW/WXdLkGCp7rI6o0Y8qPYScWB4MKNCp+iLlPIkGendcJt/07h3kdLdlUmpBTXaz1FZTyciTJJYQTZUJKxRGluo9JST/oyVVWkftBwl0a7AYAMOawbe05L9rkdD0YdQS1970WbM8IxPbwTQExDIl776sK7nPnA6a7zvZ6sDqF06AE1ICfWg4rBBegTwj18p2FqFY/JgaVrX/LPcBsMCqzAJByQ02l/sQO2H+jgAUwKVMnrCiS0b0Cv043Rd1y9+WczFp+X2iUDSeaRFv/EkG2RhdQ0k9itYEOoYNPxpbsDkSC6Bx7YqzyvCK1XgH18ilj6GwkpRBWJuz+sB0MKxJk3K36hrXQY86LLxykpFVHhs3ejWzNPszal69qHQjVF8JKzRfClqnk/V2xv9Q1GeU5RbuKeGbF9NLZm4diZZk5OwsUlmmRcPCcUmimyw1/qOi318QsMH+htfIhOlYndSa0RsDDdq96b3IucBZgc7H3hDE/niUVaog5y5xqTJQCXfS71OJsIbi8o2c76h2W36FrPSkoBL454yqQjZAAkEqdUlSYh52zbAmOrn7ilgaEYNK52Beb29fWGJxygpXGlWz3/fAi7JyBzItFFp3QCC+oTZSoVMHnYtiAaTzYioHMiPRt8kCP6IOXLDfarL9ujTtMA2CtT0X1MJFhozmGmZ3CX6/9JRjhXiBvQsSZ9EFUjemhWN4SloiQfC4TQDi1aavhoe3Gb4/21x7fryQwcs/7KJKjWrCV010WnNZrQZnolAqM99t4oS6ZBS6iCHMzGrb7Qmk6FAwRyiQQ8htIg3poYAq7lWgDwGdT4sx6+mB3XMJCIVSIwmatRawzQdhb8H9LqDtp7scQIrDVerd2gCUpXu8IEk9kz8X68peq3LaLZlsIIppql0ES9/8bpkei/VxuPqVs74W7RsSb5LwKnb6V2amI70eYqViXMEDJYn71OebUEtaK5ZRqBJqKbSZUGKUh0gLTOnJTaVQo+FylX1/kv2jIJkcCHdSxJsvUq64zRaWQMfBVYrU6u4zNzjT9eDU3EgGCZy83GczDK0CCy8tblLSMnaJ+gYg4w/MEveFJlTtulo2rFYlSjjeGTafpMrOQCY48hXbJO/HqhgXBT9+UCmzC+YkBd04Tt99ki0wrDo3Vbg9aQ+e3SIBfdfntpdtmYJ5LFC26aj7K2oB0edNJJKSxFyej+QeysyLXuCk1pTzPrzBeaBLMrKxHoXrxs2okLdqeA4qVrhhPnbZCVxPF3fw5DBk508K7/MvwkK8La5jL6KfcQjlvlLLVDEWVkkPdamLD/0E90m1UwaJ7qtcSRMfkGoKNqVDphV5ahWOCPllScxQd/6fT4yiL7lk9hozmGmhI8HJ8LVEzyM0xsfYtPX/UbY/61NdQJCh9z1W2NVpdPwAjWMI/VHQAJesxkycQUHVuMOUqjdabHbc2VAqhcO8nIHfV9kekyE0HeDEPIeVX6ytGQaeRjCG1j2EaB3P31tjsOwggvJhBy+4eQOhiwbXVfdCg74FmFH/k+Cu5CF+DfTevRMfuHD8azgEjW5i0fxotPtV64w5PchgyAquKnKuwf0Vdhc7ca0t/MY7kcLV+JsAd4QUL/gcB9HO4Y/3QhruAPXnRSSw1ulQ7mE9lMD0oS6dlPFVcAn9Fa+Tzm+5QnBfwxU8XxAfY9fRNu8pYap9QmS3uFwybtDg1juFFu1EqMPXoDryBNIZE9ARq5YCTYEk6XTpmxWvWncFF4KVtYkf2SWIKKygQc8qrvv7bOQS4XOggsJQ82khRXDbdnhUtoK27dLE0M6JTw6Ue4Jq+GUCvAeDmehtDKssE9jZbd84/BJCIVX4aisiAI6d52oKbPjCBhf8TPeYUKdAIY3SDm5A/VX8cXhINDK9eQNqkckXff3E67RrbZE/fcDPbZvs+/GWrQYtxvQHYJoPdoK0v91osu1jExlG9Nvvxvg02Kwd08rowUJUETZUc3tIZ3SayR3mqjR2UzFVwIxskwIFC8SylqY91xk8aamv26qhgKK4ra7kTvBQVE0QmmEUHDtJZTVDagKQtGKVICg27jwpO9vr4gQguD674USwskP792zGHf9aJnR1aA/TkYBnwm2+vis6kGO37gac3TqslfZWcPnF5bQrjDlqZ6NyTkmhMq++upT9Tj2sLLP9hlfWIrVgYQjaosY7Y7RXqpeX0z48nc9xnSPI9C79hXsuuJY8ZgOI8nmxaV1UN/nkK/7GUKnRjbj5AxhGLrNGlRknhL7DQsvCGkDW06UbJvNm5IidLrqSCoyS6RhhuBa23csGN4gOPzaJgU6WmuomLd8jp++k65FWJO+pjcNm8TIS6Vw/ld0L6mCe/NJhxcybyjmETIqrDCjRZAKgSm7SIYwRy7W+XDT1CEA0wytG+AoAqr3gIfS7VMWY+voC4CbotIsxC7FmE4VWyIYwCdTs2CfX4Q/cgv5JC49otCNZugvoOkbzo9FJEhzBq5uOTTar1i+gWPt6o+Ios67yKjAZ1cJRmOhXCcnOPXRTDQbdwAG0QVSg/Hf52wdgagyH6zzokDYzCqFKGsdfIr+2VL9pqC9z9nvwmvwxLAZ31pAXRdvj2BNCHwjIsOisHwl/bGAdHM64tMKzuPd5k/JNEnkIsvaXGkpDYjKYTj8nYVkCTGpC/daPgUaSWafFsriQiAcKLT/B3zNOxKVfxclsNf5j12CiEXzbNiajyTKz0uZ68kAB5rDCNgxazRLoCOR0ckMTu3ig43yZWQ8hzlG/tFoReR2HOu9Ll3aiKMux69yDr3gQgjSkGwuPUUi5Qaq3dFZhpBrFYnq5JmpxAcenovJxgkIpiBNSBg9vLYASpJozS8d/Oga1Er0Kz5yfhuQRP21lIoWC5MLdJXXs3uA4eQl9lAUCUq8roQxroJxK1Sp9K3IolN+5TvHNj/rfBw6qppxwEAjL4kpy6ADHRNhw03zNFpD+Xxd0BnhXtOUdvlewCkVqglqt49BeOt5m9UhxUb+PhoSIKyJncLEZ2GBbt8QNYR34ZgNbvYHRPzYWZq0huCYNDnibtdGoRFHu9ZwMnttNZSUklIaAwZpskCL8kWnCHt2DzPLsUiSLbFurtoYgTRn31xdHUoEArWB4PwDxEHU49E8l8Ql79wFSB2XcKNKdNcBW8zGY4glp2dU54fWkNeYPgT7Ge9vVOcfUwL4KTHb5zRUHgtYWHXmj53goxm+0pvs6OGy+qGUT6ozGIVKqV9KUks2u0s0ZXFOCDNPdAOZUpvxo5BHiz778cJSihD+CWXZ/zEVbRHGG1oTLzNSF6pHzjqDMpKxXMeJ2KxkgViqdweg2Is3mg/NMPD7XKWAKDOSf5bd2yfhmgrki0LFVetP5H8ITjsGJfDblK+UGDyScw57Kzj91+WJ65/BOARJQtCmh4KWYEtk83rAjMRZf1rA+QftTdIWerY9k97SBYpZpzxUiBoWYMSMDrOipOBAzEsZubuaTTJpr9B3MrdBU+t5sig/oHupoTLkjzj3NWh+92pyi3k6+azdOuyt9w17kkYdF3OLN221Y8vuHmUxrrJBQpfL08tGc/IIcW/xHs5moSioAqrAVOdjNA5tgVk5zUF+BH+2fv+vldNjbbRzyJxVj+Z1gvg36+PIk40VNYqw+bjM7AfOvqAy8JAGJCcuoa9zjqOGOO6ubmaj/zoFR2dfZ4cmqg9miraRqJ+A2wb0iYwmBkER5L1a+0d7g2kMcCTqh4AObmaHk0QwhORbNuVbXFIjHMLhGTx9UTJUJg9Zngo+H7wOqCGWghKODzC1smP3gy5qk6lPot1WCaKg2FxSFpJaQx+lQ476Yjk/4K5vGP615dyZX67VffC4/9dM+aQb1MSkhMH0KC0hyPJ4AH/CU50TPEAcs+cBRUC1pgt5e3Pz0MfabD8NVo9x/+VPb5b6dSOj0CVKeDXh5EVta/oEEUeCMXXo0P8no04my4WZ+YNdi+Ixd6tCBEcV8kvU1B3WImrwOK9Oo4TfjiO19wexIs3/jkrdD0HDTShpw3YB0mW3uBr5eMU7WCdQ/FAmDLF9cHn8ay9GmzZ8rJqU1yskp0VUpdLN+vcUvHtfXA3Hiab5jxGJOVlwmB/RNxZLF5ShFYCGQIreTvBqgb4oi0S7kKnyf+7am3cVyFojBgLbyrbw7mhogGfPaNkT7R2Rhj8FgREB93DW62lXMGGNdlilq3oLsBXLnhD8V6c+qpYSYr5DGMvQgbY40Ne07/SVxIdXwiovcnux+vXN99N735FktME3Qix5B95Gc/ftQBbaAKdKM4LkYUpsnYII8u/BjTgc57bgTTdo86nC+MHgOJhI5QVlRXuchSJKLnkJJ57dzCBupRS8bkW4BmxKkMe+Q8ABP2s/dad8A3NkJ6D1uS8Xbo8GXECdcNweCAAAf3bGqNov36JfVIjloFqWJWElfQBcN4UcbjQ3M19YCRTtluzTTVp+1nwdam/RPHTlr5omRjwPk+1lx3+5Aa/twR/P2a7ymXsmDjZDI08gSlLE3rsYEQRvUPWb9hUy6wEeciMm8iHxICf7356GJyioeZ/r+RcAMy/LLHZ8Uz/j+S0ztLCfYr4uHiiiQi15GxKMJlr6rq7PcXgZV1lcxVScIXmfGR6cTLtvSReE9t5SwQeYvVprg7nZYK4ejc4buAWrGWyeNixVUhVqa5pv0POg7xpGsV5U1VL9MPeQAcIQSj49YebMpRRvu7xjUNG9SKpnil9r8EenxS4nC4wInXEIHSfdSKf8aQZTS5WTGK3C0FmNh2h5J7DSJi51tbiGWDVJYTPnPzFKS9Hfg+CAHKMo5hSmtrJ35PE9e6IQGW+vBmK3SVnJzyps9dJCeHG/9bCCvntIGkeTXoEf57lCcOElPbGvBNG+vL3MtDPI+TsDKCUDS6L6Ar366uOKnyampU31iVCMlF1k5VW+/pFC6flJg97iFXB7H+ViO1Uei66ezhdTkrYIkY91BtxNN91Qm3EmyI9h/PXmOK6vYj5rtdhKOQpOT95qvLo/mo9xjaK1rHv3bNOtBrAV1w1ce0QBevEf1BFPecoqr0HPK27nI1vJ9PsQFP9Kc+8B7+n9UVhqGDhae1tWwBKEBP8ez+dBENVmsQNyzPi8Z1WCTJYXlUL5p36quSa2qVdd5VKNyOUXFcsRKhdqAG6U3SpnFkk+UgE4LURu0bjveQB7PO9zLDBYf4pzs+NSDmi8dtK1oDjIB7pcvhT3tlAK7cD595IgA86d3A1h67EBJPr7u0c5U+7UlmP8vnC8wyHccZOLzYtxL+YfVr3PDXQQsBP8/2c/iEiYoNwP2CIkietq606t1EmzGSLsURGlqy4ZS4wvEFjcsXVNyzlfYk1sdcminjXXW36HpMgbXCZXChP3+4QO/V2qBdu2JgnmSVQUEWMvoLb40VexyCHC0srnKEgqr6d6AJwovrKE+8AkFc5EAtJzSEMYIVmVmOY/L6x+BpFvxiwwa2ocOdijYwMShMSxFVijijs7I/a6K6vAagsdzLqSmurMPrLqW75b9vY01vV72JFt5emfNsS62vsif74UhSD9d2DMtgKW1trxDveogqmLlcNvsIQHxK8/1WmFUSAeUcE193CPz5tVmQpZUbia/htCWK2gwTDf5L4kZi4R9WzupnUjd+iiee9GeKk36MpUKfa/THGjq1rOwYSCmTO3VfA82p76FRzxNWJSYP0x2q/tymUPTJ1tHOIfkgRg3RHklctCp+OUMoo+NmgjH7C//KVFXwPOSSBJVxEG8hprSFQDgM4OeTJIoA0Ad/0liaRUuAZkkHMXLzhyXzHdUwqyn6PTELnxlrMnwSOLo0SnX0G4ONzSFMJIBr8XMXJu2TmXSgitLuTiHiitDbiazD94eOur9A90gbc+y8A2LLbjsymn87dj3wDTCzNsz2GKW5JbRKaPlj6FO/wwXG5cLxY/v6GBRWiPFwdUeX5VFkj62Fum/GydfAzWJ13g+KtxgMmFjNnh46oAgcHLQzGpUoXPZuh9XgH19jgoMjrCMXmhTj8dDvEdrx+DrvWT+M788yfPsHOH7iJMzrDG3+uWzhoRXGMLw2j6QNufZeH0kdaj039vRd4+VN1MbNTlsho3ACU8hOMnQctSKoACVaLDvGPK9vX95apPpZn2bxVBYTuNO6e4q9iW3SW1s4bIzGBxGLG/do12TQqixDEpV3metS3Joq4HDFl/kcDqroz2h0LHe01lrBKcva/2vfm4pDncVnUtzsbrxjpflH+O6mQFNtcP1Iv8JkaDcbvQvarmagXWo1/TTTOIeePqb2G3DTSBjQXIF/AcAc1xqRaoi/EPEr4tb4rGOwlIdbneGSECjYmFOvutqEKZYKR+vNPi/RZvBbxpE9ZxRprlGnqJTnbrxjsR2E+kjCe4TlFnXrYCPgnCMMdaesWnYDoxfgx1a4W7Xl+WX7SYS+34fvUr3V5eBQyuoN/JxFb/5dEjOTTlceVDwUf2cDepceFU/cHJsON0u4UDLfyDwRiIoTDpWHw2QIIV+89rjPva4xHdNNe6gnhmknaFyfIXsXDFMvEYMHG6RockwAx9zqs4kGDfIKcSxRPsWPKAl3YiWPKttsFkWt6qCN6ILEOoFfJPlTeHZnBls+uzuuidWXrMkRWFBhfBv+XMhWR3HnuVm5Bqkc5Rg+dfpAhOZpZnR0yYgwTsRqkHM7JvFIlPuCHWXTGGl/kamcX6kRGgVRb1R0y6Q+fLNdV/Ql4pUoUC3cXI1rKYO3Rn14wFXcqBurYuzdX8OXUhtsL7ZRZ76pSR8MHETpITnXf8xDpXexSRO19s718pyBibDzQKsIxbbkArsVsg9rRR86W71s3JwdqekuIY43x6Pk80mLKICSO5qzJW33WZrgbshY95xNtpqHByauSiv9GNrx5VVhmi0Jh6/B7vDEuW1qaRsR21hox8x9MX8kQCyGE4jtmfiWz7jAD2QPqOjivO0kYCIIJ6bI9O4Dyu6aDMfWh+M8eRAKR2QeN9cWbevXi7WySbXdGRxFl+CW5YI8obDvHMaNwM8Nsy7y18K+iB7uPzN42QAz5UV8FSHAcP4qfAICFRPnRtYGs1wTTcM3HmvomcIWuUAt/z2lN+LSHN6XCxDP0eREw5rXD+649t9H01rZRGjdAcOiipEtGiJAWaJrvRrmVOxJjiczQZb+RuyWnvkRLpuYlXyaOJwAOvytisnR+GurVxeLIbDdNKWRI2ehYkz6SxvyehWoYVhOwRCMLFu1+DYcc8pwBV1oTmcmtS0CNNSvtD3/pPkRp1R3AFdeUEzSgJQ+72kjdhc8lmoP4S8xoHewQsQY/iXTO5Ic/njZQtIcEhGJusy5CRW1Gw5mDVcpz07ldEkPYKX/LSNZskKAyxGDrRmrWgFBXRGoUYByZ6cxrJu2YrJtVUF4z92qlCkTexnRHipUx6y9iKyi7sVpVTN4AC1lavLtCsn8u7v/NawOh87cg0FtOeHHflYehAAAC6+YjwAAAELBydBfZyMqlnkW6GTYkA3qDrCEmG5OD/h2RuZn2eYbOh6dvtkiHVH4ZRtc5Xeq5A8voMSa7q9MlRbal8/4on+WkiesWgdNAqFsCBw7qI+sc5wHAlk+Q4GhNBkDCEmxC0Wx5rwZfljCyodt85K6/+K7XKgo5MOC5ZFXGL7Vpq66S+TGHttvON2W1HLH+3i/UtAnhmvT712zrVpHljtQyBQzdhGHUW2SXQxkG20wUL9+vM1xlfqcLd2wYvt1pip9YWz3MJ/KMAC5W1ePujYDkB3jCbn80m6VAmZF0Bz73x3GbJTWNy++x8jIdlyyLgGmYfm/v2Aej3T3vPSJk1S5jfgswyad7XdjaRrERVbAYVbrgMWKDfM7KR88x+xU5PIuE9F970tpP2w50HyoLoKhpPgJfHN4xAgU9WuMLUKVSmBq11I2PLUzfK4ulmxfs138RHGaV3F6MkqxCXZgKDH0iXXlzRkYfiBcCvL+osn+bgC8pQBvvuswq1MYo6B8h1pf39ZhINxmV2WQDhuzna0Kx2DfMnrhedaBk1T6ozvYs7mf/ZW0jpI2xPP2wNuKvV2uUAPhHiQ0bARcZCir6/A64P2sJa6jiVqG7IKsKlokQ6F+3OKYulr8cHc4DWmmUmTRAjYoKnGXPOmJsvQcjN5fPAJnZCJKstWeRSATsAG+UrrD9kgmpcY0iHouZNboEUbzDEd8i+pknwJRJxeBFHrXNvhpBg1jeEvWJ1K/pYfRv512oy5dV9HMvz0Yvi8UcNMJQR4VPDOlzvZ0uLApxQr3MkUDjNTxYarvMRSCku4uDxdqd8+kHc9P4fWwgbYHRFBj8MaYYyQur9cYVs86fcayK6KNUiu/9bL/CXccFdmbhVsz7zacGgGWHdi2yd1eBUZbAmsI8WmPgfd1qbaD0qa2fSpvwig7Mr8sjIF8RKVl5GrjBsvnY5EPdYkPh2NzzZcd4XKZsldeBTiqm2xyK0354+CblDV3rbdu9Y+rQf8B8Kor2pSE9MKL2Em9cINWDATxcE2ak71Qin1jAt/MuaKC9sOMDREUgT9/ETlxCwGvLkQ634oYpbYQLPMRhpsEZm/1NAuE0qHB6aaSHh+YnVuG3g73QLuK/lBtOITRpcN8aEmwug/wfDlljY64u8RC3H14mglPO+sbo76MH9/8O6ifSYiubiAj4YHMJjPwKZTJ+7ERHV64yj9qT1hUvxVGEaGbq+U0LgcleNCGJAR/Kcmll+RmClBCkgvFfQnHVLSOSUq+5369FA+ktpd/J4DBMidzae9KSwktWUIFIsM3s0NHfLaOHeFQySMCZcSDm8dht+04pkgHp6RFbEnlMEbgSoIpRztyY8IBxwKp/3sVEMKq5wske7mtcOV9sv4BX7b8Djp19t3jUP+LU8JZSU80VLYzlWCYAnEkOr4gALoAA5fHWpgVcikDUmrkbNgNlLrD00zrH7RS0UkXj1OE6soTY6FT6MCBa8vqfUir8gmVdW7kvyQTGdGdT/Dy6CO8OGuH1dF09U9soZhvMgENsgAAAAAAAAAsIoILYEufAuvTEiUmKhOmk1zxh/JYyzpV/BL+CX8Ev4JfwS/gl/BL+CX5v6QT6XZIreUpsFCNjlfy2SuBza+EDl4ZnVENzBja7qxbf8KAAlbah5ecqz16xpQDMbUQ7T9J83DVT3tjdxeUE/Isw5hT2aRGKfTQXrVuoJDIVXXVilVXVVjVVXWVjVVVsvZRw+PZe6rGoqubCoJjcANymxmuWG8nwUxoPh8I2TgxbpKNnmS09wQhvT4VDRmqaOVu5kBX2gGzCQDNNsnLVXMVnYa20zp5+eZ2O5d9a+kBoE43qmXP95OXUcvEKm/WZTDUdR40BR8Dff5s2EvdOrKpNAML4W7kDfy3V1vxbzMMV6orDNFxenqOo8aAoU/u97IEX9DlIF6heSZGJDbrBfzG123fnBxPagbCdmu50wcDTIm4iclkuPRQKz8rHvNfGp3zd4/6oEy83/YzUiHf7gSXqP9zNPPO36jK55kh5x9a+nbVq5kJzzxy2YPoaClHJVkuc0wdxD1E8oLP/RyNIdgZXPtbrYU2G7ACFFFGtNBPZfh69xVVnkiyVUfhC1BEaeG9JD/qNGjQTyYkQXyNGuWUHd17YA8LUyvwko9mwnxingjqbKEISEVgTqKVdN8JoG8YT7v1MhSFwF/VLcj3tagZDeXKx8BKrwD3dD2So9DfApMHBIC1HAuSyCwVVQMtiLoge17xOvxuzP+rdwt28/ksXOa7jFVzXu8qw3X6IQihsJGe0jKWAWN2+zEU6JL+W7IhRlmD5d7jdXvkO7uxsOSYyh5KJMmQX27yfN++UKK4sdlcJcWk/2jqBjkuwnWXz9nZg+6cPV7MJPwpoCtJU/yEEdvA1n9D6VrikhGjukK3XhncUkRXtxExxYpRuV9Sksfm8BrxVp/lBuIGcokL3EjQ1uhYx4ycneh/VFKNhvQ+2YOemK0zptDatDlqudofblF8Vx0yxI+EHIDp2f88dJkFusbt8ABtoAWaJYvNkF+1H96iwtauDZMtjAQoYMf21H+eNfuNZMtmi9tQh1aHi5oCGtgHOvI3OLxbfrUvHoLta09EX9gwiDq6nxkmf2nZm63liB8R1CSPumjnwoQSZ3eQhGV4NJdWL7Ed3GyScmaMyzxGZxulDtsKXw3aKDXmg3vNCBkCubvMapFcr8+TrwvMWO+c2FR+QsjU1rJ4V6oTbzgRuleV3YxKQQ31jfw0u1CVcnOKYjFdTvuYe7VXuMAP8k7oC4ciauSwUdgcQwOsB8sEqebhsQM6iKq4nIX0BSzI41zMQcZ6uKAv1CS2iPk6B7gbLLRiM3GWLC4VYf+Fh3cJ5vVN1yVnOVSayVqfDSfMFewiqDqHAsHtqn1CKJFU3peISaS/ijAS9VfpAeqYzXUQholKjeSpsNKBQW5wkEcOFKobMtqzSgoSKTQBDWbIUJSK5NyUkQxzA9R7UrB/tWiHY9T5+y1AkroC+N2XC57tmMj3X1C/4MXQgAwDto7VhJKLa0D55urReUpyjsJSCCM4j9oc/su4xRkkNfXUMa4rNlqA6sQdBWtR/yTo3k0EngkjrGS/jmQ/SpE1LOb1Q4QxxE/vQ90qICGhNSzwPawCyU/Qq2werwveBoUF3V4WkcTMxKztc71+nHH4AzxaawKhgIYz4hbNLTNGA3LljEeGBdqYVIr94Kd+tYm6wT5N+xsGjcljNbE3XWCs5jthNI6fT3Z4ScSwvIalEVGEYEIm3a+ADZleycIuwEsm2emNhaAZbzt1+/oyxBTlDmozdO/pebrW91HkjMKkn49XTMSNnMLF1gCh+DSSMSav1iiOlpFPi4FJwb0aw2Y/GSKTbwX3ycoMCWCGW+i1omtyZu+kw4Y+nhl00MCXKyQH/gl/4I1dwqOhjgBA9Kx5F6cNcDYz+weW6oZhEdNhZ8I1QDX5TttPHtQbtHUIDlZZIuRkrGOMJRfgSgMZzxTYBH7CvMZ+VglNCoTxPVKwdau+YMxOJkJu90zQm27H1K0+91rn7NHRM+OYMxpUsE7ymB0nQVABnrqh1e3Fq8OU3D2Hy4BHxouTJio9YVF6lnLkOO1o3qN5an1tS0LramNThsyv7YgvTiJ7lki3icG5jBp+Byql1RLAgDwYwkZGtc7H5XNmUaPippFp1UJe5nv8fLvQCNkBi6QhzRHi/9CJLxZlYABd6VUPLSakRckEPlT74F0HpUZ8KzQaaKSpoUIGPfV6W1Kehgq6eFsROUOq6f+VWXwZpgl1U9QdkqXI5fH2ZXEzmRI9Xi2sxBcBql+uiBGMorJ69T8Vo59EKmGnsCFGCnmWF6fC5lhl7Ok+GIvcEWdcO8TNAQl2w/9lCo8cQaTmnj0Xyq3Ny5RMBd4FbJvCzKnAYmuHANpHCs7R/Db5DS6d+KrSgH1j48I3nYGv1VzLFNdFtfv59Co72LW0owJOnqXv4kvHdx5jKIwMApeavdvSsv4UV5DVVo9WsQR525/IGAmLFRsq68+NOe/KuWSxQEBOQ8305hOrieaAZ4QDbAxEj1M4wsIJGMTTIkBkRcsxZTMyPVeWrgGNd5xpmRj93XYOgfJqUKNxVISxL9KtWVYAIW1osXUPLRh/wS/Wt5YiBO6H9+om2cSi5ZeIMI6cS1keJI8Vpqc7VWQaQhoWLRmi+Z79KngH8DMKG1sF+9qQzV9CykePEfGRaAXKSpLXdxoQ68KL2pqj1SqMfzYcifVxk6AgTLFVXXVjVVUZuPKT8Z/jJRcqVeZjZhWFVBqbZFGXBT7A41QdqLZmgMEIWYCvWWG7aaQGQ1WLRqJig5c8RTXKn7Ldbj/HauM6iKtUReeaqD2K3/6kwBhDrBj1K7H2pZ2kmSxqJZvzHcAdIrOJUIM8um1eg6dmlDAzikgemSirz6ZQWL9r6P4nV8+a5U4PIctYMrgTPtrhuFBzobwJ8hI8MwXr7I/Pb3a6nfVKQkDiTNj9Gd9W78fCNTVYDGxkpk8QjDXDFebjRiseU5q3MyL4mxFoFz1123rW8WJxqiAOMOAHToLAaNcAAtlEf48imVoJ13jWsCU1Ym+ch3omP5J06VkpFUrnoo9escyaRZAH0SSFGsCKUMWnknpXqWGqraVxR+kMHiEFncns/s3RfIa2PtPe3cp81FctDcsCW6uB9m0wGANYlmRZqCia5a0DnhP63QN0zdvC7YClwSv0RwC+JtzJRtC1XvUdFC0C5OzW9mEINAr0Wel2XQ7l/SuKHrhgGiGYAFj8L1bj9gNHxfl6c6qSvaq+oHIrGqquMBMiox4Fze7kjrGGU6hSzrbzP75omUnqwvGr2EkY0xfkQzWpYd5VdooSz9gQ9xekqZFHUUzNDZA1TDMoNSKL+kNg1lo0NWnzHxvXNc3gd1IVbWwavQs2AzjYxxbFkajTO4EgWVCDmQW91fuTPBoA13rHJXfRhB8gqWaKgY/4qgpPAfrQtryThSzWQw0F6qipS1YYk01ZhZ59t1+wt3scO27Yvk6Zd/Qj0IYlC0RrdWQAm594LMylkA7FqttQP7EhVfKyGq1hGrXG/AjTR2YvZKDkLFNHx6Zqv08evZNGEEQMpP/Du4/6Ipsoj0/v0Cc00cjJEtOGn9cZtWNzTaUdQlmdxd1LDL2f9YHs6tleRR3OxbNZNZp6QtDu6aeD8U2x1ihiujuPi/3SBL9WkbhzxpSJ+azAhnogTMvD5P4cML95eTYu26uCpKsNuDZH5fwo7s3WpR18BFMmRz3G/eMyg7uztW79N0EDDPVn9C8dWmuiIYYeN67O2LvzY5V+g0LcZCCj1faEdiKpj68bnBIHoAyK4btVl9wj18L2iw6MCIFk/SmfM884/B/CsOeHQUK7mWob99ZThEWtS6CXwiVqkm1YvCLAygNC+qIk7k/Lmde9Dr+NddyvGhfLWwXAFF1tDao31gikfmSvX+z0Qhq6RcEVkdS0Jf0PjAh7Yz4NevEkv4BupoDaU1cXL7EXKTgxubVdQsZdY6XPII8iZ6Uq5Y71hY4ZQVIHPqJCnYrxAvgdPIV60c7DOgQ5ZZDo+uwZ2hg/ySukXpclabk9GsMoVQ0Ev0yvmfiRYqB8htb5exPK96TRl4hWEpdoUqscOasevUgDKY16/YLOJ4gublkkHd33a5P3Z608Z7wfcZJG6wIgNswrCnOIcYe3cIOHvdVjrtCtCD1GuZh3C6ndU2IJEQ0eorgRUrVKrRSMM/WPPXBaIRSC2vsUE8K+UMgmqghaLxFnkeJna/9ZCZYExooaCQf20babhHExW/eOaDy9tvFbeANToGr5T0iguagaWoKrUiAAJ6pBT77wGPUzjwun6E6Yb91J8naZVdrMi4Nmbe8u62v1fj2e84Ovh29fUHzEeRLJKScdLnl6RI0Wc2noTTXRZX6+QCg1rJWGzrhnYQEYHWsglHaC9a1DGIeg+wVDblrp0tSNL5NcFkttninnnjLLAfyxxOTql+FDdrY/xjbgZ02H4j87UjwMvvCQmob5qjQZdY20aIYzzpjdsG90nYwNt0qUU7U001JcFCB+0cTCEE6JXF4xgxHTjUJ46L294HeY9nSjfYU4KNLrSShwS7NvEx4h2SgKs3mAJ8aoPOiwAmv7av4e/FM2gcU03+1l2Mlk2MjzuIJcto/cTjrLDxf6XJ0f8irq22o4wZ5fOHMs5qpAwKj8dyRXjQdymglkdxKxEUgwAGdJ/4k8+SX8PaG8+fswd3yDtrzSDJnXUGR+j6SkEfEP9CtYzykE5phSQcJt8BCkL7lxuzw4fnR3bTEaZqclkSLf7NGA8yPbaLKa7cvCdokxqnCussRG70ZFYITxaWAZrMMc0aPlOFbBWG3UDh5AAAF6xHwN1XOhgwuuVjGEpb81q+eRvAq7uPpWwUWvI7IKG0IwMiAuBoAbCRFY0gP5IDcQziv2Be9vqXqXAX0MYd2iJGKkazdudp00gNdA874cRZ32neWbWt5SpJZQsiw1vDarNLMA5qMXeozu9WuPkX9PCFZNh7oGFa5B52xkp535pFXYphXy4BJTrk5o/dSgreOhiRj+3YU9gXXDv0ZXxZnGVO4wHGi/O54KdSKcp7ePuLwTK22CRxJrprrJSPeYhfnZ40Hc0Txxpg687p4hR3roG2+UyCRV4z9ZwOwKJCUqzaWiT2a25DEvlrU+749X882SR61EU8vOhDs4/SxIVsNyVzo87ZD2GL+VZ+W01UvY6YppyiZ2gGL+B2M92nfmTJmjcDsOfSMgyn4EeWXT48Oj8LW7gqnh7XZO4kJR8WCAUTXhuX9MXtDMfqD5fXkMBInWVoenoTEqV6D7z7F4oJP2fhhEXRVDnT945H1cRYo/Km1BAHo+J4Q0WNMaxYk3srBCfMRAnT+LRqWKKZ7Hn5aCyWoYQEoHFzntxWB/5sUvfWhU+tJaT3j8QOC64S47PYoovdd8X+Uxfm37r7lrtwPPXm/DpI0H8JtQ57TBMwL2oxHOIoPIImDD1AjIUTTlr3M6/MilCk/aZr5LpOlY303zlhvIM6aezBVF6uKHJt3ND40HuZxonQFkb7jBBKhpkaPoabVbvJ2e7siTA6Udjv3IpJSiFFLfmBB+nPZfmCE0LCt+KKNlRzIBUWVtJ5+BmES+i1XUo3AbS9UgzjSq66saiqq30Gw7j3GTar47jcFZIyoEUPMfX43EEvsipG/8Ys9BVddO/ibZdjBkearqF0raI1wJ2MfjtTfaljuK+iL2UH95MEg0ltNK11jSl83UYfAl0fe2PrGepHU9z5dteUYPJcgTNB0r6NJ26WXbvEm1ARfQ3XiLokFOrdlSDVVsvZRkTj2Yhl4sYI6VjUVXNzJMnimxhxI5yAIwcXgf14GbdrvfBSHaOuFMZYSxL0kXi6T4Cp/jUTQBvF374d/t+P4/uOCeYGKUZcfNKj3jRJ0ZtWqrpLSAr2EQTf/gD2uWouSS1DDbS4r40fcJNDNxCPFrQgNzfYgfaszfg4xSEuE+6LuTHodWC2e3kwvCR/impNdvqSN/rjiz/qlnnUzLWX5omYlgxIyUwQ3aybjbwPJlhuqV/2MoLpTuqbW9iUDxicn6Hz7eh4maZB1fu3lqZcrduycIr19xpzyGwe3ouGtCOhFmcLmQ5jI7VSqrCGyFVkPDKYmc7kF7TA9GZf/2KCUBi86yl+FUI8utnQjmd2fsMQ13o0uBissPjce/qw4eQQwBg7XOHjtLf2Wz7Iq9kD28A3xVQtJtM6RKMheQhdrPw4Xvn/GrvRJYEthLs4c+SbGFDc3yrJQzPSDMqN7IF8M2q/i8eBTpdU5VB8vNJUjS6ztsYAeu4phomf1MzqqrtScAaKiPXX2IL83FzDwEgUPJjMFeXJse2TlmzuVddNCecPvO4hueVcepD18MNC+Ni/a5vuuJpTJn/kQyB40d/Or4wF9ZHnPd9e1WMVrNGdKDlm6HKrFuKj79csZmMYudpkYfMnVMI2rdPG/349L6EqZAtZlHH+47cyKJiQZx5VddWNVVdZWNVVdZWNVVgSsayq66saqq5ayCp4oK3pzOAUjYSdkFUsIjG9RQf7FzpPxbIjWpEwE8TzzkrxoYxUbtSssxbuirdN1yjJnETOImcRM4iY40Gl2Za+9hLlKYtiT9Lr2m88AmUygNrw5iZdNWJNWCaGTKwKlbWjqYJvibsYkjjSuAgJ/teX/9jreL/1W7nHlTU9o12WhzXJg2BSg55TodjiPjWC1XGcVzPjDMlrtsqhmtvsoj/LsX7+P7dggv/rrCzZ+fNuel04N6UJuPPTlQkctZWHr2dD2hNUubzAL0dM1mB+fP/37VlQ0tMLsxGVJXtxnf3G2SaMelH2kwPXkn0YhFKIPwUco7eGxRPxFn8QDi/WzpsfhGCtC1FsBB+475lKuNQ94tezr+4t9HHkJm2GxWFxypnhB4SOC7WVHYwtS0aPfmRIcEDLdh5mnN3ZgSSRpoDCcgpW8JBXkkH0q0o26vVcMdyf5qIjAtswYbBIIsBP5/c6CrTVIAchr7jpxorRC5l5XRvG6bxWODXJABoVXTatgJT678dOG5gjvMFIw1D3diSZy4CuO68ZoDmGEM+y69IFvEPCdLTBswZcWGoKc0G4abtYH3GTP08Abp7w+jCxAjzgR1ksVeFBSyarS6BDO3SRS/a7jGSu4mvBlLZdokvOhHLoS3RUh664JtY4i3E7VXDgHrHisn1ECGqK7p3DNV+4wXZmZpeBWDdVQQcPC3wpbxk1/z5fRG/Av6zlup1NXiD3jkuYemBCyRl22pVy7LhDtbCPLmismDY0dMRcdPOBOXK81cMyWFY0nDxrFyM+5gzdKpuNiusIv/ODgydE81c4A7M6sv80NBT9kfnYWB+KXxP6orvfo9M9GZFF+0LIOy0LhAiD2Pyj1a/19NF0HhBMyyLU0uwAWV9q+Rv6LBc64LowrlYh97E1btjOCXF+/YNsulcT1tW87JRAph4E1d+/VYt/Vcf+in2m52O/1Hl7CGrp/8DLoZ1ir6Ecb1Vak/7+jT5ho3Cj0q380ZFjjbC7dhtldmPDbd8kocFogSX35+IA6dr577+6L5tSzlsdkp1YpleRPTJ76YQMZEmKokRcPQtLXuB8roPT+s1AC8EtsR7HtKq0tipvmC91wavJ/K27fLZQ213wESzhRYwO60kPrqWwl0ejUzLznPE20SObI1zc2hLXxFgneSF9wp2HQmMAlIi3IZDO1ZLadUUc8sOQZqcKcff4iISaTmNtceE4p71m4CvYtag+kD5VIVNrc+phVAI9AV3SUZ0weK/cJp3NFQ/Xxx9OSAW4wZMIt27sNe8JttbTfhiJs7hxPbiOvU69GMdJvDFPDgqzDlNOrBwzd+d//WJ/96b+KsoBah+oUaBLzm7AJC/zttIbpnCnkrQiT0oXBvJlVGTgPpqgo+gQWCgnqKkmj1cLncXIayYFlw4jIz3qdvbTOE95berHv4YRWYDte5aIKK0+B66jhhZiwKYv5iCfyu1MZG4yltvZNcI4WnFqSTFYW8PG5IU9khWrTzGcVKSU5ammXkbli7z5WAKAFo2zANGls8xCF5j9P9vNPxsn7mfgO1UkgDrG3vgtEcoAs+UZRnwUZ3WZiuwD/FDFEIUtAV8rxpDpPpx6Lry3dnxFqVXX2FUdRDYNXYVlFNZx/gF7FGUNfsTsnd0lZ8wwUSQ8lDv4tntv4Jfy+jggOoD1z9T08k6Itx5cYKL+fqkgIBuVXAP5gMVYG0MKqEl9lEZWhsTEWG35eBVVt3yVpkrE5WGXaApqM/MyWFLvP13EjTaRUUuJhnmCG3FhZClCpcytl/E1SlGYX9+gn9p2UUfObDGovmrd0QLvT3ggtKpG/NMS/N1Ecz9eFenEk0KPlZBWzeXTnP7l7Ip4HUpPgFRScyAq05DJ0CL13mXg5vkyctlstlstlstd7GQSI83j8SIFBa9z0+WmTbKTNi1pm/+6RLn2sJLigAK9i4xKKpqTOurNafCAAAAAGKeIcc1sFTfgZmgW6x2nRYGIAeTpGrvLVsmE5wcq1nEx6wZGL2ZBjJYDkSfqkC74hHx4k8YzHPi+Gablh+vX4NMQAEzykECXWr+uYos2L67ewXDaOrnr+gO1t6dvMV6PRqO5OF3dHq3yjuTNCW+U/4IFiYLKEr/lo3xAuhwx8nRZ8BqEVLbnqrc19XXoFm72z8Se5BdgtrxAG98/rr2XBHE7k0ppqe1reQV1iA1G+Zs0ljHJSpZ3iki9SWzHDP7sh1f7SHuDEHYACcCh+a8v9N3UwB0bxNa27JzWl0SCSX+I7P6Oz/E0P+u6v82frp42ckze58GmeLg4tYNiV1WWxcxRXTK4QqiwuQfzm3IvlKFMQfQzei3YYoEUmh0ZknrH6rNvQkeYtm+sBPbGvFNK5+n3WpvG9kL6tDTxfbgq3Y/ZeVpzj+ZMlGTdGcJI1nodTrjZjxCYijvdnHL4eKwRHQa/xN1sUqJeS6d1slurtgNuLi2/VCqjbGpAxDtEL5njUMV0/yEBrHQYht3PXyHMwFYlXbPNz4KBT4mAdrNyVvNwc08LE1DWyp/KiKEPyiA17jB5DRGWx1TMM9TEJj+s+FGQl6QA6ZR+i8sjEltZ3wwNKgdhFcP7hpVQ9HkAeF8e6OhnnWkwcCo5zW01TfyEpzaGlw1OupmLefMoIWREqQGetpSiBQCOLjbQm3j0C78M0VMsCeTbILKCkwGW0RnLXq1OZgebpPHaS4naT224Zrf2gABBG0tAwW73gRhxGdUhXGT7Wdl0MM8N6n7gXW00Bcmir75073rECTSVM419gqnQrJBb/PO+dsCXgiaD/57tKPPe3Y1+TrDc1Kc+5DEFHHqqcXxKdKVK/AcNAqewbmFv9IKNmupJ7TwOH+OZrXAgb8eyuqHogcn+Z3TnIf6hM84ctmBoR5/WgqatE++nmQWD01SlR0MhmDbl40Jap3vedwXLE0HkYWs82MsabhmjYXuibM6u9EVqQnoVlMj0uCvdblsvUJDwWlEEYDTy3AK0oAS3MLauNjYByQcWUr6qZCuM1XFdlmnP6fm51PI3+BkaqoJarFUJSfgyVHNFm/LyQ8oZVFhYOtJJCReKVn14nV4gH5rWvS1nUdfPQghKYlkc13jUFFILTmvC7U481SzCQ+1QNwAC9EpjSqEsoc6ZQkWDlVaK2mpZTu7UroU8ceNw10WBj7QinHp3E+QupTyK1yY0YE0896dYDyGxBjKSXORpeNnp2yBGw8nKt+s94C98tlYgGYD5N+riEa85fKTNVj/+ojRhqpe7Qd0/BixJSpVMKr6NF5N8JYS6FMva2vVu75qNPDb4c5tNxqlF+sLVqrBGRCjxmnoTF+FHI+WE3C55Qrp+Xjm33aehZMY9fkhES9FlqoZ2O2aNFKIGIfVDD/TZggCq8kyaGt4lZRoL52EcQQAxMLkMlPYsbMTCHoVsMbq8NiOeuGvIMzEwMxc5GbAwsa9FQwP0YzSIVRTG142ZP23kLFNRQ77F3cTcuzS3OUzmro2m8TJn/U1JQoqNvptBxYpuQRUdhuSOvmyYgUsa291xSs6BHCZ/W7ICWq3twrjajJ+/YAK9tFUkOAw+pY3AN89ZC9n0wkqPVdIk9cgDO+mKjAAAAEPz4nfV6Fjdh3DWvOmk3/jStKMeHuss3nZA+l9xP0P7aeHxkE5Cp/IToY6jU2JmYhqNwG1Ynwj5C9uJe+BFxhjGcA2I08DBry+da2rY5ss/aLM0NKo48NmqDlG2NX1AJM0/fSGAJbBNk9j6rb9ozAodbt7S6LC5X/64zhignGuSqn7OZShpK+hMsREhv016MEGEUFaFU2ROZUgNejoZoAAcrUIkwDsWHNAyobzbkePdkVGykMT3Xn4HVWyjOQevUhXN888DbQMbu+s4SbiuYjSKkyIo+cQU4Njd0UesHmgeChtGpE8BYOq1NCz9FbnaOmQRPairsF5jvRTF4yKV1Km2JIsiNwdd0Lo9c9Sq/F8rKdyv4r4WONP03Eq+ME+SF8CYXisCwWwQ/z+tLbWbMfjGhvH69v9+twZLPUfj08O432n9MEyngM8HPm9LkHEpQ1VMueQibyZgrLpLhgfk21CQSSjsYwGRt/0FAoFlHa3n4hIsIbDJ3kR80GGddauQ8d/6bczVnGq0/ebCCramBvAfYX2Mded4HRXtetOmtohDn1wqggEVpcpKPCSd5V10g7KgXsqNzKdhdJPjDWzwB3VZjSWzp4ha0a7KlrHRHZ46K3tdE5d14PWkkhjVpjNhH9AVFRPyE3oi6j7fqUSg5o5sNhQpCMb43vJUfolNJSABMqOfL98Twt82SLNVXwbc2h/cR12EpyuGQxTvNYx+nzm9GN55MVYmNcdgi5erH6KfzR0l5k/Xp78mGckBS45xanTEFWqtJPcXUDTZlwvCv3gfg25n5IPzPJM2Mp2BPdk0UiOv4xZHUOaE3zHOwtFAnOBnRYBY1Fo5WQ0wujo/0S6noN8uKbskU9eh59MVLIO4xYos1IyiRFcitUZz9wH8dMp4D7554EuDxvowjfNmUl1I3tV+2xKaLLnpaQy6Pim9gqQt+A8yeNQSeVu0QdhRaVm4oHujexyEa2wIysYuT0N6rpSU47oH72sQR+pQB8vQAAAAAA9lP9hO+/4WU3g7ep/Ym9TaZe2T4tTUoqnsdf563QwoXwBYWA9hRY9+4pvhAfhAPLO1EF5zuXVcFeRCYsL0T5Q3pZxcKgf+d9/0NcMPWlmLafgrjnE6xf4fqgDbdr49uEVtpqNLQYRUt2KqPwlTiLE1W5Hk9DnChIoHCB3zmHoAg89hjNYkAV/iwzqafaM43l5fAVuz33hJSIXQpAi2H7HlE7mXga6C9mQUzJYM/jBH4kV0mKlLjcyE+1P4vrjeiLHQ4avLBsChjGCjB/wsBHP2PuEisXE4KfLMmzs/etE+2czVxXX36+atzuoo+YILK08gR8Ib52aHLIWm0q7ZhcejU/YF+aWS9cpQV5hY+kRqWAgyA3GOCcf88QLjchnTFWPBkjum+PnPYdKYCkxQKshuB+obOG16q9oSnUTEcwVDUVWfD28cghONJHWGnt9f0h0VTV8eK6g/Bd+3F6Ngrt2qpawu10yqrOmvMWB/G9Ffk6rGkteZALJrjK5Zo2eRp/Lc/JTBRNFHsJGOrO7R4uLniNkjbBD6nul5s9fEfWSwcwJkGC0Xw2r19BuSiZEduJm8xxYng47L1SrxYLHEv8ZjazSXa1j84zk+qCX44nXfoc7st1hCFcJirYAWzZzTsZaA6JDh6ymNBNayaZ8lWQuHOXTmbW/vVIS70WBM3B82lB9wLng2j99RFJlVzfNJ2unoFMK8Vr39LegJ154dERuVnj1sWl84+gEdiLDSz5eftu2VOJuKuQMSulAWEPch0YiXMknvjfywqva9VCT/oGZ8JVCtSxMw2HnCQ2HRhSXrbZHb6EbgP1U8pTGaoWconnfENIgmg/4VI9qH4Z4fYFvxvwey8E5wTlqhcykYjasPGTElPAtapdAD+ZuC6NncrGDarv+SZPXZy5l8huAk9ToGBIrr/A/vnI6nP1EIhEuTz4IZ2dogPeYA/yccmARA6y2d0LNXx4AmRe1GbmQrtIW3e8FQnFddRjTd/CaauLFdPahFp0FVvR53t2Apjy27gHpDM4DhJX+ItY0G5glsNGcijghAtASmR/GZp3nudox5hOsBjtUkg6LSM9oxRsP936zzHF2iw6A6cxpzEobG0wXj10h68U40/fujxnX08cpr4lJr8N70bHnMx0DRZeQHB27pbb+8D3NrWdNk2dJgrjukYRChz4aWZXuRihr0i5BXQVFK+4NMGgFZZ4hihM+kfwHqkvxaKVq60hPwEdbk/dIkUFdms7E56nZwFgtaaQrqvCeiaIWSGwnu4gbbscR/B+1SAAu9ydZ8vAIZ7Lfe4SId6bcQZeY8/XUKMNocubcgT3RuEyuwHvpzscUH23j7DBcY7t3e9Yv36JlGWPQxjgRjdEajAAGvb4IXlpBxrm97MobDtRkYK7SFid/A3nKA9DP5kRRGzlqbMaWtP2UZlOf6yVxV5kNhIsNv80PqHVsFHuXv6uvLTRZPu/Hkbj774EskD+QLZrKM7PRVL/jNkTQrjUz9eSedFvAkP15hQpWckBS4+S83K7HvqyEiMtm1kMgO1xoyRtr/1cS5G3JQm0emexJSYscOkVdcutCN1gtT5pDYrI2+Jtc3UYm6YAi9QRCuNli90CPALY00eM7llZ1eeVmPtxS/PeIP22fjpKzzmeYs5VL7VaMt7Waur6IajxP57KS6zo6Q9D1hk1rlGtUV/4p85WpuhgD0vxBMNQ6BnmgsED+pfBezxZteNulL6RFL9l50sDK/1IgK+sBz0o7oCu2OriUUFSkQYaTAhuCy3IgrCKybuxA7IJyvRnfpnGn3MH40vBjHjSsGcUzW2V5OjbilggEEKGpCo7sO93w8vnHNAxBanvxGRUP6V+0nOpETUcd3L/5jhWbUtn3304XVixNo3yN1ZisEvTfTZDzX3Bu2ZY0V9GmlbLvmHIhuFhiPXPUKz8QLY5Z1yFGQWZ1pCtViIPToRcKDHdcmh8IP3uEA1CDy3xQw/HL+gHjf+p3EGZlqxDbplEKVZJA6hLdcK503z2/c+3otGDZ492HudrF/Uv9D58s1yGU8uiMg3GIaGUUdaT7I0/0FT1794nYDXVRmigf8qy0s9nkMGhDJLIde+AXOguXmv63bvUDruwERcVNAQVo7VGF95mPlVi8OeRScxshSDaPu9UNKwKpkTFFuGbK1Y3GTyyltjoRYgQsTP8lxwcUFMOkiKoAsaH0IXuF/e+QP7JX+BxZe+whnAgwpPC7LghTEdDRjuFJ7ckdBrZcMubSFQ0YwvfXr5zI2G0N5GmMfrFYadxX359QqDtY/LgDgarH8moqcT02prnMvUL5VJ1NZNbTPXlNKNkesdAtd0EARAPYr+2/y8ddhOLJ1iwsWsYWgW/KTvFyDI3WoHAQVXieHczGm25/bitjzwydY8WEPh5i/UNfL7KsPgWF0mEy/7tHQg9oIlCFPsKvmcl4l8ZiofsORRW85XQoiA8S+0dozr9n39CFfLsCkieVkgeUrmD8lDAGgclbajcsLDu/vSVFok3/74P0M+aXr1i+GqwHKuhIXhGINGQcqYPVEx/kK5NHGAkw74ZwPCO3wesg7G4jIFJ/CJ7OuBI1dXuEcjB+JCBtrfePmDcLDXFU7gKaTdno87MHyCMmTuue/zpUyy8YM/lHHhGaqKdvOhL7gXrUXlgcOeUSNTfhETPRfyIHkDpgnZCtIIdPEGcSfixSuPDqvT3162+FzXZTMlQNmwCjo+8Na8PEN32Sa+pS67mL5tJORDutP9EaFttQwO9o+pFR0t1j584NYkhmnh/pYbG4sW7zEj0r07AAAAA56x4K+pspLPdhlRtXWRQSlkJfifwHREFoNo1F946TVLXDu+y1WUxpXqbWTgGEg7QBbmVi7A6vRNIxxOTW0XHos5tDO7iP88J+ZGgl3iEw8Oqr3AMkqreyNMQ96XOgnQPtWJqCIQUopmk6vE3P3q9q7l3TstaEFTBmeHTjX6iuZR+5f+ShrNOa036Fg9nsfhg3ncTjojkpFwkkCKeonHGwk/dgRQ6S4dj/mDTRzFxHJfZxg0pdt2XM/Cc5eVGul7TFYOfm9yNYStPSTmFsugCskapomNHJ2XkX+VyY6w4VfCaujjPHvoo+kOuI6U+XYVlLWQWGZygzoZXnPwgRAfJ/0DnfNDc1OgQP/x+Sx2MPKeq+VgZwUImE5OgSmcq96LrpAQThmxGDrGGSgqFHsFYUoBnUErJb8OKjTzwArkf9Ct1BemHtDAy16BKzxXlSrSDSQbLnuxCmpo6veVFRBcQXZVIHmqg0Q+Wc6rOTR0Jo09h+0W1xv66+xfa7aY72StsspFE0fc7Tz1re49pRoBOXjTUlgwhKORnNP9OP3EEQZ27wAxywwD8kwZNlKkaORJD4dnFWFHQHE8LzDm3wxOG4EXmNmdur3PDVQTvkX9T6GBuc1XqjUhAL5l4ermRXYX6BCWybOaU82BG8ZTU0TnAR6bW08wpzzZJZZwDlQbVpqLLNo7M7n3SgBBIOcc5l+nPT1ZINcpOB982iC11H7e3MRtenBwWs1ecFk9G+VRnf3wS/LOZF4t2D/D6pvl35miG/CkJbViTSObMp7lmQk3XqGmMGMJQxOw7gwD2yusb/Aqhh6EDE9GA6HXyxjFvT9janIwSbI4qnwbXe3s/uOTbemQjmQcxPaeta2FSZxJxFMVmEJDTDwG0YFoWnLGURy9asZm3yEFdG7vCdKyj+JxX5yLmKog4CefEns6dODqHQb7OnTg6h0G+zp04OCYDRm6kqfsATZ8QA7vw9UwqmBKaQ5mNgCCubABty8rxl/N6LuVw4sG2zyRWyjdOmqg2TxNlBcQIuO4PjcCfSS1bLQGeKJsjBsYYfhaScG3gIvCUj9UE4xSFWk4rKqQ5ZBf6aAi29BvZJ/kP+PH7TupQzHCQ4LQyftExrqQieHbpiNKDVRIB2k80/HDRXHSkf+wuvxITqoXDJqRtvznWT36x3o4B4En/7R3LW+k8l3ytB7S7ra0VeOY95Hs/y6Vdp/yazejzq+xQeXf0CmKu4vtfpj1RPNOmxkT0HrqklQmtABBoEuQCmZ/wBMPhPunkoccN/6sNt3SJUIosYIOnPSkoAvr7jJEGMDB5MH4zCH8AerTFgvLZlZjH2Hch9mnHKTR4AX7o14VheYM2Rg2ihaOREVb5/a+gylsmXRmb+bVaA4lypJYXwgUnwPs1P815N8PgWr7/ZW6QQWVaQdiNj5Dd3rN7WTj3k2sVXDhBY3z6biuQVX/XXLjNSrOo1NSRx+H2MSJP5ScKLN7epWCs3OFIftjlQn1lK4p/vvAKUdy/oNwgFyIschKrZFGjQeUDphnddodGcSqCLkVc8mYcsxdwJWSBAZscydhL5mhwwuSMB+vB6Y3dicwcXaWqmTAURBGTd+T2m1NS3flh5Y3yf69zUDhgzuELD4LLpTo6eI5h3DyegVQ31w4XKVQskJtXn5cACKquSQny7tnDLmuzPJV3W4en6qgw2rRN4TjbYNaO8wa6lBx0iP/U4h7WVbuYhID8EI83tPh+LQjRceYe4nKfddgRgukhymKBQxTjbOQyvi+d887uL/twr5B/D2XNlCvGLfki1zS+3Ig6aEwvw+UnhnbpvRXkkmQdHAn9IpfJ6Iox0up43QvfULl+kgGAi2JvTLW6BFMdRu51JbBDaAoP3MsjD7N8PxEKtoeTBce/4jCjF/MRUabe1Yf9Bf6QUalsA5zXXRJkhKT5meH8VBkt3RmqmZ95nrep8Dvg4PCO40AMNA8toK09KPKHD9U/CkFf+GMryhUYTMnrpvgO6kpHUQoGKKdxlXG2ULk94BBbjI/DvXyK41YPkflIRQ6FrNtDx4A1KimI5Do6E4G6Nuc+CY3Xv22nIIxniqScMbS2AaJUBdyBaOfufQa3M6vA3GcjZUAD24z1VwX+z+89Ft3IEsRo9bot4BuD8QIU3qqRGKJZxkhIrwG+m0eMO5T9LCgJFTdUvuZBHVmngalMUBYS+ANzkRhrF4AcLCCp/xY0mWLrDa8N/cstH6oyuAxhD2ePmM3YDFtjbOYJFnWAjBmYENdD+pi6Bi8VJygqjnWWg4PZayFKW4eU/3K/kqxLgAHiQ2IKbkt0X9f/dzdqWRQ4+mSJHMZmL6PRxLw6h5lGJQBtwepRnzRZpxlGRg0ikR1sPHq0PdkZIOCq+DjVGbLC9JdqUfS5sMySjMraq9CfjdkvmoX/ZgYeotPuOj7BbvBVf/waHJKRXmcD3adFO2GQqppaMwwbxWbQdXn2aa1eAuXKQ4MixgWnBDqnLiyCkdmG5vVK9ugEQk8ofzXyCbfuw4VDk8A6tRgS6SJk7ntgMJQGZtQBaPB9Kct9kjX8N9Ra/HuO/u37MeS9ALTXsyT+K5XurjsjKPEL/i2MHyXxU7/dry2Hz0nxPQpZnv8sVmD3oB2HsUL0oOTaSjnUQgog9VvIzjdWED6jCc6OChLX2sdbbwZYRlj3ODaBKRWiqSsUW7TjzP72ClfmUXoOOw02X7Yx1tVV76+k6DOF+pzNnK4x7nwdUP2q2FxkkVnyvIyKDWeo+kJP7+FLpujfYbzVM7HMBpVAOUcphFs2f6VITjwXHy7Fz5JeFJe9Kbv33fUQe4E9yIJiHRSh+qbX6qt6Ax8nDoTfWDF5qtVBG3K1LBTy0kopLZ2I5E+kVWDgBYBWANtBj7LKOX0XdhLl5nSfmUaXxRsi9cVI4ks645SluYfBfNCCMRbCYLBAgnfO4X6vbabrnwhPDUfdMOTv5TqNP/O7Ch1sOAQ/5bqQoeHTOhSH4AxoWJXaB6H76YSiVoZp6HH5yob9DcUMCt5fJKlXlSg4DagBIKhhOgkCUzrv1neGgOA8FhHDqXloFlnt9wdKNfaAA0cAw3bDnSy69CxVImvztYirxht4jASDsLePPdrjqyMnvuMNBluH9+9QbMd3D4MzzwPgYcAoK0YSmjeb8GHIuBh6abp3VRZYCEZjhlCtMKfwj9OZYNqGi/ORJz4acle7xsWY6IEMZrs+QwNUNmMnxq14/KDY6J0D/bxzCNmNszOT/vrYk3bF2OBW5RNCRql6AOWS+fYhJgTNBFrKVaIsno+ZVGUii61gPOMP2SqoKaVQC/br4z8g8Bte9dfqFnI55M12BZ7ky226o+rKxyVrpLemzx0Q0Snr9jvR+d9q0UWqTU2maeTGVZHi7jaNESWr9MMmV+vdfmDh4y4CP5MZhwvkUxn2zt4jRfXF2qiOGY9TaigyMaUhU3szBzVaAPF3dav9JDDLe1laDrvepH/eAgRALJ18p53hQhiZgvSf5UDNHC/r9p0k89hF2lwz98YUzLU1QgLdVBUgXq3R2HyoPIaV0UXn0qHaoyrUNHxix8DfVkvvYukIz3x2PScrEUVVne4zXPUGITWayQLFBTEdeXMgP3hXpIlUVaH7z1kTDKdKa3guzxlZVpBlTjvkfTMRgDGoKM2pJE9juHWOZ+KzbKoa5+7qBHCWciGi9N64kZl1BKTzv1N8Lyt/CvlKkqbtGTddGRznIU2zIZVaAaZ3jVXzum9NVmDoHR5w0H69OjpTCejpk0VDOpDxCnUm8IygP28eXj02cyQbZVytViVMIdQ3yFiyOBMqnWZ4uWTVZh3WxSlZJLsW4GCLkTGRew9LvhvFB8+lzFumNvaRM5ZrG/+VA62myWHDGdyUg1mLktc7RraPI1B/YkPR8Cfb/Kd0zLXTz6jxM8qF/TSHLGSf+++n9ewkxVHnejgqoCQp3p7cqHo8YyxeUkkd3sJ2uBmEgh+KH5+rCfjrwadeKfuwbYb/20JGYDPj4c7HuYQ7cjtr006r2VGIcyev0Ytlh9kmSlZPsdgS08M0eK69neissWkRcJ7G0Oj7zbVShL93dQ8tmbi1SEdVFm34GqMA3W7cfoTl99xUdRCBKMZnI46Np10HZf1TtffyYKID0KFufx+wHH2NY4URucLxJ22BQzKI0xMkRiOq2fl4CI1lIp8YhKPRifpd9pdUvuILMnHzInbRPBXE8Xh3CFOPvrZI3yIf2MpzsSevss8mFX0qB/wIxBWxzaX1JWS9aHeh92TCNP+/3onh2QDexLLJ1z+mm3bzX4jrWn5bQ0DdAdKfTFcyw00tDwU3orP+iQSDwjhRsD6nDb6WbgxwMmtxcZkesXBXaOqS33kQC//yOdpK3web1yISJwDkKV7B1QBGSVLzE4XduGiBnFkvwp1Ea/6vVrv6XXL2QLEgiuQCbqMJhEFSOG8H7gZE8RyjTe/F5UzMBlUW2gabs1JU/ukwm2oFRwtiOyyeIAmjPvj6oo8Te6atwPCgRRQoHfVqisGHE7WPvvmdkFZEmg/iAdEU7LGY8DkzRMTZgIXtxXGAY/uuPGwYI2wYPmlw7Nh6geyXE/ELoeW87cahZzWhHBvf5P3fHm3BRtg5CsJL7b8ytOrEOyYVlhSeKwvMf91HkMxq2CNZhr79Y4q2mFY3pj2TqjacqE8NV+KmaL7u1ixOlr0QcQN4ov5LoWVZVa2RaCEt4qkhjp7NVLWsz0BAtPF+i81jAcqoMjTx/nDb9J77Fw5cyb7fCyF2OhEdZHp+a/rE19/xlc0i/nF7U80bo+2jo9Y49KahlKSZZfXjk8RRJRmDXZLvSwIhmiM2l87yTu6TmCaeVR1pJ7LkF2rdGyGEusri6PQjm6gJ/O/ugYy2X+WnZEoyS2wh/gXHJRCoOgLsRVZAALfXHINrf9bpi29SnPGYqLsXrkbO4Ifqxih3GTYG0vEzn6ic0dukwKvXh1kJOj05CSzlVa/6ekE/ATRS1xtlo/gF2nI7ZgKEdIUWt/T7S28tUE0OG+2duGDJLLSL/G5Um8oP6KXyUdQr8Dcx8McSiczaZA9QKmnxyZrjinyC5L/4ubMIw3BdA1Sgnufe36lhKm9y57dNyPaKHKjXdklhn8LLGdsIr65sIwmsyghZQE2dB01p9auDTTuTyOjByFju+bm3GvA3pCDbKE5A7js63EDHE7gQMf/FEpnq0yiMbeaFRTvUTfnSsdOQfmDseyxenz5qbL5QaQlsveWdaucZoE3JXB5KTriNAXVcSOCslyReeLUAialE/s/kf/T+BpdCeQKw0OeG+3UzkPQUiAFumY61HkhBbarmq8EXaU9H8OSuJIeqnV4U2qPpPlnMYTHmwzTtO29Q9NuZdPSa+OLwFhbVyp3VuAknIc+slHs1R7jxXk0BhgPK9gwu0UdhCnBGKVK3hUeU18+bd5I/N4XMakUe3JJsBuOLJ8OzEo98q6KOvXj1HTTqLC9it16nZ+nMegawTIMz1hh+D0WxjE9lpB8JUQCY2Fdf7h9CtGXZuGZARxEnjJ0cJYQlSeR9osZFyriyrozl7ifyaaLOA+lGrt2dXCDc7CFBWGpN+s2EQ49g8Yd6lO6Nc7AAAAA==",
+        "height": 5842,
+        "width": 412
+      }
+    }
+  },
+  "analysisUTCTimestamp": "2026-05-14T17:23:52.354Z"
+}

--- a/tmp/perf-20260514/psi-fr_jobs_revenue_operations_manager.json
+++ b/tmp/perf-20260514/psi-fr_jobs_revenue_operations_manager.json
@@ -1,0 +1,6387 @@
+{
+  "captchaResult": "CAPTCHA_NOT_NEEDED",
+  "kind": "pagespeedonline#result",
+  "id": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+  "loadingExperience": {
+    "initial_url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager"
+  },
+  "lighthouseResult": {
+    "requestedUrl": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+    "finalUrl": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+    "mainDocumentUrl": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+    "finalDisplayedUrl": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+    "lighthouseVersion": "13.0.1",
+    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+    "fetchTime": "2026-05-14T17:23:30.101Z",
+    "environment": {
+      "networkUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36",
+      "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+      "benchmarkIndex": 742.5
+    },
+    "runWarnings": [],
+    "configSettings": {
+      "emulatedFormFactor": "mobile",
+      "formFactor": "mobile",
+      "locale": "en-US",
+      "onlyCategories": [
+        "performance"
+      ],
+      "channel": "lr"
+    },
+    "audits": {
+      "unminified-javascript": {
+        "id": "unminified-javascript",
+        "title": "Minify JavaScript",
+        "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn how to minify JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unminified-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "opportunity",
+          "overallSavingsBytes": 0,
+          "overallSavingsMs": 0,
+          "headings": [],
+          "debugData": {
+            "metricSavings": {
+              "FCP": 0,
+              "LCP": 0
+            },
+            "type": "debugdata"
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": []
+        },
+        "warnings": [],
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "main-thread-tasks": {
+        "id": "main-thread-tasks",
+        "title": "Tasks",
+        "description": "Lists the toplevel main thread tasks that executed during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "startTime": 374.789,
+              "duration": 29.934
+            },
+            {
+              "startTime": 424.995,
+              "duration": 6.5
+            },
+            {
+              "startTime": 440.947,
+              "duration": 19.318
+            },
+            {
+              "duration": 82.135,
+              "startTime": 460.284
+            },
+            {
+              "startTime": 567.829,
+              "duration": 13.522
+            },
+            {
+              "startTime": 581.363,
+              "duration": 11.842
+            },
+            {
+              "duration": 9.151,
+              "startTime": 597.969
+            },
+            {
+              "duration": 6.787,
+              "startTime": 615.734
+            },
+            {
+              "startTime": 625.591,
+              "duration": 12.627
+            },
+            {
+              "duration": 10.712,
+              "startTime": 642.097
+            },
+            {
+              "duration": 10.33,
+              "startTime": 654.683
+            },
+            {
+              "duration": 10.18,
+              "startTime": 665.91
+            },
+            {
+              "duration": 10.428,
+              "startTime": 676.821
+            },
+            {
+              "duration": 26.744,
+              "startTime": 691.281
+            },
+            {
+              "duration": 25.403,
+              "startTime": 719.086
+            },
+            {
+              "startTime": 745.199,
+              "duration": 5.298
+            },
+            {
+              "duration": 6.495,
+              "startTime": 755.505
+            },
+            {
+              "duration": 86.339,
+              "startTime": 765.052
+            },
+            {
+              "startTime": 858.548,
+              "duration": 63.795
+            },
+            {
+              "startTime": 931.767,
+              "duration": 35.11
+            },
+            {
+              "duration": 10.978,
+              "startTime": 968.824
+            },
+            {
+              "startTime": 980.026,
+              "duration": 23.203
+            },
+            {
+              "duration": 21.193,
+              "startTime": 1003.272
+            },
+            {
+              "duration": 25.687,
+              "startTime": 1029.333
+            },
+            {
+              "duration": 12.92,
+              "startTime": 1056.303
+            },
+            {
+              "duration": 6.175,
+              "startTime": 1074.414
+            },
+            {
+              "duration": 11.843,
+              "startTime": 1082.523
+            },
+            {
+              "startTime": 1094.636,
+              "duration": 9.025
+            },
+            {
+              "duration": 211.988,
+              "startTime": 1103.775
+            },
+            {
+              "duration": 27.278,
+              "startTime": 1318.648
+            },
+            {
+              "startTime": 1349.934,
+              "duration": 10.563
+            },
+            {
+              "startTime": 1361.822,
+              "duration": 66.673
+            },
+            {
+              "duration": 12.858,
+              "startTime": 1431.823
+            },
+            {
+              "startTime": 1444.87,
+              "duration": 33.72
+            },
+            {
+              "duration": 166.651,
+              "startTime": 1478.705
+            },
+            {
+              "duration": 17.303,
+              "startTime": 1646.92
+            },
+            {
+              "duration": 9.95,
+              "startTime": 1665.434
+            },
+            {
+              "duration": 10.963,
+              "startTime": 1675.395
+            },
+            {
+              "duration": 10.067,
+              "startTime": 1687.181
+            },
+            {
+              "startTime": 1697.354,
+              "duration": 5.831
+            },
+            {
+              "duration": 5.244,
+              "startTime": 1703.199
+            },
+            {
+              "duration": 5.122,
+              "startTime": 1708.471
+            },
+            {
+              "startTime": 1713.602,
+              "duration": 10.118
+            },
+            {
+              "startTime": 1723.73,
+              "duration": 13.549
+            },
+            {
+              "startTime": 1737.293,
+              "duration": 5.672
+            },
+            {
+              "startTime": 1742.974,
+              "duration": 5.189
+            },
+            {
+              "duration": 6.065,
+              "startTime": 1748.176
+            },
+            {
+              "startTime": 1754.252,
+              "duration": 5.328
+            },
+            {
+              "duration": 5.305,
+              "startTime": 1759.591
+            },
+            {
+              "duration": 5.379,
+              "startTime": 1764.912
+            },
+            {
+              "startTime": 1771.061,
+              "duration": 6.345
+            },
+            {
+              "startTime": 1777.421,
+              "duration": 14.08
+            },
+            {
+              "duration": 5.743,
+              "startTime": 1791.512
+            },
+            {
+              "startTime": 1797.742,
+              "duration": 5.652
+            },
+            {
+              "startTime": 1803.421,
+              "duration": 5.488
+            },
+            {
+              "startTime": 1812.869,
+              "duration": 6.301
+            },
+            {
+              "startTime": 1819.225,
+              "duration": 5.746
+            },
+            {
+              "startTime": 1825.641,
+              "duration": 5.476
+            },
+            {
+              "startTime": 1831.204,
+              "duration": 5.563
+            },
+            {
+              "duration": 166.491,
+              "startTime": 1836.784
+            },
+            {
+              "duration": 26.115,
+              "startTime": 2003.469
+            },
+            {
+              "duration": 15.334,
+              "startTime": 2037.075
+            },
+            {
+              "duration": 15.215,
+              "startTime": 2052.752
+            },
+            {
+              "duration": 88.199,
+              "startTime": 2069.681
+            },
+            {
+              "duration": 5.152,
+              "startTime": 2158.809
+            },
+            {
+              "startTime": 2170.019,
+              "duration": 5.652
+            },
+            {
+              "duration": 120.236,
+              "startTime": 2182.504
+            },
+            {
+              "duration": 5.527,
+              "startTime": 2310.345
+            },
+            {
+              "startTime": 2315.917,
+              "duration": 5.22
+            },
+            {
+              "duration": 9.927,
+              "startTime": 2321.149
+            },
+            {
+              "startTime": 2331.102,
+              "duration": 6.237
+            },
+            {
+              "duration": 5.236,
+              "startTime": 2337.35
+            },
+            {
+              "duration": 5.966,
+              "startTime": 2342.708
+            },
+            {
+              "duration": 5.583,
+              "startTime": 2348.786
+            },
+            {
+              "duration": 5.988,
+              "startTime": 2354.713
+            },
+            {
+              "duration": 7.435,
+              "startTime": 2360.761
+            },
+            {
+              "duration": 9.4,
+              "startTime": 2370.777
+            },
+            {
+              "startTime": 2380.483,
+              "duration": 17.697
+            },
+            {
+              "duration": 7.546,
+              "startTime": 2402.239
+            },
+            {
+              "duration": 20.324,
+              "startTime": 2409.924
+            },
+            {
+              "startTime": 2434.474,
+              "duration": 131.961
+            },
+            {
+              "startTime": 2571.612,
+              "duration": 36.241
+            },
+            {
+              "duration": 23.97,
+              "startTime": 2609.391
+            },
+            {
+              "startTime": 2637.797,
+              "duration": 10.97
+            },
+            {
+              "startTime": 2653.849,
+              "duration": 74.361
+            },
+            {
+              "startTime": 2733.951,
+              "duration": 8.096
+            },
+            {
+              "startTime": 2743.854,
+              "duration": 19.912
+            },
+            {
+              "startTime": 2763.81,
+              "duration": 12.454
+            },
+            {
+              "startTime": 2779.71,
+              "duration": 101.404
+            },
+            {
+              "duration": 5.828,
+              "startTime": 2883.589
+            },
+            {
+              "startTime": 2890.012,
+              "duration": 30.059
+            },
+            {
+              "duration": 115.875,
+              "startTime": 2921.439
+            },
+            {
+              "duration": 14.01,
+              "startTime": 3037.355
+            },
+            {
+              "startTime": 4975.355,
+              "duration": 8.925
+            }
+          ],
+          "headings": [
+            {
+              "granularity": 1,
+              "key": "startTime",
+              "valueType": "ms",
+              "label": "Start Time"
+            },
+            {
+              "label": "End Time",
+              "key": "duration",
+              "valueType": "ms",
+              "granularity": 1
+            }
+          ]
+        }
+      },
+      "max-potential-fid": {
+        "id": "max-potential-fid",
+        "title": "Max Potential First Input Delay",
+        "description": "The maximum potential First Input Delay that your users could experience is the duration of the longest task. [Learn more about the Maximum Potential First Input Delay metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-max-potential-fid/).",
+        "score": 0.66,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "200 ms",
+        "numericValue": 200,
+        "numericUnit": "millisecond"
+      },
+      "speed-index": {
+        "id": "speed-index",
+        "title": "Speed Index",
+        "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).",
+        "score": 0.94,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.0 s",
+        "numericValue": 3001.1123891260854,
+        "numericUnit": "millisecond"
+      },
+      "viewport-insight": {
+        "id": "viewport-insight",
+        "title": "Optimize viewport for mobile",
+        "description": "Tap interactions may be [delayed by up to 300 ms](https://developer.chrome.com/docs/performance/insights/viewport) if the viewport is not optimized for mobile.",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "node": {
+                "nodeLabel": "head \u003e meta",
+                "snippet": "\u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\"\u003e",
+                "path": "0,HEAD,1,META",
+                "type": "node",
+                "selector": "head \u003e meta",
+                "boundingRect": {
+                  "height": 0,
+                  "right": 0,
+                  "width": 0,
+                  "bottom": 0,
+                  "top": 0,
+                  "left": 0
+                },
+                "lhId": "page-8-META"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            }
+          ]
+        }
+      },
+      "network-rtt": {
+        "id": "network-rtt",
+        "title": "Network Round Trip Times",
+        "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "type": "table",
+          "sortedBy": [
+            "rtt"
+          ],
+          "items": [
+            {
+              "origin": "https://tag.clearbitscripts.com",
+              "rtt": 8.121195
+            },
+            {
+              "rtt": 4.3542,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "rtt": 3.1293,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "origin": "https://track-eu1.hubspot.com",
+              "rtt": 2.7066149999999998
+            },
+            {
+              "origin": "https://useago.github.io",
+              "rtt": 1.017765
+            },
+            {
+              "rtt": 0.93235499999999993,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "origin": "https://www.google-analytics.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "origin": "https://cta-eu1.hubspot.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "origin": "https://forms-eu1.hsforms.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "rtt": 0.13481176695174968,
+              "origin": "https://tally.so"
+            },
+            {
+              "origin": "https://www.ocobo.co",
+              "rtt": 0.00693881497525614
+            },
+            {
+              "rtt": 0.0028023909257425647,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.00227793124890555,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "rtt": 0.0022703403217698695,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "rtt": 0.0011202388720668623,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "origin": "https://fonts.gstatic.com",
+              "rtt": 0.00097808802186981261
+            },
+            {
+              "rtt": 0.00093848293892005307,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "origin": "https://www.googletagmanager.com",
+              "rtt": 0.00069497463715431987
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "origin",
+              "label": "URL"
+            },
+            {
+              "valueType": "ms",
+              "key": "rtt",
+              "label": "Time Spent",
+              "granularity": 1
+            }
+          ]
+        },
+        "numericValue": 8.121195,
+        "numericUnit": "millisecond"
+      },
+      "first-contentful-paint": {
+        "id": "first-contentful-paint",
+        "title": "First Contentful Paint",
+        "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).",
+        "score": 0.49,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.0 s",
+        "numericValue": 3001.1123891260854,
+        "numericUnit": "millisecond"
+      },
+      "duplicated-javascript-insight": {
+        "id": "duplicated-javascript-insight",
+        "title": "Duplicated JavaScript",
+        "description": "Remove large, [duplicate JavaScript modules](https://developer.chrome.com/docs/performance/insights/duplicated-javascript) from bundles to reduce unnecessary bytes consumed by network activity.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "table",
+          "debugData": {
+            "type": "debugdata",
+            "wastedBytes": 0
+          },
+          "items": [],
+          "headings": [
+            {
+              "label": "Source",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "valueType": "code",
+              "key": "source"
+            },
+            {
+              "granularity": 10,
+              "label": "Duplicated bytes",
+              "subItemsHeading": {
+                "key": "sourceTransferBytes"
+              },
+              "valueType": "bytes",
+              "key": "wastedBytes"
+            }
+          ]
+        }
+      },
+      "legacy-javascript-insight": {
+        "id": "legacy-javascript-insight",
+        "title": "Legacy JavaScript",
+        "description": "Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile [Baseline](https://web.dev/articles/baseline-and-polyfills) features, unless you know you must support older browsers. [Learn why most sites can deploy ES6+ code without transpiling](https://developer.chrome.com/docs/performance/insights/legacy-javascript)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 26 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 26559,
+            "type": "debugdata"
+          },
+          "type": "table",
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL",
+              "subItemsHeading": {
+                "valueType": "source-location",
+                "key": "location"
+              }
+            },
+            {
+              "subItemsHeading": {
+                "key": "signal"
+              },
+              "valueType": "code",
+              "key": null
+            },
+            {
+              "label": "Wasted bytes",
+              "valueType": "bytes",
+              "key": "wastedBytes"
+            }
+          ],
+          "items": [
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "signal": "Array.prototype.concat",
+                    "location": {
+                      "column": 6239,
+                      "line": 1,
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "type": "source-location"
+                    }
+                  },
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network",
+                      "line": 1,
+                      "column": 12925
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "line": 1,
+                      "column": 12813,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network"
+                    },
+                    "signal": "Object.assign"
+                  },
+                  {
+                    "signal": "Object.create",
+                    "location": {
+                      "type": "source-location",
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 10857,
+                      "line": 1
+                    }
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 13770,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network",
+                      "line": 1,
+                      "column": 6239,
+                      "type": "source-location"
+                    },
+                    "signal": "Array.prototype.concat"
+                  },
+                  {
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network",
+                      "line": 1,
+                      "column": 12925,
+                      "type": "source-location"
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "signal": "Object.assign",
+                    "location": {
+                      "type": "source-location",
+                      "line": 1,
+                      "column": 12813,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network"
+                    }
+                  },
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network",
+                      "line": 1,
+                      "column": 10857
+                    },
+                    "signal": "Object.create"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 13770,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "url": "https://tally.so/widgets/embed.js",
+                      "urlProvider": "network",
+                      "line": 1,
+                      "column": 951
+                    },
+                    "signal": "Array.prototype.forEach"
+                  }
+                ]
+              },
+              "wastedBytes": 12789,
+              "url": "https://tally.so/widgets/embed.js"
+            }
+          ]
+        }
+      },
+      "non-composited-animations": {
+        "id": "non-composited-animations",
+        "title": "Avoid non-composited animations",
+        "description": "Animations which are not composited can be janky and increase CLS. [Learn how to avoid non-composited animations](https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/)",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "label": "Element",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "failureReason"
+              },
+              "valueType": "node",
+              "key": "node"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "script-treemap-data": {
+        "id": "script-treemap-data",
+        "title": "Script Treemap Data",
+        "description": "Used for treemap app",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "nodes": [
+            {
+              "children": [
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 298,
+                  "name": "(inline) window.dataLaye…"
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 631,
+                  "name": "(inline) window.AGO = {\n…"
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 592,
+                  "name": "(inline) ((storageKey2, …"
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 520,
+                  "name": "(inline) window.__reactR…"
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 18824,
+                  "name": "(inline) window.__reactR…"
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 53,
+                  "name": "(inline) window.__reactR…"
+                },
+                {
+                  "resourceBytes": 7907,
+                  "name": "(inline) ;\nimport * as r…",
+                  "unusedBytes": 0
+                }
+              ],
+              "encodedBytes": 5535,
+              "resourceBytes": 28825,
+              "name": "https://www.ocobo.co/fr/jobs/revenue-operations-manager"
+            },
+            {
+              "encodedBytes": 3946,
+              "resourceBytes": 9792,
+              "name": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "unusedBytes": 763
+            },
+            {
+              "resourceBytes": 125385,
+              "name": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "encodedBytes": 43336,
+              "unusedBytes": 70219
+            },
+            {
+              "encodedBytes": 863,
+              "resourceBytes": 927,
+              "name": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 1566,
+              "resourceBytes": 3192,
+              "name": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "unusedBytes": 1084
+            },
+            {
+              "unusedBytes": 89,
+              "name": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "encodedBytes": 942,
+              "resourceBytes": 983
+            },
+            {
+              "unusedBytes": 6,
+              "name": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "encodedBytes": 95,
+              "resourceBytes": 141
+            },
+            {
+              "encodedBytes": 685,
+              "resourceBytes": 1284,
+              "name": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "unusedBytes": 467
+            },
+            {
+              "unusedBytes": 1144,
+              "encodedBytes": 6247,
+              "resourceBytes": 15426,
+              "name": "https://www.ocobo.co/assets/cx-DiffRdtV.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "encodedBytes": 5624,
+              "resourceBytes": 17234,
+              "unusedBytes": 1545
+            },
+            {
+              "encodedBytes": 1256,
+              "resourceBytes": 3070,
+              "name": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "unusedBytes": 1047
+            },
+            {
+              "encodedBytes": 365,
+              "resourceBytes": 428,
+              "name": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "unusedBytes": 239
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 364,
+              "resourceBytes": 410,
+              "name": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "encodedBytes": 463,
+              "resourceBytes": 525,
+              "unusedBytes": 65
+            },
+            {
+              "encodedBytes": 869,
+              "resourceBytes": 942,
+              "name": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "unusedBytes": 362
+            },
+            {
+              "resourceBytes": 349,
+              "name": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "encodedBytes": 277,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 1866,
+              "name": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "encodedBytes": 794
+            },
+            {
+              "encodedBytes": 287,
+              "resourceBytes": 348,
+              "name": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 32006,
+              "encodedBytes": 20674,
+              "resourceBytes": 67398,
+              "name": "https://www.ocobo.co/assets/_main-9OzAywp_.js"
+            },
+            {
+              "encodedBytes": 104,
+              "resourceBytes": 165,
+              "name": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 145,
+              "resourceBytes": 206,
+              "name": "https://www.ocobo.co/assets/lang-PH2TSE5M.js"
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 33602,
+              "resourceBytes": 109016,
+              "name": "https://www.ocobo.co/assets/resources-NaHgTejN.js"
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 543,
+              "resourceBytes": 605,
+              "name": "https://www.ocobo.co/assets/layers-CQ3InJLS.js"
+            },
+            {
+              "encodedBytes": 779,
+              "resourceBytes": 826,
+              "name": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 343,
+              "resourceBytes": 404,
+              "name": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js"
+            },
+            {
+              "encodedBytes": 426,
+              "resourceBytes": 490,
+              "name": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 337,
+              "encodedBytes": 788,
+              "resourceBytes": 835,
+              "name": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js"
+            },
+            {
+              "unusedBytes": 47528,
+              "encodedBytes": 25833,
+              "resourceBytes": 68826,
+              "name": "https://www.ocobo.co/assets/portal-Clm-6X_X.js"
+            },
+            {
+              "encodedBytes": 44681,
+              "resourceBytes": 133936,
+              "name": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "unusedBytes": 30785
+            },
+            {
+              "encodedBytes": 427,
+              "resourceBytes": 473,
+              "name": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 279,
+              "resourceBytes": 338,
+              "name": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 374,
+              "resourceBytes": 435,
+              "name": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 251,
+              "resourceBytes": 312,
+              "name": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js"
+            },
+            {
+              "resourceBytes": 309,
+              "name": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "encodedBytes": 248,
+              "unusedBytes": 194
+            },
+            {
+              "unusedBytes": 140,
+              "encodedBytes": 3551,
+              "resourceBytes": 9506,
+              "name": "https://www.ocobo.co/assets/_main.(_lang).jobs._slug-BoqAb8sy.js"
+            },
+            {
+              "encodedBytes": 274,
+              "resourceBytes": 337,
+              "name": "https://www.ocobo.co/assets/plus-Bvz3jpuZ.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 65,
+              "encodedBytes": 642,
+              "resourceBytes": 717,
+              "name": "https://www.ocobo.co/assets/text-DlkbtvSW.js"
+            },
+            {
+              "encodedBytes": 411,
+              "resourceBytes": 474,
+              "name": "https://www.ocobo.co/assets/send-CYV-iugJ.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 65,
+              "encodedBytes": 422,
+              "resourceBytes": 495,
+              "name": "https://www.ocobo.co/assets/badge-i9dgPBIb.js"
+            },
+            {
+              "encodedBytes": 658,
+              "resourceBytes": 707,
+              "name": "https://www.ocobo.co/assets/meta-pill-ClipWulT.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 9,
+              "encodedBytes": 1239,
+              "resourceBytes": 2533,
+              "name": "https://www.ocobo.co/assets/member-card-Bn7bfGBT.js"
+            },
+            {
+              "encodedBytes": 558,
+              "resourceBytes": 605,
+              "name": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "unusedBytes": 65
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 375,
+              "resourceBytes": 438,
+              "name": "https://www.ocobo.co/assets/map-pin-BFjzXly_.js"
+            },
+            {
+              "encodedBytes": 592,
+              "resourceBytes": 656,
+              "name": "https://www.ocobo.co/assets/star-BI6vQnwF.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 83800,
+              "encodedBytes": 51205,
+              "resourceBytes": 138685,
+              "name": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js"
+            },
+            {
+              "unusedBytes": 1978,
+              "encodedBytes": 1339,
+              "resourceBytes": 3506,
+              "name": "https://www.ocobo.co/assets/PageMarkdownContainer-klsUvxsc.js"
+            },
+            {
+              "encodedBytes": 567,
+              "resourceBytes": 1208,
+              "name": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "unusedBytes": 4
+            },
+            {
+              "encodedBytes": 23527,
+              "resourceBytes": 69550,
+              "name": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "unusedBytes": 28818
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 580,
+              "resourceBytes": 2125,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js"
+            },
+            {
+              "encodedBytes": 4242,
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "unusedBytes": 12049
+            },
+            {
+              "encodedBytes": 156346,
+              "resourceBytes": 471493,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "unusedBytes": 203872
+            },
+            {
+              "resourceBytes": 78059,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "encodedBytes": 26372,
+              "unusedBytes": 35974
+            },
+            {
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "encodedBytes": 42586,
+              "resourceBytes": 108995,
+              "unusedBytes": 46367
+            },
+            {
+              "encodedBytes": 25123,
+              "resourceBytes": 72608,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "unusedBytes": 36099
+            },
+            {
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "encodedBytes": 27533,
+              "resourceBytes": 97992,
+              "unusedBytes": 57100
+            },
+            {
+              "encodedBytes": 156346,
+              "resourceBytes": 471493,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "unusedBytes": 335885
+            },
+            {
+              "unusedBytes": 682,
+              "encodedBytes": 1242,
+              "resourceBytes": 2495,
+              "name": "https://www.ocobo.co/_vercel/insights/script.js"
+            },
+            {
+              "unusedBytes": 6501,
+              "encodedBytes": 4673,
+              "resourceBytes": 12567,
+              "name": "https://www.ocobo.co/_vercel/speed-insights/script.js"
+            },
+            {
+              "encodedBytes": 4242,
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "encodedBytes": 580,
+              "resourceBytes": 2125,
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 202931,
+              "resourceBytes": 587832,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "unusedBytes": 337253
+            },
+            {
+              "unusedBytes": 24780,
+              "name": "https://tally.so/widgets/embed.js",
+              "encodedBytes": 13701,
+              "resourceBytes": 36401
+            },
+            {
+              "unusedBytes": 73621,
+              "encodedBytes": 27533,
+              "resourceBytes": 97992,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            },
+            {
+              "unusedBytes": 248156,
+              "encodedBytes": 202931,
+              "resourceBytes": 587832,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "unusedBytes": 36384,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "encodedBytes": 26372,
+              "resourceBytes": 78059
+            },
+            {
+              "encodedBytes": 42586,
+              "resourceBytes": 108995,
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "unusedBytes": 68120
+            },
+            {
+              "unusedBytes": 49494,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "encodedBytes": 25123,
+              "resourceBytes": 72608
+            }
+          ],
+          "type": "treemap-data"
+        }
+      },
+      "unminified-css": {
+        "id": "unminified-css",
+        "title": "Minify CSS",
+        "description": "Minifying CSS files can reduce network payload sizes. [Learn how to minify CSS](https://developer.chrome.com/docs/lighthouse/performance/unminified-css/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [],
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "headings": [],
+          "overallSavingsBytes": 0,
+          "overallSavingsMs": 0,
+          "type": "opportunity"
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "interactive": {
+        "id": "interactive",
+        "title": "Time to Interactive",
+        "description": "Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).",
+        "score": 0.17,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "11.7 s",
+        "numericValue": 11671.511627443842,
+        "numericUnit": "millisecond"
+      },
+      "screenshot-thumbnails": {
+        "id": "screenshot-thumbnails",
+        "title": "Screenshot Thumbnails",
+        "description": "This is what the load of your site looked like.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "timestamp": 125064733405,
+              "timing": 375,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFwABAQEBAAAAAAAAAAAAAAAAAAQBCP/EABgQAQEBAQEAAAAAAAAAAAAAAAABEVEx/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AOqQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dhs7AA2dgCMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGz2KwB//Z"
+            },
+            {
+              "timestamp": 125065108405,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAAHAQAAAAAAAAAAAAAAAAIDBAUGBwgB/8QARRAAAQMDAgMGAwQIBAMJAQAAAQACAwQFEQYSEyExBxQiQVFhFXGRCDKB0SNCUlSSobHBFhczgjRy8BgkJzZidIOjs+H/xAAbAQEBAQADAQEAAAAAAAAAAAAAAQIDBAUGB//EADARAQABAwICCQMDBQAAAAAAAAABAgMRITEEEhMVUVJTYZGS0RQjoQVB4SIycYHw/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEXjnBrS5xAaBkk9Asei1xpWa4dxi1FaX1edoibVMJJ9OvX2QZEiEgDJPL1WOnXGlm1/cjqK0irzt4Xe2bs+nXr7IMiRAQQCDkHzVqvOobXZXsbdarujH4xNLG4RD5yY2j8SguqLAu2uq/8ACS/1NHPyNO1zJYn9QXN5ghXY6v09ZqSgprvfLdR1ToY/0c9Q1rubRzIJ5IMnRS6aohqoGT00sc0Mg3MkjcHNcPUEdVZbvrHTdnqxS3W+2ykqc44U1Sxrh8wTy/FBfkUqkqYKynZUUk0c8EgyySNwc1w9QR1U1AREQEREBERAREQEREBEXj3bWkoBcG9SAvBIw9HBWu5XGkt8BqLjVQ00OQ3iTPDG5PQZKoKPUtjrallPR3i3z1EhwyOOoY5zvkAUGSopFO8nwn8FPQEREBERBrftwnmfZ7HaGzPp6S8XWChq5GHaeC4kubnyzjCyOr0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3v1VZq7TtDqqxT2u5tdwZMOa9hw+J45te0+RBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHnjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fdo25W3GaB0q2x/CRYrf3LZswYW7umM7uu73zlRzaJskuiRpU0xFpbEImtB8TSDkPB/a3c8+qxpuidaMpPhzdfy/DQ3hhxt7DU7OmOLnrjzxlBZu0GqqdCdihp9O3iarMcraNlc54c+GNzyCNw82jwg9Qti6f05bLfpxlujiFRTzQhs75jxHVGRzc8n7xOVLt2jbJRaPbpkUjZrTwzG+ObxGTJyXOP7RPPPqqV2nrpbLKLPpivbTU2zhsqK17qiSnb0wxvLOPLc44QaVp55afsi7ULA2V81us1c+no3uOdsfEHgz7Y/mtz6J0pZqPSdJGaWmrnVdOySpqZmCR1U5zQS5xPUHPIeQVvHZnQU/ZrXaSoKmSPvoLp6yRu98khcCXuHLOcYSPR2o7TSdw0vqmOitobtjhqqEVDqceYjduHL0Ds4QYpp+rm0h/mjarIS6gs8XfKGL7wge+Jz3MHsCM4WU9lmkrHDoa21L6Olrqq407amrqp42yPnfINzskjmMnor1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93Uu9scgFjtFoLUOn2SUWkNW9xs5c50VJV0Tak0+TkhjiQcegOUEjs+hjsHafqzTdrGyzMhgro4Actp5H5Dmt9AeuFtBYzojSMGl4ayR9XPcLpXScasrp/vzO8hgcg0DkAOiyZAREQEREBERAREQEREBQTjMRUaHmgx3UYqTbT3IVxm3D/AILg8TH/AMvhx/NWKytu/wAUg70NRcHJ3d6FDw+h+9w/H9Fmz4SD4eYUIieT91B7AP0gVUoIowwe6jQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERUFbJVtrqdsLWmnIOTkjLvQ8jgY/n/ADCvRQSbzA7AxIWnGD5rG46a7Clpmyun3CQmQB+4gbRjnuBPPPny+SDJ0VnfS1jH3B8Es5c5o4IdJkAnrgHkD6KXA24RbX7Kp8LZsiOR7TIW7CDk5xjcQeqC+IrHBBc219C6R0nCZCwTHfkF+H7sjz57efyU/Fw+O8Tae47eFt3+eM78fPl/ZBdUVgjjuZppGyNnEjKfYCJBl8m7k4c+nTqquBleLJI1xd8Qw7JLgcuz+r5Aen80F0RY+Ke4yNYxjqhkXHB/TS+MN2OzktPTdjzU6opq41Fc+N8m0RbYBxTzdsx0zjr5lEXpFjbae6AUYkdPta6TiBryeWW7ee4E8s9foq+0MrWVlX3oTGIuyx0jhjqeQAJxyx6fJFXVERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERQTSxwxl8r2sYOpccBSZimMyI0VuN7twP8AxLf4T+SfG7d+8t/hP5Lq/X8L4tPuj5cnQ3O7PouKK3fG7d+8t/hP5J8bt37y3+E/knWHC+LT7o+Tobndn0XFFbvjdu/eW/wn8k+N2795b/CfyTrDhfFp90fJ0Nzuz6Liit3xu3fvLf4T+SfG7d+8t/hP5J1hwvi0+6Pk6G53Z9FxRW743bv3lv8ACfyT43bv3lv8J/JOsOF8Wn3R8nQ3O7PouKK3fG7d+8t/hP5KqpaynqgTTytkx1x5Ldvi7F2eW3XEz5TEpVbrpjNUTCeiIuwwIiICIiAiIgIiICIiAiIgIiICIiAsM1ZUvkuRgJPDiAwPcjOVmax/UVnkq5BUUuDLjDmk4z8l4v6/YvX+DmmxrOYzHbH/AGrtcHXRRdzW1F2g6vk0o23mKkjqTVOe3D5CzG0AgDAPM5xzwPdLlq91HrW2WHgU7W1lOyfiyzEHJc4bWgNIJ5ZGSAVmtTYZqnAqbeJtuQN8YdjPXqoX6efJPHNJbGumjADJHRAuaB0wfJfE27PLRFNfD1TOJzOu87T/AK/L1ZrzMzFcY07Gu9U9onwPVYs/cGva1sZdK+UtLt56MaGnPX+quN31fJb9c0NgbRxyMqWMcZTKWubuLxyGMHG31B58lmsthllmZNLbg+aP7j3Rgub8j5JJYZZJmzSW4PlbjD3RguGOnP8AE/Vai1TimPpqs4mJ31n9p/hOfWfuRv5bMNdq1w1obD3Vn+sI+JxOZaYeJu249fCp9Fe7nNrKqs81up46WGITd4bUZcWOJDfDjqS08s8llnwSo7xx+4Hj428TYN2PTPXCiFmqhKZRROEpAaX7OZHplcc2asYixP8Abjad+3+Gorj96438tuxhWjdWO1FWXeF0NPD3GUxbWSuc84c4ZcC0AA7fIlWfRPaO7Ut4o6F1sNNx4JJDIXkgOafut5DPhwc+62TBYJKd8j6e2iJ8nN7mRBpd88dV5Fp58JjMVsawxghhbEBtB6gei5JtU/144erXGN9NPzrqzFe33I89tWF6K1g7UlPdJXQU8JonFvDZK5z+Rd97LQBnbywT5+ig0JrOTVbK7bQinlpoYZNjn5y6QOOOnTwg59HLN6fT8lMZDT21sRk+/wAOIN3fPHXqVFBYZqcuNPbxEXAAlkYbkDkBy9Fm5Z5ufk4eqM4xvp2/5ytNeMZrjz21Yto293C9suDrjQQUfdag0w4U/E3Ob97yGB0x65WVUFS+kq45oyQWnnjzHmFFFZqqIO4VE5m5xc7azGSepPurrZ7DO+oZJVs4cTTnBPNyWuD4m9xMTYtzRrGNJxHnmSq7bptzFdWWYIiL9QeAIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIg09fPtA6Ws17uFrqbfen1FFUSU0jo4Yi0uY4tJGZAcZHosk7Pe1bTeu62WitLqqCtjZxOBVRhjnNHUjBIOM+q5Svl4qLB21Xy60dPHUz0l3rJWxSAlrsPfnIHljJ/BX/QtDTaYt931bSantM95joZTRUNI9xla942ue5rgMbWlxxg9PZEdl5HqmR6hcEW+hrL1bqi+TahMdyZUBhNVUtYcHHiL3PDvPoGnp1CyXtYtdwk0jpTUFfcaa6VLmSW+espZuKx+xxdHud5u2lwP/ACoO0sj1CZHquGviVXr7tDhuD4XTd3pGzyRu5gtp4A5wPs5zCP8AcrdSNuGrzdbtdL+4XCDEje8TNaHZJz4nPbtA8g0H5IZd7ZA6lMj1XDnaFU3OTROlIbpeaS7OgmrGRS09RxixmICGPd6gk/gQqTWQudkp9H1kd5rHyz2mKoh2u2d2G9wDGY8vDnPmSUHd2R6hMj1C4e09XS13braK2qf+lqLvBNIegy57Sf6qVYbtUWftZu1zoHZqKZ1ymiPUBwhmIOPP1Qy7myPVFwRQUtdqKir71Wagc25RStGaqoa0uzjxF7ngjr0a13TyXXHYdVXCp0BTNu11o7tUQSOiFTTT8YFowQ1zvNwzj5YRVPrftk0npC5yW6unqaqui/1YaOMPMZ9CSQM+2VBovto0lqy6RW6kmqqOtmOIo6yMM4h9AQSM+2Vx/XOfPric3f777i7vPE9TJ48/zVx1k2Cl7T7m3TYibBHcj3MUxG0Yf4duPLPTCI75yPUIuEaY1Mna1XU9Ndo7RJU3Cpp3Vshw2Fr3Pa458uRI8uvUdVlnZvf7toXtGudltl2F5t0UFSTwnl8MpjgdI17RkgEFoBx7jmiuwsj1TIHUrgmlbcNXm63a6X94uEGJG94ma3dknPic9u0DyDQfkrn2h1Nyk0TpSG6Xmkuz4JqxkUtPUcYsZiAhj3eoJP4EIjuPI9UyPVcr2bSF203oCPtIhvzpqqO0cOnp+Dgwte0RNw7d+qHbunULWdK6ao0Te7rPq4NrqiVkE1qlc50tWwOa4OJJ8jz/ANp588IrtDX+sbfojT5u91iqZqYSti20zWufl2ccnEDHL1WKO7WYrn2dVuqNLWO43A09V3TusjQ1+cNJedhd4QHD3/quV6C0w1fZbdrpJJKJ6G4wxxtBG0iRjt2eWf1BjmPNZXpGjoofs865rWVObjUVVNE+DiN8MccsRa4N68zK4E9OQRHTHZRq+46y07LX3ayy2maOYxBj92JBgHc3cAcc8fgs0yD0K4QtmqbtZOzKWgtVTNSsuFyk48sTi1xayKPDMjmAd38lV1wruzivsF2sGqoK+prIW1UsdLISIzyJjkGTkHOOfPkeQQdyZHqEyuI9KUlVfO3SelpK6e2VFVX1oE8QBfFlspOM+eMjPllUvZhfb9TOv1DaryaJ1RQPDXT1HDjD97MHc44a45LQ7lzd1QdzZHqEXA4s9VQVJl1RcbnZ6mbxU9Q6B0zJvU8Rr8+Y5gO6rtLsybI3QFiE1wZcnilbmrY9z2y/+oF2D9eaKyZERAREQahi7DbU3XlRqWa6VMzp6qapkpHxN2O4hduZnrjxEKXpXsEsWn9ROuLK+qq6V0c0LqOoY0tcyRhYQXDB6OW4kQaHqPs06ekr3yxXi5RUpdkQBrCWj0DiP6hZ3qLsvsl27PqfSNMX0NDTvbJDIwBz2uBJLjnqTl2fms9RBq/sw7HbXoO7Vdwhrp6+aeA04E0bWhjSQXdOucBY5efs36drbpLU0VzrqGnkdu7sxrXtZ6hpPPHzyt5og07f+wSwXGxWe1UVbVUMNvMzzIGtkfO+TZlzycc/AOig1N2D22/UlkglvVZCLXQtoWFsTTxGhznbj6HxLcqxztD1ONHaPuF9NL3vuoaRBxOHv3PDfvYOOueiDX1z+z/pyvu1HXPra+MxMhZNFGWhsxjaG56ZaXbeeCo9M9g9lsWrW3plwnqIQZgaKSJvDLJGPYWE9cAP/knZ523UurKa/wAlTafhz7VRurdneuLxWNzu/UbjHh9fvKR2Y9uQ1vq6nsbrB3AzRveJu+cXm1ucbdg9PVBQV32a9PTXCSamu9xpqVztwgDWu2j0Dj/fP4rb+ktOW7SlhprRZ4jHSQA43HLnE8y5x8ySpkmorLHJVRyXe3NfSs4lQ11SwGFv7Txnwj3KohrjShhdKNTWQxNcGuf3+LAJyQCd3U4P0KDCde9hum9W3eW6NmqrbWzHdMafBZI79otI5H5YyoNDdhOmtL3eG5yzVVzq4HB8PeNoZG4dHbQOZHuVsIaosDoaWYXu2GKryKd4qo9s2Dg7DnxYPI481V3O7W61RMludfSUcbzhr6iZsYJ9iSEHG2lNOQai7cqm1XWnldQ1dbXMedpGPBKQ4H1BAI9wF0d2b9kGn9DVU1ZTPqK6uljMRmqduGtPUNaByz55ysvqNVaepriLfUX21RV5c1opn1cbZMuwWjaTnJyMeuQqyuu1uoJ4IK6vpKaadwbFHNM1jpCTgBoJyT8kGmbz9m/TtbdJamiuddQ08jt3dmNa9rPUNJ54+eVcr/2CWC42Kz2qiraqhgt5meXhrZHzvk2Zc8nHPwDotk0eqLBW3L4dR3u11Fw3Ob3aKrjdLludw2g5yMHPphKjVOn6asNJU3y1xVYODDJVxteD/wApOUFNaNKUVDoin0vUk1lBHS90eZBgyMxg5x0/Baw/7OGmWx3BsdwuBdO0NgdJtcafxAkjAG4kDbz8iVtm66msNnmjiu16tlDLIziMZU1TIy5vTcA4jI5Hmp1DfbRcK51HQ3ShqaxsYmdBDUMe8MOMOLQc4O5vPpzHqg11pvsTslp0nedP1dZVV1Jc3xyOe5rWPiczO0tIzz5+atVu+z7aKC1XqihvVe4XKJkJe5jP0bWysk5DzOWAfit1og1Ha+wmwU2j6ywV1XVVkc9SKqOow1kkDw3b4eoxjqCqHS/2eNOWe7wV1bXVly4Dw9kEoayMkdNwHMj2yt1Ig1RYOxegs3aH/iyK7VUlR3map7u6NobmQPBGevLf/JWS0/ZzslG6rFRebhUQ1MJhc0MYwjxNcCDz6Fo8lvJEGhYfs0WBtS10t7ub4AecYawE/wC7H9luuw2mjsNmo7XbY+FR0sYjiaTkgD1PmVXogIiICIiAiIgIiICIiAtXfaWl4XZFdRn/AFJYGf8A2NP9ltFWLWmlrbrGyOtV5bM6kdI2QiJ+w5b05oOG9KUV3kpp5LMSBXSss8mPPjZIB+ew/RNI1lVYdVVElDI5tTDT1kTHs5EHgSNBHoc812fors205o+KojtNNI9s8scx7y/i7Xs3bXNyORG4qzWvsU0fbb7FdqeCsNVHKZQJJy5hJzkFuOY5nkiOSLM2w/4YvFTX3S40+oOTKSCFmY5mH7we76+Y/FUVN/5QuP8A76l//OoXY47FdDtnrpYrSYzVxuicBK4iMO6lgOdp9x08lRM7BtFMoZaQQ1/BllZK4d5OdzA4Dnj0e5BzBqmzQUfZ3oe6RyTvqLg2tbI17yWMEc+Ghg/VHicT6kqbqWuF11Lp2LVNZVR2qO30UZljG97ITE0uLQepyXf/ANXVFx7G9J3Cw2e0VMVYaO1cbuwbUEOHFcHPycc+YVReOyLR93tltoq63PeLfC2ngmbK5snDHRrnD734oOSKE0B7VLWLPWVVdbm3KmZTz1QxI5gewDI9sYHsByHRX2qFu1D2uX7/ADEvVXbIY5pwJmNLnMcx2GMHI4AHt5e66Rl7F9HP1BBd4qOeCpgfFJGyGYtjaYw0N8P+0Z9ea0x2y0N8PaDcKmfQsdwibMHU1YynmImYMY38N213pzGfIoNZaRrquk1ZXVtsqJpKplLXPjqOYef0EmX+oOMlU9ooLLW2SrnuV07pcmzNDA8ucHMOMnYGEuPX9Zv4rcH2eezy+O1s/Ud/tktDRQxy7WVEXD4z5GlpAYf1cOd5Y6BbSq+wfQlTXvqjb6iMPdvMMdQ5sfyA8h7AoOXO0B0fctNR092fdqeKgdHHUPgdFhomk8ADuZAORn8PJdQdjPZrbNMx0epaWsrp66422NsrZ3tLBvDHnGAD1aAOfRXLUvY9pDULqDvdHNDHQ04pYIqaUxtawOLunmcuPNZ3baOK3W6loqYOEFNEyGMOOTtaABk/IIKhERFEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEULyc7R+KCJFKdsY0ufgADJJUMT4pWkxkOA5dFOaM4zqYndPRUtTUUtLw+8zQw8R21nEeG7j6DPUqFlXRvrJKRlRTuqoxufCHgvaPUt6jqPqqKxFJhfFNEyWB7XxvG5r2HII9QQpjTnIPUIIkRQvOMAdSgiRSyGgEu+pUuKWGUkRua4j0RMqhFSVlVSUTGPrKiCnY92xrpXhgLvQZ815JV0cYnMlRTtFOAZi54HDyMjd6cvVFViKjiq6OZgfDUU8jCzihzXggs/a+XuvYqmkmpe8wzwSU2C7iteCzA6nPRBVoqM1lEJ5IDUU/GjbvfHvG5rfUjyHupkU1PMSIZIpCGhxDXA4B6H5HyQVCKijrqGRzmx1VM5zX8JwbI04f8Asn39lTC+WYxPlF0t5jjIa94qGYaTnAJzyzg/QoLsip4ZYJ25gkjkGA7LHA8iMg8vUKaDtPsgjREQEREBERAREQEREBQH7591GvHNygobpA+eANYzeefh/AgfzUqipnR1bpOAImHPpz5N9PkVccO9imHe31XWq4Wiq50s76fhuK5iOVi+rNMS3m4QVcEtDuZTyUro62l7wza8tJc0bhh3h9wVJj0lKNWvuzqqAQd6FW1jIcS7u7Ng2F+fuci7GOuPRZdh3t9Uw72+q7LC26YthsunbbbHSiY0lOyEyBu3dtGM48lcm83/ACCbXewUQGAg9UDuTx7hRoRkYKCTUR8WCSMHG5pGVRUFO9s7pHtczGRhxByTjOPbkrhtcPMFMO9vqrnTDM0xM5WDV2modTRUEFXK5lNBO6WVjeRlaYpIy3Pl9/r7fisePZ/UZvzvi5JvETo5gYRhhEmYi3z8LCW8yc8umMLYGHe31TDvb6qNMHpdCcC31FK+qimE1vlon8SN2HufK55e4NcDz3cwCOfTHRVVPpmspNEVFo7xDU1BeZG7WcNrhvDth5knIGCSSTnmsuw72+qYd7fVBgc2g5Ja+eTvdI2F01TUMeKXFQXTMe0tfJu8TBvPLA5NaPJV+htHnSstdtrn1NPPFBFFG9vOERh2Wg55ty8kDyHLyWW4d7fVMO9vqgwKzaDmt8zSa2m4DK2KqZFFA4YDOJkbnOLue/1wMchzU266DbVUksVLPDA590+I5Yx0fLYWhmWODh1JyCs4w72+qYd7fVBZ7Vbp6W8VVTKWcJ9JT07dpJy6MyFx58/1wOfPkru7pj1XuHey9a3ByTkoIkREBERAREQEREBERAREQEREBERAREJAGSgIoNzvYJl3t9EEaKDLvb6Jl3t9EEaKDLvb6Jl3t9EEaKDLvZRNdnl0KD1ERAREQEREBERAREQEREBERAREQEREBERAREQFA/74Ua8eM8x1CCTUueyB7og0vAyN3RUNFO51Qxsc7ZmyAvfn9X5fUclcc55EH6LwNaCCGgEDA5eSMzTMzlj2u7jcLZZuPaHf96DjtZ3d0vEIaSG8vu5I6+Z5ZGcim1heLpR0NJLbqeeM94LZhwt75GBhOGABwyTjG7HpkZyssz8/omfn9EaYjq2+Xe3X6zw2uikqKHcH3B7Y922Nz2sbg56jc5xxnkz0OVYxqfVYuNwp5KFjIWfEH0tQad7mObE/bE14aC7PLPIeIEY6FbKz8/omfn9EGPaEuVZdbA2ouXE7wJHsLnwcLcAeRA8x74GfRZCfvNQn5/RetBJyeXsgiREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAWrrzBrv/NBklA6Y6WdV0u8CRo2sEZ4hAznaXHmOuQMLaKINYaudrf8AzTs01lpqt2mKfhR1TWSRhku8u3uILsnaC3y8kfb9bjtiG2pqjo5zhVF/FbtaREWmLGc4L8Hotnogwyji1OLHrAbni5Pqqk2kyuaQGbBwseQG7PIqz9jg1jG2ui1lT3Jv6KJ0clZUwyh0mDxAwMaC0Z8iTyI6c1stEGsOzE63/wAT346tp6xltqw6ajMskbm054jgI2hriRlhaefor12bWe+WqS/fH7ncq5prTFRd8ka/9A1oLXjaORcXOB/5RyCzVEGqrzBr49k9DHbnVI1IKnNViRnGMPEfkNcTt3Y2efRVumYNbN7IbnFenzHVJgqRSeNnFB2nhZcPDuz5/JbIRBhPZXHqiK13JuszIawVm2BznBwdEIoxuGOgLg849SVmyIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIgOcoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8b1PzXq8b1PzQeqTHMHTyxktBYQAPMjAP8AdTkwM5xzQUtJUmaWVhbgNPhOOo6f2SrqjBMxuzcHNPT15YCqkwgp4Z3PNPkAcRhcfbp+aggqnPfM1wZlnQA/1Kq8JgeiIo4at0kG8hu7e1hx0GSPzXs1U6OfYAzAIG0nxOz6KrwPRMBBSd6cKzglnhL9od6+HJVWmERRERAREQEREBERAREQEREBERAREQEREBERARF43qfmg9REyM4zzQETI9QmRjORhARCQOpTI9UBEyM9UzzQETI9eiZQEQkDzXhcAMk8kHqJkeqICIiAiIgIiICIiAiIgIiICIiAiIgLxvU/NeoBjKAqVlMW1z5y4EO6D05Af2VUiCjZSOEU7CG+PODn1JKd0c6kZC5zeTtxwB0z8lWIhhR1FGX4DNhaGbBvGdvuPdeVdG+Z25sm0hm3Prz55VaiJhTTU7n1UcrduG9c8ykNO9lVJMXg785H9FUoiqGOje1lQMt/SggfU/mqh8b+8NkZtI27SCfdTkRMJBgyajdtIkxgH5YUqWkLqaGNgaOGQSOgPIqsRFwpH0znVEUg2DaAD5/RVaIgIiICIiAiIgIiICIiAiIgIiICIiAmUXjep+aD1EUhtS11U6ANO5vU+XQH+6CeipmVsbhKcO/R9ffmR/ZRd5aI5XPY5pjGXNOMoJ6KSydrhGQP9QkDBB8if7KOOQPLwAfCdpQRopFRUtgkjY4El/THzA/uveOO8GHacgA58kE5FJhn4p5MeGnmHHGCvIaqOWQMbnJBPPywcIJ6KmbWMMD5drg1ny5r0VTTFG9rHOLzhrRjJ/t5IKhFIfUsYIy8Obvz1HTChfVNayFwa48UZCCpREQEREBERAREQEREBERAREQEREBeN6n5r1EBeNY1rnEDBccn3XqIJYgjAeAwYf8AeHr/ANZRsETY3MDBtd1HqpiIPCxpLSRzacj2ULYmNkc9oIc7rzP9FGiCB8THua57clvQ+n/WEMTDLxMHf0zkqNEEuOCON5cxgDj5r1kTGEFrcEAgfjzKjRBKbTxNY5gb4XdQSSvXQROjDCzwjmB6KYiCAQxgMAaMMGG+yhdBG5rAWnDBhuCRhTUQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQf//Z",
+              "timing": 750
+            },
+            {
+              "timestamp": 125065483405,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAAHAQEAAAAAAAAAAAAAAAIDBAUGBwgBCf/EAEYQAAEDAwIDBgIGCQIDCAMAAAEAAgMEBREGEhMhMQcUIkFRYXGRCBUygbHRIzNCUlRykqHBF4IWNGIYJCc2dIOi8KOz4f/EABsBAQEBAAMBAQAAAAAAAAAAAAABAgMEBQYH/8QAMBEBAAEDAgIJAwMFAAAAAAAAAAECAxEhMQQSExVRUlNhkZLRFCOhBUHhIjJxgfD/2gAMAwEAAhEDEQA/AOqUREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQQT/AKmT+U/gsGWcz/qZP5T+CwZBniIiAi8c4NaXOIDQMknoFj0WuNKzXDuMWorS+rztETaphJPp16+yDIkQkAZJ5eqx0640s2v7kdRWkVedvC72zdn069fZBkSICCAQcg+atV51Da7K9jbrVd0Y/GJpY3CIfGTG0feUF1RYF211X/hJf6mjn5Gna5ksT+oLm8wQrsdX6es1JQU13vluo6p0Mf6Oeoa13No5kE8kGTopdNUQ1UDJ6aWOaGQbmSRuDmuHqCOqst31jpuz1YpbrfbZSVOccKapY1w+IJ5fegvyKVSVMFZTsqKSaOeCQZZJG4Oa4eoI6qagIiICIiAiIgIiICIiAiLx7trSUAuDepAXgkYejgrXcrjSW+A1FxqoaaHIbxJnhjcnoMlUFHqWx1tSyno7xb56iQ4ZHHUMc53wAKDJUUineT4T9ynoIJ/1Mn8p/BYMs5n/AFMn8p/BYMgzxERBrftwnmfZ7HaGzPp6S8XWChq5GHaeC4kubnyzjCyOr0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3v1VZq7TtDqqxT2u5tdwZMOa9hw+J45te0+RBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHnjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fdo25W3GaB0q2x/VIsVv7ls2YMLd3TGd3Xd75yo5tE2SXRI0qaYi0tiETWg+JpByHg/vbuefVY03ROtGUn1c3X8v1aG8MONvYanZ0xxc9ceeMoLN2g1VToTsUNPp28TVZjlbRsrnPDnwxueQRuHm0eEHqFsXT+nLZb9OMt0cQqKeaENnfMeI6oyObnk/aJypdu0bZKLR7dMikbNaeGY3xzeIyZOS5x/eJ559VSu09dLZZRZ9MV7aam2cNlRWvdUSU7emGN5Zx5bnHCDStPPLT9kXahYGyvmt1mrn09G9xztj4g8GfbH91ufROlLNR6TpIzS01c6rp2SVNTMwSOqnOaCXOJ6g55DyCt47M6Cn7Na7SVBUyR99BdPWSN3vkkLgS9w5ZzjCR6O1HaaTuGl9Ux0VtDdscNVQiodTjzEbtw5egdnCDFNP1c2kP8AVG1WQl1BZ4u+UMX2hA98TnuYPYEZwsp7LNJWOHQ1tqX0dLXVVxp21NXVTxtkfO+QbnZJHMZPRXrRejqPTNnqqQyyV9TXSOmrqqoAL6l7upd7Y5ALHaLQWodPskotIat7jZy5zoqSrom1Jp8nJDHEg49AcoJHZ9DHYO0/Vmm7WNlmZDBXRwA5bTyPyHNb6A9cLaCxnRGkYNLw1kj6ue4XSuk41ZXT/bmd5DA5BoHIAdFkyAiIgIiICIiAiIgIiICgnGYio0PNBjuoxUm2nuQrjNuH/JcHiY/93w4/urFZW3f60g70NRcHJ3d6FDw+h+1w/H8lmz4SD4eYUIieT9lB7AP0gVUoIowwe6jQQT/qZP5T+CwZZzP+pk/lP4LBkGeIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIggm/UyfylYRsd+675LOkQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEVBWyVba6nbC1ppyDk5Iy70PI4GP7/wBwr0UEm8wOwMSFpxg+axuOmuwpaZsrp9wkJkAfuIG0Y57gTzz58vggydFZ30tYx9wfBLOXOaOCHSZAJ64B5A+ilwNuEW1+yqfC2bIjke0yFuwg5OcY3EHqgviKxwQXNtfQukdJwmQsEx35Bfh+7I8+e3n8FPxcPr3ibT3Hbwtu/wA8Z34+PL/CC6orBHHczTSNkbOJGU+wESDL5N3Jw59OnVVcDK8WSRri76ww7JLgcuz+z5Aen90F0RY+Ke4yNYxjqhkXHB/TS+MN2OzktPTdjzU6opq41Fc+N8m0RbYBxTzdsx0zjr5lEXpFjbae6AUYkdPta6TiBryeWW7ee4E8s9fkq+0MrWVlX3oTGIuyx0jhjqeQAJxyx6fBFXVERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERQTSxwxl8r2sYOpccBSZimMyI0VuN7twP/Mt/pP5J9d27+Jb/SfyXV+v4XxafdHy5Ohud2fRcUVu+u7d/Et/pP5J9d27+Jb/AEn8k6w4XxafdHydDc7s+i4ord9d27+Jb/SfyT67t38S3+k/knWHC+LT7o+Tobndn0XFFbvru3fxLf6T+SfXdu/iW/0n8k6w4XxafdHydDc7s+i4ord9d27+Jb/SfyT67t38S3+k/knWHC+LT7o+Tobndn0XFFbvru3fxLf6T+SqqWsp6oE08rZMdceS3b4uxdnlt1xM+UxKVW66YzVEwnoiLsMCIiAiIgIiICIiAiIgIiICIiAiIgLDNWVL5LkYCTw4gMD3IzlZmsf1FZ5KuQVFLgy4w5pOM/BeL+v2L1/g5psazmMx2x/2rtcHXRRdzW1F2g6vk0o23mKkjqTVOe3D5CzG0AgDAPM5xzwPdLlq91HrW2WHgU7W1lOyfiyzEHJc4bWgNIJ5ZGSAVmtTYZqnAqbeJtuQN8YdjPXqoX6efJPHNJbGumjADJHRAuaB0wfJfE27PLRFNfD1TOJzOu87T/r8vVmvMzMVxjTsa71T2ifUeqxZ+4Ne1rYy6V8paXbz0Y0NOev4q43fV8lv1zQ2BtHHIypYxxlMpa5u4vHIYwcbfUHnyWay2GWWZk0tuD5o/sPdGC5vwPkklhlkmbNJbg+VuMPdGC4Y6c/vPzWotU4pj6arOJid9Z/af4Tn1n7kb+WzDXatcNaGw91Z+uEfE4nMtMPE3bcevhU+ivdzm1lVWea3U8dLDEJu8NqMuLHEhvhx1JaeWeSyz6kqO8cfuB4+NvE2Ddj0z1wohZqoSmUUThKQGl+zmR6ZXHNmrGIsT/bjad+3+Gorj96438tuxhWjdWO1FWXeF0NPD3GUxbWSuc84c4ZcC0AA7fIlWfRPaO7Ut4o6F1sNNx4JJDIXkgOafst5DPhwc+62TBYJKd8j6e2iJ8nN7mRBpd8cdV5Fp58JjMVsawxghhbEBtB6gei5JtU/144erXGN9NPzrqzFe33I89tWF6K1g7UlPdJXQU8JonFvDZK5z+Rd9rLQBnbywT5+ig0JrOTVbK7bQinlpoYZNjn5y6QOOOnTwg59HLN6fT8lMZDT21sRk+3w4g3d8cdepUUFhmpy409vERcACWRhuQOQHL0Wblnm5+Th6ozjG+nb/nK014xmuPPbVi2jb3cL2y4OuNBBR91qDTDhT8Tc5v2vIYHTHrlZVQVL6SrjmjJBaeePMeYUUVmqog7hUTmbnFztrMZJ6k+6utnsM76hklWzhxNOcE83Ja4Pib3ExNi3NGsY0nEeeZKrtum3MV1ZZgiIv1B4AiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiDT18+kDpazXu4Wupt96fUUVRJTSOjhiLS5ji0kZkBxkeiyTs97VtN67rZaK0uqoK2NnE4FVGGOc0dSMEg4z6rlK+XiosHbVfLrR08dTPSXeslbFICWuw9+cgeWMn7lf9C0NNpi33fVtJqe0z3mOhlNFQ0j3GVr3ja57muAxtaXHGD09kR2XkeqZHqFwRb6GsvVuqL5NqEx3JlQGE1VS1hwceIvc8O8+gaenULJe1i13CTSOlNQV9xprpUuZJb56ylm4rH7HF0e53m7aXA/yoO0sj1CZHquGvrKr192hw3B8Lpu70jZ5I3cwW08Ac4H2c5hH+5W6kbcNXm63a6X9wuEGJG94ma0OyTnxOe3aB5BoPwQy72yB1KZHquHO0KpucmidKQ3S80l2dBNWMilp6jjFjMQEMe71BJ+4hUmshc7JT6PrI7zWPlntMVRDtds7sN7gGMx5eHOfMkoO7sj1CZHqFw9p6ulru3W0VtU/wDS1F3gmkPQZc9pP4qVYbtUWftZu1zoHZqKZ1ymiPUBwhmIOPP1Qy7myPVFwRQUtdqKir71Wagc25RStGaqoa0uzjxF7ngjr0a13TyXXHYdVXCp0BTNu11o7tUQSOiFTTT8YFowQ1zvNwzj4YRVPrftk0npC5yW6unqaqui/Ww0cYeYz6EkgZ9sqDRfbRpLVl0it1JNVUdbMcRR1kYZxD6AgkZ9srj+uc+fXE5u/wBt9xd3niepk8ef7q46ybBS9p9zbpsRNgjuR7mKYjaMP8O3HlnphEd85HqEXCNMamTtarqemu0dokqbhU07q2Q4bC17ntcc+XIkeXXqOqyzs3v920L2jXOy2y7C826KCpJ4Ty+GUxwOka9oyQCC0A49xzRXYWR6pkDqVwTStuGrzdbtdL+8XCDEje8TNbuyTnxOe3aB5BoPwVz7Q6m5SaJ0pDdLzSXZ8E1YyKWnqOMWMxAQx7vUEn7iER3HkeqZHquV7NpC7ab0BH2kQ3501VHaOHT0/BwYWvaIm4du/ZDt3TqFrOldNUaJvd1n1cG11RKyCa1Suc6WrYHNcHEk+R5/7Tz54RXaGv8AWNv0Rp83e6xVM1MJWxbaZrXPy7OOTiBjl6rFHdrMVz7Oq3VGlrHcbgaeq7p3WRoa/OGkvOwu8IDh7/iuV6C0w1fZbdrpJJKJ6G4wxxtBG0iRjt2eWf2BjmPNZXpGjoofo865rWVObjUVVNE+DiN8MccsRa4N68zK4E9OQRHTHZRq+46y07LX3ayy2maOYxBj92JBgHc3cAcc8fcs0yD0K4QtmqbtZOzKWgtVTNSsuFyk48sTi1xayKPDMjmAd39lV1wruzivsF2sGqoK+prIW1UsdLISIzyJjkGTkHOOfPkeQQdyZHqEyuI9KUlVfO3SelpK6e2VFVX1oE8QBfFlspOM+eMjPllUvZhfb9TOv1DaryaJ1RQPDXT1HDjD97MHc44a45LQ7lzd1QdzZHqEXA4s9VQVJl1RcbnZ6mbxU9Q6B0zJvU8Rr8+Y5gO6rtLsybI3QFiE1wZcnilbmrY9z2y/9QLsH580VkyIiAiIg1DF2G2puvKjUs10qZnT1U1TJSPibsdxC7czPXHiIUvSvYJYtP6idcWV9VV0ro5oXUdQxpa5kjCwguGD0ctxIg0PUfRp09JXvlivFyipS7IgDWEtHoHEfiFneouy+yXbs+p9I0xfQ0NO9skMjAHPa4EkuOepOXZ+Kz1EGr+zDsdteg7tV3CGunr5p4DTgTRtaGNJBd065wFjl5+jfp2tuktTRXOuoaeR27uzGte1nqGk88fHK3miDTt/7BLBcbFZ7VRVtVQw28zPMga2R875NmXPJxz8A6KDU3YPbb9SWSCW9VkItdC2hYWxNPEaHOduPofEtyrHO0PU40do+4X00ve+6hpEHE4e/c8N+1g4656INfXP6P8Apyvu1HXPra+MxMhZNFGWhsxjaG56ZaXbeeCo9M9g9lsWrW3plwnqIQZgaKSJvDLJGPYWE9cAP/snZ523UurKa/yVNp+rn2qjdW7O9cXisbnd+w3GPD6/aUjsx7chrfV1PY3WDuBmje8Td84vNrc427B6eqCgrvo16emuEk1Nd7jTUrnbhAGtdtHoHH/OfvW39Jact2lLDTWizxGOkgBxuOXOJ5lzj5klTJNRWWOSqjku9ua+lZxKhrqlgMLf3njPhHuVRDXGlDC6Uamshia4Nc/v8WATkgE7upwfkUGE697DdN6tu8t0bNVW2tmO6Y0+CyR37xaRyPwxlQaG7CdNaXu8NzlmqrnVwOD4e8bQyNw6O2gcyPcrYQ1RYHQ0swvdsMVXkU7xVR7ZsHB2HPiweRx5qrud2t1qiZLc6+ko43nDX1EzYwT7EkIONtKacg1F25VNqutPK6hq62uY87SMeCUhwPqCAR7gLo7s37INP6GqpqymfUV1dLGYjNU7cNaeoa0DlnzzlZfUaq09TXEW+ovtqiry5rRTPq42yZdgtG0nOTkY9chVlddrdQTwQV1fSU007g2KOaZrHSEnADQTkn4INM3n6N+na26S1NFc66hp5Hbu7Ma17WeoaTzx8cq5X/sEsFxsVntVFW1VDBbzM8vDWyPnfJsy55OOfgHRbJo9UWCtuX1dR3u11Fw3Ob3aKrjdLludw2g5yMHPphKjVOn6asNJU3y1xVYODDJVxteD/KTlBTWjSlFQ6Ip9L1JNZQR0vdHmQYMjMYOcdPuWsP8As4aZbHcGx3C4F07Q2B0m1xp/ECSMAbiQNvPyJW2brqaw2eaOK7Xq2UMsjOIxlTVMjLm9NwDiMjkeanUN9tFwrnUdDdKGprGxiZ0ENQx7ww4w4tBzg7m8+nMeqDXWm+xOyWnSd50/V1lVXUlzfHI57mtY+JzM7S0jPPn5q1W76PtooLVeqKG9V7hcomQl7mM/RtbKyTkPM5YB963WiDUdr7CbBTaPrLBXVdVWRz1Iqo6jDWSQPDdvh6jGOoKodL/R405Z7vBXVtdWXLgPD2QShrIyR03AcyPbK3UiDVFg7F6Czdof/FkV2qpKjvM1T3d0bQ3MgeCM9eW/+yslp+jnZKN1WKi83CohqYTC5oYxhHia4EHn0LR5LeSINCw/RosDalrpb3c3wA84w1gJ/wB2P8LddhtNHYbNR2u2x8KjpYxHE0nJAHqfMqvRAREQEREBERAREQEREBau+ktLwuyK6jP6yWBn/wCRp/wtoqxa00tbdY2R1qvLZnUjpGyERP2HLenNBw3pSiu8lNPJZiQK6Vlnkx58bJAPx2H5JpGsqrDqqokoZHNqYaesiY9nIg8CRoI9Dnmuz9Fdm2nNHxVEdpppHtnljmPeX8Xa9m7a5uRyI3FWa19imj7bfYrtTwVhqo5TKBJOXMJOcgtxzHM8kRyRZm2H/hi8VNfdLjT6g5MpIIWZjmYftB7vn5j71RU3/lC4/wDrqX/9dQuxx2K6HbPXSxWkxmrjdE4CVxEYd1LAc7T7jp5KiZ2DaKZQy0ghr+DLKyVw7yc7mBwHPHo9yDmDVNmgo+zvQ90jknfUXBta2Rr3ksYI58NDB+yPE4n1JU3UtcLrqXTsWqayqjtUdvoozLGN72QmJpcWg9Tku/8A6uqLj2N6TuFhs9oqYqw0dq43dg2oIcOK4Ofk458wqi8dkWj7vbLbRV1ue8W+FtPBM2VzZOGOjXOH2vvQckUJoD2qWsWesqq63NuVMynnqhiRzA9gGR7YwPYDkOivtULdqHtcv3+ol6q7ZDHNOBMxpc5jmOwxg5HAA9vL3XSMvYvo5+oILvFRzwVMD4pI2QzFsbTGGhvh/wBoz681pjtlob4e0G4VM+hY7hE2YOpqxlPMRMwYxv4btrvTmM+RQay0jXVdJqyurbZUTSVTKWufHUcw8/oJMv8AUHGSqe0UFlrbJVz3K6d0uTZmhgeXODmHGTsDCXHr+0371uD6PPZ5fHa2fqO/2yWhooY5drKiLh8Z8jS0gMP7OHO8sdAtpVfYPoSpr31Rt9RGHu3mGOoc2P4AeQ9gUHLnaA6PuWmo6e7Pu1PFQOjjqHwOiw0TSeAB3MgHIz93kuoOxns1tmmY6PUtLWV09dcbbG2Vs72lg3hjzjAB6tAHPorlqXse0hqF1B3ujmhjoacUsEVNKY2tYHF3TzOXHms7ttHFbrdS0VMHCCmiZDGHHJ2tAAyfgEFQiIiiIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiKF5Odo+9BEilO2MaXPwABkkqGJ8UrSYyHAcuinNGcZ1MTunoqWpqKWl4feZoYeI7aziPDdx9BnqVCyro31klIyop3VUY3PhDwXtHqW9R1HzVFYikwvimiZLA9r43jc17DkEeoIUxpzkHqEESIoXnGAOpQRIpZDQCXfMqXFLDKSI3NcR6ImVQipKyqpKJjH1lRBTse7Y10rwwF3oM+a8kq6OMTmSop2inAMxc8Dh5GRu9OXqiqxFRxVdHMwPhqKeRhZxQ5rwQWfvfD3XsVTSTUveYZ4JKbBdxWvBZgdTnogq0VGayiE8kBqKfjRt3vj3jc1vqR5D3UyKanmJEMkUhDQ4hrgcA9D8D5IKhFRR11DI5zY6qmc5r+E4NkacP8A3T7+yphfLMYnyi6W8xxkNe8VDMNJzgE55ZwfkUF2RU8MsE7cwSRyDAdljgeRGQeXqFNB2n2QRoiICIiAiIgIiICIiAoD9s+6jXjm5QUN0gfPAGsZvPPw/cQP7qVRUzo6t0nAETDn058m+nwKuOHexTDvb5rrVcLRVc6Wd9Pw3FcxHKxfVmmJbzcIKuCWh3Mp5KV0dbS94ZteWkuaNww7w+4Kkx6SlGrX3Z1VAIO9CraxkOJd3dmwbC/P2ORdjHXHosuw72+aYd7fNdlhbdMWw2XTtttjpRMaSnZCZA3bu2jGceSuTeb/AIBNrvYKIDAQeqB3J49wo0IyMFBJqI+LBJGDjc0jKoqCne2d0j2uZjIw4g5JxnHtyVw2uHmCmHe3zVzphmaYmcrBq7TUOpoqCCrlcymgndLKxvIytMUkZbny+319vvWPHs/qM3531uSbxE6OYGEYYRJmIt8/CwlvMnPLpjC2Bh3t80w72+ajTB6XQnAt9RSvqophNb5aJ/Ejdh7nyueXuDXA893MAjn0x0VVT6ZrKTRFRaO8Q1NQXmRu1nDa4bw7YeZJyBgkkk55rLsO9vmmHe3zQYHNoOSWvnk73SNhdNU1DHilxUF0zHtLXybvEwbzywOTWjyVfobR50rLXba59TTzxQRRRvbzhEYdloOebcvJA8hy8lluHe3zTDvb5oMCs2g5rfM0mtpuAytiqmRRQOGAziZG5zi7nv8AXAxyHNTbroNtVSSxUs8MDn3T6xyxjo+WwtDMscHDqTkFZxh3t80w72+aCz2q3T0t4qqmUs4T6Snp27STl0ZkLjz5/tgc+fJXd3THqvcO9l61uDknJQRIiICIiAiIgIiICIiAiIgIiICIiAiISAMlARQbnewTLvb5II0UGXe3yTLvb5II0UGXe3yTLvb5II0UGXeyia7PLoUHqIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKB/2wo148Z5jqEEmpc9kD3RBpeBkbuioaKdzqhjY52zNkBe/P7Pw+Y5K45zyIPyXga0EENAIGBy8kZmmZnLHtd3G4Wyzce0O/70HHazu7peIQ0kN5fZyR18zyyM5FNrC8XSjoaSW3U88Z7wWzDhb3yMDCcMADhknGN2PTIzlZZn4/JM/H5I0xHVt8u9uv1nhtdFJUUO4PuD2x7tsbntY3Bz1G5zjjPJnocqxjU+qxcbhTyULGQs+sH0tQad7mObE/bE14aC7PLPIeIEY6FbKz8fkmfj8kGPaEuVZdbA2ouXE7wJHsLnwcLcAeRA8x74GfRZCftNQn4/JetBJyeXsgiREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAWrrzBrv8A1QZJQOmOlnVdLvAkaNrBGeIQM52lx5jrkDC2iiDWGrna3/1Ts01lpqt2mKfhR1TWSRhku8u3uILsnaC3y8kfb9bjtiG2pqjo5zhVF/FbtaREWmLGc4L8Hotnogwyji1OLHrAbni5Pqqk2kyuaQGbBwseQG7PIqz9jg1jG2ui1lT3Jv6KJ0clZUwyh0mDxAwMaC0Z8iTyI6c1stEGsOzE63/4nvx1bT1jLbVh01GZZI3NpzxHARtDXEjLC08/RXrs2s98tUl++v7ncq5prTFRd8ka/wDQNaC142jkXFzgf5RyCzVEGqrzBr49k9DHbnVI1IKnNViRnGMPEfkNcTt3Y2efRVumYNbN7IbnFenzHVJgqRSeNnFB2nhZcPDuz5/BbIRBhPZXHqiK13JuszIawVm2BznBwdEIoxuGOgLg849SVmyIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIgOcoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8b1PxXq8b1PxQeqTHMHTyxktBYQAPMjAP+VOTAznHNBS0lSZpZWFuA0+E46jp/hKuqMEzG7Nwc09PXlgKqTCCnhnc80+QBxGFx9un5qCCqc98zXBmWdAD+JVXhMD0RFHDVukg3kN3b2sOOgyR+a9mqnRz7AGYBA2k+J2fRVeB6JgIKTvThWcEs8JftDvXw5Kq0wiKIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIvG9T8UHqImRnGeaAiZHqEyMZyMICISB1KZHqgImRnqmeaAiZHr0TKAiEgea8LgBknkg9RMj1RAREQEREBERAREQEREBERAREQEREBeN6n4r1AMZQFSspi2ufOXAh3QenID/CqkQUbKRwinYQ3x5wc+pJTujnUjIXObyduOAOmfgqxEMKOooy/AZsLQzYN4zt9x7ryro3zO3Nk2kM259efPKrURMKaanc+qjlbtw3rnmUhp3sqpJi8HfnI/BVKIqhjo3tZUDLf0oIHzP5qofG/vDZGbSNu0gn3U5ETCQYMmo3bSJMYB+GFKlpC6mhjYGjhkEjoDyKrERcKR9M51RFINg2gA+fyVWiICIiAiIgIiICIiAhKK06mvVLp+x1t0r37KaliMjz646Ae5OAPigiv9+tlgoH1t4rYKOmb1fK7bk+g9T7Ba0rfpBaJp6kxRy3CpaDjixU3h/8AkQf7Ll/tA1pdNa3yWvukzuEHHgUwd4IGegHr6nzWNMZJIHFkbnBoycDOEHeWj+0nS+rZBDZrpE+qIz3eUGOT7muxn7srMQcr5v0tRLTVEc9NK+GeNwcyRji1zSOhBHQrsL6P3aNLrKyS0N2kDrzQAB7+hmjPR+PXyP3HzQbfRAchEBMovG9T8UHqIpDalrqp0Aadzep8ugP+UE9FTMrY3CU4d+j6+/Mj/Ci7y0RyuexzTGMuacZQT0Ulk7XCMgfrCQMEHyJ/wo45A8vAB8J2lBGikVFS2CSNjgSX9MfED/K9447wYdpyADnyQTkUmGfinkx4aeYccYK8hqo5ZAxuckE8/LBwgnoqZtYwwPl2uDWfDmvRVNMUb2sc4vOGtGMn/HkgqEUh9SxgjLw5u/PUdMKF9U1rIXBrjxRkIKlERAREQEREBERAPRaY+lLVzU/ZqY4SQyorYopMfu4c78WhbnPRYF2x6afqrQtyt1OAaraJoM+b2HIH38x96DhmFglnijc4Ma5waXHoMnqtidqONFa5Np0zH9Xx2xsRjqY/107nRhxe5/Ug7iNv2fZa7nikhlfFMx0crHFrmuGC0jqCFe2amqp3Uf13Ey7R0bQ2COp8mjo1z24eWj93dhEZJ2y2+kguOn7pS08VLNeLTBX1METQ1jZXAhxa0dAcZx65Vz+jTVzU3apRxRE7KinmjkA/dDdw/u0LX2pL7X6ku8tyusgfUPAaA1oa1jQMNa1o5AAeS3d9FbSs77nWalqIy2nZGaamLh9txILnD2AGPvPoiuoYjloUagiGGhRoC8b1PxXqIC8axrXOIGC45PuvUQSxBGA8Bgw/7Q9f/uUbBE2NzAwbXdR6qYiDwsaS0kc2nI9lC2JjZHPaCHO68z+CjRBA+Jj3Nc9uS3ofT/7hDEwy8TB39M5KjRBLjgjjeXMYA4+a9ZExhBa3BAIH38yo0QSm08TWOYG+F3UEkr10ETowws8I5geimIggEMYDAGjDBhvsoXQRuawFpwwYbgkYU1EBERAREQEREBERAUmaPcFOQhBpLtU7GaDVVRLcrXI233Z3N7tuY5j/ANQHQ+4+8FaUq+w/W0FQY4qKmqGZxxI6lgb/APIg/wBl2o+MO6hSjTN9Ag5f0T9H2slq459V1UcdO0gmmpXFzn+znYwB8M/cuk7JaqW1UEFHQwMgpYGhkcbBgNAVwZC1vkpoGEHoGAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIP/2Q==",
+              "timing": 1125
+            },
+            {
+              "timestamp": 125065858405,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAAHAQEAAAAAAAAAAAAAAAIDBAUGBwgBCf/EAEYQAAEDAwIDBgIGCQIDCAMAAAEAAgMEBREGEhMhMQcUIkFRYXGRCBUygbHRIzNCUlRykqHBF4IWNGIYJCc2dIOi8KOz4f/EABsBAQEBAAMBAQAAAAAAAAAAAAABAgMEBQYH/8QAMBEBAAEDAgIJAwMFAAAAAAAAAAECAxEhMQQSExVRUlNhkZLRFCOhBUHhIjJxgfD/2gAMAwEAAhEDEQA/AOqUREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQQT/AKmT+U/gsGWcz/qZP5T+CwZBniIiAi8c4NaXOIDQMknoFj0WuNKzXDuMWorS+rztETaphJPp16+yDIkQkAZJ5eqx0640s2v7kdRWkVedvC72zdn069fZBkSICCAQcg+atV51Da7K9jbrVd0Y/GJpY3CIfGTG0feUF1RYF211X/hJf6mjn5Gna5ksT+oLm8wQrsdX6es1JQU13vluo6p0Mf6Oeoa13No5kE8kGTopdNUQ1UDJ6aWOaGQbmSRuDmuHqCOqst31jpuz1YpbrfbZSVOccKapY1w+IJ5fegvyKVSVMFZTsqKSaOeCQZZJG4Oa4eoI6qagIiICIiAiIgIiICIiAiLx7trSUAuDepAXgkYejgrXcrjSW+A1FxqoaaHIbxJnhjcnoMlUFHqWx1tSyno7xb56iQ4ZHHUMc53wAKDJUUineT4T9ynoIJ/1Mn8p/BYMs5n/AFMn8p/BYMgzxERBrftwnmfZ7HaGzPp6S8XWChq5GHaeC4kubnyzjCyOr0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3v1VZq7TtDqqxT2u5tdwZMOa9hw+J45te0+RBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHnjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fdo25W3GaB0q2x/VIsVv7ls2YMLd3TGd3Xd75yo5tE2SXRI0qaYi0tiETWg+JpByHg/vbuefVY03ROtGUn1c3X8v1aG8MONvYanZ0xxc9ceeMoLN2g1VToTsUNPp28TVZjlbRsrnPDnwxueQRuHm0eEHqFsXT+nLZb9OMt0cQqKeaENnfMeI6oyObnk/aJypdu0bZKLR7dMikbNaeGY3xzeIyZOS5x/eJ559VSu09dLZZRZ9MV7aam2cNlRWvdUSU7emGN5Zx5bnHCDStPPLT9kXahYGyvmt1mrn09G9xztj4g8GfbH91ufROlLNR6TpIzS01c6rp2SVNTMwSOqnOaCXOJ6g55DyCt47M6Cn7Na7SVBUyR99BdPWSN3vkkLgS9w5ZzjCR6O1HaaTuGl9Ux0VtDdscNVQiodTjzEbtw5egdnCDFNP1c2kP8AVG1WQl1BZ4u+UMX2hA98TnuYPYEZwsp7LNJWOHQ1tqX0dLXVVxp21NXVTxtkfO+QbnZJHMZPRXrRejqPTNnqqQyyV9TXSOmrqqoAL6l7upd7Y5ALHaLQWodPskotIat7jZy5zoqSrom1Jp8nJDHEg49AcoJHZ9DHYO0/Vmm7WNlmZDBXRwA5bTyPyHNb6A9cLaCxnRGkYNLw1kj6ue4XSuk41ZXT/bmd5DA5BoHIAdFkyAiIgIiICIiAiIgIiICgnGYio0PNBjuoxUm2nuQrjNuH/JcHiY/93w4/urFZW3f60g70NRcHJ3d6FDw+h+1w/H8lmz4SD4eYUIieT9lB7AP0gVUoIowwe6jQQT/qZP5T+CwZZzP+pk/lP4LBkGeIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIggm/UyfylYRsd+675LOkQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEVBWyVba6nbC1ppyDk5Iy70PI4GP7/wBwr0UEm8wOwMSFpxg+axuOmuwpaZsrp9wkJkAfuIG0Y57gTzz58vggydFZ30tYx9wfBLOXOaOCHSZAJ64B5A+ilwNuEW1+yqfC2bIjke0yFuwg5OcY3EHqgviKxwQXNtfQukdJwmQsEx35Bfh+7I8+e3n8FPxcPr3ibT3Hbwtu/wA8Z34+PL/CC6orBHHczTSNkbOJGU+wESDL5N3Jw59OnVVcDK8WSRri76ww7JLgcuz+z5Aen90F0RY+Ke4yNYxjqhkXHB/TS+MN2OzktPTdjzU6opq41Fc+N8m0RbYBxTzdsx0zjr5lEXpFjbae6AUYkdPta6TiBryeWW7ee4E8s9fkq+0MrWVlX3oTGIuyx0jhjqeQAJxyx6fBFXVERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERQTSxwxl8r2sYOpccBSZimMyI0VuN7twP/Mt/pP5J9d27+Jb/SfyXV+v4XxafdHy5Ohud2fRcUVu+u7d/Et/pP5J9d27+Jb/AEn8k6w4XxafdHydDc7s+i4ord9d27+Jb/SfyT67t38S3+k/knWHC+LT7o+Tobndn0XFFbvru3fxLf6T+SfXdu/iW/0n8k6w4XxafdHydDc7s+i4ord9d27+Jb/SfyT67t38S3+k/knWHC+LT7o+Tobndn0XFFbvru3fxLf6T+SqqWsp6oE08rZMdceS3b4uxdnlt1xM+UxKVW66YzVEwnoiLsMCIiAiIgIiICIiAiIgIiICIiAiIgLDNWVL5LkYCTw4gMD3IzlZmsf1FZ5KuQVFLgy4w5pOM/BeL+v2L1/g5psazmMx2x/2rtcHXRRdzW1F2g6vk0o23mKkjqTVOe3D5CzG0AgDAPM5xzwPdLlq91HrW2WHgU7W1lOyfiyzEHJc4bWgNIJ5ZGSAVmtTYZqnAqbeJtuQN8YdjPXqoX6efJPHNJbGumjADJHRAuaB0wfJfE27PLRFNfD1TOJzOu87T/r8vVmvMzMVxjTsa71T2ifUeqxZ+4Ne1rYy6V8paXbz0Y0NOev4q43fV8lv1zQ2BtHHIypYxxlMpa5u4vHIYwcbfUHnyWay2GWWZk0tuD5o/sPdGC5vwPkklhlkmbNJbg+VuMPdGC4Y6c/vPzWotU4pj6arOJid9Z/af4Tn1n7kb+WzDXatcNaGw91Z+uEfE4nMtMPE3bcevhU+ivdzm1lVWea3U8dLDEJu8NqMuLHEhvhx1JaeWeSyz6kqO8cfuB4+NvE2Ddj0z1wohZqoSmUUThKQGl+zmR6ZXHNmrGIsT/bjad+3+Gorj96438tuxhWjdWO1FWXeF0NPD3GUxbWSuc84c4ZcC0AA7fIlWfRPaO7Ut4o6F1sNNx4JJDIXkgOafst5DPhwc+62TBYJKd8j6e2iJ8nN7mRBpd8cdV5Fp58JjMVsawxghhbEBtB6gei5JtU/144erXGN9NPzrqzFe33I89tWF6K1g7UlPdJXQU8JonFvDZK5z+Rd9rLQBnbywT5+ig0JrOTVbK7bQinlpoYZNjn5y6QOOOnTwg59HLN6fT8lMZDT21sRk+3w4g3d8cdepUUFhmpy409vERcACWRhuQOQHL0Wblnm5+Th6ozjG+nb/nK014xmuPPbVi2jb3cL2y4OuNBBR91qDTDhT8Tc5v2vIYHTHrlZVQVL6SrjmjJBaeePMeYUUVmqog7hUTmbnFztrMZJ6k+6utnsM76hklWzhxNOcE83Ja4Pib3ExNi3NGsY0nEeeZKrtum3MV1ZZgiIv1B4AiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiDT18+kDpazXu4Wupt96fUUVRJTSOjhiLS5ji0kZkBxkeiyTs97VtN67rZaK0uqoK2NnE4FVGGOc0dSMEg4z6rlK+XiosHbVfLrR08dTPSXeslbFICWuw9+cgeWMn7lf9C0NNpi33fVtJqe0z3mOhlNFQ0j3GVr3ja57muAxtaXHGD09kR2XkeqZHqFwRb6GsvVuqL5NqEx3JlQGE1VS1hwceIvc8O8+gaenULJe1i13CTSOlNQV9xprpUuZJb56ylm4rH7HF0e53m7aXA/yoO0sj1CZHquGvrKr192hw3B8Lpu70jZ5I3cwW08Ac4H2c5hH+5W6kbcNXm63a6X9wuEGJG94ma0OyTnxOe3aB5BoPwQy72yB1KZHquHO0KpucmidKQ3S80l2dBNWMilp6jjFjMQEMe71BJ+4hUmshc7JT6PrI7zWPlntMVRDtds7sN7gGMx5eHOfMkoO7sj1CZHqFw9p6ulru3W0VtU/wDS1F3gmkPQZc9pP4qVYbtUWftZu1zoHZqKZ1ymiPUBwhmIOPP1Qy7myPVFwRQUtdqKir71Wagc25RStGaqoa0uzjxF7ngjr0a13TyXXHYdVXCp0BTNu11o7tUQSOiFTTT8YFowQ1zvNwzj4YRVPrftk0npC5yW6unqaqui/Ww0cYeYz6EkgZ9sqDRfbRpLVl0it1JNVUdbMcRR1kYZxD6AgkZ9srj+uc+fXE5u/wBt9xd3niepk8ef7q46ybBS9p9zbpsRNgjuR7mKYjaMP8O3HlnphEd85HqEXCNMamTtarqemu0dokqbhU07q2Q4bC17ntcc+XIkeXXqOqyzs3v920L2jXOy2y7C826KCpJ4Ty+GUxwOka9oyQCC0A49xzRXYWR6pkDqVwTStuGrzdbtdL+8XCDEje8TNbuyTnxOe3aB5BoPwVz7Q6m5SaJ0pDdLzSXZ8E1YyKWnqOMWMxAQx7vUEn7iER3HkeqZHquV7NpC7ab0BH2kQ3501VHaOHT0/BwYWvaIm4du/ZDt3TqFrOldNUaJvd1n1cG11RKyCa1Suc6WrYHNcHEk+R5/7Tz54RXaGv8AWNv0Rp83e6xVM1MJWxbaZrXPy7OOTiBjl6rFHdrMVz7Oq3VGlrHcbgaeq7p3WRoa/OGkvOwu8IDh7/iuV6C0w1fZbdrpJJKJ6G4wxxtBG0iRjt2eWf2BjmPNZXpGjoofo865rWVObjUVVNE+DiN8MccsRa4N68zK4E9OQRHTHZRq+46y07LX3ayy2maOYxBj92JBgHc3cAcc8fcs0yD0K4QtmqbtZOzKWgtVTNSsuFyk48sTi1xayKPDMjmAd39lV1wruzivsF2sGqoK+prIW1UsdLISIzyJjkGTkHOOfPkeQQdyZHqEyuI9KUlVfO3SelpK6e2VFVX1oE8QBfFlspOM+eMjPllUvZhfb9TOv1DaryaJ1RQPDXT1HDjD97MHc44a45LQ7lzd1QdzZHqEXA4s9VQVJl1RcbnZ6mbxU9Q6B0zJvU8Rr8+Y5gO6rtLsybI3QFiE1wZcnilbmrY9z2y/9QLsH580VkyIiAiIg1DF2G2puvKjUs10qZnT1U1TJSPibsdxC7czPXHiIUvSvYJYtP6idcWV9VV0ro5oXUdQxpa5kjCwguGD0ctxIg0PUfRp09JXvlivFyipS7IgDWEtHoHEfiFneouy+yXbs+p9I0xfQ0NO9skMjAHPa4EkuOepOXZ+Kz1EGr+zDsdteg7tV3CGunr5p4DTgTRtaGNJBd065wFjl5+jfp2tuktTRXOuoaeR27uzGte1nqGk88fHK3miDTt/7BLBcbFZ7VRVtVQw28zPMga2R875NmXPJxz8A6KDU3YPbb9SWSCW9VkItdC2hYWxNPEaHOduPofEtyrHO0PU40do+4X00ve+6hpEHE4e/c8N+1g4656INfXP6P8Apyvu1HXPra+MxMhZNFGWhsxjaG56ZaXbeeCo9M9g9lsWrW3plwnqIQZgaKSJvDLJGPYWE9cAP/snZ523UurKa/yVNp+rn2qjdW7O9cXisbnd+w3GPD6/aUjsx7chrfV1PY3WDuBmje8Td84vNrc427B6eqCgrvo16emuEk1Nd7jTUrnbhAGtdtHoHH/OfvW39Jact2lLDTWizxGOkgBxuOXOJ5lzj5klTJNRWWOSqjku9ua+lZxKhrqlgMLf3njPhHuVRDXGlDC6Uamshia4Nc/v8WATkgE7upwfkUGE697DdN6tu8t0bNVW2tmO6Y0+CyR37xaRyPwxlQaG7CdNaXu8NzlmqrnVwOD4e8bQyNw6O2gcyPcrYQ1RYHQ0swvdsMVXkU7xVR7ZsHB2HPiweRx5qrud2t1qiZLc6+ko43nDX1EzYwT7EkIONtKacg1F25VNqutPK6hq62uY87SMeCUhwPqCAR7gLo7s37INP6GqpqymfUV1dLGYjNU7cNaeoa0DlnzzlZfUaq09TXEW+ovtqiry5rRTPq42yZdgtG0nOTkY9chVlddrdQTwQV1fSU007g2KOaZrHSEnADQTkn4INM3n6N+na26S1NFc66hp5Hbu7Ma17WeoaTzx8cq5X/sEsFxsVntVFW1VDBbzM8vDWyPnfJsy55OOfgHRbJo9UWCtuX1dR3u11Fw3Ob3aKrjdLludw2g5yMHPphKjVOn6asNJU3y1xVYODDJVxteD/KTlBTWjSlFQ6Ip9L1JNZQR0vdHmQYMjMYOcdPuWsP8As4aZbHcGx3C4F07Q2B0m1xp/ECSMAbiQNvPyJW2brqaw2eaOK7Xq2UMsjOIxlTVMjLm9NwDiMjkeanUN9tFwrnUdDdKGprGxiZ0ENQx7ww4w4tBzg7m8+nMeqDXWm+xOyWnSd50/V1lVXUlzfHI57mtY+JzM7S0jPPn5q1W76PtooLVeqKG9V7hcomQl7mM/RtbKyTkPM5YB963WiDUdr7CbBTaPrLBXVdVWRz1Iqo6jDWSQPDdvh6jGOoKodL/R405Z7vBXVtdWXLgPD2QShrIyR03AcyPbK3UiDVFg7F6Czdof/FkV2qpKjvM1T3d0bQ3MgeCM9eW/+yslp+jnZKN1WKi83CohqYTC5oYxhHia4EHn0LR5LeSINCw/RosDalrpb3c3wA84w1gJ/wB2P8LddhtNHYbNR2u2x8KjpYxHE0nJAHqfMqvRAREQEREBERAREQEREBau+ktLwuyK6jP6yWBn/wCRp/wtoqxa00tbdY2R1qvLZnUjpGyERP2HLenNBw3pSiu8lNPJZiQK6Vlnkx58bJAPx2H5JpGsqrDqqokoZHNqYaesiY9nIg8CRoI9Dnmuz9Fdm2nNHxVEdpppHtnljmPeX8Xa9m7a5uRyI3FWa19imj7bfYrtTwVhqo5TKBJOXMJOcgtxzHM8kRyRZm2H/hi8VNfdLjT6g5MpIIWZjmYftB7vn5j71RU3/lC4/wDrqX/9dQuxx2K6HbPXSxWkxmrjdE4CVxEYd1LAc7T7jp5KiZ2DaKZQy0ghr+DLKyVw7yc7mBwHPHo9yDmDVNmgo+zvQ90jknfUXBta2Rr3ksYI58NDB+yPE4n1JU3UtcLrqXTsWqayqjtUdvoozLGN72QmJpcWg9Tku/8A6uqLj2N6TuFhs9oqYqw0dq43dg2oIcOK4Ofk458wqi8dkWj7vbLbRV1ue8W+FtPBM2VzZOGOjXOH2vvQckUJoD2qWsWesqq63NuVMynnqhiRzA9gGR7YwPYDkOivtULdqHtcv3+ol6q7ZDHNOBMxpc5jmOwxg5HAA9vL3XSMvYvo5+oILvFRzwVMD4pI2QzFsbTGGhvh/wBoz681pjtlob4e0G4VM+hY7hE2YOpqxlPMRMwYxv4btrvTmM+RQay0jXVdJqyurbZUTSVTKWufHUcw8/oJMv8AUHGSqe0UFlrbJVz3K6d0uTZmhgeXODmHGTsDCXHr+0371uD6PPZ5fHa2fqO/2yWhooY5drKiLh8Z8jS0gMP7OHO8sdAtpVfYPoSpr31Rt9RGHu3mGOoc2P4AeQ9gUHLnaA6PuWmo6e7Pu1PFQOjjqHwOiw0TSeAB3MgHIz93kuoOxns1tmmY6PUtLWV09dcbbG2Vs72lg3hjzjAB6tAHPorlqXse0hqF1B3ujmhjoacUsEVNKY2tYHF3TzOXHms7ttHFbrdS0VMHCCmiZDGHHJ2tAAyfgEFQiIiiIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiKF5Odo+9BEilO2MaXPwABkkqGJ8UrSYyHAcuinNGcZ1MTunoqWpqKWl4feZoYeI7aziPDdx9BnqVCyro31klIyop3VUY3PhDwXtHqW9R1HzVFYikwvimiZLA9r43jc17DkEeoIUxpzkHqEESIoXnGAOpQRIpZDQCXfMqXFLDKSI3NcR6ImVQipKyqpKJjH1lRBTse7Y10rwwF3oM+a8kq6OMTmSop2inAMxc8Dh5GRu9OXqiqxFRxVdHMwPhqKeRhZxQ5rwQWfvfD3XsVTSTUveYZ4JKbBdxWvBZgdTnogq0VGayiE8kBqKfjRt3vj3jc1vqR5D3UyKanmJEMkUhDQ4hrgcA9D8D5IKhFRR11DI5zY6qmc5r+E4NkacP8A3T7+yphfLMYnyi6W8xxkNe8VDMNJzgE55ZwfkUF2RU8MsE7cwSRyDAdljgeRGQeXqFNB2n2QRoiICIiAiIgIiICIiAoD9s+6jXjm5QUN0gfPAGsZvPPw/cQP7qVRUzo6t0nAETDn058m+nwKuOHexTDvb5rrVcLRVc6Wd9Pw3FcxHKxfVmmJbzcIKuCWh3Mp5KV0dbS94ZteWkuaNww7w+4Kkx6SlGrX3Z1VAIO9CraxkOJd3dmwbC/P2ORdjHXHosuw72+aYd7fNdlhbdMWw2XTtttjpRMaSnZCZA3bu2jGceSuTeb/AIBNrvYKIDAQeqB3J49wo0IyMFBJqI+LBJGDjc0jKoqCne2d0j2uZjIw4g5JxnHtyVw2uHmCmHe3zVzphmaYmcrBq7TUOpoqCCrlcymgndLKxvIytMUkZbny+319vvWPHs/qM3531uSbxE6OYGEYYRJmIt8/CwlvMnPLpjC2Bh3t80w72+ajTB6XQnAt9RSvqophNb5aJ/Ejdh7nyueXuDXA893MAjn0x0VVT6ZrKTRFRaO8Q1NQXmRu1nDa4bw7YeZJyBgkkk55rLsO9vmmHe3zQYHNoOSWvnk73SNhdNU1DHilxUF0zHtLXybvEwbzywOTWjyVfobR50rLXba59TTzxQRRRvbzhEYdloOebcvJA8hy8lluHe3zTDvb5oMCs2g5rfM0mtpuAytiqmRRQOGAziZG5zi7nv8AXAxyHNTbroNtVSSxUs8MDn3T6xyxjo+WwtDMscHDqTkFZxh3t80w72+aCz2q3T0t4qqmUs4T6Snp27STl0ZkLjz5/tgc+fJXd3THqvcO9l61uDknJQRIiICIiAiIgIiICIiAiIgIiICIiAiISAMlARQbnewTLvb5II0UGXe3yTLvb5II0UGXe3yTLvb5II0UGXeyia7PLoUHqIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKB/2wo148Z5jqEEmpc9kD3RBpeBkbuioaKdzqhjY52zNkBe/P7Pw+Y5K45zyIPyXga0EENAIGBy8kZmmZnLHtd3G4Wyzce0O/70HHazu7peIQ0kN5fZyR18zyyM5FNrC8XSjoaSW3U88Z7wWzDhb3yMDCcMADhknGN2PTIzlZZn4/JM/H5I0xHVt8u9uv1nhtdFJUUO4PuD2x7tsbntY3Bz1G5zjjPJnocqxjU+qxcbhTyULGQs+sH0tQad7mObE/bE14aC7PLPIeIEY6FbKz8fkmfj8kGPaEuVZdbA2ouXE7wJHsLnwcLcAeRA8x74GfRZCftNQn4/JetBJyeXsgiREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAWrrzBrv8A1QZJQOmOlnVdLvAkaNrBGeIQM52lx5jrkDC2iiDWGrna3/1Ts01lpqt2mKfhR1TWSRhku8u3uILsnaC3y8kfb9bjtiG2pqjo5zhVF/FbtaREWmLGc4L8Hotnogwyji1OLHrAbni5Pqqk2kyuaQGbBwseQG7PIqz9jg1jG2ui1lT3Jv6KJ0clZUwyh0mDxAwMaC0Z8iTyI6c1stEGsOzE63/4nvx1bT1jLbVh01GZZI3NpzxHARtDXEjLC08/RXrs2s98tUl++v7ncq5prTFRd8ka/wDQNaC142jkXFzgf5RyCzVEGqrzBr49k9DHbnVI1IKnNViRnGMPEfkNcTt3Y2efRVumYNbN7IbnFenzHVJgqRSeNnFB2nhZcPDuz5/BbIRBhPZXHqiK13JuszIawVm2BznBwdEIoxuGOgLg849SVmyIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIgOcoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8b1PxXq8b1PxQeqTHMHTyxktBYQAPMjAP+VOTAznHNBS0lSZpZWFuA0+E46jp/hKuqMEzG7Nwc09PXlgKqTCCnhnc80+QBxGFx9un5qCCqc98zXBmWdAD+JVXhMD0RFHDVukg3kN3b2sOOgyR+a9mqnRz7AGYBA2k+J2fRVeB6JgIKTvThWcEs8JftDvXw5Kq0wiKIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIvG9T8UHqImRnGeaAiZHqEyMZyMICISB1KZHqgImRnqmeaAiZHr0TKAiEgea8LgBknkg9RMj1RAREQEREBERAREQEREBERAREQEREBeN6n4r1AMZQFSspi2ufOXAh3QenID/CqkQUbKRwinYQ3x5wc+pJTujnUjIXObyduOAOmfgqxEMKOooy/AZsLQzYN4zt9x7ryro3zO3Nk2kM259efPKrURMKaanc+qjlbtw3rnmUhp3sqpJi8HfnI/BVKIqhjo3tZUDLf0oIHzP5qofG/vDZGbSNu0gn3U5ETCQYMmo3bSJMYB+GFKlpC6mhjYGjhkEjoDyKrERcKR9M51RFINg2gA+fyVWiICIiAiIgIiICIiAhKK06mvVLp+x1t0r37KaliMjz646Ae5OAPigiv9+tlgoH1t4rYKOmb1fK7bk+g9T7Ba0rfpBaJp6kxRy3CpaDjixU3h/8AkQf7Ll/tA1pdNa3yWvukzuEHHgUwd4IGegHr6nzWNMZJIHFkbnBoycDOEHeWj+0nS+rZBDZrpE+qIz3eUGOT7muxn7srMQcr5v0tRLTVEc9NK+GeNwcyRji1zSOhBHQrsL6P3aNLrKyS0N2kDrzQAB7+hmjPR+PXyP3HzQbfRAchEBMovG9T8UHqIpDalrqp0Aadzep8ugP+UE9FTMrY3CU4d+j6+/Mj/Ci7y0RyuexzTGMuacZQT0Ulk7XCMgfrCQMEHyJ/wo45A8vAB8J2lBGikVFS2CSNjgSX9MfED/K9447wYdpyADnyQTkUmGfinkx4aeYccYK8hqo5ZAxuckE8/LBwgnoqZtYwwPl2uDWfDmvRVNMUb2sc4vOGtGMn/HkgqEUh9SxgjLw5u/PUdMKF9U1rIXBrjxRkIKlERAREQEREBERAPRaY+lLVzU/ZqY4SQyorYopMfu4c78WhbnPRYF2x6afqrQtyt1OAaraJoM+b2HIH38x96DhmFglnijc4Ma5waXHoMnqtidqONFa5Np0zH9Xx2xsRjqY/107nRhxe5/Ug7iNv2fZa7nikhlfFMx0crHFrmuGC0jqCFe2amqp3Uf13Ey7R0bQ2COp8mjo1z24eWj93dhEZJ2y2+kguOn7pS08VLNeLTBX1METQ1jZXAhxa0dAcZx65Vz+jTVzU3apRxRE7KinmjkA/dDdw/u0LX2pL7X6ku8tyusgfUPAaA1oa1jQMNa1o5AAeS3d9FbSs77nWalqIy2nZGaamLh9txILnD2AGPvPoiuoYjloUagiGGhRoC8b1PxXqIC8axrXOIGC45PuvUQSxBGA8Bgw/7Q9f/uUbBE2NzAwbXdR6qYiDwsaS0kc2nI9lC2JjZHPaCHO68z+CjRBA+Jj3Nc9uS3ofT/7hDEwy8TB39M5KjRBLjgjjeXMYA4+a9ZExhBa3BAIH38yo0QSm08TWOYG+F3UEkr10ETowws8I5geimIggEMYDAGjDBhvsoXQRuawFpwwYbgkYU1EBERAREQEREBERAUmaPcFOQhBpLtU7GaDVVRLcrXI233Z3N7tuY5j/ANQHQ+4+8FaUq+w/W0FQY4qKmqGZxxI6lgb/APIg/wBl2o+MO6hSjTN9Ag5f0T9H2slq459V1UcdO0gmmpXFzn+znYwB8M/cuk7JaqW1UEFHQwMgpYGhkcbBgNAVwZC1vkpoGEHoGAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIP/2Q==",
+              "timing": 1500
+            },
+            {
+              "timestamp": 125066233405,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAAHAQEAAAAAAAAAAAAAAAIDBAUGBwgBCf/EAEYQAAEDAwIDBgIGCQIDCAMAAAEAAgMEBREGEhMhMQcUIkFRYXGRCBUygbHRIzNCUlRykqHBF4IWNGIYJCc2dIOi8KOz4f/EABsBAQEBAAMBAQAAAAAAAAAAAAABAgMEBQYH/8QAMBEBAAEDAgIJAwMFAAAAAAAAAAECAxEhMQQSExVRUlNhkZLRFCOhBUHhIjJxgfD/2gAMAwEAAhEDEQA/AOqUREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQQT/AKmT+U/gsGWcz/qZP5T+CwZBniIiAi8c4NaXOIDQMknoFj0WuNKzXDuMWorS+rztETaphJPp16+yDIkQkAZJ5eqx0640s2v7kdRWkVedvC72zdn069fZBkSICCAQcg+atV51Da7K9jbrVd0Y/GJpY3CIfGTG0feUF1RYF211X/hJf6mjn5Gna5ksT+oLm8wQrsdX6es1JQU13vluo6p0Mf6Oeoa13No5kE8kGTopdNUQ1UDJ6aWOaGQbmSRuDmuHqCOqst31jpuz1YpbrfbZSVOccKapY1w+IJ5fegvyKVSVMFZTsqKSaOeCQZZJG4Oa4eoI6qagIiICIiAiIgIiICIiAiLx7trSUAuDepAXgkYejgrXcrjSW+A1FxqoaaHIbxJnhjcnoMlUFHqWx1tSyno7xb56iQ4ZHHUMc53wAKDJUUineT4T9ynoIJ/1Mn8p/BYMs5n/AFMn8p/BYMgzxERBrftwnmfZ7HaGzPp6S8XWChq5GHaeC4kubnyzjCyOr0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3v1VZq7TtDqqxT2u5tdwZMOa9hw+J45te0+RBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHnjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fdo25W3GaB0q2x/VIsVv7ls2YMLd3TGd3Xd75yo5tE2SXRI0qaYi0tiETWg+JpByHg/vbuefVY03ROtGUn1c3X8v1aG8MONvYanZ0xxc9ceeMoLN2g1VToTsUNPp28TVZjlbRsrnPDnwxueQRuHm0eEHqFsXT+nLZb9OMt0cQqKeaENnfMeI6oyObnk/aJypdu0bZKLR7dMikbNaeGY3xzeIyZOS5x/eJ559VSu09dLZZRZ9MV7aam2cNlRWvdUSU7emGN5Zx5bnHCDStPPLT9kXahYGyvmt1mrn09G9xztj4g8GfbH91ufROlLNR6TpIzS01c6rp2SVNTMwSOqnOaCXOJ6g55DyCt47M6Cn7Na7SVBUyR99BdPWSN3vkkLgS9w5ZzjCR6O1HaaTuGl9Ux0VtDdscNVQiodTjzEbtw5egdnCDFNP1c2kP8AVG1WQl1BZ4u+UMX2hA98TnuYPYEZwsp7LNJWOHQ1tqX0dLXVVxp21NXVTxtkfO+QbnZJHMZPRXrRejqPTNnqqQyyV9TXSOmrqqoAL6l7upd7Y5ALHaLQWodPskotIat7jZy5zoqSrom1Jp8nJDHEg49AcoJHZ9DHYO0/Vmm7WNlmZDBXRwA5bTyPyHNb6A9cLaCxnRGkYNLw1kj6ue4XSuk41ZXT/bmd5DA5BoHIAdFkyAiIgIiICIiAiIgIiICgnGYio0PNBjuoxUm2nuQrjNuH/JcHiY/93w4/urFZW3f60g70NRcHJ3d6FDw+h+1w/H8lmz4SD4eYUIieT9lB7AP0gVUoIowwe6jQQT/qZP5T+CwZZzP+pk/lP4LBkGeIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIggm/UyfylYRsd+675LOkQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEVBWyVba6nbC1ppyDk5Iy70PI4GP7/wBwr0UEm8wOwMSFpxg+axuOmuwpaZsrp9wkJkAfuIG0Y57gTzz58vggydFZ30tYx9wfBLOXOaOCHSZAJ64B5A+ilwNuEW1+yqfC2bIjke0yFuwg5OcY3EHqgviKxwQXNtfQukdJwmQsEx35Bfh+7I8+e3n8FPxcPr3ibT3Hbwtu/wA8Z34+PL/CC6orBHHczTSNkbOJGU+wESDL5N3Jw59OnVVcDK8WSRri76ww7JLgcuz+z5Aen90F0RY+Ke4yNYxjqhkXHB/TS+MN2OzktPTdjzU6opq41Fc+N8m0RbYBxTzdsx0zjr5lEXpFjbae6AUYkdPta6TiBryeWW7ee4E8s9fkq+0MrWVlX3oTGIuyx0jhjqeQAJxyx6fBFXVERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERQTSxwxl8r2sYOpccBSZimMyI0VuN7twP/Mt/pP5J9d27+Jb/SfyXV+v4XxafdHy5Ohud2fRcUVu+u7d/Et/pP5J9d27+Jb/AEn8k6w4XxafdHydDc7s+i4ord9d27+Jb/SfyT67t38S3+k/knWHC+LT7o+Tobndn0XFFbvru3fxLf6T+SfXdu/iW/0n8k6w4XxafdHydDc7s+i4ord9d27+Jb/SfyT67t38S3+k/knWHC+LT7o+Tobndn0XFFbvru3fxLf6T+SqqWsp6oE08rZMdceS3b4uxdnlt1xM+UxKVW66YzVEwnoiLsMCIiAiIgIiICIiAiIgIiICIiAiIgLDNWVL5LkYCTw4gMD3IzlZmsf1FZ5KuQVFLgy4w5pOM/BeL+v2L1/g5psazmMx2x/2rtcHXRRdzW1F2g6vk0o23mKkjqTVOe3D5CzG0AgDAPM5xzwPdLlq91HrW2WHgU7W1lOyfiyzEHJc4bWgNIJ5ZGSAVmtTYZqnAqbeJtuQN8YdjPXqoX6efJPHNJbGumjADJHRAuaB0wfJfE27PLRFNfD1TOJzOu87T/r8vVmvMzMVxjTsa71T2ifUeqxZ+4Ne1rYy6V8paXbz0Y0NOev4q43fV8lv1zQ2BtHHIypYxxlMpa5u4vHIYwcbfUHnyWay2GWWZk0tuD5o/sPdGC5vwPkklhlkmbNJbg+VuMPdGC4Y6c/vPzWotU4pj6arOJid9Z/af4Tn1n7kb+WzDXatcNaGw91Z+uEfE4nMtMPE3bcevhU+ivdzm1lVWea3U8dLDEJu8NqMuLHEhvhx1JaeWeSyz6kqO8cfuB4+NvE2Ddj0z1wohZqoSmUUThKQGl+zmR6ZXHNmrGIsT/bjad+3+Gorj96438tuxhWjdWO1FWXeF0NPD3GUxbWSuc84c4ZcC0AA7fIlWfRPaO7Ut4o6F1sNNx4JJDIXkgOafst5DPhwc+62TBYJKd8j6e2iJ8nN7mRBpd8cdV5Fp58JjMVsawxghhbEBtB6gei5JtU/144erXGN9NPzrqzFe33I89tWF6K1g7UlPdJXQU8JonFvDZK5z+Rd9rLQBnbywT5+ig0JrOTVbK7bQinlpoYZNjn5y6QOOOnTwg59HLN6fT8lMZDT21sRk+3w4g3d8cdepUUFhmpy409vERcACWRhuQOQHL0Wblnm5+Th6ozjG+nb/nK014xmuPPbVi2jb3cL2y4OuNBBR91qDTDhT8Tc5v2vIYHTHrlZVQVL6SrjmjJBaeePMeYUUVmqog7hUTmbnFztrMZJ6k+6utnsM76hklWzhxNOcE83Ja4Pib3ExNi3NGsY0nEeeZKrtum3MV1ZZgiIv1B4AiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiDT18+kDpazXu4Wupt96fUUVRJTSOjhiLS5ji0kZkBxkeiyTs97VtN67rZaK0uqoK2NnE4FVGGOc0dSMEg4z6rlK+XiosHbVfLrR08dTPSXeslbFICWuw9+cgeWMn7lf9C0NNpi33fVtJqe0z3mOhlNFQ0j3GVr3ja57muAxtaXHGD09kR2XkeqZHqFwRb6GsvVuqL5NqEx3JlQGE1VS1hwceIvc8O8+gaenULJe1i13CTSOlNQV9xprpUuZJb56ylm4rH7HF0e53m7aXA/yoO0sj1CZHquGvrKr192hw3B8Lpu70jZ5I3cwW08Ac4H2c5hH+5W6kbcNXm63a6X9wuEGJG94ma0OyTnxOe3aB5BoPwQy72yB1KZHquHO0KpucmidKQ3S80l2dBNWMilp6jjFjMQEMe71BJ+4hUmshc7JT6PrI7zWPlntMVRDtds7sN7gGMx5eHOfMkoO7sj1CZHqFw9p6ulru3W0VtU/wDS1F3gmkPQZc9pP4qVYbtUWftZu1zoHZqKZ1ymiPUBwhmIOPP1Qy7myPVFwRQUtdqKir71Wagc25RStGaqoa0uzjxF7ngjr0a13TyXXHYdVXCp0BTNu11o7tUQSOiFTTT8YFowQ1zvNwzj4YRVPrftk0npC5yW6unqaqui/Ww0cYeYz6EkgZ9sqDRfbRpLVl0it1JNVUdbMcRR1kYZxD6AgkZ9srj+uc+fXE5u/wBt9xd3niepk8ef7q46ybBS9p9zbpsRNgjuR7mKYjaMP8O3HlnphEd85HqEXCNMamTtarqemu0dokqbhU07q2Q4bC17ntcc+XIkeXXqOqyzs3v920L2jXOy2y7C826KCpJ4Ty+GUxwOka9oyQCC0A49xzRXYWR6pkDqVwTStuGrzdbtdL+8XCDEje8TNbuyTnxOe3aB5BoPwVz7Q6m5SaJ0pDdLzSXZ8E1YyKWnqOMWMxAQx7vUEn7iER3HkeqZHquV7NpC7ab0BH2kQ3501VHaOHT0/BwYWvaIm4du/ZDt3TqFrOldNUaJvd1n1cG11RKyCa1Suc6WrYHNcHEk+R5/7Tz54RXaGv8AWNv0Rp83e6xVM1MJWxbaZrXPy7OOTiBjl6rFHdrMVz7Oq3VGlrHcbgaeq7p3WRoa/OGkvOwu8IDh7/iuV6C0w1fZbdrpJJKJ6G4wxxtBG0iRjt2eWf2BjmPNZXpGjoofo865rWVObjUVVNE+DiN8MccsRa4N68zK4E9OQRHTHZRq+46y07LX3ayy2maOYxBj92JBgHc3cAcc8fcs0yD0K4QtmqbtZOzKWgtVTNSsuFyk48sTi1xayKPDMjmAd39lV1wruzivsF2sGqoK+prIW1UsdLISIzyJjkGTkHOOfPkeQQdyZHqEyuI9KUlVfO3SelpK6e2VFVX1oE8QBfFlspOM+eMjPllUvZhfb9TOv1DaryaJ1RQPDXT1HDjD97MHc44a45LQ7lzd1QdzZHqEXA4s9VQVJl1RcbnZ6mbxU9Q6B0zJvU8Rr8+Y5gO6rtLsybI3QFiE1wZcnilbmrY9z2y/9QLsH580VkyIiAiIg1DF2G2puvKjUs10qZnT1U1TJSPibsdxC7czPXHiIUvSvYJYtP6idcWV9VV0ro5oXUdQxpa5kjCwguGD0ctxIg0PUfRp09JXvlivFyipS7IgDWEtHoHEfiFneouy+yXbs+p9I0xfQ0NO9skMjAHPa4EkuOepOXZ+Kz1EGr+zDsdteg7tV3CGunr5p4DTgTRtaGNJBd065wFjl5+jfp2tuktTRXOuoaeR27uzGte1nqGk88fHK3miDTt/7BLBcbFZ7VRVtVQw28zPMga2R875NmXPJxz8A6KDU3YPbb9SWSCW9VkItdC2hYWxNPEaHOduPofEtyrHO0PU40do+4X00ve+6hpEHE4e/c8N+1g4656INfXP6P8Apyvu1HXPra+MxMhZNFGWhsxjaG56ZaXbeeCo9M9g9lsWrW3plwnqIQZgaKSJvDLJGPYWE9cAP/snZ523UurKa/yVNp+rn2qjdW7O9cXisbnd+w3GPD6/aUjsx7chrfV1PY3WDuBmje8Td84vNrc427B6eqCgrvo16emuEk1Nd7jTUrnbhAGtdtHoHH/OfvW39Jact2lLDTWizxGOkgBxuOXOJ5lzj5klTJNRWWOSqjku9ua+lZxKhrqlgMLf3njPhHuVRDXGlDC6Uamshia4Nc/v8WATkgE7upwfkUGE697DdN6tu8t0bNVW2tmO6Y0+CyR37xaRyPwxlQaG7CdNaXu8NzlmqrnVwOD4e8bQyNw6O2gcyPcrYQ1RYHQ0swvdsMVXkU7xVR7ZsHB2HPiweRx5qrud2t1qiZLc6+ko43nDX1EzYwT7EkIONtKacg1F25VNqutPK6hq62uY87SMeCUhwPqCAR7gLo7s37INP6GqpqymfUV1dLGYjNU7cNaeoa0DlnzzlZfUaq09TXEW+ovtqiry5rRTPq42yZdgtG0nOTkY9chVlddrdQTwQV1fSU007g2KOaZrHSEnADQTkn4INM3n6N+na26S1NFc66hp5Hbu7Ma17WeoaTzx8cq5X/sEsFxsVntVFW1VDBbzM8vDWyPnfJsy55OOfgHRbJo9UWCtuX1dR3u11Fw3Ob3aKrjdLludw2g5yMHPphKjVOn6asNJU3y1xVYODDJVxteD/KTlBTWjSlFQ6Ip9L1JNZQR0vdHmQYMjMYOcdPuWsP8As4aZbHcGx3C4F07Q2B0m1xp/ECSMAbiQNvPyJW2brqaw2eaOK7Xq2UMsjOIxlTVMjLm9NwDiMjkeanUN9tFwrnUdDdKGprGxiZ0ENQx7ww4w4tBzg7m8+nMeqDXWm+xOyWnSd50/V1lVXUlzfHI57mtY+JzM7S0jPPn5q1W76PtooLVeqKG9V7hcomQl7mM/RtbKyTkPM5YB963WiDUdr7CbBTaPrLBXVdVWRz1Iqo6jDWSQPDdvh6jGOoKodL/R405Z7vBXVtdWXLgPD2QShrIyR03AcyPbK3UiDVFg7F6Czdof/FkV2qpKjvM1T3d0bQ3MgeCM9eW/+yslp+jnZKN1WKi83CohqYTC5oYxhHia4EHn0LR5LeSINCw/RosDalrpb3c3wA84w1gJ/wB2P8LddhtNHYbNR2u2x8KjpYxHE0nJAHqfMqvRAREQEREBERAREQEREBau+ktLwuyK6jP6yWBn/wCRp/wtoqxa00tbdY2R1qvLZnUjpGyERP2HLenNBw3pSiu8lNPJZiQK6Vlnkx58bJAPx2H5JpGsqrDqqokoZHNqYaesiY9nIg8CRoI9Dnmuz9Fdm2nNHxVEdpppHtnljmPeX8Xa9m7a5uRyI3FWa19imj7bfYrtTwVhqo5TKBJOXMJOcgtxzHM8kRyRZm2H/hi8VNfdLjT6g5MpIIWZjmYftB7vn5j71RU3/lC4/wDrqX/9dQuxx2K6HbPXSxWkxmrjdE4CVxEYd1LAc7T7jp5KiZ2DaKZQy0ghr+DLKyVw7yc7mBwHPHo9yDmDVNmgo+zvQ90jknfUXBta2Rr3ksYI58NDB+yPE4n1JU3UtcLrqXTsWqayqjtUdvoozLGN72QmJpcWg9Tku/8A6uqLj2N6TuFhs9oqYqw0dq43dg2oIcOK4Ofk458wqi8dkWj7vbLbRV1ue8W+FtPBM2VzZOGOjXOH2vvQckUJoD2qWsWesqq63NuVMynnqhiRzA9gGR7YwPYDkOivtULdqHtcv3+ol6q7ZDHNOBMxpc5jmOwxg5HAA9vL3XSMvYvo5+oILvFRzwVMD4pI2QzFsbTGGhvh/wBoz681pjtlob4e0G4VM+hY7hE2YOpqxlPMRMwYxv4btrvTmM+RQay0jXVdJqyurbZUTSVTKWufHUcw8/oJMv8AUHGSqe0UFlrbJVz3K6d0uTZmhgeXODmHGTsDCXHr+0371uD6PPZ5fHa2fqO/2yWhooY5drKiLh8Z8jS0gMP7OHO8sdAtpVfYPoSpr31Rt9RGHu3mGOoc2P4AeQ9gUHLnaA6PuWmo6e7Pu1PFQOjjqHwOiw0TSeAB3MgHIz93kuoOxns1tmmY6PUtLWV09dcbbG2Vs72lg3hjzjAB6tAHPorlqXse0hqF1B3ujmhjoacUsEVNKY2tYHF3TzOXHms7ttHFbrdS0VMHCCmiZDGHHJ2tAAyfgEFQiIiiIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiKF5Odo+9BEilO2MaXPwABkkqGJ8UrSYyHAcuinNGcZ1MTunoqWpqKWl4feZoYeI7aziPDdx9BnqVCyro31klIyop3VUY3PhDwXtHqW9R1HzVFYikwvimiZLA9r43jc17DkEeoIUxpzkHqEESIoXnGAOpQRIpZDQCXfMqXFLDKSI3NcR6ImVQipKyqpKJjH1lRBTse7Y10rwwF3oM+a8kq6OMTmSop2inAMxc8Dh5GRu9OXqiqxFRxVdHMwPhqKeRhZxQ5rwQWfvfD3XsVTSTUveYZ4JKbBdxWvBZgdTnogq0VGayiE8kBqKfjRt3vj3jc1vqR5D3UyKanmJEMkUhDQ4hrgcA9D8D5IKhFRR11DI5zY6qmc5r+E4NkacP8A3T7+yphfLMYnyi6W8xxkNe8VDMNJzgE55ZwfkUF2RU8MsE7cwSRyDAdljgeRGQeXqFNB2n2QRoiICIiAiIgIiICIiAoD9s+6jXjm5QUN0gfPAGsZvPPw/cQP7qVRUzo6t0nAETDn058m+nwKuOHexTDvb5rrVcLRVc6Wd9Pw3FcxHKxfVmmJbzcIKuCWh3Mp5KV0dbS94ZteWkuaNww7w+4Kkx6SlGrX3Z1VAIO9CraxkOJd3dmwbC/P2ORdjHXHosuw72+aYd7fNdlhbdMWw2XTtttjpRMaSnZCZA3bu2jGceSuTeb/AIBNrvYKIDAQeqB3J49wo0IyMFBJqI+LBJGDjc0jKoqCne2d0j2uZjIw4g5JxnHtyVw2uHmCmHe3zVzphmaYmcrBq7TUOpoqCCrlcymgndLKxvIytMUkZbny+319vvWPHs/qM3531uSbxE6OYGEYYRJmIt8/CwlvMnPLpjC2Bh3t80w72+ajTB6XQnAt9RSvqophNb5aJ/Ejdh7nyueXuDXA893MAjn0x0VVT6ZrKTRFRaO8Q1NQXmRu1nDa4bw7YeZJyBgkkk55rLsO9vmmHe3zQYHNoOSWvnk73SNhdNU1DHilxUF0zHtLXybvEwbzywOTWjyVfobR50rLXba59TTzxQRRRvbzhEYdloOebcvJA8hy8lluHe3zTDvb5oMCs2g5rfM0mtpuAytiqmRRQOGAziZG5zi7nv8AXAxyHNTbroNtVSSxUs8MDn3T6xyxjo+WwtDMscHDqTkFZxh3t80w72+aCz2q3T0t4qqmUs4T6Snp27STl0ZkLjz5/tgc+fJXd3THqvcO9l61uDknJQRIiICIiAiIgIiICIiAiIgIiICIiAiISAMlARQbnewTLvb5II0UGXe3yTLvb5II0UGXe3yTLvb5II0UGXeyia7PLoUHqIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKB/2wo148Z5jqEEmpc9kD3RBpeBkbuioaKdzqhjY52zNkBe/P7Pw+Y5K45zyIPyXga0EENAIGBy8kZmmZnLHtd3G4Wyzce0O/70HHazu7peIQ0kN5fZyR18zyyM5FNrC8XSjoaSW3U88Z7wWzDhb3yMDCcMADhknGN2PTIzlZZn4/JM/H5I0xHVt8u9uv1nhtdFJUUO4PuD2x7tsbntY3Bz1G5zjjPJnocqxjU+qxcbhTyULGQs+sH0tQad7mObE/bE14aC7PLPIeIEY6FbKz8fkmfj8kGPaEuVZdbA2ouXE7wJHsLnwcLcAeRA8x74GfRZCftNQn4/JetBJyeXsgiREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAWrrzBrv8A1QZJQOmOlnVdLvAkaNrBGeIQM52lx5jrkDC2iiDWGrna3/1Ts01lpqt2mKfhR1TWSRhku8u3uILsnaC3y8kfb9bjtiG2pqjo5zhVF/FbtaREWmLGc4L8Hotnogwyji1OLHrAbni5Pqqk2kyuaQGbBwseQG7PIqz9jg1jG2ui1lT3Jv6KJ0clZUwyh0mDxAwMaC0Z8iTyI6c1stEGsOzE63/4nvx1bT1jLbVh01GZZI3NpzxHARtDXEjLC08/RXrs2s98tUl++v7ncq5prTFRd8ka/wDQNaC142jkXFzgf5RyCzVEGqrzBr49k9DHbnVI1IKnNViRnGMPEfkNcTt3Y2efRVumYNbN7IbnFenzHVJgqRSeNnFB2nhZcPDuz5/BbIRBhPZXHqiK13JuszIawVm2BznBwdEIoxuGOgLg849SVmyIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIgOcoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8b1PxXq8b1PxQeqTHMHTyxktBYQAPMjAP+VOTAznHNBS0lSZpZWFuA0+E46jp/hKuqMEzG7Nwc09PXlgKqTCCnhnc80+QBxGFx9un5qCCqc98zXBmWdAD+JVXhMD0RFHDVukg3kN3b2sOOgyR+a9mqnRz7AGYBA2k+J2fRVeB6JgIKTvThWcEs8JftDvXw5Kq0wiKIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIvG9T8UHqImRnGeaAiZHqEyMZyMICISB1KZHqgImRnqmeaAiZHr0TKAiEgea8LgBknkg9RMj1RAREQEREBERAREQEREBERAREQEREBeN6n4r1AMZQFSspi2ufOXAh3QenID/CqkQUbKRwinYQ3x5wc+pJTujnUjIXObyduOAOmfgqxEMKOooy/AZsLQzYN4zt9x7ryro3zO3Nk2kM259efPKrURMKaanc+qjlbtw3rnmUhp3sqpJi8HfnI/BVKIqhjo3tZUDLf0oIHzP5qofG/vDZGbSNu0gn3U5ETCQYMmo3bSJMYB+GFKlpC6mhjYGjhkEjoDyKrERcKR9M51RFINg2gA+fyVWiICIiAiIgIiICIiAhKK06mvVLp+x1t0r37KaliMjz646Ae5OAPigiv9+tlgoH1t4rYKOmb1fK7bk+g9T7Ba0rfpBaJp6kxRy3CpaDjixU3h/8AkQf7Ll/tA1pdNa3yWvukzuEHHgUwd4IGegHr6nzWNMZJIHFkbnBoycDOEHeWj+0nS+rZBDZrpE+qIz3eUGOT7muxn7srMQcr5v0tRLTVEc9NK+GeNwcyRji1zSOhBHQrsL6P3aNLrKyS0N2kDrzQAB7+hmjPR+PXyP3HzQbfRAchEBMovG9T8UHqIpDalrqp0Aadzep8ugP+UE9FTMrY3CU4d+j6+/Mj/Ci7y0RyuexzTGMuacZQT0Ulk7XCMgfrCQMEHyJ/wo45A8vAB8J2lBGikVFS2CSNjgSX9MfED/K9447wYdpyADnyQTkUmGfinkx4aeYccYK8hqo5ZAxuckE8/LBwgnoqZtYwwPl2uDWfDmvRVNMUb2sc4vOGtGMn/HkgqEUh9SxgjLw5u/PUdMKF9U1rIXBrjxRkIKlERAREQEREBERAPRaY+lLVzU/ZqY4SQyorYopMfu4c78WhbnPRYF2x6afqrQtyt1OAaraJoM+b2HIH38x96DhmFglnijc4Ma5waXHoMnqtidqONFa5Np0zH9Xx2xsRjqY/107nRhxe5/Ug7iNv2fZa7nikhlfFMx0crHFrmuGC0jqCFe2amqp3Uf13Ey7R0bQ2COp8mjo1z24eWj93dhEZJ2y2+kguOn7pS08VLNeLTBX1METQ1jZXAhxa0dAcZx65Vz+jTVzU3apRxRE7KinmjkA/dDdw/u0LX2pL7X6ku8tyusgfUPAaA1oa1jQMNa1o5AAeS3d9FbSs77nWalqIy2nZGaamLh9txILnD2AGPvPoiuoYjloUagiGGhRoC8b1PxXqIC8axrXOIGC45PuvUQSxBGA8Bgw/7Q9f/uUbBE2NzAwbXdR6qYiDwsaS0kc2nI9lC2JjZHPaCHO68z+CjRBA+Jj3Nc9uS3ofT/7hDEwy8TB39M5KjRBLjgjjeXMYA4+a9ZExhBa3BAIH38yo0QSm08TWOYG+F3UEkr10ETowws8I5geimIggEMYDAGjDBhvsoXQRuawFpwwYbgkYU1EBERAREQEREBERAUmaPcFOQhBpLtU7GaDVVRLcrXI233Z3N7tuY5j/ANQHQ+4+8FaUq+w/W0FQY4qKmqGZxxI6lgb/APIg/wBl2o+MO6hSjTN9Ag5f0T9H2slq459V1UcdO0gmmpXFzn+znYwB8M/cuk7JaqW1UEFHQwMgpYGhkcbBgNAVwZC1vkpoGEHoGAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIP/2Q==",
+              "timing": 1875
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAAHAQAAAAAAAAAAAAAAAAIDBAUGBwgB/8QARRAAAQMDAgMGAwQIBAMJAQAAAQACAwQFEQYSEyExBxQiQVFhFXGRCDKB0SNCUlSSobHBFhczgjRy8BgkJzZidIOjs+H/xAAbAQEBAQADAQEAAAAAAAAAAAAAAQIDBAUGB//EADARAQABAwICCQMDBQAAAAAAAAABAgMRITEEEhMVUVJTYZGS0RQjoQVB4SIycYHw/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEXjnBrS5xAaBkk9Asei1xpWa4dxi1FaX1edoibVMJJ9OvX2QZEiEgDJPL1WOnXGlm1/cjqK0irzt4Xe2bs+nXr7IMiRAQQCDkHzVqvOobXZXsbdarujH4xNLG4RD5yY2j8SguqLAu2uq/8ACS/1NHPyNO1zJYn9QXN5ghXY6v09ZqSgprvfLdR1ToY/0c9Q1rubRzIJ5IMnRS6aohqoGT00sc0Mg3MkjcHNcPUEdVZbvrHTdnqxS3W+2ykqc44U1Sxrh8wTy/FBfkUqkqYKynZUUk0c8EgyySNwc1w9QR1U1AREQEREBERAREQEREBEXj3bWkoBcG9SAvBIw9HBWu5XGkt8BqLjVQ00OQ3iTPDG5PQZKoKPUtjrallPR3i3z1EhwyOOoY5zvkAUGSopFO8nwn8FPQEREBERBrftwnmfZ7HaGzPp6S8XWChq5GHaeC4kubnyzjCyOr0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3v1VZq7TtDqqxT2u5tdwZMOa9hw+J45te0+RBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHnjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fdo25W3GaB0q2x/CRYrf3LZswYW7umM7uu73zlRzaJskuiRpU0xFpbEImtB8TSDkPB/a3c8+qxpuidaMpPhzdfy/DQ3hhxt7DU7OmOLnrjzxlBZu0GqqdCdihp9O3iarMcraNlc54c+GNzyCNw82jwg9Qti6f05bLfpxlujiFRTzQhs75jxHVGRzc8n7xOVLt2jbJRaPbpkUjZrTwzG+ObxGTJyXOP7RPPPqqV2nrpbLKLPpivbTU2zhsqK17qiSnb0wxvLOPLc44QaVp55afsi7ULA2V81us1c+no3uOdsfEHgz7Y/mtz6J0pZqPSdJGaWmrnVdOySpqZmCR1U5zQS5xPUHPIeQVvHZnQU/ZrXaSoKmSPvoLp6yRu98khcCXuHLOcYSPR2o7TSdw0vqmOitobtjhqqEVDqceYjduHL0Ds4QYpp+rm0h/mjarIS6gs8XfKGL7wge+Jz3MHsCM4WU9lmkrHDoa21L6Olrqq407amrqp42yPnfINzskjmMnor1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93Uu9scgFjtFoLUOn2SUWkNW9xs5c50VJV0Tak0+TkhjiQcegOUEjs+hjsHafqzTdrGyzMhgro4Actp5H5Dmt9AeuFtBYzojSMGl4ayR9XPcLpXScasrp/vzO8hgcg0DkAOiyZAREQEREBERAREQEREBQTjMRUaHmgx3UYqTbT3IVxm3D/AILg8TH/AMvhx/NWKytu/wAUg70NRcHJ3d6FDw+h+9w/H9Fmz4SD4eYUIieT91B7AP0gVUoIowwe6jQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERUFbJVtrqdsLWmnIOTkjLvQ8jgY/n/ADCvRQSbzA7AxIWnGD5rG46a7Clpmyun3CQmQB+4gbRjnuBPPPny+SDJ0VnfS1jH3B8Es5c5o4IdJkAnrgHkD6KXA24RbX7Kp8LZsiOR7TIW7CDk5xjcQeqC+IrHBBc219C6R0nCZCwTHfkF+H7sjz57efyU/Fw+O8Tae47eFt3+eM78fPl/ZBdUVgjjuZppGyNnEjKfYCJBl8m7k4c+nTqquBleLJI1xd8Qw7JLgcuz+r5Aen80F0RY+Ke4yNYxjqhkXHB/TS+MN2OzktPTdjzU6opq41Fc+N8m0RbYBxTzdsx0zjr5lEXpFjbae6AUYkdPta6TiBryeWW7ee4E8s9foq+0MrWVlX3oTGIuyx0jhjqeQAJxyx6fJFXVERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERQTSxwxl8r2sYOpccBSZimMyI0VuN7twP8AxLf4T+SfG7d+8t/hP5Lq/X8L4tPuj5cnQ3O7PouKK3fG7d+8t/hP5J8bt37y3+E/knWHC+LT7o+Tobndn0XFFbvjdu/eW/wn8k+N2795b/CfyTrDhfFp90fJ0Nzuz6Liit3xu3fvLf4T+SfG7d+8t/hP5J1hwvi0+6Pk6G53Z9FxRW743bv3lv8ACfyT43bv3lv8J/JOsOF8Wn3R8nQ3O7PouKK3fG7d+8t/hP5KqpaynqgTTytkx1x5Ldvi7F2eW3XEz5TEpVbrpjNUTCeiIuwwIiICIiAiIgIiICIiAiIgIiICIiAsM1ZUvkuRgJPDiAwPcjOVmax/UVnkq5BUUuDLjDmk4z8l4v6/YvX+DmmxrOYzHbH/AGrtcHXRRdzW1F2g6vk0o23mKkjqTVOe3D5CzG0AgDAPM5xzwPdLlq91HrW2WHgU7W1lOyfiyzEHJc4bWgNIJ5ZGSAVmtTYZqnAqbeJtuQN8YdjPXqoX6efJPHNJbGumjADJHRAuaB0wfJfE27PLRFNfD1TOJzOu87T/AK/L1ZrzMzFcY07Gu9U9onwPVYs/cGva1sZdK+UtLt56MaGnPX+quN31fJb9c0NgbRxyMqWMcZTKWubuLxyGMHG31B58lmsthllmZNLbg+aP7j3Rgub8j5JJYZZJmzSW4PlbjD3RguGOnP8AE/Vai1TimPpqs4mJ31n9p/hOfWfuRv5bMNdq1w1obD3Vn+sI+JxOZaYeJu249fCp9Fe7nNrKqs81up46WGITd4bUZcWOJDfDjqS08s8llnwSo7xx+4Hj428TYN2PTPXCiFmqhKZRROEpAaX7OZHplcc2asYixP8Abjad+3+Gorj96438tuxhWjdWO1FWXeF0NPD3GUxbWSuc84c4ZcC0AA7fIlWfRPaO7Ut4o6F1sNNx4JJDIXkgOafut5DPhwc+62TBYJKd8j6e2iJ8nN7mRBpd88dV5Fp58JjMVsawxghhbEBtB6gei5JtU/144erXGN9NPzrqzFe33I89tWF6K1g7UlPdJXQU8JonFvDZK5z+Rd97LQBnbywT5+ig0JrOTVbK7bQinlpoYZNjn5y6QOOOnTwg59HLN6fT8lMZDT21sRk+/wAOIN3fPHXqVFBYZqcuNPbxEXAAlkYbkDkBy9Fm5Z5ufk4eqM4xvp2/5ytNeMZrjz21Yto293C9suDrjQQUfdag0w4U/E3Ob97yGB0x65WVUFS+kq45oyQWnnjzHmFFFZqqIO4VE5m5xc7azGSepPurrZ7DO+oZJVs4cTTnBPNyWuD4m9xMTYtzRrGNJxHnmSq7bptzFdWWYIiL9QeAIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIg09fPtA6Ws17uFrqbfen1FFUSU0jo4Yi0uY4tJGZAcZHosk7Pe1bTeu62WitLqqCtjZxOBVRhjnNHUjBIOM+q5Svl4qLB21Xy60dPHUz0l3rJWxSAlrsPfnIHljJ/BX/QtDTaYt931bSantM95joZTRUNI9xla942ue5rgMbWlxxg9PZEdl5HqmR6hcEW+hrL1bqi+TahMdyZUBhNVUtYcHHiL3PDvPoGnp1CyXtYtdwk0jpTUFfcaa6VLmSW+espZuKx+xxdHud5u2lwP/ACoO0sj1CZHquGviVXr7tDhuD4XTd3pGzyRu5gtp4A5wPs5zCP8AcrdSNuGrzdbtdL+4XCDEje8TNaHZJz4nPbtA8g0H5IZd7ZA6lMj1XDnaFU3OTROlIbpeaS7OgmrGRS09RxixmICGPd6gk/gQqTWQudkp9H1kd5rHyz2mKoh2u2d2G9wDGY8vDnPmSUHd2R6hMj1C4e09XS13braK2qf+lqLvBNIegy57Sf6qVYbtUWftZu1zoHZqKZ1ymiPUBwhmIOPP1Qy7myPVFwRQUtdqKir71Wagc25RStGaqoa0uzjxF7ngjr0a13TyXXHYdVXCp0BTNu11o7tUQSOiFTTT8YFowQ1zvNwzj5YRVPrftk0npC5yW6unqaqui/1YaOMPMZ9CSQM+2VBovto0lqy6RW6kmqqOtmOIo6yMM4h9AQSM+2Vx/XOfPric3f777i7vPE9TJ48/zVx1k2Cl7T7m3TYibBHcj3MUxG0Yf4duPLPTCI75yPUIuEaY1Mna1XU9Ndo7RJU3Cpp3Vshw2Fr3Pa458uRI8uvUdVlnZvf7toXtGudltl2F5t0UFSTwnl8MpjgdI17RkgEFoBx7jmiuwsj1TIHUrgmlbcNXm63a6X94uEGJG94ma3dknPic9u0DyDQfkrn2h1Nyk0TpSG6Xmkuz4JqxkUtPUcYsZiAhj3eoJP4EIjuPI9UyPVcr2bSF203oCPtIhvzpqqO0cOnp+Dgwte0RNw7d+qHbunULWdK6ao0Te7rPq4NrqiVkE1qlc50tWwOa4OJJ8jz/ANp588IrtDX+sbfojT5u91iqZqYSti20zWufl2ccnEDHL1WKO7WYrn2dVuqNLWO43A09V3TusjQ1+cNJedhd4QHD3/quV6C0w1fZbdrpJJKJ6G4wxxtBG0iRjt2eWf1BjmPNZXpGjoofs865rWVObjUVVNE+DiN8MccsRa4N68zK4E9OQRHTHZRq+46y07LX3ayy2maOYxBj92JBgHc3cAcc8fgs0yD0K4QtmqbtZOzKWgtVTNSsuFyk48sTi1xayKPDMjmAd38lV1wruzivsF2sGqoK+prIW1UsdLISIzyJjkGTkHOOfPkeQQdyZHqEyuI9KUlVfO3SelpK6e2VFVX1oE8QBfFlspOM+eMjPllUvZhfb9TOv1DaryaJ1RQPDXT1HDjD97MHc44a45LQ7lzd1QdzZHqEXA4s9VQVJl1RcbnZ6mbxU9Q6B0zJvU8Rr8+Y5gO6rtLsybI3QFiE1wZcnilbmrY9z2y/+oF2D9eaKyZERAREQahi7DbU3XlRqWa6VMzp6qapkpHxN2O4hduZnrjxEKXpXsEsWn9ROuLK+qq6V0c0LqOoY0tcyRhYQXDB6OW4kQaHqPs06ekr3yxXi5RUpdkQBrCWj0DiP6hZ3qLsvsl27PqfSNMX0NDTvbJDIwBz2uBJLjnqTl2fms9RBq/sw7HbXoO7Vdwhrp6+aeA04E0bWhjSQXdOucBY5efs36drbpLU0VzrqGnkdu7sxrXtZ6hpPPHzyt5og07f+wSwXGxWe1UVbVUMNvMzzIGtkfO+TZlzycc/AOig1N2D22/UlkglvVZCLXQtoWFsTTxGhznbj6HxLcqxztD1ONHaPuF9NL3vuoaRBxOHv3PDfvYOOueiDX1z+z/pyvu1HXPra+MxMhZNFGWhsxjaG56ZaXbeeCo9M9g9lsWrW3plwnqIQZgaKSJvDLJGPYWE9cAP/knZ523UurKa/wAlTafhz7VRurdneuLxWNzu/UbjHh9fvKR2Y9uQ1vq6nsbrB3AzRveJu+cXm1ucbdg9PVBQV32a9PTXCSamu9xpqVztwgDWu2j0Dj/fP4rb+ktOW7SlhprRZ4jHSQA43HLnE8y5x8ySpkmorLHJVRyXe3NfSs4lQ11SwGFv7Txnwj3KohrjShhdKNTWQxNcGuf3+LAJyQCd3U4P0KDCde9hum9W3eW6NmqrbWzHdMafBZI79otI5H5YyoNDdhOmtL3eG5yzVVzq4HB8PeNoZG4dHbQOZHuVsIaosDoaWYXu2GKryKd4qo9s2Dg7DnxYPI481V3O7W61RMludfSUcbzhr6iZsYJ9iSEHG2lNOQai7cqm1XWnldQ1dbXMedpGPBKQ4H1BAI9wF0d2b9kGn9DVU1ZTPqK6uljMRmqduGtPUNaByz55ysvqNVaepriLfUX21RV5c1opn1cbZMuwWjaTnJyMeuQqyuu1uoJ4IK6vpKaadwbFHNM1jpCTgBoJyT8kGmbz9m/TtbdJamiuddQ08jt3dmNa9rPUNJ54+eVcr/2CWC42Kz2qiraqhgt5meXhrZHzvk2Zc8nHPwDotk0eqLBW3L4dR3u11Fw3Ob3aKrjdLludw2g5yMHPphKjVOn6asNJU3y1xVYODDJVxteD/wApOUFNaNKUVDoin0vUk1lBHS90eZBgyMxg5x0/Baw/7OGmWx3BsdwuBdO0NgdJtcafxAkjAG4kDbz8iVtm66msNnmjiu16tlDLIziMZU1TIy5vTcA4jI5Hmp1DfbRcK51HQ3ShqaxsYmdBDUMe8MOMOLQc4O5vPpzHqg11pvsTslp0nedP1dZVV1Jc3xyOe5rWPiczO0tIzz5+atVu+z7aKC1XqihvVe4XKJkJe5jP0bWysk5DzOWAfit1og1Ha+wmwU2j6ywV1XVVkc9SKqOow1kkDw3b4eoxjqCqHS/2eNOWe7wV1bXVly4Dw9kEoayMkdNwHMj2yt1Ig1RYOxegs3aH/iyK7VUlR3map7u6NobmQPBGevLf/JWS0/ZzslG6rFRebhUQ1MJhc0MYwjxNcCDz6Fo8lvJEGhYfs0WBtS10t7ub4AecYawE/wC7H9luuw2mjsNmo7XbY+FR0sYjiaTkgD1PmVXogIiICIiAiIgIiICIiAtXfaWl4XZFdRn/AFJYGf8A2NP9ltFWLWmlrbrGyOtV5bM6kdI2QiJ+w5b05oOG9KUV3kpp5LMSBXSss8mPPjZIB+ew/RNI1lVYdVVElDI5tTDT1kTHs5EHgSNBHoc812fors205o+KojtNNI9s8scx7y/i7Xs3bXNyORG4qzWvsU0fbb7FdqeCsNVHKZQJJy5hJzkFuOY5nkiOSLM2w/4YvFTX3S40+oOTKSCFmY5mH7we76+Y/FUVN/5QuP8A76l//OoXY47FdDtnrpYrSYzVxuicBK4iMO6lgOdp9x08lRM7BtFMoZaQQ1/BllZK4d5OdzA4Dnj0e5BzBqmzQUfZ3oe6RyTvqLg2tbI17yWMEc+Ghg/VHicT6kqbqWuF11Lp2LVNZVR2qO30UZljG97ITE0uLQepyXf/ANXVFx7G9J3Cw2e0VMVYaO1cbuwbUEOHFcHPycc+YVReOyLR93tltoq63PeLfC2ngmbK5snDHRrnD734oOSKE0B7VLWLPWVVdbm3KmZTz1QxI5gewDI9sYHsByHRX2qFu1D2uX7/ADEvVXbIY5pwJmNLnMcx2GMHI4AHt5e66Rl7F9HP1BBd4qOeCpgfFJGyGYtjaYw0N8P+0Z9ea0x2y0N8PaDcKmfQsdwibMHU1YynmImYMY38N213pzGfIoNZaRrquk1ZXVtsqJpKplLXPjqOYef0EmX+oOMlU9ooLLW2SrnuV07pcmzNDA8ucHMOMnYGEuPX9Zv4rcH2eezy+O1s/Ud/tktDRQxy7WVEXD4z5GlpAYf1cOd5Y6BbSq+wfQlTXvqjb6iMPdvMMdQ5sfyA8h7AoOXO0B0fctNR092fdqeKgdHHUPgdFhomk8ADuZAORn8PJdQdjPZrbNMx0epaWsrp66422NsrZ3tLBvDHnGAD1aAOfRXLUvY9pDULqDvdHNDHQ04pYIqaUxtawOLunmcuPNZ3baOK3W6loqYOEFNEyGMOOTtaABk/IIKhERFEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEULyc7R+KCJFKdsY0ufgADJJUMT4pWkxkOA5dFOaM4zqYndPRUtTUUtLw+8zQw8R21nEeG7j6DPUqFlXRvrJKRlRTuqoxufCHgvaPUt6jqPqqKxFJhfFNEyWB7XxvG5r2HII9QQpjTnIPUIIkRQvOMAdSgiRSyGgEu+pUuKWGUkRua4j0RMqhFSVlVSUTGPrKiCnY92xrpXhgLvQZ815JV0cYnMlRTtFOAZi54HDyMjd6cvVFViKjiq6OZgfDUU8jCzihzXggs/a+XuvYqmkmpe8wzwSU2C7iteCzA6nPRBVoqM1lEJ5IDUU/GjbvfHvG5rfUjyHupkU1PMSIZIpCGhxDXA4B6H5HyQVCKijrqGRzmx1VM5zX8JwbI04f8Asn39lTC+WYxPlF0t5jjIa94qGYaTnAJzyzg/QoLsip4ZYJ25gkjkGA7LHA8iMg8vUKaDtPsgjREQEREBERAREQEREBQH7591GvHNygobpA+eANYzeefh/AgfzUqipnR1bpOAImHPpz5N9PkVccO9imHe31XWq4Wiq50s76fhuK5iOVi+rNMS3m4QVcEtDuZTyUro62l7wza8tJc0bhh3h9wVJj0lKNWvuzqqAQd6FW1jIcS7u7Ng2F+fuci7GOuPRZdh3t9Uw72+q7LC26YthsunbbbHSiY0lOyEyBu3dtGM48lcm83/ACCbXewUQGAg9UDuTx7hRoRkYKCTUR8WCSMHG5pGVRUFO9s7pHtczGRhxByTjOPbkrhtcPMFMO9vqrnTDM0xM5WDV2modTRUEFXK5lNBO6WVjeRlaYpIy3Pl9/r7fisePZ/UZvzvi5JvETo5gYRhhEmYi3z8LCW8yc8umMLYGHe31TDvb6qNMHpdCcC31FK+qimE1vlon8SN2HufK55e4NcDz3cwCOfTHRVVPpmspNEVFo7xDU1BeZG7WcNrhvDth5knIGCSSTnmsuw72+qYd7fVBgc2g5Ja+eTvdI2F01TUMeKXFQXTMe0tfJu8TBvPLA5NaPJV+htHnSstdtrn1NPPFBFFG9vOERh2Wg55ty8kDyHLyWW4d7fVMO9vqgwKzaDmt8zSa2m4DK2KqZFFA4YDOJkbnOLue/1wMchzU266DbVUksVLPDA590+I5Yx0fLYWhmWODh1JyCs4w72+qYd7fVBZ7Vbp6W8VVTKWcJ9JT07dpJy6MyFx58/1wOfPkru7pj1XuHey9a3ByTkoIkREBERAREQEREBERAREQEREBERAREJAGSgIoNzvYJl3t9EEaKDLvb6Jl3t9EEaKDLvb6Jl3t9EEaKDLvZRNdnl0KD1ERAREQEREBERAREQEREBERAREQEREBERAREQFA/74Ua8eM8x1CCTUueyB7og0vAyN3RUNFO51Qxsc7ZmyAvfn9X5fUclcc55EH6LwNaCCGgEDA5eSMzTMzlj2u7jcLZZuPaHf96DjtZ3d0vEIaSG8vu5I6+Z5ZGcim1heLpR0NJLbqeeM94LZhwt75GBhOGABwyTjG7HpkZyssz8/omfn9EaYjq2+Xe3X6zw2uikqKHcH3B7Y922Nz2sbg56jc5xxnkz0OVYxqfVYuNwp5KFjIWfEH0tQad7mObE/bE14aC7PLPIeIEY6FbKz8/omfn9EGPaEuVZdbA2ouXE7wJHsLnwcLcAeRA8x74GfRZCfvNQn5/RetBJyeXsgiREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAWrrzBrv/NBklA6Y6WdV0u8CRo2sEZ4hAznaXHmOuQMLaKINYaudrf8AzTs01lpqt2mKfhR1TWSRhku8u3uILsnaC3y8kfb9bjtiG2pqjo5zhVF/FbtaREWmLGc4L8Hotnogwyji1OLHrAbni5Pqqk2kyuaQGbBwseQG7PIqz9jg1jG2ui1lT3Jv6KJ0clZUwyh0mDxAwMaC0Z8iTyI6c1stEGsOzE63/wAT346tp6xltqw6ajMskbm054jgI2hriRlhaefor12bWe+WqS/fH7ncq5prTFRd8ka/9A1oLXjaORcXOB/5RyCzVEGqrzBr49k9DHbnVI1IKnNViRnGMPEfkNcTt3Y2efRVumYNbN7IbnFenzHVJgqRSeNnFB2nhZcPDuz5/JbIRBhPZXHqiK13JuszIawVm2BznBwdEIoxuGOgLg849SVmyIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIgOcoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8b1PzXq8b1PzQeqTHMHTyxktBYQAPMjAP8AdTkwM5xzQUtJUmaWVhbgNPhOOo6f2SrqjBMxuzcHNPT15YCqkwgp4Z3PNPkAcRhcfbp+aggqnPfM1wZlnQA/1Kq8JgeiIo4at0kG8hu7e1hx0GSPzXs1U6OfYAzAIG0nxOz6KrwPRMBBSd6cKzglnhL9od6+HJVWmERRERAREQEREBERAREQEREBERAREQEREBERARF43qfmg9REyM4zzQETI9QmRjORhARCQOpTI9UBEyM9UzzQETI9eiZQEQkDzXhcAMk8kHqJkeqICIiAiIgIiICIiAiIgIiICIiAiIgLxvU/NeoBjKAqVlMW1z5y4EO6D05Af2VUiCjZSOEU7CG+PODn1JKd0c6kZC5zeTtxwB0z8lWIhhR1FGX4DNhaGbBvGdvuPdeVdG+Z25sm0hm3Prz55VaiJhTTU7n1UcrduG9c8ykNO9lVJMXg785H9FUoiqGOje1lQMt/SggfU/mqh8b+8NkZtI27SCfdTkRMJBgyajdtIkxgH5YUqWkLqaGNgaOGQSOgPIqsRFwpH0znVEUg2DaAD5/RVaIgIiICIiAiIgIiICIiAiIgIiICIiAmUXjep+aD1EUhtS11U6ANO5vU+XQH+6CeipmVsbhKcO/R9ffmR/ZRd5aI5XPY5pjGXNOMoJ6KSydrhGQP9QkDBB8if7KOOQPLwAfCdpQRopFRUtgkjY4El/THzA/uveOO8GHacgA58kE5FJhn4p5MeGnmHHGCvIaqOWQMbnJBPPywcIJ6KmbWMMD5drg1ny5r0VTTFG9rHOLzhrRjJ/t5IKhFIfUsYIy8Obvz1HTChfVNayFwa48UZCCpREQEREBERAREQEREBERAREQEREBeN6n5r1EBeNY1rnEDBccn3XqIJYgjAeAwYf8AeHr/ANZRsETY3MDBtd1HqpiIPCxpLSRzacj2ULYmNkc9oIc7rzP9FGiCB8THua57clvQ+n/WEMTDLxMHf0zkqNEEuOCON5cxgDj5r1kTGEFrcEAgfjzKjRBKbTxNY5gb4XdQSSvXQROjDCzwjmB6KYiCAQxgMAaMMGG+yhdBG5rAWnDBhuCRhTUQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQf//Z",
+              "timing": 2250,
+              "timestamp": 125066608405
+            },
+            {
+              "timestamp": 125066983405,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAAHAQAAAAAAAAAAAAAAAAIDBAUGBwgB/8QARRAAAQMDAgMGAwQIBAMJAQAAAQACAwQFEQYSEyExBxQiQVFhFXGRCDKB0SNCUlSSobHBFhczgjRy8BgkJzZidIOjs+H/xAAbAQEBAQADAQEAAAAAAAAAAAAAAQIDBAUGB//EADARAQABAwICCQMDBQAAAAAAAAABAgMRITEEEhMVUVJTYZGS0RQjoQVB4SIycYHw/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEXjnBrS5xAaBkk9Asei1xpWa4dxi1FaX1edoibVMJJ9OvX2QZEiEgDJPL1WOnXGlm1/cjqK0irzt4Xe2bs+nXr7IMiRAQQCDkHzVqvOobXZXsbdarujH4xNLG4RD5yY2j8SguqLAu2uq/8ACS/1NHPyNO1zJYn9QXN5ghXY6v09ZqSgprvfLdR1ToY/0c9Q1rubRzIJ5IMnRS6aohqoGT00sc0Mg3MkjcHNcPUEdVZbvrHTdnqxS3W+2ykqc44U1Sxrh8wTy/FBfkUqkqYKynZUUk0c8EgyySNwc1w9QR1U1AREQEREBERAREQEREBEXj3bWkoBcG9SAvBIw9HBWu5XGkt8BqLjVQ00OQ3iTPDG5PQZKoKPUtjrallPR3i3z1EhwyOOoY5zvkAUGSopFO8nwn8FPQEREBERBrftwnmfZ7HaGzPp6S8XWChq5GHaeC4kubnyzjCyOr0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3v1VZq7TtDqqxT2u5tdwZMOa9hw+J45te0+RBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHnjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fdo25W3GaB0q2x/CRYrf3LZswYW7umM7uu73zlRzaJskuiRpU0xFpbEImtB8TSDkPB/a3c8+qxpuidaMpPhzdfy/DQ3hhxt7DU7OmOLnrjzxlBZu0GqqdCdihp9O3iarMcraNlc54c+GNzyCNw82jwg9Qti6f05bLfpxlujiFRTzQhs75jxHVGRzc8n7xOVLt2jbJRaPbpkUjZrTwzG+ObxGTJyXOP7RPPPqqV2nrpbLKLPpivbTU2zhsqK17qiSnb0wxvLOPLc44QaVp55afsi7ULA2V81us1c+no3uOdsfEHgz7Y/mtz6J0pZqPSdJGaWmrnVdOySpqZmCR1U5zQS5xPUHPIeQVvHZnQU/ZrXaSoKmSPvoLp6yRu98khcCXuHLOcYSPR2o7TSdw0vqmOitobtjhqqEVDqceYjduHL0Ds4QYpp+rm0h/mjarIS6gs8XfKGL7wge+Jz3MHsCM4WU9lmkrHDoa21L6Olrqq407amrqp42yPnfINzskjmMnor1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93Uu9scgFjtFoLUOn2SUWkNW9xs5c50VJV0Tak0+TkhjiQcegOUEjs+hjsHafqzTdrGyzMhgro4Actp5H5Dmt9AeuFtBYzojSMGl4ayR9XPcLpXScasrp/vzO8hgcg0DkAOiyZAREQEREBERAREQEREBQTjMRUaHmgx3UYqTbT3IVxm3D/AILg8TH/AMvhx/NWKytu/wAUg70NRcHJ3d6FDw+h+9w/H9Fmz4SD4eYUIieT91B7AP0gVUoIowwe6jQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERUFbJVtrqdsLWmnIOTkjLvQ8jgY/n/ADCvRQSbzA7AxIWnGD5rG46a7Clpmyun3CQmQB+4gbRjnuBPPPny+SDJ0VnfS1jH3B8Es5c5o4IdJkAnrgHkD6KXA24RbX7Kp8LZsiOR7TIW7CDk5xjcQeqC+IrHBBc219C6R0nCZCwTHfkF+H7sjz57efyU/Fw+O8Tae47eFt3+eM78fPl/ZBdUVgjjuZppGyNnEjKfYCJBl8m7k4c+nTqquBleLJI1xd8Qw7JLgcuz+r5Aen80F0RY+Ke4yNYxjqhkXHB/TS+MN2OzktPTdjzU6opq41Fc+N8m0RbYBxTzdsx0zjr5lEXpFjbae6AUYkdPta6TiBryeWW7ee4E8s9foq+0MrWVlX3oTGIuyx0jhjqeQAJxyx6fJFXVERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERQTSxwxl8r2sYOpccBSZimMyI0VuN7twP8AxLf4T+SfG7d+8t/hP5Lq/X8L4tPuj5cnQ3O7PouKK3fG7d+8t/hP5J8bt37y3+E/knWHC+LT7o+Tobndn0XFFbvjdu/eW/wn8k+N2795b/CfyTrDhfFp90fJ0Nzuz6Liit3xu3fvLf4T+SfG7d+8t/hP5J1hwvi0+6Pk6G53Z9FxRW743bv3lv8ACfyT43bv3lv8J/JOsOF8Wn3R8nQ3O7PouKK3fG7d+8t/hP5KqpaynqgTTytkx1x5Ldvi7F2eW3XEz5TEpVbrpjNUTCeiIuwwIiICIiAiIgIiICIiAiIgIiICIiAsM1ZUvkuRgJPDiAwPcjOVmax/UVnkq5BUUuDLjDmk4z8l4v6/YvX+DmmxrOYzHbH/AGrtcHXRRdzW1F2g6vk0o23mKkjqTVOe3D5CzG0AgDAPM5xzwPdLlq91HrW2WHgU7W1lOyfiyzEHJc4bWgNIJ5ZGSAVmtTYZqnAqbeJtuQN8YdjPXqoX6efJPHNJbGumjADJHRAuaB0wfJfE27PLRFNfD1TOJzOu87T/AK/L1ZrzMzFcY07Gu9U9onwPVYs/cGva1sZdK+UtLt56MaGnPX+quN31fJb9c0NgbRxyMqWMcZTKWubuLxyGMHG31B58lmsthllmZNLbg+aP7j3Rgub8j5JJYZZJmzSW4PlbjD3RguGOnP8AE/Vai1TimPpqs4mJ31n9p/hOfWfuRv5bMNdq1w1obD3Vn+sI+JxOZaYeJu249fCp9Fe7nNrKqs81up46WGITd4bUZcWOJDfDjqS08s8llnwSo7xx+4Hj428TYN2PTPXCiFmqhKZRROEpAaX7OZHplcc2asYixP8Abjad+3+Gorj96438tuxhWjdWO1FWXeF0NPD3GUxbWSuc84c4ZcC0AA7fIlWfRPaO7Ut4o6F1sNNx4JJDIXkgOafut5DPhwc+62TBYJKd8j6e2iJ8nN7mRBpd88dV5Fp58JjMVsawxghhbEBtB6gei5JtU/144erXGN9NPzrqzFe33I89tWF6K1g7UlPdJXQU8JonFvDZK5z+Rd97LQBnbywT5+ig0JrOTVbK7bQinlpoYZNjn5y6QOOOnTwg59HLN6fT8lMZDT21sRk+/wAOIN3fPHXqVFBYZqcuNPbxEXAAlkYbkDkBy9Fm5Z5ufk4eqM4xvp2/5ytNeMZrjz21Yto293C9suDrjQQUfdag0w4U/E3Ob97yGB0x65WVUFS+kq45oyQWnnjzHmFFFZqqIO4VE5m5xc7azGSepPurrZ7DO+oZJVs4cTTnBPNyWuD4m9xMTYtzRrGNJxHnmSq7bptzFdWWYIiL9QeAIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIg09fPtA6Ws17uFrqbfen1FFUSU0jo4Yi0uY4tJGZAcZHosk7Pe1bTeu62WitLqqCtjZxOBVRhjnNHUjBIOM+q5Svl4qLB21Xy60dPHUz0l3rJWxSAlrsPfnIHljJ/BX/QtDTaYt931bSantM95joZTRUNI9xla942ue5rgMbWlxxg9PZEdl5HqmR6hcEW+hrL1bqi+TahMdyZUBhNVUtYcHHiL3PDvPoGnp1CyXtYtdwk0jpTUFfcaa6VLmSW+espZuKx+xxdHud5u2lwP/ACoO0sj1CZHquGviVXr7tDhuD4XTd3pGzyRu5gtp4A5wPs5zCP8AcrdSNuGrzdbtdL+4XCDEje8TNaHZJz4nPbtA8g0H5IZd7ZA6lMj1XDnaFU3OTROlIbpeaS7OgmrGRS09RxixmICGPd6gk/gQqTWQudkp9H1kd5rHyz2mKoh2u2d2G9wDGY8vDnPmSUHd2R6hMj1C4e09XS13braK2qf+lqLvBNIegy57Sf6qVYbtUWftZu1zoHZqKZ1ymiPUBwhmIOPP1Qy7myPVFwRQUtdqKir71Wagc25RStGaqoa0uzjxF7ngjr0a13TyXXHYdVXCp0BTNu11o7tUQSOiFTTT8YFowQ1zvNwzj5YRVPrftk0npC5yW6unqaqui/1YaOMPMZ9CSQM+2VBovto0lqy6RW6kmqqOtmOIo6yMM4h9AQSM+2Vx/XOfPric3f777i7vPE9TJ48/zVx1k2Cl7T7m3TYibBHcj3MUxG0Yf4duPLPTCI75yPUIuEaY1Mna1XU9Ndo7RJU3Cpp3Vshw2Fr3Pa458uRI8uvUdVlnZvf7toXtGudltl2F5t0UFSTwnl8MpjgdI17RkgEFoBx7jmiuwsj1TIHUrgmlbcNXm63a6X94uEGJG94ma3dknPic9u0DyDQfkrn2h1Nyk0TpSG6Xmkuz4JqxkUtPUcYsZiAhj3eoJP4EIjuPI9UyPVcr2bSF203oCPtIhvzpqqO0cOnp+Dgwte0RNw7d+qHbunULWdK6ao0Te7rPq4NrqiVkE1qlc50tWwOa4OJJ8jz/ANp588IrtDX+sbfojT5u91iqZqYSti20zWufl2ccnEDHL1WKO7WYrn2dVuqNLWO43A09V3TusjQ1+cNJedhd4QHD3/quV6C0w1fZbdrpJJKJ6G4wxxtBG0iRjt2eWf1BjmPNZXpGjoofs865rWVObjUVVNE+DiN8MccsRa4N68zK4E9OQRHTHZRq+46y07LX3ayy2maOYxBj92JBgHc3cAcc8fgs0yD0K4QtmqbtZOzKWgtVTNSsuFyk48sTi1xayKPDMjmAd38lV1wruzivsF2sGqoK+prIW1UsdLISIzyJjkGTkHOOfPkeQQdyZHqEyuI9KUlVfO3SelpK6e2VFVX1oE8QBfFlspOM+eMjPllUvZhfb9TOv1DaryaJ1RQPDXT1HDjD97MHc44a45LQ7lzd1QdzZHqEXA4s9VQVJl1RcbnZ6mbxU9Q6B0zJvU8Rr8+Y5gO6rtLsybI3QFiE1wZcnilbmrY9z2y/+oF2D9eaKyZERAREQahi7DbU3XlRqWa6VMzp6qapkpHxN2O4hduZnrjxEKXpXsEsWn9ROuLK+qq6V0c0LqOoY0tcyRhYQXDB6OW4kQaHqPs06ekr3yxXi5RUpdkQBrCWj0DiP6hZ3qLsvsl27PqfSNMX0NDTvbJDIwBz2uBJLjnqTl2fms9RBq/sw7HbXoO7Vdwhrp6+aeA04E0bWhjSQXdOucBY5efs36drbpLU0VzrqGnkdu7sxrXtZ6hpPPHzyt5og07f+wSwXGxWe1UVbVUMNvMzzIGtkfO+TZlzycc/AOig1N2D22/UlkglvVZCLXQtoWFsTTxGhznbj6HxLcqxztD1ONHaPuF9NL3vuoaRBxOHv3PDfvYOOueiDX1z+z/pyvu1HXPra+MxMhZNFGWhsxjaG56ZaXbeeCo9M9g9lsWrW3plwnqIQZgaKSJvDLJGPYWE9cAP/knZ523UurKa/wAlTafhz7VRurdneuLxWNzu/UbjHh9fvKR2Y9uQ1vq6nsbrB3AzRveJu+cXm1ucbdg9PVBQV32a9PTXCSamu9xpqVztwgDWu2j0Dj/fP4rb+ktOW7SlhprRZ4jHSQA43HLnE8y5x8ySpkmorLHJVRyXe3NfSs4lQ11SwGFv7Txnwj3KohrjShhdKNTWQxNcGuf3+LAJyQCd3U4P0KDCde9hum9W3eW6NmqrbWzHdMafBZI79otI5H5YyoNDdhOmtL3eG5yzVVzq4HB8PeNoZG4dHbQOZHuVsIaosDoaWYXu2GKryKd4qo9s2Dg7DnxYPI481V3O7W61RMludfSUcbzhr6iZsYJ9iSEHG2lNOQai7cqm1XWnldQ1dbXMedpGPBKQ4H1BAI9wF0d2b9kGn9DVU1ZTPqK6uljMRmqduGtPUNaByz55ysvqNVaepriLfUX21RV5c1opn1cbZMuwWjaTnJyMeuQqyuu1uoJ4IK6vpKaadwbFHNM1jpCTgBoJyT8kGmbz9m/TtbdJamiuddQ08jt3dmNa9rPUNJ54+eVcr/2CWC42Kz2qiraqhgt5meXhrZHzvk2Zc8nHPwDotk0eqLBW3L4dR3u11Fw3Ob3aKrjdLludw2g5yMHPphKjVOn6asNJU3y1xVYODDJVxteD/wApOUFNaNKUVDoin0vUk1lBHS90eZBgyMxg5x0/Baw/7OGmWx3BsdwuBdO0NgdJtcafxAkjAG4kDbz8iVtm66msNnmjiu16tlDLIziMZU1TIy5vTcA4jI5Hmp1DfbRcK51HQ3ShqaxsYmdBDUMe8MOMOLQc4O5vPpzHqg11pvsTslp0nedP1dZVV1Jc3xyOe5rWPiczO0tIzz5+atVu+z7aKC1XqihvVe4XKJkJe5jP0bWysk5DzOWAfit1og1Ha+wmwU2j6ywV1XVVkc9SKqOow1kkDw3b4eoxjqCqHS/2eNOWe7wV1bXVly4Dw9kEoayMkdNwHMj2yt1Ig1RYOxegs3aH/iyK7VUlR3map7u6NobmQPBGevLf/JWS0/ZzslG6rFRebhUQ1MJhc0MYwjxNcCDz6Fo8lvJEGhYfs0WBtS10t7ub4AecYawE/wC7H9luuw2mjsNmo7XbY+FR0sYjiaTkgD1PmVXogIiICIiAiIgIiICIiAtXfaWl4XZFdRn/AFJYGf8A2NP9ltFWLWmlrbrGyOtV5bM6kdI2QiJ+w5b05oOG9KUV3kpp5LMSBXSss8mPPjZIB+ew/RNI1lVYdVVElDI5tTDT1kTHs5EHgSNBHoc812fors205o+KojtNNI9s8scx7y/i7Xs3bXNyORG4qzWvsU0fbb7FdqeCsNVHKZQJJy5hJzkFuOY5nkiOSLM2w/4YvFTX3S40+oOTKSCFmY5mH7we76+Y/FUVN/5QuP8A76l//OoXY47FdDtnrpYrSYzVxuicBK4iMO6lgOdp9x08lRM7BtFMoZaQQ1/BllZK4d5OdzA4Dnj0e5BzBqmzQUfZ3oe6RyTvqLg2tbI17yWMEc+Ghg/VHicT6kqbqWuF11Lp2LVNZVR2qO30UZljG97ITE0uLQepyXf/ANXVFx7G9J3Cw2e0VMVYaO1cbuwbUEOHFcHPycc+YVReOyLR93tltoq63PeLfC2ngmbK5snDHRrnD734oOSKE0B7VLWLPWVVdbm3KmZTz1QxI5gewDI9sYHsByHRX2qFu1D2uX7/ADEvVXbIY5pwJmNLnMcx2GMHI4AHt5e66Rl7F9HP1BBd4qOeCpgfFJGyGYtjaYw0N8P+0Z9ea0x2y0N8PaDcKmfQsdwibMHU1YynmImYMY38N213pzGfIoNZaRrquk1ZXVtsqJpKplLXPjqOYef0EmX+oOMlU9ooLLW2SrnuV07pcmzNDA8ucHMOMnYGEuPX9Zv4rcH2eezy+O1s/Ud/tktDRQxy7WVEXD4z5GlpAYf1cOd5Y6BbSq+wfQlTXvqjb6iMPdvMMdQ5sfyA8h7AoOXO0B0fctNR092fdqeKgdHHUPgdFhomk8ADuZAORn8PJdQdjPZrbNMx0epaWsrp66422NsrZ3tLBvDHnGAD1aAOfRXLUvY9pDULqDvdHNDHQ04pYIqaUxtawOLunmcuPNZ3baOK3W6loqYOEFNEyGMOOTtaABk/IIKhERFEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEULyc7R+KCJFKdsY0ufgADJJUMT4pWkxkOA5dFOaM4zqYndPRUtTUUtLw+8zQw8R21nEeG7j6DPUqFlXRvrJKRlRTuqoxufCHgvaPUt6jqPqqKxFJhfFNEyWB7XxvG5r2HII9QQpjTnIPUIIkRQvOMAdSgiRSyGgEu+pUuKWGUkRua4j0RMqhFSVlVSUTGPrKiCnY92xrpXhgLvQZ815JV0cYnMlRTtFOAZi54HDyMjd6cvVFViKjiq6OZgfDUU8jCzihzXggs/a+XuvYqmkmpe8wzwSU2C7iteCzA6nPRBVoqM1lEJ5IDUU/GjbvfHvG5rfUjyHupkU1PMSIZIpCGhxDXA4B6H5HyQVCKijrqGRzmx1VM5zX8JwbI04f8Asn39lTC+WYxPlF0t5jjIa94qGYaTnAJzyzg/QoLsip4ZYJ25gkjkGA7LHA8iMg8vUKaDtPsgjREQEREBERAREQEREBQH7591GvHNygobpA+eANYzeefh/AgfzUqipnR1bpOAImHPpz5N9PkVccO9imHe31XWq4Wiq50s76fhuK5iOVi+rNMS3m4QVcEtDuZTyUro62l7wza8tJc0bhh3h9wVJj0lKNWvuzqqAQd6FW1jIcS7u7Ng2F+fuci7GOuPRZdh3t9Uw72+q7LC26YthsunbbbHSiY0lOyEyBu3dtGM48lcm83/ACCbXewUQGAg9UDuTx7hRoRkYKCTUR8WCSMHG5pGVRUFO9s7pHtczGRhxByTjOPbkrhtcPMFMO9vqrnTDM0xM5WDV2modTRUEFXK5lNBO6WVjeRlaYpIy3Pl9/r7fisePZ/UZvzvi5JvETo5gYRhhEmYi3z8LCW8yc8umMLYGHe31TDvb6qNMHpdCcC31FK+qimE1vlon8SN2HufK55e4NcDz3cwCOfTHRVVPpmspNEVFo7xDU1BeZG7WcNrhvDth5knIGCSSTnmsuw72+qYd7fVBgc2g5Ja+eTvdI2F01TUMeKXFQXTMe0tfJu8TBvPLA5NaPJV+htHnSstdtrn1NPPFBFFG9vOERh2Wg55ty8kDyHLyWW4d7fVMO9vqgwKzaDmt8zSa2m4DK2KqZFFA4YDOJkbnOLue/1wMchzU266DbVUksVLPDA590+I5Yx0fLYWhmWODh1JyCs4w72+qYd7fVBZ7Vbp6W8VVTKWcJ9JT07dpJy6MyFx58/1wOfPkru7pj1XuHey9a3ByTkoIkREBERAREQEREBERAREQEREBERAREJAGSgIoNzvYJl3t9EEaKDLvb6Jl3t9EEaKDLvb6Jl3t9EEaKDLvZRNdnl0KD1ERAREQEREBERAREQEREBERAREQEREBERAREQFA/74Ua8eM8x1CCTUueyB7og0vAyN3RUNFO51Qxsc7ZmyAvfn9X5fUclcc55EH6LwNaCCGgEDA5eSMzTMzlj2u7jcLZZuPaHf96DjtZ3d0vEIaSG8vu5I6+Z5ZGcim1heLpR0NJLbqeeM94LZhwt75GBhOGABwyTjG7HpkZyssz8/omfn9EaYjq2+Xe3X6zw2uikqKHcH3B7Y922Nz2sbg56jc5xxnkz0OVYxqfVYuNwp5KFjIWfEH0tQad7mObE/bE14aC7PLPIeIEY6FbKz8/omfn9EGPaEuVZdbA2ouXE7wJHsLnwcLcAeRA8x74GfRZCfvNQn5/RetBJyeXsgiREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAWrrzBrv/NBklA6Y6WdV0u8CRo2sEZ4hAznaXHmOuQMLaKINYaudrf8AzTs01lpqt2mKfhR1TWSRhku8u3uILsnaC3y8kfb9bjtiG2pqjo5zhVF/FbtaREWmLGc4L8Hotnogwyji1OLHrAbni5Pqqk2kyuaQGbBwseQG7PIqz9jg1jG2ui1lT3Jv6KJ0clZUwyh0mDxAwMaC0Z8iTyI6c1stEGsOzE63/wAT346tp6xltqw6ajMskbm054jgI2hriRlhaefor12bWe+WqS/fH7ncq5prTFRd8ka/9A1oLXjaORcXOB/5RyCzVEGqrzBr49k9DHbnVI1IKnNViRnGMPEfkNcTt3Y2efRVumYNbN7IbnFenzHVJgqRSeNnFB2nhZcPDuz5/JbIRBhPZXHqiK13JuszIawVm2BznBwdEIoxuGOgLg849SVmyIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIgOcoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8b1PzXq8b1PzQeqTHMHTyxktBYQAPMjAP8AdTkwM5xzQUtJUmaWVhbgNPhOOo6f2SrqjBMxuzcHNPT15YCqkwgp4Z3PNPkAcRhcfbp+aggqnPfM1wZlnQA/1Kq8JgeiIo4at0kG8hu7e1hx0GSPzXs1U6OfYAzAIG0nxOz6KrwPRMBBSd6cKzglnhL9od6+HJVWmERRERAREQEREBERAREQEREBERAREQEREBERARF43qfmg9REyM4zzQETI9QmRjORhARCQOpTI9UBEyM9UzzQETI9eiZQEQkDzXhcAMk8kHqJkeqICIiAiIgIiICIiAiIgIiICIiAiIgLxvU/NeoBjKAqVlMW1z5y4EO6D05Af2VUiCjZSOEU7CG+PODn1JKd0c6kZC5zeTtxwB0z8lWIhhR1FGX4DNhaGbBvGdvuPdeVdG+Z25sm0hm3Prz55VaiJhTTU7n1UcrduG9c8ykNO9lVJMXg785H9FUoiqGOje1lQMt/SggfU/mqh8b+8NkZtI27SCfdTkRMJBgyajdtIkxgH5YUqWkLqaGNgaOGQSOgPIqsRFwpH0znVEUg2DaAD5/RVaIgIiICIiAiIgIiICIiAiIgIiICIiAmUXjep+aD1EUhtS11U6ANO5vU+XQH+6CeipmVsbhKcO/R9ffmR/ZRd5aI5XPY5pjGXNOMoJ6KSydrhGQP9QkDBB8if7KOOQPLwAfCdpQRopFRUtgkjY4El/THzA/uveOO8GHacgA58kE5FJhn4p5MeGnmHHGCvIaqOWQMbnJBPPywcIJ6KmbWMMD5drg1ny5r0VTTFG9rHOLzhrRjJ/t5IKhFIfUsYIy8Obvz1HTChfVNayFwa48UZCCpREQEREBERAREQEREBERAREQEREBeN6n5r1EBeNY1rnEDBccn3XqIJYgjAeAwYf8AeHr/ANZRsETY3MDBtd1HqpiIPCxpLSRzacj2ULYmNkc9oIc7rzP9FGiCB8THua57clvQ+n/WEMTDLxMHf0zkqNEEuOCON5cxgDj5r1kTGEFrcEAgfjzKjRBKbTxNY5gb4XdQSSvXQROjDCzwjmB6KYiCAQxgMAaMMGG+yhdBG5rAWnDBhuCRhTUQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQf//Z",
+              "timing": 2625
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAAHAQAAAAAAAAAAAAAAAAIDBAUGBwgB/8QARRAAAQMDAgMGAwQIBAMJAQAAAQACAwQFEQYSEyExBxQiQVFhFXGRCDKB0SNCUlSSobHBFhczgjRy8BgkJzZidIOjs+H/xAAbAQEBAQADAQEAAAAAAAAAAAAAAQIDBAUGB//EADARAQABAwICCQMDBQAAAAAAAAABAgMRITEEEhMVUVJTYZGS0RQjoQVB4SIycYHw/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEXjnBrS5xAaBkk9Asei1xpWa4dxi1FaX1edoibVMJJ9OvX2QZEiEgDJPL1WOnXGlm1/cjqK0irzt4Xe2bs+nXr7IMiRAQQCDkHzVqvOobXZXsbdarujH4xNLG4RD5yY2j8SguqLAu2uq/8ACS/1NHPyNO1zJYn9QXN5ghXY6v09ZqSgprvfLdR1ToY/0c9Q1rubRzIJ5IMnRS6aohqoGT00sc0Mg3MkjcHNcPUEdVZbvrHTdnqxS3W+2ykqc44U1Sxrh8wTy/FBfkUqkqYKynZUUk0c8EgyySNwc1w9QR1U1AREQEREBERAREQEREBEXj3bWkoBcG9SAvBIw9HBWu5XGkt8BqLjVQ00OQ3iTPDG5PQZKoKPUtjrallPR3i3z1EhwyOOoY5zvkAUGSopFO8nwn8FPQEREBERBrftwnmfZ7HaGzPp6S8XWChq5GHaeC4kubnyzjCyOr0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3v1VZq7TtDqqxT2u5tdwZMOa9hw+J45te0+RBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHnjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fdo25W3GaB0q2x/CRYrf3LZswYW7umM7uu73zlRzaJskuiRpU0xFpbEImtB8TSDkPB/a3c8+qxpuidaMpPhzdfy/DQ3hhxt7DU7OmOLnrjzxlBZu0GqqdCdihp9O3iarMcraNlc54c+GNzyCNw82jwg9Qti6f05bLfpxlujiFRTzQhs75jxHVGRzc8n7xOVLt2jbJRaPbpkUjZrTwzG+ObxGTJyXOP7RPPPqqV2nrpbLKLPpivbTU2zhsqK17qiSnb0wxvLOPLc44QaVp55afsi7ULA2V81us1c+no3uOdsfEHgz7Y/mtz6J0pZqPSdJGaWmrnVdOySpqZmCR1U5zQS5xPUHPIeQVvHZnQU/ZrXaSoKmSPvoLp6yRu98khcCXuHLOcYSPR2o7TSdw0vqmOitobtjhqqEVDqceYjduHL0Ds4QYpp+rm0h/mjarIS6gs8XfKGL7wge+Jz3MHsCM4WU9lmkrHDoa21L6Olrqq407amrqp42yPnfINzskjmMnor1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93Uu9scgFjtFoLUOn2SUWkNW9xs5c50VJV0Tak0+TkhjiQcegOUEjs+hjsHafqzTdrGyzMhgro4Actp5H5Dmt9AeuFtBYzojSMGl4ayR9XPcLpXScasrp/vzO8hgcg0DkAOiyZAREQEREBERAREQEREBQTjMRUaHmgx3UYqTbT3IVxm3D/AILg8TH/AMvhx/NWKytu/wAUg70NRcHJ3d6FDw+h+9w/H9Fmz4SD4eYUIieT91B7AP0gVUoIowwe6jQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERUFbJVtrqdsLWmnIOTkjLvQ8jgY/n/ADCvRQSbzA7AxIWnGD5rG46a7Clpmyun3CQmQB+4gbRjnuBPPPny+SDJ0VnfS1jH3B8Es5c5o4IdJkAnrgHkD6KXA24RbX7Kp8LZsiOR7TIW7CDk5xjcQeqC+IrHBBc219C6R0nCZCwTHfkF+H7sjz57efyU/Fw+O8Tae47eFt3+eM78fPl/ZBdUVgjjuZppGyNnEjKfYCJBl8m7k4c+nTqquBleLJI1xd8Qw7JLgcuz+r5Aen80F0RY+Ke4yNYxjqhkXHB/TS+MN2OzktPTdjzU6opq41Fc+N8m0RbYBxTzdsx0zjr5lEXpFjbae6AUYkdPta6TiBryeWW7ee4E8s9foq+0MrWVlX3oTGIuyx0jhjqeQAJxyx6fJFXVERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERQTSxwxl8r2sYOpccBSZimMyI0VuN7twP8AxLf4T+SfG7d+8t/hP5Lq/X8L4tPuj5cnQ3O7PouKK3fG7d+8t/hP5J8bt37y3+E/knWHC+LT7o+Tobndn0XFFbvjdu/eW/wn8k+N2795b/CfyTrDhfFp90fJ0Nzuz6Liit3xu3fvLf4T+SfG7d+8t/hP5J1hwvi0+6Pk6G53Z9FxRW743bv3lv8ACfyT43bv3lv8J/JOsOF8Wn3R8nQ3O7PouKK3fG7d+8t/hP5KqpaynqgTTytkx1x5Ldvi7F2eW3XEz5TEpVbrpjNUTCeiIuwwIiICIiAiIgIiICIiAiIgIiICIiAsM1ZUvkuRgJPDiAwPcjOVmax/UVnkq5BUUuDLjDmk4z8l4v6/YvX+DmmxrOYzHbH/AGrtcHXRRdzW1F2g6vk0o23mKkjqTVOe3D5CzG0AgDAPM5xzwPdLlq91HrW2WHgU7W1lOyfiyzEHJc4bWgNIJ5ZGSAVmtTYZqnAqbeJtuQN8YdjPXqoX6efJPHNJbGumjADJHRAuaB0wfJfE27PLRFNfD1TOJzOu87T/AK/L1ZrzMzFcY07Gu9U9onwPVYs/cGva1sZdK+UtLt56MaGnPX+quN31fJb9c0NgbRxyMqWMcZTKWubuLxyGMHG31B58lmsthllmZNLbg+aP7j3Rgub8j5JJYZZJmzSW4PlbjD3RguGOnP8AE/Vai1TimPpqs4mJ31n9p/hOfWfuRv5bMNdq1w1obD3Vn+sI+JxOZaYeJu249fCp9Fe7nNrKqs81up46WGITd4bUZcWOJDfDjqS08s8llnwSo7xx+4Hj428TYN2PTPXCiFmqhKZRROEpAaX7OZHplcc2asYixP8Abjad+3+Gorj96438tuxhWjdWO1FWXeF0NPD3GUxbWSuc84c4ZcC0AA7fIlWfRPaO7Ut4o6F1sNNx4JJDIXkgOafut5DPhwc+62TBYJKd8j6e2iJ8nN7mRBpd88dV5Fp58JjMVsawxghhbEBtB6gei5JtU/144erXGN9NPzrqzFe33I89tWF6K1g7UlPdJXQU8JonFvDZK5z+Rd97LQBnbywT5+ig0JrOTVbK7bQinlpoYZNjn5y6QOOOnTwg59HLN6fT8lMZDT21sRk+/wAOIN3fPHXqVFBYZqcuNPbxEXAAlkYbkDkBy9Fm5Z5ufk4eqM4xvp2/5ytNeMZrjz21Yto293C9suDrjQQUfdag0w4U/E3Ob97yGB0x65WVUFS+kq45oyQWnnjzHmFFFZqqIO4VE5m5xc7azGSepPurrZ7DO+oZJVs4cTTnBPNyWuD4m9xMTYtzRrGNJxHnmSq7bptzFdWWYIiL9QeAIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIg09fPtA6Ws17uFrqbfen1FFUSU0jo4Yi0uY4tJGZAcZHosk7Pe1bTeu62WitLqqCtjZxOBVRhjnNHUjBIOM+q5Svl4qLB21Xy60dPHUz0l3rJWxSAlrsPfnIHljJ/BX/QtDTaYt931bSantM95joZTRUNI9xla942ue5rgMbWlxxg9PZEdl5HqmR6hcEW+hrL1bqi+TahMdyZUBhNVUtYcHHiL3PDvPoGnp1CyXtYtdwk0jpTUFfcaa6VLmSW+espZuKx+xxdHud5u2lwP/ACoO0sj1CZHquGviVXr7tDhuD4XTd3pGzyRu5gtp4A5wPs5zCP8AcrdSNuGrzdbtdL+4XCDEje8TNaHZJz4nPbtA8g0H5IZd7ZA6lMj1XDnaFU3OTROlIbpeaS7OgmrGRS09RxixmICGPd6gk/gQqTWQudkp9H1kd5rHyz2mKoh2u2d2G9wDGY8vDnPmSUHd2R6hMj1C4e09XS13braK2qf+lqLvBNIegy57Sf6qVYbtUWftZu1zoHZqKZ1ymiPUBwhmIOPP1Qy7myPVFwRQUtdqKir71Wagc25RStGaqoa0uzjxF7ngjr0a13TyXXHYdVXCp0BTNu11o7tUQSOiFTTT8YFowQ1zvNwzj5YRVPrftk0npC5yW6unqaqui/1YaOMPMZ9CSQM+2VBovto0lqy6RW6kmqqOtmOIo6yMM4h9AQSM+2Vx/XOfPric3f777i7vPE9TJ48/zVx1k2Cl7T7m3TYibBHcj3MUxG0Yf4duPLPTCI75yPUIuEaY1Mna1XU9Ndo7RJU3Cpp3Vshw2Fr3Pa458uRI8uvUdVlnZvf7toXtGudltl2F5t0UFSTwnl8MpjgdI17RkgEFoBx7jmiuwsj1TIHUrgmlbcNXm63a6X94uEGJG94ma3dknPic9u0DyDQfkrn2h1Nyk0TpSG6Xmkuz4JqxkUtPUcYsZiAhj3eoJP4EIjuPI9UyPVcr2bSF203oCPtIhvzpqqO0cOnp+Dgwte0RNw7d+qHbunULWdK6ao0Te7rPq4NrqiVkE1qlc50tWwOa4OJJ8jz/ANp588IrtDX+sbfojT5u91iqZqYSti20zWufl2ccnEDHL1WKO7WYrn2dVuqNLWO43A09V3TusjQ1+cNJedhd4QHD3/quV6C0w1fZbdrpJJKJ6G4wxxtBG0iRjt2eWf1BjmPNZXpGjoofs865rWVObjUVVNE+DiN8MccsRa4N68zK4E9OQRHTHZRq+46y07LX3ayy2maOYxBj92JBgHc3cAcc8fgs0yD0K4QtmqbtZOzKWgtVTNSsuFyk48sTi1xayKPDMjmAd38lV1wruzivsF2sGqoK+prIW1UsdLISIzyJjkGTkHOOfPkeQQdyZHqEyuI9KUlVfO3SelpK6e2VFVX1oE8QBfFlspOM+eMjPllUvZhfb9TOv1DaryaJ1RQPDXT1HDjD97MHc44a45LQ7lzd1QdzZHqEXA4s9VQVJl1RcbnZ6mbxU9Q6B0zJvU8Rr8+Y5gO6rtLsybI3QFiE1wZcnilbmrY9z2y/+oF2D9eaKyZERAREQahi7DbU3XlRqWa6VMzp6qapkpHxN2O4hduZnrjxEKXpXsEsWn9ROuLK+qq6V0c0LqOoY0tcyRhYQXDB6OW4kQaHqPs06ekr3yxXi5RUpdkQBrCWj0DiP6hZ3qLsvsl27PqfSNMX0NDTvbJDIwBz2uBJLjnqTl2fms9RBq/sw7HbXoO7Vdwhrp6+aeA04E0bWhjSQXdOucBY5efs36drbpLU0VzrqGnkdu7sxrXtZ6hpPPHzyt5og07f+wSwXGxWe1UVbVUMNvMzzIGtkfO+TZlzycc/AOig1N2D22/UlkglvVZCLXQtoWFsTTxGhznbj6HxLcqxztD1ONHaPuF9NL3vuoaRBxOHv3PDfvYOOueiDX1z+z/pyvu1HXPra+MxMhZNFGWhsxjaG56ZaXbeeCo9M9g9lsWrW3plwnqIQZgaKSJvDLJGPYWE9cAP/knZ523UurKa/wAlTafhz7VRurdneuLxWNzu/UbjHh9fvKR2Y9uQ1vq6nsbrB3AzRveJu+cXm1ucbdg9PVBQV32a9PTXCSamu9xpqVztwgDWu2j0Dj/fP4rb+ktOW7SlhprRZ4jHSQA43HLnE8y5x8ySpkmorLHJVRyXe3NfSs4lQ11SwGFv7Txnwj3KohrjShhdKNTWQxNcGuf3+LAJyQCd3U4P0KDCde9hum9W3eW6NmqrbWzHdMafBZI79otI5H5YyoNDdhOmtL3eG5yzVVzq4HB8PeNoZG4dHbQOZHuVsIaosDoaWYXu2GKryKd4qo9s2Dg7DnxYPI481V3O7W61RMludfSUcbzhr6iZsYJ9iSEHG2lNOQai7cqm1XWnldQ1dbXMedpGPBKQ4H1BAI9wF0d2b9kGn9DVU1ZTPqK6uljMRmqduGtPUNaByz55ysvqNVaepriLfUX21RV5c1opn1cbZMuwWjaTnJyMeuQqyuu1uoJ4IK6vpKaadwbFHNM1jpCTgBoJyT8kGmbz9m/TtbdJamiuddQ08jt3dmNa9rPUNJ54+eVcr/2CWC42Kz2qiraqhgt5meXhrZHzvk2Zc8nHPwDotk0eqLBW3L4dR3u11Fw3Ob3aKrjdLludw2g5yMHPphKjVOn6asNJU3y1xVYODDJVxteD/wApOUFNaNKUVDoin0vUk1lBHS90eZBgyMxg5x0/Baw/7OGmWx3BsdwuBdO0NgdJtcafxAkjAG4kDbz8iVtm66msNnmjiu16tlDLIziMZU1TIy5vTcA4jI5Hmp1DfbRcK51HQ3ShqaxsYmdBDUMe8MOMOLQc4O5vPpzHqg11pvsTslp0nedP1dZVV1Jc3xyOe5rWPiczO0tIzz5+atVu+z7aKC1XqihvVe4XKJkJe5jP0bWysk5DzOWAfit1og1Ha+wmwU2j6ywV1XVVkc9SKqOow1kkDw3b4eoxjqCqHS/2eNOWe7wV1bXVly4Dw9kEoayMkdNwHMj2yt1Ig1RYOxegs3aH/iyK7VUlR3map7u6NobmQPBGevLf/JWS0/ZzslG6rFRebhUQ1MJhc0MYwjxNcCDz6Fo8lvJEGhYfs0WBtS10t7ub4AecYawE/wC7H9luuw2mjsNmo7XbY+FR0sYjiaTkgD1PmVXogIiICIiAiIgIiICIiAtXfaWl4XZFdRn/AFJYGf8A2NP9ltFWLWmlrbrGyOtV5bM6kdI2QiJ+w5b05oOG9KUV3kpp5LMSBXSss8mPPjZIB+ew/RNI1lVYdVVElDI5tTDT1kTHs5EHgSNBHoc812fors205o+KojtNNI9s8scx7y/i7Xs3bXNyORG4qzWvsU0fbb7FdqeCsNVHKZQJJy5hJzkFuOY5nkiOSLM2w/4YvFTX3S40+oOTKSCFmY5mH7we76+Y/FUVN/5QuP8A76l//OoXY47FdDtnrpYrSYzVxuicBK4iMO6lgOdp9x08lRM7BtFMoZaQQ1/BllZK4d5OdzA4Dnj0e5BzBqmzQUfZ3oe6RyTvqLg2tbI17yWMEc+Ghg/VHicT6kqbqWuF11Lp2LVNZVR2qO30UZljG97ITE0uLQepyXf/ANXVFx7G9J3Cw2e0VMVYaO1cbuwbUEOHFcHPycc+YVReOyLR93tltoq63PeLfC2ngmbK5snDHRrnD734oOSKE0B7VLWLPWVVdbm3KmZTz1QxI5gewDI9sYHsByHRX2qFu1D2uX7/ADEvVXbIY5pwJmNLnMcx2GMHI4AHt5e66Rl7F9HP1BBd4qOeCpgfFJGyGYtjaYw0N8P+0Z9ea0x2y0N8PaDcKmfQsdwibMHU1YynmImYMY38N213pzGfIoNZaRrquk1ZXVtsqJpKplLXPjqOYef0EmX+oOMlU9ooLLW2SrnuV07pcmzNDA8ucHMOMnYGEuPX9Zv4rcH2eezy+O1s/Ud/tktDRQxy7WVEXD4z5GlpAYf1cOd5Y6BbSq+wfQlTXvqjb6iMPdvMMdQ5sfyA8h7AoOXO0B0fctNR092fdqeKgdHHUPgdFhomk8ADuZAORn8PJdQdjPZrbNMx0epaWsrp66422NsrZ3tLBvDHnGAD1aAOfRXLUvY9pDULqDvdHNDHQ04pYIqaUxtawOLunmcuPNZ3baOK3W6loqYOEFNEyGMOOTtaABk/IIKhERFEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEULyc7R+KCJFKdsY0ufgADJJUMT4pWkxkOA5dFOaM4zqYndPRUtTUUtLw+8zQw8R21nEeG7j6DPUqFlXRvrJKRlRTuqoxufCHgvaPUt6jqPqqKxFJhfFNEyWB7XxvG5r2HII9QQpjTnIPUIIkRQvOMAdSgiRSyGgEu+pUuKWGUkRua4j0RMqhFSVlVSUTGPrKiCnY92xrpXhgLvQZ815JV0cYnMlRTtFOAZi54HDyMjd6cvVFViKjiq6OZgfDUU8jCzihzXggs/a+XuvYqmkmpe8wzwSU2C7iteCzA6nPRBVoqM1lEJ5IDUU/GjbvfHvG5rfUjyHupkU1PMSIZIpCGhxDXA4B6H5HyQVCKijrqGRzmx1VM5zX8JwbI04f8Asn39lTC+WYxPlF0t5jjIa94qGYaTnAJzyzg/QoLsip4ZYJ25gkjkGA7LHA8iMg8vUKaDtPsgjREQEREBERAREQEREBQH7591GvHNygobpA+eANYzeefh/AgfzUqipnR1bpOAImHPpz5N9PkVccO9imHe31XWq4Wiq50s76fhuK5iOVi+rNMS3m4QVcEtDuZTyUro62l7wza8tJc0bhh3h9wVJj0lKNWvuzqqAQd6FW1jIcS7u7Ng2F+fuci7GOuPRZdh3t9Uw72+q7LC26YthsunbbbHSiY0lOyEyBu3dtGM48lcm83/ACCbXewUQGAg9UDuTx7hRoRkYKCTUR8WCSMHG5pGVRUFO9s7pHtczGRhxByTjOPbkrhtcPMFMO9vqrnTDM0xM5WDV2modTRUEFXK5lNBO6WVjeRlaYpIy3Pl9/r7fisePZ/UZvzvi5JvETo5gYRhhEmYi3z8LCW8yc8umMLYGHe31TDvb6qNMHpdCcC31FK+qimE1vlon8SN2HufK55e4NcDz3cwCOfTHRVVPpmspNEVFo7xDU1BeZG7WcNrhvDth5knIGCSSTnmsuw72+qYd7fVBgc2g5Ja+eTvdI2F01TUMeKXFQXTMe0tfJu8TBvPLA5NaPJV+htHnSstdtrn1NPPFBFFG9vOERh2Wg55ty8kDyHLyWW4d7fVMO9vqgwKzaDmt8zSa2m4DK2KqZFFA4YDOJkbnOLue/1wMchzU266DbVUksVLPDA590+I5Yx0fLYWhmWODh1JyCs4w72+qYd7fVBZ7Vbp6W8VVTKWcJ9JT07dpJy6MyFx58/1wOfPkru7pj1XuHey9a3ByTkoIkREBERAREQEREBERAREQEREBERAREJAGSgIoNzvYJl3t9EEaKDLvb6Jl3t9EEaKDLvb6Jl3t9EEaKDLvZRNdnl0KD1ERAREQEREBERAREQEREBERAREQEREBERAREQFA/74Ua8eM8x1CCTUueyB7og0vAyN3RUNFO51Qxsc7ZmyAvfn9X5fUclcc55EH6LwNaCCGgEDA5eSMzTMzlj2u7jcLZZuPaHf96DjtZ3d0vEIaSG8vu5I6+Z5ZGcim1heLpR0NJLbqeeM94LZhwt75GBhOGABwyTjG7HpkZyssz8/omfn9EaYjq2+Xe3X6zw2uikqKHcH3B7Y922Nz2sbg56jc5xxnkz0OVYxqfVYuNwp5KFjIWfEH0tQad7mObE/bE14aC7PLPIeIEY6FbKz8/omfn9EGPaEuVZdbA2ouXE7wJHsLnwcLcAeRA8x74GfRZCfvNQn5/RetBJyeXsgiREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAWrrzBrv/NBklA6Y6WdV0u8CRo2sEZ4hAznaXHmOuQMLaKINYaudrf8AzTs01lpqt2mKfhR1TWSRhku8u3uILsnaC3y8kfb9bjtiG2pqjo5zhVF/FbtaREWmLGc4L8Hotnogwyji1OLHrAbni5Pqqk2kyuaQGbBwseQG7PIqz9jg1jG2ui1lT3Jv6KJ0clZUwyh0mDxAwMaC0Z8iTyI6c1stEGsOzE63/wAT346tp6xltqw6ajMskbm054jgI2hriRlhaefor12bWe+WqS/fH7ncq5prTFRd8ka/9A1oLXjaORcXOB/5RyCzVEGqrzBr49k9DHbnVI1IKnNViRnGMPEfkNcTt3Y2efRVumYNbN7IbnFenzHVJgqRSeNnFB2nhZcPDuz5/JbIRBhPZXHqiK13JuszIawVm2BznBwdEIoxuGOgLg849SVmyIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIgOcoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8b1PzXq8b1PzQeqTHMHTyxktBYQAPMjAP8AdTkwM5xzQUtJUmaWVhbgNPhOOo6f2SrqjBMxuzcHNPT15YCqkwgp4Z3PNPkAcRhcfbp+aggqnPfM1wZlnQA/1Kq8JgeiIo4at0kG8hu7e1hx0GSPzXs1U6OfYAzAIG0nxOz6KrwPRMBBSd6cKzglnhL9od6+HJVWmERRERAREQEREBERAREQEREBERAREQEREBERARF43qfmg9REyM4zzQETI9QmRjORhARCQOpTI9UBEyM9UzzQETI9eiZQEQkDzXhcAMk8kHqJkeqICIiAiIgIiICIiAiIgIiICIiAiIgLxvU/NeoBjKAqVlMW1z5y4EO6D05Af2VUiCjZSOEU7CG+PODn1JKd0c6kZC5zeTtxwB0z8lWIhhR1FGX4DNhaGbBvGdvuPdeVdG+Z25sm0hm3Prz55VaiJhTTU7n1UcrduG9c8ykNO9lVJMXg785H9FUoiqGOje1lQMt/SggfU/mqh8b+8NkZtI27SCfdTkRMJBgyajdtIkxgH5YUqWkLqaGNgaOGQSOgPIqsRFwpH0znVEUg2DaAD5/RVaIgIiICIiAiIgIiICIiAiIgIiICIiAmUXjep+aD1EUhtS11U6ANO5vU+XQH+6CeipmVsbhKcO/R9ffmR/ZRd5aI5XPY5pjGXNOMoJ6KSydrhGQP9QkDBB8if7KOOQPLwAfCdpQRopFRUtgkjY4El/THzA/uveOO8GHacgA58kE5FJhn4p5MeGnmHHGCvIaqOWQMbnJBPPywcIJ6KmbWMMD5drg1ny5r0VTTFG9rHOLzhrRjJ/t5IKhFIfUsYIy8Obvz1HTChfVNayFwa48UZCCpREQEREBERAREQEREBERAREQEREBeN6n5r1EBeNY1rnEDBccn3XqIJYgjAeAwYf8AeHr/ANZRsETY3MDBtd1HqpiIPCxpLSRzacj2ULYmNkc9oIc7rzP9FGiCB8THua57clvQ+n/WEMTDLxMHf0zkqNEEuOCON5cxgDj5r1kTGEFrcEAgfjzKjRBKbTxNY5gb4XdQSSvXQROjDCzwjmB6KYiCAQxgMAaMMGG+yhdBG5rAWnDBhuCRhTUQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQf//Z",
+              "timing": 3000,
+              "timestamp": 125067358405
+            }
+          ],
+          "scale": 3000,
+          "type": "filmstrip"
+        }
+      },
+      "unused-javascript": {
+        "id": "unused-javascript",
+        "title": "Reduce unused JavaScript",
+        "description": "Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 465 KiB",
+        "metricSavings": {
+          "LCP": 1500,
+          "FCP": 300
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "URL",
+              "subItemsHeading": {
+                "key": "source",
+                "valueType": "code"
+              },
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Transfer Size",
+              "subItemsHeading": {
+                "key": "sourceBytes"
+              },
+              "valueType": "bytes",
+              "key": "totalBytes"
+            },
+            {
+              "subItemsHeading": {
+                "key": "sourceWastedBytes"
+              },
+              "label": "Est Savings",
+              "valueType": "bytes",
+              "key": "wastedBytes"
+            }
+          ],
+          "overallSavingsBytes": 476077,
+          "overallSavingsMs": 1500,
+          "type": "opportunity",
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [
+            {
+              "totalBytes": 196254,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedBytes": 112596,
+              "wastedPercent": 57.372344479375059
+            },
+            {
+              "totalBytes": 156346,
+              "wastedBytes": 111379,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedPercent": 71.238597391689808
+            },
+            {
+              "wastedPercent": 42.2154629213789,
+              "totalBytes": 196254,
+              "wastedBytes": 82850,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedBytes": 67603,
+              "totalBytes": 156346,
+              "wastedPercent": 43.239666336509771
+            },
+            {
+              "wastedPercent": 60.424703464686161,
+              "wastedBytes": 30083,
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "totalBytes": 49786
+            },
+            {
+              "wastedPercent": 62.498279737602644,
+              "wastedBytes": 26614,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "totalBytes": 42584
+            },
+            {
+              "wastedPercent": 56.002711648123778,
+              "totalBytes": 43332,
+              "wastedBytes": 24267,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            },
+            {
+              "wastedPercent": 75.1296024165238,
+              "totalBytes": 27533,
+              "wastedBytes": 20685,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            }
+          ],
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 1500,
+              "FCP": 300
+            }
+          }
+        },
+        "numericValue": 1500,
+        "numericUnit": "millisecond"
+      },
+      "image-delivery-insight": {
+        "id": "image-delivery-insight",
+        "title": "Improve image delivery",
+        "description": "Reducing the download time of images can improve the perceived load time of the page and LCP. [Learn more about optimizing image size](https://developer.chrome.com/docs/performance/insights/image-delivery)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 2,488 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "node": {
+                "type": "node",
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,1,DIV,1,DIV,1,ARTICLE,2,DIV,0,DIV,0,DIV,0,DIV,1,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/aude-…\" alt=\"Aude Cadiot\" width=\"100\" height=\"100\" class=\"d_flex ai_center jc_center flex_0_0_auto w_100px h_100px bdr_9999px obj-f_…\"\u003e",
+                "nodeLabel": "Aude Cadiot",
+                "lhId": "page-5-IMG",
+                "boundingRect": {
+                  "width": 100,
+                  "right": 149,
+                  "height": 100,
+                  "left": 49,
+                  "top": 5377,
+                  "bottom": 5477
+                },
+                "selector": "div.card \u003e div.d_flex \u003e div.group \u003e img.d_flex"
+              },
+              "subItems": {
+                "items": [
+                  {
+                    "reason": "This image file is larger than it needs to be (4284x4263) for its displayed dimensions (175x233). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 2521521
+                  }
+                ],
+                "type": "subitems"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/aude-cadiot.jpg",
+              "wastedBytes": 2521521,
+              "totalBytes": 2527172
+            },
+            {
+              "wastedBytes": 16208,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "totalBytes": 16667,
+              "node": {
+                "boundingRect": {
+                  "height": 0,
+                  "right": 0,
+                  "width": 0,
+                  "bottom": 0,
+                  "top": 0,
+                  "left": 0
+                },
+                "selector": "body \u003e div#ago-wrapper \u003e button#ago-chat-button \u003e img#open-path",
+                "lhId": "page-6-IMG",
+                "nodeLabel": "Chat",
+                "path": "1,BODY,61,DIV,1,BUTTON,0,IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"https://www.ocobo.co/android-chrome-192x192.png\" alt=\"Chat\" id=\"open-path\" style=\"width: 32px; height: 32px; object-fit: contain;\"\u003e"
+              },
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 10523,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 15421,
+                    "reason": "This image file is larger than it needs to be (192x192) for its displayed dimensions (53x53). Use responsive images to reduce the image download size."
+                  }
+                ]
+              }
+            },
+            {
+              "wastedBytes": 9533,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "totalBytes": 12266,
+              "node": {
+                "nodeLabel": "Ocobo",
+                "path": "2,HTML,1,BODY,0,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "boundingRect": {
+                  "left": 33,
+                  "top": 37,
+                  "bottom": 77,
+                  "width": 134,
+                  "right": 167,
+                  "height": 40
+                },
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "lhId": "page-7-IMG"
+              },
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 6234,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "reason": "This image file is larger than it needs to be (348x104) for its displayed dimensions (234x70). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 6709
+                  }
+                ],
+                "type": "subitems"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "valueType": "url",
+              "key": "url",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "reason"
+              },
+              "label": "URL"
+            },
+            {
+              "label": "Resource Size",
+              "valueType": "bytes",
+              "key": "totalBytes"
+            },
+            {
+              "subItemsHeading": {
+                "valueType": "bytes",
+                "key": "wastedBytes"
+              },
+              "label": "Est Savings",
+              "valueType": "bytes",
+              "key": "wastedBytes"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "type": "debugdata",
+            "wastedBytes": 2547262
+          }
+        }
+      },
+      "forced-reflow-insight": {
+        "id": "forced-reflow-insight",
+        "title": "Forced reflow",
+        "description": "A forced reflow occurs when JavaScript queries geometric properties (such as offsetWidth) after styles have been invalidated by a change to the DOM state. This can result in poor performance. Learn more about [forced reflows](https://developer.chrome.com/docs/performance/insights/forced-reflow) and possible mitigations.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "details": {
+          "items": [
+            {
+              "items": [
+                {
+                  "reflowTime": 14.05,
+                  "source": {
+                    "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+                    "urlProvider": "network",
+                    "line": 16,
+                    "column": 61324,
+                    "type": "source-location"
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "valueType": "source-location",
+                  "key": "source",
+                  "label": "Top function call"
+                },
+                {
+                  "label": "Total reflow time",
+                  "key": "reflowTime",
+                  "valueType": "ms",
+                  "granularity": 1
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "type": "table",
+              "items": [
+                {
+                  "reflowTime": 87.269,
+                  "source": {
+                    "type": "text",
+                    "value": "[unattributed]"
+                  }
+                },
+                {
+                  "reflowTime": 1.061,
+                  "source": {
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+                    "urlProvider": "network",
+                    "line": 19,
+                    "column": 85503,
+                    "type": "source-location"
+                  }
+                },
+                {
+                  "reflowTime": 0.519,
+                  "source": {
+                    "column": 100773,
+                    "line": 19,
+                    "urlProvider": "network",
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+                    "type": "source-location"
+                  }
+                },
+                {
+                  "reflowTime": 0.192,
+                  "source": {
+                    "type": "source-location",
+                    "line": 0,
+                    "column": 6803,
+                    "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+                    "urlProvider": "network"
+                  }
+                },
+                {
+                  "reflowTime": 14.05,
+                  "source": {
+                    "type": "source-location",
+                    "urlProvider": "network",
+                    "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+                    "column": 61343,
+                    "line": 15
+                  }
+                },
+                {
+                  "reflowTime": 0.632,
+                  "source": {
+                    "column": 85503,
+                    "line": 19,
+                    "urlProvider": "network",
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+                    "type": "source-location"
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "label": "Source",
+                  "valueType": "source-location",
+                  "key": "source"
+                },
+                {
+                  "granularity": 1,
+                  "label": "Total reflow time",
+                  "valueType": "ms",
+                  "key": "reflowTime"
+                }
+              ]
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "network-dependency-tree-insight": {
+        "id": "network-dependency-tree-insight",
+        "title": "Network dependency tree",
+        "description": "[Avoid chaining critical requests](https://developer.chrome.com/docs/performance/insights/network-dependency-tree) by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "type": "list-section",
+              "value": {
+                "longestChain": {
+                  "duration": 546
+                },
+                "chains": {
+                  "0C79FB609D4C65A20A8834A3DDEE3A5B": {
+                    "children": {
+                      "53.2": {
+                        "children": {
+                          "53.70": {
+                            "navStartToEndTime": 543,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                            "children": {},
+                            "transferSize": 39127
+                          },
+                          "53.65": {
+                            "children": {},
+                            "transferSize": 31975,
+                            "navStartToEndTime": 545,
+                            "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff"
+                          },
+                          "53.68": {
+                            "isLongest": true,
+                            "transferSize": 38779,
+                            "navStartToEndTime": 546,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                            "children": {}
+                          },
+                          "53.69": {
+                            "transferSize": 40711,
+                            "children": {},
+                            "navStartToEndTime": 544,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf"
+                          }
+                        },
+                        "navStartToEndTime": 431,
+                        "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                        "transferSize": 24570,
+                        "isLongest": true
+                      }
+                    },
+                    "navStartToEndTime": 409,
+                    "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                    "transferSize": 18220,
+                    "isLongest": true
+                  }
+                },
+                "type": "network-tree"
+              }
+            },
+            {
+              "type": "list-section",
+              "description": "[preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints help the browser establish a connection earlier in the page load, saving time when the first request for that origin is made. The following are the origins that the page preconnected to.",
+              "value": {
+                "type": "table",
+                "items": [
+                  {
+                    "subItems": {
+                      "type": "subitems",
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ]
+                    },
+                    "origin": "https://raw.githubusercontent.com/",
+                    "source": {
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "path": "0,HEAD,2,LINK",
+                      "type": "node",
+                      "nodeLabel": "head \u003e link",
+                      "lhId": "page-3-LINK",
+                      "selector": "head \u003e link",
+                      "boundingRect": {
+                        "bottom": 0,
+                        "top": 0,
+                        "left": 0,
+                        "height": 0,
+                        "right": 0,
+                        "width": 0
+                      }
+                    }
+                  },
+                  {
+                    "subItems": {
+                      "type": "subitems",
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ]
+                    },
+                    "source": {
+                      "selector": "head \u003e link",
+                      "boundingRect": {
+                        "top": 0,
+                        "bottom": 0,
+                        "left": 0,
+                        "height": 0,
+                        "width": 0,
+                        "right": 0
+                      },
+                      "lhId": "page-4-LINK",
+                      "nodeLabel": "head \u003e link",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "path": "2,HTML,0,HEAD,3,LINK",
+                      "type": "node"
+                    }
+                  }
+                ],
+                "headings": [
+                  {
+                    "label": "Origin",
+                    "subItemsHeading": {
+                      "key": "warning"
+                    },
+                    "valueType": "text",
+                    "key": "origin"
+                  },
+                  {
+                    "label": "Source",
+                    "valueType": "node",
+                    "key": "source"
+                  }
+                ]
+              },
+              "title": "Preconnected origins"
+            },
+            {
+              "type": "list-section",
+              "value": {
+                "type": "text",
+                "value": "No additional origins are good candidates for preconnecting"
+              },
+              "title": "Preconnect candidates",
+              "description": "Add [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints to your most important origins, but try to use no more than 4."
+            }
+          ]
+        }
+      },
+      "resource-summary": {
+        "id": "resource-summary",
+        "title": "Resources Summary",
+        "description": "Aggregates all network requests and groups them by type",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "label": "Total",
+              "requestCount": 90,
+              "resourceType": "total",
+              "transferSize": 3738347
+            },
+            {
+              "label": "Image",
+              "resourceType": "image",
+              "transferSize": 2593944,
+              "requestCount": 10
+            },
+            {
+              "requestCount": 62,
+              "transferSize": 832775,
+              "resourceType": "script",
+              "label": "Script"
+            },
+            {
+              "requestCount": 6,
+              "transferSize": 253264,
+              "resourceType": "font",
+              "label": "Font"
+            },
+            {
+              "label": "Stylesheet",
+              "transferSize": 27827,
+              "resourceType": "stylesheet",
+              "requestCount": 3
+            },
+            {
+              "transferSize": 18220,
+              "resourceType": "document",
+              "requestCount": 1,
+              "label": "Document"
+            },
+            {
+              "resourceType": "other",
+              "transferSize": 12317,
+              "requestCount": 8,
+              "label": "Other"
+            },
+            {
+              "label": "Media",
+              "requestCount": 0,
+              "resourceType": "media",
+              "transferSize": 0
+            },
+            {
+              "label": "Third-party",
+              "requestCount": 30,
+              "resourceType": "third-party",
+              "transferSize": 3165113
+            }
+          ],
+          "headings": [
+            {
+              "label": "Resource Type",
+              "key": "label",
+              "valueType": "text"
+            },
+            {
+              "valueType": "numeric",
+              "key": "requestCount",
+              "label": "Requests"
+            },
+            {
+              "valueType": "bytes",
+              "key": "transferSize",
+              "label": "Transfer Size"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "mainthread-work-breakdown": {
+        "id": "mainthread-work-breakdown",
+        "title": "Minimize main-thread work",
+        "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to minimize main-thread work](https://developer.chrome.com/docs/lighthouse/performance/mainthread-work-breakdown/)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "3.2 s",
+        "metricSavings": {
+          "TBT": 850
+        },
+        "details": {
+          "type": "table",
+          "sortedBy": [
+            "duration"
+          ],
+          "items": [
+            {
+              "duration": 1797.0479999999864,
+              "group": "scriptEvaluation",
+              "groupLabel": "Script Evaluation"
+            },
+            {
+              "group": "styleLayout",
+              "groupLabel": "Style & Layout",
+              "duration": 525.04439999999977
+            },
+            {
+              "duration": 467.36639999999994,
+              "groupLabel": "Script Parsing & Compilation",
+              "group": "scriptParseCompile"
+            },
+            {
+              "duration": 276.56879999999637,
+              "groupLabel": "Other",
+              "group": "other"
+            },
+            {
+              "group": "parseHTML",
+              "groupLabel": "Parse HTML & CSS",
+              "duration": 62.305200000000013
+            },
+            {
+              "groupLabel": "Garbage Collection",
+              "group": "garbageCollection",
+              "duration": 49.789199999999987
+            },
+            {
+              "groupLabel": "Rendering",
+              "group": "paintCompositeRender",
+              "duration": 34.2708
+            }
+          ],
+          "headings": [
+            {
+              "label": "Category",
+              "valueType": "text",
+              "key": "groupLabel"
+            },
+            {
+              "granularity": 1,
+              "label": "Time Spent",
+              "valueType": "ms",
+              "key": "duration"
+            }
+          ]
+        },
+        "numericValue": 3212.3927999999819,
+        "numericUnit": "millisecond"
+      },
+      "third-parties-insight": {
+        "id": "third-parties-insight",
+        "title": "3rd parties",
+        "description": "3rd party code can significantly impact load performance. [Reduce and defer loading of 3rd party code](https://developer.chrome.com/docs/performance/insights/third-parties) to prioritize your page's content.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "transferSize": 352705,
+              "entity": "Hubspot",
+              "subItems": {
+                "items": [
+                  {
+                    "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+                    "mainThreadTime": 287.01499998569489,
+                    "transferSize": 206380
+                  },
+                  {
+                    "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                    "mainThreadTime": 78.849999964237213,
+                    "transferSize": 27955
+                  },
+                  {
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+                    "transferSize": 43664,
+                    "mainThreadTime": 55.559000000357628
+                  },
+                  {
+                    "mainThreadTime": 46.336999982595444,
+                    "transferSize": 29757,
+                    "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+                  },
+                  {
+                    "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+                    "transferSize": 27219,
+                    "mainThreadTime": 26.74099999666214
+                  },
+                  {
+                    "url": "https://js-eu1.hs-scripts.com/27107933.js",
+                    "mainThreadTime": 6.0849999785423279,
+                    "transferSize": 2550
+                  },
+                  {
+                    "transferSize": 1095,
+                    "mainThreadTime": 0.257999986410141,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk="
+                  },
+                  {
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953&hutk=3a7ca9afb6c1031c2b87829ed4306091",
+                    "transferSize": 4083,
+                    "mainThreadTime": 0.20200002193450928
+                  },
+                  {
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=3a7ca9afb6c1031c2b87829ed4306091",
+                    "transferSize": 1095,
+                    "mainThreadTime": 0.1549999862909317
+                  },
+                  {
+                    "transferSize": 1720,
+                    "mainThreadTime": 0,
+                    "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Ffr%2Fjobs%2Frevenue-operations-manager&utk=3a7ca9afb6c1031c2b87829ed4306091&__hstc=242475741.3a7ca9afb6c1031c2b87829ed4306091.1778779411372.1778779411372.1778779411372.1&__hssc=242475741.1.1778779411372&isMobile=true"
+                  },
+                  {
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr%2Fjobs%2Frevenue-operations-manager&t=Ocobo+%C2%B7+Revenue+Operations+Manager&cts=1778779411375&vi=3a7ca9afb6c1031c2b87829ed4306091&nc=true&ce=false&cc=0",
+                    "transferSize": 1472,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr%2Fjobs%2Frevenue-operations-manager&t=Ocobo+%C2%B7+Revenue+Operations+Manager&cts=1778779413065&vi=3a7ca9afb6c1031c2b87829ed4306091&nc=true&u=242475741.3a7ca9afb6c1031c2b87829ed4306091.1778779411372.1778779411372.1778779411372.1&b=242475741.1.1778779411372&cc=15",
+                    "transferSize": 1068,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1024,
+                    "mainThreadTime": 0,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1"
+                  },
+                  {
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+                    "transferSize": 1023,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1022,
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=d3342a0b-3113-4d65-a582-dacda9aa0444&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr%2Fjobs%2Frevenue-operations-manager&t=Ocobo+%C2%B7+Revenue+Operations+Manager&cts=1778779412950&vi=3a7ca9afb6c1031c2b87829ed4306091&nc=true&u=242475741.3a7ca9afb6c1031c2b87829ed4306091.1778779411372.1778779411372.1778779411372.1&b=242475741.1.1778779411372&cc=15"
+                  },
+                  {
+                    "transferSize": 1021,
+                    "mainThreadTime": 0,
+                    "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1"
+                  },
+                  {
+                    "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+                    "transferSize": 557,
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 501.20199990272522
+            },
+            {
+              "transferSize": 157034,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+                    "mainThreadTime": 243.41800005733967,
+                    "transferSize": 157034
+                  }
+                ]
+              },
+              "mainThreadTime": 243.41800005733967,
+              "entity": "Google Tag Manager"
+            },
+            {
+              "transferSize": 7015,
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 5017,
+                    "mainThreadTime": 8.0570000112056732,
+                    "url": "https://useago.github.io/widgetjs/frame.js"
+                  },
+                  {
+                    "url": "https://useago.github.io/widgetjs/frame.css",
+                    "transferSize": 1998,
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 8.0570000112056732,
+              "entity": "GitHub"
+            },
+            {
+              "transferSize": 14514,
+              "mainThreadTime": 7.3360000252723694,
+              "entity": "tally.so",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 7.3360000252723694,
+                    "transferSize": 14514,
+                    "url": "https://tally.so/widgets/embed.js"
+                  }
+                ]
+              }
+            },
+            {
+              "transferSize": 2527840,
+              "mainThreadTime": 0,
+              "entity": "vercel-storage.com",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 2527840,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/aude-cadiot.jpg"
+                  }
+                ]
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+                    "mainThreadTime": 0,
+                    "transferSize": 1278
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0,
+              "entity": "Clearbit",
+              "transferSize": 1278
+            },
+            {
+              "transferSize": 796,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65c1h1v9100339653za200zd9100339653&_p=1778779410745&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1295526350.1778779411&frm=0&pscdl=noapi&rcb=17&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616986~115938465~115938469&dp=%2Ffr%2Fjobs%2Frevenue-operations-manager&sid=1778779411&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Ffr%2Fjobs%2Frevenue-operations-manager&dt=Ocobo%20%C2%B7%20Revenue%20Operations%20Manager&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=919",
+                    "transferSize": 796,
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "mainThreadTime": 0,
+              "entity": "Google Analytics"
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 102672,
+                    "mainThreadTime": 0,
+                    "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                  },
+                  {
+                    "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                    "mainThreadTime": 0,
+                    "transferSize": 1259
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0,
+              "entity": "Google Fonts",
+              "transferSize": 103931
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "entity",
+              "label": "3rd party",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              }
+            },
+            {
+              "granularity": 1,
+              "label": "Transfer size",
+              "valueType": "bytes",
+              "key": "transferSize",
+              "subItemsHeading": {
+                "key": "transferSize"
+              }
+            },
+            {
+              "label": "Main thread time",
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "mainThreadTime",
+              "subItemsHeading": {
+                "key": "mainThreadTime"
+              }
+            }
+          ],
+          "isEntityGrouped": true,
+          "type": "table"
+        }
+      },
+      "bootup-time": {
+        "id": "bootup-time",
+        "title": "Reduce JavaScript execution time",
+        "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to reduce Javascript execution time](https://developer.chrome.com/docs/lighthouse/performance/bootup-time/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "2.1 s",
+        "metricSavings": {
+          "TBT": 800
+        },
+        "details": {
+          "type": "table",
+          "summary": {
+            "wastedMs": 2115.4679999999953
+          },
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "label": "Total CPU Time",
+              "key": "total",
+              "valueType": "ms",
+              "granularity": 1
+            },
+            {
+              "label": "Script Evaluation",
+              "valueType": "ms",
+              "key": "scripting",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "scriptParseCompile",
+              "label": "Script Parse"
+            }
+          ],
+          "sortedBy": [
+            "total"
+          ],
+          "items": [
+            {
+              "scripting": 681.90119999999911,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "scriptParseCompile": 31.310399999999998,
+              "total": 1046.8835999999992
+            },
+            {
+              "scripting": 470.60759999999567,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "scriptParseCompile": 14.3796,
+              "total": 500.48279999999568
+            },
+            {
+              "scripting": 225.75960000000021,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "scriptParseCompile": 150.79319999999998,
+              "total": 409.36680000000024
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "scriptParseCompile": 132.5124,
+              "total": 294.2304,
+              "scripting": 158.98079999999996
+            },
+            {
+              "url": "Unattributable",
+              "scriptParseCompile": 0,
+              "total": 271.46399999999755,
+              "scripting": 49.749600000000015
+            },
+            {
+              "scripting": 5.293199999999997,
+              "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+              "scriptParseCompile": 3.7967999999999988,
+              "total": 264.4596
+            },
+            {
+              "scripting": 93.08760000000008,
+              "scriptParseCompile": 29.6004,
+              "total": 164.07600000000005,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "scriptParseCompile": 25.2096,
+              "total": 69.621600000000015,
+              "scripting": 42.486000000000026
+            }
+          ]
+        },
+        "numericValue": 2115.4679999999953,
+        "numericUnit": "millisecond"
+      },
+      "unsized-images": {
+        "id": "unsized-images",
+        "title": "Image elements do not have explicit `width` and `height`",
+        "description": "Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [
+            {
+              "node": {
+                "lhId": "1-0-IMG",
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "boundingRect": {
+                  "height": 40,
+                  "width": 134,
+                  "right": 167,
+                  "top": 37,
+                  "bottom": 77,
+                  "left": 33
+                },
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "type": "node",
+                "path": "2,HTML,1,BODY,0,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "nodeLabel": "Ocobo"
+              },
+              "url": "https://www.ocobo.co/logo-ocobo.png"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "server-response-time": {
+        "id": "server-response-time",
+        "title": "Initial server response time was short",
+        "description": "Keep the server response time for the main document short because all other requests depend on it. [Learn more about the Time to First Byte metric](https://developer.chrome.com/docs/lighthouse/performance/time-to-first-byte/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Root document took 10 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 0,
+          "type": "opportunity",
+          "items": [
+            {
+              "responseTime": 13,
+              "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager"
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "valueType": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "timespanMs",
+              "key": "responseTime",
+              "label": "Time Spent"
+            }
+          ]
+        },
+        "numericValue": 13,
+        "numericUnit": "millisecond"
+      },
+      "dom-size-insight": {
+        "id": "dom-size-insight",
+        "title": "Optimize DOM size",
+        "description": "A large DOM can increase the duration of style calculations and layout reflows, impacting page responsiveness. A large DOM will also increase memory usage. [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/performance/insights/dom-size).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "type": "table",
+          "debugData": {
+            "maxDepth": 16,
+            "totalElements": 511,
+            "maxChildren": 63,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "statistic": "Total elements",
+              "value": {
+                "value": 511,
+                "granularity": 1,
+                "type": "numeric"
+              }
+            },
+            {
+              "node": {
+                "nodeLabel": "ul.d_flex \u003e li.d_flex \u003e svg.lucide \u003e path",
+                "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,0,ASIDE,0,DIV,1,DIV,0,DIV,1,DIV,1,UL,0,LI,0,svg,0,path",
+                "type": "node",
+                "snippet": "\u003cpath d=\"M5 12h14\"\u003e",
+                "boundingRect": {
+                  "top": 0,
+                  "bottom": 0,
+                  "left": 0,
+                  "height": 0,
+                  "width": 0,
+                  "right": 0
+                },
+                "selector": "ul.d_flex \u003e li.d_flex \u003e svg.lucide \u003e path",
+                "lhId": "page-10-path"
+              },
+              "statistic": "DOM depth",
+              "value": {
+                "value": 16,
+                "granularity": 1,
+                "type": "numeric"
+              }
+            },
+            {
+              "node": {
+                "path": "1,BODY",
+                "type": "node",
+                "snippet": "\u003cbody\u003e",
+                "nodeLabel": "body",
+                "lhId": "page-9-BODY",
+                "boundingRect": {
+                  "left": 0,
+                  "bottom": 0,
+                  "top": 0,
+                  "right": 0,
+                  "width": 0,
+                  "height": 0
+                },
+                "selector": "body"
+              },
+              "statistic": "Most children",
+              "value": {
+                "granularity": 1,
+                "value": 63,
+                "type": "numeric"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "statistic",
+              "label": "Statistic"
+            },
+            {
+              "valueType": "node",
+              "key": "node",
+              "label": "Element"
+            },
+            {
+              "label": "Value",
+              "valueType": "numeric",
+              "key": "value"
+            }
+          ]
+        },
+        "numericValue": 511,
+        "numericUnit": "element"
+      },
+      "font-display-insight": {
+        "id": "font-display-insight",
+        "title": "Font display",
+        "description": "Consider setting [font-display](https://developer.chrome.com/docs/performance/insights/font-display) to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with [font metric overrides](https://developer.chrome.com/blog/font-fallbacks).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "label": "Est Savings",
+              "valueType": "ms",
+              "key": "wastedMs"
+            }
+          ],
+          "type": "table",
+          "skipSumming": [
+            "wastedMs"
+          ]
+        }
+      },
+      "total-byte-weight": {
+        "id": "total-byte-weight",
+        "title": "Avoid enormous network payloads",
+        "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn how to reduce payload sizes](https://developer.chrome.com/docs/lighthouse/performance/total-byte-weight/).",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Total size was 3,651 KiB",
+        "details": {
+          "type": "table",
+          "sortedBy": [
+            "totalBytes"
+          ],
+          "items": [
+            {
+              "totalBytes": 2527840,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/aude-cadiot.jpg"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "totalBytes": 204725
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "totalBytes": 157034
+            },
+            {
+              "totalBytes": 51798,
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js"
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "totalBytes": 45261
+            },
+            {
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "totalBytes": 43925
+            },
+            {
+              "totalBytes": 43664,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+              "totalBytes": 40711
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Transfer Size"
+            }
+          ]
+        },
+        "numericValue": 3738347,
+        "numericUnit": "byte"
+      },
+      "final-screenshot": {
+        "id": "final-screenshot",
+        "title": "Final Screenshot",
+        "description": "The last screenshot captured of the pageload.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "timestamp": 125067002045,
+          "type": "screenshot",
+          "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAAHAQAAAAAAAAAAAAAAAAIDBAUGBwgB/8QARRAAAQMDAgMGAwQIBAMJAQAAAQACAwQFEQYSEyExBxQiQVFhFXGRCDKB0SNCUlSSobHBFhczgjRy8BgkJzZidIOjs+H/xAAbAQEBAQADAQEAAAAAAAAAAAAAAQIDBAUGB//EADARAQABAwICCQMDBQAAAAAAAAABAgMRITEEEhMVUVJTYZGS0RQjoQVB4SIycYHw/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEXjnBrS5xAaBkk9Asei1xpWa4dxi1FaX1edoibVMJJ9OvX2QZEiEgDJPL1WOnXGlm1/cjqK0irzt4Xe2bs+nXr7IMiRAQQCDkHzVqvOobXZXsbdarujH4xNLG4RD5yY2j8SguqLAu2uq/8ACS/1NHPyNO1zJYn9QXN5ghXY6v09ZqSgprvfLdR1ToY/0c9Q1rubRzIJ5IMnRS6aohqoGT00sc0Mg3MkjcHNcPUEdVZbvrHTdnqxS3W+2ykqc44U1Sxrh8wTy/FBfkUqkqYKynZUUk0c8EgyySNwc1w9QR1U1AREQEREBERAREQEREBEXj3bWkoBcG9SAvBIw9HBWu5XGkt8BqLjVQ00OQ3iTPDG5PQZKoKPUtjrallPR3i3z1EhwyOOoY5zvkAUGSopFO8nwn8FPQEREBERBrftwnmfZ7HaGzPp6S8XWChq5GHaeC4kubnyzjCyOr0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3v1VZq7TtDqqxT2u5tdwZMOa9hw+J45te0+RBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHnjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fdo25W3GaB0q2x/CRYrf3LZswYW7umM7uu73zlRzaJskuiRpU0xFpbEImtB8TSDkPB/a3c8+qxpuidaMpPhzdfy/DQ3hhxt7DU7OmOLnrjzxlBZu0GqqdCdihp9O3iarMcraNlc54c+GNzyCNw82jwg9Qti6f05bLfpxlujiFRTzQhs75jxHVGRzc8n7xOVLt2jbJRaPbpkUjZrTwzG+ObxGTJyXOP7RPPPqqV2nrpbLKLPpivbTU2zhsqK17qiSnb0wxvLOPLc44QaVp55afsi7ULA2V81us1c+no3uOdsfEHgz7Y/mtz6J0pZqPSdJGaWmrnVdOySpqZmCR1U5zQS5xPUHPIeQVvHZnQU/ZrXaSoKmSPvoLp6yRu98khcCXuHLOcYSPR2o7TSdw0vqmOitobtjhqqEVDqceYjduHL0Ds4QYpp+rm0h/mjarIS6gs8XfKGL7wge+Jz3MHsCM4WU9lmkrHDoa21L6Olrqq407amrqp42yPnfINzskjmMnor1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93Uu9scgFjtFoLUOn2SUWkNW9xs5c50VJV0Tak0+TkhjiQcegOUEjs+hjsHafqzTdrGyzMhgro4Actp5H5Dmt9AeuFtBYzojSMGl4ayR9XPcLpXScasrp/vzO8hgcg0DkAOiyZAREQEREBERAREQEREBQTjMRUaHmgx3UYqTbT3IVxm3D/AILg8TH/AMvhx/NWKytu/wAUg70NRcHJ3d6FDw+h+9w/H9Fmz4SD4eYUIieT91B7AP0gVUoIowwe6jQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERUFbJVtrqdsLWmnIOTkjLvQ8jgY/n/ADCvRQSbzA7AxIWnGD5rG46a7Clpmyun3CQmQB+4gbRjnuBPPPny+SDJ0VnfS1jH3B8Es5c5o4IdJkAnrgHkD6KXA24RbX7Kp8LZsiOR7TIW7CDk5xjcQeqC+IrHBBc219C6R0nCZCwTHfkF+H7sjz57efyU/Fw+O8Tae47eFt3+eM78fPl/ZBdUVgjjuZppGyNnEjKfYCJBl8m7k4c+nTqquBleLJI1xd8Qw7JLgcuz+r5Aen80F0RY+Ke4yNYxjqhkXHB/TS+MN2OzktPTdjzU6opq41Fc+N8m0RbYBxTzdsx0zjr5lEXpFjbae6AUYkdPta6TiBryeWW7ee4E8s9foq+0MrWVlX3oTGIuyx0jhjqeQAJxyx6fJFXVERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQERQTSxwxl8r2sYOpccBSZimMyI0VuN7twP8AxLf4T+SfG7d+8t/hP5Lq/X8L4tPuj5cnQ3O7PouKK3fG7d+8t/hP5J8bt37y3+E/knWHC+LT7o+Tobndn0XFFbvjdu/eW/wn8k+N2795b/CfyTrDhfFp90fJ0Nzuz6Liit3xu3fvLf4T+SfG7d+8t/hP5J1hwvi0+6Pk6G53Z9FxRW743bv3lv8ACfyT43bv3lv8J/JOsOF8Wn3R8nQ3O7PouKK3fG7d+8t/hP5KqpaynqgTTytkx1x5Ldvi7F2eW3XEz5TEpVbrpjNUTCeiIuwwIiICIiAiIgIiICIiAiIgIiICIiAsM1ZUvkuRgJPDiAwPcjOVmax/UVnkq5BUUuDLjDmk4z8l4v6/YvX+DmmxrOYzHbH/AGrtcHXRRdzW1F2g6vk0o23mKkjqTVOe3D5CzG0AgDAPM5xzwPdLlq91HrW2WHgU7W1lOyfiyzEHJc4bWgNIJ5ZGSAVmtTYZqnAqbeJtuQN8YdjPXqoX6efJPHNJbGumjADJHRAuaB0wfJfE27PLRFNfD1TOJzOu87T/AK/L1ZrzMzFcY07Gu9U9onwPVYs/cGva1sZdK+UtLt56MaGnPX+quN31fJb9c0NgbRxyMqWMcZTKWubuLxyGMHG31B58lmsthllmZNLbg+aP7j3Rgub8j5JJYZZJmzSW4PlbjD3RguGOnP8AE/Vai1TimPpqs4mJ31n9p/hOfWfuRv5bMNdq1w1obD3Vn+sI+JxOZaYeJu249fCp9Fe7nNrKqs81up46WGITd4bUZcWOJDfDjqS08s8llnwSo7xx+4Hj428TYN2PTPXCiFmqhKZRROEpAaX7OZHplcc2asYixP8Abjad+3+Gorj96438tuxhWjdWO1FWXeF0NPD3GUxbWSuc84c4ZcC0AA7fIlWfRPaO7Ut4o6F1sNNx4JJDIXkgOafut5DPhwc+62TBYJKd8j6e2iJ8nN7mRBpd88dV5Fp58JjMVsawxghhbEBtB6gei5JtU/144erXGN9NPzrqzFe33I89tWF6K1g7UlPdJXQU8JonFvDZK5z+Rd97LQBnbywT5+ig0JrOTVbK7bQinlpoYZNjn5y6QOOOnTwg59HLN6fT8lMZDT21sRk+/wAOIN3fPHXqVFBYZqcuNPbxEXAAlkYbkDkBy9Fm5Z5ufk4eqM4xvp2/5ytNeMZrjz21Yto293C9suDrjQQUfdag0w4U/E3Ob97yGB0x65WVUFS+kq45oyQWnnjzHmFFFZqqIO4VE5m5xc7azGSepPurrZ7DO+oZJVs4cTTnBPNyWuD4m9xMTYtzRrGNJxHnmSq7bptzFdWWYIiL9QeAIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIg09fPtA6Ws17uFrqbfen1FFUSU0jo4Yi0uY4tJGZAcZHosk7Pe1bTeu62WitLqqCtjZxOBVRhjnNHUjBIOM+q5Svl4qLB21Xy60dPHUz0l3rJWxSAlrsPfnIHljJ/BX/QtDTaYt931bSantM95joZTRUNI9xla942ue5rgMbWlxxg9PZEdl5HqmR6hcEW+hrL1bqi+TahMdyZUBhNVUtYcHHiL3PDvPoGnp1CyXtYtdwk0jpTUFfcaa6VLmSW+espZuKx+xxdHud5u2lwP/ACoO0sj1CZHquGviVXr7tDhuD4XTd3pGzyRu5gtp4A5wPs5zCP8AcrdSNuGrzdbtdL+4XCDEje8TNaHZJz4nPbtA8g0H5IZd7ZA6lMj1XDnaFU3OTROlIbpeaS7OgmrGRS09RxixmICGPd6gk/gQqTWQudkp9H1kd5rHyz2mKoh2u2d2G9wDGY8vDnPmSUHd2R6hMj1C4e09XS13braK2qf+lqLvBNIegy57Sf6qVYbtUWftZu1zoHZqKZ1ymiPUBwhmIOPP1Qy7myPVFwRQUtdqKir71Wagc25RStGaqoa0uzjxF7ngjr0a13TyXXHYdVXCp0BTNu11o7tUQSOiFTTT8YFowQ1zvNwzj5YRVPrftk0npC5yW6unqaqui/1YaOMPMZ9CSQM+2VBovto0lqy6RW6kmqqOtmOIo6yMM4h9AQSM+2Vx/XOfPric3f777i7vPE9TJ48/zVx1k2Cl7T7m3TYibBHcj3MUxG0Yf4duPLPTCI75yPUIuEaY1Mna1XU9Ndo7RJU3Cpp3Vshw2Fr3Pa458uRI8uvUdVlnZvf7toXtGudltl2F5t0UFSTwnl8MpjgdI17RkgEFoBx7jmiuwsj1TIHUrgmlbcNXm63a6X94uEGJG94ma3dknPic9u0DyDQfkrn2h1Nyk0TpSG6Xmkuz4JqxkUtPUcYsZiAhj3eoJP4EIjuPI9UyPVcr2bSF203oCPtIhvzpqqO0cOnp+Dgwte0RNw7d+qHbunULWdK6ao0Te7rPq4NrqiVkE1qlc50tWwOa4OJJ8jz/ANp588IrtDX+sbfojT5u91iqZqYSti20zWufl2ccnEDHL1WKO7WYrn2dVuqNLWO43A09V3TusjQ1+cNJedhd4QHD3/quV6C0w1fZbdrpJJKJ6G4wxxtBG0iRjt2eWf1BjmPNZXpGjoofs865rWVObjUVVNE+DiN8MccsRa4N68zK4E9OQRHTHZRq+46y07LX3ayy2maOYxBj92JBgHc3cAcc8fgs0yD0K4QtmqbtZOzKWgtVTNSsuFyk48sTi1xayKPDMjmAd38lV1wruzivsF2sGqoK+prIW1UsdLISIzyJjkGTkHOOfPkeQQdyZHqEyuI9KUlVfO3SelpK6e2VFVX1oE8QBfFlspOM+eMjPllUvZhfb9TOv1DaryaJ1RQPDXT1HDjD97MHc44a45LQ7lzd1QdzZHqEXA4s9VQVJl1RcbnZ6mbxU9Q6B0zJvU8Rr8+Y5gO6rtLsybI3QFiE1wZcnilbmrY9z2y/+oF2D9eaKyZERAREQahi7DbU3XlRqWa6VMzp6qapkpHxN2O4hduZnrjxEKXpXsEsWn9ROuLK+qq6V0c0LqOoY0tcyRhYQXDB6OW4kQaHqPs06ekr3yxXi5RUpdkQBrCWj0DiP6hZ3qLsvsl27PqfSNMX0NDTvbJDIwBz2uBJLjnqTl2fms9RBq/sw7HbXoO7Vdwhrp6+aeA04E0bWhjSQXdOucBY5efs36drbpLU0VzrqGnkdu7sxrXtZ6hpPPHzyt5og07f+wSwXGxWe1UVbVUMNvMzzIGtkfO+TZlzycc/AOig1N2D22/UlkglvVZCLXQtoWFsTTxGhznbj6HxLcqxztD1ONHaPuF9NL3vuoaRBxOHv3PDfvYOOueiDX1z+z/pyvu1HXPra+MxMhZNFGWhsxjaG56ZaXbeeCo9M9g9lsWrW3plwnqIQZgaKSJvDLJGPYWE9cAP/knZ523UurKa/wAlTafhz7VRurdneuLxWNzu/UbjHh9fvKR2Y9uQ1vq6nsbrB3AzRveJu+cXm1ucbdg9PVBQV32a9PTXCSamu9xpqVztwgDWu2j0Dj/fP4rb+ktOW7SlhprRZ4jHSQA43HLnE8y5x8ySpkmorLHJVRyXe3NfSs4lQ11SwGFv7Txnwj3KohrjShhdKNTWQxNcGuf3+LAJyQCd3U4P0KDCde9hum9W3eW6NmqrbWzHdMafBZI79otI5H5YyoNDdhOmtL3eG5yzVVzq4HB8PeNoZG4dHbQOZHuVsIaosDoaWYXu2GKryKd4qo9s2Dg7DnxYPI481V3O7W61RMludfSUcbzhr6iZsYJ9iSEHG2lNOQai7cqm1XWnldQ1dbXMedpGPBKQ4H1BAI9wF0d2b9kGn9DVU1ZTPqK6uljMRmqduGtPUNaByz55ysvqNVaepriLfUX21RV5c1opn1cbZMuwWjaTnJyMeuQqyuu1uoJ4IK6vpKaadwbFHNM1jpCTgBoJyT8kGmbz9m/TtbdJamiuddQ08jt3dmNa9rPUNJ54+eVcr/2CWC42Kz2qiraqhgt5meXhrZHzvk2Zc8nHPwDotk0eqLBW3L4dR3u11Fw3Ob3aKrjdLludw2g5yMHPphKjVOn6asNJU3y1xVYODDJVxteD/wApOUFNaNKUVDoin0vUk1lBHS90eZBgyMxg5x0/Baw/7OGmWx3BsdwuBdO0NgdJtcafxAkjAG4kDbz8iVtm66msNnmjiu16tlDLIziMZU1TIy5vTcA4jI5Hmp1DfbRcK51HQ3ShqaxsYmdBDUMe8MOMOLQc4O5vPpzHqg11pvsTslp0nedP1dZVV1Jc3xyOe5rWPiczO0tIzz5+atVu+z7aKC1XqihvVe4XKJkJe5jP0bWysk5DzOWAfit1og1Ha+wmwU2j6ywV1XVVkc9SKqOow1kkDw3b4eoxjqCqHS/2eNOWe7wV1bXVly4Dw9kEoayMkdNwHMj2yt1Ig1RYOxegs3aH/iyK7VUlR3map7u6NobmQPBGevLf/JWS0/ZzslG6rFRebhUQ1MJhc0MYwjxNcCDz6Fo8lvJEGhYfs0WBtS10t7ub4AecYawE/wC7H9luuw2mjsNmo7XbY+FR0sYjiaTkgD1PmVXogIiICIiAiIgIiICIiAtXfaWl4XZFdRn/AFJYGf8A2NP9ltFWLWmlrbrGyOtV5bM6kdI2QiJ+w5b05oOG9KUV3kpp5LMSBXSss8mPPjZIB+ew/RNI1lVYdVVElDI5tTDT1kTHs5EHgSNBHoc812fors205o+KojtNNI9s8scx7y/i7Xs3bXNyORG4qzWvsU0fbb7FdqeCsNVHKZQJJy5hJzkFuOY5nkiOSLM2w/4YvFTX3S40+oOTKSCFmY5mH7we76+Y/FUVN/5QuP8A76l//OoXY47FdDtnrpYrSYzVxuicBK4iMO6lgOdp9x08lRM7BtFMoZaQQ1/BllZK4d5OdzA4Dnj0e5BzBqmzQUfZ3oe6RyTvqLg2tbI17yWMEc+Ghg/VHicT6kqbqWuF11Lp2LVNZVR2qO30UZljG97ITE0uLQepyXf/ANXVFx7G9J3Cw2e0VMVYaO1cbuwbUEOHFcHPycc+YVReOyLR93tltoq63PeLfC2ngmbK5snDHRrnD734oOSKE0B7VLWLPWVVdbm3KmZTz1QxI5gewDI9sYHsByHRX2qFu1D2uX7/ADEvVXbIY5pwJmNLnMcx2GMHI4AHt5e66Rl7F9HP1BBd4qOeCpgfFJGyGYtjaYw0N8P+0Z9ea0x2y0N8PaDcKmfQsdwibMHU1YynmImYMY38N213pzGfIoNZaRrquk1ZXVtsqJpKplLXPjqOYef0EmX+oOMlU9ooLLW2SrnuV07pcmzNDA8ucHMOMnYGEuPX9Zv4rcH2eezy+O1s/Ud/tktDRQxy7WVEXD4z5GlpAYf1cOd5Y6BbSq+wfQlTXvqjb6iMPdvMMdQ5sfyA8h7AoOXO0B0fctNR092fdqeKgdHHUPgdFhomk8ADuZAORn8PJdQdjPZrbNMx0epaWsrp66422NsrZ3tLBvDHnGAD1aAOfRXLUvY9pDULqDvdHNDHQ04pYIqaUxtawOLunmcuPNZ3baOK3W6loqYOEFNEyGMOOTtaABk/IIKhERFEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEULyc7R+KCJFKdsY0ufgADJJUMT4pWkxkOA5dFOaM4zqYndPRUtTUUtLw+8zQw8R21nEeG7j6DPUqFlXRvrJKRlRTuqoxufCHgvaPUt6jqPqqKxFJhfFNEyWB7XxvG5r2HII9QQpjTnIPUIIkRQvOMAdSgiRSyGgEu+pUuKWGUkRua4j0RMqhFSVlVSUTGPrKiCnY92xrpXhgLvQZ815JV0cYnMlRTtFOAZi54HDyMjd6cvVFViKjiq6OZgfDUU8jCzihzXggs/a+XuvYqmkmpe8wzwSU2C7iteCzA6nPRBVoqM1lEJ5IDUU/GjbvfHvG5rfUjyHupkU1PMSIZIpCGhxDXA4B6H5HyQVCKijrqGRzmx1VM5zX8JwbI04f8Asn39lTC+WYxPlF0t5jjIa94qGYaTnAJzyzg/QoLsip4ZYJ25gkjkGA7LHA8iMg8vUKaDtPsgjREQEREBERAREQEREBQH7591GvHNygobpA+eANYzeefh/AgfzUqipnR1bpOAImHPpz5N9PkVccO9imHe31XWq4Wiq50s76fhuK5iOVi+rNMS3m4QVcEtDuZTyUro62l7wza8tJc0bhh3h9wVJj0lKNWvuzqqAQd6FW1jIcS7u7Ng2F+fuci7GOuPRZdh3t9Uw72+q7LC26YthsunbbbHSiY0lOyEyBu3dtGM48lcm83/ACCbXewUQGAg9UDuTx7hRoRkYKCTUR8WCSMHG5pGVRUFO9s7pHtczGRhxByTjOPbkrhtcPMFMO9vqrnTDM0xM5WDV2modTRUEFXK5lNBO6WVjeRlaYpIy3Pl9/r7fisePZ/UZvzvi5JvETo5gYRhhEmYi3z8LCW8yc8umMLYGHe31TDvb6qNMHpdCcC31FK+qimE1vlon8SN2HufK55e4NcDz3cwCOfTHRVVPpmspNEVFo7xDU1BeZG7WcNrhvDth5knIGCSSTnmsuw72+qYd7fVBgc2g5Ja+eTvdI2F01TUMeKXFQXTMe0tfJu8TBvPLA5NaPJV+htHnSstdtrn1NPPFBFFG9vOERh2Wg55ty8kDyHLyWW4d7fVMO9vqgwKzaDmt8zSa2m4DK2KqZFFA4YDOJkbnOLue/1wMchzU266DbVUksVLPDA590+I5Yx0fLYWhmWODh1JyCs4w72+qYd7fVBZ7Vbp6W8VVTKWcJ9JT07dpJy6MyFx58/1wOfPkru7pj1XuHey9a3ByTkoIkREBERAREQEREBERAREQEREBERAREJAGSgIoNzvYJl3t9EEaKDLvb6Jl3t9EEaKDLvb6Jl3t9EEaKDLvZRNdnl0KD1ERAREQEREBERAREQEREBERAREQEREBERAREQFA/74Ua8eM8x1CCTUueyB7og0vAyN3RUNFO51Qxsc7ZmyAvfn9X5fUclcc55EH6LwNaCCGgEDA5eSMzTMzlj2u7jcLZZuPaHf96DjtZ3d0vEIaSG8vu5I6+Z5ZGcim1heLpR0NJLbqeeM94LZhwt75GBhOGABwyTjG7HpkZyssz8/omfn9EaYjq2+Xe3X6zw2uikqKHcH3B7Y922Nz2sbg56jc5xxnkz0OVYxqfVYuNwp5KFjIWfEH0tQad7mObE/bE14aC7PLPIeIEY6FbKz8/omfn9EGPaEuVZdbA2ouXE7wJHsLnwcLcAeRA8x74GfRZCfvNQn5/RetBJyeXsgiREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAWrrzBrv/NBklA6Y6WdV0u8CRo2sEZ4hAznaXHmOuQMLaKINYaudrf8AzTs01lpqt2mKfhR1TWSRhku8u3uILsnaC3y8kfb9bjtiG2pqjo5zhVF/FbtaREWmLGc4L8Hotnogwyji1OLHrAbni5Pqqk2kyuaQGbBwseQG7PIqz9jg1jG2ui1lT3Jv6KJ0clZUwyh0mDxAwMaC0Z8iTyI6c1stEGsOzE63/wAT346tp6xltqw6ajMskbm054jgI2hriRlhaefor12bWe+WqS/fH7ncq5prTFRd8ka/9A1oLXjaORcXOB/5RyCzVEGqrzBr49k9DHbnVI1IKnNViRnGMPEfkNcTt3Y2efRVumYNbN7IbnFenzHVJgqRSeNnFB2nhZcPDuz5/JbIRBhPZXHqiK13JuszIawVm2BznBwdEIoxuGOgLg849SVmyIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIgOcoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8b1PzXq8b1PzQeqTHMHTyxktBYQAPMjAP8AdTkwM5xzQUtJUmaWVhbgNPhOOo6f2SrqjBMxuzcHNPT15YCqkwgp4Z3PNPkAcRhcfbp+aggqnPfM1wZlnQA/1Kq8JgeiIo4at0kG8hu7e1hx0GSPzXs1U6OfYAzAIG0nxOz6KrwPRMBBSd6cKzglnhL9od6+HJVWmERRERAREQEREBERAREQEREBERAREQEREBERARF43qfmg9REyM4zzQETI9QmRjORhARCQOpTI9UBEyM9UzzQETI9eiZQEQkDzXhcAMk8kHqJkeqICIiAiIgIiICIiAiIgIiICIiAiIgLxvU/NeoBjKAqVlMW1z5y4EO6D05Af2VUiCjZSOEU7CG+PODn1JKd0c6kZC5zeTtxwB0z8lWIhhR1FGX4DNhaGbBvGdvuPdeVdG+Z25sm0hm3Prz55VaiJhTTU7n1UcrduG9c8ykNO9lVJMXg785H9FUoiqGOje1lQMt/SggfU/mqh8b+8NkZtI27SCfdTkRMJBgyajdtIkxgH5YUqWkLqaGNgaOGQSOgPIqsRFwpH0znVEUg2DaAD5/RVaIgIiICIiAiIgIiICIiAiIgIiICIiAmUXjep+aD1EUhtS11U6ANO5vU+XQH+6CeipmVsbhKcO/R9ffmR/ZRd5aI5XPY5pjGXNOMoJ6KSydrhGQP9QkDBB8if7KOOQPLwAfCdpQRopFRUtgkjY4El/THzA/uveOO8GHacgA58kE5FJhn4p5MeGnmHHGCvIaqOWQMbnJBPPywcIJ6KmbWMMD5drg1ny5r0VTTFG9rHOLzhrRjJ/t5IKhFIfUsYIy8Obvz1HTChfVNayFwa48UZCCpREQEREBERAREQEREBERAREQEREBeN6n5r1EBeNY1rnEDBccn3XqIJYgjAeAwYf8AeHr/ANZRsETY3MDBtd1HqpiIPCxpLSRzacj2ULYmNkc9oIc7rzP9FGiCB8THua57clvQ+n/WEMTDLxMHf0zkqNEEuOCON5cxgDj5r1kTGEFrcEAgfjzKjRBKbTxNY5gb4XdQSSvXQROjDCzwjmB6KYiCAQxgMAaMMGG+yhdBG5rAWnDBhuCRhTUQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQf//Z",
+          "timing": 2644
+        }
+      },
+      "metrics": {
+        "id": "metrics",
+        "title": "Metrics",
+        "description": "Collects all available metrics.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "observedLargestContentfulPaintTs": 125066398162,
+              "totalBlockingTime": 831,
+              "observedLargestContentfulPaintAllFrames": 2040,
+              "cumulativeLayoutShiftMainFrame": 0.015853,
+              "observedFirstContentfulPaintTs": 125064914049,
+              "observedLoad": 1068,
+              "observedTimeOrigin": 0,
+              "observedLastVisualChangeTs": 125064980405,
+              "observedFirstContentfulPaintAllFramesTs": 125064914049,
+              "largestContentfulPaint": 8176,
+              "observedTraceEndTs": 125069501946,
+              "observedDomContentLoaded": 691,
+              "interactive": 11672,
+              "cumulativeLayoutShift": 0.015853,
+              "observedNavigationStart": 0,
+              "observedTimeOriginTs": 125064358405,
+              "firstContentfulPaint": 3001,
+              "observedLastVisualChange": 622,
+              "observedFirstContentfulPaint": 556,
+              "observedSpeedIndex": 568,
+              "observedFirstPaint": 556,
+              "observedTraceEnd": 5144,
+              "observedNavigationStartTs": 125064358405,
+              "observedLoadTs": 125065426754,
+              "observedDomContentLoadedTs": 125065049015,
+              "observedFirstVisualChangeTs": 125064668405,
+              "observedLargestContentfulPaintAllFramesTs": 125066398162,
+              "timeToFirstByte": 601,
+              "observedCumulativeLayoutShiftMainFrame": 0.015853,
+              "observedFirstPaintTs": 125064914049,
+              "speedIndex": 3001,
+              "observedFirstVisualChange": 310,
+              "observedSpeedIndexTs": 125064926607,
+              "observedLargestContentfulPaint": 2040,
+              "observedCumulativeLayoutShift": 0.015853,
+              "observedFirstContentfulPaintAllFrames": 556,
+              "maxPotentialFID": 200
+            },
+            {
+              "lcpInvalidated": false
+            }
+          ]
+        },
+        "numericValue": 11672,
+        "numericUnit": "millisecond"
+      },
+      "cache-insight": {
+        "id": "cache-insight",
+        "title": "Use efficient cache lifetimes",
+        "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more about caching](https://developer.chrome.com/docs/performance/insights/cache).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 330 KiB",
+        "metricSavings": {
+          "LCP": 600,
+          "FCP": 0
+        },
+        "details": {
+          "type": "table",
+          "skipSumming": [
+            "cacheLifetimeMs"
+          ],
+          "headings": [
+            {
+              "label": "Request",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "displayUnit": "duration",
+              "label": "Cache TTL",
+              "valueType": "ms",
+              "key": "cacheLifetimeMs"
+            },
+            {
+              "granularity": 1,
+              "displayUnit": "kb",
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "key": "totalBytes"
+            }
+          ],
+          "debugData": {
+            "wastedBytes": 337904.40833333333,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedBytes": 196194.79166666669,
+              "totalBytes": 204725
+            },
+            {
+              "totalBytes": 43664,
+              "wastedBytes": 41844.666666666672,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "cacheLifetimeMs": 300000
+            },
+            {
+              "totalBytes": 29757,
+              "wastedBytes": 27277.25,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "cacheLifetimeMs": 600000
+            },
+            {
+              "wastedBytes": 26790.208333333336,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "totalBytes": 27955,
+              "cacheLifetimeMs": 300000
+            },
+            {
+              "totalBytes": 27219,
+              "wastedBytes": 26084.875,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "cacheLifetimeMs": 300000
+            },
+            {
+              "cacheLifetimeMs": 3600000,
+              "url": "https://tally.so/widgets/embed.js",
+              "wastedBytes": 11611.2,
+              "totalBytes": 14514
+            },
+            {
+              "cacheLifetimeMs": 600000,
+              "wastedBytes": 4598.9166666666661,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "totalBytes": 5017
+            },
+            {
+              "totalBytes": 1998,
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "wastedBytes": 1831.5,
+              "cacheLifetimeMs": 600000
+            },
+            {
+              "wastedBytes": 1671,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "totalBytes": 1671,
+              "cacheLifetimeMs": 0
+            }
+          ],
+          "sortedBy": [
+            "wastedBytes"
+          ]
+        }
+      },
+      "cls-culprits-insight": {
+        "id": "cls-culprits-insight",
+        "title": "Layout shift culprits",
+        "description": "Layout shifts occur when elements move absent any user interaction. [Investigate the causes of layout shifts](https://developer.chrome.com/docs/performance/insights/cls-culprit), such as elements being added, removed, or their fonts changing as the page loads.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "items": [
+                {
+                  "score": 0.015853,
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  }
+                },
+                {
+                  "score": 0.015853,
+                  "node": {
+                    "selector": "div.max-w_7xl \u003e div.mb_20 \u003e div.max-w_5xl \u003e h1.text",
+                    "boundingRect": {
+                      "left": 0,
+                      "bottom": 0,
+                      "top": 0,
+                      "right": 0,
+                      "width": 0,
+                      "height": 0
+                    },
+                    "lhId": "page-1-H1",
+                    "nodeLabel": "Revenue Operations Manager",
+                    "snippet": "\u003ch1 class=\"text text--variant_display-lg text--color_dark fs_4xl md:fs_6xl mb_10 lh_1…\"\u003e",
+                    "type": "node",
+                    "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,0,DIV,1,DIV,1,H1"
+                  },
+                  "subItems": {
+                    "items": [
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                          "type": "url"
+                        }
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                          "type": "url"
+                        }
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "type": "url",
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf"
+                        }
+                      },
+                      {
+                        "extra": {
+                          "type": "url",
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf"
+                        },
+                        "cause": "Web font"
+                      }
+                    ],
+                    "type": "subitems"
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "valueType": "node",
+                  "key": "node",
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  }
+                },
+                {
+                  "valueType": "numeric",
+                  "key": "score",
+                  "subItemsHeading": {
+                    "key": "cause",
+                    "valueType": "text"
+                  },
+                  "granularity": 0.001,
+                  "label": "Layout shift score"
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "items": [
+                {
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  },
+                  "score": 0
+                },
+                {
+                  "score": 0,
+                  "node": {
+                    "boundingRect": {
+                      "left": 270,
+                      "bottom": 117,
+                      "top": 79,
+                      "right": 380,
+                      "width": 110,
+                      "height": 38
+                    },
+                    "selector": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "lhId": "page-0-INPUT",
+                    "nodeLabel": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "type": "node",
+                    "path": "0,HTML,1,BODY,1,DIV,0,FORM,1,DIV,1,DIV,0,INPUT",
+                    "snippet": "\u003cinput type=\"submit\" class=\"hs-button primary large\" value=\"S'inscrire\"\u003e"
+                  },
+                  "subItems": {
+                    "items": [
+                      {
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        }
+                      }
+                    ],
+                    "type": "subitems"
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "key": "node",
+                  "valueType": "node",
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  }
+                },
+                {
+                  "label": "Layout shift score",
+                  "granularity": 0.001,
+                  "valueType": "numeric",
+                  "key": "score",
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  }
+                }
+              ],
+              "type": "table"
+            }
+          ]
+        }
+      },
+      "unused-css-rules": {
+        "id": "unused-css-rules",
+        "title": "Reduce unused CSS",
+        "description": "Reduce unused rules from stylesheets and defer CSS not used for above-the-fold content to decrease bytes consumed by network activity. [Learn how to reduce unused CSS](https://developer.chrome.com/docs/lighthouse/performance/unused-css-rules/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [],
+          "type": "opportunity",
+          "overallSavingsBytes": 0,
+          "overallSavingsMs": 0,
+          "items": [],
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "debugData": {
+            "metricSavings": {
+              "FCP": 0,
+              "LCP": 0
+            },
+            "type": "debugdata"
+          }
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "inp-breakdown-insight": {
+        "id": "inp-breakdown-insight",
+        "title": "INP breakdown",
+        "description": "Start investigating [how to improve INP](https://developer.chrome.com/docs/performance/insights/inp-breakdown) by looking at the longest subpart.",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "lcp-discovery-insight": {
+        "id": "lcp-discovery-insight",
+        "title": "LCP request discovery",
+        "description": "[Optimize LCP](https://developer.chrome.com/docs/performance/insights/lcp-discovery) by making the LCP image discoverable from the HTML immediately, and avoiding lazy-loading",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "diagnostics": {
+        "id": "diagnostics",
+        "title": "Diagnostics",
+        "description": "Collection of useful page vitals.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "numTasksOver10ms": 53,
+              "totalByteWeight": 3738347,
+              "numRequests": 90,
+              "numTasks": 1813,
+              "rtt": 0.00069497463715431987,
+              "mainDocumentTransferSize": 18220,
+              "maxRtt": 8.121195,
+              "numStylesheets": 3,
+              "numTasksOver25ms": 23,
+              "numTasksOver100ms": 7,
+              "throughput": 44317376204.016968,
+              "numFonts": 6,
+              "maxServerLatency": 43,
+              "numTasksOver500ms": 0,
+              "numTasksOver50ms": 13,
+              "numScripts": 62,
+              "totalTaskTime": 2676.9940000000011
+            }
+          ],
+          "type": "debugdata"
+        }
+      },
+      "layout-shifts": {
+        "id": "layout-shifts",
+        "title": "Avoid large layout shifts",
+        "description": "These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "2 layout shifts found",
+        "metricSavings": {
+          "CLS": 0.016
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "score": 0.015853,
+              "node": {
+                "boundingRect": {
+                  "left": 0,
+                  "bottom": 0,
+                  "top": 0,
+                  "right": 0,
+                  "width": 0,
+                  "height": 0
+                },
+                "selector": "div.max-w_7xl \u003e div.mb_20 \u003e div.max-w_5xl \u003e h1.text",
+                "lhId": "page-1-H1",
+                "nodeLabel": "Revenue Operations Manager",
+                "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,0,DIV,1,DIV,1,H1",
+                "type": "node",
+                "snippet": "\u003ch1 class=\"text text--variant_display-lg text--color_dark fs_4xl md:fs_6xl mb_10 lh_1…\"\u003e"
+              },
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                      "type": "url"
+                    }
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "type": "url",
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf"
+                    }
+                  },
+                  {
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  }
+                ]
+              }
+            },
+            {
+              "score": 0,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                      "type": "url"
+                    }
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                      "type": "url"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "headings": [
+            {
+              "label": "Element",
+              "subItemsHeading": {
+                "key": "extra"
+              },
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "valueType": "numeric",
+              "key": "score",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "cause"
+              },
+              "granularity": 0.001,
+              "label": "Layout shift score"
+            }
+          ]
+        }
+      },
+      "network-requests": {
+        "id": "network-requests",
+        "title": "Network Requests",
+        "description": "Lists the network requests that were made during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 369.66699999570847,
+              "rendererStartTime": 0,
+              "networkRequestTime": 1.6739999949932098,
+              "priority": "VeryHigh",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 92639,
+              "transferSize": 18220,
+              "resourceType": "Document",
+              "mimeType": "text/html",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+              "finished": true
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkEndTime": 423.67799998819828,
+              "sessionTargetType": "page",
+              "priority": "VeryHigh",
+              "networkRequestTime": 391.78100000321865,
+              "rendererStartTime": 390.20899999141693,
+              "mimeType": "text/css",
+              "experimentalFromMainFrame": true,
+              "transferSize": 24570,
+              "resourceType": "Stylesheet",
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "finished": true,
+              "protocol": "h2",
+              "resourceSize": 122090
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 538.30799999833107,
+              "rendererStartTime": 390.87399998307228,
+              "networkRequestTime": 391.89299999177456,
+              "priority": "High",
+              "transferSize": 12757,
+              "resourceType": "Image",
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "resourceSize": 12266
+            },
+            {
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "transferSize": 29546,
+              "url": "https://www.ocobo.co/images/partners/modern-revenue-club.png",
+              "finished": true,
+              "protocol": "h2",
+              "resourceSize": 29045,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "networkEndTime": 421.17200000584126,
+              "sessionTargetType": "page",
+              "priority": "Medium",
+              "networkRequestTime": 392.00599999725819,
+              "rendererStartTime": 391.17200000584126
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 520.56599998474121,
+              "networkRequestTime": 451.01899999380112,
+              "rendererStartTime": 391.35500000417233,
+              "priority": "Low",
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "resourceSize": 2527172,
+              "resourceType": "Image",
+              "transferSize": 2527840,
+              "mimeType": "image/jpeg",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/aude-cadiot.jpg"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 544.93899999558926,
+              "networkRequestTime": 458.042999997735,
+              "rendererStartTime": 391.49099999666214,
+              "priority": "Low",
+              "statusCode": 200,
+              "entity": "Google Tag Manager",
+              "resourceSize": 471493,
+              "resourceType": "Script",
+              "transferSize": 157034,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "networkEndTime": 653.41299998760223,
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "networkRequestTime": 458.12199999392033,
+              "rendererStartTime": 391.60199999809265,
+              "entity": "Clearbit",
+              "statusCode": 404,
+              "resourceSize": 0,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "transferSize": 639,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "finished": true,
+              "protocol": "h2"
+            },
+            {
+              "finished": true,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "transferSize": 1671,
+              "resourceSize": 2125,
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "priority": "Low",
+              "networkRequestTime": 458.18299999833107,
+              "rendererStartTime": 391.71400000154972,
+              "networkEndTime": 478.9210000038147,
+              "sessionTargetType": "page"
+            },
+            {
+              "finished": true,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "transferSize": 5017,
+              "resourceSize": 17494,
+              "statusCode": 200,
+              "entity": "GitHub",
+              "priority": "Low",
+              "networkRequestTime": 458.25599999725819,
+              "rendererStartTime": 391.83100000023842,
+              "networkEndTime": 480.8830000013113,
+              "sessionTargetType": "page"
+            },
+            {
+              "resourceSize": 69556,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "transferSize": 24114,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "finished": true,
+              "protocol": "h2",
+              "networkEndTime": 577.90799999237061,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "rendererStartTime": 392.04199999570847,
+              "isLinkPreload": true,
+              "networkRequestTime": 394.43999999761581,
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "resourceSize": 927,
+              "transferSize": 1454,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 584.68600000441074,
+              "networkRequestTime": 394.72299998998642,
+              "isLinkPreload": true,
+              "rendererStartTime": 392.19299998879433,
+              "priority": "High",
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "resourceSize": 125397,
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "finished": true,
+              "resourceType": "Script",
+              "transferSize": 43925,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "rendererStartTime": 392.30099999904633,
+              "networkRequestTime": 394.78799998760223,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 434.4539999961853,
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 436.59399999678135,
+              "isLinkPreload": true,
+              "networkRequestTime": 394.86299999058247,
+              "rendererStartTime": 392.3999999910593,
+              "priority": "High",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "resourceSize": 133936,
+              "transferSize": 45261,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "resourceSize": 110060,
+              "transferSize": 34185,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "finished": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 422.96499998867512,
+              "networkRequestTime": 394.945999994874,
+              "rendererStartTime": 392.50299999117851,
+              "isLinkPreload": true,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "resourceType": "Script",
+              "transferSize": 1514,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "finished": true,
+              "resourceSize": 991,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 539.26299999654293,
+              "isLinkPreload": true,
+              "networkRequestTime": 395.01500000059605,
+              "rendererStartTime": 392.60099999606609,
+              "priority": "High"
+            },
+            {
+              "resourceSize": 9799,
+              "resourceType": "Script",
+              "transferSize": 4523,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "finished": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 422.34399999678135,
+              "rendererStartTime": 392.69799999892712,
+              "networkRequestTime": 395.12299999594688,
+              "isLinkPreload": true,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "rendererStartTime": 392.82500000298023,
+              "isLinkPreload": true,
+              "networkRequestTime": 395.24400000274181,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 450.49999998509884,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "resourceSize": 3192,
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "finished": true,
+              "transferSize": 2149,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "networkEndTime": 420.52699999511242,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "isLinkPreload": true,
+              "networkRequestTime": 395.39399999380112,
+              "rendererStartTime": 393.01399999856949,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "transferSize": 670,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "finished": true,
+              "protocol": "h2",
+              "resourceSize": 141
+            },
+            {
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "networkRequestTime": 395.86199998855591,
+              "isLinkPreload": true,
+              "rendererStartTime": 393.125,
+              "networkEndTime": 424.84299999475479,
+              "sessionTargetType": "page",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "transferSize": 1270,
+              "resourceType": "Script",
+              "resourceSize": 1284
+            },
+            {
+              "resourceSize": 15426,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "transferSize": 6807,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "protocol": "h2",
+              "networkEndTime": 455.75300000607967,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkRequestTime": 396.03299999237061,
+              "isLinkPreload": true,
+              "rendererStartTime": 393.25199998915195,
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "networkRequestTime": 396.23199999332428,
+              "rendererStartTime": 393.36799998581409,
+              "isLinkPreload": true,
+              "networkEndTime": 576.944000005722,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "transferSize": 6205,
+              "resourceType": "Script",
+              "resourceSize": 17234
+            },
+            {
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "resourceType": "Script",
+              "transferSize": 1833,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 3070,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "networkRequestTime": 396.67799998819828,
+              "isLinkPreload": true,
+              "rendererStartTime": 393.6879999935627,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 424.16399998962879
+            },
+            {
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "networkEndTime": 558.75699998438358,
+              "isLinkPreload": true,
+              "rendererStartTime": 393.901000007987,
+              "networkRequestTime": 396.76899999380112,
+              "priority": "High",
+              "transferSize": 953,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "resourceSize": 428
+            },
+            {
+              "url": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "transferSize": 938,
+              "resourceSize": 410,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "isLinkPreload": true,
+              "networkRequestTime": 396.87199999392033,
+              "rendererStartTime": 394.17299999296665,
+              "networkEndTime": 431.43099999427795,
+              "sessionTargetType": "page"
+            },
+            {
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "transferSize": 1048,
+              "url": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "finished": true,
+              "protocol": "h2",
+              "resourceSize": 525,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkEndTime": 433.80200000107288,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "isLinkPreload": true,
+              "networkRequestTime": 396.97900000214577,
+              "rendererStartTime": 394.43800000846386
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "transferSize": 1472,
+              "url": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "finished": true,
+              "protocol": "h2",
+              "resourceSize": 942,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkEndTime": 451.57999999821186,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "rendererStartTime": 394.60400000214577,
+              "isLinkPreload": true,
+              "networkRequestTime": 397.20600000023842
+            },
+            {
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "transferSize": 877,
+              "resourceSize": 349,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "priority": "High",
+              "isLinkPreload": true,
+              "networkRequestTime": 397.90099999308586,
+              "rendererStartTime": 394.81699998676777,
+              "networkEndTime": 453.18299998342991,
+              "sessionTargetType": "page"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 421.82500000298023,
+              "rendererStartTime": 395.05799999833107,
+              "isLinkPreload": true,
+              "networkRequestTime": 398.02300000190735,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 1866,
+              "resourceType": "Script",
+              "transferSize": 1368,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js"
+            },
+            {
+              "networkEndTime": 432.45199999213219,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkRequestTime": 398.54699999094009,
+              "rendererStartTime": 395.2339999973774,
+              "isLinkPreload": true,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "resourceSize": 348,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "transferSize": 868,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "protocol": "h2"
+            },
+            {
+              "resourceSize": 67398,
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "finished": true,
+              "transferSize": 21253,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 395.55799999833107,
+              "isLinkPreload": true,
+              "networkRequestTime": 398.83799999952316,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 442.81100000441074,
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 432.94400000572205,
+              "rendererStartTime": 395.79399999976158,
+              "isLinkPreload": true,
+              "networkRequestTime": 399.06399999558926,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 165,
+              "resourceType": "Script",
+              "transferSize": 702,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "finished": true
+            },
+            {
+              "resourceSize": 605,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "transferSize": 1128,
+              "url": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "finished": true,
+              "protocol": "h2",
+              "networkEndTime": 433.39900000393391,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "rendererStartTime": 395.96999999880791,
+              "isLinkPreload": true,
+              "networkRequestTime": 399.20800000429153,
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "resourceSize": 826,
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "finished": true,
+              "resourceType": "Script",
+              "transferSize": 1346,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 396.27699999511242,
+              "isLinkPreload": true,
+              "networkRequestTime": 400.36599999666214,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 444.48999999463558,
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "resourceSize": 404,
+              "url": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "finished": true,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "transferSize": 930,
+              "priority": "High",
+              "rendererStartTime": 396.52899998426437,
+              "isLinkPreload": true,
+              "networkRequestTime": 400.50499999523163,
+              "networkEndTime": 443.41399998962879,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "resourceSize": 490,
+              "url": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "transferSize": 1011,
+              "priority": "High",
+              "networkRequestTime": 400.679000005126,
+              "isLinkPreload": true,
+              "rendererStartTime": 396.7509999871254,
+              "networkEndTime": 578.40999999642372,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "finished": true,
+              "transferSize": 727,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 206,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 397.05599999427795,
+              "isLinkPreload": true,
+              "networkRequestTime": 401.40799999237061,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 440.73099999129772
+            },
+            {
+              "networkRequestTime": 401.59999999403954,
+              "isLinkPreload": true,
+              "rendererStartTime": 397.22699999809265,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 446.28399999439716,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 835,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "resourceType": "Script",
+              "transferSize": 1359,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 447.49099999666214,
+              "isLinkPreload": true,
+              "networkRequestTime": 401.75799998641014,
+              "rendererStartTime": 397.4299999922514,
+              "priority": "High",
+              "resourceType": "Script",
+              "transferSize": 26413,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "finished": true,
+              "resourceSize": 68826
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 397.65699999034405,
+              "isLinkPreload": true,
+              "networkRequestTime": 401.90499998629093,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 439.5249999910593,
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "finished": true,
+              "resourceType": "Script",
+              "transferSize": 998,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 473
+            },
+            {
+              "resourceSize": 338,
+              "transferSize": 855,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 594.6630000025034,
+              "rendererStartTime": 397.95600000023842,
+              "isLinkPreload": true,
+              "networkRequestTime": 402.02099999785423,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 445.81399999558926,
+              "rendererStartTime": 398.2039999961853,
+              "isLinkPreload": true,
+              "networkRequestTime": 402.141999989748,
+              "priority": "High",
+              "transferSize": 965,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "resourceSize": 435
+            },
+            {
+              "resourceSize": 312,
+              "transferSize": 841,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 464.92800000309944,
+              "networkRequestTime": 402.69499999284744,
+              "rendererStartTime": 398.39200000464916,
+              "isLinkPreload": true,
+              "priority": "High",
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "transferSize": 832,
+              "resourceSize": 309,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "isLinkPreload": true,
+              "networkRequestTime": 402.84800000488758,
+              "rendererStartTime": 398.56899999082088,
+              "networkEndTime": 449.11900000274181,
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 580.08099998533726,
+              "isLinkPreload": true,
+              "networkRequestTime": 403.10499998927116,
+              "rendererStartTime": 398.74099999666214,
+              "priority": "High",
+              "transferSize": 4149,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/_main.(_lang).jobs._slug-BoqAb8sy.js",
+              "resourceSize": 9508
+            },
+            {
+              "priority": "High",
+              "rendererStartTime": 399.04399998486042,
+              "networkRequestTime": 403.43599998950958,
+              "isLinkPreload": true,
+              "networkEndTime": 572.44499999284744,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "resourceSize": 337,
+              "url": "https://www.ocobo.co/assets/plus-Bvz3jpuZ.js",
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "transferSize": 857,
+              "resourceType": "Script"
+            },
+            {
+              "priority": "High",
+              "isLinkPreload": true,
+              "rendererStartTime": 399.32699999213219,
+              "networkRequestTime": 403.886000007391,
+              "networkEndTime": 573.4539999961853,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "resourceSize": 717,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "transferSize": 1237
+            },
+            {
+              "resourceSize": 474,
+              "resourceType": "Script",
+              "transferSize": 994,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/send-CYV-iugJ.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 572.76199999451637,
+              "rendererStartTime": 399.51700000464916,
+              "isLinkPreload": true,
+              "networkRequestTime": 404.54999999701977,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "networkRequestTime": 405.10799999535084,
+              "isLinkPreload": true,
+              "rendererStartTime": 399.7039999961853,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 465.39699999988079,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 495,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/badge-i9dgPBIb.js",
+              "resourceType": "Script",
+              "transferSize": 1017,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "resourceSize": 707,
+              "resourceType": "Script",
+              "transferSize": 1232,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/meta-pill-ClipWulT.js",
+              "finished": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 607.46600000560284,
+              "rendererStartTime": 399.95199999213219,
+              "isLinkPreload": true,
+              "networkRequestTime": 406.95999999344349,
+              "priority": "High",
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "resourceSize": 2533,
+              "url": "https://www.ocobo.co/assets/member-card-Bn7bfGBT.js",
+              "finished": true,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "transferSize": 1823,
+              "priority": "High",
+              "networkRequestTime": 407.12000000476837,
+              "rendererStartTime": 400.16099999845028,
+              "isLinkPreload": true,
+              "networkEndTime": 455.21299999952316,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "networkRequestTime": 408.34999999403954,
+              "rendererStartTime": 400.31599999964237,
+              "isLinkPreload": true,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 605.10699999332428,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 438,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/map-pin-BFjzXly_.js",
+              "transferSize": 961,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 551.78999999165535,
+              "isLinkPreload": true,
+              "rendererStartTime": 400.51199999451637,
+              "networkRequestTime": 409.73199999332428,
+              "priority": "High",
+              "resourceType": "Script",
+              "transferSize": 1176,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/star-BI6vQnwF.js",
+              "finished": true,
+              "resourceSize": 656
+            },
+            {
+              "resourceSize": 142638,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "transferSize": 51798,
+              "priority": "High",
+              "rendererStartTime": 400.66099999845028,
+              "isLinkPreload": true,
+              "networkRequestTime": 411.25699999928474,
+              "networkEndTime": 454.50199998915195,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "networkEndTime": 571.53599999845028,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkRequestTime": 413.5160000026226,
+              "isLinkPreload": true,
+              "rendererStartTime": 400.84099999070168,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 3508,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "transferSize": 1934,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/PageMarkdownContainer-klsUvxsc.js",
+              "protocol": "h2"
+            },
+            {
+              "resourceSize": 1217,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "transferSize": 1133,
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "protocol": "h2",
+              "networkEndTime": 448.71699999272823,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "rendererStartTime": 401.07299999892712,
+              "isLinkPreload": true,
+              "networkRequestTime": 416.15999999642372,
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "resourceType": "Script",
+              "transferSize": 1126,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "finished": true,
+              "resourceSize": 605,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "networkEndTime": 440.13899999856949,
+              "networkRequestTime": 419.56699998676777,
+              "rendererStartTime": 401.26499998569489,
+              "isLinkPreload": true,
+              "priority": "High"
+            },
+            {
+              "finished": true,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+              "protocol": "h2",
+              "mimeType": "font/otf",
+              "experimentalFromMainFrame": true,
+              "transferSize": 39127,
+              "resourceType": "Font",
+              "resourceSize": 58256,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "priority": "VeryHigh",
+              "rendererStartTime": 470.25299999117851,
+              "networkRequestTime": 471.27399998903275,
+              "networkEndTime": 489.16099998354912,
+              "sessionTargetType": "page"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 490.76000000536442,
+              "networkRequestTime": 471.39699999988079,
+              "rendererStartTime": 470.48000000417233,
+              "priority": "VeryHigh",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "resourceSize": 31480,
+              "resourceType": "Font",
+              "transferSize": 31975,
+              "mimeType": "font/woff",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff"
+            },
+            {
+              "transferSize": 40711,
+              "resourceType": "Font",
+              "experimentalFromMainFrame": true,
+              "mimeType": "font/otf",
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+              "finished": true,
+              "resourceSize": 60228,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "networkEndTime": 490.11299999058247,
+              "rendererStartTime": 470.76899999380112,
+              "networkRequestTime": 471.60799999535084,
+              "priority": "VeryHigh"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkEndTime": 496.27399998903275,
+              "sessionTargetType": "page",
+              "priority": "VeryHigh",
+              "networkRequestTime": 471.77599999308586,
+              "rendererStartTime": 470.92499999701977,
+              "experimentalFromMainFrame": true,
+              "mimeType": "font/otf",
+              "resourceType": "Font",
+              "transferSize": 38779,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+              "finished": true,
+              "protocol": "h2",
+              "resourceSize": 57572
+            },
+            {
+              "resourceSize": 97992,
+              "protocol": "h2",
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "finished": true,
+              "resourceType": "Script",
+              "transferSize": 29757,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 753.17299999296665,
+              "rendererStartTime": 752.11499999463558,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "networkEndTime": 778.58099998533726,
+              "entity": "Hubspot",
+              "statusCode": 200
+            },
+            {
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "rendererStartTime": 752.891999989748,
+              "networkRequestTime": 753.79099999368191,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "networkEndTime": 768.92700000107288,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "resourceType": "Script",
+              "transferSize": 27955,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 78203
+            },
+            {
+              "resourceSize": 109001,
+              "transferSize": 43664,
+              "resourceType": "Script",
+              "mimeType": "text/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 770.22900000214577,
+              "networkRequestTime": 754.7039999961853,
+              "rendererStartTime": 753.63199999928474,
+              "priority": "Low",
+              "statusCode": 200,
+              "entity": "Hubspot"
+            },
+            {
+              "resourceType": "Script",
+              "transferSize": 27219,
+              "mimeType": "text/javascript",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "resourceSize": 72678,
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "networkEndTime": 775.402999997139,
+              "rendererStartTime": 754.35699999332428,
+              "networkRequestTime": 756.11599999666214,
+              "priority": "Low"
+            },
+            {
+              "entity": "GitHub",
+              "statusCode": 200,
+              "networkRequestTime": 759.92299999296665,
+              "rendererStartTime": 758.76399999856949,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "networkEndTime": 772.56599999964237,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "resourceType": "Stylesheet",
+              "transferSize": 1998,
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/css",
+              "resourceSize": 4371
+            },
+            {
+              "resourceSize": 16667,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "transferSize": 17171,
+              "resourceType": "Image",
+              "priority": "Low",
+              "networkRequestTime": 761.84199999272823,
+              "rendererStartTime": 760.90599998831749,
+              "networkEndTime": 779.781999990344,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "statusCode": 204,
+              "entity": "Google Analytics",
+              "priority": "High",
+              "networkRequestTime": 921.695999994874,
+              "rendererStartTime": 919.55799999833107,
+              "networkEndTime": 931.45000000298023,
+              "sessionTargetType": "page",
+              "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65c1h1v9100339653za200zd9100339653&_p=1778779410745&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1295526350.1778779411&frm=0&pscdl=noapi&rcb=17&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616986~115938465~115938469&dp=%2Ffr%2Fjobs%2Frevenue-operations-manager&sid=1778779411&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Ffr%2Fjobs%2Frevenue-operations-manager&dt=Ocobo%20%C2%B7%20Revenue%20Operations%20Manager&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=919",
+              "finished": true,
+              "protocol": "h2",
+              "mimeType": "text/plain",
+              "experimentalFromMainFrame": true,
+              "transferSize": 796,
+              "resourceType": "Fetch",
+              "resourceSize": 0
+            },
+            {
+              "networkEndTime": 1014.9409999996424,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkRequestTime": 980.17800000309944,
+              "rendererStartTime": 978.68699999153614,
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "resourceSize": 135,
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "transferSize": 1095,
+              "resourceType": "XHR",
+              "finished": true,
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+              "protocol": "h2"
+            },
+            {
+              "resourceSize": 5,
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/plain",
+              "transferSize": 557,
+              "resourceType": "Fetch",
+              "finished": true,
+              "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+              "protocol": "h2",
+              "networkEndTime": 1043.3310000002384,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkRequestTime": 1024.5230000019073,
+              "rendererStartTime": 1022.9319999963045,
+              "entity": "Hubspot",
+              "statusCode": 200
+            },
+            {
+              "resourceSize": 45,
+              "transferSize": 1472,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/gif",
+              "protocol": "h2",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr%2Fjobs%2Frevenue-operations-manager&t=Ocobo+%C2%B7+Revenue+Operations+Manager&cts=1778779411375&vi=3a7ca9afb6c1031c2b87829ed4306091&nc=true&ce=false&cc=0",
+              "finished": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 1129.6829999983311,
+              "rendererStartTime": 1067.8539999872446,
+              "networkRequestTime": 1069.5269999951124,
+              "priority": "Low",
+              "entity": "Hubspot",
+              "statusCode": 200
+            },
+            {
+              "resourceSize": 61,
+              "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Ffr%2Fjobs%2Frevenue-operations-manager&utk=3a7ca9afb6c1031c2b87829ed4306091&__hstc=242475741.3a7ca9afb6c1031c2b87829ed4306091.1778779411372.1778779411372.1778779411372.1&__hssc=242475741.1.1778779411372&isMobile=true",
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "transferSize": 1720,
+              "resourceType": "Fetch",
+              "priority": "High",
+              "networkRequestTime": 1100.8940000087023,
+              "rendererStartTime": 1099.3069999963045,
+              "networkEndTime": 1200.2959999889135,
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "statusCode": 200
+            },
+            {
+              "resourceSize": 35,
+              "protocol": "http/1.1",
+              "finished": true,
+              "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+              "transferSize": 1021,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/gif",
+              "networkRequestTime": 1430.7810000032187,
+              "rendererStartTime": 1429.3939999938011,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "networkEndTime": 1527.5499999970198,
+              "statusCode": 200,
+              "entity": "Hubspot"
+            },
+            {
+              "resourceSize": 36401,
+              "finished": true,
+              "url": "https://tally.so/widgets/embed.js",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "transferSize": 14514,
+              "resourceType": "Script",
+              "priority": "Low",
+              "rendererStartTime": 2040.7759999930859,
+              "networkRequestTime": 2042.2009999901056,
+              "networkEndTime": 2085.5170000046492,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "tally.so"
+            },
+            {
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "transferSize": 204725,
+              "finished": true,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "protocol": "h2",
+              "resourceSize": 607831,
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "networkEndTime": 2083.5379999876022,
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "networkRequestTime": 2042.8770000040531,
+              "rendererStartTime": 2041.7499999850988
+            },
+            {
+              "resourceSize": 0,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "transferSize": 639,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 2043.7140000015497,
+              "networkRequestTime": 2045.7360000014305,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "networkEndTime": 2304.9809999912977,
+              "entity": "Clearbit",
+              "statusCode": 404
+            },
+            {
+              "networkRequestTime": 2045.96099999547,
+              "rendererStartTime": 2044.402999997139,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "networkEndTime": 2063.1759999990463,
+              "entity": "Hubspot",
+              "statusCode": 304,
+              "resourceSize": 2125,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "resourceType": "Script",
+              "transferSize": 879,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "priority": "Low",
+              "rendererStartTime": 2046.4749999940395,
+              "networkRequestTime": 2047.8959999978542,
+              "networkEndTime": 2073.1629999876022,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/_vercel/insights/script.js",
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "transferSize": 1865,
+              "resourceType": "Script",
+              "resourceSize": 2495
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 2049.9639999866486,
+              "rendererStartTime": 2048.0180000066757,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "networkEndTime": 2142.2129999995232,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "resourceType": "Script",
+              "transferSize": 5311,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 12567
+            },
+            {
+              "finished": true,
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fclients%2C%2Fen%2Fjobs%2Frevenue-operations-manager%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Fjobs%2Frevenue-operations-manager%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology&version=ba6d9b28",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "transferSize": 2498,
+              "resourceType": "Fetch",
+              "resourceSize": 16435,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "networkRequestTime": 2053.7709999978542,
+              "rendererStartTime": 2050.7300000041723,
+              "networkEndTime": 2213.3129999935627,
+              "sessionTargetType": "page"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "resourceType": "Fetch",
+              "transferSize": 473,
+              "url": "https://www.ocobo.co/_vercel/insights/view",
+              "finished": true,
+              "protocol": "h2",
+              "resourceSize": 48,
+              "entity": "ocobo.co",
+              "statusCode": 202,
+              "networkEndTime": 2215.6989999860525,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "networkRequestTime": 2169.819000005722,
+              "rendererStartTime": 2168.4049999862909
+            },
+            {
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "priority": "High",
+              "networkRequestTime": 2303.7129999995232,
+              "rendererStartTime": 2301.7580000013113,
+              "networkEndTime": 2371.0879999995232,
+              "sessionTargetType": "page",
+              "finished": true,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953&hutk=3a7ca9afb6c1031c2b87829ed4306091",
+              "protocol": "http/1.1",
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "resourceType": "XHR",
+              "transferSize": 4083,
+              "resourceSize": 9346
+            },
+            {
+              "resourceSize": 607831,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "transferSize": 1655,
+              "finished": true,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "protocol": "h2",
+              "networkEndTime": 2430.265000000596,
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "networkRequestTime": 2398.5049999952316,
+              "rendererStartTime": 2396.2889999896288,
+              "statusCode": 304,
+              "entity": "Hubspot"
+            },
+            {
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "networkEndTime": 2625.4369999915361,
+              "networkRequestTime": 2567.4549999982119,
+              "rendererStartTime": 2565.4839999973774,
+              "priority": "Low",
+              "transferSize": 1024,
+              "resourceType": "Image",
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "protocol": "http/1.1",
+              "finished": true,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+              "resourceSize": 35
+            },
+            {
+              "entity": "Google Fonts",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2583.3760000020266,
+              "rendererStartTime": 2572.2799999862909,
+              "networkRequestTime": 2573.7759999930859,
+              "priority": "VeryHigh",
+              "transferSize": 1259,
+              "resourceType": "Stylesheet",
+              "mimeType": "text/css",
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+              "resourceSize": 3792
+            },
+            {
+              "resourceSize": 50524,
+              "finished": true,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "protocol": "h2",
+              "mimeType": "font/woff2",
+              "transferSize": 51336,
+              "resourceType": "Font",
+              "priority": "VeryHigh",
+              "rendererStartTime": 2610.8560000061989,
+              "networkRequestTime": 2611.8239999860525,
+              "networkEndTime": 2616.7849999964237,
+              "sessionTargetType": "page",
+              "entity": "Google Fonts",
+              "statusCode": 200
+            },
+            {
+              "networkRequestTime": 2618.5949999988079,
+              "rendererStartTime": 2617.4780000001192,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "networkEndTime": 2623.7290000021458,
+              "entity": "Google Fonts",
+              "statusCode": 200,
+              "resourceSize": 50524,
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "transferSize": 51336,
+              "resourceType": "Font",
+              "mimeType": "font/woff2"
+            },
+            {
+              "finished": true,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=d3342a0b-3113-4d65-a582-dacda9aa0444&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr%2Fjobs%2Frevenue-operations-manager&t=Ocobo+%C2%B7+Revenue+Operations+Manager&cts=1778779412950&vi=3a7ca9afb6c1031c2b87829ed4306091&nc=true&u=242475741.3a7ca9afb6c1031c2b87829ed4306091.1778779411372.1778779411372.1778779411372.1&b=242475741.1.1778779411372&cc=15",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/gif",
+              "resourceType": "Image",
+              "transferSize": 1022,
+              "resourceSize": 45,
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "priority": "Low",
+              "networkRequestTime": 2648.76099999249,
+              "rendererStartTime": 2647.3239999860525,
+              "networkEndTime": 2737.1069999933243,
+              "sessionTargetType": "page"
+            },
+            {
+              "resourceSize": 35,
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "transferSize": 1023,
+              "resourceType": "Image",
+              "finished": true,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+              "protocol": "http/1.1",
+              "networkEndTime": 2720.6089999973774,
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "rendererStartTime": 2647.917999997735,
+              "networkRequestTime": 2649.9239999949932,
+              "statusCode": 200,
+              "entity": "Hubspot"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 2773.2039999961853,
+              "networkRequestTime": 2742.5199999958277,
+              "rendererStartTime": 2740.9120000004768,
+              "priority": "High",
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "resourceSize": 135,
+              "resourceType": "XHR",
+              "transferSize": 1095,
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=3a7ca9afb6c1031c2b87829ed4306091",
+              "finished": true
+            },
+            {
+              "finished": true,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr%2Fjobs%2Frevenue-operations-manager&t=Ocobo+%C2%B7+Revenue+Operations+Manager&cts=1778779413065&vi=3a7ca9afb6c1031c2b87829ed4306091&nc=true&u=242475741.3a7ca9afb6c1031c2b87829ed4306091.1778779411372.1778779411372.1778779411372.1&b=242475741.1.1778779411372&cc=15",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/gif",
+              "resourceType": "Image",
+              "transferSize": 1068,
+              "resourceSize": 45,
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "priority": "Low",
+              "networkRequestTime": 2761.6040000021458,
+              "rendererStartTime": 2760.5329999923706,
+              "networkEndTime": 2824.7440000027418,
+              "sessionTargetType": "page"
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "valueType": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "text",
+              "key": "protocol",
+              "label": "Protocol"
+            },
+            {
+              "granularity": 1,
+              "label": "Network Request Time",
+              "valueType": "ms",
+              "key": "networkRequestTime"
+            },
+            {
+              "valueType": "ms",
+              "key": "networkEndTime",
+              "label": "Network End Time",
+              "granularity": 1
+            },
+            {
+              "valueType": "bytes",
+              "key": "transferSize",
+              "granularity": 1,
+              "label": "Transfer Size",
+              "displayUnit": "kb"
+            },
+            {
+              "valueType": "bytes",
+              "key": "resourceSize",
+              "label": "Resource Size",
+              "displayUnit": "kb",
+              "granularity": 1
+            },
+            {
+              "key": "statusCode",
+              "valueType": "text",
+              "label": "Status Code"
+            },
+            {
+              "label": "MIME Type",
+              "valueType": "text",
+              "key": "mimeType"
+            },
+            {
+              "label": "Resource Type",
+              "valueType": "text",
+              "key": "resourceType"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "networkStartTimeTs": 125064358590,
+            "type": "debugdata",
+            "initiators": [
+              {
+                "lineNumber": 3,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 245
+              },
+              {
+                "lineNumber": 24,
+                "columnNumber": 695,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 24,
+                "columnNumber": 16820,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 9010,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "lineNumber": 25
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 141,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 261,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 360,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 460,
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 536,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 602,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 671,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 731,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 795,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 857,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 916,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "type": "parser",
+                "columnNumber": 985,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager"
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 1052,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 1119
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 1176,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 1238
+              },
+              {
+                "columnNumber": 1297,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 1361,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "lineNumber": 40,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 1427
+              },
+              {
+                "columnNumber": 1488,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 1556,
+                "lineNumber": 40
+              },
+              {
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 1622,
+                "lineNumber": 40
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 1693,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1751,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "lineNumber": 40
+              },
+              {
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 1811,
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 1886,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "lineNumber": 40,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 1947
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 2005,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 2069,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 2129,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 2188
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 2250,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 2311
+              },
+              {
+                "columnNumber": 2374,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 2430,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 2498,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2565,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 2626,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 2705,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "lineNumber": 40,
+                "type": "parser",
+                "columnNumber": 2764,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager"
+              },
+              {
+                "columnNumber": 2823,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "columnNumber": 2882,
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 2942,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 3006,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 3072,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "type": "parser",
+                "columnNumber": 3134,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager"
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 3193,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 3266,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 40,
+                "columnNumber": 3342,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 3405,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "columnNumber": 3464,
+                "url": "https://www.ocobo.co/fr/jobs/revenue-operations-manager",
+                "type": "parser",
+                "lineNumber": 40
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                "type": "parser"
+              },
+              {
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                "type": "parser"
+              }
+            ]
+          }
+        }
+      },
+      "largest-contentful-paint": {
+        "id": "largest-contentful-paint",
+        "title": "Largest Contentful Paint",
+        "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)",
+        "score": 0.02,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "8.2 s",
+        "numericValue": 8176.3278016177519,
+        "numericUnit": "millisecond"
+      },
+      "user-timings": {
+        "id": "user-timings",
+        "title": "User Timing marks and measures",
+        "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more about User Timing marks](https://developer.chrome.com/docs/lighthouse/performance/user-timings/).",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "details": {
+          "type": "table",
+          "items": [],
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "name",
+              "label": "Name"
+            },
+            {
+              "label": "Type",
+              "valueType": "text",
+              "key": "timingType"
+            },
+            {
+              "granularity": 0.01,
+              "valueType": "ms",
+              "key": "startTime",
+              "label": "Start Time"
+            },
+            {
+              "granularity": 0.01,
+              "valueType": "ms",
+              "key": "duration",
+              "label": "Duration"
+            }
+          ]
+        }
+      },
+      "render-blocking-insight": {
+        "id": "render-blocking-insight",
+        "title": "Render blocking requests",
+        "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 980 ms",
+        "metricSavings": {
+          "LCP": 1000,
+          "FCP": 1000
+        },
+        "details": {
+          "type": "table",
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "key": "totalBytes"
+            },
+            {
+              "valueType": "timespanMs",
+              "key": "wastedMs",
+              "label": "Duration"
+            }
+          ],
+          "items": [
+            {
+              "wastedMs": 164,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "totalBytes": 24570
+            }
+          ]
+        }
+      },
+      "document-latency-insight": {
+        "id": "document-latency-insight",
+        "title": "Document request latency",
+        "description": "Your first network request is the most important. [Reduce its latency](https://developer.chrome.com/docs/performance/insights/document-latency) by avoiding redirects, ensuring a fast server response, and enabling text compression.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": {
+            "usesCompression": {
+              "value": true,
+              "label": "Applies text compression"
+            },
+            "serverResponseIsFast": {
+              "value": true,
+              "label": "Server responds quickly (observed 13 ms)"
+            },
+            "noRedirects": {
+              "value": true,
+              "label": "Avoids redirects"
+            }
+          },
+          "debugData": {
+            "wastedBytes": 0,
+            "redirectDuration": 0,
+            "uncompressedResponseBytes": 0,
+            "serverResponseTime": 13,
+            "type": "debugdata"
+          },
+          "type": "checklist"
+        }
+      },
+      "redirects": {
+        "id": "redirects",
+        "title": "Avoid multiple page redirects",
+        "description": "Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://developer.chrome.com/docs/lighthouse/performance/redirects/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [],
+          "overallSavingsMs": 0,
+          "type": "opportunity"
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "cumulative-layout-shift": {
+        "id": "cumulative-layout-shift",
+        "title": "Cumulative Layout Shift",
+        "description": "Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/articles/cls).",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "0.016",
+        "details": {
+          "items": [
+            {
+              "newEngineResultDiffered": false,
+              "cumulativeLayoutShiftMainFrame": 0.015853
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 0.015853,
+        "numericUnit": "unitless"
+      },
+      "network-server-latency": {
+        "id": "network-server-latency",
+        "title": "Server Backend Latencies",
+        "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "40 ms",
+        "details": {
+          "type": "table",
+          "sortedBy": [
+            "serverResponseTime"
+          ],
+          "items": [
+            {
+              "serverResponseTime": 43,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "serverResponseTime": 10,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "serverResponseTime": 4.5,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "origin": "https://js-eu1.hubspot.com",
+              "serverResponseTime": 2
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://tally.so"
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "origin": "https://js-eu1.hs-scripts.com",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "serverResponseTime": 0.5,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://useago.github.io"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://perf-eu1.hsforms.com"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "origin",
+              "label": "URL"
+            },
+            {
+              "granularity": 1,
+              "label": "Time Spent",
+              "valueType": "ms",
+              "key": "serverResponseTime"
+            }
+          ]
+        },
+        "numericValue": 43,
+        "numericUnit": "millisecond"
+      },
+      "long-tasks": {
+        "id": "long-tasks",
+        "title": "Avoid long main-thread tasks",
+        "description": "Lists the longest tasks on the main thread, useful for identifying worst contributors to input delay. [Learn how to avoid long main-thread tasks](https://web.dev/articles/optimize-long-tasks)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "12 long tasks found",
+        "metricSavings": {
+          "TBT": 850
+        },
+        "details": {
+          "sortedBy": [
+            "duration"
+          ],
+          "items": [
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "startTime": 4121.8250586082595,
+              "duration": 200
+            },
+            {
+              "duration": 200,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "startTime": 8551.3434112185987
+            },
+            {
+              "duration": 158,
+              "startTime": 12998.546439969028,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "startTime": 8251.330923537922,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "duration": 144
+            },
+            {
+              "duration": 139,
+              "startTime": 4378.8250586082595,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            },
+            {
+              "startTime": 3830.8250586082595,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "duration": 127
+            },
+            {
+              "startTime": 7104.280972815216,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "duration": 106
+            },
+            {
+              "duration": 104,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "startTime": 5630.0249753613534
+            },
+            {
+              "startTime": 7234.280972815216,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "duration": 89
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "startTime": 3986.8250586082595,
+              "duration": 80
+            },
+            {
+              "startTime": 5734.0249753613534,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "duration": 77
+            },
+            {
+              "duration": 61,
+              "startTime": 7362.280972815216,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js"
+            }
+          ],
+          "debugData": {
+            "tasks": [
+              {
+                "urlIndex": 0,
+                "duration": 200,
+                "other": 200,
+                "startTime": 4121.8
+              },
+              {
+                "urlIndex": 1,
+                "duration": 200,
+                "other": 200,
+                "startTime": 8551.3
+              },
+              {
+                "urlIndex": 2,
+                "other": 158,
+                "scriptEvaluation": 0,
+                "duration": 158,
+                "startTime": 12998.5
+              },
+              {
+                "startTime": 8251.3,
+                "duration": 144,
+                "scriptEvaluation": 0,
+                "other": 144,
+                "urlIndex": 2
+              },
+              {
+                "duration": 139,
+                "urlIndex": 0,
+                "startTime": 4378.8,
+                "other": 139
+              },
+              {
+                "scriptEvaluation": 0,
+                "other": 127,
+                "urlIndex": 0,
+                "startTime": 3830.8,
+                "duration": 127
+              },
+              {
+                "urlIndex": 3,
+                "scriptEvaluation": 0,
+                "other": 106,
+                "duration": 106,
+                "startTime": 7104.3
+              },
+              {
+                "duration": 104,
+                "startTime": 5630,
+                "urlIndex": 3,
+                "scriptEvaluation": 0,
+                "other": 104
+              },
+              {
+                "scriptEvaluation": 0,
+                "other": 89,
+                "urlIndex": 4,
+                "startTime": 7234.3,
+                "duration": 89
+              },
+              {
+                "other": 80,
+                "startTime": 3986.8,
+                "urlIndex": 0,
+                "duration": 80
+              },
+              {
+                "duration": 77,
+                "startTime": 5734,
+                "urlIndex": 3,
+                "scriptEvaluation": 0,
+                "other": 77
+              },
+              {
+                "other": 61,
+                "scriptEvaluation": 0,
+                "urlIndex": 0,
+                "startTime": 7362.3,
+                "duration": 61
+              }
+            ],
+            "urls": [
+              "https://js-eu1.hs-analytics.net/analytics/1778774100000/27107933.js",
+              "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            ],
+            "type": "debugdata"
+          },
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Start Time",
+              "valueType": "ms",
+              "key": "startTime",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "duration",
+              "label": "Duration"
+            }
+          ],
+          "type": "table",
+          "skipSumming": [
+            "startTime"
+          ]
+        }
+      },
+      "total-blocking-time": {
+        "id": "total-blocking-time",
+        "title": "Total Blocking Time",
+        "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).",
+        "score": 0.35,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "830 ms",
+        "numericValue": 831,
+        "numericUnit": "millisecond"
+      },
+      "lcp-breakdown-insight": {
+        "id": "lcp-breakdown-insight",
+        "title": "LCP breakdown",
+        "description": "Each [subpart has specific improvement strategies](https://developer.chrome.com/docs/performance/insights/lcp-breakdown). Ideally, most of the LCP time should be spent on loading the resources, not within delays.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "items": [
+                {
+                  "duration": 0.859,
+                  "label": "Time to first byte",
+                  "subpart": "timeToFirstByte"
+                },
+                {
+                  "duration": 2038.898,
+                  "subpart": "elementRenderDelay",
+                  "label": "Element render delay"
+                }
+              ],
+              "headings": [
+                {
+                  "valueType": "text",
+                  "key": "label",
+                  "label": "Subpart"
+                },
+                {
+                  "valueType": "ms",
+                  "key": "duration",
+                  "label": "Duration"
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "snippet": "\u003ch1 class=\"text text--variant_display-lg text--color_dark fs_4xl md:fs_6xl mb_10 lh_1…\"\u003e",
+              "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,1,DIV,0,DIV,1,DIV,1,H1",
+              "type": "node",
+              "nodeLabel": "Revenue Operations Manager",
+              "lhId": "page-0-H1",
+              "selector": "div.max-w_7xl \u003e div.mb_20 \u003e div.max-w_5xl \u003e h1.text",
+              "boundingRect": {
+                "top": 347,
+                "bottom": 423,
+                "left": 16,
+                "height": 76,
+                "width": 380,
+                "right": 396
+              }
+            }
+          ],
+          "type": "list"
+        }
+      }
+    },
+    "categories": {
+      "performance": {
+        "id": "performance",
+        "title": "Performance",
+        "score": 0.5,
+        "auditRefs": [
+          {
+            "id": "first-contentful-paint",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "FCP"
+          },
+          {
+            "id": "largest-contentful-paint",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "LCP"
+          },
+          {
+            "id": "total-blocking-time",
+            "weight": 30,
+            "group": "metrics",
+            "acronym": "TBT"
+          },
+          {
+            "id": "cumulative-layout-shift",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "CLS"
+          },
+          {
+            "id": "speed-index",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "SI"
+          },
+          {
+            "id": "cache-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "cls-culprits-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "document-latency-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "dom-size-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "duplicated-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "font-display-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "forced-reflow-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "image-delivery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "inp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-discovery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "legacy-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "network-dependency-tree-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "render-blocking-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "third-parties-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "viewport-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "interactive",
+            "weight": 0,
+            "group": "hidden",
+            "acronym": "TTI"
+          },
+          {
+            "id": "max-potential-fid",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "unminified-css",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unminified-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-css-rules",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "total-byte-weight",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "user-timings",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "bootup-time",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "mainthread-work-breakdown",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "long-tasks",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "non-composited-animations",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unsized-images",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "network-requests",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-rtt",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-server-latency",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "main-thread-tasks",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "diagnostics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "metrics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "screenshot-thumbnails",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "final-screenshot",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "script-treemap-data",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "resource-summary",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "redirects",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "server-response-time",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "layout-shifts",
+            "weight": 0,
+            "group": "hidden"
+          }
+        ]
+      }
+    },
+    "categoryGroups": {
+      "a11y-language": {
+        "title": "Internationalization and localization",
+        "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      },
+      "best-practices-general": {
+        "title": "General"
+      },
+      "a11y-tables-lists": {
+        "title": "Tables and lists",
+        "description": "These are opportunities to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+      },
+      "best-practices-trust-safety": {
+        "title": "Trust and Safety"
+      },
+      "seo-mobile": {
+        "title": "Mobile Friendly",
+        "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn how to make pages mobile-friendly](https://developers.google.com/search/mobile-sites/)."
+      },
+      "seo-content": {
+        "title": "Content Best Practices",
+        "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "description": "More information about the performance of your application. These numbers don't [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score."
+      },
+      "a11y-names-labels": {
+        "title": "Names and labels",
+        "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "a11y-aria": {
+        "title": "ARIA",
+        "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "a11y-color-contrast": {
+        "title": "Contrast",
+        "description": "These are opportunities to improve the legibility of your content."
+      },
+      "a11y-audio-video": {
+        "title": "Audio and video",
+        "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+      },
+      "insights": {
+        "title": "Insights",
+        "description": "These insights are also available in the Chrome DevTools Performance Panel - [record a trace](https://developer.chrome.com/docs/devtools/performance/reference) to view more detailed information."
+      },
+      "seo-crawl": {
+        "title": "Crawling and Indexing",
+        "description": "To appear in search results, crawlers need access to your app."
+      },
+      "a11y-best-practices": {
+        "title": "Best practices",
+        "description": "These items highlight common accessibility best practices."
+      },
+      "best-practices-browser-compat": {
+        "title": "Browser Compatibility"
+      },
+      "a11y-navigation": {
+        "title": "Navigation",
+        "description": "These are opportunities to improve keyboard navigation in your application."
+      },
+      "metrics": {
+        "title": "Metrics"
+      },
+      "best-practices-ux": {
+        "title": "User Experience"
+      }
+    },
+    "timing": {
+      "total": 19682
+    },
+    "i18n": {
+      "rendererFormattedStrings": {
+        "varianceDisclaimer": "Values are estimated and may vary. The [performance score is calculated](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) directly from these metrics.",
+        "opportunityResourceColumnLabel": "Opportunity",
+        "opportunitySavingsColumnLabel": "Estimated Savings",
+        "errorMissingAuditInfo": "Report error: no audit information",
+        "errorLabel": "Error!",
+        "warningHeader": "Warnings: ",
+        "passedAuditsGroupTitle": "Passed audits",
+        "notApplicableAuditsGroupTitle": "Not applicable",
+        "manualAuditsGroupTitle": "Additional items to manually check",
+        "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+        "crcLongestDurationLabel": "Maximum critical path latency:",
+        "crcInitialNavigation": "Initial Navigation",
+        "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+        "labDataTitle": "Lab Data",
+        "warningAuditsGroupTitle": "Passed audits but with warnings",
+        "snippetExpandButtonLabel": "Expand snippet",
+        "snippetCollapseButtonLabel": "Collapse snippet",
+        "thirdPartyResourcesLabel": "Show 3rd-party resources",
+        "runtimeDesktopEmulation": "Emulated Desktop",
+        "runtimeMobileEmulation": "Emulated Moto G Power",
+        "runtimeNoEmulation": "No emulation",
+        "runtimeSettingsBenchmark": "Unthrottled CPU/Memory Power",
+        "runtimeSettingsCPUThrottling": "CPU throttling",
+        "runtimeSettingsDevice": "Device",
+        "runtimeSettingsNetworkThrottling": "Network throttling",
+        "runtimeSettingsUANetwork": "User agent (network)",
+        "runtimeUnknown": "Unknown",
+        "dropdownCopyJSON": "Copy JSON",
+        "dropdownDarkTheme": "Toggle Dark Theme",
+        "dropdownPrintExpanded": "Print Expanded",
+        "dropdownPrintSummary": "Print Summary",
+        "dropdownSaveGist": "Save as Gist",
+        "dropdownSaveHTML": "Save as HTML",
+        "dropdownSaveJSON": "Save as JSON",
+        "dropdownViewer": "Open in Viewer",
+        "footerIssue": "File an issue",
+        "throttlingProvided": "Provided by environment",
+        "calculatorLink": "See calculator.",
+        "runtimeSettingsAxeVersion": "Axe version",
+        "viewTreemapLabel": "View Treemap",
+        "showRelevantAudits": "Show audits relevant to:"
+      }
+    },
+    "entities": [
+      {
+        "name": "ocobo.co",
+        "isFirstParty": true,
+        "isUnrecognized": true,
+        "origins": [
+          "https://www.ocobo.co"
+        ]
+      },
+      {
+        "name": "vercel-storage.com",
+        "isUnrecognized": true,
+        "origins": [
+          "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+        ]
+      },
+      {
+        "name": "Google Tag Manager",
+        "homepage": "https://marketingplatform.google.com/about/tag-manager/",
+        "category": "tag-manager",
+        "origins": [
+          "https://www.googletagmanager.com"
+        ]
+      },
+      {
+        "name": "Clearbit",
+        "homepage": "https://clearbit.com/",
+        "category": "analytics",
+        "origins": [
+          "https://tag.clearbitscripts.com"
+        ]
+      },
+      {
+        "name": "Hubspot",
+        "homepage": "https://hubspot.com/",
+        "category": "marketing",
+        "origins": [
+          "https://js-eu1.hs-scripts.com",
+          "https://js-eu1.hubspot.com",
+          "https://js-eu1.hscollectedforms.net",
+          "https://js-eu1.hs-analytics.net",
+          "https://js-eu1.hs-banner.com",
+          "https://forms-eu1.hscollectedforms.net",
+          "https://track-eu1.hubspot.com",
+          "https://cta-eu1.hubspot.com",
+          "https://perf-eu1.hsforms.com",
+          "https://js-eu1.hsforms.net",
+          "https://forms-eu1.hsforms.com"
+        ]
+      },
+      {
+        "name": "GitHub",
+        "category": "utility",
+        "origins": [
+          "https://useago.github.io"
+        ]
+      },
+      {
+        "name": "Google Analytics",
+        "homepage": "https://marketingplatform.google.com/about/analytics/",
+        "category": "analytics",
+        "origins": [
+          "https://www.google-analytics.com"
+        ]
+      },
+      {
+        "name": "tally.so",
+        "isUnrecognized": true,
+        "origins": [
+          "https://tally.so"
+        ]
+      },
+      {
+        "name": "Google Fonts",
+        "homepage": "https://fonts.google.com/",
+        "category": "cdn",
+        "origins": [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com"
+        ]
+      }
+    ],
+    "fullPageScreenshot": {
+      "nodes": {
+        "page-6-IMG": {
+          "height": 0,
+          "right": 0,
+          "id": "open-path",
+          "width": 0,
+          "bottom": 0,
+          "top": 0,
+          "left": 0
+        },
+        "page-14-BUTTON": {
+          "height": 0,
+          "width": 0,
+          "id": "ago-prompt-close",
+          "right": 0,
+          "top": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "page-2-DIV": {
+          "left": 0,
+          "top": 0,
+          "bottom": 0,
+          "width": 0,
+          "right": 0,
+          "height": 0
+        },
+        "1-2-IMG": {
+          "height": 100,
+          "right": 149,
+          "width": 100,
+          "bottom": 5477,
+          "top": 5377,
+          "left": 49
+        },
+        "page-8-META": {
+          "height": 0,
+          "width": 0,
+          "right": 0,
+          "top": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "page-7-IMG": {
+          "height": 40,
+          "width": 134,
+          "right": 167,
+          "top": 37,
+          "bottom": 77,
+          "left": 33
+        },
+        "1-4-IMG": {
+          "height": 0,
+          "right": 0,
+          "width": 0,
+          "bottom": 0,
+          "top": 0,
+          "left": 0
+        },
+        "page-1-H1": {
+          "left": 0,
+          "top": 0,
+          "bottom": 0,
+          "width": 0,
+          "right": 0,
+          "height": 0
+        },
+        "1-0-IMG": {
+          "left": 33,
+          "top": 37,
+          "bottom": 77,
+          "width": 134,
+          "right": 167,
+          "height": 40
+        },
+        "page-13-DIV": {
+          "top": 0,
+          "bottom": 0,
+          "left": 0,
+          "height": 0,
+          "id": "ago-prompt",
+          "width": 0,
+          "right": 0
+        },
+        "page-11-IMG": {
+          "height": 0,
+          "width": 0,
+          "right": 0,
+          "top": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "page-4-LINK": {
+          "right": 0,
+          "width": 0,
+          "height": 0,
+          "left": 0,
+          "bottom": 0,
+          "top": 0
+        },
+        "page-12-IMG": {
+          "left": 0,
+          "bottom": 0,
+          "top": 0,
+          "right": 0,
+          "width": 0,
+          "height": 0
+        },
+        "page-5-IMG": {
+          "bottom": 5477,
+          "top": 5377,
+          "left": 49,
+          "height": 100,
+          "right": 149,
+          "width": 100
+        },
+        "page-0-H1": {
+          "height": 76,
+          "right": 396,
+          "width": 380,
+          "bottom": 423,
+          "top": 347,
+          "left": 16
+        },
+        "page-3-LINK": {
+          "height": 0,
+          "right": 0,
+          "width": 0,
+          "bottom": 0,
+          "top": 0,
+          "left": 0
+        },
+        "1-3-IMG": {
+          "left": 0,
+          "top": 0,
+          "bottom": 0,
+          "width": 0,
+          "right": 0,
+          "height": 0
+        },
+        "page-9-BODY": {
+          "left": 0,
+          "top": 0,
+          "bottom": 0,
+          "width": 0,
+          "right": 0,
+          "height": 0
+        },
+        "page-10-path": {
+          "top": 0,
+          "bottom": 0,
+          "left": 0,
+          "height": 0,
+          "width": 0,
+          "right": 0
+        },
+        "1-1-IMG": {
+          "right": 0,
+          "width": 0,
+          "height": 0,
+          "left": 0,
+          "bottom": 0,
+          "top": 0
+        }
+      },
+      "screenshot": {
+        "height": 7451,
+        "width": 412,
+        "data": "data:image/webp;base64,UklGRr42AgBXRUJQVlA4WAoAAAAgAAAAmwEAGh0ASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZWUDgg0DQCAHDqCZ0BKpwBGx0/EYa7VqwpM6kj0np6cCIJZ278Xo/96NVEJedKTXFgevtrKZjU8xmP/bn9f/E9/fujM95PfE+Sn7R/Q+cf/k+sHzD/7L0S/MB+2Hq6/+X1e/4P0mfSd/7P/////wmf3z/uf//3EvOY9Xr/Hel/1e/S/+F/zf/Yf2D/Ie4L5T+0f7L++/5j/2/5j0l8pf0j+B/0n/l/PL7KPw//y/0fhb9Q/sf/f/sP+B++vwh/PfyH/g/yf7//9r5l/w//d/0P+c8jf0L+H/az2Bfb3/0/1n/B9xX5f/2f4X/Ld7Fqf+r/9H+V/0X7+/IL7efd/2f/1/7/+9R8T/4f8F/qP3t+Cv2L/P/+f/Lf6L5Af7Z57f8XwWvzH/R/dn4Bf51/kv/r/ov9t8NX+V//P+d/4fUf9kfuh8B/9U/yf/+/4//k9v////CD99//////iVI/Eg4ZeJBwy8SDhl4kHDLxIOGXiQcMvEg4ZeJBwy75dKxKA14kHDLxID9FxWJtlQTWOYBlcguNEw6lnm5oN4eZ1ra/ckKRW+/ov6NH+I5F4Rz+GupSbEQNppBvw4Zz88S6ghs37i/0vbkw2jgsaBlW1Csi10qGMVpm/hyKYsNmkMGMNlW7Xf6i7QedP+4v12l5TbaCNuFVziUPEunemgvS3ATiQcudcS6xzNGnih4l1BDxLqCHiXUEPEuoIeJdQQ8S6gh4l1BDxLqCHiXUEPEuoIeJdQQ8S6gh4l1BDxLqCHiXUEPEuoIeJdQQ8S6gh4l1BDxLqCHiXUEPEuoIeJdQQ8S6gh4l1BDxLqCHiXUEPEuoIeJdQQ8S6gh4l04+rJNsTXN9GAXOUQbKCkhO0DZEsi/abYO6z2UuHGtoc//UkjQ01WLZEcA+aYqOCosvEg4ZeJBy51yr7svEioMmJFQZMSKgyYkVBkxIqDJiRUGTEioMmJFQZMSKgyYkVBkxIfFsER/eYwyaB+U8qZ/mpPDJvzQE3j/LWH5+xKMl1ZrIcpXh28ObGEX2lzpm5ipxMNaPKgyYkVBkwY9mCcxj968eeubBBCZlASGHYRcMvqdlNsQ3FZf14xP8dKPve+qooYpRHszp7/N09qmtBkxIqDJiZ+XiB424xvl4kVBkxIqDJiRmEXpx0sgVQRLpxT8mJlnXq32b8O6bv0HtcZ4ZQa16PIwv1e1YffbZoGMREHpKKoUgqu7DDzlwt/u3xlgOIu4u5jiYA62D6H0gGoNr/R9/eUiZW/T9z1Bhk2KmBWYZLM2RsHadt3Y7SYKNMnioDHpoYqbiC1wUxgF/RFj3ErLqPdICbbaJpmCxBQ9KY90aKG267WnbTm1xdXA805bUcnNxLzlZdhsh/f+m8+L/t6/RZ1Zvdsyd+LS2JKnr3BmKvCvTpFYrlK/dO+4lixv9SmRHuqjJdgAJsm+rwUZtqHoxKgyYkP159zbqP4pp4jxnFbrNJwxHarm94l4InwRYxJsjddN09wFKBMQJ+ExeVFl4JuutZmUpChYuTwD0CRQCLVpiZMSzTGNozIu40H7WKOFm5DrvE2Yt7WWsp2uBGF9w3ZQpq06sCGGzRTVNPFDxLqCWLotSTWlPvJ92JoQ+tgh4l1BDxLqCHiXUEYriRUGTEioMmJFQZMSKgyYkVBkxIqAssfM0p0a4QNrx5n5kCg+aTEAKkJEklm9v7eGqjSC/mqRrxlOv7AcBibsAuoIeJeXzF3NdOHKH1IXqNMduft96XgmTjRIHMo1m9HiXdnp7j6dSM1Ibn7iRUGJfmeKHvM40GfgSShEuoIeJdQRFUoUxuJFQZMSKgyYkUts3L3FUHhMClNo8Np2S+OcUep5XGUqnzIwPKVJOJBwy8SDhl4icHIhPChp4oeJdQQ8S6gh5WhVTyeKHiXUEPEuoIeJeDrZeJFQZMSKgyYkVBkxIqDJiRUGTEioMmJFQZMSKgyYkVAaaZrp0mIXwpjwcq5FrnqLhQ4ZeJBwy8SDhirAySWcr6fT4LzO4sKAEsp8jCnQrX7p4HsOq27D/mO54oeJdQQ8S6gliuTxSuJdQQ8S6gh4l1BDxLqCHiXUEPEuoIeJZWyp49hKsO736a3mqlIpu1Y7UfHcnBAluOBhxjqQsvEg4ZeJBwy8SEsEsVyeKHiXUEPEuoIeJdQQ8S6gh4l1BDxLlSZvCTA63DwLwhwcWF0Px//bjFM+N2K15GW4wbW8kXYY7wxmjTxQ8S6gh4l1BK4l1BDxLqCHiXUEPEuoIeJdQQ8S6gh4aMEQK/GfDy85IbKxWGQuozenn28OZFK7LxIqDJiRUGTSEhLkmtGnih4l1BDxLqCHiXUEPEuoIeJdOGg4B/O1rg+Uer4f2wrF5Fq9zKlm4kVBkxIqDJiRV0USZLTs8UPEuoIeJdQQ8S6gh4l1BDxLqCHiXKp/8xIKNCrU0q/QuKDjh3DXGIz5ckgw7PR+ck68MxbORGq2ciNVkgbhSWBfPY9PmRwrGqLD/9qZBm2UVp3kqwz79lTKvxrHZZmfuJtv7FAHaqZ7ZGcxGsd4CKzLYp385MHZRtQ26b/tBJzwQ5P/G7H6QVu+/7D0zyAziNGPolwIJk7Tf1sVhysgnKWsftHbLxUIz3jO6e6g1fM3I0HECT9O7nTlXNyPW2ojk+1ephQ4jSqptqU28yDPuWeHdhG3NZXxhMB41I3oDrgdtDZVC4kGAaTv/YIvUcdvIJ9wHkrkXr1KUdvgQLcUnouR6Tyb6Sz8y7UChUf/N8g51ig8uDlIjwvYpjJgBupjx6KygeNywv+KHUoeNnmZDB/RqWFhwzZK1BP7AJx2Sr+OzZi0RQuw3GTOLhxxA/QmZM4nx4sLR3SAUEKSG0PZGcxHYWyHcxVpYftPH7ArPwVGLPB4DNtwV9gvf78v2aJrUbz4yur7jnx1zj0Vd925kV6no5nqFTrlg2Kcy2a0yp80v0QJy9hGtHMZ8v+NQt1PMQVLyDKT6HNWGDdTOLC9fITObW3O3JRwqfMww9IHNqeBFOi1wmSVcVHoBpd7NUc2aTkHgXcYl1soag/ib8nHSSZNpPvckGfOUdkTWkAMHswxLwdaW4DPjGILVqrJRFaA7Y2NrPfJaVbrqCcdugqIoG+Zbj8iJVrKG+gLmH/WtgEQWnQY34WPpPqX054l1BCdsV27HLu8blx1DIqDJiRD8NYRtChQ9uLjppV+hcUHHDuGuHkkDlicy5LMyChRFTg/HcDpgEYPPgLd4yViWlQCbYwxx3DtxAN3H/f0L1xa9RzSPmBYpqG4MYkTVMLC68c+44XKNj15CwWGGyiZfcl2Of2CXT2Lm8dB5wQ4I7i4HiWZNiu29BAq1NKQ62hStO9w1xiIGoPC23vZzna0FPsbUDb8FPsbUDbOkAHvwMikBzr4nprEWWK4a4xFliuGuMRZYrhgdsiB6fpWSyAqfSslkBU+lOVyxrmbSyAqfSslkBU+lZJCeKHiXUEPEuoIeJdQQ8SondvjPs7cV5vW3qJ/qOh1tPpTrqkAtaK1R9XoDI4G2Qf3JkMgoyGFH/LdDxpSnO2bB7XNnMKLxr7GAAL8aHcw2F9cPYmVI9J/YajQ6B9mTJjujALjmgHI39xgS/bY9VBlbBhHryd1YhTDAfHDGnlI/mWxJLuDwVbarAnI3PrKm+QwyltlorclSt9qXquoqFCTyNzGe25blw2Vv08VNS7BkfypuKbPM+11A/22xFcIBwo2+Qn6B3T82S7kbqXghG7UD3iahpE3VnAjt0k+7IPEDjGaf7kFK2H6NSbsFQ5Bs3RMLOg9BIt06PdthLlLFP96/MjSgGPYeAPOt/uCNHwOGlecl4kQnFci3ZfRbrTTwoj/hKq4gOmTGnc0j/My2ZRovjnMo8PIui8c0qrwqWGUaJY0jKqO/jeH0PHrxjqc5hrQFtvNCWfIFx63qQFfgQYJtp4XPQdr4ZIedk0Iw3rPghVUt/UJ3+HXhjghN6t+8WJrsi5aNUGQcUrULKXj6BOticXALqBacyefgzB7yvXs+YxnYVfo7hJ3GYTFZcO2H63ym/jJ5iApaDPKYOPWIliXJRt7fLc94Ef5uqpy2WaquQOUf5voRMZ7eJxbcJx6DRyWZO9K/8uXAfJ6fh/V6ukA+YSouvroZWCUPq8BYMYwNzCBm+4dneT8mDXQ5rcM0C/JTo+bAu52rtRvjHqwLUePhvYD7Yn6cH4TImWwnd5t+Zv+JxSiOfyQuTAU7jgm6rmeh8OpnWh9H7/umAE3auATkw3Ib/ZGgbC/GHFt0P5lt6+IQIPI/3KN5EoLjeSMRQoJD4vToS9XJQ9LfsA55qIkWN/plYcRM14PnnsIRbmff/I+kkfzSnlYKb30tlfFiGPiKaLctXpTLzI9k14cOZZ/P5K1HxaDdnEf9RIM4Ix60mOfA2yqZprQ/WwIUNhlWpO+LP2OmEF+j/hA4Sfutnis+ygFwaPBlbXGHvidmRtbmvSidiIKVxVLB5n7SAkxiC0PJyoO7MmsiWedrA1AdHnCJr8C2gNNoKOVwMHOw2UdyRJZcE2E0EMPLkRl+LIg0A5kxd+CoPIVNAFkk2T31uK/uZGEIdaB2botWlg/uljP2GH1it7QYG3EVVh7IHtZPLG46xKC2m3+M20mFk4blOI7seohfrmNUbOxU/3qrlesweNwSy/wYG04XB+DeMT93nocKDR+anWlzjJt1ngc2Tw1pMOhDOKg6PaGt1OQMkWNeL1zhPBteQXmZH5f62GVQWRF6u77SHT8rTkOTceWGzDSTVbABbvnN3HWBudGWLGxTYld0xQgfLyaugKG+ds0Q0NK9eFaDDlTCdUdQ+QoD0uXfVNoDJ38U6S/Ky6J0korjRQSyeWWeiPv7LIMXl1kRZ0aZdxy3rLZ3zrJAyR+kM8BBvvlIfIoAMSb+IiNNi/kyiVYZ/V4gl3/rJJ0beu9t0QD4b3mqY8kr1y5Qk0W1oFc8bbbkV8oD+qD6N7Ql8FXlYCpkmHr4IqJJEnGXI8NxMyvrk6QBCxNMFphJz8M7MA0za+yME5lICLJoBYfZkc7ritI0jhuKrIArgpA5pz4Tff08Ib/HvdQV7VFXGEIsBnBEuEjKJmmW6/Z3/GTqZLsPBDJISXtRmjnk2qCt/JHD7r0hX4Qw8o45CBumTexsICTivxlCmE2ElT5GW4xKvFOZAzDNzABXWcosVrsOY2gTEDWxTpmXNsMiwyQlKssWWipg9B8obyvhqinyablFsGjt7K/nox3/UJ7I7UbLymDLJGSXFedcRNpDD3vTW+ZcBXBUXuYUMYO/5MPsBOYgCrlCeIE/tZ8baKBEaEiCcxSDm+OWr29UlsOINV+YANc4aw7UsxWUF7Qj1+SYVyE5cQ7YO+s9CCtu5iHzgkNlvd06Mv9PLGuKpdOpurbf7kvycGwCatMyLSE9kJCJlwvoScobweARwbtyNS0BHVJz4H3CyAoO69HdZWgxTAki5TokJG9olHviH7sA2RTaEO9Go1tr8wVbVLEJvsML9akfcIKz2iACBXKaY3jcL3Nb1j/4i4FSbMS+V3GDvnx+L8AhdAmhmzPRRLFzwu4VYLKZDR2f1uh1SMbXZedlmScinfnqr9/DH/0j40d35tLEIdqqAIxeCdHccQZ6FEOPaLrEsEpg8U0+jOmxcw8gwskX69EoqkpzrPZFv8BU+JQ0bvsxqFrKNZRTVsLZFlkyQ6Ic+fk2fKliTNJEy16biX4Wc5AAbUQFICI/XejZ5sNnX7jBn/XoYsC2pwmqiclTJzEv7GuYDTVVX6BFQacDKzd+bUYwfCjCfATOXcR/1FUuZYmPafroeF7tSXg0RG6DBl08qDYaGI4A/CHraP1NGNckJ3suXEFtt/UXrxX3rnvxQzD5UqHSwet/Kk8wQLg0Hd339l5dRktKxbNH+X6ierk+3eGNYkd68nT//zs5r5KR8Ic/b3BkZWIORd+352Vu861PAb6B+bbkHCAsg7aHjOFPgZx+srsvEa7n1FqRFQK/EV4H4y0QNLMCm8uG8BYyGEtoMYxmD24hwSPDB81rzDOeNkLpEfON1e0AKo2aR/fDFJEoLRDC3x6ZEJdrDWQX+Q+u4QycQZ/Y86prjxJ//dK9B+PglLya0M/sMsZKB7tuCd9AxKEoMtThV2m3bDfICCyOFskYozjmY8fVgrKbTkzSiSBO6k7gziIMnTEh9T2izxHIsjrKcuR7FEapm4ZeJBwy8SDhl4kHDLxIOGXiQcMvEg4ZeJBwy8SDhl4kHDLxIOGXiQcMvEIl3ZhZWlipt+ku+Le4KXLtsJFQZMSKgyYkUqa4HDvWLzptZgHuOB3UYz78tgEdMB3ECPzMgPfgfQU9SBzLX7LllRp4oeJdQQ8S/QQ8qTxQ8S6gh4l1BDxLqCHiXUEPEuoIeJdNhg7eRZnSc0esY1vB1Kwb8sJrBBVtR08DBbG3tcjc+TRsUAw3/Tr6hQQAtpKZZ7F4XCwaoEOKCTfZ2qXHSChy65wGUX7Bxxs/i6ZrixqaAgyf6aGXTT9XcOYfXfi2bD8vxx5gdnJTQiuz1qp+LP8Tkk1LyOF24V1zshcEHiX7jMJMzg7zlVcs08uSJLSt7RLRXkw1RtCb7HqAQTmDnb5YCTgzTtGYzxzOlWCdI3i4DbqUvy+DVBtHAsZk1wL9hS+gsgcTtda+bMdb7aDKXxnUVHFELnAc+m8eLnUmPWJaLfCMAhctRWvINUE1/dqxexarJzjAGH0iOXAVyE6bQAR3D0WEpSoDABcIUg+wo1+EcOIAl2UbFUeEoeGLaI2O7gowKQ84bVCshmiPOHlx8vkJ4wRZiaG+HedPpuZBPrDAUNjArEH8k2CdpJViLH19vOyTN6F5vPjdEpKy7zuRn5skyZ16GnXEHM262Eh1gRs0tu5yW1iR/d5CRxYYDpcPBywv4vff2GEVgtaPqgiuQLiLkVP8jn/ORbI9RJVBzt/ncCwfc2+seafNWTTSHmH+7lXqXErXQRuy4JzV/iCwmVgS8e/rUjBd4ckxoYOlXcEK6g50trHXZPWLj1DGKrzdiyBimFmASyVyCFCfpoWSfQOX66KPet1kYH+DM9OiyMHRPXPkM2MAJIfkMKDrOogG6DnMXRBaxi2q0cVgFB3uaBCQIiaftK+cgSptNdXpqqIJStvzxApWhLOVlPsmmEvQG7NsOnekNBgIOolJqbJT+Zg9zJWah+9QntQwBRkJj8r9YL0H7ojJ/s4j2w/UXmagBdcZHrm4lqhXjm+EGc3Prje07jWaT4QkG2nTT2jdhYB9AmgK1WZaqBYQhOaYIg/EVr5aHWVVtT2IGZDWQZHKG0FN89xNkw3LH4HtDq90paiHlvsk6UuGRCFHcd4JM/tiO/ZNABchJl/+Isg8t+Z1psc2qLy9KnrpnK+bUxQnbE6lZg4uYn3oy5MJDz9o4flOiz7NChbp3wW7ic9tAuQ1bMFcxTvIyj9UmFkyYSxPKdIUVYlGAns+oMnHjPaOQR8GJq2N1UTsjwd4EF8ayhPf2ZqRxjnggbKi7wvUdawacQvlhid+5wrH/qwcmAv9WoX1mdZ5qqXkpRDLQ75drWgcshA5tLNCBmyQE+iG5wFAgbS9qFf0Q7UxeWPu4E5R7FEJBGTeAy1Kc/0oGWAZiSX5bJcCngMzzcCIgnpiET8Ch7ohNlLJoecb8PsSkH/GsFU7bALDStNhVxPeNuXZpVB++lVKViQQMeN9Ldu07IRZqdtl4kcdlXn4twFQYbiiIpgp88S6gh4l1AlHhEaaua591xFKuGOGpKuYkapymeBigsGu066tMKdP5U45bwhpCAAKmRZzKxJO/NENCHR4Gsn/me/nBYh1Abac3X/kSe/abr5yFzsCL9+FtW6grMJQjVcSRtvAwPw6Zaqi0gc4z0JV3HLtbWloDCEMnLuLSRHtqkfAwUKswL5iB9VNgRu9DsYbOghKZVFv4FS8iOUeBHTNina5KBlWTZ2aR0r57ACZMN4actlHBJCI3jAOgDQEoJmiL+EdtqcKhF7bUWb9BNtDuUDXJBUIbhtUBVlhEE9jVq6KAWfiM64gqIeq0aFNhDlTRR7V4APr/deJTZn1GRbT2gLXXSapRvc3AyPsel8BmCqH3NWO0TRFgjHTRHC75IvMnkoLjNJfWMlxleyBf4yTNH38KrANvHnTvqsGwFZgHNNFWxIIvhZhwaZwOrS9+goBrWCrIP6UDpAdVVnt3pJbKDlAMwGILpJ6cojn+UfjQGZ8r/KpO1lRC2dJpXDO+CS2GydlKLjo5yP6nQyuARB7wlb4k5x/I6VzLk3shCWTbg23jI+wRqNwxzl8PGRQcwk95oodX/8BmBMh4DuBymmzIWn2DRtr4oq0fwFOelgDyTULjfiP2wEbWHBnPz12b9jMTlzUQ/p4+NR+Z2mBsJQMjF8U+I1AdvczY03gCPUkX13NZC3qAr5T+q7mQv2MDEsJnOH7lMGp6aHh4LOZ6hehDJ/pCWqvjDDY03cKB9VjjpjhNkqGSqD4bKTYgk6uPlmzhvXHixj5TAxPbP0agD8BnZqv56oRACNbODlwOKaDPybZP5mzts9NwAqWWMMk6K4ECjNx4zwb4Zdktt/gAzpgdgj4xlIZCouRz432XEmx99u0GKXH3DMlsjEzGDaDdjF4WnoSSEmCZPvajpD4upaRQiHJs/fgR7g46OjSZ4MDIMnpxz6djWAoV6CzAWroj110r+sAmBElcoFFdVoteEpadUzDyuckI05oB9maMYZI0LvU5RCxHMGTFYqOLGwT8a5H69sDDRO93hCpeoAmlRLGt6EXcmJP2AZpQAMWyFsl4+6K3kl9I5xZ4lhwWWMbWP9TlXpoeNckrFxR4oUI7UwpUFcOscDhl4kHDLxIOGXiQcYCUPEuoIeJcvc4PIamq+TrhoChuVnKVuycxqLR4gpQLn/wbaSFSFG2iNue7xkWCoN4uitw6ywCxZVbM4M6KFcCpOznTuVDR+zhzSFZG3NZZJ3XQQQy5TPQ+2WLQw9ialVqJGSGs/JtAoNaGHd0E4aoyd5zRKf1MPz7L+kgaycZSS9iCh0klfrv7nWENQVIzsxxxg5GGuTh/7F679CfqohaCrSrVOw6R4js0OYgA8eE1GN7bxeQymfyNBTlyItKMtYLvqfdYho0Zs09/JmHkW0Ql1iJtyghjq7AWn+kR0X4LxQVb0dEbRWLwA+lKUd8mwAbnAD4vZyY3iBvy0V5fIRSaVttkkdli1mEuCOTzNuMZ48luS1NSiDcS5ymTy0HHE16MR4Hb5PraeWuO+gIywMXKuGCEm2BwgWxZD/U9qhnCpotALH1+tHdwpbVlaogfTFoo8oYiF7Q3sVoXb6X8IdJcm1Y4Ec9vlFPcs6ST+p5PO9ph/PX7CKsrH0B678xcvJ1JdKxuV6k4ZFsKzSosBbPZF6nXCiz3F1fDn4VEwJFIHl7MQBv3fwnZBSHdpfBtAfr7ZFjKv2kyIExepOaW9CUfAyGJm76JecCgeWBaxqX98C9itoA/rzDef2SfHrYo16kE5wDuMrr1QE7sphcaOoJbJhouBfvT3n99U4KQR1yzwb7Oz6LlWq+QTOtVfPMElx6fvN/Sxxkoj4E1STWjTxRiuJFXJUWsEZo1JXQCPxQ8S6gh4l1BDxLqCKcZeJBwy8SDhl4kHDWCM0aeKHiXUEPEuoIeJdQQ8S6gh4l1BDxLqCHiU3Qj95Qrc6CZuIuq59cOnu8gnmHpm/acBudGJsRYZdMEvBAA1VHpsZUAU4yWBJXJaNPC0h4l1BDxKhaLEJAVmKdkuxq7e3Fuini8rRkfhvDCG96sjExo9JkVO4yVZUrpJQBWlVZxn8GwwxPLxIOGXiQcudiu+7LxIqDJiRUGTEioMmJFQZMSKgyYkVBkg75ZSNUWX/wZKhMy0kHN64RlLcBKt0dbY4gcyZhsi+Gje8BX8XpSceOrj4+Ek+fcSIG7KYTCHfu5AzPiIfhEM5Knngy8kpi5pLueOXBcPARSsy10UBm+oLDzVgedUpXx2AYMhPZ+jFJZvT8QTY5K0TcEZVardYc0m1RwQUtwmNeo7/gLWSFbrDGHDdmO9HJQWnyQ3qiQ/Q1883C/0n5UJzn9wTtuHikR24Ub5K16BRaS3UqQ/UF0dqwPwP51SQpHV4saKrNr+MWHKIDQkx5YxTD/fqxaiS3MoccbJL181RPeZ/8Xja8NHKdkvOerlApYIeJUgwc8aPOq0p2SwxVQCH+yub1NCLBJpih7bYHzEnrAW8B+dkPX2heOyxW6OyQbEmWZvT22XiRSwQRoHmDubllmEMwiBwy2ZuwVr+LuPCCNq7+jWLvPC8TqmjyPTlqWJAf6lN5aeKdhRVHUGPHXyGcjYUsQPND6pgZ2HCtKR4AM2PFL2h6JKQLW1uGBPCYLVSMaMx/K0JYBeqgDSwzA3XEazu8S5NPMl0dJ3yCW/20XkhEymcXWo1W/f0R5RW9ebKZPDpTGxv8sgZC1UNda9gnS+OYB8SoDdKkSCh1A++qfb1t5lHYkq0DI0DX9DXDJCGCs3cZ6RfABeHUEgnizEGRUBlLYK/ZVMDvkgdwXfndsSuEze0XfFPLBT8BhdUKZh5WmUBZUCAuEF5d5O+y04IGR7YCgCDUaiSGSw/gCsMVJFCJLww6GnGQjq6gADCQgrnZN9zTS8h+3EUMFEUsJb7I89NdLAuVbxorPXK+DESdSUf7fr4OYyXJciR//dxaEoQ4wnuRR0XkDTjSxPDry6dOG1Wvy7tiv2hSRobE4oyTbQRR2AOpzS3/TLcT+ee//BXmKZXLU5SbHj9IPW345rkjwe6GqaJN+LkswwyJ9+iKwmduKbJkmAb1UNDiEOMs3K1mD7Q5macCpEy6MAvBmSjtnkwLTb4z1ScGZWn7zKQtxTi0uhZZibNYq/Afvky3wro0jhLuNLogyUC/BY/GoH1+dC0n/usqqiqjy2/NPx35Y00p4e5TUTUVmATkxIf2n76oghyNI0kTTrdLU9zKyeZ/a6ZSGE2I/2b855PJQnObKG16I117c+Qo65ee0nFiigVXfDVOJB9PxQ9m4VfIHiXhJZwK7GDclZmfKhE9+VmI9u1F70EJkT51BUYADAPxGugSSJk49ZzALgivDOE+FKdRKvTLqWeNbaXG8qCvNxsorpQaaZlhIrpjHxfR0DJ21Jg3AvNH85DbqltDtGC6vIkxzN5yuAud5jwcwEvHTRdzVvCOS3+6ANiBkwCBzk5NXTGxVZqgu6s9lPBe/jMyXi1zajCqDM8SlY2c5d+oPYagkXmRBgrZQK7YX5js7jFQJDRn+mblnEIoH55RCZIdoNI4l4YUiYowa/KApoXt40Bf2OMU5vkeYZ64/vCsyq/vCuvFWgxnKEeJcwgLWElrbGjYTDpR9VqqMnW9vnYC/XBe+XgQMsPgYXo4lCNqlZOwkMuY36zIK0Ner0WhJCzupuGXUCUPKwDBNQIeJdQQ8S6gh13f5aCtkUsUnrjbjVA9AVYUTGWqnvQcjpM6ZPjrpd3svIg2R7R+qQzmQvBUlWriB4Pca06jNjh+XQN9KdS6Idyysbu4JdWlTqy4xxnG4gN/m/M6R++6dSJabtXrqJ07k/gVT973HHrGgyNIaYaQ05MR7bE4jAjDeAz1naxxioCeXws6JZrGxtfTFQNI7gcYvdnPNE/PkbhYa5WuUR8KKz4ggAs0PHXCwYICIs1PBcO9QWua+gWyyYkVGJ1Nwy6lTmBJmcajTxKUT3xY1ySXecrlrLxsyJLHmKdacko3HB4X1d2ep13wQ4YiyzoWkvXxO+VRtFlo/1h/ZlWE0rS+RjlCxo2igv6c9iaETyV9nwc+EQ9Jg92pT5eQDbF5ZZQGUKc/WQ6mBUWrkHCs+xoY/xI1V94UK0jKLDlxP63VKxg05xHPOxaOiiH1W0VKQUvYDzx+U8aL8Q60Bd8AQNAJbaIFuVsVzdywsfQc2OFgsRE69yWcDapoXTHopXs8TI4r2qm41Ynxv/qDYOVhjCa8/HoE+elXnc6UiWMiNBGVAcpLioCR0jPHa5YZ5PNNcXD7Q23UtZemsmB3CdU6V0slpaL5WT0eR36QlFtdupcviu+7N7G1fMoioMk3hVVWpvAoKKqrU0HhMQMkbtmBpcVU0ioE3HnTK99BjJtWxPf0OfXG+f5jSrzxTnBB1beaZI6KcLHEnCLTNvBhl1G2CbWerxWDq8RSlHnf894XhJCY0cZ1nNDVHaxkyIfHEL0JdfvBgTCcnQPqkGZsAlwjAj7G/vQN7w52jKpxA5GHmSBqBMUVE85dTo7DxvROSnEvevDjgEK3SE5HZESWc6sPYy8Qxgg3BCcokT1jvPA6nBigir/zN+NDPxl11M/WObzLFNTY1o3l7iaODmrj2Ssn1o1+cWKqH8ixuwKx+9ZPendp7x7xulTX+KSt3Fbzn60c8aXDXxvnVGnih2vWQFT6VksgKqoAqfSsle5VwDLIoEDtvwU+eJrnokHDLxV15gNjm1pjzyXzdoCbUs6vXdnTtvtj1BOhoff7RFYCclkou+2xoIf989oTUIao39NVCIbqBFFQh57XMKcySJWNLQ64Uz17XoNzlRZmascH4qxOzxo735QCr5P8JwVPYjIFeT+ph66RZW1foIAkfJEiEl0wQUvEvo72T7iLBdfRp0TsGs1e5yoszNWqeLqHzOXUPmcupf2cMvFXXrqP2q9/uh55QV0PHdE5lMIc3Wkmp4tHsLqU5oICB2ZA0CiDHQVeSlYPxZ9wlBA36PoSOmRbpMRTw5hfdq9CG1y7eGUlVTGgCvonQrMkj8f8raDJubjM/kiDkkiZ15uDsILZIgKTytH10rerfkRYGOSCH0ZdiLEpU6iOPwP3XkieHiqq/XCjCS7n+oFj9eutt/1jHMbNH3HqzWdfAVDOliNw0ruRqEj2/KLcOjPMKz+nY06UMMvEg+onQP8mUWFQIX+lvHJGRtdjKPLXyxFGAFZiZraavbkrIs3kfBfo8PFidQeOkEEViin9AeqQMrhFG5AZbSEJFg/yMmXip2MZTw3DZCD6PsRlPHwF1VJBSks/nvoMxi5QyesxDFonDGyGJBI44qni0XDsWz2VOp7jtcux8+dAQtUqxd0KY3BLq5ljBevPrrzIkVpbmCa8LTiuhcxZBvfbqh1tNVgQ8S6g2/FQ/Tsec6mnnRvPAAPXd3plo9uZ+9LstdUDHMRfUD3uvDfiR9AtETZAv+6knVh/zkvQ4q1v8jV2ovHWsabtPOmZTCJhJVQ34ARRQepu9M0mq5k76wf72LbM2Di/oD7SSLfF6CEyU13v9yAwL2Sj4OwywtU15Q48Y5olwIoWgs6Cim/odP/+heIXrfxuT/B5RVB9jmMlljsdeIOemduv/HH93bOtbgU5ytvkyAfbsnzhKZNVv5lIVLTC8HoM7X8uD3YseRwZsp0D/PDvnL8AaoTR+crHT3/tDiX53QLzvV+Ppjn40pkJzUZcmmOFqDTOgzQBu5CsA+XJkPVDCBZe7em73iFjNz4xLeY0Px/GSJo4ViJJRdwzKLeFpSeS8yTBmXpYUXdc0i+iVEkuaYe9hZhg2AWWwMlRzmKlh408EvnxA4Kp2F5psCuCYvNMVdeumlnnS9l3wr8YxlslyKlslgr3YZmlt4kH0/FEAjRV2AJOSG5IzxLqCHiXq7B1m7bdfgCp9KyWQFT6VksgKnwWxM2PdMBZeJBwy8SDhl4kHDLxIOGXiQcMvEg4ZeJBwTOnr3sHYTGsN6T8AvXUJCAQMngFqT2lIdjjiw78vV0NycXyYraPPUq84X26dMtDgyYkVBkxIfvwVak0SgGQdfmhFCEzwjSCOXlMFTNYYTbLqtisChLUwH2WdwOO3/3IJNaCHiXUEPEvrVHBJikWp0ZQNagGd3SqRYEUgq1xYhTuBPpawbT/Kouim6amQdS6XKyYKSuKc8fiCL6pouSNZNFpKXdZhqCucph3kGfDljYYK55xirCdBzH8WKpt54MY9QpQDQ3HNrARqc1sAqXTYSjojAZQZWrCQhrolI8YKr8VCYmhScqX0cQYszTuSiFPW4TIkLFMKFyjlddtIMXXBFH/TeZ/5Hs/yNf0ICy8xmOTimJMoDi6+oZCo4Flx9zjrRfnwj9afs04wQqI+XzWTMU9r6yKynRKh4kXTtlSpJvyup/qKHXSiiBC9UFogzBH6huRkpmhnmQhlyaGIDfB8CMbsC3RpaHF8zRNAhCKDwdTMwDd4JplC2HkbQr5bxjWzYKjBCOgW2tshqwKDpfnnpyfVcp5/KR1ES9i5qw3u4krDldCRTs8UPEuoIeG/alnQTZZV1uMHrIF0mDwO/fCoemlCG1zbEZh711TAkIAhIlprEZLJyLyPsH/2rt8MA7xMjFo9Bp42tHLheIT4QilVgKuS2TzwjbRMR9LZlKQr1ehone+NHY4z94BlgdSIoNdkLhfD5chjQYofPVgmHg+zxKgQsXCVeksemowVb3ree404FLhe0BKQEi0FqMb6BXqGBA078LnCRVGrNhU3wjjRee/cEy05NwJippzptA+9ZuPmS6753zLvi+CbuqsFsJiubESah4MxO66LmG8DC1sdtsobVMqdV8ciblL1LOoIs/IBKIHUJhgMvkKAZDq1d7LPdZGiWOLHh2SqOk1AgktcyPnIYqNR03zLE/3LLiyTj3IyXauxJdir1zAJNzTENPMwijvj0OIsSTkEJDjb7xIqDJiRUGREedlmHklCktq7W4Sb19AbcHXbG8bMJOfCvAMN/M2sPGPj0PZfcs2GKyaDB72P2mNk9D1D7UBUHktbGg/S5Llpy+IdOVoBBbwuZ+dPsGNapBuLBAKQD05wYNaviMmKnUBCtkcaEAyHtPYlOx4odgM/2i08fXEuB+pRZOb38Jp2AgEU/6L3RBG7R/Ipf7Ate7Qq7tX91apmbruAnblPn/9T1UcGCRnuDmrvOHv4ufbCHPY9IhE+f9jNNU7CGU9yQREU1Zd3eTIyn3znoMhomx6azjteGO0fAHfLZZAla8ko/9PMC2Mglka/HiGiUs/D4+EZSsVSuBiTUIOJWHR4Drju1v9eUAhvkVNS1J0eyLW2Q+qgJnFDB98D9DSj5PAImhk6IemL2oKbjNgG19++MEY0W394rXGA/HQUpTUsoU9+YBNPqizTDXZABxLQkgqMWUAqMcKpz3TVMZHeaFx495mM4u+aygQ+DMyezuMsyTrjwF53VMmQkzBpe/m19HZ7jZuXJOJHF/PbENKQVoP2tgcRc45gLhUtKxm88L/6mvNvPvViY5rUNyIBedYyAewC5X7cACZKrGdgmblI+mEUwKjsd7fZfadEflYilFkmkLbb5kxvxNEE+J4N8KrChLVh0wggAsYPXzXUGCe94VF1g/Z4xyOD/0VejuDqP8sOczHvjRU2/5wDKyLQ3J4GVUOAjmKiSvOq67Nv4make1ndjUG+cam29YQfu5tTr4EtRSvqfa6qTsEtTChxGlSW1AhHZoRcJZTLNkky08vWeCPDya2nywTVq6jwrRPWRcFDypNQ9ATLWgyYkVBkxIsoJtbhsCBTkxIqDJiRUGOpq2sgKn0rJZAVPpWSyAqfELl9ZijBN/gPte6g3138mtmX1hRSUAVDA1gcZp4ogEZ9bOyc84fYcqD/Go8wyfKylIU0cNI4v82Nll2R2gWA2AcAFhHQIQLDFc9Q/XfzO18CwgQF7qqCt9TLhe2AMnlGauB2axeSOVBlVD8+WqcSdde44HgKJ81ygC26R9HmG8R23IvKkDpAcysVxIqDJiRVHmnjHNEE0AIrUuE41TKgtY0Ljg3c8k5xH3IKxw9qTJuEubmNsvOvxc8Y30vTmLFbToOjiUHzscjqG79mVbR0Ps9zxTYT3bvIQDUCoedQZh8faLxqZYLMKi7286IJxJmuECRPv0Ddq5Goidz0YkPL0+6JzRW3G/QJb5+uzVppnZr+vXaxUCx3UYZBYUN+a20+Ki+yQybXveS4s1tuOF4hQeqbXjuTbVlmiyCCo3AvLAYe2jcOjo+NbMzWkOJjmnXGYBCYF8uZNAWXiQcg6N7CjnP6qtqAkqUzqBrimNIeBdk9zimrzIUGDkWmR6C2OWKx6PuUbjebpcwXqLd6qC3IwaxCwFPvR6HYsPOcV+qIbVpRlRKGTqZrNDCQGdv4UARuSQsHZpcZKL7SXraBmmCRPXGGcns5ipOiO2b9uViBYfi+ZPObiBiq7geAbUBPgPNPopTyIOGXpxOzv09I0huSM+dU6UVBupG+iLVeFWR5y7fenNmM9zFMxsGszY1Pn5AUjXWu+Ja9HfZSvPuexFp4LXhCq97q1hl5mW6WHwpjGTfQt8vKv/+4qthP7NE19HypRPOOnQDXM2UYCyvVZ6G/k1W5Exyuikrnicfuuxjty9P85tit60HwrG6oawertWia/Pqup4RKxVXlsFIahS3UTdYWTttiStc/JUGslgQ8S9XatIeKIjXTs8UPEuoIgEYWMZCCyBD68EfkCH14I/IEPpnMVpnBEuoNvvEioMmJFQZMSKgyYkVBkxIqDJiRUGTEUAAwKqRX5NNH56d+nmdMe2gmDobX/zXsqxwWEXdu6GQ6F/+Qf2O0m3i5qSUOUHt45zsN7kRj7ZdBkjR9G6PImmcdjvFx9U8ZH2C0J4DxKeRLb+HFZCcYdKcf/vJb/XxiK0Kw3uZP2FHQVi9BHeSnL4hfoNqCkJx5Tc6GMZkEYtJ/JFrkVBGVFk5SB2DhOtfCAx97mPVF9IrsUJvS5ztG40ZoCaf4jCPk5OTcgxbr0o82jEbcMXhsNuSHh2ox9EmcKjNoTgTuwVExFqsY5RP3CRPoMy5S7QwKnWWLC+3EN5k4EkzHxR91BPVORS64CUhzRAk2aXtzS+0P2wr8ZUTH1IdUAlZ6P5/dI8Om5Njc+HXMd8fMD+9qbML9d13X4t2Nw2a0KTeXAyoK1M8iNN8sNa19y5AtcIL5EnjOaXfb8x0rmaoncTIvq4+LehmK7xsDaM1+1KHEejwzQ0xb17rUONdRb3rcnjjCOjervRHskj3s/jCoJBfYNHkmzVAvjIrjyB/c8jtbuczArJFGysiKzusFNuisqs+w/xhoa1pWbfQsh7dAy2vJ8j5l7G94Bg9mJXJ9FEZFUeaxrjwRmjUlc/uJmF5TXpT0yMzJMSCzMmWfFoGPJJ99lHo7kAjElYOTk5E3ftWQLEfyb89g2cF5oRLVw2ei7TrBP75QvBE+EHanCiooQoKKUZyfMUwc0ieOJ1aiY3tu2rZck9hWmFVz+S3/KswHXtmfaP9aWYELd6m7bcs4JFES+Vc6hkVwj+nTb5JNTq6ODmiLm0KEfo1g5534IBkdJq3s1KHgtU+86SJelsV2uuRQy0urj8pz7D/eN6Nrwn8LWAhio/Oa40aqTMue34RXTUeQPmG8JK+HDQ2IS4Z3x1QTCVgBpOd4rxJdBJxfcSY6g5EYEEN27w99srvnaMkEh2g8UxMErIGgvKCDzvFZj1Kyk+gUBUbGY3ugkoBInQbMHbKrtQs2hJxixBUGPyDewQYMtp0FqVXbpgK0qOEO1VftnxQZjWU3w3DclS+S0xAdP0p4RBsrU23Tf0kXr+gzxE1qYaJHUqXM3wQEHYiVKavkFr1BXqXA6vhjPOA4mOkWi65b406Y9JRNj2E5rdZAj6pMUwUi5j4nFCpjkmnwsLBqy+ofOrqGAMhDlR62TOISCJEshA0yHObSCCK/bZM+NgZzX2kc1iZWFsR0jA13EuhTirKlpxil+Bp5dvTCr2vgISpHhY+UAUjLi8xce/+P/1NSAhTsJtLBDotARNW4SqSLX72J356ZGQ0gTUqZDejUO88FZpHGrifogSaoVA6pnRZ6tnBgDeoRooInW+N7uG3odV04MIkn4nR2EPhXIHNBlj4WsEJbK0UyHgHZYFyGMD6BW3PvwV5Hqj2cCUmZ2A/2S+XTbzAJH8X4H+E+38SDhl4kHDLvzWe+UwlL59/4wmYLL69PaS8KHl6GlS7qDvQMpMtk6XVtcyH2xw6NDc3ND5hoaCIyF2LcW5BYsqtLjQdlz6ER2utuwMJaaOLgC0KgGNv8eoMug858As/ov/1R7jbbMAvkWahdBTU3Ne4O1FDyggQqQGAxglHZ96KIg6QwB/GXBD+dr1Pbw+3dcTxnTd89YxUQ7KHHo5zHVlFL2sB3v14fFXlMIyEsSRT1v5KzF5ySrIZ64VYq4kKqMZmxrHQ7y81yL6KRx4aztNIZ/r1XQSPspeA+1bseYQCs1uwcnpyCAC8V28JK0Rj13BsZEKkxPMij40sg4ZsYPCklE0JEEjg9sqDJWWufEfkCH14I/IE0LBiV+VaWwlDoTUxQjnCm8y+sKKSgHBaSDgdtwibaES6gaLcsdVmIAf3VGDjQMpEVzB+51Q6Rxinin0NdX10g/SQCQbAx5lZ6vTMvt+SCjtSfPzLWif/g0Wu66Y0LdZwwRgd027vFDhq14jUOMvEj9VE5d9pyUNx226R9RQvTiE8WyYEKXk7644wRLqEc0Q2f11y9c+vJR2VFl4kfqq48U5a64XcYIk9s+Yz7lPt5tJiRHmUfnJJj9xTUMvgikzO7kBll4q68rOJZlBunoqCPSeDhmSCMzwqBXFGgz41dJ+HyUtu48UHiM3d/gw2Tw1aQ7R3sxaCV9R1wFl1lCnQ3xWKIJh/ZzSUgwLbgodpotketvTidod3H+L8VlzeiwPObBVeMB4c4+X9r+uxWLmmJH6quQktFw0mBsB1uj+60TXy8SKgyYkVBupIAYQWrCoPxj3mENDJ4EiWxErU+eAQkLU+ZveRqpMZUHpalvKP6509RSlv+avKLW2zkSSsRAhaqNsiJ+nRZ4SY/jMgmwQzCQIfML0Ln8wtUU7c7EapZBhxV+lZeoOvi9MniEBUcdUsk9iT+pohOrSlCl0gNUSVyJeWW5wQXwjUf9IETXtESBMTLZLhItaAEoxgLlhDOpieQpDlxYJkkKf3+qrl6kMK4cz5tkHDLxIOQdG9hSPwSoMSAIkRnQ613Gp+xNxIrapRYHOa7VLx9ApDVOsya1NKoKVoq1y1L6enXfUHlxdka+ydOa1oVGUrdaaSmOOJr3p90TkWeEdBsvL4WGAW0iC9FQD7V5SoK9N9iXiCKzAMESJ0D0OxbkwS75oGAV3acY7Jq6tvj6hK6A1AjFcT/o/VDDcS6gh4l1BDxL1dg8uvS6vBH5Ah9eCPyBD68EdJUHzODKvoVPpWSyAqfSslkBU+kxeVFl4kHDLxIOGXiQcMvEg4ZeJBwy8SDhl4kHDLxIOGXiQcMvEg4ZeJBwy8SDhl4kHDLxIOGXfEJZIfXaSVSLCIKuglRZeJBwy709424olGeEGp1BvgG+WHB0pwbkv7AU52bFiKCtHYQdDQ41i+fM0Yfi9IA2LNOqmhWJ58Iz8Xyl5jeNolWJTJ2pHKNcDg2gB06RlsTadEuZzOIwdQQ8S6gh4oiK5kcdfdl4kVBkxIqDJiRUGTEioMmJFQZMSIKpQ2D3B9fcV6OvcK3FCAklvuO4ZPWMrYjWSoU4YRJUc6VwTD0QveuMa3LcTQzJQLBYeGWYKbvsNPvJKl1lUR2+TolDw4O2zxf2+Cy2am0Kx7iA93uEjJBiE4w9tAtzgj2EfX1G3k9qrrXDQbkWHMgw7sdkvzHQFu9jjJIuxZaZsyb/Nmjs9CVee81GygLu4UmJUqHXqrKABOThLWWecSY1/0AGypLBXqR+viRCN6o5QMMh1Z1SSiDuFjhinJjMOiAnem4lROk4aIwmcoiBteKsLkqmed+CEKLbbGziTwn6ewEyHXL/IvEQCEwoffMRi+ArpAXS7ZbwZyVPRpMCivNiQ+t27r2axzLs3IIVKpjza/8iP9IwvheTFOBxm+d6rwh3FZlcx1h+OXfzS/DXcMSMwHqktQv/GwpnQVL72A5Uml3U2JPRo3QFxWU9iVvaIZZ8Y0c0kpuo+SUSuWFN6/3W39ylDql4TpnmOw5Tvhhy1e8Lqm2u2PAk4tKxpvE3yHUoeF6A1pnNgD5FvHYRuxNDgnsOCJF40cQIXqHbxLqCHzqjUQ0BsWquk3Ja/6RBWidyIymoK6Jm3NUx0sTanqOH7pVLg/H4dEx2UYmb/J++1apoCqaI1LNgmJiAiSbgYntn6NQAQzhQpnjkCwIDzotzQh0yUVMbggP6dUz8X3HsTgj7cHAdVljSvax4AAT2bfympSl6dfUDrh+e19x1wos6nWcNHp5FZ6E3rXBkq/sXzns9BTy7eZepuMKspKCyTgiUfxbg11//D7ihpdEXLvHZjgiB5RCuWojtU2Z9Zz8n0/plo7yrnCm0d+6tkzDZXANPXkI5SKIil4kQNYKJufMhseMWW0mGg3WY6k+KTmNNyk7OSmAhPYPS2i/RhAySuf29Pmwr3zhQDrHHXCVyrhiCaVNKuByRXHDJ1QKB0hrEmlNREPJiJEq7BtkmWjQi5Y+YsgvnwaoIn0PP8hUtgQpVj3d8MxNvPkgoESIV70Z6EcKYLLJn7CG5hMH7+icbAItvBBOwS0eZAGjxk2vFaFNw5wYyFNmYsSCXgNkUKIOdpQQi3n1JLJnJ6UOls+rEXLWRRopc7bSdGQfnM9ySEu2zG2S8HgUzmHQKCqiwrBVU1K8vsUeNRbW5HKF+EKKEih6eIEaBpYyeAXAIPI24sDao3YPtiVUF7s7Y6oPLTGsl1T2bMSw1xWNKb2a7o96PDLQ5S2opckxGgzVaixTu0MYy3roYTEVsYJ8jtHwxlRsLQx1zlZyMzyEV+BCodWkFI0M7x4SoH05UjHTNSHiXUEPEuoYl+ZTyVMgXg2+8TMLzKcgqnu12xOOCdpHNrmGESFyp7ufRBvNbnoaAPsboFO9gjrAIXIN7wLjJjNuwkB4jNLWcDDcMvRAbdW/B+BCeNk350gHS2eG7EPkjTUBLn2TZNMCFgFvzQNOlSAAkWFGQoF4J9DfwGidY1AIs3EWGHnIjG7WLVdTtui/Ng/wC6ivMpylTJScDVz0Hm/NluhvCOkfKiy8meJmF5wUeKD5kqqTU4ORIO3wx8KBD/dgkutMvpsmpb8fj5NPCNUXDea0zMZlADOOhDHFweI9Cx5sh2DPoP3kiYEXnskBNiv3wlHm9Df+w107DiKoZydrvbhLdBFGKA5qRonEnZY2YgaUtSMIteYPhCBKsghMG/HpDIYytI0dvOhFR4xVCA1JBv/LypIP3TmIgLq3q6eWUUZCN11BDxspho+lmsmUnJE2pTdDcTMLyosvEg4ZeJBwy8SDhl4kHDLxIOGXiQcMvEg4ZeJBwy8SDhl4kHDLxIOGXiQcMvEg4ZeJBwy8SDhl4kHDLxIOGXiQcMvEg4ZeJBwy8SDhl4kHDLxIOGXiQcMvEg4ZeJBwy8SDhl4kHDLwtWiYoeJdQQ8S6gh4l0+Cy6aPfHcPDLxIOGXiQcMvEhD6aMZhOdykaYs0gtVh8B0JG6Hwl8Awh4l1BDxLqEhz9ivUwW41uf3c6qC57zfphJBdmBr/zKEHbN14PRczrsgRJjO4WgecMvEg4ZeJIHp2hEmmYtHzJM7DBivLu8YVbb39EMjWt4zsYZGH91vOaPF5YZRF8AwopwHiXUEPEuqz7OpJs1I271meDzAapIoSWWtywQ+04Rgf2DTQMGBK7s45msLwKE1J4oeJdQQ8hY4C1OhPoqu+0eRvghXtsEGRwjL4mYHrlDvoBd7FqXTRp4oeJdQkOfsJhJA3JTCs4khcNZna1a6dnPi1cpxdj2tWMm40+i5bxIqDJiRUG759bwoLIN8XoJApRpHv1QQ8S6gh4ndPI6yg8q/oOGXiQcMvFZLGqr/X/N11TLD8cUaA4Na1uyV9hEowvG7U+AcVsbFbmnih4l1CQ5+xM6Ism5cfvvZYSbk3ANuE+thgM7KXvHSSwxh86my0mdKvytoj+4kVBkzOuOpDMp720yvE2e9KLkaVtu3JiM79UEPEuoJBeBm3/chSdrkjU08UPEuoSHP1+IOhZ/7zpKEvKRJCWL1HiL5y9u4EmFjn6OW/AI22XigcELEtIHYfg5vtK1KTYUrDzMwgXK0aEomFoIWYl4dISkAhdfLsNThJ0fhZ2e+dh4Gei0KZC0s/CCFm2GYlSl5UgyfVl6vvo5aNfwcvvCytQx5kGOGTHC39vWhu+KZv2RcW5RBaqovKTemMziDyvZXHUnYgQq9KgAHw2y/Z8ObskKIEDG2B6dsG7AciMlRgoP5Fg3qm1M9sGytK3a8EOKIEm7E2kNTL3vgSSNUalFd7wVf8Z4fe2aHJtpCExPO6Ert5y65nxQsd1faTCcgU+YWgKlB7TcKeiuyoaGmekosJIBoC8vFsfcdTuizPy5jKSztDMWf9E65Q9tw3h1l1yB5/R5B+S2unBUwn/hBeBlrKl1v6JhEQQ5mcXCUPldJM144WaHqsnJpUlujMQcGUzzQIh6RO94r36eZ1x1dKLEkrQjMGkrzAoGvLmFANAtRC6Zgr0WJuc/dE7ieejhymxZtY8iReCEHjRd+GPBlVSqjTX4PohHeqPI9L8nggM+sprRGHTCCySTZ7k+iiMioMmKBwQsIQzPLYzeg/9/niXUEPEuoIeJ3TyOqDJiRUGTEioMmJIq1r+5igq29IBTBcCmC4FMFwKYLgUwXApguBTBcCmC4FMFwKYLfnyCkhkjxl9ZQ2sIDK/KyWQFT6VksgKnYgYjbEioyUrJZAVPpWSyAqfSskhPFDxLqCHiXUEPEuoIeJdQQ8S6gh4l1BDxLqCHiXUEPEuoIeJdQQ8S6gm5ZAVPpWSyAqfSslkBOkfKYoOk84dbMvrCikoBwWkg4Hg3138mtmReKM29rAupls7i3Id0AqfSslkBU+lZLICa/QcP/ZmHEIjQy8SDhl4kHDGQ51qWjockxipwbxPPzjBZJeKoSL09dJjdB6CNJEFwZQisEEwGIzDilU9bW7u3akiCR0zqIlIJKX0FkvSKRynxSX4ih0AJ7LE8SaE4kRBZ9vVI1rC0tsc9jZgz9r0h6EmCdDlyZJ0JquAfLcNP6WDG/NANo2hF/X6RQaGVFasszJHh5qXaZq20U83jvo5mCG+XwGR11JBgvBIzTxQnuZaZsWzTkdGn4dvAk4OpA5+1RmH038S6gWoPESblV2DW4IkxVp6j6nbV/lp/sleyYMAaJrhrAEghwyeUyFmpeWkRPZKdpch0tFTvgz5pCqIomo/q6jniXUC1B4iTYOw/HZg7yV8CFLVq2OIsUh2tOkccONPFKhHb4mhzj1zSKNWqcjasK9+Am+01CMqN/plw+TNWCOGXiETdh5xEA4u2YfBNUOlxI0GTEiIWgfZzmQBdqmJOn7EKKdlD5pRQn6VHCDcIm7BiQqWXOGpuRiYFRNSZ7LSa+J1XQz5wn8yx5fDAdUCst9DzXjfrycDxqfQ/YeP0e4+/g1fJeuHhJ5wOMXJ66BYdawNZrw4AC5YmaG4wrHV/sfVwMe2LM9+Pstb0zey+GnxGc6QbR7V1W6LxvJMgFGvgDfzAf2eJaHXyvKCYWhYYgGW64g4cFUDy1hFL+FaFJMsXUPhzVNymyJ8KlhBEMjT17mSmIXr82h+G0p18kppiCXqLyDISbVfd1exaEmFPXdzGetjjZzkE7V3w/egbwqTsY6esIOfV1rc63rI5ea+ee4f/emhZrIbkOMrwdk7iJxPpmbGcS6R7LFJTiCZCbk3xL7pY2eBVDksljVqtqrlLh1LO0ysYjjuQ78S5bOsSnWxlLdSZtS43cA1lRwoXHG7IcKBuBdAK1wIeQOsOL2/296lAsu4wmiEXiL94x+9AzqWPPviEy/6pNNBN5+P/4S6K+kG28SYE+Kxc1YcQLQw84akz2W3GXiQcMvEg4wErpyKTcN1P7iRUGTEioNSgQnuZaZ+po08UPEuoIeJdOs2lhukzmcevJ4kGwx509UM6NPFCe5lpn1jCr06ix6JqrXZyEOCdhFBizUR3x8rCYhgTcjgvLMS0fin5jq2//1fmqFXf+QgAf4ud/elz5hDoRjshP/uZSJZfflyN91C/ysQqOOqE6NJ//fXJrlOLZC21++mZ4oT3MtM+zDsI+LZMN6fNcoAtuoUUUL1+IxW1Yuye3WJdEQM+M2mArcRVTaPzTFr8OSWrFOOate18038byIVSu+TQPtD7VBavthrow0mEJJ2SiKjwGp0oqGNsSEmKzIn1ko2iTQqs8BRP/k17V9d/JrZl9YUQUe4afmRK6npn3REDPjNpgLAWYTrOTcUCT+36YUY+zSlgFVibMxEfKi/6TcNxSNO1PoLQEaoqfnEoeJdQQ8Y50c3DUmey2tk1YDdQopKAcFpIOB4N9d/JrZiMQhnk8EuKu5zHNpYbf6wFgLLOFUSAFB7JoId6XDdL0ZL9qpNmvAifFyeDuJBcH/JRYZ2yWcWl2CpGaVRLqCHiXUCReUPvQ6hpN3N2FcM/yKSBSUA4LSQcDwb67+Rl9gvifI2NIkXt8KevDZHRPw77d5KxYjZlMr9uON8oNuGepYBD8YjpfyeTBkMTxMQ3IksmbQwxuTaAjS+RcDA56CXrH+uTcH7OHI3ssW1zuLmCLdrn/ci13+7ZHsaqKR2Kx7AuoRZOzLzg4lpn1v4c4zXKALbpH1FC9OIVBwPBvqJx7WETizVdEhKcQ9NSGQuxI4DXkSqtejKgt1Z8d8zSlwloonkRidAPJM38p8XYECVIkEMprlU08UPEunCsUhHGXXBcNkarAbpIFJQDgtJBwPBvrv5NbMRhC97knarnY1YwPESfmbP1JLD0RsjnbKc/CeyRlF/PLxfhXxlwMl+1UnRXq9C5QIm7qSx25MSTS2Q18qhuecaQlt+HoITncn57Jzlf1b0qNPFDw0Qj1BkdQ0m7m68I3YFE+bTWzL6wopKAcFpH87Unt/4oz34YgNqU4WfHfM0pcN0u+ENSZ7La0LrT521kDF0uucgg19jGW76ikEfZfGL+oO/Sj5JMbXDjtqLmP4visR6/0Dl1WCtcqbF+6XHVKFuTx/WiAJbgQGGQaXtEJ7mWmfX5GX2EWg6BBcbhRYn8B9qEQp49hYofBoEOYYglCYFyt3+2RKLIUiNmyn14vKnJ2pC0D7QAwef+CXZ8APWxCeLZMCifNcoAtukfUj7bYA9bAukUm4btBbpxxqRsSWxZeIVwdm94jQPtKXtI/EZixCJeDurkZvRX0g3VzBPiGnih4l1AtQa0JTiIGw2AWgIeJrXbZcyVCEQM+OjYEgBJnLOVFl4kHDDiV+S5WbSw3dkKaczEN9ait4N9d/JrZl9YUUlAN+bghhg33MtM/U0aeKHiXUEPFDp7NpYbo9FbozWChSav2Q5+zORDlNuC6mCr9DGdTKXx7pC4u2WGkFCkV471IN++neurFEhbeISqSF5ZpePGniWoPESjaNHVkhtSJ1f5At7eWFJub12swNEv/0wj+1c0AR3L2ZrV2fUgdczLvFu9sCCBtWCmVDwtTDdBcgFz3R94spQnuZaZ9YqPCriBpjEyiGKH3CDJBfhE02ptEdpBZrdu096/I/6Jxl8QBNrb7Kiakz2W1wkRWzeYnh30qvKlAtd8KFmZjg+I7oXydY2b77f/7kz95Qvv8lbjWVdYxrDnOaPcy0z7odRtPHSpqXTMsV2+k2VF6SfcSmJvEwp68mq4cKhm4cot3UXCtU89uMUyBfP0pw9Wr0GlPbN6jSDNPui0aVMiIGfHDNtN++m8I0AnRyOvVsykZB3TnWmZN3QkAIECoHSiP6W1ohTd4leehYhcJe7vVAfZce9dFr+pZKxlfBeAK4veafXiziDAqtyGnOn286OtPnjFsOkKg8RKNsvi/rYg6j/4oLSkSI6nDSiPlyWpVOFA33RPp7hjadpMrWwenRIwftUTWvCnryZ7f+FyBSUAzjP3lWlPlmomj6QQp484m/8UZ71gtkkof+KJDaVC6Qfc9qCGaPMUqPailaqcS1ADs/adBkxIqDDl1wXDZp6EaOemk2I67pH1E3SKwXpmdi/UBDxLqBag8RKQwRtqTkjyeJBwy8R/1aAjUE9sqDJiRVHmnih2R1BMjOQyjgT2yoMmJHHZUWXiCcO3+lg45cHmgnI8B7ooe+HBaSDgeDfXfya2ZfWFFJQDgtJAcD/xQBnt9ksgKn0rJZAVO32BKwMLLKyWQFT6VksgKn0p1UJtN6GfpWSyAqfSslkBTSfFeR7oiEtNUFJVWVxfYmRoaW1vdHoSPp2Bwy8SDhl4kHDLxIOGKjyaycoXFBxw7hrjEWWK4a4xFliuGuMX0Y21JyRNqTkibUnJE2pOSJtSYQcMvEg4ZeJBwy8SDhl4kHDLxIOGXiQcMvEg4ZeJBwy8SDhl4kHDLxIOGWrf2kmJFQZMSKgyYkQBMOBAUWafDKqj6X1EOlv9gc6kNEq6WbYuwBdXVLSS87N/qdul+Sj7ulsbIOGXiQcMvEfrHROmjxH3zgjojT+1hpuMyVhFw7owz3KRyRMcZ3GrEIeJlpfd0/Vh9EXJkmRUGTEioMmJFkeuRXlRZeJBwy8SDhlp9wdrbziFp4oeJdQQ8S6ggz5Vv6Tvr19RdyGOp6hwi3N6ZvAYI5UGTEioMmJFQYtjuqpTjRsg4ZeJBwy8SDg8tTbrfh+PLitBkxIqDJiRAT/ZouCMfWNtVPwdJdZ+r+XyihPnhJDKAzlRZeJBwy7841LUuhzMgxAyYG3Apud5M/Xsr10d+SAsUEH+BYYinkMC7/wefcSKgyYkVBICNIymsrrxrgD3Og5vpoXGnih4l1BDxLt60GW0sg4ZeJBwy8SDiceKHiXUEPEuoIeJS6MHloSrh9fyGXDQ8S6gh4l1BDxLpy+IBf96wp9+MgQ03QP/Ftua/zxLqCHiXUEPEuoIezcSKgyYkVBkxIqDI+X42874EUZ7IRjMYwp+1AldoOlvvRBj6MJkm8vEg4ZeJBwy8X4FiWNLxIqDJiRUGTEhxy4rb8BeVEZghL53A1gHZPSNqbq1YxRp4oeJdQQ8S6hgDZYbiXUEPEuoIeJdQQ8XpxIOGXiQcMvEg4ZeJD2yoMmJFQZMSKgyYi3hoTDdqnxEczLcvpn3zHjEvVWSRIrRm5zxLqCHiXUEPEuoYK4P1NGnih4l1BDxLqCMbadbLxIqDJiRUGTETAAD+/pRlYKmABcwBz9lXQr4R7MAFaHhm9zcAA35Hpht9l0ChbG5aKblMlCCdpbBmsPrnapexW9mBKEQ4BDhwUTDY0+Z5bMEi4D+gJUZjryWQDuMqNasBgIireH0tvyYBYPHQDjjKH5PYiBV4o8InbJQxGbYwHEqTOqXynz/ROtdmUQx02EdooxZH+ZFCdXuEBqo5cRqm0rl+IS6CTj64smc0yH18lrw8M1Rmng1IatRptRFgxRmfNOsqHDNVr2wRWD4FQKtH/Mph6hXHSdutnr5GRkEal+buT2LAPrFNSyWhEBfT5aARYB+82C4C1YeLRhwm/qro/4J2+pYW9Oe7Kc42+iZKefCT/lQVGb8OZ5MpEZSwAosz5XwVzkd9ZsogwssBatwoam9Vx56wZjgCQAAEzKWII7MLc6+gBQBO8oiayiEBHIaGC782US6yBBn0M8NxWMv72pDZdVk7Euip7TlKZ5AFr/Wrecx4tEkrDtrIeMxRR1UaMPVHzYBiETiCvSbUV5ZNWWaIiloFiefmA4cxVnT1tC4YFCxmjtvUBAGBVQaOb3I8hQZd6jpH5lL89w6NDVtsUgvJlC3EcbRSS9wAYf8l1/rSLokk5O4j7SAO6ymjOouGmU+bGfN/sHzp72n9d0OFvVK8eNS2lwxaMJH1gKlXjCYh8wPwb5QFxH3Wfm2pDR6kqxPLwlE2kXz1gUZWww3/NG8/rmH4Zw8Aar6Twu5/NCfwu2CNDF5J5wD3ZKP/niDpAyGxKvMvf7/aRhjf8Qpw0SIXTvWiJ6XTBjZmEyYefOJZ4vQBK1mrWBygAAAAAAAAAAAAAAADsZHu7Zi5h6pOOGaI+lQRqLoTOReZmS7cbMH0y6uAIxsKpV9rLo+Q+zE8UXHj6RxfxcTfaOeKA5EQ9ftJIis82hJhuH6uKLyKON5CmdA3+VTzHrlTHskXg/EnKP64Vf8KrnBVHCJNmVIk4QGyLVNdnmQtJfnFpwLDyh3wkq6ihnKrL//iOSreYMoaDebvuKywz+Ls9hVMMX4nLJa+dEBbPRqk7sEEM81+yjp3OCFYYY3Mrk8Dp1Pi3h1ZRi65SPqIY3xOIFJNwm/8kJyg6dxbDW289RBnyBiMS187mNcDb8jCXhojHvIwl2BpNy+eaOuh4U7ajU47X/SjgABAzoi8z4RPtkDODAgSCEqGbhw/LBkWV/eN63aNn1dc0Kfhmmjpkayf5F9KWMw2fLo8AAAAAADuXI0enr8AcL/y7L74kHTOgo3n+TXlaJ2dr+taK1HtMUMhcY7EjFrmyPXrL1i6VSEGTk5aTrwiZ+C27tls1dvrvyUoQwmywPai95Zu3KT/A+XuJCqbxSc5sQH03QyDAW+4h55pwtwJC0igFt9zQYKMC+wpBG2R0TS082QqkLDEoi+XRKrwegN/7Edt8HUA94XZnHMv4oXesPsMvEFN6A8li9t4KV7A+toGLz3CeP95nLidUphzzFakuI9CmaOi9DSgy57ILyHnngbAN+DuvcDzQvw8dd68llGx4bz2INa5e7pyC58cmYPd3FfnCZ7Z9x2SMl5J2bRS8hh2JYq6Y6xbz5FKkXrPh69DmaacbYuo4EQzBhuMtL0+bN+4o2oo4tdvDlkL22NHFlorYzm3fdzbGYIwmm7KA/+RvR9WMQxsRnaKMpXhtWFqoK6a3w5eBnjklfb6ygRs/LfrzbjPwYf3P1yAa8ftNAJMXxh+xivbrGbTzTV6esWNML21YB76Gf14D1Hw52AX0QZjmTFp2T/EvEeAEDRQr9n7RFc+9I+gUswrgTO5gBvg3vghWjVRH42p7jE9AGwIBquvCL6csis9OS9ZegcjfXppT6i7NK9KK1vjL+Cc++NhXnEQWggluZzPimqAVF74yPrK4XVeavCFSCl9syxuGTv/ZF8y7tW1wm6TcV6tNZMMXm4KsjlOHQASCyNYYAL+d+IeQpcqMtsv6FfhN1v7XVZAo3/BQ5tAmA651vqgVVHA17HRKqLkOMZQI8+R3WSfsIUvVuSmrxoVoUuSKdcOpVNbpZlC+OCYPZycb5Rtz1IssklMyA33wDeTsXIavKzG/5pwklH/s+6OaKDpjn8l1EvlCdH4MDpra2SwFpF4cjKv2xFpylDubdauIPnkfvtTHWeKkXAoHJbj6N/mmZBbC4DaqLKjpV3I5/z1+K5I+h+8yF4LXUJThcY6nqAI5dWkOQzQm/PCiq83fNL3hqhGMoQPrk/kXF9dW75HnjTHoXL6NyZin5h2Tg/doLQ1yWk5ol0icchdr4oBD/snyDiNZ/m2uSQlpI8H7fOD+T4BF0A3qupQ3l8Mq/YK0xW++YjIgDZvdY0P6mXEBnmhNysUTIAwjH1bK3500r08ztUnl0kZStIOPnZIUU6nEqYQaa8nDaYNdkQ4rcTGKVY2Zku5aQPSz0InaSavWd1wHo4iBj9iiBYpFTqMmiSnKceo+fGgmZrPmdguRF+BAIsIj++xnVj7dKpcQEqCPr8fd2SYTniHJ8pM1Du9xenvt2n/wbQpIFgbLBiVkAEoP0Iv4kC9wlmEHgbF+gWbKUoa1yYdePtk/QomqvdYi7Npq5+Kq1GpZZf2B74VqPUvJhvLLaZHnEsBQE0Pa6cmNJCdWU3dyZ0MmzzOwj4vyxlPZznDovpGGr3STNpCsN8ST/07QTt56czJj8348Je9Fnvyi68MSDPrgxWaJWTZsKnl51z62mDM/44NTokPrn01IHmon5zchP6k1GNx7hmD4Sw2U6kfnIrMYt3RTKKcf2vWddiwMv8x5vQBiCDV7f+8v3muRZIXw7avIM5jaz6espq0OjYKIoZOzM2ykzLapTBM/cffiM+n3s7ZhaawbWUagI7tr3ssqquh1NDVJaPRjwuglADY78rZtgFftexoj0Ll9G5MxT8w7Jy9a+KAOpVsKJZ35I0czpBZgBNEAnxxEDU5Km8hv3NIBK/cQUHxXHaw3lbgHFE1aGzYvuVGCv8SeHloM/c6ygwG8fAQwB+oqNBMo7p/ifvRnur4bXhS6TDgVBN0Z4CmGS2bxKG+xxc/kj5jasWAQv92QpzOy1uJgvgizc7Ddbz8zN8mabHtPkJAkGxOKjLT7tarKppSLE5L4J3N5tcUA6aRn9uJkcae8iCW+6Wi7pbDX4CGBnl5tT0/m4dTy5GGUWCXjVzTl3tpIihIxmGdnjP7ghXawEcvjntnBW1hRL9SOyhbqdwxGkU1OA0qIVckcjHbXcuEqIfPJyRX9Y0jirnZAQDo9jtUCnuncSRJNiuCTwpNN+RVaMjeNFGlpeHU/Z7TpWJEHWZL4FOMK232U6/wfTyysnVXKseYyqglaA849kFsMMrjwD/rnrPvNKst6fgf1wNUvoGZizA9tAEj5d3rE39gfPEqIflRf9bxz/aCHanxkKbAWe82T2bLmZX1XnjG9qgitYocDsSILRXl22HvRSGnDUo3ppgP+yLqRjSrCogIYw6o4yovAJX35S6jRwj1PHjwtNzy0XlP+UrVDhaFUvap9cUjviojKPi9YF1Go42Sot+ouFHezkkYYjSP0ncgYaE7dnntr5BA6O/dbNEmld0FKlQeZQwwBH20FPW9fXGQeOmXOsdn/eKoOcub90GE7e0AJQi7xANx7mKlsa/3qEreiUTTMsE0MNkhSQPglQEfyfcdgzChD+6K8G87Mutcaa/bBn5ybGKbU+PEfyCHy75NoyrNdePwYD0cuWRPeHYUQ8R9FpEE4G5E/BjtuhRQ+3fs64r/Mg9QM3YYUXOGUY+pxb0ooSDfUDCjTdRxqNeH1cXY7LGmpQXCgfinOudcQvnwz0FeR/lHaNZlh0Yoo5gqsHXSCYa4auhEaKJS7Aye5YybVh4NWxFqrzl6/CEslk1JQs3Cka5hdInsfu9o7RoQWL6oSEcTF7leq9VPnYua48JXm4yrcZgCj6oApj08JTgHuQ4D7clPWJJoE4caEa41YCNcf4pRQQbq2NBQBC75rn365+tbppkFxk1nDu244CTLktaUtMS4liayrUDePpft3XnG1zpA+8Jrwb7Ri2a4+Bg6HM5clY3D0F3/a8HK3kxIO8LastTqbP+g0k/DkFgLR7RVqx5G+Rr9pq8mnHry+xqeiESZEik2YUjMtbc90SPit7jEuDy+TvOOB9ZKmhH8MWuDDnbzx4fQZ7BDSPKpjf+Kq5cqmSU7q2W/7V+D2M7gkgoP4MRECjY6C7yK4pPJBVa2YOkFz5E8hlU3X8c3l4EaNN8t8t0JS2ZEk2zlzOC+njcqe9wsPxJ2ZY5+d4cdMQ6JK1CbK8lVLGMAiPfgXS6bfez7jL6tJVdDeVzkv1zC4uC52axHoFlog91+n3oTy6hz1yMrGMM5Zo4hQ4dDYAH7JrX9RG2szzp4uZpCBBpMBOH+HgApUmlkRke5JbniIHY+V0gqJyINr4w10EoAAAADYawZw8KPiJ/cx2NcYmZTL6OTLaiXhYJYTRFA8erE+Np+88j3lFsdfsnsW7n9KIsfg7Mw+HyBSIc5eCez+W0n4SHtFziG5Z/G275Osn1Sig0uyGApV6wJ3p4XzJHpbb/GzpKpTqmCXk/UZy78DUkcQeI7koOVg3I3Unx8jWuYfXsI+4cYDtsWq9qb71VxMFP4JbeoacA37n43NN90IoEtXJCDyslrHADfD8f47GM/vTQ7UZlohFgNixq2kmIP/3SDGZWL84lvQ1myIk5wfk9mNgZBxfsRV8+Ijd2rMSY+kxJYa6DIqROyjUQ11VKu/00FQUn8JwgGKeBvnXl6R/0VjSh8nRjsLdie6gnBGS1TgD//Li5d6cU0p8YyjR/hWNNFFFrssvlkIxyYcX70I3mrhap28Fsj3r55/msWgap3dQX81JEuH5p6UFAXsUG+y2wehalFcnBwsfu0KAHgzqFZR0+YiVZgLvEzf8tmGXrK/4w3McIDjvrzbxTkbKXnCe6B4FwsPOSdmp1Jl3Nw/QPPNunCygcfn0V43JmS/ApOFZ5rtIIBbHuk9wl31uvNB+bYrRydYL20NkWu15E5OUlAOzk1QtmtXRmnlvDYT7R5NAXfzo+Gqvhv2uZhE1+sFv1gs4VqmHvbuymYYwNN9ziDMl0zo1Q+Z6ybpgIllGGH6yrQ0ibTABKIZSuXyMR9pfzlsjEFC7CwvXRuLxdKcPmaX1m0BoM++prKICptMeZ2km+ctkBpWAAOJAASNS/apLx+RUlksUmSd1PSd/WBxsOt8PWrMM1yTBp0Ea6RSPk5n9T+K9BIze9OPgwqFzRwE4bAddffmp1dMV9JTKIMzwLw0gkfbP35Qd79cJ8I2rf1llZ2uUudoMa5sDlKaq6Tw8Glfp/+AqZPxxKVQmvIKLgQYrk+juEo7VsHSwNHUL4kNAi+g6EcbjyZEIDK+cDqWh1W2wGZjElPa0LvcCxMcX/V7Nc8UZgPcNf90QAt3PUEMBUKEMEq8axO/w8gCi3TVM50AVQIAAAAAvcdK/nWAVf5A+kv5OvWvTZ0CiyI6fmkKeLVkDZMaRE+sZOAuvakueEX9X+RcNDVgGWlAAMcEpnzKPJ3oOk0sn/S5O+H2f6X8WsfN8DiCd2rXeZqldwFaTDVqs84z8dFegYtpP6rzOwQKah+u2AFgJlzL+ZfEoPIuh3M7nybOJq1yJyZWvpCIKrY/q9SRj1MjdwafQFgqt5wx8tduwCk6SuO8S3dO15K8o6yY9p5VC72fOnMpnVMofkbUbnYIxwgTiESoFNgaMv2jnFr4H73L4/DMuskhfE/LR38UF5jVA6+XQ0qctqA+zBpIPHbP1qBduQHIfdDM46L89Qr2XmFr6sqHjzn86UlS/ZExaS/2atm3An8q9rVQ5hEycmP/KgBbTPZHQMY9RK5mDvcduYPCb1lc37oU5EHchB7SEAvM/0iJiVwg4Yrk/bqb1mb7ZxNEHcL8w8MTBg4kJdLGKAAAAAKyGZXKIRLKAsAbbaVAnLsMG2qV8gtmItRwFxKzZGCldEDVkFHVqXV4QQspjNx8lhleEr1T9n4E8LkFa5eqv5WRU6cylnJSwzhg6feQRVqyNmo2wNDM3gi4AAAABhWXSoYXpI8vcYQNL4xUryoUsI0dBEFAp/fznpH4GqXXOZ8dt8H5hyqFzQnIRzBkgAGnDOO1G0U0a0oWFN+Nb9F42xZWXG0FJOYGTj5F9RHF1XEoi5zF2gK4Z+stciyTBBZcRUutv+jFp+PbojgljC0hRiywWsE2HuvU9nk/LVkA84oCmrlM9bOQAAAAD3lE+c9s6gP2W4rw0HAmEBgz2mGPUkNYGtEJ7Ybb0BIF0Bqty6XqpRnFcHd6xA3JOy777T5gIDR0Ewya2q0Pm9CPspRyhXAb9JG3/U1//zzmgVByGV7cBJuQZ8IoIbxakgtKFg2e9uQNDgFRpWMKdQCspegMk+hTOBtVvwk4YgJCaQS4QaDYVwn1Cxhf1L+C9yaP4xCqwRgWaRlQF4n2YAAAADZgAaa7NkSKlSnra9vdG+gM00j7HgzujJ5rIc5deqWwvai0Ni9z/+CGGAw/VwJiAVZCjTPVpBjrog3yqv8HCIocyfpvslpUWQE2ME3q8cN9NpznX8EQKjjiDQUUkynzZ+1NblZ2T+Hiu89Vw6f0pAApoviapv06uAtt93uXbISVXbmfc0EWwmRa738A2QvErpYdRHM3mG3ST96o9XQLiIAAAAA5xN2Nw2RgHChcKovuqaopnIAmeWfSWNvDSVVNrFwMc1ZlWREo0tH/ai2M0hrUr4iz9FuR6lkWwklj7/98NCgKqINDgKz5LkXwcJXulKN1OI4QnDCSwBGQhJ9bAd712SnVQOKhuFq/31i8jtFEZdXdOOBQwq48aWBcW8s4gGG4/Svmtfkgz1hyi0MQvRhWK+81jTUIQ99tc9DI9Jmjt0/pLLAJg89LvBuHka3eYfaHDKZGYgWy4iujtqRAU8eBI7fRwfx4qg+Z/s6c/VVYpEwaLCLeM+DSY6mLcpRCc/eF5UQU4JRtvF3BgS/a/aG+94/USN8EM+3JzUtFvcfrQZBXHssVzCYIpB7unPretVetTJEicYeC9hDd3f/KrS2eOjl8T1ifpowlgHzqoU5/goU3nvHHCD+ABayU8ls+QZdmBX4GUDhbNqT9RMMw58O6oK3FwM8npAOL8nBycZ/S+JS9BnQDZ1g7A/aWbNBTQ8Aeq+TiF+6Z6YihWMJbk2R+5QhHRFFGPayRMuMVXRZ4d3PS3VeFmLib66t0aE0y0Ip1gN9C+bZHV34Cij5EBW/hkYEcz0jfhVmuGCQe5a/SNk8QojWLWHdnKdaSYJMZi71/JwfHni9k/pRPTUxrsN/z8YK54TNMJHGlWPlnu40pNmubvvG/L5LXWTipnyYFs9Nk9ohz9gpg+YvlRCAgDtq9hKNJvQL8EsduYmXMV3lddaWWoHCya0GTkhe8nz1+N4okv7QKCN9joClxSSU0+b3X6zqztDo7STtlbd3YrRUdY4M9jS8Cg+hv+pQIGTRTFJMyAxtIaao5Gnk/bL/kXonz4DZNSTFzsazUnUoXCQKciFLTre/J+2elGbXN/khXMxhpXs7fJzB835VzVFuUmP2gBYYIdLwCwFmdSntuWnK4BYG1C7lyCVZpNqZLq3bb2rmemFBIbsUoGpUAldGkr2stOvbopOHU8mBxJ3K9W/gAn6/l1FjyuWnRCTw2FGZT01jSNDHQgM4Y1Rzi+HvXmhQD+OvzZ3ktqTYKtxytG0wqjPR123shM0piSGtNqiomOJzp46rh0kMvKJ9N1mpWKKQPz52ELoE1LmDjyl4sqySMgM507l9hG1XL4TXVWVC6EjV/Jsb6wLLC5zbG+MfSzy+kWRlKzv+F3vwuR4V4WDz+U/+BzdSVj2LaJv5j+nk9oiZE/X3s9pYzLI003UwAXyxcRNMI/2fvUTJtesf2Ghu8xTUpuHNFmIG0c4QxGRcWVyGvg7RlM2ds3g0r3yPToGylq75+9R8SVsVg7Tb6IsPU84RRJs3tUxlxCbDWASg1qFMC1tcCIwH6ySGVHY1w83d13ZSwa+t4Ig8zgZCtcSjQY5wExjVxfJAy37HP6FgiR+XekEUisVZeMpypV9QDaflRUHjN8OLKcvFMNReBWfUmGCKyQvM7HAFkSo44FCyyTAn9M8aANHSFb+94U3sPcKyADda98Rbd7QZG8ExWdE41iSb4R8fMJISOTI3dtjeA4LyauyNottX0LH/NLXOnlWgyoEGKN1CXBRkGByB+JhcrGvw2ySb/+vaIZevbJ4rOwbYJpVu2yHhKVuu/5FpvVwS2b4Rlay4OtbndYCAgA+ls7tX0tPHUJKCcHWl3OMfyi4gl46DVVUngpRlT0aMDJabW6SYj4HCENoHC37AibbXBK0Ba4MPMS7Onx8xVJYGo6RmnmZ1DtklpkBMFIvpqtVp5IQikPY7/qq6xAYCe614h9u68UqE8hfPDFykjBPoDs8PukjfwVDo1FqAb+SARw2J8GCc8h32IavoqC+4UzCdc+NehweGRK5FXaAVslDcMsp56SXr8cEgydhOyizkHyzsoxPFx4IMxneVZZHMa0Ji3nCzInNBhqNYPh4uIgPSsVqBs6iipa4JNcu8gfFWk4RJkInwbQvdn8ogsaBV6mPXrqXQ3gGlfjcl5TrojcVMcdk4CjQhmwXp9XbuyYWIX2rUdMiybmqdge/8jVOPgG2mRqFMnHVGs0D5p/RKRKX7iS++NgO1diaXO/0a9oJokoagavujD+ly/1E9xtanE1g5tn967ZQgAjGC4DlqkK0wpHv6sEbi5rxBTET+wvAftX9tq3SjHHwqbEkPqs1vGceSK1NhBhszbup6Z+qGKV86duzZ/6JmjZZ2zoN7xIaBaRwA26EQqQm3A+gS6OeMU086QO50GgMPF4DY4b+P/GGWFeXSLV1yUzXv2WgheA7fp1CWkjBC+Oko3x5zMEUAU9wuV3KLXy2IdkvXFk0aIj43h/0JODc9aGevpCh4UMAOFOmpYzwEHPDlHcvN6ohYXLLn47UW95d5fLP+glq5+NF4/fnN/4uRYvypuf5Sa70uxmPkIL10VdAF3wJHhN/QOoD57klhuMMTv7A6B8W59NCuna93eTE07REb3CbsNGklpbgbxD7qtvhCESPKYJGEuam6iH4ny652hg9D+jSfHtSUfakJk0p6CNLbn5pvdC2DOEdziplWXpEneEtiEUr16gWlbI6QjTknFIioVc1v4sLk/yijhv3S2qEWqE/ZcuqB49zQzqWwdEGU5FHUdeE6oqPlCjzSUPJWCw41Lws1YttC2tfPCgg/zBeHsBc6k7wXCFEaIrHKUfG3bXrOiMA8gSoZz7yyAxyT3/jZNj6o0cqiLCvKQA3ocEp4SxtTrCgt/ZVzNbP0d178qGqdFj6uqrjqzfOUFaMj8gkEfAtVgZKSXSc8nsF/am9sLlTfL6Q3ifMt6uqkA0vzKpiJkX/FJ7EkKT1kl3bbRt6OL7Uu3LH6Tv8haLaOvPfBhjCITBtgU2O2p3X+FwSJvzGUYDBn1wTlMo9QyJYYbTmw9fkQy+E9x+1ZJZ7rSkZJtRoHIaWyKLBdASgD/6G+qXNI3iGGTk1BWo6HNo9vWAFjJMKxOTeFEalcU01XyQ3l3Og0Bh58/L+e+VHn+9WGgArzfcNScSSbltQ30QaEWqFHJIvjTeMxMgchOT75m5QCtolTfZkRPvX2PIM82WETndtnEKdbgFUBGTP9E4rp7yS9eY3gPED9mUXKLbFlDIUeSOF+Gf9kx48I8fSgRpe9oMz8ZFLfPErpZ2I+nfidjd/NHL3HNqjUrqYXI8nqpzbope1jyiQNbvjD1df60SRl1LDYY27TWLFifn+O3nLN20ae3jZ5FO0nHOP8cwY/QqsuZAg6s7/cTwEwracK84Zp3vaarDKBjCIyIOY+yrTI93e/p7DLBCcvlwp91diPgRZw4ABbUMInY7ai/5nd2JY2DrS4wY+L3HDXgpETwFC8v2MgLFKnrmez+amWdOsheeDtJvsXPUItR1gJXZeunnMXLO3VAGUaQAABpDAhy5s4UVwPHy5N15IbBlz/Q6Rn0E54yokUvY0rokBmVhopaO0z3nEO2kaC/6+iHDS3RSdzUag2PJhgcxhg2N1eetbNy/RQLY5RP3bMInzEhj+5eP9ADCDWnYsnx5ysIz/iLpELfTDz1L9Rw8XBVCBJJt2UqbJq0JzAGGslWs+404GbiYMEPKFC3483eTCoAEStbhWEdxhHWo6bvg49YuAfmoCO1/62aYlwsx4n8QPrBEwRybR6B7NIjZimQBzaaFupx52dVNw6FuDd/d99PtWUT4EZLcUQkce1sPmjEstRbeECCHUR6PcZxno3ozCRl0Q27JyihvGzvT6iWgy42wA7NULhBEm6uuiWkHHz/3qC2PJhgcxhg2N1uXxvn071Z/pemsVhhTk7cm89AB586QZaIbGKI5iQqE6/VRMr+J2wOfCO/GOnOAbcmUs7RPSSk5QdDw3TWp0ox0EyRY1jAZjsAAABgmBbgJGsKunrVvfgFUQMVSGd8sTUkjXW5K3SPqQ1PxcIsb/ekKHs0QUYZAAglKSo5Xu8Rap2N8Wv5/bLHemoc9ek2TnegQvLQeTnX6koNBlpem8/XnWsQZ5OIk+0nl16rwhvXSMyU1IGcMFApYk6O9+Rw+tJJs53Ve8zXQO5D6u7nC1iMfo9sa9iXHY/mVfjnumiqezWso5ULvqfNNtFGqf4Dao5bbaUPr61eHyHKuHUz78pvMw13GALag+c8hj5t3bqqtYkKjHotg+Vwc3X49FY0y6vL8FtOAedYEeM4SlI6Gr0vG6QbtFysvyKgQdm5HIw7LDyQ6yxc55+r0Jfs2P51VBiXLwiPn5OGnu/RXk2r05qZ2yURtkgM6XCP242LNhnKypeRgBrgs0T/SDSXl6tKAUtlysqbZ4mp9Z23c3CB3GSiOVjLLCPYjBJi2bVKPg7uo9IJrHq+70+MBE/WBb7oAYMZRuqb3BfikIdggcGjqJW5vucNyT+8cJeAsEsUaRM54NC//H0hqYnsCsqNg8z/7Q+3s+tLR39WDO24Y9qn4Rp6Uvg9FJZrgl0Wq2JDs5zLm5fQp909wmTyKAunU/H78LnBFWYL9ZYvtv5iUR4FPvMfR8KE5pr7V6+h7/hoYaAI0KlMnV3dkXTy+SwQxqsxPM2020dqs82WTCNFZw952ZQfy0lZkvyVXRMLK6IGK7h01YOEV7Gvsi+QV7ZMJkM6kXTRh+U0XX7Sct+W/8T5flukVkj4IAFgoYnZvACNmAEiqcA6LxEg+vqrQNQhS9Taw01V+B7RXAKqu5ZLLwnXsJ440sKunuQXjjZNPXRG8zHUm5878E3oAPBg5f9Ll3ycXgrGXSJ8FW/rOBOTMDzoenEn80Ef3My6EkDOD2ZDu1cLQmJOUoiWdDpjhZFY6czSQmKLRPCIPYjbrmBd6rrCRBx6Ba2Iw7jpVlSapvJz0L2GIxzhu52+5/Hl7zGhz+kYkfzO+E8znmnZVp76vQD7irV2TQIpB07jieFpmbnXEhBlWsKQfRTExk0d3SJ+PWM3uqlvH7IxvVBwVS0Zn/Veb9c/qjlFfiNOA3SxMDvdCSto+wtn9kCeE0zexSrnDRF4qmezG5Ry2qOIgpXlEG82EbeXnuy2AK291T9kMdHXq4dtr7vo8Zdxb8IdVUf0sxvRBLOmPx4eKeCDVJje0QlIcfvy/BHfVlywx5FRHdclRl/8SeF0JswD/fo1YpIGL6xhln/nE5RzO4i3+SsD7Rz2w9ekfh1tcCCex6sZRUQZ/r+4/OYCREOH8Z9btAHkhzhrfZZIR32QDHv9TT+fzXLGHYTncRPvq4dtr+93ZWAZBpxoqNYPHsmSiFIG9AGKXb1ZPnO6B5xDzr/uHmLrb6KGcUWpRa7Lc8LavWGh+C9BRxNaFsaP1EJ6np0//sm9pTSLaLyJ22n3ju0vnpz2NsrCsfps1x+nL0EAg+7bzXtBrTlcPnKi55k3+CdJnwO7q15E6OA6DRN9G0it6BDqd6tC9RDMw+gdsqx0BBh81cJfmfNLMZ8yiIFVFz1IDiw9Wz4x0qInBMEY8Gvo05F8XtLiS695GgxIs2IM8GstLH4vMeV5jlkNZ/UuEbzLGtIUb2aCYh0q6Vl9LPE3TrIPQnichN7qaTmthj5c8PSLA8OCpepltRVddfFdE3CK8NpAFMT7NMYg3bRtri/OHTeEFeLXidj7eYywgm/Al3B29NGEeMnFdF6wF1odx2JSvg6Oevw3mdSEbh7Mr1EpFPM8HS7Kl0052uuV+eX9LUyOanbFO/yX1cgKOp0gmHK+7ymjj26hO9uI15jLSg14R3MqQiaUoTS1jkxg+a0EH1deyhxpJ+3MVy/Xi6rqg5CbLuF6OCxoWOHiSHsfrgKlfukAxg4UqN7Bro0liv7qRpVpx1G7+60WkFZ5UeQps83I3Eb6y23AQu1ItBDxp9y1e/DZd+eXsjxMCED62dQHXYCzckThgOQp8a5uC8hN9XR6mMKZkIMR28Rh4RkEQ8XUZlYozvZfradDjUutL0NswP0odhwDV7iHDHNbL5zrt/gq6O2zrQYrUdK1/tr7Z/HljX7mb3niTUYY8wkKrTO/BUgXiBtCU81sSqpLbcgi9XUc3W9qqigRUXFEzlvNHlin2cwf5v5MEq15YB8o7Q+AoezTAroC9Em+QLh7I7yjx10wDInKAuhR1Q5yR8wBU8+cAkbuiveHNrfeZSC3+DNG/+lpJ6RbPdB9BHjTyt85LyZZMcniyPWrD9iEbilhestET3FC1QzZfCvkTL1Ifz7sKpRcLAKQmRlgX5Pk3TOjYJkohSBvUO6rzb7IdNvV5HTNBbg2a23riGNNBHqXEg0cX4m3lNjs+Ism87rXyvJk+9AdPn4KEsu9HOuQp2rFJAxfWMOwnO4i3+SsD7RxJKRYUkrgveRsgKX7O3JubBT4CcaiQKhOSsD7SBiJPJ8A6sIWe95/qDH/9ZIEOn0kddOuPLS8R7bmVDtub1TQoWT/pjehgZGFWh6WEkhUV+3GLiTdxsIrzQJwftEY8CmfLxyTtIiGG39LPCpDD548W2MEBrK/Fadw/wSUU69iSqT1BbZoydYVu3acFLEpnnR2JzmPF/27gS63jPNz923Cfaf388qTSaKHdAVGaelr3rVBs6kxGEIlznvb43ircJr8uuX7G2mwGn3FNNjaPDGgSEXSlZQI95gOJRrZ/MGJ0ogMOsYvtNPrEvRxnV957tFMii5/PSZ+IPwhpHIKM5xNo7jZ3vc58s9j8XJroGvJBzvj3h6Tu/1PEl2TQIo/+TloJT55n8n9xBH2qqOaFBILAvqOcEB/2u8ossvhiKBl7x3T4qDJKOgkCtiP9YsLESUkPoKlJRA8AcR4jw+zCBeO/04lx9chEZ/1ZLdcYfrU5nWctbUPsSporvs2I20EjmmadOLpYX43VBaV6xuicBr5J7r3c+R6rJZNH4NTPZ3Y1YE3bZVpe7Ksu/EaMiZtjcroy9FsDjAlsKvGhsyrpx+v7zwC/M0QvcpFPgLO5PYhx99Hdj/cxIZ8la+SH4RlVrfKCSfmxDU3HTOx3PqJiLiHcqj4Lg+8s9ti3iOsezXpxynKS9CBhNJnrddC8WFF6MUSPevmCb7NGaEKYDdleLEGYKeKYReZ9+SiHo61K1TqIZR9FwA31JMU/9WXfiU/WOTFjrr0FG/BDO+qDbin+oyMvHLehjenRWVYa0ba8sK6Nqx+Sh4izu1o2x/VR8VkodOFJytpsj7Q7lmg2NEWv17/euEVMcz4UjrXrST47m4KHQrxHxYbXF80vHxfAjmcIn0/3+qoxwcUV6UQ50WCpQ/p6ZvHe0MyC5MJ92p/RHhYNwEOQtU8gr13uXDISTuQKr2m73Tntm0YiJuuXbh7zWEBHoTx4e+gYmyBMCIIMNz4jIIqBmkrKdcmH+I2AFWes0nmcdtNs6BeCIpjEMBDO/Sc5p9s6vchdBIHjhd8hGwDYTbMqD2nVQmZ0zYwc5a7B3P05EaU82Kw6zNUwMa9/RPIA8wca7M1pNykHFZIxQJTY6eQKsGQc2+aoDaPrGO/E3k4roufLmp8Kqs8zMdKl0W/AtgQG9Af99ZTDCCcc+10sPy5hnJvbHt8eUxYvxavg7ctwUL0YKv3fJ5Z+ntIiYC9NGaBeelxEGJWvwdtbz92XBNWXUQtWEfqAjgVapropcKtF6PmT1Tt5wiEZTVScCDxWRQOYK24rHmBfM2u7OqCz+QUukgEkRV2do2W9myeR9uGERcXtobPHhUQs5FWcJBizLMFjO9iIdfvCDaYwWv9bOJU7FiJ9iIVJ2O8coyI5AR2J0yNgHInjis8Gb+D3D2xZMA8tgG6xIjTPukk5xCtD3JzAvJR+URRorPZScs0IaC5j1OxajeWKljNy5w7L98YFFrI52dc9rW17bd7hGTNpxSvME70fPRhfoI67ouvH+U/vcXfMuLTFxdJgptINJ+tAbQFJJFcyPW5VJLGAE8j4Y3LUOnDGdfrwYVX7q17h2roki2kXa6gm/CYK62UOdbv+djm+AMqNcz23r2dA5We3QTtyU/doKsdwntYyGVhFsNOTOGfNTlY5CHjPAsTSVWQeEZt3fIPeNJ95VFSpbxtBOGXUonpa54sxQF9QbO3lqhUjU87mQmd53Z+CjTFCXsYXo0rAezLfEjBIWWTWbWRPQzcT/TZvmqcJ2hTAU6gPu56qq5M2cU1U65QkIGQy35opi7ydrqShgayDmWFS98bc26GaJmlzatV+kdn+qWkqBGxleRBRHszab4HI79/3lzwGsbIEjrjphebk7WTxCNZm5v5UjEwKizSsTf/oUD/DqO9vuh9Vj97kaNMGSOEnNWtXHRLt1Jmxt1KAfqkyorT2MwMhaCGAVLZtC03I+rgSmIm0HYqtuki0bt8NOKRtlbOh5i7F5i7Iqq2HfG16I8NNObIAzbmkgjd6Gg1LgcCWkNZXcbEEbjPo1f7BhfIHIHcVj0NCEXF1Tu3QhYMHiV/P2AAGT8K0Hfzc0ELzG9RhtSshWksj9oifjEGL/mC7N4ulbIsPVc4MLzJPaYv5hTWU+OFL6VbtVJksqmBm1CoPt+s5Qp/wVO0LDLEl/IU6n7b5UOsndBLcVpRI4Je+5MMdtZC8feG/lTQDzt0APR7m9Kw2WkuS9+mbwyXn8hjhLwfkliCO84wSlcDQaJfmlVw7xXmjz84lZqg9NZ4GOshMgNTly+UHf1NAk7YQVMI2a6Tp+9GI9WSSkCKrf4OnFG+SgPPybLXeknX+iDn++BHbPEk9g79GuxkVr9xSfdsfR4fRLV5wuRmxnhNPC7WV/k5OEHhcT4MZ9Qkhnnz1G6oFqthjjyECOVN/6SKEAbVOOh1e+nMydnk8qFb/YJ/w0EhSd5Ksy6tu2gMg2fRbVy0ukjKHqKGM9A1tIa0AyzPbk2R7E2sYpjqEoBMHF5ikUngGQkYzUKXFyUbQHvc3ykWgA34mRfOKniu2HVgBHnzWrENFPIUSdyy0QiKkuLVxA/Ix91MDIYqp8ZixRztHr4MlDOnHjCdaCypBfkDJZ+A6xU4ogomdzbI/z3PxD1Gw8aypOMW4UYx6KeCTQXw7jo7EnCEB6CBd28eyPBRJQSglVNizDJ5fGqSBjID2nL21RC6Y0F9kB3ElapoAXCgbjcBR5jbEblFUN0E748MBDYtPcqov128Guuf/SMVFjY/OL4eD+Vcwze7MegqPY7y/UE1IBaU0930EGThbSDjmTpz+7Wv0+Umey+a9aDJvXQ3EtRhx4VwZ2UISBc+9gCsmRZ6dbIpLBg8mhsXqyIZW/ULGsnJI+GNy1GExLsVFk5hDZU17rm0riFyGObIktdS2wK+lA9sTo2W/t6iYvrv7OMz2f7L5bqBKzNES1ScrkHmOyIx6kGvmJuEVpzCDqFpnKs1CxrQOl0UmKVPY//1DP3OfM8+zrzGOdV+1VOoVORoIEDE0RLZf9Iv1k2al/bxgMk8xRuVmMiTBChjt+K4kQfHG/ZnUTmX1Q1bVyhYCJV3v+zBueDQwfOP23naBqcvLS6OpaBIXN63FiooD7fuLwCwvN7WQDXAraGbSoqesOWjfEK0GkNGkQ5S0nT2TxpvXWgybiKLfDgdS7FRZOYQ2VNfBtksId3zbe9uTaem2OeGMB1T9/F4RPbudVTdBIGMutkFh4PfDqJr8Hh8R4rvNzRCwXXIPTP5RRIruujZt8fInc0vKTNwnfE2FuECYb9cUBfmLKayHTC83J2KnKMCNfLsbPIU+4s4IuC8Gb+/5rhRws6tLHuGlGfX66luzkKTXlu6K26YhQFRTgGtn6ANwbp7PI2O8WsufqAP7J+OHaM+t6LisZk0Fe/ORLqOapuuvT6qIFfAN1NN1qsaT01ngRl14Z1jUc+JQMJhs0Ke3qyfnj+tKiDDKehCFPAOmpRBk51Akv6XMECIHpQ/lsrY6tNiaXuzTKr/q5TRVu6UE1ozHfpSyl62bBx2ZIIGYKlR2wvS0Q28Xaysc7PHcd+poFb1zY/ChRILfvAXKHeJjZBWoHGBx6uzZKxeneZadVfTdevVsyy7WLTvhsTy39JtI7LdP9vx12kzvEjn9AGr+hNPRJ4BL7rzxFrt7SQ9pbppryuD0rmQzCop/zA0Odu26Q7kaDQUfbYaEW8dErFUDJGmx4JkvDX/fU5kMnqmcrtDDyaLbceF20y5OXVlZpLcSm9uNeXvFs0SNBs0e2/2Ap3wjmlB477Xd3QCfn8NUcn6iTlhKP/1UyNfkcPYlqjLi/NuUKnz9Y1pcjjH47rlfICxuVjjfisb84qUvUiLqXbswGqjrkO9lJoCw6FRrGKVEoyS9xy98HWr5arEBFJv1swdgYWfEdPgtkwVMI/Vl0/LljIcPm5K3pUdXp1uXLVwvShweG5zRI5WqxLmDK6KDL66zqYa0qhPMKJ6h9UQvjZ2qeY5nmkVYwBlOvRws7K2LGplW5duDiNY/DaUn+DEwWztcOni+X6pIZYIVi1bW0qtsiDbPux+j/OGX4JcCkAnvJMNsLfSRn8kUa5rseAPHXggZvPz0CyA0tIklxbKiW1M26SjJGpR1xxYJD6KBtEZG6DbNXSCF5Z5e1fu09pViWR6fKt/1W9V0sC96En6cTO6HhxXCvaRBjVhyR8eYsq6dafGVyylkOkCyjZ/wtJQKXHTDTO5otR42Gep/M61OZjmloGmH74mXLXzPt39Oxk7AMt/mbccbGVAJjr9PVZN0oHv69h9Z0dtfJEYIQ7yKTAk/hFphjvMhEPXdjiIYvVjDAzuPDS4MUSIOZ+jHxSUJN/9VCPD9YnCKSrSP2rBYvjmUJpqpfAQNS7w07gE21pMEx3LNo3XezWrGv5Ecgg999hLPDTGTUeRMGY9cryIFrI4tmIYfEbSwcR0EwnQwL6My+GNnWQJEcdbhwb3CZglasqlbthTMLU4kGEDrfGg1hrYF7CrbXV8e9+X2D8FkU+ViCOvKD01ylsvS8D4YOI/yhBg7O1Y/ETIAzMl2hgkkfjjrPVdFro2e8pKJKJR2iTWrsYzPvr1FzRjObxrUmaNOrEq0LWbIcg8WnifdSWpkohczJlMDUYItsqGEya6hruKptX326vbaqKRZPzg+pann1NULR7dmXLZH58YNswFD1rCoe9+X2IbfNkIGnUBiSOGDFyZ54JK7+i3iw8+5CH8DH4yJC9SkX5mHvqR+uWvToQkdhi/1oqVOHJduthmzxsc/oxz4qyBwr4EXnqdFxlqMId5eleqOBY0we8aWDes5No7IOI2/4iiixqb7n5BsgloIOWwgGKevdiUDJVtlrG0W11Crp1ZSYtUcO3NsJ7acAA3BFm1S5yj30pO80s9PdNkFRviI2sK3ayQ62k9zSw+phl+A6zYin6DzP6o5rdLBQvmgkG87mme9cx15AmS6LRdSovLZSReRUVQ12d9Au68A9R5coijHR8YegViHMiEOOqA+bl/vmREC9geTqc6DUGJFAC6I8Bi3sis58MMTt+2pzW0bgXvxgJJoB5rY6uXcY7PkbLyapwBCHWaLxImL7sWlkJmW8MBwAD47XAR86y3nVi9OizyJgmKeIfcAN5il5FcojkR+fCLjqifBoTdrBIKw4/L7j1FBelJKrOJHj+3sPg0OTwxba8w7GaG0XxBsnga5jL7MuOspws8U6g5mRQZzM0zBn+jSG/4dv7Yxx5l0a4Q6RX9imEbX8zOC/D/Bczj/DxyEXNWlMEC8nMrTz1aTURm1MeSXX82nb8m8Bf3Ot/wnXVAbfRXhW4AF/LiMOAnDgNp9t8RswYNlxLYOrNxVvcTUArRtubK3Rn5RKIe4ALjG4q7pEqzwYl5eAOb9qlz6fj7rTaQ0auBEOS+DfUdaApgIQOuWZOMxyE/hS+pfNba+BHMFSV6zT29SfrJ//HStyKydISyUaAOeMa5xmtMQTryHOuRO6vdd6wT8bUL/MvU0/DYR/xKkkoL5OC2rOED94M1QYXkWFkDXXsG6lVhlGVF1w8kT8w+09A7vhg8gIStGTlF4JCqCUyr1gtQoLrt8+zNMUQmJz34XFXfa34lPA0C7hQ/W09m/Z7dhQuDCx3N3qKajJXrfFOjnLtgTURnI2P0Z1iK3O8DEK6Y+Db+y/9ob2u0qfia6P+oRxF9GTQ2O7pIVAdXCNKt7PNe9hOtwfCOf6uT39+8Yr7HuS4h1AmQiR+xh1DoQ5oHBtFmE/SwvrAe3SXtiDubW0JcHKQkQcz0y+YsF+sRWyPNvXgKY7313ncZ5Om/G6TfrHmdTNQZJLXH+hJXSMBbPzeVwDGDaBX84ow8HseaH6MmG1bO6dm5xRBIpYeGX8ZZEclDpoUqb7pEEDP0YhXSAySi55k5D2O00zALc9yGe1pEyPvu70D+qC4T2+HVjunP1Vk4cT/KirMbbjIT0iIvGgGXRxsvn+hIDNEQ/jhBmQjS+Xq/qmV3g7hB2stG5ulFFPAKHXezWrGfWtJgmO4KMmLcY2ccxw5pCykGwlrSZXy9+3rjQd7uVMqaO+2Q4vlDU05ugMZWwsf4xPXApvPpCmsRLc+0FQgjfgTZ6DH+PEtiAUFR0RwO0VyHIbNz3JHeif7e5/ir7OwJabqwtT36+KrycrTWdMt86IH7Rhv0oKyAtn0eLmbVQZsWXZsnngn1Fyh5viK6r7Ue0KkhzrdjpU4Cj1Jj3fF9b157iqyiu3UhW1XWBKbHufRQEv94H/jYj+jsqdKxdZvq4JnE/uQWbPquMDK/6FBllp1R2aZdDwu+QUu6dcpqMQDP55bSYMete9HpWmKga+x5AbHmKScaGy0G8N8rVjxDXxNaIcIchf8hi0irFjIRbPLkC8WZHIwFD8vW9WmbTeQCVcgtSs6uTH67jjJs9KbmqEjb+Eg+ZYNk8Lm5asGo7JfRJa4kWBi9yo8Ck2E3K63B0jwHj6s1j8TGjil1vz8CaghdLOyiWE/OYXXz7RVUIgf6yxxdRrHu3cDUxLRPvMWkVZ6Gv8CJbETzdCQkcLQEKJYLPpoYmyNtiEi6ZnCHITI/0L+OKRW4tdCUZ9Pwi0dHAbQvr3AoPQJaCssxSKe0OCBTrib9w2sYygsmTd/be0z1lyXJxEhgjStwCGZzGCGNdRzCPbceAFhMKZgl9ywNGB66vFDZxtwuMd59lHp0pFBSBatiuRs52nV3oB0OwMovy9l42nZXsKKKoUjqTht3Y7YJlbznm9cCZYKkgGhc3CaD+4kz3VYKVrY2Mhxwn9PyLxwSorzIOwSFjrXG4h2c9QEMbyGtmGfMAFxx1lt0g4Zo3Q77dcHzGuGHHveo/bA0+HzOX7b7rA9V/47SUHP8ke87CHKcf8vABxIfk2izpLX7rmOvIE3lVvFzOSEG/kJZQVL63adl9YZ+HhvHC05VKwZcR7HNpIBFJmhOkcgpg492Cvl53uSvHh01yJ4yq6E8E/w2aDVsuhOmmNcmCct7A3WXAviEZsGktPwDYrdjBQbheat66erNyjbqk7QyL11nHSFV5QVwBkAO+dhmcjC434PQ9IU3csH9Co4XFY24LuiRv3u2+y+4GIp+HF/gu0h4Pq0YFyUJkqDmNtAknrmE3h0WhtR/iqy7n78ie7H7HgZwxn3jY35uKSSdE/E3dyfOVbYESD4wkyShKu2vmDIBwn/ycoGqwCUS3mkZOvYBNmz4RVZTIq3rYxYU4Clf3ELc0dxdEnhzatBsYYIhUPWmwMQwRIE+aOLNyyfnKsgOlxpxMBWnuIwgJtAEvysJJEErZ08OSzAxTckberUNhD3FftGh/pX+Iet58LEvf825mXQU4+syAOMNqHIOZcQ5z6WaAvZRNUR9vCELOSuGdtHm2Q8N96ySUz1aSN2oQN/qOVmqGx2JjxD4QvJlLbNrpVc0jlgYXkwTeaYp1TWOxezhdGktmQzz3ou65nixQ5fBnTFM4prXPED/1/TIWPWpkCM5+9fZAAsgDHXO7yUWLcA0smLQb9CWgmwREENXTCTTI+wlKagEynqI2kxlQO0WVj8MK3Q3kCvBp2cJeTTTKIZG8I75JkegYHdVdtU3cxbpZpDWul1kpUasjjpZ3wsNiXexEN9d/RZ6319VrSl9xsiT1XS9CPc430iE96U91HoMXsyCd0PACWizI83105ncgB0Q4+7uvNuY1t8EOqHYsV2b2zw7rwQuUrzdCcRuUdDbXfQPeAIFE79+hVorLBRGitwOqDC6VTUm2900leMHMQlT8dXhHiaKYnpbhEvbGY7iJ5fCGkYD+iUMbBABb6TkhvkssV7K8oWakKgQuEQSz+aFbMrmk2+gzUYmLYd48fqpDwJJ4vzpaDqavTr/iAx1lZGS4hYiXKgR5rCvVvXYM1CG8pY4Gr+4V4cKjexTe5CF3Ndta2J3sZOYxx1syTG5jWg8CESVP6fJMUyQUkJgc4ghFOj5cxhrQUdGXMWl7GAPCns6KB74W2TzbV2Qu1QlWcS64Sku34Jwnqh2bIhK0d1onIaetIF9TM9ULVJ6tdhCNhDSgE/n7DflMZVF6pwZw6nY2AjZVW/K/LWW0uwkxdcoO4DhIThUibHh3ZT1ZJjSEn5ham1mTSECkBBmvJ4NAmsgkD5MgPC5hFA3LRfaipeFdTgheJlfHYB6teRSzPrpQovHxPYFFrOiWYbwfH7YbwIjvDzoXtnycEy/RPntz3TkquFR6+qc0VoM0LgZDVYf9fUhEXbPEKf+50XegSOwxJjOEYg7dTnjMQn1nPh9LSTSOQkcM22IGvYh608gcZ3PJnTlGbgISsUO+480CIv6YbAlcxSQtGLDDKNpwvUaj/8Hv3IRcYx2LoQtQOEAj79+GlICsRqQheQv0gHwA7kkQj7rlejdo1vQEUAS/z+6wXUrVra7e5iuRAQfZ0iQfBwss44SNYqenE3hovIC5HR9ClzQwGv3cHKHS3AW4SU3UoQ2cwgZpQ52+8AeSrrQCgWyO/600KdAHvbJuPWYbIyRLUIbvABnbu60mmDe7kBCvBNvMW+J9GSkucn6nz6b339G5gi4iKDPQWXJEJAueMhAHyoij34pc5Mg7z/iAHzxpWVKE+X8HaOmFPAIPMvyUYSvgQ8vMKpyVSPlzbMcx8nj2jtcJGstOOShBouT5OmO7r3sj9iyJQdxVc9giZ/A4mCP21V9tRaCiOx+E7SOIoPtghAkhM2ALwoL/zicL4FQsAH/E53owE7VWcExiKXY2R/c7a8lb2BImtEEA0nUx5F4wlDsKBO2uBa/Q0Vhp63deIBvZMPgjj+tk3d0Q8vdq7k/pJFTvgaQB+/VKZojCs8NB2/VNzOOeXX8FVOSJKZ5MAjC5rWJQhqn9Dw3IOjh82BU8NPBK+0NQQ35JMOOqJLfGErYEDfPLUyxCotLxdoy6apGw2r7ItvT7JWC+RsdFLM/wtgoomkXNX4UQlp+konghW9pAE0fSicoSP1ta+5wlBdhA5rpsxwF7DioN8fB8er4a18gq/HxMUJSMLgtL6bbyTR5aWOoMtSRtUrdr0pJJt3VGSvGM/9EyUk0mmUKqdis1F/uYfHaEqQAbaseJ8gAbBz4KymOzxj9jb7dRqM+MDnZpcoHvr38DQdC1rE9EcRvUec75d3Fz96U7kktB4b+imzrAZfQFX3mNaxIdwQqo5neBZ02ljAxk4JymEmemGDj91rW10k1B+ge8AQKJ378PE4MMzZ3hP/LlXT+kIa7WRFeuWVP9cFgdfm2lHpK1RokXd2P3i/SLhQw3t/Ey0Hqb9GBXBeHMT7SDBGd5Ufe7dB71tBFgraxOfzCMd+rnMZfN5KrgevT+ogJZ+M8i/gvy/hMPxByjLGudk4ckKgwY50D0EjQEO0lXkZI1tGowsY3awLvtI9YKZE0/O64Dg/CSJE5YdvhD/zN3AAQxELbQc4ZN/Sef7GKfWiGy4CJHewd+ongHVvFJeMhKKu50gjduiq+GpfWK2LAYX274uuDkKjkjxhxfUOXEFBMvnSb+JVVYYbt7oHM3bD9HeMRiqKWg/GxAi19/jcyqFZEmFupYnSN9ajxZ7cAJYhdOKANexD1p5A4zueTOsf/4AQnwFMUfc7ZXWh8VM4qz4QXxhwgJaiT7SirpV8o3ASdVI0UrrdmkeKFS+U3a/IJcGYQU2qgNnvPYnLIUeDAEeMp8hsjjUOd5ukDtEDk+nnyI8b/+u2Xb2kmnKyKEwkZNncu5Iv+c+ENDqhDdvGtc3KOijugB+ZO8t43eAP/6tP3iX9M+mUsCBWZ/+WdLc1RsrqX43Kek41rKhy6BMBDXh1pIUI9dOXP+CpjKh4ohp0GvsUpPovHRIvmm5HZjzIwycdKifG4ClQAMV5VX5Cm5jAh/wpEbNsRUN12VqfS+KLj5DAiH+c1hzWvQqmMrzhTI+xvzEEqXvg8mjWhKENWyBMfuMrAVkSC4qxjqsFgvrGdUNQOKohacNgjketksqznTytT3i1qxvY9rpw9bZTenDjF+WpKDA915s1xsRHMTzsybcDwdlFrIyIyAZEn3lTiiwvDoe08F57X84aBg9OZKCwLtVIovGwtGJghUDAI256ef1N90j5VC6Sl8T49UvXIrJSXrmXmAxowSqU3kRC0temUxX5+C2j9Hc8Moq20DzVIPbdMnuuQglp8jhKy/n5Bx5aWzU9yQlCyu0evGmTOv1FVo59EZwo2abEeSZH26rK2CcXGgShfxX13Zg+rj65oF4zzRUELNL3d/Fvn6ULuZ5TQ9p4LCqub0yTIxkHSLX6thmrUdYLez5e7SoJzJy1z0kjVuppDGO4wKns4RjrZp6urL0seoLlJZWD1OxC6puO9a0rWTO1ESNDIrzAjXBmKoeMvA7XKWimc0XqoizAdFtCYk2EL/iSa/1OqkfjkLzCUf1A2AjLcu+eX/pUI1U3gUbynl2ASn8EbaCS/1Z/2lzuok0CXvz4uV4i3i3YjFeeZMMpmznE3udC9e4IVEPjatR52ZJn6MDKw29SIvOoZDyBe/ZhvYaYW9FAdagtxWCgDvCw1nyGyetnORox9QF/ezN8lHLj0BNt0t8gM8Nh9j3fpBV/hSe35hUU33LgbWAyLkGtfPJSTcBsNmQJ1RNZFa3KrfkW4k2mov5Nsj0VErvlU9+abqn4JWMgvzsGlvh1NrJoW+Gh2pODpKRsc4QeaXCRlGhc6mDV/EN2ImcD48YRDjePxAzuPHEB490L8n9IvDB0klP29cLNLd9ccBiLqfC1dlQwUDxFYhXzEyHvVV+Pi8kCR6bxizQ1P4I42+tmUA2b4YoKiyq3yIHz/MugLaRkJM4XkbOJqPvhYmMG77M82iCHwUCndgaEG8NIU01svUGfmlI3EcWb2c/VE2DlQk3h6Ehu+kmByzX+CgVR9iVUbb/RjyrPFBbZoydWp5ZZbplt5B5mOF8wgM0Y7xcCo+bzDgMMjNZAcMdJCvEDRRK86mWqtk4O35bAkREaRa6vMOiOllFpzsfGfvmxjnIDK59rivksZkJ+Z6+yY02Lw11UqNB9/2I/3WKgwkW0Zobn7+dRRmzaM3dlZR2e2d2oomrntZJRgxuEZxBlwe7FwTojS78y0iEHNuXnq8u+yJ6bUYc+FpAnVx/DoEddL5Po3x9cBmQL1tkFTeAsY0gQbtoIdJs3QoazOr+LTEnYuHbgFkOANrYpq5cF4NIo56jYV0hoxXHHHSdWVOxeeL08KyHZkWR8bE2aO5vZhBbVGioPdsuZx945TZBMgo1GhIQOZ7ApRyc4NpZPnkpJuAAV1G2EoykHTuOJ4WmZudcSDE4wqXqZbUVXXXtx6uJscKZwqpyCDqLVhryU4y2CyD64Ie72LY+67a0QvvdbCRxey/l9aT0CyaNio6AlNnpgMnO4UINCVE5nmPJxiQwPVdYSIKXlVGet8oKTxvMmFDhkPkfhdx52u+XAA6kEK7u44WAjF+X/uxGxdinVtOCE3Q1eGCaEVfZ/BKoVRJvvbnWrODziQz2TyXjU9UKcprvghNDZc14TYd8+2LTKd58W8dlT6U4IkBet06j2CNQm0fpRAYdYuvu75cADQY6X/0o5pBEvwkQOiYOhiPjxISLMDZvbi+D7tpiwkKsI1GFn954fBetUNixybKv433gFu9V0E7ryKB9A/7xW2rIVP8kCsE00bJukBmcpjtT+KzU15Q76zE9eL27KUO78Dp09qCwc70XT9N48eNvS5jZmxCeR+KyRMgJ6q/ivEjDZJujKJc34/8CX01vVLuJkmB2U0YLotZ60U4Fgmekobr2+1SHR3y7fgrhV1lNCLeoyUuzFljEQDyYk2yPQxah7xLzUYgkSeSa9zvZxB9SoEN/nP5vaA15gM544nS8qr1hEL9iU53+CE1ET4Kuf8kFwa/iSLAsAuDVmEqA7N/bw4JhgzbyUzIMRDGx8FWZTtOkRM23sjhetgQkFI8P33v1mQTpJfsYgUIPnVjAXWIFe+x7Y+3kR4gjJe/0MUfZDYo1fFesRwREaRbG7v2O8g/jFymyyDGdIozGrKWPWoPNVqY+IomnuSZU7Kjfr/Kvn4HUbEyimK8imJTyDj0O4ScMx4KxuoM2LAsONtIaH19h+XJj65ctWcWgwHWXP3DJcIILt+WvcYq6DOanm8x5NQ0lt3k33VlLjoOC3E+/Ls8keYXQZ02pS/Zky7jyRWemfMEo4q/3+BUaDroOXZFtEIg2RYZpE1pHinrCVtH1LCrnkzyQDLXnCTnQtrqWgBdyTieKfJUyA2prEH0czRMtLQ20qNJ69ppq99kO6bjSpUKiwB9/Rl4BP9+8HDAh6OMmMK3zkvJlkxlBBlQqgAuyN7seSBw35LDsntxuz5AFCA85KU13B0g+qTYWsLTxCb8ooOYoMQNBeudMeeH90b9sSvrIawiPsKULn5tbr0PMHmYb4R2PfMFMrZlHt2aIe0UBNqSuU+pJG05Sxh3LNp0pY7xmADXuXMk16T38v871tmnIA4s9zojhl6xiL3UlB/MlCGqiDDyWwjJM5p+gtt2FWnnRBQ5Hu+RjsQhyTo+EFtUNyB0KSJZpr69TTY1aoY2WNzF4x/+UujiQpjFjfKquP8PU1BBDI2A0MXVWycVz+qOUV+I04DdALNeemmTKTqWLkhvSdhUD1sseQnD0bnkaqrYzacn6PqL8Ep7vBiWadLE18WZcjDx1s5PEvQEOdJzfqlpiLAS61OE2Ho5qkkfK7BbRcAO3ShnAJ48ZWuo+RxD4sq9uDnydND5uykhK0jZxvL4AgWM6OWLH+8xxrjVxOANDF4GkSqxo264FKM4K2Q1TJ1si7K1GdAmx454KD825QpgW+vGYRSVc/1jlZ2YBzAnixchT5jGwjE0z1O/kMSZQsvsDP08al9xTlr05SVQxrac6TcGfDxDvi8gF2ZGfr3Vc1xlCRvlpVoFPpFsGnbPbahPvSZFnxx3khRSl9Y78iIQyLfe/z6PQ0hKioJ+Hlz1a9wGTzMZBT7YRg6A5EfbTcPVRKTEnNeSs3yKIJ14lTCdt+Xf/xfNLQKuHw4Xx7wzjfBzUIEZZ70AGpljBzxzwK8Y6CBzEYvqy9wIKD/5yVHu8NjUipF/BzXWvjLiFztsFLZ08gqmNYkeER/KeMpjHRvjXMajLX5UTonkUZIUtLmI4Q6JkBrJEYZtSGqMRSJsoQpH52+/xaca0kuDrIqpiN/nJkCCa499E6+EMWmKcsw7x39mf8mNOpTqASXWAEb7rqk5uwXF6io8L/XJlBGsU3T5QF2+el0aCdq+lCDeG7VN37+hcUEJdZi5yBWmxm+IhJhLgcBVmFrTs1G1B4NcxpR7mEkYqa2VTdBivlmevt3Gas600BvmtgGcJrTADOrpdBtSSyM1sbK6X965dBeddJP4H6xbQ3BW5ianxkKO+HYdm4jL5SylD+XDOCqupS9DcrJcHawYhcoT53Hhd1lyg26QjMEF2OgqFWmVGZUBZvF/1mEW/PH+uYKauoRVSp/hhkb/eYRCTdGnx6UoydFYPulT3YSRGYQtqtvUVghXLCbR2UpaggkDpR6tbcqN1cigmqrbaG8QXkAxCQKQmgZ5WpHP5T4/RanIGgvtnxZhys+vROTNi21zKdcTJC7GHd4GPSNOxh7CEKJI01K7hXgodMR0+/CEQL6Zr01ACj2Z3g/2/Vb5QT0v3jf5vFv0rQ+6kvXXJWEkJfN/liCnIqqHewRDAID/f73tdNJPtyaGlZ25KSRqLKLhDhz///8BlhOq65pIuC+WGNKzS/CH0weSuZuUXU/WWta7anyxTuGzKwCXY8m2r3XyKcpfKauxvc2J9QQGS3TTXsoQCtrGLxCHM02qkxlNFiPnhBI/56XdgiJkXnO7J2wB2w6kxWyDDMYU0kEpvUdQosYSeVk0cvR6jTMCLEzH0tBNZjT/RgSWYVYcXr6b7DKYL7HcaN5YBKdOE+jJOB6lCsFQQKG1QRxXt9fBiGle1dreTFk9I4g0F4f+0U/gcLPpbSlYwUJJzRV/hF56Zs3Ew4d9NUJIPWMk5DaMXjig9IYZkRmuuH9rZIVXupegozTn6oT6DTZmjd3kQr4YEb7rbgFHl+pC4/oNHlDwcFqlxY8im+96SoZUzdAlj/Xnz+2y0JxeBPe9MwNRCBEI4PrS50zp3j1Sivrd88WafDNzm+JwcgO0VnVojqnV3dZK0HW5uBIM+aLHOuDuWMxFqdWm6aoIhDWkztAkLvmNszWWWnMO4aFph3F6b/MqBjPpZ6X6LfQYuaHgkaFEHGUjKdDpVnCNk6PalZZYwUINGTAY9BOyyY9NtLVNHmKiuOVWz43Da3Arq/7L0/+oX17/ca9v0IhEqlIPoReCzH2Lddp3K4jWSLmqOnsyVTP9e0VsvOUT5WnyDo1k9ZegRxMqQiclmNrd49VYkEHPNMQaHz791T2AVUrJ34OoiPAby8g7y8AGCRMgh29pKl6Oy4uEiUXXrVSo4ZAa+C+yuXg/FQhm+zgRrFyJCRLM2NiW1T/brxRGpVZDc5OtKCs9zMSD4SNbVUFZHeaSkq6YUC9yxDr0rvDcXtcm69REwoVNV2EFWhmgoMgvWqoCQmS8i6wTZg8pHPELGqiHd1FAetieKy1sxy/fCNpFHrwxEs9o9U+NxjOGVBpaPgFSOxAaTu8tUVLivU9J0efPLMjB5bN4CDkjM90dgGiC3rdkSuU14lTBcfZXVMIfcLMd5dYuI37Vh6/FufrKer60Cl7RZ4quvmt/5kVElnongWLeLrKthXb0xLm9GGtW6VNYiYZfgxiSwGXIwEc7FgaX6WO7EDrpRx9aUND7vXyOWvlMsoaUceNgqohRT9oYeIka0l0VEwDMlEqEK9relQpDo+drQRaXqwHQqh/Bu1T9+HpGmh5S3KQFRnnlZVfxvZ55t+1UVHxLU6Q+3jhTKqwmmCofQlELVVIGk16e9zvWCCjY0IqkjJ4Cl2+gg9pYXil9HnE7NtS6EWELra/nEAAdJ6amYUqf2bFMxs1l4ILwQI8FKmSMYP7y3PBk0ZBUm5gPmaEY/9l40G6tRnLDObRqFeTKBx2yhkicqyn/x3wES6KZFwx5nnu0Z0gTci+MtLBPQmpur/a9WHVH7syUZMloRNp2Rdi0bzoppJhaSxIwYgxi8LurOVlMI6keIkpysQ4BbS3/K5udsUFYZmGxauU0sCGXkgNnNsPz5sKz8xMlVJv229vJNAhtPXDtwgU49QwdPOrYxFNPQDN/NqFzFke2VN1YByCxlzz/TINYRFx37vHREy884bjUObJxL07KtzefHH8C/W/t4MpA2hJBaxHF9CT6+wBHXDgyePgSBdZE6a5cmcD3Thmq3RhygwrcVAbW64eIwSOATGfYSwoDuHztjYr7fM99rvfd5kRsSgL798nVXz/GwHAx1kJkBqUuTWYAYSVV02//ONpcQ3G7rJVetc0GS26+EMRg0f+UNmeCFHv6CcWFpTbmO39WzKFIRdS3smITiaOkrUDYDznMUqzTBPwlGy+tehp4hYL1Fr69weLh/71UHgy6f/WC4T/ugkwW/GiOLIupn07HkJmKJ4TTNCjl00a67obgXewgYEGapGS41MGP/I/flOBjmIllyo5+Sdu1+MA14qSfuRANMdV1KE7OJKmBFhhB9sOWEkhgNQYZaPQCdS3QL56x7EiZeJo8HjxLcDlTp6UvemD2wHZbK6zTLjxwdIXcnwt26WHov/oCVXLRQijX3HGypuOJG/ysHgnYXrkLZeZUMrbz3kn9vBIPannr54DXfo5Tm05pZVfv3hNsvDB70d9kZVhJzfSpUxfIfZvqMQVujYd/l3y3BS1EL92WkeTdoQjg2A8B7l5rejwSVSCOg1faslBol7IOyiKwV/8Zbsonjg6ky1jplndNVQ44PEWQZIesVczjsNhsMdyvIPnSQgjluUka8qFpo1gouhr2GAsaEfDipOl71dDySydrrOlH1Lq/Wp0CI4fFjAoHe2Urol8kcXv592o114jjomCBR311Balg5EV2ZnhFQVg16n3SR4wA6xqgJpLE+e5fNnNu6JxlErwEDE3pKtYCFwSZ/c4oGKbBH6uBwnpaa8FFrN1q1DPeBxnCG7Tq0p5mDC0R6ro5BMA+y//NGbjy3s2m1lWkt6Mie7+bvcHXAK561geOA5zOVEcBhj6rnHde2pT5Bqg6P8Fso67LjXzxWYAoEshy2GJc/hwwXtc7+vIvIvSNUrUQif1sdmB9ygKLVNuA9wgQcHxwGGkVsmY3fE12k1YResDpqr61sDV3OE17zjYhE1qBj5ZS8enDwW8ISCuFud3Y/eryXH4lrlihC8kR6tKYCznywYj1W4X6QnlWlYv7/yuW4OdH8ydn8Q+rnTuTm3WEssgT+J4pbVF40qDJnyvzWgfjOpu3srFoyQQhKtNo24rz3Sg5pZwMprQTqCKylb9bSOUnrDPr9H/2cZ2fOs0n8wzUGVC5Y0o2TyQ0gYrVS4Rwin4NfjaH5YdRdEqIv6tySW/ZrCInWEuHVgsK09+0csIuHiTtgLvvvZP4A82J+Y9BplVnMKrEUZUjVqGjRTG8xTGygd/YcA2J9utUKo/vX/V1IyKIHsoB9uFHwhJ1vRfADyA9+f736zQt9IATFJdoCIcl5mNUvoj55edh8a3/7qM3pAjKX5C+5wnKNeFL8jbz2RyuIS45UtDnOKQOu4zK+JvTNIp2hSRfX3dXurVA3NGEJx+zl2OYRbtHb6ksdtSEsteag9CPo/jk7rtLWwJBAUDmMEU6TdDZLoLNlBlUAHI8VHWPi2plA30yc9w+Qw3yuCu6G1MAheSZAPlftMa2nWCFozAJ3S41wfSe8bpekhY8zQHqhPuufrrdVIllxlgu0XLNqNl3nn1Q3PesTLFFmM1lbCC5/fkavqYZBmrqGbt48fJPbQ8oYFl5Jr8SUcrw9tPTkL6KBuok+xNffA+foUpGLwiP+GSTEv+631XTNs6luxwPI/b+u9Ud/zxUKDHYbli64xlFmjWmwKUfpt5Fgs+mfYqJ9GGOHMTCyCqvYrWpoBK9277xAif42CMCBXORuiDCC0hDs+BmKS6zB6+zyDE826DGcm2ABOQs1JUGKgJDoPz/PNV9+Og4E+1LWlywfgFY2rqMbwWON+5RTHofaY4L43w38UICZ2JsNNphHZIGhwKUL1Ar2rAQJITdkMaPPmtvzm8bVD881keTu/12Mibm92nfrx+UYU5a9lhw/2xShCBs1YgdEcWZIcHeGowT9iR4cs4Jwooam3BnuyBc60aOw8SveKhDqRMll/ZzmNaKEXZSuobnwqAbEalR7aSls+/h388YxCUN7EVyl/CML6XJi90DInzAcr/cDGNBJBsaPrssLrh6EfR/IHi5Seaz3TrSzRT94Gj7br3X2FCqr5uw4eSTbTq47MnTg+rLaxHIkRBU71Y/lHcDQx3APedohB6dxk/OSmAiDWtM/O9q2gRzVZh6kKbR1J6Sek4smP5zcuCfbPR21oB8Omn+uC8yOhSlgQNQZJqgc5X7wR+Vkw/jBmqyKnI5N38JtK65zqK56mGj6capaMRm3ln9RpyprFFG2AK5VARDPNaEvywl4CDrIwbhgihmNuQshhF0Yd1Lq8jR0BXwTycmWzk+ZQuuNdfn+GL2i8CYcLrvLQUBpsfEb3CyU4Ubsgp1Wz65FNlGGoIHjSUjM2kagvxqLCkMXW/7Pi4gpYGxqYM2q+zDIv7nx8vAr2xLXxqrrYSiCd5P0ZEe3eBy85gMROzmqquJot9nmuGOiD1VxFFHimLyu4WTeQ81o3rK8xbFiC982xI6FZ/YEBYcea/6GQUTYue5P3kGeg7Zv0IL5qA1aGIeRM7Ql8N4FSiZC5/jNbsnaCmEx/or8+zmrQw+FU+eQF7AxfppJFJY9rR2T94sGA45DUvN3eUgozrjuhr+qDUdEijMZIlVu6l6PWRpf3x82vVZTsiu9ugMouzu5dz+NkfUmnM4jgAAAAABI9NK0VNxkdduT7btQhZUuMUdfHY/Bg8XifzR/TTdcIutRv725vvEelEWs7GhqhPA5MeFVtea3Pvly3L4L9bbDVYpvSVksixKO3oeBSxIVFuGP/ZzHaLE9ahkUl2IXaGGR/sT+2tjiQnVPpC6nCH0hamtem4UjXMR7zJr59wBmFNYVAAo6DEKKSdJ6ZPKWDv8HjRJIZYZbfsUaNnvxE3/ZKYEHAUXSUMfFESRl06W0byi4ICbqBlENvBkIp7VPjXpptjTN/f4lpTR6JLx9+de9jXG0jZy0NOW4u2y6CA90pBx4QuzZ8OzoiSBA6RLcZKgaL+RXhBdglMkA5TmSjQhN3sNbwu+Piqq6i7T7KLrA6QuumkNpmpbZSSiPLKSe7Sd/hnSRyipL3qmDtn8X2IS0MCOBRTgB/GMDhfGx6MVy3eAMWself3CWwQXZxsgHyblm93IHu3kh7P0APLiWVdRXWhhzOA1iD57xG08uxTUeoWPwV86wbj1Wrs34WBD7SDxUDhH9t2NftCANn6eYocXtEhaKEc/XEePbppSVUC8qRtxZ5yFDcYBpEAAAAGTuhAZngA7tDkGokKltiq4aJt8MVaLzaa841f2vOpBxmQF1U6bVXCyYSr9oGA1Mi82vHQ5/S2pmFaqiI61juzsfxG+VOE8SkRCeBBXAi12/B1YHE06UPTiuTOfAI4zuk5KyXDFkDB+xbNAWrEhFkSlHjJn2z7iAxUyievDhmXM1qhB7Vd/WZ+HMbB+AO6ezG/tLFBN6ldbxtrSc5liUoaLPXeXbT1Ez0eaWC28l5I3w7GnhapGWYsFpZtlm7KrdT/Wq72wLWkK05++UNIlVnWderSSlSta2YckoTkZTRyc4iOMYSv9FGGkE4HSFCDv4f+VbjMNfmftZRiKEjMtaLZYftn2czOkOQyKL2tdyX0Zt9/Lqu0fVDIQzLTqhGhtnkk7eS2Me7oUs1YjYb+WvMzqJy23ffpPjkG1X66+On4nYl9P1cSGL5dj0XGRzqemd0w0lfX3B32x0kZFkTWhKSHQPw4IyU1ccJ3EZ+/1swwathihoXB3AX4S82ri/WYTud8I7Tf4ipyLd9fb51+2qvRTAAwk44LUyayVRRgCuYWt6B/8m/9IfuEI52Y5DQC43xUtAngsljpfq5EjCOpy1UGopVlDqDk0rBzMIofiD5mDuF1gnBmjyngh+F1rPrG41NLmc7wcRBb0VgCHWo/n4Js9wi2buubujgDQoMVrogw/uL4dlSNihlxQRtxkFKpTzv8/PXpA7hhVqKYuWQOiTOVvOQqDBgt5pgPIMFY/QKPf2VqNiTatfzl4ba0zHa4zal7G7GPGaXgXsxF3CDQkLo4mAqxHKzcdnnUZRq0FiormXUW32Hy/Xn0e5b1yshoxuS0pc1XYn5Pncc0WGOFfQJQP7gAMWaQ6ZLoCyAEnPYSXri5b+fonkugdWu44Xg18E/925cPsKLOOTfb1mweaMGU4OHcrhKS+1iM2BzEo2/cf3F+Xp8cFZ/wfAdtDjWmg5rYemjCRVpQGoHZDfuzArsRwpgOVXsdaqy31XjsIp02+1rJI7ynonZXLk0VFAVzZpND1/XiLuwzPcKBczGbV7D0CLVcB3Qrz/FxMSg1oLQp+qhVz4C+yAnoERKXydgCGSUiojFkU8E4BQWimt8RmE643maAe7R5mRleiPqkzUAzsYYDyiaqHQVyDnjXTAmYl3Yhu0pV1CTBzAjY8MlX6jSlTEnUcQsh2mITJSCnfeG1XrWQ/lmBH/86fZlYyvqx0aSNvdFDKlmlmy9kw1NvTE4p76LJ440kK7NE6PdMPMtBW+0k9MKtN8CYIeCHKI46bwQLEJrbp1eAyFbShHC0jufSgvojSBQd4A99PAVPp9g4psiqI1T3pqzMl4n4MomKQsCh7ZDwJ5372H2ZEfrLZ6Zw0S1OoeYf6JSeLT4UBC21Mj6z9kEDe2usQ8haPRTlIGKklomRANuylkEYN+oIfHEFAhUNJMq5Dku34ihpR0LFqj/Tk2t9ohTIL+GD+gU8sqtjGrwkTYpO25o7I1vnwB+Smrn7KuOM76cW9lSjeTUhxaGwCgx/6j1y4hAkp7/IKP2ncd2LxlWjTnAZ4Eul92ial/wWIeXT6y2jzXhzTxBv6ShlAmn/Y6PJa9awtWVF/XP5Yu9S4GZb+EK81OavlGqSXEBmat6GlV21/ZPGQIt/t9MNE+wYfIHEZ/jKssIHtxfE8lxRgPSewTOlEfh0hlsHLvQc4U8BTdgK0HL0NTsx359soSO39P1HNz2z0fxwdl2nADBRlNMuedbdeGra3VO4IJCxemUCS4TrAYtTqIUq47qg4t7HGYiSQWFnUDeO+M340v/2IUUkSCqxLwjPemVaehJPbgiBgK6t95SCIFugEAn+olcHb+r0uzmVGAazyMORvPpNbBonGxduJmcCnTwJifFk26I5xV9fNfXDv9HWrckDbTeaHcTKoAVAoNM97vIH/lM+UWkFZPBxDE+oZOlABJHy1mF3oHxQm4cQUYWpycyysGCSYieCgFue27OY24/UGBd08VBk/HPT+2m8jTxQ9kZ4jXe+LwW6erEAcg7c4/+zrshjBg9fZ0eb4ihZCziirS3kdU4yMFBLUqw6/kGjhufyF/UdLLjwTXc7vSCqMt/qBKUbo+UE1R3SqmA9Sp8dGIuQpvdpQiq5BoabcyfSZK7kCxvqoTnkgmBd69LLkllHO4yWzTI0/MMcQ3bpE4isH3qGbtwWPGW31wQz5FvI6hB8CmkRVuGZ2LSqyc6Mq0rJLExQHdN+CWXI9GsWqqnmcRZKOHgOYWs9I2ZJ/wBU+3AzZlqihBA86msq3voTM+weUO2gSya0OohB1Eb8ublq+3zGqg8EMhAkflnaGd6QQMgmv0V8T0b3Egu+XGyXjvxnHAALZhCPqV/XemNQTCO5pGcgfTQWhN4aZGOQVaHuXEn84ETg5oU+decpAszyUlIjREHzG/Rkhgfh8yXFzhgO3c857uCevIKaBJtYC4r0aujr7Dsye5PWNFHkumNYh83q+j7pjtQjnkoeix7RbBwJtqArRyNiTPhdg4vStT10hTJ4buY+3fHkK8qwrH1ApkNOWY2zIEUkN+3h6sAgXlBNw2CoftyJExBaTTzpuVa/tkUbzklpwlBU5qROu7ROA7NLP1Ejoe6zfTjTJYeuziYlH53Mut4X5upqfpcH7Bx6JSNBYoNCyI9O/P5KY3aF0R+EwOYsNVP2HZRhBxfJhnMKyqTUkyOvYkiSVoDLZwBQ/byDvsZW2TdTAX2alEGT4/awGWzk8fH87DdNeVkb8IPbmGEGNwJbBQLQD0j1Z3uEGCbGpV8IwJHEqdO+nNRFXT7x3JRkFp+qXud9NIK4DT4H+DylLlC/f+6lS8Q3xtmW1ngcZIxH9+iDphwbEmtnnBo/kyLF2wp7APL0XEJR5OP9vAhQs4Fwh8R0SXVNuiMlY2bMqeZ0c25CzIP8/0J73kZzWVZ/Qt6ANcSt5deS/HC/dbrqxnsQxl44XxSU7M+eIKGyns/FtcuRC2zvgOKZjyoVDQrypn0wj2KHmCIkdDwL/hK28Z103LQsmHa2i61PyHQKuu1y9GQx4GijB4DnsQxJYQWwBiuL+xF7Y3aAbeS8kb4sLk6zLNnEbpun7Qsx6w1c5tqwVfCG5RK6NtW/pRpFym/lKZu9KMH++EHdFvUjFPlatWmQdgokv5AhxLjwCcaQ8NpxnOSNpYu4uN/cxIZgZSj/NUCza00uqilaAueHY1j8EFo4AGnM2A1haQmFaYA9e8kjZUPn9RhCIToNoE2ZpUOQyyzQS2imfPJdiwIlwwM1DPdKxWw90cMQMUr4zflqq7pZ3ye4fZ9RAUD+qIHGCYRB78hNh60BgUUlGVORmed1v4qCr936n5c4CSCoN4WGTH86vx+Y08PFogV4lT4dpBdHDvjFb++QT1O/boLm8PKmjui9s3apB+D4fIydr1XEq7KX8TF7W/UrmaWMgJf1E5nsDG1GxUxCufdG5j1s8x27K35zYUZ/u1JQIviMxwYJr4AF8NJH7li8dbbPvAeM+CXY+c+ntHxuwZscgVcVGfdP5fNjsk5BGjl7qVNhmrtiZ8BmlhBDfXp+17LzZXom574TClH9l0NA4X4Micejibh6O/aqV8Tq/dZVr6sqHdnTxRBx63POsyLlu5beQlZPth3myOxuicQijk3NNvqXOAqJJkcQ3gNNfPRzG+kGINyauHkAk8W0PMHQkoVOmYlRwYhtLDTQMNe3u+VfTo+78TosJMWZO3A1chy6yettWqZY2UEzGfWoO7ABCkwihfk+O8yTDpWZVhpLXAv/uYjFcJelezHB0iFHmTj15YFacTdlgAKwafw+CWhXtWgZRtbc5BxXjzoKzM9KLqUJrjASfquauqNu3ZzmEiwVINvuVUNgvYV8ZvxXtKs6vQbnZjA3idWcoOpv+Moh7Ojd4H0KMaBwtkwgxnee2SVojiLU/TWnXu8R4hJaiptZ1zqKkQmghYBCjNVBX2bY+/cpJJEgRgZA6PdLAkyevTnugYQLX/O0etJDmZQbvou/JkvZ17sf2HO0U6KHn58pED+g091Qeb2yXbchUNPE/r3si7SPdeH3AyeIvZSqnjjVOZajjICTl4Md+gL77vsiYa9F2UNHCPxleEY1WhR0obP6ct/OEp+n4alymALoV5yc4KLTxSUArjCjGCGXzlTCriudr6t8ISQRWKiypMjxoB89Vo1m818qEPuTwLmr4AMmLNWAKVzicwCVIIRs8gz53NmIawGDBC96xooRq7MdVoog0UaixLBMUIBXUMcFbbeqGs0pXi7q7Lm2QDWcFGG6o40/y0a4SGiBgSSE+nlHC2CTEmTRlHUJXcgvkTRAv8Nvm27pfnnp4AjqihHiQUhfoRswSQYmyIDEXJS2pg1ny0jgH1zbbzrfFvaDPYPYaZnBhPLoy+QdadZKYhCJMY/iwNhQ1UAInrLCpaG6EDPiHH6AGSAdVp10Ei6EPOpyIxKjwEm9YatkqbpkUa62IoGhCRavwV135fvfELTgljxdCHJTPOjZidC0JJIhPkDQM0hLxoFSD2ITqXbXsg4GX3GV5MQpttFOK6UvMNoXFcpXKkZAuvuIeRgdxc1hpwxsYD8KroEwNv6eAkn7j+A5bAwB3eLwlRXHWvKhkDQ1kLwAXPpN2QlL/aF4L/xiCxBU1I774U53j0b5JsmZaSnt+yrjxUrpW4mfqVreMWTol5VgxXWWvikJNmQ93m4UyDsZE5H2r/xgzNbOSmGAclVFlizDSNPtmoFVda4XkK2UiYdpg/FIyZKK4LgSKscpzdLoL9RpkfkM185mbIt78CjIumSCTQMSJZVkz376125vIKejprOi1ElBakF0SkGUvtngd/dvtibBIc5Ew41+neFTfFjpDomTRZU5NpRc2gOWD4eqSjdtqW7C4qLrNnfIBg67qfHC9FzKgnoyekTop9NIykG3tKU/p8RMWaWa4cxjcSabE2uPcLoSR2QXmL5XaylsllZwJdoL7PBMMo1iIgmsOQJM9ezY1QrnDzb4LqOGlZSNuDOaR2inmuIg+IdrVjY0ngAd/BHhPHwsnu5peI9p5HKc7GqZXSL8G+BPrC+97XWMoJz2E8lClYkTDKMwiXQ1PIZDr/sDMYEb0MUWlLl1G4ebNL2cZyeSKpcmd3zR5q6eDldjkMD6cpN8SJNWO4TUcIfGdlXFIO5hZ5pj61kNfMh8YgQpOh/v4X+G67KOvcuj0Ib8EmVXCMjSGNpCxYuesVeWhP1T3ks0PWsajTgT9q0+L/nKmDMVhP/kNfMjuYNhu8mLW58dd8qvU2SPmfipC1iaoEXMgQidakltltq+p/gimSZw0TTBvp7UptczXY9XPmrqo4kgzP86cpTpurA9Tl5II8Qfqk3xHApqvDJMJMpY1KqHi8smsN2HEQGaATW44Iz1mK+M20/OENDX421v6wlW5eHS4s33cnveydldJeegqWXNzqETWUc9gqMlmkyJasdGIvpL8eyUow92Q/fkwk4729THPfEBSJjqG8WtNY59PgiXARO01KkNy5RPHGp4BcrPXDM5DCTu1hWMYPumEqBuDAT0EBnhQjVr0k+OM4gTQQF6QNNB1oUc3rsg1hxILzF8sXWd0BvIx8bjNT9xhO190z3ugUASjIJRZBRDo6Cp037fDFt+6IB6gB1WovXn1lPoEfoQkfNbfVZhUmc5MznjkJsV9mkqcFaZ2L1pdp5AGjLkXg09CqfdJRGDZJ/4Stdcy79o8f5dUyivcxYfhJULjBoRCrP/dnDCrgO7dGWJAsrB0kLHgpXKJKBRmOmeckHMQwkdi5vMcaAyjde6GyAVaATV999OjIAU7CzklTHOJfSHQcm2sWLw9tfeay1XY8LYQ8VWqJVqBPSal8wUJKZHEs6X3T4UfgMbFWS0EG5i8Eye1Kr3tWsRsLKjnC4mtSSwvrPHjYmYMLZwiHEizDErRdZTwuHRJPQdJbljnKYzB+9tvX5geaeT1yhC+kxI8t1D54szJw/F8ynEWzMHSeI3C8ctYZeOrzyK6b0bGYQ+RecnEROo60FRfpTTtD3SUaH2pXhue5iS/UW76RaSeHcug5aX8r1zmAXGUdxd/yhOknMEeTmZryWb5s5Xgb8NZ7OIA2jn9Do5pAyZ8o8gH6KUbSx6vCfndIbeLAF7sDwbDykAAxyY0r7KIENl5z0fk6qDNlTbRk5ma8lm65oA60iSSBk9xmv6ZGXzLH/Z3ZiKYtrfSwhVwzIxEknZcaAnmT/TvzjORSwANsIKEFY2UEzGhMXmBtMOYlsX+gCxnouISjvqRdMQZmw4PpPy4OnFnsaOPSiUBC12A2qjCFPMMu2OqJ0IT9bVoAP/gqZy1tbJ6ps0dKJjuxl1H3H2387yGaK3wGCOFQHwTyG0qop7XUy87gXw1fLPcnQ18TfbbVNqVHTGXwHds2ApHhp4E6Fo76jkZtcILbLIIyS0PdQ5CGSd+8mHcNvoBK/y88EZLU3oHRqrVLfUvFQ3eyVH2O12naDBz2WAs2xU7Hz78EaDnDN4MgiVdLbtP34Fk8cY5qywdRHJhwNnaVVj3BTq0Ba+WceZhs8h0jfPcSUu4QB/YriJsB15R7W8vpl0ybD4zvNNd8r9xA4PfUb/bY19av9IrvtRCG248u2GzYwrNnXcIkp2rTAt+p/U6tw3rUUd91Q8lIpv1HrB0UxzS3M2/WnHzbeJ8wL0ucIJaMYM24le16i8GFMaDqgT5VQjUVJPZWEMaiLWGAp4Gi7RHCgZtN49aWI00AftLOMXwokDq4pmcdcM8iSstDVOWhETBZnJFF3YvMa0NfIkbZQoVxl58oP3QKGTDqoj8n3q4N2i7uvjIkep5/H1+pRBg7VzD+CciAjfqgguaTHW+THaX+E3d66BK4eaVwE2UfsZI6tt1HG4cHvrnWOfQXG4GUud9wjj5LWK8emxIAbUEeuo7IF6E3f9eJtbZ7GniCyb3LZV95A/vAPgrNK4UY1SXF3leiwPHrnWMN5HZauKq68qj7KNt2BsPjLYDkE9wlowvBgUy/g7rqxIfEOyvW+Si0Q/6LEKb7TKjNpFOZbp5vYHBqhLWHyst9TRooIR+/jei6pwHyoaXbVQN4aBby6ol3KT7+EpfxXTIVbmKlJoQ8JSCMAKnx+U8eQ8LRBAhiub6N+4p995JzG17Dh35tS9+7Z2XsybwW6KU0DmTcJpugG4WKrFE83/wEl7AM7TyuaZW7QZgWUiMy2pHojxIQwlAIbtPrFp7G+y/1jWYUD94/Vb4Y6rpy7i1wBlqioNHg6+TDIy/htSUt0ffxhFrNw4ixLeJsP0JkdSdj8fxNGNLalgckfZreBeuVZqg1+rqS8UKbzvp6kOeVVphJJkdSp1mAaxUN1JwPUl7P4rjPWLymreplsp5zrcN8rna+qeLnKcDmywGJhMyEYBtMakpzRzBLnVQj2Ou9sAN0q0eEASGBye6NdGsB+cVy70Nh3XtRP8Z8Cc6z2GLkTmSf5jRLZGTJCTQ9A1/HbqTT5u4DDb9K6z80N+CTUBa4Fm5kE939gvTizipl3y2r+2dG2NOfEsnE9EGM0W1UbsDsrT8yLp++s4fUiMmpfMANR5qSRry7YO2I7OH1mTMwnHcwbDfYF7Cheztsi06ZxwDlRnAnIIXklqTTgQRRgXAlzaOmAoXDXbZOn3fWcIumUcuIExkDdWmj/MJFl6mQzIb+qbSd6SYLRJM7Lcde1p8XT19ElWrm+6WR60yv+ZRXRlfrvF3Cdza6nkm6zKgKHJ0N8Me2ldCgcUSp9T2fUJMZFikDDIg1mW7hkSO0AIirPF+8Ny2Hqx2EfAT5hTBShW8tVurvMu/Ti2xv48yMXvIFy7+dd9OKCycNc5zUE7zjhuk2wc+VIRjRRz/q/ngF8zueYMYOOpMessljMhmwsbqLaW+m3SuOvKDjK018iqNymMk2FBNPPMnBQ1yL5WP90pGXVp95nNAJN65NmHgAZGGXcycSZlTgfhRXQlGh12hUs7b+tUBXDSEaa5f6DleDY0n8ffiYOah1nKgdbIjLaRseRA4fGW/cJ9zLYvkg/KiQBNTT5enfopXc5Td4MBZhLk+Zl57y27urNyvZt8T4+gPZE7+wFYdrT9DkZlttFOK6OlGbQuKAAD1W5/ccplTFYynTt8wfm3fbg42LyggXOPFDgDQOC2tDdKDkCRcFKtRC9SXuhvu6clc1+fPspLNf1rA941SVi+S85vMozljJCzxaK4PhRfLKd6CFpLM9zQ34JMqyyY99OUGMNqodHG39kxiprdNB7+DVGeH4NVzYYcRkkkYusTqhJQwNl5EAZJk2W+XqlIJJANhGOqAo4tGtigBP+/GglJ1hDvz6RnwgkrwFXnbGzCxdxCIZOO7cucZaniunEK3IaYRMyR7xCPFVYOX4TUy7xXggxgGpKEBv/A67y/UYFwJpjA9BlXd8pcssIF2gSwU0SokpQahFDHmrLLXAq4TY6e48sRQzYmOju0o9VVSH4bpl3D2XQfa5DV7s0yx8B42l0XQ2plNiFZXWbJZLotjFEp7GNxmq3WPQZ1pb+pgY8UiQvA6Z7xxLtnRwMv4ZAS+sdV+hdkPAcl1mxzx4JG+kXKpq3YiEEZL8UmaVd6fhGx5q9ACoFBpn67LzMXhM4S/66/RZlKPi74x0A/N+5pJeLP+jPE6MZD+6cfqpXWC8WbVtWQSt6aAia+iXzd0U/UlNnsUesdy+sfNS9s1te9Y51evFYgSS3HuViwSTNpHzLto+yJ39gKww2y4JKvUNB5weOXmr90BYGB9iq8mFLy5o4db55861jQsKfcNhuDUvLP2pqzoCSeNORVed4z4OddqbPAyZCfspkxPTezjYFUg/CbqT+UnmgkIwA1Yr4NS49bkz7VuW1SEnOV4pVjG/+cThe6IAsPHPyVIMG0QNtvg1bxSRrco6JoDDM241pMkNU86CfEIVkKcdh2eiDx8dvwgKSCTrgIlozvDvYJ91YTNoFt4N66ixGum5CCuvlzp42he3Nb0W3z8gQ2gHuO6/CAo878+/Fr32M5hl/NkdsZfy0BE7gPiaI25pDMN1066YRewLTGwW/VGANHYKbQKb3n5nYaTYau3q6h3v/QgW5quRoAl0PqpN38thPV7RreL3WH4vwoaicAqZcBcUeNfj325F5f25cGJEe/IZ/RGhdK6cu3bvPUgDfQqlQ3Tp0lePuBd40x0LaKAhBtS0xtbUp5ZBZDuMLMQgE2NveEP5BGUe+A0ObYGfmnd4tI7n0KTJQCbi3MBx5FcaGcwPXPPIkaJ2FTS4IJugWQgLi4IluJoUIdwFAbyWy1pa3zYK3H79IbmGCtikzZ7s0XcaC6zocvdzNoXx/eiuEc3pGKTEsuRdbVGSvqahdjIDDEFlYUNY1KtHGkOzS76qHJLEPS5LW2zeZa9DxlIpEa6gXpLDZUUL7YkaNMGziFGf8QNXn6LSUSN0e1TBGzved57yH8CKObYVfs070v0SVvmvKw6eeGWwC23o60CSYaehJ+WPBGzvik6ltjx44P3M7gH1vWOF3nVE8Ykv+c7qOg6h4qbHpcddoSA1U8capwIFXZ9n2K6UQ/ZPq8K1U0u+B6uNANoWZWIWy5iEmzOa9d7u4zJK7m5qcGKGjWshod91OFBgWtfV8PX1+IVf9vrez1k8TKYU73I2BhkXENtZFL1+fQLPb5kIuykcS62TyZavyH/eFL5a7e6Hr63iD2Q37yBqAiFdxBNc8Du1tVwTpoVL2Uc9USdi3W+DK2F3Vh9FkBG4EsNQ3XCx9Po+zSlymElR/+dOEtMEpSsbbF+VgnvwL1lsqZCVbYHGzazUWGPeTGMku5BQW5lRZXEGMoXUK48XVn21B6g3RvdHJuNSHcLqGY3GxDioLD1zaWIWvltMo5loD5zP/DOV8877hJMOqWWEzo3tYUKqDqlQBb2zdh5pl0ixbmEG8PCSJezYUMY5uL52TVlTchU03eMR6HZ/BEfikx2LwaO2r1C2HY7OKI7Mpj7IDRtUypSclz6McN7X5WegQik8inTM+fz1gX5ogRVOz4Irmcz/ey8NtM08hqaeovagHJyLK7taH2ODzcL3RvBWN03fdxCwwrZBySOcjrHL1qP5+D2Hipy9dPzjXAH4fd/i9g4QrkeIrJ0+aK+jEg4plraKNfL0yBMG4bhNkBG4iARVor3PDoCMnonZVS5JweuB9zrYmhf2aA50tZF7MGHTbbg7j81BVuZV8t7EezDpqAwb2Is11votY0o+i/eGyhF3r96s3EKN0m6Zp+xb7N3riYQnc7JspgsXq+SAWXTboh5IbKtLijqY7HtGArzQ7g/4yteksZtU0yuHcu+gWJtxIeBIvCmU7stsYqaoTuxy4MZu9ABqEqIcIg25wR7QxqpZNFa8JGstUsgpAIMJm/zywYbvXS9krPCF2V56R+f46Gfj27rbKA02Pg2/vF6A5XCSx55DibFJ23ctnwIVdt28CfKC1w6YuoFMEwxxDdubR3AOq7qLF20u56kpveS9eD7I8kASkzA7GbmAnIoY5794S+WPm62JN8P4l6LLQ3bcPwKWXSLEnTOaBC8wO3NDyt4lJvPmZd9cnzMvBC+rEV9ZsJgL42r6u34l2zzyl2jgJGOnYgKC/jxhy30QUCO+AKQtIopVlNA/SKm8VXMhfpFxDfMDT+76RfRTkAcLSfC+4FlilEQg/6Y/fRjK6goqEUSErhaGpb+LCLO26RRNQ3F70LaQkME++fxgjT2mVZhHf2STqLHZWTCXJhrB3yjbNeUM17V9ka8Vy5AmLkqZH3i+LbCPgudWpzDKQlv+JUEm2G5tv5ExprQBeDAyMSh7+GPkOpdnzUuU54jdo5xJyAeDrupyrEGZ3Ty2EFH4Fr2lUaenkcrGRsz+NyZ9tbnFdnbjcAjwDEOtGlEGoK15Q6mZzn9hIBhYmK84Tg5TIDqCS+Yrrh+gRfMhAfRdrQHqKletNyrsAJT2IauZcEu2j65CqYQi6T///acOA6Mzsy/sdOtKBbPfjyiLcRYJ4CcdzKzDcm9ZGT57LCNBL7/hqMtXp50PnoWrgqSONJa4CNGMU3+9+aEbQmtBGZ7HkuR4K6E3Bfx6drvZ5xty2cilM27lSSPk+BLPlBv35UzlulybDBuKqBdIRuDeAsUKJ/8vkJmMQTPqMhB88Eq56NOJWRo9QzOWwicDdIbvauq3X5758XNfSvn5vfcn25nVi8pqn2agHwV5rsDEAULua58f/Fivhf7zyMKFtN32AJ7LEDaeLxpeyVTSlStLQyAfbDyf2qYt2fJfE4XXiUyhPrMNREi+BVtyxBX3R2dlB97+PUzbUjUMQNWj3mie5mmWGcF/H1ndo3jyPo1rzz9IO88KfyiKaioa4TDzLQWNmmKldrbzGOZS/jG64CNCE6ZXSo3HXssEC5/SxayN2Kkv6Mc71/qWkLwwpFsRr8F7qqTR81YG8+rP2HFzTjBtbyikZRxZmXUtJnGhA4NmItskicyV0hOkM79wwZp/VuWTpgs4cS1HM2RCxuWRxA3EpRVjk2U31bWLHkPtSvHRtTBTK0Zk1v2fKAgLpnVfgcemoKAvU2S0In0JgCYv4Ppkc1R8MIRrXwX8b+hXuH6+Sl9cW8bJEsv4krvqpNSdIHBn0Px5/dRWc7T18BIriVORmh90qivqXkASXgMzuMTy1PWHnJrj4dRZcAqh5u+GMv6iQf6+qi60yApgMbJBqmkwf4GiPXLQswPTmRoqhn8TDgB5hfQ1xHddFWQqQ4+UTGH8W9OHBfhpRFM/UC57DS8jHars4XP1rSjoBxrJ3ui2oFqffXUTac/TD4dUwEDdMwPU1JTCzbTKallZ77uV3pPIFLwSWNTVLKC/ltbJ6p9JY1+AZMo39kojjWFivTN1j7dWjA2Jz2tNEAcRztuaZGe0Xnh3Dr2opcH9LbcyhwSb8DMuhMYhF0qaM1A5pS/uG7DxpRAzoUo+Zqya4FjfUTFg+Jd8PL35CYFPM4hGEzBEXeo2A0cMrlsVkcSLVVCLatd6Yt941+R80PD0wGdvKUzS8GQDVCv9MXRxCQ0HFLEJQ1fa9C94xx74pA7r6RdUreEf7bhKdehkHngNQ8wJ9OHlpfCyIA/D5NZejvpPYS5XLBOADPhKTN3hTWOLcehH0rFkBG4odbP/C5SHmAG0wGEh+JWEXV1PXueB5He5AhoFXnBtperiCh+xOTTcCEjIcK7alfEklyueGBjRT0kReEYK5HtS7aCqLX+D7Wmn6q3b/oG9J3lp7v2Nx/tX2RQeqqnBYCt9oJbfuw3HwweL92zu2fewqEILPx5Pi7iI+zb9kTF2gicqVERD3f0UWzdZ+WHUyF6SqbDPkKBteaJcxaakXkZzJNVfEsgCCwnGLgs4KTW/npXsGknfyEC9QABym5Xecer6g+oKvODbDxTjK+ig+VEmpKJWKNAE4aieiQk2imp23Xad8UWfDf/aJUsoxOP5REVu9wuVpbmsgIpAaOjUNLk2gwkpnA+aKTXWIoIS3OK8pSEdsW+FIoX5wz/UK/RppBLzMmzOPt4Seb6w40HP3oOvJT+bT5sCRYymdjsSsr7b8rhD7B8e/MCl5rNzc/vdltX9s6Ooy81fu2tACz595UCt8r3fcV1Vq3IiJtrsDuLmgNph8d1HyMFeMtCuMAnu3cXdCZKUVmdbAvm75xFGAEcoxAy/s+D2py6Nd0fykVxIOVGmuG+lWzUZiSlkH+f1QPQZV3mpkUGEEvL3MeZu4wX0EAbTpBizh32K2HppBmed/TBYz4PQNd3tcgIgK433NVmkFh8DkefnkTrulXkjtQp+f6u5ayuceRU7aGd7qAJIQiECN0lEYLEBQOe3C2bs5w8f9mKKeowFODzYurvHylS1Cu5XA6KriTVFIr5O5a28K98kj62wlJofJyHOcI6IEf7oTl+lVH7VhBShw9EBNrY1pYXvo8fY/ONsxQh3f3YgCiaoOInmIiboHManh3bdCLpGK1kymS5bSoWhN+j/+VZHrL8B2+ZBjpqBQJJDgcIckIET6U2XzA1wJPHvZMqrKFfjO6Zsm++c/rw/q4PTAKDU2Oq0oczSN1gXK6AE0xFAR1+pqxcIZTbwmG0/n4PFSGJTtHukDxYw7iSDC9D+u+MoYemnm/1D4C5Cvx9YWKqHyZ6/3IXKhqLIBVXy0Nu6tyuItk+VulfBI5W7PZluSKdgmlcKqXAaDwDS2h8MpgtF1xndopxXSl5htC4ahI3vWIoFOCP3m9lgzrNi97J/doFkwiHEgDazioOGgsoO8ybhJcERBTaHxs1NklFwiIg7jvXqHgl4KcXiuKa4czVUzD1WDjwMnL9DMCeVBJa0WGY2zn0YrcNpTRc01tnwMh22Sg0YBrbXQeYxDxqIEtqwwfUjsi38u1NDwc4BnKSJZcFen68JuYWCN8uSsCx/ph1hEwAwwZ50Ap+oYnFMVTBUa7LrxyXznSEi0mj2DtGmY2i9kxw8x6wDEpdji+88afMWLw96sQ5zXYtbJfRvY5dHuw96wBeEdRqJhh3prCwSxlmUX6+buinxLCNpT4smTYjo1mGMYKvQmHeJueBI0SIKltXP4UdoxYLStjo+BprNIsvAMIFlFTBpd3uVi3mQPvC7DCXXY0CMdV58NPuE6D5y5bsrpcUb5MfZTlBNrGN5yb7VDm0IxDPFZ4ljQdezOAkP+JNd2UC3lyRJmchNtecctWJnne5GZEZBHAFnJmRKtyOut1LorbQjEM76R6ci+7Nq0DkZHmnVmSf1UvmMoTzXRtADor2OCztRabgxZxMC4m/MX2kV+Il0CaZ9dE2RclqSHJxPDQA2+qaC4tz/kpP3w0AvmfF5Sh2wNFBT9TwcnXqFGg7MLTDopr/U/8rah/JkRYpxvejbGvrV/gDKiRwinixYyI3adPvxuWjELYo7HmvB4fIqtZoAbFDx2hLlMYBFtjX1q/qwRaSGMMS/qJzY1KAUvExv+ys1HPcInZLhf/vkLWFrS9w/XyUvri3eeuguQtLYs8Lh0STw2nicRsGoyVEmFF/ueWki1GyAGzZ6A6PwT+LKuXhTbqKJSVXS/QiWXUpJSDT1VDAh+WPXe9Tdo5THVrAfcHL2v9ymHTT5xP8ciqtdsoyBe7FUFnjw1SEdqdf6dhiYB2NczcDXbmIOm9gnI2L2frnGWtUnaCNwHL8U3IVNQclZBSiRhCwakHSjuKJbNwW/r8zfgBXUq7ZbTXzxzkop++uJOQFDQX17gfWmNWhGlKQoxtlajlFIbhW7q+gpCydQq1FlXQfEK12okssag/ZQ5UHdLc3fJajUtqKE1ygwBbxXV+tsreYdAs3sjGAJ5qiqZtAtvDmPunsY5pRcjhlI7C7FJw5/gXeWejLUkZ6hxvYYFQUImKe/f+0C9p6UYKEiT3uGbN9cRF4qjZsSaSpallSbKb6tq4QCx0eZ5xjzN3XK5K1v2fJ4/gwlTsGRtf3Ci4YgBS+99O//fpobsRogmPT/l1GV2kgQqlIUsYHf8zi56FTDoprr07tEMgLKhbZH7nZRNzVySY3vZyWys4iPqKfeH4V73fBLve7Ji0Ppwj9CHPxtGdaDuhQLZvXCpaG4sT/DLmA+ljq0xZqOLkXP848CReI5d3xKCIEGdXnUeDyJklfzHXYsErfEL5ZnPqSXyEMEQSfuFIaTz6MIXTFiYMxiGcJFq3APJRDCQ2/aZlD3Md30AQGipMqDYBlopybhej+0VFS8cms/yx0oWQcMV2AoWxjcli4S/hiNqv3jWfWxcAjuDKhPQgrGUQHaKGkauSo3xR8dZF7uIx13UiYYGzayK1sk1af67GoSVFlcxgRKxqBP2UfwQtGNUN/KgpVNuTbFk+R9W7zJKOnkkLr84i6oEM5iM6veffm904mUhg/q4TcK/Vec/H73kEzEMeLaPRna8RqVodHFuJGBG4mjCdxbNo7VPldqoH7C+8ymzHhgKLgJ3wR1yoh2NINrvJDmQ+PAzkFjyparIEOcHTHqMI9oTYqBElDj0I+jVDBHgRH+k3nwds+uVq/13ah+1yMwXq9LUzxbvBdiwCDFprVbGbbqRmShgFbUsjfk4F8oexUfqknFJkCaUWIpucmpQTo1AprOa/0i6OVYhHaDSEFzGeNzAPqUTpcXfYVHlmIpHiurWnqm2Up9bzubz/GIv9B4dTIWqWXR/bemK/KVp41/2gDv9aKj6ufvxCNAri/sRjoL05knqDLDQHqCEjh2udO9ynZgl95MCtWRN/ff3zaSNzbqce2ukPY4d+EqvWHiRJMCP+dFGDQ3P3eY0rpyTHfd7295yCHXtk5gS5qS/gjn7NoqOuFS0Nw0ShQBcIgl+qNrQm5WCpclSNvafE80HaULeMRMruorKgrxKBlnQhDA2ZjYLnRrHIsELjZcuBtm8IQ6Pgc6WyTERnQGViigRHaXszywsnLIFCCA8Beh7XOsJje6JOifkPDGlJiaczUnixFZ4b+JEEKh/2GCcoz9DL72hyO3wYvM3UgFgh82S9x68uXqHXD9v7A707Q98bv3gzRE1Nc45OzXSzeDFzHDo7alBGRE2LWTr9KfHmqJRxabC0W8AfLuwlKMPcingO4OFyiJRcVYf3ymIe7aspLEoeKXr98QqrZza63aAdbA1GSc/oV/dt4YuFw0itC4nuG1RudfriZwg6tOCeZ9qRDSDMKb8WqG+zeHNIwkIveJYg/UzeE66fxFs2KZW+611AgTwO40BzxwjXhygw8RlSntYfMbEfYUrRaBRn6K3+J2gEMdEM2c9nYfgDQ4oCpyaItMv70KeIgx9Fg8E6q6YsyxfbQzunLnkoeESRFdfVG+m2Qv11+vSXSWYaml0TeZzLqW8tMaRhkUYkcwtzarHtENxMCCkm9Ut27rnLgaz5A0dsVCqtQJLllCUmMeIttkx7z3lKL1vgCCOLGKEl8gmFJfKqUyjEaebkUXHpfcInEcEsEDyi4rZ7kasNFRTVVZ7DuxmHntHXkXqiRRZ7yBFIZP6xSIIQJKe/xzx+doGAvz22IX/nuOoBtTc8WYWHF+voPndvWVfc0VeO/gQI54SPQgvowcWRKlC/D1Du7IjLaLtDcwQrqRIqL0owdDSRM89FJ1mAUwPpj9Zb1NcE4NhcGLFTMUFr+mJSRlQICg4cLXnDF9jjBo4Tl5E/VbsQJKe/wLccC4p7yGrcJWlzAu6KSBtg/GRHWqBKPTMbZUQ8cnsHqIRilat1UeqicZ3QqOZGP5838Xx7udZ3TuNXNuDmRV96xo4W/WyiwevwT3u2DIv8e1MAiDjU7oeXhEdD2T74tyihDAAmsdd4chqTSIGc1u6NkZkZHVIev4TVpvh3qWAi5feLY0bFCdOqcHvz/boGOk0hLO5Ks7YHNNjNPej9Q0jZlwUNBMt4XVvcqKjmvPN6hzWyTGSnU7HmtFwjkdwMroSi+wWmGIwSP7tGuFENBTAyn770oJsaIIbHxTsuboCoUwAcQmGFrQYX1X8+UOPkQw2zZp/Qr+7bcvVSdpAMHRCV8LEdmyzxIBAFhpYJsUytXnyCOwEWaypgTOQiBLLwJuTmdjApk2BMlQ6+P27GJ8s1/2MEa5icxtMJgnWMVq+oCTP7NV/F0lYTaKpRJ7teLa5pJEsPJhdTvTYnOD87v7Yoy7yN71WYWE/08ySGcUUHBmaNf0JfKyH/5MymaDRiWz3IGK4hkBn1J8vBwxdMPMyXa/px8eEevu8TMXRsoLwV2XGzCOgfPCXc3QUFwKzkHIAxBgkweW4+5gDlqn0H5O1ukAdBt8u++AD5cpSSYdx29rSTp6TNC6OBZPHFUr0cdEsbdKVzHWmgZUHfnn2SOkuP6wzNSE4ruzDjYVULJ8r82Yi2ySJgkXU9xt7YBsftfYfL9eI60+9HWa6gN2DS+9/xKUVq4G+aNRJtxfqRuOatEL4IHFcrIwnJCL7Gufrlky9T+vf+21x1Gyo3zqI4fMrjZT7L1dWZe8XD5KUmHOyuc79XAkZa8st/P3L6GG6HaXZ4lA/MswZRLFszD7EEv4i8A6pX1BUw5iTmy6lbPwf68O/Ri80//HG9nVmgJMNM47ZXpS+oKLQrvy8votc0GGtgxXoXyqc3whauDSNDNio/E+zFdUwG8zjfFg/CWJZGZ8tR0Uf1ngJNOo+kWFV73a+Pu8AfJUGQ611GUzaW9BbCIbxUCLJ8MKKViNalc4OLLJWtvSk2MdtCaYix35hl2o4m8BRGbej2Hjou2BZkIYxqlWjPrcPXSC1HkEY7HpTCQkw9GTEsYqV6zswU+EeZQwGcaTmldtrX0hcwjKuNWGBPxvoBfPoJkN32+NmA17oeJYBkMSew/qFasmtdfMvrOuyFhmS0NzpT4/LbxINLi6f0LSuabuGkzodhUxc1yzYQIB2HHcgkDpazutuHcEvzkbVhyBoH4+FJB8A1bulKFzDvWsWSsdm/GjqrQJFa975SeCnuxpMD5cPfogJ+ngfHC1GXzdqUw+et4eBVRptsbfJmSUypLYVtpmWZxWk3X8wZp/VuWTpgs4cS1HM7FtBp+iYMVHJ2iPAWbkc/X1BT1JOSNY6yrxeU++CzBvqDRD+j7cvhzN6tUwDbAzEj9++c7YwD1gktnoeUSpb3q/UycGExxfboOF06GxeCzGgX9ZA+vz2JFUAn2fj+p+MtBOVZ2pTywRE2WeksLTo7DvZQ9+T/RcxR5bJpJ2tAilSASYRDlH/+dUDs/eSL3JYM+MgSBM2zZDHA6nrlNm0wQk2QM7oKXkTIz8KVdoUhlJnTDTOl5yEbat9bK3+yQE//zq80aY+BXenFudVI6ivZGMATzYTd+o0afy4iI3ooTslQFG6az/MQEBhrxSjm4jhRlbkBGvtd1jaRhmA+5NijVb7lMFGiTtjtaJsRcnLYFUCQjEnutWjw9eaVS/z87PPH0es/tFpxH0N1zIcz6sDdtzgj2hjVSyaK3giD9AXhgE6LIlimVbGXoCKMAfenoF9oMM5E0R5nv4djp0ppPyLJtnbleUwLsJWuqs0MWt9ihrmENIHj9Lox4YSVzIiHPEj0wiJoprW9c9Ifn8hyy5O/IETe8h2McORxKK4wkXhZceTgHZAfXYJkDONvJywjBx4qLUuEY5IgTXoMaaqCazE6SHeU9wqFzX0r5+b1z3nQGvIqGvf5AdLHyDnW4b5XO19O19XW5LAs4A97qM2uGHvyN3T3gwMs3DvmVhkftsC5Zz4nKdAVSSi+LEhBk51yJeV1W8pryoU5SR4RWM7ICtT8MgSuKCD1ov2hPvbkaLLM22OzFAD0haPRTk/nf8bvT+CaffdkNCJr+yW7XTvcMmE8/sGV5dbSiHUve7cjIRXXGh3BiJMBwkN4lslU/Y2BH66UWQ1BnY+Fxlyv1etpnDT/QJgEMf1a4K3xks+tGhkNQuB7r2+s24D+yEUOjL9xr2BEjTLt2E7hEJrbmLEhBmhAWwbt6Pn5oDzYSIFSx4sZ7yIiyaONEIS+ln2LpyTH80tA/ScFBDVO3Qm6Yoy8T9n3jKHdl9B5PyZyZPa14LWRZLEK1wwpXXy4Kfzhn084tnIUJyka3XX6oEI8O3CstBvVZPkTktbgEUZDibo4FvpjMPSibzVEvvR+oaRu3hH2mn9RG08jt7/4Zs5Eie0ciL3yKB5XcCyxSiErOGlBKUununIf2nBcs58TfXFs5CgTapXV/mYO9y/bMaWxdY6p+GZwU7iNG8I+07jOLJF8WHdVrJmgiGnnZPywzA3mOWwgX9HdzNhZ5Uxpoq0bcph6yM7L2Q6/joYCLVArj/z3nE6vCFYb9Zy5x7MAIa+xyIPcPiVIEcpQ8BVCCa1M8Y/jxH/b/PgfwR718ZVcjPeyPhds3PuK+HCFbcvRDbne8URNpYHOKBcIGdMmN41ZdecQHgSVmb/lRg88JRRWZsjx8/qXPtKrAhE3tvvChT846Qz0jikoSRwboxLhFofBpTsppPOSBjyHLAOxwwU2lX+SGw+VuL1HawRXs6BEwYMZNN3Quf/WcDxGIMfy4mvW5OePg2/vF6A5XCSx55HsRBQI8IahmwXBj3zzkzOePHI+oFMFax1Zl0TyHm8tUyt8jZu6ntaXqEYTaV5MixdsKfGzhJFFCPPc6XxasRIcfVP2BspnCV9YtTVjbpNWJVIvA4VRPlW634FL5AgxI2CuoSXpl+9vtdxLvSmQEUvpjbjZ4oRc2O2x0GRSXny+AVSAij/+KPtB8KteukfQG/0C7OlADoZ79tlyNP9CCfOQlqSEIOqHIL7ss2GbaeVu/vA7tg9KkmEbVdJEHIQDv1lsKZ8ajZ0dVbA8Qxv9xulTvrdbC1dOKpLll0IDnJ1e94ovLBZv5wF0ETRkgIj9A0ven5jAHmGmAkI86AysrZMA4jyyq8Ws91LRDhr/OkDtuM07BFZqHQhx3FaWLwFI3whaJOo1e+nef1Sj/WzXiZnH4OAUj0JeVquCIJY7nN1ihRWUGZjJWl0SyobvzPugyLnXxDQc+A1BCiSCqS5ZdCA5ydrmrLocJODKy54NmSiMGojomkJOX21+g6hR0WfBKc9fCA+cPF5Y3CZ5fCoyyOJxcbidLOeQErcqELxxR2ztkJSkWu1OAshcytXreTpThKOShFDBpoG0XdCGkKxU8yEmlXi3yV13VwsPNZHzdeQbWmRRwqKqL+4ZIm40zElct3aHOzJZmdMHEyychEEIzbvYjoTvuFWVoUdKGz0OH21PtDioaK/Y3R8mctX48O7m1VsfzBbvijOBqijOCi5vYlanHR3kTQ1Q+XKVVwff2JOcNZ60hCcECpqtk8eXLo0vO1fnRHd6EpFNgRqh6zolElS/Al9p8MQG4Ota1YnKK5ReyLo6Y6knFBFaHMSnLTUppuffaWiuKNfQW+YnVJGewe/PTnst4kGlxdP6VImhSMfzX8Lnco6JoJtF1x9OiQV4QXM2sKhODcuXDML9R4OAfSGULVKtFjce4G0o3rIjIPMYUtLOwzDdl1E8Cx15jTfB1YHDVKSweOpjf2+/2k4UiWRBZ/hWN/Xn2loriTreXMv4NWuTz2ZOulECdRWClvq0ar+vz0JM6Ncgwu+JBSF/rmlUNGIf55qT4bGwYYv/ljW+6YwzeR9srsrq+UfikwsFlaBZVreffgiNp6gTuaKdHBbfQmgi/Ro7jccDrmFycyrP2qqm1qNKi1QkLo4mAqwjVmxy2UYjus1VRLvjQaycWfnb5ZWmgH59Hu7bi4gCd8pqtdJOzbOzJ8jK70RXKD6wP/nTHX0EmrE9LDvs0l1itpGz6WTj7Vec35Dr27/XfnwiXuJFYEjCdsleuqronQ69ehjr14k7vwXw88CCnHM4Dk8exN3YcONZUZ7rTNM+LbFNVFeyQHsuB5hMCV+b9BwFS11UXdvALaq16HiWVZJ3wBkgv8ov5ywP55TzXWFH0xlTWtQ9yNKn/vLEZPHFyg1Bf6zY5yYlwtFPX2mgyxEmoqQPvvl/vWpioW4HIjp9+palWvIYDeVBesu3WvpCf6eZLv78RvUZDvpFFyNFaYoHIj7eCXcfyd2Wxc/EpG6SokYKRF9wjsgiynF3uaZo6IeRFIkGJsY0sRpkCuF934IC+cHa8VevYeuV+oFeMVJpRDXTUE3DYRueVsCr8/iwXbgWkLWNWIT3UrLLEVuDAwKhFhMUId4IqbX9HloCDoi7LjCsi0xDRrFb8aWSS3PrlGEYC1Fcpe9xbHrLIOHyNWANUfjObykzwArHjSsdVJkw9kZjLWKt5/epYCLl94z4SSo764pdfFb1FsQJZVLji6G+l/mBw6lq6HU6V0WnTOODiSDC9EJcesIk7s0c7pjvlPEEVFJUmKZNwNxcJjuX6Fe7RwAWVN1wnAInzifG4zViCLI3bQT2GXoQYAu11RVpCJHraDxTtNrP6FlziXSs/3U88B/ZDwJ+KyuuZd+5nvpBbDi0WxKz/BFLUK1LqIVPh7uGi6REfp7xvGEo9WXc8vc9EM7F4WLRWVQkT/uEDLWI07ugDkdYHoBEGLrQxpQ7CMOILRNcChrErOAONwsnQnXpZLyNlChGvdT8q3XTtAhrCTiKDIhXCb8qJjaXu0rLJbaLT1vXozYKtODXxNP0F2Pqia+7SD2ZcjpUa4/XjdVbtrFp7XbWZc0/KEZtjumEnbUv25bwPhXYV9ejcoFbfTya4jP8ZVlhA9uL4nkuJocuJ+D+gf1pv0qphWleGO8NAU7cQuSPx0KeiU7kxLfrtKz/dTzvzMyZTY5kk+RzeZ9HuK8pnVW9nIJm9/mQHmF6okUWe8gRSXFu7odLz8YENyr00EhqqF8q/4PS2zcRarsKEZYFVE13XbWQV/h+3GNFNH1eE8ifIO7O27/OdBSJRKaLQ2/e4tPDIJ0dI8WLs96ClTCj9yNf32gGfadc+RvZEqMXThxZWFVL52eSI5kEvxeCnSygp1vopXa58SnLEJ/9fidUaIQ1vyJfmmi9CR8xhQiaz2hfdlmwzacr6+Kia27SisDPkEYj4L8Ni6X4YleFV0VNX2I7zLCqvg3Cg5kjbSnxZMlDqfA5DT+B5MLA9Xby+QuUOyoI8yMv8rUrPDp4lYRs+6UoZ+busQEd1iObjNRDYoY3XuRfR+N/qHgl4gloAaREKLUk8QuCrtEJW2kgY5x3qk8O5Saz1DdotE3IwD28u/gO5SYfiLMBjXWVIbWf+NvopcQEKrsJ7NpirQyCmtOEp/YjRDNPEtcafS1YDhWhAylcONMKt6n8uT7ByUWxXq+QUFsXTVhvnAKvE3BazGkJhLbp5CxQkigHJ8zL0BkZ8GKKKA1CNapCSar+p0O/SZWhzi77p0RDk/3iKc0EZzF0wkadNm2/AOOoltmrplhHE3UAXlduyY3nRdm5oW+eyt2VPvZwxdWRM4k6j47cg1tVPPr+LGaePo//kENbDxJ4Z/LH1XFtrkO92KU6IxGL3Opn34mK84YtLkQPycalXAcnrGVtjX1q/vjjwX+N9vKh1SXN6ixwqEOYo5Ucupgt224FGPzHZAC+EI8d2qPNRePr5FteIoc2m82ucbJz5eTGBcKaH7QER35E93vJhLJp4TkNOTax0HPd0QQOPfLs8PLZCQuDNlTbRlOfsa/AMmbcQJRgD8x84bMNnkOGYeG+epQuSgtWIAmHhaI7iKUtbx2fXfHBPXJUt8N0qw56xfVP7t5H13Brep8dBLAHfkTXOMWv8e1ZsCgbTjdAHolLJfC8RkBn0m39gXv3FY4aqCazEtYyz+tsreYdAs707CtHJgz84TYKXiYsstFCQBqHbLkQ4SnAs8cmeq6Ec1PY8l6VWTjLinwdHjIue6S1J8oirQcHnBRszTOJWvMAmXsH93oVu3BocgPKbl5cMHLNZrh4ONejNJRkBZGPpkO2Q2jzGcQ8tJkWqN/gXK0d+bZv1wos3gXW/pVhdlOjaLtf/FBDokDNuIIctkvl/TJIWF2xrygR4N1PGT+azdlDmVqdGcF/H1ndo3gPK2rQAf+CvxbN2fgnwJkPGNYXJCEZnseS8hTBGrN2BdPQOjVWrYm7z99LoZdsdUToRwarSFUEsX6D6+SV6ukmAD0hWPF6dsI0segquS1z/h8V5jwQRgIHUq9qu7uT11eVVFj+psKjCpV9BSIb/d9g72zk40sUVJDkaDI/VeHYcAHZk4ngToO+Q1J87ct9cV0QqqNRQylX0qFpe5z4f8rzGJzVsEXwClxYB161KOoT/DNpE9BjTt6Y+ShqTMfq9IyGoBTX87MxmAcQp+FN/7kX8KXPn3Cl0XiNi72flh1M9KXJL3WGFY/n/t4Qb4uyvmAcCReGnUlAunW83lf5aPWOQickm9dmu1G5u0ZLn0++TkA9C7dI7TCoqeCWWMp3UiOVw8dTrJnOv29sQDJnhisiC74wcRyIy1GTaSx/L4GHP0gBTujUjRJ/kE6qglNeFWlu6MfbpfPpmoJgphAuBy2Ebg38Z/4kQUmFIEhDFSOv+8HwGDS3bOqdcrDC41qIbrODP/eD9dzWpEd8ERa4K0zY/5uURctqg97aByIGWbk8LPcz2+XWXVa9kgua6BZvUVRS5JkcqNyoNxrixTRV2mSkcpZ+TYOiMH609xyQzCfd25L2fxYpZ+pVM9CWXdBha7/hnqh/TgS8kCGazuyORhJSU9I2NlAmzNCj6cojJFMrjib0zOKgtx0ifvSarWkhXey/sMvq40DhbLAJ3LjKC+4MyekAuFJL58Rn6YjGOEairP1PXiOgrPNz4dhAiwV89XPXGEBbz4BelH8sCfjF94K/W+PBAnOpxhwXqJP9VssUPdXDInCUcWDvk6okh1mtuhvUfGtonBk979SQUHywdxKUV1mO/lyVPUMVkNG44LGDAWbXxLe9QMi/xO7zGPFOMr6KD5U+mBvMmhwcO1FNGLbCfxZJQzLFbuaktX0aeXtUymOI43qs1Qo+0hXI9lvPcbGNqBTUdCeWPzpjXdMRVKIlyNAECH+kxkhugnyByWhqp8FIlrJq07z+rJJDyEt8ADffeAfBWRhCQx2jTGmIRdJb8DcK2oEl/Ur7tBXj5oEMyr5nc0Ms7N0z9IBO6Iu0QZo9XUcQnsGOp88iClCvUJzpO1VFaWKz7bQvNoY0HGM4JJ8YBQ2KPd2UJagvNcBVDBE7gGVqNtj0Tek6KfTSMpBt7SlQ/NqTlddif/AMLzgxIqL0owdDSRM9d5+8PUOzsqDyo0TGG2gENixY39yFhqB7gC/PbYhf+e46gG0B9r+9buOWRqNT12lsz1F/n8GO2rfEy3bQyFYdJqdy5k4KHAcp+ujPskPpNeB0iMGWLgzunjk9WTp6tJPGi40GwCiMKyieZkEqZHRoOt1NL+yqZSNrnJLgNsmgwkpufumZDJfBvdsNjy8/idQd/o1j75cSguCkKx9xF7s4vMGIrn71lb8SipI7qtdx0Ct30i5VNW7EQgjJfipVM3cQvl38683TbtlriJtk2PTm9EmzjM1PkYybeu0o+2lSb+p9KToLZaHaqjXxYhNN0F0jYDhN9wrUUF1KjQtSTxt4wt5BN8CfkxTXhHnwk/g15w4fON5iCg/1Q+mkFcBp8D/KmdSkGNg29AXxKMzsJXvFLfnnFqzBA+RmI1d/Ph7n7z3lKLwXX6gwabY6QOvvOa4AH//LDKBaTVpb274df0GR5i7zh/xN5m1/e0VXSV0xma8xvWhYVNlDDy0TZQgIX1UMfokYR8av0HqvEdzF9txGT+8OLNCaX/XYTVH8wnSl4Dha4aZ9NlrUxvXoB7sgoEFsXcc/n5gfZEYfJLmuQI2UvuUQGidIuBhFb941KbfZwabb8luAktPZGOmYiPNz3FoqxqbRgPtFIEhoDtUz9zNlljSUdKZgtrQp8M204IqDMiz0OtFlsAzQGBWeRHlEX+mbaxE/eV6WIKLpBxbBAbYpxdYYCcoRd+QYxCcWfTN2Z1Lnkj2nkcpzsapldJCXy1aL0Uer7diUHQy2HSKnRYXKIlFkxdnsy3NoHBj3VjJpGti5WqB99ZGkffLBf4vNX7q5vC+F1g+4YPsf/OXipsDmQdXttoaWnKrdW/1eAnIZ6gETNEKcoEKmvVaEBXBqwWeWDI9M/SRwdF3inzmbsecZ0w9ccqGTl+hPPlp45Z1Xp3tlVvZeJ+KZXbcHzSzljVCGiIiDuLxp38pdUzKhfgJ8Z/LYswm/qG+pA/1sIABTbyoq1Tp8ITcHiB3Bc34tUPUomxVDy8clXHsqPEERah9XNqKpMUwdSq6vg50BKQ4t11yZRWzN9y4lBcBXdHHAALmx1VoFTUtGduoFbk7MjwA6rOMihafO3YKi4094yDRRf9E0+FYEL5N5j8bVoVSIQ34JMnTwJz0GsD2pgHVMPmStmlIrYQU0GtIJkrsAgcLYyDGkBh67ZoDI4bSRlm6n6NF4NoyTMjClGCEm5lB5QFUrKVadkH27NnK4Jw80Wgq7IRy2fz1LDRxTT0AGtHpI4FP9KBajqY8eNO0f/es759hIgx+6BbylARtgIX6N0HFo/+rlD2i6uFFK7fhXIbIuxOpX27Vjj/fHYXEa9JSEs64UvghE7KIznTL9R/SgWo6mNisiV01wBUi7wM7Afz/yc0l0YyudRDlq2Xc48taKA4PsuK0dBisPfNAfFrRWTGRLR0Nr2GvaPbOj07NH6AUa+gt8xNCjjdlMtZJK/7t+Ioz9gH07DiEGyn2XjZLANMvNKjefdVrxnWoGPrnQud9awJkAGYbmu9PWiNANhwL1qPFPhe6NrQzlV/c1elxzMpSF2GpG0XKYM6RKItrGTxslNNxZdWEfVEfVEkHTCGMUibOswcUp2PZCC9Cuau4mQN3L+lMC7j44KMf0tX+Xsn06WOruPp9lEBCFMq06lWhw0s77QqLaoqYnKxEMgBJ5MtX2sbgi+ui7pHdLqO36tvvUf7kD6dd6mNvKEuFB0iQbkyL/OVqhYrG+y7X59d9s3mzKPKMuHjj+FxQ1S4/goEYDKeSzihwJXQjeY46C5MdBPbYGU0Lj0o8r3TTSRbY/d1VBol1drH7TcPCfiK0fO2nLvvQzAK89wJwTNr3MNqRucndomTjZPg9tyrYOJC4uGYzbmlFiE9mZcyoX1pNiEwQLSUIQKLPvAeWiEYe3F8vmx2Sg2m77AKcKhJqeNwWKwDp5ydSCLEluNpWyMFrf3cmlmYHbKu3eVOniFW/6ZnOf2+JoV1uRtgRUMb/5AFB3Criudr6p2CADaS87V9fV0nAT/aRqf9DeFL399HUDMexDkojKQHm4bvQ6Kb/Gzxifp4wkVt/lb+fPtIREd/ikJmYXciG/pCDgRPCla204lQXiII65LLtJ5TUwWfk4UH7PPYX7wIknsyls8ZsuLMaYn3L3+5EwzJAWbpn+y3XqgLmeO++EdS2KQEUkXuL6XQiug4nuA1X5SsqfpgfPhj/xaZPmRr7q7IGdDhhcA5DgTuxZGsrBz37YxZkxN1bIrLfCjGl/q4R3KcdLYI7ey2Stf2EDmE73neAsNhgrzwCc2J0n/cgfzMjSvcQ2kyfgK1FhA/ZXWGcP5P4AB0oFqxIqOCn8g3h20wKsFShqqZRBbAMQLo27wZrgLTdxzxuEJBFHJM4hclxCFleKoc/fil1o7p6HpSu1oYLhnn/Dkwp3hSDtaGCkP6KkT35lH7ykaIZ1INZXkJnhxp8A41Udk3UTDZzV+7gnZpiMVpWiYxCLop9aRgtb+77LDap2TXWDdbjGzMXXMoUW37hnr47+HOqgGYtgw8Ut3KTEfxT03Lch6mlAbSfsnbn/gbWPRHdgcYvoXDXl4Khekfv59xlhWioBDRiuLHJa/nWhZKbUmrjCReFW82sow2Cd1K85SdWGiHWo/n4N8RGNjBGP7jLVxVSuLqcaydaiLimxAzjAgYQAAAAqZalf/fZvJbxsxpTe1dQDROAQT2gbneiQXGVbnVzd3CCMFDJv6dfh7VxVZDuGs5lUBNwhbCU6axNpObPVD8jaV8WY3HckIZwabc/zn2fKpR3J7zrC7QdjYhGv47tVAXJMbdpN6NoGlL4f10zjR8Fa4Drb3HfjA2cbI/l3I+U3kwa6xKoM+wJQ/E14vcmfgaoLs1cwfp+pBIt0lbt2epZwq98gktkZqMApAYj7r2IPz+mRUWfsjVkMMdSSvvSdPMdq313jm3Icou5D2R5IcnivI4hlTVzS5n75EszJE2Pff27AawtMhaTe2BhleJXvxi3czvnpG6sIx0++aF6+BVpDt28zlYzXeRx6lnCr3yCZwbhQeckz60TjX8fz+iC+fWvt/WvqWhtngwxw7fJ0GxvETylTViDIPGGnSYp9N6/yUcRZgDUifqRPACjelDXgZTrLCReeQ35nnC96Zdy7HLye+Z8OT3Td8f0pvSyY/Yf0IZvFq7wT6pjygWPskDpYZVDE9Ob/U499HjesWKCXs/FO9BSsZfqMdRZUWXbvNnwKL2lsLZ27EWzDlh7vnPsUZCALMqC5FRSi+TTsZ+AIJ652ugk7/IjLbBRqjSUCkpyGhlTT7dTWHUaHICvYVr00HNGm9ROswjl7DFYG1VU9362FknhZPQka88URqxT5DPFpdb3njJAZixx2wIa7HdT0VBzvWEdPAdnliB+uJCVwKJeWxVOW76KsCWWPppode8pz2BuWfvX8nsY4q6c+GYrHAXMmXa37EiVxIW/U0d/MtWudI8l5AfQmqIk1ltuK0WdSZLKn2HaqjlyVlc5C67sfBisBD6S7H8nENP7Mi/wyLbagLd0HwjMIuBp7dU5XRFWiEMQMzDEf63vXadS5QBbElnkM8E1ynJSyuL+mQJ4OSY/Sr1k5nhi9JiYq4xQ1LRRCtBzZbqyHFsK0gRSFcDdlTPcGSZGwN1QvBbHeJeAJ1gSnvIisurWfs421CAS2uxIld2sbvaCGT8Q/K3DoTVt41Hs0ez+MF1qwAAAAFlyQIpr+w3srqHB8tjGsUvDYx2EisR61rug1cqOY61nvDaiE0NsNy8+UyBDoZPkSnYet+B16HSStRIzoi19+RJx2Xj2OgW2BLuh6N8KusbhyzoW09cAKlnjaag7E+xz43JN4OcmIzRutwbmt1De2FjawYgNDK3gwsDKoPqmlXLdSLESkdTxTROclwcou6U2jOzHa5q7oGbhUalpie5Yy1ZXVvifaTSfk15/9CxnUC+C/DH12w0YlWTBq0L/G71zElk9lRQzRhrpdkhCp/m+BCiN9rPc0KCLBzQbeqztXYiV08OMB/oyr2tPMOGDicGwUTGSVFuGPhqhZuFI1zErodG00mvOF7DuUzYRnYRrPnJSwJhXaDVJllUguhs32YocwiPmKNuYXrzQZFEF8HarRpihiEH4HWa9T+JujXs1TiFaSEBLC3dPIib4ENYPu1diMyb2g8rVsssf//XZUcu6dN7Sw8tC7o/y41neJUDyVmLYhCBj+HyISu9rnZoj6bFe4e5/0dgTLdv4wVV7VkgX0H5gujjUaf8icWmKMqEoKVe96TLCpFqAn3bl8Kp/vRJrvfLt8Wuolh8wklGF3LvqTnfcEnLeHnThx+jzteUXCLtBFSEEV7z8FgqKmUTb7LUKkxd1FxDPpnGjiEVu5n3DDiQ5jp4xOInZ0O2St4ojtuBRcljAMMQfqb7FHCvzPx66je9fJ3o2mJQYKo4N6FIFvG450TqSQ5cWIjnT14AHUE08inpHm77cGTd/fkALP7qJPceqef85GIe889Q3aYYp/DpDgEa0vBxiorvcuBPa4ljSMAiq3hbefmsD3OOgnlmxd0Vg5jZCLGpJkdrwPZwNYaqwjbMYC0b1Z+IZwBmb6RPF+9ALswAZjAsFnvojLRuF3R6OD7f0AuXBcDZAOSZdqebd1gAamH8YYGaEBolT8ndPKG0YZH2KKJBaYXufVxlK/XS0H2rBTGTL7MYRdPsvxkTpjB1y5R+6y45ta8kwZyHQf1KOUWJ3ev06OzbQdn7Bi00DoKFscdJNbgDLy3Sd8vjF2cQdA+2911W+DGbGVb5SfLxPjs78jAmwW/ro15WSRt63ALPFqulJCNOzqqD8ZrDx0xRmOPdk9wiG5s0ZpR9QZlWaR7RxnawPV4j5+tAdSW3YZx8JPkXIYH+yFveS0HrLvNQZ8Fsrwoa8V4kTgwK6UEePE0B5Mie2uNTYkRHcDpqGqa7eJcHa1uQRY1qAfogpxdyM0kUS9QxChaXh19MpUGZDDzo305meI0/70afEiSl26IxykobsOWWXq5ywNYyO0Pud+0oCQJ6Y0Cpl+KXURbPcMuIneKVo34YK4Ldsa7rDKxrGr6yPWf/l7is47pfjI1EMWMPokc6zK4pYi5pJsBj6Gay1Jqe1WcD6nEuJbK0sBskLew2jd6+ptUKM5Bi5XgSXkjsO9gGh7jJ2e4q1kS40aKj0cu9I/fyGtt8PAh1jgCRKig2BoE0Gv8a85Y3ixRqrLJKbm9npyys3PJTp5GQ0dy/U0tGJrx9f55JtERSOhihzCP5QTuD5vrwViSOUfNirCMpbMlPfb0Uv6c3HlD1WZXNbheaaC8wAEjSFuFWi7nLbx10eU4ktu04wQSgk1AjFWxJZCA3DmP3L7lYKD43qjiJuAzd+hsb769Iq/dCET/2AX4HMzyTM7Kxmu8ru4JkOJvBsrG+vF6X1m516NiwXLfE5tx90U3EzTFzWydXeQMfOVVQPXH5l6/sNy2seaynI1K+S4eY6RmI5jebfewBd58G1TY5TfrTx4/33BcvzVfcqkDRggDcwx/xm+Xf60GE61vOzQ01BAavWE6WICQ07DPCzJcDqSrQWaAg3j+Q+LQw3+ctPk/MJO6PniRkaRdV/qDuFxoBtWH0iPZvdrFGaIV1AJkoaVuTmnrafYPr4vTiMaIYS8J6DWEjRQ7MujZ4eBIeczCrR+2NoOzWneuDxJJq+wM6x058S0wag7WCsyfgEtpkRxLikVLbAumjhrrDuD+QSspexyqrwvBcBtZ15vWCIyjyUHzokQp6Ox+w/oQzeA+k6Dx97B2j0a/qNlOIf5PDzbe/uB/R5hxB8/oBQm1oW4ob8hqApUSFdTvvbdQcxSL6btS/bQHkrv96dh/DPZB1C87WD/IbZl4cstumj7d3DRccQGB/nMwq0ftjfbyx0cv6q2w0xW/miyuGdD0PzWzF+TDsqQbkXsKuSfZcK6eiHszDerQALajhWzcjZJp3O0IXJ+2PeeyUS8muMyL/RuPC/wWBHcISVLYxwzu0vcQxUd6i987e+/nBQAT2fwvN0q41RSvb+cD5+QF41wGm6P8OjkZiAYVhptUuwMlXVAggKtedRn3ea873HLBqp7LLBngoxLL656Cem7zk1gCxf6ZF0U3CJrfwiYmYUG/eAfLiTBoFBpVhhFuSS1hhsp6tLO5suT1oajTvwhm0ceKXeXrOAfI1AaEaXW2+MHoPmKSMOCQPep3nhe+3btOt8jzGUCGF5XQhoQrgRtOVapJqeLtzPcEFj8j0sDHWRi2OX78khDDAfgxRk8TtXheTwM8bJiGxFgjwJ0Uv6t2WLcQWP28AY+hwJ6qJJ6zNVQqkLkPp7JJzb0STZ4LyxDIKFgcmlSIlEe3leKcmBimvUlkJwOKLx9kbCboJ0njj4E95DAxUAWKZo0R44ZcBAhJ5rEJlkKVYsFzXeI5gNGwV8EfG6nkrR3HAhvlcALW1n3KJOMj0corzKq8oOfzLS0Yue7BWgoDdrp9FxOsWhUo1Imv59O0D4jMXiOYYK6j5OcX786hW6N5wpwG7XO2rbizNkaw5muZEEkxnLSi7xXWKMFl3VX6Wj5OQLJK1beqKd9OTz30ZA1Pm9cod1e/nqc7o4zW1xOt/yztuiEEjZNto0FB11fcn0g2DC4FebHCdCic1yCu6f89+ZIPlYuCU0PXPy5NLKVVqNG3soTg3BCBK9NCHNOs1sCyX863jt4uM0aHqwg32qMnsf60IeqWtvEjH8d9cwN41HgCPK85s7+5KOC7hSSy7z5Orr/7YWjO4FJVPWIHBGYWhsxVFZ+nEEqYNq0OF3K63PxfTMZCL7Fuw1O64rRB8Wcf3RA0YTWNk+tIfb3b1Hk86uzHPjHLDQF5+P31PrP0cvsdit3+vidx2yUF8ZjiprqcLw8Ma5ZSjTC+rEym1Y7uzVSO/6Ou7ZfSQA+1eizryYusZzbEEntb9ZE59NzS7fxFuj3LFhrbv5KWWcA6/PsSGwIiksyX4wdXpULh7TTJeXAtHjnq+wP2S5akrJ75nK5Xo3FG3wDsEfKkhWxkXtXHSg6Cxd9wvK6gCNYSwa20GTMPyo95+2rVIJeXWgKbTsrgskljKpg9t/H00dewvicNUFRwUzQe3pb2KTjYBkRTpzSYLNFTki8aVFVujSbLKZFjGB2JrGnECxdce6UtQNiIxGb1FTTYGKeq82827kTDKuNPL6VxaOZVKJC4Fy7cA1YTlBsrPMcafw8h8gGwLJGOIotoZYofeq+1I9RC50Ig2LIlPgDv5MlG/CwpWh9jSZlVXoQSIY9ZfhbZ8Q4lw4g/5MGJaP++K9CUBUam0G83z46GCehOj09ukeGRSZnMyK15kx4ta6NEVxfn1yNVMJRDmLS+Q6PFcHeQRasm45eQo7loraUpcGl9dalm4eiABVZJI1ADenHKVp19tdBtx/4t7fOaJlR9s+o/HSgdRp11zzrkunZBhB5/nfw55or1GlMyLF1K8opwN/WapifmTNzE6DKoRodi5YrFR8w7t+xjrhxXzXO+TQIPqyErxZE3fifGre5jNDbWa9y11XDWGQ5Z2GwaFXz0JX0hDQOe7N56eWZIhYG4v58o3l2UJERNY/w+mX17bXLBKT0IGOitlQSSDKvbdFrGhbGMZ9thqmT5hqyRDzQgb2Guc2G6lHBjp57x7D1IXwtjkLFewVYKnZd/0iP0rvAYCsXnVZtYO8RqzHjfeuZi67WY7tPEvfmbmUXUVO0mFcvwUbWyPEO+jvwpkBjJcOfyOQex12iJwz3atMRbooeuz+lduXLgwScT6Ybz03DvV0iYzjXc1oVNJgCHiomhNaWyeQqaecj3NXEJS20Tku9LXClm97RV+Ilo/74Z7RhjtqupSen19YmMdmZuRwQVrOnkTzGiRD6cd7OdmBzfHYBDEFBVRTYJD3S3WvO8TDp8SjYEo8tP1rJF3eOqvA0Eo8tP1srLwqMyvi4Ltk05XofVchWtgVYgcrGbl7DQLIYI6KoBA038dx4w0yPFNG+M62ovg45oaPLXkXQSsWEGLa8ndEGiMmyqKi8Fp3RnKZqpkG1rZdG2Re8DAV3Ec0kJZe/pU3gK7bx0PK0On65SK66AjrhuYDig3FzXazLiDoQucOmIwo6DRWThF3Ug2eb5LSjnGtJqnc5ehbQgN7WN7ZUUhuldrkDYl5wIbdz9wzU3xGvgXGMm59+1e5eVDs27Az8JeOCtzt23y/Cnfj312NsX04pz9MWLrQaMkD6+E0O3DwinE8sm754Xo6+HlB1D+xmIeE6E1jxkKp9FZJNl9XqJnfiBnwJpXTNwTXR1wRlxMpR3f4xO6r4VMM3QBleB10l/PKykJ5SHSk7KFAFwDT0Y2wkutM8rHo1W9MdTzdBjcvmslN/+NEF/tGsVK9ftlMzGrlHg0FVqru/e+n+DQnonRKYgl+UKN/toX8wnMVBdF2+IL31VOiJrZNSZs89xgBNrnbUfeav6P08/4Kn1DOFCbGq8B+xzDyOBrvllGeE8OBUihu8NUcvUcUdzzR0NnDUUMLobbsyE2FHyauYq1a9NaQ/K7dfalXlXZAnUZHLFltx4ZSzYae3Kn40WGkjLPr5zwd2YIGpFjVcpokpBeTWfn4AZFiTbyXRxWzsUSsAq41e89ZoXspuuuU8yoEFyWtGZTp6XnSOAC2i+FHBmzQ8KrYc9xdQKGdg6W3B6VFGmPZpf7+/O6XzI18YCMRs1vRg8G+eG7u48wiQxKWCbRuTWMUaZmyuz4CnE70eaRWx6fHiRCRO86kM9K9Dc7esFrFXc0eX1RuB6L3keYm2GqITOe1Me192XJk6++ravMzPObHadUHStLi+Uk7S7YTwaaIYelRRpZvLs4n7p9SzTRPlhi38oLAHbZTD86lpxoHcFwYeBWRgQNDFEJXq134gf4bu3iPFblV+4ic2tR0OhOLn9/n8v7HZxU+d59c71bIH569J2LmmoAB6VsbFgoWF/29kiST4E/MyrnsQk7x8ozUYxunorl6wl+FTKDAp+qk4znVY/K0UuSxl3U1MwuGiG9IGByLv0FIEtRSxfCZSvu4nrrJTx5XZAs5tdSQAwZHB7GKnjPoAbgOHx/q8G4onTKnfVeNDrK4ijuaMuu5QProxoAx16FjSE28VU0GpKdhHeLKKnkK3BOqWhUkbErTL4bmTw8r23nCWmYrxuvg+r4jvK67LsQs5aFT+W9zMZGcI48BUc034WEU1l8cc2E0LyESkJpITN+s4xL8Qf0DBfsiPgoAq+YyJND3qO62sTnWlIQIZ/QknzNfXUh0E8zUc6LADRQ1NwNXhMTSQcJ4hcLh4y9uyWUHJbXvcXSoJoihl6og39i2sBSmfWlQ69bqwkdFqFDx8nTlaDRbE55XtKS6adaq9TsLe4qjpfBadg1U5iH6LAH3FkFcVwACFl3yS7hikdIFBfGqUoh/60ibrIesHgR30MTa9KptcMAYNE+eiZ9wI9wyCWBqrwF9hm5cGL0sjud23U0bQdEA9VtZ7sBxqH3FeLhVM53KUa3FPyyhadoVbPKTDjQ1EbIqSBHnN1/TYjZrJ3CeTuu+GP7nVvvwz7l6fz318j2AFqo1/yTpjGgX3nP14A2v1SR2LQwF1S6W6+SprEzgz+Ow499UbpC/83X9NiVt0Tg9sdAkCz37FiWYz6/NbMcLzpU3Uue0S6Aww/WqEiu1p1ppcO7toP+SmlShT+1QC59YV4Vb27/pvAn+akAnkk6Mtf4Q2wKHIZp18wcJR/U7V80cuqYqKHvIvdFiEXfGVAqwUsDz6usrXeMuZDI2hQvuhWTA+tCt7nC0bPlJDTYC99LGlDOvVLcBlhQxY5OuHFe8zIK6Rgayi4NB+DoAjZ+nEEqYNq0OF3QZpZOo0pmRZA9exCdd/a+uwnWNC2MYz7apFYpzAsa5vPSGWKH3qvtSPUQudCINQvgGHCeXh402FUZweNib523RYdisSPdlLPYMJaHqTggJ/T01O1a7MphYisRv0zTUZK9PMo3Su3LlwYJT7eM5EhW6P2kfulQ167ZNx6GrvkOF/SEMq15tKrghSe38jydaUpdpqdxwb4+YrC/aVJ2EdHYfhZpUN/rNNR8CLxgJS8cqaJwAxqJ9WJ0uPVsdAEF8MjBfmQRut8QR3u5uv6bEmreTlNaTzagsJ/CgXwt4OyUyGa/5NZYXq6pWg6ptv9jm2mPQiJWt9kW61+SKjpAIr9XkQVKtl7hrq7aOEn5F6ETD3BobyqWAmCNxOSjkl8bAPGdONEvQq/C3RQ6RTZEg1zKLKJCruO/GUT9wfv/kg8V/do8PbcCg36oCqJf6L+zhzf/euohHZH71oTzYT/iCyJEFGq1fw/bv3BIWMdRZQjvRSmNRmllk1lcsgOTFKzIMISEhF/6REeR+odFEhNNw+og8q2Rn4wKna1HQDbwD+cKiQK7iE+oS2SjfhYUrQ+PcK7jH+UV9OldXrJPV55AARef0vHo2emwJbAgpOojnqrgYhb+Qo+yMhDv2GE0GJNQoQOTUY2SgH08ovhKuQ3vnI8CkVqPWG2uUJzrWUE9q5Wb43/J8xh5oEtHpbQXFkTd+J8dJIivU8fhYUrQ2rR20RPWlFLXERnaxzJXg+J9d0up/WGSG1Hm05fE+/NdeoJUD1SX6xngCeaeIRSqP1Fpdm88hPVIYki2LOS5e6mI59Ij9K6kvrgra7IX2EaJ8ODqlOXh/5h1/bHWbOg+VZ4GLYQ3SKFcLpcYyF5EwQZxmrwsKVpWV0XAOUcJohCcwPoARjJnXJjHreEFJkKCVoGmEsBwLY+e1wNgSxg0NIUWtcOB2CwGyVaTsY9cPr3NjexWCoNsskYNPR9/VwYWx1kmNfsFSl1ERC9xddsHVc94V0Y8o0cWRGpuCHIZK/DdQ9RaxaokqLbd0IKGzTCnQoNxD7D29wuiQYwW3ZFmmCdLAZLV7EwgDixc0P1iWL8GV6oA2x4+zAQBl7tnKt5aiOGZAH+izYzo5Qv4AgUF0CNpW68hYBgx8R4I1PBqZfFuQJSC+Q9vqXF6OHcdPHi0iSgTtoHc0rt+Ay7m5X0BVIObn4VpwY8X3hZojcGakTCJe9ZF4yEnYMFNLuFcN3u7Fzjnc/pqgjNuko/AJoerx/b6U+S3iQLPCiaKECSqzibvrBb/+ecnrOdgSBUcLczgyHHR1fTLJ1xpQyFR+rTF3DdfjMQbiOUP71Ist3dSHOlhNEt7jyzcZNSqdSptcJqljgFF9IbcZNQ3QwCeFoSi9jkKmuOF8yeMor/RSURcKiJlQ0LSCvvUh02fV2gKbAA+BAkxBF1PeQnQCKUGDeK/GrZrIalGNkOEbARU7w1tXGM00ntLrXHjwzl7tzx7RRMYCppBTInQpON603zpacAWktf8QPESzVg7cE4l6VTGvmahpHEkAPuQFlUD73eWvIcsoPCaizwdm94ys7BumrMaQK3bRwOzPQc5NNEk5aq8OdmHtONl2PsbBrPrnwi/8XJLHOT+wm4GHf4SBCEwSuLF4Pz7ItvR+9LeAFQ6KbvhhpSBU0zvaWKlp5+D+SI2QssmG0WEKc0h/U/l7L3YswmxI4tMXY51XHs24dImDubw7arS7ARMNGdEwxIjEXA1GooSGobXh2ZCGqyduTEWYYDs3IlNRecfViwMInLFHIXmnFFwk4nqy8ym1L0HMQzfu8rLsJigXXeQxO67tdTZEecknRoxFXCxM04rPF+lIo/185AbzKZYmk4gazyCpstsO9yklaAjMMg21OyaApjHNDj5SgbnhiNq4DWhrOJCETAisnekdl8BHHdJh4ht9IKD+2iiyBaCAbfuKcD7Avsuai5PE/kdNSjIv1PcCJ1CH39vPoyvEpTZfIGNNK2qj6qyQAVZIhbY2gSBCEwStMtU0yPYBs5Fu4doBJoVPN/Q668rjpzfKvu6Gi+/+SZZmon8tPoz4IMEZLmSu7voAcfpxY5lkT+zxrvL4YHKLzDSb8FTDP/WKRZUDAT+jSb/WVaVj/8kRLOSdfxxWsY2m7AjruWpsJVvwcsmQfjWUPyzAi4L26pyOkI3vjCPOV1G775+V8CZDMBp3N38TU/aCPEd1bGxWmvth34LEnGiVbOCtsOGC5sqqZZiBkaTe2OFCfUmEYLvXFh6tgIK4GUAUCyE+wBmMlmmIKoQ0sxJ9LsNtr7PdLvQvjmeRViw3PwYO6bF2QnbdoKjm6XAEhvqPQ2U19lS/JFR0gEMe2ilB4geTwhEJsZ1X3htsbXvmtlTqZGSzpELzpV/OPo/oq5AZASl452/a4uwBFGsUoqdntXp32IXfwUIM3UCXFDJfktZXFfL4o394yf5kKtemTsrLLoH/i47G1eaNWDsksetw4Wul2gDYyBajFeF3UlQvhWLKSpxEURZI19vZEt/2tD/JQgEyWM33bO+IeQlUpFvavt+x9w9waG8pTYZuGJx106h0Yc1BFljBR/U6GcL3w+htPtcOCBqAiFQPlGF9o6VXKfWEENG8wnRXtMZsB6wOOK+XxPgWc3/ryAXQ49CD+FA2pYJgWgExIBNPRjp0aAxM8MV9PWPLUSrcfTPwu6N3SAetoZoLlb5cVZieRhbAygspRwX+nmYqtmQm9QZGfaWpsegdrah6arXhccpcEbxTIHmBapxYxPG41KUHpQvhWLGojfYmG/dF9mj8Zji04bSnJy35+nxoivz4Q9jajx9O7nw2AFqo63ovq04x7IibTAOBJV+zaj3aP4kaGN/TVIVJxd2+QCbMSupINVjlWICpvm6qC7dd+45iIzzl5T1wJEt5T/XcrQFjRCyAOyGhlREZHvc0BnGusNSFqntdxb8xdmUCL2YLk8/v9ybp7W2mzVsYLgNhw7H4sND8yvACdPX9IJhYi2WhNwu66pqNSC+kEwsRbF/YRlHft+Zj1M2net80QoV4lzNRo+lLt/8qvK+Crdb7u1DnA4oFOXXIRuSh3Wgyuphm8m9lAT03bUtp0feZg9FqS8Q3MpKpCsPtkot48k3dA9s6RxRxB1/uWlqP7b5zT1QZSKM5evvZSTykjTboxNHja4nboa26qWXDZmSi+jLMtmxJD7vxXyIETX1mCHIrIb1ss+lr/0n6eTD9KJP1c6uSmMEcqoMtTEYr8wDgGK7lcbfOpOZwe54yMFTqymeS0NG7rRMCxtpbhCaBEVbQ0++OluC1q/q71sL4HTxfsU2k4dgCBu25BkWdFoBLEu53P0QP7Pk4cUDBMwNRCPoNUtIdiP7VrRvf8xKf1iemoUc6LOPfxeukZZexUEorpTFtIWFAwujrz73FffunEWVfV0dLqEGXD/W0ZGnZT5a5zsiUu8bC2wHQ7YUF+z+K5gldIlmR9lUCPhDXP8yU0WG17pOErQzF1pLy9Lfm72yy/it3xqvm51gqJS1W/n+amMQNEw3eegCaK+g6ZJvUc5wfbMyirJc7+qSblosLVFuvwwEjzXKwW1l+BWxpzhE4oHWoRZrUaAizGl5sB/R7CeiEk33W01GuNxZn2AFkdoBsc0hqOnmIwZOZHRVlnWuwGYkXe/Jga1puIKLfxAAaxmC9hhFDF4hQWXW0++BcF1ecygKIp1SgnqH5Em3Yq10AELnmEGcBqiy0nC31C0a8tHWrJ146+CKUMO70WA/i93Rr8+lHLEHX+68I6p7a6z7bBMy503zEOjrimsgN+7sadxn8kOhr30/g8C2waEeHWSZTDrL0kBVg0n/RezQfNibDKrcBW+VHf4mwbrWQPxO14E18/zooI2dcTCTMxF7gcH4zcqhVAKYScN8i293cwodKAS0UupycDDH3zASj9hhQwSyWbIpvF/jJhqFq7tFL5Qs5lMSVe1ZSpqv/96urj1EEq7kl4ZKJOCCR5cUq+R8NmKRk2xbRECkkO+LV29OapFl6yw7Wbsk8SuImATEe9k1eiZBHIFIP46p3ibxaqdvktJVfx53kQaWBeW96Sf6S4G2vblvFOYcvOktSZK837FY9Kt8JvahPC0J1fIyDOxu3OMv7a2k9zXD6BXiNU0oJ5RC1SQ3UtqZrtitUV5Nb2QO+HTIMsxO4PHU8a4XRDzTqK+VJn2QfOCBTBa8JCXLyidBvKgAnOSL988+TryZjdsPi54oYujGFzJ5UALhsKLF3YUjnTPtDASgDcEpHx8oafdVcwlh6gfJgxn+ly6eLpkqBnCwMdSBK/28FX/uWmmC9MQBB9+aPj+4zodsI6JR9wN8F0nfGEe0tF3USplUWwFYHNNbl54BurohtgjfvyUBU1b0rd9ZawAyUX1nkGmqPyzzPoncTyxDJl3vdh2SNnG8ZpF+qoLjGOSNuVtoMo0bGPszH5+7rtz1I/e8V/7UPBTG+wPxlvBY7d65Akjd9onfutc+x7Wo8UeOaLzBWPAvYwJEVvGCwU0acJ0uuetVOElAxrGtAwD/WVBC2XNcwrRflSBDhQZPnWGOnOU6h0Yc08WA2jiDsnq5qZ3Kgz8YhznWPJj3kCKHf/nFNTx+dqHviEYJzo7NJzOtHhmlg1++Im/3xpByE6Fi1KUMfc//U1TnAtc6cDJugnq56cfMZpH+axXMs91xVamDRR2YILSimCaNkgFsizlOTYpRbQUX/n2HMu5Bg6GDG9eOWx7ytva49nCyWtaVICf+1ppg64Hm3O9SK0NXQkXfGLfiM7JqRbHOrFwSmh71Rwum4wFKx76Tas71STNJeAq52C76YW1uYK2loS9c8rvgeSidvZS6MzOLPu0zXOuXzWGw8Qtb7Iu2g02GbOCtG5ZRO3cZhzHAfsyIFiX6pz61zJxi4lCHC8+YiZ3mRQWDVvTfehvYGhO6YR7ScQNb+/06Gc66dp0nmKjrrTaHVzeOG5qSymJlEXY/5S7gV/ubtjXmLkowu5LM0g+V++EQ0pd/HeGsmxUbyrPDjBmOebHCccCt5uSUFMZLWAl7xrhf3pEvFMkRTgjwtNcjClLqsnOeVXt4E/mFH2k4ga3258C0KDFM+Awb0CikyB69iE67+Yg/lftU2VJ7HaxiBYEpi8A6CrUlpls49AK8cxSLJeRtZ2lPq7+iKVKokyR97p3oL+9MILUBXqgwKguW8K7JYK3BcarzjAaXDesk/BZtF/WFsB9bSDorgG5sVP7odumUEtHyWwe2l/wmtoYnBk19icp9JKk1/2WYlDVOFflVuPCSDZO62oTzqj8vCLK/XMm8dOrxEMhOAU7IruVb0j0scNdNqpQcFMSAcUAyK8QyI6gHXPl/Vd6N3e35SaAeGMsH5PTKV949BIDNKU+aMe4SU/siu5VvStSxw10yUGM9gHmSU/X7Gb6Q2jJVRa/QkBIBpcDELfqhtcotVHfM/Mjp0/q8mADf7rTWsgOzVsPFkTbiAORYESRFVMvC98no7uXz5X2Z7Mrn5IBKg0Cad9cqMgGkzvEQJeyeUFBJYM3YlgglJq5PRJGts5R9Kvt0WHMslppi2Omf5ptCJIwP7bwzo1EPWrxqsmO87ZQ+3HERC7SVan/mykFI+YsxHeszqzL6nqAYu2FlQGPwbT314a3M+FhStKyui4ByjhMl9bMAIJz9iIwmTskrlgAiAVYwVzRny+9de8KucrVbn1wydSR59ugwcHhDvn5KdZe9Mqml601Y/PJhnBogVB5psn5BWmvvehTQgwuB2AJIQ80Oz3PLr5RjuYwqMuriZwJs178z8dt/xYS7x7g+BiPtcmSHMwJQdyrQ4LUX+74ErYp3xNHdhQShXPTyWC3TAQWujaJywnhLbVUFrYUHicJNrJuMisgds1u+B++NsFWo3nv6MDVq8VpPsvduePis9d1EqrUVcdOb5V93QfarbnTXIVjfmeZe6DEZI3cB4GimToJXzTf7Gv9X5SbACkzKyXYqEMyIMR/Ot47eLjYISQrxAN9LXzG9ZKrYkgTvoHgtOxy5tLSp0w7uW8Nw5+0TQsg/bagB09fgH9PSBbFxdrzd8Y0M9kZVCIb3ilFzVG8yDkJ0LFqe1ggs7Kyy7QrKPorhmr9WQ7tE0BbvLBpIHIc1KC8+TOtiaAPu8OY4D7zjgzu6g3zWuZOMXEoDKVz4eB127NLEHgaajskrjN3OwXYDCwkI0ZIbst20+2w1TVuzmHXjSAcM2qfQaS5aWgyfnM+RUvGvPfSbVneb75JQ4Dp15uPIuAbfBZPUoqXX3ckAAn/c7fyh6ut6JWnC7ScQNYWt6/7lAgEm6cROxj9ntYmKDuudz+003/bA0OK/SAWYDLQASk27HUomNvEj/1L92zYAIosPJAegTGmT1qQX43cVTWvGuZDTm90fU8+8Zb5Lpvmba7brwZESVL52+3jhtkImvLZcCl/A6noaJaP++GleXgEfR6jS6bJOz6s9c2+6/ROlBPyL4mvvZx7b0mZ/ZnCh+UztQW1HQcsulFc9oluZ7L9uy/rgdWBauG9jjvql1DFRnhJZ3HynrYW3RREg8HyhxYzGz2dwfZpXA81yHBkkvQ32XldHkOHbyNkcLwojt+ITj0OFHjME76vz5cuo/lLLiXUPN0uwn4RPNFeo0pmRa1zJxi4lA8A5Rn9RLcgN27NLEHgaajskrktsE+hVJ2O3q798BKyqRBirboPvTkJiU/uEND8ot9GU2AGpsG5ZU1F6u1LgqL2BlBZSjgv9PJ1RcgPImFmHRK0Avyptb6Oi4dWGTMYNCqscpRIObjWV+iyiQCDAIqff4ta5k4xcSg9DuHtvVuCQOOfspeFwN26I+a22UKHBxZE3lVC4bi4dMUpOE0x4pKB/ZCEQGrsw6MOagr9pPdCvCPOWPzolfci55yRoZaYnoHZyO7HuRGdjD68nB7zHRhNrObkybgEUofezHVgSJtbB5yU0GSVdCBjXBwzkmxZEsk5pULkE0IjbXdA8y31GPBxnP67MLjGQvImF4VJMwcdfK2Ckoku6uLHP//lm7UGxyAK62n6eCO0pjEXMZnXa9PrxmSGENCB9lxxlKyIk9tbmBlbR/oBPGrwkgXUG/3+SrSvpz5KsVexeQbClBe3sLFG/B7a6ZWujbXzbzcCFFVQdi7FDKIBxPBEq20Iy5zWKkjAYJpYVy0smPbhsYwkj4xS2zuxpcRWi6AtLKccGd3UG+a1zJxi4lBH0ue//M8t65zQd5VNJWQleLIm8yAupn07HV/OJuQN+HtUHfcNiSQVRrW13DIuwUCh7G82HaASZWlDS0hdZTEFTUj6/3TP0qkEpo0An+6lKABxacoqzGT/KV2kFVqoMpiCpqR3sJHp+vdNPTxRiMHqSk2riSIlQ5G9T6wL1iyhkE7nHjBxtDS6vVzjyhQ2hhyxipZp1CBAMLLPN5NZkGYrMG5ktL8Wvb/h1vo2YeHxQiROA0u2Bq5+SOLNhIVsEDirujLp1+luDSR9zs4w0GitcLiH2JGemzenEw1oowOTw4qse54UhI75O0LgvJruyG6mysaxj93kJBztNa+aPrPqy6DMNdbhK8uEYwfOu4fUDu8q2h+nKriohooHkuPPwb1g4ZYOhKx6yo0T3QY6yJXitKOc7EGsoH7ILkXOS6mtS+E5O3JmsBvR530GEyC0r0DK3J1n/7REcMcSqL+daZyfaXGOfqOfmaUnZBr3j8O5Zue23HuZcSe37YQLfI52FLR/0v0cOpiPclMk0eLjtBGO9MSWGFH4odYnDv3Xwr2enPz0+n0vZKf7CQNSc4ttPQxYjwoGg1K1JFm3xd1ErK3jhhK7OJ+7rqlbB0stBKSxKKzmHFC2ClRWDlbFhO16M0xbID4XcGK9olC5qy+x2Ny8Vpr71zh4jrBTLsU+ej8eHsuLTQq+O9rpHyAIbaNgLSOlnJXPHxvUgeJfEpLc7NMb7IPnBApgtz1mfEmwdMqYVNt4/pGgeqnIRvfGEfCNH5Sk7s9LWxkhZBMkXCVjVYkc7204WLcVH9fcoLu8wICQ4a0Q2Wghl/Gq5FKjTSQWOwkZhPRYd4vjCUUDir8Gs6qa+rXAfRs8uCJRkZsW6uDeHQqR6TVPJWtfIFv8GjFqUoUx+J6+YZ19tOhlbsGna0jAiz4db7KpnfHH/ePDZkBsmiOqqe37YhpV/4a7ugGIwQB2F88Bt9YjBpI+52YfmuSwvT8E/3Z5bfFQsKOUF2raz3YD1g/4CDBph4n2dalspC8p7SetqY6BkNJnSATz/nZpiYhMgQ0SF5apBS9p1JR9CpUybX1VvBQLo/2aUb0plTYEBWHQPgnzwbz/hyC5fjYuxYXrQq5GBsQNwMe8Fml5VOVDcb60S4SLbRfAoBf9IccHHAxMfvqfWggqOP5Z6rVN+YeWk09D1ih2pZQhdUKOz/xAxtyBc0u0inusKD6TysRJt6rXUJR/bRJBeT+dyFkdaLZ4RCsEPI0ZSBIkdAXbQMRR57TWuZOMXEoDW/A62G6llyNSxB4Gmo7JK4nBSnGb9VJCzTFR15zuXy31+6iRIj4K+ozIAyFuytLFJkSh8itWfYs9y8oifUuB5ZdZ9FnbdEIZDdPDxsHPb1OB3Zl06f93ux7b85/TX0CQY347ivJhEWqq3/K/OhKgEqBNzYka5Ww7eQTTmd+d1h+wQKioHw7lS8rNhXmj/2wmyiyhgcHbjgWMHMtYVb+MDkguIH6eCOz61MUB44kigivvAjJrA8GORfhXs4lDWw5/Hrnr+VU7ScQNb5b+BaFA+HEhpGbfyKyfpEfpYy7y0DYM2rcGGuRTyv5InxenbI2CPRg/1rmTjFxKC4VkWgMnMZn45jDzQJhz10uySuWACIBVjAvV5gyZ2H7Rj48+YiXtnvh5b8POWPzolfbs7Cc5yGqrOtRozWt3xYFQp6qUCUk70QdavwF/7UNsbfam4r4aa0UNOsqowUEuv7dovfXay/mtCJgBW+IEIURcHzeVR11ptDq5eLu7D5qUNN7Mqdq159dvrahXcGfCES2rvrlNa5a7yfMYeaBL69T1BL7dslQbzMdj5ilJwmmPE3QNNR2SVywARAKsYK5oz5feuvLkmdkguzdSNCorY05rjSfEw7Ucfyz1Wpm9FFoKed0OKsGi2TXoVcMBvgxel6ovLsZfRWMDYYRyeO4EKKqg7F2Krdid/+HklJpACX9WAd8Nxd37oKvKN5dH0RIMT6EoyfkZlufUnmP/HKFZTHkB5Z5y8czgIzUbKIErXg6dRSXqvZaDum6Vky4/L8jice+rY7l6fz2VNwhgmRMD+2nykz3aanTCns15MACYR5aoUMDqg6PqmI59Ij9K6bntMf4QzvXQmsCPD6zg1qEsN94hzYE81bXZDBo+WVjyHsvAf+girUEkah6GQF9wXRFlsQ0GLFVuVklVLa2NHrUE15U4M8lt8StwX0aErsrFdhWR4SrKHTLuTQ9+kbj99C290fEVb0x1POqKgD/icaA8xiNoril2duB1ZBccFl+Ud3NNzIj8Fs69rdxk/ulbMYOfaQcFDFialpxn+86LoPMLt1n5JcSskvrv2XIsOW5cqdtrL0uIbj+LAQYMau78YL1dRpP8Cs25fCLCNzlnJhlaAXDcBVq9+qFYU+nXuI1TnrEyXUmyDYlnoQKWcK18jIMrHvC7WeM2phBi5m+nqbOndA8qkamKPRCSTSSSq69/dXDtUQgi3ZBnN/DL5T2586gPT4yX/I/lTE+D7epqnzzFeBui/XidS4pH6yTqezqkH0Qe8Qh9HNXtwelRRpjxzxFkztAVUpJS3BblSSPHC9wJeuTbpbH9To54AZ4wW9Td0HAbPpIsxBza68byjObzrrRNvgXDhYXwno2Ydg34qBt0cC501axbjzSLEgLN7rT+K8CW1x5+R3/d2Bi617V2UiScO+YbD7QdJUcnhwZp0Cs0U8LYDaSxMQ5z8mbsdk01zxAMJRCuN8JcQ5EBkmWI0JrDYJMrYeJPPON3sveffwmEr5h2CFHlWsW8gxX8CcJ3O9GjBK8fEc9j/UGPm2bEBvycaZsL578gKZ3YgXtfkHeqxrXBo4Sg2DgwtVxnnFF2L64Z7NU0qewkOPNpl6Pq+3qqVpkhJz2Cd0RQI//cCVjz5f4KkQyMqHoBoTQNLmWzWMDlEWtXQloIRHdpwG/WCxksjs+a84QhcDUaii3oyxIRn6TWhY+6foWVWzyCgqzVSbrwFCWpxRnQ78O400x3h+DNXpLjgzCOLKW3tRd5Ct1qiJ+NI5Nr2sDcgLgfui3YYcyK0pTDco0Eu2IlKSBaAuNPz2oPDPFzezssOlgdh3NeIvw4ySFrid2jND5t/LH7Jru4O83gYGHjDSBjoxa5VTN0pHneCQC47BdHpbU4XNBuOKjiDgCGt1mGJEYi4Go2Nh4fGW2k03GJlZCFVxjd/aDYe9t7SGQ/O+2Q/U7MnF0XSx5W07SmPtEVlfwCCaef3VYjZEY0JpVqO1NJDCimL5JxCv6nYCX95TtR1IwDTq4xWPMIaoFOu9me/7tbvca6J30OnvKVpSfytoEJoijwNDVS50/kbsla5AzmmhwrIczp/5n1C1bImxPUQfsihNnHnH73357XAmlFrN+dZaGgot84vCJNQFIIvwsbuGmW+7XsrfcZ3DdHuCJ9xrjYiQE4VuN6VD+0z+xqiTLNGQBYP3gK/rAHpOAGmg+3l45pVK9lmJfu5aajajI7kcFXiYOJ3IF8B6vB6brGrUAEthcDKBdjwynJzVD0aiMUtKv7CY1MW+G+yCtXQbQ8kqYFwVYjBErNv6JUlrRtz0Tm1xOGQcA2Bmrs3CGslrWlVeNutOsvzqxc1uEHX9g/ViWuSqIhyVTvC0ntwsIPvdelsTFjcwc7qpi4kyxKRNA6sx6kOfvwIY8tq2Tb1fsffD76pK27LvP2ypGnFwFoegxbmbcOjq1l/al0+XEPsiiLR/23TiJ2cPvE+eZpsj+B/si9R2rVtbRiCQly2ZYvkinbtbtVNLWaFQmBLTTmtwnDkX4V7R+tVY856dbGvjVDSNgci2vrFiIqSXYjPrhYRmXmcJgwQq0FloO+HRzd3JfeYlUr8g70p2hIbgo5GIcj4sJs62hmguVvlxVmKKtTY9A7W1D2cJVdrT/3RssllAn8Mx1hIb5nhu0nEDW+uAR1B8H7Xz+Nq4S9D58fY6ApJ+YKAGVJcOL8HhOqiaPfgEWXx5fXJHFFC292/LY9twXsQpqgL3LbfBXIVHrEp8VT8IVBibtWdTjMhuDCNGjyu6MEDQ7l6255WzkPOdP1A8iAgk1JVhirMJeaYM742e+HlvtjZX4Hd8rA5kc/JRKD2nmUAZOSZNRgoJDsNX+XX+I4W3X99MKmTbaNBQpKYrRNxWIPjsuKlQ4kFlt9VTKThUIFM7/jgUogyylZmerUwPJ/pyEQHvSduFOJWq6RTRYyRO5Oa2Y4XnSsLNoiHjwMhpOzMrA79h+WcW34MhNa9WVBkMIortcnVRf1+eZ0dKkV3JRtHre3D+0aDtgK2umeVwjRV3/LttbS3Z5mhV74pBcc0/r6UJVffBNRAnmdulryHQLRmYhyqfVvBvPR6mJ78GSQJUAZHMwnzI07ijHGZeEXRuVymRf7Um53Q4q4GSziJvunBH5Yt8pHIBnRExZAhfvo7sgY8Xa9J70mjlJMNU1Wj9ML7NL49h2ETaEQI773DBnqWpn8om4/JdId/r/7qKXSEdxO/sl5CqSJu2a1TgCRmVWDMPhJQXt7CyuOkczS9ftcuILJzG7XT+2hQzkAaiupWQP7NTpjQSfvRmVMyTjZmUujZCufurEkXHw2jmDbh+MfR/I+EWb5axzrr+/wiPaPHsOC7eLmGcFgKDByUcX2Zkyyb26L5Lj3esf5YbEPXL38i7tJzwaW1Q8VumMXWMCBnC4dzndNNVhEw25mpQcGDyx7wCqYNoWApCt4DW8Fe5rmeK+xAFRk0wSAEUIvcTdtQYrTbD+sMSb8KtBYiWCZwFEsba/842jOg1khb0OSD7Zx1ISf62vmvbwQBr5NTqRsjFoZzvw7ixQ+AspUIHWOE9/ZSVTYZ8yorJ+1R8Zk5Yuz1UtY8z87jknEWOlPvn4d+ATEdf+i+nR02e9l47kYeAfJtniYNYZntr4JxWU9K53v88cjO6qFhdWkACVP8CdJg3Xu0r8cFi/eZbmxaDXYqPYCBZWUfHoZjH8vTnk5ijUtkf3MjyM3UTug0bdyv0xCBkfBTCOh5/ahviYFydO/DlKZT2QwSAEUI6OfFVOL7nnW9xaqa09U8RpfpKB4Oq7MrnjJLUKR44oZRc5WKTvsc4LsWof5UiTDNfjTbndBYcYaJQuvRtRxC/dHGmAaL8BJFvQlMVFdxvhkfwFtc6wrEkq+U5fEkK3JJR900mWR8lAxWFXhAGJOUo4sx8G2cPqB1osjRQnHwPzf6JTS7+RKpN/QDQr40A7QelWPAIoQjAGAsgp2XKbPueTMudjyWjrDlxt6mS+ydOB6QT8g82gLEWsbJZwzUmbPPcX9o1v/Vb1PRzhGhrdNDcmgRK8Fr1w3d00ATB0bF0C8hgUs0nm8Id8/chyz31SH0wbZPHYxbCNaLDVy1e7QK8DjE88hfMT83D7QP9V5krelN2VWJDDg79gWq58P2XK1G2ZDbnQUwQHUz5XV6VoHtL71acoqzK0ulf2GN/WTSL2x7aq7GD6CtMqbl1WVKXrvjnYucIUw+V5pli76FCl6o5peHscDt/mKTuffkDGtHx72FBL6o8taCj0GskSWSJApgzFL1GqCeThXFEkqplB862RnuhUnMfS9vpvRtmbneNEb2MUzU6bZtxlzgvCzfLf+HDM8N5xRLQ1d0anBEjymv0fD+xmIdv8zvgIPVk2Bv3voIGRCTtt18ynMTJhlWPRzmqFI5TJHuIpeo1QTycK4X0WvWEOTUuq04d5gCUz/fov1bF5xqbCkQGRbhi4AyizH+PHddeMqAJlR4FSzUCfjpEY9oAxIVsje8ofKmEpDiZYIV1UTU4oBT8yB6g1E3ZNf3HzRACjBdeHgNj/6rhBHlklcIRSDYL11AA+27rAXz6O+MzYOxhJdZB1IB6w4p60axYPVW7wap/K+mn+8c6bHw1s0Jg8PdQqMw1Et6+BMp7Ei7iye2ZdTV1Clwf8fJRkPJPfJgPvY2JK7WNboi2r6Am0qj6Pen8I//ez3eTFkQ2s+3qApPPxYjEhefB5HfCAapkZmvUVNIvVxnWxhz/z/XX5BYODfhG2m7LUkL2gXcdIi3Fv4Iv1MGltZeUQ2oYnQ7Uo2+XsKZUQL1kSXKezrMWpSNYAXj0QENDQgwuH/95EnMOTxHPgBuBcvVwhgelYNlUF1eI7NmsNRcktr+kTyrP7G8zCK+yRw2sri8On9Vtu3cnBkmGYoIWvgayR7Zl0niyS5hLBYgHpip19ILOPrSvFpeEbCxyRyp0kN9wDFeW0R8lQ2e6lemIPQAsAfcWSYVTBUq5Tjgzu6g3zWuZOMXEoQ4Nx4U7qgTc2JGSzxl2mxzOeGmo7JK5JRJ7sxDeuF5SMt3+erTL4d2JCiFfiThXgpucixf+rm4KFelTFlkwUh3JtypbAhCrELFnNQMdFadoh8WEeVQMajLCo/F11q0/WV7aG9Ujs6Z2Wz4O+mckLZRUSuWrP1kQZQTxC7cb/EstGAQjjCzhf8agdSN/PviauJETHl2uMlNQkNqyWtIPSI/Su8BgKxedVnUYqWxMAUSs7I67/oqCuBxAfTN9oP+SmhMKLsLr0QAoaQ/A9Ij9K7QE/bRE9aQ+5Ulw4vwbD9lR7YkVYJfbuXp/PZU3CGCZEwP7QBQ5O+opErWCF0VdsRREMSGYTZzrshaVaSAXf8PHLc6uoK2aLFFwAIQz8T/kiY00WUxkoK5mBLuwzUFeezGHDbEGmT+GiX6rkqfNzucgT5sD4TP5JF+EUXyaq62FQPKEyIC51++g8bPsf9zZXSFIBWrcexIFT7/FvM/Wp2LJinLwtNc5oO8qnSw82OF4THT1aFyv4Ifl4Mmdh+3tIYOSuTfAmmIR9L8hZAAQ7ha+795mbFmok/8x00bhjFLomReJBVwHHWhY4ebaeNwetJzdjfv/OUaJID09vaSqvWOThM9FWsIpuVSpJ0sbkxJ1LbBvDHFPMLKbPK5flZXDLNOLfi32eGF5iYd/h/XIyi/MPNG5ZtQjvNBeokO9Q1LIy8KjMr40dJRM1fbAmSOO7IHpDS86/gHbma28sWcAAG59APgANcR+cmgDDf4igIjzW00gI3IgYXbbqiEcUWAHAUPyf76w+dPpnIOx5YWZ8M5S1oTo5fu1TSfhJkE2XP79iUysF/P8tDiC1XCBtnBTauINAWUKNYYF9GT8JOV682C7wUnW3WXHw05j8uKns80mhPmF5Z8jgJTkXZgeRhAKzGG9XCXZS0/mMKvbuCZVcAOWOhZhdaJeoWtjojA2fgAi85WAGbMiN8iRIQetBCl1NFdLTeXzQR8lGAvTSNhtNg6DQS3iuGiHBHfSMoTm3jc+4wzeGYyiSMdZGZvx2ZWEJG+8Pnn73+GpRYyznuHLd4UdnprDBqzjFj+eWLDLm00QLbeeNj54bUEqf0LkK5SvidITPeGfP2zVbwofOsNcDyIKBgvqkxst67M+TD0zFXnI6QuRLscEC3tVnEvANpe8JMXdJBv2NrkMKzDRa19QgpjbO6MOHgD7vvtJcYfaOi2IBq4PCAX9oLAhgNYTPR7UyrE0NNBz9/hXVuQTxPCkc9GwUm0hwigjtVo6ysXAR4BoV77cLhKoIKHFktBCQ7ROuLxViUpBv7qeYzFnImyGglODlZEN5Y6yl67aFaeEObLRPXyARJ1TftDqjQbe9MrDxWTfmiYO5n+w+2n0OtU/IBVOj4AkNj+ByfjkyAfgqbekN2QQvo+h614RSOCyNU6OQS7Q2xfRQmmvlK1NE0TB+QHM1dDlV5qXZkDv9/oTOIJffJYzdxhJUTJh+MHFK3xfv1nzldWQiB71RNAbCC76ORStCPM7YwrUvOFDGVNqcObr1vJy5FVlMlN6e98X0THKpyz6B/UAABUD6uu9CLyLLZmEQA6wQLOjFPUiJpPzMX6GVuOhnrP5T487KlgDWPiTI3zkNOq+Ae5Kl/FdFdyh29tGnADX0r96TV71lIIEI3KQ4y8uwO6Q9k+RGRz+pYO8bobJ3cbPLlz45Hv7IYQME8zwlhch6W6Rv6omYm5qbMnT+1Ghb3FLPSsrzBh5Rg3jjOh9IRPbFz8L3Kbpgqqg3P4bN2qoi5fdGlBNx+IuOuOA6dA3Vj2ECiQY/N4KyRm3Ub9lYR5yuo3fcvJUs1/vkvdSVr5ZAIsdhuRm3UGannB7qbAqbIt6Jt8bCjrWgjiiYNFJJ/q/qytgiw7CXzo7GAz+1Bf28N1dccOFxFLoaTYzQ+wyc75L3xLy1QhKtv+LCeYvO54UXATidrgtz8+fu2s9YPFaOlLV0nGMdCiKDwnkEzHcJW3nVv4uazig4kYz63eTRCc/hy8JGhrUXPCR6wuk5cxHKvqczIyWCg3NqCA0q0c9yPC6RYjv4ZrIiPB007w5NktvWprKqJw/p7cmmhlUR/Cp/EGZDReabEoCaIUtTWs0lRJD1hq5WnYMUCF86z+7Kr2zoSZ/C5iZvl62ozSuNvnU2BEspi5SmD5bX+XlAnH3CcXsEj8V0DcEbY0IepIVDKpptmXs883CG4aTATq5uiV3yvfiDMyWI+DMZPdQSWnxU2QPdDxkDJLOkVm6jhk3tLpVgsiocqD/hi10L7TO95n1d24CK/33/yTLo2L64fF3mCSYUShr8lJLs48UeubuZT26d5LQkROsYgzBpXScAO98AyWMCciiJO10tkGMsrMx8VOTI0FZ/Glt2IVWn+CBZ/ChTv95Ys5Fxjqh6ZecXlFV2Qk1RA4CHJeaqQvVMX7D39vcSrDW0IKMiE+a3N4lSQSUHQlQ7MeNCz2jvV2o5lTodA+Apn7RhOhMCAhFC4ChIOl0x8OS/+W2EtEwIgpzOuWIl6JyLZecHgd9L6S6iIhe/ipXvi1zC0Qv6ZGgcDtGuPdXkWTrvNeDOQ8Jh9LW/+oRnBURLPEk/dDDQQjCm+56QCA4+GseAF1rBSQVcek0FO9XKIVIcvk2QyWoETqdpJxVcLIlTRqJhkEZKht9IKD3oV4pr0WXUyAJr3X6r+tAFo2T2iBUHmnoUVSXLB80vfGhyUTTF4WQ8uo0yHBTyIAFPF4E18/euiixvcveTILbHeKPA0NrSavZXhBXug7bNb+O03ckKcblaY3AnX+vBH08/t9S63K4qAhJjYnwq8aISVQ0jWrdBPnFOa27MMWZgDHT1NFLOCaYPSJGO84DzSimCScYVBgGszvfUFbNG1rCJylyHGSlkeYMMa0IHWzARbMGIorQCSIiHqsdukS1wgULcT6WC4jkLFewVYKmI1lnbi/DfcI858lnZ9qgkXj65yPp3D+IzNuKsy1/HhxW7ZLoKBInDpux0hesTJlS1L4xjEFWvPVybnf0VVVgTXP4ufMf+OUKymPIDyzzl18qIiqpx734SWT1OEGO/GkHIToSIBzJhtgO5nqvawpfJ/gqytn09Al35mzARbLlqIxUeFECE5nmN//omPSwXEchYr2CrBVBqQfh2a/41rSXZc3U8RO3OmLAmPOvsof/FoMA9JZCWu0jdhIaa1LNuHjCZtJrw+XTIsolNfsbhoUwQVFUvuw/kvzah4R4bJ6i2FBy6gyuZamimLfy48J6gdW5uqNzGoXh7iLOnM0HcB01rPW9rLdebPkkyeqLy7Aq5k3UkiBUPnWn89/DwtTDjwXXYidfKKcEg22UPtCGnzC3+SusgAIdwtfoJaVERbcWEWuJRlubAP4hGXdBsu8ZnHTXgiYbvOYgGosiQ25t6SJPbGk27x8MG8IcQY1+HVvo4rL5NDgqXKbdjTo0EKSOm2ySSMcEwaz6vYxs4vLqA1ZtLjqsZ/5L/EcDLMRUksDhervKU0K4J5Q0GKt2LRt/fPQknf6Y8oBtXxGiyRNHNsyQQY3BfJzscOR0AKzo0uQGsGB/vq8u45F72qFK6MS4ejT9fo+H9jMQ8L17FTTYINjgAOc7HD5i5SedliWYllh161PchqV7+7qlO1hvCjl8nZgoc/TkTl42zrDGKAMUnLwLnNZhtRbi8X9kK/WbUuTPJtsReU616CWdzhQ/npSK7xj35+oR6VWJAx+/7CHwVBa6pu27mK89LhjKKY8QWEPyEohK92sSp0c3Bq4j0H3K8AGQYQuLaG4I/PfaSpML5rPlG3ujc3GkKPV+r+g57nVBKoKrpVR0wn7Xd1/yt77jzg01xuF9kWM3IIVdjicUiThicUh57E+YiQk7n+Q7J1b71+G41LwsAgzaeBXHcOCMK02z16kbwaCCPa/UDMfUEeBi6DTBRidas/JLQUsEKLvYpFGYQvJrrkFAAWUKJFDzFXK2xH3P9dcis8y0uFnx6QIrJc78HMPjUlkCRrgpYxcjLMyUxryVy5gmQ+HmoKCWzSuJ/oI4KgDHLtlHDDu3oRUDBKCS6C3K9a8GcS/rip5GtOHWeQXRjKC4F0uFbytg+Yfj3PSvLM6KttxSXDaBwoJTEhqIbGtJNKZ56LoJjU29vbiqOl8Fy0jJk7U2BMn4sKXf8/b/GPZmHdJ48MhUytB/WCDozDMLRlBjVgjG2erKT54oMHZ/4lzH0wbPSrFfvkR/ZWLJ2RH7XHnat4osTV69Rrw6huc7rkVwtJotswCdJG/BEJJmC2CRsVtDiclZJ0ZRj5hlIG3qTNjVhJE6kFSHHAEswUGUOiaCHi60x8paLYnPWdrRRu1nUcEqFqekM/J76lHby2n5Q4mEhFmEyHHD2gCyuO857UFe3X8M7s+JX1zgrGaAtgdYcqo1IOdz3lvB/OZKY3pn9mIIMiC/2jWAcQl8gD65Lw4h/gdkZQvRAgfUxOI1NVhMzdjOqv49kGz5aFQoXmYg4uWd9Ow1bUuQdtIsY4ubehgdsXVhiysOvFa9sZycgwI10AN0fTgX+pGuX12bzrqSL2qImxdyAqdq7PDt7EGsK1j8HdsiCgxK12V5bRvi4gSpBrkgw4TKXRtv2uSpEQX+0av+h5SSi+gjqxvWN6qYvrkRwQ2kjNvzhjo5svlPSEsCNSMAawegt1rlsFunEtZoDkio/6J728BVYKJXNbxdYlhwgMWhjhNtoBMwRrT6xojo0BsetjkFHGrRPXtIUK/ZyHyhSbbJ5pYF/uGFr6XmlsGMBqJi93rAy1f9oh0Br4FbDiwg31BjVbdwsj8bTQqDy3lB7oPvTjvHGc3XsMnMGwGqbLA/MVDWE4iuWmNtEeUk/K+cRAK5sy1hl4Gowoz2bPdBejXEYEWqUN7DrlUNwAXBVgNmhJVfIEHjVgpuUNOIwe4QncAB6/d2AW0ZHKYPTZTaKTKWWNHa7bjrgYhb9x9VOjH0BhPDLkZIgjat0AVY76dtt5OElWvp1KHuaaJV3ji+wL2qI0luL9heySkBq41Vy8jO0umxlIuqK6xnoe+njX9pM8qdlyqs9UsKYRanxYmxltq2ps7VbUyUuPCnikV2tOtNKsvK2khlTJaZrz+nx3zV+ard6RH6V2CCXwKl95/siffjis5K0Yq8E64i3/0zJwAX5o6KRj/bfhwQ0slr0SytMO9lLYBv6w5Vfpc09U8EsdCR1p2UdRn1b3QCdK8k9IxKflR8T3mRMnjM/+SZFYmdwka5ZljSc1BzgLBj3rkcP5x/yS9HvToL8NHrN8Kq7M1LfnHF/JvgfQIqW2VmBpTmgNRR9NHh6P+c8t2CvG0O3anQWpX4NuYnCzqbPvRo23UICU+gu4RDUvANqwUKz+ZcRVv7JBddWV9xvZ2MO/SDggrwnN7ZfuknQEkpPlGPVB3zp9o3TGMw4f0hmUcO/nvkvNlxCbYTZv9ye0PJlVMGlpDG0XJSRQlFthmVrG8j9RTtqEfXAeDvLCG0yITTYOEvQRINlRSG6TiV5IN/cN82GhaoPHiX5jSrDA1MAX3AK24kPWf0UajJTdjudpmBc21dV8XaS9iEuli2CqWwbvZ1CFdp9uD0brXaUg167bLVdw+3yoLW/yX3IOx8PbjmRNfC1cChbK9dIYU0vKnI/kl1YkTJ+jJVugoAnrkn9l0vrRJ5/qeQHHpPyVeofkrgevr5NkvQzYw4ufE2+imZlEQ1HEBTJAf4N4/h/JB9O18BZAr98JNkGcaCOlpezqBXWsK+GnkJ8QFPqomhsczMc4eE1DpiB6XF4v7JLCPqoExPZVuAZLnX5p+apFkqxypjaDkC9UNFjCiEmTszdOhNCgxm4NWngEAJjpHRR4vOwD6wPLksxsQD23vC7EL4RqrGWnXTjQO4Lgw8CqIR9WgAa3I4GT3+gPMjR2CsqnXlJPx4mtajiGu2saGMAIjAILyaDOm8xHXUizKpl7tnpJlx6bnA7NuNu0gsAn/tFlsFe9v42JCCWqmkg/6/EwDQc1+UzvZt0lOVphmKKL94uKI+SobVyDySTtP3IF76PFD1bpdcpoRvsGtldxZLWtLLbv0WNkIkX+1K/0ciS1lVddQZXyUu/YqZ+ELOpS1tbFO023aCo7dLftkkRfz2t4PzarcgJDUeFGqWnHo7de9AweoHoTzL7jQNtvE+pvJpI4Gujpo7h9HfqA99hoe9CUd0sd0MzodsQ89GJH/ph3u6h1m8C0GzBbOmCKV+6CIc3y26Ii5aim1z4oRiQcGUgRJA+SR4GX/2I0eBwqJHhTJHtR+34CbdsBoakJj8mJYTGaHWIkAtZrkbCARw0milOIeOlj0YoJowMfvt6TtwKLcsZcL/IS+ard6RH6V3ZL036Aipf5IAxlFCMHvh+d966XJQB9fqNbw6Vr07UbqCS+n0rpnO9KTjCAG4z9nHIGhu31A9GHTaKTsIaBPpDXLQlzOwsunK7JDCEUVMuAL8UdL+Dci400LNdZgfhJpuaIOOuYtdCbOfVnrm33X6J0znJklidI+mUraFoAyrvp913GfttRYDbBZoCqAkNqUbQOOACn4krIxsXxbwWbb3NT/u/6vqoClYH/GeCgOkPgMcBBT5G9Fe5knFZReP3e0bBmDTz6+6hONwmvV7EsX8VhR8z64RkGevPi8No/M6Az+UoxUY1KSLPN1rAawSnH9UXXzeWDNLFe/UhLTmFyr0GAENq4WncYqJBKxERg9wg3AxoHYo5LgRBmGIHEdcdhC/d33fuOcqWh3fzZWYbdkb1Z2JRkqolAOIel+N8xVAmqnTcNaPKj0Sy0whgk+aZ8//4pk6o/pTLdkAJhpiG3Pdg8ydDFUvEpNMmDCYkCG81PkJIQfLwZM4rle+5nRt3PWOprpc8jrQi120Ge0vgirx2jEgi0OQvVcw73KHnbdFv6NAk3UN/02hD0VIwuoGQb8XNgxZwp2XnqB0Oh9rkgIGx9LcKQwGXlTsuUnoaKQf2RjYjTdBYDaJ8fRvYR2YKr/yTsU0xsyd8y8jDrHnZZjbl7zhsa5FleAOMLko2j1vjkLSPRqYVb8/8MjG5jbsjevdoNs3xutqn/SDopmRa0l2XN1PCzdnnzESa3JjeINTYPOCe0Cxei7Jf6uyzgUkjxApFon9K0BCfHk8i2vrFiIq4fDe2b4IbKA6a1i554CdgYvFQzLC1rAImts2BWs/CecePQRfSEUdmaelC+FYqbOgaQ2WBAu+VEzFMBZaYD+nIRFCdAvJi04HbvIfjzYZHYn6nNI2ZScDll/UaAELFewVYKlsTHwsKVofR+9hWlBiFPlcerw0b7I2mm9SOPcT6WC4jkLFewVYKk8peCC6yMgUgtvMGsWQ2B4vTgUVtQeM1MwroB04P/Q7RVytsR9z/XXIrPM1VQ4JK5htYzTu+A6gT1MUeX4cKSIaYNOQag7XyRVSJh52N6qpZEWVGdPDp+mYS34AgjdeBSsCyMgGQsz+mp8X7uc51jzt5JVtnPzm+94Xrztmnfsz+iPZwD+eHcF2r66RX1H1G7FVyStvSpzrWEM0t61UFFr2rXOpzULb3QhF/i1aveHVWyBT2eIRL/Z6+QsJ2reZTSvsAHlnzI9QrYlwt0fsYO5YS6tfaiTF+fdvn3PxocTkrJVvhWi1Nr2CE8iooo5mS7R6Xp5/fvk7NXFDF0YwuZPKhMR9maoFlDcB/LWHPxiBws64RQ79atUpLn7GBUnQdRxQdqD6US1yGdlMzVnKKrshTzwln4RGpFZJ3tJGYe51cUjODTo10Ykth9+Ix+Rmx/sC6+mGrCcXsEgCMqgOSkQEVejXUB4kI0oC6QpS3LNZp13xgE6wxdVdRxo24So8sCFOni9qDFXeQ71XWBxg90PHuFNvcNaRNftZw6pGg8SylEmBIJNOsEb1qe5B1agnz1KHpl5xeUVVYt9vQ11b/0jgx98w9BmooE0VBukdprgS9GkRs2LyWifkrgEgQ+fdVCB4qJ7hV3hd5KwtZ+x4ZmM6uPfLRg5H4Amu80bD82jJOhdKrvqHXMcxob1wrc/hwzO/DOK+z1AajjLPhVvlcJXluAG5wozMb/MWJznYf+sF9gawHCjwPbd0yLyFu0ja+VtUXMX3p0ooprZMJnvY09EG6EOMDc5PkUx10vz7+FJiXMeXCDo0Xs70xcuq6jKgda9mpmvXON2Ko15bTI8axkcCJPQlrlJNk4bKHXtPAlmxn/NkihplPxVU4tU1L2VBudBrCxxFuZ2JuRZQ3CNKxQGOQdpLsSO7rNvxNsMitlNIIAuwRhDqXK/prT34uICF6eJWTE5panvITBRQy73p1b974f9ctJNkP6Jr7vLwFX0+c4I4v6a3j8mSzDVUzdgpqDyWLfb0N3dOXPSxYOF2itpwJ4cKKN7aM5xG+XUtKc+Xlj7MiYtofTbP9GD86QebbEVE60JClWKgpJXnM56Mb3EkAGHLdx4lMkvJ2O/hUke71n9NKt8odiSSHqRM2RFrDgMZlJHfhXocF3xgE62o3dPVN+rjCh+WVIoJF46CDAO5LJNo7GuPBFic6mcIVhEcCLVb4xjFyNrl0xDrfoRPD4+j1BnWfyd98Hnom6QpYKIBpTzOKLgUeAnYGLxUM0hV9MzfkzDSRVJNWXQ0/8EFqo8jzLyqu+FMnHIoWG6nC3CzxA1ARCoJkXS1tS/SMEaUfCnTS1Oj6lNBF2TEBVO0RAQopaXAI7MT0mQKZjwgusis/xl3VbuTC0R1ni3Gl2aHiCaTUPkl2gBjW0ffERYiJ7G8QamwecE9oFhKP93BvxD8CkHuFc5A5Y050AAAABqgBWW9aMttXJX3/Wdc7uPBDjoHOllJMZrNX0zCqBh4XP/dq9LyotRuwx5Yse3Ir1vjP/SkRp7VS/4dxkY075i+lo2e4X3QRRY+bMFWuotNkPGCyfKNyxA6NKBaN6vf5Q7J/07kqJIGYHRA40ASjebWyhfmenvwJUymmV2O6cwE/JN10m3hhJsgJWVPqbMHnE1HC/juQN8QpY+KxQICG45pOxyu6u8gY22N1hiyOLfKZD4PgA419mewkBvsfFSSNQ579h+q4Z89cY38PEwC/BRE4li4kCtvUdXB0rN0eYbu+bdyzQlU/nOnURnb0tX8LT7fyM0ISBkVDWWeEd4kDUiPDrDKtWh60THmi/EbedQVeLB+SnNQUUTdDkTl5kmeDWXJ9vsBpbnMbQwo3SWdp/yNcl+W/n8rEJh11DQKnlhW8x/nDEnNFLVMnkwBnqY6adCeRQDG4lN1eg+w81RUfPtuqIxzL12bqmBdrBEhC53bZraDCPHLp9tIt2uNhr5ixa1DdJkx2+AKbrLDeJklbUGsl4OjaunmJBJgT3zT3krivAfLz4KphKEBb+jFkAeJn8RWbY0Oi347gg2Tv2oEwilvfp/hsc5AhTdgLVXfC5Z/1QcU/CiPiR5U1Aqt/QC1t5NxXoMy7cWvxyNBBC3nCWNSjB8DXpdd/peuEmsSlLE10i4auZxtX2K7cW9p/FNEAFCFnY/e1oKAiUaCvq7SGBhofBLmCS1wOt1DDpWFVORdru62kadxVxKOXj1ibR8ogb1NNnNlr51+fWVLDaZWQgGzwaJNbcN5LUCf+j21ZmhDJrSsddg5mKLomMNCg35zn6QxPNxIcnE8M+H/AfBgD0tZYo7mPfL7zW2kmhSuAqoJxwrD212ukwKkaQ7ia6g2METEMp/Bdkcms/0SxXZ9vNKM8gIHIcziqpArfDJICALfibVm6EcMvYPQVqLK/xOgwRHwYR98pDRyv5ZDuKv/8sYrJziblX5F6ZCb5MnjZBSnC3wxPIXjUdut7yUY7TNlMvlIN8VcMqMU78okFM1wzVaw+1z8V+fjK2ZNKmWrGr+4Ozk4qG6ebZU+jw0WE6YNifJ+AWD2LHK+DxM4FPjvDqDEDB/lsL6AH9AMMRhdZuihiftIJmm4D5wGJStscEpWqaCfK72D9vgmBZ6MdzcnQDOnuwh+nnmQvqAGSETel+FYi3Wf5YsU3FZU3dTFUvfYMwAWUbanyBLrpqpZBSAQ0VfzKsaJF5jTpWIO9I7TK3w3fPwZaHthMpPLVxVYpAFp/S+F6ZA1rKGlQ35gI4d87888IPL8HnbYA2w4kCIjwQ1Cd/JaihpGnYDWrwJQ6bGf7MPVkZ5SesU6Q9iVsQ7fVpHY4vs3tmmDL8roDYxBIQSuYeJIV9LonZLy+g+I2FXECUizpjHUCckNFgt+29KsaN44FoiE2AiI7DIUKoXM2stTDRXGnwTDkDXD7WdCTeFEjawTkf5+BPmkN8+WxsrwBmZIR+HsT9PIcD0jvuPbdQB3lmMacB20OGRKGMaKstnu9g4yt3NuzHUW8rWONrBrRM1R/J1AJcL07NZtedHEWf9rKGOgsff17f85+jvXpSXdTyE226Hqa6mbSEX2+nok5Zxx7/QEaLCmkB+3UuOuCzSw85gKsEgp7ubBgrH6U+gByuu4m3AKZ8r+TA+Rt5MFZom4WCOOMbuJjs6R0+BaKflIUNTV1yHXGnxpf20dv+mhEShsNS6vyC75J6QOyRXesElIcAWe0VN9xSGT6HtDsyKjVhFlBPslMLz6dAN3dkL8TLEp4UNBw2e5tUT1UI293q5HsFHuVi04qZ61qxOCP3I40CKfVUu6xldMCd4fUnjGKYdAcxaTTeHuOfb+o4537p5qRjsK2YTOFzwNkbRuXwIHkKEPuui2+AQPj0ABz0lrIw5mEOoe/Z2RPAitBkhm+O5UIIdmfqOGw+gWVDEmlHAJl+hAxLSgwERy7QTQnKCm2+qoq2d7zTOLqn/zg8BPcPTcyK6tUFfzWO3g70HtE3EpFuHo5XmmTV/NFtX+7zTKpv6JND4sugOSA3Oh8JaoLdHB5PFhX9+zvumHwWDfBn/mi+itDYEWMX9wT8Lofe9uA/fGklkrXHGGzSRKJA5+MMNrKEGHv08t7wfTftl76GffwvOn/BWtpMFdeAtpdawQ9npYd9N44Y3DiMg4SHTlqKQKrBJ35AibuS4OPs7pt4LmacoMIKWRvzn6RxYS/Yd/C0LHrH2DL2qw7GOHJlGB7ayvIqFsuIb3x1JhnJ9Z1TZ12iVz114JxhFKAWcCANxIw4UtbnpflAl9SKr4VltfHEFAjwrwzOx0tYhyKc6hnjWYbuhd9VcdWZdFNlsxxBiWiL8ZDfvLV5LmvljBYiHoaLshK1z3xLqeyZuUHZjvz7Zv+cTk6nb49Xk2MTT0m1FK9iq90lVeNMt2Q7lmPvED4l8P2052jqIUqTTvFyQ65uS38BD8bGPtOIrwM1H4vxCGt+SSbEXRe4YRwdDLtr+wdO2NT8NCnh6M3oX/CKo63SQf13MZ+CnFwI7vcohuXNLSGO0VrYw4/CAvM0klW2exR+JrkOsZCPfwIQRz78gSIjhqXbOh4H/IOp+xlC/MeSpXisysUpFa7WKGYXTHg540UOlpNGaEAPUX/dNMl61XtHITKfMyloHHN3My51sIT/y23sxo5ENNuU4Ch+Vq1Kd9rELja04yqcrchJCxmO/Ptk6kY0oa45v912FjmvZGumAXX7x/9X03mkQ7XIJixpAyP9n197Xdp0QMgBXV861gd2LpBwA/KCLzccZWKTtuaOyNem7heri2OyOo6OY+7EOAngNngTQl5UPJRjrY8YU4fz7uS48itvbpgLcEsciM5bSo7VgGKgJzQeDxINyQfvNiXli2FK5EZwVuTC/GOitNHOtI7Ltf3mkQEzzjLQZgOv6MvCu1EWeIH5YaxQuNJYBhPp/p5OVBGT0zc86Bwy9OHAVm7kF0SncV1/4KGqW5SR2lxFXIonUy9aTnqo+cExl7Ok4NUPilSCwnZ3zuPoBvR4h3QhehCrXkWmMuuTzD6Widq8uX8F5hb55MpEK4SbU8DKsG8jIzMe8TBr/gdQGhw4ffFv/pOzcug9JyO9k5k4Adhk0sF2jh9NftNccDIGEt+NLdmeBebp+a1l8u2xS2iTgxV/1jFszfC35spn8frraTkMoxpIGCZFu4HizC/+2OknquxaANBfizFJ+m4gkKKWvvXWIFC8rhJgRagPZYq5liq87Pg8HeVlBCEUL6GnzB2HTiMy5cH8ugKFOtcDzH45GaqsQhNhJvxrETmbzpWt3EKZVmhm31nuS9xgJYAkEL5N62L2HUySoFfgmcuE1sLKS6R5rPCHnohpjcYPT9nGC03b5j/rQf7bx73bLC5xokAOEc6/Qph7KuuxgESh7+WLY+0VTAyJM3zgS/r7P+zA38QBZJhU9HeoMQJixIqbPArM+0K4swjLh2vTASBg1Jt/W8nIW3MSC8aqqak0dXAkeUOl2A4AB+CjhmwvRBGs/oP17pv5ZCN1zkSki/0rjrR70dg2xfwrqjw2WUPG2PF0fJmCvcyIttWTjfn69sdHEDLuSod9yMPPvvwD08vhAMFHxf19gQDnCHcKV6qyWof6Zwk9mnpFA6SfFAkUAAFGNgXcO/H+6GO2Fp/FjSmCBqFwQoOxWTtnDRslA+CCil9MpeiWBLsmpceC2YC+g5edDaKJDOg8hC97FqEiUNL/lKb8rwv57xxnK9Wl049LHiP8l0kIz97HBd3D1qOALbYNDASTmkE6rUrNkFe2aED65bBIMkwwkxgQ5NOG/8cAWD+C0SWHxIy24mL/m4PTY2B9E7Mf5Me50RoGdIiOhc5GEYOoh0BC6R5IUIpdFPTx1jvL8dyUO0tRpv6uyGy4L/hvg6orJxLMoVBJZAbSQFVFiYmURXaNQCX6yD7wqDyRCYrNMUz/dlUTBCGGIbWE/6bqxOfi/Reh45kB+tgYuF7Zk5celn6iY/jxUxEY5ceHDbxPQily781iBdnWVCEWy3JFld2fLkSiho4muJkHIw323IK16lb0NRFSS+/LNUhtpryi7OTlMUCQeFtHVQNMVJ+iK/PxfPU06HoJlLlltGAC6NxRX3Avco1iFYJDwbT6AHRNTqj2VjblK+w80bc6ESM7eViuk/UCSPwzJrSFDRaBDu2+WKI87MIYG06DQmj1WGuSdE+xUZBhL9sC+4Idx7DMiJ6bvzBaEQuILyStQwAqqgPgIzilK6QE9xOtkOG3LUCoC0a1+tLvTGUWE0ud3ZpftoQ/RLdlbZN1MtlypeVAxZq0cyhGbY7phWvEvqz7ulOyDOAgNMPGnz7mG97l7dbTcPIzuV1tviSrG3vDLv3XGR2rjeqh+DQFUqpD1LQ1rRG7vY52WKgeO/OTSsSYgAPNo6Pqa79xBAk5AV8yNaVZXy5hReFWe8eOjVD93nKpbBBSyMVt2FC6zt0CBnDDzKJAE1BgdtXcAbhsWvUzCv4B85gEORf1f6GRrQdTLqmdBvqsD1gcKf1LOlSkRVwxAGGpJKDxse1RQquCEkzD06twbwF6Q7MkYj+/RB01MrFFwZVSbSbEi9tLBYNFu8th8+1ByxzzvQPHWsQLyCciPArZ8LelxC1wD7AvDn9GQG1WSRnRF9cgK1NHfUBRcnzMvmWLJ0y93bJDVuz2ZbgQoIu7rKlN0ASPmNUFwZXJb63jnuLmteOy6hf0zIQVS4Vj/dKQ4VUuA0MGSCwtoHfdv1svU0I+En4B7VL5k8jSsq+Yg8xqLzW+5K4XhWDF1W8pryoU5SR4RalNaoy3Mgnu/sF6gY810uU9LhxNuIXJH46FPRKdyYlv2EsJpdHC0JRHAh+/PInXd4WJLpLrdONX1Gjan5clkpoeYoTsClP3HJ5m2IuyjbYphOLZPTUT11C22Z189REWxDGwPVfeJ3H4CuTkGJZEpbu54gAZKZkeYu+ixaLcXOn/I/lGi44MLsVA7z/MVPPfmBvg2KRZg9ihvwSakQepfIOqbTS6Tc9vRwdRFIGKcyi2yrjlIp4fnIl4KZIbSW5eRlADsLei9mNGtNRKwmOCua2+XpeiQGrcb4pa99OwS3rtuTaovDFFE59U5tI/SATuiLszgKoSx9+vPvhWHEvXwLmifZTwvxZO4tIH9yUTLH/htihZrMy7zAfDTYbcSXbKwGMNtAIYy06IZlFmlH6WVVq1ZMhDeQPStzZmGiS1trnhC5suBppiALSUHi4d0bmybNmYbnYcexwqVMAEFc5tC/HClvQU/TYQWwJRPQbScTZVBS/67A3mr+R//OPUn0L1B8FWmJyU9WM3v8v7eOSEUYd+EMka46NwaLkouPEuAvHOyoPJneV6Kq0DMRBE2KRBicGf13B591eEm25VQ7dXDydlN8EwpW2C5U63HVx2MmS7wnfyf6tpf/B6iOiHqHRrGBiO4DsZoiamuccnZsxBCw1FGAJvCEFBYMtQ42RjP2fV/AzSoVziDgaQuCfVKuFHro2gB0bIXo1ixTAnpcQu8LkrBqz1QNda8ffro35R0k0kcztu0orAz5BGx0T3aRaDvGhT6gt9Kd2zvKyITt6D9uT2ANxXnMLbzmCdwhIxeouWbp7gDk8xUctZD+cmpKHFP0MOnApHJ6erkzq1DKjPXM6AUTie0HoUrgKqCctDGnXEPFITPr7ahWRQThZrTBGu8ZLPI3vVSLJsMP2GGJAXTvTh+MnYD2eS7j3yxvMMLVXJu69UQfWtJkhqnmSeaKmcGhg10JiLbJIlnV2tREImtXMUercsnTBxQ4lqOZ2LaDT9EwWon6BbZyWvhwixSvdb+IiY6YU2eCtUwNHI/NEsXDCrZCX69POeGFMhiXdnD2dyEYSqPYPJmdxOW8IVDKCV9U9u/8Wu7nLySNIsmYno2yn2ux08yVUVazAWKPLz60I2eRPcLS6NCaMRqMiTmx+YEqE3AreSWe4EARruWwjkGJYxml6+vCCBHYQedoTLcHZFPG8Y/OFZSXLiF6xaexvXBxbL3Mp406NEHWdrSgKeXLo0vO1fbp+cLYR5DsrfeF020wC1AGTF448K74QICM3qlBhrhllcOQgiELXEQqrS+TULT/7Lw0C8b/UsNo1vMFA7e3UnCfdBoDKy0+bx8Dsl1Ykf3MPQUimf11X/Iu32YW4JaOorbA42bWbbwG+ce232lvi5YluhOKtT0OMwGzQm4/m4CfZ+3vgOKaECHvvm9iKm4N42AKeYbt6KwwBSoRkcxrGcQ6un5bDukRKhF1Gxt5nhbGZcXfff8+itGo+tugxT9EUWNQ2Khhw02R6wcuJ9n7d4CTp4HjL8SZeLp9Q5IxlwYuTZ18favkLMzJNNmz3cyHaJHa4TXwuPeoD8at68WGPf9NCFmQ9WRMV+R4udifpuM498tnwjFqghuVRgu9udmA1jrgjIY5u9KHN00ikqL3YVHKjQ0UvAoT4iySKrgnawh1gRWzyYYJy4iyzFw/H+2qO4zDGNtMg56heM3GW5Bhc6Lv6tDL+muIebT0MFHm/1FzEUCKEgjHm6QDMFgajkLZ7lOm8Jzy2qYjW3AAJcLatluzNMe5P3kDwRY9i/fZ8YihrrahBT5aP3Wsb+vAM/ByhRr+ptB/2RhXfX+blZunzBSK2vcc3OC3FVQLnqV6h08bDaPE8/JLKYViGJEUVegSdJFzs4ezbSnUmnKSyhytLVj1PEhzx1CBPi1w4Sa7R+idB470ZPoc92leskAiturO3wIdubzEovxXOQIVps1hFy2YqaztkrK1U3spLm2TPRWDFWxaH74bRI8nND2UGEDpQUIZXqU61CPHWy9Eb8zI8gWoOrceat9uPbFOhViznhftJSofSfwgIUFNySd2H7QoV6fDe/4tcojqM5kOvWSpIDyBcHL3xp5QSt7PYZ3O6gFjxn7Bs8CCmPic5/s+EjEkPva4yLqBWfQlimqdbD8qE9CDu0WFhpGnrQzZRaGl6O6rCMNYOTfkJYN7yHYxw5HarYBUi4RjjD9TIYl3Zw9m3RXJ+XvKcePR5Lc0oYFALJRADVNQLR8oPhp491l7J9OSPf1Y9zF3DiPZGMPpA4lP3TOkDGu0DxS5F0AUvnMhGDI/SL+olnEyu35U58FPyB2o0XeoYjPs5sv5CzmRNh3aPErW4cDgGvzmN+dyIZMEB5MEsG0rW8HZdpkQVuUg52D1xuzkQ93frb/KoirnF/9+PYhRBAAfn8H9huT5AimlTI1wyZoFXaW4nZlBW01r+O09lmCeK194kFUhzE2YDUPD/ks9YD6aEo21DHglOW3aGWq4Q0W/y4fDQqS0693MZAdYxXu1Z+En4qLvxumbs4Y1ZhiDccv+qEHkPOxQBVrreR1T6BXlg/FCbqMdHRymj+/M4pm/1LsE69Ln/zH6iHstchJrQIPw/eJSkW1BSpsF+eMjEDatOaFNmV0OTOkyxQDEShwsJabQMwgHHEGzLz+wNBvrygzjv1DeoRVTuAEmgdXj+FXK61bX2nazheYI9/2v+BM/P9pK4ugHPoRsYqD9c4y1qwIglpoAps+ncDlRB4hOAIeTsVZVJn9wLT9yv1t1yXCvlBH2VXLoTCJOe6BgavVDrxWB79q84cIG6oCyDeD5hs8h0IHZwMsfXkm63b8B7bWyepm3kb4dLOClZhuUeDxC2kqAEke8ifadIfNkGvlI97w2v5Spp2h7pKND7UryPXNb2igBompPnblvxSsbIYFODVaQqqYmvaz6TSgxeYG0w6L5WT2Vjo2Y6UTGJa8eLuWf6Pef+bHzFYXknK1EQSX6MsbrRxzD1Iv30FfulcZQEUjii6kvE2xr61f3qoaa9AiSZ7jTG5ZAb2g4IBvjU187GbXSvof5KwDU0wMgkbMWxfVgDlGPo3fcAT1Pbw9grTzmGGh7ahlaHzxZmTh+UgZ51r+pT+s21I011KRfbmcF5MAidHSS8ZNO1r2pmGyedAQoY5cc64WGYlX2TcuG/SFuS9z9f4yHBj9jf/ISSbM1PwgK1ydMcaaBYr4Vy1cDVBNAVnicaAjeuAadORQXEgi7tYo9L+bH0HQKwG460LG5mA/Ed36TKMLlimrIRHfkUslz9QMbsIWuhpNblCGDvQTt5BzsGB6q2GCmO4wc/siBKC+Ktg4mJj+MfrbtAb5IcMGF7iedbH0SraWjTIeieyZ1Mn2TnG5EzQd170X/BydNRI4j0s8uz83NYgnkOmide6Hujvfq5o03vKdLPMQe9p4rqQyvgj9ra1jBYdT+LEE/Nde2ugzK+oPvry6YQhSXvFOWul9fVmWWAUcWSnd6koYLDnU5ruEHOeFitYrc76EfRlvI6iYHGTXAeM3WPtyBO19U8XOU4HMEZDKEqC/tQxCA4tkStbi8o2wGFXESQgTT4gVvZv02Q+07yZDA9BClkb77YQF7xIwHR7aOXsjpJ4SraPBkvBB7OxFAypRK+fSKkFLDwWnOgG18/N3L4tXxgTxh6obvV0nJxmReuPQj6R2IEIMfRff+OJOehoPTS1k28rMnRX7O53ne36H9dx2hfxAqixiT5/7qKDb7pSIWcz6MsazR9vmsrZAyMj8QpvUDafe4DNQXzFdcJnpu2xAN76cdtGnIlJi+F2nVMNWXZ7UfnFpm1Pbz6RYOeXNr1EnYUxnwhPTo00iCrofl8dvn4fRLBLwexp3s2FhBFgv1Qfkv3FiIem6u/zCx3ts2/uHI1pyWoc8o69TKmsao38aABJ5XT5sbqHMXrIQ29fDsf8JMme27N3LNmgoxzOprLQikw87FkGq1oQLJcVAwky/lPS5P44jZtDhHVrCdxaPjW0ZfpMYS8pmGWSZ4mTUkxdcoH9tzTOHy0YHiV8xzu2210Z3rEGSsvcs+pL5gOn+5koMgY2gdwYDCBALubvElFWmvBWe97XLJ7vL0ftUUOgpftC4j5ywKxKRpgXzou2cmOCMxAAKVnn/doul4qSoEsV0OairnrS1ZdqJsmy/ZNh0xK4iuie9sQLMi/Va5WU/6V6uTCImg4XMY6NZaHcCgwNFm73RYpHYbDj2OFSpgAgro9RiTp/0a65waYHey7MtSyHZkeNV5GsxJHuB4qEaXqfE7/xT6ZwF1xm6nOU05S3SFi3vGLgarjAN+kjpI5CYrVDfOKk25GAnlfe2Tv0CBLZAcwPlI1gcJnofqm6GOscbGJesOdH9G3RT36TorcJA3iXARoI1ZJd9a1QtOTlhP7Ddh+Wr7FmRQd1kHNMbnSckYbCzrdJr1838nRmKxpR6myRrKUxvA4AefQ6510Nn49M5R4OHP3TMhkvU6FdPttlXHDCUTq3MC+odVog1hwuLLKyU+Fh4iIg7i6OztdNVv3r28fZiD3dbzIb+eo1e39qdERTONkcb9BkeYvEoJYe/MT9R9bJSyIQJKe/u6qCB0AIoFuaNTLvte5s3N3MvQB6k46CvTJI18573OtyihCz3kCKSZeLS41FhN0X1L+BIO6sjafjyGpy+6xBSj6Q75gbg9xS4v1QLCq4v7WaCgh0l88Xc/o0RyQ2kFfhree6FrRwvAwkuS+dkwYH2Kr9YSmjG+NZo/ccpjP53UWInk16Kg1xMOHvqRdeIir5khUJi7RoaBX7JJmDB9Nb3390Yx+0My7wlfqgU1E/y9ZyODounSjBDRTLBgECRLIq2wocY9MkbrdV4V61mE/HY+HvyOOYYD7nVpT4smQXdKLGAqODUSue8L1gMUjxv2A28sRE2CaK0orc8gK9/9iha2CpsTJE1T8d0UgPbreonWITq5acviHeekzf8wP1fWfJBNhL53t6WXk6EPGQtsULNZmXeYD4ZU/pGPTkbIuvloaD2Iwp5SXSEUQ5F6w50Z5U4Ge7xj/d/0qLA/QLs7Kg8orlGmTBRyWHt+bNKhV+BB0A65XCLMh6aen91NWY4jpchLB13jJM1IgoGbSr4DRldtv+4VLZFEA5OZNZxlE9jDbQCG+XokBq99FP3Xu/e7051ytSXCop114jmukj7H0aaDhcr7C9ZZWPP9c495gxFCuJwrET5+i/x991gql7CxKsF7SD2so8G0L2yKsSRCcK9zNawo+krk/x6c/l2DrCRA2sKcfY5gnqk8hNx7vVeg52/H2oGz8N8fSjoBLWTkV8Ot4c36ZkIKpdWucGkYCtbZojvtt+YiqoCb9wEqJqt1f2zIM27iq34ADoCWCsiPxV3b7MqotQLoyDH7jT3OpJKZd3qvFzkEhrvUenEpQpJn4bJtnh08TQOeDJ+FzhpouKHVFwzpHAKPBC1EL8LiHiQDnkiJr/yo0QvHKaiHc+ydv0vpAmg6idqJ717oo1oDltWaQcx1UTY6MX9uVWryqVWmOLjj4655AvJl9ajNcmrqqNbJOKdDBRkNVP36nmsZjk4XnHTmWlcKEYSYSs2aQrSpyISIpQLrMgot4OE8K1NlnIe4wtsreYdAs947fSwhVye+3jUfErMPftu42Eq37vNtiWdylBQFN2Zr/QPF0cWVAsVdWgsqzZy/tUImnPVHYi78ruMb6WEKugRO5elOJsM5maFXuiqZ/rp9x7ttLDoJC9bF54fS8kiwfgg99+9VpbaZxETVC6w/N6geBIER35FGFq2l5nTWe2Jt8Yufx919C6oO7ABPoc802TZPU2hqy1pYJbCyTsCfhKjMWADbCChBWNlBMxpA7aBC8TUeFrRpz/ssJuWxCHyLU+s+8y+oyCfejQ5D/+kLcl2/NGmOAazUmryoaQx6elQk/RfTwgnIXkHSjvz83vWRANqqWSfFimbnCGB4pR6wLjXpXGoehjeEpeO6pRF+akttPg1awE5czm1ev7B+CTeKAbuqpifxKgPnOkyaWkDuIwUvQ8w7dXmRIlUUMUudJhNLE+sekKJXT0zA/pcUgPhHkg7z4yzJ2jUo6Qx1Q7GmdAfo9ql8K3aRr9BJ6EYMXapEPdxl1PVae+gUGntoF2SJrq+YBdBgyRafFHlSpI6shD88vThokZsIEpVISOjuu4JZk77TeMSsWL2TvUKIj1ISelLzCYEr8jRJTTc++j3KtZp0TZtP48apzON8WD8JYk6btndLtadhvowi02ltMkbLY2ZYgJpG+w2cPiq9vULujiBqdggA7oiv5Uhpg0xUdAygeq7Mp04vjC2LmijB63T0Wrxh/3dMlvCY0lNEDcD9addxP5thGQ1tVPPpV8xY34tnKP1a9xkXQBS+fOBU9HLjHe5FzGMfpo6kBupZ1o2rX5WX9a4+tJEPHCRvQ/EFGQO3orMM7CFc9aJcLuQZ6gUN80QIjvyKMLVtLzNvzTLDOC/j6zu0bwk+4nhZ7me3pEpMPo3AnUVgr/4mHaFo3CPuOLTPC/7L1zaNsUo4VIpcFO+iyfDCkZ/Xnh08GgvHhA9s5T4u7YZ1iMmeXLoLnxCwclBSnPyr3SUb3y8OECCJPoloyAiGiAdAoMoGftPnX5wffiYrzhi7DrpORNiKletPg3nBw/QU7/sd2+mM0z+nRgS2KFMiOITSFc4RquMTYPeYzLV/4ebWNqxXXbBAhGXpuLXwDSATEMr1vkrBTLqDIYqJkoyga6swnw0qfgNmo/SGsP30j2mgKEBf4wHxuJG/8+aLPlCXF+HfJfwzGocwA2Uialzjwm7TZy5f3G5vV4jw9MAKLbdiQ15XT5sZkOkqoj0Lam2Awq5VRYI87z5Tytx/+/wKhSSl1T0wAtN9QVecGwVhWqPB2KT7TjHUOVPEB7u3mDQgowVySlM3J1RJALfHAfAnjD1Q3d/yMt+oofSFN5HvuZmaKziIS/gAq8lCVGcaOTwiF3GKhz2+fFm5Z+j+1QLhpyf0UE10CzeoqdTKXPaO5IxFX6jyV/+TQezK9sI5Z506G2v++JRZLzpNRa6ljgkxqKmG5YIgqWcNhqPku8FQldq3xODUT0SErvcm4xyTBYN9ejqp/tPyyAD5lvfCUGB/8rPrGBAOG70F7b7+s8AYaOIF03YxzdGoBfjevMIrn/HO9IdOyOGOflkHWOwgOzDOlf/1kgmWLSYKx/N2wZOjm/EzUG5T7UXXgSQETgOW9poamXZlIfJcfqpXWC/nz0aeOVODurKRS9Qo0TgpL2NAqAS1Bi92lxxCq1bGKJad5+tG3CyVjHhkdhBTRTVAYKsfJOYyBqqUhzbIqGO3pZePzJERB3EfvL7rEFKPpDvmBDDA62w2UZbelw6+Aad1AVqukMktiEKIydGyopxXnHIdzsAw93sb8JG2uW5BJb9YFclPDAYw4jJJIxdYnVMtgAZcoVd386fNE/2dNFkryPEli1YF2UHaIrZzVWlZJYmJ8eWjAZQqY7W68lmkYRPZBw8KDNEmv96enlcQEQ2kkiTXF0BaSyI9euIMXPYmXqvtr/lw5TrLXThN9woLeE8KU2pJ428YW8gm+BPyYprsANV9hetSSg2i2xvmEhLVlSRKMXd+UeOxcPCnN0/zFqL5GYipTMPDIEDlB0NsrHDCMk3Un87vvUXYluIWzF8dbrY3QvqL6dbo/ouKHpzEmU/rZ71hx20fyhNV6Ex9U+eh5llCUlTkyViSgv9Rdd/iNAlvfMINk1WQuVEuICwPHXbPLu0QayVhqT/NBl7aiHna2nq1h9kdmgeoS0hPU44NHNo859lBB+2gzcD62SpDb6WJWyBtKUS50vaeaaBB7uHXINoWDjvZ1pRxQZFNHYgb6XDZvN3Kwd569nAT01Uit4R0VXIQ46ExIXlcmYx9UTpFw+Aautp+qXud9NIK4DT4D4anxHfnEiVhSTeqW7d1zlvZXgrw27LNyKlBFDbT+Bs7PB4lQg6ZTdJNlSxW/LRr/rdHWjVHTZNOKgWOMtr2GAPeV4K5WBez0ZiKa1I79mBjSbBpU/BScIABAJpcelavicklZwDaS8m8C5+AD4yJCbT7F+uv16S6WwyiXcHRuU6dyKFvpBoEaQvkB5Fx+1AE7Nmhcz9+y3v8DfV2vrlNze/1nNzbtPQrbdDkWLvjHQCQBUaiBx1GRBHSyHKOzJ7k6v9YiOT5qJWExwWIfcw3qgJBVn+2acWMaXUdZBvGum1Pmy7AQHlGVPa/obuj9xejygrDBoabel/cUCUK3YejEjQEdPOvFuUy3spPDaskUaQvjK1LhV2TAIUB1ytcuZD009P7qasxxAIV4zwAne333WiKZcKf445em8qehCg6P5ylPFdvn0aIEmEOqGf7K5pJHVunlJS4QA017cXEwNVd6cHXhx90996fvmSe7sP5dgWTJTAuk051SBN0JzjANu5FvKTSQ0ygsX4tZsNtFLMnOHgwd3YWgrr+8hokZWWcL2m6LkNZEYXrPOv2ClkYTPV3uVaBAFsHShkLKoMLD3slAf+ceFKwTsoTex1MPbCl5cuci2fKjF4VscbRPUT/y/DVQTWYm57CLfbOSTfSRnjgERCAWCyI0UT+a88bjCv4FaUSdKhk63+6cjc0CwcLKL14ck3b9ksEq/IfblK3O0rQwMq1nreTgO/jaJMDQ+3Bp6msgYO4r2bevzA6ur/iqpWzGBndWzzhp6mHRTYWoQGsPhuXPCsjTxOCslJ15wsjk1n+i8Ovrv4gw4kaYPUHufGH3CX/PuHY6q4dpf1mS7g3KHjjWUg09Q8n7vos9Lp80nqrvg7PvroXpB7qiif5KrHjOY7qY9UV2LnrNgQ9g94j4m8d/uJWPER3dhORqbYQ8JIwh7rz9Vh4IE51Na3rpN4lRgMrJzDWHGsILiWMM/CHeay6PdTTcHAq6gQBuJGKG2SFQGEhnuozM0CsDbJSLubTtbgKQwVl4gQSxonE4zMK27rlEWCLFJmj5Dx1KS58E3OVRYDmF8K3wXS5XXDHCq3mKB2IoKheytJFvRRcZKgdWsz2BG4cdeFh95esnbWAnGRUbO1OKCJEP6QBgbTSu6d2/QIYbbQI/rcDnJPcrhKo8Y8Euld7XC/9tfELDnapHuYcsIAAAGC1NtvsQqjw0TKMAJUgV9hVbGC63Z1EO5m9LQnuuZNTkOY33Lj7vqGffUM++oZ95gTbquXQOGpLxD/HEllkVQ5fVw4mlpQF7VPbyn6Y5wYVnXDpJYoxDLgYUfOiPOceNqr7ot2c6ZM5Atx/MG8dtxWoCR3mxOJrG8QjWjUXOw9Yo2Btc7ajMERYFOmYumAh4QCy9dW/+n1bXY6FLpsfe/SHRvcxtCILtjaif/fB9vPqD0rBQKrNRc3kPFxFCfmaBXWJiShRYQ6zfgEtS/oisJyB86gQN+H2O47e8mOiril0lJIj6q481fnnO2TncdF9xV2Rc3VB4XldPVyels5yi15JrLKeTdvF7dOlZAp7BZV+hV3m9/YdQ+u0ola1kzh37VmeIRDoBJq1Tg6CmTEZNNa5CKSF+hOd8uYVexcPR7A8XFH0EV2I3wpQ56/oUn2kHiehuxAi0D/IqFi7zGocH0RCcEHrhyu/I0KW3nv3pn7ELR10cXhByPjOyRgfY21EZLtiaaJK3/0xaI8iLMo9adocfc29UjB1rv8ok+tx2PbU/cH30pAOg3HuBn/TMnTo1c2aWk9SVL632g3Ko9IBbFtXAzjWnoM8XkMlKqh09yORp5NM/DTdEQM8wOCwxyHPSDgcFl5bTPTFeue9xpKV3afYhmVIvvE3ONbQf8HKtEllc3SqiPAXQVZ1qwriZ6IGzhiTm8bfP793R/JB2aMDmt7mCqwoTCuRuNpQB3GZCJusYMvCbyxDvG4sKnNEuV8RGS0+zT4pU02RgIaPOeDQxGQTb0q/zvmUb2TChr8Xml9r8lmdwblGsdrkLHE67OsdTiFLMSLPYMJaHqTgdMbXOqtoFzlmgGXsdABdFgtaCkf5zhC8YXuBhGAdF/wkUtd4R9HTgn4wMRJ3+03Uil6MlGj8uvCgSvWTQtTJVydL95OwxsgT/T075ug+9OPVKyKo17eZhjRQ3eRg2Xy157W346j6flF8e2GtpdGgy/+6BZZu7Qrzdf02I8O652fQgyzOQpCu6z9bG9jwPWkuy5up4UAqXrxwi5hetZLpLeV37i83MEVpnqUE/xGGmu/yz69GOdh+oJbJrgqP8IRPTvNG8rSFd+abRRNA/QKGDMeMWimdFGWLrF+wtbpC/83X9Nf59I2ne95oas0fe2ahfVkSuMJZISARcl95iVCQuAJH2f9XOTF18vVt9ldhjy1CYqTNZMJl8ZBX4lJ4SIivikLRYs8/LZzR1btFefag3zZoeIJpNQuQmpix9RoGVcl95iOOLCk0DcZvF/5uvYZOYNhab/mXfSaN/RuMlzKraLA45uv6bEn5HS+6c11/Ta9Hh1AUqi2ovPJ7wZtznMkhbxWHBCSVcwPwk0+V1y0tBUn1HoIlb3taYUNLLmnu6XMQe6Lr2BY1u5ELgbwtrLR+wnPD4AxB5U0lBa8hKfnQgKYskQbx3g+vPLlY7t9MJEkCJY4iOleFYfyGoGl/qBmBoz0uBORWC31blCarlNF4zhWprb3AAxsdDD3I6zluooakFVbmsH6SLRR83Eut14l1cIzHe1ZxkX7Se46H3oofL7117lIh08HeiMPO/ARRcBnS/7ppkvgi19YyyvWMiBnD7c3Hqi1qluBYtY06wnexTWVkW2IqRhTOJG6DeEOIMa/Dq30eY9dVkcp6TDtJtpJdMctwz+1T86GDr4oPbmZXw1BB0X9YWwH9lbn2Q8h2UihEKUr8nwJI37WVlqZ8I8lwgn7TKo5BcH0GH50VaCdnQEwtWRW5PRbu0xxqfHV23i6ncD4AgJKMAhLn2P1ztJBySpy5/PARy4Pg9NB8Nt3lzuSsikmpdS55yhOV8t7SvoXy901hcGlTPZb5d5kBgSloL4OwpRnlDDfT0dSJYUEn/LJNbIf5S6rcrTmqv7KI3flkDz0ctnlIg7HIJjzmxAZ7XXUt4MZoCEM/E/5ImNNFYb+tg+XsemFij5U/p7O3g6PIjCa8EMrTjMx4tIkoHhMIkXhOCzd5y8K09wQBb3GoR1IJsrOoASKrUtHJ2OhiWJS9ws1vu7J8EN5XxdWSWX5+UhZ8qREI81ZZCQbIJPlvZW9fJt0ko6KJF7/J+WdnHc758egPF0FCbIrkgi0eRXtjnUQnfQtvVry/v7p6I216g0YZf6vQZGKdnIdSSDARLu6SfczSXk+NUmXjcz0r3APBGWaYOF1mR2Ur+dV10SNr3gKPMl6eooG55jkoweKvG3M8g/cuJyVkq3wrRamzhWr+yHgfCq5x31sxDD09ZjUDnfyWFBdAjaVmYi2bJiyppatZqvMq5CNxNcWk6Mbj4VpitJWiFVoQThx4tAPy6idYIubzrYdZs3/2rxlj7jtZlxBxz0t1rDgeZY2G52pkYqLwNAu1q8/5XdXJ8lR09dR0mJXCpTkXccbK8gJ9IArflYEf3FoldPi3qd8Hakx2Zlt7E3DHY3gcJCWNG6c5c6UdjXvfGEfBN+x/BySW67oa1zHDkPO3klW2WTDBmJpX9+T5a5xu0M+vuklNOj6KW7lVWf3tsU/0rGRI04nieiDdCGofERUrP5CIlJweK5aM+JNX6lcOZRwwIcWsfB850bYoLzgxi6p1UI05bgU7WTxjDOFhxOsKXnafq361qs6+x5YqaBepLIFEr9z+52PJaOkOy6XeWx/vQ4CxWpmb17D0WvbPWQ80ATpBXdfYLAzsGGtFxoeuZQAMQ15ouPgtYq7mFr3iAyFLvw7jTTHeH3zhGl3UG010eeNZAgLwHS2LDJ4TkKZmYJLaYnpmzv8/UDm+J9d4dHuF9+d8yjeyYUNfi80vtv8cDwU0+OIIdwvgb1ep24p6/bYeoMlsegfbekXSxU+/PILbyul/yXllvx7ySk1jWhDcmZGYVbUAnFnoB5vYOdyBg7MlZkjLzlE91NdD6y94pNA3GX363W9vgDFbZlGNAKWdcj4J2y+tVOY0u3KNFSnhKOg79zTgLMPKl2rUmpxio4lKTGr6/U8vaPVZIWarXIsLadZrYOlFyb3DDt4QoOPTfFRY2zhwBJ/5V/vzFvB7oxMhdkBba8MECxQ/tFwNlzJmg/Ypvs5i9OMkn+IOCA3kd7i/fQzsbLUtWxRioMcFrEFGLJPvfspGU3E3A8esvAwyHm5HAPK4TNO2ZcX3LZ59qJBMOfpbI1rSbeA/dw88oDpsxH0iWEHrueaK8+1BvmtJdlzdTwlWQK9/1EFBPfPVODhJE3O5UGlHKNRPa9vB6EpxXxcKKtJZ0iF50qShrMpdXwEItjfyboIIjGlG9EdopcMPLIr4osoq2uLh2vVr+mMd7rRzGALs+bbTm2vLFzCY/ezubxhH4IHYgkv3Obhy8N+HsdXfK2Fa5MtR+L+rAO+HBMLMF+NWtmyWQIkVfiVO6JgBhryVJmd2IiLeuu60PL+Ac1p5LEG0BeeZZSaG/boL0a4jAh6Jnkag3roq2xdY7nlAuCqurbJYzyskoEwOYETJ5sUdYSJAffnuE6QW3ldL/kvLLfj3jq5fKwcFKkeLSUF1qLvGjX18tFKfFPoGYsAtCkYAXAEhv1u/sF5DXSpiKJ29Ku7ks1JdPZF8TQybpkpD6tzxVyylXHjuDIJKd3hlPRtNETS52N9IYoLYD8al2jhWWfPI1BfVuuXJhBvpxEuQOs9GjvKs/VABMNKyd0Tc4lxjAAGHe/LuH2C5VvkLL1bYGqtUCOm2BZDrINSb6ahaoz8Rult4aUOFG4DQSWH7F0tUUCqdF0HEYMnZm6Yfxgh/oM6i+lcvkaAI8S8OYDkAaTPD/iz5jvrn05HgmRfQc88FBu3DDtPwfea2HJ2vKKczLQuwLdh6GeUx8sBwdfzyRB+kfshR9rqHGDCyfofUTNldfgougQJDGCEVQw5VCozQ5wEjue5Pb12uNkdUulRPO+9k1Ml4xtBQpY5BLymQPFB4C3zvZsaFDy0w4hfP6qdxe71tJuWlT1egy81V9TAIgA0GKauHWK3AUlJNOtEZy27SbATMs/r5jBalFkiY1hLnd+vMkHe3W3Gh5eQoQNoFgDpZlpL9kMi+cY1HFeFTAFsqphzMFdz9YuG/DC5WSFg0DVcHDW8fkyG9LL4YzYS6lb0UU59N2tmWLpgMdrLLN42oGeye+A57Fg46jdRBAh3fW2RfW3yeW3xFcgg7Qe5pHonXO3Ho6wuPJG8cBHTah4hJGCpJHyY1wuN0u0eL7EF38Jdl6dfYKiTP+s8hs/moBD7HY9jy5FH/SvZZogbLmTNCOeE7oekM6dIUe87i+JbLo61e0e+9bR9+C8ydCrRoqoE9xMCUlIqw7jkS8kJyCNGMKWMtQb7jWwpvkcNjIu0Uq25iiiGhnNKy5SI1ZVj1AKMPFJrPaQVI+GbjsmJF18sU85C6legnv8fn4diBZxoMLkgzaDp4XVM0/Y5UAU2JrCzuAvbuy4IhzzOBgB9ZQwZjx3ENB0M72wzXJOz6rIDebbgDsSUihEKabvXA8J4boCng8Ua9CVSdljAvPMspNDft0F6NcRgP+a52fbik8i7wBSX4tS4uZHefBrow9TLyToWykRMQN9Fg2e1XdqiNF+27tIIP0yBt9HKIhcvM3JoQnM8xwH3nHBl3seB60l2XN1PBoSvJ1zDLzgdlDu7B+XEyPyB15k4jB1waIq62tOlZ1zzwiZzdewycwa+gn0nk2FJyKahOV870No/pBrfchK8uZPhVSqgzdDmrFNBF2TYfXF66OqR8DL4Q+FBhn0nKyGkj8vTVaAMvdoJnvvg9DP/dwPDRqdRaocpdPJYQ9eq/pesVCu4iI4JQ0XTRMZ2tH5KeNaKG/4GEBLERQ09MQvNXapDnw8kGrBizyhyXu7pL1M1JMMIUoTLTBM/iMIvd04+voJYdPngGdCM3tZn2wDMp6VeTFpaLj4H7JFiG6bF9OxoFBThEzyamgtvcR/9RcSG91XhTmKhVTLpWxi88FwyGjibIhSnOYBPbtIvZpankE0n/MLyRgbBM/0FRtldU3n7+x/sYXX7mZV4dETSTk+5l/ojWzRvYuRylryciagQ0OPCmHNftynr4fj3XWqI21wzXvBoPKjH5qUAZ662H+EHPU/WMVONYd/73qp2dfckBo1ntZGJPkV9CqdINvWDdmEyL0KmlbnXs7vxR4WGLWy85RPdTXQ+q51L0moZKtnRtjAaWwj50PuedYJVdKGi7oYT6rSXwcvw7UeH5A68yNCkry8ptHSqgVfyf76yRrcWClMJPrRunsRVtAbgdb2/6VN4Cdy0IounLZlNh48713clvX/SBxiGXwlbu+ZcysKOjuLjwem7GhDuhF9m1XXss0tIaAqKPNwZNv3wfqNcVYtdhjNCC3MpUfbPhW9DnWyMfSi5UPj4NO3lhmZLs8fIQ8f2SkoM63bC43TCWiXUYlSFE+bYNnnyMHmC9H92NggtnZE7+lJcDtib31llYZjJx2cyYCl/UDuEkGZFB6T9GZkZIOtXWzHU+qclA+jrB/rI4hmvHyKXMcyCj7IYf+8RTciRGUrjNXxlDBSUEmFCgFRa6ems2oC2VqDo5Zyb62Bf2d9/RTP1tjCHExa5L3vszuctruUkeS/Q6b5yV/n0vZmhAKEfLZmNtPgi+On88E2wm5BBjrorJqJ/U01eCIOnAWsfDOL4BvOcRPkgzedhr1f10Veet5eMllLAihmvdr8g6ZDaOwaYLl9MU0Fl/COAW0+wAAAAEbn3lNGsp2Ie6mRwHXwigiWICefHwGjLn6spSvTzb6Eeggxt6jELi3BPckTITP24DYabrrXsQ5YY+3L1qN3opXcdZt/JdvL1sKFJpmg08YloNqK7idfWeNOcO+s4iW2xXIsCwyrs2AhHCi9Wm8SavRx0Yi+d14c2VL2HL0eQLcnSfxXakacqll/JcBRdgf3sl9aibdnhCN7YQEmh9cJoS6nLwLkATYi+Fsm4vvDXnADLmaqrtv8463yH0OdpA/b7zGncYqPvqSQOlc5SLo+KHo4g6eibp/XeakKbDp6brB8YUG/kI2NPW0YkIjrSeo7eZYoTGmS6G47dbeFqJ8Bjnftb+w9ePwv0JXWXG/RG9860oVcBtNXrrqn0s0sfKjVGfyGCwIZ9Pdh4s8Hfny+pel3aKLn64pf8neD2nWJLVj+XUdAAlT+iyzVkOTrdvzTUNHauVnjlBdRvgrpXJ+i3qa51lD/gFTlubgnpGC8bAAmZHlAsG6vUkY9TI2ZnCT0qiLaVr5baE9sdU06UXWO+z/iIbeslGIRBrS/evF4hN//7Q1mEx109CpWv/Xw2R3+FtPIGi8mZ6a94ablnv0E0jd5ODdPsD6+p2oy/RHEGVKOZssjXA9MVfLNWvL/OrIsX2i7yhK+Ngnq4daowfzEyumRy2affS1AVF/QR64JQLBDTWZvYfG10dPxNs6X1onHf9etXKG1ugalN2ojh7yRkRX9VBM/dMw0AGs60Qie/+tElvN8RP7t0Bcp6uVyzWNp3LqSTI1JQsU32b9euylCkZ5wtDUlNjB4HzyIp7k8b5afoXsvYWmlrxvUJh7owfQafzjHV3sI064iBezBT7Jm3BA5u3TyS0prpjZhb1c2DR9zZAojSwBOD5MvBmZg/Li5TsAUw7fPIirqBd2Vee6AQinVUYtWtmtBuzfXcVSRvGR/btwnBDMFi7MkIyQI7lQtU8jo+oL+U1BZisE0w/osi0Btj9LCW20eZNo791oa7pexN5o3vY/grcxS74UyQB3EhuNhYEwRYOquF+eEWi14IFSZZSOXOSy2kCHPtsmmCK5NwYGaL6JDz+c+U+9tEVBZ7xMSLYbf59yUMysEJ7gLXVOzGa+71sVT27ZanCCCO/cT9uW+am1WXnkr5ZIyJ4DiG3W/5GcEMhek5Zk7Texi03GUNklj5KNB4m+btacxl+di5KMbQoMsC669aupVcwXTwphDaX++wQ+vdrKBS84iokUmzNud+4c7Fbet/j9YKecYMvqziUZmvJaoYLOwGqWFLUg13+UvBxCJrHWJaOK80n3eseXmJ+6MzIz93YhIana+POXgkF6i1KRILfeLNUAo/gudkT9xEzj0GuwDHnRd9BXLEIon0p274od7ZkwDZotJGv4rLbGKiVcbDoOzPlHzoQ7Caal+gp8N+yuXYebsKetTGiMwkwIWxNovcr8eojRTrDL5fO57kAm2ZMbnJs99LQNegK2YcE1khBKVDlAFyd7Kwt2ow7qY+Z/RFXDJKPcoap1ZS2+Mo0Ctyd7syCB58OVDTjzFR97zOCwcSNVbVHxiPrWVwkAprdQHYRXvtYOKoBhtQgoEd8dVsR4yF6ef4noR7+guj9Y4sGuVH2Tm76Bsxn3sqMUE2UX4vJHjCL6Kcn77DHlm9fmxVVrJmgiKWN8qDoSDrFgiyaWdArcnbITOBnE+TovtDUfIu7QZx/85Mdj3tf5EzqFKeV1W/hNGY7RtgFY7/Oa+6H3hwnTxKzgYV61xEg2UeFwBPOWiIrGHkTwCkLUWyHgTlZZMlL4+G/eWr/TpVdtf2L27ID1P7Zhh87E2aitstQ0/jJ6ZTneO+ixcvvRYdE544DZneYe0IqFa4znEPuH54PZb3U9WP8Q1bQTvGJCJ6EfHJYA3z4dyNDSq8Hp3PJ1yAmg7Hx6QGpt/2VNVxtsVgjvyIWuY7O1ISrpTwLWwKBfsZVIodXf+9sBmZvJub8cwRwyejZFqtWllcPfbcAg5Oavs/8WXDjioVsC3IE2CbHLG/hN2q+gXBFwNjuKbNEmuPWUVEDaE9tMD6Pd4wHcJNaMSTIDT0gGlRUtn+gMhscrqkHb/k9fxzQEs2hiUALCaFlKzm15+adO5FD/MIg+Y5rz0I4SrO0gU/tDukSJwZbKoXeRDVby4V2CFiJiTR+wdrUluH62IW9ha2J7vWWDylTt5u5l6APUnHRcnaaDcIZuCkvLfJ5FlsQ3RjRRgBHKMU/F7Rvro0LU8hzAQeovkySsbsWfPw9/lC2IEsqlxxdDfS/zB4HTKuG0i849IWRxz9AZHJewdJRozIZt4Y1QUp3Hvr9fYEfQcDal75Rfhi8GRF/j2pfyRSO3g87q799RYepoQR+T1/HNASzZ2sJafndQeoEbtlU7lnjlfGTbyS5Ke/K9kAMEek3+Z5+pcPV2y3hleXVLoKEXWRTYoIp9RsGAxQZXFWUUBsSjM7B8JfKGqbgoXeWDNia52ogJBddMGixjsIvK1pLXrp3OiUSYBxHllV4tZ7qWiHMcX8umZDJfBvdsNjzTNK1JcwcdPdKOiiV4rN2WzbmL+TuzoFmnVc6c9Ak4HmqqEi/vltzRDOHylUT8TnpjSEUYd+IxmukVRIblChoittCL8CTdeeVIMV3mdH9G3RT6IlkVbYSc8INrVCc/yoQ4lRMKVtvWUbA1oRxsUF6lz7zqc+9qEPKK/izH01YJCjR7xxLtmZjQBbBI2vUsU0jh63z0n/05kSJZuAJkGadQhE+ulexcfCuuB79k54NBNqUeHPWdNESizJs9MrT8LwgfvFxWICYSJdlM4BfCFwBF0Ym4dnU36CJb5rptTuxf5t2/h5/LMRGcBLPWH8RjvA5lnmrPpyIJ4RgKj0K5yJ+z+OnuRpVcpbSFHwFSemCb5ymCvvGb67KHb+MycnXZtMtZKyUrssXOiWG7csvAfk+25e+zDS5vduBbOIhhb99cEcFgaAV8nttscuhGEnQVeNMt2Q7lmP02bmdOHIPvX9K2A1Dt6h1oZOL8cLp3qFegTPMSvyNJZghQ0Igwk57oGEsbCQmImnHkh4E7AhmK2iUnDngeNZxeRzDKUk9XT4j587ff/36aG68QZUHcFe/mYnmJHhzCnv7+FsSaCFHyC5RNO6oiBkbMagQ6XE39zY/7Ehjn72f6i6qAt2tc/XXjyMqPHAhXPFVOawlpwJcG3G2/wszgXCG4ilfqpB3lIYGSHtb13nGzchU56fNzqpHUXRavGH/d1pf5tsW5wOcPmazoYMWvFeyMri4ya9DNAq+PWbS6oUan8JtPKVNO0PdJRofaleMTwOcUBnu9FPnQZFny5e1gT4qrUMRdWXY7g5HQ8tmxdAkGE8Jg8NZe5T9+JIC+DhmwFHTCyTCi+gvxXQoo4lflTstCBi47X9azTO7TKjMhg1eSvGoOYJG+dMJK3e6+ZcK3FMEXg2kbGFje1R83OqkdRdFq8Yf93Y6i6EA9ZQYE9AJUv+yzONFTctB2k1zkkAM4fmOlY6iVmrelTuy88EZLUU90EGCMZQNUi0fH2gwaG/Ju3CsZhUK2RpEf2mHJEiXSzS602lUrV1Np+8GbdvZ5IDeEVgO2uEE0ZrtGBN1+XJ0F7zsVruBMeXMactmB/RAWi0olSfANTVoylOwCHRUulQTN5kZUSZlSIvoHdEn03ziG5rRx5eULnx/8WK3eRKTm4lP1U5jPgIa5P+YhpGY+F1zmaeWmVSwvMbBi+RtV/xDh7e/vIhcq+M01N8ZnKxKp5zz/9lZNeacghm8EdGvqEBoEh3DS8jL4pJDwbT56Lgsk9RocwhY/JuXZmFprQrkhtTXyABV+G0Xc0EiN0eMZA9/N8ghrNR9nRavGH/d2M4jJTo5I8KLTaUpDosr/yjyNFEWcY0PNF2kztSWvfN5Sc2knfTPeJXoxW+9jLLqBFLXnrUqVu9SE+QQ1mo+zvHb6WEKuGZLTR//LkDtRbo/fK09F40MeetbFY6CxhmjRd6L44mRUAdef1v/Zxqj4YQnWUoK2urFEsqCYjxIbrLWg6deveg9H5+R0cEHFUFkG45MCrsBux0wIJGnxyYMYaXM6RhHcd1cVt1RdY8ewSt65klKp8f/92P5FrT5xP8bs/SrIBBSyN5giL7PBqXdYGfy2tk9U2aOlEx3Y8otudppuB9M3AKc93wES6I95hXYCdhA6dD6cyT2mRg8bpg5ZJpFpRMLAK7mxp1QCl0W0k0dRAb2laY4MRVKIZBPnOvy6EdrXdM63xVa/3bgk6CvB9B5IgQk96reNmdcj6lR6kAER4/V6PnMA6atiEztcA2I0x4EdQGWIk1FSB3sFazaVFr1IPrA3nRmcahiEh+JcAtD8KAZfKpv94P36Ia3lhUz09QrhKXmOfKYKVb8CSVUi+3NRmwBRvAr2kOlKS0ynGQHdXGmgCiL7HPKq0hFQPTiMOK9gkArOIhM1UGHsZXKsnY5ntvggwJezCyl+ERQaIgS8vosYJAKziITNVBh7FSrTtV5C3/EGowCLVcF4lnUrV+gdoDRUm+mi0zV+BGWiI7w2hKefaLyWdg5TONFuyXBsmWQCNfWW15bJOM+jmVpysEcwi0eUpLbzXyoMCAxQ+2QNQFE+iQoUh0QMCs2DKXCxX1NWZIP0T+oJsygGhCRavwV135fvfEUSEMXApw9SNL1PnvLcprnU7a51LSkuxM41t9V94ncfgL0SQYXofhu2nMN8wiArVdKXmG0LiuUrlSMgXX3EPIwO4uaw04Y2MB+FV0CYG39PAST9x/ActgYA7vF4Sonhi9in/hETSBi0CDZPQfLU8cazG6PAQMe7Omcd4efqOO7b5aLQUCHdt8tFoKBDu2+LRBAuJj047GI0gjKZ3kkrOO+Xgbjh0GNWXXoM7Rq+YHcH563YehJm5cq4Acp2EKmyzM5RCyPz2M8d5uysN5qQN7XXZgUYH8UhPk/hgZCkw1XY3GfwqpnaHQ9RBD1ZbvF1+oPc0YtE67XpnnZKRNNPVIHE/UW4MB7R8Ct8tZkLnDQdQXn4RiLEV95j5svsJ8O3m+Cr6irN4h0wNG1pfBinS615YhPU5NTYdCSCha0d0Rr9XqaTmPWmTzYaoyZq/dwTs0wMt89QnvyRzBnKWOx3Xj0VzLuoIataZU1WS32fuAFQ4UL1Pqv7V49hCP3qU+BR8JTCSLNkwtaBFaNeQklhtykZRmm7d0c3fC9U44K2wLY2MOB6bnxRI7K3s5ruAGaDAxwj4u9iibnwJBae3pzDatJlzVdiMRQHPEtaRRTtWAlnhG93HoHfbCYr9Po7h2mv5FD9J29b2c23QNqs3qKBj5ngHpkY9neToF0U0iU3QoCJDz0Mwqig9TUpO0r1g8t7jeyKKfpKdIgk+gF+F+qq+HvP2BvJsS/1QBpjwfTZybGBZ7gQA5oIYyReU/tccqXDqSNB4mlYmGk9rgoMBEDPBbrPZy2qagGTrkpNyPMxy/DK7CthEPKgmJHBQhlQqiYDhJDJCW0tB2gs0sPG341AiFl5axVgxT6oxNtXf/mWJTwoaDhigbhCJ4QjD5rJg+5tOlc4TjHMvF8nwnL4kczMHGin+B/Zsubi3xuLJmpH4UBYF9Wu5pVihFubqvIgef7u07dvBdAziAR6UNe5Lg6Nkv/NKSu0KlGRGLWoWVVWBpiVBmPZG3MkHFpCBc+rwX69jiKqPmjp6bvZloJyLYlSIfilahJv7LMKIk2QM7oKXkB98WOULnuOVoHF65l6Q0m9lNj0k9eV/q9mc0ah6GODElto/uWmrO57prcxW9HVKIvzetKGwCsU+kt5+mWA3ujazZV1RJB0whks5LIyqL4S1Lj6LyiQ86fsuEKhlBK+qe3f+LXhNhik/XSSTv6xaVIJWzkzmQ10PTe8UfWwQbKyxu8BJ0/uIXZGdwTDkDXHZq4w+0pfs+q10bBoDzu6gDNGyvAFt3Pg/XaqxdlJ0f+yn2OsruJkDdy/pTAu7Q1aTh1AkSX8bphWXwBtDYz3+uaNHx/RHRXzyaPws4UOEzvEQ7fo2e03As53d1DMcZE+19w+s7f9AiIr2V5igK6Qqf8e8dj9u7WQAhjDpAVWnhCjj5j/XnRVLC8p3Hi6vn4m3RdGPDB9SOXctrYGM9XeaFGkRJkkwuMQUXs9payPpgxv5012bBWizCOHWeXnIkGUE8sOdNZ5QmYn+j1sDFwvaHcdNkJri7zY/5uotTA6EqDPbfPnTz8KavzzJ6Q1H72ipbrg+W8bJPtPDOC33y2mN99XIT3hIQTyQXLIWdIanNTjd5tW31FpkXlkt/Sh3L2Xoxh/EQ+H6dbrIu+351iNvvsPVDfZ0E2yjvjIK3HEdI0/DklRyNMnV/RsHQSA58OuRUH5LaXbc+rSNME8b+8wzrnHB2XCrefAKxnh/4pzvHfRYuX6nBNRDH/l7dD16BJwVJgRt2LvRORdS2YoOO9y/biM4skXxYoT60s7ARVhdmIDWwrLKleaFvhVpzYSIFRrVk8R4S7MkstN7qerGrnud5TIWA5k61CLvkEOrvKPqtu66brmie/wp3ThOj2kFA7Q3wNKv4MaeMT1ybcx0y8+Km7QO8KultxnaZc0CMspvvxcPommlVF7czKpdQgSU9/kZsbb43FeAH1JxGjsPmXskWXMxKlVf6OTb6yPPb6uU2wxlGB76JirXvTnoj4kWk5d1XbvoHjjbxp5YMXr1jt+JOsKONmOCu+CsFxZfRO/cIY3gBbRZrhacCV8ZtmZM0tIZskNQteOj+zytpJQvJZmR38xKDkHz8Gh1qPWDpsynBVmb6TE4oPd44f89qkmjhsd4S1eGzYcEbHotW+VJBomhye5PiopalDDHtMGn83wMUoZ5anoIcJBpuBL7GwZelR/GQ/7ohHti2uBIOMbGuANGa8k5IG24KlLH9GvNJkQGRyeTR2nfaKguxDRTKSUt/T6cmQhe9CW+hA4eCilUQlX+Xb8C1pWfTFf/UTpM5pVHZfS2t2APqfGSShzxCEd5sxS7KYclUPAB4OxgzyE2U12d/mXWuqLVGmfkFfBJJiL4BFFt+rUQXAJmTGX0OfqXD1pyo0VPv1++GpJvDmDa6OMXhHOpqIcxzvmP9W1Bf94vt1BwUj5yuCbPMt6y/PHDKgivfVU3jFXFr2YqkwdT6FIG99J7spjjgCqnKU7/bd0QPQZ1pVu9P7QUYHngYmlwEgfeXbTpFAppubaWw6KmFLPTSWW+znR1+dsSV4Y6WcqoZ5loIbri0mZXvf8kFhWse8HLnAvTYBQ9IXgNBLF0KfcOGRXjqHGxeUDnzdVAfyuVrXLl2PjoJaPxEiD3ZZSIXI1mop01nW73vnU4nH+qH1LgwC1boH4YBQuByeqasEv5/OngVd98DUEOClkuR9ju17iG5tuNSVJYX7HEhC0vUIwm0ryZFi7YU9hgNs3hCH2qfLMNLFgVYAXIjc8IaNO/p0/kwABSU6GuPzqVW5wIVq02FjnNUZhagwTJhkvViSRtVPmOmW3cQqD6LcxGMs1Ed82UFDks9bNZ+TGNOIevpxEY2rYk+FcY7ztmqJROZ/6kD5FNRW32xTOiRCBi0pKpPw2PYJL4aIJjYiqKH8X9gHmUKGBzEskAJilDfJ/MUqfql7nfTSCuA0+BRXhA5LIql8bZltZ4HGRXPrA7wlWwSyv0oYVGPnsijjgJ8r0p/Bkktg5C1JPG0g03wyK+4j8d6VBVPUaislIrrpn1WZ4WD87VcECL9m4z6LrhMmXm7T3XHuiuYOQ3HEJtW1zlxwMdEDtYkjvRwc76VxKstcq2hSYLvjx9Kl+m0TIncaQ4+O+ol8AyKaSLq3gbQncz5sDIqnrivjVH9RyOnkh6bNoDumxNSvYCxZssn62IFXhGBO+k5y94+mIuzrBHUE3frW9AbLOSvckJjGg5gB+pSPK5srPMSGXSp+Nu+5fKdVb4+YrC8k5WoXl3h+/rDM1ITiWmvuYHyUStdlooTincFY8bCqhZPmAaQcRuYN1b2rslFmFHetr0/J5j047GI0gjKZ5RSHxCb57U80jwupWPLEN6LZ+92xAU8uXRpedq/BPserwtGT5OyALqp9GeCROCVEYLQ4peVxYtU81FvuyLwuQ7D2vNNZWz6zzhZ7Z6OQn2ETR4znY9n1F6/SgABp4x9PbtmbKy0u+BQ36GTY6PTOTPrMgtl6Kmcg4HimoxsMT8STVxEy3H6OkfYGeZ4QpFMb0bVGW/jPki71xZb+fonkugdWu44dx3pU9uxmy5YUXxdY/M6sFnMJFrb9Gn/2rJoaa3loMNXTi7OwrR1VjW1mV11t8jIUn+0jU/6FCxcOhmnsr2odZ0bBu8DKcvjdl90Ip43jH5wVFI3SmOTzRekqyadANjeuWc2i3H3g8aGszSpmw8fKlkGPx4hCmVadXPepDJ6oe6zunm8KI3PB8cSS9rPnMxcLZuQp4WHxjaM62ruw4O+jlD2k2QEbgxELqxTpJ53BL5oMJlCQhRAHq7+dNdqwDlPZyDVqAjxS1RCdNp/d6r8pBfTbkGFzu4tPWwCnNWvPS1Aj+WWLLCHRUSLvwYgwd/aYkxXa3bvifFrs8GcZvJUsADNX/0TlnPWs50UXOMs9N6qzQ0IjAJn+NEeu+TG/58aN1PclPNEqtKD6CI1OcG6RKNWBImqDEHtUvSqQMQWCx1mbXp52GmM3RTY95k8F7Dkfp1GmVs3DZJRnB+poFHlB/AWb/xIdXKyaQgJ6BESisckOSpN2JKfAQ5zx9Luuowe5MGwWORrTlkdt/vpxWQOhm5WJjynn8B8eXHRq5NBk8oEaaABbTJ6gx7K8xZxwyAEY+EedtvO/M2+0KiOoBfj52p2n8j0tucTNf/z9Z98dSBaIEBEwoKLROZIGOw/P831R9sCx0MkptvqqNS4EXGP+jaoeGBH8O9wwgI/+ox+eyAoXZPsvhAVPwctDoVEkvJSefYaeHuStqoJ2q4bzjkgY7VkfkU9Me6ZGnx8pOoq5gwJSfevV1aErJZFEOXCBohVeQD7C1Ncaj7xORsej0IH9Rz5hpHyC76x0bbJu3YW/bohk2meorXR9b6dQ70SBGJ7OgK60f9Wf2AzzIHUk1Ju+081gusmtqme45iVSeX/yftQNK8Ks8zNbix+ouQamJT9pqO+aq04IRjChqFREeKN/3lK1VFg4xQm08xNb9XpnrmJk6iPBJvDFLohzM/ej940i8Kc6v6wWSBCK98/7IdunWUOWuRbwGKtuAqWwhEiBCOtqGl97/iUosHPYh4waLw1Z5gyAviECztR3zeYoG4Pw64LnBhv+BZd/O0OUptpqXkaNyNwJ0663cRYaNEZGccOwhCI+a3a8LPBxMCfF4cTf1Th3DQLxw8jDXd12s5nl8cleSKQn3ey8BoxbEQVP0fXWOQQGUMKhnrNAI0P1mvgNs2p/bnv8SebO8ky9yGYdJdEsFDuxbdYZXlJwoyLEd2HlgHjDwf4uy8lKtNgYOZIB1dJwPxzBNonXdWnhyn5prB6hnuqrcriDEwhzagDu2XomfM0p0XleovEOdFSN0iF/9T5caaPMcBGKyUUj0+Rlr3kDI1QhTMYLBnIh+kdSfYrDdh6AefHldwsxlXWv+GolF9nNUoHr7Cm8+HBifFLMeODoZtJoxJi7maqP/xpsmkFSpUK0QKbqGyat8jIxwz3L2T2LOH+jPfITygUFGTHZ/mBii6See/hdq/aJCf1o8NTqIUqMRYVZ5JGaUzdJho6BdCuofw73uG6JYIWy5hhe4SmIpjsowVQT3o9DGR/as6hEOC5wZDH464MQuJQ33vxfwHvMOn0YQOPf/2HZjvz7Zv+cTkQzNIyG69dROwFiXFmCjWsaTtVfXsfHpAanFZZMlMJKPcj/fOXS0reNiWxQg/1Y5To6IyhZ8lr1rC1dHH9c/llN8tEOA7tp7x85nqVw1k3hIaCWNmGHkUUdJNecTJzYWCH2eZf9OyON3pkRwJDoX2Em10akxiDfDZ6o4Oy7TgBgoye2G7EBIBzJ19GX7FCu55YT4tpYQLMh6g73YNREHO/Nab34zx7d38+Huyzk7csvAfk+25e/g1Qm3hxBzM6OANRlvVwdl2nADBRk9sN2H/g1WvbbsTLSQjukTiKwfeobNl9zWJ7JBJqj35DQ3Tv1O50KiuGXsJI+lfbDL09/Yk5BXD+5YyryA3vLjutBanNXk/xb2+SQAgC0wUFk/RwXpLx8X5hrcPRrF3KoBnO1J4yrRpzgM8CDr8gqMff5NkRcOJ+k4G9dGPwKmts997+Ipi6/WnLZZYYbRifw3gRSygCeSLiWkLz0ZSdBAusDcKQUErHVk7AzESpJ+Wm8Gc8O7iPXTkbuK0zwod2LlpEOHqrVCt6AeAms3c3UJOuIwPWms6uloYDvGdDZmKNnXj8YkgMbP1MTLAyCL4Q/yWAuxO3H4e2KSyz3VOCt12l//IM+e/uHPtyLS0X6nfzvGPffQcWH8ZHozXqNG5DsOxpKzWnqQ9uUN4VLLm5x4gNXWzdyr1ID2g6f3U1l5Gett5tggHodoU/ru4QFL+BIjyZkyg4F4Qvk3nUJxQz7uFoJTO361gM7njtcTV1kvaX5yd1DwH5oAkaiEUIe6nC74d2vKkkU/NA3UY6Ojle8328OdeqUKqHGAMed1KEJ2Pb3/hjAPRwp1S0EOgAn5R4zXdP71efcbrfKC8clXoIXreCJU+ua/XTNpYocS1vgdRXO+WtzKzFNG1HwYTkRS7P8pMYOJfFqR7tWVXKiXvEevSCPJwDGnKQCXxdqJAEyjqgnFMD3HvILDnVLesxvLogtbbNmvEzZWLO8tmjHahwzA59agT/+ucATKbTzxPnx2vywLN+P4BlNPqIoE5WngLUYJ9ZS/Lh/vBATgDuQ9gSfbhrOgq8jHshCggAuMrbw/nwy2M7LFC44B1MtLfYuRkGPO6CYRajznRl+jkwDiPLG9vQN0qd9bpNsv0EOOmApxV1+khP0x7DiV+GuuurO3A+Emu0e6h0K1pTX608Kr4ta+Yve+AtCON6VVP4z8MuoIatcAClQNEHdQEXBmQQw/ABUbBbtIOOZOGbpq0F4TSJhQ6kZ6SAeieI0O6JKn3tlFKp4YEIekej+uCN4YehFxbPtLymX/ns3D6PKPQtVwGd1yfpe14JnJ9pEct3mhRpELh5YiV3PSWElWXOKgvM0HKQ4PHI8cb5UeFRvD0zbfNki/yBj+pCD/lwbTtFOPLPoPoahClz8onzP0drQIFz+llKjWUubkJJuxryeznzDSOEdurW6cY+3uFAGawvO/IBDRiuLMBxHxV4ZwxmOXka5r0bwcT5EDLw19fJwnzyO0pQvC+z74sOKriejchHV9aPn0gqhb/Y0llAOBY1ZtI6vFVEV8qbM4J5ke4Bj0apxRfGW/zaXogREUUcGFdeRKMT2y0TLt4DhDoYnC+nom57nMV5rnzNm0MIbFoWIUIVysqJweInCbENT8RxYDY++VKjgcdK+M202fZ7S3IzuV1tqmhOizVo5lCM2x3TDtEDM8Um9O/mlE7er1+n59IWucIpdNN8kVE6jBjKVxGCmGoWGXSodISqYv4CW1FZcVp9t14Vuwonk/VVOaZeMYEcUpZsrMrWyJ6MOouce94banl3wXtWUYuS8d4Oc04sSkDPcr9VQk2vtV2YCOTob4XUXsmVZgChb7xR/5BTY0/V+uTxejyf/R4UUelXAxDy93IcPfrWSJc4PLfV3z1q5HkD3Sh0Rviwz3E3dxgXCrNyOacanDCGTxnX8arZRpW894yaV1Bw8zul+2hD1ISucHdWUi20ziUohZPFx2LYq40lXRLBTRLWCO7Ka7QC5+WMBJu3UjYeVjU4rDD3eBPJYdTXZ7spe+SzxwFvrjs/Ii2y/4ILXcPF8sdeQfLy+cCAZ5rkwLE301Z7DzL9Wif1GJ6i4S0hPUz70vwuCkHB8y3T89sfUp419yb6L3vhKvCwZsZ/O+lzpXS/bQh+iW+b4mXUoG717H8Z5mhOIjMoBl6u2FT5DD7Tfh8eifjrhYLTkyJPD/ks0FLeONSb8GOqDAfzwCipu8AvhDZ2Jyc7fsuT7RVSXzK+dFAE6j2lqWschF67Ypdz2n6pnV/bOjlz2PpGjKsVeRpaytxQQxTzlTBmKwn/yGvmR3MGw309qU2uZsFTUmFyoOMwa9M5Pfo/rFykItLFsHRM2lre6DSEvR2PzMTYvwmEcQ8f6htOG/AkHdA4TSnJ0D8zo/ODv/+PdEWfuRuVwmrElI4g52VB5SNpg/fmg4xFfWbFP0tHopyAOEz4Q243pPhHiMYeoPkx9LanNRtMh3/CdShGW0Ao4UcVMj4SKUHhlwC0uA5pIctdGQpx9Y4cbVVvI8Z+nAcFWeOCIUWhbmcGDksLfwJOSOO98r7PPqk+OQuUQobl75AfhI2viNWiXXSJv6chEQwhfbrO2aBm/+aRDdGnof3tkfb+BdQVjTwO8aShJbKn5RE4xjWAq2ClhLvMBCrCaww2WBhu3CSAAopVEUD9S+VbMdtKA3Nh5h7FY+TRU364/mgGIj9qvDI9AOo89HGa6F7TAOjbGPolxKVA2GvCRzQQlfoGbXjEPCT+DXnDiUpTpcPWUoP9UPppBXAafA/weUpcoOH0MlsHdIGJTcWVyWuZVNqxGy03d6rVQsF/fabdNvOdngLKIQAzotmxTK33WuoEAVDVAVw0KPnpbl4F5nhTw+WPoPXaZFCcrkMlngCQ+03OmLXn85D6I/TNNm3iUbexWJbm75KVRS3NIZhs2rVqC23jJF6Fv1Rdum9zeA3OGsUroug8awcVQGEeXd8MHluPuYA5ap7FOfG3fcvjSGMBkXNb0W3z8+GIaV/OUg8YQxm2KT+5+TLlpi6mh2GaHGGaLqBgX9xsfQUitdQWwTNDeQVWrJenXTAN7/Qj+IhBfxbebCwYQNcKqd8PPpOumFOlB9xxaZ4X/ZetkW0khBT586Qh4vOZBpIclz6Q3XYSuD36HucSwMwFtU+5jHSBriHn1Z0GBG4IUgbtNQUPDZoiOlCYs7M0tnXaJSZpox6HnrAtLVRDePFYbIkrYnMgNMfzZFvFyz6ekrJtkYjBnQ09oPUHn56c88RTWP5mRnNw5BulA+g2Kkpy+xLQQQ/mEQFI0RdR3QJpBoBCMu209RbjaVx6eGKBac8+X7kCVjdDh1hZWbd8GtO4Xqk1d7NWj06b2BGx8WKCKmhV8aotSldM1jPxifn8wqzbr6RGgCOdZ5dSd2AZBmnwlvpqL5VhtPNpxf5KrJ7RbNYT5534wF7URL/9i8YTxsxjGfk60mC+M6FtqSHSczjTZiWeJSv2hrgoMALpJemLLMsQ9oorPN/a45UuqqHiefkm6kuQLgnKIfYN5DpKrqn8BDICQxKEqU60KMZoy/HYywo3f/Y7YnEqCu/pLFpXMcQAWVzcmFmuXO8i5iaUplg1fL/4/Ks6GZ4cm12qHuo3ZEizYLF0vaOZdBwickXD0O3JgFU7P4EptV8bvzI6+ljVsNJhe9piHhMl9dcpAGjodPdQTTqENFX9XCO3itajIJyfFQUjvzblnUyvYXiMjdgO60EkvhafRHZ6qzQmhTv03y92MOB6Z3vjGzJ0oqELLNfy3yV002dKcHLwLv4HjbcTlgVisEE45f3pvzbPAPcs4/FH4cpLSmo4BuCezS6ahxUA/kB08303N7362oEghiKbamEsc5ab4OPtgJ6Wm02b8W5985KJLpDE1hovwl/CBMRv3sqGIlVMK5Y0FRwYa/MSDwT2MRk/taTk/wvCwdVM3r9QXfTsQ62eKZ3W/0RYam/Uqmvw0mdNZrDyMopHiWtgRFubyyNDp6kxR5Rfk9BzM5Lx+gM+gu6/OVgHTzi862eQGiJ6uQsWON7+IclIDBPu+40wuLW/CxaLYAQvt7zkghsBjHpufFEjsrezmu4AZoMDHCPi9EKrf8WyX5yCh7QtwPqHJcRjae3ZOEpOMFctTbb7EKo8AAHA7WihrR8TLamzgi39Ebg/c2uevbJglU9JnfxzSXXyqgeLhWkAKWUooOZFjLKq+1ypmddjkBNWrGkpH/zNeGFeY3WUUx39JdtY8WeVF+IW1F3eZeWjm+lAPOaxj9ZwTfvH+/MEtDHg1Md3YBSbjx06lrLPDiaM05/ypmXo+AQQTQnRvjB0GCrN5tMMt/98H28vAVuNv6GMBDAnpMW0KBCpy90xxVU+2/uCeZPPKfD6wIG+/Sc3QXpXlHcJf1E/9UCmmvTFeOC/+T1q+O+hoQUVBRPl9m9RfJ2VRUrWsmWxL9+0lEn0fpdzz4rEnEQmZ5sE+qI4GJxAaiXhqfkY0uE52BRnByT65rjOrMNdVfAq32FARc60/sHueRtRM2vNFgtUeSQk6xpjhbWJ1YNn8yZVgoXxd/RudEHocO/sQItBh16bI0zGocH0d0EXtTklswYarZp07DyRJVBO8h2JwdASH3WV2/IFJtwDMbUI4xCpwxVjjp5OtwbKaN3H9xTCmcbIWjKPDSz51jmpy1Uy2tH0raZBw9TUBZ7EqWWqUJ9Z++07p8BvSHLTd3M/FIs/n4oIleG/dvsVDy/PwO6OYWoDUOyhGshYKwF4+lIrkIRyRACp1+toHGiX1BEPCKVT6KivLRYVB6x+ZQWMN8qEb0fg3EH/xI9k4Voo4uEmMw1kL2oeJsLySEUiIoFnro9MNLEGP3/94fOY3IDzkj703DuU+lL7zdqTwSTzPCyVkjtmw6MhyPnXKVNZx0gKsBwCbsaKcQ2lj94CmW3IjQ0Ib8EmqQqFmFQlzKvO6cb4ffWoyxYa3o7vpcuCL55LJay0Hh/yWXCqFpPTDq/g6rdwuFZ/7a7yiIDDP5u2u71tUq1kFup5lC8XQAGRoFbk7E0sn2luJfqNho5Z5q91gWxV5toauRoJqHxMCszcukceyK7vTnAPVDBNzCyzv0n+pFmZQhUbDn1Vj2W7h5E2x5dAGQMG2u72QBf2iz1i2eiyYvRWmwL+Ym/56lOoRlSnL6Ri1LaSLmDz2O1x0gd6jYaRb0RhRvJqQ4tDYqTqlLb0aSvv09dPc8MblFdF8udgoJhcFlr5xL+H/0Fs1/ZPAmqVCRLl56DLaESfg1sEqMLST6FO3oiyGYenEviCJN0pJR2L2U1YEu14z4okfGx7IkzeQcGPRlEblkW7B8n2QtsULJEzLy1imCNieDRAY4jMeAsPUlY5h3gkq6wC9TtGFdi81se1MI+edEW8BYfvIJY5ooq8w0lA2tChH4elUbjUI+t3Q+HQdHEyqAFQJ1QdFtPUiNPSo4CTHWWzfX8sLLgOrH3bdtlI+jg4wnwu4EkUfXl7FllG5qLhAuOVK5RQhZ7x/rjEWecMdVgcQ6VvoJdbpalVy3wS2XcY5UQgDo9tIGVorBTBaGQAsgE1Nb27/XfWZF2yWIx6mns0l3AdxzzX6bUWvT21sBh+/nEa10cwVoPtw55HOTLfDpunFdHZhuTP4HHo38NJBeT/Z6iMGVQNxxQ0wLR/mD+bFtIdfs79VbB+H4Ra8T0fwlL8wXJKA8eXfAyQizn7sIPsmoTTp1kkI7lv9YicZIY6Vao0vVKhEnIBJGc1ekRcVYxadSm4eFFOp2oGKNK1EjOflEOTN7j/wHj0WlVM6qvxUGkOuA64huah1q8pZ06CctU90RbFbEgSKfORLwVXeT7xYrmtXPQV4SnyVfkdf5sSfUVVwHBqIc/dMyGTBMqmMk2FAuOrRK1Y56tNMtukHpVnQjCmfGURTerA79XV62hhyJZPn8Gn2UtStnNVaVkliaQLJh+EUKGoqnPW8FxN+AOTUFP3wIMkc3aQFl9ssG5tPVGiihFPlU3RGGUrCndOi1IlZeEI61tZ5MsB89SIBmP5nihZRnRtlU1JrJBe3H3rairuTVT3eVllkG+3EQ85XHUaK0qx/aWLf+kP3FQ9fM7CdAXcP3p/+RuMohpS1cGhniUyw+7iTlZbt17lJRhIgZBxe1uazdlDYi1d6liVZNVppV73VgGppgQHzsL2XT1QCKuWsbRC7Sa0GxOaXIgfk+CPrdpQBaQfjaM6/dDFpdLwEeJHkXEpALFSyR8ug1l8IhS5/X9Qrd7tSkgChZ5VPUDursPoWPW2VxYACbGfNnIG05M1nHSAqwnFsczt4vSZFDkGe/6QgFWNjmdv9LYy13izkbEG19+w/bM8paxh1N1EMS0Rfdj76IT94CPVeg4xJzatLW/ZB3Vr2baRTqti7Z+TZZFi7b+4wNcelHmBDCeRNIKMff5NeiAvcc1U9BlQCa064hT4oRB+cDBhJsJNhoszdrHM6HiS0T7UqhnqHp8Bs7ljKvIDh5DK30Eu0T4FIavaATJ2+SQAgC0syxk/NOx50vSyFd6fMvZ3Z3TgJ0MXnOCmaTbNRPpDCq9dFm0VHk1IqD8lsRn2zt7ts++zUGi4PrPtQdP0AkLP5M+16goIVGiH2YEMtTkQVJHnHIsuI5QtRdwaqBDXbdFgumqvW6skB4/vanKG+wLP4oMKx4ty0QLnbO/Sffh5gx1pcCMOCuPvTHPtxu7ZKBllbND7a44zw7iP53p5FCWZefa77yjsmzGU6jl6/vJAu6CKOGhh/0RxDncImSY6rzzxLNKCerxuDXunzuCwJQ9OXCxAg5C4C1VuMlFv8ybnz0NTsxyvuFZcVDX+lo5G76PakIAyO4DlPf21aG8VnxOcIRFyjc8YxyR6q/mdaO48ISFcf4CJJjphc6cig6SX+i/BLhFI2v6fM1otzG2SjW6/LmbbUvoK9nqHp8JwAdwLW0eSs+ohXzd+HUjVoRdUFSFFCmQdDGZoiJjM+Z/QS3y6ZNJJ8Qju7b8vGoZhdRXrF11lUjxXaTrxFhlenudLzaLTsbokt/5D/r9bQP20P7eHtfa5LGvajGHf/nInmP1m2MTJS/nG3BnOS9TVvWPMKmCP6/5kOboVB0xvZ5bPtZAU1JV3WWybEG+wk0l2qpknnr4T34CZpljvFkisBfe/lOh3R78d03pU0G07xourJO+gdHtpAywKo5dC0cV29nxdG0XI7wvJYqxGb+ZWGWxaJBw0j4kIaiDUzHCbt6SMfEZZ/Ek7p3yyFm/aI4wDtw8jm1la2bDHT9jNdw8ZV9sixHiW0s7lIMXraJ2rJOjH/Im9IPjUFyY8eCD+BMDBNcn0at2L49Q2qbLeXNtlYjXZNtqdqsOafjkrmE8L+68lGmyKtaAocwe7EGRLPgMwLci9GGcKWgK63i4zWbhusyZqnKNyDZLe5zdtf28p9YJrwhpGHXW1cWWVjozoAk4vuE56FqnsBqMtboSGnjApWeVTUlBHPK1QqK3NbMnT4FkCE76/HmeupZ9sOUyTDNeJ9f63srYIQMtvG22Ci67lOoJ1fv7PY6wrtX8QMRlJ6S4zhv4bipov9Xb+/FAQZoOUG8D5iOjcusNs9eJiQTE2BnT+lADp+3jeW1qLpwIBU8BkucyLVmU2ZwwB4kUaH4qsQC7Qdi0KxWCCccv7035Gk41g3puViY8tEwwW+9sLDCtkHAFG407Mau4Roivi54ZG68HMMQvK9Q3rebaYgqTXHzNUrSpFbAcJ4XIfOQjUoyriUcC+yQxi3ahDOQhJsgZ3QUvJLPJfNNCxTFP95neDRdaSykUUc6EMVlWkt/1fReT9JRyEDBKeTyOEXut91j4MwsM4byp2gFdBLHc43KyBhJ85aLnvepTERt4V2X3NNjgziAZF+6OmCbZHqJBt0StMLXLykjXyLSvu8CC2RT2LzOrBUwHH+6zxfGzTCHbE+3I8ERBYBdLtcS8nRRPiYQ94Gs8e7j/GNS9wbcfJFyDRwI+atxg/BLDOHHCVRYGk/3gMrt2VJCfFHrXH1oulM6brzJZdBoaIhMThKQTFDErtft2zm+SG+qF1yw2qcJnF+DCTmP9B7cJyf2CnOb6lhMyfmP9Au7a7/rXKM/QnmeNLt2m7U+9wOwAAAUzKY01zK4py8T2RbtJkGX1wS81jSKaybSbRTJNYNm9kIPx8kS2N+cbx0S0grF5fJIDd1L/rsGYhoqNQ2mYyEz/e6LFCMNyoginBXa1JnSyL57uCwR3gZ1H2WiaYU7S0owuxT8yZTqYhh5A+iym9IHTZ6hMpkqiwS1EJisZTp2+YPx3Ep+eShDaUM1+HjLhuUpFl2dkYjoXlbdJodah6DKu75S5ZYQK7USHNsiY/eE2PhmHAJTbWZREgZBO3oeA4Lw/HSG3Sz2wtMC4EzfqTuBzyrAGx8N7fcO5foWMDPXC66b5U0f5hHtgSid9wh0TzlENqfgZ7eHlK48tGAyhUx13VwlIAepT4oMqwHhOSqNML346c+yeawSjvgGFIxwEadISdhJP4FYIsULSmu3SXcaW9XH7pkJJxd+1+M5y7Lwg0Fc/uWMq8gNXsW9GzKkdD/kHSqN2pK95JjuhOpDwbQbqlIjRZL0MZMvUmfK4D9M9vOaXqdoKX1eZtMMFrb9tUD0GVd3ylyywgWtzpiaXmzzdKigJUCxMdz6q+AfYt8q6TElM86NnD/iaxfl0y6zFbAll2UOAIUVHRWebLKKipy64FW7Bv0sN+ypGvkTbFuO5F+zAcwZK9GOozxcIMv7HTXzeLpNp6/yh5xuDS4KM1dgB4kcm0TcxzknsXqJYg15D/6Ji0i4mXUFm1gPYUJdFvxgu+I59qLrQcl9yKkMMRbaFNEKpGl6nxEq3ZOmDwd2/8cyKxCFVekhEiHeo+B8uBkonjnZUHlI2mD9+YpEqPawexYXALBouh2oKEZmbcnuD95hHy36nsTaK2etwt+XodudDBL8LlRLp8k5S15vDLA5qPlOwBJ3f/gmpz0RnRW5DOcn/tMmzdME9re12wKtdWx7CXaNv/Iqul72CUCI4Rn/ck9aXLSYREd8bTK5cFMnTszMB3vGYfEVxd56u6p9XZjky/WFOJYbnDURAwZbuTfuzFvfRpgl2W2DL2H+xWEli1YFe0Osa/vI8edTwWW7mBlYTqfbVNrDftXX6InKFsL8Ozo0GLZgyqvbu98w7/3nnqWEIg2MJez46mw8yDWNXtEKnKlvZLubEvEq79VKO7aIe1JgRrOWwJF4bOBLSzUAf9DwMMC92LA8HB2cmcRXknqY3pSFnJkrryTMW4XDQclxI94fPT1ovEaPTn0EIQFAEb2cKrPG3AfXVeGW/ZwhuFfKZy6CuzSbDV44w5alx7uqf9VmZQyV5/bm4r5AfF0+p50NOo4/fvS45mUpC7DUfCjpdfu7TPoX0Th0VzkrZXOMXBns6wQH267AAAAA9CnCN+/lWVfmAAAAAAAAAAHQm+cHPmZI8zvbxlWX9bwbmVuOCobVsJlwoPZPmKrQXYy83Ta8Ex86U5h811mjQc7DFlxxLakeeFv5zMKtH7Y1DG6Eo9vWjTeo7eZYoTFu5ZABKH1yMO49nXPB7iyXAiMCyprARZoVTATUxzftdULGCuvWoBHjyL5S4PBUSGnyk0Tg0jleMlR+2criqIWnBbqe2wrrZz7vxsoaSYWv1h6Zvg2wLvPw8zWtRBL/4hoxXP1KFr9PKlqIpsxC98SUdOV3UjAQE74NbRc7rIEdRb/AxGhvENP4xPXsLnPuNry2D/ODqieXkOZwHBRen0L8SFg0m4eMcQZt4VUTz/kDRZ85qHKPZq1xZK+CKoJvD7ZzHaIFIRqt+P2H9CGbxFb5lQlnS4fKtZXDc1j2OgThactCx2QQSZboK0b13qvp9kuKUBKHzv7ykc72q+xyYESjJVuitZod8fSG9I6VAtTFp/vCKt8duJJRfocZKjs6Im5Tk0s0CQORpz/y9AgGOJgDalDtj25z8GmZfe07WBXhL0nuXpNuzat00tvgaW4S2dbpobAXM0FwFK4HQZTloFtPD9MqF5r9XHy48Z3GTuNYcrUp9DseTZGfczqZ4iM2bRkEAUo86afS0oHLQJuiM1OhJdDh1PJRwTDft640He2WszLF8lyVi0InJIt1JMVaJN5PvYnnkZhse7RyfN4kNbHnApXoJTyisRBl85vuR9CZyD8xKa+sB1oB0ah1Tq/pja1lNoFAXkDiuCjWngiBRyd+G+rgEuRU5iSHsF2+8+e0TPgp8q01wobH03ddpJwlXifbXYiP7EcS5v4/1i+Fi59utUGpbfGVMQBXFZQkTehzuMWv91YLscXsK6NqFU1YdJcK+iHnjG3AtDpqXIqkg752P2qe60GAAAAKyY9OOxiNIIynSRCBhRH3Y1F8ln1Gw0kSXVbW9qE/CAmXOkaA2q3WXx7TVAFll4rNtCZw9PSZzWw+kCxNiu9rc5OKIxDTGOFRrksEudJhNNyTpdZ79P9PB5cKzRou70+E+2fQodefge5gL3ECMAl0SJifBgEeg7oOMiGISn/bv7JjXr+zuqPDX9xHKuOitHAKQBRHcpbD+Mi5e3v/G2lD0SS0UWAalvDVVieeC6SXq/WaQpMPW6Mar1APF8+XjvqFzVdK/qEFwnCg0KKpa+rBpBffTp8I/bG16JTdyjnzP2pgIovZGehiHLib+5sf9iQxz/DVUCX/BFguiPq3dpOAhVBQMJCEWluMQ98x847yLf8lDYIPn9THGoM21I02VLev5KITCWVJalM2qlsbms3ZPXNb2igBqIuzWsiguiYlUdqTk1x9R0BSfosBcxum9ylDtgZrNMQwVAGHrW7qTP3gQhFOTcGdkSYQdpfxn+aX/ZjTJ6sSeF+mFOS3BaXGp2vaW8ygmL57eCQFckiwr4Sor92vYuRtxZYmCX6X3vfMm986HOZhFzbMYcFNtNw5YBD5Jn5l9HFOoEN276LPN5WR3a7CnBePmQ4h4mxAR4MM0EcRdwBJKbBUuMatIVVGooZSr6VC0vc58P+ViZyo3ZEis5r/YvcJx2/5qsO95vZ1eY1kXI9kTZaGb0KWaS9bbv3t+KaHnzY1y7lyfbyPg2UXbsCGpRn5sKpuqdq7JUgY/I9HgiuCwX14CYuJyWkovNSBt7j6CeiH8JAWOAoj6L1An3xEf/k7N9UOdVA5APUkmmWA9JgFzvax4NPEOHt7+8izEbDjIyzgsIC4SDBEeZmd0VWEK8nKTIBOLFLzuUwaH24NXG8dgU+jKsTwmCImo15frNZ40dxtaWt0MmxtQKakMPUa/1Kr2Z0OAMxsVgRwfGTaqnQXEeOyFC2oXoxhxKFSFzNq/+jrDhA5Ew7JFe53QVRtVGAxVlIhuJMBtXOYgqoSX3hQeE1+SYakArnMCVoc/ImG8FZn21bghcVAeqdkXzzpUmbL+foTYUA+4vTpWgxo7CLdjpWaZ4YE77yWcZOsajezYXf3lcgI/lgM7iUqjwaZhZtU5jk3fNxYhJABVKoqcZX0UHyqfsGWIkwMPY1XZwlYQ9yVgT8yu/u2bljP4JtJG4vZnzOc1yNEu6IuqVvG+Lblhwx3p0b2WjK25qZPgl94/O+OBSjL5KXYM6PTgijxkD/ZYx9saR+ecLI1aRfGz+VmMyUWQEbhwcseoDwKURaPJI3JOFfe4bXsi7DDTQZYiTUVIHQjUVZwGCf9ml4cvRkPABBMv6ujitvQi0QEbL3P6PNyHZmt1lwlmhWO175O3FVJ+ehoHK9Ixg0Hs1ZJwFRe0d74/lil/L5WhcdL8gfGvWpFuP0+oChms40Fb5NYKkPMmDY486GoHnAB/oxVAS7VXnvSzOGDXD4d3p+vGvOqodqemMEDlgkiQrJ/1KE+3csx/InBjN31pCOdygVKs+2YpPMd+UcKEktxeILwhlaS/sweYkx9NWCO+OFQbWb2kfDbYDk53jZ0/O7UqoOOgWrL25cwXFAtPgnxqIFXpvRPhoUWw3PS7k+fEx+ULYusLr591kiW6vikluk8EbYUOo7LdegL01ARE++mRrHT1vKzAd9QqMRYWuoryCuF/HjDM6PF9MI9EbYwQtn2IX2i5VS1qWIIHnw5RG8H3y7Ddh+Wsvn2R2R1HRrREy9emJ1P3BF4ltcEUhj30N/mLxlWPEEJnlJ/xrNykCCUNp0FqL42gNjCcsxzx6LhQD4SmNtzJtqEFAjv2t+wV2nvdNjcnE/TgEC/o7ukTiKwfeoZYQ2TVvUU7morc9L8+qYNqqvYHs7TPDT0QUBXUxnj6D1Hs0H0RjwOy3qQp7WnfQzzVaGSXfsFLToXKzHxFtmcpf7BWXng4d22cuxPYByYXoutOZQL8Hc+eBNCXlFMJgY8Uq0asuvOIDwl5ilpDNubBl+2UVFcoMKd+GprLvaOz9hJ8dqJAGj8t1zQ32J9UonpP7zSICZ5xloMvpMC6X5ttzhjkbVTYb/kcjPhUbK6iK/cbHTYQq4fewd4W74sSPjMwxika+hUXC+5dD0DPcYwhjsXepTB4KwGeXqU1mx+5FujkMJ2qNmFo40ZcuRpvuwOBrx5G1M0+cCDn/ThzKnBtgkEvZowCGW+c1IW79gm5IRCFsctGlbu/BAXzg6zGv5MAAUl14CMNLbUEA+vt7Uthw9kW94nyx7vj+Nwvdjwjy8YAz8Eg8oBB09DOzF5zXAVmeFg/O1XBAi/ZsKgqBvOla3cQplWaGgeQ7uFOipdf9/d20LekfTQm3R2MrhriSBR7KL5pAXsdFAGb/P7Q3yJs7spIfcMReKZf0e4sM4HQqMdtaYKqBG8rI1un3HIf3HVgEFLjQvdF7ZWLO8tmjveDXCpzY3DOGfLOZnFUo8FPVEp5CvawOh5UhRAZIAcIoREyn9bR8pWRa5nhUOe+kVI1+BtsDeW965wzWc0o2OCF7lRTSMQlWBiSzNWcuYufRHZXFE+63Kf5pXvhRlYQzsxec1NIk0rCs7B6T4aLKI/gqIHpUcMx+B6JDtLsNP2W1zSNYS7km61bxpXoPz7y0j04OnN8hNQCWuSyJADt2CbmnZmRmkj5tFSJQXGX8N4Q5PUeDMKXn5tKMo8KPuusvFuq8WJYMZXl4VFKLzvQFZnhYPztVwPiXZvsAQCxcw6eUjtq3xODUT0NPo2Dh/DvVyeWrc3RUVRd6fkX8wZxcuo8NVviH0tt+cB3WYc7+BHSv93vojcQ1UoaB181JBAuDsiu8leQY9BtLSuke4rCbVVtwFS2jxBpE0o32FfMnHJ2g74v5ywQX054T5OjJ6nWNC6Bs19aTfOion214p/ftWX4ZtfqrJGCzuGfffdjphUjOlCIEP1zMIbp+LmJTxRxjd3+ip81AMZB/yc7xbq5rGl41ouIkd2vremIQ3j+lmK+vtcz6Zk9ryhxaR3PocPQqqRcS+RNTrCVykkOTiduq45WhcGF1WJ57RHmslMjW+zBqydh/Ku+PoPx3+PduXxTYCabfw9mtq18NP1Bin3MjcgPJuJftha56muwTBsR3Vd5JikmJ0p8fkiuXvPJIZAsqb/WkQu9+sz8Ig13kaP/Jx/qbIEVZKoEUkokDn3JL3gJo+BPdUmLAYfnP90JMC5UQtl6pdB8nRREw5A1ymIekoOcQQvLo3c+J88Yj7v8WfsCJTs5F9B6jc04klSF7itgnaQb35+gTZ6Zp8hR3bAT0stbqGiC52L1p0KritHQYsEPxzvgkJysipfrjQQZ9liKoC2uM2pexuxuenQeADgjcJjb31mEFMzveticqXomVwHr4a1PCV44W1Tnj2YW5RGSjHGYpaNSbj/hcalbMt4k/xmm//0EVxE5Tuoxy0N00X5Sdnb43O1vPNaAFlEuyATxkauvL/8UbMFZ35GKTrFZFqUhyGiYxCLo17+HOqgwV3eq+WPHl//x1UI8uiwCFbI/WEzCUe4PE7lsBZy7GIyf2m+ivgeVb9CvfSuRMNd8AE2klfr9bRj+gNBKshhc8eN46D5EhNaTnMsSlK1X7VYIkbtANzT8G8gvF4WqRlmLCqs/N15BtaZEM9T10//LiAbH7X1+7Gs0XCJGojbtqxNY5rITLHOwoub2JfgN6PBIBdYUfMHK3UOof/hmzNK25wCHZc1ELONgqzM5HyMhFD9IWmfjihFK9IIGAiMcZwJlm0yMez5yubmPw9hEpnwEwiX1zGzhraIHK4eWnhkFAI5w2MH1wg6oc8y1tMI03XVLrq7KNkq3/jn4r8/FKwIiWrsOux30wa6voExuSm/THRvv6coA5T2cg4wF/OGp6cC94pZ3BCD4ZduZJFBkzC+QMkZZEjOPc1eiRvgEVzmaOdk95V0ePxbFt4nv7h5jLL5n6Jhy0rPk1bZMM/ioaJt8UiV46Rg5N7/WAv3qF0QAgpEXwY3PKaZ9DsvJSrTYFwp5ZRQ6J5myUJXumkFKzfqkCOf/QIH85sGl+baZwgip1efDY4Uy7qu3fQPGhxZUWTYGeyFT9ZvX5sVT/e7LebUNka10IvslGsW5MPHZrxyBx7/+lCklN78Z4876Bsxh/rDCCoqkWgumDnty4BUPL7H5wEJaxqxDrEvXwLnobLWX4PYn+eX4X3buKl+Hs+KjNBWcaCuCXjN75q1gzuIAnbT3sXDF3OzaZAoQ+XbEZyNBhXuLq/WRaorpa6cg+3m5rX4wlPZgaokq6rTTQpylQgp+FgwiRtlrIa6wAsGkQ4LFF9Jm4k0Xz/YjRTjcLQOQq7QQW1CU2Thl3RomM97yYj9n8clFiUxxkJECLwhBHNOMAEySxF8uDgx3MAMaoGmWFpz9hp6tMnPU9bwdenz8k00KLPG/8XR/X2MrK2JHab2sIWrjKd5rwYbyi6KIbqkC998Km+6gktaOVEVY9TH+HFZEdnEwt9eU9D4ixoFUIWlyVqkIb5NA1zZ+xmzanRdIVfhHc5SO5ayxR3P8ita/OibOwi5ZunuAOTzFR0RLbEd1RRi6wZ9FU8ChWAGaAR6HC5keAqrqxdrtnuTvWIT79Jmn1yAyzxQ3uktVRyRIyfImGRlCx6AtUFABDGBCLTRKmUgpIKTVP5dRldpJ/t2tmFQ44807hZMLaGlt7ipAiLQ4aiHc+ydv0vop9NYnlXVjvRBRQ0Im5K1QOmRL1GwN8XrKDy+dBWy2URXlkrBpUxZeNYO07IR4/KmZXtdtBw3yfbixkEyEf3Vr+UOSMzKAROimxJ5ZwRWdqvCC1kvhrLJSraVQTOFHyFV1zby9dK0w/pED0pXdbIjPvlIJ4Ez7DT8WEKMYYJktnPrc6n8WClrilAZ+hNA3q540SH9akMDuYVxhIvCvn7WUYgsuNW9jE9FZStyxxBwvPP7sg4P2ZYSw7zvuCkypLYVtWMszitEgh1VWFBDD79G7gTl7L6Ysyg0Z1mLFFQx/99BR+FeiEt7rfxEa6Kg2Kkoy6qMxCredkrvJ6yI/nsIYQhrSwXJnm377yd1NYJLZ6HlEqW8IUeufsIWRIznYATSd4LF2inKWMeffjQlFAnb4wmoUP9ajYfGDuDLakS9mwoYpv3YYhu0cox2uNgFrbfblvtdvoDNTKWb8a77X5/zXER6p3jYisAbuhV3XiZ+drTEzqfQR0HJSbNthsghHHsFj9wvseSgQhSY5Y86dYJWPSAo79I8Xo6cFb4tY8bVo+CeKdsjp5BOv22ZehK9rbUULsjhSTVMbxcTWpNqHjPdpC4XJXrvD5CEH0JmffDM/gLrgZ38JtKQeg49C8O2XB9ur0oC5AhCJV3LSQp30pFJsFOIjDzcf+EoIICpRl9CeEn6My73J/wh6ZkbNp6fQ8cyA+qYp5oaNMOW0aabfHw5q5WKELjljLnbIF/HHmaqxQjHdLceLOsJymzuYEmME8EwbPl2dbKNrGf2f5liwa3VLChm/wGca1xpweLt+2fEMNNne4udS6wOgpbg6wRWv8Zdp6bxL/wKJQQrhO16scMSJvUMmQ7ZnecS19cVGeewv3gSDb9081EXkQNnePabmp4QhD1Ft0bTahDs7CVF75852miqiCHLQoxZ506Y5pHSctBfmsPv0XftOntjp19J/LIyIYtg4kjSpuVzMZfhBYh658Uv4DpGczrMd7t85l5Y7mnsJLOyi/VwEJYrxCJ86zjXxQwIYP9EwMyCUdhXk18RXvnihnXlfFxHc4UKtmTIsZIB6dA8UOi/3z9QT+t5IIZLGqK24SkC41NlphIErMPVkZ5SesU6RgDoO1c9Y7GkvJMA0dXVJirRn+km1GcbxLDsuC1Sc90UjGICZIkSIvyXmTuOVFXYzgURzRX3Yj1hyuHlp4tm1uWJvQqeRWW//42YDWNkEpQc0uMgq27YPATGlmjLXHDV0yubG93KMjlVDfCT6cmk9UPdQQ39ezqefdDq/iuvSdhb45dw4vbCUvC0sCretNgN2pBPXRvBkUUR7YQKARylDwFUIKcprD2qlAuy3AEfmka00PujcCFYLSTO1CRvzKUdVRqX42hg1AURyIp/41VcgGDiqF3f0mWxjaOABswOrS5m/KPuO/uAsVbTzXgD8ltLtufV7pmm1HV6I0IaHmfa9PuWTpVeD07uAyMgEOlqaZXQ2MTT0mvuHEQeLk6S4+OAcmF6LtOwFRdOH01+02fgv6SNL8F501AFdyqqVwIsC7cLfmyjh6a25ZAUSw6Sz0aJilCjW/FZGMbXMzouGhTkaLfw9R2dk+PtCfk1LRg/r8hK2KTtuMnYFhPFdPQa5aVktY+G5AJax1Zl0TxsuuXRHYleHA2/UfmvadIyIlSMHxVu9mCAApEX0buIkei+LRatHJUJNWNeGiFwuHbcYTk7aXRvy1PKZrONBXDAVX7zjtZ94xzIuEai7Es4+V1W7Kye1xci52VQY8yZ76Yrb3hC0ikWXE3v/pFyP73v0QuHU1wrUsDQR7W7Cs6atUO7sk6vc9lhiU8j1Hxtm8IQ/2gUsKloYLIFrrvEFhEdXLkTfi8kPYmxjSxGpzmRRj+Z0vn5Py5GuFqG/l6ErERStQYRyrMTxTKh40WAoLIJRZDUGdkBWovEziakOLQ2OnK6hnPB+e+TDSrs4Hnw5hK4H8+C8sooadPJqfe5mKvH2cUPEk3OLI6t6incjh2nHot8H/TH8IGHmTRIR8YBVCtOqH0+H0tEl+eHD5rZrSjc/W31JWWstq13oiTHGnIZRVU9RtCF0geKOvTDmCVmJyP+4ly/y96IFhVE+Va3GP2btupM0a1d5eDYBnekqhlU5cHz9UrCmGglefBK9f0rX/jkS+B5vqsmbD5LVukLwDQ7M0S8/PTlClyBIoH8hCggOmZXzIVfqlHUg4C02D9AfIZQRmo94302s9I+qQQss4qv55+GN4KEe5P50avnYmEq8eTCar7zHDBy7exONdqYPFAz7d+3lnf6NkWIxSzQmv+Hw2Vjb8RZvw7gC6G7nwwnQl7rPjzDrS7q3s0iZAEqJ3gh8RP2aXVYhus9rLKgclOJK4HF0aNLxoe2SrNxwp9XsDNrmaeG6LxQmFAaEYJkvKgEy6vg3SU3vj0xOr5/pPwPYoWmJyFR5K6E8ikCU73BPQaqKvAybhwzD48n+N0TtS1oDltWZIX+MMcoXN7UmFK5ZFabO+SVOvDlfwhcurZTe8jcoMh2LGuMMnBRSNnVskrRHESgkgck5YtSIlF8Na8k/3VsbidBEq4nSQ9LiCPA6lX5PE/bzDWnTj0olAQtdgUNN6th99W+m2d2eUjofdGth4k7Zbqho3UbPVez9JMrKK1RP4/cQzDh/DuJGGQNj/+sqYC1GrUnkDEi0s+NVcbLfll0Yzpjq32ktbA0tNdot8uujmlGDvyUNFhOkyrP9i1bB/6vtdCUMYYl/UTm8Q4e3v7yE/t8bdqlZkpYt61cScgKGgw+jWdx0qLACZZ4SIamzF2I2uUNw0oaGkyUrWbakahiBq0e8z7zdOknMEeU5+xr8AyZDpbY8eNG16nPght4sAaHVuLGe+2OiMxwYJr3/00Twdl8rx/4ZjolpTmSYuchG+QQ1mo+xvfKBFQDpMLx3e/vIsnMMmjEPRwbIhCJzX9YTCqESADQ+3BqGWbedv2gwc9lgLNsF8IEDKABOcR8SeeQb9Z7+xAnIKEOIJ08Qq4AOH8iy2zgTwvcnJt/NNFado3pCuyhEoQ3PDt7nU/Z5NZiFR7QfQ+Hye5RJqsDogPFK9l3x+1MBFGKVWVzrsFAe5hkXardQISTEJA1fckZeHp2f2/0pQcgp/YSAYWJivOFmDwQ2h2AY1PGFsbpM/btrbKE0KZg3WN8425Iwcbi2W44QuvvykxkGMzYRAqdEoISlRx7l2VQFSjJ80Lw1hAlKqG+zLe3ozLCWDFa3WciWfBJvOT+rFSAwT+6CoQEQo8JrEGYH9OVIbFCif+EBhYOTRJXeBMY6xQtRGlCZj0O0b9uTovEDSAK0tOiYjJT3DPchGiUFS2CuUbrdFadF26mvf5wUSLAaJqITpWFBHNQAa51hRKIbnlwOXAT1D0BIlZgrS3hCETZ+s4i/kTFpJ9ov4ubM5JdIh72cwtxcizZrA7IRMGVuhigrb5AnOp6ZpwA3tf8AagMU3T5Rz6/4IHa2no239swi2L6/YUw4d1lXzTqKqjA/pW6o7HlIU2EE8ugvqCrzg2D2qUpLswBq3sojCppyfR/86K51WIviD8KSl8km0u9A5bA5WoYDODI2h5YbYuMb0ILQOzm76R2gYhEHra+/buhsGkyWr1WfYF8Sd2lqvpN3Ch0i5ebuioFDYYjC6yu7xqCT4keHrzSioZIw0Oe6bwNjz2WzC8CARiaiG5/rM7zavTt9Zo+JjGY0Hc8qiwHR2gr403iVmVxljfwuB9Ci5HxKHZ3q54UZAJvfnJY64A9AEgCEiTzd0zgOsnBd0M8O62oEl/UrLjsU1aNAc/JMjrh9HZluEcLYUTmqZwktXFxm7+jrqTFiYMxiGcJEy+kvUBAazYeBKPz4HlAK+2FO1TrOHTFGwRLui3Wxr7kc1NsIBOKSLa5xAPKs17BhT30mUZR3x71oPRIUJ2OQwPpyk1ArnkQUoV6hOdIkNWvcH9ZacJhQcQBRNUJAMZbBQgI63QVf4QuKseojiBJT391JX3SAqdgnX5vHtEhQmCTMPeu+GOoiyLCrZm30dMCjMd1WSutsXyG3B3nQx5xm1y14+5wzKLy6G5g4vZXbEDxu8BvI/LDERtAmGTL7eJP0ZXLwmYmVEQ2+IxqOJOKJChPCcEBYpmbfUWOi/g6kBy5GSvDYr9JZDhYIf7tKNDkGD6a3vv5UPCRzWq4c66qh6ubo5WdBu00ZYXXP2t2N/+TxPUOjgKcq7G+SA9K11FeUTxXzVKO5VpaJXr8jZT+g+D7TqtEpRh7zzUkgEFOKMFbquPRbFN/tKmE3g3/OqD9ip5+i8MG5ztHNDMuIZh6dIlqPMsa/qzTcoVd3OfXGz7AHZuSVjdcWy81yNwa8tc9ZpVAsDtFMsTcGDr9l5PtN7lEN48WOEitTqu4RzJVHV+Ll5f1yzq3zeNiwcd63G+kI8PlvPc76QcSZNFuIfzwe2JXFUv2A7i5rovB9gEwNv6eAkn7jyU72fncuqPITGXHI9++tduGAm5hYI3y5L8DqrgRthFuthdkPAcl1m0zHuoTIbB/n9UD0GVd3ylyywgWABOxyBYrIYtk9wHZdmW1BB5G2o3/k53jZ096VEsAt5ZOYVPY+jKE5W9/egZTEHkPTL3Ki9ZH2HcAY6h4wHdziHqpkhoGO58lLMTowoG2oqfERePSDxLv/MPVYOOxwZP25G9uQ78Xmr91PBwq4LVfLoJPPuaSekx1MUAI+sLK3J8e5ZjUYGCS1pj2HlyZeei64myQRG1UzZB4dx4LWOJFA0Cgj89n5evkopcy0rXgbo8leljac0He+HHId9cGjzxATNfv7TbBFQy+MUB6HESLmD5BMqHehDW8QYZrKfSB4Z2DZyqM9AkZJNpCmt3ZqaWTMEP+I46cmuBq+nQIsloscZxrNNyhV3c8GGS3AOrmfoTz5aeOWdV6d7ZVcAbi85yKKnElGeWXBboVhRE1lTRLugHTtmDhhTxjkX26zxZpUhqb1GHOPjBHMQfGasK8fXNkE0Bh9oPKoLcIVhgmIqhV+BB0A65WuXMh6aen91NWY4jpchLB4RD0DI5oYASq6lw7ytiXVmqUAihBtO+URK5CkN16FsuZpfzkvfANf+X+m9lcRYBZnzdn037wW0qlhiJw9ClcBVQTi6vkzKRtUL4kBE4A30yIoBPvIRvAJXxwNieK5RPRzX8YLrYK0zih+ee3nFpqO72nf2pXgUrgKqCdGMlM7TDqLlyv8eoZgoY1yOxEW84MQloo27VYcGV980bAdHZ4UHbTXRIvbNARWJo9qakV+EEUNbi2j+qMq06Dx3oxdGPFqdbb8Q+ujgN3x37HETDhMWLga5sFwmYPDRJn/X3ebtNgD4m2FoBmAWV8ifBQO6RKwez7FYSLwt2Tfe0y/pMW/1UOlgb3TZWIGSfba5UOja6cW9VzDsc3PQFLTAF5tWVcGApJbqd+IBMGLd//6dA8UQ96pyzX2V6MB5l+it+u8ugZyb+GKUlmyyfq5jnhJZbjoVKIfgasr26tp27umx59L+42pr7Df9CFIm46BBNweULgu3ggyIxa1CyqrnsYmBx0Sd0bEDVpSBfu44E7Et5dSig+t7+4eaNyeldBt+4AROAWeJXV32R4jJi2WUbA2u8MP0n0ftM2cUEZoQG2bsrBq6gZruIzkw5tzRMJ6GR+oQSuKocAcj/5EW8HqKjpWREDHmUJxmlYV4TWEcZgvoRO8Dn6WfswNyYZFaLF4+4KK3VoN1o+GGuEtmnk3VAoK7uIcxtZfojE37FA4g241EDSN4V3WpQzlN8hf0m0lc1+VmL/hm72W3ocEkXg5AZB/ujIhLHNSdU5eAqyW4npZprbZvQSTY2WjphT5U3EO9RURz4KZH3aRyKq4a4Tsck8eyE5MvmXg+0q5bqRY8/efZpSJ+T7JoT9eulK+Ie0rqwRua+u48JADhFH9yfMy71Eem67EhcDDjldfUmzrP71v+BpEAi8tH40dgBjwIpcF+EiEK4xKT5L1eu4PiW7q3K4i2T5W6V8Ejlbs9mW4EKCLu6xViW+XY3tv96IEuxMKH4zLiGYenSlhxWRaFm1uEpsreck0llNEscxTWAqV2+k2QRPwSy5Ho1i3Hcpg8lFiaB/fog6amVii4MnXX4Wck+ext4OKzN/QF/F1rDmDWxBquS5R+F2NqvOz4Omyud0QNyjHpwOxpQBFHKjMdzsTuSeUCJIG2KYTw68+eg1AdlYXnJgknHoeSAA3l3IHYYmgBqdjlkvpxekj5CMNAdqmhDWw/FtuL5wc84T/OvCMQFqp5q+ZhAR2BU8fzd2Sd4f3cihF798oPLHArosJ9CNyXmc5wpdz3O8qXAozj3X2fh8acuYNLt6zLURQR48BjDiMlFeppx5R3x3dBEJz0jtBVJ4NhkL0Ukm7cMZ3/67kdCBphLtjifQfH1tVen59IVfAYYvYRAyY9zyrJyajvQpAAHueabHeSoQ+mM12ztH41G7MPACAVpCLpUEEBQU0V4FCesjVwwUftTluRlW7bf4BEzOLnH9yp9wT41ECr03onw0KktOvdsY4VTQhqM+VLTbHwSmTxhXlggRu3tYptUYFdh4NobQm4Sm0m67a6KBCTgh9miZMfUxcYqojISdMsLty6lwWkK2gu8kVS5M7vl3kJ56cTnz7w77a+T9iFKW+Lcssishcxi6Vreq8hzAPVQRIxEVMZ393l6XTcNOSmg2EhKYzkAad/KXVEXvzYInscJnysD1vXpxB02jN54rQzJ+h3poUjnJXaJjDiMkkjF1idWINJfsSLet90FcURbYEFiLTvZjdjGXvZ+AEtJmKm+T1aY7U68/Z0mj8F/7hjTKIm5Ob+/9y9knLJVI/pI5EaIJVvXvKLFRFk4Q8Zts/er2Gw49jhUqYAHFsmIhfxDACLb7q25H5O3i6esdhFGifS/67Bcgn+Kh7BCIdcjBatGL8NS2N7fuZ4WD87VcECL9m4mIJvQTJ00WSvI8SWLVgXZQdoitnNVaVkliYnx5aMBlCpjtbtmVACWoYyAvacwnRbEwTKF05VCxLjHBtcI+4/E1jT5VM6ukEWKFlJj7E3xhmGN2jSgpQfmQ0Septb7f+BfCHuxeA7VM/czZZZzgGcpSyuZnuSWVQrpUgIIfj0iM/m7rEBHdYjm4zJofWmhZlwHvwsnVkDEC8aL5V8TiEPRpbB4eW7/cOjD/JVcX06hev6nU6skILNvPYK6jEuU07Q9td/E3RwUYhmJ1R0i+16itdqJLLGoP2UOVCXYWapaPPJvUIu5632JpoqzVaZJnByPErLcDKqR1jGjL9D/zfJhviXE34ShiBBL3fUXmFBVad/dPwpR1VM31cwx8oGoHs5LIyqL5nO5IqbxS3YTXpfNq9I0fv0kKPjM/Q/9BIKW/iIZWkHHRuBvvOqURfdhvDptY8DWGq6jtDs+Xo+T0nU0pL2zXNNg1HxbADTEFKsnrLXxGJkrB2Hwj2zUqDyPTdUk/pleve4taS8ytJ9pr9mMzb26ax6TgatVhnPQO9Krtr+wGVchyXdPIri0slGFMfZ3+aR/jJudbFgbGqH47PaMAOvQT1PQF9jZl/1QoWYZ1jYRYLXXjEwOKc7TvqmVsvseb6F8vc42YdWb7ERSm5ySjt6F4LCGTl8oIJ3kwJGU1fGdcZqvN+6yqCrT89SzTiY/ydF97Kz5vrACgdcwvvDQB8kkJ5GcpCvHuVzXz0vzpszEMPWoFq8DlRBbTpJletY0dT/ptv1MpVXY3WFk8JvTGH+qGBjHvI3tfNLg+pJXkEd/nwxdVuysntcOsjcmZwOrn5xQX6zzy8bkT6HxL8OJt0i3ojAPd0eSY6ZefFTdoGr2Z2dRuF4SLue53liqzldb+/rKVKmQtfCemmAvnp6c8qUQrOYi5Uo2O4zRnzPJoDd3Ktf1viOfBTI+7SORVXDXCdjkky9ih9p+n88PTF4AIiWQHe4ncHySlYwMoJbvVGl7OkgAAOZCf/gsLlEK0PmhuuLSZle9/yQBUVy/UNL4hVEwYvQMMnP0vyzHMZVIRIWB5zWWLnffBKxU465Nn7sPxDFj5R2vpMJRlZgV2AxMiikLaGVuv74k60tEALyK3hh9uS+QIA2mImdlMf3l206Qv0zf4j/mvb6w01wKhDI1UaHja1kBXUxj515DvNd1VRXolQwhrmizQG7mQ3c6BQWwwS7DTSLUBSu4DxqR47IN1khyUiZdgQpwoIV/csJLs0S1hUZZ+c7ddp3xRZ8N/8TkxaH90vCKGcUj9W3dmppYfHnsv5rkJRjUZFcsB48aVEqaFr/zI7442G0fkvHltnv4TjSMV/9Nw0+zKuBQ/Ls8hvJQEh5GRMRBCtv9ntKK6p5F2GF9u6mtlmL8ZDb1R68/JCPucJA71u61Bs8esorZk89oPbDVTaa+baDQDQrh3rjp4YA2/mFf/TcNPsyrgUQLycOckVduLDdXoMinmtm47/a/MKRyr6bT27jdPdOQ/zx+EZPY4/wS+y6gHTzyVmnl4++t6oYVK5Ohd97ot8oQ6ru7z8cw+6yWUtVxmd/0zg/kwJiLitea1h9oG4j+3/1KFl4Nb+SPuB/RvRaNr7bC7JdwOeTsF4a86Cjkm+2D85cupjJszj5LxhANj4b2sXyKLbDCKvjVhMddue7olOaDfAjWgdEecBRzgjS3n/vjbUt2Fwd5VkGl+ZhN1cXKxj0jF5QnsLAqj3v6/+IyisojBADz5lFIguPLwXLlTzYxXUAsLkF/QtaOGBVoLF97glMOO/n5DDXsItfkLwLrF7ZRUVygwo0Z2AO8h3yUUo/DBwbMl1Yuy+sj+k6mo+BcPZtKmURjp6DowvWegVy2ujuCjHZYyCGNMidLOeQErcqELwkGwwhnABAmnQzQzf5uw+wVUOzqKNX1Ggm4EmykG+WqdFu24GM9K0KkUCZB3Y8KXHJSRyCzRXYNmLU2kpA/01ORhkUYkcwuCrqvtDRdd2pgz7lYiWUTffLikLcyo4f0qhTFgnpgOKfrMXrRwqKjgIZsErRpheyod6/wX3cB4i/EtFP+vIWAZkNucLih6cxJlP62eLfpiAAAAAAAAAAAAAABKyGPcxgDdclWt/DlPGAVIYuugZOPWJMGaTgOAKaQkRdLp8atVjFYB3wLjFAO4Zxnk5p3aUvLvo6k2qmMDrNwT15EdZRnWn4W1GaW41MksJBekL7PAB4LJFXIRQPZhbRlgDkk+tNh+mo3rDXw2SuqvJSepUD+pyzQPimyANteD7fsRnilOD1NLQ6OAkZa3it5lwjI6/uljXdDrNFUtWZvBcLeWLu+zvXkplCaHJUB6xFrlVb/avHAnVTUzWUiGrVKQ8+zUD6eQCKwI+QABZnWTSrODeQu2fPi+eedsr9EEF5rI5dyR44yYKpcWPPl+dvASWYDVRaoAwXhMr4j4v8YCmK36xxU1YvhJ1a0Q1cFpgXFbgkL4+eEEqltvGZHekdU4dMK4UHxarnc+9zSYgLoeZecfzaq2wV8rWndm3c0PjcaTDAl0xMPdTbzipQ1XPnZ9wSr3KxQ2nykW9OKVN/oYLWlRRfOsHF98jyb0TzCpjRNErw2617PpRrvxCnB7TShIleVtvgFGhWS8URjcQM5WxQlmSkS6ilA5/y4AwSjmPcaMwGcRuClfxCXjEKJdcVB63xel0OhJkxGuluUUFCKq6b9YVeBXlDKUeReJd1q7+2hU9zjC1Hah5rR0Z9SizetnXkAKaYQyIEew+XrWckhbLCL27cBrDDX77VTLDlMINoDGbiNPv1EgKxsH/dJ2IJUBNaGCm4HoRUCF9OvTxGlpvmO/sSfKiBCWVaSmUiBStKRRR7x8nBkHWDNwfce5kRamWkryWeNrhtqWErmAAjB5OTOy4c+DjT0CkXzAecp/9O1MePRmz27z7J5555FtV9GJPbdPN4igrA1j3H3eK8NvDgeMqIIoGr9+EOgKOESKJWttRBusMdM0tXD7gnOIblFkjjCNPYo1q50/l4T5uKKfP9+oKqIUp0vCEhB6AAOL8zlPDungBDCyiPm3SlHvjNX4kkUpWBjfyvkW/8kcPQxCgABuc6FpOLgNOeSeZJf0IlfSsSmuuMoiNdz0NwjXuHwFVwtOdzmd7SACjkLhehKBuPpUzov+DwisosMLzYd8OuZc6ToPH3sHZ/iq5q36nJoVy66sks4rlKPsq4x5ANhBDW8qPRLRF9banQTNlYzGRwMX2qZXIYbdepqtutpLne6W8mv1AnIOq41+7e8UewfV0NRKn3yD+652Y1ZdeiE96CDZTivOI7upyFZ62s8/BCsIPEdq4wHRb+g9u5OAWhuoc+81jKtJL37O5fEoYfw/wUijFxL/aMb64B5GsB2ds5dHrpRxABRHCNqLyEfyXaqT8uI0BZMk0V7SDhu6n8HUUbaWjgZq5im0CnAT1agfGWLQ0wsh+UPJE9FigJdZbcHuVsmOg5MpamTE0HkoDcCPDtGkLYzfFRKDsG7mdN0FK2UNDSzuVfQ6tMbMCQFeibTVq14iLwY2lUSihmf0+uSSoGIKrl6tXxrxzWobspTpaQAe121hRPiEunFdsfgvf2OdPWFhruk/K95ugndrygV61Fn/N6DTQAkjbLehCXn5dcxiwYvcV0KoGB3gohvqzH7JKbW0jYWYgJhkZcD3sl/PQGAa+vpuu1GyUdfQGxac14ANEqEOiWisw86IDWQ7igaMeZya8R7UA//Uo1VoZx5wP3YITkYLVdYSE2BzVnuM2q3Y69WjswFicYL5LDUbHcDoT5PRIOBExJygFHf3Iy64I9n+eVl4yEn1O+A57pqSXolMZjL3ldRLVQhvkxji+1CRmKBVFAbEd1zE0r0FgtArKVTJxfyD8u3oRXBQ6MRUi+8kqtq6ctGNxv9+kIlI08meN0uZ/14pF9i5vDTRsUd0U25jATmnrsUnpNrZvuk92X1NhF11vzLUEIQtbHCVVbBxvTd3tTwLZpcUElLLuvTMT61VldCyd5c3fA9rFcGO3kjSWYnbSx3f1IHP0Je6CZkGd7CG8mFmGQdoU2FUuRvcsA2qojq8fgm2vUX/W6VQv/t/qBvbNM6uKqUme4tsUndUdQyontH6BIw8DSozhlLeUam6W1+TjcAAAC76RIzZxhjcA/T2xPpp9Dj/JxdOlBYWYUx9ng8x3C4q0IGX6uaiw7bGnwjtJm5Rz2S7W3xyt6qi60qyiisB+yLFhnsC2ITHN0crOceXAK08sGL5oeHZ96oe4hejfhAr/8djNcys1q7LogAentqpKVtMnVey8h9CkAAe/Tk/3U88B/ccYTo5+mZOjeSzmlOJr7UPYnFxHuj28xQKOPqz/yxVseLJmks91qLy4LKkbyGgSvtlRGbCthjDMLhGEW3BV99YEyyWOLLmhvwSYfQ9IFOmx+WstAbLTDVfVhe1+tPUoyUwIZwjXOQGkRGMIWf8QQ0zB/wxRaW/4xwk1PApJuNM7meF7q0/sQTLMemnY220fV2tWjT7eKrxbzVoPCH5GgZa4hbNnaltWQajIIUNC0F3jHMcE63BC7Co0KeU+3bYtPIR3xIWzSVLgaj1JNquu84tuiVMuOwyvwmKtVLLVMFRRZ9CwbYMXzlumBRmO3vXQt/sbLuaVuT6b5vJgPGhuchBQZeg+NkZF04EAqdK1wFsagNwMt32Vph2OgItCQOZ4xprUMb0Uedl/ftYCCvYjysU/Tq+UkzTPR8QWxZrO1Oy5xZJbggG6dzaRQGnFPdDWtOxT1JB1ZULYRcstU2K02fhVCY09XjMtO1JGf/q/qc9E4Qn3lq/K8Hfs7Grtj2pGWB1jGkCw1GNpxmAIsW2DNK4piBF4K0jJaNzYedFuc5CA1ydjLJ4tpitbIGNXFO2OJgZxoq2QwSszSAUMiXPv/ngy/OOMpTmJa4abF8b1JbaxRRRcYyUm2Xvi/+wSUEnRkVkn1giQAyrQq25MCtmvfUEAlIBCKjbZ/yfTkh5Yw4C8M3aFmyvIZZ6gggvxcmHA4XS84tFWImFHqol/R3c5CFd9MbUb2spZSaKpx+T+jocsuIgAGvCiek2yB4hT8NXzs5u94xmSSbYRfLM3N0NKhw2WPqvFFH7DOjkMz178wKXms3RD6bPtHDRDwLlCTIo+x30hMhWSBwvgBQ/0KT7QU8HLeUPNRcm59P/4Rm368MQpbI+5qrITt57m/1rxA0/FDGcfbC5YayQMeldtisuum7dUPoB0R+xb2i7/gmxkZXYU4gMGAL8T50uOyOT2weJgcmHZ3vJ97ush5DLDK+lSxNFJUqnO4LbSXUdZO3GmFGXAGkXTIsAV9y8wsGfo9AU/ahECzN/vBqd2H7RMKq7P66iMbRrxQbdHmOt35JnaoIcZTvCG/CjnsAN8wJxyj99zqp1esd6Oyz9URbtjGD1vG/ibRb4Kqd/xkhNbLRKlPx5UmScjbnfkYbD9Zi5rP2tPmnLyrqa+B0ak8fZaDEHF7wEx04pdfnBl/lErYpOwER47x/zLPY0celEoBpx3Suibr2CxCiDwU9Kuc7P/hQt/9sX+3JxiH05ANjm+I9b1FuCnF5H4uDP8T5e0SN27yZiWfEgO3qDsc2BVO5IrRzTOK066o7nUmsXMRFAKQTXNYdISl58JP6oox6Fm/52JCOIOPYIeyWrN/gJ4Z748cAXqEBj5v4b8q6ra2AKLj1ETFZaQjJm2pGoYgatEpD9igfWfSaSMxenUgNaKyYm+vqOev0U6DVA3bLlBrPj/PZEjav4TC6PGRYOvJaYrato74X8xdDvHJ5ZOQp+TL/mgGmzQf5RkmiGyOpORNjihUp/HHE9hssYixZtPEpX8SNfzSf11RyyTJjcOFwysr+Uf0zrwm6f6PQgrEiyi99lnFNLHg/na41GuCAKbb7tqypoui+A83DCfSc9gEtxMoWfih8RWtvZ4B5lqbITL4JlbZv+9KiMjWwHDcoBUnFzwq2ELnmgHXOfUKXhX21QWDHCyf1dALLFsIy66btgWFIBDF2rqlpNr9PYB/ozdxzyT4l8j8EQY4rULYNCmgOxaVA6JcYjr68PMCBVzuqPFImokPa5Vesoqlgd2Bsiwgf+9q2dvt+oJVgUnG3NrXQzOtPAZFH0AE6NHqfAGYFGEMHjQMgm5veTaT4zOFAOEcndxrnMgINnztn4tIoCjh0e6WJlkiRmmSWlj5scU7FxOs2op8kAtDD21Dy8hhRI6IMnM8gN7X/PiDjdadxH6mMbM0jRFVQu3AUT2uROeTNDK6tqeJsvvMQPg9Y+wX2xiuLHZdHUz0fENqRMDJ+sfLzfCiz7wtXYe7xGFOBtfeJZqTUbRlAV/tyNQaTs2H2rnpF8iswOBJqhwzBoNYFrsWi5SD+OIYIE03rC4U5gHnE+RBCnETZjHl22hQ+cBzsZBWPbtSMAP6IVb867oTJaqh3vg8eU9PlGPc8MCnCk78av5ZgZBlBXw3yyIuMflwWVJu1olFaOlweD1od+miIx0w5NXHOmhxCeylNZ5g183RPibHveNM8sV51QyOOJui+9NdnnXanNR2U3tLUOneiErdGd0M9EaERZddIPXFpUpf7NtQYBiBeWd3XZ0W3ZD0w7mf0FgGh/ZnBp4zwlJ+u3N6r/N3H2MunVdmH0KDoZqD/MqUmwc2G2r109m+yZeN6jJiBdBEU7tmc+DnbSFuu1tRz6FBR4n3BSBmvz/8ViRGrz3Q/FHaKmxHCig4har46lvPzlP7aRXfGYnyuqNHJhfp7miVl5j0wG2XtZ+sMRWJjd7xmHqL+rxykde+sXuDZsJ4C+Q+tWtrbbm3LolWpCqYtCRbHqUxFT7Kjm6HXNJIWuxOdIx8L2FIujgTsygyCUNkaby4L8fkN4bOgMmRlEMGSKQu+5DRpmIRjhjLOp49avUuYqSi4F0od8bLzjnnekEDII8zFlf+Vvxpb5awrH1PV0NdmHdvOY8mlYT+d+9k2WOUjfgszIaD1mdHlrNcUyBREAawj7u3YlZEQfmB647r3kf1CZvckh6eyeiMWey4AW+UiL8cRDK60Ol7kwyV8IOCJuQNyEs8Klom1btonII2UKEccObPX9H9uhgDc+NQcXHgdJPu86CGa19zH5dsEjTsCURMqMUeOl9wGvCw3LTUbQzghWQ0h2qlcz3A604TKyKqcFTMVMv+6/Pid9cBNCUlZpC6SevYE6jU3dJpkxcj2Gu3yrHFhowApww2ZhYW8h7sXn9wR0Hz/ecx2VyYO2kg1eDSJslXZBfLlFjgZ35Re9j9teyfZ6eSsL0EKgbML4lvqDQvZVvHMcsBdaLwvjyFkljzbcIlfK0FA69/olSYxk7jakjkLDHVtb1VZ1+k/X3yZNmowyHUvl1pKnIiO5+Nmf/G8+fXZR3XF9xVsC2yCKw4IRcnHoMjHZLXeQnH9vfhjwFoPnwoO1OErMoWDn+HlmRmRSf+pIKblKEfpuie4XIB+7pp0kU6m5dvKglZ76yI9CGJb9p6W9xOfSG2PLU9sBcgPcflyy9HQrJaNAUuQHIaEcbxRHFF9CC/DYjohuq0Z0afwxXMk9VB1Sv77FOBWkFo6+KZe4w55L4KNgEjP+0QJVK1mm7AEAW/KQ5rVw5e/RPDOOQeN389sNGO72AEZvynvkeppDeDouNSJEHbVwl48bVzTePUkRUub3P7ONpQe+kn0dv9sreYH/n039J0xh3/Hw7Pt6/ERzkrgGnRdaiAM9DPXqQBbbVLUNioYWE4YNKzpD6MpXM8Ktg54tvVupPAzFqb/oyGqppMuMq7afc4tj1thI6NReY0dgQaw02lHCHmQhtQ+KJDNvuaTzTSmUrHLE3RZBmxkN1zHHIts9zaq2P/L3pl0q1FbfYBygUsQLab9EKOHMbshDEu+Rim5xhiRofrdVqVP9/7R8bzruLDAeQ1tQ0CmEzHzSbYjTd9gFWgiIAn34NDxLAg4XEwfa23N6slufzatSE3gUNf4zw8qu4X3pVhpLSAgzdyEoz76PvYpd2tflUTYGPTNBKdcbl2oikQlIx9ZqFk7j9P3/s8z1ycjW8tMIAxzPQVcMcTe8pW9EpFbJfOxVtZGYR9RdYMj+GoJfklTa3xw58FFU61wdVvO0iFgSD7TmhtH3HRxYFH7LDblMegp+3N4Xd3vAvBOa+6yDwrvOg3q8HOl0cpWOt5REPvCEL/mnJDQnzjntTrExnaI5uxqZG8Y0Gq1xRiV0o126dR4vMVsNeYZt8m8ursES9wCBp0xOTTgd44JaFjLoMaTgfULZE/Gx19fNKD2/Ojq0jLbMsm1gvXIS6aE4TSs4gDpAGiA+y30kVAAE+y8mAsf81gTFj5qAoo+fztOod/F0FAi0agPwMVeKwln2BBj+AIsIL6diEsVi2zZrw9J8eBb21HYRmIJ/tss5Rnt/FY28YhBevQfDWv3frmgl6MwSd3oszyS7z6U1aAfW9xSK4YLG5LyUIOq/qkEvoyyfdRhJJk08KZ5Iz54E7IJZai6BGjPzZO5qHCnlhsKQ6q0WgpSoLFaWUbvO/Bj7YNKw3pW+s6b3Tz+Ypoo5UmJqiFyGx56Gs7ov32bcE1aayWji6wJrNbj5sDDFbv8sPAX+OPBhIr9jk6QNRVutAS+4bhixrglBUOIAV8VIS8cGRtEyTXkFAgpC5jKYighRrf52Yl/T5R3Ilrl+QCntYsAAIqLgcpSrTZF9VgAAAAAEj4GcgZg9Q/SWADlS1zmjiPAAAAAAAAAe9YkCCxyk/JCH5VJpX/Ldc4/8XBKl6W3gvz7vveqHzTmESlVoUyQsbNMeYcW9nA7WIDWLQA6AHQA6AHQA6AHQA6AHQA6AHQA6AHQA6AHQA3MJOBuAL0V3NuZz5+yBJ/S/l8Bq334Q3/TMbOkHZHsSrOwuOvTpABPrexkvJ7gVmO25Wj2kBw+6pCm0f8geuiRl39WdeQ4+WtWsPUqeDnlsJgeL48Rompurf+HWShJe2Ue38KiNuSPqGQJjAgG51Nrheflg74hWvHEX0ZGlpTs0DGP/eWB83xztgnKc0ns885CS1A/4igBgIozOApHUIMyiXJ6ctYqYNOujhH0Jw9F7NZYYVsD4aXsHpZVBWeoG2K8VilVDTlyhepLDvsGJ+PJ/51bkf7hBV/WlVDY5NwZQr0lCrak6ddNomgZ7/ZCOJnzl6Ab/FN93jiRNZsU+8jVtvCQQkKSXdPjXJ0kOA39qi0rw/W1Yp7EGcBfd+S6kAO++E/o8p2rVUxdhV4p6RjjpiibWW4DK3wBSHL4qKYLAehdJE+wxKpf419ox9Gzj5TMUmXgpe0Q2vcvteKB94EnKKB3JyCKvH1frEAQn8sRMGysN8hxLjU/qySyvQSh08mk6Nc1dPRLUvt+xKd/yx7Z30W5QMYwR579QJ7r3iZ2GkL6cSwaKzoCKxPFdXM8g7eUj+jkAapN2Rn/nHp6oBF63yZ4hu9zCSgBB3W5JZbY3d894sf1CCsCFXAe2Usm4POklFZmQDXA9/3M4H9GxTzUyOg6Lh1Uu61qoUMUAtK7/IdqAZ93SOpRnNAI/Rlxobv+h//OPT3q8qSq36pQYI7Sz1wu9/+VIEhJ4vYhQEZg12mVXPJHwQ4AybrIoeu7TElvZF3OB1/o2J7X/uI9EzdXktp4MVi9AnH+j2budpzo8ANN4n3Y23TSZljo7hacaDGzi86wwzlYh0IdoS7LgANuHlwDr4/0UAl+ue4yPTMl3/nXFINVhkGQ3WC6zHO6x8VCB+V76cjThWQiuXA/WUdkwHpJXjcKRkwcloYhoUGkS/PrJA+EK0Oa7QOqGImHAD+J9DBSTmGMLUSVKrgrzpdBeLpWcvqPPGEZFYjbgsqPnsKPE9bV/W+bUPFulI5cmLcme+SGvQdhttc20t3QW/Lezn3NHGpiZfURSvxKgL81M7msdeJDc+uwBAsWmHu6OgFxiG9kIp0Pm8wmDjdNMYo5nPp2ABA89l/lCtzpJhL5CpT0E+F950ug3N0crPuKEJ/wAikyNNeMAt2Q4J6pcRBG5NcfgS+DO9BqK32nEgTFnlo3F7S+VUO9XP21uoKVzU9rZK0IZv0pZE9GYijTS7EK11bbH/w52ywL/mXxHYw0roNTm8rDPuRJ29CPT/oK+7IzfOUhBCcaiV71SCn9KJ4dFZGq0ssxbMCsLoNqSWarUzMbyyhX99yLf4yBlX769r34cfzE1Pxh+3IhZZIxdz/mEu35fOb6WzxbNSIFu00qZBQnettCC69SLywdqQ8CsLyWVaPjFqRjml6OVLc/T6gjv8loWMs34A0FD4KCqcZpIz8pFmhS6U5vx1zLngKM/ydn3PxRYrPpA8tUuY5Cza8KG4+TMflT0YhSabQwNcwMnWf3+jw5RXFpwfSGCG0d7JQPSENnT0Pg6ji7ibTdak1+MUKUjOd8BpEJA+IoCjRX0H2wrYOowPRPgirqz94/4jIDkxUB4XbA8U2mhffIkMmtxl+J50FEWqtmGJyrQAJuYtV5YBZqYRNTkruV5uBFa5JAnNrcTY4ug9gX5HTHN0McL+z2MALnTpI4uSNEnGHmiLy6sghWKY86OsWBphSSh5260/TpvxuiDul4MU7VjGChSKkR/5eY2s7GHrIQGHOKGZjzDPRcQW0zeZE/NtJvIrVOnSEXj+k8lrbzaTc7DK76b0kkpw5jq3YuwLBNVbjzPd22/mn1dcgj34kyiu4UFl0eVrwMh4Du3KsutYPttSbX0HCAf5mTtNebwqF1Jma9aIMNjLDbTqbaOzaHe+awfAf6THj5q5uZLdQHv72khGbjP7l5AZFaZIQl5nPXlHQCT2TRuCOtLJ+vQtjQG2QF5b+UMRPIgNN8M1j58N4t/jhcQTs6KV5FziKwFVUuscZB0NLw+l97ncNnQN/9nUo1QPLwmf56IaqGmNW9f9DKBOArugvn2Fh1vLuZRyE6JI02y1GlBEH11Cx+nu5GMcxXSG01IucrbIWiLiYU7ErWOZDJuzQSqqj2/SDDn49YZ3H3IgeCWCquFnc5RV3ow+P+lBwn3AZ6unDZ1/0yy42ZuL2yYieNCKnheisycA9O6CnHrHLMDpOE8omY5MlU6SBqMjjyCrSQX7uR6L65KKFhtQ2gEHILUy9j2tio9CS4yFIle+/in6zp2wRO1X6VjNS5k1b6kWmFTFxGrCdpN+NIqrcOS/5UIIAB+897r54UfFrKyxIkBvH0VmXpij0lOoq+8v/R/wgBUjwHc6nw48Lhc15dPziPPWlvb81ESUG/iAgvD/ZfHiDxPLk6v3TBU8YnBBCGO/743PaJLd5v4N6gESUDMlMsOlHEmG9jCACKbQU0jv6pDpHdtEUB7VLFzFXgs1+VBxDILERp20aHsqMq6m7XkPXzFgqxGRYiLu999X+xgMg21IGuxSTQxQ8DEjKJcd8HxuJCYBYgDfiGCC6uA53qac7lnyv301m9WbJS7GkIk2MqXxKhVjhYAusRJv1RZS5z+nCT/lX+X5BTHJVqGKv5JwSQpHPnyFRDy5zfURwCie1X/8D7woParBUNZSF+FZd4EEbd/21kDnUQb8RMlKu+fCOaowlM0/5OkbuBeIEDdPSP7jdB9rrk7vLTCHJS+Ml1kM+Qgcudde+3L8BCpLppNw52CWRr3j7LMRFW9k3IYPnZ/5WBsOSABRcQvmr798L/ucVLVt0wxpuBOZbegUVeMY6MIvDNMT6xk7x64+1IBq4y0d/AEXSUy71WTtDPJZ+OBj3vUy/+N626NVkUFRF4JgDQ4cCcYF+hBrxFgLnDxbGIv5OpRgqBpR2caQeHoxRNyJMTDI/1FdEieoYcJOS3mUOuGYM06NoNGWll0zUbomxjuGGTJtkcsBV/mLaeqV6J9T0YEHhRjAGFzM1yUx0xGA/CfoqURt9oGKoDJ7NiZTpp56JtQj44BWWUNKETrVv44V8HNeGja0NBunBjDsMk8m/tYE4CDzA2ZXqN24xPL39D2eEXoQU3k02LWu+LnJdq12cxj/I+lceKu5+8NtZ8kR8Kb0lhDWtVqN3bHdhIVJc4qHO75E7N8zAeVJrHiiSxXSXWgUcd3gDv59T2o19lwawBls+AY6Ofqw5RNIUO5kSjUNIAME7yNFk1l1UunsQ5zzLNSbYeTSlUZZcsC+REGx4LxtZ1FBk/XMNccMk9kuR3Z8OqkrYGSx/QCZMDHZdSTYJLQ6wJLkEKypw0G091TGUPlNoYsIW1XqVFg1qDp3MiyZ4nJhZoSRBejZdrVNzzyVUDAu/f/nrKPrQpVw5b6EZ48cecPZht3Cc5B8U54ZiqIuxVUt3llk3Eg8FgP65xkGDuQKnpVRvK+5E5xrT+pg5NF05hCXlXwG6E3RLzQKBrmXbPkXiA4Bs7qpptJLF7FwSpQnTfb+JZbMQgnJJmFhHIMEAo3QQQMHjqJoR+odMXYxJ1bU+IXS32Bay2j4WOTiBSAgxKZ6/gd5Ged6rf3yIaUxUxD3iAy0DaL5BQ6pLQzHFX8AaWXODoNAjy6KgOhsmJSp8kHbhGl7H7P0TXuW3c05CuRSHdoNOb9cOo+s/na2iEvAKy3thhUmowzSTytMB+/91raOX7/fkaIRCPjhcZrz6zeKaRrkCClZoT5dmjEA0RYrnQ0kjOfXp2wer6fKhICTql5RRVTaqqucP+/5nqTP8W0PdY855EM/O3lWOAcSUBz+VFxvFzsq7mp0DL2ak51ZhM6PuOJlK/cxnlDQEO2aURWx025zXjSad4IROe0Om7zh6b/6ZabUFZPFTbr4LxTLgsva00audViUkD48F8E5usFC6ewC1DI+mzULfcXV+3v1MuRwUjHKHVhqRuqZ08+Bkbz655jA3De48Kih3ftVPZaaaspALEownuFw5wtPNkWSounGFyp3xVcb1TNTnKPP6ZGRW4+9cGYMUEbFk9dEsakpN5RexJlKY29HGY1KXAIKaxolI8NcNl1G3REa9ir4Q0fYJJkgbTKAt0vwLSbL+FKg8wGhVxxT+MT4DoafizInX7ao1hBZj7RgZUvLkTBiRcmPBAKMmFxvzbYM+KsjK/eRDlIF+0j0iQlvcvYbL934L+v4UZfkYfCjQR+5zDbPxLR7R/Ir2+zyEECkyiaTy2s/88xH6BbfXimq9m3YKC9WRJqOJxecwXodX3w657KtRm1iR9ED3ZPNxpj81sn76IbaP3szHb5/QK7+gcf7X6wqcqtAUy1vciqByIbRsA5ZwANNDHNRkWEp3gEcU4IxTPT8w9m0IIfLSIEVlMkOxF5R2n27iogpN2EsrqFjGEdbYVOOhwRWoBz2XMswGgFjl5EfGDIxCeJrHWIUeEbpEcHkJRRqv/GgD4dilhd49vND7IH5l6BpEAucsX6A3pI1t+XY0VmXle0fpDSmEhFHWjRNJUEKbrWekirkeIU1S1lOO9x63KLfJlIEJS9S3QzniX0xUHphE1gMfoKs7aIJUwnTzywXg/gzRWX29jsrdQrZkbJshgxCgUVLxcwgVAA0c285sH7+3ebtNHn4KNeU5lHaPfEa/T56H16qlmKe5HUeDdeuS4ITNhpBQIB2CBGBEdpJJGjcZ1x1YMG0vmRLvxfqYwk/95GgN3FzYwh9iBDamVSzaeNhCULHOXwqyICwZ6NENi2b8hntw3H4MMDPrx3m2Ocp7oZfSifiw94oYOCBCY4WqSMwhMKozt4yuhnVCpxDqVgUf6gyQ2FH+ZsHDaWU6l9qxiaSCxw3t1BVs1wc0NrDVYNDXtm3cuWtY/M/iz+m6ZRySLg47MUauSi8p4vBUa+327g9++NTQYz1bvAW5Fc9jy/tQw62gYxsJWoh+r3O/1OiARYzdEnW3M1Yk4yx0jn6Y2ZNuK1BhYaPadrRyB+aLsB6HNdGyzRDF1Gehy1kLQThxA0kxKmLmx9bhLx9UZUdsq7wLnJF0X6h+hxkuaQVbrK+rYTIwf4bxLQARd1/TBdpRgVBGAFK3Fm8AXGAWgCX7lnL04sTunEK9cITV0hQkbnoXkzj5MK1o99JSr1a2m6anASVf9S41Z+yIVVimDWmoC6CPNiOjAE30epOI2Kw1AlFbDc/m+2JkTpuTtXqRhzGP0m4DQE941D+Bpzcb4tbXmUw3LTxhKi3KJjSukLkV8hXKsZO099nxFjfPgFjJr8JalCK38lKC4WHjc8nHAzILr5Dk6xl3kYhIKd/ZTAuSXugy9BpwAr+PfX8w+b68zFGl1+RwOZTogbRDPBwlLBpiZfw2uyXfqIaxCDRaGaXWn/+167LV8aglLwglmxIMbM65bojGatl7ED1Dg9zPaaD1Hg4wWoI4X2u3dmufSDbYaDMfTwthMMLFOaYsC39DRfz4hjxyV/OhtsYsaoPeD5XaPBao9cZoS3rPBEMJh5J89zllvZSi53KBuHhgvXKXwicnkYaTWhJzkpyjS6/I4Gkdp7oxzhUPP8z4EOclGDlY1sU8m7YcOkm2i+4jy7jqigqjAq9RmDL9qfgnKMpU/AQrqO+RBVj2tQ0Js555Z8ZMCFNgh5FBFb4DBYi8MsFiCUwQQjcE3QBvlL9dZ2ertPuKPIXhvdY2RCcM4mpgeFxDYh+d2ZxBCogH79UY0qFoSLr21HEi2gcjtLjAw1sVVqG3AYW1ogdQzoxAF03Eny2qM32JS1wGPwOF+d1stVTJKVQGqA1UrTJLQNsOnmTY3mp4CSUudjrWCWmlSq4KEf7ZF9QSNqi3yraWJQ7xMbLEEgunl5GXVfTsqMdBRfHGiWu9IF0JZGL/H/t0pEKeQOh7v6y0EYgpVG6yCbowT2/S3Yy4YbVuXOxCDsfvYmPofyHSsIwz/i3mQjb4d911o7ZkeDQkcuOzQxn65H5qnhOOajqOilmsam8obJ1AEutSLGCRtGADXo6RzC9fq0SHFy58RhxVbuYizWe70LFd84FPDxjgVqIhTyjT8vqhvfsvt6yyXjdN1npRBKqCu6anHVUs12ne48nh58iSq+eQy1RReG9zikTBOL/XfVejS3kL4otWBgT/K6DTj9IwKj3yrGuFNLYh24DS2Km/aBIFQ6dswF97Ex9D+Q6fQKPQB1otmOQA52MiHA2GV8obD85KCcMXQ7jb7NmM6A+3m/vRZhcbCiSeDtx6yHkNF88Uft/U2HMmu0CynRIJ2vEAGz8QQqj3HAQfXDOOqa0PSRxOJXW9lfnk1hVK6uB2eXVJ39wNksBHU648vA2itL0Wvu3cN/dpx0tcK9gOApW7h08j/mvODXB9iuCga9qVMPG33fNQ9LBhqo/6LW8ddnm7si1kr+eVa+dVc0nfvsL9qIMWpNGoSzUvIrhKljFGahy+N/DCAjGCgqo52BAicyn9xOevvf6a89pUFpbCv09LQpcEQ0av4+dGK5rByhKbYWAVmPwwl0fDiKQPFIgEDaOkwe8bgfzABOUrfzIgmZmgyVSYmKODZGvhr38X05TZ02kPYOnOwS+6s4OfjuCV+Orl8O2EiDpFjAM/nAS3R/xZh6VB6wTsPQAKIKL7+Tkvoyw/T76VEs2gk2zqsAMEjndZuVnUxVf8Epb31r/A0IUJn34A82SngLUPqAJH4gV9Mgz8cay3oK+XOxD0WKoEiW594SxQb9I9ENFjT5bJcB8VjOSncEytL0Af2aK9HmuKASki2roocNCqMwoxCNWzlQR2HzG3TG2lC0NE0u0dDerCfBhWzlQwbt9D/3BFBvcI8C5ibeNYYu0vEf7s65bfqUOIgC+2NkSGsQGsqNJHniBYRGIUAhALrSyFdcM9+fi4H+qw5hg4uLAA8SZKvQ+G9LnFC7Qo1YVJit7ADZuo2zYxlNsnLxAHAFhZBQEGS2SngFTwObvgsoDyuryaSunbLx78o2OJVEK9hThwHDRCeNLG9OYbe+OSNI8ORJ0fR4fepU/TUuldEEoeDEC0O4/pnSCHAre0zOITjDT7u2+OfeA7Eqwpkid/CQSzll21z3di4bgafSpz/ZsbA+31LQYRVwGv0ANl3AdTHsV48fTJEFStRu+0LmglXm6DEG83vziaAMbS8vltTi/swCudtIs3nbcQwCUOB+I7NW6FLRORpWhd8vwE8CVTSEMpNA7gIudVvlh5q4HQd8hutgjjkPjNDY6s2D6zaedSG0Kjb6ec4yChx2StT8G35XMn2hx/ijhLbp+uSvQUSs1lvJxPDBZVkxTqsMNlRY9XA8GfCwf373ou0n+bA9gtOundfO7EqT0NhrsYRN9M44AwCRHiPPLwfpOByf9xlpTsIhHYV9YSC7FxrM8IVeQ6I2BVO8qjMFeHtc5S+UrkgeapGaWsYG2DQKRyvFEECnd0+R6AgnWDtcpRtvLQro4ftQjeuJRhPWjhTkJlLG+mZ4QOAByxx98L5vDJuWeAf+9mBvR8fpr5nGPQHbSs5OXDr0iOf3w5M2zd7HEOv0xSFxB1uhS0OAoBdz9c2W6YifZgY3jn9g/WC6wb8D6lunJOmUPh4NvzsH7cXzd4CvLGOTrbB08w4M+Lvm6k4LKsmKdVhhsqSwRsL+XUXLl4CSdtoy3aYB7Bu5RKknr0nNVzECAfcT8PFt6fLyKzFtkGHRPuFc1rm4U8B0zbuCIVF/OsO4mt8KSdDMonrGGZRPWMMyiesYZh4F1gmMxH92FdxYX4Vb8+tGtoRW6V0QQsDQKRzgIpGWJBxjNMw6jp67UXfT4BhlMjJMRV0CeGOtyg+QggdX7cyLizG2Pw0VoD0kuViSWATFZggbsFMm5Z4lydsFHEfH6a+Zxj0B20rOTmUQNKftJm7Tf31DREepxbjkdhW6FLRWTINllX/wSpg4ODg4ODg4ODg4Okn+mfsJeaoiWOhrzRcmQQTAL8M9wjwK7HcmjIeiE30S6iI9wyEjev+FPMRYUSaCR7Pp7G9xHniBX7QrrVqK8G+B4M8TkQbM4xSwGFw0kaVQH6ZpLgTpb5VfUh7T8Bt+O0JosLOzAF5TBz6elQIXvB1a5Ws05E2RnZ81Kbg4BTfev0q4KWWDhm2jPL2xvJKbnOi67IWCcI9f51JYxKFGU8WJ8ddAPY6PC/+M0vPCqlomN40CO/ZTdzOMLs6ZlbxawX0FkDd06rGpVweo2O8o2mF+m8VPMQvLaLQqhk3L/r0tYlWZC9EBi/aVSllImEuQBCfqmat7EkilFb+Pn7EcKbicKXfNKw9NI2/XB4e1zlL5SuSB5qkZqI+HNnDLYI2brPGjuzDEsZuqAYDFPh/ye8kF1YELYpuBRfmNn+Hwq/2Yzh0iKlq5ceQ4G/Y4RK/XpbHyANpljoLBAj+INHH7wGOqdwGnt+zk9hnxFpzNe7odPOZwGJMROxd1dznwj60+j3wOFEWcw+TJVXe2hK4rJHKkj5Ab4M2oqkrTaVZ3Xt+4FD8lKlENYpgiwMxE2gZAqyqp8Ij5Lp7zGBGcEZodeOTDdBsp9THcnMLeXT3jhTh1/nI9FMiCVjVLCBLBe385fyIawT6vNZNJSbNetKVYtOpy3CVDE3pbF0JbW6FLQ4E4Lufrmy3S+BAiQzJx3YP1guscjj0zHk2NV7VRFKvwbfnYP24vm7wFeWMA8CCv08YiNlvSovogMAZOfVctyjj1rPcc7EhoUAn+/7zacnWp7WqNGzTgmt7C7EYnIUXhJKCyWrbTnniuUClNEXcv8ZXGnk4z5M2HOtj9OYbe+mUEz0FAuzS9njSB+BA+dS6OV5LZYcMFswvaVE7r7ck7HrTO6ldCksIx4exw5d8RmQFyeswa16lvUD6thFXrp7ybAAxq7jHV7nMjWeFmX+C9v5y/kQ1gn1eayaSk2a9aUqxadTluEqCVHyvjQkVuhS0OBjXeg+4BCqnwYVs5UMG7fQ/9wQjORtr2NFVDDDm9EJvol1ER7hkJG9f8KeYiwok0Ej2fOTJYLKsmKdVhhsqCs+1ZN580bgJJ23H3n1ZGG05w4MCTMJ8naLaw8D7TY/wHtj92y9R6ZvPmI8rvcnOMj+zuktQp0mpkX8sjN2aCbiYowNbPxmkqaS1GrJlQUIVPjyVWCAY8vhrETt0M9bRgcHzmz6YoQHcOV/1G5aA+lvgboiF+vQszfqyEC3pzDb3xyRpHhyJOj6SOXMbFy+dEGaqSmJbgWZtN3UImLcpEyDnCLfr+KOLQfh5Ha52YEbmqAtlY7ALTJD9f9BGqn33EfD439UeReMJ08qlRylh9ykbhSnvvdsl5VZTmE6+xHZurB2PS/89pWFaQ6U7DSX0CIlVNd64c+saPQdC28oWqtbPxsskDyQASNk99oXNBKxm8vFHx+mvmcY9AVvE32qkCOPzQl8K5QKKYGlh8BWmDMzfrtBhLqREXgrmYhgML3YyyB1r6VsBJM/FWuW3fv8Dxc5eEiDOHWhhMBVGmEK4f+SvsyltTbdv8lkD1BZXF1HikVhejpLp9DpY1vyUJhS4ulicTtRbIqAgMlwmv19yOyVIPu4GPk0Icwf9hU/qekcYRLiQRHJOK1egPDgrm5vVTX/ksAQTA1iqDuRjDyOWeOLq1gYudp0y14sw/jpmI+HJ50x7PFyybCfddvSVY3Pb7xfwDSgeIXZAFYHJn79eKdCqP2NSsEUD+5DS1EuG+JZBWIxi0W5LazDKJknNMA+EZH7xDEe0S1YwYukyxqulCF0qVNH2IDQtZ6Q65/DE1K5BtHyw/Mt5qlUZ9+3jiouuEjUKpj9ENedxSB5C3M5P/oBsHJTqu5RQImVz/9+VLUsYCN/rjunSOAytU/l+v0qpvYl7/yXuK2Dup8K9O83Cf3VJs00qyV4Q6nUtmTqwSrDqoHqL2nwS4WdqGzFS8WjZb93q6IDfexmx+ZXngetwaBsVE5YgMsenEW4X1OXpPGbU46+S8PgUD0vl+EYnvox0upZ0JNFKeCT2JfIKWlWsQIfH0HAn2OIe6kbUVOFQFBZzK0tCotwhmtGRTVf537TfsWgkud58bXMQ9fx7U13lzgWaF/Q5zhOi+kJmomTXnK34PH4GJVcYT8FsFhO+LYwUzs4VgGkeJLwSYDFdOup9u5vFC+ovvkKPDl5JBsACt6AwFhVaX/QnYcHm0HtJF/84aVZBrVFMko1gBB+vOH69SYjKmcyMC6cSUo6Arr7zYvuBzgjDiwfAl6GmXXJjCAVT8+DTgfUt1SzO/INSwCtZXULq/Mz1/M2xK+/IBdhfQ3HP1tAF6sALVI1kKqe0fVTevgbbCXnSrHqGIj59f+LBN5azD0DTfefWvEHRy/ujUECU/r13wIEY6X/C1+TrVSo4rVG4IUVz4NHmtrmu4BxhqMS+cr7SuQHnZIgjDnR9X8R/vKWpqO3GD0WeRjoKuqTWADvBc/raruhEzxG917+91V2ib0iq/0OtBP7SXdTwNaVYSTFE0acIavpqzbKNeilmERy+HkU+zpD5yLeToyBGjF0JpkJPI/n4vah8K+KJDBNRGcuxBmYQV+FepY0n00zfvI9P1LJwDLh0Re1nGwlciY2aBwXXbs+6w2W+qLu1mhpp3hEvc2bG3chYjd1IwfP7qaTxS2O7xsXQYULHYpjfkRBERIMBCNNCPbsC+zXOWTeB1JtFTsNYoUj8OV2747+zp3S2DQcwyEEgH8KqRL83DPCv4IXBQ4n2i5Yp42Otgpod2yyiujSzIkEYXuQK3g3N4cQ+kGqPtCnUx/3FhfuewhWCwOyl7a7DPvp+I98xmMYn5snSmBodiBEod39LTjseP5SJt4RBPFSC+3dJ8bM5bDW67TDS7kedGsXaFjLZo91BcEeJDPfGI5sF09m8vFE9AAYB3ZLY7Jo6wrI4Ic48F1LbqU5SPM3cgTAdJRt+xGgaeTVbVL9kUCfk/twpXeTGEYc/2H60Ljl2Vx7MqwXDaAMR6o7yAoUQvvz5cMLDKR74Pw1OGYM5h2O6UUtHN+Z/0xfbo0NbywOO5In3ozcUhhyvvr2crvHvn50SGrYm6ydf5VSrLEXxYPkaIxUWx3SJ25DL5kzepuulU94AEKGTQ9XV1+VG/rxb9aDKTuKiUBIV09LmuFgWUzBYKLk2VioZr9Vsm7QmTRaY7zSXzihG0Mix30Xy8yY6v+01GwPWnpBXci03Z+q+Sgfp2ZOzN1F4x5xrmy2t4SDNFnkTAie1AAHW4Dq5+np1aPNASnWZBGpV/WGEbeGhQYEHWLdS//5gTKjjqFse2/kuKka6ZFeCbeYtm3J6HCj+aw+S/tn/NQWPKGQdnE/ewyWnniFbfRK9UJBjiIKaRjIL9hPF58B8NKQViUd3cyfsWA4moBIX6H1ErSLss5Ikmm8jLv6TEahkMMqQSsgJXku1+NH8st9Se5Y/T/tPNGUj9TQHo3Ur/PDpV3H62KbxyYvbJ8/E+MTPSdOmAhlkiUcMMvvX4cmoPS1w4+w68rtPuLpp2UdT8xKMzKxtiRGn2r6vISsUZ7m7P69yCXklzXF3QtvY6/hM4Gg76cpHIlkdZRSWcUbKiCBRwHxzrdQW1L4b1oNmJDMRLuGGuPuCc88RgDEo0zQ4Ve50gPtggLOLaZ1H5iLuMlAv7u1bD9klsXNJobET6uxQrPe1UAz+hzk7OAZpe23OQlxvvPebGIOqMmM3whlsjtmuwZQRuDPwNtqcCR1Rj19X/qlmm+qZ/k4R7Q68wUysDsrCE1XJKgNz+C7KeETkKyUCq7v9iANrSvuabJQRuihNAEIcdbzTBVJY66wzMfC+0f4UXUga+0g945lNRRkSrFJrZqU/heJ16B0im7wfk+mO3jsi2SCFC5A7pNX5fm8s/PzPEYDQ4K2Ov0ywtttNp91PQZ4FWbt6w0d96TsoECBBQq51NMLI1SBNzrZW39I8wMRIxZjbEUlkMa5pIWnEvcxsUuCZ6YL8iukgtM8wp/89ZhfFNz4Uh8HM7RB1zIB9VJcAp2ql6ZeEsM0avw3aj15hZ9lQt1NH5v1mL4feHmMXxpSxItdPUrKNF2Xw9shGpUQ2ZFEA3U96QTqKMBCvNJgrXBh/RodoGLn25HY/ojENOOdgh4pU9B9nyGGIbpnRM7Xp6qlA0+vzHGC7InLSak3dHzniT+nWgwkGDUE3iWr8M5GJKxLpteW2b15DIfFJK2ZWOSiFN3rU2D2lQtZy5oVGw0Bsr/ar/3mF5ofF+Yj6p4m7hOJxDKGEjCCEUvNt8XmPcQVHi673cTlVTkaI99a++scTUtNHpLiS0+Cpb3ijKxnES36WTQ2MP541vyOoL5w6PxfimhmsRuI9AAn0BxSOrtpH5ePeUC/lt9SfcAehULAXPvwSabm1ZVo4pRGPoGqMvOTImFu1kyd8Rm6p9AtuliKc41l99X5ZyJalTLhWVn49Y6nSc7vHH4ZLzq4xvBW/A59xRMUct1SbWoEqFjp1wd/PNg5EPBdKFdljS8pp7SJCpha5NVZ7si4bJTHrbcseFG4yQI3SzdBDqgdzm2jrJzTa1bFHu8wtdQIoAcAJwv/BWIMTuyCB4IWrtIwclfs5BUXzI4CtYOFZYU80xN1g4BZWl4vXtqe3QX50sAKjCu5fm/eWYDJ+Yps7QZOjhuqF9rkmGqgd8i75moZglBVaV4RxEOUHyKTDRtBk9y8X+CXeD2HFNYiKTZ0d8zmkIYJ4avxhxvMn8t3xf6H3SqfKk+trj+N8XvyTtR79G2F2sp2k4ie+BcBA/VEVAAMP5hMvpuga/AYNA4uJYcv4J9HDn6EUcCCvBUVOqDZgiF0AFsmSddCFHhFOe3QzQztQ/A1gjZlLqdRe84A7KWBsAKCtnn2gyqyiqkdxBE9srx7dGgO1a+DlX0kad2PVbBeL7Lk1FBhsM4Wm+MpiiqeNT6Y3kb47Tak3l8ijC0r8ywpXetWR5kXyKLP5BlMoWNbHwiXPCEgpn9rMTREFCq7s3ir8vdUHBSYmZ2zlbVqqHo4PqKWVBIcLsgcvB95iKH0iutGqOL7BDST0xRmv0KC+6XQRRf5Nl5Lp8wmLQ8OJj5wlNDteKg3o8JgS/L6XlNc9LoK2yRhayFhJWUEWuKD0/6fDsF12QDXuZwNRsqZyQNGYaqiKGL5+frkIWq2GxdgFZZl67Axl2YzacjqkfakiNCnlmCayIc2Ib0RBHziMX1eTu8VMqLizCfpZu9DmkeHNFvRvFcZFqHwVAYS9SIaz+Gf+rcY0a4MSELyz7BGb+TmVMx5rTX6gm029jORXsZOzJJ2zwuv/gPXM9IvoXXRIrGbQj5GvGFmCGfSDvD2TEtYTa8tUbYxoG2KiV76JhwTOO2JO5yYu/w3v3PyiDli5FJY9JNIkOjukKfHE5YcFGsiknUJwV4/xqNs3d63CmkDGwmQc4/TbX3BY7eaShFCJypM6IJSnv0+8qMuHGULqklyxh1WHpFVWV3oT1OvabjhJM8cEj7zDXe3UffFQSUzUhvTm9S+ZgB3n1xlK9o0NqhjkzURX8bKIQEEie2fGb/3U11M/Y6HxS8ePQBr/woTMDwrXsnRWn6nHl4x1jMkpBgfrIAouGS1cC2rg6WfZAp5Bdb4m0jXZxxdHJpi5CE6XbfxGGWALGjmSYfGwTAQlxBTOG0s+1kTZH2fDQHTLKIhKjFHVB9On7MsWbpCDTWHJtHZYM0JEfVKCIhG5pzEFbOtiYrLWrfZBbO+S9QT4tCkEAacmAKK6LowrjpI+W7teDsB8gmo1bQiGKkjASJjOWMJ5g6BULSXhl2ibNXycWLnWH/ISis574cbT2+RHdRPkK+OK05D5VMN6Ml2EpgptpyAX3kMRDEudlvjCPM220dVVWMYNzK5aJ1wSmnN7vP16RNDyRVkTCDIKsoQ9LNgoE2mcTWg9Npj+RbXcuZ3tnMoaPKAHTzHwmFWghlLWfSe0oSeKKjJ54n0RVU2Xnd5jqQWZ/CAj4Im8OMECjk1mEsadJki3srTHaA7+d7ZX4hOBPZYcVs3WPKAHTzHq9Oh9tNMl8LkXRUAkVj9IMe1C4QhbtTK8X0S0HGo3FEevc/beWdwYKfMzUHAN0OrkjL7oZfdAENZ4nIKzkCp5ybJRdsOMDxgigAwM7i+LNfsJo7zF8IUQbsMhk0cp7nGSCT7gjA+APp/BWVIfLrTEdycm1NFrgOUD/TIxye5WwidjMpibI8gVP/NlKpnrm08jl3VDgwM7Cor7ChY40pRHlcNgpRm7d0fHdZW81HcbHF/wZvNX37ZX6kD6iygUcJpJAwC12/6RT0iekQFbigvWa4BaU7ZOyje7kk6K/2oXJqVsSJ2dejVBFL1Qv+7aAbNQ5qjF8hJNz0BerOEF3jslRq4ECZNo9ah3333YA+cLVZ+w5lsqKbtvxu/8A7B2rnNe3Ne3SJqdz2F6jhTj4cNn5sslwxzdTcD61PHbf1uMaGI2M15CvoLODQF4oKQg8qB34MTX9sPEgrXLwgJZtaBkeQrkKbxjzs0WP8wy2gRIyK68nsuMLG1upxZt1t927f59yIvJdS0yeDd6f1cofO382pdLezr78TN7c+IuT9atCk0e5UK7s/EAHo2n4LA+2xCxr64svF7RZSe9DKHelfJrD5TcgctEiVum7PI9aZkxB/EzKE/ZLhJtzHX12GDisO1e+74IN9M2Etas5Y5J96dD3W2RPElnB45iuv7jl+BM93YAqUnzFRyId0DnVF3CrmFkzzELa08imGOcnwAxdffEyR1QNOHeClEslFJOgG8mlNx0sSVdby8goFfspHA2AEOoWraX1GbEA/DRzXiiz0kqby/ygtQXDEe5J2PVSDkuOrky/JyXQH6WJ024DjsmwLEAH0jhCo1fa3Xc2tTTG6tyywFzDKUyNfj2Jd3yemI+HJoN6r46m/uufRO74Rn3t6WdIz/kfEpCZ0HoUg5xpi1z4qP+PxncuK3WXvuNNrHFDKCT94gWHz3mC9787DvLfnNvDsr0BUL15VDEdnixZYsYnSgBWYAAAAAAABO0Dup8ySZjgCj3oBAAAAAAAmM+pr/3GuayR6ovOxNmwAeyDORErjhfieQE6p52oAVs1SAqH9lgAQ076PNEOQywRoD6n7u0KW3AtCKudKPJ8/Cnloeh8t+qXZN0m4zAcj7NSJg3dg3M6Hz2h4aNAkd0B44fFDfd07Rj3ZwUEqVxrrMfH01YxasUo3nC6qAPDB9/laTPxKCEyH/IijVrDPCtLGlRNw/6xtIi51h+a90mgaTZVPxk9zyKThfbtcbGL6WoHNm/1emu4z0caCM85cz4gMw9W+8SV3tH+82iC7m1aBHPlkblPS6XeZ/UK9jLxQtYwnEU/LQ8LVo0thi1OzrGoCeQ2ugD7EYDK4NnXjpBbhlPsWzmp6Cm1sCoVjn+5AOcJhpexyT4BsS+wqFmRPXlLkARws/9xJ3I5yLi0BNeRtVX2rr1BDk1N2pB/pH/6mddzCNyeIWyJEOmg6WnUUUDfa5N2GEKtvuqGC7OlkMNqD6S1RPHLt0tBmhdvlm9wUJx8FLVDXu043Oj4UwimxKRc5LFBhNK8UQX7usu7KwjVmJqUJ3jG86KmhVxSeh7/El4C5Jl2oVoPDOMTBQGWd+p5j+xwV4YIY8yVhjOd6sqt8xIKTU+yqUpPdWLLMJzmpCdjQ30e6sjeOYIbGxT6DWK/aa4NNW+ILNm7+qctED9HyEG6zN/p+6HrPfi/7songbzSTwd8AfJsQOweOoy0hzxKTMLgK9JFoibhYIGMlhqwNBFXIfwmXGRP9Zgtt+iYcedojlPpL0CsM/uGJB63sLeHqPKyqGX7Z4wBOOuIgAABfGaFegUhi5MYKd01sZ+JhyEUHWEEpUhj/Nb10VfTshOv1G4GUM/yBkEmdMyRCC9RrO/fbcOTWkw73yLZNyWZXNEpPQ+nadpSRwuJZ9EnDQJ4LEjBXCBp0BOl0D7ImM96P26Z7UX3qji6EPq0gwW0igWdTMGnRikeDtkywMKz/HLAi4lVTfHLCYgqjA6jM2gbS2zm9wvH6I5pCV38AB4eO+EtlhQg+ZT3O8cmTzRQTZqmTU72W8YzTACWWXxsoFmjch6e55UxQhkzy0KPPbjTpeoyovMvtIyZIMf75ANKBmRNt/lzCAoXX45iaaykO85moeerGKI4f5BlTuZrcQlGal3iW4+TPWY4KDHOhGuUkorhJyzQS8Co9/+pmqpgI988cgNOF7aJL/UNYaUMubZXOUwxXoz1La+W6McrGFheOgzRG5YuZRHAaSu8B1GlAucL77VFHu8d1sB4+PfQgsM9bQDzyIssGD4AEyhXbPspZ1kKFBNFCOHmogUgy5pHbLxovBFRjXHZqV6bR8nNG0RwuZjI9eHX8C2ZmmhkbQjrye4q99wqkZNooUbS2xSzDxqQq2aYnkMBDtyD6k10OHQekE0RrvF70SjUh+aNEaKb/244rm0Tp107GtcMHHRZcszrBykK7xYHvpmETzp8HIQnQjsuagaNXMvBlWwDhcGqVy/ywiaPeUKSalLtRZ+cuu4ZsZBqbqfG852iM7E8C/abg9nWLYWum6iIcuour8zMRCRc11LEksORV6boehmnxUnoMoFqju/pZnaIPEZYZ2NYAIUlQIKYFltySMTmiHf5s/EeiRqxozBQKerghgZdcSN5k8Pa0eLBWLDx6twAFIAv0klMapTw7hhJWa2eAClEDujsRgCsnRqGbg8OUwU9pAAJ4EIGEJ979IW9z9tsbnqCJAFLVBVVQlGxBoKmL1DfqCUEiFV7sqsFJsIjtswpPZeqeLoo/N1WExTcP5pKyH3riseeDIAOUopDQDA1DPe3C+0dxHrgApvnvprWrxhgoeAcoDqvSoqQrJgt9ntVbo8K7G8X7bfxeTflLH+Jl+SPmHBUgXE4Ce6fHtsArSuKUKoeAGhnN4wAAtlQKE7hk7srbgXB2adLDu35AnFcDe6zdNyrF8bVd9hi8n4KlN+yoTjY36MpvcSZ/41zCIn1YvoxFV54SHmvplJ5JzndE2Iwk4UdIs6XZGLbmK56nd9SGIBBnTAyEjHEaV3aQ2+8EhXKjCJupx871PyXBhsYBnpM6TrEOFrtACGHSPPBQeKoAQ+7Bnmf0Ihc7HDIYtKrobgE32wywQiN8GNe/dWvbtKQcVufB6hVh1U6KvcNjRdNN0pMdFXuGyNsyX0YdS5D7JkS0oyCsZD0k9OKiitcyJrz68r2fMqtWhtDFRDDIDK8YWRKOY8dt9w9hjwvjXVnHhfwnyFaYnw9+9bSIGhXOn68+6ofn2oA/1A2CrArM2yMq4cLvvBxL903tXJ9wjG8q6gpnTxaa8OBO6lgsPapbmg3hlKjDvNUO99WkwqyT4hoJX6tG++pXUZTmmJ5oIUCBLQIJ0HqAANH3DURRxtM2YwuGvdtzvWs+um/GVlHnu/QFUc0gt8CwK3oHmLznsK2+y6DWA0ghLGpXpgRHHtZbQpGv1WmN25NwBpJ2cKuBDjZ7Md4sRk1xvEXZNzL89k56kQdJWOJMZQwaJrKAr+nX3cobFLuyxa6bwQBCIIhzEo+5ADL7XwRAYuTKhGvRi5Q00j0K6Nn5oko64CNd6x0q3cReaYZqJVVZnR96wDigH6a23lGH3SaQPQ5Hy5dOoYeLvRyDiKZ//1/oOQqwvc0doNWrozwm7rFjbWtRMk6UDZ64IyrPFu/ddiFBwHqfE43VrcRfhvpYwTzyBWJBBP9JGYOcyXf4AAAAAAVivs6a+i9YtVKY4driljmcS315IchNv0HPq3y9d6+fXxw9SAqkstySHq9n71xdhWDFVFWPx/1nSMv+PBrOp4PBXI+2rCrsw5nOQiwCpAS8vv5twYo70O3rzxcRwM1o7B9NeUWxQEqX9OxPVXmftu4/vl2YBcdDy64l+YtmMlFJuaszZd3OWMl03cwqgCKlPc3EbqcOLz/xuJI1wX0G7I50Ut2+4hFwUYVJddmBB2ZsLxUT5YM+m76iM/CdByWsOaOnKF032tW3uPpGzA/llyyzi5tktSqb47yAMgVW1OCAAAAAA="
+      }
+    }
+  },
+  "analysisUTCTimestamp": "2026-05-14T17:23:30.101Z"
+}

--- a/tmp/perf-20260514/psi-home.json
+++ b/tmp/perf-20260514/psi-home.json
@@ -1,0 +1,8443 @@
+{
+  "captchaResult": "CAPTCHA_NOT_NEEDED",
+  "kind": "pagespeedonline#result",
+  "id": "https://www.ocobo.co/fr",
+  "loadingExperience": {
+    "initial_url": "https://www.ocobo.co/fr"
+  },
+  "lighthouseResult": {
+    "requestedUrl": "https://www.ocobo.co/",
+    "finalUrl": "https://www.ocobo.co/fr",
+    "mainDocumentUrl": "https://www.ocobo.co/fr",
+    "finalDisplayedUrl": "https://www.ocobo.co/fr",
+    "lighthouseVersion": "13.0.1",
+    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+    "fetchTime": "2026-05-14T17:21:41.363Z",
+    "environment": {
+      "networkUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36",
+      "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+      "benchmarkIndex": 707.5
+    },
+    "runWarnings": [
+      "The page may not be loading as expected because your test URL (https://www.ocobo.co/) was redirected to https://www.ocobo.co/fr. Try testing the second URL directly."
+    ],
+    "configSettings": {
+      "emulatedFormFactor": "mobile",
+      "formFactor": "mobile",
+      "locale": "en-US",
+      "onlyCategories": [
+        "performance"
+      ],
+      "channel": "lr"
+    },
+    "audits": {
+      "long-tasks": {
+        "id": "long-tasks",
+        "title": "Avoid long main-thread tasks",
+        "description": "Lists the longest tasks on the main thread, useful for identifying worst contributors to input delay. [Learn how to avoid long main-thread tasks](https://web.dev/articles/optimize-long-tasks)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 long tasks found",
+        "metricSavings": {
+          "TBT": 550
+        },
+        "details": {
+          "debugData": {
+            "tasks": [
+              {
+                "startTime": 12668,
+                "urlIndex": 0,
+                "duration": 322,
+                "other": 322,
+                "scriptEvaluation": 0
+              },
+              {
+                "urlIndex": 0,
+                "startTime": 5795.5,
+                "scriptEvaluation": 0,
+                "other": 183,
+                "duration": 183
+              },
+              {
+                "other": 143,
+                "duration": 143,
+                "startTime": 7958.2,
+                "urlIndex": 1
+              },
+              {
+                "startTime": 9359.1,
+                "urlIndex": 2,
+                "other": 118,
+                "duration": 118,
+                "scriptEvaluation": 0
+              },
+              {
+                "other": 104,
+                "duration": 104,
+                "startTime": 7820.2,
+                "urlIndex": 1
+              },
+              {
+                "scriptEvaluation": 0,
+                "other": 103,
+                "duration": 103,
+                "startTime": 9588.1,
+                "urlIndex": 2
+              },
+              {
+                "other": 97,
+                "duration": 97,
+                "scriptEvaluation": 0,
+                "startTime": 7723.2,
+                "urlIndex": 1
+              },
+              {
+                "scriptEvaluation": 0,
+                "other": 92,
+                "duration": 92,
+                "startTime": 9477.1,
+                "urlIndex": 2
+              },
+              {
+                "other": 80,
+                "duration": 80,
+                "startTime": 13005,
+                "urlIndex": 0
+              },
+              {
+                "paintCompositeRender": 0,
+                "other": 67,
+                "duration": 67,
+                "scriptEvaluation": 0,
+                "startTime": 1120.1,
+                "urlIndex": 3,
+                "styleLayout": 0
+              }
+            ],
+            "type": "debugdata",
+            "urls": [
+              "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "https://www.ocobo.co/fr"
+            ]
+          },
+          "skipSumming": [
+            "startTime"
+          ],
+          "type": "table",
+          "sortedBy": [
+            "duration"
+          ],
+          "items": [
+            {
+              "duration": 322,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "startTime": 12668.044077727622
+            },
+            {
+              "duration": 183,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "startTime": 5795.4630697765151
+            },
+            {
+              "startTime": 7958.1536289592823,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "duration": 143
+            },
+            {
+              "duration": 118,
+              "startTime": 9359.0856118846241,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "duration": 104,
+              "startTime": 7820.1536289592814,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js"
+            },
+            {
+              "startTime": 9588.0856118846241,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "duration": 103
+            },
+            {
+              "duration": 97,
+              "startTime": 7723.1536289592814,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js"
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "startTime": 9477.0856118846241,
+              "duration": 92
+            },
+            {
+              "startTime": 13005.044077727622,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "duration": 80
+            },
+            {
+              "duration": 67,
+              "startTime": 1120.0643152467387,
+              "url": "https://www.ocobo.co/fr"
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "label": "URL",
+              "valueType": "url"
+            },
+            {
+              "granularity": 1,
+              "key": "startTime",
+              "valueType": "ms",
+              "label": "Start Time"
+            },
+            {
+              "granularity": 1,
+              "key": "duration",
+              "valueType": "ms",
+              "label": "Duration"
+            }
+          ]
+        }
+      },
+      "network-server-latency": {
+        "id": "network-server-latency",
+        "title": "Server Backend Latencies",
+        "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "sortedBy": [
+            "serverResponseTime"
+          ],
+          "items": [
+            {
+              "serverResponseTime": 7,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "serverResponseTime": 3.5,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "serverResponseTime": 3,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "origin": "https://www.ocobo.co",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "origin": "https://track-eu1.hubspot.com",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "origin": "https://useago.github.io",
+              "serverResponseTime": 0.5
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "text",
+              "key": "origin"
+            },
+            {
+              "valueType": "ms",
+              "label": "Time Spent",
+              "granularity": 1,
+              "key": "serverResponseTime"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 7,
+        "numericUnit": "millisecond"
+      },
+      "font-display-insight": {
+        "id": "font-display-insight",
+        "title": "Font display",
+        "description": "Consider setting [font-display](https://developer.chrome.com/docs/performance/insights/font-display) to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with [font metric overrides](https://developer.chrome.com/blog/font-fallbacks).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "valueType": "ms",
+              "label": "Est Savings",
+              "key": "wastedMs"
+            }
+          ],
+          "skipSumming": [
+            "wastedMs"
+          ],
+          "type": "table"
+        }
+      },
+      "lcp-discovery-insight": {
+        "id": "lcp-discovery-insight",
+        "title": "LCP request discovery",
+        "description": "[Optimize LCP](https://developer.chrome.com/docs/performance/insights/lcp-discovery) by making the LCP image discoverable from the HTML immediately, and avoiding lazy-loading",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "third-parties-insight": {
+        "id": "third-parties-insight",
+        "title": "3rd parties",
+        "description": "3rd party code can significantly impact load performance. [Reduce and defer loading of 3rd party code](https://developer.chrome.com/docs/performance/insights/third-parties) to prioritize your page's content.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "isEntityGrouped": true,
+          "type": "table",
+          "items": [
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+                    "transferSize": 206382,
+                    "mainThreadTime": 447.34499999973923
+                  },
+                  {
+                    "transferSize": 43638,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+                    "mainThreadTime": 51.262000000104308
+                  },
+                  {
+                    "mainThreadTime": 31.626999999396503,
+                    "transferSize": 28212,
+                    "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                  },
+                  {
+                    "mainThreadTime": 25.520999997854233,
+                    "transferSize": 29955,
+                    "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+                  },
+                  {
+                    "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+                    "transferSize": 27217,
+                    "mainThreadTime": 16.594000001437962
+                  },
+                  {
+                    "mainThreadTime": 3.7299999985843897,
+                    "transferSize": 1638,
+                    "url": "https://js-eu1.hs-scripts.com/27107933.js"
+                  },
+                  {
+                    "transferSize": 4082,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953",
+                    "mainThreadTime": 0.64899999927729368
+                  },
+                  {
+                    "mainThreadTime": 0.17200000118464231,
+                    "transferSize": 1094,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk="
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 1712,
+                    "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Ffr&isMobile=true"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr&t=Ocobo+%C2%B7+Ocobo+%C2%B7+RevOps+%26+Revenue+Experience&cts=1778779305782&vi=fe480a240269ed36f0385aa1efc00771&nc=true&u=242475741.fe480a240269ed36f0385aa1efc00771.1778779305768.1778779305768.1778779305768.1&b=242475741.1.1778779305768&cc=15",
+                    "transferSize": 1522
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 1024,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1"
+                  },
+                  {
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+                    "transferSize": 1024,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1021,
+                    "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1020,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=c67bf936-b265-49c0-9daa-f7cd7a0e6f0b&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr&t=Ocobo+%C2%B7+Ocobo+%C2%B7+RevOps+%26+Revenue+Experience&cts=1778779306401&vi=fe480a240269ed36f0385aa1efc00771&nc=true&u=242475741.fe480a240269ed36f0385aa1efc00771.1778779305768.1778779305768.1778779305768.1&b=242475741.1.1778779305768&cc=15",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+                    "transferSize": 557,
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "transferSize": 350098,
+              "mainThreadTime": 576.89999999757856,
+              "entity": "Hubspot"
+            },
+            {
+              "mainThreadTime": 284.58199999853969,
+              "entity": "Google Tag Manager",
+              "transferSize": 157010,
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 284.58199999853969,
+                    "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+                    "transferSize": 157010
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 7.9559999983757734,
+                    "transferSize": 5019,
+                    "url": "https://useago.github.io/widgetjs/frame.js"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://useago.github.io/widgetjs/frame.css",
+                    "transferSize": 2020
+                  }
+                ]
+              },
+              "transferSize": 7039,
+              "entity": "GitHub",
+              "mainThreadTime": 7.9559999983757734
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+                    "transferSize": 1280,
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "transferSize": 1280,
+              "mainThreadTime": 0,
+              "entity": "Clearbit"
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 323772,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qobra-avatar.png"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 60332,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png"
+                  },
+                  {
+                    "transferSize": 29273,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yousign-white.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 22830,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 18630,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/wecandoo-white.png"
+                  },
+                  {
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png",
+                    "transferSize": 14019,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 11987,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png"
+                  },
+                  {
+                    "transferSize": 11477,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qobra-white.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 10974,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/resilience-white.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 10152,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vibe-co-white.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qonto-white.png",
+                    "transferSize": 9975,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 9975,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/citron-white.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 9715,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/tomorro-white.png"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 9611,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/steeple-white.png"
+                  },
+                  {
+                    "transferSize": 7672,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qare-white.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 5119,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/epack-white.png"
+                  },
+                  {
+                    "transferSize": 4852,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vizzia-white.png",
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "transferSize": 570365,
+              "mainThreadTime": 0,
+              "entity": "vercel-storage.com"
+            },
+            {
+              "entity": "Google Analytics",
+              "mainThreadTime": 0,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65c1v9100339653za200zd9100339653&_p=1778779303700&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=956976354.1778779304&frm=0&pscdl=noapi&rcb=5&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115938466~115938468~118167295&dp=%2Ffr&sid=1778779304&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Ffr&dt=Ocobo%20%C2%B7%20Ocobo%20%C2%B7%20RevOps%20%26%20Revenue%20Experience&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=2772",
+                    "transferSize": 796,
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "transferSize": 796
+            },
+            {
+              "mainThreadTime": 0,
+              "entity": "Google Fonts",
+              "transferSize": 103931,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "transferSize": 102672,
+                    "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1259,
+                    "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                    "mainThreadTime": 0
+                  }
+                ]
+              }
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "label": "3rd party",
+              "key": "entity"
+            },
+            {
+              "label": "Transfer size",
+              "granularity": 1,
+              "valueType": "bytes",
+              "subItemsHeading": {
+                "key": "transferSize"
+              },
+              "key": "transferSize"
+            },
+            {
+              "subItemsHeading": {
+                "key": "mainThreadTime"
+              },
+              "valueType": "ms",
+              "key": "mainThreadTime",
+              "label": "Main thread time",
+              "granularity": 1
+            }
+          ]
+        }
+      },
+      "render-blocking-insight": {
+        "id": "render-blocking-insight",
+        "title": "Render blocking requests",
+        "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "wastedMs": 153,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "totalBytes": 24569
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "label": "URL",
+              "valueType": "url"
+            },
+            {
+              "key": "totalBytes",
+              "valueType": "bytes",
+              "label": "Transfer Size"
+            },
+            {
+              "valueType": "timespanMs",
+              "label": "Duration",
+              "key": "wastedMs"
+            }
+          ]
+        }
+      },
+      "main-thread-tasks": {
+        "id": "main-thread-tasks",
+        "title": "Tasks",
+        "description": "Lists the toplevel main thread tasks that executed during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "duration": 33.029,
+              "startTime": 1643.315
+            },
+            {
+              "startTime": 2174.144,
+              "duration": 6.817
+            },
+            {
+              "startTime": 2182.724,
+              "duration": 13.534
+            },
+            {
+              "startTime": 2196.276,
+              "duration": 111.874
+            },
+            {
+              "startTime": 2309.237,
+              "duration": 10.409
+            },
+            {
+              "startTime": 2327.439,
+              "duration": 10.255
+            },
+            {
+              "startTime": 2339,
+              "duration": 10.078
+            },
+            {
+              "startTime": 2350.202,
+              "duration": 16.152
+            },
+            {
+              "duration": 13.99,
+              "startTime": 2368.039
+            },
+            {
+              "startTime": 2387.466,
+              "duration": 8.496
+            },
+            {
+              "startTime": 2397.493,
+              "duration": 12.955
+            },
+            {
+              "startTime": 2414.555,
+              "duration": 5.946
+            },
+            {
+              "startTime": 2424.463,
+              "duration": 20.533
+            },
+            {
+              "startTime": 2449.74,
+              "duration": 16.82
+            },
+            {
+              "startTime": 2469.497,
+              "duration": 31.304
+            },
+            {
+              "startTime": 2510.768,
+              "duration": 34.554
+            },
+            {
+              "startTime": 2553.215,
+              "duration": 7.017
+            },
+            {
+              "duration": 21.324,
+              "startTime": 2561.665
+            },
+            {
+              "startTime": 2586.847,
+              "duration": 5.091
+            },
+            {
+              "startTime": 2591.965,
+              "duration": 98.749
+            },
+            {
+              "startTime": 2691.56,
+              "duration": 6.33
+            },
+            {
+              "duration": 76.861,
+              "startTime": 2698.527
+            },
+            {
+              "startTime": 2792.182,
+              "duration": 6.152
+            },
+            {
+              "startTime": 2801.531,
+              "duration": 5.221
+            },
+            {
+              "startTime": 2806.76,
+              "duration": 16.646
+            },
+            {
+              "startTime": 2827.274,
+              "duration": 11.192
+            },
+            {
+              "startTime": 2838.557,
+              "duration": 15.881
+            },
+            {
+              "startTime": 2857.179,
+              "duration": 6.626
+            },
+            {
+              "startTime": 2866.694,
+              "duration": 5.448
+            },
+            {
+              "startTime": 2874.7,
+              "duration": 5.558
+            },
+            {
+              "startTime": 2880.302,
+              "duration": 15.439
+            },
+            {
+              "startTime": 2901.216,
+              "duration": 8.233
+            },
+            {
+              "duration": 22.161,
+              "startTime": 2909.569
+            },
+            {
+              "startTime": 2938.551,
+              "duration": 5.537
+            },
+            {
+              "startTime": 2945.288,
+              "duration": 5.905
+            },
+            {
+              "startTime": 2951.299,
+              "duration": 5.398
+            },
+            {
+              "startTime": 2960.543,
+              "duration": 5.27
+            },
+            {
+              "startTime": 2968.163,
+              "duration": 5.999
+            },
+            {
+              "startTime": 2974.207,
+              "duration": 5.361
+            },
+            {
+              "startTime": 2979.576,
+              "duration": 5.172
+            },
+            {
+              "duration": 11.759,
+              "startTime": 2986.636
+            },
+            {
+              "startTime": 3001.615,
+              "duration": 10.97
+            },
+            {
+              "startTime": 3012.64,
+              "duration": 5.865
+            },
+            {
+              "duration": 5.499,
+              "startTime": 3018.545
+            },
+            {
+              "startTime": 3027.704,
+              "duration": 8.105
+            },
+            {
+              "startTime": 3038.89,
+              "duration": 22.114
+            },
+            {
+              "startTime": 3061.103,
+              "duration": 20.926
+            },
+            {
+              "startTime": 3082.723,
+              "duration": 5.327
+            },
+            {
+              "startTime": 3091.434,
+              "duration": 8.257
+            },
+            {
+              "startTime": 3099.729,
+              "duration": 12.546
+            },
+            {
+              "startTime": 3118.86,
+              "duration": 5.247
+            },
+            {
+              "startTime": 3133.175,
+              "duration": 5.784
+            },
+            {
+              "startTime": 3142.319,
+              "duration": 6.407
+            },
+            {
+              "startTime": 3151.797,
+              "duration": 6.408
+            },
+            {
+              "startTime": 3160.251,
+              "duration": 5.33
+            },
+            {
+              "startTime": 3168.142,
+              "duration": 8.617
+            },
+            {
+              "startTime": 3176.8,
+              "duration": 5.234
+            },
+            {
+              "startTime": 3183.883,
+              "duration": 5.268
+            },
+            {
+              "startTime": 3189.205,
+              "duration": 5.173
+            },
+            {
+              "startTime": 3195.221,
+              "duration": 26.298
+            },
+            {
+              "startTime": 3224.464,
+              "duration": 6.705
+            },
+            {
+              "startTime": 3235.324,
+              "duration": 5.374
+            },
+            {
+              "duration": 6.274,
+              "startTime": 3243.254
+            },
+            {
+              "startTime": 3252.114,
+              "duration": 5.355
+            },
+            {
+              "startTime": 3257.598,
+              "duration": 5.297
+            },
+            {
+              "startTime": 3263.177,
+              "duration": 9.542
+            },
+            {
+              "startTime": 3274.919,
+              "duration": 5.294
+            },
+            {
+              "startTime": 3280.278,
+              "duration": 7.487
+            },
+            {
+              "startTime": 3290.387,
+              "duration": 6.295
+            },
+            {
+              "startTime": 3296.766,
+              "duration": 6.083
+            },
+            {
+              "startTime": 3305.414,
+              "duration": 5.722
+            },
+            {
+              "startTime": 3311.192,
+              "duration": 5.187
+            },
+            {
+              "duration": 5.53,
+              "startTime": 3319.003
+            },
+            {
+              "startTime": 3324.592,
+              "duration": 9.397
+            },
+            {
+              "startTime": 3337.099,
+              "duration": 15.598
+            },
+            {
+              "startTime": 3355.567,
+              "duration": 31.714
+            },
+            {
+              "startTime": 3394.375,
+              "duration": 8.52
+            },
+            {
+              "duration": 20.601,
+              "startTime": 3405.904
+            },
+            {
+              "startTime": 3428.982,
+              "duration": 18.855
+            },
+            {
+              "startTime": 3455.499,
+              "duration": 25.229
+            },
+            {
+              "startTime": 3496.655,
+              "duration": 86.233
+            },
+            {
+              "startTime": 3585.241,
+              "duration": 162.08
+            },
+            {
+              "startTime": 3751.298,
+              "duration": 8.898
+            },
+            {
+              "startTime": 3762.724,
+              "duration": 6.832
+            },
+            {
+              "startTime": 3769.696,
+              "duration": 86.809
+            },
+            {
+              "startTime": 3860.898,
+              "duration": 28.7
+            },
+            {
+              "startTime": 3893.277,
+              "duration": 27.279
+            },
+            {
+              "startTime": 3920.745,
+              "duration": 119.519
+            },
+            {
+              "startTime": 4044.106,
+              "duration": 11.479
+            },
+            {
+              "startTime": 4067.095,
+              "duration": 152.902
+            },
+            {
+              "startTime": 4222.551,
+              "duration": 6.914
+            },
+            {
+              "startTime": 4231.439,
+              "duration": 58.15
+            },
+            {
+              "startTime": 4289.766,
+              "duration": 7.62
+            },
+            {
+              "startTime": 4297.586,
+              "duration": 13.593
+            },
+            {
+              "startTime": 4311.203,
+              "duration": 6.253
+            },
+            {
+              "startTime": 4319.09,
+              "duration": 5.673
+            },
+            {
+              "startTime": 4331.37,
+              "duration": 6.289
+            },
+            {
+              "startTime": 4349.414,
+              "duration": 8.121
+            },
+            {
+              "startTime": 4369.537,
+              "duration": 34.974
+            },
+            {
+              "startTime": 4405.129,
+              "duration": 12.391
+            },
+            {
+              "startTime": 4461.34,
+              "duration": 6.266
+            },
+            {
+              "startTime": 4471.029,
+              "duration": 268.721
+            },
+            {
+              "startTime": 4739.862,
+              "duration": 11.724
+            },
+            {
+              "startTime": 4751.749,
+              "duration": 24.219
+            },
+            {
+              "startTime": 4778.373,
+              "duration": 66.29
+            },
+            {
+              "startTime": 4849.536,
+              "duration": 25.6
+            },
+            {
+              "startTime": 4879.848,
+              "duration": 13.002
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "ms",
+              "label": "Start Time",
+              "granularity": 1,
+              "key": "startTime"
+            },
+            {
+              "granularity": 1,
+              "key": "duration",
+              "label": "End Time",
+              "valueType": "ms"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "resource-summary": {
+        "id": "resource-summary",
+        "title": "Resources Summary",
+        "description": "Aggregates all network requests and groups them by type",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "transferSize": 1972710,
+              "label": "Total",
+              "resourceType": "total",
+              "requestCount": 117
+            },
+            {
+              "requestCount": 37,
+              "label": "Image",
+              "resourceType": "image",
+              "transferSize": 928372
+            },
+            {
+              "label": "Script",
+              "resourceType": "script",
+              "requestCount": 63,
+              "transferSize": 771909
+            },
+            {
+              "transferSize": 212550,
+              "label": "Font",
+              "resourceType": "font",
+              "requestCount": 5
+            },
+            {
+              "requestCount": 3,
+              "label": "Stylesheet",
+              "resourceType": "stylesheet",
+              "transferSize": 27848
+            },
+            {
+              "requestCount": 1,
+              "label": "Document",
+              "resourceType": "document",
+              "transferSize": 20539
+            },
+            {
+              "transferSize": 11492,
+              "label": "Other",
+              "resourceType": "other",
+              "requestCount": 8
+            },
+            {
+              "label": "Media",
+              "resourceType": "media",
+              "requestCount": 0,
+              "transferSize": 0
+            },
+            {
+              "label": "Third-party",
+              "resourceType": "third-party",
+              "requestCount": 42,
+              "transferSize": 1190519
+            }
+          ],
+          "headings": [
+            {
+              "key": "label",
+              "valueType": "text",
+              "label": "Resource Type"
+            },
+            {
+              "key": "requestCount",
+              "label": "Requests",
+              "valueType": "numeric"
+            },
+            {
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "key": "transferSize"
+            }
+          ]
+        }
+      },
+      "forced-reflow-insight": {
+        "id": "forced-reflow-insight",
+        "title": "Forced reflow",
+        "description": "A forced reflow occurs when JavaScript queries geometric properties (such as offsetWidth) after styles have been invalidated by a change to the DOM state. This can result in poor performance. Learn more about [forced reflows](https://developer.chrome.com/docs/performance/insights/forced-reflow) and possible mitigations.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "details": {
+          "items": [
+            {
+              "type": "table",
+              "items": [
+                {
+                  "source": {
+                    "type": "text",
+                    "value": "[unattributed]"
+                  },
+                  "reflowTime": 61.26
+                },
+                {
+                  "reflowTime": 1.609,
+                  "source": {
+                    "type": "source-location",
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+                    "line": 19,
+                    "urlProvider": "network",
+                    "column": 85503
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "key": "source",
+                  "valueType": "source-location",
+                  "label": "Source"
+                },
+                {
+                  "granularity": 1,
+                  "key": "reflowTime",
+                  "label": "Total reflow time",
+                  "valueType": "ms"
+                }
+              ]
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "diagnostics": {
+        "id": "diagnostics",
+        "title": "Diagnostics",
+        "description": "Collection of useful page vitals.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "numTasks": 2366,
+              "maxRtt": 10.711665,
+              "totalByteWeight": 1972710,
+              "throughput": 12824801330.561886,
+              "maxServerLatency": 7,
+              "totalTaskTime": 3025.5209999999975,
+              "numTasksOver25ms": 21,
+              "rtt": 0.00046695065229571039,
+              "numStylesheets": 3,
+              "numTasksOver10ms": 50,
+              "numScripts": 63,
+              "mainDocumentTransferSize": 20539,
+              "numTasksOver50ms": 11,
+              "numTasksOver100ms": 5,
+              "numFonts": 5,
+              "numRequests": 117,
+              "numTasksOver500ms": 0
+            }
+          ],
+          "type": "debugdata"
+        }
+      },
+      "legacy-javascript-insight": {
+        "id": "legacy-javascript-insight",
+        "title": "Legacy JavaScript",
+        "description": "Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile [Baseline](https://web.dev/articles/baseline-and-polyfills) features, unless you know you must support older browsers. [Learn why most sites can deploy ES6+ code without transpiling](https://developer.chrome.com/docs/performance/insights/legacy-javascript)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 14 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 13896,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "wastedBytes": 13896,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "signal": "Array.prototype.concat",
+                    "location": {
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "type": "source-location",
+                      "column": 6239,
+                      "urlProvider": "network"
+                    }
+                  },
+                  {
+                    "location": {
+                      "urlProvider": "network",
+                      "column": 12925,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "type": "source-location",
+                      "line": 1
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "location": {
+                      "column": 12813,
+                      "urlProvider": "network",
+                      "line": 1,
+                      "type": "source-location",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    },
+                    "signal": "Object.assign"
+                  },
+                  {
+                    "signal": "Object.create",
+                    "location": {
+                      "urlProvider": "network",
+                      "column": 10857,
+                      "type": "source-location",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1
+                    }
+                  }
+                ]
+              },
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "valueType": "url",
+              "subItemsHeading": {
+                "valueType": "source-location",
+                "key": "location"
+              },
+              "label": "URL"
+            },
+            {
+              "subItemsHeading": {
+                "key": "signal"
+              },
+              "valueType": "code",
+              "key": null
+            },
+            {
+              "label": "Wasted bytes",
+              "valueType": "bytes",
+              "key": "wastedBytes"
+            }
+          ]
+        }
+      },
+      "bootup-time": {
+        "id": "bootup-time",
+        "title": "Reduce JavaScript execution time",
+        "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to reduce Javascript execution time](https://developer.chrome.com/docs/lighthouse/performance/bootup-time/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "2.0 s",
+        "metricSavings": {
+          "TBT": 750
+        },
+        "details": {
+          "summary": {
+            "wastedMs": 1954.1735999999987
+          },
+          "items": [
+            {
+              "scriptParseCompile": 4.3919999999999995,
+              "scripting": 13.999199999999991,
+              "total": 943.59959999999955,
+              "url": "https://www.ocobo.co/fr"
+            },
+            {
+              "total": 658.89719999999932,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "scriptParseCompile": 166.30199999999996,
+              "scripting": 464.78999999999928
+            },
+            {
+              "total": 563.1744,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "scriptParseCompile": 13.814400000000001,
+              "scripting": 398.4132
+            },
+            {
+              "total": 556.02839999999958,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "scripting": 458.29679999999962,
+              "scriptParseCompile": 11.343599999999999
+            },
+            {
+              "total": 342.84239999999988,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "scriptParseCompile": 149.86079999999998,
+              "scripting": 190.39199999999988
+            },
+            {
+              "scriptParseCompile": 0,
+              "scripting": 31.96440000000003,
+              "total": 277.76399999999569,
+              "url": "Unattributable"
+            },
+            {
+              "total": 54.555599999999991,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "scriptParseCompile": 12.0252,
+              "scripting": 38.58
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "valueType": "ms",
+              "label": "Total CPU Time",
+              "granularity": 1,
+              "key": "total"
+            },
+            {
+              "valueType": "ms",
+              "label": "Script Evaluation",
+              "key": "scripting",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "key": "scriptParseCompile",
+              "label": "Script Parse",
+              "valueType": "ms"
+            }
+          ],
+          "sortedBy": [
+            "total"
+          ],
+          "type": "table"
+        },
+        "numericValue": 1954.1735999999987,
+        "numericUnit": "millisecond"
+      },
+      "unused-javascript": {
+        "id": "unused-javascript",
+        "title": "Reduce unused JavaScript",
+        "description": "Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/).",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 390 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [
+            {
+              "wastedBytes": 112602,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedPercent": 57.372344479375059,
+              "totalBytes": 196265
+            },
+            {
+              "wastedPercent": 71.210996802564736,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "totalBytes": 156323,
+              "wastedBytes": 111319
+            },
+            {
+              "wastedBytes": 82854,
+              "totalBytes": 196265,
+              "wastedPercent": 42.2154629213789,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "totalBytes": 156323,
+              "wastedPercent": 43.31273800537712,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedBytes": 67708
+            },
+            {
+              "wastedPercent": 57.9279818160067,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "totalBytes": 43331,
+              "wastedBytes": 25101
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "subItemsHeading": {
+                "valueType": "code",
+                "key": "source"
+              },
+              "valueType": "url",
+              "label": "URL"
+            },
+            {
+              "subItemsHeading": {
+                "key": "sourceBytes"
+              },
+              "valueType": "bytes",
+              "label": "Transfer Size",
+              "key": "totalBytes"
+            },
+            {
+              "key": "wastedBytes",
+              "label": "Est Savings",
+              "subItemsHeading": {
+                "key": "sourceWastedBytes"
+              },
+              "valueType": "bytes"
+            }
+          ],
+          "overallSavingsMs": 0,
+          "overallSavingsBytes": 399584,
+          "type": "opportunity",
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          }
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "viewport-insight": {
+        "id": "viewport-insight",
+        "title": "Optimize viewport for mobile",
+        "description": "Tap interactions may be [delayed by up to 300 ms](https://developer.chrome.com/docs/performance/insights/viewport) if the viewport is not optimized for mobile.",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "node": {
+                "boundingRect": {
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                  "height": 0,
+                  "left": 0,
+                  "bottom": 0
+                },
+                "lhId": "page-21-META",
+                "snippet": "\u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\"\u003e",
+                "path": "1,HTML,0,HEAD,2,META",
+                "nodeLabel": "head \u003e meta",
+                "selector": "head \u003e meta",
+                "type": "node"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "largest-contentful-paint": {
+        "id": "largest-contentful-paint",
+        "title": "Largest Contentful Paint",
+        "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)",
+        "score": 0.06,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "7.0 s",
+        "numericValue": 6988.0643152467364,
+        "numericUnit": "millisecond"
+      },
+      "layout-shifts": {
+        "id": "layout-shifts",
+        "title": "Avoid large layout shifts",
+        "description": "These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "2 layout shifts found",
+        "metricSavings": {
+          "CLS": 0.022
+        },
+        "details": {
+          "items": [
+            {
+              "score": 0.022351,
+              "subItems": {
+                "items": [
+                  {
+                    "extra": {
+                      "type": "url",
+                      "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff"
+                    },
+                    "cause": "Web font loaded"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "node": {
+                "type": "node",
+                "nodeLabel": "header.pt_8 \u003e div.mx_auto \u003e div.d_flex \u003e div.flex_1",
+                "selector": "header.pt_8 \u003e div.mx_auto \u003e div.d_flex \u003e div.flex_1",
+                "snippet": "\u003cdiv class=\"flex_1 d_flex ai_center jc_center lg:jc_flex-end\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,HEADER,0,DIV,0,DIV,1,DIV",
+                "lhId": "page-18-DIV",
+                "boundingRect": {
+                  "width": 380,
+                  "height": 380,
+                  "right": 396,
+                  "top": 720,
+                  "bottom": 1100,
+                  "left": 16
+                }
+              }
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "extra": {
+                      "type": "url",
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                    },
+                    "cause": "Web font loaded"
+                  },
+                  {
+                    "extra": {
+                      "type": "url",
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                    },
+                    "cause": "Web font loaded"
+                  }
+                ]
+              },
+              "score": 0
+            }
+          ],
+          "headings": [
+            {
+              "subItemsHeading": {
+                "key": "extra"
+              },
+              "valueType": "node",
+              "label": "Element",
+              "key": "node"
+            },
+            {
+              "key": "score",
+              "subItemsHeading": {
+                "key": "cause",
+                "valueType": "text"
+              },
+              "valueType": "numeric",
+              "granularity": 0.001,
+              "label": "Layout shift score"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "script-treemap-data": {
+        "id": "script-treemap-data",
+        "title": "Script Treemap Data",
+        "description": "Used for treemap app",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "nodes": [
+            {
+              "resourceBytes": 17048,
+              "name": "https://www.ocobo.co/fr",
+              "children": [
+                {
+                  "name": "(inline) window.dataLaye…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 298
+                },
+                {
+                  "name": "(inline) window.AGO = {\n…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 631
+                },
+                {
+                  "resourceBytes": 592,
+                  "name": "(inline) ((storageKey2, …",
+                  "unusedBytes": 0
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 520
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 9806
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 53
+                },
+                {
+                  "unusedBytes": 0,
+                  "name": "(inline) ;\nimport * as r…",
+                  "resourceBytes": 5148
+                }
+              ],
+              "encodedBytes": 2850
+            },
+            {
+              "unusedBytes": 749,
+              "encodedBytes": 3933,
+              "name": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "resourceBytes": 9792
+            },
+            {
+              "resourceBytes": 125385,
+              "unusedBytes": 72633,
+              "encodedBytes": 43335,
+              "name": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            },
+            {
+              "resourceBytes": 927,
+              "unusedBytes": 0,
+              "encodedBytes": 878,
+              "name": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js"
+            },
+            {
+              "unusedBytes": 1084,
+              "encodedBytes": 1560,
+              "name": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "resourceBytes": 3192
+            },
+            {
+              "unusedBytes": 89,
+              "encodedBytes": 916,
+              "name": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "resourceBytes": 983
+            },
+            {
+              "resourceBytes": 141,
+              "name": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "unusedBytes": 6,
+              "encodedBytes": 78
+            },
+            {
+              "name": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "unusedBytes": 467,
+              "encodedBytes": 672,
+              "resourceBytes": 1284
+            },
+            {
+              "unusedBytes": 1144,
+              "encodedBytes": 6230,
+              "name": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "resourceBytes": 15426
+            },
+            {
+              "resourceBytes": 17234,
+              "unusedBytes": 1545,
+              "encodedBytes": 5624,
+              "name": "https://www.ocobo.co/assets/factory-hx59odkt.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "unusedBytes": 1266,
+              "encodedBytes": 1254,
+              "resourceBytes": 3070
+            },
+            {
+              "resourceBytes": 428,
+              "name": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "unusedBytes": 239,
+              "encodedBytes": 365
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 362,
+              "name": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "resourceBytes": 410
+            },
+            {
+              "resourceBytes": 525,
+              "name": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "unusedBytes": 65,
+              "encodedBytes": 450
+            },
+            {
+              "resourceBytes": 942,
+              "name": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "unusedBytes": 362,
+              "encodedBytes": 867
+            },
+            {
+              "resourceBytes": 349,
+              "unusedBytes": 0,
+              "encodedBytes": 275,
+              "name": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js"
+            },
+            {
+              "resourceBytes": 1866,
+              "encodedBytes": 766,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js"
+            },
+            {
+              "resourceBytes": 348,
+              "name": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "unusedBytes": 0,
+              "encodedBytes": 300
+            },
+            {
+              "unusedBytes": 32058,
+              "encodedBytes": 20672,
+              "name": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "resourceBytes": 67398
+            },
+            {
+              "name": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "unusedBytes": 0,
+              "encodedBytes": 117,
+              "resourceBytes": 165
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 143,
+              "name": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "resourceBytes": 206
+            },
+            {
+              "name": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "unusedBytes": 0,
+              "encodedBytes": 33600,
+              "resourceBytes": 109016
+            },
+            {
+              "resourceBytes": 605,
+              "unusedBytes": 0,
+              "encodedBytes": 556,
+              "name": "https://www.ocobo.co/assets/layers-CQ3InJLS.js"
+            },
+            {
+              "resourceBytes": 826,
+              "unusedBytes": 0,
+              "encodedBytes": 762,
+              "name": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js"
+            },
+            {
+              "resourceBytes": 404,
+              "unusedBytes": 0,
+              "encodedBytes": 345,
+              "name": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "unusedBytes": 0,
+              "encodedBytes": 426,
+              "resourceBytes": 490
+            },
+            {
+              "name": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "unusedBytes": 337,
+              "encodedBytes": 771,
+              "resourceBytes": 835
+            },
+            {
+              "resourceBytes": 68826,
+              "unusedBytes": 47522,
+              "encodedBytes": 25831,
+              "name": "https://www.ocobo.co/assets/portal-Clm-6X_X.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "unusedBytes": 31128,
+              "encodedBytes": 44679,
+              "resourceBytes": 133936
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 399,
+              "name": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "resourceBytes": 473
+            },
+            {
+              "resourceBytes": 338,
+              "unusedBytes": 0,
+              "encodedBytes": 275,
+              "name": "https://www.ocobo.co/assets/x-B1I3g_bH.js"
+            },
+            {
+              "resourceBytes": 435,
+              "unusedBytes": 0,
+              "encodedBytes": 376,
+              "name": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js"
+            },
+            {
+              "resourceBytes": 312,
+              "name": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "unusedBytes": 0,
+              "encodedBytes": 264
+            },
+            {
+              "unusedBytes": 194,
+              "encodedBytes": 235,
+              "name": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "resourceBytes": 309
+            },
+            {
+              "resourceBytes": 27349,
+              "unusedBytes": 158,
+              "encodedBytes": 6962,
+              "name": "https://www.ocobo.co/assets/_main.(_lang)._index-BJmsIfGa.js"
+            },
+            {
+              "resourceBytes": 521,
+              "unusedBytes": 65,
+              "encodedBytes": 446,
+              "name": "https://www.ocobo.co/assets/section-CAd8zqOP.js"
+            },
+            {
+              "resourceBytes": 717,
+              "unusedBytes": 65,
+              "encodedBytes": 653,
+              "name": "https://www.ocobo.co/assets/text-DlkbtvSW.js"
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 485,
+              "name": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "resourceBytes": 549
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 255,
+              "name": "https://www.ocobo.co/assets/check-D95Zi0fi.js",
+              "resourceBytes": 303
+            },
+            {
+              "encodedBytes": 502,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/hero-split-DCf1X66c.js",
+              "resourceBytes": 551
+            },
+            {
+              "resourceBytes": 495,
+              "name": "https://www.ocobo.co/assets/badge-i9dgPBIb.js",
+              "unusedBytes": 65,
+              "encodedBytes": 431
+            },
+            {
+              "resourceBytes": 605,
+              "name": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "unusedBytes": 65,
+              "encodedBytes": 530
+            },
+            {
+              "name": "https://www.ocobo.co/assets/plus-Bvz3jpuZ.js",
+              "encodedBytes": 289,
+              "unusedBytes": 0,
+              "resourceBytes": 337
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 364,
+              "name": "https://www.ocobo.co/assets/panels-top-left-BeWfuLW7.js",
+              "resourceBytes": 412
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 387,
+              "name": "https://www.ocobo.co/assets/zap-C3uzvT7-.js",
+              "resourceBytes": 446
+            },
+            {
+              "resourceBytes": 405,
+              "name": "https://www.ocobo.co/assets/target-DyzL19b9.js",
+              "unusedBytes": 0,
+              "encodedBytes": 346
+            },
+            {
+              "name": "https://www.ocobo.co/assets/chart-column-CxnbmN-k.js",
+              "unusedBytes": 0,
+              "encodedBytes": 376,
+              "resourceBytes": 435
+            },
+            {
+              "resourceBytes": 3009,
+              "name": "https://www.ocobo.co/assets/modular-stack-grid-DBlYkSNY.js",
+              "unusedBytes": 0,
+              "encodedBytes": 1181
+            },
+            {
+              "name": "https://www.ocobo.co/assets/flex-pair-BLQ5DP05.js",
+              "unusedBytes": 0,
+              "encodedBytes": 504,
+              "resourceBytes": 568
+            },
+            {
+              "name": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "unusedBytes": 4,
+              "encodedBytes": 550,
+              "resourceBytes": 1208
+            },
+            {
+              "unusedBytes": 28818,
+              "encodedBytes": 23527,
+              "name": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "resourceBytes": 69550
+            },
+            {
+              "resourceBytes": 471628,
+              "unusedBytes": 204275,
+              "encodedBytes": 156323,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "unusedBytes": 0,
+              "encodedBytes": 577,
+              "resourceBytes": 2125
+            },
+            {
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "encodedBytes": 4213,
+              "unusedBytes": 12049,
+              "resourceBytes": 17494
+            },
+            {
+              "resourceBytes": 12567,
+              "unusedBytes": 6432,
+              "encodedBytes": 4673,
+              "name": "https://www.ocobo.co/_vercel/speed-insights/script.js"
+            },
+            {
+              "name": "https://www.ocobo.co/_vercel/insights/script.js",
+              "unusedBytes": 682,
+              "encodedBytes": 1227,
+              "resourceBytes": 2495
+            },
+            {
+              "resourceBytes": 78059,
+              "unusedBytes": 35974,
+              "encodedBytes": 26496,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "unusedBytes": 36142,
+              "encodedBytes": 25121,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "resourceBytes": 72608
+            },
+            {
+              "resourceBytes": 108995,
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "unusedBytes": 46367,
+              "encodedBytes": 42582
+            },
+            {
+              "unusedBytes": 56996,
+              "encodedBytes": 27869,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "resourceBytes": 97992
+            },
+            {
+              "resourceBytes": 471628,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "unusedBytes": 335851,
+              "encodedBytes": 156323
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 577,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "resourceBytes": 2125
+            },
+            {
+              "resourceBytes": 17494,
+              "encodedBytes": 4213,
+              "name": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "unusedBytes": 337253,
+              "encodedBytes": 202942,
+              "resourceBytes": 587832
+            },
+            {
+              "resourceBytes": 587832,
+              "unusedBytes": 248156,
+              "encodedBytes": 202942,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            }
+          ],
+          "type": "treemap-data"
+        }
+      },
+      "lcp-breakdown-insight": {
+        "id": "lcp-breakdown-insight",
+        "title": "LCP breakdown",
+        "description": "Each [subpart has specific improvement strategies](https://developer.chrome.com/docs/performance/insights/lcp-breakdown). Ideally, most of the LCP time should be spent on loading the resources, not within delays.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "type": "table",
+              "items": [
+                {
+                  "label": "Time to first byte",
+                  "subpart": "timeToFirstByte",
+                  "duration": 521.25
+                },
+                {
+                  "duration": 1998.715,
+                  "label": "Element render delay",
+                  "subpart": "elementRenderDelay"
+                }
+              ],
+              "headings": [
+                {
+                  "key": "label",
+                  "valueType": "text",
+                  "label": "Subpart"
+                },
+                {
+                  "key": "duration",
+                  "valueType": "ms",
+                  "label": "Duration"
+                }
+              ]
+            },
+            {
+              "nodeLabel": "L'architecture\nqui fait tenir\nvotre croissance.",
+              "selector": "div.mx_auto \u003e div.d_flex \u003e div.flex_1 \u003e h1.text",
+              "type": "node",
+              "boundingRect": {
+                "width": 380,
+                "height": 182,
+                "right": 396,
+                "top": 128,
+                "bottom": 310,
+                "left": 16
+              },
+              "lhId": "page-17-H1",
+              "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark c_ocobo.dark mb_10 op_0 ani…\"\u003e",
+              "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,HEADER,0,DIV,0,DIV,0,DIV,0,H1"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "server-response-time": {
+        "id": "server-response-time",
+        "title": "Initial server response time was short",
+        "description": "Keep the server response time for the main document short because all other requests depend on it. [Learn more about the Time to First Byte metric](https://developer.chrome.com/docs/lighthouse/performance/time-to-first-byte/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Root document took 40 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "opportunity",
+          "items": [
+            {
+              "url": "https://www.ocobo.co/fr",
+              "responseTime": 38
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "label": "URL",
+              "valueType": "url"
+            },
+            {
+              "key": "responseTime",
+              "valueType": "timespanMs",
+              "label": "Time Spent"
+            }
+          ],
+          "overallSavingsMs": 0
+        },
+        "numericValue": 38,
+        "numericUnit": "millisecond"
+      },
+      "speed-index": {
+        "id": "speed-index",
+        "title": "Speed Index",
+        "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).",
+        "score": 0.32,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "7.1 s",
+        "numericValue": 7057.3989602015063,
+        "numericUnit": "millisecond"
+      },
+      "non-composited-animations": {
+        "id": "non-composited-animations",
+        "title": "Avoid non-composited animations",
+        "description": "Animations which are not composited can be janky and increase CLS. [Learn how to avoid non-composited animations](https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/)",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "key": "node",
+              "label": "Element",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "failureReason"
+              },
+              "valueType": "node"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "metrics": {
+        "id": "metrics",
+        "title": "Metrics",
+        "description": "Collects all available metrics.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "observedSpeedIndexTs": 4956606544,
+              "totalBlockingTime": 560,
+              "observedNavigationStart": 0,
+              "observedFirstPaintTs": 4955722606,
+              "observedFirstPaint": 2335,
+              "largestContentfulPaint": 6988,
+              "observedDomContentLoaded": 2423,
+              "observedLastVisualChangeTs": 4960107788,
+              "observedTraceEndTs": 4960133746,
+              "observedFirstContentfulPaintTs": 4955722606,
+              "timeToFirstByte": 601,
+              "observedLargestContentfulPaintAllFrames": 2520,
+              "observedLastVisualChange": 6720,
+              "observedLoad": 4281,
+              "maxPotentialFID": 322,
+              "interactive": 11369,
+              "observedFirstContentfulPaintAllFrames": 2335,
+              "observedTimeOriginTs": 4953387788,
+              "speedIndex": 7057,
+              "observedLargestContentfulPaint": 2520,
+              "cumulativeLayoutShift": 0.022351,
+              "observedTraceEnd": 6746,
+              "observedDomContentLoadedTs": 4955811069,
+              "observedFirstContentfulPaintAllFramesTs": 4955722606,
+              "observedCumulativeLayoutShift": 0.022351,
+              "observedTimeOrigin": 0,
+              "observedCumulativeLayoutShiftMainFrame": 0.022351,
+              "cumulativeLayoutShiftMainFrame": 0.022351,
+              "observedLargestContentfulPaintAllFramesTs": 4955907753,
+              "observedFirstVisualChangeTs": 4953771788,
+              "firstContentfulPaint": 3690,
+              "observedNavigationStartTs": 4953387788,
+              "observedSpeedIndex": 3219,
+              "observedLargestContentfulPaintTs": 4955907753,
+              "observedFirstVisualChange": 384,
+              "observedLoadTs": 4957668741,
+              "observedFirstContentfulPaint": 2335
+            },
+            {
+              "lcpInvalidated": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 11369,
+        "numericUnit": "millisecond"
+      },
+      "cls-culprits-insight": {
+        "id": "cls-culprits-insight",
+        "title": "Layout shift culprits",
+        "description": "Layout shifts occur when elements move absent any user interaction. [Investigate the causes of layout shifts](https://developer.chrome.com/docs/performance/insights/cls-culprit), such as elements being added, removed, or their fonts changing as the page loads.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "type": "table",
+              "items": [
+                {
+                  "score": 0.022351,
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  }
+                },
+                {
+                  "subItems": {
+                    "items": [
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "type": "url",
+                          "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff"
+                        }
+                      }
+                    ],
+                    "type": "subitems"
+                  },
+                  "node": {
+                    "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,HEADER,0,DIV,0,DIV,1,DIV",
+                    "snippet": "\u003cdiv class=\"flex_1 d_flex ai_center jc_center lg:jc_flex-end\"\u003e",
+                    "boundingRect": {
+                      "height": 380,
+                      "width": 380,
+                      "top": 720,
+                      "right": 396,
+                      "bottom": 1100,
+                      "left": 16
+                    },
+                    "lhId": "page-18-DIV",
+                    "selector": "header.pt_8 \u003e div.mx_auto \u003e div.d_flex \u003e div.flex_1",
+                    "nodeLabel": "header.pt_8 \u003e div.mx_auto \u003e div.d_flex \u003e div.flex_1",
+                    "type": "node"
+                  },
+                  "score": 0.022351
+                }
+              ],
+              "headings": [
+                {
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "valueType": "node",
+                  "key": "node"
+                },
+                {
+                  "key": "score",
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  },
+                  "valueType": "numeric",
+                  "granularity": 0.001,
+                  "label": "Layout shift score"
+                }
+              ]
+            },
+            {
+              "type": "table",
+              "items": [
+                {
+                  "score": 0,
+                  "node": {
+                    "type": "text",
+                    "value": "Total"
+                  }
+                },
+                {
+                  "subItems": {
+                    "type": "subitems",
+                    "items": [
+                      {
+                        "extra": {
+                          "type": "url",
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      }
+                    ]
+                  },
+                  "node": {
+                    "lhId": "page-0-INPUT",
+                    "boundingRect": {
+                      "top": 79,
+                      "right": 380,
+                      "height": 38,
+                      "width": 110,
+                      "left": 270,
+                      "bottom": 117
+                    },
+                    "path": "0,HTML,1,BODY,1,DIV,0,FORM,1,DIV,1,DIV,0,INPUT",
+                    "snippet": "\u003cinput type=\"submit\" class=\"hs-button primary large\" value=\"S'inscrire\"\u003e",
+                    "type": "node",
+                    "selector": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "nodeLabel": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button"
+                  },
+                  "score": 0
+                }
+              ],
+              "headings": [
+                {
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "valueType": "node",
+                  "label": "Element",
+                  "key": "node"
+                },
+                {
+                  "subItemsHeading": {
+                    "key": "cause",
+                    "valueType": "text"
+                  },
+                  "valueType": "numeric",
+                  "key": "score",
+                  "label": "Layout shift score",
+                  "granularity": 0.001
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "unsized-images": {
+        "id": "unsized-images",
+        "title": "Image elements do not have explicit `width` and `height`",
+        "description": "Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,3,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cy…\" alt=\"CybelAngel\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "lhId": "1-5-IMG",
+                "boundingRect": {
+                  "left": 269,
+                  "bottom": 1498,
+                  "right": 403,
+                  "top": 1466,
+                  "width": 134,
+                  "height": 32
+                },
+                "type": "node",
+                "nodeLabel": "CybelAngel",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png"
+            },
+            {
+              "node": {
+                "type": "node",
+                "nodeLabel": "CybelAngel",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "lhId": "1-21-IMG",
+                "boundingRect": {
+                  "top": 1466,
+                  "right": 3133,
+                  "height": 32,
+                  "width": 134,
+                  "left": 2999,
+                  "bottom": 1498
+                },
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cy…\" alt=\"CybelAngel\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,19,DIV,0,IMG"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png"
+            },
+            {
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cy…\" alt=\"CybelAngel\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,35,DIV,0,IMG",
+                "lhId": "1-37-IMG",
+                "boundingRect": {
+                  "left": 5729,
+                  "bottom": 1498,
+                  "right": 5863,
+                  "top": 1466,
+                  "width": 134,
+                  "height": 32
+                },
+                "type": "node",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "nodeLabel": "CybelAngel"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png"
+            },
+            {
+              "node": {
+                "boundingRect": {
+                  "right": 1076,
+                  "top": 1466,
+                  "width": 99,
+                  "height": 32,
+                  "left": 977,
+                  "bottom": 1498
+                },
+                "lhId": "1-9-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/co…\" alt=\"Combo\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,7,DIV,0,IMG",
+                "nodeLabel": "Combo",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "type": "node"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png"
+            },
+            {
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/co…\" alt=\"Combo\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,23,DIV,0,IMG",
+                "lhId": "1-25-IMG",
+                "boundingRect": {
+                  "bottom": 1498,
+                  "left": 3707,
+                  "width": 99,
+                  "height": 32,
+                  "right": 3806,
+                  "top": 1466
+                },
+                "type": "node",
+                "nodeLabel": "Combo",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png"
+            },
+            {
+              "node": {
+                "boundingRect": {
+                  "left": 6437,
+                  "bottom": 1498,
+                  "top": 1466,
+                  "right": 6536,
+                  "height": 32,
+                  "width": 99
+                },
+                "lhId": "1-41-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/co…\" alt=\"Combo\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,39,DIV,0,IMG",
+                "nodeLabel": "Combo",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "type": "node"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png"
+            },
+            {
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,11,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ju…\" alt=\"Jus Mundi\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "width": 81,
+                  "height": 32,
+                  "right": 1775,
+                  "top": 1466,
+                  "bottom": 1498,
+                  "left": 1694
+                },
+                "lhId": "1-13-IMG",
+                "nodeLabel": "Jus Mundi",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "type": "node"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png"
+            },
+            {
+              "node": {
+                "nodeLabel": "Jus Mundi",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "type": "node",
+                "boundingRect": {
+                  "left": 4424,
+                  "bottom": 1498,
+                  "top": 1466,
+                  "right": 4504,
+                  "height": 32,
+                  "width": 81
+                },
+                "lhId": "1-29-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ju…\" alt=\"Jus Mundi\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,27,DIV,0,IMG"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png"
+            },
+            {
+              "node": {
+                "boundingRect": {
+                  "width": 81,
+                  "height": 32,
+                  "right": 7234,
+                  "top": 1466,
+                  "bottom": 1498,
+                  "left": 7153
+                },
+                "lhId": "1-45-IMG",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,43,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ju…\" alt=\"Jus Mundi\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "nodeLabel": "Jus Mundi",
+                "type": "node"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png"
+            },
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yousign-white.png",
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,10,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yo…\" alt=\"Yousign\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "lhId": "1-12-IMG",
+                "boundingRect": {
+                  "bottom": 1498,
+                  "left": 1518,
+                  "height": 32,
+                  "width": 96,
+                  "top": 1466,
+                  "right": 1614
+                },
+                "type": "node",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "nodeLabel": "Yousign"
+              }
+            },
+            {
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yo…\" alt=\"Yousign\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,26,DIV,0,IMG",
+                "boundingRect": {
+                  "left": 4248,
+                  "bottom": 1498,
+                  "top": 1466,
+                  "right": 4344,
+                  "height": 32,
+                  "width": 96
+                },
+                "lhId": "1-28-IMG",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "nodeLabel": "Yousign",
+                "type": "node"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yousign-white.png"
+            },
+            {
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yo…\" alt=\"Yousign\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,42,DIV,0,IMG",
+                "boundingRect": {
+                  "height": 32,
+                  "width": 96,
+                  "top": 1466,
+                  "right": 7073,
+                  "bottom": 1498,
+                  "left": 6977
+                },
+                "lhId": "1-44-IMG",
+                "nodeLabel": "Yousign",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "type": "node"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yousign-white.png"
+            }
+          ],
+          "headings": [
+            {
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "key": "url",
+              "valueType": "url",
+              "label": "URL"
+            }
+          ]
+        }
+      },
+      "document-latency-insight": {
+        "id": "document-latency-insight",
+        "title": "Document request latency",
+        "description": "Your first network request is the most important. [Reduce its latency](https://developer.chrome.com/docs/performance/insights/document-latency) by avoiding redirects, ensuring a fast server response, and enabling text compression.",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 520 ms",
+        "metricSavings": {
+          "LCP": 500,
+          "FCP": 500
+        },
+        "details": {
+          "items": {
+            "serverResponseIsFast": {
+              "value": true,
+              "label": "Server responds quickly (observed 38 ms)"
+            },
+            "usesCompression": {
+              "value": true,
+              "label": "Applies text compression"
+            },
+            "noRedirects": {
+              "value": false,
+              "label": "Had redirects (1 redirects, +521 ms)"
+            }
+          },
+          "type": "checklist",
+          "debugData": {
+            "uncompressedResponseBytes": 0,
+            "serverResponseTime": 38,
+            "type": "debugdata",
+            "redirectDuration": 521,
+            "wastedBytes": 0
+          }
+        }
+      },
+      "inp-breakdown-insight": {
+        "id": "inp-breakdown-insight",
+        "title": "INP breakdown",
+        "description": "Start investigating [how to improve INP](https://developer.chrome.com/docs/performance/insights/inp-breakdown) by looking at the longest subpart.",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "cumulative-layout-shift": {
+        "id": "cumulative-layout-shift",
+        "title": "Cumulative Layout Shift",
+        "description": "Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/articles/cls).",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "0.022",
+        "details": {
+          "items": [
+            {
+              "cumulativeLayoutShiftMainFrame": 0.022351,
+              "newEngineResultDiffered": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 0.022351,
+        "numericUnit": "unitless"
+      },
+      "dom-size-insight": {
+        "id": "dom-size-insight",
+        "title": "Optimize DOM size",
+        "description": "A large DOM can increase the duration of style calculations and layout reflows, impacting page responsiveness. A large DOM will also increase memory usage. [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/performance/insights/dom-size).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "type": "table",
+          "debugData": {
+            "maxDepth": 14,
+            "maxChildren": 63,
+            "totalElements": 883,
+            "type": "debugdata"
+          },
+          "headings": [
+            {
+              "valueType": "text",
+              "label": "Statistic",
+              "key": "statistic"
+            },
+            {
+              "label": "Element",
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "key": "value",
+              "label": "Value",
+              "valueType": "numeric"
+            }
+          ],
+          "items": [
+            {
+              "statistic": "Total elements",
+              "value": {
+                "granularity": 1,
+                "type": "numeric",
+                "value": 883
+              }
+            },
+            {
+              "value": {
+                "value": 14,
+                "type": "numeric",
+                "granularity": 1
+              },
+              "statistic": "DOM depth",
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,HEADER,0,DIV,0,DIV,1,DIV,0,DIV,4,svg,0,g,5,g,0,rect",
+                "snippet": "\u003crect x=\"0\" y=\"0\" width=\"200\" height=\"6\" rx=\"3\" fill=\"currentColor\"\u003e",
+                "lhId": "page-23-rect",
+                "boundingRect": {
+                  "bottom": 827,
+                  "left": 70,
+                  "height": 4,
+                  "width": 127,
+                  "top": 823,
+                  "right": 197
+                },
+                "type": "node",
+                "selector": "svg.pos_relative \u003e g.anim_float-very-slow \u003e g \u003e rect",
+                "nodeLabel": "svg.pos_relative \u003e g.anim_float-very-slow \u003e g \u003e rect"
+              }
+            },
+            {
+              "node": {
+                "lhId": "page-22-BODY",
+                "boundingRect": {
+                  "bottom": 12931,
+                  "left": 0,
+                  "width": 412,
+                  "height": 12931,
+                  "right": 412,
+                  "top": 0
+                },
+                "snippet": "\u003cbody\u003e",
+                "path": "1,HTML,1,BODY",
+                "type": "node",
+                "nodeLabel": "body",
+                "selector": "body"
+              },
+              "statistic": "Most children",
+              "value": {
+                "type": "numeric",
+                "granularity": 1,
+                "value": 63
+              }
+            }
+          ]
+        },
+        "numericValue": 883,
+        "numericUnit": "element"
+      },
+      "unminified-css": {
+        "id": "unminified-css",
+        "title": "Minify CSS",
+        "description": "Minifying CSS files can reduce network payload sizes. [Learn how to minify CSS](https://developer.chrome.com/docs/lighthouse/performance/unminified-css/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [],
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsMs": 0,
+          "overallSavingsBytes": 0,
+          "type": "opportunity",
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          }
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "duplicated-javascript-insight": {
+        "id": "duplicated-javascript-insight",
+        "title": "Duplicated JavaScript",
+        "description": "Remove large, [duplicate JavaScript modules](https://developer.chrome.com/docs/performance/insights/duplicated-javascript) from bundles to reduce unnecessary bytes consumed by network activity.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "key": "source",
+              "label": "Source",
+              "subItemsHeading": {
+                "key": "url",
+                "valueType": "url"
+              },
+              "valueType": "code"
+            },
+            {
+              "key": "wastedBytes",
+              "subItemsHeading": {
+                "key": "sourceTransferBytes"
+              },
+              "valueType": "bytes",
+              "granularity": 10,
+              "label": "Duplicated bytes"
+            }
+          ],
+          "debugData": {
+            "type": "debugdata",
+            "wastedBytes": 0
+          },
+          "type": "table"
+        }
+      },
+      "network-dependency-tree-insight": {
+        "id": "network-dependency-tree-insight",
+        "title": "Network dependency tree",
+        "description": "[Avoid chaining critical requests](https://developer.chrome.com/docs/performance/insights/network-dependency-tree) by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "type": "list-section",
+              "value": {
+                "longestChain": {
+                  "duration": 2552
+                },
+                "type": "network-tree",
+                "chains": {
+                  "42B5AE18A261F7202456837110FF46B8": {
+                    "children": {
+                      "42B5AE18A261F7202456837110FF46B8": {
+                        "navStartToEndTime": 1681,
+                        "isLongest": true,
+                        "children": {
+                          "51.2": {
+                            "transferSize": 24569,
+                            "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                            "children": {
+                              "51.143": {
+                                "transferSize": 38778,
+                                "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                                "navStartToEndTime": 2503,
+                                "children": {}
+                              },
+                              "51.145": {
+                                "children": {},
+                                "transferSize": 39126,
+                                "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                                "navStartToEndTime": 2469
+                              },
+                              "51.140": {
+                                "children": {},
+                                "transferSize": 31974,
+                                "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                                "isLongest": true,
+                                "navStartToEndTime": 2552
+                              }
+                            },
+                            "navStartToEndTime": 2180,
+                            "isLongest": true
+                          }
+                        },
+                        "transferSize": 20539,
+                        "url": "https://www.ocobo.co/fr"
+                      }
+                    },
+                    "transferSize": 20539,
+                    "url": "https://www.ocobo.co/fr",
+                    "isLongest": true,
+                    "navStartToEndTime": 1681
+                  }
+                }
+              }
+            },
+            {
+              "value": {
+                "headings": [
+                  {
+                    "subItemsHeading": {
+                      "key": "warning"
+                    },
+                    "valueType": "text",
+                    "label": "Origin",
+                    "key": "origin"
+                  },
+                  {
+                    "label": "Source",
+                    "valueType": "node",
+                    "key": "source"
+                  }
+                ],
+                "items": [
+                  {
+                    "source": {
+                      "type": "node",
+                      "nodeLabel": "head \u003e link",
+                      "selector": "head \u003e link",
+                      "lhId": "page-20-LINK",
+                      "boundingRect": {
+                        "bottom": 0,
+                        "left": 0,
+                        "width": 0,
+                        "height": 0,
+                        "right": 0,
+                        "top": 0
+                      },
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "path": "1,HTML,0,HEAD,3,LINK"
+                    },
+                    "subItems": {
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ],
+                      "type": "subitems"
+                    },
+                    "origin": "https://raw.githubusercontent.com/"
+                  }
+                ],
+                "type": "table"
+              },
+              "description": "[preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints help the browser establish a connection earlier in the page load, saving time when the first request for that origin is made. The following are the origins that the page preconnected to.",
+              "type": "list-section",
+              "title": "Preconnected origins"
+            },
+            {
+              "value": {
+                "value": "No additional origins are good candidates for preconnecting",
+                "type": "text"
+              },
+              "title": "Preconnect candidates",
+              "description": "Add [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints to your most important origins, but try to use no more than 4.",
+              "type": "list-section"
+            }
+          ]
+        }
+      },
+      "user-timings": {
+        "id": "user-timings",
+        "title": "User Timing marks and measures",
+        "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more about User Timing marks](https://developer.chrome.com/docs/lighthouse/performance/user-timings/).",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "details": {
+          "type": "table",
+          "items": [],
+          "headings": [
+            {
+              "key": "name",
+              "valueType": "text",
+              "label": "Name"
+            },
+            {
+              "key": "timingType",
+              "label": "Type",
+              "valueType": "text"
+            },
+            {
+              "label": "Start Time",
+              "valueType": "ms",
+              "granularity": 0.01,
+              "key": "startTime"
+            },
+            {
+              "granularity": 0.01,
+              "key": "duration",
+              "valueType": "ms",
+              "label": "Duration"
+            }
+          ]
+        }
+      },
+      "mainthread-work-breakdown": {
+        "id": "mainthread-work-breakdown",
+        "title": "Minimize main-thread work",
+        "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to minimize main-thread work](https://developer.chrome.com/docs/lighthouse/performance/mainthread-work-breakdown/)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "3.6 s",
+        "metricSavings": {
+          "TBT": 550
+        },
+        "details": {
+          "headings": [
+            {
+              "valueType": "text",
+              "label": "Category",
+              "key": "groupLabel"
+            },
+            {
+              "granularity": 1,
+              "key": "duration",
+              "valueType": "ms",
+              "label": "Time Spent"
+            }
+          ],
+          "sortedBy": [
+            "duration"
+          ],
+          "items": [
+            {
+              "groupLabel": "Script Evaluation",
+              "duration": 1695.2495999999815,
+              "group": "scriptEvaluation"
+            },
+            {
+              "duration": 607.89119999999957,
+              "groupLabel": "Style & Layout",
+              "group": "styleLayout"
+            },
+            {
+              "group": "other",
+              "duration": 590.52479999999616,
+              "groupLabel": "Other"
+            },
+            {
+              "duration": 444.26039999999989,
+              "groupLabel": "Script Parsing & Compilation",
+              "group": "scriptParseCompile"
+            },
+            {
+              "group": "paintCompositeRender",
+              "duration": 223.13640000000075,
+              "groupLabel": "Rendering"
+            },
+            {
+              "group": "parseHTML",
+              "duration": 43.049999999999962,
+              "groupLabel": "Parse HTML & CSS"
+            },
+            {
+              "group": "garbageCollection",
+              "groupLabel": "Garbage Collection",
+              "duration": 26.512800000000006
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 3630.6251999999777,
+        "numericUnit": "millisecond"
+      },
+      "image-delivery-insight": {
+        "id": "image-delivery-insight",
+        "title": "Improve image delivery",
+        "description": "Reducing the download time of images can improve the perceived load time of the page and LCP. [Learn more about optimizing image size](https://developer.chrome.com/docs/performance/insights/image-delivery)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 546 KiB",
+        "metricSavings": {
+          "LCP": 1300,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "wastedBytes": 321504,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qobra-avatar.png",
+              "node": {
+                "nodeLabel": "Antoine Fort",
+                "selector": "div.d_flex \u003e div.d_flex \u003e div.text \u003e img.w_full",
+                "type": "node",
+                "boundingRect": {
+                  "width": 59,
+                  "height": 59,
+                  "right": 106,
+                  "top": 1880,
+                  "bottom": 1939,
+                  "left": 48
+                },
+                "lhId": "page-0-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qo…\" alt=\"Antoine Fort\" class=\"w_full h_full obj-f_cover\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,2,DIV,1,DIV,2,DIV,0,DIV,0,DIV,0,IMG"
+              },
+              "totalBytes": 323105,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size.",
+                    "wastedBytes": 296438
+                  },
+                  {
+                    "wastedBytes": 303711,
+                    "reason": "This image file is larger than it needs to be (400x400) for its displayed dimensions (98x98). Use responsive images to reduce the image download size."
+                  }
+                ]
+              }
+            },
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png",
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,35,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cy…\" alt=\"CybelAngel\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "bottom": 1498,
+                  "left": 5495,
+                  "width": 134,
+                  "height": 32,
+                  "right": 5629,
+                  "top": 1466
+                },
+                "lhId": "page-1-IMG",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "nodeLabel": "CybelAngel",
+                "type": "node"
+              },
+              "totalBytes": 59662,
+              "wastedBytes": 59534,
+              "subItems": {
+                "items": [
+                  {
+                    "reason": "This image file is larger than it needs to be (5064x1211) for its displayed dimensions (234x56). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 59534
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "wastedBytes": 27609,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yousign-white.png",
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,42,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yo…\" alt=\"Yousign\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "left": 6743,
+                  "bottom": 1498,
+                  "right": 6839,
+                  "top": 1466,
+                  "width": 96,
+                  "height": 32
+                },
+                "lhId": "page-2-IMG",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "nodeLabel": "Yousign",
+                "type": "node"
+              },
+              "totalBytes": 28606,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 27609,
+                    "reason": "This image file is larger than it needs to be (900x300) for its displayed dimensions (168x56). Use responsive images to reduce the image download size."
+                  }
+                ]
+              }
+            },
+            {
+              "wastedBytes": 21796,
+              "totalBytes": 22161,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png",
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,43,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ju…\" alt=\"Jus Mundi\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "bottom": 1498,
+                  "left": 6919,
+                  "height": 32,
+                  "width": 81,
+                  "top": 1466,
+                  "right": 7000
+                },
+                "lhId": "page-3-IMG",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "nodeLabel": "Jus Mundi",
+                "type": "node"
+              },
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 21796,
+                    "reason": "This image file is larger than it needs to be (1102x436) for its displayed dimensions (142x56). Use responsive images to reduce the image download size."
+                  }
+                ]
+              }
+            },
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/wecandoo-white.png",
+              "node": {
+                "type": "node",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "nodeLabel": "Wecandoo",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,38,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/we…\" alt=\"Wecandoo\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "lhId": "page-4-IMG",
+                "boundingRect": {
+                  "right": 6122,
+                  "top": 1466,
+                  "width": 62,
+                  "height": 32,
+                  "left": 6060,
+                  "bottom": 1498
+                }
+              },
+              "totalBytes": 17962,
+              "wastedBytes": 16948,
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 4229,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 16635,
+                    "reason": "This image file is larger than it needs to be (400x206) for its displayed dimensions (109x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 10523,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "reason": "This image file is larger than it needs to be (192x192) for its displayed dimensions (53x53). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 15421
+                  }
+                ],
+                "type": "subitems"
+              },
+              "node": {
+                "snippet": "\u003cimg src=\"https://www.ocobo.co/android-chrome-192x192.png\" alt=\"Chat\" id=\"open-path\" style=\"width: 32px; height: 32px; object-fit: contain;\"\u003e",
+                "path": "1,HTML,1,BODY,12,DIV,1,BUTTON,0,IMG",
+                "lhId": "page-5-IMG",
+                "boundingRect": {
+                  "bottom": 808,
+                  "left": 359,
+                  "height": 32,
+                  "width": 30,
+                  "top": 776,
+                  "right": 389
+                },
+                "type": "node",
+                "selector": "body \u003e div#ago-wrapper \u003e button#ago-chat-button \u003e img#open-path",
+                "nodeLabel": "Chat"
+              },
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "totalBytes": 16667,
+              "wastedBytes": 16208
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 13185,
+                    "reason": "This image file is larger than it needs to be (1536x497) for its displayed dimensions (173x56). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png",
+              "node": {
+                "lhId": "page-6-IMG",
+                "boundingRect": {
+                  "bottom": 1498,
+                  "left": 6200,
+                  "height": 32,
+                  "width": 99,
+                  "top": 1466,
+                  "right": 6299
+                },
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/co…\" alt=\"Combo\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,39,DIV,0,IMG",
+                "type": "node",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "nodeLabel": "Combo"
+              },
+              "totalBytes": 13354,
+              "wastedBytes": 13185
+            },
+            {
+              "wastedBytes": 9860,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png",
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,33,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"ekodev\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "bottom": 1498,
+                  "left": 5165,
+                  "width": 90,
+                  "height": 32,
+                  "right": 5254,
+                  "top": 1466
+                },
+                "lhId": "page-7-IMG",
+                "nodeLabel": "ekodev",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "type": "node"
+              },
+              "totalBytes": 11321,
+              "subItems": {
+                "items": [
+                  {
+                    "reason": "This image file is larger than it needs to be (400x143) for its displayed dimensions (157x56). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 9586
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "totalBytes": 12266,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "node": {
+                "type": "node",
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "nodeLabel": "Ocobo",
+                "path": "1,HTML,1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "lhId": "page-8-IMG",
+                "boundingRect": {
+                  "top": 37,
+                  "right": 167,
+                  "height": 40,
+                  "width": 134,
+                  "left": 33,
+                  "bottom": 77
+                }
+              },
+              "wastedBytes": 9533,
+              "subItems": {
+                "items": [
+                  {
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size.",
+                    "wastedBytes": 6234
+                  },
+                  {
+                    "reason": "This image file is larger than it needs to be (348x104) for its displayed dimensions (234x70). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 6709
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "totalBytes": 10812,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qobra-white.png",
+              "node": {
+                "nodeLabel": "Qobra",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "type": "node",
+                "boundingRect": {
+                  "right": 5083,
+                  "top": 1466,
+                  "width": 81,
+                  "height": 32,
+                  "left": 5002,
+                  "bottom": 1498
+                },
+                "lhId": "page-9-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qo…\" alt=\"Qobra\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,32,DIV,0,IMG"
+              },
+              "wastedBytes": 9490,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "reason": "This image file is larger than it needs to be (400x158) for its displayed dimensions (142x56). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 9455
+                  }
+                ]
+              }
+            },
+            {
+              "wastedBytes": 8696,
+              "totalBytes": 9486,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vibe-co-white.png",
+              "node": {
+                "lhId": "page-10-IMG",
+                "boundingRect": {
+                  "right": 7529,
+                  "top": 1466,
+                  "width": 99,
+                  "height": 32,
+                  "left": 7430,
+                  "bottom": 1498
+                },
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vi…\" alt=\"Vibe.co\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,46,DIV,0,IMG",
+                "type": "node",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "nodeLabel": "Vibe.co"
+              },
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 8696,
+                    "reason": "This image file is larger than it needs to be (600x194) for its displayed dimensions (173x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 8061,
+                    "reason": "This image file is larger than it needs to be (378x120) for its displayed dimensions (176x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 8658,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/resilience-white.png",
+              "node": {
+                "type": "node",
+                "nodeLabel": "Resilience Care",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "lhId": "page-11-IMG",
+                "boundingRect": {
+                  "bottom": 1498,
+                  "left": 6376,
+                  "width": 101,
+                  "height": 32,
+                  "right": 6477,
+                  "top": 1466
+                },
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/re…\" alt=\"Resilience Care\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,40,DIV,0,IMG"
+              },
+              "totalBytes": 10304
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 7282,
+                    "reason": "This image file is larger than it needs to be (360x120) for its displayed dimensions (168x56). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "wastedBytes": 7742,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/citron-white.png",
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,36,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ci…\" alt=\"Citron\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "lhId": "page-12-IMG",
+                "boundingRect": {
+                  "width": 96,
+                  "height": 32,
+                  "right": 5799,
+                  "top": 1466,
+                  "bottom": 1498,
+                  "left": 5703
+                },
+                "type": "node",
+                "nodeLabel": "Citron",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8"
+              },
+              "totalBytes": 9310
+            },
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qonto-white.png",
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qo…\" alt=\"Qonto\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,44,DIV,0,IMG",
+                "boundingRect": {
+                  "left": 7074,
+                  "bottom": 1498,
+                  "top": 1466,
+                  "right": 7175,
+                  "height": 32,
+                  "width": 101
+                },
+                "lhId": "page-13-IMG",
+                "nodeLabel": "Qonto",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "type": "node"
+              },
+              "totalBytes": 9311,
+              "wastedBytes": 7665,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "reason": "This image file is larger than it needs to be (378x120) for its displayed dimensions (176x56). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 7284
+                  }
+                ]
+              }
+            },
+            {
+              "totalBytes": 9049,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/tomorro-white.png",
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,37,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/to…\" alt=\"Tomorro\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "left": 5878,
+                  "bottom": 1498,
+                  "right": 5974,
+                  "top": 1466,
+                  "width": 96,
+                  "height": 32
+                },
+                "lhId": "page-14-IMG",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "nodeLabel": "Tomorro",
+                "type": "node"
+              },
+              "wastedBytes": 7481,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 7078,
+                    "reason": "This image file is larger than it needs to be (360x120) for its displayed dimensions (168x56). Use responsive images to reduce the image download size."
+                  }
+                ]
+              }
+            },
+            {
+              "totalBytes": 8945,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/steeple-white.png",
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/st…\" alt=\"Steeple\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,41,DIV,0,IMG",
+                "lhId": "page-15-IMG",
+                "boundingRect": {
+                  "top": 1466,
+                  "right": 6657,
+                  "height": 32,
+                  "width": 101,
+                  "left": 6556,
+                  "bottom": 1498
+                },
+                "type": "node",
+                "nodeLabel": "Steeple",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8"
+              },
+              "wastedBytes": 7299,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "reason": "This image file is larger than it needs to be (378x120) for its displayed dimensions (176x56). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 6998
+                  }
+                ]
+              }
+            },
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qare-white.png",
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,34,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qa…\" alt=\"Qare\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "width": 78,
+                  "height": 32,
+                  "right": 5408,
+                  "top": 1466,
+                  "bottom": 1498,
+                  "left": 5330
+                },
+                "lhId": "page-16-IMG",
+                "nodeLabel": "Qare",
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "type": "node"
+              },
+              "totalBytes": 7009,
+              "wastedBytes": 5738,
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 5483,
+                    "reason": "This image file is larger than it needs to be (292x120) for its displayed dimensions (136x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "label": "URL",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "reason"
+              },
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "key": "totalBytes",
+              "label": "Resource Size",
+              "valueType": "bytes"
+            },
+            {
+              "label": "Est Savings",
+              "valueType": "bytes",
+              "subItemsHeading": {
+                "key": "wastedBytes",
+                "valueType": "bytes"
+              },
+              "key": "wastedBytes"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 558946,
+            "type": "debugdata"
+          }
+        }
+      },
+      "first-contentful-paint": {
+        "id": "first-contentful-paint",
+        "title": "First Contentful Paint",
+        "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).",
+        "score": 0.3,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.7 s",
+        "numericValue": 3690.2829870856503,
+        "numericUnit": "millisecond"
+      },
+      "screenshot-thumbnails": {
+        "id": "screenshot-thumbnails",
+        "title": "Screenshot Thumbnails",
+        "description": "This is what the load of your site looked like.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "filmstrip",
+          "scale": 6720,
+          "items": [
+            {
+              "timing": 840,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 4954227788
+            },
+            {
+              "timestamp": 4955067788,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timing": 1680
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAIDAQEBAAAAAAAAAAAAAAMGAgQFAQcI/8QASBAAAQQBAgQDBQMHCQUJAAAAAAECAwQRBRIGEyExFEFRIlNhcZIHMoEVNpGhscHRFiMzQlJyc7LxFzWCwuEkJ0NGYnSDovD/xAAVAQEBAAAAAAAAAAAAAAAAAAAAAf/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AP1SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8c5GtVzlRGomVVeyFei444Vm1DwMXEWkvt52pE20xVVfTv3+AFiAVURMqvT1K6vHHCzb/gl4i0lLedvK8Wzdn079/gBYgEVFRFRcovmcrWeIdL0V7G6ra8Ix+MTSxuSJPnJjan4qB1QUL7a7X/AHSa/Zpz9FrtcyWJ/dFc3qiodZeL+HtGqUK2r65p1O06GP8Am57DWu6tTqqKvQCzgjrWIbUDJ60sc0MibmSRuRzXJ6oqdzi6vxjw3o9tKuq67plSznHKmssa5Pmir0/EDvAiqWYLldlipNHPBImWSRuRzXJ6oqdyUAAAAAAAAAAAAAAAAAYue1vdUMJ3q1MJ3U4eo69pGmTpBqOp0qsyt3IyadrHKnrhV+AFga5ruyop6cTS9X0/VEe7S71a2kaoj1glR+1V7Zwp2In72Z8wMwAAAAHzf7cJ5n6PoekNmfXqaxqsFG3Ixdq8lyqrm58s4wWO3wLwxY0F2kP0Wg2jsViNbC1Fb0xuR2Mo749zc4u4do8VaFPpeptdyZMOa9i4fE9OrXtXyVFKfLwXxnZpLplrjx7tNc3lvezT2NsuZ2VOZu7488ZAoi67qU/2H06Lrsqsk1hNEdfa7Dn1uard+fi1NuT64zgHhVuh/klNC0/wWzZhYW7u2M7u+745yZzcE6JLwSnCq1lTSWxJE1qL7TVRco9F/tbuufUrTeCeNGVPyc3j+X8mo3lo5dPYtnZ2xzc98eeMgcb7QbVngT7FFr8O6xNbWOVtNl5z0c+GNz1RU3J5tT2UXuh9F4f4c0zT+HGadHElivNCjZ3zLzHWMp1c9V+8q5I9O4N0Slwe3hlKjZtJ5axvjm9pZMrlXOX+0q9c+pqu4e1TTNFTR+GL7a1bZy2WLr3WJK7e2GN6Zx5bnLgD4rXnlr/ZF9qGgNlfNp2jXn16b3LnbHzE9jPwx+s+z8E8KaNT4TqRrVrXnW67JLNmZiSOtOc1FVzlXui56J5Ic9PszoV/s1vcJULMkfjUV09yRu98kiuRVe5Omc4wI+DuI9JqeA4X4pjpaajdscNqilh1dPNI3bk6eiOzgCqcP25uEP8AajpWiKrqGjxeMoxfeSB74nPcxPgipnBafss4S0OHgbTbL6dW9a1Gu2zbtTxtkfO+RNzsqqdUyvY7XBfB1PhnR7VRZZL9m9I6a9asIivsvd3V3wx0RCu0uAuIeH2SUuEOLfA6OrnOiqW6TbK18rlUY5VRceiLkCD7PoY9A+0/izhvS02aMyGC9HAi5bXkflHNb6IvfB9QKzwRwjBwvDckfbn1DVL0nOuXp/vzO8kwnRGonRETsWYAAAAAAAAAAAAAAAADXsp7SL8Co8Spqa6g3wKa4sXLTPgUp7M5X33tZ/UXSRiPbhTWdE9F7Z+QFf4WS8kdjx6aoi5Tb4/w2f8Ah5PT9JZayewvzI2QuVevRDZaiNRETsB6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaeo6nU05Y0uS8tX52+yq5x8kNwp32gf0lH5P/cBcUVFRFTsvU0tT1SrpvL8W9WczO3DVXOPl8zbh/omf3UOLxPo8urMr8hzGujcudyr2XH8AO2xyPY1zeyplD04es6vLQngpUayz2HImM5wnwNSvxBdh1KKpqtRsSyqiIrfLK4RfPKAWcFa1biKahq7qja7ZGIiYxncqqnRP04M4dds19Pns6rV5LmuRkbERWq9VTPn+0CxGnqWpVtNYx9t6ta9cJhqr1/Arv8otUjgbbm09vg3KntdU6fP/AKEfGNqO7o9CxDnZI9VTPdOnYC4RvbJG17Fy1yI5F+CkN+5DRrOnsuVsaKiKqJnuVlde1GvQhnioIlJrWt3vXq7yz8De1PVIrPDPjUrslY5URYpOqIuceQHYr3IJ6bbTJESBUVdzunT8SWGVk0TJInI5jky1U80KNrlqWXh6ikdZkVV/tKrM4a7K9P3nV0bVZamhLLfg5cELGNhVO8uc/wDQCzgqScRaokHjF05vgs98rnHz/fg7Mut1o9HbqHVY3dGt81d6AdQxkkZExz5HNYxqZVzlwiFT/lFqqQJbdp7PB5+917fP9+DX4q1J9/S6r4IlSpJhyvXuj0ym0C6QyMmiZJG5HMeiOaqeaGRVaOrXanDizS1WNbC2NsSuzh7V6ZO1p159rRmXHtaj1Yrtqdumf4AdAFe0vXZrmk3rb4o2vrtVWomcL0z1NGDibULUbfCUEke1f5xWtVUT0At4K3e1+wt7wWmVmz2G/fVV6IvmifxJ9F1yS1cfSvQeHttTKJ5KB3QAAAAAAAAAAKd9oH9JR+T/ANxcTQ1TSauprGtpHry87drsd/8AQD2LU6CRMRblfOE/8RDagnisM3wSMkZnG5i5Q4v8lNM/sy/WdTTaEOnV+RWRyR7ld7S56gcHWNUuSa63TKkrKydEWVyIq5VM9MnH1SBa+v0o5Lr7cqPYr3OX7vtdvgW3VNEpalIklhjkkRMbmLhVQgThnTUbGjY3tdGu5HI/qq/FfwA415qO48hReqZav/1Nnj+N606r0zsa9Ud81Tp+xTtv0mq/U233I/xDcYXd07Y7G3ZrxWoHwzsR8bkwrVA5S6vQi0WOdzmSRoxqcpFRVz06Y+BxeLrcd3RqNiFj2RvkdhHphex1WcKaY2TcrZXJnO1X9Df1DSat+CKGdipHF91GLjHTAGjrDUThByInRIGfuOJ/5C/+X/mLfYpQz0VqSI7kq1G9F64T/Q1/yNU/JngMP8Pu3Y3dc5z3ArGo/mPQ/wAT97jPWVSbhChynI/lbOYjVzt6KnX8SzP0mq/TG0HNctdvbK9U65zki0/Q6VGKeONrnsmREeki5yif6gV2KKZ+gtkk1prKixox0fLRdvlt9TW1KokXDEC1p/EQJYVyuRitxlMdl+KfrLAvCmmczdtlxnO3f0/idh1SB1TwqxN8Pt27MdMAcutqtGLh+KV743tZE1ro0VMqqJjGDl8T3Ir/AA5BYgjeyNZkREciIvZfQ6LeFNMSTdtlVM52q/p/E6dvTq1qj4SSNEhTG1G9NuO2AOBqUjJeCI0je1ysii3Ii5x1TuT6Pdrx8JIr5WIrI3tVM9c9emDfoaFSpwTwsa98c6Ij0e7OUT/Ugr8MabDNzEje/HZr3ZRAODw7+bWs/wBxf8qnW4EaiaRIqd1lXP6EOjU0apVp2K0SPSKdMPy7K9sGxptCDTq6w1kcjFdu9pc9QKRpsNhOILkLLng51c5Nzmou7r26/pOhSqsdxJG6XVEsXI16tSJfawnbKdOx3tT0OlqMiSTsVJe29i4VfmZaXo1PTFc6sxeY7or3LlcegHRAAAAAAAAAAAxkeyNivkc1rE6q5y4RDIqHGcsljUqWnterY5Nqr8VV2E/QBZmX6kkbnstQKxn3nI9MJ8zN9usyJsr7ELY3fder0RF+SlT4k0Gtp+lLPUV7HNVGvy7O9FXz/HBqav8AmjpX99f3gXp0sbYua6RiRYzvVUxj1yaGqzOm0qR9C3Cx2U2yq9NqdevXsamp/mev/tmfsQ4sX5hS/wCJ/wAyAWrRVmXTYlszMnl65kY5HIvVfNDQ4s1N1ChitKxtl7kTGU3I3r1x+BJwj+b9X/i/zKczjypF4aO3heduSPOem3qvYDZ4VbYczxE+p+Ja+NFdEr9yxqvr16HXTUqKybEt11f2xzEK/X0unFw2kjrDqqWI2OlkznPwx+JxNRbpKafsoRWJJmYzYwqNX1zkC5cQrYSixadqKtJvTL5Ho1FTC9MqaWr6xJpek1tskM1x7Woq7kXy+9jzQ5GqSOl4J090iqruYiZX4bkT9hHxFViTQ9LtIi850bI1XPltyBctNsstU4ntlZI/Y3ftVFwuPPHY0eJdX/JdVqw8t071wjXL2Tr1wTcP0YKWnxrA1U5rWvdlc5XBxePa0fh4LWF525I858sKoFg0m223Qgk5rJJOW1ZNqouHKnXOOxml+o6blJZhWXONu9M5KnqDG6VwvAtPcx91Gcx2f/TlcehzXN0f8jo1nP8AH7d2/auN3p6YA+iTTRQM3zyMjbnG57kRP1kUt6pDs5tmFm9Mty9EynqU69aktcGQrMqrIyZGKq91xnH6iePQ60nDK25d77SwrIj1cvTCdEx6YAsuqukdpkrqs8cT1aitlc5EanXvkh0iZ0OlMfqFuGR25cypIm1evTr2K3psjn8E32uVVRj8Nz5J7K4MXfmG3/F/5gLit6qj2MWzDuemWpvT2vkbBVOGtCry1Kl+d0j5870TPREToifqQtYAAAAAAAAAAAAAAK5xbpVi2sFukirPD02p3VM5RU+SljAFF12fWLelq69XbXrxqiu8levZOhtyadNqPCFFtZEdLH7aNzjKdULDrdBdS099ZJOXuVF3Yz2Uk0qp4HT4ayv38tMbsYz1ArDma3d0daL6bYmMYiK9Vwr0b2RE/BCWPTLicHyVFgd4lX5RmUzjcilsMJpmQs3SORE/aBz+G68tXRq8Nhiskbuy1fLqprcX07F3TWR1Y1kekiOVEVO2FO21Uc1FTsqZPQKxq2lWrXDdKGJv8/A1qujVe/TCp8zUsR6xd0dtFuntgZG1Nyq7Cvx5IhcgBULWm3ZeE6lRtZ3iI5cuZlO3tde/xQn1vTLVjhujDFEqzwo1XMz1+7hS0ADk8Oy3X09l+vyeWjWM9XIid1IuLqM9/TGtrM3yMejtvmqYVP3nbAFTjo39V0J1S3XSu+ujOQq9N2EVFz+BEyXXo6DKTKO2RqI1Jkx0RP1FxAFb1vT78/D0UDl8TbR6OerURPX5G9HWmThhKysXn+GVmz47exvJaYttYNrt3r5dsmwBUdP0u5FwverSQOSeR+WsynXt/A9XTLn8kG1OQ7xHMzsymcbsltAGhoUMlfSKsUzVZIxmHNXyN8AAAAAAAAAAAAAAAGhbsy17bEVU5LseRvmnqsXMrK5E9pnX+IHmpWXQNYkSpvcvpnoY2rckDY40RHTuRM9DVp7rVyNz+qRtT9Rnf/mdQjlcmWLhQjJ9i5W2unRFYpHqj3SJG9MclUy31z5kupWopa+yN25zlTt5ENyN0dGs1yYVFXPwyBO+azBSRz1ajsoidPLAgntSKyVyI2D+svTy7mN6VklBmxyLhURf0GzExX6Y1je6x9ANZlm3Zc51dGtY31NmhaWdHNkTEje5zqbY1a9JZ3xKi9kXGTb0xsSyvfEsirjCq7AG9NIkMTnu7NQ5rJ7s7XSRI1GJ5YN3UWK+nIje/c1dPtxR1dj3Yc3PT1CsktyuoPkVu2RuOuOi9SOCe5PtcxERiLhy4Q9msrZ0+Zyx7ERUTvnPU2NMT/sLE+f7QiB9ueedY6iJhPNT2C5LHYSG0iZXspBp8jatiVk3sqvTKiy9LeoRpD1RMdfxA2Umd+VFjw3b8uvb1IvFTzzvZA5jEauER3mG/wC+nf8A7+qRyNqzzP8AadA/z3dlUDdpy2Fc9lhnbs5E6Gqy1ZsyOSF0bETsi91MdPkey2sbXrJGiLn0MVZUne9WvdC7PZ3YDfpyzu3tsR4VvZyJ3IOZemc5Y2pG1OyOTBDQllbJK1HLIxrVVDGBzbCPdbsOTH9XOMgbVG3JK2VsmN7EzlCGvat2Ec2PblOquVOxhpmN8+O23oTaJ9yX5oBlRtSvnfDPhXJnqYLasWJ3NqoiNb5qYwJnVpU+Zhpsra00rJl2qvTK/ADaqWZeY+Oy3G3ruROhE2xatPctdGtY31JPFeKdLDEzLVaqI/Jo02xqj0lnfCqL2RcZA6VC0s+5kiIkje+PM2zmackXNkkjWVcJ1VyIb1exHYRVjz075QKlAAAKiKmF7AARwwxw55bEbnvgykY2Ru17Uc30UyAEEdSCN25saZTz7kksTJWbZGo5DMAQJUgRmzlptVc4JmNRjUa1MNToiHoAgkqQSO3PjRXepLHGyNu1jUa30QyAA13U67nK5Y0ypsADBYY1i5asTZ/ZPY2NjYjWJhqeRkAIpq8UyosjEVU8z2GGOFF5bEbkkAEfIj5vN2JzPUxlrQyu3PjRV9SYAYRQxwoqRsRufQwkqwSO3PjRXevYmAGEUUcTcRtRqfAjWnXV+5Ym57k4AibXiY9zmsRHO7qhlFDHCipG1G574MwBG2CNsqyIxEevmYy1oZnbpGIq+pMAMIoo4UxG1GovoYS1YZXbnxorvUmAGEcTI2bGNRG+iCKGOFFSNqNz3wZgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAj58PvY/qQc+H3sf1IBICPnw+9j+pBz4fex/UgEgI+fD72P6kHPh97H9SASAj58PvY/qQc+H3sf1IBICPnw+9j+pBz4fex/UgEgI+fD72P6kHPh97H9SASAj58PvY/qQc+H3sf1IBICPnw+9j+pBz4fex/UgEgI+fD72P6kHPh97H9SASAj58PvY/qQc+H3sf1IBICPnw+9j+pBz4fex/UgEgI+fD72P6kHPh97H9SASAj58PvY/qQc+H3sf1IBICPnw+9j+pBz4fex/UgEgI+fD72P6kHPh97H9SASA8a5HJlqoqeqKegfKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAX/AIV/3FX+bv8AMp1gAP/Z",
+              "timing": 2520,
+              "timestamp": 4955907788
+            },
+            {
+              "timing": 3360,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcBAwgCCf/EAFcQAAEDAwIDBAIMCgUJBQkAAAECAwQABREGEhMhMQcUQVEiYQgVFhgyVHGBkZTR0iNSVVZik6GisdNCcpWjwRckMzZTc3SCskOSs8LhJSc0NTdERcPw/8QAGQEBAQEBAQEAAAAAAAAAAAAAAAECAwQF/8QALhEBAAIBAQUHAwUBAQAAAAAAAAERAgMEEyFRkRIUMVKS0uFBYdEVMnGxwUKh/9oADAMBAAIRAxEAPwD1TSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSuFKCUlSiAkDJJ6Cq81rjSr1w7i1qK0rl52hpMpBJPl16+qgsVKEgDJPLzqunXGlkz+5HUVpEvO3hd7Ruz5devqoLFSgIIBByD41FXnUNrsq0JusruiF4w862oND5XMbR85oJWlULtrlf8Aukv8mG/yMdKkOtL6gqTzBFSx1fp6zRIEa73y3Q5SmW/wb8hKVc0jmQTyoLPSuuNIZlMIfjOtvMuDchxtQUlQ8wR1qFu+sdN2eWIt1vtsiSc44T0lCVD5QTy+egnqV1RJLEyOiREebfYcGUONqCkqHmCOtdtApSlApSlApSlApSlApSlApSlAr5UtKepFfD6ykYHU1B3G/Wi2Phi43OFFeKdwQ8+lCiPPBPqoLAlSVdCDXNQlru9vugWq1zo0sNkBZYdC9pPTODUw0vejPjQfdKUoFKUoNb9uD7y7PY7Ql5ceJeLqxBluIO08FRJUnPhnGKscvQumJFhVaF2WAmDsKAlLKQU8sbgrGQr19azNXadg6qsT9ruaVcFzCkrQcLaWOaVpPgQap7ui9ZyYRtkrXi1W1SeGtaLehMlSOhHE3dceOM0FEN9uT/YfDgqmulDl4FkVPSrClxuKU78+tI25rbiNA6VTY/akWK39y2bMFlO7pjO7ru9ec19vaJsjuiRpUxiLSloNJSD6SSDkLB/G3c8+dVpOidaIie1ydfu+1oTwwo29Bk7OmOLnrjxxmghu0GVJ0J2KGPp28PSy26mGicpYUtltSyCNw8Uj0QeorYun9OWy36cRbm2hIjvMhL63jxFSMjmpZPwic1127RtkhaPTpkREvWnhltbb3pFzJyVKP4xPPPnWKrT10tllFn0xPTGjbOGiRNWqQ5HT0whPLOPDco4oNKx33Y/ZF2oWBLq3rdZpy48Najna3xB6GfVj9tbn0TpSzQ9JxGzFjTlS46HJMl5AcVKUpIJUonqDnkPAVHjszgR+zWdpKBJcb76Cp+Y4netxwqBK1DlnOMUb0dqO0xO4aX1S3CtoTtbZlQRIVHHiG1bhy8grOKCqaflvaQ/yo2qyEqgWdrvkFr4QYWtpS1IHqBGcVaeyzSVjZ0NbZK4cWdKuMdMmXKfbS4t9bg3KySOYyelTWi9HQ9M2eVELrk+TOcU9OlSACuStXUq9WOQFV2FoLUOn0OQtIat7jZypSmokuEmSY+TkhCiQceQOaDo7PmW7B2n6s03axssyGWJzbAOUx3F5Ckp8geuK2hVZ0RpFjS7Mxxct+4XSc5xpk5/4byvAYHIJA5ADpVmoFKUoFKUoFKUoFKUoFKUoFKUoMeSPSB9VVHUouZuCe4i+FrhjPcRD2Zyf9t6Wf2VdHEBacGsZTSwemfkoK/pYTg3I7+LoDkbe/wDds/8ALweX01ZYw9A/LXWhlRPPkKyUgJAA6UHNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKV8POoYZcdeWENNpKlKUcBIHMk0H3SqvB7QdIz5jESFqK2PyX1htppD4KlqJwAB51aKBSqxe9f6UsdxMC7X6DGmDG5pbnNP9bHT56sUSSxMjNSYjrb0d1IW242oKSpJ6EEdRQdtKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFeR/ZC6u1Hae1K4xLXfrrCioaZKWY8txtAJbSTgA46164rxZ7Jn/6vXT/csf8AhJoPS3ZZPmTux61TZsp+RMXDcWp91wqWogq5lR555Vpn2MWqb/eu0GZGvF7uc+Om2uOBqTKW4kKDjYBwokZwTz9dXD2P/aFZLpp+z6KSxN9sWorgcUpCQ0QCScKCs9D5VZZnZ1pzQ+nNSXbSduci3T2qktocEh1w/A3YAUojqlP0UR3XPtq0Rb76LU7c1OPBzhOPNNFTLas49JfTA8xmo+89vWjrTdZdvfFycdjOqaUtllKkKIOMpO7mPXXlTQbOmZF9KNay50W2cJRDkRO5XEyMA8jyxnoDzxUPd0w03SWm1recgB1QjreAC1N59EqA8cYoPXs32QWjYcx6M83duI0soVtjpIyP+ape3dsOmrjrRrTcPvTkpwlIfCE8IEI3EE7s8sEHl1FeM9T/AOsVy/4hf8a9J6i7JtOad7OZ+orM1NRdWrYp1KzIJAK28LOPkUqgsl89kBou2TnIrK508tq2qdjMgtk+oqIz8o5VnWvtW0trWy3aHapTrU/uTyhGkt7FqAQclPUH5jmvKfZy3o9y6yBrt6e1B4J4JiDP4TP9LAJ6dPX1qb0mnR7eo0Lts3Ufet6xFSY7QSQQQAshWcY6kDpmgrvZpKZhdoWnJUtxLUdmey444o4CUhYJJ+avTulO3/Tt91Im1PxJMBDzvCjyXVBSFknCd3inPLz6868w9mkVid2habizGUPxnrgwhxpxOUrSVjII8RTtHjswO0PUceG2hhhi4voaQ2NqUAOHAAHQCg2z2rw+y5HaDdk3d7Uka5cbfKRDQ2ppS1AKJSVcxnNRHa7rRVqf09adB3W82y2RLWyrhokLa3BxIdQTtVzVtWM+vNUvtfdW/wBodzddUVOOIjqUT4ksNk1YO26KwzbOz99phtt1/T0VTriUAFwhCQCo+JAAHPwxQbb9jv2jR5Gkboxqe7ynJcBapT0uc6VpS0ralIC1EnOQeXr9dTz/ALILQrUsspkT3UA44yIp2H18yD+yvNEi4W1HZHDgxlRk3Zy6uOSQlIDqmQ2Nm44yU7irAz1rHsls09J0pMlXGe3HuaFkISZCtxHLG1oNHd8vET81B7asestP3ywvXm23SO7bmAVPOk7eFgZO8HBTy8615P8AZEaLjSlNMJucpCTjitMAJPrG5QP7K0BCagQOz3UwsWoZM1chuOJcQwlMpSkPJworKiDzOMev1VgaAb0K5Aup1u/dGpQSO5iGMg8jnwPPOOuBQeq4fa5pa86Uu90tsx4qgRy69HLe19APIEAnB5kcwa8s6X7SdSQtTWmVddSX1+3MS2nJLRmOL3tBYKk7SrByARg9atvYnE0lI1WY8V28ypT0OQhceVFa7u4jhkkL9InGQCOXUCtY6KXCa1lYl3YM+1yJ7Bk8ZIUjhBxO/cD1GM5FB63vXbvpGzzUxZbd0LqmGXxsjpI2utpcT/S67VjPrqS1J2v6b09abHcZ6LgY94YMiNw2QpQSNvwhuGD6Q868sdt8u3zu0u6SbItldsW3HEdTAw3sSw2kBI8AMY+aprtgmxpOhezRqO+064zalBxKFAlB/BjB8uaT9FBvVz2QGjkQGZim7rwXnVtJ/wA3TnKAgn+l+mn9tJPb/o9m0MT0JuLgefWyGQ0kODalJKiN2An0wBz5nPlXkyV/qlbP+Nlf9Eet09gPZbprW2jJVyvrUpcpucthJafKBtCGyOQ9ajQbl1J2v6Q08zGM+etUl9pDwistlx1CVJChuA5JOCORNdOle2jRmpJ7UGNPciy3SEtty2i3vJ6AK5pz6s14+cjML1q9FvC1NRxMW08pbhQUAKIwVbVEYxjO048qmJ1m0k3qBbKNSKhw07Slxhlc0JPjhe1sn/u0HvClYNiXxLHb1l9ckqjtnjLQUKc9EekUnoT1x4VnUUpSlApSlArTHaX2Go1vq6VfFX9UIvobRwRE4mNqQn4W8eXlW56UGnOzHsRRoXVbV6TflTihpbfBMTh53DGc7z/CtxOIS4hSFpCkKGCCMgjyrmlBo66+xx07LvomRLhLiQVOb3ISUhQxnmlK85SPlzUbevY1Qpt2lyYWoDBiuuqW1GTC3BpJPJIPEGcedeg6wr49Nj2ac9aY6JNwbZWqOytW1LjgB2pJ9ZoNDXP2NbU64yZXupWjjOFe3uAOMnpniVvpm3tC0It0hKX2AwI6wtPJxO3acjyI8K0DovWXa9N1pCi3ayui3uPhMlLsHhIabz6RC/UM45nPrrf15uDVptE64yMliIwuQ5jrtQkqP7BQaQvvsarJLmLetF5l29pSieCtoPpT6knKTj5c1P6J7C7FpdciT3uROuTjDjLb7yQEs70lJUlA8cE9Sa0rc/ZB61lXFx2C7DiRiolthMdK8J8ASeZPr5V6q0Nc5F50dZblN296lxG3ndgwNykgnA8KI1DpT2O7dg1Na7uNSrfMGS3I4RghO/aoHGeIcZx1xXGqvY7t3/Ut0u51MtgzpLkjhdxCtm9ROM8QZxnrit91r/tlvGr7Np9h7Q9u75JU4UvrS3xVtJxyKUeOT488eXkVRtV+x5b1BfX7kdSrjl1LaeGIW7GxtKOvEHXbn56uWqeyWz6m0dZLJcn3RJtEVuNHnNJCV4ShKTlJyMHaDj9tVns313rWNYr/AHbtFtUhFst7Aebd7sGXlqzzSlJIBGOeeXy1NaH7bdPax1NFsdtg3VmVJCyhb7bYQNqCo5IWT0SfCiK9pn2OdltsiUq73R+5sPMqaDXBDOwnBCgdxORjlUa/7GO3KlFTGpJaI+eTa4qVKx/W3Afsr0NWmIHsiNLTbnHgtW29h195LKSppraCpWAT+E6c6KtWleynTGntLz7G3FVLYuCdst2Qcrex05jGMdRjoefWtdXH2MtqdlFdv1DMjME54bsdLpH/ADAp/hXoKlBr3sy7J7HoFb8mGt+ZcHkcNciRjknqUpSOQB5eZ5VS9Uexxst0uj0u0XWRa23VFao/BDyEk9dvpAgernW9qUGj797HizXK2W1mNdpUWZDYDCpBaSsPAEkFSMjB545HoBWLdfY32mTarZFt94ciPxgsyJCo3EVJUrbzxvG0DHIc+v03/thu+rLPppt/RFuE2Yp3a8QjiLaRj4SUf0uePPHl5V3sP1F2gXuXPRre2rYgttgsvuxuAsuZHogcsjGTnHLHroisO+xtbctMaD7qFgMvOvb+4DnvS2MY4nhw/wBtbQ7JtCp7PtNv2lNwM8OylSeKWeFjKUJ243H8Trnxq6UorUfaJ2F2LV92dukaU/ap753PKaQFtuK/GKTjB+QiovSfsdLBabizLu9xkXbhKC0slsNNqI/GGSSPVmt4UoAAAAAwBSlKBSlKBSlKBXnr2Rfard9O3lrTumn+6OpZS9JkpSCv0uiE56cuZPXmOleha81eyY7N7vcb8jU1iiPTmnGUtymmU7ltqSMBQSOZBGOnTHroNc3LXPaJD0hDFxm3uPHlyO8xbip1xtTidpBQFf0k9FAfL51zA1zqtfZ5e5StSXgyW7lCbQ6Zjm5KVNySpIOeQJSnI/RHlUJqK76qumjLdFva3faa1OpiRkONBBCthwM4BOEpxz6ZFSWhtOT9SdmmsGrUw5JkxJcGVwW07lrSEyEkAeJwvOPVRF07INW6iuOle0N6ffbnJdiWdbsdbspayyvav0kknkeQ5iqt2c641VM1SlmXqS8Ptdzmr2OTHFDcmK6pJwT1BAI9YFY3Z23qmDatYxLXaFKjybY4ic5IbUngtpSonHmo8wB5/JUd2YwZaNXIUuK+kdxnDJbI/wDtHqCf7Ktb6pn9o+nYs3Ud3kRnpjaHGnZjikrST0IJwRXp3tqhzZ3ZZqNq2ye7PpiqdUvcU5bQQpxOR+MhKk46HODyryR2PwZbfafplbkV9KRObJKmyAOdezO0ZKl9n2p0oBUo2uSAAMknhKoPDWgLdc7vrC2QLFN7hc33CliTxFI4Z2k53J5jkD0raPav2mast94j6Utd0fZXbGGYsmRHUS7KkBCd6t5G74WQOhPU9aqXYZClN9rGm1uRn0IEg5UpsgD0FVZPZAaDvtr19Ov1vhyn7dNcEhEiOgqLTmBkKxzScjIProIjWWu+0aDAs9vvkm82mVHQspe4jjC5SDtwV4xuKcEZ68+frklaz1N/kMRcfdBde/8AujMfvHe18Th92Ctm7OdueePOqnriLrW4wbNddWKnShLbWIgeBK0tp25O0DkDuHrOM+VSqoUr3vyG+7P8T3TlW3hnOO6jnjyoM3Tl01Rqvsx1z3rUE+QmCIr6xKlOLy1+GC0Dr19Hl0O31VVOye2XS76/tUOwzu4XBalqQ/xFI2pSgqUMp580gj562L2BaenXnRvaNammlNSZkNhtnipKQVfhcDJ9ePprXVlZ1boTVjMqJbJkW8RitCEuRSvO5JScDGFcieYoPc2pokyfpy6Q7ZI7rPfiutR39xTwnFJISrI5jBIORzr8+LWxIfvUSPGe4UpyQhtt3cRtWVABWRz5HnX6G2V19+zQXpgKZLjDanQU7SFlIJ5eHPPKvDGq9Haj0TqlYft8nMeRxY8lLRW24ArKVAgY8uVBsrtZ7TNV6XchaPg3Iom2+Gy3PnoJW7IeKASQpQyBzHPqc1S1a57TNKTIz1wul4aW6N6Gp5LiVj+qvP8AhTWuldZ3+HH1rcLdJlLuKcyODGKVNKQdgKkAZCSlKSDjFYtvuWu7vOiMWODKYkNDYlNugJjgnlzWUJAJ5dVdKCf7U+0/UVzmWG4Wy6XK0plWtC3o0WSttAdDrqFEAHx2/RisW/6u1/8A5OtNT37tLZti3Xm2pSJau8SHAtWStWc4A9EDP9H5K6u26zagiXqxM35x+4XRNpbMh5Kd3pF107cgYOAQPmqT1bEkq9jvoZtMd4uJnSipAQcj8I51FBw52m6on9kL3EvM1u4wbuw0JjTpbdW04y8dilJwTzbzz9XlVbja91crStxeOpr0XUTYyErM1zISUPkgHPQ7U/QKxIEGWOzK9IMV/cbtBIHDOSODK+0VHxYEz3IXNPdJGTOikDhn/ZyPVQW7SN/7S9U2q726xTbxc1FTKnne+KK2UjfgJKlctx64/Fr1L2QxbzC7PrXH1N3n22QFh7vDm9fw1YycnPLHjWnPYgRn2JeqeOy41uRGxvSU55u+delKBSlKKUpSgUpSgUpSgUpVXv2rkWe4riOwnFkAKCwsAKB+agp/sitG3vWmnLXE09GRIfYll1xKnUt4TsIzlRHiajvY36D1BolGoRqOIiMZhj8Ha8hzds4m74JOPhCthXDV8eHbYEsR1Od7SVBAUAU465+evqJq6I5alz5TS47YXw0JzuU4cZOBVoWWlUpHaBDLuFQ3w3n4QUCfo/8AWvjXN5jy9PRu6K4iJK8hYONu3GQR89KF4pWotH3cWm5OOuNqdC2inAVjHQ/4VaY2vorr6UOxHGkHqsrBxy8sUoXSlVa06xjTGZb0loxmo4ByVbirOcADHXlWGvtAiBwhEJ9SPxioA/RShdaVG2O9RLywpyIpQUjktCxhSakqgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVRO0+DluJOSPgktL+Q8x/j9NXusO7W9i6QXIkndw145pOCMHPKkDSrj7jzTDSjlDQKUDyyc/wATVg1fb3LdBs7CgQhLJz5cQnKv4j6KtsbQ9rYkNPByUstqCgla0kHB8fRqfuVvjXKMWJjQcbPMZ6g+YPhWrRqaU5ZjYWUR2XhdARvWScevxxWTDQ77iJ6lA8HvLe35fH/CrgnQtpS7uJkqH4hcGP4Z/bVgFviCAYQYQIpTt4eOWKWNTacnsQPbHvBUOPEWyjAz6RxiunTTDUm+wmX0BbS3MKSehFX9ehbSpZUFSUg/0Q4MD9ma7bdo23QJrMpl2UXGlbkhSkkfPypYhtfWmLb7SyuBGSylTwDhTnnyOM/tqpw1W8W54SR/nOfRwhRV8x3AD5wa3LKjsy462JLaXGljCkqHI1Wl6FtKnNwVJSPxQ4MftGaRIjOzkQu+yDEEvihrCy4U7Oox055/9avtYdqtkS1x+DCaDaSck9So+s1mVJUpSlQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUrXHaLdZBufcGnFIYbQCpKTjcTz5/NirEWNjBaVHAUCfUa5rUDtgvEJMd9KFAuc0FtzmPHzrnUz09SbeLkFokJZKSSrmobjg8v8A+5UpG3VKSn4RA+Wua1LbLHdrzbGlx1tmM2tQSFLxz5ZP8K5vV0uNyuftey4sISsMIaQrAURy5+fOlDbNUe+xtVLurqoTi+7FX4LhrSkAeGQfGqsXbvpq4JQtxbTmAvYV7krHr8PA11aklGTeZD6FKCXQhYGemUA1YgbdtwkIgMCcpKpIQOIodCayEqSr4KgfkNan1RIn93tzbinUwu6MlvBO1R2DJPrzUdbYUmQA5DlsoezyQXti/mzj+NShuonAya4SpKvgqB+Q1qjVzt1Q5GZnKeS0llAAJOFK2jcSfE5zUfbYUqQEuQpbSX88m+PsX82cUotuilap1XdZ65TUBbriAy0hK0hXNSykEk+fM1h31m7QY0ONc9yUJCiz6YJwcZGQfUKUW3FQkAZPIVplS1+5pB3Kz3tXj+gK+7eia7Ybo4zI2R2i2XU88rySAM+XOlFtxg5GRXBUkHBUAfWa03Zr7MtbUlDDqsON7UgnISrI9IevGaW613K9iQ/HJdLfNalucyfnpRbctK1ppuVeLQxKdebdXDSypQC1AhKgOR6568uXnUCp+4XiStT0rcsel+FdCAPUMnHzClFt00rWmjZV4jXRlpTcp2EtWxYUkqSn9IHwrZdJhSlKVApSlApSlApSlApSlAqja503LnTROgIDpKAlxvODy8Rn1VeaUGnU2G+SVIaVDlEJ5J4nJKR6s8qzr5pmfFbgssR3ZCg0S4ppJUAoqPL6MVtSlW0pXdBRX4lh4UplbLnFUdq04OOVVjUul7ixdXZlsbW62tfESWz6aFE56fL5VsmlLVqmPp2+XiaFzkPIzgKekHmB6geZr51FYZ/txIESDIcYTtShSWyQQEgf4VtilLSmuJ0DUUfguQUPlhUdkFsEKAIbSCCg+OR5VDCwXqfKKlQXELWealIDaR/AfRW4KUsprm6WzUcKR/minX2OGhJ2kLSSEAH0T6x5VDI09ep8oqVBcQtRyVLQG0j5uQ+itv0pZTW2qNKXDityIyTKJbQl3b8LcEgE48QcVFzNO3nusZ51iQ8tzcOHgqU2kYxnyzk8vVW3aUspqZVmuXufQ13GTxRKUrbwznGwDNZ1ntU9rTF8Zchvpdd4WxBQcqwrngVsulLGo7Tpi4S5DjL8V6OC2SlxxBCQodAa6l2C+RFrbTEkjdyUWuYUPlFbhpSymutM6QlLL7lySWEKaU2hOQVZUMZx6qi1WK/2iWvujT+SCniR+YUPm/xrbNKWNeaS09dRcm5c5T0dlCt5SpZ3OH1jy881gmz6i9v9+1/jcTPeN3oYz1z5eqto0palKUqBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlU7UVylWu5TobT6+Lc2Ue1+45CHtwbXj1Dc2vH9Y0FxpVTjXie2GniqMuCmb7X8FQUZBIc4e8r3YJyN2Nvweea6bbd5r/Dh20RIuxp2Qtcre4FAPLRtB3A/0ckknGRyq0lrlSoTT00TJFwc2Iz+BUVNulxKtzSVejnljn4AZ61Ep1JcGrKm7yPa9Ud+KuQ1GBUh1GE7gkkkhWP6RAGPXSi1xpVSm3y624SWHu4ypQZbeaW0hTaBucCNqgVKPjkHPPB5cq6pt7vsFN4W97XLbtaUvLKW1gvIKdxSBu9AgA8/Szy5ClFrlSqg5er0pxDjCLeI7lwXBSlaV7gAVAOE5wfg/Bxz8xXQ5qS8mYLYxHjuT0OvJceQ3lBSgNkYQpxJyQ6P6Rxg9aUWu1KqCL7eJjTPdGoLDvclSnOLl1O5KinakoVjBxnOTjyNNMXC5XHUM11yWx3FceM+iMWlbkBaFEYO/GfM7eePClFrfSqrJvdzRcJ6m0xBBhzmIikqQouOBwNZIVuwCC55HOMcutdUXUVwWiBLcTEMWe64y1HQhXFaKUrIKjuwr4GCABjPU4pRa30qpL1JNVDtaorEd6TLtpmFoK25XlkADJ6fhFcieeAM1J2K4yblAmBa20TWXC0d0dbYQraCNyFHPiOisEeNKLTVKo9jud89p9PNmTBkvzuSnltLBbSlsqOfTO5WRjqOtd7OppiriUER3IrqJBZUhpaebfT0lH0xy54SAD4mlFrjSqam/wB6bbZS7HiPyJUNEtlDKSnZ6aErSdyvTICwRgpzjFR896VqCbYW3HIK0ImvNvMvwnMb0tKV6SFLGDg8uvMg58KUW2FSqsxfJ6nWZKu6GC7OXCTHShXGSQtSN27dg805I2jAzz5V0xb1e5LFrUE29py4vOIRlC1BpCULOT6Q3E7Ry5Yz40otb6VSW9T3ViBHuE1iK5HW5IYUwwlXE3spdO4KJxhRaPo45bhzOK+puo7pboLz0juElxduenscBKkpQUBPoqyo7gd49IY6HlSi10pVSk3q8xZEmGWYsiUgMuJUy2RtQ5xM+gV5WU8PwIyD05c+y5XJyboObMS5h7hLSVNoU0QpKik+ir0kkEHl/GlFrTSqqrUMoahZjJ4DkJyUYmUtLBSoIUo/hCQCcpwUhJx51aqilKUoFKUoFdL8SO+8w6+w046woraWtIJbJBBKT4HBI5edd1R06926DLRGly22nlAHac+iCcAqPROTyGcZoO4WyCJxmiHHEs/9twxv6Y+F16cq+JNntkpptqTb4jzTZKkIWylQSSckgEcsnrXS5qC1NmSFTWsxiEvAZOxROAn+sTyx1oi9RXxDciPR3GX3VNKUtwoUkpSpRASRncNvMHGBk+GKqcEg0wyypammkIUvG4pSBuwMDPzDFYzNptzEl2QzAitvughxxLSQpYPXJxzzWO3qG0usOvInsFtrbuVn8bknHnk8hjr4Vw7qK0tRmn1zW+E7u2lIKj6PwiQBkAeOenjTicGTHtNujMrajwYrTSyFKQhpICiDkEgDwNdzsOM6l9LsdpYkJ2vBSAeIMYwrzGPOsKTqC1RpCGH5rSXFBCgOZwlXJKiRyAPmeVfYvdtNx7gJbfet2zZzxuxnbnpuxzxnNOKsoQ4wCQI7QCXC6BsHJZySr5eZ5+uuiXaLbMQtEuBFfStfFUHGkqBXjG45HXAAz5V8W+9224SVx4Utt11IKsDPpAHBKT0UAeWRmky922FNRElS2231bfROcJ3HCdx6JyemcZonBlIhxmwkNx2khLfCGEAYR+L8nqr5bt8Np5p5uKwh1psNNrS2ApCB0SD4D1Vje3ts9se497b71v4ZRz5LxnaT0BxzA8a+rperfa1ITPlIZUsFQBBJCR1UcDkkeZ5VBkmHGVxcx2jxVpdXlA9NYxhR8yNqefqHlXWzbYLMtcpmHHRJXnc6lsBas9cnrXwq7QEvFpUlviBSEbfElfwceeefMcuR8jXTG1DapMwRWJzS31KUgAZwVJzuTnpuGDy68qDtRZbW3v2W6GnekpVhlI3AkEg8uhIH0VkQ4caE0W4cdphsncUtoCQT58qjYepLbLfloakI4cdBcLhPJaB8JSfNI6ZHjX2zfYTxU63JjGCllTpfLuOSVYJxjG39LNXicGYxboTCwtiJHbUFlwFDYB3EYKuXiR411Cz2wLKxb4gUVFeQynO45yenXmfpNdLeorSuG5K762lhpaW1lYKChSiAkEEAjORjzodRWoQ0yjLTwlLLQG1W8rHVOzG7IHPGOnOnE4Mt62wnkJS9EjuJS3wgFNggIyDt+TKRy9Qoxb4cdLQYiMNhlRU2ENgbCQQSPIkE/TWHJ1HaI7bDjs9nhvI4iFJJUNn4xI6J9ZwKzZs+LBjB+W+htokBKifhE9APM+oVFfKbZBRNMxMOOJZ6vBsbzyx8Lr0rsRDjIDIRHaSGCS1hAGzIIO3y5E/TWCb5DA45kxhA4BfLxd5gBWD6OOg8TnkeWK6hqmy/lBoEK2qBCgU9OauXIcxzPLn1q8USSYUVCW0pjspS2tTqAED0VqzlQ8idysn1nzrpas9tZafbat8RDb6drqUspAcHkoY5jma6V6gtSJ3c1TWhI4gaKeforPRJPQE+APXwrGY1PBEBEmetMUreeaS3zWohtxSCrAGccsk4wM9acTgk5NuhSisyYjDxWEhRW2FZCclPXy3HHymvoQooh90EZkRcbeCEDZjyx0rtbebdYS+0tK2lJC0rQchQIyCMdaqFs1c7Nlsna0mI7Mdjc2nELQlCXjuJUACTwgeXTJB50FlXabct9Ty4MVTylBallpO4qHQ5x15DnWbUbLu8ZqKlxh1ha3Ge8NBxZQlSMpG7dg4HpJ8PGsW7amgQHFsB5DstDjbZaBIwVqSMbsY3YVnb1xQTlKjmL3bX7iqC1LbVKBKdgzgqHVIPQkeIByKkailKUoFV+bZ54nz3bbJittXDZxuO0XFIKUhOUjODlIHI8gefPOKsFKCuuaecEYcB5pMpu4LntqUjKSSVDCgOvoqIz4HB8K6hpyQ5LbmSJDCpCpapTyUtnZzjlkJAJ58sEk9efSrPSraUqLGmJSI7zSnI5ZKWg3GK3VNpKFZ3JJVls9MBPTHjXPubuKmGmnLiVt4eCkKcc9DeQU4VncvaARhR559VW3IpSylRRpWQbLcYbkhnjSra1BC0pOElCVjd+8DWYxZZ7Dq47cmN7WrkuSVbmiXvTUVlIJOB6Sj6WM45eurFSllKrpvTUi1yoZkPR3GITJZZKd5WroATuUQnkOiepPh0r5u2mJEq5znWHmBHnqQp4O7yU7UhB2pCglWUpHUcjnr0q2UpclK89p9a0SQl5CS7cmZ+dvQILZKflIQR89dd/sEmZdFToLzKXHI4jLS8XAAApRSobFDPw1ZB68uY8bLWFKtcOU8XX2d7h5E7iP4GuWrlqRF6URM/ea/yf6axjGf3IUaacRd7fPbfZC7e2iOwjh8i1jC8/pHwx0x+kaj7NYrhJtzMaapliCic/J28NSXj+FWUjyHM53eI5eurL7RW74v++r7ae0Vu+L/vq+2uG82zyY+qfY32dLnPT5VyFpCU1EVFekRi21CchsLSFlR3J2hStyiE8hzCev0CpG86a9sWlNB5LKO6Jjo2g+ipK0rSeRHLKRy5cqkvaK3fF/31fbT2it3xf99X203u2eTH1T7Ds6XOenyhG9MyXEuLluxkvLkRnMNhagEMuBeCpZJJPP1D6a73bBLavT91gvx+8qfWtKHkko2LaaQoHHMHLIOfIkeNSntFbvi/76vtp7RW74v++r7am82zyY+qfYdnS5z0+UBM0xcHHTIRLiLkvxww+VIW2gEKWoKSlChn/SKGFZzgc+uZm6WjvFriRGUsq7spBTxNyfgpI9FSSCg8+o9Y8a7vaK3fF/31fbT2it3xf99X203m2eTH1T7Ds6XOenyhHNLynoKmZE0OrVFcjlTmVfCdCwMk5IAG3J5nGTWbc7AqYq/qS62k3KEiKnKfgFIcGT5j0x9FZ3tFbvi/76vtp7RW74v++r7abzbPJj6p9h2dLnPT5V6NZbjJVdI6lMNQZFw4y1LbUHSlOw+j4HO0YV4c+vLHK9JymlsvxJDCpCO8IUHS4lJS48XAQUKByM4x0Pqqwe0Vu+L/AL6vtp7RW74v++r7au82zyY+qfYdnS5z0+XzZIci3MtQiWFQ2I7aEKQkpUpYzv5dAn4OB6zWAdOrU1CbW+naxMkyVYHwkuh0YHrHFH0VI+0Vu+L/AL6vtp7RW74v++r7am82vyY+qfYdnT5z0+UCdMT3ozDMiXG2sQDBRsQfS9Js7zk+TfTw8zXbL05NcblxGZMYQn5yJ2VtkuAhxK1J8uqeR8Byx41M+0Vu+L/vq+2ntFbvi/76vtpvNs8mPqn2HZ0uc9PlCWvSz8K4RsvsLgxn3JDed5cJVuwCCraMbz6QGTjwyattRzdlt7a0rQxhSTkHerr9NSNd9LLVyid7ER/E3/kM5RjH7ZKUpXVkqj6m1BcYd3ntMSGYrcNttbaHdmJBUM88ndjPojYM5B68hV4qMmF9UoKFqbkcM5bdU4kEfJkZFc9TWx0Y7WUTP8RM/wBRKxhOXCENZXHU6zvDMm7LKlcNxuEvhjKCgc0jG7APLI+esGfqCe1Mvq0XKMg26U20zBLY3PhSEHaTnOVFRCcePXPSrN3q4bt3tUN3TPHT9lYMWK/HlyZIs4W8+9xypb6CUK2JT6JxyGECuHf9Lll6M/a3ucucdY/Kv+2DseQZsaMzx47F2UhptGAtSH0AZA6k45+ZzXN9nznbHeo0a9CaBbVyu9RkIBaP4nLIwoZI8RtPM1a0vzUqBTaEAjPMPp8Tk+HjXDTsxlKg1Zm0BRyQl5Ayfop3/S5ZejP2pucucdY/Kr37UciBAcdtt3TPEWIZZcShkpd9JQAUoEAj0SMIGeXM9K6XrpJhTtUy4VxjoUxKbdbiFAUZJLDWE56+lyCdvj59Ktqly1lJXZWlFIISS8g4B6gcq4BkhSVCyMhSeaTxUZHLHLl5AfRTv+l5cvRn7Tc5c46x+VYVdJkRLUaM8IiJM2ctb52ZBS7yQN525OSfHkk/KLTpu6e2FtiGS/HVMcaLhS0r4aQogLA8j8459TXDqpTrZbdsrS2ydxSp1BBPnjFZMJchb+X7eiOAjaHA4lRx5cvCtYbZp5zGMRlc88co/wDZiidLLGLmY6x+WfSlK9LBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlQbWq7M7qx7TSJmb001x1x+GvkjAOd2NvRQ8aCcpWFFu9tlzHYkS4RH5TX+kZbeSpaPlSDkVVT2q6MTenLSu8pRObkmItC47qUpdCinaVlO3qD445UF3pUcb7aBIkMG6QA/HSVvNmQjc2kdSoZyAPM1gztZ6ZgxDJk362JZDfGBElCipGcbgAckZ5cvGgn6VU9PdouktQiSbVfIrgjILr3Ey1sQOqjvA5dOfSpti+2mQ064xdILrbSUrcWiQhQQlQyCSDyBBBBoJGlYEa82yXBemxbjDehsglx9t9Km0ADJKlA4GBz51Gz9a6bg2uRcXb1BciMNh1xbDoeIQVbN21GSRuOMgUFhpUb7f2kKiJXcojbktCVsNuupQtwKGRhJIJz8lcKv9nRJejKusASGUqW413hG9CUglRKc5AABJ+Sgk6VX9O6z0/qKySLxark05bI7hadkOpUylCgATneBjkoc+nOs9i+WmQy87HukF1plAcdWiQhQQkjIUog8gRzyaCRpUWxqKyP8fgXi3O8BIW7skoVw0noVYPIHzNfaL7aHLa5cUXSAq3tnC5IkILSTyGCvOB1Hj4igkaVD+6nT+HT7eWrDTaXnD3tv0EK27VHnyB3Jweh3DzFZdvutuuRWLdPiSygJUrgPJcwFDKScHoRzFBm0qNVfrQkygq6wAYozIzIR+BHmvn6Pz1hyNY6cYiSpKr5bltRWDJe4UhLiktDHpbUkkjmMYHPIx1FBPUqjN9qelXn7Y1FmOyPbGO9JjqQwoBSGt4Vndgg5bWBkc8Vm2HtB09eNJ+6NMvudpDpZLswBvCgcY6nxNBbKVgzbxbIMVqTOuESNHexw3XnkoSvIyMEnBrEVqizJvYtKp7YnGJ3/AG4O3gbtu/fjbjI86CZpUc1fbQ7BcmtXSAuG2dq30yEFtJ8irOBUTN17peHcLVBcvMVyTdHA1ESwS8HFFQSOaAQOZAySB18jQWelVl3W1pa1ynSay+LoqOZOSgcMIwTzVnyB8KlIV/s86UmLBu1vkyVJK0tMyULWUjqQAc49dBJUpSgUpSgVq2f2e3xXbIrWFvucRiC80iO+wpBLimwhKVAcsAkpHOtpVrnWnanF0xqluyLs1wluqSgl5soQglXRKdxG5XqHOggOzLsfmaP1e3dJFxhSY0dDqGi2wUvO7883FE+APh5CoZfYjeU6wuV+YulsK5F178008yXEhsrWogggjeNycH5auD/a5D908u0RbNcnmo8tUBc5CQWkvjqCM5wD41WdM9uKvcZAuN8ty5d0mzH47LEJIQkpbShRJKleSx8tEd2kOxN+yauVOmXCFMto7x1YPeHQ6kpKVqzjkCefy1DWz2PMhFmvUS43hlyQ82hq3uoSohlCXCshQOOpx09dWC6dvlrgLYCrFc1ByGJh3FKFIBUUkEH1jr48qkrp20W2K7CRBst0uBfgtXB3gJTllpzATkE8zzHIedBSovYrebLZdSz5M1i4XJ+0G3xYsNspCsIQgElWOeED5yTX3p3sRuatPPOSpNvjy5drYipiqjqSArehxfGKVZUoFJTkeo+FXhntjtcjV6bJEtVyeR3pMNcpKU7UOnwKc7sA9T6jX1r/ALXrdo+8Trcu1zpzsJht6QtkpShveoBIJJ/SHP1gUHVovs2n2Hs11Fp2RLgLl3Rp5tC47JQ23va2Jz4qx5nn8tVrQfYdIsWobVLvD1qnQI8N2PKjloqD6lLcUCQoYIG5HX8X5KlLl2722C5LQuzTFGPbo1xOHU80vBkhPyjjj/umpDRPaPN1L2oTbH3dlq1ptLFxZG38KFOIZXhSs4P+lx08KCI1v2Myb7rhy8QZ8FmE/wAALZejlS46W0hOGsHABAHlXbpbsjnWrtGf1BLk2lcFxb6y03GUXHOIFDmVZ28l89vI+XOshvt0szrsnZarj3ZLMl2LIUEhMrgJKlgc8p5DlmsuJ2wxndIMX96wXNpmXJREgtZQpUpxRUMJOcADYeZoqFtvZredK9j+sNONPM3NyaVuxEsJKVqKkpTg55Z9EftqDsPYZcZGmpXfbhGgS5tqYioZZYKdiwpDquNg+krcnaSPD6KskLt5tUptOyyXIyFzFRER0lBWranKldcDAI5euvhjt6tz1ts8xFinKFymuwm20uoKkqQGufkc8YfRREPbOw+7RYepWnZtmX7atspQ2hlaWkFDgWRtBBA5YGDVjs3ZTNjdkt60lLuEISrg7xUvR2NraMFBSCORV8AZJ58/HFRVq7blX/WOmolphlq1zm3jKQ8jc8laAs4SQrHRI8PGpGL262tyFc5UqyXOMzCbC8LKN6yVpQElOcpJKs8+WAaCsM9hN8TGvjbt3tq1z7XHgNlKFgJLS45yeXTDBHykchVr7K+yydozVMy5SJsRyNItjULhRwoHiJS2FL5jHMoUfP0qsmlO0FvUenLxc49nnMP20K3xXcZdISVYQocjnBHy1TonsgrJJjPSEWmeWmWEOLKSkkOLXtS18p658gaCHhdgMxpU1Dt7ihoxX47DjUcpceLhJBfOfSxn9g8qydIdiNztU28Kud0gvMT7Iu1DhNqyhRSgBeDyONmevl0rO1Z21OxNEO3my2comxbkLdLjT/8AsVbVK/oq59MfTVhtHam1ctYTLAzZZi1QQFypaFpLbaNm4rI64zgfPQUqw9il9gT7C7JutucatcSTFSEJWCoO8Yg9PAvH5hVy0RoW96U7MzYIsq0v3ISFOpcksqcY2lQOCnkc4Fdmgu1iBrK+Jt8O03GO262t1iS6ElC0pJBztJ2nkevlUez20wVOaiW7Y7imDY1rbkykqQpO4KKUgDOcqUMD9tB39q/ZxcNZvWSVEmW5EiA0404zLYK2F70gFQT4EEZHzeVZVz7MIs7s39z3EitXXuSIntkiMAralwObB4hBUPg56Gor/LZEGnJt3c0/c22ob7LbyVKRgIdB2rChyPQAj1iuF9uNsFpbnNWee8mTNdhw0IUkd44YBUsE4AT6SfnPqoqFj9ilyb0Zc7UuZZlSZktl/YmOtLIS2lYxyIVuJXnPqx419M9i10jxNJOs3O2JudlnKluKTG2NuAqbUB6PUjh+IGcms+59vdsgLhBViuau8wjNwopQpAClpIIP+7Jz5EV23jt2tNuVE22ma8iTbk3FKt6U4ScjaR58jRGbqvsxm37tFm34XBmPDk2py3bQCXUKW2pG4eHLdnrUR2YdkF00jraLe5c62usNQzGLUVpTZJwAFHPIk4yT4k1tbSt6a1Fpy3XdlpTLc1hL6W1kFSQoZwcVK0UpSlApSlAqp33s60rfr6m83a0NybinaeIpxYB29MpCtpxjxFWylBUnezjSbuo131yzMm6LWXFPb14Kz/S2527vXjOedYp7KtGGxN2c2Rs29t5T6EF5wqQtQAUQvduGQkcs45Vd6UFGl9k+ipZRxrIjCI4ipCH3UANg5xgKHjzz1rtuHZdo24e1/fLIy73BlMdjLjnJtPwUq9L0gP0s1dKUFUX2d6UXqNu+myxxdG1hxLqSoDcOitgO0keeKje0vswsmuory320RLutCW0XBKCpaEhYVjbkBXIEc+mavtKCgHsl0lLt8Jq8WxE6UxBZgrk71tKdS0lIBISoYPoD145ZxU3ZNEafsl7Vd7ZA4FwVFRCLvGWrLKEoSlOCojkG0DOM8vlqyUoKaOzHRyZc+SmxR0vTm3Gn1JUoZSsEL2gH0cgnmnBrF1V2aWu76AZ0nbXFWuAw4HGSlPGKDuKj8M55lR8c/NV8pQav0p2K6ZtFgNuurXtysye9l15PDwvGAEhJ5Jx1GTnxqYj9lGjI7FvZas+1uBIVKjjvLp2Oq2ZV8Ln/AKNHI5HL1mrxSgo9r7KdGWqXFkwbMG3ooWGlGQ6rbvBCuRUQcgnrXNv7KdFQGJzUawscOa3wnw44tzcnIVgblHbzAPLHQVd6UEHpTSlk0nBdh2CAiIw6ve4ApSitXmVKJJ+momB2ZaPg265QI1kYES4lKpLalrWFlJJTjJO3BJxjFXKlBUx2daTGmXNPizMC0uOB5TIUrKljoorzuz4Zz0rv05obTunJ0mZZrcI8iQymO6ourXubSAAMKUR0Aqy0oKtp3s/0vpy7u3Oy2hiLNdSUlxKlHAPUJBJCfmAr7g6E03BYvTMe1t8G8r4k5Di1rS8rJOSFE45qPTFWalBUIPZtpKBY7jZ4tnaRb7ht7y3xFkubTlPpFW4YPTB5VzI7N9JSdORLE/Z2l2yIpS2Gi4vc2VElRC87uefOrdSgo8nso0XJMfi2RH4CMYjYQ+6kJaO4lOAoeK1c+vPrXM/sq0XPYiNS7I24iJHEVn8M4ClsEkJyFZPU8zzq70oK9p7Rth09N73aIPd5Hd0RN3FWr8EjASnCiRywOfXlVhpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpXC1pbQpa1BKEjJUTgAUHNK0xrT2QWm7HJci2dl68yEHCltKCGQf6x6/MMeuqYr2TsrcdumGceGZh+5QemqV5k987L/Nhj64fuU987L/Nhj64fuUHpuleZPfOy/wA2GPrh+5T3zsv82GPrh+5Qem6V5k987L/Nhj64fuU987L/ADYY+uH7lB6bpXmT3zsv82GPrh+5T3zsv82GPrh+5Qem6V5k987L/Nhj64fuU987L/Nhj64fuUHpuleZPfOy/wA2GPrh+5T3zsv82GPrh+5Qem6V5k987L/Nhj64fuU987L/ADYY+uH7lB6bpXmT3zsv82GPrh+5T3zsv82GPrh+5Qem6V5k987L/Nhj64fuU987L/Nhj64fuUHpuleZ2fZOv7xxtMN7PHZMOf8AorZ/Z72x6Z1m+3Dbcct9zXyTGlYG8+SFDkfk5H1UGyaUpQKUpQKUpQKUpQK87eyn15IgoY0na3i2qQ3xpq0HB2E4S3n14JPqx516JrxB7IdTiu1+/cXPItBPycJFBrilKtPZc/FjdoFkeuC2URUP5cU8oBAG09SeX00RVqVut9jSWo9SOSLg9GcQm2xlRkqkNtKkKUTxC6oKbSHE5IxkcgDg1C2azaJMhceUtDqJF4kQm33JuwsRg2kodIHI+kTzPI8/mDV1Kvl3tWnmtMQn4fdlFTLCnJff8v8AFURxUGP5J546dAdxzirDK0/odueyFriojpXJ4QZuYc70wiOtTbiz/wBksrCBt5Z3Y28qDUVK3BbU6Xbtt7YgQrWty4WiNKQxJuJSG3eIOI0lZUMEbd2Cd3h05VFWm16Mem6chzOGjjW5UqU/3vkuRhe1k+kAgZCc5IPPqM5oNaUrZV2tmj7e7qV1lDcru0aMYkfvoxxlnDgSUqO8J64BOPOsbQdg0/drbb37pJhtLbmyETQ/MDKizwUlnakqBP4TeMp+flQa+pWwW7ZpZej0A8JN3VaVTTI75zD6ZBSGuHnGSjnjr0IrnR1g09cdIS3bpIiN3NwSRHUualtSFoaCm0lBIAClZGSFA/o45hr2lbTetWjlaku8O3x4rqYbDfdUP3PhtS1kpK1F0kAbQThIIzjxNd2nWdKu2pNougiKYfv7rSXO/AGO0WUgO78J3JBHIkBJ58qDU5BGMgjIyM1xW4rO/ZltyIbwgXJ9/TUZLXfbhw0pdDiCpkLKgEHAJxkEbceJBwXbBoX3L2yQqdsdc7qX30SElwKWsB5Jb3kgJBVg7B8Eczmg1XSts2dvTtl7R7CtyFamoSnnEK23TvLYT0bdUeiScnkTjzCcVxbrBo9+0XN65mLGnodfSppi4JUmMlLYLZbJc/CblZ6Bfly60Gp6Vy3t4ieJnZkbtvXHqq/KRpj3BzStU/eHD7Xl1LYcL3LcPROeHjGc+OMc80FAr6acW04lxpSkOIIUlSTggjxBr5pQe2uwHXDutNFg3Be+6QFCPIV4uDGUr+cdfWDWzK8u+w9W6L7qNAzwDGaKv6wUcfsKq9RUUpSlApSlApSlArzN7K3RL/fY+rYDSlsKQmPN2jOwj4Cz6iDtz6h516ZrqlxmZkZ2PKaQ8w6koW24kKSoHqCD1oPzepXqXW3scYM6U5J0rcfa/fz7q+krbB/RV1A9RzVIV7G3VwUdtwshT4EvOD/9dEaRpW7Pe26w+P2P9e5/Lp723WHx+x/r3P5dBpOlbs97brD4/Y/17n8unvbdYfH7H+vc/l0Gk6Vuz3tusPj9j/Xufy6e9t1h8fsf69z+XQaTpW7Pe26w+P2P9e5/Lp723WHx+x/r3P5dBpOlbs97brD4/Y/17n8unvbdYfH7H+vc/l0Gk6Vuz3tusPj9j/Xufy6e9t1h8fsf69z+XQaTpW7Pe26w+P2P9e5/Lp723WHx+x/r3P5dBpOlbs97brD4/Y/17n8unvbdYfH7H+vc/l0Gk6Vuz3tusPj9j/Xufy6e9t1h8fsf69z+XQaToOZwOtbxY9jZqtTgD9yszaPEpccUfo2Ctp9nHYRY9Ly2rhdnjd7i2rc3vRtabPmEc8n1n6KDI9jdop/SmjFy7i0WrjdFJeW2oYU22B6CT6+ZP/NW2qUopSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlYF0ubUBGD6bp6IH+NEyyjGLlnkgDJOBWG9c4bRwuQjPkOf8KqM24yZijxXDt/FHIViVLePPa/LC6C9QCccf8AdP2VlsSmHx+BdQv5DVArlJKTlJII8RS2Y2vL6w2JSqpbb66wQiVlxvz8R9tWhl1DzaXGlBSFcwRVevT1cdSOD7pSuCoAZJAo6OaV0rlx0fDebT8qhXQu6wUdZKD8nOszljHjLUYZZeEM2lRTl+gp6LUr5EmuhepI4+Cy6flwKxOtpx9XWNm1Z/5lOUrqiyEyY7byMhKxkA11zJsaEwp6W+0wynqt1YSkfOa6RN8YcZiYmpZNKrsfWumZD/BY1DaHHScbETGyc/Jmp9DiVpBSQQeYI8aqPulKUClKUClKwLrKcaVGjRiBIkrKEqIyEAAlSiPUB9JFBn0qDd02y8sreuN3Us9Sic42P+6kgD6K+PctF/KF6/tN/wC9QT9KgPctF/KF6/tN/wC9T3LRfyhev7Tf+9QT9KgPctF/KF6/tN/71PctF/KF6/tN/wC9QT9KgPctF/KF6/tN/wC9T3LRfyhev7Tf+9QStylphRVOq5nokeZqkPurfdU46rctRyTU6/o+A+AHpl4WB0Crk+f/ADV0+4W1f7e6/wBovfeqS82tpZak+PBCUqb9wtq/291/tF771PcLav8Ab3X+0XvvUpx7plzQlKl5WkGokZxy1SZZfSNwbkSFOpX6vSJIz5ioFt9L0JMhvO1be9OeuCM1HHV0stPxdzAdkuqREjPvlPJSm0+iD5Enln1VnsJvccFDEOUhs8yBs6/TVj0s0hnTltSgYzHQonzJAJJ9ZJJrpav6HNWv2LuMxK2owk96Lf4FQJxtCvOplh2op9DZ9KNDKM/Gfv4INaL0v4Ueaf8AmT96ulUK5q+FBlH5Sn71WKJf0SdVTrIIMxC4jKHjJW3hlzd4JV4kfbU1XGdmxnxmX0o27PHwiOig+19w/J8j937ae19w/J8j937av1KndMPu1+o6vKFB9r7h+T5H7v20NvuA/wDx8j937av1fKzgU7ph9z9R1eUNb6q1/D0RolyXMQszkKLTMNwFC1rOSnI/F6kn1edeQ9ZavvWr7kubfJi3iSdjQOG2h5JT0H8T41s32Vl0dla5g28n8DEiBSR+ktRyfoSn6K1x2e6YRqq/OxZElUaHFjOzJLqE7lBttOTtHiTyFenHHsxEPFnlOeU5T9VZzWyeyrtWu+iZzLD7zkyxqUA7FWrPDHipvPQ+rof21haCYsWodUtadk25aINxUWYslSwZMZwj0VFSQkLGeoI6Hkaplxhrt9ylwnSC5HdWyojoSkkH+FVl+iFouMa626NOguh2LIbS62sdFJIyDWbWk/YsXV6b2fORHlFSYMtbTefBJAXj6VGt10HNKUoFRU//AFitX+7f/wDJUrUFe2n3b7aUxZHd17Hzu2BfLCOWDQStwjmXAkxkvOMKebU2HWzhSMjG4esVEwdPuxdHCxqus113u6mO/rV+Gyc+lnzGeXyVk9yun5WH1ZP207ldPysPqyftoMb3Pu+432i9tZvF7t3f2w3fh84xvz51J2iGq32qJDXIdlKYaS0X3jlbhAxuV6z1rF7ldPysPqyftp3K6flYfVk/bQStKiu5XT8rD6sn7adyun5WH1ZP20ErSoruV0/Kw+rJ+2ncrp+Vh9WT9tBK0qK7ldPysPqyftp3K6flYfVk/bQStKiu5XT8rD6sn7adyun5WH1ZP20Eor4J+StXw1pVZIpSgIAjJGB4+j1q9qhXTaf/AGsOnxZP21RLe44rT0NC1bgiOAOX6NSXk2vwhbNP6gtiLFbkqk4UmM2CNivxR6qz/dFa/jP92r7K7tOf6v2z/hmv+kVIVXrRPuitfxn+7V9lPdFa/jX92r7KlqUET7orX8a/u1fZT3RWv41/dq+ypalBE+6K1/Gv7tX2V8uahtZB/wA5/u1fZUxXChkUHkj2UENp/UVuvUNZcYeY7u4dpG1aSSOvmD+6a1TpPUU3S95TcLeGlqKFNONPJ3IdbUMKQoeRFe1+0jTsLUsKBa7m3vjSJCknHIpPBdIUD4EEZry3rnse1JpuU4qFFcutvySh6MgqWB+kgcwfkyKCG0nqOzacvLl/YgvLuLO5UGGVZYZWRgLUsncrbnknHlk1UZD7kqS9IfUVuurK1qPionJNSMfTt6kPhli0XBx4nGxMZZP8K3F2W9h06XNYuOr2+7xEKC0ws5W6R+Pj4KfV1PqoNn+xrsL1m7PGXZKCh24OqlBJHMIIAT9ITn562/WLCjpYaShCQlCQAlIGAB5Vl4oFKUoFRU//AFitX+7f/wDJSlBK0pSgUpSgUpSgUpSgUpSgUpSg4V8E/JWrLd/8jj/8On/ppSpLx7X4Q2Jpz/V+2f8ADNf9IqQpSq9hSlKBSlKBSlKCGvv/AMfZP+MV/wCA7XdIA58hSlBjADPQVmxwPKlKDNT0r6pSg//Z",
+              "timestamp": 4956747788
+            },
+            {
+              "timestamp": 4957587788,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAFUQAAEDAwIDBQIJCAcGAwUJAAECAwQABREGEhMhMQcUQVFhFSIIGDJScYGRlNIWI1RVVqGx0UJicpOio8EzNnN0krIXJII1U7PC4SUnN0NEY4PT8P/EABkBAQEBAQEBAAAAAAAAAAAAAAABAwIEBf/EAC4RAQABAwAJAwMFAQEAAAAAAAABAgMRBBITITFRkZLSFFLhQWHRFTJxscEFof/aAAwDAQACEQMRAD8A9U0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUr4pQSkqUQEgZJPQVXmtcaVeuHcWtRWlcvO0NJlIJJ8uvX0oLFShIAyTy86rp1xpZM/uR1FaRLzt4Xe0bs+XXr6UFipQEEAg5B8airzqG12VaE3WV3RC8YedbUGh9LmNo+s0ErSqF21yv/ALpL/Jhv8jHSpDrS+oKk8wRUsdX6es0SBGu98t0OUplv82/ISlXNI5kE8qCz0rrjSGZTCH4zrbzLg3IcbUFJUPMEdahbvrHTdnliLdb7bIknOOE9JQlQ+kE8vroJ6ldUSSxMjokRHm32HBlDjagpKh5gjrXbQKUpQKUpQKUpQKUpQKUpQKUpQK4qWlPUiuD6ykYHU1B3G/Wi2Phi43OFFeKdwQ8+lCiPPBPpQWBKkq6EGvtQlru9vugWq1zo0sNkBZYdC9pPTODUw0vejPjQc6UpQKUpQa37cH3l2ex2hLy48S8XViDLcQdp4KiSpOfDOMVY5ehdMSLCq0LssBMHYUBKWUgp5Y3BWMhXr1rM1dp2DqqxP2u5pVwXMKStBwtpY5pWk+BBqnu6L1nJhG2SteLVbVJ4a1ot6EyVI6EcTd1x44zQUQ325P8AYfDgqmulDl4FkVPSrClxuKU78+qRtzW3EaB0qmx+yRYrf3LZswWU7umM7uu71zmub2ibI7okaVMYi0paDSUg+8kg5CwfnbuefOq0nROtERPZydfu+zQnhhRt6DJ2dMcXPXHjjNBDdoMqToTsUMfTt4ellt1MNE5SwpbLalkEbh4pHug9RWxdP6ctlv04i3NtCRHeZCX1vHiKkZHNSyflE5rrt2jbJC0enTIiJetPDLa23veLmTkqUfnE88+dYqtPXS2WUWfTE9MaNs4aJE1apDkdPTCE8s48Nyjig0rHfdj9kXahYEuret1mnLjw1qOdrfEHuZ9Mfvrc+idKWaHpOI2YsacqXHQ5JkvIDipSlJBKlE9Qc8h4Co8dmcCP2aztJQJLjffQVPzHE71uOFQJWocs5xijejtR2mJ3DS+qW4VtCdrbMqCJCo48Q2rcOXkFZxQVTT8t7SH/AIo2qyEqgWdrvkFr5QYWtpS1IHoCM4q09lmkrGzoa2yVw4s6VcY6ZMuU+2lxb63BuVkkcxk9KmtF6Oh6Zs8qIXXJ8mc4p6dKkAFclaupV6Y5AVXYWgtQ6fQ5C0hq3uNnKlKaiS4SZJj5OSEKJBx5A5oOjs+ZbsHafqzTdrGyzIZYnNsA5THcXkKSnyB64raFVnRGkWNLszHFy37hdJznGmTn/lvK8BgcgkDkAOlWagUpSgUpSgUpSgUpSgUpSgUpSgx5I94H0qo6lFzNwT3EXwtcMZ7iIezOT/773s/uq6OIC04NYymlg9M/RQV/SwnBuR38XQHI29/7tn/08Hl9tWWMPcP011oZUTz5CslICQAOlB9pSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSuDzqGGXHXlhDTaSpSlHASBzJNBzpVXg9oOkZ8xiJC1FbH5L6w200h8FS1E4AA86tFApVYvev9KWO4mBdr9BjTBjc0tzmn+1jp9dWKJJYmRmpMR1t6O6kLbcbUFJUk9CCOooO2lKUClKUClKUClKUClKUClKUClKUClKUClKUCvI/wAIXV2o7T2pXGJa79dYUVDTJSzHluNoBLaScAHHWvXFeLPhM/8A4vXT/gsf/CTQeluyyfMndj1qmzZT8iYuG4tT7rhUtRBVzKjzzyrTPwYtU3+9doMyNeL3c58dNtccDUmUtxIUHGwDhRIzgnn61cPg/wDaFZLpp+z6KSxN9otRXA4pSEhogEk4UFZ6HyqyzOzrTmh9Oaku2k7c5FunsqS2hwSHXD8jdgBSiOqU/ZRHdc+2rRFvvotTtzU48HOE4800VMtqzj3l9MDzGaj7z29aOtN1l298XJx2M6ppS2WUqQog4yk7uY9a8qaDZ0zIvpRrWXOi2zhKIciJ3K4mRgHkeWM9AeeKh7umGm6S02tbzkAOqEdbwAWpvPulQHjjFB69m/CC0bDmPRnm7txGllCtsdJGR/6ql7d2w6auOtGtNw+9OSnCUh8ITwgQjcQTuzywQeXUV4z1P/vFcv8AmF/xr0nqLsm05p3s5n6iszU1F1atinUrMgkArbws4+hSqCyXz4QGi7ZOcisrnTy2rap2MyC2T6FRGfpHKs619q2lta2W7Q7VKdan9yeUI0lvYtQCDkp6g/Uc15T7OW9HuXWQNdvT2oPBPBMQZ/OZ/pYBPTp69am9Jp0e3qNC7bN1H3resRUmO0EkEEALIVnGOpA6ZoK72aSmYXaFpyVLcS1HZnsuOOKOAlIWCSfqr07pTt/07fdSJtT8STAQ87wo8l1QUhZJwnd4pzy8+vOvMPZpFYndoWm4sxlD8Z64MIcacTlK0lYyCPEU7R47MDtD1HHhtoYYYuL6GkNjalADhwAB0AoNs9q8PsuR2g3ZN3e1JGuXG3ykQ0NqaUtQCiUlXMZzUR2u60Van9PWnQd1vNstkS1sq4aJC2twcSHUE7Vc1bVjPrmqX2vurf7Q7m66oqccRHUonxJYbJqwdt0Vhm2dn77TDbbr+noqnXEoALhCEgFR8SAAOfhig238HftGjyNI3RjU93lOS4C1Snpc50rSlpW1KQFqJOcg8vX1qef+EFoVqWWUyJ7qAccZEU7D68yD+6vNEi4W1HZHDgxlRk3Zy6uOSQlIDqmQ2Nm44yU7irAz1rHsls09J0pMlXGe3HuaFkISZCtxHLG1oNHd9PET9VB7asestP3ywvXm23SO7bmAVPOk7eFgZO8HBTy8615P+ERouNKU0wm5ykJOOK0wAk+o3KB/dWgITUCB2e6mFi1DJmrkNxxLiGEplKUh5OFFZUQeZxj19KwNAN6FcgXU63fujUoJHcxDGQeRz4HnnHXAoPVcPtc0tedKXe6W2Y8VQI5dejlva+gHkCATg8yOYNeWdL9pOpIWprTKuupL6/bmJbTklozHF72gsFSdpVg5AIwetW3sTiaSkarMeK7eZUp6HIQuPKitd3cRwySF+8TjIBHLqBWsdFLhNaysS7sGfZyJ7Bk8ZIUjhBxO/cD1GM5FB63vXbvpGzzUxZbd0LqmGXxsjpI2utpcT/S67VjPrUlqTtf03p602O4z0XAx7wwZEbhshSgkbflDcMH3h515Y7b5dvndpd0k2RbK7YtuOI6mBhvYlhtICR4AYx9VTXbBNjSdC9mjUd9p1xm1KDiUKBKD+bGD5c0n7KDernwgNHIgMzFN3XgvOraT/wCXTnKAgn+l/XT++knt/wBHs2hiehNxcDz62QyGkhwbUpJURuwE++AOfM58q8mSv90rZ/zsr/sj1unsB7LdNa20ZKuV9alLlNzlsJLT5QNoQ2RyHqo0G5dSdr+kNPMxjPnrVJfaQ8IrLZcdQlSQobgOSTgjkTXTpXto0ZqSe1BjT3Ist0hLbctot7yegCuac+ma8fORmF61ei3hamo4mLaeUtwoKAFEYKtqiMYxnaceVTE6zaSb1AtlGpFQ4adpS4wyuaEnxwva2T/00HvClYNiXxLHb1l9ckqjtnjLQUKc90e8UnoT1x4VnUUpSlApSlArTHaX2Go1vq6VfFX9UIvobRwRE4mNqQn5W8eXlW56UGnOzHsRRoXVbV6TflTihpbfBMTh53DGc7z/AArcTiEuIUhaQpChggjII8q+0oNHXX4OOnZd9EyJcJcSCpze5CSkKGM80pXnKR9Oajb18GqFNu0uTC1AYMV11S2oyYW4NJJ5JB4gzjzr0HWFfHpsezTnrTHRJuDbK1R2Vq2pccAO1JPqaDQ1z+DW1OuMmV+VK0cZwr29wBxk9M8St9M29oWhFukJS+wGBHWFp5OJ27TkeRHhWgdF6y7XputIUW7WV0W9x8Jkpdg8JDTefeIX6DOOZz61v683Bq02idcZGSxEYXIcx12oSVH9woNIX34NVklzFvWi8y7e0pRPBW0H0p9EnKTj6c1P6J7C7FpdciT3uROuTjDjLb7yQEs70lJUlA8cE9Sa0rc/hB61lXFx2C7DiRiolthMdK8J8ASeZPryr1Voa5yLzo6y3Kbt71LiNvO7BgblJBOB4URqHSnwd27Bqa13calW+YMluRwjBCd+1QOM8Q4zjrivmqvg7t3/AFLdLudTLYM6S5I4XcQrZvUTjPEGcZ64rfda/wC2W8avs2n2HtD27vklThS+tLfFW0nHIpR45Pjzx5eRVG1X8HlvUF9fuR1KuOXUtp4YhbsbG0o68Qddufrq5ap7JbPqbR1kslyfdEm0RW40ec0kJXhKEpOUnIwdoOP31WezfXetY1iv927RbVIRbLewHm3e7Bl5as80pSSARjnnl9NTWh+23T2sdTRbHbYN1ZlSQsoW+22EDagqOSFk9EnwoivaZ+DnZbbIlKu90fubDzKmg1wQzsJwQoHcTkY5VGv/AAY7cqUVMakloj55NripUrH9rcB+6vQ1aYgfCI0tNuceC1bb2HX3kspKmmtoKlYBP5zpzoq1aV7KdMae0vPsbcVUti4J2y3ZByt7HTmMYx1GOh59a11cfgy2p2UV2/UMyMwTnhux0ukf+oFP8K9BUoNe9mXZPY9Arfkw1vzLg8jhrkSMck9SlKRyAPLzPKqXqj4ONlul0el2i6yLW26orVH4IeQknrt94ED051valBo+/fB4s1ytltZjXaVFmQ2AwqQWkrDwBJBUjIweeOR6AVi3X4N9pk2q2RbfeHIj8YLMiQqNxFSVK288bxtAxyHPr9t/7Ybvqyz6abf0RbhNmKd2vEI4i2kY+UlH9Lnjzx5eVd7D9RdoF7lz0a3tq2ILbYLL7sbgLLmR7oHLIxk5xyx60RWHfg2tuWmNB/KhYDLzr2/uA570tjGOJ4cP99bQ7JtCp7PtNv2lNwM8OylSeKWeFjKUJ243H5nXPjV0pRWo+0TsLsWr7s7dI0p+1T3zueU0gLbcV84pOMH6CKi9J/B0sFpuLMu73GRduEoLSyWw02oj5wySR6ZreFKAAAAAMAUpSgUpSgUpSgV56+EX2q3fTt5a07pp/ujqWUvSZKUgr97ohOenLmT15jpXoWvNXwmOze73G/I1NYoj05pxlLcpplO5bakjAUEjmQRjp0x60GublrntEh6Qhi4zb3Hjy5HeYtxU642pxO0goCv6SeigPp86+wNc6rX2eXuUrUl4Mlu5Qm0OmY5uSlTckqSDnkCUpyP6o8qhNRXfVV00Zbot7W77GtTqYkZDjQQQrYcDOAThKcc+mRUlobTk/UnZprBq1MOSZMSXBlcFtO5a0hMhJAHicLzj0oi6dkGrdRXHSvaG9PvtzkuxLOt2Ot2UtZZXtX7ySTyPIcxVW7OdcaqmapSzL1JeH2u5zV7HJjihuTFdUk4J6ggEeoFY3Z23qmDatYxLXaFKjybY4ic5IbUngtpSonHmo8wB5/RUd2YwZaNXIUuK+kdxnDJbI/8A0j1BP9lWt9Uz+0fTsWbqO7yIz0xtDjTsxxSVpJ6EE4Ir0721Q5s7ss1G1bZPdn0xVOqXuKctoIU4nI+chKk46HODyryR2PwZbfafplbkV9KRObJKmyAOdezO0ZKl9n2p0oBUo2uSAAMknhKoPDWgLdc7vrC2QLFN7hc33CliTxFI4Z2k53J5jkD0raPav2mast94j6Utd0fZXbGGYsmRHUS7KkBCd6t5G75WQOhPU9aqXYZClN9rGm1uRn0IEg5UpsgD3FVZPhAaDvtr19Ov1vhyn7dNcEhEiOgqLTmBkKxzScjIPrQRGstd9o0GBZ7ffJN5tMqOhZS9xHGFykHbgrxjcU4Iz158/WSVrPU3/gYi4/lBde//AJRmP3jva+Jw+7BWzdnO3PPHnVT1xF1rcYNmuurFTpQltrEQPAlaW07cnaByB3D1OM+VSqoUr4vyG+7P8T8pyrbwznHdRzx5UGbpy6ao1X2Y6571qCfITBEV9YlSnF5a/PBaB16+7y6Hb6VVOye2XS76/tUOwzu4XBalqQ/xFI2pSgqUMp580gj662L2BaenXnRvaNammlNSZkNhtnipKQVfncDJ9cfbWurKzq3QmrGZUS2TIt4jFaEJciledySk4GMK5E8xQe5tTRJk/Tl0h2yR3We/Fdajv7inhOKSQlWRzGCQcjnX58WtiQ/eokeM9wpTkhDbbu4jasqACsjnyPOv0Nsrr79mgvTAUyXGG1Ogp2kLKQTy8OeeVeGNV6O1HonVKw/b5OY8jix5KWittwBWUqBAx5cqDZXaz2mar0u5C0fBuRRNt8NlufPQSt2Q8UAkhShkDmOfU5qlq1z2maUmRnrhdLw0t0b0NTyXErH9lef9Ka10rrO/w4+tbhbpMpdxTmRwYxSppSDsBUgDISUpSQcYrFt9y13d50RixwZTEhobEpt0BMcE8uayhIBPLqrpQT/an2n6iucyw3C2XS5WlMq1oW9GiyVtoDoddQogA+O37MVi3/V2v/8Aw601Pfu0tm2LdebalIlq7xIcC1ZK1ZzgD3QM/wBH6K6u26zagiXqxM35x+4XRNpbMh5Kd3vF107cgYOAQPqqT1bEkq+DvoZtMd4uJnSipAQcj8451FB8c7TdUT+yF7iXma3cYN3YaExp0turacZeOxSk4J5t55+nlVbja91crStxeOpr0XUTYyErM1zISUPkgHPQ7U/YKxIEGWOzK9IMV/cbtBIHDOSODK/mKj4sCZ+SFzT3SRkzopA4Z/8AdyPSgt2kb/2l6ptV3t1im3i5qKmVPO98UVspG/ASVK5bj1x82vUvZDFvMLs+tcfU3efayAsPd4c3r+WrGTk55Y8a058ECM+xL1Tx2XGtyI2N6SnPN3zr0pQKUpRSlKUClKUClKUClKq9+1ciz3FcR2E4sgBQWFgBQP1UFP8AhFaNvetNOWuJp6MiQ+xLLriVOpbwnYRnKiPE1HfBv0HqDRKNQjUcREYzDH4O15Dm7ZxN3yScfKFbCuGr48O2wJYjqc72kqCAoApx1z9dcomrojlqXPlNLjthfDQnO5Thxk4FXAstKpSO0CGXcKhvhvPygoE/Z/8AWuGubzHl6ejd0VxESV5CwcbduMgj66YF4pWotH3cWm5OOuNqdC2inAVjHQ/6VaY2vorr6UOxHGkHqsrBxy8sUwLpSqtadYxpjMt6S0YzUcA5KtxVnOABjryrDX2gRA4QiE+pHzioA/ZTAutKjbHeol5YU5EUoKRyWhYwpNSVQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKonafBy3EnJHySWl/QeY/1+2r3WHdrexdILkSTu4a8c0nBGDnlSBpVx9x5phpRyhoFKB5ZOf4mrBq+3uW6DZ2FAhCWTny4hOVfxH2VbY2h7WxIaeDkpZbUFBK1pIOD4+7U/crfGuUYsTGg42eYz1B8wfCuso1NKcsxsLKI7LwugI3rJOPXxxWTDQ7+RE9SgeD3lvb9Pj/pVwToW0pd3EyVD5hcGP4Z/fVgFviCAYQYQIpTt4eOWKZGptOT2IHtHvBUOPEWyjAz7xxiunTTDUm+wmX0BbS3MKSehFX9ehbSpZUFSUg/0Q4MD92a7bdo23QJrMpl2UXGlbkhSkkfXypkQ2vrTFt9pZXAjJZSp4Bwpzz5HGf31U4areLc8JI/8zn3cIUVfUdwA+sGtyyo7MuOtiS2lxpYwpKhyNVpehbSpzcFSUj5ocGP3jNIkRnZyIXfZBiCXxQ1hZcKdnUY6c8//AFq+1h2q2RLXH4MJoNpJyT1Kj6msypKlKUqBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSla47RbrINz7g04pDDaAVJScbiefP6sVYjI2MFpUcBQJ9DX2tQO2C8Qkx30oUC5zQW3OY8fOvupnp6k28XILRISyUklXNQ3HB5f/AO5UwjbqlJT8ogfTX2tS2yx3a82xpcdbZjNrUEhS8c+WT/Cvt6ulxuVz9nsuLCErDCGkKwFEcufnzpgbZqj32Nqpd1dVCcX3Yq/NcNaUgDwyD41Vi7d9NXBKFuLacwF7CvclY9fDwNdWpJRk3mQ+hSgl0IWBnplANWIG3bcJCIDAnKSqSEDiKHQmshKkq+SoH6DWp9USJ/d7c24p1MLujJbwTtUdgyT65qOtsKTIAchy2UPZ5IL2xf1Zx/GpgbqJwMmviVJV8lQP0GtUauduqHIzM5TyWksoABJwpW0biT4nOaj7bClSAlyFLaS/nk3x9i/qzimDLdFK1Tqu6z1ymoC3XEBlpCVpCuallIJJ8+ZrDvrN2gxoca57koSFFn3wTg4yMg+gpgy3FQkAZPIVplS1/k0g7lZ72rx/qCudvRNdsN0cZkbI7RbLqeeV5JAGfLnTBluMHIyK+FSQcFQB9TWm7NfZlrakoYdVhxvakE5CVZHvD1xmlutdyvYkPxyXS3zWpbnMn66YMty0rWmm5V4tDEp15t1cNLKlALUCEqA5Hrnry5edQKn7heJK1PStyx73510IA9Bk4+oUwZbppWtNGyrxGujLSm5TsJatiwpJUlP9YHwrZdJhSlKVApSlApSlApSlApSlAqja503LnTROgIDpKAlxvODy8Rn0q80oNOpsN8kqQ0qHKITyTxOSUj0zyrOvmmZ8VuCyxHdkKDRLimklQCio8vsxW1KVcphXdBRX4lh4UplbLnFUdq04OOVVjUul7ixdXZlsbW62tfESWz76FE56fT5VsmlMq1TH07fLxNC5yHkZwFPSDzA9AeZrjqKwz/bEgRIMhxhO1KFJbJBASB/pW2KUymGuJ0DUUfguQUPlhUdkFsEKAIbSCCg+OR5VDCwXqfKKlQXELWealIDaR/AfZW4KUyYa5uls1HCkf+UU6+xw0JO0haSQgA+6fUeVQyNPXqfKKlQXELUclS0BtI+rkPsrb9KZMNbao0pcOK3IjJMoltCXdvytwSATjxBxUXM07ee6xnnWJDy3Nw4eCpTaRjGfLOTy9K27SmTDUyrNcvyfQ13GTxRKUrbwznGwDNZ1ntU9rTF8Zchvpdd4WxBQcqwrngVsulMjUdp0xcJchxl+K9HBbJS44ghIUOgNdS7BfIi1tpiSRu5KLXMKH0itw0pkw11pnSEpZfcuSSwhTSm0JyCrKhjOPSotViv9olr7o0/kgp4kfmFD6v8AWts0pka80lp66i5Ny5yno7KFbylSzucPqPLzzWCbPqL2/v2v8biZ7xu9zGeufL0raNKZUpSlQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUqnaiuUq13KdDafXxbmyj2fuOQh7cG149BubXj+0aC40qpxrxPbDTxVGXBTN9n8FQUZBIc4e8r3YJyN2Nvyeea6bbd5r/Dh20RIuxp2Qtcre4FAPLRtB3A/wBHJJJxkcquEyuVKhNPTRMkXBzYjP5lRU26XEq3NJV7ueWOfgBnrUSnUlwasqbvI9nqjvxVyGowKkOowncEkkkKx/SIAx60wZXGlVKbfLrbhJYe7jKlBlt5pbSFNoG5wI2qBUo+OQc88Hlyrqm3u+wU3hb3s5bdrSl5ZS2sF5BTuKQN3uEAHn72eXIUwZXKlVBy9XpTiHGEW8R3LguClK0r3AAqAcJzg/J+Tjn5iuhzUl5MwWxiPHcnodeS48hvKClAbIwhTiTkh0f0jjB60wZXalVBF9vExpnujUFh3uSpTnFy6nclRTtSUKxg4znJx5GmmLhcrjqGa65LY7iuPGfRGLStyAtCiMHfjPmdvPHhTBlb6VVZN7uaLhPU2mIIMOcxEUlSFFxwOBrJCt2AQXPI5xjl1rqi6iuC0QJbiYhiz3XGWo6EK4rRSlZBUd2FfIwQAMZ6nFMGVvpVSXqSaqHa1RWI70mXbTMLQVtyvLIAGT0/OK5E88AZqTsVxk3KBMC1tomsuFo7o62whW0EbkKOfEdFYI8aYMpqlUex3O+ex9PNmTBkvzuSnltLBbSlsqOffO5WRjqOtd7OppiriUER3IrqJBZUhpaebfT3lH3xy54SAD4mmDK40qmpv96bbZS7HiPyJUNEtlDKSnZ76ErSdyvfICwRgpzjFR896VqCbYW3HIK0ImvNvMvwnMb0tKV7yFLGDg8uvMg58KYMthUqrMXyep1mSruhguzlwkx0oVxkkLUjdu3YPNOSNowM8+VdMW9XuSxa1BNvacuLziEZQtQaQlCzk+8NxO0cuWM+NMGVvpVJb1PdWIEe4TWIrkdbkhhTDCVcTeyl07gonGFFo+7jluHM4rlN1HdLdBeekdwkuLtz09jgJUlKCgJ91WVHcDvHvDHQ8qYMrpSqlJvV5iyJMMsxZEpAZcSplsjahziZ9wrysp4fgRkHpy59lyuTk3Qc2YlzD3CWkqbQpohSVFJ91XvJIIPL+NMGVppVVVqGUNQsxk8ByE5KMTKWlgpUEKUfzhIBOU4KQk486tVRSlKUClKUCul+JHfeYdfYacdYUVtLWkEtkgglJ8DgkcvOu6o6de7dBlojS5bbTygDtOfdBOAVHonJ5DOM0HcLZBE4zRDjiWf/AM7hjf0x8rr05Vwk2e2Smm2pNviPNNkqQhbKVBJJySARyyetdLmoLU2ZIVNazGIS8Bk7FE4Cf7RPLHWiL1FfENyI9HcZfdU0pS3ChSSlKlEBJGdw28wcYGT4YqpuSDTDLKlqaaQhS8bilIG7AwM/UMVjM2m3MSXZDMCK2+6CHHEtJClg9cnHPNY7eobS6w68iewW2tu5Wfnck488nkMdfCvjuorS1GafXNb4Tu7aUgqPu/KJAGQB456eNN5uZMe026MytqPBitNLIUpCGkgKIOQSAPA13Ow4zqX0ux2liQna8FIB4gxjCvMY86wpOoLVGkIYfmtJcUEKA5nCVckqJHIA+Z5VzF7tpuPcBLb71u2bOeN2M7c9N2OeM5pvVlCHGASBHaAS4XQNg5LOSVfTzPP1rol2i2zELRLgRX0rXxVBxpKgV4xuOR1wAM+VcLfe7bcJK48KW266kFWBn3gDglJ6KAPLIzSZe7bCmoiSpbbb6tvunOE7jhO49E5PTOM0TcykQ4zYSG47SQlvhDCAMI+b9HpXFu3w2nmnm4rCHWmw02tLYCkIHRIPgPSsb27bPaPce9t9638Mo58l4ztJ6A45geNcrperfa1ITPlIZUsFQBBJCR1UcDkkeZ5VBkmHGVxcx2jxVpdXlA99YxhR8yNqefoPKutm2wWZa5TMOOiSvO51LYC1Z65PWuCrtAS8WlSW+IFIRt8SV/Jx5558xy5HyNdMbUNqkzBFYnNLfUpSABnBUnO5Oem4YPLryoO1Fltbe/Zboad6SlWGUjcCQSDy6EgfZWRDhxoTRbhx2mGydxS2gJBPnyqNh6ktst+WhqQjhx0FwuE8loHylJ80jpkeNc2b7CeKnW5MYwUsqdL5dxySrBOMY2/1s1d5uZjFuhMLC2IkdtQWXAUNgHcRgq5eJHjXULPbAsrFviBRUV5DKc7jnJ6deZ+010t6itK4bkrvraWGlpbWVgoKFKICQQQCM5GPOh1FahDTKMtPCUstAbVbysdU7Mbsgc8Y6c6bzcy3rbCeQlL0SO4lLfCAU2CAjIO36MpHL0FGLfDjpaDERhsMqKmwhsDYSCCR5Egn7aw5Oo7RHbYcdns8N5HEQpJKhs+cSOifU4FZs2fFgxg/LfQ20SAlRPyiegHmfQVFcU2yCiaZiYccSz1eDY3nlj5XXpXYiHGQGQiO0kMElrCANmQQdvlyJ+2sE3yGBxzJjCBwC+Xi7zACsH3cdB4nPI8sV1DVNl/WDQIVtUCFAp6c1cuQ5jmeXPrV3okkwoqEtpTHZSltanUAIHurVnKh5E7lZPqfOulqz21lp9tq3xENvp2upSykBweShjmOZrpXqC1IndzVNaEjiBop5+6s9Ek9AT4A9fCsZjU8EQESZ60xSt55pLfNaiG3FIKsAZxyyTjAz1pvNyTk26FKKzJiMPFYSFFbYVkJyU9fLccfSa5CFFEPugjMiLjbwQgbMeWOldrbzbrCX2lpW0pIWlaDkKBGQRjrVQtmrnZstk7WkxHZjsbm04haEoS8dxKgASeEDy6ZIPOgsq7TblvqeXBiqeUoLUstJ3FQ6HOOvIc6zajZd3jNRUuMOsLW4z3hoOLKEqRlI3bsHA95Ph41i3bU0CA4tgPIdlocbbLQJGCtSRjdjG7Cs7euKCcpUcxe7a/cVQWpbapQJTsGcFQ6pB6EjxAORUjUUpSlAqvzbPPE+e7bZMVtq4bONx2i4pBSkJykZwcpA5HkDz55xVgpQV1zTzgjDgPNJlN3Bc9tSkZSSSoYUB191RGfA4PhXUNOSHJbcyRIYVIVLVKeSls7OccshIBPPlgknrz6VZ6VcphUWNMSkR3mlORyyUtBuMVuqbSUKzuSSrLZ6YCemPGvv5N3FTDTTlxK28PBSFOOe5vIKcKzuXtAIwo88+lW3IpTJhUUaVkGy3GG5IZ40q2tQQtKThJQlY3f4gazGLLPYdXHbkxvZq5LklW5ol731FZSCTge8o+9jOOXrVipTJhVdN6akWuVDMh6O4xCZLLJTvK1dACdyiE8h0T1J8OlcbtpiRKuc51h5gR56kKeDu8lO1IQdqQoJVlKR1HI569KtlKZkwrz2n1rRJCXkJLtyZn529Agtkp+khBH1113+wSZl0VOgvMpccjiMtLxcAAClFKhsUM/LVkHry5jxstYUq1w5TxdfZ3uHkTuI/gayu1XIjNqImfvOP8AJ/p1TFM/uQo004i72+e2+yF29tEdhHD5FrGF5/rHwx0x/WNR9msVwk25mNNUyxBROfk7eGpLx/OrKR5Dmc7vEcvWrL7Ct36P/jV/OnsK3fo/+NX86w2mmeynunwd6trnPT5VyFpCU1EVFekRi21CchsLSFlR3J2hStyiE8hzCev2CpG86a9otKaDyWUd0THRtB91SVpWk8iOWUjly5VJewrd+j/41fzp7Ct36P8A41fzptdM9lPdPgatrnPT5QjemZLiXFy3YyXlyIzmGwtQCGXAvBUskknn6D7a73bBLavT91gvx+8qfWtKHkko2LaaQoHHMHLIOfIkeNSnsK3fo/8AjV/OnsK3fo/+NX86m00z2U90+Bq2uc9PlATNMXBx0yES4i5L8cMPlSFtoBClqCkpQoZ/2ihhWc4HPrmZulo7xa4kRlLKu7KQU8Tcn5KSPdUkgoPPqPUeNd3sK3fo/wDjV/OnsK3fo/8AjV/Om00z2U90+Bq2uc9PlCOaXlPQVMyJodWqK5HKnMq+U6FgZJyQANuTzOMms252BUxV/Ul1tJuUJEVOU/IKQ4MnzHvj7KzvYVu/R/8AGr+dPYVu/R/8av502mmeynunwNW1znp8q9GstxkqukdSmGoMi4cZaltqDpSnYfd8DnaMK8OfXlj6vScppbL8SQwqQjvCFB0uJSUuPFwEFCgcjOMdD6VYPYVu/R/8av509hW79H/xq/nV2mmeynunwNW1znp8uNkhyLcy1CJYVDYjtoQpCSlSljO/l0Cfk4HqawDp1amoTa307WJkmSrA+Ul0OjA9RxR9lSPsK3fo/wDjV/OnsK3fo/8AjV/OptNL9lPdPgatvnPT5QJ0xPejMMyJcbaxAMFGxB973mzvOT5N9PDzNdsvTk1xuXEZkxhCfnInZW2S4CHErUny6p5HwHLHjUz7Ct36P/jV/OnsK3fo/wDjV/Om00z2U90+Bq2uc9PlCWvSz8K4RsvsLgxn3JDed5cJVuwCCraMbz7wGTjwyattRzdlt7a0rQxhSTkHerr9tSNb2qrtUTtYiP4nP+Q5qimP2yUpStXJVH1NqC4w7vPaYkMxW4bba20O7MSCoZ55O7GfdGwZyD15CrxUZML6pQULU3I4Zy26pxII+jIyKzuXqbMa1UTP8RM/1ErFE1boQ1lcdTrO8MybssqVw3G4S+GMoKBzSMbsA8sj66wZ+oJ7Uy+rRcoyDbpTbTMEtjc+FIQdpOc5UVEJx49c9Ks3erhu3eyhu6Z46f5VgxYr8eXJkizhbz73HKlvoJQrYlPunHIYQKw9fa5Vdlfi72NXOOsflX/aDseQZsaMzx47F2UhptGAtSH0AZA6k45+ZzX2+z5ztjvUaNehNAtq5XeoyEAtH5nLIwoZI8RtPM1a0vzUqBTaEAjPMPp8Tk+HjXxp2YylQaszaAo5IS8gZP2U9fa5Vdlfimxq5x1j8qvftRyIEBx223dM8RYhllxKGSl33lABSgQCPdIwgZ5cz0rpeukmFO1TLhXGOhTEpt1uIUBRkksNYTnr73IJ2+Pn0q2qXLWUldlaUUghJLyDgHqByr4DJCkqFkZCk80nioyOWOXLyA+ynr7Xtq7K/E2NXOOsflWFXSZES1GjPCIiTNnLW+dmQUu8kDeduTknx5JP0i06buntC2xDJfjqmONFwpaV8tIUQFgeR+sc+pr46qU62W3bK0tsncUqdQQT54xWTCXIW/l+3ojgI2hwOJUceXLwrqjTLdcxTEVZnnTVH/sxgm1VTGZmOsfln0pSvS4KUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUqDa1ZZXdWvaZRMzemmuOuPwl8kYBzuxt6KHjQTlKwYl4tkyY7EiXGG/La/2jLT6VLR9KQciqqe1bRib25aV3kInNyTDWlcd1KUuhRTtKynb1B8ccqC8UqNN/s4kSGDdYAfjpK3mzIRuaSOpUM5AHmawZ2tdMQYhkyb/AGtLIa4wIkoUVIzjckAkkZ5cvGgsFKqWnu0fSOoRKNrvkVYioLr3F3M7EDqo7wPd5jn051Nx79Z5DTrse6wHW2kJccWiQhQQlQyFEg8gQQQaCSpWBFvVrlwHp0W5Qn4TIJdkNvpU2gAZJUoHAwOfOoyfrfTMK1SLi7e4LkRhsOuLjuh8hBVs3bUZJG44yB1oLFSoz8oLQFREOXOG05LQlxht15KFuJUMjCSQTn6K+L1DZUSnoyrtbxJZSpbjPeUb0JSCVEpzkAAEn6KCUpVe07rTT+orHIvNquTS7ZHcLTsh5KmUoUACc7wMDChz6c6z49+tEll52PdYDrTCA46tEhCktpIyFKIPIEc8mgkqVFMakscgPli8213gJC3tkpCuGk9CrB5A56muaL/Z3LY5cm7rb1W5s4XKEhBaQeQwV5wOo8fEUElSob8q9PYdPt604abS84e+N+4hW3ao8+STuTg9DuHmKzLdd7bcysW24RJZQlKlBh5Lm0KGUk4PQjmPOgzaVGK1BZkmUFXa3gxBmRmSj8yOmV8/d+usORrPTTESVJVfbatuKwZToakJcUloAe9tSSSOYxgc8jHUUE/SqK32q6VfftjUSW9I9pR3pMdSGFAKQ0VhWd2CDltYGRzxWbYe0LT140l+UglmFaQ6WS7MAbwoHHmfE0FtpWBOvNsgRWZM+4w4sZ7HDdfeS2leRkYJODyrEVqmypvYtKp7YnGH3/bg7OBu279+NuMjzoJqlRrV/s7sByc1dYC4TZ2rkJkILaT5FWcCombr/S0O42qC5eYrkm6OBuImOS8HFFQSOaAQnmQMkgdfI0FopVYd1taWtdJ0m53gXRUcydxQOEEYJ5qz5A+FSkHUNlny0xYN3t0mSpJWllmShaykdSEg5x60EnSlKBSlKBWrZ/Z7e1dsatYW+6RGITzSGH2FIJcU2EJSoA4wCSkc62lWudadqcfTGqW7Iqy3CW4pKDxkKQhBKuiUlRG5XoOdBA9mXY9L0dq5u6P3KFJjR0OoaLccped355uKJ8AfDyFQy+xC8J1hcr8xdbbvkXXvzTTzBcSGytaiCFAjeMpwfpq3P9rkX8p5doi2W5PMx5aoC5yEgtpfHUFOc7QfGqzpntxc/IyBcL5blTLpOmPx2WIQDaSltKFEkqV5LH00RkaQ7E3rJq4zplwhS7aO8cjHPeHQ6kpKVqJxyBPMevnUNbPg8vIs97iXG8suPvtoagPIQohlKXCshQOOpx09anrr2+2yAtgKsNyUHIYmEKUlCkAqKSCD6jr48qkrp20W6K7CRBsl0uBegtXB3ghOWWnCAnIJ5nmOQ86CmRexS8WWy6lnSJrFxub9oNvixobZSFYQhIJKsc8IH15Nc9O9iFyVp95yXJt8eXLtbEURVRilIVvQ4vjFKsqUCkp3D0PhV2Z7Y7ZI1emyRLTcnm+9JhLlBKQEOq80Z3YB6n0Nctf9r9u0feJ1uVap092Cw29IW0UpQ3vUAkEn+0OePED6A4aM7Np1h7NtRadkTIC5d0aebQ4wyW2297WxOfFWPM8/pqtaD7Dn7DqG0zLu/ap8GPEdjyoxZKg+pS3FAkKGDjcjr836Kkrl2726C5LQuyy1mPbo1xOHU+8l4MkJ6dRxx/0mpDRHaPN1J2ozbGWGWrWm0MXFkbfzoU4hleFKzg/7XHTwoIrW/YxIv2t3LzCuEFmHI4AWy9GKlsJbSE4awcAEAcuVduluyObau0V/UEqVaVwlrfWWmoxLjnEChzKidvJfPbyPlzrvb7dLO65JKLTce7BmS7FkK2hMrgJKlgc8p5DlmsqJ2wx3dIMX9/T9yaZmSURILQUhSpTiioYSc4AGw8zQQ9t7NLxpXsg1fpxl9q5uTSt2IhhJSskpSnBzyz7o/fUHYewu4P6ald9uEeBLm2piKhlmPt2LCkOq42D7ytydpI8OfpVihdvVrlNp2WO5GSuYqI3HSpBWranKldQBgEcvWuDHb3b3rbZ5iLFOV7SmuwkNpdRuSpAa588A54w+ygibZ2H3WLD1K07OsyzdW2UobQwtDSChwLI2gggcsDBzVjs3ZTMjdkt60lLuEISrg7xUvR4+1CMFBSCORV8gZJ58/HFRFp7bl3/WOmotqh8G1zm3jKbeRueStAWcJIVjokeHjUjG7drYuFc5UqxXOMzCbC8LU2VrJWlCUlOcpJKs8+WAaCss9hF7TGvbbt4ty1T7XHgNqShYCC0uOckc+WGCPpI5CrZ2Wdlk7RmqZlyfmxHI0i2NQuFHSpJ4iUthS+YxzKFHz96rHpTtATqPTl5uTFmnMSLYFb4rpTl0hJVhChkHOCPpqmxPhBWWTGekItE8tMsIcWUKSSHVr2pa8snrnPQGgiYXYBKaVNQ7fIwa7q/HYcajFLjpcJIU+c+9jP7h5Vk6Q7Eblapt3Vc7rBeYn2VdqHCaVuQopQkLweRxsz18ulZmrO2p+Jod682WzludFuQt0uNP5hlW1Sv6CufTH21YbP2pt3LWEywM2WWswQFypaFpLbaNm4rx1xnA8etBTLD2J3yBPsLsm7W5xq1xJMVIQhYKg7xiD08C8fsq5aI0Le9J9mhsESXanrkJCnUuyWFOMbSoHBTyOcCuege1iDrK+pt8S0XGM262t1iS6ElC0pJBztJ2nkevlUez20w1OaicdsVwTAsa1tyZSVoUncFFCAByOVKGB++gyO1bs4n6zeskuJNt6JMBpxpxmXHLjC96QCoJ8CCMjPp5VlXPswiTuzf8neJFaughoie00Rkhe1Lgc2DxCCofJz0NRP8A42RRpubd3NPXJtqG+y28lSkY2Og7VhQ5HoAR6iuK+3G2+yWpzNmnPCVNdhwkJWkd44YBUsE4AT7yfrPpRUPH7FLi3oy5Wpc2zKkzJbL+wRlpZCW0rSByIVuO/OfTHjXJnsVuceHpJ1m6WxNyss5UtxSYvDbcBU2oD3epHD8QM5NZt07e7bAXCBsNyV3mEZu1SkoUgBS0kEH/AIZOfIiu28du9rtyomy0THkSbam4pVxEpIScjaR58qIz9V9mMy/dok2/C4ssQ5NqctxQEkuoK21I3Dw5bs9aiOzDsguekNbRb3Ln211lqGYxaisqbJOAAo+BJxknxJraulL03qLTluu7LSmUTWEvpaUQVIChnBqVopSlKBSlKBVTvvZ3pS/X1N5u9nak3FO386pxYB29MpCtpxjxFWylBU3uznSb2ol31yysKuq1FxT25fNXztudu71xnPOsY9lmizYm7OqxtKt7byn0Nl5wqStQAUQvduGQkcs45VdaUFHl9lGipZRxrE3hEcRUhD7qAGgc7cJUB1556+tdtw7L9G3D2f32xMPdwZTHj7nHPdbT8lKve94D+tmrnSgqi+zzSa9RN31Vkje1G1BxLw3ABQ6K2g7SR54qO7S+zCya6ivLkNoi3daEtouCUFS0JCwrG3ICuQI59Mmr5SgoJ7JtJS7fCZvFrbnymILMFckrW0p1LSUgEhKhg+4PXHLOKm7LonT1kvarvbLeGLiqKiEXuM4rLKEoSlOCojkG0DOM8uvWrHSgp47M9HJlz5KbDGS/ObW0+pJUMpWCFhOD7uQTzTg86xNVdmlqvGgGtJ25arXb2HA4yUp4xQdxUflknmVHxz9XKr3Sg1jpTsW0xZ7AbbdWfbKlSe9l19PDwvGAEhJ5Jx4ZOfGpdjsp0XHYgMs2UJbgSFSow7y8eG6rZlXy+f8As0cjkcvpq70oKRa+yrRlrlxZMGypaejBYaUZDqtu8EK5FZByCetfbf2VaJt7M1qLYI4bmt8J8LWtzcnIVgblHbzAPLHQVdqUEJpXSlk0pBdh6ft7cOO6ve4EqUorV0yVKJJ+2oqB2Z6Pg265QI1jYTEuJSqS2pa1hZSSU43KO3BJxjFXClBVB2d6TGml6fFlji0rcDqmQpQJWOit+d2fXOccq7tOaG07pybIl2a2pjyJDKY7quK4vc2kABOFKI6AVZaUFX07oDS+nLu9c7LZ48Sc6ClTiCo4B6hIJIT9QFc4OhdNwWLyzHtbfBvC+JOQta3EvKyTkhROOaj0xVlpQVGB2baSgWO42iJZWW7fcMd6b4iyXMHIyoq3DB5jB5V9kdnGkpOnIlifszK7XEUpbDRWvLZUSSQvdu5586ttKCkSeynRUkscWxt/mIxiNhDzqAlo7iU4ChnmtXPrz619n9lei57ERqXY2nERI4is/nnQUtA5CchWT1PM5POrtSgr+n9G2DT00y7PbxGkGOiJv4q1fmkYCU+8T0wOfXlVgpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpXxxaW0KW4oJQkZKlHAA8zQfaVpXWnwhdOWWS5Fssd68voOFONqDbIPooglX1DHrVMV8J2bk7dMR8eGZivwUHp2leYvjOzv2Yjfe1fhp8Z2d+zEb72r8NB6dpXmL4zs79mI33tX4afGdnfsxG+9q/DQenaV5i+M7O/ZiN97V+GnxnZ37MRvvavw0Hp2leYvjOzv2Yjfe1fhp8Z2d+zEb72r8NB6dpXmL4zs79mI33tX4afGdnfsxG+9q/DQenaV5i+M7O/ZiN97V+GnxnZ37MRvvavw0Hp2leYvjOzv2Yjfe1fhp8Z2d+zEb72r8NB6dpXmL4zs79mI33tX4afGdnfsxG+9q/DQenaV5i+M7O/ZiN97V+GnxnZ37MRvvavw0Hp2leZWvhOyt442mGdnjtmHP/ZWzuz3tm0zrKQ3CSty23RfJMaVjDh8kLHI/RyPpQbMpSlApSlApSlApSlAzXnT4VOvH4aWNJWx4t8dsPzlIOCUE+63n1wSfTHnXojdXiH4QynFdr1+4ngpoJ/s8JGKDXOaZr5Vp7LpEWJr+ySLg4y1Fbf3OLeUEoA2nqTyH10RV80zW6XxpHUepHJNzfiOoTbYxipckttqfUSeIXlBTaQ4nJGMjIAOD0qFs1r0QZDkeUpl5uReJENuQ5O2GPGDaSh3AIB94nCjyPP6g1hmmavV2tunWtMQnYQhqKmWFOSxcMyeKSOKgx+fJPPBwOQB3HOKsMqyaFbns71QkR0rk8JLF04nemEx1qbW4c/mnC4EDbyyVEbeXMNSZpmtv21Wl27bemIEK0KcuFojSUsSbiUJbdDg4jIWpYwRt34J3eHMcqirTb9FuzdORJgZQHbcZUuR3w4XIwvayr3glsZCc80nn1Gc0Gtc0zWybtb9HW97UjrDbMvu8eMYcfv3u8ZZw5tKFHeE9cBSseZrF0JY9O3O3W9+7SYLS25shM1MiaGVKZ4KSztSVAn85v5p+vlQUDNM1sBuBpRekEpIYTd1WlUwyO+HcJCZBSGuHnGSjnjGehHr90dZNOT9IS3LrIhN3RwSRHWucG1oWhoKaBQVAAKVkZIUD0ynHMNfZpmtovW7Rq9R3aLb40FxENhsRESLoW2ZayUlxRd3AApBOEgjOPE13aeTpRdqTaLoISoz9/dbSvv2DGZLKQHQvCSpII5FQCTz5UGqSCnGQRkZGa+ZrcFmmWVTciG97OuLz+moyGzPuJbQl1LiCpkLK0hHIE4yCNuB1IOE7ZNB/kvbH1TQh5zupffbkJLoUpYD6S1vJwkFWDwx0HvKzzDVmaZrbFn/ACdsnaPYnVQ7O1CLriFFu6GS0lPRt1ZzhJ68irHmlOOfy22TRj1oubt0MKNcEuvhTUe4JUmOlLYLZaJd/OblZ6Bzy93rQaozTNfW9vETxN2zI3beuPSr6r8mPyEm8Tv+/iH2dxuFxONy3fJ58PGM58cY55oKDmuTbim1pW2pSVpIKVJOCCPEVwpQe2vg/wCuXdaaLHtBe+629YjyFnq4MZQv6xyPqDWzs15a+B+t0X3USRngGM0Vf2go4/cVV6h3CiuzNM117hTcKDszTNcN1M+tBzpXHNfc0GKV15r+FRo14zI+rIDRWyUJjzdozsI+Qs+hB259B516Z7uj1+2uuTb40qO4xJbS6w4koW2sZSoHqCPEUH5wZpmvZk34Pmh5Mpx5DM9gLOeG1I91P0ZBOK6fi7aJ87n94H4aI8c5pmvY3xdtE+dz+8D8NPi7aJ87n94H4aDxzmma9jfF20T53P7wPw0+Ltonzuf3gfhoPHOaZr2N8XbRPnc/vA/DT4u2ifO5/eB+Gg8c5pmvY3xdtE+dz+8D8NPi7aJ87n94H4aDxzmma9jfF20T53P7wPw0+Ltonzuf3gfhoPHOaZr2N8XbRPnc/vA/DT4u2ifO5/eB+Gg8c5pmvY3xdtE+dz+8D8NPi7aJ87n94H4aDxzmma9jfF20T53P7wPw0+Ltonzuf3gfhoPHOaZr2N8XbRPnc/vA/DT4u2ifO5/eB+Gg8c5r6Mk4HWvYvxdtE+dz+8D8NSumexDRmn7o1cGIkiTIaO5vvTu9KFee3ABP00EV8HTRz+lNGrlXFotXG6KDzjahhTbYHuJPrzJ/9WK2vvru7sj1+2ndkev20V07/Wvu/wBa7e7I9ftp3ZHr9tB1b65Bdc+7o9ftr7wE+tBxSquW6uK2ykZHMVw3UGVSlKBSldchzhMrX5DpUmcRkdlKpPtt9qUVrUtQ5+7nln+VfO0O93O2P2CPa1vIVOecQ53eOH3CEtlQ2pJHiOfpXg0H/pWdO1tlxp4t7+j12Ma31Xela2ja8uduhRmr7aszI7LLlyUHEoLfFcKEbUc9x5ZIB5dKI7UEBi5l+2KZkRnENtMKcO5ze7wwT7vTODkbvtr6DBsmlUGHr2TLuNmiM2kF2eVBxBkYWwlCilSyCn5PLkeWc9KkLzrRFr1CbQ7CWqSooWztV/tGilRWvp/R2HI+jzoLdStbHtNcEFx/2K4pamWpUdCHwve04raFKwCUkeIAJqde1igaRgXmNGD7k11thpkO4SHFq24KscgDnPKgtlK1yntNQIU15227FxY7z5Rxwdxbe4RSDjxPPNcne0oiTdUMWd99uGHg2pCjlxbSwlQPLAyTywT06UGxKVq6V2iTpMeI9BisNsuQ5zr54hK2nGEjAAIHzgcEDr6c85ntFw43vt6lxdxjF/igLU+GeKRsxkJxyz/pQbDpWtl9pchFtcfXY18YIjPIbQ9vHDeCiFHCc8tpyADUtqDVhb0ZCu1vKA9N2cIBeeZ5kDkd3QjkM/RQXOlUufqaVMsWmZ9rxHN1kNtlLg3bUqQo4+0Cq1edaXmzQ7vClzIpurciNEju8L3EqU0FuLKRzIHvH7KDbNKrGndWxZ+j7fepRWnjJCHEtNLcKXRkKGEgnqDWXF1Ta5UlthlcouOKCU7obyRk+ZKcD66CcpWtdS6mvDEvVMiHcIkRiwhvZEdaCjKy2Fkk5yAc7RjxFZyu0HhpuUl62lMCFxEKXx0h1TiEJWpIbPPHvYz6Z6UF8pWsZmvroq5QYce3MtTUyizIjqkJKFpLBcSQ5jl68vCsiP2moliO9FtazEV3dDy1vBKm3HvkAJ6qGepoNjUqk2fV81WgWtQ3OE2VBw8ZDK+SWw4UlfTwHPHpWDJ7StkfvDFqU5HQyuWtSnwj/wAsHCgLSCPeJxnHlig2JSqG72hthoqatzjq8zAG0uAKPAx/3Z+qpzROpE6mtK5fBDDrbpacaCiShQAPPIBHIjkRQWCsBZwojyNZ9Rrp/OL+k0ElSlKBXxaUrSUqAKT1Br7VX7RbvcrNYmn7S3lxchDTjuzeGWznK8fUB9dBJybFEkSw+oEHOSkHkaznokd5+O+8y2t6OSplak5LZIwSD4ZBxWs42r9RKu1iYkJQmNKZbXMdTFWQws79qcnpxMDqPd+sVDw9WX+/WmMVOqfQ53F9xceMtngOGSgKbz/SBRkk+XoaxtaNaszVVbpiJq3z93dVyquIiqc4bam2O1z57E2ZAjPy2P8AZOrbBUnnkYP010I0xY0JlBNqhgSuT44Q/Oc88/r5/TWrJWs79Z7M0oLTFCGXHWw9GW6ZDhlLQU7ifd2oCVc/neQqVuut9QR1ymIUQvzGHJwU33ZXJKFDgnPjlJzy64rZwvf5Jaf7xHf9jQONHADK+CncgA5GD4c+dSTsCI7NamOxmlymkKbQ6pIKkpPUA+RqjwNR3xfZ1d7otLbtxjcTuy0snDoAGCU+PPI5cuVRly1TqODx4sl9plLcstG49yUtITwUrSNgPiolOfTzoL03pWwtx5DCLTCS1IUFOpDQwsg5BP0VlOWW2uWkWxcGObeAAI+wbBg5HL6a1bB1Fqx25O73jHkzFQUpjuRVKQwlxB3qAz4H1+mrBpDUWoJ+sZtvubSExWi6nbwShSNqgEKz0IUMn+HSgm7foawxIQiu2+PKbQ46tvjtpVsDitxSOXTPh6VJL07Z3H5Ty7ZEU7KTsfUWhlweR8+g+ytZ3vX9+h3C+8BA7rGbdLRdilJbUhxCQDg88hRPM5PUAUla5vjRYaM1puO6/KQ1OMBZ4yUNoUnDfX5SinPjQbJGmLGGGGRaofCZ38NPCGE7xhf/AFDr51zGnLMJxmC2RO9FvhF3hDdtxtx9nL6KoCdU6rVbLhPkttxEMuRGFNGIpZj8VtlTjp55UEFa+X29K4M6x1AtEDvToix1F7ZLFvW4JpS6EoAQOaNyST/Cg2C/puyyGS09bIi2yhDe0tD5KM7B9WTjyzXbJsdrlW9iDIgRnIbBBaZLY2ox0wPCtXxr/qmzxZqmELnJdVcXGWXGFFTZbdGz3s5IIUeXkOVXHQWopNxhNtXlxCpjrjnd1IaUjito25J5YBG7HrQWNu1QG40WOiGwliKoKYQEDDRHQpHh1NfPY9u9o9/7jH77ndx+GN+cbc5+gAVraTra/RL3qCO+2pbEdtxUcsRCvh4UkAqyUnofUHqDgV0M6v1ZKtgUzw23mmZrqlmIVcXg7S2McsbgfDr4UG14cONCS6IjDbIdcLqwhONyz1UfU131rfTOq73N10q3T2h3FxsqQG2COHhCVe8TgjmSM8wfCsG46uvTl/u0CM4h5tmTIjGKiMoKS0GCsO8QHqFYTj1oNg3DTtnuNwanTrZEkTGsbHnGgpQwcjn6GuTlgtLk96a5boipbyC246WgVLSRggnxyOVaptmotQwW5AemOttrVBSVuxVuiGypjcpYHj7w2nPicmpNq86gbvjlwYfW7GWm2IcaXFWlLodcUhakpJyjAO4/VmgvQ0lp8QkxPY8HuyVlaWyyMBRGCfpxyrIOnbOZseX7Nid5jpCGXOEMoSOgH0eFUPtTvF5ZmPQITrkaPwmHGuEwpa5Ci8AsBY+TtSAfrqR0RqK/XXU1xiXNlDUZvi4b4RSpkpc2o59DuTz/AIcqC5RrTb4sF2FHhsNxHSouMpQNqt3ysj1rHlads0oQxItkRwQwExwpoENAdAPIchyqhTtV6rZjXlKIQ4lsKWFu8AkOKW7ycSPEJbwT6n0rGVqzVi4CH2+CCzDVJURFUrvBD+wDwxlPPl9I5UGxVabsqpT0lVrhl97cHHC0Mr3DCs/SOtZVqtcG0xjHtsVmKyVFRQ0kJBJ8T61qN/VWqbbGlJaeU64blKSXHoxIaCcFtv6FZ5Y8uVbatE9M+MSRtkNbUPo2kBK9oUQMjn1HOgzqinf9qv8AtGpWop7/AGq/7RoJWlKUClKUHwgEEEcjyrpgQ48CGzEhtJZjspCG20jASkdAK76UGPcIMa4xHIs5lD0dwYUhYyDzzWRilKBihAPUUpQMDypSlBjz4Ma4RHIs1lD0dzG9ChyVg5/0r49BivS40p1hCpEYKDSyOaNwAVj6cCsmlAwKYHlSlArrLLReS6W0l1IKUqxzAPUA/UK7KUDA8hTFKUDAzWPEhRoi5C4zKG1SHC66Uj5ayACT68hWRSgYHlSlKBTFKUCmKUoGB5UpSgVGOgcVf0mpB1wNpJPXwFYBBJyfGg4lx756q+cV756vtrv4dfOHQdPFe+eqnFe+equ7h04dB08V756qcV756q7uHTh0HTxXvnqpxXvnqru4dOHQdPFe+eqnFe+equ7h04dB08V756qcV756q7uHTh0HTxXvnqpxXvnqru4dYF0ntQEYI3unogf60SqqKYzLJLzoGS4oD6aw3bwy0cLljPoc/wAKrE2bIlk8Vfu/NHIVibKmXjq0v2wtov8AGJx3pX1pP8qy2J4kD8zIC/QHnVH2V9CSDkcj5imXMaXV9YX3ivfPVTivfPVVatt4dYUEScuNef8ASH86tDJQ82lxpQUhXMEVXrt3abkbnDivfPVTivfPVXdw6+FAAySAPWjR1cV756qcV756qLfjo+W+0n6VCsddxgo6yEH6OdczXTHGXcW66uEMjivfPVTivfPVWCu8wU9FrV9Cax1X6OPksun6cCuJv24+rSNFvTwplLcV756qB1756vtr7FWiTHbeQMJWMgGuEyTGhMqelvtMNJ6rcWEpH1mtInO+GMxMTiUhHfC04VyUOtdTz6lKw2SEjx86rsfWGmn3wyxf7S46TjYmW2Tn6M1YG9q0hSSCDzBFVHEAqOVEk+tdm2uaU1z20H3ZXzZXbimKDq2U2V24qOuz7qXYkOMoodlKILgGS2hIypQz49B9dBmbKbKjDpu2q5utOuq8VuPrUT9ea+fkzacZ7ry/4q/50EpspsqL/Jm04z3Xl/xV/wA6fkzaf0U/3q/50EpspsqM/Jm0/op/vV/zp+TNp/RT/er/AJ0EnspsqM/Jm0/op/vV/wA6fkzaf0U/3q/50GTcpKYURTquauiR5mqO+tb7qnHVFS1HJNWxzSlmcADkIKA83FH/AFrr/I6w/q5v/qV/OpMPPes1XJ47lU2U2Va/yOsP6ub/AOpX86fkdYf1c3/1K/nTDH0c81U2U2VZJ2kYKI612pCoslIyjC1FCj5KSTjB8+tVdl/jwUSEApC2wsA9RkZqMLtmbfFyablSSoQIMiWEHapTe0JB8sqIBP0Vlx06hjpKGLVNQ2eZHFZ6/wDXVt0u0lrTlsSgYHd2yfUlIJJ9STXS1e3XNWv2U2uYlpuMJAnlP5lRJxsB+dSqnWjD6Gj2os1RXG+furK06hX8q2XA/wD87X/9ldKod6Ucqs0wn1eZ/HVsiXt2RqqdZ1WuY01GZQ6mctP5l0q/opPmP9DU1isZ0aieOX0Y065TwiOjXHcbx+pZf96z+Oncbx+pZf8Aes/jrY+KYqektuv1G99muO43j9Sy/wC9Z/HTuN48bLL/AL1n8dbHxXFfIGnpLZ+o3vs1pqvXcXQ+jHJNwZWm4oJbZhuYCnFqyRzHLb1yRnpjryryPrDV151bclzL3MW6SSUNA4baHklPQfx862b8Ky6OydcQbeT+YiRAtI/rLUcn7Ep+ytcdnumEaqvzsWRJVGhxYzsyS6hO5QbbTk7R4k8hXopjViIh466prqmqfqrOa2R2V9ql20VOZYfecmWRSgHYq1Z4YzzU3nofTof31h6CYsWodUtadk25aINxUWYslSwZMZwj3VFSQkLGeoI6Hkaplxhrt9ylwnSC5HdWyojoSkkH+FVy/Q2z3CNdbdGnQXQ7FkNpdbWOikkZBrOxWlfgsXV6b2fORHlFSYMtbTefBJAXj7VGt10H2lKUComf/vFaf+G//wDJUtUDfY65N8tKG5L0Y7HzvaxnojlzBoJe4RUToEiI6paW321NKKFbVAEYOD4HnUTB0xDh6P8AycbelKhd3VH4inSXdqs5O7z513+yZP65uH+X+CnsmT+ubh/l/goMf8l4f5G/k3xpfcu7d14nFPF24xnd51J2iA1a7XEgMKcWzGaSyhTityiEjAJPieVYnsmT+ubh/l/gp7Jk/rm4f5f4KCWpUT7Jk/rm4f5f4KeyZP65uH+X+CglqVE+yZP65uH+X+CnsmT+ubh/l/goJalRPsmT+ubh/l/gp7Jk/rm4f5f4KCWpUT7Jk/rm4f5f4KeyZP65uH+X+CglVfJP0Vq6GsLssUpQlAEZI5ePu9avarTJ2n/7ZuHT/wDb/BVEt7i1aehNrWVJbjgJz/ZqS8ml8IW7T98hosNuSRLyIzYOIjp/oj+rWf7eheUv7m7+Gu3Tn+79s/5Zr/tFSFV60V7eheUv7m7+Gvvt6F5S/ubv4alKUEX7eheUv7m7+Gnt6F5S/ubv4alKUEX7eheUv7m7+GuDl9hEdJf3R38NS9fFDIoPJPwoYAe1Dbr3GQ/3d5nuzhWytAStJJHygOoJ/wCk1qjSeopul7ym4W8NLUUKacaeTuQ62oYUhQ8iK9r9pGnYWpYcC13NvfGkSVJOORSeC6QoHwIIzXlvXPY9qTTcpxUKK5dbfklD0ZBUsD+sgcwfoyKCG0nqOzacvLl/YgvLuLO5UGGVZYZWRgLUsncrbnknHlk1UZD7kqS9IfUVuurK1qPionJNSMfTt6kPhli0XBx4nGxMZZP8K3F2W9h06XNYuOr2+7xEKC0ws5W6R8/HyU+nU+lBs/4Ndhes3Z4y7JQUO3B1UoJI5hBACftCc/XW36xYUdLDSUISEoSAEpAwAPKsvFApSlAqJn/7xWn/AIb/AP8AJSlBK/0hX2lKBSlKBSlKBSlKBSlKBSlKD4r5J+itV27/ANiRv+XT/wBtKVJePTOENi6c/wB37Z/yzX/aKkKUqvYUpSgUpSgUpSghb7/7Qsf/ADiv/gO13yAOfIUpQYwAz0FZscDypSgzU9K5UpQf/9k=",
+              "timing": 4200
+            },
+            {
+              "timestamp": 4958427788,
+              "timing": 5040,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAFMQAAEDAwMBBAUHCAYIAwcFAAECAwQABREGEiExBxNBURQVImFxCBgyUoGR0hYjVZOUodHTQlRWYqKxJDM2cnSCssEXc5I1U4OzwuHwJzdDRMP/xAAZAQEBAQEBAQAAAAAAAAAAAAAAAQIDBAX/xAAuEQEAAQMBBgUDBQEBAAAAAAAAAQIDEQQSEyExUZEUUpLS4UFh0RUycbHBYqH/2gAMAwEAAhEDEQA/APVNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFK+KUEpKlEBIGST0FV5rXGlXrh6C1qK0rl52hpMpBJPl16+6gsVKEgDJPHnVdOuNLJn+hHUVpEvO3uvS0bs+XXr7qCxUoCCAQcg+NRV51Da7KtCbrK9EQvGHnW1BofFzG0faaCVpVC7a5X/6SX+TDf4MdKkOtL6gqTyCKljq/T1miQI13vluhylMt/m35CUq5SOSCeKCz0rrjSGZTCH4zrbzLg3IcbUFJUPMEdahbvrHTdnliLdb7bIknOO6ekoSofEE8fbQT1K6okliZHRIiPNvsODKHG1BSVDzBHWu2gUpSgUpSgUpSgUpSgUpSgUpSgVxUtKepFcH1lIwOpqDuN+tFsfDFxucKK8U7gh59KFEeeCfdQWBKkq6EGvtQlru9vugWq1zo0sNkBZYdC9pPTODUw0vejPjQc6UpQKUpQa37cH3l2ex2hLy48S8XViDLcQdp7lRJUnPhnGKscvQumJFhVaF2WAmDsKAlLKQU8Y3BWMhXv61mau07B1VYn7Xc0q7lzCkrQcLaWOUrSfAg1T3dF6zkwjbJWvFqtqk92taLehMlSOhHebuuPHGaCiG+3J/sPhwVTXShy8CyKnpVhS43elO/PvSNua24jQOlU2P1SLFb/QtmzBZTu6Yzu67vfnNc3tE2R3RI0qYxFpS0GkpB9pJByFg/W3c586rSdE60RE9XJ1+76tCe7Cjb0GTs6Y73PXHjjNBDdoMqToTsUMfTt4ellt1MNE5SwpbLalkEbh4pHsg9RWxdP6ctlv04i3NtCRHeZCX1vHvFSMjlSyfpE5rrt2jbJC0enTIiJetPdltbb3tFzJyVKP1iec+dYqtPXS2WUWfTE9MaNs7tEiatUhyOnphCeM48Nyjig0rHfdj9kXahYEuret1mnLjw1qOdrfeD2M+7H763PonSlmh6TiNmLGnKlx0OSZLyA4qUpSQSpRPUHPA8BUeOzOBH7NZ2koElxv00FT8xxO9bjhUCVqHGc4xRvR2o7TE9A0vqluFbQna2zKgiQqOPENq3DjyCs4oKpp+W9pD/AMUbVZCVQLO16ZBa+kGFraUtSB7gRnFWnss0lY2dDW2SuHFnSrjHTJlyn20uLfW4NyskjkZPSprRejoembPKiF1yfJnOKenSpABXJWrqVe7HAFV2FoLUOn0OQtIat9Bs5UpTUSXCTJMfJyQhRIOPIHNB0dnzLdg7T9WabtY2WZDLE5tgHKY7i8hSU+QPXFbQqs6I0ixpdmY4uW/cLpOc76ZOf+m8rwGBwEgcADpVmoFKUoFKUoFKUoFKUoFKUoFKUoMeSPaB91VHUouZuCfQRfC13Yz6CIezOT/772s/uq6OIC04NYymlg9M/Cgr+lhODcj08XQHI2+n+jZ/5e54++rLGHsH411oZUTzwKyUgJAA6UH2lKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClK4POoYZcdeWENNpKlKUcBIHJJoOdKq8HtB0jPmMRIWorY/JfWG2mkPgqWonAAHnVooFKrF71/pSx3EwLtfoMaYMbmlucp/3sdPtqxRJLEyM1JiOtvR3UhbbjagpKknoQR1FB20pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgV5H+ULq7Udp7UrjEtd+usKKhpkpZjy3G0AltJOADjrXrivFnymf/3eun/ksf8Ayk0HpbssnzJ3Y9aps2U/ImLhuLU+64VLUQVclR5zxWmfkxapv967QZka8Xu5z46ba44GpMpbiQoONgHCiRnBPPvq4fJ/7QrJdNP2fRSWJvrFqK4HFKQkNEAknCgrPQ+VWWZ2dac0PpzUl20nbnIt09VSW0OCQ64fobsAKUR1Sn7qI7rn21aIt99FqduanHg53TjzTRUy2rOPaX0wPMZqPvPb1o603WXb3xcnHYzqmlLZZSpCiDjKTu5HvrypoNnTMi+lGtZc6LbO6UQ5ETuV3mRgHg8Yz0B5xUPd0w03SWm1recgB1QjreAC1N59kqA8cYoPXs35QWjYcx6M83du8aWUK2x0kZH/ADVL27th01cdaNabh+lOSnCUh8IT3QIRuIJ3Z4wQeOorxnqf/aK5f8Qv/OvSeouybTmnezmfqKzNTUXVq2KdSsyCQCtvCzj4KVQWS+fKA0XbJzkVlc6eW1bVOxmQWyfcVEZ+I4rOtfatpbWtlu0O1SnWp/oTyhGkt7FqAQclPUH7DmvKfZy3o9y6yBrt6e1B7k9yYgz+cz/SwCenT39am9Jp0e3qNC7bN1H6VvWIqTHaCSCCAFkKzjHUgdM0Fd7NJTMLtC05KluJajsz2XHHFHASkLBJP2V6d0p2/wCnb7qRNqfiSYCHne6jyXVBSFknCd3inPHn15rzD2aRWJ3aFpuLMZQ/GeuDCHGnE5StJWMgjxFO0eOzA7Q9Rx4baGGGLi+hpDY2pQA4cAAdAKDbPavD7LkdoN2Td3tSRrl32+UiGhtTSlqAUSkq5Gc1EdrutFWp/T1p0HdbzbLZEtbKu7RIW1uDiQ6gnarlW1Yz781S+191b/aHc3XVFTjiI6lE+JLDZNWDtuisM2zs/faYbbdf09FU64lABcIQkAqPiQABz4YoNt/J37Ro8jSN0Y1Pd5TkuAtUp6XOdK0paVtSkBaiTnIPHv8AfU8/8oLQrUsspkT3UA475EU7D7+SD+6vNEi4W1HZHDgxlRk3Zy6uOSQlIDqmQ2Nm44yU7irAz1rHsls09J0pMlXGe3HuaFkISZCtxHGNrQaO7494n7KD21Y9ZafvlhevNtukd23MAqedJ291gZO8HBTx51ryf8ojRcaUpphNzlIScd60wAk+8blA/urQEJqBA7PdTCxahkzVyG44lxDCUylKQ8nCisqIPJxj3+6sDQDehXIF1Ot37o1KCR6GIYyDwc+B5zjrgUHquH2uaWvOlLvdLbMeKoEcuvRy3tfQDwCATg8kcg15Z0v2k6khamtMq66kvr9uYltOSWjMcXvaCwVJ2lWDkAjB61bexOJpKRqsx4rt5lSnochC48qK16O4juySF+0TjIBHHUCtY6KXCa1lYl3YM+rkT2DJ75IUjug4nfuB6jGcig9b3rt30jZ5qYstu6F1TDL42R0kbXW0uJ/pddqxn31Jak7X9N6etNjuM9FwMe8MGRG7tkKUEjb9Ibhg+0POvLHbfLt87tLukmyLZXbFtxxHUwMN7EsNpASPADGPsqa7YJsaToXs0ajvtOuM2pQcShQJQfzYwfLlJ+6g3q58oDRyIDMxTd17l51bSf8AR05ygIJ/pf30/vpJ7f8AR7NoYnoTcXA8+tkMhpIcG1KSVEbsBPtgDnk58q8mSv8AZK2f8bK/6I9bp7Aey3TWttGSrlfWpS5Tc5bCS0+UDaENkcD3qNBuXUna/pDTzMYz561SX2kPCKy2XHUJUkKG4DhJwRwTXTpXto0ZqSe1BjT3Ist0hLbctot7yegCuU592a8fORmF61ei3hamo4mLaeUtwoKAFEYKtqiMYxnaceVTE6zaSb1AtlGpFQ4adpS4wyuaEnxwva2T/wCmg94UrBsS+8sdvWX1ySqO2e+WgoU57I9opPQnrjwrOopSlKBSlKBWmO0vsNRrfV0q+Kv6oRfQ2juRE7zG1IT9LePLyrc9KDTnZj2Io0Lqtq9JvypxQ0tvuTE7vO4Yznef8q3E4hLiFIWkKQoYIIyCPKvtKDR11+Tjp2XfRMiXCXEgqc3uQkpChjPKUrzlI+Oajb18mqFNu0uTC1AYMV11S2oyYW4NJJ4SD3gzjzr0HWFfHpsezTnrTHRJuDbK1R2Vq2pccAO1JPvNBoa5/JranXGTK/KlaO+cK9voAOMnpnvK30zb2haEW6QlL7AYEdYWnhxO3acjyI8K0DovWXa9N1pCi3ayui3uPhMlLsHukNN59ohfuGccnPvrf15uDVptE64yMliIwuQ5jrtQkqP7hQaQvvyarJLmLetF5l29pSie5W0H0p9yTlJx8c1P6J7C7FpdciT6XInXJxhxlt95ICWd6SkqSgeOCepNaVufyg9ayri47BdhxIxUS2wmOleE+AJPJPv4r1Voa5yLzo6y3Kbt9KlxG3ndgwNykgnA8KI1DpT5O7dg1Na7uNSrfMGS3I7owQnftUDjPeHGcdcV81V8ndu/6lul3OplsGdJckd16CFbN6icZ7wZxnrit91r/tlvGr7Np9h7Q9u9MkqcKX1pb71bSccFKPHJ8eceXkVRtV/J5b1BfX7kdSrjl1Lae7ELdjY2lHXvB125+2rlqnsls+ptHWSyXJ90SbRFbjR5zSQleEoSk5ScjB2g4/fVZ7N9d61jWK/3btFtUhFst7Aebd9GDLy1Z5SlJIBGOc8fGprQ/bbp7WOpotjtsG6sypIWULfbbCBtQVHJCyeiT4URXtM/JzsttkSlXe6P3Nh5lTQa7kM7CcEKB3E5GOKjX/kx25UoqY1JLRHzw2uKlSsf724D91ehq0xA+URpabc48Fq23sOvvJZSVNNbQVKwCfznTmirVpXsp0xp7S8+xtxVS2LgnbLdkHK3sdORjGOox0PPWtdXH5MtqdlFdv1DMjME57t2Ol0j/mBT/lXoKlBr3sy7J7HoFb8mGt+ZcHkd2uRIxwnqUpSOADx5niqXqj5ONlul0el2i6yLW26orVH7kPIST12+0CB7ua3tSg0ffvk8Wa5Wy2sxrtKizIbAYVILSVh4AkgqRkYPOOD0ArFuvyb7TJtVsi2+8ORH4wWZEhUbvFSVK2843jaBjgc9fvv/AGw3fVln002/oi3CbMU7teIR3i2kY+klH9LnHnjy8q72H6i7QL3Lno1vbVsQW2wWX3Y3cLLmR7IHGRjJzjjHvoisO/JtbctMaD+VCwGXnXt/oA53pbGMd54d3++todk2hU9n2m37Sm4GeHZSpPelnusZShO3G4/U658aulKK1H2idhdi1fdnbpGlP2qe+dzymkBbbivrFJxg/AiovSfydLBabizLu9xkXbulBaWS2Gm1EfWGSSPdmt4UoAAAAAwBSlKBSlKBSlKBXnr5Rfard9O3lrTumn/RHUspekyUpBX7XRCc9OOSevI6V6FrzV8pjs3u9xvyNTWKI9OacZS3KaZTuW2pIwFBI5IIx06Y99Brm5a57RIekIYuM29x48uR6TFuKnXG1OJ2kFAV/ST0UB8fOvsDXOq19nl7lK1JeDJbuUJtDpmObkpU3JKkg54BKU5H90eVQmorvqq6aMt0W9rd9TWp1MSMhxoIIVsOBnAJwlOOemRUlobTk/UnZprBq1MOSZMSXBldy2nctaQmQkgDxOF5x7qIunZBq3UVx0r2hvT77c5LsSzrdjrdlLWWV7V+0kk8Hgciqt2c641VM1SlmXqS8PtehzV7HJjihuTFdUk4J6ggEe8Csbs7b1TBtWsYlrtClR5NscROckNqT3LaUqJx5qPIA8/hUd2YwZaNXIUuK+kegzhktkf/ANR6gn+yrW+qZ/aPp2LN1Hd5EZ6Y2hxp2Y4pK0k9CCcEV6d7aoc2d2Wajatsn0Z9MVTql7inLaCFOJyPrISpOOhzg8V5I7H4MtvtP0ytyK+lInNklTZAHNezO0ZKl9n2p0oBUo2uSAAMknulUHhrQFuud31hbIFim+gXN9wpYk94pHdnaTncnkcA9K2j2r9pmrLfeI+lLXdH2V2xhmLJkR1EuypAQnereRu+lkDoT1PWql2GQpTfaxptbkZ9CBIOVKbIA9hVWT5QGg77a9fTr9b4cp+3TXBIRIjoKi05gZCscpORkH30ERrLXfaNBgWe33yTebTKjoWUvd44wuUg7cFeMbinBGevPPvklaz1N/4GIuP5QXX0/wDKMx/SPS1953fowVs3Zztzzjzqp64i61uMGzXXVip0oS21iIHgStLaduTtA4B3D3nGfKpVUKV835Dfoz/eflOVbe7OceijnHlQZunLpqjVfZjrn0rUE+QmCIr6xKlOLy1+eC0Dr19njodvuqqdk9sul31/aodhnegXBalqQ/3ikbUpQVKGU88pBH21sXsC09OvOje0a1NNKakzIbDbPepKQVfncDJ9+PvrXVlZ1boTVjMqJbJkW8RitCEuRSvO5JScDGFcE8ig9zamiTJ+nLpDtkj0We/Fdajv7inunFJISrI5GCQcjmvz4tbEh+9RI8Z7upTkhDbbu4jasqACsjng81+htldffs0F6YCmS4w2p0FO0hZSCePDnPFeGNV6O1HonVKw/b5OY8jvY8lLRW24ArKVAgY8uKDZXaz2mar0u5C0fBuRRNt8NlufPQSt2Q8UAkhShkDkc9TmqWrXPaZpSZGeuF0vDS3RvQ1PJcSsf7q8/wDamtdK6zv8OPrW4W6TKXcU5kdzGKVNKQdgKkAZCSlKSDjFYtvuWu7vOiMWODKYkNDYlNugJjgnjlZQkAnjqrpQT/an2n6iucyw3C2XS5WlMq1oW9GiyVtoDoddQogA+O37sVi3/V2v/wDw601Pfu0tm2LdebalIlq9IkOBaslas5wB7IGf6Pwrq7brNqCJerEzfnH7hdE2lsyHkp3e0XXTtyBg4BA+ypPVsSSr5O+hm0x3i4mdKKkBByPzjnUUHxztN1RP7IXu8vM1u4wbuw0JjTpbdW04y8dilJwTy3nn3eVVuNr3VytK3F46mvRdRNjISszXMhJQ+SAc9DtT9wrEgQZY7Mr0gxX9xu0Egd2ckdzK/iKj4sCZ+SFzT6JIyZ0Ugd2f/dyPdQW7SN/7S9U2q726xTbxc1FTKnnfTFFbKRvwElSuNx64+rXqXshi3mF2fWuPqb0n1sgLD3pDm9f01YycnPGPGtOfJAjPsS9U9+y41uRGxvSU55d869KUClKUUpSlApSlApSlApSqvftXIs9xXEdhOLIAUFhYAUD9lBT/AJRWjb3rTTlriaejIkPsSy64lTqW8J2EZyojxNR3yb9B6g0SjUI1HERGMwx+52vIc3bO83fRJx9IVsK4avjw7bAliOpz0tJUEBQBTjrn7a5RNXRHLUufKaXHbC+7QnO5Thxk4FXAstKpSO0CGXcKhvhvP0goE/d/964a5vMeXp6N6IrvESV5CwcbduMgj7aYF4pWotH3cWm5OOuNqdC2inAVjHQ/9qtMbX0V19KHYjjSD1WVg448sUwLpSqtadYxpjMt6S0YzUcA5KtxVnOABjrxWGvtAiBwhEJ9SPrFQB+6mBdaVG2O9RLywpyIpQUjhaFjCk1JVApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAqidp8HLcSckfRJaX8DyP8Av99XusO7W9i6QXIknd3a8cpOCMHPFIGlXH3HmmGlHKGgUoHlk5/zNWDV9vct0GzsKBCEsnPl3hOVf5j7qtsbQ9rYkNPByUstqCgla0kHB8fZqfuVvjXKMWJjQcbPIz1B8wfCtZRqaU5ZjYWUR2XhdARvWSce/wAcVkw0O/kRPUoHufSW9vx8f+1XBOhbSl3cTJUPqFwY/wAs/vqwC3xBAMIMIEUp293jjFMjU2nJ7ED1j6QVDv4i2UYGfaOMV06aYak32Ey+gLaW5hST0Iq/r0LaVLKgqSkH+iHBgfuzXbbtG26BNZlMuyi40rckKUkj7eKZENr60xbfaWVwIyWUqeAcKc88HGf31U4areLc8JI/0nPs4Qoq+w7gB9oNbllR2ZcdbEltLjSxhSVDg1Wl6FtKnNwVJSPqhwY/eM0iRGdnIhemyDEEvvQ1hZcKdnUY6c5/+9X2sO1WyJa4/cwmg2knJPUqPvNZlSVKUpUClKUClKUClKUClKUClKUClKUClKUClKUClKUClK1x2i3WQbn6A04pDDaAVJScbieefsxViMjYwWlRwFAn3GvtagdsF4hJjvpQoFzlBbc5Hj5191M9PUm3i5BaJCWSkkq5UNxweP8A84phG3VKSn6RA+Nfa1LbLHdrzbGlx1tmM2tQSFLxzxk/5V9vV0uNyufq9lxYQlYYQ0hWAojjnz5pgbZqj32Nqpd1dVCcX6MVfmu7WlIA8Mg+NVYu3fTVwShbi2nMBewr3JWPf4eBrq1JKMm8yH0KUEuhCwM9MoBqxA27bhIRAYE5SVSQgd4odCayEqSr6Kgfga1PqiRP9HtzbinUwvRGS3gnao7Bkn35qOtsKTIAchy2UPZ4QXti/szj/OpgbqJwMmviVJV9FQPwNao1c7dUORmZynktJZQACThSto3EnxOc1H22FKkBLkKW0l/PDff7F/ZnFMGW6KVqnVd1nrlNQFuuIDLSErSFcqWUgknz5NYd9Zu0GNDjXPclCQos+2CcHGRkH3CmDLcVCQBk8CtMqWv8mkHcrPpavH+4K529E12w3RxmRsjtFsup5yvJIAz5c0wZbjByMivhUkHBUAfea03Zr7MtbUlDDqsON7UgnISrI9oe/GaW613K9iQ/HJdLfK1Lc5J+2mDLctK1ppuVeLQxKdebdXDSypQC1AhKgOD1z14486gVP3C8SVqelblj2vzroQB7hk4+wUwZbppWtNGyrxGujLSm5TsJatiwpJUlP94HwrZdJhSlKVApSlApSlApSlApSlAqja503LnTROgIDpKAlxvODx4jPuq80oNOpsN8kqQ0qHKITwnvOEpHuzxWdfNMz4rcFliO7IUGiXFNJKgFFR4+7FbUpVymFd0FFfiWHupTK2XO9Udq04OOKrGpdL3Fi6uzLY2t1ta+8SWz7aFE56fHyrZNKZVqmPp2+XiaFzkPIzgKekHkD3A8muOorDP9cSBEgyHGE7UoUlskEBIH/atsUplMNcToGoo/cuQUPlhUdkFsEKAIbSCCg+OR5VDCwXqfKKlQXELWeVKQG0j/ACH3VuClMmGubpbNRwpH+iKdfY7tCTtIWkkIAPsn3jyqGRp69T5RUqC4hajkqWgNpH2cD7q2/SmTDW2qNKXDvW5EZJlEtoS7t+luCQCceIOKi5mnbz6LGedYkPLc3Du8FSm0jGM+Wcnj3Vt2lMmGplWa5fk+hr0GT3olKVt7s5xsAzWdZ7VPa0xfGXIb6XXe62IKDlWFc4FbLpTI1HadMXCXIcZfivRwWyUuOIISFDoDXUuwXyItbaYkkbuFFrkKHxFbhpTJhrrTOkJSy+5cklhCmlNoTkFWVDGce6otViv9olr9EafyQU95H5Ch9n/ets0pka80lp66i5Ny5yno7KFbylSzucPvHl55rBNn1F6/37X++7zPpG72MZ658vdW0aUypSlKgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpVO1FcpVruU6G0+vvbmyj1fuOQh7cG149w3Nrx/vGguNKqca8T2w08VRlwUzfV/cqCjIJDnd7yvdgnI3Y2/R5zXTbbvNf7uHbREi7GnZC1yt7gUA8tG0HcD/RySScZHFXCZXKlQmnpomSLg5sRn8yoqbdLiVbmkq9nPGOfADPWolOpLg1ZU3eR6vVHfirkNRgVIdRhO4JJJIVj+kQBj30wZXGlVKbfLrbhJYe9BlSgy280tpCm0Dc4EbVAqUfHIOecHjiuqbe77BTeFverlt2tKXllLawXkFO4pA3ewQAefazxwKYMrlSqg5er0pxDjCLeI7lwXBSlaV7gAVAOE5wfo/Rxz5iuhzUl5MwWxiPHcnodeS48hvKClAbIwhTiTkh0f0jjB60wZXalVBF9vExpn0RqCw76EqU53uXU7kqKdqShWMHGc5OPI00xcLlcdQzXXJbHoK48Z9EYtK3IC0KIwd+M+Z2848KYMrfSqrJvdzRcJ6m0xBBhzmIikqQouOBwNZIVuwCC55HOMcda6ouorgtECW4mIYs91xlqOhCu9aKUrIKjuwr6GCABjPU4pgyt9KqS9STVQ7WqKxHeky7aZhaCtuV5ZAAyen5xXBPOAM1J2K4yblAmBa20TWXC0d0dbYQraCNyFHPiOisEeNMGU1SqPY7nfPU+nmzJgyX53CnltLBbSlsqOfbO5WRjqOtd7OppiriUER3IrqJBZUhpaeW+ntKPtjjnCQAfE0wZXGlU1N/vTbbKXY8R+RKholsoZSU7PbQlaTuV7ZAWCMFOcYqPnvStQTbC245BWhE15t5l+E5jelpSvaQpYwcHjryQc+FMGWwqVVmL5PU6zJV6IYLs5cJMdKFd8khakbt27B5TkjaMDPPFdMW9XuSxa1BNvacuLziEZQtQaQlCzk+0NxO0ccYz40wZW+lUlvU91YgR7hNYiuR1uSGFMMJV3m9lLp3BROMKLR9nHG4cnFcpuo7pboLz0j0CS4u3PT2O4SpKUFAT7KsqO4HePaGOh4pgyulKqUm9XmLIkwyzFkSkBlxKmWyNqHO8z7BXlZT3fgRkHpxz2XK5OTdBzZiXMPd0tJU2hTRCkqKT7KvaSQQeP86YMrTSqqrUMoahZjJ7hyE5KMTKWlgpUEKUfzhIBOU4KQk486tVRSlKUClKUCul+JHfeYdfYacdYUVtLWkEtkgglJ8Dgkcedd1R06926DLRGly22nlAHac+yCcAqPROTwM4zQdwtkETjNEOOJZ//m7sb+mPpdenFcJNntkpptqTb4jzTZKkIWylQSSckgEcZPWulzUFqbMkKmtZjEJeAydiicBP+8TxjrRF6iviG5EejuMvuqaUpbhQpJSlSiAkjO4beQcYGT4YqpwSDTDLKlqaaQhS8bilIG7AwM/YMVjM2m3MSXZDMCK2+6CHHEtJClg9cnHOax29Q2l1h15E9gttbdys/W4TjzyeBjr4V8d1FaWozT65rfdO7tpSCo+z9IkAZAHjnp404nBkx7TbozK2o8GK00shSkIaSAog5BIA8DXc7DjOpfS7HaWJCdrwUgHvBjGFeYx51hSdQWqNIQw/NaS4oIUBycJVwlRI4APmeK5i9203H0AS2/St2zZzjdjO3PTdjnGc04qyhDjAJAjtAJcLoGwcLOSVfHk8++uiXaLbMQtEuBFfStfeqDjSVArxjccjrgAZ8q4W+9224SVx4Utt11IKsDPtAHBKT0UAeMjNJl7tsKaiJKlttvq2+yc4TuOE7j0Tk9M4zRODKRDjNhIbjtJCW+6GEAYR9X4e6uLdvhtPNPNxWEOtNhptaWwFIQOiQfAe6sb17bPWPoPpbfpW/uyjnheM7SegOOQPGuV0vVvtakJnykMqWCoAgkhI6qOBwkeZ4qDJMOMrvcx2j3q0uryge2sYwo+ZG1PPuHlXWzbYLMtcpmHHRJXnc6lsBas9cnrXBV2gJeLSpLfeBSEbfElf0ceeeeRxwfI10xtQ2qTMEVic0t9SlIAGcFSc7k56bhg8deKDtRZbW3v2W6GnekpVhlI3AkEg8dCQPurIhw40Jotw47TDZO4pbQEgnz4qNh6ktst+WhqQju46C4XCeFoH0lJ80jpkeNc2b7CeKnW5MYwUsqdL5dxwlWCcYxt/vZq8TgzGLdCYWFsRI7agsuAobAO4jBVx4keNdQs9sCysW+IFFRXkMpzuOcnp15P3mulvUVpXDclemtpYaWltZWCgoUogJBBAIzkY86HUVqENMoy090pZaA2q3lY6p2Y3ZA5xjpzTicGW9bYTyEpeiR3Epb7oBTYICMg7fhlI49woxb4cdLQYiMNhlRU2ENgbCQQSPIkE/fWHJ1HaI7bDjs9nu3kd4hSSVDZ9YkdE+84FZs2fFgxg/LfQ20SAlRP0iegHmfcKiuKbZBRNMxMOOJZ6vBsbzxj6XXpXYiHGQGQiO0kMElrCANmQQdvlwT99YJvkMDvzJjCB3BfLxd5ACsH2cdB4nPB4xXUNU2X9INAhW1QIUCnpyrjgcjk8c9avFEkmFFQltKY7KUtrU6gBA9las5UPIncrJ95866WrPbWWn22rfEQ2+na6lLKQHB5KGORya6V6gtSJ3oaprQkd4Ginn2VnoknoCfAHr4VjMangiAiTPWmKVvPNJb5WohtxSCrAGccZJxgZ604nBJybdClFZkxGHisJCitsKyE5KevluOPia5CFFEP0QRmRFxt7kIGzHljpXa2826wl9paVtKSFpWg5CgRkEY61ULZq52bLZO1pMR2Y7G5acQtCUJeO4lQAJPdA8dMkHmgsq7TblvqeXBiqeUoLUstJ3FQ6HOOvA5rNqNl3eM1FS4w6wtbjPpDQcWUJUjKRu3YOB7SfDxrFu2poEBxbAeQ7LQ422WgSMFakjG7GN2FZ29cUE5So5i921+4qgtS21SgSnYM4Kh1SD0JHiAcipGopSlKBVfm2eeJ8922yYrbVw2d937RcUgpSE5SM4OUgcHgHnnOKsFKCuuaecEYdw80mU3cFz21KRlJJKhhQHX2VEZ8Dg+FdQ05IcltzJEhhUhUtUp5KWzs5jlkJAJ54wST156VZ6VcphUWNMSkR3mlORyyUtBuMVuqbSUKzuSSrLZ6YCemPGvv5N3FTDTTlxK28PBSFOOexvIKcKzuXtAIwo8591W3IpTJhUUaVkGy3GG5IZ76VbWoIWlJwkoSsbv8AEDWYxZZ7Dq47cmN6tXJckq3NEve2orKQScD2lH2sZxx76sVKZMKrpvTUi1yoZkPR3GITJZZKd5WroATuUQngdE9SfDpXG7aYkSrnOdYeYEeepCng7vJTtSEHakKCVZSkdRwc9elWylMyYV57T61okhLyEl25Mz87egQWyU/EhBH2113+wSZl0VOgvMpccjiMtLxcAAClFKhsUM/TVkHrxyPGy1hSrXDlPF19ne4eCdxH+RrldquRGbURM/ecf5P9NUxTP7kKNNOIu9vntvshdvbRHYR3fBaxhef7x8MdMf3jUfZrFcJNuZjTVMsQUTn5O3u1JeP51ZSPIcnO7xHHvqy+ord/V/8AGr+NPUVu/q/+NX8a4bzWeSn1T7G9m11nt8q5C0hKaiKivSIxbahOQ2FpCyo7k7QpW5RCeByE9fuFSN5016xaU0Hkso9ETHRtB9lSVpWk8EcZSOOOKkvUVu/q/wDjV/GnqK3f1f8Axq/jTe6zyU+qfYbNrrPb5QjemZLiXFy3YyXlyIzmGwtQCGXAvBUskknn3D7673bBLavT91gvx/SVPrWlDySUbFtNIUDjkHLIOfIkeNSnqK3f1f8Axq/jT1Fbv6v/AI1fxqbzWeSn1T7DZtdZ7fKAmaYuDjpkIlxFyX44YfKkLbQCFLUFJShQz/rFDCs5wOeuZm6Wj0i1xIjKWVejKQU95uT9FJHsqSQUHnqPePGu71Fbv6v/AI1fxp6it39X/wAav403ms8lPqn2Gza6z2+UI5peU9BUzImh1aorkcqcyr6ToWBknJAA25PJxk1m3OwKmKv6kutpNyhIipyn6BSHBk+Y9sfdWd6it39X/wAav409RW7+r/41fxpvNZ5KfVPsNm11nt8q9GstxkqukdSmGoMi4d8tS21B0pTsPs+BztGFeHPXjH1ek5TS2X4khhUhHpCFB0uJSUuPFwEFCgcjOMdD7qsHqK3f1f8Axq/jT1Fbv6v/AI1fxq7zWeSn1T7DZtdZ7fLjZIci3MtQiWFQ2I7aEKQkpUpYzv46BP0cD3msA6dWpqE2t9O1iZJkqwPpJdDowPeO9H3VI+ord/V/8av409RW7+r/AONX8am81fkp9U+w2bfWe3ygTpie9GYZkS421iAYKNiD7XtNnecnyb6eHma7ZenJrjcuIzJjCE/OROytslwEOJWpPl1TwfAcY8amfUVu/q/+NX8aeord/V/8av403ms8lPqn2Gza6z2+UJa9LPwrhGy+wuDGfckN53lwlW7AIKtoxvPtAZOPDJq21HN2W3trStDGFJOQd6uv31I13tVXaonexEfxOf8AIZqimP2yUpSurJVH1NqC4w7vPaYkMxW4bba20O7MSCoZ5yd2M+yNgzkHrwKvFRkwvqlBQtTcjuzlt1TiQR8MjIrncvU2Y2qomf4iZ/qJWKJq4QhrK46nWd4Zk3ZZUru3G4S+7GUFA5SMbsA8ZH21gz9QT2pl9Wi5RkG3Sm2mYJbG58KQg7Sc5yoqITjx656VZvSrhu3eqhu6Z79P8KwYsV+PLkyRZwt597vypb6CUK2JT7JxwMIFcPH2ulXor9re5q6x3j8q/wCsHY8gzY0Znv47F2UhptGAtSH0AZA6k458zmvt9nznbHeo0a9CaBbVyvSoyEAtH6nGRhQyR4jaeTVrS/NSoFNoQCM8h9Picnw8a+NOzGUqDVmbQFHJCXkDJ+6nj7XSr0V+1NzV1jvH5Ve/ajkQIDjttu6Z4ixDLLiUMlLvtKAClAgEeyRhAzxyeldL10kwp2qZcK4x0KYlNutxCgKMklhrCc9fa4Cdvj59Ktqly1lJXZWlFIISS8g4B6gcV8BkhSVCyMhSeUnvUZHGOOPID7qePteWr0V+03NXWO8flWFXSZES1GjPCIiTNnLW+dmQUu8IG87cnJPjwk/EWnTd09YW2IZL8dUxxouFLSvppCiAsDyP2jnqa+OqlOtlt2ytLbJ3FKnUEE+eMVkwlyFv5ft6I4CNocDiVHHlx4VqjWW65imIqzPWmqP/AGYwTaqpjMzHePyz6UpXpYKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUqDa1ZZXdWvaZRMzemmu/XH7pfCMA53Y29FDxoJylYMS8WyZMdiRLjDfltf6xlp9Klo+KQciqqe1bRib25aV3kInNyTDWlcd1KUuhRTtKynb1B8ccUF4pUab/AGcSJDBusAPx0lbzZkI3NJHUqGcgDzNYM7WumIMQyZN/taWQ13wIkoUVIzjckAkkZ448aCwUqpae7R9I6hEo2u+RViKguvd7uZ2IHVR3gezyOenNTce/WeQ067HusB1tpCXHFokIUEJUMhRIPAIIINBJUrAi3q1y4D06LcoT8JkEuyG30qbQAMkqUDgYHPNRk/W+mYVqkXF29wXIjDYdcXHdD5CCrZu2oySNxxkDrQWKlRn5QWgKiIcucNpyWhLjDbryULcSoZGEkgnPwr4vUNlRKejKu1vEllKluM+ko3oSkEqJTnIAAJPwoJSlV7TutNP6isci82q5NLtkdwtOyHkqZShQAJzvAwMKHPTms+PfrRJZedj3WA60wgOOrRIQpLaSMhSiDwCOcmgkqVFMakscgPli8213uEhb2yUhXdpPQqweAc9TXNF/s7lscuTd1t6rc2cLlCQgtIPAwV5wOo8fEUElSob8q9PYdPr604abS84fTG/YQrbtUeeEncnB6HcPMVmW67225lYttwiSyhKVKDDyXNoUMpJwehHI86DNpUYrUFmSZQVdreDEGZGZKPzI6ZXz7P21hyNZ6aYiSpKr7bVtxWDKdDUhLiktAD2tqSSRyMYHORjqKCfpVFb7VdKvv2xqJLekeso70mOpDCgFIaKwrO7BBy2sDI5xWbYe0LT140l+UglmFaQ6WS7MAbwoHHmfE0FtpWBOvNsgRWZM+4w4sZ7HduvvJbSvIyMEnB4rEVqmypvYtKp7YnGH6ftwdncbtu/fjbjI86CapUa1f7O7AcnNXWAuE2dq5CZCC2k+RVnAqJm6/wBLQ7jaoLl5iuSbo4G4iY5LwcUVBI5QCE8kDJIHXyNBaKVWHdbWlrXSdJuekC6KjmTuKB3QRgnlWfIHwqUg6hss+WmLBu9ukyVJK0ssyULWUjqQkHOPfQSdKUoFKUoFatn9nt7V2xq1hb7pEYhPNIYfYUglxTYQlKgDjAJKRzW0q1zrTtTj6Y1S3ZFWW4S3FJQe+QpCEEq6JSVEble4c0ED2Zdj0vR2rm7o/coUmNHQ6hotxyl53fnlxRPgD4eQqGX2IXhOsLlfmLrbd8i6+nNNPMFxIbK1qIIUCN4ynB+NW5/tci/lPLtEWy3J5mPLVAXOQkFtL46gpznaD41WdM9uLn5GQLhfLcqZdJ0x+OyxCAbSUtpQoklSvJY+NEZGkOxN6yauM6ZcIUu2j0jgxz6Q6HUlJStROOATyPf51DWz5PLyLPe4lxvLLj77aGoDyEKIZSlwrIUDjqcdPfU9de322QFsBVhuSg5DEwhSkoUgFRSQQfeOvjxUldO2i3RXYSINkulwL0Fq4O9yE5ZacICcgnk8jgedBTIvYpeLLZdSzpE1i43N+0G3xY0NspCsIQkElWOcIH25Nc9O9iFyVp95yXJt8eXLtbEURVRilIVvQ4vvilWVKBSU7h7j4Vdme2O2SNXpskS03J5v0pMJcoJSAh1XmjO7APU+41y1/wBr9u0feJ1uVap092Cw29IW0UpQ3vUAkEn/AHhzjxA+AcNGdm06w9m2otOyJkBcu6NPNocYZLbbe9rYnPirHmefjVa0H2HP2HUNpmXd+1T4MeI7HlRiyVB9SluKBIUMHG5HX6vwqSuXbvboLktC7LLWY9ujXE4dT7SXgyQnp1Hfj/0mpDRHaPN1J2ozbGWGWrWm0MXFkbfzoU4hleFKzg/63HTwoIrW/YxIv2t3LzCuEFmHI7gLZejFS2EtpCcNYOACAOOK7dLdkc21dor+oJUq0rhLW+stNRiXHO8ChyVE7eF87eD5c13t9ulndcklFpuPowZkuxZCtoTK7hJUsDnKeBxmsqJ2wx3dIMX9/T9yaZmSURILQUhSpTiioYSc4AGw8mgh7b2aXjSvZBq/TjL7VzcmlbsRDCSlZJSlODnjPsj99Qdh7C7g/pqV6bcI8CXNtTEVDLMfbsWFIdV32D7StydpI8OfdVihdvVrlNp2WO5GSuYqI3HSpBWranKldQBgEce+uDHb3b3rbZ5iLFOV6ymuwkNpdRuSpAa55wDnvh91BE2zsPusWHqVp2dZlm6tspQ2hhaGkFDgWRtBBA4wMHNWOzdlMyN2S3rSUu4QhKuDvepejx9qEYKCkEcFX0BknnnxxURae25d/wBY6ai2qH3NrnNvGU28jc8laAs4SQrHRI8PGpGN27WxcK5ypViucZmE2F4WpsrWStKEpKc5SSVZ54wDQVlnsIvaY17bdvFuWqfa48BtSULAQWlxzkjnjDBHxI4FWzss7LJ2jNUzLk/NiORpFsahd1HSpJ7xKWwpfIxyUKPn7VWPSnaAnUenLzcmLNOYkWwK3xXSnLpCSrCFDIOcEfGqbE+UFZZMZ6Qi0Ty0ywhxZQpJIdWvalryyeuc9AaCJhdgEppU1Dt8jBr0V+Ow41GKXHS4SQp859rGf3DyrJ0h2I3K1Tbuq53WC8xPsq7UO6aVuQopQkLweDjZnr5dKzNWdtT8TQ715stnLc6LchbpcafyGVbVK/oK56Y++rDZ+1Nu5awmWBmyy1mCAuVLQtJbbRs3FeOuM4Hj1oKZYexO+QJ9hdk3a3ONWuJJipCELBUHe+IPTwLx+6rlojQt70n2aGwRJdqeuQkKdS7JYU4xtKgcFPBzgVz0D2sQdZX1NviWi4xm3W1usSXQkoWlJIOdpO08Hr5VHs9tMNTmonHbFcEwLGtbcmUlaFJ3BRQgAcHKlDA/fQZHat2cT9ZvWSXEm29EmA0404zLjlxhe9IBUE+BBGRn3eVZVz7MIk7s3/J3vIrV0ENET1miMkL2pcDmweIQVD6OehqJ/wDGyKNNzbu5p65NtQ32W3kqUjGx0HasKHB6AEe8VxX24231S1OZs054SprsOEhK0j0juwCpYJwAn2k/afdRUPH7FLi3oy5Wpc2zKkzJbL+wRlpZCW0rSBwQrcd+c+7HjXJnsVuceHpJ1m6WxNyss5UtxSYvdtuAqbUB7PUju/EDOTWbdO3u2wFwgbDclekwjN2qUlCkAKWkgg/+WTnyIrtvHbva7cqJstEx5Em2puKVd4lJCTkbSPPiiM/VfZjMv3aJNvwuLLEOTanLcUBJLqCttSNw8ON2etRHZh2QXPSGtot7lz7a6y1DMYtRWVNknAAUfAk4yT4k1tXSl6b1Fpy3XdlpTKJrCX0tKIKkBQzg1K0UpSlApSlAqp33s70pfr6m83eztSbinb+dU4sA7emUhW04x4irZSgqb3ZzpN7US765ZWFXVai4p7cvlX1tudu734znmsY9lmizYm7OqxtKt7byn0Nl5wqStQAUQvduGQkcZxxV1pQUeX2UaKllHfWJvCI4ipCH3UANA524SoDrznr767bh2X6NuHq/02xMPegMpjx9zjnstp+ilXte0B/ezVzpQVRfZ5pNeom76qyRvWjag4l4bgAodFbQdpI88VHdpfZhZNdRXlyG0RbutCW0XBKCpaEhYVjbkBXAI56ZNXylBQT2TaSl2+EzeLW3PlMQWYK5JWtpTqWkpAJCVDB9ge/HGcVN2XROnrJe1Xe2W8MXFUVEIvd84rLKEoSlOCojgNoGcZ469asdKCnjsz0cmXPkpsMZL85tbT6klQylYIWE4Ps5BPKcHmsTVXZparxoBrSduWq129hwOMlKe+KDuKj9Mk8lR8c/ZxV7pQax0p2LaYs9gNturPrlSpPpZdfT3eF4wAkJPCceGTnxqXY7KdFx2IDLNlCW4EhUqMPSXj3bqtmVfT5/1aODkcfGrvSgpFr7KtGWuXFkwbKlp6MFhpRkOq27wQrgrIOQT1r7b+yrRNvZmtRbBHDc1vunwta3NychWBuUdvIB4x0FXalBCaV0pZNKQXYen7e3Djur3uBKlKK1dMlSiSfvqKgdmej4NuuUCNY2ExLiUqktqWtYWUklONyjtwScYxVwpQVQdnekxppenxZY4tK3A6pkKUCVjorfndn35zjiu7TmhtO6cmyJdmtqY8iQymO6rvXF7m0gAJwpRHQCrLSgq+ndAaX05d3rnZbPHiTnQUqcQVHAPUJBJCfsArnB0LpuCxeWY9rb7m8L7ycha1uJeVknJCiccqPTFWWlBUYHZtpKBY7jaIllZbt9wx6U33iyXMHIyoq3DB5GDxX2R2caSk6ciWJ+zMrtcRSlsNFa8tlRJJC927nPnVtpQUiT2U6KkljvbG3+YjGI2EPOoCWjuJTgKGeVq5689a+z+yvRc9iI1LsbTiIkcRWfzzoKWgchOQrJ6nk5PNXalBX9P6NsGnppl2e3iNIMdETf3q1fmkYCU+0T0wOevFWClKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlfHFpbQpbiglCRkqUcADzNB9pWldafKF05ZZLkWyx3ry+g4U42oNsg+5RBKvsGPfVMV8p2bk7dMR8eGZivwUHp2leYvnOzv7MRv2tX4afOdnf2Yjftavw0Hp2leYvnOzv7MRv2tX4afOdnf2Yjftavw0Hp2leYvnOzv7MRv2tX4afOdnf2Yjftavw0Hp2leYvnOzv7MRv2tX4afOdnf2Yjftavw0Hp2leYvnOzv7MRv2tX4afOdnf2Yjftavw0Hp2leYvnOzv7MRv2tX4afOdnf2Yjftavw0Hp2leYvnOzv7MRv2tX4afOdnf2Yjftavw0Hp2leYvnOzv7MRv2tX4afOdnf2Yjftavw0Hp2leYvnOzv7MRv2tX4afOdnf2Yjftavw0Hp2leZWvlOyt477TDOzx2zDn/orZ3Z72zaZ1lIbhJW5bbovhMaVjDh8kLHB+HB91BsylKUClKUClKUClKUCvOvyqddyIaWNJWx4t9+2HpykHkoJ9lv7cEn3Y869FZrw/8AKHW4rtfv3eeCmgn4d0jFBrmlfM1aey6TFidoFkkXBxlqK2/ucW8oJQBtPUngfbRFXpW6nxpHUepHJNzfiOoTbYxipckttqfUSe9LygppIcTkjGRkAHB6VC2a16HMhyPKUy83IvEiG3IdnbDHjBtJQ7gEA+0ThR4PP2Bq+lXq723TrWmIT0L0NSlMsKcli4Zk96SO9QY/PCecHCeADuOcVYpVk0K3PZ3qhIjpXJ7pLF07z0phMdam3HDn804XAgbeMlRG3jkNR0rb9tXpZu23tiBCtCnLhaI0lLEm4lCW3e8HeMpWpYwRt34J3eHI4qKtNv0W9N05DmBlAdtypUuR6YcLkYXtZV7QS2MhOeUnnqM5oNa0rZN2gaNt72pXWG2Zfo8aMYcf072e+WcOBJQo7wnrgKVjzNY2g7Jp26W23v3aTBZW3NkJmpkTQypTPcoLO1JUCfzm/lP28UGv6VsBuBpRej0pIYTd1WlUwyfTDuEhMgpDXd5xko5xjPQj3/dHWTTk/SEty6yITd0dEkR1uTg2ttaGgpoFBUAApWRkhQPTKcchr6lbRft+jV6ju8W3RoLqIbDYiIkXQtsy1kpLii7uABSCcJBGceJrv06NKLtSbRdRCVGfv7raV+nYMZkspAdC8JKkgjgqASeeKDVBSU4yCMjIzXytw2aZZVNyIbpttxef01GQ2Z9xLaEupcQVMhZWkI4BOMgjbgdSDhO2TQf5L2x9U0Iec9FL77chJdClLAfSWt5OEgqwe7HQe0rPIarpW2LOdO2TtHsTqodmahKdcQot3QyWkp6IdWc4SeTwVY80pxyttk0Y9aLm7dDCjXBLr4U1HuCVpjpS2C2WlF385uVnoHPL2etBqelfWynvE95nZkbtvXHuq+qOmPyDm7/WG/vD6u77uu877jd9Hnu8YznxxjnNBQa+trU2tK21FK0kFKknBBHiK45pmg9s/J/1w9rTRY9YL33S3rEeQs9XBjKF/aOD7wa2dXlz5Hy3RftRJH+oMZoq/wB7ccfuKq9RZor7SvmaZoPtK+Zpmg+0r5mvuaDgTXmf5Vmi3jMj6tgNFbJQmPN2jOwj6Cz7iDtz7h516SKq6JTLcqO5HkspeYdSULbWnclQPUEHqKD856V6g1p8naBPlOSdMTlW7fkmK8guNg/3VdQPdzVKX8nHVgUdtxspT4EuOj//ADojSlK3T83HVv6Qsn617+XT5uOrf0hZP1r38ug0tSt0/Nx1b+kLJ+te/l0+bjq39IWT9a9/LoNLUrdPzcdW/pCyfrXv5dPm46t/SFk/Wvfy6DS1K3T83HVv6Qsn617+XT5uOrf0hZP1r38ug0tSt0/Nx1b+kLJ+te/l0+bjq39IWT9a9/LoNLUrdPzcdW/pCyfrXv5dPm46t/SFk/Wvfy6DS1K3T83HVv6Qsn617+XT5uOrf0hZP1r38ug0tSt0/Nx1b+kLJ+te/l0+bjq39IWT9a9/LoNLUrdPzcdW/pCyfrXv5dPm46t/SFk/Wvfy6DS1BycDrW7WPk4aoU4A/c7QhHiUKdUfuKB/nW0OzvsPsulpbVwua13e4tnc2pxva02fAhHOT7yfsoM35OWjXtJ6MXKuLRauN0UHnG1DCm2wPYSffyT/AM2K2xvrGyr6p+6mVfVP3UVk76b6xsq+qfur7uV9U/dQZG+m+sbcr6p+6uuXMYgQJE6aVpjMJ3OFKSopHicDnA60GeFZr7msC3z4tyhomW9wuRVqUlLmCAvBIynzGRweh6isrdQdrSAlIJ61zpSgUpSgUpWJcZ7cFtKnASVdAKxcuU2qZrrnEQtNM1TiGXSsSFPalMFxBxtGSnxA/wDwVD2PWdlvO4xn3WgI6ZQMplTIU0o4C0lQAKc+Iq0V01xtUzmCYmJxKx0rHTOiKW0hMlgrdTubSHBlY8x5iul28W1lsOO3GGhsqKNynkgbh1Gc9R5VpGdSuhyZGbKg5IZQUhKiFLAwFHAP2ngVw9Ywtjy/TI2xk7XFd6nCD5K54+2gyqV0uyo7LAfdfaQycYcUsBJz05rg3cIbm3u5cdW4hI2uA5JGQBz4jmgyaVi+soPdJc9Njd2pfdhXepwVeWc9fdWFH1JapM1yLHmIcdbccac29G1NgFQUfDGRQS9Kw1XW3pabcVPiBtz6Cy8nCuccHPPJH313NSo7rzjLT7S3W/poSsFSfiPCg7qVhQrpFmrmIYXlcRwtupPUEDOfhz/n5VE2rWdmukmMxEfdK5Ge73tKSDhoO9SPqqB/dQWOlRenL/btR24zrQ/38YOKbKtpSQodeDz5H4EVKUClQF31dabTOciy3Xt7IQqQttha0R0q+iXFAYSD7/DnpUsZ8RKnUqlMAsp3OAuD2B5nyFBk0qL9f2z1m1A9Ma9IdZD7ftDatBVtG1XQnPgK5XG/Wq3R3npk+M22ytLbhKwdilHABA6ZJoJKuJrrdlxmlKS7IZQUgKUFLAwCcAn4ngV1Jnw1lQRLjqKVhtQDgOFHok89fdQd6qwrpBRc7dJgPPPMtSE7FrZUEq2+IBIOMjjz54xXamdDccbbRKjqcczsSHASrBwcDxwQa7iKCNtVtj2O1tW2E46qM0T3SXFBXdIzkIBx9EdBnJx41mZrhJ4cT8K+ZoJClKUClKUCoq+WtU9sqQvDiR7IPSpWqlM1vHZvFxtzECZIchJWFOI2hClpbDhRknj2SOTgZ4zXHUWKNRbm1cjMS3brqt1RVTzhI6etb0KNITIICneMA5x1/jUBF7NrdC0zEt8IsonsCOVTFs7w8pogjegq+iSCdoI/dXWjtOguW+NPZts52G/HelhaS3lLDa0oUsgq9+cda6o3aC4ia83Kj98O8faZaYRhTikzPR2xuUrAzkZz7z7qzpdNRpbVNm3yhbtyq7XNdXOX1ns3LM23yGrp3ZYyXu7YKS5lxxZSkb9qU5cIAKSUjoaw09lryLSxARdYhbQ62t0OwVOJfS2nCEqBd+04IBwBjAqXR2iwiw64uDLbU0grUhRRkYkmORwcZ3DPwqT01q+JqB6YmLFlNtsJK0OuJG11IUpOQQTg5SeDg4Ir0Ob5fdJtXi9Wi4PSS2YeA+0hHsyQkhaAeeAlaQodfEeNV1PZiEwnWPWLRKW22WFCMUEJQ4VhThSsKU5k43gp8eOTWZB7SI8xuOG7RPEmUGFRmCpvLwdStSTndgYDS+pHQedY7HaV38xwR7PJeir9Gbj7VoDi3HisbVAnAwUEZzjg89KCUn6PekabstvTcG3JNsWFpdkRgtt0hCkEKbyPBRxzwQOtV6y9m0tNstzcy4iNsRHW+whrcoONsKa9lwKwBhWeh5FWzTWr4t/nyo0eJKaDAWQ64kbF7FlCsEE4II6HGRzUOz2lQ5LxYiWya8+ZDbDaEraw5vS4pKgrdtx+aV4+VBHK7LVepmoiLmy3JQvPpCI7gOO7S3073rhIznKT0Kay5vZt6Y/OLt0CWZDkhwBMcBQLyUA7juwQCjpgZBIrIjdpVvkFtbUCb6KoMgvnYAhTqCpCSN2c8EZAIz7q+xO0aM8iM47aZ7LTrbDzi1KbIaQ+vY0ogKycnwAOBQYsjs0RKblGTPZ76S1KQru4gS2hbyG07kI3ezgNg4zyVE5FS2m9HrsupZtzTPC2ZCVj0dLZA3KUFFRJURnIP0QnOcnJrCm67eciQZNstT62pM1thvvVN5kNqUtJKBvyk5R/Sx1rvs/aHb7tcocOLCnZfSgrWUpIZUsKISrBz/RPIyORzQc9JaNesN0uU165CUqY0GsBkoxha1An2iM+2RgADjpXRM0I67YrLb412Md22xXYwfDGSsON92VAbvZIGccmpfV2qY+mBDVLiyXm5CikuNgBDQGOVqJAT14zxwaiJvaNAi3CbEEKU8uNgJU0ptSXT3qGiAd3BCljg48elBmaY0Wzp43FmLcJblvmNtp7latq21oTs3JWnBGUhA4HG0c1JN6bhtuJWmTdSUkEBVyfI+0FfNQbHaHDXOgRXrdNjrkvLjqW5sDbbiXVNFJXuwTlOcA9CMZPFZt01lHt2oF2x2FJUltUdDklJRsQXiUoyCdx5GOAaDov2jXrjMuyotz9Fh3dtDU9ksBalBI25bVkbCU8HIV51gu9npWme0ifGTHefMlndCSpxKy8l3a4sqytGUAbfZyng9AaxbF2jPyw2mRa3HlPMw/R+4UlJeceaLhGFKwkAJPUnp1ORUjbdbuPamdt0uA6iO5IajsPJKDsWuP3u1eFHJ4UMpyOnNBFyOy8vObvWjKe9QpD4EIYG5/vld17X5vngdcdea7H+zPe0+lFyaChu9HUYoyMyEvkvHd+cOUAA+zgE+dZd/7QEW29COmG6IEaQ6zMlKCSPzcZTyggBW7IATyRjrUpF1gzI01PvHq+Y2iEcusqCdxTgKKkkEhQCVZ4PgR1oOeoNKM3q+Wq4uyFN+iH880lGRJSFBaEq54CVpCh18R41XmOzVcdDZZujaXoxZ9GWImBht3vAXcK/OKJ43ZT4+ZqQR2iW92fHjMwpryXlkJdbSlQ7vvS0HMZyUlSVdM8DPlWC/2klxmOYNmkFx5yPsDziAFtuPFoqGD1BSRg46g9KBa+zpy33O1TEXVJVDUVOlLBSXsuOLxjeUgfnCMlJIxwRmthVXtKasi6lckiJGlMoaAUhx1I2upKlJyCCcHKTwecEVY8UGDL/wBcn4Vwrsm/65PwrhQSFK4MuBxAPj41zoFKUoFRcrT1nlS35Um2xHZD6C264toErSRgg+fHHw4qUpQVuTomwSbkzMdt0c90lYDHdp7oqWpKispx9LKR++s9/TtmfQ8l62RFh4KDmWh7W5feKz8V+18ealaUFdg6LsMSI1HNujvoZW4tsvNpUUb3S4Ujj6IUeB4YFScCzW23vSHYMGOw7IJLqm0AFeSTz9pJ+JNZ9KCJd03ZXY/cOWuGpnYhsILQwEozsA9ycnHlmvqdO2dElmQi2REvMpQhtQaA2BBygDyx4eVStKDAhWa2wZUiTDgx2ZEgkuuIQAV5OTn4nn41DzNCadkhhPq1hptt5LykNICQ4UpWlIVxyB3isDwqz0oK7G0ZYmLq5PTb2FPKShDaVNp2spQjYAgY44NZ69P2hb0N1VtiFyGlKI6i0MtJT9EJ8gPDyqTpQRMfTdljPreYtcNt1bofUtLQBKwSQr45UT9p864HTFk3pWm1w0OIbLSFpaSClJzwOP7yvvPnUzSgi5On7VKhxIsuAxIZioDbIdQFbU4Axz4EAZ88VwGmbIJLsgWqH3zqty190Mk7gv8A6khXxGal6UEUvTlmXJbkKtkQvtrLiV90MhRVvz8dxKvjzXSvS1qd1E5e5EZL85SW0oU6AoNbN2Cnjg+0f3VN0oIR3SlgdRsctEIo7tDW3uhgIR9AD4eHlWUxY7XHU2pi3xWy2tK0FLQG1SUbEke8J9ke7ipGlBFPadsz9xXPetcNyavhTymklR9kp5P+6SPhXfb7RbrdCXEgwmGIy872kIASrIwcjx44rOpQRStO2YmETbIn+hJCI/5ofmkgggJ8gCAceYr49pyzPMBly2RC0EpQE90OEpVvAHwUSfjUtSgio2nbNFdU5HtkRtxTofKktAHeCSFfEFSj9p86laUPHWgw5g/PJ+FcMVyeUHHcjoOK5YoOogpOUkg+6vhdd8FmsgprgUUGOXn/AK5r53z/ANdVd/d187ug6e+f+uqnfP8A11V3d3Tu6Dp75/66qd8/9dVd3d07ug6e+f8Arqp3z/11V3d3Tu6Dp75/66qd8/8AXVXd3dO7oOnvn/rqp3z/ANdVd3d1gXSe1ARgje6fooH/AHolVUUxmWSX3gMlwgVhu3lpo4XLGfdz/lVYmzZEsnvV+z9UcCsTZUy8dWr8sLcNQRycelK/9J/hWUxcPSB+ZkBfuBGao+yvoSQcjg+YplmNXV9YX3vn/rqp3z/11VWrbeHWFBEnLjXn/SH8atDJQ82lxpQUhXIIq5eu3dpuRwcO+f8Arqp3z/11V3d3XwoAGSQB76Ojq75/66qd8/8AXVRb0dH032k/FQroXcYKOshB+HNZmumOctxbrq5Q7++f+uqnfP8A11VgrvMFPRa1fBNY6r9HH0WXT8cCsTftx9XSNLenlTKW75/66q7GZDqV+2SpPjXCKtEmO28gYSsZANcJcmNCZU9LfaYZT1W4sJSPtNdInPGHGYmJxKRdfCUAo5J6VilTi/pKJFQMfWGmpD4ZYv8AaXHScbEzGyc/DNWJspWAUkEHkEeNVHxCcV24rklNc8Cg+kVxKa7KYoOvZXzZXbiou8LW5JhQG1FCZKlF1STg7EjJAPhklI+BNBnbR5imB5isNVptTDSlLgw0toBKlKaTwPEkmupuJY3YImtsW5UQp398EIKNvnnpigkcDzFMDzFR3olj9B9N7i3eh7O87/YjZt67t3THvruZtlpfaQ6zChONLAUlaWkkKB6EHFBl4HmKYHmKx/U9t/R8T9Sn+FPU9t/R8T9Sn+FBkYHmKYHmKx/U9t/R8T9Sn+FPU9t/R8T9Sn+FBxuUpEKIp04KuiR5mqO+4p91Tjqty1HJNXn1Nbf0fE/Up/hT1NbP0fD/AFKf4VJcL1mbk81D2im0VfPU1s/R8P8AUp/hT1NbP0fD/Up/hTDj4P8A6UPaKbKuNz05b5MZYYjMxpAGW3mkBJSfDp1HuqkxnlP25qQRtUtoLIHgSM1MOF6zNrHFyQmS+pQgQJMzYcKLW0JB8sqIGfhWTHVqKOkoYs09DZ5IDjHX9ZVx0uyhnTlsSgYBjoUfeSkEk+8kk10NXxTmrX7J6umJS1GEj00o/MqycbAfrUqpiqMPfp7UWaorjjKrrOoV/StNzP8A8dn+ZXSqPelHKrHPJ97rP8yrdEvipGqp1lNumNpisodExaMMu7v6KT4kfxqbxXGdNRPPL6NOuuU8ojs1r6JeP0DO/WM/zKeiXj9Azv1jP8ytlYpip4S21+o3vs1r6JeP0DO/WM/zKeiXj9BTR/8AEZ/mVsrFcV8CnhLZ+o3vs1nqrXkTROinJU9labgglpmG5wta1ZI/5epJHl515H1hq686tuS5l7mLeJJ2NAkNtDySnoP8/Otm/KsujsnXMG3k/mIkQLSP7y1HJ+5KfurXHZ7phGqr87FkSVRocWM7MkuoTuUG205O0eJPAr0UxsxEQ8ddU11TVP1VnNbI7K+1W7aKnMsPuuTLGpQDsVas92M8qbz0Pu6H99YegmLFqHVLWnZNuWiDcVFmLJUsGTGcI9lRUkJCxnqCOh4NUy4w12+5S4TpBcjurZUR0JSSD/lVZfodZ7hGuttjToLqXYshtLra09FJIyKzsVpT5LF1em9nzkR5RUmDLW03nwSQF4+9RrddB9pSlAqJn/7RWn/y3/8A6Klqgr3EamX20tvd5tCHz7DikHojxBBoJiZGZmRHospsOMPILbiD0UkjBH3VHRdO2qLpz1CxDQi090pj0cE7dis5Hnzk199QwvOV+1O/ir76hhecr9qd/FQcfydtX5N+oPQ0eqO59H9HycbPLzrOt0KPboEeFCaS1FjtpaabT0SlIwB91YfqGF5yv2p38VPUMLzlftTv4qCUpUX6hhecr9qd/FT1DC85X7U7+KglKVF+oYXnK/anfxU9QwvOV+1O/ioJSlRfqGF5yv2p38VPUMLzlftTv4qCUpUX6hhecr9qd/FT1DC85X7U7+Kgk1fRPwrV0NYXZYpShKAIyRx4+z1q+KsMLaeZXT+tO/iqh29xZ0/CbKiUNxwEg+Hs1JePV8oW7T99gIsNuSpb+RGbB/0dz6o/u1n+v7f9d/8AZnPw126c/wBn7Z/wzX/SKkKr2Ir1/b/rv/szn4aev7f9d/8AZnPw1K0oIr1/b/rv/szn4aev7f8AXf8A2Zz8NStKCK9f2/67/wCzOfhri5f4BH03/wBmc/DUvXxQyKDyT8qGEh7UVuvUUOqYeY9GcKmlJCVpJI6gdQT/AOk1qjSeopul7ym4W8NLUUKacaeTuQ62oYUhQ8iK9r9pGnYWpYcC13NvfGkSVJOOCk9y6QoHwIIzXlvXPY9qTTcpxUKK5dbfklD0ZBUsD+8gcg/DIoIbSeo7Npy8uX9iC8u4s7lQYZVlhlZGAtSydytueE48smqjIfclSXpD6it11ZWtR8VE5JqRj6dvUh8MsWi4OPE42JjLJ/yrcXZb2HTpc1i46vb9HiIUFphZyt0j6+Pop93U+6g2f8muwvWbs8ZdkoKHbg6qUEkchBACfvCc/bW36xYUdLDSUISEoSAEpAwAPKsvFApSlAqJn/7RWn/y3/8A6KUoJMn88keG0/8AaudKUClKUClKUClKUClKUClKUHxX0T8K1Xbv/Ykb/h0/9NKVJePWcobF05/s/bP+Ga/6RUhSlV7ClKUClKUClKUELff/AGhY/wDjFf8AyHa75AHPApSgxgBnoKzY4HlSlBmp6VypSg//2Q=="
+            },
+            {
+              "timestamp": 4959267788,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAFQQAAEDAwMBBAQICwQIAwcFAAECAwQABREGEiExBxNBURQVImEIGDJScYGR0RYjVFVWkpOUoaLSQmKx0yQzNnJ0o7LBF3OCJzVTs8Lh8DQ3Q0TD/8QAGQEBAQEBAQEAAAAAAAAAAAAAAAECAwQF/8QALREBAAEDAQYFAwUBAAAAAAAAAAECAxEEEhMhMVGRFFKS0uFBYdEVMnGxwaH/2gAMAwEAAhEDEQA/APVNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFK+KUEpKlEBIGST0FV5rXGlXrh6C1qK0rl52hpMpBJPl16+6gsVKEgDJPHnVdOuNLJn+hHUVpEvO3uvS0bs+XXr7qCxUoCCAQcg+NRV51Da7KtCbrK9EQvGHnW1BofS5jaPrNBK0qhdtcr/2SX+TDf4MdKkOtL6gqTyCKljq/T1miQI13vluhylMt/i35CUq5SOSCeKCz0rrjSGZTCH4zrbzLg3IcbUFJUPMEdahbvrHTdnliLdb7bIknOO6ekoSofSCeProJ6ldUSSxMjokRHm32HBlDjagpKh5gjrXbQKUpQKUpQKUpQKUpQKUpQKUpQK4qWlPUiuD6ykYHU1B3G/Wi2Phi43OFFeKdwQ8+lCiPPBPuoLAlSVdCDX2oS13e33QLVa50aWGyAssOhe0npnBqYaXvRnxoOdKUoFKUoNb9uD7y7PY7Ql5ceJeLqxBluIO09yokqTnwzjFWOXoXTEiwqtC7LATB2FASllIKeMbgrGQr39azNXadg6qsT9ruaVdy5hSVoOFtLHKVpPgQap7ui9ZyYRtkrXi1W1Se7WtFvQmSpHQjvN3XHjjNBRDfbk/2Hw4KprpQ5eBZFT0qwpcbvSnfn3pG3NbcRoHSqbH6pFit/oWzZgsp3dMZ3dd3vzmub2ibI7okaVMYi0paDSUg+0kg5Cwfnbuc+dVpOidaIierk6/d9WhPdhRt6DJ2dMd7nrjxxmghu0GVJ0J2KGPp28PSy26mGicpYUtltSyCNw8Uj2QeorYun9OWy36cRbm2hIjvMhL63j3ipGRypZPyic1127RtkhaPTpkREvWnuy2tt72i5k5KlH5xPOfOsVWnrpbLKLPpiemNG2d2iRNWqQ5HT0whPGceG5RxQaVjvux+yLtQsCXVvW6zTlx4a1HO1vvB7Gfdj+Nbn0TpSzQ9JxGzFjTlS46HJMl5AcVKUpIJUonqDngeAqPHZnAj9ms7SUCS436aCp+Y4netxwqBK1DjOcYo3o7UdpiegaX1S3CtoTtbZlQRIVHHiG1bhx5BWcUFU0/Le0h/4o2qyEqgWdr0yC18oMLW0pakD3AjOKtPZZpKxs6GtslcOLOlXGOmTLlPtpcW+twblZJHIyelTWi9HQ9M2eVELrk+TOcU9OlSACuStXUq92OAKrsLQWodPochaQ1b6DZypSmokuEmSY+TkhCiQceQOaDo7PmW7B2n6s03axssyGWJzbAOUx3F5Ckp8geuK2hVZ0RpFjS7Mxxct+4XSc530yc/8t5XgMDgJA4AHSrNQKUpQKUpQKUpQKUpQKUpQKUpQY8ke0D7qqOpRczcE+gi+Fruxn0EQ9mcn/43tZ/hV0cQFpwaxlNLB6Z+igr+lhODcj08XQHI2+n+jZ/9Pc8fbVljD2D9NdaGVE88CslICQAOlB9pSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSuDzqGGXHXlhDTaSpSlHASBySaDnSqvB7QdIz5jESFqK2PyX1htppD4KlqJwAB51aKBSqxe9f6UsdxMC7X6DGmDG5pbnKf8Aex0+urFEksTIzUmI629HdSFtuNqCkqSehBHUUHbSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBXkf4QurtR2ntSuMS1366woqGmSlmPLcbQCW0k4AOOteuK8WfCZ/8A3eun/ksf/KTQeluyyfMndj1qmzZT8iYuG4tT7rhUtRBVyVHnPFaZ+DFqm/3rtBmRrxe7nPjptrjgakyluJCg42AcKJGcE8++rh8H/tCsl00/Z9FJYm+sWorgcUpCQ0QCScKCs9D5VZZnZ1pzQ+nNSXbSduci3T1VJbQ4JDrh+RuwApRHVKfsojuufbVoi330Wp25qceDndOPNNFTLas49pfTA8xmo+89vWjrTdZdvfFycdjOqaUtllKkKIOMpO7ke+vKmg2dMyL6Ua1lzots7pRDkRO5XeZGAeDxjPQHnFQ93TDTdJabWt5yAHVCOt4ALU3n2SoDxxig9ezfhBaNhzHozzd27xpZQrbHSRkf+qpe3dsOmrjrRrTcP0pyU4SkPhCe6BCNxBO7PGCDx1FeM9T/AO0Vy/4hf+Nek9Rdk2nNO9nM/UVmamourVsU6lZkEgFbeFnH0KVQWS+fCA0XbJzkVlc6eW1bVOxmQWyfcVEZ+kcVnWvtW0trWy3aHapTrU/0J5QjSW9i1AIOSnqD9RzXlPs5b0e5dZA129Pag9ye5MQZ/GZ/tYBPTp7+tTek06Pb1Ghdtm6j9K3rEVJjtBJBBACyFZxjqQOmaCu9mkpmF2haclS3EtR2Z7LjjijgJSFgkn6q9O6U7f8ATt91Im1PxJMBDzvdR5LqgpCyThO7xTnjz6815h7NIrE7tC03FmMofjPXBhDjTicpWkrGQR4inaPHZgdoeo48NtDDDFxfQ0hsbUoAcOAAOgFBtntXh9lyO0G7Ju72pI1y77fKRDQ2ppS1AKJSVcjOaiO13WirU/p606Dut5tlsiWtlXdokLa3BxIdQTtVyrasZ9+apfa+6t/tDubrqipxxEdSifElhsmrB23RWGbZ2fvtMNtuv6eiqdcSgAuEISAVHxIAA58MUG2/g79o0eRpG6Manu8pyXAWqU9LnOlaUtK2pSAtRJzkHj3++p5/4QWhWpZZTInuoBx3yIp2H38kH+FeaJFwtqOyOHBjKjJuzl1cckhKQHVMhsbNxxkp3FWBnrWPZLZp6TpSZKuM9uPc0LIQkyFbiOMbWg0d3094n6qD21Y9ZafvlhevNtukd23MAqedJ291gZO8HBTx51ryf8IjRcaUpphNzlIScd60wAk+8blA/wAK0BCagQOz3UwsWoZM1chuOJcQwlMpSkPJworKiDycY9/urA0A3oVyBdTrd+6NSgkehiGMg8HPgec464FB6rh9rmlrzpS73S2zHiqBHLr0ct7X0A8AgE4PJHINeWdL9pOpIWprTKuupL6/bmJbTklozHF72gsFSdpVg5AIwetW3sTiaSkarMeK7eZUp6HIQuPKitejuI7skhftE4yARx1ArWOilwmtZWJd2DPq5E9gye+SFI7oOJ37geoxnIoPW967d9I2eamLLbuhdUwy+NkdJG11tLif7XXasZ99SWpO1/TenrTY7jPRcDHvDBkRu7ZClBI2/KG4YPtDzryx23y7fO7S7pJsi2V2xbccR1MDDexLDaQEjwAxj6qmu2CbGk6F7NGo77TrjNqUHEoUCUH8WMHy5SfsoN6ufCA0ciAzMU3de5edW0n/AEdOcoCCf7X99P8AGknt/wBHs2hiehNxcDz62QyGkhwbUpJURuwE+2AOeTnyryZK/wBkrZ/xsr/oj1unsB7LdNa20ZKuV9alLlNzlsJLT5QNoQ2RwPeo0G5dSdr+kNPMxjPnrVJfaQ8IrLZcdQlSQobgOEnBHBNdOle2jRmpJ7UGNPciy3SEtty2i3vJ6AK5Tn3Zrx85GYXrV6LeFqajiYtp5S3CgoAURgq2qIxjGdpx5VMTrNpJvUC2UakVDhp2lLjDK5oSfHC9rZP6tB7wpWDYl95Y7esvrklUds98tBQpz2R7RSehPXHhWdRSlKUClKUCtMdpfYajW+rpV8Vf1Qi+htHciJ3mNqQn5W8eXlW56UGnOzHsRRoXVbV6TflTihpbfcmJ3edwxnO8/wCFbicQlxCkLSFIUMEEZBHlX2lBo66/Bx07LvomRLhLiQVOb3ISUhQxnlKV5ykfTmo29fBqhTbtLkwtQGDFddUtqMmFuDSSeEg94M4869B1hXx6bHs0560x0Sbg2ytUdlatqXHADtST7zQaGufwa2p1xkyvwpWjvnCvb6ADjJ6Z7yt9M29oWhFukJS+wGBHWFp4cTt2nI8iPCtA6L1l2vTdaQot2srot7j4TJS7B7pDTefaIX7hnHJz7639ebg1abROuMjJYiMLkOY67UJKj/AUGkL78GqyS5i3rReZdvaUonuVtB9Kfck5ScfTmp/RPYXYtLrkSfS5E65OMOMtvvJASzvSUlSUDxwT1JrStz+EHrWVcXHYLsOJGKiW2Ex0rwnwBJ5J9/FeqtDXORedHWW5TdvpUuI287sGBuUkE4HhRGodKfB3bsGprXdxqVb5gyW5HdGCE79qgcZ7w4zjrivmqvg7t3/Ut0u51MtgzpLkjuvQQrZvUTjPeDOM9cVvutf9st41fZtPsPaHt3pklThS+tLferaTjgpR45Pjzjy8iqNqv4PLeoL6/cjqVccupbT3YhbsbG0o694Ou3P11ctU9ktn1No6yWS5PuiTaIrcaPOaSErwlCUnKTkYO0HH8arPZvrvWsaxX+7dotqkItlvYDzbvowZeWrPKUpJAIxznj6amtD9tuntY6mi2O2wbqzKkhZQt9tsIG1BUckLJ6JPhRFe0z8HOy22RKVd7o/c2HmVNBruQzsJwQoHcTkY4qNf+DHblSipjUktEfPDa4qVKx/vbgP4V6GrTED4RGlptzjwWrbew6+8llJU01tBUrAJ/GdOaKtWleynTGntLz7G3FVLYuCdst2Qcrex05GMY6jHQ89a11cfgy2p2UV2/UMyMwTnu3Y6XSP/AFAp/wAK9BUoNe9mXZPY9Arfkw1vzLg8ju1yJGOE9SlKRwAePM8VS9UfBxst0uj0u0XWRa23VFao/ch5CSeu32gQPdzW9qUGj798HizXK2W1mNdpUWZDYDCpBaSsPAEkFSMjB5xwegFYt1+DfaZNqtkW33hyI/GCzIkKjd4qSpW3nG8bQMcDnr9t/wC2G76ss+mm39EW4TZindrxCO8W0jHyko/tc488eXlXew/UXaBe5c9Gt7atiC22Cy+7G7hZcyPZA4yMZOccY99EVh34NrblpjQfwoWAy869v9AHO9LYxjvPDu/41tDsm0Kns+02/aU3Azw7KVJ70s91jKUJ243H5nXPjV0pRWo+0TsLsWr7s7dI0p+1T3zueU0gLbcV84pOMH6CKi9J/B0sFpuLMu73GRdu6UFpZLYabUR84ZJI92a3hSgAAAADAFKUoFKUoFKUoFeevhF9qt307eWtO6af9EdSyl6TJSkFftdEJz045J68jpXoWvNXwmOze73G/I1NYoj05pxlLcpplO5bakjAUEjkgjHTpj30GublrntEh6Qhi4zb3Hjy5HpMW4qdcbU4naQUBX9pPRQH0+dfYGudVr7PL3KVqS8GS3coTaHTMc3JSpuSVJBzwCUpyP7o8qhNRXfVV00Zbot7W76mtTqYkZDjQQQrYcDOAThKcc9MipLQ2nJ+pOzTWDVqYckyYkuDK7ltO5a0hMhJAHicLzj3URdOyDVuorjpXtDen325yXYlnW7HW7KWssr2r9pJJ4PA5FVbs51xqqZqlLMvUl4fa9Dmr2OTHFDcmK6pJwT1BAI94FY3Z23qmDatYxLXaFKjybY4ic5IbUnuW0pUTjzUeQB5/RUd2YwZaNXIUuK+kegzhktkf/1HqCf7Ktb6pn9o+nYs3Ud3kRnpjaHGnZjikrST0IJwRXp3tqhzZ3ZZqNq2yfRn0xVOqXuKctoIU4nI+chKk46HODxXkjsfgy2+0/TK3Ir6Uic2SVNkAc17M7RkqX2fanSgFSja5IAAySe6VQeGtAW653fWFsgWKb6Bc33CliT3ikd2dpOdyeRwD0raPav2mast94j6Utd0fZXbGGYsmRHUS7KkBCd6t5G75WQOhPU9aqXYZClN9rGm1uRn0IEg5UpsgD2FVZPhAaDvtr19Ov1vhyn7dNcEhEiOgqLTmBkKxyk5GQffQRGstd9o0GBZ7ffJN5tMqOhZS93jjC5SDtwV4xuKcEZ688++SVrPU3/gYi4/hBdfT/wjMf0j0tfed36MFbN2c7c8486qeuIutbjBs111YqdKEttYiB4ErS2nbk7QOAdw95xnyqVVClfF+Q36M/3n4TlW3uznHoo5x5UGbpy6ao1X2Y659K1BPkJgiK+sSpTi8tfjgtA69fZ46Hb7qqnZPbLpd9f2qHYZ3oFwWpakP94pG1KUFShlPPKQR9dbF7AtPTrzo3tGtTTSmpMyGw2z3qSkFX43Ayffj7a11ZWdW6E1YzKiWyZFvEYrQhLkUrzuSUnAxhXBPIoPc2pokyfpy6Q7ZI9FnvxXWo7+4p7pxSSEqyORgkHI5r8+LWxIfvUSPGe7qU5IQ227uI2rKgArI54PNfobZXX37NBemApkuMNqdBTtIWUgnjw5zxXhjVejtR6J1SsP2+TmPI72PJS0VtuAKylQIGPLig2V2s9pmq9LuQtHwbkUTbfDZbnz0ErdkPFAJIUoZA5HPU5qlq1z2maUmRnrhdLw0t0b0NTyXErH+6vP/amtdK6zv8OPrW4W6TKXcU5kdzGKVNKQdgKkAZCSlKSDjFYtvuWu7vOiMWODKYkNDYlNugJjgnjlZQkAnjqrpQT/AGp9p+ornMsNwtl0uVpTKtaFvRoslbaA6HXUKIAPjt+zFYt/1dr/AP8ADrTU9+7S2bYt15tqUiWr0iQ4FqyVqznAHsgZ/s/RXV23WbUES9WJm/OP3C6JtLZkPJTu9ouunbkDBwCB9VSerYklXwd9DNpjvFxM6UVICDkfjHOooPjnabqif2Qvd5eZrdxg3dhoTGnS26tpxl47FKTgnlvPPu8qrcbXurlaVuLx1Nei6ibGQlZmuZCSh8kA56Han7BWJAgyx2ZXpBiv7jdoJA7s5I7mV94qPiwJn4IXNPokjJnRSB3Z/wDhyPdQW7SN/wC0vVNqu9usU28XNRUyp530xRWykb8BJUrjceuPm16l7IYt5hdn1rj6m9J9bICw96Q5vX8tWMnJzxjxrTnwQIz7EvVPfsuNbkRsb0lOeXfOvSlApSlFKUpQKUpQKUpQKUqr37VyLPcVxHYTiyAFBYWAFA/VQU/4RWjb3rTTlriaejIkPsSy64lTqW8J2EZyojxNR3wb9B6g0SjUI1HERGMwx+52vIc3bO83fJJx8oVsK4avjw7bAliOpz0tJUEBQBTjrn665RNXRHLUufKaXHbC+7QnO5Thxk4FXAstKpSO0CGXcKhvhvPygoE/Z/8AeuGubzHl6ejeiK7xEleQsHG3bjII+umBeKVqLR93FpuTjrjanQtopwFYx0P/AGq0xtfRXX0odiONIPVZWDjjyxTAulKq1p1jGmMy3pLRjNRwDkq3FWc4AGOvFYa+0CIHCEQn1I+cVAH7KYF1pUbY71EvLCnIilBSOFoWMKTUlUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUCqJ2nwctxJyR8klpf0Hkf9/tq91h3a3sXSC5Ek7u7XjlJwRg54pA0q4+480w0o5Q0ClA8snP8AiasGr7e5boNnYUCEJZOfLvCcq/xH2VbY2h7WxIaeDkpZbUFBK1pIOD4+zU/crfGuUYsTGg42eRnqD5g+FayjU0pyzGwsojsvC6Ajesk49/jismGh38CJ6lA9z6S3t+nx/wC1XBOhbSl3cTJUPmFwY/wz/GrALfEEAwgwgRSnb3eOMUyNTacnsQPWPpBUO/iLZRgZ9o4xXTpphqTfYTL6AtpbmFJPQir+vQtpUsqCpKQf7IcGB/DNdtu0bboE1mUy7KLjStyQpSSPr4pkQ2vrTFt9pZXAjJZSp4BwpzzwcZ/jVThqt4tzwkj/AEnPs4Qoq+o7gB9YNbllR2ZcdbEltLjSxhSVDg1Wl6FtKnNwVJSPmhwY/iM0iRGdnIhemyDEEvvQ1hZcKdnUY6c5/wDvV9rDtVsiWuP3MJoNpJyT1Kj7zWZUlSlKVApSlApSlApSlApSlApSlApSlApSlApSlApSlApStcdot1kG5+gNOKQw2gFSUnG4nnn6sVYjI2MFpUcBQJ9xr7WoHbBeISY76UKBc5QW3OR4+dfdTPT1Jt4uQWiQlkpJKuVDccHj/wDOKYRt1Skp+UQPpr7WpbZY7tebY0uOtsxm1qCQpeOeMn/Cvt6ulxuVz9XsuLCErDCGkKwFEcc+fNMDbNUe+xtVLurqoTi/Rir8V3a0pAHhkHxqrF276auCULcW05gL2Fe5Kx7/AA8DXVqSUZN5kPoUoJdCFgZ6ZQDViBt23CQiAwJykqkhA7xQ6E1kJUlXyVA/Qa1PqiRP9HtzbinUwvRGS3gnao7Bkn35qOtsKTIAchy2UPZ4QXti/qzj/GpgbqJwMmviVJV8lQP0GtUauduqHIzM5TyWksoABJwpW0biT4nOaj7bClSAlyFLaS/nhvv9i/qzimDLdFK1Tqu6z1ymoC3XEBlpCVpCuVLKQST58msO+s3aDGhxrnuShIUWfbBODjIyD7hTBluKhIAyeBWmVLX+DSDuVn0tXj/cFc7eia7Ybo4zI2R2i2XU85XkkAZ8uaYMtxg5GRXwqSDgqAPvNabs19mWtqShh1WHG9qQTkJVke0PfjNLda7lexIfjkulvlaluck/XTBluWla003KvFoYlOvNurhpZUoBagQlQHB6568cedQKn7heJK1PStyx7X410IA9wycfUKYMt00rWmjZV4jXRlpTcp2EtWxYUkqSn+8D4VsukwpSlKgUpSgUpSgUpSgUpSgVRtc6blzponQEB0lAS43nB48Rn3VeaUGnU2G+SVIaVDlEJ4T3nCUj3Z4rOvmmZ8VuCyxHdkKDRLimklQCio8fZitqUq5TCu6CivxLD3UplbLneqO1acHHFVjUul7ixdXZlsbW62tfeJLZ9tCic9Pp8q2TSmVapj6dvl4mhc5DyM4CnpB5A9wPJrjqKwz/AFxIESDIcYTtShSWyQQEgf8AatsUplMNcToGoo/cuQUPlhUdkFsEKAIbSCCg+OR5VDCwXqfKKlQXELWeVKQG0j/AfZW4KUyYa5uls1HCkf6Ip19ju0JO0haSQgA+yfePKoZGnr1PlFSoLiFqOSpaA2kfVwPsrb9KZMNbao0pcO9bkRkmUS2hLu35W4JAJx4g4qLmadvPosZ51iQ8tzcO7wVKbSMYz5ZyePdW3aUyYamVZrl+D6GvQZPeiUpW3uznGwDNZ1ntU9rTF8Zchvpdd7rYgoOVYVzgVsulMjUdp0xcJchxl+K9HBbJS44ghIUOgNdS7BfIi1tpiSRu4UWuQofSK3DSmTDXWmdISll9y5JLCFNKbQnIKsqGM491RarFf7RLX6I0/kgp7yPyFD6v+9bZpTI15pLT11FyblzlPR2UK3lKlnc4fePLzzWCbPqL1/v2v993mfSN3sYz1z5e6to0plSlKVApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSqdqK5SrXcp0Np9fe3NlHq/cchD24Nrx7hubXj/eNBcaVU414nthp4qjLgpm+r+5UFGQSHO73le7BORuxt+Tzmum23ea/wB3DtoiRdjTsha5W9wKAeWjaDuB/s5JJOMjirhMrlSoTT00TJFwc2Iz+JUVNulxKtzSVeznjHPgBnrUSnUlwasqbvI9XqjvxVyGowKkOowncEkkkKx/aIAx76YMrjSqlNvl1twksPegypQZbeaW0hTaBucCNqgVKPjkHPODxxXVNvd9gpvC3vVy27WlLyyltYLyCncUgbvYIAPPtZ44FMGVypVQcvV6U4hxhFvEdy4LgpStK9wAKgHCc4Pyfk458xXQ5qS8mYLYxHjuT0OvJceQ3lBSgNkYQpxJyQ6P7Rxg9aYMrtSqgi+3iY0z6I1BYd9CVKc73LqdyVFO1JQrGDjOcnHkaaYuFyuOoZrrktj0FceM+iMWlbkBaFEYO/GfM7eceFMGVvpVVk3u5ouE9TaYggw5zERSVIUXHA4GskK3YBBc8jnGOOtdUXUVwWiBLcTEMWe64y1HQhXetFKVkFR3YV8jBAAxnqcUwZW+lVJepJqodrVFYjvSZdtMwtBW3K8sgAZPT8YrgnnAGak7FcZNygTAtbaJrLhaO6OtsIVtBG5CjnxHRWCPGmDKapVHsdzvnqfTzZkwZL87hTy2lgtpS2VHPtncrIx1HWu9nU0xVxKCI7kV1EgsqQ0tPLfT2lH2xxzhIAPiaYMrjSqam/3pttlLseI/IlQ0S2UMpKdntoStJ3K9sgLBGCnOMVHz3pWoJthbccgrQia828y/CcxvS0pXtIUsYODx15IOfCmDLYVKqzF8nqdZkq9EMF2cuEmOlCu+SQtSN27dg8pyRtGBnniumLer3JYtagm3tOXF5xCMoWoNIShZyfaG4naOOMZ8aYMrfSqS3qe6sQI9wmsRXI63JDCmGEq7zeyl07gonGFFo+zjjcOTiuU3Ud0t0F56R6BJcXbnp7HcJUlKCgJ9lWVHcDvHtDHQ8UwZXSlVKTerzFkSYZZiyJSAy4lTLZG1DneZ9grysp7vwIyD0457LlcnJug5sxLmHu6WkqbQpohSVFJ9lXtJIIPH+NMGVppVVVqGUNQsxk9w5CclGJlLSwUqCFKP4wkAnKcFIScedWqopSlKBSlKBXS/EjvvMOvsNOOsKK2lrSCWyQQSk+BwSOPOu6o6de7dBlojS5bbTygDtOfZBOAVHonJ4GcZoO4WyCJxmiHHEs//AM3djf0x8rr04rhJs9slNNtSbfEeabJUhC2UqCSTkkAjjJ610uagtTZkhU1rMYhLwGTsUTgJ/wB4njHWiL1FfENyI9HcZfdU0pS3ChSSlKlEBJGdw28g4wMnwxVTgkGmGWVLU00hCl43FKQN2BgZ+oYrGZtNuYkuyGYEVt90EOOJaSFLB65OOc1jt6htLrDryJ7Bba27lZ+dwnHnk8DHXwr47qK0tRmn1zW+6d3bSkFR9n5RIAyAPHPTxpxODJj2m3RmVtR4MVppZClIQ0kBRByCQB4Gu52HGdS+l2O0sSE7XgpAPeDGMK8xjzrCk6gtUaQhh+a0lxQQoDk4SrhKiRwAfM8VzF7tpuPoAlt+lbtmznG7Gduem7HOM5pxVlCHGASBHaAS4XQNg4Wckq+nk8++uiXaLbMQtEuBFfStfeqDjSVArxjccjrgAZ8q4W+9224SVx4Utt11IKsDPtAHBKT0UAeMjNJl7tsKaiJKlttvq2+yc4TuOE7j0Tk9M4zRODKRDjNhIbjtJCW+6GEAYR836PdXFu3w2nmnm4rCHWmw02tLYCkIHRIPgPdWN69tnrH0H0tv0rf3ZRzwvGdpPQHHIHjXK6Xq32tSEz5SGVLBUAQSQkdVHA4SPM8VBkmHGV3uY7R71aXV5QPbWMYUfMjann3DyrrZtsFmWuUzDjokrzudS2AtWeuT1rgq7QEvFpUlvvApCNviSv5OPPPPI44Pka6Y2obVJmCKxOaW+pSkADOCpOdyc9NwweOvFB2ostrb37LdDTvSUqwykbgSCQeOhIH2VkQ4caE0W4cdphsncUtoCQT58VGw9SW2W/LQ1IR3cdBcLhPC0D5Sk+aR0yPGubN9hPFTrcmMYKWVOl8u44SrBOMY2/3s1eJwZjFuhMLC2IkdtQWXAUNgHcRgq48SPGuoWe2BZWLfECioryGU53HOT068n7TXS3qK0rhuSvTW0sNLS2srBQUKUQEgggEZyMedDqK1CGmUZae6UstAbVbysdU7Mbsgc4x05pxODLetsJ5CUvRI7iUt90ApsEBGQdv0ZSOPcKMW+HHS0GIjDYZUVNhDYGwkEEjyJBP21hydR2iO2w47PZ7t5HeIUklQ2fOJHRPvOBWbNnxYMYPy30NtEgJUT8onoB5n3Corim2QUTTMTDjiWerwbG88Y+V16V2IhxkBkIjtJDBJawgDZkEHb5cE/bWCb5DA78yYwgdwXy8XeQArB9nHQeJzweMV1DVNl/ODQIVtUCFAp6cq44HI5PHPWrxRJJhRUJbSmOylLa1OoAQPZWrOVDyJ3KyfefOulqz21lp9tq3xENvp2upSykBweShjkcmuleoLUid6Gqa0JHeBop59lZ6JJ6AnwB6+FYzGp4IgIkz1pilbzzSW+VqIbcUgqwBnHGScYGetOJwScm3QpRWZMRh4rCQorbCshOSnr5bjj6TXIQooh+iCMyIuNvchA2Y8sdK7W3m3WEvtLStpSQtK0HIUCMgjHWqhbNXOzZbJ2tJiOzHY3LTiFoShLx3EqABJ7oHjpkg80FlXabct9Ty4MVTylBallpO4qHQ5x14HNZtRsu7xmoqXGHWFrcZ9IaDiyhKkZSN27BwPaT4eNYt21NAgOLYDyHZaHG2y0CRgrUkY3YxuwrO3rignKVHMXu2v3FUFqW2qUCU7BnBUOqQehI8QDkVI1FKUpQKr82zzxPnu22TFbauGzvu/aLikFKQnKRnBykDg8A885xVgpQV1zTzgjDuHmkym7gue2pSMpJJUMKA6+yojPgcHwrqGnJDktuZIkMKkKlqlPJS2dnMcshIBPPGCSevPSrPSrlMKixpiUiO80pyOWSloNxit1TaShWdySVZbPTAT0x419/Bu4qYaacuJW3h4KQpxz2N5BThWdy9oBGFHnPuq25FKZMKijSsg2W4w3JDPfSra1BC0pOElCVjd/MDWYxZZ7Dq47cmN6tXJckq3NEve2orKQScD2lH2sZxx76sVKZMKrpvTUi1yoZkPR3GITJZZKd5WroATuUQngdE9SfDpXG7aYkSrnOdYeYEeepCng7vJTtSEHakKCVZSkdRwc9elWylMyYV57T61okhLyEl25Mz87egQWyU/SQgj6667/YJMy6KnQXmUuORxGWl4uAABSilQ2KGflqyD145HjZawpVrhyni6+zvcPBO4j/A1yu1XIjNqImfvOP8AJ/pqmKZ/chRppxF3t89t9kLt7aI7CO74LWMLz/ePhjpj+8aj7NYrhJtzMaapliCic/J292pLx/GrKR5Dk53eI499WX1Fbvyf+dX309RW78n/AJ1ffXDeazyU+qfY3s2us9vlXIWkJTURUV6RGLbUJyGwtIWVHcnaFK3KITwOQnr9gqRvOmvWLSmg8llHoiY6NoPsqStK0ngjjKRxxxUl6it35P8Azq++nqK3fk/86vvpvdZ5KfVPsNm11nt8oRvTMlxLi5bsZLy5EZzDYWoBDLgXgqWSSTz7h9td7tgltXp+6wX4/pKn1rSh5JKNi2mkKBxyDlkHPkSPGpT1Fbvyf+dX309RW78n/nV99TeazyU+qfYbNrrPb5QEzTFwcdMhEuIuS/HDD5UhbaAQpagpKUKGf9YoYVnOBz1zM3S0ekWuJEZSyr0ZSCnvNyfkpI9lSSCg89R7x413eord+T/zq++nqK3fk/8AOr76bzWeSn1T7DZtdZ7fKEc0vKegqZkTQ6tUVyOVOZV8p0LAyTkgAbcnk4yazbnYFTFX9SXW0m5QkRU5T8gpDgyfMe2PsrO9RW78n/nV99PUVu/J/wCdX303ms8lPqn2Gza6z2+VejWW4yVXSOpTDUGRcO+Wpbag6Up2H2fA52jCvDnrxj6vScppbL8SQwqQj0hCg6XEpKXHi4CChQORnGOh91WD1Fbvyf8AnV99PUVu/J/51ffV3ms8lPqn2Gza6z2+XGyQ5FuZahEsKhsR20IUhJSpSxnfx0Cfk4HvNYB06tTUJtb6drEyTJVgfKS6HRge8d6PsqR9RW78n/nV99PUVu/J/wCdX31N5q/JT6p9hs2+s9vlAnTE96MwzIlxtrEAwUbEH2vabO85Pk308PM12y9OTXG5cRmTGEJ+cidlbZLgIcStSfLqng+A4x41M+ord+T/AM6vvp6it35P/Or76bzWeSn1T7DZtdZ7fKEteln4VwjZfYXBjPuSG87y4SrdgEFW0Y3n2gMnHhk1bajm7Lb21pWhjCknIO9XX7aka72qrtUTvYiP4nP+QzVFMftkpSldWSqPqbUFxh3ee0xIZitw221tod2YkFQzzk7sZ9kbBnIPXgVeKjJhfVKCham5HdnLbqnEgj6MjIrncvU2Y2qomf4iZ/qJWKJq4QhrK46nWd4Zk3ZZUru3G4S+7GUFA5SMbsA8ZH11gz9QT2pl9Wi5RkG3Sm2mYJbG58KQg7Sc5yoqITjx656VZvSrhu3eqhu6Z79P3VgxYr8eXJkizhbz73flS30EoVsSn2TjgYQK4ePtdKvRX7W9zV1jvH5V/wBYOx5BmxozPfx2LspDTaMBakPoAyB1Jxz5nNfb7PnO2O9Ro16E0C2rlelRkIBaPzOMjChkjxG08mrWl+alQKbQgEZ5D6fE5Ph418admMpUGrM2gKOSEvIGT9lPH2ulXor9qbmrrHePyq9+1HIgQHHbbd0zxFiGWXEoZKXfaUAFKBAI9kjCBnjk9K6XrpJhTtUy4VxjoUxKbdbiFAUZJLDWE56+1wE7fHz6VbVLlrKSuytKKQQkl5BwD1A4r4DJCkqFkZCk8pPeoyOMcceQH2U8fa8tXor9puausd4/KsKukyIlqNGeEREmbOWt87Mgpd4QN525OSfHhJ+kWnTd09YW2IZL8dUxxouFLSvlpCiAsDyP1jnqa+OqlOtlt2ytLbJ3FKnUEE+eMVkwlyFv5ft6I4CNocDiVHHlx4VqjWW65imIqzPWmqP+zGCbVVMZmY7x+WfSlK9LBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlQbWrLK7q17TKJmb001364/dL4RgHO7G3ooeNBOUrBiXi2TJjsSJcYb8tr/WMtPpUtH0pByKqp7VtGJvblpXeQic3JMNaVx3UpS6FFO0rKdvUHxxxQXilRpv8AZxIkMG6wA/HSVvNmQjc0kdSoZyAPM1gzta6YgxDJk3+1pZDXfAiShRUjONyQCSRnjjxoLBSqlp7tH0jqESja75FWIqC693u5nYgdVHeB7PI56c1Nx79Z5DTrse6wHW2kJccWiQhQQlQyFEg8Aggg0ElSsCLerXLgPTotyhPwmQS7IbfSptAAySpQOBgc81GT9b6ZhWqRcXb3BciMNh1xcd0PkIKtm7ajJI3HGQOtBYqVGfhBaAqIhy5w2nJaEuMNuvJQtxKhkYSSCc/RXxeobKiU9GVdreJLKVLcZ9JRvQlIJUSnOQAASfooJSlV7TutNP6isci82q5NLtkdwtOyHkqZShQAJzvAwMKHPTms+PfrRJZedj3WA60wgOOrRIQpLaSMhSiDwCOcmgkqVFMakscgPli8213uEhb2yUhXdpPQqweAc9TXNF/s7lscuTd1t6rc2cLlCQgtIPAwV5wOo8fEUElSob8K9PYdPr604abS84fTG/YQrbtUeeEncnB6HcPMVmW67225lYttwiSyhKVKDDyXNoUMpJwehHI86DNpUYrUFmSZQVdreDEGZGZKPxI6ZXz7P11hyNZ6aYiSpKr7bVtxWDKdDUhLiktAD2tqSSRyMYHORjqKCfpVFb7VdKvv2xqJLekeso70mOpDCgFIaKwrO7BBy2sDI5xWbYe0LT140l+EglmFaQ6WS7MAbwoHHmfE0FtpWBOvNsgRWZM+4w4sZ7HduvvJbSvIyMEnB4rEVqmypvYtKp7YnGH6ftwdncbtu/fjbjI86CapUa1f7O7AcnNXWAuE2dq5CZCC2k+RVnAqJm6/0tDuNqguXmK5JujgbiJjkvBxRUEjlAITyQMkgdfI0FopVYd1taWtdJ0m56QLoqOZO4oHdBGCeVZ8gfCpSDqGyz5aYsG726TJUkrSyzJQtZSOpCQc499BJ0pSgUpSgVq2f2e3tXbGrWFvukRiE80hh9hSCXFNhCUqAOMAkpHNbSrXOtO1OPpjVLdkVZbhLcUlB75CkIQSrolJURuV7hzQQPZl2PS9Haubuj9yhSY0dDqGi3HKXnd+eXFE+APh5CoZfYheE6wuV+Yutt3yLr6c008wXEhsrWoghQI3jKcH6atz/a5F/CeXaItluTzMeWqAuchILaXx1BTnO0Hxqs6Z7cXPwMgXC+W5Uy6Tpj8dliEA2kpbShRJKleSx9NEZGkOxN6yauM6ZcIUu2j0jgxz6Q6HUlJStROOATyPf51DWz4PLyLPe4lxvLLj77aGoDyEKIZSlwrIUDjqcdPfU9de322QFsBVhuSg5DEwhSkoUgFRSQQfeOvjxUldO2i3RXYSINkulwL0Fq4O9yE5ZacICcgnk8jgedBTIvYpeLLZdSzpE1i43N+0G3xY0NspCsIQkElWOcIH15Nc9O9iFyVp95yXJt8eXLtbEURVRilIVvQ4vvilWVKBSU7h7j4Vdme2O2SNXpskS03J5v0pMJcoJSAh1XmjO7APU+41y1/2v27R94nW5VqnT3YLDb0hbRSlDe9QCQSf94c48QPoDhozs2nWHs21Fp2RMgLl3Rp5tDjDJbbb3tbE58VY8zz9NVrQfYc/YdQ2mZd37VPgx4jseVGLJUH1KW4oEhQwcbkdfm/RUlcu3e3QXJaF2WWsx7dGuJw6n2kvBkhPTqO/H6pqQ0R2jzdSdqM2xlhlq1ptDFxZG38aFOIZXhSs4P8ArcdPCgitb9jEi/a3cvMK4QWYcjuAtl6MVLYS2kJw1g4AIA44rt0t2RzbV2iv6glSrSuEtb6y01GJcc7wKHJUTt4Xzt4PlzXe326Wd1ySUWm4+jBmS7FkK2hMruElSwOcp4HGayonbDHd0gxf39P3JpmZJREgtBSFKlOKKhhJzgAbDyaCHtvZpeNK9kGr9OMvtXNyaVuxEMJKVklKU4OeM+yP41B2HsLuD+mpXptwjwJc21MRUMsx9uxYUh1XfYPtK3J2kjw591WKF29WuU2nZY7kZK5iojcdKkFatqcqV1AGARx764MdvdvettnmIsU5XrKa7CQ2l1G5KkBrnnAOe+H2UETbOw+6xYepWnZ1mWbq2ylDaGFoaQUOBZG0EEDjAwc1Y7N2UzI3ZLetJS7hCEq4O96l6PH2oRgoKQRwVfIGSeefHFRFp7bl3/WOmotqh9za5zbxlNvI3PJWgLOEkKx0SPDxqRjdu1sXCucqVYrnGZhNheFqbK1krShKSnOUklWeeMA0FZZ7CL2mNe23bxblqn2uPAbUlCwEFpcc5I54wwR9JHAq2dlnZZO0ZqmZcn5sRyNItjULuo6VJPeJS2FL5GOShR8/aqx6U7QE6j05ebkxZpzEi2BW+K6U5dISVYQoZBzgj6apsT4QVlkxnpCLRPLTLCHFlCkkh1a9qWvLJ65z0BoImF2ASmlTUO3yMGvRX47DjUYpcdLhJCnzn2sZ/gPKsnSHYjcrVNu6rndYLzE+yrtQ7ppW5CilCQvB4ONmevl0rM1Z21PxNDvXmy2ctzotyFulxp/IZVtUr+wrnpj7asNn7U27lrCZYGbLLWYIC5UtC0lttGzcV464zgePWgplh7E75An2F2Tdrc41a4kmKkIQsFQd74g9PAvH7KuWiNC3vSfZobBEl2p65CQp1LslhTjG0qBwU8HOBXPQPaxB1lfU2+JaLjGbdbW6xJdCShaUkg52k7TwevlUez20w1OaicdsVwTAsa1tyZSVoUncFFCABwcqUMD+NBkdq3ZxP1m9ZJcSbb0SYDTjTjMuOXGF70gFQT4EEZGfd5VlXPswiTuzf8He8itXQQ0RPWaIyQvalwObB4hBUPk56Gon/wAbIo03Nu7mnrk21DfZbeSpSMbHQdqwocHoAR7xXFfbjbfVLU5mzTnhKmuw4SErSPSO7AKlgnACfaT9Z91FQ8fsUuLejLlalzbMqTMlsv7BGWlkJbStIHBCtx35z7seNcmexW5x4eknWbpbE3KyzlS3FJi9224CptQHs9SO78QM5NZt07e7bAXCBsNyV6TCM3apSUKQApaSCD/5ZOfIiu28du9rtyomy0THkSbam4pV3iUkJORtI8+KIz9V9mMy/dok2/C4ssQ5NqctxQEkuoK21I3Dw43Z61EdmHZBc9Ia2i3uXPtrrLUMxi1FZU2ScABR8CTjJPiTW1dKXpvUWnLdd2WlMomsJfS0ogqQFDODUrRSlKUClKUCqnfezvSl+vqbzd7O1JuKdv41TiwDt6ZSFbTjHiKtlKCpvdnOk3tRLvrllYVdVqLinty+VfO2527vfjOeaxj2WaLNibs6rG0q3tvKfQ2XnCpK1ABRC924ZCRxnHFXWlBR5fZRoqWUd9Ym8IjiKkIfdQA0DnbhKgOvOevvrtuHZfo24er/AE2xMPegMpjx9zjnstp+SlXte0B/ezVzpQVRfZ5pNeom76qyRvWjag4l4bgAodFbQdpI88VHdpfZhZNdRXlyG0RbutCW0XBKCpaEhYVjbkBXAI56ZNXylBQT2TaSl2+EzeLW3PlMQWYK5JWtpTqWkpAJCVDB9ge/HGcVN2XROnrJe1Xe2W8MXFUVEIvd84rLKEoSlOCojgNoGcZ469asdKCnjsz0cmXPkpsMZL85tbT6klQylYIWE4Ps5BPKcHmsTVXZparxoBrSduWq129hwOMlKe+KDuKj8sk8lR8c/VxV7pQax0p2LaYs9gNturPrlSpPpZdfT3eF4wAkJPCceGTnxqXY7KdFx2IDLNlCW4EhUqMPSXj3bqtmVfL5/wBWjg5HH01d6UFItfZVoy1y4smDZUtPRgsNKMh1W3eCFcFZByCetfbf2VaJt7M1qLYI4bmt90+FrW5uTkKwNyjt5APGOgq7UoITSulLJpSC7D0/b24cd1e9wJUpRWrpkqUST9tRUDsz0fBt1ygRrGwmJcSlUltS1rCykkpxuUduCTjGKuFKCqDs70mNNL0+LLHFpW4HVMhSgSsdFb87s+/OccV3ac0Np3Tk2RLs1tTHkSGUx3Vd64vc2kABOFKI6AVZaUFX07oDS+nLu9c7LZ48Sc6ClTiCo4B6hIJIT9QFc4OhdNwWLyzHtbfc3hfeTkLWtxLysk5IUTjlR6Yqy0oKjA7NtJQLHcbREsrLdvuGPSm+8WS5g5GVFW4YPIweK+yOzjSUnTkSxP2ZldriKUthorXlsqJJIXu3c586ttKCkSeynRUksd7Y2/xEYxGwh51AS0dxKcBQzytXPXnrX2f2V6LnsRGpdjacREjiKz+OdBS0DkJyFZPU8nJ5q7UoK/p/Rtg09NMuz28RpBjoib+9Wr8UjASn2iemBz14qwUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUr44tLaFLcUEoSMlSjgAeZoPtK0rrT4QunLLJci2WO9eX0HCnG1BtkH3KIJV9Qx76pivhOzcnbpiPjwzMV/RQenaV5i+M7O/RiN+9q/pp8Z2d+jEb97V/TQenaV5i+M7O/RiN+9q/pp8Z2d+jEb97V/TQenaV5i+M7O/RiN+9q/pp8Z2d+jEb97V/TQenaV5i+M7O/RiN+9q/pp8Z2d+jEb97V/TQenaV5i+M7O/RiN+9q/pp8Z2d+jEb97V/TQenaV5i+M7O/RiN+9q/pp8Z2d+jEb97V/TQenaV5i+M7O/RiN+9q/pp8Z2d+jEb97V/TQenaV5i+M7O/RiN+9q/pp8Z2d+jEb97V/TQenaV5i+M7O/RiN+9q/pp8Z2d+jEb97V/TQenaV5la+E7K3jvtMM7PHbMOf+itndnvbNpnWUhuElbltui+ExpWMOHyQscH6OD7qDZlKUoFKUoFKUoFKUoFedfhU67kQ0saStjxb79sPTlIPJQT7Lf14JPux516KzXh/wCEOtxXa/fu88FNBP0d0jFBrmlfM1aey6TFidoFkkXBxlqK2/ucW8oJQBtPUngfXRFXpW6nxpHUepHJNzfiOoTbYxipckttqfUSe9LygppIcTkjGRkAHB6VC2a16HMhyPKUy83IvEiG3IdnbDHjBtJQ7gEA+0ThR4PP1Bq+lXq723TrWmIT0L0NSlMsKcli4Zk96SO9QY/PCecHCeADuOcVYpVk0K3PZ3qhIjpXJ7pLF07z0phMdam3HDn8U4XAgbeMlRG3jkNR0rb9tXpZu23tiBCtCnLhaI0lLEm4lCW3e8HeMpWpYwRt34J3eHI4qKtNv0W9N05DmBlAdtypUuR6YcLkYXtZV7QS2MhOeUnnqM5oNa0rZN2gaNt72pXWG2Zfo8aMYcf072e+WcOBJQo7wnrgKVjzNY2g7Jp26W23v3aTBZW3NkJmpkTQypTPcoLO1JUCfxm/lP18UGv6VsBuBpRej0pIYTd1WlUwyfTDuEhMgpDXd5xko5xjPQj3/dHWTTk/SEty6yITd0dEkR1uTg2ttaGgpoFBUAApWRkhQPTKcchr6lbRft+jV6ju8W3RoLqIbDYiIkXQtsy1kpLii7uABSCcJBGceJrv06NKLtSbRdRCVGfv7raV+nYMZkspAdC8JKkgjgqASeeKDVBSU4yCMjIzXytw2aZZVNyIbpttxef01GQ2Z9xLaEupcQVMhZWkI4BOMgjbgdSDhO2TQf4L2x9U0Iec9FL77chJdClLAfSWt5OEgqwe7HQe0rPIarpW2LOdO2TtHsTqodmahKdcQot3QyWkp6IdWc4SeTwVY80pxyttk0Y9aLm7dDCjXBLr4U1HuCVpjpS2C2WlF38ZuVnoHPL2etBqelfWynvE95nZkbtvXHuq+qOmPwDm7/WG/vD6u77uu877jd8nnu8YznxxjnNBQa+trU2tK21FK0kFKknBBHiK45pmg9s/B/1w9rTRY9YL33S3rEeQs9XBjKF/WOD7wa2dXlz4Hy3RftRJH+oMZoq/3txx/Aqr1FmivtK+Zpmg+0r5mmaD7Svma+5oOBNeZ/hWaLeMyPq2A0VslCY83aM7CPkLPuIO3PuHnXpIqrolMtyo7keSyl5h1JQttadyVA9QQeooPznpXqDWnwdoE+U5J0xOVbt+SYryC42D/dV1A93NUpfwcdWBR23GylPgS46P/wDOiNKUrdPxcdW/nCyftXv8unxcdW/nCyftXv8ALoNLUrdPxcdW/nCyftXv8unxcdW/nCyftXv8ug0tSt0/Fx1b+cLJ+1e/y6fFx1b+cLJ+1e/y6DS1K3T8XHVv5wsn7V7/AC6fFx1b+cLJ+1e/y6DS1K3T8XHVv5wsn7V7/Lp8XHVv5wsn7V7/AC6DS1K3T8XHVv5wsn7V7/Lp8XHVv5wsn7V7/LoNLUrdPxcdW/nCyftXv8unxcdW/nCyftXv8ug0tSt0/Fx1b+cLJ+1e/wAunxcdW/nCyftXv8ug0tSt0/Fx1b+cLJ+1e/y6fFx1b+cLJ+1e/wAug0tQcnA61u1j4OGqFOAP3O0IR4lCnVH7Cgf41tDs77D7LpaW1cLmtd3uLZ3Nqcb2tNnwIRzk+8n6qDN+Dlo17SejFyri0WrjdFB5xtQwptsD2En38k/+rFbY31jZV80/ZTKvmn7KKyd9N9Y2VfNP2V93K+afsoMjfTfWNuV80/ZXXLmMQIEidNK0xmE7nClJUUjxOBzgdaDPCs19zWBb58W5Q0TLe4XIq1KSlzBAXgkZT5jI4PQ9RWVuoO1pASkE9a50pQKUpQKUrEuM9uC2lTgJKugFYuXKbVM11ziIWmmapxDLpWJCntSmC4g42jJT4gf/AIKh7HrOy3ncYz7rQEdMoGUypkKaUcBaSoAFOfEVaK6a42qZzBMTE4lY6VjpnRFLaQmSwVup3NpDgyseY8xXS7eLay2HHbjDQ2VFG5TyQNw6jOeo8q0jOpXQ5MjNlQckMoKQlRClgYCjgH6zwK4esYWx5fpkbYydriu9ThB8lc8fXQZVK6XZUdlgPuvtIZOMOKWAk56c1wbuENzb3cuOrcQkbXAckjIA58RzQZNKxfWUHukuemxu7UvuwrvU4KvLOevurCj6ktUma5FjzEOOtuONObejamwCoKPhjIoJelYarrb0tNuKnxA258hZeThXOODnnkj7a7mpUd15xlp9pbrfy0JWCpP0jwoO6lYUK6RZq5iGF5XEcLbqT1BAzn6Of8fKom1azs10kxmIj7pXIz3e9pSQcNB3qR81QP8ACgsdKi9OX+3ajtxnWh/v4wcU2VbSkhQ68HnyP0EVKUClQF31dabTOciy3Xt7IQqQttha0R0q+SXFAYSD7/DnpUsZ8RKnUqlMAsp3OAuD2B5nyFBk0qL9f2z1m1A9Ma9IdZD7ftDatBVtG1XQnPgK5XG/Wq3R3npk+M22ytLbhKwdilHABA6ZJoJKuJrrdlxmlKS7IZQUgKUFLAwCcAn6TwK6kz4ayoIlx1FKw2oBwHCj0SeevuoO9VYV0goudukwHnnmWpCdi1sqCVbfEAkHGRx588YrtTOhuONtolR1OOZ2JDgJVg4OB44INdxFBG2q2x7Ha2rbCcdVGaJ7pLigrukZyEA4+SOgzk48azM1wk8OJ+ivmaCQpSlApSlAqKvlrVPbKkLw4keyD0qVqpTNbx2bxcbcxAmSHISVhTiNoQpaWw4UZJ49kjk4GeM1x1FijUW5tXIzEt266rdUVU84SOnrW9CjSEyCAp3jAOcdfvqAi9m1uhaZiW+EWUT2BHKpi2d4eU0QRvQVfJJBO0EfwrrR2nQXLfGns22c7DfjvSwtJbylhtaUKWQVe/OOtdUbtBcRNeblR++HePtMtMIwpxSZno7Y3KVgZyM59591Z0umo0tqmzb5Qt25VdrmurnL6z2blmbb5DV07ssZL3dsFJcy44spSN+1KcuEAFJKR0NYaey15FpYgIusQtodbW6HYKnEvpbThCVAu/WcEA4AxgVLo7RYRYdcXBltqaQVqQooyMSTHI4OM7hn6Kk9NaviagemJixZTbbCStDriRtdSFKTkEE4OUng4OCK9Dm+X3SbV4vVouD0ktmHgPtIR7MkJIWgHngJWkKHXxHjVdT2YhMJ1j1i0SlttlhQjFBCUOFYU4UrClOZON4KfHjk1mQe0iPMbjhu0TxJlBhUZgqby8HUrUk53YGA0vqR0HnWOx2ld/McEezyXoq/Rm4+1aA4tx4rG1QJwMFBGc44PPSglJ+j3pGm7Lb03BtyTbFhaXZEYLbdIQpBCm8jwUcc8EDrVesvZtLTbLc3MuIjbER1vsIa3KDjbCmvZcCsAYVnoeRVs01q+Lf58qNHiSmgwFkOuJGxexZQrBBOCCOhxkc1Ds9pUOS8WIlsmvPmQ2w2hK2sOb0uKSoK3bcfilePlQRyuy1XqZqIi5styULz6QiO4Dju0t9O964SM5yk9Cmsub2bemPzi7dAlmQ5IcATHAUC8lAO47sEAo6YGQSKyI3aVb5BbW1Am+iqDIL52AIU6gqQkjdnPBGQCM+6vsTtGjPIjOO2mey062w84tSmyGkPr2NKICsnJ8ADgUGLI7NESm5Rkz2e+ktSkK7uIEtoW8htO5CN3s4DYOM8lRORUtpvR67LqWbc0zwtmQlY9HS2QNylBRUSVEZyD8kJznJyawpuu3nIkGTbLU+tqTNbYb71TeZDalLSSgb8pOUf2sda77P2h2+7XKHDiwp2X0oK1lKSGVLCiEqwc/2TyMjkc0HPSWjXrDdLlNeuQlKmNBrAZKMYWtQJ9ojPtkYAA46V0TNCOu2Ky2+NdjHdtsV2MHwxkrDjfdlQG72SBnHJqX1dqmPpgQ1S4sl5uQopLjYAQ0BjlaiQE9eM8cGoib2jQItwmxBClPLjYCVNKbUl096hogHdwQpY4OPHpQZmmNFs6eNxZi3CW5b5jbae5WrattaE7NyVpwRlIQOBxtHNSTem4bbiVpk3UlJBAVcnyPrBXzUGx2hw1zoEV63TY65Ly46lubA224l1TRSV7sE5TnAPQjGTxWbdNZR7dqBdsdhSVJbVHQ5JSUbEF4lKMgnceRjgGg6L9o164zLsqLc/RYd3bQ1PZLAWpQSNuW1ZGwlPByFedYLvZ6VpntInxkx3nzJZ3QkqcSsvJd2uLKsrRlAG32cp4PQGsWxdoz8sNpkWtx5TzMP0fuFJSXnHmi4RhSsJACT1J6dTkVI23W7j2pnbdLgOojuSGo7DySg7Frj97tXhRyeFDKcjpzQRcjsvLzm71oynvUKQ+BCGBuf75Xde1+L54HXHXmux/sz3tPpRcmgobvR1GKMjMhL5Lx3fjDlAAPs4BPnWXf8AtARbb0I6YbogRpDrMyUoJI/FxlPKCAFbsgBPJGOtSkXWDMjTU+8er5jaIRy6yoJ3FOAoqSQSFAJVng+BHWg56g0ozer5ari7IU36IfxzSUZElIUFoSrngJWkKHXxHjVeY7NVx0Nlm6NpejFn0ZYiYGG3e8Bdwr8YonjdlPj5mpBHaJb3Z8eMzCmvJeWQl1tKVDu+9LQcxnJSVJV0zwM+VYL/AGklxmOYNmkFx5yPsDziAFtuPFoqGD1BSRg46g9KBa+zpy33O1TEXVJVDUVOlLBSXsuOLxjeUgfjCMlJIxwRmthVXtKasi6lckiJGlMoaAUhx1I2upKlJyCCcHKTwecEVY8UGDL/ANcn6K4V2Tf9cn6K4UEhSuDLgcQD4+Nc6BSlKBUXK09Z5Ut+VJtsR2Q+gtuuLaBK0kYIPnxx9HFSlKCtydE2CTcmZjtujnukrAY7tPdFS1JUVlOPlZSP41nv6dsz6HkvWyIsPBQcy0Pa3L7xWfpX7X081K0oK7B0XYYkRqObdHfQytxbZebSoo3ulwpHHyQo8DwwKk4FmttvekOwYMdh2QSXVNoAK8knn6yT9JNZ9KCJd03ZXY/cOWuGpnYhsILQwEozsA9ycnHlmvqdO2dElmQi2REvMpQhtQaA2BBygDyx4eVStKDAhWa2wZUiTDgx2ZEgkuuIQAV5OTn6Tz9NQ8zQmnZIYT6tYabbeS8pDSAkOFKVpSFccgd4rA8Ks9KCuxtGWJi6uT029hTykoQ2lTadrKUI2AIGOODWevT9oW9DdVbYhchpSiOotDLSU/JCfIDw8qk6UETH03ZYz63mLXDbdW6H1LS0ASsEkK+nKifrPnXA6Ysm9K02uGhxDZaQtLSQUpOeBx/eV9p86maUEXJ0/apUOJFlwGJDMVAbZDqAranAGOfAgDPniuA0zZBJdkC1Q++dVuWvuhkncF/9SQr6RmpelBFL05ZlyW5CrZEL7ay4lfdDIUVb8/TuJV9PNdK9LWp3UTl7kRkvzlJbShToCg1s3YKeOD7R/hU3SghHdKWB1Gxy0Qiju0Nbe6GAhHyAPo8PKspix2uOptTFvitltaVoKWgNqko2JI94T7I93FSNKCKe07Zn7iue9a4bk1fCnlNJKj7JTyf90kfRXfb7RbrdCXEgwmGIy872kIASrIwcjx44rOpQRStO2YmETbIn+hJCI/4ofikgggJ8gCAceYr49pyzPMBly2RC0EpQE90OEpVvAH0KJP01LUoIqNp2zRXVOR7ZEbcU6HypLQB3gkhX0gqUfrPnUrSh460GHMH45P0VwxXJ5QcdyOg4rlig6iCk5SSD7q+F13wWayCmuBRQY5ef+ea+d8/89Vd/d187ug6e+f8Anqp3z/z1V3d3Tu6Dp75/56qd8/8APVXd3dO7oOnvn/nqp3z/AM9Vd3d07ug6e+f+eqnfP/PVXd3dO7oOnvn/AJ6qd8/89Vd3d1gXSe1ARgje6fkoH/eiVVRTGZZJfeAyXCBWG7eWmjhcsZ93P+FVibNkSye9X7PzRwKxNlTLx1avywtw1BHJx6Ur9U/dWUxcPSB+JkBfuBGao+yvoSQcjg+YplmNXV9YX3vn/nqp3z/z1VWrbeHWFBEnLjXn/aH31aGSh5tLjSgpCuQRVy9du7Tcjg4d8/8APVTvn/nqru7uvhQAMkgD30dHV3z/AM9VO+f+eqi3o6PlvtJ+lQroXcYKOshB+jmszXTHOW4t11cod/fP/PVTvn/nqrBXeYKei1q+hNY6r9HHyWXT9OBWJv24+rpGlvTyplLd8/8APVXYzIdSv2yVJ8a4RVokx23kDCVjIBrhLkxoTKnpb7TDKeq3FhKR9ZrpE54w4zExOJSLr4SgFHJPSsUqcX8pRIqBj6w01IfDLF/tLjpONiZjZOfozVibKVgFJBB5BHjVR8QnFduK5JTXPAoPpFcSmuymKDr2V82V24qKvBL0yBAyQ1IUtTuDgqQkfJz7yU592aDk7dLaysoduENCx1Sp5II/jXD1zafznB/eEffWYpqHAiLWpDEeM0krUdoSlKRyT7qx2Llan7P61ZkxV23uy76Skju9g6qz5cGg6/XNp/OcH94R99PXNp/OcH94R99dnrK1epvW3pMX1Z3Xfek5Hd7MZ3Z8qyYi4syKzJiqaejvIC23EYKVJIyCD5UGF65tP5zg/vCPvp65tP5zg/vCPvqT7lv5iP1ady38xH6tBGeubT+c4P7wj76eubT+c4P7wj76k+5b+Yj9Wnct/MR+rQQk/UNqjRVuJuEJahwlIfScn7apb91hvuqcdnxlLUck98n762f3LfzEfq07lv5iP1ajhds7znLVnrCB+Wxf2yfvp6wgflsX9sn762n3LfzEfq07lv5iP1aYcvBx1axYkR5BIYfadI+YsK/wru2VebvZ4lxirQ40hLoH4t5KQFtq8CD/ANvGqDEeU9bWX1ABa2gsgdASM1Jh571ndY4uxht2S4pESM++U8KLafZB8iTxn3VnsN3qOChiHKQ2eSAUdftq0aWZQzpy2pQMZjoUT4kkAkn3kkmulq/Ic1a/YvQZiVtRhJ9KLf4lQJxtCvOpVRtRh79PaixVFccZ+/JX1tXlfyo04/8ArH9VdKoFyUcqgSifeU/fVmiX5EnVU6xiDMQuIyh4ylt4Zc3eCVeJH31N4rjOlpnnMvp06+5TyiOzXvq64fm6R/L99PV1w/N0j+X762FimKng6Pu1+pXekNe+rrh+bpH8v30NuuH5ukfy/fWwsVxXwKeDo+5+pXekNZ6q15D0TopyXMbX6chRaZiOApWtZyRkfN6kn3edeR9YauvOrbkuZe5i3iSdjQJDbQ8kp6D/AB862Z8Ky5uydcwbeT+JiRApI/vLUcn7EprXPZ7phGqr87FkSVRocWM7MkuoTuUG205O0eJPAr0007MRDw11zXVNU/VWc1sjsr7Vbtoqcyw+65MsalAOxVqz3YzypvPQ+7of41h6CYsWodUtadk25aINxUWYslSwZMZwj2VFSQkLGeoI6Hg1TLjDXb7lLhOkFyO6tlRHQlJIP+FVl+h1nuEa622NOgupdiyG0utrT0UkjIrOxWlPgsXV6b2fORHlFSYMtbTefBJAXj7VGt10H2lKUComf/tFaf8Ay3//AKKlqgr5DYm320tSmw42EPqwSRzhHlQTMhpmTHcYkIQ4y4koWhQyFJIwQRWGxZ7bHs3qlmHHRbO7LXowSNmw9RjyOTXT+Dtq/JE/rq++vv4O2r8kT+ur76Dt9T2z1L6o9Dj+q+67n0baNmz5uPKsqHHjwojMWI2hmOygNttoGEoSBgADyrA/B21fkif11ffT8HbV+SJ/XV99BK5HmKZHmKivwdtX5In9dX30/B21fkif11ffQSuR5imR5ior8HbV+SJ/XV99PwdtX5In9dX30ErkeYpkeYqK/B21fkif11ffT8HbV+SJ/XV99BK5HmKZHmKivwdtX5In9dX30/B21fkif11ffQSiiNp5HStXQ1hdkilKEoAjJHHj7PWr2rTtq2n/AERPT56vvqiW9xR0/CaJ9huOAkeXs1JeTV8oW3T+oLYiw25KpOFCM2CNivmj3Vn/AIRWv8p/5avuru05/s/bP+Ga/wCkVIVXrRP4RWv8p/5avup+EVr/ACr/AJavuqWpQRP4RWv8q/5avup+EVr/ACr/AJavuqWpQRP4RWv8q/5avuri5qG1kH/Sf+Wr7qmK+KGRQeSPhQQ2n9RW69Q1lxh5j0dw7SNq0kkdfMH+U1qnSeopul7ym4W8NLUUKacaeTuQ62oYUhQ8iK9r9pGnYWpYcC13NvfGkSVJOOCk9y6QoHwIIzXlvXPY9qTTcpxUKK5dbfklD0ZBUsD+8gcg/RkUENpPUdm05eXL+xBeXcWdyoMMqywysjAWpZO5W3PCceWTVRkPuSpL0h9RW66srWo+Kick1Ix9O3qQ+GWLRcHHicbExlk/4VuLst7Dp0uaxcdXt+jxEKC0ws5W6R8/HyU+7qfdQbP+DXYXrN2eMuyUFDtwdVKCSOQggBP2hOfrrb9YsKOlhpKEJCUJACUgYAHlWXigUpSgVEz/APaK0/8Alv8A/wBFKUEkr/8AUIH91X/auylKBSlKBSlKBSlKBSlKBSlKD4r5J+itV27/ANyRv+HT/wBNKVJePWcobF05/s/bP+Ga/wCkVIUpVewpSlApSlApSlBC33/3hY/+MV/8h2u+QBzwKUoMYAZ6Cs2OB5UpQZqelcqUoP/Z",
+              "timing": 5880
+            },
+            {
+              "timestamp": 4960107788,
+              "timing": 6720,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcBAwgCCf/EAFUQAAEDAwMCAwMHBgsEBwYHAAECAwQABREGEiETMQdBURQiYQgVMlJxgZEWGCNVk9FCVFZikpShorHS0zNlcsEXJDU2dIKyU3OzwuHwJSc0N0NEw//EABkBAQEBAQEBAAAAAAAAAAAAAAABAgMEBf/EAC4RAQABAwAKAQIGAwAAAAAAAAABAgMRBBITITFRUpGS0uEU0RUyQXGxwQVhof/aAAwDAQACEQMRAD8A9U0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUrhSglJUogJAySewqvNa40q9cPYWtRWlcvO0NJlIJJ9O/f4UFipQkAZJ49arp1xpZM/wBiOorSJedvS9rRuz6d+/woLFSgIIBByD51FXnUNrsq0Jusr2RC8YedbUGh9rmNo+80ErSqF41yv/ykv8mG/wAGOlSHWl9wVJ5BFSx1fp6zRIEa73y3Q5SmW/0b8hKVcpHJBPFBZ6V1xpDMphD8Z1t5lwbkONqCkqHqCO9Qt31jpuzyxFut9tkSTnHSekoSofaCePvoJ6ldUSSxMjokRHm32HBlDjagpKh6gjvXbQKUpQKUpQKUpQKUpQKUpQKUpQK+VLSnuRXw+spGB3NQdxv1otj4YuNzhRXincEPPpQoj1wT8KCwJUlXYg1zUJa7vb7oFqtc6NLDZAWWHQvaT2zg1MNL3oz50H3SlKBSlKDW/jg+8uz2O0JeXHiXi6sQZbiDtPRUSVJz5ZxirHL0LpiRYVWhdlgJg7CgJSykFPGNwVjIV8e9ZmrtOwdVWJ+13NKui5hSVoOFtLHKVpPkQap7ui9ZyYRtkrXi1W1SemtaLehMlSOxHU3d8eeM0FEN9uT/AIHw4KprpQ5eBZFT0qwpcbqlO/PxSNua24jQOlU2P5pFit/sWzZgsp3dsZ3d93xzmvt7RNkd0SNKmMRaUtBpKQfeSQchYP1t3OfWq0nROtERPm5Ov3fm0J6YUbegydnbHVz3x54zQQ3iDKk6E8FDH07eHpZbdTDROUsKWy2pZBG4eaR7oPcVsXT+nLZb9OItzbQkR3mQl9bx6ipGRypZP0ic1127RtkhaPTpkREvWnpltbb3vFzJyVKP1iec+tYqtPXS2WUWfTE9MaNs6aJE1apDkdPbCE8Zx5blHFBpWO+7H8IvFCwJdW9brNOXHhrUc7W+oPcz8Mf21ufROlLND0nEbMWNOVLjockyXkBxUpSkglSie4OeB5Co8eGcCP4aztJQJLjftoKn5jid63HCoErUOM5xijejtR2mJ7BpfVLcK2hO1tmVBEhUceYbVuHHoFZxQVTT8t7SH/SjarISqBZ2vbILX0gwtbSlqQPgCM4q0+FmkrGzoa2yVw4s6VcY6ZMuU+2lxb63BuVkkcjJ7VNaL0dD0zZ5UQuuT5M5xT06VIAK5K1dyr4Y4AquwtBah0+hyFpDVvsNnKlKaiS4SZJj5OSEKJBx6A5oOjw+ZbsHifqzTdrGyzIZYnNsA5THcXkKSn0B74raFVnRGkWNLszHFy37hdJznWmTn/pvK8hgcBIHAA7VZqBSlKBSlKBSlKBSlKBSlKBSlKDHkj3gfhVR1KLmbgn2EXwtdMZ9hEPZnJ/9t72f7KujiAtODWMppYPbP2UFf0sJwbke3i6A5G32/wBmz/5ejx+NWWMPcP211oZUTzwKyUgJAA7UHNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKV8POoYZcdeWENNpKlKUcBIHJJoPulVeD4g6RnzGIkLUVsfkvrDbTSHwVLUTgAD1q0UClVi96/0pY7iYF2v0GNMGNzS3OU/wDFjt99WKJJYmRmpMR1t6O6kLbcbUFJUk9iCO4oO2lKUClKUClKUClKUClKUClKUClKUClKUClKUCvI/wAoXV2o7T4pXGJa79dYUVDTJSzHluNoBLaScAHHevXFeLPlM/8A7vXT/wByx/8ACTQelvCyfMneD1qmzZT8iYuG4tT7rhUtRBVyVHnPFaZ+TFqm/wB68QZka8Xu5z46ba44GpMpbiQoONgHCiRnBPPxq4fJ/wDEKyXTT9n0Ulib84tRXA4pSEhogEk4UFZ7H0qyzPDrTmh9Oaku2k7c5FunzVJbQ4JDrh+huwApRHdKfwojuufjVoi330Wp25qceDnSceaaKmW1Zx7y+2B6jNR958etHWm6y7e+Lk47GdU0pbLKVIUQcZSd3I+NeVNBs6ZkX0o1rLnRbZ0lEORE7ldTIwDweMZ7A84qHu6YabpLTa1vOQA6oR1vABam8+6VAeeMUHr2b8oLRsOY9Gebu3UaWUK2x0kZH/mqXt3jDpq460a03D9qclOEpD4QnpAhG4gndnjBB47ivGep/wDvFcv/ABC/8a9J6i8JtOad8OZ+orM1NRdWrYp1KzIJAK28LOPsUqgsl8+UBou2TnIrK508tq2qdjMgtk/AqIz9o4rOtfitpbWtlu0O1SnWp/sTyhGkt7FqAQclPcH7jmvKfhy3o9y6yBrt6e1B6J6JiDP6TP8ACwCe3b496m9Jp0e3qNC7bN1H7VvWIqTHaCSCCAFkKzjHcgds0Fd8NJTMLxC05KluJajsz2XHHFHASkLBJP3V6d0p4/6dvupE2p+JJgIed6UeS6oKQsk4Tu80549e/NeYfDSKxO8QtNxZjKH4z1wYQ404nKVpKxkEeYp4jx2YHiHqOPDbQwwxcX0NIbG1KAHDgADsBQbZ8V4fhcjxBuybu9qSNcutvlIhobU0pagFEpKuRnNRHi7rRVqf09adB3W82y2RLWyrpokLa3BxIdQTtVyrasZ+Oapfi+6t/wAQ7m66oqccRHUonzJYbJqweN0Vhm2eH77TDbbr+noqnXEoALhCEgFR8yAAOfLFBtv5O/iNHkaRujGp7vKclwFqlPS5zpWlLStqUgLUSc5B4+Pxqef+UFoVqWWUyJ7qAcdZEU7D8eSD/ZXmiRcLajwjhwYyoybs5dXHJISkB1TIbGzccZKdxVgZ71j2S2aek6UmSrjPbj3NCyEJMhW4jjG1oNHd9vUT91B7asestP3ywvXm23SO7bmAVPOk7elgZO8HBTx61ryf8ojRcaUpphNzlIScdVpgBJ+I3KB/srQEJqBA8PdTCxahkzVyG44lxDCUylKQ8nCisqIPJxj4/CsDQDehXIF1Ot37o1KCR7GIYyDwc+R5zjvgUHquH4uaWvOlLvdLbMeKoEcuvRy3tfQDwCATg8kcg15Z0v4k6khamtMq66kvr9uYltOSWjMcXvaCwVJ2lWDkAjB71bfBOJpKRqsx4rt5lSnochC48qK17O4jpkkL94nGQCOO4Fax0UuE1rKxLuwZ+bkT2DJ6yQpHSDid+4HuMZyKD1vevHfSNnmpiy27oXVMMvjZHSRtdbS4n+F32rGfjUlqTxf03p602O4z0XAx7wwZEbpshSgkbfpDcMH3h615Y8b5dvneJd0k2RbK7YtuOI6mBhvYlhtICR5AYx91TXjBNjSdC+GjUd9p1xm1KDiUKBKD+jGD6cpP4UG9XPlAaORAZmKbuvRedW0n/q6c5QEE/wAL+en+2knx/wBHs2hiehNxcDz62QyGkhwbUpJURuwE++AOeTn0ryZK/wC6Vs/8bK/9Eet0+APhbprW2jJVyvrUpcpucthJafKBtCGyOB8VGg3LqTxf0hp5mMZ89apL7SHhFZbLjqEqSFDcBwk4I4Jrp0r40aM1JPagxp7kWW6QltuW0W95PYBXKc/DNePnIzC9avRbwtTUcTFtPKW4UFACiMFW1RGMYztOPSpidZtJN6gWyjUiocNO0pcYZXNCT54XtbJ/o0HvClYNiX1LHb1l9ckqjtnrLQUKc90e8UnsT3x5VnUUpSlApSlArTHiX4Go1vq6VfFX9UIvobR0RE6mNqQn6W8enpW56UGnPDHwRRoXVbV6TflTihpbfRMTp53DGc7z/hW4nEJcQpC0hSFDBBGQR6VzSg0ddfk46dl30TIlwlxIKnN7kJKQoYzylK85SPtzUbevk1Qpt2lyYWoDBiuuqW1GTC3BpJPCQeoM49a9B1hXx6bHs0560x0Sbg2ytUdlatqXHADtST8TQaGufya2p1xkyvypWjrOFe32AHGT2z1K30zb2haEW6QlL7AYEdYWnhxO3acj0I8q0DovWXi9N1pCi3ayui3uPhMlLsHpIabz7xC/gM45OfjW/rzcGrTaJ1xkZLERhchzHfahJUf7BQaQvvyarJLmLetF5l29pSieitoPpT8EnKTj7c1P6J8C7FpdciT7XInXJxhxlt95ICWd6SkqSgeeCe5NaVufyg9ayri47BdhxIxUS2wmOleE+QJPJPx4r1Voa5yLzo6y3Kbt9qlxG3ndgwNykgnA8qI1DpT5O7dg1Na7uNSrfMGS3I6RghO/aoHGeocZx3xXGqvk7t3/AFLdLudTLYM6S5I6XsIVs3qJxnqDOM98Vvutf+Mt41fZtPsPaHt3tklThS+tLfVW0nHBSjzyfPnHp6FUbVfyeW9QX1+5HUq45dS2npiFuxsbSjv1B325++rlqnwls+ptHWSyXJ90SbRFbjR5zSQleEoSk5ScjB2g4/tqs+G+u9axrFf7t4i2qQi2W9gPNu+zBl5as8pSkkAjHOePtqa0P426e1jqaLY7bBurMqSFlC322wgbUFRyQsnsk+VEV7TPyc7LbZEpV3uj9zYeZU0GuiGdhOCFA7icjHFRr/yY7cqUVMakloj54bXFSpWP+LcB/ZXoatMQPlEaWm3OPBatt7Dr7yWUlTTW0FSsAn9J25oq1aV8KdMae0vPsbcVUti4J2y3ZByt7HbkYxjuMdjz3rXVx+TLanZRXb9QzIzBOem7HS6R/wCYFP8AhXoKlBr3wy8J7HoFb8mGt+ZcHkdNciRjhPcpSkcAHj1PFUvVHycbLdLo9LtF1kWtt1RWqP0Q8hJPfb7wIHw5re1KDR9++TxZrlbLazGu0qLMhsBhUgtJWHgCSCpGRg844PYCsW6/JvtMm1WyLb7w5EfjBZkSFRuoqSpW3nG8bQMcDnv+N/8AGG76ss+mm39EW4TZindrxCOotpGPpJR/C5x649PSu+B+ovEC9y56Nb21bEFtsFl92N0FlzI90DjIxk5xxj40RWHfk2tuWmNB/KhYDLzr2/2Ac70tjGOp5dP+2toeE2hU+H2m37Sm4GeHZSpPVLPSxlKE7cbj9Tvnzq6UorUfiJ4F2LV92dukaU/ap753PKaQFtuK+sUnGD9hFRek/k6WC03FmXd7jIu3SUFpZLYabUR9YZJI+Ga3hSgAAAADAFKUoFKUoFKUoFeevlF+Kt307eWtO6af9kdSyl6TJSkFfvdkJz245J78jtXoWvNXymPDe73G/I1NYoj05pxlLcpplO5bakjAUEjkgjHbtj40GublrnxEh6Qhi4zb3Hjy5HtMW4qdcbU4naQUBX8JPZQH2+tcwNc6rX4eXuUrUl4Mlu5Qm0OmY5uSlTckqSDngEpTkfzR6VCaiu+qrpoy3Rb2t35mtTqYkZDjQQQrYcDOAThKcc9sipLQ2nJ+pPDTWDVqYckyYkuDK6Lady1pCZCSAPM4XnHwoi6eEGrdRXHSviG9PvtzkuxLOt2Ot2UtZZXtX7ySTweByKq3hzrjVUzVKWZepLw+17HNXscmOKG5MV1STgnuCAR8QKxvDtvVMG1axiWu0KVHk2xxE5yQ2pPRbSlROPVR5AHr9lR3hjBlo1chS4r6R7DOGS2R/wD1HqCf8Ktb6pn+I+nYs3Ud3kRnpjaHGnZjikrST2IJwRXp3xqhzZ3hZqNq2yfZn0xVOqXuKctoIU4nI+shKk47HODxXkjwfgy2/E/TK3Ir6Uic2SVNkAc17M8RkqX4fanSgFSja5IAAySekqg8NaAt1zu+sLZAsU32C5vuFLEnqKR0ztJzuTyOAe1bR8V/EzVlvvEfSlruj7K7YwzFkyI6iXZUgITvVvI3fSyB2J7nvVS8DIUpvxY02tyM+hAkHKlNkAe4qrJ8oDQd9tevp1+t8OU/bprgkIkR0FRacwMhWOUnIyD8aCI1lrvxGgwLPb75JvNplR0LKXuo4wuUg7cFeMbinBGe/PPxklaz1N/0GIuP5QXX2/8AKMx/aPa19Tp+zBWzdnO3POPWqnriLrW4wbNddWKnShLbWIgeBK0tp25O0DgHcPicZ9KlVQpX5vyG/Zn+p+U5Vt6Zzj2Uc49KDN05dNUar8Mdc+1agnyEwRFfWJUpxeWv0wWgd+/u8djt+FVTwntl0u+v7VDsM72C4LUtSH+opG1KUFShlPPKQR99bF8AtPTrzo3xGtTTSmpMyGw2z1UlIKv0uBk/HH41rqys6t0JqxmVEtkyLeIxWhCXIpXnckpOBjCuCeRQe5tTRJk/Tl0h2yR7LPfiutR39xT0nFJISrI5GCQcjmvz4tbEh+9RI8Z7pSnJCG23dxG1ZUAFZHPB5r9DbK6+/ZoL0wFMlxhtToKdpCykE8eXOeK8Mar0dqPROqVh+3ycx5HVjyUtFbbgCspUCBj04oNleLPiZqvS7kLR8G5FE23w2W589BK3ZDxQCSFKGQORz3Oapatc+JmlJkZ64XS8NLdG9DU8lxKx/wAK8/8AKmtdK6zv8OPrW4W6TKXcU5kdGMUqaUg7AVIAyElKUkHGKxbfctd3edEYscGUxIaGxKbdATHBPHKyhIBPHdXagn/FPxP1Fc5lhuFsulytKZVrQt6NFkrbQHQ66hRAB89v4YrFv+rtf/8AR1pqe/dpbNsW6821KRLV7RIcC1ZK1ZzgD3QM/wAH7K6vG6zagiXqxM35x+4XRNpbMh5Kd3vF107cgYOAQPuqT1bEkq+TvoZtMd4uJnSipAQcj9I53FBw54m6on+EL3UvM1u4wbuw0JjTpbdW04y8dilJwTy3nn4elVuNr3VytK3F46mvRdRNjISszXMhJQ+SAc9jtT+ArEgQZY8Mr0gxX9xu0EgdM5I6Mr94qPiwJn5IXNPskjJnRSB0z/7OR8KC3aRv/iXqm1Xe3WKbeLmoqZU877YorZSN+AkqVxuPfH1a9S+EMW8wvD61x9Te0/OyAsPe0Ob1/TVjJyc8Y86058kCM+xL1T12XGtyI2N6SnPLvrXpSgUpSilKUoFKUoFKUoFKVV79q5FnuK4jsJxZACgsLACgfuoKf8orRt71ppy1xNPRkSH2JZdcSp1LeE7CM5UR5mo75N+g9QaJRqEajiIjGYY/R2vIc3bOpu+iTj6QrYVw1fHh22BLEdTntaSoICgCnHfP319RNXRHLUufKaXHbC+mhOdynDjJwKuBZaVSkeIEMu4VDfDefpBQJ/D/AOtfGubzHl6ejeyK6iJK8hYONu3GQR99MC8UrUWj7uLTcnHXG1OhbRTgKxjsf+VWmNr6K6+lDsRxpB7rKwccemKYF0pVWtOsY0xmW9JaMZqOAclW4qznAAx34rDX4gRA4QiE+pH1ioA/hTAutKjbHeol5YU5EUoKRwtCxhSakqgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVRPE+DluJOSPoktL+w8j/AJ/jV7rDu1vYukFyJJ3dNeOUnBGDnikDSrj7jzTDSjlDQKUD0yc/4mrBq+3uW6DZ2FAhCWTn06hOVf4j8KtsbQ9rYkNPByUstqCgla0kHB8/dqfuVvjXKMWJjQcbPIz3B9QfKtZRqaU5ZjYWUR2XhdARvWScfHzxWTDQ7+RE9Sgej7S3t+3z/wCVXBOhbSl3cTJUPqFwY/wz/bVgFviCAYQYQIpTt6eOMUyNTacnsQPnH2gqHXiLZRgZ944xXTpphqTfYTL6AtpbmFJPYir+vQtpUsqCpKQf4IcGB/Zmu23aNt0CazKZdlFxpW5IUpJH38UyIbX1pi2+0srgRkspU8A4U554OM/21U4areLc8JI/6zn3cIUVfcdwA+8Gtyyo7MuOtiS2lxpYwpKhwarS9C2lTm4KkpH1Q4Mf2jNIkRnhyIXtsgxBL6oawsuFOzuMduc//Wr7WHarZEtcfowmg2knJPcqPxNZlSVKUpUClKUClKUClKUClKUClKUClKUClKUClKUClKUClK1x4i3WQbn7A04pDDaAVJScbieefuxViMjYwWlRwFAn4Gua1A7YLxCTHfShQLnKC25yPP1rnUz09SbeLkFokJZKSSrlQ3HB4/8AvimEbdUpKfpED7a5rUtssd2vNsaXHW2Yza1BIUvHPGT/AIVzerpcblc/m9lxYQlYYQ0hWAojjn15pgbZqj32Nqpd1dVCcX7MVfoumtKQB5ZB86qxdu+mrglC3FtOYC9hXuSsfHy8jXVqSUZN5kPoUoJdCFgZ7ZQDViBt23CQiAwJykqkhA6ih2JrISpKvoqB+w1qfVEif7Pbm3FOpheyMlvBO1R2DJPxzUdbYUmQA5DlsoezwgvbF/dnH+NTA3UTgZNcJUlX0VA/Ya1Rq526ocjMzlPJaSygAEnClbRuJPmc5qPtsKVICXIUtpL+eG+vsX92cUwZbopWqdV3WeuU1AW64gMtIStIVypZSCSfXk1h31m7QY0ONc9yUJCiz74JwcZGQfgKYMtxUJAGTwK0ypa/yaQdys+1q8/5gr7t6JrthujjMjZHaLZdTzleSQBn05pgy3GDkZFcFSQcFQB+JrTdmvsy1tSUMOqw43tSCchKsj3h8cZpbrXcr2JD8cl0t8rUtzkn76YMty0rWmm5V4tDEp15t1cNLKlALUCEqA4PfPfjj1qBU/cLxJWp6VuWPe/SuhAHwGTj7hTBlumla00bKvEa6MtKblOwlq2LCklSU/zgfKtl0mFKUpUClKUClKUClKUClKUCqNrnTcudNE6AgOkoCXG84PHmM/CrzSg06mw3ySpDSocohPCepwlI+GeKzr5pmfFbgssR3ZCg0S4ppJUAoqPH4YralKuUwrugor8Sw9KUytlzqqO1acHHFVjUul7ixdXZlsbW62tfUSWz76FE57fb6VsmlMq1TH07fLxNC5yHkZwFPSDyB8AeTXzqKwz/AJ4kCJBkOMJ2pQpLZIICQP8AlW2KUymGuJ0DUUfouQUPlhUdkFsEKAIbSCCg+eR6VDCwXqfKKlQXELWeVKQG0j/AfhW4KUyYa5uls1HCkf8AVFOvsdNCTtIWkkIAPun4j0qGRp69T5RUqC4hajkqWgNpH3cD8K2/SmTDW2qNKXDqtyIyTKJbQl3b9LcEgE48wcVFzNO3n2WM86xIeW5uHTwVKbSMYz6ZyePhW3aUyYamVZrl+T6GvYZPVEpStvTOcbAM1nWe1T2tMXxlyG+l13pbEFByrCucCtl0pkajtOmLhLkOMvxXo4LZKXHEEJCh2BrqXYL5EWttMSSN3Ci1yFD7RW4aUyYa60zpCUsvuXJJYQppTaE5BVlQxnHwqLVYr/aJa/ZGn8kFPUj8hQ+7/nW2aUyNeaS09dRcm5c5T0dlCt5SpZ3OH4j09c1gmz6i+f8Aftf63Uz7Ru9zGe+fT4VtGlMqUpSoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKVTtRXKVa7lOhtPr6tzZR837jkIe3BtePgNza8f8RoLjSqnGvE9sNPFUZcFM35v6KgoyCQ5095XuwTkbsbfo85rptt3mv8ATh20RIuxp2Qtcre4FAPLRtB3A/wckknGRxVwmVypUJp6aJki4ObEZ/QqKm3S4lW5pKvdzxjnyAz3qJTqS4NWVN3kfN6o78VchqMCpDqMJ3BJJJCsfwiAMfGmDK40qpTb5dbcJLD3sMqUGW3mltIU2gbnAjaoFSj55Bzzg8cV1Tb3fYKbwt75uW3a0peWUtrBeQU7ikDd7hAB597PHApgyuVKqDl6vSnEOMIt4juXBcFKVpXuABUA4TnB+j9HHPqK6HNSXkzBbGI8dyeh15LjyG8oKUBsjCFOJOSHR/COMHvTBldqVUEX28TGmfZGoLDvsSpTnVy6nclRTtSUKxg4znJx6GmmLhcrjqGa65LY9hXHjPojFpW5AWhRGDvxn1O3nHlTBlb6VVZN7uaLhPU2mIIMOcxEUlSFFxwOBrJCt2AQXPQ5xjjvXVF1FcFogS3ExDFnuuMtR0IV1WilKyCo7sK+hggAYz3OKYMrfSqkvUk1UO1qisR3pMu2mYWgrbleWQAMnt+kVwTzgDNSdiuMm5QJgWttE1lwtHdHW2EK2gjchRz5jsrBHnTBlNUqj2O53z5n082ZMGS/O4U8tpYLaUtlRz753KyMdx3rvZ1NMVcSgiO5FdRILKkNLTy3295R98cc4SAD5mmDK40qmpv96bbZS7HiPyJUNEtlDKSnZ76ErSdyvfICwRgpzjFR896VqCbYW3HIK0ImvNvMvwnMb0tKV7yFLGDg8d+SDnypgy2FSqsxfJ6nWZKvZDBdnLhJjpQrrJIWpG7duweU5I2jAzzxXTFvV7ksWtQTb2nLi84hGULUGkJQs5PvDcTtHHGM+dMGVvpVJb1PdWIEe4TWIrkdbkhhTDCVdTeyl07gonGFFo+7jjcOTivqbqO6W6C89I9gkuLtz09joJUlKCgJ91WVHcDvHvDHY8UwZXSlVKTerzFkSYZZiyJSAy4lTLZG1DnUz7hXlZT0/IjIPbjnsuVycm6DmzEuYe6S0lTaFNEKSopPuq95JBB4/wAaYMrTSqqrUMoahZjJ6DkJyUYmUtLBSoIUo/pCQCcpwUhJx61aqilKUoFKUoFdL8SO+8w6+w046woraWtIJbJBBKT5HBI49a7qjp17t0GWiNLlttPKAO0590E4BUeycngZxmg7hbIInGaIccSz/wDzdMb+2Ppd+3FfEmz2yU021Jt8R5pslSELZSoJJOSQCOMnvXS5qC1NmSFTWsxiEvAZOxROAn/iJ4x3oi9RXxDciPR3GX3VNKUtwoUkpSpRASRncNvIOMDJ8sVU3JBphllS1NNIQpeNxSkDdgYGfuGKxmbTbmJLshmBFbfdBDjiWkhSwe+TjnNY7eobS6w68iewW2tu5WfrcJx65PAx38q4d1FaWozT65rfSd3bSkFR936RIAyAPPPbzpvNzJj2m3RmVtR4MVppZClIQ0kBRByCQB5Gu52HGdS+l2O0sSE7XgpAPUGMYV6jHrWFJ1Bao0hDD81pLighQHJwlXCVEjgA+p4r7F7tpuPsAlt+1btmznG7Gdue27HOM5pvVlCHGASBHaAS4XQNg4Wckq+3k8/GuiXaLbMQtEuBFfStfVUHGkqBXjG45HfAAz6V8W+9224SVx4Utt11IKsDPvAHBKT2UAeMjNJl7tsKaiJKlttvq2+6c4TuOE7j2Tk9s4zRNzKRDjNhIbjtJCW+kMIAwj6v2fCvlu3w2nmnm4rCHWmw02tLYCkIHZIPkPhWN8+2z5x9h9rb9q39Mo54XjO0nsDjkDzr6ul6t9rUhM+UhlSwVAEEkJHdRwOEj1PFQZJhxldXMdo9VaXV5QPfWMYUfUjann4D0rrZtsFmWuUzDjokrzudS2AtWe+T3r4VdoCXi0qS31ApCNvmSv6OPXPPI44Poa6Y2obVJmCKxOaW+pSkADOCpOdyc9twweO/FB2ostrb37LdDTvSUqwykbgSCQeOxIH4VkQ4caE0W4cdphsncUtoCQT68VGw9SW2W/LQ1IR046C4XCeFoH0lJ9UjtkedfbN9hPFTrcmMYKWVOl8u44SrBOMY2/zs1d5uZjFuhMLC2IkdtQWXAUNgHcRgq48yPOuoWe2BZWLfECioryGU53HOT278n8TXS3qK0rhuSvbW0sNLS2srBQUKUQEgggEZyMetDqK1CGmUZaekpZaA2q3lY7p2Y3ZA5xjtzTebmW9bYTyEpeiR3Epb6QCmwQEZB2/ZlI4+Aoxb4cdLQYiMNhlRU2ENgbCQQSPQkE/jWHJ1HaI7bDjs9npvI6iFJJUNn1iR2T8TgVmzZ8WDGD8t9DbRICVE/SJ7Aep+AqK+U2yCiaZiYccSz3eDY3njH0u/auxEOMgMhEdpIYJLWEAbMgg7fTgn8awTfIYHXMmMIHQL5eLvIAVg+7jsPM54PGK6hqmy/rBoEK2qBCgU9uVccDkcnjnvV3okkwoqEtpTHZSltanUAIHurVnKh6E7lZPxPrXS1Z7ay0+21b4iG307XUpZSA4PRQxyOTXSvUFqRO9jVNaEjqBop591Z7JJ7AnyB7+VYzGp4IgIkz1pilbzzSW+VqIbcUgqwBnHGScYGe9N5uScm3QpRWZMRh4rCQorbCshOSnv6bjj7TX0IUUQ/ZBGZEXG3ohA2Y9Mdq7W3m3WEvtLStpSQtK0HIUCMgjHeqhbNXOzZbJ2tJiOzHY3LTiFoShLx3EqABJ6QPHbJB5oLKu025b6nlwYqnlKC1LLSdxUOxzjvwOazajZd3jNRUuMOsLW4z7Q0HFlCVIykbt2Dge8ny86xbtqaBAcWwHkOy0ONtloEjBWpIxuxjdhWdvfFBOUqOYvdtfuKoLUttUoEp2DOCod0g9iR5gHIqRqKUpSgVX5tnnifPdtsmK21cNnW67RcUgpSE5SM4OUgcHgHnnOKsFKCuuaecEYdB5pMpu4LntqUjKSSVDCgO/uqIz5HB8q6hpyQ5LbmSJDCpCpapTyUtnZzHLISATzxgknvz2qz0q5TCosaYlIjvNKcjlkpaDcYrdU2koVncklWWz2wE9sedc/k3cVMNNOXErbw8FIU457m8gpwrO5e0AjCjzn4VbcilMmFRRpWQbLcYbkhnrSra1BC0pOElCVjd/eBrMYss9h1cduTG+bVyXJKtzRL3vqKykEnA95R97GccfGrFSmTCq6b01ItcqGZD0dxiEyWWSneVq7AE7lEJ4HZPcny7V83bTEiVc5zrDzAjz1IU8Hd5KdqQg7UhQSrKUjuODnv2q2UpmTCvPafWtEkJeQku3Jmfnb2CC2Sn7SEEffXXf7BJmXRU6C8ylxyOIy0vFwAAKUUqGxQz9NWQe/HI87LWFKtcOU8XX2d7h4J3Ef4GuV2q5EZtREz/ucf1P8NUxTP5kKNNOIu9vntvshdvbRHYR0+C1jC8/zj5Y7Y/nGo+zWK4SbczGmqZYgonPydvTUl4/pVlI9Byc7vMcfGrL8xW7+L/31fvp8xW7+L/31fvrhtNM6KfKfRvVtc57fKuQtISmoior0iMW2oTkNhaQsqO5O0KVuUQngchPf8BUjedNfOLSmg8llHsiY6NoPuqStK0ngjjKRxxxUl8xW7+L/AN9X76fMVu/i/wDfV++m10zop8p9DVtc57fKEb0zJcS4uW7GS8uRGcw2FqAQy4F4Klkkk8/AfjXe7YJbV6fusF+P7Sp9a0oeSSjYtppCgccg5ZBz6EjzqU+Yrd/F/wC+r99PmK3fxf8Avq/fU2mmdFPlPoatrnPb5QEzTFwcdMhEuIuS/HDD5UhbaAQpagpKUKGf9ooYVnOBz3zM3S0e0WuJEZSyr2ZSCnqbk/RSR7qkkFB57j4jzru+Yrd/F/76v30+Yrd/F/76v302mmdFPlPoatrnPb5Qjml5T0FTMiaHVqiuRypzKvpOhYGSckADbk8nGTWbc7AqYq/qS62k3KEiKnKfoFIcGT6j3x+FZ3zFbv4v/fV++nzFbv4v/fV++m00zop8p9DVtc57fKvRrLcZKrpHUphqDIuHWWpbag6Up2H3fI52jCvLnvxjlek5TS2X4khhUhHtCFB0uJSUuPFwEFCgcjOMdj8KsHzFbv4v/fV++nzFbv4v/fV++rtNM6KfKfQ1bXOe3y+bJDkW5lqESwqGxHbQhSElKlLGd/HYJ+jgfE1gHTq1NQm1vp2sTJMlWB9JLodGB8R1R+FSPzFbv4v/AH1fvp8xW7+L/wB9X76m00vop8p9DVt857fKBOmJ70ZhmRLjbWIBgo2IPve82d5yfRvt5eprtl6cmuNy4jMmMIT85E7K2yXAQ4lak+ndPB8hxjzqZ+Yrd/F/76v30+Yrd/F/76v302mmdFPlPoatrnPb5Qlr0s/CuEbL7C4MZ9yQ3neXCVbsAgq2jG8+8Bk48smrbUc3Zbe2tK0MYUk5B3q7/jUjXe1VdqidrER+05/qGaopj8slKUrqyVR9TaguMO7z2mJDMVuG22ttDuzEgqGecndjPujYM5B78CrxUZML6pQULU3I6Zy26pxII+zIyK53L1NmNaqJn9omf4iViiat0IayuOp1neGZN2WVK6bjcJfTGUFA5SMbsA8ZH31gz9QT2pl9Wi5RkG3Sm2mYJbG58KQg7Sc5yoqITjz757VZvarhu3fNQ3ds9dP7qwYsV+PLkyRZwt597rlS30EoVsSn3TjgYQK4fX2uVXhX6t7GrnHePur/AM4Ox5BmxozPXjsXZSGm0YC1IfQBkDuTjn1Oa5vs+c7Y71GjXoTQLauV7VGQgFo/U4yMKGSPMbTyataX5qVAptCARnkPp8zk+XnXDTsxlKg1Zm0BRyQl5Ayfwp9fa5VeFfqmxq5x3j7qvftRyIEBx223dM8RYhllxKGSl33lABSgQCPdIwgZ45Paul66SYU7VMuFcY6FMSm3W4hQFGSSw1hOe/vcBO3z9e1W1S5aykrsrSikEJJeQcA9wOK4BkhSVCyMhSeUnqoyOMccegH4U+vtdNXhX6mxq5x3j7qwq6TIiWo0Z4RESZs5a3zsyCl3hA3nbk5J8+En7RadN3T5wtsQyX46pjjRcKWlfTSFEBYHofvHPc1w6qU62W3bK0tsncUqdQQT64xWTCXIW/l+3ojgI2hwOJUcenHlWqNMt1zFMRVmedNUf9mME2qqYzMx3j7s+lKV6WClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKg2tWWV3Vr2mUTM3pprrrj9JfCMA53Y29lDzoJylYMS8WyZMdiRLjDfltf7Rlp9Klo+1IORVVPitoxN7ctK7yETm5JhrSuO6lKXQop2lZTt7g+eOKC8UqNN/s4kSGDdYAfjpK3mzIRuaSO5UM5AHqawZ2tdMQYhkyb/a0shrrAiShRUjONyQCSRnjjzoLBSqlp7xH0jqESja75FWIqC691dzOxA7qO8D3eRz25qbj36zyGnXY91gOttIS44tEhCghKhkKJB4BBBBoJKlYEW9WuXAenRblCfhMgl2Q2+lTaABklSgcDA55qMn630zCtUi4u3uC5EYbDri47ofIQVbN21GSRuOMgd6CxUqM/KC0BURDlzhtOS0JcYbdeShbiVDIwkkE5+yuF6hsqJT0ZV2t4kspUtxn2lG9CUglRKc5AABJ+yglKVXtO600/qKxyLzark0u2R3C07IeSplKFAAnO8DAwoc9uaz49+tEll52PdYDrTCA46tEhCktpIyFKIPAI5yaCSpUUxqSxyA+WLzbXegkLe2SkK6aT2KsHgHPc19ov8AZ3LY5cm7rb1W5s4XKEhBaQeBgrzgdx5+YoJKlQ35V6ew6fn604abS84fbG/cQrbtUeeEncnB7HcPUVmW67225lYttwiSyhKVKDDyXNoUMpJwexHI9aDNpUYrUFmSZQVdreDEGZGZKP0I7ZXz7v31hyNZ6aYiSpKr7bVtxWDKdDUhLiktAD3tqSSRyMYHORjuKCfpVFb8VdKvv2xqJLekfOUd6THUhhQCkNFYVndgg5bWBkc4rNsPiFp68aS/KQSzCtIdLJdmAN4UDj1PmaC20rAnXm2QIrMmfcYcWM9jpuvvJbSvIyMEnB4rEVqmypvYtKp7YnGH7ftwdnQ3bd+/G3GR60E1So1q/wBndgOTmrrAXCbO1chMhBbSfQqzgVEzdf6Wh3G1QXLzFck3RwNxExyXg4oqCRygEJ5IGSQO/oaC0UqsO62tLWuk6Tc9oF0VHMncUDpBGCeVZ9AfKpSDqGyz5aYsG726TJUkrSyzJQtZSO5CQc4+NBJ0pSgUpSgVq2f4e3tXjGrWFvukRiE80hh9hSCXFNhCUqAOMAkpHNbSrXOtPFOPpjVLdkVZbhLcUlB6yFIQglXZKSojcr4DmggfDLwel6O1c3dH7lCkxo6HUNFuOUvO788uKJ8gfL0FQy/BC8J1hcr8xdbbvkXX25pp5guJDZWtRBCgRvGU4P21bn/FyL+U8u0RbLcnmY8tUBc5CQW0vjuCnOdoPnVZ0z44ufkZAuF8typl0nTH47LEIBtJS2lCiSVK9Fj7aIyNIeCb1k1cZ0y4QpdtHtHBjn2h0OpKSlaiccAnkfH1qGtnyeXkWe9xLjeWXH320NQHkIUQylLhWQoHHc47fGp66+PtsgLYCrDclByGJhClJQpAKikgg/Ed/PipK6eNFuiuwkQbJdLgXoLVwd6ITllpwgJyCeTyOB60FMi+Cl4stl1LOkTWLjc37QbfFjQ2ykKwhCQSVY5wgffk196d8ELkrT7zkuTb48uXa2IoiqjFKQrehxfWKVZUoFJTuHwPlV2Z8Y7ZI1emyRLTcnm/akwlyglICHVeqM7sA9z8DX1r/wAX7do+8Trcq1Tp7sFht6QtopShveoBIJP/ABDnHmB9gfGjPDadYfDbUWnZEyAuXdGnm0OMMlttve1sTnzVj1PP21WtB+Bz9h1DaZl3ftU+DHiOx5UYslQfUpbigSFDBxuR3+r9lSVy8d7dBcloXZZazHt0a4nDqfeS8GSE9u464/ompDRHiPN1J4ozbGWGWrWm0MXFkbf0oU4hleFKzg/7XHbyoIrW/gxIv2t3LzCuEFmHI6AWy9GKlsJbSE4awcAEAccV26W8I5tq8RX9QSpVpXCWt9ZaajEuOdQKHJUTt4Xzt4PpzXe346Wd1ySUWm4+zBmS7FkK2hMroJKlgc5TwOM1lRPGGO7pBi/v6fuTTMySiJBaCkKVKcUVDCTnAA2Hk0EPbfDS8aV8INX6cZfaubk0rdiIYSUrJKUpwc8Z90f21B2HwLuD+mpXttwjwJc21MRUMsx9uxYUh1XWwfeVuTtJHlz8KsULx6tcptOyx3IyVzFRG46VIK1bU5UruAMAjj418MePdvettnmIsU5XzlNdhIbS6jclSA1zzgHPWH4UETbPA+6xYepWnZ1mWbq2ylDaGFoaQUOBZG0EEDjAwc1Y7N4UzI3hLetJS7hCEq4O9VL0ePtQjBQUgjgq+gMk88+eKiLT43Lv+sdNRbVD6NrnNvGU28jc8laAs4SQrHZI8vOpGN47WxcK5ypViucZmE2F4WpsrWStKEpKc5SSVZ54wDQVlnwIvaY17bdvFuWqfa48BtSULAQWlxzkjnjDBH2kcCrZ4WeFk7RmqZlyfmxHI0i2NQulHSpJ6iUthS+RjkoUfX3qselPEBOo9OXm5MWacxItgVviulOXSElWEKGQc4I+2qbE+UFZZMZ6Qi0Ty0ywhxZQpJIdWvalr0ye+c9gaCJheAEppU1Dt8jBr2V+Ow41GKXHS4SQp8597Gf7B6Vk6Q8Eblapt3Vc7rBeYn2VdqHSaVuQopQkLweDjZnv6dqzNWeNT8TQ715stnLc6LchbpcafyGVbVK/gK57Y/GrDZ/FNu5awmWBmyy1mCAuVLQtJbbRs3FeO+M4Hn3oKZYfBO+QJ9hdk3a3ONWuJJipCELBUHesQe3kXj+FXLRGhb3pPw0NgiS7U9chIU6l2SwpxjaVA4KeDnAr70D4sQdZX1NviWi4xm3W1usSXQkoWlJIOdpO08Hv6VHs+NMNTmonHbFcEwLGtbcmUlaFJ3BRQgAcHKlDA/toMjxW8OJ+s3rJLiTbeiTAacacZlxy4wvekAqCfIgjIz8PSsq5+GESd4b/AJO9SK1dBDRE+c0Rkhe1Lgc2DzCCofRz2NRP/TZFGm5t3c09cm2ob7LbyVKRjY6DtWFDg9gCPiK+V+ONt+aWpzNmnPCVNdhwkJWke0dMAqWCcAJ95P3n4UVDx/BS4t6MuVqXNsypMyWy/sEZaWQltK0gcEK3HfnPwx519M+Ctzjw9JOs3S2JuVlnKluKTF6bbgKm1Ae73I6fmBnJrNunj3bYC4QNhuSvaYRm7VKShSAFLSQQf/dk59CK7bx472u3KibLRMeRJtqbilXUSkhJyNpHrxRGfqvwxmX7xEm34XFliHJtTluKAkl1BW2pG4eXG7Peojww8ILnpDW0W9y59tdZahmMWorKmyTgAKPkScZJ8ya2rpS9N6i05bruy0plE1hL6WlEFSAoZwalaKUpSgUpSgVU774d6Uv19TebvZ2pNxTt/SqcWAdvbKQracY8xVspQVN7w50m9qJd9csrCrqtRcU9uXyr623O3d8cZzzWMfCzRZsTdnVY2lW9t5T6Gy84VJWoAKIXu3DISOM44q60oKPL8KNFSyjrWJvCI4ipCH3UANA524SoDvznv8a7bh4X6NuHzf7bYmHvYGUx4+5xz3W0/RSr3veA/nZq50oKovw80mvUTd9VZI3zo2oOJeG4AKHZW0HaSPXFR3iX4YWTXUV5chtEW7rQltFwSgqWhIWFY25AVwCOe2TV8pQUE+E2kpdvhM3i1tz5TEFmCuSVraU6lpKQCQlQwfcHxxxnFTdl0Tp6yXtV3tlvDFxVFRCL3WcVllCUJSnBURwG0DOM8d+9WOlBTx4Z6OTLnyU2GMl+c2tp9SSoZSsELCcH3cgnlODzWJqrw0tV40A1pO3LVa7ew4HGSlPWKDuKj9Mk8lR88/dxV7pQax0p4LaYs9gNturPzypUn2suvp6eF4wAkJPCceWTnzqXY8KdFx2IDLNlCW4EhUqMPaXj03VbMq+nz/s0cHI4+2rvSgpFr8KtGWuXFkwbKlp6MFhpRkOq27wQrgrIOQT3rm3+FWibezNai2COG5rfSfC1rc3JyFYG5R28gHjHYVdqUEJpXSlk0pBdh6ft7cOO6ve4EqUorV2yVKJJ/GoqB4Z6Pg265QI1jYTEuJSqS2pa1hZSSU43KO3BJxjFXClBVB4d6TGml6fFlji0rcDqmQpQJWOyt+d2fjnOOK7tOaG07pybIl2a2pjyJDKY7quq4vc2kABOFKI7AVZaUFX07oDS+nLu9c7LZ48Sc6ClTiCo4B7hIJIT9wFfcHQum4LF5Zj2tvo3hfUnIWtbiXlZJyQonHKj2xVlpQVGB4baSgWO42iJZWW7fcMe1N9RZLmDkZUVbhg8jB4rmR4caSk6ciWJ+zMrtcRSlsNFa8tlRJJC927nPrVtpQUiT4U6Kkljq2Nv9BGMRsIedQEtHcSnAUM8rVz3571zP8K9Fz2IjUuxtOIiRxFZ/TOgpaByE5CsnueTk81dqUFf0/o2waemmXZ7eI0gx0RN/VWr9EjASn3ie2Bz34qwUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUrhxaW0KW4oJQkZKlHAA9TQc0rSutPlC6csslyLZY715fQcKcbUG2QfgoglX3DHxqmK+U7NydumI+PLMxX+Sg9O0rzF+c7O/kxG/rav8tPznZ38mI39bV/loPTtK8xfnOzv5MRv62r/LT852d/JiN/W1f5aD07SvMX5zs7+TEb+tq/y0/OdnfyYjf1tX+Wg9O0rzF+c7O/kxG/rav8tPznZ38mI39bV/loPTtK8xfnOzv5MRv62r/LT852d/JiN/W1f5aD07SvMX5zs7+TEb+tq/y0/OdnfyYjf1tX+Wg9O0rzF+c7O/kxG/rav8tPznZ38mI39bV/loPTtK8xfnOzv5MRv62r/LT852d/JiN/W1f5aD07SvMX5zs7+TEb+tq/y0/OdnfyYjf1tX+Wg9O0rzK18p2VvHW0wzs89sw5/9FbO8PfGbTOspDcJK3LbdF8JjSsYcPohY4P2cH4UGzKUpQKUpQKUpQKUpQK86/Kp13IhpY0lbHi312w9OUg8lBPut/fgk/DHrXorNeH/lDrcV4v37qeSmgn7OkjFBrmlcZq0+F0mLE8QLJIuDjLUVt/c4t5QSgDae5PA++iKvSt1PjSOo9SOSbm/EdQm2xjFS5JbbU+ok9UvKCmkhxOSMZGQAcHtULZrXocyHI8pTLzci8SIbch2dsMeMG0lDuAQD7xOFHg8/cGr6VervbdOtaYhPQvY1KUywpyWLhmT1SR1UGPzwnnBwngA7jnFWKVZNCtz2d6oSI6Vyekli6dT2phMdam3HDn9E4XAgbeMlRG3jkNR0rb9tXpZu23tiBCtCnLhaI0lLEm4lCW3eoOoylaljBG3fgnd5cjioq02/Rb03TkOYGUB23KlS5HthwuRhe1lXvBLYyE55See4zmg1rStk3aBo23valdYbZl+zxoxhx/bvd6yzhwJKFHeE98BSseprG0HZNO3S229+7SYLK25shM1MiaGVKZ6KCztSVAn9Jv5T9/FBr+lbAbgaUXo9KSGE3dVpVMMn2w7hITIKQ1084yUc4xnsR8edHWTTk/SEty6yITd0dEkR1uTg2ttaGgpoFBUAApWRkhQPbKcchr6lbRft+jV6ju8W3RoLqIbDYiIkXQtsy1kpLii7uABSCcJBGceZrv06NKLtSbRdRCVGfv7raV+3YMZkspAdC8JKkgjgqASeeKDVBSU4yCMjIzXFbhs0yyqbkQ3Tbbi8/pqMhsz7iW0JdS4gqZCytIRwCcZBG3A7kHCdsmg/yXtj6poQ857KX325CS6FKWA+ktbycJBVg9Mdh7ys8hqulbYs507ZPEexOqh2ZqEp1xCi3dDJaSnsh1ZzhJ5PBVj1SnHK22TRj1oubt0MKNcEuvhTUe4JWmOlLYLZaUXf0m5Wewc9Pd70Gp6Vy2U9RPUzsyN23vj4VfVHTH5Bzd/zhv6h+but0up1uN30eenjGc+eMc5oKDXLa1NrSttRStJBSpJwQR5ivnNM0Htn5P8Arh7Wmix84L33S3rEeQs93BjKF/eOD8Qa2dXlz5Hy3RftRJH+wMZoq/4txx/YVV6izRXNK4zTNBzSuM0zQc0rjNc5oPgmvM/yrNFvGZH1bAaK2ShMebtGdhH0Fn4EHbn4D1r0kVV0SmW5UdyPJZS8w6koW2tO5Kge4IPcUH5z0r1BrT5O0CfKck6YnKt2/JMV5BcbB/mq7gfDmqUv5OOrAo7bjZSnyJcdH/8AnRGlKVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqDk4Het2sfJw1QpwB+52hCPMoU6o/gUD/GtoeHfgfZdLS2rhc1ru9xbO5tTje1ps+RCOcn4k/dQZvyctGvaT0YuVcWi1cbooPONqGFNtge4k/Hkn/wA2K2xvrGyr6p/CmVfVP4UVk76b6xsq+qfwrncr6p/CgyN9N9Y25X1T+FdcuYxAgSJ00rTGYTucKUlRSPM4HOB3oM8KzXOawLfPi3KGiZb3C5FWpSUuYIC8EjKfUZHB7HuKyt1B2tICUgnvX3SlApSlApSsS4z24LaVOAkq7AVi5cptUzXXOIhaaZqnEMulYkKe1KYLiDjaMlPmB/8AYqHses7LedxjPutAR0ygZTKmQppRwFpKgAU58xVorprjWpnMExMTiVjpWOmdEUtpCZLBW6nc2kODKx6j1FdLt4trLYcduMNDZUUblPJA3DuM57j0rSM6ldDkyM2VByQygpCVEKWBgKOAfvPAr4+cYWx5ftkbYydriuqnCD6K54++gyqV0uyo7LAfdfaQycYcUsBJz25r4buENzb05cdW4hI2uA5JGQBz5jmgyaVi/OUHpJc9tjdNS+mFdVOCr0znv8Kwo+pLVJmuRY8xDjrbjjTm3s2psAqCj5YyKCXpWGq629LTbip8QNufQWXk4Vzjg555I/Gu5qVHdecZafaW639NCVgqT9o8qDupWFCukWauYhheVxHC26k9wQM5+zn/AB9KibVrOzXSTGYiPulcjPT3tKSDhoO9yPqqB/soLHSovTl/t2o7cZ1of68YOKbKtpSQod+Dz6H7CKlKBSoC76utNpnORZbr29kIVIW2wtaI6VfRLigMJB+Plz2qWM+IlTqVSmAWU7nAXB7g9T6CgyaVF/P9s+c2oHtjXtDrIfb94bVoKto2q7E58hX1cb9ardHeemT4zbbK0tuErB2KUcAEDtkmgkq+TXW7LjNKUl2QygpAUoKWBgE4BP2ngV1Jnw1lQRLjqKVhtQDgOFHsk89/hQd6qwrpBRc7dJgPPPMtSE7FrZUEq2+YBIOMjj154xXamdDccbbRKjqcczsSHASrBwcDzwQa7iKCNtVtj2O1tW2E46qM0T0kuKCukjOQgHH0R2GcnHnWZmviTw4n7K4zQSFKUoFKUoFRV8tap7ZUheHEj3Qe1StVKZreOzeLjbmIEyQ5CSsKcRtCFLS2HCjJPHukcnAzxmuOkWKNItzauRmJbt11W6oqp4wkdPWt6FGkJkEBTvGAc47/AL6gIvhtboWmYlvhFlE9gRyqYtneHlNEEb0FX0SQTtBH9ldaPE6C5b409m2znYb8d6WFpLeUsNrShSyCr45x3rqjeILiJrzcqP1h1H2mWmEYU4pMz2dsblKwM5Gc/E/Cs6Lo1Gi2qbNvhC3blV2ua6uMuWfDcszbfIaunTLGS902CkuZccWUpG/alOXCACklI7GsNPha8i0sQEXWIW0OtrdDsFTiX0tpwhKgXfvOCAcAYwKl0eIsIsOuLgy21NIK1IUUZGJJjkcHGdwz9lSemtXxNQPTExYsptthJWh1xI2upClJyCCcHKTwcHBFehzcX3SbV4vVouD0ktmHgPtIR7skJIWgHngJWkKHfzHnVdT4YhMJ1j5xaJS22ywoRighKHCsKcKVhSnMnG8FPnxyazIPiRHmNxw3aJ4kygwqMwVN5eDqVqSc7sDAaX3I7D1rHY8SuvMcEezyXoq/Zm4+1aA4tx4rG1QJwMFBGc44PPaglJ+j3pGm7Lb03BtyTbFhaXZEYLbdIQpBCm8jyUcc8EDvVesvhtLTbLc3MuIjbER1vsIa3KDjbCmvdcCsAYVnseRVs01q+Lf58qNHiSmgwFkOuJGxexZQrBBOCCOxxkc1Ds+JUOS8WIlsmvPmQ2w2hK2sOb0uKSoK3bcfolefpQRyvC1XzM1ERc2W5KF59oRHcBx00t9ur3wkZzlJ7FNZc3w29sfnF26BLMhyQ4AmOAoF5KAdx3YIBR2wMgkVkRvEq3yC2tqBN9lUGQXzsAQp1BUhJG7OeCMgEZ+FcxPEaM8iM47aZ7LTrbDzi1KbIaQ+vY0ogKycnyAOBQYsjw0RKblGTPZ60lqUhXTiBLaFvIbTuQjd7uA2DjPJUTkVLab0euy6lm3NM8LZkJWPZ0tkDcpQUVElRGcg/RCc5ycmsKbrt5yJBk2y1PrakzW2G+qpvMhtSlpJQN+UnKP4WO9d9n8Q7fdrlDhxYU7L6UFaylJDKlhRCVYOf4J5GRyOaD70lo16w3S5TXrkJSpjQawGSjGFrUCfeIz75GAAOO1dEzQjrtistvjXYx3bbFdjB8MZKw430yoDd7pAzjk1L6u1TH0wIapcWS83IUUlxsAIaAxytRICe/GeODURN8RoEW4TYghSnlxsBKmlNqS6eqhogHdwQpY4OPPtQZmmNFs6eNxZi3CW5b5jbaeitW1ba0J2bkrTgjKQgcDjaOakm9Nw23ErTJupKSCAq5PkfeCvmoNjxDhrnQIr1umx1yXlx1Lc2BttxLqmikr3YJynOAexGMnis26ayj27UC7Y7CkqS2qOhySko2ILxKUZBO48jHANB0X7Rr1xmXZUW5+yw7u2hqeyWAtSgkbctqyNhKeDkK9awXfD0rTPaRPjJjvPmSzuhJU4lZeS7tcWVZWjKANvu5TwewNYti8Rn5YbTItbjynmYfs/QUlJeceaLhGFKwkAJPcnt3ORUjbdbuPamdt0uA6iO5IajsPJKDsWuP1dq8KOTwoZTkduaCLkeF5ec3fOjKeqhSHwIQwNz/WV0ve/R88DvjvzXY/4Z72n0ouTQUN3s6jFGRmQl8l47v0hygAH3cAn1rLv/iAi23oR0w3RAjSHWZkpQSR+jjKeUEAK3ZACeSMd6lIusGZGmp94+b5jaIRy6yoJ3FOAoqSQSFAJVng+RHeg+9QaUZvV8tVxdkKb9kP6ZpKMiSkKC0JVzwErSFDv5jzqvMeGq46GyzdG0vRiz7MsRMDDbvUBdwr9IonjdlPn6mpBHiJb3Z8eMzCmvJeWQl1tKVDp9UtBzGclJUlXbPAz6Vgv+JJcZjmDZpBcecj7A84gBbbjxaKhg9wUkYOO4PagWvw6ct9ztUxF1SVQ1FTpSwUl7Lji8Y3lIH6QjJSSMcEZrYVV7SmrIupXJIiRpTKGgFIcdSNrqSpScggnByk8HnBFWPFBgy/9sn7K+K7Jv+2T9lfFBIUr4ZcDiAfPzr7oFKUoFRcrT1nlS35Um2xHZD6C264toErSRgg+vHH2cVKUoK3J0TYJNyZmO26OeklYDHTT0ipakqKynH0spH9tZ7+nbM+h5L1siLDwUHMtD3ty+orP2r977ealaUFdg6LsMSI1HNujvoZW4tsvNpUUb3S4Ujj6IUeB5YFScCzW23vSHYMGOw7IJLqm0AFeSTz95J+0ms+lBEu6bsrsfoOWuGpnYhsILQwEozsA+CcnHpmuU6ds6JLMhFsiJeZShDag0BsCDlAHpjy9KlaUGBCs1tgypEmHBjsyJBJdcQgArycnP2nn7ah5mhNOyQwn5tYabbeS8pDSAkOFKVpSFccgdRWB5VZ6UFdjaMsTF1cnpt7CnlJQhtKm07WUoRsAQMccGs9en7Qt6G6q2xC5DSlEdRaGWkp+iE+gHl6VJ0oImPpuyxn1vMWuG26t0PqWloAlYJIV9uVE/efWvg6Ysm9K02uGhxDZaQtLSQUpOeBx/OV+J9amaUEXJ0/apUOJFlwGJDMVAbZDqAranAGOfIgDPrivgaZsgkuyBaofWdVuWvpDJO4L/wDUkK+0ZqXpQRS9OWZcluQq2RC+2suJX0hkKKt+ft3Eq+3mulelrU7qJy9yIyX5yktpQp0BQa2bsFPHB94/2VN0oIR3SlgdRsctEIo6aGtvSGAhH0APs8vSspix2uOptTFvitltaVoKWgNqko2JI+IT7o+HFSNKCKe07Zn7iue9a4bk1fCnlNJKj7pTyf8AhJH2V32+0W63QlxIMJhiMvO9pCAEqyMHI8+OKzqUEUrTtmJhE2yJ/wBSSER/0Q/RJBBAT6AEA49RXD2nLM8wGXLZELQSlAT0hwlKt4A+xRJ+2palBFRtO2aK6pyPbIjbinQ+VJaAO8EkK+0FSj959alaUPHegw5g/TJ+yvjFfTyg47kdhxX1ig6iCk5SSD8K4Lrvks1kFNfBRQY5ef8ArmuOs/8AXVXf0646dB09Z/66qdZ/66q7unTp0HT1n/rqp1n/AK6q7unTp0HT1n/rqp1n/rqru6dOnQdPWf8Arqp1n/rqru6dOnQdPWf+uqnWf+uqu7p1gXSe1ARgje6fooH/ADolVUUxmWSX3gMlwgVhu3lpo4XLGfhz/hVYmzZEsnqr936o4FYmypl46tL6YW4agjk49qV/RP7qymLh7QP0MgL+AIzVH2VyEkHI4PqKZZjS6v1hfes/9dVOs/8AXVVatt4dYUEScuNev8Ifvq0MlDzaXGlBSFcgirl67d2m5G58dZ/66qdZ/wCuqu7p1wUADJIA+NHR1dZ/66qdZ/66qLejo+m+0n7VCuhdxgo7yEH7OazNdMcZbi3XVwh39Z/66qdZ/wCuqsFd5gp7LWr7E1jqv0cfRZdP24FYm/bj9XSNFvTwplLdZ/66q7GZDqV++SpPnXxFWiTHbeQMJWMgGviXJjQmVPS32mGU91uLCUj7zXSJzvhxmJicSkXXwlAKOSe1YpU4v6SiRUDH1hpqQ+GWL/aXHScbEzGyc/ZmrE2UrAKSCDyCPOqjhCcV24r6SmvvAoOSK+SmuymKDr2V1vrbYZW68tKG0DKlKOABWRiom6jq3e1R1H9EVOPKT5KKAMZ+9WftAoOg3tsnLVvuTqPJaY5AP44NcfPf+6rp+wH76lrhJRBgyJbqVqbYbU4oITuUQBk4HmaiYOpoczSH5Rtsy0wvZ1SOmpkh3anORt9eKB89/wC6rp+wH76fPf8Auq6fsB++n5TQ/wAjvyk6Mv2L2b2rpdE9bbjONnrUnaZzV0tcSewlxDMlpLyEup2qAUMgEeR5oIz57/3VdP2A/fT57/3VdP2A/fU9imKCB+e/91XT9gP30+e/91XT9gP31PYpigrr98WlpRatF0U5j3QWAMn8aqr67i+6px20XNS1HJPSH762ZimKOVy1Fzi1fsnfqe5fsh++myd+p7l+yH762himKmHP6Shq4rW2pIlxJUXccJL7ZSkn0z2z8K7tlbEmxmpcR5h9AW04kpUk+YrWlvcWq1RnXFblllKlE+Z21Jh5r9mLeJh9qcaS70itPUxnZnnH2V3s3CRF/RsOOJbVydqT3q36SiNx7BCWkDqvtJedXjlalDJJ/H7hX23frY5qN2wokpN1aYElbGDkNk4znt6VK6NaMZw9ui24sVxcneqC5z6/pPvn71V0qd3HKi4T8Qausa/WyTqGXY2ZKVXOI0l55nBylKuxz28x+NSu0V550SJ41S+tH+RmnhRDWm5Por+iabk+iv6JrZe0U2ip9HTza/E6+mGtNyfRX9E1wVp9Ff0TWzNor5WMCn0dPM/E6+mGtdT68gaO0Gbk4UyHt6mI7KVcuOHJAPoB3PwryNrDV151bclzL3MW8STsaBIbaHolPYf4+tbK+VTPU9ryLCASluPESs4H0lKJyT9wArXfh7phGqr87FkSVRocWM7MkuoTuUG205O0eZPAr1U06tMQ+fcr16pq5qzmtkeFfirdtFTmWH3XJljUoB2KtWemM8qbz2Pw7H+2sPQTFi1DqlrTsm3LRBuKizFkqWDJjOEe6oqSEhYz3BHY8GqZcYa7fcpcJ0guR3VsqI7EpJB/wrTD9DrPcI11tsadBdS7FkNpdbWnspJGRWditKfJYur03w+ciPKKkwZa2m8+SSAvH4qNbroOaUpQKgr5Mjwb7aXZbyGWyh9O5ZwM4RU7UTcADqK05Gf0b/8A8lBz+UVn/WMb+mK4/KGzYx84xcem8VKbUZxhOfsrnYn6o/Cgivyhs2MfOMXHpvFc/lFZ/wBYxv6YqU2J+qPwpsT9UfhQRf5RWf8AWMb+mKflFZ/1jG/pipTYn6o/CmxP1R+FBF/lFZ/1jG/pin5RWf8AWMb+mKlNifqj8KbE/VH4UEX+UVn/AFjG/pin5RWf9Yxv6YqU2J+qPwpsT9UfhQRf5RWf9Yxv6Yp+UVn/AFjG/pipTYn6o/CmxP1R+FBFK1FZ9p//ABGN2+uKocFxLljiKQhKU+yo+j5+73rZ6kJ2n3R29K1hBdWuwQ0KVlCI42j092pLx6Xwhe9OzIwsFtBkMgiM3/DH1RWUF24SjJCogkFOwu5TuKfTPfHwqP09abcqw21SoEQkxmySWU8+6PhWf80W39Xw/wBin91V7HKV25ElchKoiZCwEqdBTuUB2BPciu72yL/GWf6Yro+aLb+r4f7FP7qfNFt/V8P9in91B3+2Rf4yz/TFPbIv8ZZ/piuj5otv6vh/sU/up80W39Xw/wBin91B3+2Rf4yz/TFfDkyMQf8ArLP9MV1/NFt/V8P9in91cGz23H/Z8P8AYp/dQeXflU2nbqG23thaXGH2fZnCkg7VpJIz9oP901qLSeopul7ym4W8NLUUKacaeTuQ62oYUhQ9CK9n+IGkLPfIsC2yoLKWJMhSCppASpP6FwgggdwQD91eY9c+D2pNNynFQorl1t+SUPRkFSwP5yByD9mRQQ2k9R2bTl5cv7EF5dxZ3KgwyrLDKyMBalk7lbc8Jx6ZNVGQ+5KkvSH1Fbrqytaj5qJyTUjH07epD4ZYtFwceJxsTGWT/hW4vC3wOnS5rFx1e37PEQoLTCzlbpH18fRT8O5+FBs/5Ndhes3h4y7JQUO3B1UoJI5CCAE/iE5++tv1iwo6WGkoQkJQkAJSBgAelZeKBSlKBUTP/wC8Vp/92/8A/JSlBJK//UI/4Vf4iuylKBSlKBSlKBSlKBSlKBSlKDhX0T9lart3/Ykb/wAOn/00pUl49M4Q2Lpz/u/bP/DNf+kVIUpVewpSlApSlApSlBC33/tCx/8AjFf/AAHa75AHPApSgxgBnsKzY4HpSlBmp7V9UpQf/9k="
+            }
+          ]
+        }
+      },
+      "total-blocking-time": {
+        "id": "total-blocking-time",
+        "title": "Total Blocking Time",
+        "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).",
+        "score": 0.53,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "560 ms",
+        "numericValue": 559.5,
+        "numericUnit": "millisecond"
+      },
+      "max-potential-fid": {
+        "id": "max-potential-fid",
+        "title": "Max Potential First Input Delay",
+        "description": "The maximum potential First Input Delay that your users could experience is the duration of the longest task. [Learn more about the Maximum Potential First Input Delay metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-max-potential-fid/).",
+        "score": 0.3,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "320 ms",
+        "numericValue": 322,
+        "numericUnit": "millisecond"
+      },
+      "unused-css-rules": {
+        "id": "unused-css-rules",
+        "title": "Reduce unused CSS",
+        "description": "Reduce unused rules from stylesheets and defer CSS not used for above-the-fold content to decrease bytes consumed by network activity. [Learn how to reduce unused CSS](https://developer.chrome.com/docs/lighthouse/performance/unused-css-rules/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [],
+          "headings": [],
+          "overallSavingsMs": 0,
+          "overallSavingsBytes": 0,
+          "type": "opportunity",
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          }
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "final-screenshot": {
+        "id": "final-screenshot",
+        "title": "Final Screenshot",
+        "description": "The last screenshot captured of the pageload.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "timestamp": 4960123943,
+          "timing": 6736,
+          "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcBAwgCCf/EAFUQAAEDAwMCAwMHBgsEBwYHAAECAwQABREGEiETMQdBURQiYQgVMlJxgZEWGCNVk9FCVFZikpShorHS0zNlcsEXJDU2dIKyU3OzwuHwJSc0N0NEw//EABkBAQEBAQEBAAAAAAAAAAAAAAABAgMEBf/EAC4RAQABAwAKAQIGAwAAAAAAAAABAgMRBBITITFRUpGS0uEU0RUyQXGxwQVhof/aAAwDAQACEQMRAD8A9U0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUrhSglJUogJAySewqvNa40q9cPYWtRWlcvO0NJlIJJ9O/f4UFipQkAZJ49arp1xpZM/wBiOorSJedvS9rRuz6d+/woLFSgIIBByD51FXnUNrsq0Jusr2RC8YedbUGh9rmNo+80ErSqF41yv/ykv8mG/wAGOlSHWl9wVJ5BFSx1fp6zRIEa73y3Q5SmW/0b8hKVcpHJBPFBZ6V1xpDMphD8Z1t5lwbkONqCkqHqCO9Qt31jpuzyxFut9tkSTnHSekoSofaCePvoJ6ldUSSxMjokRHm32HBlDjagpKh6gjvXbQKUpQKUpQKUpQKUpQKUpQKUpQK+VLSnuRXw+spGB3NQdxv1otj4YuNzhRXincEPPpQoj1wT8KCwJUlXYg1zUJa7vb7oFqtc6NLDZAWWHQvaT2zg1MNL3oz50H3SlKBSlKDW/jg+8uz2O0JeXHiXi6sQZbiDtPRUSVJz5ZxirHL0LpiRYVWhdlgJg7CgJSykFPGNwVjIV8e9ZmrtOwdVWJ+13NKui5hSVoOFtLHKVpPkQap7ui9ZyYRtkrXi1W1SemtaLehMlSOxHU3d8eeM0FEN9uT/AIHw4KprpQ5eBZFT0qwpcbqlO/PxSNua24jQOlU2P5pFit/sWzZgsp3dsZ3d93xzmvt7RNkd0SNKmMRaUtBpKQfeSQchYP1t3OfWq0nROtERPm5Ov3fm0J6YUbegydnbHVz3x54zQQ3iDKk6E8FDH07eHpZbdTDROUsKWy2pZBG4eaR7oPcVsXT+nLZb9OItzbQkR3mQl9bx6ipGRypZP0ic1127RtkhaPTpkREvWnpltbb3vFzJyVKP1iec+tYqtPXS2WUWfTE9MaNs6aJE1apDkdPbCE8Zx5blHFBpWO+7H8IvFCwJdW9brNOXHhrUc7W+oPcz8Mf21ufROlLND0nEbMWNOVLjockyXkBxUpSkglSie4OeB5Co8eGcCP4aztJQJLjftoKn5jid63HCoErUOM5xijejtR2mJ7BpfVLcK2hO1tmVBEhUceYbVuHHoFZxQVTT8t7SH/SjarISqBZ2vbILX0gwtbSlqQPgCM4q0+FmkrGzoa2yVw4s6VcY6ZMuU+2lxb63BuVkkcjJ7VNaL0dD0zZ5UQuuT5M5xT06VIAK5K1dyr4Y4AquwtBah0+hyFpDVvsNnKlKaiS4SZJj5OSEKJBx6A5oOjw+ZbsHifqzTdrGyzIZYnNsA5THcXkKSn0B74raFVnRGkWNLszHFy37hdJznWmTn/pvK8hgcBIHAA7VZqBSlKBSlKBSlKBSlKBSlKBSlKDHkj3gfhVR1KLmbgn2EXwtdMZ9hEPZnJ/9t72f7KujiAtODWMppYPbP2UFf0sJwbke3i6A5G32/wBmz/5ejx+NWWMPcP211oZUTzwKyUgJAA7UHNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKV8POoYZcdeWENNpKlKUcBIHJJoPulVeD4g6RnzGIkLUVsfkvrDbTSHwVLUTgAD1q0UClVi96/0pY7iYF2v0GNMGNzS3OU/wDFjt99WKJJYmRmpMR1t6O6kLbcbUFJUk9iCO4oO2lKUClKUClKUClKUClKUClKUClKUClKUClKUCvI/wAoXV2o7T4pXGJa79dYUVDTJSzHluNoBLaScAHHevXFeLPlM/8A7vXT/wByx/8ACTQelvCyfMneD1qmzZT8iYuG4tT7rhUtRBVyVHnPFaZ+TFqm/wB68QZka8Xu5z46ba44GpMpbiQoONgHCiRnBPPxq4fJ/wDEKyXTT9n0Ulib84tRXA4pSEhogEk4UFZ7H0qyzPDrTmh9Oaku2k7c5FunzVJbQ4JDrh+huwApRHdKfwojuufjVoi330Wp25qceDnSceaaKmW1Zx7y+2B6jNR958etHWm6y7e+Lk47GdU0pbLKVIUQcZSd3I+NeVNBs6ZkX0o1rLnRbZ0lEORE7ldTIwDweMZ7A84qHu6YabpLTa1vOQA6oR1vABam8+6VAeeMUHr2b8oLRsOY9Gebu3UaWUK2x0kZH/mqXt3jDpq460a03D9qclOEpD4QnpAhG4gndnjBB47ivGep/wDvFcv/ABC/8a9J6i8JtOad8OZ+orM1NRdWrYp1KzIJAK28LOPsUqgsl8+UBou2TnIrK508tq2qdjMgtk/AqIz9o4rOtfitpbWtlu0O1SnWp/sTyhGkt7FqAQclPcH7jmvKfhy3o9y6yBrt6e1B6J6JiDP6TP8ACwCe3b496m9Jp0e3qNC7bN1H7VvWIqTHaCSCCAFkKzjHcgds0Fd8NJTMLxC05KluJajsz2XHHFHASkLBJP3V6d0p4/6dvupE2p+JJgIed6UeS6oKQsk4Tu80549e/NeYfDSKxO8QtNxZjKH4z1wYQ404nKVpKxkEeYp4jx2YHiHqOPDbQwwxcX0NIbG1KAHDgADsBQbZ8V4fhcjxBuybu9qSNcutvlIhobU0pagFEpKuRnNRHi7rRVqf09adB3W82y2RLWyrpokLa3BxIdQTtVyrasZ+Oapfi+6t/wAQ7m66oqccRHUonzJYbJqweN0Vhm2eH77TDbbr+noqnXEoALhCEgFR8yAAOfLFBtv5O/iNHkaRujGp7vKclwFqlPS5zpWlLStqUgLUSc5B4+Pxqef+UFoVqWWUyJ7qAcdZEU7D8eSD/ZXmiRcLajwjhwYyoybs5dXHJISkB1TIbGzccZKdxVgZ71j2S2aek6UmSrjPbj3NCyEJMhW4jjG1oNHd9vUT91B7asestP3ywvXm23SO7bmAVPOk7elgZO8HBTx61ryf8ojRcaUpphNzlIScdVpgBJ+I3KB/srQEJqBA8PdTCxahkzVyG44lxDCUylKQ8nCisqIPJxj4/CsDQDehXIF1Ot37o1KCR7GIYyDwc+R5zjvgUHquH4uaWvOlLvdLbMeKoEcuvRy3tfQDwCATg8kcg15Z0v4k6khamtMq66kvr9uYltOSWjMcXvaCwVJ2lWDkAjB71bfBOJpKRqsx4rt5lSnochC48qK17O4jpkkL94nGQCOO4Fax0UuE1rKxLuwZ+bkT2DJ6yQpHSDid+4HuMZyKD1vevHfSNnmpiy27oXVMMvjZHSRtdbS4n+F32rGfjUlqTxf03p602O4z0XAx7wwZEbpshSgkbfpDcMH3h615Y8b5dvneJd0k2RbK7YtuOI6mBhvYlhtICR5AYx91TXjBNjSdC+GjUd9p1xm1KDiUKBKD+jGD6cpP4UG9XPlAaORAZmKbuvRedW0n/q6c5QEE/wAL+en+2knx/wBHs2hiehNxcDz62QyGkhwbUpJURuwE++AOeTn0ryZK/wC6Vs/8bK/9Eet0+APhbprW2jJVyvrUpcpucthJafKBtCGyOB8VGg3LqTxf0hp5mMZ89apL7SHhFZbLjqEqSFDcBwk4I4Jrp0r40aM1JPagxp7kWW6QltuW0W95PYBXKc/DNePnIzC9avRbwtTUcTFtPKW4UFACiMFW1RGMYztOPSpidZtJN6gWyjUiocNO0pcYZXNCT54XtbJ/o0HvClYNiX1LHb1l9ckqjtnrLQUKc90e8UnsT3x5VnUUpSlApSlArTHiX4Go1vq6VfFX9UIvobR0RE6mNqQn6W8enpW56UGnPDHwRRoXVbV6TflTihpbfRMTp53DGc7z/hW4nEJcQpC0hSFDBBGQR6VzSg0ddfk46dl30TIlwlxIKnN7kJKQoYzylK85SPtzUbevk1Qpt2lyYWoDBiuuqW1GTC3BpJPCQeoM49a9B1hXx6bHs0560x0Sbg2ytUdlatqXHADtST8TQaGufya2p1xkyvypWjrOFe32AHGT2z1K30zb2haEW6QlL7AYEdYWnhxO3acj0I8q0DovWXi9N1pCi3ayui3uPhMlLsHpIabz7xC/gM45OfjW/rzcGrTaJ1xkZLERhchzHfahJUf7BQaQvvyarJLmLetF5l29pSieitoPpT8EnKTj7c1P6J8C7FpdciT7XInXJxhxlt95ICWd6SkqSgeeCe5NaVufyg9ayri47BdhxIxUS2wmOleE+QJPJPx4r1Voa5yLzo6y3Kbt9qlxG3ndgwNykgnA8qI1DpT5O7dg1Na7uNSrfMGS3I6RghO/aoHGeocZx3xXGqvk7t3/AFLdLudTLYM6S5I6XsIVs3qJxnqDOM98Vvutf+Mt41fZtPsPaHt3tklThS+tLfVW0nHBSjzyfPnHp6FUbVfyeW9QX1+5HUq45dS2npiFuxsbSjv1B325++rlqnwls+ptHWSyXJ90SbRFbjR5zSQleEoSk5ScjB2g4/tqs+G+u9axrFf7t4i2qQi2W9gPNu+zBl5as8pSkkAjHOePtqa0P426e1jqaLY7bBurMqSFlC322wgbUFRyQsnsk+VEV7TPyc7LbZEpV3uj9zYeZU0GuiGdhOCFA7icjHFRr/yY7cqUVMakloj54bXFSpWP+LcB/ZXoatMQPlEaWm3OPBatt7Dr7yWUlTTW0FSsAn9J25oq1aV8KdMae0vPsbcVUti4J2y3ZByt7HbkYxjuMdjz3rXVx+TLanZRXb9QzIzBOem7HS6R/wCYFP8AhXoKlBr3wy8J7HoFb8mGt+ZcHkdNciRjhPcpSkcAHj1PFUvVHycbLdLo9LtF1kWtt1RWqP0Q8hJPfb7wIHw5re1KDR9++TxZrlbLazGu0qLMhsBhUgtJWHgCSCpGRg844PYCsW6/JvtMm1WyLb7w5EfjBZkSFRuoqSpW3nG8bQMcDnv+N/8AGG76ss+mm39EW4TZindrxCOotpGPpJR/C5x649PSu+B+ovEC9y56Nb21bEFtsFl92N0FlzI90DjIxk5xxj40RWHfk2tuWmNB/KhYDLzr2/2Ac70tjGOp5dP+2toeE2hU+H2m37Sm4GeHZSpPVLPSxlKE7cbj9Tvnzq6UorUfiJ4F2LV92dukaU/ap753PKaQFtuK+sUnGD9hFRek/k6WC03FmXd7jIu3SUFpZLYabUR9YZJI+Ga3hSgAAAADAFKUoFKUoFKUoFeevlF+Kt307eWtO6af9kdSyl6TJSkFfvdkJz245J78jtXoWvNXymPDe73G/I1NYoj05pxlLcpplO5bakjAUEjkgjHbtj40GublrnxEh6Qhi4zb3Hjy5HtMW4qdcbU4naQUBX8JPZQH2+tcwNc6rX4eXuUrUl4Mlu5Qm0OmY5uSlTckqSDngEpTkfzR6VCaiu+qrpoy3Rb2t35mtTqYkZDjQQQrYcDOAThKcc9sipLQ2nJ+pPDTWDVqYckyYkuDK6Lady1pCZCSAPM4XnHwoi6eEGrdRXHSviG9PvtzkuxLOt2Ot2UtZZXtX7ySTweByKq3hzrjVUzVKWZepLw+17HNXscmOKG5MV1STgnuCAR8QKxvDtvVMG1axiWu0KVHk2xxE5yQ2pPRbSlROPVR5AHr9lR3hjBlo1chS4r6R7DOGS2R/wD1HqCf8Ktb6pn+I+nYs3Ud3kRnpjaHGnZjikrST2IJwRXp3xqhzZ3hZqNq2yfZn0xVOqXuKctoIU4nI+shKk47HODxXkjwfgy2/E/TK3Ir6Uic2SVNkAc17M8RkqX4fanSgFSja5IAAySekqg8NaAt1zu+sLZAsU32C5vuFLEnqKR0ztJzuTyOAe1bR8V/EzVlvvEfSlruj7K7YwzFkyI6iXZUgITvVvI3fSyB2J7nvVS8DIUpvxY02tyM+hAkHKlNkAe4qrJ8oDQd9tevp1+t8OU/bprgkIkR0FRacwMhWOUnIyD8aCI1lrvxGgwLPb75JvNplR0LKXuo4wuUg7cFeMbinBGe/PPxklaz1N/0GIuP5QXX2/8AKMx/aPa19Tp+zBWzdnO3POPWqnriLrW4wbNddWKnShLbWIgeBK0tp25O0DgHcPicZ9KlVQpX5vyG/Zn+p+U5Vt6Zzj2Uc49KDN05dNUar8Mdc+1agnyEwRFfWJUpxeWv0wWgd+/u8djt+FVTwntl0u+v7VDsM72C4LUtSH+opG1KUFShlPPKQR99bF8AtPTrzo3xGtTTSmpMyGw2z1UlIKv0uBk/HH41rqys6t0JqxmVEtkyLeIxWhCXIpXnckpOBjCuCeRQe5tTRJk/Tl0h2yR7LPfiutR39xT0nFJISrI5GCQcjmvz4tbEh+9RI8Z7pSnJCG23dxG1ZUAFZHPB5r9DbK6+/ZoL0wFMlxhtToKdpCykE8eXOeK8Mar0dqPROqVh+3ycx5HVjyUtFbbgCspUCBj04oNleLPiZqvS7kLR8G5FE23w2W589BK3ZDxQCSFKGQORz3Oapatc+JmlJkZ64XS8NLdG9DU8lxKx/wAK8/8AKmtdK6zv8OPrW4W6TKXcU5kdGMUqaUg7AVIAyElKUkHGKxbfctd3edEYscGUxIaGxKbdATHBPHKyhIBPHdXagn/FPxP1Fc5lhuFsulytKZVrQt6NFkrbQHQ66hRAB89v4YrFv+rtf/8AR1pqe/dpbNsW6821KRLV7RIcC1ZK1ZzgD3QM/wAH7K6vG6zagiXqxM35x+4XRNpbMh5Kd3vF107cgYOAQPuqT1bEkq+TvoZtMd4uJnSipAQcj9I53FBw54m6on+EL3UvM1u4wbuw0JjTpbdW04y8dilJwTy3nn4elVuNr3VytK3F46mvRdRNjISszXMhJQ+SAc9jtT+ArEgQZY8Mr0gxX9xu0EgdM5I6Mr94qPiwJn5IXNPskjJnRSB0z/7OR8KC3aRv/iXqm1Xe3WKbeLmoqZU877YorZSN+AkqVxuPfH1a9S+EMW8wvD61x9Te0/OyAsPe0Ob1/TVjJyc8Y86058kCM+xL1T12XGtyI2N6SnPLvrXpSgUpSilKUoFKUoFKUoFKVV79q5FnuK4jsJxZACgsLACgfuoKf8orRt71ppy1xNPRkSH2JZdcSp1LeE7CM5UR5mo75N+g9QaJRqEajiIjGYY/R2vIc3bOpu+iTj6QrYVw1fHh22BLEdTntaSoICgCnHfP319RNXRHLUufKaXHbC+mhOdynDjJwKuBZaVSkeIEMu4VDfDefpBQJ/D/AOtfGubzHl6ejeyK6iJK8hYONu3GQR99MC8UrUWj7uLTcnHXG1OhbRTgKxjsf+VWmNr6K6+lDsRxpB7rKwccemKYF0pVWtOsY0xmW9JaMZqOAclW4qznAAx34rDX4gRA4QiE+pH1ioA/hTAutKjbHeol5YU5EUoKRwtCxhSakqgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVRPE+DluJOSPoktL+w8j/AJ/jV7rDu1vYukFyJJ3dNeOUnBGDnikDSrj7jzTDSjlDQKUD0yc/4mrBq+3uW6DZ2FAhCWTn06hOVf4j8KtsbQ9rYkNPByUstqCgla0kHB8/dqfuVvjXKMWJjQcbPIz3B9QfKtZRqaU5ZjYWUR2XhdARvWScfHzxWTDQ7+RE9Sgej7S3t+3z/wCVXBOhbSl3cTJUPqFwY/wz/bVgFviCAYQYQIpTt6eOMUyNTacnsQPnH2gqHXiLZRgZ944xXTpphqTfYTL6AtpbmFJPYir+vQtpUsqCpKQf4IcGB/Zmu23aNt0CazKZdlFxpW5IUpJH38UyIbX1pi2+0srgRkspU8A4U554OM/21U4areLc8JI/6zn3cIUVfcdwA+8Gtyyo7MuOtiS2lxpYwpKhwarS9C2lTm4KkpH1Q4Mf2jNIkRnhyIXtsgxBL6oawsuFOzuMduc//Wr7WHarZEtcfowmg2knJPcqPxNZlSVKUpUClKUClKUClKUClKUClKUClKUClKUClKUClKUClK1x4i3WQbn7A04pDDaAVJScbieefuxViMjYwWlRwFAn4Gua1A7YLxCTHfShQLnKC25yPP1rnUz09SbeLkFokJZKSSrlQ3HB4/8AvimEbdUpKfpED7a5rUtssd2vNsaXHW2Yza1BIUvHPGT/AIVzerpcblc/m9lxYQlYYQ0hWAojjn15pgbZqj32Nqpd1dVCcX7MVfoumtKQB5ZB86qxdu+mrglC3FtOYC9hXuSsfHy8jXVqSUZN5kPoUoJdCFgZ7ZQDViBt23CQiAwJykqkhA6ih2JrISpKvoqB+w1qfVEif7Pbm3FOpheyMlvBO1R2DJPxzUdbYUmQA5DlsoezwgvbF/dnH+NTA3UTgZNcJUlX0VA/Ya1Rq526ocjMzlPJaSygAEnClbRuJPmc5qPtsKVICXIUtpL+eG+vsX92cUwZbopWqdV3WeuU1AW64gMtIStIVypZSCSfXk1h31m7QY0ONc9yUJCiz74JwcZGQfgKYMtxUJAGTwK0ypa/yaQdys+1q8/5gr7t6JrthujjMjZHaLZdTzleSQBn05pgy3GDkZFcFSQcFQB+JrTdmvsy1tSUMOqw43tSCchKsj3h8cZpbrXcr2JD8cl0t8rUtzkn76YMty0rWmm5V4tDEp15t1cNLKlALUCEqA4PfPfjj1qBU/cLxJWp6VuWPe/SuhAHwGTj7hTBlumla00bKvEa6MtKblOwlq2LCklSU/zgfKtl0mFKUpUClKUClKUClKUClKUCqNrnTcudNE6AgOkoCXG84PHmM/CrzSg06mw3ySpDSocohPCepwlI+GeKzr5pmfFbgssR3ZCg0S4ppJUAoqPH4YralKuUwrugor8Sw9KUytlzqqO1acHHFVjUul7ixdXZlsbW62tfUSWz76FE57fb6VsmlMq1TH07fLxNC5yHkZwFPSDyB8AeTXzqKwz/AJ4kCJBkOMJ2pQpLZIICQP8AlW2KUymGuJ0DUUfouQUPlhUdkFsEKAIbSCCg+eR6VDCwXqfKKlQXELWeVKQG0j/AfhW4KUyYa5uls1HCkf8AVFOvsdNCTtIWkkIAPun4j0qGRp69T5RUqC4hajkqWgNpH3cD8K2/SmTDW2qNKXDqtyIyTKJbQl3b9LcEgE48wcVFzNO3n2WM86xIeW5uHTwVKbSMYz6ZyePhW3aUyYamVZrl+T6GvYZPVEpStvTOcbAM1nWe1T2tMXxlyG+l13pbEFByrCucCtl0pkajtOmLhLkOMvxXo4LZKXHEEJCh2BrqXYL5EWttMSSN3Ci1yFD7RW4aUyYa60zpCUsvuXJJYQppTaE5BVlQxnHwqLVYr/aJa/ZGn8kFPUj8hQ+7/nW2aUyNeaS09dRcm5c5T0dlCt5SpZ3OH4j09c1gmz6i+f8Aftf63Uz7Ru9zGe+fT4VtGlMqUpSoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKVTtRXKVa7lOhtPr6tzZR837jkIe3BtePgNza8f8RoLjSqnGvE9sNPFUZcFM35v6KgoyCQ5095XuwTkbsbfo85rptt3mv8ATh20RIuxp2Qtcre4FAPLRtB3A/wckknGRxVwmVypUJp6aJki4ObEZ/QqKm3S4lW5pKvdzxjnyAz3qJTqS4NWVN3kfN6o78VchqMCpDqMJ3BJJJCsfwiAMfGmDK40qpTb5dbcJLD3sMqUGW3mltIU2gbnAjaoFSj55Bzzg8cV1Tb3fYKbwt75uW3a0peWUtrBeQU7ikDd7hAB597PHApgyuVKqDl6vSnEOMIt4juXBcFKVpXuABUA4TnB+j9HHPqK6HNSXkzBbGI8dyeh15LjyG8oKUBsjCFOJOSHR/COMHvTBldqVUEX28TGmfZGoLDvsSpTnVy6nclRTtSUKxg4znJx6GmmLhcrjqGa65LY9hXHjPojFpW5AWhRGDvxn1O3nHlTBlb6VVZN7uaLhPU2mIIMOcxEUlSFFxwOBrJCt2AQXPQ5xjjvXVF1FcFogS3ExDFnuuMtR0IV1WilKyCo7sK+hggAYz3OKYMrfSqkvUk1UO1qisR3pMu2mYWgrbleWQAMnt+kVwTzgDNSdiuMm5QJgWttE1lwtHdHW2EK2gjchRz5jsrBHnTBlNUqj2O53z5n082ZMGS/O4U8tpYLaUtlRz753KyMdx3rvZ1NMVcSgiO5FdRILKkNLTy3295R98cc4SAD5mmDK40qmpv96bbZS7HiPyJUNEtlDKSnZ76ErSdyvfICwRgpzjFR896VqCbYW3HIK0ImvNvMvwnMb0tKV7yFLGDg8d+SDnypgy2FSqsxfJ6nWZKvZDBdnLhJjpQrrJIWpG7duweU5I2jAzzxXTFvV7ksWtQTb2nLi84hGULUGkJQs5PvDcTtHHGM+dMGVvpVJb1PdWIEe4TWIrkdbkhhTDCVdTeyl07gonGFFo+7jjcOTivqbqO6W6C89I9gkuLtz09joJUlKCgJ91WVHcDvHvDHY8UwZXSlVKTerzFkSYZZiyJSAy4lTLZG1DnUz7hXlZT0/IjIPbjnsuVycm6DmzEuYe6S0lTaFNEKSopPuq95JBB4/wAaYMrTSqqrUMoahZjJ6DkJyUYmUtLBSoIUo/pCQCcpwUhJx61aqilKUoFKUoFdL8SO+8w6+w046woraWtIJbJBBKT5HBI49a7qjp17t0GWiNLlttPKAO0590E4BUeycngZxmg7hbIInGaIccSz/wDzdMb+2Ppd+3FfEmz2yU021Jt8R5pslSELZSoJJOSQCOMnvXS5qC1NmSFTWsxiEvAZOxROAn/iJ4x3oi9RXxDciPR3GX3VNKUtwoUkpSpRASRncNvIOMDJ8sVU3JBphllS1NNIQpeNxSkDdgYGfuGKxmbTbmJLshmBFbfdBDjiWkhSwe+TjnNY7eobS6w68iewW2tu5WfrcJx65PAx38q4d1FaWozT65rfSd3bSkFR936RIAyAPPPbzpvNzJj2m3RmVtR4MVppZClIQ0kBRByCQB5Gu52HGdS+l2O0sSE7XgpAPUGMYV6jHrWFJ1Bao0hDD81pLighQHJwlXCVEjgA+p4r7F7tpuPsAlt+1btmznG7Gdue27HOM5pvVlCHGASBHaAS4XQNg4Wckq+3k8/GuiXaLbMQtEuBFfStfVUHGkqBXjG45HfAAz6V8W+9224SVx4Utt11IKsDPvAHBKT2UAeMjNJl7tsKaiJKlttvq2+6c4TuOE7j2Tk9s4zRNzKRDjNhIbjtJCW+kMIAwj6v2fCvlu3w2nmnm4rCHWmw02tLYCkIHZIPkPhWN8+2z5x9h9rb9q39Mo54XjO0nsDjkDzr6ul6t9rUhM+UhlSwVAEEkJHdRwOEj1PFQZJhxldXMdo9VaXV5QPfWMYUfUjann4D0rrZtsFmWuUzDjokrzudS2AtWe+T3r4VdoCXi0qS31ApCNvmSv6OPXPPI44Poa6Y2obVJmCKxOaW+pSkADOCpOdyc9twweO/FB2ostrb37LdDTvSUqwykbgSCQeOxIH4VkQ4caE0W4cdphsncUtoCQT68VGw9SW2W/LQ1IR046C4XCeFoH0lJ9UjtkedfbN9hPFTrcmMYKWVOl8u44SrBOMY2/zs1d5uZjFuhMLC2IkdtQWXAUNgHcRgq48yPOuoWe2BZWLfECioryGU53HOT278n8TXS3qK0rhuSvbW0sNLS2srBQUKUQEgggEZyMetDqK1CGmUZaekpZaA2q3lY7p2Y3ZA5xjtzTebmW9bYTyEpeiR3Epb6QCmwQEZB2/ZlI4+Aoxb4cdLQYiMNhlRU2ENgbCQQSPQkE/jWHJ1HaI7bDjs9npvI6iFJJUNn1iR2T8TgVmzZ8WDGD8t9DbRICVE/SJ7Aep+AqK+U2yCiaZiYccSz3eDY3njH0u/auxEOMgMhEdpIYJLWEAbMgg7fTgn8awTfIYHXMmMIHQL5eLvIAVg+7jsPM54PGK6hqmy/rBoEK2qBCgU9uVccDkcnjnvV3okkwoqEtpTHZSltanUAIHurVnKh6E7lZPxPrXS1Z7ay0+21b4iG307XUpZSA4PRQxyOTXSvUFqRO9jVNaEjqBop591Z7JJ7AnyB7+VYzGp4IgIkz1pilbzzSW+VqIbcUgqwBnHGScYGe9N5uScm3QpRWZMRh4rCQorbCshOSnv6bjj7TX0IUUQ/ZBGZEXG3ohA2Y9Mdq7W3m3WEvtLStpSQtK0HIUCMgjHeqhbNXOzZbJ2tJiOzHY3LTiFoShLx3EqABJ6QPHbJB5oLKu025b6nlwYqnlKC1LLSdxUOxzjvwOazajZd3jNRUuMOsLW4z7Q0HFlCVIykbt2Dge8ny86xbtqaBAcWwHkOy0ONtloEjBWpIxuxjdhWdvfFBOUqOYvdtfuKoLUttUoEp2DOCod0g9iR5gHIqRqKUpSgVX5tnnifPdtsmK21cNnW67RcUgpSE5SM4OUgcHgHnnOKsFKCuuaecEYdB5pMpu4LntqUjKSSVDCgO/uqIz5HB8q6hpyQ5LbmSJDCpCpapTyUtnZzHLISATzxgknvz2qz0q5TCosaYlIjvNKcjlkpaDcYrdU2koVncklWWz2wE9sedc/k3cVMNNOXErbw8FIU457m8gpwrO5e0AjCjzn4VbcilMmFRRpWQbLcYbkhnrSra1BC0pOElCVjd/eBrMYss9h1cduTG+bVyXJKtzRL3vqKykEnA95R97GccfGrFSmTCq6b01ItcqGZD0dxiEyWWSneVq7AE7lEJ4HZPcny7V83bTEiVc5zrDzAjz1IU8Hd5KdqQg7UhQSrKUjuODnv2q2UpmTCvPafWtEkJeQku3Jmfnb2CC2Sn7SEEffXXf7BJmXRU6C8ylxyOIy0vFwAAKUUqGxQz9NWQe/HI87LWFKtcOU8XX2d7h4J3Ef4GuV2q5EZtREz/ucf1P8NUxTP5kKNNOIu9vntvshdvbRHYR0+C1jC8/zj5Y7Y/nGo+zWK4SbczGmqZYgonPydvTUl4/pVlI9Byc7vMcfGrL8xW7+L/31fvp8xW7+L/31fvrhtNM6KfKfRvVtc57fKuQtISmoior0iMW2oTkNhaQsqO5O0KVuUQngchPf8BUjedNfOLSmg8llHsiY6NoPuqStK0ngjjKRxxxUl8xW7+L/AN9X76fMVu/i/wDfV++m10zop8p9DVtc57fKEb0zJcS4uW7GS8uRGcw2FqAQy4F4Klkkk8/AfjXe7YJbV6fusF+P7Sp9a0oeSSjYtppCgccg5ZBz6EjzqU+Yrd/F/wC+r99PmK3fxf8Avq/fU2mmdFPlPoatrnPb5QEzTFwcdMhEuIuS/HDD5UhbaAQpagpKUKGf9ooYVnOBz3zM3S0e0WuJEZSyr2ZSCnqbk/RSR7qkkFB57j4jzru+Yrd/F/76v30+Yrd/F/76v302mmdFPlPoatrnPb5Qjml5T0FTMiaHVqiuRypzKvpOhYGSckADbk8nGTWbc7AqYq/qS62k3KEiKnKfoFIcGT6j3x+FZ3zFbv4v/fV++nzFbv4v/fV++m00zop8p9DVtc57fKvRrLcZKrpHUphqDIuHWWpbag6Up2H3fI52jCvLnvxjlek5TS2X4khhUhHtCFB0uJSUuPFwEFCgcjOMdj8KsHzFbv4v/fV++nzFbv4v/fV++rtNM6KfKfQ1bXOe3y+bJDkW5lqESwqGxHbQhSElKlLGd/HYJ+jgfE1gHTq1NQm1vp2sTJMlWB9JLodGB8R1R+FSPzFbv4v/AH1fvp8xW7+L/wB9X76m00vop8p9DVt857fKBOmJ70ZhmRLjbWIBgo2IPve82d5yfRvt5eprtl6cmuNy4jMmMIT85E7K2yXAQ4lak+ndPB8hxjzqZ+Yrd/F/76v30+Yrd/F/76v302mmdFPlPoatrnPb5Qlr0s/CuEbL7C4MZ9yQ3neXCVbsAgq2jG8+8Bk48smrbUc3Zbe2tK0MYUk5B3q7/jUjXe1VdqidrER+05/qGaopj8slKUrqyVR9TaguMO7z2mJDMVuG22ttDuzEgqGecndjPujYM5B78CrxUZML6pQULU3I6Zy26pxII+zIyK53L1NmNaqJn9omf4iViiat0IayuOp1neGZN2WVK6bjcJfTGUFA5SMbsA8ZH31gz9QT2pl9Wi5RkG3Sm2mYJbG58KQg7Sc5yoqITjz757VZvarhu3fNQ3ds9dP7qwYsV+PLkyRZwt597rlS30EoVsSn3TjgYQK4fX2uVXhX6t7GrnHePur/AM4Ox5BmxozPXjsXZSGm0YC1IfQBkDuTjn1Oa5vs+c7Y71GjXoTQLauV7VGQgFo/U4yMKGSPMbTyataX5qVAptCARnkPp8zk+XnXDTsxlKg1Zm0BRyQl5Ayfwp9fa5VeFfqmxq5x3j7qvftRyIEBx223dM8RYhllxKGSl33lABSgQCPdIwgZ45Paul66SYU7VMuFcY6FMSm3W4hQFGSSw1hOe/vcBO3z9e1W1S5aykrsrSikEJJeQcA9wOK4BkhSVCyMhSeUnqoyOMccegH4U+vtdNXhX6mxq5x3j7qwq6TIiWo0Z4RESZs5a3zsyCl3hA3nbk5J8+En7RadN3T5wtsQyX46pjjRcKWlfTSFEBYHofvHPc1w6qU62W3bK0tsncUqdQQT64xWTCXIW/l+3ojgI2hwOJUcenHlWqNMt1zFMRVmedNUf9mME2qqYzMx3j7s+lKV6WClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKg2tWWV3Vr2mUTM3pprrrj9JfCMA53Y29lDzoJylYMS8WyZMdiRLjDfltf7Rlp9Klo+1IORVVPitoxN7ctK7yETm5JhrSuO6lKXQop2lZTt7g+eOKC8UqNN/s4kSGDdYAfjpK3mzIRuaSO5UM5AHqawZ2tdMQYhkyb/a0shrrAiShRUjONyQCSRnjjzoLBSqlp7xH0jqESja75FWIqC691dzOxA7qO8D3eRz25qbj36zyGnXY91gOttIS44tEhCghKhkKJB4BBBBoJKlYEW9WuXAenRblCfhMgl2Q2+lTaABklSgcDA55qMn630zCtUi4u3uC5EYbDri47ofIQVbN21GSRuOMgd6CxUqM/KC0BURDlzhtOS0JcYbdeShbiVDIwkkE5+yuF6hsqJT0ZV2t4kspUtxn2lG9CUglRKc5AABJ+yglKVXtO600/qKxyLzark0u2R3C07IeSplKFAAnO8DAwoc9uaz49+tEll52PdYDrTCA46tEhCktpIyFKIPAI5yaCSpUUxqSxyA+WLzbXegkLe2SkK6aT2KsHgHPc19ov8AZ3LY5cm7rb1W5s4XKEhBaQeBgrzgdx5+YoJKlQ35V6ew6fn604abS84fbG/cQrbtUeeEncnB7HcPUVmW67225lYttwiSyhKVKDDyXNoUMpJwexHI9aDNpUYrUFmSZQVdreDEGZGZKP0I7ZXz7v31hyNZ6aYiSpKr7bVtxWDKdDUhLiktAD3tqSSRyMYHORjuKCfpVFb8VdKvv2xqJLekfOUd6THUhhQCkNFYVndgg5bWBkc4rNsPiFp68aS/KQSzCtIdLJdmAN4UDj1PmaC20rAnXm2QIrMmfcYcWM9jpuvvJbSvIyMEnB4rEVqmypvYtKp7YnGH7ftwdnQ3bd+/G3GR60E1So1q/wBndgOTmrrAXCbO1chMhBbSfQqzgVEzdf6Wh3G1QXLzFck3RwNxExyXg4oqCRygEJ5IGSQO/oaC0UqsO62tLWuk6Tc9oF0VHMncUDpBGCeVZ9AfKpSDqGyz5aYsG726TJUkrSyzJQtZSO5CQc4+NBJ0pSgUpSgVq2f4e3tXjGrWFvukRiE80hh9hSCXFNhCUqAOMAkpHNbSrXOtPFOPpjVLdkVZbhLcUlB6yFIQglXZKSojcr4DmggfDLwel6O1c3dH7lCkxo6HUNFuOUvO788uKJ8gfL0FQy/BC8J1hcr8xdbbvkXX25pp5guJDZWtRBCgRvGU4P21bn/FyL+U8u0RbLcnmY8tUBc5CQW0vjuCnOdoPnVZ0z44ufkZAuF8typl0nTH47LEIBtJS2lCiSVK9Fj7aIyNIeCb1k1cZ0y4QpdtHtHBjn2h0OpKSlaiccAnkfH1qGtnyeXkWe9xLjeWXH320NQHkIUQylLhWQoHHc47fGp66+PtsgLYCrDclByGJhClJQpAKikgg/Ed/PipK6eNFuiuwkQbJdLgXoLVwd6ITllpwgJyCeTyOB60FMi+Cl4stl1LOkTWLjc37QbfFjQ2ykKwhCQSVY5wgffk196d8ELkrT7zkuTb48uXa2IoiqjFKQrehxfWKVZUoFJTuHwPlV2Z8Y7ZI1emyRLTcnm/akwlyglICHVeqM7sA9z8DX1r/wAX7do+8Trcq1Tp7sFht6QtopShveoBIJP/ABDnHmB9gfGjPDadYfDbUWnZEyAuXdGnm0OMMlttve1sTnzVj1PP21WtB+Bz9h1DaZl3ftU+DHiOx5UYslQfUpbigSFDBxuR3+r9lSVy8d7dBcloXZZazHt0a4nDqfeS8GSE9u464/ompDRHiPN1J4ozbGWGWrWm0MXFkbf0oU4hleFKzg/7XHbyoIrW/gxIv2t3LzCuEFmHI6AWy9GKlsJbSE4awcAEAccV26W8I5tq8RX9QSpVpXCWt9ZaajEuOdQKHJUTt4Xzt4PpzXe346Wd1ySUWm4+zBmS7FkK2hMroJKlgc5TwOM1lRPGGO7pBi/v6fuTTMySiJBaCkKVKcUVDCTnAA2Hk0EPbfDS8aV8INX6cZfaubk0rdiIYSUrJKUpwc8Z90f21B2HwLuD+mpXttwjwJc21MRUMsx9uxYUh1XWwfeVuTtJHlz8KsULx6tcptOyx3IyVzFRG46VIK1bU5UruAMAjj418MePdvettnmIsU5XzlNdhIbS6jclSA1zzgHPWH4UETbPA+6xYepWnZ1mWbq2ylDaGFoaQUOBZG0EEDjAwc1Y7N4UzI3hLetJS7hCEq4O9VL0ePtQjBQUgjgq+gMk88+eKiLT43Lv+sdNRbVD6NrnNvGU28jc8laAs4SQrHZI8vOpGN47WxcK5ypViucZmE2F4WpsrWStKEpKc5SSVZ54wDQVlnwIvaY17bdvFuWqfa48BtSULAQWlxzkjnjDBH2kcCrZ4WeFk7RmqZlyfmxHI0i2NQulHSpJ6iUthS+RjkoUfX3qselPEBOo9OXm5MWacxItgVviulOXSElWEKGQc4I+2qbE+UFZZMZ6Qi0Ty0ywhxZQpJIdWvalr0ye+c9gaCJheAEppU1Dt8jBr2V+Ow41GKXHS4SQp8597Gf7B6Vk6Q8Eblapt3Vc7rBeYn2VdqHSaVuQopQkLweDjZnv6dqzNWeNT8TQ715stnLc6LchbpcafyGVbVK/gK57Y/GrDZ/FNu5awmWBmyy1mCAuVLQtJbbRs3FeO+M4Hn3oKZYfBO+QJ9hdk3a3ONWuJJipCELBUHesQe3kXj+FXLRGhb3pPw0NgiS7U9chIU6l2SwpxjaVA4KeDnAr70D4sQdZX1NviWi4xm3W1usSXQkoWlJIOdpO08Hv6VHs+NMNTmonHbFcEwLGtbcmUlaFJ3BRQgAcHKlDA/toMjxW8OJ+s3rJLiTbeiTAacacZlxy4wvekAqCfIgjIz8PSsq5+GESd4b/AJO9SK1dBDRE+c0Rkhe1Lgc2DzCCofRz2NRP/TZFGm5t3c09cm2ob7LbyVKRjY6DtWFDg9gCPiK+V+ONt+aWpzNmnPCVNdhwkJWke0dMAqWCcAJ95P3n4UVDx/BS4t6MuVqXNsypMyWy/sEZaWQltK0gcEK3HfnPwx519M+Ctzjw9JOs3S2JuVlnKluKTF6bbgKm1Ae73I6fmBnJrNunj3bYC4QNhuSvaYRm7VKShSAFLSQQf/dk59CK7bx472u3KibLRMeRJtqbilXUSkhJyNpHrxRGfqvwxmX7xEm34XFliHJtTluKAkl1BW2pG4eXG7Peojww8ILnpDW0W9y59tdZahmMWorKmyTgAKPkScZJ8ya2rpS9N6i05bruy0plE1hL6WlEFSAoZwalaKUpSgUpSgVU774d6Uv19TebvZ2pNxTt/SqcWAdvbKQracY8xVspQVN7w50m9qJd9csrCrqtRcU9uXyr623O3d8cZzzWMfCzRZsTdnVY2lW9t5T6Gy84VJWoAKIXu3DISOM44q60oKPL8KNFSyjrWJvCI4ipCH3UANA524SoDvznv8a7bh4X6NuHzf7bYmHvYGUx4+5xz3W0/RSr3veA/nZq50oKovw80mvUTd9VZI3zo2oOJeG4AKHZW0HaSPXFR3iX4YWTXUV5chtEW7rQltFwSgqWhIWFY25AVwCOe2TV8pQUE+E2kpdvhM3i1tz5TEFmCuSVraU6lpKQCQlQwfcHxxxnFTdl0Tp6yXtV3tlvDFxVFRCL3WcVllCUJSnBURwG0DOM8d+9WOlBTx4Z6OTLnyU2GMl+c2tp9SSoZSsELCcH3cgnlODzWJqrw0tV40A1pO3LVa7ew4HGSlPWKDuKj9Mk8lR88/dxV7pQax0p4LaYs9gNturPzypUn2suvp6eF4wAkJPCceWTnzqXY8KdFx2IDLNlCW4EhUqMPaXj03VbMq+nz/s0cHI4+2rvSgpFr8KtGWuXFkwbKlp6MFhpRkOq27wQrgrIOQT3rm3+FWibezNai2COG5rfSfC1rc3JyFYG5R28gHjHYVdqUEJpXSlk0pBdh6ft7cOO6ve4EqUorV2yVKJJ/GoqB4Z6Pg265QI1jYTEuJSqS2pa1hZSSU43KO3BJxjFXClBVB4d6TGml6fFlji0rcDqmQpQJWOyt+d2fjnOOK7tOaG07pybIl2a2pjyJDKY7quq4vc2kABOFKI7AVZaUFX07oDS+nLu9c7LZ48Sc6ClTiCo4B7hIJIT9wFfcHQum4LF5Zj2tvo3hfUnIWtbiXlZJyQonHKj2xVlpQVGB4baSgWO42iJZWW7fcMe1N9RZLmDkZUVbhg8jB4rmR4caSk6ciWJ+zMrtcRSlsNFa8tlRJJC927nPrVtpQUiT4U6Kkljq2Nv9BGMRsIedQEtHcSnAUM8rVz3571zP8K9Fz2IjUuxtOIiRxFZ/TOgpaByE5CsnueTk81dqUFf0/o2waemmXZ7eI0gx0RN/VWr9EjASn3ie2Bz34qwUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUrhxaW0KW4oJQkZKlHAA9TQc0rSutPlC6csslyLZY715fQcKcbUG2QfgoglX3DHxqmK+U7NydumI+PLMxX+Sg9O0rzF+c7O/kxG/rav8tPznZ38mI39bV/loPTtK8xfnOzv5MRv62r/LT852d/JiN/W1f5aD07SvMX5zs7+TEb+tq/y0/OdnfyYjf1tX+Wg9O0rzF+c7O/kxG/rav8tPznZ38mI39bV/loPTtK8xfnOzv5MRv62r/LT852d/JiN/W1f5aD07SvMX5zs7+TEb+tq/y0/OdnfyYjf1tX+Wg9O0rzF+c7O/kxG/rav8tPznZ38mI39bV/loPTtK8xfnOzv5MRv62r/LT852d/JiN/W1f5aD07SvMX5zs7+TEb+tq/y0/OdnfyYjf1tX+Wg9O0rzK18p2VvHW0wzs89sw5/9FbO8PfGbTOspDcJK3LbdF8JjSsYcPohY4P2cH4UGzKUpQKUpQKUpQKUpQK86/Kp13IhpY0lbHi312w9OUg8lBPut/fgk/DHrXorNeH/lDrcV4v37qeSmgn7OkjFBrmlcZq0+F0mLE8QLJIuDjLUVt/c4t5QSgDae5PA++iKvSt1PjSOo9SOSbm/EdQm2xjFS5JbbU+ok9UvKCmkhxOSMZGQAcHtULZrXocyHI8pTLzci8SIbch2dsMeMG0lDuAQD7xOFHg8/cGr6VervbdOtaYhPQvY1KUywpyWLhmT1SR1UGPzwnnBwngA7jnFWKVZNCtz2d6oSI6Vyekli6dT2phMdam3HDn9E4XAgbeMlRG3jkNR0rb9tXpZu23tiBCtCnLhaI0lLEm4lCW3eoOoylaljBG3fgnd5cjioq02/Rb03TkOYGUB23KlS5HthwuRhe1lXvBLYyE55See4zmg1rStk3aBo23valdYbZl+zxoxhx/bvd6yzhwJKFHeE98BSseprG0HZNO3S229+7SYLK25shM1MiaGVKZ6KCztSVAn9Jv5T9/FBr+lbAbgaUXo9KSGE3dVpVMMn2w7hITIKQ1084yUc4xnsR8edHWTTk/SEty6yITd0dEkR1uTg2ttaGgpoFBUAApWRkhQPbKcchr6lbRft+jV6ju8W3RoLqIbDYiIkXQtsy1kpLii7uABSCcJBGceZrv06NKLtSbRdRCVGfv7raV+3YMZkspAdC8JKkgjgqASeeKDVBSU4yCMjIzXFbhs0yyqbkQ3Tbbi8/pqMhsz7iW0JdS4gqZCytIRwCcZBG3A7kHCdsmg/yXtj6poQ857KX325CS6FKWA+ktbycJBVg9Mdh7ys8hqulbYs507ZPEexOqh2ZqEp1xCi3dDJaSnsh1ZzhJ5PBVj1SnHK22TRj1oubt0MKNcEuvhTUe4JWmOlLYLZaUXf0m5Wewc9Pd70Gp6Vy2U9RPUzsyN23vj4VfVHTH5Bzd/zhv6h+but0up1uN30eenjGc+eMc5oKDXLa1NrSttRStJBSpJwQR5ivnNM0Htn5P8Arh7Wmix84L33S3rEeQs93BjKF/eOD8Qa2dXlz5Hy3RftRJH+wMZoq/4txx/YVV6izRXNK4zTNBzSuM0zQc0rjNc5oPgmvM/yrNFvGZH1bAaK2ShMebtGdhH0Fn4EHbn4D1r0kVV0SmW5UdyPJZS8w6koW2tO5Kge4IPcUH5z0r1BrT5O0CfKck6YnKt2/JMV5BcbB/mq7gfDmqUv5OOrAo7bjZSnyJcdH/8AnRGlKVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqVun83HVv6wsn7V7/Tp+bjq39YWT9q9/p0GlqDk4Het2sfJw1QpwB+52hCPMoU6o/gUD/GtoeHfgfZdLS2rhc1ru9xbO5tTje1ps+RCOcn4k/dQZvyctGvaT0YuVcWi1cbooPONqGFNtge4k/Hkn/wA2K2xvrGyr6p/CmVfVP4UVk76b6xsq+qfwrncr6p/CgyN9N9Y25X1T+FdcuYxAgSJ00rTGYTucKUlRSPM4HOB3oM8KzXOawLfPi3KGiZb3C5FWpSUuYIC8EjKfUZHB7HuKyt1B2tICUgnvX3SlApSlApSsS4z24LaVOAkq7AVi5cptUzXXOIhaaZqnEMulYkKe1KYLiDjaMlPmB/8AYqHses7LedxjPutAR0ygZTKmQppRwFpKgAU58xVorprjWpnMExMTiVjpWOmdEUtpCZLBW6nc2kODKx6j1FdLt4trLYcduMNDZUUblPJA3DuM57j0rSM6ldDkyM2VByQygpCVEKWBgKOAfvPAr4+cYWx5ftkbYydriuqnCD6K54++gyqV0uyo7LAfdfaQycYcUsBJz25r4buENzb05cdW4hI2uA5JGQBz5jmgyaVi/OUHpJc9tjdNS+mFdVOCr0znv8Kwo+pLVJmuRY8xDjrbjjTm3s2psAqCj5YyKCXpWGq629LTbip8QNufQWXk4Vzjg555I/Gu5qVHdecZafaW639NCVgqT9o8qDupWFCukWauYhheVxHC26k9wQM5+zn/AB9KibVrOzXSTGYiPulcjPT3tKSDhoO9yPqqB/soLHSovTl/t2o7cZ1of68YOKbKtpSQod+Dz6H7CKlKBSoC76utNpnORZbr29kIVIW2wtaI6VfRLigMJB+Plz2qWM+IlTqVSmAWU7nAXB7g9T6CgyaVF/P9s+c2oHtjXtDrIfb94bVoKto2q7E58hX1cb9ardHeemT4zbbK0tuErB2KUcAEDtkmgkq+TXW7LjNKUl2QygpAUoKWBgE4BP2ngV1Jnw1lQRLjqKVhtQDgOFHsk89/hQd6qwrpBRc7dJgPPPMtSE7FrZUEq2+YBIOMjj154xXamdDccbbRKjqcczsSHASrBwcDzwQa7iKCNtVtj2O1tW2E46qM0T0kuKCukjOQgHH0R2GcnHnWZmviTw4n7K4zQSFKUoFKUoFRV8tap7ZUheHEj3Qe1StVKZreOzeLjbmIEyQ5CSsKcRtCFLS2HCjJPHukcnAzxmuOkWKNItzauRmJbt11W6oqp4wkdPWt6FGkJkEBTvGAc47/AL6gIvhtboWmYlvhFlE9gRyqYtneHlNEEb0FX0SQTtBH9ldaPE6C5b409m2znYb8d6WFpLeUsNrShSyCr45x3rqjeILiJrzcqP1h1H2mWmEYU4pMz2dsblKwM5Gc/E/Cs6Lo1Gi2qbNvhC3blV2ua6uMuWfDcszbfIaunTLGS902CkuZccWUpG/alOXCACklI7GsNPha8i0sQEXWIW0OtrdDsFTiX0tpwhKgXfvOCAcAYwKl0eIsIsOuLgy21NIK1IUUZGJJjkcHGdwz9lSemtXxNQPTExYsptthJWh1xI2upClJyCCcHKTwcHBFehzcX3SbV4vVouD0ktmHgPtIR7skJIWgHngJWkKHfzHnVdT4YhMJ1j5xaJS22ywoRighKHCsKcKVhSnMnG8FPnxyazIPiRHmNxw3aJ4kygwqMwVN5eDqVqSc7sDAaX3I7D1rHY8SuvMcEezyXoq/Zm4+1aA4tx4rG1QJwMFBGc44PPaglJ+j3pGm7Lb03BtyTbFhaXZEYLbdIQpBCm8jyUcc8EDvVesvhtLTbLc3MuIjbER1vsIa3KDjbCmvdcCsAYVnseRVs01q+Lf58qNHiSmgwFkOuJGxexZQrBBOCCOxxkc1Ds+JUOS8WIlsmvPmQ2w2hK2sOb0uKSoK3bcfolefpQRyvC1XzM1ERc2W5KF59oRHcBx00t9ur3wkZzlJ7FNZc3w29sfnF26BLMhyQ4AmOAoF5KAdx3YIBR2wMgkVkRvEq3yC2tqBN9lUGQXzsAQp1BUhJG7OeCMgEZ+FcxPEaM8iM47aZ7LTrbDzi1KbIaQ+vY0ogKycnyAOBQYsjw0RKblGTPZ60lqUhXTiBLaFvIbTuQjd7uA2DjPJUTkVLab0euy6lm3NM8LZkJWPZ0tkDcpQUVElRGcg/RCc5ycmsKbrt5yJBk2y1PrakzW2G+qpvMhtSlpJQN+UnKP4WO9d9n8Q7fdrlDhxYU7L6UFaylJDKlhRCVYOf4J5GRyOaD70lo16w3S5TXrkJSpjQawGSjGFrUCfeIz75GAAOO1dEzQjrtistvjXYx3bbFdjB8MZKw430yoDd7pAzjk1L6u1TH0wIapcWS83IUUlxsAIaAxytRICe/GeODURN8RoEW4TYghSnlxsBKmlNqS6eqhogHdwQpY4OPPtQZmmNFs6eNxZi3CW5b5jbaeitW1ba0J2bkrTgjKQgcDjaOakm9Nw23ErTJupKSCAq5PkfeCvmoNjxDhrnQIr1umx1yXlx1Lc2BttxLqmikr3YJynOAexGMnis26ayj27UC7Y7CkqS2qOhySko2ILxKUZBO48jHANB0X7Rr1xmXZUW5+yw7u2hqeyWAtSgkbctqyNhKeDkK9awXfD0rTPaRPjJjvPmSzuhJU4lZeS7tcWVZWjKANvu5TwewNYti8Rn5YbTItbjynmYfs/QUlJeceaLhGFKwkAJPcnt3ORUjbdbuPamdt0uA6iO5IajsPJKDsWuP1dq8KOTwoZTkduaCLkeF5ec3fOjKeqhSHwIQwNz/WV0ve/R88DvjvzXY/4Z72n0ouTQUN3s6jFGRmQl8l47v0hygAH3cAn1rLv/iAi23oR0w3RAjSHWZkpQSR+jjKeUEAK3ZACeSMd6lIusGZGmp94+b5jaIRy6yoJ3FOAoqSQSFAJVng+RHeg+9QaUZvV8tVxdkKb9kP6ZpKMiSkKC0JVzwErSFDv5jzqvMeGq46GyzdG0vRiz7MsRMDDbvUBdwr9IonjdlPn6mpBHiJb3Z8eMzCmvJeWQl1tKVDp9UtBzGclJUlXbPAz6Vgv+JJcZjmDZpBcecj7A84gBbbjxaKhg9wUkYOO4PagWvw6ct9ztUxF1SVQ1FTpSwUl7Lji8Y3lIH6QjJSSMcEZrYVV7SmrIupXJIiRpTKGgFIcdSNrqSpScggnByk8HnBFWPFBgy/9sn7K+K7Jv+2T9lfFBIUr4ZcDiAfPzr7oFKUoFRcrT1nlS35Um2xHZD6C264toErSRgg+vHH2cVKUoK3J0TYJNyZmO26OeklYDHTT0ipakqKynH0spH9tZ7+nbM+h5L1siLDwUHMtD3ty+orP2r977ealaUFdg6LsMSI1HNujvoZW4tsvNpUUb3S4Ujj6IUeB5YFScCzW23vSHYMGOw7IJLqm0AFeSTz95J+0ms+lBEu6bsrsfoOWuGpnYhsILQwEozsA+CcnHpmuU6ds6JLMhFsiJeZShDag0BsCDlAHpjy9KlaUGBCs1tgypEmHBjsyJBJdcQgArycnP2nn7ah5mhNOyQwn5tYabbeS8pDSAkOFKVpSFccgdRWB5VZ6UFdjaMsTF1cnpt7CnlJQhtKm07WUoRsAQMccGs9en7Qt6G6q2xC5DSlEdRaGWkp+iE+gHl6VJ0oImPpuyxn1vMWuG26t0PqWloAlYJIV9uVE/efWvg6Ysm9K02uGhxDZaQtLSQUpOeBx/OV+J9amaUEXJ0/apUOJFlwGJDMVAbZDqAranAGOfIgDPrivgaZsgkuyBaofWdVuWvpDJO4L/wDUkK+0ZqXpQRS9OWZcluQq2RC+2suJX0hkKKt+ft3Eq+3mulelrU7qJy9yIyX5yktpQp0BQa2bsFPHB94/2VN0oIR3SlgdRsctEIo6aGtvSGAhH0APs8vSspix2uOptTFvitltaVoKWgNqko2JI+IT7o+HFSNKCKe07Zn7iue9a4bk1fCnlNJKj7pTyf8AhJH2V32+0W63QlxIMJhiMvO9pCAEqyMHI8+OKzqUEUrTtmJhE2yJ/wBSSER/0Q/RJBBAT6AEA49RXD2nLM8wGXLZELQSlAT0hwlKt4A+xRJ+2palBFRtO2aK6pyPbIjbinQ+VJaAO8EkK+0FSj959alaUPHegw5g/TJ+yvjFfTyg47kdhxX1ig6iCk5SSD8K4Lrvks1kFNfBRQY5ef8ArmuOs/8AXVXf0646dB09Z/66qdZ/66q7unTp0HT1n/rqp1n/AK6q7unTp0HT1n/rqp1n/rqru6dOnQdPWf8Arqp1n/rqru6dOnQdPWf+uqnWf+uqu7p1gXSe1ARgje6fooH/ADolVUUxmWSX3gMlwgVhu3lpo4XLGfhz/hVYmzZEsnqr936o4FYmypl46tL6YW4agjk49qV/RP7qymLh7QP0MgL+AIzVH2VyEkHI4PqKZZjS6v1hfes/9dVOs/8AXVVatt4dYUEScuNev8Ifvq0MlDzaXGlBSFcgirl67d2m5G58dZ/66qdZ/wCuqu7p1wUADJIA+NHR1dZ/66qdZ/66qLejo+m+0n7VCuhdxgo7yEH7OazNdMcZbi3XVwh39Z/66qdZ/wCuqsFd5gp7LWr7E1jqv0cfRZdP24FYm/bj9XSNFvTwplLdZ/66q7GZDqV++SpPnXxFWiTHbeQMJWMgGviXJjQmVPS32mGU91uLCUj7zXSJzvhxmJicSkXXwlAKOSe1YpU4v6SiRUDH1hpqQ+GWL/aXHScbEzGyc/ZmrE2UrAKSCDyCPOqjhCcV24r6SmvvAoOSK+SmuymKDr2V1vrbYZW68tKG0DKlKOABWRiom6jq3e1R1H9EVOPKT5KKAMZ+9WftAoOg3tsnLVvuTqPJaY5AP44NcfPf+6rp+wH76lrhJRBgyJbqVqbYbU4oITuUQBk4HmaiYOpoczSH5Rtsy0wvZ1SOmpkh3anORt9eKB89/wC6rp+wH76fPf8Auq6fsB++n5TQ/wAjvyk6Mv2L2b2rpdE9bbjONnrUnaZzV0tcSewlxDMlpLyEup2qAUMgEeR5oIz57/3VdP2A/fT57/3VdP2A/fU9imKCB+e/91XT9gP30+e/91XT9gP31PYpigrr98WlpRatF0U5j3QWAMn8aqr67i+6px20XNS1HJPSH762ZimKOVy1Fzi1fsnfqe5fsh++myd+p7l+yH762himKmHP6Shq4rW2pIlxJUXccJL7ZSkn0z2z8K7tlbEmxmpcR5h9AW04kpUk+YrWlvcWq1RnXFblllKlE+Z21Jh5r9mLeJh9qcaS70itPUxnZnnH2V3s3CRF/RsOOJbVydqT3q36SiNx7BCWkDqvtJedXjlalDJJ/H7hX23frY5qN2wokpN1aYElbGDkNk4znt6VK6NaMZw9ui24sVxcneqC5z6/pPvn71V0qd3HKi4T8Qausa/WyTqGXY2ZKVXOI0l55nBylKuxz28x+NSu0V550SJ41S+tH+RmnhRDWm5Por+iabk+iv6JrZe0U2ip9HTza/E6+mGtNyfRX9E1wVp9Ff0TWzNor5WMCn0dPM/E6+mGtdT68gaO0Gbk4UyHt6mI7KVcuOHJAPoB3PwryNrDV151bclzL3MW8STsaBIbaHolPYf4+tbK+VTPU9ryLCASluPESs4H0lKJyT9wArXfh7phGqr87FkSVRocWM7MkuoTuUG205O0eZPAr1U06tMQ+fcr16pq5qzmtkeFfirdtFTmWH3XJljUoB2KtWemM8qbz2Pw7H+2sPQTFi1DqlrTsm3LRBuKizFkqWDJjOEe6oqSEhYz3BHY8GqZcYa7fcpcJ0guR3VsqI7EpJB/wrTD9DrPcI11tsadBdS7FkNpdbWnspJGRWditKfJYur03w+ciPKKkwZa2m8+SSAvH4qNbroOaUpQKgr5Mjwb7aXZbyGWyh9O5ZwM4RU7UTcADqK05Gf0b/8A8lBz+UVn/WMb+mK4/KGzYx84xcem8VKbUZxhOfsrnYn6o/Cgivyhs2MfOMXHpvFc/lFZ/wBYxv6YqU2J+qPwpsT9UfhQRf5RWf8AWMb+mKflFZ/1jG/pipTYn6o/CmxP1R+FBF/lFZ/1jG/pin5RWf8AWMb+mKlNifqj8KbE/VH4UEX+UVn/AFjG/pin5RWf9Yxv6YqU2J+qPwpsT9UfhQRf5RWf9Yxv6Yp+UVn/AFjG/pipTYn6o/CmxP1R+FBFK1FZ9p//ABGN2+uKocFxLljiKQhKU+yo+j5+73rZ6kJ2n3R29K1hBdWuwQ0KVlCI42j092pLx6Xwhe9OzIwsFtBkMgiM3/DH1RWUF24SjJCogkFOwu5TuKfTPfHwqP09abcqw21SoEQkxmySWU8+6PhWf80W39Xw/wBin91V7HKV25ElchKoiZCwEqdBTuUB2BPciu72yL/GWf6Yro+aLb+r4f7FP7qfNFt/V8P9in91B3+2Rf4yz/TFPbIv8ZZ/piuj5otv6vh/sU/up80W39Xw/wBin91B3+2Rf4yz/TFfDkyMQf8ArLP9MV1/NFt/V8P9in91cGz23H/Z8P8AYp/dQeXflU2nbqG23thaXGH2fZnCkg7VpJIz9oP901qLSeopul7ym4W8NLUUKacaeTuQ62oYUhQ9CK9n+IGkLPfIsC2yoLKWJMhSCppASpP6FwgggdwQD91eY9c+D2pNNynFQorl1t+SUPRkFSwP5yByD9mRQQ2k9R2bTl5cv7EF5dxZ3KgwyrLDKyMBalk7lbc8Jx6ZNVGQ+5KkvSH1Fbrqytaj5qJyTUjH07epD4ZYtFwceJxsTGWT/hW4vC3wOnS5rFx1e37PEQoLTCzlbpH18fRT8O5+FBs/5Ndhes3h4y7JQUO3B1UoJI5CCAE/iE5++tv1iwo6WGkoQkJQkAJSBgAelZeKBSlKBUTP/wC8Vp/92/8A/JSlBJK//UI/4Vf4iuylKBSlKBSlKBSlKBSlKBSlKDhX0T9lart3/Ykb/wAOn/00pUl49M4Q2Lpz/u/bP/DNf+kVIUpVewpSlApSlApSlBC33/tCx/8AjFf/AAHa75AHPApSgxgBnsKzY4HpSlBmp7V9UpQf/9k=",
+          "type": "screenshot"
+        }
+      },
+      "network-rtt": {
+        "id": "network-rtt",
+        "title": "Network Round Trip Times",
+        "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "type": "table",
+          "headings": [
+            {
+              "key": "origin",
+              "label": "URL",
+              "valueType": "text"
+            },
+            {
+              "key": "rtt",
+              "granularity": 1,
+              "label": "Time Spent",
+              "valueType": "ms"
+            }
+          ],
+          "sortedBy": [
+            "rtt"
+          ],
+          "items": [
+            {
+              "rtt": 10.711665,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "rtt": 8.84394,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "origin": "https://useago.github.io",
+              "rtt": 6.907545
+            },
+            {
+              "origin": "https://perf-eu1.hsforms.com",
+              "rtt": 5.73633
+            },
+            {
+              "rtt": 3.9450149999999997,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "origin": "https://www.ocobo.co",
+              "rtt": 2.0133300000000003
+            },
+            {
+              "rtt": 1.3168499999999994,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "origin": "https://forms-eu1.hsforms.com",
+              "rtt": 1.1090549999999992
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "rtt": 0.0033788405461718783,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.0029193432881005135,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "origin": "https://js-eu1.hubspot.com",
+              "rtt": 0.00282179191132073
+            },
+            {
+              "origin": "https://js-eu1.hs-analytics.net",
+              "rtt": 0.0014944494812223622
+            },
+            {
+              "origin": "https://fonts.gstatic.com",
+              "rtt": 0.0011411005752176016
+            },
+            {
+              "rtt": 0.000938487622388957,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "rtt": 0.00086877400868673742,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "rtt": 0.00046695065229571039,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            }
+          ]
+        },
+        "numericValue": 10.711665,
+        "numericUnit": "millisecond"
+      },
+      "total-byte-weight": {
+        "id": "total-byte-weight",
+        "title": "Avoids enormous network payloads",
+        "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn how to reduce payload sizes](https://developer.chrome.com/docs/lighthouse/performance/total-byte-weight/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Total size was 1,926 KiB",
+        "details": {
+          "sortedBy": [
+            "totalBytes"
+          ],
+          "items": [
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qobra-avatar.png",
+              "totalBytes": 323772
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "totalBytes": 204723
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "totalBytes": 157010
+            },
+            {
+              "url": "https://www.ocobo.co/images/partners/aircall.png",
+              "totalBytes": 95799
+            },
+            {
+              "totalBytes": 60332,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png"
+            },
+            {
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "totalBytes": 51336
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "totalBytes": 50337,
+              "url": "https://www.ocobo.co/images/partners/clay.png"
+            },
+            {
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "totalBytes": 45260
+            },
+            {
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "totalBytes": 43924
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "valueType": "bytes",
+              "label": "Transfer Size",
+              "key": "totalBytes"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 1972710,
+        "numericUnit": "byte"
+      },
+      "unminified-javascript": {
+        "id": "unminified-javascript",
+        "title": "Minify JavaScript",
+        "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn how to minify JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unminified-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [],
+          "headings": [],
+          "overallSavingsBytes": 0,
+          "type": "opportunity",
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            }
+          },
+          "overallSavingsMs": 0
+        },
+        "warnings": [],
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "network-requests": {
+        "id": "network-requests",
+        "title": "Network Requests",
+        "description": "Lists the network requests that were made during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "key": "protocol",
+              "label": "Protocol",
+              "valueType": "text"
+            },
+            {
+              "valueType": "ms",
+              "label": "Network Request Time",
+              "key": "networkRequestTime",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "key": "networkEndTime",
+              "label": "Network End Time",
+              "valueType": "ms"
+            },
+            {
+              "valueType": "bytes",
+              "key": "transferSize",
+              "displayUnit": "kb",
+              "label": "Transfer Size",
+              "granularity": 1
+            },
+            {
+              "key": "resourceSize",
+              "valueType": "bytes",
+              "granularity": 1,
+              "displayUnit": "kb",
+              "label": "Resource Size"
+            },
+            {
+              "key": "statusCode",
+              "valueType": "text",
+              "label": "Status Code"
+            },
+            {
+              "valueType": "text",
+              "label": "MIME Type",
+              "key": "mimeType"
+            },
+            {
+              "label": "Resource Type",
+              "valueType": "text",
+              "key": "resourceType"
+            }
+          ],
+          "items": [
+            {
+              "priority": "VeryHigh",
+              "resourceSize": 0,
+              "rendererStartTime": 0,
+              "protocol": "http/1.1",
+              "statusCode": 301,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "transferSize": 368,
+              "networkEndTime": 521.3640000000596,
+              "mimeType": "text/plain",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "url": "https://www.ocobo.co/",
+              "networkRequestTime": 1.5059999991208315
+            },
+            {
+              "url": "https://www.ocobo.co/fr",
+              "networkRequestTime": 522.04299999959767,
+              "mimeType": "text/html",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Document",
+              "finished": true,
+              "sessionTargetType": "page",
+              "transferSize": 20539,
+              "networkEndTime": 1638.901999999769,
+              "rendererStartTime": 521.3640000000596,
+              "priority": "VeryHigh",
+              "resourceSize": 120277,
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 24569,
+              "networkEndTime": 2172.9469999996945,
+              "priority": "VeryHigh",
+              "resourceSize": 122090,
+              "rendererStartTime": 1658.1239999998361,
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "networkRequestTime": 1659.6059999996796,
+              "mimeType": "text/css",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Stylesheet",
+              "finished": true
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 2030.8269999995828,
+              "transferSize": 12757,
+              "protocol": "h2",
+              "rendererStartTime": 1658.8300000000745,
+              "resourceSize": 12266,
+              "priority": "Medium",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 1659.8080000001937,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "finished": true,
+              "resourceType": "Image"
+            },
+            {
+              "networkEndTime": 2023.438000000082,
+              "transferSize": 29545,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "protocol": "h2",
+              "rendererStartTime": 1659.0949999997392,
+              "priority": "Medium",
+              "resourceSize": 29045,
+              "networkRequestTime": 1660.0499999998137,
+              "url": "https://www.ocobo.co/images/partners/modern-revenue-club.png",
+              "finished": true,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png"
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 1659.3219999996945,
+              "priority": "Medium",
+              "resourceSize": 323105,
+              "entity": "vercel-storage.com",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2457.7120000002906,
+              "transferSize": 323772,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "finished": true,
+              "resourceType": "Image",
+              "networkRequestTime": 2025.6499999994412,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qobra-avatar.png"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 2388.4440000001341,
+              "transferSize": 37618,
+              "protocol": "h2",
+              "resourceSize": 37130,
+              "rendererStartTime": 1659.5109999999404,
+              "priority": "Low",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 2183.5,
+              "url": "https://www.ocobo.co/images/partners/hubspot.png",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "finished": true,
+              "resourceType": "Image"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 1659.6469999998808,
+              "resourceSize": 49852,
+              "priority": "Low",
+              "protocol": "h2",
+              "networkEndTime": 2472.3729999996722,
+              "transferSize": 50337,
+              "sessionTargetType": "page",
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2183.6150000002235,
+              "url": "https://www.ocobo.co/images/partners/clay.png"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 2373.4379999991506,
+              "transferSize": 19377,
+              "resourceSize": 18886,
+              "rendererStartTime": 1659.8510000007227,
+              "priority": "Low",
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 2183.6970000006258,
+              "url": "https://www.ocobo.co/images/partners/salesforce.png",
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "finished": true
+            },
+            {
+              "networkEndTime": 2355.2050000000745,
+              "transferSize": 11893,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "priority": "Low",
+              "resourceSize": 11406,
+              "rendererStartTime": 1660.0010000001639,
+              "protocol": "h2",
+              "networkRequestTime": 2183.8090000003576,
+              "url": "https://www.ocobo.co/images/partners/notion.png",
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "url": "https://www.ocobo.co/images/partners/vasco.webp",
+              "networkRequestTime": 2183.9589999997988,
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/webp",
+              "experimentalFromMainFrame": true,
+              "transferSize": 25724,
+              "networkEndTime": 2376.5209999997169,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "rendererStartTime": 1660.1409999998286,
+              "resourceSize": 25236,
+              "priority": "Low",
+              "protocol": "h2"
+            },
+            {
+              "protocol": "h2",
+              "priority": "Low",
+              "resourceSize": 95311,
+              "rendererStartTime": 1660.2779999999329,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "transferSize": 95799,
+              "networkEndTime": 2469.7749999994412,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "finished": true,
+              "resourceType": "Image",
+              "url": "https://www.ocobo.co/images/partners/aircall.png",
+              "networkRequestTime": 2184.1080000000075
+            },
+            {
+              "networkRequestTime": 2184.2539999997243,
+              "url": "https://www.ocobo.co/images/partners/qobra.png",
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "finished": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 2448.0249999994412,
+              "transferSize": 2958,
+              "resourceSize": 2473,
+              "priority": "Low",
+              "rendererStartTime": 1660.3969999998808,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "rendererStartTime": 1660.5040000006557,
+              "resourceSize": 3071,
+              "priority": "Low",
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2551.4069999996573,
+              "transferSize": 3558,
+              "mimeType": "image/jpeg",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "finished": true,
+              "networkRequestTime": 2184.473000000231,
+              "url": "https://www.ocobo.co/images/partners/modjo.jpeg"
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 13245,
+              "networkEndTime": 2428.5719999996945,
+              "resourceSize": 12757,
+              "rendererStartTime": 1660.6260000001639,
+              "priority": "Low",
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/images/partners/planhat.png",
+              "networkRequestTime": 2185.0240000002086,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "finished": true
+            },
+            {
+              "finished": true,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "url": "https://www.ocobo.co/images/partners/dust.png",
+              "networkRequestTime": 2185.151999999769,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "priority": "Low",
+              "resourceSize": 8957,
+              "rendererStartTime": 1660.761999999173,
+              "transferSize": 9441,
+              "networkEndTime": 2395.5109999999404,
+              "sessionTargetType": "page"
+            },
+            {
+              "networkRequestTime": 2185.2560000000522,
+              "url": "https://www.ocobo.co/images/partners/hyperline.png",
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "finished": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 2383.4459999995306,
+              "transferSize": 19683,
+              "resourceSize": 19193,
+              "rendererStartTime": 1660.8880000002682,
+              "priority": "Low",
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 3291,
+              "networkEndTime": 2365.7290000002831,
+              "protocol": "h2",
+              "resourceSize": 2802,
+              "rendererStartTime": 1661.061999999918,
+              "priority": "Low",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/images/partners/lemlist.webp",
+              "networkRequestTime": 2185.3359999991953,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/webp",
+              "finished": true,
+              "resourceType": "Image"
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 157010,
+              "networkEndTime": 2219.9479999998584,
+              "protocol": "h2",
+              "resourceSize": 471628,
+              "priority": "Low",
+              "rendererStartTime": 1661.2779999999329,
+              "statusCode": 200,
+              "entity": "Google Tag Manager",
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "networkRequestTime": 2185.4589999997988,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script"
+            },
+            {
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2185.5299999993294,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "entity": "Clearbit",
+              "statusCode": 404,
+              "rendererStartTime": 1661.4189999997616,
+              "resourceSize": 0,
+              "priority": "Low",
+              "protocol": "h2",
+              "networkEndTime": 2446.2019999995828,
+              "transferSize": 640,
+              "sessionTargetType": "page"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 2185.5939999995753,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "protocol": "h2",
+              "rendererStartTime": 1661.5579999992624,
+              "priority": "Low",
+              "resourceSize": 2125,
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2273.2690000003204,
+              "transferSize": 1638
+            },
+            {
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "networkRequestTime": 2186.0779999997467,
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "transferSize": 5019,
+              "networkEndTime": 2339.5879999995232,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "GitHub",
+              "protocol": "h2",
+              "rendererStartTime": 1661.714999999851,
+              "priority": "Low",
+              "resourceSize": 17494
+            },
+            {
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "networkRequestTime": 1663.0279999999329,
+              "rendererStartTime": 1661.8839999996126,
+              "resourceSize": 69556,
+              "priority": "High",
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "transferSize": 24114,
+              "isLinkPreload": true,
+              "networkEndTime": 2058.6100000003353
+            },
+            {
+              "protocol": "h2",
+              "priority": "High",
+              "resourceSize": 927,
+              "rendererStartTime": 1662.0729999998584,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "isLinkPreload": true,
+              "transferSize": 1454,
+              "networkEndTime": 2071.2919999994338,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "networkRequestTime": 1663.2200000006706
+            },
+            {
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "networkRequestTime": 1663.4670000001788,
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "transferSize": 43924,
+              "isLinkPreload": true,
+              "networkEndTime": 2370.0609999997541,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "rendererStartTime": 1662.2879999997094,
+              "priority": "High",
+              "resourceSize": 125397,
+              "protocol": "h2"
+            },
+            {
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "networkRequestTime": 1663.9610000001267,
+              "resourceSize": 133936,
+              "priority": "High",
+              "rendererStartTime": 1662.4759999997914,
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "transferSize": 45260,
+              "isLinkPreload": true,
+              "networkEndTime": 2146.6490000002086
+            },
+            {
+              "priority": "High",
+              "resourceSize": 110060,
+              "rendererStartTime": 1662.6450000004843,
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "transferSize": 34184,
+              "isLinkPreload": true,
+              "networkEndTime": 2221.8380000004545,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "networkRequestTime": 1664.2970000002533
+            },
+            {
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "resourceSize": 991,
+              "priority": "High",
+              "rendererStartTime": 1662.8580000000075,
+              "isLinkPreload": true,
+              "transferSize": 1514,
+              "networkEndTime": 2014.4639999996871,
+              "sessionTargetType": "page",
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "networkRequestTime": 1664.5570000000298
+            },
+            {
+              "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "networkRequestTime": 1664.7369999997318,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "isLinkPreload": true,
+              "transferSize": 4522,
+              "networkEndTime": 2014.9939999999478,
+              "protocol": "h2",
+              "priority": "High",
+              "rendererStartTime": 1663.0279999999329,
+              "resourceSize": 9799,
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "networkEndTime": 1923.5310000004247,
+              "transferSize": 2148,
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 3192,
+              "rendererStartTime": 1663.2269999999553,
+              "priority": "High",
+              "protocol": "h2",
+              "networkRequestTime": 1665.3090000003576,
+              "url": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 669,
+              "isLinkPreload": true,
+              "networkEndTime": 2070.8930000001565,
+              "priority": "High",
+              "resourceSize": 141,
+              "rendererStartTime": 1663.3959999997169,
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "networkRequestTime": 1665.5019999993965,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true
+            },
+            {
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1665.7939999997616,
+              "url": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 1663.5859999991953,
+              "resourceSize": 1284,
+              "priority": "High",
+              "protocol": "h2",
+              "networkEndTime": 1959.1010000007227,
+              "transferSize": 1269,
+              "isLinkPreload": true,
+              "sessionTargetType": "page"
+            },
+            {
+              "transferSize": 6806,
+              "isLinkPreload": true,
+              "networkEndTime": 2044.9060000004247,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "resourceSize": 15426,
+              "rendererStartTime": 1663.8249999992549,
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "networkRequestTime": 1666.0300000002608,
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "protocol": "h2",
+              "priority": "High",
+              "rendererStartTime": 1664.1509999996051,
+              "resourceSize": 17234,
+              "networkEndTime": 2115.6709999991581,
+              "isLinkPreload": true,
+              "transferSize": 6205,
+              "sessionTargetType": "page",
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 1666.4499999992549,
+              "url": "https://www.ocobo.co/assets/factory-hx59odkt.js"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 1667.1450000004843,
+              "url": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "protocol": "h2",
+              "resourceSize": 3070,
+              "rendererStartTime": 1664.3930000001565,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2028.5400000000373,
+              "isLinkPreload": true,
+              "transferSize": 1832
+            },
+            {
+              "networkRequestTime": 1667.7609999999404,
+              "url": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2029.4850000003353,
+              "transferSize": 953,
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 428,
+              "rendererStartTime": 1664.5829999996349,
+              "priority": "High",
+              "protocol": "h2"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 410,
+              "rendererStartTime": 1664.8499999996275,
+              "priority": "High",
+              "protocol": "h2",
+              "networkEndTime": 1947.5089999996126,
+              "transferSize": 937,
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1667.9529999997467,
+              "url": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js"
+            },
+            {
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "url": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "networkRequestTime": 1668.3969999998808,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "rendererStartTime": 1665.0360000003129,
+              "priority": "High",
+              "resourceSize": 525,
+              "protocol": "h2",
+              "transferSize": 1047,
+              "isLinkPreload": true,
+              "networkEndTime": 1975.36699999962,
+              "sessionTargetType": "page"
+            },
+            {
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "networkRequestTime": 1668.6200000001118,
+              "rendererStartTime": 1665.2309999996796,
+              "resourceSize": 942,
+              "priority": "High",
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "transferSize": 1471,
+              "isLinkPreload": true,
+              "networkEndTime": 2015.5409999992698
+            },
+            {
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 1665.4840000001714,
+              "priority": "High",
+              "resourceSize": 349,
+              "isLinkPreload": true,
+              "transferSize": 876,
+              "networkEndTime": 2085.3820000002161,
+              "sessionTargetType": "page",
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "networkRequestTime": 1668.7910000002012
+            },
+            {
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 1668.9280000003055,
+              "url": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "protocol": "h2",
+              "rendererStartTime": 1665.6689999997616,
+              "priority": "High",
+              "resourceSize": 1866,
+              "networkEndTime": 2062.0750000001863,
+              "isLinkPreload": true,
+              "transferSize": 1367,
+              "sessionTargetType": "page"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 1669.1480000000447,
+              "url": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "protocol": "h2",
+              "resourceSize": 348,
+              "priority": "High",
+              "rendererStartTime": 1665.8829999994487,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2112.2730000000447,
+              "isLinkPreload": true,
+              "transferSize": 867
+            },
+            {
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "resourceSize": 67398,
+              "priority": "High",
+              "rendererStartTime": 1666.0499999998137,
+              "protocol": "h2",
+              "transferSize": 21252,
+              "isLinkPreload": true,
+              "networkEndTime": 2168.7779999999329,
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "networkRequestTime": 1669.7430000007153
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "protocol": "h2",
+              "rendererStartTime": 1666.2319999998435,
+              "priority": "High",
+              "resourceSize": 165,
+              "networkEndTime": 2162.3499999996275,
+              "isLinkPreload": true,
+              "transferSize": 701,
+              "sessionTargetType": "page",
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 1669.9720000000671,
+              "url": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js"
+            },
+            {
+              "url": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "networkRequestTime": 1670.2029999997467,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "isLinkPreload": true,
+              "transferSize": 1127,
+              "networkEndTime": 1984.3879999993369,
+              "protocol": "h2",
+              "priority": "High",
+              "resourceSize": 605,
+              "rendererStartTime": 1666.4610000001267,
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "networkRequestTime": 1670.3470000000671,
+              "url": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 2088.9809999996796,
+              "transferSize": 1345,
+              "isLinkPreload": true,
+              "rendererStartTime": 1666.6290000006557,
+              "priority": "High",
+              "resourceSize": 826,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "networkRequestTime": 1670.5849999999627,
+              "url": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2040.3789999997243,
+              "transferSize": 929,
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "priority": "High",
+              "rendererStartTime": 1666.811999999918,
+              "resourceSize": 404,
+              "protocol": "h2"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 2182.1990000000224,
+              "isLinkPreload": true,
+              "transferSize": 1011,
+              "protocol": "h2",
+              "resourceSize": 490,
+              "rendererStartTime": 1667.4110000003129,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 1671.0190000003204,
+              "url": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script"
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 1667.7989999996498,
+              "priority": "High",
+              "resourceSize": 206,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2058.1499999994412,
+              "isLinkPreload": true,
+              "transferSize": 726,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 1671.3499999996275,
+              "url": "https://www.ocobo.co/assets/lang-PH2TSE5M.js"
+            },
+            {
+              "networkRequestTime": 1671.6650000000373,
+              "url": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2036.11699999962,
+              "transferSize": 1358,
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 1668.0239999992773,
+              "priority": "High",
+              "resourceSize": 835,
+              "protocol": "h2"
+            },
+            {
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "rendererStartTime": 1668.2600000007078,
+              "resourceSize": 68826,
+              "priority": "High",
+              "protocol": "h2",
+              "transferSize": 26412,
+              "isLinkPreload": true,
+              "networkEndTime": 1982.3070000000298,
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "url": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "networkRequestTime": 1671.9169999994338
+            },
+            {
+              "priority": "High",
+              "rendererStartTime": 1668.4550000000745,
+              "resourceSize": 473,
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "transferSize": 997,
+              "isLinkPreload": true,
+              "networkEndTime": 2051.8629999998957,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "networkRequestTime": 1672.5599999995902
+            },
+            {
+              "url": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "networkRequestTime": 1672.9230000004172,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true,
+              "sessionTargetType": "page",
+              "transferSize": 855,
+              "isLinkPreload": true,
+              "networkEndTime": 2045.4339999994263,
+              "priority": "High",
+              "resourceSize": 338,
+              "rendererStartTime": 1668.6440000003204,
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 1984.6979999998584,
+              "transferSize": 964,
+              "isLinkPreload": true,
+              "priority": "High",
+              "resourceSize": 435,
+              "rendererStartTime": 1668.8820000002161,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 1673.2190000005066,
+              "url": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true
+            },
+            {
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true,
+              "networkRequestTime": 1673.3679999997839,
+              "url": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "priority": "High",
+              "rendererStartTime": 1669.0539999995381,
+              "resourceSize": 312,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2005.188000000082,
+              "transferSize": 840,
+              "isLinkPreload": true
+            },
+            {
+              "url": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "networkRequestTime": 1673.6469999998808,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true,
+              "sessionTargetType": "page",
+              "transferSize": 831,
+              "isLinkPreload": true,
+              "networkEndTime": 2016.9740000003949,
+              "rendererStartTime": 1669.3509999997914,
+              "resourceSize": 309,
+              "priority": "High",
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "networkRequestTime": 1673.9079999998212,
+              "url": "https://www.ocobo.co/assets/_main.(_lang)._index-BJmsIfGa.js",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2064.7000000001863,
+              "transferSize": 7567,
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 1669.5750000001863,
+              "priority": "High",
+              "resourceSize": 27349,
+              "protocol": "h2"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 1674.0449999999255,
+              "url": "https://www.ocobo.co/assets/section-CAd8zqOP.js",
+              "protocol": "h2",
+              "priority": "High",
+              "rendererStartTime": 1669.8009999999776,
+              "resourceSize": 521,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2031.5300000002608,
+              "isLinkPreload": true,
+              "transferSize": 1044
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 2048.813000000082,
+              "isLinkPreload": true,
+              "transferSize": 1237,
+              "protocol": "h2",
+              "priority": "High",
+              "resourceSize": 717,
+              "rendererStartTime": 1670.0410000002012,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 1674.2009999994189,
+              "url": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script"
+            },
+            {
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "priority": "High",
+              "resourceSize": 549,
+              "rendererStartTime": 1670.2259999997914,
+              "isLinkPreload": true,
+              "transferSize": 1074,
+              "networkEndTime": 2053.8729999996722,
+              "sessionTargetType": "page",
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "networkRequestTime": 1675.578000000678
+            },
+            {
+              "networkEndTime": 2005.6029999991879,
+              "transferSize": 824,
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 1670.4189999997616,
+              "priority": "High",
+              "resourceSize": 303,
+              "protocol": "h2",
+              "networkRequestTime": 1677.2539999997243,
+              "url": "https://www.ocobo.co/assets/check-D95Zi0fi.js",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script",
+              "networkRequestTime": 1681.3349999999627,
+              "url": "https://www.ocobo.co/assets/hero-split-DCf1X66c.js",
+              "protocol": "h2",
+              "rendererStartTime": 1670.5869999993593,
+              "resourceSize": 551,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 1993.6159999994561,
+              "isLinkPreload": true,
+              "transferSize": 1077
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "priority": "High",
+              "resourceSize": 495,
+              "rendererStartTime": 1670.7779999999329,
+              "protocol": "h2",
+              "networkEndTime": 2004.5760000003502,
+              "transferSize": 1016,
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1681.4429999999702,
+              "url": "https://www.ocobo.co/assets/badge-i9dgPBIb.js"
+            },
+            {
+              "transferSize": 1125,
+              "isLinkPreload": true,
+              "networkEndTime": 2021.9669999992475,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "resourceSize": 605,
+              "rendererStartTime": 1670.9520000005141,
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "networkRequestTime": 1685.5499999998137,
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "networkRequestTime": 1685.8580000000075,
+              "url": "https://www.ocobo.co/assets/plus-Bvz3jpuZ.js",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2024.3080000001937,
+              "transferSize": 857,
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 337,
+              "priority": "High",
+              "rendererStartTime": 1671.1260000001639,
+              "protocol": "h2"
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 943,
+              "isLinkPreload": true,
+              "networkEndTime": 2091.0339999999851,
+              "resourceSize": 412,
+              "priority": "High",
+              "rendererStartTime": 1671.5740000000224,
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/assets/panels-top-left-BeWfuLW7.js",
+              "networkRequestTime": 1685.9939999999478,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true
+            },
+            {
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1686.1900000004098,
+              "url": "https://www.ocobo.co/assets/zap-C3uzvT7-.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "priority": "High",
+              "resourceSize": 446,
+              "rendererStartTime": 1671.8590000001714,
+              "protocol": "h2",
+              "networkEndTime": 2020.6749999998137,
+              "transferSize": 965,
+              "isLinkPreload": true,
+              "sessionTargetType": "page"
+            },
+            {
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/target-DyzL19b9.js",
+              "networkRequestTime": 1686.2739999992773,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 1672.0809999993071,
+              "resourceSize": 405,
+              "priority": "High",
+              "isLinkPreload": true,
+              "transferSize": 927,
+              "networkEndTime": 2018.5920000001788,
+              "sessionTargetType": "page"
+            },
+            {
+              "priority": "High",
+              "resourceSize": 435,
+              "rendererStartTime": 1672.2779999999329,
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "transferSize": 963,
+              "isLinkPreload": true,
+              "networkEndTime": 2030.4390000002459,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/chart-column-CxnbmN-k.js",
+              "networkRequestTime": 1686.3729999996722
+            },
+            {
+              "transferSize": 1773,
+              "isLinkPreload": true,
+              "networkEndTime": 1969.0690000001341,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "rendererStartTime": 1672.4440000001341,
+              "resourceSize": 3009,
+              "priority": "High",
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/modular-stack-grid-DBlYkSNY.js",
+              "networkRequestTime": 1686.4749999996275,
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "url": "https://www.ocobo.co/assets/flex-pair-BLQ5DP05.js",
+              "networkRequestTime": 1689.4320000000298,
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "transferSize": 1093,
+              "networkEndTime": 2050.8309999993071,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "priority": "High",
+              "resourceSize": 568,
+              "rendererStartTime": 1672.6419999990612
+            },
+            {
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "networkRequestTime": 1689.651999999769,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "priority": "High",
+              "rendererStartTime": 1672.8629999998957,
+              "resourceSize": 1217,
+              "isLinkPreload": true,
+              "transferSize": 1132,
+              "networkEndTime": 2061.6509999996051,
+              "sessionTargetType": "page"
+            },
+            {
+              "protocol": "h2",
+              "priority": "VeryHigh",
+              "resourceSize": 31480,
+              "rendererStartTime": 2226.0120000001043,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2537.0439999997616,
+              "transferSize": 31974,
+              "experimentalFromMainFrame": true,
+              "mimeType": "font/woff",
+              "finished": true,
+              "resourceType": "Font",
+              "networkRequestTime": 2227.0200000004843,
+              "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff"
+            },
+            {
+              "transferSize": 38778,
+              "networkEndTime": 2470.6569999996573,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "priority": "VeryHigh",
+              "rendererStartTime": 2226.2659999998286,
+              "resourceSize": 57572,
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+              "networkRequestTime": 2227.1179999997839,
+              "resourceType": "Font",
+              "finished": true,
+              "mimeType": "font/otf",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "rendererStartTime": 2226.4409999996424,
+              "resourceSize": 58256,
+              "priority": "VeryHigh",
+              "transferSize": 39126,
+              "networkEndTime": 2461.8689999999478,
+              "sessionTargetType": "page",
+              "finished": true,
+              "resourceType": "Font",
+              "experimentalFromMainFrame": true,
+              "mimeType": "font/otf",
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+              "networkRequestTime": 2227.2529999995604
+            },
+            {
+              "transferSize": 11477,
+              "networkEndTime": 2514.2340000001714,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "resourceSize": 10812,
+              "rendererStartTime": 2300.3710000002757,
+              "priority": "Low",
+              "protocol": "h2",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qobra-white.png",
+              "networkRequestTime": 2302.5209999997169,
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png",
+              "networkRequestTime": 2302.6749999998137,
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "transferSize": 11987,
+              "networkEndTime": 2496.0089999996126,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "resourceSize": 11321,
+              "rendererStartTime": 2300.6509999996051,
+              "priority": "Low",
+              "protocol": "h2"
+            },
+            {
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "finished": true,
+              "networkRequestTime": 2302.75,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qare-white.png",
+              "priority": "Low",
+              "resourceSize": 7009,
+              "rendererStartTime": 2300.7749999994412,
+              "protocol": "h2",
+              "entity": "vercel-storage.com",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2555.0070000002161,
+              "transferSize": 7672
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 60332,
+              "networkEndTime": 2570.5550000006333,
+              "protocol": "h2",
+              "priority": "Low",
+              "rendererStartTime": 2300.9780000001192,
+              "resourceSize": 59662,
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png",
+              "networkRequestTime": 2304.0429999995977,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "finished": true,
+              "resourceType": "Image"
+            },
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/citron-white.png",
+              "networkRequestTime": 2304.1549999993294,
+              "finished": true,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "transferSize": 9975,
+              "networkEndTime": 2523.4959999993443,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "protocol": "h2",
+              "resourceSize": 9310,
+              "priority": "Low",
+              "rendererStartTime": 2301.1479999991134
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "finished": true,
+              "resourceType": "Image",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/tomorro-white.png",
+              "networkRequestTime": 2304.4199999999255,
+              "protocol": "h2",
+              "resourceSize": 9049,
+              "priority": "Low",
+              "rendererStartTime": 2301.3020000001416,
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "sessionTargetType": "page",
+              "transferSize": 9715,
+              "networkEndTime": 2565.3199999993667
+            },
+            {
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/wecandoo-white.png",
+              "networkRequestTime": 2304.526999999769,
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "priority": "Low",
+              "rendererStartTime": 2301.43200000003,
+              "resourceSize": 17962,
+              "protocol": "h2",
+              "transferSize": 18630,
+              "networkEndTime": 2530.3590000001714,
+              "sessionTargetType": "page"
+            },
+            {
+              "transferSize": 14019,
+              "networkEndTime": 2527.0970000000671,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "resourceSize": 13354,
+              "rendererStartTime": 2301.5320000005886,
+              "priority": "Low",
+              "protocol": "h2",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png",
+              "networkRequestTime": 2304.5979999992996,
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/resilience-white.png",
+              "networkRequestTime": 2304.6749999998137,
+              "finished": true,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "transferSize": 10974,
+              "networkEndTime": 2520.5970000000671,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "protocol": "h2",
+              "resourceSize": 10304,
+              "priority": "Low",
+              "rendererStartTime": 2301.68200000003
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "finished": true,
+              "resourceType": "Image",
+              "networkRequestTime": 2304.7439999999478,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/steeple-white.png",
+              "protocol": "h2",
+              "rendererStartTime": 2301.80700000003,
+              "resourceSize": 8945,
+              "priority": "Low",
+              "entity": "vercel-storage.com",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2524.0539999995381,
+              "transferSize": 9611
+            },
+            {
+              "networkRequestTime": 2304.8569999998435,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yousign-white.png",
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2614.1959999995306,
+              "transferSize": 29273,
+              "sessionTargetType": "page",
+              "entity": "vercel-storage.com",
+              "statusCode": 200,
+              "rendererStartTime": 2301.9459999995306,
+              "resourceSize": 28606,
+              "priority": "Low",
+              "protocol": "h2"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 2538.1289999997243,
+              "transferSize": 22830,
+              "protocol": "h2",
+              "rendererStartTime": 2302.0970000000671,
+              "priority": "Low",
+              "resourceSize": 22161,
+              "entity": "vercel-storage.com",
+              "statusCode": 200,
+              "networkRequestTime": 2320.839999999851,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "finished": true,
+              "resourceType": "Image"
+            },
+            {
+              "priority": "Low",
+              "resourceSize": 9311,
+              "rendererStartTime": 2302.2979999994859,
+              "protocol": "h2",
+              "entity": "vercel-storage.com",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 2518.589999999851,
+              "transferSize": 9975,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "finished": true,
+              "networkRequestTime": 2321.1979999998584,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qonto-white.png"
+            },
+            {
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vizzia-white.png",
+              "networkRequestTime": 2321.3870000001043,
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "priority": "Low",
+              "resourceSize": 4187,
+              "rendererStartTime": 2302.418000000529,
+              "protocol": "h2",
+              "transferSize": 4852,
+              "networkEndTime": 2531.6670000003651,
+              "sessionTargetType": "page"
+            },
+            {
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vibe-co-white.png",
+              "networkRequestTime": 2321.4980000006035,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "finished": true,
+              "sessionTargetType": "page",
+              "transferSize": 10152,
+              "networkEndTime": 2529.3559999996796,
+              "resourceSize": 9486,
+              "rendererStartTime": 2302.5120000001043,
+              "priority": "Low",
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "vercel-storage.com"
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 5119,
+              "networkEndTime": 2473.25800000038,
+              "resourceSize": 4455,
+              "rendererStartTime": 2302.6189999999478,
+              "priority": "Low",
+              "protocol": "h2",
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/epack-white.png",
+              "networkRequestTime": 2321.5989999994636,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "finished": true
+            },
+            {
+              "networkRequestTime": 2776.6749999998137,
+              "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65c1v9100339653za200zd9100339653&_p=1778779303700&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=956976354.1778779304&frm=0&pscdl=noapi&rcb=5&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115938466~115938468~118167295&dp=%2Ffr&sid=1778779304&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Ffr&dt=Ocobo%20%C2%B7%20Ocobo%20%C2%B7%20RevOps%20%26%20Revenue%20Experience&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=2772",
+              "resourceType": "Fetch",
+              "finished": true,
+              "mimeType": "text/plain",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2786.1270000003278,
+              "transferSize": 796,
+              "sessionTargetType": "page",
+              "entity": "Google Analytics",
+              "statusCode": 204,
+              "resourceSize": 0,
+              "priority": "High",
+              "rendererStartTime": 2772.9830000000075,
+              "protocol": "h2"
+            },
+            {
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "protocol": "h2",
+              "resourceSize": 97992,
+              "rendererStartTime": 2787.313000000082,
+              "priority": "Low",
+              "transferSize": 29955,
+              "networkEndTime": 2918.5810000002384,
+              "sessionTargetType": "page",
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "networkRequestTime": 2789.8159999996424
+            },
+            {
+              "networkRequestTime": 2790.7089999997988,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2882.1529999999329,
+              "transferSize": 28212,
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "priority": "Low",
+              "resourceSize": 78203,
+              "rendererStartTime": 2787.8640000000596,
+              "protocol": "h2"
+            },
+            {
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "protocol": "h2",
+              "rendererStartTime": 2788.3689999999478,
+              "priority": "Low",
+              "resourceSize": 109001,
+              "transferSize": 43638,
+              "networkEndTime": 2906.6839999994263,
+              "sessionTargetType": "page",
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/javascript",
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "networkRequestTime": 2790.8859999999404
+            },
+            {
+              "protocol": "h2",
+              "resourceSize": 72678,
+              "rendererStartTime": 2788.8629999998957,
+              "priority": "Low",
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "transferSize": 27217,
+              "networkEndTime": 2890.0509999999776,
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/javascript",
+              "finished": true,
+              "resourceType": "Script",
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "networkRequestTime": 2790.973000000231
+            },
+            {
+              "transferSize": 2020,
+              "networkEndTime": 2939.9939999999478,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "entity": "GitHub",
+              "rendererStartTime": 2794.4859999995679,
+              "priority": "VeryHigh",
+              "resourceSize": 4371,
+              "protocol": "h2",
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "networkRequestTime": 2796.081999999471,
+              "resourceType": "Stylesheet",
+              "finished": true,
+              "mimeType": "text/css",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 16667,
+              "rendererStartTime": 2797.5219999998808,
+              "priority": "High",
+              "protocol": "h2",
+              "networkEndTime": 3025.4720000000671,
+              "transferSize": 17170,
+              "sessionTargetType": "page",
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2805.2549999998882,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png"
+            },
+            {
+              "priority": "Low",
+              "rendererStartTime": 3042.4210000000894,
+              "resourceSize": 0,
+              "protocol": "h2",
+              "statusCode": 404,
+              "entity": "Clearbit",
+              "sessionTargetType": "page",
+              "transferSize": 640,
+              "networkEndTime": 3231.5040000006557,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "finished": true,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "networkRequestTime": 3043.2800000002608
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 2495,
+              "priority": "Low",
+              "rendererStartTime": 3043.6589999999851,
+              "protocol": "h2",
+              "networkEndTime": 3071.5490000005811,
+              "transferSize": 1864,
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 3044.4040000000969,
+              "url": "https://www.ocobo.co/_vercel/insights/script.js"
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 5310,
+              "networkEndTime": 3066.7369999997318,
+              "protocol": "h2",
+              "resourceSize": 12567,
+              "priority": "Low",
+              "rendererStartTime": 3044.5860000001267,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "networkRequestTime": 3045.269999999553,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceType": "Script"
+            },
+            {
+              "finished": true,
+              "resourceType": "Fetch",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "networkRequestTime": 3047.0219999998808,
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fclients%2C%2Fen%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fclients%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology&version=ba6d9b28",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "protocol": "h2",
+              "resourceSize": 15297,
+              "rendererStartTime": 3046.1969999996945,
+              "priority": "High",
+              "networkEndTime": 3130.9749999996275,
+              "transferSize": 2410,
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "protocol": "h2",
+              "priority": "Low",
+              "resourceSize": 607831,
+              "rendererStartTime": 3059.0419999994338,
+              "networkEndTime": 3115.6709999991581,
+              "transferSize": 204723,
+              "sessionTargetType": "page",
+              "finished": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "networkRequestTime": 3060.1749999998137,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Fetch",
+              "finished": true,
+              "url": "https://www.ocobo.co/_vercel/insights/view",
+              "networkRequestTime": 3121.8019999992102,
+              "resourceSize": 48,
+              "priority": "High",
+              "rendererStartTime": 3114.8310000002384,
+              "protocol": "h2",
+              "statusCode": 202,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "transferSize": 473,
+              "networkEndTime": 3188.9170000003651
+            },
+            {
+              "resourceSize": 135,
+              "rendererStartTime": 3401.938000000082,
+              "priority": "High",
+              "protocol": "h2",
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3474.4079999998212,
+              "transferSize": 1094,
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "resourceType": "XHR",
+              "finished": true,
+              "networkRequestTime": 3405.438000000082,
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk="
+            },
+            {
+              "mimeType": "text/plain",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Fetch",
+              "finished": true,
+              "networkRequestTime": 3426.3919999999925,
+              "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+              "rendererStartTime": 3425.1679999995977,
+              "resourceSize": 5,
+              "priority": "High",
+              "protocol": "h2",
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3445.561999999918,
+              "transferSize": 557
+            },
+            {
+              "networkRequestTime": 3766.9640000006184,
+              "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Ffr&isMobile=true",
+              "finished": true,
+              "resourceType": "Fetch",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "networkEndTime": 3942.5490000005811,
+              "transferSize": 1712,
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "protocol": "h2",
+              "rendererStartTime": 3765.9270000001416,
+              "resourceSize": 61,
+              "priority": "High"
+            },
+            {
+              "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+              "networkRequestTime": 4065.3059999998659,
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "finished": true,
+              "sessionTargetType": "page",
+              "transferSize": 1021,
+              "networkEndTime": 4193.0690000001341,
+              "rendererStartTime": 4064.4329999992624,
+              "resourceSize": 35,
+              "priority": "Low",
+              "protocol": "http/1.1",
+              "statusCode": 200,
+              "entity": "Hubspot"
+            },
+            {
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "priority": "High",
+              "rendererStartTime": 4215.1109999995679,
+              "resourceSize": 9346,
+              "protocol": "http/1.1",
+              "networkEndTime": 4367.3879999993369,
+              "transferSize": 4082,
+              "sessionTargetType": "page",
+              "resourceType": "XHR",
+              "finished": true,
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 4219.4859999995679,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953"
+            },
+            {
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "protocol": "h2",
+              "priority": "Low",
+              "rendererStartTime": 4274.3650000002235,
+              "resourceSize": 45,
+              "transferSize": 1522,
+              "networkEndTime": 4474.9229999994859,
+              "sessionTargetType": "page",
+              "finished": true,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/gif",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr&t=Ocobo+%C2%B7+Ocobo+%C2%B7+RevOps+%26+Revenue+Experience&cts=1778779305782&vi=fe480a240269ed36f0385aa1efc00771&nc=true&u=242475741.fe480a240269ed36f0385aa1efc00771.1778779305768.1778779305768.1778779305768.1&b=242475741.1.1778779305768&cc=15",
+              "networkRequestTime": 4278.3360000001267
+            },
+            {
+              "networkRequestTime": 4407.81799999997,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "networkEndTime": 4457.7779999999329,
+              "transferSize": 1659,
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "statusCode": 304,
+              "priority": "Low",
+              "rendererStartTime": 4398.5999999996275,
+              "resourceSize": 607831,
+              "protocol": "h2"
+            },
+            {
+              "networkEndTime": 4839.4740000003949,
+              "transferSize": 1024,
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "priority": "Low",
+              "resourceSize": 35,
+              "rendererStartTime": 4734.1080000000075,
+              "protocol": "http/1.1",
+              "networkRequestTime": 4748.464999999851,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "statusCode": 200,
+              "entity": "Google Fonts",
+              "priority": "VeryHigh",
+              "resourceSize": 3792,
+              "rendererStartTime": 4779.4169999994338,
+              "protocol": "h2",
+              "transferSize": 1259,
+              "networkEndTime": 4786.5419999994338,
+              "sessionTargetType": "page",
+              "resourceType": "Stylesheet",
+              "finished": true,
+              "mimeType": "text/css",
+              "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+              "networkRequestTime": 4780.6730000004172
+            },
+            {
+              "resourceType": "Font",
+              "finished": true,
+              "mimeType": "font/woff2",
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "networkRequestTime": 4856.8050000006333,
+              "statusCode": 200,
+              "entity": "Google Fonts",
+              "priority": "VeryHigh",
+              "rendererStartTime": 4853.6200000001118,
+              "resourceSize": 50524,
+              "protocol": "h2",
+              "transferSize": 51336,
+              "networkEndTime": 4861.8279999997467,
+              "sessionTargetType": "page"
+            },
+            {
+              "protocol": "h2",
+              "rendererStartTime": 4861.0200000004843,
+              "priority": "VeryHigh",
+              "resourceSize": 50524,
+              "entity": "Google Fonts",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 4868.5789999999106,
+              "transferSize": 51336,
+              "mimeType": "font/woff2",
+              "finished": true,
+              "resourceType": "Font",
+              "networkRequestTime": 4862.4160000002012,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "networkEndTime": 5013.9040000000969,
+              "transferSize": 1020,
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "rendererStartTime": 4891.7190000005066,
+              "resourceSize": 45,
+              "priority": "Low",
+              "protocol": "h2",
+              "networkRequestTime": 4893.1260000001639,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=c67bf936-b265-49c0-9daa-f7cd7a0e6f0b&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr&t=Ocobo+%C2%B7+Ocobo+%C2%B7+RevOps+%26+Revenue+Experience&cts=1778779306401&vi=fe480a240269ed36f0385aa1efc00771&nc=true&u=242475741.fe480a240269ed36f0385aa1efc00771.1778779305768.1778779305768.1778779305768.1&b=242475741.1.1778779305768&cc=15",
+              "resourceType": "Image",
+              "finished": true,
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "finished": true,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+              "networkRequestTime": 4894.186999999918,
+              "priority": "Low",
+              "resourceSize": 35,
+              "rendererStartTime": 4892.0740000000224,
+              "protocol": "http/1.1",
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "transferSize": 1024,
+              "networkEndTime": 5013.6430000001565
+            }
+          ],
+          "debugData": {
+            "type": "debugdata",
+            "networkStartTimeTs": 4953387995,
+            "initiators": [
+              {
+                "lineNumber": 0,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 1727,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 695,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 16793,
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 53414,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 78108,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 78648,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 79197,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 79744,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 80286
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 80830,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 81946,
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 82487,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 83605,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 84145,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 85266,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 85815,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 141,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 261,
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36
+              },
+              {
+                "type": "parser",
+                "columnNumber": 360,
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 460,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 536
+              },
+              {
+                "columnNumber": 602,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 671,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 731,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 795,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 857,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 916,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 985,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1052,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 1119,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 1176,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1238,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 1297
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1361,
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36
+              },
+              {
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 1427
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 1488,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1556,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 1622,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1693,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 1751,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1811,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 1886,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 1947
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2005,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 2069,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2129,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 2188
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 2250,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2311,
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 2374
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2430,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 2498,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2565,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2626,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 2701,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2763,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 2822,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2886,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2946,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 3011,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 3071,
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36
+              },
+              {
+                "columnNumber": 3130,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 3189,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 3259
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 3317
+              },
+              {
+                "columnNumber": 3378,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 3445,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 3518
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 3582,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 3645,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 141
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 141
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 141
+              },
+              {
+                "type": "parser",
+                "columnNumber": 141,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 141,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 141,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 141,
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36
+              },
+              {
+                "columnNumber": 141,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 141,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 141,
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 141
+              },
+              {
+                "columnNumber": 141,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 141,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 141
+              },
+              {
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 141
+              },
+              {
+                "columnNumber": 141,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 9994,
+                "type": "parser",
+                "lineNumber": 183,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                "type": "parser"
+              },
+              {
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                "type": "parser"
+              }
+            ]
+          },
+          "type": "table"
+        }
+      },
+      "cache-insight": {
+        "id": "cache-insight",
+        "title": "Use efficient cache lifetimes",
+        "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more about caching](https://developer.chrome.com/docs/performance/insights/cache).",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 319 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 326681.25,
+            "type": "debugdata"
+          },
+          "skipSumming": [
+            "cacheLifetimeMs"
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "label": "Request",
+              "valueType": "url"
+            },
+            {
+              "key": "cacheLifetimeMs",
+              "label": "Cache TTL",
+              "displayUnit": "duration",
+              "valueType": "ms"
+            },
+            {
+              "granularity": 1,
+              "displayUnit": "kb",
+              "label": "Transfer Size",
+              "key": "totalBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [
+            {
+              "totalBytes": 204723,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedBytes": 196192.875,
+              "cacheLifetimeMs": 300000
+            },
+            {
+              "totalBytes": 43638,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 41819.75
+            },
+            {
+              "totalBytes": 29955,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "wastedBytes": 27458.75,
+              "cacheLifetimeMs": 600000
+            },
+            {
+              "wastedBytes": 27036.5,
+              "cacheLifetimeMs": 300000,
+              "totalBytes": 28212,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "totalBytes": 27217,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 26082.958333333336
+            },
+            {
+              "wastedBytes": 4600.75,
+              "cacheLifetimeMs": 600000,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "totalBytes": 5019
+            },
+            {
+              "cacheLifetimeMs": 600000,
+              "wastedBytes": 1851.6666666666665,
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "totalBytes": 2020
+            },
+            {
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "totalBytes": 1638,
+              "cacheLifetimeMs": 0,
+              "wastedBytes": 1638
+            }
+          ]
+        }
+      },
+      "interactive": {
+        "id": "interactive",
+        "title": "Time to Interactive",
+        "description": "Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).",
+        "score": 0.19,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "11.4 s",
+        "numericValue": 11369.27909560467,
+        "numericUnit": "millisecond"
+      },
+      "redirects": {
+        "id": "redirects",
+        "title": "Avoid multiple page redirects",
+        "description": "Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://developer.chrome.com/docs/lighthouse/performance/redirects/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 760 ms",
+        "metricSavings": {
+          "LCP": 750,
+          "FCP": 750
+        },
+        "details": {
+          "items": [
+            {
+              "url": "https://www.ocobo.co/",
+              "wastedMs": 757.03858914804323
+            },
+            {
+              "url": "https://www.ocobo.co/fr",
+              "wastedMs": 0
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "label": "URL",
+              "valueType": "url"
+            },
+            {
+              "key": "wastedMs",
+              "valueType": "timespanMs",
+              "label": "Time Spent"
+            }
+          ],
+          "overallSavingsMs": 757.03858914804323,
+          "type": "opportunity"
+        },
+        "numericValue": 757.03858914804323,
+        "numericUnit": "millisecond"
+      }
+    },
+    "categories": {
+      "performance": {
+        "id": "performance",
+        "title": "Performance",
+        "score": 0.49,
+        "auditRefs": [
+          {
+            "id": "first-contentful-paint",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "FCP"
+          },
+          {
+            "id": "largest-contentful-paint",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "LCP"
+          },
+          {
+            "id": "total-blocking-time",
+            "weight": 30,
+            "group": "metrics",
+            "acronym": "TBT"
+          },
+          {
+            "id": "cumulative-layout-shift",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "CLS"
+          },
+          {
+            "id": "speed-index",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "SI"
+          },
+          {
+            "id": "cache-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "cls-culprits-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "document-latency-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "dom-size-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "duplicated-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "font-display-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "forced-reflow-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "image-delivery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "inp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-discovery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "legacy-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "network-dependency-tree-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "render-blocking-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "third-parties-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "viewport-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "interactive",
+            "weight": 0,
+            "group": "hidden",
+            "acronym": "TTI"
+          },
+          {
+            "id": "max-potential-fid",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "unminified-css",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unminified-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-css-rules",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "total-byte-weight",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "user-timings",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "bootup-time",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "mainthread-work-breakdown",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "long-tasks",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "non-composited-animations",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unsized-images",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "network-requests",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-rtt",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-server-latency",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "main-thread-tasks",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "diagnostics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "metrics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "screenshot-thumbnails",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "final-screenshot",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "script-treemap-data",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "resource-summary",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "redirects",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "server-response-time",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "layout-shifts",
+            "weight": 0,
+            "group": "hidden"
+          }
+        ]
+      }
+    },
+    "categoryGroups": {
+      "a11y-names-labels": {
+        "title": "Names and labels",
+        "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "metrics": {
+        "title": "Metrics"
+      },
+      "seo-crawl": {
+        "title": "Crawling and Indexing",
+        "description": "To appear in search results, crawlers need access to your app."
+      },
+      "a11y-language": {
+        "title": "Internationalization and localization",
+        "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      },
+      "a11y-aria": {
+        "title": "ARIA",
+        "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "a11y-tables-lists": {
+        "title": "Tables and lists",
+        "description": "These are opportunities to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+      },
+      "best-practices-browser-compat": {
+        "title": "Browser Compatibility"
+      },
+      "a11y-navigation": {
+        "title": "Navigation",
+        "description": "These are opportunities to improve keyboard navigation in your application."
+      },
+      "insights": {
+        "title": "Insights",
+        "description": "These insights are also available in the Chrome DevTools Performance Panel - [record a trace](https://developer.chrome.com/docs/devtools/performance/reference) to view more detailed information."
+      },
+      "a11y-best-practices": {
+        "title": "Best practices",
+        "description": "These items highlight common accessibility best practices."
+      },
+      "seo-content": {
+        "title": "Content Best Practices",
+        "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+      },
+      "seo-mobile": {
+        "title": "Mobile Friendly",
+        "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn how to make pages mobile-friendly](https://developers.google.com/search/mobile-sites/)."
+      },
+      "a11y-color-contrast": {
+        "title": "Contrast",
+        "description": "These are opportunities to improve the legibility of your content."
+      },
+      "a11y-audio-video": {
+        "title": "Audio and video",
+        "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+      },
+      "best-practices-trust-safety": {
+        "title": "Trust and Safety"
+      },
+      "best-practices-ux": {
+        "title": "User Experience"
+      },
+      "best-practices-general": {
+        "title": "General"
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "description": "More information about the performance of your application. These numbers don't [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score."
+      }
+    },
+    "timing": {
+      "total": 25817.6
+    },
+    "i18n": {
+      "rendererFormattedStrings": {
+        "varianceDisclaimer": "Values are estimated and may vary. The [performance score is calculated](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) directly from these metrics.",
+        "opportunityResourceColumnLabel": "Opportunity",
+        "opportunitySavingsColumnLabel": "Estimated Savings",
+        "errorMissingAuditInfo": "Report error: no audit information",
+        "errorLabel": "Error!",
+        "warningHeader": "Warnings: ",
+        "passedAuditsGroupTitle": "Passed audits",
+        "notApplicableAuditsGroupTitle": "Not applicable",
+        "manualAuditsGroupTitle": "Additional items to manually check",
+        "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+        "crcLongestDurationLabel": "Maximum critical path latency:",
+        "crcInitialNavigation": "Initial Navigation",
+        "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+        "labDataTitle": "Lab Data",
+        "warningAuditsGroupTitle": "Passed audits but with warnings",
+        "snippetExpandButtonLabel": "Expand snippet",
+        "snippetCollapseButtonLabel": "Collapse snippet",
+        "thirdPartyResourcesLabel": "Show 3rd-party resources",
+        "runtimeDesktopEmulation": "Emulated Desktop",
+        "runtimeMobileEmulation": "Emulated Moto G Power",
+        "runtimeNoEmulation": "No emulation",
+        "runtimeSettingsBenchmark": "Unthrottled CPU/Memory Power",
+        "runtimeSettingsCPUThrottling": "CPU throttling",
+        "runtimeSettingsDevice": "Device",
+        "runtimeSettingsNetworkThrottling": "Network throttling",
+        "runtimeSettingsUANetwork": "User agent (network)",
+        "runtimeUnknown": "Unknown",
+        "dropdownCopyJSON": "Copy JSON",
+        "dropdownDarkTheme": "Toggle Dark Theme",
+        "dropdownPrintExpanded": "Print Expanded",
+        "dropdownPrintSummary": "Print Summary",
+        "dropdownSaveGist": "Save as Gist",
+        "dropdownSaveHTML": "Save as HTML",
+        "dropdownSaveJSON": "Save as JSON",
+        "dropdownViewer": "Open in Viewer",
+        "footerIssue": "File an issue",
+        "throttlingProvided": "Provided by environment",
+        "calculatorLink": "See calculator.",
+        "runtimeSettingsAxeVersion": "Axe version",
+        "viewTreemapLabel": "View Treemap",
+        "showRelevantAudits": "Show audits relevant to:"
+      }
+    },
+    "entities": [
+      {
+        "name": "ocobo.co",
+        "isFirstParty": true,
+        "isUnrecognized": true,
+        "origins": [
+          "https://www.ocobo.co"
+        ]
+      },
+      {
+        "name": "vercel-storage.com",
+        "isUnrecognized": true,
+        "origins": [
+          "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+        ]
+      },
+      {
+        "name": "Google Tag Manager",
+        "homepage": "https://marketingplatform.google.com/about/tag-manager/",
+        "category": "tag-manager",
+        "origins": [
+          "https://www.googletagmanager.com"
+        ]
+      },
+      {
+        "name": "Clearbit",
+        "homepage": "https://clearbit.com/",
+        "category": "analytics",
+        "origins": [
+          "https://tag.clearbitscripts.com"
+        ]
+      },
+      {
+        "name": "Hubspot",
+        "homepage": "https://hubspot.com/",
+        "category": "marketing",
+        "origins": [
+          "https://js-eu1.hs-scripts.com",
+          "https://js-eu1.hubspot.com",
+          "https://js-eu1.hscollectedforms.net",
+          "https://js-eu1.hs-analytics.net",
+          "https://js-eu1.hs-banner.com",
+          "https://js-eu1.hsforms.net",
+          "https://forms-eu1.hscollectedforms.net",
+          "https://cta-eu1.hubspot.com",
+          "https://perf-eu1.hsforms.com",
+          "https://forms-eu1.hsforms.com",
+          "https://track-eu1.hubspot.com"
+        ]
+      },
+      {
+        "name": "GitHub",
+        "category": "utility",
+        "origins": [
+          "https://useago.github.io"
+        ]
+      },
+      {
+        "name": "Google Analytics",
+        "homepage": "https://marketingplatform.google.com/about/analytics/",
+        "category": "analytics",
+        "origins": [
+          "https://www.google-analytics.com"
+        ]
+      },
+      {
+        "name": "Google Fonts",
+        "homepage": "https://fonts.google.com/",
+        "category": "cdn",
+        "origins": [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com"
+        ]
+      }
+    ],
+    "fullPageScreenshot": {
+      "nodes": {
+        "1-64-IMG": {
+          "right": 0,
+          "top": 0,
+          "width": 0,
+          "height": 0,
+          "left": 0,
+          "bottom": 0
+        },
+        "page-9-IMG": {
+          "bottom": 1498,
+          "left": 4952,
+          "height": 32,
+          "width": 81,
+          "top": 1466,
+          "right": 5033
+        },
+        "page-1-IMG": {
+          "top": 1466,
+          "right": 5574,
+          "height": 32,
+          "width": 134,
+          "left": 5440,
+          "bottom": 1498
+        },
+        "page-45-IMG": {
+          "left": 3597,
+          "bottom": 1498,
+          "top": 1466,
+          "right": 3698,
+          "height": 32,
+          "width": 101
+        },
+        "page-0-IMG": {
+          "width": 59,
+          "height": 59,
+          "right": 106,
+          "top": 1880,
+          "bottom": 1939,
+          "left": 48
+        },
+        "1-44-IMG": {
+          "top": 1466,
+          "right": 6784,
+          "height": 32,
+          "width": 96,
+          "left": 6688,
+          "bottom": 1498
+        },
+        "page-22-BODY": {
+          "left": 0,
+          "bottom": 12931,
+          "top": 0,
+          "right": 412,
+          "height": 12931,
+          "width": 412
+        },
+        "page-60-DIV": {
+          "left": 0,
+          "id": "ago-prompt",
+          "bottom": 12851,
+          "right": 401,
+          "top": 12726,
+          "width": 401,
+          "height": 125
+        },
+        "page-64-g": {
+          "width": 82,
+          "height": 133,
+          "right": 225,
+          "top": 908,
+          "bottom": 1041,
+          "left": 143
+        },
+        "1-23-IMG": {
+          "left": 3100,
+          "bottom": 1498,
+          "top": 1466,
+          "right": 3196,
+          "height": 32,
+          "width": 96
+        },
+        "1-49-IMG": {
+          "width": 43,
+          "height": 32,
+          "right": 7601,
+          "top": 1466,
+          "bottom": 1498,
+          "left": 7559
+        },
+        "page-15-IMG": {
+          "left": 6508,
+          "bottom": 1498,
+          "right": 6609,
+          "top": 1466,
+          "width": 101,
+          "height": 32
+        },
+        "1-39-IMG": {
+          "right": 5926,
+          "top": 1466,
+          "width": 96,
+          "height": 32,
+          "left": 5830,
+          "bottom": 1498
+        },
+        "1-38-IMG": {
+          "bottom": 1498,
+          "left": 5654,
+          "width": 96,
+          "height": 32,
+          "right": 5750,
+          "top": 1466
+        },
+        "1-54-IMG": {
+          "left": 329,
+          "bottom": 10746,
+          "right": 353,
+          "top": 10722,
+          "width": 24,
+          "height": 24
+        },
+        "page-61-g": {
+          "bottom": 928,
+          "left": 238,
+          "height": 146,
+          "width": 114,
+          "top": 782,
+          "right": 352
+        },
+        "1-2-IMG": {
+          "width": 81,
+          "height": 32,
+          "right": -427,
+          "top": 1466,
+          "bottom": 1498,
+          "left": -508
+        },
+        "page-54-IMG": {
+          "bottom": 1498,
+          "left": 2711,
+          "height": 32,
+          "width": 134,
+          "top": 1466,
+          "right": 2844
+        },
+        "page-51-IMG": {
+          "left": 7206,
+          "bottom": 1498,
+          "right": 7300,
+          "top": 1466,
+          "width": 94,
+          "height": 32
+        },
+        "page-5-IMG": {
+          "left": 359,
+          "bottom": 12900,
+          "id": "open-path",
+          "top": 12868,
+          "right": 389,
+          "height": 32,
+          "width": 30
+        },
+        "1-16-IMG": {
+          "bottom": 1498,
+          "left": 1920,
+          "width": 99,
+          "height": 32,
+          "right": 2019,
+          "top": 1466
+        },
+        "1-30-IMG": {
+          "right": 4396,
+          "top": 1466,
+          "width": 101,
+          "height": 32,
+          "left": 4295,
+          "bottom": 1498
+        },
+        "page-3-IMG": {
+          "left": 6865,
+          "bottom": 1498,
+          "right": 6946,
+          "top": 1466,
+          "width": 81,
+          "height": 32
+        },
+        "1-4-IMG": {
+          "height": 32,
+          "width": 78,
+          "top": 1466,
+          "right": -100,
+          "bottom": 1498,
+          "left": -178
+        },
+        "page-18-DIV": {
+          "right": 396,
+          "top": 720,
+          "width": 380,
+          "height": 380,
+          "left": 16,
+          "bottom": 1100
+        },
+        "1-42-IMG": {
+          "left": 6327,
+          "bottom": 1498,
+          "right": 6427,
+          "top": 1466,
+          "width": 101,
+          "height": 32
+        },
+        "page-17-H1": {
+          "width": 380,
+          "height": 182,
+          "right": 396,
+          "top": 128,
+          "bottom": 310,
+          "left": 16
+        },
+        "page-50-IMG": {
+          "right": 4749,
+          "top": 1466,
+          "width": 99,
+          "height": 32,
+          "left": 4650,
+          "bottom": 1498
+        },
+        "1-33-IMG": {
+          "bottom": 1498,
+          "left": 4829,
+          "height": 32,
+          "width": 43,
+          "top": 1466,
+          "right": 4872
+        },
+        "1-65-IMG": {
+          "height": 0,
+          "width": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "1-52-IMG": {
+          "width": 24,
+          "height": 24,
+          "right": 173,
+          "top": 10722,
+          "bottom": 10746,
+          "left": 149
+        },
+        "page-16-IMG": {
+          "bottom": 1498,
+          "left": 5283,
+          "width": 78,
+          "height": 32,
+          "right": 5360,
+          "top": 1466
+        },
+        "page-10-IMG": {
+          "left": 7380,
+          "bottom": 1498,
+          "top": 1466,
+          "right": 7479,
+          "height": 32,
+          "width": 99
+        },
+        "1-58-IMG": {
+          "left": 59,
+          "bottom": 10926,
+          "right": 83,
+          "top": 10902,
+          "width": 24,
+          "height": 24
+        },
+        "page-29-IMG": {
+          "left": -508,
+          "bottom": 1498,
+          "top": 1466,
+          "right": -427,
+          "height": 32,
+          "width": 81
+        },
+        "1-47-IMG": {
+          "height": 32,
+          "width": 94,
+          "top": 1466,
+          "right": 7300,
+          "bottom": 1498,
+          "left": 7206
+        },
+        "page-67-g": {
+          "left": 48,
+          "bottom": 890,
+          "right": 225,
+          "top": 776,
+          "width": 177,
+          "height": 114
+        },
+        "1-11-IMG": {
+          "top": 1466,
+          "right": 1149,
+          "height": 32,
+          "width": 101,
+          "left": 1048,
+          "bottom": 1498
+        },
+        "page-47-IMG": {
+          "top": 1466,
+          "right": 4216,
+          "height": 32,
+          "width": 81,
+          "left": 4135,
+          "bottom": 1498
+        },
+        "1-41-IMG": {
+          "bottom": 1498,
+          "left": 6148,
+          "height": 32,
+          "width": 99,
+          "top": 1466,
+          "right": 6247
+        },
+        "page-19-SPAN": {
+          "left": 16,
+          "bottom": 321,
+          "right": 291,
+          "top": 208,
+          "width": 275,
+          "height": 113
+        },
+        "page-11-IMG": {
+          "left": 6327,
+          "bottom": 1498,
+          "right": 6428,
+          "top": 1466,
+          "width": 101,
+          "height": 32
+        },
+        "1-5-IMG": {
+          "bottom": 1498,
+          "left": -20,
+          "width": 134,
+          "height": 32,
+          "right": 114,
+          "top": 1466
+        },
+        "page-2-IMG": {
+          "left": 6689,
+          "bottom": 1498,
+          "top": 1466,
+          "right": 6785,
+          "height": 32,
+          "width": 96
+        },
+        "page-28-IMG": {
+          "top": 1466,
+          "right": 7602,
+          "height": 32,
+          "width": 43,
+          "left": 7559,
+          "bottom": 1498
+        },
+        "1-26-IMG": {
+          "top": 1466,
+          "right": 3698,
+          "height": 32,
+          "width": 101,
+          "left": 3597,
+          "bottom": 1498
+        },
+        "1-60-IMG": {
+          "bottom": 10926,
+          "left": 329,
+          "width": 24,
+          "height": 24,
+          "right": 353,
+          "top": 10902
+        },
+        "page-4-IMG": {
+          "width": 62,
+          "height": 32,
+          "right": 6068,
+          "top": 1466,
+          "bottom": 1498,
+          "left": 6006
+        },
+        "page-12-IMG": {
+          "left": 5654,
+          "bottom": 1498,
+          "top": 1466,
+          "right": 5750,
+          "height": 32,
+          "width": 96
+        },
+        "1-8-IMG": {
+          "bottom": 1498,
+          "left": 546,
+          "width": 62,
+          "height": 32,
+          "right": 608,
+          "top": 1466
+        },
+        "page-40-IMG": {
+          "left": 2222,
+          "bottom": 1498,
+          "top": 1466,
+          "right": 2303,
+          "height": 32,
+          "width": 81
+        },
+        "1-59-IMG": {
+          "height": 24,
+          "width": 24,
+          "top": 10902,
+          "right": 263,
+          "bottom": 10926,
+          "left": 239
+        },
+        "page-63-g": {
+          "left": 48,
+          "bottom": 1046,
+          "top": 913,
+          "right": 130,
+          "height": 133,
+          "width": 82
+        },
+        "page-26-IMG": {
+          "left": 2383,
+          "bottom": 1498,
+          "right": 2473,
+          "top": 1466,
+          "width": 90,
+          "height": 32
+        },
+        "1-36-IMG": {
+          "left": 5282,
+          "bottom": 1498,
+          "right": 5360,
+          "top": 1466,
+          "width": 78,
+          "height": 32
+        },
+        "page-48-IMG": {
+          "left": 4296,
+          "bottom": 1498,
+          "right": 4397,
+          "top": 1466,
+          "width": 101,
+          "height": 32
+        },
+        "1-45-IMG": {
+          "left": 6864,
+          "bottom": 1498,
+          "right": 6945,
+          "top": 1466,
+          "width": 81,
+          "height": 32
+        },
+        "page-65-P": {
+          "width": 380,
+          "height": 98,
+          "right": 396,
+          "top": 350,
+          "bottom": 448,
+          "left": 16
+        },
+        "page-37-IMG": {
+          "right": 1667,
+          "top": 1466,
+          "width": 101,
+          "height": 32,
+          "left": 1566,
+          "bottom": 1498
+        },
+        "1-63-IMG": {
+          "top": 12868,
+          "right": 389,
+          "height": 32,
+          "width": 30,
+          "left": 359,
+          "bottom": 12900,
+          "id": "open-path"
+        },
+        "page-62-DIV": {
+          "width": 380,
+          "height": 57,
+          "right": 396,
+          "top": 488,
+          "bottom": 545,
+          "left": 16
+        },
+        "page-66-DIV": {
+          "bottom": 1498,
+          "left": -548,
+          "height": 32,
+          "width": 8189,
+          "top": 1466,
+          "right": 7642
+        },
+        "page-25-IMG": {
+          "bottom": 1498,
+          "left": 2100,
+          "width": 43,
+          "height": 32,
+          "right": 2142,
+          "top": 1466
+        },
+        "1-13-IMG": {
+          "bottom": 1498,
+          "left": 1405,
+          "width": 81,
+          "height": 32,
+          "right": 1486,
+          "top": 1466
+        },
+        "page-52-IMG": {
+          "width": 134,
+          "height": 32,
+          "right": 115,
+          "top": 1466,
+          "bottom": 1498,
+          "left": -19
+        },
+        "1-31-IMG": {
+          "height": 32,
+          "width": 94,
+          "top": 1466,
+          "right": 4570,
+          "bottom": 1498,
+          "left": 4476
+        },
+        "1-1-IMG": {
+          "height": 0,
+          "width": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "page-32-IMG": {
+          "bottom": 1498,
+          "left": 547,
+          "height": 32,
+          "width": 62,
+          "top": 1466,
+          "right": 609
+        },
+        "page-23-rect": {
+          "right": 197,
+          "top": 823,
+          "width": 127,
+          "height": 4,
+          "left": 70,
+          "bottom": 827
+        },
+        "page-56-IMG": {
+          "width": 96,
+          "height": 32,
+          "right": 1325,
+          "top": 1466,
+          "bottom": 1498,
+          "left": 1229
+        },
+        "page-21-META": {
+          "left": 0,
+          "bottom": 0,
+          "top": 0,
+          "right": 0,
+          "height": 0,
+          "width": 0
+        },
+        "1-34-IMG": {
+          "height": 32,
+          "width": 81,
+          "top": 1466,
+          "right": 5033,
+          "bottom": 1498,
+          "left": 4952
+        },
+        "page-36-IMG": {
+          "bottom": 1498,
+          "left": 1405,
+          "height": 32,
+          "width": 81,
+          "top": 1466,
+          "right": 1486
+        },
+        "page-39-IMG": {
+          "right": 2020,
+          "top": 1466,
+          "width": 99,
+          "height": 32,
+          "left": 1921,
+          "bottom": 1498
+        },
+        "1-61-IMG": {
+          "bottom": 11016,
+          "left": 149,
+          "width": 24,
+          "height": 24,
+          "right": 173,
+          "top": 10992
+        },
+        "1-29-IMG": {
+          "left": 4134,
+          "bottom": 1498,
+          "right": 4215,
+          "top": 1466,
+          "width": 81,
+          "height": 32
+        },
+        "page-20-LINK": {
+          "bottom": 0,
+          "left": 0,
+          "height": 0,
+          "width": 0,
+          "top": 0,
+          "right": 0
+        },
+        "page-38-IMG": {
+          "right": 1841,
+          "top": 1466,
+          "width": 94,
+          "height": 32,
+          "left": 1747,
+          "bottom": 1498
+        },
+        "page-58-BUTTON": {
+          "left": 386,
+          "bottom": 12767,
+          "id": "ago-prompt-close",
+          "top": 12741,
+          "right": 406,
+          "height": 26,
+          "width": 20
+        },
+        "1-50-IMG": {
+          "bottom": 1939,
+          "left": 48,
+          "height": 59,
+          "width": 59,
+          "top": 1880,
+          "right": 106
+        },
+        "page-46-IMG": {
+          "right": 3879,
+          "top": 1466,
+          "width": 101,
+          "height": 32,
+          "left": 3778,
+          "bottom": 1498
+        },
+        "1-15-IMG": {
+          "left": 1746,
+          "bottom": 1498,
+          "right": 1840,
+          "top": 1466,
+          "width": 94,
+          "height": 32
+        },
+        "1-7-IMG": {
+          "top": 1466,
+          "right": 466,
+          "height": 32,
+          "width": 96,
+          "left": 370,
+          "bottom": 1498
+        },
+        "1-3-IMG": {
+          "top": 1466,
+          "right": -258,
+          "height": 32,
+          "width": 90,
+          "left": -347,
+          "bottom": 1498
+        },
+        "page-41-IMG": {
+          "top": 1466,
+          "right": 2631,
+          "height": 32,
+          "width": 78,
+          "left": 2553,
+          "bottom": 1498
+        },
+        "1-19-IMG": {
+          "top": 1466,
+          "right": 2472,
+          "height": 32,
+          "width": 90,
+          "left": 2383,
+          "bottom": 1498
+        },
+        "1-21-IMG": {
+          "width": 134,
+          "height": 32,
+          "right": 2844,
+          "top": 1466,
+          "bottom": 1498,
+          "left": 2710
+        },
+        "1-10-IMG": {
+          "bottom": 1498,
+          "left": 867,
+          "width": 101,
+          "height": 32,
+          "right": 968,
+          "top": 1466
+        },
+        "page-33-IMG": {
+          "height": 32,
+          "width": 99,
+          "top": 1466,
+          "right": 788,
+          "bottom": 1498,
+          "left": 689
+        },
+        "page-43-IMG": {
+          "width": 62,
+          "height": 32,
+          "right": 3339,
+          "top": 1466,
+          "bottom": 1498,
+          "left": 3276
+        },
+        "1-46-IMG": {
+          "height": 32,
+          "width": 101,
+          "top": 1466,
+          "right": 7126,
+          "bottom": 1498,
+          "left": 7025
+        },
+        "page-42-IMG": {
+          "top": 1466,
+          "right": 3020,
+          "height": 32,
+          "width": 96,
+          "left": 2924,
+          "bottom": 1498
+        },
+        "page-59-g": {
+          "bottom": 1033,
+          "left": 238,
+          "height": 95,
+          "width": 114,
+          "top": 938,
+          "right": 352
+        },
+        "1-9-IMG": {
+          "left": 688,
+          "bottom": 1498,
+          "right": 787,
+          "top": 1466,
+          "width": 99,
+          "height": 32
+        },
+        "1-48-IMG": {
+          "width": 99,
+          "height": 32,
+          "right": 7479,
+          "top": 1466,
+          "bottom": 1498,
+          "left": 7380
+        },
+        "page-57-IMG": {
+          "top": 1466,
+          "right": 4055,
+          "height": 32,
+          "width": 96,
+          "left": 3959,
+          "bottom": 1498
+        },
+        "page-31-IMG": {
+          "bottom": 1498,
+          "left": 195,
+          "height": 32,
+          "width": 96,
+          "top": 1466,
+          "right": 291
+        },
+        "1-51-IMG": {
+          "right": 83,
+          "top": 10722,
+          "width": 24,
+          "height": 24,
+          "left": 59,
+          "bottom": 10746
+        },
+        "page-35-IMG": {
+          "bottom": 1498,
+          "left": 1048,
+          "height": 32,
+          "width": 101,
+          "top": 1466,
+          "right": 1149
+        },
+        "1-62-IMG": {
+          "left": 239,
+          "bottom": 11016,
+          "top": 10992,
+          "right": 263,
+          "height": 24,
+          "width": 24
+        },
+        "1-20-IMG": {
+          "left": 2552,
+          "bottom": 1498,
+          "right": 2630,
+          "top": 1466,
+          "width": 78,
+          "height": 32
+        },
+        "page-6-IMG": {
+          "top": 1466,
+          "right": 6247,
+          "height": 32,
+          "width": 99,
+          "left": 6148,
+          "bottom": 1498
+        },
+        "1-17-IMG": {
+          "bottom": 1498,
+          "left": 2099,
+          "width": 43,
+          "height": 32,
+          "right": 2142,
+          "top": 1466
+        },
+        "1-40-IMG": {
+          "left": 6006,
+          "bottom": 1498,
+          "right": 6068,
+          "top": 1466,
+          "width": 62,
+          "height": 32
+        },
+        "1-6-IMG": {
+          "right": 290,
+          "top": 1466,
+          "width": 96,
+          "height": 32,
+          "left": 194,
+          "bottom": 1498
+        },
+        "page-68-DIV": {
+          "bottom": 656,
+          "left": 16,
+          "height": 55,
+          "width": 380,
+          "top": 601,
+          "right": 396
+        },
+        "1-43-IMG": {
+          "left": 6507,
+          "bottom": 1498,
+          "right": 6608,
+          "top": 1466,
+          "width": 101,
+          "height": 32
+        },
+        "page-27-IMG": {
+          "width": 43,
+          "height": 32,
+          "right": 4872,
+          "top": 1466,
+          "bottom": 1498,
+          "left": 4829
+        },
+        "1-14-IMG": {
+          "right": 1666,
+          "top": 1466,
+          "width": 101,
+          "height": 32,
+          "left": 1566,
+          "bottom": 1498
+        },
+        "1-22-IMG": {
+          "left": 2924,
+          "bottom": 1498,
+          "right": 3020,
+          "top": 1466,
+          "width": 96,
+          "height": 32
+        },
+        "1-37-IMG": {
+          "bottom": 1498,
+          "left": 5440,
+          "height": 32,
+          "width": 134,
+          "top": 1466,
+          "right": 5574
+        },
+        "1-55-IMG": {
+          "top": 10812,
+          "right": 83,
+          "height": 24,
+          "width": 24,
+          "left": 59,
+          "bottom": 10836
+        },
+        "page-14-IMG": {
+          "height": 32,
+          "width": 96,
+          "top": 1466,
+          "right": 5926,
+          "bottom": 1498,
+          "left": 5830
+        },
+        "page-55-IMG": {
+          "width": 96,
+          "height": 32,
+          "right": 3196,
+          "top": 1466,
+          "bottom": 1498,
+          "left": 3100
+        },
+        "page-24-IMG": {
+          "bottom": 1498,
+          "left": -347,
+          "height": 32,
+          "width": 90,
+          "top": 1466,
+          "right": -257
+        },
+        "1-53-IMG": {
+          "width": 24,
+          "height": 24,
+          "right": 263,
+          "top": 10722,
+          "bottom": 10746,
+          "left": 239
+        },
+        "1-0-IMG": {
+          "top": 37,
+          "right": 167,
+          "height": 40,
+          "width": 134,
+          "left": 33,
+          "bottom": 77
+        },
+        "1-27-IMG": {
+          "left": 3778,
+          "bottom": 1498,
+          "top": 1466,
+          "right": 3878,
+          "height": 32,
+          "width": 101
+        },
+        "1-18-IMG": {
+          "bottom": 1498,
+          "left": 2222,
+          "height": 32,
+          "width": 81,
+          "top": 1466,
+          "right": 2303
+        },
+        "page-8-IMG": {
+          "top": 37,
+          "right": 167,
+          "height": 40,
+          "width": 134,
+          "left": 33,
+          "bottom": 77
+        },
+        "page-44-IMG": {
+          "width": 99,
+          "height": 32,
+          "right": 3517,
+          "top": 1466,
+          "bottom": 1498,
+          "left": 3419
+        },
+        "page-34-IMG": {
+          "right": 968,
+          "top": 1466,
+          "width": 101,
+          "height": 32,
+          "left": 868,
+          "bottom": 1498
+        },
+        "1-25-IMG": {
+          "bottom": 1498,
+          "left": 3418,
+          "width": 99,
+          "height": 32,
+          "right": 3517,
+          "top": 1466
+        },
+        "page-30-IMG": {
+          "right": -99,
+          "top": 1466,
+          "width": 78,
+          "height": 32,
+          "left": -177,
+          "bottom": 1498
+        },
+        "page-53-IMG": {
+          "left": 371,
+          "bottom": 1498,
+          "top": 1466,
+          "right": 467,
+          "height": 32,
+          "width": 96
+        },
+        "1-32-IMG": {
+          "left": 4650,
+          "bottom": 1498,
+          "right": 4749,
+          "top": 1466,
+          "width": 99,
+          "height": 32
+        },
+        "1-35-IMG": {
+          "left": 5113,
+          "bottom": 1498,
+          "top": 1466,
+          "right": 5202,
+          "height": 32,
+          "width": 90
+        },
+        "page-7-IMG": {
+          "right": 5203,
+          "top": 1466,
+          "width": 90,
+          "height": 32,
+          "left": 5113,
+          "bottom": 1498
+        },
+        "1-24-IMG": {
+          "bottom": 1498,
+          "left": 3276,
+          "height": 32,
+          "width": 62,
+          "top": 1466,
+          "right": 3338
+        },
+        "page-49-IMG": {
+          "height": 32,
+          "width": 94,
+          "top": 1466,
+          "right": 4570,
+          "bottom": 1498,
+          "left": 4477
+        },
+        "page-13-IMG": {
+          "height": 32,
+          "width": 101,
+          "top": 1466,
+          "right": 7126,
+          "bottom": 1498,
+          "left": 7026
+        },
+        "1-57-IMG": {
+          "width": 24,
+          "height": 24,
+          "right": 353,
+          "top": 10812,
+          "bottom": 10836,
+          "left": 329
+        },
+        "1-12-IMG": {
+          "bottom": 1498,
+          "left": 1229,
+          "height": 32,
+          "width": 96,
+          "top": 1466,
+          "right": 1325
+        },
+        "1-56-IMG": {
+          "left": 149,
+          "bottom": 10836,
+          "right": 173,
+          "top": 10812,
+          "width": 24,
+          "height": 24
+        },
+        "1-28-IMG": {
+          "width": 96,
+          "height": 32,
+          "right": 4054,
+          "top": 1466,
+          "bottom": 1498,
+          "left": 3958
+        }
+      },
+      "screenshot": {
+        "width": 412,
+        "data": "data:image/webp;base64,UklGRswvAgBXRUJQVlA4WAoAAAAgAAAAmwEAizEASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZWUDgg3i0CAJAyDZ0BKpwBjDE/EYi8WCwpNC8iMmnagCIJaW78PYudt89DoAsIFnG+v0n6Abbt5ueUrH/1H+x3bfA80PkV8f5HXuvfM/7P6z+9b+1eoN47n7Se+7+++gD9y/1393f0pf3r0zPTA9Vv/Bepb5zfrA/530vdR6+O/0v/Mf23/Nf8r4BfMf2r/V/37/Vf9b/L/ux7i/mX1r++/wv7zewx/3f7Lxa+tf4H/1/3fqt/PfyH/V/xn7//FX+R/7H+Q/1/6++i/yy/8P9V7Av6V/W/v/+GD67/1f5n/od8ztv/H/ab2Bffv8D+0/qGfM/9//J/6393PhD9w/1v/x/0/wA+YX/N/bL/HedB+W/5v7l/AR/OP8f/9v83+bny/fZPok+z//9/0/ga/rf+d//3/K/6/cy/P//w/Er+8YzMuY30XRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOi3UOSf4PblzG+i6ATItP0cQ4DM1MzFhJMiFEnqM5WPEXesPE3vVCBmTqN/A0W3oR6XEE9fDT6meeoTn30s2XUMuY0m2KmNO3ISkWqc1pQYlAsdug1uC+xxuB5B5pSK58L7lf60IU9u4yNmcrUKMf32XTbaCJfc+WRdQy5gsIHPoOdUq7UtM7lzG+i6IrahTh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqbuESFuR3lqzMR3juHEc6h+BxwdWKVm6S4ymrBPiCdQP0Y7fWaJGNNUuE6HUKzRgqhom3dlW8Z0amVtKhM1N3mkuzcxnKSRvv3zXqTBkB+Ovi18xrQakMJSpPumnbV4LodEMZlGRcscJzDAsReGQaMcKJ4ttGQGLYBwMebXAS9STUG/Y8aX93I6z7Eyh1BeSKR/UBQ/griDX4NQPua+35e88Z3gArV1Z+iawsaG6FY1jtK/yNr4EYbZX37FtajCY197W9RAO2IMzKmhOMhHkwoXzRBbosoaekXVbT9ax0gjrkctxvQYpvs9i6HogTYiIQmnZzeuQ9t/KskN7Zb0Em4qAsOYvVYHsDnIj+7cI9WSN9AsO9IulyclS4z0zFul1nb6owNBjt2HiRaJEzQfaN7b5ooCMvV/rK9WRoYSzwZMSRfHFnrCHnFQxREPLvbwHRPnuvkSACdm8vEW4gsFjqj7idGJw2+418TFUptcRQNPrMIFu3eAgofxqV5oJIzOfEHUTzJH4Q3ZiRJmQPhC5BSsAuxfDphAFDgekGI6wSPAtswjiYols1Lp/AKcN0g7p9MJ4sxPEvZ5jRhI5+1k9g88uDK0ZNdHZ4uYX3ehh2/KrYL2/SLfTOMUqEUfE+Eowfk/3DRV0LY5jjbtsVssMtXTUWWiPo3hTh0Q6otWz1982/elKohVcGs2B1Rnjh0Q6ozvXRF7KdComB+5kAowP0GsQIGRW8k0C6aXFG42jWNAZ32d31h/C+ZPI7SAC/7+LOXOqM32MgXWjFLDWwvyUl9HmDhkJTs8cN2iggrKMmkhkAU50QjCgF+rpe6i0hAZA31WDCYfyrj23WJbueUtH9lv6yTlGu8zhQcG7MW1/inotf542xZHGUkj66RiDeac7msJ8uIQuaBDLY1l7cEEIiCNdQy+Mb1b9/Z8Ha9j5e5bypqjPHDoiIGHRDqj8yHVGeOHRDqjPH6hGeOHRDqjM4qG5XlI0XtTd8snEx77u+apietGBNywpbzE7Fa2pZL1OdxumOtOGCg6kPJn5cXcWlXKguuAvkJttwKYVBlH2heujJEqfPDUwgXapGhtQFbAvDTDi4gm35XGn1nrVgEqGbBewXCqOMrs2w1RP3OjqTtN5uJlPvxbVnN+0EXKY91i4q8oJoz9Z+V9nsJwmqJMN3cxnmBAOujqPd2uOlwE3vdNXmxkSc7/ibjJLPk3ubGHP6Yzmwy+DOLX/Xsbf/33G5fb69qmX7hyG2LBZv1Ndu84cMyOHdooQX28Th05qV+4bymqs/2qxbJZFMaIpOEJ8+5RaQG/roWcfgOeAefo7YITyt9yyBGd7T0K5xNWTmOT9O1rkYaH8zFsk/IyDp4Dmsq33kdvrr7vHiX2m3492K5K9Pe7m3lvhsUml3aWerIwv5piG/VOxvBRZCwY/Qspurt/0S7OQTef0aKa9Z9kuP8QWK9NcKGbZNbn5tfX9xzESDEQPuAVAHVlEqMTHokDLxf2Wv1i2ji5qnhFqJr5PgyTlYx/QoCBKIfeQXahMQhkmyxyDnJDno8+HRa8Bdc1BBGvJK2c/I205GfP7UptDvF+eXBPGpSiozjyTQK8lrLKzGE4xGo7GCbjoYdy5j5tlx3jSYdEOqNIiIBdDDuXMb6LyAXQw7lzG+i6IdUZ6e2XMb6Loh1RU1PCaR6hrvmFwG2BDIPIIbxxUWTe3NQe5AhNcdC6D3GtNPEEhVC+nd9AiOO/aUGkks8INwGfGmM6SopCa+s+Ua75juvlPkDwnUhjmFrzWQF7qsFa8pswBDdEu0NTo/Vrchkoopl7atMwZxakeybrfujYqwtyOlkzqwy04CxBqLbfM08RYpMJ2PDZ5Lp4iEFPLoEV0WQ+IbN6TqPEoHkF8HLIZEPm6zBZSPVrlyUeVo4wWFV/5fPzSuu1127VVK6sAw+3N3VLvvjs7F8obndK2EFx6jN4kIQ6fRKZp/mHdquL9g2rc8iYfKnyEJKvgUglOPTDH19OlG3eiH4KoBDIL/1YYa39NKrdglOdv4CXfePVG/MK/kncy7tRAuJAch8iMO1lrhk0TfbO3LmN9GUHpOY30sjOW3PHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVFaKdUc023dK4sRBKNu6VxYh+v2tDtGXDLmM8iJd6nfuR+6atAIVFoLNEsFReLqFpLkI7RuGy/SvZbly/SAuYf/xtlh5MIKIFZ+AEEBRSeC5CYB4lahQJggznU+YwG4/FT4lSfAlls6u55p30nerCEJKt9dRZlL7wj7tIqMwM7aWXwitZPI2SkFxfOe3ZFCBAGRONTPC8SSzxXaozvkEKrRLqCZo/3JcOhEbh8h20AFfwFZplsrgkjPobW7v5nmKO7pXFiIJRteVIU4dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6nZ1Oc46pTh0Q6ozxw6IdTsm35XURHtKEsKkBQMunPLuuEZFwlr4FbON6NA/I70MKbfhk43iIJRt3QvWByYA1LvdUvQMlQ3BRaDKhybZNI9e95veP0dCIdGkR6CXR1ICvmzpP/4bEPC7OX1F2X5lJntAx/vNcrfzXf50fy7Yh3kDlkWTmNCkHdvwLn2cXxYiCUbOD02k29bd0rd+OG+cTpQQdNiIJRt0k00Y105UWcUYr8cN84oQxZHM7ixEEozqRgwyMwwvO9+FWJT1IDuPZqYqQPEgoD0cqHP0aiDgsKJEW6VoMW0x8Y8Vbt0zC6lWje7Vtn727mbXqNfokJyV8HLctwMJwu5y4fPZQbkKB8ijIZXFMk6z4c/O8N/w21jK4oHBgo70PregscdBcv35wrbGWPpAJzzmPjS5YTMJV7kK2bOk1dIyC+aRj99xJvjlpzfgUk5SpdiIp6m1GaKfp86kimM6kyWGjuf/IUJjKuEq5CGnBaBaM5NKABeHhyEkZk/3fPLBLOhK9iJLSPp1N2HBJjLSd45xxtYIGm4LuuP9Rkyr6IV/bjAA8366EzPigU4Ew1IFERMTEZFjZjGH7r+YZW/zGYvqV52C7F4zEXxTKDhzTsF0Oh4TirjVm6/N3zmi2//qXroPALOb8XHJmQzXvuNuxz3y/Y+yIJPzD34OvXw2tU+hgfuV0ZdHcwDfP5IXSjbukhJGZSsHZifaGvn2m5O8nWN9Hk9Fn9qUAa4DoJwLHdOPHCB2HNNJZ2fy3bX36gYWafMOpukqO40vquctwVL4nCRzLGsJhP+exrVR5NZqTjNCeDk63ruJSiaKQRrTDCw5BsKxtgWqe+iXbpoPWVsRpuyRQagiLNVwVpHnhsbPEzYE1/mabliIz48Xzq7Z44GVBruTPDCdz8ynvAiniqnQ/YgjweDR7Gmqspwafl8AH/B7lvjXj0NsKdX/qCzSf45HLFzHGyjhfaBrbr60s1AuYB1Rm1ZchzcGkPBvtkDv5lf72BWLUvXPOHRDqt3dRBg5WmjlsFYqnuXAd+zuUpWwYKcdy5jfRdEOqM8mib8b6Loh1Rnjh0Q6oz09suY30XRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGaQxRiyju6VxYiCUbd0rixEEo27pXFiIJpvo9dgew57iLGIEMHLGT7tHWPouiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6NUr2dEHP+OxQQyFbaGr+Qsu//+Po8oPVcgNh4KA7sJkgPdAztd/jZ+heQyVRtsQYeF8yzYJl6/d45UphZ+8h4gGqFGC6GHcvXlH6BBSRnjh0Q6ozxw5791rooRNASEiCXFOHW7W9IXw9OWESf0aQfJPYaxDnQXaQ/kEBbGuqM8cOiHU3wrICqEjSR2EzTxQkovxrhbyf/b7WHMg1J1e4aUdKNEC4Hp1tMzYpfY+inePDLGb37G+i6IdUZl6WjDn7/0syWeHty5jfRdD2nb8PTv5rMdEITu15vLx/NMs69TCDSydsAw3xdAT25fe72LMA27cgSMHEU/x4vbAanGVxYGbYZfjj+jvQ2xSXCfHIv56zWLA5N1vj8Kpq0nLB4Xao9wkii6bKLiMTJOw1MTG+iR58P3nsAuHuxGV8oSVNHzwldDjLFAcNZzNBw4NUP9MiS38zSzYoMX9bo8QyKcOiHWGrLUy3xxmevFyHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1RbvKLOb6Loh1Rnjh0Q6oqdOnirNfoIbvE8ySuu0SLOHnqUgnr+dup028cHVsb6Loh1RYcmpe5+kaIsSXDhID8LidaGdHAXzxzj25cxvouiHVGeOHRDu6OHRDqjPHOwDl4sJ6zQpiY30XRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozdqD0n804o8/8RP+qvP/ET/kpGhaWUpD3sds0Ohh3LmN9F0Q6oxjJMMalOu/p6kFvwvgFOHRDqkhj8i4ST27ZOjXzGFVWbiItMTsh0Q6ozxygNaf63ZSPM0vA4R+bPCmhU5YwC6GFVxygNZMpju8paW8cYJCyy8mrSzfOpgJsvOpA6ye8mDUA0b3YPi3tExniUuhMKticjTvr4yDnfWW1pnwe1g1gMfkt9yypnVdqbCP3kPpaHlYpEPVZ3MIH/slRf1Y/X0abmYIT7pcQqnUDzTWzWhkRe2b11CodSAfilwj+4y09tW61H83FZNbz30OyZhMnpGxSWS0CFthzeMOy9RUm68j8pKMDa1ZLviu4VP4tD5XR65w9kcJIBIcPxVjx9e1IEsLNdFu0bPduMURCfdLXLiguH4C3WnmEfvo51w//tbayQOUcF45oGkBQB3lb45zED5Ah1VoWsbxI/5goKrKt1miIwdrqWRg4ZL147oPQE+X60tvwf9pj8MDuFcC87vWV3jnsRDkRY3y0UDS5hA4kcaQOF0Q6pHogB1U6KFy0EGgcxrIyxf6fdy9LEyTFcSNBus/GvOVPZB0H0KhMaGgYCjE3x+8sQy0hjMVeA5gwI3b5dDDubqCSltg7oedD1EtV0NkUGbmzLlAZ9aFmz8f83T7fWaoEt2SsXmEYZApkMz2TRprMlNlD74VG8ISEcbiuMgMz3BHsD4FSUpu84nqHbbVP+wEw0j1buXs58jhFiKYAqULw+UP5DoyQ1jJjJsXrmEGncLfIUbdTizeBSZ9+/bzfyfMcwjXDjhTZPrFE/ldjHHNQ7ba+g8NPFsZqEKvFhBoffFEdFL5/c09uXMb6MDa1a43BRA2G3aMyzHACkMJ38zzPTJdce1ioq2p7HsLHzC+/tOboYkrbqLd39LhWOUs5LVU918MANr6DuXMcCGAYPF6CSBOp6MunthLLhpMRAlzxw6IiBh0TMfUrYJSOBX3Fy8bUKP/i1v+YJmquI+vcyLMZznJhQrJ+XbZe5bKtMYUqSt/E7SX8VQNNMFfs3oLusQxMb7rEq4al2/dj1yolgOjlwetDYU0uAHiJ3CwqHxDNpy4ZMhzdEIdbRGP+w77TzrV5Y6e8SQPbE77MwU8TjF2oHoO5d9SPLudRXIY9FpMIDGzw4xbYQxv5Kqrr4GRpagfjd+rGtUDSj5+86Bwyv8ydOEADnGkKQo4QWKQcHHRDq1uUApnCbBDL41qN5NRdEOrW5QGJ7METHBxCR1oSNRdTB7fycyKvf4ybJ+6n8WdYMfI2UtXXQuoLJ7VMGxx02mX+FzLwbg9XFRCIL9xYj3QqT1AIVTWnIaNaEkeh3WVYAP7vgOXPgFFRnuspx98Apw6IdUZ44dFL6khkOiHVGeOHRDqjUXNjsT0tdBZw6IdUZ44dEOk7aS0G5vDLMSjovOHuKPP/ET/qrz/t9i0xNvnHQw7lzG+i6IdUZ44vCnDoh1Rnjh0Q9G548sCnDoh1Rnjh0Q6ozzvgFOHRDqjPHDohoxRJiyl09+n7EXxYiCUbd0rixEEo27pXG5PO+AU4dEOqM8cOiHVGh7cApw6IdUZ44dEOqOtCW7wqHv2IGOknzJjqAS4LoYdy5jfRdEOqM874BTh0Q6ozxw6IdUaHtwCnDoh1Rnjh0Q6o60JGeOHRDqjPHDoh1Uy9smQuKxkq++JT3px/c2gAqlhzXGan96okaDrrmX0StlKjqjPHDxyTxJTVZ1lwMPrF2AlozYDI/Z4XpqvSK/htUsGTeZ/60uSXkH+BM2s/4Dmn4cCyhy1cYBlAxBouwQeX30T5TDrZRTHObt8Apw8bhNx5DGlBf9U5bTpqZRjo+ACd8pMajkMd9CtLrFGEUOWX4vrEiPMNCFfXhpdALBHnKaPncbuHRDraMpWR6YqtMgc+BLHlCZKrabh+Eg2/5ndz1NINCo5XYcup6mln7e2cnR2u9SXvVh1RnjsU/Z6N4hLvmPbI/dgE4bBDbLLM80Ey9vAkpQHWVL4wfQwFvlm7d8+I9WS8TcZH2SLw2AERnS0g4ykVJca25Td0s4puhk6Yb3HUK8oqcOiODLWZSP/wzYwH1SUYVEYeBCYjbDUO6ebt3YS9NuGeZN31h7bD2EfzHb0ARIr+gvkvRyzAPOZKCegAhS+VMr8BjfRJcmhCT5ymbzlxB63GGHEQz/0KiwlAkcAXW9WlqGK9wEapacjNMGkaaP7hJoliOLScqT/eOCyTZVKzSvWQYyUpI6OoIzHQljeJf0SAjSnV7QQYUyMi1jYZKwVWfLD7SFHCsrdoKJTIiMmNYMFLL/+uGuEiYoB9lRSQVGpiOzzkuKblR8SKEgY58PjtAWbAdx8jFaZzTZ0ORavCUme152lOEEFg60m9/z0CQhbV2WY9w2+T3CECKem0WKTCTnd094LJVT2K3Qof3dx4XWlKPzX4i2bKcVD+yP048z1BjFHfDm7okY8S7Mwvuj4w7esauOYr/dzhcz2ZSsA+36qoX1plx5rL7Ug4DdNN2nhT8jvRPpXB99C5z9+sIWX3pWrRI/yulqUX3Sa6hLAfmM2B66NhDCnDfNUppwSJ2+Nigh7XTaZxVUATY9x1p8RGG2JIGHUoo34vjhOOJn0fuwmBVionQNLenMDU55eAc3KT4PvOZue2YFlfhXvE+uN5aC7HGoL47kgcaa+g7gZiPuhNeq3M/BrC2BAyEEt9ad2JZdRTstRyR7UoMW/lpqLoh7ylawIDaF4IkkbJPGx9DQA3FkKaF6RvZKOmRf0fek52nAtuvl0pa2VSEHiO9xYj1cEgiyDLoleFSpWSo8irbb+acTz7BIiFZiev+w+38whrOzKrqt4FOHRHBJzBWym6CzvLWrlo4mjx+xE+HqFh5pmfdE63shSXxrsUKarajhmZThn3E2q+KfFdH4YiGqmDBDbGAzbH/466K87jmbHKu12zA7dESpfuXMc940nSEHSE6EwavqAxP75+Sjr6XBHJkzrBHC2AUxgucQBrk1y73VIne7bTI6IZ+ikkNdnD0qYxuw3YAcOv6Cd57RQgX0cGSKuYFYn1UUrJyboUFwUeLZ/2O1boocsLWxjluzcUKL5VaJNHHLkE4QNFKsGkHCTS6Kv1Q40iHMHMSBFKz0S8WLF0MOhMJyifFO+qTivVE/zdkt2Jew+kCyoF19KN4RQgJlLGRWkMgUsvgSweawLO9hSI7hLiEdOqZcDpPAoXJCtPrEpGxFrX0kBqX9mDgSYGaXQNVumGswUvLfxvwZcx4D68moxbbO2wBpxlxnAAENVZfPwgukpdDDuXMb6MV9suY30bwpw6IdUZ44dEOqM74R2irUpcUG/oq5rZsgbmG2UpBqjF9Xufo10dfBlYfkcBhFSGoAhCppM5OL6Cit4jLRZxhWyEGa1myQODQ08+seZSGaBtcQjzj83F4iOniHR2BQYbBCD9MB9LmpwCn7uqIcDsGaz2B3RnioTsysmusrJqzBNDYCXJj+/qlgZhsig1PJkM4lKU305YjG8DquRkhXQyVvpdIWFxDVkwTyPY4NQ7VGulnYwO2xCshngdiEKU33ucEJ4C4zjSOOaFuzpG24QVZ1rpdEL+uoOAabaA2YwNa1B6xQp4I79V2orw6uYVvQYaCfWDt0Y1hyxy0hk5lF1CH/bbAzY/0EmEDczYRIrmguc40JWc6ZnQrKKYbOdTw5GxsY065dSc+9M4mXX1hx7uq9IbhASW5RIo/OyloeSdiCp9nvDAgU0p5xHh9naB/TSavedInHg103zTQujDkffLPVTlq9oIvlJACqtgeMkDZILJeA7blWNC9BU9fuUvIMAPHLQa46qDRW48UUPDzYP0DOXRDsTJZYug84sE5R0SAhFY1xkRi2pPNEACXVrmvOV9ardcT6UVa2sp5bn115HJGMim1wfp+htkYd7q+tAGUj2pwjmYiDmMqjYoCbTEoFCP6XEVGHo2egXcih3n66ylFNAgzrmWgldPizGB5wFcrjYAr8SKc6ALqEJC9hAn3IpgIEb+AiMCozRzAmHMDMmZEp3TfYcDxWxMQY3eQlQIuDTINZbBGQKZwpNHDcRvRSXCo8zjLGcuTe4tLQ1tTydZ9mrFg4rtisW6VJnFkRl7Bas+J2XR92s7JC/pYe/XXfQ4ha1Ntly997MjHEvBsICiTiV4Rfr2sZMjQn7SS8ojZBG5USu80lgHrw6XxGCHpY+SEhe0qovH8goII37RfXtd6v7dHy/OgEjHgQKH3vsH45+7TDfOn8+z0v/5RXC/rmfxPITSpoZIKQ61NOGQEggKwwK3iuqBjk2v0O6RXrC/6SrWQliO7BudtHIq+LEJKfM6ZWGxo3CWyUfAAj/b6z1o/nExFu/zM9iBtM/Rbes3LpECminQeU2IpbXnXLvZFn171io1JqpeHH2VG4CM/2b/lvgm2s3ZsRCP00ywKdOCmCEzOHjh5ALyuWKs8cOiHVGeOHSUvazY30W5ZcLrZR3dK4sRBKNu6VxPoRsyHDLmM0Yjo/BDYNtE/2bWu7LC1UTTn4NpDXa+o/B7OV83qsoqDKqYsH7B3uUqIAoQdLWjaxAvWaMuX44OykBkYza3YYEwwCS0FuixATBrbRFrrwBAU5okMUI3VOSOSkg5I78WoEwTfU9hEf2bmu73A+PoG7waRQbD+nYrtqouiGhL4MC9H3B1vesPQZdwi5NDuSMQ9Uv1F0PxMK7vSHuKPVA7FEpKLoh2DdPVqAcvFhQunkU1UuoZjHhEDDoh1Rnjh0Q6o0PbgFOHRDqjPHDoh1R1oSM8cOiHVGeOHRDqpx3LmN9F0Q6ozxw6M93HD3FHn/iJ/1V5/4cXW1OpZUYkOqM8cOiHVGeCxfn9LHjh0Q6ozxw6Id4pIK4QkZ44dEOqM8cQR638/0HcuY30XRDqjUkh1VsCnDoh1Rnjh0RLrjbmQ6ozvZv9T9zCfkh1RnjlIeBeEF0Q6HNEy0mKpp2tKxjfRdFOTjuDEOqM0loirKJWENjApw6Il1xtzIdUZ46RbcuY30kh4F4QXPg7J73tFif37SKm1CmyYCjPwKnDopycdwYh0jvmT7g666KjPHKQ8C8ILnugfumcXeDe1Ljh0Q6oz3kPT+u+iOJ54cxnu0hu+drXdOHtuJzrilyQAFv9EEYWTlNjOv/XFMYTrTnIYn1w6Id4pIK4QkWCAJCWrzEdcD1r7vbTuLwR4fslSloTs40NjPkHrIdUkNZFH9jflU0JlSFOHREuuNuZDqjNh1ivwCnDoh3ikgrhCRYcSj7YpWOly0OyUh2EJi3rmHTJk1Qtw/3CxEJirwAiHu0wT69U6R3X+93DoiXXG3Mh1RnkxToUozxxBHrfz/Qdy5jfRdEOqNSSHVWwKcOiHVGeOHREuuNuZDqjPHDoh1RnjlIeBeEF0Q6ozxw6IdUkKID4sA+y1aYmWhIzxw6IdUZ44OxNAStIhYlM6L3QkwnrOHuKPP/ET/qYlS2AuPStV5/4if9Vef+In/U2CVWnF31wdCCzh0Q6ozxw6IdUaepVoA30XRDqjPHDoiXXHI3nMb6Loh1Rnjh1Mv3zLQkZ44dEOqM8cQR643okOqM8cOiHVGeRNl+7t0HcuNW0JjXUMuY4jOzYZDoh1NB67SAf7S/YK9pRCzOmy5jfRdTL98y0JGeMqaG9kb7IkYdUZ45SHgy+11DLnTw0MO5cyF/QGYQXPe3nBrPIEQhmTqEZ44gj1xvRIdHJryZa6uLRSpzF+daNhtDq/lSonkECSM8ibL93boOeKVsffXB2ue+i6mX75loK/avGjGkDUEuLgAwQsLBJo/jjaxP9X0KOVLJSgn6n57ZsZbtW6oRnnkHYb/TbQ42cOO+/dlA1eSTQ+IdWzkPVAGdBM/Sq9rzoYkc22ansoTMWYkB6VCKKxhY9xpR4QHxwhJB1tZbFr3zwiEBTiCPXG9Eh1hmbmdlJLKz8xvoupl++ZaEjPHDoh1RnjiCPXG9Eh0Wu4fDoNP6elGMzSckl7D1P7Z6zlWiP6HAFDqLcDGJwi675LkHcubeOSpGC6JIih5hqpdQy8AZ2Y8KcOiHVGeOHRDvFJDshgFOHRDqjPHDopych0CEjPHDoh1RnjiCPXG9Eh1Rnjh0Q6ozyJsKVuOsd4U4dEOqM8cOiGwF65yS0xurfQxyLgm/iJ/1V5/4if9VeUB0w7jah/bV5/4if9Vef+In/U2CVWX+K1qvP/ET/qrz/xE/6mwVJAka6hlzG+i6IdUakj0ibyMSHVGeOHRDqjPImy+peOhh3LmN9F0Q6tnIcLmozxw6IdUZ44dTL90wxDqjPHDoh1RnkTZfUvHQw7d3DCD5KSNmRIeWTOWBTh0RLrjbmQ6ozvJVcoFnGh34UvsS8jOa544dES6425kOqM8f56w6IdUakkOqtgU4dEOqM8cOiJdcbcyHU35+nBTlpVI8drMjzF+deMJF0mc0ftM6xjXMAmN9GCPW/n+g7lzG/L57cuZC/n9LHjOc5ko1IS6JOWX8QV2TvH5KJs72UyXIpV6MzmUixSPC09bWz3XXn9c8Ez9QzerYsPbfJFTHmvWH8wT9JwL/f/KMyMKr4j9bHfzwHn1ly4BaagPZYGIRMXf7KkdLap27bh0U5OO4MQ6pWDuWyZ57cubeORR/Y30XRDqjPHDopycdwYh0UuJuAywzP3Ds/yGujUPxajU+KhRlzHEZ2X5ALnpD2heZjIPyVM1MEM2BuCTxw6KcnHcGIdUa+2U9uXMb7uy+peOhh3LmN9F0Q6tnIcLmozxw6IdUZ44dTL90wxDqjPHDoh1RnkTZfUvHQw7lzG+i6IdKqBXNUbvVTMDl0URP7tBZPWcPcUef+In2mxjQqx0p4AG+i6IdUZ44dEOqNuE6Cyes4e4o8/8RP+psE8cXhTh0Q6ozxw6Id4o2Ege76Loh1Rnjh0Q7xSQVwhIzxw6IdUZ44gj1v5/oO5cxvouiHVGpJDqrYFOHRDqjPHDoiXXG3Mh1RnevlfcS1Q6IdUakkOqtgU4c+jZJKnxvrzQ/l1DLm3jkUf2N9F2BP8O5cxvu7L6l46GHcuY30XRDq2chwuajM78BUeN1l/Opu9dN4vqi2EsKTOax0DGg2QK3wCnEEet/P9B3LmN9LHty5kL+f0seOB3fSN+xYVrzkNo2mUL3w54FL7dSBoBGeOII9b+f6Do+ErncNdD3dSAIifxCI+RHRsx233ZHK9oR9f0QAa/N8Gn/oAopkJGeRNl9S8dCqkWLoenCzrmk2ouDXXOSkSsyTxw6KcnHcGIdUZ5M89uXMb7uy+peOekWQYCDMXjDzPYjW9Pkno3SxtC9gJ/Lt/eO4MQ0RyRanuJJ+BNSQE0CKrC4S0FN49gHlh4aAEpNOGVs/Ny6hm9WxYe3AKmeiC0B59F0U5OO4MQ6ozxw6IdUZ5E2X1Lx0MO5cxvouiHVs5Dhc1GeOHRDqjPHDqZfumGIdUZ44dEOqM8iaYYlau4isTHU5MJ6zh7ijz/xE/6l9aDfAmYYAVq8/8RP+qvP/ET/p+InDyAXQw7lzG+i6IdUZ48sCnDoh1Rnjh0Q6ozzvgFOHRDqjPHDoh1Roe3AKcOiHVGeOHRDqjrQkZ44dEOqM8cOiHVTjuXMb6Loh1Rnjh0RAZbJP6EOVt2jqMxwAEjwqtrqGXMcCF8PhlKUuGU3dcL5NTzrbbfJiGR80RWPS+XgLNqFLEIG6qLxGjbyNNiNXDuXMcCF8XlImnFonK8jnV7sIDEtR7a8lXtjqJE9pUfu72EF4E3kMQBJkLUMrnEchKokaGHcumQ8iYcpJJssb1bGEQC6GHddrqGXMb6LoiAy6hlxCzQKwMsKb991/GViJazv2H5BEdzQgpxcSFX5yNcQsR85ujWDmgGN9Vs33r8Gt7klPN4qx0JiceJV5vot9lFBPRCfm0Ufiu8YpGvL439Pq11FcmhNzXYItgnmftulVEWTDQ+QQx6p6hqs7Y/hiDGisP5jGeF5QRtu+Mgn+WZnZJelgL+Cz7Ob5r8ev3qD3AByeOq7xSNkOp09t8yfePBc0xiRXDguZPuD6HRDOMy36bbQv9oxDmqL9iQzDRHyN6/sX433BA1wxfnJnGkIiw6NrUb8k3Ynm6Fa2Idf+LrWlt+wnpxnsBLp5xlP8LApIQl1JNkJU20zxV3DdhJJlwOweGgpsl9poavFwcQsoxs22S46ZyvaODdI7NsL1iy0mXHuKzV3hE8yN239dfbP/gcSRWrZcPi/DEbHF+au4PDLxka3YHckMlq8JkkM1u4LE+F2tvYtvN2MyatHB64zel7VmHzjIpfMet39Eha7bHyW322ifG2dxab8vznicIRiNCnYKNCnQpRnjh0yf4dy5jfRdEOqMy9I6JVvjcU5nZ5flqoN2gBmICMPp2TlO3fJUJ94vVsFIy40s1SKcYgPYdHDj5GNPH86aehU1MlYoVMtvUjAJIBlB4ks5Ol0o77P7ZuIkoAaJ3X0lALAIn1ef8q4tbWn0gG7zZiwQRlSG5BwAoCK2eqhsOtD0eowYC30bQz+jYarpbSYKdA7QEzygYt/BTgRw/cJZGnvLHWhbHQJV2Nk6RWO1E+SXpCTKXIoaLlcdqg4SsU1JTUABtC2dqfAxFihwWhyQceOIGEjHeUcMORq2QvT+ADX4at3kIBAIsyoyk9b0ALfayqhWUI4zKiXx2TF4Ge7BcVcoJEvcLWxe6uzLUDPiq/MQpk6PGxvEmgys/B2wANHf+Kr1G85IXRe/Mke6IpKk2vqJk7g0eZcUAkTfg6ipEcO71k9ykCcwkgZFsh5s9Lx6LFBs7YqND24AOzNy2S/1Ye6IkNGipEzMWL3XIhrUql3UWiTZIQqATTiNWwSnnKb9rWX47lzG+i8gF0SFHNfmpnouiHVGed8Apx0knp7ZcxvouiIDLqGXMb6Loh1Rnjh0lLoYdy5jfRdEOqM8cXhTh0Q6ozxw6IdUZ48sCnDoh1Rnjh0Q6ozzvgFOHRDqjPHDoh1Roe3AKcOiHVGeOHRD0xa3qrz/xE/6q8/8RP+quecXhTh0Q6ozxw6IdUZ48sCnDoh1Rnjh0Q6ozzvgFOHRDqjPHDoh1Roe3AKcOiHVGeOHRDqjrQkZ44dEOqM8cOh52VXJKomN8wSlgt0HcuY30RUclQ6IA6VpqGue4CXuMDpe1bcna9kGRJ4UiUY7KxZCkq68tpmNP6Z+9q/Y5+MVSRi4od4K3pe9V13UPFzL9AN3woOETpYSfeM+LKLOgHnIcmzjJhqvypeSnAjiCrwYmKNHirOAd/sMW84k/xZNqpSaOj1Tfy9kH7FrTiyDI22hBD0Chknbp0QAPavUPBf0mW2mhehnpB2Lb1phtd3rZJqzsVTiz9+ABnHqg4QUdZQWaQgIeLCZlNHp1LcNIRMijvm4AtjTlkjTnV6LNCDD8UuFLgv5fkLgl1y1Oe/FEC1fuIWyoGqPF0oumIRZvvp6B2cf3pgFaCcuhQ0d0mI3sr8qPTiFxy35yGBDU0Wz7vAubhZn3x6p3OzwG6fPyGWNgLDVpj7Z1gCtRBWI8js3Gg0/6cmIBa2UtmwceNdeA7Ere+K6BNccorGhDGl/GY7l3EWwvecrJOZjlLX+iUdgvUC/3ZClPvbVaWQZCJ2qUEwQAPXcO1rtap6lJxhKaiP2rYiUs576LA5nIykIVNcccHEWKClAN6J9w6nacQhP79yH4hAIzsfUT+RTfBTOp2c6ozyZ86FML7qQrpmFwDAUQNsbvnte89gQxEhMtE4iOsVhZJMQDw47Hc29WKGqto2QAlR+HWIuPU8MeW5D3NB6m24HTP3e5YtclORbjuzU8JEwG0ED+TlWRHpJvgwG1hvten8/plVqvL/k6QHI90+uSmEsG10AdYldy3O8Dyqz30Sc+FPoxpm5BXmS1wvlOHNcMSIuxs200eT3FgImu28dNCau18jK7D5PdbI3sg2/+95rsky89VozYEWw7S1nRaOmrXKA3WDkAGEAiOiHVTscvFhO6Hh1Rnjh0Q6qcdy5jfRdEOqM8cNuOvUV2LmtFEHucwj59n9MBhpgEw+UDD8Ehr4fZKwTL5JHNamkPDU6fC8nDpxnf3JzmEr/gIcYg6XwS7WU+xC4AWsQA2lA2Qz085qvIITpxBkF5aOugMLiKhczireSGC5ommM9ob2thNjPWy2xwVscnzP/yyVJAcG8Y/AdeDvOcL8jhsgdPYBaVzERvMGQgSqSTlc74rBRmjKTx53S1euUquZFUAch01JgddHEz5AIbJ1cQK0X4FPLRswDzb1vYaQETWbCNa4HOSLbCRvfNzMj63Ikd3HgC1FkkUWjakQ+M+EUDstDShj5ivr2bpDthXF/o9iNrkPUl0x8sQf9/vEcwPI8gU8IaxMqVsTrnZ5pI4c0uQs71vQF/RfKj1mS8lhfL9kCUUEEfJSC1Yws1qC0LZKmqAmDYMOOC9mFFhWy9JqDO34ir/h0ZZ0z8RCpolp81GRtCQrFZwM3XlN1goSGXRcrkYVCfMyFD/9WcV0AGmMbnbTrp7ch96EprcoMW4Af/2kkR2fZf0qHSIrB3e6HcVWT3uoE6Xlsrw00GTRAoHMwy1cCCBO4T9mfg5OfNu1zPkvL7jmxB2/D7VvAcDcaUF1GGvlrMKP3H7ooWx/Z4zU3//pHoQdhyUdW+U+2FfU2syF3qTF+kg11KpjqXyu80q1EvcxAaa1/DuXMb6WPiK+L73P9B3LmN9F0P9iXu/Re/gpw6IdUZ44ThFbNMuRM582ps97kAHoy7P+dzwylOqlVedF6LbIJq5hg8+61rbGsPOGHkAH8zAjrV1Fh7cuY3ty4JqxIVqZSnXcIItM8DPl42DwQcf4rrh1BNkoNp9E1XIoyAGeZRK+6cELD2dq0Ijoh1Rmg9e1/bKSv2pcThxtUIUK6icKb9n+SAkUhkkLySV9X2VVuZZRY7Ztcdm07uNE2VUZT1WiQY/vD1Hvy8YVTI+SqU372nIBVMVgSx26XjpHiFOa+xjZxUyr8GYLLutQWtVhoxYuGLw+XsxJhRBgLC9HaljSb2tCmBNK+ELUuozebe0KHW3PWAunJtwz3AKwRPKQu4zBlcIDt6oxA+bx+3+OHItNfE+J0xNF8Ap5G1zAIHWzRjoFKH6JraEqatzS+6FPDquwdNzveDNmLUZcnDq4fScpxohZXK2gxqt2T9Q0hsZ25dL2VrFE8v3Eh1gF1eQ4iiST7CD4iuY30XRJJMe6KjPHDoh1RnjWgLD232TIhQyRWSaXUeTEsS4vkxA1aLDZDrmfAU13ccNGNg7s91Y3YIJC5m9YIG33+TwC2izm8N7PzkJFpV/Z9OPSCbMrxbDCSGfcnF5uAaZMYym1+VNO6sBja92OMHsnCuDcdmNDyOJSeinraYPSqpdRUN9PqVoyyqOt7fLpwSsvhqz7/7p6xANEJIOKbFwurd1ygoG8313loGy3K9quxgyheZQRjoZiSPEDTclCzyszfF3f+8e23AyyxylTOLopSWtMP6u5aDQpCmH29J7QuM3FESOVNG9cbXCvbkocB+++Ciauyc5Utst1obW8CVAsBNCVSgBVPCUdrbJdiNNMBOitdC+gWVStdB56xcK/wdwtHGKX40XrRknKoK+7gRU0ANqUt5mafewxlkaESHC3TYg+89MY5hg94QvlhCvpdZ68vQ0tntV4+xFgUM7oBcvEa+sR0EQFcFATQJMTZ3kH5/8cORQjN+mz5IlprHG+jc5GuxaWtnBsnC9Gpkw18ZKptZIR/HeOVeP0NDqjPHlwk1t66+RF+5cxvouiHTC6+mPEOqM8cOiHVGeOG7JL1K27CdjWOs7Ry4wCy5ZE1cF/L3jXzvQBCRlXiSjxgVGVtZXcPBXNDMkKoLemwDeLL2IVjmTWsHP6lpy61yz3x0ZuX8BcT+zycFkLCazzgxn2JuoolL8wNloBKzTULe8F3GkpjwTWiFaDCLm4GokQeMFBt4qxbdw3jDw5w/ljmmtG2kI6lNmEcO67g5DsD6+6ZSKDFBqcC1+jlZbMvMdxUh9/cZUII/VCR2CTxZi+MN1MbZ9khYiDsZf2+8YxKOhT3L8gPr0pUs4BeajwjgTzh3YZd1E4ir2jwEuyuPJGfYx6TnKPiGp6SizZPTe/3/o6VaCT9ZFzipUAUeTOb8O3d8vzNsOZ666qh/Y9u3pgo0AB5092Pdw8cANaDv/D2Ya68I+GcCpgV4H/0hcwT7g63vTJBl3B1veoR7dcNatNGAWImCgJiEjo9TFuVgu+1DVgcvFhPWcPScx3NRnkxHty5jfRdEOqOtCRnjh0Q6ozxw6IdVOO5cxvouiHVGeOG5d3BcgxwArTm6IHK27R1GY4AVpkbiNiMgx5PbNirCx8wwAny46IHK27R1GY4AVTm9Ruhk3meNGeOHRDqjPHDrp6pkCAUs7RrBdaKDPI3lUsX8sG4JulnBDs5xeHN9vuEvxEtPaR6eguD5/3AsqiqP5CgL/GoBgR+6vEhMxni5gk25cd1cFX7t6BglperFMU5risXVA8DHk4Tu0rrBv+dpIVPFN2aanNQmMNZv971V635z33zLyeW8L8XNo6InEWak80YVP3u5wVD8Ony+bAAGdRQdwG58M4m9Wb2LewayySO3QqVy7/TTcRH9IQpQNrESsITtOa77rHBYqHCU946wH6qDk54XXHn3gTtCifBw4PS4A3G2xnp/dQKbKfDe3OTn5e5eCm+Eo9g30JTcum2b9L4dEpvV70RlDHO0+uIcKrcH98tVu/u04JvDqHc2QU30ZQe4o85RdEOqSGshRH5eSxFjECGDljJ92inubIDD2MbUcPcUeqB2KPQJ21us0LXuEyJ+39m/dTzAKovuywMTM/WPvf8ARBqLhfWXgGJ/yFgqOtDiHVYZkBg9OTkhx0Mww+8bnwuQnMSqEnam2y2y8jggpU8AuOWNEMe5OsphXc3RN6s/hHUh4DY6Iy3MYoU0R4f/EeGEwrvypbIBJ4o/bPPiC/M9rniKpiLyU9YrIayFSdId0diW4Oeou4tOeov0z4vahJgxOai+ho0w7XAj6QaxJnesn+5UzSQlbIbtVWLO/3FHn+zde1CTBUr0FqxWQi/Qmuj98c898XdoAcYXvY64INInPm1D/ipN0+ueozCsbsT8T7wOvjDAocwwclNk/jEr6+xhgzc0WgFTAYoaMCoFgzvje9yStTa24hc53IME3Q0uBhsSi+IN6j4QtebmKYzSn4AzLoUDOkAxDqtVdR52RohjXgqNl5uzXolcUqz2+S1NcnvkoSsVeSzzgw7s17hdngTsBdJ/YgHh7DnuIsYgRTX5eqZ1nQ08xhr4VdhBrgHcaUQFM44Cfk0XrOt52VO4C84i2BINrJ+Ol0aQJhzF1DLmN9/ISEFbBSapVd4pOM5gFj7cWBlwhnZEp7woD49mcC4QtlYwBBRk6tfwP/84hC6Aj1A0OUaN7LwKRXcqmH2vYx8JM8BKJy6PdkYEoaeU7ETIf9cI94CacbT1Qewz83o2qx39xV06C0gv5F7RxJs/8Za8lqa5PfJQlYq8kMQJDoP1/3USTexLcHPUX6cReSzLFZDWQyC4BJObd3DrFjoYpQKs/sHxSNNLNBsoAkIQ0h+Sb664tOQJEIZcxvuxpfP1+J2mr/QgRKox68ob6ZD4S171caeAXUyTuC8SguBwaaOdVBhcw0xlWw0pEdNT6SB2eNhqwrDUe2ocoDRQ9XAXP9eYGrsZET2vsTfKMF/8tcTBdeo2nqhBOX8ynjf4uEdoaQzLu4D8EqU6wYSxw1xSDnqL9OIvJTxyDnkUuZlPkjg+i6IdUZ44dEOqS/ad3AyPMN40j0eosqIiSrC4Rj0o4iwfAbnKO3UTaE30suUn8cu/ZhKENZSvk3PSgDm3Jag3lQKvtOc++KfvQ/H++IxgdKnaMb7gn40Tl941GLgkvtlmEgUqkHlj3we4kr3hgkMz9LGHW3mysgpwgAWtlJhFxRYgJTBH52d3sF0U5OOxTWGlK2AYi+K9gQ/ODMFHFhyhiCQurhUt0NL1p5+O69BjDvwBrx4twh2DABp3qL8wINoJK+sDg+gMEuR0jX0vPRtJw6RsiP8a9S3Biu65rTk5K2PKazWnJkokwgo28wNYFa4zSVmPr365ERrtpT9ixFQj6W6GmbDqDd2oraUDMQOhLwcLlqrkd1Hfh8+Cx0udyt51dqVbtM17YwUW64Y1uKLo3WMUKSAllgvpghUdDAbJ7W8fdBzorsk6FiX2ZAYz2HfPbV5avixEEo27pXFiH9p73hr/F0+7svqETijz/xE/6q8/4CD+5tnkEYic2bd0rixEEo27pXFiIJRt3Ssctagu+wbC8p0gX2t3fzPMUd3SuLEQSjbulcWIXh1hQdhPWcPcUef+In/VXhPujHLxYT1nD3FHn/iJ/1TCnDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVMTfxE/6q8/8RP+qvP/ET+iYsJ6zh7ijz/xE/6q8/8QNDLmN9F0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDdgZucm+tPMnucBDZfMfX3bMjnbUIOjkOy5K5S2/IfTDgGAaeMB102D5auMU2h0sOdb5cw9i1191TEP6Ln0vvx6MFPDjmFD4V0iRP01ZFv4IfCMw0u8NcBVjL5gQJx4ZPZvBfbd8BOb9JT6TEWh/Z2DetKzSZ/UzHppLfLMZ80IWwPJSVvKnyE1gYz04rjKFtJ4H9IgeR7GtEFgwO+4u88ctf/3b+Kh2ep2HZcxvy/Oh30FDoWg8/8UK5jfRdEOk7lOzwFeeHntOJPHBCL8Rn9pshxSawXcQwUfIugjxJqz4PW60Wz7zkBJFMuPe2vATypXSaBgBgcaSLMwUFtbLHznb/Edwa6aBIQncYEDFC2sWdp/SwDSaaAO8evUcGBv9GzGuBO1vjFDKOwrFD/FlNv6eomHPseeeOBBoR2Skw/RnBNdwoti1XqLvTGyZesjDRWsAKQuJEKTei64Ejy3GH8JmYHT3YrCtIUchbJpWEDQgZfMazX+eOgkLoZtSF8OXe5Hc9QbjwAYKUOxSIiNg7e8ML9jfS0etkT6s4+0XhyZb5VkaIYFDLmN9F0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8dKwOXiwnrOHuKPP/ET8uslgU7pZF1DLmN9F0Q6ozwUaDDDzA/D4D2IktOG4qguiHVGeOII859GMdgL8XmMe9yIbs2hEr8Y4JU6KlgQV6m7oga1/5b/GVLyuNC8I7ug7lzG+jBHnPoxj4ZGGDreKC5sCYYm71etIDXBScvRlzG+i6Kcl8osrCeVwROM/gJVyRf1u0pYhzR24YiNboiNWLMuwKcOiHVs4s4CYb7jB9iO11O9q30IFj/5W/1/t+zLFyorizMkU4dEOqSGpcpp7gWqYODp9uXMb6MEec+jGoZ4nwpwMiz8XHUMuY30YI859GONn/KrugEzRaEwot3eHP/3Jalmz7EiGt6YHKExKWVOustNy6dQ7h9Kml4W246vDD0KkUJhJvZ7UhF1i8q0dW+QSeOHRTkvlFliKPFZBdKGSTJKjdn+ZnT+WC7kF2jtmKxMNHnoac/j1kOqM95C+Jxcoo2HlNRgtfkiQJa1oa7ktDyETlM8HKmSvjt4Xktze1kt/ISUGtDNML+WlGL6Rbc2is0OmbSmabgFOUhwTn8DPPqwedjfL1kTuNm9lZHeMY5RdY6eOwJeGbH78d70c1fh4TmeVr5lEV6P4/DaSEj7vRX4gGGqKD/+LQ9W8xxWobzOVvv+3Lm3jLlNIfq+a7/7EwBTC8TrVhLNHWaB4aw3ASRqTGyXNJVWerjmwLPs8cOinJfKLL38+9G9uQRa2LJeF184SfUcb6zik1bfTl4XJRkpCI/iFaq94MFrNtlg5HvZhEWBHPfKvfIgOmXIa8uHTeTkhqby1goWHKCpmseXduAU5SHBOfvCurAcJkDWTyryIJoxvoupl6Wjy9AUMuY30XRDqjPeQvicbGeOHRDqjPHDoh3ijKmCd50ZHH9W9eXUDlmiCBqtFORydn/K8ML15gLKHuL4OqSlmYmfGy3GajUSr3xhGKY9NsnBcS23pk4KvoFRf45xGctTl31GPYzVNhcEgFG6clDO+AjbyezEe8JMZOaOEBikLLVAI2uWkbVDh5m3paH7Gp0GCPOfRjcTV2OAjsfw5fiTrvmvkH9Gx09eYMnA8euy+Eq3KDgOtLIIr7t8CASegIdFmyR+f0I2hz55ficiOEuaXvmOvIIBrP4K4MKpYBhq4v5mVL+ilj/WSoFnywMZKIIWVYaIozyy5GdFjJkyOhcx3OE0jCmSD8DAtCdiD88XGQ7wzn6uzsmL8HQW0c+zD7uQeYba3o+7A9KhCzOgwrqxWeBJgRXyELYnmBhwODeLMz5qtWjiyyaNZloY4BeZFPmpEGDy2kIqLwMZKIIWVxPuccBHfCpJvgytbFkUHUU3i5nGjPi4cExAcgV1h/KRKkg0dbBEiPzLJe8i9+p5O6xu6vAGGHl8pBMQwMFlovzJIS5tKHcVqnhkgy7g+h0U5L5RZadAihduDwH0h55xmI6gwFYhP9SOvRRdQy5jfRdES62TF+whMbY30XRDqjPHKQ4Jz/BdDDuXMb6Loh1SQ1LlNPcApw6IdUZ44dES62TF+wdy5jfRdEOqM8cpDgnP8F0MO5cxvouiHVJDUuU09wCnDoh1Rnjh0RLrjbY30XRDqjPHDohsAyRDnqoDrpCLg3Y/iJ/1V5/4if9Vef9OCAA0YsBBcxYT1nD3FHn/iJ/1V4Kb8KvP/ET/qrz/xE/6q85Qx/f/Dv8RP+qvP/ET/qrz/vL4V9EOqM8cOiHVGeOUhwTn74Kg/xKb049utEyD49ds71RL2HpHG0tTBkXUMuY30YI9bxjryRDbRe2kyEgxJoVoD6Cp4PUyPHmjHY9RhhHuw74nHQw7lzHEZ2YNumZBDEj1++W+7IWUEZ44dEOrZyG4EBkDLt6SmIYPbVXwpu7Jy66vQVwwNzOu5fIbRom5gC3l2qTPLnhVb6oWipYDjbcdSjdB3LmQv5/RNfq7WjW/rx0MO5eAM6ify7EAuhh3LmN9JIeAtJ1odJy5VYDwoq7qg/tEGGrqqTmrp/YQwoO7GRI8eGw/2FTOHQRJ+CrTExvowR63jqU6GI5Sq7ywtJmFW+ZLu8YrZD67AKw69fV2kHgg8ibm0kFIZsXdTL+C1auaRkrVJhjkNJG9hhVTtP/7cuY4jOyzgjaLfLPs7FpEhQBlRAz1M/UMubeOQpW9jJoTPH9cMcXlTP2HbQAele5eMgytsjuK7Un2GqKXJTj9k5y7qYjG31S8BtaNnXvjRs++AN93EoItdMsJFjkBJnt9a94ZdcUb7vf2DbVTePKLJFM/RpjfSSHgKwZ2Rm9TQu0eaRQ37TremVNpB/iPbm9WxG0tXI968G6HhxgxqFEdIKCghQ0YPviIba/s7Jc2ppc8OTLS0Fvg56PDsziWZVxahIzxw6Il1xr78kmFMQRt+yOiZrVqrJP+FGGnt5JOEsQDGSfrqHZfE2aYUMRjfRdEOrZyHB9GLdGVIU4dEOqNSSHVF0Q6ozxw6IdUZ7yHp9B3DaxAGQ3mZGeOII9byI6NcMSvWkDaDERB+Tu30fQSi/HCXnNitOgN9QYGQOlkbDDT12gG2jcITAzGYcQJ5cF0Dkq20ANyqUk8IMDV3x3AqvoYnzjdbDqCC+1o/uZC/n6YA8IDCX1ujCNoP1vORkzasJtRBDUCzDERtNYKc1i/iym1fC16tEYtpAuWo13sTCZt5EG/nPZFSTfES0Rl0lH4aQ4T82WlT64O4i0teUqzYr2lu+5dGzd3ZPE71eJTc03CVdWxHa6sIA8FBogDlYUldMEj8Pu/sOJYP77xQcusdjY8BV13Pmes3iQ3fkRs0g/xDnrQmNESLYkBuXGRrPysmTcq8jgoLzBAtg6xEThgoLn5lpOgy+h3ZrzhnQNCmdz3I0QEHcvAGdJPKAkjFEytL6Aj5LrqjPHDoh1RnjlIeBbcuY30XRDqjPHEEet+5cxvouiHVGeOHUy/dJGeOHRDqjPHDoiXXG2xvouiHVGeOHRDvFJBTfRdEOqM8cOiHVs5Dg+i6IdUZ44dEOqSGsify6hlzG+i6IdUXIwef1CTwfTAtcRl/VXn/iJ/1V5/4ifaZSjCOQQX4U4dEOqM8cOiHVGeVJsDl4sJ6zh7ijz/xElee/zww+Sq47gFOHRDqjPHDoh1bNZDqjPHDoh1RnjiCPW8TeKj7FL/ovPn0vnZQ51iVRjodXr39B3LmN9F1Mv3EgGrCko8TxIFf5eNjEqLGVRA8DkpqIvtwLDOSCamb6Loh1RnvIemGBHn791x/Pv+lYzupdPZNmqi2wSRnjh0RLrjZuk50+DqC8QrP/OI0KnYrJJToSwmDAq/8yeAJf8XjMRSeOHRDq2chwj93IU9Nt9F0Q6o1JIdUXRDqjPHDoh1RnvIelX8JfHfuEbiVJEHHDdYPQepxD3ASEqfz2wzT/86ILfnzvZDyhvCIYN80sqxzVM997Xcbf7mqpJiOAISDuovIGK03AKibL5ME1C4zcYQweA4x95eUyjj2QT6TiczIeRkcqmWBxx2jGYIRinqS1vxm195BrwOFoRSQJSVtnumd4Rt8uY4jOyzti8P31EzXjP+hw1X0hnAszpK4Orve8fb1ZtVRWpKmMmbzMKQhjUV2JOsetR3LmQv5+q0qw3ny5OiYlknupPxj54g3M7iZIUOAF75eiqeTRNUXjxI2Lvpogk22kZMvxswoEJl0k4TiGfFaIU6LtMtT3nzdRwi8WdV6g7wSwomYIupNwiNgU4gj1wEVTQl/+zAp/L6IKUZ44gj1vE/dTJZoqqxBC1IjeLhvoxdfPLLjk17DVl2M0gRax3UBUvudxQ7riCms2PBhn2CYpv/yR6t9FOpMMB7NQAp1q3juchTIdUakkOhJsuBCxlHq5zAZGHeQv6sKDOHJzBhRoSJyT4SCxk4weS2OAXbHdwCnEEet4NT9g+QmmNKfC95SaJXlp/kYyoP8Rd++a+M9JI7W3NSlGsKWxRdEOqSGshasOEEXX5fkW4B8B8phT29mQFKv7LYiSB1ykwKmAnHjq0fayAokVjR9F0Q6pIayKGm6j08KcOiHVGeRNl9Qdy5jfRdEOqM8cpDwLblzG+i6IdUZ44gj1vIchHSKOaLKnmO7PceZIgyusanAc/BNUCbrwTzCDU/CTFh0PlYvqmfSn9VmewckxQVv7cIvd5NjfrUPRQd732/MkLUFuf2xUxm+KSAeL49Og9BK6LfHo6QN8qX/qlDDZ80csc/2vapHkYc6SZDvoQ1hu45SHgL/Z8BzogYhg6YGlVEBPTkY1Z/pXGg6XEBvz9BMlPjfWQR0oHQzOtJhDXwO9uAgfkYnXtJSbWtcAazf9XA3wnEiQR63hzIVtShZ9paRaorOHvTwtE/loDKtbD/u0pkzaEkU5WTgUaT8RIBMpB1RnvIelyDLuDre9MkGXPo5chEUMuY4jOy+iHVGeOHRDqjPHKQ8C25cxvouiHVGeOII9b9y5jfRdEOqM8cOpl+6SM8cOiHVGeOHREuuNtjfRdEOqM8cOiHeKSCm+i6IdUZ44dEOrZaLR5DnqGAnjh0Q6ozxw6IdKku8MkV6FwPyE5xE/6q8/8RP+qvP/Dbsu1sOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6m2Scrdl7W27pXFiIJRt3SuLEQSjbq50j1o9y2UZIsYmKd0wlEgvcoheA6wAHWTgwIrwp6CSdIRoCBHfSIerarQv222Vl3hPLUt29UgfgiS1jJYhzpnn4J4sedYpbH0b8z1HjePcu0gcQtcMMcw3G6Q9z5RI3K98TUgBEmaTQ7o8TkhpyGY8UALJi9laVYMYP5yi9cEYYS1ZKMBQYCA/t9pTojaDelEUfwzcx20SV28kGbgHW96ZIMu4OwJId8W7+VJTjDue5G/CR/qrz/xE/6ehTh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiGj1S2B27v5nmKO7pXFiIJRt3SuLEQSjbuyfy6j7DnuIsYgQwcsZPu0dkch1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHSUuhh3LmN9F0Q6ozxw6IdUZ44dEOqM8cOmOU4dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44c9s3riULyhmXHU0Ixzf5g1GlAw64Scyl5YW1jYI5MCMSnX0EcYhvLhII2k0oZma7Lk9bNLIqr7Tv4gnG0PGYoVBsAkMTHLF5mTy86QxDD74skhCk+Kh/csGpq0EIEQYFfEE0I4HHlAyFjCwrAgDFCmZBt2d8u0fUbqL5N+CaFHm81RDLVYfIrkZ5sXAAXLiNNdy40kds33kvZ9sMLARXeNl0NNuYr3OuY/lCkhDlAPhXUkBgQqBVAHIP0Gt1j1kK+8U+jF32/2OQgORFB6e9YlUxMb6Loh1Rnjh0Q6ozxw6IdUZ44dEOqM8cDnhc5hY+RSJfMUd3SuLEQSjbulcWIfokCMBWjvxpzsG8IZKRVunxugeQa5tO9B7cu1ijz/xE/6q8/8OHPU65Wz49fvlu9aoIR1Rnjh0Q6ozVSkcjh0Q6ozxw6IdUZqpSOV8I+AVoiqkDKYVqjaLpSVraBpGywV6+e3ZsMy0anRvo9AlpVaEn/WeF5NjCTgAqX2eBuXpx/LQsVyLxGS18gegFWZ0Pr1MQCAcogwLANcCcCwcsGzpULPCvaV0b2G10Iz96AL21zdUjoAVQFmZ2nMojRCx/WoGVhjq1kH4NTmQmEP7GB9UEXgaSSJVYeDPkVOTYDBlbPA3OJ16D8OZrL853xyqaNrBGQGJjfRdEOqM8cN9blRDPrv1f+heTOaLJsgEb+DbNRjr4OsKXBPoXzNfVM1qMhGXdhIicxtphKKyADnu4yHIqSqwBaftQnBaKy7SAOAhP9vxu1b7117TCyNvAF9TuSmbNQlkUFjbArj5Cg/v8sRBsI6J5fOKxy1hWtosngcyKvhJPP28eIqLdAShorSeHYcEBDyaAGL6x1QyrIqlp0KTnuuPHonQpRcAw7lzG+iYA4sKuitYqDU8twE41qBzLIAEgPUTSmgv4rdSBQbh8QN0PySSH4jAI0mZIQtC7Wq9N699GAMNRQBVDh0vTZ7s51OA28OAfLc9lJfUxJ7RglYAfG1biSjX0346x2QmX1imlgw7glRjMoslI1YrWLRex+2OzhadJ1cInQx1lcTKkKcGAOLDQY75k+4Ot8WFdDDuXGBieWV79wBRIVhmVX3aJnemZG714tDvXcD26PPw3aiIt3QEueZJXcmE7X7u/ijJuSAbPqZiKH71vzd+JGkGMNdCBxbd0+r/mIDX1tgRpGHXD4jGSRxzLrSqq5Tflgm0UVGCcrw7HcUwNpwVlAHQeRYllFtOHhyEN0eLgLIICXNyQKWUKyl64d3EAamMP3BIUMqxJrI8eStqOEfuiihjPHDoh1Oe648KIkqPks/PWT+NoagW5CIVvbhaoAwBcLEYRfQEQDmBB5HtL9wnwfWDRVbuzimU0Hj3HYCKxovwFXL3mWd4DIsAEyu3sA6yIYdJM127AvlzAObQ7Kdwc/2JlZHtzOq4VCQMZtTjKduQapPZwBzK1jD+NbzjHvnDxmgfi46VIOdn9in53vqRUlU9/enEo8YHLiCbgmpt6sTAHFhoLKPhkpCfgDJeBLwzkrIuigVAEC+huArTxob8ZAuIFSQnjz0dzXfbDw2eJhfO2UPrV8Zo7QBWBBr9EwqFRekXKVeHIP7h/o7EUYlneimM4l6t5oacWdTqF7m4qZaQ0zASMnBkVVIicO92lWsaEpt96f0L4xPkFgDLJisN5CH4T5v4ikxc0qIn2Ql5t1fn3vBWyL5lDgmsHYNi/N577oQnfsb6Ln6xTSwU30XRDqjPHDohqM0PreFYvixEEo27pXFiIJRt3SuLEQSWv8VN06gKGXXjJ92jsliLGIEMHLFpu57Ut3FHn/iJ/1V5/4if9TzyJzfQRwfRdEOqM8cOiHVrcpBTfRdEOqM8cOiHd0ianZ44dEOqM8cOiJYRFerzOevMChPYDYCKv/Vv9DoWzX+Dyt+BRitoX4fZiBEX60Xpss5Yh1KTnJYIjx4EoU1ajPHKA1yWvpaNBX2U7CW/PrPKQ6Lh5DhVrhrF/ANEJKlDXcXmFi/00VRP681RtRdATdY0D7HgW3Lm19fAdJNgXyuxPWaFMTHELfuI6IdUZ44dEOqM91lNoOTyPbsP1rLbiBH2k0l79Rp4dk5N/M0fNAl6Dioz9Jndthg5ZV3WDllwhNCY+qRf/WB6ooveHdfa9n4DW7e7SgacIzBrItkOxUrbDoltkKQ8n7HldSW3LmSn3kHc3UE3DHzVxnM3KaX+4tTX1exfGkLEPCexcokarBYx0pru2iuR1gFaJdElvYlhCrSrFDxxA2tkFDLLvgnk8a8UVvocTOJPRuAWD4vu+gX6AadpDGCJhOQ+NsmgWV5QGUPaVh1a3KQYiDB5TBRCMNWnAdJCVDyiIJc0cwe8ERTiFv12AFYEt4KJHZUPeIbHPCKUw5zE69jm0n/zYb/qwfmich8s5ebaElv9fG96CEsFn9wFiV9wB4kfuQln2r08K2PeadrzgUga+uVtBmC93UZv2674qDgi7d7n2CRb206V0qOmU/o09Fw49zynKPt6hgWUKg5atcXrByBxHFxatRdTKjoYhF/2iyiEjPHEDa2PY6asEek1AdWiejIaIXHQoYDM3sAEqSczBLXN19Qxx6CUKjaCa46WycD+5NzJy6ziVtDL5YjRWtDd+UCxnxC367KkIWklOQiZfHuondTP4iLip8ypu8h0lMfrwZTlBBwG3LIK3Oq105fDFGbFEYl09FPmRWvjbe2MCdt7ZQGySvt2STx581zCu8KrupAtGzln96/CI6RLh9pxjzE3q4Yo9McCBvAAsQm/r30Gi8MPiQfJddOBLEsibZAmWLgUcaJm18wHwPKnwodLCNwR5zoTdnvyL5AWgjEKfoCYfq/QaKHbyRu1nxR5K0J+Xm1hoUYUu7rybl5cTL8KcOiJYRGU+KPo3Qjnv11RnnfFEgjg+i6IiBh0Q6o60R0NcWG8wOXiwnrOHuKPQJ3FG7K7/VmXTxy8WE9Zw9xR5/4if9PQpw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1RWinUzZrYiCUbd0rixEEo27pWRg3ENZ8nblU9YIe1hJzJIUZsjiw8lS7usjizk4JSEoCX2VEjQ4pnZ3vkdNg7exl7wBeoMrWQBBgEDgdtl6zy9ST/WMhGXWdgRaeh/yRCS1b0ZwtzSYa59w/XgDOQKtr7gPtSM8twAb48ruUkwBhI6q7ox1+zpjZgCAMP4Fm/T3SKBJMI+qiNHMMSsrYyyk9wGuOPbQbxBPoNOkPiiPwNNkPHFgtl74+pG/CC3UEOjN55iju6VxYiCUbd0rioA01vyQpw6Iyov04i8lmW4Oeov04iL0KYmN9F0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM76Qg339bp+xF8WIglG3dK4sRBKNu6VxYiLrm8/8RP+qvP/ET/qrz/xA0MuY30XRDqjPHDoh1Rnp7b2D0k+ZMdTSfTxdpvouiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ4zSiFrzOKbR0XRDqjPHDoh1RY5fALZdf/WG2+4KmvMVTVFJpIi+717PWTsOwe17ilWSMVFcZYJMYU0/wX1NcpysuaZow0eABf22N9F0Q6ozQzWAzFoQGJp3kkJtSux5LfGcaJZgf0JxAZ4mnY6DahaTfacOiHU22f6eRAgBhguic1PzCvj2eGMlMkPbcSJu8Cwav8ytWYYNx4A758PlkqGsvSbM/r3HTB8vbdt0EdOeNsUm5ygTiTkQ6ZkkjKjCMHGknppADNXttBhEeuwY9ZXBMaBzIUZLhk8Mevzu/9IJflHZQq4KsmSKo6uYojM+nTq7sPVO+cjijBWIhfKpU9aVQEU4LkhV70qhKjj4QZFhngS/3oYlY5R8DuJPxnpsgBE8DLiP+nGp2VXH3McYg50VjoWWwXJ4wReCWbwEMZgENYNziWrhbUXPnlXknG5sL9xs0fNqW+LRUYZR8aywDW1MRDcipd407utOkFLjXhWGvH83IvBAviCd1kppdtPqFbpnCT6mPpTCCB1GPtxGnbZDo4GN5EThnmrAnD472RlInynByyHcxZqAgDWalcGQ878empTmHYbFnAwu983ne5wMvWDe5gOTIs2mFIw/GmWBROG9qwNVQglcl6ydZy9WlHsXl6w4X8AkPqcOYkcQMadvEFRnexNpA8SXb1gvmsBdoIQDTRB6reUpylvxfgjQU7z4ViK6+RDpzC9Hg6RKiKer7g6tXuiHhzfOmvkvHNSXK2LTArmSA/Bk4e54eIp6BrZn+UW5xFtes2kuAxIAwEgtrDmIh91SFUTnOon8s9Y/JtmK9GtrL75jRWKdzoMxqVl1pbbuux7EYFJKtvsDy4qbySBBUmcz8Z1NKfMaefHThSkQ3DgajFe1bhZ+fMMXgBa4L0EMxiawuqzA+FfnGmtznKUmLvYN+7sqM9i/TSmD/TgO3piY3zYlH3B1vemSDLu67emSDMRQy5jfRdEOqM8cOiHVGeM0z/P1mbWiyU/mSzERftquaZub3KoR6GIrM08wozqKRi8DCfmHZWNvXcqwdIFEBkAd+ZQXbbPiCNOoKN9blnhAUUgsqYkoal5CL60bQHwK0GKN2QAuIJOBcoNYpjEG0o4iB8iQLS+IorInI4YcKYTp/CTikul51WYzoIhdo+AbX4rjMArvqTu4J5eUDBnEyWYoJSj+wDhI6Wb9jkSpLIW5/hGafNoGDvKKdZpXQdqfDJHSwNRoDzr57ZOUngSno7+iEKfktOWbpF/I6HZpfC1vAZGC0GbXh5HeUBtVk+00dT2uPHCeOROekQS0ZwEVdlvyie4h20UNniwEJS/2mpDB874nVqsY2a3/aZC88h00ALA14p+ygIgr9Gm+fiCJVNNN2OQlUgAmtWdtNcQS6vRIvUQUgKfylEFkIqM7MFgaF16u470bYK2HgwwIOOIyTRvaKMQUGpmbYpFE9h4YyNhaNQtheVdQaC6hhZJwqLsRYZ1AxcHeiabUa2D5zaR+xiAvSZGbfUgcP/3zanTWVVbK/Odf8NjIXjWiKRq+y0K8CibO3Zo3Zr+LlDXvtExgT8kTHy0RnDkixYr9Fm/slKocyfjEOzKMpA/CaYOX2sBoQyy/bJ/8MSqcG8kojjeXB1RnlRT3AvwzW9GcGM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44QWPoh1RnegP8DM54teThXv+dWCYmr8SYCDyc4lrMeUCF/CQBwRlLm1TLWnusNlwaAQtaOVSoGD044F4krjjt/2Kp7LyEKoUBWrDyScgYTLtONYmpAKnnQJPFiFyA4AQe5OR7wreG7+7nXrVQ2AUDUPZ+7BRU/sYSEV8CZUfQykozEDFx844awTXS6TsNohjMuI5rWwoE7syDwioFFfmmlI/l1EEif4d+g1TIwPR+6DwMGfg0lF5LoRVcjCrP0hTgZD9Ldz3kwwGq4vSjiL3Q0PHFXx40jVEyfy1AgwQIwDV7mIauyhAt869Ho0VJCpMdtLvgFRLof7xlcmn5yk8sGU7gjg4KoAVhgphuW11lib7mZCXccn/rGQvRVHlZ8RzdL7yzG8+5hcd+7wCo5RY07UgphBTSyWxGB7hawqxfROjAZHG4lHux8g3zUifllmUiOifKr+IewajK1nokHE8Dq+oPDO886UZ1STMSnVhCTPmfyKabMv9uZE28h19etD86jO9WAfJ/x6efFUaoFaeDyqYBnCjYLDLvR0ENaE7FF0hyJPGc0KJnz88BnxHpM/Bkm+WRF7jssGPvslUFAFfMVhRm7+yBMXrjpMPguH4XF+h6OH3m0gSJbJV189fyizfKo7K7/fbmLmyMWxIfE/2CVkl2Qf+PPRNEkmGwmoupVrywI2BcxiJ24JuoesfHa24fq9yiNkmus6aOQ9OsaHBjPHJkhvFu4D2zUj7ue+ehg0PRxTEwPK7uh3iSXJxg0+ARwLoFFnhYojHLkVA87njmK8ianais4VrMTPyHR/Vk2TcFsjsIIlXbUVuc9BGxx0CI5KfqWVq1XYZBiKB4UJbFOZuKjwTqYoQl5uQSzcRs7wSiApVle9hywyx1Z2muyNmP3M/fVKMVZOqKjzfrFaC6053uRGYiAHYVdogMbMwKj95/bZqYP/tMSldDDuXMb6Loh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoeepMIuxEEo27pXFiIJRt3QER3LoYc/d8zR63wzemwOXiwnrOHdtQcuvCvDWP90Hb6B/wOmQYIBSIeIudZbRHIB9+BLgf/2fdeO9AN5gmxqE5RsGqCQSN0atF00f1ZL/TC7JHXsRoGDjUqQh0J+jIJU5/MwBpvsqanlh/v2Zd3pllT5EkACrozLrvytVa4vnjNchCoezTKsjQ2kYbCiIjQ/ug7ABlrbIuoEw9LaMRxFx+K4sRBKNu6VxYiCSitKJVCoJXty5jfRGWyY3zddMTG+i6IdGO5MgiJUiRxnWg3F4C5VvGzTyw7Z1N6GfBpcHwqtcucy3mUegAROlasI6yAKoeN9DQOg0OCKazDZWV4u3JFS/z+ic6VD8J5PBytsKXruVzjaNd6lNI4B/Sa9o1h+b4LnmFEINWCOdLQu7q4neqttiIG74TcDFSXJbjRzZB553Y+LQtrFNqo/IBnBsZv/l8ROiqUb2Lepu5vNfyhNk+ZkkW+4O+sqmCKuPihT3o6Ta7MZ3zOHD1QhIiBDKki3LNfWgiOrlkt5111G7wBUH4YTrA0peXUcJKKATCMxlFFBMfOaXQKmrpJvck73AMburb7YwM25PacwL2KsmaAw83MqsJzZ5Mo9QUG4gdz9dkAqWKN0Hd8nBrws0jMRaEzFiiFghjCGmcg1/+ZBSV1mILE/fMxrX4qNOO5cxvo9ehI3YxF+U4fCHh7cuY30XRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6OjjhWCW0wYyVnMLHzDACtObogcrbtHUZjgBWnN1zQgBdDD3gdWwdZw4kYpKvwU4dEOqM8cOiHVGeOHRDtEPfwU46STx+oRnjh0Q6ozxw6IdUZ44dEOwYh1R+ZDqt3dQ3sF0THT+XUMuY30XRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8cOiHVGZMZ76JV2B97TsXZ+rtO2ypsz3PRe4MMjE3QfgND7CFClUt0Q2AGlDjaAUAAE50qXatJ90hN7b5VVS84DTboO5cMPE2V+S4FhfEoMTn/zrc5m6/OlIrpBOQOVJfkKkmUOw4AIha8xflUjyo/mFvZPZbZE3nyJ+0HPIOLjMMaO9GeIJSvYMpninOnXd3Go0omClIsIaDgZ4dU2rYaVr5pWwkBCRnjnHxsmCds6AOWYMkF/Lp/i+WIy4SGRmV1DfjD2fPevZ/qrmB5x/uIZNRUg4pZv+PdJjVn7dYg5wDEoeEoiwr1BhAvUr43+pMxQophGJmMajDbnqRZA01Jgl8IUTsT+0zqjURDTTKilEa6E5eFx3v7kb8506Eag+u+JZkuPSJMxxdATTQlrcmeQY/7Ibk65+8J9unwrZqNSM6TxqPhiiVOz25WQgpGbHP2e2KZk2aV20Thjtv4UsMn8fef6cKSP4IXJAc3QpRl/pBKKnvWA9DDFFrb3a4ZJE9iWmrk+md8wHdpubSpflICMs6+ep5jcdeVs6Vs5f72NVzR8CUMueP1CM8cOiHVGeOHv4BQy0sS8ziMUrwo7k8aaw6qduuplVRE+OS47uqrdw8V+U+dM/QQTeXpzAzvIAGwQPBBbWkCxTKNY/BrWjxKmv8lcYAuNc/1LoD8rWYz/ibAG98+lHiwdiWpO4/K1wAWTESwGDgDEev7Sa7594orz2+Z6Qs+lipMAT5ektJbPc3x/ACPlt48hkUDYgBf62afKhlVDZOxIuNIEBjZ9IhKNrYZk4p6acLNpbsLANYoKKGnUFJQkDlbzx1h5JKrY2tXKytD9DoCBTU4a0btuZ5SDc7FHpzYP2YJinL5+yjTmJNAi+apYMzr7oFkjfJOzZnRj/oDylUK9PikcEsb/SFreKmtbR47aPHNWdxG9WyCC0Vm62DcdIrJMXl7J8aWXv0SVDVsYCVlQ7QAyWVS61PJySaPk3i+vZP/qPH57ZYjRgSUD98cZ3j/FUWAdZfxwssRNcQgU6t6YrJ3/ESzo5HE+UbiAMNylFCTln9tEjO6IjzeWxuajWebSS+mrcRpI+pm5VmUUEnR/gDjfRdGHbveQQg4QAzuXMb6Loh1RpEIZm+6IdUZ44dEOipu5RmOAFac3RAVYEOiHVGeOG4g2sjDOqReSzLcGnaWTAfoGtKLHwy6hlzG+Xj5Yvlpzba/F43CXwo9/dTQp+ejB4X6TGrYIr/nN8ZJpmuMo09hH0K3pk/nKoKBSoZvVChx6jdB3LmN3wAvx7uQA5zd8e4MFy2rBbXukugw7PHDoh1YWtklDvDXea2iXxGx7pw/LM/1LXpHow3tdxndTG5cxvouf6HQPE8lqa5PfJOQj5YFOHRDqsNc4yWHH/tXbOEJGeOHREQOWBTh0Q7BiHVGeOHRMdR/un3P9Lx0MO5cxvovfwU4eQDbGN9F0Q6ozxw6JjqA/ZPHDoh1Rnjh0Q6ozxw6HuvC1zMhytu0dRmOAFac3RA5W3aOozHACtObogcrdeHu79hQt3hUPfsQMdJPmQ6ozxw6IdUZ44dEOqND24BTh0Q6ozxw6IdUdaEjPHDoh1Rnjh0Q6qcRP4wjPHDoh1Rnjhz6DEcTqXSvLUy4Ra/oh80lq32W+ybw+6tMdENdTFQRSNaVfbHNHEecna2HIM4b6Loh1RnjgUmNGhICPwTaqIOQ2lYFKeAF3xsAc0F1ZspFtpGphUWKNkxCrg/j5/xPTXoS30XRDqjPHDoh1SrtlR7cuY30XRDophV3iNWFExvouiHVGeOBM1FdzwbbQ//54LdphLzeRPl+v0hta6A30XRDqjPHDoh5ilSZukpdDDuXMb6Ln+xA9TlIzNT/uOy/cuY30XRDQ5KoIjo9VNhH0ZZ2AhBl8MIJNwFitt6O5cxvouiGj5op3uBQYv4csgQFUUIByB6PYquKJPdMboscJP7ysu9ay7z/kDBT0Hty5jfRboawxnOflmNlCo1CVbyhx+46ozxw6IdUZ6hDBtN9F0Q6ozxw6IdUZ44dEOqM8cOiHVGZrYXAbb8gK1Un6ozxw6IdUZ44dDxnOsyZLW4J4OE8EM0QxoMdL7uHRDqjPHDoh1Rn2t57cuY30XRDqjPHAnkG0Vx2RAijlEIX/y5WTJTB29JdEO04dEOqM8cOiGqkQxrveY30XRDqjPHDbWxpgeaAi3vK80s0YIbhwgWki/BG7ZjiE6XAuOjqGXMb6Loh1Rn2t86FKM8cOiHVGeOHRDqjPHDoh1Rnjh0Q6ozxw6IdUZ44dEOqM8ZX0TTEM20/8eBrvTsbeyVzae0BFiIs5HM5eta5LsgwXQw7lzG+i6IeYUD1NseOHRDqjPHDohrlRe/gpw6IdUZ44dEMt/E+48CpeoL0QBdv7GTVD/NpixExAfFXwM+tYYHwHerw4kMe9gNVT9DeUSEgHYqqxQTf9sZhWPtV6p5NC/CF1/W8JooO5cxvojmSZgByrQIRB6l6Loh1RnfNizq5qFQMlhFGkYZ2bu507qgY5KQSRnjh0Q6ozxw3LdJU4/Bh8iBoB019B3LmN9F0Q6Okr4/EhbkClgFg5f3mmMk5SNAu8MNS1cRQRi0mbUxMb6Loh1RsD9DQ8cZ44dEOqM8cOiHVGeOHRDqjPHDoh0VLuodk6CFmCmzkMRpp1+t4w3LUS2lxBFy3T+gxfdCG49dQy4qaCL+f/ZNJapJOBhhyTcmTpQ8ImVUcSPsqjESkzC6/9B1gk2vIrCbSCeTGdzDP9AgTppW6wJHzi+KyUlCe6pHEX6+O9SiCicOi3HZQSVg70MO5c0rAc/t0HcuY4EMApw6Idoh0xynDomOn8uoZcxvouiHVbu6hlzG+iS6FOuK0o26liTqPq+KflvCdjdK4p+TyyVW6fsReo6O9mFHNXi74bA4SyzvwNn3jtaiQByzzLyPSFsyrfADkMm9CSIOE2W9iVgwldv97+bEYNRvbtRvbZwX/DNLmp71q5aEPoDd6n1GsvGjwlrlHrotbtBZGIC1s1i5XXZGG1EhKOmSDMqfUear6ZbpXFiIApXLfMfcQqFTTvWbHYluDnqL9OIvJZluDjl1NUZ44dEOqM8Zi1No7ulY5a2Y8suaTkOqM8cOfBOblEG5SbHW4kIk8OlnF2lAAA/v6SWAACgZJHqfGSCTt7MI/1FApwK9ndQRXou4T65FFFpfYnah766ixNYYlLdZry0VaqcC2DoYPmaoMYDI22UwECV/zzqWhmHT/vBMJ7ek+WoVvzU9vXdFQsLKdSDgWtHP+RheBJa11x46jWA7oS8tnylUwNxDhuOf/HtIgDOm8I3LVEx4h1aCReDBepmoRFT0NeORrp+9aZuE0yNq1z5OFJDyIVoTErYt2N9Natt/yB0ID+Q1V/bVxztzKcvqpY+rJk46qnIsZXGSDPHoM9CYlpO6beyWGS/e3EIYy9wFG1hULoAZ0TLybB6SEFYQF6aIFKWY/kdUmm0QyPITM8aYi4HTnuMVX0CM+fjcZa91JuNYPSDmvtrfq/iR+OqelCcORNAvDU0zwSitjRlrWlEqa1uoa+LfWRs6ZDrNALqBfYZsFDGb3YZlgDEJOJBKmdYvQsk6Y4mkq9hs+wcLcMbosOrM43Ob87EW4ibZvhYDTLVDxsKgA3Fa1soXHEfi3rgHe7Fk3E4YiFurdMcjijsFAjcYIocLgx+CVRl6614u+xMQHXGdEVqwJTZiZufE/l1dkuQgLr2A7Cm8USU4f2jTApqpX2ITEGttt0hAVuB5hKsu9MaPw9B6gz063bLEIoGirIun3DYVbmZkx7NxfWRRDSiB4rpMTfKJjEBqYow2SU+2T3NyESnPcgolD9BZ9Q8ARIsHC40f1LfPk5G18K94HRnt9QzbBQ0i4T27d9rhGiOj2W/gIF2cMpQhoAAAAI1U/4ahahldTao3vfbVk5VVNWvxEEu/EgMlQNmf2Mh0rGfNpQRN6WCjH34tNq9BBDgNbbTThr0U+aqQZ4IYQtoH6BcFZaXWaTW9EcShj0ybmx1mOLz8b2sGH1DsZyDxmr6mUtsxy+1U0T0bu0hxhYhqW+iQTBxlgryKtyelDLjv85I4uOgB9pX1bpDMY+Pf1b5COo76E5qfCN+MjHJjzNMLs4k+56D+6QTRfxLcYHCqu1lFwyGfdRFyfRegB4X6alteKq9jv/BZCHZNJTn/AP/5gvWxONs+UDlE69DRI/Rm/Oqmp5tCz1gFiPAXLfj/VGLZf2WrIIfU8/Xx2Ge/IMp7xNEOgRYEkMnpFsTuf/epDxw3TTLExYGVhPIMhNVsftlNVyD//PqpjfTRbI4HVu6tS2WtK/TsNR+cWxWoquFD1X9sVbyx0Pzgm4A+NwI5yQv53BG3+9ZNxZx7llopAHMCNdUn5W8NTQzzIzwBiWrIKXwJZbRDLI6hqMH8UQ+Beis2kC4lPMt7dEKzWF2NQ1OEQgKZhqd9jHDr2EDg7EbdWqHVYR26Tx1SgSetTzcXmj03ZMxL3d3BWjxHfUdymx+fuCx7ooSSMh4nDDO5zQTzYU0Dr0TTbqZfPP0judj8002c0c41NGdQG0ipezSSNIra2kb+LvpIxzPQZ/w5/0rf1QNkjEiTqJX2f1VXaOoHo7QYmnMMXF6jU9nl2CcdgBmSejGmAtII6raJtVbBIWztjt6hOI4kcdH+YitwFgt11trwJ8mGYozSqOdYcwf7WIUrxIaFEfQ2+yBmdpqjeCrcdvwZdn7DnjK5VvvlpeHM0Oe5sNd9xfdxMq4JTpFXZWF/7QJx+17WAWVARKhYjxtmi20j76d5MIi63+KkyKc+zQv+B9U5p2Lf/N3OPG2rPTXFMNVcBKfubOiXaSIfzzZG9rY4Wq2Aq3NEqkE2kG8Ty4oXZCu6+k5ZSFW8fnwbYpnOOlHDgxVYQMrIJhhOJ7MkOm2f5LlHXnVmiAoTfendKFRRkpR20mDSWjN+B4+3nxvISUnaTo2ky2BdRviNfxbC70NHuq6ukD1W3G8AubnD+O+8/BelweFKr37VDJH7IV58NYSqlBOG0f7RGQ1Ep1H0c3NIGFMHlBeimZOGAQ017IpQ4IeLU8RLTIoP09Wezi0Omi2JZUA21/85NF0okAZWfzTLET4Zl1CnALUszOtrAXQr8F5oJV0PLgXxfbizT0gqJmDskOpuFQzoADyUGxatZgE1EVYGXX7a9Iu8wfjnFE/sVCLhF7rcQc8mS8JDWAGVLuIF4jjpGd5741lWg7/fnYHpgENAI/Db+2Vk1iGCb3zk3uQzdLszSGWWYN3y+DsegdES+AMYsDZj09G8mFKx86vzXnSBDICWSkPkl2z8Go20llQFjux/kNMpGQ27W7TFlPE09FO7OpEIqNBfO+K5XGvnNnOh7UC/DZIWP3rVfLbkKIknQAk6gtspfyXLJwxffHQTUEoUtuoGeAdTA6LW9fVbuuwCLbE/c0dFP7rG6hqnmsWgiZJYJhRSKC0cDHX9V/Dh/h23RxR/jjRxaKhbq+SjRulGQbJ6dTjugaYN2tAmMUuyZHXWKenDY9Amf54ws7+aG2tTrLoVVzqVZXgrXjzGeL96+TpteZHVoDJv8HHKN+p6COyToWmSWQ7Yml+UilA7yqY4jS4LJ7N3qGBpeAplxfTYqe2ZhmJ8gzIvTuG8EXYol8zZYxl9oepH9Gfy9YMSrZ9g0Ik7FN6qZHoZPMKWOSjodBxAbVkEVcVrsQCfCdu7eKQJcLOUxyMMPB2QUf4aK48mktHsZrHScYRixbpd9+eVTVmp2Gur5ZT2niackG3A5fhn2lKCPiE848BoVPZvRg6tWrYWdetMin8Z19Vu67AdE9hNUp8sogD363vX70voS+O+uE9LzbbHQdlYU+89nPBPOCGXoJLGZ2tVDS0QBR+lXdBSslph2mIvhDnXOqW1+R1prVf9fmFJwlCbX0x4MrgMIwZkGRsVD2Iv0b49hyKzLOU8ewSfiQeLopmSZKNT8NYC0Wg+CrDeySTvEtq1L5YtfadsE0peIL2jgv1iAaEyaPjeX7kIEEOiY99zgXxg1aVhJWNpsA4eoRy1lkzvcmXLKiM8d1hMS9L8c/EQvyjVhDKeA/gm7ogoI51woI43SuemYdaCLsLXaKKEZMxWixKqLLaszLKPlH/FgseLk5r8olSTqlxNRU0w+YLXKlL2qgNB5YBnkr+zvFGrPw0uPBpHQJ1UxHqZSoOTCbBmlZDEwTBAVaARsrAr+oV/6QGCcVUVu3p5l7oWWprJcs8KCB8WgavYOZkxPhjPHYVXpR/aslRim1Iu0AY4KalOdmYVPXjbw7Q/mWNoAUp5zBCvoDMYwy11Ofsia/p5pm9ogBd1fvmKjWARdPgR98YxmZLHi8n2NgAYhPl0cEGfsUrGCo7FULTQ1GOZ3WTZiEnpBNRL0jsSNcRz8dmXLNd/IrBsRonKUKKBxdOwhsJuwjoagxCH81opbndjAgMZdVXEqpulFyfNvZOYjl200UgHNK4dzMUgQY4MfTB8QdGHgYIwAnH1dis+XhafIcu5hLNP7tiWCC992fOyYA+TK91rLghk1zWC0zOQFJ45jC4dYfEkhRZuABXyrkqIiGh5VUMiW68xhM+0wDHNt+7KhNFGmD4Zwz1Co9FljmIQ3jF9Iyf+mREaJ2ienJlixl2it8GmhFjXMZpg4JWEyOx27zuALT/1qlBxHmWFA2RHhranb0B+n00s8IVbCFPYOmrSAqhG1+naDztliBAyDkdeCIwN+QmouQ87ELZKBVQX/hhxGz3aS0GHCG0qUUT1vLDNu3A1a0hDlD4L4VjfE51BWKt8URI3N75O+Ptf4IMxdZR0wiY6ekIawWg0Vvxabv/V/O/uH+C66Fm0+pbFaRd3ruxKpTGLjzNZBGaUuKlruowq7nNNOJKJxaeFsBszb9034KgbT1+Kt4a0brBn63xbmZWACZipGIbkUlWLb2QavwQmq3YVP1TUozn2uW5sBgJGvMa+bEMSKD1Jye4C4w49HAURkitHhg0NkBfPNlg37Mw89SndfjZ+JuCraUa6Ah6GYJyTf8AL+SiXHhjTdzSQPQhWumU26ro1rXO1FIME0RjdkD1tizCVQ7ZS7X6HZEM+KJxbEXR4boVscVvOI1PioXkQI+L4PglF60qLSZ6EpIT4IVL4Pva/2Y/mafQUKho1bfGpOjaNEMQzElM8Lk6zuF2gKtqJ5m5vbcHofTYtDqYMxQFMuWcoa6V8nsgb7ExcFXbLL6FJobtcaSoEMWhDI6A0UX2+Y4qnTW2WMbtf+sLCPfHaEZXGlVvFpBE4qYCpDU3lSK8AguhKFdEjfSyNRrdB3h0EARf1x3dq/sCz72TEeByUOECmF52kXZfUsbarVMMDosBXGpsMRjYNvOxM5pcilNRACGbzRyQl3tI6JigdhOqCGNJXbQn1MruKfEn4pJ7CdYEgGdts11mgtFDZrH69K2Q+DY2ac0Lz4J319Ms9WtuT+52Tyy1NIiq351+uvLTkLLazOMt0kBeIzpUfBg+PN7P4sUBXydYE5RghzUmk/lDEahljD3CbrCj3Gx81ToxrtCe+g6hZMqnvgADg6BOEdsixYgG9WZb9CTA4ugHn2OzhOPjWWh0EQkoc34p66T3W+jLlg1LI0F0UCoimB9X2tRtfel4bTIzIeBqCWF8rHGLZ7V0nrmnd8zkN3aZOHHuiyqQL5HkTXM1caiYXorG9VV/EpgnH5OmnNHEMP4fKBYFFJFhX/oTj1C3ZGRZMZaRE4q3RXRLKe7mKPcH4A1ysNbGIc0QlI8U2Z6erBgUEESp5Bs8+6lAbTeTDUICDYIApVQgAA5HmIElrbXZR+r1+Kd/5lOQ5AS7d1U3al+Vunf2+uA5n5emrWk1Jx3MpwqDY+HZDBhQduguXweQnhylQEeyfOqYteBdq7nvOU+sLrUB5z5Pk0lT0n4IJnQaodHZH/L2RamoA0WPWd0hOn0a6pB1tUG4LG2QiDehkO43NTH55IyBIl0YHefIqsHjIhGvOUAhDd2t5kgWxTY/BojNdEEkT24KMCpr7xxdBtLICQZr/lz5wvogAEWvR71hRb3p+Y+GFYUqgpxeUChAAlkCyVSgQ74UBORuHo39ZX80KGjfE+dkgANEATcmsbnlVwxnk0dI8B6DRtaZvQ48KZakMtR6vVwRB9DUtQmOD2K9gqxPziSbzpy8EtxRouJCFHOrWNxKnAyFA2px0+y3IdqNYt7zvzN6HHhTLUhlqPWB5BFoJA77OkqBVqSmDf1BOD5DE0TBQWzb8ZxrA4AKX9UF4W33CoAjl7qaynmA3iHWTQ0iKxKOzL7Cnho2SA2BNV/Y2JggDXCM42pforexbKbJC/TdNsex7CWNrVcwAjWgsfwh6CuFVy9gi42lHkSwR6m4EAGMDPra7SPU44a58MnjdflKliNdwlXlj3D7Cq+zoHJwnvT3gWKfWcUO80EAJPJOdesKYWtazJhLIK0Lzk6UObo5+sc2qk9nrgzYK5XpJhZY271LdkruDwR/LhfDnjFBn6Xz9A/XSHl+pHz+10smgDh6jCT9fbL/9Ybp2XLrHlJ15aOVPF9vxCzPHQ6bHo9pEPF2iJxC8gsH6UTWofTuSLyxd4ikrERkX+kqqaq8PEqyGEy/HCy6z8nmCzXOdWEhxY37NHVzpyXoknWLBYfsEepuBa4oWN6X36VW+W301ZujvmsB40SQiXZwwO4gQCS5ONzrCaoQTivNtaCl7MeA0Fo4WFQxk70FPizISm5E6NKxEkzz/yWcjfwGWZMZxpVbLNVqDkdAWhc7E8U2jlmplWgXPEKIqt7JRDUePx/XOK/QRl91BwYzdkTmSG6Gpx84ebPzph0Pw28CgznpUIA4EFhfRlC3C2SM8iPC/OdD5vSaNbx2pRH9R7utK3cD+NwB4DQeA01l0VqITr+Qz2C4niTiFnGk01yRgnndMkG0iNoOULr0b0IVCBq6cVkBf7QKVbpcpblp5XEXVZRR7BdmTavWVyF3FDuCE3tcNm/orr79R2K+mYlEVw2Y0w5ki+ZPw1q3l7BYmxKZq2s2lQcFsWxQB0QFKk4vE+W0f5K/QWSmJW+8VZi7uPIKWF7uuP2w+Ym5iq+g8zoRL4HLc7gguJmC46TIs+RYpKOZ0gwBoaizb6EumsjZ9HGojKSIJqi2TX38RBM9x9zKByo82CG0ZZi1NUrWAHWwqGH2W8Zd71rVs3nqd4+0DowtTUFb2M0d0wMVcB9nW1bWpgQbi+nCXrGWew0B4wv+g/ACsnMfdO2U06968dYlYTDfvye+jYrUWkcK1SxRI3HoW1vcCYrOb/jCaW/qpxpCsOTOjXZsnW9NDhaQU9Khag4wRBuMmmuNwO0mm5uyIszkdrr5e9KNoEYdgHithXsLlwnNeKgLZ1gpm+e5w1ZLg49pj2YdYeGP++NK2QPwbxNZAV8HigRrq1azpjIKtop91MgNq498+2oKqUnTnYZf647Q6/TWnj3Xtxp8QGrDOxmCuJ+xcSBrLtXY8IksWJNj865suKFjefAP9g1EuAd50tqfeW7yxVttsbNJmT2dXDM9qkG8+lrLfysJMHZNuQFe7+47p7TOD10ledTri0LBi49opG6xg2EtlGCE3DyK42zBOq9rDdJ+QlHGVqfZ08OG7HAzZYEUk9lijybjzQeBMwT8J13H1O7KjartlccSPjPIZHDXPhk7x9hxKypXHlr6AyJlfS+ZkJU9llcehGOcRXtyS3QkgZaXWS34g9C9amXk8EXEhzSCgtMB7p22qx1h655q9o3AeBYAdQhBLzILdW7NVN5UF2io/vNJtlDj5Nssyl9RdvaFSlU8b+0HUW9ZkVj/8vz4c0isDOW+6NmvXhnjwTzi58vF8XN4IZrH6+AzSj+1SjZ3nIM+c7LEzXs/v+JwFzAL2Nb3fqKxbM/aruHkPp3WrioJ3GCz1fMB40iIfp9T74msE2N+YJinOIy6j7WxVwbDIFEPYaRldFQJt9NHSkgf8zW2ymnTlTLniDmHdr1W2lIBjc5dvS2tngssQEaqoDYGtS2P1NQiBEmOounjdiBas+kHPJZNlC/Dy46Zc6c0lR4T/wyUgQ5jJoQSBI2PN6cSmmDTdzgvwsn8UamvXhnjsqzagYQOl0w+EOv7/dcEx43uW59L4z6PWYTuyIUWkb4JaXPQtnejWvCUP4Wv7iduUF/1YpCCxU1axjUkn3GBm9yvolsa5IKYx9hSGJyxp3p4ddYh9ZUWO+pfQAQQFva/oPKXNrYGEp8eWaButR02QfEXrwSnJ3fGAPOHh1UZJU3s3gCurvE2Q8D6teN3LfOLbFlRnHCfDYrACambFqwrcD7td+9/NqWfLc7ffZcL6L2WL3he5Hhfgv1q2Ljxcnn5R3+MeRZrjfb+kRguepjqtHs+6RBa+5QVn3Fsal1+uZqfB6lbuH8uU9GPLAN//Kog461YBmz3e6yzNmwdDeSmylu8wEUjwrsEKGRP5ByVe1mzmpgOU5O943KXjo66DJFmRFwN6viDtyykWC5QbwUjOJCLjUJUzC/JGzCMBSRBMGKk5u3bEF6ISsxfbbKbysoAxttu+n4VYQqd6k+pY6ILjR8uxWN6PLAXuWpsBaLeiWFrRe/ePegiAlHAfQiz+jwZ6Nt22CTylPScpiwmvM5p+kNPC8xtoelqELcUb9J2+VXlS8yCb/kTw/3G2UbIKu1Z410qRBSpPnkj72YIRkOl52vlVvwUVhg7HQtYh5+7JUuCm8gspwYn87PdwkU9eNKUU7ew9hWEk2cb/ci4DDTOwefvWHSueDAD+3RRi09LKUWaJ5pATae+l3hZMvCtiL/tUyUq867zIc4EpyjpOlqGxLVxPVuahPl+D35kPhxzWz94kTJMc42sdN1yi5i8u533zeujMB1wxgVpPMe52E1MIEnJdr+UuPvI/M1MWrOwGjXQyoSeAA+D6xyXxfMeToap2gFUwataZ1wqUu98kJnjWXtYdmgN1pladuPb1cc5oN24DyvNxiZRqE3X5t+uiQy+4BY881FFUP6+owGiOf19hRhwUvRSqBnjvgzx3wZvZ7W+PD0z4odMzsu98WCHIT63cKvY2sajezJHyLDvmLgOWCkr9K9KmzmIjt4Vx/GEg2fwqDZpImQaEli06Asx3kqPItlznbgvaPAP69qBsoV+s6NLIp6Tr9S2xg/A6NREH2nZf/Zc0wYghyE69gQLQgJ3d9wty9UoTTKD68fMncK5uoxMPZXwE9cDVEewyA8PYEC3v2mG7AWCsPp6NkcEFN1aF+hJLec7cnK3sl66b6JCUSGiqB17r609K0EQxoqBbF9SUMxRhEi356fLaW/w4Lf9LQBuaXOdmrTN3LS6y/Nrm9wrwmMudYubLYRHph/hQk8w9Iu+60kj8QtoQmhQAAI2oLlO9zXGkQJc+gAqpbTabT1YcokQ9r8DCeb8fzoBdwpyPt3cZQSoQm8DeC6NuGxzSXJyvNeVu7nY5Yg6UeDQkDUJVzbOipzWxpy4+K7W+Q7ZhfRleEYx2mFUITeBvBdWKet0K+5vxGAnS1Q87+twEJ/gsilnBj7SZh+OZYuWbLGgV6JZ9nNdCrOjdVi1UnNpT7JzyRavI0zFc5mmrYQHDl7l0q1ru5BS/1bXMooCzuvDUWwOXxMN7DJsrlB5+bXPKj6GNFTvZbja8y2eEf9YYehUjo36UySIzg9ZNKDP0ZMkBahI63nlRj0UAREE3c4rgFzVUMqsFJsZzWa8CMQfGowI+NbTquZhZPUG++ugdYaL+lgz6eFtf8VhxgYHiMsibC+hcQ+v0A3Lgv862XnVkJmuCxF7LkC9TUKseMdY24Xz8Pz+gtYYdwC3IR98COhabCD+UHoniylSoLlO9zXNd09FjlAefZSiik2NAfPMAd2pIAJKkegISZkJONjEXh5xr3+iCOAkM5QO9m71q6HSIsJhqIJdSw4bxgIw6QyKpGLycuqPNBkSiNqWq5q71Ga0Uaz1tv7OGuWXJ2fC6UGk2b6B18Ftu74yYsGNn3ELOVvnc118BMZcRSehXOoNvrG9vTss8DZzFE7M2RofZWlfhnr0gzkioOllJr5hdEQDkVfWMTf5nG7zmfVQaIdhQXtXNEaZGfvjt+oRA3yKJp8x6mDRJhg0zJrJ0hvCYCVe6kVaS+Vp27Il8hHgcxCrVxa/daZ7rUinbUee5KmaJe223Z74IfFTrAIVJVAuyMVPefGWGqiTIhla9aGF1JZgCbreYks95c8K/UhXPs75cDNrUCzJI3vXcg07nXEhlNK2la/Hct+S5n8u4MT4TF4iWeCQrpd7uE0gb1jKydExygtpPrTme4jvyFk9ylpidba/cWk89qP/s9S5DaybceusQr/KX2YFIZl2YfUJVGcAgKLsflmiWo9hQoy75ckRM2PCsU/SxeN8dtgd9YQbYbBbbHtgx4ApAAlz+0RIX9U9Jv2i027t9N335OkyFXsoWbvP0k+K3MeDtSi57K06Io1Wmpbl5C8LRg2WegaTUTD4++LiWnhEdq7xwzot/tby62Cs5/NA5n6tW6Y14dlo2HdWcls19I+w64x28z9NXGJpt4DErzHZQ/hVUfzY2hRSjgjW5s7ApZxaVEDYZe5WVP9Zy154LfiIgTsgBCzawT4X5Ckwag8qZjPT//Whqx7Kw7+ya8F6kPibTVQ/SzmpIxBwoX+glxfTXp8Rs/0t/WXTy4OqMYskd6KSB/w3unfi2NmYvSR/g8UECiDTFTObZOA4Wc0a1oR0qeH0piE2KeCb3Chbi3YJW5jwJbOCo01bB9HxP3iSdUwsmVfsjGg9fEt6+FSkV0YYMf0fMWmdQZYr3m1AnQ7eENvzCeABLMqEJzIh0fGUYpb3IUqEfgSxwzaFHzPGhxbe+/AxCiRTgp07emp6hMFeZarV/BUdf37kvqaLrDmJuY1+YaOlb4ducT41csREMFjdw7/XhlQW1Dm1EeJ30NgOOG1CpNwVRsWMqzMETCq57xtzJEuu7ApwAJFiQwGN8G9iTqloJFh6Tb5Wv9axCBiuo/Uls5pAF6duXPV+1YmkD9Pd5TOhiLFKAfvTk4QNR9uYwfMvYaH74xczoGNMA8dlergxMqUUbIFnL14apVsX1yd//9euhiJlpICJzdLjClPXWCeCLm3bR+NhspbvIrdaTKSw/ZXKcwtcpL/lTVwovUvXn1+FowswW5R82AkVOdgXRiJ8SjSEWDJcbemFA1WOAR1fy8IomuhgTrSD4HK4UmAGLxHKiu4QujxNVJ2oGcVR9sWgGYe96sKITQWFGY/Tj+UmaCsEOA79Q/V2kN4pa8QvkdhHabHmHZBc1LKzZN/E1dfRF67itePKYLbW/S0OpMKuBpwXp16EWBxD0euj6/mH8BmLXiHpkoLXn4hV+EckRYqc2GLNNMZHGQitPFYdFUDSI09Fe353GAnzyFAKgkF6+qP4pY6Cb84p9RNIbcUK3H7Hvvb+hUTM/s5+tNBoXsEQWB1SqYuJtdMP6c9lCo92tESvRwsW9LJh0kv813RE8XqiaXCb84k0WHMg8HcIBAyTnDd0Vy2CC3Dj2yo1VWzT8Hx5hKHv4h7F6dVGG9Sy7/gWv4NLgPdsNBorX2XHitABqBZMmbPETIPkUnYnNqb4y+AaxHZc+/7c60FaQVz4VS01MbafXrRcYmEoTEGSRfljOtoqcwbEfMtFV4rpfalAZhFVn7b5NXHim1WMFPqJFvDW7PVpB8MciKa8F6kPia2HVfUNh+tHbOLnvrodP0aloOg1TBt5oNMkI3B5qL5opJ74EkfTQxKyD6dmg0q+mYp9vUoG/NhVnT4YuChANkMXQhTP1WHPD5yUnKwQTHsJGINcqqZ6+ietq4VsbVte71YafOYUak8xEHSqOYjKYClpSef69ayKDBNKEgW3IWjW2NTPtpsABySYYmrAf2/tmSLbEVHD5DRSOT2tXGsUKfetad3h6gTDh9XPOuqee9CR7ibl+mcZORMxk2XU3ypSuAVljWVYCeUl3SfYZLXWcogiYbK5mIxx7dX+/NcRWySoTOUWOQa6KgEjWj9XVJufcdFhrtsyxxUWnN+j0MhUa3/nDC4W00qH8FC7i7Q6UNaKGfXeYIv5RoOtDAo/BZh11w647I/QtpdHYO7WFn37WsiAPoe25afIda2anlZW7hZaTShCO19ZgejXHGNm4rY8PwqA+zTlqwcMiYAjDTEy678S+69QAAABvUu4XlzyuE8F3iVovoezHLTGmyrArMIX6NrcFWbrItdGHy+M8OaHOFOvZV5b+ichmpaLHD05n/au2O0fkYDj9x+MZKR04ljaBlSlzkDV2ctuV6njW1JIK0Xs1W/9aH04wAMWdnCp4SOFcQciTZd9VCUuF/66V9d57bphHEFhEW3zdwROetCWg7JsnwMpJouYevvhyDzdiVBti5qhxVH3DOgyaTgOyS5wbh0KOydHzt2vH5uzP/L0WVo6U1ca8cTg82QKg06rTqKzSF/VEK6Sa4j321/zecU2P6QiAM/l/ZKOK2allJq6iOi0glcRWfz6ydWhHZXk0o+dcdA4F19hxJxKZdWmXb6/8nualzjUUufoMlaCUqq0EPIPowaw5vZrq/Nvk/tcRIA92qd/BbzUNN6Jb/MWnx6m/TMirLJLXUtV350ZIUmOLDr8UDikwIh3EC3hfaa6XsvbIfeOSW6XtW3VnXusi/d9r/zN5hEqS3DTjDFen9mPqeufQ9ywg+zSXY4gWOChZRdRvRdKKQu1OepV8D+WzuTG+YwdeYf5QAoqdlevy2oPf47lpPvgCClKL1C0BNrUzW0ZiazTCYqJ04KTE9WljduMa86aOjYYcQ/roLvrSw86R92lGHDoSycVaGNRovIzTt8vlDQSl1luiPmMHxoPRF1fVrcq15KxXv7jcZ0Pil1XejOhGy7OxKC/tAPhp80dDcl3JZ1+ZjiD39SRQFRKwO/nM0T7C1dlIgKP9c+zfbc1dv1SqifwhVQ04u88OFaSljz/rRnQBXn3YivygNcEHdVCroEucQUSHuONpRj5gH7/OF6Rrj4TZWsUelhKujKQnRX/kIJ6wvpAf0OT6+G5n2QpA5HEBL3/uiSDVVVCeEA6T2aSARTh4sOTeHFS/59BRSV7KrCjPqPRgz8nD7UCEpmc/ExyhiHvFwW7AlEXizOIKJDARvhLND24rHBL3nJ9+4lpHjZ/wsUMG7pRQS+Ixq+djYs4eZyWJ4Z7uTdyMh7hQoSxqOSSwV2SGQ1dQIZ/kU4f2RxOU2GvQsTealSy+D27J2y15zq9jIqPFEhypOs97NEgGrzR8PPcquZcmmzXO539d2SWVvZ7r6Ve4eSaNq9F/P7G2VuR7r+zPKNcsioLZiryekx4Mpb8NnieU7eS/jKOrQi7oqxlxO3gASvJOadwzVAD7TV43JBdXApCNtVO4MZ/4LL1Rqvgt4Nn0w5FVsFNiNnitMOx+Ju/OsP477MAAAAAAAAIAwHgryH4SFx5D8/9HcO8BfEN0hQfhkjcs52Yb5xpxoeanYEtabxbZzPgT/6pKmVpC1agGc2miJ0dB0b7RUyxzZXxZLsnj4DOYrVqroXeeyU3XiFNZa8NBZATgJaotVWNftmW3CM0bsyExysKwcUbmhx7QEN4E4bouaN/JQws6T4Dc2So2u6iOmYcvWJItkxNss71mxTEzaElJhcTdnyCCdPB7U2iECFtIW+h37G/ZMbqwXwe1sLNsNZkFBpA8lAyPo/92eNE/gFesLfGYLoBh18pmOUgYHdNmyyxEACiQTFc/1DLHBJ4IvNsGAkfQ75YFQ/ix0IECGvocuQGGflLAGWTT8uGDoc9Zo+4it9xkQdeFgnfoyOGMlFf39UIA15//+g3A2hwH5urOwMqD+wk997KS4c1/4SBArZZrL23+K/6CE0n7dOC/4iJFMmdgvwF8gvVG+rOOby7+fJ7m/iSb1mf4G08xW44nrskbdX3k+iWy3YUmPAKzxd35s9zd3rwPCslNqjL5YEn4YJU66jpGbf7XjzcLFSl2sl0Y5v7hEcz9H5VY93XfdkQ7xlD+kX9ed+y7nIm4Ei7lfMJ0oIUAyid0kSZ4mM59Ghh7/NjWhRpVVlz1RVCp9M3sIHBqIO8ORS3f1GV3Pa+Tn0FVBQFIwmr9Bqmrx+rtVV+kz51BmQDRIh6RY++GKOx06eF757o7Dlhz/Zn3Gnn0fn26sFBu7ERZSxyqoecz1wcNwWaz75GTdXJ2ZGb6zW7IWBgk88oakZuPV64ji+jfSMzXjE/lTway3eKSsRB0kNcGJcY5Qw0j2eSpg+FGqSJT0Psk3HElOv6beru6ofRHluIYmV1wFHtqmy3RlnshvRAHJPhRfuFrbqtcR1Lk5MI+FBFHoY2NgGPTABc9JrB0x8wyOXs5Xa7COVIWgt3lHahoZZS7acX7cMVeARLsgHjhGhQ3ZbnTrUtd7tWv8zYSBxX3wLavCewVKuXEF2bz9oxV2lING7p0R8WtOdiqvMG9SEcEun21UumWJ9P8BPGU8DaQfAF2Vd2EbHzKxj2Baxb+fclo9o1j/Ab8crl61LnZmVBWVE+WSRGu53R5GWBmRv+Cgt6NkCr99rCkYW7/eGEGGXQRSAVTp7G8KrKsDCXFxr+vocayU0W/EhFOePq9kTBuBYLHVZfQbu/1SoJ48z9hUfUQO3CjOJRxCfGcxG8ikTc/4Ot2vzX9G9+85L7+3ZRK4urbXCHJoIFeBQe5/hGcKrgHlM5jxzFb9TF2MjjrQyWo+R2aCD1jdib6w1qANhcy6CjM5jE5r69cEnB2Ml2fuxLlsren55hC+6gaom+NA1JmzjY8OiWCgM1IxGkIOaOdhSKZneLLG7KEdhyzqtpR+A0DaYhKF9F/FdY54N8U18rJOBrYmxux3eNr7MLkJa0G66wvytcrZ1nOGYeXeIiGieAFf4uhLR26DTVgWSyx6mSFtE+sQ3nYoET18l72ZWoFUv5ktLzaAa6ObEIqcOraBoD06ZTYJKhK98osSYh3EiQq3B9OK1icdXS8K3SXRH7QrfCWwEpOz3hCJtK9lD68lfcEHoJSQVw+y6ZQB6L0plFOKSjNFmddqKzCdhLlzGxtLb2ByUeqERFZ5ytv/gUrID1uY/g4M2HaL3p0YNth530ITfVyQ/H2GJcWKweZA/1gWdzz1L5U0VEb/amdsm5EE9+mCvrCLLH2Z7uXkIVj9nnxUP12B5VZ0mCIE4cBsOrlmgP5KYC99FizBXGxa+iGUvakOTas7basSnATJNqetrT9QE56gJBzz8LEXzaen11v5hXXPqfQWj2w+tmHfZC5Joczl4QJEeXTj6W0kLxFg/83fNEuDf2DnmgHolnB/kkZKsTYTElWtZBe5auzYob17UhVgX8piPOOTxUddUcSAo4xA4JWrJRIwGpafGJD/B3BpbnWo7NjK8dPLRw1WWzoWmvdxa12fEKCeBpXDRpZeZVSqfA3hmWS6HxgF8DzPM/R+UWcMwYaczeHk3uaZAxxvj0V9Cb2PQzmQPhtAYNgucsOeOdekC6WX5YgmAdpbyjbRFjnTeDpqCBGmGFuDMmlVj+RRY83Qoi9K3+s6TJ2Cj6l7r4BFZDzEQ4xpP4P0Qv29TFMlESINlkMI2WT9e6dui7ifeDiDRbd1QRSpXAWNM1V8FhWdu2SYHVVR1IQVbJXJw9LZlHZlNRpqketaxokKLOiHh54P6cV6nYaA3fg8tQOkVSzoBuDvnUmJBSm3ys/xjIMEEwgsI9XRwsP9DHiUqPm9QByRo3VArujRUIXUI+/jDi+CNiX6GjXGTMIxuFsVdDY5ofCsys87bI4tqCnxz1Q0zFeCfV8zKWFC51wkgJX+CeFS96fpR6GQjHYhEvCDmY/f8ykpQGfaTcBNiMnR0WXvRrnNB0cgnAkgotv1Lxzfu1QI54QNNCuDHJzq5GelNwhRDbGCjospsT1UDOJJTNXSkv+QLjMaRLgFYvRYiKpVd+AwAbbcU4MxWtFwHOAg72JjNPELB4Joor8Rpu0Sd4n3qHWflAZGJ/DtOzPJqGPKbhj9118gRx8s/LqT9M8c9hPafZY5SsYgIb+6FC4MZpHnUDM4H0dPkd5g3t8AMivG5grChIgxs6ZozvJQanDz0Ai9EZwUDcOD1UHl4XG+s+QUtSvUdMfxI93JFcAU997RRMblFPGEYrBoUn6KecsaVo4G/fJJUjGyZPkdtxsnll4YGTk74S4WItND0PdSGKyGTWPaYS4FL26ruDZ735lCJLepTU+5st253Ya+TsDx16Mdz408q6c4mnWeFUVp0aAT5w6wx5B/ctk/2b1T8Gl7vwmbQEObg1bDiCp93AcJo/NvnbqL6MS7V4cS4c2VNHcUVW9fDljaoebQHjYtPwR4kTvFXXud3/WcKAgtlUBHp4AjYhK8Kluz44hAiWGb8lwoW8vG2ySlyjz2vWX1w4BK2PEhhWunooAO47wIAAAAAAACuxPAXQ46ITLhDkHAAAH0ksMnvakHb8EPWySoCUkr2LHKVJwHc+YwGJixjcRFstNcmu19095V0JduF8HWZiAEphECXHYpXr4ST71O4+nRS7lkZIjmh4y6Q1VPMoRO9t7DYiu4YklyAcmkzKIK4l8MelRO64bNHndUHgj0/DVGJwODrX2gkhIzFHzRi4YLdjTJEoKeDPKSXhIWParsDQHxSZehMcsnC4lBJNawKdcXe4IEV+OPDBNnjYijKDp3eKVeqnU8bEwrwhe93blgNLyQtAT76Bp88OjACmOW1YWjjesY9q4PIJhp3CEk3gbSeC9srJtZ7cjo8mkICHxy1J1Bla5bvkTi5i5y83MMkJMXYjT++o9c25aWig12yhq8CPMuYY+8ynE8w/T8/hNYQeZ5nhvH7HG5EsisvbIxrY3MnjsawVgKLaXuh7WVsXLHAw6Zbl+Lr3k6yEzOBpjlRRctb5linBy4gQ1Bq84HyXJrktQABpwZRNcxM3sSFoLWVyC4y0Ra1pvBCA7O+k14GdhgoqsXpQKLBtBhnf6eGSuii5t1J3h5Jif3VVxKx6IGYMmD/6e5PQYzgyT0iTPwXlNLCRXa9+JbOrcTG/y5JTl/XQnzlc9BRW5gRGRsdtl/Z9taaBabiCdG1H++MKPpEdIRVt7U+bUzftbqcTx/So+qUA+wIoqpR68fjZSlqsrKfQWsplr11qSYgqPaa/0TX5slgz4IHYZ9eV4ESk+SusRb7BZPPPyMJJjsYO+6kXoT6BhH5COImsrwVrx6L8enwz8lTjcqS7Lxz6HSq8TDndXzsQfCvLSwWL+tFOzg6rSHBaFpgg3wQBgrr3361LeB4iZSZ4GN0apFpFIjzCBEon1agdk1HfLjQ6mVTm1BAnt/BCJngCCV+BBO2ZJkKKi0JzL4ODK1J8s2MCY2sAkS6JAvFfKD0iANVionX3dlkEKl4h1wPA4Vb/uANIf/kuefYoX2hR6aDn86jhOk4NCfk1kYulIqrUsi+qIavf30tJnb4TXxPahIqzfkj0nMqAvGjdUMSOuqoEixsSpj25ZkboDe41wXAMBTL8RbS8t+dVZml6ZyD83IU+smEJGWvtxscW3EVc2gVfeFZLX5dA8FF0pzyrzBh+hgCNJb7YkBzjjABnarlqWkwAIyrKqUntdlMHk2m0RGWiBhtWfchGFGEnvGQrqrXVPGvudX861SSJr+ae5sItOJjgZ6KIp7QijuEcxprFxO3grd/NN1irkfzPbEY87e0cJfa0LbHEzX89vxdj6zaeJmSQEcEcFjLadu1lC8DXlQn3r/F1yHkjwO138gI0Ju6/BvAyEqEGpLSVyZzN0p1XdioduN9RtyEMVM4I9c9ZmEJTSX7zVxU3myWXXPo7QFNC7SGyAYwYMbKitn8bkIX/gwWlQPRNtkiEfanrm+HG+exHYcYRozXE5J2aEePnv69dad3/u+d/0RjgXwPb+basq8Ly0fwaACWkHM5CV/ZS0YhrSYWe7gtDfNIz2uz1TMmoFyISbZOGvgFwkKx8jvUwvFLepT4eTuo918+aFsn6DbiGUsVeK40MANiZzFO0j+ZI7UbwTbyRaQs2gSyJReN4lwPjzLAIW+H5dLqhkIoRh/3Y0PUEBFq2+Qakvi8eOjNchnjgFU/klZSEm15IUjfzE/HuqTANKchYUxcLCJ/eom6Z1Go1YXWFJl/MqdtUQ9m2mHlcfhPqWOvYmiBLOXJ07r5zY4mXFnDojjQEvZTfctqGtfOBP8OFHRypGKYzfP9EZruT5mfii8lCOAe8DYwyv+1IR4l33iyI+yHAnKfTAutz8+sZUWyEL1ED/IXHF5gzetIJxoJxGa1hcP3Cv8V6alPJ1nhY64BEhw5k7jSLD8L4f/b4TbeTqW6krtTD7H3Qp9rZc7kZMTCW+aSyygujpap76iH0JGCXui6Mh/UouOd6c8Aac24X4vzW+5ZVY91dVwkAv+P788v37BmmfhgGt3FTfobpLLre7VZkZCXMTW+q1i4Pt0QeNhzZR6pM4SW8V9gVTdPsyOEPLIFTWOcbKQyykKI7tTsSOlCIgb9f3jqAwMta3V/7iDJPX6YJmrDeP2IxJXcBm26O4gKGMK2A2UnjZ097OzOsHk8GjDU622tAhp2xJlZyfAPbXazA/Xo+ybPAWiziFRYOkB/Yl0+xcs9YW1BD/g2FjgZtLFInGXuPoT8sRaev00wJQn/Qc60u28ax/XVBllW6cD7Emw+3OkXO9jlwXbH0DHtd4Lf8q2jYxvthq0gAAAAAADQnoklghuBygG0/oEB2NQ3PAlmEXJubOScCcP4OiL9xSgoDoxF3LiYTi/l7VXbyfjCNch4LjQSwEwsKeTyVbm/mnxHviYgmx3ONdO60L9chkOwbjWB/d/M5OweAGZmbhJu/nTDr1j3Xr5n7FtBt2ZAh7jmtvH3a2gmgtLOomAH7ji2eCAweGqOvoypxKHFNmzNVgNtWxfmabiy10wyeIqCyMJqp+jd+6i2siBZvS9zgKaKLqhJs4bsmV34LR6lprkBg3F+wECCBwCIAAAAAAAAAN2PV2n+AWA+gZoBBgC78QkUAGHwWIzlY/yxxGDgaPXJlVt3SFwZMIg3FRxKh8Ja4Nv5KAVhaeoSKXKrImsxqDWu5hOkPEHSYc08ZzhUDPcKvMwKJD7+rtlMqdg0q9chrFrveQsajxxNlmvYCRSuF/dAcyxP0Scdd7L7uHS0k88iHD6IQkXpwScHvgtMO+6Zh8xPA+whD8cZg+cx3Qw8kZhZIDX/vLjWXzH0eF2VSK2xZU+CU8WFn+dqoxaMbBR52+FPknJSs4efwtbSMebW83MbWpBv+IFSrd1eR3jAACX5Pck+VqCH3oQnYMkRDzn7hZvtD+drRFIG/XYPuE8LGc34JtsJK4koXohzUa0ZSFfYiHP9FsvBTskMhufZtcZVxgvyJAqI62AjpgqccV6NqDQGZ8SwfGf66v/HNamMe9lLL1Ov7KC/nbAT9b3ChGEC0ZTU8Oia/QaySeIIJN/Mi5/zCCayeAVPd53YqS6IrtFeA2G6fYRrWCLM0oxIijiKdHfdZjQI/BZMLnl6mbD8q8w8JtCeUmeBNOz0mnaNfCXWzN+0ihcbuvKdJpcjHXrKX1vCHCrmqF5p/ejBStvVVUXRYE2BVnCXs781EqZFDSQhYxzUvpMf4YxBFQHX9dDxBcoZb2abuRNHt8xC8dhAv2FGjJ5E+W6dJa58Yp4Hvwof3X+31FJ/EszkKlPRnZxi0khQ7xE2gTytOa3GtuXBh+xEZgrBUvE6GS/gQGVrviOOJP9KX7RirNoX7CUmDjxRdATSqaN7GTW0uCRzgn2Cne8lRNBoEfgsmGGvt9Ccz9tZdKx8jfmV6NIuE/MJeu7tsbQkIPwOlllAdzLYfGpz2f++abYgVkWg//4ZOw8tCtZADLeFMR2f+3YlckUaCggEBvtw77waNts0WOTaNFO9c010jVsnM5SET3FhNe8sCJ4tA9MvCpVpRNlLTAgja66v3G2eABQEXs3pWsqQUsqcZrrp2ygoKOwu6F/eKDfjB1KRgsnkymyc2MxBuynSYZGjVRmBNg5Xbjrtnwvu5WTqdnIMtlWl50aE+a80cus/T7gYXN0awXrdFrlSmvfdXg4WaFAr9qPiSZ2T2BPABCDgli0t+K8uudAhlW6wCYHDsEE9hX/ZSUnkzXxxrmwanNDFBpk100PxjrjIyk3Cd8F8ZFcWApGWzekrKiISYIJUkBIPQcfjh3qyS+4rCujAqsckOvok5VPnd96qt0U4M+MpmIg+NcFXX6Vyal1LOChTbewRPbXLZHdFBv/RsZSScWFSRMO9BvKB6aXkI9Pu16uxFuD154cdvthCRLjzFnoTwhWLmyXojX4sNBNS2A4FNwJ1SpTyMXEGyaSDxpuOrNbv5uwaGJ3NMTLxhypKEsH/yoeo1gZdKnfWKkhACouoF4BE4kIIuQ6vNc81HzrB/2yPUN3hDWaCjPlnJqx5xoFxuk9sTo5HKy9yJehwWTSSh9foVTNwxYW7XFNsUe9+B8llHnNXdZXS59mR8x6fYu8jqbqfTtF8WbAvNRkH2sLGqTlU3MiKimEtu8xdSL9PyH1yVzZ1kHqXszLvbCNSPsD3iShLR4bIt1SfS+A4/q9t+J+JCeuTGc1dtkfUk3xwHAS74nZkddUnQwrhYO0pxCv9LPyCWhvz3zKglNpygfgTuvh9GR6WTUNvyidSqP7Pi4V1N28drk63+38lGDJVBxqs7aLUcFLVfFJxIpgjsbSAThP4iGZrXMcbopH0DUgHbTxhttH1nWPADN7ZNJx8IAbd82t4LFqUvBiQWItpH239WRZVP48S8Jw10pAZODVZA84rGR9rBnlwGURGAy7ksGTcC9UmT7HAtbzmvtacR/G+B1tS2h/PPkB8qKDT69oaVgIM31nsAXzle2a4bwg9oyYboZYXUCrweR4jruBgq9pkRKnqGIsZGiNrII/VU7eZVr+35R4/XZVfecynnKtL/B1BT3ahgE4IukKAmhguqotS0DSxdRcznqY6sDzElycO35du0n/NeLR91w29ejn5xKNVq+7YdjZ+GSc2vbYE2f8DDof9hRkR7rvJAd76eheBaaucZARnK8YLjF3zYx0hE/tY0o12uzJIJZ0sn61p4de8DJ54xJzVUYcVObFL2S8cOhXQk8nfkArR8DQeAfIah0hDVQoWkKrI39UJSROoFJWwo8qEgDTrnDBHYPgzKjs6PkVR8J6l03aWdNIV/u5R6s7uRp5oQoG4R7H56AcDDvD7DoWghmySlSQEg9CnCh1jUt2j4dKrRRUFHJXI049hnhTDeX6BBcxepEgCTKapt5b16316uprTfwUeOqyK55kF40AJhKCXC9vB9OgGJcV5SqRd3WaG3lnv7VZsJ5ymp+srQCwpfNXvw8V/KySDF3qdOUYbX296rykUwwBdblFZLFUX8tME6q+/jBQIeKBvI6L1gUy1OscfXr2TsySSPZ0yltmy9GCf7IPus2ZZx9OPmcM/bGBRvWdgOTDRshsRmi9t5aNFy7TLp+X6uQjFLzNBNlzuT26rakIHE8IeYkj2t8adTYfDNGuSW8H1uCg2SJgip5J5mQnF/EC9XidUIsGWD8Zx2t7wYezxgLOhAfy/Phe5UzSwql7TE1EP/7852zgv6jCqjXKzi/BICTLux5C5Y8su8yntzP2rFi12bQdxtBPJbqf42DhY7xebkMQQoVg/89V4yaYe1drOVCTR6sX0VdHHjP39EeVogMGh7vVDMG0dMU/47xIWXR451JrHYWr5quTf9whFD2unLQDAOISlr702e7gQx5ks60wJ/HHh2YzHAxJvFtebT40HICWa2Ynu2NrizBsEee7kWFT/ia8AdfEpl9QYSWCbXEL2/mNJp4pBgYn4SWxkRxVqh2IsJNwVevxYt5bCoe+/8g/R/rWRmUtOlNr71F8nfL/qq466cVxWCJb0UkQ8y5E9MgaaPBEVlsqcaU/SBc8c+lK+UJ5mgNC4E49bc4XGEVYUR9vsQGUSYNEyDrjg6k5R79rqNVGGRdMV4fa1padTFouCP60BYuy7iVyNZiR69Ggpv4kDQKU7F3iRHTngkonQ9CsjaqRTCbdUc2+oNMuyA7BKV+zIOKBLz9mb9c13sg8uw68c/dHB5tGEA3nogCwbpiVxIl6UTZZBmxh8OQgJ1JtmOFi3cm5OEIsFhf7K9Nh+efcDvtFscV+YqKq+fyifJad/nx5m+WljDM1N6pofrKXVp6mDgsQWr8z+yxsEClayeek4YzuLjysoWaOYfq2Hod7n5fuRDBgfDlP2dtVsCn7SnWlU/FHxwKlihQVdmXxidlnp8DL7AVO10ULfBNlKwgXVgMWBIdbobEgmt2aDgp+0iBtqS9XJPXuk2fpGxINGSDQLh5SQYGkNUedHC4fkjS5MyJwMdCcO/spoNvZ2Wcm+LblA33RSKAIXE+xw2ykeurD8dl0PR6U5oNsieVwWkCwGRmT439evhc/H87b4ifEZUgnlpKzUFDBKKpo1NcT00KhlMKL4LNA+eoadSDe70SIj3+xcFBF8xznYt2EaMh7/EgaQ+6z0NkiPNluRDBbuacMcrtVsBgzVhQ/on+ewIM0bZYfQKXM0ltkdxgxQx9tsQ4ZYZwZJ6NNlYHnIkju8DOpOX6XEKaiqAC7ml/khB78AuiP7qljBdkdY78yqdiiDckgpB8/aO3Otc1/p1y1NNEURTyvMgRppQaKYZUT45TLgNXfZz+yli7uGYGK5jsUe4w7F1op5R8hfsd9nPruGLOYSk9oaefVy4E/285+5K2SlIAYUqCwCfXWDdMO6H3PEJKxlfEDOHIki709CrBvxB6N40JEneksPbN3ckBDwJ67/0AmZIw2sx7x8EPWpfgkscj4MlxJEC9dq/eNbDWORgkGJO/opjktLN3L8UIYc7RC9kADVYl6O2cE9ecP1Y+fcJ1VTLhSD2BSA1lDLWQgtWXrFTBQmoBrNtVzKx2bjNqdCONArYTpUrgT7J0+68W/Y7Fih129T+r6o8wAKwSYV5eWzXHrO0+AODxje2Ew0qO3T3BSO/fFE8POTlAoT13/oB7R6771twp//R7tuDqX/A+yMugHGY83QRDxYtXgDwCyetC9effMXTjKG338hf0ig8r5lw2x0aT8+pGyiuCMypH9553rHa1XcTYdf2Dlvq7l2AY2wFB0jN2RL5xj3QyJKfdy3gVCoUGvQCeftFCPzUc76t8hw3m9ZftM0zyg8KdkXtTkjx+Q/KOpicmaQ59mTDu/5XYoJKp7GD7XwXRZlAukDTZ+3LBcGE0BjV21TiB6H24FM0vHcEYb0Am2c9k0HR61YUvU0jZXiTFQ7ulx1n16TlblQzKRVop6BAQSRMHAIq3iBIsX5+M5YUbj5896twrXPTXlrK8+1t1dBtCmKICT3XQXYSC7mWhd4Fe94zDvMaR0CJVchQSnbzyU15SvoTCBs17wKo6CsYUSAjJd3IN2JuoCfDVvJWBWU69QvRNSXgFqcAkY/rapen1bsBmH0nGuxLGWx4+XT7cx4SqvKRziexmy9d9FjKgg+tB76O671AEZLSaTPfmNVc79ZywBhDdEBGqcg6UIvwdh+W9xVY/c/isr+J7/dLQv3NfxREd2Xx+W8GzdHcEGTO/Kg4RzsimAiJ/aMbY88qwCjgd75tswspzuy7Wu3Qd7PksLvmQ4hrFU8s8fxSG1zxPxPilBPAfTAl99jrep9upiGlfJAiwrBxxKg1B2KrOVZGE4kLjUeqUnGlwa8UVaHBVNnBwNkwVO+wx6V1s4NnCRJQJCOmJjWUmTYEFCFe++JlRrOUr2qo9iuKh/NvahCsz2q0ZPXFn/KFn8UFnn69STPK8couTyMbaGAqH3jSB4ZyrR1l9wRRRiG6Tjk/WW8Pnk7co9wt6ptvzD8R2kgTK8D1uDP5fy0AMPDz/ae5x27KK+Kw/KUtfpxxdeNCn1hKQ+r3XNet2/1BoF8CX1pf2M2RIqE2i39XbDA8tnJEMhbipczBw49xBG4l3ePD0SAaZrhNSAVzpg1MjMhQAqe85CZ0EutmWOhi7pDYUYgr+UbwhXEa9MvTmWNUzjuQgS3CDIF5rWTZwrPbi+vlACdVjDkARD/JxcoqIY7MjmfX8bnr/pVy5KddrL0Qv65q8LqfT01Zre1/kIZ8F/QTjWvApkJCqj3kAUVPVqwzpFNDFJ+fSC38jbLenL3lrCZslP8CZ8fbgyimaVGrDZpRoNoe4ymMlYAzEanief07L+wpUHGGs3ZlbL69EdWQToHzzJMNzHdV/VxSDeAnkwZ+YiPfmAKalUNe4WyXddFbrE2FkHEdZrhsMhj98RNKFboh/1VYWiHfPsLQPCYDxpfsQTyY3qNKFalV6eMy76fe7arf0n7Z6mnXepj4lRyacFCutGtm1ppGQJThE+9hZbjepfoy/2jy/8VxXKz3IpjZX2ImHCHjpLHHXOWTzvp5mEiPPFRVS0XOqrnSHdqOQVwpJH8WVSVtEk5q43Bf/pUwZVaHRsADMGl5Uug5Isn+isToiWBNo4V5y35JWP1te4FK1smRPbn9ppAMZcRaGuQK+PS3XGj1C1WMndnB5EI8tonnKU/kQ5paPuMwCmXGVTe9wKuE3ELrTOHh9kj/lBIlQhnujn/uJDQakUd8Ga2gQSfZUsrPl2j3lIjQCUvux09tqldqBJYcq0gYzf2wvnmaCcqcRykEI2jqUqDrdwiJXvqeoteDj0AbNcyk2mUNFdtvZqkHX7YEyis0CUkoMcIKsWGbRtJ3BkrYu9Yvms/u0VXrEaFfQQCNSjdQjaD2U37JOOHFTURgBzl+HUnFgGkL232ptBsmOdtlM5gyo/UR/JkeVeUHTbpQ3YuU1zSCIlSIWiY4LOt+L2NUuGV2ONVRpA/56RYOxzmalHVFpzKAhuforCIhgh45iBMsdvnTLWRih5CalT65An/54BW1yVdRdaTtb7jWo9PXBNn9/h19hUDZktkV6uk4jXTk6AGnu3vpxdwHrNyLvMPyao7+XAOhVXrwa/kZW+CJ2YFQg6XkxBSzMfXXTxJ+6tE5pEYn6JQ+vioEYSHnAVTgfxbW0J8DZUcFAQOvKz9OfztmixySSEpq0/pGiSUaD47kpSJFDwB7cS2u05jkrjWo7PMxYAAaFeT+0o7+DD1CFjOfcp7iF/khSekV+YtPH4gAAA0fDln2ts4I7dVAJUI+Xi2WnJpHOT77S8Mb69MC0I76cFhRyAAn5CqP3c08QqLwFInIpCdKE6UJ0oTpQnShOlCdKEjgAAAAAAAC6ww5NKZIzKQ0l0wxUHcSvJwaWomM8jiWrHJCnni3qv82sQ6kRGXCDjwDDYP9cK1BcfW9Bakz7uvQvgMBeFB5g1ChR5Pp7RgKZWfZQl7bAxjFKnz2SQreUjdG07glID18NpRgtXnjQDbFo6cb84kCe/qZfWmdFpSRfljOk2QaDz84fmfCDK3TM/IKa5+fqAFMo46ChVOlgIPxYeSkDU1CcdhRhWrmyy078dCh5QKpQshRxNVfFrn9M71CFvzPr1t0HFPXfDFmBkyrmOCl88/MUBtCwqrY1QyE9a17+DDn27aPkq8GaAki+k7XQ8NIDTB9bbMmUgPitaNNyz4AUiUXUqrx8Vn9SkR2iydR8pPtU5Kbe2Us1aeQ+zggfSn1qjLtLPmo9G8RzV23qGZOPuCnAzxXPg3twIfLb3ttr39SwPOKYygjfKGKCZMuNMBZzgzmDKlqhwCeXjxCn6WuXpZOG4v55S85c4l9hSv853toyZE30eVBFfzIxU+2I09WadKtYUlG1os2EpAUsG2gMUOAj6Wv9UURRfN73BGzURZ+9/HmXk/chjl+YxwGJnc6wryxpEcECs6Mca8wqcOrxvkL932MjLdyadJ3qVjKHlD4Y9i0E8lCsYvLiH4pG2wKBrb1r91SlT3Q8yrs54PhOtmOnGsOTTOPWxo/Gnxn8D/AQtHBttaN7wz2EeuH60GPBCworlrfNdho3LuPgAavCAJeGOF3SdsIcvXyVNU00+TXz/dCJ/BsuKotRMm4BPHaDX3pex5LjI4ldkAu74f/Rl3CUvOgcGkn6lCTJI5h7IlwV97BI7SxWMuqriVyb2+hvlYdterjZVvrXTGv1/pzVBBp+pESHt5+AHL6GKzf2buY02gZMbjc7M71eACQDRCqx8lZuZA7iFLQhI77Xx325JKFNuMvtKJj13IuUzSA00IDAq3Ff9nk3nCJD06j7qg+7Lbl/cJ/eSj2JHCwtDEAxEzKidxTHducV9p6Kd7OBB2kCsIib+3n7Xms2Nwe+/l7Keny15RdIaHAhtgzahCElLLNUC7FWGSQnEJ4P/8/awnQL6jVJ+7FoZi1yCZzgqCtLNddHkMgVIWxwGoF4CvkxVLhBO8UvtCcOZn85tERlovcub0xrFa1MuXnRAjCskyiEzLm9m9wWKk9VSiU7IERYACU5ItpRXsnFq+kBXz/vNsUr3tqumCT0kbbKytmpMohNf9wfsUqQknFYge7yOgj5kgJVoEr/iotv76f+/Tp9LdFwRDBtSWOglTplIaTUYb4fvdgJdMfhrgJae3oM2tjqaJtru8OYywrUOWR85qV5G9wC8HNH4+c2cL40eU4onBeWcVMe7D19rolQra2kvI29VM5xE0wIyhoHcREFr2Q8sUJHM1Wrz80hoZEOIzYEHiuM72drqgAn0LBt8IBGYDafyykWSglnplRz4H8PgK0pjXnGZJdOy1EKXyyTxIyqeHXlVicXgbs6I9zQ7iCasFhdO0k/22LVAFPzFDel0abS9OqQr6BeLtrzfOWOPpYg84TjSwvEDSrVbCG6OFUUpMfh5rYgskXSW8k6SrHhG0X6b3Oxn+JlWBVZEGYLKdCRozuXlHCPglZsm/R/ywYeaxQ4tjeHVWeO5xjIOMo7gZjWu1PfBfmsNUl7oNVF/QBZfIMWxspz5gQy9aaAlSw0XQkHeoiZP3Z3uM7Tp/IHX1phwwt3pmV05pj3zMJVx8o+OG1NyZMuyqpvcT/Gx3tLlAN+ceN6fIMNaTBG+rtYZsDwH6kWZA1KMMQqJavCJYd+jnljk43LGhlpBLgfOG7CKK1gMHCmKP5LrWkTkG6D7wUptJqWqpIv/XTjjPiWeAg1IVezIhiyO/Ry+oUN9rvRLCQhqgtXcp3ua52p7KE6tB1dGSmczw7Iqo9o2BGfyCntMyIBKa3iBeNtj/0gtC6D8+M5t7PKTmR1YYKWPnW+FasXl7bUVKtBumRKUhz5hzg05i2a+iAamzsrRHHeWMiCZy1eFwN37MaatM2xb7xvVoCuQw+UcHXSoW8+Og2is4RiAlwvJbNmTYe1zW8/k7NWJSUi7vxKdvswDmzEGP1o3hZIvonQksweyK+AfrtnuWrp128smScpusfdU9WVGlm8XDF7tr4h3dh0uV0AEPXHUTjmbbQB0/ASCoR1Ih23WeGcpgzNyKEvxmsHCGAYaDUC3ET/6f8C2aVC2jVVGO4cuONaoA4OngmS4zycDf27FhtYNlZ0A76EYy71/ht01Z6LG3qr7d/gqbxGMUHU6JYp2RqGutV/xP9MRU4TQ/LfkKr26zYJ13ebxh8CjkikBGkUy2tZl4aXszNKDY6SPkBmms4iVYlxF5dhE6A6PBDCZCs1998SChllE6hyK0nxG0vZNlsZtxCb8Z1QigriNebK3IILd2Ge/IMp7yI8MlJP0QWoELeIRE5EpymCSJ6QVcZwz1quQvEz5XGx1LMhZp1V6A7+ErdkuoSJqS4ARKKfbiPM4kujGnSIQynoLvPPWJ9XJRt2h7HygB6HpZN8ClxHmEE0L7CFfNqkGv4xnnT6uvdZ6owYgSdPBZ7bT9RR8a/VUIa52onEkoUFmt8UWIBNXbuXipw989LvVQSXJxkTjLuaLRQjIjS15NNkM+wibf4YSZGDWJeKo+Ua+Nhd8ObReO1+g5x/Gva1m5YM4Axc+x13AXr0qFbQ1gzA3b3soh2rXZJHJMu/PZjsHImScg4SLR/8tCcQiZ549MvmdbfX4SrnRF7qPHvZDoAcoJFHWkbQCpvmcNK+mOKPycJ4UUw6E26DBNqs+il5NEhEORsR3a3FIZ+l2FTyQQsMv0XsHSfMjk42A1Tx4/1+dqoH3CWlKrw/WASHm68+PY1ZqCCTkomVIE0P0/SW/cnVnGmRZi0VZmZ6jb3d7L3xrQMAw9xIjQT0jlfik56itwxsUdo5iI0i6oLzmQuIFd0670gPTyemShOrQi7A7cqP3p3cE25xjTuF7UGxVUOPftATs5KbdJoPC5nMB0CTW5y5sKiPsrB5QGDMG2PgFPsuIHnMufMiG5T9AGP/ptfSx47mclfXjIle5hHrlWz/m9758ogNqi+RIRP7fVxC2UvdQil8BjcvksTRc2K4qzpXfrHi/VvSrzOXxZJfpfdv2H/Pg4lXh+t/Odmly6sYtvx5ei0ZNF791M8PPcS43VhtBJMy+kettpqeDK8YAJlkMb5HiZwm/PzruVQc+5RmPBMuV7mAExTlsyliCHLLrWmuxqbA2jpRq9I7JxymzuxCAw1xQuPtbzWOWP6p780ciXGzatUshg++dmnRhQsOssp1M60d3kHwVIO7PJd9GQIWVewOLFk41O8HXunindl4yh+INAF8XUpnvCTEotYHsp4TD4l4TCjrZRRFsG84tpCBjC0txtkrmKT830FawXfPWDBcxc11j3q0Wy+UlA0kWILWaejV0whieYIAM3xYrCxTRU8RQANnH94DJ1dBiEdzou0JPVua4HMi/njDzBYfgRFmlALoxOAdNPyDv7pqqfaAoTzQUAblTlhVA0vcy/IXW5tc4gCMoLlQYeDYyEHune5JS+Xz0zmAq5H7M2QSRGD/8aQ7rhL1Do4chTZSV4Hk70dAnm4jWnzR8iNvr/N3BoWApX/bxYcGLK1fsN74+LD5AyZcREqsTch76DBlfGGssprOv7ZFWZ9cpIZRo9zjbNVZC+LwxsyM4OgTr3l6Li/mNIu2JjAOULK76hEevHWdrsAg+4HzJakv4pSucDHamWK1i15laQU1G3NQBbbU98ijbzIjxrTHAl5/532buyshlwXQ3D8Ziwe8/Ad9yc5nRr/Vnlojk2UIszkboMuWC3Q6Ccog1YYYp620mjnWhloQO5bQjAz0TZL/mkVUuY46esIabOVUvfkZvXVyMDroK8/cuCqlpJitgUyzT4uk6eRUtXdZIm+2ovalRnu52ZcS5KCJ+6R0nPF70IzF3GAG1VJuPj9u2oXxCKOOP4u/ziwCA7scxMMqfGS0OwleKsV9rTSLHp3iyVtrXbVBxM2EeAxyAhJyDVAIVHw9pZjDqU6Ojwrk5BlYytugIsaTp/2U9XspP32bYuuptR704/xrM3frwYaziDJuH/a7x1G05fY6iwietViCOxx55IJdG2zcW+e1x+gkQJ+tuKtilY+nkU/F1EyBZxeMvFcpeVG0irnulKAE+RgHpt3uO4MiLjSPR9HyWLFN0eXTWRJXf4UBhfLuCp+9sV8Z8pkYj2crV+9Pt1yBu9b+24b/mYG9r3agVJBkNXoxXMsHCn/CROrGKcx8JnXDa8kfOnGLUJrFLPNFkIrZVLd5eLjFepWwqwWbMgXieQa4GvF1L/Ste9fFwH8zAROVlq1P00ofpuDXN3KG3Q6H0lJJYq3J52U+wsPheSWZlGU+gbu4jhxEAvKwtN8OVJxHMeI8Wob+tZnoz3KGZep64MxILdYDFfY/MQb3aAII3yvc/JsBpZ/hxynKKNYL95nL+NK6SOP+kcna2uiQtmmo7q/LG3Ip4BDl5WJh+HdC2xt+JvOWcwIB8QOprT2IQvia4vGb7F7T6OKrRh/8ZdMQYTaWguGiUA/oVzxvoL32Ur+9hLff5v9K/vR66/N8b2WL71ZBuYYwwEIJ+lYaRM8h4p5GxEWpmt1b5AM1XsIY/xdubFoSdCO374AeRLgFtFy+9cwH+NN0S+nLN+FX2RujpFBfqB79IIE+p4PLvt/gSgoNSzHSAXd2EA5/pY8yg5wJZQk2+EAiuTqgettFr0Un30BZwObsAhWfpCiAVFID1foau/GX/4Rxq0m8lecaZBRhRii6TKtHCwzBgzcYFGGHVoGss29ZlNsf6ELfPcXgNh2KLrHPrNhj8DrmaTY7JNYi9BF2nGmxhJZE6DX0uLFSppXgpGnjGrvvfxVV5OJVeUzEdtTlksDQ6som6E4SYwsrZ3AEc2azE6RXH5AKX+TgvO0PZ0+0w7C4EPm+JYOoAXZs/UdEsuDsbCD+UHonNzFo89xOlCqYFT2uzPquS88gnStPD48rtnxxIPIW/+ibTYy6vRAhDSZbuaatnY0Mt07/YDazzTGHwgfMZgxByOm1vjl/YoMYltCnypJcCI7rpenFwwsV4o8lwfHWfB/8ctZsn9JGq36bGKgSV3Ld9bvdKcbToD55P/v4niIXy/hv94Dgp3JkUJbaIBUnUbCTLe2+y6bYp7bwc2XjSLyY3tLfGxyTJFXR6HeUr2yTRYpuVmH4l+JJ2fjKoIZ9N/ebcFiiUxDfH232vMrSKxCIgi9Wr7RVIJblK8kIW/mZIVtN+4fGX2CBJXxvkZOXCtZbzjx5YGB9PZJHtdF/bmRiRlb/NI+VmwM0TlDYZmoNM7bo4W25EeAde5YDPFE0TftG+KsginvWkOlb2g3uPfHBdbfdvlNvl1wwkNdWHU24AvDEulN74tYlpcawXMVJvFo1XKWvVJK8LOtlgmTYkjwgPfLilXLer3soWdpdI0Gl2adLFcl8KyRIa6qDPDOTuhcGFfSrOhJWdWN6QBibfxGBHR217NE+BKuMQJrC8TW3CaSYcoBvp9nBtrnhoJ85rYS6feYQkjfp6lwWGBtsMqFBZxCENGRl5YUZWpkgg6zaHkR5qLtGvoGBfClBAGQrAzplmcKsS1Nvr3ZOzefD+9rdV9ot6/l+KkTqLkbBCph7sBZk2MXyJrjJsSLv1P7Ino1FQSToyzMhtkFMXgxKIQaV61mQlkL/CVE33OLjwuEPAu7jJicmvhrqLT/H5kU4mel2NMxfjwfVgmQpKJHs5unKWyuk0xC0go1/BVUNhXZQAbkVvliJKMBdcgb8pMFhOm4JrzGy2EovqF19vpGGWClY+itAB4Abo2T0yvO6E9MGuAx+h9aZjUaFn0m9cNPNQT+pvegaQezz3jhGoi18XN+KOICGDEtH5PXetT6PTT/c1/YLub0Xv8Hi27lbOSMcRwwIfUVa0rGnUrydC4gpOQ2kHgGaw6/CxbOIQYdQFw9yKjgueDrZNAfOdBx1Q+pX3KGWj530IILVK02gjhPZoS22lLsTpX8vQSDdyGCZKd/Jno1dIj0AwbX5EbhsWqDM8x0OKWdiZf8/H0VI9zmW5NoKZLePxoPSM3ivtFfK6IoxZJ76cD5DAvzgzZnciPl4wRMRhgkZMolMOWGxY5ex92J9NwewgF1GQY2XKR5uOrBNR1NKH19140n5sg0ARZdq0grBR8wETVPU6SU4ewVyxcA2ODwdeJ1El8Rua6eBhTJEy7cA1jxvOEkNljviauVP+R2eB8ZpJQhyImV0ii2653sBf3gTr1c8/H17ka1Brn8fOWqtxhhyaUwrL+htWxhsQjQEMpa1ByhmzCDFfUOukVxlhFQBfXEm/x0YChWUInsQ9zZQ8C9DncHbx3RfV5r5ZwagHwFIJsnVr4NzabbCSDUiejBMKPOr7ynCTz1c1GDrQKWgkWR0vfkZvXgWyaOzltQaDip5DjfYDKPj1aWrTSvItg2N4NmwFTp7aIUw1J1MLjWoDQF09HsWIIlCokCWi4BKgeT/Rbzh4khl7taWOx1PXF1t73eVQTB2YKnuwfBoz8TBplntsJ1DEwUhKqheGfJo2PhijBBaXkasDPyDI9D7gL4v3vbYrsAWGfQACFBGi3KevRPs23XzxnGcA814BA5zSCfYdrKSwWGTswuiQcjOj8hRkZGaRPnfvT7cFKLY78cyrCA1oPZahrHaGeZISa0u2nudd7u/3oIfge9Kpdn9d2HpH4rI61i03drsY9ivkBhrI9QD0lmk1qK1gSIJJQ2auNjJgtb2JIrtzLR4XaevTsmmeao1cX029F2so257Iz1dDAVyeaRPr0vPANmu+0PPHm9W2qsOugX70Tl93vSSOobXxsVApzPS24QDgvlHYDDXovmn9WgKpdiDyV6xi7+zjW4GYBSlYkEJm+/+832TOzVbdtPyqRzlwVakJO+1LIqT4puqxR6qZHmBnIxl/9rhoqyGwaiQvcESbnqAH7UzsiSVSDI6pIKhinjvLW+2FJCZcktbZGsICvzoVvgraqvhz5o0uYSoOOgd6K60SE8HLbqq4lUdAkUT8it7l5VS4Vka4YzEVjkR2RbE3WSvUVr+8Ceshqy9NHMjUWrNU6IdbLhpl16P8vnhEg8eVJbyeQLoVhoj0jYYARd+mvAiGT4CHxDQUtFJ6/7Pkpp+WFFuC3SCKCwCsZC0PMmldvD0r6BoJTozuP5ReqihhD+QZ0G1m1mpfNZdRkkkv+Gr2EHObI1TcMglZncs2eGFoTHdheUJPUAh0/Yvi4HLaFw1ATVlhocz2zQNxkY+weXRbNSHkug+Nc/snzb5G4UXC86C8ulBNsiHrXBZYl/utTTOL31GC1xM2WFrutalPOyVm0K6BqwWT3wc8evBBbNlDFFjELfFWmlzcHxx+8X5PGeUk1XRPEy+faJyMrKqKadqoox1G6qdOJ4/hDN2N2DTYzyNx/eidbTxgDF7vG/F0T0Kw16OcWRgHKexJtXoft3xOV/UaEQtt3U9CTnVJMwxVtNyv/xiPaDaB6sam5acZnDs0F2aqOO7c7oAFhJb5YwFAiJzLKilLKIGDhu5nGDU9EkJjzTY1ZssvIcuI4zIQdb+qXTsjz3GqDyevnxHozBBWWRdPxVeZ4oDYyHMJAWBlOEE7FHKjVa69vUVDA5lNuH8RwHTjvqMnc73k6ZCBmfCnyGlTM7Pc4MzmYbWdtJVrTaf+vUHFKZfzyaxx+L9LjVP0Ws8VlMSOGUxZFLp2urk1qkhihcjyZmuh8M9D8NgEz5qWUHpWZbO2MKFTr2SfM9dj+js24VrVAEqKJ9dP8y/7yAr6j4GKt1gU/EDEbzO9KSCjmY8tkt+2TrVYxxXRppPRJqqZry89U357st0wNiPkpd+rtC8DDOu25BLinVFcPrxXssz/LSt59ymnZwuVX0z46S8oD05Z7xYMPSLen+I/xxQBaBGERD8nUeOBsNr3Id8uBwH9bKgShk1Uq5XlAHGUe0tima+c6q7ksf+RmY0/tDYBCFZq6gSB/bayZfDdItBZalx428R1lRr30DO64oGb0Y+ERVtgX3n8MN4UGzx09kv0slKB3NbNvn8OD+GAbphWU2U3pt3CdDVEzB3LA7FNebgATLOqpBNu33OQgyFXDeJJkipazo26FspyluUDpaRK/LlNTMsoC4TNuykmwND8lYZ9Hz7EXVNqpchnXEQuSql5JTDJYzKI9MM3+H9V4qRONTDIjeFRQm0M241GavDpz7Yykbw3wJ3B8dnLnUEcl80kZj4UR/QRfGNGFZhnGE4rXO+PpyhnXLgwOs77swtnyTJu3uRQPnlOv/kLNfAWkxeZiQrtUg9uUtAvv6539SWpNYeXtlLjmlS3pk/Km4k8eX5dLIct/BM4M5C8bQS+AFLdfxPlJR6npMhdoA3fg8ty6Xxu1PkqwOHkGVJ/s97IsAE2DyX8SDoUX1JtDbsD9vARBUs5/UfQN/dEcUt86DWnBccr8Nmo9/EE6ZnJGrXCsUwGmCdJqRV533q1IZyGycZPdeJLyG55heMpNLAvGui4S6hyKs8HWUJr7t9CYCL7XMXyrABN8tKktWa3nUvdTh0IeZ5racMJ1SMlRZOJQLi/ybIzHhXN6Bge+KULxUEnmBeNXIyURvIu8cmbE3llA9wPdr5uP8STrRKyE+bokv2j73w7jkW6QSqfAbi66vRCH8tXiGNl5yS5MNJoioPFtjfxGuovNB5IiZMAz9f4ZLsspHWYG1YcK35yksHnvf+jtm09P3yBctrr0b4zg60UQ0GVYZCFmiq17jGa+RI95q79rVKVG4d6pXXNaQrVlQwkQadIWGiDn5VZCyiEjuTEAHvTIYK5UyHedsQKy4ywlW8GNF19x1TysPxjQaQx4dktqF/uGbtrKuNLN242MpnKfILnfTs2FkXEYxFY+BeUw8WP01RATYhj7h8JMcdLit0eQjNGZgHkfzZyFZuyNqMVIrR3f/XwLShFZ6YA6o/YeZQdw9vgE+51Tv/zCx3LMrr6nS9Tln3L43oPddRZNVwQ+W6c6qv31AZ16A0VnF6G3zwYLbXx0rqOG/3BZ9nw5Vl5ESnWXQN4qlf8ajrQM1ANQnxEzvMA0xME+24HLRh8pWXGWEq4xlFP8Sg/ii1solHjOmg3eaBO8iNPqo/8ePRin10N2BDQ42YqZfcSfzp+N00p84dny8+yHM7lSTB3syh+i+8+TpSy/RxGnk6zuYVqMCfQhaNcILvEjPi6uSiXaI6PzShjQ/geC6zqS24TF3GpeTn6fPrFy36zPzbhRqhQdQjEONsueqRRLYEcdaFpbx2FgyRTKeEqlUb5enhyAXhoqflHTYEk7JG9u+lTAtlEqYoHRlVvvzchIWbaWCHHaP/D5cqIqYjgM2KhQtdCf5EsNEcvU++V9S3y+C2INQ0Cc+MRBzvCWCgymWA1YDG3qgIoDaJbB59MYVhNg4cfCz/OZ4nRAi4FWrF5cG17cf/bc8BcHR954QgT5BEOeh1e/7gC1YYaePBRRWzLjT+lShnyK6ayqtQX3LLybxdX51fxFo8kZvkUIIsjAa1pXRGWjZDvRoTK0ig8tUAxIXWF21BAjuxL4sS7CTmD7ym8S9IuanL8A21wEEDMWP3TwW/Xk65mT7xxulNwEXmAZkeHmRX/sKfI1ikyBPLS7hrUNc48Ivnx0Ig8jkA5ClrGYwUQbR36H/ayF3pRpz9mlQDURQDqvkI+IRYeZFdyF8M0OOqbMVpwysvVuLxFLfNR2YwBuXgTMJ8hvGOkDd5mfB1wQn4p2+ExGHpgWPfrNd2wjF4lLoySfAgEnFHg3gayvDsdrgwMHVsYLaUDKlqGtVsfuvYjqGlheVag85zvM3UbGRxkDb3/IqzqFEjabKUvfPUKdRZfQsgviVmbn2Lf82X05ZTns9tErmNT0m9eI4sCyhxisYSm+Fgz2vjV6Dplp7a/1lUdReMueatQ3ayZMFVInYqgWejzZ4Q+7B9MFfGLSA4IriAp6rld9kePp5MlxCG8yUQ4dUY+SdnreM3C2Cj+WwszdcDHKFOio6B7dClAJEb7wyJ2NJE3qc4v8YWHVF/YiKrDbZfaBMdFLAALKTb0KSRiLv1O3WOoP4+MhzKlYoKwCrTB3sej2jwgZH0SbALUF4SOaFEDnUoZYHGRTPzJ//Wr4J1tzAIDavpAqw2dYwJB/3mmloVYSGT4wc66ZGV5o/wxMy7z85Z8TpMU8QR4EeeyW2yKVNivM9q+Pzc1vbpbFyQYEsPDbYyARQd5rndwdEdUvCjuHot6RDzvtrQB79KZNpVHD98Fxa3pI/JAl8hknJkmRyv1YSRiYKvlvdsGW2s71ICyj97MPs0r4fc3uRkXeV5YTVPuYvSSFlkUPPtZSzPlEsyIaIBBIfu5ltsQ40jfYC7gLgtlk6DygkYgSUNJaPYds5dtvWfNScnkocDmA9aKqM/di2P7LVpLuiUqLEzXLms/7nK9JOxT6CK7goRUjJvgokmZF8gSYQly+YRUw3Ok/wD+AwCaYDoje3fSphScp2j61dHOEwwahQkogCSh2w5BPh96/BldoGLFZ//ryBnO6QmP9NX8Qhazqs15eaaeyNA1hLR0KyQtSvORoMf5oIemAIGlI2qsvjDsSNYCOB2Q7FPmXBH8+hLUDoiI8838UatLKfGen0JOadAkLx71IIMoIbr5+2HaoiK6+R/D5tMefzNutUurxUgJ0E/8tWY3qOtgaxTVEK9BD1vG6hvisSq39su/XLZcD8306NJGmrSCTaKVSDmzY4YkeTMP2umKV9kJ4fLmsVE+tAzUFSBss9Mdm3mFd7V9WNLwJgwLIy25fLpL8trZdscmLoXEsvDyrxFzU5fg/mzEmmG82wztzQrk4RNcpwYM3+ryRY2k8motW9YP7/Uu+sD8nEgipJ9kJJ74XRk9OaxksoLT4yKs1U7F9wGdxIAaXkCpu81opTBUn5Fdf6QJPkWLunTzLv1KRugnIWL+RvO4J4/pHiUrUv08W6Tj6CbqZgxhtiSGeGlzrR5IiFUgURHTmvjqPhz5BIepUXRNgBLy50l7ouf9m85iKarKG31yhSvu+O4u2/xhi96wepTG7UnKBmvHYO5aUzPSxR0sikMfQHrqbPuWVQciZY3A23h3Juu9f+W53rtXzF+B3MNtKJNCIIRgG3Fht3234eCyXXW2EYZ9lFiimwq6Fhx/8Yn8bJsXznlIW6XJ0XRXbHvfnpZJeeF/1nXYrO7fdqgvo5+XbUQv0NAZLj5M3ZwlnGIBakPNZmMQua0wRBr0OpEcYQKCzgbCSz1ZYhZTAZuNY42xGPoojAFwa81hHJMEOUtjqZL9bGifJkW3DeB/WVrxrQxAtbWxpnJyd0v8RYKq5RU4YOdS26A3tfBr/8MxiIl7vcTADT9SniMyM8vAEyX5bH5tSuniyeYG6Htjyg47f8AlFClK1g2J/e4PH90WBEp+6vimCT3uPNxDLkKOUcGe+0TRgmsw3njuXGS+bqL3a54UWZfwGccCWRiWlppQDSYsVWvZCaBBBnsmvhmIU0G5WkAF254xRywCuWSlM5bgrGPPxO+h6ZkC0X+Rzw1osc7g5EVfYVVdCL0kDC6x/DUI0URY/ZK8085o+2uyZOrlLNSK5GF3Ax55Buxnyn21/TrXP7yANXKofDlGlalGTwvkmwwvv3bzj9RuzalXTLTR9yE+9jpXNRpQ9dfsXpjWA28kZ9z2lCVa/GF0MnXAUinX4ZnFHZAbpDkgJAcS8a48/hel6sMg1Q/N5eY06G5BjzCXshWQhX1UInbLpwyskFeXzjKBulLJy8KW+epthypIuCl6PbkBNhqoiBABNIuIeEAkXLIy9jaMKuWUdUUcuk8uW8SXOlGaCFI3rgQilU37utdhVf4exUVerdkLw+4/MUFwFsZ/jLjkPN3iDFYTCG6+JBVPdtZkThcqN32jzcUj+/t+QQQaQzlTkI7muU8PzJI2Pmm87ObhwWpjWceTK0ehOVI5yQkYKCwhC8CV6MWoQyGwFpKCisPB/00Goz0YjhKVPgv0IScE6zATReIEZ8F4NpSCWUh4A32mfcjLFwFUOK/5Kb3/sAIBVT2AWPXivSn7hGJIsxTLbTrFm/EodpGIUs8FawbJVzcymAbXX3OGWwRZsenHjrTVejthsmsq6bokqH1v4ebLPWuXuRiYlSWYVsi5qcvwdxQBYgV8+R0QtuLBDcphZGGKuG4kfD+9U+Xk2N4ZsfnnXqp+/XXzsPk1v6HAJ4Sa7TSlk9mHdQ8JN06EkLN4Kov1J1EeI5dAOuI4WQpt9BXjsi5q7nYsWEykH462hmTwfILkiSJA3T2sqqMDl6RNj8h+NdWeHKpz/tNb2LskSbvfLObYqcLNSx3KOjqDb1cW3/7Dzc1QvikZWshiNlSWrrMUK3IYEjnu2+H9f1HYlaK/V9fr84Y5Q4f3FNOaVtbqfS8Bldm/+RDIOtPvcwWquCaFB00ip8BtkHs4Q/eH1qTVvLIdpL/18JknRqlzQXBLKN7AaquOsdTZJYWQutJdnS6H2BB5j35ZkhEEEUz79lhwslLQ5nhfNmc++FNeD9xQcGLC3BgLCreGO1THvSKSZG+kxbvk8BKzUNFKfM0rnXQ09H//MIDe5uoAdK167AQlQKzeCLChXHDCKeqK5FgRfSOEQSRpAxUkh393KzGB2MAouLX9K0BWiGCqZqbl4OFPv4UTw7GpoNDbcC7oq11sM8Cuut6wBqA0gnBdkcBTohCRcWeFaQKh+Xj8HNwLTqjHsGI6pW3swYtGs7emrIF169Ut1c3LSpuIfywGHEe4V3ja5P+ElsJXDQx0im/p73Ga36tuKZSkdiGQsRCWWxA60HuXdQToji4J2Jawu1oPjMFbR5QQ0yP9S21i8PJbU7aplVeIzQzSA2hg7K1j1bdD8UPhShIHW+tDkWdxAuj8GXGIOiNHr1ZdPKLX/jOFpLtPuWgWPFxfV7nMQD4Z1HiVP9n8wI6DiKHvIzACyI/Mt6kxvhrDS2zHwtqKAF5IInAj2Uh6EC7zOsF+4v6wb7rrkVtYZS2Rc1OX4E3x+DT/OvQapiFncWCq/M2pMlRGN6lLL9UuaC3mg9fP/V2MTZ/qNydKQx7AwSDLJ1yH4IC0+mmDP/XCSp6IWQasI5sIzDQbmMrJXx/WkHnHlKGh/tXNyM88Sf2Ly/10dS6HoVHj9yD28mXALdNXfp8PdAXEAp+JKxy5M8ndUfQFiDzrSFnzsJG0nuUBY98NVPlFzXeou6ZCjyjjLxcrMrGK/4i2FCebH+SPL2n72L5fv2Bu/iGRLSgyHhWEo1spnln2s4+h8UFfkntM6k5YDRBK+dfGyyqya2q6pvHVCoKBsm3SUkU66ExZGd7A8Yszl2FNN/ghsri45OLswIa94VqHt+iszaUGV+4Z/FQO17lAPU7U9IAcMSZFvyH9kO4g/hItBqolZmBg76kn29GjSwwzBXd9wgMtdILR9DuoeLd6VEli14mCUcEZiKd+tui3brcnyxSp3PpgIskL5vtm0qnK7igz0bIvZBSzmo0XH45CBO9hrPZcr6QEjjmXz4K9eJHBQqAgMQsO1CtXe+HJyD/nqn7TIKtTUgVYrM5IkwLVfzyE6iqGGxNI2zGB3KzNIpRpDMozGXf7tTdHYGso1zRAnfhOKh6QoHDdI8pDv/eSTanxNCqaZQusFcZyYQSqPHEv8Bg49QvnpGqKYfrZNVppIUd/uyymO5E65s0w/72/PY/RYVGoQzkR9YkbAej57s+rhZHb/MQtdUN1XPKkVmprCxnChdKT52wmWkH35QLaMo0TK3cUJvPX7NOyns2jFPsIpdwlwPGKIE2kYsj61RcWlJ89ZAxL7697ALswNJky18+NOaV8qiPUAEWpToGtAj7aTUTmetbFnBnf6qShIgKiullJgldNyVtYftkmlddmOdOVmoQGF8VJwou6dD3opBeQqWoGEDxGjcNrnG+QGcFkQQwYi8aSuAbgemB7qDoCc7i+4eMhfo5t8kM2icDcv9f2B7L+tG1ct5H0KqyfOGxgJ+MM+5oUbmV52Y5DNEPOQiYWO2PzJM4o6T/uhVX8ICX2UQsPTGMT0VitG9AfWNSAQG5Me9MCHXKRjiuS1bgyO6Y/lN73ZGaR0A2lHMhkR8nnf3+1ygEJk8Ua4Epmn6cusL5WviqST9Or/8Lftk6RlrCpeZ6AiWG3uJ36Pn6uxcz5NU5ea/iXc3Kfe18nSehlU0Lryb9lPPk0DlwkRpX3v5NhH2oLzZ2gst1MePflhp0lpW+Pu9aQGXy/wM8Jf+g+VmoPYHfdYRVzC9ccFOhaW/OftDIHoKNXKkRqVHbHyWjirlw/PsaC9bFDlz4hQDaYGbfm3HwjYePR9qP6/Wfs8KM8yl9P5YmsiSFr+O/PPHOuHi1lZObKcuDB65HnWOnQ+tGl27siGbq3D37qrAsapA9tx9oONYMnt90oxFbhwfUGnD+7gT0O6iRVyAPWq/AMv5VVkP/FN3o6CjZ9ihuqdNyTtCidQCFYyDJx+zSDXBgU3GftpaZRfN9fwo/a3+wBH2rj4jVb7mqlnNUwmldE6GpSJacIGhCPHDBMqTZXMdPN//LtGKVQTV/3giUdczu+qcV/PcXxET2Uv1UNiddcCa9VR25CIDHzC+jzQWWD7dc1Gd9URt7+/4STC2lk+W63RG4h+XcCtZVRi7f/DjMsbsH+VHnCiBBNfDD3YXBMczYqkKUj59X0frz8tvjnhXfRHo7ukXMPngExv1/p/qmlNJqQVwVoDHy9qRyyR/X3qyQvl8lu5TraFxKtvD8UvsNZkDXYtF61//TQ5wUnltd0SEKpHsiEIvXQ57htkhpIEKH2nqyz3eElqdsFUcI0Gu4WB5lIskLwaSgKhLgbvXrO5ketH3gjmknmCV0fGCDstLv4hG5uCvZKpTB7IUKHiq3d1knbDKDlPGAxVw0ot+qwDnUMY9YO/KT85Q0wnSmxgY7jGTnjYwu9X6p4OA7p/kythggMsza4AY4JbglqBlFv1XKMkwvAPcTkQIJj/r7KOcqlwcJ0UQeCb67sVU1cCTx2j6HVO76imJZmL0BI94zQgENIbnVRu4LjwRuzkWAhyeSM5ZD3vatJWU30iEZuCySeN9N/lfXPHCFL91hJTtb7+gvAAoWw/JwFix73F+T8jBp5xdQIWzxWGUZkt6ph/1KMx16A5v8htKlvHt785gOw1QZtCST/mfLwCPhyfOZYjPm5bM/4B295sG3OcM11RkD0dIK3aKf7IhzJwl+e8KnsiB/fwO82Ex71E/VclvCjwnNSubwxfI9GU0mlR7BjUEM5tAv/t9RgHzutCd5ejPUssUuGEhTsu1UDKaXqpP+cpe58BQ8wxXJPLICyj5R/xYbWjZb8eq3UqXzyM8yvw2eL8tz30IXN29acfgcFqvB2Eygus5I6mB1IxNu8tpPzC/lqBntyN7r2AavTUMv6GgtgtkYJRe0nTgTdrV0U/Wf1zyWjSHe3JUVveS6UPaYSYAC/zPUNcTYd6NFXaxcqUFbdG6RpmRbDeNm6vubggheTfWjeCSLI1MWXkBTaC6btOehWSTiRFLlFwXY7qqZpEdfPgnT0QJMoVundX8K9dxYZlY+VvLcJjnnATBFKpNXwkwzbZ6Xf3FM/y6dQ+O4iI5JHc6kKnqQXyRPEcmImw+pvluB2UfPO7/grr/u/rwfrg3cPDoPWNhuAQPO7pSnpV4PG9fHNqn7SapN2qwOzkDWNz5RWj5L+AoTx+JcPSNCKCdeCZFn8cYhdcK/psMwzjc9wYSjH2bNgkqHOme+Yq9pT52fA01q/zTuquLr6U82r/PI3BK/O1D40CYAanmGs+VyLDX8JU/I4BAw8SEseIyHv2vmXJXet69GxfGPBOPm6CiDc4JQoGc8E66zzd4Q7z8my7R4jeryrqc0f5G6gCHfCTRKnuj8+eXAlssO/yDOXpwgNr7/scz3W1UCfUfOzZ4SuBEsL+IezSHpfepGn3ZckQ/Igr7S6vN0LKnbUypkiOuk/Re7rmi+bZCRcKKFL2aBsHe4C+3ZEHxHBVP1n9lmj4hRdCMHcjrNA6wx5Lsg31l3SakZhU1gID8nQ4UaX39gNJM/gKL87BnebLCA8r+nG6usQiWZEMlel0fD7sB/ygkjjh1cUkR4SdDOSbd8XFB2V4IzrnYX7+88JZ5Yl91oAAAAAGaWO4dyJEDTde/mzbnDjkBRhQEgAAAAABzYNcz4GvNuOKxgcx7Fve7XdGeIj9GWSeTC3MYCVs8lgl5RkyrMFDEHenY6W0o6GEujmlIAum3Ksj0rpKApVBAH80ZqW2H914d+CLHtOycrxep0WTR32gRDfgl+fcT/hAEK3bmvoxvQD74H4A7uIAKTtgTYA3Fgpvb1HdGNXmJ22u0nrWwseW56GIOdlCkQwvDXqIms63RXU3RZAKkbiwMCn/Lb0ztGFAb93VtTESIVD9fs2EOKbj4rntQrGtd0FE6PRlo6jwR3UpyPblrP5DJfpS8+nMksT0DyVAABk0JYNXcgOiguJbOUX+NY3Ztjj6eWE3TZloeuFaKQD6PCM7S5hVnRSCkdnTAUf47XA6Am3fApHPDSTythw68LFOn11/Kv0Q1WVgSbxwMB1iHJmU9gYvytZxn2kFstYv0VzzBIx8uTBROpE7ZrP85V2kljZDm/SGgRKTtiuKzmtLTZek63hpj7z9ugbLgs8GT6E341EAWwW3cBekl7wMPHLsAO5b5+RbAzy3iMXetz9m+2G/NVqdYUbYtLN9oYJ3LeMrNVnmZl9vLzXyyg+BSlCqNDXxTTod5kl0Ut6oEIriKFkJBpSniRYpW0VZHNTX4jnzPL4BR8A+JTlGfTVBrNKKmzbUXVo3+R2kpIAK/mfbU6ZWYrTcePrrNZ6Wjbho8FvgBmuqhHT7dd7rfU0XbvT0X8FLxPFhmWcIOd8uQGcl/m8CkkpEcxiBjQcZCJkzyDObHWRH0AFFam/cOn+NbM57EixVD54pb/Ms4p7Mez6R7w4uhpZgzEMpiIpGV8kFhi1zSvdGUgwyQieSrCJ4tPcU9CcSdJO+xHjIACvNdbrzUOZtAhPHZz7JvrQXlLK76gLPJgAAMAqu9Afx/efFR9AjHowikYwqqRUoel0dRSM9xy+BzHlhluDLP4/K4LfL251FnWi72k9ZEkBRp/6SivuOLnjzJGNyMps1Xr2hSRhSnr2ncCXsm4FqSCwRry2t6y2KTdLR/cvIzdIUmNNp4xL7+iReSmyVQwn40jLE6y1Eeyl4scy9zjPsq4Pe9T/LQMXBpHTyW4wG9fdpScPEl7GcT31qb9KUIrW2SwKlVzYHlRS1btRAzxZQPFOAz3TkYqSxbyXjSohvIAAAAAAABK+gGAcQgK6tXrbMX0Euj/pUzOU7yazIYZpIArb5uwAH05wVGq7sCA6ZAAAAC7yiXPFz0jBtRgNhr00jcZAPglS3jQn3HTlPp06p1B/SLQ0l4+6W9DgN/fFU7NKC7bcqHfqiAhQoDQuyk8nFgmgK1J0AA5XTQazymmd8GYINSWGktTIXOSrJCxgACPgUVcAL/5t/ABOu9ERDehJjCNQ+p3Hhi/72acLtA9LXjWYj6+JjDX2j/hX7VY+dpXqI1nHN0y0jOpUBkaZakldlCUdIoNFplRe0mzsr9cTu32GGqa2px9pUoY4+UIH5x81lNM7AMPo1Nev2Zg1mDd+QhhFqCANphLf6C71UKtnab6pVKctIPo29VP+bqT5cV2WUO6V1JaAOpvKIZd5Zl1ilJhpgqMMjD5f5Ptij2iT/3sY44pMCUAhsfMmpi18qZpkUDC9bDFxO3qSzDgB49mfv2QKF+y9Nuy7KswrWmNoRQ9kIiy6/MXEmE2mUsV7Jhs0N2rKv2kbyE7oIo2wZDqT62+Jab7GxdLMCrLLdsLErsNmIREc9Iv9xtFrwqJotG0FGGf5y07Aa2aIWfRKn808f1r/NBh8CAeB6ICgbyaftKefzZXWWtU7kK8t01xUoxbzrgNviRRrNfeKxSaY5fj/P8Ru1VpenMDcjfOZPakv00VOUgTki5wNy2KaszSEQ4S7Cyzb55QvJdhtGiQO1RUdRO3U4qtNz9Td8vADhvR0bIkMy+P2y2QAqY9h9rPjL4HMLYxn/rcAkhQ/eEUn7ufNued+w/HGenHjrHmse6w2D9mRYKJG4rGhc8gpb61GIzr5RWwLAoMrAIBuX6+lisYcGBM78GWzMCM0xpZw7r6PDX5mBn8SdV0mUa436gsLhNLIuNYXIyc/TGxdIgnhyTJGiZ1tDnbH+k3grgaTnLfnc+OWVNx3fLyft9nrJ4Y7YWYG4YAQNraRbX7zOMZ5I8ZsBIFOoFg0deBj1jNcIYdGiXWSNZt2d1duuBlcu1UBHEuik9wYLWpuz8bw+R6UkYlLJlNueESznZB0taBld9STUUwZU7E4AygDUGIOeE1OBKYAhqDTrmPBND1eMDor89xLj6N036W02NG6qsdTxspied2D2BGoLwTpxDa+Hl33JNwAAB0iJTSJBQPuxpQ9HZA7UpsJBvExal9wUby7GtNmMUR9Lvif5ypkUhYq9Nv1LB/PaYNhPw9w0HabiSnJVanHCsWW5jrzUT3AorVB7fC9HhwHdXIrrOYQPp+Fmr1OGynymom6X/acJypSD99FoD3P3MwFUBRn85B4uJDZ0gPPWDlk1555h73HRxyovxu970cpeBwJsYWJA/ntOWoBsxRH0u+J+NzyfxjN8/oyu2ykHhbmGujEpb/RP7YyLJuOEyi4Q7ZDufIKAAAAAAAGLhwcXa6XUruZHyORdNicFGvKBPZD4hT0IZcQCoX5JKsObua2D+B3y50wrJS8gAAAAAwoGOn4DISNu2/7fz8jDJAltW1PEo6DGhclmgxrmQXDONBEjGp0bsXhgxdUGol6k3S2FNYbOvZx72dTMLEIt92FKkaeHy+krKYpaQDltoAAAmDgCAcQLKYdlRQG7Pz1d3+x35FKz82I7JyG2x8f09L6h2Xyp9Mpslh/xRsghzDTtbAOW8D/w4u+NdozOR+YuzuuvGFaalbCHFNxwwbGRPd0k3q1eMWrMi0nF8cchA7g6b4igfGCGSdiMzksQrvn6wABA0pclT2k+bIAr/0aGIJ009zrscUsFGBnz7bl52fcVJkR5jsvvFzZlHALdx2oC60HCDpGZBITrrle0NHox+42+V7L/SpwVPfzg4XlBFQiYLPN86I6NjufgzCgcBnNI2xG+ZRlCIsRtKKf183CGtQjXAAkzyZX2QBcWt4bxWKtWDvW5b6+TPglTR/8n+gziUd6u/HDq9FBJfIQWJOJ/RLKZCqrcg4rZZVa0UDenFJPmEK9Akx4beuOs0sP0gsSEwzH7VR2ZaNZwOFK6MJe4JooZ+lzuzU7/kUcyDJJ3hemstbrlQX7XGbA0VhxwJ/M4vV9iY5esGJVslHCcPsGgZQrTR9zOd5vsmdqAXo/pJRcPiZzuCad/xO2bBmnwG1Rbvox4l9cg6KuVGobVxVwx7o1Y5MENcTrlr1JJm2dDXeaZu1cVcLxBqna60Mf3LNazAiFdm4Kp/P2o/5IS/EnUJ42S1oOWUQ66HubRuwB0NQ7IG7hBqnWsbu2Ap+CtYj1kKL8sG7a3/ZJ2FSggNF69vICZ1auAXoRp24oJAN8tHLlov4UUraXupR+G6vZWgDTeBvBdSgVLyDeQTElAgGCX1Kmlv7DacrOUKue5yMk2J6H+TFqPQeudx37qXzWuIgesUMuHqz6lHfqirl8EhGq7y6tuT5CUGlu3xYaFMZr4zgYFuXtu1KzRVAwKRnwlMmRIDTEKMcS2EKlGMY6WZmu4qtvWIqCDEDiOWvzxYI+v8ef7JuDP7gJdAZXmMIQ31RSv32C3lJXI0so/XNGOfJWEYDyCEr4AAAAQBMabReHjVkHlPHeQZldFUMWZ9Lgol2QPROE5QpIpG0moaqOLZM0T1wXB3I5q3D6Lxs2kOKsBVcpEEBGFTs29Mt81MsY5s8ak3PEGQ1ZR5kSBFDwvAq7haO4vOn5lsFUMLzs4FmtUu7XVAiiN8BtaLwPxqZp7BbLjgPtKMBBxDJBh3yuyj7u7xPQYlm7sSJsFBRzq7SGNDConrdSSAVhah3uUbbxQkcgsMqnHt/4PRKXJaDwCe7DEzb3JQ33Yip0D6AAAAAAGph0MDir0ry20LjBYDw3rkJsx5NquuPQBSrdedpfDniP/Km46HYLLBTx58BChl/sea3AAAAAAJCeGQPnrhF4iJKWlg23RDEqAHWX250hgs+CYJ+t+7WS3pDfLBdu0BlzUwe+Z7UPSCXIAAANzJzZo1alBn9NMy+uT8TPWftVVeN6EmmhpyNFSa9hK13ThcgdjHEhHe78110DeYPHOtNgrgfdFdLfMeo0Lq2piJEKh+v2bCHFNxw1JIrTOTZoZpbi1SMZyLj/l5CB3B03xFA+MEMk7EvladRCvOzAACGpS5KntGUMNIwyd2QYxFNP8T8Sq4AHJEqDfK1EtU0ciISjAhB9scOa1pyzzp5Sv8kOUT24x18V274cyDbgdI6ES58qtWSVMCp7XZn1Z7b9kxHqccFiDvtVOia5cI/gzutesuvob62jmq2GrZYBvEgddwn2bjiAIj03oSjHzU85WSWCYVS5UVYQHXJgwyeCcmLM2c9VIEEq7TyQc5ULFwmWGbDAcblUIRyZmziTOy2HRBRLGKkdWF0t9/YEUIxCfOsS2A70cl2HtSM+mdLoUwv+O9M1v0KY5RyvTC4g+zz2v4cm6b836O1JczeO6eAly4RE3t1NtrhPEw0PBDOMCUXbTjeWYeTHrh4/KHL35cak9LfePjVK7AH3bVYu/HLjtN37IjYMZxW0vu4kf7gdwPa7lqu+WjOqhnmNCd6bPr9m3qdDKjyZWFwHPV5HevtraVoYMK5okACCmYQ5KH7qdiEItu8O8GyOqFhSRbR7d/CknTRgvMdLD8Zq1njbuO3k/SiY1fq5E/+h23cJs4IQUZSkHMaSrYL1pvGo05cs24AAAOcRKaRHLIVI6DqnfrarbS/blFoDMvJe83AX2cF2rJdEBBentePyUBUf4n7APlB4vTM3/Wuf1FYZXwjDgtmqAgpUFmElOSqhEWks5x0GQjjFEHr3Z/PUH8aWGFQnDrLrE7he4nKcOLVhDRO/Qr+YoqHYihcQYlm7sSJsFBSfNHxg7/l3O/JLLhMprGAyP5Xj3USpzxTShC2qk2CEhCA71FxILEBhId9BkzgJsCh0pGXVTYyFqRUFfo1qEIKdjhy3FBzcz1TZuul7NA5rXicF/st3uTcvj0ydlB42lzTDIIAP8+chTRfOwSI27ZgI9ZKVKYtdbjDn/+eaS7puP8B6+drGxs79AAAAAAAG1NHwMAE1Mh+Hwo3lAoBSanZr5oxsAAAAAAAAAMZRmbrUQn+4TNPCNo0kKx9fN8FVYl+K79aJ9p9HNQtv77HghUQTH4YKkTWAl/JVtdZGukgNG0KQ3Q9kZulyPhQrM1xBF5f6Y8msrNBdkSHAppYwms1rvAqjtFUu+xBZ2cA9IAmERV/TOiIt0aNC5XJkk8aS+cNmhLFAlOwb2p4q6oZLFMRCTE7OPtApLE8O8BvN7SogWt3W06z48y174Im8T/g80WWp41bLfY0D99bAVz6gWjVCHMcvz1e5l9NONmyhlZb0ld/8WVGf42lH0ZrqfFJsp+7KGm7hdHt72JDMlHTWSuZXuRTXyp/cC2p17Q2za2X2j6AMMneIw2UdyqPy60ZWtTyVkUiDb4zNEJrbijCI5URmYa6XeVCYdM1l9OVlmhXu+gjytGga4/bHKYH29z2XoaZDtXeXzyQXxHGuf5vdZZ3w6W/nF07qiAopreqyhcdjLTQtVAgfiU/+2aKi3+8hNIK1vDu6QnQPdOsg1hikuSAeqtiesDj9D+JVGebNpWuIP3dkC1ZV0649N9x+0RGM9ELwtUqeGik4k2F8xAGjV0Hcd4idqAxU8bvf7ogT2A0IrJZS/ESXANSoHOVHvqxHHUQ/cj+x3EHK7MsqlqiSiKQ4AkzD8Ksgccq6aqfir54SiplpZb82WKwIAhRILRjaIaTmdk6MWls3alGc83tc2FOjXlXJ67JQdKOxWL+/0MS1nYrU79z4dkeOsmME06yDl7ofinu8hTOuj/VUAUHgELpYUT4Xc1HIzPkYzvZYgUCWL+N9q/an5tTUlGEmEMX2Xt0nsSumfbS1hXaEU62YShGrYG0fBMI140wfw2G7gWRbzgq7AcBnNIdVdVzUnyd7O7wNgbbO5gDynTXTY64k3gN0Y+S/EMpuZYxeO+SS1gZ4Z1y7ikcKQ5UU+63F8B3fnWoCu4dtkRHtqH2CgpA3j5ar9YE99IBstzAsOUhSX5OddOl/nplG7+9Mtdt6PZKE2qV2lC1ZKO7DPfkGU94nvfT26BPNN8DjTnr/iHNqQ+ZIPq/+j8bN2u6nyRNY7oq97zUzH7Nz6VB8xggZ+QmKMwi5cibas5lLrjGrFMy2tmTcltdWuAP4Q0s9XNCj1tIGYVp2mmXLk/vcxF3o7GlA6RHcF0Fq60ARKn1KXYbqU2vsQRKGdbY4uzzlSb7Km4aINWUCxSVjmyGzRxFCgCGWTjAVZ6aRtFVC7U4Jr6OsQKhI1hc9FNGihQqCnlW1Di9+VZgVPCuxFQljzRWv+SqC260GNNHEr/LYw5nGhXzN60J9p4NQBowOGERuKgoC4NazsWxdfWKnMil/x07Ad0VYGxr9lbB432VB0nrbSKlUPukj27VwSl9pXvCgeM8Bp+jg3B8uCaG1cUYReshN61u26ylA+4dH0BGrWUBBmak3gcJYnXigvliT/2sfhxWQ385at5gF4KjeJ7yjPL5PcEHN0/lFUmiLFUI+Qls0cCABoEp8txfocTZzUY6zV8Mm2qeeMZFv9liHjHDenFJ9t+j0lsscbWUCYBAzLyru/b/papmz6gHvFuXrsFBHM7N2+u7u3zo2ugOfTOhyFEmjzaUav/D23s6rd7U7w9ypFywpFVOpgI70p2TKlbogw1JQ2LSgRJvEFxpgUnynrwlMF4PLL83us3xZdNBPdjZiNTimXCIgIfkjl2rH0Do784sqMkdwtiux5JoLKLvRTV3k75wU1FlDo09nbVI43DZkh/VwYQQqsDN+znMXcFAF8TGdWvoReTGfs3tLsInZiArrJtiW8G/3lXz5c1s3HoobtmaCUAgC2qwuO7FF1WyLGAYInXRKoabuE1/nBIgvuZwHuGPJogtrVtT4AQJ0CpfRvxastE+lSH1+Ppu53LjjZL5K6SmPRt5ImABzBpgUG7XkQk6i0lM1Z5+psRPjLMsPNnPQLdWTH5yUZ2+Xy3Cbso2V+gW5uO3cRNoLP5Mg2DskOKvC302ScA95LLgS4j2ssgm/hlia5+hI9XHViqFRTif07Co61ZzVqBqlIPN7jv4OCMjUKBSk6WYDa/Wf15Ix0b1TYDkJxbjNiD+EXnMLIjYGE6RgUeLX7C4q/or5IhYjWS+INknSZRCatvDEkLmIvB1l5gx+c2iQTxlRhMKZ7UVaTjdgr4pd8ernfUyuVZsJfjNYOEhUdgozSmL1RKNFG/8LgX/t5ytg3l8d6psByE4txmxCtAORqj09yK0myxgpNeDpCKB0Uy0tZzYHBVjYwdVoB/ausja/8kA9ZwgLYHXwAmZzDnjO1Rg71k4+cY2bnlPHgu9fBYUzkLdZXgrXjz4kKzyYKMxzV2Vfiud0G2TB6jwFc/hkZQImsBqsZR/2RtiyUlE5AxlRhMKZ7UVaTXZDAhf8Cxb6N1pg3n5w/PEnJHyAg7HbKH63lpQenicxIqUBX/V06kTSCf4zDo6BQJ+c4bAXzBrb8asuQ4E7I21nlnW4MBoQvmrwFQHbnopes9b2l0HtxN16Vh9jgJg9t3/xASfy8vWKLWE2uwBWHxXrZ54J6a9rAO/nVgNGlvpuXRxn6wjF1CMIcnlGISoQ4/ThBDqnRJRi91B9RdLDK4XmNgIk8zlz3izD/kOFPY/bmTr6fB3T4GoDL0qMX7NGdfpoAJY04f6vSH//I2EDzkPV4bx+bZFvIe4RGOY9fcJAORJeBEI26ED+LgIu0LOkbyrzl1RlDf15wqn8J6ddk9C592eTyjXiyICnf+jSCNlnIzG9dMA4coggVxMTexM20xPp9BEU+7JCS3YXilDtO4uHNFm3A4HPFJz+3Urc0cQu4gDp9H9h/yHCnsftzJ19Pg7p5CMR2V7aigefENJaA5P8VdBgHfoRvYUxiz8Kku0bQnQ+poxA3dvyW1NA3BUCLYoEke7oKn/NfWX7zbE0m5eGeTQ2OTSVMqNwiaSJLWpTztnC9SiuKZ2siosu2yFY0zs+EsvbMaazQ8q3y8aMRQpMz3UW3bV9CQn1eyrHVwSewe6ZEF6zvrijEvuFDZxiXiNMciu9tBxKUd6ssUQWOxY9yaX9XFaP1st2yPNLf0/MCazE9EFYGZVmw6JOPPenzs57ACPjEVxfwY0U3lOzUK+E6E/JI7t5WOCcuNSeOyqRSYeUALzg3f84XTQOg5isRUD+Z6BB8WQo6N1q8jvdqwfGAPhaVNlrCdFNJ47QywwI9eIhFLadbHpSSWSs8v1FkJ8R1GdIwcMp2UPWg4GfvbTzudJ2Vt5p4Nmqo24FwTm3ibYTb9tXzzYrfO9H21izLXgH6muxdZ8xC0dsqENlnjv2pbm1TRLv4dqAPY6c/89NJt8Uzev5uv14QJt2QjE3HqIruHZcnd6nQMkisvJQdjemRi0f369FdDj3RpN6hc3bUCn8jqkky1Wr08BWA5z6clL/jisH6NbjUSPnysdvBMxh2GmbJ7Wj+YOfvfQPrMssvYRA/AOqoS5BWSAHTW3oMVnSf4ATLPJqrECpA5BlQTMhXQaAajumX03b30D9mXLyI2jfszBZ9dFeIIwKsPBiBl7/aV3MaVaaBSkCV2gS9s7XkCra/uaj95UPO8nN9LWN1g/3jUyIhysdEVAe1NihOT2RjZ9R3OO0+lgWFQEmniyuHb79JrlFEFmIlGR9wgNBprXQqmCvy/kTSKCioohUWFWN3fGiRrlHnuGSbQwn4uEGbGUmqwGt4vK66ZgqvTSGyCThX1JzdJx3l4NoROFnfkg9nMpCOAaVDZuCD8Hrc8K06V8oPARSyRT7e/W1IQ61vo5jwL12ccTCHzhwkzE2PR2mPHzB69FiNvJIw+Y/VrCqaNMc8vEMe43rMW2mm4OEmTsH/uMypinrgaz9CHmvXgw934mbM5wtvEOMXTcAUv5HDr7rABCvB+bQO7lDh6G+bzx0JIxwZiKFL51cwXYoN+fJEKpUPZWP6ghoFya4vy9aTHdq9EbroZklH6tmR4+AiDdwpkEyOOF5eR19d53j9y5J35T0dRDI3mACzT6Bae/F8Zeb3skSICPtmPndlq+/J7RfkHeozt6PJC/H/ufPyYsHSnU7U9UiKd/ekvXMxAcxkHtQnCwMARbQ6NYLPa1rJpPRJqqZry+nUdicyBgxGcxMHziMnPEzbOxAGCu4mGRYrcAPfwPyipnXdOZ1Y+pK3pBpT7ZjTjseG4xhhNSZvu9LU3tCm+GgbIqICugVVgPpzlUeWaJiFp4YYUg6/tfVBxlPmqvsMUH5kghEqtI3lSGpINNg/ATTSjUhUOWCxa8q/faNgFFVc90hZAJMkaehZNEUhmZX1Od9TGmHxX+OWa/54V0BdQSa+BQV/dbqhhTs4+VfbzLccmzDG/02WUaeHAvSVB1CP8jp7WVHBuCy95XERgYLWYBDwQrzGt6QNOxxng2mxlZ5Zhmbrfxixh/podExAJpjdennXOd69YDL4UFg9VapxrlkL7bj9wdwdJd5ajRMSYjILHM0/PRRMhV9zXq0gmrtOF9o4YoAU9B+qO7stcsn/wlvP/N2mML3c6qDvnom9VYduF1h8D5GrfORS6j3qrFi+2xNF0DHOP8DRiVraQOGHsQoOtdcEHGIWwLYrd5Kam0pNEbNoMB/hzvLh8mKwx9rRCTw9gm5x5M1T4ILqxjCOtLvzzH/cDs2mHQotNWwc9ubfW5OKCcY2IqczpGzCB94ONiU5jLvuSlO03wsnj0/LKG7S4pbZvenSE0TJq1iiq4fQgflNbsBqFzNY/bwaLt0Hct0/KHOsGW51AyelOqlsY5zESDwVt4geYrI/AK80UIR++kc7Zul13KhNIheHjpT/g3ynduPc26jekWlxkybus2vzm9Ai563jH0dEc1D3pIg0q1n6N1CBMkZyHagagXA8oRsGR5CBuBZdBxqA/fCBNp3btpN7Tl8msFeR46taXU8T8FOENTvat9cYFMtKJu2aEy2QpXmHiI8JiMCeIHgdO7rRPDxR8K4yKfTBwXRC7cLQzRJg5SO7Xdb/StiSsaDncQSDaTPAdFs0Ydi7ZRnB73qXlLiG4G/0aMsatJqwD51bVt7x1BkjZdiOqb9pljm5Dg83oiFKyeXBBtIvqwaCy6Dh76NyQeRttWRPRsdu8+t5DESSWq//S41Sdj6eiV3Xh+mwJolGzmQ4rTpZ+HJ8uNye0m2NY+lzrh8JYV9OXxfLSaVInatmg2Wf0f4MFFRa7w3yXPGMy7P4x6AGNJ7fTf+Zco6uzsNMm0a/lGDD2t7uLwzef1JEQ35bp2BLuWCY+0lN8foNlFbSI7WgEJFAokm3Yfy9utmuHewjhafIgpufzFYAmZUO4YkQKQb/vW2hMJHd+EKLB2CHaTbHFJGXuSBpfg9+efNUSf+jHnwW3A0uUIlAmYT5DmnExPVpNQcC7iMvyG8srZ1JPk6kdjNnnCQPyF0kR0Fd7XSqX96a3rHnDTP7KONbGToD2v3NnZp/NMhEDIK64D6ayTcxvTJY+vsOAj9kUgsAtdCIH3AZdtyh/kaN1gPX1Bje7noaL9sEgr+GkbgvD59dkmAU3p/lga0BOXGJtTdlASjn5KezKCOJMskCJrUHIJu2e8YcHaokwiXIgw+bTHn8zbrVLq8VINgPEou5Zu/N2qfCXhXP2ngedqLxDsHPB67K7tgK0Wl7e6oyAq0j8LkIQJDc5ZMIMW8dLDNNLW2BXpdgIqfVBcwF6Gc+pt04RT93aZI2xD82oigZjl8oO1bY2MfBaV2hoaKMiwJsvNnjX3jY1ATHQR4yxhXyamyBH8A+Vqh2yR50WEKV7yFTPblQmkOMMW7CuPl0qVPFY5BeNmMspKbUbkE0BLBMyyb81leY6kAtZbdBfOHtR2mZP32Noyrh9Bc/T+LhBhzIrThIZc+FUo5IWAVpoTdNWIcbcQHqAco597zzXNDYAU7wQ4TjbeAZuIOXGtXR6tE+wUIfYnPCPModzPZ9VM/SMy1VXTZMtgfdS68PIuQDONyHlvRQzG6+6doEFgKCfok4MYHczC7WblZercXiKW+oze1+epAn0o8p/cdD1pCTDYPDbSthvaHn+5JwpvG8RdZG/ZvqNYSo4b9ffMRdgI1Y+VeyG6yfTIW41eit/smDGCKTslP2/C77C+yG6WrxUg+Sn0rSESEpPVRVWxcNzNb0m4sfew3k+T3XrBMSW1h2HwXkIDa7ulhopuIqI/FdmmskaqymtkQnSaatTCSsgByCwFiSmBoTI6m2r/vXEI553sjXUESAcHrofL8ruT2cbsCb24AUp7rpl+72Iqqt8/DxYr3S+4nws5JsgCZS5W6Trop92Cc9bF+SsD7ABQYt9rBF7XgxI2kXoAAAAAAAAAAAHF5tABaAAAAAAABTDcUEbxfe9OuafTCvXIwRLZObpQVP4n+oDUoc4BJTjrbs8f2VkHwfmt+kHU6TxRgyBaeDERrnX/wrhkc0hUr02Pz89PYd0dr2zC/0356JK3L7HKjTEmDEQODaGYzD5sjLx1GbXWtyAoqO0A4Yvni2kNrNzqrFwkAeGTKqPNA6HfiffODyj/GxBCWsuCMiNHpGtTrjDvjAwzPhjyAsEnOaAcJS9vIS1ed9uYMCvFzqdsZHXSpO/EERCSFVqvYbyDn7yLkVf0458TKaAMIUvd43IpoaTv480+S96TShc+2hl4y5ch/NxtiOJatqlDNXbCDo4IB7onDCHiEJc5/100qoTj0nUnyQbSqeQ+/8tRqiFngvG5pM456bXx1FSTYumv61tRZ/VENmsZwUUw5CLHPDMbFMzW3pfzDjpewSf5Hl91u9z4ocZYyS8sgI33soHO3Nzxtlw1ekq8EvTjXYDRHWcUh/efCCgTzw+9ucQR87Am5LjOm122Oo8Noac4kZK5ALfytW1UvY5N1POneGdTqWaJKADYCIrE8U6JJZT/FdsYnU/vTGtVZg4aLo3w4VW1S2wD/UuDCzLoZeN1WiRnBUvg9i2+TILasmaoP1o3yhI764I2MkjkOVE/wgFnv0y+wVnKfXV4gVsx0W3Wu0atiXf0zWuoxK1XnYTyUzhX4nbug//+78IPn4j1MNf8u8LG0m2xJtWqRh8Idw2W4tnoCdToaWC5CM8/TTlPQVP/KsxnFBIh4GomfBS4n/w1VPqCHPna0lCoNXjJt1twaX0BW4I6zfvm/eBP29FRU0pxHAqa4c+F/pnfvvKLneIZNgd6I+Wih2N1fr4QSEvbkZSgKOB4wVkZfkpUKeVmOz0+cC6xR4RF18fMLeEz2l7jRb5NxGyDOr6Lj75fuTui426uiHMPj4yI/5sd6x+9s2tLePP/LpOsaivcoL6r4YoNglfwJwD+36lKblTXedoLW1tt3X9qzxHLD+H8n2aRjfVBhKUEfDQbKgpXzr5t6CA1OdF7sHBVxKhmqN/kxty6AIMWD15CQ3qz10AQYsHqBuD+0RmA51prOsz3RGL0q1aJh9LLaJvG9dUr24xNzBNlmvOET3sMoZ5lrBjV0mo/DsxT+o0YozBfJvYCzbSjDKPn+VctIg8Ii9mVlOoNKiTDE2dHqm/M0JixHyJsb3ukjngq4gmpQ6E6CZ8lB+1oy45hcDftfE+2sOe7PcLoOKN397Igb6AnqMQ3Es29LLvzkc2f+KEAv+m1lgMv1sGPUMQNGGXENbPHTabLe1VFV6fSqg8aIxY7UZzEBNAARgOsWSohQvc4Rh9/7YuZO5/8PnmjVSUzZ9ZdxooxRe/LkYGyN14z1UtjTgL5Qw0Ue0cIfgLcC2LTq55h0nB9s2QqIjoE53VS8ucAqLz5VPIhHjI35xDjf9uYV639ysHFci/7K1dnhi5RGYjTGDfeI4ELuLRdGiehOFzWnz1RxKx5ovLCdYzFyF3gq/THKnweFKa9l1P3oD5JM4qs0aVk05v5kuhqAngBp09tSZskMKjE64oYYzEu4Brt4qPhl6PQuYgqs7j1HQafKoZlgNpt/lktsVrHXUp4JqRxKZO6nYeCcgSpIyKVwx/oxFTCo+dPmAdWxHAsfViEnA4imTqY4HHC7fYlOcyfkh6JTvr8//TRUFxF2hP6Gyanpys5xI4UrNUI68GMypEi4zRTMvPgo7hRxhQ2t5xw8TW5wxENFS/dI7d5sTv9L8ClTLr2c4HKz35ma+aXueppKxfO7j3W2OoyY7+U3rpEcmSwPQGKLqymGIQLSb8ewqwXI+qa22AQ78hMXyVGU7L9UKtsYFj6si5IFPQLMiGYu6xHoUFjy0E4KJzpZ3PdHjB7kErBY/aPJa5Jh2bsaxnCLZG3PQrqGlEpQzZL39P3htweWlU5yjek6d/5bRAE518Ao1juNz2sZjsEMp34gtFS41CzE+XPoBy/OYLPT3h1Z9vLOaYXCYgv9SpTBWuL0nMxcYU54DfOAAwvZI+fKfv6h6kcr1INv2+EwX71AaQ//ycPIjisvVgZNIpZgEnOXLPh8EfW1SuKf+GEFlA5LlD9Cg/JlaMcZI1SwKU5lTeYjlJApBoNKHV/pjrhwtcqx5aoPKakrLYbkBiFeVT2Sa1L5tL9AMAvGSG8Yo3R+i2n1TL0oYnXAoyu6UOEUlqe23HnrbZ44jSoRFrnFtbUZOt5Ib1wgtteBD6V3//DtdP+KmIgXlqbQKXhF2k7bB2/BhrhoWN0sHWfn0uLu1F6nnGx8G6gJfxsI4E93SAiN5RKh7bhimVbFP8XuRXsHS6bEHv2WkTUB/wEhv+MneWLtIplcnme+TfylKI0mdHQiYNsBkHii0GtHCbDOJyYn/wVU5epMd/Mk0kb42BeStRo1f9Wctygz6TgjtoPzjRIWwLfAMD+oEx4d78Zri3jVCLXziIe/JfSJtleNAh4JR8k8w6uwT/iypYmJpxAsqKkzdPvU8QYhcjYJ5Jh+I3ZBGZSlJNk7Jc9XqoqegUwPhvOSFGOJbDA4nhweVRLc08hnAl9s2oW1f4bsVXyMd/QSQL0Jett5OertcbA715nKJ8am5KrZAvJtQ2jBWOO8FqjJZ2HgTk5iNRUAzrWkWAaS6+3Czpindvg7iz4meU6w7cu4eYw41QUR5DGZKdiJCK1OMYMOfpKrJMBfJrS3fWDM2jh/xnkzTQdBcDySC2P/KcidOR976TW86hnVQsMklqfufXnJqfaMGumhoIjGnhTm9GWcHbOAXbd4d4O688+Kwk3XjVfo16ruHEUOSMJU7lVNpseuVbIybEaw9iVWE+DCtxg1YQRBo0pINmXbMbrskFolOHdoLUakkf5vaqvaWp4mUSua4e9FA9os8lveh95gZlg6e7JCuv46+Q4QLcvJVoPUDRP9qeSU/ux8JKnAMkOEnfmKC2Hlh3/IF0l7fFe5fYctVh4E0cTDF0t4pB5JPS2mAPa5WfeGH4IiPXSq/pdLZUtMC+DHKOwwVW3oS61ejGxPG0EYJmAnpqMJkIBvT34ooBIwH7J7/zfLTQaSVIAmk5fY6u04KHYgVjnyhTmaa9HISpxjLKRxMdqmtI5M0pG9izfjJBwoo6NIgVmymkDswVKBQ8NeVwb16cNIGW+foTAdJaj0k94CGqfuY4L0xY6PO6BkDM22aLOPbfzplN2M7sYWaIh8mou8ogcmJ1InU/Lro8c6cr0dpcKMUKX6abi/l6cPpn7txhWoXsKdaUYBSFhRcsps0nxy/4Ct0QcAMjmk8YJ2HutwLIq0UOfFiu/tfeBDCUMkD5Ph5W/lb9FCwdNju8nm/kpPmBteHzZa5inGkiKIWH37Jh+XnephbvDJIPZnevPRV3SZHnIR8zr/af8dZOIql317Fi4ZhCCjbLTRIYi+pCUzH5Lrpt5wknh4Bwd16pOVH309++FfL4vG5MN7NqN+vFLfNtsH2csX3jKL/PVgtUSKwc2vaUXaUXsI033hAhqO13EHRImAMBLRy8kGWAFTlN+M+S2VDCM4EqxRfrFmsaWRv5CFHCitWszFqwIjaKybw002hXZRus7b4M+UPApkp+v/HLyx1ELlFDvv7qo3efiPWgaw7nmMaIeTJVCQL/wgekwHJTgilSK7iaHi5WzhgODHiXgxfVrSg3rLtZCEuOgXEgN5zP7yuOS1jEnzGHZ0Ik4YChQUTZAJqXmtB4NqKbJXdTi9DjX8mqP90C2cgns0eJ+dQ7RQ/db9k7v2An29OiBtxjIuEdN5/vpfh2n6IlOb7Pm6naCjCrqeK+9WtVJq9dBY+DcVUTmpsw/BKrn43y09v9RSYIi/ea3dUPzVSOh+n4vmQHeMtHhls52VfU1E8QFcABPYIjB8Ak3G0+mqkRGbtyzkjI0w69OOoj8SXsgIVA0X7vtLynQktHoQf9j9utMi9Z1jffl+qy6Uf+lfXAUwBgIvWGWeCHRE/+4V9u3Y6QvcfhY3r/jtQJGNRkOdkKMn5nFlv/7h5EkqMvy80JdECDi+AEKoTPKvICHZ+mEzY3HvicDrM6ZL+GwS5gv7jA2qy7xDNMBjMYbY8VnwilczIyp7FUzImEC+Dph3Tri/r7y9fL1Q5qr+9LDI0m19pW7TLAPBMTo5PWUHE3rwFsUrcNj7fJBPEVMlBPORRBY/jeGw6qANmTMri/iD6r8xsSsCP5ZcLpmWFupY76WVu8tSwTtFMmOVvAjs94wb6z5xz4YMJGAqtIoEU3cxPz7brQHkITZrP8NU/7p0AVUQbVyDgBf6LpXVhvpsJ5tY8pORK/fWaE40RGo2znapf3rGJxu2mDXHmiRHswAALjKhnq/sODgCcSOPNdvQy1GNKnhESii++7y5jyHbMc1QTYPdW1p3JUxlWnhfbF+VSw+0bbPEB8GWuH4pTTGCnx7Xyix5Mh6vzel/vYQHWyXt1TyPF6kj490cNECtomYQwwLxNTHsbKcRGK3la8SaUhe9lGuVl0QIS9hNVBTE5yGVS7djZ10YnAw52HQWIUbzloMMNmuI6mPIb6UB5KNX5MavMeNOwNqKVH8mTraHrh/pGg4SsiNkjDaNKyOlyu87CF2IhoSJC3z1LX7t2KLt+32Ik1kbmQQkXB2AhPR/KTmkXcKOyuAHFuehKqR+dPNkZNyQYAHf9eWA2XvlPEhS11BTXIEoub10FICw1D6UsfWb91qaK7D5pVkeXpoQk/A99oAmw52j9D8d/cy3J8nAQjXwd5hvNSP2eAMqhCufZcCsD16z+WBLxos3rGxBRT5V18XiShzLU+RKnGyK0xWTNV0KBFLUpBB5++GftRhSpUjCAsyySrWAjaygbSkvmmPy5gN1xo0pU3wNWoPzDVHCLWIXuqLXwyqPuJHHNRb38U+3uDv8wg5LkwXHhY0Npv7ysCSJY25qqUNqCdSboyGWOrJ/w+W3NYza4iW12KzMrZOXOuujF+huna04SEeIKHV3kART3BaNfJC7zSRq4bsRAK3j0/P1hGfcNc8aeja4cEuSTBvQmVtiNvEw1OIzPIqnkHUjVSs3U+Ve0/ZKag1tb796vJoqOOOjeEbp8maMCXn1LZ88n5EPV5TGs5goVhf53wTDwMEjzb8vKhkSrzSOtevATp2Pcoc08u6tzz7SFOU5S5WHFDEhBF78EHvVTz7LsLbGbY1wDFw9N+jbPCKmpVSM5ociE3dYCo0Ej67Pw0U1gn6D/BZ3b+a2AIbsSxya0YrihxBBYK8e6xlqPt47riieoC8zGqnv4akEKQwNdTai6N2nTY1SJEbvjKSlRHWKoaTiOYVmWFdgOV1PF1oOfj0m/GG+FLBKqOfDq9GfSUErq5Cr9brEiG1AtDrWU2oB2Xxoo1Y85pcyhjwPqfPFOV5XBp9BiYgImJnyYAigrNeN/HezF3gvFg6FzoVCMbflPHirq0YTOoVNM668MpNHhMeqJU83DBZllzjtX+DIBCLkQMC2bbCXoHpPcfzzMhAMeJQp+EnfpdkzfAkhpCKJFiaPdDHjWXwcaKHMGEm6ToGkWuITf2pi3Jlf9cxzHxNSemZc5X9jAFTN0JFQ8kt1029r9RErAvzs8WrymvLDWExEIbw73vVSKDjHGmuzsUTDsGvy2FRRfX1n1myw4KQHJJ/dUI5xDs0U3VQj5SICPNtjA4BCAPaJuwE964Jf8cnXv9SKK87ZKE4Cuk+KvVq4aGKz8F2ADNmzNqkFLeCANHAyGFNGML8hsSp4XNoHbAg8TWrsHLkdVYKpDLzYt9Y6JeT1WYaC1O6Vnk22lAIl/stgPivmAB2EmPbXpch8PpxUtbKZGLEH4aG2lMkKumhxTYIKGP5Xoxz5gbidew9PH+137t7usfd6l2ooOV+vIZL1+ZP+9v/fsShpL/P9jyAZZMdXuGBnacF7AJvaTgTpQV4yoaKN+lekBEGKL5EewrSoAniyauHt6S9HEl+al12+fxuJ16C2m0l2AsYXFL//VXZrxw3ZN3OcANXvYfud6P3V4ujhcfkm/hC86wQ62OTpDQEZFzD6IdrE6KoGpmd8+/ps7IPjGZ2AkKx5PowNCwVtTPusq/NcpJkpldhpjl0sL2fPUxOemGhcjTrKU+wDDGHSON3Z4RPpByTzcySttu05QW9qIxncI6l3mQveBkt67h0fTLljIBl8pL84BcL4zdBd9rZyCRcp78V1toMwC+Pl7lpSZyNRplygiowwLlUTBUHPNTYSSTWKpgO3FylxHlR7ywgo36B0DcAzchqtDbUbdK28/TaduTOv/9z1JRCfelv1Kd2sd1rbZKpAwNfQoy2SmqhtIDrKaXuIengoTfGoAtNxK0GUpj3Xe/Rswo5R++GK7pUMjPL99axuATB6wxAJ41ISDn/r86oyLAZ2hHrqG8unZtReoeFxXKZT2bn51G38dsW0K+H4SfbtUDn2PSJ6wtO+uGzNJW23adGkWl5XEQHVHTfOWb2/9SMfKZfxM15V4kRWRufKw4zkDxZT4eXzL3JGCBIs4A5miXAm6O05NWaMkD5Xh3c+wr+NM6TLSca2u+r/nnCN+HNW2ivq7GZhzssArA6/OA7BD07nhz4GkS0UrhxT0itrfJ24kFJr0ECCuVWKFcS9H5C/RO7IRIKXFOFgF/sBW/js3GT8pWLoolp+5J5uZV/Sf9tiy/jtL1J7aKI3+a7yTAXyAa+Co4z5c2QRVJUHlTUVUr03MbQkPHNvgE09wumU/XgtwrKyU1S4nrC0zq1DuwXg+oMXG4wQfkkbRtG0XDTAP5C5XXT53/i2Ks80E8mizwErjBXNNIE76bFNsVJ1zKxM+h0mf+hvXrLe4j5Thg4WZE+assETEU5j/AMwi6+zzHd8Upxz47ZkSUfjfl16qRvKyOfUg9xV0MdbsYuA4jGBqsPQKhL9LfcyUvAkM5QPj8gp0nnUURAQnAJd6FEKbLKgzcmdd9fq8Es4T4oGY8JFCkxptFzKtgGC8Qh+6LhLO8iW31L4ngY+clsEjT3eVEAhWu74qrg7h00j69OHlg0T0GhJOgf4C1wXmhQQ4qWQ2w9NpJVw6r5cABeS9/PvtGwrRRjN3gnxA8Lv8BtHCgSiZUtAvLukfA7PP8nYqeGDyq2bwjdOASE63KZgUiAAk4MoYmAioHjFTsgflLMsi/w7nkdfzEPjkQBGI2gNiq+wmwiqwMJjLTx5I+xC5eKOa362Daj8vFbccTOj+B3FiHrx0+izFX/IXX3XktpLIGb0K5k1X1PyWkVKNaE3QPmrMNyhPo7dgn7IT5I70lrUG7/xjX0wuc2WY/TOSL6zMWZ7EGgSuEsK/q7gHSqsnzjcMLJsUE4zOXd0c3CgSteuqv5Haw9mY5qtKIPE7bbriR269UPsMcKPZdjSMjJHKOVfCajc4Wy6cmuMR17OjRjGglCb16+8rPbLv/VyiIPa1O7kkGGS3I/7R65HnaxTkQPBZO6GgvKG/gdQ4nZKDVxV8+o6AkuT2rvgewO8zsBEdJi6wOm3sRMaUVv610rkSx4gkyNXasq8hUAwxyeeKEeRS7H+DGde9JSau/VRkGQr9FfRzW6a3jMfgpmv5chuRG/aTK88PG9hwXul8BIlm8Dz87TVuL1IxUkP8LoG2wvD5uom/GzMq1XAhAFdDZzFCFP0OdcKVE7nF8vp1bxwqCW08LIsOXHs7TiTcZ7uXccKO0jAyUw76AsG1D8wZNt4e0BoYRgZS16rzsnI8bhIVkNIwJk2ExzUl0DTyXQmorKNYRqAq/g0Z6HetOJR7UTT3qEOGalDBiyhCLEnbaNTpdDSuAW10xGVnftyx3uLLwp3VdYAZh3Y+Z3d7jMP9mTiqN8CtaHXf2ppPpU5/fXLNtbVtN8UwGxEQLHqcH3nAAFM7eATBmPdhFpflY4+sNxCz6GGBOhMsgy4gRY3idWrdyP9CZ4iwHICkJucndwMSZC3S8SjPEuDzVOqu0cSaY92Bw9qQjLoxOhJmUDmMA5zJIsQ7XuIWouiRVKQW6fEXvBc4Gz6oVl9uK892EKuOP+TU5MOcPMsDZ4TMCfm7OyebG4DYJQuZHA/XpubBKUy6CxJ6ft+5UAUPydibJREihVZ18OPxaIEj8N5l9JDtf2BYbWpWv0Qe9av2fV+gZkH+RChwWlxuitxAMNNQnERN1IjhhkajSqvxAJj6uUi7KHbT4xJYmx6/R0GzfhNGGwLp/cTY/3DCoYRO47986O747P89dTOgsURwY/gu4SIBA9vNZdddWM7irTa6qv6KSf0O/NvREQGQweV2OrEoF1Tu831+z0WvpeONAwpl4vBGxPJrmgl0aDpEaRIlao5t2VrFuZ2CbCEimav3hmq8JXQMhqXEXIBzQevZhWZYXfh9QIINfThcrfYHtF1lVkmTpUZEYRW2/WuYaYHWkyiZyey+8nN7dbDCPt3ae4ThIWqTXffRoSWbbi3BpiWToZMxo4E9kCPSENhC3ZzMLW3tQsiztY3+LDVA/BVmKDOkNoiZp5qhtCQz5X2/t7mESvp4rdgqL5V3tf8zcV+p7YhKj0/LI/NwljSZpfIwfQAeeibZdT/L6RKLNEwTZWEIbw7LAMbEokwfh7R3AZ5v8XhJgNG9912V81b7BF9lr0z1C/lgXX9puN1MNm6x1FfpKO4G9Brzpfudhah7c4J8Ty7YXi9i7yYFyqP6o21yyecYio9TyRVOzJ9z5Ym0r6zUb2LKd9RDEFJZgmKYGenX8x3qcCUKFFoe++5vyrCoFkxlUNUMF4f+Bm3zsNSYr9seJlvpo/3e7SIUf3yqU4PQhz3zqYvohM/P7nortBGku8BtlGKdRxNuFWFcAolHUt4aCuChcD96uOodXBOe272E2Ivv/pShp/nYyxTPda9QaGm8K5W2eaKGuDhi6V4ICV/xPyJfpJqoV9nGSr55Awbd+YvsYFJEx8fCy/9dLD2lPYCjdmcOIJwNwdfk1pSrxMODQNp5BBVp1f1woYv17EnGMvhzvHUU+5pIjpErfhlr/YyTbiFMKzHVKgr7CiOc1tqU4mJdDlBW9vnmd2wDjMewwNGf0SsSb13q3+tgL5nKg70PC6P9d50gV5/6kxqQFW/y/H7cFYuQCx99tuHOF3TjMmzkr54Ab6UEeE+NlKGxaQmUCPmVLSSdjM4NBIi4MDzY5GxcGvYKj/iBmwNcS00AXsG9NmCeCZBEv5X4YCc2Kd8WJSgfXWso4JonUVExWDTGfkOfm5UfhXhBnGndpu/X58CQK26B2k6v8grMikAhTz8BdxqS28naFjFBmcNKu8St8zQuwiAqs9xdV4XVVYHtvIJZD/wT/9fwcV0ByLS6cmLpWU45yzmpBZ4OVcpwQW1c0coBIKGDt2cpjTfRAQ8movat7oEoutl7c4H6yU3OwUo9ZbhCgFbU1FJLjFCne+3tNAGQPtgk/UIxu6ssyYX9MMO1t2Yxe/v3hPYa+ju5ReYu6Boux9ThV/w/XNAwU+munFQZsYRnyx7RDAzLshFc2E4IieTXkoCB0CH5rqfowzqADA5B1FeFHsU9Yp1ZkXVaAWC45eTmanFyy2CSfawipETEzBzLWsylMQ6nhc82Awq+VRpo/71386E5CC+3P6Ua2pVFo8kqqxr6vtBAF6jedsSSELkFmg9/mABqWiz9+JTqUiAPwjJ69fhJWdyJYf1joqfOpzl5gXv4RL+H7zXTulRbU1fYtksg3EquY7e8xukXLtN53dFHD2I9OohL88PjxcKevXgEWTlhhdyAtfPbO75sbSCAIawRiN7xGxhvnWxI0YiyIi7/CIfRUR9ufYZNRBa6bamZbHjKfULIeW3zfcXyF9tf3fJffPU7Ur9Z/nIPE6+STVWF2LVR0xWHDOeAzpwlRtunbxymiGmtKaQYSD1TWLIkrVkAz8TeAFblLNUaLTEbvYDaN2ZxTaayfapffWPzk+c5eItnZXYbF/uTtrcMPVrAQ0WhwEFiULYKsiAZCOh9nANptsrFy87Ekj49oQzpI1IotBq7tDHEv7Mo9oHazDsh9lVlcQKu2ZjwpVOMp0XmxxU9gK1iXoEcLsM9Z1AtaREfV2CqXSf6SocscaWKoPaGIfC3kgzdN68xZyb+noY+gZ0fKFiKJNI2yho3D2nYTliyoqeJRjn56iFK3V8/m2OKjqtsK1+7uxFQCMya2e1CfBPLBlNbIQuSnltH42oPZm2vqtc2s9lorRtAUQTxLc+90IVL55etvHfgmcm9gPckTyUcSOH6kLTOG/W5TUNab5h00rqHfip8I4qb1g6Wz+WNnWli0PJmfzYpqw+v7ICCmXCkir1UzBrpzTowyYKLGk/3t/KVvtDgxFQtzcdiSKz0hJOUr6OjasFBCjCE7XCwFTX5PVGzOmdBaa6FN8aSXWlsOzo1jYNRfxBLCG4a1P/4T+supPDC9ss4GexLCoROdC+vdbyctKQX3OvvAECayRn9Jl5vkMvs+QtbXpHUXhBv9JrJCQs/6Ycj5dU/NXiTTgmXahYI/omJzlgqyRl65nB2zuZRuAmqOZ0coZ0ttlhrABQirEH/080paEYCiu/ESbWEv4Z/E214bFsdwAl0LXwVpMc4hHlnxkchDtCOH9XFG0uoFFU9C/J93PGpXsGYh0uSGR6PuhUiIxMC2cYNAhRfrBOgv67uwru4AZ+b2zxeNhyxcjEktClJtPZ0Z1BrYBJY1aDStxanh/BNWr9njm8Z3En3zEeyz3BMhYzxcqrJ84uKVyPydLshiN9Zl826erXHm5f1hJQFlMbnUfxFXwE5640soqUaytsLD6z/HSn/Z1BYJdPOQsJJz6/lr0u6Wng5gwaTDANKleZyiic+DRPCf6SINKp8Y3BW/aSv/Vs+QNFHY0MLI4oE8iqHSvasjChE8SnmLfFlvolU4fRFCpQV3DryrAVMRbS95RV1WZhTYsXdk3PnQzdsPGg93n1LcSLmtJ6p9ifqHWzTrPVrxpCw+PRBVdif/A8q8ctv4mlepHgURgH9d+NT9LbsMDeFD/6sc8Y25fOGD4mXc05Bhh/KqA1I0ULcHyIMNTXt+ZaiGPHYNbAKGVrps42duU1HME2BOtxI8iW+rKNkikTUIfCh6+jg2YIk8yvapmmZyM5yPetmlDOQGH3QDAiv2YqfMue1l2mHyeeV0DY+8bPeyXnAu4EEr2mBnqwCc5rKpvd5711LqCpnTuZQ9zWFo315n1QD3peZ/CamHLMuETjjfUSx+zGHLiXCslua+NO3csB5TrFSBkTXmOE1MeDL3E+Mz1H/riAPgprNYi2DR7VPim1KSjt1HkOwvqfG+Fl+CBr8vbMUkne6DUwCp0lCGaycsg9SvclnuGG/1FouO9stJFFMY33gXwiAdjvaA069XEbp41tUFt95tFyljxENVnPDK9NQghKLS2iFfxKxKWnmgrQCP8gX74taIWygZBCdZGcKHrkgKPkA6xF8b87XwR0ObY4vek1G6IU8ZygaAPFCC2GV+TirY3Gr8be3sfeBw2NwIq9EKCVa0DezlugxTISuqMEh2bGGw9eoLXRvGQWkecv9lL5lEfFT4N5vCO4K7w++ajimFM7duDbKpmILxMex42CGMYDeuwNuJBbFDFKZvIQu2VKeGCO7HXmjbZjIvrSnNsENyNBJKL4oaAEqwAlaQ6M1uRMmNkaXGo9Avb2cPUVT+EAIEl4NRG4fYQPu+2U8dV3VMKtEx0mwhgFeEj9tihhr1Tad5t+DlHkeAxS6Ud58RIBu4/6R4rsoCXhsv+yUtY07iW/WjiYIuucFUpPeNpWWKjFxCm50EwXS2oTpTdCJ4OK7rOY4QVugb7W7Ap7GQml/4Cax4extl7xWklCFZ/+veEI7LfhfJZIE3MmQIa+i4WX17zhtlHYff9Uj1ZlxWIbpU4HBS6KTdB3aP7PTECPNNFVWltlaaft7Z/v9r33zOA67oKiWOYLhwHVqQNjJoeLCEqKbyorhb0h5Ovii1xgeGBSab0zQyfGuhvOduoABwb3XWYgsJtGUsVZQiDUL2KqTorsLy+5w478rIvcfrz7eaEaM++0SIRmreE+OGJpjmxKUnajt5ty5WMGtOXj8NnF6CBln7I/K9jnlYdy/KLQP0MjUG7ddWPLyTtXKFBzEhpFkPf2bLHCLMw/n8DMcVQfn+gQA3wwAFkznW+bcIYAeWXVmbWgeNGB+7ZaKTH86bnYESkhzgh9xcakTu37a7TbaadI+JNGWerCtKy7vW8bcZePs73QW9GMt57sb53G5TvHmfSQfWUYgqMWowEmbjiPLRvY4KHYOgw/Pq05ICplJ8nVOeQeg4oKGF4V3M7NiMjdJqTatJpGE6h0Y1FVwp4PWNcUsgyoV9d7agwBkUoEo+AENg6xCoMtC8kHW+o+hb/LZNGyifaHeQW/KTGGiMBwgsIVk9TDem82PJRrMD41PgN1e2WDBx6fCBl1bmXM9fC9ZYsCgeH4RaMRhhTVLW8ukYu6gkojtjaYEBgo1F0qysOEo8v+LTjgXFmSSoWHLYImJJMYZISpleF1/s4Rb1WK326ByDQI2W7qQvpJ74QRi3osI7D3VdluRytUZrbTnj2rqW8602DIYfjlxslO0YEis8oR2o67d0kzzr9+P0wTEeDBTdAsMvUeHzGPjeoGqxWtFxbpt9Q2twEZoPxganKfT1P8wGY5PI4ec1pzdcyetn7y3Byg/uQfcB3C0LyyWA7BKRUmAp1ybiMoutmP/VNKkhNmYJ5OHOU3ppoPEC4aK0lfgUoSYTLRi+5deH5/3Q7r+/KYIiRWJ15iooHvz6pew9ZusWQuBnELOn8qGz2/dwIKXfSSJaCaQnIL1Ajtrmqvcsywc/hs612IsOul/slVoAt5Adr5Z2HDrAYlNQHh0DVNRkN7J87PbMjLm8fj2LeslyY6KUT5jwv5GaN9zsE1h3Zm/JH21jLszNySdHKjJbvEGZXijPzuC/B1fxA2Xefta6+INaNhtwFtwTKJ4PTmyAd9EhLNzTRPQmrhQkJ9B0Bzgrdczv5zzYZSh7eKrCKiJUnnEpbnYFEk123Z0hauO1K+wU+YcRc8mjDkhMbtO55Bz6qC6mEClQ2PN+lhzXAbR3t8a/jwYSK1dlGov7WVe9BW4wRNZap7+z8dzCiyjhAGG95a3QXEHvh8ef2eaJsmL9EUJE8U3GMXmGaQWI5sOYrl5oeEkSPdcicJXwiSBD7vecfvSMeA+oPuqnydBUh6M6TQedFM5Gx/c7s70v6ZIhdv7+cN8F0b9FaIjkFKvBTqNX/ZYO6RR5t1R2w2Ya8hhIEhGkZsNn1pt0i26/mDS2Vt2dZQ7AE7d9bIaGktNl0JYjGHd9VhYFtXWsufTKwtanZfhtuQIaLeD30vL3NqO/jYZDu679hU7UbAt4HRPdLi9EX90MQCplzOnckOR5H68+szib5LuUBehN19kTUBE1lN4Q8+RuAGbSPsi1Bk9nk6+CXRg4juWdR2ezAsQ5gyjDOMCtUc4h70ppNBq8zV3osrUVz6f0HWoOQzCCou4lVQ3X6AZVmh/q5JuQ8LXBG5tpoSaFTRhiYNz2f/X6i6z/tkPIiEcs/ERCfEvWMi0eeMBtXFrPJSlNncBT6PFAKvbZ+56/QBdCNNaYpBnFOw+ms8XELz7DQZaIfkT9gg3545VlsQr6tg0SxQFJtvC/v7f/oPSgfnVoHz09Ose31cp0VHo5uUIqcwV8wPfqxMZ+Nsgg5Ky+h/bK0AkoRYD0whphZymrrrrwTt8JOM9veGdBY82rzwrI/Gpmzjf0EPyA1R6qoCqT8g1EFWDg/Nda1TXKPetHvRovnRrj2HZiVXK9BLibL5U11EGCm1RVaY9NPgoW4UxT+kppPASQpGRWwffoUIXWxhGSiFmD//rtAhhq1PCTfpzjrQ4V4+WbDl+aQyh40iKGEv2Pl+hK2zuTrcqNDHpWCHcotl/VUjRS0QlEH++LQ6a0x6A3kcypcDTLNaZeHvz0PfrSaDV5m08f68i6M0fm+iOoKb3Q9W2wvSeB1Txr07uEbqH0AC4mHIdE9/aDayl2F/kCALII0L90l5loyPRp2EzTIkh/CENUAMZcJif0qk8CMXf5Jn6CYTAsbd+MBll6Y32UJzr+L0/ZDqriWSUkKxpPPaq0Lom+a28a6tsusZ7DO6X46Mg/XGOozaOs3iHD9aOdcQebpHRRIEMRelRIkLq67Jt2hl6ukeqfjgX4JFKCOrvWbl4gAHk833nE0C0+jLopK1NP5jxburN64e49GHpjJdWqPz9KNzAhFrFAd4ckt6WW+VfWW57NdeM7SQEe2pCWyFqPbZMuccZlcZbCexmbYaxDW9A/KHAIRkYPFU4eagrkz0SY0zmMGb9i3DQqzblbsMLpRfGWiR58rjJLlqZ4QZ7em4Gp0Fb3o7R0L2//DfNDq4kbSzDxGeFJs14R2lZsbtih3eK7WqvCV5nwN/pwcO7+DUU7FOmQql2cFhcZgJ1JTtwnt0vZ9Kow2xQnpBRZv1d0eCgbumSFknR3RcVATL9EAZlqq/XSnSQl6z5vuFaSTEWMW0Oyfo0y6wggJ2RU6xXwrCZR7LUyHUpcsfgtO4/53MVMbqyWSDnhW26Cg6sAGPHrk2OhXJAFNxax6JmuLhu0ylbj6H0NZZDFznUl3xV8EZfxwXvNsuCkDtitX/vbEe8/anKdpp3TXJkxifysv7mjX0r2/EKRlOOZg7ogIQ9YkGLw3GyoVZ9YE1mc6LDTwWmRlhxUsF+fw7lV/w1XaMlY2OkYVxANAdBXu3dC9MLiHg15sMxfdtkPIZYfJh+7yb/LNh33fU1fBxQRbCWVDgmnacu41Mfno2y4MDWPFHlfd8ReO9IiLBN1IIUVVvLE9p7d+SWpJeW8EQ/1KbHWuqAwruTYVVcMaeCZJsU1BknqGxauhU/G3RvAsp8UpTLBVRpwQf9Rx/1suV1lx0coMsEN1/oij0/JJuxxSmCnuvgzO51eZmykU9+EdCqD1//Y9WUZr+3e2Yvn8DhZTy7nmFkyNBVfGykwMD084A3yeLLjbgllfNtT+D1+NYCcpO8l47L2ZQCSb4/hZylHkHOA/eIteHpiPz0M/z+gmmMm/W2JBInxiQ/PhD4GpGCW1uqI8TGKtMQdRuY6ReX4LyFRDui3aP4Pi+d6mnYDhC0q0R3iiNnhVuYKZJK5P44qG9YpqKk+0UQa3Vq0ZTbhHzl0/6bM81NSBtis+/oMY7no3G9q71Jh9Yc7g92+HY/qPnLqxMVuJS7a6ioL/AXWgd5Y+piUpunrwulOwov00QPMOiiCP+n2inBeS+IHAOninvriSXFfF/JzclwunSMbM/vm+O3uJd2g/q6n+OBBBoIeWu1qND4S7UyTYkOJobfvkDbFj9h7rW0w2cdsp2SkYKt9XvqmtCACj605u8uMfriC6p5bC3n1lt767gpeXsVLCXIwMsRw/GBaueDYhw0u1jQbcxmMp/wPu2tdVO3ighKxRoxNCulEbM5CoROBdbDRdpxRKV7Ko48pqYZM22J657WqdLWb0ayFZdCK9feM2bdiDdBbdmrEh25fWj8ET29AXAOWlmCulPuMsJrpF0nnEAOg3ZMjlKLE+zap+qS/7r206NSpWn1POskqJE6Vq0kQD6mfweyf1X2XnyWfxTx28zQHSV5u8R8+/n6DaJIIf2aUuGAbLMUwo+z1YWtWlVt2DWX+52UBcBftKMZT4dV2l9dhZLc5MRIRnbAkaGQC/2mpgZpPksDikNL7IpURiKgUcLaNQARBFLL/IuhTCNdTK7u+V12GUJCzq/XpY3eEU1jJO1h+v7VitwC1d5w2tOQHTCIm3PDyx2a/kRCxV+5yQmm/BAoXTRSduZsdjI4/DcYB22Cu3MYYN5lNOUy1iQpo1U2AY6AIOiSRZ/0B4SUB9ShIIIZTuSvnf/vp8nyxlcPoLZO2/NSRdqUZzzh8k7pT8UpdA++DrgpxrOZNLMO9LcX7oTvoeV/DML03/Veo+WJxnM6FmgPnZFnxS+sSqaY6F5MoNeF4j++D5gzUq6vLPwDhPSgk/e6bKTAWY6kn+yTSeo6uYN1LBVX97BtWvmpZIKUxVdPUuO2vRmDU+HJowbrXUC6xw/NZJF4aCbncVVgZZeW90AxNNdkHoo6uivmOTjZLLYSjMe2MbnLiCteBEvw5L+xUEUY1cmr5c9Ha8sWYp0EoAvJNCHMgVr2ao5havLRtKL5qUK+pdn9N7o6/TyH+D87yH60IkEUI1GZUzk5ABhvw9d13qZF7hK3etaJv6vQjD02ybdowEI7U7Uupko3cxKARhrblg0kI6Elqg9cC/uAuWlf5Ae6fQKc2pbVpD8CeHolAGvGKjv6c5/ukVTWQF9HMQUs4t7Uj7XLgJE8fJiA+UZ/y2H2katm3EuzdapRjw8ZnOD+Q4LplrrrjNQUcg0LD/r4YDfo8HnK+L+13eGISDA/V7/fZheq+LwGtSBO3PgQexyDo8PzHUxf0d4f2P+hma4BxP8es3jB8qi2bUZDVAaeriT3+7TY+SxV+V4xL71Cth5LBP/cC78n8AOmfkfRS2Ij3hddcPYb7ukoxTJfPQ+cnaGEvBB3GUCWbzSrDmTArZZVbAOf9Ml22DN0ng26MKY+vOUjDmN7Pa6c4JQIj+2xpcBCPNL2gR/GUw+oV3birupOywg33hUWZVih/o4S7jbgPQgC7r3wcjQGZlQnAygerl4kPOumEEcyt4GQtN/wAa9MgQgm1ziAIyjPaa0ikKbo/iiOact5O9By7BnImVNwDLrunTdiUTB0q9y2R8SwW96ooBgvCVL4bJgvrMMhQ8tbyl4PYIPRToMbmctgKy8eeoNBxVkSKXJSELak0I0ZdddS0I/SchSOdFOQru0B6HOFZjiFP199EJWY6NL35Vj5Bd1gCEHgbsSipfmYqgu27w7weFvwQ5RV1G5XDZxLg3Uf8/RlIJaUga8vM+aTzkI6XQ3/45td645vSjlEZNAZGbHlwWuW6oLKrqao+P46iisd1C0tsCBkj1knqE34x4AwhuI8zBM8tWpCxXgsJAL/UOAjKAnx/SJxCx9Iu8O/EX1u4K+jIQhTfbm44yI7upwW4ca+4ITEmXqrI6JW1atzOkXwYIeGdwYktxdR6ra/p8rncrcBmNWtckPooniSoDsmT8B8SrLhxcyboOjSh28iS3sURHJ/CoBgeR58ftKZXTOzUklqerQipXURj6AQLh0gQhS5KVs4XeK15qSCIQXpfdC2URzQ6oxXYutk054vieyega/Wdnte+SeMTuXLoF0NYNGEKX399Tejw/JzmDiv+qx5pauiFGYYCy7melSo/OrOVQi8YgwF5ZwiTg6cRRHGsBYyKxskwBhOq4dDbSltikHro2Addrs3y9/2rBh22b3GjhBf/ldtia4530yewnxLhrQFKtLVDam7B8/NWZHj4vXaybIaxRoBJe5DJABiudF5OGNr6pdbASL4/w4YgMbw8Kpo88EX1IStFGuEdpDbJyow4xr3toiC/DmApA04cz0qOW9NouN9vRaQUiT2PZoCMWE/HnFQxWw54Fynf2AMOmXrtUfSSh6K1UdyGxS29o8wQP3REQyzLOALIIkioQIYFuf90MPbtOcYublt+/32O68fbpWXvVuv02l3uxt12tCiHaBG3FRBS0yw/RNVYnkalW6WktagP5z58ZotYGUAnxXYy4K7t5POpYmYuP9NTHy+W/jNwpOWlMCMQvS7FX50vhEB2kKXbcYCqcZL5bNHxL9BDRJ5nquZTpX35GKEolY4Sr8dxEwAErS9T8WEDNbGQZiHRWNJTivDo8IEIcG1N6R8E3nuBWpwpCOB65fWmB+kUUVak75VOsMZcCLj9qUlwmkY2f1Efi92Qmc9mLr86MXDIkGzY+4xIpdo78/E2+fVYm19bfDAPPelDRyUnYUZMJ3GatAtshiaRgZ5HrCZgRZsWiNqhS4Xq9CbZXiQY0E69844jL5o5wjklQojW28eKlrDGb7A1GyNO3L+3uUhj9t0lYDOKaipwrI4/lqCPfl1c+bGsmfanJHELN4dTEQE/M+1Xk5qTyPYMhmVCQ2QSjDe5HihgpjX4Ve/Jv2azNatdjz882YZCak9zqMp02ejSeqVt8V/EahkzZxdKA/PLP3aYEBI+1brCGPgyXx85d0BjF9pEc9n9CJ9x5BKks59RfgGJFJ6BRZVKwKQcXxscSL6rZ2gK+bBJPH4nRDtx79Lt94voAW/6+Ic+7Is/W0DOmV5rEXqVOw/+77D7C4G7FCtrmew+TpSTsLZY0lmHTmnHWv35CyTNGqPsCBV6KA0uQWvhxA5cEp/6lKz3WSTlQnzUOKuGLGJZGQckt6sOGwNiLXd5gWSTr+dNaG+CsTvgqKghwc18yeBqHcAKhMJTMP8/yBiF+h/K1ECZZ+Ws77qzLw1forTpNgwIt2YXPbdBgLmIWytpuHuzzvoml8l4Mm5OGO8753uSujNcBykS55djzTunpu5jBs/Wxr2E6R2I8ngFG501gf0lGnHpxU4bPIooRMQpx0cZMG5PzTDCFQJiK+e/0Ov9E29v8//jw+BNhiQmfj4eHmqzKA1MC+jwTH2HE5jV01LDASYGesfDryaHInJ2zs82ylijC9c6gQ/f0fx/LNvhI0rtuAYL+o0/DCDZetyG+aeCQjd45WxtUbebCkunel0I6Sjt/B8GaGyPpYWmSsZKoiKYk2EQdCpG4jh8hEYtSFU5T/HXfWHIVl4fmA4f7xFecSS9BI6xPiI0RXUYim2lLlopi35HDAEwi3FJC8P5ENsZLWxwHlYeGaZeig6J9a8oi0VsHXwOs6WEDO+WGftBXtOn8jzuyLt3xsnFpt6pnuKwzPTLEuoSwoyGko1jmL8ijqVuVI7uv7GTO5fujFyC4LtgJo2+MMJ7fPCxPHK2RqE0i4J87kccoFtEJW3toSNCKB/uXCM7qcqsUMaXn7Ha7ordPnNbJX06vmJ2EJnkOwKC45Nym0O0LxWTiSrf3YX2zLsbf8YiOZJGKa/yeqD5LpviYHgz8x3O0RsCvmufmev8PK3OutEm0sVBYNqvsB2Q07zQOjnaKG5GLUaVdXU90lXgFNZhpt1xWhwTw3bw/sLcyuLjPYtXxHJZVN2Pt/BtaTPPf9UJVr8irUjoKc3JvpG/nLUvdjoBCWXnRjwnq1YMeASpsA1bh68B68b2hgFZkNisSYDoZt7rp61vYokYLguTrlKz8SE57oMwHKF+vcVemOKMLk2h9UO4pUnpu26p+dYxvXy3nsiASM4odsIRi+V+dbI/O3Wxo5ZT+OWcK9c4ZryAB7jxz2lfM6iDiqO229FLDXgdngI9X6MWzPe6TF4rZjmw+YAAABFy9+WVX9UF0qGZ7raEBZfywSq3Cv0bxkaMOPnbSgiWr6EwZRBuM/tyU2DwxiGF94EyBTMFX0oCeJIOQlXVbpu+NO+ry1YrlepCqvlvZO+7tHxX3AuRwBMDKuXzcZ8sy+KO5cVDHZ1Gc5nKRfRLp2RE85UebAlwXzbk9gi70yWDVmgpes++K/T1v+Ce2+FtpJZ9afmGZIQYpWPQfXvq2qRp9vIIS720iKIMM22hNbLsNV3C595nK0URLU27+hPqpWpMJda9ce6tjohztpIsUt5oxqKrhVOqRsBseIBQWCDpq76yuKm8AeDaznfNnKTlLnxw15R0S5VPZ5SpEHeI0wvTC9u1aViWhqxZxIAlDAK5e9fLnpHGDuyp7/ChK/BTf7tfzsaWnrn0AHb9YdwDqZ92ryWBXOnT3buIm0Fn9I49ZQbE6oFHdMQj5h8pxRFtJ49RTGDWXKt9ofpmOOL4uedNzel3MIQ9h6av9tBZtSImILsz6ofqqZa0yMlQG7C6xAp2SXXnb3+/wbbAz/nhIHLrho85V6DGPq00CKJsT+Y0n3sVYcLUKJEiUp27ItqhSwWnsXy9RFObS1HUmVfpKgogHTl53TdU0OFCvlf8rk/FFMc9tPK5cGcIlVbtueHqFO68DzKHRWgnXdY1msIG8g0F0ea4GhyqFzCmYDZX2YT8eBy3ypOvxRL31GAolpjMAuCCDlHE/gQJPSQNRjLTZyI1nMx9k3w7H+SHymfHmLpQ7eVnh9EHESi2DwFBbnzunJCoeSLTcKyUCUAR3Cp5SbWu9+74pSpcsmk9gN6CHBmJCImkQvgleSrmidsQodWCkcZH6i4QsP/6Q5JY2msDOrza8kBmW/Y0n9Y2zf0xCtJlxcJmIjt0V2FcrRPPKUOkg7RQNUn/uivfNwRoe8wTZZzPu5GhjNv0vm+Diq6r4UOjddF8E7+9lLK9B1fEBqvcOlw+aeldqUgUuXPwaz3zn6xgu0jkZX9mDB7fBXVC67iJ2kfeS0eMDlVLAB1djgvgQyNTZqP+kkB0gNT7dxUWToaSnyVKIOgdb+/NDVJC3nrb0QwKsGgiRP8/1Rg+oNunvBMxjKSXsUQUTrvB0rWo7JicsSWe+ybjvG2B421CpYEVklEQPvEuoNIAZ87JZtI8qkiENHqZPyFOAkWbzr/4W4hGp/yuTe/0UpaAfQTKxgJp3ueatQ3Ha0xMHY4k+ZxgHYd7iErzuxlHz9Vo/u0Rg74A9QkzYobHTYT/nv+xittZFNYdHvjPTh+32Rvck+wQ+GPxU3gDwbWp1+hBlibK4vsf082cpOUufGswn77zyDumb3MS77GpZbCXUcW+e/Bd32Lb0G1wc4+gMS4PXQyNKvSXjNnjjWoy9TfAMFGCzmL6jmMHyQXbbsU2SNEJN3VH3GHJCpah5G+Atx3RRwuffEHaq7K28eCPjXET4BnYBDdtI/VsuI8A9C1dFh8K3ITZBxMpsA1xys/Qz45Bt2g/Fg8fK//vCcEYWvqRmjv7JrwU+LuP08aVfOOou3BoXpNWGB7KKycikcSeytHoNbn6LINum+tqbutzLbhAOC7MzyAqdNfvKAzygXkHaKq71sxz3gBvv4kFFK75veAGIGyqbl2TeDgOLiltVEnVeNhYYQwYA9Iv2WycW/PMsBc+CP94IsAGsO/smvCKQvcVeEyNfbQvn1eAmtLQU79l3LhabY2YG/cFJKzU6i0HqO/FPg76N4ci46IQpIO9uWyUgr1t8hT09EI79Pxynk9JsL+6ibCqSCuJPKFwGjMQuxgPdP7IaPGE1yQB9FjR+7KfL0v2su+NbJ6Ybe2/Nihq32MTamfwMzi4gfFCiVXAlu7BKnfMrZNxwhItcYTzBo1K1b6AIXv+iKhTaA/Jvak1WN7GQAxFYl3HW5ya7JLi4HoqKz9FfrpLKl820Wz2rRITXZmCAx5Smf7MqWVZGRGY47LAAHFWnp3Y/by/dpKn7clIEQJqk4NwLoVKIePYwjQlvao98Q5Rs0CFrGwDw2NquSOgrxZs0CFrGwDw2NquSOgrxYp9H2z0ZChYM43uVyrqWOlO1efwX4pQs5jY2pt2YKGwqcOnmUzE8iA5mci+Dz9gTDE19p4qUJk8BymCvnAiehijVyNAsLbN2S1pSbMA+mw9H0bBdBp7yKFS3tmpesSsQyTb7RhxgxH3gMKFVceV0tD/xbeomN4KDIQK+WzIn97tuIhkXD/lBN0CdleAqh78EPUDvA9KU/LPal6KFouX7VwZOpVqen3rrvN+Nf30poA58I8Qo/z9JXz1Jp+D8E9wjE1T8j26XL4mIvRtSnf3LEUtX2LvysaGMigsqFZYiD1HXNmgfubaEuKK6ozvxdCK6M3n+kplJvL+iwVdisCwW0S4TQ2eHmS2pPtIBA/nq3Y2e37TW8xx+jAQanACjIbuCIbCPIGFYKyvERlJNY05zOONL74PpE3VMY4YednAlQSt2EZkxFo+ASqRPjuqGDg71NdJZXOtoOsqnRCXEUkFKJc7DYSh7HSjDu9nMqEoSW4opHV5dIHdd/ld8JqW02xwc5sfRrc4Tupv/VTu5t1AT9j7tL7QoeXWH/5U0x2vqtL07qLtQX4XnF5ZQNynWIUJlUynTlVov9e+CKydEQgvPplf2HFhL1LQKLcPx4zZLueGk41KCg17CzmwBT2umWpZiezsBtjN6pg4jnqYKJezM6KRIcgNEAuFM1GNd59F+To1FDMaxxAL8Mz2v5875Xf0gWPI/Ah8C51GreDfcsRFm2WLGPkGUVvabPfD139DIzP/tXznC/0pPFvuCChKv7PlqgLaNo5R9y+jYYOr5cog+jeo2Btm2eawqUXQLuu+KRacdOUkVfBpbN3BsCm6EM+LGPXTHXCCaK3AV0/CQJVl97707MqKvokcjQJh+ooGvcX9ksKfhRjTd5SerGG5dETw6oZKyNrGbS4kzmZRj8iBXz85xLsr8OkKl6a+i36/uQTwaYh5pLlrmrpErbR/1AwGI1nMH48HTdjUJTTuhzFftV1r931HPgOUxtQ1kjUS6BvaV6nkFVDuUHja52Td29g3GCY7iRLUt3X9KX+dMSSZo9T3CLNT0g20VkdWWvpINZS77bVoscuDpLlJuCS6sZCX8K9cv1kzBxAhuwKYDIAGAkFeAYo0RBjDfdcXtM2VnDYlM/dqzDjtMflJ4nBpLW4QZEqddd4dmEEWEuwyMjIyDWxSrzogIXP5hxzBml37Ay41E67nuwyMjIyB0uhTHvzF/ygaSNNLMWQSsthfy/+3+svk7gpaubfEHt4/J6fgr9OgC+I0OUdY5k2NScTf+hPfHBt74WPubninoWXcJOEt5YpUsC/lYQxPaZf5ZcmYfMS4pATr5Ozkxzh5+MijzPPcenJrmuLx1l0XGpmRbz1TdfyFrxJZCXWClc5J/1pSGBqh9aXmDHX7ltMSGgYFZlr796FGoZyhEj8Vq9AmKfugc+UfT+vsRo4gBlxYorM6A9dbLNV9vaYNyk5rdPAkUP3Q0sHEIxP57+uZ9Esb8TJcVs5LGZDNt45PKp8OHDmMaQ+1ZBVz9HKvfyi2Ig6Ffk3GFf63cF6bG/gb5itAK+vZWHr/8evU8TJFtBWFjAnBFMFY2d1CZ0Hivi46X0LslnJl4BVsorTWQYD1tdbDbuBe1XNZPxvcKU1WsVr+uyqRt63dF8Y22m0xdP3PsWiedLtHGBgaY+djlHJ0a1w3krnAup39RMyJj7N7qYdvBpjWiqbIv6J9Y/+1WpkQG5ZDa5AWzAnlKKKljus/c8seUv7TyHuuKT4nxxjYoeiMwvUjNDEJknnV7fdmKwPtZJi19w3kyliovHfbXN97JfhOvqVeQdSw9k5NKZMCWzKoK1wKCHQbOZL0k/aDg4ty2F+z0GpjZZk4JzdC8RmshBMqdAehbwlGysucz7Nv06n84BEqoHhkZqH0iMb24pdVbVA/VwJKGvAZm1NyRPQjyTOFRu50tbdXzDmlPvPEXxOUIkvqoQ+oF5x3gYMdlTPREMOMrUTs7SWlDQp4+nXNwo5jqFvo/Qo+AidHltc51aVj8D5sw/AbFjIZn7eDSeNMJvPo+eeJY9bLl+D1RB7Ziw+8wt7bA7DTFjGQeGIG8Ojf0MIgSVjpHEzLvWQHaIeSJlLfL8Ec/qmXBKhKhSGrFjchINe4jfBTeM8BqqH0+Fk/CbOJdcO669+F/ZivdmdFyoOrwwOF8nDo1Goy96rY4tv1KsRzWUocMl548yuigzHpaPPNruBg8KaYGc3yibXMjb2v9on27nizHAo/qk6qUHwVH/ccSZ7HpkO8vPhbCajQ8Xo7oQ244XhqvvICDv32ARn1QLVVhuTocnqYc/3uAkuzJm/0oSYZgJo5PtaHgP2vgKq1ZdutgI1xjUTD1DfLlWzHyYswqwlklRk0Ca0viN15T9rD0f3M36HDqSu1qtsuVVebVLpfFc1q1CF8qY9rHYkai+hUsumjPiPy6BRZUOzJdMfMqm8JBWE9Zuk/EWB0WJqPtnHZVVMqUEqN+uEAleiuJKmvQxVPOPywIqgVoDwEZ9zz8s8gaK8/Htq7OS0B1T/nLHqizxkwAvZubZOFi6xumv6tbLj2Z3wZ874M+d8GfO+DPnfBq4hyB+MVmdqHvmhzhoZ4/elnTIS8cZH1KEEKkUqv70QY82Tmtkq9gzmCpWPd/EKbS3EDEgTa/YhUvI9QASolxQEw8p6R6Xte/Docj85cSfAGDoHXvHfFYo9r+/Cu8p/VaAj3/HXQyURwFnN32nBRtBdR7F4Q2HOiB1hAbO0khTekrnD/JDzdcNQYHltBV12nI/bIm/rrl6nwvTI19igajTegLHVHBl1bFZrBB+k8DIDGVdbVUIpzIMjT/z+b4DKDvGkSdlLNasaY12CxG2EbOK2dbviMc9uvIBz2Job/9ZhkEGtMU3EHVmcMymo5buuAIwOaEBIEWLe+WiEYkbZzb/IvvQFNdqRY+Np0Dm6Jz0RwD4OtSATWRXhLewyztKSevC46efQ31oLXJnabVwIo12CMsCOpOEtn9fnJiArW22PQusTghRtVLhKPUQulSH2dC267orepEN8s4QrCADIieAe/VNEbgu6bu1jAOeoJrAqV8kLSD7P9trRtTDYRQ/2mDNpjDvtZ38keWyVCZzkugCkAmYnafR7s9xz1Xhjl2Zpu1k84vC6uheA2iNOCHKlQiwArQ62fFARasoJQavyRtGDrq8nKXkOiB0YdS9fvfUOUex8AqiVEuUWGaXu+D4W770ZVYPaRNtMJ/DZdEuceDjtjVM/xyN3Gnz+tm8TLa6KsN22COIs/5ud8vu6AeBC5C5tKUmoVH84LFTHRzXa9BgMN4WJGJErm8IcxBp0TbvjcFIrzXGygD6w6ixPkLkYa60UTzreKb/dFcYmWJlhZfx3mabDnHHQ8TDOn3MwsLjGjrFp3m6SEV+p0y8bOKjV6ylUTB0YdS9aeN/sTyepfXFgKrTO93/4MLxYH5EHmQpMl5ixqddYXk9O80+JBWSFMBWHVIgOdalamrVIn6bCPuz3BffSZr9jLetXM/ctrF87ZDFCJd2o+hpctCBatIiSBKHpBOakHjrdySDX3Jr9QWm2ib8flCkUp8xj5xwK34feJKK/zvyRmlmi8VdI9NXQMK/437DXj6id0a41tPr9zdksQuAg+zaR0oODslwxy7EwMAAKRLp1juKX86VW7KY5yLNs8qXwYGnyfvmdivS3xoPncGw75TZ9n7ygiu1fpIAnV+L+OSGarCQendBKRuq9YfUvpuXbN8E01MwOBSt8F3/MQI9IS+9xvudQBWXEYBVunbSBQmm8GXDXltKqlOrQMUBPEaM34+62os28zBy3vP36R+NS/cBOAiBP4FNXyMMJ4wZCu5/zM4n0uvt6LOVNa4/YB9PzTpmyjVaui2IMB4xiwGgN0/4qdxT++RI+u7rwzwu3ynDNuaYIBt+BiHC5W913j6ZJvejd3RZPPNvnSyAPo2C7XroB1Lal73EK80yU3ygirP2a97zhx1NqBMfgzVR8yr+cpf8EtsZf2Zroj2N8ht+w4VCKS4fltYcjV91gooop6vSc5DXlLAgLYr3PNplG6T4Zkqa3LrbzrCcBu1b8FJGEOIuATOOcoLCHKNQtRMBaynBT+39hLpPyqPM8OSe/8zHiCZ8ehGl1guXM1VTr9UtITEYl0jLxnm2fM+lkG2zJlKxvbAfibws9sfNn38BnXqpkEO3Wfgqr3RZ4OLSdvvlS5525u0Kh6AefgCvM7K55bysp/upqumlvdJ3M0tbMxBIRbfXW/6SLUHSwwgHCq4VFV4y0LQZ/NvBYKLqh9v9y/wu7E0rPcRap/2ePnIvc30aPUhzWWVKYjLNMAssBFVMq6ZV0yrplW1PFvxSTJv/F3QxFGKnD/4kfGwPbt2t8hasE38vZoBGTbvvXxY1A0eHU2GZiUumP2qsfOyLo7la7FjK6A/1JsJ/uwqZPZuzUTZLZXL0zPYbRYUJ1/LCqiHbSIwBo1kIGf6D2Jw+tTHv4EBHV6BL1ZkWOwPX/9DF+phT69lGIRrsG069goddbgH4dgWO0rc5NHKIkXconKfHrM/i5qUAkqqzXyyhu7/q+m/RUf7XPhBaBndtnmTrlR/MQP3L02oz1LUouRFzRoit+DDK54CxFgk0oGN8i8kVwVulTvam3RZwKiOWTJZP+9aCSINRi11E/CSb8IovpsfOGixKrzSdn96w80AnKb8Pe5aIqH64ohHZ/l9o2J90gPDXihW0DBHJQbf7evht7xLRQyN9u0r2nLJQlCzA2vHCpikTk2T14vk9Eo4ubEaM5jl1MOCksoVVNbSmvFR8w2CedfeO64+Rk6bX5Lh41DWLmsLkvef5iWmHKXS1YfeiLzscPMYU2IKh+OWvKg6nSoSvaIns1BLSbXFbgFJnQ8u3s5xk4ve/WO0K5AU6dl+bOTbXcr4QcWU/kiwP0We6AQEMHaUlGQascglDSBuNF8XQsAMy7pmueOP36//FhErp4zOZJ4GVxXaOzDDDlGAuX9+d41Ad7hjqBRCPqIxcrcb/GcnGYxp0Z9bHV5B7HggiOUr8rwWPC4/MmmGNknOTvWEQCclF/LNLdD7J29BAdMSFAGijat651QI3oIDqnPSAvJW1nG0wTyCJVuaBydeaZH9TProDOjTfyOZ2Sw9Cun8YLJOJivwm/6mCs3NGKn4uL5RUwgmvjiXXh7RqO5MajU3COEszoCj3dNWIRHx0O/OZdZgR8DxJOv4pGYvYIrXDEr4chB0qsP0/XsnZh4NvHAWr6Bft/753CN73dMK7bR/NiKC9THQjZ42BnCEZB0M2Ao2kc2IL4Qdx2e5WtTXVsn4h/Bz+65E1hjbbeNMcxtyTJEK7w5ZO+Q/Q/eLDSxhzBMkFoWxkrp2ztf9EVf4S3WFsHm47dCiwqmOhGzv4MEMogl4U54gHjEeCwWoibaYpbrboXISb0N+2DO829CKY8f38XDP88nZ3f17J2Yd/ecneJ014BmZy5uabJLM94sbPId25hnkYMHkaOwIilbe+U1Ts9iWjDplbGCkTiyxfQwbBU86jFeKh7g6ILx2iKtRhifHoir/CaHIZh+ujVAeCqTR8Nze6talVrMWNuK/Vo/JWFJei76D4C2NXvzgHEYNShzw3qgmj5fYLjafYIAsF82MaHtZPxArXWS1QW4YtuELBf6GfIUMwOIfIb7Tpa3WKcYqXsZZdlbfY+UGN7nFZRxCecKL4MDgvNiAVn1KNQG5dfmAnscSz1qGjciafvncEy2NTM5/SoOXVUiIIQoqqMh+BRrFOOPDTk8XigNdM8ntw7H5O0kRBKG4rI6VX0RIq8ABtzmOmgLezpHqHIBbEZchQ+odRXWZJ6B/hhxLdp1UqdEPH4bpe3ZdEfWbm0lxThMhIKTEebHV3rxuBlY7IrRexrYlXbFbp3t5zO2XLoihSlaHy2rZT5U3cOG+7ht0iJAJNNwJ0okMZY2k+HSpfesQSzLDS60BklO7jekP+puJRpbVX42vmC4ANyG7zlOzUoVAxNip3GJzx9UxP7Mi/XYEGC8roVRRUXjheU0j8N8Ln1uHQveXPiYCGu4fxm0K/Cqgk6WjRFqZpypWY1+CdxUjyTNg0fD2j5n/HCmwgMXWwAcZHJF788gOFaC7WGGSUo3d+oLwPQbxxv222DRV3FVnW5AJ0EFAmvrGfQNuYbsK/u7AAtITYTJq/9TfBxUb9TX8w4c1JcrUeM7KCZSDqwxhY0jn9aN934Pfu5Ji40xvOPUn7QdEwTtYLTc7cbK8eJi4wa2pmZtHEFd8PJyMGzsyJmJ8q9i1aQE01gQ77BOF/SJ5zhv2FEB1+jCBlzPbEduban0P1CdEpkB1PGUoylHTCoXYS3aYo0ZMCjAxZTx1tJ51GXsvwY/WQKoHq2zLaBFo0ohHi1ivVxB0Ieh6abh8phsBYKgtUp7mwwWHhUaiQ+YVTzCyDlTxeI+2DICboyJgW/x9zwBrVwycSVVcZWyBuvR3vmswZNruvyBHIgF15UYa/FC4TxHtt/rp2a9UYLx/1nxtYw8V27pRfVbr28lsQGMDu39Dd0SCmeqkJ3cgsYT+r/j6cfhzASreI3ltcbd+859l4PspUPCqtB7dHfDLS6oy0O4YSJk6LM0Xbtdpz/OPfAr6Ilo23mQ5wmJdviBtRAxZFHM+URKtMU71TXLeipeZ5UfRHPlVGXBw2w8n6IDgeiaG0O/uyKLgFaKlB5P6z+Uus60VQc75H5WLfeH0B1mjgvxyQh0q1iUTCwg3n5NIIvqOWKuxjD0vr42ZBc39Uyi9E3ouUMVcFpa8XNIxXjMP350/F+Vfhh+yHZcwMVdHiAoKh4/QaTaKZdUWqm4kFb2/pp+S/hyNFuw0KCo61z8T6ubOw6TYVYywbFlsI9lRdynMT8mtPm6gWDnCoUao10j4dffHBdDPs9gSi3VqESp/nLiaJMkl8uPg8Mh026vmMBp7tyX6yNhEB8aQpOib82kj4x2Ocx6x3BPWr0f5gkQBmxPn5LMZNYAVwLxup5RE361obT8cyJHiBpgmPHLBXOnC2XUJtl/SPYXVmGunifTonQ3c8T0bk7GrYMs6jYWRAE2LKLuPBoi/CgrEv2ToBaF0/h1xliuVhR5wvCGgRR8CRQu8MOqf71jbWio0vE+M41ylkyo0pYN4213x/48qwTiE0sPN/yuNiwl0ZZvqAX5SJRl7nY4kwizYy1lGhsgnAAd6J2f+b9qIUGJwNhI2H1BoggpAViGsrflF70OiuIXRSYNWC9P9Z1nntYNugjxyyK5FwnOqSJcoW5QA3vRywkI9yZkLnMYwHpoIPLZeI7dIGt1QP3JcooxAzgNP9XyLeax4ddAH5s+50N7jA0X0dpsyDwTw4VK4gtEQHmyhwFFgAZzKi5knwAAAAAAADHomsmQ5KHQj0mh7MCbAB7N8Pt20+1RU4nxhGd53PBSalgIkdZULU6ZdW65r11shUwQ8AtA+5sBVN7W2+apY0GNsmqy9IpyijBgbmKl1tQ4yWs8C7X9MJkEZv2nAJNWfFJsTRF75CyU5f10Jf5vyLHrgzPTpqvUJsaJ+IvsPWs8Anp+tmbW8Wr6QFfaR03MQPXmq4ZW04BfRD4zxgdct5PESWsG56BiwaCxkW23C9rf2l4HjkhBGu0hnKnKowqERNFGHNa/srKfiuHRXZFRwGoYoZ+91ADKbF5vOQ6n86dZfC/omsmQ5KFzBzzD2z+PnMtTdq1ArIoysCbfbi9XMoGsgqy79EEeHT/GwncQvqmdX/Q2sBNCU/H7sE8OEvFlb7aJGeNfva73HcGScrNQupsF2UYkNAjv7wYrA+gKVXiA6hw2wnbmh8HkSbf6hL3boM8fu7sGTBoPPR264AzlMfSVCKf/Wux6UM7sVw7hfmTh239pJmuXtdGsS344v01VYG5gSNU8RkQMa36RO9i5x+BXIo8AnrbZwRsByh5SrFjRbCXywzELQnaqCJY0u4KwEWf4cFxFD/55SlcyfUoWzlUS5yJsgmYrbnbzQopWOM7OwLR9u50c7SnQ34n5lGA6BT71OtMaTjYaTctKrycj/dLm5NwCeO0GJ9SJjYzhr7DtC3YoRIK7xyinkcaRXvVxDMYr4tR98nvR23yH7Ts/WHU6gA2sScrsoKbFvxzz/9Ka6TcEm+adi7PL7x0Zvbud70H+lWU1SE0/ffZII2ZJG4eeaxs1HtmGvz1FYIZ2I1iqWxwTUpsL8LAbuoOWY6PdRnzqyNU6cTx/SGc6WKht1AsmLvTxX4+C00FA4xENax9V7iPWrSQSW+rvBmxh8Hnwi2hrDxQ3qRtMlHW6rWBqNZkwj9ODuvx7nwharxC8EUbvl1U/NLeW3s1NXMukxHm9ivA+GmijPWe0WgivhhudgElGdHdmtk1bhKUdaahmnz5dISMpYPRHffSgV3jlFPI2aRa+9ZFdIAsBMt7jm8o9yJvvsd54MqR76762a66SuyDyDQvayZQ20LWxSLGBGpNxXBv4EtXxqimLLRRYWPoUcEnMsy9yRiQCFRtOV21tSleZuDhpgXPj7pzsjLNLGYX2LRT9DToiKtbTGdPvwoPKcEhXzbgYBHxRCpCugLvo5U+ZFiDJnphQI9WMOPIlU3qwTjsgwjhEJl4ot4yufymxwj1YACMg6fjWRQyORzR5SlcyfUmyOgcmInoK4Z86faBTY/o0bH4DL1M3auIMDuK4cAAAjSn7jfZKgDIqSI+BLnWj3lQ+/crOxWpDLkTVRqbIrreBv8VvYs9Nop4nlWVazGr4QgDbUyl98K2X26wX1BlhcV2rUe/wPgS5QY5hI98o4+pbFc2rN44+jATSwwiPbb1fFSloTH1LPz2qnFewxpWCgZvALi8qnztdTxJeUemPqdpWMDGRqFqMbPPd3WY6eC440t91SvzxiepTmrs/wjatL/5BLcikaR4GlNYjd1be1tO0p3d4gKgMCeMOShKcEKVz65h7PMBbXxc7P3IjRHv9fZf55Rlda6oNQ7w5YVFIneXUVOAGX3nVyX6GMHbbcw+TsaT93qodnOWACGF+wBWH1Awq4knOdKT50yh6OV2CASnuSkI2moRQj++BzOw/sgvjnvjsPsAo4BRIW6qhURoq72WCnjJjvcgM2QarxasRR9Bgc9CPp6A0srlUY094S2kX8spM4OYWOypIz1yfmCSv9qDGh8VS886HrbGUHKZd4UX5q4/OCgvFGtuPAuHDSmyQnaLjlzbDTZqeWZUiOOa8Y2Im7CWQpaYLsTMEmmNhWbrgBkJ2bH9oI+2SeE0TD/gufZkG/UbnXuqwyBUQ0LAWhl10AIbiNAqjwVWbI5cS89BTVjK02CJ6Q44sWtwtOl8NlVV8CeoTWY0HD1wfoPhPMn9upal3qvsdgpfzuW9jEHz5dVczuADxOh39g/XlbWz3t0o/6TBILUE3XwTfCSPsaessYY+Gp1qNYTeQKE+VRVIsbotBkAm3oMibOOV8imnEJ6k4tN+YDEjrVQZGma3RjhxbZ3q/iSM8uXm2yXPq6d5SxKAQtW+hXAzWo3Ex1BIV0k8uMLZdRAS7Q2PXnjrDQHL+yURQj75zQx4ilFuLm9Z5B+bWTa+S6efTnbl60Fs6n+vD172nrknrRBeF6ZDgB0aSbzrI++hUZr1LwRz8d3l5gLOg50J07w2VEiBHHQbsmFI+oZNmhY1xygib+I3HmJ5GPYsUxoPKFemTBbtzGv3WK+SIU1o4N5TGyQ74Z6XxFPHFnWOPEFK0A/PXK80PZDFJwLuYr8XIVjvqJhwMyVGqo3rZPBQgRuFvcRjpxE5k9PWsLsGoeunoghuXSWHSyJSL5LRMJm6ObUI4LpjHyoXlv33aYKW/KyJRAZ0ElEKYbQdQflkUL8mVxpWpPlpJGJ7/kdXTqh6YHKZd4A+NEBOvP6r7HYKX87lvYw7q1+aXm4OmVpN28Tyj9aSRJr+zt0SjpiAUUSwWX/hlDIfYE50GELZjB+DvQvZ2I/rZ9dtv0GLL4LsJn9/z+G5j3eW7IYyGqw2kWG6AhAx5g9PCddA6nEycMVZbOTlrVc/Hl7vHTeuQr+TDVc2BjYGGTwCGdQPnBYvoEIZ8jXepNddgl3QMN4LOaB27/uaoGy0L2DdTPuXV+i1ThIbkTeeWPimCrckA23jIADXCXCHh9DRKYFfgpBvOOB+3Hqk0i9oFnOFrmMUtqHj0LikJXQGo/1qeS5HEQr4AhxVb1WFZZOMiL/ciOILwu1kcaaMo3h7cJZCiwYCHHy6jjM0W55KmRyPAfE2HP0izZerrt7ykubyNpzY/hGlHcWLcJVJolnq+eFzZe10MvBglM+2qS7v8eS+pphvhetMNMOePSSb4RHrXRbfPaI3nIZcmx3hub+OpUgxYcr3iuzTSgFu4t1ap5aVOQAmM+O1j0DrdqDy7SUr5V6avinmVOmqstJM52yd0dBWRDS9wrRAMKeAATas0337L3+LVhVnY8Ou3alh3VC0E9lYXVx5tBI6/O3hN+f+0i+F97+V3lDDGshnidD9jcoYGQuJVyhojSa5k/q0bue094XLEPSTEhPXDon8K0VjxUaSkHvJn7YXAPcKNWZpiVuvaO89W8/qE7RsoX7pCMOegk2wql4YlO/qi7wyntmXucbccG32ooebQZTCpjddZS1Sup2NOgF3VGORsNS2ksw4+7YKv7splfBpjkZF97uBlXZDKZwNNIV2P/73eSW9DpKPlMNJs1FGCIOQI1pztXmLC+2y6s4HBkmrMPIMUt2a/K1bCQN3TI5PQ9mTyFnWPfKKRqzU3YPbdb+mBzPt+RycDfMTdmcyeFvg7sZcqm9kqjukI97sjbsd/xzIjiK0pjUiOWH5E5GqnQx5SXW4rTiwp7DMBqRaZ1I6J19CoD+cDzN4vQwTaQiVVwuMLT6IA61ZDPXNTxcsHreoXDApQMWe1e62G69DW3i4tQDCYfcSCNjpinESe9EzmUWjQlJiW8HuSlbO4EKZhyiEM4HFTgWfqQoo+wr6KN9VUwUxfEpv7zET3QQnEXOhMMz6LrYymH+riAfqZdT6rFLdQLHBsDtODxQGlF5fL0QAAAAAABZLRX2PBDALvK+sTw45DnbKERsWbkTZO1PzW+5y4O5LFbomVJG+L/8zD/qJsxdaFkaMUqXKf2ObNJD2Vl36cSKrofs5moCvSpvVS1JMp5fcj0vy7/lEjWdiYHf+ZXu+fHgnSOqpTAHgAvUHrpTUjBH5b3iLL3cHy1tTzRud0Ij4neYVf0TUlbznblYlwcWB3tyr6zwLhISwkFoLCaJDRDl3LHE0sMmnUzIDFLxaq9Sn4YPqrulEBTH72jhQJXKhBwuLOLG/StV7Okfoabmqa7P4WCR7+1hXO3+QWbIK8bZ4XM08f8XafdlngC3ZKVfpNVo51w8pQjeDUaSaGDQDZCsdGY9xS/qQF/nWGUdlAMQAJj9Z4LCiRY6CmR7pddPTWOl9aTPBrXc4G7+IWrIvXeDHB1GLRXTUommAg5KjQLAXvIH9c84ecrieWTHQm4NopxqF3pQCG2Kt3NL1qOTr1AG+iwerLCsltY7iyBtNr6UWPDa185SEXkwE6IFj+5i/X2NyagsQ7LK8iwU5+xrU6apXqC6rXkzK6jobpohzXRR71AR7pU7YdT50+Xaz6lqNrhaDyfXldl81auIb3ka4zOwJKnZcUT8Gqmgvxn0z90CHEfv9FrqlcZCVnQAzYj6kehnWKM0DRLSCZko0fY5dFhYqwpIWq/uQfq3UZCF/I8DM30eHyUhlC9ezRxwdEJeiTOvAX4GqlIA5SRzuX9gQVec/APqtgZgdLyp3SeDKyIcPdagyUngfJw1U8woGqqB6lzYEUD+HXwoOpMI0D8GlAZhFVuUvVpNtgOwakEUlN9IhGXT3ZQFQH5g36yICekS6Rza2GEnVa5hLtHsqsJui3k3yro/1pU8H3c8QaRPEf9tko351BMd1oAsdT0sCoIUlfRamqG19ijc4au1NflbyNXWNY+p6iRTgp06C3FY/LW41qQwA4bwr3l1KviU8QDmihnlBRbaT1TdEAoHES0KfDjhCCdNYCX3GgJpKPQdGMH6tsegi8sAfcK8xnAiQZDlx7M+I844+e6wZr3ye4srcK2S1nX8Zf0ZG4zlz6Xk9rEEK/T7C9VDIccCBtYd/ZNeCiEkhSAuwF5oQyus6eql44Tk0+0KzeD/zYOj0SBG8EqeZeu8FZdiHVhxZZrwAQS600CLYBR8gWxNutgRcK4ql49zgzg1mhdC+WZAEVLC+fMsbk4zHmaB7QFeZ/ytmwPVPJzFQKPuejimIBvXMEzBjpwtTM733LavWcFloDRX4OF4YZBGKHDxfGu6CcWoElUDioElDw0VHB1d8KsjDG9UFqtgV39n8H8UtzLiLvh1bSiBQm5Zfgh1mPMfjWVDzcq7eXn1NyTWn2RAFtenQtVsCjq6bSQ0dphIFMvSarOOeTk7gxHjhNy166irN4T3SPixdRDufcnTp8Q9gwjUan5aOcZuzpAhAfXkpDZn9jw9fNvQx0fD9bO08cxRQIou4AWzXpIFQOkUFXAkdae+Pki4iKlfC7mQVyKHjKJlyb0CXlFMmlvGC8YDHTxGRGXI2LgedWtXzyBVuC84izgE57zDeO8SDEAvBHlnoxDY8bPKxe+VmtgdAkEDAFKphbff3BUHJO1CelGYDwpOtQ2BIXUu405GYEI7sU70LU0eOGiP9526SNUWGs6/qEA1NbymUQy7ve5/4x73dLZLdnGuT+naPNZdINzHr9ofaodvj5zZzq3XywuzHk9A3Rr+WzF2Wh5np7AudTmNn2R/PfvYmiL35S+q/9crJufodnyK9mr0G3iIZu5/JI84/Yo8I3MehAlf5vip2y7fxoSNYOeO+C5IQR3cekT67gPXOplGWTyEfvMMwhShmalaCrhzj6N8vbqFGKEwGrdulfumq4WzqvrAkSTwfIUYfbl7aC8QH4+c0+1VHNFXnWRK6oiUmjksw1jAr4HbhkWZuIqdT6Kr0d8lomcKwpgwg1qxF0LrRNmZ/2jUE0atig+2ILscFSlyg/1w5q7n/9jTKFbTOxOd+eDDM/M5P5XX5TN/KxCFs/CfbonuK6Qv6Qv6QrjfQMcTAVhWw8NT0t9wal6fCp8f3lcW9+fHPq0yR/AcyeRWQcQ6fCqPRnoYKgj8dzuMrwYcuJSSid9rfiUsEcysqW9QdEoeIL4oB4mv9n/I1I20OrCbAd9tcAO7t+WmTDyDkffQE3GRVsorV/gNejLPB90JpOgzZj1za5UOa/AEB4c+d5oyym+tkxHGnwsfLpWn8Wzdu4ycz/xyAOlIaof3Epr+jIBU7HsG09xIn3aPMd6BTROjY+kGAPHOH183rT0/rHHLtveuFE/9wy0Zpki3LceQJJdKqc5dxGNWqmvYheQmUyhy5tPaC4TB7Xc4JhLt7LMpBOxavnfLR/yHA/VKxhI+g50lWBBgM/KLPdx/RfBAOfww0gMIR8A6j/2KpJoUZfupoNEMAnJq0bBygTw9k/S0a6VJvAzFqDV5FoGYnQF9WGU5Q7xbX/X5Z/yv/XpLLUlL49dSdbt0OxD2hK/WBr/B5USSb87nwBC73OX7XZn1X+6aF9U3FDZbheSzicTCz/PAcvw/sYBy5dUjmOqdoOUAj6WToIux43KgoDRtXsJNLvkzGwM66I0KGMzrQAIUqTOOti7vySOuaAKpenwraZdWe8an4sSyfC8FzMkne/PKqXCZ6TOY8RkVj6okdVB0kgd400FmBqihgQNx9Y4iUqpPs7C/hEHsZepDxw3TTUyna9tcxBgPalx9ey7zAxmq8gynvGPzyCdK08PvA8+QcsRT+NjLax48qxmGieb4AAHrPRuXH9BoNlLFDiA8zlwF+Q0DdDFqqJkFkbMWHSE6L/bWYgFqlSkahAwc5jt+CvCPwoETeU1S3x/6llTR5S2IezB6M9wSNz5MRP+70392FhaTi6Taj2Gh/7LhSi5NaO+z7S3cPFihXRZ7SqGZ5ooZvRdovxyvriSyKUarX0Xrdq2W5an0ylF/zYELuG9zrdBSBxNBCbiqs17if11vIPooJj1nVe77QDjvhjMRZqF87lZDs5ypxfLSYhj9bKhDZR1oLIrG1+cYu4tdOA18sjDCznm6Cf02n3Tytpt4hReIrYbufjU7wK9Mnm8ANbCUl5QQjqRWLTEny4bocxJBpIKpjdaPwHR0jt0sn0QIlkWnYOzWYjuLY7OolFb03py4TGxNxYNgKMO7GbdluXWMH6Nv2FXOtO1KsKCLHaVdrcZR3BfQMvSSTOTZ7a1d7a6oqThP9FsWhdDUPFMFl3mngzUPcwKhfItK01UfxRli0LnfVioVYzmJ1m9Brcu4Gt4RnnUQs0/2287CsfdBIc4HVYdTXPMmqS1FtgVuMfQnRVkliP584OJBquwJbePVz2W7UCZId8Km8DeC6Kk2DTUDpswoAXX9ToXKc1IMhnBnRzmiET8QAAAAAAoqpATej29dWOJ0WdA6ugiF9/jOetsFV6nRN6sAikXMaJC6inJLK09VK2DwLm7H6qNd0O7Vk7pjQtdPCOgZEMUEQhbN6zECNwunsSJ+9K34Daml6eG5cloCstbGFs9S0XNc5lpchzwZ3+mEQjdcDCcH8XheyGE2yXV30VQ/rB8bvQPbsJakeBTYYeBBn5kg2tD5gG1hTg38YKyGWn5jhf/B9GjrKqFfDXcMCZH5b6HdkEWbDi3dINLZLSx+txeTktrUdLRVOFqa0oBERWGaemzxdzQiqLQE0lr+zy8eTalmPC1cFmLoas0bgqjaFkLudCtHEmhWPZ2Tu9Nu4Hr8TKE42u3xKnk+wG58K4Lx1VTlphpTrVbtO1Nx0LkyLKfsmwMKVQyXnI+tAEsjAgz8yYdz4BMVjN0stO12cTOZPZuMcmd0ksj+iQgNYWwo/q9cGW/B/IbqMHFYREJN6vIXiGeHZspDEvzQu6SqQyI1vvMyNteAvqQWNl/+g2fGNFzWm5Z1ycIihLl86yPfSNFzN+8LrxUyZl6I9sHXjOk5q4UHtrv2Mej917yIWKp5i6WZzpBxc+VsVtRXjFwuEjJPX/MjXmqgJIZHm8Hu6qtfNHP1fKOpvZbGzmEu7AdiQKSIiCiucoIhY7KnGKhtp11dxnxQHL0h5xi+hRNIKYkc0t+GmVXuCaP5qswbHLxgQTzVEvt8i1Il2DoMIWx/1MqjbgrMh6AVxj/1LTsNRZH+4zkPCsr4Er36f0YayV2EGrn4hdgUFG6cqp8IC0SP210stuoQAIBThq5o0sjXlYXjdnwnVI6vs2ITO4XV3b/RGcGY30MNi47/8bX4RnWG77wrJxN01WprTYOVc8JzCg7NpJJYiOJUACxZH4HOYXxUTvi+UcrU37qomtup/Eus6xZkQQUhWdJHGg0qlivoskQ59SpOvSHen6B2k2Y7VjdqZ7xOxcpMktGbbo/8boP2P/UqgfZ1RIeBmD0KOeQpbSbOmZ4mzCST9t+0pyGjWcYvVGzazDWBXT03zbA63TuFe7+Oqg+MiXtdsY78akG71cHvr3NMzsXiFIntj68pWa5B0tj2Se2OU7COlru0fwe33URPN2DKFgAhMVgz4FaXYhjtKzjUju42pBf1e8Q4JGyRIqPTm8gvhASgpqvIY3Wk7U8bddipBaMX9+Gfxdom9D0E/mYPtSFdv1tizf334YKuRzOb6Q9QkZie/3g4EWEPAq1CSkhBDVl7zz6+Uflwb+kwUf/8R2S16dQgexsgM1G/GfqwA72MkhX4HjVb3HIqgziAgt6BLIHQjqfB9ToqGIUxMs0NjYZx0Jl3Qr7pgbX0G6vAQzMG3YL9z0JBR+2tHj6Ile3rbpVrgI7A2u6NZtI8Ye6cN9eOpo6s1RyNV/pTue4U/rWXGFW8UUUR14Xz9pySzQ89/qRegiDvnzdJeehYH9M4/+25MRFjPl17/s7ifQVH8mV0bapfZY1FQVGeY3iiFctsPZVrqqV2JRs5PSNmn8v6Wquge2tVrHEGnzU2ab0SQ2a7H6D79g4prGzOr7fl5YK79CTO6BugUlm2/9EwdvJLPAL4IbV+53RzqfVX5VvZaJuXgsPb42RZVxQ6Sh8lEjQpKm50oAQqN520vPQsDppzAlmMFCc6fM4QJCAsgcj5cjOklRCBVDSmhisSm2Yh/Z9PUtc47b7Cp4qyaQVID0s52X/EIfKdLreEwr06yR3Fh989GTmuPIqgG9Yf6jD8Fzzm98AdD5RPIJPHADEvNBiKTSJpgpqk1RdakB4UdgCYQEFncXCIGW90Ppz9y2pVt2w32N79S1XmfRKiEY8wwROsixPTmLTL5aJvuqiK0+LXm1BL6HL459rrgA7ccMtGk1b+nMtA+gmQ47oY0nntvfQLrR84sGzzJkkNH9zbymUfbRfLejudQRKHBRtuw44koSgY71yjobVQrHi9jfkJ08Zd3+HfUuRDXFYjcfjCeIjwWIAe8smmRJO079KHzqA6GL1uM/OkrQ311FGOTX3ygQNbdzzDUk7SX2QCW7lBsrL5EcnvIybC6JHrP/jl2ESwwfQoQupfHW8Z8Hx3iEtdug6pPjToAl4IEvyCdHTs+tTZzR2ZLtWdqzdNiJZLLOx3fum0fc4D5JTjqo86aGiUDoU4gLwIwSylIc77mO0ZIC2MZuvjU59t4M2Z6BtALMrOt93aEBxlqP1ePyheRyYdo/jAhkP9uCjhivEB4oDl67LZ/wYv7ILssRDquYfh7s4gl1MZDF2dWm86NRIhp1gplflgqPzlbjYf9ZN4kEOB3uVzKRvBAYhcPU7In8QpP72G7zrfpnlRSEDr6pHZu3a8MfEaJZlx5TupvxJJiPcDGHhMToQ4+cJCUg84ZqmB5F0hc8da9KfaK0iLWMzvmeEqW+qVK1EJyUpYSJwV+EBEXRU4cCOpRr0p9owCLHCaKvBhdqg/UdAX7gB+mLFSKrZSzwjlw/s/q3fAScDfVGtf66ln0GxIb2LtVEnD442Q9Zcri4MEvYvUU8YaxhRlCnfrZR8R1seus1JuZ2OrjCqCJLvxf7JNib5uzvoEE89HE3agv1xvxQQYBCUx2aDY9SPCUS2dd8tF+ZQlhgTdLuHSSHPtks0+ZVqewF1iuGxFRAj3n+5Y+pnuFxvyyS2CtPFj3lVAjeJIfUpzWKG86yB4vxU+DeAORV9DgLQ/SHUOs+WqLbRsi1RNod5FoFpuMRbK31Bz64+KNyE1w/qK2RR+LivxcJkKKL8AnNcupb3XWeFgp0fsCw5ejY0Aa4QzM2ApnsNRH44pJ5eCErYwRuI6NMNMlFtyOS7DJlp2njJwHKvR6m5FNIJJU2PCkfyJvBPUhuXwDQLqA33//wgTZqiSBNma/PHtzNhfjuyNj36wiEFUkSZfNUXNEpkpKCsR+t8FxX/5qrktF/Eg1zocDL+1JgeIDdF/kKXLB5UtJiEJlmZe6R/+rpoaeFBPoXUULUoPvA9PcmM1/C2VjbgF2Ci3K6hr8JJrf9nvAdEvMQ1TyUfgzRE7dh8qBXtE7K7CPyo0luLadIJOB4NRGj7qRTVTDheRUE62RokJ/vqtqLuf2RObrCWagUEiWbAL1gB1skX6HbuICyDVWm5RF+kKoAmkz4V3EaNsE9yiqvLfQqbLCWfvBmJtZDWtIhyrDQHbHRgavL7Ve/CrQpwiUzCCjg+B16AOFuWtzlYh2ouKxU/YlXX7xwTaaE5qqQT8RS7+KMQzSQu+PptH6vg3XooOUy7wcNLWunh6siXAcZtASr0wdeEU383DRsc5CXaL25O0zabqfNqenOkKWmC7EzBJXChRxODD/j1Y/EpGyNinkI+hVuVIbboA/xo/Wg/HDOn+PF/y1KId0U/LxSFq6g87t24EtsBdWS4/wzI2b0ZRPF8N1M3XWzHXHQuJ7D5QK1UvwGBM1LHTD1CxvR1spFz+DXxHYUxO8ifysRF8LNqarPPJG4SQwW2WtlZ4R3lZ7JUm2uuE7JxlUzjmLX+fYtBKsNTeh5u3sZz9rr1cpu2JkDmZImtRu3/km5V2g42zCTIhvg/YNi/7vF4Zh6yNVZVszwZSPN0crZLlT6dBqjifNcqT/XEi0S1bUG5Irev1CQMNkwlDmfiCWB4oeMvzEjqcKD+AICTDm93D54nmfDl7qMvDdvetxo/cu6CeGwX5V5Bc2AVAs3YPiyGg7Ac4W9MPPWwoCH4qt7am/CVBGo2ofFffPTn9s6rS7ZKheuaqQ6gFon3TdEKlY4UB59SbCoOIfg2M+8+HNhAuQLtfM4kE1k1vT5mTmHiKaf3m9/BHciGd8wqG4AHrm3V5p4a6X55eB5D+8mu0klzEGia+AqMQ5auoqt9JcO7Xr4aX7uIPjlLLAHW3M0wiNAHxB5heOe2TJ3UxZZ8xlZ/k9JCq4JJTDjohB20xDsrTNc/cwIOfPC3OU5mbfxMn3R8+xvJNg92tEoZaU04j5im7dHjDitGHZmrOuZWn2MOBXCDW//yuW7D/MNjwXv4ofSgHMBmtlu6trdV4l6ZYbC9PRcMvakv44gTjjpZQEymn4KUXWmDTvmGP5JoX0hU+SlM+33n8XWwAz9zyOW++00swWYyjV8BYIbgyMBQfaLG79Cm55Qb3mzZQTDJkAhAPyRdmEdGE4BT1IaLuFw+y7YOvGdJf/Y9wOILnIszBSwksqHF9mltndpA1gMtNUwXEAotdbgBBuwytdbOKO4QUnZqDJ796MCMZe0vkd0OjaQIfQ01FZKsoyEL/6hkM6T5t4Jf8PbRO/wMCkPJ2tS6PN50GJbSTWFyXkSyJzVYPfE4czcsHggLsqg5hpoF1IU4IavLxpGHrbd8EyEw26fP6X6qAz69jmFK4ep+p+6KHoB/A4CU+ETJBfNGH85HgrpPpt4cvGOOYxcN8IVGHUIqyhocSTHEpUR9/EjQgIAAAAAAAAAAAALpeS28Z6jfAqm7+ulYR0YiEbBPuArq1cJ7Gi+kuCrZcZeuCLGXrk2Axi5M2An6S9hKFFCqB+JWU29p5VNpgehhfkLoUH9sNWOePnADV0x3MZyzfcd9K6Z9BSGH0XGNKOU5pJsx6b4DlaPOYgaumO5jeFsp+/E7cq7obIwQulDBcnT3RdmdoSgZUMNq7tvgrT70+g+ya49BwBLowg7Sk6L/YCWQBWOAyJ6GA42rMSKIqyFLbVNfewRHmiaJrZqD2ZOWatzCjr5RFT0r9EgBoWR8dEZhaRE+FUMKvbRgStIBe9JMLo3HCke6KsDbEPDLBOyBEJ9bu/g/uBfGjwY5JIovF3vRAkSat3nORF9wnxhctRbIizgz/W/WEnkhACMe6osqu69t4e2jXWvNqUYQ1/Zh3KbfNwJYZelIOZCMvnjENZTAsdRjMBuSXIfSaui68DN2tOzFoAUgfCURPeA6M9WP3UntJvzRSvQXCKF05BTwbqNn1+wznq/uZxtMf3JNDSTHlBD7XeWXjHgcwNhvD+vldpDDI8qO/ybDFGpo3w19KrqD7MbjVk1X6b4tCCUekmylQ3hSoJwMZtZY283nqYiJRn3mHc92jElS2wnnePI6+I7CloKrpdKYUoRC7eYT76nkUkLg+359QM13XDvWi2epkT6hFSmRgCihMgo6x0f+QZT3iaFWumeYmXPdIFWdtpd8tpYnTYfhDs+2qilDQEYfkXffdyx5eg910s/OXlC1XsQCDlCqiZqf/3IAhmR23fk3J7xZydoXlr2/xHg+2COZ66iDA3kNpufepSekG0i31glrqN1v+JSyfEBjp60kdc/de3aTmnFpge4wOH1Htb5dz0KLxxIqrW5CT7kML1KW2I4l+P0OJoCwKCgemVHEFvL7fZu/Wva236TuWtMzozT/JFxqaCIRrTMvqm2LzvB1lRSbZMWYFDJHfBOwqgl5JOjnhdKxTBM9vJ8lfdbJ1T8jAUHjsJhIpDjNd8CgkTuTEBe4FzSpGKCxP6PgSQVsouu0m4SuCDgqa538Q9dFWlywlX8zhjtMdbNh5Z5QejBtMzGrtSB40gVsqENksbcF7Xhjgw1QlDFLMRwg0TgKfrJMr6M6VZLKon/zFz/45e1kQVcC/3mw53At5uGSqzBI76RNA1+9P7r2HZ6yrgmG/PUpUVtBzF/l3cHalrAamarbJlAnWzFROJC5C5MMjI0xPTlV4fhXro3aEfS46957KLgMSiiZezT/2JtJXO/2hG/n5eOosqc4yOAiBGPkN2L2ZiMMkKa0GDNpCtRYueuiBynNH5F8Q0zOXIbm6rWnOwTXf0CU1eu3JqSLDjs3z3doNyEkvFbRpqmuPo4p4OHRSXpSJ95m+7S3tiI+zju5+RHaVfuwUbxK9xuUrbV0Xipb1/JAlorFgYi7S1pkTVkO4aH3rlc7LBP2OCqvJghm71asQvf9ex/5oAEHwGc0g0Eb3/qH6lENhWshxfSlzohNFxUoUy4F61UW5xvX5BVL0+FPhpd4SzZA8DR3hRH/JfnwGioMoueU1CKZV36mbDF94fgSdanccUZ5ZoVmHYbv3a9/78uMWMFpf+rVZ+K7SvZLcYh80OeyjAqjyLziu+hv1gswioen14p3Ujl53GHWOnfiMtmpDzLuLFJGZx6orgjFV/TmdrDnmV92a9S1EHNorGSy/b1jcKZyQ1tojxnqv9TD6loK07SxEY0oQBtHR3G7dHHxKxUgOCx/vH2qACIOYGX4/KcMEMzUPsP7YKZnCXkSK1QMgXDNdf8wL1GKG5Joc+mY5lE2ET5+6sQBlhqULQzdoG1J0cm//2qrKSvKXIZPWzNrNwRoba1OvQw96t2F9ep6ml/aPc44EbIrZ6CTxFf3HoIu+N251qYXVcVGs7e6qNbueW/bGUA2TdjUrspIJ0zrYxzqArjysvECLOlmvJ9wvP/p4jxh3Q8lQTt29krJK+aeEZtJaFCjVobq7vR03SdAo46uUnk2NWYAIVK2mGRorjX0c+run00NjI7fPHjY3Paha35gIgoKMbbDRXcwkgSVdrs8UTyTfblm1a7TSB7YwCCBZhkzh6Ok17o7IQYfLLS9lNEeM9V9Ri/xqKuLaC5UgkKa8SDuslEVoVhz+YXFRNZybrBAQZGuHnxi2QJjcCdgWbJCy3q7/szDVc1sEiaiT0ttAoaXmfaoasqb1FADv999gCeDfvWismrbmW79b66r/uxAM2+oRuR7t3vU/WcbB9605CiKSLgEaQZqcGekEMvUMQfoM93zPObdfMHy6Iv2SATvyGPsARGx4bJH37QEYFIGk5DKhJHFXwb+EqtqAJ737l2rPWn5MaWCQbuELOM0jS2KAqwVlXButeOsz4eQxIhMC6GY877NEk015A44n4e8x9MF7he/l1pzGPgI+h/em/F3H6eNIbi5vpDrkHSEgBeQBIt5CfiN7BMBNKjJUJP5jdiFhTzILgg6VkkXNmKOqhUTkdpy1UEeWAaUhAQ+GI2/Sg1ap9LWb99itRVcKbO4eIw64FW+sHqpbIoOXpMikg8DlGtjjDlzm9meQthBFmVS+tKJgYjahVKeaDslPI1p5gavLHYEwP9u7LdF+3rOUJp4y99jvMcb8lRMcfeurSgskAG//8TODseiPJWrV43MCtv8QpgESIAHI5IoN4lf3vs/kB66xIuhhtGJlb4doLJXZjesB4qy/1Op50cYmMRs+PX3A1ZZxarfsSbEbCf/QuuRUa+cm6VEkXoUpaxRio06vmYZSPgtEj9AkTWfABSOphjlMM8nj5461ZxSgNSRupBUpRw08mdAX24EXLZwVOtHhO1Oz9h7tr/qHy0gyT5kTqgesANelo7ToeQgjYMQ6hkOKZQ0FSsq9LdoDu+ujf4/rA6yEk+2uiDvH6qXNORqmah8WJ+6RDpaoN4YOs0Qf/GDais1NfAHkDch7Kfyq6MZncnVqZSRzGDLTrQPcflSUGDmJo/iquWjEKzCnltw9dZZZiQO6bMcYEtRMnukY+xUt3FtAAAABeDIqSI+jJ5BDARhuj9Wx/cupTUM+VcqLR0fOdvBh5YKb7roVUXHyJ+FlHi8gdWf57lEV7HUwDGWzwmjx4AJx7qw2BDFm5ZlzfFPEowOiTzcFYT/p/Ere+oX7PJPbDmAyZJNxVVJH3/wk3m5ZUjBzqyrMxKbpDLTxLnlRGIqA1KdYuh3HXHZc0Kw3pYRYDt4Mo121oMj9d+wYdixGzTYyAfuDgx6/UlRQCyWCmV0evAfmkPa4oP9f1wLIw3uKvMoGGDKksQrAB62KDiAjiPejaGsoyHqIR+LgIxmOCz1Vmzj8cFyN9aKAaD+nN4htnU61aNTShJTjqnK0zMiDEdais2MY0lgCsAWnoTdmuzEQf2izdDhIZ63zF6BkId4VeqMqjcUVHeisfZdpQc6R28LbbhV3Bd1JXHrWyKqRoa0RVyvcgMoqGv7kLtyRml4HktwZ/5+m6OHOIzesHlS0gnlAmbElMoptm/Fuosl/LGTZCPrcnKIXnPqZdVM77uWL557HdzjW3JrAwBN+F6e07n1fEP8yAfwQJliKtBUX3cW2Ls6jor7Si86xLzpO98XuKEdU0FoxhjueD5Dag7GIkR0ZtbUB8m4EitaCx2nV8/kSxeyWW5J2eXk6dXBgOB3YyPNKD++XKtQyzuUDZ6TknFsBEqIE9l2LNWr9llUdcDhlo7bSqXtfdCpEuK6xTPl75ttZ+jSb+dezh6tbbJR5T4m7W582DeUyril902j2nDiCiucltwS6Bn+9/iiT5a18TR5510T/S2tTuUiLSmzcuDlEQzN1/ESy7ke+RmzysV00IP8VgK3br7oVIlxXWKZ+IPfaQx/6GzdmcU2msniclzp4uQjfr+1pg2lyZdtXVJ4uJmlhKkyUp3X21uGXFVQwckzDzElk1v3cVGmmjlkPPL49h+iocxvAO37F8aBaWOFpuu0BIM8LWMXxqaBxJe1cl/0stoDJ1hW0Pf6cSl+bwc0Ve5iF4d9VwORpzL+0Bj91WAAiQr6kA83XZBf6Uyvc8vHZMk7dAY4f6r2S45nb68qsfjoQ+4IFAzvkwqEZsq3nttErQ8ihp6bOSeWeWilWJg0T37OLkXPrUpd6cABkoMWODDjNJBWeOX+BTlGfawCtGtlLKta7cViJuWNAyTbGbISEBLvvFkR4IiJ9M3Tg/C77YAZ2ym9QdKwaf9+IjEdclHeR267HcpPhvG6ZCacoH68hm4bha+G7l894X4QFJPo6HY+lo/S6A+TiWCDRqwCKTchNV5n0gV3vT9il/t1PApnNJNfeOfsDDBuIiL2ivmDZH5DNzig0xw6Z+jjudhBsvW5DfFLKv72ZbGGchk0P6dHBd7M7gXSdJt6iGmhcEZUASFWzJtgmjtTR1IcLuLpgSuMYbGLNfvTXuQl36hIeoSWvliQPIEbPv0JItXerJeYmMM3cCuKRP+5XQKkJF9Jy4zj5/XZYLPBSLz2RJM9ArNY7izQxOPqvoBxQikGZutN/IyR78BoHED+nCEzd37Xr0MjwvRoBFY4+pSadBAOp63Ed8tZ9zRzw5JBsG+5XzwsTpSwqgcKqVF60T39sMlP0ejaa4Z0Oq8bnhms5WLIPH4c5p/IbxbVVezUQWRAciokIrvjXGUnku2P67eJso2gh67jDlO4ZuaoN7aZEssW8NByosBiKts7F6JXY805VoYZr1LWIn8zrylS2tAq65TpDOqS0B4xHNKGYQKbrV59+VbaQOGuiW4jG3fkQ2/M8PouCKMIbvPzly3UFAcyuUZgZHwNYwNolf3rKitga+Vx6NgaLA8IdV86ItAC4vOFMb1mcvorgYOfgMpf2Ulc8Wfo5WF62Z8O1LQuYDMWUwyN47ROh9mgeknaTBEBHJwLcCXNnnD4mUk+CjT3goICyx7cR8+OcVOl6Gt0yax6JbiMbd+RaeGwlkcmb9ohTo/wWBoNQpMvsX6nH/jTLsyrysv3MrE0iCMs748Lb3j5cb0Drh/dVh2yGDpCKnfG2/To0Zykx6JRfVrzrjZ2h2D9Ny0k6miUwAT/S/5nIBsYDxAzCfdWOzWmHTHzGaWU3Qgh+CBkZo/N6++b+uGh49dL6ZI9OymHrzBwP8DdEDTDTHrsoTsA+PTqs3DAHrLbcdcRyRdJZIi4p3Jmxok6wFSBs3na4HKhb4QG9rNb9b9bQ87+aXVXCFFGAPkVFTr+7DLR27FK6ugJljJ4SOrFOHq/XufcISkwmMNknqB1MjMxI+aXJdkaucBrGVeq/OO6EkgEd2l9dhZLcd+eVKi5mwic2aXhkMoIp+QZB+g+EzVJw7XHlGVTej7Qv4iba308whJsW09ABI3sGVfC84SqeYWTPb4/9OgXHxHITVIjZ5lDM6hPy/t+9TkpOjHujT8/Dcy6mq2+6UDo83HVU3xmfg5OIP2vmQlByXpDy2i9pcDgtIcaiyaE+GuiohobwssG3l2HnIx9MURnvO/L3Jx9rMF8ySiUnI0Z74Yezmr/AMIykbOwlUQGDCK0I7BgVYyLkri9KnzsPN6GPZUJSV3NvRM4MK4JyyUXPpRufaWtzHOLOraAaKxl+fU8lUx0wfiggv6HtGBrdMody7YUeaiRsEQdy//juEEPWWCOVpsYK2qBlGGzkSpWLGMW0HvR8eBSCtaw3FgDnXuS2tW32seVFO6qskgI/huly2GCHAE82cXdOQo2i8oTDnINpyNWWszY89ju5oDoGqzD9Q1qb1eis7bMywnXzoo6IpOAdiTxQBKwX48SiS1NCI29Rc8mP9X6EdIyEZp1aWwiiJqLhzUoZXxNwLAhrhNkJPvTxPR9lyGXvU5DGow3dICpVyKh/Zo21tPXP9E6yx0s9jLy4zPUfBqJoh56ej48lennkt7aomxNFxvyyS15wmozRqCLiz9cuQVNnD4wsAworV8UB2i/YN38J10aP5UdIbmenBiBKaE4OocXNNcxhH2ATUgJ9faH6qWClKMZZab98/bCmd/4/YVE1F1oLy99fTmbJOZEY/PbBMbLK7KiBac8Dr7/1u8Zu5XuDVuQH3gqQKTHDTxJ2wAAAAAAAAA7cOSYaeL+u7x6PEGhQ+zHq8m0XgClcHq4Rv3n4ALSS4/vq7sCCjdytiI+AAT1Db/aSyqXf2YLt113EYSAhgXL9dOhZg+gSPzKWSuA2/JFpR0BA6eq3PbTc8Ru2cgjExzM1nSFvkgsN9igsQU2hD+C0RHYVr+4ZxXBfUkvR8KL5DIUGBnWMqudTobT2Bg9t3zv+1iOWUk1UTI1kkBzGfG/DJ7dcN0CzXs5mSw2GEH82f4TQQmdT8sB5PlTQ6Q/nZI55jBBad7KLCWEbg2enBkMrj6u3q/YFivDxxkZmzmH+oCbKpnRMUKyChFKfyRU17nSpAHYZOcxqr/G0dj5SYaM9dycDfyAujAhRuhy10MEd1QWu+7qdOLlVfuB505HR9sDoKER77/wc7BQgxOGSRpzevzyrgFFPVYbcklVgK6+AK4I18cC4WIyLqbuFSKs1DwwNpLNMDNgrIaaFAgQJ5ogBwoHAFA2wAfokbe2D64awpGHKMB7qnh8xKPhNlcDbxoXCZLF5R0AABylMtTj1VFYEYDAoILDU+WJaq5kCrbAVs1sWZcjEAWHTFm0UPMxMjj7IrTreL9OlmpsDLY2skrc8iYbJbrXuQg/W/xQVtyx9RlZoRTC3EHr7BQtu8/TiPRQ9M8oG8+PJhSgBMw7Iba3j3FYzLBlKSR+VRbO1AL0f0kjxLedVMQb7z1uwK/KXdsRv+qBq9c4pN6c+9b4y9/05yilcs99litmfaEGB8YyklBoRxBmghH5p8uQseAXwiJoX2ooDYPaSW0qu+j3K/Y/rMKmCsAYoylkoo1BdcsVJrOxTzlqmsaIhGNZF3ZmsmtKzCmWZYPq39yOnu0U59b+i2n2iGyQrfmcIqdQka6DYwqNE+fKlf3UGyTnnLwvCxzp/SHy1mDgRJNowI1YKJD0Qf4ZcT12oHLgToFRk/t4Xfg/HWLd8KJsdRj9Wo9R7uIKo5MH2pCu26537Lz92agOYffUnL+kc98nEdpePGxniH8G8fGT5SEsmnXBLeek5/zgdwKmA+V7u7QaBOwmOPwmBJpCSjtoOiwzXeNZLS51m0Jlzgu9Gvsh1CBt7RwomX1GHGEO6/h6nGzZWjm+HVE5w7KEpf/gPhnDveyl8oQ4Tl+JoPetMsnXlA+8WyBItEJQbevZslZnQ5jmKE42iKmKiiXN2dNvddyNQm7kcNmtgj7PW1xeh6QgAoZHLnWnG4jJI/vgMMML/yKENcAPfAQ/qeBky5JsdXav6pxPH5K+dkFbY+0DXxUchMFDgbWYIg/e/ikCnjayo/tk7Ys63fX7D7NnnIYRkMb8Mm92VwmZJtPVhvtpLspWvK4EMvQ1XIxKMKon3ap9/918tI6cXZ2nJQkwW8bTuqJMAPLBoBC4z68ymi7+wgnrKx6EP61TQ87WZV0wPHzBjlKs6ZZk/7DI5Kd1WxsWKXndgRCH1Vo8B8iWvjKdTmSE/v/b1mr3hAC3BCA5s8XlKSCyoiScsx9syyMqSSRhCvenvw4DZB1nCi00mOap7C3CkATJbb3wUdZqMMiF4+tEZTggRBVNvPb3fuPCObkx9MNhgE2u9A48o0HvWmWBIqimJ559WS/xcbI+oRMKpF2YDXyYw9x9YV+yl3glV2LXQWuTcTyGsIGrm8MXyOGRYUkP9Ba5UrZK2KOEC6erOtbD9SuslvUGCJrugSuIm6S1PzRkPRmStXCgo2iNV1KyWY79LrcW1q9LEN2UuYBueMZ6f83WdCTbK/k9CNJzH0uq2RvJTQcVQnBFnGGILxMQFqnDUKIHe2/BaTrS6eiX7eABQMwFr+bFP9gh8KMzyN+BjLFT19GNThr/FPMnYp4Rg+ULhfYrJLmBpia+wQ+JyxEAW6Gu71im6/X3qcjmpQyeKDzlheYzDH8FxZty7MSpWxe7YXi9kCbjO06QUSnd2R4BWu8S5/3sW/Uy1Wc4/yPSOKshsGaAsZwZJ6DCAGUCC6+55gwt3Iza/I57u3m99hdcfipvAHg2suQa1V6cN8DNklLAd4Fj9i8tD94oETvZJ+heWOcXvMPWWwArCuZA81oNOH17ok96sDGaATMkarjY79ox5onjWk8lImbx/NougrQl0Hx/cWLSjEZ3QixsCvp6e8NP7rCYl9XNpONJ4GmL3v6x2V5EdhbLg19xa1BDhNeyiRPHlDcDnIgD6kIRo8WsA8Zjj+E7YF2FeuVswLx1nBfO0SbcxAfj3PQgHg+143fKVCibn/ChQn02dSmY1Z3PImxxxGgv+MG1FtwdD/ClU1A1R6JmgAhtSBpF70NNVcgOaYSg3McGMKKpd/y3Y8Bvyag+MDubaJDZ8Vlrcatt0XayRkSEemZD7lx626PMcCUBfwQ7tgcl5kgD44E/CgOHhPnEBsHgkS0FrOilagfffhXabOVvDCFEM7FTFefGe9v9DNCxi1lYHzxaAWUJY39OKMkJ16qKppTLj8GvUbfBINB1TmQt0K4wLMkDkoTmjYwUmXFI8n3sZrDMgVou9V+GAgRCe8rsrxApvTcFBRibMc4xRGPD7Us9/unUNYK2GC6HJmQiFz8/TKHUvsxTnNjO4AaqbwOrvftQ53JBevgmd4SwGF/1EQW9zl+12Z9WB91ntfbhU7biFobiEy5l234j/qydujd1Jmk0PLeC/XtLydTO0WQF8Qcjz661grs1W2kVDoYxi1MKr8cT/3aXNg5iXrD8/uA+Sdgg9AO5/2jhLy6z1Zwwg+7Iqr7X2pdMbUmFjarWNuSorMkswYQYgvyp/qBQjRsVvXyovhjBZSoiPS2AWlY0n0JmrcnN9WodMvPb1KtrJQhhYgd8kJE2vNgznlaPP+YCeFlQleXmZVlHDlT8glfYP+UCpbDwlGlJ8oOKYjoQoQ5M8hqgjXlBACues3Inds4AHtVzt4VJBVS4iP6q9/fenrWp3GVVFa/7UhnXJUOrT6TwOB9HfM5lwOgQR6TKRh0R4jucSx7O+6CQeqgIE77RnWRWNSn3FQDS9QEen50VCVCrK44UBYDzUOnRwu4vm3uX0n9pJ9NhGJ0XD5H5Lu+1cHmNTyhnpXNPUFSn3kq1YzthqXMGb0Kq2f0kRPXOpY1fasVoQGImVbdtds00Lu2ZPmwuAZA4RvSzKdHJXMc6iVe1C7JnXc4Ikaru+9nKYcUSp8Rjn1fcTp5SoMh1heZr4zqnBPh1P4M7FMMXSdzt6W3pwbLQsYt4Hh4hs2qFsWaz6OAgP4O5/2jhMAuZd1+5E2b56KYEkhW9JJj0uFsI5oZa53mvoJjbGN5yiyvcfkVpA/QfQN7tvta+W06gdzjzMvtkPWTqx/lG0XREjztoGfAOY+sz9Ep8xModLjrgrDO51T+jFjm8GoI31p+FYUPxHUIDpErCxq/X5a/gQrjWgwuiTfJvtpGkbaGvQEdY96m/cUiTNLMr2qCoEQSnS0jDvhgD+AjI4TYThHAMO6JWAA+e6fSTxwRnmqCGjjWxSKOTn47zSU5osB59Hhvgci0unJi6Vplyuylm2LfZEXKO0U1cPRgOQdHjJ+g5pmeDw1BOF4Gex+XlDP1sza/Ya3T9dHlydU3ptm9Opr/zmhx/YNAPUENlkvPCpAR47BGVcbh8ckVPnJfYogFw1+CSFZhxaiwvHfYIf0ypJkuw/j6nPm4w1tQ+hrNZ9YWeFKS54utR0KdEkH/jKC6oZ0SW4BhEb3OX7XZn1Zz3Cpfjhummcz1lZ0fev4cLkOrIVnTS4Y6OaU3uzqnXAaRZMuAHlBZqHnN80YSdhSX5nKIBVtFl05PRxBLrZ/PUlxuSMIqNBml8GUMUO9jaPKiy2LV680IZM/tC+nMHMimQOI1Am2KP03lIVrx4fmpBE/iWAQzezGsTxSKLz33eBp8eHa8eMwyqrIOUcwApxpyrhl+xu2lhUlOtLuzymCShPHxel6Q+Jl7tb1MrbTRkucftSntkB3BQ18+8PsCqjgrRgwOJIBna7PdWniySnMwoi3M7sa5S9ae7wjuc4yvp0zibgGFFkiFP180GcwAAAAEdsYOI7DUEb7FdUczxHA5ElgedL6zuvO86c8OL1mV5/YRtO8UoqJle1aVrscemkeKT2wTqpxdWAHN8op3BLl/R0crETR8DPi2qPKPJ2fk7FCsOB3xNt77z2fxMHZIhoChsphVhNgEbqj0AIzXpvQL88HigSeJBoTFkSeNiMKvYsEwJeMP4dlMwFutGg5Aj1AL9UWqjSPulyD4nZelPt/rkiK6q55UzXdqHQ1yS/OiczosuLdbHAcgL35F09d7LNleXF4eg3HV9wQiHouvGfl4SrFFED3kwJVn6ziJRonqqenuA7Onc1prouNTqKv3shGg4DFkBMTZNNJ9B2RjyIKB48HgIANZr06e3cyXHPH0XX7PwQ8v9pb3miTIx79kieO1ohnwgrusQWbsyeNWkGQKOGRSme5otIdAGLiADAuj4zDQvRa9KroOOT8aLVNGLCWCK2xOFS2NgP7AoA0gwhlkw4buXz3hfhAUkkTbAMf8/FOjY0494Jh6yiM13WpIpSuYpGZVG6GAs9qtyxEmsfhIaK6zrXlcSVFSSx+LU26d6cPrG3OUymrw8U0KbWzoiIuRXcimVzUvWlwuwWcx3yYmvm/9i6bHrbd9Mg/KkBlqMDFWApTQheQ94oFAuwoF3lKdyFfSWKIOjMk2fOUUU6bJkPckgheCLeXVQKvdNdlSIRnEMEi92JX+a+P0k9ydFkl6wu+A+qQKiq1AEVPBSxcat80YeAyIxc2wH1i82onQLPbDHRHiQsz3dlSBP9/9B8nhTRM1t2FpKhGVkuVznWyeVE2LyxlvipwHiI6YckoLlTNgxiOKGDEbPcwGGF3YACv0k1ybCmIM8a3agovVK3dpn/9Ye4ksvQxlQVVeql3dbMk9P06ai46yw95wRNr4lndCbcc8cXm1bLh36CYYbl0PKM9hVrEL5ClW9DD8E4goOzDhRTQ4IgKapRhURMnR4yRm25TvXaFI1NL5IjlqE1ZC0v2AjwFxeX0zxK0f0SVsJA1M/Y8sQHUHi/FbNErLDjvXGK7PiK9igxqggFg6Wxamon147kqCDrFv/pXMfHCCAK9+tKycXLpqpHishlvGKEH83XTppgPnRP9lsS1ZWUv8hNisZTJaAU2d4nT2o1KW2/QXZKEQhw5dg5g5p+es7ZyRHI6EYqweAD9LNjumbPXs6T7IdUveIGcZTRrOeEBKOHE41zdXILqc+cxSR5W3Fna2t5t0G+DCsPnaWwokoHwnePZtL6fuiAUwP5yatMvNkcwc0/PRDWsUq06PJb4XVRO069NCmG/zg3gS8jRObgGG/2FpKhEF9n65MLvo7az517lThO43elrX26fZrU83yUIU0wgIo4Zz3isRqVoIdmKnN2Z8E5lEhooFZXQnQ1kGylKdgdFsBvW+yNQgfZFkh4uus8YJuI0TCvRO9keGf6kgKFf9oQQsM/Bn4wZH/r1gJXOQSQYoAVZAUV16hjGnKr/eP3W/LuQTyg4GnHfxdUI0mlbIXGD5T13nPI0PKPUjcqxtVOJUbN8hsdIOdNdrOFYHT1lahORBt6BYEO/+KngxZ6q/L/xpYZmAIKDShhHvjv+XzPG1E0kBdolmhKhqsdHKzSr42vwjOsNzeDgEx1IDLGPGxrc9NhIO6didDigfyjXeZO9fk2Mcn8uM3pD6EaLtbYSnkx6BT7VlCT7DzST1dx5WnVCF2nohwZr7xNPrZ5p7R4A9bjRZQ/xo1B5DK5pH8kW16yJFfXT+WF012fRXBbDCfIbuf6oHrDbFvoKfJRLD8TzB0tncZ0ANJt9CkZ6wSxqttD3iSEOf2SwFAkT21D5RpDQqgYr+XCuzJLJkIWmNhiv1A9jr7Rxab1hwZmw7q5slMwyNRMp+LOJ5WvoSl3Jz1kmWHBOEg8xm3mGs4HoBuq2ikocb+ZvNaMe9yUIGl41nz9VGMeFXBhLM1iK5gtz9kNN0jQ6/IF14Uo1/dhNiwvpbjAb12BtxdQdU9tOaQ5BA6oirAhfCyNwHlvg1KazRmIK7ioVlzqwzsnWxQAoHwC0QAbRnYWyxpQDAwwbiIlF3bhID0s52X9ofRr6EakcLta97J+w4ifIttdLPBFwsd9uxyyanFmjdBnhcTJB+YS9TIyCfqPYvnYfgMiUokB6v2NA2T4s8F1T3QIeD9vE2Sat749P/VnFbEGNc1pLNcFeMYSVCV54eFDUbXWd9e7LeDeTR8DHdk9BCC8x8eN93Z0rpjvpj8sDuwe/cVgoMTvHtRSbacx31CU7CnxWPbszXMMwu/eYW+850mgj62g/hN9oE5tHltIqXj6ooou06HEiy6/BAkRK8xzLERXvYIhervyaCPraFfbvL6Gq0RWQHyhqLKZGhD8TVmDYTtuxTdZJOZR3XiNkj81jTAGRmYPBcj2GS1mdcS24ubY+ZR7cxaPHCoNH1R0X4ozkrwBPOXii9k78Xbqew3RDc5njVFramfokYot2i8uUqCz0rjX3TUyEO+zdA2R4+EG1asPXiO0J3d4szH9V9AOKEUgzN3b/xjQv04uvEsjz4aPCo6Q3M9ODECU0MGX7rcSmRw4reCnEq2EaCwYhSxM6Hm+4X5uvEhHHS7QW9BV/AdBIAqifYBh5oAAAAAAAAAArwiVFqrAtK0r6O4skcc9S/koijoGvDAAAAAAAzt15UwfooVVKiabLogn7QqmQT8qVCkumrYPogZpokcuciGy9+U1nJvplEHVpckHSD01mu6K00W813RU3jWzwdjcWux1LUFN2TAS/7zTeIqZGXd6sTdatzpxJF7pp2gjXSwK/7ehIm4m1Zzr01ErNFfD2E6A3oPYtZJHtvcZFEY0FFzi2MCqclTBu5HUZRZFCINx+RBjdcNUOzkDytAzMRInbfH4HV27vh2p2fLQa63zWfRsuVeRUm7ET7MusBE/ywzCI47v3w11MMqgBkIdNLZXZvDOdbw6+FB3xj75U9AVRe9fKjsTo4MfJvvBLNhYpVL/Ez8aEyXpctQdXeq/keQZT3jVGQcXbdlyuN9ddKdv0wduZAD3yheiee4ly8pd8ZDKXZZfdJQyP6wxaJw715hULdMdiflk/VScmpPLkN/UnlyEqOj0QzOUb2wCmwYE2YzfKinDQg3DqCTsqiAhXLTbfyTbbzwWLqxaRTX4xK6UfvawlXtIMQGsItAy1ioVaM5KH+f6Fyffy3sWhCZh1xY/ICSS8A5wSYi+X5hy94xE5as1sulTEdZ7/XVi7ZKHFJb022ucyGw/Dax0K9zsb6lHv756yPpCEzlNSXzjrQf6F5fUqJYYkmbqNsmBbCQ359P6a/RR95XbCqt94tIW+4I8BydJ4czuUFnig8dmR693gZZGsrNof77v5b/w0zfCSMWh9Ti0NIN0HLO82OdwNB2GbiHTYAOLasbd6PpZMIOiwhkENDg+5Jy/wy30WsZ7rJzx2juaKhZjBG33SIY7rRXH+dmDfPtyGW7vNkZGPYQzfzLeTLevGDpt71OZqV2spISNA65/lwvG3nga2qdIcVeFvkTfRO2ST0OKSBJgZ2unoV3gUgnybztyKzbzGaIaofE1yeQzo0MRgbaKb/f/dFRnW2IjatzYZFFYH6/wd5y7RLt7aNUyGiY7JB5cTNX3N13SLVaLxSeKO8HL7uBy1Fpflo+1c+zvaaAiDNY+g5dKGNpwO2JhqxB6/NO5+ewZ2YWGL+zs+EHbU/LtAxbtT+hR3UP9L3AKeNt4G3/OMpx0zqLUG8tthIIbvzmm+6C+CkCFVB8z3UTVTQbvQJKVhXZKVICsIKPMC35Lg66b6vS3qqgoCgHydOjyxre89OsRB8BCZRbRDEplhdVWcqssxiJmdRdlPmfG33s9blRs3m7mNRmGNoEpsKuw73t8PTuDMC/K4VGkbiwW1DXLqlpj5bOYJE5HMb5bCvGSazmIo2pNr7E6RYXW5sGP2NtYrGviboQL+kd5+es2DqVg9szz1lYUM0gcnZiEIQsmCX2Ni+v/AYcc1/f6ESVsVH3FkSPaqrlzL7vJQJN6VsOiWFDS1ipCmbmu7S9GdXMCMjW7at89ZWFDNIHJ2K9qSKWzNwvE+2+fuwk4Xb2SlzP1lSle5fmRQLlN9fFUM7HqEGmuruecO76CtXhJLXmIS6VaBjKy3ej/5LDgCJIqJzLfUiBsxUhdslUup3YwF1iVvM0dnYfmE6CIGeCaH50M6P87Q0V87xOqceJdJ1a1+aQpNh3LBkkLOis7c6/PZej+RW9i1IXLjyPyrL8/3d2D/rKkjSi4kaU1upD+vXqRwklAAAAAAAANFg81NvGJ3ihJ9zbN//CeEIcw4z4QAAAAAAAAAAAAAAAAAAAFnBL35Zm49No2MqjQl/s+tRtC8H16orLlkARunEPPFe7gi+UxRWK73FwPDGyFYGBqIE+GhlrqEea0qTB1CNSyNuwv85rd42zOGdW1xWWp57M4Gfb13A5LWKNNolGNgNrcT1cPzScsNGyHj7WM35mjvS8OakMALBr6FNdN6HE9/s1Q5XAnx9b++Vnet3+0v+8AUMQmed/qAT8H81Hkq1YUh+uP3ebnKf+PXPhC44Rbjuo7G4XCW1gbGK64NdMj4JpISXesVmls2DQ5E9yRMHoH2QEfLwyCUnYm7C3gKNEhDxGhxgIZzQJJaBoSvyie0OIJtB6k2tFetfgAhgQajx5mf5diMBIrkUl8cHqCBXz9ihAlrJW095oy9KJBCgXJAjhoEjuOAEHFyYiH+p4TaOxKijEv6ompB3Hxbz+gd3lbYhDlVw+EP9s93eKvRVOx8E8qQCJ24BFHva9roA/E6yPhwOg6EjJv3glRc1z3+WFrtPpZPd+M6B0pz1HszgZWrE7348OASkwm9TJafSwk2Rq66cg8vWpdk62rA9KahfMFDWloGsoIATl4KJpg4xkKMHYEUiT/K238UWVn9hlsWRaY23OvW1Yl3s2Np1A4DtReSZ+87mY2NrCFIJxgo7n6iYzg5+76YGkksE7XG8in6UmB8oNeeM8aTKzZ+xyaug2L0wQCuP6pv+hL4NBid2mdBx6o7/Ld0q1z5bhLL8MA9FZiQyoOy7Nzn9vLz58Av5HLTCftFgWTMBKStheWJs2ObMXR0xEq7++B1iYpbGsgKotGZZ4j55sa9d9t5CHMUpeyXPejywmqnSK6V9L2Bt8qQQB9nNWpHeoxlKukyHIkGOSsgdTog252aQJEIk2xZd+hCVwXT/NarKJtLo2IW3IclKr8ATKVHKhPZsyoFMMfDytowN4yKb7BhHUrQBlZ1x42mkcQsZvIP1Ll+bKz/GsrVekQowg5lC1AeQ9O2quuMG/em1AKwMjbjwLbeIkWzNhbXbemuwlmHLlW8rFDlfnyaUy85ZrcMb5sCo2a1aaTLkbNl/DWe6hXnvvE14U94J8P6l1vxJiPyLmlSzK9DA79WFRk3kc+JF3NDDSbPJUb6teId6M4sX4DfuH7tcMgWrLYucQmpOpEHHo0fkhFv28x1M6vRoIZCTIesZMCVoA3JdXTTKCI7G7gd+rCr2VHyTy35+GOW2HcdFF/Inkzym2wm2kYZJFgM0fyz3lWeyOA7WNyAVEDrhgif4T6HxMvjhpDWIVBVFUnslGy5gLchV4epHbJcEpIdrJ4Ck6wfgpqPcuwjBC1aCuFj8Go0gaquzJBGhdKroSvfU98/kTUL4kt+bwq494FtXqAOfDTfZgeCcYD+/uFT2POPYPOFVS5LLU35UlsdvdN7j4IrGWG0F1KaDK0ymMgVVW09xZ5ySgQjSuCKd4pAPz1pMgJCWtLlxq++IbeITgGdXrL/VrptRF4gciQegTqZLewXrZy0NWamxhyEk6ClpD3Flq91nUda1TjztG9LTpzIjrmFtAI+OdjaY3r9XFvjveKK+8zYKulnlHPnly2sf8TIPEVkrDyprnRznkX+1hgqWXdzjFZsXvHwbRK5EFHzRScpdXceNCDtgnlwkwZzMtbGNEAviJmNCIho+eSnP2BiabLDx5JXhTUb60QfoD/Lj2h2RS47lJPWtw/ZnGz8QxYm5dEw1VJYPnsOpN8HK5ZQZ6Gn1yz1NGe54a1JzLUzgz20RhciYNGBExhIY2+7uKjPrXIY6+ZwLA5XPNuYom9TDwQeaxyoHm9iGzTvnF3V8N+36TDoIuYOVlCeN5VYMS5IoVh3CkokgUlxLCtJVzwIkc0Txm6kh+O3Ue+BMJOWA3PYRB0ijfJEM+NTiUwZ0y3QzGSHun09HIdsvZ3lbtr3kIQRU67Oj2eOGwueAjYHWyModhv+lyzs9OXfsR7O+qdbxmKby1vZkhEQqVkPK08f6vpixsPofHC3FIaUu6ENiE100gdtHlig0E3imanegejD5sXS1ev1dYn64qphkJLMb6cP5M2+OMDud30I7FIUZdpyab0A3zt3EjV4OAGcop1AykKtyg0Rb2u3tsguVckXv88Vs39KlOwALvDZlZNBswEXKPIVBX0E80iVh3J04I95m7OKP2OnwqDjbNDYr7n5mjvkvdg1TQEysnvQZNt8bKtF84+ETxLI++XaXGaQoDJTKSnsnV138jAAAAAKYq6lPhE/mYrdGSat0LomVJYaTEcsncAbAafETyraTcaSrTo/RfCIYJskYOo4xtOFPdrjdQZ8DXwNOe+tQoPgSjbstam9P2XGfnNC4iv+zM+fShGcZzwHvYmSgY25aUqjWI88JlCgRDjzdcz87lHS34tGuE1oaiFFxmR1SlFk4L8Xh8m/6h5Dn9VO/39wqaB263kGtOQj01YPGdBQk+Tn4O9b4sRpjau1YaKdpglxX8a1SThbFTMqkg4N6XNrMHNYuQIv7tDwxMoe3hWFB5nExIeluDRW1/6LNeq+aW91zK3cFmLW6wJla6gnIHSGD00Oy7bZcULzCZcShUSBLRcqyG2vrnfxpSjLNdwyLIdo1bT5nUMPQE1QBJ6s74OF5QVYKTsqPyMEUqIx7/oVPMs0zeyA1RQtVlgot/fuieNuyQ8AaovP73OX95GP5pyehCRYkefFCwvndf4Qje6f+bZ/D9J64oA9CToabWr6qdTMdqmpOr92K+DEY5G5ZeGXD3M+9WH9K33uvYR2O78MgVtqSdk6THbw+3bT8dWTZOItHfcSZpOCmjpw1cLRobUyhM/KU34KchPQPqrdHTyILHbtrmNmldSHvnqgRsvw1kOMHyUdzULSeU2OXyf7NzeRJbShnHmRrfNkcZFrKB3vTtq2r9qqUUK5X4exq/aoF33gz47klLaoSOrr4elD9J64oAyfj10mcx4jIsFLzvkd701ncjOW81ljDEVZSGZE6Cjm5oqit2dYjfLMRaQnRgEUiipTIuEfLz7SqMXz1vUMPii9az5cAtG41NeDgeyinSkpnwvrTyR4dNn8LJB9btNUVB6rsIvOCmne9kqfGmedadOw9NnuBkDv2/3lqN45ZU3HMs/vtEgOmEWUsVJcSfX/B7X/SGfkBcLDCty3AupCY0u4ElfXUVbFvd/wKTZdTm14qCmrJkZOCTG4FRIJ8o+H3TxOcrQZvMZWM8J7hYeWeVcurtWKqxLerOxnLXGOlQZMmiV/VfTj8KcrBQK6P5Egi3whDVq9J5PXq4TE/dnhtwIw5pYW+mh3fzYo4RcKcfn28qoZZbumFJPg764+W5uPMy+E+4xqonLAf6gMUvfCSCyAT+XNv0HeZxJj0JQPvlULXi1LDeuGIV+xDsyWba/Zj4W6OxHwHnGPArSyrLkCKr75XQrSCh14l7vpcddJEGwM0VuyYrZUoj2DVVI7DfMJ2suAt2xflep+A5GBv5LbZM9SDlwY/2Zxnfk+ylj3YjCZF3/NehruQVQtAK4++jvEWu4XIa76zS5EUKr5+ghl7djECST0YEHxnQG2JHQ4ya1Ph4NiQqae8nEUtT6ToJFAQlWdhGcN8B/+OydXCzqwJVEIBTxqJsjm4FjaOzZL2PNN3rWWRi5eVA3wZQ+VrATB9pGd4dDelfsxpqgezIg5/OyaC5YPwQmQMdsyXn+kDp+r2acHEnMkuWCbSmXNjMGKtppVttp0DLiBBkVIQS/Dp3QqnBCbwN4LpslV43LS7OitJo1MJ9VYVBHBowFKgwl9pvz6Tlu+hQT5kR1WnEYj5aVZGZJcCXMuqiuUqxUHQ/GhUi9D4f1CWX7MexaOzUXmYLtcx4QsEkowAAAHCRf0aIZCdDmb6BzNBNH6WnNzhp9ZYF9oUhzAfg/AjpyVD9gJVyXUg73JC/wkH+7suEBULvu/eZoqnhaz+rSD7kuQ9FauOhbi4/uA/mvQ/q6ADeSJNlp6KBQKpoeuTcHnmG5PCae1SOtnEornPg9WfOjkd6Kty/U6bBvF/PNJa3uSd3D43vCRJSYvgK56Iq+WhTxnLZzq8HUo9rbJe7NaiD+Zi+JO0vYv3oWMBm6f1zLQS0ZUYwpAs0r9QxEQv82tNqFgBifuRFNUp2OrAkYGf2flDq/JmG+JfLHIfEgduVJG8xbOiCNOGql0LbJwN4u390Ib70jGyvWCqlLHiz6ZT8MbIKB8FV/r6I7JK1Wwq8TtM873vatLjBvXusdWsWuNqdBvYfQ+8MK2z1N974J/MSGY4qOjNCTiKW9/LUoh3MCLFVi/LDlIONHsZHaaG24TzZ6h8pD1nCzOAofUKqhTyjLj9hiGz/kPsJR5ooejpbV/je2+tYoF2t/TzeVhR1W4IpOHrjwN1e4pIPXJuXgsKswglajMH5l7hf1XcKR16cAnW1baCnjZo23Z6392yit6904NRxt6P9t4OwL8ZqXgVRj04cvBLcPoQ+P0xA9pQD+1e5w53jPug6nA424ogKBjN3EcPPlOzHJwrEjpIxYYsd7V3ualpAXlIYxn2u3jkJzDTlesFVKWPFnzJvV9+1ejxCnf7W/awed9IChD7VVmQfN5NXYY+p7CXmPzlZEG6Uh/0WdeW7lAphUGexOgIRDbDWgHFqaD94H6d196wDaPNfj5603ta3Z3lpLPm7Og1GfT7XLIOeH+b6Lrggrvgdq7gLdaEqLdHeROSVMvoomNYD0+ILt+lDzrwFgQgoagfy7ULPWvnNoTjM6G38/AGDe5hnz1K7egYKEuO9YFHQLkJ2ryHbJanDFDmXcuz2k7YgbxelxZzYTaCWYRTgrMFZ/PEH5d0hHpM2vkDg98bQwkI1sL+w/hP3yPWn9uDKAU0wo+Euj/QGm28VpvctEeThxz2VDbMVMliz+gdYs2KLyNAqR8ys8NgPemwBHkm5inCFekuh5Bp01Y9R2MlkV+97o4u+lSGKpbWUrClCzf7BdwM3waV2qksWCsqNU82d9aygW9ErV6WjilkEi74S0ZzhflSil5vcfrZOjZ7/eRYHT/hc3EI3JzBB0LzBZ3YdTF8aB3+EfFAjSbiEqE9Di0fKIYYwlqh6cfzmHxl+qWvaePuXsuMg413Yu7Ld3c9PzNgSVCilw6UvwcVWdS8VC1X8uCR8oJfiaQjaU2VnG6SFoRs0BfYdTF8azx0mPQUue0WFIh2z1i2NatHKF3CPoCh+GHVAoCFumkRY7KQ85uOQcQIk15i+m8L8rCOJlqA45pAp89FE3m4Dx9zL57uZ5bsC438W2ysIRbGvgT9n3rHVmvC+4sOk5efMUQmMf+O2FYXz0VLSKPVuohdAueIN6FNilg3FSbVNmmQVZSAqIYkmbqJcmB82EPqGqiw4ENbS3tH5CNg3x3T3aqYZijDOh42W3RTg9t02t+B3z8Jfbwj9yetn5Ibqm3PJMBIPZDuGLlLr0xuqcrSTQg4UFMAR+JqKw/gC2trKC8V5pse62MAfSCvz63Q6bT+0ZAafqqUHT4q4hMTnpMYR1sihxqUzyf1yOcrrR+xjyPuZlHP0DDvrZqiVJeKa8zyZrbCIcGYvq42Ix6eqZspcJFhzN3f3t6Hopf71n80tmEEFTS3ntbZtIWSfjNHPuVGE++vF4nmefZhHS7PRH/48tT2CGjZHzUnBGaQ9sz9lO1t0jFgoqxsiI03/E4NnBgWFYjwwIDfhUAZ63b/rJqWQLEJdqv2p46pUrjJv2ysfYkjtmr7WPkBKDt7sjUOUSVlQUYp8ywHTzwXgeThYYh4Fn8dmiAsZyy8liNpNiOvAQ5qXSaoSFPT9AAt8BZdmZgLg3KxRsVHrW0yhe4W4AftbScEfU1LntszgQGiahRY5BB4OmwaiVRLiMF7AGGqwnCO81AzwCBBOsZEwIbLHgYVhvEQyGvFhuW/Ycq0oD90wNGHl0gc8rA9Tyhto4/ub1+S+zYhM5DGc/gNcMCiirDgFI0mE8LZipojTV7o5ddnW4HoAWWDwbOqWalilfLWB/jjKhpFgRFmnFOzOTnYPphGpjC+/YPwr3ZbaoTeLIVJzHcs6wKPP5GmN/zEXLRIoLlFkOFhwbXUpSWawiuvsP7oa+19h2sYVFdbBEpgrrnUA2OzYILZwr+5SXaFY0ir0REKz26CaJ6+JIS/rDerj+SxcfGIcSiec2SxNv0n8YYDexnMqJ2FCSIUp9wFrVtZJNPkVgOLWhsyS2Ps3q/7ToFd4zoEYcxxllp5nzCtyhBKBZzvQ1ygo8UDIN7m64I4ktz7qcmGhyfgmFf7p0jPEMReJhLQC9hmHVZPWMauPUySm6S2LFEE3KrMJtfyiwGhrK153dxakSQmwUjBnhN+hUcMSe8YfgSdY7F62S8cmAjFLfnKS849A59hNgOWStjIGhFPXgnmfe4GUaSxHz0LiqzT5wJ+nNM7IWxnDq93es3FdqDgs5FhGhdWdttWBDxYEjCK9lvddkO3mLCcTvMcX71Xhsjk5VH/w4AH1UPfhR9KXoGlPD/IbQapZyXzhrl+f89r+9ubt9pGrxMOjayDleNXcB/erjaRd3iTa8GCNXnFxGg5WpUOx7W5jsIcno0Cn6qTpB5gE2us7690dg1BKrDStY7FqhercB7mgaO4Jrmu5S3X3kM8dqwnAUEWZvr7fqGr5FGSXsqgcoPL+M7vAmpMt6WwXYx1Ebdw55vPfPoti74qMnqE/seeVN3AzjwaxMvXCcntLBUluK4nqkV7RDJaCNBVOjYWrdoOiOBcfN9Nh+ypvmm6VMxqBxkcIozNzbdnzJd0ai8pD5COrMBV4h22u+ggHO4m1oaV8XQZFv7iC9vu5tLym4Y/smJZU8dh2my5DG5wC9c+11wAduOGWjSat/f5WhVLl7HOarMgagnIiqTDMzy86Jzz2P0p5apL1kohtx3/M4dXLi6ZwS8HNkPYgv3g2ZclmnBSO4+wl0JrCufz3Lr3H+v9RVpvcRWXsZ/ygEUyT2tz7DHuO20SIMGVAPUT8MWPA8R6bZ7+9YfHJXwYKchD1dvoAByHtd5NIupaYgPmNX8HjiIeTly+MeWP3m9BO1cZMc/2r54kWL1KEfd3lJ0m6g4PmEIUOi1Gl6eSqcJh/1O0HawxxFya+5sDGvkiuzXePzi+ex6o7GIYsmu5Siqg9uIXpQvR0RN/nOqK8oDMlV2gjsRkeJcqn4uyMuKWNs7m73VK2cH3batA7MgqDhtUYo1h3xqLtq2sqvp7DBDhEjaZHaVcKSOyqpdGHgR5WEVvT/fmF1Lk4/ULq9TMzJroDmTtReZXsVCXWEQpZzTEf9TTJRTZEfuvfEzSzkH3qlpwXyArV0elF0zFDlqk1vjhAz0nNYkKbNmZYF3S8TwyTYWqJ9DlWHrOkReF2rwUJVOd3fqNACfGeihc+eia+ySzq6GUn66IsJP1cV2oZtDaoxRrDvhGmP++a2F+Zpa7wNeX6jPGhl+RocF/TleX7iaJFjoJcwIUYhXbUN2onsvC11qG56pDF52WTL4xwyBtKaiDadodTSFiASl3pHFo/JG7T30/t9fYKvABY0s1x8aCK+kyEd/qj6M1XlFIn1suz6sNDBZFD7o7rjF6KWA+06wYRD8We2CWv+8QAWfoEmgNqnHhHcsFBDZRhvPEK/J7fkoL9BmndJS5iOy5h9T3K2T13iauGBZ19yhUAshJ5rEhfSxHBnJZrEt7+lrNRtgv+659Zn5TJPg/deijyy1UsmPLwAu6XTZaMzN8cKuI7zOEc4z/DGiGN8k/74Kn22Eu9kh1W7QHaqBXv1KVDdBqvtiyKZiQW/XI7dzaY8EGCxjijC+xsQJhLvtjBadsh4RSOSNeonlNQKR/HCriY3i9hi4C7YcysqEdD4iYErRefy5rE0LX/eK0mt89BAKZtuvYqeUZmhqYJBsQaJzjmy+cE94e7GsPiE5bWETFgrEyARvPyicsl02VaNYQJ5JKSg0Tyk4SRYr//q7WFV+HdfmSyOIl9nHPEESOCcMGoSkPe8qtU/SWuFMRRiXIKo9bAwgUBydCwX7V1giWyWuKdapoHyy9RKVyCaUeXQEHdayWMmAShjZYMCkfsUvcyvxciXDmDPRO4jzonnIYfu4Jq85JwVDgmY9h3gphGQHxGG30HnwHhVbmZZA1mnmx6LaYuFup4BpaYX3QMMepr57g+3+eNO+Hbbj+LcGj45J2nIPC52D7mVgnCx6c4vsx/UErRDIDFByp+53Vlq3jBr5mte9vX8wb3RoO0KM0hnKhOxW4XiIP0ZUYhtUppsL3/7bRs/cWmCywI4IuDmHBZmln8O3HqRlNrXt+R3oT1V/F34zDpEpE+qjmoAl0v7HBnqTNYW3b+lTRzNsPtzjRzWsACgjEtqU8e8ferTPdmX763cdBKDJkCzdgyaChhPZMnL5pPW5Sze+95G5na4JmrezCCQnnLCV+HJAT729ATTFdcaCsaJYROn1yFPATxwh7bPlsaYp9apAWqpetjeY68mY9vvUQ8+U8coHJ7dSvgDQ5avXQN936RR5Ps6lrihBIScEkwnfs1W8htaVfz1p2dqgW4GcmfVlHvFfYLTP5HNV1l9TIEKsjApMqGFODoge/B7IYMmM4ZR1Fgnnh1rUQPb9ov2encaAKxYm8laJklvbfFq+LcfRR2z6gkQ06zY7YyV04DKrJce9oNLwtHn25Gh/BwN43HesCjoFzkvQxSveI6xJQKskOHa5P9dx9Ax/Cx6BiQy+MUjLuS4YZ0BP/YhnvJiASMNGEugHcGht3989ig+uiBLvh3e1+j/ad63dhviDYvVhNxSkxfAVz0RVxfOYTAYzJxjNIwdPBpO6CQpRG7YqRjWqIXgT9b3vXEaNlaal914J8YFS/mwdna+X/BNHIpBiVX2/ixqMPfsgKnhWkVpl21jtGOI6Za7y7GooCGRKJ8ecrPwPtXAvYUBJGf6jb6xq09zCEJVU1lRsTsWGRiFYwu1vtv1rFjqMYZL5PZd3RE/XvAVR5fG2BreVtDztTxW+j/0vNDshMtp0JSISx43YJVPoPlfN0S5kCAsUsxDDJT9FYm9HZAyuZUsEHCfGf1vPNNqKn5hC/npBR2Ssm4xu6Sr7pNtTwx5tsr/TGFgErVBA/S1al2KCy3uiYelBmuxgUdAudqdDcfvqB02gNwkvIGnPTf6XZpBeGpOZRyAw3Y6NIn1CTklMhn5oB/5up1F5Y0D1dGVfaoffWy3bDBwNT0HXGmWuQOFH7jSgKmwlbnzctEdyQIWK3sV6ZpHhTOBVcBtOyU9RKr3cdE3PIg+JpDoQRuibjYr8lPm6aHFoUVXIaB7FhMiX4rMxIH0zG4dlc/U41B4v3qYyYtiMkU6+aUs9nQUhKyV5Wzgv/zumUt/cux12ePDu5QgRysUUVsgJqB4LlsDbIt4sf3WPlvUA8Dqdds6b/yx/cP0ImTfbDrJSEDwzPCloen2JmhY5dVtDNuIU4hp4tbCkg6dUjZIAzjInEG9j9kI1R8ZTuWJe7e5lYMKBmQqO7nBaQqW5kcVHPPqqKb4Gd7hrQSIMzSQFY4vgcfzGLW6CEcIio66ioTDKAiAxf+A0vDMq2ZKZo7ALFql1k/uOAmbPLPbMN1Te6HYjSJFA6sY5LXU5112FywlGYGzWoi6K0LgQ+YNC+3IIYme0YmBFxO+02g2zXqhxwrFY3wREwaJX6/1ymuYL2+geDs9NiLIqWa7+LiFj6k7C94rhUjU2m0m0GWNsI0b3TnRkpjDR7S7EQBmFGEhL2DYtczTcrIZb9Gm1YEgbCs8FOrwa0LKbKGx0mDDPpK6fUYC61F22G+MlfL5Cn+SwpM2wxezzAWXE96IV5a1Dj6xpo6I7liEVja0IQ8+KDrtuZIaSKiLGtC8KihrGlAKk7SxNtO2lyQ2RTWBZm8rtQZd95jqASwwzvXlIVrx5abuyyneSaLYrfMmQ/MM8Qu5W72CvbkGgyXeofn5n26+qXgvCpVojWXwpYGaUjW9m2TUnxem33O5NKtTK3y/Ffswqjbtqnv5A1ZUBTV6BSFisJr/EERXXsaz7l8rIcDG8LoVY4TjQX+986dOhP/VL1/2doYgXcV6qFQ56eCETp6NlVVXim4mIm+jCTmIk/R5RE5U8Knuyi8cPcvwBvC8F8204Tf211lsgGaZhgNbmKjTRHhol5a4ke8Z6og/KPP/0bI1ichdE/23O+tRKj6EDZlSrfcQtiC/khmKzT9i7rA66te+ycerl7uYE/LIHYqbvgkknyg7d6exhSJXUTQWrmWrhv+jB1G1+aEvhBotorjS03uijfBZhz2Jucil/D0JPvUQBjSZP9mmm96lRrX5twHJ8avgInEy8R5awTButoGOlCLpeeePsNMU7g4IswsG9tNqd9Hsm8Byu0/SzPvtYM4Pr5X9m1PRuV3M7PLlposPe2tiIYmdClXyS7F3WB12eSfw/DQna0nH7XR3uIUe8jUxHiiG1WEANOLBNaLMbbirK0LDr4k+LCExLFcFxJcX3jsTTbpDhTPLRHU52hcKkusLrGqeYDYlaEhqdjoLki8f6b+wnmsopcBL99yz1p9NtxGswPdK558GvHrGHAwA6tnrceB8CaTLJP8PtxtSzBFcH8Zd+VtWnZSXklW0SERRk0KnHSgFTbmdC8Dhi/o7TnWpiaOyTxKzpkNFagBb9B32y2Mo+EIGnpMJ7ihnDObKAPnTBdXgVltUp8aN5h3x23DyC2s1S723xYOUA3aPe1K/ZNN41INPrKZkcsYFQda5aoJNoneMApOdCapNDYcRfpEw/Bd0IUw3BYIpb+a7BzttSUB/jf0eJtmYgOiNaGqnWbsUi0tB4vKlBbm8oisXtBQb7wKHzmic1DCD1lMyPQMXNB4Sb/La8q+q8Q7Z49ELTuuJzMcqy+08Zoee4nVegwVo+T5nCzVLKYNyHz5AQqdbEdGTvXlx2pfqlhzFSNxrcoWHmDKJHbSwj/Sc6XMvqEMy+vAj7QAFoFUEubrxIRyRiOBXVKXrmdp8yJoNdiBmOP9gJtXNCZu8zxhWZWznuJFX+Rfj71uUNys78GwcusSLn6RXNDeCWd73CuoMAyVWpxGPN3kfPrq7QnOCXKYVlyRjbM8Yx2h6yWhYgKv8Ey1f8Mx+WI0SovTQPrVX6t1p4bjbo1Yxy/TILUGliwQ0JN1tnkGzVvFtSc1ojJ1H/9mmhVW8Fkei0A/WJdixWQ5nnHWSjjnSDzWo+D9dNlRnyfNRlMXuf/d3NuZpwAz0NIhx8mtOatltAPrZT9YzDia76l4y3NcS6jDaEf5X1Mw72eIoBncHpowsiweL9sLNXuAYLMdJ28naCXawxZmndG4NhuR/ox28ZkHhJ81fgly3Z9Dyd/GXnyWl3JYuj16AMtvP2N+wKuLAk3+06c50PVP6GDsT7xLLxebDk1t/UCpt+SwewRpYCxVklhVeJXcAzRS9e++wUOpm8uEkKcPf963e2Px/iHQ/ZW9zu7XZE0WVIMfvP/AaR0wAAAEVP6jCYULtpwIF4/+FRrj//Pc4jODY+CAAAACNRcAxGYRcuXMLP4oFRlzeY1DcAWkRatElK2KQebfQpNxmAEsRWmoTJXTuQrZtV6H67al5E5LQhibzmQKCVQIph2SM8rxWjXanNAiE9GMJsZv9hCUYXMWiVmUGIgOgXN/gkZ0/9xze5XYj9zCVT8m5S/n193U+/PtACqVKyUP5c8hJfLGi3koX1jL0WKzmOmgxuxOfqFZMqyBtFPH9ldIr9MdULXKN2NfaN1xOJewjtwSxjTKdGQh7NAoAN8MrGU6tB8eBx/wM3FhoONFyXS0g38Mrn87g6vF5PgF7g+DKhZPJz81+EkWagIMHY/D8xc9X/PZaxIuUWSxQurh/aHq909tuNd1xGcgu+JO2+bqfVk3LXnoHCkkMjs9V/gNnAgCJkPYw7dUpG82wROZpu67IysEg+GkUcByob/AQ1NdGuQHbgO2pn0b71HtHxXoqpEYtkLLAazSqB0e7R/LlRjW/f4VqkOqE5BGGHhLjka5wplG90WJpZfxGhlRiU+PJqIBEFTyCA5rplzd1bKSm5ijUL0Mx5UoL1/7i3I28mon31785Abrz1wdJoZeE3GiNOP/GhLor2XNFGBFmdjLEccR1oQ1RSAO1xJgXgQdES2XcA39BYs3cVppw6h4A5fG+5gH8kGcPiWvWMqH3UqiFckCo2Rl1I4ReZcDK7p5UyOiW5R6eQwrgXr4QdUcwCNXhSyT0UjpA4BdtkOWWIa6Pwne9BJMke6/e6Djd21AfOn0LUe0EAtiACWcmzYkukw3UgAAEWYtm0JNi5xDs/9T64bf+aV520PUl0cIXY416kndvMrS2KfCRedIc+d65eg2zANpu5O6hgujdofm5j7C6aC5vVlhRoRS4hF0tg4jDCqSlRna05qK6VVqbMGEp0NP6DopX8GQF7cL96R0Ohn5eYi7w8ZhD97ShXgPLoT7SglpqrWwNByNO/QUR8kyPiAbR72LjoZNcxxPjOMVCscoeRIeSPh+UmViUEMaYipGD3DluanZCEMPKsX2Sq60Ig9g25jEu2V+zXgYrrmcx2VZtraULVIlfeAsLo6P6LzckwGKEX45YIsAgPDIdOrtCtZ5shggDYFdipmQ0Vm/xwbC2VSfzQEhRcSFreMvYwNc1OW38bpEXKpBOuqHiTdX+VgBqhq1hNdAzRKaQfyZEGTSxl9zEu/mV+ijEDYev6e5kVoqqPRvnH9X1bJOZzjTlLz3W1ev9x0v8Njn3ycVHWFjj3/+jzvyN0Mbkx5LctmiT6Za1f4yKxYzX11lq7bkHL9LGjOMVCsbf2/j5myDL4hh6f84PhlXEeaT1fgzfLkUNlnN5f22lPR3HkLsm6+P8bHLH1Kly9WyEDsm9DXx+X1blEiX0kuglGAgpe6SSE2EVmUAw0gSEDsm9DXxtzJ5yQPWS4Ah3rntt9Nf8YgNpcwqh4Yt+kWYF/tf9otv0uZTmFOD61kTxcNawBP1xiDbmRTIEbED7wz0zfbrbeCQFYHzLXhl2zDutL0fD5HTKwIYHZZ40qcwmiJgxqulIS4jUNpXcL8dmcSM8Xzq72P/akLqCfEM6Jg/BJTXwYdt5tgz9E8nL3144srISm//OAAEgYJQZpS5RZL4zRbE5mmo7/FND69ntJZyVi27yS5T9mY2yHKQrcZ1jrDeMxtXl4voJRzyb8WItQcDO2UoZlLb/KpOATQYvAwiVAWoo+oSxKS6YuyYZS0UJc1g4FYM9jclKVkarG25LuSep7c6yazV9XmtuI9DGjBWyOXQcqE6nTf90GChx2RbVIS3d/8jzZI2pdRO1NhxRO+VeBaafMpcXmltJ61z/DNc+O4iFJPuLCJFecixLmDQ+MyZ0ZGVJ9qsZtfOCpuEcZO2zG6k9D2eSwKy8b8QCYLJdTWR8Q1NPq9me1Cavlvg4jjbgwDzERdnoCJSmRB0bSl4UJLbSK4Qm55O1R6gzXMujX5xPxn43DsBKViHZ6GqwBEqEiMdEyy9wyjFW9cAdmNtLrQhIkiJ2RFP5S5tEwmsL0EjCCWrqqbtyWcbqkw7kkTSjH+78Sjbm8F24fx6vKNJmbDWa8npnA4owr3g/Jw9yedqHqaZjAlHlNE49WkJlwxuZY3kD7PERGdRye4b+kDu1LXh+Sq3lp9b2JhvR373kPVuBeC/BIMEldZaM558CNtbOCNWI1TkZCXaXrHdnf/BOVGCENgDfsksFNNKT4d83C+x5J3rcNz7P5OSUM2cKWNhJUaJArh6tADYEokn7qO48+o3YJq2jja5JS+zIxrIAASaRTSPezsSSkrADhI3DB3WTZkNYbbI1rSgPenKVILVNGmik9+DEf3f2+l9WwRB211tmGe1M6o8/4CS5QC+jpaPsDje4IVEg6NFEmfaFBd0Nh9ZhJBbc01gd4SiSkWZuJJBUhkDLTQQqJB0aKAfOmDLizN0vxY6g3biX257o7t2uIi8UsCd8h4b+Rn+uIi7cXIEbHTdBIbeBDiK56tjygWyeWV9tE2QX8rTVD8lUaVIAAZN4skV3ko1pt2HYdznll75hSmnpPMIfujyhtVNUsqGnMy1U0j3e3RLQq3G44DM+vzx76vK/n7quC4PBbRqwHhb+k5FUDThHaMQUbG7xZIc2sCAIcjjlyOZRyhBywECIY9VUfUWEj9tyicXVyKFgTvqOMvLo7DXqWm8pv1grWnYEKHAB7wAgFjmXabBu8eUjLPW93H8lNKMRGkA8zhR6PfCDR4Fcsj5WQmbLcqFaorkQbYOlncCIfognR9u/qxctoepLp+IfxO1yJN1UV3IbeRrOur7uFs0Lb0dXpIKsxFmA2bSMQdktVph71w8m62MeOH5hCl5HBkkosfg1EKr+vkCL9qakV6/2fzjdcwE4W6MSyoMrelI9/4Zxde1Gq2N4gJFZ0KlREIS8oNys6sJi40/8wmi97WRasBlTFXTf70OneNrxKZnSNDHvx5RuLt1xPgIjfYsVBqiBk4FEGKPMf5er0njlJlNr3hoauw7UO/sqCOHvSV/+B+1xrYLK8i6jg71S25uLzOw6sI/wINJJjqqrkCIECTSEJKa87EUuP3IIxtDyaOmKUoqNC5T1GzdlWM5nZLVL7Jg28+XVp0MzxSewSzI8UMNyAzczkK+wsCmr7zUMiHJcmfpfKvNTMSfZ1/sJ2VVTc2WbdcAJZI1rwceALGW9W1j0CUz0pgFRDfY62v6xdMm45iPXsUDkwvIvoiw2lJA3jB4dZnJUTsynYbSSzvgnXWnoD4yGtQbsCWHA58HPI4NZIV4L1pQfjjvKDfSuAdVRTfdh2yE+4p1wrVZRhY+lolP8Vgb/KeZQxdzVS0bpgrkhKRIo2apKah2aQd4VvWgQFpAEZblrPTsFpY6vEKDbkry21BhsBnwGOg3HjMpyswN9cWd4qB5R6RuYuGset/rLEo9f7J+knSmCKIJLoPKaaQ9V3SkLxIiD+ES2pIrLiOyPpKdO3iAOn2BRCkF3I+o/MqZ3so+cuK4DD9Q71yUW9DR1LEv9Drore4AFcGW+EOwysLGOK8ueWZq1eULNR6V42XO0i07tlZ541CEqhx+ANhlANv/JFHhHoyS/LSsTExuC7Mt9UtgdLlIjpOTwtCOi8NDAjpXZBFPUxqxmsrkamla2G6R3S9L+nz3uFFh+dToMVawr2gVBubxjiBRyEgoC+gLThVzj9pRRP0EpX2slg5CCa2tZLPzhQffk0Zz1SyiII+scHfaWh/2ktKWlAzRFmWYeFDwNGE1D4idbggoZhhKn4nDibgz6Qiia/C8U5yKa2kIJylLAYpWr3UZ3KAE8FqXQiZNAdG3W16StiHbsee/MNKJaqHXszmKjg4cSKZFdSuMDKcmHkjRSnD0mhT92TJDezDsM8BJ/MegfXyqv00EeNwWU+1hArTC1R5Tid/0N23Klw3uIhfl0lXHRcBh6JQLUscGlPi/KWg+ohwtf8DBk1ptq2iWfXjFTiJuw9pTaNj9QTgpBOKOnU2mZqDBGHr7YQ2OzoWa703xmjNBDJxyZ5yUGbjCyX0u61F32fmC9XBb8v9VAPrCDKPtnR2u5L8H8OtOiABIoN1MV3w16sZzQhtTPMqCfd/O6ik4hPiX/ikygYqnw2w+iCElMlJP9gUqGEjG025HHE01QwaaTDr0RHoGYNiamKa48kmZp3w7PDtyIFfPUJhEiZq8jviU/6iee5CI7MrUeVxCCEBAe5u3lM+P06ssO8vUCJgRQIlMdv5WX8aK/YnrblrpdFwyJMkI1FDFS6CYUKXRFMSmSApXCiZ3/aD1V5EY6KR0UITJPpHYee5QepUkJh4OWxkwb9fpbfAT9C8gBJe4ddVpRYhnx5l6yCWNJbZRtwR06t/7lynTrNKJ6EdFfxM4Mrm8KpGg3jtsq8nZmj+ysgpsG8nmqAWYMCubDXZlZlNOdYlJf5vC+Ui5Y61uynupROqdeNVvqPjQUZQ1X9k76qLVUnYxs/JyhL2T/fSO+BEUrpapIBN5gn6IuQ17wUx4VB8PtLvbFXBgyGjrS0igD26VyH+DwojWYWu0a4JE1qamGmP+7RxxCvrYgaX8OEs/iTWhHLNBEQ8it68Sw8UvmqsDg9PLzRBr4ERve/JXTBYgdjYYPOCwmESbMsce8PIrevEsyzYXFZedsYtbtjmZXoRtilp9wS3IsupQ7afQLVfWO9ZUsvyXt49TqBfx9XgjutynhPTkCo7KWud5GptOgPVaL739/yyfHXQ+ef7lOiorztY/IJNhI4n4v+ja4+5vxLbI/QSpYPhHb6zGXaXXjMQNZs0x3Qp8yhfI7qVpUMNA/fmCiABTak4CMNAol4wzti8MKP6UISXlzNETgfs5I7lOkQ6QWOCs9fVcK2et8enjLbY038x4mPQjCupLkAOZGMHzLb4In62heVwmMP2kjieYTa63KXgmGHVXbHiBBe8JdhCpn9eiT1jfrWhOh7SuWXGeTZiGinIIQHzQdaKDcjTVG5ieiCDZVPjk1L5UvPTTksT/tVVL0TmW4zbFkMhErZ7UUYwg4lgKgR9hZWvHSzFcnsK2ofSMFHj1D0wA3GpbQsr4vx9N63xETsiYTpRDeBDhL7jxCatAcwjfPU/e/uwwKjngsMJsiJyZH59enaCbnoZnaEwe4uqdHHYZXY6QKsB9J75XagKP88CxGQCPP3HIt1LpoAJoFzE1ts4e53q8iLv+/r/J66rND4pZwbHBE5NQLTxNwVq4QTfCtqkPNTMdhqoT4ctJWaqEN5AnsA8dhANjJHul80W6XO8OmaPvmDD5wvXaiVCoD/qRcnqLBCMwJ6rZeZftCvWXYcJzfMO9q8OGzMxr5mf5bGCi3Lh75p/JYG6mHKGU42jKFpze8L/WCu+NySPHQhiK6ngdZs25bSzq/XPfkW7omAVuRM/XFyKzgeinRWdx7Rs23I3ZYtQ9EGnKw8u4Jnc3RJEe41VwHrOE1EGdon5MeinRWfcR46zSKeVnNiwYF9Fn5/Cu1rH6xU7Rs2LqVtvIn/QcQhMD+yiKIlvhc0YnI8TxQDOFlYHRAXyIBM8HD7jLHppbR4NOsWwpe6IhM0WY1i7r0k7YtdUHsbZjO1RWbkY6v5qflu+g48Fb/o40hOKDBU+kANVs/9yt3RARIGLbeYQHwJTx+taQbVRKl1XfIjXwhiyWqFr1frndScRLP+oQ68WJ/NWOQrBEJJ3qqWrMDSfVlFawHDkXbIe2jI8uxGHMkCQKz7B8bO5YVm+RKsjymFZ9+qyTuJX15XRp3HAScegYFSvNHFNpiMGAsrLKt/Ens43sHe3h4rQi1yHZRo48dNU57J19ruoq7sMxBtzAOYfAzTOmWQG7neZrL5MRUGfShi+7bHseF8TUh3QG8HpkgdAetm3/Y5GWKLK36lbPO2wqYdT858w0ppryVug7JoTW1eUKkWEkbc/nE9cnOp6OIwgbjTpt9lU7utuCWiow4+t3comfnvfkorJ6DwGpikRQndzuWwMsv4MGM1fct9912jikoPYX/VB+vesBRKBnRwkNmrqHpeU9KfV+3zpQEcSD6o2hXmTcWl7rdIEyxSwtcy0Ij7wev9sDvG1p3Gii/BYYr0TQhKR19zLEDE6Y6Tf6MIyapPUwExwJbPuo5gV14rPVvNqReqPvVCpmULHJNOgasDkogMAoGvGY/VvrUydzK1HTE5KSjbF3hNQSfdP369slqCZPCpJJ+Gr7D3/RsiC1gcgU5AMIOocaE69q8wBwe3YAAAAzQWiukWj+s0iDgonlgCAtmFPAhbECNOATh9En9UG1hocgCjBSBHBVmt0+0junU3MmeIkEZ/0m5wuIdmWemAukoYL7EClXQcMU+ksgFVKAAGtTtNPeMSWIujj9XBwJB7+PwlXFEjBek6TUts5yDKyVS+tCRtJUSHipaEl4bQFf0Dc7bbuOiJdmpPo7oCimSa4aMd4auseLJ7LkEkdTMepw9ajBn6oXu3jR4Clwx1qWokghkJ0BHcD2PR0zuq0IWyUorPpxGEFHYYBetkkZ6dsRbZTnKwc/w8uCUuP/GY2YyjBgxwh4jf8nNnf03+Xii98Zsll8cL2OUGGLFuCt+m4BwSCaslTzc9xOuBgrSEBMenCTfnN/ySsK7KIhK2EFya7mErNgwZrhmyRrIMXq01ATnBjxWEEYpVfF3n2AavNomwyaQOqV96WLOlvUtKgbS0qR5ZPFLy/1o3cn2ABnX5FtJRPhf0e8qRwxlsAcKioq37aIBeMhrDQfsa0V+1tLKICrczoSTyx7IHOEbfG0DjkSjeBXfEnFI+ARs63RcVg4fFRy/mYTs3J5RvnJk76E6Nd4XA72mEKa+qmh+9oUuZdNNuzbxkNYaF+IGEoSnSB3J7eFX+IAqNVacFvP17ulRBIU9bBEpfaem7aCRYVVpWdRWp23Z01tRTa0uSHNIIbhoOriUzvf4t7Dwk/6hNUQunvWfanD03MjW/TcBNGj8qX/sZ2cP6K+ZzAVdD9BhwpqdSfy5sYEtvY6hx48A+aaCWzWt6V9CmEnV2MPvkzL5+awaPvN31RQEwwyBIEDVqyzEJjeVJFf1bvI6ENu3I/SvAsqQnhmj6Eeibe0G7bJRDlEWxS3Ho7bCmxi7aLRIFpSWN5HALk9XnowfCi80darI2yjdT53dqIaQrXNTB0fw6r/kaPLMaWxGjvmhFNsxMtZruNB18eTx18kG/TfpjDCHY1RIPmFO+yqJ437ATt7FhC5iUz6wzRyMr/JSQAWAIoHiJFHhQrFcy/UsVgXsZlXgsuYczhvoum8eNneUsX6POiMfcc/LNEwKcqam0eZjZ3glId79F10Czd4fjTSd6nKRGCZgCcySuvpH1wPqO9/MZ7RLUMvJNJLzRhek2WGCJjinS/KHId7046kLFDkd/Fo27SF0pn4PHJojIYIWuTOedsnbk46lPXPMnn4R4xfhEYCVl6D4nOCzSybrCw65NgQUEEgyhhmA4HjPfI5cuVnLIAvhXI09ZRgSp0BhB3AUgh5imiCmnjm9torXBHbPFso0ZHq5RIZ2qA687vrUv3kOIyRJJnPF2SUsHLmBS4kECNbVQRmRweUKY3YQAAAAADuH7cVcIstJFX3POlCdKE6UJ0oTpQnShOlCdKEjgAAAAAjp/532fthpDCfvmKXS2WpI396oTZ4BlDhJQJscFECWYASIbZ4v6JNgH8ivtiwzIpUSWhh92TJ+kzBSlA5h8T2LERR3HRwvM/FTeAPBtZmen35Jk7LXF19pKwvTC1lyJoz3AZ5YAzw93hoKrwayNUrHnOJay9f2GF8pQhd0Qfz3vBcH7WNUf3l6FMQ2VHPcADXOjFQi5kb2uzf8iYaNRVd+xxJOMlP9V0yiojrZphtdsD7xuQIriIimVlx4p83i8e/0OONe2pzaY5pesjJzdMoLSITZy4LwGLHdeUUgIXi5RuvmX9z290H5RzPjmbjlWV/aUntyA0TAzqJVkcUQzr72w/EWGREPzRYIeS7+NAuWedwE4LD3v1ZUowBPmOzvYCtAfUMU5py3tEXbH02VXwRVogUE4KFVG2m9HDFB5QKapTiJBxq1JwqL0nKkTdzmrI70J1uEqRwlod/x4NM1y/MFXRYaJAbKXMO7BLQRMUndLh0ELYhXh97+fPQAqAwwf+AXPaNVt7uA7Sdg5HkM1icNDnVNE9G7tIcX3wsVejaDjGqv9hEtK7X1sZqIOThdsFJvLZiktabB+cYYcmlOv50nemX+tmZ5R6pfK+3QvihyL+uhKZrD8qYM7/1sfVbIsXvX6jpamPuiyN0wSq8YvGamKMrfZIgNSERicG3tU2/g/PpHbN5SDM+rOC6BRiFYe1HNF1qi0uCwjjXQFn1ryRYqGwNnqmwHITi3GbEEO0v5+oibaPhw4KKYv29EYImvZ/HpGEJaFpDRXHlC2VhN/9xYtwrjOSNnCLS6lQJnSnh6FoXbuetpoy6yqkkC/KS/JScfjL4Dtx2M807rIbBi/vWzZV/9px9bIjerpZnwDUAlJX1PRxKsZ4CNh6iZXNuLRbHfDiJ6GW0AsEG6pvya2XpPNUdrwCZIaqvqI9p7wRnpXTCW+AQjE0Yc2j5XrBrFfrurrw+G0pmhKbYyTgOhqa5oz2PnMWkTdZDO5nVBw165Jje8HxRlGhUue8DWYeZzoeDiygthKZXQzS2MrzC0Zd8ASDLWM8gZKiM5eQ6RndOOdQ656DBtGurw00mnWxhWMGVMUYvsnzYqGJARSq8EhlvGVmqzoykToqKSdEBgKAXpVVPJHb8KFIWe4MlBPBq1VzWl18Ja5mFokxcd2ye7mLCYqdPoya7AmR7Zncrcbuzq6hUiw3JFkl4arbMcOd41QNxtNp6bTvU4fg/A4+/WkU9kBRzLJazXHSP03MyS8eMW/P60IWUw0qT4Zrm00as7bu27ieOBiuEQoJMrn0Z1XmHhP+Rija6uKqbrwxqfpKmrZ4aja7Zgz2yTX7YEa/4MS0yMud3g5TR/wZL4NLCraNgEVSGG31UFfbcEkKmcXVLVYyYuDCoKgLv8YdrvX0rnxVxCy+7LtZSeZy58BAYr6zvrijEvuFv6uK1nqjEMwykSW0oChXg15KG4bkYZWUiuJrfxmYt1GPoUy5+iComyCkhogfktPC5TF21nwQZRIG1ZOkYa18VOh8fBW8679Kr0tpN4vGmUhGWa0Z1HqY/Ycl4LafTFLFjCDAF1mOaiIoIWQYW62KNdqsx5xvoMKFKVWaO/R1/vDBK9AGXgqOUwx6EMx4Jf4dX/0AbYIz1h1QCjkJZJyZHlK/iCq3m7cHCknUITr8LkAZeVrqz9mJrkQcTg4P2TxWCTUAQF8zQRLhhY+E64bbz6V2bbAeBH/t5MTVtj1opVz/o9UTmqmAFt9hNOqVafQ/uY5Ms+tB1XOSCGwZDTB67qwIEhfGswtVrGvRpn3WZcVU5gSsVY0kj/cKw5ItB/1/3e5QdED9iVxbf+YDYVVKQ7wevLLHbnXgpeyr99LCCQ3R8BSC4BhBYlkO8IOtM5Y3NN7LVgte9/RY7GwwQPRkKOGQzeW+kSErlSjg/Mu9/gZ9zVCmeGHqmMVgrVIlKP1eUwTGjbBc3pUFCIayY6XTLsrIXNXWwYoHHBNpWIx7wR68h9MrwBOx++GPAfGDiX/psMzHLMKFvhcU3xa6nL+6aqFn2S4rAi+JcicaUfVX7ai46XHXe/ZXPN+qBIeob1ZOJyab8DVa05yCO+Z0kTqPmLkelEu1epPO3Uu49j5Bfp/AsjAWrphSQxI5+ZYhprlEmnFVz1TyGlBtI10lmRkd7DGfnLvfKeHTEVvgY4oO+lw1QDpAle6V7AvkIbovSjNDrEdKPpKxOgAJuUSUkrJoopYA/L1M7sSAyVA2ZvSaTe5g5kUqTGtjIrEVEyKhbxBBpAzol3ccO9KEbTSvH89x8/PTW6qkPe9rGxIuGVUOIKK6CX5cRUzH5LrrNqkhQPjWaJ4vKuuhWsPjoiR4Y6u3LJP8u01NvGf1Xxy60cD0q+CC6663QyGd9z0oIKvwvnhLgfpBh5RJSo+5FbceQgXxrXxIDJT6aMr3n0s5qSS8fn1XXBu62oqqp3CxGnGK7CwZ+cvQiCJ2Amg1LoAX74//SeHAfaenmF+N+2EUc7I1DXWt7XTnegPB/jPAVVZx6Na2t78FFCLVHasYclS8CHs2JmDXOW21UMImjChj8/9O2T4YvkKTl8tGyPW+nFu1tSRcjSWQm+SfbRUlcoiOyxEQGx6OqgDkMnC8OLaaHoUwsE0ooCjc/WJDU7OHqijK1R5/8wrMxFrD3oXSjM5Cy7/t8cUe7zOXGg2RTiMcxOAW48DHT1yrjdC42pfaK1zFGIGXbiBbuKPmAs03YtwXfBeanqu4F7R4hbzOz3/sgOznOfUjTYAuydO2BH3VE08BR+ACu7A5wfO27qdXdM6Nxk75t8fvrZ3n81cPYTutrTnSR2wwchHy+xdVieAVoQ7NZMKEy/pJbCkhWt3bTfwPbGNrBbrwvXtCOy4QTvNRMeM26n28m9gtWuI2DM4fVY+TDShIbzE+5xyCyn5M79xjHDGA11b+U+XS6pGCj3T1Ixr6oWLtSRcjK5uwNfs79uSJAukJX+lTUxJa5uy39gr9rbvQwS1q73k83E2dGPPrSZcBq/HnF8toBepFEpEH32YJk72hnhiyO7dNQsWjgfztTCFw5vsnWipcjXngY9v67jsec0tnu7BDQCAyoQSlGI62E0xLLRWVpE3OG1CMEGmNfZ7V1hlLrEVIcSzRY9xhUOTCcEsnrXiF4XhoY+aCoAJ4FtHHX/owCSsDuBlIZ93pY5Zm5GrC2t6KFfh4FWGWsk02Fa8DlYk0YcWU3t6oNSr8W7yvhXtv7o8ZyEVB8eiR6iQpJgeSvwtfjD5tbyuRmKA10b/H9YHQQgrRkeVxxJtQ5icAbROrIHUw1i1H38jGmml3ILJu8JE1QlibWlgSc+VsAwoCmMKhkI76yPW99lhQSoL8ibUV0Sgyl2MVqe3kllAu6+3OglaMC0Y+p6PyAMDEREroo528IvLWscHbZtMPId44iQb2TVphBUxAvXC6BNpwt1aGQ9fIoTz7wOzzRQ1wcMXStMSWY28cN00zZjJYB9eyAGDpijLQea0OLAj+u8l0ChP4dsKX5Z/W7wYEf17ozJWrhRDb/lNGrf8RLCZFYBCrO2tO4DGHuPrCvx+ZNdQPP3/ksOW9nJx+zGbM+2W4OtZpmHHdftYWV0OrYkDPmlp5kN5j5TfLs2NN1NhoQoYssZUv+73dTKbxnBQj8QDhXN4MsKlmXoK7B3E8hSmB3tYycfyBURuvOS6BMIG/AM7WM8/N2dnJWkPTYaugGl/PRNd0qc5bPbIT4DrXXVZt8Yrfq4tOpNyNwNOpTAQZBkuJaBAGMwowOsIJYm3OuAKtqoxrTprgZrCSaC8CukfPYk4JGKCW5R+qE1G1SMys9yPsuFOZTGYhkXHfZoPNl2G30JNH0aJBrLKgwRzJJuHpy0YXGBVz5Xvn3nEVa1GwUA1J3JCReZoDj1JEZqHgKGo3GJPywJJwhg6Y6C8u5/vESIsugg9Bceu2mPBs1u3D+2H9iPFiHRYnpFf3caocn/NKyVsIYmVg085tTNzLS1tiaa6HDQHl98LG56HnDcb/vgDKC0iFE1K4YJGEUwDR1nWbITnBGLCIBnZSjPSxlOhaw6RCiUKqqLD2xYiCKdPrw8o5ipjp5/lvtY7s9yiz5sAROxNjCGmMCcu4hWAbMZH2kpItaq2mPgtKPE8UrS3f22l9Mj48eWGVVToX4S//X41rVq7kFu6ve78D2MGlhUtziedAY8m0kHnMc9cwnoTxUjzLjFMlY7C5PI98Ss8WXiocsxb/s6WSfVvrfwH7xEib34lrsx8fTu+LsvKrK6dOHP17GGbvs+xb+c0SqgBgVctpF5bG0YhiQRSqn8t5JFjbvzmIHjbTRLtXCMbgaQvh97Z16usqzgps1JmxLTqZGQXR4FooIAjW9/CYsgYDnwpdyoDwLLDXMje12czqoseQKWGthcg4lmkUc1Lh1ac+k+j9MNukG1fHPddt39OaasFqEPmvPC6rEWXfdBR7j+Ifz8LU6RJa+39HkCqI4I9cUQc0UEu+7jd2wH1IEAZN8kuwiSoyezs+cfZrMdYu9tYHfNjI3r8hTv8iZrRtcoAbaNcosgp7r5OmYIW6ePkKvvq+1QQX2idxpDaAAA4Vf5Enp2tt2LyGPfVgamI+6dUOObWPerBPPjtoc+Fxk4BcffgyMxZO6ivE4a/J0NHAHszY16S2vUVUsCdmAXQnJ9HOQ/JyzsrAdp8SekaP1oMouWaZ+m07cod5naUnHj0vIEH6nJWqw5itIXd/tSsL2+sqX1ee+k4s69qONmpOXTRzuwad3xgJFIllEbt8F9sLqmu5ZhLO8hMVi/pW5/A8qXFPXA3DxZsygJv23+R9cwC0LIPxNVtnZWkHfPt+sYnLtOdp4pBqiVrzPl7Xqas8XJwNpJhF9nQyPSaQYw2wzGDIHU5XNDVFgRT98KoeMEJr7Pqrlp1FLykRRLda980OfC4ycAvA1RDUBrpSneqjfW9XXDloAieeAKmgNursg9gVFbITMSE6o7RvBHGpCPS82+dkqv/2zTo03E76l/QxrO/1DaBOEjLiIbqTH9B+qUUxtM70NQ4M6noAQYyj5Ygy3qD42MyqjRkqfBcyQsTgtywwF57qHL+Xj/G5MSRHTR7Ox9D2nikFzGZnGEBQZWC3q2/P4gZ4EEVbd/e+Qym0PIESzJ2f7dtdubgEDodu0ZXsYV4PxrS/NWKQAPfJP+As3jgf9Tte2h0RL5UyTRwO38cKIU6iBvSjT+He5EQ/VVPeQPQW7nKjUV1b/qA8xf+9/7052yM5shNSzIfj+adMIba0Q1j2nt8OHn3eR/HV8qlFqWLaFCfQEjlU/8BIWMF32qm/j5WjtJuXyuFKW4CTzeQAGUOMiKQSIMS1iwawc4FPE42OFZN0jsJK20ztCTSqWM200hv/cGHw/259kOM4JUlD+Sr+kN3dRlFXuCdgz4iDDI+lZ5M2d9+hcE6uTmYHzCkx4CK2jKDgAysE6xzS5H64I+5/L2eaXtgc96SOmr0fkACkwrJENseXnkfBvLMWK4cas5pC+Z+v47dYxa1j9GO6YpeL1clovs3E2tJakUdOd+VQrYlWtXiXEHPbjlx8XS5e0rPxvAHNayv36dmbq0FqkY4WfYjITXZEzkAxFWDWjy+VnkzDIS7lfJyc836TbQkCuOO7Gdh6KhJmr+cOL6Hddro0I3MHnLQsxXrgyNo6omyfEUb8vF4gSTaYoLEaIPh49Yw93UrEcN6S1yIIgq/atWDnL+1yVOLEtbKs9n9W5Wy5aNucwB7KtOGf20QSrLh7FUUBNdejqZcnUSC2Bc6M1HeJcBapMmRyfC5WQo6y8aoALjhdYgjz4iwwNVOW7oBNNxHd60GnJ5s2HI8ac2v5dvZ/EKwAltd3b1iZQ2zoYxtWSJxf0bQiRiZazEyq8S58/1zZRC5xV1fkWCmQ7QE5TFso15GLyDOreuW1e8f9o4cPLecGKmvkBdJo4/CdCnzFoY/yWl/cISWXM9sfsOO0psVEwwhVJ+hktiy2ldoQD9DCx4Zkd9JC/X4BV+LnueCvlxDQDmn70aMF38aQAP55E+zQbCCWlh9gM4VyVhIwxKAJzTG0sCxMxqw7cI+NtCvLfFUxEmrLVjG60EGqJ71Y5ZPJWyILXKjs/J24Su0Iqqntl46ZBHqBCKaq5iGGMyeEdCSwkEqOoFSO0pkoelJXiCDx5Ou664C5Z5l6XJLgIAFHvjP86xsp7eAdyLervfJ/h6xBsiHS4+5e16x6taUxWPdxfzNU8TB0/YpDTKgoF3Mr1VK8boJHzR4Ooxi8igNylPK9IgB1+UN3CuzY3q1nEWu6adwaxm8qF2Fp7d2oNa88K1l1EkYuuJtOzzdpzoiX+wih/xvao52LJ3Z1eHTqrMC6AnM2LfltUX+YE/nWxGNZ3DK3NCKLREeU8SAHHl8eoyTIhkj1C/bh0JaFjbXtvF+TpEU0XeNnyV8aEk29NWhgNTqliqZ4/Qn++f6tsQA84bXzjrVExVQ6Xm96BRhNRZO6vHPXA7tCZH6Sn+KKWQx8+5teo+phDrGV5A6O52t6ylx4GpdkKNXROjDPmDpWMQi8rhMXs4sVNTd7zEIcAREK+1mPMNtHf/9IVDfgiUpnk4lutM+NN2YX0k9g6dxqaSFOareSz3m/H53v19fMSOqcvoVkhLWLxWufeocYf4uFJGBAEpgl9pfTJButLWYz7Ur/TzLMOjPiZyBHDOYzgElz62xBiVN5Y34Y7HKdLSn6Y9TvE1UtxmDIIkQB7AqbGFHjLbB0LGKFdL/2nA3Q2zh222s0gkr4C87FMb2q2klkU+Iv7LVVWdnzA0AxrjoNncoEFhx7TIxnSuytcGr/OWfreiqqZM+PYwS8SvKfPlLJuPdqzr8eoshyBpnPjPdqXerrkYXQDcaC1O4MdEXVWYJriDUFia5eHh25Ocp+rO08bJ7zo2DnGGPFLH8z8q/aaE45xB8EJnT3z9/QXcaSncpj0IhC6Y9ifDlDAqi2PNWst4oHnY9ztamtk5hRFUn9/qKc8jgHKcM7wR42Fk75y62UkyoH+Btc/cM4Is2b9+hOKrGwQRaSKTExIs2CM3ODL9+4Ek8crwpJsitTvXDNg259Qh6Y8TwqVqRx8U/vDWf26gy5UD5dEicHaQ5gWghrFdnOlabrs6wRr7iYhuWcsqGt6SMStFk3Ya/Xo7hjgsvbQlcI0SeK5OJw5gVOEqzsFM5zBIveqcge/xLaxIWdrmvFCJ9kvUjR4j5eC2HVlftGXyA+5NMQUVEJr6uqHuJEEuv1NVK9gRTOrDoUWKqwEtPQoobrLKW1klRf4V/gjZ3oO5Pe8DIj4gpQK+Nck7D8KM61ztJTga4izhRQY7W+LvrAxNIWdTiFuDHxqyW9HwUfcB2bZ9QaL0iFBjU0qVlYgjfMsXzcDHydyqaj5WlvKbBx/TAqPa/LlroU7WBgMVv2DA3cTUrzlTpyZ4HnLI52IEo9m8imj9MJdygo7/vSgPJRq8ESMSHtvr0Kn4eKP5da778Th1vZO+6v+xxeuX7Taa6oe4kQSwqeVcjq1ytQRiwyVKCtZ+rmkimbRm02bu2vNgZvQZnHHIj34cZa4pKuX9E6VZo0FyAoLWapBqjmjZxLUl/duItqjlCjbzADrCPZ1ANeo3DO3MtfznF712dzsBOrL89WBwKgKneK6F9u7gTW4YDX/PCqiLzEFsFruYV3ruk20FUxLXGE7m20KkkbD7UXJ6QtOjtqMwOgeKlyVYBaYkjIS/MI/8wQFR8fGyxSn/YYNSn277ZlI5bvQ6SSWMkKb3rd+qfl5/rApn+euXActbCbVKmf8H/QDgEVHoHXDsKh6ZzjNR+dznPWaQeGhKKxGqcGXHSlAjXnEhuTV6p2+Tl7F7emLLA85u0d/e1B6AYwb1HRIdwQ3z/dK2CWCF9DcQ1aaX16E7i7bYDek3Qxbe5bInyPBcr6AP1XyTyG56ekhF0dbfMml3q65GF0A3GgtJrq4D2vFS0ztzrpZJGV4LvZqBKPNubk/z1g7KjLTMjjmYOuC4MAjng93ZkY2tgibZC8leB4HXOhCii+4ZdwV30qPDL7N9M5iw1goAte7DplAoFH2dzART7L0thL572q8TVA3EMUTC3lPt6tPeWQXl3GzSdab2U41qCZYcda81duC+3wJNyp/wLrHlc02n1XbBRDNxVmldrrjW0noGhYV5nxikBNSraDZWPn2g1/u0wpKPeYviD+l0H61t3ZE22wN57oj+oJkE0Oeq95k7mBEimLKV++48IwXvK03SuaT5qWzuC4jPXSVNDlj0U7AjZ+payX2IrwMXr4yyX2w5xFvWp1kJXd/oPcYOh4bGTIrTZUjda2LoDGXpRSKLgRFhl0X72UeVhkO6WiZrokOoXJqHVIAf/xyZOJxVDY+OCF55lRXrn7r2FufZY7qdN3Db7nZoio3byXSnQ0YP0xgl9FCBB/6Y54xpaEpGY3GNKONnXqiHuc6plx6WZejrXQckhPqSd+6RAX9cVgi/JRlKgqpb7H0k5V+5Jy+VA9ZJy2bwsWUByPONyuOF6CIE6AXmR3Jy2/017Y3GvXxTBcV4eryxYGXxugl6aeSY7AtVypL6FqTnH1ckfwKgosUQcVtmTZAkUzzuJxVkm898tf44yQHjFlKzvqB7O6vOKY41mxbEg3NdJrarCDUO7qNfZ3R6KYBEE22Owq2SuPClaiMp7NrBLCMpVQXwwGjKpSNoRRbmveqcx1eeXaIs49m86XQ0rXQR/pmo2yBgS+6NbIlXgy53BNYN3uOc0dzYqTtFrl0oKC3F07YMFnF0fUm5UOVUy+6mzpgbwJHbbQ0jEt2hDiZK7NaunYTCHe0Qb78LXS5NORJ7qYoQS2lhm0+XF9BsdmUAloQswQVSt9zIeNQ5Ar8dffEitvs+5QJMojk8WLZyICrl08Ka3+u0F3to9I6p/3dzxxQDcXp8eMY0Fibc28NTBWZ8NvGsZ+zzAcZv3LacClwvwOLAo66ZIZT1Qn4CG22fjmNOgIy5wM8o590QSbsJ08g4Fd5hJW/Pg6Ri8ODpKLsTgAAAAABq/A+J1l8pAEEZ9L556infVuu9Xn/Q5PXvER4V4S0MOv0si6qPYiA1+Kp13edm8BYF9Npa5j7pj3c31QpfVOKzyahjbrZA74xeaMS+klhP4WaX0WyQ9qwzhWa7WUH6bHGzHPP1bqiYDrkiW3+UlljN2sskZDit2VpE6wKrSppWhDKdVq6DiZXoJxfCqALIO7UBhqUxuifEX7XQGHKQrmqlLFjyp+pQHXYu0M0OdZvuVFhEjXf0SMJzxNs8PsfwixJ73B84FHS5RSy5UKBJmw3Lwo2py6p2cgTS96HkPQFnx6pGva0DxdKhYSGaMtcaJnHk/lD+TF++cUWAmoeNIczNdsnWa1DkXXzmbzh4uIVIB62Rm7N0d2uLVRc0mqKGZI5x0rURkpdb/gZ+Be3WM5Z+vE4IFggfilfZRJAITl9j9zu60XTpsaqJXskcR8Rhd9zzpHkH4XQDlaAql4wADmgFKYxSWfO6Fx10wrUK5ES06MZKz4hRrtSX6wPQAfX9ogUWDMJ/Aa11jkr+5OKxnK33GaQlJ4jWrW9j5C1krepvaMG7ZZL4/8KD5EiI95ukuF+xNyAuAZ+dZztpMvLZiswo5SGTRZ/OUkVZMoYD77jqb6mTaqnfOSnafLywzln68ThZsWAuP4bqcqgeq6y24lOQAmJUwXE23CL+aPat8tZK4/9OL3jYt/f6C19CDZtMNe1P8araike0ob4PZmQSc9qz4XCpgT3HqkYMVsMtRMmEaK67ouog3zC+SzDAkq8KqVBpVOvUWtQ7N4aQHKkFayK3b9SY1RylEKBq2CM81IQhR8nGMnwe0J93RFSo5eJycaitxlKH+bB1L6OUcE2mZ08cuNwJUNQ38IBpe/wm/zJEn2JkK9GOQqtraZhVbSYVW2eq8qIiX+omTSoIn07WPOF9ebE92txvCBd6rUCECzgEN+NJUQYPtA8PeCWINq9B5M2a/2JwncnEmnt6lTbMnuDPtfjGO5skzA54b9dv4RqYCbSojNG0uSg5wEoLoNqYw3yMCmy40pFoiEAu232miwwfpKbOVAemKVWxux9LEAdjNIl3MnB4jn28K8NtqY5p7+WKM5BCPB/p6ucUfDMSLACTOjIIwCLlB4HZomIGYypTMh2fFrq+fG22jCCf5PoSMcdjQQav8t1mGrkaqttPX3T0YpDrKNm/Je3GbuXygy3XVy32m44i7zU2wHBTiKQX5DLI1lPFDBy9gkypsl7mYRAnVfRLXRxb7HuQR2gOhIpicueXuzof288Z7Wxagm66iRtG0qRCe7/KR15CsApCGDgGO0fK8bGyK81/ssbMCz2rolvGOMgJFMjyApCVo+7uj3qalppZwMik9RvMqdEWI+gjKPmf6zhSAhugv6mMoYYC82umnQOWE7Bu+jRC+4+NBQ+0L3Cdy1nBY6N+MQ7C5Y2mPxdntSST7s3O9Qv86fM7kuncGjCYyuJtLwaaJqh1z5xuu0lGGmw5jFDPM34jldvjDhm5zlv7Fh+hU+e3mBVTqmKSTGrdYNH9+lQBmHWvQeFl2zPnyde2vyZIvOh9bb5hUAnSQsOciJD3GlrOiHrhA8QA8+jxRB2aV7FiO0Xy/IZXeOxIOi/qxDgJhBKxyqBBKw8B7sDHDYyzWXzPS1m7AZyxf1dgnEOBmaNrr/isxyDird88hTmxIILjpbJyLU44K8WsiufZ7fMAtm5Bti1mBN4YivUfmfTStsHidyKa/oZgkFyhgS8y7rrqZj4w5ywWT4FPzsdOfgtIK5TVSncY9lRAaA89SOypb7J6cRXd1lg+kiJO0Rgpq9+7nOoMwhKAKFR9K4iFLBhRVtIaoj7E2oe9Cyn3MoQAv6ZnhRaso5+l6ysaN4IuRhfom24CNISVTU3g0IAZ0mIfBvLB5fxK2VEkLqujIdBprLkSVGFHakF8cGQyk+mnMjOdi9klZhjEBuTlkPIQkRyL6zSUj6I/vYiy8RztpJqvXNO/Dli8TCURAo9k5n0wnIxT3cV8UZPwLO9mXiT5lM6JX9Iynh6g+HFl/CYR4ghRyVxs4bbIM5Ww/PTaGkgc97q5Ive+ithwKnYiO6odHc6kGDgxAvgA1lrf4ohL8vZngdmwja8fnkAnh8kGThmPM0FYXpnQ+kUy9wXJfWSeikbQm0lUvEy1RaSCNGQuGpGMyZztMMnwLsIaZD+ARNy5RklC85Su116x7xYS6jhxknAkIbYWLZPo/STCG9kPXZgUIIOmFZ+V8LFTusHOAVJ+bgoQDGUyzD670pct5E65iNydx76xJ/ajDQCXhAJg09cHSsP+auV6GlA5QC1EQYy11Kx8oftt0c/DpAdyBtPZahcCmyjurqmTBj2zOdTU47xTmr4f7MGdjdOwDRFiY2b/ZUCQcqpzenDdbL8bgxFajkOEjhd3XpD9Zp0xrU1s1BdrW43/KATvfIVmVjwOZhUXFiYwIvitpC/fRbnkYcGe4hZhetHJ63EA4VLVkfbvN+i4yxzoviIoH9oPQPmNXtApJEY5dRynNWr42R2B8nBcqD91YiLu8au20jNisBQiXO3J3pg3+6Ruh8hByQIYNgZg4y7DtL3GikU7BKctI2zEaQh8JQQb/yNWBU7dJnnLq4rW+9BIMbWOKiusLBmBfw2goXgTdKUuMSukFTpcVbJOljQrS7Nx2XbH8LYgYtWQDfeyach2YyMGrMtX0n+UVd/YdoJ5TwdIp1/8h6G8ejhM+b+j3qCit562FIPjJwi5dIcgTh5qNra8cCmqDdTgeM6rQBBvhZXSuZiMyn5WSEd/o1QDyWyvMBxIkztIGrAcXNaBCD/wcghc+UnIFNJx/cHsga5dNiP+qWL6J5gAAAAGBl/KrRHtnZF5RRxifrBoxBzLXY6lRUM8cekXJWQ3AniJxYz7YBOIrgh1O8eVG44KENlMMcY9g1YUTOwo9wSKE+pHuM4MLSTkqU1fjhMw03VQ87YKfPmVgSAOFlblXsqWiWDbI+kyUZM3P3lqcPVAH2/vcW09RZnpg0DDpoCEgtSYmpTrHdavXisx0jQ7hwrxDJ0y44lTjd0yfKU5vz//WAudt/+wzLBrtWuXBixvHRYtOXp1X0dUraWiI/t3fOUlvzGvMVWRqhAle6p+H32FfPBNdXcZ7f9jicff/TN3+ZmIFN0a2NrI4CidPPGyY+xsB2aIgqemuOxWNAbojUbKbxaodmyDPP/vboxzg6+aZKaVRPyGCj68O93k+IcLBPl8y47xqQgrvjV/Hcik8QFiWmmr2zZOojkw4b9VYzr7Lh1azsmYjlA72bvWALGvFkR8ikOQ2R9SRd8zIuF7sbt+PDQ3EfYM2fGldK2uCPZn3q9mmHlJ6iv+gUAk4hXbAHdfTLMG+t6IrXV3BVwsVZ24NinnbAEHrs+nntwtZWZ+yd85lrbqW4WDEo+MB3U6okGON/9lzwAL6nlL03RoOvhaGMRNqZQ/70Ud7nEf5NJPDmd0T43vPpTqKCktCfG0M40J4OCOXFKScKGf12Hx8eWR265Ky3SNPFmhp0NjtUn4W9Cn5Z39NhKlwnkCqt1nNWlY4GtiMa0LS1fLkSoLm5sJGue8ZyoivTbk/C/wx8Rx4g57FfksQ6mqhXdeWwZQbnJpvc9j8fUhFrraXZE65+geCH56/g2So5FeqWMSIe0L0OCy8+Y66ANrz73LR1wc0dTDJffqSW0EQJZe9T07040e82skJ9nCY+UelyWrt3Z3IKa0JcTBhbfP/fZVaHPkJMEdIkbNUMneUBTX1s18/WCT/x3t6lGUil5dZ9/6lz+4Gw8cxsTSjmLjkeyjTcQ+kpdT44tVkQauS0ebRZWfnk86ZtF83x4JtWEoz6IBJp9LS57KyfEjdaw9Q79ppTivktgcIqMfmzeuM9l5fN2KP2pT3mDMataLLoszHgKV531MgzE33lLbusrI8ckw26nnah3AcKtzUgIEYQ4ur8PvpIoKt5GK2AwkGzksoq3pIkjriZiWXA7YmGrEHr807n57C5ncU37237hTnMOmpdKLLtYnFmEz5CwpDcodCBrG723HKukARJFRMbBgjC4o9ep/FuZXPXahEmqX5uxtz1qZvMvdGq/NglBWUEYoZNbJC7+fTq2sL8IeAF/QcxQCT8lvjl76n3S8teeR46r0ubzXm2FEzhNFkZPvrOc57WuMpIhWi2V/ryHn1XvhmcX+UzAGpudfnsvR25orQtHeBHv4IU21mpc35EsEFRZcAK8BBIhMzW94ElTwuxAVHyMeMU+QCXPEhLjRwSQCoc14Glz6p6qUcXsZ9YBOpU2iPxk9rxrFC9KkwvdYabOWYHHfdFjXtuCLqUtY3jWKxMrR6ano8sTyBrRRhcJdWnY7xugzoiCdFkRYfyTaEFwl1aey9MJYJX/vtHHN/ixb0dYXmTP2BRDF3yzFgapztZjwmQn+J9SOJwELigT5JGrVUM3idUJqInq2CfMaFfe4gGHsnmd5gamCIML/y4jFt9+85HCnD3d7X3H7beEEFHu8GgCrai/FU8hZpodFpWTINgWYtfL1Jy5l2YSDOkuZkA+bZfj79oX4A0BlssqxEzSCs9faGv4KokqLvwZeboOlDF758Hb7IKT2IidE6hDwbWixr04FDOoHXDr287nKIpOk3O247piyuNJYapwSt+u8AM4Dv23J1ybCnjs53BLIHrrkKxRlajZgR2lnwXKsS9gBXUI0vhL7BSsT6FIKhP+7iDF5aVFUSneT+w4lbVjBUk00Zvmwp0LwdXr/+oW9jY4IhAA5FXJUNRfcaNtlGG2y7C50nRiKQSoOcSTmF+fRCUmnRlZshsi7MsU1wD0QCDe9YJMCJPRAoj+416FedDn03s9WFdy+nWem8xHImC+H7CJPnhaZ8s0+SOTPOkD+n3Xe6hBP1um/v6/j9LYk9WWJvJysbS0x+PkOukWxZM5no3XL68cCkhdvmHtIU8XAeKAuMPN0+pUA2uYE34r7kl/CMv1lqjIY0ahcKVMEjLh48tKI6Sj6JemiYPUZ785Qy3ShPLbtbN4yJgpdHN7LLbj5dr3S6j3VX5VWZkvaBwrmjWJoi3AGKlPWPt4fe9K/G/O5E1Wx2GqfvFtfd2KX6Qqz+jVyEWOKvqlGQtIHVUkovq3EDGQGkC/1El0/7M6Wdouom8wDeYcxo4VTwz1XZ1R4Na1A3/DJYD/qjUEk/928/4LmYQFKFrbUdSo/vNTQnZxT3PXAlzSsaY9Gf+/CD64/ZXHGprei/i62fQdrxKXwDfGV4fOF4+FPm2CP4HXxR7xt/5yw8mH8Mp01D75jouoUzAwQ3H2eSSVY7PTrYWZG1vMlddqM675Wliv1sOvFA1uGa7R1ShWSQu2tBSI7mWL6fale4JplqXqulEdJRaxWe3sP90EJpxgoMHZK3XM7yDEnerWM4TCSkL0vj+eUxeCvJCo/wk4B3TpDjJRyBb5I4nCD+C5Jl+g8klJDhrrqsy3NKxqla4/ZXG9wgwkxNcENjOi9F9DK8PlgxWJw//qPEYj0eRakG2CrcfJHTnEFc3UYYr7XhqVBLUjKM2ZOQ6wF6xwxlRMvjbGzvg99QAzIVjfIwI0i3RqL2DezSPZhhOtaFwyrXF+UFKp3gVW+kD3BCy0mfYsaNruzWm2FsIzRBGlALlBtdGNlzdJX6mbB5NhZSmfh0Skac9bmo2kk0D+46q4qkrNnK1v7atZXG2iakXrxU3k3CfjhDDhVyur8JeFhdEoCsQi8zegYSXEk0O8QMPflVJ6bV3bMCLSIkT8KjwlwczQnrWqeaKhzLDt1hTYzdWdpCTHnnSFEEg0viHWgmgbSK9UHJAMdtaT9hQwQs9EQW/Gwd4wJLOt3D/rRQ6Cd4bKv0NUrsOy1U5mzrElmJkJKkWErgM8fLm6p2PsniT+9O18Iq6h+14T3ijfD0p0YBqvYJbantITFmUgli3YrYQLxKczwymrCRN48SWVeZHnpD05QANzJvyVQtG0mwrG2xNAATiqJqcw7T2JDQu9auAgAAAAAFiNtlNT/oohbqu6f7B/siTEGz5mJVYlh0FC487bOfsQOuNQb3K3lip34HVvkF2472xc53rtx3ti5zvXbjvbFzneu3He2LnO9dksV/XOgjkWvWxl8LdbGXwt1sZf3FnQCHUdtSDYlC9o7a1RwAAAAAALM8T9/KsRKP1jaM96DGHsRB+X+QhcQpzv+73jWe8u3rKvnTj6c2S79UU5IPozx89FRs4NvVLoljoj+f+7X/SCEzNYhiHg7uW5G4aEdCxtAgqKMHs6KwC/JUM3Gei9HZDIgObTfW4fFciKCovj74ICv0SbJ3CFX6G/y86Zq3xQwyyW2dS0C/fasR3A2HT9oBvfRvWwdnkJfhisCuG0ICSnugtMcD13BIqAmrNDwU9/v476fp0YbKF77i8X2SrpZ2JtrZ0RwOw0Bb1SX4kQ5LRqnvcGqr+jOIQJZItH2+UNsyeV/MYzNB1+cyc1pSf8Tqo6mSs7IQV+us/GDgLF4PTnD1n8rQnZl6ypNe2QnPWiauk1mjIlydiohuaYE8TYiW7fzfl7SXIX+Gezj5tnKQy3U7aH+hr4Ub5V4Py1ILKmXyz/rXaoeDz7A3Z5upai+urWkxPu5pAKWsaYaXZMNDBrhqX/JUNEe0T1i/1uM5vhtccqs1LGKFM6/BdWa+jdcyuGlHmGtS8iSLkPSCB8dQP/GZvs/q2fnrohuP/4OgRXGNY3ZF53+UebICM6i8CL7gNYcofzS79p6Aspx1L4mXbBHKoXprzV+S4i2DcWjN9xzbGfEkwgJg4g1qObUgHdy24748uV4t/uckWkKLe9QT+y+rjNN22pvK/vvQ3KVEygMlpgYuPwMtiOzem+z8biiVW4votTJkuqxRMdOf8aJwgCw9g9/jqnAfeclL3qXx9ZdI6gZGNXQqkxZt5qK1pdR0VFA6d9pGCsyMENeCyLW3SmPbx/iV1B1/Be38QMyCGEhW4fSsAYk+ry7Jq4/SVdCRI9R3uMJZmJP5WFy5KTMm1wRyeYAccTxQtGmPVbaQJRRoQzrx5j/BeLdqjHFIB1Ljy9FHADdHFSJ++wXbF2ehKtWLMY/7Z61+8Be/zWI300WKDAyX4MHEhqI/dbHAf3Rq8evK8Ws3BJaog3kADQPIJNsUSVPNTW2FDreqhiwTPDAjWjWCnejWr2hneDw5K32QZ/Q7Fri4ALWd+D1OVwqCaNYKp+5wtejZOSQLmxYGYMPDh+dalVtyMT1EjaY5WfVzX2V7x8vRvjbus6/bOB5e5H9P6MEcwhR5oXzs8D21P4AoKUPGcG+6Zi3oCd9K5VzwtRp5j1TfUCCq/awPicFL57D6FwbKKTWuQcGz22PlwM7wjt+WfszBYbBNpkAJHkRyq+ah88m2rdGhN5BCTAr8RsLA/k77cviQvL+2BJAgFBnhMBkfSnAX8vFhmDeF8MqnLsknEpaqDm2RbIzrsq41Eb13hR8evu1nMQyL5WQ+ZmxXi+nlukZWcZA3OaFrXDkEenuB9qucrG+iUKcfDrenT604XcUvA6yO/zsc4Tyrl9fA+a6mAntjV6AAAG9CEax07frezT2m2zSf1/V2gginwyF8+MRAReqtT1NKBYq+nKH10ob/6G8cUXR5DfdjX3cQhBH4tvp/Zx9Q7SQO03qSaWIULc4DtmPQJbW7Yq4uF0rd3PQgmQieJmMuQQZRmwZNi8D9nkuN+lyW1KZHpsjYVKqhUwTtX6RRpZrL4cN7Qllj4CykM72ulyjfdikt1MUCVPVAjqfBNev2uhUhLsH94TUbBw1Scg6AoJfgxzpeXuA+hnpBOZ9pAlCh4/hMtvhYnIT/MYFzElrWxMmRxj12HHCJghvE7ncQeiBbTZn3YL+Sl1X8/7uScBeR910fpLQ4E0I0O7m1ZxJc8pjg7/xFYQaxtWw5LmrTmZ9vCGjuMBIp0zgyex4H2dtwIS6f3Odud+Ihzsfhao/tjvtx6iM55/SZRqGQlkTzn54f2ya94zHig8/Vh643wwtvSWhu+9r825lT/T3S0+/5CKCjcCgch/XQU+viikZxCldHhQyuwngPpZjbu7ypo7NKbdJlf++AUXrYa1v/BV0zapA0JcsEM1cay6LWQLUxlvUhcClSifQMrgtJRRMxFvZh+WxXF6sV5Ji1EWVRQCEfvBcKegZAm8dzARMRXfGIuzqTRS5QBukmTuPhfvd0hSTKEHb77zWTsRw4395ATbFW+g9JbHwHaP/CdueRddgm2iX/k6vcbyiTgGs+kuU4Zfmk9qXuqL8aeWE8b1ginGW4GW8lctVnv8A8LVohFSKA83PIGHMAVBINvav7kTkBD9cBekOE9vTaU4p89ayY89RiIU6eqoHb89c6+899cIDEYlSL+C59imafB1MLpyyp+jPTMere41PP1KyPy60ObKLtgztGzhJ6hYU0dIHQ+XM/Q8qiDztOjwMrzf8fKQsDQXjHKF9LlAJWSEro/Ti/X2Zoon0uxzyDsIdq6qOBEFG20g3Zci1ProZBlwYRC/R5QPRmAw/OlTAfHfrE8wffGW71ohrs5lKAJvWGILxZxKYWGzPn1Pc1p0V6CJMiDcd3tql9nqoPpVY0LxpIvD2aunafDloAK+NAuMjkHqvgZIoWh5BVM+YV/0l4HwB4Kc7EybwaUJ0JCD3GpufO4r63muT0bbWHZE9Oq9x0W4CCgmYZ82Dj/JqaY/uGjCxcSqBqZPPmdEyncicAoQKShcX3jLo1WI34I9NmdZeQ7ZQqUYkD1upZbv3mbSZWVTVP6q4LxGPLSNKLE8c2rl0H61V09xcE5NvqJ3M+GbdMgNsChbFIYsiJ4j/v/faXMowlzIUFTnD1kOmlU4UnZglugx78QOv4Dc0liW3ooQJ52kvHFC9gqVnuY3QjWH/aHH7TeIbRfRSPWAMrQS1OhO1/FJSP+AOzYaicc8t+7q+YbifiaNBlLeIy1s+54uR8j/qMEHOiapEISJSNB1gVB1rOSd8blzz47CE2ax/yUVjrmFlhU5fJEchyFDOypl3tJnEYWC0ZNoaBHPS5SMzwS/ho2PvlTFOwqNs50PLg6PWIduMP731fYfgMB2m5tPrydeE5De5eIIWpchlEBpQ7D41tA+2wNrHfhecI1SDwL4NvK+wDs58HArkyiXS69psAxeJ26zO8Y3cK9FAnzhF4bJSXlhEX8X4KpqdlOFJCQ7kVmdyUz5YxMHttSpnhtUsZhvpwCwrDtMSNQugewfXB6rSwRsnJ5IzuU8sOgEKYDM3vDbcvlVQryI87i0RP7/B0jxBcVL3SsQN/X2yAOqNa5S67L6A8PLhjrZJt8j1K7nNIJmpIKWoYXFp6RatygIUHt6dPya8si8/d1iUgW0RLCYp3ZhiS21fNrYkiwycURNjFInWPi1bRYH/ixglsMSNSaDCiUzJqwIOtkvLC47xwABygI2KpxMgemgthdKkUQQAOAAAAmoG12TCjY3ZdEUQCC33GWuxc6VMIYIo4FKLKsRw1CLIE9s0l1N88qbFipFOa4MfDY/f+QYYSnLjo4KruW+S3L/d5/BQkBnR+3n3fc3mAxl0bUAwdY16giJW+LQ6at8NA/N7qSf5NoSTTFfTKS7aL/yPLoJuOsUWnuvIOHSNnFHboz3XFlJ/Yf6vKbCilxs04Hzki3kUTm4LH4cLk8UoE3Fw/oI6613tsp7K7+2WRpZHEXgk6Y6lQoMezyg+sJJyMWW0HVTdLlb4ZimTfS7WVqlfU9hTSZALbOXppg4nKzbb6n60uFsSWKjhKpv+w+N7neOdwI1EvsluotobWxsuF99tEgEvVhVBZBClXIXGTaGNGqOVvYiOmvDdpGUqU4g4z0/vIJq43+Vx3LGCCnGNbRHTdjF5C5joruklqF8Fdei9pVj7TcX8Fe6oFvIne4Ph0n0sz41Ud5LM+pFkJeplVRmda7gmYzHNAEzjZGNmFoJeM7xxVysXeHD33nG0xd165yYk2P4fjrYgntjcLFZX2m/hjjH2zJeziEf57tCly5XDDcQ05FxM8DZFB8fcji5OqKytdu+zON+hXtEvrZqG02UG4+enSVfQAyODir9gUzrdyKvW7gblyRhtc9dbSvNRUGTMxuCHEYcdM4tUVJ+YmuhiUHiGO/5LgimP1+jCLHtz0jNWmNVQcUzEBFtbVxN8hXUinaVJNCvm0uzIuKKGrV3E0y/QK2255x4R+x9N5JxxKbNhsxwZYTSqYLM8EBofbcA/xSnM4z6vzDTQ3rq+sB+cD+uTuVY/tZxwgKdld++GmzazDBJ4OzcPGf4wVqrGbN5Yau98e4eLuw+2MUqALBLvGc/v20zh1+VWmzUxvWoxqoblecJCq0z50PgOC8citfcJaVhDEA7hD6TyHpszxXSYNsZzFOqtrRNe1U/nA91P3M5l32HOnexBck/9UBp6PyLTDrW8bo6mtqw+gygKKXQXfgJkZYUx6+oit25rduqMBYXa+gmdmWytDY1magwFPEbpg44oWXmnaQzK17t8fJsOoq0sU0vZaIOQHS9zsVhkdtlsDqrp1N6XKp3QfYLjeD2eC5msazsnu3GKM9Cawk98Ot9lleSOqxSU5G2VyllcVM+NdoRUcaX9NcpMg7JRCRRttuzNCtrYSzaEgppjXKmEnlS6t9/sUH9MtWw93NEYAzQZC21oWgB8LHZRhii7r3MMBnfa/N9harVY2uYfOozhVMJece0bCT/RAdsMybFi6D3Q22044+I59fJsgtvhxqMmxRVTBs08oUfuclE6xSinLwA3gkxKfuY86nYPyIbOIcaSL8/JVOWeKqKLwh3bPHZ+zOre4VT5U7G+cHIcjnXgGcnurPE9sfStlF9JqDZF3S+I6iHd3qahQuqeORJ8FIg2bA8EznZl1g7oc9F7YjWfHWKr80or/byp3FL3pXZlO6HMGXrJ2QHWdJcwnVm3oo8DxF/OGI9UmjWz0e4qsl6LChWSN1+w4PJarnEblrYtAzqtiwqoV3S1+vFLR9ZyxRkV1DXoQNVGYBtKMmv7z4vndor1rfPc7WYARVsi8TO7HdkeqBzvgddsjuBviUQQurkbw4Lqyhu7C9CwlceXXmikEByExmLGd/TLhqz7giGMY7okf3Nk45oX9tyN6bS4d9xMtT66bYZ3kBNC+qI3j8E2APPlDQwXGp9rRvGwERyKGIN1v0scZahheGhU3LO4T+075ncuyzV7J9IAA9N0bAqpWIooqIgal6Wo4YyfQW/Ms2BaEHbaNZQ7+7OhCS5J7Iic4FSYU/Leb3+Jzh2DOjc2O2xQt2EV8+oduGFfZ/SD7hJTFFoTfuqZUf1lWxVYait71uryTq2yhXwK8K9uG4mlrGky73LZKAahj64Y40rzhJJCDHXaELZbdadLwfhHwbXkk3clq+ANVaOhCm5A1yTPcC20obYehZGmmhClBCmA5OAeTD8DtD4qp97YQ2qIRLt2RjwBpUmJq4d1aNzZkRa0IJYF65sv00l3B2aR1hRThGlK8++K3fER4vVcJoIOPUiARhBZBxwj15VcvvmfJCs1dYHCpp53NAifHiLJkHCBoaGWKsGvp4rNFkS+grrOeF4I2SGVlwmH14hafOYXj+qWw2NevIe5DqpSMHeb32MirPm+Z1bTUOfChbi03WRlVhTEzRWdZ6hWvMEAgFA+lLunl0KVeScAL6d68xCqhzUR28E3vqeEnvtzPQibgM1jIPidKlXEE4Ho9Kzluv03vRECmjjB8gm59Jha+VXVhf7491vRpP+/NjA3+v/V7hEHzg4xT68McgSoxRTbwRrroBq6W9tHZjIhP0Y/BEJ2RNjOEKx9E8giuj6u0wbcc1yLnIH4cTaIdhvT+uVLq+gasJWQhf5UrDBB++bnTdhOhNOgPxIwdmcD6RHMlDt8tSUPg20cssVoqbu950GeJvX5Y24DLc2EHnXsHpINkNuRa5roVuFHXzdW6gjeTtqHID4uA1vx6MaTJ8zyV5iNXC/K/msuKh/Mw943I5TIuiiEEhmxB7sTLxpUQ9GafVCDnlq3GcFxk2zBTgrQYSYRR7jax5FJSfJAHwfujUeSm8QhCdx2NoU58qXXvWlYFKaCuiOdsWvRmnYfDL50vakt5Oiv0fAMPkoYlzxjZn4zQ0BiaLgrmouFynRNug5dCLu1qB8FqfakHksh8IVeQ3KCllYsAS42xu0EFderuplKoRA5x/teMaJACZu5p3h5vQAc50QIbO4nk+I987gQ6SGyrYOzozTtGnlzjg6QkczZZ1nFaG6MAi6mFqKCNQEKdnf/i8wL0D81uITEQQOlRTEm/t8hSlLoL7LTI7+iVS86Zq7wCoLHWN0AFBK7INk8I67IjkzOK9Is2LcrUgTyrPkeJX7x+OCPg0Q5mrMJk4ywo1/8JUcowt6lPRSRhIOW6bulo5YDOLSSzU++aggDC/rvOVk5eAY2/6uaKlkrpjpYUApwGt2dCHHHevbdRyhQUTfRMV1Z6vjxOViQMZa6EyRESUHuqu/ICzxjaEpJI8w0097zHExekMCpSNp1lRUCYQnK8pvhWufar5Kua9EngjNob64Y40GBNlR11YP2lUoYXqP0jI15tJuTy4Rud5OcVwsFtLdvXtk1O62+xbdJja266F/BFpvlDsSn2JfVPCwa7plQ8/Fz7Is/rVlv1ZQWxtbGVnvp8MTucHQREENfLiF9iKlZDJeS9KF8xsYI2lGM2cGk/9a8ENJLY6mlmBzLU5lN5B8Q/jEf3DdHfRgJ8HduUMbU1mfGJl+xPF4Nhpy8/f9zB8bY09g0UCJAXa0CWiZjjIC1kpq9mK/CGm9T1Os+N7yrHKrnNPegA4Zw8EdUIACVVxHCPqKFHEXjEqE2OWHFz+d5xc/krmWExEhhXpldcHEoU9qNMvorzQBXtJR5kn/r+08ycN60q7s9/ygU4Jl9iAEtrCAt/yliMXGTRZIbnjRVLy/w/G9jV7/hm+znpIyGhpDQ0hDLGv6VCEk2htxEN14DibMB9QAETYTItzz7gu+N5OmBUAD9OGqfQdZQodiTmxQkhEs7zeOnc0J5sMJ6ZtoMsr1aFOfJseMzJuE94seJtAMf0EO1lkVLH7OOYVNX/wlWmETj1O60lRBmsLWWWsQnERRCGKJ/+rGK1fXsnu45qsVs3npAmkeEfMmeLCYWV9u0A5XnTI1qr8oxog0RMzyYTYVTlrtB+aOLv/5Hel2bvsKwKzJRynIFT2V+Mi8kBZQM2kwmlowGdbVKuWZ7PW8gn1vg6Bnm5mXWQbfI7FpvKLYSenFr+WjR8oC2nKfRpmjH9MUupEo3LRCXZ/hnrvEIgqfUYAhOYuAbCOFSH8Vj0oYd85sxRGE3+DlMmi/mSqwjAB+5ErCqvHvogzHkd1uIPIxiD9qYheQ0K3JCwe/xWSkkQ2aVoV7lNmVW6t/8Td4rJebUnk++6BOq1EMQI7pYAMY5+XjNn9ts6l3962aug8HxUqxlUcKyxC+Y2JOgcYy3QhvP9rcisRjX/SW62hsQTZjg3pP0LEX/ElMFPHYD1rzcs1bj8AJ9NK9P8qxgBJ4aa72kybXbhZECIw1lUTs7ZNTEYcoVIB8QQzpVYM/Bs9+5pvCivd4cFvVDnvz0ZvuSAAfS9T1OxPeQ+Eh8RXM2VC76VzqlHBQau8etiykcTzD3M/NalXFIv2Ds8DAi88vwIPpzkIN9sHY7h4EW42jQn+eR6YBBNk6mtza+qKwGmjrJwz6t+B2ayZCTCTuVKN53wpwnoEE+KIkCAAW2hDK+g+I/9/Pry3dA15g/KxJZhyFRTJg+Mt5rsiOb8t5rsiOb8t5rsiOb8t5rsiOb8t5rsiOb8t5rsiOb8t5rsiOb8t5r5d8AjPEcAAABf4AAAGkLBqoJ15cqYql86vmQAKAm9z5IcGvMjrDv2f4BhF+7HBrpyDSKGmLMlKoBmp+q4Xk5RRA9KAODvyrhyhd3ic1WskD3WrhM2aIKwgZ/nweAcuEiuK19rkZ71Je/WZtQ3qy4OylrNH8XkElNX7+ABqE45H0jFX0w9BuAD159+ya70Xcf3IzEP5NIi2rXdjiaEi3qg8IRo+92h1sfCcsYHQgCO+JdX4qhKgEgocWXNn2hdB/4SuGHBC2F2eHF1U43KIoRhcmZJY8zh0lx/1vC1IqXUZJt09IeEigej1KiByVP8JKHwcdhck2XfnoxEKkmDBVwsuIq2wYGgz2WMJ7TknPvq/AS7hAlmRPk9TJi1Gi/7OVo3QTRU/MSdGHQAVJFQ/l/eV9yaDN1aqQnQ6unkGE5ZdlIkYXSCoH63K0ed3mFKL+cOAWk/pzMRvHVNv5v/q/IFLs5AUj8a+dTUx0QgPCBbgXLKIHT/qmeJYUA37EmfnF6EViVtP4Himfk3joz0YEbcHLzBk0HR8nizzkD6Hz7JPR2KOhIhnt4lnt7L+Ic+E+gxmPcf6aO1doAzgixq5j9YAexzFWgI9K865JqdznMiqKLrAt8Qt4iMT+Tzvhn0xoxJMfGzWp91pbC2oCW4H3NW9La6sR7tV5cuJ2DSbhvpITQBikHRQ5R0rPyPohotjIy8ls05zYuMRY60WM8v26hJdqT3g7BWziGR7jdbMmwa4swAAIWL3pPlQ7NEI1c+GF0BO0hR6KuVEBMBjZdFvAYGhcaWT4FWzvJaoe2URAzgVZVecYjJl4DEyQtuDURsNdBA0C3ELrFnvNLGaoOUXNz53G+oQu5JSYEbg3mjcAFQe0EGw9tquOWDEqLuYJXX6BJV6u7h2Agm4tWJDTk4crKWJcpqMM1m9tRmIb/ogQvyxOw5x57TQhCZdX8smMywExskwandhwuS2gmAQGg7UHL6d+3ph6GZFrsFKYK8ERAhOGesiMA8RGy8eg19dfFiMX6dYkETScxxtyA+J4xu8kLvJO7hjZREUxnH4RPV2KIBZvDaX77P6GKgP4iCaF9YEEQbaKF+puAReubXJsxccOTNmPB1yYm8oHQMdNpfevJGYz46EubCtXruxU7pXwugBfEcmIalvokExgsPMGSChnmzOXhvNGS4qYjxx+9WuLg10MHoMcGD1LLjjXy66RY552XG5iBEK4ni1sj334u1gHAQNcQEpOjD7Paa+0D+LfDZ5H7X/KxdqvO++plJ493uvD6hs4SL7x7nYIx2JnWIh1SqQwi4xvAfST/if60j2amE0jbgItZxyibGDc8O8q7CBVFHxUeub4TDdO/4vn863Nxejl+IYMTOHL9HQnkzAdMYd6ThiOjUXXj32MFsiiU2Vtch1EaF7ucdbguHu71W2GTDPhEPcMo/nu87yvV5bTYG8Zxmhrm6GpG13lAaCkEX5yaKEevVWXO+szDq5YM+3OMvaUYNq9xpH3kaKKJ4K+zZcT5f/WOnZnm6jYuSpJFqJP7vsve4J+gx7+OEAerapubS/yj/dJYmOhl6rQP1/AD9v2a2oWOsx6XnzsMb3ZpuELSMcFMhSTP6jG/inWewm0d9F4b+FHHWAABRZjREM4M9mN59rbIeF9urp8WtP3AbdUhRg9dYRxxojg+XvOWIG3PUZGPFw9HIMYCusUJwHf5dolet8FGrAdAydf+OF1JkZFOvPAfUw982f4CYNEu7a/hpBwSEGbVk4xHIOwtmSm17Cc9nXQikq+0l8dtfAv2XfZ9ojy+mLhv7Dekd3KYiXbX9bRtIQ3gASIoAL1PKaoxcmv1JJGCrzGdroRh3gV5ofLNL/3cfMS6pQbadsIMXPk1Jn5fMKo6VHLf4W3ngJDFS17y+zFMWrqs1R9jWIy4FBmu6gCH9P2a2ACGD4hRomj2yz1Z0u6g8TE7YhFKWjfggz0kPxdjKQr7unXFiyVV8Cx3BA0e8IVi9m3OZrTnSgbPdomZ9XBKe5780MdRQkFQ1V4+Xn3wYriBxHx5I3BtM7B7IH1+DAhJnpctrmQJDwav66JihgkHTAjsbZnq0ogvKSeP7xvpH/4EUCtxFHEjJBvLAwJTtJ4CgZzvI5qKXKBm4x2avMA5/8XsiBZW9kYORzoA+44Hv5aqaZVCeg+qpaWf2KNDn6/CiuhRevxgo6OmEcemZDlgkyaImFDuvybPQwkADLepxqXGhqQv4o07sk0+zZyNDxuI1kv8iYs1nXrzD74nRNQi3XNiFsfI1oA9rOBPfnQCRA8cO0x38tuCFt6SYZ2HeEmUYwbYL5KapQBExLYlF9HI7xLiZtpeK32MH8iR0NNRdk156qPY7vmbAb9tQ//WhBBxf0Z7RoDWtOQFSkViIJMkPFh4UGzNPorW9oYuwyZvKQOrY02lzSaCRqpBlpFtMujLATi74x+mgMZpwz+RIICg+AGqogx1tWqT9TRQBRXpZDhtb83+VbxN4s4csBu39dXnH5aJq56as1IjbmysjmQO5XG8bcBuNSpiSViYlWlskY6UAAAAAPeHkPLQ1IV4AtLGsJiF3XQHS09W9eFBZMB2efxIqUsfGZT6TsqbYW2+bLlXMIxmqwopKzUchbkZvjFybVaUjeMuiigeoNwqsWXVe3z/3r1Svnl6Na8nqW+jruiGhnU69d1vwcsg4FcjSEO/yw5oYBOgel1fhv6///VaYzdpQFZqNap5v93tFOmEo9L0gRSbwBNpWzeyXDYltRtdkrUEMjLBiGIifqBWyrWnep07zhOCU+MGBQ2bW2gucGTtQtjjWQvj9r+AACx76Y7QPzm3HLKfWCPoB6SoDhG8FtUlw5KQo7EkJD/X9ut/VAYHSN1ctLupJJ1QwbuKCNqQiCSoJn+Amq0QGq7QHkltarDmP20x00Cq8CLW8Ke9pnDoaOa0OM6Wf6jsWie1lcQucHTKpmZjaGSgEFDrerRMERL3Jb6nSUJJE83KVA3w1ryDRrEcTZHIfy7FwjQfwV1JouiYtFBLn9XZzgN74j/MVYvFEyfX52U4XUbxQCNexWRxUsupuyPN7snMgzPKobHXyKdiLfJ1cExvUKkuHVLJQXm/zUKYjCE1ll4/YY8DRCN/nr4M1FoWvHTxwP23gw4pcVpMYf/Lox9cvopqos4bqYHScSqlDluxxbppcr/l5a3iwa/5xXkIrEolDv5HTYymIxXOYhrz7P04yJDzg3RE4WzWOY+AVtRxl4eJScyd1X3OirrN0yLSS0EmHTYymyHM6dAEaBXf8aNl3WUprafNpp6WCUFg0Us998B7U0lIdL8St1m7A+DoRERQ66U4obzMzGB495CHK5yxzMDYp8TfYwo2fXHywn1vugMc+onIM2ji+ut0NsypInakWJHOZJac8TrJOntmzDZWnW6bcQWnhUfEXG2MZSzQvOWCNNdsdx9+Nvg0Y3WGveuhP/N9t1wPl5PaMPrzduchyZpYg84/fLYgEshysTTHWLPSn60MLPwOwEYYQlLIqiFYkbnsUmH9eTFSpOs1lzb9m45YwqLOAT2mUyqpXOoJ591o0Zv5KZ3u/3De2rsEAGH9f9gGi7ITOTt8iScbZGHrvGRJ1k7CADCwjYyj/iKozLwqCCgQ6RKT5mO6C4wZbLeDa0V2aPN+3WcUSq3nEqiWslpJJc3Voh6LkIn5IIQbXvyHiT25SWsuXM4ZmvhUjDbila4HzUHnpz+j3gC4dKbljUoV2kEXjIf91fNIigtOA8aIAmCliQonGhWA2RnwmYdMmShwXlmZfDo5zT+VFzSyjZk0+qKex7hKPR/LSwAV02GR3TqHgvgLpYyl5U/te+Z1pKpWwXFxaYY8wqLFM+wEmMAGHhC/kCFaIYXbu0C3CcTZdFLpypoqUBszgRyubYmT3w1kWkShEUoXiJNDCORCPO283P8XHWOgIz83pkJz9ayxEzh3CrgB4hxc2ogzn6zboUdSeZSyBxORjizkV3yygivrl0uSNqZPKyBysL1bvSrdyE87+k+gKIcMbrXKq935fnPf9pljmAx6jU1jroJ4jEKzpvZyaBGQssZT0v/Zjt6RiLLZkYJq1A3NDzUFiBcctj8jWAPnuz/5Pgan/r7Lt4YlCx4n09LmYGLoBtdPut0ceUr55azye+Y3nsD0YBKrXlQQ0sU5NPEAm1R82y2FnBN6MWf2gjP0B4E56pHM8mQRV3OOcTkiJryHRzIqmli7sfpzFNbGsg1EtLdaOrE4B/gdvF/U0Vpp6qrh8YA5ldBdbm4KW3Nj9pL7bibPWbrUcnN0bPg6NJh7moL5GiBeDQ8xEEyaNWAAAAcuvURlUzzYEOiJbeWMmi5M1/3svsw2PFvrCMDORqv1Lf3ZAl0QXTRJP+GiM0WVpZNjxM8UOJ2w8jdNeAR4Wr53eNPcdqti5zHKyCnYGri38ktXPN/9q9bUCvCN2B0/cFLH7hooPRyr3NZNsiUbUT2bn30mOl7RhSPk2jeh9BO1LuCbdIoNyfGm2NOhgls4UmVOljiaEhJU4DnYMx4Wr53eNPqEw6MvgLchrQhBb7dTDY8RCoST/SOdgzHhavnd4091EA9IvQFuHLDOLu3L2rQwDhM2s3r/m/JCvktbXIcRxlrrHLRniQHYmTtqams1xZuBWORd8d6gbGaMOZ2+u/5eTpJTQlnu8nHsJRvt6l3UUwdwekT9g0clS0pC02fkavOD2H+ME5+xBfWcdlX8KCIHL6vH0M5c0HdL3vktSt1ncWwwc2w5KOeWkdK8uVvKgLovWZhOMcbpKXBO0mutdOM5duzA2pv/cR3jkdX9IyZ+Ugnir+eIbT8NuNNO4rY/NcWn/DVE95esloD0TLnF0PaYmbl8nTBJHNQLjDDAZcg8bkzFtoYtLtp1TU1gaxBrVCoQOzPVruFP+FZFmQbEUxMCeYMWQDOwreWSd3LccLDdPuaiIqo0RbPWdSGDXtn1kuBE39t8DqgRE9uNxoCUrTEVGUhIKvs3/nznKjr6VjzetDCNNA7uoLlFY9DHS6WSvGuLUklxhI/h2pAB2e7WKk7hzGoSy7sXuy1yJrB69rhtpR1CK2oN+h/9x4TgQno6XIFGjS1l/IdiO2LwOY7D1drtYVt/6o9T/POPG+mgwJn6nNgEYdpf7S/2l/shAACR3T7Sce6EG/tKBrxsDwD8/meQ+GjSn4raJt2POo9wvkjqa3Ja4q2bDBkUDig5vfHHb6E1hmyRATubwAEuhfhitvd2pqd9A0Ws2JxZ5cgJa9Wq6TYIMZQO8lRYtL6RlksnrxeXWruTqWkF4J8jWoZSFpIIwqBS10TV6ylZq01bHGlOlk5EIPEtHorIk/SKqUa05wFVGq5xXm5n1KE9WKMa55xuEDdur0gkQXvjhXHULkDWmvb5h7eHdHxKTfC44ZEufXZES6Ps+janVcxtPYkJ/ms8QKwsy+53b014+gt8J3RqPZpBbozGhS3sZpMYMTiXyofYC7OG2M5yOFHzrLwZHR4O4mo2o7QArBV8FDOI3bgMmHO/B5P+z2gnqBgZXtUVAOtepp3wgr4S1+089SeorDtYeRaPgtXAD2dKIkie2U7TUg25BBFOCVt0E1GTiw/oB8epunz1DUAXGosQ69kvOSeNdPnfu6K0V44rcLtvH3u8j8GXQVGSjl4Ue7dcSaCl+xJcQ7BW6+XerqfoZyBUbDaMxgxsKTt4eTpf+e1YyUELqm6TxV/uZb8sRXWY/BkxTCAw7PZ9TtsZpOOp+YHzLpO5ZYlbzFJPCRLNcKXHlA4dr1ir/evn2TCic76KlH4Yvhi1WeFIBAGGNyjci8nL1EnX2rSDdmjLTWIRbIc2MxYMVmsrssk3rktx/5re9XsUKAB1NdQfAPZUXBQ1dciBfUNK5zxtyCDzqj0CaArwpUTikLv3dHjCe+aIj9h5GYPnoaEAmZB+OVk9DbWyAAAAA",
+        "height": 12684
+      }
+    }
+  },
+  "analysisUTCTimestamp": "2026-05-14T17:21:41.363Z"
+}

--- a/tmp/perf-20260514/psi-jobs.json
+++ b/tmp/perf-20260514/psi-jobs.json
@@ -1,0 +1,6522 @@
+{
+  "captchaResult": "CAPTCHA_NOT_NEEDED",
+  "kind": "pagespeedonline#result",
+  "id": "https://www.ocobo.co/jobs",
+  "loadingExperience": {
+    "initial_url": "https://www.ocobo.co/jobs"
+  },
+  "lighthouseResult": {
+    "requestedUrl": "https://www.ocobo.co/jobs",
+    "finalUrl": "https://www.ocobo.co/jobs",
+    "mainDocumentUrl": "https://www.ocobo.co/jobs",
+    "finalDisplayedUrl": "https://www.ocobo.co/jobs",
+    "lighthouseVersion": "13.0.1",
+    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+    "fetchTime": "2026-05-14T17:23:06.320Z",
+    "environment": {
+      "networkUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36",
+      "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+      "benchmarkIndex": 694
+    },
+    "runWarnings": [],
+    "configSettings": {
+      "emulatedFormFactor": "mobile",
+      "formFactor": "mobile",
+      "locale": "en-US",
+      "onlyCategories": [
+        "performance"
+      ],
+      "channel": "lr"
+    },
+    "audits": {
+      "largest-contentful-paint": {
+        "id": "largest-contentful-paint",
+        "title": "Largest Contentful Paint",
+        "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)",
+        "score": 0.02,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "8.3 s",
+        "numericValue": 8251.062365221298,
+        "numericUnit": "millisecond"
+      },
+      "dom-size-insight": {
+        "id": "dom-size-insight",
+        "title": "Optimize DOM size",
+        "description": "A large DOM can increase the duration of style calculations and layout reflows, impacting page responsiveness. A large DOM will also increase memory usage. [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/performance/insights/dom-size).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "value": {
+                "granularity": 1,
+                "type": "numeric",
+                "value": 606
+              },
+              "statistic": "Total elements"
+            },
+            {
+              "value": {
+                "value": 16,
+                "type": "numeric",
+                "granularity": 1
+              },
+              "statistic": "DOM depth",
+              "node": {
+                "boundingRect": {
+                  "width": 0,
+                  "bottom": 0,
+                  "right": 0,
+                  "left": 0,
+                  "top": 0,
+                  "height": 0
+                },
+                "lhId": "page-15-path",
+                "type": "node",
+                "selector": "div.d_flex \u003e span.d_flex \u003e svg.lucide \u003e path",
+                "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,2,SECTION,0,DIV,1,UL,0,LI,0,A,0,DIV,1,DIV,1,DIV,0,SPAN,0,svg,0,path",
+                "nodeLabel": "div.d_flex \u003e span.d_flex \u003e svg.lucide \u003e path",
+                "snippet": "\u003cpath d=\"M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 …\"\u003e"
+              }
+            },
+            {
+              "node": {
+                "nodeLabel": "body",
+                "snippet": "\u003cbody\u003e",
+                "selector": "body",
+                "path": "1,BODY",
+                "lhId": "page-14-BODY",
+                "type": "node",
+                "boundingRect": {
+                  "left": 0,
+                  "height": 0,
+                  "top": 0,
+                  "width": 0,
+                  "right": 0,
+                  "bottom": 0
+                }
+              },
+              "statistic": "Most children",
+              "value": {
+                "value": 61,
+                "type": "numeric",
+                "granularity": 1
+              }
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "type": "debugdata",
+            "maxChildren": 61,
+            "totalElements": 606,
+            "maxDepth": 16
+          },
+          "headings": [
+            {
+              "label": "Statistic",
+              "valueType": "text",
+              "key": "statistic"
+            },
+            {
+              "label": "Element",
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "valueType": "numeric",
+              "key": "value",
+              "label": "Value"
+            }
+          ]
+        },
+        "numericValue": 606,
+        "numericUnit": "element"
+      },
+      "unused-javascript": {
+        "id": "unused-javascript",
+        "title": "Reduce unused JavaScript",
+        "description": "Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 436 KiB",
+        "metricSavings": {
+          "LCP": 1350,
+          "FCP": 150
+        },
+        "details": {
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "type": "opportunity",
+          "debugData": {
+            "metricSavings": {
+              "LCP": 1350,
+              "FCP": 150
+            },
+            "type": "debugdata"
+          },
+          "overallSavingsBytes": 446560,
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL",
+              "subItemsHeading": {
+                "valueType": "code",
+                "key": "source"
+              }
+            },
+            {
+              "label": "Transfer Size",
+              "subItemsHeading": {
+                "key": "sourceBytes"
+              },
+              "valueType": "bytes",
+              "key": "totalBytes"
+            },
+            {
+              "valueType": "bytes",
+              "key": "wastedBytes",
+              "label": "Est Savings",
+              "subItemsHeading": {
+                "key": "sourceWastedBytes"
+              }
+            }
+          ],
+          "overallSavingsMs": 1350,
+          "items": [
+            {
+              "totalBytes": 196265,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedPercent": 57.372344479375059,
+              "wastedBytes": 112602
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedPercent": 71.209258234242483,
+              "totalBytes": 156501,
+              "wastedBytes": 111443
+            },
+            {
+              "wastedBytes": 82854,
+              "wastedPercent": 42.2154629213789,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "totalBytes": 196265
+            },
+            {
+              "wastedPercent": 43.305191321147653,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "totalBytes": 156501,
+              "wastedBytes": 67773
+            },
+            {
+              "wastedBytes": 26614,
+              "totalBytes": 42584,
+              "wastedPercent": 62.498279737602644,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js"
+            },
+            {
+              "wastedBytes": 24335,
+              "totalBytes": 43332,
+              "wastedPercent": 56.160625274155592,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            },
+            {
+              "totalBytes": 27871,
+              "wastedPercent": 75.1296024165238,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "wastedBytes": 20939
+            }
+          ]
+        },
+        "numericValue": 1350,
+        "numericUnit": "millisecond"
+      },
+      "layout-shifts": {
+        "id": "layout-shifts",
+        "title": "Avoid large layout shifts",
+        "description": "These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "2 layout shifts found",
+        "metricSavings": {
+          "CLS": 0.002
+        },
+        "details": {
+          "items": [
+            {
+              "score": 0.002049,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "extra": {
+                      "type": "node",
+                      "lhId": "page-10-IMG",
+                      "boundingRect": {
+                        "left": 0,
+                        "top": 0,
+                        "height": 0,
+                        "width": 0,
+                        "right": 0,
+                        "bottom": 0
+                      },
+                      "nodeLabel": "Ocobo",
+                      "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                      "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                      "path": "1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG"
+                    },
+                    "cause": "Media element lacking an explicit size"
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                      "type": "url"
+                    }
+                  },
+                  {
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  },
+                  {
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  }
+                ]
+              },
+              "node": {
+                "boundingRect": {
+                  "width": 0,
+                  "bottom": 0,
+                  "right": 0,
+                  "left": 0,
+                  "top": 0,
+                  "height": 0
+                },
+                "type": "node",
+                "lhId": "page-8-H1",
+                "selector": "div.mx_auto \u003e div.d_flex \u003e div.lg:w_1/2 \u003e h1.text",
+                "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,0,DIV,1,H1",
+                "nodeLabel": "Rejoignez les\narchitectes.",
+                "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark mb_10 white-space_pre-line\"\u003e"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                      "type": "url"
+                    }
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                      "type": "url"
+                    }
+                  }
+                ],
+                "type": "subitems"
+              },
+              "score": 0
+            }
+          ],
+          "type": "table",
+          "headings": [
+            {
+              "label": "Element",
+              "subItemsHeading": {
+                "key": "extra"
+              },
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "cause"
+              },
+              "granularity": 0.001,
+              "valueType": "numeric",
+              "key": "score",
+              "label": "Layout shift score"
+            }
+          ]
+        }
+      },
+      "total-blocking-time": {
+        "id": "total-blocking-time",
+        "title": "Total Blocking Time",
+        "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).",
+        "score": 0.32,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "890 ms",
+        "numericValue": 892,
+        "numericUnit": "millisecond"
+      },
+      "speed-index": {
+        "id": "speed-index",
+        "title": "Speed Index",
+        "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).",
+        "score": 0.8,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "4.1 s",
+        "numericValue": 4071.7143385049394,
+        "numericUnit": "millisecond"
+      },
+      "duplicated-javascript-insight": {
+        "id": "duplicated-javascript-insight",
+        "title": "Duplicated JavaScript",
+        "description": "Remove large, [duplicate JavaScript modules](https://developer.chrome.com/docs/performance/insights/duplicated-javascript) from bundles to reduce unnecessary bytes consumed by network activity.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "Source",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "valueType": "code",
+              "key": "source"
+            },
+            {
+              "granularity": 10,
+              "valueType": "bytes",
+              "key": "wastedBytes",
+              "label": "Duplicated bytes",
+              "subItemsHeading": {
+                "key": "sourceTransferBytes"
+              }
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 0,
+            "type": "debugdata"
+          },
+          "items": []
+        }
+      },
+      "cumulative-layout-shift": {
+        "id": "cumulative-layout-shift",
+        "title": "Cumulative Layout Shift",
+        "description": "Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/articles/cls).",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "0.002",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "newEngineResultDiffered": false,
+              "cumulativeLayoutShiftMainFrame": 0.002049
+            }
+          ]
+        },
+        "numericValue": 0.002049,
+        "numericUnit": "unitless"
+      },
+      "server-response-time": {
+        "id": "server-response-time",
+        "title": "Initial server response time was short",
+        "description": "Keep the server response time for the main document short because all other requests depend on it. [Learn more about the Time to First Byte metric](https://developer.chrome.com/docs/lighthouse/performance/time-to-first-byte/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Root document took 40 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 0,
+          "items": [
+            {
+              "responseTime": 39,
+              "url": "https://www.ocobo.co/jobs"
+            }
+          ],
+          "type": "opportunity",
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "label": "Time Spent",
+              "valueType": "timespanMs",
+              "key": "responseTime"
+            }
+          ]
+        },
+        "numericValue": 39,
+        "numericUnit": "millisecond"
+      },
+      "total-byte-weight": {
+        "id": "total-byte-weight",
+        "title": "Avoids enormous network payloads",
+        "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn how to reduce payload sizes](https://developer.chrome.com/docs/lighthouse/performance/total-byte-weight/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Total size was 1,909 KiB",
+        "details": {
+          "sortedBy": [
+            "totalBytes"
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "key": "totalBytes"
+            }
+          ],
+          "items": [
+            {
+              "url": "https://www.ocobo.co/images/jobs/seminaire.jpeg",
+              "totalBytes": 251265
+            },
+            {
+              "totalBytes": 204725,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "totalBytes": 157188
+            },
+            {
+              "totalBytes": 135167,
+              "url": "https://www.ocobo.co/images/jobs/cafet.jpeg"
+            },
+            {
+              "totalBytes": 124999,
+              "url": "https://www.ocobo.co/images/jobs/bureau-1.jpeg"
+            },
+            {
+              "totalBytes": 115932,
+              "url": "https://www.ocobo.co/images/jobs/bureau-3.jpeg"
+            },
+            {
+              "totalBytes": 115414,
+              "url": "https://www.ocobo.co/images/jobs/bureau-2.jpeg"
+            },
+            {
+              "totalBytes": 105040,
+              "url": "https://www.ocobo.co/images/jobs/rooftop.jpeg"
+            },
+            {
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "totalBytes": 51336
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 1955192,
+        "numericUnit": "byte"
+      },
+      "main-thread-tasks": {
+        "id": "main-thread-tasks",
+        "title": "Tasks",
+        "description": "Lists the toplevel main thread tasks that executed during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "headings": [
+            {
+              "label": "Start Time",
+              "valueType": "ms",
+              "key": "startTime",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "label": "End Time",
+              "valueType": "ms",
+              "key": "duration"
+            }
+          ],
+          "items": [
+            {
+              "startTime": 882.429,
+              "duration": 24.579
+            },
+            {
+              "startTime": 1021.339,
+              "duration": 6.337
+            },
+            {
+              "startTime": 1029.434,
+              "duration": 23.674
+            },
+            {
+              "startTime": 1053.127,
+              "duration": 121.3
+            },
+            {
+              "duration": 7.314,
+              "startTime": 1179.967
+            },
+            {
+              "startTime": 1190.612,
+              "duration": 15.375
+            },
+            {
+              "startTime": 1207.629,
+              "duration": 5.561
+            },
+            {
+              "duration": 22.583,
+              "startTime": 1217.539
+            },
+            {
+              "startTime": 1240.6,
+              "duration": 10.106
+            },
+            {
+              "startTime": 1252.974,
+              "duration": 12.011
+            },
+            {
+              "startTime": 1266.206,
+              "duration": 11.209
+            },
+            {
+              "startTime": 1278.204,
+              "duration": 9.193
+            },
+            {
+              "startTime": 1288.929,
+              "duration": 5.405
+            },
+            {
+              "startTime": 1303.177,
+              "duration": 113.691
+            },
+            {
+              "startTime": 1429.518,
+              "duration": 82.697
+            },
+            {
+              "startTime": 1518.374,
+              "duration": 31.224
+            },
+            {
+              "duration": 20.338,
+              "startTime": 1552.325
+            },
+            {
+              "startTime": 1573.673,
+              "duration": 5.562
+            },
+            {
+              "startTime": 1579.469,
+              "duration": 33.272
+            },
+            {
+              "duration": 8.746,
+              "startTime": 1614.203
+            },
+            {
+              "duration": 18.878,
+              "startTime": 1623.161
+            },
+            {
+              "startTime": 1645.283,
+              "duration": 24.564
+            },
+            {
+              "duration": 18.323,
+              "startTime": 1670.646
+            },
+            {
+              "startTime": 1690.666,
+              "duration": 10.562
+            },
+            {
+              "startTime": 1703.047,
+              "duration": 9.227
+            },
+            {
+              "startTime": 1717.031,
+              "duration": 13.556
+            },
+            {
+              "startTime": 1731.234,
+              "duration": 11.106
+            },
+            {
+              "startTime": 1742.742,
+              "duration": 9.859
+            },
+            {
+              "startTime": 1752.661,
+              "duration": 5.955
+            },
+            {
+              "duration": 311.431,
+              "startTime": 1758.632
+            },
+            {
+              "startTime": 2072.967,
+              "duration": 5.951
+            },
+            {
+              "startTime": 2079.031,
+              "duration": 5.597
+            },
+            {
+              "startTime": 2088.99,
+              "duration": 6.119
+            },
+            {
+              "startTime": 2095.231,
+              "duration": 29.601
+            },
+            {
+              "duration": 15.493,
+              "startTime": 2125.23
+            },
+            {
+              "startTime": 2141.923,
+              "duration": 8.796
+            },
+            {
+              "duration": 9.681,
+              "startTime": 2152.443
+            },
+            {
+              "startTime": 2162.226,
+              "duration": 61.174
+            },
+            {
+              "startTime": 2225.483,
+              "duration": 6.102
+            },
+            {
+              "startTime": 2231.632,
+              "duration": 8.965
+            },
+            {
+              "startTime": 2240.677,
+              "duration": 6.71
+            },
+            {
+              "startTime": 2247.395,
+              "duration": 35.306
+            },
+            {
+              "duration": 6.745,
+              "startTime": 2283.631
+            },
+            {
+              "startTime": 2290.556,
+              "duration": 112.293
+            },
+            {
+              "startTime": 2402.913,
+              "duration": 5.487
+            },
+            {
+              "startTime": 2408.431,
+              "duration": 9.259
+            },
+            {
+              "startTime": 2418.436,
+              "duration": 5.684
+            },
+            {
+              "startTime": 2424.133,
+              "duration": 14.497
+            },
+            {
+              "startTime": 2438.728,
+              "duration": 6.69
+            },
+            {
+              "startTime": 2445.853,
+              "duration": 6.525
+            },
+            {
+              "startTime": 2452.407,
+              "duration": 5.289
+            },
+            {
+              "startTime": 2461.658,
+              "duration": 5.292
+            },
+            {
+              "startTime": 2467.004,
+              "duration": 5.942
+            },
+            {
+              "duration": 5.581,
+              "startTime": 2473.462
+            },
+            {
+              "duration": 6.035,
+              "startTime": 2479.092
+            },
+            {
+              "startTime": 2485.137,
+              "duration": 6.534
+            },
+            {
+              "duration": 5.484,
+              "startTime": 2491.705
+            },
+            {
+              "startTime": 2497.202,
+              "duration": 5.44
+            },
+            {
+              "startTime": 2502.655,
+              "duration": 161.762
+            },
+            {
+              "startTime": 2664.57,
+              "duration": 21.804
+            },
+            {
+              "startTime": 2693.776,
+              "duration": 12.533
+            },
+            {
+              "startTime": 2706.397,
+              "duration": 15.762
+            },
+            {
+              "duration": 21.1,
+              "startTime": 2722.613
+            },
+            {
+              "startTime": 2747.22,
+              "duration": 7.615
+            },
+            {
+              "startTime": 2759.971,
+              "duration": 6.742
+            },
+            {
+              "startTime": 2769.298,
+              "duration": 101.448
+            },
+            {
+              "startTime": 2878.865,
+              "duration": 6.793
+            },
+            {
+              "startTime": 2885.666,
+              "duration": 5.345
+            },
+            {
+              "startTime": 2892.039,
+              "duration": 8.944
+            },
+            {
+              "startTime": 2901.063,
+              "duration": 5.295
+            },
+            {
+              "startTime": 2906.369,
+              "duration": 5.942
+            },
+            {
+              "startTime": 2912.515,
+              "duration": 7.637
+            },
+            {
+              "startTime": 2920.7,
+              "duration": 5.675
+            },
+            {
+              "duration": 22.081,
+              "startTime": 2926.892
+            },
+            {
+              "startTime": 2949.177,
+              "duration": 8.839
+            },
+            {
+              "duration": 7.196,
+              "startTime": 2958.426
+            },
+            {
+              "startTime": 2965.65,
+              "duration": 5.431
+            },
+            {
+              "startTime": 2971.106,
+              "duration": 9.889
+            },
+            {
+              "startTime": 2984.482,
+              "duration": 20.382
+            },
+            {
+              "startTime": 3006.972,
+              "duration": 141.867
+            },
+            {
+              "startTime": 3153.823,
+              "duration": 18.025
+            },
+            {
+              "startTime": 3178.434,
+              "duration": 44.651
+            },
+            {
+              "startTime": 3224.686,
+              "duration": 5.26
+            },
+            {
+              "startTime": 3230.446,
+              "duration": 24.941
+            },
+            {
+              "startTime": 3255.944,
+              "duration": 13.597
+            },
+            {
+              "duration": 142.565,
+              "startTime": 3271.766
+            },
+            {
+              "startTime": 3420.228,
+              "duration": 7.656
+            },
+            {
+              "startTime": 3427.896,
+              "duration": 18.412
+            },
+            {
+              "startTime": 3452.877,
+              "duration": 14.728
+            },
+            {
+              "startTime": 3467.765,
+              "duration": 23.383
+            },
+            {
+              "startTime": 3492.309,
+              "duration": 110.166
+            },
+            {
+              "startTime": 3602.511,
+              "duration": 131.564
+            },
+            {
+              "startTime": 3736.969,
+              "duration": 9.333
+            },
+            {
+              "startTime": 3747.506,
+              "duration": 34.142
+            },
+            {
+              "startTime": 3782.739,
+              "duration": 40.052
+            },
+            {
+              "startTime": 3828.661,
+              "duration": 13.97
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "long-tasks": {
+        "id": "long-tasks",
+        "title": "Avoid long main-thread tasks",
+        "description": "Lists the longest tasks on the main thread, useful for identifying worst contributors to input delay. [Learn how to avoid long main-thread tasks](https://web.dev/articles/optimize-long-tasks)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "13 long tasks found",
+        "metricSavings": {
+          "TBT": 900
+        },
+        "details": {
+          "sortedBy": [
+            "duration"
+          ],
+          "type": "table",
+          "debugData": {
+            "urls": [
+              "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "https://www.ocobo.co/jobs",
+              "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            ],
+            "type": "debugdata",
+            "tasks": [
+              {
+                "other": 194,
+                "startTime": 8851.1,
+                "urlIndex": 0,
+                "duration": 194
+              },
+              {
+                "scriptEvaluation": 0,
+                "duration": 187,
+                "urlIndex": 1,
+                "startTime": 7530.1,
+                "other": 187
+              },
+              {
+                "urlIndex": 2,
+                "duration": 170,
+                "other": 170,
+                "startTime": 8435.1,
+                "scriptEvaluation": 0
+              },
+              {
+                "duration": 158,
+                "urlIndex": 2,
+                "startTime": 12064.7,
+                "other": 158,
+                "scriptEvaluation": 0
+              },
+              {
+                "scriptEvaluation": 0,
+                "other": 136,
+                "startTime": 5288,
+                "duration": 136,
+                "urlIndex": 3
+              },
+              {
+                "urlIndex": 1,
+                "duration": 135,
+                "startTime": 3956.3,
+                "other": 135
+              },
+              {
+                "urlIndex": 1,
+                "duration": 132,
+                "startTime": 4137.3,
+                "other": 132
+              },
+              {
+                "scriptEvaluation": 0,
+                "startTime": 7736.1,
+                "other": 122,
+                "urlIndex": 3,
+                "duration": 122
+              },
+              {
+                "urlIndex": 3,
+                "duration": 99,
+                "other": 99,
+                "startTime": 5424,
+                "scriptEvaluation": 0
+              },
+              {
+                "scriptEvaluation": 0,
+                "startTime": 8030.1,
+                "other": 86,
+                "duration": 86,
+                "urlIndex": 1
+              },
+              {
+                "paintCompositeRender": 0,
+                "scriptEvaluation": 0,
+                "duration": 73,
+                "urlIndex": 4,
+                "styleLayout": 0,
+                "startTime": 959,
+                "other": 73
+              },
+              {
+                "duration": 73,
+                "urlIndex": 1,
+                "startTime": 3841.3,
+                "other": 73
+              },
+              {
+                "duration": 54,
+                "urlIndex": 5,
+                "startTime": 7930.1,
+                "other": 54,
+                "scriptEvaluation": 0
+              }
+            ]
+          },
+          "skipSumming": [
+            "startTime"
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Start Time",
+              "valueType": "ms",
+              "key": "startTime",
+              "granularity": 1
+            },
+            {
+              "key": "duration",
+              "label": "Duration",
+              "valueType": "ms",
+              "granularity": 1
+            }
+          ],
+          "items": [
+            {
+              "duration": 194,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "startTime": 8851.0670720304533
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "duration": 187,
+              "startTime": 7530.0564817098566
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "duration": 170,
+              "startTime": 8435.0635419235878
+            },
+            {
+              "startTime": 12064.733796849747,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "duration": 158
+            },
+            {
+              "duration": 136,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "startTime": 5288.00773568264
+            },
+            {
+              "duration": 135,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "startTime": 3956.2675542701409
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "duration": 132,
+              "startTime": 4137.2675542701418
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "duration": 122,
+              "startTime": 7736.0564817098566
+            },
+            {
+              "startTime": 5424.00773568264,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "duration": 99
+            },
+            {
+              "startTime": 8030.0564817098566,
+              "duration": 86,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js"
+            },
+            {
+              "url": "https://www.ocobo.co/jobs",
+              "duration": 73,
+              "startTime": 959.00470680915441
+            },
+            {
+              "duration": 73,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "startTime": 3841.2675542701409
+            },
+            {
+              "startTime": 7930.0564817098566,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "duration": 54
+            }
+          ]
+        }
+      },
+      "legacy-javascript-insight": {
+        "id": "legacy-javascript-insight",
+        "title": "Legacy JavaScript",
+        "description": "Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile [Baseline](https://web.dev/articles/baseline-and-polyfills) features, unless you know you must support older browsers. [Learn why most sites can deploy ES6+ code without transpiling](https://developer.chrome.com/docs/performance/insights/legacy-javascript)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 14 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 13897,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "location": {
+                      "urlProvider": "network",
+                      "column": 6239,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1,
+                      "type": "source-location"
+                    },
+                    "signal": "Array.prototype.concat"
+                  },
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 12925,
+                      "urlProvider": "network"
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "signal": "Object.assign",
+                    "location": {
+                      "line": 1,
+                      "type": "source-location",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 12813,
+                      "urlProvider": "network"
+                    }
+                  },
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 10857,
+                      "urlProvider": "network"
+                    },
+                    "signal": "Object.create"
+                  }
+                ]
+              },
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "wastedBytes": 13897
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "signal": "Array.prototype.concat",
+                    "location": {
+                      "urlProvider": "network",
+                      "column": 6239,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "type": "source-location",
+                      "line": 1
+                    }
+                  },
+                  {
+                    "signal": "Array.prototype.slice",
+                    "location": {
+                      "type": "source-location",
+                      "line": 1,
+                      "column": 12925,
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    }
+                  },
+                  {
+                    "location": {
+                      "column": 12813,
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1,
+                      "type": "source-location"
+                    },
+                    "signal": "Object.assign"
+                  },
+                  {
+                    "signal": "Object.create",
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network",
+                      "column": 10857,
+                      "type": "source-location",
+                      "line": 1
+                    }
+                  }
+                ]
+              },
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "wastedBytes": 13897
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "subItemsHeading": {
+                "valueType": "source-location",
+                "key": "location"
+              },
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "subItemsHeading": {
+                "key": "signal"
+              },
+              "valueType": "code",
+              "key": null
+            },
+            {
+              "label": "Wasted bytes",
+              "valueType": "bytes",
+              "key": "wastedBytes"
+            }
+          ]
+        }
+      },
+      "screenshot-thumbnails": {
+        "id": "screenshot-thumbnails",
+        "title": "Screenshot Thumbnails",
+        "description": "This is what the load of your site looked like.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "scale": 3000,
+          "items": [
+            {
+              "timing": 375,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEABALDA4MChAODQ4SERATGCgaGBYWGDEjJR0oOjM9PDkzODdASFxOQERXRTc4UG1RV19iZ2hnPk1xeXBkeFxlZ2MBERISGBUYLxoaL2NCOEJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY//AABEIAfIA+gMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/APQKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoA//9k=",
+              "timestamp": 5249460524
+            },
+            {
+              "timing": 750,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 5249835524
+            },
+            {
+              "timestamp": 5250210524,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timing": 1125
+            },
+            {
+              "timestamp": 5250585524,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAEkQAAEEAQMDAQYCBwYDBQcFAAEAAgMEEQUSIQYTMUEHFCJRYXEygRUjQlORkrEIFjVSYqEXM3IkN0OCgxgnc7KzwdE0dHWi8f/EABkBAQEBAQEBAAAAAAAAAAAAAAABBAMCBf/EACcRAQACAQEHBQEBAQAAAAAAAAABEQIDBCEycXKywRIUMTNSQiIj/9oADAMBAAIRAxEAPwD1SiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICL45wa0ucQGgZJPgKvRdcdKzah7jF1FpL7edoibaYST8vPn6ILEiEgDJPHzVdPXHSzb/uR6i0kW87e172zdn5efP0QWJEBBAIOQfVRWs9Q6Xor2N1W17ox+MTSxuEQ+8mNo/MoJVFQvbXa/90mv2ac/BrtcyWJ/kFzeQQpY9X9PaNUoVtX1zTqdp0Mf6uew1ruWjkgnhBZ0XXWsQ2oGT1pY5oZBuZJG4Oa4fMEeVC6v1j03o9sVdV13TKlnOO1NZY1w+4J4/NBPIuqpZguV2WKk0c8EgyySNwc1w+YI8rtQEREBERAREQEREBERARF8e7a0lALg3yQF8EjD4cFF6lqNTT4DY1G1DWhyG9yZ4Y3J8DJWBT6l0O7ZZXp6xp89iQ4ZHHYY5zvsAUFlRdFd5Pwn8l3oCIiAiIg1v7cJ5n6PoekNmfXqaxqsFG3Iw7T2XElzc+mcYVjt9C9MWNBdpD9FoNo7CwNbC0FvGNwdjId9fKzOrunaPVWhT6XqbXdmTDmvYcPieOWvafQgqny9F9Z2aR0y11492mub23vZp7G2XM8Edzd5x64ygoh13Up/YfTouuylkmsDRHX2uw59bulu/P1aNuVtxnQPSrdD/RI0LT/ctmzBhbu8Yzu87vrnK5zdE6JL0SOlTWI0lsQia0H4mkHIeD/m3c5+arTeietGVP0c3r+X9GhvbDjp7DZ2eMd3PnHrjKCG9oNqz0J7FDX6d1ia2Y5W02XnPDnwxueQRuHq0fCD5C2L0/05pmn9OM06OIWK80IbO+Y9x1jI5c8n8ROV16d0bolLo9vTIqNm0ntmN8c3xGTJyXOP+YnnPzWK7p7VNM0UaP0xfbWrbO2yxde6xJXb4wxvGcem5xwg0rXnlr+yL2oaA2V82naNefXpvcc7Y+4Pgz9Mf7rc/RPSmjU+k6kZq1rzrddklmzMwSOtOc0EucT5BzwPQKPHszoV/Zre6SoWZI/fQXT3JG73ySFwJe4cZzjCR9HdR6TU9w6X6pjpaaG7Y4bVEWHVx6iN24cfIOzhBVOn7c3SH/FHStEJdQ0eL3yjF+IQPfE57mD6AjOFafZZ0locPQ2m2X06t61qNdtm3anjbI+d8g3OySORk+FNdF9HU+mdHtVDLJfs3pHTXrVgAvsvd5LvpjgBV2l0F1D0+ySl0h1b7jo5c50VS3SbZNfJyQxxIOPkDlB0ez6GPQPaf1Z03pY2aMyGC9HADlteR+Q5rfkD5wtoKs9EdIwdLw3JH259Q1S9J3rl6f8AHM70GBwGgcADwrMgIiICIiAiIgIiICIiAuE4zEVzQ8oK71GLJ00+5C8Ztw//AEXZ7mP/AFfhx/uoLRW6v+lIPeh1F2cnd70KPb8H8Xb+P+Cuz4SD8PIXERPJ/Cg+wD9YFlLhFGGD6rmgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIePKKldXalK+46pG4tijA3AH8RIyjlrasaWPqlcDYhH/is/mT3mH96z+ZaM6q6rpdNTUo70NmQ29+wwtadu0tBzlwP7Q8ZK56j1NWo9RUtGNa1LatRiVrowzY1pdtydzgePOACcKWyRtmU7/S3h7zD+9Z/MnvMP71n8y0JqXW+mUOoTo8kVx9hr42SSRxgxxueMtBOc+OeAV36v1ZR0vqKno1iG06zaaxzHxtaWDe4tGfiz5afAKWvvM/w3p7zD+9Z/MnvMP71n8y0fF1PSk6iOjNise9CR8e4tbsy2NjzznPh49POU03qSK/1Dd0hun6jDNUG5800TRERkhpBDicOwSOOQClp7zL8t4e8w/vWfzJ7zD+9Z/MtGaR1TV1Szq0NetaaNNfJHNI8M2ucwkENAcT6cZAWJ0v13pPUmox0tObZEzqxsnuNaA0B20tOHH4vX5Y9Utfd57/8fDf3vMP71n8ye8w/vWfzLRWl9WU9Sj1eSGtbZFphkbK54Z8ZZnIaA4n9k+QF96f6toa/TuWNNhtSCrG17mbBucXNLtrRn8XGMccpZO2Zx/LenvMP71n8y7Gua8ZaQR8wtH9L9QRdQ1Zp4KV6qyKQxH3qNrC5wODjBPgggq0aTqM2n2mPjce3n42Z4ISyNtrKssabJRAcgEeqKt4iIgIiICIiAiIgIiICIiAiIgIiICpXV2mysuOuRtLopANxH7JAwrqh58o5a2lGrj6ZaU1jQdN1mWvJqVbvSV93advc0syQSQQRz8I5+i4ah07peoapU1K5V7l2pt7MvccNu124cA4PPPK3Sa0B8wx/yhPdYP3Mf8oUpkjYso+MmkrvS+i3tXj1S1p8Ul5ha4Skny38JIzgkfULuu6Bpt7VYNSs1t96ANbHMHuaWhpJA4PjLj988rc/usH7mP8AlCe6wfuY/wCUJR7LL9tNs0TTmaw/VW1Wi+8EGXJ9QATjOAcADOM4CyIqNeG/Yuxx4s2GsZK/J+IMztGPHG4/xW3PdYP3Mf8AKE91g/cx/wAoSk9jlP8ATStDpvSaF29bqVO3YvbveHdxx37jk8E4GT8sLjpfS+jaXcitafRZBYih7DXtc78HyPPPgcnnhbs91g/cx/yhPdYP3Mf8oSl9ln+2k6PTOkUX6g+rU7btQDhZ/WPPc3Zz5PHk+MLv0fQ9O0YznTKra/e29za4ndtG0eT8luX3WD9zH/KE91g/cx/yhKJ2LKfnNqPT6NfT4HQ04+3G6R8pGScuc4ucefmSVMaRp02oWmMjae2D8b/QBbE91g/cx/yhdjWtYMNAA+QSjHYd95ZW+gYAA9ERFX0BERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBad9o/txrdE9WWdDl0Oa4+BjHmZtkMB3NDvG0/NbiXiz+0z/3vap/8GD/AOk1Bs2H+05pxkaJ+mrbI/VzLLXEfkWj+q3T0X1VpfWOgxatosrn1nktc142vjcPLXD0K8Yzi11toXTukdM9OSyXdJgey1PAwF05e4FpdgeBjyfmVeb1rqf2N+y6rpm9tLWdcuSzktIe6vExjGkA+A4kjkZx9/BHrJU32rnq0dJv/uH2/wBLdxu7O3d28HOzd8O7OPPpn1Xjkaj1k+gNZGt3zG52A79J/rXHOMiPfvIz64wti3etOrdS9iWqR69+kYLNS3W93vvY+F0zHF2W7uNxGPP15Qbb9h7vaO517/iAD7lsHu/fDBNvzz+D9nGfxc5xhbYXhbob2k630sdXsxXrFm5PU93r+8yukbG4yMJftJxkNBx91yqf8RepNK1DqWtc1m3RqOcbFltstDCBudhu4HABB4HAQeyeujrzelNQPSLYXa3sHu4lxjORnzxnGcZ4ytS+yY+17++EX97RN+hMO94967X+U7dm3nOceOFr/pX2na7rPs16v0XVr009qrRbZq3NxEwaJWNc0uHJ/EMHz5UJ7EOrNQo9dC7qWoXrVSpRt2XxSTucHBkLneCceiD2mi8Tt6o9ontM6qk/Qtu8+ywGeOpUsdmOBgcMeSBwSBk8lQfXPVHVk3VV861cu0dSYWR2IIp3Ma17WNaSADgZxnjjlB70ReBequoNZj1SEM1fUGg0absCy8cmtESfPqSSpn2i3ur6cfS1rWNXftsaVBLSFWd4McW0AF3j4zjJPOSfKFvcKLx7qntl6lZ7M9E06tqErNSkdMyxez+udG0gMAd6Hk5d5+Ec8lUv3/rOtUr6q3WtQAmcO2WanumJPgmMP3gfUhFe9kXjTrnrPq/VuhOn/wBMDVKd+vZnj94DHwGzGWxlrjjGSDkZ+3zVF0rUOqdW1GGhpt/WLNyV21kMdiQuJ+2UR+gq8le1T2s9baJ7Qtd03S9bdBSrWCyKP3aF20YHGSwk/mV6F9kuiat090Fp2ndQzmfU2b3yuMpkI3PLgC4+cAgfkvIPtu/72Opv/wB0f/lCD2t0bcn1DpDQ7tyTuWbNGCaV+ANz3RtJOBwOSfCmF4s669pXUNmHSOntGv2KOn06FSDbXeY3TSdlm4ucOcZOMZxwoiprHXvTesV/c9V1CW2fjbHXuC4130c1jnD8jyg91JkHwV5C9t3XPWF+PQxaZqGi0bFFkjoWh8IkmyRJnweCOAfTB9VSulNP6r1RjbPT+s/9qLjtrt1VsVhxHyYXglC3vJFX/Z9+kv7k6KNd736UFZgs9/8AHvxzu+qsCKIiICIiAiIgLyL/AGh+leodU9qepWtM0LVblV8UIbNXpySMJEbQcOAI8r10iDxb1L7MupKOgdN6zo2j6n3p6my3DBC/vQzNc4ZLANwBbt9PQ/NSmlezHqnqj2ZzvnqX49Z0/UHyQ1tQa+N80Toow4N349WjHpwV6+RB4dq6J7TKemHQ6mka/BTMm8siqObznP8AzAM4zzjOFcOqOmOpOnfYhqM3WOo2pLd25XEFOeyZey1pcfUkBxzyB6Afl6yWi/7QHs26k666i0qXQmVzVgrGOR804Y0O3E+OSePoiNBezHoqfrqfWtPovY2/BR95rh5w17hIwFpPpkOPPzwpKtoftP0HTL3T9PS9fh0+2SLEEFdz435GD8QBHIABweQvRfsQ9lP/AA+it3NQtR2tXtsEbjED24mA52tJ5OTgk4HgfnIe0L2u6B0JrkWlaxW1KWxJA2wHVomObtLnNHJeDnLT6INLdL+ybXtF9mvVmp6lRm/Sl2k2tVoRN7k23usc4kNzydo488HKh/Yh0NrZ68jh13QtWp6dYp2a8s09SSNoD4XN/E4YzyvVPRXU1LrDpurremRzx1LJeGNnaGvG15acgEjy0+qwvaF1xpHQmkR39aMxbK/txRQs3PkdjOBnAHHqSg8iTdB9Y9P6x3ulxbuwuJbX1LR5S5sjCfJcw5b9QcYVR6opT6f1BeqXbbbluKTbNO1+8Okx8XxeuDkZ9cKY6X6X1TqzUdRh6Xna8wMNhzZ5RXd284Ljk7eMjPxeq2D0J7CLupatX/vFq2mV6u7Lq9a02aeUDkgbeB98n7IKR1B0h1LfuVbNHp/V7NZ9CnslhpSPY7FaIHDg3B5BV69svS3UF/SegWUdC1Wy+toFeGZsNSR5ieGjLXYHDh8jyvWVWCKrWir12COGJgYxg8NaBgBdiFPHFf2R9Rax7Mql6rplqHVqVudslKzGYpJYiGEOaHAZwd33zx4UNX0f2n/o6DRa+ldQQ1IX5YxlV0QBz6yADI59The4ERXl3Uq/tS6J6Kq6dU/S+oajqpfLYlhbLbfSY0ANja4ZDXHLiSPpjxlav03QvaJpdua1pmldWU7M3/Mmgr2I3v5zyQMle6LWo0qkgZbuVoHkbg2SVrSR88Erur2IbMQlrSxzRngPjcHA/mEFV9kh1Q+znQzr/vn6T7Tu/wC+7u9ne78W7nOMeV5b9sPSHUt/2m9Q2qPT2sWa0tkuZLDSkex4wOQQ3BXtJEHjvr/2RdSwRaTrWi6dZtxWaNZ00ETD3q0whYHAs8+RnjwcgrBraH7WOpNTrN9112vIwCNskjHU44x8zw0fn5K9pIg8v9edP+07p27BX0l2o65poqwiV8jG3GSShvxkxv3Ec5xx4wtYv6G646h1h0o6VvQWJSM7aHucQPjONrWhe7kQQfQ2nX9J6P0fT9Yse8ahXrMjmk3bsuA+frjxn1wpxEQEREBERAREQFrf2te1jTfZ66tVkqyX9TsM7ja7HhgYzONznYOMkHHHoVsheOP7U1WzD7UpJ52u7FipE6Bx8FoG0gf+YH+KDYU39pSn/d6K1Bom7VO/25ab7BADMEh7X7TnxgjAwuVb+0RPN0vqGr/3bjBq269bte+n4u6yZ27OzjHa8Y/a+i0X1l1Hoet6PpVfRulq+jz1G7Z7MUpcZzj14HqCcnJXTpv/AHY6/wD/AMrQ/wDpW0Ru2P8AtMdzS70jtAjhus2CtF7yXtkJJ3Fx2jAAH5khTNn+0FVodF6VqVrSxNrN/uOFOKXaxjGvLdznEEjJbwMHwVRf7Kei6ZrOsdQM1bT6l1kcERYLETZA0lzs4yOFDf2m9Gj0b2gwsp046mnyUozAyGMMYMF24ADjOeT90Fuqf2nLgsD3zpqu6AnxFaIcB+bcH/ZUP+0B1PQ6v6o0fWdKL/d59KjBY8YdG4SygtP1BWJrXXXTt/RdJpRdCaXFNTaGzTd17TNhuDyzaeTzySqz1bLXsTafZpaNHo9aeqHshZM+QPxI9pfl5JGS0jHjj6oNkdO+2DVujPZ903pmg0oniPvmzPaicWOcZnODGEEeGkE/9QWw+pvazouveySrrmpdN1dUcb7aVnT7EmGwyGN7t7XbSfDeOAeT8lrHq1o/9nPoV2Bn3+1z/wCpJ/8AhU+g4/8AC7W25O0avRIH/o2v/wAINm6X11pVv2cdas6d6Iq6W/3VkEr68xkcWS7mlxOzOG4zjx9lrH2X67Z6b660vVqWnv1KxXMm2qwkF+6NzT4BPAcT49Fd/YbE+boz2nRxNL3u0cgNHk/DIqZ7KOpKnSPX+la3qUc0lSqZd7YQC87onsGASB5cPVB6T9o3t60npXWZ9J07T5NVuV3bJ3CURxscPLc4JJHrxwobpj+0npt7UYa+u6NLp0Ejg33iOfvNYT6uG0HH1GfsvO+oWGRdbz29TgkdA+4bD45Y9znMe7cDtyAcgg4zg/NTWo6v0dZ6gdMzQtRt13BrWsjlipBx+kUbHAfzFB6O9q3tu0/orVBpWn0f0pqAY2SX9bsjiDhloJwSSQQcfIjlUfSv7TcvvLRqvTkfu5PLq1g7mj7OGD/ELUftPqTaT7QbDbtGSJobXkbWneXnt9pmGF37WANpP0Kk+quu+mtZvVJq3QOlVYoY9j42zSM3n/09g/iCUGT/AGiOpYuqOu4LlSFzaLKEDK0pz+vY4GTfjHGDIW455afstlewL2g1enfZhqP6dqS1tN0p4dFZGXG0+V7zsYMAZBGPJ884Wqva/CRW6NsxaV+iqs+jAxVg90jWfr5nYDncnh7Xc+Ny43Op6+oexfT+mKsFs3NOuuu2X7B2u24uaOc58yN8hBtOx/adYLLhW6Yc6vnh0lza4j7BhH+6vvTntu6c1fpHVNaljsVZtMY19im7Dnncdrdh8OBJAzxj1wvLHTeq6BV6b1Grq9OWa7Kf1Loq8ZcRj968kx4/0tKtXR13pJvTHUs0vS+qOqR1YorU/wCkQ44fPGGho2BocCNwz/lI9UF0t/2nLpsH3Ppuu2DPAlsuLiPyaAFsv2Pe1uP2iXrlJ2kvoWa0ImJEwkY4ZA+QOeV5Xsv6f0h0epdM6rZs2muwKmpaZG4Bp85Jc5hx9v4La3sY9o2m0IOpdX1Dp6nXuUKAlfZ06Lsidpka0McwHaHFzm8gDjPyQepEWlfZb7co+teq4tDtaMaMthr3QSMm7gJa0uIcMDHAPP0W6kUREQEREBERAREQFBdW9JaH1bSZV6g0+K5Gw7mF2WvYf9LhghTqINfzeyDouXQIdGOlFtKOc2AGTPa9z8EZc7OTwcYJ4XRF7FuiYtJs6azTpxUsTRzyN96kyXxh4ac5z4kf/FbHRBUuiPZ5070TYtTdPVJK8llrWSl8z5MgEkfiJx5Up1R0vovVVFtTX9PhuwtO5m8Ycw/NrhyPyKmUQa0q+w7oCvOJRopkIOdslmRzf4blI9UeyjpDqa5Xs6pppL69dtWJsMzomMjaSQ0NaQP2ir0iCjXfZX0pd6X0/p6xRmdpdCR8sEYsPBa5xJJLs5PLj5WDH7FuiY9JsaazTpxUnmjsSN96kyXxte1pznPiR/8AFbHRBUuifZ5050VLbk6fpyQOttayXfM+TcG5x+In5lQ2p+xboTUb8lubRBHLI7e5sMz42E/9IOB+S2MiCmdRezHpHqGGpHqmjxPNWJsEUjHuY8MaMBpcCCQAPXK6OmvZN0Z05fjvabo0fvcZzHJPI6UsPzAcSAfqr0iCudXdEdO9XsjHUGlw23xjDJeWSNHyDmkHH08KuaX7Feg9OtMsRaI2WRjtzRPM+Ruf+knB/NbGRBB9U9J6H1VpzKOu6fDarsOYwctdGf8AS4YI/JQnS/ss6Q6ZsWZtL0oB9mJ0EomldK10ZxlpDiRg4Cu6INZz+w3oCawZTormEnOxlmVrf4blaavQ/TVXpyXQYNGqN0mXmSuWZDz53OPkngc5zwrGiDWM3sK6Alk3/oeRn+llqUD/AOZWnRuhOmdG0W1pOn6PVio227LDCC4zD/U48n+PHorKiCm9IezPpTpHUn6hoemCG45paJXyukLAfIbuJx+SuSIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAoXVOoqum3Za88FpzIYmTTTsYCyJj3OaC7nPlp8A4U0qrrnTk9/XpNQY4FgZWaIXSuEcoY+Qva9g4Iw8EZzyArCSsPv9P373L3uv75t3djuDuY+e3OcLpOrVIa0c1+aGkJHmNonmYMkEjAIOCTjxnKrLenrVfUnyyQxS123n3veO+8vALi7AjDeXDO3zggePRcdK0i+xsN5tKCcywzRmtccYzGHTPeD+E+Q4BwxngJRcrY+9HHZljmxFGxrHd58jQ0lxIA85Hj1ABzxnlcf0tp3uIu+/1Pcycd/vN7ec4xuzjyqr/dG2K7K75IZ42w6dES8n4+xM57+OeCDwsqxoFuPWzfrw1poW3HTtrPdtBa6BkZcOCA4Fp/Jx5CVBcpunrVGy1x78cf650LBI9o7ha7blvPIJI/iFk179OzYmgr268s8JxJHHIHOZ/1AHI/NVXQulp62qV7VyKo1sXvjmtiJIidNKxzduR6Brhnhcul+nLem29P95ggDaMLohO2w57pScDO3AABxuOSecfdKguU5f1uGrbdWirW7c8bQ+RtaLd2wfGSSBn6DJ+i7W61ppp17T7sEUNg4idK8R7j/lw7Bz6Y8rBfV1PT9V1Cxp0Fa1Ddc2VzZZjE6OQMaz0a7LSGt+oOfOVFw9PX6MvvDYKWoyzQSMlineWMje+V8ji34XZaS/B9cNalC0zahThtRVZrdeOzLzHE6QB7/sM5Kxq2t0Z7clUzxRWWSuhbFI9ofIWgElozkjlV+bp292L1VsFFzbvaJsBxaa5axjDsaQScbNzfi8n8yn6euvk1OIVqWy7eZaFree5G1uznG3lw2cc45+nKoN60x36ctySpHbrvtRjL4WyAvaPmW+Qu2xPDWgfNZljhhYMufI4Na0fMk+FVaGgXYJNPhdFVbHStSWfemPPdm3b+CNvBO/4jk+PrxIarUuarpmmTmvFHbgmjtSU5JMscQ0gsLgPQuyDjy0JQko9SqSyQiGZkrJo3SslY4OYWtIBO4cftBfa+p0LNV9mvdrS1mEh0rJWuY3HnJBwoS3olm/05qVSSCnSsWnuc1lcktxlpw52Bndt+IgeD6+Tgs6bsyx3ZLFKGN8pg2xtuPLj2yTuLtuMgngbeccnngXKdt9S6PUtUq8+o1WPuAuhJmaA4D1zn18D5lZ09xsFlscrdsXadK6Zz2hrA0jzk59fOMcckcKtVND1OudLnc2pPNWnmLmyODD23+DuYzBcOP2Rn5+p7+rdCtau+c1jEA/TLVMb3EfHIY9vp4+E5Tcb0hf6k0ejUNmfUanZE7a5cJmkB7nAYPPGM5PyAJXdLrenRy0oxbge+4f1AbK07xjO4c8j7KG1Tp6eSe3JRjqtaY6ZijcdrXPhmc8g4BwCCBnB+ywtU6bv27t6Q1q0jb7Yt2bT2trlrQ0tADQXAY3AgtOSfHlKguVsl1OhDa91mu1o7ON3adK0Px88ZzhH6nQYyZz7tZrYRmUmVoEfJHxc8cgjn5LXvUDWssahpdeTTrE9rUIpgx4d70HbmHGzHLQBw/OA37Kal6WnbpsYijgdZZqc157BIWCZrnybQXYPIa9p8Hlv5pRa0nUaIrR2DcrCvJyyXut2u+xzgrvdNE2XtOkYJNu/YXDO354+X1VV03puRs2nS2q1ZohtTWXRCR0oaXM2ggkcn1OABkn7qR1ajddq7LtFkMuaklZzZHlm0lzSHeDkcHIQSLtToNfCx16qHzY7TTK3MmRkbeecj5LkL9N140hbrm4BuMAkHcA+e3OcKpR9J2Rod2u9tY3ZaNavHJn8L4mYznGQN3IXOn03bh1ZhkhhfC29Jc95Nh27DnOcAGAefi2/ixgfXCVBcrmiIooiIgIiICIqH1Vr2oV9Xux12tji05kczA9zGtmLgfxEyNO39kYa7kZ54CsRaTNL4io2t9R6jWh1m1Fap1xQmZAypLHlz9zWHcTkHJ3HGBj4f4Zz9emMVGN74TLY1KxUezHPbZ3scenDGc/X6pRa1ote6Xrl2SvBBXuadpkEOjVrrWviyNzg/I/EMMG0fXlD1bq00rpmQMrMi93zXl7Y39xjHEEukDgcvLRhp5b6+AotsJFB9QX7MOoaXSqzxVRbdJusSM3AbQCGNBIG45/g0qtUdQt0umbusQzx2JRamrgM/5WXWi0y4LgMAHPJxj1xylFtgoqN/ePVK+m35nCOzNTniayIBncsbhzFiNzgH85Bz8sgDJXe3Wr9mzplZmp0IBZovtvn7W4FwcPhaCRwATnPPw+nootckWuJ+sNWkhdLE2CEQU47JJDNk5cXc5fI0hh28bQTz+RzOor+r2tJ6pfFbZTr0YdsYjjzJuMLHnLs8Y3HwP6JRa9oqZqWu3aTo5Ib9ezp8cTZJLMUbJScvIO5oeCG4AALQec/LCleorT6uoVHQx1nTNrWZI3znaGua1pGXejT6/RKLTyKkR69q7q8kIdGbzZYg5j4o2Oax7XH4P1pY8/DwNwOATzxntrdTTmpZmlmi2x6fJO17ou3mVj3tdxuPja3OCRzwcEJRa5IqZV6g1F2o0/enwsqTOhjBjia8Oc+Npw4h+5jtxOPhIxj8s7W9Stt1malBdq0YoKfvRdOzd3SXOGPIw1u0Zxz8Q8eqi1lRau07qbU62iU2VmxxxU9OqSASdvExdE0nJc9rgM/CNrTyD58Kzs1q+3qNsFl0TKclgwRCONsgd8G7BcH7muyD5bjA/NKLWrAznHPzRVPWNXus6hv0YNRpUYa1GO0HTx7i5xdIDnkfCNoz68rE0TWLD7rbL4xXF+5AJo5P/DDqYft+h3ABKLXdFRLHU2pvhlnrSV/dopbQfIxjZHBscm1p2l7ctwDkjJ8LP6tsvJ6ZmgsRQOlvDEsrTtAdBL6ZHPPAPrhKLWxFQZupdVFoafG+KQtsTRG9EyMCQMZG4AB72t3frCDyf+W7j5Y2p359R0x1qx2xM/SJtxiILXYlaNwwSOcZ4J8+T5Si2x0VGl6l1Ma3MxrI2V4r7KYgf2xvaS0bsl+/cc7hhuMY+4kNG1m/Nrvu198Qjl73ZbFG1zHBjuCHh5OcEZDmjn5JRa0oiKKIiICx7FKrZmimsVoJZojmN74w5zD9CfCyFg2NX0+vdZTnuQMtPIAjc4ZyfH2z6fNB067otXVqk8ckcTJ5I+2LHbBe0Z8A+Vme4VPeXWPdYPeHEEy9sbjgYHPnwSFjRa5pktuStHegM8e7c3d42/i58HHr8vVYs/UlH3P3ijKy3ieCFzWuwR3ZGsDvHjkkfPCu9NzuOgac6++1LWilLo4omxvjaWRiMvLS0Y4Pxn+AWbLRqTWY7MtaB9iL8ErowXM+x8hY7Na01+omgy5CbYJb2w7ncBkt+WQOceVlusQtstrukaJ3MMgZ6loIBP8AEj+KivlqrXuRdq3BFPFkHZKwOGR44K+trwthdE2GMROzuYGjac+cj6qNm6k0aERmXUa7d8bZm5d+w7w4/Jv1PCyf0xp3v4o++we9k4EW8ZzjOPvjnHnCDtr6fTrRxx16leKONxexrIw0NceCQB4PJ/isWxoWn2LjZ7FaKVojLO0+Nro+Xbi7BHnPr9Suy5qPYttqQQPsWXROm2McBhocBySeM54+xUTH1SPc4bdmjJVrSWTX7k0rOCC5pPBPqz88qpuTs9CpYfC+xVglfCcxOfGHFh/058fku1sUbTIWsaDIcvwPxHGOfnwAFHSdQ6THUitOvQiGVzmsOclxb+IY88YOfl6rrsa2PfK9ehVfeM0BstfFIwN2ZAByTznPooJCShUkfC+SrA58P/Lc6MEs/wCn5fku18Ub3Nc9jXOaCASMkA+VgO1uhHbjqWLMUNx20GFzgS1zvDSRwCfQevoum11BSjsNgrSx2JxYZXlYx/MRc4tyfzB4QZrdMoNrPrNpVRXecuiETdrj8yMYK5SafTlZCyWpXe2H/lh0YIZ6cccfku2CxDYDzBKyQMcWOLDnDh5H3ChZupI4dSmryU5xBDajpusbm7RI9rXN4znHxtGcf7IJYUajbDLDasAnY3Y2QRjc0fIHyAvtmnWsujdZrwzOiO5hkYHFh+Yz4WHX1/SrLHPgvQva0saSDx8btrT9ieAfBXDUdbjq2oataF9y1JL2THG5o2Htl/xEkD8I/wBwgzH6dSe+B76ddz64xC4xNJj/AOnjj8lzFOqLfvQrw+84297YN+Plu8qH1PqRmlVLNnUqxhZBC2V0bZA+XJc4AbRxj4eDn5/JTVWxFartmgcXRu8EtI/2PKKwptEo2NTmvWoGWJZI42bZWNe1mwvILQRwfjPP2WXPTrTxyxz14ZI5SDI17AQ/GMZB8+B/BQ7upWiu643T7btLa4g3Bs27QcGTbu3bPrjxzjHKz3a1pzdQFF1yEWiQ3t553EZDflnHOPKu9Nztk02jIxjJKVZzGO3ta6JpDXfMccFd89eGw0NsQxytGcB7Q4DIIPn6Ej81HDqHSXTSQsvQvlj37mNOTlmdw48kYOR5XRS6p0q1pFbUHWOzDOG7WytIdkt3bQMcnHyylSbklLp1GWo2rLTrPqt8QuiaWD/y4wux1Wu5u10ERbs7eCwfh/y/bjwseHVK89qrFA4SsswunimYQWODS0Hn/wAwWcorHdSqOuNturQG00bWzGMbwPkHeV9ip1YbEk8NeGOeT8cjWAOd9z5K70QEREBERAVd1HRLU2ti5Ukjrh8kT5JGSSNc4MIy1zM7H5AIycEA+uArEiCq19C1WvSbp0NqlHUgZKIJjDvly5rg0kHgY3ckfix6ZKxmdL6g61LNLPD+u90LmmWSQtME3c4LvIcCflg4+6uaK2lKhS6Ws19VYTNE+jHbkuNJmlLyXOc7bs3bBguPxfIeOcqTuaVaZqNa5p0rHPZDJA8Wnudw8sO4Hkkgs8eufIU4iWUoWnaFq9Oxap1RUc39GVaT5rEbtpLRIC5uB8WM/hOPI5ClKnTdmlqVZ9SdsVaJzHSObK/dMGsDcOjPwZOB8fnjwrSiWUiexJH1X7xscYZqYj3AcNcx5OD9w/8A/qVjRaHI2jRge+Nxr3n2zwcEF73AD6jcP4KfRQpTr3S1s6jJfqTRGYyzERumlhbskEf7UZByDH45Bysqn0pWZNQN6GpbirVDBtki3DeXBxcA7OBwfXKs6K2UrFvp+3I+9WhmrN069OyeQlp7seAwFrccH8AwfT6r7b6ZfZ02Sr3+yZdRNx8kJLXFpfuwD5DsYGVZkSykLoNC9pMNXT815aEDXsbJyJNoLe2CPGcbgT64B9SuEPT8TNQ1i8Y63vtuXfBYMQc+L9SyMcn6tJx9VOopZSlHQLVevak1FzrEc1L3WRld8ksm4H4Xsz45JOBgNwPPld+ndNS2dP0h2uNr2bTZ3XLrZYw5r5HRubgDkfDloH0arcitlK3qnTQtN1KKq+GrBZosqRNYziMtc92dowMfGOPupej+kRM5l73Z0QiZiSEFpL8u3DaScDG3HPqVmooUo9/p3Xo9Oj0zT7dV+lsY6uWO3NkdXdgFnqN4HAfx9RypB/TtoumqMngGmy3Rec4tPea4PEmwen4m+fQcY9VaEVspXafT8sEdBpkjzX1CxceQD8TZO9gfcd0fwKx6eg6nRg0p0VmnNZ02J9aMOjcxj4nBg55JD/gacjjyMeqtSJZSr19Mt0rFKCAtknjjtWHTFhbEJZHAhv8A05c7jOcNVmi39pnd29zA3bfGfXC5IooiIgIiICIiAiLpisxSzywxvzJFjeMHjPheZzxxmImfn4WImXciIvSCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKI0v8AxvVfvH/QqXURpf8Ajeq/eP8AoVg2v7tDqnsyddPhz5eYS6Ii3uQCCMggj5hcYpGSxtkie17HDLXNOQR8wVWNO07UKzqrJYp3bQza+O1sZEAfiDm5+Inn0Oc4y3GVkWTqEfSVqKRssd2KpgStflzn7eSCPUFBYUVSnoaoWvFeO2yB8rcRvtlz24Y4F27ePhJ28ZPjOOcLu0ytqzNUpyWWWCzttExkmBY0iPBwGv5O4ZwWnyTu9EFlfIyMtD3tbuO1uTjJ+QXJVa9pupTai18YmL22jKJ3T/qmx7CGgMz5BI9Pmc+iyunKeoVmWPeTO0uja1osTd39YM5cOTwePUZ+Q9QnZJGRRukkc1jGjLnOOAB9VyULe/SEPT13vPdLccwtiMDS45IwMYHz9fz4HAjrVTWpGTQRCduHWS2YTgbg92YwOc/CDjkDGOOEFpMjGyNjL2h7gS1pPJA84H5j+K5KsS6bqrJ7MdaWb3Xc/tbrBLi0th43EkgkiUA+mfsvtPTtQfcbJI65BUAldHC+1ucwkRhu4gnPIeQMkDP5ILMigNJp33aVdr2TYgkflsUkkpc8fD+Lh7sc/Ij7BYFuhrdiCCWQ2BNKJHSRQWQ3svONnOQC0Ac4zyScHKC3Li2RjpHsa9pezG5oPIz4yqxLpeqiOWSKef3mSSZpJsHaIyDswM4BztwQMjK4VKWo1dQltQ1LfYfI39S+y18m0RubyS7GA4g4yfn9EFsRVfSaerQajQdaE72CFgnc+fLGkRYOAHcncPVp8k7vRdlilqb7FwQ99s7+6Y7PvOIgC0hje3zyDj0HjOT4QWRFVotLvWJ2B/v1akS4mJ1wmQHZgEuDicE8gZ9M+uFxr6TqggqxyTWjvjrm0feTneCe5g54yP8ALx8kFrRVMaTq0VUivYs99wsMJksl3wb/ANVjJODtAGfPPKy6lLUW6JeiDrMc0jsxNmnDpGtwMjcCdpOHY+I4znjwAn2yMc97GvaXMxuAPLc/NclTX6XqXcsSRQ3Y60k7XdkWh3i3thv4t/gOycbvX6YWbplPVYNXrus9+WIRgSyST5YD2wPhAIydw9WepOfRBZUREBERAREQFEaX/jeq/eP+hUuojS/8b1X7x/0KwbX92h1T2ZOunw58vMJdEQ+Dhb3IRUxmjar2O050/ZbKxzx7xmWUBrwRk/CRksOcNJwcjwsqDRdQjDJHTSunjdW2F9guwxrh3AfAOWkjOOeEFnje2SNr43BzHDII8ELkqrDpWptMHdc5847JFjvnEQa0B7C39rcQ7n13c/hCM0e/A3ShEZpHxMjExfZJaXbgXuPIOfOMZHoRhBalxL2B7WFzQ9wJDc8kDz/ULDnjve/tkhlZ7q1vMR8uOHfTjy319Fg6tpc+o3aNphFeavBIWPzkxyksI+4wHA/MFBNsc17Q5jg5p9Qcr6qlHpGp+712yNHd7LWtMc5Da0u9znO9NwILfT9nHglfZdO1aWNsTxK1sUL4y6OwA6Q91jgR/wCVp4OPJHHlBbF1tnjdYkga7MrGtc5uPAOcf0P8FCGjedotKKRm58Uu6aBsxHcZ8WG7iTzy04zjjGcLHbotrviyA6OZorhg94c7aGyuc8Enz8Dsc/ZBZ112Jo60Ek0ztsUbS5zseAPKqVTQdS2BlmxZLnGMWH+84E2JAXOaAARkZ9QecegKyLekXZo78Pbc58rZg2wbJAc1wIYzZ6YyB+WfJKC0oqxPo9uOxII2Pno73FlcWXMOTGwB27OeHB/H+rPkLgNE1IM3usSPtF5a+Rtgtyz3ct48gfrMHx55QWeaWOGN0kr2sY3y5xwAuTXNcMtIIzjIKrtbTbzun7lSVuJXyAxb5MuLfh/FyQDkHxx68ElcdQ0e0/WGS1nztrgscztzhrWHeXSZBBzuz6efBwOUFlRVODSdTjgxYD52d8SmEWCCYtrgIs/6SQc/tL6dH1F2oQSmSdrW9rZstZbEG/iacty7PPPrnnGAUFmr2YLIJrzRyAAE7HA8EZB/MLtVNboOoMqwsJeGN7IkZDKGueGxFpGTwcOwcH5LIg0TUWM7hsSm0x0Aje6cu2tDQH58A/tenPCC1Iqk/SNQfSjjYyWENfGZ2ttb3ThocHEF3AyS084zjBwrDo1eWrpsEM73vkYMEvfvPngF2BnA4QZiIiAiIgIiICiNL/xvVfvH/QqXURpf+N6r94/6FYNr+7Q6p7MnXT4c+XmEuiIeQVvchcXvZGAXuDQSAMnGSfRUyfQ7sNaBvba52+Fk5jlcfeiHgukfgfDwDnz+LHgLnc6avTRMZHIIom90xwxzYbAXEbS0lh8YPjBGcDhBcl1vniY4tc9u4bcgckbjgcfUqtWen7L6kjG9uWWW1JLI6R5OWnds8gjjI4xgeRylfQbMc8djtVRadFWbLYDv1hMbwX87ckOH19EFpRVOPp62Wxsk7bR8AsPbM7NsiRri9wxwcB3HP4seAuX93JyJviZmNjxU/WOxE7uvcwj5YaWj8iPCCzzzRwR75nhjMhuT8ycD/chIJo54xJC8PYSRkfQ4P+4VSZ03fFqaV0+4vk3OLpARIO814yAwHhrSBknHgcJJ03efZrv7+Gxj4NkgHad3XPLhlhPLXNHBH4ceCguC6X2oGQOmdKztNJaX5yAQcEfx4UFrWiWr2tRWo5nCJjYwzDwO2Q8lxALD5BA4IzjB4X2voTq+iXaNeCrCZZ3yMMfAc0ybhuwOCAcevhBYkVe0nS71bXJbc3aEMolDwx+dxLwWHxk4AxyTjPGAuiTRbvbstjhrd2XIfMZn5maZAfiGMZDcgZyPTxlBaEVIj0K818NWzBHZYyKwWB0rmsaXSNLOQ3ALQSBgDGOFky6Fqrrb5GWY2SOjdEbAdhxzFtDiMZyHc4zj80FrklZGWiRwbuzjP0GU7sfwfG39Z+Dn8XGePmq63Q5ZI2xGtWrViXCSBsrpGuzG5uSCAPJB8emTysRnTdttmk+MRVmQNiDWQSANjLXkvIBZn4h5wRnwUFu3t7mzcN+M7c84+a5Kvalpd2fXoLsHaDInx4dvw4sGdw8H5+hGfVdtvTJ5dXdZEcUgLmGOZ0rmuhaPxNa0ec8nzznnICCcRVKDp2yRAyZsTYmmP3gNlc73ktJ3Pdx5Py9c4PgLpudP2amkze6Z75jnjd23uLnNdIDEPn8LRj6eiC5oq1W0GQXIXujjgqMn73u0cri0YZgHwPLsHHjjPlYVLpi7G3bZsGTc6PvkyjE+JA4uIDQeQCOSfOM4QW+eWOCF8szgyNjS5zj4AHkrmqbd6auS07MG2CUOilirB8rmivmR5aRgf5HMH02Y8FZF3p2xNA8B+XSXHzyt7n/Mj+La34muHGQcYxwgtSLE0mvJU0ytXnkdJLHGGuc524k/fAz98LLQEREBRGl/43qv3j/oVLqI0v8AxvVfvH/QrBtf3aHVPZk66fDny8wl0RFvcnXWniswRzQPD4pBua75hdip8PTNxlik90kLjAyIB+87o9h+IN+HOHf9TfPIPhZukaLcqafqFYyRVzPHsikidve12CN5dtbk8jzk8ckoLGuLZGue9gzlmAcggc/X1VU0/pd7HRNuRVTWEgfJXa7cx+GPbkja0Ekub5Hp5PC6G9P6hPWbDYDHthdE0smkGybbEGlwy137XIy3+HlBdF1WrEdWtLYmOIoml7iBnAAyVWa+g6hAGxE1p4e7HM90kjsuLYRGW42ngloOc+vhZFTQrUHTeo6c+aOWewx7WzFzudzMAOzk4b4HJ4A9coLGDkLjI9scbnuztaCTgZP8AqzW0S7WsR2a8FKDZM1/uscrhGcMka5+7Z+I7xnj9kc+qx4+ndQj7O11beKvZfKZCSHdot+EbMgZwfxY88ZQW9rg5oI8EZGRhfVVZ+mrD+5JFNHDce9+bDSS9rDXMYAOPR+HY8cZ8rG/uxbbSMccdRri8OEXdHbB243EdrBJ4/ZB4/EguaKC0zSrVXXJrTxB2ZGuBcHbnkkgj9kEDg8FzvTGFExdPWrEFgtihrSyG00zb3CSUPc8Na7jhoyCDk+BgBBc1j0bcd2ATQh/bd+EubjcPmPooO109vugxQ1exujLZHE74WNxujY3GC12DnkfiOQVinpZ0WnVq1avRy2DtZ5YIZP3rMN5d4+R4HIQW5dcc8ckssbHAviIDx8iRkf7KtSdNy9uV0TohYldN3ZMkGVjn7mtcQM4xwflk4WPN01aMdjsV6MQkmEkcDZT22DYG+DGQeRngDzwRzkLg9zWMc5xw0DJP0XGCVk8McsTt0cjQ5p+YIyCobXtJl1DskR1p9kL49szi1rHuxiRuAeRg/I8+Vgab05aq6nVsSyQu7TYx3A74gGxBhYBtztJBP4sc+MoLWird/p6Wxas2IZGQ2ZZnkWGk72RmAx4H2fh2PHGfKxLHTll9d4hrUYMuaRXjlPayAQXnMZyTkfs+g5QW9dENuCaV0cTy5zS5pw04BbjIz49QorWNKnuGo7tVLPajcx0U5c1gcduJG4B5GDjwefIWFb6fuzR2Gx2I2CQyHhx+Lc6M4PB4IY4Hz+L1QWlcWSMeXhj2uLDtcAc4OM4P8Qqj/dWV9WRj21gezMIIw4lsMjtm1zcNAGC0nIaMZ4Hkrsu9MuJtmpVogz2BPnIjLvgwQ/4HA85Pj19CgtiLHotnZXay0It7AGgxk4dwMnB8c5454xyshAREQFEaX/jeq/eP+hUuojS/wDG9V+8f9CsG1/dodU9mTrp8OfLzCXREW9yEREBERAREQEREBEJDRkkAfMogIiICICD4IPpwiAiJkZIyMj0QEREBERARMjJGeR6IgIgIIyCCEQEREBERAURpf8Ajeq/eP8AoVLqI0v/ABvVfvH/AEKwbX92h1T2ZOunw58vMJdfHgljg04djgr6i3uSq6Ppo7deKehYiumMsuWt4AkdtwSTn48nkccfTwsfta/vtOdZstLt2Q2FpDf1jdu34+Rs3DgA4/1YVyXx72sYXPcGtAySTgBBXNGrXBqVe1ciuAuhMZLp8taQ52C4ZHlpGOCfnzyuq07WnslhgbYZI02f1nw4wZQYsZ8/Bn+HKszJY3u2skY53PAOTwcH/dc0FP1CvrrJpIa89oVY5JO1IGiSR2WRlmTubxuMo544GeFJ60zUC2DtOskiB3NbA/XcbSc/s+fp81Oogq4brO2zuNr37EnLCzsbf2NgP7WMfnnPGFj6mNXNIs01uogkSOidM9pcHBrdoPrjJceTjg5yMBXBEFTsjV5LFvY2xI2SPLGua1rWHDeMHIdzn5HzlfbUetOdYFd9ps5dIHOy3thu/wDV7B8w3/759FaO7H3u1vb3Nu7bnnHjOFzQQL49Sg0+/HE6eV0VqN0Bc4F74f1bnDPr/wCIOVhWGazZ97kjdbha1th8DAWgucNnaB+n4uP4q1BzXOcA4Et4IB8I1zXFwa4EtOCAfB8oKpedqlevaeW2WMAsPjMAYPizlhd9MZ/3z6IJ9blqxio2UzuLntkfjtkGudufp3COP/srW9rXNLXgFpGCD4IXyLYYmdnb28Dbt8Y9MfREV7S49Xj0vUR3pZLBizW94jDSJNp/1O4zj6eccLFho2xY1G0xl97468bq3ee0PfIGSggZz/n9fU/JW1EVSmSaqyxXrW33hC+eQjtHD3xiJpHJJP48+ufsOFzgfq8lt0Uktw2ImV9oaWBgcfx9z0PHn88cq5YTjKCo262ue619tm0N75nTFjQ57Tn9UAAW4bjPr5xnjK5yQ6+1rpo5ZH2i9zAx20Rhvu5IOP8A4oH8fkrWiCoQ0dRdqbnQyahHXkNdr5ZXN3lrRKXj7ZLf48cLN0ePVhrUz7k0pgJlyx0YDAN36vad3+X5D555wrEvge0vLA4FwAJGeRnx/RBTn1dbjmjZXfLBCC90YZGHZeZ3k7/iHG0t858n1wpfQffxcuC6Z3xnlj5AGjyeA3nwMcg4PHAKm0QEREBERAURpf8Ajeq/eP8AoVLqI0v/ABvVfvH/AEKwbX92h1T2ZOunw58vMJdERb3JUWaTqoqdw2b5s+6F+02ePeB+H1xj0x+E+vPK4zU9fdbvPEkpLu6GAEdssIPbABfgEfDk7R68lWutZiste6B+9rXFhIBxkefuu1BT7Gmaqw2n02GOR5lw4OGS11gOIHxDkszjkfcI2DXoKViNrbUzpISyE91odE4PON2Xk5wfOSeOVcEQVW9Q1c1x25rTu5aldK1snxBm53bDcPbhuMcA58Zyu3SoNYj1WB10zyxmNolcXNaxp7YzgBx3ZcP8oPJ5xgKyriJGOkcwPaXtALmg8jPjKCuO0q/PeEk1m82KSzKJGssloEOCWYAPHxBvI55weFhtoa7NdqPtPm+FsQ3NcAGjAEocQ8fEfi5DT6YIVrtWYarA+d+1pO0cEkn5ADyu4kAZPhBR4NB1CtSHurbsVmtSeyIm2Xb5xjbyXH4Tj8JwPmFmz1dZMlgwm02VzpN7zMNj4y74RG3PwuDeM4HOc58q1ogqEWn345rJ7Ope5yTbgxtoCcgRsDSX7s4BDuN2fHkcL7FQ1ZocbjbMgkcHSipM2N739mNodnLfhBa/I4yccYVsjkZI0ujc1wBLctOeQcEfxQSMMpjD29wAOLc8gfPH5FBS+/fj1OrXs2Z36l3oQ9sU7dhj2jfmPPzDiTt/PHC7oaevi5VdJJM0MZCMMI2AbR3A4bwCc7v2T6YIVwXWyxDJIY2SxueM5aHAng4PH3RFfoVdRdoep17bJ3zSRObG6Z4y9xaR43ODeceuPoFGs0XUqdTsVGyRxmcukFfazc3YNpAa5mMHg88kZ5Cuy4xSMlja+J7Xsd4c05BRVWNHXZIXwSTP5r93u9wDdMWBnb45AyHOz4yRjwsXUa09aJ0+l6fJpMexkcjWGNrpXuljAxtJGQN4yf8AMrjHYhleWxyxvcBkhrgT5I/qCPyXYgqFmrrDIf8AsovmNsr3RQvnaX7drMbn78/iD8fiGDyPGMvqWtq89uI6dJK2JsR29o4xLny7425GMeQ4eeFZEQV6jp1ulR1iOqJ225TI+GSWd0jC47i0gOcduCeeB+ai5dN1Zs9h1Nt2OCQwNf3Zw+VzWiXcARICPicw/iHGcfJXNssb3FrXtc4eQCuSDD0dlmPTK7Lri+wG4cXefpnk84x6lZiIgIiICIiAojS/8b1X7x/0Kl1E6Y1w1nUyWkAlmDjzwVh2uP8AtodU9mTrp8OfLzCWXxw3NIOcEY4OF9RbnJTbGk6nV0+CDTmWd7RM/ItOOHl2W5y8cY+4+YHld7Y9Rkt3YALTbmHyd02cR9txdsa1uSA4AAZwMEZyc82tEFUi0zUJ5sPdfr0sSFsTrZMjTtYG7nBxJ5DiBk4/PC4v07XDEZop5mXXve3L5sxsaa5AO3OP+btPjP5K2ogq2m6bqRsVTYfeirNl3vZJZy44YfJDnHaXY4z6eByuzW6GoyXZ5aYl7L3Q7xFIGPkY1smQDubjDnMPkZAKsqIICXS57NLR2WjM6WvMHyETua4Da4ckEZPIHqsCxp+q3ovd7MVlscUL2lxs7RM8SNLSNrs/hB5OMZVuRBVLNfWTG6vWhtRta6RzJTZB+EwODW5LtxIeR59RnKkr9Oy3TKUNd1mVscjTYa2ciWRuDkB5I53Fp8jgEKZRBSY9K1qNsbW+8sZmQsaywAY3mZ7g6Q7huG0s9HeDxypXW6d596aapFI9j4YoyY5NjuHuLsfE30I9R+fhWFEFfbX1J3T9WGds5sRyATtjmAkkYCfwv3evB5IOMqPg03Voqs7WttRtcZHta2ZrpOZg5oJ3DJ25B+IevOeVcEQVerV1Pu1XWYLRIawN2W8Niw87u4C47iW4/wA/yz6rDbV1aSd0Ljb95ZXh2ObZ2xxSbn5c4Zw4YAyOc4xgeVdEQVYabqe4xgyxQOlDnduXacGw9zuQcjLCP/8AV0O07WxYjaZLToWFzYi2x+DEzyHSEu+IGPt+Q48HI5VwRBXtaqanNrEUlZ0/uwYwM7UuxrHhxLi8bhkEbfR3g8Dyuei0b9W5BJYkneySGXv9yYvAfvb28Anj4S7x+ankQVSloFqvpm0TztnlnBe1hjYWRmbc7D2tDuW/NxP5rhap62btw122WxvjmiYRYyMlv6twy/jx52ggn15KtyIKxY0+/DO5rBes0Q8kRMtlshJYzB3lwO0EP4z65wcL5HU1iLVhPJ7zKxmHANnGxzRHgswSAXF2edo85yPCtCIPjCXMaXNLSRkg+i+oiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIg//Z",
+              "timing": 1500
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAEkQAAEDAwMCBAQCBwcBBQcFAAECAwQABREGEiETMQcUQVEiMmFxgZEIFSNCU5KxFjM1UmJyoRckN0OCgxhzorKzwdEnNHR18f/EABkBAQEBAQEBAAAAAAAAAAAAAAABBAMCBf/EACcRAQACAQEHBQEBAQAAAAAAAAABEQIDBCEycXKywRIUMTNSQiIj/9oADAMBAAIRAxEAPwD1TSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKDg//AHLn+0/0qjVeX/7lz/af6VRqC+UpSgUr4pQSkqUQEgZJPYVXmtcaVeuHkWtRWlcvO0NJlIJJ9u/f6UFipQkAZJ496rp1xpZM/wAkdRWkS87el5tG7Pt37/SgsVKAggEHIPrUVedQ2uyrQm6yvKIXjDzrag0Pu5jaPxNBK0qheNcr/wDSS/yYb/BjpUh1pfcFSeQRUsdX6es0SBGu98t0OUplv9m/ISlXKRyQTxQWeldcaQzKYQ/GdbeZcG5DjagpKh7gjvULd9Y6bs8sRbrfbZEk5x0npKEqH3BPH40E9SuqJJYmR0SIjzb7DgyhxtQUlQ9wR3rtoFKUoFKUoFKUoFKUoFKUoFKV8WrakmgFQT3IFfA4g9lCou5XGJb2DIuMpmMzkJ6jywhOT2GTWBD1LY5slEeHeLe/IcOENtyEKUr7AGgstK6I6yfhP4V30HB/+5c/2n+lUary/wD3Ln+0/wBKo1BfKUpQa38cH3l2ex2hLy48S8XViDLcQdp6KiSpOfTOMVY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvr3rM1dp2DqqxP2u5pV0XMKStBwtpY5StJ9CDVPd0XrOTCNsla8Wq2qT01rRb0JkqR2I6m7vj1xmgohvtyf8D4cFU10ocvAsip6VYUuN1Snfn6pG3NbcRoHSqbH+qRYrf5LZswWU7u2M7u+765zXN7RNkd0SNKmMRaUtBpKQfiSQchYP8Am3c596rSdE60RE/Vydfu/q0J6YUbegydnbHVz3x64zQQ3iDKk6E8FDH07eHpZbdTDROUsKWy2pZBG4eqR8IPcVsXT+nLZb9OItzbQkR3mQl9bx6ipGRypZPzE5rrt2jbJC0enTIiJetPTLa23viLmTkqUf8AMTzn3rFVp66Wyyiz6YnpjRtnTRImrVIcjp7YQnjOPTco4oNKx33Y/hF4oWBLq3rdZpy48Najna31B8Gfpj/mtz6J0pZoek4jZixpypcdDkmS8gOKlKUkEqUT3BzwPQVHjwzgR/DWdpKBJcb86Cp+Y4netxwqBK1DjOcYo3o7UdpieQ0vqluFbQna2zKgiQqOPUNq3Dj2Cs4oKpp+W9pD/qjarISqBZ2vOQWvmDC1tKWpA+gIzirT4WaSsbOhrbJXDizpVxjpky5T7aXFvrcG5WSRyMntU1ovR0PTNnlRC65PkznFPTpUgArkrV3KvpjgCq7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNB0eHzLdg8T9WabtY2WZDLE5tgHKY7i8hSU+wPfFbQqs6I0ixpdmY4uW/cLpOc60yc/87yvQYHASBwAO1WagUpSgUpSgUpSgUpSgUpSgVwfGWjXOh5oK7qMSTbT5ITi9uH/AOy6PUx/6vw4/wCagrKm7/rRjzQ1F0cnd5oQen2PzdP4/wAquy2SD8PIriGlk/LQfWB+0FZVcGmwgfWudBwf/uXP9p/pVGq9PDLKwOTtNUzykj+A7/IaC60pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUPHelUrV1ydXMVEbUUtNgbgD8xIzRy1tWNLH1SuBkMj/xUfzU8yz/FR/NWjNVarhaaehNzmZLhl79hZSk7dpSDnKgf3h2ya53HU0aDqKFZjGlOypTYdSpsI2JSVbcncoHjvgAnFS2SNsynf6W8PMs/xUfzU8yz/FR/NWhLlre2QNQmzuNTFyErbQ4422C22pYykE5z254Brvu+rINr1FDs0hmUqTKShSFtpSUDeopGfiz3SewNLX3mf4b08yz/ABUfzU8yz/FR/NWj2tTwnNRGzJakeaDi29xSnZlLaFnnOeyx6d80tupGp+oZtoTb7iy9EG5bzzSQ0RkhJBCicKwSOOQDS095l+W8PMs/xUfzU8yz/FR/NWjLRqmLdJN2ZjxpSRbVuNvOLCNqlIJBCQFE+nGQKxNL67tOpLi3CtyZIeVGMk9RKQEgK2lJwo/F6+2PWlr7vPf/AI+G/vMs/wAVH81PMs/xUfzVoq16sh3Ju7uMxpaGrYXEuqWEfGUZyEgKJ/dPcCvun9WwL/DmSLazKcEVtK1I2DcoqSVbUjPzcYxxzSydszj+W9PMs/xUfzV2JUlYykgj3FaP0vqBrUMV59iFOioacLR802lBUoHBxgnsQQatFpuL1vlIW2o9PPxozwRSyNtrKssabJpQHIBHrSq3lKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFUrV1tdRMVMbSVNOAbiP3SBirrQ896OWtpRq4+mWlLxYbbeXY7lyjdZyPu6St6klGSCSCCOfhHP0rhcNO2u4XSJcpkXqTYm3ou9RQ27VbhwDg8881ukxmD3Zb/lFPKsfwW/5RUpkjYso+Mmkpul7LOu7d0lW9pycgpUHST3T8pIzgkfUV3TbBbZ11YuUmNvnMBKW3gtSSkJJIHB7ZUfvnmtz+VY/gt/yinlWP4Lf8opR7LL9tNosluReF3VMVInrBBdyfUAE4zgHAAzjOBWQ1Bjsz5E1tvEmQlCHV5PxBGdox243H86255Vj+C3/ACinlWP4Lf8AKKUnscp/ppWBpu0wJs6XEidORO3eYV1FHfuOTwTgZPtiuNr0vZrXMalW+ChiQ0z0ErSpXyex557Dk88VuzyrH8Fv+UU8qx/Bb/lFKX2Wf7aTg6ZtEFdwXFidNVwChJ/aLPU3Zz3PHc9sV32ex26zF82yKmP1tvU2qJ3bRtHc+1bl8qx/Bb/lFPKsfwW/5RSidiyn5zajt8GPb2FMw2+m2pxbpGScqUoqUefck1MWi3PXCUhDaT0wfjX6AVsTyrH8Fv8AlFdiUpQMJAA9hSjHYd95ZW+gYAA9KUpVfQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQK074j+OMbROrJNjdsb0xbCELLyZIQDuSFdtp963FXiz9Jn/veun/uWP/pJoNms/pOW4uJD+mpaG/VSJKVEfgUj+tbp0Xqq16xsLV2srqlxlkpUlY2rbUO6VD0NeMXxK1tYtO2jTOnHXJtpYWiU+wgFT5WoFJVgdhjufc1eZ0rU/g34XRbZvTCvN8mOvkpIWqO0hCEkA9gokjkZx9+xHrKqb4rnVo0mv+wfT/W3UTuzt3dPBzs3fDuzjv6Z9a8ci46yXAF5F7nltSsBX6z/AGqjnGQ3v3kZ9cYrYs3Wmrbl4JXRu/frFiTElxvLz1oWyp5CirKd3G4jHf680G2/A9XiOpU7/qAD5LYPL9cID2/PPyfu4z83OcYrbFeFtDeJN70sbvJanSJMx+J5eP5l1TiW1FxBK9pOMhIOPvXKJ/1F1JarhqWNMvMuDEUoyJKZZSEEDcrCdwOACDwOBQeyddG/J0pcDpFLKr3sHlw7jGcjPfjOM4zxmtS+Ex8Xv7YNf2tD36kwrzHmul/lO3Zt5znHbitf6V8Tr7efDXV9lu055+VFgpkxZm4h4JDqEqSVDk/MMHv3qE8ENWXCDroTblcJ0qJEgy5K2nH1KCghlSuxOPSg9p0rxOnVHiJ4maqc/UsucuSgF9uJEkdFthAUMdyBwSBk8moPXOqNWPaqnm9TJsG5IKG5DDT6kJStKEpJABwM4zxxzQe9KV4F1VqC8t3RkIu9wSDBhqwJKxyYzRJ7+pJNTPiLO1fDb0tKvF3XtkWph2EIr6wW2toAKu3xnGSeck96FvcNK8e3Txl1KjwzslujXB1FycU8iROz+2U2kgIAV6Hk5V3+Ec8mqX5/WcaJHuqb1cAHlDplFz3PEnsS2F7wPqRRXvaleNNc6z1fdtCaf/XAukOfHkvt+YCFsGS2UtlKjjGSDkZ+3vVFtVw1TdrizAts+8SZjqtqGW5DhUT9s0R+gteSvFTxZ1tZPEK+2213tTEKNIKGm/LMq2jA4yUEn8TXoXwlsl209oK3W7UL5fuaN63VF0uEbllQBUe+AQPwryD43f8Aexqb/wDlH/5RQe1tGzH7hpCxzZjnUkyYLDzq8AblqbSScDgck9qmK8Wa68StQyWbRp6zT5EG3w4ERjbHWW1POdFG4qUOcZOMZxxUREvGvdN3iP5O63B2WfjS3HmCYlX0UlClD8DzQe6qZB7GvIXjdrnWE9uxiUi4WWDIgocUykLZDj2SHM9jwRwD6YPrVK0pb9V3RCZOn7z/ANqKjtjpuqWpCiPZBWCaFveVKr/h9+sv7E2UX3rfrQRkCT1/n3453fWrBRSlKUClKUClKUCvIv6Q+ldQ3TxTuUq2WK6zIq2mQl6PDccQSG0g4UAR3r11Sg8W6l8MtSQbBpu82az3PrPxNktlhlfWZeSpQyUAbgCnb6eh96lLV4Y6p1R4ZvrfiT27zb7gtxmNcErbW80ppsKCd+PVIx6cGvX1KDw7FsniZDthscS0X9iGXN5Q1EUnnOf7wDOM84zirhqjTGpNO+CFxe1jcZTkubMjhiG/JLvRSkqPqSAo55A9APw9ZVov9IDw21JrrUVqdsSI5isRi24t58ISFbie3JPH0ojQXhjop/XT96t8FaEz2IPmY4WcJWoOIBST6ZCjz74qSjWPxPsNsnafh2u/s2+WSJDDEdS215GD8QBHIABweRXovwQ8Kf8Ap81LmXCU3Ku8tAbUWgem0gHO1JPJycEnA7D8ZDxC8XbBoS+NWq8Rrk7IcYTICozSFJ2lSkjkrBzlJ9KDS2l/Ca/WXw11Zc7lBe/Wk2EmNFgNJ6j23qoUokJzydo478HNQ/ghoa9nXjbN9sV2h26RDkx3Xn4jjaQFsqT8yhjPNeqdFamhaw03FvdsbfbiSSsIS+kJWNqyk5AJHdJ9awvELXFo0JaG596LxS6vptNMo3LcVjOBnAHHqTQeRHtB6x0/eOtpcS5rKiUx7lZ3SpLiCe5Ug5T9QcYqo6ohP2/UE6JNlpmS2nNrz6V7wpzHxfF64ORn1xUxpfS901Zcbizpd9KywgyFJfdEdXTzgqOTt4yM/F61sHQngRNuV2j/ANortbI8XdlUeNKS8+6ByQNvA++T9qCkag0hqWfMiyYOn7vJjLgQ9jrMJxaFYjNA4UE4PINXrxl0tqCfadAog2K6yVxrBHZeSzEcWWlhIylWBwoex5r1lFYaixmo8dAbZaQEIQOyUgYArsoU8cR/CPUV48Mok6LbJTN2hS30uQpLZacdaIQQpIUBnB3ffPHaoaPZ/E/9XMWWPatQMxGV5QhEVTQBz6uADI59TivcFKK8u3KP4paJ0VFt0T9b3C43UrdkOspdlrhISAEtpUMhKjlRJH0x2zWr7bYvES1y3pVstWrIcl7+8eYjyG1r5zyQMmvdEq4wojgRLmRmFkbglx1KSR74JrujyGZLQdjOtvNngLbUFA/iKCq+Ehuh8ObGb/5z9Z9JXX87u62d6vm3c5xjvXlvxh0hqWf4m6hlQdPXiTGdklSHWYTi0LGByCE4Ne0qUHjvX/hFqVhq03qy26TLakwYynmGkHrRngygKBR37jPHY5BrBjWPxY1Jc4yfK32O4gBtLjiFQ22x7nhI/Hua9pUoPL+vNP8Aidp2axHtKrjfLaIrIdW4hMxDjoT8ZLa9xHOccdsVrFehtcahvCnRpWcxIdIztgeTaB7ZxtSkV7upQQehrdPtOj7Pb7xI8xcI8ZDbzm7dlQHv647Z9cVOUpQKUpQKUpQKUpQK1v4teLFt8PVRorkVyfc5COomOhYQEIzjcpWDjJBxx6GtkV44/SmiyWfFJx99KuhIiNKYUexSBtIH/mB/Og2E9+kpD/s81KYsm66dfpuw1yCAEYJC0r2nPbBGBiuUb9Ih97S9wu/9m2wYsuPG6XnT8XVQ8rdnZxjpdsfvfStF6y1HY73Z7VHs2lo9nfiJ2vyWnSovnHrwPUE5OTXTbf8Auxv/AP8A2sD/AOlLojdrf6THUtc5xVgbZmo2CM15krS4STuKjtGAAPxJFTMn9IKLA0XarlKtYevM/qKENp3ahCErKdylEEjJTwMHsaov6Kdltl5vGoEXa3xJqG2GigSGkuBJKlZxkcVDfpN2ZuzeILKIcNuJb3ITZYQy2EIGCrcABxnPJ+9Bbon6TkwSB5zTUdTBPZqUQoD8U4P/ABVD/SA1PA1fqiz3m1Ffl37U2ChYwptQddBSfqDWJetdadn2W0wmtCWtp6GkJee6q0l7CcHlG08nnkmqzq12PIet8mFZm7PGfihaGUPLcC8OLSV5WSRkpIx24+tBsjTvjBdtGeH2m7ZYYTSw31zJflNKKFKLylBCCCOySCf9wrYepvFmy37wki3y5abi3RRnphSbfIcwllwtrVvSraT2TxwDyfatY6tSP/Zz0KrAz5+Vz/6jn/4qnwFH/pde05O0XeCQP/Rlf/ig2ba9dWqX4ca1Rp3REW1r8qhh1cd4uKKHdySonZnCcZx2+1ax8L77J03rq13aFb13KRHLm2KgkFe5tST2BPAUT29Ku/ga0t7Rnic20krWqzkBI7n4XKpnhRqSJpHX9qvdybeciRS7vSyAVnc0tAwCQO6h60HpPxG8erTpW8v2m3W9y6zI6tj6g6G20KHdOcEkj144qG0x+knbZ1xZj32zO25hxQT5ht/rJQT6qG0HH1GftXne4SENa3fl3NhxTC5hkLbdb3KUhatwO3IByCDjOD71NXG76Ok6gU8ixXGXHUEpSht1qEFH6NNoUB/MaD0d4reN1v0VdBarfB/WlwCEuO/tdjbQUMpBOCSSCDj2I5qj2r9Jt3zKRddON+XJ5VGkHckfZQwfzFaj8T4j1p8QZCZsFxpITHcTGfWVnp9JGEFX72ANpP0NSeqtd6avM6I9G0DaorTLexbaXnEbz/6ewfmCaDJ/SI1K1qjXbEyIypMFEBhEZ05/boUC5vxjjBcKcc8pP2rZXgF4gxdO+GFx/XsR2NbbUsKakjKjKW6tZ2IGAMgjHc9+cVqrxfZIjaNktWr9VRX7MC1GC1OJR+3eVgKVyeFpVz23Vxmanj3DwXt+mIrEszLdNVNkr2DpdNRUkc5z3cT3FBtOR+k6gSVCNphSo+eFOTNqiPsEEf8ANX3Tnjdpy76Rul6dbkRXrYhK5ENWFLO47U7D2UCSBnjHrivLGm7rYIum7jFu8N16a6f2Kmo7ZURj+Kskt4/0pNWrR03SSdMaled0vdFRG4rTUp/9YhRwt9sJCRsCQoEbhn/KR60F0l/pOTTIPk9Nx0sZ4DslRUR+CQBWy/B7xbb8RJ0yEq0rgSYzIeJDwcQoZA9gc815Xkr0/aFN3LTN1kyZSVYES5WxtQCT3ySpSDj7flW1vBjxGtsBjUt3uGnoceZAgB1cm3NdEPpLiUhCkA7QoqUnkAcZ9qD1JStK+Fvjk3rXVbVjlWYwXZCVqYcQ91ASlJUQoYGOAefpW6qKUpSgUpSgUpSgUpSgVBat0lY9WwkRdQW9qY2g7kFWUrQf9Khgip2lBr97wg0W7YGbMbUUwm3zIAQ8tK1LwRlSs5PBxgniuhrwW0S1aZNtRbnxEkPNvuJ805krbCwk5zns4v8AOtj0oKlojw807omRKe09EcjuSUpQ6VvLcyASR8xOO9SmqNL2XVUFMS/29mayk7kbxhSD7pUOR+BqZpQa0i+B2gI74dFlLhBztckuKT+W6pHVHhRpDU0yPJultJXHjpitJZeU0hDaSSEhKSB+8avVKCjTfCvSk3S9v09IgvKtcBxbrDYkLBSpRJJKs5PKj3rBb8FtEt2mRbUW58RH3m5DifNOZK20rSk5zns4v862PSgqWifDzTminZbmn4bjCpaUod3vLc3BOcfMT7moa5+C2hLjPclvWQNuuK3qSy8ttBP+0HA/CtjUoKZqLwx0jqFmI3dLO0sxWksNOIWpCwhIwElQIJAA9c10aa8JtGacntzrbZm/NtnLbj7inSg+4CiQD9avVKCuau0Rp3V6GxqC1sy1tjCHeUOJHsFJIOPp2quWvwV0HbpSJDVkS64hW5IfeW4nP+0nB/GtjUoIPVOk7Hqq3Ig323syo6DlsHKVNn/SoYI/CoTS/hZpDTMiS9a7UAuS0ph0POqdSps4ykhRIwcCrvSg1m/4G6AekF02VSCTnYiS6lP5bqtMXQ+mounHbCxZoibS7y5HKMhZ77lHuTwOc54qx0oNYveBWgHXN/6ncR/pRKdA/wDmq02bQmmbNZZVpt9nitQZadkhBBUXh/qUeT+fHpVlpQU3SHhnpTSNyXcLHbAzMUkpDq3VOFAPcJ3E4/CrlSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAqFumoottmux32JSkMtIeefQgFDSFqUkFXOe6T2BxU1VVvmnH59+cuCFAoCIyQyp1QbdCFuFaVoHBGFgjOeQKsJKw+fh+e8l5uP5zbu6HUHUx77c5xXSbtEZjNvT3mYQcWW0h95AyQSMAg4JOO2c1WU6elR7kt1xlp2Omcud5jrrKwCoqwGwnlQzt74IHb0rjarRPQlmcmEw+XWXmzGmKLZbCnlrB+U9woBQxngUouVsXObbkutvYabQlCustxISSokAd8jt6gA54zzXH9bW7yIm+fieTJx1+snp5zjG7OO9VX+yMsR0R1uMvtpZtzRKyfj6Dylr454IPFZUiwS272Z8dmM8ymYp9MZatoKVMIbKhwQFApP4KPIpUFym4d6gyUqPXbb/bKZQHFpHUKVbcp55BJH5ismPPhyZDzEeXHdfZOHG23ApSP9wByPxqq2LSz8a6R5UxqIlLXnFJS0SQ0p51Ck7cj0CVDPFctL6cl22Xb/MsMBMFlTQfTIUtTpOBnbgAA43HJPOPvSoLlOT72zFlqjNRpct9tIW4mM1u6YPbJJAz9Bk/Su1N6tphx5S5rDTMg4aU6sN7j/lwrBz6Y71gri3O33W4SLcxGlMzVJdUl14tKbcCEo9EqykhKfqDnvmotnT0+C75hLEK4uvMOIdafWUIbWt1biin4VZSSvB9cJTShaXrhDZlNRXpcduS7y20pwBa/sM5NY0a9wX5bkUvtNSUOqZS04tIW4UgElIzkjmq+9p2d0J0VLEFSZvSJkBRSY5ShCDsSQScbNyfi7n8Sf09NW5c2hGhbJs5EoSt56jaU7OcbeVDZxzjn6cqg3rS3PhuzHIjcuOuU2MrZS4CtI9ynuK7ZD7MZhb0l1tllAypbiglKR7kntVVgWCaw5b2VNRUtwpTknzSFnqvbt/BG3gnf8Rye314kLrEmXW2Wx8x2m5bDzcpyG45lCiEkFBUB6FWQcd0ilCSbuUR1xkMvIdQ82p1DqFBSClJAJ3Dj94V9j3OBJirkx5sZ2MgkKdQ6lSE475IOKhJdkkz9OXKI4xDhSJS1KSiOSU4yk4UrAzu2/EQOx9e5wUabkutzXJEJltbpY2tpmLKj0yTuKtuMgngbeccnngXKdl6ls8SVCjv3GKhcwFTJLyQFAeuc+vYe5rOfmJYkpbdTta6SnVPKWkJQEkd8nPr3xjjkjiq1Esdzjm1vqTEfejPvFSXFBB6a+x3IRgqHH7oz7+p79W2KVd1vmMWgF2yVDG9RHxuFvb6dvhOabjekJ+pLPBiGS/cYnRD6Y5UHkkBalAYPPGM5PsATXc7e7c27CbEtha5h/YBLqTvGM7hzyPtUNdNPPuPy3ILcVKS3DLTajtSpbLylkHAOAQQM4P2rCumm58ubOcMaM4melrdmUtKY5SkJKQAkFQGNwIKTknt3pUFytjtzgMyvKvTYzcnG7pKdSF498Zzii7nAQh5S5sZKWRl0l1IDfJHxc8cgjn2rXuoEpRIuFrjuW6Q/KuDTwQsK80FbkHGzHKQBwvOAn7VNO6WfTbWw02wqSi5vTloDhQHkqW5tBVg8hK0nseU/jSi1pNxgiM3IMyMI7nKHeqnar7HODXep5pLvSU4gObd+wqGdvvj2+tVW26bcS9bnZUaMkMynpKmg4p0JKkbQQSOT6nAAyT96kbtBmqu6JsFDLuYjkZSXFlG0lSSFdjkcHIoJFVzgJWyhU6KFvY6SS6nLmRkbeecj2rkJ8NU4whLjmYBuLAcHUA99uc4qpN6TkixzY60xjNdgxo7bmflW0jGc4yBu5Fc4em5bN2QXGWVspnOTPMmQrdhSlKACAO/xbfmxgfXFKguVzpSlRSlKUClKUClKoeqr9cI93mtx0pbatyG3kBakJS8VA/MS4k7f3RhKuRnngVYi0maXylUa96juMZm8ympUOOIDyGERHW8qXuSg7icg5O44wMfD+Wcu/PFqC2tbJdkXKREWjHPTR1scenCEc/X60ota6Vr213ya5HYYjzLdbGGbNGmpStrI3KC8j5hhA2j680Orbs86p5DCIyGvL5ju9Mb+ohCiCVOBQOVlIwk8p9ewUW2FSoPUE+SzcLXCivtRRLU5ukOI3AbQCEJBIG45/JJqtQbhLhaZm3hl9uQ6JT0cBH91lUopLuCoDABzycY9cc0otsGlUb+0d0j22e8oNyXob7SUNAI6kjcOWsNqUAvnIOfbIAya703qfJk2yMi5wGBJgrlrf6W4FQUPhSCRwATnPPw+nootcqVrh/WF2cZU60lhkMQ25JJCNj5UVc5W4khB28bQTz+BzNRT7vKtOqVtS0Q48Fna2G28ubiyhZyrPGNx7D+lKLXulUy5X2bCU24zPjybe20lxyS02h0nKyDuSFghOAACkHnPtipXUUpcW4RFMtxlPJjSXG1vnaEqSlJGVeiT6/SlFp6lUhu/XdUdxkKbM5LrQUhbTaFJQtKj8H7UoWfh4G4HAJ54z2xtTPmJJedea2t29x9K1NdPLqFrSrjce21OcEjng4IpRa5UqmRdQXFVxh+aWyiI8plsFtpKwpS20nCiF7kK3E4+EjGPwzr3cpaby9CYmxYLTEPzRU+jd1SVKGO4wlO0Zxz8Q7eqi1lpWrrdqa5xrJDRGS221Dt0RwBzp4eKmkk5KlpUBn4RtSeQe/arOi9T06jSxJU0iG5ILDQbbS4FfBuwVBe5Ksg904wPxpRa1YGc4596VU7xd5qNQz4LFxhQWY0FuUFPt7ipRU4DnkfCNoz681iWS8SFzUyVtiOJ8xgPNuf+GFQwvb9DuAFKLXelUSRqa5rZdfjOR/LNOygtxCEuKCW3NqTtK05TgHJGT2rP1bJWTpl5iQ0wp2cMOupO0BTDvpkc88A+uKUWtlKoL2pbqJQt7a2nCmQ80ZzSGwHAhDagAFrSnd+0IPJ/u1ce2Nc579xtipUjph5doe3FogpVh1I3DBI5xngnv3PelFtj0qjO6luYvbyEobRHanohhhfTG9JKRuyV79xzuGE4xj7iQs15nvX3y09bQbd63RS02lSFBCuCFhZOcEZCkjn2pRa00pSopSlKBWPIhRZLzT0iMw680ctrW2FKQfoT2rIrBkXe3x5qIb8xhEpZADalDOT2+2fT3oOm+2WLdoj7bjbSH3G+mJHTBWkZ7A96zPIRPMqkeVY8wogl3pjccDA579iRWM1fLY7LcjNzmC+3u3J3dtvzc9jj19vWsV/UkHyfmILqJeH2GVJSrBHVcSgK7duSR74q703O42C3KnrlOxmnSptppLa20lDYbKykpGOD8Z/IVmuwYj0luS7GYXIa+R1TYKkfY9xWOi9W1dxMBExkywSnphXO4DJT7ZA5x3rLVIZTJTHU4kPqQXAj1KQQCfzI/Oor5Kix5jXSlsNPtZB2OoChkduDX1MdlLKmksthpWdyAkbTnvkfWo17UlmZDZduMdO9tLycq/cV2UfZP1PFZP64t3nxB86x5snAa3jOcZx98c474oO2Pb4cZttuPEjtNtqK0JQ2EhKjwSAOx5P51iyLFb5ExL8iM06kNlHSW2lTfKtxVgjvn1+prsmXHoS0xGGFyJKmlPbEKAwkKA5JPGc8fY1Et6pHk2ZcmC5FjOSTH6jzqOCCpJPBPqj8c1U3J1+BEkLZXIisOrZOWlLbCig/wCnPb8K7UtNpLhShILhyvA+Y4xz78ACo5zUNpbiNSlTmQy6pSUHOSop+YY78YOfb1rrkXsecjx4EVc4vMGSlbTiAnZkAHJPOc+lQSDkCI4tlbkVhS2f7tSmwSj/AG+34V2rabWpKloSpSQQCRkgHvWAq9wG5bcSRJaZmK2gsqUCUqV2SSOAT6D19K6ZWoITchLEZ1uQ+JCI7qEL5aKlFOT+IPFBmptkBMZcZMKKI6zlTQaTtUfcjGDXJy3w3UModiR1pZ/uwpsEI9OOOPwrtYkMyAssOocCFFCig5wodx9xUK9qRtm5PR3Ib4YZlNw1SNydocWlKk8Zzj40jOP+KCWEGImQiQmKwH0J2JcDY3JHsD3Ar7JhxpKm1SY7LymjuQXEBRQfcZ7Vhx7/AGqShS2JzK0pKEkg8fGrak/YngHsa4XG9txZTMWMyuZKcd6JbbUkbD0yv4iSB8o/5FBmLt0Ja2Frhx1LjjDKi0klv/bxx+FcxDiiX5oR2fM429bYN+Pbd3qHuepEWqJJk3KMWUMMpdU2lwLdyVKAG0cY+Hg59/apqLIalR0vMKKm1diUkf8AB5orCeskGRc3p0phEh1xttG11CVpRsKyCkEcH4zz9qy34cZ9t1t+Oy426QXErQCF4xjIPfsPyqHVqVIjqmJt8tVrSogzBs27QcFzbu3bPrjtzjHNZ6r1bk3AQVTGRKJCennncRkJ9s45x3q703O1y2wXEIQ5CjKQhW9KVNJISr3HHBrvfjsyEhMhlt1IzgLSFAZBB7/QkfjUcNQ2lTzjKJzK3W9+5CTk5RncOO5GDkd66IWqbVKtEa4KkdFl8J2pdSQrJTu2gY5OPbNKk3JJ23QXYiYrsOMuKnsyppJQP/LjFdiosdSdqmGinZ08FA+X/L9uO1Y7N0jvyorTCg6iSyp9p5BBQoJKQef/ADCs6orHVCiKmJlqjMGUkbUvFsbwPYK719ahxWZDj7Mdlt9z53EoAUr7nua76UClKUClKUCq7cbJKevYmRHG44W40txxDjiVKCCMpUjOxeQCMnBAPrgVYqUFVj2K6x4SbczKhNxGEOhh4s73cqSoJJB4GN3JHzY9MmsZGl7gqU686+z+28oVJLrjhSWHupwVdwoE+2Dj71c6VbSlQhaWkx7qgl5pcFuW5MSS86VkqUpW3Zu2DBUfi9h25zUnMtUpFxjTLc6hS0MuMLEpalcLKDuB5JIKO3rnuKnKUspQrdYrvDkSocURFJ/VkWEt6Q2raSkOAqTgfFjPynHccipSJpuTCuUZcR9LUZpSFOKS6vc8EoCcKbPwZOB8ffjtVppSykT0HG9V+Y2KLL0MN7gOEqQsnB+4X/8ACaxmrG4mDBYWttRjzlyzwcEFa1AD6jcPyqfpUKU6dpaWbi5PiPNF4uvENqedZTscDf7zZByC325BzWVD0pGQ9AM5mJLajRCxtca3DeVBRUArOBwfXNWelWylYl6fluLnRmXoybdOfQ+4Sk9VvAQClOOD8gwfT619l6ZXJtrkXr9Eu3EzFuMkpUUle7APcKxgZqzUpZSFsMCdaWYtvzHdgMJWhLnIc2gp6YI7ZxuBPrgH1NcGdPtIuF4nFuN52W7vYkFoKW1+xQ2OT9Uk4+tTtKllKUbBKjx5TlxUqQ29C8q4iOtx1zcD8K0Z7cknAwE4HfvXfbtNOybfaFXxMeTKS+qZNS62FJW4ptScAcj4cpA+iat1KtlK3dNNCUm5NRVsxWJMFERpKEcNlKlqztGBj4xx96l4P6xDykTvLKaDSMOMgpJXlW4bSTgY2459TWbSoUo8/Tt+btzdst8uKu1oQqOUK3JcVHVgFHqN4HAXx9RzUgvTsoqeiIfYFtdmicpRSeslQWHNg9PmT39Bxj1q0Uq2UrsPT7rDcBJcbzHuEiYsgH4kudbA+46o/I1jw7Dc4LFqU1JhvSba0uM2FNqQhbSggc8khfwJORx3GPWrVSllKvHtkuFIhMMFLj7bcqQp4oKWg64oEJ/25UrjOcJqzNb+kjq7epgbtvbPriuVKilKUoFKUoFKUoFKV0tSWnX3WW15caxvGDxntXmc8cZiJn5+FiJl3UpSvSFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFRFr/xu6/dv+hqXqItf+N3X7t/0NYNr+7Q6p7MnXT4c+XmEvSlK3uQCCMggj3FcWnEOtpcaWlaFDKVJOQR7g1WLdbrhGVFQ60+raEbVtytiGgD8QUnPxE8+hznGU4zWRJNwb0lKacS63NaiYDqV5Upe3kgj1BoLDSqk/AuhSsR25aGFupw2uWVLThCgVbt4+Enbxk9s45xXdbI12RdIbklEgo6aQ8XHgUJIbwcBK+TuGcFJ7k7vSgsq3ENlIWtKdx2pycZPsK5VVp1tuT1xStsPFaZRdD6n/2SW9hCQEZ7gkenuc+lZWnIdwjIkeZL6SptKUiQ91f2gzlQ5PB49Rn2HqE644hptTjikoQkZUpRwAPrXKoWd+sGdPTestTsxSClosJKjkjAxge/r+PA4EdKiXpxDzDQfThUkpeD4G4LVlsDnPwg45AxjjigtJcQlxLZWkLUCUpJ5IHfA/EfnXKqw7bbqh+S3Gde8ruX0t0glRSUs8biSQSQ6AfTP2r7Dt1wXMS44qYxEAdU2yuVuUgkNhO4gnPIWQMkDP4UFmpUBaYc9Vqmx5JkMOLylpxx0qWPh+bhasc+xH2FYEuBe5DDDrhkB50OKcaYkhPRWcbOcgFIA5xnkk4OaC3VxS4hTi0JWkrRjckHkZ7ZqsO2u6ht1xp9/wAy448kkyDtDZB2YGcA524IGRmuESFcYtwdlMxJfQW4n9iuSlbm0NqTySrGAog4yff6UFspVXtMO7MXGAqUH1oDKA+pb+UJIawcAK5O4eqT3J3eldkiFc1yJgZ66X19UtyfM4aAKSEJ6fPIOPQds5PagslKqzVrnSH0Bfno0IlRLSphLgOzAJUFE4J5Az6Z9cVxj2m6BiK249KO9uOZR8yc7wT1MHPGR/l49qC10qpi03ZqKRHkSeuoSEEuSSr4N/7LGScHaAM9+eay4kK4psk5oKktvOKy0l58KcSnAyNwJ2k4Vj4jjOeOwCfS4hS1oStJUjG4A8pz71yqmrtdy6khxpma3GcfSroiUOsU9MJ+bf2CsnG71+mKzbZDurF3jqk9d1oNgOuOP5QD0wPhAIydw9UepOfSgstKUoFKUoFKUoFRFr/xu6/dv+hqXqItf+N3X7t/0NYNr+7Q6p7MnXT4c+XmEvSlD2OK3uRSqYizXXodJSn+il1CljzGXXQErBGT8JGSg5wknByO1ZTFluDYQ4p51T7ao2wrkFWEJUOoD2BykkZxzxQWdtaXG0rbUFIUMgjsRXKqqzarmksdVSlvjokSOucNBKQFoKf3txCufXdz8ooizz2E2oNF5xbSGw8VySUlW4FajyDnvjGR6EYoLVXErQFpQVJC1AkJzyQO/wDUVhvtzvPpcZdR5VKeWj3UcK+nHdPr6Vg3a1v3GbBlIIjvR2HCheclt0lBH3GAoH3BoJtCkrSFIUFJPqDmvtVJu0XPy8dLiR1eilKS2+QmM7vUpSvTcCCn0/dx2Jr67brs62lpYdSlplbZU3IAU4eqhQI/8qTwcdyOO9BbK60vtqkOMJVl1CUqUnHYHOP6H8qhDBnKssJpxG5bTu55hLxHUR8WE7iTzyk4zjjGcVjpssrriSApt5IjhA8wpW0JdUpYJPf4FY5+1BZ665DzcZhx55W1ptJUpWOwHeqlEsNy2BEmRJKlFsSF+ZwHsOAqUkAAjIz6g849AayJdomvNz2empS3UvBMgySApKgQhGz0xkD8M9yaC00qsP2eW3IcDaFvwd6iiOJKkHJbQArdnPCgvj/VnuK4CyXII3qkOLlFZStxMgpyjy5Tx3A/aYPbvzQWd51tltTjq0oQnupRwBXJKkqGUkEZxkGq7Gts5Wn5kR1OHVuAtb3MqKfh+bkgHIPbj14JNcbhZ5S7wh2Mt9McFCkdN8JSg7ypzIIOd2fTv2OBzQWWlVNi03NtjEgLfR1w6WRIIJa2qAaz/pJBz+9X02e4quDDpcfSlPS2bJWUtBPzJOU5Vnnn1zzjANBZo8liSCY7zbgABOxQPBGQfxFdtU1NhuCIrKCVhCeiHEMuhKlhLRSRk8HCsHB9qyGLJcUI6hkOmUhTAbWp8q2pCQF57A/venPFBaqVUl2i4LhNtoQ6yErbL6Uyt6nwkKCiCrgZJSecZxg4qw2aO7FtrDL61rcQMErXvPfgFWBnA4oMylKUClKUClKUCoi1/wCN3X7t/wBDUvURa/8AG7r92/6GsG1/dodU9mTrp8OfLzCXpSh5Bre5FcVrQ2AVqCQSAMnGSfSqY/Y5rMZhPTSpW9lD5bdUfNELBU4vA+HgHPf5sdhXOZpqc80hDbgaaT1S2y29hLBURtKSUHtg9sEZwOKC5V1rfaQopUtO4bcgckbjgcfU1WpOn5K4jiE9N112U464pxZOUnds7gjjI4xgdxzSPYZLb7cjpRRKU1GS7ICv2hLawV87ckKH19KC00qpt6ellLaHOmkfAJC0vKzLIcSorUMcHAVxz82Owrl/Zx8h74kZbQsRP2isNK6q1II9sJKR+BHags77zbDe95YQjITk+5OB/wAkUYebfbDjKwtBJGR9Dg/8iqkjTc8SnnVP7itzcoqcBDg6yVjICAeEpIGScdhxRzTc5cmOvr4S2Pg2OAdJXVUsqGUE8pUkcEfLjsaC4V0rlMIYU8p1HSSSkrzkAg4I/PioK9WSVOvTUpt5QaQlsIwsDpkLJUQCg9wQOCM4weK+x7EqPZJsGOxFZLr63EFvgKSXNw3YHBAOPXtQWKlV602udGvjst7pBl0OhYQvO4lYKD2ycAY5JxnjArocss3pyUtsxuq7kLeLy8vJLgPxDGMhOQM5Hp2zQWilUhuxTkrZiyWG5KENSCgKdUlCSpxJRyE4BSCQMAYxxWS7YrqqWtxEltDim1NGQFYUctbQojGchXOM4/GgtbjqGykOKCd2cZ+gzTqt/B8af2nyc/Nxnj3qupsbrjaWjGjRoxKg4wl1TiVZbUnJBAHcg9vTJ5rERpuWmTCW2GoyGEtBKGHAEtlKyVkAoz8Q74Iz2NBbt6eps3DfjO3POPeuVV65Wua/fmJrHSCGlt4VvwooGdw7H39CM+tdsu2Pu3dUkNtOAqQW3lOqSplI+ZKUjvnk9+c85AoJylVJjTskhhDyWktJLfmAl1SvMlJO5auO59vXOD2FdMzT8mJaXvKZ65bfbV01qKlJU4C0Pf4UjH09KC50qtRrC4JjK1NtsREP9byzbqikYRgHsO6sHHbjPesKFpia2nbJkFzcpvrkujD+HAoqICQeQCOSe+M4oLe+62wyt15QQ2hJUpR7ADua51TZumpjsOSxtYdCmnWowW6pIj5cWUkYH+RSB9NmOxrIm6dkPMLAXlTkxb7qep/eN/FtT8SVDjIOMY4oLVSsS0x3IlsjR33FOOtthKlKVuJP3wM/fFZdApSlAqItf+N3X7t/0NS9RFr/AMbuv3b/AKGsG1/dodU9mTrp8OfLzCXpSlb3J1xn2pLDbzCwtpwbkq9xXZVPZ0zMRIhLU4yosIaAXvO5vYfiCfhzhX+5PfkHtWbaLLMiW+4Ri41HL7expxpW9aVYI3lW1OTyO+TxyTQWOuKXEqWtAzlGAcggc/X1qqW/S60KaTMaimMHAtyOlW5C8IWnJG1IJJUnuPTueK6E6fuD8ZLMgIWllTSSh5wbHtrQSVDKVfvcjKfy70F0rqlSG4sZ2Q8cNNJK1EDOABk1WY9huDAS0TGfZ6rby1OOKyopZDZTjaeCUg5z69qyIlilMabuNuW826/IQtKXipXO5GAFZycJ7Dk8AeuaCxg5FcXFpbbUtWdqQScDJ/IVWY1kmxpDcmOxCY2PJX5Vt1QbOEOJUvds+Y7xnj90c+tY7enbg30dqo28Reit0uEkK6RT8I2ZAzg/Njvxmgt6VBSQR2IyMjFfaqr+mpC+o4082zMWteZCSStKDHLYAOPReFY7cZ71jf2YlphFttuIlRWFBrqjpg7cbiOlgk8fug8fNQXOlQVstUqLfHpSwx0XEqBUFblkkgj90EDg8FSvTGKiWtPSpDEgpaZjOuGUkvb1Bx0LUsJSrjhIyCDk9hgCgudY8GW3NYDzIX01fKVJxuHuPpUHK09vmgtMxehubKXFE72UJxubQnGClWDnkfMcg1inSymrdGjRo8HKWOlnlAZc/iownlXb2PA5FBbq62323HXW0KBW0QFj2JGR/wAVWnNNu9N1TSmhIdU91XMkF1Cl7kpUQM4xwfbJxWO9pqUW5HQjwWg48HG2EunpoGwJ7Fsg8jPAHfgjnIXBakoQpSjhIGSfpXFh1D7LbrStzbiQpJ9wRkGoa/Wl24dEhuM/sZW3teUUpQtWMOJwDyMH2PPesC26clRbnFkOuMq6SWx1Ar4gEtBBQBtztJBPzY57ZoLXSq3P087IlSZDLiGZLryyJCSd6GywW8D7LwrHbjPesSRpySuOsMxoLGVJIjtunpZAIKzls5JyP3fQc0FvroZlsPOqbaWVKSVJOEnAKcZGe3qKirxan5hiK6UST0m1IU0+VJQFHbhxOAeRg47HnuKwpen5rzchLchtAcLh4Ufi3KbODweCEKB7/N60FprihxCysIWlRQdqgDnBxnB/MVUf7KuriuIWmMD0Xgw2FEpZcVs2qThIAwUk5CRjPA7muybplRMsxIsEF+QH85DZV8GCF/AoHnJ7evoaC2UrHgpfRHSiUGt6AEgtk4VwMnB7c5454xzWRQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6UpW9yKUpQKUpQKUpQKUpQKUJCRkkAe5pQKUpQKUBB7EH04pQKUpkZIyMj0oFKUoFKUoFKZGSM8j0pQKUBBGQQRSgUpSgUpSgVEWv/G7r92/6Gpeoi1/43dfu3/Q1g2v7tDqnsyddPhz5eYS9fFglCgk4Vjg19pW9yVWz20dOO0/AkNTS2UTJW8AOK24JJz8eTyOOPp2rH6V/wB8pSpMlJVuyEspIT+0Tt2/HyNm4cAHH+rFXKvi1pQgqWoJSBkknAFBXLNGmC5R5UxqYCpktkqfylJClYKhkd0kY4J9+ea6pSr0tDrLCZCHEmT+0+HGC6C1jPf4M/lzVmQ62tW1DiFK54ByeDg/81zoKfcI99Q84zHflCK2450nAkOOKyhsoydyeNxdHPHAzxUnekXApY6SpJIYVzGwP23G0nP7vf6e9TtKCrhN52ydxleew5ygo6G39zYD+9jH45zxise5i7mEUW1NxBIcU0p5aSoKCU7QfXGSo8nHBzkYFXClBU5Iu7kiXsTIcS43lCVJSlKDhPGDkK5z7Hvmvspu9KVIEdcpL5U4FKynphO/9nsHuE//AHz6VaOq31ulvT1Nu7bnnHbOK50ECtu5MW+e20p91TUptTBUoFa2f2alDPr/AOIOawpCLzJ8242qWylKZC2EApBUobOkD9Pm4/OrUFJUpQCgSnggHtRKkqKglQJScEA9j3oKpOVdI8eUspkoQBIW2WAgfFnKCr6Yz/zn0oH727FbERLpfUVLS4vHTIMc7c/TqEcf/arWtKVJKVgFJGCD2Ir41sLSOjt6eBt29semPpRFetbd3btdxHWdckFrMbzDYSQ5tP8AqVxnH0744rFZgyxIuMpCJ61tx21RustIWtwIdBAzn/P6+p9qttKKpSHLqiRHjS1zgyt9wjpHC1thpJHJJPz59c/YcVzYXd3JamnHZhkNIj7QkoCAo/P1PQ8d/wAcc1csU4zQVGXGvnlY+2TKG9bynihIUtJz+yAAKcJxn174zxmubjN/SlTzbri5RWpAQraGwny5IOP/AHoH5+1WulBUGYNxVc1KZcuDcdwx0rddUneUpDpWPtkp/Pjis2zt3YXp5cx50sEu5QpsBAG79ntO7/L7D3zzirFXwLSVlAUCoAEjPIz2/pQU5cW9tvNojrdYZBWpsIbCsrL6yd/xDjaU989z64qXsPnxMmCaX1tnlC3AEjueAnnsMcg4PHANTdKBSlKBSlKBURa/8buv3b/oal6iLX/jd1+7f9DWDa/u0OqezJ10+HPl5hL0pSt7kqKLTdRE6hkzzJ8oV7TJ48wPl9cY9MfKfXnmuL0O/qlzlhx0lXVCACOmUEHpgArwCPhydo9eTVrjSWpKVqYXvSlRQSAcZHf7120FPkWy6oMpcNBbcWXcKChkpVICiB8Q5KM45H3FEsX5iFIbSmU8pxkoZPVSFNKCzjdlZOcHvknjmrhSgqs6BdzHHTelK6kp1TqUufEEbldMJwtOE4xwDntnNdtqYvDd1YVNL7rZbSHVFSUoSemM4AUd2VD/ACg8nnGBVlriHEKcUgLSVpAKkg8jPbNBXFWqe/ODj0mclpyS6HEoklIDOCUYAPHxBPI55weKw0wL69NiLlLe+FLQ3JUAEjADoUQsfEfi5CT6YIq1ypLMVAW+vaknaOCST7ADvXcSAMntQUdiw3CNCHlUzWpMaEtDRMsq3vjG3kqPwnHynA9xWa/FvJckFkykuqU5vWXhsW2VfCG05+FQTxnA5znPerXSgqDVvntvST0bl5Nx7cEJlAPkBtASSvdnAIVxuz27jivrUC7JCjMTJcDigp0RHktrWvotpCs5T8IKV5HGTjjFWxtxDiSptSVAEpyk55BwR+dA4gulsLT1AAopzyB74/A0FL689u5xY8mS+u5dZkLS0+nYW9o35bz7hRJ2/jjiu5mHfxMiqcceSEIZGEEbANo6gUN4BOd37p9MEVcK60SGXHC2h1tSxnKQoE8HB4+9EV+BFuKrHc48tD63nGlJbU8sZWopI7blBPOPXH0FRqLLcocToREuNtl8qcEfajcnYNpASpGMHg88kZ5FXauLTiHW0raWlaFdlJOQaKqxg31xlbDjy+Y/V6vUA3PFAR0+OQMhSs9skY7Vi3GM/GaU/a7e5aW9iG3EoLaVOrU62BjaSMgbxk/5quLchl1ZS262tQGSEqBPcj+oI/CuygqEmLeEM/8AZRPLaXVqaZW+kr27UY3L35+YLx8wweR2xl6ljXd+W0bc46lpLR29I4w7nur405GMdwod+KslKCvQbdLhQbw3FD6ZbpcWy46+pxBUdxSQFKO3BPPA/Got223ZL8hUNM1thwsJX1Xwt1SUh3cAQ4CPiUg/MOM49quaXW1qKUrSpQ7gGuVBh2dElu2R0TVFcgJwoq7/AEzyecY9TWZSlApSlApSlAqItf8Ajd1+7f8AQ1L1E2xKhebmSkgEowcd+DWHa4/7aHVPZk66fDny8wlq+KG5JBzgjHBxX2lbnJTZFpucW3sMW5EnekPLyJSjhZVlOcrHGPuPcDvXelu4uS5rAEpMzC3OqZOG+moq2JSnJAUAAM4GCM5OebXSgqjVsuD72Fqnx4WHClpUslxJ2oCdygok8hRAycfjiuK7dfC0Xmn3kTVrWnK3stoSY5AO3OP73ae2fwq20oKtbbbcjIimQuc1GS7vWhyTlRwg9yFKO0qxxn07Dmuy9wLi5Nfdhh3orUzvDTgQtxCUuZAO5OMKUg9xkA1ZaUEA7a35MKzolF5Tsd4LcIfUlQG1Q5IIyeQPWsCRb7rOa8vJakpbaZWkqMnaHlhxJSRtVn5QeTjGat1KCqSY95Lao8ZmU2lKnFIdMkH4SwoJTkq3EhZHf1Gc1JT4clNshMx1SXUtuJMhKXyHXE4OQFkjncUnuOARUzSgpLdqvTaW0p8yhGXChKJABbWXlqCnDuG4bSj0V2PHNSt7hzlznnojTi0LZabJbc2K4Woqx8SfQj1H49qsNKCvpj3JWn4rL6XzIbcAfS28A44gE/Kvd68Hkg4zUexbbs1FfSlMptKi4tKUvJU5y8FJBO4ZO3IPxD15zzVwpQVeLFufViqksSiQlATsl4S1hZ3dQFR3Epx/n9s+tYaYt2cfUyoy/Mojs7FJk7W2nNy8qUM4UMAZHOcYwO9XSlBVhbbnuLYLrTCnQpXTd2nBkLUrkHIygj//AGuhVuvYkNpLkpTKCpLRTI+TDyyFOEq+IFvp9wo8HI5q4UoK9eolzevDTkZT/lghAR0ndiULCiVFY3DII2+iux4Heudlgz4sxhyQ4+tDjLvX6jxWAvenp4BPHwlXb8anqUFUhWCVHtm0PvpfdfBWlBbQUNl7crC0pCuU+6ifxrrlxL352YY6ZKW1tvNIIkZGSn9moZXx277QQT68mrfUTqa9RdP2ObdJ69kaK0XFn3x2A+pOAPvQVvU01vTUd2XdprzdoQskBU4ocKihGCFFQJAIX8OfXgHFa4d8ctOxLyHTNuktCFpGWUnplHTwRhRSCd2edo75z6VoHxA1pdNa3x2fdHldIKPQjBXwMI9gPf3PrVaQhxwKKG1KCRk4GcUR7x0d4k6X1ctLVnubapRTkxnQW3PwSe/4Zq5A5r834sh2NIbfjOrZfbUFIcQopUkjsQR2Newv0fvEZ3WVkdg3ZwKvMAALX2LzZ7Lx7+h/A+tFbfpQHIpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQD2rTH6Ust6P4altkkIkTWmnMf5cKV/VIrc57VQvGPTS9VaFuVujgGVtDzGfVaDkD8eR+NB4ZZQHX2m1KCEqUElR7DJ71sTxRxorXJtOmW/1e3bEtFuS3/fPqU2FFal9yDuI2/L9K12+04y6tp5Cm3UKKVJUMFJHcEVNo1NKfVD/XbSLs3DSEsNyfRI7JUtOFlI/y7sURZPGW3xGLjp+6RY7UV68WlifJYaSEoS6oEKKUjsDjOPfNSf6NMt6N4qQ2midkiO824B/lCdw/5SK19qS+z9SXd25XVwLkLASAlISlCQMJSlI4AA9K3d+itpV9dzmalkNlMdDZjRiofOokFSh9ABj8T7UV6haOUiudcGhhIrnQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQK6Xm9wruoRQaS8VPBmBqqQ7crW4m33ZXK1bctvH/AFAdj9R+INaUl+B+tmJBbahRpCM46jclAT/8RB/4r2otsK7iuoxk+woPL+if0fZjstt/VcptuOkgmNFUVKX9FKxgD7Z/CvSdktUW1QGIcFhDEVhIQ22gYCQKkEMpT6V2gYoPoGBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKD/2Q==",
+              "timing": 1875,
+              "timestamp": 5250960524
+            },
+            {
+              "timestamp": 5251335524,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAEkQAAEDAwMCBAQCBwcBBQcFAAECAwQABREGEiETMQcUQVEiMmFxgZEIFSNCU5KxFjM1UmJyoRckN0OCgxhzorKzwdEnNHR18f/EABkBAQEBAQEBAAAAAAAAAAAAAAABBAMCBf/EACcRAQACAQEHBQEBAQAAAAAAAAABEQIDBCEycXKywRIUMTNSQiIj/9oADAMBAAIRAxEAPwD1TSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKDg//AHLn+0/0qjVeX/7lz/af6VRqC+UpSgUr4pQSkqUQEgZJPYVXmtcaVeuHkWtRWlcvO0NJlIJJ9u/f6UFipQkAZJ496rp1xpZM/wAkdRWkS87el5tG7Pt37/SgsVKAggEHIPrUVedQ2uyrQm6yvKIXjDzrag0Pu5jaPxNBK0qheNcr/wDSS/yYb/BjpUh1pfcFSeQRUsdX6es0SBGu98t0OUplv9m/ISlXKRyQTxQWeldcaQzKYQ/GdbeZcG5DjagpKh7gjvULd9Y6bs8sRbrfbZEk5x0npKEqH3BPH40E9SuqJJYmR0SIjzb7DgyhxtQUlQ9wR3rtoFKUoFKUoFKUoFKUoFKUoFKV8WrakmgFQT3IFfA4g9lCou5XGJb2DIuMpmMzkJ6jywhOT2GTWBD1LY5slEeHeLe/IcOENtyEKUr7AGgstK6I6yfhP4V30HB/+5c/2n+lUary/wD3Ln+0/wBKo1BfKUpQa38cH3l2ex2hLy48S8XViDLcQdp6KiSpOfTOMVY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvr3rM1dp2DqqxP2u5pV0XMKStBwtpY5StJ9CDVPd0XrOTCNsla8Wq2qT01rRb0JkqR2I6m7vj1xmgohvtyf8D4cFU10ocvAsip6VYUuN1Snfn6pG3NbcRoHSqbH+qRYrf5LZswWU7u2M7u+765zXN7RNkd0SNKmMRaUtBpKQfiSQchYP8Am3c596rSdE60RE/Vydfu/q0J6YUbegydnbHVz3x64zQQ3iDKk6E8FDH07eHpZbdTDROUsKWy2pZBG4eqR8IPcVsXT+nLZb9OItzbQkR3mQl9bx6ipGRypZPzE5rrt2jbJC0enTIiJetPTLa23viLmTkqUf8AMTzn3rFVp66Wyyiz6YnpjRtnTRImrVIcjp7YQnjOPTco4oNKx33Y/hF4oWBLq3rdZpy48Najna31B8Gfpj/mtz6J0pZoek4jZixpypcdDkmS8gOKlKUkEqUT3BzwPQVHjwzgR/DWdpKBJcb86Cp+Y4netxwqBK1DjOcYo3o7UdpieQ0vqluFbQna2zKgiQqOPUNq3Dj2Cs4oKpp+W9pD/qjarISqBZ2vOQWvmDC1tKWpA+gIzirT4WaSsbOhrbJXDizpVxjpky5T7aXFvrcG5WSRyMntU1ovR0PTNnlRC65PkznFPTpUgArkrV3KvpjgCq7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNB0eHzLdg8T9WabtY2WZDLE5tgHKY7i8hSU+wPfFbQqs6I0ixpdmY4uW/cLpOc60yc/87yvQYHASBwAO1WagUpSgUpSgUpSgUpSgUpSgVwfGWjXOh5oK7qMSTbT5ITi9uH/AOy6PUx/6vw4/wCagrKm7/rRjzQ1F0cnd5oQen2PzdP4/wAquy2SD8PIriGlk/LQfWB+0FZVcGmwgfWudBwf/uXP9p/pVGq9PDLKwOTtNUzykj+A7/IaC60pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUPHelUrV1ydXMVEbUUtNgbgD8xIzRy1tWNLH1SuBkMj/xUfzU8yz/FR/NWjNVarhaaehNzmZLhl79hZSk7dpSDnKgf3h2ya53HU0aDqKFZjGlOypTYdSpsI2JSVbcncoHjvgAnFS2SNsynf6W8PMs/xUfzU8yz/FR/NWhLlre2QNQmzuNTFyErbQ4422C22pYykE5z254Brvu+rINr1FDs0hmUqTKShSFtpSUDeopGfiz3SewNLX3mf4b08yz/ABUfzU8yz/FR/NWj2tTwnNRGzJakeaDi29xSnZlLaFnnOeyx6d80tupGp+oZtoTb7iy9EG5bzzSQ0RkhJBCicKwSOOQDS095l+W8PMs/xUfzU8yz/FR/NWjLRqmLdJN2ZjxpSRbVuNvOLCNqlIJBCQFE+nGQKxNL67tOpLi3CtyZIeVGMk9RKQEgK2lJwo/F6+2PWlr7vPf/AI+G/vMs/wAVH81PMs/xUfzVoq16sh3Ju7uMxpaGrYXEuqWEfGUZyEgKJ/dPcCvun9WwL/DmSLazKcEVtK1I2DcoqSVbUjPzcYxxzSydszj+W9PMs/xUfzV2JUlYykgj3FaP0vqBrUMV59iFOioacLR802lBUoHBxgnsQQatFpuL1vlIW2o9PPxozwRSyNtrKssabJpQHIBHrSq3lKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFUrV1tdRMVMbSVNOAbiP3SBirrQ896OWtpRq4+mWlLxYbbeXY7lyjdZyPu6St6klGSCSCCOfhHP0rhcNO2u4XSJcpkXqTYm3ou9RQ27VbhwDg8881ukxmD3Zb/lFPKsfwW/5RUpkjYso+Mmkpul7LOu7d0lW9pycgpUHST3T8pIzgkfUV3TbBbZ11YuUmNvnMBKW3gtSSkJJIHB7ZUfvnmtz+VY/gt/yinlWP4Lf8opR7LL9tNosluReF3VMVInrBBdyfUAE4zgHAAzjOBWQ1Bjsz5E1tvEmQlCHV5PxBGdox243H86255Vj+C3/ACinlWP4Lf8AKKUnscp/ppWBpu0wJs6XEidORO3eYV1FHfuOTwTgZPtiuNr0vZrXMalW+ChiQ0z0ErSpXyex557Dk88VuzyrH8Fv+UU8qx/Bb/lFKX2Wf7aTg6ZtEFdwXFidNVwChJ/aLPU3Zz3PHc9sV32ex26zF82yKmP1tvU2qJ3bRtHc+1bl8qx/Bb/lFPKsfwW/5RSidiyn5zajt8GPb2FMw2+m2pxbpGScqUoqUefck1MWi3PXCUhDaT0wfjX6AVsTyrH8Fv8AlFdiUpQMJAA9hSjHYd95ZW+gYAA9KUpVfQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQK074j+OMbROrJNjdsb0xbCELLyZIQDuSFdtp963FXiz9Jn/veun/uWP/pJoNms/pOW4uJD+mpaG/VSJKVEfgUj+tbp0Xqq16xsLV2srqlxlkpUlY2rbUO6VD0NeMXxK1tYtO2jTOnHXJtpYWiU+wgFT5WoFJVgdhjufc1eZ0rU/g34XRbZvTCvN8mOvkpIWqO0hCEkA9gokjkZx9+xHrKqb4rnVo0mv+wfT/W3UTuzt3dPBzs3fDuzjv6Z9a8ci46yXAF5F7nltSsBX6z/AGqjnGQ3v3kZ9cYrYs3Wmrbl4JXRu/frFiTElxvLz1oWyp5CirKd3G4jHf680G2/A9XiOpU7/qAD5LYPL9cID2/PPyfu4z83OcYrbFeFtDeJN70sbvJanSJMx+J5eP5l1TiW1FxBK9pOMhIOPvXKJ/1F1JarhqWNMvMuDEUoyJKZZSEEDcrCdwOACDwOBQeyddG/J0pcDpFLKr3sHlw7jGcjPfjOM4zxmtS+Ex8Xv7YNf2tD36kwrzHmul/lO3Zt5znHbitf6V8Tr7efDXV9lu055+VFgpkxZm4h4JDqEqSVDk/MMHv3qE8ENWXCDroTblcJ0qJEgy5K2nH1KCghlSuxOPSg9p0rxOnVHiJ4maqc/UsucuSgF9uJEkdFthAUMdyBwSBk8moPXOqNWPaqnm9TJsG5IKG5DDT6kJStKEpJABwM4zxxzQe9KV4F1VqC8t3RkIu9wSDBhqwJKxyYzRJ7+pJNTPiLO1fDb0tKvF3XtkWph2EIr6wW2toAKu3xnGSeck96FvcNK8e3Txl1KjwzslujXB1FycU8iROz+2U2kgIAV6Hk5V3+Ec8mqX5/WcaJHuqb1cAHlDplFz3PEnsS2F7wPqRRXvaleNNc6z1fdtCaf/XAukOfHkvt+YCFsGS2UtlKjjGSDkZ+3vVFtVw1TdrizAts+8SZjqtqGW5DhUT9s0R+gteSvFTxZ1tZPEK+2213tTEKNIKGm/LMq2jA4yUEn8TXoXwlsl209oK3W7UL5fuaN63VF0uEbllQBUe+AQPwryD43f8Aexqb/wDlH/5RQe1tGzH7hpCxzZjnUkyYLDzq8AblqbSScDgck9qmK8Wa68StQyWbRp6zT5EG3w4ERjbHWW1POdFG4qUOcZOMZxxUREvGvdN3iP5O63B2WfjS3HmCYlX0UlClD8DzQe6qZB7GvIXjdrnWE9uxiUi4WWDIgocUykLZDj2SHM9jwRwD6YPrVK0pb9V3RCZOn7z/ANqKjtjpuqWpCiPZBWCaFveVKr/h9+sv7E2UX3rfrQRkCT1/n3453fWrBRSlKUClKUClKUCvIv6Q+ldQ3TxTuUq2WK6zIq2mQl6PDccQSG0g4UAR3r11Sg8W6l8MtSQbBpu82az3PrPxNktlhlfWZeSpQyUAbgCnb6eh96lLV4Y6p1R4ZvrfiT27zb7gtxmNcErbW80ppsKCd+PVIx6cGvX1KDw7FsniZDthscS0X9iGXN5Q1EUnnOf7wDOM84zirhqjTGpNO+CFxe1jcZTkubMjhiG/JLvRSkqPqSAo55A9APw9ZVov9IDw21JrrUVqdsSI5isRi24t58ISFbie3JPH0ojQXhjop/XT96t8FaEz2IPmY4WcJWoOIBST6ZCjz74qSjWPxPsNsnafh2u/s2+WSJDDEdS215GD8QBHIABweRXovwQ8Kf8Ap81LmXCU3Ku8tAbUWgem0gHO1JPJycEnA7D8ZDxC8XbBoS+NWq8Rrk7IcYTICozSFJ2lSkjkrBzlJ9KDS2l/Ca/WXw11Zc7lBe/Wk2EmNFgNJ6j23qoUokJzydo478HNQ/ghoa9nXjbN9sV2h26RDkx3Xn4jjaQFsqT8yhjPNeqdFamhaw03FvdsbfbiSSsIS+kJWNqyk5AJHdJ9awvELXFo0JaG596LxS6vptNMo3LcVjOBnAHHqTQeRHtB6x0/eOtpcS5rKiUx7lZ3SpLiCe5Ug5T9QcYqo6ohP2/UE6JNlpmS2nNrz6V7wpzHxfF64ORn1xUxpfS901Zcbizpd9KywgyFJfdEdXTzgqOTt4yM/F61sHQngRNuV2j/ANortbI8XdlUeNKS8+6ByQNvA++T9qCkag0hqWfMiyYOn7vJjLgQ9jrMJxaFYjNA4UE4PINXrxl0tqCfadAog2K6yVxrBHZeSzEcWWlhIylWBwoex5r1lFYaixmo8dAbZaQEIQOyUgYArsoU8cR/CPUV48Mok6LbJTN2hS30uQpLZacdaIQQpIUBnB3ffPHaoaPZ/E/9XMWWPatQMxGV5QhEVTQBz6uADI59TivcFKK8u3KP4paJ0VFt0T9b3C43UrdkOspdlrhISAEtpUMhKjlRJH0x2zWr7bYvES1y3pVstWrIcl7+8eYjyG1r5zyQMmvdEq4wojgRLmRmFkbglx1KSR74JrujyGZLQdjOtvNngLbUFA/iKCq+Ehuh8ObGb/5z9Z9JXX87u62d6vm3c5xjvXlvxh0hqWf4m6hlQdPXiTGdklSHWYTi0LGByCE4Ne0qUHjvX/hFqVhq03qy26TLakwYynmGkHrRngygKBR37jPHY5BrBjWPxY1Jc4yfK32O4gBtLjiFQ22x7nhI/Hua9pUoPL+vNP8Aidp2axHtKrjfLaIrIdW4hMxDjoT8ZLa9xHOccdsVrFehtcahvCnRpWcxIdIztgeTaB7ZxtSkV7upQQehrdPtOj7Pb7xI8xcI8ZDbzm7dlQHv647Z9cVOUpQKUpQKUpQKUpQK1v4teLFt8PVRorkVyfc5COomOhYQEIzjcpWDjJBxx6GtkV44/SmiyWfFJx99KuhIiNKYUexSBtIH/mB/Og2E9+kpD/s81KYsm66dfpuw1yCAEYJC0r2nPbBGBiuUb9Ih97S9wu/9m2wYsuPG6XnT8XVQ8rdnZxjpdsfvfStF6y1HY73Z7VHs2lo9nfiJ2vyWnSovnHrwPUE5OTXTbf8Auxv/AP8A2sD/AOlLojdrf6THUtc5xVgbZmo2CM15krS4STuKjtGAAPxJFTMn9IKLA0XarlKtYevM/qKENp3ahCErKdylEEjJTwMHsaov6Kdltl5vGoEXa3xJqG2GigSGkuBJKlZxkcVDfpN2ZuzeILKIcNuJb3ITZYQy2EIGCrcABxnPJ+9Bbon6TkwSB5zTUdTBPZqUQoD8U4P/ABVD/SA1PA1fqiz3m1Ffl37U2ChYwptQddBSfqDWJetdadn2W0wmtCWtp6GkJee6q0l7CcHlG08nnkmqzq12PIet8mFZm7PGfihaGUPLcC8OLSV5WSRkpIx24+tBsjTvjBdtGeH2m7ZYYTSw31zJflNKKFKLylBCCCOySCf9wrYepvFmy37wki3y5abi3RRnphSbfIcwllwtrVvSraT2TxwDyfatY6tSP/Zz0KrAz5+Vz/6jn/4qnwFH/pde05O0XeCQP/Rlf/ig2ba9dWqX4ca1Rp3REW1r8qhh1cd4uKKHdySonZnCcZx2+1ax8L77J03rq13aFb13KRHLm2KgkFe5tST2BPAUT29Ku/ga0t7Rnic20krWqzkBI7n4XKpnhRqSJpHX9qvdybeciRS7vSyAVnc0tAwCQO6h60HpPxG8erTpW8v2m3W9y6zI6tj6g6G20KHdOcEkj144qG0x+knbZ1xZj32zO25hxQT5ht/rJQT6qG0HH1GftXne4SENa3fl3NhxTC5hkLbdb3KUhatwO3IByCDjOD71NXG76Ok6gU8ixXGXHUEpSht1qEFH6NNoUB/MaD0d4reN1v0VdBarfB/WlwCEuO/tdjbQUMpBOCSSCDj2I5qj2r9Jt3zKRddON+XJ5VGkHckfZQwfzFaj8T4j1p8QZCZsFxpITHcTGfWVnp9JGEFX72ANpP0NSeqtd6avM6I9G0DaorTLexbaXnEbz/6ewfmCaDJ/SI1K1qjXbEyIypMFEBhEZ05/boUC5vxjjBcKcc8pP2rZXgF4gxdO+GFx/XsR2NbbUsKakjKjKW6tZ2IGAMgjHc9+cVqrxfZIjaNktWr9VRX7MC1GC1OJR+3eVgKVyeFpVz23Vxmanj3DwXt+mIrEszLdNVNkr2DpdNRUkc5z3cT3FBtOR+k6gSVCNphSo+eFOTNqiPsEEf8ANX3Tnjdpy76Rul6dbkRXrYhK5ENWFLO47U7D2UCSBnjHrivLGm7rYIum7jFu8N16a6f2Kmo7ZURj+Kskt4/0pNWrR03SSdMaled0vdFRG4rTUp/9YhRwt9sJCRsCQoEbhn/KR60F0l/pOTTIPk9Nx0sZ4DslRUR+CQBWy/B7xbb8RJ0yEq0rgSYzIeJDwcQoZA9gc815Xkr0/aFN3LTN1kyZSVYES5WxtQCT3ySpSDj7flW1vBjxGtsBjUt3uGnoceZAgB1cm3NdEPpLiUhCkA7QoqUnkAcZ9qD1JStK+Fvjk3rXVbVjlWYwXZCVqYcQ91ASlJUQoYGOAefpW6qKUpSgUpSgUpSgUpSgVBat0lY9WwkRdQW9qY2g7kFWUrQf9Khgip2lBr97wg0W7YGbMbUUwm3zIAQ8tK1LwRlSs5PBxgniuhrwW0S1aZNtRbnxEkPNvuJ805krbCwk5zns4v8AOtj0oKlojw807omRKe09EcjuSUpQ6VvLcyASR8xOO9SmqNL2XVUFMS/29mayk7kbxhSD7pUOR+BqZpQa0i+B2gI74dFlLhBztckuKT+W6pHVHhRpDU0yPJultJXHjpitJZeU0hDaSSEhKSB+8avVKCjTfCvSk3S9v09IgvKtcBxbrDYkLBSpRJJKs5PKj3rBb8FtEt2mRbUW58RH3m5DifNOZK20rSk5zns4v862PSgqWifDzTminZbmn4bjCpaUod3vLc3BOcfMT7moa5+C2hLjPclvWQNuuK3qSy8ttBP+0HA/CtjUoKZqLwx0jqFmI3dLO0sxWksNOIWpCwhIwElQIJAA9c10aa8JtGacntzrbZm/NtnLbj7inSg+4CiQD9avVKCuau0Rp3V6GxqC1sy1tjCHeUOJHsFJIOPp2quWvwV0HbpSJDVkS64hW5IfeW4nP+0nB/GtjUoIPVOk7Hqq3Ig323syo6DlsHKVNn/SoYI/CoTS/hZpDTMiS9a7UAuS0ph0POqdSps4ykhRIwcCrvSg1m/4G6AekF02VSCTnYiS6lP5bqtMXQ+mounHbCxZoibS7y5HKMhZ77lHuTwOc54qx0oNYveBWgHXN/6ncR/pRKdA/wDmq02bQmmbNZZVpt9nitQZadkhBBUXh/qUeT+fHpVlpQU3SHhnpTSNyXcLHbAzMUkpDq3VOFAPcJ3E4/CrlSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAqFumoottmux32JSkMtIeefQgFDSFqUkFXOe6T2BxU1VVvmnH59+cuCFAoCIyQyp1QbdCFuFaVoHBGFgjOeQKsJKw+fh+e8l5uP5zbu6HUHUx77c5xXSbtEZjNvT3mYQcWW0h95AyQSMAg4JOO2c1WU6elR7kt1xlp2Omcud5jrrKwCoqwGwnlQzt74IHb0rjarRPQlmcmEw+XWXmzGmKLZbCnlrB+U9woBQxngUouVsXObbkutvYabQlCustxISSokAd8jt6gA54zzXH9bW7yIm+fieTJx1+snp5zjG7OO9VX+yMsR0R1uMvtpZtzRKyfj6Dylr454IPFZUiwS272Z8dmM8ymYp9MZatoKVMIbKhwQFApP4KPIpUFym4d6gyUqPXbb/bKZQHFpHUKVbcp55BJH5ismPPhyZDzEeXHdfZOHG23ApSP9wByPxqq2LSz8a6R5UxqIlLXnFJS0SQ0p51Ck7cj0CVDPFctL6cl22Xb/MsMBMFlTQfTIUtTpOBnbgAA43HJPOPvSoLlOT72zFlqjNRpct9tIW4mM1u6YPbJJAz9Bk/Su1N6tphx5S5rDTMg4aU6sN7j/lwrBz6Y71gri3O33W4SLcxGlMzVJdUl14tKbcCEo9EqykhKfqDnvmotnT0+C75hLEK4uvMOIdafWUIbWt1biin4VZSSvB9cJTShaXrhDZlNRXpcduS7y20pwBa/sM5NY0a9wX5bkUvtNSUOqZS04tIW4UgElIzkjmq+9p2d0J0VLEFSZvSJkBRSY5ShCDsSQScbNyfi7n8Sf09NW5c2hGhbJs5EoSt56jaU7OcbeVDZxzjn6cqg3rS3PhuzHIjcuOuU2MrZS4CtI9ynuK7ZD7MZhb0l1tllAypbiglKR7kntVVgWCaw5b2VNRUtwpTknzSFnqvbt/BG3gnf8Rye314kLrEmXW2Wx8x2m5bDzcpyG45lCiEkFBUB6FWQcd0ilCSbuUR1xkMvIdQ82p1DqFBSClJAJ3Dj94V9j3OBJirkx5sZ2MgkKdQ6lSE475IOKhJdkkz9OXKI4xDhSJS1KSiOSU4yk4UrAzu2/EQOx9e5wUabkutzXJEJltbpY2tpmLKj0yTuKtuMgngbeccnngXKdl6ls8SVCjv3GKhcwFTJLyQFAeuc+vYe5rOfmJYkpbdTta6SnVPKWkJQEkd8nPr3xjjkjiq1Esdzjm1vqTEfejPvFSXFBB6a+x3IRgqHH7oz7+p79W2KVd1vmMWgF2yVDG9RHxuFvb6dvhOabjekJ+pLPBiGS/cYnRD6Y5UHkkBalAYPPGM5PsATXc7e7c27CbEtha5h/YBLqTvGM7hzyPtUNdNPPuPy3ILcVKS3DLTajtSpbLylkHAOAQQM4P2rCumm58ubOcMaM4melrdmUtKY5SkJKQAkFQGNwIKTknt3pUFytjtzgMyvKvTYzcnG7pKdSF498Zzii7nAQh5S5sZKWRl0l1IDfJHxc8cgjn2rXuoEpRIuFrjuW6Q/KuDTwQsK80FbkHGzHKQBwvOAn7VNO6WfTbWw02wqSi5vTloDhQHkqW5tBVg8hK0nseU/jSi1pNxgiM3IMyMI7nKHeqnar7HODXep5pLvSU4gObd+wqGdvvj2+tVW26bcS9bnZUaMkMynpKmg4p0JKkbQQSOT6nAAyT96kbtBmqu6JsFDLuYjkZSXFlG0lSSFdjkcHIoJFVzgJWyhU6KFvY6SS6nLmRkbeecj2rkJ8NU4whLjmYBuLAcHUA99uc4qpN6TkixzY60xjNdgxo7bmflW0jGc4yBu5Fc4em5bN2QXGWVspnOTPMmQrdhSlKACAO/xbfmxgfXFKguVzpSlRSlKUClKUClKoeqr9cI93mtx0pbatyG3kBakJS8VA/MS4k7f3RhKuRnngVYi0maXylUa96juMZm8ympUOOIDyGERHW8qXuSg7icg5O44wMfD+Wcu/PFqC2tbJdkXKREWjHPTR1scenCEc/X60ota6Vr213ya5HYYjzLdbGGbNGmpStrI3KC8j5hhA2j680Orbs86p5DCIyGvL5ju9Mb+ohCiCVOBQOVlIwk8p9ewUW2FSoPUE+SzcLXCivtRRLU5ukOI3AbQCEJBIG45/JJqtQbhLhaZm3hl9uQ6JT0cBH91lUopLuCoDABzycY9cc0otsGlUb+0d0j22e8oNyXob7SUNAI6kjcOWsNqUAvnIOfbIAya703qfJk2yMi5wGBJgrlrf6W4FQUPhSCRwATnPPw+nootcqVrh/WF2cZU60lhkMQ25JJCNj5UVc5W4khB28bQTz+BzNRT7vKtOqVtS0Q48Fna2G28ubiyhZyrPGNx7D+lKLXulUy5X2bCU24zPjybe20lxyS02h0nKyDuSFghOAACkHnPtipXUUpcW4RFMtxlPJjSXG1vnaEqSlJGVeiT6/SlFp6lUhu/XdUdxkKbM5LrQUhbTaFJQtKj8H7UoWfh4G4HAJ54z2xtTPmJJedea2t29x9K1NdPLqFrSrjce21OcEjng4IpRa5UqmRdQXFVxh+aWyiI8plsFtpKwpS20nCiF7kK3E4+EjGPwzr3cpaby9CYmxYLTEPzRU+jd1SVKGO4wlO0Zxz8Q7eqi1lpWrrdqa5xrJDRGS221Dt0RwBzp4eKmkk5KlpUBn4RtSeQe/arOi9T06jSxJU0iG5ILDQbbS4FfBuwVBe5Ksg904wPxpRa1YGc4596VU7xd5qNQz4LFxhQWY0FuUFPt7ipRU4DnkfCNoz681iWS8SFzUyVtiOJ8xgPNuf+GFQwvb9DuAFKLXelUSRqa5rZdfjOR/LNOygtxCEuKCW3NqTtK05TgHJGT2rP1bJWTpl5iQ0wp2cMOupO0BTDvpkc88A+uKUWtlKoL2pbqJQt7a2nCmQ80ZzSGwHAhDagAFrSnd+0IPJ/u1ce2Nc579xtipUjph5doe3FogpVh1I3DBI5xngnv3PelFtj0qjO6luYvbyEobRHanohhhfTG9JKRuyV79xzuGE4xj7iQs15nvX3y09bQbd63RS02lSFBCuCFhZOcEZCkjn2pRa00pSopSlKBWPIhRZLzT0iMw680ctrW2FKQfoT2rIrBkXe3x5qIb8xhEpZADalDOT2+2fT3oOm+2WLdoj7bjbSH3G+mJHTBWkZ7A96zPIRPMqkeVY8wogl3pjccDA579iRWM1fLY7LcjNzmC+3u3J3dtvzc9jj19vWsV/UkHyfmILqJeH2GVJSrBHVcSgK7duSR74q703O42C3KnrlOxmnSptppLa20lDYbKykpGOD8Z/IVmuwYj0luS7GYXIa+R1TYKkfY9xWOi9W1dxMBExkywSnphXO4DJT7ZA5x3rLVIZTJTHU4kPqQXAj1KQQCfzI/Oor5Kix5jXSlsNPtZB2OoChkduDX1MdlLKmksthpWdyAkbTnvkfWo17UlmZDZduMdO9tLycq/cV2UfZP1PFZP64t3nxB86x5snAa3jOcZx98c474oO2Pb4cZttuPEjtNtqK0JQ2EhKjwSAOx5P51iyLFb5ExL8iM06kNlHSW2lTfKtxVgjvn1+prsmXHoS0xGGFyJKmlPbEKAwkKA5JPGc8fY1Et6pHk2ZcmC5FjOSTH6jzqOCCpJPBPqj8c1U3J1+BEkLZXIisOrZOWlLbCig/wCnPb8K7UtNpLhShILhyvA+Y4xz78ACo5zUNpbiNSlTmQy6pSUHOSop+YY78YOfb1rrkXsecjx4EVc4vMGSlbTiAnZkAHJPOc+lQSDkCI4tlbkVhS2f7tSmwSj/AG+34V2rabWpKloSpSQQCRkgHvWAq9wG5bcSRJaZmK2gsqUCUqV2SSOAT6D19K6ZWoITchLEZ1uQ+JCI7qEL5aKlFOT+IPFBmptkBMZcZMKKI6zlTQaTtUfcjGDXJy3w3UModiR1pZ/uwpsEI9OOOPwrtYkMyAssOocCFFCig5wodx9xUK9qRtm5PR3Ib4YZlNw1SNydocWlKk8Zzj40jOP+KCWEGImQiQmKwH0J2JcDY3JHsD3Ar7JhxpKm1SY7LymjuQXEBRQfcZ7Vhx7/AGqShS2JzK0pKEkg8fGrak/YngHsa4XG9txZTMWMyuZKcd6JbbUkbD0yv4iSB8o/5FBmLt0Ja2Frhx1LjjDKi0klv/bxx+FcxDiiX5oR2fM429bYN+Pbd3qHuepEWqJJk3KMWUMMpdU2lwLdyVKAG0cY+Hg59/apqLIalR0vMKKm1diUkf8AB5orCeskGRc3p0phEh1xttG11CVpRsKyCkEcH4zz9qy34cZ9t1t+Oy426QXErQCF4xjIPfsPyqHVqVIjqmJt8tVrSogzBs27QcFzbu3bPrjtzjHNZ6r1bk3AQVTGRKJCennncRkJ9s45x3q703O1y2wXEIQ5CjKQhW9KVNJISr3HHBrvfjsyEhMhlt1IzgLSFAZBB7/QkfjUcNQ2lTzjKJzK3W9+5CTk5RncOO5GDkd66IWqbVKtEa4KkdFl8J2pdSQrJTu2gY5OPbNKk3JJ23QXYiYrsOMuKnsyppJQP/LjFdiosdSdqmGinZ08FA+X/L9uO1Y7N0jvyorTCg6iSyp9p5BBQoJKQef/ADCs6orHVCiKmJlqjMGUkbUvFsbwPYK719ahxWZDj7Mdlt9z53EoAUr7nua76UClKUClKUCq7cbJKevYmRHG44W40txxDjiVKCCMpUjOxeQCMnBAPrgVYqUFVj2K6x4SbczKhNxGEOhh4s73cqSoJJB4GN3JHzY9MmsZGl7gqU686+z+28oVJLrjhSWHupwVdwoE+2Dj71c6VbSlQhaWkx7qgl5pcFuW5MSS86VkqUpW3Zu2DBUfi9h25zUnMtUpFxjTLc6hS0MuMLEpalcLKDuB5JIKO3rnuKnKUspQrdYrvDkSocURFJ/VkWEt6Q2raSkOAqTgfFjPynHccipSJpuTCuUZcR9LUZpSFOKS6vc8EoCcKbPwZOB8ffjtVppSykT0HG9V+Y2KLL0MN7gOEqQsnB+4X/8ACaxmrG4mDBYWttRjzlyzwcEFa1AD6jcPyqfpUKU6dpaWbi5PiPNF4uvENqedZTscDf7zZByC325BzWVD0pGQ9AM5mJLajRCxtca3DeVBRUArOBwfXNWelWylYl6fluLnRmXoybdOfQ+4Sk9VvAQClOOD8gwfT619l6ZXJtrkXr9Eu3EzFuMkpUUle7APcKxgZqzUpZSFsMCdaWYtvzHdgMJWhLnIc2gp6YI7ZxuBPrgH1NcGdPtIuF4nFuN52W7vYkFoKW1+xQ2OT9Uk4+tTtKllKUbBKjx5TlxUqQ29C8q4iOtx1zcD8K0Z7cknAwE4HfvXfbtNOybfaFXxMeTKS+qZNS62FJW4ptScAcj4cpA+iat1KtlK3dNNCUm5NRVsxWJMFERpKEcNlKlqztGBj4xx96l4P6xDykTvLKaDSMOMgpJXlW4bSTgY2459TWbSoUo8/Tt+btzdst8uKu1oQqOUK3JcVHVgFHqN4HAXx9RzUgvTsoqeiIfYFtdmicpRSeslQWHNg9PmT39Bxj1q0Uq2UrsPT7rDcBJcbzHuEiYsgH4kudbA+46o/I1jw7Dc4LFqU1JhvSba0uM2FNqQhbSggc8khfwJORx3GPWrVSllKvHtkuFIhMMFLj7bcqQp4oKWg64oEJ/25UrjOcJqzNb+kjq7epgbtvbPriuVKilKUoFKUoFKUoFKV0tSWnX3WW15caxvGDxntXmc8cZiJn5+FiJl3UpSvSFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFRFr/xu6/dv+hqXqItf+N3X7t/0NYNr+7Q6p7MnXT4c+XmEvSlK3uQCCMggj3FcWnEOtpcaWlaFDKVJOQR7g1WLdbrhGVFQ60+raEbVtytiGgD8QUnPxE8+hznGU4zWRJNwb0lKacS63NaiYDqV5Upe3kgj1BoLDSqk/AuhSsR25aGFupw2uWVLThCgVbt4+Enbxk9s45xXdbI12RdIbklEgo6aQ8XHgUJIbwcBK+TuGcFJ7k7vSgsq3ENlIWtKdx2pycZPsK5VVp1tuT1xStsPFaZRdD6n/2SW9hCQEZ7gkenuc+lZWnIdwjIkeZL6SptKUiQ91f2gzlQ5PB49Rn2HqE644hptTjikoQkZUpRwAPrXKoWd+sGdPTestTsxSClosJKjkjAxge/r+PA4EdKiXpxDzDQfThUkpeD4G4LVlsDnPwg45AxjjigtJcQlxLZWkLUCUpJ5IHfA/EfnXKqw7bbqh+S3Gde8ruX0t0glRSUs8biSQSQ6AfTP2r7Dt1wXMS44qYxEAdU2yuVuUgkNhO4gnPIWQMkDP4UFmpUBaYc9Vqmx5JkMOLylpxx0qWPh+bhasc+xH2FYEuBe5DDDrhkB50OKcaYkhPRWcbOcgFIA5xnkk4OaC3VxS4hTi0JWkrRjckHkZ7ZqsO2u6ht1xp9/wAy448kkyDtDZB2YGcA524IGRmuESFcYtwdlMxJfQW4n9iuSlbm0NqTySrGAog4yff6UFspVXtMO7MXGAqUH1oDKA+pb+UJIawcAK5O4eqT3J3eldkiFc1yJgZ66X19UtyfM4aAKSEJ6fPIOPQds5PagslKqzVrnSH0Bfno0IlRLSphLgOzAJUFE4J5Az6Z9cVxj2m6BiK249KO9uOZR8yc7wT1MHPGR/l49qC10qpi03ZqKRHkSeuoSEEuSSr4N/7LGScHaAM9+eay4kK4psk5oKktvOKy0l58KcSnAyNwJ2k4Vj4jjOeOwCfS4hS1oStJUjG4A8pz71yqmrtdy6khxpma3GcfSroiUOsU9MJ+bf2CsnG71+mKzbZDurF3jqk9d1oNgOuOP5QD0wPhAIydw9UepOfSgstKUoFKUoFKUoFRFr/xu6/dv+hqXqItf+N3X7t/0NYNr+7Q6p7MnXT4c+XmEvSlD2OK3uRSqYizXXodJSn+il1CljzGXXQErBGT8JGSg5wknByO1ZTFluDYQ4p51T7ao2wrkFWEJUOoD2BykkZxzxQWdtaXG0rbUFIUMgjsRXKqqzarmksdVSlvjokSOucNBKQFoKf3txCufXdz8ooizz2E2oNF5xbSGw8VySUlW4FajyDnvjGR6EYoLVXErQFpQVJC1AkJzyQO/wDUVhvtzvPpcZdR5VKeWj3UcK+nHdPr6Vg3a1v3GbBlIIjvR2HCheclt0lBH3GAoH3BoJtCkrSFIUFJPqDmvtVJu0XPy8dLiR1eilKS2+QmM7vUpSvTcCCn0/dx2Jr67brs62lpYdSlplbZU3IAU4eqhQI/8qTwcdyOO9BbK60vtqkOMJVl1CUqUnHYHOP6H8qhDBnKssJpxG5bTu55hLxHUR8WE7iTzyk4zjjGcVjpssrriSApt5IjhA8wpW0JdUpYJPf4FY5+1BZ665DzcZhx55W1ptJUpWOwHeqlEsNy2BEmRJKlFsSF+ZwHsOAqUkAAjIz6g849AayJdomvNz2empS3UvBMgySApKgQhGz0xkD8M9yaC00qsP2eW3IcDaFvwd6iiOJKkHJbQArdnPCgvj/VnuK4CyXII3qkOLlFZStxMgpyjy5Tx3A/aYPbvzQWd51tltTjq0oQnupRwBXJKkqGUkEZxkGq7Gts5Wn5kR1OHVuAtb3MqKfh+bkgHIPbj14JNcbhZ5S7wh2Mt9McFCkdN8JSg7ypzIIOd2fTv2OBzQWWlVNi03NtjEgLfR1w6WRIIJa2qAaz/pJBz+9X02e4quDDpcfSlPS2bJWUtBPzJOU5Vnnn1zzjANBZo8liSCY7zbgABOxQPBGQfxFdtU1NhuCIrKCVhCeiHEMuhKlhLRSRk8HCsHB9qyGLJcUI6hkOmUhTAbWp8q2pCQF57A/venPFBaqVUl2i4LhNtoQ6yErbL6Uyt6nwkKCiCrgZJSecZxg4qw2aO7FtrDL61rcQMErXvPfgFWBnA4oMylKUClKUClKUCoi1/wCN3X7t/wBDUvURa/8AG7r92/6GsG1/dodU9mTrp8OfLzCXpSh5Bre5FcVrQ2AVqCQSAMnGSfSqY/Y5rMZhPTSpW9lD5bdUfNELBU4vA+HgHPf5sdhXOZpqc80hDbgaaT1S2y29hLBURtKSUHtg9sEZwOKC5V1rfaQopUtO4bcgckbjgcfU1WpOn5K4jiE9N112U464pxZOUnds7gjjI4xgdxzSPYZLb7cjpRRKU1GS7ICv2hLawV87ckKH19KC00qpt6ellLaHOmkfAJC0vKzLIcSorUMcHAVxz82Owrl/Zx8h74kZbQsRP2isNK6q1II9sJKR+BHags77zbDe95YQjITk+5OB/wAkUYebfbDjKwtBJGR9Dg/8iqkjTc8SnnVP7itzcoqcBDg6yVjICAeEpIGScdhxRzTc5cmOvr4S2Pg2OAdJXVUsqGUE8pUkcEfLjsaC4V0rlMIYU8p1HSSSkrzkAg4I/PioK9WSVOvTUpt5QaQlsIwsDpkLJUQCg9wQOCM4weK+x7EqPZJsGOxFZLr63EFvgKSXNw3YHBAOPXtQWKlV602udGvjst7pBl0OhYQvO4lYKD2ycAY5JxnjArocss3pyUtsxuq7kLeLy8vJLgPxDGMhOQM5Hp2zQWilUhuxTkrZiyWG5KENSCgKdUlCSpxJRyE4BSCQMAYxxWS7YrqqWtxEltDim1NGQFYUctbQojGchXOM4/GgtbjqGykOKCd2cZ+gzTqt/B8af2nyc/Nxnj3qupsbrjaWjGjRoxKg4wl1TiVZbUnJBAHcg9vTJ5rERpuWmTCW2GoyGEtBKGHAEtlKyVkAoz8Q74Iz2NBbt6eps3DfjO3POPeuVV65Wua/fmJrHSCGlt4VvwooGdw7H39CM+tdsu2Pu3dUkNtOAqQW3lOqSplI+ZKUjvnk9+c85AoJylVJjTskhhDyWktJLfmAl1SvMlJO5auO59vXOD2FdMzT8mJaXvKZ65bfbV01qKlJU4C0Pf4UjH09KC50qtRrC4JjK1NtsREP9byzbqikYRgHsO6sHHbjPesKFpia2nbJkFzcpvrkujD+HAoqICQeQCOSe+M4oLe+62wyt15QQ2hJUpR7ADua51TZumpjsOSxtYdCmnWowW6pIj5cWUkYH+RSB9NmOxrIm6dkPMLAXlTkxb7qep/eN/FtT8SVDjIOMY4oLVSsS0x3IlsjR33FOOtthKlKVuJP3wM/fFZdApSlAqItf+N3X7t/0NS9RFr/AMbuv3b/AKGsG1/dodU9mTrp8OfLzCXpSlb3J1xn2pLDbzCwtpwbkq9xXZVPZ0zMRIhLU4yosIaAXvO5vYfiCfhzhX+5PfkHtWbaLLMiW+4Ri41HL7expxpW9aVYI3lW1OTyO+TxyTQWOuKXEqWtAzlGAcggc/X1qqW/S60KaTMaimMHAtyOlW5C8IWnJG1IJJUnuPTueK6E6fuD8ZLMgIWllTSSh5wbHtrQSVDKVfvcjKfy70F0rqlSG4sZ2Q8cNNJK1EDOABk1WY9huDAS0TGfZ6rby1OOKyopZDZTjaeCUg5z69qyIlilMabuNuW826/IQtKXipXO5GAFZycJ7Dk8AeuaCxg5FcXFpbbUtWdqQScDJ/IVWY1kmxpDcmOxCY2PJX5Vt1QbOEOJUvds+Y7xnj90c+tY7enbg30dqo28Reit0uEkK6RT8I2ZAzg/Njvxmgt6VBSQR2IyMjFfaqr+mpC+o4082zMWteZCSStKDHLYAOPReFY7cZ71jf2YlphFttuIlRWFBrqjpg7cbiOlgk8fug8fNQXOlQVstUqLfHpSwx0XEqBUFblkkgj90EDg8FSvTGKiWtPSpDEgpaZjOuGUkvb1Bx0LUsJSrjhIyCDk9hgCgudY8GW3NYDzIX01fKVJxuHuPpUHK09vmgtMxehubKXFE72UJxubQnGClWDnkfMcg1inSymrdGjRo8HKWOlnlAZc/iownlXb2PA5FBbq62323HXW0KBW0QFj2JGR/wAVWnNNu9N1TSmhIdU91XMkF1Cl7kpUQM4xwfbJxWO9pqUW5HQjwWg48HG2EunpoGwJ7Fsg8jPAHfgjnIXBakoQpSjhIGSfpXFh1D7LbrStzbiQpJ9wRkGoa/Wl24dEhuM/sZW3teUUpQtWMOJwDyMH2PPesC26clRbnFkOuMq6SWx1Ar4gEtBBQBtztJBPzY57ZoLXSq3P087IlSZDLiGZLryyJCSd6GywW8D7LwrHbjPesSRpySuOsMxoLGVJIjtunpZAIKzls5JyP3fQc0FvroZlsPOqbaWVKSVJOEnAKcZGe3qKirxan5hiK6UST0m1IU0+VJQFHbhxOAeRg47HnuKwpen5rzchLchtAcLh4Ufi3KbODweCEKB7/N60FprihxCysIWlRQdqgDnBxnB/MVUf7KuriuIWmMD0Xgw2FEpZcVs2qThIAwUk5CRjPA7muybplRMsxIsEF+QH85DZV8GCF/AoHnJ7evoaC2UrHgpfRHSiUGt6AEgtk4VwMnB7c5454xzWRQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6UpW9yKUpQKUpQKUpQKUpQKUJCRkkAe5pQKUpQKUBB7EH04pQKUpkZIyMj0oFKUoFKUoFKZGSM8j0pQKUBBGQQRSgUpSgUpSgVEWv/G7r92/6Gpeoi1/43dfu3/Q1g2v7tDqnsyddPhz5eYS9fFglCgk4Vjg19pW9yVWz20dOO0/AkNTS2UTJW8AOK24JJz8eTyOOPp2rH6V/wB8pSpMlJVuyEspIT+0Tt2/HyNm4cAHH+rFXKvi1pQgqWoJSBkknAFBXLNGmC5R5UxqYCpktkqfylJClYKhkd0kY4J9+ea6pSr0tDrLCZCHEmT+0+HGC6C1jPf4M/lzVmQ62tW1DiFK54ByeDg/81zoKfcI99Q84zHflCK2450nAkOOKyhsoydyeNxdHPHAzxUnekXApY6SpJIYVzGwP23G0nP7vf6e9TtKCrhN52ydxleew5ygo6G39zYD+9jH45zxise5i7mEUW1NxBIcU0p5aSoKCU7QfXGSo8nHBzkYFXClBU5Iu7kiXsTIcS43lCVJSlKDhPGDkK5z7Hvmvspu9KVIEdcpL5U4FKynphO/9nsHuE//AHz6VaOq31ulvT1Nu7bnnHbOK50ECtu5MW+e20p91TUptTBUoFa2f2alDPr/AOIOawpCLzJ8242qWylKZC2EApBUobOkD9Pm4/OrUFJUpQCgSnggHtRKkqKglQJScEA9j3oKpOVdI8eUspkoQBIW2WAgfFnKCr6Yz/zn0oH727FbERLpfUVLS4vHTIMc7c/TqEcf/arWtKVJKVgFJGCD2Ir41sLSOjt6eBt29semPpRFetbd3btdxHWdckFrMbzDYSQ5tP8AqVxnH0744rFZgyxIuMpCJ61tx21RustIWtwIdBAzn/P6+p9qttKKpSHLqiRHjS1zgyt9wjpHC1thpJHJJPz59c/YcVzYXd3JamnHZhkNIj7QkoCAo/P1PQ8d/wAcc1csU4zQVGXGvnlY+2TKG9bynihIUtJz+yAAKcJxn174zxmubjN/SlTzbri5RWpAQraGwny5IOP/AHoH5+1WulBUGYNxVc1KZcuDcdwx0rddUneUpDpWPtkp/Pjis2zt3YXp5cx50sEu5QpsBAG79ntO7/L7D3zzirFXwLSVlAUCoAEjPIz2/pQU5cW9tvNojrdYZBWpsIbCsrL6yd/xDjaU989z64qXsPnxMmCaX1tnlC3AEjueAnnsMcg4PHANTdKBSlKBSlKBURa/8buv3b/oal6iLX/jd1+7f9DWDa/u0OqezJ10+HPl5hL0pSt7kqKLTdRE6hkzzJ8oV7TJ48wPl9cY9MfKfXnmuL0O/qlzlhx0lXVCACOmUEHpgArwCPhydo9eTVrjSWpKVqYXvSlRQSAcZHf7120FPkWy6oMpcNBbcWXcKChkpVICiB8Q5KM45H3FEsX5iFIbSmU8pxkoZPVSFNKCzjdlZOcHvknjmrhSgqs6BdzHHTelK6kp1TqUufEEbldMJwtOE4xwDntnNdtqYvDd1YVNL7rZbSHVFSUoSemM4AUd2VD/ACg8nnGBVlriHEKcUgLSVpAKkg8jPbNBXFWqe/ODj0mclpyS6HEoklIDOCUYAPHxBPI55weKw0wL69NiLlLe+FLQ3JUAEjADoUQsfEfi5CT6YIq1ypLMVAW+vaknaOCST7ADvXcSAMntQUdiw3CNCHlUzWpMaEtDRMsq3vjG3kqPwnHynA9xWa/FvJckFkykuqU5vWXhsW2VfCG05+FQTxnA5znPerXSgqDVvntvST0bl5Nx7cEJlAPkBtASSvdnAIVxuz27jivrUC7JCjMTJcDigp0RHktrWvotpCs5T8IKV5HGTjjFWxtxDiSptSVAEpyk55BwR+dA4gulsLT1AAopzyB74/A0FL689u5xY8mS+u5dZkLS0+nYW9o35bz7hRJ2/jjiu5mHfxMiqcceSEIZGEEbANo6gUN4BOd37p9MEVcK60SGXHC2h1tSxnKQoE8HB4+9EV+BFuKrHc48tD63nGlJbU8sZWopI7blBPOPXH0FRqLLcocToREuNtl8qcEfajcnYNpASpGMHg88kZ5FXauLTiHW0raWlaFdlJOQaKqxg31xlbDjy+Y/V6vUA3PFAR0+OQMhSs9skY7Vi3GM/GaU/a7e5aW9iG3EoLaVOrU62BjaSMgbxk/5quLchl1ZS262tQGSEqBPcj+oI/CuygqEmLeEM/8AZRPLaXVqaZW+kr27UY3L35+YLx8wweR2xl6ljXd+W0bc46lpLR29I4w7nur405GMdwod+KslKCvQbdLhQbw3FD6ZbpcWy46+pxBUdxSQFKO3BPPA/Got223ZL8hUNM1thwsJX1Xwt1SUh3cAQ4CPiUg/MOM49quaXW1qKUrSpQ7gGuVBh2dElu2R0TVFcgJwoq7/AEzyecY9TWZSlApSlApSlAqItf8Ajd1+7f8AQ1L1E2xKhebmSkgEowcd+DWHa4/7aHVPZk66fDny8wlq+KG5JBzgjHBxX2lbnJTZFpucW3sMW5EnekPLyJSjhZVlOcrHGPuPcDvXelu4uS5rAEpMzC3OqZOG+moq2JSnJAUAAM4GCM5OebXSgqjVsuD72Fqnx4WHClpUslxJ2oCdygok8hRAycfjiuK7dfC0Xmn3kTVrWnK3stoSY5AO3OP73ae2fwq20oKtbbbcjIimQuc1GS7vWhyTlRwg9yFKO0qxxn07Dmuy9wLi5Nfdhh3orUzvDTgQtxCUuZAO5OMKUg9xkA1ZaUEA7a35MKzolF5Tsd4LcIfUlQG1Q5IIyeQPWsCRb7rOa8vJakpbaZWkqMnaHlhxJSRtVn5QeTjGat1KCqSY95Lao8ZmU2lKnFIdMkH4SwoJTkq3EhZHf1Gc1JT4clNshMx1SXUtuJMhKXyHXE4OQFkjncUnuOARUzSgpLdqvTaW0p8yhGXChKJABbWXlqCnDuG4bSj0V2PHNSt7hzlznnojTi0LZabJbc2K4Woqx8SfQj1H49qsNKCvpj3JWn4rL6XzIbcAfS28A44gE/Kvd68Hkg4zUexbbs1FfSlMptKi4tKUvJU5y8FJBO4ZO3IPxD15zzVwpQVeLFufViqksSiQlATsl4S1hZ3dQFR3Epx/n9s+tYaYt2cfUyoy/Mojs7FJk7W2nNy8qUM4UMAZHOcYwO9XSlBVhbbnuLYLrTCnQpXTd2nBkLUrkHIygj//AGuhVuvYkNpLkpTKCpLRTI+TDyyFOEq+IFvp9wo8HI5q4UoK9eolzevDTkZT/lghAR0ndiULCiVFY3DII2+iux4Heudlgz4sxhyQ4+tDjLvX6jxWAvenp4BPHwlXb8anqUFUhWCVHtm0PvpfdfBWlBbQUNl7crC0pCuU+6ifxrrlxL352YY6ZKW1tvNIIkZGSn9moZXx277QQT68mrfUTqa9RdP2ObdJ69kaK0XFn3x2A+pOAPvQVvU01vTUd2XdprzdoQskBU4ocKihGCFFQJAIX8OfXgHFa4d8ctOxLyHTNuktCFpGWUnplHTwRhRSCd2edo75z6VoHxA1pdNa3x2fdHldIKPQjBXwMI9gPf3PrVaQhxwKKG1KCRk4GcUR7x0d4k6X1ctLVnubapRTkxnQW3PwSe/4Zq5A5r834sh2NIbfjOrZfbUFIcQopUkjsQR2Newv0fvEZ3WVkdg3ZwKvMAALX2LzZ7Lx7+h/A+tFbfpQHIpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQD2rTH6Ust6P4altkkIkTWmnMf5cKV/VIrc57VQvGPTS9VaFuVujgGVtDzGfVaDkD8eR+NB4ZZQHX2m1KCEqUElR7DJ71sTxRxorXJtOmW/1e3bEtFuS3/fPqU2FFal9yDuI2/L9K12+04y6tp5Cm3UKKVJUMFJHcEVNo1NKfVD/XbSLs3DSEsNyfRI7JUtOFlI/y7sURZPGW3xGLjp+6RY7UV68WlifJYaSEoS6oEKKUjsDjOPfNSf6NMt6N4qQ2midkiO824B/lCdw/5SK19qS+z9SXd25XVwLkLASAlISlCQMJSlI4AA9K3d+itpV9dzmalkNlMdDZjRiofOokFSh9ABj8T7UV6haOUiudcGhhIrnQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQK6Xm9wruoRQaS8VPBmBqqQ7crW4m33ZXK1bctvH/AFAdj9R+INaUl+B+tmJBbahRpCM46jclAT/8RB/4r2otsK7iuoxk+woPL+if0fZjstt/VcptuOkgmNFUVKX9FKxgD7Z/CvSdktUW1QGIcFhDEVhIQ22gYCQKkEMpT6V2gYoPoGBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKD/2Q==",
+              "timing": 2250
+            },
+            {
+              "timestamp": 5251710524,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAEkQAAEDAwMCBAQCBwcBBQcFAAECAwQABREGEiETMQcUQVEiMmFxgZEIFSNCU5KxFjM1UmJyoRckN0OCgxhzorKzwdEnNHR18f/EABkBAQEBAQEBAAAAAAAAAAAAAAABBAMCBf/EACcRAQACAQEHBQEBAQAAAAAAAAABEQIDBCEycXKywRIUMTNSQiIj/9oADAMBAAIRAxEAPwD1TSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKDg//AHLn+0/0qjVeX/7lz/af6VRqC+UpSgUr4pQSkqUQEgZJPYVXmtcaVeuHkWtRWlcvO0NJlIJJ9u/f6UFipQkAZJ496rp1xpZM/wAkdRWkS87el5tG7Pt37/SgsVKAggEHIPrUVedQ2uyrQm6yvKIXjDzrag0Pu5jaPxNBK0qheNcr/wDSS/yYb/BjpUh1pfcFSeQRUsdX6es0SBGu98t0OUplv9m/ISlXKRyQTxQWeldcaQzKYQ/GdbeZcG5DjagpKh7gjvULd9Y6bs8sRbrfbZEk5x0npKEqH3BPH40E9SuqJJYmR0SIjzb7DgyhxtQUlQ9wR3rtoFKUoFKUoFKUoFKUoFKUoFKV8WrakmgFQT3IFfA4g9lCou5XGJb2DIuMpmMzkJ6jywhOT2GTWBD1LY5slEeHeLe/IcOENtyEKUr7AGgstK6I6yfhP4V30HB/+5c/2n+lUary/wD3Ln+0/wBKo1BfKUpQa38cH3l2ex2hLy48S8XViDLcQdp6KiSpOfTOMVY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvr3rM1dp2DqqxP2u5pV0XMKStBwtpY5StJ9CDVPd0XrOTCNsla8Wq2qT01rRb0JkqR2I6m7vj1xmgohvtyf8D4cFU10ocvAsip6VYUuN1Snfn6pG3NbcRoHSqbH+qRYrf5LZswWU7u2M7u+765zXN7RNkd0SNKmMRaUtBpKQfiSQchYP8Am3c596rSdE60RE/Vydfu/q0J6YUbegydnbHVz3x64zQQ3iDKk6E8FDH07eHpZbdTDROUsKWy2pZBG4eqR8IPcVsXT+nLZb9OItzbQkR3mQl9bx6ipGRypZPzE5rrt2jbJC0enTIiJetPTLa23viLmTkqUf8AMTzn3rFVp66Wyyiz6YnpjRtnTRImrVIcjp7YQnjOPTco4oNKx33Y/hF4oWBLq3rdZpy48Najna31B8Gfpj/mtz6J0pZoek4jZixpypcdDkmS8gOKlKUkEqUT3BzwPQVHjwzgR/DWdpKBJcb86Cp+Y4netxwqBK1DjOcYo3o7UdpieQ0vqluFbQna2zKgiQqOPUNq3Dj2Cs4oKpp+W9pD/qjarISqBZ2vOQWvmDC1tKWpA+gIzirT4WaSsbOhrbJXDizpVxjpky5T7aXFvrcG5WSRyMntU1ovR0PTNnlRC65PkznFPTpUgArkrV3KvpjgCq7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNB0eHzLdg8T9WabtY2WZDLE5tgHKY7i8hSU+wPfFbQqs6I0ixpdmY4uW/cLpOc60yc/87yvQYHASBwAO1WagUpSgUpSgUpSgUpSgUpSgVwfGWjXOh5oK7qMSTbT5ITi9uH/AOy6PUx/6vw4/wCagrKm7/rRjzQ1F0cnd5oQen2PzdP4/wAquy2SD8PIriGlk/LQfWB+0FZVcGmwgfWudBwf/uXP9p/pVGq9PDLKwOTtNUzykj+A7/IaC60pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUPHelUrV1ydXMVEbUUtNgbgD8xIzRy1tWNLH1SuBkMj/xUfzU8yz/FR/NWjNVarhaaehNzmZLhl79hZSk7dpSDnKgf3h2ya53HU0aDqKFZjGlOypTYdSpsI2JSVbcncoHjvgAnFS2SNsynf6W8PMs/xUfzU8yz/FR/NWhLlre2QNQmzuNTFyErbQ4422C22pYykE5z254Brvu+rINr1FDs0hmUqTKShSFtpSUDeopGfiz3SewNLX3mf4b08yz/ABUfzU8yz/FR/NWj2tTwnNRGzJakeaDi29xSnZlLaFnnOeyx6d80tupGp+oZtoTb7iy9EG5bzzSQ0RkhJBCicKwSOOQDS095l+W8PMs/xUfzU8yz/FR/NWjLRqmLdJN2ZjxpSRbVuNvOLCNqlIJBCQFE+nGQKxNL67tOpLi3CtyZIeVGMk9RKQEgK2lJwo/F6+2PWlr7vPf/AI+G/vMs/wAVH81PMs/xUfzVoq16sh3Ju7uMxpaGrYXEuqWEfGUZyEgKJ/dPcCvun9WwL/DmSLazKcEVtK1I2DcoqSVbUjPzcYxxzSydszj+W9PMs/xUfzV2JUlYykgj3FaP0vqBrUMV59iFOioacLR802lBUoHBxgnsQQatFpuL1vlIW2o9PPxozwRSyNtrKssabJpQHIBHrSq3lKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFUrV1tdRMVMbSVNOAbiP3SBirrQ896OWtpRq4+mWlLxYbbeXY7lyjdZyPu6St6klGSCSCCOfhHP0rhcNO2u4XSJcpkXqTYm3ou9RQ27VbhwDg8881ukxmD3Zb/lFPKsfwW/5RUpkjYso+Mmkpul7LOu7d0lW9pycgpUHST3T8pIzgkfUV3TbBbZ11YuUmNvnMBKW3gtSSkJJIHB7ZUfvnmtz+VY/gt/yinlWP4Lf8opR7LL9tNosluReF3VMVInrBBdyfUAE4zgHAAzjOBWQ1Bjsz5E1tvEmQlCHV5PxBGdox243H86255Vj+C3/ACinlWP4Lf8AKKUnscp/ppWBpu0wJs6XEidORO3eYV1FHfuOTwTgZPtiuNr0vZrXMalW+ChiQ0z0ErSpXyex557Dk88VuzyrH8Fv+UU8qx/Bb/lFKX2Wf7aTg6ZtEFdwXFidNVwChJ/aLPU3Zz3PHc9sV32ex26zF82yKmP1tvU2qJ3bRtHc+1bl8qx/Bb/lFPKsfwW/5RSidiyn5zajt8GPb2FMw2+m2pxbpGScqUoqUefck1MWi3PXCUhDaT0wfjX6AVsTyrH8Fv8AlFdiUpQMJAA9hSjHYd95ZW+gYAA9KUpVfQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQK074j+OMbROrJNjdsb0xbCELLyZIQDuSFdtp963FXiz9Jn/veun/uWP/pJoNms/pOW4uJD+mpaG/VSJKVEfgUj+tbp0Xqq16xsLV2srqlxlkpUlY2rbUO6VD0NeMXxK1tYtO2jTOnHXJtpYWiU+wgFT5WoFJVgdhjufc1eZ0rU/g34XRbZvTCvN8mOvkpIWqO0hCEkA9gokjkZx9+xHrKqb4rnVo0mv+wfT/W3UTuzt3dPBzs3fDuzjv6Z9a8ci46yXAF5F7nltSsBX6z/AGqjnGQ3v3kZ9cYrYs3Wmrbl4JXRu/frFiTElxvLz1oWyp5CirKd3G4jHf680G2/A9XiOpU7/qAD5LYPL9cID2/PPyfu4z83OcYrbFeFtDeJN70sbvJanSJMx+J5eP5l1TiW1FxBK9pOMhIOPvXKJ/1F1JarhqWNMvMuDEUoyJKZZSEEDcrCdwOACDwOBQeyddG/J0pcDpFLKr3sHlw7jGcjPfjOM4zxmtS+Ex8Xv7YNf2tD36kwrzHmul/lO3Zt5znHbitf6V8Tr7efDXV9lu055+VFgpkxZm4h4JDqEqSVDk/MMHv3qE8ENWXCDroTblcJ0qJEgy5K2nH1KCghlSuxOPSg9p0rxOnVHiJ4maqc/UsucuSgF9uJEkdFthAUMdyBwSBk8moPXOqNWPaqnm9TJsG5IKG5DDT6kJStKEpJABwM4zxxzQe9KV4F1VqC8t3RkIu9wSDBhqwJKxyYzRJ7+pJNTPiLO1fDb0tKvF3XtkWph2EIr6wW2toAKu3xnGSeck96FvcNK8e3Txl1KjwzslujXB1FycU8iROz+2U2kgIAV6Hk5V3+Ec8mqX5/WcaJHuqb1cAHlDplFz3PEnsS2F7wPqRRXvaleNNc6z1fdtCaf/XAukOfHkvt+YCFsGS2UtlKjjGSDkZ+3vVFtVw1TdrizAts+8SZjqtqGW5DhUT9s0R+gteSvFTxZ1tZPEK+2213tTEKNIKGm/LMq2jA4yUEn8TXoXwlsl209oK3W7UL5fuaN63VF0uEbllQBUe+AQPwryD43f8Aexqb/wDlH/5RQe1tGzH7hpCxzZjnUkyYLDzq8AblqbSScDgck9qmK8Wa68StQyWbRp6zT5EG3w4ERjbHWW1POdFG4qUOcZOMZxxUREvGvdN3iP5O63B2WfjS3HmCYlX0UlClD8DzQe6qZB7GvIXjdrnWE9uxiUi4WWDIgocUykLZDj2SHM9jwRwD6YPrVK0pb9V3RCZOn7z/ANqKjtjpuqWpCiPZBWCaFveVKr/h9+sv7E2UX3rfrQRkCT1/n3453fWrBRSlKUClKUClKUCvIv6Q+ldQ3TxTuUq2WK6zIq2mQl6PDccQSG0g4UAR3r11Sg8W6l8MtSQbBpu82az3PrPxNktlhlfWZeSpQyUAbgCnb6eh96lLV4Y6p1R4ZvrfiT27zb7gtxmNcErbW80ppsKCd+PVIx6cGvX1KDw7FsniZDthscS0X9iGXN5Q1EUnnOf7wDOM84zirhqjTGpNO+CFxe1jcZTkubMjhiG/JLvRSkqPqSAo55A9APw9ZVov9IDw21JrrUVqdsSI5isRi24t58ISFbie3JPH0ojQXhjop/XT96t8FaEz2IPmY4WcJWoOIBST6ZCjz74qSjWPxPsNsnafh2u/s2+WSJDDEdS215GD8QBHIABweRXovwQ8Kf8Ap81LmXCU3Ku8tAbUWgem0gHO1JPJycEnA7D8ZDxC8XbBoS+NWq8Rrk7IcYTICozSFJ2lSkjkrBzlJ9KDS2l/Ca/WXw11Zc7lBe/Wk2EmNFgNJ6j23qoUokJzydo478HNQ/ghoa9nXjbN9sV2h26RDkx3Xn4jjaQFsqT8yhjPNeqdFamhaw03FvdsbfbiSSsIS+kJWNqyk5AJHdJ9awvELXFo0JaG596LxS6vptNMo3LcVjOBnAHHqTQeRHtB6x0/eOtpcS5rKiUx7lZ3SpLiCe5Ug5T9QcYqo6ohP2/UE6JNlpmS2nNrz6V7wpzHxfF64ORn1xUxpfS901Zcbizpd9KywgyFJfdEdXTzgqOTt4yM/F61sHQngRNuV2j/ANortbI8XdlUeNKS8+6ByQNvA++T9qCkag0hqWfMiyYOn7vJjLgQ9jrMJxaFYjNA4UE4PINXrxl0tqCfadAog2K6yVxrBHZeSzEcWWlhIylWBwoex5r1lFYaixmo8dAbZaQEIQOyUgYArsoU8cR/CPUV48Mok6LbJTN2hS30uQpLZacdaIQQpIUBnB3ffPHaoaPZ/E/9XMWWPatQMxGV5QhEVTQBz6uADI59TivcFKK8u3KP4paJ0VFt0T9b3C43UrdkOspdlrhISAEtpUMhKjlRJH0x2zWr7bYvES1y3pVstWrIcl7+8eYjyG1r5zyQMmvdEq4wojgRLmRmFkbglx1KSR74JrujyGZLQdjOtvNngLbUFA/iKCq+Ehuh8ObGb/5z9Z9JXX87u62d6vm3c5xjvXlvxh0hqWf4m6hlQdPXiTGdklSHWYTi0LGByCE4Ne0qUHjvX/hFqVhq03qy26TLakwYynmGkHrRngygKBR37jPHY5BrBjWPxY1Jc4yfK32O4gBtLjiFQ22x7nhI/Hua9pUoPL+vNP8Aidp2axHtKrjfLaIrIdW4hMxDjoT8ZLa9xHOccdsVrFehtcahvCnRpWcxIdIztgeTaB7ZxtSkV7upQQehrdPtOj7Pb7xI8xcI8ZDbzm7dlQHv647Z9cVOUpQKUpQKUpQKUpQK1v4teLFt8PVRorkVyfc5COomOhYQEIzjcpWDjJBxx6GtkV44/SmiyWfFJx99KuhIiNKYUexSBtIH/mB/Og2E9+kpD/s81KYsm66dfpuw1yCAEYJC0r2nPbBGBiuUb9Ih97S9wu/9m2wYsuPG6XnT8XVQ8rdnZxjpdsfvfStF6y1HY73Z7VHs2lo9nfiJ2vyWnSovnHrwPUE5OTXTbf8Auxv/AP8A2sD/AOlLojdrf6THUtc5xVgbZmo2CM15krS4STuKjtGAAPxJFTMn9IKLA0XarlKtYevM/qKENp3ahCErKdylEEjJTwMHsaov6Kdltl5vGoEXa3xJqG2GigSGkuBJKlZxkcVDfpN2ZuzeILKIcNuJb3ITZYQy2EIGCrcABxnPJ+9Bbon6TkwSB5zTUdTBPZqUQoD8U4P/ABVD/SA1PA1fqiz3m1Ffl37U2ChYwptQddBSfqDWJetdadn2W0wmtCWtp6GkJee6q0l7CcHlG08nnkmqzq12PIet8mFZm7PGfihaGUPLcC8OLSV5WSRkpIx24+tBsjTvjBdtGeH2m7ZYYTSw31zJflNKKFKLylBCCCOySCf9wrYepvFmy37wki3y5abi3RRnphSbfIcwllwtrVvSraT2TxwDyfatY6tSP/Zz0KrAz5+Vz/6jn/4qnwFH/pde05O0XeCQP/Rlf/ig2ba9dWqX4ca1Rp3REW1r8qhh1cd4uKKHdySonZnCcZx2+1ax8L77J03rq13aFb13KRHLm2KgkFe5tST2BPAUT29Ku/ga0t7Rnic20krWqzkBI7n4XKpnhRqSJpHX9qvdybeciRS7vSyAVnc0tAwCQO6h60HpPxG8erTpW8v2m3W9y6zI6tj6g6G20KHdOcEkj144qG0x+knbZ1xZj32zO25hxQT5ht/rJQT6qG0HH1GftXne4SENa3fl3NhxTC5hkLbdb3KUhatwO3IByCDjOD71NXG76Ok6gU8ixXGXHUEpSht1qEFH6NNoUB/MaD0d4reN1v0VdBarfB/WlwCEuO/tdjbQUMpBOCSSCDj2I5qj2r9Jt3zKRddON+XJ5VGkHckfZQwfzFaj8T4j1p8QZCZsFxpITHcTGfWVnp9JGEFX72ANpP0NSeqtd6avM6I9G0DaorTLexbaXnEbz/6ewfmCaDJ/SI1K1qjXbEyIypMFEBhEZ05/boUC5vxjjBcKcc8pP2rZXgF4gxdO+GFx/XsR2NbbUsKakjKjKW6tZ2IGAMgjHc9+cVqrxfZIjaNktWr9VRX7MC1GC1OJR+3eVgKVyeFpVz23Vxmanj3DwXt+mIrEszLdNVNkr2DpdNRUkc5z3cT3FBtOR+k6gSVCNphSo+eFOTNqiPsEEf8ANX3Tnjdpy76Rul6dbkRXrYhK5ENWFLO47U7D2UCSBnjHrivLGm7rYIum7jFu8N16a6f2Kmo7ZURj+Kskt4/0pNWrR03SSdMaled0vdFRG4rTUp/9YhRwt9sJCRsCQoEbhn/KR60F0l/pOTTIPk9Nx0sZ4DslRUR+CQBWy/B7xbb8RJ0yEq0rgSYzIeJDwcQoZA9gc815Xkr0/aFN3LTN1kyZSVYES5WxtQCT3ySpSDj7flW1vBjxGtsBjUt3uGnoceZAgB1cm3NdEPpLiUhCkA7QoqUnkAcZ9qD1JStK+Fvjk3rXVbVjlWYwXZCVqYcQ91ASlJUQoYGOAefpW6qKUpSgUpSgUpSgUpSgVBat0lY9WwkRdQW9qY2g7kFWUrQf9Khgip2lBr97wg0W7YGbMbUUwm3zIAQ8tK1LwRlSs5PBxgniuhrwW0S1aZNtRbnxEkPNvuJ805krbCwk5zns4v8AOtj0oKlojw807omRKe09EcjuSUpQ6VvLcyASR8xOO9SmqNL2XVUFMS/29mayk7kbxhSD7pUOR+BqZpQa0i+B2gI74dFlLhBztckuKT+W6pHVHhRpDU0yPJultJXHjpitJZeU0hDaSSEhKSB+8avVKCjTfCvSk3S9v09IgvKtcBxbrDYkLBSpRJJKs5PKj3rBb8FtEt2mRbUW58RH3m5DifNOZK20rSk5zns4v862PSgqWifDzTminZbmn4bjCpaUod3vLc3BOcfMT7moa5+C2hLjPclvWQNuuK3qSy8ttBP+0HA/CtjUoKZqLwx0jqFmI3dLO0sxWksNOIWpCwhIwElQIJAA9c10aa8JtGacntzrbZm/NtnLbj7inSg+4CiQD9avVKCuau0Rp3V6GxqC1sy1tjCHeUOJHsFJIOPp2quWvwV0HbpSJDVkS64hW5IfeW4nP+0nB/GtjUoIPVOk7Hqq3Ig323syo6DlsHKVNn/SoYI/CoTS/hZpDTMiS9a7UAuS0ph0POqdSps4ykhRIwcCrvSg1m/4G6AekF02VSCTnYiS6lP5bqtMXQ+mounHbCxZoibS7y5HKMhZ77lHuTwOc54qx0oNYveBWgHXN/6ncR/pRKdA/wDmq02bQmmbNZZVpt9nitQZadkhBBUXh/qUeT+fHpVlpQU3SHhnpTSNyXcLHbAzMUkpDq3VOFAPcJ3E4/CrlSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAqFumoottmux32JSkMtIeefQgFDSFqUkFXOe6T2BxU1VVvmnH59+cuCFAoCIyQyp1QbdCFuFaVoHBGFgjOeQKsJKw+fh+e8l5uP5zbu6HUHUx77c5xXSbtEZjNvT3mYQcWW0h95AyQSMAg4JOO2c1WU6elR7kt1xlp2Omcud5jrrKwCoqwGwnlQzt74IHb0rjarRPQlmcmEw+XWXmzGmKLZbCnlrB+U9woBQxngUouVsXObbkutvYabQlCustxISSokAd8jt6gA54zzXH9bW7yIm+fieTJx1+snp5zjG7OO9VX+yMsR0R1uMvtpZtzRKyfj6Dylr454IPFZUiwS272Z8dmM8ymYp9MZatoKVMIbKhwQFApP4KPIpUFym4d6gyUqPXbb/bKZQHFpHUKVbcp55BJH5ismPPhyZDzEeXHdfZOHG23ApSP9wByPxqq2LSz8a6R5UxqIlLXnFJS0SQ0p51Ck7cj0CVDPFctL6cl22Xb/MsMBMFlTQfTIUtTpOBnbgAA43HJPOPvSoLlOT72zFlqjNRpct9tIW4mM1u6YPbJJAz9Bk/Su1N6tphx5S5rDTMg4aU6sN7j/lwrBz6Y71gri3O33W4SLcxGlMzVJdUl14tKbcCEo9EqykhKfqDnvmotnT0+C75hLEK4uvMOIdafWUIbWt1biin4VZSSvB9cJTShaXrhDZlNRXpcduS7y20pwBa/sM5NY0a9wX5bkUvtNSUOqZS04tIW4UgElIzkjmq+9p2d0J0VLEFSZvSJkBRSY5ShCDsSQScbNyfi7n8Sf09NW5c2hGhbJs5EoSt56jaU7OcbeVDZxzjn6cqg3rS3PhuzHIjcuOuU2MrZS4CtI9ynuK7ZD7MZhb0l1tllAypbiglKR7kntVVgWCaw5b2VNRUtwpTknzSFnqvbt/BG3gnf8Rye314kLrEmXW2Wx8x2m5bDzcpyG45lCiEkFBUB6FWQcd0ilCSbuUR1xkMvIdQ82p1DqFBSClJAJ3Dj94V9j3OBJirkx5sZ2MgkKdQ6lSE475IOKhJdkkz9OXKI4xDhSJS1KSiOSU4yk4UrAzu2/EQOx9e5wUabkutzXJEJltbpY2tpmLKj0yTuKtuMgngbeccnngXKdl6ls8SVCjv3GKhcwFTJLyQFAeuc+vYe5rOfmJYkpbdTta6SnVPKWkJQEkd8nPr3xjjkjiq1Esdzjm1vqTEfejPvFSXFBB6a+x3IRgqHH7oz7+p79W2KVd1vmMWgF2yVDG9RHxuFvb6dvhOabjekJ+pLPBiGS/cYnRD6Y5UHkkBalAYPPGM5PsATXc7e7c27CbEtha5h/YBLqTvGM7hzyPtUNdNPPuPy3ILcVKS3DLTajtSpbLylkHAOAQQM4P2rCumm58ubOcMaM4melrdmUtKY5SkJKQAkFQGNwIKTknt3pUFytjtzgMyvKvTYzcnG7pKdSF498Zzii7nAQh5S5sZKWRl0l1IDfJHxc8cgjn2rXuoEpRIuFrjuW6Q/KuDTwQsK80FbkHGzHKQBwvOAn7VNO6WfTbWw02wqSi5vTloDhQHkqW5tBVg8hK0nseU/jSi1pNxgiM3IMyMI7nKHeqnar7HODXep5pLvSU4gObd+wqGdvvj2+tVW26bcS9bnZUaMkMynpKmg4p0JKkbQQSOT6nAAyT96kbtBmqu6JsFDLuYjkZSXFlG0lSSFdjkcHIoJFVzgJWyhU6KFvY6SS6nLmRkbeecj2rkJ8NU4whLjmYBuLAcHUA99uc4qpN6TkixzY60xjNdgxo7bmflW0jGc4yBu5Fc4em5bN2QXGWVspnOTPMmQrdhSlKACAO/xbfmxgfXFKguVzpSlRSlKUClKUClKoeqr9cI93mtx0pbatyG3kBakJS8VA/MS4k7f3RhKuRnngVYi0maXylUa96juMZm8ympUOOIDyGERHW8qXuSg7icg5O44wMfD+Wcu/PFqC2tbJdkXKREWjHPTR1scenCEc/X60ota6Vr213ya5HYYjzLdbGGbNGmpStrI3KC8j5hhA2j680Orbs86p5DCIyGvL5ju9Mb+ohCiCVOBQOVlIwk8p9ewUW2FSoPUE+SzcLXCivtRRLU5ukOI3AbQCEJBIG45/JJqtQbhLhaZm3hl9uQ6JT0cBH91lUopLuCoDABzycY9cc0otsGlUb+0d0j22e8oNyXob7SUNAI6kjcOWsNqUAvnIOfbIAya703qfJk2yMi5wGBJgrlrf6W4FQUPhSCRwATnPPw+nootcqVrh/WF2cZU60lhkMQ25JJCNj5UVc5W4khB28bQTz+BzNRT7vKtOqVtS0Q48Fna2G28ubiyhZyrPGNx7D+lKLXulUy5X2bCU24zPjybe20lxyS02h0nKyDuSFghOAACkHnPtipXUUpcW4RFMtxlPJjSXG1vnaEqSlJGVeiT6/SlFp6lUhu/XdUdxkKbM5LrQUhbTaFJQtKj8H7UoWfh4G4HAJ54z2xtTPmJJedea2t29x9K1NdPLqFrSrjce21OcEjng4IpRa5UqmRdQXFVxh+aWyiI8plsFtpKwpS20nCiF7kK3E4+EjGPwzr3cpaby9CYmxYLTEPzRU+jd1SVKGO4wlO0Zxz8Q7eqi1lpWrrdqa5xrJDRGS221Dt0RwBzp4eKmkk5KlpUBn4RtSeQe/arOi9T06jSxJU0iG5ILDQbbS4FfBuwVBe5Ksg904wPxpRa1YGc4596VU7xd5qNQz4LFxhQWY0FuUFPt7ipRU4DnkfCNoz681iWS8SFzUyVtiOJ8xgPNuf+GFQwvb9DuAFKLXelUSRqa5rZdfjOR/LNOygtxCEuKCW3NqTtK05TgHJGT2rP1bJWTpl5iQ0wp2cMOupO0BTDvpkc88A+uKUWtlKoL2pbqJQt7a2nCmQ80ZzSGwHAhDagAFrSnd+0IPJ/u1ce2Nc579xtipUjph5doe3FogpVh1I3DBI5xngnv3PelFtj0qjO6luYvbyEobRHanohhhfTG9JKRuyV79xzuGE4xj7iQs15nvX3y09bQbd63RS02lSFBCuCFhZOcEZCkjn2pRa00pSopSlKBWPIhRZLzT0iMw680ctrW2FKQfoT2rIrBkXe3x5qIb8xhEpZADalDOT2+2fT3oOm+2WLdoj7bjbSH3G+mJHTBWkZ7A96zPIRPMqkeVY8wogl3pjccDA579iRWM1fLY7LcjNzmC+3u3J3dtvzc9jj19vWsV/UkHyfmILqJeH2GVJSrBHVcSgK7duSR74q703O42C3KnrlOxmnSptppLa20lDYbKykpGOD8Z/IVmuwYj0luS7GYXIa+R1TYKkfY9xWOi9W1dxMBExkywSnphXO4DJT7ZA5x3rLVIZTJTHU4kPqQXAj1KQQCfzI/Oor5Kix5jXSlsNPtZB2OoChkduDX1MdlLKmksthpWdyAkbTnvkfWo17UlmZDZduMdO9tLycq/cV2UfZP1PFZP64t3nxB86x5snAa3jOcZx98c474oO2Pb4cZttuPEjtNtqK0JQ2EhKjwSAOx5P51iyLFb5ExL8iM06kNlHSW2lTfKtxVgjvn1+prsmXHoS0xGGFyJKmlPbEKAwkKA5JPGc8fY1Et6pHk2ZcmC5FjOSTH6jzqOCCpJPBPqj8c1U3J1+BEkLZXIisOrZOWlLbCig/wCnPb8K7UtNpLhShILhyvA+Y4xz78ACo5zUNpbiNSlTmQy6pSUHOSop+YY78YOfb1rrkXsecjx4EVc4vMGSlbTiAnZkAHJPOc+lQSDkCI4tlbkVhS2f7tSmwSj/AG+34V2rabWpKloSpSQQCRkgHvWAq9wG5bcSRJaZmK2gsqUCUqV2SSOAT6D19K6ZWoITchLEZ1uQ+JCI7qEL5aKlFOT+IPFBmptkBMZcZMKKI6zlTQaTtUfcjGDXJy3w3UModiR1pZ/uwpsEI9OOOPwrtYkMyAssOocCFFCig5wodx9xUK9qRtm5PR3Ib4YZlNw1SNydocWlKk8Zzj40jOP+KCWEGImQiQmKwH0J2JcDY3JHsD3Ar7JhxpKm1SY7LymjuQXEBRQfcZ7Vhx7/AGqShS2JzK0pKEkg8fGrak/YngHsa4XG9txZTMWMyuZKcd6JbbUkbD0yv4iSB8o/5FBmLt0Ja2Frhx1LjjDKi0klv/bxx+FcxDiiX5oR2fM429bYN+Pbd3qHuepEWqJJk3KMWUMMpdU2lwLdyVKAG0cY+Hg59/apqLIalR0vMKKm1diUkf8AB5orCeskGRc3p0phEh1xttG11CVpRsKyCkEcH4zz9qy34cZ9t1t+Oy426QXErQCF4xjIPfsPyqHVqVIjqmJt8tVrSogzBs27QcFzbu3bPrjtzjHNZ6r1bk3AQVTGRKJCennncRkJ9s45x3q703O1y2wXEIQ5CjKQhW9KVNJISr3HHBrvfjsyEhMhlt1IzgLSFAZBB7/QkfjUcNQ2lTzjKJzK3W9+5CTk5RncOO5GDkd66IWqbVKtEa4KkdFl8J2pdSQrJTu2gY5OPbNKk3JJ23QXYiYrsOMuKnsyppJQP/LjFdiosdSdqmGinZ08FA+X/L9uO1Y7N0jvyorTCg6iSyp9p5BBQoJKQef/ADCs6orHVCiKmJlqjMGUkbUvFsbwPYK719ahxWZDj7Mdlt9z53EoAUr7nua76UClKUClKUCq7cbJKevYmRHG44W40txxDjiVKCCMpUjOxeQCMnBAPrgVYqUFVj2K6x4SbczKhNxGEOhh4s73cqSoJJB4GN3JHzY9MmsZGl7gqU686+z+28oVJLrjhSWHupwVdwoE+2Dj71c6VbSlQhaWkx7qgl5pcFuW5MSS86VkqUpW3Zu2DBUfi9h25zUnMtUpFxjTLc6hS0MuMLEpalcLKDuB5JIKO3rnuKnKUspQrdYrvDkSocURFJ/VkWEt6Q2raSkOAqTgfFjPynHccipSJpuTCuUZcR9LUZpSFOKS6vc8EoCcKbPwZOB8ffjtVppSykT0HG9V+Y2KLL0MN7gOEqQsnB+4X/8ACaxmrG4mDBYWttRjzlyzwcEFa1AD6jcPyqfpUKU6dpaWbi5PiPNF4uvENqedZTscDf7zZByC325BzWVD0pGQ9AM5mJLajRCxtca3DeVBRUArOBwfXNWelWylYl6fluLnRmXoybdOfQ+4Sk9VvAQClOOD8gwfT619l6ZXJtrkXr9Eu3EzFuMkpUUle7APcKxgZqzUpZSFsMCdaWYtvzHdgMJWhLnIc2gp6YI7ZxuBPrgH1NcGdPtIuF4nFuN52W7vYkFoKW1+xQ2OT9Uk4+tTtKllKUbBKjx5TlxUqQ29C8q4iOtx1zcD8K0Z7cknAwE4HfvXfbtNOybfaFXxMeTKS+qZNS62FJW4ptScAcj4cpA+iat1KtlK3dNNCUm5NRVsxWJMFERpKEcNlKlqztGBj4xx96l4P6xDykTvLKaDSMOMgpJXlW4bSTgY2459TWbSoUo8/Tt+btzdst8uKu1oQqOUK3JcVHVgFHqN4HAXx9RzUgvTsoqeiIfYFtdmicpRSeslQWHNg9PmT39Bxj1q0Uq2UrsPT7rDcBJcbzHuEiYsgH4kudbA+46o/I1jw7Dc4LFqU1JhvSba0uM2FNqQhbSggc8khfwJORx3GPWrVSllKvHtkuFIhMMFLj7bcqQp4oKWg64oEJ/25UrjOcJqzNb+kjq7epgbtvbPriuVKilKUoFKUoFKUoFKV0tSWnX3WW15caxvGDxntXmc8cZiJn5+FiJl3UpSvSFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFRFr/xu6/dv+hqXqItf+N3X7t/0NYNr+7Q6p7MnXT4c+XmEvSlK3uQCCMggj3FcWnEOtpcaWlaFDKVJOQR7g1WLdbrhGVFQ60+raEbVtytiGgD8QUnPxE8+hznGU4zWRJNwb0lKacS63NaiYDqV5Upe3kgj1BoLDSqk/AuhSsR25aGFupw2uWVLThCgVbt4+Enbxk9s45xXdbI12RdIbklEgo6aQ8XHgUJIbwcBK+TuGcFJ7k7vSgsq3ENlIWtKdx2pycZPsK5VVp1tuT1xStsPFaZRdD6n/2SW9hCQEZ7gkenuc+lZWnIdwjIkeZL6SptKUiQ91f2gzlQ5PB49Rn2HqE644hptTjikoQkZUpRwAPrXKoWd+sGdPTestTsxSClosJKjkjAxge/r+PA4EdKiXpxDzDQfThUkpeD4G4LVlsDnPwg45AxjjigtJcQlxLZWkLUCUpJ5IHfA/EfnXKqw7bbqh+S3Gde8ruX0t0glRSUs8biSQSQ6AfTP2r7Dt1wXMS44qYxEAdU2yuVuUgkNhO4gnPIWQMkDP4UFmpUBaYc9Vqmx5JkMOLylpxx0qWPh+bhasc+xH2FYEuBe5DDDrhkB50OKcaYkhPRWcbOcgFIA5xnkk4OaC3VxS4hTi0JWkrRjckHkZ7ZqsO2u6ht1xp9/wAy448kkyDtDZB2YGcA524IGRmuESFcYtwdlMxJfQW4n9iuSlbm0NqTySrGAog4yff6UFspVXtMO7MXGAqUH1oDKA+pb+UJIawcAK5O4eqT3J3eldkiFc1yJgZ66X19UtyfM4aAKSEJ6fPIOPQds5PagslKqzVrnSH0Bfno0IlRLSphLgOzAJUFE4J5Az6Z9cVxj2m6BiK249KO9uOZR8yc7wT1MHPGR/l49qC10qpi03ZqKRHkSeuoSEEuSSr4N/7LGScHaAM9+eay4kK4psk5oKktvOKy0l58KcSnAyNwJ2k4Vj4jjOeOwCfS4hS1oStJUjG4A8pz71yqmrtdy6khxpma3GcfSroiUOsU9MJ+bf2CsnG71+mKzbZDurF3jqk9d1oNgOuOP5QD0wPhAIydw9UepOfSgstKUoFKUoFKUoFRFr/xu6/dv+hqXqItf+N3X7t/0NYNr+7Q6p7MnXT4c+XmEvSlD2OK3uRSqYizXXodJSn+il1CljzGXXQErBGT8JGSg5wknByO1ZTFluDYQ4p51T7ao2wrkFWEJUOoD2BykkZxzxQWdtaXG0rbUFIUMgjsRXKqqzarmksdVSlvjokSOucNBKQFoKf3txCufXdz8ooizz2E2oNF5xbSGw8VySUlW4FajyDnvjGR6EYoLVXErQFpQVJC1AkJzyQO/wDUVhvtzvPpcZdR5VKeWj3UcK+nHdPr6Vg3a1v3GbBlIIjvR2HCheclt0lBH3GAoH3BoJtCkrSFIUFJPqDmvtVJu0XPy8dLiR1eilKS2+QmM7vUpSvTcCCn0/dx2Jr67brs62lpYdSlplbZU3IAU4eqhQI/8qTwcdyOO9BbK60vtqkOMJVl1CUqUnHYHOP6H8qhDBnKssJpxG5bTu55hLxHUR8WE7iTzyk4zjjGcVjpssrriSApt5IjhA8wpW0JdUpYJPf4FY5+1BZ665DzcZhx55W1ptJUpWOwHeqlEsNy2BEmRJKlFsSF+ZwHsOAqUkAAjIz6g849AayJdomvNz2empS3UvBMgySApKgQhGz0xkD8M9yaC00qsP2eW3IcDaFvwd6iiOJKkHJbQArdnPCgvj/VnuK4CyXII3qkOLlFZStxMgpyjy5Tx3A/aYPbvzQWd51tltTjq0oQnupRwBXJKkqGUkEZxkGq7Gts5Wn5kR1OHVuAtb3MqKfh+bkgHIPbj14JNcbhZ5S7wh2Mt9McFCkdN8JSg7ypzIIOd2fTv2OBzQWWlVNi03NtjEgLfR1w6WRIIJa2qAaz/pJBz+9X02e4quDDpcfSlPS2bJWUtBPzJOU5Vnnn1zzjANBZo8liSCY7zbgABOxQPBGQfxFdtU1NhuCIrKCVhCeiHEMuhKlhLRSRk8HCsHB9qyGLJcUI6hkOmUhTAbWp8q2pCQF57A/venPFBaqVUl2i4LhNtoQ6yErbL6Uyt6nwkKCiCrgZJSecZxg4qw2aO7FtrDL61rcQMErXvPfgFWBnA4oMylKUClKUClKUCoi1/wCN3X7t/wBDUvURa/8AG7r92/6GsG1/dodU9mTrp8OfLzCXpSh5Bre5FcVrQ2AVqCQSAMnGSfSqY/Y5rMZhPTSpW9lD5bdUfNELBU4vA+HgHPf5sdhXOZpqc80hDbgaaT1S2y29hLBURtKSUHtg9sEZwOKC5V1rfaQopUtO4bcgckbjgcfU1WpOn5K4jiE9N112U464pxZOUnds7gjjI4xgdxzSPYZLb7cjpRRKU1GS7ICv2hLawV87ckKH19KC00qpt6ellLaHOmkfAJC0vKzLIcSorUMcHAVxz82Owrl/Zx8h74kZbQsRP2isNK6q1II9sJKR+BHags77zbDe95YQjITk+5OB/wAkUYebfbDjKwtBJGR9Dg/8iqkjTc8SnnVP7itzcoqcBDg6yVjICAeEpIGScdhxRzTc5cmOvr4S2Pg2OAdJXVUsqGUE8pUkcEfLjsaC4V0rlMIYU8p1HSSSkrzkAg4I/PioK9WSVOvTUpt5QaQlsIwsDpkLJUQCg9wQOCM4weK+x7EqPZJsGOxFZLr63EFvgKSXNw3YHBAOPXtQWKlV602udGvjst7pBl0OhYQvO4lYKD2ycAY5JxnjArocss3pyUtsxuq7kLeLy8vJLgPxDGMhOQM5Hp2zQWilUhuxTkrZiyWG5KENSCgKdUlCSpxJRyE4BSCQMAYxxWS7YrqqWtxEltDim1NGQFYUctbQojGchXOM4/GgtbjqGykOKCd2cZ+gzTqt/B8af2nyc/Nxnj3qupsbrjaWjGjRoxKg4wl1TiVZbUnJBAHcg9vTJ5rERpuWmTCW2GoyGEtBKGHAEtlKyVkAoz8Q74Iz2NBbt6eps3DfjO3POPeuVV65Wua/fmJrHSCGlt4VvwooGdw7H39CM+tdsu2Pu3dUkNtOAqQW3lOqSplI+ZKUjvnk9+c85AoJylVJjTskhhDyWktJLfmAl1SvMlJO5auO59vXOD2FdMzT8mJaXvKZ65bfbV01qKlJU4C0Pf4UjH09KC50qtRrC4JjK1NtsREP9byzbqikYRgHsO6sHHbjPesKFpia2nbJkFzcpvrkujD+HAoqICQeQCOSe+M4oLe+62wyt15QQ2hJUpR7ADua51TZumpjsOSxtYdCmnWowW6pIj5cWUkYH+RSB9NmOxrIm6dkPMLAXlTkxb7qep/eN/FtT8SVDjIOMY4oLVSsS0x3IlsjR33FOOtthKlKVuJP3wM/fFZdApSlAqItf+N3X7t/0NS9RFr/AMbuv3b/AKGsG1/dodU9mTrp8OfLzCXpSlb3J1xn2pLDbzCwtpwbkq9xXZVPZ0zMRIhLU4yosIaAXvO5vYfiCfhzhX+5PfkHtWbaLLMiW+4Ri41HL7expxpW9aVYI3lW1OTyO+TxyTQWOuKXEqWtAzlGAcggc/X1qqW/S60KaTMaimMHAtyOlW5C8IWnJG1IJJUnuPTueK6E6fuD8ZLMgIWllTSSh5wbHtrQSVDKVfvcjKfy70F0rqlSG4sZ2Q8cNNJK1EDOABk1WY9huDAS0TGfZ6rby1OOKyopZDZTjaeCUg5z69qyIlilMabuNuW826/IQtKXipXO5GAFZycJ7Dk8AeuaCxg5FcXFpbbUtWdqQScDJ/IVWY1kmxpDcmOxCY2PJX5Vt1QbOEOJUvds+Y7xnj90c+tY7enbg30dqo28Reit0uEkK6RT8I2ZAzg/Njvxmgt6VBSQR2IyMjFfaqr+mpC+o4082zMWteZCSStKDHLYAOPReFY7cZ71jf2YlphFttuIlRWFBrqjpg7cbiOlgk8fug8fNQXOlQVstUqLfHpSwx0XEqBUFblkkgj90EDg8FSvTGKiWtPSpDEgpaZjOuGUkvb1Bx0LUsJSrjhIyCDk9hgCgudY8GW3NYDzIX01fKVJxuHuPpUHK09vmgtMxehubKXFE72UJxubQnGClWDnkfMcg1inSymrdGjRo8HKWOlnlAZc/iownlXb2PA5FBbq62323HXW0KBW0QFj2JGR/wAVWnNNu9N1TSmhIdU91XMkF1Cl7kpUQM4xwfbJxWO9pqUW5HQjwWg48HG2EunpoGwJ7Fsg8jPAHfgjnIXBakoQpSjhIGSfpXFh1D7LbrStzbiQpJ9wRkGoa/Wl24dEhuM/sZW3teUUpQtWMOJwDyMH2PPesC26clRbnFkOuMq6SWx1Ar4gEtBBQBtztJBPzY57ZoLXSq3P087IlSZDLiGZLryyJCSd6GywW8D7LwrHbjPesSRpySuOsMxoLGVJIjtunpZAIKzls5JyP3fQc0FvroZlsPOqbaWVKSVJOEnAKcZGe3qKirxan5hiK6UST0m1IU0+VJQFHbhxOAeRg47HnuKwpen5rzchLchtAcLh4Ufi3KbODweCEKB7/N60FprihxCysIWlRQdqgDnBxnB/MVUf7KuriuIWmMD0Xgw2FEpZcVs2qThIAwUk5CRjPA7muybplRMsxIsEF+QH85DZV8GCF/AoHnJ7evoaC2UrHgpfRHSiUGt6AEgtk4VwMnB7c5454xzWRQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6UpW9yKUpQKUpQKUpQKUpQKUJCRkkAe5pQKUpQKUBB7EH04pQKUpkZIyMj0oFKUoFKUoFKZGSM8j0pQKUBBGQQRSgUpSgUpSgVEWv/G7r92/6Gpeoi1/43dfu3/Q1g2v7tDqnsyddPhz5eYS9fFglCgk4Vjg19pW9yVWz20dOO0/AkNTS2UTJW8AOK24JJz8eTyOOPp2rH6V/wB8pSpMlJVuyEspIT+0Tt2/HyNm4cAHH+rFXKvi1pQgqWoJSBkknAFBXLNGmC5R5UxqYCpktkqfylJClYKhkd0kY4J9+ea6pSr0tDrLCZCHEmT+0+HGC6C1jPf4M/lzVmQ62tW1DiFK54ByeDg/81zoKfcI99Q84zHflCK2450nAkOOKyhsoydyeNxdHPHAzxUnekXApY6SpJIYVzGwP23G0nP7vf6e9TtKCrhN52ydxleew5ygo6G39zYD+9jH45zxise5i7mEUW1NxBIcU0p5aSoKCU7QfXGSo8nHBzkYFXClBU5Iu7kiXsTIcS43lCVJSlKDhPGDkK5z7Hvmvspu9KVIEdcpL5U4FKynphO/9nsHuE//AHz6VaOq31ulvT1Nu7bnnHbOK50ECtu5MW+e20p91TUptTBUoFa2f2alDPr/AOIOawpCLzJ8242qWylKZC2EApBUobOkD9Pm4/OrUFJUpQCgSnggHtRKkqKglQJScEA9j3oKpOVdI8eUspkoQBIW2WAgfFnKCr6Yz/zn0oH727FbERLpfUVLS4vHTIMc7c/TqEcf/arWtKVJKVgFJGCD2Ir41sLSOjt6eBt29semPpRFetbd3btdxHWdckFrMbzDYSQ5tP8AqVxnH0744rFZgyxIuMpCJ61tx21RustIWtwIdBAzn/P6+p9qttKKpSHLqiRHjS1zgyt9wjpHC1thpJHJJPz59c/YcVzYXd3JamnHZhkNIj7QkoCAo/P1PQ8d/wAcc1csU4zQVGXGvnlY+2TKG9bynihIUtJz+yAAKcJxn174zxmubjN/SlTzbri5RWpAQraGwny5IOP/AHoH5+1WulBUGYNxVc1KZcuDcdwx0rddUneUpDpWPtkp/Pjis2zt3YXp5cx50sEu5QpsBAG79ntO7/L7D3zzirFXwLSVlAUCoAEjPIz2/pQU5cW9tvNojrdYZBWpsIbCsrL6yd/xDjaU989z64qXsPnxMmCaX1tnlC3AEjueAnnsMcg4PHANTdKBSlKBSlKBURa/8buv3b/oal6iLX/jd1+7f9DWDa/u0OqezJ10+HPl5hL0pSt7kqKLTdRE6hkzzJ8oV7TJ48wPl9cY9MfKfXnmuL0O/qlzlhx0lXVCACOmUEHpgArwCPhydo9eTVrjSWpKVqYXvSlRQSAcZHf7120FPkWy6oMpcNBbcWXcKChkpVICiB8Q5KM45H3FEsX5iFIbSmU8pxkoZPVSFNKCzjdlZOcHvknjmrhSgqs6BdzHHTelK6kp1TqUufEEbldMJwtOE4xwDntnNdtqYvDd1YVNL7rZbSHVFSUoSemM4AUd2VD/ACg8nnGBVlriHEKcUgLSVpAKkg8jPbNBXFWqe/ODj0mclpyS6HEoklIDOCUYAPHxBPI55weKw0wL69NiLlLe+FLQ3JUAEjADoUQsfEfi5CT6YIq1ypLMVAW+vaknaOCST7ADvXcSAMntQUdiw3CNCHlUzWpMaEtDRMsq3vjG3kqPwnHynA9xWa/FvJckFkykuqU5vWXhsW2VfCG05+FQTxnA5znPerXSgqDVvntvST0bl5Nx7cEJlAPkBtASSvdnAIVxuz27jivrUC7JCjMTJcDigp0RHktrWvotpCs5T8IKV5HGTjjFWxtxDiSptSVAEpyk55BwR+dA4gulsLT1AAopzyB74/A0FL689u5xY8mS+u5dZkLS0+nYW9o35bz7hRJ2/jjiu5mHfxMiqcceSEIZGEEbANo6gUN4BOd37p9MEVcK60SGXHC2h1tSxnKQoE8HB4+9EV+BFuKrHc48tD63nGlJbU8sZWopI7blBPOPXH0FRqLLcocToREuNtl8qcEfajcnYNpASpGMHg88kZ5FXauLTiHW0raWlaFdlJOQaKqxg31xlbDjy+Y/V6vUA3PFAR0+OQMhSs9skY7Vi3GM/GaU/a7e5aW9iG3EoLaVOrU62BjaSMgbxk/5quLchl1ZS262tQGSEqBPcj+oI/CuygqEmLeEM/8AZRPLaXVqaZW+kr27UY3L35+YLx8wweR2xl6ljXd+W0bc46lpLR29I4w7nur405GMdwod+KslKCvQbdLhQbw3FD6ZbpcWy46+pxBUdxSQFKO3BPPA/Got223ZL8hUNM1thwsJX1Xwt1SUh3cAQ4CPiUg/MOM49quaXW1qKUrSpQ7gGuVBh2dElu2R0TVFcgJwoq7/AEzyecY9TWZSlApSlApSlAqItf8Ajd1+7f8AQ1L1E2xKhebmSkgEowcd+DWHa4/7aHVPZk66fDny8wlq+KG5JBzgjHBxX2lbnJTZFpucW3sMW5EnekPLyJSjhZVlOcrHGPuPcDvXelu4uS5rAEpMzC3OqZOG+moq2JSnJAUAAM4GCM5OebXSgqjVsuD72Fqnx4WHClpUslxJ2oCdygok8hRAycfjiuK7dfC0Xmn3kTVrWnK3stoSY5AO3OP73ae2fwq20oKtbbbcjIimQuc1GS7vWhyTlRwg9yFKO0qxxn07Dmuy9wLi5Nfdhh3orUzvDTgQtxCUuZAO5OMKUg9xkA1ZaUEA7a35MKzolF5Tsd4LcIfUlQG1Q5IIyeQPWsCRb7rOa8vJakpbaZWkqMnaHlhxJSRtVn5QeTjGat1KCqSY95Lao8ZmU2lKnFIdMkH4SwoJTkq3EhZHf1Gc1JT4clNshMx1SXUtuJMhKXyHXE4OQFkjncUnuOARUzSgpLdqvTaW0p8yhGXChKJABbWXlqCnDuG4bSj0V2PHNSt7hzlznnojTi0LZabJbc2K4Woqx8SfQj1H49qsNKCvpj3JWn4rL6XzIbcAfS28A44gE/Kvd68Hkg4zUexbbs1FfSlMptKi4tKUvJU5y8FJBO4ZO3IPxD15zzVwpQVeLFufViqksSiQlATsl4S1hZ3dQFR3Epx/n9s+tYaYt2cfUyoy/Mojs7FJk7W2nNy8qUM4UMAZHOcYwO9XSlBVhbbnuLYLrTCnQpXTd2nBkLUrkHIygj//AGuhVuvYkNpLkpTKCpLRTI+TDyyFOEq+IFvp9wo8HI5q4UoK9eolzevDTkZT/lghAR0ndiULCiVFY3DII2+iux4Heudlgz4sxhyQ4+tDjLvX6jxWAvenp4BPHwlXb8anqUFUhWCVHtm0PvpfdfBWlBbQUNl7crC0pCuU+6ifxrrlxL352YY6ZKW1tvNIIkZGSn9moZXx277QQT68mrfUTqa9RdP2ObdJ69kaK0XFn3x2A+pOAPvQVvU01vTUd2XdprzdoQskBU4ocKihGCFFQJAIX8OfXgHFa4d8ctOxLyHTNuktCFpGWUnplHTwRhRSCd2edo75z6VoHxA1pdNa3x2fdHldIKPQjBXwMI9gPf3PrVaQhxwKKG1KCRk4GcUR7x0d4k6X1ctLVnubapRTkxnQW3PwSe/4Zq5A5r834sh2NIbfjOrZfbUFIcQopUkjsQR2Newv0fvEZ3WVkdg3ZwKvMAALX2LzZ7Lx7+h/A+tFbfpQHIpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQD2rTH6Ust6P4altkkIkTWmnMf5cKV/VIrc57VQvGPTS9VaFuVujgGVtDzGfVaDkD8eR+NB4ZZQHX2m1KCEqUElR7DJ71sTxRxorXJtOmW/1e3bEtFuS3/fPqU2FFal9yDuI2/L9K12+04y6tp5Cm3UKKVJUMFJHcEVNo1NKfVD/XbSLs3DSEsNyfRI7JUtOFlI/y7sURZPGW3xGLjp+6RY7UV68WlifJYaSEoS6oEKKUjsDjOPfNSf6NMt6N4qQ2midkiO824B/lCdw/5SK19qS+z9SXd25XVwLkLASAlISlCQMJSlI4AA9K3d+itpV9dzmalkNlMdDZjRiofOokFSh9ABj8T7UV6haOUiudcGhhIrnQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQK6Xm9wruoRQaS8VPBmBqqQ7crW4m33ZXK1bctvH/AFAdj9R+INaUl+B+tmJBbahRpCM46jclAT/8RB/4r2otsK7iuoxk+woPL+if0fZjstt/VcptuOkgmNFUVKX9FKxgD7Z/CvSdktUW1QGIcFhDEVhIQ22gYCQKkEMpT6V2gYoPoGBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKD/2Q==",
+              "timing": 2625
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAEkQAAEEAQMDAQYCBwYDBQcFAAEAAgMEEQUSIQYTMUEHFCJRYXEygRUjQlORkrEIFjVSYqEXM3IkN0OCgxgnc7KzwdE0dHWi8f/EABkBAQEBAQEBAAAAAAAAAAAAAAABBAMCBf/EACcRAQACAQEHBQEBAQAAAAAAAAABEQIDBCEycXKywRIUMTNSQiIj/9oADAMBAAIRAxEAPwD1SiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICL45wa0ucQGgZJPgKvRdcdKzah7jF1FpL7edoibaYST8vPn6ILEiEgDJPHzVdPXHSzb/uR6i0kW87e172zdn5efP0QWJEBBAIOQfVRWs9Q6Xor2N1W17ox+MTSxuEQ+8mNo/MoJVFQvbXa/90mv2ac/BrtcyWJ/kFzeQQpY9X9PaNUoVtX1zTqdp0Mf6uew1ruWjkgnhBZ0XXWsQ2oGT1pY5oZBuZJG4Oa4fMEeVC6v1j03o9sVdV13TKlnOO1NZY1w+4J4/NBPIuqpZguV2WKk0c8EgyySNwc1w+YI8rtQEREBERAREQEREBERARF8e7a0lALg3yQF8EjD4cFF6lqNTT4DY1G1DWhyG9yZ4Y3J8DJWBT6l0O7ZZXp6xp89iQ4ZHHYY5zvsAUFlRdFd5Pwn8l3oCIiAiIg1v7cJ5n6PoekNmfXqaxqsFG3Iw7T2XElzc+mcYVjt9C9MWNBdpD9FoNo7CwNbC0FvGNwdjId9fKzOrunaPVWhT6XqbXdmTDmvYcPieOWvafQgqny9F9Z2aR0y11492mub23vZp7G2XM8Edzd5x64ygoh13Up/YfTouuylkmsDRHX2uw59bulu/P1aNuVtxnQPSrdD/RI0LT/ctmzBhbu8Yzu87vrnK5zdE6JL0SOlTWI0lsQia0H4mkHIeD/m3c5+arTeietGVP0c3r+X9GhvbDjp7DZ2eMd3PnHrjKCG9oNqz0J7FDX6d1ia2Y5W02XnPDnwxueQRuHq0fCD5C2L0/05pmn9OM06OIWK80IbO+Y9x1jI5c8n8ROV16d0bolLo9vTIqNm0ntmN8c3xGTJyXOP+YnnPzWK7p7VNM0UaP0xfbWrbO2yxde6xJXb4wxvGcem5xwg0rXnlr+yL2oaA2V82naNefXpvcc7Y+4Pgz9Mf7rc/RPSmjU+k6kZq1rzrddklmzMwSOtOc0EucT5BzwPQKPHszoV/Zre6SoWZI/fQXT3JG73ySFwJe4cZzjCR9HdR6TU9w6X6pjpaaG7Y4bVEWHVx6iN24cfIOzhBVOn7c3SH/FHStEJdQ0eL3yjF+IQPfE57mD6AjOFafZZ0locPQ2m2X06t61qNdtm3anjbI+d8g3OySORk+FNdF9HU+mdHtVDLJfs3pHTXrVgAvsvd5LvpjgBV2l0F1D0+ySl0h1b7jo5c50VS3SbZNfJyQxxIOPkDlB0ez6GPQPaf1Z03pY2aMyGC9HADlteR+Q5rfkD5wtoKs9EdIwdLw3JH259Q1S9J3rl6f8AHM70GBwGgcADwrMgIiICIiAiIgIiICIiAuE4zEVzQ8oK71GLJ00+5C8Ztw//AEXZ7mP/AFfhx/uoLRW6v+lIPeh1F2cnd70KPb8H8Xb+P+Cuz4SD8PIXERPJ/Cg+wD9YFlLhFGGD6rmgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIePKKldXalK+46pG4tijA3AH8RIyjlrasaWPqlcDYhH/is/mT3mH96z+ZaM6q6rpdNTUo70NmQ29+wwtadu0tBzlwP7Q8ZK56j1NWo9RUtGNa1LatRiVrowzY1pdtydzgePOACcKWyRtmU7/S3h7zD+9Z/MnvMP71n8y0JqXW+mUOoTo8kVx9hr42SSRxgxxueMtBOc+OeAV36v1ZR0vqKno1iG06zaaxzHxtaWDe4tGfiz5afAKWvvM/w3p7zD+9Z/MnvMP71n8y0fF1PSk6iOjNise9CR8e4tbsy2NjzznPh49POU03qSK/1Dd0hun6jDNUG5800TRERkhpBDicOwSOOQClp7zL8t4e8w/vWfzJ7zD+9Z/MtGaR1TV1Szq0NetaaNNfJHNI8M2ucwkENAcT6cZAWJ0v13pPUmox0tObZEzqxsnuNaA0B20tOHH4vX5Y9Utfd57/8fDf3vMP71n8ye8w/vWfzLRWl9WU9Sj1eSGtbZFphkbK54Z8ZZnIaA4n9k+QF96f6toa/TuWNNhtSCrG17mbBucXNLtrRn8XGMccpZO2Zx/LenvMP71n8y7Gua8ZaQR8wtH9L9QRdQ1Zp4KV6qyKQxH3qNrC5wODjBPgggq0aTqM2n2mPjce3n42Z4ISyNtrKssabJRAcgEeqKt4iIgIiICIiAiIgIiICIiAiIgIiICpXV2mysuOuRtLopANxH7JAwrqh58o5a2lGrj6ZaU1jQdN1mWvJqVbvSV93advc0syQSQQRz8I5+i4ah07peoapU1K5V7l2pt7MvccNu124cA4PPPK3Sa0B8wx/yhPdYP3Mf8oUpkjYso+MmkrvS+i3tXj1S1p8Ul5ha4Skny38JIzgkfULuu6Bpt7VYNSs1t96ANbHMHuaWhpJA4PjLj988rc/usH7mP8AlCe6wfuY/wCUJR7LL9tNs0TTmaw/VW1Wi+8EGXJ9QATjOAcADOM4CyIqNeG/Yuxx4s2GsZK/J+IMztGPHG4/xW3PdYP3Mf8AKE91g/cx/wAoSk9jlP8ATStDpvSaF29bqVO3YvbveHdxx37jk8E4GT8sLjpfS+jaXcitafRZBYih7DXtc78HyPPPgcnnhbs91g/cx/yhPdYP3Mf8oSl9ln+2k6PTOkUX6g+rU7btQDhZ/WPPc3Zz5PHk+MLv0fQ9O0YznTKra/e29za4ndtG0eT8luX3WD9zH/KE91g/cx/yhKJ2LKfnNqPT6NfT4HQ04+3G6R8pGScuc4ucefmSVMaRp02oWmMjae2D8b/QBbE91g/cx/yhdjWtYMNAA+QSjHYd95ZW+gYAA9ERFX0BERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBad9o/txrdE9WWdDl0Oa4+BjHmZtkMB3NDvG0/NbiXiz+0z/3vap/8GD/AOk1Bs2H+05pxkaJ+mrbI/VzLLXEfkWj+q3T0X1VpfWOgxatosrn1nktc142vjcPLXD0K8Yzi11toXTukdM9OSyXdJgey1PAwF05e4FpdgeBjyfmVeb1rqf2N+y6rpm9tLWdcuSzktIe6vExjGkA+A4kjkZx9/BHrJU32rnq0dJv/uH2/wBLdxu7O3d28HOzd8O7OPPpn1Xjkaj1k+gNZGt3zG52A79J/rXHOMiPfvIz64wti3etOrdS9iWqR69+kYLNS3W93vvY+F0zHF2W7uNxGPP15Qbb9h7vaO517/iAD7lsHu/fDBNvzz+D9nGfxc5xhbYXhbob2k630sdXsxXrFm5PU93r+8yukbG4yMJftJxkNBx91yqf8RepNK1DqWtc1m3RqOcbFltstDCBudhu4HABB4HAQeyeujrzelNQPSLYXa3sHu4lxjORnzxnGcZ4ytS+yY+17++EX97RN+hMO94967X+U7dm3nOceOFr/pX2na7rPs16v0XVr009qrRbZq3NxEwaJWNc0uHJ/EMHz5UJ7EOrNQo9dC7qWoXrVSpRt2XxSTucHBkLneCceiD2mi8Tt6o9ontM6qk/Qtu8+ywGeOpUsdmOBgcMeSBwSBk8lQfXPVHVk3VV861cu0dSYWR2IIp3Ma17WNaSADgZxnjjlB70ReBequoNZj1SEM1fUGg0absCy8cmtESfPqSSpn2i3ur6cfS1rWNXftsaVBLSFWd4McW0AF3j4zjJPOSfKFvcKLx7qntl6lZ7M9E06tqErNSkdMyxez+udG0gMAd6Hk5d5+Ec8lUv3/rOtUr6q3WtQAmcO2WanumJPgmMP3gfUhFe9kXjTrnrPq/VuhOn/wBMDVKd+vZnj94DHwGzGWxlrjjGSDkZ+3zVF0rUOqdW1GGhpt/WLNyV21kMdiQuJ+2UR+gq8le1T2s9baJ7Qtd03S9bdBSrWCyKP3aF20YHGSwk/mV6F9kuiat090Fp2ndQzmfU2b3yuMpkI3PLgC4+cAgfkvIPtu/72Opv/wB0f/lCD2t0bcn1DpDQ7tyTuWbNGCaV+ANz3RtJOBwOSfCmF4s669pXUNmHSOntGv2KOn06FSDbXeY3TSdlm4ucOcZOMZxwoiprHXvTesV/c9V1CW2fjbHXuC4130c1jnD8jyg91JkHwV5C9t3XPWF+PQxaZqGi0bFFkjoWh8IkmyRJnweCOAfTB9VSulNP6r1RjbPT+s/9qLjtrt1VsVhxHyYXglC3vJFX/Z9+kv7k6KNd736UFZgs9/8AHvxzu+qsCKIiICIiAiIgLyL/AGh+leodU9qepWtM0LVblV8UIbNXpySMJEbQcOAI8r10iDxb1L7MupKOgdN6zo2j6n3p6my3DBC/vQzNc4ZLANwBbt9PQ/NSmlezHqnqj2ZzvnqX49Z0/UHyQ1tQa+N80Toow4N349WjHpwV6+RB4dq6J7TKemHQ6mka/BTMm8siqObznP8AzAM4zzjOFcOqOmOpOnfYhqM3WOo2pLd25XEFOeyZey1pcfUkBxzyB6Afl6yWi/7QHs26k666i0qXQmVzVgrGOR804Y0O3E+OSePoiNBezHoqfrqfWtPovY2/BR95rh5w17hIwFpPpkOPPzwpKtoftP0HTL3T9PS9fh0+2SLEEFdz435GD8QBHIABweQvRfsQ9lP/AA+it3NQtR2tXtsEbjED24mA52tJ5OTgk4HgfnIe0L2u6B0JrkWlaxW1KWxJA2wHVomObtLnNHJeDnLT6INLdL+ybXtF9mvVmp6lRm/Sl2k2tVoRN7k23usc4kNzydo488HKh/Yh0NrZ68jh13QtWp6dYp2a8s09SSNoD4XN/E4YzyvVPRXU1LrDpurremRzx1LJeGNnaGvG15acgEjy0+qwvaF1xpHQmkR39aMxbK/txRQs3PkdjOBnAHHqSg8iTdB9Y9P6x3ulxbuwuJbX1LR5S5sjCfJcw5b9QcYVR6opT6f1BeqXbbbluKTbNO1+8Okx8XxeuDkZ9cKY6X6X1TqzUdRh6Xna8wMNhzZ5RXd284Ljk7eMjPxeq2D0J7CLupatX/vFq2mV6u7Lq9a02aeUDkgbeB98n7IKR1B0h1LfuVbNHp/V7NZ9CnslhpSPY7FaIHDg3B5BV69svS3UF/SegWUdC1Wy+toFeGZsNSR5ieGjLXYHDh8jyvWVWCKrWir12COGJgYxg8NaBgBdiFPHFf2R9Rax7Mql6rplqHVqVudslKzGYpJYiGEOaHAZwd33zx4UNX0f2n/o6DRa+ldQQ1IX5YxlV0QBz6yADI59The4ERXl3Uq/tS6J6Kq6dU/S+oajqpfLYlhbLbfSY0ANja4ZDXHLiSPpjxlav03QvaJpdua1pmldWU7M3/Mmgr2I3v5zyQMle6LWo0qkgZbuVoHkbg2SVrSR88Erur2IbMQlrSxzRngPjcHA/mEFV9kh1Q+znQzr/vn6T7Tu/wC+7u9ne78W7nOMeV5b9sPSHUt/2m9Q2qPT2sWa0tkuZLDSkex4wOQQ3BXtJEHjvr/2RdSwRaTrWi6dZtxWaNZ00ETD3q0whYHAs8+RnjwcgrBraH7WOpNTrN9112vIwCNskjHU44x8zw0fn5K9pIg8v9edP+07p27BX0l2o65poqwiV8jG3GSShvxkxv3Ec5xx4wtYv6G646h1h0o6VvQWJSM7aHucQPjONrWhe7kQQfQ2nX9J6P0fT9Yse8ahXrMjmk3bsuA+frjxn1wpxEQEREBERAREQFrf2te1jTfZ66tVkqyX9TsM7ja7HhgYzONznYOMkHHHoVsheOP7U1WzD7UpJ52u7FipE6Bx8FoG0gf+YH+KDYU39pSn/d6K1Bom7VO/25ab7BADMEh7X7TnxgjAwuVb+0RPN0vqGr/3bjBq269bte+n4u6yZ27OzjHa8Y/a+i0X1l1Hoet6PpVfRulq+jz1G7Z7MUpcZzj14HqCcnJXTpv/AHY6/wD/AMrQ/wDpW0Ru2P8AtMdzS70jtAjhus2CtF7yXtkJJ3Fx2jAAH5khTNn+0FVodF6VqVrSxNrN/uOFOKXaxjGvLdznEEjJbwMHwVRf7Kei6ZrOsdQM1bT6l1kcERYLETZA0lzs4yOFDf2m9Gj0b2gwsp046mnyUozAyGMMYMF24ADjOeT90Fuqf2nLgsD3zpqu6AnxFaIcB+bcH/ZUP+0B1PQ6v6o0fWdKL/d59KjBY8YdG4SygtP1BWJrXXXTt/RdJpRdCaXFNTaGzTd17TNhuDyzaeTzySqz1bLXsTafZpaNHo9aeqHshZM+QPxI9pfl5JGS0jHjj6oNkdO+2DVujPZ903pmg0oniPvmzPaicWOcZnODGEEeGkE/9QWw+pvazouveySrrmpdN1dUcb7aVnT7EmGwyGN7t7XbSfDeOAeT8lrHq1o/9nPoV2Bn3+1z/wCpJ/8AhU+g4/8AC7W25O0avRIH/o2v/wAINm6X11pVv2cdas6d6Iq6W/3VkEr68xkcWS7mlxOzOG4zjx9lrH2X67Z6b660vVqWnv1KxXMm2qwkF+6NzT4BPAcT49Fd/YbE+boz2nRxNL3u0cgNHk/DIqZ7KOpKnSPX+la3qUc0lSqZd7YQC87onsGASB5cPVB6T9o3t60npXWZ9J07T5NVuV3bJ3CURxscPLc4JJHrxwobpj+0npt7UYa+u6NLp0Ejg33iOfvNYT6uG0HH1GfsvO+oWGRdbz29TgkdA+4bD45Y9znMe7cDtyAcgg4zg/NTWo6v0dZ6gdMzQtRt13BrWsjlipBx+kUbHAfzFB6O9q3tu0/orVBpWn0f0pqAY2SX9bsjiDhloJwSSQQcfIjlUfSv7TcvvLRqvTkfu5PLq1g7mj7OGD/ELUftPqTaT7QbDbtGSJobXkbWneXnt9pmGF37WANpP0Kk+quu+mtZvVJq3QOlVYoY9j42zSM3n/09g/iCUGT/AGiOpYuqOu4LlSFzaLKEDK0pz+vY4GTfjHGDIW455afstlewL2g1enfZhqP6dqS1tN0p4dFZGXG0+V7zsYMAZBGPJ884Wqva/CRW6NsxaV+iqs+jAxVg90jWfr5nYDncnh7Xc+Ny43Op6+oexfT+mKsFs3NOuuu2X7B2u24uaOc58yN8hBtOx/adYLLhW6Yc6vnh0lza4j7BhH+6vvTntu6c1fpHVNaljsVZtMY19im7Dnncdrdh8OBJAzxj1wvLHTeq6BV6b1Grq9OWa7Kf1Loq8ZcRj968kx4/0tKtXR13pJvTHUs0vS+qOqR1YorU/wCkQ44fPGGho2BocCNwz/lI9UF0t/2nLpsH3Ppuu2DPAlsuLiPyaAFsv2Pe1uP2iXrlJ2kvoWa0ImJEwkY4ZA+QOeV5Xsv6f0h0epdM6rZs2muwKmpaZG4Bp85Jc5hx9v4La3sY9o2m0IOpdX1Dp6nXuUKAlfZ06Lsidpka0McwHaHFzm8gDjPyQepEWlfZb7co+teq4tDtaMaMthr3QSMm7gJa0uIcMDHAPP0W6kUREQEREBERAREQFBdW9JaH1bSZV6g0+K5Gw7mF2WvYf9LhghTqINfzeyDouXQIdGOlFtKOc2AGTPa9z8EZc7OTwcYJ4XRF7FuiYtJs6azTpxUsTRzyN96kyXxh4ac5z4kf/FbHRBUuiPZ5070TYtTdPVJK8llrWSl8z5MgEkfiJx5Up1R0vovVVFtTX9PhuwtO5m8Ycw/NrhyPyKmUQa0q+w7oCvOJRopkIOdslmRzf4blI9UeyjpDqa5Xs6pppL69dtWJsMzomMjaSQ0NaQP2ir0iCjXfZX0pd6X0/p6xRmdpdCR8sEYsPBa5xJJLs5PLj5WDH7FuiY9JsaazTpxUnmjsSN96kyXxte1pznPiR/8AFbHRBUuifZ5050VLbk6fpyQOttayXfM+TcG5x+In5lQ2p+xboTUb8lubRBHLI7e5sMz42E/9IOB+S2MiCmdRezHpHqGGpHqmjxPNWJsEUjHuY8MaMBpcCCQAPXK6OmvZN0Z05fjvabo0fvcZzHJPI6UsPzAcSAfqr0iCudXdEdO9XsjHUGlw23xjDJeWSNHyDmkHH08KuaX7Feg9OtMsRaI2WRjtzRPM+Ruf+knB/NbGRBB9U9J6H1VpzKOu6fDarsOYwctdGf8AS4YI/JQnS/ss6Q6ZsWZtL0oB9mJ0EomldK10ZxlpDiRg4Cu6INZz+w3oCawZTormEnOxlmVrf4blaavQ/TVXpyXQYNGqN0mXmSuWZDz53OPkngc5zwrGiDWM3sK6Alk3/oeRn+llqUD/AOZWnRuhOmdG0W1pOn6PVio227LDCC4zD/U48n+PHorKiCm9IezPpTpHUn6hoemCG45paJXyukLAfIbuJx+SuSIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAoXVOoqum3Za88FpzIYmTTTsYCyJj3OaC7nPlp8A4U0qrrnTk9/XpNQY4FgZWaIXSuEcoY+Qva9g4Iw8EZzyArCSsPv9P373L3uv75t3djuDuY+e3OcLpOrVIa0c1+aGkJHmNonmYMkEjAIOCTjxnKrLenrVfUnyyQxS123n3veO+8vALi7AjDeXDO3zggePRcdK0i+xsN5tKCcywzRmtccYzGHTPeD+E+Q4BwxngJRcrY+9HHZljmxFGxrHd58jQ0lxIA85Hj1ABzxnlcf0tp3uIu+/1Pcycd/vN7ec4xuzjyqr/dG2K7K75IZ42w6dES8n4+xM57+OeCDwsqxoFuPWzfrw1poW3HTtrPdtBa6BkZcOCA4Fp/Jx5CVBcpunrVGy1x78cf650LBI9o7ha7blvPIJI/iFk179OzYmgr268s8JxJHHIHOZ/1AHI/NVXQulp62qV7VyKo1sXvjmtiJIidNKxzduR6Brhnhcul+nLem29P95ggDaMLohO2w57pScDO3AABxuOSecfdKguU5f1uGrbdWirW7c8bQ+RtaLd2wfGSSBn6DJ+i7W61ppp17T7sEUNg4idK8R7j/lw7Bz6Y8rBfV1PT9V1Cxp0Fa1Ddc2VzZZjE6OQMaz0a7LSGt+oOfOVFw9PX6MvvDYKWoyzQSMlineWMje+V8ji34XZaS/B9cNalC0zahThtRVZrdeOzLzHE6QB7/sM5Kxq2t0Z7clUzxRWWSuhbFI9ofIWgElozkjlV+bp292L1VsFFzbvaJsBxaa5axjDsaQScbNzfi8n8yn6euvk1OIVqWy7eZaFree5G1uznG3lw2cc45+nKoN60x36ctySpHbrvtRjL4WyAvaPmW+Qu2xPDWgfNZljhhYMufI4Na0fMk+FVaGgXYJNPhdFVbHStSWfemPPdm3b+CNvBO/4jk+PrxIarUuarpmmTmvFHbgmjtSU5JMscQ0gsLgPQuyDjy0JQko9SqSyQiGZkrJo3SslY4OYWtIBO4cftBfa+p0LNV9mvdrS1mEh0rJWuY3HnJBwoS3olm/05qVSSCnSsWnuc1lcktxlpw52Bndt+IgeD6+Tgs6bsyx3ZLFKGN8pg2xtuPLj2yTuLtuMgngbeccnngXKdt9S6PUtUq8+o1WPuAuhJmaA4D1zn18D5lZ09xsFlscrdsXadK6Zz2hrA0jzk59fOMcckcKtVND1OudLnc2pPNWnmLmyODD23+DuYzBcOP2Rn5+p7+rdCtau+c1jEA/TLVMb3EfHIY9vp4+E5Tcb0hf6k0ejUNmfUanZE7a5cJmkB7nAYPPGM5PyAJXdLrenRy0oxbge+4f1AbK07xjO4c8j7KG1Tp6eSe3JRjqtaY6ZijcdrXPhmc8g4BwCCBnB+ywtU6bv27t6Q1q0jb7Yt2bT2trlrQ0tADQXAY3AgtOSfHlKguVsl1OhDa91mu1o7ON3adK0Px88ZzhH6nQYyZz7tZrYRmUmVoEfJHxc8cgjn5LXvUDWssahpdeTTrE9rUIpgx4d70HbmHGzHLQBw/OA37Kal6WnbpsYijgdZZqc157BIWCZrnybQXYPIa9p8Hlv5pRa0nUaIrR2DcrCvJyyXut2u+xzgrvdNE2XtOkYJNu/YXDO354+X1VV03puRs2nS2q1ZohtTWXRCR0oaXM2ggkcn1OABkn7qR1ajddq7LtFkMuaklZzZHlm0lzSHeDkcHIQSLtToNfCx16qHzY7TTK3MmRkbeecj5LkL9N140hbrm4BuMAkHcA+e3OcKpR9J2Rod2u9tY3ZaNavHJn8L4mYznGQN3IXOn03bh1ZhkhhfC29Jc95Nh27DnOcAGAefi2/ixgfXCVBcrmiIooiIgIiICIqH1Vr2oV9Xux12tji05kczA9zGtmLgfxEyNO39kYa7kZ54CsRaTNL4io2t9R6jWh1m1Fap1xQmZAypLHlz9zWHcTkHJ3HGBj4f4Zz9emMVGN74TLY1KxUezHPbZ3scenDGc/X6pRa1ote6Xrl2SvBBXuadpkEOjVrrWviyNzg/I/EMMG0fXlD1bq00rpmQMrMi93zXl7Y39xjHEEukDgcvLRhp5b6+AotsJFB9QX7MOoaXSqzxVRbdJusSM3AbQCGNBIG45/g0qtUdQt0umbusQzx2JRamrgM/5WXWi0y4LgMAHPJxj1xylFtgoqN/ePVK+m35nCOzNTniayIBncsbhzFiNzgH85Bz8sgDJXe3Wr9mzplZmp0IBZovtvn7W4FwcPhaCRwATnPPw+nootckWuJ+sNWkhdLE2CEQU47JJDNk5cXc5fI0hh28bQTz+RzOor+r2tJ6pfFbZTr0YdsYjjzJuMLHnLs8Y3HwP6JRa9oqZqWu3aTo5Ib9ezp8cTZJLMUbJScvIO5oeCG4AALQec/LCleorT6uoVHQx1nTNrWZI3znaGua1pGXejT6/RKLTyKkR69q7q8kIdGbzZYg5j4o2Oax7XH4P1pY8/DwNwOATzxntrdTTmpZmlmi2x6fJO17ou3mVj3tdxuPja3OCRzwcEJRa5IqZV6g1F2o0/enwsqTOhjBjia8Oc+Npw4h+5jtxOPhIxj8s7W9Stt1malBdq0YoKfvRdOzd3SXOGPIw1u0Zxz8Q8eqi1lRau07qbU62iU2VmxxxU9OqSASdvExdE0nJc9rgM/CNrTyD58Kzs1q+3qNsFl0TKclgwRCONsgd8G7BcH7muyD5bjA/NKLWrAznHPzRVPWNXus6hv0YNRpUYa1GO0HTx7i5xdIDnkfCNoz68rE0TWLD7rbL4xXF+5AJo5P/DDqYft+h3ABKLXdFRLHU2pvhlnrSV/dopbQfIxjZHBscm1p2l7ctwDkjJ8LP6tsvJ6ZmgsRQOlvDEsrTtAdBL6ZHPPAPrhKLWxFQZupdVFoafG+KQtsTRG9EyMCQMZG4AB72t3frCDyf+W7j5Y2p359R0x1qx2xM/SJtxiILXYlaNwwSOcZ4J8+T5Si2x0VGl6l1Ma3MxrI2V4r7KYgf2xvaS0bsl+/cc7hhuMY+4kNG1m/Nrvu198Qjl73ZbFG1zHBjuCHh5OcEZDmjn5JRa0oiKKIiICx7FKrZmimsVoJZojmN74w5zD9CfCyFg2NX0+vdZTnuQMtPIAjc4ZyfH2z6fNB067otXVqk8ckcTJ5I+2LHbBe0Z8A+Vme4VPeXWPdYPeHEEy9sbjgYHPnwSFjRa5pktuStHegM8e7c3d42/i58HHr8vVYs/UlH3P3ijKy3ieCFzWuwR3ZGsDvHjkkfPCu9NzuOgac6++1LWilLo4omxvjaWRiMvLS0Y4Pxn+AWbLRqTWY7MtaB9iL8ErowXM+x8hY7Na01+omgy5CbYJb2w7ncBkt+WQOceVlusQtstrukaJ3MMgZ6loIBP8AEj+KivlqrXuRdq3BFPFkHZKwOGR44K+trwthdE2GMROzuYGjac+cj6qNm6k0aERmXUa7d8bZm5d+w7w4/Jv1PCyf0xp3v4o++we9k4EW8ZzjOPvjnHnCDtr6fTrRxx16leKONxexrIw0NceCQB4PJ/isWxoWn2LjZ7FaKVojLO0+Nro+Xbi7BHnPr9Suy5qPYttqQQPsWXROm2McBhocBySeM54+xUTH1SPc4bdmjJVrSWTX7k0rOCC5pPBPqz88qpuTs9CpYfC+xVglfCcxOfGHFh/058fku1sUbTIWsaDIcvwPxHGOfnwAFHSdQ6THUitOvQiGVzmsOclxb+IY88YOfl6rrsa2PfK9ehVfeM0BstfFIwN2ZAByTznPooJCShUkfC+SrA58P/Lc6MEs/wCn5fku18Ub3Nc9jXOaCASMkA+VgO1uhHbjqWLMUNx20GFzgS1zvDSRwCfQevoum11BSjsNgrSx2JxYZXlYx/MRc4tyfzB4QZrdMoNrPrNpVRXecuiETdrj8yMYK5SafTlZCyWpXe2H/lh0YIZ6cccfku2CxDYDzBKyQMcWOLDnDh5H3ChZupI4dSmryU5xBDajpusbm7RI9rXN4znHxtGcf7IJYUajbDLDasAnY3Y2QRjc0fIHyAvtmnWsujdZrwzOiO5hkYHFh+Yz4WHX1/SrLHPgvQva0saSDx8btrT9ieAfBXDUdbjq2oataF9y1JL2THG5o2Htl/xEkD8I/wBwgzH6dSe+B76ddz64xC4xNJj/AOnjj8lzFOqLfvQrw+84297YN+Plu8qH1PqRmlVLNnUqxhZBC2V0bZA+XJc4AbRxj4eDn5/JTVWxFartmgcXRu8EtI/2PKKwptEo2NTmvWoGWJZI42bZWNe1mwvILQRwfjPP2WXPTrTxyxz14ZI5SDI17AQ/GMZB8+B/BQ7upWiu643T7btLa4g3Bs27QcGTbu3bPrjxzjHKz3a1pzdQFF1yEWiQ3t553EZDflnHOPKu9Nztk02jIxjJKVZzGO3ta6JpDXfMccFd89eGw0NsQxytGcB7Q4DIIPn6Ej81HDqHSXTSQsvQvlj37mNOTlmdw48kYOR5XRS6p0q1pFbUHWOzDOG7WytIdkt3bQMcnHyylSbklLp1GWo2rLTrPqt8QuiaWD/y4wux1Wu5u10ERbs7eCwfh/y/bjwseHVK89qrFA4SsswunimYQWODS0Hn/wAwWcorHdSqOuNturQG00bWzGMbwPkHeV9ip1YbEk8NeGOeT8cjWAOd9z5K70QEREBERAVd1HRLU2ti5Ukjrh8kT5JGSSNc4MIy1zM7H5AIycEA+uArEiCq19C1WvSbp0NqlHUgZKIJjDvly5rg0kHgY3ckfix6ZKxmdL6g61LNLPD+u90LmmWSQtME3c4LvIcCflg4+6uaK2lKhS6Ws19VYTNE+jHbkuNJmlLyXOc7bs3bBguPxfIeOcqTuaVaZqNa5p0rHPZDJA8Wnudw8sO4Hkkgs8eufIU4iWUoWnaFq9Oxap1RUc39GVaT5rEbtpLRIC5uB8WM/hOPI5ClKnTdmlqVZ9SdsVaJzHSObK/dMGsDcOjPwZOB8fnjwrSiWUiexJH1X7xscYZqYj3AcNcx5OD9w/8A/qVjRaHI2jRge+Nxr3n2zwcEF73AD6jcP4KfRQpTr3S1s6jJfqTRGYyzERumlhbskEf7UZByDH45Bysqn0pWZNQN6GpbirVDBtki3DeXBxcA7OBwfXKs6K2UrFvp+3I+9WhmrN069OyeQlp7seAwFrccH8AwfT6r7b6ZfZ02Sr3+yZdRNx8kJLXFpfuwD5DsYGVZkSykLoNC9pMNXT815aEDXsbJyJNoLe2CPGcbgT64B9SuEPT8TNQ1i8Y63vtuXfBYMQc+L9SyMcn6tJx9VOopZSlHQLVevak1FzrEc1L3WRld8ksm4H4Xsz45JOBgNwPPld+ndNS2dP0h2uNr2bTZ3XLrZYw5r5HRubgDkfDloH0arcitlK3qnTQtN1KKq+GrBZosqRNYziMtc92dowMfGOPupej+kRM5l73Z0QiZiSEFpL8u3DaScDG3HPqVmooUo9/p3Xo9Oj0zT7dV+lsY6uWO3NkdXdgFnqN4HAfx9RypB/TtoumqMngGmy3Rec4tPea4PEmwen4m+fQcY9VaEVspXafT8sEdBpkjzX1CxceQD8TZO9gfcd0fwKx6eg6nRg0p0VmnNZ02J9aMOjcxj4nBg55JD/gacjjyMeqtSJZSr19Mt0rFKCAtknjjtWHTFhbEJZHAhv8A05c7jOcNVmi39pnd29zA3bfGfXC5IooiIgIiICIiAiLpisxSzywxvzJFjeMHjPheZzxxmImfn4WImXciIvSCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKI0v8AxvVfvH/QqXURpf8Ajeq/eP8AoVg2v7tDqnsyddPhz5eYS6Ii3uQCCMggj5hcYpGSxtkie17HDLXNOQR8wVWNO07UKzqrJYp3bQza+O1sZEAfiDm5+Inn0Oc4y3GVkWTqEfSVqKRssd2KpgStflzn7eSCPUFBYUVSnoaoWvFeO2yB8rcRvtlz24Y4F27ePhJ28ZPjOOcLu0ytqzNUpyWWWCzttExkmBY0iPBwGv5O4ZwWnyTu9EFlfIyMtD3tbuO1uTjJ+QXJVa9pupTai18YmL22jKJ3T/qmx7CGgMz5BI9Pmc+iyunKeoVmWPeTO0uja1osTd39YM5cOTwePUZ+Q9QnZJGRRukkc1jGjLnOOAB9VyULe/SEPT13vPdLccwtiMDS45IwMYHz9fz4HAjrVTWpGTQRCduHWS2YTgbg92YwOc/CDjkDGOOEFpMjGyNjL2h7gS1pPJA84H5j+K5KsS6bqrJ7MdaWb3Xc/tbrBLi0th43EkgkiUA+mfsvtPTtQfcbJI65BUAldHC+1ucwkRhu4gnPIeQMkDP5ILMigNJp33aVdr2TYgkflsUkkpc8fD+Lh7sc/Ij7BYFuhrdiCCWQ2BNKJHSRQWQ3svONnOQC0Ac4zyScHKC3Li2RjpHsa9pezG5oPIz4yqxLpeqiOWSKef3mSSZpJsHaIyDswM4BztwQMjK4VKWo1dQltQ1LfYfI39S+y18m0RubyS7GA4g4yfn9EFsRVfSaerQajQdaE72CFgnc+fLGkRYOAHcncPVp8k7vRdlilqb7FwQ99s7+6Y7PvOIgC0hje3zyDj0HjOT4QWRFVotLvWJ2B/v1akS4mJ1wmQHZgEuDicE8gZ9M+uFxr6TqggqxyTWjvjrm0feTneCe5g54yP8ALx8kFrRVMaTq0VUivYs99wsMJksl3wb/ANVjJODtAGfPPKy6lLUW6JeiDrMc0jsxNmnDpGtwMjcCdpOHY+I4znjwAn2yMc97GvaXMxuAPLc/NclTX6XqXcsSRQ3Y60k7XdkWh3i3thv4t/gOycbvX6YWbplPVYNXrus9+WIRgSyST5YD2wPhAIydw9WepOfRBZUREBERAREQFEaX/jeq/eP+hUuojS/8b1X7x/0KwbX92h1T2ZOunw58vMJdEQ+Dhb3IRUxmjar2O050/ZbKxzx7xmWUBrwRk/CRksOcNJwcjwsqDRdQjDJHTSunjdW2F9guwxrh3AfAOWkjOOeEFnje2SNr43BzHDII8ELkqrDpWptMHdc5847JFjvnEQa0B7C39rcQ7n13c/hCM0e/A3ShEZpHxMjExfZJaXbgXuPIOfOMZHoRhBalxL2B7WFzQ9wJDc8kDz/ULDnjve/tkhlZ7q1vMR8uOHfTjy319Fg6tpc+o3aNphFeavBIWPzkxyksI+4wHA/MFBNsc17Q5jg5p9Qcr6qlHpGp+712yNHd7LWtMc5Da0u9znO9NwILfT9nHglfZdO1aWNsTxK1sUL4y6OwA6Q91jgR/wCVp4OPJHHlBbF1tnjdYkga7MrGtc5uPAOcf0P8FCGjedotKKRm58Uu6aBsxHcZ8WG7iTzy04zjjGcLHbotrviyA6OZorhg94c7aGyuc8Enz8Dsc/ZBZ112Jo60Ek0ztsUbS5zseAPKqVTQdS2BlmxZLnGMWH+84E2JAXOaAARkZ9QecegKyLekXZo78Pbc58rZg2wbJAc1wIYzZ6YyB+WfJKC0oqxPo9uOxII2Pno73FlcWXMOTGwB27OeHB/H+rPkLgNE1IM3usSPtF5a+Rtgtyz3ct48gfrMHx55QWeaWOGN0kr2sY3y5xwAuTXNcMtIIzjIKrtbTbzun7lSVuJXyAxb5MuLfh/FyQDkHxx68ElcdQ0e0/WGS1nztrgscztzhrWHeXSZBBzuz6efBwOUFlRVODSdTjgxYD52d8SmEWCCYtrgIs/6SQc/tL6dH1F2oQSmSdrW9rZstZbEG/iacty7PPPrnnGAUFmr2YLIJrzRyAAE7HA8EZB/MLtVNboOoMqwsJeGN7IkZDKGueGxFpGTwcOwcH5LIg0TUWM7hsSm0x0Aje6cu2tDQH58A/tenPCC1Iqk/SNQfSjjYyWENfGZ2ttb3ThocHEF3AyS084zjBwrDo1eWrpsEM73vkYMEvfvPngF2BnA4QZiIiAiIgIiICiNL/xvVfvH/QqXURpf+N6r94/6FYNr+7Q6p7MnXT4c+XmEuiIeQVvchcXvZGAXuDQSAMnGSfRUyfQ7sNaBvba52+Fk5jlcfeiHgukfgfDwDnz+LHgLnc6avTRMZHIIom90xwxzYbAXEbS0lh8YPjBGcDhBcl1vniY4tc9u4bcgckbjgcfUqtWen7L6kjG9uWWW1JLI6R5OWnds8gjjI4xgeRylfQbMc8djtVRadFWbLYDv1hMbwX87ckOH19EFpRVOPp62Wxsk7bR8AsPbM7NsiRri9wxwcB3HP4seAuX93JyJviZmNjxU/WOxE7uvcwj5YaWj8iPCCzzzRwR75nhjMhuT8ycD/chIJo54xJC8PYSRkfQ4P+4VSZ03fFqaV0+4vk3OLpARIO814yAwHhrSBknHgcJJ03efZrv7+Gxj4NkgHad3XPLhlhPLXNHBH4ceCguC6X2oGQOmdKztNJaX5yAQcEfx4UFrWiWr2tRWo5nCJjYwzDwO2Q8lxALD5BA4IzjB4X2voTq+iXaNeCrCZZ3yMMfAc0ybhuwOCAcevhBYkVe0nS71bXJbc3aEMolDwx+dxLwWHxk4AxyTjPGAuiTRbvbstjhrd2XIfMZn5maZAfiGMZDcgZyPTxlBaEVIj0K818NWzBHZYyKwWB0rmsaXSNLOQ3ALQSBgDGOFky6Fqrrb5GWY2SOjdEbAdhxzFtDiMZyHc4zj80FrklZGWiRwbuzjP0GU7sfwfG39Z+Dn8XGePmq63Q5ZI2xGtWrViXCSBsrpGuzG5uSCAPJB8emTysRnTdttmk+MRVmQNiDWQSANjLXkvIBZn4h5wRnwUFu3t7mzcN+M7c84+a5Kvalpd2fXoLsHaDInx4dvw4sGdw8H5+hGfVdtvTJ5dXdZEcUgLmGOZ0rmuhaPxNa0ec8nzznnICCcRVKDp2yRAyZsTYmmP3gNlc73ktJ3Pdx5Py9c4PgLpudP2amkze6Z75jnjd23uLnNdIDEPn8LRj6eiC5oq1W0GQXIXujjgqMn73u0cri0YZgHwPLsHHjjPlYVLpi7G3bZsGTc6PvkyjE+JA4uIDQeQCOSfOM4QW+eWOCF8szgyNjS5zj4AHkrmqbd6auS07MG2CUOilirB8rmivmR5aRgf5HMH02Y8FZF3p2xNA8B+XSXHzyt7n/Mj+La34muHGQcYxwgtSLE0mvJU0ytXnkdJLHGGuc524k/fAz98LLQEREBRGl/43qv3j/oVLqI0v8AxvVfvH/QrBtf3aHVPZk66fDny8wl0RFvcnXWniswRzQPD4pBua75hdip8PTNxlik90kLjAyIB+87o9h+IN+HOHf9TfPIPhZukaLcqafqFYyRVzPHsikidve12CN5dtbk8jzk8ckoLGuLZGue9gzlmAcggc/X1VU0/pd7HRNuRVTWEgfJXa7cx+GPbkja0Ekub5Hp5PC6G9P6hPWbDYDHthdE0smkGybbEGlwy137XIy3+HlBdF1WrEdWtLYmOIoml7iBnAAyVWa+g6hAGxE1p4e7HM90kjsuLYRGW42ngloOc+vhZFTQrUHTeo6c+aOWewx7WzFzudzMAOzk4b4HJ4A9coLGDkLjI9scbnuztaCTgZP8AqzW0S7WsR2a8FKDZM1/uscrhGcMka5+7Z+I7xnj9kc+qx4+ndQj7O11beKvZfKZCSHdot+EbMgZwfxY88ZQW9rg5oI8EZGRhfVVZ+mrD+5JFNHDce9+bDSS9rDXMYAOPR+HY8cZ8rG/uxbbSMccdRri8OEXdHbB243EdrBJ4/ZB4/EguaKC0zSrVXXJrTxB2ZGuBcHbnkkgj9kEDg8FzvTGFExdPWrEFgtihrSyG00zb3CSUPc8Na7jhoyCDk+BgBBc1j0bcd2ATQh/bd+EubjcPmPooO109vugxQ1exujLZHE74WNxujY3GC12DnkfiOQVinpZ0WnVq1avRy2DtZ5YIZP3rMN5d4+R4HIQW5dcc8ckssbHAviIDx8iRkf7KtSdNy9uV0TohYldN3ZMkGVjn7mtcQM4xwflk4WPN01aMdjsV6MQkmEkcDZT22DYG+DGQeRngDzwRzkLg9zWMc5xw0DJP0XGCVk8McsTt0cjQ5p+YIyCobXtJl1DskR1p9kL49szi1rHuxiRuAeRg/I8+Vgab05aq6nVsSyQu7TYx3A74gGxBhYBtztJBP4sc+MoLWird/p6Wxas2IZGQ2ZZnkWGk72RmAx4H2fh2PHGfKxLHTll9d4hrUYMuaRXjlPayAQXnMZyTkfs+g5QW9dENuCaV0cTy5zS5pw04BbjIz49QorWNKnuGo7tVLPajcx0U5c1gcduJG4B5GDjwefIWFb6fuzR2Gx2I2CQyHhx+Lc6M4PB4IY4Hz+L1QWlcWSMeXhj2uLDtcAc4OM4P8Qqj/dWV9WRj21gezMIIw4lsMjtm1zcNAGC0nIaMZ4Hkrsu9MuJtmpVogz2BPnIjLvgwQ/4HA85Pj19CgtiLHotnZXay0It7AGgxk4dwMnB8c5454xyshAREQFEaX/jeq/eP+hUuojS/wDG9V+8f9CsG1/dodU9mTrp8OfLzCXREW9yEREBERAREQEREBEJDRkkAfMogIiICICD4IPpwiAiJkZIyMj0QEREBERARMjJGeR6IgIgIIyCCEQEREBERAURpf8Ajeq/eP8AoVLqI0v/ABvVfvH/AEKwbX92h1T2ZOunw58vMJdfHgljg04djgr6i3uSq6Ppo7deKehYiumMsuWt4AkdtwSTn48nkccfTwsfta/vtOdZstLt2Q2FpDf1jdu34+Rs3DgA4/1YVyXx72sYXPcGtAySTgBBXNGrXBqVe1ciuAuhMZLp8taQ52C4ZHlpGOCfnzyuq07WnslhgbYZI02f1nw4wZQYsZ8/Bn+HKszJY3u2skY53PAOTwcH/dc0FP1CvrrJpIa89oVY5JO1IGiSR2WRlmTubxuMo544GeFJ60zUC2DtOskiB3NbA/XcbSc/s+fp81Oogq4brO2zuNr37EnLCzsbf2NgP7WMfnnPGFj6mNXNIs01uogkSOidM9pcHBrdoPrjJceTjg5yMBXBEFTsjV5LFvY2xI2SPLGua1rWHDeMHIdzn5HzlfbUetOdYFd9ps5dIHOy3thu/wDV7B8w3/759FaO7H3u1vb3Nu7bnnHjOFzQQL49Sg0+/HE6eV0VqN0Bc4F74f1bnDPr/wCIOVhWGazZ97kjdbha1th8DAWgucNnaB+n4uP4q1BzXOcA4Et4IB8I1zXFwa4EtOCAfB8oKpedqlevaeW2WMAsPjMAYPizlhd9MZ/3z6IJ9blqxio2UzuLntkfjtkGudufp3COP/srW9rXNLXgFpGCD4IXyLYYmdnb28Dbt8Y9MfREV7S49Xj0vUR3pZLBizW94jDSJNp/1O4zj6eccLFho2xY1G0xl97468bq3ee0PfIGSggZz/n9fU/JW1EVSmSaqyxXrW33hC+eQjtHD3xiJpHJJP48+ufsOFzgfq8lt0Uktw2ImV9oaWBgcfx9z0PHn88cq5YTjKCo262ue619tm0N75nTFjQ57Tn9UAAW4bjPr5xnjK5yQ6+1rpo5ZH2i9zAx20Rhvu5IOP8A4oH8fkrWiCoQ0dRdqbnQyahHXkNdr5ZXN3lrRKXj7ZLf48cLN0ePVhrUz7k0pgJlyx0YDAN36vad3+X5D555wrEvge0vLA4FwAJGeRnx/RBTn1dbjmjZXfLBCC90YZGHZeZ3k7/iHG0t858n1wpfQffxcuC6Z3xnlj5AGjyeA3nwMcg4PHAKm0QEREBERAURpf8Ajeq/eP8AoVLqI0v/ABvVfvH/AEKwbX92h1T2ZOunw58vMJdERb3JUWaTqoqdw2b5s+6F+02ePeB+H1xj0x+E+vPK4zU9fdbvPEkpLu6GAEdssIPbABfgEfDk7R68lWutZiste6B+9rXFhIBxkefuu1BT7Gmaqw2n02GOR5lw4OGS11gOIHxDkszjkfcI2DXoKViNrbUzpISyE91odE4PON2Xk5wfOSeOVcEQVW9Q1c1x25rTu5aldK1snxBm53bDcPbhuMcA58Zyu3SoNYj1WB10zyxmNolcXNaxp7YzgBx3ZcP8oPJ5xgKyriJGOkcwPaXtALmg8jPjKCuO0q/PeEk1m82KSzKJGssloEOCWYAPHxBvI55weFhtoa7NdqPtPm+FsQ3NcAGjAEocQ8fEfi5DT6YIVrtWYarA+d+1pO0cEkn5ADyu4kAZPhBR4NB1CtSHurbsVmtSeyIm2Xb5xjbyXH4Tj8JwPmFmz1dZMlgwm02VzpN7zMNj4y74RG3PwuDeM4HOc58q1ogqEWn345rJ7Ope5yTbgxtoCcgRsDSX7s4BDuN2fHkcL7FQ1ZocbjbMgkcHSipM2N739mNodnLfhBa/I4yccYVsjkZI0ujc1wBLctOeQcEfxQSMMpjD29wAOLc8gfPH5FBS+/fj1OrXs2Z36l3oQ9sU7dhj2jfmPPzDiTt/PHC7oaevi5VdJJM0MZCMMI2AbR3A4bwCc7v2T6YIVwXWyxDJIY2SxueM5aHAng4PH3RFfoVdRdoep17bJ3zSRObG6Z4y9xaR43ODeceuPoFGs0XUqdTsVGyRxmcukFfazc3YNpAa5mMHg88kZ5Cuy4xSMlja+J7Xsd4c05BRVWNHXZIXwSTP5r93u9wDdMWBnb45AyHOz4yRjwsXUa09aJ0+l6fJpMexkcjWGNrpXuljAxtJGQN4yf8AMrjHYhleWxyxvcBkhrgT5I/qCPyXYgqFmrrDIf8AsovmNsr3RQvnaX7drMbn78/iD8fiGDyPGMvqWtq89uI6dJK2JsR29o4xLny7425GMeQ4eeFZEQV6jp1ulR1iOqJ225TI+GSWd0jC47i0gOcduCeeB+ai5dN1Zs9h1Nt2OCQwNf3Zw+VzWiXcARICPicw/iHGcfJXNssb3FrXtc4eQCuSDD0dlmPTK7Lri+wG4cXefpnk84x6lZiIgIiICIiAojS/8b1X7x/0Kl1E6Y1w1nUyWkAlmDjzwVh2uP8AtodU9mTrp8OfLzCWXxw3NIOcEY4OF9RbnJTbGk6nV0+CDTmWd7RM/ItOOHl2W5y8cY+4+YHld7Y9Rkt3YALTbmHyd02cR9txdsa1uSA4AAZwMEZyc82tEFUi0zUJ5sPdfr0sSFsTrZMjTtYG7nBxJ5DiBk4/PC4v07XDEZop5mXXve3L5sxsaa5AO3OP+btPjP5K2ogq2m6bqRsVTYfeirNl3vZJZy44YfJDnHaXY4z6eByuzW6GoyXZ5aYl7L3Q7xFIGPkY1smQDubjDnMPkZAKsqIICXS57NLR2WjM6WvMHyETua4Da4ckEZPIHqsCxp+q3ovd7MVlscUL2lxs7RM8SNLSNrs/hB5OMZVuRBVLNfWTG6vWhtRta6RzJTZB+EwODW5LtxIeR59RnKkr9Oy3TKUNd1mVscjTYa2ciWRuDkB5I53Fp8jgEKZRBSY9K1qNsbW+8sZmQsaywAY3mZ7g6Q7huG0s9HeDxypXW6d596aapFI9j4YoyY5NjuHuLsfE30I9R+fhWFEFfbX1J3T9WGds5sRyATtjmAkkYCfwv3evB5IOMqPg03Voqs7WttRtcZHta2ZrpOZg5oJ3DJ25B+IevOeVcEQVerV1Pu1XWYLRIawN2W8Niw87u4C47iW4/wA/yz6rDbV1aSd0Ljb95ZXh2ObZ2xxSbn5c4Zw4YAyOc4xgeVdEQVYabqe4xgyxQOlDnduXacGw9zuQcjLCP/8AV0O07WxYjaZLToWFzYi2x+DEzyHSEu+IGPt+Q48HI5VwRBXtaqanNrEUlZ0/uwYwM7UuxrHhxLi8bhkEbfR3g8Dyuei0b9W5BJYkneySGXv9yYvAfvb28Anj4S7x+ankQVSloFqvpm0TztnlnBe1hjYWRmbc7D2tDuW/NxP5rhap62btw122WxvjmiYRYyMlv6twy/jx52ggn15KtyIKxY0+/DO5rBes0Q8kRMtlshJYzB3lwO0EP4z65wcL5HU1iLVhPJ7zKxmHANnGxzRHgswSAXF2edo85yPCtCIPjCXMaXNLSRkg+i+oiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIg//Z",
+              "timing": 3000,
+              "timestamp": 5252085524
+            }
+          ],
+          "type": "filmstrip"
+        }
+      },
+      "first-contentful-paint": {
+        "id": "first-contentful-paint",
+        "title": "First Contentful Paint",
+        "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).",
+        "score": 0.49,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.0 s",
+        "numericValue": 3001.0211806411958,
+        "numericUnit": "millisecond"
+      },
+      "user-timings": {
+        "id": "user-timings",
+        "title": "User Timing marks and measures",
+        "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more about User Timing marks](https://developer.chrome.com/docs/lighthouse/performance/user-timings/).",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "details": {
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "name",
+              "label": "Name"
+            },
+            {
+              "label": "Type",
+              "valueType": "text",
+              "key": "timingType"
+            },
+            {
+              "granularity": 0.01,
+              "label": "Start Time",
+              "valueType": "ms",
+              "key": "startTime"
+            },
+            {
+              "label": "Duration",
+              "valueType": "ms",
+              "key": "duration",
+              "granularity": 0.01
+            }
+          ],
+          "items": [],
+          "type": "table"
+        }
+      },
+      "network-requests": {
+        "id": "network-requests",
+        "title": "Network Requests",
+        "description": "Lists the network requests that were made during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "table",
+          "debugData": {
+            "initiators": [
+              {
+                "lineNumber": 0,
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 1066,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 668,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 21,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 16766
+              },
+              {
+                "lineNumber": 22,
+                "columnNumber": 1748,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 22,
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 2076
+              },
+              {
+                "columnNumber": 22201,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 23,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 22433,
+                "lineNumber": 23
+              },
+              {
+                "columnNumber": 22662,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 23,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 23,
+                "columnNumber": 22956,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 141,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 261,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 360,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 460,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 39,
+                "columnNumber": 536,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 602,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 671,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 731,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 795,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39
+              },
+              {
+                "type": "parser",
+                "columnNumber": 857,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39
+              },
+              {
+                "type": "parser",
+                "columnNumber": 916,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39
+              },
+              {
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 985,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1052,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1119,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 1176,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 1238,
+                "lineNumber": 39
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 1297,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 1361,
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 1427,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 1488,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 1556,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "lineNumber": 39,
+                "columnNumber": 1622,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 1693,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1751,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39
+              },
+              {
+                "lineNumber": 39,
+                "columnNumber": 1811,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 1886,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 1947,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 2005,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2069,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 2129,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 2188,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 2250,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "columnNumber": 2311,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 2374,
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2430,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 2498,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 2565,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2626,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 2706,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "columnNumber": 2769,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 39,
+                "columnNumber": 2829,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 2888,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 2952,
+                "lineNumber": 39,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 3011,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39
+              },
+              {
+                "type": "parser",
+                "columnNumber": 3073,
+                "url": "https://www.ocobo.co/jobs",
+                "lineNumber": 39
+              },
+              {
+                "lineNumber": 39,
+                "columnNumber": 3132,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 3195,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 3262,
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "lineNumber": 39,
+                "columnNumber": 3320,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+              },
+              {
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                "type": "parser"
+              }
+            ],
+            "networkStartTimeTs": 5249085822,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "priority": "VeryHigh",
+              "transferSize": 23030,
+              "resourceSize": 120211,
+              "finished": true,
+              "rendererStartTime": 0,
+              "url": "https://www.ocobo.co/jobs",
+              "sessionTargetType": "page",
+              "networkEndTime": 878.17100000102073,
+              "statusCode": 200,
+              "mimeType": "text/html",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Document",
+              "networkRequestTime": 2.1280000004917383,
+              "entity": "ocobo.co"
+            },
+            {
+              "networkRequestTime": 897.01700000092387,
+              "resourceType": "Stylesheet",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "text/css",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "statusCode": 200,
+              "networkEndTime": 1019.9540000008419,
+              "finished": true,
+              "rendererStartTime": 895.86600000038743,
+              "transferSize": 24570,
+              "resourceSize": 122090,
+              "priority": "VeryHigh"
+            },
+            {
+              "priority": "Medium",
+              "resourceSize": 12266,
+              "transferSize": 12758,
+              "rendererStartTime": 896.26900000032037,
+              "finished": true,
+              "statusCode": 200,
+              "networkEndTime": 955.87199999950826,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "protocol": "h2",
+              "mimeType": "image/png",
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 897.140000000596,
+              "resourceType": "Image"
+            },
+            {
+              "resourceSize": 29045,
+              "transferSize": 29546,
+              "priority": "Medium",
+              "finished": true,
+              "rendererStartTime": 896.42200000025332,
+              "statusCode": 200,
+              "networkEndTime": 933.16600000020117,
+              "url": "https://www.ocobo.co/images/partners/modern-revenue-club.png",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "mimeType": "image/png",
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 897.20800000056624,
+              "resourceType": "Image"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 897.28899999987334,
+              "resourceType": "Image",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "image/jpeg",
+              "url": "https://www.ocobo.co/images/jobs/seminaire.jpeg",
+              "sessionTargetType": "page",
+              "networkEndTime": 1622.765000000596,
+              "statusCode": 200,
+              "priority": "High",
+              "resourceSize": 250772,
+              "transferSize": 251265,
+              "finished": true,
+              "rendererStartTime": 896.57900000084192
+            },
+            {
+              "mimeType": "image/jpeg",
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "networkRequestTime": 1032.3120000008494,
+              "priority": "Low",
+              "resourceSize": 134678,
+              "transferSize": 135167,
+              "rendererStartTime": 896.71700000017881,
+              "finished": true,
+              "statusCode": 200,
+              "networkEndTime": 1473.4440000001341,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/images/jobs/cafet.jpeg"
+            },
+            {
+              "networkEndTime": 1312.0890000006184,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/images/jobs/bureau-1.jpeg",
+              "priority": "Low",
+              "resourceSize": 124507,
+              "transferSize": 124999,
+              "finished": true,
+              "rendererStartTime": 896.80400000046939,
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1032.793000000529,
+              "resourceType": "Image",
+              "protocol": "h2",
+              "mimeType": "image/jpeg"
+            },
+            {
+              "resourceType": "Image",
+              "networkRequestTime": 1032.9040000000969,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "mimeType": "image/jpeg",
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/images/jobs/bureau-2.jpeg",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 1313.6160000003874,
+              "finished": true,
+              "rendererStartTime": 896.961000001058,
+              "resourceSize": 114922,
+              "transferSize": 115414,
+              "priority": "Low"
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "image/jpeg",
+              "networkRequestTime": 1032.9709999999031,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "rendererStartTime": 897.06000000052154,
+              "finished": true,
+              "priority": "Low",
+              "resourceSize": 115440,
+              "transferSize": 115932,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/images/jobs/bureau-3.jpeg",
+              "statusCode": 200,
+              "networkEndTime": 1372.8780000004917
+            },
+            {
+              "entity": "ocobo.co",
+              "resourceType": "Image",
+              "networkRequestTime": 1033.0420000003651,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/jpeg",
+              "protocol": "h2",
+              "networkEndTime": 1291.5030000004917,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/images/jobs/rooftop.jpeg",
+              "finished": true,
+              "rendererStartTime": 897.16100000031292,
+              "transferSize": 105040,
+              "priority": "Low",
+              "resourceSize": 104549
+            },
+            {
+              "priority": "Low",
+              "resourceSize": 471537,
+              "transferSize": 157188,
+              "finished": true,
+              "rendererStartTime": 897.29800000041723,
+              "networkEndTime": 1080.6119999997318,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "entity": "Google Tag Manager",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "networkRequestTime": 1033.223000000231
+            },
+            {
+              "networkRequestTime": 1033.3859999999404,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "entity": "Clearbit",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "networkEndTime": 1251.4579999996349,
+              "statusCode": 404,
+              "finished": true,
+              "rendererStartTime": 897.39400000032037,
+              "transferSize": 640,
+              "priority": "Low",
+              "resourceSize": 0
+            },
+            {
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "resourceType": "Script",
+              "networkRequestTime": 1033.4730000011623,
+              "experimentalFromMainFrame": true,
+              "entity": "Hubspot",
+              "finished": true,
+              "rendererStartTime": 897.49600000027567,
+              "resourceSize": 2125,
+              "priority": "Low",
+              "transferSize": 1647,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 1065.0729999998584
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1033.563000000082,
+              "resourceType": "Script",
+              "entity": "GitHub",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "networkEndTime": 1047.4780000010505,
+              "statusCode": 200,
+              "resourceSize": 17494,
+              "transferSize": 5018,
+              "priority": "Low",
+              "finished": true,
+              "rendererStartTime": 897.64199999999255
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1029.5540000004694,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "finished": true,
+              "rendererStartTime": 897.80700000096112,
+              "transferSize": 24115,
+              "resourceSize": 69556,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "networkRequestTime": 898.53000000026077,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "mimeType": "application/javascript"
+            },
+            {
+              "finished": true,
+              "rendererStartTime": 897.94799999985844,
+              "transferSize": 1455,
+              "resourceSize": 927,
+              "priority": "High",
+              "networkEndTime": 933.92400000058115,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "networkRequestTime": 898.89200000092387,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true
+            },
+            {
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 977.3519999999553,
+              "statusCode": 200,
+              "rendererStartTime": 898.25100000016391,
+              "finished": true,
+              "resourceSize": 125397,
+              "priority": "High",
+              "transferSize": 43925,
+              "networkRequestTime": 899.22900000028312,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "application/javascript"
+            },
+            {
+              "networkEndTime": 954.0550000006333,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "finished": true,
+              "rendererStartTime": 898.45600000023842,
+              "resourceSize": 133936,
+              "priority": "High",
+              "transferSize": 45261,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "networkRequestTime": 899.51900000032037,
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 899.99100000038743,
+              "resourceType": "Script",
+              "resourceSize": 110060,
+              "priority": "High",
+              "transferSize": 34185,
+              "finished": true,
+              "rendererStartTime": 898.62000000011176,
+              "networkEndTime": 948.71900000050664,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "sessionTargetType": "page"
+            },
+            {
+              "networkRequestTime": 900.28199999965727,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "networkEndTime": 932.52800000086427,
+              "statusCode": 200,
+              "finished": true,
+              "rendererStartTime": 898.74000000022352,
+              "priority": "High",
+              "transferSize": 1515,
+              "resourceSize": 991
+            },
+            {
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "networkRequestTime": 900.70899999979883,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "transferSize": 4523,
+              "resourceSize": 9799,
+              "finished": true,
+              "rendererStartTime": 898.9769999999553,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "networkEndTime": 934.32899999991059,
+              "statusCode": 200
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 900.85800000000745,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "transferSize": 2149,
+              "priority": "High",
+              "resourceSize": 3192,
+              "rendererStartTime": 899.09999999962747,
+              "finished": true,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "statusCode": 200,
+              "networkEndTime": 946.54700000025332
+            },
+            {
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 901.36700000055134,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "statusCode": 200,
+              "networkEndTime": 958.78199999965727,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "priority": "High",
+              "transferSize": 670,
+              "resourceSize": 141,
+              "rendererStartTime": 899.20900000073016,
+              "finished": true
+            },
+            {
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 901.60900000017136,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "statusCode": 200,
+              "networkEndTime": 1021.0010000001639,
+              "resourceSize": 1284,
+              "priority": "High",
+              "transferSize": 1270,
+              "finished": true,
+              "rendererStartTime": 899.30399999953806
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "statusCode": 200,
+              "networkEndTime": 952.648000000976,
+              "finished": true,
+              "rendererStartTime": 899.49799999967217,
+              "priority": "High",
+              "resourceSize": 15426,
+              "transferSize": 6807,
+              "networkRequestTime": 902.27400000020862,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "application/javascript"
+            },
+            {
+              "transferSize": 6206,
+              "priority": "High",
+              "resourceSize": 17234,
+              "rendererStartTime": 899.81600000057369,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 969.64599999971688,
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "networkRequestTime": 902.68600000068545,
+              "entity": "ocobo.co"
+            },
+            {
+              "resourceType": "Script",
+              "networkRequestTime": 902.95000000018626,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "networkEndTime": 960.472000000067,
+              "statusCode": 200,
+              "rendererStartTime": 899.9640000006184,
+              "finished": true,
+              "resourceSize": 3070,
+              "priority": "High",
+              "transferSize": 1833
+            },
+            {
+              "finished": true,
+              "rendererStartTime": 900.05800000019372,
+              "resourceSize": 428,
+              "transferSize": 954,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "statusCode": 200,
+              "networkEndTime": 968.4870000006631,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "networkRequestTime": 903.50200000032783,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co"
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 903.81900000013411,
+              "resourceType": "Script",
+              "transferSize": 938,
+              "resourceSize": 410,
+              "priority": "High",
+              "rendererStartTime": 900.25499999988824,
+              "finished": true,
+              "statusCode": 200,
+              "networkEndTime": 1003.3930000001565,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js"
+            },
+            {
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 904.313000000082,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "networkEndTime": 964.68100000079721,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "priority": "High",
+              "resourceSize": 525,
+              "transferSize": 1048,
+              "rendererStartTime": 900.34200000017881,
+              "finished": true
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "networkRequestTime": 904.97099999990314,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "networkEndTime": 970.07700000051409,
+              "statusCode": 200,
+              "priority": "High",
+              "resourceSize": 942,
+              "transferSize": 1472,
+              "rendererStartTime": 900.42300000041723,
+              "finished": true
+            },
+            {
+              "finished": true,
+              "rendererStartTime": 900.61500000022352,
+              "priority": "High",
+              "resourceSize": 349,
+              "transferSize": 877,
+              "statusCode": 200,
+              "networkEndTime": 953.26000000070781,
+              "url": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "sessionTargetType": "page",
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "networkRequestTime": 905.20100000035018,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "statusCode": 200,
+              "networkEndTime": 1015.3640000000596,
+              "rendererStartTime": 900.83299999963492,
+              "finished": true,
+              "resourceSize": 1866,
+              "transferSize": 1368,
+              "priority": "High",
+              "networkRequestTime": 905.4870000006631,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "application/javascript"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 906.00200000032783,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "statusCode": 200,
+              "networkEndTime": 1058.5330000007525,
+              "resourceSize": 348,
+              "priority": "High",
+              "transferSize": 868,
+              "finished": true,
+              "rendererStartTime": 901.08200000040233
+            },
+            {
+              "networkEndTime": 962.62200000043958,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "transferSize": 21253,
+              "resourceSize": 67398,
+              "rendererStartTime": 901.203000000678,
+              "finished": true,
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "networkRequestTime": 906.49600000027567,
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "url": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 971.13300000038,
+              "statusCode": 200,
+              "finished": true,
+              "rendererStartTime": 901.46800000034273,
+              "resourceSize": 165,
+              "transferSize": 702,
+              "priority": "High",
+              "resourceType": "Script",
+              "networkRequestTime": 906.85800000093877,
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "networkRequestTime": 907.37100000027567,
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "networkEndTime": 964.07199999969453,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "finished": true,
+              "rendererStartTime": 901.61799999978393,
+              "priority": "High",
+              "resourceSize": 605,
+              "transferSize": 1128
+            },
+            {
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 907.95999999996275,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "networkEndTime": 956.35200000088662,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "resourceSize": 826,
+              "priority": "High",
+              "transferSize": 1346,
+              "finished": true,
+              "rendererStartTime": 901.7730000000447
+            },
+            {
+              "url": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 971.55000000074506,
+              "priority": "High",
+              "resourceSize": 404,
+              "transferSize": 930,
+              "rendererStartTime": 901.90100000053644,
+              "finished": true,
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "networkRequestTime": 908.42700000107288,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "networkRequestTime": 910.60400000028312,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "rendererStartTime": 902.01100000087172,
+              "finished": true,
+              "resourceSize": 490,
+              "transferSize": 1012,
+              "priority": "High",
+              "networkEndTime": 957.23600000049919,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/users-Cf70nLSI.js"
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 960.11800000071526,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "finished": true,
+              "rendererStartTime": 902.19700000062585,
+              "transferSize": 727,
+              "priority": "High",
+              "resourceSize": 206,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "networkRequestTime": 910.9190000006929,
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 911.31800000090152,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "priority": "High",
+              "resourceSize": 835,
+              "transferSize": 1359,
+              "finished": true,
+              "rendererStartTime": 902.45399999991059,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "statusCode": 200,
+              "networkEndTime": 964.35699999984354
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "networkEndTime": 961.56200000084937,
+              "statusCode": 200,
+              "resourceSize": 68826,
+              "priority": "High",
+              "transferSize": 26413,
+              "finished": true,
+              "rendererStartTime": 902.66600000020117,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "networkRequestTime": 911.77600000053644,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "networkRequestTime": 913.67200000025332,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "statusCode": 200,
+              "networkEndTime": 970.53000000026077,
+              "transferSize": 998,
+              "resourceSize": 473,
+              "priority": "High",
+              "rendererStartTime": 902.79700000025332,
+              "finished": true
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 913.74900000076741,
+              "resourceType": "Script",
+              "priority": "High",
+              "resourceSize": 338,
+              "transferSize": 856,
+              "rendererStartTime": 902.88200000021607,
+              "finished": true,
+              "networkEndTime": 982.18400000035763,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/x-B1I3g_bH.js"
+            },
+            {
+              "networkEndTime": 963.73099999967963,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "sessionTargetType": "page",
+              "rendererStartTime": 902.96000000089407,
+              "finished": true,
+              "priority": "High",
+              "resourceSize": 435,
+              "transferSize": 965,
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "networkRequestTime": 915.61900000087917,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "finished": true,
+              "rendererStartTime": 903.04999999981374,
+              "priority": "High",
+              "resourceSize": 312,
+              "transferSize": 841,
+              "statusCode": 200,
+              "networkEndTime": 956.87900000065565,
+              "url": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "sessionTargetType": "page",
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "networkRequestTime": 915.85900000017136,
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "url": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 978.18900000024587,
+              "finished": true,
+              "rendererStartTime": 903.23300000000745,
+              "resourceSize": 309,
+              "priority": "High",
+              "transferSize": 832,
+              "networkRequestTime": 916.54100000020117,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "application/javascript"
+            },
+            {
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 917.66300000064075,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "statusCode": 200,
+              "networkEndTime": 1328.3610000004992,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/_main.(_lang).jobs._index-Djw8wGmL.js",
+              "resourceSize": 16573,
+              "transferSize": 5264,
+              "priority": "High",
+              "finished": true,
+              "rendererStartTime": 903.35900000017136
+            },
+            {
+              "transferSize": 1133,
+              "priority": "High",
+              "resourceSize": 1217,
+              "rendererStartTime": 903.53500000108033,
+              "finished": true,
+              "statusCode": 200,
+              "networkEndTime": 971.86799999978393,
+              "url": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 918.98200000077486,
+              "resourceType": "Script"
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1031.535000000149,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/badge-i9dgPBIb.js",
+              "transferSize": 1017,
+              "priority": "High",
+              "resourceSize": 495,
+              "finished": true,
+              "rendererStartTime": 903.66600000020117,
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 921.26200000010431,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "mimeType": "application/javascript"
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "statusCode": 200,
+              "networkEndTime": 969.26700000092387,
+              "finished": true,
+              "rendererStartTime": 903.83399999979883,
+              "transferSize": 1238,
+              "priority": "High",
+              "resourceSize": 717,
+              "resourceType": "Script",
+              "networkRequestTime": 926.86799999978393,
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 927.02900000102818,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "transferSize": 1075,
+              "priority": "High",
+              "resourceSize": 549,
+              "finished": true,
+              "rendererStartTime": 903.99100000038743,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "statusCode": 200,
+              "networkEndTime": 1049.4930000007153
+            },
+            {
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 927.13800000026822,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 1049.0980000011623,
+              "resourceSize": 605,
+              "transferSize": 1126,
+              "priority": "High",
+              "finished": true,
+              "rendererStartTime": 904.07700000051409
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 927.26400000043213,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "transferSize": 961,
+              "resourceSize": 438,
+              "priority": "High",
+              "rendererStartTime": 904.20199999958277,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/map-pin-BFjzXly_.js",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 1123.4620000002906
+            },
+            {
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "networkRequestTime": 927.37000000104308,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "resourceSize": 656,
+              "transferSize": 1176,
+              "rendererStartTime": 904.36700000055134,
+              "finished": true,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/star-BI6vQnwF.js",
+              "networkEndTime": 1145.9640000006184,
+              "statusCode": 200
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/sparkles-Cv6LQ7xb.js",
+              "networkEndTime": 1121.00800000038,
+              "statusCode": 200,
+              "resourceSize": 678,
+              "priority": "High",
+              "transferSize": 1202,
+              "finished": true,
+              "rendererStartTime": 904.48500000033528,
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 927.47200000099838,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "application/javascript"
+            },
+            {
+              "transferSize": 1027,
+              "priority": "High",
+              "resourceSize": 499,
+              "rendererStartTime": 904.58899999968708,
+              "finished": true,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/shield-check-CXoajV1s.js",
+              "statusCode": 200,
+              "networkEndTime": 1171.4089999999851,
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 929.25899999961257,
+              "resourceType": "Script",
+              "entity": "ocobo.co"
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "networkRequestTime": 929.60200000088662,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "transferSize": 966,
+              "resourceSize": 446,
+              "priority": "High",
+              "finished": true,
+              "rendererStartTime": 904.74000000022352,
+              "url": "https://www.ocobo.co/assets/zap-C3uzvT7-.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 978.61600000038743,
+              "statusCode": 200
+            },
+            {
+              "mimeType": "font/woff",
+              "protocol": "h2",
+              "resourceType": "Font",
+              "networkRequestTime": 1084.9860000004992,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "rendererStartTime": 1073.4790000002831,
+              "finished": true,
+              "resourceSize": 31480,
+              "transferSize": 31975,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+              "networkEndTime": 1105.0180000001565,
+              "statusCode": 200
+            },
+            {
+              "networkEndTime": 1107.4029999999329,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+              "resourceSize": 57572,
+              "priority": "VeryHigh",
+              "transferSize": 38779,
+              "finished": true,
+              "rendererStartTime": 1073.8849999997765,
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Font",
+              "networkRequestTime": 1086.3320000004023,
+              "mimeType": "font/otf",
+              "protocol": "h2"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1086.5500000007451,
+              "resourceType": "Font",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "font/otf",
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 1127.3520000008866,
+              "priority": "VeryHigh",
+              "transferSize": 39127,
+              "resourceSize": 58256,
+              "finished": true,
+              "rendererStartTime": 1074.6289999997243
+            },
+            {
+              "mimeType": "text/css",
+              "protocol": "h2",
+              "entity": "GitHub",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Stylesheet",
+              "networkRequestTime": 1294.2880000006407,
+              "priority": "VeryHigh",
+              "resourceSize": 4371,
+              "transferSize": 2019,
+              "finished": true,
+              "rendererStartTime": 1291.401999999769,
+              "statusCode": 200,
+              "networkEndTime": 1302.5870000002906,
+              "sessionTargetType": "page",
+              "url": "https://useago.github.io/widgetjs/frame.css"
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "networkEndTime": 1314.6409999998286,
+              "statusCode": 200,
+              "transferSize": 17171,
+              "priority": "Low",
+              "resourceSize": 16667,
+              "rendererStartTime": 1293.2819999996573,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "networkRequestTime": 1294.8180000009015,
+              "entity": "ocobo.co",
+              "mimeType": "image/png",
+              "protocol": "h2"
+            },
+            {
+              "priority": "Low",
+              "transferSize": 29958,
+              "resourceSize": 97992,
+              "rendererStartTime": 1300.2949999999255,
+              "finished": true,
+              "networkEndTime": 1341.3840000005439,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "entity": "Hubspot",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1301.3389999996871,
+              "resourceType": "Script"
+            },
+            {
+              "networkRequestTime": 1302.2560000000522,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "entity": "Hubspot",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "statusCode": 200,
+              "networkEndTime": 1322.0530000003055,
+              "finished": true,
+              "rendererStartTime": 1301.0379999997094,
+              "priority": "Low",
+              "transferSize": 28213,
+              "resourceSize": 78203
+            },
+            {
+              "entity": "Hubspot",
+              "networkRequestTime": 1302.4720000009984,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "mimeType": "text/javascript",
+              "statusCode": 200,
+              "networkEndTime": 1329.0930000003427,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "sessionTargetType": "page",
+              "rendererStartTime": 1301.5889999996871,
+              "finished": true,
+              "resourceSize": 109001,
+              "transferSize": 43646,
+              "priority": "Low"
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1349.7999999998137,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "resourceSize": 72678,
+              "transferSize": 27219,
+              "finished": true,
+              "rendererStartTime": 1302.1320000002161,
+              "entity": "Hubspot",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1303.1529999999329,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "mimeType": "text/javascript"
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "text/plain",
+              "entity": "Google Analytics",
+              "networkRequestTime": 1511.6070000007749,
+              "resourceType": "Fetch",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "rendererStartTime": 1509.5530000003055,
+              "priority": "High",
+              "resourceSize": 0,
+              "transferSize": 796,
+              "networkEndTime": 1572.6009999997914,
+              "statusCode": 204,
+              "sessionTargetType": "page",
+              "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65d0h2v9100339653za200zd9100339653&_p=1778779387512&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1806729512.1778779388&frm=0&pscdl=noapi&rcb=0&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616986~115938466~115938468&dp=%2Fjobs&sid=1778779387&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fjobs&dt=Ocobo%20%C2%B7%20Nous%20rejoindre%20%E2%80%94%20Ocobo&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1509"
+            },
+            {
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+              "sessionTargetType": "page",
+              "networkEndTime": 1701.9400000004098,
+              "statusCode": 200,
+              "rendererStartTime": 1622.0370000004768,
+              "finished": true,
+              "resourceSize": 135,
+              "transferSize": 1095,
+              "priority": "High",
+              "resourceType": "XHR",
+              "networkRequestTime": 1624.2819999996573,
+              "experimentalFromMainFrame": true,
+              "entity": "Hubspot",
+              "mimeType": "application/json",
+              "protocol": "h2"
+            },
+            {
+              "entity": "Hubspot",
+              "resourceType": "Fetch",
+              "networkRequestTime": 1688.855000000447,
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/plain",
+              "protocol": "h2",
+              "statusCode": 200,
+              "networkEndTime": 1712.5650000004098,
+              "sessionTargetType": "page",
+              "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+              "rendererStartTime": 1687.7990000005811,
+              "finished": true,
+              "resourceSize": 5,
+              "transferSize": 558,
+              "priority": "High"
+            },
+            {
+              "entity": "Hubspot",
+              "networkRequestTime": 1701.1279999995604,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "mimeType": "image/gif",
+              "networkEndTime": 1808.9529999997467,
+              "statusCode": 200,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fjobs&t=Ocobo+%C2%B7+Nous+rejoindre+%E2%80%94+Ocobo&cts=1778779388182&vi=18dd8404db3b1e624593e3cc9c48926f&nc=true&ce=false&cc=0",
+              "sessionTargetType": "page",
+              "rendererStartTime": 1699.945000000298,
+              "finished": true,
+              "transferSize": 1474,
+              "priority": "Low",
+              "resourceSize": 45
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/json",
+              "entity": "Hubspot",
+              "networkRequestTime": 1752.1850000005215,
+              "resourceType": "Fetch",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "rendererStartTime": 1746.6540000000969,
+              "transferSize": 1712,
+              "priority": "High",
+              "resourceSize": 61,
+              "networkEndTime": 1950.7640000004321,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fjobs&utk=18dd8404db3b1e624593e3cc9c48926f&__hstc=242475741.18dd8404db3b1e624593e3cc9c48926f.1778779388179.1778779388179.1778779388179.1&__hssc=242475741.1.1778779388179&isMobile=true"
+            },
+            {
+              "networkEndTime": 2264.0090000005439,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+              "priority": "Low",
+              "transferSize": 1020,
+              "resourceSize": 35,
+              "finished": true,
+              "rendererStartTime": 2151.6840000003576,
+              "entity": "Hubspot",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2152.6450000004843,
+              "resourceType": "Image",
+              "protocol": "http/1.1",
+              "mimeType": "image/gif"
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "entity": "Hubspot",
+              "networkRequestTime": 2697.5380000006407,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "rendererStartTime": 2696.4070000005886,
+              "priority": "Low",
+              "resourceSize": 607831,
+              "transferSize": 204725,
+              "statusCode": 200,
+              "networkEndTime": 2742.7340000011027,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "sessionTargetType": "page"
+            },
+            {
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2709.0920000001788,
+              "resourceType": "Script",
+              "entity": "Clearbit",
+              "transferSize": 640,
+              "priority": "Low",
+              "resourceSize": 0,
+              "rendererStartTime": 2698.1919999998063,
+              "finished": true,
+              "sessionTargetType": "page",
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "statusCode": 404,
+              "networkEndTime": 2891.4550000000745
+            },
+            {
+              "entity": "Hubspot",
+              "resourceType": "Script",
+              "networkRequestTime": 2709.4690000005066,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "protocol": "h2",
+              "statusCode": 304,
+              "networkEndTime": 2743.1340000005439,
+              "sessionTargetType": "page",
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "finished": true,
+              "rendererStartTime": 2698.8220000006258,
+              "resourceSize": 2125,
+              "transferSize": 856,
+              "priority": "Low"
+            },
+            {
+              "transferSize": 1865,
+              "resourceSize": 2495,
+              "priority": "Low",
+              "rendererStartTime": 2700.4639999996871,
+              "finished": true,
+              "networkEndTime": 2743.2669999999925,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/_vercel/insights/script.js",
+              "protocol": "h2",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2709.5499999998137,
+              "resourceType": "Script"
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "statusCode": 200,
+              "networkEndTime": 2747.7050000000745,
+              "rendererStartTime": 2701.9360000006855,
+              "finished": true,
+              "priority": "Low",
+              "resourceSize": 12567,
+              "transferSize": 5310,
+              "resourceType": "Script",
+              "networkRequestTime": 2709.6570000005886,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "protocol": "h2"
+            },
+            {
+              "priority": "High",
+              "resourceSize": 16435,
+              "transferSize": 2496,
+              "finished": true,
+              "rendererStartTime": 2704.8109999997541,
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fclients%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Fjobs%2Fmarketing-brand-communication%2C%2Ffr%2Fjobs%2Frevenue-operations-associate%2C%2Ffr%2Fjobs%2Frevenue-operations-manager%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology%2C%2Fjobs&version=ba6d9b28",
+              "statusCode": 200,
+              "networkEndTime": 2800.5279999999329,
+              "protocol": "h2",
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2709.8710000002757,
+              "resourceType": "Fetch",
+              "entity": "ocobo.co"
+            },
+            {
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/_vercel/insights/view",
+              "networkEndTime": 2817.9810000006109,
+              "statusCode": 202,
+              "finished": true,
+              "rendererStartTime": 2757.7009999994189,
+              "resourceSize": 48,
+              "transferSize": 473,
+              "priority": "High",
+              "networkRequestTime": 2759.5609999997541,
+              "resourceType": "Fetch",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "mimeType": "application/json"
+            },
+            {
+              "priority": "High",
+              "resourceSize": 9346,
+              "transferSize": 4082,
+              "rendererStartTime": 3146.8880000002682,
+              "finished": true,
+              "sessionTargetType": "page",
+              "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953&hutk=18dd8404db3b1e624593e3cc9c48926f",
+              "networkEndTime": 3312.9360000006855,
+              "statusCode": 200,
+              "mimeType": "application/json",
+              "protocol": "http/1.1",
+              "experimentalFromMainFrame": true,
+              "resourceType": "XHR",
+              "networkRequestTime": 3149.6699999999255,
+              "entity": "Hubspot"
+            },
+            {
+              "priority": "High",
+              "resourceSize": 135,
+              "transferSize": 1095,
+              "rendererStartTime": 3228.9670000001788,
+              "finished": true,
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=18dd8404db3b1e624593e3cc9c48926f",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 3297.5970000000671,
+              "mimeType": "application/json",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceType": "XHR",
+              "networkRequestTime": 3230.2319999998435,
+              "entity": "Hubspot"
+            },
+            {
+              "entity": "Hubspot",
+              "resourceType": "Image",
+              "networkRequestTime": 3252.1220000004396,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/gif",
+              "protocol": "h2",
+              "statusCode": 200,
+              "networkEndTime": 3373.1500000003725,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fjobs&t=Ocobo+%C2%B7+Nous+rejoindre+%E2%80%94+Ocobo&cts=1778779389727&vi=18dd8404db3b1e624593e3cc9c48926f&nc=true&u=242475741.18dd8404db3b1e624593e3cc9c48926f.1778779388179.1778779388179.1778779388179.1&b=242475741.1.1778779388179&cc=15",
+              "sessionTargetType": "page",
+              "rendererStartTime": 3250.6290000006557,
+              "finished": true,
+              "priority": "Low",
+              "resourceSize": 45,
+              "transferSize": 1028
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "sessionTargetType": "page",
+              "networkEndTime": 3486.8219999996945,
+              "statusCode": 304,
+              "resourceSize": 607831,
+              "priority": "Low",
+              "transferSize": 1655,
+              "rendererStartTime": 3444.20100000035,
+              "finished": true,
+              "networkRequestTime": 3446.1520000007004,
+              "resourceType": "Script",
+              "entity": "Hubspot",
+              "protocol": "h2",
+              "mimeType": "application/javascript"
+            },
+            {
+              "transferSize": 1024,
+              "resourceSize": 35,
+              "priority": "Low",
+              "rendererStartTime": 3733.1120000006631,
+              "finished": true,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 3843.6150000002235,
+              "mimeType": "image/gif",
+              "protocol": "http/1.1",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "networkRequestTime": 3734.1809999998659,
+              "entity": "Hubspot"
+            },
+            {
+              "networkRequestTime": 3749.1589999999851,
+              "resourceType": "Stylesheet",
+              "entity": "Google Fonts",
+              "protocol": "h2",
+              "mimeType": "text/css",
+              "sessionTargetType": "page",
+              "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+              "statusCode": 200,
+              "networkEndTime": 3755.5410000002012,
+              "finished": true,
+              "rendererStartTime": 3748.0460000000894,
+              "resourceSize": 3792,
+              "priority": "VeryHigh",
+              "transferSize": 1259
+            },
+            {
+              "transferSize": 51336,
+              "priority": "VeryHigh",
+              "resourceSize": 50524,
+              "rendererStartTime": 3784.1129999998957,
+              "finished": true,
+              "statusCode": 200,
+              "networkEndTime": 3799.3009999999776,
+              "sessionTargetType": "page",
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "protocol": "h2",
+              "mimeType": "font/woff2",
+              "entity": "Google Fonts",
+              "networkRequestTime": 3785.0930000003427,
+              "resourceType": "Font"
+            },
+            {
+              "mimeType": "font/woff2",
+              "protocol": "h2",
+              "entity": "Google Fonts",
+              "resourceType": "Font",
+              "networkRequestTime": 3797.6090000001714,
+              "rendererStartTime": 3795.9769999999553,
+              "finished": true,
+              "resourceSize": 50524,
+              "priority": "VeryHigh",
+              "transferSize": 51336,
+              "statusCode": 200,
+              "networkEndTime": 3803.7700000004843,
+              "sessionTargetType": "page",
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 3951.5570000009611,
+              "sessionTargetType": "page",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=3a0a55e6-3178-435d-8fff-89bf75c6934f&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fjobs&t=Ocobo+%C2%B7+Nous+rejoindre+%E2%80%94+Ocobo&cts=1778779390316&vi=18dd8404db3b1e624593e3cc9c48926f&nc=true&u=242475741.18dd8404db3b1e624593e3cc9c48926f.1778779388179.1778779388179.1778779388179.1&b=242475741.1.1778779388179&cc=15",
+              "finished": true,
+              "rendererStartTime": 3840.9309999998659,
+              "resourceSize": 45,
+              "transferSize": 1026,
+              "priority": "Low",
+              "entity": "Hubspot",
+              "resourceType": "Image",
+              "networkRequestTime": 3842.3020000001416,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/gif",
+              "protocol": "h2"
+            },
+            {
+              "rendererStartTime": 3841.4610000001267,
+              "finished": true,
+              "transferSize": 1024,
+              "priority": "Low",
+              "resourceSize": 35,
+              "networkEndTime": 3945.20900000073,
+              "statusCode": 200,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+              "sessionTargetType": "page",
+              "mimeType": "image/gif",
+              "protocol": "http/1.1",
+              "entity": "Hubspot",
+              "resourceType": "Image",
+              "networkRequestTime": 3842.8379999995232,
+              "experimentalFromMainFrame": true
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "key": "protocol",
+              "label": "Protocol",
+              "valueType": "text"
+            },
+            {
+              "valueType": "ms",
+              "key": "networkRequestTime",
+              "label": "Network Request Time",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "label": "Network End Time",
+              "valueType": "ms",
+              "key": "networkEndTime"
+            },
+            {
+              "key": "transferSize",
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "granularity": 1,
+              "displayUnit": "kb"
+            },
+            {
+              "granularity": 1,
+              "label": "Resource Size",
+              "valueType": "bytes",
+              "key": "resourceSize",
+              "displayUnit": "kb"
+            },
+            {
+              "key": "statusCode",
+              "label": "Status Code",
+              "valueType": "text"
+            },
+            {
+              "label": "MIME Type",
+              "valueType": "text",
+              "key": "mimeType"
+            },
+            {
+              "label": "Resource Type",
+              "valueType": "text",
+              "key": "resourceType"
+            }
+          ]
+        }
+      },
+      "render-blocking-insight": {
+        "id": "render-blocking-insight",
+        "title": "Render blocking requests",
+        "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 710 ms",
+        "metricSavings": {
+          "LCP": 700,
+          "FCP": 700
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Transfer Size"
+            },
+            {
+              "label": "Duration",
+              "valueType": "timespanMs",
+              "key": "wastedMs"
+            }
+          ],
+          "items": [
+            {
+              "wastedMs": 236,
+              "totalBytes": 24570,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "lcp-breakdown-insight": {
+        "id": "lcp-breakdown-insight",
+        "title": "LCP breakdown",
+        "description": "Each [subpart has specific improvement strategies](https://developer.chrome.com/docs/performance/insights/lcp-breakdown). Ideally, most of the LCP time should be spent on loading the resources, not within delays.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "headings": [
+                {
+                  "label": "Subpart",
+                  "valueType": "text",
+                  "key": "label"
+                },
+                {
+                  "valueType": "ms",
+                  "key": "duration",
+                  "label": "Duration"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "subpart": "timeToFirstByte",
+                  "duration": 1.426,
+                  "label": "Time to first byte"
+                },
+                {
+                  "subpart": "elementRenderDelay",
+                  "duration": 2712.598,
+                  "label": "Element render delay"
+                }
+              ]
+            },
+            {
+              "lhId": "page-7-H1",
+              "type": "node",
+              "boundingRect": {
+                "left": 16,
+                "height": 91,
+                "top": 292,
+                "width": 380,
+                "right": 396,
+                "bottom": 383
+              },
+              "nodeLabel": "Rejoignez les\narchitectes.",
+              "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark mb_10 white-space_pre-line\"\u003e",
+              "selector": "div.mx_auto \u003e div.d_flex \u003e div.lg:w_1/2 \u003e h1.text",
+              "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,0,DIV,1,H1"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "cache-insight": {
+        "id": "cache-insight",
+        "title": "Use efficient cache lifetimes",
+        "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more about caching](https://developer.chrome.com/docs/performance/insights/cache).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 319 KiB",
+        "metricSavings": {
+          "LCP": 600,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "Request",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "valueType": "ms",
+              "key": "cacheLifetimeMs",
+              "label": "Cache TTL",
+              "displayUnit": "duration"
+            },
+            {
+              "displayUnit": "kb",
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Transfer Size",
+              "granularity": 1
+            }
+          ],
+          "items": [
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "totalBytes": 204725,
+              "wastedBytes": 196194.79166666669,
+              "cacheLifetimeMs": 300000
+            },
+            {
+              "wastedBytes": 41827.416666666672,
+              "cacheLifetimeMs": 300000,
+              "totalBytes": 43646,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js"
+            },
+            {
+              "wastedBytes": 27461.5,
+              "cacheLifetimeMs": 600000,
+              "totalBytes": 29958,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            },
+            {
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 27037.458333333336,
+              "totalBytes": 28213,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "wastedBytes": 26084.875,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "totalBytes": 27219
+            },
+            {
+              "wastedBytes": 4599.833333333333,
+              "cacheLifetimeMs": 600000,
+              "totalBytes": 5018,
+              "url": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "totalBytes": 2019,
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "cacheLifetimeMs": 600000,
+              "wastedBytes": 1850.75
+            },
+            {
+              "wastedBytes": 1647,
+              "cacheLifetimeMs": 0,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "totalBytes": 1647
+            }
+          ],
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "skipSumming": [
+            "cacheLifetimeMs"
+          ],
+          "type": "table",
+          "debugData": {
+            "type": "debugdata",
+            "wastedBytes": 326703.625
+          }
+        }
+      },
+      "cls-culprits-insight": {
+        "id": "cls-culprits-insight",
+        "title": "Layout shift culprits",
+        "description": "Layout shifts occur when elements move absent any user interaction. [Investigate the causes of layout shifts](https://developer.chrome.com/docs/performance/insights/cls-culprit), such as elements being added, removed, or their fonts changing as the page loads.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "type": "table",
+              "items": [
+                {
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  },
+                  "score": 0.002049
+                },
+                {
+                  "subItems": {
+                    "type": "subitems",
+                    "items": [
+                      {
+                        "cause": "Unsized image element",
+                        "extra": {
+                          "boundingRect": {
+                            "top": 0,
+                            "height": 0,
+                            "left": 0,
+                            "bottom": 0,
+                            "right": 0,
+                            "width": 0
+                          },
+                          "type": "node",
+                          "lhId": "page-10-IMG",
+                          "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                          "path": "1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                          "nodeLabel": "Ocobo",
+                          "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e"
+                        }
+                      },
+                      {
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                          "type": "url"
+                        }
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                          "type": "url"
+                        }
+                      }
+                    ]
+                  },
+                  "node": {
+                    "type": "node",
+                    "lhId": "page-8-H1",
+                    "boundingRect": {
+                      "left": 0,
+                      "height": 0,
+                      "top": 0,
+                      "width": 0,
+                      "bottom": 0,
+                      "right": 0
+                    },
+                    "nodeLabel": "Rejoignez les\narchitectes.",
+                    "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark mb_10 white-space_pre-line\"\u003e",
+                    "selector": "div.mx_auto \u003e div.d_flex \u003e div.lg:w_1/2 \u003e h1.text",
+                    "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,0,DIV,1,H1"
+                  },
+                  "score": 0.002049
+                }
+              ],
+              "headings": [
+                {
+                  "valueType": "node",
+                  "key": "node",
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  }
+                },
+                {
+                  "label": "Layout shift score",
+                  "valueType": "numeric",
+                  "key": "score",
+                  "granularity": 0.001,
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  }
+                }
+              ]
+            },
+            {
+              "headings": [
+                {
+                  "key": "node",
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "valueType": "node"
+                },
+                {
+                  "granularity": 0.001,
+                  "key": "score",
+                  "label": "Layout shift score",
+                  "valueType": "numeric",
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  }
+                }
+              ],
+              "items": [
+                {
+                  "score": 0,
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  }
+                },
+                {
+                  "score": 0,
+                  "node": {
+                    "type": "node",
+                    "lhId": "page-0-INPUT",
+                    "boundingRect": {
+                      "right": 380,
+                      "bottom": 117,
+                      "width": 110,
+                      "top": 79,
+                      "height": 38,
+                      "left": 270
+                    },
+                    "nodeLabel": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "snippet": "\u003cinput type=\"submit\" class=\"hs-button primary large\" value=\"S'inscrire\"\u003e",
+                    "selector": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "path": "0,HTML,1,BODY,1,DIV,0,FORM,1,DIV,1,DIV,0,INPUT"
+                  },
+                  "subItems": {
+                    "items": [
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        }
+                      },
+                      {
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      }
+                    ],
+                    "type": "subitems"
+                  }
+                }
+              ],
+              "type": "table"
+            }
+          ]
+        }
+      },
+      "unminified-javascript": {
+        "id": "unminified-javascript",
+        "title": "Minify JavaScript",
+        "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn how to minify JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unminified-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 0,
+          "items": [],
+          "headings": [],
+          "overallSavingsBytes": 0,
+          "type": "opportunity",
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ]
+        },
+        "warnings": [],
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "network-dependency-tree-insight": {
+        "id": "network-dependency-tree-insight",
+        "title": "Network dependency tree",
+        "description": "[Avoid chaining critical requests](https://developer.chrome.com/docs/performance/insights/network-dependency-tree) by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "value": {
+                "longestChain": {
+                  "duration": 1179
+                },
+                "chains": {
+                  "337F30A10429C9385B494C15984B7E05": {
+                    "url": "https://www.ocobo.co/jobs",
+                    "transferSize": 23030,
+                    "isLongest": true,
+                    "children": {
+                      "51.2": {
+                        "navStartToEndTime": 1027,
+                        "children": {
+                          "51.80": {
+                            "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                            "children": {},
+                            "navStartToEndTime": 1176,
+                            "transferSize": 31975
+                          },
+                          "51.85": {
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                            "isLongest": true,
+                            "transferSize": 39127,
+                            "children": {},
+                            "navStartToEndTime": 1179
+                          },
+                          "51.83": {
+                            "children": {},
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                            "transferSize": 38779,
+                            "navStartToEndTime": 1175
+                          }
+                        },
+                        "isLongest": true,
+                        "transferSize": 24570,
+                        "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+                      }
+                    },
+                    "navStartToEndTime": 911
+                  }
+                },
+                "type": "network-tree"
+              },
+              "type": "list-section"
+            },
+            {
+              "description": "[preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints help the browser establish a connection earlier in the page load, saving time when the first request for that origin is made. The following are the origins that the page preconnected to.",
+              "value": {
+                "items": [
+                  {
+                    "source": {
+                      "boundingRect": {
+                        "left": 0,
+                        "height": 0,
+                        "top": 0,
+                        "width": 0,
+                        "bottom": 0,
+                        "right": 0
+                      },
+                      "type": "node",
+                      "lhId": "page-11-LINK",
+                      "path": "0,HEAD,2,LINK",
+                      "selector": "head \u003e link",
+                      "nodeLabel": "head \u003e link",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e"
+                    },
+                    "origin": "https://raw.githubusercontent.com/",
+                    "subItems": {
+                      "type": "subitems",
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "source": {
+                      "nodeLabel": "head \u003e link",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "path": "2,HTML,0,HEAD,3,LINK",
+                      "selector": "head \u003e link",
+                      "type": "node",
+                      "lhId": "page-12-LINK",
+                      "boundingRect": {
+                        "width": 0,
+                        "bottom": 0,
+                        "right": 0,
+                        "left": 0,
+                        "top": 0,
+                        "height": 0
+                      }
+                    },
+                    "subItems": {
+                      "type": "subitems",
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "type": "table",
+                "headings": [
+                  {
+                    "key": "origin",
+                    "label": "Origin",
+                    "subItemsHeading": {
+                      "key": "warning"
+                    },
+                    "valueType": "text"
+                  },
+                  {
+                    "label": "Source",
+                    "valueType": "node",
+                    "key": "source"
+                  }
+                ]
+              },
+              "type": "list-section",
+              "title": "Preconnected origins"
+            },
+            {
+              "type": "list-section",
+              "value": {
+                "value": "No additional origins are good candidates for preconnecting",
+                "type": "text"
+              },
+              "description": "Add [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints to your most important origins, but try to use no more than 4.",
+              "title": "Preconnect candidates"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "diagnostics": {
+        "id": "diagnostics",
+        "title": "Diagnostics",
+        "description": "Collection of useful page vitals.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "numTasksOver10ms": 48,
+              "numStylesheets": 3,
+              "rtt": 0.0010166912804124224,
+              "numTasks": 1783,
+              "totalByteWeight": 1955192,
+              "numFonts": 5,
+              "throughput": 23970568446.197235,
+              "totalTaskTime": 2889.407000000002,
+              "maxServerLatency": 8,
+              "numTasksOver25ms": 19,
+              "numTasksOver500ms": 0,
+              "numTasksOver100ms": 10,
+              "numRequests": 91,
+              "numScripts": 59,
+              "maxRtt": 8.5345199999999988,
+              "mainDocumentTransferSize": 23030,
+              "numTasksOver50ms": 12
+            }
+          ],
+          "type": "debugdata"
+        }
+      },
+      "final-screenshot": {
+        "id": "final-screenshot",
+        "title": "Final Screenshot",
+        "description": "The last screenshot captured of the pageload.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "screenshot",
+          "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAEkQAAEEAQMDAQYCBwYDBQcFAAEAAgMEEQUSIQYTMUEHFCJRYXEygRUjQlORkrEIFjVSYqEXM3IkN0OCgxgnc7KzwdE0dHWi8f/EABkBAQEBAQEBAAAAAAAAAAAAAAABBAMCBf/EACcRAQACAQEHBQEBAQAAAAAAAAABEQIDBCEycXKywRIUMTNSQiIj/9oADAMBAAIRAxEAPwD1SiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICL45wa0ucQGgZJPgKvRdcdKzah7jF1FpL7edoibaYST8vPn6ILEiEgDJPHzVdPXHSzb/uR6i0kW87e172zdn5efP0QWJEBBAIOQfVRWs9Q6Xor2N1W17ox+MTSxuEQ+8mNo/MoJVFQvbXa/90mv2ac/BrtcyWJ/kFzeQQpY9X9PaNUoVtX1zTqdp0Mf6uew1ruWjkgnhBZ0XXWsQ2oGT1pY5oZBuZJG4Oa4fMEeVC6v1j03o9sVdV13TKlnOO1NZY1w+4J4/NBPIuqpZguV2WKk0c8EgyySNwc1w+YI8rtQEREBERAREQEREBERARF8e7a0lALg3yQF8EjD4cFF6lqNTT4DY1G1DWhyG9yZ4Y3J8DJWBT6l0O7ZZXp6xp89iQ4ZHHYY5zvsAUFlRdFd5Pwn8l3oCIiAiIg1v7cJ5n6PoekNmfXqaxqsFG3Iw7T2XElzc+mcYVjt9C9MWNBdpD9FoNo7CwNbC0FvGNwdjId9fKzOrunaPVWhT6XqbXdmTDmvYcPieOWvafQgqny9F9Z2aR0y11492mub23vZp7G2XM8Edzd5x64ygoh13Up/YfTouuylkmsDRHX2uw59bulu/P1aNuVtxnQPSrdD/RI0LT/ctmzBhbu8Yzu87vrnK5zdE6JL0SOlTWI0lsQia0H4mkHIeD/m3c5+arTeietGVP0c3r+X9GhvbDjp7DZ2eMd3PnHrjKCG9oNqz0J7FDX6d1ia2Y5W02XnPDnwxueQRuHq0fCD5C2L0/05pmn9OM06OIWK80IbO+Y9x1jI5c8n8ROV16d0bolLo9vTIqNm0ntmN8c3xGTJyXOP+YnnPzWK7p7VNM0UaP0xfbWrbO2yxde6xJXb4wxvGcem5xwg0rXnlr+yL2oaA2V82naNefXpvcc7Y+4Pgz9Mf7rc/RPSmjU+k6kZq1rzrddklmzMwSOtOc0EucT5BzwPQKPHszoV/Zre6SoWZI/fQXT3JG73ySFwJe4cZzjCR9HdR6TU9w6X6pjpaaG7Y4bVEWHVx6iN24cfIOzhBVOn7c3SH/FHStEJdQ0eL3yjF+IQPfE57mD6AjOFafZZ0locPQ2m2X06t61qNdtm3anjbI+d8g3OySORk+FNdF9HU+mdHtVDLJfs3pHTXrVgAvsvd5LvpjgBV2l0F1D0+ySl0h1b7jo5c50VS3SbZNfJyQxxIOPkDlB0ez6GPQPaf1Z03pY2aMyGC9HADlteR+Q5rfkD5wtoKs9EdIwdLw3JH259Q1S9J3rl6f8AHM70GBwGgcADwrMgIiICIiAiIgIiICIiAuE4zEVzQ8oK71GLJ00+5C8Ztw//AEXZ7mP/AFfhx/uoLRW6v+lIPeh1F2cnd70KPb8H8Xb+P+Cuz4SD8PIXERPJ/Cg+wD9YFlLhFGGD6rmgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIePKKldXalK+46pG4tijA3AH8RIyjlrasaWPqlcDYhH/is/mT3mH96z+ZaM6q6rpdNTUo70NmQ29+wwtadu0tBzlwP7Q8ZK56j1NWo9RUtGNa1LatRiVrowzY1pdtydzgePOACcKWyRtmU7/S3h7zD+9Z/MnvMP71n8y0JqXW+mUOoTo8kVx9hr42SSRxgxxueMtBOc+OeAV36v1ZR0vqKno1iG06zaaxzHxtaWDe4tGfiz5afAKWvvM/w3p7zD+9Z/MnvMP71n8y0fF1PSk6iOjNise9CR8e4tbsy2NjzznPh49POU03qSK/1Dd0hun6jDNUG5800TRERkhpBDicOwSOOQClp7zL8t4e8w/vWfzJ7zD+9Z/MtGaR1TV1Szq0NetaaNNfJHNI8M2ucwkENAcT6cZAWJ0v13pPUmox0tObZEzqxsnuNaA0B20tOHH4vX5Y9Utfd57/8fDf3vMP71n8ye8w/vWfzLRWl9WU9Sj1eSGtbZFphkbK54Z8ZZnIaA4n9k+QF96f6toa/TuWNNhtSCrG17mbBucXNLtrRn8XGMccpZO2Zx/LenvMP71n8y7Gua8ZaQR8wtH9L9QRdQ1Zp4KV6qyKQxH3qNrC5wODjBPgggq0aTqM2n2mPjce3n42Z4ISyNtrKssabJRAcgEeqKt4iIgIiICIiAiIgIiICIiAiIgIiICpXV2mysuOuRtLopANxH7JAwrqh58o5a2lGrj6ZaU1jQdN1mWvJqVbvSV93advc0syQSQQRz8I5+i4ah07peoapU1K5V7l2pt7MvccNu124cA4PPPK3Sa0B8wx/yhPdYP3Mf8oUpkjYso+MmkrvS+i3tXj1S1p8Ul5ha4Skny38JIzgkfULuu6Bpt7VYNSs1t96ANbHMHuaWhpJA4PjLj988rc/usH7mP8AlCe6wfuY/wCUJR7LL9tNs0TTmaw/VW1Wi+8EGXJ9QATjOAcADOM4CyIqNeG/Yuxx4s2GsZK/J+IMztGPHG4/xW3PdYP3Mf8AKE91g/cx/wAoSk9jlP8ATStDpvSaF29bqVO3YvbveHdxx37jk8E4GT8sLjpfS+jaXcitafRZBYih7DXtc78HyPPPgcnnhbs91g/cx/yhPdYP3Mf8oSl9ln+2k6PTOkUX6g+rU7btQDhZ/WPPc3Zz5PHk+MLv0fQ9O0YznTKra/e29za4ndtG0eT8luX3WD9zH/KE91g/cx/yhKJ2LKfnNqPT6NfT4HQ04+3G6R8pGScuc4ucefmSVMaRp02oWmMjae2D8b/QBbE91g/cx/yhdjWtYMNAA+QSjHYd95ZW+gYAA9ERFX0BERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBad9o/txrdE9WWdDl0Oa4+BjHmZtkMB3NDvG0/NbiXiz+0z/3vap/8GD/AOk1Bs2H+05pxkaJ+mrbI/VzLLXEfkWj+q3T0X1VpfWOgxatosrn1nktc142vjcPLXD0K8Yzi11toXTukdM9OSyXdJgey1PAwF05e4FpdgeBjyfmVeb1rqf2N+y6rpm9tLWdcuSzktIe6vExjGkA+A4kjkZx9/BHrJU32rnq0dJv/uH2/wBLdxu7O3d28HOzd8O7OPPpn1Xjkaj1k+gNZGt3zG52A79J/rXHOMiPfvIz64wti3etOrdS9iWqR69+kYLNS3W93vvY+F0zHF2W7uNxGPP15Qbb9h7vaO517/iAD7lsHu/fDBNvzz+D9nGfxc5xhbYXhbob2k630sdXsxXrFm5PU93r+8yukbG4yMJftJxkNBx91yqf8RepNK1DqWtc1m3RqOcbFltstDCBudhu4HABB4HAQeyeujrzelNQPSLYXa3sHu4lxjORnzxnGcZ4ytS+yY+17++EX97RN+hMO94967X+U7dm3nOceOFr/pX2na7rPs16v0XVr009qrRbZq3NxEwaJWNc0uHJ/EMHz5UJ7EOrNQo9dC7qWoXrVSpRt2XxSTucHBkLneCceiD2mi8Tt6o9ontM6qk/Qtu8+ywGeOpUsdmOBgcMeSBwSBk8lQfXPVHVk3VV861cu0dSYWR2IIp3Ma17WNaSADgZxnjjlB70ReBequoNZj1SEM1fUGg0absCy8cmtESfPqSSpn2i3ur6cfS1rWNXftsaVBLSFWd4McW0AF3j4zjJPOSfKFvcKLx7qntl6lZ7M9E06tqErNSkdMyxez+udG0gMAd6Hk5d5+Ec8lUv3/rOtUr6q3WtQAmcO2WanumJPgmMP3gfUhFe9kXjTrnrPq/VuhOn/wBMDVKd+vZnj94DHwGzGWxlrjjGSDkZ+3zVF0rUOqdW1GGhpt/WLNyV21kMdiQuJ+2UR+gq8le1T2s9baJ7Qtd03S9bdBSrWCyKP3aF20YHGSwk/mV6F9kuiat090Fp2ndQzmfU2b3yuMpkI3PLgC4+cAgfkvIPtu/72Opv/wB0f/lCD2t0bcn1DpDQ7tyTuWbNGCaV+ANz3RtJOBwOSfCmF4s669pXUNmHSOntGv2KOn06FSDbXeY3TSdlm4ucOcZOMZxwoiprHXvTesV/c9V1CW2fjbHXuC4130c1jnD8jyg91JkHwV5C9t3XPWF+PQxaZqGi0bFFkjoWh8IkmyRJnweCOAfTB9VSulNP6r1RjbPT+s/9qLjtrt1VsVhxHyYXglC3vJFX/Z9+kv7k6KNd736UFZgs9/8AHvxzu+qsCKIiICIiAiIgLyL/AGh+leodU9qepWtM0LVblV8UIbNXpySMJEbQcOAI8r10iDxb1L7MupKOgdN6zo2j6n3p6my3DBC/vQzNc4ZLANwBbt9PQ/NSmlezHqnqj2ZzvnqX49Z0/UHyQ1tQa+N80Toow4N349WjHpwV6+RB4dq6J7TKemHQ6mka/BTMm8siqObznP8AzAM4zzjOFcOqOmOpOnfYhqM3WOo2pLd25XEFOeyZey1pcfUkBxzyB6Afl6yWi/7QHs26k666i0qXQmVzVgrGOR804Y0O3E+OSePoiNBezHoqfrqfWtPovY2/BR95rh5w17hIwFpPpkOPPzwpKtoftP0HTL3T9PS9fh0+2SLEEFdz435GD8QBHIABweQvRfsQ9lP/AA+it3NQtR2tXtsEbjED24mA52tJ5OTgk4HgfnIe0L2u6B0JrkWlaxW1KWxJA2wHVomObtLnNHJeDnLT6INLdL+ybXtF9mvVmp6lRm/Sl2k2tVoRN7k23usc4kNzydo488HKh/Yh0NrZ68jh13QtWp6dYp2a8s09SSNoD4XN/E4YzyvVPRXU1LrDpurremRzx1LJeGNnaGvG15acgEjy0+qwvaF1xpHQmkR39aMxbK/txRQs3PkdjOBnAHHqSg8iTdB9Y9P6x3ulxbuwuJbX1LR5S5sjCfJcw5b9QcYVR6opT6f1BeqXbbbluKTbNO1+8Okx8XxeuDkZ9cKY6X6X1TqzUdRh6Xna8wMNhzZ5RXd284Ljk7eMjPxeq2D0J7CLupatX/vFq2mV6u7Lq9a02aeUDkgbeB98n7IKR1B0h1LfuVbNHp/V7NZ9CnslhpSPY7FaIHDg3B5BV69svS3UF/SegWUdC1Wy+toFeGZsNSR5ieGjLXYHDh8jyvWVWCKrWir12COGJgYxg8NaBgBdiFPHFf2R9Rax7Mql6rplqHVqVudslKzGYpJYiGEOaHAZwd33zx4UNX0f2n/o6DRa+ldQQ1IX5YxlV0QBz6yADI59The4ERXl3Uq/tS6J6Kq6dU/S+oajqpfLYlhbLbfSY0ANja4ZDXHLiSPpjxlav03QvaJpdua1pmldWU7M3/Mmgr2I3v5zyQMle6LWo0qkgZbuVoHkbg2SVrSR88Erur2IbMQlrSxzRngPjcHA/mEFV9kh1Q+znQzr/vn6T7Tu/wC+7u9ne78W7nOMeV5b9sPSHUt/2m9Q2qPT2sWa0tkuZLDSkex4wOQQ3BXtJEHjvr/2RdSwRaTrWi6dZtxWaNZ00ETD3q0whYHAs8+RnjwcgrBraH7WOpNTrN9112vIwCNskjHU44x8zw0fn5K9pIg8v9edP+07p27BX0l2o65poqwiV8jG3GSShvxkxv3Ec5xx4wtYv6G646h1h0o6VvQWJSM7aHucQPjONrWhe7kQQfQ2nX9J6P0fT9Yse8ahXrMjmk3bsuA+frjxn1wpxEQEREBERAREQFrf2te1jTfZ66tVkqyX9TsM7ja7HhgYzONznYOMkHHHoVsheOP7U1WzD7UpJ52u7FipE6Bx8FoG0gf+YH+KDYU39pSn/d6K1Bom7VO/25ab7BADMEh7X7TnxgjAwuVb+0RPN0vqGr/3bjBq269bte+n4u6yZ27OzjHa8Y/a+i0X1l1Hoet6PpVfRulq+jz1G7Z7MUpcZzj14HqCcnJXTpv/AHY6/wD/AMrQ/wDpW0Ru2P8AtMdzS70jtAjhus2CtF7yXtkJJ3Fx2jAAH5khTNn+0FVodF6VqVrSxNrN/uOFOKXaxjGvLdznEEjJbwMHwVRf7Kei6ZrOsdQM1bT6l1kcERYLETZA0lzs4yOFDf2m9Gj0b2gwsp046mnyUozAyGMMYMF24ADjOeT90Fuqf2nLgsD3zpqu6AnxFaIcB+bcH/ZUP+0B1PQ6v6o0fWdKL/d59KjBY8YdG4SygtP1BWJrXXXTt/RdJpRdCaXFNTaGzTd17TNhuDyzaeTzySqz1bLXsTafZpaNHo9aeqHshZM+QPxI9pfl5JGS0jHjj6oNkdO+2DVujPZ903pmg0oniPvmzPaicWOcZnODGEEeGkE/9QWw+pvazouveySrrmpdN1dUcb7aVnT7EmGwyGN7t7XbSfDeOAeT8lrHq1o/9nPoV2Bn3+1z/wCpJ/8AhU+g4/8AC7W25O0avRIH/o2v/wAINm6X11pVv2cdas6d6Iq6W/3VkEr68xkcWS7mlxOzOG4zjx9lrH2X67Z6b660vVqWnv1KxXMm2qwkF+6NzT4BPAcT49Fd/YbE+boz2nRxNL3u0cgNHk/DIqZ7KOpKnSPX+la3qUc0lSqZd7YQC87onsGASB5cPVB6T9o3t60npXWZ9J07T5NVuV3bJ3CURxscPLc4JJHrxwobpj+0npt7UYa+u6NLp0Ejg33iOfvNYT6uG0HH1GfsvO+oWGRdbz29TgkdA+4bD45Y9znMe7cDtyAcgg4zg/NTWo6v0dZ6gdMzQtRt13BrWsjlipBx+kUbHAfzFB6O9q3tu0/orVBpWn0f0pqAY2SX9bsjiDhloJwSSQQcfIjlUfSv7TcvvLRqvTkfu5PLq1g7mj7OGD/ELUftPqTaT7QbDbtGSJobXkbWneXnt9pmGF37WANpP0Kk+quu+mtZvVJq3QOlVYoY9j42zSM3n/09g/iCUGT/AGiOpYuqOu4LlSFzaLKEDK0pz+vY4GTfjHGDIW455afstlewL2g1enfZhqP6dqS1tN0p4dFZGXG0+V7zsYMAZBGPJ884Wqva/CRW6NsxaV+iqs+jAxVg90jWfr5nYDncnh7Xc+Ny43Op6+oexfT+mKsFs3NOuuu2X7B2u24uaOc58yN8hBtOx/adYLLhW6Yc6vnh0lza4j7BhH+6vvTntu6c1fpHVNaljsVZtMY19im7Dnncdrdh8OBJAzxj1wvLHTeq6BV6b1Grq9OWa7Kf1Loq8ZcRj968kx4/0tKtXR13pJvTHUs0vS+qOqR1YorU/wCkQ44fPGGho2BocCNwz/lI9UF0t/2nLpsH3Ppuu2DPAlsuLiPyaAFsv2Pe1uP2iXrlJ2kvoWa0ImJEwkY4ZA+QOeV5Xsv6f0h0epdM6rZs2muwKmpaZG4Bp85Jc5hx9v4La3sY9o2m0IOpdX1Dp6nXuUKAlfZ06Lsidpka0McwHaHFzm8gDjPyQepEWlfZb7co+teq4tDtaMaMthr3QSMm7gJa0uIcMDHAPP0W6kUREQEREBERAREQFBdW9JaH1bSZV6g0+K5Gw7mF2WvYf9LhghTqINfzeyDouXQIdGOlFtKOc2AGTPa9z8EZc7OTwcYJ4XRF7FuiYtJs6azTpxUsTRzyN96kyXxh4ac5z4kf/FbHRBUuiPZ5070TYtTdPVJK8llrWSl8z5MgEkfiJx5Up1R0vovVVFtTX9PhuwtO5m8Ycw/NrhyPyKmUQa0q+w7oCvOJRopkIOdslmRzf4blI9UeyjpDqa5Xs6pppL69dtWJsMzomMjaSQ0NaQP2ir0iCjXfZX0pd6X0/p6xRmdpdCR8sEYsPBa5xJJLs5PLj5WDH7FuiY9JsaazTpxUnmjsSN96kyXxte1pznPiR/8AFbHRBUuifZ5050VLbk6fpyQOttayXfM+TcG5x+In5lQ2p+xboTUb8lubRBHLI7e5sMz42E/9IOB+S2MiCmdRezHpHqGGpHqmjxPNWJsEUjHuY8MaMBpcCCQAPXK6OmvZN0Z05fjvabo0fvcZzHJPI6UsPzAcSAfqr0iCudXdEdO9XsjHUGlw23xjDJeWSNHyDmkHH08KuaX7Feg9OtMsRaI2WRjtzRPM+Ruf+knB/NbGRBB9U9J6H1VpzKOu6fDarsOYwctdGf8AS4YI/JQnS/ss6Q6ZsWZtL0oB9mJ0EomldK10ZxlpDiRg4Cu6INZz+w3oCawZTormEnOxlmVrf4blaavQ/TVXpyXQYNGqN0mXmSuWZDz53OPkngc5zwrGiDWM3sK6Alk3/oeRn+llqUD/AOZWnRuhOmdG0W1pOn6PVio227LDCC4zD/U48n+PHorKiCm9IezPpTpHUn6hoemCG45paJXyukLAfIbuJx+SuSIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAoXVOoqum3Za88FpzIYmTTTsYCyJj3OaC7nPlp8A4U0qrrnTk9/XpNQY4FgZWaIXSuEcoY+Qva9g4Iw8EZzyArCSsPv9P373L3uv75t3djuDuY+e3OcLpOrVIa0c1+aGkJHmNonmYMkEjAIOCTjxnKrLenrVfUnyyQxS123n3veO+8vALi7AjDeXDO3zggePRcdK0i+xsN5tKCcywzRmtccYzGHTPeD+E+Q4BwxngJRcrY+9HHZljmxFGxrHd58jQ0lxIA85Hj1ABzxnlcf0tp3uIu+/1Pcycd/vN7ec4xuzjyqr/dG2K7K75IZ42w6dES8n4+xM57+OeCDwsqxoFuPWzfrw1poW3HTtrPdtBa6BkZcOCA4Fp/Jx5CVBcpunrVGy1x78cf650LBI9o7ha7blvPIJI/iFk179OzYmgr268s8JxJHHIHOZ/1AHI/NVXQulp62qV7VyKo1sXvjmtiJIidNKxzduR6Brhnhcul+nLem29P95ggDaMLohO2w57pScDO3AABxuOSecfdKguU5f1uGrbdWirW7c8bQ+RtaLd2wfGSSBn6DJ+i7W61ppp17T7sEUNg4idK8R7j/lw7Bz6Y8rBfV1PT9V1Cxp0Fa1Ddc2VzZZjE6OQMaz0a7LSGt+oOfOVFw9PX6MvvDYKWoyzQSMlineWMje+V8ji34XZaS/B9cNalC0zahThtRVZrdeOzLzHE6QB7/sM5Kxq2t0Z7clUzxRWWSuhbFI9ofIWgElozkjlV+bp292L1VsFFzbvaJsBxaa5axjDsaQScbNzfi8n8yn6euvk1OIVqWy7eZaFree5G1uznG3lw2cc45+nKoN60x36ctySpHbrvtRjL4WyAvaPmW+Qu2xPDWgfNZljhhYMufI4Na0fMk+FVaGgXYJNPhdFVbHStSWfemPPdm3b+CNvBO/4jk+PrxIarUuarpmmTmvFHbgmjtSU5JMscQ0gsLgPQuyDjy0JQko9SqSyQiGZkrJo3SslY4OYWtIBO4cftBfa+p0LNV9mvdrS1mEh0rJWuY3HnJBwoS3olm/05qVSSCnSsWnuc1lcktxlpw52Bndt+IgeD6+Tgs6bsyx3ZLFKGN8pg2xtuPLj2yTuLtuMgngbeccnngXKdt9S6PUtUq8+o1WPuAuhJmaA4D1zn18D5lZ09xsFlscrdsXadK6Zz2hrA0jzk59fOMcckcKtVND1OudLnc2pPNWnmLmyODD23+DuYzBcOP2Rn5+p7+rdCtau+c1jEA/TLVMb3EfHIY9vp4+E5Tcb0hf6k0ejUNmfUanZE7a5cJmkB7nAYPPGM5PyAJXdLrenRy0oxbge+4f1AbK07xjO4c8j7KG1Tp6eSe3JRjqtaY6ZijcdrXPhmc8g4BwCCBnB+ywtU6bv27t6Q1q0jb7Yt2bT2trlrQ0tADQXAY3AgtOSfHlKguVsl1OhDa91mu1o7ON3adK0Px88ZzhH6nQYyZz7tZrYRmUmVoEfJHxc8cgjn5LXvUDWssahpdeTTrE9rUIpgx4d70HbmHGzHLQBw/OA37Kal6WnbpsYijgdZZqc157BIWCZrnybQXYPIa9p8Hlv5pRa0nUaIrR2DcrCvJyyXut2u+xzgrvdNE2XtOkYJNu/YXDO354+X1VV03puRs2nS2q1ZohtTWXRCR0oaXM2ggkcn1OABkn7qR1ajddq7LtFkMuaklZzZHlm0lzSHeDkcHIQSLtToNfCx16qHzY7TTK3MmRkbeecj5LkL9N140hbrm4BuMAkHcA+e3OcKpR9J2Rod2u9tY3ZaNavHJn8L4mYznGQN3IXOn03bh1ZhkhhfC29Jc95Nh27DnOcAGAefi2/ixgfXCVBcrmiIooiIgIiICIqH1Vr2oV9Xux12tji05kczA9zGtmLgfxEyNO39kYa7kZ54CsRaTNL4io2t9R6jWh1m1Fap1xQmZAypLHlz9zWHcTkHJ3HGBj4f4Zz9emMVGN74TLY1KxUezHPbZ3scenDGc/X6pRa1ote6Xrl2SvBBXuadpkEOjVrrWviyNzg/I/EMMG0fXlD1bq00rpmQMrMi93zXl7Y39xjHEEukDgcvLRhp5b6+AotsJFB9QX7MOoaXSqzxVRbdJusSM3AbQCGNBIG45/g0qtUdQt0umbusQzx2JRamrgM/5WXWi0y4LgMAHPJxj1xylFtgoqN/ePVK+m35nCOzNTniayIBncsbhzFiNzgH85Bz8sgDJXe3Wr9mzplZmp0IBZovtvn7W4FwcPhaCRwATnPPw+nootckWuJ+sNWkhdLE2CEQU47JJDNk5cXc5fI0hh28bQTz+RzOor+r2tJ6pfFbZTr0YdsYjjzJuMLHnLs8Y3HwP6JRa9oqZqWu3aTo5Ib9ezp8cTZJLMUbJScvIO5oeCG4AALQec/LCleorT6uoVHQx1nTNrWZI3znaGua1pGXejT6/RKLTyKkR69q7q8kIdGbzZYg5j4o2Oax7XH4P1pY8/DwNwOATzxntrdTTmpZmlmi2x6fJO17ou3mVj3tdxuPja3OCRzwcEJRa5IqZV6g1F2o0/enwsqTOhjBjia8Oc+Npw4h+5jtxOPhIxj8s7W9Stt1malBdq0YoKfvRdOzd3SXOGPIw1u0Zxz8Q8eqi1lRau07qbU62iU2VmxxxU9OqSASdvExdE0nJc9rgM/CNrTyD58Kzs1q+3qNsFl0TKclgwRCONsgd8G7BcH7muyD5bjA/NKLWrAznHPzRVPWNXus6hv0YNRpUYa1GO0HTx7i5xdIDnkfCNoz68rE0TWLD7rbL4xXF+5AJo5P/DDqYft+h3ABKLXdFRLHU2pvhlnrSV/dopbQfIxjZHBscm1p2l7ctwDkjJ8LP6tsvJ6ZmgsRQOlvDEsrTtAdBL6ZHPPAPrhKLWxFQZupdVFoafG+KQtsTRG9EyMCQMZG4AB72t3frCDyf+W7j5Y2p359R0x1qx2xM/SJtxiILXYlaNwwSOcZ4J8+T5Si2x0VGl6l1Ma3MxrI2V4r7KYgf2xvaS0bsl+/cc7hhuMY+4kNG1m/Nrvu198Qjl73ZbFG1zHBjuCHh5OcEZDmjn5JRa0oiKKIiICx7FKrZmimsVoJZojmN74w5zD9CfCyFg2NX0+vdZTnuQMtPIAjc4ZyfH2z6fNB067otXVqk8ckcTJ5I+2LHbBe0Z8A+Vme4VPeXWPdYPeHEEy9sbjgYHPnwSFjRa5pktuStHegM8e7c3d42/i58HHr8vVYs/UlH3P3ijKy3ieCFzWuwR3ZGsDvHjkkfPCu9NzuOgac6++1LWilLo4omxvjaWRiMvLS0Y4Pxn+AWbLRqTWY7MtaB9iL8ErowXM+x8hY7Na01+omgy5CbYJb2w7ncBkt+WQOceVlusQtstrukaJ3MMgZ6loIBP8AEj+KivlqrXuRdq3BFPFkHZKwOGR44K+trwthdE2GMROzuYGjac+cj6qNm6k0aERmXUa7d8bZm5d+w7w4/Jv1PCyf0xp3v4o++we9k4EW8ZzjOPvjnHnCDtr6fTrRxx16leKONxexrIw0NceCQB4PJ/isWxoWn2LjZ7FaKVojLO0+Nro+Xbi7BHnPr9Suy5qPYttqQQPsWXROm2McBhocBySeM54+xUTH1SPc4bdmjJVrSWTX7k0rOCC5pPBPqz88qpuTs9CpYfC+xVglfCcxOfGHFh/058fku1sUbTIWsaDIcvwPxHGOfnwAFHSdQ6THUitOvQiGVzmsOclxb+IY88YOfl6rrsa2PfK9ehVfeM0BstfFIwN2ZAByTznPooJCShUkfC+SrA58P/Lc6MEs/wCn5fku18Ub3Nc9jXOaCASMkA+VgO1uhHbjqWLMUNx20GFzgS1zvDSRwCfQevoum11BSjsNgrSx2JxYZXlYx/MRc4tyfzB4QZrdMoNrPrNpVRXecuiETdrj8yMYK5SafTlZCyWpXe2H/lh0YIZ6cccfku2CxDYDzBKyQMcWOLDnDh5H3ChZupI4dSmryU5xBDajpusbm7RI9rXN4znHxtGcf7IJYUajbDLDasAnY3Y2QRjc0fIHyAvtmnWsujdZrwzOiO5hkYHFh+Yz4WHX1/SrLHPgvQva0saSDx8btrT9ieAfBXDUdbjq2oataF9y1JL2THG5o2Htl/xEkD8I/wBwgzH6dSe+B76ddz64xC4xNJj/AOnjj8lzFOqLfvQrw+84297YN+Plu8qH1PqRmlVLNnUqxhZBC2V0bZA+XJc4AbRxj4eDn5/JTVWxFartmgcXRu8EtI/2PKKwptEo2NTmvWoGWJZI42bZWNe1mwvILQRwfjPP2WXPTrTxyxz14ZI5SDI17AQ/GMZB8+B/BQ7upWiu643T7btLa4g3Bs27QcGTbu3bPrjxzjHKz3a1pzdQFF1yEWiQ3t553EZDflnHOPKu9Nztk02jIxjJKVZzGO3ta6JpDXfMccFd89eGw0NsQxytGcB7Q4DIIPn6Ej81HDqHSXTSQsvQvlj37mNOTlmdw48kYOR5XRS6p0q1pFbUHWOzDOG7WytIdkt3bQMcnHyylSbklLp1GWo2rLTrPqt8QuiaWD/y4wux1Wu5u10ERbs7eCwfh/y/bjwseHVK89qrFA4SsswunimYQWODS0Hn/wAwWcorHdSqOuNturQG00bWzGMbwPkHeV9ip1YbEk8NeGOeT8cjWAOd9z5K70QEREBERAVd1HRLU2ti5Ukjrh8kT5JGSSNc4MIy1zM7H5AIycEA+uArEiCq19C1WvSbp0NqlHUgZKIJjDvly5rg0kHgY3ckfix6ZKxmdL6g61LNLPD+u90LmmWSQtME3c4LvIcCflg4+6uaK2lKhS6Ws19VYTNE+jHbkuNJmlLyXOc7bs3bBguPxfIeOcqTuaVaZqNa5p0rHPZDJA8Wnudw8sO4Hkkgs8eufIU4iWUoWnaFq9Oxap1RUc39GVaT5rEbtpLRIC5uB8WM/hOPI5ClKnTdmlqVZ9SdsVaJzHSObK/dMGsDcOjPwZOB8fnjwrSiWUiexJH1X7xscYZqYj3AcNcx5OD9w/8A/qVjRaHI2jRge+Nxr3n2zwcEF73AD6jcP4KfRQpTr3S1s6jJfqTRGYyzERumlhbskEf7UZByDH45Bysqn0pWZNQN6GpbirVDBtki3DeXBxcA7OBwfXKs6K2UrFvp+3I+9WhmrN069OyeQlp7seAwFrccH8AwfT6r7b6ZfZ02Sr3+yZdRNx8kJLXFpfuwD5DsYGVZkSykLoNC9pMNXT815aEDXsbJyJNoLe2CPGcbgT64B9SuEPT8TNQ1i8Y63vtuXfBYMQc+L9SyMcn6tJx9VOopZSlHQLVevak1FzrEc1L3WRld8ksm4H4Xsz45JOBgNwPPld+ndNS2dP0h2uNr2bTZ3XLrZYw5r5HRubgDkfDloH0arcitlK3qnTQtN1KKq+GrBZosqRNYziMtc92dowMfGOPupej+kRM5l73Z0QiZiSEFpL8u3DaScDG3HPqVmooUo9/p3Xo9Oj0zT7dV+lsY6uWO3NkdXdgFnqN4HAfx9RypB/TtoumqMngGmy3Rec4tPea4PEmwen4m+fQcY9VaEVspXafT8sEdBpkjzX1CxceQD8TZO9gfcd0fwKx6eg6nRg0p0VmnNZ02J9aMOjcxj4nBg55JD/gacjjyMeqtSJZSr19Mt0rFKCAtknjjtWHTFhbEJZHAhv8A05c7jOcNVmi39pnd29zA3bfGfXC5IooiIgIiICIiAiLpisxSzywxvzJFjeMHjPheZzxxmImfn4WImXciIvSCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKI0v8AxvVfvH/QqXURpf8Ajeq/eP8AoVg2v7tDqnsyddPhz5eYS6Ii3uQCCMggj5hcYpGSxtkie17HDLXNOQR8wVWNO07UKzqrJYp3bQza+O1sZEAfiDm5+Inn0Oc4y3GVkWTqEfSVqKRssd2KpgStflzn7eSCPUFBYUVSnoaoWvFeO2yB8rcRvtlz24Y4F27ePhJ28ZPjOOcLu0ytqzNUpyWWWCzttExkmBY0iPBwGv5O4ZwWnyTu9EFlfIyMtD3tbuO1uTjJ+QXJVa9pupTai18YmL22jKJ3T/qmx7CGgMz5BI9Pmc+iyunKeoVmWPeTO0uja1osTd39YM5cOTwePUZ+Q9QnZJGRRukkc1jGjLnOOAB9VyULe/SEPT13vPdLccwtiMDS45IwMYHz9fz4HAjrVTWpGTQRCduHWS2YTgbg92YwOc/CDjkDGOOEFpMjGyNjL2h7gS1pPJA84H5j+K5KsS6bqrJ7MdaWb3Xc/tbrBLi0th43EkgkiUA+mfsvtPTtQfcbJI65BUAldHC+1ucwkRhu4gnPIeQMkDP5ILMigNJp33aVdr2TYgkflsUkkpc8fD+Lh7sc/Ij7BYFuhrdiCCWQ2BNKJHSRQWQ3svONnOQC0Ac4zyScHKC3Li2RjpHsa9pezG5oPIz4yqxLpeqiOWSKef3mSSZpJsHaIyDswM4BztwQMjK4VKWo1dQltQ1LfYfI39S+y18m0RubyS7GA4g4yfn9EFsRVfSaerQajQdaE72CFgnc+fLGkRYOAHcncPVp8k7vRdlilqb7FwQ99s7+6Y7PvOIgC0hje3zyDj0HjOT4QWRFVotLvWJ2B/v1akS4mJ1wmQHZgEuDicE8gZ9M+uFxr6TqggqxyTWjvjrm0feTneCe5g54yP8ALx8kFrRVMaTq0VUivYs99wsMJksl3wb/ANVjJODtAGfPPKy6lLUW6JeiDrMc0jsxNmnDpGtwMjcCdpOHY+I4znjwAn2yMc97GvaXMxuAPLc/NclTX6XqXcsSRQ3Y60k7XdkWh3i3thv4t/gOycbvX6YWbplPVYNXrus9+WIRgSyST5YD2wPhAIydw9WepOfRBZUREBERAREQFEaX/jeq/eP+hUuojS/8b1X7x/0KwbX92h1T2ZOunw58vMJdEQ+Dhb3IRUxmjar2O050/ZbKxzx7xmWUBrwRk/CRksOcNJwcjwsqDRdQjDJHTSunjdW2F9guwxrh3AfAOWkjOOeEFnje2SNr43BzHDII8ELkqrDpWptMHdc5847JFjvnEQa0B7C39rcQ7n13c/hCM0e/A3ShEZpHxMjExfZJaXbgXuPIOfOMZHoRhBalxL2B7WFzQ9wJDc8kDz/ULDnjve/tkhlZ7q1vMR8uOHfTjy319Fg6tpc+o3aNphFeavBIWPzkxyksI+4wHA/MFBNsc17Q5jg5p9Qcr6qlHpGp+712yNHd7LWtMc5Da0u9znO9NwILfT9nHglfZdO1aWNsTxK1sUL4y6OwA6Q91jgR/wCVp4OPJHHlBbF1tnjdYkga7MrGtc5uPAOcf0P8FCGjedotKKRm58Uu6aBsxHcZ8WG7iTzy04zjjGcLHbotrviyA6OZorhg94c7aGyuc8Enz8Dsc/ZBZ112Jo60Ek0ztsUbS5zseAPKqVTQdS2BlmxZLnGMWH+84E2JAXOaAARkZ9QecegKyLekXZo78Pbc58rZg2wbJAc1wIYzZ6YyB+WfJKC0oqxPo9uOxII2Pno73FlcWXMOTGwB27OeHB/H+rPkLgNE1IM3usSPtF5a+Rtgtyz3ct48gfrMHx55QWeaWOGN0kr2sY3y5xwAuTXNcMtIIzjIKrtbTbzun7lSVuJXyAxb5MuLfh/FyQDkHxx68ElcdQ0e0/WGS1nztrgscztzhrWHeXSZBBzuz6efBwOUFlRVODSdTjgxYD52d8SmEWCCYtrgIs/6SQc/tL6dH1F2oQSmSdrW9rZstZbEG/iacty7PPPrnnGAUFmr2YLIJrzRyAAE7HA8EZB/MLtVNboOoMqwsJeGN7IkZDKGueGxFpGTwcOwcH5LIg0TUWM7hsSm0x0Aje6cu2tDQH58A/tenPCC1Iqk/SNQfSjjYyWENfGZ2ttb3ThocHEF3AyS084zjBwrDo1eWrpsEM73vkYMEvfvPngF2BnA4QZiIiAiIgIiICiNL/xvVfvH/QqXURpf+N6r94/6FYNr+7Q6p7MnXT4c+XmEuiIeQVvchcXvZGAXuDQSAMnGSfRUyfQ7sNaBvba52+Fk5jlcfeiHgukfgfDwDnz+LHgLnc6avTRMZHIIom90xwxzYbAXEbS0lh8YPjBGcDhBcl1vniY4tc9u4bcgckbjgcfUqtWen7L6kjG9uWWW1JLI6R5OWnds8gjjI4xgeRylfQbMc8djtVRadFWbLYDv1hMbwX87ckOH19EFpRVOPp62Wxsk7bR8AsPbM7NsiRri9wxwcB3HP4seAuX93JyJviZmNjxU/WOxE7uvcwj5YaWj8iPCCzzzRwR75nhjMhuT8ycD/chIJo54xJC8PYSRkfQ4P+4VSZ03fFqaV0+4vk3OLpARIO814yAwHhrSBknHgcJJ03efZrv7+Gxj4NkgHad3XPLhlhPLXNHBH4ceCguC6X2oGQOmdKztNJaX5yAQcEfx4UFrWiWr2tRWo5nCJjYwzDwO2Q8lxALD5BA4IzjB4X2voTq+iXaNeCrCZZ3yMMfAc0ybhuwOCAcevhBYkVe0nS71bXJbc3aEMolDwx+dxLwWHxk4AxyTjPGAuiTRbvbstjhrd2XIfMZn5maZAfiGMZDcgZyPTxlBaEVIj0K818NWzBHZYyKwWB0rmsaXSNLOQ3ALQSBgDGOFky6Fqrrb5GWY2SOjdEbAdhxzFtDiMZyHc4zj80FrklZGWiRwbuzjP0GU7sfwfG39Z+Dn8XGePmq63Q5ZI2xGtWrViXCSBsrpGuzG5uSCAPJB8emTysRnTdttmk+MRVmQNiDWQSANjLXkvIBZn4h5wRnwUFu3t7mzcN+M7c84+a5Kvalpd2fXoLsHaDInx4dvw4sGdw8H5+hGfVdtvTJ5dXdZEcUgLmGOZ0rmuhaPxNa0ec8nzznnICCcRVKDp2yRAyZsTYmmP3gNlc73ktJ3Pdx5Py9c4PgLpudP2amkze6Z75jnjd23uLnNdIDEPn8LRj6eiC5oq1W0GQXIXujjgqMn73u0cri0YZgHwPLsHHjjPlYVLpi7G3bZsGTc6PvkyjE+JA4uIDQeQCOSfOM4QW+eWOCF8szgyNjS5zj4AHkrmqbd6auS07MG2CUOilirB8rmivmR5aRgf5HMH02Y8FZF3p2xNA8B+XSXHzyt7n/Mj+La34muHGQcYxwgtSLE0mvJU0ytXnkdJLHGGuc524k/fAz98LLQEREBRGl/43qv3j/oVLqI0v8AxvVfvH/QrBtf3aHVPZk66fDny8wl0RFvcnXWniswRzQPD4pBua75hdip8PTNxlik90kLjAyIB+87o9h+IN+HOHf9TfPIPhZukaLcqafqFYyRVzPHsikidve12CN5dtbk8jzk8ckoLGuLZGue9gzlmAcggc/X1VU0/pd7HRNuRVTWEgfJXa7cx+GPbkja0Ekub5Hp5PC6G9P6hPWbDYDHthdE0smkGybbEGlwy137XIy3+HlBdF1WrEdWtLYmOIoml7iBnAAyVWa+g6hAGxE1p4e7HM90kjsuLYRGW42ngloOc+vhZFTQrUHTeo6c+aOWewx7WzFzudzMAOzk4b4HJ4A9coLGDkLjI9scbnuztaCTgZP8AqzW0S7WsR2a8FKDZM1/uscrhGcMka5+7Z+I7xnj9kc+qx4+ndQj7O11beKvZfKZCSHdot+EbMgZwfxY88ZQW9rg5oI8EZGRhfVVZ+mrD+5JFNHDce9+bDSS9rDXMYAOPR+HY8cZ8rG/uxbbSMccdRri8OEXdHbB243EdrBJ4/ZB4/EguaKC0zSrVXXJrTxB2ZGuBcHbnkkgj9kEDg8FzvTGFExdPWrEFgtihrSyG00zb3CSUPc8Na7jhoyCDk+BgBBc1j0bcd2ATQh/bd+EubjcPmPooO109vugxQ1exujLZHE74WNxujY3GC12DnkfiOQVinpZ0WnVq1avRy2DtZ5YIZP3rMN5d4+R4HIQW5dcc8ckssbHAviIDx8iRkf7KtSdNy9uV0TohYldN3ZMkGVjn7mtcQM4xwflk4WPN01aMdjsV6MQkmEkcDZT22DYG+DGQeRngDzwRzkLg9zWMc5xw0DJP0XGCVk8McsTt0cjQ5p+YIyCobXtJl1DskR1p9kL49szi1rHuxiRuAeRg/I8+Vgab05aq6nVsSyQu7TYx3A74gGxBhYBtztJBP4sc+MoLWird/p6Wxas2IZGQ2ZZnkWGk72RmAx4H2fh2PHGfKxLHTll9d4hrUYMuaRXjlPayAQXnMZyTkfs+g5QW9dENuCaV0cTy5zS5pw04BbjIz49QorWNKnuGo7tVLPajcx0U5c1gcduJG4B5GDjwefIWFb6fuzR2Gx2I2CQyHhx+Lc6M4PB4IY4Hz+L1QWlcWSMeXhj2uLDtcAc4OM4P8Qqj/dWV9WRj21gezMIIw4lsMjtm1zcNAGC0nIaMZ4Hkrsu9MuJtmpVogz2BPnIjLvgwQ/4HA85Pj19CgtiLHotnZXay0It7AGgxk4dwMnB8c5454xyshAREQFEaX/jeq/eP+hUuojS/wDG9V+8f9CsG1/dodU9mTrp8OfLzCXREW9yEREBERAREQEREBEJDRkkAfMogIiICICD4IPpwiAiJkZIyMj0QEREBERARMjJGeR6IgIgIIyCCEQEREBERAURpf8Ajeq/eP8AoVLqI0v/ABvVfvH/AEKwbX92h1T2ZOunw58vMJdfHgljg04djgr6i3uSq6Ppo7deKehYiumMsuWt4AkdtwSTn48nkccfTwsfta/vtOdZstLt2Q2FpDf1jdu34+Rs3DgA4/1YVyXx72sYXPcGtAySTgBBXNGrXBqVe1ciuAuhMZLp8taQ52C4ZHlpGOCfnzyuq07WnslhgbYZI02f1nw4wZQYsZ8/Bn+HKszJY3u2skY53PAOTwcH/dc0FP1CvrrJpIa89oVY5JO1IGiSR2WRlmTubxuMo544GeFJ60zUC2DtOskiB3NbA/XcbSc/s+fp81Oogq4brO2zuNr37EnLCzsbf2NgP7WMfnnPGFj6mNXNIs01uogkSOidM9pcHBrdoPrjJceTjg5yMBXBEFTsjV5LFvY2xI2SPLGua1rWHDeMHIdzn5HzlfbUetOdYFd9ps5dIHOy3thu/wDV7B8w3/759FaO7H3u1vb3Nu7bnnHjOFzQQL49Sg0+/HE6eV0VqN0Bc4F74f1bnDPr/wCIOVhWGazZ97kjdbha1th8DAWgucNnaB+n4uP4q1BzXOcA4Et4IB8I1zXFwa4EtOCAfB8oKpedqlevaeW2WMAsPjMAYPizlhd9MZ/3z6IJ9blqxio2UzuLntkfjtkGudufp3COP/srW9rXNLXgFpGCD4IXyLYYmdnb28Dbt8Y9MfREV7S49Xj0vUR3pZLBizW94jDSJNp/1O4zj6eccLFho2xY1G0xl97468bq3ee0PfIGSggZz/n9fU/JW1EVSmSaqyxXrW33hC+eQjtHD3xiJpHJJP48+ufsOFzgfq8lt0Uktw2ImV9oaWBgcfx9z0PHn88cq5YTjKCo262ue619tm0N75nTFjQ57Tn9UAAW4bjPr5xnjK5yQ6+1rpo5ZH2i9zAx20Rhvu5IOP8A4oH8fkrWiCoQ0dRdqbnQyahHXkNdr5ZXN3lrRKXj7ZLf48cLN0ePVhrUz7k0pgJlyx0YDAN36vad3+X5D555wrEvge0vLA4FwAJGeRnx/RBTn1dbjmjZXfLBCC90YZGHZeZ3k7/iHG0t858n1wpfQffxcuC6Z3xnlj5AGjyeA3nwMcg4PHAKm0QEREBERAURpf8Ajeq/eP8AoVLqI0v/ABvVfvH/AEKwbX92h1T2ZOunw58vMJdERb3JUWaTqoqdw2b5s+6F+02ePeB+H1xj0x+E+vPK4zU9fdbvPEkpLu6GAEdssIPbABfgEfDk7R68lWutZiste6B+9rXFhIBxkefuu1BT7Gmaqw2n02GOR5lw4OGS11gOIHxDkszjkfcI2DXoKViNrbUzpISyE91odE4PON2Xk5wfOSeOVcEQVW9Q1c1x25rTu5aldK1snxBm53bDcPbhuMcA58Zyu3SoNYj1WB10zyxmNolcXNaxp7YzgBx3ZcP8oPJ5xgKyriJGOkcwPaXtALmg8jPjKCuO0q/PeEk1m82KSzKJGssloEOCWYAPHxBvI55weFhtoa7NdqPtPm+FsQ3NcAGjAEocQ8fEfi5DT6YIVrtWYarA+d+1pO0cEkn5ADyu4kAZPhBR4NB1CtSHurbsVmtSeyIm2Xb5xjbyXH4Tj8JwPmFmz1dZMlgwm02VzpN7zMNj4y74RG3PwuDeM4HOc58q1ogqEWn345rJ7Ope5yTbgxtoCcgRsDSX7s4BDuN2fHkcL7FQ1ZocbjbMgkcHSipM2N739mNodnLfhBa/I4yccYVsjkZI0ujc1wBLctOeQcEfxQSMMpjD29wAOLc8gfPH5FBS+/fj1OrXs2Z36l3oQ9sU7dhj2jfmPPzDiTt/PHC7oaevi5VdJJM0MZCMMI2AbR3A4bwCc7v2T6YIVwXWyxDJIY2SxueM5aHAng4PH3RFfoVdRdoep17bJ3zSRObG6Z4y9xaR43ODeceuPoFGs0XUqdTsVGyRxmcukFfazc3YNpAa5mMHg88kZ5Cuy4xSMlja+J7Xsd4c05BRVWNHXZIXwSTP5r93u9wDdMWBnb45AyHOz4yRjwsXUa09aJ0+l6fJpMexkcjWGNrpXuljAxtJGQN4yf8AMrjHYhleWxyxvcBkhrgT5I/qCPyXYgqFmrrDIf8AsovmNsr3RQvnaX7drMbn78/iD8fiGDyPGMvqWtq89uI6dJK2JsR29o4xLny7425GMeQ4eeFZEQV6jp1ulR1iOqJ225TI+GSWd0jC47i0gOcduCeeB+ai5dN1Zs9h1Nt2OCQwNf3Zw+VzWiXcARICPicw/iHGcfJXNssb3FrXtc4eQCuSDD0dlmPTK7Lri+wG4cXefpnk84x6lZiIgIiICIiAojS/8b1X7x/0Kl1E6Y1w1nUyWkAlmDjzwVh2uP8AtodU9mTrp8OfLzCWXxw3NIOcEY4OF9RbnJTbGk6nV0+CDTmWd7RM/ItOOHl2W5y8cY+4+YHld7Y9Rkt3YALTbmHyd02cR9txdsa1uSA4AAZwMEZyc82tEFUi0zUJ5sPdfr0sSFsTrZMjTtYG7nBxJ5DiBk4/PC4v07XDEZop5mXXve3L5sxsaa5AO3OP+btPjP5K2ogq2m6bqRsVTYfeirNl3vZJZy44YfJDnHaXY4z6eByuzW6GoyXZ5aYl7L3Q7xFIGPkY1smQDubjDnMPkZAKsqIICXS57NLR2WjM6WvMHyETua4Da4ckEZPIHqsCxp+q3ovd7MVlscUL2lxs7RM8SNLSNrs/hB5OMZVuRBVLNfWTG6vWhtRta6RzJTZB+EwODW5LtxIeR59RnKkr9Oy3TKUNd1mVscjTYa2ciWRuDkB5I53Fp8jgEKZRBSY9K1qNsbW+8sZmQsaywAY3mZ7g6Q7huG0s9HeDxypXW6d596aapFI9j4YoyY5NjuHuLsfE30I9R+fhWFEFfbX1J3T9WGds5sRyATtjmAkkYCfwv3evB5IOMqPg03Voqs7WttRtcZHta2ZrpOZg5oJ3DJ25B+IevOeVcEQVerV1Pu1XWYLRIawN2W8Niw87u4C47iW4/wA/yz6rDbV1aSd0Ljb95ZXh2ObZ2xxSbn5c4Zw4YAyOc4xgeVdEQVYabqe4xgyxQOlDnduXacGw9zuQcjLCP/8AV0O07WxYjaZLToWFzYi2x+DEzyHSEu+IGPt+Q48HI5VwRBXtaqanNrEUlZ0/uwYwM7UuxrHhxLi8bhkEbfR3g8Dyuei0b9W5BJYkneySGXv9yYvAfvb28Anj4S7x+ankQVSloFqvpm0TztnlnBe1hjYWRmbc7D2tDuW/NxP5rhap62btw122WxvjmiYRYyMlv6twy/jx52ggn15KtyIKxY0+/DO5rBes0Q8kRMtlshJYzB3lwO0EP4z65wcL5HU1iLVhPJ7zKxmHANnGxzRHgswSAXF2edo85yPCtCIPjCXMaXNLSRkg+i+oiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIg//Z",
+          "timing": 3835,
+          "timestamp": 5252920765
+        }
+      },
+      "mainthread-work-breakdown": {
+        "id": "mainthread-work-breakdown",
+        "title": "Minimize main-thread work",
+        "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to minimize main-thread work](https://developer.chrome.com/docs/lighthouse/performance/mainthread-work-breakdown/)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "3.5 s",
+        "metricSavings": {
+          "TBT": 900
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "group": "scriptEvaluation",
+              "groupLabel": "Script Evaluation",
+              "duration": 1802.605199999982
+            },
+            {
+              "group": "styleLayout",
+              "groupLabel": "Style & Layout",
+              "duration": 746.18759999999986
+            },
+            {
+              "group": "scriptParseCompile",
+              "groupLabel": "Script Parsing & Compilation",
+              "duration": 532.84919999999988
+            },
+            {
+              "group": "other",
+              "groupLabel": "Other",
+              "duration": 280.1507999999962
+            },
+            {
+              "groupLabel": "Parse HTML & CSS",
+              "group": "parseHTML",
+              "duration": 48.154799999999994
+            },
+            {
+              "duration": 32.1372,
+              "group": "paintCompositeRender",
+              "groupLabel": "Rendering"
+            },
+            {
+              "duration": 25.203599999999994,
+              "groupLabel": "Garbage Collection",
+              "group": "garbageCollection"
+            }
+          ],
+          "sortedBy": [
+            "duration"
+          ],
+          "headings": [
+            {
+              "label": "Category",
+              "valueType": "text",
+              "key": "groupLabel"
+            },
+            {
+              "granularity": 1,
+              "label": "Time Spent",
+              "valueType": "ms",
+              "key": "duration"
+            }
+          ]
+        },
+        "numericValue": 3467.2883999999772,
+        "numericUnit": "millisecond"
+      },
+      "viewport-insight": {
+        "id": "viewport-insight",
+        "title": "Optimize viewport for mobile",
+        "description": "Tap interactions may be [delayed by up to 300 ms](https://developer.chrome.com/docs/performance/insights/viewport) if the viewport is not optimized for mobile.",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "node": {
+                "snippet": "\u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\"\u003e",
+                "nodeLabel": "head \u003e meta",
+                "selector": "head \u003e meta",
+                "path": "0,HEAD,1,META",
+                "type": "node",
+                "lhId": "page-13-META",
+                "boundingRect": {
+                  "height": 0,
+                  "top": 0,
+                  "left": 0,
+                  "right": 0,
+                  "bottom": 0,
+                  "width": 0
+                }
+              }
+            }
+          ]
+        }
+      },
+      "script-treemap-data": {
+        "id": "script-treemap-data",
+        "title": "Script Treemap Data",
+        "description": "Used for treemap app",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "nodes": [
+            {
+              "resourceBytes": 50828,
+              "children": [
+                {
+                  "name": "(inline) window.dataLaye…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 298
+                },
+                {
+                  "name": "(inline) window.AGO = {\n…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 631
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 592,
+                  "name": "(inline) ((storageKey2, …"
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 520,
+                  "name": "(inline) window.__reactR…"
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 42302
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "resourceBytes": 53,
+                  "unusedBytes": 0
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 6432,
+                  "name": "(inline) ;\nimport * as r…"
+                }
+              ],
+              "encodedBytes": 9555,
+              "name": "https://www.ocobo.co/jobs"
+            },
+            {
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "encodedBytes": 4227,
+              "unusedBytes": 12049,
+              "resourceBytes": 17494
+            },
+            {
+              "encodedBytes": 579,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "unusedBytes": 0,
+              "resourceBytes": 2125
+            },
+            {
+              "encodedBytes": 156501,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "unusedBytes": 204200,
+              "resourceBytes": 471537
+            },
+            {
+              "resourceBytes": 9792,
+              "unusedBytes": 763,
+              "name": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "encodedBytes": 3961
+            },
+            {
+              "unusedBytes": 70417,
+              "resourceBytes": 125385,
+              "name": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "encodedBytes": 43336
+            },
+            {
+              "name": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "encodedBytes": 880,
+              "resourceBytes": 927,
+              "unusedBytes": 0
+            },
+            {
+              "name": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "encodedBytes": 1562,
+              "unusedBytes": 1084,
+              "resourceBytes": 3192
+            },
+            {
+              "encodedBytes": 929,
+              "name": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "resourceBytes": 983,
+              "unusedBytes": 89
+            },
+            {
+              "resourceBytes": 141,
+              "unusedBytes": 6,
+              "name": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "encodedBytes": 84
+            },
+            {
+              "resourceBytes": 1284,
+              "unusedBytes": 467,
+              "name": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "encodedBytes": 700
+            },
+            {
+              "unusedBytes": 1144,
+              "resourceBytes": 15426,
+              "encodedBytes": 6232,
+              "name": "https://www.ocobo.co/assets/cx-DiffRdtV.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "encodedBytes": 5626,
+              "unusedBytes": 1545,
+              "resourceBytes": 17234
+            },
+            {
+              "unusedBytes": 1266,
+              "resourceBytes": 3070,
+              "encodedBytes": 1271,
+              "name": "https://www.ocobo.co/assets/grid-DIis54sB.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "encodedBytes": 367,
+              "unusedBytes": 239,
+              "resourceBytes": 428
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 410,
+              "encodedBytes": 353,
+              "name": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "encodedBytes": 463,
+              "unusedBytes": 65,
+              "resourceBytes": 525
+            },
+            {
+              "unusedBytes": 362,
+              "resourceBytes": 942,
+              "name": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "encodedBytes": 895
+            },
+            {
+              "resourceBytes": 349,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "encodedBytes": 303
+            },
+            {
+              "name": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "encodedBytes": 779,
+              "unusedBytes": 0,
+              "resourceBytes": 1866
+            },
+            {
+              "encodedBytes": 287,
+              "name": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "unusedBytes": 0,
+              "resourceBytes": 348
+            },
+            {
+              "resourceBytes": 67398,
+              "unusedBytes": 32006,
+              "encodedBytes": 20674,
+              "name": "https://www.ocobo.co/assets/_main-9OzAywp_.js"
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 165,
+              "name": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "encodedBytes": 104
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 206,
+              "encodedBytes": 145,
+              "name": "https://www.ocobo.co/assets/lang-PH2TSE5M.js"
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 109016,
+              "name": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "encodedBytes": 33602
+            },
+            {
+              "encodedBytes": 543,
+              "name": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "unusedBytes": 0,
+              "resourceBytes": 605
+            },
+            {
+              "encodedBytes": 779,
+              "name": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "unusedBytes": 0,
+              "resourceBytes": 826
+            },
+            {
+              "resourceBytes": 404,
+              "unusedBytes": 0,
+              "encodedBytes": 358,
+              "name": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "encodedBytes": 443,
+              "unusedBytes": 0,
+              "resourceBytes": 490
+            },
+            {
+              "name": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "encodedBytes": 773,
+              "unusedBytes": 337,
+              "resourceBytes": 835
+            },
+            {
+              "name": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "encodedBytes": 25833,
+              "resourceBytes": 68826,
+              "unusedBytes": 47528
+            },
+            {
+              "unusedBytes": 30785,
+              "resourceBytes": 133936,
+              "encodedBytes": 44671,
+              "name": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "encodedBytes": 412,
+              "unusedBytes": 0,
+              "resourceBytes": 473
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 338,
+              "encodedBytes": 266,
+              "name": "https://www.ocobo.co/assets/x-B1I3g_bH.js"
+            },
+            {
+              "encodedBytes": 389,
+              "name": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "unusedBytes": 0,
+              "resourceBytes": 435
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 312,
+              "encodedBytes": 251,
+              "name": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js"
+            },
+            {
+              "encodedBytes": 263,
+              "name": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "resourceBytes": 309,
+              "unusedBytes": 194
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 16557,
+              "encodedBytes": 4665,
+              "name": "https://www.ocobo.co/assets/_main.(_lang).jobs._index-Djw8wGmL.js"
+            },
+            {
+              "encodedBytes": 552,
+              "name": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "unusedBytes": 4,
+              "resourceBytes": 1208
+            },
+            {
+              "unusedBytes": 65,
+              "resourceBytes": 495,
+              "name": "https://www.ocobo.co/assets/badge-i9dgPBIb.js",
+              "encodedBytes": 448
+            },
+            {
+              "encodedBytes": 655,
+              "name": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "unusedBytes": 65,
+              "resourceBytes": 717
+            },
+            {
+              "name": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "encodedBytes": 491,
+              "unusedBytes": 0,
+              "resourceBytes": 549
+            },
+            {
+              "name": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "encodedBytes": 547,
+              "unusedBytes": 65,
+              "resourceBytes": 605
+            },
+            {
+              "resourceBytes": 438,
+              "unusedBytes": 0,
+              "encodedBytes": 375,
+              "name": "https://www.ocobo.co/assets/map-pin-BFjzXly_.js"
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 656,
+              "encodedBytes": 607,
+              "name": "https://www.ocobo.co/assets/star-BI6vQnwF.js"
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 678,
+              "encodedBytes": 614,
+              "name": "https://www.ocobo.co/assets/sparkles-Cv6LQ7xb.js"
+            },
+            {
+              "encodedBytes": 435,
+              "name": "https://www.ocobo.co/assets/shield-check-CXoajV1s.js",
+              "unusedBytes": 0,
+              "resourceBytes": 499
+            },
+            {
+              "encodedBytes": 400,
+              "name": "https://www.ocobo.co/assets/zap-C3uzvT7-.js",
+              "resourceBytes": 446,
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 23529,
+              "name": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "unusedBytes": 28104,
+              "resourceBytes": 69550
+            },
+            {
+              "encodedBytes": 26498,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "unusedBytes": 35974,
+              "resourceBytes": 78059
+            },
+            {
+              "encodedBytes": 42586,
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "unusedBytes": 46367,
+              "resourceBytes": 108995
+            },
+            {
+              "unusedBytes": 57100,
+              "resourceBytes": 97992,
+              "encodedBytes": 27871,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            },
+            {
+              "unusedBytes": 36099,
+              "resourceBytes": 72608,
+              "encodedBytes": 25123,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+            },
+            {
+              "unusedBytes": 682,
+              "resourceBytes": 2495,
+              "encodedBytes": 1227,
+              "name": "https://www.ocobo.co/_vercel/insights/script.js"
+            },
+            {
+              "unusedBytes": 6501,
+              "resourceBytes": 12567,
+              "encodedBytes": 4673,
+              "name": "https://www.ocobo.co/_vercel/speed-insights/script.js"
+            },
+            {
+              "encodedBytes": 156501,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "unusedBytes": 335778,
+              "resourceBytes": 471537
+            },
+            {
+              "resourceBytes": 17494,
+              "encodedBytes": 4227,
+              "name": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "encodedBytes": 202942,
+              "resourceBytes": 587832,
+              "unusedBytes": 337253
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 2125,
+              "encodedBytes": 579,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js"
+            },
+            {
+              "resourceBytes": 97992,
+              "unusedBytes": 73621,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "encodedBytes": 27871
+            },
+            {
+              "unusedBytes": 36384,
+              "resourceBytes": 78059,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "encodedBytes": 26498
+            },
+            {
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+              "encodedBytes": 42586,
+              "resourceBytes": 108995,
+              "unusedBytes": 68120
+            },
+            {
+              "encodedBytes": 25123,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "unusedBytes": 49494,
+              "resourceBytes": 72608
+            },
+            {
+              "unusedBytes": 248156,
+              "resourceBytes": 587832,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "encodedBytes": 202942
+            }
+          ],
+          "type": "treemap-data"
+        }
+      },
+      "third-parties-insight": {
+        "id": "third-parties-insight",
+        "title": "3rd parties",
+        "description": "3rd party code can significantly impact load performance. [Reduce and defer loading of 3rd party code](https://developer.chrome.com/docs/performance/insights/third-parties) to prioritize your page's content.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "headings": [
+            {
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "label": "3rd party",
+              "valueType": "text",
+              "key": "entity"
+            },
+            {
+              "granularity": 1,
+              "label": "Transfer size",
+              "valueType": "bytes",
+              "key": "transferSize",
+              "subItemsHeading": {
+                "key": "transferSize"
+              }
+            },
+            {
+              "key": "mainThreadTime",
+              "label": "Main thread time",
+              "valueType": "ms",
+              "granularity": 1,
+              "subItemsHeading": {
+                "key": "mainThreadTime"
+              }
+            }
+          ],
+          "isEntityGrouped": true,
+          "items": [
+            {
+              "transferSize": 353057,
+              "mainThreadTime": 514.75999999046326,
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 206380,
+                    "mainThreadTime": 307.5899999961257,
+                    "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+                  },
+                  {
+                    "transferSize": 28213,
+                    "mainThreadTime": 77.389000000432134,
+                    "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                  },
+                  {
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+                    "transferSize": 43646,
+                    "mainThreadTime": 54.850999995134771
+                  },
+                  {
+                    "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+                    "transferSize": 29958,
+                    "mainThreadTime": 42.780000002123415
+                  },
+                  {
+                    "transferSize": 27219,
+                    "mainThreadTime": 25.836999994702637,
+                    "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+                  },
+                  {
+                    "transferSize": 2503,
+                    "mainThreadTime": 5.4850000003352761,
+                    "url": "https://js-eu1.hs-scripts.com/27107933.js"
+                  },
+                  {
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+                    "transferSize": 1095,
+                    "mainThreadTime": 0.29800000227987766
+                  },
+                  {
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953&hutk=18dd8404db3b1e624593e3cc9c48926f",
+                    "transferSize": 4082,
+                    "mainThreadTime": 0.27200000081211329
+                  },
+                  {
+                    "transferSize": 1095,
+                    "mainThreadTime": 0.25799999851733446,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=18dd8404db3b1e624593e3cc9c48926f"
+                  },
+                  {
+                    "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fjobs&utk=18dd8404db3b1e624593e3cc9c48926f&__hstc=242475741.18dd8404db3b1e624593e3cc9c48926f.1778779388179.1778779388179.1778779388179.1&__hssc=242475741.1.1778779388179&isMobile=true",
+                    "transferSize": 1712,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1474,
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fjobs&t=Ocobo+%C2%B7+Nous+rejoindre+%E2%80%94+Ocobo&cts=1778779388182&vi=18dd8404db3b1e624593e3cc9c48926f&nc=true&ce=false&cc=0"
+                  },
+                  {
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fjobs&t=Ocobo+%C2%B7+Nous+rejoindre+%E2%80%94+Ocobo&cts=1778779389727&vi=18dd8404db3b1e624593e3cc9c48926f&nc=true&u=242475741.18dd8404db3b1e624593e3cc9c48926f.1778779388179.1778779388179.1778779388179.1&b=242475741.1.1778779388179&cc=15",
+                    "transferSize": 1028,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=3a0a55e6-3178-435d-8fff-89bf75c6934f&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fjobs&t=Ocobo+%C2%B7+Nous+rejoindre+%E2%80%94+Ocobo&cts=1778779390316&vi=18dd8404db3b1e624593e3cc9c48926f&nc=true&u=242475741.18dd8404db3b1e624593e3cc9c48926f.1778779388179.1778779388179.1778779388179.1&b=242475741.1.1778779388179&cc=15",
+                    "transferSize": 1026,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1024,
+                    "mainThreadTime": 0,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1"
+                  },
+                  {
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+                    "transferSize": 1024,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+                    "transferSize": 1020,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+                    "transferSize": 558,
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "entity": "Hubspot"
+            },
+            {
+              "entity": "Google Tag Manager",
+              "subItems": {
+                "items": [
+                  {
+                    "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+                    "mainThreadTime": 301.91699999943376,
+                    "transferSize": 157188
+                  }
+                ],
+                "type": "subitems"
+              },
+              "transferSize": 157188,
+              "mainThreadTime": 301.91699999943376
+            },
+            {
+              "entity": "GitHub",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "transferSize": 5018,
+                    "mainThreadTime": 6.8550000004470348,
+                    "url": "https://useago.github.io/widgetjs/frame.js"
+                  },
+                  {
+                    "url": "https://useago.github.io/widgetjs/frame.css",
+                    "transferSize": 2019,
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "transferSize": 7037,
+              "mainThreadTime": 6.8550000004470348
+            },
+            {
+              "transferSize": 1280,
+              "mainThreadTime": 0,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+                    "transferSize": 1280,
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "entity": "Clearbit"
+            },
+            {
+              "transferSize": 796,
+              "mainThreadTime": 0,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65d0h2v9100339653za200zd9100339653&_p=1778779387512&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1806729512.1778779388&frm=0&pscdl=noapi&rcb=0&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616986~115938466~115938468&dp=%2Fjobs&sid=1778779387&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fjobs&dt=Ocobo%20%C2%B7%20Nous%20rejoindre%20%E2%80%94%20Ocobo&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1509",
+                    "transferSize": 796,
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "entity": "Google Analytics"
+            },
+            {
+              "transferSize": 103931,
+              "mainThreadTime": 0,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                    "transferSize": 102672,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                    "transferSize": 1259,
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "entity": "Google Fonts"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "unused-css-rules": {
+        "id": "unused-css-rules",
+        "title": "Reduce unused CSS",
+        "description": "Reduce unused rules from stylesheets and defer CSS not used for above-the-fold content to decrease bytes consumed by network activity. [Learn how to reduce unused CSS](https://developer.chrome.com/docs/lighthouse/performance/unused-css-rules/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 0,
+          "items": [],
+          "headings": [],
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "overallSavingsBytes": 0,
+          "type": "opportunity",
+          "sortedBy": [
+            "wastedBytes"
+          ]
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "forced-reflow-insight": {
+        "id": "forced-reflow-insight",
+        "title": "Forced reflow",
+        "description": "A forced reflow occurs when JavaScript queries geometric properties (such as offsetWidth) after styles have been invalidated by a change to the DOM state. This can result in poor performance. Learn more about [forced reflows](https://developer.chrome.com/docs/performance/insights/forced-reflow) and possible mitigations.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "details": {
+          "items": [
+            {
+              "headings": [
+                {
+                  "label": "Source",
+                  "valueType": "source-location",
+                  "key": "source"
+                },
+                {
+                  "label": "Total reflow time",
+                  "valueType": "ms",
+                  "key": "reflowTime",
+                  "granularity": 1
+                }
+              ],
+              "items": [
+                {
+                  "reflowTime": 42.37,
+                  "source": {
+                    "value": "[unattributed]",
+                    "type": "text"
+                  }
+                },
+                {
+                  "reflowTime": 1.434,
+                  "source": {
+                    "line": 19,
+                    "type": "source-location",
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+                    "column": 85503,
+                    "urlProvider": "network"
+                  }
+                },
+                {
+                  "source": {
+                    "line": 19,
+                    "type": "source-location",
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js",
+                    "urlProvider": "network",
+                    "column": 85503
+                  },
+                  "reflowTime": 0.761
+                }
+              ],
+              "type": "table"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "unminified-css": {
+        "id": "unminified-css",
+        "title": "Minify CSS",
+        "description": "Minifying CSS files can reduce network payload sizes. [Learn how to minify CSS](https://developer.chrome.com/docs/lighthouse/performance/unminified-css/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "opportunity",
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            }
+          },
+          "overallSavingsBytes": 0,
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsMs": 0,
+          "items": [],
+          "headings": []
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "image-delivery-insight": {
+        "id": "image-delivery-insight",
+        "title": "Improve image delivery",
+        "description": "Reducing the download time of images can improve the perceived load time of the page and LCP. [Learn more about optimizing image size](https://developer.chrome.com/docs/performance/insights/image-delivery)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 693 KiB",
+        "metricSavings": {
+          "LCP": 750,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 709470,
+            "type": "debugdata"
+          },
+          "type": "table",
+          "items": [
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 115421,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 216682,
+                    "reason": "This image file is larger than it needs to be (902x900) for its displayed dimensions (354x312). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "node": {
+                "boundingRect": {
+                  "bottom": 1322,
+                  "right": 194,
+                  "width": 178,
+                  "top": 1144,
+                  "height": 178,
+                  "left": 16
+                },
+                "lhId": "page-0-IMG",
+                "type": "node",
+                "selector": "div.d_grid \u003e div.d_flex \u003e div.group \u003e img.w_full",
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,1,DIV,0,DIV,0,DIV,1,DIV,0,IMG",
+                "nodeLabel": "L'équipe Ocobo en séminaire",
+                "snippet": "\u003cimg src=\"/images/jobs/seminaire.jpeg\" alt=\"L'équipe Ocobo en séminaire\" width=\"1024\" height=\"900\" loading=\"eager\" decoding=\"async\" fetchpriority=\"high\" class=\"w_full asp_1 obj-f_cover bdr_3xl filter_grayscale(100%) trs_all_500ms grou…\"\u003e"
+              },
+              "url": "https://www.ocobo.co/images/jobs/seminaire.jpeg",
+              "totalBytes": 250772,
+              "wastedBytes": 232373
+            },
+            {
+              "wastedBytes": 119614,
+              "totalBytes": 124507,
+              "url": "https://www.ocobo.co/images/jobs/bureau-1.jpeg",
+              "node": {
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,4,SECTION,0,DIV,1,DIV,0,DIV,0,IMG",
+                "selector": "div.mx_auto \u003e div.d_grid \u003e div.group \u003e img.w_full",
+                "nodeLabel": "Bureaux Ocobo — espace de travail",
+                "snippet": "\u003cimg src=\"/images/jobs/bureau-1.jpeg\" alt=\"Bureaux Ocobo — espace de travail\" class=\"w_full asp_4/3 obj-f_cover bdr_2xl filter_grayscale(100%) trs_all_500ms gr…\"\u003e",
+                "boundingRect": {
+                  "top": 7200,
+                  "height": 87,
+                  "left": 16,
+                  "right": 132,
+                  "bottom": 7287,
+                  "width": 116
+                },
+                "type": "node",
+                "lhId": "page-1-IMG"
+              },
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 119614,
+                    "reason": "This image file is larger than it needs to be (1024x768) for its displayed dimensions (203x152). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 110903,
+                    "reason": "This image file is larger than it needs to be (1024x768) for its displayed dimensions (203x152). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "node": {
+                "type": "node",
+                "lhId": "page-2-IMG",
+                "boundingRect": {
+                  "top": 7200,
+                  "height": 87,
+                  "left": 280,
+                  "bottom": 7287,
+                  "right": 396,
+                  "width": 116
+                },
+                "snippet": "\u003cimg src=\"/images/jobs/bureau-3.jpeg\" alt=\"Bureaux Ocobo — espace commun\" class=\"w_full asp_4/3 obj-f_cover bdr_2xl filter_grayscale(100%) trs_all_500ms gr…\"\u003e",
+                "nodeLabel": "Bureaux Ocobo — espace commun",
+                "selector": "div.mx_auto \u003e div.d_grid \u003e div.group \u003e img.w_full",
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,4,SECTION,0,DIV,1,DIV,2,DIV,0,IMG"
+              },
+              "wastedBytes": 110903,
+              "url": "https://www.ocobo.co/images/jobs/bureau-3.jpeg",
+              "totalBytes": 115440
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 60288,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 90783,
+                    "reason": "This image file is larger than it needs to be (669x667) for its displayed dimensions (467x312). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "node": {
+                "boundingRect": {
+                  "top": 894,
+                  "height": 178,
+                  "left": 218,
+                  "right": 396,
+                  "bottom": 1072,
+                  "width": 178
+                },
+                "type": "node",
+                "lhId": "page-3-IMG",
+                "selector": "div.d_grid \u003e div.d_flex \u003e div.group \u003e img.w_full",
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,1,DIV,0,DIV,1,DIV,0,DIV,0,IMG",
+                "nodeLabel": "Les bureaux Ocobo",
+                "snippet": "\u003cimg src=\"/images/jobs/cafet.jpeg\" alt=\"Les bureaux Ocobo\" width=\"1000\" height=\"667\" loading=\"eager\" decoding=\"async\" class=\"w_full asp_1 obj-f_cover bdr_3xl filter_grayscale(100%) trs_all_500ms grou…\"\u003e"
+              },
+              "url": "https://www.ocobo.co/images/jobs/cafet.jpeg",
+              "totalBytes": 134678,
+              "wastedBytes": 110433
+            },
+            {
+              "totalBytes": 114922,
+              "url": "https://www.ocobo.co/images/jobs/bureau-2.jpeg",
+              "wastedBytes": 110406,
+              "node": {
+                "boundingRect": {
+                  "height": 87,
+                  "top": 7200,
+                  "left": 148,
+                  "right": 264,
+                  "bottom": 7287,
+                  "width": 116
+                },
+                "type": "node",
+                "lhId": "page-4-IMG",
+                "selector": "div.mx_auto \u003e div.d_grid \u003e div.group \u003e img.w_full",
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,4,SECTION,0,DIV,1,DIV,1,DIV,0,IMG",
+                "nodeLabel": "Bureaux Ocobo — salle de réunion",
+                "snippet": "\u003cimg src=\"/images/jobs/bureau-2.jpeg\" alt=\"Bureaux Ocobo — salle de réunion\" class=\"w_full asp_4/3 obj-f_cover bdr_2xl filter_grayscale(100%) trs_all_500ms gr…\"\u003e"
+              },
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 110406,
+                    "reason": "This image file is larger than it needs to be (1024x768) for its displayed dimensions (203x152). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "wastedBytes": 16208,
+              "totalBytes": 16667,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "node": {
+                "boundingRect": {
+                  "top": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "bottom": 0,
+                  "width": 0
+                },
+                "lhId": "page-5-IMG",
+                "type": "node",
+                "selector": "body \u003e div#ago-wrapper \u003e button#ago-chat-button \u003e img#open-path",
+                "path": "1,BODY,59,DIV,1,BUTTON,0,IMG",
+                "nodeLabel": "Chat",
+                "snippet": "\u003cimg src=\"https://www.ocobo.co/android-chrome-192x192.png\" alt=\"Chat\" id=\"open-path\" style=\"width: 32px; height: 32px; object-fit: contain;\"\u003e"
+              },
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 10523,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 15421,
+                    "reason": "This image file is larger than it needs to be (192x192) for its displayed dimensions (53x53). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "wastedBytes": 9533,
+              "totalBytes": 12266,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "node": {
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "path": "2,HTML,1,BODY,0,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "nodeLabel": "Ocobo",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "boundingRect": {
+                  "left": 33,
+                  "top": 37,
+                  "height": 40,
+                  "width": 134,
+                  "right": 167,
+                  "bottom": 77
+                },
+                "type": "node",
+                "lhId": "page-6-IMG"
+              },
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 6234,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 6709,
+                    "reason": "This image file is larger than it needs to be (348x104) for its displayed dimensions (234x70). Use responsive images to reduce the image download size."
+                  }
+                ]
+              }
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "subItemsHeading": {
+                "key": "reason",
+                "valueType": "text"
+              },
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Resource Size",
+              "valueType": "bytes",
+              "key": "totalBytes"
+            },
+            {
+              "key": "wastedBytes",
+              "subItemsHeading": {
+                "valueType": "bytes",
+                "key": "wastedBytes"
+              },
+              "label": "Est Savings",
+              "valueType": "bytes"
+            }
+          ]
+        }
+      },
+      "interactive": {
+        "id": "interactive",
+        "title": "Time to Interactive",
+        "description": "Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).",
+        "score": 0.2,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "11.1 s",
+        "numericValue": 11066.677972173418,
+        "numericUnit": "millisecond"
+      },
+      "document-latency-insight": {
+        "id": "document-latency-insight",
+        "title": "Document request latency",
+        "description": "Your first network request is the most important. [Reduce its latency](https://developer.chrome.com/docs/performance/insights/document-latency) by avoiding redirects, ensuring a fast server response, and enabling text compression.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "redirectDuration": 0,
+            "wastedBytes": 0,
+            "type": "debugdata",
+            "serverResponseTime": 39,
+            "uncompressedResponseBytes": 0
+          },
+          "type": "checklist",
+          "items": {
+            "usesCompression": {
+              "value": true,
+              "label": "Applies text compression"
+            },
+            "serverResponseIsFast": {
+              "value": true,
+              "label": "Server responds quickly (observed 39 ms)"
+            },
+            "noRedirects": {
+              "value": true,
+              "label": "Avoids redirects"
+            }
+          }
+        }
+      },
+      "network-rtt": {
+        "id": "network-rtt",
+        "title": "Network Round Trip Times",
+        "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "items": [
+            {
+              "origin": "https://tag.clearbitscripts.com",
+              "rtt": 8.5345199999999988
+            },
+            {
+              "rtt": 5.010975,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "rtt": 4.85082,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "origin": "https://cta-eu1.hubspot.com",
+              "rtt": 1.4892674999999997
+            },
+            {
+              "origin": "https://js-eu1.hs-scripts.com",
+              "rtt": 1.42155
+            },
+            {
+              "origin": "https://forms-eu1.hsforms.com",
+              "rtt": 1.2244349999999991
+            },
+            {
+              "origin": "https://useago.github.io",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "origin": "https://www.google-analytics.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "origin": "https://js-eu1.hs-banner.com",
+              "rtt": 0.0029190087476284156
+            },
+            {
+              "origin": "https://js-eu1.hubspot.com",
+              "rtt": 0.0028214085652182078
+            },
+            {
+              "origin": "https://js-eu1.hscollectedforms.net",
+              "rtt": 0.00276436120787486
+            },
+            {
+              "origin": "https://www.ocobo.co",
+              "rtt": 0.0021933935690544842
+            },
+            {
+              "origin": "https://fonts.gstatic.com",
+              "rtt": 0.0016301438258429992
+            },
+            {
+              "rtt": 0.0011288717797776127,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "rtt": 0.0011206525160619072,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "origin": "https://js-eu1.hsforms.net",
+              "rtt": 0.0010166912804124224
+            }
+          ],
+          "type": "table",
+          "sortedBy": [
+            "rtt"
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "text",
+              "key": "origin"
+            },
+            {
+              "granularity": 1,
+              "key": "rtt",
+              "label": "Time Spent",
+              "valueType": "ms"
+            }
+          ]
+        },
+        "numericValue": 8.5345199999999988,
+        "numericUnit": "millisecond"
+      },
+      "inp-breakdown-insight": {
+        "id": "inp-breakdown-insight",
+        "title": "INP breakdown",
+        "description": "Start investigating [how to improve INP](https://developer.chrome.com/docs/performance/insights/inp-breakdown) by looking at the longest subpart.",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "font-display-insight": {
+        "id": "font-display-insight",
+        "title": "Font display",
+        "description": "Consider setting [font-display](https://developer.chrome.com/docs/performance/insights/font-display) to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with [font metric overrides](https://developer.chrome.com/blog/font-fallbacks).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "key": "wastedMs",
+              "label": "Est Savings",
+              "valueType": "ms"
+            }
+          ],
+          "skipSumming": [
+            "wastedMs"
+          ],
+          "type": "table",
+          "items": []
+        }
+      },
+      "metrics": {
+        "id": "metrics",
+        "title": "Metrics",
+        "description": "Collects all available metrics.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "observedFirstContentfulPaintTs": 5250293743,
+              "observedTimeOriginTs": 5249085524,
+              "observedFirstVisualChange": 375,
+              "maxPotentialFID": 194,
+              "observedDomContentLoaded": 1288,
+              "observedLargestContentfulPaintTs": 5251799548,
+              "largestContentfulPaint": 8251,
+              "firstContentfulPaint": 3001,
+              "observedSpeedIndex": 1224,
+              "observedLargestContentfulPaintAllFrames": 2714,
+              "observedLoadTs": 5250786038,
+              "interactive": 11067,
+              "cumulativeLayoutShift": 0.002049,
+              "observedFirstContentfulPaintAllFramesTs": 5250293743,
+              "observedTraceEnd": 6174,
+              "observedFirstPaint": 1208,
+              "observedFirstContentfulPaint": 1208,
+              "cumulativeLayoutShiftMainFrame": 0.002049,
+              "observedNavigationStartTs": 5249085524,
+              "observedCumulativeLayoutShift": 0.002049,
+              "totalBlockingTime": 892,
+              "speedIndex": 4072,
+              "observedDomContentLoadedTs": 5250373373,
+              "observedFirstVisualChangeTs": 5249460524,
+              "observedLargestContentfulPaintAllFramesTs": 5251799548,
+              "observedTimeOrigin": 0,
+              "timeToFirstByte": 601,
+              "observedLoad": 1701,
+              "observedLastVisualChangeTs": 5250343524,
+              "observedFirstPaintTs": 5250293743,
+              "observedCumulativeLayoutShiftMainFrame": 0.002049,
+              "observedTraceEndTs": 5255259701,
+              "observedLargestContentfulPaint": 2714,
+              "observedNavigationStart": 0,
+              "observedSpeedIndexTs": 5250309922,
+              "observedLastVisualChange": 1258,
+              "observedFirstContentfulPaintAllFrames": 1208
+            },
+            {
+              "lcpInvalidated": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 11067,
+        "numericUnit": "millisecond"
+      },
+      "max-potential-fid": {
+        "id": "max-potential-fid",
+        "title": "Max Potential First Input Delay",
+        "description": "The maximum potential First Input Delay that your users could experience is the duration of the longest task. [Learn more about the Maximum Potential First Input Delay metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-max-potential-fid/).",
+        "score": 0.69,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "190 ms",
+        "numericValue": 194,
+        "numericUnit": "millisecond"
+      },
+      "redirects": {
+        "id": "redirects",
+        "title": "Avoid multiple page redirects",
+        "description": "Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://developer.chrome.com/docs/lighthouse/performance/redirects/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "overallSavingsMs": 0,
+          "type": "opportunity",
+          "headings": []
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "bootup-time": {
+        "id": "bootup-time",
+        "title": "Reduce JavaScript execution time",
+        "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to reduce Javascript execution time](https://developer.chrome.com/docs/lighthouse/performance/bootup-time/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "2.2 s",
+        "metricSavings": {
+          "TBT": 800
+        },
+        "details": {
+          "type": "table",
+          "sortedBy": [
+            "total"
+          ],
+          "summary": {
+            "wastedMs": 2198.5139999999983
+          },
+          "items": [
+            {
+              "scripting": 613.68839999999966,
+              "scriptParseCompile": 30.0684,
+              "total": 1133.5595999999996,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778778600000/27107933.js"
+            },
+            {
+              "scripting": 545.55599999999856,
+              "scriptParseCompile": 17.886,
+              "total": 580.60439999999846,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "scriptParseCompile": 185.988,
+              "total": 458.0316000000002,
+              "scripting": 218.51520000000019
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "total": 365.61599999999981,
+              "scriptParseCompile": 166.07519999999997,
+              "scripting": 195.59399999999985
+            },
+            {
+              "scripting": 5.2883999999999984,
+              "scriptParseCompile": 5.3148,
+              "total": 290.38319999999993,
+              "url": "https://www.ocobo.co/jobs"
+            },
+            {
+              "url": "Unattributable",
+              "scripting": 37.2696,
+              "scriptParseCompile": 0,
+              "total": 271.87919999999713
+            },
+            {
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "total": 122.61600000000001,
+              "scriptParseCompile": 32.016000000000005,
+              "scripting": 82.618800000000022
+            },
+            {
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "scripting": 42.2772,
+              "total": 64.345199999999991,
+              "scriptParseCompile": 20.357999999999993
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "granularity": 1,
+              "label": "Total CPU Time",
+              "valueType": "ms",
+              "key": "total"
+            },
+            {
+              "granularity": 1,
+              "label": "Script Evaluation",
+              "valueType": "ms",
+              "key": "scripting"
+            },
+            {
+              "granularity": 1,
+              "key": "scriptParseCompile",
+              "label": "Script Parse",
+              "valueType": "ms"
+            }
+          ]
+        },
+        "numericValue": 2198.5139999999983,
+        "numericUnit": "millisecond"
+      },
+      "network-server-latency": {
+        "id": "network-server-latency",
+        "title": "Server Backend Latencies",
+        "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "headings": [
+            {
+              "key": "origin",
+              "label": "URL",
+              "valueType": "text"
+            },
+            {
+              "valueType": "ms",
+              "key": "serverResponseTime",
+              "label": "Time Spent",
+              "granularity": 1
+            }
+          ],
+          "sortedBy": [
+            "serverResponseTime"
+          ],
+          "type": "table",
+          "items": [
+            {
+              "serverResponseTime": 8,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "serverResponseTime": 3,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "serverResponseTime": 3,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "origin": "https://cta-eu1.hubspot.com",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "origin": "https://useago.github.io",
+              "serverResponseTime": 0.5
+            },
+            {
+              "serverResponseTime": 0.5,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://track-eu1.hubspot.com"
+            }
+          ]
+        },
+        "numericValue": 8,
+        "numericUnit": "millisecond"
+      },
+      "lcp-discovery-insight": {
+        "id": "lcp-discovery-insight",
+        "title": "LCP request discovery",
+        "description": "[Optimize LCP](https://developer.chrome.com/docs/performance/insights/lcp-discovery) by making the LCP image discoverable from the HTML immediately, and avoiding lazy-loading",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "unsized-images": {
+        "id": "unsized-images",
+        "title": "Image elements do not have explicit `width` and `height`",
+        "description": "Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            }
+          ],
+          "items": [
+            {
+              "node": {
+                "type": "node",
+                "lhId": "1-0-IMG",
+                "boundingRect": {
+                  "bottom": 77,
+                  "right": 167,
+                  "width": 134,
+                  "top": 37,
+                  "height": 40,
+                  "left": 33
+                },
+                "nodeLabel": "Ocobo",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "path": "2,HTML,1,BODY,0,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG"
+              },
+              "url": "https://www.ocobo.co/logo-ocobo.png"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "resource-summary": {
+        "id": "resource-summary",
+        "title": "Resources Summary",
+        "description": "Aggregates all network requests and groups them by type",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "requestCount": 91,
+              "label": "Total",
+              "resourceType": "total",
+              "transferSize": 1955192
+            },
+            {
+              "label": "Image",
+              "resourceType": "image",
+              "requestCount": 15,
+              "transferSize": 913888
+            },
+            {
+              "requestCount": 59,
+              "label": "Script",
+              "resourceType": "script",
+              "transferSize": 765566
+            },
+            {
+              "transferSize": 212553,
+              "label": "Font",
+              "resourceType": "font",
+              "requestCount": 5
+            },
+            {
+              "transferSize": 27848,
+              "requestCount": 3,
+              "label": "Stylesheet",
+              "resourceType": "stylesheet"
+            },
+            {
+              "label": "Document",
+              "resourceType": "document",
+              "requestCount": 1,
+              "transferSize": 23030
+            },
+            {
+              "transferSize": 12307,
+              "requestCount": 8,
+              "label": "Other",
+              "resourceType": "other"
+            },
+            {
+              "transferSize": 0,
+              "requestCount": 0,
+              "label": "Media",
+              "resourceType": "media"
+            },
+            {
+              "transferSize": 623289,
+              "requestCount": 28,
+              "label": "Third-party",
+              "resourceType": "third-party"
+            }
+          ],
+          "headings": [
+            {
+              "label": "Resource Type",
+              "valueType": "text",
+              "key": "label"
+            },
+            {
+              "key": "requestCount",
+              "label": "Requests",
+              "valueType": "numeric"
+            },
+            {
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "key": "transferSize"
+            }
+          ]
+        }
+      },
+      "non-composited-animations": {
+        "id": "non-composited-animations",
+        "title": "Avoid non-composited animations",
+        "description": "Animations which are not composited can be janky and increase CLS. [Learn how to avoid non-composited animations](https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/)",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "type": "table",
+          "items": [],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node",
+              "label": "Element",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "failureReason"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "categories": {
+      "performance": {
+        "id": "performance",
+        "title": "Performance",
+        "score": 0.48,
+        "auditRefs": [
+          {
+            "id": "first-contentful-paint",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "FCP"
+          },
+          {
+            "id": "largest-contentful-paint",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "LCP"
+          },
+          {
+            "id": "total-blocking-time",
+            "weight": 30,
+            "group": "metrics",
+            "acronym": "TBT"
+          },
+          {
+            "id": "cumulative-layout-shift",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "CLS"
+          },
+          {
+            "id": "speed-index",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "SI"
+          },
+          {
+            "id": "cache-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "cls-culprits-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "document-latency-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "dom-size-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "duplicated-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "font-display-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "forced-reflow-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "image-delivery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "inp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-discovery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "legacy-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "network-dependency-tree-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "render-blocking-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "third-parties-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "viewport-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "interactive",
+            "weight": 0,
+            "group": "hidden",
+            "acronym": "TTI"
+          },
+          {
+            "id": "max-potential-fid",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "unminified-css",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unminified-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-css-rules",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "total-byte-weight",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "user-timings",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "bootup-time",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "mainthread-work-breakdown",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "long-tasks",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "non-composited-animations",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unsized-images",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "network-requests",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-rtt",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-server-latency",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "main-thread-tasks",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "diagnostics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "metrics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "screenshot-thumbnails",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "final-screenshot",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "script-treemap-data",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "resource-summary",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "redirects",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "server-response-time",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "layout-shifts",
+            "weight": 0,
+            "group": "hidden"
+          }
+        ]
+      }
+    },
+    "categoryGroups": {
+      "best-practices-general": {
+        "title": "General"
+      },
+      "seo-mobile": {
+        "title": "Mobile Friendly",
+        "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn how to make pages mobile-friendly](https://developers.google.com/search/mobile-sites/)."
+      },
+      "a11y-audio-video": {
+        "title": "Audio and video",
+        "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+      },
+      "a11y-aria": {
+        "title": "ARIA",
+        "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "seo-content": {
+        "title": "Content Best Practices",
+        "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+      },
+      "a11y-names-labels": {
+        "title": "Names and labels",
+        "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "metrics": {
+        "title": "Metrics"
+      },
+      "best-practices-ux": {
+        "title": "User Experience"
+      },
+      "a11y-tables-lists": {
+        "title": "Tables and lists",
+        "description": "These are opportunities to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+      },
+      "insights": {
+        "title": "Insights",
+        "description": "These insights are also available in the Chrome DevTools Performance Panel - [record a trace](https://developer.chrome.com/docs/devtools/performance/reference) to view more detailed information."
+      },
+      "best-practices-browser-compat": {
+        "title": "Browser Compatibility"
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "description": "More information about the performance of your application. These numbers don't [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score."
+      },
+      "a11y-language": {
+        "title": "Internationalization and localization",
+        "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      },
+      "a11y-best-practices": {
+        "title": "Best practices",
+        "description": "These items highlight common accessibility best practices."
+      },
+      "a11y-color-contrast": {
+        "title": "Contrast",
+        "description": "These are opportunities to improve the legibility of your content."
+      },
+      "seo-crawl": {
+        "title": "Crawling and Indexing",
+        "description": "To appear in search results, crawlers need access to your app."
+      },
+      "best-practices-trust-safety": {
+        "title": "Trust and Safety"
+      },
+      "a11y-navigation": {
+        "title": "Navigation",
+        "description": "These are opportunities to improve keyboard navigation in your application."
+      }
+    },
+    "timing": {
+      "total": 20524.3
+    },
+    "i18n": {
+      "rendererFormattedStrings": {
+        "varianceDisclaimer": "Values are estimated and may vary. The [performance score is calculated](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) directly from these metrics.",
+        "opportunityResourceColumnLabel": "Opportunity",
+        "opportunitySavingsColumnLabel": "Estimated Savings",
+        "errorMissingAuditInfo": "Report error: no audit information",
+        "errorLabel": "Error!",
+        "warningHeader": "Warnings: ",
+        "passedAuditsGroupTitle": "Passed audits",
+        "notApplicableAuditsGroupTitle": "Not applicable",
+        "manualAuditsGroupTitle": "Additional items to manually check",
+        "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+        "crcLongestDurationLabel": "Maximum critical path latency:",
+        "crcInitialNavigation": "Initial Navigation",
+        "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+        "labDataTitle": "Lab Data",
+        "warningAuditsGroupTitle": "Passed audits but with warnings",
+        "snippetExpandButtonLabel": "Expand snippet",
+        "snippetCollapseButtonLabel": "Collapse snippet",
+        "thirdPartyResourcesLabel": "Show 3rd-party resources",
+        "runtimeDesktopEmulation": "Emulated Desktop",
+        "runtimeMobileEmulation": "Emulated Moto G Power",
+        "runtimeNoEmulation": "No emulation",
+        "runtimeSettingsBenchmark": "Unthrottled CPU/Memory Power",
+        "runtimeSettingsCPUThrottling": "CPU throttling",
+        "runtimeSettingsDevice": "Device",
+        "runtimeSettingsNetworkThrottling": "Network throttling",
+        "runtimeSettingsUANetwork": "User agent (network)",
+        "runtimeUnknown": "Unknown",
+        "dropdownCopyJSON": "Copy JSON",
+        "dropdownDarkTheme": "Toggle Dark Theme",
+        "dropdownPrintExpanded": "Print Expanded",
+        "dropdownPrintSummary": "Print Summary",
+        "dropdownSaveGist": "Save as Gist",
+        "dropdownSaveHTML": "Save as HTML",
+        "dropdownSaveJSON": "Save as JSON",
+        "dropdownViewer": "Open in Viewer",
+        "footerIssue": "File an issue",
+        "throttlingProvided": "Provided by environment",
+        "calculatorLink": "See calculator.",
+        "runtimeSettingsAxeVersion": "Axe version",
+        "viewTreemapLabel": "View Treemap",
+        "showRelevantAudits": "Show audits relevant to:"
+      }
+    },
+    "entities": [
+      {
+        "name": "ocobo.co",
+        "isFirstParty": true,
+        "isUnrecognized": true,
+        "origins": [
+          "https://www.ocobo.co"
+        ]
+      },
+      {
+        "name": "Google Tag Manager",
+        "homepage": "https://marketingplatform.google.com/about/tag-manager/",
+        "category": "tag-manager",
+        "origins": [
+          "https://www.googletagmanager.com"
+        ]
+      },
+      {
+        "name": "Clearbit",
+        "homepage": "https://clearbit.com/",
+        "category": "analytics",
+        "origins": [
+          "https://tag.clearbitscripts.com"
+        ]
+      },
+      {
+        "name": "Hubspot",
+        "homepage": "https://hubspot.com/",
+        "category": "marketing",
+        "origins": [
+          "https://js-eu1.hs-scripts.com",
+          "https://js-eu1.hubspot.com",
+          "https://js-eu1.hscollectedforms.net",
+          "https://js-eu1.hs-analytics.net",
+          "https://js-eu1.hs-banner.com",
+          "https://forms-eu1.hscollectedforms.net",
+          "https://track-eu1.hubspot.com",
+          "https://cta-eu1.hubspot.com",
+          "https://perf-eu1.hsforms.com",
+          "https://js-eu1.hsforms.net",
+          "https://forms-eu1.hsforms.com"
+        ]
+      },
+      {
+        "name": "GitHub",
+        "category": "utility",
+        "origins": [
+          "https://useago.github.io"
+        ]
+      },
+      {
+        "name": "Google Analytics",
+        "homepage": "https://marketingplatform.google.com/about/analytics/",
+        "category": "analytics",
+        "origins": [
+          "https://www.google-analytics.com"
+        ]
+      },
+      {
+        "name": "Google Fonts",
+        "homepage": "https://fonts.google.com/",
+        "category": "cdn",
+        "origins": [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com"
+        ]
+      }
+    ],
+    "fullPageScreenshot": {
+      "nodes": {
+        "1-1-IMG": {
+          "left": 0,
+          "top": 0,
+          "height": 0,
+          "width": 0,
+          "bottom": 0,
+          "right": 0
+        },
+        "1-4-IMG": {
+          "top": 7200,
+          "height": 87,
+          "left": 16,
+          "right": 132,
+          "bottom": 7287,
+          "width": 116
+        },
+        "page-3-IMG": {
+          "left": 218,
+          "height": 178,
+          "top": 894,
+          "width": 178,
+          "right": 396,
+          "bottom": 1072
+        },
+        "page-5-IMG": {
+          "left": 0,
+          "id": "open-path",
+          "top": 0,
+          "height": 0,
+          "width": 0,
+          "right": 0,
+          "bottom": 0
+        },
+        "page-2-IMG": {
+          "left": 280,
+          "top": 7200,
+          "height": 87,
+          "width": 116,
+          "bottom": 7287,
+          "right": 396
+        },
+        "page-7-H1": {
+          "height": 91,
+          "top": 292,
+          "left": 16,
+          "bottom": 383,
+          "right": 396,
+          "width": 380
+        },
+        "page-15-path": {
+          "right": 0,
+          "bottom": 0,
+          "width": 0,
+          "height": 0,
+          "top": 0,
+          "left": 0
+        },
+        "page-10-IMG": {
+          "bottom": 0,
+          "right": 0,
+          "width": 0,
+          "top": 0,
+          "height": 0,
+          "left": 0
+        },
+        "page-19-IMG": {
+          "width": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0,
+          "height": 0,
+          "top": 0
+        },
+        "page-20-IMG": {
+          "right": 0,
+          "bottom": 0,
+          "width": 0,
+          "top": 0,
+          "height": 0,
+          "left": 0
+        },
+        "page-16-IMG": {
+          "right": 0,
+          "bottom": 0,
+          "width": 0,
+          "top": 0,
+          "height": 0,
+          "left": 0
+        },
+        "page-14-BODY": {
+          "width": 0,
+          "bottom": 0,
+          "right": 0,
+          "left": 0,
+          "top": 0,
+          "height": 0
+        },
+        "1-5-IMG": {
+          "height": 87,
+          "top": 7200,
+          "left": 148,
+          "bottom": 7287,
+          "right": 264,
+          "width": 116
+        },
+        "page-21-BUTTON": {
+          "bottom": 0,
+          "right": 0,
+          "width": 0,
+          "height": 0,
+          "top": 0,
+          "id": "ago-prompt-close",
+          "left": 0
+        },
+        "page-8-H1": {
+          "bottom": 0,
+          "right": 0,
+          "width": 0,
+          "height": 0,
+          "top": 0,
+          "left": 0
+        },
+        "1-0-IMG": {
+          "height": 40,
+          "top": 37,
+          "left": 33,
+          "right": 167,
+          "bottom": 77,
+          "width": 134
+        },
+        "1-8-IMG": {
+          "left": 0,
+          "height": 0,
+          "top": 0,
+          "width": 0,
+          "right": 0,
+          "bottom": 0
+        },
+        "page-4-IMG": {
+          "height": 87,
+          "top": 7200,
+          "left": 148,
+          "bottom": 7287,
+          "right": 264,
+          "width": 116
+        },
+        "page-0-IMG": {
+          "bottom": 1322,
+          "right": 194,
+          "width": 178,
+          "height": 178,
+          "top": 1144,
+          "left": 16
+        },
+        "page-17-IMG": {
+          "right": 0,
+          "bottom": 0,
+          "width": 0,
+          "top": 0,
+          "height": 0,
+          "left": 0
+        },
+        "1-2-IMG": {
+          "right": 194,
+          "bottom": 1322,
+          "width": 178,
+          "height": 178,
+          "top": 1144,
+          "left": 16
+        },
+        "page-18-IMG": {
+          "width": 0,
+          "bottom": 0,
+          "right": 0,
+          "left": 0,
+          "top": 0,
+          "height": 0
+        },
+        "page-6-IMG": {
+          "bottom": 77,
+          "right": 167,
+          "width": 134,
+          "top": 37,
+          "height": 40,
+          "left": 33
+        },
+        "page-13-META": {
+          "width": 0,
+          "bottom": 0,
+          "right": 0,
+          "left": 0,
+          "top": 0,
+          "height": 0
+        },
+        "page-9-P": {
+          "bottom": 0,
+          "right": 0,
+          "width": 0,
+          "top": 0,
+          "height": 0,
+          "left": 0
+        },
+        "page-11-LINK": {
+          "top": 0,
+          "height": 0,
+          "left": 0,
+          "bottom": 0,
+          "right": 0,
+          "width": 0
+        },
+        "page-1-IMG": {
+          "right": 132,
+          "bottom": 7287,
+          "width": 116,
+          "height": 87,
+          "top": 7200,
+          "left": 16
+        },
+        "1-7-IMG": {
+          "left": 0,
+          "top": 0,
+          "height": 0,
+          "width": 0,
+          "right": 0,
+          "bottom": 0
+        },
+        "1-3-IMG": {
+          "right": 396,
+          "bottom": 1072,
+          "width": 178,
+          "height": 178,
+          "top": 894,
+          "left": 218
+        },
+        "page-22-DIV": {
+          "top": 0,
+          "height": 0,
+          "id": "ago-prompt",
+          "left": 0,
+          "bottom": 0,
+          "right": 0,
+          "width": 0
+        },
+        "page-12-LINK": {
+          "top": 0,
+          "height": 0,
+          "left": 0,
+          "right": 0,
+          "bottom": 0,
+          "width": 0
+        },
+        "1-6-IMG": {
+          "width": 116,
+          "bottom": 7287,
+          "right": 396,
+          "left": 280,
+          "top": 7200,
+          "height": 87
+        },
+        "1-9-IMG": {
+          "width": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0,
+          "height": 0,
+          "top": 0
+        }
+      },
+      "screenshot": {
+        "height": 8765,
+        "data": "data:image/webp;base64,UklGRrRlAQBXRUJQVlA4WAoAAAAgAAAAmwEAPCIASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZWUDggxmMBABBjCJ0BKpwBPSI/EYa7WKw4Oi8h8jmbQCIJaW78RCAXpOj58tWxEbA194ZF/xxif0bX8quQfk99vyb+bacuZB2nlt2afSl/d/UD59PmS83//xerr+5+kl6U3qyf4L1Iv3A9aX1hP8lkwPmP/Rf3T/Je3P5l+5f7b/B/uh/mfT381+x/43+D9Cr/t8H/sH975sf0L8t/3f8v+//+Y+a38x/6/8T+UXo38u9Qj3R6Lf2H7P92Ltv/D/bL2Bff78X5gXy//n/yP+l/fH4R/dP9N/8vcB/Yb0//537a+VP+X/6fsD/zX/Kf/X/Qf7390fmK0A/sH/Q//3/V/7nyL/17/P//7/of9/uZ+lYLBMUzhSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhJhdQ5J/JygiwlBCcE/748uBhCF5G37lupnrb0NaFJU3HDAnDK4SeV3W29qY575+ztDbhUJ0JQcpoh3ElW6dHOFKCLCu59Kp9PL2J/pT5DLhkrLBQLajMr9Gb47ksnXN+woQlgrAbGak/4vQ5Sh9zHC5wPW1l8qP3zsfJjSiPG+dkgH2yALOx++dj+Htj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fL+n91c2MDZbnyStcqHw3w3IanXr5dOWx56ouHvRO5y3KGqIkX3QJwVFYiNfefK5O/FSHvnKCLCUEUqmHzvj2C6PnMuDE0199c3OdJLg0+7ApFciViFM4zqEvPNg44z7IKk30S1sjRimcKUEWGiYxUOuTmfHU/cNFhKCLCUEWEoIsUcUoIsJQRSa+iE7de8fVnUBBvsjFXOkQUfk3sdw20+zmkjgszjh2QlBFhJi3WFCfqoEBTrNImo4eqSYoQQajA8idEyx2vCZOjS4e7tNK3HhRdfRroVKvMSNbdSgE0sNgnvY3yzy9xOk7BpNhkaTNPU5oajR4OzxuvhF5418I6yZXjFqjVtc63fsJtJ3YSggTiLNL06SFuDQthrAlVpEi3CZYbtYJZC462sCCUUrGB6t2w0Ucpn3vs5AQJhyMMmOMjyKF66gTi5E2ZnKcCg52xSGImyALY2l+0AqQpHrfHIpm2jq2uJygn79jbP/ADHAQoYFbhp2GeLpX3ydJGaz4KXJc+pNhGXhAYUpWyuB28MnBkN3G+QIZq0UP7HOx++W4pfrsbSBfvQcAxqNF/aa6Mdm1Va372MCq78WID16kqUsbmuM8Z7BB9XcTE6Wa35Or7S2zvkKwlNPN6NBJuKTtALyHosZr6saSdaT3e6u8HOGnI1CehipQe68P52P3zAVBjqJeip/ng0ujvZnkInN3h9TCy4nQ/h0f0sVDvqFRA44qJ9hpfaN7XX98BMiuTpVH8mB855FzPisJsOArnYqtYQkRQpZ8m1Zee1/2cNFhKCLCUEWEoIsJQRYSggAMZBvX2+Z2XkTR++dj0DNuOUX6dXdiWV4mgIKw0CLzWtnr1tfQqLx0l9iBzT0EAYyOkWq7sJQKcTqDsy3GVnCKY0Y5Yzh9U+j6MuNPkvWs4iMJBl+OMN5Pf38SDb9jy808BwYZw8N4WGGoDg6rFzp4hIAXSV0BaLAF4XQmCjCV5ZIlFeBCFbXdOg/V65i3JiXebrtGy11etiRSQ9rD/qHbMksyt30+LA+VLUr20cS2aU/1xpkRMIViTSwM9fHCL49E8+RXNDB8qRx/J+1OSEiG3M6mJQh7SEAmaQVoAzlkOjQVRVMR7xf7/nOHUwim2ItUwJjn3Fa3ufTYSPqcoH6Az/tELU/fg8wjKCWfGBDjBuBNwR1XpkV1WShvj08iqrxMKVGZQR0uToJHtPYZ3Ly/EpQeqfppXF4h4QU3MEPfzPiMwPcX3yjOGCSDoHPTWHMwMnjZXLSDQ43RKdPVzSQrjZChAPvZC+lS8IS9P0i7z39prHuGAV4K+dhs/gRoXfx8FGhym4PKIDsgye+mdElcScsk600Xbqr9P2fktbrouoc4Kkgs2fQIvPWUKwB4mKCEA9l3YidsBVXFCZ5T6uYDblRIssmkO+iNGxpcHlLfQoENNW+tyNjNS/AKgpksVLLG33UyQmh0cNK/T+GxJ8liSlZW8IH6F0mcNOeJ3TSos2EoIsUcODhqQ2nClBFjdpUEn2qnMnFxXsZZkLYle9iskYlTaA1t/l5YlZFs74wUfyFuvy7/KSks2xcoC7/FpJZMhE95QM5hL3xG7rKd5MTEQq7P+Z9OhzN7dGmo6aJZopZc3SAYqcgi/JYdVcjp2BgyWKBvjUvyrFAiON2J2TAycGGG+LcWbHamuC1iylwSDWcxXYKVzhN3rJ1KnkP/WwFjA8PErnoAo24wubDQZqipv12FqLsyWcX+AFnp/dB6HqUnfGxltxxdip4PN3nwXLR2q6UtZF0/cOoJcmT/Fkpm47UYOA1DS7if0JTsBiDVllhOiWAtcOjUyKJgRekUoW4zBcwNmufnAEM9/xlEkv6I0hkxGvsdvNICTXRimJYnQaMrH4Cz3vogqruZNKrYQsf+/K+EoLeR6wajvUD6w67AoWgUsqAtl5BvH2cwBy2moH1D3jV7YPXaQhZ2TxccX/ZNbG3dmqnPUeGxWL0pqAULIMZzdnPw0JpRJ9w7YQkTzA5pXUUewIIoMykWIShm14+7lMeHCNLfOTorap6XQnWhT1l4NrSqsrztHNzXBIHZ+W8pKrS3qAcROvUEKe17gOmfmY9WS7GQTsLPsWukzhRJ5VK6uannaZ482GvOphkinIDmHFzjt5YFa8yWJbwcgL4WD5I5qUiD4ibhsaZoOBlC76x1Maok90G/VPPtQg9AIu27uRUkrDu95pPuIaBQmbcrdfKfAFLN6xwtKJBE+ZkoMi0N1CNsYrNl66dLKaECSBnx4Rr3hsWLiJcEMWwv490fU2OPO7RStRfKq9K8hU62pIUGkP9dqOWWzIv8FgHiwOvWLz7CDoLBn7nrgiYPScp6fv4hr3XS+ed3ua4VMau8+/G/n1f6HJ/DidCBB3zCXwql94HDF2FH+aCymHZaTqu77VaKw/q/nDo0vAMc4m4B+rNg0LLiKmvCUrCbGwvp6s+bUI5ZGBjpBnxgAKAuBcpBp/KjCO9HZhmQmYcMIeeGi7eKem2RK3vrNoje8OmxrfDYHIhtKFRMR2Y7WUzqPXQpl3Yeqrfl+GOhNedCMyMbARYMYBbXBmS0YNbBGFPsET8sk0fvnY/fOx++dj+yn752P3zsf2U/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOw+Gd9z6UkjPhMntUtUD36LCUEWEoICM5DjpUizhY1jzRR7YgLMg/NxCHPgJscle4RYSgiwk/8N+JHIsO4xcajDU0U94B4sA+71FgZJAkVCsjjFXRbLAlzeqKUoeiVvOR83f1slD3hqiGQNKLMMU0oq3+sOO6dzZk1GAEH/D7D3weH3+kUEYuhyTPJA3fvxAtrogEpkdHLxB46vw2orxl3VVcun25KryO3gd/CPrwUTesWrNozVhe7qA8NMToPusCL+Gl9FV9Vp0BjMMB8qkkrtB5Q2CJh/B71zBFUJQGmcv30g/K+dFxJTqQeMjsknfaD/WtQuymc6CRl1DWQw8ixEL9QGnn+BliQnhYYH139hyGgDiW1Xhvxhg6nGhE0jJJjzX7OkqV6zrTSQJhKuKTNVkTnQLDRUZwMaEKlRfRDUF0ncdjMolyoGg3N/xhuYu8CHdAruWZ50+lNpO/4g2TOXcgWT7xL7buqdSJVLikzVb9DjzQdHg8v5vJfiI/GSBECZk+78caIBpAGrNRpJanBqnpLoqtNRDUxfZ2Tj1SWL1agBXXzzZlbB1lbemZ+Pr2oOHx7U5DOsPuBpzVpw3Fjsi01eQYpNr4vUjS9r0TriORn1YrKXLKqDituysPg9iMNhLR8KhyW+5OlI10NWK35PRvDv3zse2C6fHb3Ykwp3yz6JY/+Iws0H1wmvY03FGeDeAcgr1Q/Iy4/boDXuC/A0n5FtKDXLLdNwfdiRhFMGERN8M+O1mHDRVVc0yN/B1vSC3gWfBMOxLnr8t2b4sYMUS2B6jweKPgl07uUKJTOafe/dTm/DgcRUx60JglCT1GoUGSkI4nizqpg9p4irLK2fzRuLohJJBsJUzqB3y1K7V6psht8U/dYL8M1zkLBSR654oURIXKKGNoObuVwzW6mGvX9S6aYSFtzuXwAgYbCuEtnM13yf/Cfpt1puvKggkP0B/GE1XVoDZ+miIDdLAAPVZuctOaWjafRoXNQTxecd10c6OsAFjlv+14rDPuYcudZWe83avmSfiEooIDPt+MBlxAn1XHyjZAkkGX+6MIRbbLqWVYDcVrOSgqLhPzBUOqYEPxkE69QQ2qasw/hqbNXp1nCf0dDRHRLFc3aIUGoSr0cXYef6UUefbQFUGdOEolaDyN33BYSgHGo4+qM4aVS1BGta7THxkzhTFNmhSuy4PICPkhJW5K5Vu85Ad15hj1KCZYXF9dmoKohh3HokwSvmd6FDHmKVarZygw9p6F+LwVVgsUY2eITkvsotFByh9ys6qVFn/BeoTzGQz5DDx4Xz8wcU5lURVxz2aaii9s4nEzuvB6QWBn8nVXiEi/Bxhx4OdIKP5reFKe/dnClBFhLBZQEPxXAJc5peq+coIsJQ0gfVr5vDNbgBIDbihubNbrEQRPZhBS7oLuGD6IeVFs1TjA7J8YJ34skrcEDXZpETR++eYTwDqji57enGQwtXow6+xEsc8jX0A+lML6OZ1YvkdJljj86Wi4EuwgQCt3nbI6Kcv3zsfvqVKvcxabJVkTxVmmcKUEWFgpZuyQBPBNfuzhSgiwld8c5klDok/hPfReChgMRosJQRYQlTXkN7AJb3RFw74QHcct4rTGXvaVawhIiaMhmwvGXiqw1YPnNBFhKCLCTWskj+iEsAnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx+9EDWc11ASr0cXYedwuYs/fbs4UoIsJQRRzBOhLTfGz/wl/Z1l3Sr9Cj0KJYrkC0yp2bAWJoVRRwuVy+qteasBZWiwlBFhKCKN0PBz0tDRE7wVZeRqNvet1gMG9sJQRYSgiwmEaohh47uyTR++dj1R+rBvVZuAXC2VSk5a2LthdTgrjOhgC0uG3tnRVLF+1EP7SExGKB5suUNur0cfQkdJiQDe/swVNUnjFWfezfTOFKCBMPBZauu79SJCtkIg6LzZmaPFAi3BVy+QUCOhEup3csopZf5Bhck8NPF4ylhdu1qMhPAckT8PMIxxu9Aknlto8ORqYKD/4FCyq8nfOUEWGQJmZXnDEHPb5esl2MgnXqCG84pQRYQk1QKTelie/SZ8Y1hwIydcTqVK425LUr/iZn9b68xKIo+wwF9/qnTkRE0fvTCOrfpTIHvLXGoFloe5MXukrqe2KiFVWcAgHmNj5SCnfx6wj7e3UG+NGxTrS/t+OeqipidD9zsR+kAbWFgOKANehqWCztOpzmESaKuwabF/2PHfTOFKCLDOC1g8Yo96DOiaP3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H75j6OVGqQhRfyK+EB3HLeK2UOLsPVIQov4qrdN7bPMNOFj8Kk0UnyL092c4LalMR14qsNWDikLEnfCZioea37L/MdSP6IYePC95FPkul9y5AODNfGTXBwpQRYSgiwh/jyISuuICHfWDl5u01/H4eUY+ssC5ELqpq1kmDDnswOCsVtH752P3zpq/waTWzy6MLE9EsdJJgBY0VUNpnClBFhKASF1U0wwU++0mKZwpQRYQ/x5EFuRJdSfmqZDooLGbjGAFvAxYx5Vk/sB+Z3GfBhfGVejUWvCt7nRaGbH71Xj/BX0g5oZQYy/RbGWEO/XhbJkIL9YTUB6dFT4u9se2z2c4yzRxYRc8O/p0jqXmI6/H+fsbWG0qP1RkO26bSdJvvGMZdmkRDJ4kk/yUCNy6q5RgGfOx7dWecMmcKUEzbs5QRYSZ0fzkPZXJnFHaaucZvGPVCFlPIFxKstjtxUz/bKlOlpfDQUCmenQgyeEg+/wJQjSW1tIV2adTzsXfiJKVrLXxzmvZKAiZ5P1rE1V4z4zSzdeg4jOLhAK79bBF/YwfUDHzm7SGs09CMWMzPThpbvvjYWQcm/or2PJ/p+BpA/p2B+AXqZhkwek4v23Grx74tVNYGw2sI6sa861XAfA9R7qkq3+Yg8Q/fGLF02JaOnr7ccPQgs6jrtkRaP5yH67hno88jvk81fccz8Kno3dt0EQ0i+uYKsIqzW856UUZBNnnhhVUIBjWDu0SOREt5xhxA83OaAr9Qn4UPmxcwc1POpAijOti72/ykWbzTODzlKrvwgd6yMFc+wfWKy37501f39BzXnkQchIiaP3zsfvmPfY+ScgT5XfcGoSr0cXYeqQhRfyK+EB3HLeK2UOJy9bIyZwpQRYSgiwlBFhKCTqtyk8B4kxPT3ZzgtqUxHXiqw1YSb/MthGNdBhUrEUfIP30xqQe9N6b03pvTePdap2kQIlsOfRawlBFhKCLCXCYZbFfSQnmvi2OYhLzSImj987ItmM3XVijPeB+kzA+i3kfVUoIsJQRYXzReTI5mhw6gMShSrV4R4xKtYQkRNH8Jm92NGdFLn6rSyN6FM4UoIsJQRZeLRH+ParWEJDl7s65uhrvnfNF49rjvnFpgIc1zfQVB0D5otpKmm3POaDi6suI06F+tHJ5w5PW3cuHOir4YAc7h6iyaXubM1mZXz081adYMH3PNjoMPgbvKWok8abzZR9Xg0kdUtev+hij20WdljiLyRE1hKqn/apbd+hhtn6ghtX+nJdjIp3olFi9nDu29t7b23tvbe26cTxaI/x7VawhIiaP3ztL/YNGDtaJTrHFk0OyDgt2ydvncsOlkLau5A3kgtmJ57HG51LC4UBO6/4mQGwwi/MQF7C8/I/cwnDNlCSTN3CM0ytwwvfPZY4ioDfA1TNHvP5GMv0KumMFwG0KEmt56K9xPYM7zQPB0bD23BdnuLQRUWh/+Qdl+AXu70eBsT1JdbJ4INktL7+Gw8+KbdGRvwXPIWqGADABH3semMjIj/tPYeo/id3j2o9p2CpuTlEqYBSWzF1kbawOv/td8cn2APRkxJepvrgZpBqsiPuTQiIgYBLIfu4UNxSg0zhSiMTFHkhQZUvPp7WlQParanIcHpykQGTppUEWNpwpQRX2vGSWugwboXEW+ety2ZK8ZeKrDVhJwUnyLuLpbhcM2zrvLalMR14qsNWEnBSfIvT1TnXxgqzwyx6e7OcFtSmI68VWGrCTgJga1uRkj0cQVfCLFnFKCLCUEWEoK87Coa74wGIuGiwlBFhKCLCUCoJx7R6rCv9I3kmi52P3zsfvnZFrGCEh56IHX361whFBRimcKUEWEuEwy9ZIGb8WoW4Bs2lawhIiaP3z2WOIqXBDS8XyMNC6nAIiLn7hIiaP3zsf9p7EUsZIxftH752P3zsi1jA4ojF6sbtRkN6VMzXzgygayuxWLC52xxYDOoGKt1H6ygABFPYn/UzwTFM8heyErHkTVjuHzswkL4G8btx6xaW+DXuRsBiMj9j3/470kb1btzFJ7biwqPi0UILr3cKwHSIrvDE2UtMMAyzfTTV2KIux++vNBpzIXflqeAxtAVayZwpcJhl2P3zs1SKZwpQRYXzReOhS0r2ZTU9FAb/LXz6VvSx1LNCKLSr6wiqtF3aOtjSR05f9p7D0rlhOMc6KYlZs8sAZ9FHvp6alDyqHEkEhnVWoVzQ8dsvWs75/hP5+4sGaEnE+Bhjv/8t9aaEJgli0NnXPQT+OkVEJrKBh1StgijiPyS8chIZ9qhjQ8lI8qMs5jR1AofKKsK12kB0uoeMscCFgyyJAHhKr4ij0YhgyK80Gg76YmwV+18EPEUts7IYrBl6UVhOMm/GHzlKXYNPGSq+1GLB9t9eaDQpkwsqkNSnziDLiuNHWgBBUtXSUtIX9ZoHKWzymrWEJEcI3BK1hCRymGrmsISInyxFnRlPDhHtVrCEiJo/fOnkhB20ywgmyGaUxHXiqw1YScFJ8i9PdnNnwObP8TRYSgiwlBFhKCLDQFCotN9KIeKL+RXwgO45bxWyhxdh6pCFF/Ir4KzLbTPcOhmhzr3BBy1aBdJLEdeKrDVhJwUnyJgyBbWfK77R++dj987H752Jmy5WpICNP5pYcLtjFKCLCUEWEP8eRCZBP3Oi6hTESGtJrVDzsfvnY/fOmr/Bptj5ylCXuhI16JjfS9w0WEoIsJM6P5yS+eCwdlCLvr5qmABIidj987H75iTxJKileFrrYsX4YFiE4iBZP3GmcKTOj+ckoRFJirmBcF3HCA44uquRr5h9672/sXogYAzwtE14C5XxFP7Tbm2tbcMKI8iJlccBYcdG8406OJl6bH0RDWjyXV3vOx+9V4/wZebSaKLmcuzdAVYhcTb+xZYJGbZFM4UP8eRC7YaHP6iRI1IInY/eq8f4NEgmbdnKCLCUEWEP8eRCpR7QBSEkQeLFXyEwjpBKxGtnBJcbtPsJ9GJTwFV9rfFWYr1Rzra7kEtosLVGDRS+ceiucuhJ1pT0cN+MWQZKlIdDi4gkcRX2xsb+gO/HOoQRBRw9urPOIGgoJbv/UGJGzRAcMaHNl3Kr8Vm1kGDmVKkqeZC4pfhRT8IEUeJUN0c/9PRhhqN5sCCj1gPLvAstl1K+anPUr9veEYn4/eRQqQVMBJEvZnmUPY3xDtooNNyUqG6OkQa90gM61hEFSwzBFQBBtWjhSsuYy8s6w1JCVXiQJTjiYpIhdVOB6gmz+2+dj987Ht1Z1S0Moc8WcUoIsJQRYSggBeRYAvXHfImb6pp874QHcct4rZQ4uw9UhCi/kV8IDuOVmmL0M5cFMa3dpVhY2YUwphTCmFMSA/fTA9Wm1LOkPLDTQ4pQRgXnClBJ9nClBFjacKUEWEoJlkzhSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhKCLCUEUpzm2UW91f9jtzV2C07QQ46oGGRjQrY+gHLTlf5LC4JRho1HB6MhxTd30XrvRKM+mKdr9sExu1Q0tA7tN5fWMzjMUzhQyvg68/mL/Bg1k8EvOf5IVR8g+tXXwCEf77CRliaALOrMZHfLsf3afji3Oa0zjoK1ssMyHpJpDpDaVuZeeGVqFemB8VkTS8k1QSqk7UYE7VHP9r0TBBpYu1E8foY/+4hKKfXma2j987JAQP6DznHweC/hosJP+ia8II75g21rTj9VObReBfvS2sy58NmMpJhNZ4oY792xhsa6ZOuLBNy/arRlmsW2sEHn2YB6nrFcqPB7Z/+V3wquiX7M13VgmkjmKYhA/0704TRiYMb9U+R4FEJO5vwpi7jXHyK56U7DNO8WqqrmCq/L2o/wcc9UCbctqHoUQiocKxim6MhvfIxZJX5TeZUuxeoXHcNSBioGpygOcZo8r533zKyIc/dhzQQiQ6LNqtYRHNyIgkrnjAJ2P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/e43s+Rvohh48L6y/zHUj+ff0zGwhOImj987H752P3zScNvZaaIREPYKYbvHmw80eVY2r8qAnJfEmrnzYJw+AWwmSDBZmAjbi1My2K1XzAXWM4awhIvlvj0zZFC4lEAad3LmiXc3cfbXunCaiAkvhGAYPnQNChdth/Lqb6Je3kf7ZUv6b8XxqMPgZN4TX4dPKnRbR4+sOROx/tB9c9ao+Fqy30tYFzBlkrAVc3xd37QNI63u9hhO2Nz/snJql893Z19GZrX/KXhBSjyEVj8oUXVQLC9qtZTuWHJpoKxtXe9VCJknhX5uALmcZO2ukqQrpqOTWh0H93blX/Ktu+y+zLp9o9htvpj2q2dV8aZ8xh48L4EROx++sPRe1WsISIiDmUEWEtD/Bnwu8Vjoj/CT8l40xudlcxVbhBspYxI9cwb8Fc/1bc+6PCuKM7c4jgvD0EkN2pa9R6VHa0wedj99Yeiujuvb97PmH3oDaEoIzH5UfvnY/fOx++dj+DdX09qtYQkRNH7DCc0vlvp7VawhIeSFJcqOY8UZjVoXLVKFwP8ROx++dj14yvHMyCvokUBxq2KgaOAWp50M9K9ovarWEJETR++PlECFUZJqj/hKRawdNYprdj987H752QA/Qb4Nhvsz9v747LTpHdhJ2P3zsfvnY/et84cNg85dAykSEl9Zf5jqR/RDDx4XjZeLguej2G037L/MdSP6IYePCreuIzV+UEWEoIsJQRYSbhyuzfpBHkhhihOB585UxnKImj99YejW5Zyq8QkyAQYxihYMR6mgoC0yXxvrvCZDieoNOSwZsRHWQ9MNuJbzr5ALyegjBH+Ky6ZouGTWjAVWciSBpVc29u2G0GsTWVvaW+X+SfW6CyHKPNwbKFRkFQfTg5EWpZ1yjILiKky2EL6V01bCxmDkXc0mj/aD88k7qqIHP4+ENeu23y7Pojz1ugoUXSVfeXbsvbM5/SJpEoXOFHwigABJXbuQAr0BjsW094HbVN2LDhwlDBG2/GMK0QqtwJ0UPUyaufSA1FBxrhosJQRYW5sWnhAiJ2P3zsfvnaIwGSEoIsJQRYSgiwlof5FIYTtMt0wOcMnpjjihKMljL/Kkws6g1cmftXnr5sh8Lhkhuf2YoUOnPL99YejW+rJbmNzg3f5ob7FgMAX4NdomkqL6KgRUMwCL4cy0OCvIGmRH756VSzzciIJs9KccTFM4VubFp2j987H752P4qfZO2LTtH752P3zsfvnaIwGSEoIsJP+yUCdhciNz8nDz03gZ/KMO0GZfpR0/sBHdnmsISImj9861FSNy4a7wMLB7iL5M4UoIsJQQ6cuNCqlnVT7SlD1XmkBARVGiwlBFhKCLCUBCR9Jdp/QdcR76IYePC+sv8x1I/nMZzS1ljlEBWF9Zf5jqR/RDDx4XlwhFgvyr8PHhfWX+Y6kf0Qw5EiupvKNFhKCLCUEWEoIspuqrirUhN5BmV8q6Dvn0bSEVaWw4GxZbm+Lnu7ZU+l+8uVSHnwdH3zp5lunh3CD+QOaXoViVifau2vHcDaafN70LkJ326P8OHYUTCCGO4nZE1GQsvkyCMwyChzj/XmQwbFg2srz+rXNK6Hv79gC/tgPd6IdpRrKE7GKu5HlB+GiwuIxyFC11FFqOVF+EZxB6pyXEPHizFBICi7cD0q9YqFjtoKJVbmk3/M2A6gxgtKZwpagLUfb8caCptJE0fvnY/fPT63+sJQRYSgiwlBFhcRjjphZRpNH75262PEJEa5/HYDEOMH3cALx4uWwRxLW5TymgUmsLA4FZI4kmQ/RnwXG7CudwhLVHI+BHRWdpYLKcOLU6TzPfD+sJQ+2USY9PsNNp9wec49qtn6zDZxSgiwlBFhKCLKbtnETR++dj986oKqdQn2yhy/fOx+9Ff8lBrVXFXQySEfPqN3eoZy/Ma62Us81hCRE0eu7ALfH1JtCgjvhZQAqioqL6wq2InY/fOx/GF7/4MG4kW5/lop8sboUxvzvaMY26/3zsfvnY/fOx+9gXO0VhjOIHbBXKTOm/Zf5jqR/RDDx4PCU9YcXdL1Qmc/ohh48L6y/zHUj+heDfOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfxhfWX+Y6kf0Qw8eF9XtYQkRNH752P3zsfvnZEnaPUevenJ2UOLsPVIQotaWBv0B2P3z0pE6VyO1ASVGEXUDHiF1vVP5E88HIHEhv52OXShLTHXNsbTQHaYik8qG/6XKtnIsKLePecOyiH7klNxotKv7+WhNCb9R4TiJ5SW4SHElucytmF1jGrcnZsAiJ3e5/f7lV0s9h4O/2dCImj987H752QnMf7OhEQNrRPJ4dkalIO3xwtClzZzWCBnWjGUjKb8nQ5VSuUbDwyewqmzpTkA0/VuaM2EbrlGprhFzujMKisxSTkuYBcBS+ukBRfnwC8cb+B2la9wJeDB+gPvH7v80tnPwGM/MKUiJFlD7eDeKcsv59abW7jqPfJfCXz1kZVw+xmcuy7JDlZThyhmQqpCYxLhSBbD3cmjcHfjAqLoCMG0F7B9A0lq13ovmxYJdG8zTpVs6W6eTTRYQsrtS0fwIuDj4/jizBBuntboXU1tG9e97OcQ0kLnkHjSnCkVI/2dCIhdxy/ZmIv3iWtupz7eF8XyVvW3viSHVARnSmsu75djzWz8cglCzBzYmAbs1F9UyBgaPX67eKAFcNJBw+GQHLyRVusVKdNrOet+Lyy6NPQkXxuVfnmY9WS7GQTr1BDapsA/g3DlYQkRNH752P3zsiTvH9RSJJ8+rPfUg+WQPuRSmABSnOw7mnxagkk0w+fLDvL0MHUjlIjWVICZP3kUAmYIUucKSSAv82huJvgna/9aHnZEXqyCPRscvNBcJgyvFfboFjU0q9emioqqTHFEeXGZkwcFEkYMJ0/zCS4SRtwpnHOQH42YTENaLEv5UyN9ZWmepLN544SZ+T2xAZEiI1MiJq9NJEwe+WfUcMobnIpnClBFhKCLCUFHloYpQRYSgiwlBFhLQyQ2cUoIsJQRYSgiyhucimcKUEWEoIsJQUeWhilBFhKCLCUEWEtDJDZxSgiwlBFhKCLKG5xsGUhW0fvnY/fOx/BuHKiGJzCuE5H5b2MBeFslktVcVakLDyoB/Ea+ckFfZh9ZEBYG9n69qtnS3TIxOLG330aLce0Bi/kjfCoOQ9E6jlAZIhPSktw5Z78CrHzMg23FlwKvFjpZI+OfbJJFhXcHwm1cBnpAcvJHiVgYw9jBRc3emz2t0MBxl+WzSxTzKrm3UvondNhEt1iVVTjQyQ3OYNya5ik+nZFxTY7/l+/ayXYyCdeoIbz+av3bVYJ0j9Zti0YOhzqvp56zdok74DO/DzsfwbhyspxynXaPFcXZximcSG5yPYnKCKROWnkNsOHZNxXTjgfaaF1CqWYZiK3UATKGzilAC1vOpgOg6tMyk4wgS6NQ7fjurWCa5RE3foaCmOFbY2KyjBBkC6XxuVlOImj9WUlfwIqROGD+zHNyEbdVfGK+Y2pwlk2NnKhCcZ0Q/PmwvkRGplvEJETG2MLMo3WonGImwCsMt4qmsISHEIwC+bGlKrS9A3psDWhB0jvQTSkFLRl0r5CXT8ZIkJ1cUAei56ERqZbxCREw2T09v0XlE7ON3t0xafDJQ3OR7E5QRS9/1c+feFLT5jMj+M5Dd+ruNPxOBaqKFMt4qmsISHDVynVu5hkxdHViBsNCgBqONypPA+RLdIYsuPCks0f7OhEamRE0fsBpW/ksBU8v9mNX7lBFfoLpdJfYU4AJquw7t++IWnccVXrLH1XlkGQZarWnx9IQ9G9eG3WiI1Mt4hIiYhPbhUrr8Ms15MySc9DBjcmox3rnTedvXD9C3HeaZwpMiMtVd7zBzFxkjyjOdaiTwIbPAg0luHKynETR/EC9lsgXX+zoRGpkRNH752P3zsiTvKS3CRE0fvnY/fO0RGplvEJETR++dj989KS3DlYQkRNH752P31hlu8wmrdeMBjZt4kL6BkG1BZwpSaP31hlu8U+iiettF9BcYmwg1gecl3uBHcCCpycbxMfHcYSG3++8b34wvFq6vcP3z0pLb7z35xJ33vXJw5xBtfaWS+MeU3VxcjFqi5ObLERGT8iP9nQiNc/XDSDwU9lPLEKCCABySkr7O9LsF2HJQIB/0b/SSBojQ0Dlm71qh2AHhykz0V45n8TtREamXLwzKr2bSDolX2Nbmre2hTAgxdT+tCDx+Fj4d1LmsR/ecoKPLQyTg1DpLL4p/OrR9JQxNzYkJsAY5FM4VuO81hfJnChI7ahOM0+L52RJ3lJdnETR6QKxjWHVHA90hVUHV15RF87Ik7ykuziJo/jBHSaP31hlvFX09qtRV/I9B/VlN8UowZQKCa0yunjiy/RyM+RwmeT18wF/x/qEjUuq+ppX7zYOU6XBPUJq+VvNX7uH3KCKQ3/i78L3bVvDqZBWniVguRDoRGuTWEI5YJJ6DvXn6kD4L+TrCbWZVAXo/h++sMt4q+ntVqPQZBo8nLSDGI41SX+HfevKiGr92478ROx+qvmgRpbbDnTG5lUVANH0WA6epRcVuO81hfJnCg7p4GusOl9GhA80gmy+vnTgJm4gC4Kl8n1tzNBgbu2CwrHklxkCJbhysrFYQkOVPdd4NcgU0Yb2nE1kkO/8G4crKxWEJDrsULhgKX4LzVjKLrK71RwcqZnl8vlheMYq9Jglc9CI1MuWlWsHKAmkXidNIhvAdZ1V48qC1XsYqpeCFSetgQsrFhs/mr93D7lBFfaES38WtBbO81fu4fcoIo3xxALlD8BOV5aQ2wrQC9Db3xzlo+jVxdwCXruDYhFsXzh59thuPtem/4X4w6HlZTjATrCT/pV1bk7/poQ1B29fK9BhhtHl0Ep68jZ+1QO7DOE1RRBo6RWZNYQjssomSMrXlZ/bdF2azPdG3809Ax/b6FMgdVNnS3yaLCUEyzNPPQzx5aGSa3Y/fOx++dj+DcOVlYrCEiJo/fOx/BuHKysVhCRE0fvnY/g3DlZWKwhIiaP3zsfwbhyo2EMYN/FBmWd0lNFhJgaoImj/Z0IcVLyIljzfDiIUKKZliG7UqES9EedSY2BIxrbJr1ZZYwny1Q3QuYFmVo0xpgDhDGs7niw5+jIJlFo+/kATKG5yOCBwLjawHk0XbvDkbW8BTsUhfd0hhknEfvnpSW4dHB7Rz6Ha1wzdB2rQn5jzIW0jcal4M/ezriSLxmvzHtr7t/7O+0PrcTjr73H6BgZEFtWx/+mLq3A5NEJNHO81fu4iNbEYfJyR+f0PRM3GPL9RsroSggTzuMiYq/duO/DnlrOFuZfbnrAc0gqu6oydwPx9mgRDQGJv2cSG5yPlVxxOzVJKr97vnbjvNYXyZwoUr8iS2cjUHxArsq1g3Mwn5YbuNQx2DI+lZEFLQyQ3QRfOx67LjpqB1Tgbgu6gSGEkOxhoHeSNg/K/dw+5QRSkh1a68bTtxru4thJcJtZGfxZOmK84lNqkNKK8tfHXYrDdBF87HqPc1oNCBQEWIWg1jILxUK/2kATKG6CL52PYpeH5meuIHf2GVzGDBLyNRiQ5EPQ712TBaY/aiI1MuWlWsHRqsVZp4/ve4yABokdOKlNXMxH1dCvrDOnny3JXrTZ0t8miwkyOQItkwLqmzFIqoo3nT82gTdYLcd+InY/UhcAypxEGuwT85fhiZyQv8uczMmofULDgAChS8mihSOy4upSMGF+jh6Ul2cRNHppRRwrmeEScPbREamXLSrWDsVlDH6gIZJOCCd7NUjzT6e1km5s6W+TRYSi6lyKSZxS0MkN0EXzsfvnY/fOyJO8pLs4iaP3zsfvnZEneUl2cRNH752P3zsiTvKS7OImj987H752RJ3lDhKaoGkRE7H752PUw889CI1LUWTqXEI6A3kEb2vkMYIGVX3j4K8LtLYJ6NHEWOHlmjkTk6JMExC/8B2kHqdU7r1R/56BiCrBES9NFzPeRuOhcG4crK/P9hH4tClTGRuN1z/vbkwQ2qasl1ibacnGjnTk1Mt4qobB7yg8O+3O8NAM/GGB7IO0aplCqPIZjTC15QgjKCjy0MkBEPAcz07JcpCDYB5nh/3YiLk7NgERTmgo8tDJDRKOszgAIM3jGMgDLNZukcyR21A7E40wuAfWGW8VTcTarBxMdT4MVx0GKW8rPCIDwE3gU4aadc9Z4CLDBqAmo8tDFKCKSgCRZVG2FVTF3hs7d7UD5NZYIjT4QIH1X4isMt4hIiYkz8QIBEF/T+DSAwkuyAtw5WU4iaP1IK0Az3aXZThThrb+EAaPIAfuxDNCabIiuZG9BiXCz1AJzqcSG5yPYnKCKTfmkSRhx0qBpNRg0cIQlSWpvV39ps6W6gCYSgil+xcukUlngTdkYBx422WniHU8GGRyvtgijTv071OL43KwhIh/AsC0SjLIbGMV0RDJw0LHNLg6kwH7VLQ1YDA4uupzxb70AvnNSPYrDZxSgjgT1Wp+YA3toiNTLeISImKZre5L6RL7K2arUxbg7en+kyN0vpTzrngAiT282uK3Heav3KCK/Bo+kHH8x3JKQxfTM4SUUH1vNTx7rBbjvNM4UmSl1rCjIHwMc1IPQMAUnWEOVlOL40iJo/fbW/pE1ERqZbxCRE0fvnY/fPSktw5WEJETR++dj99YZbxVNYQkRNH752P4Nw5WU4iaP3zsfvnY/2dCHJ6nPpD2PXhW05QDNwTYh38ae9yF/9nQhxEt4p+fDBDoVcSrWvTv7YLESykY7UQEIQlV1GPW2Z7UPkuJGxBpx6kVs7ZvcLGnReWrxbkRplp2uOfNNHM7ehEamV5un6pWZ06l/Lye2HQSyXRgaV/kTFNqR7FZu0Zq2E8AuKwZ9MfRi5NRs9uoW9lB34YabQkRNREamXLwzKr2bSDolX2M4I/CnGNLrfqKXDRYW47zWGX+v/Z7A1cvrkpJoUyg/ljLy3yKJ8u2qSelJbh0XtVq+x5YkctKQs/cMZ0bGm9zq3uFUULqIK6kIl0SZ3mr93D7lBFJdxvsjm496iiYAd/sgc0NOTB74iOq+cpHVbPwjK5z7SpSW4dF7VawwTw3RjdQ0OKDijWprn2Kw3QRfOx670dqMVP1qJLvUzr6dZ/QvzfObnhByMpbrlFx+K6nFjxAcnPmAjm2Jy9Fq1F7rBcPuUEUk960/HzR22on02CutFpe5ME/g2eaIy6FIxcQcGH3bjvxE7H60SduzKnOOCSFNXO7Fet8alQh5FzlwIB1tx3msL5M4UG0r0ig+gXTseG7Pyt1wiVpEKGMfMhETM7v6TLWTM5mNX7uH3KCKSOz6NVQT29SRw01al6awqmzpb5NFhJdCndrwuglSBj1+/4YWoy0eALsZSPuXeIcrKcYCdYSf9HoOShVQgxRQ21q8uGPkIX3lKfFdO/bQUAFTHBuHKysVhCQ79QQ2jCAba32zFiCLODcOVlYrCEhxCFeTYJPXpoYoOWx6KrzSkxO+ZRWatnTzAwIOTKZWb0MUwe2Y1fu4fcoIpCS5dM46l+E80NypnUPMaUnZ0t1AK8oIr9Vx8WFvAmZOStAFPSfTOBhYblH+a9e8gWJmDQ+X/2dCI1yawhHK+jZRY+R180SImjTd86uL6ZWizeUluHRe1WsITZJy/fPSktw6L2q1hCRE0fvnpSW4dF7VawhIiaP3z0pLcOi9qtYQkRNH756UluHRe1WsISImj989KS3DovarWEJETR++elJbc6rhk2Obr+XaNGE5o50rwBvObP1kozgSPFAbt0FPYzhS0MkMjqFjMAN2xrF6ix8lw3BXAISwpALjeRNo3iTzKYE1UyLv9AMl205/dKU1bEDkSlZS+brxhNwkXxuVW8K82w96rFyYHQANmbhIK9evVpCBrYHYzBrnL+kHR4Z3Ru3X0hby30lKjzoz4bRoLR0isMt6dK9TYDGe2MywsBnRLav289zy4wjNP1ABb2YT7z5EHxYiEBNbxWj8jRO8pLcORVtIcbtdGuXpsdqzMtCHLLcZUUO/aFTl8YBPSktw5Vnh8NmAdYM5tpGRUWZU5IBJ++doiNTLeISODl++dj989KS3DlYQkQ/r+SuAoiTlYaE6dO431d/iipKBGANzIMFnypaWeOUSVhoHtWwvyyn5U3gjiamW8VTWEJDk3i46LrcNFCUngh6PktMyl7HpSW4crCEiIFwD2CDaWprNNKYVJPoctIhvT1+gLOES7dWHfEGjpFYZETR6qiYrNHScsLgDGAxiRMm7zXT+kXxuVPBm/GmcKG5YR7sxQeM1KtU9HfAaXPaxW6EoehbjhSgiwlBaFL2+doiIgw1lmYBb+tx5lBFhKCLCUEWEoIsJhT6IYcidj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3y/+PLExnFRFhZ/GdFoG9MRCDV2ZdyJ9JOdIr6KjP9TOQpvDDkQTZgXbqa3/QQlWAL1W3YtMUzhSgivy07SArFORz5DWb7ehNMtSCastk7upMFVtp95EIcvYlif241AjjzNihQ1FxWIr1Zt+hVawhIiaPVevMPCm3BnaBhQ46mfjQTl++dj986Ww5TQYZKDqFdm6zSXYvIcERFewiF6lXWYp55WPw4MIu8FwakFyWkBWANeep8jzcH2ANoQOOxVnut2Qu8T488NFJHaEjVXuidNqOODPoTRfM3aHOfzDotPC7XIX5AU3fAtZJ2yqeUhMUh0+DCXM2mCQ6QfXS2ueSyx5ZJbSKTriIW/PdJbWt5ejOWHt44C4Uy0u84S9ATPLxlYMag6b0boXkPQYwxmNsdQjAxAYJ8uADK5NLEBpVqOz0nkjdU0rjDGd9I1sFpTjzopnClBFhKCLCUEWEoIsJQRYSgilu/9PrG0DWt+zkKvv8n26gzIOf/+vKnthfFZma5wBl5+zQ2IuHksOhJo18hSfknF9qaimvALVH4ScelwZXn6KUsQ7fATKuB1ZoFp5FsvxsCbGeZ8wprOSnt+R/kuY9TsIoGxmRnqtPvB4AUlOcpgpxxeSL4vYmi3FUbCna8rx38rmWNf89qhWDGoeZlsNhjCvsxS6Q51Clco6b/arZAhiwFquWCdFo149lNhGOohB0fjifUNHiEuO5Q140Aj6ltEsduCSJGDwaApMSbHRuOgIFUT7no3JCiDopwK6yKitl1lizSou8onPObbNQ3nDhFqYIQkZeGsceSCqyUTyucxlMTZJwZtt87K2973ECjve+nLvqVZfNVbpDr59gGcAtMN/spVkoq4avo8rZqHlSHvuv9IK3jm43EktOEEt37a/8fwBfS6QWmqwn6TPzlV62j73zzOcyh8YKRi+SnIGo8lhXPrT/FmvvNFegqrl7Z9t+HOcJNkdzV0eRIOzFKbS3uJzmivpmUAHl8NeLgiZnn5Wa0Myl39kzxJJKGiGSZhtodpW0Hhl0VFUUyq4d/wBNhYLrmM6IMGZDk1oG8w66TNPJKgUB8YU4wqzwTBHp1ZrzVI364YaNRp09YBWY1GiGyka/fJ9F9dU1ZE+3d4M3iP40gGD5fPU+pZbpLvLIFCyx+gDgL2EY99CjZCRe7h9oJC3yLSbK/pvOFSIs4NTWgQWRX4c9DKUMNocXYepETvBVq+EB3G1KG2LeLZAyZdzp60V0NawhIiaP3zsfvl3+k31gjBETsfvpjUmpNSak1JWKVf3CyxjL8SX7NHrr9B8ZQegyXmxAU+aCXpz5RYAylrb54+YJJMhuTjqBZGeD27+Sk1K0GXbxMvzHRdPjHSbVr+WfLXABV5kqHsNjDFwriw/erMOdj26/W0PWly1ib2qfNIRRwVvEK4H9lZZM54BDdK0+JwaT48YhkNjuI/CTRmgDw1axZUhtvpL5dF+ykLL1yGy7awv9x2EoBImIguddzeg1WKhBwNoIrBKGCxsAo5Kvxt8ojF8rw60gNhIIYKn4jRZ6YXSZOOL1W+Hl3YYgmLCYmj/LhJyHsxC+F70uZT5e1TGMYYE2johDrwDllCOhHQidNYo5B7XX759D3xlMCJ2JnC+cMmcKUEXUuKUEWEP9NiSsXUntgovecct5CrDs/nZEkeqHKsXADF4iE6rVT0nfHSRwctXKZOb7TSSKBleHh269yeEmfTQb8LHgXV2lBVgyxPe4r6eR1DC5a9ypagBwKQSgzl48GhV5mF2hKLFZxbYcUDpVNEWFHID7CXwESkC6zRlDLkDomJI3uLa3OdLuwf81NpT5b+cP4wVHO61o2YIGHNehDJATUKy3Qi35eu0rW4+zbgdvpykwI4EYSc3eSbR8ba2I1ReRsC8OWhgLTKnspcYOJZt/Vxy3zXT49kze/UoOu7N5doYUgey7RNRG4twwf6oFCbTa/OtOs+VHwjn8XyGaKVQOruwKWUEVCIX/MDsso3WY8sK89lKNJHUJ8jQ7RjH8B8RDv6cHKatLnDqv3dEDs5V9Sr6lAJFYoMFhKCLCUEWEoIr+c99o2CyzNqqUEWEoIsJQRYQaA5VBLEc3VNLeK2UOLsPVIQov5FfCA7jlvFbKHF2CeuRYSgiwlBFhKCLCYILCUEWEoIsJQRYSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhKCLCUEUxetthFczbKR83f1tsIrmbZSPm7+ttvxSsKvVd7S7SrCr1Xe0u0qCLCUEWEoIsJQRYSgiwlBFhKCLCUEWEoIsJQRYSgiwlBFhKCK+6xH2UqaW0n3Lo+HSquNkZE7laRE0fvnY/eeyzMh8HHGVH7TConSyPC56tGgCo6Sj9WwIx2L7KtpFbXgNsoklCDgEaVJwj3rdAievCXRjw987H752P3y+GJNN/a1IrcEk/zF32Kmc0CpvA74Ysz1ovC6YoSImj987H752SFIGt/SJo/fOx++dHmpBpTXh+7lpUf24s4pQRYSgiwlAAo7GBGokO3q/KtEN2Yh7MiUmj987H752P33THBQeSIiaP3zsfvnY94eQJ2qvy94/752P3zsfvlXWZEYWbbYfnBk34wwVWiipViCcv7Qe4KXC5Vtd01DRYSgiwk//1IuiK5JETWQTj5PGkEiwlBFhKCKcNNNrRn9EMGDXIofcNFhKCLCUEWEoIsJQRYSgiwlBFhKCLCUEWEoIsJQRX1Bk4Y9hQ6IEK8IAnG1HYK3EwwisrT4dIOs2P3zsfvnY/fOyTMmcoHtVrCEiJo/fOx+/oROx++dj987H75bWrx06PHQkMEDIL2voLNuIAAKsvMwbiOEAzY1GGIzH234qXM8wJWsISImj986OLv8ypBZ2P3zsfvnY/eehwpMUbw0xE0DOsBRNkWVosWiExcJsUhU8e1WsISImj987XJedj987H752P3zsfvpgROx++dj987H75c1X0mcKUEWEoIsJQQIlyBwx5ZliBSAbCgoVYogSxSfiEcUoIsJQRYSgjgtVOUzhSgiwlBFhKCAUKfaX48ca/8B6I1Ok9kDPczA0BTLzUbdk6NHQ+cKUEWEmMFBiR0FKX6tSRZn7A7oAFf0doHSEsgEWHHBNuqm7io16qlBFhJ/0vcJo52ompUvuTrpgPwcB8q/PHtVrCEdwzfQk8uzSDlANJYaqvV3l94hIiaP3zsfvnSJSIiI9Z0FlFewNU5+jZJ56AwehZQA1qrQmtcUoIsJQRYSZ6pqn7eR1n5lqyXFKCLCUEWEoIsJQSfZwpQRYSgiwlBM27OUEWEoIsJQRX4Icmh1VlhaCqhJQ0LHbB0TtkxgpFD0rCJJYy+0QasmhqQjX+1yVc3Dhx6yW1VWIRVEXo9cBOIidiGG5kmSiiwZS0GkJGVAqsNHaonx4Q8/wjL7Bt/4nAN1UT9BCmk9IKGBsH4NpfuQux++dkhSaOf6414UckzHb1rCEiJo/fOx++dj987H75dtu2Epd5yPm7+tthFczbKR83f1tri6CPgUlRuUwpWP0t2Kkdl8nCkmsrBNK91LydATZg74S3Lp3oQr8xn5egN6T+DgrJr/yIvNTQur+uvP1RhU+kXDaFMRRAWSmVqcRqDBV1ZeBD6eDhdLAJuFpFHgSsSAZ/J+GzihY3yK0ibMnUSvnqmE69QQ2qasl2MlZ5oA+t/P6DdU8Wk1+EfIvT3ZzgtqUxHXg3I/oWlNVOZwpQRYSaURrE3ClVAH1u7KTN93nHvRFxwpQRYSgiwhiEJGDEZ19s7Fde1eQwtOPXHotxCQymqsQsy89lHKCLCUEWEoIE4nUR9ONIblrmE4IMFxOR7+FY9zsfvnY/fOx+/ACk6ORE0fvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zsfvnY/fOx++dj987H752P3zqdRtSlTJZ/25iHZHhOd9SCCUf9fCk/aHlUWRITOHQZlbvIJJr6r9CvLxyUk6D3Dgh5/31ImDALyACT9i3eol+8uBkDoAy/t2p+3WQ+oYpnrToWLSRC5It9ckdIbHJnUSxBhhpCGmo+M7iI+tQcnj6zyikEqrir0j0/4j/usA7/p8+46K64jNnqYfJdNZBOvUEN4tZL9XROX752P3zsfvn1Zfpj2q1hCRE0fvnY/fOx++dj98tAA/vxZLQZAA25cjyhX68D7Y4CHUt53T9GavXKHabC23AyPvp1Sslu9rXwzrsxTPbR2xM904YG9po7Yl8VA8QFnvQOmabMEAvVAO4gWAJPLc4w8HL7gls50MojGkWRXSJAhx/yEsX5xvm1hdfiV9hWxrFoQFpFFF1umk475WvfTFujyH9gHwWZdMyCEuaH5Q4E3FwzZTzXBG85OwVtlqJTa5Z3lfgV1iZnlJFUGho3czYGnaiEQVK/h4gUk/jTI66cnnQDlXBisUG6+nCN78yWncOsuE4QFcoXZU6efSr4m3xlF6tq1wbBbgrMs2MzjV1oOi4EP+895gI7Q5doTKCH+lsvjO8zYN+IxiL/wc9I8LEKj3WO3q8V67BIH/OSk29QK/pySTz0qbTRTTlXYG5D4b2ky9j2aSAQENuZWw+o//93xfwh517wpWz41NpnsOBytxQMiQdNuNtcZyE2bdX/Elp69+tt/1tw6pMoTayGAFFzY0aTsmBW+a3QBrEaBv6PNtdnBEdO6zcD8ERwuClC1QhCDe8sR1R6nvlsDCI1EYcVvutNb/6pPAlaN4AC00pxPVHarL9BlHAZcwoYe4IY+AAh7BWJCGJkimsjF+8nv2K8e8OWHGWlC8bAhLCNUlScSELreI6CgysvW+qIg5+/hVguShphGV8hw5wBGHdaOS+CzVsivF9p0PVshUEmRiwZmWZSH4DSWHgPbhsD6huZ8M+AgwnSxZysbfyJ+/4M4Xu3dJ1sHpFsKxR2s3SmcbShLNdfPNpAV2WVc2oAAAAAAAAAAxD440jqIEYhGBCb4qWhNYQOV7+Z0lOxXfjLgIC3G8sWzVYu3WfJV3ULlMJjsNZgbaXD/Lag201MW47XXnJtEX/cv33o6yh+qZeWQxeGSVePV524YLe/6yjvOIk+7MHJLk81PU85H+j+XBi6UpZGyIXgiSsdHMmbb9ljotz8NJKe3uHJyFazqGgl5alNstQAvr6rNt1FOwu7z+rRIqd+OoDdn1KMib/Zo8C8Oq3owerfyBTbQ/nqEDsWkLpE6/iqsneT04B/HimXTCbo3/VfB4i91lIK3o1cW7YyunGzq6aE+VRN2+X4Yi6gCt368lgSzhM1nbiOw7S4ZNjsy5ULnh/3q8G76gVY/KcbZ0po43/dKl19BbXEWc968yPzgp512o7QwzxQ9yLhEViO7WLm2kvdDeOos/2tatoy78TvrvgXdtzhOwH2ykABZ3N/Qi+kkXIuO4nVt0mBIGQsNUPJi/zpp4SKPU7yeoCn9QzoO7YZ1YjzUSYP/t8lBXzmmJHmvHypCX7lXHbC8w3WDyIWn8ypz+B7FxVARGe9V6OE1h2NQ4KHRPp73bbytamZyP4U9XwPMCzOyw4tDXBXj09l605MyGIDSY+cWGwFjtzarKf0xJWrvzXHaoQaDoyf+hOnBKfTKgjGiLsZgqAJK0hoh5x4v54X8rsKq9j5XGdQOwrEVY0mbsQjTlsL7rtCD/0K/7hP2VzPzjTh2WHFoa4K8ekc2UZP4tg+47qQxcOZUa7OPhqIKSyWWOTssG+K8dHsMdP/zlcpxhfHr+qDM1P3xybLXDh+OtkehoEKsN4gOy3VxeHfxZ2WHwjrqcaKyQHzyqKd+QmZsQ5wgeDGKQ2ReBqnyMd32PFtT/sn4bGaEoLVY8P/cAo2RDdVJJ7dFkZ7KBYixIPBAB0vVO0naIWlCITwciObySaomPvjkais8Xckevo3pmKJjGPjquKizWUoAQOldP8AFkNeMvCGZtK8Cs9d8FTWGueo1Lf4qsDD7QCs4JOXlqzlP+IGPPFe1J+WTOzE/ijevPd+T0T2UaNlL6rxSa7NRayOGyk5cM9WlKm6fqd2YOsEJNf4VfAPRz0FdSYOYmD4wLbWz2nY6+iXFVjo5l5nxKyfascBgyzUkO2s5L7s6swdlyQeiSQvs4RusPt2hBXGokg7f3Z5sZxP+UWS18QzPQLyiTHUT9tfs4XlhSkow6NdWIbW1tfUyFnJXF/h7dAw5Um0hstfxMV6fQSorB5w3ggs7TdlZ5Yy7jdVpl4/FGBHb6QduiGuPY5tLqZWMgkGnuWDefVZI31xqrjjV4Kib5EwPrOajBGagCd0z30kjNDIfa7Qyd282gXpW1/vmoX6AEqLdFsRdezaIMJDwOM1N153di4zt8EB7VBx9MoT7+3+0jhysxzU9aV8hW2YFO7htqcqRENIqMwDDkdS+CM2oorgAD5P7RSC+NMxaBalZ2PPC523T9Y4mqtpLS7yYUzH9W0Ts+U6yrSJqEEUtn1FQwKmMGmuWqRo3yU8eFbG87R78W8EHqpb9k0/UkPX3f08eUgGrHXBXlwpgMLjfAxAbVPCLUPQcJS+6NgJ+LhC/d2ouzBN29JEnNOSFFwTEpyWrgJol3h3LN5VSp8YAKy7aFLIwZP1Mn3Cto/zKoEYGXoTEdispJz68qvhiNGFN5ObnKoJgiPAnX/pbah/UCrm/e/bcogzeO6MPyNhf0OpFderu8N2mwM0QKvdRLvX+b3i23KpOcg/StbLRUrg217dye5DK7frzS/bDNCfbz9XUCXvvnJkw0Me9CD909IHQ1SanpWp3pFiXK4EN85CNKWjNyKpIWI98cnuMfHylAEN1PrmUtTxU4MAYKutK2PywvmabArYNW2nhs+kp7ONIJM6CCtRd92Oh/Uqw0bjs6+MFCeRPfRfV5JigVvo1bgMRYVe2nw1hC3FgucgOxzOAEVHTbPZ3kplxT6budt+4dtnKFuuZtN4WYet8Y+MayXM7Te/kTRwHgl7hgN8oQtnAloSTKMsJ5mxTrNJR8SQ+NO9E01vqL30feGWCYEgEvhIEg00eYfP+w6Vrjnfd5vD8EhZ039FAQ7wkZqdbueQc/ClQZXSKqvghi0AvZYP1BzhHjuEd6p//NpzvM32rwDx5VI60gRDs8An5VR7jmH+QyZK4QrDt9d43zgkcjLUjst+Tlc64ZvNsUW0uC4pPoj3sYDo4Ibr73XNA4YetSphyRCjLF/SwvkyPCRccFiJcSeFzZ8HfHk/UBe+X2w/lnKHK199L7znjKUs4cZUHzgJvGsIIbsyj0ZDuGvwjGAygovIt6wYAeR5KUFjPp+oPoKcRHFfIlu7JDQf1RqGLPd/wovO5Xi3GEvZnAPezS0LdF0waoHTKgM2ZO2K8zZHCBLvlSpin7mQBxmDo29lwxzQ97UYlBbpUbyddjSjh+Z/1k/0AGhQkvW36mMAhaDe8YVs2bi3rlftmD4/8dYYc3G0qMGmW52UZeljL6vhhtq955/96JYRpB4K0lY4ewn7xZv5uwtpJmIpgzRryDkKsVRLKcl+mIIy9sAzbtDoSROMX8QNkAZmtPFOQx08igCJLe/YBDGgN3rKHGS5vZ2+CUUw8xLBkjIVuZycN3qslaRBSAZXYBS5zOwSdKKEITrNooIrqvCbvkiltpP762O9Z1QxoSg8ZjrDtWJ47tAKuirLMWwK9xXWLxoOLqfK0JQbUz0RBXntdkiPg1miXnE3KXtu+TsbXCiCsztTfydplWJvTLffeBgdhcKrUfEmLuRuswtyyNvf/3j7s6x5ZI8eIt4/Sl6rW230wk1BcTvw1qjL/UdoOiF7leRtcl3TBw1G6Nl5jB2ylKrhymN4m33hBmHf34wUAT7UFhuO3rt1XdaA9LUYP/LUvTetofJmLGloRbCAboocoq5/vzu2AmVeuu0hU2s5vezqVDjf10FxoEjYjoSUPQps9nQ90LkwRipPXScY6HeP6Hz4QqBnKMwoKCOdVeMCCsKkdmtrugU7arai14KASyDiTBywoUvMV5Rst3XoaVrS90nQfNdQ/49BOI+3QTBhrWi0OJB9lj3mgeDP0TMyXMWE0sS6xQRXY9VAK0nB1DzbBh8945oaEz2rUBcZqnec04mnU7W031XFR4RlbGHHmIQARb9I5N33cBmDzzt3oQeMW0Ih5ZBmjzGubrXYh2YkMpv4KPOxsqdwbo3zlz+UYCE/NkbSglNOWH2SznYiTfGaJj0QFfw9hLMy1y6mJRUlydYg1Y1d0noINdZwOPZ+B7yponJF7xoSgipy3o8Z/LLCKY1eoCkkuuT0m1clIRBuE39lVU0ixhPdjHqpIX33MOuKEMa6wJDOWpyvtcZRPIahN3Tgzoh9cy7tuaoQCy1a5g3lCA7udVkx/PqxkDIB4AgDWwkGtWgm46KV/QlOTwcZISD/7UpduA31hblemoHt5YU0/+xkE8aqwQ7n3xLxQWbmqgN3tCs6oRkxxvyElSMOYN+4TSze7XeEdz5sdKaY8OSlKUw4upokAlEsA4w6OaA8dG7jo12Ic+IaQAAfrriFbnbft0N/h0pTUiKdJ7QxptQv7nxJ3hU2PbM5Qweh5VPt/+Qk2fV3BAAbeOc/gXynxSBb32HYXPnz5d7SeoyrINgv2K6BQtULZIh0uRygbJ0paErDDx7HGjLIQ8/UFOZrmBjwr7bUW6dAIKP4AZT8DzbYR2gxLJ6+pbpavXfX+4rfgvmvqbWS2JxrJn8XeT5hGdZWO88ik7GpP2tXiTGhkQumI4DYkup+FMFg9vzkG7iFyCm9Luptk44/0T96rMGs8cfSe33OXWr0AOqq0QlU0dstEu47S2yFhcLRkuml/Uf4L4YH3kAHo7reV6pGeXHs2UrSPU+DJBXGKvy+7ak30VMwnC2PoXBii34CowJeSnEWQ2Cm59AEt1dJFEXcGyn3uZOPf6g5y0qUoCmYixbUSATK1B+s8ZlmtB8R8TClWMpJQNdqvytn1gmztm1IEDgyPRMhYJJgSBdxAStOXm+2mkSvyQelOp9P7/anyBf7zUtedlnNW0G5L4lh4q/luTe2EwiszooJ5cMsTOdU+VIm8+E49lXyy0bg7NCVjhs8ib216jr5k15MZRRLz3Q0HBkCumNLxoJjGV1QU5sJcCWwMYsW4R4xBylc5ZVQHAGnIJ2KtFg3A7awTsMx5DIF/o7gqmeDgCRx5ZYUrBRn7wyxM51T5jB1YpipPLWk6ZFm0m4y6kXoTuaWd4cB6LkrqZnE56SmpvINXPU3W2a/yhRdA0MuTDcmCRAn+O7UO10WlIy/G4sJJUtLQQFsE8Dga6wBKI7FtoVhSpe7GrAnFufwrPSJEXlGU4z0gOWkwwgrPWFDJKVDIvj0pMSBUaeNQKT0fL/13mvXt70fnaQxbQFbhdl5TrRapbPs+ezncHF9XNqSkDdTuJ1YPe8yB9wqzOK4TBZRbDalFbmyE2xKM3nYLVC/Nrmu27jEKDFW9gOxJ/Oh5cG2sWQ/h7gxwm5zGsp0eM8HYV/fRkKI0ggNMsVTHC2oKCi/qqgnpEQJOeEe5QUt5RavzLJf6QlQUpYrueSq6MeJAHOD/Bfld3m3IeJmUXzDnFy+681ymQXNvTgp8qzo1c3LgHUnel+J2dchcqGpmDXJZB9YBjTrZPzbH+8RE/uUntALQsjV8cliL6kBlxNUoeTlflVcum4H/PGWRi5iPgePt8ASrOfP2qH3hUgscr8MyTAhrnGbKQy5joc1A4cglvJFXridapXbXVmhjZwZB+3YQqZig/jUwYCNt6ds4Z1TOKw53cbbVj6mU4iJTClSZGHU3yAxwHdcuiUvYJC0WzOTjfUJ218fJyDRBoNptRtRd/YfzRQAeED6Dtikljy3hliMY0wR4BTJFhIqPxXpwNGDWcC3TIfTjDuRoyQDe6kQcgU2q68I60pDgOffguDiLDzyPNRKOnjXS5TdVW6g5y+n3egJGm+QLuCzGilUKD0x0coy3tngy1DB6HlZYB9XUDwvsAys2Eu1qJ9oaRmnHrzH25uEcaIQg4mba9pgZUt1Od6JIepCI1i0/GVMnTEdFg14lHIhu71s9awOPMdB+hCTmLsUIMYRel0Lqkrt8ZT5+O/1fv6jB/gJGimWa+CNKCQ5VFIbFA/zYosWBVNg+3HqWSq0hr/fFmd8cD/Y8nye1Oa35wiqvrfJ9VwW9mqlUwHkVKMI+fQ0+7Y/nTLi3YvpaG0uOzEwrkX1I+LTK/zFMI/owV6U6WKsCWQhpR8sLuP2BxLy0LPODxMuZPpbbT3rGZZ/t9l14m5fr9qxI72bQqIEfu+Ll6T1EUWZWpJtv/g7S8Xd+mCeFGyqj4CmHCu+IHojFNhi664MxxyLsCF3FiePdSwF0A/KDHTreuCX1/WXpgVuuGiG5kOtFJ+qdI02hImcNExbZRbuLckPmaeZ2W299BIZN3rQZC6WOXysUsRvUhvHOkZHGWiEKfKHJbetGxRF4/yfOvocOyghusvQVj6Xu+Fcye9vqmUajP6LHfbnI/ngoDYDwDWYXIG5ymapiDlyUPwi++a0UHtgVxFmoBFsd+hO121DPqDXSA5BObukq4Kpv8KT4+a+MmqUX1i3PoJtlXeRHwBtVVG3Fv21pPwkNE6kFtTmfK3Y4T9QBXS5mvS5I540K9MB9SCzjpq8XhDLBzmbIZY8pTVCEuliNA3h5wd+JC8R4G17bUa1Wzss48nXmWaIM0wVMPwaOsdG3TCkRb07ZHlJdXae4zzn56G4iLw+yp8BdTh2F9HADb/9a4cw37E7B9zw+3rNWe7XHVlTwANfMPe1qN8pSOtz8fHzxXIXqlLTe4FTQ6SoKjykHyU3DDroI1qGPZCAOPSKKqjOlfeT2Zp4RTndHZSEeLXaoHidDCmDZsJh0Spm6Ui7/+3zEJXrSfpqNJszPsktd6/WSSBgodeGZ7rlZGYrqB3hHY4F2NxnBAPI4izp7Zw1mQtr4c515/BfDA+8efMfyzZFbx6yYLs4nMGxgW+rX1cyiRYyyYDfv361vjk3zt6TEZbfTkJXvVY0/F5pW9VAjSK2poq6xbP3wzLSu9jSrJMbTWcNwiz5No4DSJl+TSr5M+mUnbcHr6lR9V3E9ZXD1ROeUmoQRX/HgIb8WtgWXz5nN9EEY+aG2aTrs6Q+aVN3Ez7AFE5tLkBXzSe0r27SUvSRX1gy4C1yQjlQwLZZFjJL1Fz0L8B1SoXUUfZK0zB/gCMS5JDxup6UB9S3h6K82AadtIf3c5AKezTGqswE0DMYmCh/1NxOnKgWwaJ/xFkInjYy/+TtCrcHRkZn5v++j3KHdVaXmD9k/mNO/S5zzFkVy0AbODDGvCYqhhR5Y56og5waxkeugCaUWsvLXiVeqJGi4nJi8VWySQ+VF6hdlz3Ttvco8BU1UOlCmPSxkM0hMKKm9JFhQEQURpD6uZVuDW+xT4L+5Vg7KF3612w8605iJMPNfnHHRgR6WknGIYab6kTvCxCVZOOry/qHzQ1n/asiSzRmOusAxtDKgVSgDXjGACjWvNu+DN/M000BvOFjn2puI+h/n785+a6q7Jos2ru8MlHw04BJ9XqPUeVL19Chlk3BvUc3Jj+LVbNrFxnFr8Ecb6ZpFgOo2ILWXss0CchuYc/0oEl8qPiYgofj0RZGgPfdghYaLsHsmKzNp+2GJDBKQ6nzMv9+OQLIFc1puIyVQvVMLMVb+fPWy/BgwQoVWqxZNjzFbOetdNQLa1kQ6L0rOscl4OW0ZrXSvOLzQTyJRpUHzlvPGF4Dr4BJ4jwWdoriK0SNdbb26n4AI1H6Ivz5vyU1gRJObn2AS1DuMRispIY+Bg5V2x/kxWrhWIFPZdWdiyceaeSFhLb0mHZsKhBXnFsOM9Fayf2ExPP837Z+mqspXtEPsiSlHjqa4//1rxCfvxH+BnKqTIiqYoH/P80SrnZOOICpVKceZR86gYR7HqgygAt9OLnZBpq1S5tqDz4LnvKWnq6J7fkd8ab2ryQlxeu33chvame6gvJ3NOJ6q7kdw2O2/a4HZyMtEU8bTWctrI8f4lSsDZN9qpxSJ1pyCOB5A+eO61O678g6K+ZjZ8FG3ksOj/QEY0D4NMDigN6GBrlVKvUvpIhuMnZmrQfvXf0m3T8rBCH4g5H5+maQJZG3YHMvQ5c62X9MaaiDV9kaWcUQYQu/Azyjs1SeUSUvqgtwg3KuJ3VE2bpVOO7Pz+kH0Y2LXkMM923iJYGzqoZc5ulxjk7JYiyHZnGFg9LTNAuo3MdodtvuKzrYdpRMcR+UqdQq6lEX+iYrq3julJmVL864/YsEGrd6l+I7W3ZPAvmWcB+NFW+u+SbvzC84Js7sql3sEJlhF6nuBSAv4Xj/2JN32BPYXHtVqOcXEvS2CZJ5XditzcOfS6dBBNIM6rrRRWJ17b1CY7NtymHx6HDjxApektac0y8bXHpLGf4jQ8Zr1HGRgjRvmsp0j9Ue84ta5T9iGdCsTxl20YCrShlNVlIr4QM3N9AkQ+59ImKKICygAV/yOiuO33Go8uzVu693f6v8Q9LhQ2Rxr7cfO3qIOdv5j7u1BoG6TBGn7TjYOji5cjp6oS33bHpJYlQk5q06vJpiy6Ji523MWl4wYXEi8jcQwTHlWQVMKj7SkJZX3FkbmqI9yx584UkGIqjccK20Xd5GLGpdF3MYKmEDbTMusplI7Db6oGZJY3mHJv+4k50viWP3wbEAphx6hUQGgNhhTElhBCF4EzkcSnm+MDe7DN8xEWGrC9hgABbo8F6b1f/U7R7BSel2f2Bilcn96CJFj8UPP4Qia6zNnJPagsmnCauwr6joQJWFLuAlrToBFzzTe7cFHetlYJGG0KubJYYpD0RrFQnXoEvoB+WQI3L+hScp1WV/Zcqu9qVeXd89K8tpaNIL7HHglGJYCEe8Y2tE2U3cb3Zn1dv0PQep9to62b62Gp3TQFB0X2KjZQ5hUnLq1oHBniThENjwJEYU5RqIS9qvrplzcnyyF17gcH6oGgJRSepvIh8IwDTWegLaV61BFVoR+81ZrvT4SLXnaFs/CYnzKSndWASghScaeishkEilBq8IPhjvocQlGBvPRQqG3CQp0h0tcpVfICXDWStMe2PkF3HoPvaRulKfmkq9crusmIvZ7N0ib+VrK8HxjwDCnzsoGxBnGpxgNEE2SAAr7rx0R5y77zy91vnMFKJqhHymUiWg0sDGgDd7lwWC1r6BgpfoWPqt7cg+uFXwCFgKJcdd9k24+wom7UnP4y0PDJmXuB2/CBqrmCVNPqAFGPvLvea2Su3jVDAePy27sgAnxID4uR6AlVywZFKXu4+xu8si3805CG1OAalE16WmKd0cpeOtFKzSjwwvmSw5ldg+oFhG7iGxclZryKH1Rk039nuV8Ux7BQhp2Br/eJPV0TvFUmXRmqYRuiV+YcHzxDNE/HRoMoC//kJCwHo9wQLu8XHHhkYnN4uLELs1FinsTf5TLwWVDegdcB4WqbldOAwQvadTXf4bMInRmZfDdTwHpfM4v/uxMAyOZUborJyb95N0U/VZE6h8yn/zLhuEj6ssDtWoO0bhLtVl1gI/gbRV+nrsiDROGaRrwyaVyP5XEauR71GE03ocGUH3CNUQ9GJ44HEaNsljbTf1Bmp4fWoPlj8S8sqFfXgvTLYZuTG7/7wwQ4PtvvBCBGiZh7UpB9XShJK7zbmUA+au0IfPG8xhdGy5XLr1oS0RzxVH+6vVcJCqXMqkZ8MIAa0cBj4j8SKov1SxtmgKChkiQsaFtbK8Q0lrOeymi301mvzVIsrhhsjin8zubxCABYKgcsMmiKJVLS3xImg4/lA4m2OCQuWjdXKZ1Pd3ChXb9rnKkFz4faPRFh7nfIAarUt3ws8xbNB5PG9yoAGTK7qKzhczjejunyHHFfOU8cGyfBwY9oIwHLx9N+5sHrKosSNPFDRJXzAG17i7hayEamPZgH4UrEKR3rYaNSM8qaVU/dFa0BBCTi+Ytp91aaUXEXxDKSSOxy5CSrQvLjF1VJ6dqy2YTLUaElOhn/Yo0b8n4KQxipDY2hmmuZ3FfYLa0rno8emjv5VHmjdMha/zHcqv6RGNquNETzjswpS+FJzkYafYkcTGBBH1B1hiv7iG60+b7ZS7oyWrTvDjr6sTrUaz3ykpoueWBQyZ8HmHnl5fJRoC8PQH2V4wv/YDcMA3XGGvT84CKsqMSWwKFccOeBwJRvKMcVp6dOBLS1OIDQF+MiY/NlDFzUeZCJKtvgDTd+AoNkjBuIGtyQoSEcam/uwzlu1w/36EhR0Ks4IJjKgywscIe6UKFTqNkpY9CzBCVKUNtBd0UdOOzXfwuPB9BCUPS9/GkOSKDlWIls62ycErZ7KLowS+3VVE8N6a1bYSkRf5KmfcXcqrMHbcXewSQq1ajTCx3pRfBenId71aacFSYMx6+al9KOvRyyzCgOOmBUE/Rfp5NcqnGKKNlB4A+mIaBvIW+Ik7L/NaDombz6B/1qN0keAVoHy3mFqezm53llwujazHOEF7AisuPZJ2a2zJx5omRbwSj0nb0X5MpHUFXpiQx+mcQ8ZepqCflxEEo0md/AVwYmuDwYdTBHDKwmY7L2U2HGeOgzOvxczWTwv1bHjPrNDCHpTrxdhMsuwZriXbBcwjx9ZKYShQ6Lk8hb3gOkX41xQCtl8xD0uHMJVJaJu0HLAYGwZzMDt3ygG+JZauo8iMdXbb9tqB/7FGiOEfARgtO+dIgf8dNLgjGtNOtHR+RwmCro6s7N12KnAIOAGUSrY43DMJGOGt5GQ3PjRUidMWZ/aSoAkhXxubXU9yTn4d6o5fYDfMf9NVOAAYDIFfsxqL5CgspnRvbz/iQEAirVvCkprq1JhTMZMh4685FIuAwucdprfdSyRJ8cfNmPHEBX2h/PR3iWv56nBioYkZfxD6nc54lt7anNELiQ/GclOKLheb+ToWoB3MUvOvXcY6/QqhgMhq7nsHr28ce15atRJ65k2Xvvaz/AfM3M7TwgWlG9TrWs27ZrSRiQ4AyJmvcecyGsVBh1uWP3wMYLxYOYhJwQF6vWddKKurSLViIOPUqEl1r1MPmEm/RvTrWs27ZrSNDQby2BMWjRQFDnXz1yvaz/AfLf9N3ujsIQdpMCmxiLWJQ8LFiEs1Q1zoAnCojQOCQZv7/VER8LxeNskJ+/BPUQtxqYk4MEGXEhaUytg70lBTo+6GLcsL2YTjUCu/2yqsnU+W/edVhCLebHFDQHy9OVlPxq3NYzsiRo6vzCV2cc6j576rynFamH0fp1Q5urMyOz8tu7IAMTT5/p39GjgPbdgEewdLccgpfWTbQoxelQNfQfjCisROa/RIVPM6563is1CvFcXz/VF5UGgd33RJahhmv3FKRQdQ5BJsMAfhjdj6xs99T0lgzHW1X46/hVclBh971nYfmdI3PS9SHxEHF+2WqwNZjPMN+ZaI/LFTzydsQu/M3GM4OFMvbFR4Z14i4zFHBue4WbEBNgSE1KyO5ACXEvvUS+a7O1cuPnlkJF2B4Ty0giIA+OU0y2cJ9q0GesYlrjxfu30JvMN0N3CdRqdtj7Si5JUOpfXk10CCY1IrmSVgilults0egujcuUZKQ4v3eJfyw1opYERAs2QZVhR2zJGgJIHc86RRntkNz2BmFzimTcZG1mDre2/jM+nzyKWuGR+IiDlCu8UETP9g8KnaU5X/UGJEAgzky7N4ufmaBkyeKlm7XSjZThLfjiiB++lk2nA/3hPNQIAeDd6kIErKFIsZ7Ik0DwZ/WjT8u0i6GRAn48jgy4CugpWoLIZuDv471NMrt8SggiMA3OHlmRXYCWHGw6RiBPCuzLmMApI4+BDtaJFOBieKjgk5KPRRYK1a7RevqLAUckAWo0cUBN1bx578zJ3ManONWg0NE3GsA5t3+MwW4dXScpxgXUffZoESzh4Win842e3T2nL/krUUOB64bHFszcQj/iZ4e/ylcmrhnMftxfZUdDjJ8wGnv8T8+E4DJWgupSuu9Sl3cKCqlkgay9HFCowgOoFK+jYdacfM31gGWY53cqYoJpLGmLRX4Zbl4Y8MnEcVLq8TuMiJAGW/cxeB95QWt64yuMMBSk0fGLDLsYltwyPKZpOHbZTV50DugyMIdadMaT12ZJRbg9kdb+VhF512OBm05xYPpvf1Fa+va8zqZ4nxjEdoCnEnfqzDo+2XCzNbAxBZzy+LJBxTFdQJsQE4giviF4wYOe/ycXmnOCtzeylUDBT2qFgSitKJoqtJoHEtovqpaTHV23CqLwKT9Kwvdvj5sx44fSVbx8ukWBbj54KPfitTVp3h5pgSMcNcFKv3L0Ln1Eq6LO8qd48XkIVzpRI2QPiBgddkc5QwhfzuQZKd4YVopB/vFi92R0Thost1bNwwi1d8672bACYgwLAfoUHOAyMZILh0E8DMZ/FG4KYnaRkOQOn2odfAldUx2VxhtQAbi1K1i7O2K6uQKD8D75SQFIt+VOG79ynW3ZHllO1g6mUVQGpONPcVSHEV7g2yhewKZOthgdnN1TCLTizZvYcZMnAMSx56S8KwshbmG4Sxf0HFaAghJxfMSt95IbWZpEOpyAHpxN/gmI8Bo1c8SJJXPBx3ZkZqLP+hzSLNU4+nVx6KEwbnxnsCSMCtq6cZi/27aTs4Mx1oYH+67/fPoxeeG1/+h8JSPTtarSe4Q/A3JvrAY9C2K7t5BrU2ZAIP/zEMyfaD0gfUzsjMH47a/yKeYz25e/jH7vAjJfZW3TSWwxibhs0iv7aeZcsxhSPGRd83PJlJghtpDdjrYhgY2Gtx6PscXwvzCiOcSTzy6whAzM7BLqHnN25EAiJV9ZiVTvXGgjQxl0qVAH14v1h8tA7nvoBqh75gNZAM5+SAEOQ0/MjC52lkcAXY0vDVwnTKEcFAtmvpJ2f7W/WC49E3iB69l9EwLhad5dU9B14nkXFdYFrpkGUcOihWtQVgBdhMRc9X35yyQV2HaSveUBWae0QNiFnDDYZLmDDDZFyp4nl4VtjsmHexTsWcaW77tVDoq0gD/cZOuDNsc+1/cL/f4aOVmqvv/CteVwMurWDLjYpvAc8Agl5+hIUdE1xt4YzM0DBzqZ3xuFjB0NJAIQDfCnLuGeDunmbi2DZzNbhNd/C48H0EJQrxFHIT02iwEJVON5C4kUmcNzXwP6wUu5R5KfScfTvKZ03ymwKHpxS6XKLNLhA/o674vr5FEQQj3c5MqZnNTolp3+fYzBPxlkH2xzf2PsVA00HovZMM/EZSsbCtBgvGwIxH/Dm+qChkb9cUcHz8xTw3duWtwcZVPvJUbQ8qz5uCD//RKgl4R1hmQV+VARw6AU3Dqb5AYViH3/PUc+3mX3cb5+BdWzjQ3GnPg7VJZ84uJx0+sgvDbbrgceEziX09lHvTSubMJjeiKOmOAzSM58vn98p5kR+uYS/Qe8mLPspdHV6M3ybx3jmA5UwWckXUi0AN+ptEaluWu/05ztnp5UAerfu6ipP4xzztIiY3jhXIIRgjtMRpaB5sjbs8SRYpVfDdoJBFBsIOYsLPQ9BR2uuxfMM0uAkANuEQU+Tqalqwj+PSfwjOc8qe9W5JEf7ekEqIePLuuEJ7qeA9L5lUQwL8DE6KMyPleullCCc+APUaB999meT4HdsKSBOaKfVE9BhZMQUht2KuJWhStldLrN1fNg5zi2R1ppPtAc9AnubvKxZm9BJWKm3AJOr/lro3QLy0/A1Lo+H+qZO7v4QHMuB7oVJGV49Jo9Tkp+/ePAL2K4N4wNtCzAUDxd2FjbZ/JzhK61AMHljy/621EvrJFKK4RPd2Bg+TZRpoiOCFm+L06jlEDnsITcRYsgni5PMfy2IteWbpCA9dIiQx9lt/1ApIbIxO9N8Abfwc3/+SKU9HxC3DutmUvZAViIH8EI5ixmYUJZcT3uaeURFL7V+GoJhaI56vyLMPGr3WP8ZlcD2R7splQuhbbji/OO9+OwRPqRloTMybrNtlaHGIUYx+4bPVDKVnGfPUche9LNCB/BCOTTstxUjdesGDRjNPFOIIr2eZmcwHws1yBAQCEh6A/CbQGIhsMnPvM2nml7OStLTHHG//s8J4lWXkilucfKSrwzIPeNgLimQ5+DjNxGQ/s6bGTG02l0Jzx+2wpturj4wgH43XmBs/7utsfrIGAVsVOB99+JWQRPMxf3kYKMs4dq0VYZG8XQK6lBeVhF4/CoFY9wABCU6M92FZ/1AsZknMelyEVpNYUa/0C/+B3jr11213EfV5kZW5lmiMvUrGnHu9vgVe2inkbA/iSUluDPO2lOfI5CFYVPEfCvbdzAqvSIl0qqkG4yUMJYGDT5z6bjebiYeDXn1z5VWDYskf8P7TenggYzuxCz21ErEGouDoGa45Rs4mv6G1e7q+IsJPyKmHOd3sVCys+78ynmeV9vV4qWd399tjEkMgVMP2gHp5eip3x+/FrVJ2Jh26rr8RUXkrFe6mwBNLPO5Z7eNkFLkvV++3nejUbPdsoGZr7l1CERhW2q1bfPA1BJh4wuKJwcNPVdjvV0lmvtYRAJoua4GaImqXG7Uxs5JeSFbjhiaw67UgjGMDsywePcoDjF9EvWnQapdOPmLBDQgkXgUn6Vhe3osQUMffC5gTRxNChsvxcouY4LBIC518XgUn6VhfQD07V7iiuf16FlR1zttsEqwSBUiuBEsRwLiFFUMjkb1sS57nMHOBtmKiAC0zHGdZN/O/GihmMVCkIhNYNNy9mhUfkIBHz4K/Kgrddq8/eH5Nq1Or455CISp8AqT/sK/LAmDK7jqra7ZbAFNgTRP92IlpprWYJLPev5YdEgcU3MyORN/LztSSaNp7Va+AcU+2ad3TAqu9W12y175wblzCczRNJTUdkBLCFd3EOwTPMm+72JkmL7P44k/txCWCjV3VT9tp7lnApmhKE3oP//IX/SCSk0Ks1E92p/6zwLGUOmqgb7mxJaNpFTeeo8ncD2U3liBAbq4sE3WLQlWTfkp2LiK+PSFiePj8GmrRKv3x+1+3lZwOSE/atDpnj8aCvVqMGGRvga0hG4xW/hGdQuRYniCaFNDnTkKRPcteCgGLvYJIVathOOt5B0D9pigcdOLFcTL0dort0WdPlJhRGaWnIIx212CFyCPrr2FRHOGoaYhSntnH0mHGVnWPqaHZh1582oui5UIfRYCDx9hiddTACBaeXSJVG/f0CkrJegFg/BcWt/B5T0BXB1MAIFp5dI4nfXl6Fz6iVdFneVOtUCgKUbkLsWX4izdt1nrB04K1heb+gA90cfOIt1+V49O+Kd4fVwd3G7fHYMGszTU1gaZ9cKSA+ymj0EeGIQIknkZdEgMRTYa2uHN45Q5cZRG7Vf4n5ACKLwvR94HoSg5w85JNWjLa5d9Y2968VY669MsE6nqaHZhzW7u85mTCf0De5mPdtFAvoisiQoBC67wou+Gqp4Qi21e3d2bR3eUpa0elswEF+tBpG96BZ70dtcjraEeDiarsO3s4N5YoNe6SyJSgeJnGwov5r85PI8sX9HLYZXkG9gck9icCcukwyjTmcFXhujZCiuTuk1UERNBKwfcDdMbjMMeQvGhXXh9xORaL9jMN7GcJNbB9ThQgF+4+dUxgQzwJC8C//QtFEZyYVVby6WhmhWLv78bxMhca3FUbSn3vxhUQ9Z/TqptIpGwh8E8DYL4vg5z10JdG82YtAyXiil75Xx00IVK9VnJvqFAf1+bZI1fcXjyavINKgSUIP8x4MKB6yRY8nb6rMXCUeiKfPYeFrujBWgofiMnZpxQreJUcBwcxXnGW4qR3RCZoFc+s+AfL3ZlgGnk6Fyu9djq79drjKZxa7HUyYv8oyhLywyyiL13XjX8p2C2affyht4jxh8Xii4QovZkDMMoZJyL4jGI9JJUj/ef0bOHflcVS4hKdd0jVdUl71mDHyzlI+Ixib8lc3mb+SNZomXulNX42QFnBCi/EtJMJgqzqTtGwmuFz7cvjCBVlze3cJAn9d0j8ndG5+5OMgDLawn9l7+g14/yvRXT+W9p4R3MwYDEmjFuBsLnzFEMUTmF5ru+HVXCCZbipHsfSZqTab9Fgy+18YjhGJIQf7+zpjZqn1LhHsSQuPrDUlgaHvahGMr5+NLhESPbokVcCh6HYvJuw7gVVPo/TIGiDoCP7oRXymoYqdaodjRiPwmTXxPWY8bFAvxW30hComMYjiXeuQwGHEZSbFGanNg/d6bFYpz+Gxw+M+AlgG0u1eBAPHWAqxQqm+9b+ErbqiaVgQO/uhsusuntAfxM9PqjfoirYsCjvahFaCJnQmia/uu596qWg5ZNaFpvDLo0h6pfqZm/ISBufUKPqYuhc4kFM1nf6yPc/IZYMn3a21e1OQJtl5lttYxI4TVnWcRHmoSRa7Q1wkp9PsdpM3syBmZFaHGIBDhLnucp9bqgccOr0uWMXpWyXShg6VLGhrfYQZeHUKXwkV9Wo6AalmqTdAnfC0+02oUcCcZs5IcEPMU8Vuqn01B15GfZHhUKXmBWjymn73QwaJkFpQ5iQDqQua2Vg05Fv87vHhF7Toy1MxrdPzLz9hy8wIfsbrdG1ME760dfX8u8S2ZgXVnC8yWylkna6PUM9FcgoRHKbvjGKSaklX8rOJPct+1yXPc5T63VFB7lw8xRaekZxI2zincjbPGoRHnzoQCOjhFzviTXzGFLWLK+nf3q1AsHIdFjJzNTCNXvdzVJcSe0hNUkj9GBc+BjuMim9KVTTrBUzxOGotvS0OYI4oX7gCfwcHpXYNhJ0uyEfHftai8QzzgiDhAgAAAAAAAASsCb3WHgGKNqf/6FyrhIAcN7f+qMwQv6ShqsepHfHGebE5GFFJTLKOqk4ohApS9obPtLzfhLywbaXZfwlU8fYSzXeoesGvlRpZCVz4jRNJ6RphQrcilUJGyEVltTZRki/9+/PwbXYoPtOuHEDnbnCBv6hrUZrLsS17hd4Z4WxiwDl0GrhMrUlp9BdbqQBZhks5EQJam+noQQdNkYpmuugIsF7pDr5/KhcimAlg1D8ZD/Hzs7VMSjo5dlCI3e/YxtE7eRoXp3E0mK+92sDqBW8RBotmcZxjwmQn069uJsj50dZApDwYET87cpH8jWhoV3uLoO9OudllCYC0hj4TNUUkPWRcRo0Qjr2OHXKGLds2dtcwzi/Jbqc48i+oMkTDuXIz2XFKfDrH4hNCfjVBQ6aNP4urC/b2tZsQq8af/VwZnRbCjnc2lsKAVT6tfNOSTjB2+sze2KSRxadvqG6GEVOIftOgCQC0CiLdmtIqPyB32ORI0OB5PMg3U84sy/V2CdNc5GSwa+spj67FegEkNlSxBYaGpxSJ0fEcnMUq951XdwBnKS2er5W75Pf7WVwAsljfFhUvyCvME34byV6tJ5E6IwDBWSFGVIH8kds7VOkW+Yi2nF8PeQ9F3FiziW0nUVME7umXpaJiqOQiH4XUee9xtKHDxuKsKr9LA1gt0xmwUUZDtwov/fYnwUtT+vrXR66pNQND/K9hrjf+5g+pVZoGzwLmKyeo4mme7Nm6zBUp3e4wGVMWixvGbqhVzlSm3WW7GN+1CjPUPcoRhtmATav7pnSSKWha8d1I+L/dy52aC4ZSm5qg0+JGN0r3z6Igbea+Ej0a2DeId1o50uFDnqwN2LHi7PbMZIM30bTXzy2JL0999DL7buZFfSXZkZYXYTJAf0t6+a9cyyCHpSPz7NNogIJUQFrUfw7sjQFoYPiwvcarNTv5zVMQycBlea9qePrKCiQ0T16PgOKJjOt8+lhk0i9lHvGFQwMBDSLTez/6ieKbJqLIaQKeGG1JSFMRciw2IGrW6jLvb5xJsC5Y1zXRvp0JxD/M06wpAL3NK0JE0RxQXnInc8xlVAvfTB/dO0m4aeH5bnSR8WidTk8+n/pBSW1v8kmfielDImVn4Ff5kL3SypMHr4ZWrheNbRUy0oQAk1c3cdiXhSFtQzooh//k//JZse5B9ryF96FZuoRCpMBsmLIhMqwf9YhQlh1d5/P2AZJ7tPFurW8ry1NSS2DsWR5gty4kJVaeQPB+C142lH13QHcq6jweNvSMdNf9LIF9MluVqdguYphQJKVwQ1DF48dsyF8IaRCX/dudQCRKQQMlrcY1qnwQbtnYvG5kgutYWWQCyFsMxMDQU1qopzrrm5SWcVmVX0c/ZvmEfPZqov+VqLX6JuBWSGQMDxF0bXMtlrStIQZ+ArKk+k8J/TgA70gYE1vu1EL7P8OdVcAIHrYBpUqQWIDnA2iT8B0dFsVGTVNp4XdAzP2/F5XA/qJ+KzEflbkhGBXYTwyEZFIIfZtXp3XGehX5QCNuElGZRE7fZVd4o3mlF06VvkdJBmnYBSmon2yUYE2v2YssvdWnsHRjyac+zu7AF+4tGa4DzJ4q2pNMT5HE4pupxgPWor3+bWuGMwVd++xUKYLLdVSUSDjd/n7GDHNTxAsVR+frNp0JP15GOH+fZ2IMSvPWacxIki1ERJi0GFnaY1PEvXczZYVaPyX3GNcPLBriPJcEDu7w7h+J8sLZ62jDvJ1wil5LLle1dq+jmxTlia2uvwl1EnlAl1oGWGqGID6B/lnksVDwm7k26fl/yq8MHx5iGlz4FdIixlc7/t+GF/PQX8y6DaUawGBnh9nzBSNKUpIzq4bKqvJGrUdOiqDi6szH7QoF3vzhfh4tVdkVVYnY8T89QlG+gnPgQs7q2MtoMAFKeRdsmZcBl+6qqvo/GyEzSfxZPkbVPTK16b5MX2ZpBSrXqNYTIs8jdKct1PAZvfo9708+BXbUV3E+DN02kyJMdnVknhF8+apDGJrWEurgBL76z/5lEHiSBcU6e+Maw2/HUj6qe9MNMAOBeV6pXujaKrZzuJ5wB1hNGhkbBXjsloZeXoEhcH5zp3Po08/7a/OgTJHWO/N06kIxkxYnEpxsPhFx+ja06IYiB++QZ7c1KQarO6sUD/riiM2gyJ3T6M/a/S2ELolUDczoJP882dsc5/e1IX+3E/Rei6DSplxV1Lc1YulBFR4b7kTcdTQ7XvAIkjH1NLr6D3R9hg9+5MjQzKG2qgaaJKqkzmgy3HIqTnXYU3gQRqt4GM8u6zp2TYRM6hr0k0sXSHl7m9fpJoS7yPUnfIGvc20ovtI6951dxRjnbKg5AQ241g9iL4+HlvD9vUeQiRQYGda/gM4mS/0KPOEvjsn4D7PPZM2hXtbDKxAz/p07Ucv/psQC6vkJVKI0nI3KeS2T/1SiSBTf54k2ZRKWCmmKEokG3Hna9MFqJOiRRgCQYhD/+Ap8JnQYUJc+vhv+YRlGIITCfhXczss/C1PvNvjid8uJ+clBU8NR6fOyoISx0/0m3gUVzvvnVmdogX4Hd4p02ia9ieR3rdnbzyZsWEkj3AKJFY5uDJm/PF1mrH7Lo2yyOf4HciZaFDnFQfMbBrdetLAAZWDG9kW+UpjjCBL+YmWbhfrLLwUo5h7pa3rMnnIwuNyO9AfceM5rJBQktot5VCaXysLBGdIqAj4YNnazF7wBJ7WQcMBM5U3TKj9XhUHAJhOzGFX4SFN/RTcliity0aIrTC1NmR202ZgnJ/iB90tgyETvZeEayGJTEEFBcKdqh35lQl/+ciBQK6nT8NcaYCY3qhNeCyEIucHGVX56IDQK23uwTeIHx6o4ifLdj80GeC3liQTeO2h9epBULtipj2lRv5LFIXsNntSaQjaPowlqUYboOZl6hBIGkxW8PRYGEFtGWausJTuNpFJlwAUxhjMuUwuNqxgMWg5g0fpXcw9+8Ep04Pva4k4H8+oa3sktx77regoFuadBIT1JuDGKKwVYX92zXSgrTPrFydEsxXyCfqlSSrJeuK+cG2wDZjguTi8YNz7Bq4uOgBlHG0zgQ4mQZZND9CHu9QsPSbm+kB/dbCZOAhGMRDjGiwof8aeYKc9YdHMcyHSsBfaI0qHGbneoka9XPCrYrT+ezRtbxeVE4kVSMzF5DO/BuNUZt9TA5eI0GBwnWoy4VGjIopQ6SVI0l9ax7KuMGoSlHlKrCmb+iCP4pIzFIgvSyl9tU+B0rA8qnVEc0pUVwsAHdsGVI8Kt0sKvQWE5N17bYZXKRV2RH1iThZpzfvuE6Oh6xnmbDgB/NkeKhhYJELY0pBGolYLgGnY8Q1/NWeCL3UjGlvumjgIhE9zTnckSEr1H6e7w9sQLmhGi8u7KErCS4TZI1NfpO+R/mdObAZJq8e9+9L+XhASpqVUqTVzuR+iBN4MGd91MgtENUyWODJy1ABlETcMLehtv0TktSJI4fEdRwRapECqPNfIMLXZRmNvnozXvWYsijFqQij3sgtxi/0JeOsco3nd3OOHny7PAbfqbD2CcLILiVeP/cvokDOrtctX2PkvguvhqQnZqNebHiS6toBERpo4+y+2iEuN+OI3VwiajzM2MA1uO+ZZDKBQWsBby2XesZpZOHmBRw2qMnSxrEfjrWKxh2Df1Tm/2TlKJ62g7jQj9IQVONqcRzsVFui2oAzc/zvAzhk9Ql109bP1XyhzCTUAd/1NsTQt/n2Elnr0DmKLBsObaSsd3DptbqWzXf+1QRr8dosMB7skh5+/Jgrg7kfa+MrOHqY/tjlm8ggKFz9s924feIDKwLwdyCQo+guLfjjk9X+tB3dGoHc/R8eiDdSwE9LpAyDBotwyGtwZ7i7Qx/xggmhw+X5XXiu2KdqwAWb6UnT8UUDcZNjiKjt4tikla+ReS0A7mdszkAL333rx0hEM+qKCmeBgCqurIBWvd21epy1pyljFfiEHzO2gzC29OrGigi6liQsPdvvMW1rCcnZ2jGNpghW2imEJpEJo4M1j7bGfgEmt6fphsQrP+QIe5MFURsw6hcLQjxtqJT1NuZcCLtVBwGHOPH5caxrHfNKOYqaU7L3JVaFU4A7++miHbLYawQnjYAMCzGau62iXAAnu3CIunP4HFYvYoqJZoOb/TtnYNjQfAOQyvWx6KRYJrYMGLVwHBIzDLcBhBhWK1oKzaMjckWwfh88iUC1ISmOnpXVWvYwYsWRI4dJr9eR3e0Fk2RfeP1D3P4SjTfMAP2Q47sbh+WPO/nL8SamAhFywJVD3chUKb4zlf8JUDGAvIg55KJ/nB0LOg5tI/gD42orQeTuELqc2FDuRMpf+yIToZffRhDSbI+DQUieV2jjkeiBQB586ks4ES3h0pf9UHcmdIeq1dSxaa0CPkBxDJmYsM+EESeBAiRHkiES/3fGrnipsx7oA0HIb4EYz+3DkLgUMIaFMkjhEGwVgTIM/6szVM6UdMhHHUOBnDyHhFAB8QeU+hsyYcIH95xERMfAy3UuftU2PV4jwMk0367V5FD/9b1dEO06uXrZchWG14xRcptyjkrT4mxaEqyFdjs89OXuoEmKFcEAqw48gTFQx24L3zegFWCk3x8Z2IqRHcL1X80grMA56Mk5Qh3y1JHzPtSYqaBuYV2TeI5tTs9AYzJlpPn8XhIhweYEYYJtu7TRSchnfruiTsAPlVRoGtgZGArOUkKl9EEHg+dsgXh5RZBMGnNCIHDs1GM+0kohDMl6MRhCgkyJOE97ChQxZpysKox854+e4hpoEY7ppieRGW54A/1AZrr2UoLWGTvorYo9U+czzxQcAohQyKE2QyLlGYSLF3sICgMYzA/wOaF2fkko99tYDjHarFaPcyyJGXuu15a3QXlVgby3OqlgEC4h9e1WXH7UMgM9im9Ec2zYh6ppfnBMptWI9Yq54dBkBsgISapY7Ikw6BaW5yoTWw1dQbZwwWcX3kbeYLcP0lrpOU1xwlwdphKkGRyBhPxky8opFU7E38fhOL/EXMFVcYFdOeVxqEFMohVdnQLmTFWwRA6ef2cMxj1I9pcwB5JKsnoqeRf5YcqvqYftL8PfXIX7B3fX8onnzCiz7gtpEdOzE/kdbh3Wii9d/HuRuXO10LK0fHMHTVrt4HgP3PxPUjTDnc3/yNZfiQYy+M4ryowveWAB+BQOSdCdYtDylGfPsozTQGHnRx7a1GgP6tQiFG/eFh93/ry/6n3/t4jbaLRaLRaLRZQ/wnuIDPDY3oilNTqnMtXg0g6e0PRwRyrI1Ou9Zt1hdbpNJjWNwZ53LcpQcECvsL3RT1CyqQHGlf8H2TTt0mEQj72rVDH/NsxlRfBWWDn2DtoTVf5K3I8yVOR5oGO9DgXqgraTHD3JHCFLmSuB7mVbjveq4ThtRjkrFQ1MGkoSEH1nqnlPaElzWeatXAPHvG92ZPmq4iZ1aYKPLz9x8CatJ8La9+3IgX2h2NruOqLtf31j6odtbPH+Ki5oS00GIbAkdDS2OMpN7n/M5zx98eaaC51+t38Va3uz7cdJ0enp5rWuHGaKRjn7EMSwsy63sWWocSO9xcC6SQIPrgIT+HG8x9YtYNVpfW0V0tAShLayz0zI8zCVqh7scZkZG/TBGYG9RVusWfNso09R8biZbAfe9x7K0l+sXHSrw8mAorvOGU7xQd/++MfYmGQBXqmWrvAADawPqTmyA97T5ZvIr4sq6Cu6ldVz+rbWu4iHh+qh0tOlyVd5h4WcW0i2EkY4eiBHewSq/nzP9aPqZHSCe3jVCKkz8lt/mPQMpLyOwU9wflXQdfcfBqSH8l+AiddebuqpxV600C7PrX4ID47JKUMHrL24LlWpFsk8YlWtLpQw9W8wUZuOjVAXLDx0CmIiq0LP9K6eiB+hbH2rlvd7H7NFD8q0Ql48cI8mqeBX4X86iomX7KWLWHWkuq8/Vm/6oDUCav/jfX5lf43gIuux3gvTRO5MRr9hJcbQxM4Lq5ADFNQROfeq/SiRysCQRL09NVmbAMp1UP4L9YtcUW+S/2yboUlpHBhx/9j5r59Lizh1YOFH0xTxxgm33EYcMgFVobH6rkEpwRSAJTu5mpGj15CYywtIk32qnbShY16SXhEJPEe9z93YHzeN1EopDh6SVUGgTZAEbHrzbA3JUsbeLb9M4Q6vOoLW4DidgVqDBw/QT6FZ+zwY98oNglOE8B5ng6f9yWTGryicAfwdCRwYW5LYYy7jLIIFQIZZgO4QDmpgiEbL2ywnKx9VzbBNfcFjBaiNhd9aRXMaeM1/QuDI5kI6nz9vUYPJvQCnflxvxZhDZcsvQ54GP3KSFIkfSql6wzZxGAi4fytIRqxTnQYtpIhuvmc4zE3L+c0z2xrKNGSKqQYzhzaLGBy63gMuZewQaaud4N5iGoQxDgyxPdnw8rbx09GOpZA3AHL2AwKICSja2PLFhOeYMTrebEx/KM+Xh/ZaUMUiKcxXNI+Iw5B504JY02lV3n5EBpsFyn+aVzIopRdr+3nJV243pE503gzl9rmRvaxJNq43t6Cwkt+SeV7z5cpOKdje4TwcBX+bg9FMxnxWEb6dpZ25gM9e3MyFFWW8PiGpqi08mK8DCj1QhIO0A7zDLkJjU8QVFYiBdnuqz2CNqvzYJeJ+CTh2gmRK6e9E2uOSaeV0ypjxZaaQUjDjkCwOOFn/kAXq//zuBr/qgbwDS57mwm+sGalQG+7+Cl1Ws/nucZkry4jMbE9PQjcRjKqeGo1FMBEmjEWgMIJSBpU4SoyTh3sQopuGD540TyXpvuKdeJ+qpk3cN/2HZgGFHGv1xk9YrR8zqHu0Qx3ottin4GL3K8sGv9/YCdR0BQFSUGYHBXKt1FynNOOlArymUZweUztGo+7iAiooI4wDVU3LiJs3Kxmv1jhR/gQ5lBclwlhQYn8a4b6e/8Yj2nG0KZ0TuPZeuDAXoWXo2I2yng+kvnI9Xtty2E0gfdnvWOYElJtcXRO4lvMvp/+jbRoM0H/KrwEUNewD+X3PiGovoBH+B8/tAiwuRw8sdt/eEBnk2cLMHN9KueO3MXSKC2L1oSorNlclMYlGS0fq+KtFrOizc1A2cwsj21lfvPpXMP4mP/b8eFejxgkYNeIAPkhu7tLpsfjB32xT99gWukMxXmeLeCg173FQsLBnw8r0IAAAAAAAAAAAAAAAACi5iUE8nkKu+kysZg6MCOBskJByvcwGmkhr4tFotFlEliS0ExmM2ckhg0lx1YoffdgZj9ZmxcFV/1aCWgrPzyBpRWBkSHqG8QWkPx96eQXzLXtimsGdbxj2FgpPdLX5TUuf/c3AzC/HftrNivu2wkbEl9uTSJL0IHZaFTFTgmLcILdUtWRCH6fh3kqNseTFCIIf3CoEIH7Ue3YE0XORT1mHXzEBxmNwLAye5tCobZe1RkaRu5gEBfIo8E2pP65KBzlKRhdTBwfwi3WtbwTpPZYdPBTB4whcGo0GywyV7lC16FxBWF4Het5I00GamTuxEx6qS9lIOX2XGui+axeu4eGQoiCJmYpKBYUdjX9MmnPGcgvcCldml4I9dRw7etg/2iwcN7Q2MigCxV5D1aYmiia2sjQZgyLCEluwufeZ7UJM8qDj3JNa3F3PR0Q1qACzWxMBPs3xAGou1LqotXDpLZOnJHUtg3/A/Oi0Kog88dS+KqXN2c12RKV7S94AFFHfKZ8XFCPBafBZLo/G2fYqvFgsPY38DwesWEYJliPP92tO9LW9S6CGXF5xwC6DaGlzdi/qcfwdlOcDecWyrl4K4iqXcWtbd+dhdVXpL+IO93o9OoryecAMScUWdxBuLfMxx05Z61uqDK/jZW/sJN6wsAgFmCZZOgRyiMUT0riIR1RGhCNqDkITHXLMYLLJMPJwO+aPAJw7fXchvMh/yGD2Kfd9cIPvOr1k+qf/zamqZr5VXQcxTLaOy94fYpbLmORROwqp86k2AP++B73QNG7elBN8TZfkvfB4GGUsxWtUIFo8t5fxt9ZmJXLRNtH6pp9y+dtpU8XryMeN955Y60rqKo/J0omTOym1tZtvsQK014Fbwc9EKCa+2RaLkNLoZMb+iTJGascgDsVs/SPZuI7e9mZW4yrY274fsDQGMVKYsfe3QdMaKqo+nbB+cAtNqx/lCNXCOa+SsENQ/rVOVU3aKfsGLHbj1d5vx99hrBfN4sJZ1LEyovKCVPM7OQKWVShfz8Vea8BfblQXNZ6BOwWoB4MwzhokJKIO04aSG95KNxeDaTf0+YgaJKVGGFfiHdhhy6wyA+1JzUSp0OLnB/yNwT97tPQoRmV/VLx+uA495bwV2cGLdgEAhAZM3Lxjwo003xQBGRfRKBnyqdDmdUj/YXYPqTCG+acx3erbYQBXUZJ1wL1IUXqo0kVI23kG3kKWxjhnc900rW8EKNKuhKr2XU7RAAu+8AfvRM7MtTOrwrv2bbEIj+WfpIbLk+DKsYw9KsdI2zcCEG0JtRhDemUqkg12CYfRxZW4aGHtOUOKkQOhwyiUZOH42s3I7FshioAYyVOw+BJ/QSVH52VMQTpx5Vg9cvmq3uzMB14/wJai1y60neFFYidnSkeddo2qlWCQ4RBfCvJ2DqZrYxLSv5vVFtuIAUvGx0Ts43BOB5vNT05I62JbEtTrFb/EeQcoI+dPBwc7odcTM3VNL3IHhxctE+qzcJWjMkDYNnEoBnmaUsRqtw1oYi7zzDQkFh4CU3+Vqlmv45fKo729sRdd8cU79+7jpAArAyV7SvMly4gm7jET4KPAG+9ZDRlYB81/1um60FtcCeq8tkFMwIYH2+HwTNIiW46Y3ejIBfp9YSrN3pxQSEl62/UylNuNGzCet03bIfHQwMqVm+1cywn3qOaKacyWcvk8oTi8SEeBSnf0O3OWfBG+ToXXsM8n7QXjdaILdGlJ6Qe1jXGfDj66CMgikisvJd3sO2CeEwObRYA+SHpbuvT/+XqkenhksbS/X0b0zEzYaWSWp5o8fxCuNxOl2WyuqC4zbLFjq2/CP/BsdL8snrgqQn8V4bk+/z67wSrxS20mxh9s7P0G6EBR0JIzYHS/rlesi1hFTdL/amcfDAZ0ilgAOhb6FmT+9k9otnB5HFk9NadzkAnVkZ6Fe/mP5PdFKEGIBvqfaNxiGVfXliYiGQ5fI6DytTR6Q5/DVbgcUG7pk9WMGi+6GmQHrUoDZhuSOe7719hM1jp6aMABgmPEwFfEkS0Y9AaFecOuTVZFoBYb6uJi/rPITJKOHAnCBUouHsWr7Hq6LzU52ono2spzLYvMGXFrts3dPNSJ+s8An9KE5Bn0+OugRulbhZUDRkNkzVKPYNHqyjn0gzfE74O7FZEl/POtHc7I/W43dgrxLST2c6S/9PHdXj2u1OC4UNLQysYTlJS6NdU15fxyisIvhLpRlk8EQCx3+4JnC2vB3qP7rvCaCFp1Nq1WApi9J/pRq4DHg7r8ZeOYTJuBKWY7QHLG3YqC4z8RVLov40pqrpxphvGizHdDNvT0QLMCh0GbeUNow4YnhnOkyD7FwoLaAmpHZyE14P3GEnfguo789F/jEb1g5Ol9o07YzcVSqkJxXoiwlqIrq69asyilT11s01ZhQxOxqLBisgUMokBRx2MnLfiaiXLRME7NNOyEO+aKnO4C9nGdTDfuPn9lGqzK10iYlCy17lKtO8SAZgQzEYSlukzh1NadSkHlBAAAAAADuKu8Ydt9ePRq5z4iDukA8VJ8exwx5X9xrNuy1cLCLRaLRaLRaLRaLRaLRaLRaLIEbDvpP7golWmKtUwymIRjQj6UlVAOOPTEjUjufRvojahujJXTot+vp+2Gq5wOBwOBwOBwOBwOBwOBwOBDECa6/NsXIww9/nqvYsiFiU+3VjxeCkLFdNojexGjrPlvHy3j5bx8t4+oE9r1eQVR21gEV65m5w/CV06SZvsCFvYWXCgFvcxo/nZq3798OZ0jv+PZB5BAmHXEHoUqONAP+uP7vUyIxBwtdAAyJKUn8kIes1yazHQmxSOP8Y0aB/hMqTEyFBUbYWtnk3Oa3sFxzrXJ3Bp7Q5FU+zjcFbpDjHAQa0J1GAxIEYxTRFI8W+ieOOghZW85ZwT1xLTxd+fAKWahR9kuhPcjFN8/MbFDUEoH+qUYMHIiWAYL47wgwJFih5BV+ytyVVdbchBZCwfomjo+hloTL5O0MvFXrPml7BuRABcqRpPhb8PuS/IF/70GBoKgo+V1SPvdOyFE93dEVcEEVgBwr4zh8fysnEidRhA/OvGeZDCfLejl/MiCq6UQ38KY/lPeH/4rETdY7pxw1KnU+Rp7E6b1jLFtz93g1ps950r1S3rBNmfGviJNC6BdLG0HjLMq6mbgYXOhp6EAkTQQ626Yf2zFOITI2POsDD+awbkWt75IEkgTafN0v6UymD1rQN8qACI9048KRkE5dszOCpXoNHVfQTo10QANnE33Zc8yDkApOzCITQdnaG1qEef1aB/qZFueotLZYxbkHppNyBMiaAQCM26SuyQMF67u3rPOhKOV8rpsTGDwnQCKYdluMC/DCOdhNuo1X0thB6diW4RTqVCMPlBc56ULJPJjqEdG2DAQQ+Tli5kzVqPhFjceUTF4ak4v7Xak0h4aJ78o8S0sdx/N2CxtOZDv4KS7br37gkYPiqhg9MFylDOqUny43HLeika8Hk4vn6YCHtVZZE4zaccDktr9ZbP4KOQio41tbg+zWlculCHpSxBIK9JQwwCw8cAasqnuxD9Gc/e4tyFc9Lj2GNzxqnXE2BQNA5VzoDnKHX4ze4YY9lVjFs5ARaTKUg/JaJrNJZQHn7OeochLx1rieVyvb2i/nzPyu2Jwz6GZbjXrbL/lzvNZ6YApwNhxZ4BLcyOOYFXHqUwJXBdpMpSC9vE7kn8yMjyCdmu5zHlieGGU/1F+AO6pRjb5igDtu18PYUWzQHLoqCp9/NQNeQHHn3d+t05r9OgZC3MGtgCj2p5zwexbiL5+gS9F5YbgYpFCGkUBtBR+WU8TB7LNfnMs6H0Ma7bHG//eIdWG6eOghtSyxm5r2QZ9qLRYV/uycPvMjwsKSHIQGJW1r1cf37V71lW1SfncF9ZF3BITjUiShD4fVRtgqRrVQJRcpR29Ev3QVuCmCXgZOcgBfHAdSBkqJkOPSfIUIekIU3rce6bj6PAMCwMw4cqOAllERopf0XqeU5K5jp6CHBwgO1yjkUz/QY0vNpsfcs60NlID/9v2yEmHHd/6IUBwi5tXI+ugK0RHOia1MEMCcMigtPAnRSW/mVA5AyLzLceSYl+U0TVHRpNSPATfqy/VWIUe1cd6LeYetd5tTIztQS3bkQj+deSwvRoL6dQZdzbKomlOL3Lb4uRfBXyl6sWSKlryHXuyniSRuhn9qMKTJ1jAmVz4nQaeCGkYP2ULThuY2sqw6DMpb6YHE/5navSpWsYsgXW/iddnGWVAckun8Yc/Mqxeyh/0kW3g6b45mSxlrfD4iAsJ/E9GMQi3L4AoThCo1RzkpQ/KekbkDZGAcTFick9r2rFjL9NoBkSKeOzydDo/WMCTD+4KteAR0+GIV7yqAWL/rEpwXLOVhBZps2X8NH04FYFtqQpkVOLS7IV/wT3IlUVgiAKaxBV/CWR5YlV3eJQGh71YoiuQOEpgzf2/XlEVPSrRL0WWhjuuAAs9Q7ICShektoeeTUqyO4ZggXbn+r2B56w78B1h9Oq1WHWeZw4nyKy7BTFuHmHAIIUsdAb5afNx3BOd30QvF1DlPm92ieQB8lVkcuAoTZ5SBLcOkmc2hXTAjqzMHUdidC7lUVBJIoejJHv32EpyjYVqizWvRgBXBHdLJxeMMTZYIgBBql6hFYHw7G5cXZ6aS1bNcEPn8+NNuA/D9Avyczes/3m1x25yINP9qP6DpjkjR7MgAsvchZXubpUPKublZSX6gUCNqfdLB3Gt881AAu86nuYxgIbxS7G8nTy9ZztP8UpTreXIwTUDrYdfB9KqxuR8EOxM1ixMVTKU3Z91eJPeTIit8MlQjrZyjzLdDZ3OFiukCZOa20/drEnGh6pKNOjvJiSF4VozmverujgqsXrCX7OibmWc9H740FSHU6VYvrUkLG+EFyE4e+tn8LyLPFXYqSlxpfxtxjDcf84VApqRaqf5VmOPirExp1s2x+u7ajSZhq3LRYgrWui+NvsPM2S1AHYuI92HXpPeqhw1zDe+uz2h6orsLpKg3QFGQyTmo7a5xYWPlvNWK9J3g7yBdqgVTfqxxTVAbUZ66ASRXOn3ZGn0dWaaATs1PgjVj2GAbr+9GWUO0BCRblxwtMMpN2XhhKDR24v8zYFZ4ZscJZL996qZHCE3nrs1gaQSXZ8BjnpAbeKRlx5yBtmqgqmyvl7ZHLg3o+T1917ZQ3TpSng7dHvT9+P6W+4+pgdsXn2aTAFWcQM2rG3TKGnkpOI+EqwrvMHUKhWvZ8azwYJI8GAYg/8282UlLnIhYIBkD0xAsF/TEj2co1+h2WoSXXjXVXQcjgiW78I87G5ljfYanJCYlMSHt0lCHGZkTcnqoRDtw8prtR/aYLN+XSY9eNzUMAnN8r/v2kzAMrSuNP14uuu2lY1T+BHNMpcDezHeEBu6/obsfRguMZ35LtBr7wngqLJUr/j3uKIMGCwTdVVe2xdVMfLfW8i9clJ8oHa9LhPvKBbGG+eAklo12gVgbpWoVBkoDWOrCdOWgv6zzuTmo/yXP+yIxfCdLSwWXuiMO7/v26QUkSxMvG6ckx4255kLdhg0a6xHBNx+7Fe8Fpc2LMXay5Ksx3uW8hScbb9Tf07TaSOC+tZnIFNlkMkPaTIkroKD+kegQRbmyrG5TkzH6wWhsf9qDI19KR7OK2Odhr39mEYJhGw1zwOBjlbz+tRBMhAggneUnfoiFDd1p+TLMZkh/dpLGmSp5TruwUCjFtKsip8eZktEz585/Gk6+rVnXLBOuwJ1CT8b180rFuk13zT0TJcdXSJTQuqPI98/2FLdxwVX1zK187HiPzXBs20jKkrpOjusgwf+d/5Bsb/L8x9dFpUVJigoa6j5pYliTJZVXDBZHuZjc4sxcH0zoD2Cu09PDSxlgxc0+CMKF1XJ2H6gTJW/IViOiquCF0V+j1BPRdQU0XoRxPW+9alf40VRiJCVHAye/LcfeGIikypxMPWY6CLsCys0keXcPsR7UQgaRgTXk1mv2BawLK9j6wolS2ypQEoBxiTvTco9FoxbByBZ30UzFerbWiKOQxHZFNCX0+dCm9sRiDxwdbkuZn9hneOTDkS6bi/mWOhQHnJT8Wd9Z+xhIS1LjsJ2weA0J0o8IGyjqE4a9fq7bi7QQs2pMcqMvFStgIUdGB52ZEQf9huMkcqact4kWS3LTEO4okTk52h75E85pJEQGHSeie0WXHOKHMpk54hwPIK9e8XXpXo0Un2oCuqWdi5TvQ7hxou9eXE805/7hLXjiYa336nldiYxhg7ssdUu2SDbRq8J47TCxXYEzEdFynU9vwv/JemVFSwor1CnvIn3zBAZOdrAt9/SiEDZKGAKP7Q4bS5PIebL1WV2Ha0dRN3AHauroRMdyzT+woRrLbHwbap2sHvphHXzsvMNje4x08HKA8wSIIQlur+0HEBaUSB5k9RvzJvrBQZS+/cWorX0EdAj3IoqAXo70yjC/avajwcKxDjg/b5EY2bNsRIRxfHZVWByJbcQ+KQV8lkcM4HA4HA4HA4HA4HA4HA4HA4HA4HA4+QTXDTnRJtlq8iFviYbMCB3FXeMOw6utAs6mXgx8ue1/n1opXUkjRgBBhF26DoiUc7RoxwgXIqj8xkKY0E4AgtIV5LCphnHr/dhVBMUljj9M/G8d7rcIQr3i400f7HvtjIYfhdYENz+xsbVh6IlLGnR0YrERbklcnGXLESvgJfAOKq8/xTV85hAVnqaRkucFgUawFa74I9rju3rfCobTccb86/gFrjlq+gtgk7Kzb2WcIMu5yuMHRNC74h0RR2utwWcg6sGlpUERvuOU1kwwjhxwkbY8VMvSm6P8DPn1oIsBtvY0V8tM5IngiM11Rbt6OCl5OsHmNWgK4ls4HWMU7frMF9WQzrnH7/sT8bpMsFRezWPqrC7wWSOLk2+CmxqcUb0zFExhWW3JSYyNc0PgkyoT3RUWhhwSs38RxjtdL4++zPR1qZitSWLqvY8fSURbMTE0s8hOAjT5q/i4zIXVSt3PB9i7Y8YNmGoc9hNmO3jpRzIdjH8fj3uN9AL+nu2yp1jKr40FYNRij4VpDo0l0RfDldhjyBa0mB1XVG2X5Z1DGyzBn4/MohyPhuLqAY6QjSTy9qyzPq1EYP9L0W953bF8VUfdeyZFLq16DDP49lCSmD4ucxvcyGOKhwrZgQ1H6aptywbwQ/JltTdvsSr++kvtwMlpswId6k09GCj1bSug9HTpkAA//j5N1xPoCcPWa+TJuP1NoNcY/jztQ9uiiF1zGRofcRR6wOxv/7X59A4FcMMDR242m5Y01DvRUNqGM3eBktBJxPAl0Sq5IowAon5WW5nOEyU9nSwjojGnzednu4/MSAFhIbbKh2Rs+C6CpzphsE1wTsKgwCMhLTCCOWCIYi1OHzafEQx35RDchpDFYWSKMeIdiJi7pkYCuQn0KwL4kF1VXAvHb44uICS10u6a9rKjH6t5Svaa/Pi3VfcsGUVFbez7d8/WGzSg8xVL5Syk05yqVDLtYuvKa2PynDSf92zsFInOlzO7U0DyX/top6qt6Xz1ciLbcApTjEuFh5gUaRYeai5YPV/OlZ/oufKmQgdBNbYU34CgdCPCp7KhrQnfBED09LjRUEI3CaBiXdzBgS8bvJ63eQ5Ok6W5S9iCUHAlpc9S9dXrgmSLqFbzVrHvDvOt7kanD5uy0jc0os0eumHob+NAzDhkApiuc0xXnlquN9XEjFJ9XvJLOHOgIanjhPRu911TljgefcrOCSO/dqZitSV+qddbgjXTRmFpPjqLHoe2ydC6XWT4hb+ra63u+xOCDf40YY+6FUmX9JAOhSQU8Aa1KguXgHmrD4W4G0RYDqFXpYtO3brdWEv5OtESNxSVPEbdmC/nsxvG27kpXyyibp9PJ2l+cvZVC6ISy6MBU2SxyAMbEK2Lt0JQkDeGc/hOTAm6YtahmpmHDeE0TKDWOPG+L6dfIT4yHdNkOv8GJUfJkxeu9rCYLT4f7k5MGAdm4qKalvmf0a09kbwBmMNB4Q9DcEMirOUpdpSfZfcn8imFx+xsCIr9fILuPQfiENWfUOpzxscbybwy0NU8ft5whggAlzif7dwpph4ivbuxnQ57YwmlYbysdvhVz+VWHsGnajGVe3J2KhR2wwDTeMf5vrfN8UG0GH6pyIUAX0heu7H+nJhFGJwERvXv3pI5oRkXezMdDfnFRMm0rQsX93bGsinmdE4FjF6cv1iaQs6Guh14q18Hl7QAbG8Xb94BI3h3B/turXFSe1jXJ0qAavCTaC0oTWawANLuoBvOt4j0VqCK2pHz2vdyq+efR2+7syz4AJcqw/227YTvhRAKDbG5iWwAe4wYXAGg2rwnEbz+gxM8ucsLy8F/rZGFE/497ChHScNUqsdOtBoHb/FZUBU5QhN39b5mRYb2D+00pPsxf62RhRP9teK8IfSjMq3l80/dNqBP1PvLBEI8EetgFMDbvFT40158u4bk95/utNQh+GAcUDXPJP9PZ5sgBUglt/EalIczQDILFE0GYbt6Lp1FmSFb+sRj0EJJXT6hVgS6uRh7qdJ8OXjunucYzniqZ+cLEmjvDNtl6FawKk+Mj3MdgowqckVG/Z2/LXjkLwB4zcAwKGLSFkNGFeXpyQIx9FTXb7ecr9JhkuVtHjUNwLvRBrwL+IfAxFbH+dppUT2UW6gqb8NwZjQ8dF/x4Me0yMikHIV1Mde6kgTxM4omjYvuhtR2tPgV1ZLI8aBd/UXmIN5ZkbnsjKOlNjX1ShI02m125iFQdvwpUoSgDuU6D7zMjazpdly43/Y0Gc2aYzcFfrMSuhlwQ5NzDxSZlvCffBt4msOgQFai8VX/wL56TDIWshI6bHqkM5xSRvb+oNNoCvCq2X8JMEuN0XybQQmDGW4cImboRmqlGIPIka3VtRSrxoLgO1FAcmI+TvIkwZ4p0IduEuj1U4huKIs2jXBsvPNUDsXI9S2xz1Axr5Mks/KwTacxzfYA6V3aSfLi7hxgT7xxJA10Zoeu5C+9eAc6IsStotxd+FqwX3qpCw2uNGRrMptFjjVR7vbB2aYrsbTrQ1iT5Mzf40dH+BuPZWIOhUOr0CABFXGbZbndSXM5DBdjWEeRIj76zX9jHQHT7MeKdUn3dtQ96MBx6vI4eIS7CZj8RY+NyWsTOnkY0DwzPxKlncMi2Sp6dB5eVOXSyvDe5SM/4brbmv2o33RwfdFJRv2+dambEQ/w5HkTkjsGahOTi+T/ocznlFhvZh1Cp+quxUmNXYORPYRIj84RJiqZ0KYe5YeHzVRrO6tOK+DIPfhzpX7qK5i7diYg49Iicm0bQWU0VgtYgKO+UuVL4h8jVBtoB4RWMJ1J7/169gFzpIwdB/cUKrboBRszplLhaU+co490iopsZqO3JAsDusD7BZD29DKnaGyK6pliOHYeBqh7xvRDFFhlDKagzrzpzzsRuDQwl7q2V1sh9ddE7M5FBMKJse7hYEjTnrSikVvMrOiG8fDAJhjwpG/9uuLRRlbAJYLkjjY5YrpxRe4UCywJd6e6nj4//vY7ljPZQ+4zc8aV4ZFqlekXWOyeRIQvAC8/tKG19C5yoLKz5H+D5Aqw50WnO81KcYssZl4bblMMzKXACheygXK9tr4ubEPDaWLdGO3/OBkNLh7V3vfFXH5OmDKngYFtCL1OjTx3Aev27ct6eeY+7O25vcjNekCfqmp+og0r/Fyl5nRoGb8ZV+VmX+1oUtmq0iS840Ee+Jmgo29EnxC7GhMKgw6cqhY8q5o3XYMjq62WGJn533ud9Yn57DGBvkeVzQGjEGlDmp0hdlIKup0ITrGcIg1fjPVKRpmaUorV9D2GyQGtvWjt27L+5UE0TwV4vskO+0M3WGeGXYLCPR4g9V5CRg3VeiX+fF22MiiF+RTOFB+wwpMnkts8sTnk0GoMO32sYxQuLXZkoPwE9bbcAGYEPLfN1HtDPKXPi1MAxkguIvCxOwas4at8XYJJYtIcIEaq2MwHJm52FwDHt9+7VbOP9nOIkhFR6tSiZcP3vD88tEKZcaVhskkHF7YiUki68G96AeqC3V5ndKtxmEFgM+lRjZHW5LMKosZG2I5EVotGd4JE4br2s6FosqibsMrLKttn7uNl2mvJh8nWd++ZSKWmBeb77zXkI+sqO7iw0yFIhQPes2HFppXLIPiEhMJRVFKSlSeCLvciwPBX+b0SPV1ShAYcSKMIkM3dCMFW936PcWUg8xb62Z5DZjli0A2lAQGAfY23EcF6uU7Mn1qVhc3XqIByrU7//kPN8VCuYMAGt0SNBxS43k463zsWBLRCTFkqzHPh7ZedZIlrSBlKM53Ofb5MO9I6XyFD7nQybLQxvpfAva7i1raV/GUayUSUMiut4sUOU2gbReAiokC3rEhxFcTfiAGg6jd/LMgK+hbJnJoAdU61Tp7Bdm6DH8JwYcBjlLxeVIF4vKLwrou8ou8ovCwizEW4xAJThpqarXwL9zr+V5mDOvdFmzgq3A4HA4HA4HA4HA4HA4HA4HA4HA4G0MDKFZWwMD+ceSeHZ7WFAybuJPLAAjxxvFsaJUu9va6utAt8BWlElHogQsWR8QIALksNADlyWyy4DzKMzQHrFiRa01EadD2vLHY6jB9y1ZE3GcR1gjOvYBQW8GqE0XI4QoetBbvXI9IkQ7KlPP56F1nNvbO4homiMeDZHFXYNkxQwyLLUI1N+8sxLCSk8XLerG1iI9whnmF7z3CbJFQS3n1+Vqo5JGDksDXVR5uj/Fjl01LFNgI67YvJS0dvjgYe76aIi7IBiySvAS+w5TuA0qt2eQU8u8JIwrcttoZ3Z1j1v+D3aOxJIZwNrTme5r7nOPaiCpXINrXgakQVACp9I0cjWfiCfDB3TjhqVn00BfOnNamt1QZX8bLgI84YcGimLHvHfi3lPUJjEe04PGe5wN6Kqo/FG/YVgEJ+KVMWZMmRM9I+CKHDO5LbChegUNP6nSSq2KGfmgLSfToZHH8Ed7p4NbYdgqcFb4fgcYnkU7x+Z/zSuHjZynUQ4mQVIEUQf94UiOPOknLPQPwdY5RvO7ucsVEWktCad/z7lZwcjaRpNF9jqT1mx4WRzpFg8/s/FB1sVGRXxZdCHbEjQlZ2Xf6AjXIs4dlYx5vOIQ4b7trPnEQHcQv6oAEXRF/v5TxMS8lzvxgo4YGq3L3HK9z5IL0ZdWnTbwEnAhnFtYABtzbv8XcCXLycF7x2WuVGBOLiQTdN54FICC7SkgjdTgBWafBr5pgmX3xNtW97i3IU8pZOXiRTh1rlXElf8dOejzfS18mCtJhaa0yz6gso3URSKAlrOk+WBPad0T3xS5EA7kuzHdjyMb+VTLRCflvU2GwLf6uVS9FSEfXwWHiJXUmrW3k8N3cgguOXWufcd9vAwPVjVIE3xoadKtk2CZIjGPZPiUQEowDaJBm1yFGayU4pyeR+0CAUPFHwd4TyT0f7Z0un2qQayHKlmTtXYF0WRDe0NL8u9J455T7RMlxssK5tdUlRJcVetV/cGs70beLDBJCVku30ZXQBZix++RK0On3rNI95v1ZsH1ogDU9Crtf8Z+jUTIGrqSprXTYTy2D9CQMsDAqcl3kKeA8tebu8C1KF44r9r9tq/nfR0LHp7aby/BJu4Cm8Yo/PdyozmoCSc7vPBbsqy/lJiKGi+7HMaaxupraS8ibRqeSRCbFH28J5N3lRazO4/QYmtv/YvyGcrI1P00CY58WsG2kTnxKQVq1vvE4MPOtUcofyXCpWANUHx6mNxcrrxIF5EjWalEmG/nuZ0EgNvEA2Vp70bMUCUwfcE4MQ15MtCHHWgsImgEHqbdEtfiTFHKPTywbgrsom+lLhCstiqnc4oZ5CVuxPNm3le/ZfjawYpoBRf9k5aEgUwkInFHgQrZxIJqGzcEiTgVC7Wd/69S0YS/Z0X/Ip8NeS/X3MGhMWDq5MPfLNnf+vIPCz+JSUmQCICJiZpOIJ4Ei8/aRJhlsMxqgE5kjyobMD5yHMuC7JW8HxeIREoHPMMf/dJyCld6A9I5Dqh9aPLnZxvIuI9uFeOHLoJBb6VN5qd6RHuCO5DQ/O3Ll5etn/M1MCbaSv8QmJyj/KWcwex5HZZRvftQ2apYvEs4f4JJDUwmP4TRf5DpqWeu/pJykklTW/Fvuq/dCCZWnek7nB/ewNV4vy2ri211hdf6vXfavysuU1ixFTN587h0NUogs8uwFQGSg1FIvnvpmT9pbFQlAtFeD6INOk7es6geV1mq8AtAtpAdoE/F46czhx5Nl75ElVrrI82OT7PB2ECHPXPcYww3AFyMkG1QWwg3IQOndGRpABuq8x/d00V9XI01g/iipQ/Xi0UvyklbDSe50yHRs2jpes6FZ2cB8KWTOAa9RaxOXjcRcjd+RpOg/I4y6UUHTyudLefR4FHivRNTh/cC8IpyK0guH0QNl5J1Ebgynoe6FimQQDBC7sz7kaPOOzKt5qUDlQnTrN4BaRCXvMTywAN+faepR5dCsUWlJMmdwsOEAXFbF5N6QssTTW3UIieLvqvM+y4v9kH5zUHqKGk1vaZWuvJ4PTTEtWJbz6TiI6cof3UaQFacMa077yb4OhiBUg0AM3AOsV2jmXU5IwwDxViPgQ7OeeyiDUOmZREuOcb3L+dFLF14IaAjigsr4CuxYA1b8XGsVIZHod9lyk/3iXMdKEfUg5jsIuSJwvmMiStIZMH3OVtqXwtUQB/MFIb7ja4JqyWAt0ewLaTwO/xuNYBxmpNU3VQmFAVaEnXdwNlORHaiTAKpu2t9XUUFiUZ7p7O8kNEBxtlU7KhHghoPbOdtvvN3ubd6sKk0TpztxhSrT/Nph7C9luWtrA6SpTel85EaYePCSKkKIisq3j1LkGgqkVTKq3K2jxqG4FfP9GQMgJ4zoQcPqLkgP2e/OqEXZOP3frexDxOjHISUVgHniqmx61nHd37HIivM11E8MVILLjZMGFPLfXR0afmLtU4U4x5pFJ8y/lJloJ5ojQz/VhlUiiUOvIAN62xrKJw29u0t2wwnODgKk7Yha8A/J2EzxpSSsH/58ju9Q4lWNv33qWQITSE/AAkVN7ydz0blAlRe+FSjefxyob5usqYb/wn3xJ2Qy/enqEHfzdg4Y7Y9WTYC6KPedHfj4bGDrVt2Uhkei8IhKG7hr83Qn4gvBKGdrPladeQRCR8FXaXZfertb1ulZ21cLct8drvMUC88mEMvEefXuAmDrCSQTRFa1Jz5UCN2DI77tyDoW2ejCVSGZPM/VPsq7SiL9nCFEjzyOdrpUhS1tiOt/1JLYoIs31Qg/HNPpjZSOqo9KZLQw6MZoKDWNprLJJOje5Q/D8hAQgjpI8jsyiOE4G6sbhGofsTXGCxzr4U8eQtGfsWrHN5KpsLA1YoDQykxPfF1CHJ6Bo3bMFa+BEWTpv+1eC2wMCmtDiI2WOTlrN46Y+ohndew2EVjzwSwN2cDrDmX5hAoz3IMrs2tRoySRTjdU8YssZSSvDqfHU7MSLTlVCddCDESuBst8gCLurvT8ilQcrdiRdwKbB7c7x2ddivglX+ZmRCyZsX8xxjbV3h1uqpuuO5EvQeqVJlhiTfOuGV2bxfaxwVa8VWCR+WnygRtzPUoFRyD9vNZBBfHKyZMC8kQUMw7Sxj93qHNtuaPmg6ioTuvBlNrIvCuw87kh2at84nkZk+k2hXfmUENBMhIlJXWzFqGu4s9T8cevGN9XLb9AQlJUCXAqbeBpbbf+0QR1DDzDDYVJHpHsdBk2PwMnwuTifM3WORz+ryXPjl+KS70kWjjeTXG1gZ368ZuqVUhnBaplB09E4PiFYt0iSmbme9duN0kFm5tKgkhrSwHQMWuXJFSQ52LRuK/xRiz4yImBFEJq1xTF0LeJoljJTvFh8ga7QFFanZ/zdzd10trQnJDfYtVE3XTeZuo5RBfZY2El709J4EpTj33eLNRkNW4+bXpXxnW0xY1JBTPgmgtE++X09RJQpxFxmZN1mrbpOPSPO+gW7+dqkLhU4xYVy5d7tIxD3o2bAsvR5qauufy5kGgj/1K//xuN0OQ/ziPz8alFRZ/IKggU4X24dpxW5ea47NhXXWSDpQcINshy5A2Qd35heMEA/B0yg0ThbhPX6ams130x0wAUAhqOdTfIEi7T3GiLAJgM/JQvB2MbXjpP+b4R7zebzebzebzebzebzebzebzebzfQBfThGCpY48pNE0TRNE0FYUKytgYE6Po9EuT6KaUGo3vTg70hiOnGFONUoq6lvsB/NdWXILUvRJedNZAhmTyuixnhbwTUf0ZfYApZgJo6tEwBD03tQ8rpi4gbGbzp18w4cKzAwbKKtiqRTWvFG4AGsS/LCS20+0HfDTpXaXf1ADfKRkh6/pHQy4N94LX1qjInVw5m03/0Iz7Hl5x9mkm5wTq2ODxQ93GBGNgxiNxmIPG8YpiYxnazsGQEYaP50NqDoHSOHu8Y4VLdGNsDdRqmdZ0fhRj4EKLMz00OG23+EFEYHUe8FdmRjXiUJVP0oO1D6rmwA1iEdw7sXKZ+uvgH4Q5Qv7n7UBmVkpYemRK9XXHKFmHOUdvjgYe76aIi7IAuC2HV4CU1KzjTR0VgFtf3WqqNExqYtxAuqqMprsedvCdGFleZSQ4BW/CHJlud28KXq2i2S16wUqC1o9U9hMiu7XDcses4TgNTPb9KXV2hZne/rxUe16OcG9vOR/15MBF0VdYyMJt0zWLo1dBN6UH9M9vv7NmGr4VJU5nm32Z3AGu1bsTPztoRC5dc3PlABMvNWR4WIoqO4TTxcmSgxLNWmRfhrgBrAmmUhrK7arh81HefzQYVkMTZLV53BIoc9HWbQIm6WfxKtb3ajDifc+zC2JwJJrxpj9L7DefWZHrSuaSaZfMoPF9tYMDnOZEoDiFAdIwI9K1Npj7k0fSgOQsR1Lacfysjddc7XBSxEaqLvDETqecWeKTNsaRiBvcGGFcVAjJyifBdDbYR+49+hddqVG1o5Y1xnow0M1G9+L7nLDhlf2YCUYReklPA5WSn6AbQayxq6nQRaJT4hAxwvRmBndizeo68zpS81DTXdThv6Y/fB81ZJb+jR3Z3TYjn1+8LVu5UD575G4EvunkTiIVsYmPofg5l5tXC8Rclawf7CwTYHKVAebN/tvowdSvL9J4bxqhE0n6LBpL5ppTo/kw6vmHCEmbaOjClvUoHsFhPawzBvR+jVhVzqsGvI95kkdQSGijbx0zfv/AAw9tLBbgc5vgWinJK8e2FBFEiwhU+3H5ayu70Ywqjd5QhdWHF4VH+cq3cbTNJ61xMUeHZ66bYP8fE2iXtVRI5W2eB6dbHfiuAfsgSgPzwFqbBMGLb2P+sVjkvmRW6lMM2sAP+SfQ45Z9l5Ya+OkuvJqPA4+VIFTw2QxZ6R+vt8xfxhJwl6DUkk2KoNTdQzXIOaN/x0uLtg/tK9uGROL+Q+bbMXX17mHQF/RHv9NzjoGbUtDvFp8/5gBRnzXd6LNKsPNIPI1RcCYLVyVK55T8jqWxI0VElx+W7gfbl/S65Qvu+9qc4Dktdmn4wRuMEHTrJcz7s4lZ0TnPZN5NCBYC/W3Wc4GONg2x7qH25oJNdiJ5iNLL0CjBrqXVuTcRpod4sZ/w/3haTpsJIrwVAMx1KmF2HK0waPyXfq/Z5MM5VPYIwlonvhi4EH2yfJXhm5g6008Z4lcYz/EsB9LXj4np/gE8jf/TrTwLk28I+BIeoyDdE8w8lqJK0DrXAPe1r9E7JZ+jDbAvTe1R3AZAm7kJtJKmt+LiW9hMGxuXv3+QCwH4Y6R9JXjx2G6dbtV2Z9u7LLbYdEI2+lA4OpnkEOWFUm55IOlm4VH+cq3cbTNJ610VDZUqQqz8sifMhpBWeIiKP8dDzzj9qznjvBvUYAnHtPC5OKd58ZaXXiNk2m5g1fpz4ZmvPwq8MQm3tsJVif7vTrrlsBVBnYSD1LJot94Hb7aTUcBQZOaNpUZ9qEssalYMoIYfTbNWR7c6kiKUn2qTIsfUI337Mgaf25Y3LFhdbcs515b4cODMK7BZXwM6IGPrYSFZvVmBqYEJsfgYYnUVcg4e0EdpJ8biXk8W/2pLTXQgLq7ImrjdOSYKb1GezFiW8qPGNA0If41q3fAfXjm8uKliIk/ID5Q3iYdONZh7BLx3sTMwnujh7/5SyIZtRSJ3Uix88zK50EqzFAsOenO2giGh65i+vm0sirm6QC0e1atvFl4xLt4ThwnNvFAIxcisUsIGmQfrZIpXjBOb64Mz04p4yhJpyTPu2Ry/UWA5i/OHEJh6RykD2JasxNtDWioOXys9Ggd8ShSPj952zRZN1RAGByf7qoIgiTUeXAY2tU5oYpxFwoGib3F1ZRNLUEImUuvGBG/GIHUE4PTOFw9pIegmZdnL1P4udydZbtJ+r9pazYLRICbQYfpI3tiwB6DR8ZPRCsbQ/moHr5/6WCBYnlUA1a6zwlSeEYjQSkm2vNYurLEwsIpTt46AeKtfrZ9T+NZs5HqxjQY8AM3A9j44EpyKg8uczk5dnK+XXnuxnxf0sBuDHSWK/Y103oamMKo0lU7GJQlUtZI/qhQDPjCwuP/D21x0rpVKFRVPRoTRC+3ZMb/PfkcVlIqrWkTVisppr/rbGijqoUtbynXbOqRwlzwpmqh4ppr5FIpqI8LMDEiK9rARbwAnvC5+pO8pXHtrhTQsUee8onDTtoNO1NkEy9xP0bQs7gc+AFSzZYtZMHVh9gRZoVaU5pwX5vw2rb6ptuuWSqZXho0Yih01X62CpnoKxgcsQNvWkyLqO6LkXvIJ8IaPrax5hfOlxv3z4R87ELxQVmMzSBQlWLDGlyRNZB5IhDrp+HPIlfgfUtMSRILVxd41+9TVMU08AZ+egscRw4vpE+B4uIAnu+BUJYv4k91MvD80r9QcDqPHAlosIzxpKuLvx091PHyAD8DSH4978ZDpxw4raWtGchiNGCfmNQj6kHOIx32XjpMMykST3LMktDYhCtMXXBo8M/b7KfrtCDUL89CIj63XOJ+3j3e6JDOtS83gPmsQm4PoTQqKRMEifcx8iTqr6bbUW0NYTx3RKifKgPJZfRDc0Y+qq5WJVFnGXcaXJJSnpdI7zflSZTBu5AQyXoZZo0z3eqFXetU8GieUCiiymF/J8ipEHfLD/ocznlFhvZh1CoOS4OVBY588mOstO1/m3WAlYXfBgm4rl5eVUryD/mqIbPwEyQyHzU/ut7DtLue4KBG7LMsQVqggOTMvu7X4y3e0BJkUxmvfKvsjy9xBNCUH8YOJy1m8N8tqYnJ6YpwR0Bgzy5TmNgC03tJXXFGs3VdoE9Xu9GWhXALQvjVsFBsDJNY74A4YFMzYnspiz7iMgJDo9ZDX2NixpyWZ4rlJlwTRV3FfSKfHzokY8Ac2M2yuMtdcIU1SbpkBC8pK1npxpqS1BFmRwk0nQLyblroTH5ou1P+lb87L99Hti4WtLzfDfX3vJpo20EETdEyfjJe71AUEpNpLQVAw1EjwLhRssy/hJFv/FeLajd1nJk9Us9/ryLFW2/HIlInqQfjbhsVNAgK9WjKzIQIqBdThFsSfqZONG80ezkJsCsImwAANwEUc6ZoERuPEZ5ty7Hho6DiigQGkdoi0tI7w1tO0zP8HMUBfhQa3kE9gf/Gb0GvGj76n31PvqffU++p99T76n31PvqffU++p99T76n31PvqffU++p9Rg+gLQB/++OWATJB/jKHolYWWu5VCToaejAZFjjZwmHq7GzBcirknuKdEgX41AM1Y1vhYRUhUSTFmppyMkBAp86E6TpOk6FAAAAAAAAAK/m0GLMp0o8DOO+LEpKb/Qra0YaBi922qUJk788Kl6pc3CSq94wjIO+xcIyJXsS8UCNeFapQy13UUtVypOKMVXSvYtYmDYyet+b/yMjnuFSpdkJbBxzSp4YzcFyFhR0n0IWy3AUWaFUKkFy0wg3GzpHP/QDkH866MrWxxyqSqoRQujwCrYM20meZFn7lfLQIQOmn4sxsR6oitOvQyOy1ecbn6lkRs+WMY5rRkpOLSqE9G5QV4PUpOV4dwTFGQM6R8P7dI2VnReca2rKreOem+LADXm7n46THnyahh/4p2pwCXLldVJj32A3EcAH074KbZPuZPhob5jYEwLOulBVNvW06O/SXv+LtTBuj0OlkqXRGB2eCCex48SmlXhyQlqSF3GTqzr4FeqfjN6/MDR42yjEqP93WhElrUHvPxFIUIcY2a8yeDftljZu4g2cxs+e/mTXdckkV2vM+QSKz9t7MOqmSX2m8ZinpojogBtgd2px2A9CR7O+rpgVQL81KhN7fo8t6sS0iYLg9gBOSWPLOYHSFLSTEyPZaU44A5zcBx/paUOkazfMwz9wHpNbitxHIjWAwLnKIvoiQ3EkWVgqHP9pjH0P4a49u+ck/J2xALPvdMT3iU/+KiAeWA44NY7FwYvDgCx3Rz/xfTWnma8yWqEAQ0k/k7cmhcFDlaVj3RIBnXnho2B/IB9ozSi0w4DHfNRWpR3WNrppFJWLh4W8/kYuFmR591VDWh5DYhxkAlJJZSSqiYMeS/2BlVKhKIQ+D3rgjdAsZEIS8dcMCcCfVuJQZH7Nio7B86odeXaMGBIf//Qb41r/npaPl/S86BxweVqHjsYR8JhAMTW4AAs3PXqtCaIMeXrQ1pGsNdOyyM9EAWmS8SsBeoOtI+4pf923Yc8AN69Kc5tGKEwDaWbhxF6KxIcsez1kz4mEqaVgHWGfSLxdthe4yIXqe3ROGb9baOinNd374rsskkA9TvZDWM5mGlhLGzNzAn1OoGjJiIPPLAf82yVJvdf4czGqxx3hav8sLWMsqlctKIDYl7U6j8Nkx/iV6WYKyJjbe09wURottgLt3nskQ/yeuT4Je+llITwTjSDYSbwJQaNJq6QvPfP4Yj0mXNb/NjbgZr8Hp//w6uTsPhzi+3pK7ka3dw43OG9XQeBMwbsvKlSilYmHHH6psAwnxpQhd64feLZqGFjbOe+4T4dkYyKZojbNxOyfUfHzWc6joBoR4MJaymTOj2dZF1pQJBJdc9oWd/2h2sam2oiD3R3hvdg7Kt/epdMqLUGToYOdARoaEa7pE9o4SsMAO2hv3DQ2mppvlKPbwa5VJ2b0t4JGmOos89oXf114X9wCO8MZr3a/jjQDw6MiV5pSXNOeZ0n3Xu8AJ5l+ZsrIH3W9veVSrU/p9GLyxpurBanvWjrz8Qm07zt9/ZEvfu0bgr+aI+8KBtAkihsON97vF/upZJG98FesX0LYoSIq+gbGUI0N23pRl8a0B9RALc1Bz2ISgD43M+wP6xv2VnsbVaWHZK2O3J+67tz66aaL2JxLhgbLP+1VsLY1LeZpf0TK6BpDJK44/v1hcg7q2XC+54Yru7NBdvwafRbR3+6YcdcjgfK8yuZF6yvmokPMcnbU4O56es4C6RwDjSHUaGdP0OW/ViLvt98QIMBYQUHaAelr7PTKglQcFp759GLzM+SsvR+j9K/eGpabVTC8w3rxXfIpFkiShFUFYVRDqiYY7QbhNCr9Nbr1jq1W+VDCL5x9Vibkwl+QWpe5gpjSjXl0lwAfiD4txS6ISaPdF6z50eykx+0lUaeuIkI3jRJXrZbgPLj5C9u5TJxFtB/p4QmjZf/enGVqqvHMy/NJnOevwznnlW80VxENRNnBhkdntdPgeu7qYbgBbC4WSCbPoOlPxrrLa5ABv7ocesNj6XxCv2a4W+YtTnwBwHi0aKXxVhiIHRY4IfRg5L8rTfErk/BswjFmwILXWEGXGrSKp4b0qQvituQFRJIoE8tp7A2/dXvLfr1WP7wp4hL2lF2jRFIRr/oRlXCj24ZxEqn9KBpXQ8Xzi6kMOIu5Y1qrNzj71QLCkVSZH81n2o/1aY/ACPy7JJnGcVe5MMBZLSWC4EFolqySIirSqS1pv1flCLwoQYO1fC04zANAXFtGKgsBeSa/S81LG60/dCI9poTZq9pyXgjVz0t4JKETwdQK2cNlHuxIP+XhTXIvEDzNAqLfxiQwoEWSFAhDrzFuiu8xZ0L1DBJJ02bX2a1OZQVdlesJRX0eVfIBAJbfTxlWgu4xk4Et3v4+rs6vZNy4a0zAePaAzHLeWNkYO6K6T6wiJHHG5/jFNuQvHKQNn+uDTtN1wyY9rhXaqk0zWaPAufUxHywZ1maNurAisjpnOeRaCye2Avdql/bqY7Ym58hZDFAXLQAK+RPZLd5iMHee3Dz6cyLJcYEau08s+mopFZZYLE5LMCbYNYDwD+ZIYjdjnLjG0NNmczzx190U8hR4ntik+EpTBM5XM4ZRTNB8wcZ/tFUl53nltST5i+rMjbajgOeAFPxVKkTM1XmCT1ESgwTuPg8Yt5g5PnWBgVp5NwFitxW9Kp+TR91RoNL+EmpD0w6p3hp1divy4deZ/nf9cNFGsIBN1ebS2hG7SZUZKgE64Ksdf/tPoahkVh4nBgrH1bNjzY6UvUoLent8K/gknideJ8LPS04hZT4wsHnxdfa6l4svuSFvcZaLqTsfVCU2nYJHQka7Glh/pmFN30NpTfsJDgraDcHrQyGoxsHBJCCHOlIiehwB4sYKY77eEkuJm6ybSrvDHrxaK2dn3TDW3dkhfow75GhZyJ2x587GBzZlApd6Twx5K50HFZYMTu1ZlAKSLEqzWTwF0xBGtBfsfTfNR3homiggUdk4Zx8OrAS7AWwTUbukPItu2LAUvDXxcNgqYFSuRHmEy4w33HQXUzX575QAAa4vZTe9J0kh6aUplwJK39PIbQYIpZgYUFjn6k6HdV3IyAYR1hyguUAIDN3tYgn0tb+r6H/dpqzHTq2I6yIouMWZlBeXsnAN6BX/KN8bIAAAAARQdSFpJk/zmrHBg8d3w4d1WX64u5fNzyso9GGOM2uVtaedm7bes/IflyVcnFkaGU+UoBOFfbaq1Bz0idDhalTdPN0lmaMeFPSVle+6vhV+tnD8G1lnqFVUe/PQXHOq6mCqOJuO/+EYnC5YtWnfsyCpAih5ajXaCZZe6pyeQRqY1RaN3XzzV+kQ9N1LGz9ymBuT2IsAMhWoRrSH5jxU4a2wTMo0C7oW3YVmfZwJU733gCfXYe2aHv/xgSqbn3HD5G+R5MsiqKbTclH8te2C1fXRRD4/ypM9B2ZMISHysccY01iPGv5v1OZy4/WI6cCsHlpNUcMkf0dRXWpRInBWc0Tow8Y35r5KwRHXis21Yv2EwKfs1JpGKzDGYsUxHlY9oGVBUHNNF/omfDAw9amRGnXYqIy4WDC/dulnIaOWZrHONz6OQcSlVtw1k2okiyrnAxgDpd1ep9vh4e/QlycoNIanxZjo5+a+6rp+RPJHAUNaMUdfiS1sXGeTuKOoSZ969yhpxfP0wEPaqyyJ3y1j2kfOGLR1uUk147QdEQZcSVso9Yy/3StdDlUj5Y3KSZRgBktAbjUCO70w8PF9TVhzRUxB+6IB/s1bJSe4TgeMxuyay3yp+p1vUtR4pfLjMj6wQ++3s9Lj+PvsA2yqWqYK1h5PV1Cl12CjzWzQZyTGfgE/RAVXBR1S4+zzeAYgU7Fk4EkdBlaVSdw9uT+Ljyh7JFl6VYXPvlYFlhraMryFZsvVdEe2wIdtrlyiOZdya2G6pvzpyQVARFiJmc4OFipI7pa+gKeO9yRh2EEkICc3wpF8jE/ybY+xFxonLCDb3vFtng5ZKvfdpVXBSFnZc0A01uFrnlcw7+3fFkYmaA6jZGVdeEcImjZzDFjMLEMuE1PZ2oH9QbZAAxUKyScV/DpS2l/C+FK13NODJM8fFHxdKHnZbFPlC+i8UTdMjP8qzL2NWO/apgNniBVkiglw+zza/FO1DoAV2ECvnouVOIl9VkCFK+dIkouZ/ZD/oA1PhsSDLuFpXCrwlqCGov1mHPRb+oq/5kKfBPXguCb1gp5rK2n3InT8/lZRrgvYNNIR5CqePScPnhizJAWP8TRQ7ZdY9gD2A9ycB1JHeH2C+F6s1lHltyemoR00JrxXpHA9sJTruLZl+0hxsy4TaWP+0EAkHTngyazfBJ9TSBWOdQUsJ+jb9NWXIrlYAiiGjw4g9CLvpyqThkiiENC0UfVm+VX5bTRjY8jmanNIUQ8+Oz7OIsPUPUhR8HqJxb4v9cLW3l2j11Khic+s41UgID9g3ZG1SGYSq01FQ0wtIeSiisiarzOQSTRx43eTbJ9MPADS+TEbywCw4jkQi3TBk9u/xdwJch79Gk2oo+axThvGizaIjiWzknEpjNPL9MWyWROMR9BVq/i9Vq77Z1SCwAICnpUwZc5GsYuS+I3l2yvaz2xSFSdAh9bNk6lTz38K3ci1+w/KZ429CQlXcYn2oxdD4quFAhKrNwr1/7HK2vQLn4RRdkAzUL1UJ675tMXhXH3DIsebAvlez9XXV/AIAze9mSicEeXxxfAc70W5BUWuQSAxCoPewjKAAAAAs0tZXOS53dPluaGcSfbogFyda4+nHsKfCtmmsbv9wIS/WKXmjYAFTWotCVaNkCbOAcdmPkF9zkQEDQkse6wE1m0zp1C9XLi9dpCrB+aLOG6MBOubEKIfSmW3P6J7cfW1XNBY/H5mneB3uG8ce8O2YEm4OXdrR4HhH7DhrUdgqarNzje6P7hJMLGLvrZGRFzzlxgzokSrfgdnHiuI4ZvxirxGgkuYnqnWq++W8MyiSWyXHWerlVwdJ/HrAKqxchIZ589zqW035HKCaWLFAVB4LqSGfKqq7sQaRCG+bWgik8NortaPA8RYZ+qgVHiuT4LbDriz+ssCRmSeOlbdCLHIRjRewL+F7E2O2r/p6bdrucTO0FDsnvhp/dgoRa8I1h+pXs1lKLkky+9k3VU+sBE/yXACo9zTP3zP8QPkMBsjGehAHz0I1TBfQ1LVWHhj4d1iIqXnORnX4lNLMCS1+V0rLtLWR4DhD5+fBLLP1YAEgb8VdV7wV1PJccGYxwsuniMkkW2hBFDEeb6UlXJfzfUMP973TWBLxz9D1rTlrAHrRWZAAQ5mMKIkGWGEAUlj1kLXDg0pjJw5xhdkMD3s5w1v08iK/Szeg+XT+UuzWBZwqo2LFO/MiV1uLkx3QD0LfBGhyapqy9f4403w+nuRnW3aVqZWFrr+dX+R8R2lpnHt8ulStUzAdWjx+QnK/IDQvxTbTIetg8tG/b1a7Xv0Ww5o6VJGvJ+qld75NofqMwAGo68FUqgOYSm8A039qYcc1squMame8fVngXXzmLPT/YkMxaXwBDQDJ4GPghQ3qkJUSAGpdiQhuuH+EqN3BL72uxj60TPAMDbIyj8Hyv4j55UbfZ44bWEpGS/TKaqeyt7tJSJRX6i2+8PWQILqMInkxzY6fC8hZy34KpyqplqPne2vhdxSpjk/S/1nuEDTgT7rlVqSy5u3tv1m5gg/WVsNvb7FDPdo94B3MLYVwf2sIY7n7I3tEzRLVyW36H5ODqsTToX6itapIUpjyqN+RICI/7v64b4/NCSaoL9/2ayatxkaOjI4bw23K7fIw6V9+OOBr5//iSKb4yP+D2nsztYMbBYua2xcy7MHBbIkFvmUd2KfCrCfz1AY7LgBUIoqcs0wlSTQQu2sFKK0DtyfNQLwQt1fiKzztpC5MXt3HkCUGkHZCOXiWKJSbss4u4rQBdepwASJyT2NqPzQvxSa7nKheaof3QwqsuymKGgBKomrY8Gyuv4rRWiJ3CiMO4Nb2FA+ZI8KbdcfNgFcLS4CdaOV5/QkT6iwGOaHtMHgloKEaWzdZNMjOQT5BgzgtoldTXx8ROTOVqXIghy3ZNDQDahFPs4OWa/Ox0KNrDPTDbDFUBjS9cK5zNNzqM+nJelp59uCVhw+kUoWjd0PeTfKafBBy8vuY1cfn76A32HONJe/Lr83w7rORIj2Knf0t+bMim+u/qNd//npOONCCJsE1BH4XEjQRb5bCuEAEV9N4LMi0WfNSq4T8tLtH1iV6LBhLSGnj/Soyeiqidf+P/xdEltz4LZaoP0i1fyBL/oXiVqjkOPtDjcLl7jr9dJz9AGJ/ajTduICgZQx5w38r6ZN8zY2DwjTJXU5o34RAY+0e1z+MJjrtRMmIvu9S+glpk1Ylpqm32m+eCvYDigsbMZ7iajBtD+HVJ0aksqlDnmCyLawtH1iv1LbgK9ivz7g2pDfXpsYeeiMNt5c1B7M6Wh46qbPE/5PAjjPxQx5paH6d8wrwSWehWaIoJPY0M5keVYeMKueCthtNasrsFbXP81tn4GK19TkWpeeAsTiSkPe0CP05B6KpuPSRkgirxtHAUHTaxN2ThcHfisynnBSOLg0q+rPey1g4Ba07dP8I7nyA17IHWL4tgNVMI8AK1FKgt6QpZWYIPnT+eh4FNptTnv5Hx1UOzDnj8E9qEaRmzvTAPg1Hp1lNDoOEbc88CNln9q5R1O8GH8ck/mt4GRZcxjoDdc4KtPbrOiGahYLxj9sq9Qk3INDYECtV/03mdEIp2NPc1P3fRdiARaDSPmtV0XBx0DuWbkkXfiOhJnwgYcQ7W4BsI3SKtGeHbiHr3aIdJNFmyMET63D9AfRk1uKkM0tT7ZNthUHs5PUgEcQrxJaVUZemlAe/hZVKDXjUTYi+9GW2UID7GZ2562IfP2fgJx9wA9HkNpjSDi4V1GAeyau5UEwck3WsGmKTJM8pOl7RAUjm2VcBcVFDl4LMSBiWTsO83qHzGy4f/Hjy2XRzu8ZzX8yhTRDJp7fJUvGyuhNdjSeZwjgmrP4DT3AoxczvVLXbU69/WV0KKE2wX++6eje8B0kGXm2EDfktrHuQJgqvbSe+r+2CuPH00NXqpxdDtah6w3Fe4G8h3igO25EbYckmLZbKz2pOC4jyBH0qhgkRqjvgp9GkcVPvAGyVxpPBUpKy59I2OfnHDF5KHlpaWHYT1gnfWasgVriQ8qDUirVbXf4smeVwCYgm18tCUNODgQAe2omSmERhkUBt1hx2VTzF9ZKBLqKhpppu4ZXIamSwbmc8+RZc3cDAAADDDA0oR7MozEWNb83FCJHQh7Z5awnZD59krMml240rRLstYcAnnMA6N6mSO09yeQg8m77svmk0vi7JXiI9SUaCGRz50l6rJF4T7Vp2aflwTrAnfyxg5LmBht95nO+1fhe+aYZC7chEid9cnT3C06gfkk99MykpaEFtLqcdsY8BdudNWO8BYEuC8uIz93x/0CopfZPu2aYuZfhMG2BgUeKcCHoBhdBWWkjVY++zYuE3N9233UlJrPkjykRv/+jNVTZCzmfb7B30hMWe7Nwp+EryXYape/S/YQXBqcwLiswgMryw52TmtrJ5tTozl0+czlwoXkTr0DftZBMrbiC55PiSNHEMGDNb+AKDay8iK8ziJUMAJUvY6zFLUn2cWp+5+SeVXUsfHXUivs2B35sFSJ8y1W2xmaTbeh4i9D6E17WCcBMxJY/7lK5jgj90OzQo7uVwmisWAC6TSyBKHd6gfIzGBkhase8lEaQZ011UUnx1+W2Sp4G3GFi6xQo7qP5iTFF3cuxqq0/3/0yDhyno7rQV68qhJtkynVSUeE9x6RLQBf0lkRUsenQh9skf9s8/22w+QmIm/EwO5+joUjQpXyYbWkf2nsz4J4G6W1gABj8iNwOjIXWSxgVgOIpAx9czQZ2lI/Wuyl/s5cGRoirk3JULPXXzpRdxO69JX26jathudlrj32ATHucjD27iDsBwwdKw0ewHRF+XlvmdurPaYOd6tAFwFPP29QLHAze95dXsJv4fyBxs/uRzlXfIY+TWCeVEacLwFZVOsJv1qmj6wAKSv8EgdqEffrF9Wu2dOw5pWYrnKUgB5PxTMDrRLRtAKEWNrOHS6i+tygC8VrAfsLkdJLdngIj26x7H8lLv7ejl+ZKB4InFc/GdlE5nOFbrKduyZlpIJZ8x5pAAdsSIcFOtN71jW+Ypea+n8TRQ7ZjcxeFkBnjJj6PPWwPVV65/O5AAyDGuvEZu7S2nEJF+Re+HaEgKZ8Kv1wXvB8hoejzUxsWBUIfcWJ+HvhR4xtzgbDBN8CEsa6FbL2DusiRA+3nABNkN/z/vyGe1KdXfPIiVZBbjW95LVsJ92VNXd9jf9d0eUX/MaQd1AlyRbRMh9BdHU0e6WAX3HMVy71ztyuV+Q6Dlcxzy+7U3oD7wjoH9/2vrc8fK0jrRanxz2Pi125/tFvZLJf8R1754rZwuIPoiiyuB/Oai7qUos0qyfMMqkSkcoDycrSMHgBnX4PF79Ey17OxzqPeb5UrmfknASEi4rYgNgKzSirTiE+k9S98HiVU3bbXxNpqazaXApe7GIwPIiZd/7doSs+FlSTxE6wn0y0WGLtmpCCnrn7qCvTa+wmkjJiqwZdAhVgYAXLh1GCMMcvZoesjGAJPbrHMaQuhlD8jOMBEiGOHu9oAvAgX+O4n6IHasKTK17wgFxJuVWQWR2ZdvOElZ2t0PafimRFkfv7BRoDLhsQqDHLpqZ7Z/3gXUfgWordENtRCURmbDjUiyvt3MZF5uEjNU/Wr6n7Ad3zcXBdbeNBEcyjiAHYZOzTurPSJYlemlgv4MZggAiTxWAiX67PMXjZdMFtVxFXQuy7annwSsrU+spTD1VleKyH6p9Yn4di1CtjKx3ozHpCfR9kfrN3cH+D8CSQPhTwXzAVm4MLtSqXqovGP6T3d9gWr2lB+xS5fjUOXHwwGdIpYADpwaoyskMB4XrpWlKvKLcoyDYZTDHLfCCh7DNURMvAfG2I35XvW5VJ7EVttAmMIglSj1+bmoooBHE5+slqK+glXRTmyiKrzw+AdB50CiMOzVryO9kBCCOJwgdRgcK2yDIcWue/pQ232UBGzh7OFGfnaUDVp7nNITdIKzRm+nmQpt6JyYEdlcn5ol/j4PY5exmaYC340m/YHS0Hd38td0sLAQuo65IMgc6AqortFtzzv1ZPnc4nB11m/M+2uzKsq5o135OjgAR6TjODgWWRw7BXQrcbx51cmZrHfOqQ+T4O+J/5lNuL2tJb9xYl9KVcSE1L03m4fyCI6CrPZ5kIjjD0lP92aL1q6dknHW8CBEiPJEHywG+3C3X/5jLdyDqoY3sxmrF/hZ5xXUCwppfvyf/PFMZHr4GPH6OReXZl8sXIAj2yVdXnCNXiDXBhDes4w6yU21ixJp/jL6neehBH/AVV1nprrUlZtZJBfZC6hP0Ml4nGn0VqN+imkm0e6U3zObAEmJXSSCdS/mOGtiR0Yk5jTmJ3KR27cFUVgYlNEJft1MmgOVdBUotszk1TL91DuGyi8F7JDy06b70bW+9+4N7ZcmsDf8/9or2Hq/Ply/gRzeu14ItkE6FRRpfnXtJQUP4lNbQYsE/ImQUQAzfVxH4SKQm+7oo+jdoEBpn35s5C0kPwEq3bB6CzNdE6Oay6kIUFAgI90+9g3Nc6hTNOuMjqKgR0YtAJwUAElmGGAKxVumiLegI8ynvABdB4Du9mCixQ321S3QV7Xi1LNyJAAf5XiLotdA25vARLHJbtbUYEdL3fwt4l7mtM7D2jMcDRXV2B9mrTBFWWho2dhUDZq3FnSzWT1MNm0NCmYwcP9CLK+Ll1W6dYgSiwKFZ6+KvjF38hHtoh4RCVpjdREAhzntyuIWuCqvkaZtqAMJhAnG3xQEau11nPS7rBhl1lBC5enVorHH9nXJgyO0IfQvZyU9u7uHviAQYenFntdN5jeu+eJ28OpiKfUoyCwMftZaO36ZgwvN6vNaoTvOc6hmBRvekKktfhPQVUzmAiJZJaxceNqXQEr1/fIIbYvDrapwuTmMLgZQ2pzYHixJZJDgV+eM4Vj5qMOiCg7oYis+UbyxIToT+7lbsFJlJYEpac5WgstzyIKTHI390DHrnSuo/zCA8Sz3BwSA6NHJKlJ5qX7bKG+CIFGOC64O9B+ohm3Tnho5SqG9GgofWsldFK1BdKWZJQup/Ul9rTbvo481UuZ1Vc7wte2lT0WrZRUkP6A6L8AUHGUBkA4SDT1tyuOaGjCNnRxD6CxSAAADU5kayO9ETv5pZ7hWLZCtEnUsyrNlS4Xa0imiPV8bPk0l7I9xAF3tx+hy9kGIO3dHUyRZzFCB7hlcRnFebHFsqEi4nNJX2kfLFRXcYfPcCQ8+jF8J8va6lQPeSeL1VnOYVfzF8G5/T1huBnK0qqpSv3n7iIjFhdnFqAZCcU+C9S4C+n6QNg77TF0SIatrQDKSYEbHxGLDHQMBoMJRGNhIIIhwFaL1CZSqpYxHnF6wDluVAailsMAAAAAAAAAAAXhEjJ2GFxH9SnNoelO9MwPkEeSAHFYfnDkKkTuMuECDXiS+mv99yFLo5TLj411J1Ai9NrUFc/BPMTW5zRJDr/rcGH2voMNNeZO4sCa127QBGjkRP0myJ7ry2xcHH4IAfZTJy1ggsyNXkIEhsaSkxgPcGo+U3gXtBW6+Qdkkg62FbUCONEEycpqj7/7puyK9l/XOEIzqi1LtQT2SW4AAxoFg98w7Wt38xfpNY6aXjLjWTFB+Zqfj9Yh/ICnCtpATIRh+oHpiaUKd2ZOXRMlq9T7Qyd++ujtTogP90ag+aXXIHMs8IswhMV7BFI5sjF8RhrkeC1z75MMZoMmj5TeBe0BFbZLRdbP4YX21FsipertOBtRmGbL/Gh1H0ooAPnIW4AAnzsbq8ydy5Gr0QuxyB5A5hATOQDWjXoLIwlpXQZrSeMswNhKD+jFDzmS4Lf54SiDNnycTEuEq/EgaYYY3fN7kRL3XHxDjvX+6Fen962NR0A72n1KvyZWPogciDadRiglUAu6w2uqZelyRNxrPH53ZJ0ky9bw186mQ4TgfCP87uYU4ywARlAHr82e65PKyXnJtdDwBYufLPE7GzeGR53osT2Q6DLDxF6rkK0ABzOyw4tDSpRXsYxRW8k9Lnrsd+ltPN8SupsPpUQ8yxRoCD4okv+ldn76EUjZJF5mIE+sfPboGhYfZCNsNEYBZ9BZ0ysLSgMwtTvTuasFuxjbFh1tWsYzQ4BftObTHLDratYxmhwC3XX5qfmNIO6gN3Rz+mRK9InPFp/UA0g8RHn+2u2mrGJ+Kb0cmQMNbfWy95Lb0ULIlVnecq31VdUpw6i0YRgkyYY+BE6ehk/pPlTCvbzBMkgsv4lD61mfJIOCRM/lQpAVkQf/s1kJImd+bWGy0eQAXinamimZACs8ZZcy5ufzsiFzLEm3jA9md5OfzTtO2v4/OlEF1LxZ6TUtYqP7n59ikU4Nv8f7/k9ySGa8xVuOw/zKPc6Bq8AK2S06F2b0QozThlaO+TvP2VvLNAN/R0UNzCvUklHefEzMhYohfQ6m27ETZHJwwXXBA+WqAk6gfQeHusQUx/X/u2CEUKXFlYnKaOsdGFMEutgwqriBpCihvIKxDWzHRW0yrKuX44XJvCVrfXkvR4IHC1VvIbXJizJiVKb/+Q5q3HDg490y0k+B9yRQY9owws/OGaATVlRGUmJCPrztR36g7nOSTSFajqr6CbmNn40Zg59awDLpcnnSifU+Y0kI6F6YnkjJEdpIdNpHmL/R7fFJgl1ts/OgTZjur2aL6xIijtIP3NLmlZSEoRbq+1dTsp7ImcuqEI8ItyLqT3IXSsMV9i3n6wQ2KO5YkjtGx24D/3FJqh6wuXLwz3Bheo3c+KH1KDB7zE17xSKakqzebUElN92gGhFbUAVF07BG1AM/STBXAuLMqMorToN123vuz+Qk6NatWJe4rb487JZD31E+2oD9myNy+W907vvxsb9ERtYeee1pz1mUpIlTAkS1ae9pRsN+xuPB+81kI3kK8WqQ/AueCWkt4c6qwu8DnexWN4zxc6TiILykt2BBgqH3UzAMqqO0Q+05wWcG1RWRb2LC8umNHo52/VbffStYzO5Kg2ZJv2tfwrCzj8WL1g720dQkoY7srAM7C3OKtKRby9XQ66Z8cTaLu+MPspqF3sVgpZSst/GLy7ohj431VO5RH8SnaOdKkMUd9tRzGXNQlZet5gYGY7FDKEYHcwmfG5/CzzyhHxIDAPF3v/5/5uuYDN7wcRsINkDzdpUh3v4WKR7q7WqOamhFGBOE9mSaPSI1kllH7tf1R5Hl2JD+HIfbZZo11ulJTrH9o7hDVjRhydkvGjROPmhjmIzqCNDmPyXB84TNLMq5G1idAfx8QBOLsVISeWuSzpon0zrOXm0YnLYTSNAzsQpdY3sl8kjqVtwsDNhmmXkxg5plUwA24+j6GWYlDBIwjCo3HyZL3koFK+lsWW4WSbUnTMdfRarqGQsTpywdfLIccqMMKlmaE5iJoQ3OWkgDwdcQTOHvabnXxQnBmD+uOljLLZtgaf/34UrhuxrtBMsvdUJf+Z7CtnynLMfaLtddk5bU+SpMRNBNS9AFTGridwjYTqk6zCP9MiqkuyQAKYFER2kfi5cGw7gktPsl4ntD+4Am+lmCsiZwy5nVHDEzChqn+ogtkZgLlP2Iylu99xaQOOybv0IAKGMjWR/j2HPADet0cDaNRUH/rLzubVaYeO9DrqQzNz/l34DAjqacgYcN063Oiz8E0m0LYv7T+iHVwoCXY+AvOUdpH5vTCZBpV2xHXr2BTqrepnadcThJDOp43Fl+QmfT+GYVcLOFtouCGSgA2lyH/xyFw2lifPiwCVWqPpEbuKZCon5sC0cKASNJoJ/bgdMMH5fKS8EtI7I+HbQbGUfhKaLFxjUTgrniht+v4c4ck8Db4Dz6WIyyNQ1G25so42cOIKVSGSZjETm6HzDkBWf5QgzeqgcMIE53M7nKi2CshdqJvE67HC5ZEr2tHxKL6WMryb6FIVEzx06bognAaiXjgAJ8D9/+bG/scQ7sMOXWyAxhtjumONwbYBxa5mQmPwHB0in/SDhESTxAbS4B4KpVvxwqDaaclMjcUkSMPPbKs3rLxP6pfa+rbzYWkUSUm4TjvUFMtxltMD7t/GRcwADdT+ClpDy8zJtmaXh11ILHWexLCtWixD0kOKqHvIAADEhJvQPlQxEPVYcNdzSwb7cZrV2ehiqKs3FKBx4X4AXMLI9ECF/n4P/RP0shjEHymlbQpqiyO6kuZ1Mkth+LAkST8gOpeOGb6q+RT/dKUMLaHRV3s1lnKd5nzamY+F5rFwKuIPNi1r9LLUsKu1Okj7v8LF0bFigzymjZBY9vL/cE83EBsOsw9xysZRDvk+i6KIXAz1f4pOo9dfnSkKCxJGa9UnsbvlF65YGN8qNYicDkAdQLHEuoofpQbnOWNX48s1/ob+Ce7rBSqxATkyw6EOK8NpUJsDgcTXz+JANI7Y+GQaXtfTz+1uM8OSaT0Aj1EGUMP8Pei+YErGQxLbuSgzkWz/YJ7B0klNF8Tx1cPuBA/LO6J65LTy+8ObDNXWdl3oA9iETTnSqt3AOs0611+m+Lm3e3MOS9vMeW3ehOuzsYCs14KKobeE5amJIKVb0KW/8VN0wsvi4hN2ap5w5asOW0XXPykGSXZ+65Im4dbZD19rVaprTnZlEtFEWw5GspcQTHRMuIn8ZCUzOzDGrQzuW1jKYkBVz4EhM3b4MGwQy6neyfFAtj89tMjaDo7x5w40Hp0V2F0na/AAAyf2SkqDgAl5qN7yVfSYYl1BvsH7J+aTR0BCRqkOgWIaUgvTTW7U/XuHb6TnIqEf3knFqwojgkmCr87BRgOlUpKmgSB9FhUOhBL9zfI9mtTIYsBUWu3LwTcfz3cCeUgzt6QyvUzRA5azLujZ8fQZfpD+jscCryKoSee5SUySaLr24hPoblXVvQrXm13zUZbF8m5lySVnsrPuYnL0Xy1gNI4XXB9gC8QyInFU3VEbiLx8uwPQiMkV2hok5+IxB+SShGMazmIwu1ef3qMPQm1Qc4Q5AsAaRlNdDGi9lmOj116rScywuTG2JvNtj2J0H2YrrdkxL+jqQYIpJYeRB1yZFmHV7jpPfapZyKDehRQhXyjVzi+AIo1jK9TNEDlrMu67WPw6H0WLUUwwca6dAWVcXFn8YW7nULb8KsYFapT1Hx9EmCQa5nsuhZrYvYrxaOzaCQo5LaK21tdU+sSm74EKl3GYULVfBv7+YFvAkZ2XKrpsUQVNGpEqF0kAAAAAAAABoF0dqfZbHINEk4nQi19//XoApxYnb+R2P9g3gJr8MfT07VEW+RnUOuL3N59ocKjExJATPyjiBYJbTdX2hh8YjvTrSfQhbLC7sH2ygwnWWmdu5vXue7K9JFycyT0pyXkiL6jOFTKbu8McXqamKXBHG+vY5UWnE2w4XeKDUR4jJgr+C7UQcDUn8twBCfw6XgFWoEJFQ7ywra72oVu22JcdK5zVhN0PYm/PorzWiSnnoZcq2yk67tzMwfCyOSH6hGSiVlKNk4p2UX839A8zEHyQwQ+a/+rkCfNn3N+adwJ5pQXsg3ouNWdhydNyOjW4xzGJ0RqfqOdikot8YSCBrDqV4fkqAPyBFq7L/4AzRxGYlTW0qKLkverrZNasBsfdMenVFuo1cR6ujdjTLr7OcPYwSdDmL0UA1qqQUwjouAA4yCGaxbEKcZZflNh+zjgXCYXvEACPxo3kC6g0JYbvqWZAMf3bIVJTxVSWGKlNu67u89vyiI5YYmGHHlI1gV9hJT6Sq5QuOjpVFZ4HP2eNwU8aNMlw+wQMr9E94O79cMkZbccZf/GGNFzzIUn+Mp5yeWNJKwjfQ53T0vIRex/z80FpV1Wg5VqAT/VlTBuwlLP7MhFqeRU/lWwn6inHt47z1r58cynsnhA6WIedngeTrusyYbjLIpLHMU/3fLKlH9CyZM24tQXf2Kma4IIhd8S9NgWnEW88Ju4//93UxTug3ItBOImIsRS33MVv7/BG9s5xTbYylB4bHHVy6lMZoKLBMMSwoLpo96hWZl4yBTEzx2SyQ5Qe4cMkGK2nqgT0GT+1SFan5SzjWv5v64e+ExmPFoYE5PzYgTirI+uI+Uy8zY/pXlTKfVI0sWGK6bgEdJ968938CxJQHR0Gi/3RNmFyxQIC/c4d3ybr+0Doh0zK0vuNPKDlxeTxG4EWJfnXdnbYkz1P7xESCSi3bMnhyMdJAd1dK1QfIRy3xn9QcwAr6vU7iXLFvj8j5FIS7R+LYiShG1P0fichbJ0ffYZD0sWDUEwHZrTAXLhUiRE5LEZZN85tTXh2z/aMVKQruFFhsH7no9CcotES6/XriDTqNPEu/Zw4vqyVH6qTCvQb7HNr8U7UOgD1i65v2JsitfRefx91Hf5KdkUAkOelMQzB+6FuiQpFnEdJ/FNRfbAC+sYVNgr9aSdwADqzSCpFt/HkPtbtPaW4OuBkhxiiKyKT/oT0dHgcwVmSFcnDuwR7IfFbf0ArQwZYTdSIZqCccKigNWFYzWecFy+XEE+tDBmnTrTd5CqS1sOiiHpzceNJUi1TvCKOFJHYGKxhewTfvREWgc7qpMAAFuI6XkMtr6pqM2q/Rympw54rRsKEGLVHDz3AkcYDo2or3XthNvGPeXxjVTj/wNeRbS4g//NZp1ZxSpks7DLHzjGh+1s3LQ0r07LcVIzWQx3ZUA5Mp3MIrEABg/IMl4eVy+YRiYTCUKhzAJd1aLESj3xn1S9BtRq/BM+i7ltKKwJXvE3FDnMuUFXLIQ+Kq5K61AONvGPeRfGbYx74ho9WrPSC5s0b+9/q6azGII0o28IOZvX3tt+xDO9yveJvNlwSIWj24C/5xRz2LFuiFqbPXP4BsbTcxaNRp8M/ShXZod5UovKyDbVdpYQcmzcpqbhI1cjqIz5JR3KCtMMi+reNsgMu+Ccm+GTev00Dwh4fZPeQQJIiCc7mRQHHykq7PjoEt8CZbwfLuGReRrELEa61kNwfPhCVQ3y+NctQkMV7x4w+O/VfpRMVmodpdKNRboN0HSKpEZvAAMhIg7mvjVFxqP7PLn/uhyoETRPqKpfRYnQQtGSSr2tZwL4EPgTX8hzm24bEa2mA/KB16FzmvGQxXk/jq991dyDRSF0IILwDVRGl2GqpXrVFnC74PvLAZKo7gISvvgIlJCCGXvopHXLm7dp/VahmjKCe42xdyhCRHzYgINp9rxMEl4abqDyQr3iuHJ8HM9hvysDu1UebTbdeiunrcU4ePh8dETYitWcPGgVLatU9vH9VKNL/YU1En5Dmpnf/FemjNDDh3EBLGS9xmyWfnsqgpXkjJ3UDC7IWRHiRte1SS+rYH4le/vUkiBjoKR0FO49c0eLA5dbD6S+cVT8As8lfTXhHkjbnXOyq8vJkRB1GEhChn05tS9L6dRHTeuEstdcA0bSs6pNpJw98oR6SRQKWx7kQbDeAsyb+oXgq4idA3eETacG2iS34axj+vNAhc4tT+OaPZczMI6BQ05bm2xIBSMIQID5BtqznWHZJNyiRZJ7RMugT/1UHtQct2uzhBDICfVuqNQda9FPf8Xtd9tdYx8A3pYXFc00g37PA24H3d8uFrWR7Azin4wqWXMH9Wbij4y2AqEVevoVrDFS0DjNY7QB3M7hNLYoEgNUiPnVNfXjuI4ruQFQWZpAPSgA9Vwh1jZlOgzY1OyjnoLAOBEV9fK2Oamoi04E5Bh55k8spTyWNYGOHkQTkLvDkZqcDeA5WngJpKnAKjd+fW0WjWeA3r9gkO7C5+Pma+M/7791YyEP54zDhuby6AlVq5jMeVKaV2Frkbu3Yox7r9LUTcbhMzzqnCRPyRSoIRcBV/s1geYx3z7v22OvyvS7ySD83YADpPXA+swHFe/m35htBfM1P+TZX1HiDwMC0OrCYqS+L4J/fO8sseGvixNh2GoDfFabGCbHezwJEHsRWq2GnqTwXkfg2ak4AIzrpQMU5Fg8TgTxscvNFNtJ01AAgRTdyQJ/Lx45vEVMFanzv9sbKyLsINa+c92F3EXPMHIXS2sTJlPewCPsszMOwEYypA+8KbvaI4+qw5nnVBJs+U8VZTiwlCA+QVtE73cdY6yD6RgAmPeRcCxhyVpt1YgLH+L/eWI2Paq6HgHa7ME/ElV8t86w3tedmrlinzL49QkUNhrRrAQgw55GFgl+6ip144XyZpY85S+yeVsgrrSgk4wKRzxduTwY5Bxtv61VH0aewhZfqqZJnelDh8v4IVbl0N93Isx5WgYDA2gHM5QI1Mjem8jky5rdmyXPse9AYru1uSELbplQNjpL9nasOPVet0diqxPj75QWkYZ4GOnUq6Q4Z63fp5byMmhUdfblKCmI1OJDe2iWgEekkUCxNmWiS3n7N+waJfn4Q9UFd3M8wHrbQOzn5n4296yjqmKktsquEtZUTh/UlAQHLUXX0ifg1AXFd3V1B2VATL1jE2EA40FAVkWBOcCPdujeFlozK2D/0La0eVxIEqX89DZFmaqRi6sDtw46nv9xo8lve7wyr8mLbFVSShjUAtBkKREAHjNz540zhm25sHXm7Xp3ixeeOzUb9OoeJbI8S/p7pdw9WJ8Cr97k5OU428QTwvYdR/glLVR1GDVmxirhXwhTsy7eGKzF0Gl2sKbbTHY6Uo4LO51dJrQF6MazQEq3rvqOGo5PS9qwILZBuGwzcJoeJceDQukamt4uicopXfKTyO4Hr8K/QevGB+EBFu4R0NrHZZKROMATjhDkVlsuSS+qfuP5TjbcKhDFUCwpBRjTZrYW8XZ1Cs96/7+O2wbp8M7fBBgvksEOo0xFu1eFrJbML8od9Z2oaEhjj3H1g9aCZbGXkFdf1VJ1wjywhspi6aLtJXvZWkkbgidG6vNUUSyEJUVc/jnNcBKB5VedKp1ZQQQ3I3UzRnsvuHigsbtY9J/OnuNh2QhNMrArtrMdDqLQbIvacO1W/Nc+amLzkGVMeIGT5nNb7G4J90nfvR/Sf5SmfmlPOFh47zUIltcrwEwfTsaoCszmPwIqTCW8wA0bnXi5+R5MG/K/vwk1F9/B5smLxKHb32GI7qIPU8jNU7s1SC3D+y8UKK8lsB55gfykAblNVvq/OTyEZj7aT8NN1cvbXZ4YMmkI52Ue7EhCtvFmNkTBhv12NcIqEqOp7/h4Z6FgPx2ptsQcRXpowZ43ZPQEnzcrjyrqDkp19fzsTyQghWIitIzMvhup4Bf26FghBkYQFZO8fzj/NT67bwMuNT5bGG6IPFyFpcWno/lAzfKaR21hTwUrwccJGZyvvdj5xsQai0ti2sVQoQeGRpfs3Uj0KY3RIL7CHwTwP56vtEatDITX2IJ+JP5NBGZcFp3MS4bsld7xKsumdphVB0XAiKIjt856rD/UOONj4kzVHFb4ZiNGvQ/B/yZNsM6keYoj1mPGxLm7oI9mVhIKKIJE3dnqxoIKxUGJJjr3ehpJMtR5Pishhh4MX6HxuVplKudhkqceqo5hcKmoiNT7Up9iEcCHw0B6xzmgNhNj9QIzVMM+YA4Zot7ge2mewsEAOW02ggYZjfI7rGWuWpnicNRNaJlrWMxW5aa8NpIYo00XaAzq0M8TqAVITrjw815ooJV1/QZy4+ejppZQCT0PszV3IGJBtFUqb2UrHqtElTLYAAAAAAAuWzxPi8sac2cSivTy4cv5IDc0tLpr+/69SvItNSC8N3B8IrADhx+DzGhaxjKGHCMDMJj5wvOOvoRzg45I84FpuCvGm43qVX/r/qkQgcqEvfHvQ/yFEaZJAxHx4+Pm3QuFm6FkuwODLwALxXPZW9k9qLlxxZDYm0PDuVm8VjE/v/0YAOStvWoxtuoLaGIh5giyg4IGQTEkAwVpL1UU6usXxHfsslLH0nzpTcVTYb+ORwnMyheP3chJGX4UY5E906JGNwZ24vZ0oZtZux2FZdIqLd9KXFuSBGT/CfIk8uqSTxTfExZxenQ1If4Qa6rFhUnisCkbYuk1NHUj72ut9WH8/44Up0ti/yvDQxqWINqpZQnjspb5upyo0z3PBFA7Ofpx3D1FyyJoG2dAHgtwPcJnfynsfhP4q8FPqJSFZDo3hffNMvf04PnngrrecqN1/y4sj4AbelBq1DPiFlSc9tUm9OUzAkaqoZrI85B3vGqz4RqXC3hKCElNlZJWRbmLLMUS0kYZvsxcOdk8qjpEbfb+//BR53SFTjZvk8DRdfJk3FostGJQg8S8ArRLV1JvdCf07Yurxc5ugKUV9SVm24oh2uEYEnkP6SMcy0i//aBILeZOjghuvxYm7TZzCOpGolSTHCLogNQ8WZxR6jq9gmG7eYjNdUWy87ENbrvUJIrADhx+DZCmYfXQMYDndjrqGgH9gTlKxEDV6rbd3pJk2yHQ6PAgRIjyRB8sBv0QUx2z0igh0WsewJBevVKEMZX037dk4drlbRCtlNPymE3M/76lgwdzYBUm4rPQFI5+STPVYW1MYXUJ+hkvE40+itTNmVOrZ+MkegV0BCEyK+3O20XRMmmFuL+Lf0AMhQwHtp2zZqw+bQFmBcov4qXbuXORV8kSuLcB1afNdpjFUna8z4Q69rgTLYp0qQRDJ+V73Ntt78P3CA1+iMlW07m4tLw5owdswRCvUI9HpC3IcV/WVeQc2ej0MVS1kjr9cvnW+2lmHeM5kfhOpEkQM+OYjATc7KERTCdkvP5GDGW2nFwHjjtLzEmfoUaVWMgUiKBAiRuSWbOZVivCI5nJbR8NYxSqfGMGm02TarTsygaPDJVzyTl75bcSS6No/tcyO278mwcDcgVCBykEGlvpSRbMfCzXAmPIIA2uzjpWS3EIJ+J+ixnASC2cgLQk6RNRs0gempUxccR+KD7n1ht+3iBGh3swevRa2K3FW9ba/drp3b2oKetQIMYIhiXmKsLkm4wXc9GiHY+JgHXiehNXrtW8AJMEnEuUsYEOFjHwXGQwWnUdVtPc9Ux554qF5ATgCKP20ZrqqfLKGBVRdn2wB0tmtP41HKf8Qm0+quTwvNKi9bx2BuEov9VhjmN3kCZ5zjJSl2c4V8ptWxV4x+rJusMAFcPBruqkwBYpbnw3Byh0C+qsxg1KyEt1yrAb33hw0haOJkEfyzVaDEd84rVyOxXeA68fXHvnZy8Z8hLd5ikfsXPYN76EYqnd5v4U3DD/GE26+oKh1f+FsPn/VWQYbJJw25XmrfzRUUZxKZbXAb7re5QG+/pGROuWoLbpHo4DngBo4TtcyZ5a0OdI96P28GSQMj9YC0TkgpGSzQzAN8WiZJeK4MiBIGhcmBRbimx2FY8zQ5jjZUU8j4swAgHUE6xoVcFtugjHi+tkrNl/efh9B5T1XZ34QdSX4BxiXtgCP4QEQRzOnfPQ8fFloY9DEVMDPgPDrtlP2xDxndYhJM+T8OYkYc2E+qPJDE/1BrWXG6c2Z62YRD1J4ZDePpqjBAitSyOLmOvIkciAVG9zTUz9GPWvImOBbYWFtYCfqnTolDBNDR5l0EsyJJ51DJqwYgIXlKflvEXbhTbpzEASqOEFygKTpMCqDO21YGP4vEvkBfGvZbw2C7ALBLckpcOA5umrT5Ps5DUB78vxv9aXyn2tqFQnwMKeCctTfR/Z9LS74eKk81M1JsuIPYsoRi+6Mb5unSBIMC1+2YGPmlwO4mtFouHzTA+7ajX3gxE4+ONZzab2On95ofFRfo0oUCsrs1sQJydlo0gb6chcDsixbOPmAoCUrgSVTodRFDG/RC1uoDKaDeddZlmGo3oZur6kMP+blo4w+XqGJA4OX0UHd8Ruhx6duwSc31nQnZn3bWPAqpMTv5ruSU36lg+5WcPJGIksFjYW5uH0pFU00clWbiIg6Q/TM2moydzt0mRYRwkgZzfRkrZzBy0IshcxzsCTdHoAbPHOdQWbgtwBlmGpRbCLj0/lsRsvX5yDqBaxewdbosWM/MkS3LI5agIydBmET/FztwkwtWtHgaOBXJOAoQY5fGsQTVitDt7q0VXi1YBnz1IQ87Hf53YhJWy0V3j6hxhlzCw5UpiK1g15aJWP6X3adrRwgJHAg4djvTG2yViPDAE1rN5uhWV3uFLJYMc8+4aI4V37RXSDFaBhCJQ+N5BVnMJ78uJAMFKWh/XfmATLCdcKWe71O/Y6jIZw7UEaYYX6ZW1NwJbWMXzQwA6tttbQvr1qnMGPfF2FK7NQTPjqkjrXsGod6rSPF6fzCAC0Iw+b/S/i/AH9wXneJJhA3VYdQcUukSM/aEEcBLd9P67CY+UlMAVkJ/TgcJ1ePU0jImggwgdtisCNK+fhZlxED5Pn3xvdgKdAnv95hWJDuM7fJUtzdFpgPXIn6igOTU24jjSp1pFAXRHfVv7yda3K4hYuGDWFpPJ6JU8UA6Cfk7GY5xcl68/foqeKEALO8mgIElfW7fgzZ937lH04bKaC/+APWTu/8MEQVsX/8SL+JOhnxq5Du2QiIZ2kGyIajpyR3mzLeYYzSqBy5ocnnK1Xi8CZSXxGb+CuwtI4qp7rv18iBAlLEYjtEA9j2hMuetB2C+49naolBgTNia/RnvCHfXZV91T8H3H06oLwC8OblXBMHF+xPQPyMr4V3TO/7zkJOG1+gMynK+aPwfVnjggBRii0Jin9cI67eCiyiZ5oLpPznacTBgsRoiqOUaZGxAqncZ2oMZdFun/Dwhk1Rl37pGtBBr+TDXfROe+4CpO8UBY6iv9KLYOVtoDsboJ4XQs7Z+L63OORaWFHqopqXPnHeQixreigB5Lh4T4pbNSxXaCtsnmvmrt0fMJPP4JN1poNYoHTvhNcaOvaJtPp91Zn5KnSAFedAzlASmXcwGxxPmttJ/NpT31G2rELDXiLE+JHdX0pOuSDt/SMlpUWFmiwkhhwHMBX+CN391Mhu1VPc0OVP3zGqSGkhWtLxuVHcGhzfPwNpflPlu6yEFsLqUxs8qMLt9QHU9GoAMaz+IFFNAI4HocrhpBhSx7EMihflTLfE4tY9Ll9bxaxBdcYcsh65Y+C6WD5j2LUNkATPLse98KeHdX97NYLRj8lOoH9Fwas86IMEuBKeNWARBSHJG58E5BYQ4FbQ7ZQDe1Zd8lRS2J4G2tPwiby+erDwgbuRL37LzIjjZn9npuy1RdROipWyRxmmqF/JjKXvuIET8cabK0clx85egefo2BkEOZQ97h7EnUQQ83+AICLgxtxNLd32vwuh7T0IbWwKvABeLjvlmN7ptoaFalReoNay43Px09cg9bf+8ZoC+04718d0h473epH3XVhLbSN2J8+lNDXFXRdO2gUnTZguH8guUgwkbFgc6WuHrW+NNB7I45i1wtIWqwgzNg0JHywjWQcx823mWtca3jAw09ZMr2FrSuxREVPKGtKlv5b/rpgd3jb9LHOFy7Bh+pJiuh5GCrF2G5ybfIeTPTZ+OgOVoPbfWP0qiRIQzqV/uxy4dAPRiUW1jBV2rjMKn3MII9hDFKHMQ+c3YQj6utFZ6BYVHv6ktsNSuL+BeZtjze7cBx68rZU6j4xi5vI/EHrfMJOy8c97jgkJcAwLyeT0G3SQ4a191sHefqNGXQHujFMCCTultPQNdJYJkJCJAtVYi9q5Xc29AWhSnOQEZ61ryM74lC7DFNMh9xlK8ZXopIZYZEnuZ3GlGXghZ6ARGJt/vyDNJhbDgsAJ+KgoImyGbmcDvQl32te9fOgWOYa47n/7Fk5WhPEyNy11X+cnUIFM0Kws4M4Ed5/AdmgxgdzCvLhMdy3cxAvXeP9y0D2rDkDR7QtNIRLD9tkBsxcgIR3UPxWKRAnkqEl7TaH40QAX9PNPfMo+v/RhZMQcXTRFeEciWeVOKuxA6SiTkqR68/IrRUyqynRTLwgLJrG3Q/UKFNATJeWRnH8oSnKpwBMen1Eryhb/3W7Yf3hTROA1giuk/XvQizIFKQRcQomd6lhTrI43HId6Ms1c2L6ZJxj+ZcJAosQUJHcZ7XzOMh+PrKWBIZJD+HO8/UIJ2yLlBGEBpa1qAhVlwAf8t28x8s+uSZE0tSordn5yRekRwVQQkxLSK4lGSKgD1SpDdRNl6jj65Zg0mz9pmyey1TUcCWZkd1o3ZkCdO87Xe7khAXGXbZWvzlUmxzF7jagxxjjZcSPdXGbG0uz9CBoXO1iwNXG9nKNvFyH1a3F0hnvEJkp02ry2YCyMP7aWa8LpyAkAGJvrHNeF74T/fjrKdBH+JPk+JyCky3LLOY44In36G+zznqRTndmXAZpyT86EqW8oreS+u/qkbtDsR9XSGt8OuoKjrtolzM71QTUclTTCY16498pz0iPnPU90nK2KmQqI6tq5wY/9wgXaAREMEaqvAvOzuywUHZlgzpyGm6lMHC6UxhOT3H5rd/RDij9YfXjXNl00+LedrfP+T6CGniME7Jq4lwAKhG2vzTER0/ENmgWmoTsCX6739j6cOpVWLgBI9Lx2Ni1psmPvVWNxFT3i/PO5UWtAlHzESRqd6NLVNqhocP/IWFWuxfvj8DbbHd37NNJIVO9zEjtw6IlrJXh62fzOKbZtpXKbvogIF2NlSMKfjRsoLP3326UaQ52ACkptWxXZ/HQqbobWQVYgmRmERstidnIAAAAAAtcdEx78sPx7HUPwreGH6jSNFUsWJlmLAcP2ijeD5CROKMVYwh+c1W1DH2wEj61TYYgQWcjq4XN+iZjej6SIezlzTZQdbb2PXEuQeth5QHKm/Vl9YQGy0Xw6uCckQ9v/wUedVAW++vftWmKAqB3Vy6vvcCh8TL7cHhleoP/CGMjuWxm5xk4+GAzpFLAAcwChk7/R0bVs4JbrKg+94UqLe/nGwAxvIIS8K35V49Rr/cRdRPs+IKKy04f/J/AYVNgUzbLUUKozeO+O6xWuuEUpEJQHbsXkAXboiTxrEJXWwR8uiYtV/LRmGWfC8GTHOHuelJNAW7pTlqMENJkBkft9IUsg/UJvSeq5huWKp9EmBLP6FomqJACmGfcf+8dYF2rZTG6b5nUkcWu8l1gSlaVMb+M7YDxFYNIuJxo17ypC8KsOa8ikZOoTRtPqWrlGmUjTb3aBAaZ9/LhrfJbY+Ux9aawGNd56hvGz2ZppoD5433LbsNIMJmdD3ulzDPNxTWpOTr95mTayeATwxVJBsXCnu4UmuDVmjDiWzWflLV2P1EUHEKA3zjUPp6DnI9CbLsQlts3uZOYmWDGd1CX1UlRnHEUstcn8ZIm6wiskfYwqglM6qYP+5bTRsudAqdWlOoKheE5PH6J9L6B+2FtacwnozfL9t0LIp6qvD/m/my+23kg5+Ax4/Jt8n4RAO9mVQbEMCYi0Octs3E3MD7N/7P8kWL6n5R6+38UPYrsmiS9T1trh8C0Fx9DjqWeqGfE7a+WQS+B0Ez9iZvfWDW+i9pmMkDPemRsf20lrc7JNgJ9uRvAKQOS4Q6VtAQWJiXjlh3mqzZZHPzYVBQmO6bF6TV2RI9lcQpHg33DDu5xCOqZGZdPJttVNUOgWvag3iH7FtAu6nOPz4D2gGWi3nD0bey30t155P6NKE+xQ8Lq1vHXRi+w4smZ969Pz51eVZFcNSdDFcYpw61yrp7/g97D7slrpaXVoFtxeqjJS2MlL2IFOGT1STIAN1zP6jKM2oc4hyafAh9/rbnteN/N0zvN+bJ3nfJvK56OUclG3N3wt4hWqPiGto9fpt3nZTpgYz/mn1SJz/K17rHpfPtMDoC1eB2WpIaCstwdtlXJFXFF272DYhXYCOB2toIBygTmldi03vc5ANfbBaz/oapNJOJQ1SDWhkbzDmR3MQ+xKKoXz9MMmrp7oUww5LnzI/5ErTD91j9QYH7jtLzEnb8TNWII8pJVKe8GZHaSIbMkXP/PwHTgDL/npOUIzDv66lgSzPUoMDew7DSbgHF0p3P2xJBSns/jq0SoOrqrqJbTgK1GqmXiHh+utor3TF5fUamMIdSfK0tzgzlYizLHc8BE3WpLI9Cs2Am7v85Gpnk/OtVOsAmfUcdK7lBBCySldpfzUSJFPB8AL2jYEsDXgnrngJe/VTVZfWhBFbh3TApGj/FLBLGf6PzZjTH0s1jEYZ7wutshOKLAbjAozmin9NfPCh/SQVJ0AgbL74a+uDwvT3kRHa4w0NM52/sSBc8zi2KjzoFfFJIOXIVa/K8ov22qiSfaNvjtOxsvrJkCpTqN+4mMQrSQUGBXDX0tcXarM4UcbGbRdX/LKyzoQTAQpXQY35nwGR7M/q9abYXlLPzKC/7xbKl2eUR0sNPNb8wvrJWGm57kD8KjAhExhwmD+dccOG3wp4Akqs28By0MR14zG4dQ3bm7QY5tLdPWD7zT39XSLwW6zjc54+aea29eU9jgQ9NaRxl2Cno/x7OkK3zil4C5RwDJeVf3t+NeKpwStYm/gYz35tGvcDLnVRycUlm0xjW+o0R9lW9t4+dZ1S3mZe5JfWjDRGHyYazQwU+xwQImks9eBL1x8tG8TYdClrdtJMYXeHm7gyQY+r98lGzJdn62t8b+M03LkHquEhWwPCygKXbxgrXi/Hv5x3qIIn3Lmwnu56WGAPMHyjhui/hqVYkLrjlcjFrMvjWhWCJg1Um97QxpjdY1HysJbzADRudc6l/BrUPa3UKFnGFERJASQUSoxcBR2yf86USFzHzkCxggct9pqsf1P+kOaUlJ4Ugwpjrod2TgVxua1oXg7Ffx8RTO6zTSqWVOoA+vfUVJkpuASkSld64WWcYIYEpOF4U+ovZ1xwVLhRXpovE5Dgb1LNu360ZiYZZB9sW4I7SmDDUBEhibm8E+9YG5+ze3VSYMdc4YA8wp+gozgTg8VJ7FOWwYr5cJUYzqpJB6GX9hIYIjVPmu2WhsnTdGI3EY1kXGgceBTtKXzzeEjm9/vWRXgSI9TNIcYOYEBAd1C9UncIT3U8KrPbIgP9nOGt8CjxDPrMN9KZtV9lQzPJTStTi6z7dygYI77yfDJvfIlhMMQ/cy96cI08wCzrOAJn3f3SZ4Qf9/o4euATekV/jPAfKEedDhCe6nhVZ7ZEZSneYXj7lUT+JP5NBGZWzDrXlachgOztOhcrvXY6pviE8icZfch2UJdVEPCRxhN/WoDJhczSUW3lppw+HJWDuwoBBAxIT7bl1/Qt+rOOTgwdFb9Z4jpOF6otno/1xRES0SM9IFZO4FlXOiDOm0/eiOcAG1jdH6DbmSKgklm8hXrlAJxwhyLTNlyc/VD1YN274fnE0qNrKoQpEr92urVMiN9AnSGySGIA1EQCOCponOQoTsFjMVuWmrAsxs3l8J9Sc6OBwKMiARr33wuu/zFui0qGaQHoFRWpbVHwgbxFFWGVU/B8DWW/jsCrFEM5d6zJA9Pc5wQfPO5kQqDPRRWJwbNATKQuHFSfR4Prwtix1dp+2zAK2cHru/cgZ9dsNT3aG/dqnThB/sRQ01ONBywxccS82SGq606YlEqqgbBlF5TO8HPZst8hFM/pm11590LU/j8i3Z0rEeAjBb7BC+iiVFkl6JOGAXJy87MrmRkSrJxpDpOvnRg0tBBpA7np6ziMYUZABVsM9clfs3AUrcuQ5HrAQONZw9GR9DcvTr/8biK9kGjys3LTfNkNC4HrTP+ubiPb0F7IQAbHWHar2gSG22sXpeN6oV3USb2Rh9WMWJ3X0n0YJnWZsXTiAaEhySxBWX+lAiI1UaPPnthbyiqX+6Ircb8ZWftxfky/sa1EYD5h8NkWxcCeF949GVG7EI1iMnloA5bw3U/ixOSHX1+4JxKZlnTe1nUeQHc+LcE4sFxw/Db+sjvVrwNUesO1nZ4y1ccAB8FTl2ke7ai5Tq4qyUJ5W5bVYD4rRYgIq09GLfAsPmoNfXzkPOveCvNbEqs/89pIYpNYaDtzbyRMUSMHZh+3Dp+VzuG9LDV2kezgO4OdPV034mOGJ5/gtITP/wMe7ai5Tr6oRkDOVECg+L4SbB3duxRj3X4HoAYw+R85QzGLcajCc0FtP3i3r4E6Ge/jZRjn81zX94Dq8zUmURC0iNy19da1TK20UzfCKphL/acx7l07iE0WujzP0SHDirV7hExF0Z5Z0jeGOIgrOf8SWoIO4kupnStB5d1zcNN+5AqKuRMkUXch1J1JBtu5LRXvzyU5N3GMxfF4z9MQVuupP42Oqyc78++3GvBxtorVZ7Fjq8sjZ24XDuuOL+6qg77XGp4CabFFiN19xTlKlJpv9YikKfOZ0vXcG7OOKFhYyvejDFB3RJJijQr2B+3BlQ7sl9WAjxZhxj7t2XaKfi8ax8vZgPPaRo/i5/EKZATXJQbMfkN1nlK7B+Bi5zY82VeYUHv0wsYnIWBmYPmtcexOoWCgvh+65hiMCYKtHgWJvMdtHMV1TJr9SWsxEdfOsYwdq26mJAfFzZ657J1ivLQQ8lZ3sJUSw4JhioGQEF4TCeiOpcgUz4C9E1iFNgbwdvvxhWdg1RxDCcT0knrT4pI/FBBd4k10Omit/IaHwUrwlRYeMrlG0hsS7uawXPY7/AgAAAAAXnI0Ps6IhfEI7s7hMU6AZn683V+Q0A9u35SyjWpdY1NEtcch1MEPbJbvsVwuCidaEhWTVbbystYnN9MGMWZHM2LfUF3KlHwrZyNp17X4tI5eYWiBpV8OrgnJENK7uz5u8HOmjRRbyb4FzrEBO2A+bVV5tWpJuuKMFPDaKcd7GgoNwhj7D1ITTIEe22S+UAlloHIU/JyEVmZnEmABP1ixTyxxvyX8opzQuSxCZOdQZLtfsV0+1AABW4IVj30sIQJLPbyiNkrxVGM/pDf0oJBqoj2HaLs6NtqxPPJKNhkdC8HVHDYpO1n1ll5kANn6lKoDjZlME2utLQQcYNELzAkEKcRMtQf6vouZsJ7rWeujUAhec4lr06zBBNr7ViWWwbgxyZtbJ1Hnfwim/LjJy2yQObwbyZ3xBez6kf0P0nIvP1NekI65g/Nh9ik5YswdTYIGJHFnJ4rd1UBmIatACpu2Oh8X3EYn4e8jf+jmkvvBjstqxwKgEYVIDjdUL6y/X1ssiSkZkemtr3wfNa95MHANm6dqm4rOfpQ7Da9bVV67Y86ZXxqWO/oujKJp1KvHE3F5Sx4xYvngGd9Lv7xycQ5CDk155DJQuqUbOxO6ZA7zVonrj4HDlnP1/wYgl4E+i1ePoy4t5qIoTJYd9SAfRSY3YVHSQIzzcz2FK1eBbhfr+j4Uy9kEP5PEOA54jDoelgvRtmroCrpjiNkXFCQSAqWM9DHWokf+FblWd9d8Gt8K5Wn+EALt6nQAIfgjF6lQ2O6vocNu5vE2On5otVPGQBtSL7V5DWb+FHV3n0v6KSd0gU9zcAAjYm44cNcLCH3FJ2rzour8Z7QOA+41HGLnKEIOb9q6y1T6lcgi/Hpv29Wz3QbfeIgy/2J/LiI5Qggys0OZO2fajiVg1WuWUnhp/eaGNgIeOnEDniwXRn3yl5H/ndgZj8/kSHnnbVsEYyeq2fZ9A9nezBpXaX81EgoeVPf538GuUAjii3R0dOieLDpxzDhXeo24xchShzA14w41wMpwBzkIa+YS2/bPbFWmvBhPk8Ut1wkPtUjPDgAE2VmhSBP3hBUmijnAuyqRgq6WiNpXUfQboC+AnsVQP490uNKUzewTENmH+YQzICidlyH5nuSMkJv0EXJDAJyKwdKKyf4h1Wy9NUIoLo3bas0sQLri7wwKNEwaFl4Wv+bI8xdXomhFDmv5z8ThYJ3t4bDchE83oX4zZyDJ1T3Sgt3Oc6UhPREKwjcRBcuQ2Nrc1fPYlpIepb1QDmIPBgjIDRycAYyjJfT44RjzwyNL9m6xXvE+A/MyHeieRd+U3ITdSLi5y6IIsP0CBbB6IaJk5kBF/W82QKKlMmwCGBMuHBLB2QOFqbrJGJ4QM1HcCJZ+dC/jUpz0t2+k3QumEUUeU170W1AXVZx4V9TADef2C/U+N+/Ma6SZ3fUxhiOf1fn7NmxF6rdZq5MigOPlJV26MXOqdZkFhxT9BGtF00NuzOIN1MGl/jrsjy7q518xlPNZkFTCYyQsUmhXY491nVGVyghhapu1E+yYxP2XXih5Rh2Po8GiUX++/aodMJG6Iq2K+IbywNcGvxc0P1pvOPiK6D/FSUdJ/cjJrBabVcv5tA63c9x+HccM/CBFGW9K6/S7DTuPs+L6K2qKGW6gvVJzFUYFnMAn60rczF/0scZUrOuEl0OJ4d+rDNV3Jr1vu8eL5R20mwan+dMnTZ1ueWk4Nb2pR0+3ddfpRPvijDuICVJyDWFItipZtnIz2ThjElnGlu+6vlze9Eid8jGzQBCsBVX6J+3rtlCtXnC9mAfwwjYyDBT3QhNSKObNLElLfgRP9gqnbsKXrijtpNh7/G/cv/bjYFwo0VHywULualmfDsJsMKaXlKiTESUSkW9171ABOCc+eB5XCdulaBAmtDDQ0EAcG4rlcu4Q17GOvpgfuZUE2qtv8GTly/qMddsPy1tbEAG2jIWA/HajQpmvGVaEkmI16WNDPZOGMSWcaW8DsLeyO1u5mj5r2LsIqBpwQMAtbpY25Ko+js+jbwmBmjwYuKfIKEfJvn6vk1m5zW8cPHs/Xp+zw86VuGTd0mquJKrdTuW1VSFt0Tyk5ml6IAamUUDvQz3bU2FhB5/TZ/a9gFtv+4dQq8MbNzGHrQtrzrj2v4+qw2TcNhTwSFg1XAwqKaPLG5sW7PpqOzljUULPe6rt8Z9Xi3J2j1Uymm9zOiP0TsIwFMs2ROnBxg66yAZsBoyJrWcm3sYp6Vpp5bTHhwnjz9YNfBHfnIvjcsX6LRKAc4gVbGNcj0gIxWacoBbBkkZYGVKJ7U2MKJzOQko5eDSUDUTLh0QysejHV94ffmi7EyewHg6+OtTA3XWnNmFroJgUOQYQ28bETgF8X4/rEE7USCtNfrjttESNYYtfVhlbf95MoyyE6PiuT4QV/X2FRFBmlYWaYFdezSBg6jMDdfur2BFmtRvEj+GaW95HFWs8yDr1edweu1RG/6y28Zro320abvLikXW3t+cEmSeU+1DMqJz0jXMKciTxNt0Hkjhlu63uEowimorjCmMTI2L2uZCvX/9jz1n5jauO18L4Xow/TAagyIfigFoS8VoU+Bb+ozvu6GUyl4JP8C5f8BdnPCb6chb8CSoXgq4hyIIUmEGB3e1ISWz5+FT0fUwO2LbIls/erxVyGIbqdvg7uJIDunTLhN6RJyZRPvijDuICd20hnnrdDfcvhgBLQLPMpGpGLLjfK1DBlR+HUBW/zxu6Q3dxOEBwsh+cK6M+gONhg2iZUQ7SCl52/i3XX8sK5Xz+kdOUHuF40dsk2OSxuABgVTMY2hHiQ4EyibFHBO7W5IP1GpP1NzWkal/C0U8LDCQ0s41L8ngJwT43Zw3ylBAfKRLHXMdq0p/WOZfN9nFZYC9600E34LOCWFFWSc2dMoVXsVLSTl5119HhVTgCWLv83IrUZ9jWojAc4GJWOfw5W8yzZE6Sr6qqIRLzY/6r41pouDiygAQmC8+pVpFcxcefvkAdiVBSIFPaPgby+rFlLrqUkWknyJNe5saTb4JexKJMsZRcN8DMdmIYPs4epmHDnpDv/TsyJyg2wMC0OgxRE9T9+XkMld8E5N+1VFD41oae+FljbqNiZOTGIl8+oekRCgy23Y9Ul5sgAjpStLjpQWHRsAXbGSi0kmjjqQu702KwkTUkAMbaoGLOwk27TCfk8jtoF2tF2yywD7nypaA3zpQHGPWcluLHt/0nJW5nzdmjpKs9TKpPhTqj2DVbli9mRyN8GHmWlDBgXf37rGXTvB5x+pTz8xgogLHTh9jszGSHvLo6ru4fuHfCVMU9A0TlwsGxlGKYypHm/mZr7i+NuT+V9gjHevnNbO6+n8nJnumzVlzlSeCyX05Miu3LzmvGIWYFQ3VPKfudqL/U6E1NgMTCrOGoVK0YAt2EdaWiWLK9fg05FF+/SfRVauSrEhdccrkYtZl8a0KwRMGqk3vaGNMbrGoQf760SzywngUGZD3JsxgLza6fCu/U6EfxGGj5OVNaLYGp6ulkF3QydUKqBHOhsBQGkGz9cXCJRw01xrE6/uBLu/CHkgxilqqUFWz9CchzukbO1r8fVJbRXEnpEUxqaPI0fBJqZpWO4MIPXIXh0wBh+Ny4olngc+yTyuUJ6SIyXojUOBrfgXQK1cV7Esf4kaf0MmIbgElJ/CN7P0N1GcCcHipQsK6gggI9DUzYzqpJB6GX9hIetPcYTNWJhZjYQYjwbqfIFhk8HQgnM8gFPWcnCohmDAPwvGhr7RKZnMQXWahah6zHjYouI/lvb2zy0xyxnSR/A8kRBOeSwxf7gnWMUgqDIzYRM4jpifG1l+PvRG20FbfSskGo4BwwcA+b68MjBRloHMZ1XqH1vsXFVXDWeV5LgNnhFtX9585sMifsIVQGhMXa7CDWCyLftdN111XnEadOYc+qGxhSocO6oxfau0jw2Ycj9GBL2sORdU6OBHbjIvZ2eRFnJvwfv1GXCQgcXShtRGDNaacPhyVg7sKAEoWGSDfnKpDadMwfChYqCsev95DEtj9QI016mFNXNV/Uu4zsJAG2mUUWAwQDD1UAB3XxLAnzgQXh8SyR/r5Iuyi2EY+Z03AAAAAAACud+m+871pzZxKK9PLhy/kgNzS0umv7/r1K8i01ILw3cHGLKkhAhdfKRVX+PybfJ+EQDvZlVARcdNkiiQ+0VEJ6gl6g/8Fv3BF09UJxxAaJWprUpWEL7sKlaa4MdjXI3fuqueLzg8IvYxWnJ5BDzza3Ke5rkUNZTN553R8bDkh+Ow63+3DcGayLdScaCY1EB2zNi4kVB2TitQyi9plZvF/aBzMrrj5xP8RXRccm5XHKSWxk3kB2qKT28WzWEbwepGcgAnT8bxGAhxdHe18u2bwZic7am8G5UMUZN5q17EUaUBhlBCrrh2MxmLahnb7GepMgsvWqJMhTfvqeJ91dsdTP9kb0cp4qAbo2YmDWA6nLldUY45/6YEvMq1+1ART3deVhgnBOTn3na43+RlhHYA4vqLiwLUWuccOwP+O3UrgSVtFkvXQp2JmdEyvVaCyNaA0/gdBcL8aBCYXYzoWWRO2WmxncCqyLV6V7fOMXcHrwAJqKr6SjXE5L3vwWrgZRPx17X4mRf8i+P1atq6QGx1H5ilFfteaENn0YIbeBkqo4MZj7/WcraI6hw8x+dfX/V7XvLnTh8j0W886rVLCAph1ghPAY30tzXBTuIof24VtcRpuxWGphfQiNMwnvwEWz+QV5aEDM+X0ooV6Wk8L6SIMlydrWsZAwOA8MVtqj7pBjjwMdfBMSBxHavHOSTzFA7kOzrdLyP5hCZlRnGxnMF1rNG+1oiagqoPy+dcvZKReqWrAMI6XonaAiZ1dTL9pMiRGjhuBwOFKK5cX8/sN7ZW4o4het2APRnzzCnPUtBhAPT+WoEcSQ+II02KCMDs/LhmDMebdYPf0nLhDNCKv/1EI5UO6Z3LF7Cbzuagb0+hphvPGVFCIISRVCOZPGJzhMW9loGUd2RdOPkC7PixPApyX0eUsa7BvsluWRY2fIEBog1DSGkG9mOTSlRG7yAurxGgfd/fLNjNa1/IWY0O2ViSLzXtbcdpeYkz9CjSqxi5VIvQSnjAAOONOYf3TUca6spW7PvZ0m8oy/YXsVydjbmTpRdASh1LqEw6FCYG0Ut4quVqJVC/qM0pbIuG0a7bOD13Tl6E6LbBIcYn6X8V0H7XT4HoFIIF/12B4WHr5/INV7QrhozomWIgRP9Ab1L9HRdPFfaGH9lvMFvv4iyihUTw03UHkhXvFcOT4OZ7DeyL6+M0JJigpflhZvV8MnEa+sHWIgzLKhBxIHoglye1ZotI2+zjAYKH5L4Y0PaYNIy5FJoGH3PFcPAUK/S327xitRiMJA1x5MYHOk9NKTN2wvfiPSSKBYmzLRJb6bB1aLwsFZyENQ4eFX8BFVZiYXfoNsir1xBfnxkzyeEpj69h8tCiea/dTJYUiFKqAm3X2F33hHnWzAQMZmAiMC4jngMFAnY72FAyEkRmFQK4bAuBIPL8wkJHHAUCBgoZhRQMZddNwTyYWHmxwrT58WTuvsfaEY4pkt0JSyAiKeTm4zgr6reXqmNpLXZRNUb5mjgQTii30ubSPxaZlHhOwkNZ6titvBn9EO9RPz57n5Bq6L4UBS2Uk+T08UZRpq/agV7aa7TArr2aQpoufeTZDYUS9Iy1Rlemu2vK0mcJ3eEl9S1Wrtxf5c7GHCZ6f1QiWr4HZvaQGn7H6RbMo71XVlC7ezG3MF05Lp0gFgIhZNugwwhMOaln/B/h45qV7Mhec9swAo0DAHnGOIcpmeeZdmLZaVoTdX+gIB0YLff0By5buD+Rwl8DlCedJVdtaciggp8LiVAH1moC312debRF7AzX3F8bchA1MeeoEEF5EonPUCmSlDiBkkhV7Be7uBETutsx/8Ai1XOuZl+jFSaRFlFD7VzjsjHsnN2uAeyBQgXUAmp5ohgxA8Bs972cpsNDTCzFoL76qVlv1voqTa9AM5wRqfqeH5OZlQheAE6kwhQMORJd+znOxDcj3Oj3LxnXzv2lZicbfhlBVELenTcqvfvCyqBQzGjsXDB4xJTvJAJNZA0aOHh4M91v37Drqpb6WC+dn0B+CS0LyzqcPnkzWeZqAurtXbPbL1zowIt3sFfG0WSgYaY+qltxabZ/aaCIhUd3X60p9VSjS/2FiNByIwg9clUDN1Trm1MEusH+72FxICS4LoFawaHEf0JKUo7MkCA6GxK+8iiNQvcSvwsvaWzJRUpsrF9JKTvFqxHiCaZbYhekdHT5l3ircPg7mA5MEATd0UGj82GGmPqnKUMnuhx6AkrwDHzTOVVo78dM8N6WIqdjGGru1u/Ty49g2M6i7/yzexSEQVif4lnz28DQkzLrXJWAgmYBBziUVrPDE4uPAmFTPLgr/PE5f3MGYYTO3Yunlmxyk2fY1qIwN8TG/ikV/ig/XEgvgYJuZupxs0RhcTKZbg1+4E2eQLYH82UeY3oGjdi/Bv2vAKZPZwUbwNVPwOrplEAjCLtUkj9GBSXCgcOOZQgb/QDXI34CgOL84k8aQDqAmB//k1d23cQg3PsF9sGghRvVeVC0bg613HJeAUsJEe2b7yl7vfW5R9avHnIVDuuq6RFyJ0lQcSTJxkWTb6BROshDkUibvhYi2DYuq76+IoQo0q2kAKJ9mQRQD5uzOozXoVHt44mkZnHq6cf+BryLafVcDvt2393SPNoEHUQ8SpjsZOIdVsvUJIDYm3nVqpLBZyfhNIR+I3KUhDpBIfZXHZqvjdxxIeFZXQl5BsuMi8vglbKMtVNjXBK7LcpFY4/yqEFAtJTDkD5CYXPev3IAdEXccqUYBKS/tqVhxsGSZLLy52VUv5IVnDlcNh8TMHMNWP328UnKKQlPzk9WPIDtA3zJHRAE4alYVAGxrmH1LT0poNABns94SNY+OR0io1vJxVNYDrh+vf2nZw9rUc6lEMCk+xYIFejJUSVljJGvHtPeTUY71l7o0teR8iyCtLJ3+9psOIGpxdvAcMTGg6eoMFpfjuKsRKM0bClxS3eXllChK3k5RXSQ0GQ86eQGnDlhTDFP8V67qjzPmS2W0ZlyRrT7kXgemtOcsaM7cWbI8By06piRq0jw13amNwealipNqOAU1DMqe4XcvkS1MFqhpKzk9NHkRrI9AUXtNruvHXActpy3gN2vLI44k2f8/NeWsW5ycvjA1KmIB7REKrTa06eKfyioVOqwewNiFnDDYZLmDHJc/Ce0p6spLDvTn+cYpbyCbx16XuGj/yPys2W59ZnWO6xSxv3KVbnqipRweGPHZdS3MqAPbmHJiABHhOSW4s/wQNf/hUu8gdODZp1slBHunNu7h9f2xXfY+32tgwl0O90kzftN/eobxN//T1Ugbd6Kqq0/FAe2ATSx3mlmmul0JzxT/UUSP3nKzrCw3ssOiXnKJh8v+1DNF2Jk91oohY/23GUDqzfJrBuaorRNDDCP4rHeMOme2XD32gpJVOmihmgyNYkjDBXtPc/qmf0Qih0TTcH7aZ1Cvph83JTUuza3X9qoNUh3aP42QJEhVIxG0BFkYE8VWrysNdZ7Miup3msGnxAlyiS7qTZQFRj8aQ3VtlTEE86SIS3vAYTQk6VUMdWZ25LqL/aADJOc1f4UEzCChLgub5ZjMwGqxYnBbActuRb42+pvVQWL3JzygR6ZMi99U2Ib/Myj525L26sJo2VBuZV6/OiNLxht5Y6xbfxKUuNQzGoNKkUc+GTTpS3VWu42lqHuXFsbYKMiSLHASiiTdKiuVFRlK4WtKlRhNYpcbUyCk2wxa2c/85gXta1GsjHCE6FwD4wt0SVZ75GKNz/kItQCKncgS0ZtNgrKOFwsZqErB+Z9y/BCl11rskAF3z88M37XQ6a7ko4U9pW9rzn3OOpWlo+qN0zSx5zQWy2FTuRz06bHce53F8JAqgZDMgVl6EYdh3wddmRqWEalD7RU8oACIxhdNYW1NFVn9A4pFP201N+D3JT/5U30qydK3/lEd0Haq77uOseypkbF7XZjsPGiX2sJkVenls8ESz6CDP3+zEGQWhUdhk46wyajLmGwFFLNpJw85gAUrQxHZ6aFBTsJvDX5y0wACEM/XEd/kBKuWz9kfRZKFUNpeT9iptrtqej9BbVBvHBa48FnzsiZqqfpdoAEyFpXROl9MRqXUfRlPmwhjJ4yYFSAuRTbudPN5kb/1hYMhgbDc0D3hiNdyVtwQjuG6d8qmIf9HT6NGnTuKItkn/n42E0Xa9YoMXjPX1pRNcwKI0+Oa5ERNntvWBFOqFbIR15FOXkD+SoG7/MXpTpghLBgjYbvTrLkXUbC3t6Yc/O3pv/Dl1vLt3ws3vfAkTS1DHG+iQdD4ThTcGe0ozmSoke7djYevKlEkVwJgHM9o/f4HnhX5BnIFobNvHxOaUS6v6jtE/3M41TYLWHvTdg56HkMmocVObjv/tz7B51RRpfcHRhix5/VJVfAjVZxriKFXKrJ0CpsxgH8i/68N9PQnaU3YkIt9syYYnCC/zR71Sgins4j0LUzP4zY0m3wS9w97hi+yu3hA3KCHtLRLFlevwacijJqVrZIbrkRjaqhNF6vUQwG9H6j2Gz0tISneL8s+NFnDUGZsbvUVlO4N9v1VMkzwAvlxIISPyimDCxV6I9xFfnm3meCfoze6Q0clNhFjf9ZbePH6gKYSIUQW6/wVh5bciNN3lQnNvwhWml3AkwJMzw8EX4/cuePYlBA8D0OLOtojzL7vKvnpGzdXA5j6cYvbfVIUjFzDoJ0kI8sR/SmK9+UAGRykBlCOJ7o7N773DFJSQHrPIC0sjcRjWTxCYMqPN5l/Iu+PYNjOqAOS4qX6IB7REUmgghig4Y4lwKwl9aP1ct5fSnQikymDmKe1SvuYBfYnptuE1+mPacBr4Z4Tl4lEgM05FohQTh1QvGK16aRcKLxhRXIc3NBN/rRHpJFAnkDZhbV1t+gsvu667bIpMa01Aj86P1M6h/dU/IZd7rnEtRf189YfdcKYJkXgXLIIy08oci0FFVSltgAQ1blpRNLmafdrdKuHPQX7ZKm3t0Lv/wwPkYwbaxzvuxn1BhvKnmXi65KVdtxICUZTr6n5xWQmCFi0tJJ/B3jrmCMakJQceZGHtfS0U15oC61+rKX1g7/3JeKHXmnwk4PqYova/Bd0qQr8eaeN83sODtOzVZVhlUzZrgyjetterRfIMl1gAAAAAAA9zme1THf+6BP+/yuYhm+ctD5w5EWAz5uNXZguhTwCjpunZTjUyOVV95KuKZ5ZWFxnFMwPs3/tP3TItvQUu40pm8d8dz4EN+276WGz3NgYJlZ8JnXsmqQ9i0R065PErmcD1T/+bZ+FE0CN/jKy7jh1Ztnw5s6gENcK1myE2VUp0nJ5n33BymDpOa+McEGfsiWj1Dn9igT/2LxQjC89L0PRxVK6gfY56JsO40kBbHuzFqae1YLEztkH361r7vAzSq6elWuCBCE0Zn0LpDZsDRUR1T9IQiFcfr7SswP2/gSWgZ5PY6RdEMaJ5+ycnnDReziosB8pc0tJq0twHMigSpLOCDRtHDHrHHd4xrLiDV+r1JZD+7eHOqsLvBzlkBZL2W856u/ys95Ck2XN05XPw7l0bcXsiub4Ln57kk1GgfNNut5bmews5T7zW7N3qSfzqwF+3ibYIUagVJwai27ThDFq68idFBLANsDCWbmz6OPv0rETgFYgvlLeqHDrzVLuWvEaqv3zZ51ns0jSqagln5qAh3HGx6GUyti7MZ0hZECri0jDkETJsGAvjXpgZi0hTdkqQi8P3PfMhFtuLHFQGCPQuzeMMKdlbioS26epPQ4hEwp4A4dJgBwGdYq3KagpWl77D55S2XIeVOrygwI1CIgC1JNu2qH3yNZTsbg1DaX++hRRrPwjYDw8H61ErFRu/5vfpeJxMavWq+We5ZKyQAjjphl7aSeo9ywxGEVBYduSIvnSzDDBELsuTvn+0V493CkKF3pWkuJczazangblsN8cewj+YCiEc/yiCjW6o5Y11nU50pn6/TUbXartoLjS315xCio0GlnrffKOOvptVYUWLykUIr3b5fzqY2yjboxCkgsmenoScdrjWr1a0jjY4el1LCwxKl4kicLt9FfWj0cplEvhFKRIsExlvWgsteka4E0Ie9HXPIWVDdp41SkPpudRt/1kVcH/PvrrPTXWpKzbPCHrSkfIFakgdsbFGs9NfY1sLMEPmaG43ASsDBqE4VGJIctH3L3fw3ZWfAz+AVQbaIOUrEW2IUUDWp6v3UJKx/jPNIHjIlEqqiWS7JPYnEky6+w5tZpkGLfKl5ZlqC9Tn4Ju0H6MPSshjsgNkxp+FKnL5te9oIfje3Rb8CGjV/BVHYJWJkUvR50roGBOc4oBpYrt5flqpspc7iC3Io1siFxIkM5Tq38uhljQkuTVqfEDXFwtGAWXBZw6qmVYXYTpZhF2W2AXXjH7a6lopklLYevdx852pty/++XoGFk+8nBghtLZrG94BumuT89fy09msSnY4Dt0Vl8VnQHsGHiAGpTrjMBTJrC6G5ISMtfFlCClA3fgGBSUV9OdBTF8JOsSanobeLp0tuvtSu2OZ/0gEZ3EOq2oHCsfSpN9FjGVot8ve3WZGH/fGcLLewlIvWIwXaWdT1TzntRpDcWTrmWQlabX+z6LyLYDYoachnCMzjjIjWJW6J0XSn1MzcEfiwVRLXBMWzcufZwN8eb7QzZ3nU6WPloGiekCebqaQTR1JPMwACa7wztxjT1UmDMLsX7+GZ6ix6GdbwMg9fgLHPPSd7kJ+MJtyPd21UCNqVs2nIDBj7RvBBvL20HUZp8PTptIlFVzIBkzDN6cM1a6CcA7rP47WA8pvEerh3fVnuUI4hTnxnYLST+/Klt5PemkNhEYiN+Ekf0DZkNmNfpgsIBN0o2DrkSR1FIupm5b32BYjG9X21SdwwwfxXkreTpkoE/Admd1XbSFd4khxDCWtPsP2FDvIkF/FE5I2Oek8eYC+pTPIHlC37cHnJGoNeXoaRs7xU0v/IKHHRc4gNzYlOMgounZ9hBYEZKTjv9IhkqFHFLGVq5HYrvAdePrjytZEV3fQzrTIEvU+hK+ecvUHNDaFRZOxxWv0H8P9MQHof70CtXM2k7QqcIbotZ+b/Y7lW+JX3JVScxW6jkwNjD+0g23DkQm7upcNNBvZ/XYsCrKCwS3JKXDc5U6HOLC4tUxCodLBNVrZ1prtAWvS10tlOBo+RNwqdaFDRHYVgJbw/HGf1LbHWsX2olvRMQtkUdgoGh9UpvlKk4/5OQsR7O1QaFMD9u3gj3eSNNo2iCJ0eN31qhJuRUyfFrxUIvKW1pBU/gzSfcxukJQ7cut8Sf5QhOSPXHHw6PMFIf+8pP1roV6VnUjL0NhZMSHApRG8+srKfqfPJXRvW7UF/x7B5xDZAgEwc8w1yR9IvSlZ7FYyFif+ktapezzoF8+81L0iH8UN2rmKk7n/tSaipBzW++VmgglijtoZcTSFo+bypL0kAJD9Pm4k+rNOtxeyJwJmyttepXQ0ihtgUgeCsk4/XipvluSew7GLumXc+Lcf898wPg5UEZZhpzc+l2brSMQgk1o2y2RB8NtxcgfmfQu22UMqUzyQao6fOacrUrOMB5F/FSCUPA6Q4OSUwAAmQ40XiLS+jQ41Ls/QgaFsHz6c06I7jnhcOvnu+0g5jwGX2DEcfLiMw7YRzWJTbEiiNaKmaTczTiCtOVSbm8KpU+z4OMzEzpq0vH+rDwPLMiW5ZHGCfVZpr//Zh91pc4ML4d/yuvzpR+8qQtYJ0URTsIVJYj5x16Yu7tcowpoU1G0BITR4D5nP+Li3cDU5AuNF2zgcG63pUy1rn4HQoTVEq3IetBz7u6Gas5J78mtPKolOTydb5bnK/jZuTnF+x3/uNvy0J6QpMwig4jB68gCOi/2bAo+PKg2U7i6/HTX+jt+KfiiiNKksEiwvUn9hrn0Ueyl25U5xTRDTIOMC5lQxuXZoBbnJILxVXc1QDFPUAAAAZkgAAAAAAAAAABxPzhI9JjGYHtAbKg2Zz9SSm4qmwmJshOoRTJvgqOq7x0ZTxOjMKnFlNRhevDXZyeI1+22eoscSgCAscAov6sP69ma5kk8CAANGQBgyS+U7cPoXhDIZUMnnJdp8GNE3t8jUZZvGGTky9xmYYTw65PM5XNoMWZTEsLS79wG+aki73KHxk1uSbZOp25+yTePLUk5MQjnMeqzPKPqDuf5VjfhdCliRa/G2NdZIjpxTxPu/lth8Cye/L0RY9lv7uS+Cn3tdjH1cJ89cNPHDAfN3nmb7V4DSJQ9cqIcSmZI+J/ClsoGQN9pmwXB1i2W8tay/v4HLuWecB/Itfy81bHDfHmSpO8p1edtw9M3ksRdcNKxUBdQ/+F4JDjVU7PwKJ4meRSQBNvwVAbkh3AnOP+6Evy4QADqA/Zamqu9rXQz6omZ4TKeGhmIcUiWyOzVNF5tnNnZGDLoPxiaJQMEWuqmQnQs+mMvZUbAgzK90rWq3rS4CX0CndedaGunpFLxgViOxZFRXk8OZb8KzudDVinzfSVYz1Udr4yc0iXeSTv3owajIjBK1qNwb5gOKnco65Pc5A0EBJP9NAkk65lBXvsBiWZGm1/8BVVo4K5J+tq9oFbbvaXAi8HRgAEjgpcrdyslMznZeh5Nc7rvKVHetSbN182ZWj+3oMCGHcmY3mArONvRVza1fe0IaQsbgXa5oTy1ziA78g78en17V5uzPRZDxQJdaSFy424vZlLC17FHtxHBm7KuG+iMl+nVVXa2jRPrFhBV9da9Q+4IgZiqCGabS9gbY9eYqNm7q8SPrIv9ihf1ciqN4rmRWTRioxhD5FAVFsLYD4eBdch0sK4pVJGmVcT6DAHshjFFYyLQFb3ex1tRFDqgxJ/wKHZhErAi0Sh9UWt16YKY2Z2AKXvajEkNkKT4dWpsUO67NA/62HwN0uYqnOIt3yoM9i5vibgLLYRflNy/BVuxw7RYIlX2rAslsy/FbpYbjs5TtyBb1zuszLFWTaKTzOhufCgFcau3I9ZlPkflzELWTDS5LXUgnMIBgtVhwYwJ276YUg+Oupuq9ELeYq3XnG1h/wAVxGm36Vq/KJYkN1qKz1hqYO1Dy0L07VLbpvi0HvcvYRaTrOACQkgzZjGUu1FvaITGJFSn1E63iHEfJwwwKi1en1gfSjhIkZDxUEa/KtRPRQJojq69r2QPIR2+qowJ0XDMHZintY2Rv72yNxmrGwcM9Y5f0RQ+W2pl7UtupUqJKfDcBibh0RFwKS4W/dLlAROBatZcuu3o7DXSMIYeJ4q5mncjSCIO5lhmc0oloOhayjlMG1tQf7gmINZMVMNLwD+Q9tALU4MYMAi/8Nn75fM2OUiSSIFGIB1e0p+VtkrirZQjmMzisxzeZxFQr7kNR2YKe8V1naiuVM01Q2QLXStJe5GLQMhdWnvX0h56/9ZChU/eRVR1O6cOrCDY1B6z0C76Phl9JegLoEMySkNdGRL+vyeP9Ow7GyutEKH03e8FwYb2G26lLSNNe7aQxzCbTtRrg/F54wD0a684Iu0Qg2yUVJ4TXFVSpOQHwasuc1/Gg4QDazoDdcETb+LINjd6iqD0+MraiDCtLlbYMIImzATK0+ugOYMIu0nc+qxOoNsTj9Nk9tcUr4EmrRGdB6Zj1iCbofbtIOPiX+9RVKPgHrqi2v2IlyP3IorH8bPJljYQKXTjKySOvfvIWlodIZ/exrJIcg7xHXMzcpKZ2/rlb7JmDKJ+gVS+D1nTycR/gyRDS6EM4SlwjTpsUWSIvQDtrsxmNEYOfw6aOvnGTxRmm1WnC3sMN9U6n66MKpEL5Kv3KW1h/OR3OBgdYY93UGCy4RFTRvqAQ/mC357gOk5KMXK5ORZNFIuqZh0B98ovV+DDgaiwIfXxD7/AS7yTCLRXe8cB6+NyJ7Byu7golK7mvJWL6U3l1EIM6PwgDePFU4tRqRjJ/FHHpj1N+ubxQxdEufZ754yS/1oF3cIm5uu13SE+X18qUrbECEE70mobb0TuKDvDH4N/WUua1/TbJdOXb35ogUNCF2S001JxgfgvfS419NmayqJywY1Qz/8RtBjwV7TeGSUX46dM7IOTENfUltgL5qbDBDGM3b5Lfwh990s6gfVVcT957gVG43rmjDCQMRNhKiGZeCMUWJQu4ulAsFskZ/8PT9p2+X03ksQEJS+sXhIu6pbfdLtvpgFZdpEg5ojNAqD0bi0LHZrHsJJf6Jug08yE0okxuYF6x2311NYZ/UYDyANaasWLz1G9WzEbv9K2Pn8t56nIwKsjFIVZzcP/fI97Gee55r/vloSFQnX/un0SNnjRWCLWHaeO+bJ4u+4A/+oL2TH+F3l6bHqTjYKqRkIV/xcOtjZCMn68q1PwVjaX7NSaRitKbn9n9kBC8mRoR5CPLvz2VzpB/c23xGsBNtKPBGWgdJBMPjF0MJYbm3sry+IQLkzxKjMyhQj9kv3RmiZit9pbsNOQB5vsg71idjyj0hdDdwFm1Yeq4MiqkTqtNNnLxSVGXghOIiFI+9msMoN2rzAnVZ/wSghMa+njmE+bpt+X3zZIcTwfgjFEwLhWCQSeas13wuIgBhcue6+gQSpS/SdQn858P68tV1YrtXMYFb7acPAt/n335mA45szRGN+nBvhODtHDvfwal+8svwMJjAvNWKnFQUfQqFj9FXEDyLmgPQFcBPUYfj3Q5LwYiNt4/+XeQ3vTFGLXzk3UMPyeqyZsJ8jBITSylUThIq45D2qi6EiIvSnZsHZv/Gl8MN1f4GtkztIiSsMuVtgflE2YAreTYSQm8z+f6YgmNkaEBSL5816Z4rxnSOKksIOyNN+gJ7LFkPkh4MQpO80XCd+fj9n8Be2Z2duJ4+lltVe8IAGtrIc7O/bhyPNkgJrXV3cAyCZh43xOg4lSZ7ifP3kQJqWGLn+MpeNFsVEQIH+GQdXpriNRuQ4ytyDhG0zO+qjoynkUqscZXIFzHu/LT2y6j3jGYzt1YZJYCgAEaX7lwBTXL6QexsK7ldeZvu9TlBqZdOPLBK+lSnQ5oQUeHIjvosxgykmheE16cFr4okUXpxB4n7vU4ULta1bs9m/6zBlZipZ4H1CkFeHvPrG0uqD08VAcYuDMjmhb8X1tSXao38neoZTUiqoGzVZoIo7Zjn1oghZGBpNt6DHoGPmfcu4MNzpmgIrMZdYRUBL45O0emFmKaud9e1VzftVzqI2d4t4xaKingSKLeOOGXXqnkYpECqjNJOeLXZ3g5jjVdZK29l92Evosn12GLGvKNNV3CfIBY4RjyZQLmXfQkDrrUY2n7eL+Uojv4KobmccZkC/D7IfLtvNzyBa2vhLHHNAM6d9pL8m4zQlQM3wsT1uQsb6BK8GFl03TePBTby2CMGgiRjuwou3iDBb494mVgvdNbKhtGfuCQI4FfHDSVxcW+R8n+YVkLEDyxsjjxbtziz8T600fMEOLdkDubsmraryFPnuA2GwhEZdYEg8Tgn6wxFiuxqXdHnZQoDvVObOlViMQ0hIPLgd9HXlZq1FWaRV8eLzi1Z9yPAOjSXuVJptk+eS7EPcpcUziolhRj3PEOlgMR7VxNkIXd96yaBfyyc0mnPBep4kIPYDtINVcyAFO3iCy0AvuiHgh2GZhiV/kd/HX0SnclQlotzAkMOQwkgxAA5Qr1tO/KzlNJ1FNhkiOGTvVlpQh1C0unHk8fMlMqFcNi1+YmQn1o/CrpDCuOLmnaUse4fn1XjJayJsXhbE8ZYVo0TR/BWfxWFR8YZkC4nKJ63TZ4xJnNQDjNG+rcuzqKknwDqAj+Tj/OZ3BZ+NvIuFXyJOISzFNuTf2GU3aLJ8LeQN9XuiE1+nNvYlTl88z4I6sGHJBeH3n0cOguGtJ72UmBPiutUN1EgN6z4fqgoueI0IKWMBJ+Y97uDmGOBfXU5bpcAhWP4fP7q/YTfRuaF2ngVxD2zV2FqX4STflScbPKKqOHn3zFoykRShWIkPdpuT1zjlJPD32mA1wCuJ4ybP1rMEQnutuqu/PeSnNeRP0X5v2EcwyTGchFlg//UksUtTyWIRrVtXUNoFgJLp8WhgLUDSXyniwZt1u57CY4JLcQ8/t41jjv0sE0se3oLhmJc7mn4x1jRKlSEEP4Krq3gGW5DRGSSWo6JFS71x2Q+fMJfE3N5zJvc+uSaNfV7U20AHidQFRPd7Txh6d+Nhe2GbGAxbebXmaM5WUEB2Z3JOYUFk1JzCah0ss9ETYo9jiJNHwH2uuc2w/MDsu1G4BtCwUGf4V0qQ6ACRPP1C8LbkMejD7NXzJemAORMTZOzJTeQXPeAvMIAVAoTPO1Xq3vKyJ1n07/L5YMAVg1FO6d33yc65hNIRUWufJK/7NOojp1djtGNis+P2om0eRIahVBmPnl7wFOhFLM4Sd3QFlyjO/TX8PpGJ38NY3N675bXKh/Gn4PeIuTxbOogtwP3PRYMo3Cj8MqkqzzXj/wWvMsHUdNlqeiXhXFPgkocACpOJS5RAdSOzxXVRYr5/izeoCh3mwnhkrUf4UEgGo5sCrWQPiMmsJij3q83/w/aGJDSmeC5/6kxmQ4QbhXfCZ5R7a3US94SlUPPk5j0suLtFidAEC6byxZPmKs7RVI7fwWdgKwjd2//scHG2kpGP8ASURL03NRj9oN+liYJjexttRbBxa/WKFz2JJPa8k0Y2RBuaOIs5xYZxNT28aFcFt8zmZVyyVDpaBVXQWZH6bVWkWlV4qEndqWn/vH2Xw7k0WSdlgHPI6jR1I9pACMnOFlD0UZUO6MAdCijrkQKubz4DlJfEJ0z9fyUgjghqz8GyyguVe+5/FJBTUVMAiQp+BjxeVE5CJJkfa5BT2GZhKV21JXkHGTk0/US0Wyoto6ZF8IbyMoTpmN4yHwgmi60cKdATzhkabNVIvt6IZunPb2fOB3fOdKuNckZXssNuih0bf8rDlsqITQuIiktKghW5qAKEB1K+vWlVsZHHjQ0AnPARaR+0+uD8N8N8VxpiMqXBk4b5RZajqE7lnVLqGGRm7iygOKeIlV3mkRleNeymsR3ea/0HYxuHPQY+zgaORw/BuS/oA8G9P3+v8JOA8CwtuE+/Qq4TcRUbshodeDuE/3fshKT1Fkb5X8CrjHvSb6lF6nUR5ZcKK1bxTl3FgbKjhP0Cp2t6JJmFtuEXTm0wT0feSlKS4KcAs2QT+H3iKIljo2pmiABjPZInNWEW/e8/BPmdjPAFEfuZRUQvrxXPixuo5XVIHEoczSClqt/4LiHJcGk11c8C/xQxnJTmo3meozH8Tl2nNUKmzzCTO82K0KpqMiZkyl+b3QbC2wPXxaX83qkt1IUR6LEzirpu1Axv8qfyoWpFIZCBGnIz+yfvEhwIK8YRgdETVnSg/+rROOUE1i/9jxvweUe6Eh1VRi6QhOptUzUpOtNJpSjNGVUPyaErSUVKKlFSipWkrSVpK0lFStJWkoqWM0RQSKy3f/vzrF0tDV/ZsCcPUKmvpa8BXNKYQgoAZUNpl+ZurefpvTksIwK5P9rUvn691uBx5tNNl6jnFScO6PvdFVqhz/dDWR3i/jWw+6FQNgXaVCB/W7IG0EfZ5nYNBk7ESaDIxAWTyx/ygD5oxp0s2v8Dhc2Fy8mHktdbQTZALY1b1JZ8sHMly74D7JH3Dqr4xPpuYR89TlF95U6+cDgYOBdCiszZVFg72GtGW5T5xtNjpi3lPflEAS1ylb3vJduKrKqil3TbBQrFYbnaMbJ5YAOIJ5zwYeX+Cnxj9gFY3vC2Jmvxo2qVX6GEFsR5VXNiH7E/YxS5RLvesDvW8jSoigve04Wke/ZpMgAdOA1evbE5Alokako1Zhk4JYa/9T6XNOWGb0GCoV61OR3P19/y2Xtc2sawNbtGUniWuIwf78aWHcOWNNUG72tgTRc5hZps8YvzcB8qlRen4wbHvS7QCtWdmYvf+I313PzhXZ79Ad/f+oCkqdPg+cS2PTizI3HPWyuupy43MKj+IIIPoHsWCcTTj8G7+1BQoCBpmAeWVtm53mcxAcZuHmplUsb995hOqdfOB3Fdg2eiY9RbVBJ0F3QtdDPC97yJUjouJYEJo5yOQ6fi+++zQ+YJ15bRFcT89tapjb+tvJUJcbk7DwEwkj/op3PzEkV1ERqshWqkurUSsvptGT65apfS1Qp1wjjMt+dc78Gt9sgTRc5hvv5FvCqsEz5v6qvgjvC/3e0c7SjfM0aeziw8xGXy9HcjFbsONnijJ44XKAPtjBwKZ+piXOZTL9V1QiNncX53SeGaAhPAhk5UqljfbvAQmdBbzICpQM+XzBZjRN5/WMy5K4WLiyevtWJRmFOC7U/EYMLKM+hnpd0fpquDXSIgKRH5X2wq8DYHMn2DkPRQTANBFPrd4o10R0WX+GqBoN/ODIolyWjjwhEe2znUZ9/SJ09G8+d7w+wNKIEpEbTNLgXeKGP3BV6OpPT6/DXb6JOlPBLDrpRrZYSRo9VIWNiSARXJKnJjIFzzkcj8Db5XJ0BV/KdwQubEGHim9O2v6XDgTAyZP5EGF/pWdI5yfk6HZyIVpAagjqL2N+b0rinNMzyMWi/ZNps86v5Vup0Mt3YTiHdrqFr/gn8pJZUesKITYDockx9SdJ5ZImFPuE/kxhNUJu4wIuhSVo1wqF4P95wF1kSbepOJmqYtQMkKBJClCowiS/oX9tU19D6HpH7We3rd2+9klklPyqCETX59Ft3ajiuzUt96IHiYL2eh9wfWTYpLRDKzgmb8UBqHN16JVYSWIGLdqkvbb+GTPGuZ2LtQLFkL6T7Nv6jhtUHKarkcMOoM5OK2nP3dwlA7/o6aaRMYWpgiBTg5E015NfZT/MetIGgn+yVoD40RW6rESaY+03oGSNIrJqNvpR4tw+8o59ze6BW2k4Sy6xi1hwBvXeWgId2hrsRnPI/X7epI04CBUyV/d71Nw3t3tfwa+pe+JoQ5UdsJZZO0jyU74Rqo2PShIGZuptHhUXHRW+DywgizP3U6zu8373xy8RuW4G51hT2ohE8187BhikFbx1zQEj2KZJsKS27L6SYa7F0tC6HDdyoavTdEYosMKNP4lxWIe87UVS4/isSVp47ZFfpoztXTNOcaWSbWO+V10E2KrjBrsq3aYhbMS7LWVrfKedDgelXQAxWV6yJajIY3QA2xjiihgUqzUqrny/TT6Txv9ukm9CrkyVnsBFPkcO9QAKPw3LeKpWIPfilTaYVMoKoWJ0joifD9CZId4NAsz5nvA47CQBeYy7rvCQPyFgIYDTC3L+dFaj4A8OFcv63Xgrv4pIOG179EnfxsbQiLIDu2lTKLwG/RSxpy5EPp4aXB1RUHaCGDp/39eLIORESsQlULFbaz+L02MqHXq9zJ/Jblq5Do1eXMMB/TESvcko4Z06jzxjdyuILHHjbtzYbAHNZK7mr3R2J/igo8zkGyjfA9qsh7U5gCYZcC1+Iqfk6+t3zWhGuN3+v+CI/D9FK13IaQcnuBwPtZcUqbmbQtY/HHBZuBvgo6NzOFErBZzQgIXxcBOAHJQodIkhMzTVjR22GdcDVvoklT8wIbzuVGPyc8JX/d6bqzmJMnzT3IKagD0f1ivbCkmkF7HCkYt2/BTstTXb2XMKBp8IueRcinLHq4L7GoIR/oLMCVOf4CCiDelWqbPl2QFmoHQR5IqXIe701p1N5/ktcFe8NXYMbJb/3iKbHRrhWd6kadEIouwM5d7UI1qEdrQLynvBz+1eCeF8CdNxvpmxTNYGvV3OGCuEGTipp6KlwkWgCqXoZkKlHjbbDBjwVNeE9876OXf1OXVB4O4fOupA7668jhQPnlfynQvMizUAbaphfYuVIFRwwuRUUYNmVYasy68ztINqGHNCdssytVB7yo5z+s0tb3/Zbkh62HyVm2msjTlGwEkmMEfutl6wcB08BuIVVi2aWA7j3LcG76aiFHVI/xc3v8OPXYVNIc5LHlEmBtuHyTT3/OJUzeJwbvhUhoTmplcL85zvTUVnFnRq4OK1fZHs6sqdpM3F+ymPOLxG2mSZ5o1njx25nnjbleY7T3/J8Td3E2nEJJVR/01ZU7SefRwql3MFqUtdHMA8/j16g/QNpfOgNjl0I2bRew0QGL0IE8lvDNhG6aVcsCFvO+efOGIjplPxSpm08cjfBYjUO6Ziz0rgCoUQuuTgHnfrVAFPTDisqPqFjBB7XuJLsORMGWaQS83NqSB63UPe0z1vt16k1cOPVjZI/dZkzK9eOeQFk9gKQiNt5T/1yysKTaMvGSfSEpzJfGGIzJk1p7rqagjwDuscXdFCP55jHlqlz4iAxYO5efwKXpL3H32UG8BHr3uDoGTl+iO8cSve50AiH1XzNqNwTDb1/Tox8oOmlMhnAjwSznAShK8sKonULqXBvU64m7GInx/vzXqDbKyxAcGcjOPTi1C61eWSF/YID0FbGhlh/vxFpDLz4xmCQM9citKkMN9zi5hPpT401nuHXVcWQAiNRumQHXk7gPI+E4mjfv7Xg1kU9OjjdlK8gbi0TM0Omt1EEQqQfepUziYhSZnSPkwyW85j3nl0LPoEP2G9V9/hQqCnS775NddA8FMwdYBLc2PRUMuH3gOUG8DyqqYnwKsS+cMSMhk9oKHhiLuBntzpEo2rt7RrcxZlXuw07FuivQC2smN8Opk1wZ3MAdBnwXHhqjZzL56ZPoSOii1y2rwt3tLe3qV3H5ZMV7qN540xdB5UbGaFo33V6j8v21rWnDY/Zr1zLGLfMo+yHVovOOb7cTd4M5NCWDi999ei57ij9gU9ekvaLTdGXjbHXr7yz0k1IJxAWZBiFvfu18TBWjelH4VtDJU0J7w0hpH+aywtVKjv/051e4Y6xvNPRfHc5BTVEk/vInZ4ZmW4h6HhbR35Ei7j9CyGah0bGbY+QSV5GNKzSZmwPw4bqdi7AJw0TY3e7iwYDJpdAUR8M5+jft41oS5sDQE0vfdYDv4+z4d9mN+nUEV3ksG27WoBKXYgcE1x9YVahcpZsxSckjf7TelviBxZEmIb+sCrnbWlQrzfjpI2VndUQoo02vZimbx93WTgre81sb5375Ndc1yfzGECnND/kyMgktI6Y7P4hVvi1hD+HUABTcusjuvsMutvWblj72DCkFnuAW9Znupw23GDR22Ou0DurvYiW4KxIKR2wah/lPQkXgl0+01yBzDzr24E2jSfLvOj9+fL04ax5S6+m9tI/tdmQU0Tq8/PKZ5dlTIbv5Sjq7U4TVIGOs/NuTg8ry8vB4BZrVniB9IhykvHUreBB0z4g6OoYShhtprPL1bkIfK/C+aQdjLTwXwBZJmZljgI7r1VTz8j+eZkxclerL3iiNXrqmYxgeVTzUFHkrvJlSJSxUZdxm1OTIhCuUZ900mNnZ58Hnp+oSVMsLh6gESkwZOZbAtYOE4tsiGO+oRk5kwpq4WDME8ATcxtOF35OgQMHAjQT+HYsd2aBhk4ml6tCbiX3/Tg6JugimIzQ9IhjHjFHGdOHK6LtC/gcYe3geQhn2lOQswtsPlpfxGkMniOs2eY46L4m2OCVG0JOYkRmKfFD4TFrceg/JpMbOzz+I89PoAoblAaX8aS3XSd7xA5GvBUb8dLbas0yVcb6PLfERVAPA8bz8hcFPf2odHlTz10fiD8JWc8EI2Q3X4syJrwbXLdynzptpqQ2xLRDCNfAKluRgO4YRwf1AnJ9sCDF0sh4yneTQMgaZS3T1KprTLzc+UVSAM3mext5tWOFqi8sfSaZgWs5s1PW8TCNUQ6pi7UjNLdQ6sZ0jZSTcqWdbxQV7rdJPBG5rnZGCJXgS8cdzOTH6hga4+4fmJ3HtN7H3uJAf35tQW7UANTAhOI2O83rqCNlPrZstfUmgQAAAAAAAAAAAAAOD+W5IiEQiEQiDNAirAgAAsRZN8YDhcDTkp14FSPiCAauKJHEC2L7AwdPdyT26e1xKbD/0pyRW526AAWRYag09WlnS6OA8TbtmI3hi29P9Q6BAsrKQkmpuQT9zJ51DooHKNVy3Cqky5tzffC6fwR0lKM3wBh4erIeqrixg2ipguU4QLyEkMT43bo7nddojJpH2I66H7aEuFIwI6aw0vRXKLYvvDAqMTcyojXs3VProJBQPFNWz3bRY1esjIwrG1XJKWiETlnNdsC5jEaCEFlN0VrEaOfR1EMwsvolgytk63VaPDQqgRHFnzUQ27sbvfyZHkUW0TzWkuW43rGoSQQ5eOq/6gSsVIiXS3s140LMJSHbhCRQKFfVOD8E3XTnVVCVq8rx1X1TRPOjgryGvHVM1MQXEp/V5Ox2erUsWnTDBYnp2SQS1hvLMty7iAFos/pbqoQKcrIWIZJbOtJkwn0mHKOBx/MMAhn8w7LSHSepEcfRxvAXeqJTbww0bqNa7zAXyRCdPcpCQrzfjWScSdcEAjowrm4dQGNwWN5bwvm0QoILalvia1/hxvWblmBidQ6ct6keKJa2YwUPJc7GP+M6fei/Fe3sjBAhKOkvnLgNZsexb97Q5vviSEOvN/hnzBpBeJ2Eb11KrgHaI22aBeRyReBd2lOssuVRiI1MgG0ULzTOVcm9Al2Vw4dDi+PYsPx0m1+p1e1icsZLChdC+kAAp8VaycxA/V5NHIKHLHmU+tmjVa4IRz2g39Gi0XnU3OAeuC745iFNAzyJ9/ys9zcY7Aswngp/oGI3NKyoxy1bonRts3zjRedgCMr4RhdCqTmiqzqbjX13CiWsXhzizQgXlQclbncbikyYH76NK6hRBNylFisz19c/BrC8mYCOwerAKoCbM9rqZHPh4+Htownj11740yDVlpC04/UcCL2j2O7vNRlHTZR4SRCO+NSJ4NcXs2DrBNdNvqIABgLtdVxIlYZ1e1+kjNosXcZDggm++k1H0fDfiXYhYyyIxPMtLQgXf43WGi4nRoXfjsEDI3b8xbEY8bBVVblN7knb7a63djH7FXdspWq1eSSk8/Q1lbGB7vvN25T8SC7n0iTO7N4jgip8PkjOQb8KRXxZzMu4HuAsWfiB7dn2KKIY+aCY7XgHW/XNbk6M/h3anaW02Ri+z8vMYK+6eL548O7ueg/Owqv1x2zlk/iaJH0NZWxge77zduU++Vv/MM2gmdih/EEPn82tYiEakh4PGYtVnLN1AyZHWpIEdBrNSImLfxVGvge4Q4s5RXKD1gPCZq8EYuqJKCu3Qgpp6ME/ebgWm+PPdlqvvkYKyKbYAoLC92devAymTJuHcraiYM/juTtp//viw9HVnoc23s9cTPZ0+O1kWOcjlVQRk3r3LOXCUTMKC86iExUYrfgCEYgctH8/cAejZz8zeZ//OLN1L/vLSAx5lIAu6SljcCjugDAAD1PQyfywPjjSD0sU/fIB0DBmWIAAAAA1gdayLO9BbFYKfw5b8/CVmxqpuh1M+M3ezKfwkTozkWFYfHMkx25IK7cmxNIlz+9Z05Xt9xWOTYBPdwAujRBx8YTJKVfVn71n0QWpq0V8ww0TOa3vtj5cHyHdRt4rqrh2KJY+eAkly1iQ6GiiJOPL4IEOcmGgc2DQAADxnc93JLcvYHS5ETdevzQYsY27cQKw9wRIq/62mV+697Wgfc8Wj9b/HKsXmNSkI/48GIUUZ6QEcBVaFDYsiHx5//Z3OVYFlXSCZuUM5TrpxYHSVZ2lDh++VSp/mTWzk1Y2v9WKqfXYhlEz3/bFhC57p9n2sHV83GZ+pjOcd8aB5VcwJYzL+pbAlDI0+yIOxmeKwxvNKwLncWRbyI07XG2yoCNENjZLyoymH1KhPLYZQqN8SkTF2H6ZptKTYM/zm6gsw1q/guF8R06ukM9XZ5bycenZm3DHYfbrQ+/XKTD4pTfySoaUu0diU4YrllH4sTydPm9SwyWyAiRKzXKASoRFgIK94/XlvjCXR/dAFiIXhf+UmWS/snolj3EfDLTD3eyB2fvHgfg0gtzj0QDhxODtIdiNC0QhgLKeBXIP4w6aMdZ+XsjCJIK7UdUVl7YG5vBRr6cFl0tUo6sessvgWN4+ZGHRP4/9S58ZtaI49Gv7I9uxHgmqbreghxMdpCKgzeK6aEkbS2Vu6hWuvIm5tfsChm2Eptiy44KzwfcLvJ7fsclnAUg9Fe+Df9kVmlvxGEbElHCPmN1EWh6MnE5pWxqdL2wb/VScSSPWj7roHbvOt3tAqkl4CeivsbU4WTiRbNnr1vHgmX3Xt93xMw8oP04+XgeDW5dbZnAD/iIchX3IYqDq6DA64DBq7S80Y2XXE8XdSPpY5XwG6kLF4xvE1JyAYKf0H49vBBIL7qSXFW1+lKQqCn2a8WR0buQPzd9lgNFWBhXwOygLwKlNF4eVNPp2tynCpzlw1EervCuAFq90eBAHpzpbG5gDXnrk+aYbsmz4gWcj9Bh/4Y/vSDxqfOpY1Q/mpAbxCvBwKOJYRhck7x1Uj1RrUOPabvJ/oZy0BAR2o2qwka2LtX0/M1JG0BaVJS4fDnZ9krJRJ3X74vjZ/ezTJOrX3KW13bsw2NEDsRypu/dNpfs7pcU7ao4JeFxnsoCR7BxVKVhHVFjrzgDeP+WJWwTUH5a90f+Ys6G20u887mAY8s9UFgk46rpwdgxTAbRO9fiGXjZb+WDBiFyoGhJJ2daroLgmPwxSAQoGlnuU8m6KCg9p7iWscAuXYoUXcCjlwjIT3mpm7zA3FNrTap0MSu7+CU2DZExWds51h7BtWwtEqZnQpVqZbyaODiavRxDoqBQqAdYgu2VSOrIOOuRFrF52KfBlAFrVWEudJEfsbZDLGCXnxSB5bQSyLpWvsye4BN9/j7hbIDe42GL8O12uY8RAIsU7LSJ8XxTZvjPJ6uXDuzH7fFQ6PzB/ZM38BrRWmnieGmMv5B7cMxWVrWiXL9/V9KqTgUgtYh33gZBFOOmw8t6beX2Myl7YoM9IDs4GmBCcjnP90ZyNPHvenBWyQwwnrH52YRPbdx8wIwKjxaLjCQTAhMxBZgNc3ljmdl3XaGrSPujBr0N5zCeFMb2iMt/WCiTyKXa9kHPZtrwWLmUOwrup6pHsXCz4QEgm9U7gki1f/S2jg8vX5TVfaI9BXbRAEieTNQ5m+J/Wvg775CNfKmyCdR8CDU4noY8czOsiETODmhAoWC9m4I1FTJ1zhVCOZJ4orGP0d0uj4MJFUwLC3ysUTVH60wo0Rnqu8eCzDmqt22ZqPxG8DZ3ZqmoUQtk8u2XPw6finry7JawXhp7H3ZSS+zdGedhbKVdl/y7cZJguDekExqlPI3uOE7w5cTwQ5jPrhHQJ8RahzXCE1WZlwpTqcn/QHZkWhNFAge7D56+zY69LLRW1htTSHmAy6tgur0CVSoyCGB+v7hhbAtLIfPpD4/p5+LLbBkd9pTeZ8OKWwe0x7xXjhIZTWqUZ8fdTHl9zsR4Rz65jiTtYvTWmPgeYkg/6pfDVzzj27o1FTJ1zkSvkEPdEifT5Ij1O1XDfuADej0vkmVj64VnVFHpA2FSk8tLTZhhKi4quD2lcmgln5tPMtp4lejatf6e0kEBRowTrpdEiqOjiRGDSMkUn/LhYh7AwZIz8aVKm9g375eq+K2hMF6noAJswv9TbMJZQ7kGKt/qyPqSlOhlPluyCQK/wSHtvOwBXWPwGhZQlOMGI9U8h01enOXd+mK9N7sedXbnsvTm6SNTd541Cgc9amXS7QsRaxfbQyTaAk8Yx1z3Gdfkv8D+Y4gGmLL3qkXutwSYpVDiwKa4s4AZG1sK2rK7LtyY/PyiNO29UOHr3wncbL/MDvY5JJLC2pR3fG6YLGfqu+YVU6c6+jXM4ZrnNDX5MHD+ZZdFKR54CurSLpZFStdCp09X6qhDUalLH9RSgJqYPzaL3i43NJQ91cUSvcr+ClEN4Kvx2CHPD/gh0cPC8JD1lgtL+9AWNhitpjs7z0ED2/8jU5ODtcFmQNC4RkUGAIJ6+ST9LaMUCK4OIzN2OR8sCET0W8tiiKse0ti8fVXC3bysC+UdIlK4Q0//quB7++Je8YGsW8Jkc+SAq2aPuDOd/1t68Q+zU+zGzyG5OirDuJ+DuPv3h7AOOhHiFHK+STh2RAhGqwH+YQDsrRvePJQ7zwKk3CcRtukjyExu9ubyj4a7GJ5yFe9SJ5k7axawPcP4+LQdd5YkNe1C25s4weFpZl+kmPXAwpvuRy/I95R+kg9xI6lVzltI1dQsm/PXpEgA5qWEXShA22DYIohs6MOjz32C7XL3XIEBKtuPN07nV1pVtZBGENo8ONjD8fi+Ocf8L4hw44L3baVMabxZxlSmZ04fb59tc+P8lALOJz1Ubz7u6fjAqqHdb22+xLn3zy7jlxoouY59MNy4wU04yOxtxl3AUAjitTZRKZg8o3pcpag/HpCiyLjMqUgFR56DiEpa1JN2Rlyn86eJh+Q+aUt8PY5OdtPt6rW03PtpvOVeY2ATM3ShNN9XHGfpO+d+kcUaaI39Nd/Q0Y0Vid/WxUYn+rsyYILsnXK2+QMWfRIgwFGBEmZnsBWr3H7ViWlg6nFEwQCo2ZIIEn4lMpiYuju7hOdgLD89HFy3sH8ijFMU9XfpMNtgU0KgQZ6JoR8lrNULwQrO4WNqNsFOhDIWbKA7UC8tOqvC28jIJJbwzIEAf2p33r5abbMrwVQD5ODFvt11lk/UdCPb1bcN/mPvRstFZ/N+jx1olyr0kq2ivrGg0UWbMi6eHF+CU1iihQC7Z19yiXolFu9uC97dw8R9X0+d1BPaQkCO3SeneLM3GeRXr6iF/8DpDqkwfRscQY9AvVtVBqAl1Il4fLVsyejPIqbvQfmw0b+mMYHh/ysPoUUVSOoaA9ZXsa3IA60TfJhW0jEJrXsqrPGIbf4joEq/XnqGvX7cxH1SHpyjvImnSfCVjJrSnaWJdLOe4vl/ZWy7juNkCsUX7w6q9vLREgn8BkCyijb1hQq3/eZ1ymsHxO/RYOxi+2UiFyL8kUhbKv156hGwO5VTuN+gXCR8JpU0BuGVBwsRww4BApDJeMh4sLR8Lbx0EWY+nCUGfwMW1cwDAamCcDuQzbJCQ39sB4iXeauy2Adlg1AzXAwnAqA/IgLTMnYydXe4V9t4IMvgyq4Qx9NvuC9XdTW3EkN+sSAbZsu8i36syg+sgMEcAYor2whziwfCbJ+ZbJW3beXeM+zhbDgok1aJO5UF3JBjCmMGzqcc1EZ6COOBjLcDsXKyApHOVzV+hOHTU8kPeYcejHBbMG/mDi84PpRCOG/pZcObn04dU/BgK8O1DSFP/gvC/JwTeRKW5/LDhulKRYrWATkK8hNt07bmM3ixITZMJY2WMcVyzge0s1rUoYNJBcSbRLoLVPnmAMqqT8lEapqSyF4zXMGuU1/sxW/agjItxxJ/IMLKvjiLb23w0Vamj6P4hHL6w9gpk2jctiZVoIn8aC+kZgEB+assAMg/o81GePph3avh+rEwjd6vli9bXkYesEQWSfILwhC5r0MNaj/206M1BSSa9djMPrph914SvCXWSger+ijqR+Vkwsihi5NT/zxh0plhV2Cy92ZxzeES70WbBMA1tR9teTRr7MDzXGVIQXGWj9mDm0c/KSEhCZgU88ee5siuuHszmPBcWcez2bDqEkFnUBc6ALKTvOODHvFVV9GguA+wCg2oqRMO3RVzYIcd9zdM06hwoMIolhypjtw4NcvQJM+TdmOv2AzSXYBt8h4enLHmiM2lYvAYyDdf9UdMyJuNvvyJqhZKa6gs6Vz6ajXCFmBEmAYFLt4UD7aXH1dLxpB+HghmedbqvMFxgbNqpAc/yXEDMQRXV0JJ8Vztkc92g8w+0TAQvGwlQjDloFuvxigZw3aDs7auo7nzsyoEGEHyVAms5DK3K3VUNdknBUAal7rcC0MTpGUqudLHD+jdGeE6RjYF5DdRuymPncD9uxeohjVEHsSUQhVseUq+yJg12PED+NtillrWIVDNHqAm/PgwObFmt4WOsAKVw+Iyu1cvkqgNszW7TV0Uwfe/zdX6jntgnwHayltqOqp37YWVsHwKti+f/0DuCKTB6yKaF65tGck8tsTGcrvQcvkYRcueKfuVdVKEF1EKdFkj/+uudAaS/R1Vs4nifgAzbj2dzs411hddbbmbrRhY68N+XliT7/FA7UhihNsleFIHG7J22Fz3YM3k559U6kOTDQfCs3MKtZghFpZ13Jz9DvIzKnIBIohAJkpEP1P0r1EslfHTI8JCs8Ald87Pld5JpJPsQIf1aZedPC0H3xkS3jpBLkn3nwxCvs93PI/tA/Qx+70nDFRgPLbELIDqG41bJfHh10Fcyz4AAAAAAAAABrZdZGEWtALIRfP18kPaHTRJ7+fpzzMcO22ixgXx1qASFELjM4ufF3Pjn8oUenJ1qCrvlnvL9++ZVt+0tnygiaA1eMrBxvhL6vUj/iz1qYPWR1g25ExODty8GV81Z25jN6A0Ek4y8MRRDXiNinYKY6VnsdjhIwgMJbpUpyWllFYsn04B4cpjJli6Oz5JIjqmXIWQm9TA9PG2wlLES0jLsIuzLFTX7Zjze7Ev+SPlefAIz9DLoZhuOeG1saml9ouwmJlvV4nObZVYHgB52C2QlSMW1cLJmH/zWGHczOa1eZl26OBPJPl4kRN6b5aLBwIZcAcB3iPPvTCQ7re/j4lusl6zHdIXlUB2z/FLu/wctoE4KzgH3e/V32Ubh6UBpzcOsOGVtbZ1QyER24ubMf4mz43ngrbl5Cl+1UTMVOgmq/FeAFoFU8A8yLtztdUt/TpSvkGmP5Evn/eAeoQKo8Z6rO3jKqDym5KrOY0M90yCPU+nJCAEuxW10SqyGcH4xiyAQiQnJO/4M2CSYm5jjT5KZA6rH5YX6xkmc1Z9Dp1qLbcXHem2aIU7iWG0hCW1cvj6gIGRWOx2upwrcPwod3OivCbaWoffhUmeKsDp2lTsYGgLHmf+bS0xum5OsRmwEkxUeXLOdHlXQjnlRCE/AmgFY0olUHBk2sTYm9Zukrx/Va547HiGRC5SdbnfpNy2RwB5BKmVSOmmFbWiaxVYHsP8d451rk8jyPoBwjlbenY3rY+Sb2cu04P/iINXxdnFvhg1tUg6Trp2xzR1afZx7dU765j4zojkGBEJ3fEwWpMulKoxAcwVzotSiq/JEI/HCSzYOjNFoWCGsXh8lBCnC5DsclyZ2fqEl3M/NYOabzQg3s1KEiJuS04y7sAgAA0rGpWudWbYnIjkchkKmeag4fcJN4EaQn+rsi5EoQQtGf3hqdjORvdUiaWRNZIaeAEEy5UK7kcIE8SXI6wIwoFtpnvNG0dKM5VAJ3iwy8KOu9kWqmUukH3JKIM+QbziWIQA9IFv94GRhwyK/GbY8oAitEmW3ZnAztsYzXT9z/vaBjG5NsDlAJwBvm8REZn9QIL3Up3gw/fzGTWxqp6GsrYv6v/O+63eG3rWvuARqPkFzAya+5AqfumhWcQUmUCCT/0k8gduIp+Doh17AAAAAA=",
+        "width": 412
+      }
+    }
+  },
+  "analysisUTCTimestamp": "2026-05-14T17:23:06.320Z"
+}

--- a/tmp/perf-20260515/psi-blog.json
+++ b/tmp/perf-20260515/psi-blog.json
@@ -1,0 +1,7154 @@
+{
+  "captchaResult": "CAPTCHA_NOT_NEEDED",
+  "kind": "pagespeedonline#result",
+  "id": "https://www.ocobo.co/blog",
+  "loadingExperience": {
+    "initial_url": "https://www.ocobo.co/blog"
+  },
+  "lighthouseResult": {
+    "requestedUrl": "https://www.ocobo.co/blog",
+    "finalUrl": "https://www.ocobo.co/blog",
+    "mainDocumentUrl": "https://www.ocobo.co/blog",
+    "finalDisplayedUrl": "https://www.ocobo.co/blog",
+    "lighthouseVersion": "13.0.1",
+    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+    "fetchTime": "2026-05-15T09:28:49.544Z",
+    "environment": {
+      "networkUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36",
+      "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+      "benchmarkIndex": 512.5
+    },
+    "runWarnings": [],
+    "configSettings": {
+      "emulatedFormFactor": "mobile",
+      "formFactor": "mobile",
+      "locale": "en-US",
+      "onlyCategories": [
+        "performance"
+      ],
+      "channel": "lr"
+    },
+    "audits": {
+      "metrics": {
+        "id": "metrics",
+        "title": "Metrics",
+        "description": "Collects all available metrics.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "totalBlockingTime": 794,
+              "observedDomContentLoaded": 3822,
+              "observedSpeedIndexTs": 79117703,
+              "observedDomContentLoadedTs": 79116548,
+              "cumulativeLayoutShiftMainFrame": 0.00213,
+              "observedLargestContentfulPaintTs": 78940456,
+              "maxPotentialFID": 236,
+              "observedLargestContentfulPaint": 3646,
+              "observedFirstPaintTs": 78750345,
+              "observedFirstContentfulPaintAllFramesTs": 78750345,
+              "observedNavigationStart": 0,
+              "timeToFirstByte": 601,
+              "observedCumulativeLayoutShiftMainFrame": 0.00213,
+              "firstContentfulPaint": 3751,
+              "observedLastVisualChange": 6249,
+              "observedNavigationStartTs": 75294535,
+              "observedCumulativeLayoutShift": 0.00213,
+              "observedFirstContentfulPaintTs": 78750345,
+              "observedFirstContentfulPaint": 3456,
+              "observedTimeOrigin": 0,
+              "observedFirstVisualChange": 341,
+              "observedTimeOriginTs": 75294535,
+              "observedTraceEndTs": 83675330,
+              "speedIndex": 8451,
+              "observedTraceEnd": 8381,
+              "observedSpeedIndex": 3823,
+              "observedFirstPaint": 3456,
+              "observedLoadTs": 81070422,
+              "interactive": 15979,
+              "lcpLoadDuration": 7274,
+              "observedFirstVisualChangeTs": 75635535,
+              "cumulativeLayoutShift": 0.00213,
+              "observedFirstContentfulPaintAllFrames": 3456,
+              "observedLargestContentfulPaintAllFramesTs": 78940456,
+              "observedLargestContentfulPaintAllFrames": 3646,
+              "largestContentfulPaint": 7426,
+              "lcpLoadDelay": 6368,
+              "observedLastVisualChangeTs": 81543535,
+              "observedLoad": 5776
+            },
+            {
+              "lcpInvalidated": false
+            }
+          ]
+        },
+        "numericValue": 15979,
+        "numericUnit": "millisecond"
+      },
+      "total-byte-weight": {
+        "id": "total-byte-weight",
+        "title": "Avoid enormous network payloads",
+        "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn how to reduce payload sizes](https://developer.chrome.com/docs/lighthouse/performance/total-byte-weight/).",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Total size was 9,793 KiB",
+        "details": {
+          "sortedBy": [
+            "totalBytes"
+          ],
+          "items": [
+            {
+              "totalBytes": 2701533,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/corentin-guerin.jpeg"
+            },
+            {
+              "totalBytes": 2527840,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/aude-cadiot.jpg"
+            },
+            {
+              "totalBytes": 2246162,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/ethel-gosset.jpeg"
+            },
+            {
+              "totalBytes": 348931,
+              "url": "https://www.ocobo.co/blog"
+            },
+            {
+              "totalBytes": 204723,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "totalBytes": 204723
+            },
+            {
+              "totalBytes": 202020,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png"
+            },
+            {
+              "totalBytes": 179761,
+              "url": "https://images.unsplash.com/photo-1566140967404-b8b3932483f5?w=1200&h=800&fit=crop"
+            },
+            {
+              "totalBytes": 159091,
+              "url": "https://images.unsplash.com/photo-1612385763901-68857dd4c43c?w=1200&h=800&fit=crop"
+            },
+            {
+              "totalBytes": 158846,
+              "url": "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=1200&h=800&fit=crop"
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "label": "Transfer Size",
+              "key": "totalBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 10027542,
+        "numericUnit": "byte"
+      },
+      "diagnostics": {
+        "id": "diagnostics",
+        "title": "Diagnostics",
+        "description": "Collection of useful page vitals.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "mainDocumentTransferSize": 348931,
+              "numFonts": 5,
+              "numTasks": 1789,
+              "maxRtt": 10.600109999999997,
+              "rtt": 0.00039086018355857067,
+              "numTasksOver100ms": 9,
+              "totalByteWeight": 10027542,
+              "numTasksOver500ms": 0,
+              "throughput": 60852600916.481232,
+              "numTasksOver25ms": 27,
+              "numTasksOver10ms": 46,
+              "numTasksOver50ms": 15,
+              "maxServerLatency": 25.5,
+              "numScripts": 54,
+              "totalTaskTime": 3057.6489999999972,
+              "numRequests": 90,
+              "numStylesheets": 3
+            }
+          ]
+        }
+      },
+      "third-parties-insight": {
+        "id": "third-parties-insight",
+        "title": "3rd parties",
+        "description": "3rd party code can significantly impact load performance. [Reduce and defer loading of 3rd party code](https://developer.chrome.com/docs/performance/insights/third-parties) to prioritize your page's content.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "entity": "Hubspot",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+                    "transferSize": 409446,
+                    "mainThreadTime": 315.90400000003865
+                  },
+                  {
+                    "transferSize": 43657,
+                    "mainThreadTime": 36.19800000001851,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+                  },
+                  {
+                    "transferSize": 28210,
+                    "mainThreadTime": 33.553000000014435,
+                    "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                  },
+                  {
+                    "transferSize": 29959,
+                    "mainThreadTime": 29.95700000000943,
+                    "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+                  },
+                  {
+                    "transferSize": 27218,
+                    "mainThreadTime": 25.038000000029569,
+                    "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+                  },
+                  {
+                    "transferSize": 1642,
+                    "mainThreadTime": 6.0119999999878928,
+                    "url": "https://js-eu1.hs-scripts.com/27107933.js"
+                  },
+                  {
+                    "transferSize": 4082,
+                    "mainThreadTime": 0.26599999998870771,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953"
+                  },
+                  {
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+                    "transferSize": 1095,
+                    "mainThreadTime": 0.19600000001082662
+                  },
+                  {
+                    "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fblog&isMobile=true",
+                    "transferSize": 1710,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog&t=Ocobo+%C2%B7+Le+blog+des+Revenue+Operations&cts=1778837335448&vi=95a8156d5c77c5165ba180d5febfdaee&nc=true&u=242475741.95a8156d5c77c5165ba180d5febfdaee.1778837335442.1778837335442.1778837335442.1&b=242475741.1.1778837335442&cc=15",
+                    "transferSize": 1474,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=fcc77d25-95de-4d4f-ae82-37b6b3f8bf1d&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog&t=Ocobo+%C2%B7+Le+blog+des+Revenue+Operations&cts=1778837335804&vi=95a8156d5c77c5165ba180d5febfdaee&nc=true&u=242475741.95a8156d5c77c5165ba180d5febfdaee.1778837335442.1778837335442.1778837335442.1&b=242475741.1.1778837335442&cc=15",
+                    "transferSize": 1066,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+                    "transferSize": 1024,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+                    "transferSize": 1022,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+                    "transferSize": 1021,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+                    "transferSize": 558,
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "transferSize": 553184,
+              "mainThreadTime": 447.124000000098
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 157231,
+                    "mainThreadTime": 327.92400000001362,
+                    "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "entity": "Google Tag Manager",
+              "mainThreadTime": 327.92400000001362,
+              "transferSize": 157231
+            },
+            {
+              "transferSize": 7057,
+              "mainThreadTime": 10.407000000006519,
+              "entity": "GitHub",
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 5038,
+                    "mainThreadTime": 10.407000000006519,
+                    "url": "https://useago.github.io/widgetjs/frame.js"
+                  },
+                  {
+                    "url": "https://useago.github.io/widgetjs/frame.css",
+                    "transferSize": 2019,
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "transferSize": 559835,
+              "mainThreadTime": 0,
+              "entity": "unsplash.com",
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 179761,
+                    "mainThreadTime": 0,
+                    "url": "https://images.unsplash.com/photo-1566140967404-b8b3932483f5?w=1200&h=800&fit=crop"
+                  },
+                  {
+                    "transferSize": 159091,
+                    "mainThreadTime": 0,
+                    "url": "https://images.unsplash.com/photo-1612385763901-68857dd4c43c?w=1200&h=800&fit=crop"
+                  },
+                  {
+                    "transferSize": 158846,
+                    "mainThreadTime": 0,
+                    "url": "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=1200&h=800&fit=crop"
+                  },
+                  {
+                    "url": "https://images.unsplash.com/photo-1493612276216-ee3925520721?ixlib=rb-4.0.3&q=85&fm=jpg&cs=srgb&w=1200&h=800&fit=crop",
+                    "transferSize": 62137,
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "entity": "vercel-storage.com",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/corentin-guerin.jpeg",
+                    "transferSize": 2701533,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/aude-cadiot.jpg",
+                    "transferSize": 2527840,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 2246162,
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/ethel-gosset.jpeg"
+                  },
+                  {
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png",
+                    "transferSize": 202020,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-13/cover-1.png",
+                    "transferSize": 92677,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 67588,
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg"
+                  }
+                ]
+              },
+              "transferSize": 7837820,
+              "mainThreadTime": 0
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 1280,
+                    "mainThreadTime": 0,
+                    "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "entity": "Clearbit",
+              "transferSize": 1280,
+              "mainThreadTime": 0
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 796,
+                    "mainThreadTime": 0,
+                    "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65e0h2v9100339653za200zd9100339653&_p=1778837333019&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1024313207.1778837334&frm=0&pscdl=noapi&rcb=16&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616986~115938465~115938468&dp=%2Fblog&sid=1778837333&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fblog&dt=Ocobo%20%C2%B7%20Le%20blog%20des%20Revenue%20Operations&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=4055"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "entity": "Google Analytics",
+              "transferSize": 796,
+              "mainThreadTime": 0
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                    "transferSize": 102671,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1259,
+                    "mainThreadTime": 0,
+                    "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "entity": "Google Fonts",
+              "transferSize": 103930,
+              "mainThreadTime": 0
+            }
+          ],
+          "type": "table",
+          "headings": [
+            {
+              "subItemsHeading": {
+                "key": "url",
+                "valueType": "url"
+              },
+              "label": "3rd party",
+              "key": "entity",
+              "valueType": "text"
+            },
+            {
+              "label": "Transfer size",
+              "granularity": 1,
+              "key": "transferSize",
+              "subItemsHeading": {
+                "key": "transferSize"
+              },
+              "valueType": "bytes"
+            },
+            {
+              "granularity": 1,
+              "label": "Main thread time",
+              "valueType": "ms",
+              "subItemsHeading": {
+                "key": "mainThreadTime"
+              },
+              "key": "mainThreadTime"
+            }
+          ],
+          "isEntityGrouped": true
+        }
+      },
+      "lcp-discovery-insight": {
+        "id": "lcp-discovery-insight",
+        "title": "LCP request discovery",
+        "description": "[Optimize LCP](https://developer.chrome.com/docs/performance/insights/lcp-discovery) by making the LCP image discoverable from the HTML immediately, and avoiding lazy-loading",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "type": "checklist",
+              "items": {
+                "priorityHinted": {
+                  "value": true,
+                  "label": "fetchpriority=high applied"
+                },
+                "eagerlyLoaded": {
+                  "label": "lazy load not applied",
+                  "value": true
+                },
+                "requestDiscoverable": {
+                  "value": true,
+                  "label": "Request is discoverable in initial document"
+                }
+              }
+            },
+            {
+              "lhId": "page-1-IMG",
+              "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"pos_absolute inset_0 w_full h_full obj-f_cover op_0.8\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+              "boundingRect": {
+                "width": 380,
+                "height": 224,
+                "right": 396,
+                "bottom": 892,
+                "top": 668,
+                "left": 16
+              },
+              "type": "node",
+              "selector": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute",
+              "nodeLabel": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute",
+              "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,1,A,0,DIV,0,IMG"
+            }
+          ]
+        }
+      },
+      "non-composited-animations": {
+        "id": "non-composited-animations",
+        "title": "Avoid non-composited animations",
+        "description": "Animations which are not composited can be janky and increase CLS. [Learn how to avoid non-composited animations](https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/)",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "subItemsHeading": {
+                "key": "failureReason",
+                "valueType": "text"
+              },
+              "key": "node",
+              "label": "Element",
+              "valueType": "node"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "render-blocking-insight": {
+        "id": "render-blocking-insight",
+        "title": "Render blocking requests",
+        "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "valueType": "bytes",
+              "label": "Transfer Size",
+              "key": "totalBytes"
+            },
+            {
+              "valueType": "timespanMs",
+              "label": "Duration",
+              "key": "wastedMs"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "wastedMs": 173,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "totalBytes": 24572
+            }
+          ]
+        }
+      },
+      "network-requests": {
+        "id": "network-requests",
+        "title": "Network Requests",
+        "description": "Lists the network requests that were made during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "rendererStartTime": 0,
+              "url": "https://www.ocobo.co/blog",
+              "resourceSize": 1856276,
+              "priority": "VeryHigh",
+              "mimeType": "text/html",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "transferSize": 348931,
+              "protocol": "h2",
+              "resourceType": "Document",
+              "finished": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 1.2590000000054715,
+              "networkEndTime": 3079.6710000000021
+            },
+            {
+              "entity": "ocobo.co",
+              "transferSize": 24572,
+              "protocol": "h2",
+              "resourceType": "Stylesheet",
+              "finished": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3125.5039999999863,
+              "networkEndTime": 3332.4640000000072,
+              "rendererStartTime": 3124.1129999999976,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "resourceSize": 122090,
+              "priority": "VeryHigh",
+              "mimeType": "text/css",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "finished": true,
+              "resourceType": "Image",
+              "protocol": "h2",
+              "transferSize": 12757,
+              "entity": "ocobo.co",
+              "networkEndTime": 3416.4829999999929,
+              "networkRequestTime": 3125.6600000000035,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "resourceSize": 12266,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "rendererStartTime": 3124.7329999999929,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "priority": "High"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/png",
+              "priority": "Medium",
+              "resourceSize": 29045,
+              "url": "https://www.ocobo.co/images/partners/modern-revenue-club.png",
+              "rendererStartTime": 3124.974000000002,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3125.8479999999981,
+              "networkEndTime": 3410.833999999988,
+              "statusCode": 200,
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Image",
+              "transferSize": 29545,
+              "entity": "ocobo.co"
+            },
+            {
+              "resourceType": "Image",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "vercel-storage.com",
+              "transferSize": 202020,
+              "networkEndTime": 3571.0699999999924,
+              "networkRequestTime": 3126.0580000000045,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png",
+              "resourceSize": 201358,
+              "rendererStartTime": 3125.2309999999998,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "priority": "High"
+            },
+            {
+              "resourceType": "Image",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "vercel-storage.com",
+              "transferSize": 2246162,
+              "networkEndTime": 3910.2909999999974,
+              "networkRequestTime": 3344.7589999999909,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/ethel-gosset.jpeg",
+              "resourceSize": 2245492,
+              "rendererStartTime": 3125.4869999999937,
+              "mimeType": "image/jpeg",
+              "experimentalFromMainFrame": true,
+              "priority": "Low"
+            },
+            {
+              "resourceType": "Image",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "vercel-storage.com",
+              "transferSize": 67588,
+              "networkRequestTime": 3344.9530000000086,
+              "networkEndTime": 3634.68299999999,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg",
+              "resourceSize": 66917,
+              "rendererStartTime": 3125.6359999999986,
+              "mimeType": "image/jpeg",
+              "experimentalFromMainFrame": true,
+              "priority": "Low"
+            },
+            {
+              "resourceSize": 2700860,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/corentin-guerin.jpeg",
+              "rendererStartTime": 3126.5240000000049,
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/jpeg",
+              "priority": "Low",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Image",
+              "transferSize": 2701533,
+              "entity": "vercel-storage.com",
+              "sessionTargetType": "page",
+              "networkRequestTime": 3345.1340000000055,
+              "networkEndTime": 4059.4370000000054,
+              "statusCode": 200
+            },
+            {
+              "rendererStartTime": 3126.9700000000012,
+              "resourceSize": 2527172,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/aude-cadiot.jpg",
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/jpeg",
+              "transferSize": 2527840,
+              "entity": "vercel-storage.com",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Image",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3345.2949999999983,
+              "networkEndTime": 3900.8260000000009
+            },
+            {
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "entity": "Google Tag Manager",
+              "transferSize": 157231,
+              "sessionTargetType": "page",
+              "networkEndTime": 3377.586999999985,
+              "networkRequestTime": 3345.3969999999972,
+              "statusCode": 200,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "resourceSize": 472102,
+              "rendererStartTime": 3127.5500000000029,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "Low"
+            },
+            {
+              "statusCode": 404,
+              "networkEndTime": 3788.8479999999981,
+              "networkRequestTime": 3345.5639999999985,
+              "sessionTargetType": "page",
+              "transferSize": 640,
+              "entity": "Clearbit",
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 3127.7149999999965,
+              "resourceSize": 0,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js"
+            },
+            {
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "resourceSize": 2125,
+              "rendererStartTime": 3127.8800000000047,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3345.8990000000049,
+              "networkEndTime": 3507.9239999999991,
+              "statusCode": 200,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "entity": "Hubspot",
+              "transferSize": 1642
+            },
+            {
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 3128.0869999999995,
+              "resourceSize": 17494,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3516.2200000000012,
+              "networkRequestTime": 3346.2599999999948,
+              "transferSize": 5038,
+              "entity": "GitHub",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Script"
+            },
+            {
+              "networkRequestTime": 3129.2160000000003,
+              "networkEndTime": 3216.9219999999914,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 24117,
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 69556,
+              "url": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "rendererStartTime": 3128.2569999999978,
+              "isLinkPreload": true
+            },
+            {
+              "url": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "resourceSize": 927,
+              "rendererStartTime": 3128.4830000000075,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 1457,
+              "networkEndTime": 3239.976999999999,
+              "networkRequestTime": 3129.3869999999879,
+              "sessionTargetType": "page",
+              "statusCode": 200
+            },
+            {
+              "rendererStartTime": 3128.6379999999917,
+              "isLinkPreload": true,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "resourceSize": 125397,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "transferSize": 43927,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "statusCode": 200,
+              "networkEndTime": 3262.2480000000069,
+              "networkRequestTime": 3129.6349999999948,
+              "sessionTargetType": "page"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 3233.8790000000008,
+              "networkRequestTime": 3129.8369999999995,
+              "statusCode": 200,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 45263,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "resourceSize": 133936,
+              "isLinkPreload": true,
+              "rendererStartTime": 3128.8459999999905
+            },
+            {
+              "url": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "resourceSize": 110060,
+              "isLinkPreload": true,
+              "rendererStartTime": 3129.0409999999974,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 34187,
+              "sessionTargetType": "page",
+              "networkEndTime": 3210.099000000002,
+              "networkRequestTime": 3130.3839999999909,
+              "statusCode": 200
+            },
+            {
+              "url": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "resourceSize": 991,
+              "isLinkPreload": true,
+              "rendererStartTime": 3129.2129999999888,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 1517,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3130.6910000000062,
+              "networkEndTime": 3321.0390000000043,
+              "statusCode": 200
+            },
+            {
+              "transferSize": 4525,
+              "entity": "ocobo.co",
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "statusCode": 200,
+              "networkRequestTime": 3130.8559999999998,
+              "networkEndTime": 3254.2969999999914,
+              "sessionTargetType": "page",
+              "rendererStartTime": 3129.4070000000065,
+              "isLinkPreload": true,
+              "resourceSize": 9799,
+              "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "url": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "resourceSize": 3192,
+              "rendererStartTime": 3129.5829999999987,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 2151,
+              "networkRequestTime": 3130.9809999999852,
+              "networkEndTime": 3222.7639999999956,
+              "sessionTargetType": "page",
+              "statusCode": 200
+            },
+            {
+              "url": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "resourceSize": 141,
+              "rendererStartTime": 3129.7519999999931,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 672,
+              "networkEndTime": 3223.1189999999915,
+              "networkRequestTime": 3131.4689999999973,
+              "sessionTargetType": "page",
+              "statusCode": 200
+            },
+            {
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3131.9720000000088,
+              "networkEndTime": 3166.0449999999983,
+              "entity": "ocobo.co",
+              "transferSize": 1272,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "rendererStartTime": 3129.9199999999983,
+              "url": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "resourceSize": 1284
+            },
+            {
+              "transferSize": 6809,
+              "entity": "ocobo.co",
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "statusCode": 200,
+              "networkRequestTime": 3132.0920000000042,
+              "networkEndTime": 3324.7559999999939,
+              "sessionTargetType": "page",
+              "rendererStartTime": 3130.122000000003,
+              "isLinkPreload": true,
+              "resourceSize": 15426,
+              "url": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "resourceSize": 17234,
+              "url": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "rendererStartTime": 3130.6029999999882,
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 6208,
+              "entity": "ocobo.co",
+              "networkEndTime": 3255.6849999999977,
+              "networkRequestTime": 3132.42300000001,
+              "sessionTargetType": "page",
+              "statusCode": 200
+            },
+            {
+              "networkEndTime": 3321.6900000000023,
+              "networkRequestTime": 3132.9140000000043,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 1835,
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 3070,
+              "url": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "rendererStartTime": 3130.8009999999922,
+              "isLinkPreload": true
+            },
+            {
+              "rendererStartTime": 3130.9760000000097,
+              "isLinkPreload": true,
+              "resourceSize": 428,
+              "url": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "transferSize": 956,
+              "entity": "ocobo.co",
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "statusCode": 200,
+              "networkEndTime": 3173.9149999999936,
+              "networkRequestTime": 3133.1649999999936,
+              "sessionTargetType": "page"
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 3324.375,
+              "networkRequestTime": 3133.2540000000008,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "transferSize": 940,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 3131.1619999999966,
+              "isLinkPreload": true,
+              "url": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "resourceSize": 410
+            },
+            {
+              "transferSize": 1050,
+              "entity": "ocobo.co",
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "statusCode": 200,
+              "networkRequestTime": 3133.55799999999,
+              "networkEndTime": 3217.6120000000083,
+              "sessionTargetType": "page",
+              "rendererStartTime": 3131.3559999999998,
+              "isLinkPreload": true,
+              "resourceSize": 525,
+              "url": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "networkEndTime": 3234.726999999999,
+              "networkRequestTime": 3133.7790000000095,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 1474,
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 942,
+              "url": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "rendererStartTime": 3131.7519999999931,
+              "isLinkPreload": true
+            },
+            {
+              "statusCode": 200,
+              "networkRequestTime": 3134.0059999999939,
+              "networkEndTime": 3322.57699999999,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "transferSize": 879,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 3132.0439999999944,
+              "isLinkPreload": true,
+              "url": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "resourceSize": 349
+            },
+            {
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3134.553,
+              "networkEndTime": 3200.0269999999873,
+              "entity": "ocobo.co",
+              "transferSize": 1370,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "rendererStartTime": 3132.5749999999971,
+              "url": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "resourceSize": 1866
+            },
+            {
+              "transferSize": 870,
+              "entity": "ocobo.co",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3338.0270000000019,
+              "networkRequestTime": 3135.0439999999944,
+              "isLinkPreload": true,
+              "rendererStartTime": 3132.898000000001,
+              "resourceSize": 348,
+              "url": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "rendererStartTime": 3133.1759999999922,
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "resourceSize": 67398,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3135.4369999999908,
+              "networkEndTime": 3246.6610000000073,
+              "entity": "ocobo.co",
+              "transferSize": 21255,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true
+            },
+            {
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "resourceSize": 165,
+              "rendererStartTime": 3133.4569999999949,
+              "isLinkPreload": true,
+              "networkEndTime": 3326.8499999999913,
+              "networkRequestTime": 3135.7160000000003,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 704
+            },
+            {
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 1130,
+              "networkEndTime": 3174.62999999999,
+              "networkRequestTime": 3136.4489999999932,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "resourceSize": 605,
+              "rendererStartTime": 3133.6529999999912,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "High"
+            },
+            {
+              "statusCode": 200,
+              "networkRequestTime": 3136.6680000000051,
+              "networkEndTime": 3293.0059999999939,
+              "sessionTargetType": "page",
+              "transferSize": 1348,
+              "entity": "ocobo.co",
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 3133.9679999999935,
+              "isLinkPreload": true,
+              "resourceSize": 826,
+              "url": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js"
+            },
+            {
+              "transferSize": 932,
+              "entity": "ocobo.co",
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "statusCode": 200,
+              "networkEndTime": 3171.0819999999949,
+              "networkRequestTime": 3137.0089999999909,
+              "sessionTargetType": "page",
+              "rendererStartTime": 3134.2229999999981,
+              "isLinkPreload": true,
+              "resourceSize": 404,
+              "url": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "rendererStartTime": 3134.580999999991,
+              "isLinkPreload": true,
+              "resourceSize": 490,
+              "url": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "transferSize": 1014,
+              "entity": "ocobo.co",
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "statusCode": 200,
+              "networkRequestTime": 3137.5899999999965,
+              "networkEndTime": 3285.0430000000051,
+              "sessionTargetType": "page"
+            },
+            {
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 729,
+              "networkEndTime": 3327.6839999999938,
+              "networkRequestTime": 3137.8289999999979,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "resourceSize": 206,
+              "rendererStartTime": 3134.7859999999928,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "High"
+            },
+            {
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 1361,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3137.9479999999894,
+              "networkEndTime": 3243.3279999999941,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "resourceSize": 835,
+              "isLinkPreload": true,
+              "rendererStartTime": 3135.0089999999909,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "High"
+            },
+            {
+              "rendererStartTime": 3135.3419999999896,
+              "isLinkPreload": true,
+              "url": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "resourceSize": 68826,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "transferSize": 26415,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 3138.252999999997,
+              "networkEndTime": 3275.3939999999857,
+              "sessionTargetType": "page"
+            },
+            {
+              "isLinkPreload": true,
+              "rendererStartTime": 3135.8739999999962,
+              "url": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "resourceSize": 473,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "transferSize": 1000,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3249.9339999999938,
+              "networkRequestTime": 3138.38900000001
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 3322.1739999999991,
+              "networkRequestTime": 3138.502999999997,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "transferSize": 858,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 3136.0420000000013,
+              "isLinkPreload": true,
+              "url": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "resourceSize": 338
+            },
+            {
+              "isLinkPreload": true,
+              "rendererStartTime": 3136.36099999999,
+              "url": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "resourceSize": 435,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "transferSize": 967,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3141.5200000000041,
+              "networkEndTime": 3198.7560000000085
+            },
+            {
+              "entity": "ocobo.co",
+              "transferSize": 843,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 3145.6230000000069,
+              "networkEndTime": 3222.23599999999,
+              "sessionTargetType": "page",
+              "rendererStartTime": 3137.0910000000003,
+              "isLinkPreload": true,
+              "url": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "resourceSize": 312,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "entity": "ocobo.co",
+              "transferSize": 834,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3212.1300000000047,
+              "networkRequestTime": 3145.7639999999956,
+              "isLinkPreload": true,
+              "rendererStartTime": 3137.3589999999967,
+              "url": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "resourceSize": 309,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "isLinkPreload": true,
+              "rendererStartTime": 3137.5570000000007,
+              "url": "https://www.ocobo.co/assets/_main.blog._index-Ch2d6Qju.js",
+              "resourceSize": 9172,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "transferSize": 4152,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3145.926999999996,
+              "networkEndTime": 3508.2379999999976
+            },
+            {
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3264.0650000000023,
+              "networkRequestTime": 3146.0760000000009,
+              "entity": "ocobo.co",
+              "transferSize": 1240,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "isLinkPreload": true,
+              "rendererStartTime": 3137.7620000000024,
+              "url": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "resourceSize": 717
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 272,
+              "url": "https://www.ocobo.co/assets/optimized-image-BKBFj58i.js",
+              "rendererStartTime": 3137.9479999999894,
+              "isLinkPreload": true,
+              "networkEndTime": 3418.7390000000014,
+              "networkRequestTime": 3150.9530000000086,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 803,
+              "entity": "ocobo.co"
+            },
+            {
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 832,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3151.0739999999932,
+              "networkEndTime": 3422.1040000000066,
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/labels-CtAnB7VF.js",
+              "resourceSize": 310,
+              "isLinkPreload": true,
+              "rendererStartTime": 3138.1169999999984,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "High"
+            },
+            {
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 3138.3160000000062,
+              "isLinkPreload": true,
+              "resourceSize": 302,
+              "url": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js",
+              "statusCode": 200,
+              "networkEndTime": 3341.3870000000024,
+              "networkRequestTime": 3151.1589999999997,
+              "sessionTargetType": "page",
+              "transferSize": 829,
+              "entity": "ocobo.co",
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 549,
+              "url": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "rendererStartTime": 3138.4649999999965,
+              "isLinkPreload": true,
+              "networkEndTime": 3236.1760000000068,
+              "networkRequestTime": 3151.2350000000006,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 1077,
+              "entity": "ocobo.co"
+            },
+            {
+              "isLinkPreload": true,
+              "rendererStartTime": 3138.6499999999942,
+              "resourceSize": 1217,
+              "url": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "transferSize": 1135,
+              "entity": "ocobo.co",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3200.9799999999959,
+              "networkRequestTime": 3151.3929999999964
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/svg+xml",
+              "priority": "Low",
+              "resourceSize": 515,
+              "url": "data:image/svg+xml,%3Csvg width='28' height='9' viewBox='0 0 28 9' fill='currentColor' xmlns='http:…",
+              "rendererStartTime": 3363.2709999999934,
+              "networkRequestTime": 3363.2709999999934,
+              "networkEndTime": 3363.4400000000023,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Image",
+              "protocol": "data",
+              "transferSize": 0
+            },
+            {
+              "resourceType": "Font",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 31974,
+              "networkEndTime": 3541.2540000000008,
+              "networkRequestTime": 3369.531999999992,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+              "resourceSize": 31480,
+              "rendererStartTime": 3368.4489999999932,
+              "mimeType": "font/woff",
+              "experimentalFromMainFrame": true,
+              "priority": "VeryHigh"
+            },
+            {
+              "entity": "ocobo.co",
+              "transferSize": 38778,
+              "protocol": "h2",
+              "resourceType": "Font",
+              "finished": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 3369.7390000000014,
+              "networkEndTime": 3718.9049999999988,
+              "rendererStartTime": 3368.7010000000009,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+              "resourceSize": 57572,
+              "priority": "VeryHigh",
+              "mimeType": "font/otf",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "rendererStartTime": 3368.7979999999952,
+              "resourceSize": 58256,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+              "priority": "VeryHigh",
+              "experimentalFromMainFrame": true,
+              "mimeType": "font/otf",
+              "transferSize": 39126,
+              "entity": "ocobo.co",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Font",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3540.1300000000047,
+              "networkRequestTime": 3369.9170000000013
+            },
+            {
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/jpeg",
+              "rendererStartTime": 3438.596000000005,
+              "resourceSize": 158261,
+              "url": "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=1200&h=800&fit=crop",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3458.1160000000091,
+              "networkRequestTime": 3439.403999999995,
+              "transferSize": 158846,
+              "entity": "unsplash.com",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Image"
+            },
+            {
+              "entity": "vercel-storage.com",
+              "transferSize": 92677,
+              "protocol": "h2",
+              "resourceType": "Image",
+              "finished": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3623.8989999999903,
+              "networkRequestTime": 3439.5540000000037,
+              "rendererStartTime": 3438.8469999999943,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-13/cover-1.png",
+              "resourceSize": 92016,
+              "priority": "Low",
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/jpeg",
+              "rendererStartTime": 3438.9719999999943,
+              "resourceSize": 61553,
+              "url": "https://images.unsplash.com/photo-1493612276216-ee3925520721?ixlib=rb-4.0.3&q=85&fm=jpg&cs=srgb&w=1200&h=800&fit=crop",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 3493.4159999999974,
+              "networkRequestTime": 3439.6860000000015,
+              "transferSize": 62137,
+              "entity": "unsplash.com",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Image"
+            },
+            {
+              "networkEndTime": 3484.4530000000086,
+              "networkRequestTime": 3440.8559999999998,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Image",
+              "protocol": "h2",
+              "transferSize": 159091,
+              "entity": "unsplash.com",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/jpeg",
+              "priority": "Low",
+              "resourceSize": 158506,
+              "url": "https://images.unsplash.com/photo-1612385763901-68857dd4c43c?w=1200&h=800&fit=crop",
+              "rendererStartTime": 3439.1080000000075
+            },
+            {
+              "networkEndTime": 3497.3179999999993,
+              "networkRequestTime": 3441.8129999999946,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Image",
+              "protocol": "h2",
+              "transferSize": 179761,
+              "entity": "unsplash.com",
+              "experimentalFromMainFrame": true,
+              "mimeType": "image/jpeg",
+              "priority": "Low",
+              "resourceSize": 179176,
+              "url": "https://images.unsplash.com/photo-1566140967404-b8b3932483f5?w=1200&h=800&fit=crop",
+              "rendererStartTime": 3439.275999999998
+            },
+            {
+              "rendererStartTime": 4056.080999999991,
+              "resourceSize": 0,
+              "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65e0h2v9100339653za200zd9100339653&_p=1778837333019&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1024313207.1778837334&frm=0&pscdl=noapi&rcb=16&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616986~115938465~115938468&dp=%2Fblog&sid=1778837333&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fblog&dt=Ocobo%20%C2%B7%20Le%20blog%20des%20Revenue%20Operations&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=4055",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/plain",
+              "transferSize": 796,
+              "entity": "Google Analytics",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Fetch",
+              "statusCode": 204,
+              "sessionTargetType": "page",
+              "networkRequestTime": 4074.3949999999895,
+              "networkEndTime": 4100.0749999999971
+            },
+            {
+              "transferSize": 29959,
+              "entity": "Hubspot",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 4074.05799999999,
+              "networkEndTime": 4166.426999999996,
+              "rendererStartTime": 4068.3760000000038,
+              "resourceSize": 97992,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "rendererStartTime": 4069.0379999999859,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "resourceSize": 78203,
+              "priority": "Low",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "entity": "Hubspot",
+              "transferSize": 28210,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 4074.4989999999962,
+              "networkEndTime": 4156.0409999999974
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "resourceSize": 109001,
+              "rendererStartTime": 4069.5510000000068,
+              "mimeType": "text/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "entity": "Hubspot",
+              "transferSize": 43657,
+              "sessionTargetType": "page",
+              "networkRequestTime": 4074.6359999999986,
+              "networkEndTime": 4132.3169999999955,
+              "statusCode": 200
+            },
+            {
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 4248.3859999999986,
+              "networkRequestTime": 4074.7399999999907,
+              "transferSize": 27218,
+              "entity": "Hubspot",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/javascript",
+              "rendererStartTime": 4070.6059999999998,
+              "resourceSize": 72678,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+            },
+            {
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "resourceSize": 4371,
+              "rendererStartTime": 4105.6560000000027,
+              "mimeType": "text/css",
+              "experimentalFromMainFrame": true,
+              "priority": "VeryHigh",
+              "protocol": "h2",
+              "resourceType": "Stylesheet",
+              "finished": true,
+              "entity": "GitHub",
+              "transferSize": 2019,
+              "sessionTargetType": "page",
+              "networkRequestTime": 4107.4529999999941,
+              "networkEndTime": 4279.6169999999984,
+              "statusCode": 200
+            },
+            {
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "resourceSize": 16667,
+              "rendererStartTime": 4107.8579999999929,
+              "mimeType": "image/png",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "resourceType": "Image",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 17170,
+              "networkRequestTime": 4109.1260000000038,
+              "networkEndTime": 4284.6180000000022,
+              "sessionTargetType": "page",
+              "statusCode": 200
+            },
+            {
+              "sessionTargetType": "page",
+              "networkRequestTime": 4490.8080000000045,
+              "networkEndTime": 4760.7150000000111,
+              "statusCode": 404,
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "transferSize": 640,
+              "entity": "Clearbit",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "priority": "Low",
+              "resourceSize": 0,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "rendererStartTime": 4489.4189999999944
+            },
+            {
+              "rendererStartTime": 4491.4320000000007,
+              "url": "https://www.ocobo.co/_vercel/insights/script.js",
+              "resourceSize": 2495,
+              "priority": "Low",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "transferSize": 1868,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "statusCode": 200,
+              "networkEndTime": 4519.1119999999937,
+              "networkRequestTime": 4493.2649999999994,
+              "sessionTargetType": "page"
+            },
+            {
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 4493.127999999997,
+              "resourceSize": 12567,
+              "url": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "statusCode": 200,
+              "networkRequestTime": 4494.2520000000077,
+              "networkEndTime": 4516.8120000000054,
+              "sessionTargetType": "page",
+              "transferSize": 5314,
+              "entity": "ocobo.co",
+              "finished": true,
+              "resourceType": "Script",
+              "protocol": "h2"
+            },
+            {
+              "networkRequestTime": 4498.6269999999931,
+              "networkEndTime": 4744.333999999988,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "resourceType": "Fetch",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 2482,
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fblog%2Fagence-conseil-revenue-operations-business-partner%2C%2Fblog%2Fbusiness-ops-revenue-ops-definition%2C%2Fblog%2Fcomment-orchestrer-ses-talents-revops%2C%2Fblog%2Fcomment-partoo-repense-ae-kam%2C%2Fblog%2Fcomprendre-et-structurer-une-equipe-RevOps-modeles-stades-de-maturite%2C%2Fblog%2Fconception-plan-compensation-contenu%2C%2Fblog%2Fconception-plan-compensation-contours%2C%2Fblog%2Fconseils-astuces-maitriser-croissance-entreprise%2C%2Fblog%2Fconseils-optimiser-customer-journey-choisir-customer-success-platform%2C%2Fblog%2Fcontrole-depenses-logiciels-saas%2C%2Fblog%2Fcroissance-alan-culture-entreprise%2C%2Fblog%2Fcroissance-spendesk-co-fondateur-rodolphe-ardant%2C%2Fblog%2Fdeployer-business-model-internationa-cas-the-fork%2C%2Fblog%2Fetapes-choisir-nouvel-outil%2C%2Fblog%2Fexperience-utilisateur-revops-croissance-alan%2C%2Fblog%2Fia-vente-humain-commercial-IA%2C%2Fblog%2Flancer-business-unit-saas-performante%2C%2Fblog%2Flivestorm-les-grandes-etapes%2C%2Fblog%2Flivestorm-strategie-sales-led-self-service%2C%2Fblog%2Fmarketing-ops-maillon-indispensable-scaler%2C%2Fblog%2Fnet-retention-rate%2C%2Fblog%2Fparcours-carriere-revops-attirer-fideliser-faire-evoluer-talents%2C%2Fblog%2Fpartoo-evolution-organisationnelle%2C%2Fblog%2Fplans-compensation-ne-fonctionnent-pas%2C%2Fblog%2Fprincipes-plan-compensation-reussi%2C%2Fblog%2Fremuneration-variable-commerciale-qobra%2C%2Fblog%2Frepenser-la-remuneration-variable-pour-booster-la-performance%2C%2Fblog%2Freussir-implementation-hubspot%2C%2Fblog%2Frole-business-operations-engineer%2C%2Fblog%2Frole-business-ops-manager%2C%2Fblog%2Frole-cro-startup-hypercroissance%2C%2Fblog%2Froles-cles-en-revops%2C%2Fblog%2Fsales-marketing-comment-collaborer-efficacement%2C%2Fblog%2Fse-faire-un-nom-marche-concurrentiel-sellsy%2C%2Fblog%2Fstructurer-equipe-marketing-profils%2C%2Fblog%2Fstructurer-equipe-revenue-spendesk%2C%2Fblog%2Fstructurer-equipe-revops-90-jours%2C%2Fblog%2Fstructurer-equipes-vente-complexe%2C%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe%2C%2Fblog%2Ftarget-setting-guide%2C%2Fblog%2Fthe-most-comprehensive-report-on-sales-compensation-structures-in-europe%2C%2Fblog%2Ftransversalite-data-passer-a-lechelle%2C%2Fblog%2Fvirage-strategique-diffusely-tech-company%2C%2Fclients%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology&version=ba6d9b28",
+              "resourceSize": 16621,
+              "rendererStartTime": 4497.002999999997
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 4576.106,
+              "networkRequestTime": 4520.4619999999995,
+              "statusCode": 200,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "finished": true,
+              "entity": "Hubspot",
+              "transferSize": 204723,
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "resourceSize": 607831,
+              "rendererStartTime": 4518.3229999999894
+            },
+            {
+              "statusCode": 202,
+              "sessionTargetType": "page",
+              "networkEndTime": 4648.1979999999894,
+              "networkRequestTime": 4581.794000000009,
+              "transferSize": 473,
+              "entity": "ocobo.co",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Fetch",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "rendererStartTime": 4580.400999999998,
+              "resourceSize": 48,
+              "url": "https://www.ocobo.co/_vercel/insights/view"
+            },
+            {
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fblog%2Fagence-conseil-revenue-operations-business-partner%2C%2Fblog%2Fbusiness-ops-revenue-ops-definition%2C%2Fblog%2Fcomment-orchestrer-ses-talents-revops%2C%2Fblog%2Fcomment-partoo-repense-ae-kam%2C%2Fblog%2Fcomprendre-et-structurer-une-equipe-RevOps-modeles-stades-de-maturite%2C%2Fblog%2Fconception-plan-compensation-contenu%2C%2Fblog%2Fconception-plan-compensation-contours%2C%2Fblog%2Fconseils-astuces-maitriser-croissance-entreprise%2C%2Fblog%2Fconseils-optimiser-customer-journey-choisir-customer-success-platform%2C%2Fblog%2Fcontrole-depenses-logiciels-saas%2C%2Fblog%2Fcroissance-alan-culture-entreprise%2C%2Fblog%2Fcroissance-spendesk-co-fondateur-rodolphe-ardant%2C%2Fblog%2Fdeployer-business-model-internationa-cas-the-fork%2C%2Fblog%2Fetapes-choisir-nouvel-outil%2C%2Fblog%2Fexperience-utilisateur-revops-croissance-alan%2C%2Fblog%2Fia-vente-humain-commercial-IA%2C%2Fblog%2Flancer-business-unit-saas-performante%2C%2Fblog%2Flivestorm-les-grandes-etapes%2C%2Fblog%2Flivestorm-strategie-sales-led-self-service%2C%2Fblog%2Fmarketing-ops-maillon-indispensable-scaler%2C%2Fblog%2Fnet-retention-rate%2C%2Fblog%2Fparcours-carriere-revops-attirer-fideliser-faire-evoluer-talents%2C%2Fblog%2Fpartoo-evolution-organisationnelle%2C%2Fblog%2Fplans-compensation-ne-fonctionnent-pas%2C%2Fblog%2Fprincipes-plan-compensation-reussi%2C%2Fblog%2Fremuneration-variable-commerciale-qobra%2C%2Fblog%2Frepenser-la-remuneration-variable-pour-booster-la-performance%2C%2Fblog%2Freussir-implementation-hubspot%2C%2Fblog%2Frole-business-operations-engineer%2C%2Fblog%2Frole-business-ops-manager%2C%2Fblog%2Frole-cro-startup-hypercroissance%2C%2Fblog%2Froles-cles-en-revops%2C%2Fblog%2Fsales-marketing-comment-collaborer-efficacement%2C%2Fblog%2Fse-faire-un-nom-marche-concurrentiel-sellsy%2C%2Fblog%2Fstructurer-equipe-marketing-profils%2C%2Fblog%2Fstructurer-equipe-revenue-spendesk%2C%2Fblog%2Fstructurer-equipe-revops-90-jours%2C%2Fblog%2Fstructurer-equipes-vente-complexe%2C%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe%2C%2Fblog%2Ftarget-setting-guide%2C%2Fblog%2Fthe-most-comprehensive-report-on-sales-compensation-structures-in-europe%2C%2Fblog%2Ftransversalite-data-passer-a-lechelle%2C%2Fblog%2Fvirage-strategique-diffusely-tech-company%2C%2Fclients%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology&version=ba6d9b28",
+              "resourceSize": 16621,
+              "rendererStartTime": 4631.3409999999858,
+              "networkRequestTime": 4634.025999999998,
+              "networkEndTime": 4865.7379999999976,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "resourceType": "Fetch",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "ocobo.co",
+              "transferSize": 2482
+            },
+            {
+              "transferSize": 1095,
+              "entity": "Hubspot",
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "XHR",
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 4838.9799999999959,
+              "networkRequestTime": 4772.3869999999879,
+              "rendererStartTime": 4771.2559999999939,
+              "resourceSize": 135,
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "mimeType": "text/plain",
+              "priority": "High",
+              "resourceSize": 5,
+              "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+              "rendererStartTime": 5436.3919999999925,
+              "sessionTargetType": "page",
+              "networkRequestTime": 5438.2989999999991,
+              "networkEndTime": 5461.8929999999964,
+              "statusCode": 200,
+              "finished": true,
+              "protocol": "h2",
+              "resourceType": "Fetch",
+              "transferSize": 558,
+              "entity": "Hubspot"
+            },
+            {
+              "protocol": "http/1.1",
+              "resourceType": "XHR",
+              "finished": true,
+              "entity": "Hubspot",
+              "transferSize": 4082,
+              "sessionTargetType": "page",
+              "networkRequestTime": 5733.2399999999907,
+              "networkEndTime": 5876.7060000000056,
+              "statusCode": 200,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953",
+              "resourceSize": 9346,
+              "rendererStartTime": 5732.0100000000093,
+              "mimeType": "application/json",
+              "experimentalFromMainFrame": true,
+              "priority": "High"
+            },
+            {
+              "transferSize": 1710,
+              "entity": "Hubspot",
+              "finished": true,
+              "resourceType": "Fetch",
+              "protocol": "h2",
+              "statusCode": 200,
+              "networkRequestTime": 5740.4229999999952,
+              "networkEndTime": 5824.4469999999856,
+              "sessionTargetType": "page",
+              "rendererStartTime": 5739.2509999999893,
+              "resourceSize": 61,
+              "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fblog&isMobile=true",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json"
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 5866.997000000003,
+              "networkRequestTime": 5775.1929999999993,
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "transferSize": 1474,
+              "resourceType": "Image",
+              "protocol": "h2",
+              "finished": true,
+              "priority": "Low",
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 5774.0210000000079,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog&t=Ocobo+%C2%B7+Le+blog+des+Revenue+Operations&cts=1778837335448&vi=95a8156d5c77c5165ba180d5febfdaee&nc=true&u=242475741.95a8156d5c77c5165ba180d5febfdaee.1778837335442.1778837335442.1778837335442.1&b=242475741.1.1778837335442&cc=15",
+              "resourceSize": 45
+            },
+            {
+              "rendererStartTime": 5828.0350000000035,
+              "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+              "resourceSize": 35,
+              "priority": "Low",
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "entity": "Hubspot",
+              "transferSize": 1021,
+              "resourceType": "Image",
+              "protocol": "http/1.1",
+              "finished": true,
+              "statusCode": 200,
+              "networkRequestTime": 5828.8539999999921,
+              "networkEndTime": 5929.0979999999981,
+              "sessionTargetType": "page"
+            },
+            {
+              "networkRequestTime": 5891.4700000000012,
+              "networkEndTime": 5892.0950000000012,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "Hubspot",
+              "transferSize": 204723,
+              "mimeType": "application/javascript",
+              "priority": "Low",
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "resourceSize": 607831,
+              "rendererStartTime": 5891.4700000000012
+            },
+            {
+              "protocol": "http/1.1",
+              "resourceType": "Image",
+              "finished": true,
+              "entity": "Hubspot",
+              "transferSize": 1022,
+              "sessionTargetType": "page",
+              "networkEndTime": 6133.78899999999,
+              "networkRequestTime": 6045.93299999999,
+              "statusCode": 200,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+              "resourceSize": 35,
+              "rendererStartTime": 6042.6460000000079,
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "priority": "Low"
+            },
+            {
+              "priority": "VeryHigh",
+              "mimeType": "text/css",
+              "rendererStartTime": 6052.322,
+              "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+              "resourceSize": 3792,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkRequestTime": 6059.1500000000087,
+              "networkEndTime": 6068.0109999999986,
+              "entity": "Google Fonts",
+              "transferSize": 1259,
+              "protocol": "h2",
+              "resourceType": "Stylesheet",
+              "finished": true
+            },
+            {
+              "networkRequestTime": 6095.8239999999932,
+              "networkEndTime": 6100.3429999999935,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "finished": true,
+              "resourceType": "Font",
+              "protocol": "h2",
+              "transferSize": 51336,
+              "entity": "Google Fonts",
+              "mimeType": "font/woff2",
+              "priority": "VeryHigh",
+              "resourceSize": 50524,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "rendererStartTime": 6094.8530000000028
+            },
+            {
+              "statusCode": 200,
+              "networkRequestTime": 6102.0599999999977,
+              "networkEndTime": 6106.7069999999949,
+              "sessionTargetType": "page",
+              "transferSize": 51335,
+              "entity": "Google Fonts",
+              "finished": true,
+              "resourceType": "Font",
+              "protocol": "h2",
+              "priority": "VeryHigh",
+              "mimeType": "font/woff2",
+              "rendererStartTime": 6101.1199999999953,
+              "resourceSize": 50524,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "sessionTargetType": "page",
+              "networkRequestTime": 6139.55799999999,
+              "networkEndTime": 6311.1879999999946,
+              "statusCode": 200,
+              "protocol": "h2",
+              "resourceType": "Image",
+              "finished": true,
+              "entity": "Hubspot",
+              "transferSize": 1066,
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=fcc77d25-95de-4d4f-ae82-37b6b3f8bf1d&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog&t=Ocobo+%C2%B7+Le+blog+des+Revenue+Operations&cts=1778837335804&vi=95a8156d5c77c5165ba180d5febfdaee&nc=true&u=242475741.95a8156d5c77c5165ba180d5febfdaee.1778837335442.1778837335442.1778837335442.1&b=242475741.1.1778837335442&cc=15",
+              "resourceSize": 45,
+              "rendererStartTime": 6138.42300000001
+            },
+            {
+              "priority": "Low",
+              "mimeType": "image/gif",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 6138.9349999999977,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+              "resourceSize": 35,
+              "statusCode": 200,
+              "sessionTargetType": "page",
+              "networkEndTime": 6241.591,
+              "networkRequestTime": 6139.679999999993,
+              "entity": "Hubspot",
+              "transferSize": 1024,
+              "protocol": "http/1.1",
+              "resourceType": "Image",
+              "finished": true
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "label": "URL",
+              "valueType": "url"
+            },
+            {
+              "valueType": "text",
+              "label": "Protocol",
+              "key": "protocol"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "label": "Network Request Time",
+              "key": "networkRequestTime"
+            },
+            {
+              "label": "Network End Time",
+              "key": "networkEndTime",
+              "granularity": 1,
+              "valueType": "ms"
+            },
+            {
+              "key": "transferSize",
+              "displayUnit": "kb",
+              "valueType": "bytes",
+              "label": "Transfer Size",
+              "granularity": 1
+            },
+            {
+              "displayUnit": "kb",
+              "valueType": "bytes",
+              "key": "resourceSize",
+              "granularity": 1,
+              "label": "Resource Size"
+            },
+            {
+              "key": "statusCode",
+              "label": "Status Code",
+              "valueType": "text"
+            },
+            {
+              "label": "MIME Type",
+              "key": "mimeType",
+              "valueType": "text"
+            },
+            {
+              "label": "Resource Type",
+              "key": "resourceType",
+              "valueType": "text"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "type": "debugdata",
+            "initiators": [
+              {
+                "lineNumber": 0,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1354,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 668
+              },
+              {
+                "columnNumber": 16793,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 21,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 30261
+              },
+              {
+                "lineNumber": 23,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1609,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 23,
+                "columnNumber": 5225,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 50,
+                "columnNumber": 14492,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "lineNumber": 60,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 13575,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 75,
+                "columnNumber": 141,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 261,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 360,
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 460,
+                "lineNumber": 75
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 536,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 602,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 671,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "type": "parser",
+                "columnNumber": 731,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "type": "parser",
+                "columnNumber": 795,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "type": "parser",
+                "columnNumber": 857,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "type": "parser",
+                "columnNumber": 916,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "type": "parser",
+                "columnNumber": 985,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1052,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 1119,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 75,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1176
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 1238,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1297,
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 75,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1361
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 1427,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 1488,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 75,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1556,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1622,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 75,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1693,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 1751,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 75,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 1811,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1886,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1947,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2005,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 2069,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 2129,
+                "lineNumber": 75
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 2188,
+                "lineNumber": 75
+              },
+              {
+                "columnNumber": 2250,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2311,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "type": "parser",
+                "lineNumber": 75,
+                "columnNumber": 2374,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "columnNumber": 2430,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2498,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75
+              },
+              {
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 2565,
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 75,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 2626,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 75,
+                "columnNumber": 2698,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 2757,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2827,
+                "url": "https://www.ocobo.co/blog",
+                "lineNumber": 75,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 75,
+                "columnNumber": 2888,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 2954,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 75,
+                "columnNumber": 3018,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 75,
+                "url": "https://www.ocobo.co/blog",
+                "columnNumber": 3081,
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 60,
+                "columnNumber": 10329,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 60,
+                "columnNumber": 10329,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 60,
+                "columnNumber": 10329,
+                "url": "https://www.ocobo.co/blog"
+              },
+              {
+                "lineNumber": 60,
+                "columnNumber": 10329,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 60,
+                "columnNumber": 10329,
+                "url": "https://www.ocobo.co/blog",
+                "type": "parser"
+              },
+              {
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                "type": "parser"
+              },
+              {
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                "type": "parser"
+              }
+            ],
+            "networkStartTimeTs": 75294724
+          }
+        }
+      },
+      "network-server-latency": {
+        "id": "network-server-latency",
+        "title": "Server Backend Latencies",
+        "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "30 ms",
+        "details": {
+          "sortedBy": [
+            "serverResponseTime"
+          ],
+          "items": [
+            {
+              "serverResponseTime": 25.5,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "serverResponseTime": 7,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "serverResponseTime": 6,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "origin": "https://images.unsplash.com",
+              "serverResponseTime": 2
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://useago.github.io"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "origin": "https://js-eu1.hs-banner.com",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "origin": "https://forms-eu1.hsforms.com",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://fonts.googleapis.com"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "label": "URL",
+              "key": "origin"
+            },
+            {
+              "label": "Time Spent",
+              "key": "serverResponseTime",
+              "granularity": 1,
+              "valueType": "ms"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 25.5,
+        "numericUnit": "millisecond"
+      },
+      "final-screenshot": {
+        "id": "final-screenshot",
+        "title": "Final Screenshot",
+        "description": "The last screenshot captured of the pageload.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "timestamp": 81544385,
+          "timing": 6250,
+          "type": "screenshot",
+          "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAMEBQYHCAIBCf/EAFUQAAEDAwIDAwgECgcEBQ0AAAEAAgMEBREGEhMhMQdBURQiUmFxgZGhCBUjMhY3VXJzlLGzwdEkMzRCYnXTGDaSshcnU3TjJlRWZoKDk5WipcLh8P/EABkBAQEBAQEBAAAAAAAAAAAAAAABAgMEBf/EAC0RAQABAwIDBgUFAAAAAAAAAAABAgMREjEEIUEFEzNRcaEUIjTR8DJCYZHB/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEXxzg1pc4gNAySegWPRa40rNcPIYtRWl9XnaIm1TCSfDr19SDIkQkAZJ5eKx0640s2v8iOorSKvO3heVs3Z8OvX1IMiRAQQCDkHvVqvOobXZXsbdaryRj8YmljcIh7ZMbR7yguqLAu2uq/6pL/U0c/I07XMlif1Bc3mCFdjq/T1mpKCmu98t1HVOhj+znqGtdzaOZBPJBk6KOmqIaqBk9NLHNDINzJI3BzXDxBHVWW76x03Z6sUt1vtspKnOOFNUsa4e0E8vegvyKKkqYKynZUUk0c8EgyySNwc1w8QR1UqAiIgIiICIiAiIgIiICIvj3bWkoBcG9SAvgkYejgrXcrjSW+A1FxqoaaHIbxJnhjcnoMlUFHqWx1tSyno7xb56iQ4ZHHUMc53sAKDJUUFO8nzT7lOgIiICIiDW/bhPM+z2O0NmfT0l4usFDVyMO08FxJc3PdnGFkdXoXTFRYXWh9loG0OwsDWwtBbyxuDsZDvX1VZq7TtDqqxT2u5tdwZMOa9hw+J45te09xBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHfjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fW0bcrbjNA6VbY/qkWK3+RbNmDC3d0xnd13evOV7m0TZJdEjSppiLS2IRNaD5zSDkPB9Ldzz4rGm6J1oyk+rm6/l+rQ3hhxt7DU7OmOLnrjvxlBZu0GqqdCdihp9O3iarMcraNlc54c+GNzyCNw72jzQeoWxdP6ctlv04y3RxCop5oQ2d8x4jqjI5ueT94nKjt2jbJRaPbpkUjZrTwzG+ObzjJk5LnH0ieefFUrtPXS2WUWfTFe2mptnDZUVr3VElO3phjeWcd25xwg0rTzy0/ZF2oWBsr5rdZq59PRvcc7Y+IPMz6sfNbn0TpSzUek6SM0tNXOq6dklTUzMEjqpzmglzieoOeQ7greOzOgp+zWu0lQVMkfloLp6yRu98khcCXuHLOcYSPR2o7TSeQaX1THRW0N2xw1VCKh1OO8Ru3Dl4B2cIMU0/VzaQ/6UbVZCXUFni8soYvvCB74nPcweoEZwsp7LNJWOHQ1tqX0dLXVVxp21NXVTxtkfO+QbnZJHMZPRXrRejqPTNnqqQyyV9TXSOmrqqoAL6l7upd6scgFjtFoLUOn2SUWkNW+Q2cuc6Kkq6JtSafJyQxxIOPAHKCDs+hjsHafqzTdrGyzMhgro4Actp5H5Dmt8AeuFtBYzojSMGl4ayR9XPcLpXScasrp/vzO7hgcg0DkAOiyZAREQEREBERAREQEREBeJxmIr2h5oMd1GKk20+RCuM24f2Lg8TH/AL3zcfNWKytu/wBaQeVDUXByd3lQoeH0P3uH5/wWbPhIPm8wvIieT91B9gH2gVUvEUYYPWvaAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiLHa6suDNQCGJ7m0oLMgx5GDjPPCxXXFERMutq1N2ZiJ2jLIkWP22qrai4VsMs0jQ0vEQMYAAzyOcfxVPQV12lpqyR4cXwxgNaYwNzs9enPksd/HlPX2dPhaufOOWPdlCLGbbX3OWgr3y7y6OLdG4x4O7HMAY5pHVXdllknnf9q5zeGdgJDT1yAP4KRfiYziVnhaomY1RvEf2yZFaKGpq5LBJPKX+Uhjy0lgByM45Kkpq+ukbacmTMjntnzHjOMY7uS130cuW7EcPVMzGY5faZ/xkSLGKK4XJ94qIZTJwGmTZmIY5Zxzwo6C5XP6urJahz3SBg4Q4WCCTjPTCzHEU+U9fZ0nhKojeOnv+c2VosYNwuQskziZPLIpQ3dwxkj2YwlTV3VlngqGSl04e5kgEfXwOMdyfER5TtlPhKttUb4/P4ZOiipWyMpo2zv4kob5zsAZPuUq7w808hEREEREBERAREQEREBERAREQEREBERARFFJUwRuLZJo2OHc5wBQSooPLKb/ziH/jCma4OaHNILTzBB6oPqIiAiLDu0TtFsugRQG+tq3eW8TheTxh/wBzbnOSMfeCDMUWLdn2ubTry3VNbY21TYaeXgv8ojDDuwDywTywVlKAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC4s+kz+N66foYP3TV2muLPpM/jeun6GD901Bidp0HqW70dPVW62OnhqP6otmjBdzxyBdnqt1xds1z7N7bbNL3rR7hV0NHCzc6v27xsGDjhn1jqeYK1ZpHWWlrBHbJ5tDtrbvRPbMK43WaPfI125ruGAWjGBy6clmX0l7/bL9DpGpiphFeJ7eyrn2v3cOOVrXMjJxzIO455fNEbA1h9IWjsdTb47fZfrFtTRRVb3eWcPhGQZ2EbHZIGOfrVBePpE1dofSx12jxHJUU7KlrTceYY/m3P2XeMH3rm2jY233igfeKWR9KHRTSRHkZITh3I+tvRbA+kZVUtb2iiqt7mPo5qCmkhcwYBYWZGPcg2zWfSStlPRWuSOyyT1FRG6SqijqRimO4gN3FvnEgZ7sZCwX6Q+tLVrnT+kbnZ3PDWvq45YZRh8T8QnB/mFgVHfNP0mgZ7VWaWbLfJyXw3R0xaQ0u5ED1YIwOR71jU1FUx2alrZA4Uk08scZPQuY1hdj/iag3/8AR51datF9mN+ul7mcyEXEMjjYMvlfwm4a0ePL2Kvd9J2k8r2t0xOaXP3zWAPx47dmM+9aKkpap/ZrT1MYcaOK7Sslx0D3Qx7M+5r1dYr3owdlr7XJYpzq0yEivyNuN+Qc7s/d83bj1oOjtQduFppNA0up7JROuLZKxtFLSyTcCSBxY9/nea70e7kc9eSxJn0l4JLRWznT4hro3Rtp4DWF4l3btxJ2DAaGjxyXBaIpaWqb2b3KqLXCifdaWNpI5OeIagnHsBHxC2n9FbT1nv8AV6kbe7ZSV4hZTmMVEQfsyZM4z0zgfBBsibt6tFBoq03a50UhulwY97KCnfu2ta9zdznHGAS3wJ+Cxyg+k5RPqWtrtNVEMBPN8VWJHAfmlrf2rW30krIyydovBpKSOktr6SJ1LHEzawN5hwAHL724+/1qx3S66NnobWwWysfLEz7cUrGUmDgci5xlMnPvO3+CDpHtC7a6HTNo09dLTbheKK8MlfG/yjg7OGWAgjY7nlxBHLGFhH+1Af8A0SH/AMx/8JY5eafQUvZZYai5uvlvMb6mSgt7J45Jpw8sDnklmGs3R8jgd/Vay0hW6coL2avUVtrbhRRndFSRzNaHc+QkdjmPUAM/JB3D2d6m/DHRtuvxpPI/LA88DicTZte5n3sDOduenesjVm0bXUtz0naK630jaOkqaWOWKnaABE1zQQ3ly5K8ooiIgIiICIiAiIgIiICIiAiIgLXusOyHSurb9Nd7xFVurJmta4xzljcNAA5ewLYSINR/7Pmhf+wuH60f5KoruwjRldOJaplykkEbIgTVHk1jQ1o6dzWge5bURBrrUfY3pDUFRSTV1LUtdTU0dJGIZiwcNgw3Picd65h7d9P0el9eG0Wx05o6eliEYmk3uaCCcZ8Oa7jVDWWa2VsxmrLdRVExGC+WBr3Y9pCDSnZT2c6b1p2W6Xq9QUb5pqZs7GuZI6Pc0zOOHY5kZz8Ss/1N2VaV1FbLVb6uifBRWwPFNFSycMN37d2fH7o5+1ZrS00FJA2Glhighb92ONga0ewBSoMN032a6Z0/p+uslNRGottbJxJ4ap3FDjgDv6dAscPYHoI1PF+r6oNznhCrft9nXPzW1UQYdqDs301e9MUmn56I01qpZhPFDSu4eHhrm5J7+Tj1X3QPZ3YdCSVr7BHUMdWBgl40pfnbnGPD7xWYIgsWrtI2PV9A2k1BQR1cbDljiS18Z8WuGCP4rCqDsH0HSVTZzbZ6jadwZPUvcz3jIz7CtpIgwTWXZTpfV1TRzXWmmYaSAU0LKaThMZGCSAAB61j3+z5oX/sLh+tH+S24iCisdrprLZ6K2UIcKWkhbBEHnJDWjAye9VqIgIiICIiAiIgIiICIiAiIgIiIC0P2r9t100VrarslJaaKphgZG4SSvcHHcwO7vat8Liz6TP43rp+hg/dNQdY9nl/m1Tou1XqphjgmrIjI6OMktb5xHLPsWRLk2XtfuOj+zvSti04yAVvkXFqKiVu/h7nu2ta3pnHPJz1CoK/t41sNO0cBk8kuYlLzW+TR4qIiOQ2ubgEHvb1HzDsFFpb6NmuNQa0g1A7UlcKt1K6AQ4hjj27hJn7jRn7o6qH6Q/ajd9FVdBadPtjhqqmAzvqpIw/a3cWgNB5Z5HOQe5Bu9Fxfa+1ftRnY+to66srKaN2JHCgZJGD1wSGcuqznVXbrfaLQ2n3UsVLFf7jFJNPNw/Nia2RzBtYSeZ2nrkDHRB0utcdtWvrnoO1UVRabMbg6pe5rpnhxjhxjG7bzycnHMdCucm9sHaXRNhrqi5VBppTljp6KMRSeoHYPkVm+q+2vUFZ2b2S8WaaK3XF9ZLSVrWQskY8tY1wIDwcAhwKDZ3Yj2h3bXtLcX3ezii8lLAyeMOEcuc5A3d4wO89Vs9c09nvbReabQupr1qadtynpJqeCihEUcIL5BIcHY0cvNyfYsKn7de0OtnlqaSphhp2c3Rw0THMYPWXAn5oOy0XMND28Xu6dn2oA7gUeo6GOGanqoYwWSMM0bH5Y7IBw/wBnPuwrPobtl7QrhXXCFpde5xRSPhgbTxMEbgW/auLWgkNG7lnmSEHWyLkns47eNR02oqaHVNYyutUpLZC6FjXx8uRaWgd+ORyrfd+2/XuoLvI2wSupISSYqSkpmyvDfWS0knx6D1IOxkXK/Zd246l/CygtGq3x1lLVTtpnPdC2OWFzjtB80AEZxkEZUeu/pAaiqr7UUekWw0dHHKY4pOCJZZsHGcOyAD3DHvQdWIuTtH/SA1Pbr1BT6tZFWUTnhkxMAhmjB/vDbgcuuCOfqXWDHNexr2HLXDIPiEH1ERAREQEREBERAREQEREBcWfSZ/G9dP0MH7pq7TVurbDaK6odPW2qgqZ3YBkmp2PccdOZGUHDWsdN19HYNOXwwSPt1dQsAmDSWskaXNLCe44APrz6lPrTVWq9W6atdRfmtdaqSQ09PM2BsYfJt58x1IAGccgu52UFIyiFGylgbSAbRAIwGAeG3oqeayWqelipp7ZQyU0RJjifAwsYT1wCMBEaB+hz/ZdV/n037JV9+k1qE27U1uoblYaK62d9G2Rrp2PY9ku94cGSsIIOAzI5jpyXQNutdvtgkFuoaWkEmN/AhbHux0zgc+pVRPDFURmOeJksZ6te0OB9xRX5+SX99JdxU6RbX2RpAAiirXSOLvzgGkjpyOVm/azZ9U3HTeltUX+jnMklCaaok4W0sLZXljngfdLmuByuvqWw2iknE1JaqCCYdJIqdjXfEBXFzQ5pa4AtPIg96JhwjUdqOq6iwWyy+XRijoA1sAbTs3Ya3a0Ekc8Dksk7R3ajm7JdNVWrHP8AKai4TPp2PhbE5sPDaBkNA6kE8+eCF13BY7TT1HHp7XQxT5zxGU7Gu+IGVLcLZQ3JjGXGipqtrDlonibIGn1ZHJBxZojTVfqbsr1XHaoX1FTRVtJV8Fgy57QyZpAHecOzj1LHtP6tq7BZrha2UcUoqHHPHklAjOMH7MPDHHl/eaf4LvS3WugtokFuoaWkEmN4gibHux0zgc+pUVRZLVU1HHqbZQzT9eJJTsc74kZQceUMl8uXZVqmvqrTbaW0RwwRsqorfHBJLIamLk1zQMgAHPd0VT9GX/fe7/5NUf8ANGuw6mipaqkNLVU0E1MQAYZIw5hwcjzTy5YCpaKx2mhldJQ2uhppHNLC6GnYwlp6gkDp6kH59aetr7xf7bbYSBJWVMdO0nuL3Bo/ar3p6+aj7NNT1EtLGaG6MY6nliqYQctJBIwfW0HI8F3NBpuxwTRzQWa2xyxuDmPZSsDmkdCCByKqq+2UFwDRX0VLVBvTjRNfj4hByJ2Vak1xqjtApWUVW6SOeqE9dIKaPYyPdl5J28sjIHyWG3S3XXs410W11JIJqSVxj3PkjbPGcgOa9ha7BB6g+o94XeVJSU9HEIqSnigjH9yJgaPgF5rqCkr4xHXUsFTGOYbNGHj4FBxTprUGoNT6xbHZbFaKmpqpG+ZLQNqRGOQ3Okk3PwOpLnLtyFpZExrsZDQDtGB7lBQ0FHQRllDSU9Mw9Wwxhg+ACqUUREQEREBERAREQEREBERAREcQ0EuIAHUlARag+kte6u3dnMFXYrnPSzfWMcZmo5yx2NkhLS5p9Q5LB/ovaqulxv17GoL7W1UDKZhYK2rc9rXF/duOAcIOl0VPFX0krXuiqoHtjG55bICGjxPgvkNwop5BHDV08kjujWSNJPuygqUUVRUQUzA6omjiaTgGRwaCfeqd92t0dPJO+vpGwR43yGZoa3PTJzgIK1FDBVU9RTNqKeeKWncNzZWPDmkeII5L5DW0s79kNTDI7wZICfkgnRU89dSU8myoqoIn4ztfIGn4FfTW0racTmphEBOBIXjaT7eiCdFBT1lNUlwpqiGYt5kRvDsfBfDXUjZeG6qgEnTYZBn4IKhFHUVENOwPqJo4mE4DnuDRn3qJlwo5I5Hsq6dzI27nuEgIaPE8+QQVKKlhuNDPTGohrKaSnb1lbK0tHvzheoK+kqH7IKqCV+M7WSBxx7kFQipGXOge9rGVtK57jgAStJJ8Oqq0BERAREQEREBERAREQEREBcq/Sn1jcpNVN01TVEsFupoWSSxscW8aRwz52OoAxgeOV1UtHdvvZFW6xuEN8046E3JsYhnp5XbBK0Z2uDum4Zxz7seCDQ180jqjT/ZtQ3OsqYPwfu80U7Kdk25wfscWOLcYBLSeh9qxek/3buX/AHmn/wCWVbMl7F+0OfTOKqGaR1NOI6a2mrY4BhBLpBl+1ozgYHM5PgqrTPYhq6psV+pLnbm0NQ5kUtIZZ43NkkY45adrjjLXO5nvwiKHsR/3P7Tv8jf/AMsitP0d/wAcmnfzp/3EiyjSHZD2i0NHqGAMNsp6mhkifE2WKQ1pwS2IcztBPVxI5Equ7F+y3WWnu0yy3S8WV1NQU5lMspqInbcwvaOTXk9SB0QZt9Lv/cK0/wCZt/dSLSPZToO9a/ob1QWi401JSwPp5ahk+7EjvtAw8genn/FdFfSP0petXaQt1Fp2iNZUxVzZnsEjGYZw3jOXEDqQrN9GfRGodHP1EdSW51EKoU/BzLG/ft4m77rjjG4dfFBpTtVrL3psUGg57gfJLRA0Ssp3Fsc0khMm49CcB7Rz6YKsztF6it8tBPbOLUTzeex9G2VpicMHm9zWtz62k+1b97fOx+46tu7L/pt0T650bYqimkds4m3kHNceWcYGDjoFqxnY32mXiamp7nTSMhhAjjfV1zHsib6gHOIHqAQVPbNZr9PojSmotT0r4ruwPt1W9zmuMgBLonu2kjJG7PsWGV+r31PZZa9LZOaW4S1DvzC0bB/xPk+AXTt17LWwdiFRpGheaqvjjNRHIcN4lQHb+WeQB+77CueGdiXaC57QdPOaCcEmqg5f/Wg901VctG9kdNVW+aSkqtTVcgdNEdr/ACaAAbQeoy956dwWM0GlLpcrE68UjxPh2BCxkr5TzxnIYWjn4uBXVfaN2TRai7ObRYrXNHT1tnjaKV7x5j8Nw5rvDdgHPiFocdj3adHTPtbKGb6vc/e6NtfGIXO9It3/AMEEOovwupux8UOqIKkW+O5wPopKiQOc37KYOZ1Jx0Iz05q0dntkuN50xrQ0V0dQ0tHQCrqYmsz5SGbiGE5GByJ7+7kth3LsL1Dbuzcw0sLbjqCqr4ZZYIZWtZDCxkowHPIBOXjPux4qv7K+zXVtk0zrylulodBPcrU6npGGeJ3FkLXjbkOIHUdcBBoCiudVR0VfSwTPbT1sYimjB814D2vGR6i0LZ/0X/xkzf5bP/8Aio9O9hetKu6sgutpNFSvjlBqH1ETmsfw3bMhricb9o5DvV40D2P9olp1UHx4s0RjfFLXMlilzGRgta3JJJ7sgY65CDWPZx+MPS/+a0v75q79dWUzaoUzqmEVBGREXjefd1XIGiex/XVu1nYK6tsL4qWmuFPNK/ymE7WNkaXHAfk4APRV937GO0Co7QJ6qMiRklWZm3U1LRtG7IcRncCB3AexB1ui+MBaxocckDBPivqKIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIixfU2o3Wu90FMyWmZCNslUJXAOLHvEbdvPxLnH1M9aDKEWK33UdbBTXn6toA51vIYZpZAGFxa13IYJPJ3qVTNepaWrnZUwympEUG2lje1zN8kj2tw4gHJ28yeQHTvyGQosdq7xVQ1FvNXA6iZxpGztJEjXsbC9+WuHdkDwPJRUWrY6iOSR9FMGCndUxiJwlc5ox5pA+67mOXPv58kGTorbYrq27QSyMYxvDdtOyZsoPLPVp5H1HCpK+8+Q1tUwRz1Lw+CNsILQAZCQMHr7cn2IL6ixSXUNxkuFBT0tBEHmpkpqmOSfGHNiLwGkNPLG0592FU0+qI57kKdlMTAZ3UwlEgLt7SQSWdQ3IIz8sc0GRIrBRakEwp5qmjkpaOcyNjmkeOZYCTkDoCGvIP+H1qmk1NHTtknmjqA58VO6OmeWgB0pfgZxkHzcnPTHL1hlCKw0OpI6gwtmpzCXTmnc7eHMDtm8EOxzBAIzy58sLxBqiGejjnipZ3Oc6UuhHORrGM37sesFmB/jCDIUVrsN4Zd4pXsjYzhkDzJmSdRnntPI+o/NW23aqbcJmNpaTdHOHGmfxQdxAJG8AZYDjkefrweSDJkVl05cqys09FXXGnijkdEJPs5N28YznoMezmqOm1LVVLqdkVnl4tTTeVwtdO0Ax8s7j3Hzm8ufX24DJkWNv1VCHUL2wf0epbC4OdM1rxxSA3DOpxkZ6erK9HUjpqmspaWlbx4RIGtlnaxxLOWSz7wae44OeXTKDIkWJ02qKmO02p9bSQ+XVsAnDRUBrC0NaS4kjkcuGG4PtVWNTsdwHNo5xE6mdVTSOIAhY0kOz4nI5YzlBkKLG6q81xtr5jQy0ZcI3xSF7Xgtc9oId4OwenP28lOdRMZemUEkAHEkdExzZmueXBhfzYOYBDTg9enJBfUWM0+rYpqKoqRSvxEGHYJWOe3ccDe3OWY6nPIAHwX2XVcYp6UxQRvnqOIWt8pZw9rCA47xkdXAAYzz7kGSosbm1ZCwUhFLI3jxiT7aRkQHnbS0Fxw52R0B6YOeYWSICIiAiIgK3VFloak1xqIRKa1uyUu5+bt24HgMZ6d5JVxViuF7qobhWU1JbvKRSQsnkeZgzLXbuTRg5d5p5HA9aCs+paM0ldTSNe+KtOZg55y47Gs69RyaOneon2Cie2QP473PjjjL3TOc8bHOc0hxOcguJzlUX4Sl7JKuCj32uKRkclQZcPBdt5hmOYG4Z5g9cAqpN9AhpZDT/19ZLSY39NnE87p38Pp6/UglhsVHG5j5DNPI2R0pfNIXlxLCw5z3bTjHReaTT9JS7tktW4cIwRh9Q48JhxyZz5dBz68hzXm2Xmas04LtLQSRh8PHjgY7iPe3bkdB1PgrRWalrp6KCS2QUbpPLYYJG+VZwHOHI+ZkE5wcgY6jKC+QWaKCpbPHUVPFMgklcZOcuGFoa7uwM5x4jKmntVLNUvne13Ec+N5Id3xklv7VbHagqWT1bH28BlLNDBJIJ8gvk4fJvm5IHE78dB48pKq/SMuU1BS0YmqmzNhjDpdjXZi4hLjg4AHLoUFTPYaGeV0j2zNkdUeVb45nMcH7AzkWkHG0YwvkVipIq0VDH1AaJHTCDjO4QeertvjzJ8MnPVUL7peHXq3U7KCCOKWGV0zJKjBBa9gyCGHIw7I6ZzzxhfZtTtitlFWGlJFTBNPs4n3eGwux055xhBXVVioaq0stszHGlYQ4DcQeRz19fMH1Eheq2y0dZJPJK14klEYL2vLS0xklhaR0ILirVU6mqonxQttTnVToRUPi4jjsjJIbzaw+ccHl05dVXUF6krroKWGikbCKeOofLK7Y5m/dhuzGc+bzQepNPUU1sqKGczzR1DxJLI+UmRzhjB3d2NoHLwU31NReWz1Yjc2aaHgOLXluG+rHQ8hzHPzR4Kmkvojq30ppz5Q2pEO3d/c2b+J06bQfeMKmjv9XLBC8W+OIVkLpaMuqM78N3APAb5p28+W7ogu1BbYaKaaZj5ZJ5g1r5JXbnENztHuyfiqeisVJR1TJonVBbHuMULpSY4t3Xa3oOp9meWFbLPfbnLQ2RtVQRSVVfAJS+OfzQ0NYS93mjGd3QA88DPeJbNqZ1zq4GtoJm0dTu4M43HkASC8bQGggcsE93RBdaC101DRyUtPxRA/Pmvlc8NB7m5J2j1DklPa6anlppI2uDqenNLHl3Rh2/PzAqSru9S2vqKehoPKm0oaZ3GYMI3DIDAR5xxz5kDmOap5NRTCSdrLeSG1PkcJdKBxZOvh5rQMkn1HkUEg0tb2w8KM1DIyIwWtlIBMYAY72jaPVy6KrbZqbyxlRI+eVzC9zGySFzWFwIcR7iR6s8sK3/Xb31lNT1EMtPVsqzBLFDIHsceC6Qcy3JaQPAHPzip9V8akqZfI/tIgxxhbJmRgccfaMxuZjqeRGAeqIrW6boo6anhp5KyDycFsUjKl5expABYCSfN5Dl05BVdPaKOANDIy5og8nw9xdlmc4OepOTzKtMmpz9XwVEENJI6UvGBWN2+b1DSAS48+m0dOeO/xNqp/CknpaAy0sVFFXyvfKGFsbw44AwcuAaeWQPWiq+LTlFG0tc+qlaGCNglnc7htDg4NbnpzaPXyC9fg9ReUMmDpwWVDqljRKdrXuzuIHr3O+JxheKe81FTUvdBQb6Bk7qd04lAeHNJa47CPuggjOc+pU9j1I+6VMANvlipqlhkhm848sZG8FoDcjpglBWMsVM175DNVumLBG2V0x3saDkAH29c5z35Xh2naPY0xyVMU4e+Q1EcpbI4vxuyfA4by6ch4K8ogtM1go5aVtMX1IpxFwXxiZxEjPB2epOTk9TnqrsiICIiAiIgKx1OnoKy7VtVVOkMdRFHFsjlezc1u7IdtIyPO/b4q+IgtjrHQOqDNwXNy5r3RtkcI3ObjaSwHaSMDu7h4L4bFQGpZOY5C5krp2N4rtrXuBDnBucDO53xKuiIKaKhp4baygja5tMyIQtaHHIaBgDPXp39VSOsNA+GaOVkshlcx73umeX5YctIdnIwemCroiCgNpozBVRGNxZUua+QmRxcXNa1oOc5BAY3n4jPVQfg9b/tDsm4r5BMZRO/ibw3bkOzkeby9iuyILayx0MbaYMjla6nc57HiZ4dlxy7c7OXZPMg5yoXabtrz58UjhtkY1pmftY2QYeGjOADnuV4RBbq+zUdc9j5hMx7WcLdDM+MlnoktIyPap6WgpqSZ8lPEI3OjZEcE42sztAHdjcVVIgpHW2lddBcXRZqxFwN+T9zOcY6e9QUVkoaOVr4Y3+Y0sja+Vz2xtPUNBOGjkOiuSILfQWaioOB5NG9oga5kQdK5+xrtuWjJOB5o5d2OS8UljoaSqZUQslDmFxjY6Z7mRl3XawnDe/oO9XNEFtr7JQ1875ahkm6RoZIGSvYJWjoHgEBw5nr44Uktpo5aeWF8R2SS8c4eQQ/OdwIOQeXcq5EFuistDHwyInOfHKZw98jnOc8sLCXEnJ80kc/V4Ly2x0bS539IMhaGCR1Q8va0HIAdnI5/FXNEFqFgt4c1wjlDxv3P4z9z9+N245552t6+ASKwW6KjmpWQu4M1O2keDI45ibuw3Oc8tzldUQWw2OhNX5QY5N3E43D4r+Hv9LZnbnvzjrz6rxT6foKdxMTZwOG6NjfKH4ia7qGDOGe7GO5XZEHmJgiiZG0uLWgNG4knl4k9V6REBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAXkh+eRbj2L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9IgIiICIuavpMdpdwpLodKWKpfSsjja+tmidte4uGRGCOgxgnHXOPaHQlRfbRTSuiqbrQQyt5FklQxpHuJUX4S2L8tWz9aj/muALRZbne3zC10U9Y+IbpOE3cWjnzPwKoHMc1xDmkEd2ER+iUF/s88jY4Ltb5JHHAaypYSfcCrkvzaIIwSCF0D9GvtLuDL9BpS9VL6mjqgRSSSuy6F4GdmT/dIBwO44x1QdSKkrbnQUBArq2lpieYE0rWZ+JUFznkfV09vpnmOWdrpJJAOccbcA47txLgB7z3I6G1WOjmqnsp6WFg3Szv6nuy5x5k9OZKK8fhHY/yzbf1pn80/COx/lm2/rTP5qsoqqkrqaOoo5YpoJM7HsIIODgr7FUUs0s0cUkT3wuDJGgglhIBAPuIPvQUX4R2P8s239aZ/NPwjsf5Ztv60z+auX2eCfM5dVFT1NLUcTgSxScN5iftIO1w6tPrQUX4R2P8s239aZ/NPwjsf5Ztv60z+auZDB1DVC6ogbUsgOeI9jpAQwluAQDl2MA8xyJyfcUFF+Edj/LNt/WmfzT8I7H+Wbb+tM/mrnhn+FfPs8A+ZgoLb+Edj/LNt/WmfzQajshOBeLbn/vTP5q5/Z/4fFQOqKTytlI6SHyiSN0jYiRucwEAkDwBI+KCeKRksbZIntexwyHNOQR7V6VorLeygjlrbTC2KdgL3wx+aycdSCOm49zuufVkK508zKiCOaJ26ORoe0+IIyEEiIiAiIgIiICIiAiIgIiIPmVxb9Ja0VNu7U6+qmY4U9wZHPC/ucAwNI9oLf2eK7PLsLGtdaPs2tbT5BfKfiNaS6KVh2yRO8Wn+HQoOErHdX2mpqJo42yGWmlpyHdAHsLSfdlZe7tLqJawTVFsgljLTujdM/73FjlG05y1gdE3DByALvFbTqvozQOmcaXVMkcWfNbJQh7gPWRIM/BRf7Mv/rb/APbv/FRGnNZ6zm1RRW+nnpGwmkLyHCQnO7HIDAA6deZ9eOSvHYDZqm8dqdlNO13CopfK5ngcmNZzGfacD3rZ8H0ZohK0z6qe+PPNrKANJHqJkP7FuTQGiLLoa2OpLJCd8mDNUSndJKR0yfDwA5IL1UONPqSmlePsqmB0Adno9p3Ae8F//CvepLVHfbJVW2aR8UdQA1z2dQAQeXwU9VFFVQOhnbujd1GcEeBBHMEdQR0VuNNdohspbnTuYOhqqUyPx7Wvbn4Iq1XXQNvraindBPNSRRRtjDYwC9uHufuY85c1zi47jnLh1VDR9m9PTMH9NY5/F4hHkUXCH2bGEiPoHYjBDu4l3ccLIuHfvyja/wBQk/1k4d+/KNr/AFCT/WQYzUdmkU9HdIH3Nx8vmjndmnaGtewvw7a0gEkP59x2jl3L1U9mlLJG9kVa2IGsFY1wpWbg7bg5xgO7yMggZ6FZJw79+UbX+oSf6ycO/flG1/qEn+sgtWrdDx6irpp33GamjmiDJI2RtdkiOVgcCeY5TO5eoKnrOzqjnMYiq3RRxSSPjh4LXRDe6JxaWHkW5i6f4iVfeHfvyja/1CT/AFk4d+/KNr/UJP8AWQYjRdmRltFLS3C5zxbY9sscAHN/DliDg7kR5snTpyVYzsxtn1fR0k075m0xJZxGBwBMzJTjJOAdm3r0cVkXDv35Rtf6hJ/rJw79+UbX+oSf6yDFj2VW/wAqfMK+qAdE+IM/utacgNAzgNAONuO7PqV4t2iKS33uguNNIwOpDUhsZgaQGTScQMaf7oaeQx3EjvVx4d+/KNr/AFCT/WTh378o2v8AUJP9ZBdblVso6GeokBIY0kNAyXHuaB3knAA9aisVK632S30bzl9PTxxE+Ja0D+CpqeikM7Z7hU+Uys5saGbI2HxDck59ZJ9WOauG9BPlMqDem9BPlMqDem9BPlMqDem9BPlMqDenEQT5TKgD19EnrQTZX3K8A5X3KCn5uOGjKGOTuHzVRG3a0BekFJwpfD5r5wpfD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpfD5r4Y5fD5qsK8nogpoo3cQB45e1Wax6kF4v12tIpWxSWw7Zn8UOBJJ2bQOZy0ZPTB5c1fzkEEdQqKG326ikNRSUUMU+HN3tZg+e7c7J78u5+1BVMcpdypYyp8oJ0REBERBDWTtpqZ8zuYaOnirLbL6aisbDMG5dyaGj5//AN4q+TwsnZskGW5zhWmj0/FS3BtS2Vxa3JazHT3r5nGRxvf26uHxoz833/Or02Zs6Koub9GO3jX7rfrR1hbQwy7ZqeInynEzhKPvNj28w3qeY5BV8naHpyOmfPJVysjG3YX0728VrnFoczI85uQRkcviFkFNbKWmuNdXRRkVNbs47i4kO2DDeXQclZG6EsbIZYmRVLWvaGNxUyfZsDi4Mbz5MySdvTp4BfTeZI7WtlFa2kbNO+pdEJGxtp3kkmMyBnT75aCQ3qvdBrC1VtlZdo3VDKF1SKUSSwuZ55eGd/8Ad3HGeipYtAWCE/0enqIAYBTkRVMjMtDCwE4PXacZ9ngFX0ulrXT6cmsQjnktkjDGYpp3vLW4xhpJy0DHLHTuQUkOubFNPBEyomPGLQJBA8sbveWMLnYw0OLTtz15HvCrLHqm03yiqqu31JfTU2eLK+NzGgAEk5I9R9igOjLJ5RSytpnsFOyGNsbJXNY4RHMe9oOHbTzGVNadK2q1mvNNC9xrmCOoM0rpC9oyA0kn/EfXzQUtv1xZa6oiggkqRLK5rWNlp3xk7o3yNPnAci1jjn2KFnaFpt7Q7y14YaYVW4wvwG8Li4zj72zztvVU9F2d2umq55HT1kkTjC6AGd++ExsczAfuyQWvIx4KspNCWKjfupYKiEcBtPtjqZGja2MRg8j97YAM+rPXmgoK/tFt0UEMtHBUVEUtHUVbZnRuZGBDtyCcE4O4cwCOniFXz67sNO6qbNUTNFOH7n8B+x5YQHhjsYcWkjICjHZ/YBT8EQThhE7X4neDIJg0SB2Dzzsb8ApptD2KeWpfLTSOE+8lhnfsYXkF5Y3OGlxAyR/EoPEevLE+ppafj1DKmomfAyF9O9rw9jgHAgjI5ub8c+Kq7zqWltN+tluqyWitOxr9j+TycMGQMcznvGOXioK7RNkrZjJUQTHdUOqXNE7w10hLSSRnHVrfh6yqi6aUtVzvUF1q4pHVkPD2ubK5o+zcXMyAcHBcfigteotYVVqq7xHT2ryqC2U4qJ5eOGYaYpHjljvcwN/9rPcpqTWcFRrFti8nLWui5VO/zTPtDzDjHXY4Oz7QrtW2C3VguoqIXO+s4WwVWHkb2AEADny5OPRUMOidPw1cdXHb421sdT5WKrJ42/n1f1LcHG3OMcsILtLdrdFI6OWvpGSNOHNdM0EH1jKt1/1B5FFbm2uGK4VVxqDT0zRMGRkhrnOc54BwAGO6AnPJXKS12+WR0ktDSPe45LnQtJJ9Zwqe6WG33KihpZoTFHBIJoXU7jE6J4z5zS3BB5n4lBZrVrejqC2mroJ4LoJpYJaaCN9RsMbg1ztzW/cy5vnEDr6iorh2hWiCmfJSceoeyaKMN4L28Rjp2wufGdvnhrndG5zy8VWt0TZWeTGKKpifCX5kZUyNfLvcHvEjs5flwBOfBRv0FYXsmaaefa8gtAqZBwcSiXEfPzBvaHcsdEAa8sJ4X9InG/O/NNJ9h9oY/teXmeeC3njmFNa9XUVbYGXeeGopKZ1UaX7aMgh3F4YJ9ROOfd7lE3Qlibwv6POdnN+ah54/2hk+15+f55LueeZKr49NW1ljrLQYpH2+rdI6SJ8jjjiElwaerRkkjHQ9EFBHrmxSzwxsqJiJS0CQQPMbdz3MYXOxhoc5p2568j0IUVRr7T9PSR1M1VI2KWGKdh4TubZXPazu6kxu+CqzoyycakkbTPYKaOGNsbZXBj2xHMe9ucO2nmMqmZoKxxwSRRx1TWPYyL+0yeaxjnOawc/ugvdy6c0GRU0zKqmiqIdxilYHtLmlpwRkZB5j3rzVDEDvd+1LZQU9st1NQ0TOHTU0bYomZJ2tAwBk81R6mrvq20SVRGWsfGHewvAPyKJM4jMpoSqjIVLAQQCCqnIRVUiIgIiIMO7RdSXLT0dv+rKWOXyhzw+SVhc1pa3LWciMFx5A8+nIE8lj1117eaKpvbTT0zIKMMNNI+CQiYukja9ue8x7yDj7xxjGCFtJQ1lLBW05gq4mTQkgljxkEggj4EA+5Bqp2qb5W11PKC90AxEH07HxxTgV9PHxQCcjLHP7zyz3KSk7RLs+smZPDShsQjkmiEEgfTNNW2J4eSeZbGS7IAHqx12uoPJKfy3yvgs8q4fC4uPO2Zztz4Z5oNc0Wu71U3u20rbfGKapmc3c6JwMjPKXx5aSeRaxrXnkc5/ujmrrfNSXui1LNT0lJDNQQzU0Wzhu4knFa8kh2cDBaO49e5ZwiDU1PrLUNebW574KeA1dMKmaOkkDW8Rsm+Bwcc7mua0Fw73Dp0NTR601KH6cZWUVIXXOGKofshe0Ye9oMYy7Ic1pLicHPLkBkraGEQa/1brO42jVtPbaOmZJTFjTKZIjnzmvO5rt3QFoB83HPrlWCm7SLvLQ0UsjrdGyofCHVZpZeHEXwySOjLd2XOYWNyQceeOi27IxskbmSNDmOBa4HvB7lTC20Qjo2Cli2UeDTjbyiw0tG3w80kexBruHWepZqKatlo6WipmmkjdxaeR5hMsbHvkdhwJa3JGOR5jJGCqii1nd6msoIKqCGiE8IcN1NK51UTI9mY8fcG1rX+cDgPGcdVsdEGn6LWmprbp+hZWQxVEz6ekeat8DvsxJHITxAXjcd0bRnLeb+njnj9QTSaSrK6mjiF1pqVsktO9ry2OUxh+04GSOY6LJF4ZFHG6R0bGtdIdzyBguOAMnxOAB7kGqZu0e7sobXIyia6aWVzZg6mIY9olazzHCQjo4nI3dO4AqebWupIaaeZ9LRYdE+SLML28PbU8IhxLsElvnDO0DvOOa2lhEGB3PV9bBpDT90aIKWa4VDIZn1NO8tiBY8l2wOzjLAeuMd/esei1ZqGouFvqnNdRwyy0nGhMT3NeHwznaMnzQ5zGDxy5uemDteopYKl0JqImSGF/FjLhnY7BG4evBI96mQapZqnUF0htE9HUUzagyvdMxtJMI4/6NI8xSAkbi1wAyCOeMjuVz1hqq602l7TUUkTKWW40UkskroXycKTghzY2hvMOcSQCem3oVsNEGvNHaqvNdqKK1VtIG07IG7nvYRIfsWO4pOeYc5xGNo9p5hRXbWWoaKa8xNtjMWyRsb5zE4seJZWiN7fOGQ2Iku59e8BbIRBrKLWOpJ5KZzaSkjhIpOIDA9xfxpnxlzTuwAA0Pxz69e9UWmNbagfVWSgrIo6p0zW+UTOgcxzyZHteB53IsDQTyOc/3eRW2kwgho6iKspIammdvgmYJGOwRlpGQcHmFj3aSP/I6u9sf/O1ZOsa7RsHSNaD3mP8A52rneuRat1XJ6RkmibnyR1VdAfsI/wA0fsVcrfQ/1Mf5oVwHRbjnA9UtUxzQ17g145c+9VBewHm5vxVknb1XHfbEP+tG/fpGfu2Kjt/iM9NvxTiM9NvxX56sypD3ImX6DcRnpt+KcRnpt+K/PxqmZla0pqd+8Rnpt+KcRnpt+K4CcPtPcvbev8VzmrE4daaMxl31xGem34pxGek34rgRnMuCqLY3zpfclM5nCVU6Yy7z4jPSb8U4jPSb8Vw80HKmaDhddDlrdub2+kPim9vpD4rjSkB4QVWwLEtRLsDe30h8U3t9IfFciZDGFzjgDmV9ZUMz92b/AOE7+SGXXW9vpD4pub6Q+K5JdM2RmxjJS5xA5xuA6+JCuDW5whl1Nub6Q+Kbm+kPiuYWNUzGlDLpjc30h8U3N8R8VzcxpU7GoZdFbm+I+Kbm+I+K58YxTsYhlvzcPEJuHiFolrVOxiGW78jxC+rTEG6N7XsJa5pyCOoKzm36sAtrvK2F1WwYbgcn+v1etFZZJIyNpdI5rWjqScLX/aRdo6q3spaV26MSgvcOjjg8gqGpqJq2pdPUOLnu+A9QVu1A3FA39IP2FeHtL6W56OtjxKWxaH+pj/NCrweXeqGhH2Mf5oVeOi9tO0OUqSZvJccdsgx2pX79Iz92xdlzDquNu2f8ad//AEjP3bEkYixSkcgoWdVOArDMvTBzUzQom4HM8kdVRsIAO4+pdIZSy7RsyQCTgetfQwnvVBVSudslwPs3ZA9XRV8LxJGHN5ZXG7GJeizPJ5awtfnccK4W9oEO4dXEkq0yyEy7ARlSUta6mdsAD2eHeCtWqJn5mL1f7WQMCnYFbaS5QTcidhzgZ71dYgHY2kHPeF2xh51dTACNvMKqZjxCoG08RPOJhJ/whTNp4f8Aso/+ELlMOmcKmrx5M/mO79oVewK3R08QcC2KMEd4aFVsCYNStYAp2AKhYFOxMGpXMaFOxoVCwKdgV0pqV7AFMxoVAwKdgTSa1cNrWlziAAMkq0ae1Tbb1cqyipJCZKd+G5BG9uBkjl45HuVwYF8pKKnppqiWCMMkqHh8hH94gAfsCaTWu7Gj1KdgHiFb2BQ3SvhtduqK2qdthgYXu/l7T0TBqXC5XKitVI6puNTFTwN6ukdj3DxPqWJT9rWmIJtjJKuYA43xw+b8yD8lo3VGoa3UVxfVVsh4YJ4UIPmxt8B/PvVoYySQOLI3ODRk4GcLLbrDTOs7DqB4jttfG6fGeDICx/wPX3ZV31Dg0Dfzx+wrjmCaSGZksL3RysIc1zTgtI7wVvzs61g/UlhdS17wblSObud3ysOcO9vcf/2vD2n9Jc9HWx4lLo6iH2Mf5oVaqOi5wx/mhVi9tO0Oco5Vxp2z/jTv/wCkZ+7Yuy5Vxp2z/jTv/wCkZ+7YgxBg5qdoULOqnaqy8VUbnNBbzA6hUwaOo9nuVzYo5aUO5x8j4LpTVhmYUmBkBwy3oVPSv4Ue0jIHTkvD43sOHNI/ivUZPDPPuwfWtTTFS01zTs8Y3Svec5IwAF9ZGN3TqvYHw7yqmmpZJiC1hwTknoAtxiGJ5qaKLLG4ByTyWUWaldTwZkJ3O57fBRUFAyna0vw+QDr3D2K6R9FiuvPKCITMHNTNChZ1U7VzWUzAp2BQMU7EROwKeMKGNTx9VRM0KZg5qJqmb1QTMCnYFCxTM6IidgUzQoY1O3qgmaFr/tnuUcGmmUTZQJ6iZuWd5YMkn4gLYLVj+vLIb7pqqpY2g1AHEhJ9NvMD38x70lY3c4QsEs8UbnBjXODS49Bk9VsTtRxorXJtOmY/q+O2NiMdTH/XTudGHF7n9SDuI2/d9S11LG6N7mSNLXtJBaRgg+CvjNTVU7qP67iZdo6NobBHU9zR0a57cPLR6O7Cw6sk7ZbfSQXHT90paeKlmvFpgr6mCJoaxsrgQ4taOgOM48cq39k80kWsYGMJ2yxva/2AZ/aArDqS+1+pLvLcrrIH1DwGgNaGtY0DDWtaOQAHcs97G7FKX1F7mYWwtHAhJH3ifvEezGPeV4+0JxwtzPlLrZ8Sn1deW/8As8fsCrVRW/8As8fsCrV66doc5RyrjTtn/Gnf/wBIz92xdlyrjTtn/Gnf/wBIz92xBiLOqnaoGdVO1VlOzuU7FAzuU7FUTM5jmvYhjPWNvwXiNTs7kR7ihjb92No9yqmKBinYqJ2KePooGqePogmZ1U7VAzqp2okpmKdigYvFZI6NjCxxBJRmZxGVyjU8fVYxfNSQWJlIJ4Zp5JwdoZgdOuSfavlHrW3SVEsdQyemEUDZ3vlZyAO3lgc8+cFctMvapm9VjQ1dZAHE1zcNYZCdjvug4z08V7drGyMkkjZWtkmZGZOG1py7Dd2AcYzjuTKYZSxTM6LEbfriy1FBFUzTupuJG6XhyMJIaHFpPLI6hVsesrAXyM+sYw6Nu9+WuAAxnPTwTJiWURqdvVYkzXWm+CyX6zjLXuc1vmOzkAEjGM94U101fS2vUFHQVLAymnpX1Tqpz8BjWgn7uOfRDDLmr3tyrJp/Ulpvz52WmsbUugDTJtaRt3Zx1HqKvzeiIwHW3Z3S32V9ZRPFJXu5uOPMkP8AiHcfWFrufsy1LHLsjpoZm5++yZoHzwV0OG5XtsYUw1FUw0xpjsjqJKhkuoKhjIRgmCA5c71F3d7srbstFBQWmGmpImxQRENYxowAMFXKNmFDdxijb+cP4rw9pxjhLno68PObtLZtEMQR/mhVapaT+pj/ADQqpeunaCUcq407Z/xp3/8ASM/dsREGGykiF5BwcL5bXOdv3OJ6dSiKsrmxTsRFUTRqdiIhKdqscdRN9chnFk2cbG3ccYyiIi6alcW2SctJB83mD/iCudqJNupSTkmNv7ERBXs6qdqIqkpmKKv/AKtntREliv8ASw7tKceFRMydhgkO3uyMc1iEjnCKoAcQHW6MEZ682IijpTtC89oZLa6k2kjNqjBx3+cqKzTysur4WSyNhcZC5gcQ0/ZHqEROqxstUsj/AKtpBvdgUkjRz7uIeXsWVUAB0hrTIBwyk/giISpdIyPk1Pp9sj3Pa2vIAcc481qyftk/3ki/yub9pRE6HVU9gMj5bjqF8r3PeW0+XOOSeT1ulvREWo2Yq3TsU0aIjKdiprx/ZG/nD+KIvD2p9Jc9HfhvFpbNpP6mP80KqRF6qdoV/9k="
+        }
+      },
+      "server-response-time": {
+        "id": "server-response-time",
+        "title": "Initial server response time was short",
+        "description": "Keep the server response time for the main document short because all other requests depend on it. [Learn more about the Time to First Byte metric](https://developer.chrome.com/docs/lighthouse/performance/time-to-first-byte/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Root document took 180 ms",
+        "metricSavings": {
+          "LCP": 100,
+          "FCP": 100
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "label": "Time Spent",
+              "key": "responseTime",
+              "valueType": "timespanMs"
+            }
+          ],
+          "type": "opportunity",
+          "overallSavingsMs": 79,
+          "items": [
+            {
+              "url": "https://www.ocobo.co/blog",
+              "responseTime": 179
+            }
+          ]
+        },
+        "numericValue": 179,
+        "numericUnit": "millisecond"
+      },
+      "network-rtt": {
+        "id": "network-rtt",
+        "title": "Network Round Trip Times",
+        "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "items": [
+            {
+              "rtt": 10.600109999999997,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "rtt": 7.6474799999999989,
+              "origin": "https://useago.github.io"
+            },
+            {
+              "rtt": 7.2906749999999985,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "rtt": 4.5105299999999993,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "rtt": 4.130775,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "origin": "https://forms-eu1.hsforms.com",
+              "rtt": 1.0759199999999993
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "rtt": 0.0042319208246190841,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "rtt": 0.003243528964370078,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "rtt": 0.0027647954042598938,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "origin": "https://fonts.gstatic.com",
+              "rtt": 0.0014671294968584834
+            },
+            {
+              "rtt": 0.0013071322178010813,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "rtt": 0.00095509014297153047,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "rtt": 0.00078207306140634951,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "rtt": 0.00051874479932548494,
+              "origin": "https://images.unsplash.com"
+            },
+            {
+              "rtt": 0.00047160126105689381,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "rtt": 0.00039086018355857067,
+              "origin": "https://www.ocobo.co"
+            }
+          ],
+          "sortedBy": [
+            "rtt"
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "origin",
+              "valueType": "text"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "label": "Time Spent",
+              "key": "rtt"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 10.600109999999997,
+        "numericUnit": "millisecond"
+      },
+      "redirects": {
+        "id": "redirects",
+        "title": "Avoid multiple page redirects",
+        "description": "Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://developer.chrome.com/docs/lighthouse/performance/redirects/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [],
+          "type": "opportunity",
+          "overallSavingsMs": 0
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "first-contentful-paint": {
+        "id": "first-contentful-paint",
+        "title": "First Contentful Paint",
+        "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).",
+        "score": 0.28,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.8 s",
+        "numericValue": 3751,
+        "numericUnit": "millisecond"
+      },
+      "bootup-time": {
+        "id": "bootup-time",
+        "title": "Reduce JavaScript execution time",
+        "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to reduce Javascript execution time](https://developer.chrome.com/docs/lighthouse/performance/bootup-time/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "2.1 s",
+        "metricSavings": {
+          "TBT": 750
+        },
+        "details": {
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "key": "total",
+              "label": "Total CPU Time",
+              "granularity": 1,
+              "valueType": "ms"
+            },
+            {
+              "valueType": "ms",
+              "granularity": 1,
+              "label": "Script Evaluation",
+              "key": "scripting"
+            },
+            {
+              "valueType": "ms",
+              "granularity": 1,
+              "label": "Script Parse",
+              "key": "scriptParseCompile"
+            }
+          ],
+          "sortedBy": [
+            "total"
+          ],
+          "type": "table",
+          "summary": {
+            "wastedMs": 2091.1703999999945
+          },
+          "items": [
+            {
+              "scriptParseCompile": 11.7708,
+              "scripting": 629.45999999999458,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "total": 759.13079999999457
+            },
+            {
+              "scripting": 343.66079999999988,
+              "scriptParseCompile": 14.934,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "total": 620.27279999999985
+            },
+            {
+              "total": 602.829599999996,
+              "url": "Unattributable",
+              "scriptParseCompile": 0,
+              "scripting": 39.968400000000024
+            },
+            {
+              "scriptParseCompile": 174.53999999999991,
+              "scripting": 8.4096,
+              "total": 551.24399999999991,
+              "url": "https://www.ocobo.co/blog"
+            },
+            {
+              "scriptParseCompile": 167.7864,
+              "scripting": 248.96159999999986,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "total": 425.5859999999999
+            },
+            {
+              "scriptParseCompile": 193.59240000000003,
+              "scripting": 197.71080000000003,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "total": 394.1856
+            },
+            {
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "total": 57.391200000000005,
+              "scriptParseCompile": 12.0192,
+              "scripting": 42.700800000000008
+            },
+            {
+              "scriptParseCompile": 5.1612,
+              "scripting": 0.49439999999999995,
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "total": 50.876400000000004
+            }
+          ]
+        },
+        "numericValue": 2091.1703999999945,
+        "numericUnit": "millisecond"
+      },
+      "unminified-javascript": {
+        "id": "unminified-javascript",
+        "title": "Minify JavaScript",
+        "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn how to minify JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unminified-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "type": "opportunity",
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsBytes": 0,
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            }
+          },
+          "overallSavingsMs": 0,
+          "headings": []
+        },
+        "warnings": [],
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "interactive": {
+        "id": "interactive",
+        "title": "Time to Interactive",
+        "description": "Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).",
+        "score": 0.06,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "16.0 s",
+        "numericValue": 15979.337541380031,
+        "numericUnit": "millisecond"
+      },
+      "user-timings": {
+        "id": "user-timings",
+        "title": "User Timing marks and measures",
+        "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more about User Timing marks](https://developer.chrome.com/docs/lighthouse/performance/user-timings/).",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "details": {
+          "headings": [
+            {
+              "label": "Name",
+              "key": "name",
+              "valueType": "text"
+            },
+            {
+              "key": "timingType",
+              "label": "Type",
+              "valueType": "text"
+            },
+            {
+              "granularity": 0.01,
+              "valueType": "ms",
+              "label": "Start Time",
+              "key": "startTime"
+            },
+            {
+              "granularity": 0.01,
+              "valueType": "ms",
+              "label": "Duration",
+              "key": "duration"
+            }
+          ],
+          "type": "table",
+          "items": []
+        }
+      },
+      "main-thread-tasks": {
+        "id": "main-thread-tasks",
+        "title": "Tasks",
+        "description": "Lists the toplevel main thread tasks that executed during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "headings": [
+            {
+              "label": "Start Time",
+              "key": "startTime",
+              "granularity": 1,
+              "valueType": "ms"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "duration",
+              "label": "End Time"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "startTime": 3087.086,
+              "duration": 54.996
+            },
+            {
+              "duration": 7.176,
+              "startTime": 3143.122
+            },
+            {
+              "duration": 6.515,
+              "startTime": 3150.308
+            },
+            {
+              "startTime": 3156.838,
+              "duration": 58.741
+            },
+            {
+              "startTime": 3333.501,
+              "duration": 7.919
+            },
+            {
+              "startTime": 3343.798,
+              "duration": 11.14
+            },
+            {
+              "startTime": 3354.949,
+              "duration": 85.098
+            },
+            {
+              "startTime": 3444.705,
+              "duration": 14.632
+            },
+            {
+              "startTime": 3466.378,
+              "duration": 19.972
+            },
+            {
+              "startTime": 3488.046,
+              "duration": 20.03
+            },
+            {
+              "startTime": 3514.622,
+              "duration": 10.105
+            },
+            {
+              "startTime": 3528.252,
+              "duration": 13.704
+            },
+            {
+              "startTime": 3542.988,
+              "duration": 32.646
+            },
+            {
+              "startTime": 3579.151,
+              "duration": 28.891
+            },
+            {
+              "duration": 145.062,
+              "startTime": 3608.109
+            },
+            {
+              "startTime": 3757.063,
+              "duration": 30.987
+            },
+            {
+              "startTime": 3791.693,
+              "duration": 29.444
+            },
+            {
+              "startTime": 3822.265,
+              "duration": 21.435
+            },
+            {
+              "startTime": 3845.329,
+              "duration": 6.049
+            },
+            {
+              "startTime": 3851.546,
+              "duration": 104.368
+            },
+            {
+              "startTime": 3971.572,
+              "duration": 5.269
+            },
+            {
+              "startTime": 3977.329,
+              "duration": 81.854
+            },
+            {
+              "duration": 5.748,
+              "startTime": 4066.148
+            },
+            {
+              "startTime": 4071.918,
+              "duration": 5.347
+            },
+            {
+              "startTime": 4077.311,
+              "duration": 6.104
+            },
+            {
+              "startTime": 4083.439,
+              "duration": 7.842
+            },
+            {
+              "startTime": 4100.491,
+              "duration": 8.128
+            },
+            {
+              "startTime": 4112.589,
+              "duration": 11.122
+            },
+            {
+              "duration": 15.192,
+              "startTime": 4123.927
+            },
+            {
+              "startTime": 4142.012,
+              "duration": 6.823
+            },
+            {
+              "startTime": 4148.887,
+              "duration": 196.366
+            },
+            {
+              "startTime": 4347.291,
+              "duration": 5.411
+            },
+            {
+              "startTime": 4356.05,
+              "duration": 7.995
+            },
+            {
+              "startTime": 4365.663,
+              "duration": 6.448
+            },
+            {
+              "startTime": 4372.428,
+              "duration": 5.621
+            },
+            {
+              "startTime": 4378.124,
+              "duration": 16.098
+            },
+            {
+              "startTime": 4394.255,
+              "duration": 5.367
+            },
+            {
+              "startTime": 4399.634,
+              "duration": 5.288
+            },
+            {
+              "startTime": 4404.929,
+              "duration": 5.137
+            },
+            {
+              "startTime": 4410.074,
+              "duration": 5.243
+            },
+            {
+              "startTime": 4415.329,
+              "duration": 5.263
+            },
+            {
+              "startTime": 4420.604,
+              "duration": 5.584
+            },
+            {
+              "startTime": 4426.2,
+              "duration": 5.445
+            },
+            {
+              "startTime": 4431.656,
+              "duration": 9.838
+            },
+            {
+              "startTime": 4441.506,
+              "duration": 6.131
+            },
+            {
+              "startTime": 4447.66,
+              "duration": 5.319
+            },
+            {
+              "startTime": 4452.993,
+              "duration": 10.352
+            },
+            {
+              "startTime": 4463.357,
+              "duration": 57.659
+            },
+            {
+              "startTime": 4521.046,
+              "duration": 39.772
+            },
+            {
+              "startTime": 4565.451,
+              "duration": 5.283
+            },
+            {
+              "startTime": 4570.939,
+              "duration": 6.991
+            },
+            {
+              "startTime": 4581.627,
+              "duration": 7.367
+            },
+            {
+              "startTime": 4591.463,
+              "duration": 5.776
+            },
+            {
+              "startTime": 4597.499,
+              "duration": 5.658
+            },
+            {
+              "startTime": 4603.656,
+              "duration": 5.214
+            },
+            {
+              "startTime": 4608.907,
+              "duration": 5.432
+            },
+            {
+              "startTime": 4614.35,
+              "duration": 5.078
+            },
+            {
+              "startTime": 4619.437,
+              "duration": 5.792
+            },
+            {
+              "duration": 5.171,
+              "startTime": 4625.25
+            },
+            {
+              "startTime": 4632.776,
+              "duration": 5.242
+            },
+            {
+              "duration": 5.725,
+              "startTime": 4638.047
+            },
+            {
+              "startTime": 4643.782,
+              "duration": 5.158
+            },
+            {
+              "startTime": 4648.951,
+              "duration": 6.776
+            },
+            {
+              "startTime": 4656.499,
+              "duration": 15.477
+            },
+            {
+              "startTime": 4672.182,
+              "duration": 5.334
+            },
+            {
+              "startTime": 4677.531,
+              "duration": 5.391
+            },
+            {
+              "duration": 5.212,
+              "startTime": 4682.933
+            },
+            {
+              "startTime": 4688.154,
+              "duration": 5.348
+            },
+            {
+              "startTime": 4693.511,
+              "duration": 7.37
+            },
+            {
+              "startTime": 4701.997,
+              "duration": 22.066
+            },
+            {
+              "duration": 35.089,
+              "startTime": 4725.105
+            },
+            {
+              "startTime": 4763.856,
+              "duration": 8.186
+            },
+            {
+              "startTime": 4776.758,
+              "duration": 9.007
+            },
+            {
+              "startTime": 4785.783,
+              "duration": 7.038
+            },
+            {
+              "startTime": 4792.856,
+              "duration": 5.381
+            },
+            {
+              "startTime": 4798.263,
+              "duration": 6.888
+            },
+            {
+              "startTime": 4805.162,
+              "duration": 5.114
+            },
+            {
+              "startTime": 4810.29,
+              "duration": 6.711
+            },
+            {
+              "startTime": 4817.12,
+              "duration": 5.175
+            },
+            {
+              "startTime": 4822.305,
+              "duration": 5.687
+            },
+            {
+              "startTime": 4828.006,
+              "duration": 5.215
+            },
+            {
+              "startTime": 4833.254,
+              "duration": 251.602
+            },
+            {
+              "startTime": 5087.175,
+              "duration": 5.721
+            },
+            {
+              "startTime": 5097.069,
+              "duration": 27.438
+            },
+            {
+              "duration": 5.224,
+              "startTime": 5128.568
+            },
+            {
+              "startTime": 5134.552,
+              "duration": 50.12
+            },
+            {
+              "startTime": 5187.623,
+              "duration": 9.482
+            },
+            {
+              "startTime": 5197.247,
+              "duration": 9.54
+            },
+            {
+              "startTime": 5206.823,
+              "duration": 11.296
+            },
+            {
+              "duration": 10.381,
+              "startTime": 5218.351
+            },
+            {
+              "startTime": 5231.334,
+              "duration": 22.491
+            },
+            {
+              "startTime": 5257.625,
+              "duration": 101.387
+            },
+            {
+              "startTime": 5359.682,
+              "duration": 16.389
+            },
+            {
+              "startTime": 5377.066,
+              "duration": 29.454
+            },
+            {
+              "startTime": 5406.535,
+              "duration": 32.267
+            },
+            {
+              "startTime": 5456.501,
+              "duration": 134.347
+            },
+            {
+              "duration": 132.375,
+              "startTime": 5600.541
+            },
+            {
+              "startTime": 5735.209,
+              "duration": 8.683
+            },
+            {
+              "startTime": 5750.317,
+              "duration": 28.428
+            },
+            {
+              "startTime": 5877.835,
+              "duration": 15.699
+            },
+            {
+              "startTime": 5896.944,
+              "duration": 146.782
+            },
+            {
+              "startTime": 6051.459,
+              "duration": 39.79
+            },
+            {
+              "startTime": 6092.766,
+              "duration": 26.896
+            },
+            {
+              "startTime": 6124.754,
+              "duration": 15.188
+            },
+            {
+              "startTime": 6916.671,
+              "duration": 144.577
+            },
+            {
+              "startTime": 7062.124,
+              "duration": 5.074
+            },
+            {
+              "startTime": 7070.094,
+              "duration": 5.17
+            }
+          ]
+        }
+      },
+      "duplicated-javascript-insight": {
+        "id": "duplicated-javascript-insight",
+        "title": "Duplicated JavaScript",
+        "description": "Remove large, [duplicate JavaScript modules](https://developer.chrome.com/docs/performance/insights/duplicated-javascript) from bundles to reduce unnecessary bytes consumed by network activity.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "debugData": {
+            "type": "debugdata",
+            "wastedBytes": 0
+          },
+          "headings": [
+            {
+              "label": "Source",
+              "subItemsHeading": {
+                "key": "url",
+                "valueType": "url"
+              },
+              "key": "source",
+              "valueType": "code"
+            },
+            {
+              "label": "Duplicated bytes",
+              "granularity": 10,
+              "subItemsHeading": {
+                "key": "sourceTransferBytes"
+              },
+              "key": "wastedBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "inp-breakdown-insight": {
+        "id": "inp-breakdown-insight",
+        "title": "INP breakdown",
+        "description": "Start investigating [how to improve INP](https://developer.chrome.com/docs/performance/insights/inp-breakdown) by looking at the longest subpart.",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "total-blocking-time": {
+        "id": "total-blocking-time",
+        "title": "Total Blocking Time",
+        "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).",
+        "score": 0.37,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "790 ms",
+        "numericValue": 794,
+        "numericUnit": "millisecond"
+      },
+      "cumulative-layout-shift": {
+        "id": "cumulative-layout-shift",
+        "title": "Cumulative Layout Shift",
+        "description": "Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/articles/cls).",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "0.002",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "newEngineResultDiffered": false,
+              "cumulativeLayoutShiftMainFrame": 0.00213
+            }
+          ]
+        },
+        "numericValue": 0.00213,
+        "numericUnit": "unitless"
+      },
+      "network-dependency-tree-insight": {
+        "id": "network-dependency-tree-insight",
+        "title": "Network dependency tree",
+        "description": "[Avoid chaining critical requests](https://developer.chrome.com/docs/performance/insights/network-dependency-tree) by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "value": {
+                "chains": {
+                  "7F87198682BDF238F977AC3471B8A6F8": {
+                    "url": "https://www.ocobo.co/blog",
+                    "children": {
+                      "98.2": {
+                        "children": {
+                          "98.161": {
+                            "children": {},
+                            "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                            "transferSize": 31974,
+                            "navStartToEndTime": 3577
+                          },
+                          "98.164": {
+                            "transferSize": 38778,
+                            "isLongest": true,
+                            "navStartToEndTime": 3756,
+                            "children": {},
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf"
+                          },
+                          "98.166": {
+                            "transferSize": 39126,
+                            "navStartToEndTime": 3576,
+                            "children": {},
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf"
+                          }
+                        },
+                        "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                        "transferSize": 24572,
+                        "isLongest": true,
+                        "navStartToEndTime": 3341
+                      }
+                    },
+                    "isLongest": true,
+                    "navStartToEndTime": 3212,
+                    "transferSize": 348931
+                  }
+                },
+                "longestChain": {
+                  "duration": 3756
+                },
+                "type": "network-tree"
+              },
+              "type": "list-section"
+            },
+            {
+              "title": "Preconnected origins",
+              "value": {
+                "headings": [
+                  {
+                    "key": "origin",
+                    "label": "Origin",
+                    "subItemsHeading": {
+                      "key": "warning"
+                    },
+                    "valueType": "text"
+                  },
+                  {
+                    "label": "Source",
+                    "key": "source",
+                    "valueType": "node"
+                  }
+                ],
+                "type": "table",
+                "items": [
+                  {
+                    "subItems": {
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ],
+                      "type": "subitems"
+                    },
+                    "source": {
+                      "selector": "head \u003e link",
+                      "boundingRect": {
+                        "height": 0,
+                        "right": 0,
+                        "width": 0,
+                        "bottom": 0,
+                        "top": 0,
+                        "left": 0
+                      },
+                      "type": "node",
+                      "path": "1,HTML,0,HEAD,3,LINK",
+                      "nodeLabel": "head \u003e link",
+                      "lhId": "page-8-LINK",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e"
+                    },
+                    "origin": "https://raw.githubusercontent.com/"
+                  }
+                ]
+              },
+              "type": "list-section",
+              "description": "[preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints help the browser establish a connection earlier in the page load, saving time when the first request for that origin is made. The following are the origins that the page preconnected to."
+            },
+            {
+              "value": {
+                "value": "No additional origins are good candidates for preconnecting",
+                "type": "text"
+              },
+              "type": "list-section",
+              "title": "Preconnect candidates",
+              "description": "Add [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints to your most important origins, but try to use no more than 4."
+            }
+          ]
+        }
+      },
+      "forced-reflow-insight": {
+        "id": "forced-reflow-insight",
+        "title": "Forced reflow",
+        "description": "A forced reflow occurs when JavaScript queries geometric properties (such as offsetWidth) after styles have been invalidated by a change to the DOM state. This can result in poor performance. Learn more about [forced reflows](https://developer.chrome.com/docs/performance/insights/forced-reflow) and possible mitigations.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "items": [
+                {
+                  "reflowTime": 32.18,
+                  "source": {
+                    "urlProvider": "network",
+                    "line": 16,
+                    "column": 61324,
+                    "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+                    "type": "source-location"
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "label": "Top function call",
+                  "key": "source",
+                  "valueType": "source-location"
+                },
+                {
+                  "granularity": 1,
+                  "valueType": "ms",
+                  "label": "Total reflow time",
+                  "key": "reflowTime"
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "type": "table",
+              "headings": [
+                {
+                  "key": "source",
+                  "label": "Source",
+                  "valueType": "source-location"
+                },
+                {
+                  "key": "reflowTime",
+                  "label": "Total reflow time",
+                  "valueType": "ms",
+                  "granularity": 1
+                }
+              ],
+              "items": [
+                {
+                  "reflowTime": 36.744,
+                  "source": {
+                    "value": "[unattributed]",
+                    "type": "text"
+                  }
+                },
+                {
+                  "source": {
+                    "type": "source-location",
+                    "column": 61343,
+                    "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+                    "line": 15,
+                    "urlProvider": "network"
+                  },
+                  "reflowTime": 32.18
+                },
+                {
+                  "reflowTime": 1.024,
+                  "source": {
+                    "type": "source-location",
+                    "column": 85503,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+                    "line": 19,
+                    "urlProvider": "network"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "dom-size-insight": {
+        "id": "dom-size-insight",
+        "title": "Optimize DOM size",
+        "description": "A large DOM can increase the duration of style calculations and layout reflows, impacting page responsiveness. A large DOM will also increase memory usage. [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/performance/insights/dom-size).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "debugData": {
+            "totalElements": 1360,
+            "type": "debugdata",
+            "maxDepth": 14,
+            "maxChildren": 55
+          },
+          "headings": [
+            {
+              "valueType": "text",
+              "label": "Statistic",
+              "key": "statistic"
+            },
+            {
+              "valueType": "node",
+              "label": "Element",
+              "key": "node"
+            },
+            {
+              "label": "Value",
+              "key": "value",
+              "valueType": "numeric"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "value": {
+                "value": 1360,
+                "granularity": 1,
+                "type": "numeric"
+              },
+              "statistic": "Total elements"
+            },
+            {
+              "value": {
+                "value": 14,
+                "granularity": 1,
+                "type": "numeric"
+              },
+              "statistic": "DOM depth",
+              "node": {
+                "nodeLabel": "div.px_6 \u003e div.d_flex \u003e svg.lucide \u003e circle",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,2,UL,0,LI,0,ARTICLE,1,DIV,1,DIV,2,svg,0,circle",
+                "type": "node",
+                "boundingRect": {
+                  "left": 165,
+                  "bottom": 1806,
+                  "top": 1805,
+                  "width": 1,
+                  "height": 1,
+                  "right": 167
+                },
+                "selector": "div.px_6 \u003e div.d_flex \u003e svg.lucide \u003e circle",
+                "snippet": "\u003ccircle cx=\"12.1\" cy=\"12.1\" r=\"1\"\u003e",
+                "lhId": "page-11-circle"
+              }
+            },
+            {
+              "value": {
+                "value": 55,
+                "granularity": 1,
+                "type": "numeric"
+              },
+              "statistic": "Most children",
+              "node": {
+                "selector": "body",
+                "boundingRect": {
+                  "left": 0,
+                  "width": 412,
+                  "right": 412,
+                  "height": 25905,
+                  "bottom": 25905,
+                  "top": 0
+                },
+                "type": "node",
+                "nodeLabel": "body",
+                "path": "1,HTML,1,BODY",
+                "lhId": "page-10-BODY",
+                "snippet": "\u003cbody\u003e"
+              }
+            }
+          ]
+        },
+        "numericValue": 1360,
+        "numericUnit": "element"
+      },
+      "cls-culprits-insight": {
+        "id": "cls-culprits-insight",
+        "title": "Layout shift culprits",
+        "description": "Layout shifts occur when elements move absent any user interaction. [Investigate the causes of layout shifts](https://developer.chrome.com/docs/performance/insights/cls-culprit), such as elements being added, removed, or their fonts changing as the page loads.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "items": [
+                {
+                  "node": {
+                    "type": "text",
+                    "value": "Total"
+                  },
+                  "score": 0.00213
+                },
+                {
+                  "score": 0.001897,
+                  "node": {
+                    "boundingRect": {
+                      "bottom": 437,
+                      "top": 250,
+                      "width": 380,
+                      "height": 187,
+                      "right": 396,
+                      "left": 16
+                    },
+                    "type": "node",
+                    "selector": "section.pt_32 \u003e div.pb_12 \u003e div.max-w_2xl \u003e h1.ff_display",
+                    "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,1,H1",
+                    "nodeLabel": "Explorez la science du revenu.",
+                    "lhId": "page-5-H1",
+                    "snippet": "\u003ch1 class=\"ff_display fs_5xl fw_bold c_ocobo.dark mb_6\"\u003e"
+                  }
+                },
+                {
+                  "subItems": {
+                    "items": [
+                      {
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      }
+                    ],
+                    "type": "subitems"
+                  },
+                  "score": 0.000233,
+                  "node": {
+                    "nodeLabel": "Articles, interviews et masterclasses pour structurer votre croissance.",
+                    "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,2,P",
+                    "boundingRect": {
+                      "height": 52,
+                      "right": 396,
+                      "width": 380,
+                      "top": 461,
+                      "bottom": 513,
+                      "left": 16
+                    },
+                    "type": "node",
+                    "selector": "section.pt_32 \u003e div.pb_12 \u003e div.max-w_2xl \u003e p.fs_xl",
+                    "snippet": "\u003cp class=\"fs_xl c_gray.600 fw_medium\"\u003e",
+                    "lhId": "page-6-P"
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "valueType": "node",
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "key": "node"
+                },
+                {
+                  "granularity": 0.001,
+                  "label": "Layout shift score",
+                  "valueType": "numeric",
+                  "subItemsHeading": {
+                    "key": "cause",
+                    "valueType": "text"
+                  },
+                  "key": "score"
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "headings": [
+                {
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "key": "node",
+                  "valueType": "node"
+                },
+                {
+                  "key": "score",
+                  "subItemsHeading": {
+                    "key": "cause",
+                    "valueType": "text"
+                  },
+                  "valueType": "numeric",
+                  "label": "Layout shift score",
+                  "granularity": 0.001
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "score": 0,
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  }
+                },
+                {
+                  "score": 0,
+                  "node": {
+                    "selector": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "boundingRect": {
+                      "width": 110,
+                      "right": 380,
+                      "height": 38,
+                      "bottom": 117,
+                      "top": 79,
+                      "left": 270
+                    },
+                    "type": "node",
+                    "path": "0,HTML,1,BODY,1,DIV,0,FORM,1,DIV,1,DIV,0,INPUT",
+                    "nodeLabel": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "lhId": "page-0-INPUT",
+                    "snippet": "\u003cinput type=\"submit\" class=\"hs-button primary large\" value=\"S'inscrire\"\u003e"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "font-display-insight": {
+        "id": "font-display-insight",
+        "title": "Font display",
+        "description": "Consider setting [font-display](https://developer.chrome.com/docs/performance/insights/font-display) to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with [font metric overrides](https://developer.chrome.com/blog/font-fallbacks).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [],
+          "skipSumming": [
+            "wastedMs"
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "label": "Est Savings",
+              "key": "wastedMs",
+              "valueType": "ms"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "mainthread-work-breakdown": {
+        "id": "mainthread-work-breakdown",
+        "title": "Minimize main-thread work",
+        "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to minimize main-thread work](https://developer.chrome.com/docs/lighthouse/performance/mainthread-work-breakdown/)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "3.7 s",
+        "metricSavings": {
+          "TBT": 800
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "Category",
+              "key": "groupLabel",
+              "valueType": "text"
+            },
+            {
+              "valueType": "ms",
+              "granularity": 1,
+              "key": "duration",
+              "label": "Time Spent"
+            }
+          ],
+          "type": "table",
+          "sortedBy": [
+            "duration"
+          ],
+          "items": [
+            {
+              "group": "scriptEvaluation",
+              "duration": 1612.6595999999947,
+              "groupLabel": "Script Evaluation"
+            },
+            {
+              "duration": 658.44840000000011,
+              "group": "scriptParseCompile",
+              "groupLabel": "Script Parsing & Compilation"
+            },
+            {
+              "duration": 499.48800000000011,
+              "group": "styleLayout",
+              "groupLabel": "Style & Layout"
+            },
+            {
+              "group": "other",
+              "duration": 488.09879999999572,
+              "groupLabel": "Other"
+            },
+            {
+              "groupLabel": "Garbage Collection",
+              "group": "garbageCollection",
+              "duration": 248.66640000000007
+            },
+            {
+              "groupLabel": "Parse HTML & CSS",
+              "group": "parseHTML",
+              "duration": 91.213199999999986
+            },
+            {
+              "duration": 70.604400000000069,
+              "group": "paintCompositeRender",
+              "groupLabel": "Rendering"
+            }
+          ]
+        },
+        "numericValue": 3669.1787999999915,
+        "numericUnit": "millisecond"
+      },
+      "unused-javascript": {
+        "id": "unused-javascript",
+        "title": "Reduce unused JavaScript",
+        "description": "Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 391 KiB",
+        "metricSavings": {
+          "LCP": 150,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "metricSavings": {
+              "LCP": 150,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "overallSavingsBytes": 399885,
+          "overallSavingsMs": 150,
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL",
+              "subItemsHeading": {
+                "key": "source",
+                "valueType": "code"
+              }
+            },
+            {
+              "label": "Transfer Size",
+              "subItemsHeading": {
+                "key": "sourceBytes"
+              },
+              "key": "totalBytes",
+              "valueType": "bytes"
+            },
+            {
+              "label": "Est Savings",
+              "subItemsHeading": {
+                "key": "sourceWastedBytes"
+              },
+              "key": "wastedBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "type": "opportunity",
+          "items": [
+            {
+              "totalBytes": 196265,
+              "wastedPercent": 57.372344479375059,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedBytes": 112602
+            },
+            {
+              "wastedBytes": 111385,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "totalBytes": 156544,
+              "wastedPercent": 71.1524204515126
+            },
+            {
+              "wastedPercent": 42.2154629213789,
+              "totalBytes": 196265,
+              "wastedBytes": 82854,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "totalBytes": 156544,
+              "wastedPercent": 43.708986617298805,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedBytes": 68424
+            },
+            {
+              "wastedBytes": 24620,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "totalBytes": 43321,
+              "wastedPercent": 56.831359413007931
+            }
+          ]
+        },
+        "numericValue": 150,
+        "numericUnit": "millisecond"
+      },
+      "max-potential-fid": {
+        "id": "max-potential-fid",
+        "title": "Max Potential First Input Delay",
+        "description": "The maximum potential First Input Delay that your users could experience is the duration of the longest task. [Learn more about the Maximum Potential First Input Delay metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-max-potential-fid/).",
+        "score": 0.54,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "240 ms",
+        "numericValue": 236,
+        "numericUnit": "millisecond"
+      },
+      "unminified-css": {
+        "id": "unminified-css",
+        "title": "Minify CSS",
+        "description": "Minifying CSS files can reduce network payload sizes. [Learn how to minify CSS](https://developer.chrome.com/docs/lighthouse/performance/unminified-css/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "opportunity",
+          "items": [],
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            }
+          },
+          "overallSavingsBytes": 0,
+          "overallSavingsMs": 0,
+          "headings": [],
+          "sortedBy": [
+            "wastedBytes"
+          ]
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "resource-summary": {
+        "id": "resource-summary",
+        "title": "Resources Summary",
+        "description": "Aggregates all network requests and groups them by type",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "headings": [
+            {
+              "key": "label",
+              "label": "Resource Type",
+              "valueType": "text"
+            },
+            {
+              "valueType": "numeric",
+              "label": "Requests",
+              "key": "requestCount"
+            },
+            {
+              "valueType": "bytes",
+              "key": "transferSize",
+              "label": "Transfer Size"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "label": "Total",
+              "resourceType": "total",
+              "transferSize": 10027542,
+              "requestCount": 89
+            },
+            {
+              "resourceType": "image",
+              "label": "Image",
+              "requestCount": 18,
+              "transferSize": 8462734
+            },
+            {
+              "requestCount": 54,
+              "transferSize": 961800,
+              "resourceType": "script",
+              "label": "Script"
+            },
+            {
+              "requestCount": 1,
+              "transferSize": 348931,
+              "resourceType": "document",
+              "label": "Document"
+            },
+            {
+              "requestCount": 5,
+              "transferSize": 212549,
+              "resourceType": "font",
+              "label": "Font"
+            },
+            {
+              "label": "Stylesheet",
+              "resourceType": "stylesheet",
+              "transferSize": 27850,
+              "requestCount": 3
+            },
+            {
+              "transferSize": 13678,
+              "requestCount": 8,
+              "label": "Other",
+              "resourceType": "other"
+            },
+            {
+              "requestCount": 0,
+              "transferSize": 0,
+              "resourceType": "media",
+              "label": "Media"
+            },
+            {
+              "label": "Third-party",
+              "resourceType": "third-party",
+              "transferSize": 9221133,
+              "requestCount": 35
+            }
+          ]
+        }
+      },
+      "long-tasks": {
+        "id": "long-tasks",
+        "title": "Avoid long main-thread tasks",
+        "description": "Lists the longest tasks on the main thread, useful for identifying worst contributors to input delay. [Learn how to avoid long main-thread tasks](https://web.dev/articles/optimize-long-tasks)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "15 long tasks found",
+        "metricSavings": {
+          "TBT": 800
+        },
+        "details": {
+          "items": [
+            {
+              "startTime": 9901,
+              "duration": 236,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "startTime": 18711.241062295929,
+              "duration": 176
+            },
+            {
+              "duration": 174,
+              "startTime": 2747,
+              "url": "https://www.ocobo.co/blog"
+            },
+            {
+              "startTime": 3039,
+              "duration": 173,
+              "url": "Unattributable"
+            },
+            {
+              "startTime": 8247.01974804858,
+              "duration": 161,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "startTime": 11575,
+              "duration": 159
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "startTime": 10243,
+              "duration": 151
+            },
+            {
+              "startTime": 8024.01974804858,
+              "duration": 125,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "duration": 122,
+              "startTime": 5918.8845964999628
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "startTime": 8149.01974804858,
+              "duration": 98
+            },
+            {
+              "url": "Unattributable",
+              "startTime": 2475,
+              "duration": 70
+            },
+            {
+              "startTime": 12013,
+              "duration": 69,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "url": "Unattributable",
+              "startTime": 2401,
+              "duration": 66
+            },
+            {
+              "startTime": 5831.8845964999628,
+              "duration": 60,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "url": "https://www.ocobo.co/blog",
+              "duration": 51,
+              "startTime": 2558
+            }
+          ],
+          "skipSumming": [
+            "startTime"
+          ],
+          "type": "table",
+          "sortedBy": [
+            "duration"
+          ],
+          "debugData": {
+            "tasks": [
+              {
+                "other": 236,
+                "duration": 236,
+                "startTime": 9901,
+                "urlIndex": 0
+              },
+              {
+                "duration": 176,
+                "urlIndex": 1,
+                "other": 176,
+                "scriptEvaluation": 0,
+                "startTime": 18711.2
+              },
+              {
+                "other": 174,
+                "startTime": 2747,
+                "urlIndex": 2,
+                "parseHTML": 0,
+                "duration": 174
+              },
+              {
+                "urlIndex": 3,
+                "duration": 173,
+                "startTime": 3039,
+                "other": 173
+              },
+              {
+                "startTime": 8247,
+                "scriptEvaluation": 0,
+                "other": 161,
+                "urlIndex": 4,
+                "duration": 161
+              },
+              {
+                "startTime": 11575,
+                "other": 159,
+                "scriptEvaluation": 0,
+                "duration": 159,
+                "urlIndex": 1
+              },
+              {
+                "other": 151,
+                "scriptEvaluation": 0,
+                "startTime": 10243,
+                "duration": 151,
+                "urlIndex": 5
+              },
+              {
+                "startTime": 8024,
+                "other": 125,
+                "scriptEvaluation": 0,
+                "duration": 125,
+                "urlIndex": 4
+              },
+              {
+                "other": 122,
+                "urlIndex": 5,
+                "duration": 122,
+                "startTime": 5918.9
+              },
+              {
+                "urlIndex": 4,
+                "duration": 98,
+                "scriptEvaluation": 0,
+                "other": 98,
+                "startTime": 8149
+              },
+              {
+                "other": 70,
+                "duration": 70,
+                "startTime": 2475,
+                "urlIndex": 3
+              },
+              {
+                "other": 69,
+                "duration": 69,
+                "startTime": 12013,
+                "urlIndex": 0
+              },
+              {
+                "startTime": 2401,
+                "other": 66,
+                "scriptEvaluation": 0,
+                "duration": 66,
+                "urlIndex": 3
+              },
+              {
+                "urlIndex": 5,
+                "duration": 60,
+                "startTime": 5831.9,
+                "other": 60
+              },
+              {
+                "duration": 51,
+                "urlIndex": 2,
+                "other": 51,
+                "scriptEvaluation": 0,
+                "startTime": 2558,
+                "styleLayout": 0,
+                "paintCompositeRender": 0
+              }
+            ],
+            "type": "debugdata",
+            "urls": [
+              "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "https://www.ocobo.co/blog",
+              "Unattributable",
+              "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            ]
+          },
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "startTime",
+              "label": "Start Time"
+            },
+            {
+              "key": "duration",
+              "label": "Duration",
+              "granularity": 1,
+              "valueType": "ms"
+            }
+          ]
+        }
+      },
+      "screenshot-thumbnails": {
+        "id": "screenshot-thumbnails",
+        "title": "Screenshot Thumbnails",
+        "description": "This is what the load of your site looked like.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "filmstrip",
+          "items": [
+            {
+              "timing": 781,
+              "timestamp": 76075660,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k="
+            },
+            {
+              "timestamp": 76856785,
+              "timing": 1562,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k="
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 77637910,
+              "timing": 2343
+            },
+            {
+              "timestamp": 78419035,
+              "timing": 3125,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k="
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAMEBQYHCAIBCf/EAFkQAAEDAwIDAwUIDQgHBQkAAAEAAgMEBREGEgchMRNBURQiYXGRCBUjMlJygZQWMzQ3RVVzk6Gxs8HRNkJ1ktLT4eIYNURGU2KyFyR0ouMnVFZmgoOVpcL/xAAYAQEBAQEBAAAAAAAAAAAAAAAAAQIDBP/EAC4RAQABAgQDBgUFAAAAAAAAAAABAhEDEiExBAVBFDIzNHGhEyIkUfBCYZHB0f/aAAwDAQACEQMRAD8A6pREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERBHU/c0vzD+pauW0an7nl+Yf1LWHZv+Q72INpoiICL45wa0ucQGgZJPQLHotcaVmuHkMWorS+rztETaphJPh16+hBkSISAMk8vFY6dcaWbX+RHUVpFXnb2XlbN2fDr19CDIkQEEAg5B71arzqG12V7G3Wq8kY/GJpY3CIeuTG0fSUF1RYFxrqv/ZJf6mjn5Gna5ksT+oLm8wQrsdX6es1JQU13vluo6p0Mfwc9Q1rubRzIJ5IMnRR01RDVQMnppY5oZBuZJG4Oa4eII6qy3fWOm7PVilut9tlJU5x2U1Sxrh6wTy+lBfkUVJUwVlOyopJo54JBlkkbg5rh4gjqpUBERAREQEREBERAREQERfHu2tJQC4N6kBfBIw9HBWu5XGkt8BqLjVQ00OQ3tJnhjcnoMlUFHqWx1tSyno7xb56iQ4ZHHUMc53qAKDJUUFO8nzT9CnQEREBERBrfjhPM+z2O0NmfT0l4usFDVyMO09i4kubnuzjCyOr0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3p6qs1dp2h1VYp7Xc2u7GTDmvYcPieObXtPcQVh8ui9Z1NEbZVa8e62ub2b3st7G1LmdCO03dcd+MoMEN9uU/A+joXVspZJeBZHV7XYc+m7Ut359LRtytuM0DpVtj96RYrf5Fs2YMLd3TGd3Xd6c5XubRNkl0SNKmmItLYhE1oPnNIOQ8H5W7nnxWNN0TrRlJ73N1/L72hvZhxt7DU7OmO1z1x34ygs3EGqqdCcFDT6dvE1WY5W0bK5zw58MbnkEbh3tHmg9Qti6f05bLfpxlujiFRTzQhs75j2jqjI5ueT8YnKjt2jbJRaPbpkUjZrT2ZjfHN5xkyclzj8onnnxVK7T10tllFn0xXtpqbZ2bKite6okp29MMbyzju3OOEGlaeeWn4RcULA2V81us1c+no3uOdsfaDzM+jH6VufROlLNR6TpIzS01c6rp2SVNTMwSOqnOaCXOJ6g55DuCt44Z0FPw1rtJUFTJH5aC6eskbvfJIXAl7hyznGEj0dqO00nkGl9Ux0VtDdscNVQiodTjvEbtw5eAdnCDFNP1c2kP8AtRtVkJdQWeLyyhi+MIHvic9zB6ARnCynhZpKxw6GttS+jpa6quNO2pq6qeNsj53yDc7JI5jJ6K9aL0dR6Zs9VSGWSvqa6R01dVVABfUvd1LvRjkAsdotBah0+ySi0hq3yGzlznRUlXRNqTT5OSGOJBx4A5QQcPoY7BxP1Zpu1jZZmQwV0cAOW08j8hzW+APXC2gsZ0RpGDS8NZI+rnuF0rpO2rK6f48zu4YHINA5ADosmQEREBERAREQEREBERAXicZiK9oeaDHdRipNtPkQrjNuH3F2PaY/+75uP0qxWVt399IPKhqLscnd5UKHs+h+N2fn+xZs+Eg+bzC8iJ5PxUH2AfCBVS8RRhg9K9oCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIsdrqy4M1AIYnubSgsyDHkYOM88LFdcUREy64WFOLMxE7RdkSLH7bVVtRcK2GWaRoaXiIGMAAZ5HOP3qnoK67S01ZI8OL4YwGtMYG52evTnyWPjx9p6+zp2WrXWNLe7KEWM22vuctBXvl3l0cW6Nxjwd2OYAxzSOqu7LLJPO/4Vzm9mdgJDT1yAP3KRjxMXtKzwtUTMZo3iP5ZMitFDU1clgknlL/KQx5aSwA5GcclSU1fXSNtOTJmRz2z5jxnGMd3Ja+NGmm7EcPVMzF40/yZ/pkSLGKK4XJ94qIZTJ2DTJszEMcs454UdBcrn73VktQ57pAwdkOywQScZ6YWY4in7T19nSeEqiN46e/5qytFjBuFyFkmcTJ5ZFKG7uzGSPVjCVNXdWWeCoZKXTh7mSAR9fA4x3J2iPtO107JVtmje35+zJ0UVK2RlNG2d/aShvnOwBk/QpV3h5p0EREQREQEREBERAREQEREBERAREQEREBEUUlTBG4tkmjY4dznAFBKig8spv8A3iH+uFM1wc0OaQWnmCD1QfUREBEWHcROItl0CKA31tW7y3tOy8njD/ibc5yRj4wQZiixbh9rm068t1TW2NtU2Gnl7F/lEYYd2AeWCeWCspQEREBERAREQEREBERAREQEREBERAREQEREBERAXFnumfvvXT8jB+yau01xZ7pn7710/IwfsmoMTtOg9S3ejp6q3Wx08NR9qLZowXc8cgXZ6rdcXGa58N7bbNL3rR7hV0NHCzc6v27xsGDjsz6R1PMFas0jrLS1gjtk82h21t3ontmFcbrNHvka7c13ZgFoxgcunJZl7pe/2y/Q6RqYqYRXie3sq59r93Zxyta5kZOOZB3HPL9KI2BrD3QtHY6m3x2+y++Lamiiq3u8s7PsjIM7CNjskDHP0qgvHuiau0PpY67R4jkqKdlS1puPMMfzbn4LvGD9K5to2Nt94oH3ilkfSh0U0kR5GSE4dyPpb0WwPdGVVLW8RRVW9zH0c1BTSQuYMAsLMjH0INs1nukrZT0Vrkjssk9RURukqoo6kYpjuIDdxb5xIGe7GQsF90PrS1a50/pG52dzw1r6uOWGUYfE/EJwf4hYFR3zT9JoGe1Vmlmy3ycl8N0dMWkNLuRA9GCMDke9Y1NRVMdmpa2QOFJNPLHGT0LmNYXY/rNQb/8Ac86utWi+GN+ul7mcyEXEMjjYMvlf2TcNaPHl6lXu907SeV7W6YnNLn45rAH48duzGfpWipKWqfw1p6mMONHFdpWS46B7oY9mfoa9XWK96MHC19rksU51aZCRX5G3G/IOd2fi+btx6UHR2oOOFppNA0up7JROuLZKxtFLSyTdhJA4se/zvNd8nu5HPXksSZ7peCS0Vs50+Ia6N0baeA1heJd27cSdgwGho8clwWiKWlqm8N7lVFrhRPutLG0kcnPENQTj1Aj2hbT9ytp6z3+r1I292ykrxCynMYqIg/ZkyZxnpnA9iDZE3Hq0UGirTdrnRSG6XBj3soKd+7a1r3N3OccYBLfAn2LHKD3TlE+pa2u01UQwE83xVYkcB80tb+ta290lZGWTiL2NJSR0ltfSROpY4mbWBvMOAA5fG3H6fSrHdLro2ehtbBbKx8sTPhxSsZSYOByLnGUyc+87f3IOkeIXGuh0zaNPXS024XiivDJXxv8AKOx2dmWAgjY7nlxBHLGFhH+lAf8A4SH/AOR/9JY5eafQUvCyw1FzdfLeY31MlBb2TxyTTh5YHPJLMNZuj5HA7+q1lpCt05QXs1eorbW3CijO6Kkjma0O58hI7HMegAZ/Qg7h4d6m+zHRtuvxpPI/LA89h2nabNr3M+NgZztz071kas2ja6luek7RXW+kbR0lTSxyxU7QAImuaCG8uXJXlFEREBERAREQEREBERAREQEREBa91hwh0rq2/TXe8RVbqyZrWuMc5Y3DQAOXqC2EiDUf+j5oX/gXD60f4KoruBGjK6cS1TLlJII2RAmqPJrGhrR07mtA+hbURBrrUfBvSGoKikmrqWpa6mpo6SMQzFg7Ngw3Picd65h476fo9L68NotjpzR09LEIxNJvc0EE4z4c13GqGss1srZjNWW6iqJiMF8sDXux6yEGlOFPDnTetOFul6vUFG+aambOxrmSOj3NMzjh2OZGc+0rP9TcKtK6itlqt9XRPgorYHimipZOzDd+3dnx+KOfrWa0tNBSQNhpYYoIW/FjjYGtHqAUqDDdN8NdM6f0/XWSmojUW2tk7SeGqd2occAd/ToFjh4B6CNT2vvfVBuc9kKt+31dc/pW1UQYdqDhvpq96YpNPz0RprVSzCeKGld2eHhrm5J7+Tj1X3QPDuw6EkrX2COoY6sDBL20pfnbnGPD4xWYIgsWrtI2PV9A2k1BQR1cbDljiS18Z8WuGCP3rCqDgPoOkqmzm2z1G07gyepe5n0jIz6itpIgwTWXCnS+rqmjmutNMw0kApoWU0nZMZGCSAAB6Vj3+j5oX/gXD60f4LbiIKKx2umstnorZQhwpaSFsEQeckNaMDJ71WoiAiIgIiICIiAiIgIiICIiAiIgLQ/FfjddNFa2q7JSWmiqYYGRuEkr3Bx3MDu71rfC4s90z9966fkYP2TUHWPDy/zap0Xar1UwxwTVkRkdHGSWt84jln1LIlybLxfuOj+HelbFpxkArfIu1qKiVu/s9z3bWtb0zjnk56hUFfx41sNO0cBk8kuYlLzW+TR4qIiOQ2ubgEHvb1H6Q7BRaW9zZrjUGtINQO1JXCrdSugEOIY49u4SZ+I0Z+KOqh90PxRu+iqugtOn2xw1VTAZ31UkYftbuLQGg8s8jnIPcg3ei4vtfFfijOx9bR11ZWU0bsSOFAySMHrgkM5dVnOquOt9otDafdSxUsV/uMUk083Z+bE1sjmDawk8ztPXIGOiDpda441a+ueg7VRVFpsxuDql7mumeHGOHGMbtvPJyccx0K5ybxg4l0TYa6ouVQaaU5Y6eijEUnoB2D9BWb6r416grOG9kvFmmit1xfWS0la1kLJGPLWNcCA8HAIcCg2dwR4h3bXtLcX3ezii8lLAyeMOEcuc5A3d4wO89Vs9c08PeNF5ptC6mvWpp23Kekmp4KKERRwgvkEhwdjRy83J9SwqfjrxDrZ5amkqYYadnN0cNExzGD0lwJ/Sg7LRcw0PHi93Th9qAO7Cj1HQxwzU9VDGCyRhmjY/LHZAOH+rn3YVn0Nxl4hXCuuELS69ziikfDA2niYI3At+FcWtBIaN3LPMkIOtkXJPDjjxqOm1FTQ6prGV1qlJbIXQsa+PlyLS0DvxyOVb7vxv17qC7yNsErqSEkmKkpKZsrw30ktJJ8eg9CDsZFyvwu446l+yygtGq3x1lLVTtpnPdC2OWFzjtB80AEZxkEZUeu/dAaiqr7UUekWw0dHHKY4pOxEss2DjOHZAB7hj6UHViLk7R/ugNT269QU+rWRVlE54ZMTAIZowf5w24HLrgjn6F1gxzXsa9hy1wyD4hB9REQEREBERAREQEREBERAXFnumfvvXT8jB+yau01bq2w2iuqHT1tqoKmd2AZJqdj3HHTmRlBw1rHTdfR2DTl8MEj7dXULAJg0lrJGlzSwnuOAD6c+hT601VqvVumrXUX5rXWqkkNPTzNgbGHybefMdSABnHILudlBSMohRspYG0gG0QCMBgHht6KnmslqnpYqae2UMlNESY4nwMLGE9cAjARGgfcc/cuq/n036pV9901qE27U1uoblYaK62d9G2Rrp2PY9ku94cGSsIIOAzI5jpyXQNutdvtgkFuoaWkEmN/YQtj3Y6ZwOfUqonhiqIzHPEyWM9WvaHA/QUV+fkl/fSXcVOkW19kaQAIoq10ji75wDSR05HKzfizZ9U3HTeltUX+jnMklCaaok7LaWFsryxzwPilzXA5XX1LYbRSTiaktVBBMOkkVOxrvaAri5oc0tcAWnkQe9Es4RqOKOq6iwWyy+XRijoA1sAbTs3Ya3a0Ekc8Dksk4ju1HNwl01Vasc/wApqLhM+nY+FsTmw9m0DIaB1IJ588ELruCx2mnqO3p7XQxT5z2jKdjXe0DKluFsobkxjLjRU1W1hy0TxNkDT6Mjkg4s0Rpqv1Nwr1XHaoX1FTRVtJV9iwZc9oZM0gDvOHZx6Fj2n9W1dgs1wtbKOKUVDjnt5JQIzjB+DDwxx5fzmn9y70t1roLaJBbqGlpBJjeIImx7sdM4HPqVFUWS1VNR29TbKGafr2klOxzvaRlBx5QyXy5cKtU19VabbS2iOGCNlVFb44JJZDUxcmuaBkAA57uiqfcy/wAt7v8A0NUf9Ua7DqaKlqqQ0tVTQTUxABhkjDmHByPNPLlgKlorHaaGV0lDa6Gmkc0sLoadjCWnqCQOnoQfn1p62vvF/ttthIElZUx07Se4vcGj9avenr5qPhpqeolpYzQ3RjHU8sVTCDlpIJGD6Wg5Hgu5oNN2OCaOaCzW2OWNwcx7KVgc0joQQORVVX2yguAaK+ipaoN6dtE1+PaEHInCrUmuNUcQKVlFVukjnqhPXSCmj2Mj3ZeSdvLIyB+hYbdLddeHGui2upJBNSSuMe58kbZ4zkBzXsLXYIPUH0HvC7ypKSno4hFSU8UEY/mRMDR7AvNdQUlfGI66lgqYxzDZow8ewoOKdNag1BqfWLY7LYrRU1NVI3zJaBtSIxyG50km5+B1Jc5duQtLImNdjIaAdowPoUFDQUdBGWUNJT0zD1bDGGD2AKpRRERAREQEREBERAREQEREBERxDQS4gAdSUBFqD3S17q7dw5gq7Fc56Wb3xjjM1HOWOxskJaXNPoHJYP7l7VV0uN+vY1Bfa2qgZTMLBW1bnta4v7txwDhB0uip4q+kla90VVA9sY3PLZAQ0eJ8F8huFFPII4aunkkd0ayRpJ+jKCpRRVFRBTMDqiaOJpOAZHBoJ+lU77tbo6eSd9fSNgjxvkMzQ1uemTnAQVqKGCqp6imbUU88UtO4bmyseHNI8QRyXyGtpZ37IamGR3gyQE/oQToqeeupKeTZUVUET8Z2vkDT7CvpraVtOJzUwiAnAkLxtJ9fRBOigp6ymqS4U1RDMW8yI3h2PYvhrqRsvZuqoBJ02GQZ9iCoRR1FRDTsD6iaOJhOA57g0Z+lRMuFHJHI9lXTuZG3c9wkBDR4nnyCCpRUsNxoZ6Y1ENZTSU7esrZWlo+nOF6gr6SofsgqoJX4ztZIHHH0IKhFSMudA97WMraVz3HAAlaST4dVVoCIiAiIgIiICIiAiIgIiIC5V91PrG5SaqbpqmqJYLdTQskljY4t7aRwz52OoAxgeOV1UtHcfeEVbrG4Q3zTjoTcmxiGenldsErRna4O6bhnHPux4INDXzSOqNP8NqG51lTB9j93minZTsm3OD9jixxbjAJaT0PrWL0n8m7l/wCJp/8AplWzJeC/EOfTOKqGaR1NOI6a2mrY4BhBLpBl+1ozgYHM5PgqrTPBDV1TYr9SXO3NoahzIpaQyzxubJIxxy07XHGWudzPfhEUPBH+R/E7+g3/APTIrT7nf78mnfnT/sJFlGkOEPEWho9QwBhtlPU0MkT4myxSGtOCWxDmdoJ6uJHIlV3BfhbrLT3Eyy3S8WV1NQU5lMspqInbcwvaOTXk9SB0QZt7rv8AkFaf6Tb+ykWkeFOg71r+hvVBaLjTUlLA+nlqGT7sSO+EDDyB6ef7V0V7o/Sl61dpC3UWnaI1lTFXNmewSMZhnZvGcuIHUhWb3M+iNQ6OfqI6ktzqIVQp+xzLG/ft7Td8VxxjcOvig0pxVrL3psUGg57gfJLRA0Ssp3Fsc0khMm49CcB7Rz6YKsztF6it8tBPbO1qJ5vPY+jbK0xOGDze5rW59LSfWt+8fOD9x1bd2X/Tbon1zo2xVFNI7Z2m3kHNceWcYGDjoFqxnBviZeJqanudNIyGECON9XXMeyJvoAc4gegBBU8ZrNfp9EaU1FqelfFd2B9uq3uc1xkAJdE920kZI3Z9Swyv1e+p4WWvS2TmluEtQ75haNg/rPk9gXTt14Wtg4IVGkaF5qq+OM1Echw3tKgO38s8gD8X1Fc8M4JcQXPaDp5zQTgk1UHL/wA6D3TVVy0bwjpqq3zSUlVqarkDpojtf5NAANoPUZe89O4LGaDSl0uVideKR4nw7AhYyV8p54zkMLRz8XArqviNwmi1Fw5tFitc0dPW2eNopXvHmPw3Dmu8N2Ac+IWhxwe4nR0z7Wyhm973P3ujbXxiFzvlFu/9yCHUX2XU3B8UOqIKkW+O5wPopKiQOc34KYOZ1Jx0Iz05q0cPbJcbzpjWhoro6hpaOgFXUxNZnykM3EMJyMDkT393JbDuXAvUNu4bmGlhbcdQVVfDLLBDK1rIYWMlGA55AJy8Z+jHiq/hXw11bZNM68pbpaHQT3K1Op6Rhnid2sha8bchxA6jrgINAUVzqqOir6WCZ7aetjEU0YPmvAe14yPQWhbP9y/98mb+jZ//AOVHp3gXrSrurILraTRUr45Qah9RE5rH9m7ZkNcTjftHId6vGgeD/ES06qD48WaIxvilrmSxS5jIwWtbkkk92QMdchBrHhx98PS/9K0v7Zq79dWUzaoUzqmEVBGREXjefo6rkDRPB/XVu1nYK6tsL4qWmuFPNK/ymE7WNkaXHAfk4APRV934McQKjiBPVRkSMkqzM26mpaNo3ZDiM7gQO4D1IOt0XxgLWNDjkgYJ8V9RRERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEWD661O+03OCGnrIYPJYvLaiN7mgzs3hvZjPeW9oeXe0IM4RYbqLU9dHS3f3mpYnso6RtR5W+bA89pc3a3ac9P1KaDUVSLhLQspzPcH1IibG+YCJmIGSOIcGZ2+d4EknuHQMsRYRUarqLdcK419OYyWUkcVLJI0NjkeZdxLwDywzOefIdF7m1wWU0UjaOIZkkjfLLOWQAsDSAJNn84O5ZAHI56JYZoijppRPTRSgYEjQ7GQcZHiORWJRanqvKZqSjoXVczXVchdNOGBrYpizAw32cvWe9BmKLB36ymgmq6qWGM0DoKN9KwybXbpt2N3m8hy58zjbyzlVMOr5ql1NBR29k1XNUvp8CfEXmx9puDy3JGD4deSWGXosPr9Wh9re6KCWOobBNJUCOQbqcxvDCMkEEl2ccuYBK9N1pFJdX0sNM18bap1GCJT2heOW7btwGbhjOc9+MIMuRYazXdPI4Mio5HPdRsnaN45yuc1vY/OBe32qvsepXXK7TUUlNFTuYZBsdP8MNrsZdGQOR6gguCDI0WKXfWUNvu9TRtgbI2kMYmPaEPJeAcMbg7sNIJyR15Kt0vcq2tprnLXti+ArJoo+zdnzGuwAeQQX5FhMOsq+SjjnFlaBLQm4sBqx9qbjcD5vJ3MYHMc+oVVU6xZDXQRCngMMskEePKR23wu3DuzAOGguA5kHr6MhliLB63WNVJbr15NTQU9XSU88sbJZ/hWGPkC+Mtzz6jG4dxIypX62bBWuppqaNzoHRR1G2Ul294aTsbt84AOBJOO/A5IMzRYrDqernfGyG2M3VFXLSU2+owHmMvD3uw07R5hx1JyFA/UVbS3GvfWQNhEVLTu8nmnYxkb3SyNLjJ4YaD44xyzyQZiiwp2uCKZrxRwgiokp5JnzkU7S1rXA9ps/nBwxkAcjzVX9lh9+IKN1LFGyVsRa+WoDTJvGcx8trwM4OHZ64B7wypFhlDrqKskzDRuljkbM6FsTy+V2wEgObjDdwacczzwD1V30tfvfyKZxZTsdHtJEM/aYyOjgQ1zSMdCPVlBfEWKN1a+NjKmtoOxt8k1RAyVsu5+6IPJJbjkCI3Y5nu8UfqyambD5fbhC6oijmgDJt+WukYwh3IYcO0acDI680GVosZuWp5Ke4y0NJQeUVLaqOlaDLsBL4jJknBwBjCyVhcWNLwGuxzAOcFB9REQFR09tpoKqtqGsLpaxzTKXHOcNDQB4DHd6SqxYzcNST0eo2299LDHA50bGSzyOj7Uu+Qdu04PLBcCfDpkKql0vbaa21VBGyU09TA2neHSEnY0ENAPdgFfPsYocbhJVCp7UTCoEpEgeIxHnPpaACOhVlseo7zN5HTTUlNPPO+qkfJ25aGRRTBnTZzPnYA9HM81Vz6xbBarfWvoyfK6B1YGCTmHB0TQzOO8yjn3YVRXt0rbWseGtmD3CLEnane10ZcWuB67svdk9+eaSaZpnwtZ5XcGvy/fKKh26QPxuDu7HIdAMY5YVBXXW+xXK0U8tJSwCas7KQsqN7ZGdi93LzcggtPUDmBzwTjxV6yNPZqGv8iDvKaCat2dp8Xs2tO3OOed3X0IMgtltbb5HtgkeKURRxRQFxLYgwEcsnv5exQ0tgoaaqkqImvEsjZmuJd3Sydo//AMysFw1jWUFQ+mmtsbqqGAVE0cckj8hxdtYwiM5dhp64GcDPhebJd6m6XCvYKNkVFTSdiJXSHtHP2td8THIYf49QorwdK27a1o7drWwQwANlIwIjmNw/5h4qopbDSwT085fUTVEMr5hJLKXEuc3Yc92McsDAVpqtYNpo5e0pCZ6Z1SamJr+cbIRncOXPdujx0+P6FSag1HeKSklp/Jaanr8QTRuZOXsMb5mscCSzkRkDp0OR0wiL9Jpq2vfdXmFwdcw1tSQ48wBgY8O88u8r0ywUjK/ymN9QxpmNQYGykRGQ9Xbf046Z54yrFU6wq4GzPfboQzy51vhd2znbpG7i5xAYSG7Wk8snl071d7dqAT6fq7nVU74RSCQyNAd5wYM5buAJBHTICD5DpO0xSskZA4OZWurx55+2u6/R05dOQ8FPR6fpKa4srBJUyyRl5hbLKXti3nztoPj6c4HIK11OobvTUlNJLaKffVyQsgDavLcyZ5OO3IIwM4BByvbNSVYf20tDC2hZWMoZHtnJeJC4MJDduC0PdjqDjnjuQXKtsFJV1klS59TE6UtMzIpSxsu34u4D2csZAweSqKC1wUJrOwMm2qldM9jnZAc7423wz1WJUWsJ46e1h9M1tPPCx5qKuct3lzy0tDwzbuAAPMtzkYVfBqyY3Otpqmkgg7ETFjJZzHI4R9HYc0NLXAZy1xwOvegusenaCOnigayTs46J1A3zz9qOMj1+aOapfsStwky19U2Lto6jsRMQwyR7Q1xHf8RvLpy6K0x62qDFVf8AcaeaaMUxj7Gd2yQTSmPG5zB0I6gEFVkWpa6SrNuFBTi6CpdAW+UHsg1sbZC/dsz0e0Yx1VFY7SlvkdN5Q+qnZJFLC1ksxcI2SfHDe8Z+nHcvbNM0bZA8TVgyWOlAnIEzmABrn46nAGcYzgZyrNW60qKWpkgdaz21NEySpiD3PdudnzIyxhDjgZ5lucgcueM0a7c0OGcEZ5qKtUun6J9HFA3tojFO+piljeQ+OR7nOcQfTvcMdMFUr9JW1zOXlDZR2ZEolJeHMe54dk9+57ic+KyBEGPs0rRxtd2NVcI5XyumfK2oO57nNa12e7BDR6u7C+t0pbmmBrHVLaWHsttMJj2RMWNhI9GB68c8q/ogskOmqGFzgx9UINsjWQCdwjj353bQOnU48O7CqLRZae2TTTslqJ6iVrY3zTyb3Frc7W+oZPtVzRBjFl0nBTMLrg99S/t6iVsTpC6Fnavechp79rsH1nHVTDSNtMEkUjqqUOhEEbpJ3OdCwEOAYe7Ba056+aPBZCiCyUemaGmqRUbqmao7cVJkllLnOeGFgJ/+knl0V7REBERAVpq7BQ1deaqYTFznskfGJnCN7mEFrizOCRgeweCuyILXQ2Ggoao1FPG8SfC43SOcGiRwc8AE4AJaDj1+KpKfSNngaWiCWRnYPpmslne9rInEEsaCcAZaOnTCv6ILM3TdvaY3kVDpo5mztmfUPc/c1paPOJzja5wx05nxVONHWfY5joZ3xmKSBrH1EhayOT4zWjOGj1LIUQWu5WKhuEzpZ2yte+MRSGKZ0faMBJDXbSMjmevifFVdDQ09Cag00ezt5O1k5k5dtDc+jk0KpRBbXWO3Prq6rfSsdPWxCCoLskSMAxgjp0OD44HgFSnS1rdT1EUjJ5O2YyNz5Kh7nhrHbmhricgA8+Xer4iC1GwW80jqcRyBpnNVvErg8Snq8OzkHr7SqmjtlLSUUlLGxz4ZC4ydq4yGQu+NuLsk5VYiCywaYtkL4nCOZ7onMdGZJ3vLNmS0DJ5AZPJSP09b31/lZjk3mUTmPtXdmZBjDyzO3dyHPHdlXZEFhOk7SY44hHO2BkbYjC2d4ZI1pJAcM+dgk9fFfZdK2qZ8xnimlZIJB2T53ljO0BD9rc4Gcnp4nCvqILJHpe2tkfJI2omlf2W581Q95PZv3sHM9A7mpqmwUFRLLM6ORk8k3bmWOVzHh+wMyCDy80AY6FXVEFkdpa1FjWNiljZsEb2xzvaJWgkgPwfO5k9fEq7QU7IHyuYZD2rtxDnlwHIDDQT5o5dByUqICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAvJD88i3HqXpEHnD/lN9iYf8pvsXpEHnD/lN9iYf8pvsXpEHnD/AJTfYmH/ACm+xekQecP+U32Jh/ym+xekQecP+U32Jh/ym+xekQecP+U32Jh/ym+xekQecP8AlN9iYf8AKb7F6RB5w/5TfYmH/Kb7F6RB5w/5TfYmH/Kb7F6RB5w/5TfYmH/Kb7F6RB5w/wCU32Jh/wApvsXpEHnD/lN9iYf8pvsXpEHnD/lN9iYf8pvsXpEHnD/lN9iYf8pvsXpEBERARFzV7pjiXcKS6HSliqX0rI42vrZonbXuLhkRgjoMYJx1zj1h0JUX20U0roqm60EMreRZJUMaR9BKi+yWxfjq2fWo/wCK4AtFlud7fMLXRT1j4huk7Ju4tHPmfYVQOY5riHNII7sIj9EoL/Z55GxwXa3ySOOA1lSwk/QCrkvzaIIwSCF0D7mviXcGX6DSl6qX1NHVAikkldl0LwM7Mn+aQDgdxxjqg6kVJW3OgoCBXVtLTE8wJpWsz7SoLnPI+rp7fTPMcs7XSSSAc4424Bx3biXAD6T3I6G1WOjmqnsp6WFg3Szv6nuy5x5k9OZKK8fZHY/xzbfrTP4p9kdj/HNt+tM/iqyiqqSupo6ijlimgkzsewgg4OCvsVRSzSzRxSRPfC4MkaCCWEgEA/QQfpQUX2R2P8c2360z+KfZHY/xzbfrTP4q5fB4J8zl1UVPU0tR2nYSxSdm8xP2kHa4dWn0oKL7I7H+Obb9aZ/FPsjsf45tv1pn8VcyGDqGqF1RA2pZAc9o9jpAQwluAQDl2MA8xyJyfoKCi+yOx/jm2/WmfxT7I7H+Obb9aZ/FXPDP+VfPg8A+ZgoLb9kdj/HNt+tM/ig1HZCcC8W3P/imfxVz+D/5fFQOqKTytlI6SHyiSN0jYiRucwEAkDwBI9qCeKRksbZIntexwyHNOQR616VorLeygjlrbTC2KdgL3wx+aycdSCOm49zuufRkK508zKiCOaJ26ORoe0+IIyEEiIiAiIgIiICIiAiIgIiIC4t90tZ6m28U6+qmY4U9wZHPC/ucAwNI9YLf1eK7SWOa50ZZtbWj3vvlP2jWndFKw7ZIXeLT+7oe9BwbY7q+01NRNHEyQzU0tOQ7oA9haT9GVl7+JdRLWCaotcEsZad0bpn/ABu1jlG05y1gdE3DByALvFbYqvcwwumcaXVUkcWfNbJQh7gPSRIM+xRf6L//AM2//rv/AFURpfWesptUUVvp56RsJpC8hwkJyHY5AYAHTrzPp7leeANlqbzxTspp2u7Kjl8rmeByY1nMZ9ZwPpW0oPcwxiVpn1W98eebWUAaSPQTIf1Lc/D/AEJZNC2x1JZIHb5MGaolO6SUjxPh4AckF0qCafUlNK8fBVMDoA7we07gPpBf/VXvUlpjvtkqrbNI+KOoAa57OoAIPL2KtqqeKqgdDO3dG7qM4I8CCOYI6gjorcaO7xAMpbnTuYOhqqUyPx4Za9gPsRVjuugLfW1FO6CeakiijbGGxgF7cPc/cx5y5rnFx3HPnDqqGj4a09NGMVsbn9r2mPIo+yHwbGEiPoHYjBDu4l3ccLKOwv8A+MbX9Qk/vk7C/wD4xtf1CT++QYpUcM4Z6S6QPubj5fNHO7NO0Na9hfg7WkAkh/PuO0cu5eqnhnSyxvZFWtiBrBWNcKVm4O24OcYDu8jIIGehWU9hf/xja/qEn98nYX/8Y2v6hJ/fILLq3Q0eoq6ad9xmpo5ogySNkbXZIjlYHAnmOUzuXoCp6zhzRzmMRVboo4pJHxw9i10Q3uicWlh5FuYun/MSsi7C/wD4xtf1CT++TsL/APjG1/UJP75BhdFwxMtopaW4XOeLbHtljgA5u7OWIODuRHmydOnJVrOGFs976OkmnfM2lJLO0ZuAJmZKcZJwDs29ejisn7C//jG1/UJP75Owv/4xtf1CT++QYieFNv8AKnzCvqgHRPiDP5rWnIDQM4DQDjbjuz6FeLdoejt97oLjTysDqQ1IawwNIDJpO0DGn+aGnkMdxI71duwv/wCMbX9Qk/vk7C//AIxtf1CT++QV9yqmUdDPUSAkMaSGgZLj3NA7yTgAelRWKkdb7Jb6N5y+np44ifEtaB+5eKe3ymds9xqfKpWc2NazZGw+IbknPpJPoxzVxQEREBERAREQEREBERAREQEREBEymUBF8ymUH1F8ymUH1F8ymUH1F8ymUH1F8ymUH1F8ymUH1F8ymUH1F8ymUH1F8ymUH1F8ymUH1F8ymUH1F8yvuUBEyiAiIgZUNVUw0lPJUVMrIYI2lz5Hu2taB1JKkJXNPul9Z1E97ZpailLKOnY2WqDT9skPNrT6AMH1n0IM11Dx809QVD4bVSVVzLTgyNIijPqJyT7FZm+6IhP+7Un10f2FzpGqhiI6Hb7oSE/7uSfXB/YXtvugIT/u7J9cH9hc+xqZhx1Qb/bx8iP+7z/rg/sKQceIj/u+/wCtj+wtACQDoMqVsp8AraUzN+jjpEfwA/62P7CkHHCI/gF/1of2FoVkxHUBVUUrT15JlkzN5jjZGfwE/wCtD+wpG8aIz+A3/Wh/YWlGdynYorc7eMkZ/Aj/AKz/AJVI3jBGfwK76z/lWm2KTtWsdtO4nGcNaSg3IOLkZ/AzvrP+VIuLkMjntbaH5Ydrvh+/APyfStQsnb8mT82f4Kel5ukdggOdkZGO4INvN4qMP4Id9Y/yr23igw/gp35//KtVs6KdiDaLeJjD+C3fn/8AKvY4ksP4Md+f/wAq1lGqhiDZI4iNP4Nd+e/yr23iC0/g5357/KtdMU8aDYTdetP4PP57/Bexrlp/2A/nf8FgLFUMQZ0NatP+wn87/gpG6xaf9iP53/Ba5vVLVVtrlp6GsdR1Dx5szWgke1XSna5sTWveXuAALiMZPigzVurWn/Yz+c/wUjdUtP8Ash/Of4LEI1OxBlsWpWOfiSmc1ni1+T7MBXqkqoauLtIHhze/xHrWv2KX30faJqeoB+DdIGSjxaf4dUSassXlsIFfcrw0gjI5heso0jcVxdxuJdxZ1Bn/AIkf7Ni7NeVxjxr58WNQflGfs2KDD41UMVPGqhiqJ2uDQvocT1UIOSpGLcQzMlRUtp48uI3HoPFWyorZj0e4Z58jhVNREJ6wbhlrApvIIX83N/SudVetm6MO8XUdPe5Y/NkaH+vksioKmOqhEkR5dCO8FWp9BA1p2sHgpLAOxnmhB834wVorvNkrw7RdkUEhYfEeCrxKxrA572taTjJOOatrFVUrgHBrsEHx8V0qpvq50z0V7Jov+Iz+sFJA5r6h5a4OG1vQ+krywDwCqIxjouboqGKdigYp2IKhnRTsUDOinYgnjX2pn7CLcG7nE4aM4ycE/uK+RqSSJk0ZZIMtPpwg9PbO2Jzu2GQCcNaB+vKnhpchpllme8DmQ8tBPqHJQuhldGWCbkRg7m5/VhTw+VMa0ERSEDBdktz9GCgqewjLTu3EY6F5x+taUn1bWwa7MULhHRtqfJ3RsaG5G7aXZ65zz/Qt1NfMG84QfQ1/8QFrt/DuWfVvvphzIO1Exidt5vHPOQTyzzx9HpQWPiFquroNSQx2ssgELWvf5gJc7wyeeOX6fUt2aarjcrHR1hBHbRh+CcnBGRla41fw+l1DeYKqESUzA0MkyGnc0Huw7rzP0erns+0UbLfb4KWIAMiaGgDoPQguManYoI1OxBO1W7U/+rW/PH6iri1UGpBm3s+eP1FceIxowMKrFq2hJw5xfkjq2bSu+Aj+aP1KfKpKU/Ax/NCqMrrGsNIZDyXGfGnnxW1B+UZ+zYuypTyXGnGf76t//KM/ZsQYjGps4ChjUp7lqGZSM6KViiZ0UrFuGXgjE7jjwU0coLtvevLvtg9S9txu/evPVvL1Ud2Hx8wPLI+lerUN1a9+OjMfpXiMAlw/Sqq1AB83LwSjvQzi91dGKZihYpmdF6nkXSB25gPoVSxUlH9qCq2LlO7rGyoYp2Km3tYwuccNAyV9ZVx/Jm/NO/goqvDg1hc4gNAySegX2KspjIyMVERe84a0PGScZ5exUbqhskexjJi5xA5xOA6+JCubAOXLognjVQxU8aqGIFZTNrKOane+RjZWlpdG4tcM+BCq6WMQwsjaXODQAC5xcT6yeqjYp40E7FUMVOxVDEE7O5VDOip2dyqGdEE8alglZIXCN7XFjtrsHOD4H2qKNfKGipqN0zqWCOJ07+0kLBjc4959iCvYqDUn+r2fPH6iq9qoNSf6vZ88fqK8PM/KYno7cP4lLY1IfgY/mhVOVR0Z+Bj+aFVZXtp2hylDL0XGvGb76l//ACjP2bF2VKuNOM/307/+UZ+zYgxONSnooGdVM3orDMpWdFKxQtIA5r46qjYQAdx9C6QyqZXNGzJAcTgDxQNJ7yrdVSudsl5fBuyB6Oir4XiSMOacZC44sWm70YM6DW7X5LjhXG3NAh3Dq4klWaWVxl2AjOFJSVzqZ2xoD2eHflawqJn5mMav9LJGKZitdJc4JuROw55Z71dIsOxg5BXfZ51ypSBEMkKqY4eIVsbBEXc4mE+loUzaeH/hR/1QuMw6Xsratw8ldzHUd/pCuDCPFWmOCJrgWxRgjoQ0KrYljMuTCMKoYR4q2xqePqrYzLkwjxU7CPFW1qmb1TKmZdGEeKnjI8Va2KZnRMpnXQPa1pc4gADJKs+ndW2293OtoqSQmSnfhuQR2jcDJHLxyPoVXGvlJR09NPUSwRtZJUPD5CP5xAA/UEymdfmEcuYU7CMdQrS1TN6JlM67xkeIVQwjxCs7FNGmVM68sI8VQajI972c/wCeP1FeGKmvH3I35w/evBzSPpMT0d+Gqvi0tm0f2mP5oVYqOk+0x/NCql7KdoZRyrjTjP8AfTv/AOUZ+zYuy5Vxpxn++nf/AMoz9mxBiLOqnaoGdVO1Vl4qmOc0FvMDqFTADu9X0K5sUctKHc4+R8F0pqszMKTlkbhlvQqopX9lHtIyB05KN8b2HDmkfvXqMnszz7sH0rU0xUtNc07PHxpXvOckYAC9MYN3TqvQHs7yqmmpZJiC1hwTknoAtxaGJ1U0UWWN5HJPJZTZqV9PBmQnc7ntPcoaCgZTtaX4fIB17h6ldI+ixXXfSCITM6qdqgZ1U7VzWUzFOxQMU7ERUM6qePqoI1PH1VE7VM3qoWqZvVBOxTM6KFimZ0RE8anb1UEanb1QTtVn1Hqm26edSsr5cPnkawNHMtaTzefQFeGqOsoKaubCKuFsohlbMzcPiub0KCuppWTwslicHxvG5rh0IVTGoWKaNETsVNePuRvzh+9VLFTXj7kb84fvXh5p5TE9HfhvFpbNpPtMfzQqpUtJ9pj+aFVL1U7QqOVcacZ/vp3/APKM/ZsXZcq404z/AH07/wDlGfs2IMRZ1U7VAzqp2qsp2dynYoGdynYqiZnMc17EMZ6xt9i8RqdnciPcUMbfixtH0KqYoGKdionYp4+igap4+iCZnVTtUDOqnaiSmYp2KBi8Vkjo2MLHEElGZm0XXKNTx9VjF81JBYmUgnhmnknB2hmB065J9a+UetbdJUSx1DJ6YRQNne+VnIA7eWBzz5wVu0y9qmb1WNDV1kAcTXNw1hkJ2O+KDjPTxXt2sbIySSNla2SZkZk7NrTl2G7sA4xnHcl0sylimZ0WI2/XFlqKCKpmndTdpG6Xs5GEkNDi0nlkdQq2PWVgL5Ge+MYdG3e/LXAAYznp4JctLKI1O3qsSZrrTfYsl984y17nNb5js5ABIxjPeFNdNX0tr1BR0FSwMpp6V9U6qc/AY1oJ+Ljn0Qsy5qmb0Vh0/qS03587LTWNqXQBpk2tI27s46j0FX5vRElOxTRqFimjRE7FTXj7kb84fvVSxU14+5G/OH714eaeUxPR34bxaWzaT7TH80KqVLSfaY/mhVS9VO0KjlXGnGf76d//ACjP2bERBhspIheQcHC+W1znb9zienUoirK5sU7ERVE0anYiISnarHHUTe/IZ2smztsbdxxjKIiLpqVxbZJy0kHzeYP/ADBXO1Em3UpJyTG39SIgr2dVO1EVSUzFFX/a2etESWK+6w7iU49lRMydhgkO3uyMc1iEjnCKoAcQHW6MEZ682IijpTtC88QyW11JtJGbVGDjv85UVmnlZdXwslkbC4yFzA4hp+CPUIidVjZapZH+9tIN7sCkkaOfd2h5epZVQAHSGtMgHDKT9yIhKl0jI+TU+n2yPc9ra8gBxzjzWrJ+Mn8pIv6Lm/WUROh1VPAGR8tx1C+V7nvLafLnHJPJ63S3oiLUbMVbp2KaNERlOxU14+5G/OH70ReHmnlMT0d+G8Wls2k+0x/NCqkReqnaFf/Z",
+              "timing": 3906,
+              "timestamp": 79200160
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAMEBQYHCAIBCf/EAFgQAAEDAwIDAwYGDAoIAwkAAAEAAgMEBREGEgchMRNBURQiYXGBkQgVIzJSlBY3RVVyc5OhsbPB0TNCU2J1ktLT4eIYJDQ1NkRGshd04ydUVmaDlaKlwv/EABgBAQEBAQEAAAAAAAAAAAAAAAABAgME/8QALREBAAEDAgMGBQUAAAAAAAAAAAECAxESMQQhQQUyM1FxoRMUIjTwQmGRwdH/2gAMAwEAAhEDEQA/AOqUREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERARfHODWlziA0DJJ6BY9FrjSs1w8hi1FaX1edoibVMJJ8OvX0IMiRCQBknl4rHTrjSza/yI6itIq87ey8rZuz4devoQZEiAggEHIPerVedQ2uyvY261XkjH4xNLG4RD1yY2j2lBdUWBca6r/2SX+po5+Rp2uZLE/qC5vMEK7HV+nrNSUFNd75bqOqdDH8nPUNa7m0cyCeSDJ0UdNUQ1UDJ6aWOaGQbmSRuDmuHiCOqst31jpuz1YpbrfbZSVOcdlNUsa4esE8vagvyKKkqYKynZUUk0c8EgyySNwc1w8QR1UqAiIgIiICIiAiIgIiICIvj3bWkoBcG9SAvgkYejgrXcrjSW+A1FxqoaaHIb2kzwxuT0GSqCj1LY62pZT0d4t89RIcMjjqGOc71AFBkqKCneT5p9inQEREBERBrfjhPM+z2O0NmfT0l4usFDVyMO09i4kubnuzjCyOr0LpiosLrQ+y0DaHYWBrYWgt5Y3B2Mh3p6qs1dp2h1VYp7Xc2u7GTDmvYcPieObXtPcQVh8ui9Z1NEbZVa8e62ub2b3st7G1LmdCO03dcd+MoMEN9uU/A+joXVspZJeBZHV7XYc+m7Ut359LRtytuM0DpVtj+KRYrf5Fs2YMLd3TGd3Xd6c5XubRNkl0SNKmmItLYhE1oPnNIOQ8H6W7nnxWNN0TrRlJ8XN1/L8WhvZhxt7DU7OmO1z1x34ygs3EGqqdCcFDT6dvE1WY5W0bK5zw58MbnkEbh3tHmg9Qti6f05bLfpxlujiFRTzQhs75j2jqjI5ueT84nKjt2jbJRaPbpkUjZrT2ZjfHN5xkyclzj9InnnxVK7T10tllFn0xXtpqbZ2bKite6okp29MMbyzju3OOEGlaeeWn4RcULA2V81us1c+no3uOdsfaDzM+jH51ufROlLNR6TpIzS01c6rp2SVNTMwSOqnOaCXOJ6g55DuCt44Z0FPw1rtJUFTJH5aC6eskbvfJIXAl7hyznGEj0dqO00nkGl9Ux0VtDdscNVQiodTjvEbtw5eAdnCDFNP1c2kP/ABRtVkJdQWeLyyhi+cIHvic9zB6ARnCynhZpKxw6GttS+jpa6quNO2pq6qeNsj53yDc7JI5jJ6K9aL0dR6Zs9VSGWSvqa6R01dVVABfUvd1LvRjkAsdotBah0+ySi0hq3yGzlznRUlXRNqTT5OSGOJBx4A5QQcPoY7BxP1Zpu1jZZmQwV0cAOW08j8hzW+APXC2gsZ0RpGDS8NZI+rnuF0rpO2rK6f58zu4YHINA5ADosmQEREBERAREQEREBERAXicZiK9oeaDHdRipNtPkQrjNuH+xdj2mP/q+bj86sVlbd/jSDyoai7HJ3eVCh7Pofndn5/uWbPhIPm8wvIieT81B9gHygVUvEUYYPSvaAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiLHa6suDNQCGJ7m0oLMgx5GDjPPCxXXFERMutq1N2ZiJ2jLIkWP22qrai4VsMs0jQ0vEQMYAAzyOcftVPQV12lpqyR4cXwxgNaYwNzs9enPksfHjynr7OnytXPnHLHuyhFjNtr7nLQV75d5dHFujcY8HdjmAMc0jqruyyyTzv+Vc5vZnYCQ09cgD9ikX4mM4lZ4WqJmNUbxH8smRWihqauSwSTyl/lIY8tJYAcjOOSpKavrpG2nJkzI57Z8x4zjGO7ktfGjly3Yjh6pmYzHL/ACZ/pkSLGKK4XJ94qIZTJ2DTJszEMcs454UdBcrn8XVktQ57pAwdkOywQScZ6YWY4inynr7Ok8JVEbx09/zmytFjBuFyFkmcTJ5ZFKG7uzGSPVjCVNXdWWeCoZKXTh7mSAR9fA4x3J8xHlO2U+Uq21Rvj8/Zk6KKlbIymjbO/tJQ3znYAyfYpV3h5p5CIiIIiICIiAiIgIiICIiAiIgIiICIiAiKKSpgjcWyTRscO5zgCglRQeWU3/vEP9cKZrg5oc0gtPMEHqg+oiICIsO4icRbLoEUBvrat3lvadl5PGH/ADNuc5Ix84IMxRYtw+1zadeW6prbG2qbDTy9i/yiMMO7APLBPLBWUoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgLiz4TP23rp+Jg/VNXaa4s+Ez9t66fiYP1TUGJ2nQepbvR09VbrY6eGo/gi2aMF3PHIF2eq3XFxmufDe22zS960e4VdDRws3Or9u8bBg47M+kdTzBWrNI6y0tYI7ZPNodtbd6J7ZhXG6zR75Gu3Nd2YBaMYHLpyWZfCXv9sv0OkamKmEV4nt7Kufa/d2ccrWuZGTjmQdxzy/OiNgaw+ELR2Opt8dvsvxi2pooqt7vLOz7IyDOwjY7JAxz9KoLx8ImrtD6WOu0eI5KinZUtabjzDH825+S7xg+1c20bG2+8UD7xSyPpQ6KaSI8jJCcO5H0t6LYHwjKqlreIoqre5j6OagppIXMGAWFmRj2INs1nwkrZT0Vrkjssk9RURukqoo6kYpjuIDdxb5xIGe7GQsF+EPrS1a50/pG52dzw1r6uOWGUYfE/EJwf3hYFR3zT9JoGe1Vmlmy3ycl8N0dMWkNLuRA9GCMDke9Y1NRVMdmpa2QOFJNPLHGT0LmNYXY/rNQb/wDg86utWi+GN+ul7mcyEXEMjjYMvlf2TcNaPHl6lXu+E7SeV7W6YnNLn55rAH48duzGfatFSUtU/hrT1MYcaOK7Sslx0D3Qx7M+xr1dYr3owcLX2uSxTnVpkJFfkbcb8g53Z+b5u3HpQdHag44Wmk0DS6nslE64tkrG0UtLJN2EkDix7/O8130e7kc9eSxJnwl4JLRWznT4hro3Rtp4DWF4l3btxJ2DAaGjxyXBaIpaWqbw3uVUWuFE+60sbSRyc8Q1BOPUCPeFtP4K2nrPf6vUjb3bKSvELKcxioiD9mTJnGemcD3INkTcerRQaKtN2udFIbpcGPeygp37trWvc3c5xxgEt8CfcscoPhOUT6lra7TVRDATzfFViRwH4Ja39K1t8JKyMsnEXsaSkjpLa+kidSxxM2sDeYcABy+duPt9Ksd0uujZ6G1sFsrHyxM+XFKxlJg4HIucZTJz7zt/Yg6R4hca6HTNo09dLTbheKK8MlfG/wAo7HZ2ZYCCNjueXEEcsYWEf6UB/wDhIf8A3H/0ljl5p9BS8LLDUXN18t5jfUyUFvZPHJNOHlgc8ksw1m6PkcDv6rWWkK3TlBezV6ittbcKKM7oqSOZrQ7nyEjscx6ABn8yDuHh3qb7MdG26/Gk8j8sDz2Hadps2vcz52BnO3PTvWRqzaNrqW56TtFdb6RtHSVNLHLFTtAAia5oIby5cleUUREQEREBERAREQEREBERAREQFr3WHCHSurb9Nd7xFVurJmta4xzljcNAA5eoLYSINR/6Pmhf5C4fWj+5VFdwI0ZXTiWqZcpJBGyIE1R5NY0NaOnc1oHsW1EQa61Hwb0hqCopJq6lqWupqaOkjEMxYOzYMNz4nHeuYeO+n6PS+vDaLY6c0dPSxCMTSb3NBBOM+HNdxqhrLNbK2YzVluoqiYjBfLA17seshBpThTw503rThbper1BRvmmpmzsa5kjo9zTM44djmRnPvKz/AFNwq0rqK2Wq31dE+CitgeKaKlk7MN37d2fH5o5+tZrS00FJA2Glhighb82ONga0eoBSoMN03w10zp/T9dZKaiNRba2TtJ4ap3ahxwB39OgWOHgHoI1Pa/F9UG5z2Qq37fV1z+dbVRBh2oOG+mr3pik0/PRGmtVLMJ4oaV3Z4eGubknv5OPVfdA8O7DoSStfYI6hjqwMEvbSl+ducY8PnFZgiCxau0jY9X0DaTUFBHVxsOWOJLXxnxa4YI/asKoOA+g6SqbObbPUbTuDJ6l7me0ZGfUVtJEGCay4U6X1dU0c11ppmGkgFNCymk7JjIwSQAAPSse/0fNC/wAhcPrR/ctuIgorHa6ay2eitlCHClpIWwRB5yQ1owMnvVaiICIiAiIgIiICIiAiIgIiICIiAtD8V+N100VrarslJaaKphgZG4SSvcHHcwO7vWt8Liz4TP23rp+Jg/VNQdY8PL/NqnRdqvVTDHBNWRGR0cZJa3ziOWfUsiXJsvF+46P4d6VsWnGQCt8i7WoqJW7+z3Pdta1vTOOeTnqFQV/HjWw07RwGTyS5iUvNb5NHioiI5Da5uAQe9vUfnDsFFpb4NmuNQa0g1A7UlcKt1K6AQ4hjj27hJn5jRn5o6qH4Q/FG76Kq6C06fbHDVVMBnfVSRh+1u4tAaDyzyOcg9yDd6Li+18V+KM7H1tHXVlZTRuxI4UDJIweuCQzl1Wc6q4632i0Np91LFSxX+4xSTTzdn5sTWyOYNrCTzO09cgY6IOl1rjjVr656DtVFUWmzG4OqXua6Z4cY4cYxu288nJxzHQrnJvGDiXRNhrqi5VBppTljp6KMRSegHYPzFZvqvjXqCs4b2S8WaaK3XF9ZLSVrWQskY8tY1wIDwcAhwKDZ3BHiHdte0txfd7OKLyUsDJ4w4Ry5zkDd3jA7z1Wz1zTw940Xmm0Lqa9amnbcp6SangooRFHCC+QSHB2NHLzcn1LCp+OvEOtnlqaSphhp2c3Rw0THMYPSXAn86DstFzDQ8eL3dOH2oA7sKPUdDHDNT1UMYLJGGaNj8sdkA4f6ufdhWfQ3GXiFcK64QtLr3OKKR8MDaeJgjcC35Vxa0Eho3cs8yQg62Rck8OOPGo6bUVNDqmsZXWqUlshdCxr4+XItLQO/HI5Vvu/G/XuoLvI2wSupISSYqSkpmyvDfSS0knx6D0IOxkXK/C7jjqX7LKC0arfHWUtVO2mc90LY5YXOO0HzQARnGQRlR67+EBqKqvtRR6RbDR0ccpjik7ESyzYOM4dkAHuGPag6sRcnaP8AhAant16gp9WsirKJzwyYmAQzRg/xhtwOXXBHP0LrBjmvY17DlrhkHxCD6iIgIiICIiAiIgIiICIiAuLPhM/beun4mD9U1dpq3VthtFdUOnrbVQVM7sAyTU7HuOOnMjKDhrWOm6+jsGnL4YJH26uoWATBpLWSNLmlhPccAH059Cn1pqrVerdNWuovzWutVJIaenmbA2MPk28+Y6kADOOQXc7KCkZRCjZSwNpANogEYDAPDb0VPNZLVPSxU09soZKaIkxxPgYWMJ64BGAiNA/A5/2XVf4dN+iVffhNahNu1NbqG5WGiutnfRtka6dj2PZLveHBkrCCDgMyOY6cl0DbrXb7YJBbqGlpBJjf2ELY92OmcDn1KqJ4YqiMxzxMljPVr2hwPsKK/PyS/vpLuKnSLa+yNIAEUVa6Rxd+EA0kdORys34s2fVNx03pbVF/o5zJJQmmqJOy2lhbK8sc8D5pc1wOV19S2G0Uk4mpLVQQTDpJFTsa73gK4uaHNLXAFp5EHvRMOEajijquosFssvl0Yo6ANbAG07N2Gt2tBJHPA5LJOI7tRzcJdNVWrHP8pqLhM+nY+FsTmw9m0DIaB1IJ588ELruCx2mnqO3p7XQxT5z2jKdjXe8DKluFsobkxjLjRU1W1hy0TxNkDT6Mjkg4s0Rpqv1Nwr1XHaoX1FTRVtJV9iwZc9oZM0gDvOHZx6Fj2n9W1dgs1wtbKOKUVDjnt5JQIzjB+TDwxx5fxmn9i70t1roLaJBbqGlpBJjeIImx7sdM4HPqVFUWS1VNR29TbKGafr2klOxzveRlBx5QyXy5cKtU19VabbS2iOGCNlVFb44JJZDUxcmuaBkAA57uiqfgy/8AG93/AKGqP+6Ndh1NFS1VIaWqpoJqYgAwyRhzDg5HmnlywFS0VjtNDK6ShtdDTSOaWF0NOxhLT1BIHT0IPz609bX3i/222wkCSsqY6dpPcXuDR+lXvT181Hw01PUS0sZoboxjqeWKphBy0kEjB9LQcjwXc0Gm7HBNHNBZrbHLG4OY9lKwOaR0IIHIqqr7ZQXANFfRUtUG9O2ia/HvCDkThVqTXGqOIFKyiq3SRz1QnrpBTR7GR7svJO3lkZA/MsNuluuvDjXRbXUkgmpJXGPc+SNs8ZyA5r2FrsEHqD6D3hd5UlJT0cQipKeKCMfxImBo9wXmuoKSvjEddSwVMY5hs0YePcUHFOmtQag1PrFsdlsVoqamqkb5ktA2pEY5Dc6STc/A6kucu3IWlkTGuxkNAO0YHsUFDQUdBGWUNJT0zD1bDGGD3AKpRRERAREQEREBERAREQEREBERxDQS4gAdSUBFqD4S17q7dw5gq7Fc56Wb4xjjM1HOWOxskJaXNPoHJYP8F7VV0uN+vY1Bfa2qgZTMLBW1bnta4v7txwDhB0uip4q+kla90VVA9sY3PLZAQ0eJ8F8huFFPII4aunkkd0ayRpJ9mUFSiiqKiCmYHVE0cTScAyODQT7VTvu1ujp5J319I2CPG+QzNDW56ZOcBBWooYKqnqKZtRTzxS07hubKx4c0jxBHJfIa2lnfshqYZHeDJAT+ZBOip566kp5NlRVQRPxna+QNPuK+mtpW04nNTCICcCQvG0n19EE6KCnrKapLhTVEMxbzIjeHY9y+GupGy9m6qgEnTYZBn3IKhFHUVENOwPqJo4mE4DnuDRn2qJlwo5I5Hsq6dzI27nuEgIaPE8+QQVKKlhuNDPTGohrKaSnb1lbK0tHtzheoK+kqH7IKqCV+M7WSBxx7EFQipGXOge9rGVtK57jgAStJJ8Oqq0BERAREQEREBERAREQEREBcq/Cn1jcpNVN01TVEsFupoWSSxscW9tI4Z87HUAYwPHK6qWjuPvCKt1jcIb5px0JuTYxDPTyu2CVoztcHdNwzjn3Y8EGhr5pHVGn+G1Dc6ypg+x+7zRTsp2TbnB+xxY4txgEtJ6H1rF6T/hu5f+Zp/wDtlWzJeC/EOfTOKqGaR1NOI6a2mrY4BhBLpBl+1ozgYHM5PgqrTPBDV1TYr9SXO3NoahzIpaQyzxubJIxxy07XHGWudzPfhEUPBH/g/id/Qb/+2RWn4O/25NO/hT/qJFlGkOEPEWho9QwBhtlPU0MkT4myxSGtOCWxDmdoJ6uJHIlV3BfhbrLT3Eyy3S8WV1NQU5lMspqInbcwvaOTXk9SB0QZt8Lv/gK0/wBJt/VSLSPCnQd61/Q3qgtFxpqSlgfTy1DJ92JHfKBh5A9PP966K+EfpS9au0hbqLTtEaypirmzPYJGMwzs3jOXEDqQrN8GfRGodHP1EdSW51EKoU/Y5ljfv29pu+a44xuHXxQaU4q1l702KDQc9wPklogaJWU7i2OaSQmTcehOA9o59MFWZ2i9RW+Wgntna1E83nsfRtlaYnDB5vc1rc+lpPrW/ePnB+46tu7L/pt0T650bYqimkds7TbyDmuPLOMDBx0C1Yzg3xMvE1NT3OmkZDCBHG+rrmPZE30AOcQPQAgqeM1mv0+iNKai1PSviu7A+3Vb3Oa4yAEuie7aSMkbs+pYZX6vfU8LLXpbJzS3CWod+AWjYP6z5PcF07deFrYOCFRpGheaqvjjNRHIcN7SoDt/LPIA/N9RXPDOCXEFz2g6ec0E4JNVBy//ADQe6aquWjeEdNVW+aSkqtTVcgdNEdr/ACaAAbQeoy956dwWM0GlLpcrE68UjxPh2BCxkr5TzxnIYWjn4uBXVfEbhNFqLhzaLFa5o6ets8bRSvePMfhuHNd4bsA58QtDjg9xOjpn2tlDN8XufvdG2vjELnfSLd/7EEOovsupuD4odUQVIt8dzgfRSVEgc5vyUwczqTjoRnpzVo4e2S43nTGtDRXR1DS0dAKupiazPlIZuIYTkYHInv7uS2HcuBeobdw3MNLC246gqq+GWWCGVrWQwsZKMBzyATl4z7MeKr+FfDXVtk0zrylulodBPcrU6npGGeJ3ayFrxtyHEDqOuAg0BRXOqo6KvpYJntp62MRTRg+a8B7XjI9BaFs/4L/2yZv6Nn//AJUeneBetKu6sgutpNFSvjlBqH1ETmsf2btmQ1xON+0ch3q8aB4P8RLTqoPjxZojG+KWuZLFLmMjBa1uSST3ZAx1yEGseHH2w9L/ANK0v65q79dWUzaoUzqmEVBGREXjefZ1XIGieD+urdrOwV1bYXxUtNcKeaV/lMJ2sbI0uOA/JwAeir7vwY4gVHECeqjIkZJVmZt1NS0bRuyHEZ3AgdwHqQdbovjAWsaHHJAwT4r6iiIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIsX1NqN1rvdBTMlpmQjbJVCVwDix7xG3bz8S5x9DPSgyhFit91HWwU15+LaAOdbyGGaWQBhcWtdyGCTyd6FUzXqWlq52VMMpqRFBtpY3tczfJI9rcOIBydvMnkB078hkKLHau8VUNRbzVwOomdtI2dpIka9jYXvy1w7sgeB5KKi1bHURySPopgwU7qmMROErnNGPNIHzXcxy59/PkgydFbbFdW3aCWRjGN7N207Jmyg8s9WnkfQcKkr7z5DW1TBHPUvD4I2wgtABkJAwevryfUgvqLFJdQ3GS4UFPS0EQeamSmqY5J8Yc2IvAaQ08sbTn2YVTT6ojnuQp2UxMBndTCUSAu3tJBJZ1DcgjP5sc0GRIrBRakEwp5qmjkpaOcyNjmkeOZYCTkDoCGvIP830qmk1NHTtknmjqA58VO6OmeWgB0pfgZxkHzcnPTHL0hlCKw0OpI6gwtmpzCXTmnc7eHMDtm8EOxzBAIzy58sLxBqiGejjnipZ3Oc6UuhHORrGM37sekFmB/PCDIUVrsN4Zd4pXsjYzsyB5kzJOozz2nkfQfzq227VTbhMxtLSbo5w40z+1B3EAkbwBlgOOR5+nB5IMmRWXTlyrKzT0VdcaeKOR0Qk+Tk3bxjOegx6uao6bUtVUup2RWeXtamm8rha6doBj5Z3HuPnN5c+vrwGTIsbfqqEOoXtg/1epbC4OdM1rx2pAbhnU4yM9PRlejqR01TWUtLSt7eESBrZZ2scSzlks+cGnuODnl0ygyJFidNqipjtNqfW0kPl1bAJw0VAawtDWkuJI5HLhhuD61VjU7Hdg5tHOInUzqqaRxAELGkh2fE5HLGcoMhRY3VXmuNtfMaGWjLhG+KQva8FrntBDvB2D05+vkpzqJjL0ygkgA7SR0THNma55cGF/Ng5gENOD16ckF9RYzT6timoqipFK/EQYdglY57dxwN7c5Zjqc8gAfBfZdVxinpTFBG+eo7Qtb5Szs9rCA47xkdXAAYzz7kGSosbm1ZCwUhFLI3t4xJ8tIyIDztpaC44c7I6A9MHPMLJEBERAREQFbqiy0NSa41EIlNa3ZKXc/N27cDwGM9O8kq4qxXC91UNwrKakt3lIpIWTyPMwZlrt3Jowcu808jgelBWfEtGaSuppGvfFWnMwc85cdjWdeo5NHTvUT7BRPbIH9u9z444y90znPGxznNIcTnILic5VF9kpeySrgo99rikZHJUGXDwXbeYZjmBuGeYPXAKqTfQIaWQ0/8AD1ktJjf02dp53Tv7Pp6fQglhsVHG5j5DNPI2R0pfNIXlxLCw5z3bTjHReaTT9JS7tktW4dkYIw+oceyYccmc+XQc+vIc15tl5mrNOC7S0EkYfD28cDHdo97duR0HU+CtFZqWunooJLZBRuk8thgkb5VnAc4cj5mQTnByBjqMoL5BZooKls8dRU9qZBJK4yc5cMLQ13dgZzjxGVNPaqWapfO9ru0c+N5Id3xklv6VbHagqWT1bH28BlLNDBJIJ8gvk7Pk3zckDtO/HQePKSqv0jLlNQUtGJqpszYYw6XY12Yu0JccHAA5dCgqZ7DQzyuke2ZsjqjyrfHM5jg/YGci0g42jGF8isVJFWioY+oDRI6YQds7sg89XbfHmT4ZOeqoX3S8OvVup2UEEcUsMrpmSVGCC17BkEMORh2R0znnjC+zanbFbKKsNKSKmCafZ2nzezYXY6c84wgrqqxUNVaWW2ZjjSsIcBuIPI56+nmD6CQvVbZaOsknkla8SSiMF7XlpaYySwtI6EFxVqqdTVUT4oW2pzqp0IqHxdo47IySG82sPnHB5dOXVV1BepK66ClhopGwinjqHyyu2OZv3YbsxnPm80HqTT1FNbKihnM80dQ8SSyPlJkc4Ywd3djaBy8FN8TUXls9WI3Nmmh7Bxa8tw30Y6HkOY5+aPBU0l9EdW+lNOfKG1Ih27v4mzf2nTptB9owqaO/1csELxb44hWQuloy6ozvw3cA8Bvmnbz5buiC7UFthopppmPlknmDWvklducQ3O0ezJ96p6KxUlHVMmidUFse4xQulJji3ddreg6n1Z5YVss99uctDZG1VBFJVV8AlL45/NDQ1hL3eaMZ3dADzwM94ls2pnXOrga2gmbR1O7sZxuPIAkF42gNBA5YJ7uiC60FrpqGjkpaftRA/Pmvlc8NB7m5J2j0DklPa6anlppI2uDqenNLHl3Rh2/n8wKkq7vUtr6inoaDyptKGmdxmDCNwyAwEeccc+ZA5jmqeTUUwknay3khtT5HCXSgdrJ18PNaBkk+g8igkGlre2HsozUMjIjBa2UgExgBjvWNo9HLoqttmpvLGVEj55XML3MbJIXNYXAhxHsJHozywrf8dvfWU1PUQy09WyrMEsUMgexx7F0g5luS0geAOfzxU+q+2pKmXyP5SIMcYWyZkYHHHyjMbmY6nkRgHqiK1um6KOmp4aeSsg8nBbFIypeXsaQAWAknzeQ5dOQVXT2ijgDQyMuaIPJ8PcXZZnODnqTk8yrTJqc/F8FRBDSSOlLxgVjdvm9Q0gEuPPptHTnjv8Taqf2Uk9LQGWliooq+V75QwtjeHHAGDlwDTyyB6UVXxacoo2lrn1UrQwRsEs7ndm0ODg1uenNo9PIL19j1F5QyYOnBZUOqWNEp2te7O4genc73nGF4p7zUVNS90FBvoGTup3TiUB4c0lrjsI+aCCM5z6FT2PUj7pUwA2+WKmqWGSGbzjyxkbwWgNyOmCUFYyxUzXvkM1W6YsEbZXTHexoOQAfX1znPfleHado9jTHJUxTh75DURylsji/G7J8DhvLpyHgryiC0zWCjlpW0xfUinEXYvjEziJGeDs9ScnJ6nPVXZEQEREBERAVjqdPQVl2raqqdIY6iKOLZHK9m5rd2Q7aRked+nxV8RBbHWOgdUGbsXNy5r3RtkcI3ObjaSwHaSMDu7h4L4bFQGpZOY5C5krp2N7V21r3Ahzg3OBnc73lXREFNFQ08NtZQRtc2mZEIWtDjkNAwBnr07+qpHWGgfDNHKyWQyuY973TPL8sOWkOzkYPTBV0RBQG00ZgqojG4sqXNfITI4uLmta0HOcggMbz8RnqoPset/wAodk3avkExlE7+03hu3IdnI83l6ldkQW1ljoY20wZHK11O5z2PEzw7Ljl252cuyeZBzlQu03bXnz4pHDbIxrTM/axsgw8NGcAHPcrwiC3V9mo657HzCZj2s7LdDM+Mln0SWkZHrU9LQU1JM+SniEbnRsiOCcbWZ2gDuxuKqkQUjrbSuuguLos1Yi7Dfk/MznGOntUFFZKGjla+GN/mNLI2vlc9sbT1DQTho5DorkiC30FmoqDsPJo3tEDXMiDpXP2Ndty0ZJwPNHLuxyXiksdDSVTKiFkocwuMbHTPcyMu67WE4b39B3q5ogttfZKGvnfLUMk3SNDJAyV7BK0dA8AgOHM9fHCkltNHLTywviOySXtzh5BD853Ag5B5dyrkQW6Ky0MfZkROc+OUzh75HOc55YWEuJOT5pI5+jwXltjo2lzv9YMhaGCR1Q8va0HIAdnI5+9XNEFqFgt4c1wjlDxv3P7Z+5+/G7cc887W9fAJFYLdFRzUrIXdjNTtpHgyOOYm7sNznPLc5XVEFsNjoTV+UGOTd2nbdn2r+z3/AEtmdue/OOvPqvFPp+gp3ExNnA7N0bG+UPxE13UMGcM9mMdyuyIPMTBFEyNpcWtAaNxJPLxJ6r0iICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAvJD88i3HqXpEHnD/pN9yYf9JvuXpEHnD/pN9yYf9JvuXpEHnD/pN9yYf9JvuXpEHnD/AKTfcmH/AEm+5ekQecP+k33Jh/0m+5ekQecP+k33Jh/0m+5ekQecP+k33Jh/0m+5ekQecP8ApN9yYf8ASb7l6RB5w/6TfcmH/Sb7l6RB5w/6TfcmH/Sb7l6RB5w/6TfcmH/Sb7l6RB5w/wCk33Jh/wBJvuXpEHnD/pN9yYf9JvuXpEHnD/pN9yYf9JvuXpEBERARFzV8JjiXcKS6HSliqX0rI42vrZonbXuLhkRgjoMYJx1zj1h0JUX20U0roqm60EMreRZJUMaR7CVF9kti+/Vs+tR/vXAFostzvb5ha6KesfEN0nZN3Fo58z7iqBzHNcQ5pBHdhEfolBf7PPI2OC7W+SRxwGsqWEn2Aq5L82iCMEghdA/Br4l3Bl+g0peql9TR1QIpJJXZdC8DOzJ/ikA4HccY6oOpFSVtzoKAgV1bS0xPMCaVrM+8qC5zyPq6e30zzHLO10kkgHOONuAcd24lwA9p7kdDarHRzVT2U9LCwbpZ39T3Zc48yenMlFePsjsf35tv1pn70+yOx/fm2/WmfvVZRVVJXU0dRRyxTQSZ2PYQQcHBX2KopZpZo4pInvhcGSNBBLCQCAfYQfagovsjsf35tv1pn70+yOx/fm2/WmfvVy+TwT5nLqoqeppajtOwlik7N5iftIO1w6tPpQUX2R2P782360z96fZHY/vzbfrTP3q5kMHUNULqiBtSyA57R7HSAhhLcAgHLsYB5jkTk+woKL7I7H9+bb9aZ+9Psjsf35tv1pn71c8M/mr58ngHzMFBbfsjsf35tv1pn70Go7ITgXi25/8ANM/ern8n/N8VA6opPK2UjpIfKJI3SNiJG5zAQCQPAEj3oJ4pGSxtkie17HDIc05BHrXpWist7KCOWttMLYp2AvfDH5rJx1II6bj3O659GQrnTzMqII5onbo5Gh7T4gjIQSIiICIiAiIgIiICIiAiIgLi34S1nqbbxTr6qZjhT3Bkc8L+5wDA0j1gt/R4rtJY5rnRlm1taPi++U/aNad0UrDtkhd4tP7Oh70HBtjur7TU1E0cTJDNTS05DugD2FpPsysvfxLqJawTVFrgljLTujdM/wCd2sco2nOWsDom4YOQBd4rbFV8GGF0zjS6qkjiz5rZKEPcB6SJBn3KL/Rf/wDm3/8AXf8AqojS+s9ZTaoorfTz0jYTSF5DhITkOxyAwAOnXmfT3K88AbLU3ninZTTtd2VHL5XM8DkxrOYz6zge1bSg+DDGJWmfVb3x55tZQBpI9BMh/Qtz8P8AQlk0LbHUlkgdvkwZqiU7pJSPE+HgByQXSoJp9SU0rx8lUwOgDvB7TuA9oL/6q96ktMd9slVbZpHxR1ADXPZ1ABB5e5VtVTxVUDoZ27o3dRnBHgQRzBHUEdFbjR3eIBlLc6dzB0NVSmR+PDLXsB9yKsd10Bb62op3QTzUkUUbYw2MAvbh7n7mPOXNc4uO4584dVQ0fDWnpoxitjc/te0x5FH2Q+TYwkR9A7EYId3Eu7jhZR2F/wDvja/qEn98nYX/AO+Nr+oSf3yDFKjhnDPSXSB9zcfL5o53Zp2hrXsL8Ha0gEkP59x2jl3L1U8M6WWN7Iq1sQNYKxrhSs3B23BzjAd3kZBAz0KynsL/APfG1/UJP75Owv8A98bX9Qk/vkFl1boaPUVdNO+4zU0c0QZJGyNrskRysDgTzHKZ3L0BU9Zw5o5zGIqt0UcUkj44exa6Ib3ROLSw8i3MXT+cSsi7C/8A3xtf1CT++TsL/wDfG1/UJP75BhdFwxMtopaW4XOeLbHtljgA5u7OWIODuRHmydOnJVrOGFs+L6OkmnfM2lJLO0ZuAJmZKcZJwDs29ejisn7C/wD3xtf1CT++TsL/APfG1/UJP75BiJ4U2/yp8wr6oB0T4gz+K1pyA0DOA0A4247s+hXi3aHo7fe6C408rA6kNSGsMDSAyaTtAxp/ihp5DHcSO9XbsL/98bX9Qk/vk7C//fG1/UJP75BX3KqZR0M9RICQxpIaBkuPc0DvJOAB6VFYqR1vslvo3nL6enjiJ8S1oH7F4p7fKZ2z3Gp8qlZzY1rNkbD4huSc+kk+jHNXFAREQEREBERAREQEREBERAREQETKZQEXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzKZQfUXzK+5QETKICIiBlQ1VTDSU8lRUyshgjaXPke7a1oHUkqQlc0/CX1nUT3tmlqKUso6djZaoNP8JIebWn0AYPrPoQZrqHj5p6gqHw2qkqrmWnBkaRFGfUTkn3KzN+ERCf+mpPro/sLnSNVDER0O34QkJ/6ck+uD+wvbfhAQn/p2T64P7C59jUzDjqg3+3j5Ef+nn/XB/YUg48RH/p9/wBbH9haAEgHQZUrZT4BXEpqb9HHSI/cB/1sf2FIOOER+4L/AK0P7C0KyYjqAqqKVp68k0yam8xxsjP3Cf8AWh/YUjeNEZ+4b/rQ/sLSjO5TsUVudvGSM/cR/wBZ/wAqkbxgjP3Fd9Z/yrTbFJ2rWO2ncTjOGtJQbkHFyM/cZ31n/KkXFyGRz2ttD8sO13y/fgH6PpWoWTt+jJ+TP7lPS83SOwQHOyMjHcEG3m8VGH7kO+sf5V7bxQYfuU78v/lWq2dFOxBtFvExh+5bvy/+VexxJYfuY78v/lWso1UMQbJHERp+5rvy3+Ve28QWn7nO/Lf5VrpinjQbCbr1p+55/Lf4L2NctP8AyB/K/wCCwFiqGIM6GtWn/kT+V/wUjdYtP/JH8r/gtc3qlqq21y09DWOo6h482ZrQSPerpTtc2JrXvL3AAFxGMnxQZq3VrT/yZ/Kf4KRuqWn/AJQ/lP8ABYhGp2IMti1Kxz8SUzms8WvyfdgK9UlVDVxdpA8Ob3+I9a1+xS/Gj7RNT1APybpAyUeLT+7qiTVpjMthAr7leGkEZHML1lGkbiuLuNxLuLOoM/ykf6ti7NeVxjxr58WNQfjGfq2KDD41UMVPGqhiqJ2uDQvocT1UIOSpGLcQzMlRUtp48uI3HoPFWyorZj0e4Z58jhVNREJ6wbhlrApvIIX83N/OudVfPDdFvMZUdPe5Y/NkaH+vksioKmOqhEkR5dCO8FWp9BA1p2sHgpLAOxnmhB835wVorzOErt4jLIoJCw+I8FXiVjWBz3ta0nGScc1bWKqpXAODXYIPj4rpVTnm50z0V7Jov5Rn9YKSBzX1Dy1wcNreh9JXlgHgFURjHRc3RUMU7FAxTsQVDOinYoGdFOxBPGvtTP2EW4N3OJw0Zxk4J/YV8jUkkTJoyyQZafThB6e2dsTndsMgE4a0D9OVPDS5DTLLM94HMh5aCfUOShdDK6MsE3IjB3Nz+jCnh8qY1oIikIGC7Jbn2YKCp7CMtO7cRjoXnH6VpSfVtbBrsxQuEdG2p8ndGxobkbtpdnrnPP8AMt1NfMG84QfQ1/7wFrt/DuWfVvxphzIO1Exidt5vHPOQTyzzx7PSgsfELVdXQakhjtZZAIWte/zAS53hk88cvz+pbs01XG5WOjrCCO2jD8E5OCMjK1xq/h9LqG8wVUIkpmBoZJkNO5oPdh3XmfZ6uez7RRst9vgpYgAyJoaAOg9CC4xqdigjU7EE7VbtT/7tb+GP0FXFqoNSDNvZ+GP0FceIvRYtVXatoSbc3fojq2bSu+Qj/BH6FPlUlKfkY/wQqjK6xzhpDIeS4z408+K2oPxjP1bF2VKeS404z/bVv/4xn6tiDEY1NnAUMalPctQzKRnRSsUTOilYtwy8EYncceCmjlBdt715d/CD1L23G79q89W8vVR3YfHzA8sj2r1ahurXvx0Zj868RgEuH51VWoAPm5eCUd6GbvdXRimYoWKZnRep5F0gduYD6FUsVJR/wQVWxcp3dY2VDFOxU29rGFzjhoGSvrKuP6M35J37lFV4cGsLnEBoGST0C+xVlMZGRioiL3nDWh4yTjPL3KjdUNkj2MZMXOIHOJwHXxIVzYBy5dEE8aqGKnjVQxArKZtZRzU73yMbK0tLo3FrhnwIVXSxiGFkbS5waAAXOLifWT1UbFPGgnYqhip2KoYgnZ3KoZ0VOzuVQzognjUsErJC4Rva4sdtdg5wfA+9RRr5Q0VNRumdSwRxOnf2khYMbnHvPuQV7FQak/3ez8MfoKr2qg1J/u9n4Y/QV4e0/tLno7cP4lLY1IfkY/wQqnKo6M/Ix/ghVWV7adocpQy9Fxrxm+2pf/xjP1bF2VKuNOM/207/APjGfq2IMTjUp6KBnVTN6KwzKVnRSsULSAOa+Oqo2EAHcfQukMqmVzRsyQHE4A8UDSe8q3VUrnbJeXybsgejoq+F4kjDmnGQuN2MTl6LM8hrdr8lxwrjbmgQ7h1cSSrNLK4y7ARnCkpK51M7Y0B7PDvytWqJn6mL1f6WSMUzFa6S5wTcidhzyz3q6RYdjByCu+zzrlSkCIZIVUxw8QrY2CIu5xMJ9LQpm08P8lH/AFQuMw6Zwratw8ldzHUd/pCuDCPFWmOCJrgWxRgjoQ0KrYmDUuTCMKoYR4q2xqePqrg1LkwjxU7CPFW1qmb1TSmpdGEeKnjI8Va2KZnRNJrXQPa1pc4gADJKs+ndW2293OtoqSQmSnfhuQR2jcDJHLxyPYquNfKSjp6aeolgjaySoeHyEfxiAB+gJpNa/MI5cwp2EY6hWlqp7pcIbXbqitqnbYYGF7v3es9Ewal3uV2obTSOqbjVRU0Df40jsZ9A8T6AsQn4v6Xgm2MkrJhnG+ODzfzkH8y0PqnUVbqK5Pqq2R3ZgnsoQfNjb4D9/erOxkkgcWRucGjJwM4WW3W+mNb2HULxFbbhG6oxnsZAWP8AcevsyrrqJwNvZz/jj9BXGkE0kMzJYXujlYQ5rmnBaR3grf3DrWMmpLC6luDwblSObud/Ks54d6+4+zxXh7T+0uejrY8Sl0fR/wADH+CFWKiojmGP8EKrXtp2hzlHKuNOM/207/8AjGfq2LsuVcacZ/tp3/8AGM/VsQYizqp2qBnVTtVZeKpjnNBbzA6hUwA7vV7Fc2KOWlDucfI+C6U1YZmFJyyNwy3oVUUr+yj2kZA6clG+N7DhzSP2r1GT2Z592D6VqaYqWmuadnj50r3nOSMABemMG7p1XoD3d5VTTUskxBaw4JyT0AW4xDE81NFFljeRyTyWU2alfTwZkJ3O57T3KGgoGU7Wl+HyAde4epXSPosV155QRCZnVTtUDOqnauaymYp2KBinYiKhnVTx9VBGp4+qonapm9VC1TN6oJ2KZnRQsUzOiInjU7eqgjU7eqCdq19xouTINNMomygT1Ezcs7ywZJPvAWwWrH9eWQ33TVVSxtBqAO0hJ+m3mB7eY9qSsbucIWCWeKNzgxrnBpcegyeq2JxRxorXJtOmY/i+O2NiMdTH/DTudGHF7n9SDuI2/N9C11LG6N7mSNLXtJBaRgg+CvjNTVU7qP47iZdo6NobBHU9zR0a57cPLR9HdhYdWScZbfSQXHT90paeKlmvFpgr6mCJoaxsrgQ4taOgOM48cq38J5pItYwMYTtlje1/qAz+kBWHUl9r9SXeW5XWQPqHgNAa0NaxoGGta0cgAO5Z7wbsUpfUXuZhbC0dhCSPnE/OI9WMe0rx9oTjhbmfKXWz4lPq68t/+zx+oKtVFb/9nj9QVavXTtDnKOVcacZ/tp3/APGM/VsXZcq404z/AG07/wDjGfq2IMRZ1U7VAzqp2qsp2dynYoGdynYqiZnMc17EMZ6xt9y8RqdnciPcUMbfmxtHsVUxQMU7FROxTx9FA1Tx9EEzOqnaoGdVO1ElMxTsUDF4rJHRsYWOIJKMzOIyuUanj6rGL5qSCxMpBPDNPJODtDMDp1yT618o9a26SoljqGT0wigbO98rOQB28sDnnzgrlpl7VM3qsaGrrIA4mubhrDITsd80HGenivbtY2RkkkbK1skzIzJ2bWnLsN3YBxjOO5MphlLFMzosRt+uLLUUEVTNO6m7SN0vZyMJIaHFpPLI6hVsesrAXyM+MYw6Nu9+WuAAxnPTwTJiWURqdvVYkzXWm+xZL8Zxlr3Oa3zHZyACRjGe8Ka6avpbXqCjoKlgZTT0r6p1U5+AxrQT83HPohhlzV725Vk0/qS03587LTWNqXQBpk2tI27s46j0FX5vREYDrbh3S32V9ZRPFJXu5uOPMkP84dx9IWu5+GWpY5dkdNDM3Pz2TNA/PgrocNyvbYwphqKphpjTHCOokqGS6gqGMhGCYIDlzvQXd3sytuy0UFBaYaakibFBEQ1jGjAAwVco2YUN3GKNv4Q/avD2nGOEuejrw85u0tm0QxBH+CFVqlpP4GP8EKqXrp2glHKuNOM/207/APjGfq2IiDDZSRC8g4OF8trnO37nE9OpRFWVzYp2IiqJo1OxEQlO1WOOom+OQztZNnbY27jjGUREXTUri2yTlpIPm8wf5wVztRJt1KSckxt/QiIK9nVTtRFUlMxRV/8ABs9aIksV91h3Epx7KiZk7DBIdvdkY5rEJHOEVQA4gOt0YIz15sRFHSnaF54hktrqTaSM2qMHHf5yorNPKy6vhZLI2FxkLmBxDT8keoRE6rGy1SyP+LaQb3YFJI0c+7tDy9SyqgAOkNaZAOGUn7ERCVLpGR8mp9Ptke57W15ADjnHmtWT8ZP+JIv6Lm/SUROh1VPAGR8tx1C+V7nvLafLnHJPJ63S3oiLUbMVbp2KaNERlOxU14/2Rv4Q/aiLw9qfaXPR34bxaWzaT+Bj/BCqkReqnaFf/9k=",
+              "timestamp": 79981285,
+              "timing": 4687
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAMEBQYHCAIBCf/EAFQQAAEDAwIDBAUGCgcEBgsAAAEAAgMEBREGEhMhMQcUQVEiYXGBkQgjMlJTkhUWN1VylKGxs9EkM0Jic8HTGDQ2dRcndLLh40NUVmNmg5OVoqXC/8QAGQEBAQEBAQEAAAAAAAAAAAAAAAECAwQF/8QALREBAAECBQEGBQUAAAAAAAAAAAECEQMEEiExQQUTFFFxoSIzNGHwMkKRwdH/2gAMAwEAAhEDEQA/AOqUREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERARfHODWlziA0DJJ6BY9FrjSs1w7jFqK0vq87RE2qYST5devqQZEiEgDJPLzWOnXGlm1/cjqK0irzt4Xe2bs+XXr6kGRIgIIBByD4q1XnUNrsr2NutV3Rj8YmljcIh7ZMbR7yguqLAu2uq/wCqS/1NHPyNO1zJYn9QXN5ghXY6v09ZqSgprvfLdR1ToY/m56hrXc2jmQTyQZOijpqiGqgZPTSxzQyDcySNwc1w8wR1Vlu+sdN2erFLdb7bKSpzjhTVLGuHtBPL3oL8iipKmCsp2VFJNHPBIMskjcHNcPMEdVKgIiICIiAiIgIiICIiAiL4921pKAXBvUgL4JGHo4K13K40lvgNRcaqGmhyG8SZ4Y3J6DJVBR6lsdbUsp6O8W+eokOGRx1DHOd7ACgyVFBTvJ9E+5ToCIiAiIg1v24TzPs9jtDZn09JeLrBQ1cjDtPBcSXNz4ZxhZHV6F0xUWF1ofZaBtDsLA1sLQW8sbg7GQ719VWau07Q6qsU9rubXcGTDmvYcPieObXtPgQVh8ui9Z1NEbZVa8e62ubw3vZb2NqXM6EcTd1x44ygwQ325T9h9HQurZSyS8CyOr2uw59NxS3fn1tG3K24zQOlW2P8EixW/uWzZgwt3dMZ3dd3rzle5tE2SXRI0qaYi0tiETWg+k0g5DwfrbuefNY03ROtGUn4Obr+X8GhvDDjb2Gp2dMcXPXHjjKCzdoNVU6E7FDT6dvE1WY5W0bK5zw58MbnkEbh4tHog9Qti6f05bLfpxlujiFRTzQhs75jxHVGRzc8n6ROVHbtG2Si0e3TIpGzWnhmN8c3pGTJyXOP1ieefNUrtPXS2WUWfTFe2mptnDZUVr3VElO3phjeWceG5xwg0rTzy0/ZF2oWBsr5rdZq59PRvcc7Y+IPQz6sftW59E6Us1HpOkjNLTVzqunZJU1MzBI6qc5oJc4nqDnkPAK3jszoKfs1rtJUFTJH30F09ZI3e+SQuBL3DlnOMJHo7UdppO4aX1THRW0N2xw1VCKh1OPERu3Dl5B2cIMU0/VzaQ/6UbVZCXUFni75QxfSED3xOe5g9QIzhZT2WaSscOhrbUvo6WuqrjTtqauqnjbI+d8g3OySOYyeivWi9HUembPVUhlkr6mukdNXVVQAX1L3dS71Y5ALHaLQWodPskotIat7jZy5zoqSrom1Jp8nJDHEg48gcoIOz6GOwdp+rNN2sbLMyGCujgBy2nkfkOa3yB64W0FjOiNIwaXhrJH1c9wuldJxqyun+nM7wGByDQOQA6LJkBERAREQEREBERAREQF4nGYivaHmgx3UYqTbT3IVxm3D/cuDxMf/ADfRx+1WKytu/wCFIO9DUXByd3ehQ8PofpcP0/gs2fCQfR5heRE8n6KD7APnAqpeIowwete0BERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEWO11ZcGagEMT3NpQWZBjyMHGeeFiuuKIiZdcLCnFmYieIuyJFj9tqq2ouFbDLNI0NLxEDGAAM8jnH+ap6Cuu0tNWSPDi+GMBrTGBudnr058ljv48p6+zp4WrfeNre7KEWM22vuctBXvl3l0cW6Nxjwd2OYAxzSOqu7LLJPO/51zm8M7ASGnrkAf5KRjxMXtKzlaomY1RzEfyyZFaKGpq5LBJPKX95DHlpLADkZxyVJTV9dI205MmZHPbPmPGcYx4clrvo225YjL1TMxeNv8AJn+mRIsYorhcn3iohlMnAaZNmYhjlnHPCjoLlc/wdWS1DnukDBwhwsEEnGemFmMxT5T19nScpVEcx09/zdlaLGDcLkLJM4mTvkUobu4YyR7MYSpq7qyzwVDJS6cPcyQCPr5HGPBPER5TxdPCVcao5t+fZk6KKlbIymjbO/iShvpOwBk+5SrvDzTsIiIgiIgIiICIiAiIgIiICIiAiIgIiICIopKmCNxbJNGxw8HOAKCVFB3ym/8AWIfvhTNcHNDmkFp5gg9UH1ERARFh3aJ2i2XQIoDfW1bu+8Thd3jD/obc5yRj6QQZiixbs+1zadeW6prbG2qbDTy8F/eIww7sA8sE8sFZSgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAuLPlM/leun+DB/Cau01xZ8pn8r10/wYP4TUGJ2nQepbvR09VbrY6eGo/qi2aMF3PHIF2eq3XF2zXPs3tts0vetHuFXQ0cLNzq/bvGwYOOGfWOp5grVmkdZaWsEdsnm0O2tu9E9swrjdZo98jXbmu4YBaMYHLpyWZfKXv9sv0OkamKmEV4nt7Kufa/dw45WtcyMnHMg7jnl+1EbA1h8oWjsdTb47fZfwi2pooqt7u+cPhGQZ2EbHZIGOfrVBePlE1dofSx12jxHJUU7KlrTceYY/m3PzXiMH3rm2jY233igfeKWR9KHRTSRHkZITh3I+tvRbA+UZVUtb2iiqt7mPo5qCmkhcwYBYWZGPcg2zWfKStlPRWuSOyyT1FRG6SqijqRimO4gN3FvpEgZ8MZCwX5Q+tLVrnT+kbnZ3PDWvq45YZRh8T8QnB/mFgVHfNP0mgZ7VWaWbLfJyXw3R0xaQ0u5ED1YIwOR8VjU1FUx2alrZA4Uk08scZPQuY1hdj7zUG//k86utWi+zG/XS9zOZCLiGRxsGXyv4TcNaPPl7FXu+U7Sd72t0xOaXP0zWAPx57dmM+9aKkpap/ZrT1MYcaOK7Sslx0D3Qx7M+5r1dYr3owdlr7XJYpzq0yEivyNuN+Qc7s/R9Hbj1oOjtQduFppNA0up7JROuLZKxtFLSyTcCSBxY9/pei76vhyOevJYkz5S8ElorZzp8Q10bo208BrC8S7t24k7BgNDR55LgtEUtLVN7N7lVFrhRPutLG0kcnPENQTj2Aj4hbT+Stp6z3+r1I292ykrxCynMYqIg/ZkyZxnpnA+CDZE3b1aKDRVpu1zopDdLgx72UFO/dta17m7nOOMAlvkT8FjlB8pyifUtbXaaqIYCeb4qsSOA/RLW/vWtvlJWRlk7ReDSUkdJbX0kTqWOJm1gbzDgAOX0tx9/rVjul10bPQ2tgtlY+WJnz4pWMpMHA5FzjKZOfidv8Akg6R7Qu2uh0zaNPXS024XiivDJXxv7xwdnDLAQRsdzy4gjljCwj/AGoD/wCyQ/8AuP8A5Sxy80+gpeyyw1FzdfLeY31MlBb2TxyTTh5YHPJLMNZuj5HA8eq1lpCt05QXs1eorbW3CijO6Kkjma0O58hI7HMeoAZ/Yg7h7O9Tfjjo23X40nc++B54HE4mza9zPpYGc7c9PFZGrNo2upbnpO0V1vpG0dJU0scsVO0ACJrmghvLlyV5RRERAREQEREBERAREQEREBERAWvdYdkOldW36a73iKrdWTNa1xjnLG4aABy9gWwkQaj/ANnzQv2Fw/Wj/JVFd2EaMrpxLVMuUkgjZECao8msaGtHTwa0D3LaiINdaj7G9IagqKSaupalrqamjpIxDMWDhsGG58zjxXMPbvp+j0vrw2i2OnNHT0sQjE0m9zQQTjPlzXcaoayzWytmM1ZbqKomIwXywNe7HtIQaU7KeznTetOy3S9XqCjfNNTNnY1zJHR7mmZxw7HMjOfiVn+puyrSuorZarfV0T4KK2B4poqWThhu/buz5/RHP2rNaWmgpIGw0sMUELfoxxsDWj2AKVBhum+zXTOn9P11kpqI1FtrZOJPDVO4occAePToFjh7A9BGp4v4Pqg3OeEKt+32dc/tW1UQYdqDs301e9MUmn56I01qpZhPFDSu4eHhrm5J8eTj1X3QPZ3YdCSVr7BHUMdWBgl40pfnbnGPL6RWYIgsWrtI2PV9A2k1BQR1cbDljiS18Z82uGCP81hVB2D6DpKps5ts9RtO4MnqXuZ7xkZ9hW0kQYJrLsp0vq6po5rrTTMNJAKaFlNJwmMjBJAAA9ax7/Z80L9hcP1o/wAltxEFFY7XTWWz0VsoQ4UtJC2CIPOSGtGBk+KrURAREQEREBERAREQEREBERAREQFoftX7brporW1XZKS00VTDAyNwkle4OO5gd4e1b4XFnymfyvXT/Bg/hNQdY9nl/m1Tou1XqphjgmrIjI6OMktb6RHLPsWRLk2XtfuOj+zvSti04yAVvcuLUVErd/D3Pdta1vTOOeTnqFQV/bxrYado4DJ3S5iUvNb3aPFRERyG1zcAg+Leo/aHYKLS3ybNcag1pBqB2pK4VbqV0AhxDHHt3CTP0GjP0R1UPyh+1G76Kq6C06fbHDVVMBnfVSRh+1u4tAaDyzyOcg+CDd6Li+19q/ajOx9bR11ZWU0bsSOFAySMHrgkM5dVnOqu3W+0WhtPupYqWK/3GKSaebh+jE1sjmDawk8ztPXIGOiDpda47atfXPQdqoqi02Y3B1S9zXTPDjHDjGN23nk5OOY6Fc5N7YO0uibDXVFyqDTSnLHT0UYik9QOwfsKzfVfbXqCs7N7JeLNNFbri+slpK1rIWSMeWsa4EB4OAQ4FBs7sR7Q7tr2luL7vZxRd1LAyeMOEcuc5A3eIwPE9Vs9c09nvbReabQupr1qadtynpJqeCihEUcIL5BIcHY0cvRyfYsKn7de0OtnlqaSphhp2c3Rw0THMYPWXAn9qDstFzDQ9vF7unZ9qAO4FHqOhjhmp6qGMFkjDNGx+WOyAcP9nPwwrPobtl7QrhXXCFpde5xRSPhgbTxMEbgW/OuLWgkNG7lnmSEHWyLkns47eNR02oqaHVNYyutUpLZC6FjXx8uRaWgeOORyrfd+2/XuoLvI2wSupISSYqSkpmyvDfWS0knz6D1IOxkXK/Zd246l/GygtGq3x1lLVTtpnPdC2OWFzjtB9EAEZxkEZUeu/lAaiqr7UUekWw0dHHKY4pOCJZZsHGcOyAD4DHvQdWIuTtH/ACgNT269QU+rWRVlE54ZMTAIZowf7Q24HLrgjn6l1gxzXsa9hy1wyD5hB9REQEREBERAREQEREBERAXFnymfyvXT/Bg/hNXaat1bYbRXVDp621UFTO7AMk1Ox7jjpzIyg4a1jpuvo7Bpy+GCR9urqFgEwaS1kjS5pYT4HAB9efUp9aaq1Xq3TVrqL81rrVSSGnp5mwNjD5NvPmOpAAzjkF3OygpGUQo2UsDaQDaIBGAwDy29FTzWS1T0sVNPbKGSmiJMcT4GFjCeuARgIjQPyOf911X+nTfulX35TWoTbtTW6huVhorrZ30bZGunY9j2S73hwZKwgg4DMjmOnJdA2612+2CQW6hpaQSY38CFse7HTOBz6lVE8MVRGY54mSxnq17Q4H3FFfn5Jf30l3FTpFtfZGkACKKtdI4u/SAaSOnI5Wb9rNn1TcdN6W1Rf6OcySUJpqiThbSwtleWOeB9Eua4HK6+pbDaKScTUlqoIJh0kip2Nd8QFcXNDmlrgC08iD4olnCNR2o6rqLBbLL36MUdAGtgDadm7DW7WgkjngclknaO7Uc3ZLpqq1Y5/eai4TPp2PhbE5sPDaBkNA6kE8+eCF13BY7TT1HHp7XQxT5zxGU7Gu+IGVLcLZQ3JjGXGipqtrDlonibIGn1ZHJBxZojTVfqbsr1XHaoX1FTRVtJV8Fgy57QyZpAHicOzj1LHtP6tq7BZrha2UcUoqHHPHklAjOMH5sPDHHl/aaf8l3pbrXQW0SC3UNLSCTG8QRNj3Y6ZwOfUqKoslqqajj1NsoZp+vEkp2Od8SMoOPKGS+XLsq1TX1VpttLaI4YI2VUVvjgklkNTFya5oGQADnw6Kp+TL/xvd/+TVH/AHo12HU0VLVUhpaqmgmpiADDJGHMODkeieXLAVLRWO00MrpKG10NNI5pYXQ07GEtPUEgdPUg/PrT1tfeL/bbbCQJKypjp2k+Be4NH71e9PXzUfZpqeolpYzQ3RjHU8sVTCDlpIJGD62g5Hku5oNN2OCaOaCzW2OWNwcx7KVgc0joQQORVVX2yguAaK+ipaoN6caJr8fEIOROyrUmuNUdoFKyiq3SRz1QnrpBTR7GR7svJO3lkZA/YsNuluuvZxrotrqSQTUkrjHufJG2eM5Ac17C12CD1B9R8Qu8qSkp6OIRUlPFBGP7ETA0fALzXUFJXxiOupYKmMcw2aMPHwKDinTWoNQan1i2Oy2K0VNTVSN9CWgbUiMchudJJufgdSXOXbkLSyJjXYyGgHaMD3KChoKOgjLKGkp6Zh6thjDB8AFUooiIgIiICIiAiIgIiICIiAiI4hoJcQAOpKAi1B8pa91du7OYKuxXOelm/CMcZmo5yx2NkhLS5p9Q5LB/kvaqulxv17GoL7W1UDKZhYK2rc9rXF/huOAcIOl0VPFX0krXuiqoHtjG55bICGjzPkvkNwop5BHDV08kjujWSNJPuygqUUVRUQUzA6omjiaTgGRwaCfeqd92t0dPJO+vpGwR43yGZoa3PTJzgIK1FDBVU9RTNqKeeKWncNzZWPDmkeYI5L5DW0s79kNTDI7yZICf2IJ0VPPXUlPJsqKqCJ+M7XyBp+BX01tK2nE5qYRATgSF42k+3ognRQU9ZTVJcKaohmLeZEbw7HwXw11I2XhuqoBJ02GQZ+CCoRR1FRDTsD6iaOJhOA57g0Z96iZcKOSOR7KuncyNu57hICGjzPPkEFSipYbjQz0xqIaymkp29ZWytLR784XqCvpKh+yCqglfjO1kgcce5BUIqRlzoHvaxlbSue44AErSSfLqqtAREQEREBERAREQEREBERAXKvyp9Y3KTVTdNU1RLBbqaFkksbHFvGkcM+ljqAMYHnldVLR3b72RVusbhDfNOOhNybGIZ6eV2wStGdrg7puGcc/DHkg0NfNI6o0/2bUNzrKmD8X7vNFOynZNucH7HFji3GAS0nofasXpP+G7l/2mn/7sq2ZL2L9oc+mcVUM0jqacR01tNWxwDCCXSDL9rRnAwOZyfJVWmexDV1TYr9SXO3NoahzIpaQyzxubJIxxy07XHGWudzPjhEUPYj/wf2nf8jf/AN2RWn5O/wCWTTv6U/8AAkWUaQ7Ie0Who9QwBhtlPU0MkT4myxSGtOCWxDmdoJ6uJHIlV3Yv2W6y092mWW6XiyupqCnMpllNRE7bmF7Rya8nqQOiDNvld/8AAVp/5m3+FItI9lOg71r+hvVBaLjTUlLA+nlqGT7sSO+cDDyB6en8V0V8o/Sl61dpC3UWnaI1lTFXNmewSMZhnDeM5cQOpCs3yZ9Eah0c/UR1JbnUQqhT8HMsb9+3ibvouOMbh180GlO1WsvemxQaDnuB7paIGiVlO4tjmkkJk3HoTgPaOfTBVmdovUVvloJ7Zxaieb02Po2ytMThg83ua1ufW0n2rfvb52P3HVt3Zf8ATbon1zo2xVFNI7ZxNvIOa48s4wMHHQLVjOxvtMvE1NT3OmkZDCBHG+rrmPZE31AOcQPUAgqe2azX6fRGlNRanpXxXdgfbqt7nNcZACXRPdtJGSN2fYsMr9Xvqeyy16Wyc0twlqHfoFo2D7z5PgF07dey1sHYhUaRoXmqr44zURyHDeJUB2/lnkAfo+wrnhnYl2gue0HTzmgnBJqoOX/5oPdNVXLRvZHTVVvmkpKrU1XIHTRHa/u0AA2g9Rl7z08AsZoNKXS5WJ14pHifDsCFjJXynnjOQwtHPzcCuq+0bsmi1F2c2ixWuaOnrbPG0Ur3j0H4bhzXeW7AOfMLQ47Hu06Omfa2UM34Pc/e6NtfGIXO+sW7/wDJBDqL8bqbsfFDqiCpFvjucD6KSokDnN+amDmdScdCM9OatHZ7ZLjedMa0NFdHUNLR0Aq6mJrM95DNxDCcjA5E+PhyWw7l2F6ht3ZuYaWFtx1BVV8MssEMrWshhYyUYDnkAnLxn3Y81X9lfZrq2yaZ15S3S0OgnuVqdT0jDPE7iyFrxtyHEDqOuAg0BRXOqo6KvpYJntp62MRTRg+i8B7XjI9RaFs/5L/5SZv+Wz//AMqPTvYXrSrurILraTRUr45Qah9RE5rH8N2zIa4nG/aOQ8VeNA9j/aJadVB8eLNEY3xS1zJYpcxkYLWtySSfDIGOuQg1j2cflD0v/wA1pf4zV366spm1QpnVMIqCMiIvG8+7quQNE9j+urdrOwV1bYXxUtNcKeaV/eYTtY2RpccB+TgA9FX3fsY7QKjtAnqoyJGSVZmbdTUtG0bshxGdwIHgB7EHW6L4wFrGhxyQME+a+ooiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiLF9Tajda73QUzJaZkI2yVQlcA4se8Rt28/MucfUz1oMoRYrfdR1sFNefwbQBzreQwzSyAMLi1ruQwSeTvUqma9S0tXOyphlNSIoNtLG9rmb5JHtbhxAOTt5k8gOnjkMhRY7V3iqhqLeauB1EzjSNnaSJGvY2F78tcPDIHkeSiotWx1Eckj6KYMFO6pjEThK5zRj0SB9F3Mcufjz5IMnRW2xXVt2glkYxjeG7adkzZQeWerTyPqOFSV957jW1TBHPUvD4I2wgtABkJAwevtyfYgvqLFJdQ3GS4UFPS0EQeamSmqY5J8Yc2IvAaQ08sbTn3YVTT6ojnuQp2UxMBndTCUSAu3tJBJZ1DcgjP7Mc0GRIrBRakEwp5qmjkpaOcyNjmkeOZYCTkDoCGvIP8Ad9appNTR07ZJ5o6gOfFTujpnloAdKX4GcZB9HJz0xy9YZQisNDqSOoMLZqcwl05p3O3hzA7ZvBDscwQCM8ufLC8Qaohno454qWdznOlLoRzkaxjN+7HrBZgf3wgyFFa7DeGXeKV7I2M4ZA9CZknUZ57TyPqP7VbbdqptwmY2lpN0c4caZ/FB3EAkbwBlgOOR5+vB5IMmRWXTlyrKzT0VdcaeKOR0Qk+bk3bxjOegx7Oao6bUtVUup2RWeXi1NN3uFrp2gGPlncfA+k3lz6+3AZMixt+qoQ6he2D+j1LYXBzpmteOKQG4Z1OMjPT1ZXo6kdNU1lLS0rePCJA1ss7WOJZyyWfSDT4HBzy6ZQZEixOm1RUx2m1PraSHv1bAJw0VAawtDWkuJI5HLhhuD7VVjU7HcBzaOcROpnVU0jiAIWNJDs+ZyOWM5QZCixuqvNcba+Y0MtGXCN8Uhe14LXPaCHeTsHpz9vJTnUTGXplBJABxJHRMc2ZrnlwYX82DmAQ04PXpyQX1FjNPq2KaiqKkUr8RBh2CVjnt3HA3tzlmOpzyAB8l9l1XGKelMUEb56jiFre8s4e1hAcd4yOrgAMZ5+CDJUWNzashYKQilkbx4xJ89IyID0tpaC44c7I6A9MHPMLJEBERAREQFbqiy0NSa41EIlNa3ZKXc/R27cDyGM9PEkq4qxXC91UNwrKakt3eRSQsnkeZgzLXbuTRg5d6J5HA9aCs/AtGaSuppGvfFWnMwc85cdjWdeo5NHTxUT7BRPbIH8d7nxxxl7pnOeNjnOaQ4nOQXE5yqL8ZS9klXBR77XFIyOSoMuHgu28wzHMDcM8weuAVUm+gQ0shp/6+slpMb+mziel08eH09fqQSw2Kjjcx8hmnkbI6UvmkLy4lhYc58NpxjovNJp+kpd2yWrcOEYIw+oceEw45M58ug59eQ5rzbLzNWacF2loJIw+HjxwMdxHvbtyOg6nyVorNS109FBJbIKN0nfYYJG96zgOcOR9DIJzg5Ax1GUF8gs0UFS2eOoqeKZBJK4yc5cMLQ13hgZzjzGVNPaqWapfO9ruI58byQ7xjJLf3q2O1BUsnq2Pt4DKWaGCSQT5BfJw+TfRyQOJ446Dz5SVV+kZcpqCloxNVNmbDGHS7GuzFxCXHBwAOXQoKmew0M8rpHtmbI6o71vjmcxwfsDORaQcbRjC+RWKkirRUMfUBokdMIOM7hB56u2+fMnyyc9VQvul4derdTsoII4pYZXTMkqMEFr2DIIYcjDsjpnPPGF9m1O2K2UVYaUkVME0+zifR4bC7HTnnGEFdVWKhqrSy2zMcaVhDgNxB5HPX18wfUSF6rbLR1kk8krXiSURgva8tLTGSWFpHQguKtVTqaqifFC21OdVOhFQ+LiOOyMkhvNrD6RweXTl1VdQXqSuugpYaKRsIp46h8srtjmb92G7MZz6PNB6k09RTWyooZzPNHUPEksj5SZHOGMHd4Y2gcvJTfgai77PViNzZpoeA4teW4b6sdDyHMc/RHkqaS+iOrfSmnPeG1Ih27v7GzfxOnTaD7xhU0d/q5YIXi3xxCshdLRl1Rnfhu4B4DfRO3ny3dEF2oLbDRTTTMfLJPMGtfJK7c4hudo92T8VT0VipKOqZNE6oLY9xihdKTHFu67W9B1PszywrZZ77c5aGyNqqCKSqr4BKXxz+iGhrCXu9EYzu6AHngZ8RLZtTOudXA1tBM2jqd3BnG48gCQXjaA0EDlgnw6ILrQWumoaOSlp+KIH59F8rnhoPg3JO0eockp7XTU8tNJG1wdT05pY8u6MO39voBUlXd6ltfUU9DQd6bShpncZgwjcMgMBHpHHPmQOY5qnk1FMJJ2st5IbU9zhLpQOLJ18vRaBkk+o8igkGlre2HhRmoZGRGC1spAJjADHe0bR6uXRVbbNTd8ZUSPnlcwvcxskhc1hcCHEe4kerPLCt/wCG3vrKanqIZaerZVmCWKGQPY48F0g5luS0geQOf2xU+q+NSVMvc/nIgxxhbJmRgccfOMxuZjqeRGAeqIrW6boo6anhp5KyDu4LYpGVLy9jSACwEk+jyHLpyCq6e0UcAaGRlzRB3fD3F2WZzg56k5PMq0yanP4PgqIIaSR0peMCsbt9HqGkAlx59No6c8ePibVT+FJPS0BlpYqKKvle+UMLY3hxwBg5cA08sgetFV8WnKKNpa59VK0MEbBLO53DaHBwa3PTm0evkF6/F6i7wyYOnBZUOqWNEp2te7O4gevc74nGF4p7zUVNS90FBvoGTup3TiUB4c0lrjsI+iCCM5z6lT2PUj7pUwA2+WKmqWGSGb0jyxkbwWgNyOmCUFYyxUzXvkM1W6YsEbZXTHexoOQAfb1znPjleHado9jTHJUxTh75DURylsji/G7J8jhvLpyHkryiC0zWCjlpW0xfUinEXBfGJnESM8nZ6k5OT1OequyIgIiICIiArHU6egrLtW1VU6Qx1EUcWyOV7NzW7sh20jI9L9/mr4iC2OsdA6oM3Bc3LmvdG2Rwjc5uNpLAdpIwPDwHkvhsVAalk5jkLmSunY3iu2te4EOcG5wM7nfEq6IgpoqGnhtrKCNrm0zIhC1occhoGAM9enj1VI6w0D4Zo5WSyGVzHve6Z5flhy0h2cjB6YKuiIKA2mjMFVEY3FlS5r5CZHFxc1rWg5zkEBjefmM9VB+L1v8AnDsm4r5BMZRO/ibw3bkOzkejy9iuyILayx0MbaYMjla6nc57HiZ4dlxy7c7OXZPMg5yoXabtrz6cUjhtkY1pmftY2QYeGjOADnwV4RBbq+zUdc9j5hMx7WcLdDM+Mln1SWkZHtU9LQU1JM+SniEbnRsiOCcbWZ2gDwxuKqkQUjrbSuuguLos1Yi4G/J+hnOMdPeoKKyUNHK18Mb/AEGlkbXyue2Np6hoJw0ch0VyRBb6CzUVBwO7RvaIGuZEHSufsa7bloyTgeiOXhjkvFJY6GkqmVELJQ5hcY2Ome5kZd12sJw3x6DxVzRBba+yUNfO+WoZJukaGSBkr2CVo6B4BAcOZ6+eFJLaaOWnlhfEdkkvHOHkEPzncCDkHl4KuRBborLQx8MiJznxymcPfI5znPLCwlxJyfRJHP1eS8tsdG0ud/SDIWhgkdUPL2tByAHZyOfxVzRBahYLeHNcI5Q8b9z+M/c/fjduOeedrevkEisFuio5qVkLuDNTtpHgyOOYm7sNznPLc5XVEFsNjoTV94Mcm7icbh8V/D3/AFtmdufHOOvPqvFPp+gp3ExNnA4bo2N7w/ETXdQwZwz3Yx4K7Ig8xMEUTI2lxa0Bo3Ek8vMnqvSIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8kPzyLcexekQecP+s34Jh/1m/BekQecP+s34Jh/1m/BekQecP8ArN+CYf8AWb8F6RB5w/6zfgmH/Wb8F6RB5w/6zfgmH/Wb8F6RB5w/6zfgmH/Wb8F6RB5w/wCs34Jh/wBZvwXpEHnD/rN+CYf9ZvwXpEHnD/rN+CYf9ZvwXpEHnD/rN+CYf9ZvwXpEHnD/AKzfgmH/AFm/BekQecP+s34Jh/1m/BekQecP+s34Jh/1m/BekQecP+s34Jh/1m/BekQEREBEXNXymO0u4Ul0OlLFUvpWRxtfWzRO2vcXDIjBHQYwTjrnHtDoSovtoppXRVN1oIZW8iySoY0j3EqL8ZbF+erZ+tR/zXAFostzvb5ha6KesfEN0nCbuLRz5n4FUDmOa4hzSCPDCI/RKC/2eeRscF2t8kjjgNZUsJPuBVyX5tEEYJBC6B+TX2l3Bl+g0peql9TR1QIpJJXZdC8DOzJ/skA4HgcY6oOpFSVtzoKAgV1bS0xPMCaVrM/EqC5zyPq6e30zzHLO10kkgHOONuAceG4lwA958EdDarHRzVT2U9LCwbpZ39T4Zc48yenMlFePxjsf55tv60z+afjHY/zzbf1pn81WUVVSV1NHUUcsU0Emdj2EEHBwV9iqKWaWaOKSJ74XBkjQQSwkAgH3EH3oKL8Y7H+ebb+tM/mn4x2P88239aZ/NXL5vBPocuqip6mlqOJwJYpOG8xP2kHa4dWn1oKL8Y7H+ebb+tM/mn4x2P8APNt/WmfzVzIYOoaoXVEDalkBzxHsdICGEtwCAcuxgHmOROT7igovxjsf55tv60z+afjHY/zzbf1pn81c8M/ur583gH0MFBbfxjsf55tv60z+aDUdkJwLxbc/9qZ/NXP5v+75qB1RSd7ZSOkh7xJG6RsRI3OYCASB5AkfFBPFIyWNskT2vY4ZDmnII9q9K0VlvZQRy1tphbFOwF74Y/RZOOpBHTcfB3XPqyFc6eZlRBHNE7dHI0PafMEZCCRERAREQEREBERAREQEREHzK4t+UtaKm3dqdfVTMcKe4Mjnhf4OAYGke0Fv7vNdnFyxvXOkLNrW09wvlOZGtO6KVh2yQu82n/LoUHCVjur7TUVE0cbZDLTS05DjyAewtJ92Vl7u0uolrBNUWyCWMtO6N0z/AKXFjlG05y1gdE3DByALvNbTqfkzQOmcaXVMkcWfRbJQh7gPWRIM/BRf7Mv/AMWf/rv/ADURpzWes5tUUVvp56RsJpC8hwkJzuxyAwAOnXmfXjkrx2A2apvHanZTTtdwqKXvczwOTGs5jPtOB71s+D5M0QlaZ9VPfHnm1lBtJHqJkP7luTQGiLLoa2OpLLC7fJgzVEp3SSkdMny8gOSC9VDjT6kppXj5qpgdAHZ6PadwHvBf91e9SWqO+2Sqts0j4o6gBrns6gAg8vgp6qKKqgdDO3dG7rzII8iCOYI6gjorcaa7RAMpbnA5g6GqpTI/Hllr25+CKtV10Db62op3QTzUkUUbYw2MAvbh7n7mPOXNc4uO45y4dVQ0fZvT0zB/TWOfxeIR3KLhD5tjCRH0DsRgh3gS7wOFkXDv35xtf6hJ/rJw79+cbX+oSf6yDGajs0ino7pA+5uPf5o53Zp2hrXsL8O2tIBJD+fgdo5eC9VPZpSyRvZFWtiBrBWNcKVm4O24OcYDvEjIIGehWScO/fnG1/qEn+snDv35xtf6hJ/rILVq3Q8eoq6ad9xmpo5ogySNkbXZIjlYHAnmOUzuXqCp6zs6o5zGIqt0UcUkj44eC10Q3uicWlh5FuYun94lX3h37842v9Qk/wBZOHfvzja/1CT/AFkGI0XZkZbRS0twuc8W2PbLHABzfw5Yg4O5EejJ06clWM7MbZ+D6OkmnfM2mJLOIwOAJmZKcZJwDs29ejisi4d+/ONr/UJP9ZOHfvzja/1CT/WQYseyq396fMK+qAdE+IM/stacgNAzgNAONuPDPqV4t2iKS33uguNNIwOpDUhsZgaQGTScQMaf7IaeQx4EjxVx4d+/ONr/AFCT/WTh37842v8AUJP9ZBdblVso6GeokBIY0kNAyXHwaB4knAA9aisVK632S30bzl9PTxxE+Za0D/JUtPRSGds9wqTVSs5sa1myNh8w3JOfWSfVjmrjvQT5TKg3pvQT5TKg3pvQT5TKg3pvQT5TKg3r6HoJsr7lQh69ByCRF5yvWUFOGPcM9F8ML/MKpRBS8CTzCcCT6w+KqkQUvd5PNqd3k82qqRBS93k82p3eTzaqpEFL3eTzand5PNqqkQUvd5PNqd3k82qqRBS93k82p3eTzaqpEFL3eTzand5PNqqkQUvd5PNqd3k82qqRBS93k82p3eTzaqpEFL3eTzand5PNqqkQUvd5PNqd3k82qqRBS93k82pwJPMKqRBS8CT6wTgSeYVUiCnELx4hfObTgqpUc4zGT4hB8a5e1TscpcoJUREBERBbb3cDQwNLMb3HllQWG6muLo3+lI0ZJxjCuFbRQ1kbmzNzkYz4hUtotEVtdI5j3Pc/lkjGAvl4lGcjO01UTHdTG/2emmcHuZiY+Jg9o7SpJqyqdcKONtugE/ElpxI50Rjk2Na7LdpL/AA9VdpO0ezwy0sNRBXQ1E07qd0UsYa6F7S3Idl2P7TThuTgrIfwBbfwNPau6tNBMXl8RJOS5xcTnr1OVbZNDWCSnjhko3vYx5kO6Z5MjiQSXnPpdB1z0X1HmW93aTZdtydFHVzNoQXSFjW+k0OLHOblw5Bwxg4PMYBV2r9WUFuttBXXCOppoKyNz28SPBYQwv2uGeTiAcDzCgqdCaeqY6iOWhdw55BK5jZ5GgODi7kA7l6RJ5eKuVXp62VtpgttZTmoo4XMexkr3POWnIJcTk+8oLHL2h2iF8nFgr2xMa4GXgZaZGs3uiBz9MN93I81W0usrZU6Vff2CfubXbNgAc8u3BoaNpIJJIA5+Kln0hZJ7hPWS0eZptxfiRwbuc3a5waDgOI5bhzUlPpa0QWWotUdL/Qqh5klaXuLnPJB3FxOc5A558AgtQ7QbSIqp8sNbC6ljnkljkiAc3hFgeOvXLx7eahqO0qxQS3KMiqcaHIcWsBDyHhjgOfLDnAEuwOp6BSUvZ3ZGU9RDWRyVTJJ5pQXSvDg2TbuYSDlwy0Hn4q5O0fZHSVbxSOaarnJsme0Z3BxIAPokkAkhBYZu0aF87G0lDKad8NPMJ5CNvzswi2+iTz68+Y5Krf2i2hvExBXkZaICIf95BkEW6PnzG8gc8dVXxaJsETYmsocNja1gHFfzAk4ozz5nfzyfMr1DouwwzPkZRek57ZBmRxDC1/EAaM+iN3PA5ZQUFN2h2ee426iEdWyetyGh7Gt2OD3MLTk8zuaR6OVV3LVdPb9YUNlnacVbdrX46SHJaOuSCGuyccjjnzUrtG2N1RTzGjO6CUzMHFft37y/JGcH0iTzU9Tpi01N7Zd5qYmva5jw8SOA3NBDTgHBIBI6eKDHr7rG5W+a/OprdBNSWl4bJI6Ug842Oby9ZcR7lUW7XEFZryo0+I4hExpZHMJAXPma1rns2+AAd182u8lf6mwW2pjuUc1MHMuJa6qG4/OEANHjy5AdFBBpSyQSQSQ2+Js0E7qlkozxOI4kkl3U53HkTjmglm1LY4JnxTXi3xyscWuY6oYC0jqCMqhv2o3Qw2ptjFLWz3OcwQSOl+ZGGuc5xc3OcBp5DxV/dTQOJLoIiTzJLAqO8WSgu9GylroN0UbxJHscWOjcOjmuaQQeZ6IMbtmu2SSmirbfUOukU8kM8dE3jMYGOaDJnkdvpt8M9eXJQ3XtGoYKSpfRUtVLJG5pi3xlrKlnGbE8xnxwXeOM8vBXj8SrCIaaIUOGwFxaRK8OducHO3nOX5IBO7OcLy7Q+n3d63UO4VH02mR+G+mJMNGfRBcATjHMIKGXtFtEcQc+nr97N5qYxDl1K1j9jnSc8AA+WVVW3WMFTp6rvFVRVNNTU1U+ndkBxw2TZv5Hp4nywVJJoewSMha+hJEe7J4r8yBztzg859MFwzh2Vcqew26CgraKOn/AKJWPkfNEXEtcX/Sxk8s5PRBY5O0GzsewNjrJIycvlZDlkTOIYxI45+iXNOMZOBnGEq+0Gz0tCKp7Kp0ZZLIA2MZxHNwXeOB6XieWOarpdGWKXuW6hAbRxMhia17gCxpy1rgD6QB588814/Emw753ijc10wcCWzPG0Ofvdt5+jlwzyxzQXayXOC82qmuFJu4E7dzd2Mj4Ej4KqqP6l/sVPZ7ZSWe3RUNuhENNHnawEnmSSTk8ySSSl4qW0dsqKh4yyNuTjyQ4eInKoyqOB2QCDyKqcoKpERAREQYHfb/AH6m1qKCnhEdrEbTxDTufuBa4ueHDxaQ30fH3hY03XOphQUffw2grZ3zNLDb5HkBsIdGQ3OTvJ5+WcdQtwqGWlglqIZ5ImOmhzw3kZLMjBwfDIQanfedUQVVRWNoal1SRLKIHNkcxjhSRuDQAcEby7l5g45qWm1zfOHVuA75FC+pgZLHQyNLpGwRviBZzIy5z/bhbZUMFLBTvmfBEyN8z+JIWjBe7AGT5nAA9yDBdLah1HX6tdR3GkbFQ8MktMDmloDGFrw7ockuGP5FUdVqXVdN3mVtK2eN4rBHGKR2YRFO1jHHB9LLHOdjlnbyWzEQagqdS6rDoauJ8ksbIaxsJFC9jKtzNhje5mctzl2B47Tjqsgt161M3W8NrrWRyUQa3dKKZzBI0x7jIHZIGHejgnw81n6INVan1tf7Zcr8KaA9zo4ZTG6akc0NezZtO7PpA5d5ZxyAVJXa41JDI6GFzHksqX0sht0m6rLOHsbszloLnObuPllbarKWCtppKerhZNBIMPje3LXD1hHUsDqqOpdEw1EbSxkhHpNacZAPkcD4INdVuodURQTTzFlJTvr30weKB8xp42tJDiAcv3Ow3PIBUVRqTU9bQVkVXDLQVL6Bzo6WKikc5zjAXbxKDhpD+WOvh1W2EQalrtTawttKymZAJnRy7O9mkeQRwI3taWgnq9zm7v7vmszvl7qxpOvrLQ1puNMRG5r4nuDZARuGAMnGeuMLJ15YxrM7GhuSScDqfNBqz8c9Rlth2Uc/En2mpa+hcA4GYsJBDjjDefTyPjheZNU6witb5nwxmWSmiqGk0b28ImVzHM8cna0Hn0z5La6INf3rVNzp9Naaq9xoqi4vDKh0tG57o/m3OJEQcTnLRyyVZIL1qme4WyqqIaijMktKaiFsLy1xdTvJbgn0RvDR6iRnotqz0sE8kL5omSPhdvjc4ZLHYIyPI4JCmQanp7xqe7GzOZVSxVImc6fFukjZCe7yExuBOHgOAAPnjqrxqK+338VrHUQRupJ66mL6p7aV8pik4O5rAwcxudyyemPNbARBrLRN+1NNe7bbrhTObRimjEhmhfvcOA13E39M7yWkH96mvmotV0tXeaekt4e23gyNn4BcJWSOZw9ozzLG8QuA+qPNbHRBq2PU2rnsgkEEfDjgjlfikf8AP5qXR46jaeGA7HPz6Kkt2pNW001FSuD6jdWTtlkmpHelio2iPI6DhncD6x5FbdRBBRVUdbTNnh37HEgb2Fp5Eg8jz6hW3WX/AAtc/wDBKvKs+sMfixcs/YlYxK4oomuehp1fDHV5oT8xF+iFXK30P9TH+iFXgjC1G8CpimjkGWuHsXx1TA1xa6aIOHUF4yrNO1ce9sLnDtQvwDiBxGeP/u2KjtrvdP8AbxffCd7p/t4vvhfn0xzvrH4qUudy9I/FEu/QDvdP9vF98J3un+3i++FwE1zvrH4qZjnfWPxWtKane/eqf7eL74TvVP8AbxffC4Ic53EHpHp5r21zs/SPtyuc1WmzrTReLu9O9U/28X3wneqf7eL74XBLHElw3H4qothdul5nw8Upm82SqnTF3d/eYPtovvBO8wfbR/eC4jaXcvSPxUzC76x+K66HLW7W7xB9tH94L73iH7WP7wXHFIXcMcz8VVsLvMrEtRLrzvEP2sf3gnHh+1j+8FyRv2MLnOIAGSvrKpvlN/8ASd/JC7rbjw/ax/eC+d4gzjjR8/7wXJzp+IzYxsxc4gc43Dx8yFcWgnHMoXdQ8eL7Vn3gvvGi+0Z94LmRmfMqdgPmULulONF9oz7wTjR/aM+8FziwO8yp2A+ZQu6H4sf2jPvBOLH9oz4hc/sB8ypmNPmULt9cWP7RnxX3iM+u34rRbAfWp2NPmUG7RIwnAe34r0tMRbmkEEgjmCFnFn1SG0Dm14Lp4x6JH/pP/FFZc97WDL3NaPMnCwbtFvUbrS6jpHh/EeGyOHTHXH7Fba6tnuFS6ad3XkGjo0eQVp1A3+gN/TH7ivF2jMxlcSY8nXA3xIbGof6mP9EKuHTxVFQj5mP9EKvHReyniHKVJM3kuOO2Qf8AWlfv8Rn8Ni7LmHVcbds/5U7/AP4jP4bEkYixS45BQs6qcKwzL0wc1M0KJuBzKOqo2EAHcfUukMppdo2ZOCTgetAwnxOFQVUrnbJcDMbsgeroq+F4kjDm8srjixaXowZ2eWs2uzuOFcLe0CHcP7RJKtUshMuwEZwvdLXOpnbAA9nlnmCtYVEz8TGNX+1kLApmBW2kuUE3InYc4GfFXWLDgNpBz4hd7WedXUwAjHMKqZjzCoG08RPOJhJ/uhTNp4fso/uhcZh0vZU1eO7P5jw/eFXsAVuip4muBbFGCPENCq2BLGpWsAU7APBULAp2BLGpXMA9SnYAqJgUzArpTUr2AKdgCoGBTMCaTWrhta0ucQABklWjT2qbderlWUVJITJTvw3II3twMkcvPI9yuDAvlJRQU01RLBGGSVDw+Qj+0cAfuCaTWu7Gj1KdgA8lQMCgutfDa7dUVtU7bDAwvd/L2noljUuNxuVFaqV1TcamKnhb1dI7HuHmfUsRn7WtMQTbGSVczQcb44fR/aQf2LRuqdQ1uori+qrZDw8nhQg+jG3yH8/FWhjJJA4sjc4NGTgZwstusNM6zsOoHiO218bp8Z4MgLH+4Hr7ld9Q4NAzH1x+4rjmCaSGZksL3RysIc1zTgtI8QVvzs61g/UlhdS17wblSObud4ysOcO9vgf/ABXh7T+kxPR1wPmUujqIfMx/ohVqo6LnDH+iFWL208Q5yjlXGnbP+VO//wCIz+GxdlyrjTtn/Knf/wDEZ/DYgxFnVTNULOqnaqy8VUbnMBbzA6hUwaOvu9yubFHLSh3OPkfJdKarcszCk5ZG4Zb0KnpX8KPaRkDpyXh8b2HDmkf5r1GTwzz8MH1rU0xUtNc08PH0pXvOckYAC+sjG7p1XsD4eJVTTUskxBaw4JyT0AW4tDE7qaKLLG4ByTyWUWaldTwZkJ3O57fJRUFAyna0vw+QDr4D2K6R9Fiuu+0ER1TM6qdoUDOqnauaymYp2KBinYiJ2dVOwc1DGp4+qomaFM3qomqZvVBMxTsULFMzoiJ4wpmqGNTt6oJmrX/bPco4NNMomygT1Ezcs8SwZJPxAWwWrH9eWQ33TVVSxtBqAOJCT9dvMD38x70lY5c4QsEs8UbnBjXODS49Bk9VsTtRxorXJtOmY/wfHbGxGOpj/rp3OjDi9z+pB3Ebfo+pa6ljdG9zJGlr2kgtIwQfJXxmpqqd1H+G4mXaOjaGwR1Pg0dGue3Dy0fV3YWHVknbLb6SC46fulLTxUs14tMFfUwRNDWNlcCHFrR0BxnHnlW/snmki1jAxhO2WN7X+wDP7wFYdSX2v1Jd5bldZA+oeA0BrQ1rGgYa1rRyAA8FnvY3YpS+ovczC2Fo4EJI+kT9Ij2Yx7yvH2hNsriX8pdcH5lPq68t/wDu8fsCrVRW/wD3eP2BVq9dPEOco5Vxp2z/AJU7/wD4jP4bF2XKuNO2f8qd/wD8Rn8NiDEWdVO1QM6qdqrKdngp2KBngp2KomZzHNexDGesbfgvEanZ4Ij3FDG36MbR7lVMUDFOxUTsU8fRQNU8fRBMzqp2qBnVTtRJTMU7FAxeKyR0bGFjiCSjMzaLrlGp4+qxi+akgsTKQTwzTyTg7QzA6dck+1fKPWtukqJY6hk9MIoGzvfKzkAdvLA559IK3aZe1TN6rGhq6yAOJrm4awyE7HfRBxnp5r27WNkZJJGytbJMyMycNrTl2G7sA4xnHgl0sylimZ0WI2/XFlqKCKpmndTcSN0vDkYSQ0OLSeWR1CrY9ZWAvkZ+EYw6Nu9+WuAAxnPTyS5aWURqdvVYkzXWm+CyX8Jxlr3Oa30HZyACRjGfEKa6avpbXqCjoKlgZTT0r6p1U5+AxrQT9HHPohZlzV725Vk0/qS03587LTWNqXQBpk2tI27s46j1FX5vREYDrbs7pb7K+sonikr3c3HHoSH+8PA+sLXc/ZlqWOXZHTQzNz9NkzQP24K6HDcr22MKWaiqYaY0x2R1ElQyXUFQxkIwTBAcud6i7w92Vt2WigoLTDTUkTYoIiGsY0YAGCrlGzChu4xRt/SH+a8PacWymJ6OuXm+LS2bRDEEf6IVWqWk/qY/0QqpeuniCUcq407Z/wAqd/8A8Rn8NiIgw2UkQvIODhfLa5zt+5xPTqURVlc2KdiIqiaNTsREJTtVjjqJvwyGcWTZxsbdxxjKIiLpqVxbZJy0kH0eYP8AeCudqJNupSTkmNv7kRBXs6qdqIqkpmKKv/q2e1ESWK/0sO7SnHhUTMnYYJDt8MjHNYhI5wiqAHEB1ujBGevNiIo6U8QvPaGS2upNpIzaowcePpKis08rLq+FksjYXGQuYHENPzR6hETqscLVLI/8G0g3uwKSRo5+HEPL2LKqAA6Q1pkA4ZSf5IiEqXSMj5NT6fbI9z2tryAHHOPRasn7ZP8AiSL/AJXN+8oidDqqewGR8tx1C+V7nvLafLnHJPJ63S3oiLUcMVcp2KaNERlOxU14/wB0b+kP80ReHtT6TE9HfLfNpbNpP6mP9EKqRF6qeIV//9k=",
+              "timestamp": 80762410,
+              "timing": 5468
+            },
+            {
+              "timestamp": 81543535,
+              "timing": 6249,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAMEBQYHCAIBCf/EAFUQAAEDAwIDAwgECgcEBQ0AAAEAAgMEBREGEhMhMQdBURQiUmFxgZGhCBUjMhY3VXJzlLGzwdEkMzRCYnXTGDaSshcnU3TjJlRWZoKDk5WipcLh8P/EABkBAQEBAQEBAAAAAAAAAAAAAAABAgMEBf/EAC0RAQABAwIDBgUFAAAAAAAAAAABAgMREjEEIUEFEzNRcaEUIjTR8DJCYZHB/9oADAMBAAIRAxEAPwDqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEXxzg1pc4gNAySegWPRa40rNcPIYtRWl9XnaIm1TCSfDr19SDIkQkAZJ5eKx0640s2v8iOorSKvO3heVs3Z8OvX1IMiRAQQCDkHvVqvOobXZXsbdaryRj8YmljcIh7ZMbR7yguqLAu2uq/6pL/U0c/I07XMlif1Bc3mCFdjq/T1mpKCmu98t1HVOhj+znqGtdzaOZBPJBk6KOmqIaqBk9NLHNDINzJI3BzXDxBHVWW76x03Z6sUt1vtspKnOOFNUsa4e0E8vegvyKKkqYKynZUUk0c8EgyySNwc1w8QR1UqAiIgIiICIiAiIgIiICIvj3bWkoBcG9SAvgkYejgrXcrjSW+A1FxqoaaHIbxJnhjcnoMlUFHqWx1tSyno7xb56iQ4ZHHUMc53sAKDJUUFO8nzT7lOgIiICIiDW/bhPM+z2O0NmfT0l4usFDVyMO08FxJc3PdnGFkdXoXTFRYXWh9loG0OwsDWwtBbyxuDsZDvX1VZq7TtDqqxT2u5tdwZMOa9hw+J45te09xBWHy6L1nU0RtlVrx7ra5vDe9lvY2pczoRxN3XHfjKDBDfblP2H0dC6tlLJLwLI6va7Dn03FLd+fW0bcrbjNA6VbY/qkWK3+RbNmDC3d0xnd13evOV7m0TZJdEjSppiLS2IRNaD5zSDkPB9Ldzz4rGm6J1oyk+rm6/l+rQ3hhxt7DU7OmOLnrjvxlBZu0GqqdCdihp9O3iarMcraNlc54c+GNzyCNw72jzQeoWxdP6ctlv04y3RxCop5oQ2d8x4jqjI5ueT94nKjt2jbJRaPbpkUjZrTwzG+ObzjJk5LnH0ieefFUrtPXS2WUWfTFe2mptnDZUVr3VElO3phjeWcd25xwg0rTzy0/ZF2oWBsr5rdZq59PRvcc7Y+IPMz6sfNbn0TpSzUek6SM0tNXOq6dklTUzMEjqpzmglzieoOeQ7greOzOgp+zWu0lQVMkfloLp6yRu98khcCXuHLOcYSPR2o7TSeQaX1THRW0N2xw1VCKh1OO8Ru3Dl4B2cIMU0/VzaQ/6UbVZCXUFni8soYvvCB74nPcweoEZwsp7LNJWOHQ1tqX0dLXVVxp21NXVTxtkfO+QbnZJHMZPRXrRejqPTNnqqQyyV9TXSOmrqqoAL6l7upd6scgFjtFoLUOn2SUWkNW+Q2cuc6Kkq6JtSafJyQxxIOPAHKCDs+hjsHafqzTdrGyzMhgro4Actp5H5Dmt8AeuFtBYzojSMGl4ayR9XPcLpXScasrp/vzO7hgcg0DkAOiyZAREQEREBERAREQEREBeJxmIr2h5oMd1GKk20+RCuM24f2Lg8TH/AL3zcfNWKytu/wBaQeVDUXByd3lQoeH0P3uH5/wWbPhIPm8wvIieT91B9gH2gVUvEUYYPWvaAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiLHa6suDNQCGJ7m0oLMgx5GDjPPCxXXFERMutq1N2ZiJ2jLIkWP22qrai4VsMs0jQ0vEQMYAAzyOcfxVPQV12lpqyR4cXwxgNaYwNzs9enPksd/HlPX2dPhaufOOWPdlCLGbbX3OWgr3y7y6OLdG4x4O7HMAY5pHVXdllknnf9q5zeGdgJDT1yAP4KRfiYziVnhaomY1RvEf2yZFaKGpq5LBJPKX+Uhjy0lgByM45Kkpq+ukbacmTMjntnzHjOMY7uS130cuW7EcPVMzGY5faZ/xkSLGKK4XJ94qIZTJwGmTZmIY5Zxzwo6C5XP6urJahz3SBg4Q4WCCTjPTCzHEU+U9fZ0nhKojeOnv+c2VosYNwuQskziZPLIpQ3dwxkj2YwlTV3VlngqGSl04e5kgEfXwOMdyfER5TtlPhKttUb4/P4ZOiipWyMpo2zv4kob5zsAZPuUq7w808hEREEREBERAREQEREBERAREQEREBERARFFJUwRuLZJo2OHc5wBQSooPLKb/ziH/jCma4OaHNILTzBB6oPqIiAiLDu0TtFsugRQG+tq3eW8TheTxh/wBzbnOSMfeCDMUWLdn2ubTry3VNbY21TYaeXgv8ojDDuwDywTywVlKAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC4s+kz+N66foYP3TV2muLPpM/jeun6GD901Bidp0HqW70dPVW62OnhqP6otmjBdzxyBdnqt1xds1z7N7bbNL3rR7hV0NHCzc6v27xsGDjhn1jqeYK1ZpHWWlrBHbJ5tDtrbvRPbMK43WaPfI125ruGAWjGBy6clmX0l7/bL9DpGpiphFeJ7eyrn2v3cOOVrXMjJxzIO455fNEbA1h9IWjsdTb47fZfrFtTRRVb3eWcPhGQZ2EbHZIGOfrVBePpE1dofSx12jxHJUU7KlrTceYY/m3P2XeMH3rm2jY233igfeKWR9KHRTSRHkZITh3I+tvRbA+kZVUtb2iiqt7mPo5qCmkhcwYBYWZGPcg2zWfSStlPRWuSOyyT1FRG6SqijqRimO4gN3FvnEgZ7sZCwX6Q+tLVrnT+kbnZ3PDWvq45YZRh8T8QnB/mFgVHfNP0mgZ7VWaWbLfJyXw3R0xaQ0u5ED1YIwOR71jU1FUx2alrZA4Uk08scZPQuY1hdj/iag3/8AR51datF9mN+ul7mcyEXEMjjYMvlfwm4a0ePL2Kvd9J2k8r2t0xOaXP3zWAPx47dmM+9aKkpap/ZrT1MYcaOK7Sslx0D3Qx7M+5r1dYr3owdlr7XJYpzq0yEivyNuN+Qc7s/d83bj1oOjtQduFppNA0up7JROuLZKxtFLSyTcCSBxY9/nea70e7kc9eSxJn0l4JLRWznT4hro3Rtp4DWF4l3btxJ2DAaGjxyXBaIpaWqb2b3KqLXCifdaWNpI5OeIagnHsBHxC2n9FbT1nv8AV6kbe7ZSV4hZTmMVEQfsyZM4z0zgfBBsibt6tFBoq03a50UhulwY97KCnfu2ta9zdznHGAS3wJ+Cxyg+k5RPqWtrtNVEMBPN8VWJHAfmlrf2rW30krIyydovBpKSOktr6SJ1LHEzawN5hwAHL724+/1qx3S66NnobWwWysfLEz7cUrGUmDgci5xlMnPvO3+CDpHtC7a6HTNo09dLTbheKK8MlfG/yjg7OGWAgjY7nlxBHLGFhH+1Af8A0SH/AMx/8JY5eafQUvZZYai5uvlvMb6mSgt7J45Jpw8sDnklmGs3R8jgd/Vay0hW6coL2avUVtrbhRRndFSRzNaHc+QkdjmPUAM/JB3D2d6m/DHRtuvxpPI/LA88DicTZte5n3sDOduenesjVm0bXUtz0naK630jaOkqaWOWKnaABE1zQQ3ly5K8ooiIgIiICIiAiIgIiICIiAiIgLXusOyHSurb9Nd7xFVurJmta4xzljcNAA5ewLYSINR/7Pmhf+wuH60f5KoruwjRldOJaplykkEbIgTVHk1jQ1o6dzWge5bURBrrUfY3pDUFRSTV1LUtdTU0dJGIZiwcNgw3Picd65h7d9P0el9eG0Wx05o6eliEYmk3uaCCcZ8Oa7jVDWWa2VsxmrLdRVExGC+WBr3Y9pCDSnZT2c6b1p2W6Xq9QUb5pqZs7GuZI6Pc0zOOHY5kZz8Ss/1N2VaV1FbLVb6uifBRWwPFNFSycMN37d2fH7o5+1ZrS00FJA2Glhighb92ONga0ewBSoMN032a6Z0/p+uslNRGottbJxJ4ap3FDjgDv6dAscPYHoI1PF+r6oNznhCrft9nXPzW1UQYdqDs301e9MUmn56I01qpZhPFDSu4eHhrm5J7+Tj1X3QPZ3YdCSVr7BHUMdWBgl40pfnbnGPD7xWYIgsWrtI2PV9A2k1BQR1cbDljiS18Z8WuGCP4rCqDsH0HSVTZzbZ6jadwZPUvcz3jIz7CtpIgwTWXZTpfV1TRzXWmmYaSAU0LKaThMZGCSAAB61j3+z5oX/sLh+tH+S24iCisdrprLZ6K2UIcKWkhbBEHnJDWjAye9VqIgIiICIiAiIgIiICIiAiIgIiIC0P2r9t100VrarslJaaKphgZG4SSvcHHcwO7vat8Liz6TP43rp+hg/dNQdY9nl/m1Tou1XqphjgmrIjI6OMktb5xHLPsWRLk2XtfuOj+zvSti04yAVvkXFqKiVu/h7nu2ta3pnHPJz1CoK/t41sNO0cBk8kuYlLzW+TR4qIiOQ2ubgEHvb1HzDsFFpb6NmuNQa0g1A7UlcKt1K6AQ4hjj27hJn7jRn7o6qH6Q/ajd9FVdBadPtjhqqmAzvqpIw/a3cWgNB5Z5HOQe5Bu9Fxfa+1ftRnY+to66srKaN2JHCgZJGD1wSGcuqznVXbrfaLQ2n3UsVLFf7jFJNPNw/Nia2RzBtYSeZ2nrkDHRB0utcdtWvrnoO1UVRabMbg6pe5rpnhxjhxjG7bzycnHMdCucm9sHaXRNhrqi5VBppTljp6KMRSeoHYPkVm+q+2vUFZ2b2S8WaaK3XF9ZLSVrWQskY8tY1wIDwcAhwKDZ3Yj2h3bXtLcX3ezii8lLAyeMOEcuc5A3d4wO89Vs9c09nvbReabQupr1qadtynpJqeCihEUcIL5BIcHY0cvNyfYsKn7de0OtnlqaSphhp2c3Rw0THMYPWXAn5oOy0XMND28Xu6dn2oA7gUeo6GOGanqoYwWSMM0bH5Y7IBw/wBnPuwrPobtl7QrhXXCFpde5xRSPhgbTxMEbgW/auLWgkNG7lnmSEHWyLkns47eNR02oqaHVNYyutUpLZC6FjXx8uRaWgd+ORyrfd+2/XuoLvI2wSupISSYqSkpmyvDfWS0knx6D1IOxkXK/Zd246l/CygtGq3x1lLVTtpnPdC2OWFzjtB80AEZxkEZUeu/pAaiqr7UUekWw0dHHKY4pOCJZZsHGcOyAD3DHvQdWIuTtH/SA1Pbr1BT6tZFWUTnhkxMAhmjB/vDbgcuuCOfqXWDHNexr2HLXDIPiEH1ERAREQEREBERAREQEREBcWfSZ/G9dP0MH7pq7TVurbDaK6odPW2qgqZ3YBkmp2PccdOZGUHDWsdN19HYNOXwwSPt1dQsAmDSWskaXNLCe44APrz6lPrTVWq9W6atdRfmtdaqSQ09PM2BsYfJt58x1IAGccgu52UFIyiFGylgbSAbRAIwGAeG3oqeayWqelipp7ZQyU0RJjifAwsYT1wCMBEaB+hz/ZdV/n037JV9+k1qE27U1uoblYaK62d9G2Rrp2PY9ku94cGSsIIOAzI5jpyXQNutdvtgkFuoaWkEmN/AhbHux0zgc+pVRPDFURmOeJksZ6te0OB9xRX5+SX99JdxU6RbX2RpAAiirXSOLvzgGkjpyOVm/azZ9U3HTeltUX+jnMklCaaok4W0sLZXljngfdLmuByuvqWw2iknE1JaqCCYdJIqdjXfEBXFzQ5pa4AtPIg96JhwjUdqOq6iwWyy+XRijoA1sAbTs3Ya3a0Ekc8Dksk7R3ajm7JdNVWrHP8AKai4TPp2PhbE5sPDaBkNA6kE8+eCF13BY7TT1HHp7XQxT5zxGU7Gu+IGVLcLZQ3JjGXGipqtrDlonibIGn1ZHJBxZojTVfqbsr1XHaoX1FTRVtJV8Fgy57QyZpAHecOzj1LHtP6tq7BZrha2UcUoqHHPHklAjOMH7MPDHHl/eaf4LvS3WugtokFuoaWkEmN4gibHux0zgc+pUVRZLVU1HHqbZQzT9eJJTsc74kZQceUMl8uXZVqmvqrTbaW0RwwRsqorfHBJLIamLk1zQMgAHPd0VT9GX/fe7/5NUf8ANGuw6mipaqkNLVU0E1MQAYZIw5hwcjzTy5YCpaKx2mhldJQ2uhppHNLC6GnYwlp6gkDp6kH59aetr7xf7bbYSBJWVMdO0nuL3Bo/ar3p6+aj7NNT1EtLGaG6MY6nliqYQctJBIwfW0HI8F3NBpuxwTRzQWa2xyxuDmPZSsDmkdCCByKqq+2UFwDRX0VLVBvTjRNfj4hByJ2Vak1xqjtApWUVW6SOeqE9dIKaPYyPdl5J28sjIHyWG3S3XXs410W11JIJqSVxj3PkjbPGcgOa9ha7BB6g+o94XeVJSU9HEIqSnigjH9yJgaPgF5rqCkr4xHXUsFTGOYbNGHj4FBxTprUGoNT6xbHZbFaKmpqpG+ZLQNqRGOQ3Okk3PwOpLnLtyFpZExrsZDQDtGB7lBQ0FHQRllDSU9Mw9Wwxhg+ACqUUREQEREBERAREQEREBERAREcQ0EuIAHUlARag+kte6u3dnMFXYrnPSzfWMcZmo5yx2NkhLS5p9Q5LB/ovaqulxv17GoL7W1UDKZhYK2rc9rXF/duOAcIOl0VPFX0krXuiqoHtjG55bICGjxPgvkNwop5BHDV08kjujWSNJPuygqUUVRUQUzA6omjiaTgGRwaCfeqd92t0dPJO+vpGwR43yGZoa3PTJzgIK1FDBVU9RTNqKeeKWncNzZWPDmkeII5L5DW0s79kNTDI7wZICfkgnRU89dSU8myoqoIn4ztfIGn4FfTW0racTmphEBOBIXjaT7eiCdFBT1lNUlwpqiGYt5kRvDsfBfDXUjZeG6qgEnTYZBn4IKhFHUVENOwPqJo4mE4DnuDRn3qJlwo5I5Hsq6dzI27nuEgIaPE8+QQVKKlhuNDPTGohrKaSnb1lbK0tHvzheoK+kqH7IKqCV+M7WSBxx7kFQipGXOge9rGVtK57jgAStJJ8Oqq0BERAREQEREBERAREQEREBcq/Sn1jcpNVN01TVEsFupoWSSxscW8aRwz52OoAxgeOV1UtHdvvZFW6xuEN8046E3JsYhnp5XbBK0Z2uDum4Zxz7seCDQ180jqjT/ZtQ3OsqYPwfu80U7Kdk25wfscWOLcYBLSeh9qxek/3buX/AHmn/wCWVbMl7F+0OfTOKqGaR1NOI6a2mrY4BhBLpBl+1ozgYHM5PgqrTPYhq6psV+pLnbm0NQ5kUtIZZ43NkkY45adrjjLXO5nvwiKHsR/3P7Tv8jf/AMsitP0d/wAcmnfzp/3EiyjSHZD2i0NHqGAMNsp6mhkifE2WKQ1pwS2IcztBPVxI5Equ7F+y3WWnu0yy3S8WV1NQU5lMspqInbcwvaOTXk9SB0QZt9Lv/cK0/wCZt/dSLSPZToO9a/ob1QWi401JSwPp5ahk+7EjvtAw8genn/FdFfSP0petXaQt1Fp2iNZUxVzZnsEjGYZw3jOXEDqQrN9GfRGodHP1EdSW51EKoU/BzLG/ft4m77rjjG4dfFBpTtVrL3psUGg57gfJLRA0Ssp3Fsc0khMm49CcB7Rz6YKsztF6it8tBPbOLUTzeex9G2VpicMHm9zWtz62k+1b97fOx+46tu7L/pt0T650bYqimkds4m3kHNceWcYGDjoFqxnY32mXiamp7nTSMhhAjjfV1zHsib6gHOIHqAQVPbNZr9PojSmotT0r4ruwPt1W9zmuMgBLonu2kjJG7PsWGV+r31PZZa9LZOaW4S1DvzC0bB/xPk+AXTt17LWwdiFRpGheaqvjjNRHIcN4lQHb+WeQB+77CueGdiXaC57QdPOaCcEmqg5f/Wg901VctG9kdNVW+aSkqtTVcgdNEdr/ACaAAbQeoy956dwWM0GlLpcrE68UjxPh2BCxkr5TzxnIYWjn4uBXVfaN2TRai7ObRYrXNHT1tnjaKV7x5j8Nw5rvDdgHPiFocdj3adHTPtbKGb6vc/e6NtfGIXO9It3/AMEEOovwupux8UOqIKkW+O5wPopKiQOc37KYOZ1Jx0Iz05q0dntkuN50xrQ0V0dQ0tHQCrqYmsz5SGbiGE5GByJ7+7kth3LsL1Dbuzcw0sLbjqCqr4ZZYIZWtZDCxkowHPIBOXjPux4qv7K+zXVtk0zrylulodBPcrU6npGGeJ3FkLXjbkOIHUdcBBoCiudVR0VfSwTPbT1sYimjB814D2vGR6i0LZ/0X/xkzf5bP/8Aio9O9hetKu6sgutpNFSvjlBqH1ETmsfw3bMhricb9o5DvV40D2P9olp1UHx4s0RjfFLXMlilzGRgta3JJJ7sgY65CDWPZx+MPS/+a0v75q79dWUzaoUzqmEVBGREXjefd1XIGiex/XVu1nYK6tsL4qWmuFPNK/ymE7WNkaXHAfk4APRV937GO0Co7QJ6qMiRklWZm3U1LRtG7IcRncCB3AexB1ui+MBaxocckDBPivqKIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIixfU2o3Wu90FMyWmZCNslUJXAOLHvEbdvPxLnH1M9aDKEWK33UdbBTXn6toA51vIYZpZAGFxa13IYJPJ3qVTNepaWrnZUwympEUG2lje1zN8kj2tw4gHJ28yeQHTvyGQosdq7xVQ1FvNXA6iZxpGztJEjXsbC9+WuHdkDwPJRUWrY6iOSR9FMGCndUxiJwlc5ox5pA+67mOXPv58kGTorbYrq27QSyMYxvDdtOyZsoPLPVp5H1HCpK+8+Q1tUwRz1Lw+CNsILQAZCQMHr7cn2IL6ixSXUNxkuFBT0tBEHmpkpqmOSfGHNiLwGkNPLG0592FU0+qI57kKdlMTAZ3UwlEgLt7SQSWdQ3IIz8sc0GRIrBRakEwp5qmjkpaOcyNjmkeOZYCTkDoCGvIP+H1qmk1NHTtknmjqA58VO6OmeWgB0pfgZxkHzcnPTHL1hlCKw0OpI6gwtmpzCXTmnc7eHMDtm8EOxzBAIzy58sLxBqiGejjnipZ3Oc6UuhHORrGM37sesFmB/jCDIUVrsN4Zd4pXsjYzhkDzJmSdRnntPI+o/NW23aqbcJmNpaTdHOHGmfxQdxAJG8AZYDjkefrweSDJkVl05cqys09FXXGnijkdEJPs5N28YznoMezmqOm1LVVLqdkVnl4tTTeVwtdO0Ax8s7j3Hzm8ufX24DJkWNv1VCHUL2wf0epbC4OdM1rxxSA3DOpxkZ6erK9HUjpqmspaWlbx4RIGtlnaxxLOWSz7wae44OeXTKDIkWJ02qKmO02p9bSQ+XVsAnDRUBrC0NaS4kjkcuGG4PtVWNTsdwHNo5xE6mdVTSOIAhY0kOz4nI5YzlBkKLG6q81xtr5jQy0ZcI3xSF7Xgtc9oId4OwenP28lOdRMZemUEkAHEkdExzZmueXBhfzYOYBDTg9enJBfUWM0+rYpqKoqRSvxEGHYJWOe3ccDe3OWY6nPIAHwX2XVcYp6UxQRvnqOIWt8pZw9rCA47xkdXAAYzz7kGSosbm1ZCwUhFLI3jxiT7aRkQHnbS0Fxw52R0B6YOeYWSICIiAiIgK3VFloak1xqIRKa1uyUu5+bt24HgMZ6d5JVxViuF7qobhWU1JbvKRSQsnkeZgzLXbuTRg5d5p5HA9aCs+paM0ldTSNe+KtOZg55y47Gs69RyaOneon2Cie2QP473PjjjL3TOc8bHOc0hxOcguJzlUX4Sl7JKuCj32uKRkclQZcPBdt5hmOYG4Z5g9cAqpN9AhpZDT/19ZLSY39NnE87p38Pp6/UglhsVHG5j5DNPI2R0pfNIXlxLCw5z3bTjHReaTT9JS7tktW4cIwRh9Q48JhxyZz5dBz68hzXm2Xmas04LtLQSRh8PHjgY7iPe3bkdB1PgrRWalrp6KCS2QUbpPLYYJG+VZwHOHI+ZkE5wcgY6jKC+QWaKCpbPHUVPFMgklcZOcuGFoa7uwM5x4jKmntVLNUvne13Ec+N5Id3xklv7VbHagqWT1bH28BlLNDBJIJ8gvk4fJvm5IHE78dB48pKq/SMuU1BS0YmqmzNhjDpdjXZi4hLjg4AHLoUFTPYaGeV0j2zNkdUeVb45nMcH7AzkWkHG0YwvkVipIq0VDH1AaJHTCDjO4QeertvjzJ8MnPVUL7peHXq3U7KCCOKWGV0zJKjBBa9gyCGHIw7I6ZzzxhfZtTtitlFWGlJFTBNPs4n3eGwux055xhBXVVioaq0stszHGlYQ4DcQeRz19fMH1Eheq2y0dZJPJK14klEYL2vLS0xklhaR0ILirVU6mqonxQttTnVToRUPi4jjsjJIbzaw+ccHl05dVXUF6krroKWGikbCKeOofLK7Y5m/dhuzGc+bzQepNPUU1sqKGczzR1DxJLI+UmRzhjB3d2NoHLwU31NReWz1Yjc2aaHgOLXluG+rHQ8hzHPzR4Kmkvojq30ppz5Q2pEO3d/c2b+J06bQfeMKmjv9XLBC8W+OIVkLpaMuqM78N3APAb5p28+W7ogu1BbYaKaaZj5ZJ5g1r5JXbnENztHuyfiqeisVJR1TJonVBbHuMULpSY4t3Xa3oOp9meWFbLPfbnLQ2RtVQRSVVfAJS+OfzQ0NYS93mjGd3QA88DPeJbNqZ1zq4GtoJm0dTu4M43HkASC8bQGggcsE93RBdaC101DRyUtPxRA/Pmvlc8NB7m5J2j1DklPa6anlppI2uDqenNLHl3Rh2/PzAqSru9S2vqKehoPKm0oaZ3GYMI3DIDAR5xxz5kDmOap5NRTCSdrLeSG1PkcJdKBxZOvh5rQMkn1HkUEg0tb2w8KM1DIyIwWtlIBMYAY72jaPVy6KrbZqbyxlRI+eVzC9zGySFzWFwIcR7iR6s8sK3/Xb31lNT1EMtPVsqzBLFDIHsceC6Qcy3JaQPAHPzip9V8akqZfI/tIgxxhbJmRgccfaMxuZjqeRGAeqIrW6boo6anhp5KyDycFsUjKl5expABYCSfN5Dl05BVdPaKOANDIy5og8nw9xdlmc4OepOTzKtMmpz9XwVEENJI6UvGBWN2+b1DSAS48+m0dOeO/xNqp/CknpaAy0sVFFXyvfKGFsbw44AwcuAaeWQPWiq+LTlFG0tc+qlaGCNglnc7htDg4NbnpzaPXyC9fg9ReUMmDpwWVDqljRKdrXuzuIHr3O+JxheKe81FTUvdBQb6Bk7qd04lAeHNJa47CPuggjOc+pU9j1I+6VMANvlipqlhkhm848sZG8FoDcjpglBWMsVM175DNVumLBG2V0x3saDkAH29c5z35Xh2naPY0xyVMU4e+Q1EcpbI4vxuyfA4by6ch4K8ogtM1go5aVtMX1IpxFwXxiZxEjPB2epOTk9TnqrsiICIiAiIgKx1OnoKy7VtVVOkMdRFHFsjlezc1u7IdtIyPO/b4q+IgtjrHQOqDNwXNy5r3RtkcI3ObjaSwHaSMDu7h4L4bFQGpZOY5C5krp2N4rtrXuBDnBucDO53xKuiIKaKhp4baygja5tMyIQtaHHIaBgDPXp39VSOsNA+GaOVkshlcx73umeX5YctIdnIwemCroiCgNpozBVRGNxZUua+QmRxcXNa1oOc5BAY3n4jPVQfg9b/tDsm4r5BMZRO/ibw3bkOzkeby9iuyILayx0MbaYMjla6nc57HiZ4dlxy7c7OXZPMg5yoXabtrz58UjhtkY1pmftY2QYeGjOADnuV4RBbq+zUdc9j5hMx7WcLdDM+MlnoktIyPap6WgpqSZ8lPEI3OjZEcE42sztAHdjcVVIgpHW2lddBcXRZqxFwN+T9zOcY6e9QUVkoaOVr4Y3+Y0sja+Vz2xtPUNBOGjkOiuSILfQWaioOB5NG9oga5kQdK5+xrtuWjJOB5o5d2OS8UljoaSqZUQslDmFxjY6Z7mRl3XawnDe/oO9XNEFtr7JQ1875ahkm6RoZIGSvYJWjoHgEBw5nr44Uktpo5aeWF8R2SS8c4eQQ/OdwIOQeXcq5EFuistDHwyInOfHKZw98jnOc8sLCXEnJ80kc/V4Ly2x0bS539IMhaGCR1Q8va0HIAdnI5/FXNEFqFgt4c1wjlDxv3P4z9z9+N245552t6+ASKwW6KjmpWQu4M1O2keDI45ibuw3Oc8tzldUQWw2OhNX5QY5N3E43D4r+Hv9LZnbnvzjrz6rxT6foKdxMTZwOG6NjfKH4ia7qGDOGe7GO5XZEHmJgiiZG0uLWgNG4knl4k9V6REBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAXkh+eRbj2L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9Ig84f6TfgmH+k34L0iDzh/pN+CYf6TfgvSIPOH+k34Jh/pN+C9IgIiICIuavpMdpdwpLodKWKpfSsjja+tmidte4uGRGCOgxgnHXOPaHQlRfbRTSuiqbrQQyt5FklQxpHuJUX4S2L8tWz9aj/muALRZbne3zC10U9Y+IbpOE3cWjnzPwKoHMc1xDmkEd2ER+iUF/s88jY4Ltb5JHHAaypYSfcCrkvzaIIwSCF0D9GvtLuDL9BpS9VL6mjqgRSSSuy6F4GdmT/dIBwO44x1QdSKkrbnQUBArq2lpieYE0rWZ+JUFznkfV09vpnmOWdrpJJAOccbcA47txLgB7z3I6G1WOjmqnsp6WFg3Szv6nuy5x5k9OZKK8fhHY/yzbf1pn80/COx/lm2/rTP5qsoqqkrqaOoo5YpoJM7HsIIODgr7FUUs0s0cUkT3wuDJGgglhIBAPuIPvQUX4R2P8s239aZ/NPwjsf5Ztv60z+auX2eCfM5dVFT1NLUcTgSxScN5iftIO1w6tPrQUX4R2P8s239aZ/NPwjsf5Ztv60z+auZDB1DVC6ogbUsgOeI9jpAQwluAQDl2MA8xyJyfcUFF+Edj/LNt/WmfzT8I7H+Wbb+tM/mrnhn+FfPs8A+ZgoLb+Edj/LNt/WmfzQajshOBeLbn/vTP5q5/Z/4fFQOqKTytlI6SHyiSN0jYiRucwEAkDwBI+KCeKRksbZIntexwyHNOQR7V6VorLeygjlrbTC2KdgL3wx+aycdSCOm49zuufVkK508zKiCOaJ26ORoe0+IIyEEiIiAiIgIiICIiAiIgIiIPmVxb9Ja0VNu7U6+qmY4U9wZHPC/ucAwNI9oLf2eK7PLsLGtdaPs2tbT5BfKfiNaS6KVh2yRO8Wn+HQoOErHdX2mpqJo42yGWmlpyHdAHsLSfdlZe7tLqJawTVFsgljLTujdM/73FjlG05y1gdE3DByALvFbTqvozQOmcaXVMkcWfNbJQh7gPWRIM/BRf7Mv/rb/APbv/FRGnNZ6zm1RRW+nnpGwmkLyHCQnO7HIDAA6deZ9eOSvHYDZqm8dqdlNO13CopfK5ngcmNZzGfacD3rZ8H0ZohK0z6qe+PPNrKANJHqJkP7FuTQGiLLoa2OpLJCd8mDNUSndJKR0yfDwA5IL1UONPqSmlePsqmB0Adno9p3Ae8F//CvepLVHfbJVW2aR8UdQA1z2dQAQeXwU9VFFVQOhnbujd1GcEeBBHMEdQR0VuNNdohspbnTuYOhqqUyPx7Wvbn4Iq1XXQNvraindBPNSRRRtjDYwC9uHufuY85c1zi47jnLh1VDR9m9PTMH9NY5/F4hHkUXCH2bGEiPoHYjBDu4l3ccLIuHfvyja/wBQk/1k4d+/KNr/AFCT/WQYzUdmkU9HdIH3Nx8vmjndmnaGtewvw7a0gEkP59x2jl3L1U9mlLJG9kVa2IGsFY1wpWbg7bg5xgO7yMggZ6FZJw79+UbX+oSf6ycO/flG1/qEn+sgtWrdDx6irpp33GamjmiDJI2RtdkiOVgcCeY5TO5eoKnrOzqjnMYiq3RRxSSPjh4LXRDe6JxaWHkW5i6f4iVfeHfvyja/1CT/AFk4d+/KNr/UJP8AWQYjRdmRltFLS3C5zxbY9sscAHN/DliDg7kR5snTpyVYzsxtn1fR0k075m0xJZxGBwBMzJTjJOAdm3r0cVkXDv35Rtf6hJ/rJw79+UbX+oSf6yDFj2VW/wAqfMK+qAdE+IM/utacgNAzgNAONuO7PqV4t2iKS33uguNNIwOpDUhsZgaQGTScQMaf7oaeQx3EjvVx4d+/KNr/AFCT/WTh378o2v8AUJP9ZBdblVso6GeokBIY0kNAyXHuaB3knAA9aisVK632S30bzl9PTxxE+Ja0D+CpqeikM7Z7hU+Uys5saGbI2HxDck59ZJ9WOauG9BPlMqDem9BPlMqDem9BPlMqDem9BPlMqDenEQT5TKgD19EnrQTZX3K8A5X3KCn5uOGjKGOTuHzVRG3a0BekFJwpfD5r5wpfD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpvD5pwpvD5qsRBR8Kbw+acKbw+arEQUfCm8PmnCm8PmqxEFHwpfD5r4Y5fD5qsK8nogpoo3cQB45e1Wax6kF4v12tIpWxSWw7Zn8UOBJJ2bQOZy0ZPTB5c1fzkEEdQqKG326ikNRSUUMU+HN3tZg+e7c7J78u5+1BVMcpdypYyp8oJ0REBERBDWTtpqZ8zuYaOnirLbL6aisbDMG5dyaGj5//AN4q+TwsnZskGW5zhWmj0/FS3BtS2Vxa3JazHT3r5nGRxvf26uHxoz833/Or02Zs6Koub9GO3jX7rfrR1hbQwy7ZqeInynEzhKPvNj28w3qeY5BV8naHpyOmfPJVysjG3YX0728VrnFoczI85uQRkcviFkFNbKWmuNdXRRkVNbs47i4kO2DDeXQclZG6EsbIZYmRVLWvaGNxUyfZsDi4Mbz5MySdvTp4BfTeZI7WtlFa2kbNO+pdEJGxtp3kkmMyBnT75aCQ3qvdBrC1VtlZdo3VDKF1SKUSSwuZ55eGd/8Ad3HGeipYtAWCE/0enqIAYBTkRVMjMtDCwE4PXacZ9ngFX0ulrXT6cmsQjnktkjDGYpp3vLW4xhpJy0DHLHTuQUkOubFNPBEyomPGLQJBA8sbveWMLnYw0OLTtz15HvCrLHqm03yiqqu31JfTU2eLK+NzGgAEk5I9R9igOjLJ5RSytpnsFOyGNsbJXNY4RHMe9oOHbTzGVNadK2q1mvNNC9xrmCOoM0rpC9oyA0kn/EfXzQUtv1xZa6oiggkqRLK5rWNlp3xk7o3yNPnAci1jjn2KFnaFpt7Q7y14YaYVW4wvwG8Li4zj72zztvVU9F2d2umq55HT1kkTjC6AGd++ExsczAfuyQWvIx4KspNCWKjfupYKiEcBtPtjqZGja2MRg8j97YAM+rPXmgoK/tFt0UEMtHBUVEUtHUVbZnRuZGBDtyCcE4O4cwCOniFXz67sNO6qbNUTNFOH7n8B+x5YQHhjsYcWkjICjHZ/YBT8EQThhE7X4neDIJg0SB2Dzzsb8ApptD2KeWpfLTSOE+8lhnfsYXkF5Y3OGlxAyR/EoPEevLE+ppafj1DKmomfAyF9O9rw9jgHAgjI5ub8c+Kq7zqWltN+tluqyWitOxr9j+TycMGQMcznvGOXioK7RNkrZjJUQTHdUOqXNE7w10hLSSRnHVrfh6yqi6aUtVzvUF1q4pHVkPD2ubK5o+zcXMyAcHBcfigteotYVVqq7xHT2ryqC2U4qJ5eOGYaYpHjljvcwN/9rPcpqTWcFRrFti8nLWui5VO/zTPtDzDjHXY4Oz7QrtW2C3VguoqIXO+s4WwVWHkb2AEADny5OPRUMOidPw1cdXHb421sdT5WKrJ42/n1f1LcHG3OMcsILtLdrdFI6OWvpGSNOHNdM0EH1jKt1/1B5FFbm2uGK4VVxqDT0zRMGRkhrnOc54BwAGO6AnPJXKS12+WR0ktDSPe45LnQtJJ9Zwqe6WG33KihpZoTFHBIJoXU7jE6J4z5zS3BB5n4lBZrVrejqC2mroJ4LoJpYJaaCN9RsMbg1ztzW/cy5vnEDr6iorh2hWiCmfJSceoeyaKMN4L28Rjp2wufGdvnhrndG5zy8VWt0TZWeTGKKpifCX5kZUyNfLvcHvEjs5flwBOfBRv0FYXsmaaefa8gtAqZBwcSiXEfPzBvaHcsdEAa8sJ4X9InG/O/NNJ9h9oY/teXmeeC3njmFNa9XUVbYGXeeGopKZ1UaX7aMgh3F4YJ9ROOfd7lE3Qlibwv6POdnN+ah54/2hk+15+f55LueeZKr49NW1ljrLQYpH2+rdI6SJ8jjjiElwaerRkkjHQ9EFBHrmxSzwxsqJiJS0CQQPMbdz3MYXOxhoc5p2568j0IUVRr7T9PSR1M1VI2KWGKdh4TubZXPazu6kxu+CqzoyycakkbTPYKaOGNsbZXBj2xHMe9ucO2nmMqmZoKxxwSRRx1TWPYyL+0yeaxjnOawc/ugvdy6c0GRU0zKqmiqIdxilYHtLmlpwRkZB5j3rzVDEDvd+1LZQU9st1NQ0TOHTU0bYomZJ2tAwBk81R6mrvq20SVRGWsfGHewvAPyKJM4jMpoSqjIVLAQQCCqnIRVUiIgIiIMO7RdSXLT0dv+rKWOXyhzw+SVhc1pa3LWciMFx5A8+nIE8lj1117eaKpvbTT0zIKMMNNI+CQiYukja9ue8x7yDj7xxjGCFtJQ1lLBW05gq4mTQkgljxkEggj4EA+5Bqp2qb5W11PKC90AxEH07HxxTgV9PHxQCcjLHP7zyz3KSk7RLs+smZPDShsQjkmiEEgfTNNW2J4eSeZbGS7IAHqx12uoPJKfy3yvgs8q4fC4uPO2Zztz4Z5oNc0Wu71U3u20rbfGKapmc3c6JwMjPKXx5aSeRaxrXnkc5/ujmrrfNSXui1LNT0lJDNQQzU0Wzhu4knFa8kh2cDBaO49e5ZwiDU1PrLUNebW574KeA1dMKmaOkkDW8Rsm+Bwcc7mua0Fw73Dp0NTR601KH6cZWUVIXXOGKofshe0Ye9oMYy7Ic1pLicHPLkBkraGEQa/1brO42jVtPbaOmZJTFjTKZIjnzmvO5rt3QFoB83HPrlWCm7SLvLQ0UsjrdGyofCHVZpZeHEXwySOjLd2XOYWNyQceeOi27IxskbmSNDmOBa4HvB7lTC20Qjo2Cli2UeDTjbyiw0tG3w80kexBruHWepZqKatlo6WipmmkjdxaeR5hMsbHvkdhwJa3JGOR5jJGCqii1nd6msoIKqCGiE8IcN1NK51UTI9mY8fcG1rX+cDgPGcdVsdEGn6LWmprbp+hZWQxVEz6ekeat8DvsxJHITxAXjcd0bRnLeb+njnj9QTSaSrK6mjiF1pqVsktO9ry2OUxh+04GSOY6LJF4ZFHG6R0bGtdIdzyBguOAMnxOAB7kGqZu0e7sobXIyia6aWVzZg6mIY9olazzHCQjo4nI3dO4AqebWupIaaeZ9LRYdE+SLML28PbU8IhxLsElvnDO0DvOOa2lhEGB3PV9bBpDT90aIKWa4VDIZn1NO8tiBY8l2wOzjLAeuMd/esei1ZqGouFvqnNdRwyy0nGhMT3NeHwznaMnzQ5zGDxy5uemDteopYKl0JqImSGF/FjLhnY7BG4evBI96mQapZqnUF0htE9HUUzagyvdMxtJMI4/6NI8xSAkbi1wAyCOeMjuVz1hqq602l7TUUkTKWW40UkskroXycKTghzY2hvMOcSQCem3oVsNEGvNHaqvNdqKK1VtIG07IG7nvYRIfsWO4pOeYc5xGNo9p5hRXbWWoaKa8xNtjMWyRsb5zE4seJZWiN7fOGQ2Iku59e8BbIRBrKLWOpJ5KZzaSkjhIpOIDA9xfxpnxlzTuwAA0Pxz69e9UWmNbagfVWSgrIo6p0zW+UTOgcxzyZHteB53IsDQTyOc/3eRW2kwgho6iKspIammdvgmYJGOwRlpGQcHmFj3aSP/I6u9sf/O1ZOsa7RsHSNaD3mP8A52rneuRat1XJ6RkmibnyR1VdAfsI/wA0fsVcrfQ/1Mf5oVwHRbjnA9UtUxzQ17g145c+9VBewHm5vxVknb1XHfbEP+tG/fpGfu2Kjt/iM9NvxTiM9NvxX56sypD3ImX6DcRnpt+KcRnpt+K/PxqmZla0pqd+8Rnpt+KcRnpt+K4CcPtPcvbev8VzmrE4daaMxl31xGem34pxGek34rgRnMuCqLY3zpfclM5nCVU6Yy7z4jPSb8U4jPSb8Vw80HKmaDhddDlrdub2+kPim9vpD4rjSkB4QVWwLEtRLsDe30h8U3t9IfFciZDGFzjgDmV9ZUMz92b/AOE7+SGXXW9vpD4pub6Q+K5JdM2RmxjJS5xA5xuA6+JCuDW5whl1Nub6Q+Kbm+kPiuYWNUzGlDLpjc30h8U3N8R8VzcxpU7GoZdFbm+I+Kbm+I+K58YxTsYhlvzcPEJuHiFolrVOxiGW78jxC+rTEG6N7XsJa5pyCOoKzm36sAtrvK2F1WwYbgcn+v1etFZZJIyNpdI5rWjqScLX/aRdo6q3spaV26MSgvcOjjg8gqGpqJq2pdPUOLnu+A9QVu1A3FA39IP2FeHtL6W56OtjxKWxaH+pj/NCrweXeqGhH2Mf5oVeOi9tO0OUqSZvJccdsgx2pX79Iz92xdlzDquNu2f8ad//AEjP3bEkYixSkcgoWdVOArDMvTBzUzQom4HM8kdVRsIAO4+pdIZSy7RsyQCTgetfQwnvVBVSudslwPs3ZA9XRV8LxJGHN5ZXG7GJeizPJ5awtfnccK4W9oEO4dXEkq0yyEy7ARlSUta6mdsAD2eHeCtWqJn5mL1f7WQMCnYFbaS5QTcidhzgZ71dYgHY2kHPeF2xh51dTACNvMKqZjxCoG08RPOJhJ/whTNp4f8Aso/+ELlMOmcKmrx5M/mO79oVewK3R08QcC2KMEd4aFVsCYNStYAp2AKhYFOxMGpXMaFOxoVCwKdgV0pqV7AFMxoVAwKdgTSa1cNrWlziAAMkq0ae1Tbb1cqyipJCZKd+G5BG9uBkjl45HuVwYF8pKKnppqiWCMMkqHh8hH94gAfsCaTWu7Gj1KdgHiFb2BQ3SvhtduqK2qdthgYXu/l7T0TBqXC5XKitVI6puNTFTwN6ukdj3DxPqWJT9rWmIJtjJKuYA43xw+b8yD8lo3VGoa3UVxfVVsh4YJ4UIPmxt8B/PvVoYySQOLI3ODRk4GcLLbrDTOs7DqB4jttfG6fGeDICx/wPX3ZV31Dg0Dfzx+wrjmCaSGZksL3RysIc1zTgtI7wVvzs61g/UlhdS17wblSObud3ysOcO9vcf/2vD2n9Jc9HWx4lLo6iH2Mf5oVaqOi5wx/mhVi9tO0Oco5Vxp2z/jTv/wCkZ+7Yuy5Vxp2z/jTv/wCkZ+7YgxBg5qdoULOqnaqy8VUbnNBbzA6hUwaOo9nuVzYo5aUO5x8j4LpTVhmYUmBkBwy3oVPSv4Ue0jIHTkvD43sOHNI/ivUZPDPPuwfWtTTFS01zTs8Y3Svec5IwAF9ZGN3TqvYHw7yqmmpZJiC1hwTknoAtxiGJ5qaKLLG4ByTyWUWaldTwZkJ3O57fBRUFAyna0vw+QDr3D2K6R9FiuvPKCITMHNTNChZ1U7VzWUzAp2BQMU7EROwKeMKGNTx9VRM0KZg5qJqmb1QTMCnYFCxTM6IidgUzQoY1O3qgmaFr/tnuUcGmmUTZQJ6iZuWd5YMkn4gLYLVj+vLIb7pqqpY2g1AHEhJ9NvMD38x70lY3c4QsEs8UbnBjXODS49Bk9VsTtRxorXJtOmY/q+O2NiMdTH/XTudGHF7n9SDuI2/d9S11LG6N7mSNLXtJBaRgg+CvjNTVU7qP67iZdo6NobBHU9zR0a57cPLR6O7Cw6sk7ZbfSQXHT90paeKlmvFpgr6mCJoaxsrgQ4taOgOM48cq39k80kWsYGMJ2yxva/2AZ/aArDqS+1+pLvLcrrIH1DwGgNaGtY0DDWtaOQAHcs97G7FKX1F7mYWwtHAhJH3ifvEezGPeV4+0JxwtzPlLrZ8Sn1deW/8As8fsCrVRW/8As8fsCrV66doc5RyrjTtn/Gnf/wBIz92xdlyrjTtn/Gnf/wBIz92xBiLOqnaoGdVO1VlOzuU7FAzuU7FUTM5jmvYhjPWNvwXiNTs7kR7ihjb92No9yqmKBinYqJ2KePooGqePogmZ1U7VAzqp2okpmKdigYvFZI6NjCxxBJRmZxGVyjU8fVYxfNSQWJlIJ4Zp5JwdoZgdOuSfavlHrW3SVEsdQyemEUDZ3vlZyAO3lgc8+cFctMvapm9VjQ1dZAHE1zcNYZCdjvug4z08V7drGyMkkjZWtkmZGZOG1py7Dd2AcYzjuTKYZSxTM6LEbfriy1FBFUzTupuJG6XhyMJIaHFpPLI6hVsesrAXyM+sYw6Nu9+WuAAxnPTwTJiWURqdvVYkzXWm+CyX6zjLXuc1vmOzkAEjGM94U101fS2vUFHQVLAymnpX1Tqpz8BjWgn7uOfRDDLmr3tyrJp/Ulpvz52WmsbUugDTJtaRt3Zx1HqKvzeiIwHW3Z3S32V9ZRPFJXu5uOPMkP8AiHcfWFrufsy1LHLsjpoZm5++yZoHzwV0OG5XtsYUw1FUw0xpjsjqJKhkuoKhjIRgmCA5c71F3d7srbstFBQWmGmpImxQRENYxowAMFXKNmFDdxijb+cP4rw9pxjhLno68PObtLZtEMQR/mhVapaT+pj/ADQqpeunaCUcq407Z/xp3/8ASM/dsREGGykiF5BwcL5bXOdv3OJ6dSiKsrmxTsRFUTRqdiIhKdqscdRN9chnFk2cbG3ccYyiIi6alcW2SctJB83mD/iCudqJNupSTkmNv7ERBXs6qdqIqkpmKKv/AKtntREliv8ASw7tKceFRMydhgkO3uyMc1iEjnCKoAcQHW6MEZ682IijpTtC89oZLa6k2kjNqjBx3+cqKzTysur4WSyNhcZC5gcQ0/ZHqEROqxstUsj/AKtpBvdgUkjRz7uIeXsWVUAB0hrTIBwyk/giISpdIyPk1Pp9sj3Pa2vIAcc481qyftk/3ki/yub9pRE6HVU9gMj5bjqF8r3PeW0+XOOSeT1ulvREWo2Yq3TsU0aIjKdiprx/ZG/nD+KIvD2p9Jc9HfhvFpbNpP6mP80KqRF6qdoV/9k="
+            }
+          ],
+          "scale": 6249
+        }
+      },
+      "speed-index": {
+        "id": "speed-index",
+        "title": "Speed Index",
+        "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).",
+        "score": 0.18,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "8.5 s",
+        "numericValue": 8451.3377499915568,
+        "numericUnit": "millisecond"
+      },
+      "legacy-javascript-insight": {
+        "id": "legacy-javascript-insight",
+        "title": "Legacy JavaScript",
+        "description": "Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile [Baseline](https://web.dev/articles/baseline-and-polyfills) features, unless you know you must support older browsers. [Learn why most sites can deploy ES6+ code without transpiling](https://developer.chrome.com/docs/performance/insights/legacy-javascript)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 14 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 13895,
+            "type": "debugdata"
+          },
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "subItemsHeading": {
+                "key": "location",
+                "valueType": "source-location"
+              },
+              "key": "url"
+            },
+            {
+              "subItemsHeading": {
+                "key": "signal"
+              },
+              "key": null,
+              "valueType": "code"
+            },
+            {
+              "valueType": "bytes",
+              "label": "Wasted bytes",
+              "key": "wastedBytes"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "wastedBytes": 13895,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "subItems": {
+                "items": [
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 6239,
+                      "line": 1,
+                      "urlProvider": "network"
+                    },
+                    "signal": "Array.prototype.concat"
+                  },
+                  {
+                    "location": {
+                      "line": 1,
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 12925
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "signal": "Object.assign",
+                    "location": {
+                      "type": "source-location",
+                      "column": 12813,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1,
+                      "urlProvider": "network"
+                    }
+                  },
+                  {
+                    "signal": "Object.create",
+                    "location": {
+                      "urlProvider": "network",
+                      "line": 1,
+                      "column": 10857,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "type": "source-location"
+                    }
+                  }
+                ],
+                "type": "subitems"
+              }
+            }
+          ]
+        }
+      },
+      "unused-css-rules": {
+        "id": "unused-css-rules",
+        "title": "Reduce unused CSS",
+        "description": "Reduce unused rules from stylesheets and defer CSS not used for above-the-fold content to decrease bytes consumed by network activity. [Learn how to reduce unused CSS](https://developer.chrome.com/docs/lighthouse/performance/unused-css-rules/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            }
+          },
+          "overallSavingsBytes": 0,
+          "overallSavingsMs": 0,
+          "headings": [],
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "type": "opportunity",
+          "items": []
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "largest-contentful-paint": {
+        "id": "largest-contentful-paint",
+        "title": "Largest Contentful Paint",
+        "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)",
+        "score": 0.04,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "7.4 s",
+        "numericValue": 7426,
+        "numericUnit": "millisecond"
+      },
+      "unsized-images": {
+        "id": "unsized-images",
+        "title": "Image elements have explicit `width` and `height`",
+        "description": "Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            }
+          ],
+          "type": "table",
+          "items": []
+        }
+      },
+      "layout-shifts": {
+        "id": "layout-shifts",
+        "title": "Avoid large layout shifts",
+        "description": "These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "3 layout shifts found",
+        "metricSavings": {
+          "CLS": 0.002
+        },
+        "details": {
+          "headings": [
+            {
+              "key": "node",
+              "label": "Element",
+              "subItemsHeading": {
+                "key": "extra"
+              },
+              "valueType": "node"
+            },
+            {
+              "valueType": "numeric",
+              "subItemsHeading": {
+                "key": "cause",
+                "valueType": "text"
+              },
+              "key": "score",
+              "granularity": 0.001,
+              "label": "Layout shift score"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,1,H1",
+                "nodeLabel": "Explorez la science du revenu.",
+                "boundingRect": {
+                  "left": 16,
+                  "height": 187,
+                  "right": 396,
+                  "width": 380,
+                  "top": 250,
+                  "bottom": 437
+                },
+                "type": "node",
+                "selector": "section.pt_32 \u003e div.pb_12 \u003e div.max-w_2xl \u003e h1.ff_display",
+                "snippet": "\u003ch1 class=\"ff_display fs_5xl fw_bold c_ocobo.dark mb_6\"\u003e",
+                "lhId": "page-5-H1"
+              },
+              "score": 0.001897
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "score": 0.000233,
+              "node": {
+                "boundingRect": {
+                  "bottom": 513,
+                  "top": 461,
+                  "height": 52,
+                  "right": 396,
+                  "width": 380,
+                  "left": 16
+                },
+                "type": "node",
+                "selector": "section.pt_32 \u003e div.pb_12 \u003e div.max-w_2xl \u003e p.fs_xl",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,2,P",
+                "nodeLabel": "Articles, interviews et masterclasses pour structurer votre croissance.",
+                "lhId": "page-6-P",
+                "snippet": "\u003cp class=\"fs_xl c_gray.600 fw_medium\"\u003e"
+              }
+            },
+            {
+              "score": 0
+            }
+          ]
+        }
+      },
+      "lcp-breakdown-insight": {
+        "id": "lcp-breakdown-insight",
+        "title": "LCP breakdown",
+        "description": "Each [subpart has specific improvement strategies](https://developer.chrome.com/docs/performance/insights/lcp-breakdown). Ideally, most of the LCP time should be spent on loading the resources, not within delays.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "items": [
+                {
+                  "duration": 0.448,
+                  "label": "Time to first byte",
+                  "subpart": "timeToFirstByte"
+                },
+                {
+                  "duration": 3124.972,
+                  "label": "Resource load delay",
+                  "subpart": "resourceLoadDelay"
+                },
+                {
+                  "subpart": "resourceLoadDuration",
+                  "duration": 445.839,
+                  "label": "Resource load duration"
+                },
+                {
+                  "subpart": "elementRenderDelay",
+                  "duration": 74.662,
+                  "label": "Element render delay"
+                }
+              ],
+              "headings": [
+                {
+                  "valueType": "text",
+                  "label": "Subpart",
+                  "key": "label"
+                },
+                {
+                  "label": "Duration",
+                  "key": "duration",
+                  "valueType": "ms"
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,1,A,0,DIV,0,IMG",
+              "nodeLabel": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute",
+              "selector": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute",
+              "type": "node",
+              "boundingRect": {
+                "width": 380,
+                "height": 224,
+                "right": 396,
+                "bottom": 892,
+                "top": 668,
+                "left": 16
+              },
+              "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"pos_absolute inset_0 w_full h_full obj-f_cover op_0.8\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+              "lhId": "page-1-IMG"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "document-latency-insight": {
+        "id": "document-latency-insight",
+        "title": "Document request latency",
+        "description": "Your first network request is the most important. [Reduce its latency](https://developer.chrome.com/docs/performance/insights/document-latency) by avoiding redirects, ensuring a fast server response, and enabling text compression.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "checklist",
+          "debugData": {
+            "uncompressedResponseBytes": 0,
+            "type": "debugdata",
+            "serverResponseTime": 179,
+            "redirectDuration": 0,
+            "wastedBytes": 0
+          },
+          "items": {
+            "serverResponseIsFast": {
+              "label": "Server responds quickly (observed 179 ms)",
+              "value": true
+            },
+            "noRedirects": {
+              "value": true,
+              "label": "Avoids redirects"
+            },
+            "usesCompression": {
+              "label": "Applies text compression",
+              "value": true
+            }
+          }
+        }
+      },
+      "cache-insight": {
+        "id": "cache-insight",
+        "title": "Use efficient cache lifetimes",
+        "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more about caching](https://developer.chrome.com/docs/performance/insights/cache).",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 511 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "totalBytes": 204723,
+              "wastedBytes": 196192.875,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "wastedBytes": 196192.875,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "totalBytes": 204723
+            },
+            {
+              "wastedBytes": 41837.958333333336,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "totalBytes": 43657
+            },
+            {
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "wastedBytes": 27462.416666666664,
+              "cacheLifetimeMs": 600000,
+              "totalBytes": 29959
+            },
+            {
+              "wastedBytes": 27034.583333333336,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "totalBytes": 28210
+            },
+            {
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "wastedBytes": 26083.916666666668,
+              "cacheLifetimeMs": 300000,
+              "totalBytes": 27218
+            },
+            {
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "wastedBytes": 4618.1666666666661,
+              "cacheLifetimeMs": 600000,
+              "totalBytes": 5038
+            },
+            {
+              "totalBytes": 2019,
+              "wastedBytes": 1850.75,
+              "cacheLifetimeMs": 600000,
+              "url": "https://useago.github.io/widgetjs/frame.css"
+            },
+            {
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "wastedBytes": 1642,
+              "cacheLifetimeMs": 0,
+              "totalBytes": 1642
+            }
+          ],
+          "type": "table",
+          "skipSumming": [
+            "cacheLifetimeMs"
+          ],
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "headings": [
+            {
+              "label": "Request",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "displayUnit": "duration",
+              "valueType": "ms",
+              "key": "cacheLifetimeMs",
+              "label": "Cache TTL"
+            },
+            {
+              "label": "Transfer Size",
+              "granularity": 1,
+              "key": "totalBytes",
+              "valueType": "bytes",
+              "displayUnit": "kb"
+            }
+          ],
+          "debugData": {
+            "wastedBytes": 522915.54166666669,
+            "type": "debugdata"
+          }
+        }
+      },
+      "viewport-insight": {
+        "id": "viewport-insight",
+        "title": "Optimize viewport for mobile",
+        "description": "Tap interactions may be [delayed by up to 300 ms](https://developer.chrome.com/docs/performance/insights/viewport) if the viewport is not optimized for mobile.",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "key": "node",
+              "valueType": "node"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "node": {
+                "nodeLabel": "head \u003e meta",
+                "path": "1,HTML,0,HEAD,2,META",
+                "selector": "head \u003e meta",
+                "boundingRect": {
+                  "bottom": 0,
+                  "top": 0,
+                  "width": 0,
+                  "right": 0,
+                  "height": 0,
+                  "left": 0
+                },
+                "type": "node",
+                "snippet": "\u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\"\u003e",
+                "lhId": "page-9-META"
+              }
+            }
+          ]
+        }
+      },
+      "script-treemap-data": {
+        "id": "script-treemap-data",
+        "title": "Script Treemap Data",
+        "description": "Used for treemap app",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "nodes": [
+            {
+              "encodedBytes": 305689,
+              "children": [
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 298,
+                  "name": "(inline) window.dataLaye…"
+                },
+                {
+                  "resourceBytes": 631,
+                  "name": "(inline) window.AGO = {\n…",
+                  "unusedBytes": 0
+                },
+                {
+                  "resourceBytes": 592,
+                  "name": "(inline) ((storageKey2, …",
+                  "unusedBytes": 0
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 520,
+                  "name": "(inline) window.__reactR…"
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 1619794,
+                  "name": "(inline) window.__reactR…"
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "resourceBytes": 53,
+                  "unusedBytes": 0
+                },
+                {
+                  "resourceBytes": 6359,
+                  "name": "(inline) ;\nimport * as r…",
+                  "unusedBytes": 0
+                }
+              ],
+              "resourceBytes": 1628247,
+              "name": "https://www.ocobo.co/blog"
+            },
+            {
+              "resourceBytes": 9792,
+              "name": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "encodedBytes": 3946,
+              "unusedBytes": 749
+            },
+            {
+              "resourceBytes": 125385,
+              "name": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "unusedBytes": 71258,
+              "encodedBytes": 43325
+            },
+            {
+              "resourceBytes": 927,
+              "name": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "encodedBytes": 869,
+              "unusedBytes": 0
+            },
+            {
+              "resourceBytes": 3192,
+              "name": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "unusedBytes": 1084,
+              "encodedBytes": 1562
+            },
+            {
+              "resourceBytes": 983,
+              "name": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "unusedBytes": 89,
+              "encodedBytes": 917
+            },
+            {
+              "unusedBytes": 6,
+              "encodedBytes": 69,
+              "resourceBytes": 141,
+              "name": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js"
+            },
+            {
+              "resourceBytes": 1284,
+              "name": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "unusedBytes": 467,
+              "encodedBytes": 685
+            },
+            {
+              "resourceBytes": 15426,
+              "name": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "encodedBytes": 6235,
+              "unusedBytes": 809
+            },
+            {
+              "unusedBytes": 370,
+              "encodedBytes": 5615,
+              "resourceBytes": 17234,
+              "name": "https://www.ocobo.co/assets/factory-hx59odkt.js"
+            },
+            {
+              "resourceBytes": 3070,
+              "name": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "unusedBytes": 519,
+              "encodedBytes": 1243
+            },
+            {
+              "unusedBytes": 239,
+              "encodedBytes": 367,
+              "resourceBytes": 428,
+              "name": "https://www.ocobo.co/assets/container-DmKIJmEK.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "resourceBytes": 410,
+              "unusedBytes": 0,
+              "encodedBytes": 351
+            },
+            {
+              "resourceBytes": 525,
+              "name": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "unusedBytes": 65,
+              "encodedBytes": 463
+            },
+            {
+              "unusedBytes": 362,
+              "encodedBytes": 895,
+              "resourceBytes": 942,
+              "name": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js"
+            },
+            {
+              "resourceBytes": 349,
+              "name": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "encodedBytes": 286,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 768,
+              "resourceBytes": 1866,
+              "name": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js"
+            },
+            {
+              "encodedBytes": 275,
+              "unusedBytes": 0,
+              "resourceBytes": 348,
+              "name": "https://www.ocobo.co/assets/url-Do_uLi_4.js"
+            },
+            {
+              "resourceBytes": 67398,
+              "name": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "unusedBytes": 32058,
+              "encodedBytes": 20674
+            },
+            {
+              "resourceBytes": 165,
+              "name": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "unusedBytes": 0,
+              "encodedBytes": 102
+            },
+            {
+              "resourceBytes": 206,
+              "name": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "unusedBytes": 0,
+              "encodedBytes": 132
+            },
+            {
+              "resourceBytes": 109016,
+              "name": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "encodedBytes": 33602,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 558,
+              "resourceBytes": 605,
+              "name": "https://www.ocobo.co/assets/layers-CQ3InJLS.js"
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 753,
+              "resourceBytes": 826,
+              "name": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js"
+            },
+            {
+              "resourceBytes": 404,
+              "name": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "unusedBytes": 0,
+              "encodedBytes": 343
+            },
+            {
+              "resourceBytes": 490,
+              "name": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "unusedBytes": 0,
+              "encodedBytes": 426
+            },
+            {
+              "resourceBytes": 835,
+              "name": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "unusedBytes": 337,
+              "encodedBytes": 773
+            },
+            {
+              "unusedBytes": 47522,
+              "encodedBytes": 25822,
+              "resourceBytes": 68826,
+              "name": "https://www.ocobo.co/assets/portal-Clm-6X_X.js"
+            },
+            {
+              "resourceBytes": 133936,
+              "name": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "unusedBytes": 31846,
+              "encodedBytes": 44682
+            },
+            {
+              "resourceBytes": 473,
+              "name": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "unusedBytes": 0,
+              "encodedBytes": 400
+            },
+            {
+              "resourceBytes": 338,
+              "name": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "unusedBytes": 0,
+              "encodedBytes": 275
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 374,
+              "resourceBytes": 435,
+              "name": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js"
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 255,
+              "resourceBytes": 312,
+              "name": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js"
+            },
+            {
+              "unusedBytes": 194,
+              "encodedBytes": 237,
+              "resourceBytes": 309,
+              "name": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js"
+            },
+            {
+              "unusedBytes": 46,
+              "encodedBytes": 3561,
+              "resourceBytes": 9169,
+              "name": "https://www.ocobo.co/assets/_main.blog._index-Ch2d6Qju.js"
+            },
+            {
+              "resourceBytes": 717,
+              "name": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "unusedBytes": 65,
+              "encodedBytes": 659
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 209,
+              "resourceBytes": 272,
+              "name": "https://www.ocobo.co/assets/optimized-image-BKBFj58i.js"
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 236,
+              "resourceBytes": 303,
+              "name": "https://www.ocobo.co/assets/labels-CtAnB7VF.js"
+            },
+            {
+              "encodedBytes": 254,
+              "unusedBytes": 4,
+              "resourceBytes": 302,
+              "name": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js"
+            },
+            {
+              "unusedBytes": 4,
+              "encodedBytes": 556,
+              "resourceBytes": 1208,
+              "name": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js"
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 476,
+              "resourceBytes": 549,
+              "name": "https://www.ocobo.co/assets/Container-AZtpvsXO.js"
+            },
+            {
+              "resourceBytes": 69550,
+              "name": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "encodedBytes": 23529,
+              "unusedBytes": 28818
+            },
+            {
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "resourceBytes": 472102,
+              "unusedBytes": 206351,
+              "encodedBytes": 156544
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 576,
+              "resourceBytes": 2125,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js"
+            },
+            {
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "unusedBytes": 12049,
+              "encodedBytes": 4214
+            },
+            {
+              "resourceBytes": 12567,
+              "name": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "unusedBytes": 6432,
+              "encodedBytes": 4673
+            },
+            {
+              "unusedBytes": 682,
+              "encodedBytes": 1242,
+              "resourceBytes": 2495,
+              "name": "https://www.ocobo.co/_vercel/insights/script.js"
+            },
+            {
+              "resourceBytes": 108995,
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "unusedBytes": 46367,
+              "encodedBytes": 42584
+            },
+            {
+              "unusedBytes": 35974,
+              "encodedBytes": 26496,
+              "resourceBytes": 78059,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "unusedBytes": 56996,
+              "encodedBytes": 27869,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "resourceBytes": 97992
+            },
+            {
+              "unusedBytes": 36142,
+              "encodedBytes": 25119,
+              "resourceBytes": 72608,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+            },
+            {
+              "resourceBytes": 472102,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "encodedBytes": 156544,
+              "unusedBytes": 335912
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 576,
+              "resourceBytes": 2125,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js"
+            },
+            {
+              "encodedBytes": 4214,
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "unusedBytes": 337253,
+              "encodedBytes": 202942,
+              "resourceBytes": 587832,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "resourceBytes": 587832,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "unusedBytes": 248156,
+              "encodedBytes": 202942
+            }
+          ],
+          "type": "treemap-data"
+        }
+      },
+      "image-delivery-insight": {
+        "id": "image-delivery-insight",
+        "title": "Improve image delivery",
+        "description": "Reducing the download time of images can improve the perceived load time of the page and LCP. [Learn more about optimizing image size](https://developer.chrome.com/docs/performance/insights/image-delivery)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 2,466 KiB",
+        "metricSavings": {
+          "LCP": 1000,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 2525510,
+            "type": "debugdata"
+          },
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "valueType": "url",
+              "key": "url",
+              "subItemsHeading": {
+                "key": "reason",
+                "valueType": "text"
+              },
+              "label": "URL"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Resource Size"
+            },
+            {
+              "subItemsHeading": {
+                "valueType": "bytes",
+                "key": "wastedBytes"
+              },
+              "label": "Est Savings",
+              "key": "wastedBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "node": {
+                "nodeLabel": "article.d_flex \u003e div.px_6 \u003e div.d_flex \u003e img.d_flex",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,2,UL,5,LI,0,ARTICLE,1,DIV,1,DIV,0,IMG",
+                "selector": "article.d_flex \u003e div.px_6 \u003e div.d_flex \u003e img.d_flex",
+                "type": "node",
+                "boundingRect": {
+                  "left": 41,
+                  "bottom": 4667,
+                  "top": 4647,
+                  "width": 20,
+                  "height": 20,
+                  "right": 61
+                },
+                "snippet": "\u003cimg class=\"d_flex ai_center jc_center flex_0_0_auto w_20px h_20px bdr_9999px\" alt=\"\" src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/ethel…\"\u003e",
+                "lhId": "page-0-IMG"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/ethel-gosset.jpeg",
+              "totalBytes": 2245492,
+              "wastedBytes": 2245455,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 2245455,
+                    "reason": "This image file is larger than it needs to be (4284x5712) for its displayed dimensions (20x20). Use responsive images to reduce the image download size."
+                  }
+                ]
+              }
+            },
+            {
+              "wastedBytes": 185314,
+              "subItems": {
+                "items": [
+                  {
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size.",
+                    "wastedBytes": 60256
+                  },
+                  {
+                    "reason": "This image file is larger than it needs to be (1200x706) for its displayed dimensions (380x253). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 178462
+                  }
+                ],
+                "type": "subitems"
+              },
+              "totalBytes": 201358,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png",
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"pos_absolute inset_0 w_full h_full obj-f_cover op_0.8\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+                "lhId": "page-1-IMG",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,1,A,0,DIV,0,IMG",
+                "nodeLabel": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute",
+                "selector": "div.py_8 \u003e a.d_grid \u003e div.pos_relative \u003e img.pos_absolute",
+                "type": "node",
+                "boundingRect": {
+                  "height": 224,
+                  "right": 396,
+                  "width": 380,
+                  "bottom": 892,
+                  "top": 668,
+                  "left": 16
+                }
+              }
+            },
+            {
+              "node": {
+                "nodeLabel": "article.d_flex \u003e div.px_6 \u003e div.d_flex \u003e img.d_flex",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,DIV,1,DIV,2,UL,10,LI,0,ARTICLE,1,DIV,1,DIV,0,IMG",
+                "type": "node",
+                "boundingRect": {
+                  "left": 41,
+                  "height": 20,
+                  "right": 61,
+                  "width": 20,
+                  "bottom": 7462,
+                  "top": 7442
+                },
+                "selector": "article.d_flex \u003e div.px_6 \u003e div.d_flex \u003e img.d_flex",
+                "snippet": "\u003cimg class=\"d_flex ai_center jc_center flex_0_0_auto w_20px h_20px bdr_9999px\" alt=\"\" src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benja…\"\u003e",
+                "lhId": "page-2-IMG"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg",
+              "totalBytes": 66917,
+              "subItems": {
+                "items": [
+                  {
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size.",
+                    "wastedBytes": 25189
+                  },
+                  {
+                    "wastedBytes": 66810,
+                    "reason": "This image file is larger than it needs to be (512x489) for its displayed dimensions (20x20). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 66850
+            },
+            {
+              "node": {
+                "selector": "body \u003e div#ago-wrapper \u003e button#ago-chat-button \u003e img#open-path",
+                "type": "node",
+                "boundingRect": {
+                  "bottom": 792,
+                  "top": 760,
+                  "height": 32,
+                  "right": 380,
+                  "width": 30,
+                  "left": 350
+                },
+                "path": "1,HTML,1,BODY,12,DIV,1,BUTTON,0,IMG",
+                "nodeLabel": "Chat",
+                "lhId": "page-3-IMG",
+                "snippet": "\u003cimg src=\"https://www.ocobo.co/android-chrome-192x192.png\" alt=\"Chat\" id=\"open-path\" style=\"width: 32px; height: 32px; object-fit: contain;\"\u003e"
+              },
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "totalBytes": 16667,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 10523,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 16260,
+                    "reason": "This image file is larger than it needs to be (192x192) for its displayed dimensions (30x30). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "wastedBytes": 16517
+            },
+            {
+              "node": {
+                "path": "1,HTML,1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "nodeLabel": "Ocobo",
+                "boundingRect": {
+                  "left": 33,
+                  "bottom": 77,
+                  "top": 37,
+                  "right": 167,
+                  "height": 40,
+                  "width": 134
+                },
+                "type": "node",
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "lhId": "page-4-IMG"
+              },
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "totalBytes": 12266,
+              "wastedBytes": 11374,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size.",
+                    "wastedBytes": 6234
+                  },
+                  {
+                    "wastedBytes": 10452,
+                    "reason": "This image file is larger than it needs to be (348x104) for its displayed dimensions (134x40). Use responsive images to reduce the image download size."
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "categories": {
+      "performance": {
+        "id": "performance",
+        "title": "Performance",
+        "score": 0.42,
+        "auditRefs": [
+          {
+            "id": "first-contentful-paint",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "FCP"
+          },
+          {
+            "id": "largest-contentful-paint",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "LCP"
+          },
+          {
+            "id": "total-blocking-time",
+            "weight": 30,
+            "group": "metrics",
+            "acronym": "TBT"
+          },
+          {
+            "id": "cumulative-layout-shift",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "CLS"
+          },
+          {
+            "id": "speed-index",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "SI"
+          },
+          {
+            "id": "cache-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "cls-culprits-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "document-latency-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "dom-size-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "duplicated-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "font-display-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "forced-reflow-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "image-delivery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "inp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-discovery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "legacy-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "network-dependency-tree-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "render-blocking-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "third-parties-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "viewport-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "interactive",
+            "weight": 0,
+            "group": "hidden",
+            "acronym": "TTI"
+          },
+          {
+            "id": "max-potential-fid",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "unminified-css",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unminified-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-css-rules",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "total-byte-weight",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "user-timings",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "bootup-time",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "mainthread-work-breakdown",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "long-tasks",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "non-composited-animations",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unsized-images",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "network-requests",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-rtt",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-server-latency",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "main-thread-tasks",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "diagnostics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "metrics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "screenshot-thumbnails",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "final-screenshot",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "script-treemap-data",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "resource-summary",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "redirects",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "server-response-time",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "layout-shifts",
+            "weight": 0,
+            "group": "hidden"
+          }
+        ]
+      }
+    },
+    "categoryGroups": {
+      "a11y-names-labels": {
+        "title": "Names and labels",
+        "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "seo-crawl": {
+        "title": "Crawling and Indexing",
+        "description": "To appear in search results, crawlers need access to your app."
+      },
+      "a11y-navigation": {
+        "title": "Navigation",
+        "description": "These are opportunities to improve keyboard navigation in your application."
+      },
+      "a11y-color-contrast": {
+        "title": "Contrast",
+        "description": "These are opportunities to improve the legibility of your content."
+      },
+      "insights": {
+        "title": "Insights",
+        "description": "These insights are also available in the Chrome DevTools Performance Panel - [record a trace](https://developer.chrome.com/docs/devtools/performance/reference) to view more detailed information."
+      },
+      "metrics": {
+        "title": "Metrics"
+      },
+      "seo-mobile": {
+        "title": "Mobile Friendly",
+        "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn how to make pages mobile-friendly](https://developers.google.com/search/mobile-sites/)."
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "description": "More information about the performance of your application. These numbers don't [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score."
+      },
+      "a11y-best-practices": {
+        "title": "Best practices",
+        "description": "These items highlight common accessibility best practices."
+      },
+      "best-practices-general": {
+        "title": "General"
+      },
+      "seo-content": {
+        "title": "Content Best Practices",
+        "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+      },
+      "a11y-aria": {
+        "title": "ARIA",
+        "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "best-practices-ux": {
+        "title": "User Experience"
+      },
+      "a11y-audio-video": {
+        "title": "Audio and video",
+        "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+      },
+      "a11y-tables-lists": {
+        "title": "Tables and lists",
+        "description": "These are opportunities to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+      },
+      "a11y-language": {
+        "title": "Internationalization and localization",
+        "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      },
+      "best-practices-trust-safety": {
+        "title": "Trust and Safety"
+      },
+      "best-practices-browser-compat": {
+        "title": "Browser Compatibility"
+      }
+    },
+    "timing": {
+      "total": 32271.3
+    },
+    "i18n": {
+      "rendererFormattedStrings": {
+        "varianceDisclaimer": "Values are estimated and may vary. The [performance score is calculated](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) directly from these metrics.",
+        "opportunityResourceColumnLabel": "Opportunity",
+        "opportunitySavingsColumnLabel": "Estimated Savings",
+        "errorMissingAuditInfo": "Report error: no audit information",
+        "errorLabel": "Error!",
+        "warningHeader": "Warnings: ",
+        "passedAuditsGroupTitle": "Passed audits",
+        "notApplicableAuditsGroupTitle": "Not applicable",
+        "manualAuditsGroupTitle": "Additional items to manually check",
+        "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+        "crcLongestDurationLabel": "Maximum critical path latency:",
+        "crcInitialNavigation": "Initial Navigation",
+        "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+        "labDataTitle": "Lab Data",
+        "warningAuditsGroupTitle": "Passed audits but with warnings",
+        "snippetExpandButtonLabel": "Expand snippet",
+        "snippetCollapseButtonLabel": "Collapse snippet",
+        "thirdPartyResourcesLabel": "Show 3rd-party resources",
+        "runtimeDesktopEmulation": "Emulated Desktop",
+        "runtimeMobileEmulation": "Emulated Moto G Power",
+        "runtimeNoEmulation": "No emulation",
+        "runtimeSettingsBenchmark": "Unthrottled CPU/Memory Power",
+        "runtimeSettingsCPUThrottling": "CPU throttling",
+        "runtimeSettingsDevice": "Device",
+        "runtimeSettingsNetworkThrottling": "Network throttling",
+        "runtimeSettingsUANetwork": "User agent (network)",
+        "runtimeUnknown": "Unknown",
+        "dropdownCopyJSON": "Copy JSON",
+        "dropdownDarkTheme": "Toggle Dark Theme",
+        "dropdownPrintExpanded": "Print Expanded",
+        "dropdownPrintSummary": "Print Summary",
+        "dropdownSaveGist": "Save as Gist",
+        "dropdownSaveHTML": "Save as HTML",
+        "dropdownSaveJSON": "Save as JSON",
+        "dropdownViewer": "Open in Viewer",
+        "footerIssue": "File an issue",
+        "throttlingProvided": "Provided by environment",
+        "calculatorLink": "See calculator.",
+        "runtimeSettingsAxeVersion": "Axe version",
+        "viewTreemapLabel": "View Treemap",
+        "showRelevantAudits": "Show audits relevant to:"
+      }
+    },
+    "entities": [
+      {
+        "name": "ocobo.co",
+        "isFirstParty": true,
+        "isUnrecognized": true,
+        "origins": [
+          "https://www.ocobo.co"
+        ]
+      },
+      {
+        "name": "vercel-storage.com",
+        "isUnrecognized": true,
+        "origins": [
+          "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+        ]
+      },
+      {
+        "name": "Google Tag Manager",
+        "homepage": "https://marketingplatform.google.com/about/tag-manager/",
+        "category": "tag-manager",
+        "origins": [
+          "https://www.googletagmanager.com"
+        ]
+      },
+      {
+        "name": "Clearbit",
+        "homepage": "https://clearbit.com/",
+        "category": "analytics",
+        "origins": [
+          "https://tag.clearbitscripts.com"
+        ]
+      },
+      {
+        "name": "Hubspot",
+        "homepage": "https://hubspot.com/",
+        "category": "marketing",
+        "origins": [
+          "https://js-eu1.hs-scripts.com",
+          "https://js-eu1.hubspot.com",
+          "https://js-eu1.hscollectedforms.net",
+          "https://js-eu1.hs-analytics.net",
+          "https://js-eu1.hs-banner.com",
+          "https://js-eu1.hsforms.net",
+          "https://forms-eu1.hscollectedforms.net",
+          "https://forms-eu1.hsforms.com",
+          "https://cta-eu1.hubspot.com",
+          "https://track-eu1.hubspot.com",
+          "https://perf-eu1.hsforms.com"
+        ]
+      },
+      {
+        "name": "GitHub",
+        "category": "utility",
+        "origins": [
+          "https://useago.github.io"
+        ]
+      },
+      {
+        "name": "unsplash.com",
+        "isUnrecognized": true,
+        "origins": [
+          "https://images.unsplash.com"
+        ]
+      },
+      {
+        "name": "Google Analytics",
+        "homepage": "https://marketingplatform.google.com/about/analytics/",
+        "category": "analytics",
+        "origins": [
+          "https://www.google-analytics.com"
+        ]
+      },
+      {
+        "name": "Google Fonts",
+        "homepage": "https://fonts.google.com/",
+        "category": "cdn",
+        "origins": [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com"
+        ]
+      }
+    ],
+    "fullPageScreenshot": {
+      "nodes": {
+        "1-2-IMG": {
+          "bottom": 892,
+          "top": 668,
+          "height": 224,
+          "right": 396,
+          "width": 380,
+          "left": 16
+        },
+        "1-57-IMG": {
+          "left": 17,
+          "bottom": 16917,
+          "top": 16704,
+          "height": 213,
+          "right": 395,
+          "width": 378
+        },
+        "1-10-IMG": {
+          "bottom": 3504,
+          "top": 3484,
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "left": 41
+        },
+        "1-6-IMG": {
+          "left": 41,
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "bottom": 2369,
+          "top": 2349
+        },
+        "1-12-IMG": {
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "bottom": 4086,
+          "top": 4066,
+          "left": 41
+        },
+        "1-63-IMG": {
+          "left": 17,
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "bottom": 18605,
+          "top": 18393
+        },
+        "page-8-LINK": {
+          "width": 0,
+          "right": 0,
+          "height": 0,
+          "bottom": 0,
+          "top": 0,
+          "left": 0
+        },
+        "1-45-IMG": {
+          "left": 17,
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "bottom": 13598,
+          "top": 13385
+        },
+        "1-40-IMG": {
+          "width": 20,
+          "right": 61,
+          "height": 20,
+          "bottom": 12051,
+          "top": 12031,
+          "left": 41
+        },
+        "1-44-IMG": {
+          "width": 20,
+          "right": 61,
+          "height": 20,
+          "bottom": 13186,
+          "top": 13166,
+          "left": 41
+        },
+        "page-12-IMG": {
+          "left": 17,
+          "bottom": 1674,
+          "top": 1461,
+          "width": 378,
+          "height": 213,
+          "right": 395
+        },
+        "1-55-IMG": {
+          "left": 17,
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "top": 16180,
+          "bottom": 16392
+        },
+        "1-46-IMG": {
+          "bottom": 13740,
+          "top": 13720,
+          "right": 61,
+          "height": 20,
+          "width": 20,
+          "left": 41
+        },
+        "1-66-IMG": {
+          "left": 41,
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "bottom": 19272,
+          "top": 19252
+        },
+        "page-13-IMG": {
+          "top": 2568,
+          "bottom": 2780,
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "left": 17
+        },
+        "1-1-IMG": {
+          "left": 0,
+          "bottom": 0,
+          "top": 0,
+          "width": 0,
+          "height": 0,
+          "right": 0
+        },
+        "page-20-IMG": {
+          "left": 41,
+          "bottom": 5221,
+          "top": 5201,
+          "width": 20,
+          "height": 20,
+          "right": 61
+        },
+        "page-6-P": {
+          "left": 16,
+          "width": 380,
+          "height": 52,
+          "right": 396,
+          "bottom": 513,
+          "top": 461
+        },
+        "1-72-IMG": {
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 20988,
+          "top": 20968,
+          "left": 41
+        },
+        "1-67-IMG": {
+          "left": 17,
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "bottom": 19683,
+          "top": 19470
+        },
+        "1-47-IMG": {
+          "left": 17,
+          "bottom": 14151,
+          "top": 13938,
+          "right": 395,
+          "height": 213,
+          "width": 378
+        },
+        "1-49-IMG": {
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "bottom": 14704,
+          "top": 14492,
+          "left": 17
+        },
+        "1-33-IMG": {
+          "left": 17,
+          "top": 9894,
+          "bottom": 10107,
+          "width": 378,
+          "height": 213,
+          "right": 395
+        },
+        "1-54-IMG": {
+          "width": 20,
+          "right": 61,
+          "height": 20,
+          "bottom": 15981,
+          "top": 15961,
+          "left": 41
+        },
+        "page-19-IMG": {
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 2951,
+          "top": 2931,
+          "left": 41
+        },
+        "page-21-IMG": {
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 5774,
+          "top": 5754,
+          "left": 41
+        },
+        "page-17-IMG": {
+          "width": 378,
+          "right": 395,
+          "height": 213,
+          "bottom": 2227,
+          "top": 2014,
+          "left": 17
+        },
+        "page-2-IMG": {
+          "left": 41,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 7462,
+          "top": 7442
+        },
+        "page-25-IMG": {
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 3504,
+          "top": 3484,
+          "left": 41
+        },
+        "1-88-IMG": {
+          "left": 0,
+          "bottom": 0,
+          "top": 0,
+          "height": 0,
+          "right": 0,
+          "width": 0
+        },
+        "1-30-IMG": {
+          "bottom": 9122,
+          "top": 9102,
+          "width": 20,
+          "right": 61,
+          "height": 20,
+          "left": 41
+        },
+        "1-83-IMG": {
+          "bottom": 24052,
+          "top": 23839,
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "left": 17
+        },
+        "page-5-H1": {
+          "height": 187,
+          "right": 396,
+          "width": 380,
+          "bottom": 437,
+          "top": 250,
+          "left": 16
+        },
+        "1-13-IMG": {
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "bottom": 4497,
+          "top": 4284,
+          "left": 17
+        },
+        "1-28-IMG": {
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 8568,
+          "top": 8548,
+          "left": 41
+        },
+        "1-42-IMG": {
+          "left": 41,
+          "bottom": 12605,
+          "top": 12585,
+          "width": 20,
+          "height": 20,
+          "right": 61
+        },
+        "1-76-IMG": {
+          "right": 61,
+          "height": 20,
+          "width": 20,
+          "bottom": 22066,
+          "top": 22046,
+          "left": 41
+        },
+        "1-11-IMG": {
+          "bottom": 3915,
+          "top": 3703,
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "left": 17
+        },
+        "page-23-IMG": {
+          "left": 41,
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "bottom": 6909,
+          "top": 6889
+        },
+        "1-8-IMG": {
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 2951,
+          "top": 2931,
+          "left": 41
+        },
+        "page-10-BODY": {
+          "top": 0,
+          "bottom": 25905,
+          "height": 25905,
+          "right": 412,
+          "width": 412,
+          "left": 0
+        },
+        "page-1-IMG": {
+          "left": 16,
+          "bottom": 892,
+          "top": 668,
+          "width": 380,
+          "height": 224,
+          "right": 396
+        },
+        "1-25-IMG": {
+          "left": 17,
+          "width": 378,
+          "right": 395,
+          "height": 213,
+          "bottom": 7873,
+          "top": 7661
+        },
+        "1-75-IMG": {
+          "bottom": 21953,
+          "top": 21740,
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "left": 17
+        },
+        "1-84-IMG": {
+          "bottom": 24193,
+          "top": 24173,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "left": 41
+        },
+        "1-5-IMG": {
+          "left": 17,
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "bottom": 2227,
+          "top": 2014
+        },
+        "1-82-IMG": {
+          "left": 41,
+          "bottom": 23640,
+          "top": 23620,
+          "width": 20,
+          "right": 61,
+          "height": 20
+        },
+        "1-53-IMG": {
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "bottom": 15868,
+          "top": 15655,
+          "left": 17
+        },
+        "1-38-IMG": {
+          "left": 41,
+          "width": 20,
+          "right": 61,
+          "height": 20,
+          "bottom": 11470,
+          "top": 11450
+        },
+        "1-3-IMG": {
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "top": 1461,
+          "bottom": 1674,
+          "left": 17
+        },
+        "1-85-IMG": {
+          "left": 17,
+          "width": 378,
+          "right": 395,
+          "height": 213,
+          "bottom": 24605,
+          "top": 24392
+        },
+        "page-28-DIV": {
+          "left": 0,
+          "id": "ago-prompt",
+          "width": 392,
+          "height": 125,
+          "right": 392,
+          "bottom": 16303,
+          "top": 16178
+        },
+        "1-32-IMG": {
+          "bottom": 9696,
+          "top": 9676,
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "left": 41
+        },
+        "1-36-IMG": {
+          "bottom": 10888,
+          "top": 10868,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "left": 41
+        },
+        "1-39-IMG": {
+          "left": 17,
+          "right": 395,
+          "height": 213,
+          "width": 378,
+          "bottom": 11881,
+          "top": 11668
+        },
+        "1-89-IMG": {
+          "left": 0,
+          "height": 0,
+          "right": 0,
+          "width": 0,
+          "bottom": 0,
+          "top": 0
+        },
+        "1-78-IMG": {
+          "top": 22571,
+          "bottom": 22591,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "left": 41
+        },
+        "1-50-IMG": {
+          "left": 41,
+          "bottom": 14875,
+          "top": 14855,
+          "height": 20,
+          "right": 61,
+          "width": 20
+        },
+        "1-21-IMG": {
+          "left": 17,
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "top": 6526,
+          "bottom": 6738
+        },
+        "page-15-IMG": {
+          "bottom": 3915,
+          "top": 3703,
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "left": 17
+        },
+        "page-16-IMG": {
+          "left": 17,
+          "bottom": 19683,
+          "top": 19470,
+          "height": 213,
+          "right": 395,
+          "width": 378
+        },
+        "1-4-IMG": {
+          "left": 41,
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "bottom": 1816,
+          "top": 1796
+        },
+        "1-37-IMG": {
+          "bottom": 11299,
+          "top": 11087,
+          "right": 395,
+          "height": 213,
+          "width": 378,
+          "left": 17
+        },
+        "1-18-IMG": {
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 5774,
+          "top": 5754,
+          "left": 41
+        },
+        "1-69-IMG": {
+          "bottom": 20265,
+          "top": 20052,
+          "width": 378,
+          "right": 395,
+          "height": 213,
+          "left": 17
+        },
+        "page-9-META": {
+          "left": 0,
+          "width": 0,
+          "height": 0,
+          "right": 0,
+          "bottom": 0,
+          "top": 0
+        },
+        "1-80-IMG": {
+          "left": 41,
+          "bottom": 23116,
+          "top": 23096,
+          "width": 20,
+          "right": 61,
+          "height": 20
+        },
+        "1-41-IMG": {
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "bottom": 12463,
+          "top": 12250,
+          "left": 17
+        },
+        "page-24-IMG": {
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "bottom": 1816,
+          "top": 1796,
+          "left": 41
+        },
+        "1-71-IMG": {
+          "left": 17,
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "bottom": 20847,
+          "top": 20634
+        },
+        "1-23-IMG": {
+          "bottom": 7320,
+          "top": 7108,
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "left": 17
+        },
+        "1-59-IMG": {
+          "bottom": 17470,
+          "top": 17258,
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "left": 17
+        },
+        "1-62-IMG": {
+          "left": 41,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 18194,
+          "top": 18174
+        },
+        "1-68-IMG": {
+          "left": 41,
+          "bottom": 19853,
+          "top": 19833,
+          "width": 20,
+          "right": 61,
+          "height": 20
+        },
+        "1-58-IMG": {
+          "left": 41,
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "bottom": 17059,
+          "top": 17039
+        },
+        "page-11-circle": {
+          "left": 165,
+          "width": 1,
+          "height": 1,
+          "right": 167,
+          "bottom": 1806,
+          "top": 1805
+        },
+        "1-65-IMG": {
+          "left": 17,
+          "right": 395,
+          "height": 213,
+          "width": 378,
+          "bottom": 19130,
+          "top": 18917
+        },
+        "1-16-IMG": {
+          "left": 41,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 5221,
+          "top": 5201
+        },
+        "page-26-IMG": {
+          "width": 20,
+          "right": 61,
+          "height": 20,
+          "bottom": 4086,
+          "top": 4066,
+          "left": 41
+        },
+        "page-7-svg": {
+          "right": 0,
+          "height": 0,
+          "width": 0,
+          "bottom": 0,
+          "top": 0,
+          "left": 0
+        },
+        "1-52-IMG": {
+          "left": 41,
+          "bottom": 15456,
+          "top": 15436,
+          "width": 20,
+          "height": 20,
+          "right": 61
+        },
+        "1-60-IMG": {
+          "bottom": 17641,
+          "top": 17621,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "left": 41
+        },
+        "1-17-IMG": {
+          "left": 17,
+          "bottom": 5632,
+          "top": 5419,
+          "right": 395,
+          "height": 213,
+          "width": 378
+        },
+        "1-31-IMG": {
+          "left": 17,
+          "bottom": 9554,
+          "top": 9341,
+          "height": 213,
+          "right": 395,
+          "width": 378
+        },
+        "page-4-IMG": {
+          "bottom": 77,
+          "top": 37,
+          "right": 167,
+          "height": 40,
+          "width": 134,
+          "left": 33
+        },
+        "1-73-IMG": {
+          "left": 17,
+          "bottom": 21400,
+          "top": 21187,
+          "width": 378,
+          "right": 395,
+          "height": 213
+        },
+        "1-27-IMG": {
+          "left": 17,
+          "width": 378,
+          "right": 395,
+          "height": 213,
+          "bottom": 8427,
+          "top": 8214
+        },
+        "page-27-BUTTON": {
+          "height": 26,
+          "right": 397,
+          "width": 20,
+          "bottom": 16219,
+          "top": 16193,
+          "id": "ago-prompt-close",
+          "left": 377
+        },
+        "1-7-IMG": {
+          "left": 17,
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "bottom": 2780,
+          "top": 2568
+        },
+        "1-86-IMG": {
+          "left": 41,
+          "bottom": 24718,
+          "top": 24698,
+          "right": 61,
+          "height": 20,
+          "width": 20
+        },
+        "1-26-IMG": {
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "bottom": 8015,
+          "top": 7995,
+          "left": 41
+        },
+        "page-22-IMG": {
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "bottom": 6327,
+          "top": 6307,
+          "left": 41
+        },
+        "1-14-IMG": {
+          "left": 41,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 4667,
+          "top": 4647
+        },
+        "page-0-IMG": {
+          "left": 41,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 4667,
+          "top": 4647
+        },
+        "1-74-IMG": {
+          "left": 41,
+          "bottom": 21542,
+          "top": 21522,
+          "width": 20,
+          "height": 20,
+          "right": 61
+        },
+        "1-35-IMG": {
+          "left": 17,
+          "width": 378,
+          "right": 395,
+          "height": 213,
+          "bottom": 10717,
+          "top": 10505
+        },
+        "page-14-IMG": {
+          "left": 17,
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "bottom": 3362,
+          "top": 3149
+        },
+        "1-79-IMG": {
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "bottom": 23002,
+          "top": 22790,
+          "left": 17
+        },
+        "1-20-IMG": {
+          "left": 41,
+          "bottom": 6327,
+          "top": 6307,
+          "width": 20,
+          "height": 20,
+          "right": 61
+        },
+        "1-81-IMG": {
+          "left": 17,
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "bottom": 23527,
+          "top": 23314
+        },
+        "1-51-IMG": {
+          "bottom": 15286,
+          "top": 15073,
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "left": 17
+        },
+        "1-43-IMG": {
+          "left": 17,
+          "bottom": 13016,
+          "top": 12803,
+          "width": 378,
+          "right": 395,
+          "height": 213
+        },
+        "1-29-IMG": {
+          "left": 17,
+          "width": 378,
+          "right": 395,
+          "height": 213,
+          "bottom": 8980,
+          "top": 8767
+        },
+        "1-22-IMG": {
+          "bottom": 6909,
+          "top": 6889,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "left": 41
+        },
+        "1-34-IMG": {
+          "left": 41,
+          "bottom": 10306,
+          "top": 10286,
+          "right": 61,
+          "height": 20,
+          "width": 20
+        },
+        "page-18-IMG": {
+          "left": 41,
+          "bottom": 2369,
+          "top": 2349,
+          "right": 61,
+          "height": 20,
+          "width": 20
+        },
+        "1-70-IMG": {
+          "left": 41,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 20435,
+          "top": 20415
+        },
+        "1-77-IMG": {
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "bottom": 22478,
+          "top": 22265,
+          "left": 17
+        },
+        "1-24-IMG": {
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "top": 7442,
+          "bottom": 7462,
+          "left": 41
+        },
+        "1-0-IMG": {
+          "bottom": 77,
+          "top": 37,
+          "right": 167,
+          "height": 40,
+          "width": 134,
+          "left": 33
+        },
+        "1-64-IMG": {
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "top": 18698,
+          "bottom": 18718,
+          "left": 41
+        },
+        "1-9-IMG": {
+          "left": 17,
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "top": 3149,
+          "bottom": 3362
+        },
+        "1-87-IMG": {
+          "left": 350,
+          "id": "open-path",
+          "width": 30,
+          "right": 380,
+          "height": 32,
+          "bottom": 16352,
+          "top": 16320
+        },
+        "1-15-IMG": {
+          "left": 17,
+          "width": 378,
+          "height": 213,
+          "right": 395,
+          "bottom": 5079,
+          "top": 4866
+        },
+        "page-3-IMG": {
+          "top": 16320,
+          "bottom": 16352,
+          "width": 30,
+          "height": 32,
+          "right": 380,
+          "left": 350,
+          "id": "open-path"
+        },
+        "1-48-IMG": {
+          "bottom": 14293,
+          "top": 14273,
+          "height": 20,
+          "right": 61,
+          "width": 20,
+          "left": 41
+        },
+        "1-61-IMG": {
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "bottom": 18052,
+          "top": 17839,
+          "left": 17
+        },
+        "1-56-IMG": {
+          "left": 41,
+          "width": 20,
+          "height": 20,
+          "right": 61,
+          "bottom": 16506,
+          "top": 16486
+        },
+        "1-19-IMG": {
+          "bottom": 6185,
+          "top": 5973,
+          "height": 213,
+          "right": 395,
+          "width": 378,
+          "left": 17
+        }
+      },
+      "screenshot": {
+        "width": 412,
+        "height": 16383,
+        "data": "data:image/webp;base64,UklGRpJqAgBXRUJQVlA4WAoAAAAgAAAAmwEA/j8ASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZWUDggpGgCABAGD50BKpwB/z8/EYa8WSwoOyohkgk7YCIJaW78RhFhKmVRxHabP1fHoKjVTZ57VjSx8S2G7K3Adqn/FNtP/05H9icnm9CdcJ3bN9M+3k51HTvd6YyIj4f/Sv8D/aP9H/wP7n///nz8u/Zf9J/ef2v/xPpz5YPiX75/pf+5/i/33+zf8t/0fB/6x/d//P/cf732V/nP4N/j/5H9//8t8zv5D/c/6f9//7X6L/LLUF/Pv6l/yP8X+//wSfWf/H/e/jP40m2/8D/4f8T2Bfcv7x+1H+i/fj37vj/+5/nf9r+7vwX+1/5//z/6D4Af6h/iv2a9wP+H+x3+A82/8d/x/3F+AP+Yf4D/3/5b84Pp0/0f/5/xPQZ+uf87///9n4Hf6z+/3/R/83t////4Wfn/71oioZhDMIZhDMIZhDMIZhDMIZhDMIZhDMIZhDMHqbKxJ+exALQzB+5jQfVBWYPrCCNXhLKBPB7/Whhd2Wrtm55P9cyvHxY7Cqe/an8ajozHdBrPBJRDUv5ZPa8BrMiiHJeOwT13ft27HyR3A/dZWnbdRB0+jNwexz9WvwGDvERzCPu6IyjKUZRlkd7qW9IOBIpAhjFehYr1B4gjFeiJM7YScAtDMIZmCMV6F7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7gvcF7fiNLqAX/Q3niN0LGQ+8Of4jj32iGTSH68MJOOEpM35EWKKlPd8q4MBV050wa50rQOEgYtDMIZhDML8Gi+rAeSgCCiHFoZhDJ+Mqhi+PypE7gfezBdSvsQgI4K08VCrbkp9u/ECcfdM1+ddWyNKxfQq8E66OMgfakYaeln0aaD6cK7ZMMHWTi764FFjoglXrSVpkWZ1XwNdV/JxWStdXaXXxpEyILCQ7oEXFoZhDMHsgWmNN1AB3dwEEIODL86MHf8laQij2x6iDqPEIFYNEal96IoaR+PCgNub5iQBRDi0MwieGjI67m9CA9I/+diAWhlFJXzdUKQl9hiUoDPEsTxaJ22v+kJ436iyYKqDlmlmp02ChOsG2+i7tTj7pmvyDWSxekYgu9k0nBlZALHcuH/rG1tqUrBveseZvZ4nsbJep5KqvY1VdUI88OVPqE0C/eix9pos9Ofp21YC0WKsHqIFqZ0cVJ2O6t6eU4XpikzCGYQsPZneobPEia+JdVULK3SQe+pqtXEBTrEvnOjC3iLSa6dIkdZF3CQVU4TwPjwbMiibAqRbCGYQzCJ6d7mkwZtVLCGYQzB6W9XiGsyHd+iY9KWyjl8ZuFSdkW+oUTzCpG852Aq9iD9ARGNerYx90zXvZeWbSW2BElPbp0IjUsE+pG0qGhj5q+TLCqcmmj6ZWTAefAGSuTKf1ctfP0QdDYfDOAgfJ4WuIcaVNBxBALQyjMhe47WejI/AknD98XoLIhzTcKO58ixd/fOti/65sbssSn/9ZpWn8Cn3UCNxlmh2qD6QbPGYNiAWhmEPxiu5TnfWNGZ9wXuC9wXuC926mRRDi0Mv1V8Nba8rOrOVtWBsNZWdRJYV3l3KzHZlNU2QUZqHAvqSrvmnsjN0djZrYJCU4YjW1S3Ygd41Ax2ZAjK/aHG3nzAaQFAtvifP5EmEgWiV1FSkJ1K3+YQUboEwi8KTuQYpZZz1aSPLz+c51o2k4KAMlDbDSVC8tBUwdTuT1yrAUfvKv+/Jz9FDVXbPgXu52uYQmuLlJCHhlsn9HkJWF9zwy9tSzNXXN0lTcNZWYpGTTocqMjkt8mder5NKqMzbOKzSnivDLBkUgksC171CW+7TsIBALMp26vcCoZlx/PLBQZpOPd9COQntatYl/lJHYCwXQBdbQJDEFq3/zkTbCpfvBUhOfAwtrzyHACi6fwyAKIc4FfaRTI4jHWUNkVTIcWhmEMwhmEM8TdrtRLQzCGYQ5P3dX52IBaD//mdz1+Y3ZLlWAoSGu8l9mzIohxaQzGK9C9wiQ1Y9UoSApcf2MrGM+fpDp27tuhkd0lVmOddBvIHoQ3kEd+8Wj7+DX0BBmgjrNfnYgDp66lPHik0RCBQrbJ7JHkOUo3v3a/furLohWV9KD13lKBYuSqBCEoWR52zXITMn/+0giVx21IYAp+vgmwDIohxZ6rRLSRvGHSuD5RtdKhSk2tBOS6Ca6wA+FF7gvcF7gxEQ3gP0OLQzCGYPSlceKBa3Qp5mMRMw4iZQp5mMRMoU8iuQPu9IgGYH0zqzZv62Afd68Of3rHhgs0m6hH5eXOuti5V1G//fOJ4egGS9Tka8rta9FthlEwvtr+9PnDchCgsfo1JP5+ybXH6kJG7U/doxLFKubHF5A9UM/Q/HNi4TwSK4jJ7ige3dQogytAmwZyeOHQDWUIH8oiF9LD4P2UNqb3eUwxKjYrvQTyBexRBv3qBKvaz5f7Qhz0RiOcOpr2tw/I5fF8ZbNoHFzv0aczcWrtEl+QhK9j+hSHOKgy24pDVeBJhlBKxpa053Wl1wFro1OyI28fR3ypJ05YrPWkBeWN6INwq5vzdk6NLK5OKN+O7r+2rtEl727Uo3o2USozOKYJNplW8Bfgo98lk7UCxxS/hDmFlMEGiaF1X5z9JXzgGYlK4xoet5EQtxWNO7XxoVOyzeB5qZyTuzMtx+hpBxx5MB1Q+PbmpcgYGtAgX2pUbsFHZBeNWZi0bKbzWuk8yAN9vS5zCjKNrtCc/CVaDD7jA+dqCee1sdgqmppnyTNwBJ+mx+5C6waX7peXbR0mD34EdClhJoE7VlMp4qxIxfoljs/wcD/bOjP0C4wHnuZHVOiDOJhze96lH+DtWOa/+leE9vIrR5UUulwpehSA6eYbKbgiYP0sMlq7BagjQW71K31wcdf8Dn/nSOTqgFQ5TBpE9DDWLlwHXv/1QJvxn0ksqjHhyDQf7ebE9BC9TRvcwlz2fZuKBaZeN9XCjCbemzGkaTgbIJwWQTUg3/vtdjBo5HBMYjoqY2cc6RyXePhhVwYOyqvIgt5ZG8UPNeZ1wkMFbKWmfoZtltTwurBXThF5/cMmK9Aa8RTtktKTld/4E2h0mnBGB7c0BSiGJEw88Bj/0NzZyxQbSOACeKJoFuOZNIQ29BOwM8zFcmUNxVApTYiHDTOTFtDhJGt24XFXmMRqLjIbNM8vFOXrzkEnmwD4WrobcBxaGYQzESjiqH3CoE3WLPxwsBlq+kEZr9SQEuuc4QTjbdpf+amkUoaTgZgF0DU825JSUjKD0tE0xdHA12ILP6hD2VJmusx9UPdXDy9qTbV0L3BfxK8zVbL3BeFQp2ojqU70L2nsfRI4114LVEll2TaI00E2GfPGt7GHVYEOOUYU7rGvdX2Nx1xu2BGBTzwCrkmcUuG4LQO7MzUqbOQkYNqoBcZ8eaK+UPoCLyy+8QJcIIYAh3FSIrbIyUcbJNCeQPRWdoOdR5BgKOG5SG3hjOvDcUpinaxmJvT5a/YpLzb5zcjgTD3OZ/1gcpeh9kbyGE5hJWrPDdXF6Su0RzJkRAViWd/xv+ri2lFVUKl/YeeC9gb4eeXI+mTo47ABTDtEPTK+IP2P4pWm6WHgbAI/DZda2ZwAW2ksydcJQibTA04lgzaA2Xs/E7alSri9hjncOHGoCHHC3fa/ABkUfIskNQRP16c83fWjZyLcAxwx+jey3zyahUWt3jK829gIYeVESI89UFWMnskm07kYF8/K0lXf5x9wNUs0f/LRr0eBv76zxF1mU8q1mRQh+ZlTza6DRJsC2+LGt4xamXgTis9eT6tcI3cnXc2MFQS1WHcHoZA8MZgBuOA+0Vn5491uNiudkG8+4KulWBTpLn3KS2jlwK+faex9EpSavn3Be4L3Be09j6JGz91S+GrUXSo5wgWEcFzfeheLY40hRzDuA1SiAjDhFtSBy5ToGNWp4fHwXKCgQDh7MQB2YDzF01hUMqhPLaqkpHP0b2W98WRwH2WKh7W3lPejyh6u7ek8U4UL4fS8IM3Hbft1phxilyO+fQN3G/SvFZ21Pik3Wg7jNDk9uqxmhHJaDAI/pywHAbHUEPAktA5IdiL7bgKJSoQQLbmZzbnE658WKBO3Pgse2o0+6L/uH/w1lNKJBQ9JjI9LJzDwwDnd6VfXOL2otL+Xf1fwq4s+El1zkVjoe4c1hWyK9EMKIf+ifbRV0nC+pBZjnQkvFiMZ8AwELmnB8Hof1p4K4jYWhBN02EUDLlZLWLWHFdgsMEdswavV0Z0u+QSbGqlN9fxP/NwDfug0IEoDkTYo13gEqUdZch+Hv/vOrTwkinUljEpnGgFhISJg+El1zlR0FRoQAuJRNhQDYKDJbwvAjxwBBgtrI+tXITP/5/gye67EDCN+rnNsaP8wRXTngMQBwvb9pshDfMwSlfQoOf+dzAxq438pulEv7keeXI+iv0yJcgjuZhxCGAauAhuCIHV3AEhnyTxHm/vofJkIZGLVskqCh+g40BLp2Fu4LtX4sb4WJevpgOdCacMO+L20gvbe5eNhV10cTJnUa+1zlIbeGKuvsfSlKoR3OuQyRFDDHJPdmZX4IDkLF5YhYFYQvbiGXduLLFqQBT3ipwZ8zCfNI88uR9HC1l5/Hds4CbemYJsZxfz0yzpuVou9DgPXpmFNHcTEso03o55Swl7YvdxYnUMr9LHDv0G3btvGxFnmT59NYlRBaPcgpqkCJPJYzBXQOI8RehoMEQ7GInPh6IHh5c/0YOw0EfmN1t4PmRmhyyA/hbywhmEMwhl/3D/4qHFoZhDMIZhDL/uH/wz+W0e++yQhTzMYiZPXAsdlaB/wPBe4L2nsfRI4/X5VYhn9Tg/TYlzYI7Bduii713gNyIuwuVT9QOB6oGj1JjygLutkdm1RLQyk8uR9MP4ISuN4M+54ZbWghI93Dlvc4+QHfnYgDzy37yKBS/LMIZmCMV6F7flrjmrzTOW2RmShe4L3DbL3Be37Lw5CGiFPg+xlO+UTKFPMxiJlCnmYxEyhTzMYiZO0lozSgwx1gG+hrvJhWAoSGu8mBXD8CZ6Gu8mFYChIa7yYFjvHDWSUsBQkNd5MKwFBwdvJ0Kxpc/65VgKEhrvJJHCEBezCGYQzCGYQzCGYREx9HBaGYQzCGYQzCGizfdn3Be4L3Be4L3B5hvkiiHFoZhDMIZhETaYXz7gvcF7gvcF7jhE3dM1+diAWhmEMwpE5vuC9wXuC9wXuC+DMGj/52IBaGYQzCGZC/Av3Be4L3Be4L3Bg2zY5r87EAtDMIZhDRZvuz7gvcF7gvcF7g8w3yRRDi0MwhmEMwiJtNRrvJhWAoSGu8mFYChIDMAuLQzCGYQzCGYRE2k0p7Xz8wMoCLX13TnT8MxO3mMfyvMCUXAMM4uuinMRUx5bgRx2KiWhx4S6Z5pzLuNkUwNB8p5mgaBtQb9KF3MazRvlEdSXgpZO3fwkj8lWmRVXmqbDnEtZ/78tJa+cNtiID0e8pxgX3pjqp4e7G1KAGTjC6W9jXWAuhZz+J1o4XDIxQ441zSbWLcvCvY4NTPexjvD1cKq9KgPccX705TD5RDIgC3JycG2Z/V6Digolhe1Olg3coH9gi73uXkVMMRDOSEqCR8/b+95g70KgaGNyUwmhnjnd4FAJpO13wdGx0oyD5ucq/k1uZA2DeIu5HnV3L3lxKeKjW2OHOnBkldNSXZ8aTg6dNmqrSPJ/0vCSYSWmFUo4XYgcDVKi0KEl2o5kmyOmnIfMAlgxpLwFAkXkG6IOmjTn8rWcYmSRgZYDSphswhcARRVIiMDK+WTA+ql51/F6yIceGmsA6dJMQ78as3eDL6GUi21KZFR1i7Fn5BSCNL18QlRg1jj/fobClbUCS++vB8MIA5Cs4WVa8GqA/J3rwyFdJjwh91nMuKIGR1vc7s4ZTE5YPka5dUwcC6nvHZxzysuPUQPJXweneVovTMcIix4Sq+kYgGB8fb+J7aqgLbmTsvVNIV9CIhvAJyTgK5vVfP0pMnHKz0r/hA1hnT9HedcAJhEBS2RzZZ8SdGKGh8lulhSkhXwaJUTtiUzX525Q9JjODWCR+na/NUsaxN0H6PPVwXvW0RU5FF4LttAvFhwbLOs7s+4MG2bJgEW37gyi2yqcZxPx+NWZFEQY0y1HHsjmL0RkGff3kGSD1ohrBjG9+cX/fFCiViQgOjpBZ7mBwO4qDWCIgFoibTEErwp3oN6eIK/OxALUic33DbL3BfkazIohyub7s/lnJ0ejbL3Be4PMNsYI//RKD7chiij0T7gvcGDbM/zCHngdaykooYYpem7MsZ5QOmgUuoGnHo6hrCA2kYEvT7VO2KiQr+kFZLKFa8m2sFX3iD7gvcF7jhEq4K88uJNrQTkb3t7LZwC0MwhmQtrEP3a8MO3413kzFY0uf9cqwFAumSat560frzVpkhsFVYChIa7yYVesIZhDODWNfnYgFoZhDKkj/rqKxpc/65VgKEhrfk0fnBe7dTIohxaGYQtn5YLJmz9Di0MwhmEMyF+BfuG2XuC9wXuC9xwibumeexALQzCGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb7s+7dTIohxaGYQ0Wb21j/tmGpIa7yYVgKEhoKtWnCp73YVmvAyDk23U8FITzu5rNeC3elzHMF/VZyVcOrEltqy4wCUyvmwr3/qZnI5evjQ6aTzaMOnSHkUQXgIO/j8FMr0xlwuIOJBp1mByubSBU2orNx0EAJa7112WXQCTFNEJwlowRNhe1k7qbBZwQra5QgoTpwrDuVbcWbwR9fIvECe7bXpnZiZOa+13GE+Aa1BIcYF954VEFr9yizayojW6IEQ49Y/lcsiA9GTZs0c/B1Z23glZHQgFYLA6dTX7C9wXwZgpuKRkEctCjNrrL5+QUNVbLXsv8+6yt7gMVjffmFTBOpHtGTY5MqBXu0V8UG0YVetubMjFXS4m39gcitCSwiWOmqJaGizeq5KvW9k+CU0+t/V+RvoIH7p7Gok3P65eVp1/9xX6Drva8do1RuJW4aVgBWwpvWIHRltOQF3OlCqRynYSrqcxTsQFc3rEAqW3tGOUGvcRW8h+GXONj/vdLKuaIb8IfUMoldl9b46XpgOJAtX0X+iiGSq4mktJNB/sZgCZZQWf1VbtihmQvvckr0Msr+nqT44imRSlMipEUrBiCBqbxZOjjP6tErzE8UTUNQjCa+lIW9SvuYxygzIKQUbU+F4fs8fki9IoXpPyFE9dDMkgl6F8GYKxFqw0Dq4GAfxJy5Xvn3B5hvbgdNwdoaao3bMjHyQf8kOuAD9oyCHJGrHxmSnG1LRbcAV86wbzkSfkKQ6ZBsgy7wiJtMAWvt+4SwnYnYcaJxG5lUhltaCcNJ57jhE3waOTdr3TiDyAWhmQvwL9wXuC962lxaGYUic33cy3FoZhIn5kURBjSX4aMWK14GM6hg4mhRxcfEScvcdWzShxaGZC+9GgB2fdfpKbsCELcqkJ49xwIEwhxR/qY1/vjY8R9yX8Ay2NAFDFkwrnfUL3BfBlwxJIIPNL1fxJyWhmEMwfXfQDRPxaFc/Y3QVVgKEhrvJhWAoSFZypBRoZw73FuQW0vQ1JDXeTCsBM6+fyNZkUQ4tDMIZhC6qmd/7AUJDXeTCsBQkNYw5DcH3TkiiHFoZhDMIZhSJu7AUUQ4tDMIZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZv5QCBoakhrvJhWAoSGuaEY2Ga0ofkwrAUJDXeTCsBOixgOrYjdR8bb9S9oFL321DLYt4cH47/RlCTOahvSywcLcPrZQkNSEGj1Eeg5Rl6D8X3hgr989DWmuh6bqRM9vDJvEPKeuShd3Be44RKpaOSJTxO+YcEr0pBZvg7c9pJb15/7ohXXSdwJfyaPtCCykIE+a+nXAqzrVuwfSIqJzfu76yiyEHu4L3HCJU4EeHbb+xP988mX3vUrn3Cv+ct/lE0YGLWzH6o5BcamDd8CSZaNVcpqWdHRe3g/zCXnMIO5OSOKTyjBC6KMqKaFd3et8BznMLKi8An32GI231LwIkogcA3RGx+juLQCuppt30lfLcAY7vbtThUfA1BAKDX6FHETKhvi6D/Fjps3VINReTy03kf1QAzEqeEcacMK4FNv4uAvlWGAkAOOsh9hYwgjd5lTcLoDkgqXxdmGBKt7Qo0l/SQLT88/2K6NBAkV65GVKp1iXWYwQgtMDwGzqGBJ5wTIT3zlAaxh3/1n8lAPb9EKQjvH4bcu16sLUDc8HWepxwjYvxbk603LelygF4X4qnck1/L195NB7uLhQrLWP/VPkMjsDVSJtJgAoG74QuDxYSY0prqlShZWcsiq/iMjjIOzNsMAGmDlfq1MuWu5TNhZEnCKlQWNNSTXQZqkvkgCRw9B+RrXWvSDIE4BSzvKhm/DYeilOfFSKJb4GbIYWk7YZx24Dq7xoB08JNmztSo08ROw6+K9C9xwido0seWEMwhmEMwhos3qk/RRMAPqz5pqacma9ou9M3+GAw6oamhfAQNy77YNU/ZG+nv2vWpkOLUicmux5EuqwDU9BLwHoWBYoHB7+CDahgEbHDm6D9gcFAI37R/87F1+ZyMD8k5SwcCXqg6Ysfkp5x5QDZaSYU3wD7DsqXGBfgoUr50EyjTZTMCH7ej3a62qUC+8ezmXxtAdBcO7HbVV2q/sHUTlnAKLiASiP9QLfA9IwFdQ5XN+zqm3/OrEF3oN6/LWDk/xRN3TNfqXFoengVdxakTm+7dTJXxaGYQzCGizeqZy+AucYNp2LQzCHn6zk7J0KlM/Fi3HXfZkwItxDZQlRzWAv45Wz8em7FFNHRcRo/4CUtOikzMEffoBIQ4lZaBIyJXNn3Be4MG2Z+yHCE2HIJrxECka/OxALQ0WN0d7/pLwDJ3uLekDlBbS9DUkNd5KzwmjnDWMjwP+2YadBrvJhWAoSD3Wa/U+n3Be4L3Be4L2/2C97y5/1yrAUJDXeTB8YmkQI7GoHr8xutvCsaXP+uIWRDGnx90zX52IBaGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfdpBGa/OxALQzCGizfygEDQ1JDXeTCsBQkNc0IxsI0PTQvNLE9TiDWEqIUhTCTbR2EvBbj0NA6qeaE6JUCtiVG5U4fvELZVkHKvp0mZQwmuZavS7PSW2CmVy86pXwZkL70YMQ7n+KJS1fotjVwi+uqpk17tvzrQdg8XvyEvFQ4pckGWuyRzlj50rxBw2lCNau36VVf2dtYUAVCWi9n9HEbllNq+qicipBd2CrQRBUp9+2pOR0z+nwbQtNGiaLIXLbX45/XoG2Z7NT47GOghI9gseHs/iufApi/x7TZRwiDLSdfFQHmBVmBDRoTI2RpQaG3/qiKG/FRDbcGQnXxX/Y7dN/MBIlsybW+yVwRugJh9EOHVPcSzN40ROTM2wXj+6re6Ku5G2iJ+n6rRjRgd5JeJN5ILunnMhMpS21k2ORDcP5t0q6dihCFXt2gpI9RAw0om2cLEGf/gQitYRoRs+bujhCFz8uQTlLBgiHaqB8SUeKy7zeqTwbsNWpNTsS+WlIxdWX3NQHOSIj1FVBdxaVdk1Lp3JjJ1RO82e6KO4g/2kd1ut6G7y3LEbzD590MIPr6Q+LvlYzAOlU8zKze11qILG2XmOgQokwlpq25Q9MXyXZ8PgQg0d/SO9hduYP5bLJe9Rh86Qjq1pVzgUW6QMDAsU7J+V84NVknN8+44RKgEX3elALfDT4jUAeXvBe4L4MwUL9eJDLgvpQr4HhDONCGampfTyIZAnSNxiwuD+vsESE+rEabdu1hDBdufA1RGoj+f4GAE0tApUfucL7gvcHmG9yjgFoamv8r3Be4PMN+ui0joBjz2/TUISUa5mgjaKc61h3Fm4tVMakIkoHiXj4wAgqLYv7Ze4L3B5hvawMMcMsmtlzM35DjvJq+fccIm+DQVw6QAIBaGYQzIX4F+7mW5Em6ckUQ4tSJzfcF7gvdupkUQ4tSJyWJjc33ksgDRq1ZfSxQvCp8S9MblOT3Efv+nBQQCPFJSavn3Bg2zP45do+o6WDSGLz18k5YPv2en5bswCXCYBPIPzKNt7ddd0tGQQUQ4tDMhevcCrt2r/KYkg86vzsQCz7AUJKSJrIIw08yrOsuf9cqwFCQ13krH4xCdfnYgFoZhDMIZhDMIZhDk/Fehe4L3Be4L2rZhhxpc/65VgKEhrvJXlA11N4QxRkvZsljZgxlWOVDzmJDMYr0L3Be4L3HCJu7AUUQ4tDMIZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvu0gjNfnYgFoZhDRZvbWRWXoakhrvJhWAoSGuaBhMFVYChIa7yYVgKEhrmfYDlebVEKKeGhCQ0M3fgVYncH7ewqxSKBKxIy8Rj/ag+5H76kLV1hDVt9UF16W48ygIo9O/LE/s2S9OXRRAzF9dbFgGayYRcFiWJalGesaCkRodnp7LVLbeR0+dqPZ3cYL8f9jA+qMqg+GKAheBTHw/Dpl7ohiuryEbPKb+51KyywUMO2BJOgYgFhC82YMbD/IFVlV3EfkwQnu1bgjXQFbiFmQGaqCh50+Z3o0ViVNU0heoc9Nnpzff+8jk9PPfH1qzbdvNp+Nl2VgG0hpPGz8PfDqytAmhe7XHU/NOwT+psbfvTcQ84Lflto+GDZsLWk03vblD2ij31LXtb5rdDAJ7gZZi5SFFgFB9pQcTxTwy74r0L3HCJUrv3Rua+0u7grb66MsHcAWMrqBdC0cadFxpwWypyxa7uMApY4tWfDhPer1OMjVNz20o0/YVyMOlVfxOSCgmD99ljJuGPyg7zyKX8naO277T537qd6utELTaRjObJE85bumK9DBtmepio/aaLTJxQ+F2kI+kliR+tZn9mkEeR7GMUYFVhMkxevWjdl5br617Ey6kmUN7reS+hY0UxdPhCOmbu4+CKp3M7FirDRvYi/w1E+t0Ogja28xjLFdrXI6czJ87brmd/fq9YSRBMsBYFvPIHjgoEYakdvD+MVAlRnTF+oVVUmhxnIf6Oclh0ELiCQ3tGJBpCkLhFikHOuCYFe7f55DjAvwL9ypleeeYYXAr5+DMFKkhXf8G7Q/oyWGTP+P/yCh9Ns11+rsvEQxH0InY4OwkfE+VnlyGrFs41UJb9l6F7g8w21kt5Uc/u5KX3PDLbAKvfCXivF0IuhIS0MwiJtKXBL2T9N8VE3Or3ZKLjJobCUbWtIqTPKkt0tre6Zr87F1+VckKctj74gPL6DPSMOOnrcnzfjLBxDvCiAimsSfVcNqiWhmERNpn31pBbgBm2K9C9wXuOETd0zX55vCGYQzCGizfdpBGa/UuLQzCGYUiclYXia0UCBK6WkMxivQvgzBTav4A+TVDX6oMXfV/4ueEQXGj9ukjsPHoNpkxAWCyX6bYyoVXLBUdxpTZ4bMub1fPuC+DMFM8Jbw4iYtpaqvi4fzsQC0RM7j/rA5XxgSt0D1po3LvhWNLn/W08IuH9Mxg+/kiiHFoZhDMIZhDMIcn4r0L3Be4L3Be1W2YcaXP+uVYChIa7yV+6PA/n8zKtyC2l6GpIa7yYVgJoVljvJq+fcF7gvcGDbNjnnsQC0MwhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5+tuO56/MbrbwrGlz/qzy71ECGI1aA8PsWw0oRpcTTk3X7lL5nNlwLSbP6oGxta1oxS4sePG0J8vcF7gwbZn1G85aRTcrlIlKe1x1KT8HzSXMV4WL937qqAyfgalUScxwKTXqUPsi3/3VTAV+gE9moJWR1og6/OLOVpOOqX4v+2Oa/OxCY0l+Glnd5nSH5a4refXVdfVyvAA7Sd+abLMlaQWunyEymprBlxncwJjyVi/oZnjMqPtTw/n0f0fXqExBompu9kOVzetWezdPZ/vysDrajKpDiLcZhU2tIgRCPXqotgDRvHBjA5JXTTXZA8w2DIGN2Q61jWfeDoJ/5I4tPKjHjWovJMIMpZEEBXN61T4ghFmLu3hPvflrNzSxKEi+Z2KWZLMN3Mz7jYPr6z2qgPYlQZAzmYpW/AiJEj2m+f+Z/vJRBmdVw4oycDeOwKBXGfs3Orw7EBjqMtHrEZyf7Uc1ItDMKROS4hw3iDl8Ycbwuz/HeCL8y6D/EhrDo7OQAjyzgxgFbAHFBtiINwj7q0Tdfx7ld3BfBmCkVqzg+os87VEYfK96jaCz2ErFyEC1VyRYkXJvft0IqKcwutQMwMjwo0AMgsXfe16r+GX9EVMKNju9TgB/a60mkWl6xAmHnlG9H2jGmSqY66Mtra6GJoERzX6Ac7DK4iMsmJlEhEAtDMhfeeMhkSTS6w8tPB23WbCBAVpcXm6gL5W+nEGpKJaGYUicmyWix1KfNu4IjtQnWqTQbGmgEDMXshGJ2cEh0/h50FD4j9BZon1AF2yoXXgRFwxXoXwZgsAEFtzRXfKPgDU/+FQ3mAGu1znhE5LIx2BBLAwJAcls77gam7h+YWcA7hpDjcxMbwmJdaael0z20OMNmqQELTyUdSC7ydNTh8bNkdDvME6koir51RDxWDS/rnEAZMr4KIm7p8+03h11N8Pq+fet/wWmYQzCGYQ8/WZFErfmhmShe4L3Be4L3B5htqW7LSFFulqnqt6pr2jAng9hiecORMA1rGdoWDiWUDwSt8f9M+sjFNGqZmEufTQWC9wXuC+DMFIJOexoJsLNB41ZurCHy4IV759wXuDBsD99pvKbVCAfPuC9wXuC9wXtWSPczMmHt7bAUJDXeTCsBQkNd5KtBd9pG5/87EAtDMIZhDMIZvyavn3Be4L3Be4L5sFVYChIa7yYVgKEhgF8jhpMs1N+7L3Be4L3Be4MZaKYkMxivQvcF7gvcbRNID9Di0MwhmEMwiIS3ECVmRRDi0MwhmFGOSyV8WhmEMwhmEMyCA3dgKKIcWhmEMwhomGJAfocWhmEMwhmERCW4gSsyKIcWhmEMwoxyWSvi0MwhmEMwhmQQG7sBRRDi0MwhmENEwxID9Di0MwhmEMwiIS3ECVmRRDi0MwhmFGOWGit/ILaXoakhrvJhWANm4f70pUwAQ1scSz0FeqojbhHjrGsIiEgxNBno2QPbGlpJ9II4hzcWORYKIXo4tFLWkPwtnxnNbAGwhgmTOBLAkZF5NVoM4mn23SXvSREf26F7Rar1RKuZjE3qRz4Qa/ExWLYB4Qm5YIuNT0+cHRLOGf2wFDPnm602M6ZRcSVHWTaWTlUn82AS3JlGvuCYXHga6B7ec26QoHXcTXrd6zyy7Kl1A4yPG+6CjL35m0ueZv0I8vijkdGWrCbxyZJpJUMlwsbCjHFfNysmR6ZauYz97PEbD5zB9wCSVSIHhl7J8xEokw8AvyVbjS+blwKdi2g5YpwPLGQK9hu8uel5PbI69DQGhPi0ltP+JEbPShRw7YgFqMcVY+Icx2XQRePhsByAIxWKBjPp1oEYeefdgrdCbl7cvs8oZIOp32CCXHBQGG6iWoxxZs/2VRk8Fe+DFpDLiPe+7eCpDCawMsQiAXBKtMY8cg6omAWMR0pJ48gU9eNs0nc/lodXaTnuAbBLkEclreQYGfQBXg2tsiMwJkvDzdk0cMilCnu0gjNfnYgGQRivTaJSp1OABjVXt6TxGd1PZze7Z8JBdsfSfNsMfAW4eYtKxpybgDl08DACqUdsW2qJajHFk1zpIFev+1iRJcu4ubFPqxlV87EAwEBbVlwdmYkaV69vecE/6xzWBgPFWpfmSxHPSFT69ZdTDwJIMf1Zmex9pR4GRShT5IwK3dkc/OSsJQlqKwieSAdeGgE1PSjxBppbvOiUGpsoaR6uFWiK/ZzeNYq/SVtj5aZDlWGP4c/OW073+YNEPae0URBMtw+6Zr899QvdupkZIPG/gNpcWhmEiJ/cGDHRhBVZlgWxciHAFEbpfr/3SIZUmyV8xb1fPwTb/7eWBPcrhVcm0yolA/2wgfDCbVyM9DA76ybiBCGaEPfCe6N0MFGY25Ql+IvQ1DLLkvZhDMIZkEBU/x/5hF7zAC3kzoZhDMIZhRfXTDIfgPkfRSwNn1trS9DUkNd5Kzwi9gHgx0+hsFVYChIa7yYVgKENBe4cDXYgFoZhDMIZg+zl1FY0uf9cqwFCQ13iuEh/hJaQzGK9C9wXuC9wYNpJ3k1fPuC9wXuDBtmxzz2IBaGYQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic33bqZFEOLQzCGYUic/W3Hc9fmN1t4VjS5/1xuqVSslLfuSs25gQfYbAuj/kklYPgsB2HpWGSkqAIg8Q6I65gaxFQC0MwpE5NM/klBcUr2HRyrq58JpEFA4/A2I8yUftqgX+orfis+oNs0If0M4c/H9l/aiML6GbY+A75Ytu2zoxJZxpG70TsQC0RNpMK1mETiHKNk/X2pblsO0Eo0iZEqDAmCN6gyz3eWnsLspFTY/e0eySUBh6nDKL0Jrcz4bv+WsTX/6IP/nblD0ypboTrMe3YteNRuGp0aup+BjOml2BEKnkd1wDKV1JB8BZ1Oqldtw4h8zQ3MDCdYQSxH2v8GxbUEOpzgjfnYuvyLyV1EDG/ow4bNKh1fy+K9JZuqQOEuBDptdKGZBEpogS0GVY3x7bDzaDVFW7/nJI93bg4ByLUWyGZR3ZG47+78M59Dcd/9pIYmrBxrtIQYrNVMw5wtjpb/EjqgU+ZPspnPh5rc516cIlVYGhVgtR/Z5yCV0N8SdiFjRgPlz0sEu95aEiOTR/qEp2/qHLP4QijUeRJ39i2YcKbOjIpSmREP24j4GH8qdXvR1LHcK8iyOVNf9AOdJwYh80xREMDpb1dZbCov9JczRFCB0tpLeIwZt0HhwRNKxfu9g/s1BUPsYic0YYsqQmecotDG451HZSxMaj7KIsKP9DMIibTD7pzCLMba7+rvJdcOZkL8DhfL33xIxL7fiPIgP7GGvzSBrMytAw5Dh499qm93C5TmHqS3cWF7d9q+tL/84u+L6lYbt+w8URtmK0K2r+8xqEf+7DzbiB6HDapsaWIJ93FBkx1nO4D9g+0MwpE5vuC9wi5Sp8gsRkUSt+aGMV6F7gvcF7htnmG+Uod5SfivRtm4dPIyqD3m/ytDGzb0uzI6l8dSqdNXeOy8lXPS4tG9gjhrpcB0OF+Dvg6hHMduqoCIgFqROTXsrApnlZ70e+oGpjLazDh0Cwd0Hq+Wn2HOGOutMWxlUIwzfk1fPwYlkAOhXV5v9v7TgOmbBN6vn2/0U5g9fZBngm3HOsuf9cqwFCQ13kwqg20716EYTZkUQ4tDMIZhDMIZvyavn3Be4L3Be4K5He8uf9cqwFCQ13kwqjem6ywAutxjFehe4L3Be4MG2WZaoloZhDMIZhDRZvu7svcF7gvcF7gvgzBpG9iAWhmEMwhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNphlvdM1+diAWhmERNpqOnyrAUJDXeTCsBQkNc0JPfk1fPuC9wXuC+DL2tQJWBLSPXNLiEWuR9VMgIAlSjSUHikMMBmkdfV0FdpDK8Wrap3wPwxgNAwJn2QzMvGSRt5/U+m9wXuC+DMFN0oAIs/5Lj0A9NxvPIAx8mWZYdJ2aOhz6sDLru07xu7Lk4tB0KgH/dM2FkSbCx7tzzVbdUcPkB4yDl5jJG6IuYFOIFVST9c7IXF3/NKIjIfDA4gadIbwS3Qn9PbKRMHIMRbqxpW9LBxaYPcYHiWBAim0SiAwQiA4vAnu7Ya2CSYQQRoeavVPkRlR/RRd0OmbCyJNmEZD3BE0lG/WbJR/iIVYaTNjeRH6kSq3cl/2+FM26XGcPYzWg6SVpuGwU0mygkYjahT+MP2HyyatSCyVNjSa2YE38gRSFCX0I4lk36JVns+haW7govEEfIXzmsRBneYAoJmES6Me8AWZuZAdVb1Kf3xYiYwL4HRqclCbP3ZWsBUMFUrjXoHrOaYtFavTX4gEGvdy34MzY3oABmMNTRfO3wPr9lhVj7LCuFhN/NeIez3HZoX4Gq3D1WVeaQr7Ve7RSlMiLuT5ZuBWfNQunJsYRKmSviTdKJE7BffmckKELLlD9cqMLf3jvX8GRRK35HV7CJdVgGp6CXgPQsCwkKvq54t4v/CTolOpXRfn0ymOq2JIHxmEMyF+BsSCba7IKbZupcI+6Zr9/gt4FM75MHAgReDqYBRhrfFoZhDMIaLN+zqm2hVpZEtDMIZhETaYX0ADRPuC9wXuC+DMGkB+hxaGYQzCGYRE2kvsFqkdq0dOH3n3Be4L3Bg2zP7pQfCAs8Jfhil59YHp+TYWffzqxcmHNC3luibkVVNGX3cJQJGmbKiWUXHGTeb4sePsqd3Be4L3HCJVwV55cmLYck2Hvb2UxALQzCGZC2sQ/dsAlWXxYCrcgtpehqSGu8mDtxihICTatd7gYX65VgKEhrvJhTywhmIxtmRRDi0MwhmELcHIKqwFCQ13kwrAUJDKkzUQ/Cb87EAtDMIZg/sZbePxRKczCGYQzCGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb+UAgaGpIa7yYVgKEhrmhLeiosIlA6aIRaT49kp0gxOZU9d5PKrs9gp1n0sdYJ7HGCIYHhSwIZhDMIs3RlI1CtFAoSR8KVuieEcp22xTU5bEko2ZGSShMaSB0z9kIjYmX22h6x7XByPtDSzqNT7WGnm9C9wXuNolH0lF2OJ8rPi8t9dROJ3R87Vv7dUQpJVBqAsYd5yV3oCi+JKcYWRphWJ/wflM1Gn6AKuUqMiLKMMgUkNXcb5foTmhEgIgKsLm6eyhO5ESjr+jTdiUhGQKrK5nzWbFMl2mGDPiHVkLAGCA5Ezql2mmYCIGnomXQNmy4DcxAXGA2LPt4/PC3kBRd5xuScQf1QyyIlsqzrAtEQllTW5jL41IgESiX3Gk73nhHuiFPJkOHpXmEvHvuXjkBe6zhu7j9/M7XP7VyLJoyh8fAzJThkBdU34iwhZ8zWCz5nnvO2e4H3wXKsLmIegPDVPyVLF9nOqsbE0/tsF4Wq7z/95nrgpw3kkufKKCM+YhvTr8i1/N5y6qLls6IweRO6uWeBtiHyffb/MVzPqLdVIghJllA+B72clJU+VisUikN0u/8jo3SDS/4wiufl7YsXm7qURK8iaCQgyLHYT2QlxHD1nD0Vhj5Ppg50OGUewCW/6bRcoSd7w/Q5LREJZnhltaF7zCE2FxJtaEhLQzCjHFU6nuhX3vza5QXQ86Ci0sS0MyCAqhSpb5QGiWn8ZyXUErIM8AeQHiZwZYxDIifVLrkOb4PSWL6XnW1UOx/Zh7GEzY0csIOLREJZu2BVUtlzI4w3w+r5+CbirjOTgbXXxPoLehlSGYGVYhrjPog5quP6EB0OVVfJFEOLQzCjHKnw1JBywfZoZhDMIiEtw+6Zr87EAtDMIaJhiP/sJ6F7gvcF7gwY6UrvIwhmEMwhmEMyCAqPRdA37nF1uRNWJAq3SIUp5qyBDYGFa2nBZp9xiWDdqalHd5sQC0MwiISyr6a530zHm0QliqfLBLz+6Zr87EAwB397aVvx3sAemYrGRlw+6Zr87DdB08Q24D39imtlDXeTCsBQkNd5MHfuRQd3BoIzX52IBaGYQzCGYSGYxXoXuC9wXuC8+iG6u9ILaXoakhrvJhV+dSimSvi0MwhmEMwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwL/I1mRRDi0MwhmQvwee2YakhrvJhWAoSGu8i+c4aUyGZsS9wXkBWHXeq4Bkq/dQ86fzWzyQtxDUDjNAXx2zGbSyZ65fklOei3AlxQcBbQNYSLp5yzSkZ64qahkSSokRLiK4wMht3dv34cK+YXq5T2R6XLE1pO1aR8khvqbo16dMV6L6gt3vda8OntmklgALUicmsRKR+z3YRm7ZwF/AGPPiVTXSe99QYVHLFDQTXzpbzEhTryNeLsjGlJFeSfT6plh+SV3+QXcfFWU34BMe8VAOTN1UAxS13LoM4nB2LEIHoUnD0w5AH3wlAVal6+5otEpg2Tj9IY9/iJuIAjVF9poGCndHHA4H8Y3yDTK3t3tR2ZNfzEWn8nQ6k31cbB13eM5nPDloZALwjX4DqIh9Jecw78MJWFmKiW1WyrazQv7wjhqE3FQr3BodCIRKglTuRE3gqw3Q/wsXZSta+EcANwj/t5LjEFXE0906kpqBH28f+n6sqHXAqodXXCeJw9clY8lOS7uPillXi+yKqcVkD75UUnN2oDAtwKHa+9cBtNEKZ4I4tXZWfSgxnXirxipJAMdsjtYljR1eEb2IED5Tv4EDrvDR+ZAFHceNhZsBUYopIsQBVqaCoRsymADD3gjEMm+SA/T4V1/UDjfT5NMLN+zsJ6zQI+mr7Ve7RSlMiKzfYZhd/28cHElhF6V7KcF2E7T0GcY5xAwI5JCaAlUjyVLC8nfPJLskUt5HdxFhSNRREGNJq21WFRUzG7tolWL7+ZbWhIF2jNBPboXzsQFc3v/1qXeaGP+Uc7kJK1hCb3/n7CUVRc0LSNaStzyxTYG3BRgSm+YczdkfzQpFN/Ui4+RkL8E9zDZcAIxVRHduxp+HWip2glkuvBe3ehaqlMx6k2tshwD5sAAbTgYrjBfioTTi5QQRCQJVCf6NOXwZg39YoNILtu03Mmg3pQhmQvwL9wXuC/+OLQ5PxbizcPumbZyavn3rXYhMaS+wUu3oWNaMIZizqZr9/goT45VDhgeQ7suNDCB70v0r/bFPoMqaPyB6C9E4o7IW10kYKpLTopMzAVNK2bkl/AbKcoZfjZNXz7gvgzBTPBgDlueGW1jwDRnALQzCGZC2sQ5xO5Yck4zMBQkNd5MKwFCQ13iehZc8wzmK+u8mFXuBIa7yYVgJ8tBe4L3Be4L3Be4L3BeToVjS5/1yrAUJDXeTB8YmkQI7F6GpIa7yYVgKEhrulPmhjFehe4L3Be4L4MwaP/nYgFoZhDMIZkL8C/cF7gvcF7gvcGDbNjmvzsQC0MwhmENFm+7PuC9wXuC9wXuDzDfJFEOLQzCGYQzCIm0wvn3Be4L3Be4L3HCJu6Zr87EAtDMIZhSJzfcF7gvcF7gvcF8GYNH/zsQC0MwhmEMyF+BfuC9wXuC9wXuDBtmxzX52IBaGYQzCGizfyf9cqwFCQ13kwrAUJAZe1qAoXt1gkm+xbDSgpk/Xo0z4Ur10sRzYxVsf19GTXntFW6SAm74basCs9C5v9Fq+fccIlUo+a74aBNgGPg7cGQtIeiJQ4JSpe7MQa4HsW5d4SH2w+hu7UJO/SrlZkzuYulEYISqidpiiLX/YlZxlZ3blj7YaN4ummbMiiIMaS/DRKDxspFpEvC2rbfGdWR5e1/Do3jqDTuPGHkhP0i8X0OTwRDAFkgFZ29mpTE1NOv9rrgBKcMzJbWpDprTR/OxdfkcOC3wfyoyUbMsBFAPD+BQLMptWYJ8lM1f4Ojdct4jj2OWs4NW+0gomrj9Tm4GSCF6RiO1t1t18MV6HmG2Ytva7gWm4q//mcUNnK6/7QgI+41Ks5qgEZuHBh+cWjCc5+mV5SazypOh6xVZcNXgcmQHS/RcUdCGevKrAh3P5Kk5QJ5HNfoBzpJ6cdguuRI08U+Coysu55XUvJmHwmXBgvMieCV6EFMgkMpTXeWbMilKZEISw36hn0LWcH+2mV/z2IBgX3l9a+FP1TaPtM70rmwsEoN4jaYbjBvc3wIXqHCWTnVfzUo8rRKS2qIJHD0xdvy5YjDggBtMkBWEvl2lpvqP/nYhMaYYYctrAWHyHTyKIcWpE50iIm2q9dZjVvqKJnapqTk8N2lqymsvcF7gvcHmG9yoki2eTnuC9wXuDBtmxzX7Cj/90zX52ICub7tIIzX52IBaGYQ0Wb7tIIzX52IBaGYQ0Wb1dQb/uc9JcvC7e7lVtUzPTJRnRjtGKkLseSy/VlBVcZA+hzGK9C9weYba3otrRl2v0REujY9chrYRDnJrifqDzUPnIHLrQ3c1dtziK7gveGThe4L3BfBiWQA6FqzI3u3UzWzAFoZhDKjkAsBhPq3txhs+wVVgKEhrvJhWAoRj+ph2+C9wXuC9wXuC9wXuC9waCM1+diAWhmEMwfZy6isaXP+uVYChIa7xgl78qDN3/xWNLn/XKsBQkNd5BXcZm/Jq+fcF7gvcGDbNjnnsQC0MwhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5vu3UyKIcWhmEMwpE5T3NmGpIa7yYVgKEhrvIvzS76NL0NSQ13kwrAUJDQTrHDTb7RagW3CtLoQj0qlRQTSWUCVZRenEE2XoLPz4qnyNT0Rux4FYWNRpG/sjShszhDCJCiRoWaJsukFS9cvgFRw4x1No229/fqAeMMWG15dXswhos3rHpRerEDbNs4RyZxwWynVfIX88tCXa5NKJWh2tG2o8nEG2qDyZFdSA8E6X4Ce+V3hF6F8GYKaPBiZBDW6M+8qQ/hJhwx8rTDwo24Q9qubBOHRwHIJFBoFS0kMEic8rzbkdbVdLEE1FOP8qyupaxDEYLzgLtXyM5xJePJcrQ1feP/wvvX9EUj0zEQKGhHkmF1wQ7V/XGSZLt5X3B5htofGyyxycHfWXc0iSLO7NZFqZtzHuucFuS0NFm9bOtd9jC2QHWouXPf1jRxnHZk+z7aafkKNMicP3krBXsFZPRln/Mf37QQ+qIKQ0VQwTnu21u8XbJqRGdtjVIyRf8paGxvop52a7d59wXwZg0gI0Noi/WNLng+6Zr9/gn/G9ubjTYHzZkbLi9rG/jKCyZhKZVkWI5MP5XB+bECS72NYT0gSyocSk03nYgGBfemSYneS0e8HLGedjRBo5wLgZXrF1qWc7IbpeM78k3esB/H8Ng77l7g8w3z8MWjhSIrUs+5UysyKJW/Noz7BMlOXT2P45f5eWP2VBOCOqhqgfYZe4L3Be4PMOBcdeipoiJN+diAWhmQvwL9wX/xxaGYQzCGizfdn3Be4L3Be4L3B5hvkiRuH2X8+8+4L3Be4MG2Z8qyhLsL3PGwonowOwGQofJsDZks2j0eaGzulwtD7AuDFdPhxv3RZpBI7gqkNMn0xaeEMwhmFInJo6qhuJSDQRzVsfGYxXoXuDBs+QiI2J0RXAi9DToNd5MKwFCQ1eS+kj9XwEmFYChIP7yYVgKEhqAj/52IBaGYQzCGYQzB9nLlWAoSGu8mFYChIa35NH6a7yYVgKEhrvJhWAoR8cC4Yz7gvcF7gvcF7g8w3yRRDi0MwhmEMwiJtML59wXuC9wXuC9xwibuma/OxALQzCGYUic33Be4L3Be4L3BfBmDR/87EAtDMIZhDMhfgX7gvcF7gvcF7gwbZsc1+diAWhmEMwhos33Z9wXuC9wXuC9weYb5IohxaGYQzCGYRE2mF8+4L3Be4L3Be44RN3TNfnYgFoZhDMKROfraXoakhrvJhWAoSGswYXfxPXDTSkqKUSgDbYaa7TnfOruzGel7DqwLJ7g8w2yZG/srGaK/pfkY1FL2+tJaFOkfye3VuB1p6XsyNlfuoI4+c7tBdLQWKwLZHtqBXW+rz1BhR+ghL/po853j8tJ/iG0DWvvbXpBtUKn5/mGFlzgbz0RgpmxnR4JUIR6/vnLN+z7H2irGZ0Dg1Px74MyTscV7XCh4oAS9bXUbILd6Cw1Xhm5ZSekKegbG6RryhC4Z3myXbUnkuzVnxt7x7gSH+fMLJvI107ehNTX/f4KFZ75sY/e1khdMGIEtexeAt6Xn7CKqdoUtHVW5lWvsStkKACP1Cb9HtvjzD7nA631ugBDAeLXGGjjETwSvl/ZFRD13MX9WKCvqOdIZ98hmqsY+4PMNsZtPeYBaN2psBreNb3geKjUIcy8AaZ67dCrncYO+Ohahx5oMe8JZe5NHYwb8dCwy+S8TFp5FU3K5LySYT0gXOutJjPPmNiWYJal4UpTIiNQkeXUSdX0yFSgm5336fF0S8rFYDysL9Eu8fip+n9nrhmyJrf+nOFvml4rYHU90jMyTWgH3LETFXNs9pVSoIPP7rP8y5lad9aRwyIuG9PIgxpQp8hK4yOZcP4B8/6Ac6T7jKKU/sTlw596jdh21fPgwKPojvCb8621CnZNQ/wBmHRoBUOw9h/n52LCfhCBUy9MAKQXrTtJlKp66gIgIZhETaTGA0lGjihcWdTNfnYgGBffSM+rZJBxo3xwqKzxgfdLpwyPZG344CRnB/cvb+P4/IF/RqWaah2ZSmDfIwbH8MK5CPdCCYmiIXfHE6bGb8GBaRJc5erb0CVnc+Sq6yxPJCsteTU2LcWZRSKU5qg3bJkz8a6/pvK4t1dvI+Iqor9aL8njs2q2autMN0fCXMFUJhIpldtsvvY4Vs8sDyS5dxYW/NDGK9DbgYczCGYRE2mF+7L3Be7dTIohxgX3nfp0fdsStXobcBxaGYRE2k1IOVQ+VXyQ29SmBFHBjnzlf7Yp9BlTR+QPQXonMGS7+i7eDaCohut3hON/QDOxyqy0CRkSubPuC9wYNsz9kOEXvMITWsBNXz7gvcF8GSEYZ9ntHzWUNrEJ4akhrvJhV+MX6CoiEnzgYX65VgKEhrvJhWAnvvn3bqZFEOLQzCGYQypJAIGhqSGu8mFYChIawd0P5/MyrcgtpehqSGu8mFX/oX2KpkOLQzCGYQzCIm0wv3Ze4L3Be4L3Bg2zY557EAtDMIZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROfrbjuevzG628Kxpc/6s8u9RAiosIms+KXHZQoie5o4Ikvn9oFWLolMqe0mX8yijgjzhRiIGSZkqnmS8Hlxj/KqgMw4oQptM0l/sugYdnblD0YMKHzadsNUJO0eQDbt1X+OyyY6iwSB93bQki8G5dCUmCHeQbclgYmy4cSk/2D+vuQajKKyxTSUHk1+IQSdkHYZNnFyImKaAMwWSwGuo7RATSMhVBuNTsKkJvdYY5rCkTkvy2xkMd/zY45Gqp7uX6V8a4LqeAwiyRuWosk7t97dZr1+3KDFsgJLTESwU93OBlh35tUi810XuFy5Cjb3Jfn37QZI5Z/g5kvQmi0le4rAM/zWBtmfXFck3gSnxOOIseh8UZprUsMsHsfI5AL6eEQK9mEVMcFSMgVbZUTbKWW6H4OApFJ6KUxkRntpLhqDCdw1mgGdP15aqeS+Hmgq+gN+7c3gXC9ehfehBmmRMpM0T1N/rKVwshbZKeI+nuBwUIHDSQdPuk2rGyOowqGjp/BjMelNxC3a31Ng7wkWprubPDYS+xhVwl9mYsOKILbwayURSmzbnBhatMOfP9SszXLKCsT6O14veVdtKtJBZytmU7OIPCUyAA43FkFXjpVoi8DP1wOYGixWBxwkbDK9R8OSURk0vDn1GDovh15SUgZJ9eQ9N0mvvD+ECSFxkTBvBklZr87mKkiQR02tCYqEwcqGoukRjZx9ztU1dCU4BA5xEp0C7ZSREm2IEtsjf24BYwClDZS5qLlGLkZsA3IcOBVArTkJAxnMvppFDwp91xaIm0wF8IKIjptaUh90zYWRMHWzhh2daRnhCZJlsqEVACJtz0WPzNZL73cFkMpeIuzIcWhmENFm+9im2fu9nY5WQ4tDMIZkL8C/etdiAWhmEMwhos33aQRmwHji0MwhmFInN926mRYIiAWhmENFm9XUG/7nPSXLwu3u5VbVMz0yUZ0Y7Rf9n8d6nGWgquNDYAkIgFoZhETaTVmKDntggzSi7/UVky2hwthztBqgO650Zj4aLVWtD0PZf7C97A2h0RRDi0MwpB9qF86b4nAsf/yHodfPuC9v9Oz+QpbxUP6u4jDDjS5/1yrAUJDXeJw6YdvgvcF7gvcF7gvcF7gvcGgjNfnYgFoZhDMH2cuorGlz/rlWAoSGu8YJe/Kgzd/8VjS5/1yrAUJDXeQV3GZvyavn3Be4L3Bg2zY557EAtDMIZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROU9zZhqSGu8mFYChIa7yL80u+jS9DUkNd5MKwFCQ0E6xw1JUwxQqNRhjjCFzBKbtKQQCStyZ2smbu7Fk4xxabR+RFhIvlUFn/Bo6O4QHzwLHLFGVSyoMzw9+9xYI2CXnFpgi8DGolWz2QVlEBdC9weYba5LvFw87xuK9XZ6qACdeG7elDh0BOJYtfioZls7nNWXH0dMOZg42NLde+Z46dHHFS9mENFm9XUHugtk139uoh0DbNdMG9I3jX/5RjupOfardulI9AdyveI8dd79LNUm+kDzY7NRz1yfot5yvndWHBJe3lMdig6t9C8hzX52Lr8luJNiFNiQQqeXN8BW6TjDFRzt/YsLXfC3ST1J+se2e70JY/PpEri0NFm9XMvJqrc0GLb801SWnocXsB5Xdfb/0aUmAaAnSg5WprhQzmXa+iVZgAt+xPBSfEIOrc9Gn60T14uZYuGrZ+m+ME/6aLnphV0hUyO8WlKGJ3yAtpU18k8IZkL7zoLaFSz7axf0zGMIwDrxgLn9KZFIM25W7l0Rl3j/7CRxA/3p7TPL5/4QFiWhos3reGZSWwp6Lo3SGpsYGwIjsACCOLMCCS3FDeeLmgIjEwc0jLVr9v+c40QCbLrSuOZ0opf24kmwZWzZNfKBnauc+T4Wj2bwoWCwnnDpxY4Vn4L4lJpiSn2lRLRE2kv0dZUjBDlQS7tfxIWyCjmdcwXn7SeLmk8YpsFLXcYnRJA0Lf4Gut/h4pFobibpa/6LQtg6VDSbxJTdzHLogYm8lrsCeZr5O0I/FNF2qKub1UKXAYUSL+gXRl7MZe42Aby4QCAadALqwBgaXBRST/wBLbMzedocXUx5otnku0kg33VTFSW56WoDA4l1wnaWcGIi2539GpIhihlYgpIgDmaQvunLV9DhhLUicmydad+R+HcMt+eQvsR5ZbjbH8iKmx15y6WRC+/o9s+fZgeoRuNH0oh1rflBfSrEU8VFeVXE7XSiJNgmy0TrsaoRf5sWhmQvvQSb7ROoUOEUygHFoZhDMhffSM+rZJBxo3xuFRaxmkQF8g3vsF7thAqhkKcdl7gvcF7jhEwYGFkNxkglEo3Zu+lAszbA44c0EBEQC0Mwhos33ryJmlFgiIBaGYQ0Wb7s+4L3bqZFEOLQ0Wb7tIij9lrsQC0Mwhos3qtQv/fsh4ukKLsDedzc8Ln81zLihFF8OIu5kUQ4tDRZvWHYtHCi1e7HVvQ1BPIA/pZWIFcQV6z/VPY8WtsR6l1Qt/NLZVDKiBoLoANO3UXoXuC9xwhSVhtywt4RbIvQvcF7f6bc6SNli6xbXeXIFCQ13kwrAUJDV3l9ZGHxXsQC0MwhmEMwhmFrxXo2y9wXuC9wXuC9wXzYKqwFCQ13kwrAUJCyDJ87roqh0+VYChIa7yYVgKEfHCICwREAtDMIZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKROb7t1MiiHFoZhDMKRObcmgevzG628Kxpc/643cgy08oa7yYVgKEhrvJhRb5zhcsDQf9v+OUpni6PCjxzFwG8Zi9a9mnRJmhk0crKFmZQ25UQe2TF+yh2fe4zYxRNJNcbAjKNRpX3sGnzBDuJB31e1wOeDV6eEKbCCleohN/3TSebRIu4OJdWuZ8GIhR6/MrZ4pgHGwd0Ts5SPwB2uO4nAWS+p+CHGsaNZt+XoG0wj45CZAHs4Qa43ztThjSDtyc5m2bAImFaCvQwbZn7rf3pesmH7PP3GTGFmTLGzyHt/FusWTpkFx/5nwW+6jTXYHF+knWTOs5jTneDiUCk5a4WD+iiyU00tmAiVqO1wz1leX/9CisMBmDXk+XpmGcbhez8rWXzl4dgT19mQvvP2LZsIX1TlCVGaThbghobQJNmw4ELVSD9xwzTYqbQppRJhk0TGYAvJEnxjkdn+EqblKKcnZOYIjmMiMwCkSGGri5LGlHCPxlvdSkbQzmLsDSa7euqErF5ErTo4meq7SF7rjv+K1JONR9bMDtSgJ4Ss7shG1EZeX3W0awY0VPjU2NjpcISSofD0u/wDk/mT/UBWzErstHLb/WKoB71ZhA+RE4e6/tWjr2qwqxDswb0nA4LeZa0LpcuSCzOHIh3ef/C/s6bPT/Ej2ioMVxDZrmCiEyMc7XtKAO8Gyz57VDaqhCEL81yC3iymu330v61GU+mlQq73FLXNC09G6RbXs2CwApw6NidB0bDVrq6VmcgRVyqRDupETvHHRYORxb6QlSLXbdwgB52SovtH+WE2oYJVtyEqAmdgoib4J9JY2EUGnAdM1+/wT/je0i5QA0C4PSmLEEBFXPYC7mbImCrx5E7epIVIiR13FSI3DA+Gs7uC+DMFOACvjyUtpzW/7QSIXVkmxaJXLCuGouMBzrGpf6uRAsNMCzMYr04RN8tILpX+QXfs6AUXaGYRE2mRURRn5njWc3KZe3RIzkB6ik3LowMvJYm/3Be4L3Bg2zbw5ANUGj1WZFEOLQzIX4F+4L3DbL3Be4L3HCJu6Zr9hPQvcF7gvgzBo/7jjGEecw+6Zr87EAwL70LVwQze+ET+8lx6aEosCGqhTSwsyAv8ZFiAHAJ35nVYmZUhLPkCw0xQGGICKBfzKuKiWhmEMyF96T+hltaJjC2GMtbehe4L3BfBiWANMLshS4lLXLAkNdZMKwFCQ13kwdsUvcy6e5saXP+s5YChIa7yYU5LQzCGYQzCGYQzCGYQtwcd5MKwFCQ13kwrAUG3is5jJDXeTCsBQkNd5MKv/QsfiiAWhmEMwhmEMwpE5vuC9wXuC9wXuC+DMGj/52IBaGYQzCGZC/Av3Be4L3Be4L3Bg2zY5r87EAtDMIZhDRZvuz7gvcF7gvcF7g8w3yRRDi0MwhmEMwiJtML59wXuC9wXuC9xwibuma/OxALQzCGYUic33Be4L3Be4L3BfBmDR/87EAtDMIZhDMhfgX7gvcF7gvcF7gwbZozFMKwFCQ13kwrAUJDQVatPksScdZISPHM408Zl1mzUsVp4cCxCXaQnIVkY5nLhGGdXZKelW33Be44RKmiUBh9TG47AYJpiq+XNgyA9mJPodsfaq2P9brAxBVt0a4mURdxT2DiY66FZf6Pgxl53xcHEb0lRj7CGsBhUw1x8NwxB2LdK4tDRZvVORAJ+GhTzJSKo1NBfDpbyVLBjUTdJSY5p1shqVKwHPpmOUMZe6NpK80aY3WlbxpmHYfAV6hcEmKrznDoyqD5gNoJtET+PjQ2DuyDf/VyyNzo/uHWE/+rDxWbkrX8gaDY7rV6DebH9hvtOO3sk6s6eukOJ4GBAdccE5+n96MtlrtGAVkf514s35rs+NrfsJeq4X196BtmfGFJi9x8Egn2sK/3CC0SeDhA2xqF8apHyFPPPLf1AkgtREXd4a5fa0PAMlLX8vmOBncTMZgEolGcVlK4NTp8V3Mtb+Gwvb7Pkb2S/NJF7X/Hz3lHXJSmRT3MgJpVkM1/hsIRXWo3//0yym8irW7Ybd/235AWLZ3jmM15eXrExKR+sMMYsTTZ/Ykbf4DMf8FsjjrlF8cHXDXTtmNLO+/lddQ5qyO8IS36CuogZMzwK3KCRQqK2F1iykYep9B97N6zZ2h3hVjv+j7CMmJ1HdnPy5T1XDiB/NxW+NyOAWb3vbQVNTO9GoVRUEsKVzibIOgIXnkv4eQfFkbE/e2xG9llGfIcUOTe1uKuY+EBNSxKJiKxRvZDZos3rJPSKYn8koGU6ZAOZ2IZLa0X246HBLiJQsu6C8pECEdLgnBUxLClXgbg+EH9ETDXGTCkTksZhI3D+TK8PUsdo+FTzRLQzIX3pYkQVtgilwX2LWGvNvPhUV46PpTTebMH54CSHV/SOecIX724zp7nQaQFJojDHm1o9K8UUh2EiNEVpXZNX0DbNkhmabdAo77cyKIcWpE5w/OEJJEsIcFEx5EF+swa/NIGszUCrRvfpJ+X3uWlXz7gvccImPQo51aP+5kUQ4tDMIibTC+fcF7gvcF7gvccIm7pmv2E9C9wXuC+DMGkb2ZKGYQzCGYQzIX3n0UfwqwKJw7tW/8o239h8TDkOgELP1aWa0j+IDk3gejKJ9wbuGYoohxaGYUicmtYyOHP+4jBCyjTxM9vTYgFoZhDMhVu7218nHVE+wS5VesIZhDMIZg+ucmW+vbr2zJdn5jdbeFY0uf9cqwETqupb3z+RrMiiHFoZhDMIZhDk/Fehe4L3Be4L3AW+T/MJDXeTCsBQkNd5MHxzGQJWZFEOLQzCGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mGW90zX52IBaGYRE2mo6fKsBQkNd5MKwFCQ1zQnXpivQvcF7gvcF8GXtagK2rpfB7/J1HICgC/vgPWeBICr9qVI20yqY+D1xgLcsEu6PntVfUWEcQ56qFFBLb3nom0+ojzAsoLTTg1GhFiSxs8tW84cjtpDT/0MdaZWCCZr9/goUlwNF8ebHhi5eucBgOd/Bl2RyEDKdn3BM+RwBFG1DuPqjPYKNymy3nZQmFBaCZr9/goIBMwGccl4/hL+QkPQ1T35VvDCbEuJUIRzSvEupjoNporki/Cj7AMiKl0Hyu5028pWZXsbJyKhW2VxwYQGUP4PkQshgPsVAPfP8i+mTr+ehCK2a20uH2NhyBpVHGugEDhCQr3S9CkOAqmCEgaQrOWiJtJevTCQ1YiooB0AaLJjMwXN1vNWk0mm+Ui9+l/cXvyRoGdTEkIUeL/kNeLUeM1jr3WhTA6kyu752ITGkzEWgDXuzCrLOgb9EouFvw4/nPHj6BRwFF0w9S7m/+caW3B2UMRA0A3aPbcPBV2YkM1ClraBwyB4mdo7iwv4I+veb/0hYgYNVvskALYkjLvlCyEzDz/m29mERNpMIV3aRTy4wIvhRJzVS/OD7uQCCUNoVts0fD0QXnjZ8bNjuvaOOeGV0rj9vEGBwVu/dM1+/wUGtgnbC51NTcbkJH00VEtJTjmnQCSTX/Ql8uJ0SA71yQHlT332gJnLgHwaruheYq5WLfpDpN7gvccIm12GyPpr7plZkUQ5XN6un+hkJhtK26QL+uiD5OFy7BfLHI6rKCd/MZ2DEpDmV7vggDyWvhscGiBJEgNAAOolUE3Gj52ICub1cho/9j93NWZXsi2tyWhmFInNp2mkPTS8f4lZSmZToANrocWhmEMwpE50rjjGgMRJTZcdo2bGYcIngM1RLQzCGZC/A1X68QUFDMIZhDMIibTC+fdupkUQ4tDMIibTDLe7BWQ4tDMIZhETaTBqBvsmXxqKws4aUldTyZT0GSsHf52IBaGizes5CQ5VN1HItNY3CXLQsiYCQqxf66nrFYtlSQnY4+X+3BG1z4C20b+DgCGK9C9wYNscCaQ9Mx55fdFm1RLQzCGYBxll8jSHLNdth3ll6OizaXP+uVYChIVkVa5NZ6Jr6CsaXP+uVYChIa7yB/OzJQzCGYQzCGYQzCGwML9cqwFCQ13kwrAUDHmTtDuJTmYQzCGYQzCGVwxKYWGNz/52IBaGYQzCIhLcVWa/OxALQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYUic38jWZFEOLQzCGYZELKYHU3VbYPKhu5O7LiJBD1io6SPLypPQrx/mdFkdrnG1eLocqu1L2zS+kXiIHRByiiGLAMVfEd6vMjNQK02USEY+bUDxuj/n40MaKZjA9ZHQ+KQNtdRX1AgXWLr2YjyjlebudKYO5TvwoWpHM4cIpS9ZqIrPoXwgz5LAmPTsj800eI9WZ5YNfmEybxCNUlN/G+iaFA0kaFLP8o1tDE5Klxku7j4GH3DOaNL43LFi/nWMdSABuC2rltRsjGv0jz+I/sFAh2Pkmy+H943ciRgOxDZKeWOPl401hNqb+8Nt7fYvMUXAQl+sofFVe7hS+2QwMGWR6KP/W6CrI8mT3r7eqgMYL2C2X2ZUMC+9GIjh8Rj0ckF9kiHSsaNXWecj9SYYXuLGJGRTyYoBVqt/KMyfNAqbFEK0M4L2mHJFt6ZgEo6Ez7kqMZsGe6wHKcbcJb8i8kNA/AqUch/3+zP4ukSPPZ/Jc6tMHENhNCLZwT4bOi3iprBDuFfvtS6YkqA4andc1U6wF5vDVvDBetxkxu7Y00UQcX9jWVxZ9HcJt0wCRv/TcWwzMHwVWDimY2cnZQgC8Qy2tBNdB8r5McMtrQTYXGEQDAvvOuaak1+XYi5BIVMvqwX168C0MyF96HaN5qx8txDhfvs1DkQb8pggZlmghj2aEvM6dGc0EtPOlGSwciAlkjkH3Y0NgFgG4xYmqIZhSJynLC8HLV9iOvmV36zIpSmVeUDjbQ7eXx4YeBOY7VDln6LNPlKCXbmhniIBaGYQzIX38ros+uVWzvJq+fcF7jhE328mFXKpq+fcF7gwbZsc1+diAWhmEMwhos33eA2n0+4L3Be4L3HCJUeuoxjv6120l/NoqEtqOtCmlhZ3kxqeI9P4oSLkxOpimCf+il0wHBiARenonGlWj52IBaGZC+89F7aCclyqq0Jlb/3ZAJe4L3Be4PK6z4sRQP1PclDC76ZuLQzCGYPrRFka5TCiFgmeRQwv1yrAUJDXeTCr8gXtvPu5luLQzCGYQzCGYQzES1fPuC9wXuC9wXucCBoakhrvJhWAoSGu10IvRtl7gvcF7gvcF7jgXDHdl7gvcF7gvcF8GYNI3sQC0MwhmEMwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtNR0+VYChIa7yYVgKEhrmhJ78mr59wXuC9wXwZgpsrgEiO1bJ70iob72yH6EGukjJbjogy3RVzfQRLfKa7cJf7XRm+PebMFAaJZF5lBkyEiymRTggIDpq3N+cRGBKGgphP+LduB5P2WWH+IBaGizezoJsOQTXz+X74GpW3/ROJLmv9KsJ3aZrdS8r7PXu/bN6syKJW/Iu3jXmQ2O88/5aaytpT2kjiA5Dcz4lVw/vZV86CdSubGn7Hn2FiPZOC+jBWdwSkjUpzAPfuGLfqsLw4HlYzt+x0IyjcAR2Or8Od3xDyDw4UdYdYgn7ehUqUPRXB99XCgnhzBd0hMDYgK5vVKF5JCxwDMCYW75PEHSpXZo33rdNT15Z69yzskswUUMaSrJ9niKI6w8c3/voPXeEY2IbDFhmv3+CgaCNXUwLxVmsoMdkMe/BKa3UW8QXLGbC5wCxpWCDm5P9l+owlsXseCeMKvNLEsQCbrba7kHfxl+90EBrFF2+yCkUO76iDhh506berUBhoYU0GaihVNeuwV8Whos3qnKxM2PrXsV4sk98TWjHoMZ6eaeuFA/jQtKsmM0G/LjRgCmMnfzKrAjhSTxdguLWTduX5i72m1XRoYO0MyF96HD00DmWZAEXRRbwDGOOzYMGWf5q0DgiqpEpWcq/QCWiGgo0ZIySIeVKAyYPHk0ia0AkpnePBaMIZhSJymGWQ+JX6HEj6avn3HCJWDxlFKZMGKvFP5KEhBlls25i/kRU2OvOXSyIX39Htnz7MEpkSJRIsBw7X0wNqkTyd4MxqFRAzydQxO2xCVrL4qeRS0Q4tSJyXp/OtW6lstDMIZhDMIibTADzwwlg3NSJoGGWeoT0ELu5VXvLYFeEtS6wDkfZkxhFpXX6E8pXOOGeF/9EaAk1+Ydin0DPNsr3N1f6CqKXhIBS/RBjTIpsnzOGn/KFOxQzrkhdc0s+xp0x97gs8sL6GSUgeEZEeTDEmYiVlhtJDl4kJPYuvzSS5/+SXqM8KOxLjy1x2Yj/52Z5RKzIoh3kZC/AxBHJFEY46ma/UuMC+8+Bj1Lsm+ZKNJwmLjf7lOlokrqCgSQCpBUzX576hg2zPqWf7Q58BSKkBIS/V51X9LKxArkOWTXzHmPhinsnbSYkbyoSZBWaxSX2fvqiWRRDi0NFmtaObctjnLW1rsQC0MwfX8zQRSM05QqKs6y5/1yrAUJDXeTB18xt5KH4/vJhWAoSGu8mFYChIOUzZ+hxaGYQzCGYQzCGaIj65VgKEhrvJhWAoFan9kugCRWXoakhrvJhWAoSGuAecyJavn3Be4L3Be44RN4TfnYgFoZhDMIaLN93dl7gvcF7gvcF8GYNI3sQC0MwhmEMwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJtMMt7pmvzsQC0MwiJsuXNGLT2Dp7YJ19bzxR7GGGNT8aKNJldlONuDNXrUCOXuP8nYctoXLBVddxh7lr1t41J6Bq6rv2Gpq5liuR4bcoJ4LrU6urzMk4TeWrH6KtXQcBo5EyQapYg2R2A/FlpAD/cOaFv/MDTBtT3aIGxDAn6xggEEMFAL8BYCDpZc1ugTgvSR0/4gETv19hxpZERVS68NP/5sQMS3gppMnjJQiExpMgsAUKMemftBDLmHwtdkQpLdaOXwx/CoxqwnBaJzqFkVFYC0eCMcKEFhlf4romk+rUY2dMgBmy8ZSsiYe10Tp5a5vbmhz2hiWSMwApOHAonDgBShUK7eLkOMC+9MW+G42CMn+uoBtoXS4nIJV001zGw7t+vcpBriuJpxBuI7RLAg5V9lHwwiIyj3DK2/sKeCArm9X6wIhQA7149C7222IxxpVWuZoREQxXy9hrP+VCV3OOtALsxYQZGPxqLMa4QqQM5pFIME1XXMJ4GBX9J71Yl4BoDSHzzX8urMYOF4O8St9Nm39hEk47ohZbS7iMdt26dwgfQlGfLPgZEEMtw1OdiKhGeQwOZEQY0z6o2BD2qiplgbJpv69NeK9OESoMRHrq2BtC+VBFSc4xOS/CBMsvduAFVTlIQcAO0IgFqROTYT3cjQLQ/22wtO7g+JljT/jboC7t27Cr7O6wI8sdjDPapJ9etMiE8sSa4t4Px3FnwuGdqcFEX+t7pm7uPtTuwO4hEfuu5U0fB3kYQ0Wb8ibgP0Noc2LmI/tq6mFOhAiRc6wFn7Wg2NvaPgNnRgBfmhei0kwX4xg8N+diArm+7bmB/C3mm1xL0L3B5hvkij2+OALTrsyUMwiJtML59wXuDbgOLQzCkTm+4L3Be4L3Be4L4MwU0dO54YQHy3+JtpTHd8c+WeFkeTAxAWkI0+VFa9nuX0smoDeVFJj33RqmZhLn00Fg24Di0MyF956Hv8km1oH/eVfW9c4UdzJoRRDi0MwpB9prH81M5Lli0MwhmEMwhmELbRICij03UGfU9fmN1t4VjS5/1yqfA3Ijb8mr59wXuC9wXuC9w2y9wXuC9wXuC9wXudWXoakhrvJhWAoSGtLxdgBGNHeKZDi0MwhmEMwhr0Ky3kYQzCGYQzCGYUY5LShxaGYQzCGYQzIIDeE352IBaGYQzCGiYYkb2IBaGYQzCGYREJbiqzX52IBaGYQzCjHJaUOLQzCGYQzCGZBAbwm/OxALQzCGYQ0TDEjexALQzCGYQzCIhLcVWa/OxALQzCGYUY5LShxaGYQzCGYQzIIDeE352IBaGYQzCGiYZJmKxpc/65VgKEhrvJhRb1QAdaP+ApgMSu9Aw5kSKasc2BcdMvTAP0lOAzfRBCCdA1Yi4VIgM33hxciO+T8Mz97qke3YoJOPsONSEqlEgI7ghClA0WSHoNnStk00PCJ+QKfmPLWJFqS9HN+9h7G0mmX22XeRnl8Jw2UhjmPlUZr57xK2Oq7IxLoiCEVTzJukyoJaia58ti6dwW9Xda1w4ttYSHyMJKBzjp1bgvBLt+jyG5XtrDnMqZmdVk9ox4v+o1EAXxG44/8qH1y/INNKJhXPhSlU/nUvSN92I8stCLBEkqSGYy/x1ShvUvF4sPGfGkCNnROeAle7X4WTsrZTXAjxC7vnznSJS7PlfiPSQMwXKKirHzBgdJSxaGZBAVLo4iIA6dnAvhXkJ27UewLjVfNid+Ps3j24X7bp9kW6yIv282zMoerrxXoYMdGTHzZoDm1v+Sjc0HYVz0iEg7d7psSpET6/lhBfVQyTjr9SRKskmOvyaqCf5m2B1LqixtgCEYESyBv9Szi1J+WMxbtUm4hDMIaJhiQCcGsJaGYQzCGZBAVQieWDh5jDfz8ZrHvELJq7+kDAjDKMpP43DlB5H8yO3+kiPzm9N68MwVN1e14Ld/9ABXuxeYbrZOvW9CfDrEfPbn32kJXFoZkEBbVmLQpxa+ZuBLqLIZIFxX6d/JBYCIBaGYUY5PfoiEj4yRtbHLa2xS9NlXF1wY6FqyYBRRDi0Mwoxyprs5dyuzNfnYgFoaJhiP/nYgFoZhDMIZkEBvCcB44tDMIZhDMKMcVQUuzEo4kUy7ZaGYQzCIhLKuB/trp1XpGiPswrDimDRNobj+BQzIHO+BoTKASHIn71S/vLwiL0NQyy5L2YQzCGZBAVbQr01kUzMfMXXWa/OxALREEaEfLvAqB01p/IJEXG6khrvJhV+NIarwWoGO9fPcF7gvcF7gvcF7g0EZr87EAtDMIZhC2hU+VYChIa7yYVgKEhZs7yn8/mbZ+QW0vQ1JDXeTCsBNCst5GEMwhmEMwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInN/I1mRRDi0MwhmFInP19BWNLn/XKsBQkNd5F+XeogRUWETNMlsjADYha4uLi9aJdPhZ0yxZvfaTF/Gna15jrsM2bc4SEWXUr16KdMcnNFQvew6oKdiAYF96LlgGq8RQr/881Q3E9Z4CsJU9v5+OMM7dk7flnyBh6pGyFb7HBaQUFWkgtOQs71Ibxn1srkeIQhXJ/y1l2HlVyQtkl7deRzIolb8iqRRZN6t4lDboOWDtubM9jVU8DevXdWdTtQFM3IaLxu0UjQElPu/LcqXezCGYQ0Wb1ksO3WspVml/heOGJ1CSB+bscy5O9o4WuIZ0an78JbnQxD4I4lPPB9k6QTMYr0L3HCJVwNPR/7g+YRbnARYKlJoP4ds9SiuTKd+LKIjlT/AvGu3W0e0G4L7rg35YdZfC8jIwPlN++uoN1hEq6k5khxeB81D8qZDD7szV/Yqb9MI7OxALUicmt4Wo7LY1oUhrJHXaWcr7/KAgKPbYwz5iR9uSiWtSCVOHAgJpeE4XQf/Oxdfkc7htkBX1da8RqLTyhsx4RFsG1wYlvIQhbDTVKA0ufg2hiBCcu6C7eF/W7oHsa6SMUTco2xPqxmNXAdmyKoeCAGo0zSZ6q6I7hRX/0J3C7x32GgAUQ4tETaZ6306qFOxyPBdu5hgI/+diAYF951fDpvuKtbIJCpmAAuEenzuZIuxYAbJ4k78EAtDRZvWz/pyzo96tuqcowFtIiaFUJBwXIQqgqMKh7RkY/GADlwOILbyM1oCmyTnsXBFs5SxaGizfew5bW4giTrVXzsQFc35FHyeIeILFh3l4KAWO/1uMYr0L3B5hvn4EJwTnb3TNfnYgGBfgX7gvcF7gvcF7gwbZsc1+ebwhmEMwhmFInN9wX/xxaGYQzCGZC+9KORhnMSaGj2ej1I+yqh5X0cOI1+WFHFfKpMNbqFXaTiFfdjwNEGnra2uXVv3BbZIQ6MTMIZhDMhfeeBjE2FxJtZOYP+WYQzCGYUh17+5icpljia14U7lhM/WbUjHUpPutaOYohx4YAxSCvcqJLLtA8gmvOmFJWM+QoSGu8mFYChIa7yP6jgdV+diAWhmEMwhmEMwhmEMwhmEMwhmEMwhmENgSGu8mFYChIa7yYVf0XY1g+j0oSGu8mFYChIa7yYVdY0EzX52IBaGYQzCIm0wvn3Be4L3Be4L3HCJu6Zr87EAtDMIZhSJzfcF7gvcF7gvcF8GYNH/zsQC0MwhmEMyF+BfuC9wXuC9wXuDBtmxzX52IBaGYQzCGizfdn3Be4L3Be4L3B5hvkiiHFoZhDMIZhETaYXz7gvcF7gvcF7jhE3dM1+diAWhmEMwpE5T3LlWAoSGu8mFYChIa5oQEOu9fnHTqLZ6X+AhAl4TFEOLQ0Wb1vblocWoZoh8WXOAXZ+MeSk0/JodmBrYdLSHbCdFoAr11wVaUgLsxuZUqWWdoNQqgP4u1iKrCilCvY0y69xGKVCrqJVk3svRCXf6y1SLjJw32Nc5Of5nzD1lvCePRWdSh8FiNhM7MQzIX3nX0wYc1Cov5mq7iR1MiE49ZV31+9VO2Miu0mM8i/pdKBzRkmT1mIf6iWpE5Nd2LtlZTTrWlB5s0a6+PQB0cIL7TQxOfywUrtvFGl2qYlcBi/DFA5qeglkQalDAAcIJS7gT8ECJEmAJ5nb+j+NNhgOA9Y7uPzwvlhD4VEq7F4+ZjnMoYX7g8w21omyKeSuaEZngepRvHrXrHYeFJIaHn1ul6nbJrA/IifcOG8iIujWTC2F0WcRBQMKV0SdFlN5uiUiWSIt133fcvccIlU7VcH6CJI4Xt1nh6bNn2TEIUAU5EaEbCU5mpYZ9QUZkaE8I1axOwjPi2uKHozCCaHOKL1k+xRrHSQH4w7pUorIvdcWpE5LZb91Xm26YLOj08hCgvkcP+mCO6i6gzgdmLTd8Ed7RBzZ+SNDwTRdyOKTYzvqoRLJWC4Ir9KEr9X/k1evaREze6/Q4uboJeh5htrkjET9+lN3IDbY+g7crgx91fq1Wr/rVFz1Id7+nhFE/z+8JId5J+vVl9tfEy3/ERRYdf7wiY3yf4WeboDYMG2Z6BH+1+Y3U8F1/KZr87F1+RgrOQpBjZx9zqa0KFSj62JmdvuaCW1rIkqSYeyLAk/fNhdg6xslR49j7CwbntHQCAOf/mROCzl7IAohyub7UlUzCGZgkNkUyKJW/NotnDDs60ip9XBQprUkbcQERx7I/85WW4LIY6XlU/Fehe4MG2bI6FvNDWxjuSKIcWhmFInN9wXuC/I1mRRDi1InN9279zCGYQzCGYRE2mF9IIzX52IBaGYRE2kvwz6x2dY0wBCac89+0nKnxL0xuU8Bt52h95hHOLHwnMMUyKIcWiJtJpsvtOGfKeZwO/0R9Iucdjxu8Zox8Gu9JSHnwdytB7ZyLbXCc3z7gvcHmDvQNzA3L+dpXuC9wXuC8mSVy+tmt6+b7M/86y5/1yrAUJDXeTB18kHIOPuwFFEOLQzCGYQzCGYSGYxXoXuC9wXuC80GW6TCQ13kwrAUJDXeSvKBrqaxlocl+TknuuC6UlI8ISeIlq+fcF7gvcF8GYNID9Di0MwhmEMwiJtML92XuC9wXuC9wYNs2OeexALQzCGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTm+7dTIohxaGYQzCkTn6247nr8xutvCsaXP+rPLvUbhvo0vQ1JDXeTCsBQkBmCkEC0vlGODamlV2+bnSXLgJiZmAZZuoxTMViNVJx9bfiIvh451IsumUbqLurPiTLvaq/QiaQPe7FWMt40ZVabUefnrJOvIRE39yVAsbC7wkYgs6V4kWIv2YKXTGNHLb/19g3wVCRk8TOzhoe9yEdH/LaQoVC1436aa+Jz+wLNQEnvqCMnoja+zWrwb7ks8hFgSTu23DNGRS/MuvCJBPOgW67cBtJkFcu9sga0WIT35wS5Idn0htjbEHNDA0QN1ruU3AQ7rHx5dclNzTadQ0eoW1TOdGQ/ubPKmae64sInYGu1PdbPXVQqzHjQAVvF44/yIIPJk4Jq4ZJQZ8iaNmpPE0uyamY3tGX+KQa7TFS9eJb2/S4iWQhNhccKG4j9SvgDPFIZVxJtZq/ocbcwGtJtaE+1QexasB61k5r7ICgupx4B4N1lMkNcA86fR4zkhBoh11gCF7JqeISsgpgRMicxCsWDLGIZET6pdchzfB6SxOF2Iv6+dPm+Dov6gjZWFEOVze2RxP5Ron+9LZ5QS0MyF+Cf72cn31w/ZSOYL2TdkXXvAjboU9dcZbFbqGYQzCGYUic4atvCqqJ+ZFEOLQ0Wb7s+4L3Be4L3Be4PMN8kUeifcF7gvcF7jhE3dgKKIcWhmEMwhos3qu93htwdllMEwsvpffskMi2UKt9YfuQ8MLI1XQZIL2MZoHC9c8+4L3Bg2zP7yJnCL3mAGHbqFkLfoKIcWhmEMyFW7vbXoH+pHkuU3OBXz7gvcFb9Qjj1+6dAxOqgQwvJhWAoSGu8mFYCKEEzwIYxp8fdM1+diAWhmEMwkMxivQvcF7gvcF7m/tmGpIa7yYVgKEhrt17jntCLt7zX5jdbeFY0uf9b3pVxcX8b/ENngAeOLQzCGYQzCFh00sBmoiS8YiLorGUTnm6yRLTzmAd4a/FZ0jPOmQBYuyAfzQmPGhkCAh6js3670k60lPDO8Wv1I6DQCJ19kRDTIypZoHzXQqMJ5RVB+0Z/5EheYRFialKhh/awqByqcX09P437Rs0RkN4AVjReTevT9iaLF4FfUw9AJIWavZeE7yBCFg1vlT6kLX2AisGtp9OZ4t0cCQ6sIY/flvDxQiitWS5gG6i5aUrzMbOYH1RFuNBLSU3B2rZyzIPMI5/10oXb4IFYBWYAbOe8ykP493xgIYpd+ki4d/t9JDjjOA+bP5CjLNgXjWuM3swVbZbROXIo2z55gFkfCqjykNpIxtCJ2r/IBteOV/lMSQNty03L+dpANC43J3HpIrobNyC2l6GpIa7yVp2v4es833BowFCQ13kwrAUJDV3mwGxFVmNlXKiGO8UTwQ8RUYChIa7yYVf8KBKrw7qTbQ1WubfSAVhYkIjaZb8mr59wXuDArcj074YqmQDhijPjDr1Inix28Kssd5NXz7gvcFZgiOhEzyCwwK4sjFVB/DGaGZKF7gvcF7gxEaPQAAD+/uPkAIr6Cd54fAsb0IYYKcAw7YY119YCju0s1WfzSXv6YSZDJT9Oa6MjcfvEKp+6+GGveRMaAV8zqivrIhLzySJqhmavSC8WQbLkEwZwrqPTnmql/NX+1uPO7WoJ2YUW4EZzQoe6MwD4OqzBH+bx4Z+QkOgUwiIT709H/BQbUVLvPZ7sRy1bavxKo/uc1i4TCwUJ7bPTSg+3Hh/lJy5LxIqJuj6vqNGFvqwNgaUFPNffZlgULXagHugICbBk7aMSXYTUNoKkdiu/J5h5g0u+bl4dcevZEnmMkRrwCBgnUTgwuwT7Tp3WQu5WkK/SMPidXyhIuYa6D4KCB1QBJTN/iHYLVhn0Um+ZbsP8BzTrKaGuka3nqr5rLYr3R5zR/PlBjR4H7O46Ka4LVszgtCD1NYndxEWVsLBCMkkO4WkaoY+vmIWSrVUN/tDxHafRkh1vfBzE3gzN3eFM7EYq1fkGUZlNg4Y9XGOjK5nGVasThDEvFXaeUMhtp7A4OAmVEZJtEmLXz4sM6zy6NZ6wwKg/iaifup3d3V4W/8dtI/1CYNj/qt+CoOXPlOyU3fFxf2OIk1ET0hnK2dkiNt5X4NTgUlreFbuodgZSfPeDd3+WpG24eFXhmCRzMD//nmwV3VdVW13ePbfVokD3g4t8mDIA/64eP9uHWE4iuuEOc5gSpSM01zodwTxGvQHLjwHaIxGySNrebMWv6aAjDoYTJAh2otGpw96o5cL2eLPzOR5TaQAGFW9L7x4Kv/DjXwzue0VKwRa7cAH/MmIawAAAAAAAAy5OW8d7oXWQw1+YyC0mgsVTT/up+yVG8/+RgW4HKuVgK2W3Y59YT9qp+O5WmL2QbCl/1IbbNnaAESCqOubjLCjjdWEMH7XFWyWqcT8M1CdrwHhk0/l0D2yl7f4BmYtxq6Mnndsp8EbOHoZOYTE9hM9KbVN85dwmy/oFhz7zrv9P3b1La+5YGOOabxhbVo1svJDpgeNO77cAT9e/0LdukNp+IkNjknfgkCkTJyrMpCbSUCdn7x8b8jNhtljreb/i2w3I1nFCkblaZN9JLzCrukjq8TK0pxqoUQ6v5F6We4Q5DA4UU5W9DBt5oBRFu4l1sLgnhR4aFDgUewJq7NbP+kkpIT7nBT5ssk9ePiTMCnbTwF+iCcAXghtTfiBKnG5HPWZoY0DxDguLkKH2wWG+xc/bqk7AJwPOrCtqIKap54mDLL/+zmkbX3HB0/O35yRJBh6laqwLBUkta/s5fTdZjNwUZUQasqydtuNiETgCjr4VYQEIGN4Kc9c1GSp8iCCFjVJa3XkO2mvtMsm3jDY8RmS/LfStjZKh3D9ICEH9ge4eWn6P7LBWnK2dXdrrhM14LEhsawNF3uRZw2+4KUpfiVQRwvUL9Tht2xRR5E9VF9Scem8RUb1yNJ28D0PCPqFpG/iajlUrHRkZ/U5c6EnFpdAVfuPy/2o3oLQ+fJN7ON77AYbygMGFq05+vlorFV7BBBsyol3W1016uwfAgjR3F7GMsI1KSHEK+cLtyJipZHFT3h7F8kU1SjEEa3eoOUQ0t2jNcpEqlVsLXa/lfo4QmJ3jp5A5an3RNlh2XWgNIAKJRSP38aJi3xWmj/0AGJ97Y6B9bnZjtOuQ1FbmgvUi48KNoXcSq/MBN4tu/jlWUeQuYQlrig6Bn97cfIRPgjJo4d8p/by7fPb0YspKWBy0HzNgB+7OkeaXaWpBMIaqEI2NnI0m50Cz2wFoClGtUQGQz+r5mHT0YINOYZKoBlECTA7BFbQE0ALVhP7F4xr7T/H4KsfJeMFOkrAXmzwed7ruXoPN64KfWtviuikSRGSYHTRD6fzm5Es3ZoDTVdqWd6JxiWg15kXQQtp6hcGpbvzChm5zqm+2tgs3Kf/xB1zZrzNYAdWrRhEwQekP4Rv7x8XjsKgea0TTfbEq45OoxLjqpZtie0dA34Pg2gpuXyCtbwKBVHi9pascnPWDi+FR1BQVsUkUgdzdQRHMuMcITiGNmGBcaI4bgUm8bswBH1Uuep+zojFiRmwR0DzljgCSBlubnaEjQEVYZL/AH1M5zHTLHI3W9pJ5oNAdkai9VOoPtl+LeUOKYATHsIL6OYZaez9DZ/gJT6EW9whKpS0EbmHtOZWeUY1am1XgeAPnQIljJ+g+Z8PfP20YxlF+UkFQagl9MJ591fa67drOCoQvl+wTTCw33BswXOn/jQLEbOd2un6JTq4qxgVq8N4IP4kgGora/Qkik/XLXhPc8Hi9EKbF0JKtSzxDx2NXq4kNopV+PJik/5IEdO0W7XzbLwb3Pyl4XyO3wGYW91Mhp6HBAzWcrVcLXF0nHdE9RF5PDZDxCjR3DaSwiQJcR8ehMp7/ahaUgy1FNy2VRQJCUGMs5m+/UZ2GgtcpPTGnCzHE2U5CyiAswnsaxdQvzpmLsCiARLICjaowk+ZB/vhjJurTojZyC94ry46C/jJQAmm2qltqQloMmCmxmz5jLXIhkJkTn75xxTk6VzUbq0Y5mGFotuXByYqEPOi5OJz21b2on2cofiXRFJQpC2rdtzk4dtaZ86qsHu3ONTJrGplOSLmduwfquf52VC+hBs0XI4lwrOisK5Zt4Eej0Djh0iiDp6yuKaMREKPT6nnkDu2GyN04MJrk/Kzl+ttNqzSIEu/t1wISk1w9hSGJATt5BiH/vms2aDmFN50HT/A7h1r8bA9YAaA+uyK+kjizcvEcbS2gPuyt1iUaW5Xi4jRdqiEaAJqW1rgLu2y3wikgaCUws0k2q+g2OZ3oPw5eZBdcsM/KQ2X9DqaD1zNp6YEFgtgwBCmZuqjBvtETgY+CZqN2Sr530hS2ebTQNHKcF8OfyUA27z0remCgdl4/gwn+bfkbTSj4vx3mN8BvQbIox2uTLxbCO5oav5ElvqS8lHf312ak2s6c+OOvnvcHDfDvb7qz5ufX7gidcb3OnXZ7Mg2Epaj/HhEoYHupLJAFeAaNPvXnnATcIBe8crw6oNIdxkmPAG4d+JQY58/kcd1NRZIREfqD8Aoe18kuwhYs3OYfa7kf+QPA/jAZCCWWCshdDKpnvzCLD2G+Q0amgUCdnGuXFkXrBG7nOBStiLjDq7b3WHFIQBZhBOu2/yjHQAcmAHlXXC9GA+WEABcB5172bLn8tYQEssdpEqMjwjqlsyUx0C3SJmGYnWr/8qG+34WjxuSeYAJRs7X/6QjyTa5fz0BJpbEyyuKpZoZQtRPk/On7H62FYYh2iZQS5xxtpoS3bnG4xhU9Q9HihSsj3ug6hFLvZyWAmwIWXliIpZy3YukxKWz60EfZnA1joSUVjJg3uaTj1SxY08O9sdX/a6EyihUjRZKl5N09gz3+it85JT/pALAcfbgyOBLhCZCpI3gl7+uIap35Fwbj3YcmjtM3fZu/Hz8YIE21xL7cc4F982l43FiGd67892NNpdMUk1OdxMYbpXzyidw41tbFr6migqjdP4zwYiBwBEqk2+wFkiOvRdEYuXImdmA/RWt0jPAxLHQUK3tS9CLzUQYasHzLisKyFwOkaJn0clZwS70hqAT61LCFf+GdEOG4L+vnorqw6z+ZgD2moTYo6PN54x9WzH8Iq35joWJTtPTo18UQL1el72msBFs5LesRTzyjGJOA9LKUiXN7fbyaAl6FUvZJV1Ynyz9J2CQ7jOyI5FqY6SBIDdQJu6e3kbJnBvto0UVgzIs5THPI0GrxxgJrnvXzdnqjsyGHtDLg4RCud8b9f0vrMlO9gPk/K1XNPBkvK1YUPzNVjaYQf4rZEdEcx19kXAzd2zj0xG6geDpAvEkAR2fTdgsQx5YvrofCFtYzP3W+7VU1ZpQcxbY6sRClwvB6gVypxJTBC3xgi/dTKavObXi33D+/19WNF0SUTTWWlAs8kRKbVns1q58Hyc3dqTkh5+acQqs418AmAO3Htk0GEd32lGsWwLQpgKSOvVod7/KEjT+uQn44HyCkI1rZzJct3TxorQRoluUkddDpl94HPrK3gZxDMlb+s0eKK+Y2LJM2D6eGU43N+MI3Fp/UqN69Y1sHwSAR9oKcsajCgaAB2Z9xkVOWWA3k5jAAZ13YtIMEeqAg6JJV7qSTLnv33yoIIOZauSsJFUKwkPgGzABAxC3IsU6zU0fgJyd+ACEFy5Sc+abq82yylT9M7/7oDWPk0FBohcKjVc5CGZz+PTQ0sNgH6Ih0Xsd7XVcoW4Dyh5NLrJK8FK7nqaK2mhi3ESRQc3tN8fUrCVG2oDRF4caa3C0Xly6euQ0XomAjkLXsWnmK0MSrfIHaO1nTG5jfacFt+R25p559qZShBKbxJ3wMCNrjVvUurx0K05HvBG9YT5oMeKI9ADlBfu5IX/Pje0xwbkINlCrTqZaOwuKTZIb46UY4IZ/U5fRW7/BTG2s1+GYHKCbyioiGIbnwbsM/3IV/3NzgSCWF56VNXlTm18uhjvwO+UP341BwobAjksSAgx6EL+7jfpgQ5QbdQRYEHEKRdutNcDi1YjeLQi8Gyv4E7XwmAN8X78gswRBIZ2Le2hIsUpIwRjzfc+g2ER5EW+8HQUAT9TgRGQ62rg5Mlq15Zu4ay+0dVy49+3VPc123ZD1GTIMwbBMIpgE/fijF8juHBKjIgBBUrJ6JNhb5I7qRIipdTfzZSxIBmMS/XrkOt6Mt4KHQV3pv6Q4GgDfvy2Ghyo7552vipv0pnofwJXOkLE5VqAu5sl4m4qGARz3BxsCK5y56so15BcCo980GPQnDOhBcr07LuAFEvdA9Pksnfv/y7LhiKrBTwPOHStJt3u3wgvIaf4GmGnmpR8uefBmLRYgqkX7JdHki+8bjWAUe6004kfMPx+63orXraCsU8snAJNyNUjALtKFg6iAAPt7BxuMq+KfQVeZwmb1w3kunPSeBoBEzCAaE1TUrLE0Bc/hxwxw7ylrb1sCCbD+gJStAdM16pP2YgVX4lQQUNu/VTgER7YjR36Ncpu5gXHYgHi8rz7hC2kNB+3Pt9ClzTQXmvFgNQrqxMkDq9GTCRWRDMEwDUn9Vwhbe2q9QGOWIIEX+IURJudHd/ZTyER+Ecd7XVcoWVRUPShhIFOjYTRBgWTXlR9Z+E5xJymti5P5EIS2hjsPucRYuQeit7h0AyHjZ7rhbe6A420ud40bYbwY45umw88CTVhVO/ilBhOPiii+fbg8e0q1essCbb6RtbAfSllbhURkWCf32trWeMd2+0BnUE+BOU/Q6I0yPS+B3PglTnUjHUvwQPVZ3iOG7C0vZO8poRiZwmb2eP/66e+4qVofHMWK1yHFzAAxe1IxoTNdZDslnWKiyAmessCbb6RtbAgnlgXero0cZ7S50IzdXSMyG5AONCO9aqgar0Jvi1OCQkJE8OJpuowv8TJg4gCuH1bS9sb9awr/GSckxb7nmdVunRYYVgj6SlOlyFSm/qnqnZsCaW4c8HWSCYlRm12Fa1RjmDx1K9FSIQiiGguXUCQhQ4nUjprn53eFexzhBBrVV+ki27mOn+PQAq1Q94g4WKSQsygs01DONfAGyn1XeagvCXYIdYA2Uch7OpzuHFBEzhRMVX7d9FGPjVNwIAt/npNaYodknl9v6nUs/g1cwUmV5XV9c4z5zRT1gCG8HktdMX2VK1ObNN3w6QOPAV7A7MhTr4CZaBNv+qfPVmz6+oPfx7S86IWdvRxhbOPVmU0FDdh7BYuv06cwwZBLU99RFfmzLJGOV7t3JITOMXLQo6ZsZhWOWRq2anXyhiFexIiXtJJHI80Ostkjxpj54fiHpmuzIWZId80nVBNIa5DT4QRr8Gk49VzEAE498Pt8qQhHLh25Pr0VvxGDpDS4yx9SJ6mFMcaXd15x5yZuKsNkJMGt8i3PCAKfXLWvgYXJ1iD/OTLcm3+7/+Js47PBBZe6FtlcjMxiPIU1pT1z1Z+W6eY+yJNt3ObLqsFWk09+JUrdsXnR+2c3Qp7zrCSuxLaryKXLMtQJQ28avLJcZjVfNIPAcbIRb41EwWrjRBD2S8YU0aJncu41L2YFSmoy6PduDFw7O8jphUreBZHa9E2B+gx+MVwRWprhB1qH4A5IILIRmsayV5FsPpfrgEOZMSR8/eVRsy7FtuWMuapAXJk0pI697SkkUUvRJ2eKL3+tDpBcZEqrB0JC8SSNM1nAVixTJl/cUqSRsi0sSIIzS/LzoWmFA4D8z+rw0s0cTgjEVfAu3+kGQ21DfwrKKG0fgQ7u9UoYoAWbngpnZ0uiCmIFVlqXbpWl9ZxcuX5UcXQEcl3d2mryt28fRNMMoOkYOseYC0BikkitgaD9gNiHcFnXjTSc35k6owfHQtmYKgGjVDtMDXz2TvvalajkVlsYHpVrDd7gg7iff6EMgY72BuYUx8AwRgTr9fZdAOEY5vAUXpLtU2wyyLxfrUKN3/Bwt89YMEmnxM14Jckxzb6cIHZz8AsFjp4LMWLtVjWNZzwfY66tEeU07smTWl/pK4XnsIIxWo+KaSLoIqSpfU5MlEK3ew8WrzXFZWLM2XnQXiR1CR7xfMHiIhpzkZ29fTCfYKda+Fa2NxzxXl4BEkoaxWka7WnJ5AEx/AuFQIhUn8WHSETUR4ugA1Ft5U1I+bFYnzeeNgKq55/mCbyv0/WCANYHMjSj5y2CoAGL7kEXjfBoVL0+nbYjrfbEhfbyAWIXvsCx1W9/dJblIG4lXlR0nh8OLc4JY+mbOG1p4GTavhAm4pRizFLAUZP/uTTi3Xfq+Ig7QZuljQnhDIqb9M48VNb0dH0gwATDbrHGyfl3FlQ++Q6yfhIHTdceqhufEaJZoCojYGTU+2tQ/Pt6Tzmd16ZRQVcKbiw135zNuG2kuK79t/MLH89HVQIIvC6SHD2J+dy9Ql9tdwhOeZSuwLzi7qiwuszviUDOkEYOpzQHlA53nf6RQ3+4R6lavLG0bEBuyVGZi5IWNpZ3GAjVeVwgsqEV8p+WTV30XWSCoqpNZOnNsOZemXqRf1K5Y5EzsDR1bKvKTqk51HKgCpbmdzgGo+wAkj6bbehpVQ1r5SijT2R2AWb1A0JG14TJShOhl5ceqnKyvhPcSq2XosMSVC/5xQLS1h4Y+mbSc37QV0Xz51b5FOQ/6R931Ck2LImDzpz4Kgtf32Z37J3j4eE5fSmyylJ7MVL6yuj1Rhrcl23zRBEgkvyG5vpgBWVxpZRthXxh83acmKuRpIxIjwnFFABzNfnbxbNY3j0wN3b3tB46g8AnnO1oOBjHSuz93wIua+2UNGRkqCMzsORkuxUMM1cKw4+U1z3HCmYHh8Tg3A3jQ55QQfcwQ8JB/9lYyE6HF4HoInPJ2ktTLXkC0IyxgP6jx0mGjr0a/930+8+pDLtuHeX1UcAJ3/mP+3ALp7gjFN2p1xc0uoMilevvCb90POw0IC2r/i+RNrHKnWS+kn8wwkohM0HesdIpr4gxb9pc0vi+BfPgoSfyMGrMNacuGdbjXIDQEKhKyKkwLs2THk8bH/Dgft9sXVVFaqxxFbcEM110ACJFPuugiqSR3hqj4isiR7ADp7KVkjZ79DKWnpg9FKZKrZpSylZebIZbAAXBX+5KlrypGrHbyp/Re0oNP+lIEAQt9annCaX9RR2wADlp0gjVBpJk47PWLYLJvBGPlIQS00+l9ZCoYxVZaNlcAZOTo+nyuL8tWeMzmt80UR027N9KlUi/WtKr2sLzqiTeYV48UdyrZoCZ1a+eq5lZ8aGGs6foV8jrXOq/8o5xgYo5RSZDq0uZRFhInRQOY7LmrSiPur8mjyVl6aunl016OnREibWu9c4xb70bnHmPK66vEusF2yQz+O21dbQTvYh9d2ARsNiUUjh6mqPB5EHW0RKIUz3F+6TntzgDnghDS7LodTTp03IvaCQIj6z1xDgZkuQs2JO9VM9s7GWyBCUDKpUpSETCKfBl9+bS0LTohdWmoo1i3gxeM8M/f46d+GjMDBNBLsbPV9JANK7v4MPmzkyXVOWYyKfr4O9a+FDmEaouvzX0JrqCQpLm5kzlod7HT1Yb3GFcGxFwKRUHPoL3TIICencnaPlUK2ePzB5zJkd61x4Ryn5hWqei/yGOGADP5uf1h3fmCQ+xAZTb+oBwIkZVJW3dvsK5smZk6/bKgiSf51nXeX+8RSm2iG+Dc+QhbqSeHg3JeY7hOYmGn5s6HPFfO9LpVoGCH6vpJb/vAwZuY275i/ZR9g8vAyHD+L7InCbFYVivdYPU/kQzB+Hxkk6R9YmBZrZRUVWsJSQ3by4FDVAx5Qq5+1Uqn2JJYC8vsoWeEX0hlZD/FKb/y88iW7rtjhZr5txSP6JrwtvMA+JR1DWBBsXfStx57bG+fauXdcZYyVRRliLQWPKENa5nLxfzcNyMrECecq1+a2zjs4Z9agPzABcUxz1i2qOdr5feRsExqXnHFBtDnyzGHp4SdtjjW1iAraw/wMVPC5Y9Rwzx7aB5XSg7ffVzsvTVV0WKqtk3mPEBS0wTWXDhEGmDrQD27Xw1eZDcR0/AveLLGuXTj4Br657CAkqtUavWlglMtxgP3LXnqGVEeaObxx7vAnBK1vu+sFBvlDDDgCnnvjqwNKN314xOQXk2HVwuhz7MZqiW4RmbcQimCgpKPSjNDoBtCG5L6q/AMJC462KEWHnUUjQUSRNhVRVJXLQTxhO+DXVvwRAiiGhjWfbRggViFFENkO7Yho32ZiOTD0VcQoZ0gh4wucUW+DFs3228doNxLGJoyAjzKYrexvGX6NzL+AVBa6hI3d1amIiuobtgPPsVpTVi01QkZMvQClapWl7xTv4hkZA7kBGsmty5A0iWnjnrxssKh9rbEjepAnMAIjOdlYJgDbkIdTvZW38hVMIqGUQfyU4WP9mu8riIaFX6AJhIq61Oa0z1C5mV5zhqKx2VgNJrAudALCl785vydpZgCpSqKa0UxaRw3PVkiNscHZhK6DWShC6PvRyGnwDWOfIX3la3dgov40GZbRd2yC1ZGTGYmU+SKfA/OZSzpL3ZzUsXly6g1rGwL+bOGm77JN7gwuc3gecnRh9DmcBHTnolxb8MSimruLcgwb1THDNBe7BCPPukzAa7vWbKRnrO0YTJOAf/v47MmXS2rQu9VbFCd5ayJozlfcO2qlBV5cypbXVgrYEGqnTIdGq5tjn2AygvupeSnqxZ2Mio56k1AqlUxM2v/QczCoH1U/Wq5+8SXTASGen51eNn77AlAaRlRK+OI63+99ie0O4SZTYHtwp65wvXgXe/wX8+H9bGrgnDscsvMn6apwi5GjTwo49gytsniXvhxgn7p2QRRmNoxkwFm78W3grzCqnHxgIqkxvtf5/MCyH40bRe4CDWKwkT0gowyXt28GJ//frYs6AkSSZUtnDuqw6B8CqLvA5uXmmdqY6wKvoKiSknOn8TJzVeD1ggdctWwVGJKAvBKJe8zp0UPp2czFtYdfYZ4DcicY7oNxYOn9mq0NUb8zZHREo34GEs8xaC44Zq5y1xe/fR/1jQ0CnbnQx9G0XPFPo+YyUvGapbDxvYcKD7lXjsQlRi9pF+9CwAKTni8FkCBCJ4aMKvTovxszYe73csNYkwaYcsDdLiQ3CFevU4JdzN++DT51iqG7S/q3oh7g1UjC2PhG9E4CzN+fRc07YZtUGP11kyb9vsxt5YXdPw6B5iCtubP0aRR976yStctDHqPprEpPqmVvaHYSaTVOwr7uDP50/ELR/IH/Hdt5D6GnfRhWVYk8Kv8Y0sUZshgidZEF54EdhB3KX+FEcNJ0nU3nfbxyC547jlQZ2gEh0cpVRO3KM6UDyP1mdOTXnO4bj78DqVRd5b8vps8d0DZA0WENN3w5TmOTKyyogTYcVltOe8W2ggI+RPyMMhaBTra5HwyQeGczpidof1GiyddEXzSIJvXG8LNCZWkmTAZdNGwiDE04aH8rg7MdSNsNkdmls7CuRSHSF0tJzqRwZrxc8EUDYuU+DyBt7qPyv9RkPLCp30Xb+82wbf9oBWLIoZ2e6He3kqxMxPUNGhfGBIDYORhSwpHMRD+Hgo8RxuUAjp9otg/l7OjaN7VPJsmaQKMsSeNIUr6Y+JAG9WVOuendLcfdJj88HV38bWvzE9XjmJklFKJVJjJaSt/S0ZmtJdn5X6BknzsIQB9/YvymVZjpM36HPS9IXhPdy/bJr7muA5570uDqOhH1DUwiDLIZwNnzpCnYeN/g0IFjzOm2zfIiv4VWmLShI/6EqJpT4mJzVKP9uN87oFSlTnb6xU6tB9qYfNyR0/XsXq21WpDAAa9sP6OFEvRLunmE42C3pcqkooOdsPO9//OxUaRX0B1g8gcZeDKMWuLzs/NNiUnCwqViRW/N8MhIypLC3VSDCvRq104+yi/uNlWLfvQD6xOeVJwBdpRXPwaAboDrKwWDm67O/E8w4/95iV+q05knDS4qske5+1jQU0Y7CJdhsJCnZQkkO6/sfAtGDbHbdUtpGGkzWocx7uXSxlMdlwC/MRPZdADOdZlBZjp0sSpJO1GAcyWDwLHN3tVA9byoxmDO+6zuJ6fVXMXQLkUOYZBtxGzMuegR+cBMGICUxuNdEHzzmj2ljcRsZEGjOgbvUqxNs6bVOdJrIOR3qW4BHMaZX10L8I6M0RJ+y7Pk2cX8CUmgvwPpJFMziW1sStgxEt1TNF8+cQfq50FZreSSDBBg5olQqMsfscxZcu3g0u2V0xKtQMBw8Yxgu1NOupwi5HrOjnD5T6sUVr7Yw3z2sjqsDDoGxE5q06VHa6YbRSxPpWKnuvAMjWEiQMjuWIWLa8fi4+F7mAWxrx018w3MScK8NNtbLrdkqTuK41cXMT0Mm5Iiz2N+pBGzsUBGyAcwSQ7765dMkHcZ7rP+sF3jKTY+QD10WuMqbzv0ZW7SnIalfM2xgNDHQ9DKH98FHU8ibogrQtSdujpMETyg1fPp5VQPcmCP/vX5Glsx8jAq/rjTCWY8OOKziJ7zNN2+ae6+6iPshWnIk1kaGDyCbBGofLA+kHqqHgO+6pcO59/Dq8akDSx/glP5jjr3vAINLyoJLRm/yAGQqaimOzkLJA4Mut9rGKz5mULe3wuqzNbsZdhANRh9YvrES5B1Jg5Os25L8rY74Eblz7j9XZzRaHxQzB6CGzCtXFpXwgGvk9Un7jNCcuzcsiDvpuVQ4KchYB6AGeHz0f2LeZ4Xw+GdrtQ8JcysQRxJlIYwBz9BlE1mbVy83uQtgWMq4VtQwknsXrVoZrVx/96/YkqjE4TtAHVnoZLGWWzZ2HWUPMKT55D4GTqd1tjjrNPW349lryURF/dD9KTHj5KWZxEOaDO2nJafVpWgz6KfloT9GZ6A7RuYxT21ZmdANQQsRQOK7lqRpZ8oS2jL2cHBfbU2F67xKZsVG7NQthzByWMf1ApFCf8Kwgg8VA86t9ThvE0x0Eczk5AQ76ZdW98cejrBqwok/HCzoUlt6f5Reu4Kv0Pk0gbVAjp/d4CSnWa/rjEpPAzwPS7kQZeNpAK0VWxHrV/Bb8aom4QWLHASkZqVc9qDal2DDWxvvjMHs4xMAjwZkIDW8nB5q3jsvMBY4ZgRQQ8NKAbHFardzNqfAjrrvaeGiSyvwpFxGJ1x0MLC5PDQQoxxqYGA7xK9KTNuPNcR/L3JiG3sOt+TS48I6AWubFCurQlHjlAv1crj4EVUP4nQZOYpDYWa+aBFEm6dNKqXUrCCH2rYBYNDqHMiIsjjS/jGE8ERnOQJREYEjmkZDo94rgHPbmEAXhKxuApWXHjxpE2l3L7P/56qCW0a0kPk4/f/0vmxb+b55e81+DiyM8VTPLFcMv44aUw33DtOhFPSvbewWboKb+9zCZx/i9SOkDu6Js1R3SUTJQuJQMX3lUErout7iaUrXVKhh/OesCfwaffT3crNXyHf3tHUP76HWK3BuDoLuvoAheB75NsU2QERRukYmv1512WoWjs4EWXnpKIq+UDTKwQUv4QUp3ndYNSXJichNQH6IgtW8JFEUC+1+p5NHkT0Oa2I4tu35G4x9rcbX/EpZOvKBmG6NWm8MtzG3ZwKSBl2Bvkh/HwfyRCpMuyNuvPZBVxDt/mV/v8bY/GjY7bDoEQiWeWf+/StcVSO2PwCMK1MA/OLpzNbnesW30wRFAk7a2U188wccXK8ye1hTo8lMwobfCyjpuZY3MbiJ9XKBuzH+IWGLF6OiXCMQxGuhSqm3wejbs/r8kOXGcn42s2ZIaYV6fzQxT4toynGezE+YH43x6UFS7TiDzxQ4+BQsTqz0MljLLZs2m7dgEEhHxeuF3QXQv/k4UUBeAc0GC5HXrWIlok7WmMFvQ5xg0H4Sz9WOBC6l2mTAZaRYcgHSSDqVu1O5cz32FLZQJODQbMbAS4KY2LQ++dU2kqUFuhJOZ3wC0Xfwl4EWPd6GK2MYza5/jyjWUwgnIDA90sPbde6kIgwNNDwTqPjB6Ol5/guMRuviA8waffX5JjkzH5HEzQjQQ5H5GkkVXzLedJk7gSIpbyUcZZSg/UIe4M9DIQ5ooDKm1SdDTkMljLLZHH/1TlRLZlhWLktE3OOu2eLOaYoUReEDmSrleEu5/cQCdnTEJpp/lnfL6Di4XCHvdCPyg0TBIrDorUWf+oxAkFskvYY73/dRYe+97QRsx9Jy0ezHqMCMTrzn8nzzoEEM7gCngDqiiLMJh8lSvemYA5u2CwQwgEDm6ZLDglVaOlEKNmMnAf80M0hpmLm4iRiTQMvFrY7TPsl/ZqZYfl/BAD/e4QleXE2x0dAOAgoxjJ1Bv2jLRpW+TvQPen4jsM93geXIcAGZ8Io/nzOLYf301yIZQdn8z3vtAGol/u1POs5+SLavmvkBi7fjUyaB+K8btcelo5CxAWp4ARI/7xJpULsL0WQauNuXFeZZOLT7eIxlEES+yTkgLjFQB3zIXecHGvTps47n41z62+0tdSB7x/AJ93Men1/UQ0HUbUFpe2wSYbYZj/U9PyaztiexN5wQ6tl5o2FPgWpdetnL7nMRvnFnEFMowIONhKsXGT9+3Rzi0dzHqMR1WwZXQN37xtQAoX7J9CUTdZA6ojBluHYqGELqR9rI2Bg9iIO8M01Bwmr39I6iYCRSDJ9VkS1Inij/LYl0FckpIo6YPhh0UgJZZZiXiLn5z+9ibc6oeTj8+aS7DfNJh4SnGfQStqtLn2Cm0GjtOJUWhAfEpHmeQ4+Swl8plqzuk3vTYFAMmIFDByWTDezeFLWRtzPqJwi0lUwbCH4Nt9KkjQ5KPfMOCjJTlfRrRmnIYeBMf4BbG8ceWModyaqWBJtHDML0OT3QlChzeRQk2dtTpjxFqtl/hxtLTcAVlAPwAIen573UGElxTaBLOSK7DO9gzF1jpSFmbCiLU8vysSGDX6FnT/Oq8lk3V3o+aU6C3hTc7XdjOTIy30x1xLWKdBhIMV2JdyZwl/HtUGo4SHPb1pFwCfvsMGuKWWFd00cwrDVNotYJqq776V44/kaFJWyADrnoRc4K9piARztrpuQvnUwBlqLecZ12eBuTWNEIV+lMeJSLR+i4uQz/s6JsmbbZN1TmqeJsrBEoKyzKcJQu7goFfrhjhWsuTRN75eH0qx7nXXBGINKPQasIahYejymT1GzYeUfKvOrcDTQ9ugmiMw+XQp3QR7Y2RumoFt1wwsYZe5G4XYX4wfBcTD9EjYhJk4DJ+TdVzHiB8fGgSw18EDogO7cBpRVWLa9sZa0UBrujQAMMPtVxYZNqehNHmGObb/eK0dxbR0LEZFTEHUbqVIT6h0mQLuTdDbg/AkC06sPm6TFA3+2KEsgPfO4Z8/KhCHgsnNgvEfgjNyYuiaz7tXfsTtK8YJM7WkHc1iWc2HQd8AxTt+4Bs0sas2XkFiYxKWyef8/Sr6jCHlbxgcwLYis/xEyZo4FtHQsRkTWjzMHFa4FDLraj6D/pwgkeSXUjssehik16N5FVMFjqTA3xiW/pzP+QwXnklagl+CZrmUUe6M/r3FfEK27VIG0wmRobpRIVhS+mkNCMmaQluysQ60GgCaOL0XOcqmYaWrsVFiA8sBu95ik8dY/d1U/rmAGeQA4pUY257locwK9bM/YqRZ/k4ulUfiM7IF6t76wIkHqvkaas+ta6OrJ8k404II93IDmaYA/TqoeGtqjjn+rZj6vQ5I/YG2kihQkC/JpJEek2wbAE/lvR6V+dqKW4jtsxquS+vfzS2BBHL9h/NoDH9zPKCOJ3g1VO455prlW2t7B3NPmfOlc4ajDY/iOQq30lb4oK3n+Fzs/n0M3NjqPDJrxv2YLpBQUM+EUAJzIefIjWyAGQisaZCJZUcu2c/2uudkln1/6z4inu0jBF59XlSYngwqLnaEUlLgFQVSSqIX6P8a01vmXplHZ0AAl4zTKxrPG2BbHDHd78JDRjcsVIDP3RzW7zHMh/kFQZF8hATB9X+gLo2UZGJyw91GkC4SIZQZSlynBNvClVYbhaC+JX8U3zWmlGoJeIN7Ardw72klXmUOxSMddHHPq+PoeHnuMjjEKGBnJYhwLiiPq3RbtGoeDCJa9yPtIUoxSZIY2l8f6A8cfT5AqlBd/cPqrA1tlMIXFf2Cyq5Dd6H0f12eT7j/JQ7sTNhm8m3GhrGpaBOEFU4NIaIbrCHNNu31AMxgTKjfyQI/gboyLYYBJ+k/QrCZok1QbKOdr7NBLJZdlLHS/OwFns5O/ec7u8EbDZZxJHbKKhfiX9RoM6KDvmPEJNmdSrRXblsUCUJEOIE4NJC7JHUXyga+MLFuc90bV9w6yjYYzJj07olx7SAfmGEER8KZVRDQNFdClybFUHd+KHNtPqfL6/4vLcu8aNQl/KxEec35sCswJf+oUTYyPSREZYt2pFTxiXSFa5S7HlS5+HkBkHt8aZ1McQv4kT6u75Ia2C/NBvIBxZsODjpE5YEcF70pkwjJkt0ZLRVfBKfw8Mtpn0IuSV2HnRXXqPBDB62vEnkHSubJ/oPrXX8TC4Y1R+m+6rCzC4m2fkflvkOIgkCXsDQsASJRZDRhaJ/fc2IWXs4w4Rq2KD5QtbULuJqpOU/+XcA2KKPVwr4j4ZonXXfe4swD8lsaa5kL+q9ZKXllK0fAJGpshhhLv872rjo+LlI/R7zv3FeauwT37oNpn+sdxZoxIkTDdbD/wCp1yNCz8LVfa192E+yzvoY6+z9LaIdvDvfBl92kSXyQoCoDtEBwt0ENIlq4vvGOh/UVqrYhLc8JQIDsfcK4/Gaa+dJ9WAr9kSRJcMwpBoMXJiuy4b7rBLUozkX3cQ/sYxs+aePR76uf+h7+i4C+42aR2O4uFF1ZRKr7mP0EMCtNERwMDH6E+r+8THISzNJZAhZIESJJfD2Ps5ZEMrZnSSqElqEuyaRwAGzBxSSYLwHlvMbN7yMokFSHjhKip+R1smMoob3sZ+Gd5Y4OeVIYCRCBNRKP1mlXLcUszSGkiXhOm/xbiQihQSG4Y3qM+5p+tKpOecb5wOymkZDLl2oMz9lxkD0nYjHyRN5tByo7JbETGw6MUUNf3VuKc394c9dx/LylNWBeDgsK/jd9ImGVpIqDNrVj2THUtTO3po/5T3GbFQu34xPt05zAiRucYG5lGO3kTbusPjizPh7dxlfkS8KTSoqObyQcpQBD2hQ3j6GjE13KJssijIhkf0Wuheyk8/lMJfepzqM7atElPhr6HclODA5z34ZeFKutwgBiknVCxS9N1+vENNJsNenOzVk/xfrcQTYxsi5PSK39jtHLZjqys6nuntzl69KiPm0MCYHQLGlNhRdAw0RZKjS5MtIpKjdlA59Sy8gqkwIv2g/A78edL5RcN8A56aVFtIO8u9aXkHvxxsFCwJ1HRNK3az50FiVXVu9UojhAoi3OoxSlj3bc+0N92LOvLKWXyW+5EX9x5S9I8moF5dHBVkh41Tighp+ddxbnFGWbfe4X88UOxLqe38vDkBNAOsR4+yQ9lyFwGIoSLo1mxdOetTqst70Yyg7vdOs1vfU+ndN1P0ZYnsSU5Stc48vXujlkvYY7Hd0lvZRZIobt6lj7tix8nDorxwtVqIB6Y7zakjxxlJ9JqlxXBD1KKg6FGDKkdlR3pCN7TMGj2uT8gDSMChv3nYJSMFWh9vJVv0ucgU5Yp0da50QXGEhr3lrDS8UYhnmuksTUv22/1nsdnzgIwdjGgUdBbtVcVRtQc9/veiFVinW3IJgKFOhlUor+tQHaeFtxTg7lSnRMRacQFl/dEHqN+M99A031LqrPSflHFORU8hCAx3SiTowGNoQ0iXS9KIwo/AVCGB4zH7m7xsZplY1njbAtjhju9+EhoxuWKkBn7ZNH++JmcA0uhcpY0RUgjftEwGL6SVc+r67HSOkWZ5TqEUqrDcLQXxK/qKOSbNDIo2oibx5K9+TkHQV7EPa5XS0iVQhWOBg5EbZo1mAEyq+RkJ7w+tH2BnjoNJBi7mTMTVHZZg727mPBTh7H3zkUACaoQHSksujyIdkgnNzZLtVWJb4etMLvhG6/KIjVQNwSFJ60FDJrVrveTqoINyziKJRPZL6zbIBCb5h9guG1uTPZm4oe8JZAJMikjM3sxgqBXrLLXmlrYbjcmSoUyvBU5H1d3XpWtyw3gCmkMbxMw4I8iGJwtrmU1gSwfUQrc5zojqmxpmbjnWsPhJ4M2QTAbM00Xvk3cEedVba7cOjXYjqUF3HRlqXpA9/qJomRUVOqwdtbk1jvC5JXcKImOGxXFuqL0iQpEIuxRRYEAV+TjGLUrssg0hohusrjZ9ZJ7p9Xik2prveW3AlUiaVihHbcbB/8pTewZjrjmpLnWxqmMmW1lNFU7puahFgF4BkondvZERwXegRTEVgoJNnHDZb7/FAVwZ91jir5hIL+xTaH20VsuV15dkFEZfq84eIBcG8tWq1Z6zngNy/OU6SNwHvIWiiFmgthdPmsOtjX/jubef2nzWlFGxNUynWLzhhAOCN62n1+bSlCMkc1MRV7P9A1WHJoINU0Ijrdt3Rla1LJ2tLNJlN87hcGWee8QUOOlL29h3+ikp93WuQhwuP36h8I+Zceo0GTy3o36FlnAnIqO1WifYjob1VD4mEV/z8nRVlgCaeL4om6Z1sFaERjdVizAzyZfNjczRA9l6RS/1pE36CnbZoXMmPL+DPiQpiv+18eUYjVp5/u/+LLCQ2hD5njOxjBWzGY31T23WYkkYR9J7Umif4xLA7psLPgqCC2KfywOsmxoJHsnr55UWDj7V+Wws0Af5mrRdJVP0ZmLVp3U71aIpM7b4Gb+4+cqPTl/jzJaGfTsdr/9bdKCQEQWLSHIvVwxq0yWbWmzcJcP/cCICRmnEDNQ6i4JT4SKw0QSmYsf+y29juFawFn47xli6GsqhO/v1/PEEltv292ONloR0VqL+yN+58Ag0s+HUVX+1czsulm/5JlWVCCKSuFOHcfsglMHr2EiqLTRabpEwC14k3k7ADasA6Cq236PulLtUX8rbteFSSSdc3Sxrb1MlPVhWDPgeMTFPrAmpappNtZPSQrj4AEiNlxOuC3QF3XbZYY4J3796jZeD8oyOIIJK9jXfayWA6u7kqjXqQh3ps81mQcE3NfuQZXrl2Rs04rn18VEWke3Wktk/sNioqCjHMt9dcutZ3TFwV+wGw/WQ1cfoUhhR7j1NMZtMt3mO2jJsKXWEUast3CEeHlzO7WAIkDKxmWzhoXS9OhqoKh6asxVLUfRpTJIpS4a6TvnRPPZGESZdR1eofu9y+16k7BItXy2d2TEoEMxWsVZeCYJdVRqestalRPqh24bw1xW6LEQ5pgk4TYMdIxCZifxSOM0jW/U0h1TWF31Zrl2nKqp2UV55aYmwP4Uk9TUMB9Uu1DAwvZDHBzhC9dKBxMtICRCI9xgXwl7waNEojUqJcNGNYjziE9N92+sTE7kZwvxBq40d72pdZAdudtTA9lVQeLkjorFlHNLyAjwwN+wo/rNtJBQuOH/MFUQ6qODgiunrNOGz0H5K+Jwh2u3kJWLr7km3a7Ebq9yyeB7cCiXyA66jki1El92M8edj/RHGt9mpARL7WU28txnv8QQBsx03hS62qZplL7+10mVl7e3/fBgB6SQWmaUt4zKGFrC/a+UGX4klc+6dbchwVxF+qIY2ule7qQsBZH/YQ7NdyzIyHXA2tzatRfSoI8J7GViZKPagk/atQ6mL9rGVIV7MIhvN5vbiHi2i+Uaxp36KXwcYTd6592/QjD8Fg2XVcZiSTabzJ4iwDQxgCb6cSriiNCMWhI+mqnBJ+HHQ1oPK2wUK5s7r0ShaQso01M7Qe2NyJ1FUGDZ99U0tF2X84JXJXUDgQelg84MyE2aoJNv2XHCrBXFS+FGYKnNEnDDfwkscVMnTFjUpLsIBw/mnzvuqnG+0Vjv+zed3svn7tOIegqKhaojFkxgx4Ebg5i9/wz4sxKjPZk/7+Q+M3TuHgEOJ0yTfmq+/wwBb8V5ciwc1mkmA1Z4D3lOWLQ8Fe0gnKQ+VSl1APNmuraees5SMwZIYRXeTglFKYndvLdezZHIhRgR7P0gwO4zvxRKsVb0ZgguY7LktgKTwACfVue0Pn0vVDWvBbRwEtLr829YV+mWlm2IsB7gnku7XinTb32S92uqiNk1JHvgjomgOZL+cT59jn/iGP7rHrbM9aieJ7I/rQyuQJIiohkV3QXm9AbgIWF14zxRd8LAenakitOTJPFRabfC5EFuSi5n+flzQGB0yYVKApiX7QqVB2g0uGmxDjdOcOEfyGFGnl2u3M9w/uQ+lYzQU7xs7VSmlROOVdYPxDRwSfYsYSrPU9Uij4npWAwXNui0vaZuA2PubgI5u872OyECc6jFNolG3C6qYbarW1niaQjgORCUUdZRiFu0JHL27kzovrzUwlU4xJ4DbCg6Syey/BoH1q4s4jHbyK5mFGWLCveLdNwuMu2dlY5x7l4ebJ7AshPk537nu9iCbFgVmS5uia+reEqs/VBu92f7tOdzAH6O+0UmNq4/fe6q1qpJCeMd8JOYn5L3Y72xJEhTfL6t5JvqSADbMBXU7vxHZJV7zx9iImv8cxjKDy5WGtKVeJAbgEuga0Sm7Qgdgh7CWsV1GN3V1jp5HuX3pni/MSJbuqdel+RZyj5D9xRBklQyy16MNZVB6BmaeuWrYcZ3Oa2cACOxGfUmSa9OpM1/buR1q22h/bq571XVFGGK6v7pLiJIcSRwY1ab0CFvXE+4Im82oRp215WGOBRsqkZNz/qqpQHgqvciX1pA76lH4S3hDrM2A7emJVt5EE2gv/UJa0bdcJm1Vb7o8leX1HvrXWpRzZPAsMCpyvQW/HW3Urun+eeCQaXu4z7ldXJ1DaHLS7UZYkoljGYccl2qljMBMJ1s4OSmWMa1Imw6dA+55XlkETM2L2YKXCo1+QFDHdn6I+sXweQaTSfUq6K5vvPL4T10MNgpD5cUQRmWf4WniYjHyh2/fUNOUKXTjMNx0dxBgQLtaMAs4GNdsrvHQiV5aXpFsDMFe7Ok71iSnB3tDEApwAl9+MgQXpIYf5DXvmgyNnW+Wc5RRvRgexxkhDeOtVQ1BcWDuyW9/ooOk2glCcyjw8hVFyczl5TDJSd69zC5MG0hGquwoFAak1TjJ/jmahhefCiJHAj8wBE7BGKI6AcAZmSDUtzF9B8c/l2aaRS9g784iwggOJV09dom6u2OAWAMEUQIxkZacff6zTSKBbUymxm06EGUIo3R37R9fZXrur9LI+toonYrqy4RCaaBXvJAChFkL671jjKMWXEwS/uZNmOUUS4E8cZYQYgBx9HVj/eiuakQL5WSCFO4ll5yRur9OKPdYGukJz/06Tva3PjYjev5JNDL9iQTxgJN17LABA0eIphKi7LtpRDWLPBYttjqiBcBWUXS9OvvP/mOIfua40LcipIz046uB8iphQbGm479BKOkumj2Hr9vvbswbwT7meybAt/7VhZrjJw1DlGYEu+Zwe+xXAVIEO+UmbHIhgXNT24qc+i6b+cHgfdNM6gKdHieFHPDa/DbFo/8AAvlu0GYqLApm4W7tprWYcN5deQMYUqaqaz08Ma8v7bSWBdDnlI9FXsLLUIylYCmscqPymFBlPDa7iTZjfAzkY+YvTdJJSUwqgSOJU2gG9TctPyxx0zukNipXubpFiw85+HUozta3Qzr8b0ube0hh/Y2aJhnWwAmzBfSN0MqpnsFT0KRi6F02uY9umcBEb0ts6RG+uL5NLH9yuRQrcYu2piXW25Z4rbhn7GugFW0VHmujTxJ4lz2x1EKxmft76YKhegl8kCQjAmdrmkQeIygQ94Fh+hS8QajA+sdIOZ1XYuF6xUEuKqnKANyCns3a52SfEm9A7bWfjc8q3qqYq3NLkuE3frzvsdU0nlommFTyzIg/OBR8fYHbuLcYehCf7Dpqi5/15S15V+unxkDRPo200C0hB09B0W+tkYM6r0rMbtZaAUYhD6m1KqWxEAzUyXr6nX1xuujfWXMlOQD3VOaplbpPiD9DgmnN8UTXB702DjHx1CUjPvFXx1AxfBGJlFDxtv1Ri1w2RMd7jW0m3eP21liTfHix1DlyKofQmy4CG0GW64RTtm4Fi6KOSR8dTsVdAXP7BJ35TKv1znEFa5s0elNCsG1ncZHp5zbH701gD7gxhctEn0F7+6jqnuCsSbi5sL6idhB6g+/bKFkiX95yLngUyzfnUDzjEAD7Vz8gL6OAVpeTj88a9tIxuwEXxno/ZwvB1XD8X9govDIZgjPiaDrNfJEnZJeKw+6uWHEdavXRYcBDfg2TiFL3/stRHLzKECGsAGD7oRvYwT+PhUAAAAAAAAAeltFsulPqIr86HxCsftxR6bYr4RFbKgZ4BP0iBpBSYhb1zj+g2xJf/RifmGISeyiavETyPh7KS847IoKYybpDqT4n1Ug8eRqh/zsrJSzaiK/HvFDzvwY5oJoI1ADPln+8iakQLWzO5S9gdj3oAUVmuWri43DIcUQcUXUwwg3juCW77tlZhi+6bP0e3Jng8B5QmlIKomFgAlGCdpDJKRTklU3ueDxeiFNnWfOMn5lATUwuBojyL+fr5QAva324i3D7h96Jy2JeHvJODu+o2ebzbiMb60x9+QycoUHefR3dvTV5a5K51q+GOnkCGoeXKxa/pvncqIHbzttoDv7V1v3DTfThfvVZwMxzpRbTqu0WGL14f9BIGzz5yXoldbbzC7J4wOJewOwtrMaFiMgz1vHj5nuqGOgDHmj/K0uKxzr2e5/jTPO4ymLUsMcSFfQOBYx0OS8Sahg+OceNR0ZQPuB0eKh8jh0sF4xjeTqRGmomZSY1iBuhEd9xRxf2Yfz8sS/j8hDNqWdLmveOJXnGwSHS6xvJiRqw4G3LtaXLkdjiIvI4F4Z5V00YrBZOeqMrkLMzeZq0gxQF0qkjV1HAufDUHSDxDTo/blV7xCz9iwbAAhPsEPoCBqMNfhzxZ07LglDNKIN+h4T0slgwyVyR7nywWiHTbUgTE+SO3MTVKxenT0vdYy8zeMGXFe+lDAT7CpWS+sx3CjK5UJRL/+JNSN3fnAA96sQ6ALUsnc7NAQJgj7F4I1AEYbp7zO8j2+xfXE5jZ6B7tubGC+QiM/tR2qkIJFgIQlM24daL322ls1XvPxB+r9u39UQ5k+PJST57uvRm2bciwn8MXyDpKI5GbchUknL9UTOvRyN/5SCJeEXtLUy9OFdKz2LGh0t8qGqUl7+9Re6DAAv5dWvC3/enk3E5bxyraPPNEpYb45qV6GpJOPKp6fNGFXigc/3UukvwqFZ4bXLJ104iimGx3RAc8IKTs4ZykvOtwBBWz2gTGw15Ou/n2l/gA1rnTpcZ0lE2CCYsDuEmVwElQNuH5yBCwtlzVForIJQIFDvpTRBIs5tiYovefAqrRh1f019IoChvgBWwlIAIB1+GV4O055vILofothnswaqmng5Rh/FUD9L1hiymHsxcrv51gZt1aGSXWnhwg+VDvz7d3sbhMsjsAFD8Qr0soB8n6L2o2ZSahFfmHncJY/9xfwQl8VUUaJ/T3/jx4lRDXXw/6SuPORT8UJtlPuWm5aFd48RmBygJSj4osPDXLc2FIi2Jl8Ssbfe+jFeGGquvKDVPanl+IEUlmgK3zpklkzJnkqvtTyZ2DZXMaYemBwLAS7+GYRW7OJL2NoWcWmIS0fWATpu9+oIzYhbbkh5VVJJ76RTcAlJHQD5QxNwvBXIGy2VUnRJPeN+54FT7sMwRQ93GiIWAlMpIZZIXMsQrktzudUubH0sAYMfI4JQXjATEW2ELyfn3sNEj/yKgmp3AbJN4VGS24dm7uBAWSgAJzteH3/W7yNxNFSzBEE2B6+EwV7l+FU+ugxOllzuowURnL90az2AJigA4fZVizuGvXc/16dcPeLd4hfcd5pZ0UCJp5/02O1noKe6wnsbv7b6+ZhDK2QS6PL6fIkSrMxyy+Rak1ZApv4bz2Yd3jgIYipmTcbCr5QOddem3i4zqZfR7Qnp6gz8q3WRpeS9scnWGuPMi3q3Q8/0H3aS9z1a7OaimQOo4do5SqrFkzKjaa0BjyGtRSWSYR2WqA4vdpwOOhKfbicR2gqf7YMb8wqMqp4t3q/PoMG4LDIBsj6hvqG+HWmIGe5kJhEFwUs1LGeu1dH5bILW00UP/rAicTU+4JEOWECKx1PuFoMZ4q0jHZ7QWus+dvS8x8U1CBKdMtY6CyhspCELPjTJrsPPV4jH8M1D2ZxJlmUjLrhYcPLmx0D6G+q8XCt8FYKHjW1zUepo2Bvj06kP3KHYZpUaCw4pl1410+XRSPDHgbZ7JqIdVt2JTy0FbhNSWDTU7rItRMrNbZl18k224WnZCCj8vT6fufCP7L+z4CSfccmf56fXjqyvlaCOCEqYg3pwKUVvGHRPv3h2uYyvnmGkbKo9upmeuVQ8J8C+ftkJtwsrB2KuSWVvzcrrJeF2NYGCBCDNDWtXgRgwb+yBFiiYB+8h6f+p15ZBI995HxQCaSU8DnpBSI+hB8SspWY49B71C5kWkX+cW1ZuQVYqMPAXO1d8fVeiSmp2nmhgqDxEi7ValVFJcGmKRZydMwxpdlo+uw7IC4A6mM9KRXw2YpcoziGsbvz8H+R/ZpF8LZ2y5EzM2Dz6cvS+irN25ij9dOiREmKEn89g66xxgYZGW8XZnrTlfSIQKy2ZHPUT0VpXjrzDGG47Lve83fh/2wMeV4Gg7mylyKTIadBaMEnZoZC9Jhp3Ydi14EzrbIsogaRtV4ALCxAxtnvdctLp1NdOqz/1Qjqi1XBqBwkjolgKKtuMoULLyBTu5TTpDQcccRkel/l1OJsPGZ2o/4wHmlJccRcvRpspr5pN5GyJRU4EEeWRChfzIiy//B8F9YMdJjo+xFUgMsbAu+LhIiZD8NnkM7sQFtL1H2vnvtMA4G/NJrvuALh3w4HgcRMMZMF00JD9sGF1SNmxNAJF/wYqN5MR2O3DbQzehhPY/fUYaj+S8Dzx1WBcNkEG6yoxn4Fxo8+6kfw+Qg/bCxe9X+YXNZ6iaaZ7gM8KyE3K0uI7ZoGooh9xpyAgl2yRm/sZLyajmmQsRsJcwNvPYuHE1Asy6BOsuIW0wn1ZiDv06qCtwgOwgYIfF7HNRqaY2SdMUiLYmYPUeW/PTbqL3Icndig0L5D+6DTLijQ2RduTsIBDwU+a8QVjZL760b3caf7SwzlBvproNsdgFjzVriMeJQLeIbalKfVH6TkaIBbrpXUD7vIoqn9lkE7o0Q9CpMkUj4URbuJEFeQXTRJ2Aqjkk3UdOy4p2OxHtYvth9ugY63VAQL6KOtBrPyuuwYwF8+rdBvKmpHzRGO4WavhjrPOB4SY2kuwJ86hUWpJ5T8lV+OFNyhfguADS52B3tSS3nGGylzgIQ4vHXfFwuLhi6F/6oxoibl76pzYUql48OL22ut23u+feKkgp5cd7iskWoRF0NARYq7rM8rLPtyH13f918AZYQjwfNROPEBi6AurRCmslAokGJ0KS1Kli6DTtW/AKJBKi5gt6HN+7S7Do8GMZN4c1OVZhofEKx8UE1DoXdRkv752eg9Qnym4hijnHW9LocA+DYPoO4M7m9Xr/4RbF13cDrDNlOhrGfvZLh9o81Ebe7bjk9jZm+7rk8w2Th55H+Y3lO5SphLjeLoG1KKmk9CEbl1QWDD8BQwGi/UCzHaGg17/hPZ0DNJeK4lIkqY4IjNa2eueaS/3VHvOZOleZg1mo7qyM/8Jf3sAG0l5JVtGR0kIb4EwCpwRUu5U7m8RjjvW5lEwJhgbI/6K2dlYXmruaEFVlJcYX37T0cKD/wM8b8qw7cgeOl4W0xmiapb6Kd+I9SrOFyCysMb1g7NJUxrfJFkJ1MdknPf5ZePL2ibAl/hBPnWBskgDTq0VHVF3inP+fF9xjVu3gYLyuqHYnr4Qwp7rZZW+ibuz8ugS7CkV5RjFiYwtFsO2pohDF3+eyN9XnTUNqItjF9IHXKSu8jwDyDFZQWzKXbYyuIQPYRhRG6+6MRb/U7T4U/321BaNZMD6an4fpP2k33x8xqjG6U448k7pWw8ezIHOhh4DNNHVNly7ULI6TffNae1oWglJMoon+6MEzBcSDp4DbOwdPYzvwAAGLen7AGpW5gH+nzVwmiLbpxkTIXPVDzaf1Qq10Bg6kcXNkfkCL2tQdxkgJ0jpk4yE4X59Tk4zm3a51apl5cyGZ/RQFxAMqKRVd5PNbDlLJzZVuFx2UbLrzm8cFfTVykOKsi65mR9eP3SIe+KE5takOcVolroVGL43J8XmverUbBqMpfCxu3abTOar9Tbeqgnynj5CWFA4oPNJGCsaiAEv/Vi2ohXxax0xwvPjiJz+APwg9tf/RmPNXc0ILSAumPZkDnQw8BmmjqPtADUuIip9b/uOmcY7Xj6UXE953AgfR7u/FTHQW3U1gicUnfw21czHyja2UoDHSpm8eekJ7qKKNo1X84w4r+y22qr1RljyPYnRnCZl0U6K+JD4TABATQWDjTCG4ATxNG509zRPXBWcm22i0Sdz72oqqPzjmI8gs8y5fkc+t0tqz/0d0/EbOoZ4vpgdJKeZcxsnta8XKm9zS9u8AJFiRB6HoixJFdhoyZPJTl93wnLg7ErvZHTWcaAdXnbnEFsT2cZEFrjNMAF/2C5E4dfTKpvAaUlxflAibpiwSM5sAWDQOEBOP1ClXdE/w5tFd0TnMt/mdTMb5nEhwzP4aLmTJm8KlLvg8DyIr0navxpSjeCIvcJAnKhPdhG4c7+//9ohB4XeYqml/68lStCgEz8uZwGfmPmkodAuSfmIy+dk4ehNs80OCvxtPy+gNX/lQK2rxj14jL3ln28fphNWVbczrXt9O+csIHS0unq+GQ325EEHpLuc1OpTGpcuWAgq6/8628M30LVcbpSj3WluDQ8HO2nhtDFWfgc+pmjOv6pKDuaNOj6EI0lRK438WZHrLjjM68i3TsH2KbvxAhdssnx6O1wcjIpBSF6JUbbZd4vpB6bPcUZIZ+AbmiBwQfjx4AK6KzAWMTfqBAhXdH0VIGwROgMbd85qRBmULSpqi9/dXoSeoYLl1ckEE/yVm5RDa9qQyojM7UtgHHWYBHgIL6ZdMAt5GGwuosR+SlBPIDIuzQhrqBxxCRqz41KRP0+V7O4/IYdTcgbKyYC/jzLc+AyRMIRLK8+h5CIKi6tpevHUhpKssof3tjTwrYVLpBa3j8NVUO3IY0sFkcq9e42N/Z7QFCdfSXaal4kyqfuF112n5p9AzKh6Ufe1RYvVgN6O66CUKBKuenv1iBgyEWMJW9Y+mCcIqtRn1EAbumW4E41geT1n5jDpGJVEZRehVuQp235D9zI936nkx4vuSelo3RyNzYIAmpbSsz0YkUoD6HYE3l6fj6T8gH9DeEq58smFN5OSfuVWceQAZBF/QMO8VmfapUceMPL/E3RgD1TB2rD1nsJLUhSOKo6UVRZvUY/kMjg3wtZKP0NXZHACVPbpevhcMHgBGGNtlklxG9Ntx0csOFWer96Upql86MWJw1TT5tvup2+3fbnTO2apBEKgarN6Pr9EqzNmjOPfzNDfcUBhjUeZl7W/QtQh30agmr9jyfRlC6xBM4Zh5mAQdgi9vFuL9v3iBE7qpTt0TnsE34jgFNBAwX3dsuU8LA8mBRjdLt5pCZzJQZCpa70vuPtjkPPrxwN1BrZtWRpn4Dpk6fqIhHEdUa1QLIGjiIsHKufUHdWlMjDJ/jATL/I8cuFK8DzwqMQDLCBF1IrySNeeEf76QOoeuS9vt6lIjvKkmnUGw7HGhIesrzQ5SZXMfzFEMFllIC/IJ8F4u0r/hO5fqGMre3dEns+AfYz74Yvpj8hfrs8bXQjnT0GltoHWUY8c2U+mVTsf0dVEWGu+yDLYVWqVxYwxmI8flFggMBTSEiNiKoCVAZeK2sVWNSHNI0N/drx/OXZ/Xo3k/Rzal8AMeN2UzvWzs9nTIFMD3zoYFOirQ3zFaJvV7SOjgZMDBgSH3XGu7DPdb5WozsvneEmF7USnPS86UDd35GFWttyqAtXYk82yji9NP6Pt4EBCzB5rDCV1P6gKE/P5ElNeyha1bFQbm35/fFh1mKLJXyK7Em/skTgHditisqjy32Jp/rOUVdTWLd6dWED73sirQMp1fBYyJQJQLQkcnvGX868qOi58qeH3KOXGg3MpUnFztZuGiG1VkBmW+bzOnfKvb3u2xTbx4BgRk9RKyQGNtXUAJEjDiKaeAjKo46fXsZEF+MbYAgChFEzVA07zpgtqGEg4W8AAAAAAAAADavXemIuWCxfd0o1Xt93YcCvqFf3HU2enixWi5ZeJ11a5McC/kshKcH2512PTze4UWHh9SgZ65aOUWiu6+7cUbMBdQxd0ghzRJsXSIuxE4XcWexbQ92FUYFAyFciogx/N8ilkc8Z5sRKc4GmuBfyWQlOD7c67Hp5vcKLDw+pQM7l5haT6PCIBo1nTmAXTjiJhOToNd2syzTxp+L9/+a+mg+pyjb2cN3PE479aFXcRU8t/xpAMqMa0xeRc9MlAPGSNsdv0JRNtIg9JQQBNaLndjMhFQKKOJwwMzKiT4ZJMdMscjex+wXse3+cj4kQikmNEgQDyiZs84yJIu7S0L1RxcLcR8sTfC25RjL5EmSO2kV07JEQN1pIZ21sGW9ccm20DcjUfZNAXVohTWSe08VW/aM3H9m2pirOhsMwYhGGW6+EwFYO76jZ5vKH8CNOxvZwFwcS4JgReJFQffmhmlDlszHQLP6qeBKpKMARXo/3r9fgXOoJrmhK92CE7b/7uapwHFDfIoPmAj3ZEYWB9EyxdyVwB7nFHCgSgKQZwryIdqaHwpZ42sN3qiR74tCc4Tf1rzkFjf9d6ohHvBuhrBYbiF00qsnrhij8heEKDZbLC73IDXFSJuhQTmPFSv3Cu3RlYMnHkfxOQBVQpwN58g+wE8U8CVSUYAitiAi5btGXD+xn+LvIRjQ0rrC9XZgYJ33c+kPCXGAfLdzWoNu8FaGFOT9drAZTTImsQga3NzBGY2Y7Alq/vEZozIaBj+HgNkW1/w2F9LJExLJ44TjFDyNQ9IHtgT780DqZwXGENnsVil9O0AumLjm8GpkXRzya+rVkzUpcbh5kq1rnZNZrUhCB/MimonncVeWNWRq7cSFa9Q/jpkkPTRFKi5bxSSXtRDQLcrU7fnnm/5tZA0d0WnbOBtYI/3uVDgat1OevliKKVV9L3rMQtiSN4ds5i3HT0/XjBj5p5/v4fEiencHy+thorD8j/v0IsIT+VqfNuNeSnBnJv5hWex0Iu10BIQnT6OyVcScQVnxG7tOEcLGOyRTa2e1Udce2hNAyQE38diN4W94nTcadZh2EeNSeYA3j35skZsRXNwnimrbgQ4Cj2JJG6rfIENOSjy6KolT93p7JhGnOVkz22MW0cxLKpDStDyQJ2kg4IAZHGYXMm5BqybE29qTOpTTBCGXuE0R9Pek3h9P73Wbss6xzVn3LlI3EnZvkE5lZyVDeyqwgVQ7e6+JiDrguKc7rBPK8YZa6Vz7PgE8U8d8FqlgQ0XJudbISvaYcdgUCkCVjrNxk7q007bRNtdT4a5HFMBkoBfgw2e3qAuTtFp34QXMbTnioBcpEWF+JIwGRKBXLcO5kMMhyLtgBdRWkhNE59HeauwQMRQ7inYIU5zh16KfMkHg7JCS/5q2mKoHxZag/RAEeQGjQN7U37/2i9DtQsdH9xH1IG2+gtOL+A4pOGTIYu0i9oZeNr6kZUYmMBYLagWDnw65o3Wo9ECrKd2WHJZ/se9O+k8OuNKkQUvDfPD6MV2vo7rswrPCscBMSS2J4KTb87uIY67dgoO4bTZyZ447wHx9JzCl2yqiZXvvw7lCvniVrcNnlq0cCvmQkLHciogyhVH9UbTMCFwQCZx+TvbRgFaeyySk/jOED+yuIUefKZ29c6hf9AazoRkNBw7WOS3DzbYIz1i/FKyjKDo61rcahSF5CpTXCUqISiAGRkAjAnPs3LcyoKlj7pKagzuvYImPAbOJSbPvr4uSKK8popkxWEeUHDMzdUy1Kn/K8uvQi3b+yVP9YET+uiegskbDzH9sTj00231hVAJTWtTnK+6Uq4YdKqrpSS+5fBKme9sB94/fkOJrh3kOdVe18j+ClUlnNo2grXau0x5EdkbbgTGdhCwAki/RzWTZXahDo4HpZm/4pqycCI/uiG+XFCVbGPaws6L/ddB4ALsCHXVubjHAXKTBeD6ZgOXCb1M1x/04ed75NvGeSGddAlwoacY445G9ROdlo8ZBtsU5bYis4sTCHx4jLkfVHTbZ3vw5RA+ZkGdMbraiv9PLizTbWPnTROjtucngITpxrIq2ywEXrAGUg446RMc0tNe3mhiTBx6JonPo7zV2CBiDGFvezzRgiAo7STaJ0QS8UWYZczVsV84pWoRGyqt0ApWkhDhlCFHlC9et0AriySAZrJpGI/E91+9vKHaLnalX045X9GTCpIkwtORxZnXAlLL0dz9cr8XTeeY+euha4JA6KuH0csGOsGcdcdtPeGy3IsW9BRu+S84012+TllHXwD2JrjJisAdTD2A4tV6iJFzHKlwHZk4tvlPfYXHI2VIvfPid+reRW9bxf82/ZHdPgjC5YF0wk/ebOAvPnp2wg9exFk4KeBGlWdfdaVhFhiSTTTriBrUB8n5oQcvH+psWM/rsvnm2ypX3ufKr9zgzyjJ/+7F2SeduU/HsfJ+UfcrMTXrQtVK8sGvHYJFnNsTFF7zxqTAm6I8L6dXjsd1qVRQaPmL8iu9Givk+JGYmSgKn2PndidhAn2TFmExcl040Vn8uFYwksbEQHZ3y84fAje+VWxc5IXuEsYaLC7YntaZE0I7uMy6og9UXEAvBlYX9Di2DEiLG8638yU/v2tQECz8vQaOdOpQ57q7Gt1TUoZHqo7fibDIf8xuImzwtakhUm1hOCitV6HjIjHXiXJKFQwUNnCukQHAb+EGF7ftGic710Yt1z+OKJy1YuXryVW+xI/m4S2Bykh7KgBWcG/V+nO+XE9kxRZktnMLvIqM4DycsoRnb6ut9mgChUqmFnYuhJFwdxGcOBXXpAgd20J1ifnS1+rw+DLOoC6cr0aGuPWOrsj6OCX4oqit6K64GIR43608CNWlEmMNK2bH67afIYFBeslfvmb9zrVaCPQKhznp2s8XMQA8jqlg71Len5y1LoIQWKiPUdnURJ/sDyASyO4sZuaRTsnoKWt/d1/gCRBL5JsxJWuvGwnPOYsJomRrXVBZdthNoOfzSd6UO/q1yvoLYn4PEIDowRgXZ74XXRxhewVfoQvJhZ2CfJhVni9tLJnUPT2h2TqsiA3Uh2RdDPo+NsGwuz7U5H1bZNNG90O8c/pmIVLBt3elRjvkPVUbbUQZGIB10gmmDZZSMlhETtzhw+IVHS+xMg+6lOvrfOt8YjIlrMY/YGK21G0oWbLVZiyDsR0M9/99jowJL9XNfvt1IFfEgcb+sci64HHz9PgVLt5yGUlTdkm8QW+u/yfcAa+fw9b43+op24HlZ5sKQ77tCP01w8u0wc/08hH1tvg5dDcxjbom2pU7EVyJGJTQwYkvf6yM524hXbLOLZyLct4r2HZI0tvbgu6GDW8KfTwmweMK//2f2qzv77RhyOWil7X8Du/bEo1l+vwBn6oScwlySpN8WJHioqW11xAOoXlnqfSri52VJjs342KSKdrRcXTSjSJ9PNkBg8ArVbVHjQnBxqKWq7SLimak1cElD1WKK6fEqKJaGB8JIa08M+TLztAhV9HlmEUCN+wjOlePEOTv03rU3uMYSYuTn4wK7y+LPEL1gFlUajhLkuo3kHlAyqwNxPx0lSiCpJZHMz2yt3TyTXh26AQv+iPV11SsXR+FHabi7cGKCAO6222GwdJdkhJysBEcpN0b39kzxrC3lR8eJlIUBa7It7gn7ZsEA4VOg+iRTg2dqK38zkpp0GU4MMjcLBUPEupRgcRW/nRgKnumyzP8V40SN+wv5LDH2vIx6ucAxWBEFfCnFDCgJhOwD7KQ+efNiPVSXfDoGURnRqoT/jDhFUJm5vbt3ZDeLK4Iy3Ps0v33Gzh9h//cqaLJCYUWAFTMy8LZVC6OOjBaMBAR3fFfbceyf++WExeYdBRKJpny7ZnZa7UGZvDOdwqvlguNrWFAgjPGXCBLD1XhGsqMSs1UpIh3HW92tvMUuwBytvWgqN8MJxEL/8G3ItBq11Lxdot6LJ/lWyXEaYHjAYp9qtuNGWjCUeHnLvXlE/Lxza5NR7x56uyKgdiNZU/+GUfpU4yIp2oX62G2pcXDvfij3vY+ZzAtlXBgLvsN7C9i+vWfNjzCW327Wz9lSZ4fP0TY3giyRXb3aKiKQPdL3HzOH4E1BtWacyIYa8QmiYqnxjdt8DiM3qsPJpJAGdsllkDKJ9yT0w/talSwRgGAYDaw86mmBvJ+YwMlNhmaWS/pOlvqgqCED3tWW7UxX0odFLTI5/kC4ep9+TDB8rHluubBhujjV4CN16Jo6bI3ajpR9YqoJlFv9IGXjfjJXnn0lnT15uLCnDmO//XD9hccBGO7NS8UkErDdSuuNuDQK1cC1gO0c0f++vv1i/KxevpVaEuxcb/+ewxP1vsj14JHLSPKFcksqnlLcAxXLs6mQkcVjtpr1XDT0z+eMkVbV6RrpYp4DMYBk5jdrrT2KJ9KHLq8micm8pHQAUTbY617PEVjq8DHNi59NkCVeRTZyU88TXd0MN0/QlJsPi4u023hA1DLgGRMWI3jwXli2WWeZh9UghOUxuoQpfEteJ1O67qJorHdTF51HiTpTaW9CESaPph9lJD/X2gNPjwR/HEtLuN+L2rFxBmEF/45ABMvsXSdPO/wUuRFdsU0yK9goBGk6jtSq6VhwNt0pDqKPpAn6OqdoyYr0eI9VnswiN64v3WMDHkmNXXzwAK+ns6to1MXJ59+5EpaaHJqFu72UGLzVEee6SIxB3OY8zo3YpvrFpwCQ9gYdkc09R27QCTfn6Vd4fWQKQdh7z6Vii8MXYcJzOUJtKmZTgRFROFfcbvNxOvBDTR3F+ORJgOaSoAA4mjFRKypqfXKwAWeEz2L0aE/AAAAAAAAAhVduYC/67UqWhaHRqKGlt835gy2wxx13tT6/m6OjmJOiQFuCGNk/U7LQVfKT0/R3JeVVHl8qbklKi5e5U7zxLah1WHbhSJaP3vVzdvJoIdadsBTxzE+VEnqGUkbfOIL6ZWa5sWJhD4vuyMIYPVoEnxl3WIUXeJNM9wmNwNbMAV6BSWJhd7OQ6FoX/4k8UD/Qs5kfeBql4koMFjb/WOEH47taKPW4+s1dc/c1ZE/4ZdIFIPNd3X9Ezkn3pPJQmgNoMvK3LqaoRaq0K2JoX9qJHcHoIad1xS3LgaS6vXR/joWOiayZ+GTlsizbV32WWT3uSFqhPAxXgejgH6tA+CiU5d8CniXU+j7McpD9Pj0L705n4Mknc8gXsURAi7u4OLJ+ccRGHm3gY6cuggVu21qC4ucnGCE44zN1wa0S/3AHPzNIjXzOf6zAOM4EW6AmeRn94XfoAT1WlRzaerT5gTA8Ngzqbmanzkq/tEfFzkAi2aPa+eD6MG3EQOYKmBG4yvvdZ5I+hUCHlWs82ya4WfJnLCP07SV4D3qcfzJbQswE0wmx3IlBshBmA2eVyLW2NaF3tubWpMhGaVekQzAr9zHNxXNGi0j+vT9YU/LXUWDxT6GwJc6ganvjp/QdRcFL00bkT/GeAAcYKb/AoLhBYNY+jf01ID4IizS7lvvlGdqVIoAGZHbYN7fHsrPLQ3IXkiJXLB9GD6xdfeFP0gh3q6TV95VefEWFnFkj0oEwVKOapyeALHU4ojoBszZzKSYsMz73riqRJ/aeDrJG/bzqYr/1CZy1odiNVNENt6XJYln1x0FtcDpM4TyJb3ZUo+298aYXjWmwXxLMEsgMa0p75KW6XNnoQ39eDiS7q5gu4J4ZqXkT42MONQLIK+dZ00lEdgA1bPtSQamO9Qt3i31e4A6WhCqwvjGic5+xR8lmOsIhjz1LLF7IwK+TssJsfZYoOblP0qFAARfJcsKpabvhLmRXkwDSglO+KiZAhysAHmcs9sWMzrCCqhWZVDexz9hS1mk3GkUv53G5DEi//jkvxCgNYygUb0Picib7vos9vZubHDtA6JnqdEfjhzsAmG5sfv5TATxwjWUxLLjcXrWhoqmO3x4unlUi5UNc8PiYDoMwdUDNgGKKRx4C1/mMJVrIIUHGfpA0mDiaeZxeAI4djemPnsffE17uT/b9qdROHr3dAxb46OAIIUtkEwynHTLXHFvv8NCmkVwipLgzT0ktQYH5RQIA+YYdsEJad+115hc/vNcDi6vHxLB6yLaDkw5KM/DUgo7JPlMwcvlL/Wa/cBhHgwaSCbmWUUpLJoCOgnOHJZMT913FVZr8LhkAyKsuQl4twUyi4zxFAGhi4u1biRjOGpg4yV0QgTc7ihSyvh4x0yBNON9TBl8URMiJOgJX+Gcs0ER4ILmwZSqxHL5jCuj9IdDMf4bW2KwegjGYOSuq0nMsLvVHthwUpL9rYpQab+68BTa+BTCRw+YAcvGAtg/hCDCFUqEr9bELr0P+u+9u7iHO9U9TxrNZELzDVrmJ53vGvznLkejjwtqmmlyoB57KfaI5PR9RAJfLQDScY72aHzEJOzAiIFAB2cT/8q6IDxBRqVIh9/Ilpzqx3/7LaeLB5xmhM6V7wP6biKIQnQZJ8gNPSRcUuqfe5/nVJDvJIs4pbW50yrr13gL+2MXu1BpQszIQEAhI9mJiS+RFpc1QW7EH7++0Vw2pqwW+2GqGY1xh5yfn1S79Eil1BasrkakGJI+yj+Xqvz3YF13V2DJKvLB68GUyT7c/ddxVWa85MDffhO/fJsbbM9+ZfMgSzddfHvd3NfBC4ZAMir8zKXeVMxvP+SweErkw0mPLY8nTJ3GorlXoupurdHVr8c9f9NRmt9Xzou9Ue2HEf7j8EaM4XUbdm1n56+bcbpIv6mDc6f5QKUAiKYw1b19jueyyW3UMjGdQljaQb/ZGCNjaf8zeHoCPRu8LOYRPdDdv7Tw9sv49wcqimd1TGxu3aeEXcRTcnYXdPweudlRfSSYfwtg1qNA1C1wS8yzFdGM00xcW8y4jLwJFRaXBCIBr4RB3Uyt5aqtzxQ6XmVcczR5E7SrFedYEekqs0MolsTpzhpDWbIqX/vxt19xUE33n4ChEoGpDRz5WSffPLtkD/xmG5n/8mIo6T0apjK4QLWrkdIDXWhYLWLfNpeO/Q0+zWKZhRn3q3EszsYpObT/YipN9VUvpv398FxrrjBzJd3cY9cpGq/9TCP3eK/1Cx4T9R7CdtP9L4n225YB1pIdVYY3lA9AmB0VaRs42vuNusoiA+KwN3RFSeGW2fQVoLCvBN0YThsKruQDANiDkAw1m2ndIgsMn3NGJkX7s4UEMbrIXDOxOmAAPiDwiNmxJb0erdioDpXyABTupLKrKDAE/xZ0f91m7FQ4c2it7Q//eZDlmjJCqOzuM+1XWieM/yp3DWQo7k0s/h0jJZ6kem8tH8X6nmOkZvu5dCo1EuMQ52FnMiWgxZLDqMfcKrF4TspQeGPhSAtdf7O0kCYeJuZokitvJCUs3UmhmfC1yXlEWyKdtyl4hsTvfPOKMAOk3YmcBrVPOag55Kbj2ybSBtJcb8FRdLBHXcLM6VWIOlooemYNAOzfY8qw7FsfuqLKey4K2n9s3jREgQMxIRBawd1DaAwpKFb1yqrEbOmo51tP/bSdL7ZtEoIj1Ut1TdsjwBmW/0C/MUCCazeNNE/ZpncAy5U0fc2lF4dO74cReB8SBQANHIPaJcg+GcmHDL2KeZS5pZEI6faXQ5+mTU0M5qIDXJ3ILrB4gPNCS2Nwx08o4V6FmdIZ/QXrMwNOROflxUtogb/S7zbzmrhahudLHwnUs+x7AggIu9m4J2asCksjt5UdDVBpWFGydZ6oWbX6lEAlS9boWXl4fKXjnjoCRtL0/J9hDJmi28bmPQxkjDgIjnoOk9qzAeES5MOe5kkJeYndtfyPsz5uX7vMz27Atrc6ZV167wGEw38bLwsP/3P5/TpFbjlLqEKgV4JujRCOyYaScN18QKE+b1xgtMRPor2eKIv+Cdv2jNw9mDVJeOKAUJn6tEIo4rZ4EJ25Yq12cfuJrZGa94McL0sfrna7mMIwf9crPebAtIYEynTV/IX9wDBXO1geONj7kWXwlvrtTt/JTbJHska9RGuMM9ffSfh2hTmqQqsXceKUqXE8m00rusTvbCXhH7dTaHOfkrQf891bRvqU8oCyYH8+oJCju+JT7syXqtBI3uqzZmLtHDQ+ykn11GZiJYFESxadVuqBoWDNwD6SQEeEGdG1eKpGjayjNBauhHRgo9MCaDdzHQWodLsTQ27Nre8KKK9AEw+fw2wfaJEeH/S2yfiSeeaOJGjxlgSSW5nRLQbYggESYPeFyV0V2+xXLKvW231XdcE946HfckWhpJnLw4/1c7bxJ4XJcfT8YdzdJXhWv5aOQSKT6fKUGWAMQ7ORU9/+hIn0L3ktMc1UD4jaAurRCmsk+xh43MvBE+i9/tTkUwFFZ621NEX4jF6j0zfxVzIIq8DPTDaR0rU5Fyn2qyoCAWG76rbcdDWK7vhEVvFno4abg3FK3CB0LmLF6fS+dLRpxjsxuDPiZBCiBiD5x4XyunXSbqngzU3OJ3imcOcJ06T2gJhQ/jh9ZvQH/kRxu0CGdvaQ9i2LuUNM+o1gbVf8eEfpICicepJEGqZGRf7quihEPzQcMHsxfoCqYO68uZiKWi3M+6JnacFfu7FPCVa9FPo/n45RcpZXokCmt1uAG821J1acNAp0nn6ROsaLkCH5OmYXKvLAhlRY70JJnimkQ5e+svbO6Cb2Rcwll9zXYmeEBuuRjKKTXtxPGHg6MlnP5/+igMbt5msnnXTZPTIj9F9azyoVl6VU4+zOUD0K6c5/k51mevK1Fb6JZWsp6BabkAlpo0Snio5hrZKSB3YeJZct4cSoDxXJvkQr3sxj8lYhUZ5kja5/2s9EMyJ13sIoFpHUlwmn0BYUKDxt7OxGik3XOHie+N0YIHe8PHmG/U0ga2LUoUYjLHwOK0ZF2tRYVyiUV87U8uBX+rTttieKUTnDOwFzRN7Qh3GWGs6JkRm3gg8W2VgJjvapnJoSwG7vth3z5LLDG9grj5KxfwX8ONkMYlQGGRA6QIv96ptZYAmGVB+HunE8fgSeTrewIrK+VoI4INckcIQY/P+QiDrgL9cg1GxwRa9dH+sQuJ46DMiFHleBn9ULUzzcpfE5t3dY+Nkp9QVo0Z5s/lihuwVP+6A5yl26OLgIM5fr/ztUX+SOsQHBQMOHpaPbiITZIhuUJ3F7nyxHMNbJSQO7DxLLlxKCYBwws0cZbP/BgAesv/EivT9P2o9RW1p3fuQbZY5B+fZkdS4CXfwpFXADITVD+SFONWhctcVzVtSG8guUCG0NxOPT1Ty8HgRkEAmtGeF0KIIA4Kf3CGk1ODqZ6VnUd6QToHagg672V3g+pfJNzH3C1fhMpKK27O+OGPLI8Y/hIE9V4qtC1zIK9MbVjbusmKvVPId4cSsmjfa8jaYXSBW8GSVEGvGnEaG4Zenp+FzUChw6AtmJg4QQ10RZQ7dMRLknzIZ60b0RJHKqOprGnFLJeYLlNTo0z3V8dPnuFdeKV33cEDacgG9MUd/qCs0g+2xRxdRoayx23TQBa6diCLtGLhOISp8Z5zF3AWhSAeossQY7luKRzqOYkVufKFGbcke9Fci6w0Bdavf3f1WDwNC9htnevQjMjtjACdHN0kFdFxIy05CNtD0MPvRK39dizLjEFLHx8YrBgn2BFH6T66Q17o2A1qq547acm+stWVMKx77/G3EObhv87gThHdrmC8ZWzHtfOaQF4lbIb8GwwIOy7kFqJlHodgblFzzEWy1IZYqiHSTTB3oduXeSO/qOzb0i8rdlWJm3LO5xflTkaKMlm6ZPexhQqFNtYpOiQAiVi60ChMcEEysna9sM1OTgQyI7+bZD7rqv88Yv+Ou9fVuAk5+kQ2wGFQSxjGh7o7skULQ/Y0S4m5xpSvtJM1PzJ4ReP2OmTpmGItQ7a3sspqEaEXAn1m8qkXxvUjftkUMhAXsstZqOeRq/oKDDrLUraXr2Wc86Ff3MTSoYasvjGLf+3jVliKGGEy0SR5EAc6PJk7u1BuXEp/f8kgGU6o+lELuRrduOeHaT9gMlHzuvBfOvp0r3tq5jELHd+ISjHr0mf3X7XfQrlJ8c3Jd/9JkI1H0eIVXd2mWeuw7B+ZAgMJrPKxDfE9XZBc5AO9IlaJp6Nk13PiMuFBhCxk1LoKKYeenzqDZ93Vn6HL7BHRDp3gIeCva2jpzhWG5gexmwr90HZ2NMdPPLx7UWd/9yxmxfUkZVhbQIyQg7pLB4t6A+n3qOfqCpcMpBT4aP85yndusIrCko5Rav6utJsAn7XjvT50uFGXDzPc0DW3k4qOI+gS2njbmPWl9wPXCrQaCC/HYlAEmr9lkCoNCfknbj6JVuf1XQCslOG9L6C410Q2EuwrrlvxpuCEyjEwDzPu2/XyRqsMtD64yUaQws27SGXHQoT9Kx06ygRUijPQLUmRsxqz/YCR0c79bybfHysF9RtGtICbn9aoxbvkiyenqqzEAyq5gR8H2HqJNTyNoFMLNyY02LmE3Mb+GpOT/L+VGhXCB7HAdPVuXRTsHjm/JWqaQ+4vLGir4ibkwH0lMA6wzkWa/yaZWItn1yHRaXO1XNpaF2aFiZKp27xh/rouLdLnQuWu4yPPOh15Ezp8Y9VKKYGahxerw1BGcc7ejBHcpSE+RahkXfXa9apaTZAUlh8RXJGAldIsXKIEKmkU51gx690+Lj4/EgKq56aJVPEne8yMu8tIUFYyPWHrFkGALgE1LoPUu4EJHxTSCfYrczYWB+gC5rRxfwMQj9cmgKAatf2CFdFlb1yQAEscFTIUiU1P3KwHUyaJqGXgiYCHWeEy7t4o6e4usDR3ibkHwMlFnViJ8Z49gST9xJNK6NI0quoI6GbYlW8Cb8l2fgrAmnuTVuCp+fMadHcjMA7qsXH+wEWhEhhq/7moo+21YEV81+HjWMzmhIaicFEoSbpyuoNlav9pCTkADvsY7ncGQ5ce9r4BU76itvVRvZwp2+F5YNJIwI9d56W7dHAE8+dmSTMCsk+IRGshr357AlsjrVrSuNIRxI1MElnxnxZ2z5gaHTMcm2ViUiUW5TNPHk0W9KMNH1lrkQhXY5jisyrjtq6WEJqz8kk0LB2XPnrA+9qyp8QQVuFEnAXDzyx4LWqD4O0hH8qt5cyMg5pZUFHGeKMHJj27YWHjLtncLqWtJvbiosokDWx0LqeHpFZsx1xVnYWnQqjJ2qUrdfmziA2uzRQ2Z0AYm6Tk6dwsQO52grVczEujQmRDDvLfeHfpBnMQycXLt2ZznjaCs9uj0RVErJAZPy+8nXVmoObrgDBFaeV284TpdFa2AMY0y6JUyxk0o4fXlsvGgAAAAAAAACt7gdXXW9wZKLn7dpjdsng2bdwzQBuJ9/aveu7RO8B3eYJB1WJJ95kQqiCtq4zRZAvTHAi0hqEwXzpqtZKD4nsUmy8Pe3wr4PgQSDn5qTKZbe203q5S7Yk+bMj7wzRdYxUJisoB9QiPUwrHQdZfaGXja+F2vosxCpOUrIkPsXCJZQVU8hfbqF/GWEoxj8gNflvaUTmYilotRAanJXR00RC8dmJKtwnSHF/7IYwWi8mFcSHR9RuGus4cdSPHdLUM+dkY6TyQcZLYVFnJ5fTDNbDXHD1gdIoUl6EMxXFFdTNBSXH/QnnROuGonZENVcB1aSsIOBFpDUJgab2+8UZBaIX+wCn+EuZnbhhqya8SRFXruHMCC0Us+XES79+ua1rlpkr4N9OHO0qUaPpFkG1ti3UY48UXep3IByHh4xoHHgb6i/N0ozAc9uLocBOmWiU0vwXXuZVmu7jMC8Sb2Tw/6llS2gXglnElcHZwoIY06uK+Iye1lo8QXQJ1sxv8kqSbwqMltw7N3cCAsk//pWs4oO45RV9RQmrD0tEdacOvW12Eu5glG2sYiU6kBMPKulcee6Kmh9MrXWkMiSJCkdA+e/Hztwx2oAz+OVFu1HkCCbhF9dlUXeUr1bhSMFRm5nBVm8PVhDPfwsCIGm/RxkpjPe3vMdRF3AJvPyQevG4O4L4K8P/tKMHT76vOhu5B1adPhpa4RelONg/SaIudZdPACHfdJoPWGxzfoC3Y2Rm8prZcAlBY4P6GReRCsnEv1qJoH+wLEPO+dVqrIldLOlg+nDNmdnSKmR/kpFnEDqmB+wRFijD2NtGw1YrKIzE9lMiq/LID30aJ3jJ6T0dmE/3XqqQuKOjQ6UOZqbtIauE9exzcoMDHFXbexs74MDju2l+3s5CG/ZdGd7XlTgDMJLgeAaLC1tD8q/pWhNE+8U1Fhc8TODaXQvzP8H/9ufGsjqzie2BgKW72dQZs2vBTUipwWWMTJEq6jRFnFNz+wxUVfLb7vTsSiXK1NUCJARg3HkZqEIj389aagye++PBwDjePEq2pxPHIR48v+s+vy+sRqpAFmoaNmg330ej/SWKGlnoBVx63HtZtzMIxjsuUh9rTePTq2IEvQLHkVXG4eooG6kZuBrHVJwxdsDu2s4TGpd+WcdXMGD1scxrjgwdI7EcIp+1jrLpsuAfYytxz/NpPoK28DoZ5lJDuVtjB6SyiA66JHRVjEjgR2lNfB9PVHbyl+Z75Cfv5djePVMWElqBW7mAnjTJayTQX/17JuAS0MWeyS4rBucT6KYAd6stlCqi9pqjq3Wd/VUWbrggp0RV6lbyaCY13V0Uql3gSN2z12Z1H8Yg3GtxOKH0nywo71kyMBEAQO65XwL5LkKfLCLR+ozjkGDWyz9QBoGY+5dkjB3TWql8ILyB0lsuwD4XDGpssvpusyAM/eKThlF0NWj2qqfxkEXRD3zC8khM9pwSTyp0VYAwMiO7MmZEc3rBzqoCdogJ65fTZudBP92VuiIDtLBtBCxsl5Or2z5dXHNTPmGXYYRhicipA2dOORhQ3lWBSP4v28ohBFiXjk1GYDkN1bDF0dff8XUoy37butQV5ongqtL62gkGQroMVwU6YfAZzY978qdTikPkV9o3FCMv8GAtqTiLT0DuMhMS6xZNMfcUUQfF5+0eAvtosSBXZ801iv53cQxBiwRe7WdKj83UED4/DbyPl8pmDN5z9qd59cxkd1uO9nUsYoqNEAsuBZ8fdbrsjW+zMkrt9PCVkMECFKNA0XZqc4CMH3qCle7mpixvh8nFLB+305tT5J3lQU8uO9xWSLSZP8gzi961GFvJjBwYZSGBHMNfKgWZSgw7uxBk17f7AudMK8iGmN5sc3IK0ZJiRglhdqhJR3E9zuSLAyzZCg525hLyHAq8uCTEgnQOhfeQJ6W3/kKb+fzQ+9wf9ZaTKjFjZVItFVEji/QMhFt7ne+SqChu/P/z66Nwb9KfykkB7chq5chiDOEsYZmN2DJFTDhxaRXxoFiNe5LNxLLdDxZludwz+ntD6w36dPfxJ4eOHzE9MFMzYgeswbBWGhc24GQ2dmJFiNmpOaOGMzBRIM0PwbCAVJ5rHQGBBdGCNFQaSz6MXNLJ3uKnS19oHL5rpS1yaczOYN8GUsDFdiRQdHYNGOcwOUYZX+sbrJOQPubeFON5ZEuergCwKOt+PxYSKcYpO7I3wZWT02xecVk+gUv6Re0MvG2EFki94eMVY1kLYEo8GFbHCKoW7HIiRVjYWUQhji4smxmByCUBeo1dIcp6Lhm4Pkfd6SfbpGuOMiJU2zSNgIRHg+JQHOsgXOqTFkfwbJF6tfAeBXHsTsjrFB+VuhFpoJ5jvfvm9bNZo0mr3qUMBMZ5Pz8nwM+73P0iZ56BN7eRN6N7OVoeD4ynasHCVrHn96fMTLSm+XX6Hp8sBX12pdXislc6R32IrUvmC+x5ZTpYnnD026EUVTrL+KuMdCoai0LRLF4GiMpTRccqgGXDLpvfBw1Z4ow9TQuTXyx6eTKLtKu5IXwdrcfpzHAuMg6uGz06ALNGZeOGRs4Gjwf9z8hkHQzJ+ssFwTbbP2tq0tvsnBA2vqTYjjzGxj4jWD7J/32D9q/wF+MyErBS3Fz2Lu8Vt9kE3l2+/NeVwY1HIWp/qbdxNvnVJiyQG6cOZCH347C/FKLjfily6aPynSuDGFPcXoZE4AkxzlFnihiewMd508WKZKZGYmB0nnIisxLhF7R67ZmI40p56eUhcreDdXNg3oLH7qsn/D7FxkOBRvTF6S4+ZXARsiIApFcM3Dw8U8WzXlY8B8+anD3e+MiITkMwfNFB+RlCOmbVdHIzleFzk28Y1LP+CbBqSuCJuKa8U9gw/ycDchMVUOrexYxW0Svvlw6fmr5Sq+SUO87D5AGmyW30fY5dv0Nl8+bygJ5Cjlxkx65MY9GBBMw99ATYtZ9UAvmoKlRw3j7Ga03qRAp7VWNdYZH3IU5kkEFEeerneDjyS42XpgwzxqYBxSFzdUAyUWyqsTSMPke6DbAEgWB077ngpMe0jsShxAd7b8x3tVo+uAFcgxLdjcUXK25cWlZN9op8d/VQGnJfNttlVEu2YIG3Cfenz+scdZ52LtPTlb0ezhQQyk658F9luAHp56qZBe+ImhmmkE6nyjfC0wen0y35pQLvOjZGAMKClrEhrmui7GDQEmIbI5aX2LpojHDWjHTT00Ajk7Qfj1zUZKpwaCbJwokdjXlgfCXW4B6taZ1AM5le2BOl5dwuXpal1aqGhpTjGFq+Aiedx/YDYp8Ye8T3RGW1/qr0MoTXDhKp4QZnwZ9Zy1JWBpC/p6ssIdrivXS/6zm7ecriVqEB3YDHrxGJHiPKkUzRzYpef0c0X0NiK2tN6kQGJCAFV8zzZKlSUMBe6B3AVkDRc09xehDP2dw5K7x3PYtfYvdD4tf6tY29rRyb1z9ukUQFPq4qkBP/So80nGbQCfGg9vWWwP4uQwo+1oNKbkDRoq0EVKXzAQRiVJTWvWXon6hPHvO/dl5vuyS+WLr9QQuxJo2uiIoaYeeJgpRVnZVIjhTudWRG9gPdPKpLbvuZXaU9ERQAKMvnVftuVcsW46Cj/Q4CJSaLDvGXPOsgsV015xVWrtN1UGoa8GgdmLvjvlo6hRf4c8sBt8LdXux++23NaMSocPqAOe79LbBcihLWEje7ZNhXoJdsDlnp7JacZZ/1xwVKDyEPKkliPjgUvPNmp9+ofhmpv5YgGmVBFyPTbVDklh0LDRussNK8eQ2d5TOTLCNJvb80KPN8sUZ5JnomEdQjkntUPUqgI18tkE9Slxq0P2OP0nwyTd1xAi1xgC62MV1VuJJ5lsM6APQGBY2jPKK5hNnDawcvXktYhw0d0c+R0BoLxbrgJqc8twsEwJIClcAL8ZyOBU0pSKXNE5MuEfonde0bNMZ+GUd3xTsC2Ko80THfH92tH45qJIArlX0am5763kFHqWZF6jdAfPM2e3vDRCg0cyYIXfDqbU/QIDTRDJPl0FaDjnb2MZlxAq0VBF33zDkfTDPMk81rxe5BDUarkfHdvYjdGd17qIW6DF3muLo17O7DcGgpaedgA0aS5b+LWiVG23AOVXfeZYEwl1W0w8efTxSL192nvHLDOoVuNLjB9FJp80LobszCTS7SHau/T9SzZ27z58DQ7XJUt525xBbE9nGRBa4zTABf9guROHX1H5NRuhjCHceNvvZosJaVlHH3jREgXR2SNZPQX3CziAM5RqDCI+mgh4lxUI78Mr/R0nUUNGPjXuMyqgIigUt3K344vWT0DKwPso0weaRSf4PAUsskrrSCjqJfECYnILlgmzqcSHiPfb5IHbaA7g/mGfSw46X73dHUV1JZlNc5KepvOcZA2INKSWfD3EyIB0jElxhMYI6H5j4D/mPDJAxBbSP3k3AZdAe5a29LCFYzuB/cdc5z3LC7CTUcCBWIoXEVNcGJO3Tqy+mbjXojBWdAgrSpejUjSyvOLo41CpANiR1+1xQvNExAszaHZGzbXgtYKQB9F/N1vs/rgV0IGd6nuJiFRt8ufPN8kbxPiFuG9kju0hJONA1bUpTPWsVet5NFfhQ55ifrvRtduOemMDJpu2xyjeoIinHqkNW7TN9slC/+BB2q+DsYjBZDMj2vBeFQQAX+QosVW9Y+mCcIqtRplkbEkaA+oajem6/LETpwMbX/YMUiWIx/z0PGF+mTSRpLIe/naxz7TH89xeZDGZRpLjZeFSs628xVif/ZypcqFV7skwd9RPrh/ZVDmhCrgsMo/48OktdIa7sHN1c8fWLtPNAyAc2P8X/rS+W99Mhjxixg7Vh6z2ElWZAkWdJaLRSpP3830HcZwvA6k1O328PTt9DBjVHw+o8aIXL0v15MLuZf+WLOQwEl4CJa0HRiyqt8tFp3lByWIC62pJKGtdy5BX92x1vijmIm6D1d36OK/AvugbonKia96k/5oHNrXBbmuUK1S1MqKZuDoCKsXnqIxlwf2CyrclDIGembA0f2MTOWce3NS2cJ1gfKOUdOsfMJmMoFSwi+4hoPPoM8mrT7zEtkSa6gShu35QldsI5vsqxEn1cl/V67PQ7R1bz+Qcfc5VS54CgrchlchphWdDKv/0eZmDz7T6iTm7gL1Q2HTR07dAryneLWY1JHzhq0nyVn817VE77R1iNcwUrzNx4RFHwyzUleRontm8hXfP6Mbg/TO0xMeETo1trC9XJY3faXqT3L0Shtb2F+vvwVljLotq63BkpR3v5FBXbfMs0iqznI70YoryFUhuzve8XlHRHPCHBMthVSCAIocFInFH636jme5h7lw0fvKXjqlJJoh78ZaCij4TKWLO411r1W52XSIlTO/JmX6iDsKMmdooZMrmx3QdkVIWW1oF7wBvgdEsOl2nNkWO7QbmUqTi52syB48KgJeuTd7j65QJUCiw59XW05HRcW9FeL7PbaGwRcjXW/v5XmUspXQuo7lEkhe3I59bbGyjQQViF8wRGSUoIGRjkvvh0U6FYyjuFVnmYY0JYX3HGpouyXHUGiUOVyDffwGY/LBk+Ju8/qvAVx3oO/Uqs1LOhkHctdpfTUx66ffxJAjNtZcU1kMzExqmq5mZxtR1aAJWH9PqdQ8FY4ZPfFZYIpVlJAJ58l7yQ8GJb8Erjgv7G/I5T9oZBPIBwB6tZfYQIDIBX/XoABNxdp5peaaeayfaE3TmXFbCtk+0JunMuK2FbJ9oTNMxXppyAA96x7F6PSqAAAAAAAAAWaOlb1Xe8Axva+pShTNZxd6vsGBRwbLE5waF813vUdlLMZ/57pKb80lSQtRpkG9SLBo3BkQcEkI7TkA87Q9IYdmMq2P/LmXftJJruHhjpfO35eEtJbKCRZzbExRe9AwZSLR614IHKCfmgEWpbVl0Vnrj8P7/aEoObZJB7IXPQwR3b2hBopO9PzL8vkg68f1rZ42sLun0NW0I36QvzsCJtwSb1wfixf5NAJ0lv/WNHHbmsx83Sr3IUrELMTKMqIPn3GAxmvYl8z3SnVPsT2ujD+dnBv2djbUHAXHywaTgCBoVpdfFRTJx3olnvgpIdXMqfLXA6vZlNTNDEmycZXhhpKnmfutzxVjk7jfB3XehfJDsu7RSn7LRu1xRfKorap7mG6JEV6TAw7XAMpso7alp60zLRDP1rU0ezxDxlJSBKWAZgtBv2FyqpqSOGhC6BMAZNBKy9boEwLSGbpUhWE9wF5qClmIVcX1c47MqAeetzKvapyUQ7+hy8NdfLrG6LteNXUkybwfrus6mh3SvZIzIuOAPWYOUXtXO9Jxkd20ixDa2CwMi4iOCXsumzABCXUN6TN5mDitcCjDPWIhgD8BXqbb43gi3MFjrFsYCkv/58F5uhyvoxf8gf6csDYwjL/w4cCyM92fJ1krkEvWw5Pw+EnV5g+kEIaQCCLFQXg77fW6vVx782xlY0nPTnVJJQP57B26DHWBeiCyOyTnv/83bfGGN96WHoYO4Z2NIRFpcwiDp0zQf5yx/1llGxyuFk/Uuwj427akrvdavKFI3jaKdcOhjRnL+HTbWEQWMMdmsyRVmpNlEwBj/o+ayY31/66MKS76RoDrQoEnoobCVj+PPUYnx39vwhd8yv3oBn9kA6sFmGMOjciCRDOV2ZJOLxY4LPy5ZOeXE+oedPVY9h3KlS6+PP9WLQBGrd7x9AAQIN0XQKhsIKeTi0Efm+WHP9eZV18wU3Y9Q6Tn5mfg/oi2WiJm9Jp1Xig4uIYtRTrVJHRYpGUKeS2zaRrX9BmUot0Yz10XKGhBnWTHGb3omzpCHuodQiJHa4xeqLDMH2Xbal9MI1DL5BH3bJGrF7CFVVfLJzPC9Bf8szAGWh2UKiLs7oCAdqXeBFIOqVB1/5sYbC5c+CsXheiOcLAQG1QLZugqRKJVrC+UJor1eAx7KsxrAQSK5HLuu+QVju51+HFd3NW2wKNlHxHCRafPhqwsEC9aOnYY9cQx16Tr5EZOHzr7UA+oAxSIaGrJos6gVzT1cq4VreBpQQJLXAFL2Uax+4GtNHxkyNImUaUPqUDSxRHX8KJC3T/5RECeZ15hZ9kML0osuSOg/pEZo2i7QNJbQVB1TtWra1Z1JQQnHrghy0Ba1Z2TEoFSuffaXmSnROmHv3Y/Y3KFu4NPctH8aOfOFhM5P2EhiZQPGmyR72gQRyZ6Ui+AokOwNFSu5Wf+DOhoEuFEqqpYgtftHbs3pwCRWqfOrclzzdYWHjvK53FMI2++UpYI2aqRqJM4uyvx68hDftgx3bCtAamQ6bPf+spExvPzGS5zL9IOgqq2WQpeDqGQsin7Z6yUXFOKemxNb1FvO1nky6tZo1jRGVDMJejV/eRO+QG95jfv5YnXCS173rMuD3QH7WQTEl+EG4niql04KVJA6pfXcK03txP/Mp/l6qbzScUYcjyh/XErZ458jPKefJtOzkAWEKv+m4jIfErEmrdfqc7IAH/xnzoF3Xa2OYer2mYlSYQg57GRhQ7o5Y/2Dib+NIn45z3V2bezebFYjIwpfdyeWSxMiONIcaRoPbmlFyzewAA31sgTkWd0EPsQwIIfI2ZTVDAoBl4oUPcsO16N7J8C11YY+QaqWJHMvb3TWetGVmLLBkaV/IFaB3ytNggEGafCItJiOha4kgRbj5W3Z7DQM9DoO5syoFwWhMTvj/SJeWBOMKxpgf7sDCwwSN/JP7O+KWHFC7JhLAn6lE5XekK85bYnfNiT+EpUlGl5p5SM3suC8mGDvaXJAEL+s2ZRJX9MoAloes95kiK6zo/zZcQCsPg8aixwoXrpjdOc5+cpYdnPD9CqIaR6Dg9SV0nlcNKpcSumJ8HitkPHXujrAYw/0cs2No+sDHpF2piRhhqL/437ex3XeaqqVG/f9ItACi7bYFUmTA54CJyJFNcPG8n66kzLwxXmc8TP/0CspJYdvVMsP/e4/le9UCYuUA6zzj52al3YiqnxkBGIvUUswmkfHa2J3zYk/hKVJP+WKU3L6xNCHEX6BDY5Pn5TBxEPqa7MYfUYMRIV/P1ycK5AEcPKnQFF1ipF3DmfLAOgUxhxWV7gtCYnd17h7xOh1y43RfAp6KJ+FS32OVh57hlcVUIwVHX4dRLLSoFk6/uXzMDJwUuuegvhX/mLnY2zH1Qc+WlvYj2PWgnENb11gpLtwwmOWDxpCxc6rhL/SbWEiECVOKFsnGcW/pwwQkqq6ACTU8Asy87fxftgx3bC+9hPJUrohw+xPBx6qgmx0AwI5t0euhThsM0j5FrT/uKmejaL+mF8Zo6PA1bWhDJb/e8kOly+WDwHrqtu+aHN2RheaMhjcSiL7UnaSuL6QAczxwRTihcZWa7oYvBJ+Vz5pKcX2wyb1tRgcJWHZAZKcEHgUy14sZSrE3oiFuqJCZGwA9dQ2AE/wF/G9nSftDTXU5leUaQjDIOfrgfR2w3cs9tLHxnyT8JBq2bsBnt31GRv7ECxUGGuhAbz5SBJ/yOhNPGUebccNVd0+vPLrom6ExMFXvB9TIWd2q02OqUMX/L3cZDYsID8L+b6rXAvAxcd4erkxCgsMxZ2iWbb0MpERNzA1cDFh4dV/TGLwZWdqXmy8ekHW9nO0s0D6mEVE7FnQQaz5h10+16dSF0ezOt45jluTn7MbKiKNH2mOISfgYJU1zAhVu5kXiI/T77SbCFrKr0OZi7+Bbn60imxdfJwRbFIdyWag6SB7/nL8/bfdqb9mspva80n82UCjrot+19RjpasBUPRJ4mLMtEAYkDm0KdizsU1O55ZLr6L0eeTQzJoJextpYkyceeG62hPqP05yng6tPEFFvRchudP8hQLT6otmON7b7LMlqwLCvA/rb0+0Fjf1/iTU5KwLVlrdVLruoEh4hbhqfliG6R/HGbr44olVGdbhgtrFKSNs+dAyIouFm7uNOa01PF2C3v8G5JL6wiwxJERB8gg1CJtTWmJylYS2zQ3+RY14ujj4lvMr+k936Ro9gMbBEQJ//VJm5kbbVRXo60ZLQQTX7QtznvIdaZTwKW1jpoWS4HQ018AWASWy6AAGq+3HOBdOxZpJtmmHDqNg5EAoOXjAaRLwH21vJxqL5Lba72x/BFipgt6HN/MtIK+MYOVWhcR1whH9uxXc+ibHBkHJLlXOgnRoL/zqEe97lJBfXwLd4ldsDQ8dnzGFvxYULiDaz8GxCh1odqJ5TLWpS5t/zRP6pyuSO50+wBmcU+XVLeY+t2l9ceEb+G6ChXMKKo6+uqbOlzbKR0+hTvhRnZCeBhOdU8pkzpB2hG2Kn62cO81gfyvBHIJbBhi2VVCIjGeLODFuoxvDvyvr1LAOGVUgvsZs4E7FnM2LhnPq1a3gaxywrVCR89GIPk5OKFcZUxgsv0ZdoVPeH8gmFozmz4NlpjJ9ecSUqEjWRvr0dhwJ4fdzXFdvS4IJIWivArbmZw/pVnq31T/HPYEiAYZI9/gd4UwUEspX5uV20NfYz1JIk4iXj4v/HR5+UDQAJ9M/kzGNBwyEeFSV1cC8+alQHnamPAdXREzICEEnoPOAME4elZ+tTsMVrJkktyKIPSACp0b/dStwj36Zvs3l+/DHTp1GLa0oBqAR1k6ljHafO3Chx95RnPK1pTeTnZooXPBHwSc6sZS5fBFhUSHxkPL3o/VWrpIz9K63FYSe9leCyVDfBJ4r5Lfi03rSmfpDO5cE7HuZ/KFw702Kl/8fDxykpLxdpP2MSRqesaHnKx+BjzQ9E7urqlY1k/4uqGf8M1ihZSNSEjGiVFPjZfBXXdHOxcpePXzBTyQ1kJasadHGmgb3dQluQVkBlTyE9I1dBVYIGDKjfp4ltAF4whtZpXL/R2DUZPdCHfu0alM5ZpRKF59jfQDmCS758nRP4ztWsnwgq7ZwXpywC1Gq6W9Dl4/6ugDC+spFeEJoVLnCNWkiWZwK3KyTtehAgyfXctWx0Gdl7i/b47rVRqr9BYxLbZ81cTwnn676DJWcu17pxyUlzN6iVoCbkg+3PIo64hpD76j+/MuSx/Pmh13JsjPYA2rhqV0m4cw1OodKWAZoPLQ0DOi0Zj39GcpQhvlO3JTK6XFuVHyhVrRccEQBhe+AkNnf+A1fdlWZs6lMOwWRSuF9Zwn03V0Chl+lVur7emh386v0WKOS1nQ6H9so4puDKykH8dY62pw0+Jl/gpwDABK1QtXJdrYzOhyobkTXjDm6xA4aJl/7Q8EclU4Phc12nmgypHGItIDkqN8p8jI19a3pEDYxg6bJmOFFF76CWUu8wLd7W/VChPrLyWDg94W/KV2M2Cq0fVmQJ5gEUuySJ31uT79/4tBIYJ1knYWKLBUTH4l6Q/LpgxKPYt/aGNiR+010EmGDS23p3dqtxxOj39z8cutnjwjqAQa7TFTS2eEbKf6EX/RUhZ7t+aTpatT8s6501Wo/Gg0cbpuZiUD33RagpOTIn3xQO+Lh/Bfs20f0ReHSJsk3QBe4Rw1d6F3kT+cw/SIlHmae9YCx/L4/F8NUtyvIBHeDVczsQlesg7KYgGK+r/IAM1C7G/+sdF78VUbNQa7swdd2UGgoUuUOWoYDR1Zoa29Wu0W8hhZWlyTUIxVSTk7pjAySlNuVEMM6/liqmSv0l8hrlASGU2sq4CcIkFzvQVgAXLvORzNczx5aoRS+zHoEetTcEppf8P9gyBh8AzSUgwcz/tcnOfx+zQ4etjyvKHJTc4MM4fvKfRdJoSiN0OM+Gwh3KNBLPJUtS4QgWF+gXB4NKmcm8P4MOk5JSgJ2HcPiyMsRZKS92S2trViB9Bn1EyUZKgYW9cjHgHkXxEjZWtBpFikFJd4slM3WyUyA0aFcCFiZ/NjU7t2n4z07rA3/wgtE531rqwbR+NqEP/A8tynsmj25X2mf4r/O09JrrDqf2T/ExoO1yjQBM7B4EeJBK7WsTczsGJFf2OjaTjPSw9p3ouOJY2i35Tvfu3LkxbaL3b9CLI7ITp9cwxaVndO9SMUzYhhR9gezw/aSgBQ1OwPDzDlcDfY/DOilqC/9Qf0+FO+P0PrQ3X18KdH4LKdXd2bwpfBzzof2svaH4KjQBeQMReFBbY8tKvJE3gC7IuzCkVIChDYuV1hPeJjo5na1AFfuYoWP/D86HnjJFbQf2xDBNKoJZ3MRshdHkR2k1mXJ9DBdrrT2KJ9KHLq8micm8pHQAUTbY617PEiVIv64v3WMDHkmNXXzwBixrSx12yNjtXR6mGqG6iDXi7rE0B8sAPz+H/f3BIFdoLM6/FYjUaph2/sb4BoKrnNIN45wL2VkDTFicj6muq0awWa8j0sSGMI9NGtCIWsdgAZc4rocBLICqZf3AYS0WUofCJ4b7oU32XC5LEfozoAg4pM4xhtZofYs0B9cYdf6Pj1lnXejg5iLCIQm6wDO9UAM9c/pfG8ObTNyosqommyg6vYACdjFhBhAAOx7zrygAAAAAAAAAD56IpG8vEET638S43Qf25WiodBH053HSIhmJrd9gr93GdD0487dwmivqtKJg4Sy6V8F4lBpyli0j5SUL+uwCZrxKkswew3bs7KouxUwLlj437e2Pm2wdcSfau9ukoZPzO5UNATtrVbXrowhlfsaysj8UNhD6A/hwwxgQSKLvX3MTOxqgzVijZNynifgPd6pIf6bhoHdBQZ7Ac9Z6/J9/Ou1v2VNCkuZfZVdTVIcY7SnPON+Ffgg2q3b+H51FKinHsylEeRS0nTDGpTkAYS6ndJXVmdBOfBW1vpAGZpCZ2FJe2DklyrnQTo0T7VMG9O5oybj5xfOiRKGMFqA5vI8sBl8r47fMNNOxHkjsUYTOyO4ssOIyj0LQHNhwjEFdT7ZQy2qczb37RXCsqr08uzWWzS+aGILko/AQvazAXYWoO+yqY1poVemdb2dBqvNjoSmVOXeTRtI40RDEB2YFdq8Gc/6mdPjNKbvibKbwtgViiQyYXfsXJc4x5B3UXgN9VHxjiIZtKwPHPVtI7EuoXpQRjBRnJK3s6DVd3Bkza4wpemL8VB4g1yhrpc3zqpGfC2MaSRAU98BmZmAvH8zSpq6cEKJG7urAt7elSiLLqxp8RvYp2CBzDESFXey3lcGzZCDLnV0pbhcDauCZaO1kcV104fid9RpkVG5geClVLI5irFhAhdhpZJaFx3WtlDS3aX554xSRnYC3EKasFAQgF4XMPlM35f5RkWRgLJq2GQG1C+Dz9la2RhLGyDZjEBvF9eRq+cHx1nI17NvPwnQFdKSStOG5EJF40ISbPW67Y4kiaA81rPc7V5sOKWV4vGw8IyWwDPxvX0hdGl/+yX/znntNYwN5vAPl7t7VJIm/LwwFnE5yp3FfXnX5FOzaxPPAiSxkYg0pf2/N5Z7Ful409JUT15UF4BhtecFVT5+ySJK6xnmrAa2uSujydiD7r4S7Bddb23qweX/SX8PJBwWcdC4xJWOvmCYlzS8zVDsC19XvEpG3uyctcvpusyBzTFvqJYgNyTk3Yurg/4xT7V2mzWpQYUhYNgTyQGvbiqU2UF6Yh4CBtlqqOuXpW4px0TMdwetIrAeOnaZoV8SlB4nMgHTFT9P6VJPAgYVy1GPZuwIrneIuf/WVVJG6KcBV4RJw4O7vVVQ+KS9kt1sfWDpdfCYIoZdiC1fJy0nEU9/PxQr0bWgKO5myLRIaYfi9EKbL17u6e8zvI9vsX1xC9ZZapdo9OZBW+iMHJey7sJXPf2La09EPuWYWpMD1TdMZUQasy/6Ng0afiHQ1RjsD/5Gp7ARazuBtCziokvchANFiaPjfA8WYwmgO4IMAPun7TUtbbS4FbkEWUXHnLMVU6f7m/Wr/7lak/QWRpFVBAlbcHDGn5tnAYRXPAdsL21LcEn/MGSpi7NehFWdRs83m6EW4fcPvI9vsX1xPRJFKeYzhX4cTK1pjkxtRpM1vdCsuoyIql+HkPNsM9nCMH6ienCyNCkcJYDQyDYgQI8OxitcNYoNRloZTlNEX4jF6k5Iq5femtN0ExpEzzyIvakBX45pXzQHshbCeRDHROdRBn3NW7uXGqysyrg1BL+jx9Va7M5J+sp/Mu674YIu/ueqzcMiVrfkXplEF+4pUwxVhpm3wpUoyXUMDodeA6ZMVBxQE39acAoBJBL3fAc5n9bMvAZtH3rztSd6e/5du5HDn2AuBqZQrf3t+sCloS1tDvsqcMBPtash183D+2z4cWC7Uu9rlPN+HIhtPtHaew1wMOwx1kMqOsT2bdYaiEZX1DiUQUMB1dC/jJ+8KZ2jkboBmESZKAFMBolqNDGjY5rSepav7T/q3szD6dukjiTek7n4V6CYRXOV+ULoEj+2y/7w45XqKGtlnt/1womDuwdltFwyksFHw9PXwhr40s+aMhGAyRA+LCe+iqXAgZag2PZhTRoBstee9AVB87SxJV3CxmcKXn0wAlVFvd1CkzwevxRqwmS2+b5M8x91gNxa2gzptFe5MQh6/OulkBN+8MYUwd8lG+16b5DVZE9FgbkpcTdgx6oPd33Jz9T/dEawv5YB+1QaJ99fO0De0BgyUXP27TG7ZPBeUen646J/JMh5ppy+N6NO4hE+aoYQgdaelqkKut7hHYvesRvSaiMZixeQxCz1T3GPGRJqnDb4CE1U3ySyWcnEIhW730xRKInJDXeyszqF8KQLqw1x5kW8ijuOcieO2L9Z2vpx2lwwjY7efo1iulaAx5DWopLJMG1mOhcQ4Nw+Kdw+kZcPwfc0GbEk0mmIfGJorsdjfkvv5kZrJL/nlnx3XP3Q+1D/dbEuYJP8lGnGw8UknqgUZuujb+zWWqQGApqEuPyr8iVNJD0iujf1/djdlTKd0HuOiKtvwgFekxFTG4sT0EY7FuED3+GroacCWUOwzSo0FhxTLrxrp8uikeGPFW4p+5ZpIj1kXpXEQodCBED3af+d5huCjcu69DjIygRpCZ1iKi05TDNoQEfLG896kwO+YV1ZkyliPfzCsFv/rAe4/TfZXrSJXmURZy0DSgP9GFCpZwNQzisG8bn+lLIdZrAoiWcLWylX5Oh1mr9C2nHheJwkNnwbCtVjjE2HjNODlUmtWNLllIe5uLlhqDc6v9/FDdTfvU2pbWzFo476rxNeYUqKJT1gWpTtPFjPoCZepiHI+al9SjQeNVcjHnXoeW78GV4ow4qeMDYX2VZ9dkJaXpJQTkLoWAgrERFoIl+avA0nkHWAqQ0gWF73UTG0/sV8hOdk05j/cCESBqf3LBlp2AhwSgvuwQm/c1J4RTkv2DXwl3geIb6cvX1MOR1jd9BB6fPpZXkdwCL2Vw5qAO+27Q3yA1p2PRkknDAlss25tLl8lyuO8+dVjXWBcyw83KtmAHq8rMqatxgJiLX9X4RmwK2uWC1VcegBqA7EJcp/hP7R1Rqn1DTcFekaXJisYEmJ9JEUnkZ00XmgNudu6AQ66FbPnF86JE8f58DiEn/yZ6aKyl8q+mGoxQreTEjkABDiaGDDcXAOjzk3ZHCcFhSFeqZky6yv1BuFwRkdFwRmMZ6ZqrUoOrZp0lYVPZhUfd+ImTYgKCrBsOsIVNuyokTZRm1yvPcYTs+Fx2gt0zXHkhNA+xAUAEIDfNT23NhhVVd+aB/LD8pvxQtrB44iJOs3mMvPZ1YkXCHamAhxpHg2AJqwbT7SQDeMrkOY2ADIQdGRPsLbFPKgvjRKsbpfgDR9PseOujpespCWDWu0drhxool2rBrF9vnyrlkiFCJgC+u04WO9PNca5/udC7c8lsqPzgbwHx9+SU8Zp8IT4g4ChaXwCsoo52toDNVDxhCM6bHXAhip7ZTfAiGthdbU+IkHxvBL5rtihprui8cZIiupQ3yZRUtreEYMYSpgdvi4a/UTKdgwvR9/cXjA3f4a0XRirCwBTj8ZkB3CPfK81c3pC9TVpFv0QN/YBviLnTTPAw9do7gWB+daTXXnP7EdMI9BCCLVYZYtzJWqg3B+WTTnDL/+3idI1hn2MEdKRpoDIvNPQY8id5hqoAqiuqAI01ia/Ii63Gbe/rfy+fhM0y4QD6+KOlNuBDDk4Gnn6oH06Tq561FivTzSpGyqNBRpuFUB2u/pX0+TCjR7F6pA9V54GjwDhgOsZIcllm6x7C9DZ1Gm94vDSJKhPBEgGxXl9ypgPHjeiiRLoIbMD5VE+917A/s4zypBc+1zVBmdgsbqHhXzvvnXOB8HSilkoKWsS9pJJOO23hm2ZqeNhLkA3HmYyYpqS8wRjLd6yEzmgs4Bymh4/jasTtUp62UTL5uRItZVe8IEJipYnz6PE2v+MPC3JF5sklXCCVOrUzaKK9nVOpv4TeF661QBHixfcIrHGN2CbihcYZhv/KIHsKRnGTKajw1ufWuO3l4eTnchRYY+/BImhAuFva87RD/UVYB3wCGNyNBR9gyc7FrPGH1MSEUzlUODneg+X/6x9goYrG3zUi5WtspI0fIRCMZNl+rdrdL+AxAEC4qs2CRVi0RqIoVRVlu75+7Kl+6wtMFLIRHhABwixDDhJn4KlNEIUeYLttozp4uQnsfCxITEjoUK6ZG57lUR/AjjbsNBJK8fyKhjV5t1A9+ftARPLtmzYp5XAiICaE/sTwfN3l+54jSxJR2uTdFL2HFQDRaJvJa4wFvSY+XN/G4/gjfiSZpWYzhXkluqTjy59Pd95QeCR9CE+5L3PgbuwN03roH5mugN93VBWFECTkHf6R30mXT8qCYA5EAdqO1sgrKt+HouiXVYjf0acmMQOwRkD8j0KilWZ2GLgAgWWr2ztMLfJGo0G71r2E3tB1/BfITxwUvfufMETqPeBhvCZimS4BTH1RRdXljF0VSFnUu9Kj+ul8fxCX2YoVj8D/ncTGAisULR7nEPigTbbruCIKVfHbWS+JQWncKZ03VHe1zMdy2JH4O39BK5i0xudQfFHPUlYIjac3i+cM7334BUB1ZVfds6aYo7tVyRgXYMPpCggRT+YokpjJrEuC+PiYVie6YcltbipnaLBYVZTnMkiQCW8CoFqRuiCgpg5GNx1EqxTKqCLjQP7z6NFCrPsgcm6YV6bJRlMRteY2aKZTCMUeRE1hwZUfXzyF0kERg3HBTJehQjq976emFqPY15Jmu9srlqpivbSXQ2K7PiJBvkxvu1rXXXmYEOVXrlkptppMgXwpCv/T2O6TsLGidDV92rM5tQpH2xiKtnuwQ0xXgSnDsdJv5qcDO4T6uUv0/QpIW5909u2/TgIZZkfatS7gTKxU0hMxkv469oO/VajyeC9NX17Vh+Rq+AJW0SJr9Ug0bzzV34bwujUJPNM3+LJAx4r85/0pTsGt7+YDXb84PpUmqxoVHi6+YXOuSdpG59JpIkcQZCIyCt6VjomKpv99ExMJMEO9Ya47MUxPwVCmoaCMAgGPoiw5ibyAMBXbzsUHB8mKgYycOjb/ImfiTAy1a9H39lHAG3tQF8K3iZZk9i8s5OASKVcoNDwBxNo1x8bi/AxI8oxhRvruZWq47cYTx/ER7eFSYazNU4qrXnKnlWbezrIt2E5I5AlFxyeo6QVAjc6YMs/rwDJAoY/W0p4f8v/UqzS8BJ7O5Fv6WZepUGjEAO04S5m5APbBvIsekaufJ0ddCrH1gaA8VbzhQS+dNg88AxtDdh8UFSvvzxcaYmN5HemvDSWskvP0nT6Xc+kBiR7aqaVOGLUIJktkjpeuCihXZ6XstY/7ux4IhaRdqkSDIL/8Ukd+kxVWy9HnimEwJjC28NIGYlEl6muEe2gR8RSFofvNzH81vCtyuyji+O76O+kIj407qzD/i122CRyW76XCZEzrXCXveZU4BHeVyG1Y/bFcwA3/2+ThUDcECrEObqt55/ppYO0bv0UgasK1mJY7+Cos+ofsEBKwgq3E55BWBriHQ+x33ONQ2HaWM2jeOt/0sIHFbv0S1EsHpX1Exj4/536AbxzEdRS2KenOGOZEyU9VEe9u5EtWy7vqHRDJ56/FWyqHgUc9hMbaXxWdRGPIqsUW6gFZj1gBzJ9aTInUiCbRgHCgLas1vEel+8iv1yk8M8/PdW1CsMnSsnB9c0qrWektDGMkUXi9vW5I0cULKelPNM9vZ7I8oxgmnPk6mOXLaj14PG5DbQ3OQU1nqURMDSQ4aeysY/AGwZfvVIYz9aQ+b9lR4wUlQ7z2jE4VA8LwDMJWsbKAk/27w4LqD9pEQPcA9yBe+Ei1c8f5UFVUN7sHoOHBkweUuvJqX0pYJRzEfELq3g7R1Uv0hwrDb1UrhBnhyfDLiKOUh3seR1c8GWtc37HeKzQzugK7+LcSh5wLJyWrhrKV44th3BfukYWYZcGik5Rv4Ke6Gi5aIr0w70NLWgU0PuDsk5Cxc4PoXtsE7d1Ehpv9CScZXoapqH8uAHkr+OxqNJqe1X2sEZBFXYH8Za2VnO6N8iKSsGOxFvE486srPmIdRPSkkEoxC+g6MQtTsps3+sU0/Q7y12mUdH74+BlEg5LT9MJ0Zrqrq3XGvB2whyF17kFuFI03ESmr798tBhEEYMn6/Cr8OWoce2rNgkNNsQAjan+I32SlNob4xLjWCjG1Zb02u+GdhrUYdED0EE3Np54OS38nhsc7qaBRlRTrblxxF6RqukBAr0NyYwgvSNmbOvnJme3/7UfjGpg/zMjLxledRD477MJvGfIsd2g3MpUnFztZvL3uwAQRNEK3+wUvc9zIiqmdzVhtYN1zt9O6e/bZQsx7GLEqKBLPvy84bACWmoN68DC+YujGVjTAeXDemBPYNmXaw/PIAAXXnM7SzoFYX06i2TggAAAAAAAAAj0dzmHyNzrSW9nCghjJYapSAi9ACMPXnvMHvVRJuEZs5VP+BIoY0BJ9UdLfnjtHB6l+XxgaehrFX+8mc0FUaFHY+NpAYRYbK9Rs83lERUuYgb+Zy7veIcj3/kaClCvkNR5tE4BPuaatyeO9Gpg4td+C/Y3+zTwkWjgDEsFlrWTNvUaYEfrQUciiBkbnQqXZtaOsJRZXjwcH2vPK7cQAiL1HM9RIZ5E7Vg1oZcSLuQxWrwOEQ1QaElqlFeDCN5LL1/2CovsneaVga0LFuka2dyGwuBbEwCzYe2VJMSmJL82KMz354xCgawvBFu/dJefSaXm7hyVpPct6KvIzZ0xiu0lixpJcoKEhMKO+iWBGfWcztvILyzOrFUvpQ3VQt6dhE03IpEDf63fRT5cTHAHFSxT4g4ChaXwCv2rGUdytRNNXFi+CDxpWpx+LFzy8kb9JHx5uevDcZmB6wW3atqCbz+La5ImYGYuSFCxxun+8x3zyF7HdmZvPiEYsw+WkIcieYEIS5VCpDziDwgBAZyTd/+RSrfNeygMUoIjNmDHvH21EmW/i/3BImEyoTCIevzE6iPnYztiv5oEzuf2TF0kzXsPch7W5dDg/nneuCXfy9y4YgltzvJIRZ8tZ8Ba5Cx2BqXuGKEGCHnqUiEg3uLe5GDttsGatOjB8dG0wi/fIWjhFanze3c9sgYuIG+Zbe/19kxY4GLa7z5eRc6UsZpHV83KZ+U6Qx0aUd5yJ5RO70StNhnTpYZ98eqvjudbnLO1Oka2YDdzQjXuWoj5Y3fA6m5tsMXyDpRzoAaifg2EC9EZIAnZcANKjvj9NwGdFoI/IuG42dAT8UyXiDtrqls8pkj52nNbEoLsWtuzbsjj6nzf6s/UH32wRX8XA0T3FwIGS8Uw1KYKFe8/dc4bEHxzUDpfYSLM1Y9xKdSfP+3b8IW9Tr8FZKueJEKDv8slbDoJfXhayPf2jAlPu2GcszPsf7VqVWzPG4MvgOXNhRHRRSNbOV7veLSMUUpaimBIVQ6omxw8ciUJaoSjyyNo7wBpYZnciKY768IvSqYCAiqGbUDubHrMHHE6dj7FP119be+spepDOS0WtM9UBscDok3tpZGA1r3o6ckv4W+Vi6lwwjX/BwaPh0LPpoxumhbOG2twFTnRS0Bymee8Iq/E74H1Pp62hRUrxijKGeo6hyB18G29hTfxI1mLu8owxTEUOwLihBNvMBnNjAyb85imil9N2XG3PMTdwJPLqkMAmefA+xJVrmrDeQknsadlwcXqOlhewp5xOH1wKKdNgrfGfY4ZRy+BYscWEJgnI7Scn7k5KKfdcwpVtvbTZq+usPH65VLyIsamQjH8m5sM62wU3GU9IIJxJGOZdUCtzEdRrApFbnTTzxMFlk9IbMMFJT3LuPIZ7/ecKuT0mDWzKUGHd2IMmvb/eno3PWuVdOHoHG48SGIpIH1H2c9IrNa03qQ9pAd7D9nCghjjlmfoFjpqOPom1aOJRtn2kBhFhsr1Gzzebl3fbjePFuDiIxv7cfV3szecx0yxyN7H5duhr+dE1HWSJ3T/o+sDImIl6ht8C8iuFQ+FhaN1qPRAtWENcrt+eeD+7WLuHTdZjDE6jKuJH+GEZEZrWitYhcfYYsph7MjE1W+AqjgByqMbF+A+CxVVEdD0q1L91wwlioXIdQ85uRvqovAekUo1BT96nz8rxWXH1FcLHMIDy8mu83GCtbwSxNwlraX+VXlK2lIZDRcfHy7wKcxLSF/VHWBTuMPDzsR+YCua84ru5q21/Y/vHMr+3q7toTa5pPC1v01TXv7TyP6pf80pOjDpVR5fQ6LmVpg1FtIH3QbafNqsZXj/gHxULrCJ+n8ge4LM3lr8E1LagHn9pBFDg5MlbEtg+MhFX82vM3aIc4Zv2pYxRUmtqDNvb7uwSk1/VSs7ZMTC+3Qa6awEDmIfvxW67OEsdokO12uElPDSYZNe8CHCsTkYsbZzjKspU07ljBuUHXREuBSkyYaTGFIRpIGo3wuvWi4pAI2DwZmGsXDLy74/XV67bgpBcszZTMUnhfcetptFj6pKykWDEzPjoVTv4+BfStLPCIYYGEkKYd4rvSSGt4LfqFRsPomZ7bneVrHWlP0cZJABtknPgEq3l0Xm5IGIgPkhuv6mWFPh95iHrMwRRiBALDm735CZzW5Luv8csKBjHiMnZjNXlDGTZYx3LKaJRjmBdZyAMECmhtPm6Q/GZ88h4aarrvQbLaDanGsapBmI93i60Ta+VGwwYDvUxxIkMemNDnDO12Uet/nA3eGYplLMoAdGYHX7UWJvfRB7wvCAOJW5uMcBcpL+o1WkAPXNRtP4Ixn5KhWyrornwJqHX8VZJ7odf5m/+QFKfSZXI+yEOkFO2z19KzqVT5rKeccROAPJNmiV7pug2jFTWXQRbHZOjS14SGQGdWeTDn3auts1OesTc2LWgYYRQN62uS0ijsb9/ATWHGj7x+GRvmm5STY6uGV0kV+TJxuIInQA54GS2rEuyhpjTCf38NhDQ+3dCKJQw+x8hVmbrli2bWW4YHsNUmvpSfeuyFj/iBVYX8dBRjCDDSVVDgQhbL0By6paOcjcxKJyu9IV5y2xFZxYmEPjtphNv/lT4TYOsagOkAR7VuCdw9ysaN3zYk/9ltqHOaJBMNUgF73R71fGkiI+gisLZw4qno+yolKfeW5v7/F9+YdzdJXhTsOjFzRmgStpqVpC/cquWX279CbmpO4P9m56GHyOnt+mYDlwm9TNcii7hwMKjTOY3+GLANTqFaEjAv/aENmG4uN1gKjbTTi2m0W/tb2FLORRuEnJFljvFqwzlndVDqM4x/jku1Akp0oxc0RPlrWHFT3hWwLOBbMoiBqMfeXXYysRXpo78Ns+IjenNCjpyWoB8Qn6V2CjAN04r/TMsQ+JneiyRbqYeCVLCG4QxuHyxQynJv3DJFUTjsqkhq4CuulsCTQCtV5a+QBNcId1FN6MxAkGlV9i69ziKz+g3mVrU6/jcULr0WYKDR8yFYiNgXOr9W9y2C2/8yd5byWkD1cLn3/GP4MrOagZsaH/0xutqH+0YNgV22l2an7jgYegtP0omnoGnLt1d3JnamcVFDLlZd9PTzBD3eRuhSI9E6Q+xpgD9NQHnKZbRNA0QZ/LJ7SbjUZ5BTjVEDXgv5WukbUNlLXCXyLtl6s3aQRhFe7YRlsZ6F7tAgcDeIi0oSQIjMZKs54BO1arx7qY/LRBiYnwX6Jokn4wTu2wQhlMjx0ujYEEdOQzN+72zUFBUieb7OnUPrp6lqHdU8dFW1zwAsMrA8C9XTW9ZIhZMqhCJMJqSyjcB16aDP16SxBf0yU78H+iwUP62R4RHAmaP0r0h7Tfd6uZgWJpFkQeIP3szXFe/LYAnmGkexGGpQlQDXAvQhoVpwejVBwJ9Y3nIZSVWbpU8mDNZzTeg4w9jgDB3Ot2hEbHGg4g5Rrr+FCUlaGysIyAizve5JOn5hVq/gB0Wsq+QVgCEd4BvrLP2/F5xgUazq7FWUf/jdYJQaqjzKmbUKnKibJU6Fl626lV7a+bB+nCfjB4faTNjPEgyOY58KTomIb58b5mVl8wMHI/pMnNhfodUCt6fllYsIEgTeRT81ZRS9r+B3ftiUay/X4Az9UJOYS5HzX31nUCXf10JndHu1hqQuf61/W+bb1WK3Dlw7C/YBfVyUYuuhp4URSwf2qKxVzJ6Fem2EeKZqTVwSoq6cNvj838jmUlVu4gNz+nr2pPs1UasdybSE4Xtq+tTe4xhJi5OfjArvL4s8QvWAa2Bh9LVNEbpeVwz+9mDgGNMGIbRH04ethc/78uBM+FUZN8pVu1eKXEj0+AFwANjTp0iinr/95DBno8sSxPhmSDATknFiQtJIUQDS3XupLaimugTyufSveHTc0MB1grTCJL9sZsU6ZhZb4UZoCddIJxzEjiiCGRbulQvi+cMgwWzj10JoCKM6TSK3PxH/rt7qQpT0m/ZJuLByeHuiuNN7Ny0qVJNWa4ezkLm3bQNn7h44aL143ADNj7Qi8ShwgPw8dRURURB4/tjDhB4WvcBTXdl34wfykZOswmaWujvS685jT3CHAGqszFAwEof6F2Leiyf5VslxGmB4wGKfamktC2bhgadkFjyHQy6eCNb/k7LaPBiNIuh2BpeegTJxp6mphPPTFjtQBYgAqTnwYdyvW5aeCKMqyaD5iH/2IjKPYbQ8Fi6LVpCtZmLzsv7wU1hPzvjoe2WyLRjJKkunePLtEpQ6GLdE5xDnCWoHrGs1WBcQEx5dLKYebp+dUBttOdPAHu8qOErwA2KzqmJ6mlNy6O6fOwYaIVK/zUd9w9rX/+T3ZAlATO+DZRBlIybokx/RILivOnGimMOCSEBHba9sQTUEitldoaGGvgksXHSLZLQyM3vysqZeDMrUgZHRWs4XWzcvc7It4cKPC7Sy65R0nGu+OtwopVnsOkKVNPPnAxs94e7SNd2dwkngIy33ykyii3cuPOC1c5PWoDRK822U28M4xu5cswhj+8vR3FyH6DrA320z8Pp9KdHWWoyiBbIKyTj8BlQtreN/Ko/tMs2NUhMHObXvYs2B+Z1q3d4+Nk7sak259uIf13FIkFg3Bgvwn817VE77R1iNcwUrzNx4RE2Rl+7sM9od6uMr6nnl3TQ3FUZxYx0PBnB5OItfPQB1U6lInPB4oTPjsLJMW0cNZrr6Az7+uJEr36/SciIEcOi5E04sRW0lh1Pg7CjJj8mxKS0ENKvsex8wbaXZq7DdWfBbyAwBJfrmta5aZKatcuD0uSIvQl8cLnQaSNg+c/Dbk2z62E9Q08jAYoCul6AqAV52zKbk0ZlQui5gJdeA5lJ/BTpdjZcSDpvyRW4F+6TFdGkAfT1ch+L4EUm44roztLANaZ0K75/RjpFYI/2+SEj6qxSlVTqTXmdZxLuQoQ93KBUqj22SHduq29asFBtOwlCHhzZREJalB/U5UbYCqNilbQkHhYOyn9XelS/TxPBoO/U5hOVrv2RcPH11V2k26kmAVhA4Qf9kKWurncVPIYdyufo1TEk5wmj5KGGI2dtBXyhNAvVlQYVnfFM73TfcaYxqFI1A0/LM09F4iuZMMSO0Cu9DTqXLTDGVumCCIBIAHXwSpvUJTF1vF6IXJ5QVBsHYpuOR+dSOHGx/Bp4JbXvg0yIAABgl4oGYi++CtAqU1WPXmAfiAAAAAAAAABU9wOyAYfUft2+SFoTG1M+rdGaDQzmkRhhtlFglIsTrowhlfsazD7t7OC6hD7ZUgLiuXoEViNqskV7RNhK8S9RYI5NvHlOB6OAOCekYuHt4swkYl52/i82n+xFTmdRk6Q0h4JysAHmcs9sWMzqXidAQ0KzJagSndcncDJQZ8oWMZUHou9Phuu93WYdZWyMTDLkaKIIt3qU2O6Fs4cVT0fZUSmWMO85ykONfV/4MRO4Rj16Kk30BoXLXQaQi7OTljvH1j2zYAys5slz/MYVypaeH4w7m6SvCtfyuYnhbnCkdJl79NNDpFAfkzP+P72Xl2Si2ykYuHx/pNVVubsB3Qjk0nuAWCYuXwcWHPnOccxJ0SBBLpU6G3aU5YhuDryUMtkPWhysw0MVdEderrY+KSfZYEW+bxVems5c4tr17PZBDSGY4nc8xC9KSaq4CpLOS7eui+tT+J9Kaux+VrS16zB4s2MbaMYc6Gs7YASt0620ixv3RYOxL/3maQwAwnb/sLyg/0tiGKlJikH3I/go9pRqnSkpahIc6q9NIZtNRBAzlS6IWWycMmhmRs4YE2Ocwsx6LKsv1RldE03PBODlgNPhToOyaS1Xgv79/2kw4ysNqIpO4kC2rELeN6kxfPuV1zIuhzsRDa9I5r3s6u5e2Wq85zC2kpI6YfQRAyTD2t1xvPLp+WpkKGbotdVFFWo8g7YsNwGHD1LBB/OpJvgngJUSvDNJmSo4IoehZ6MYPUyltIf8rQ2uiZmglSGo9aLF/z2hfP3vfrWeDTaEGJNBnOD1EdAfuFiBGEDqTomO1JT+2B2kOnz4JKaiNouae8XyWIVDFrtTw85DOvLMpFZ6qyBOee0ZKOHk45B9XSgfi3jtZiIrXyo4rOSp3hIAx+6UyIbtzYlOELTkKvLn+geMZpyf/8bgZbCUMn+9xlM+1IzsuwHbmwMSN09mcqyohbxU2y7sE6Xzi/P1LD198WjefMdAr+BogYeGJCgETfZzxQs8HPG0tXRnYWDo4qTWWBiw2Jkk6A3HvaQ1EHsWkbZMNmIZWiLtcq90DMLb871xBtpc65qPxKqxLGhTKw682ifkaqJWBGpShdDSpOFiNRXnvVhmoyA6FM9TVxc+jSWSOD78zqPwg3NDmj7PGgWI168dGcuXKeJ9aRVruD0OwJEcxGPIkZu5A9oqUoh2RdrToEQ/fX8wIfFTU5b1H+U0zUxOt22q6adSW+QBlWry5SHwk7Yxg0Wd+DaWslLOxNrAI1/d1EuIhHso8Np+aZRFlqZPeHZ7QpRXk668SywX3WHAouxGKVlPNKXXwvIFPaJ0tBpoZJfyDXdOpJtW9mC3YwajFT4dD02SiKM4rfVfor76bA1BRo/XXLz+XQZsax2mvEiBeO0q0T4AZpRcL7z4BiV/4r4LsZePSYyJYBijJu6YeUhw+zgCrWbnPaYJ2eRtwHnfOq5HUYWUVkBWusrO06hSZp9HXpALdTZY8UKIJw8A3+jxOxgeoiYF0vdcapLfNvXKfZr1WlTzXSsR4lBK4FdespIFq2XynMpDS9UDKTOqb5ThqAZj6WY2RA8gqWCzP6hQaOgeAVoXOjU5KANQnsj8vpfJA79FYKHp8P4TNfehjV8cG78Ywah6RkyUr8q0zOePTVputAKFEaU2yp2cZ+xh2KoSND4vgcmj08gj0k+df2eeyxmT0Ny++arjJ1xcSje0fE1CmjpPzcGi0+OhuSpV2gtFYveoCG3hig613fsk7t1v5iX1fQngJHzg6b9CSFuTMVhXcHpkmM5jY4TrIVFqVzTidHK5cqJTlo81HIsj5Asa4Ktk5Rgcx7WLW6C8hZO0fSH3IT2wJdUQkIcVuGJlk20450cgcV3+vLSH9IyOur2Vm3SXqEeEp65TDzk3FdyeQeeGBj47s4nUietmSTITqrGBGgIuNq53mVYWkFPQMXjjLPtu4gdb6cSh2gEp0rycOqofN7glO6Ts3mJUZD+z5a5USiukK5V7FXirIn7tkTj0WC+R5ZWNqExXrSllnKJSrb925ekuZwxqtQvsws8WB22ZZwDMohuQqeltYqT/WbZMyh17Uf2Kh9/ljcD3ueV7FdlvqlrakYmMKhFNsUJx1ON1kBXqHIPozbu/Ejp3a5CmfnhwL4B27GGTPmkO7iB3uy0B3hWQtbLgYOytP6t0ruzVFni9qLlFX+WqYb+9Q69c32Zz0UEYmHUdy4ytTbgLO/7NgwACT+lmxeofTkCLxRNzCGbPner+jIiuCGZiFZDRd5gWKfwJnCdhPkmO8dfsZguqxPbXkim8rgQCFzoKIVHMIeeNSw7XF8Q2IFOwGjA/3Jtrc+labE6XtBVg0OkU87npvJQ/MOWUCtKNJpAKxDYttRqKqcbZMZwrcDzJPdPecyXoL1tH/UTILyEcMYaEZ6V+wlVg7OItbeRew13dzyYgFocR71EPUkrMMYRtAgAMFUTmtCKeguJuObHykOJTppQmcFTWehP7rGxLm9ANpf449WJOFK/DvCK2MAc5d/roC561nr4ETRxif4w8GBqSf73be8rtanhqibzwafWHL/zD8sOJy8CdIemz+bSbie/gdzYbOgqLtq0p6v9jqRolooKVh1uqe5MO/sWh+1Wiz3GRwI2Jc2ta50B/SNTM7lHQPyjL6dcqd68/HGR+wOn71GwnlQRfwkdHWohIHBGIaY3X/ybyZDQCswGSbrFxoEAnD19JbBhUz5OTVn3log1dkUu/fTVNelCU4MAFIXi7cvQx6LVizuGvXcpCy/rYtSmMy9ISAhALwDUHaWWONVSX7Rtez14WuwFHXJa0WC/+RhIFQgWrYIKPug6MFTimXhw0GHCmLDbCQKtL/89SA94RcaqvJrDd3xtg3Qhiz9dPNoC9K7U3+aYZENsUFKe1/7TbPXBRGQJzpRvwlLGoINIJGPnmYDpOxJGuRbhI6/ANNwjS+Fd5sZkBjVmc/j6z4Obmz7f5UpqsgVsz0wjOrr0QwB4ejUVD2KYgQemE1WJMeIk7rvl1m584KcuichNl1diNX/gQ0HPBXGAoqWxGDVjirgiocMwbpaegmDKgPhgh56GSEgDad3xufcdJOeH8SbnfeVoChQVpPv/4rOvduWZRX9S3jLqRg8ny7qf24e7Y1UQf/wNTUMLJ2OuAzabiH3TIaYkvMB1Uh2w7crmwJO7knyOJ4AeIaH4ONMPCKK7tFlXgz11mFMMunTqzmui01W+ObNdbBY6qU2DxS85YS5B3IlQHA1RE7A4Y9zMaV1Gz9sAkjFAxlVm6OGkBCmntjLcasTSQ6b/hDZv2npDSzACYzzuCzu2J005q32kyJZb/Sm0OW0P1nceBP8XQsIfX0UFfNF8UsSZ2SkAqXQKYtto8Hbq5tQsy+Hlpt6NK1cCYjTpuBoOkEemirqFVGPIlw1RDLzazr+Zti6DDXLSoBe3pOVuBp87WjrxI1+VTkYvc4bZpY4B6wOROs5oQJl3+WepSBJ91n+vSrbs81mn5H3rayCT91HEpxesj1EAXTxbuV1Bnw8kX/DHtggeQ4Fk+vlsMfbvuE/jgXdjmiGRppPRGoR8B/KH0Tg2IOp4eIMJcrg5EDojUifDH0LmknZ0VNrukMb6oYW8aU0/FTtCaljgzcHwnOwq/afYsdY2GeEU5eBs6+sdBCLb//yklvyHbthOGx/WjiR6CgMtRTGhwCrszQ7uiSRh68v5OyH+/IF46yeDdFk8PxbMXCW7INPYZlX47tpgyALxkSNQ5oAvIx2uTy6p46msesY+YsS8LaXDYMHb0192CMpxEaVJhFhBOJV36uILZ4+o+sl2R0K0yok///TR/kkGW3l35WgmL+2/FbwYz83uvryADlVAMIQO6H45CSePwZJYjqwOXjDvN3EIDTuqRccRV/xiIkVpJS6DNgr0WG7MTvx93fi8LMvAbDN7bKG+1muQyTfG8WpYERxXsGIHuB0u/iNWi8hi1/1FDTlKxp14j4yw5QPHtHOO7PEcoIM78jIYAaWKAbUgl/DpKcGS6Nci1q1HGnNzpKBDDlVL/prBzw35EMQpnmpYYByaFNVGDv23ErTJCBxl61QpwZ3O9RbEV/53GXBS9UKPGOL9fXd3zmLVLtosfOV+3tgYMXszoK9Byv00+o7W9X+IbKokn/eBjq7zQLiEd7pOMLhiKdA3ArVifOe0hO267Dp0P6lTQ+eSwdfFEBp5Ett1AnWny1bldrhMNPU8hhrDJBaHDBljrAvI6/Wc1eaixh7gOTTbRvPsbKiT//+yMgxuF59/GJ0Ct3vlhqzaJ6RxIcOQ5Dad/Acjt8ujAQZ585WZAWsPfE0DwdXHYp3WT0SfwYipRDFtHh3ycFZsi969ldGqNVkfr4ZEtmw3oKOmL1sCahOEdRLJHPjI6MDSdY8usjOFVbOsXds62KXf6lC29FRj4AVcYq1KS5jffT6K5C4ZGIX2jx7oWPn+OJ3jBDsbp+iPEUMmqo+xWS48mtNS40d8O+1U/KTCGNcPLpVVx4AoMzeU9ff5RNx8M5v5zUxAh8EIa5V4Ww/baLZXbxzBdOvGh8xMHS6UYYrvnznYrgV1h2pLxBhEmoVWSgY9Kq3zZ3mSx/Q85923mfVIW09avP+vTQxPBDF7PMRf8t3uNFKBEdO0SAFa3+d5sjSlcGZSpbFiUL2FmpVBfSBCxHh4MhQ7iB/1AR1EVrseGJ8OuVNNVLJ5jY+AEYYHV68wJHH1mVuctG6WJorK8x0Y0Moenth4XSFJp4qhpmsRL0REOVP/3Lgr67PxH2HGpti09XnZULdEEdEBiO/6AkTQBtE0nwleAqvIQGkJ9vmnOx47cACm10v6k2gifDi0BcsiacAkaAOKC/SJc/tkTp9GfO72NgCvDH2482LtH6GQCDyRI2/yko4Dzd0GMCnPk+Mc3j2dPfawjqM0Jroqnm/ErJZSemjd3I/sKZmlVdgDrgXbBym4bEiaMXBSMH7SILoyzXMYqtYJX3Exn0p1H3zYdHQdrPuvp2mFoRUEvpzTgU7I+ksZg/svB8A0ByOGjUL5zU6vy4pAAA69efNg+cxQ0nbQ6uxgn9hKgAAAAAAAAFmjug/ipVisWkV8aBYjXG/yU3gsR11kXk3ee8sS20rsWDlBusiXXPPsiIkWGnKhlzWAQFZgMk3WLjPOb3Qzt7o7HjbTUU9dBtP/1lttOySsFG0D7HkBBPBJDuwiku2wd5/0Z4T9ps3zkgB35AwhMd70D1u6aJ1lMllfuntpkgw/yY1pnAx0PYDl614XOgAJQqvojaL1dCzjmvFYrUD//2BNfKskxgSh6gLyVS8tk5fKNCjtmrF5PzsU8sVG+yk+VhfnD9K7QTcvYWlMupW3ILPWNIZArDYWmhufqXeJAzaDk+UgUMqr060RMCCKq3ckjlyYwWX6eYIv9Rce16YKwNgSx3/jMd2NaZwMbd2Yq6cCZ3ar9iYFyjo03Ku1vxfhKK9kIJeIhJMAkxnPzlv2S4B93Kxj4lioXVnWtVLktiOZ55+W+dK0LLKLHQJ+YKbCr4zW1Ddv8jAOvZWkX2DFONDwY4oZVXqPENbXX2yX69c8wGB+SbJP2mlgbWTvezZTZf7lvj+Mu0Zad35vCIbO3BVO3R2FsUDTpS0bAp4KNRBOT2SNDjH8QyRom4mgbPIogOQhqWhj1eKbgUoL/fGZWu6oE1IWU6+MG67LKvzwJyDouPrE3dd9am3GqIRedgeDRPg413MSzuhAeOhW4QMqEFWOMSWXlAwMTJpNvzu4hjrt2Cg7ce8m6yJHBaCuzzkvHU4M/w1Q6nQ/qc4FK2ag16b4VeIp+CWr4TIgUt1tusyBzTFvqJOdcG7aqZGiPuJzmeA2SAEirl9N1mQOaYt9RJNh0IWkOXMZmHXF7IIiAuO7Aq1dGBhu/AYQJ9n+xm6vdEBzwgpgtpfAcpcj8VtiJDgUwuXCPJ1OMJ/BfXD3ZhtF6aWqrUlq9RFbKgksoXbJDCPBK5KgmxWeEWkqVvIN7epIMMT2yKpzOtKroJ5Qfg6iUnu/UT21zqNsV4KqQfO0V6gUHB5IHbjwfuN0XsbPOJ9MOLqJjb1QrJDXmotJSzcLYROeyQsIamWlHwjRcdcEVLo6fdmC4a58B9OU0SKSHvCPMTeuW78eG9s8f5wmo8zV0rVfAnrPCjou76AsFEJC+x+fECIqm8ICFpxMIaNOqyVEIbRhaFEi/UYH7GfcxrHvuSU+bBTY5f3rjgfJsdShtIbYIXvM7m8p2Xay1DwMYqMZZU5xuFl684U6rKWLNPKkU7EcZqBEYbCSr6Bi8Bd/iMZiO/n31twArfenA6KusDXnb+G49QZak/JBqjiQ1OuxDPcyEwiDrm1VRt2+6DgEHYjl498DVNU7kYeXiGyKglrd6pHcfOQEsiKSd5dNuHAI34iunUN3KYKSt095neR7fYvrieiSovATcke1HF7KcrerTljvfW5lX1cgWflFC6EpfPTIb7G9iUmgNMWoIr7730iBRKM4ska8KUCo0rXmTYcpI6uJiv4BMIp6xf/9THfQYaBMYI7OcsHQBRRbREKo5DIfehHA9NxwA8/AgGd79N4ukKUgZzUcEHVpAe+YKfaZrr3Tzgn1CbKOExrHeCCwos9eoXEa0S8uu2oS4OnVzorlhcxZ4dU4R45FSwdE5cr5B2vA5WmxD5InGHu69Gbrj34n2AGPDjld39a+toPb20WJ1tVQTT0EGVba/MjS0aLZ7ymNBo+CkdLJlHmgFmHippC0J6Gp5KPuNrWwPvpJNVFueup/M4tRg5BULnGt0RWhgAubUgLkBapWNI353vovtQtsq+6JOFCHp5PZIEJ2Dugd/QtSs/cb6DOoT/Dll7kpcTdgmpr61VxRuvlEi6Jfk7Pg0IB7Y9/XYkF928xM+xT7lrUTwr1oWEGuqVJbBHx26b14zl5edpA37kz2ZAhTn9vhf70dBzLlZT3t5Preqd7qHMluimvkAlKl68H/QFRTCo/yiNySgBsq1lX+Rn4bQSdUrQQ7QIyRhtpqA9iCeSaOF98rvbH8Bflt4fYuq5/RdN2GtLPC/rY9DCKgUWHPq7B8OeuGC0NBN/wTbF8rtXEKyQKKmizjhWNmquCynxDZ+oCxLcU0WW0tqf/4AYQyYSYJ4atWM18FXQsaGG3DWQ98VvXsG6qdB0/BE88gRK9jqlX2qg5za+UAe0nMxFLRjoyGiD2Duit3aIQH/XDeiOcT3UILDUO227aCFUpdGb02idWKpowUUpYihdi9K4iFDoP948oSZs+HkrVpsZtPuUYaMNFfRsHTkkdKZDQw2gaIH1aGxBhBa5sUkqnzVU26uhkcRJ1+USdvx73qWv+7h7um8/99nnwg2hJ/1fr8bxCjUfrlA3ifL5XWPyEHq1hPN2WiFNZJziq7BVGhTLU+ckqr9bCphzhORWL46vDPVn34YrG7+kBnPM70lqzAY8O4+IiUCC7VTCnuxcpCtAKJAHfzFmwECLkIUuyrJ5FeeZES6RE6MxLnUm+/4C4Bz8JxzUc5XxjLoJvUm0Ql9c3I909+PzasmsVMEXhX1BGHcefKplhFnfI7VZoFtazO5bmH4TDSmorY/pI+7ZvwJCtorVQQUOdN2LWoBzLbettyGuomt4Djm1CqJUeE/PY3fUTuezwDjGuElYMbe/YcjiWYrAyuXov9q4jqUDBzhC40oPgx1An3wn5E9j/p+u1oLniYa5CEuwNBZ+K+ooH4Ha4EXRwRMSQYib4tqmVkhSSTOH4UPjzsuS+WLIGMgdNMkVCMExiTIsWRRgFKlXUFJ75pk1UgjZrTdgzPdEZx0Xzg/LlMeR6hLz5k66fpSh35O+ojE1T1QwbggEIbo4kICiyVYq7zXOjUwKbN3NJpiHeJL11H6gYW3kEb3+j1SmKi0rPA2xjqIglQ72DY75hdgTeoIckMrXrxvO1XEC3BXjTnOWHolkIroC0iIAFXyEtGwCbcB2LI7JXRbjuAeIqK8pI2X0fKXA8mcouol6hkA2R8BF36iIKltvWBalOZfiPjMxiLQsUAIBkX76TsQsvoBJkAdMfa61k3KL09U5OFxGa/ZgmlOKNldA0gTkLzYsblKUrXKJQzYn9DUGlPFfE2FUyTzKfTTYRYmmA838euAQgSkbz987bPWuaLZkO2yvjk6l+JsN54VAa3qt7rzTDfa10BukdNbK+sL5tzq6H3rCmnT6WpTRZUVWJVIi7fxmXnNvuLS+twpUfwbzDSzUCu1+cUaRNKsARytc1sSilyFECPFB5SD4ipwBU6T/wyaF8fvPVeztl62L5fpQBE74g9x050Q9Mj1VwfajiS7e6r9hlIlXT5jJSEuq5jMbZShsmj+G867W1gTESb5ds+TsGLD2eP1qtWxQNN3cpfWZ+7cmBTBxtoQjArOGSIIiag8dqFlcL9LJ6FjvqlArt3UrkeLgcqefVPch3kupcBLv4UirgBkJqh/JCnGrQuWuK5q2pDeQXKBDaG4nItkJlOclmkgs7G/nfSIO4ILF3z8PsjfOgf6oKwMjOdnZSSiVfegwfaYTUrVAOqHvo/lHxuls7d0mwSXOk7UD1hMurMmdVEFgOV2SPS/JzrG/EGEtueZLMtVHreW1CmsdqARxRqzxzAd9uqHOTAubiF1LBiz2zN39/RPt0xEuSfMhnrRvREkcqo6msacUsl5guU1OjTPdXx0+e4V14pXfdwQNpyAa/ORWWo/DJcgbK7y3kQvg1/EiZsfFc3UKLGOf/hL8sr+XA1v+rAqGCken5Wk4zQN2/dhgFDbSneoeL5jUIOwjHzYrE0hcXeds07IE3CucL9bg2zvs7BzYLZ+Wusqg/h0hFnxC93txg1fKpELeQW2EdJRcMkiHl37fc6SPxSe6yK/8uviboXW7f91ZCr9xJc50JuNuYNLDLN5YU/OXijrcRjzIKHpMnzsWDW5ZbPBentQoepE3Y1CgvXZ5+gZFc5o47G+b1y04Y/juNONWxHkg8/WpMNupEVaDgfN9vxnpH3Km7QsqHWMsRMlqe+YBH25ocA+aHeNJ8yTgQvGkS2212oLTK9hBU1H0unhJ4KN4rioJYxjQ90d2SKFofsaJcTc40pX2kman5k8Iu38to9WHAaDc7S5hV7GarAC4aZHF+6qh3XMg1KWx6XDM7TeT4pFohgVA3BYMsgUZMSsbkkBeHB1RZ7G7YqNDF47pA/JI0NDuvyloHKl49YfZzoGSYqkAqv+bCaBDxGOg9avrot4oibDpR0E3kAYCu3nYoOD5MVAxk4dG3+QYfyQqxSj/A4vMS6rdY64hqXdndec8gfCq4z3w3TQ63dZMK6Y8mBWbPTnnZeih465HhkdbyvQSMMD6l7tMf90I+lCb8mOg8pq0Ivee8/xWsQEqeMRaxt6WFKyfSH56DQVeJuquMfdpVlNf1aW8UivMnoP6ZoevqA90ez5XZx5PR/LcVgbqKPGI6VUMaFukIciar9FfumWSYRoIkIC3Fv7gEbhEudseafYtLkINgmO94+n6ZcGE2IF2liBX6ocMqpyrAbBeEoueiIbeqa3CzcpiA8wAXz4qb2CapV1ilGUI6uMqaxCeHb9r48XHKR10NzBt1gmRjLZPRTaHoR80rD8F0f0KGup/OypJp1BsOxxoSHrK80OUmVzH8x/K6ubgFHHGbiEk27bPxv/Io/40VXlxIbktXDWUrxxbDuC/dIwswy4Aw0DaED4AI6mTli2JHLzzw8e11yiAnfkJ3oKgyh+RYwxmI8flFggMJHWkxw3oINfi/JYLjLWlkzCMVEIxRBrxq/wuzQ2A8xEsvbNXehes0BrUMlHsIPQ9Sf4yKcGOXMk/cHn5W5x2MGBxe/VT3MGQvWBbzlC67ACpffO9ADOuVc/N9SLMw8iRic7d2bTWChRkzS0x5wN4k+AHLirhFkoe08SGjUlF3MIV0svCwscPNlnTW0GfThJv9lweGbbUJ6cyhiEs0Vb7NtcPJhcqHSmbm/FH7yHSrGDVXaX8tqqG7Lp6SECKrznMMjRax0b1g80GT6A507hYgdztBWq5mJdGhMiPWRelcRCh1qaZ3mNSqJl/VolZIDGsDtrJJCUkoXdcH2AXeDIokLIDlkAFv/w2IS2mnedMFoAwCgAAAAAAAAA8LwrWM7sg0Db3YVWwJWhi9NAunjfPDgbHaAk3ShXe1YdSdCCXJjaIu40Byrl6qHVvFuYFVCjMEg6rLKc+YhpUX3/2XUIbNIOILkSDcyxCuS3O51S5oaQQkGuW7arNyfjnbNLOflvFAe2+zR/ycNpSItiZgjqqywxXnPo0b2pPfxoSsp4VO3mqgaBsrO59HNYJ6JdFsNEnwJ06ZXaldATZeTupFjEmjVQbsezTVCaeL0QptUzyBCnPycShSZV4TardvTYSaXWFlbRFhGXrjrLJJZXjah/Tr7ZmmdTNBSXH/QnyiD3JFvBuhEd9xLYVmwSl1jrw/TfnHqQEw8q6Vx57oqaH0ytdt6kYj0nFps4wExFt4hALpvaoe91+ubN6fIJnFQnvTJsQFANrwP0l9TpxMx2UvnEyI+fANRoLhxHSTUuObVYeAuNIjo55L7Mq37EuEVtojmKyo8MjWhwb5TuerJrIixzbE7lruiBYzAS9rJGMllGO7nTNR5KJVL7RZGM+VDgmm0tzsrzahSwqGR3wwPeQqn2Tgln/nXueWTtJTzC6f9wgnlNB1vvdu2tkfkM15B7Xwdo+iT+32cfw2/aFPwGEDiviL0azYjEI0+uHfJnP/dtG+ODB5WEOEI2B6hF2wijsTtNoNMWbdpFm3C7qploERUABk7wF9/o0Zxoe8BtsLMlz9sujvTUi25FgHm+gKJD2rFlkUzZwly+wCFprZ6Gr9nh9LzC2226MV6qx24beNLt3oLRh+pZ+UMbC5U9tghIH1aGxH4ohJZihGPES3VtLEmTjzw3W0J9R+nMZPeJUBLSdY7f8283UQ/ndtLqCgwjYx7GITuO26Ae59/s57tyQ0XA6vtDTTRT1TnzmxadJgCC2rLooruqQOvfpwUpY5JfEfZCHeTEarMGprCBuVDpMtfEQPwUXSTt7phyvUAhHtXhRQls/GchTZFk+ffccUYOCi5scyRxcAQ0wExopy7ougZEh0mWviIH5nISvnTXJNJsYOpyn+Vj1UUcA2916CAD71ive3wxr2scovU+M4B2imdc0NCrb3/NyVe1I1XHgf8CZ4iP9LyuVU5fMNp+a1Gz2vNUsXgTujCZrsGoT6rNqjSFewXQ4Nnc12X4W2WdhtBhHpZ9tI0PzWRyLX+XoZoE4hGjqpT4uL1kzMzMqlcPFfOQW5vD5A4kwUIdE/v4a+CpaLQS1V+j/xbubwPrIhnqMo/x6oCBSUaveJr9U3+UTz+hODlC68o7jBptjsPuGKHZ3MlfD4Ixx3a9yD+5aE5FU8XHsKHonj5UQuHxFidPXRXjs8lMRMGvoi6BtKBseR9NgKhUCdYHKBV9Y3NXD5ACTdDosjCDwSVPBeuVAWGneQp3xT/HZn0CdLnSgQF1ZlZt5daulocT1Ne+7XlxgdbIBrO83Db4OG8Yc5JHD5/Dz0QJlq0FKJEmPNAfAeECWJz9wIbZHAoTYuvcthRApRR9ZstKAypHUwVZAhZApwLE0bCN2YR6OXV652rQlaHMayovlHA4gm7QADdwOt8clv1cVV+0kERMMlnEJmAABJCFfyXs7FgBijNya81NgGgVpSwvSMn+RHvC6SX22utK/ZWB93kiP6dwXT43AzX54BtmXi8phxhceOpZlmO0iUcjzy8SbexlNBJUa8oxybhkp/zFkEjwf/xwUFm5U1srQIlm9Wpl3Gyxz7qMDXJEzg9g1sBtvZZtyAqiplaAxwOqOCt8ZgjgfBp9bGeYPXJzNNFb3DxHRXMPWcDlomKQV4WSTuMJgVF8Z0ZdljUnv8Or8Sfbjeph1gy+qCuOSIoHPb4gqRxhW/+K66CSb4wTQ3J4gBimVjyi7CmfuYrUMzLXq37XbtV/9605eRiVbx1/ZkcWYZiBq4mqDPXz6AslJ4TmBeaiJBeCXkpLb44XwcNJCTFrfl4m3WoZS9qdF+nJ+6sxB8tjdqBhgQQGs1AijIoDR4hIrqS/m51315QLHFHo+R3n6q9RtqYj1HmZRiOuw+YwGTGByjw38dW2tO3A77GrgDum0tsyu7/D6mKOGRM1w2wwO6Dk67ZfRQ+Z9ppkGVM8HuT59M39NBZKkO7XP29Zn0dpxwrFpUx+bVJ7fHqTgCovfhygi531fu5iqt0FO6jEfCvsDNnnRXmRNXNSucTZ2gNGZDzGQKTo5STA976+R/6BHXzqXYdr2KIgRsssN37GLGWum0yRtzd1nirsirW8YkRzbUdG6ghuNjtMTn8jPose6Tj3eF6WSzlkhcyxCuS3O51S5oRWPYZ3R6D5ZZ1AUmSx2Mh0BVhwlW8FkeZUET/cqSbvl2GAP0u69FjKLDmMzN7nYy57QshSlzeCdbL2WPJ7b5/D1w7Ybb9fWSQCefCanwTRnDEHAQfh4NsVH+tExbqxJnbK3C++QhMtmgPL1NZ0ZVnO19vlOGHFp/PzxXV+Ua+hmSdme1MXrNHl2aZd2TVJl8leubIeBfEwrtxMEaP1taqyHf8Rr8EtVJk4ACJeoCr53gCQXlCoBEimlnSe2GzxtLlF3uRDE4wFJl2KGK6j1Eh10GuGwZ9Z/0poJYhcSYb4PtWKqwDslg7Yb6qdlMX1iUpLjTQOFTGSdc8mWfgyeA58x//jEj7shTnOK/BSfYSe+y3tmSWIat209WnzApmk0/+wMBXN/hSu/ERh+OxEKphP7+GukayjH3x10cFzcUwXM3JuHQzEEfZNtUM55Wr3c0J5DdMNktrV4SWUH2DSFpuv3wa2NcheT18KNuFqr58cwMlzaj40/ypXQO8IamOIp4iTX9aW97vkZmcrMk2KmnkNA7u7q4amxutgqxQPHQJ9VyitqIYJiUXIGZ+NA+4YL4i7KYK0ShOKqOlxC5AwNhbyzayCMi5ErKMAFBIFoZBcCUhGp3KR/wiVwJmzv/C7cPwhVvowLNWDzNe8/LAeb9glwVlmNKo8THp+5+k2mqW9PzlnLHRED/tb5o3iYn9Si6f92IpOTE4fWf/S2MN9M9lQA9mv0vcCmBdi4a1o+fZV3/pluBN/MVQ5O+tqHJvFdTep7eojnomw7ZG0KCHZPzBEyT31jroZ4OO97dUtACk4V09t/DBTpZneNqO+z3NboRWsqhsg4f4rmOlpkdFrCcRDpkSb6YO1b+ygbVtALK0jQ1DLbQap0pKwc26XVtqlgyoOOfftlrWi3jVY/UJqvy3xRttXwkI1isTArQWzHmtYZbDbtj7oGsoUCKXQ/vejUsiucrqkwFp4DNdbQ1XGOOgF5YH/p2zcfjhlFpcgyWjTDNdbPrkNpWmGr/AnXpoqyEhLqbccqV2fGFKN+Izlzy5QY7OK1zftZVSqhziTOgxDXVK+GwGEdX1LrZhcsFG0Szh32ZyHbCE/ZAXe6jkTLthoDkOSVdITCIFalYCAzVhejVeXoAxT0HYJ5Jc5UMrfUwA9ZtfmihMoJIsxE/BVOwJ5HPt0nx6tbsW8cz4RHpH9zhDgCyY9Nbt1RtylmToUY1qqVIaUy3xMCsvuxOnMLsjYlHM92wIqGbTOXbbJY0BqmzdiuH8ykVw9vEGX6+GU4WfKXWgPCA5+h+GIhHNur7rV9e4L1qylfGlGCGh2GwQOuxX4bvDoWFqJVNXv03xFtECq/CaTHdyN6s97gkc7qkjgTbmEA41Ntxu7aE9c9ZfJIB7+DZcMMxspavkh0kAAuwYw4tb6L8VXz15Mu8K2oFV52WBekFasH1UkKW0TcLlk2OcIqkw6soT9Rw3+IZRluZFa4r5zuAggojlubxE24hYWLuaPb8TNWq8e6rHF4vBN64qHdWwYEQ/blERRpJ5v4vXCj4XoiWmnxgO//EUFU2coVOrjc/PbD3rVl0XKjy+oJU6aWwW1ND8zcQR6quSkx2nvx0CP9psGMEjQP3mXpj+sGsLflGMsk0ruetEsssXq2O6WudjimF6xicjwVRy7hTj3laXFTBCSROeRh+uJS9pI89R4RJg8bTGFbzDGCAmCfeHDbqZ+ifGRndPhm5wFMpzhoERFtSRhbCtBa7Kph5IRnDy+utCoY15s2kBzxWKGLnaOailI3VjKczkVyMGTx0Pd3A15dNRZBP2GfYk4uOjWNr73idN15aQMVtoyudSsaIdB/x0nCvQr6DIIaescYHRevijFuD1TfF9ocgDAEB7Dpa2B00Cb5ZIShiMZHColqSxmtEpNcPLtL4BrAhJbxtAcuhuYxt0TbUqdiK5EjEpoYMG0sRiAfU8uIp8fY3ysH+js1eYdIQRMAvUFN4cf+yu283DPA21rwYBFL2v4Hd+2JRrL9fgDP1Qk5hLknl3F1BpbwT9xqfA+zG+UzPfZiQnIg7Tolzh/zjAjOyKk1PNs6oJWkVt36BAarqVlv+PV97T1DJRPWnat14krv51kZVhzQzTpKdDcntL0RC2gtjTn5OxN2Y3vXGsVemfZ6Lo7voK22QW9uhtDWE2OF6Ihnhfu/R4RGaECTRZSjrxDJoIpxvpMX3C0ld12afFxA+OFuGXHCCAwm9BAdmU/vlUX4itCFQIsx/yoHavKOILpY9bKxJxMiFI1O1o102W+Oy0u6RlTmIWUnVBuaxvWJ9/UdPVwGoMGR0Z2ycX4FSc+IeXAUccOnPGB/jOJYJs8hhKmDYm9XuKzSlnARHKlV8X4+XpM+GRruG1qkLV9R0J+XaA0F2J+kq07ldJ8jnj9onfq+1YkediC72Ugn5roYHE9KGFLTYhGRzgZ+7L95Z8btJ39VTwEyKiRGvejYAQEcPDSAdieKsKOurARe3bu2c/gH4P2cwYvKD5VD7933+MO5ZN6exHqwRoFYEAjfHqBGO7NS8UkErDdSuuNuDQK1cC1gO0c0zz0bMwnTFGdDmqFXVc8BRHh7zpn3gtd8nHM9Eo326I3q3zcBXot1WHmxHcCZPtQUfYUZaLq9qqNI3rtXLaOu+7PsSooWyAr9zFCx/4fnQ88ZIraFmXCewr0II/XCf1XOWufBZVH5GIJcDuUJhp77NhO1iVaaztsG/6JiZJa/mRCpqWSqIJG/FiLnkATg9hfRqe2BiVt0v8UgQOGjl0oneyNlA5ru6GG6foSh8EJsQzPdPVXRP0jXcqiYu6b8/wV0XoS4QUJvcj2d7mRonU9P/QllAzcu1/tOhT7oDubxe8aAZutIQZLOOxyy92/utd7gMJaLIxv93v2ztMSXjD625fjYo4eJYxwlWQai/yam4N0W1pMnn9DPt9FEOtnyrZSpN/DCALf4esEGXRtqF83yvbHTvnlAIr05JH/Ao9Na9zYy1+C2DVIcwpx8Te7w+gAAFPS/pKy2lPrtYAMINA+wzsYJ/AAAAAAAAABCakhXafkFQooz7M3pZWtkcUrV5ftZUZoNJKQqtEo6Ebsxv7+fzQ+9qZIRbe53c1ELcmYrCu4PEwu1wKSRGb2tYhs5OYT6D1rSWBHCMw0Vv6J+rE8Bz5j/+U3E6Ha7QFVMOmnp/J0w+DlAE8dfcpKq9oht2trKFhLun9qQa2AjYAbllM8EBEkGATHIH3DBfEXadhOfw8FDTCeJl7+HLk5TKJ8eNcwOM0afrjbQnkSy3n+Ku4uzkaRmVFxgSGiFsSi5sJ1q5HYUWECfu1ynYLyyChlVvE4w0daHb78hHnnmPAprIoOaT5D/zKAi/kRDDOZDgejN3vEWkyggkYaJMc3uBRigFNBxv42EYhPV2SegVvW0huFM/SPwNXNJuZ8wAQmFSZb+ZEl++OQrk62xE8kUQRyho4H5KS9p+YReGQlf0ZHuTv5KykysDao/d9/AeAYwOcHW5kZCLi1CmnYHgvZk0E2+oZxU1FwqDCLrRAaeA2qlwYOxAeSqEMx0z9P/93d9Yg2HiafgDlRIfi4AG/ynIvYAISRZYwdzlz2/qNCi7CDOUfUPXKPDUEO7eAhW/K8PiNvH090ZCXatVfdH4uC4ceBa/CTS6wsrd51UlrPNuszRUQq3oKN3yXnEXM5eDxyE5fOt+YLNBE46t3Sukpb6ZWNwtuBI7eYvAUQaQ/dOuXXyvJHZA2EToKzl+9Yt5DC10pnFwCDjUWEG7FFFBu6kgU4qd1OBYC2as49ZsMLG9Y1FlV57cjNytCrSrEXoRjP2BqoYvF6PvVcgfyRV7rEmNOJUfvnIgwmDnyMnKoTWhXQk0gYk6Q3BJUvsoc7I7rjPD6vumL63Xj+d9u78SOndsj1vtYAsRrAhA8iE/TRGATxDlxvyAO30LnUrR4dGKbK+6u/eCECMxEgNQvDYM6m/9uJ0LDPNY6RcpKE4Sf+K+1/T8Eb1Te4ssnO80G6hKqXA+3QFNEUl0PXAhBPzvDfzR6uPq/NqwA7MQ6r4OOBg6bJisJguWBep3mg917OXxPHLgVH2oJS0CXWp/NPxptaRRFNC8aBYjWbW9Tr4vleabG2CXRLfqFRNXFd5nm2WlB8TC1YFVUa/Yc9o/wAbnrfqfpXuQVDDQlHr/jg0Jk+6SXrVL2myxO+Mejq8DVv1+UeVRqBI7CQQqRJZtHCuzazUIfQJuZX49H0yx5xjjg7BbTNHjvi4o+6jsADwvvD+qG6EMWfrhoIeYOUWkV8aBYjYOJA8O0gMbLCoFLvyH9WA6EW/ThLZ3ldhUJS9RpS0bAqRNcN4IfQvLh/amBUOKzFzcbc8FmlV86gua2G+UDv+/TfnUB7Q4WQIgo3G7+ys++1a3IFmWiRrUtyUKLKTqrEhBk5ihT8+EtphJ6V2sfEO4CJ05hii6Z5xDBfvX9vy32pAp62WilKJJOi1FG2pso0l0HC7VrDX0J/rOMtc+2y6gVG6XN4NVU6Vxhn+Ezxofu2Y2eiY5WA23NMahishMNzO9vt2WnaXPuUvGl5GiXwYZAmdd+h3jVj7zUZG80Z8lSXzkdQY6MMbvy7pSM4QIFaLjbxvspRFemwZaAKAM18vG7ErqfwOgAz4IMdaqE9ZJeQJ2N344dhwAFaOlVN0j16CLqRq+nQYScrwJBFXNBPdE9IGzzGYSzIG+kRcitD1ZfdAHxG9edYn6GGVuN8LyY8hHoSVjx+RmUrSQCFAdPYiI3U8WKNZlOwwQENLYwfFseFZ37mYyb8yDja8svjx9t7sjWBhcXprPDtOuKa17aC/DnacnKQitljeDumRP5Kly3ghwXXPKMGgd2ll7MHkg0xM93Qf98xTobu6Flfj8AdAdnbpnzUPX69TdsOjrM/AyHPsb1zlY34CAOIZgBRHAmpC4rVPEberHy/KGrAm79YJRgkAFde3aruvMOy1ttPCxEGRNOcmk64JeaVIFsHCzxe/UQu5+oSyoAc+RKFuhDSdIeH1ryuvTSt/5Od/iJtuRXho7r0vr4lCJf7GNKQxTZSu8hDcLE3LOnT0Zqjv/tS5tBdAYFgu3m37p2caFDmrYPw4Bp2yWyYaScMUY3/2HNhPPgpi0gW11F/Q5AdtaJdl8hcLbfcJxE8H83hfKoofbp6jVIIAzN4PvzrlKBv/bdAp2LQqx46UduQwdJYiJT3cGV5k/lzrNB2wS42qNbtjt7CouR8jgXUwVjMtwUw5dK/rWILxPJbcDovoVlc2u87jqh1Utzbj0CEsywdXAX7ENX3v7Tsu9j0BgmGNgHFWxDqEt/NcM1imfZZ4wnF5wCosDQjyG4QFnzFVu/rWc6U+yefxZ7ZTVzUGJ7tsB5xIkMpZRtktKUq8Wl2QA4PwuYHatCx0ynsYtjtP8FuSPldwSoS/gsiXZEnJyFeGfssIKT5cTQEzRsPhQRcFx/715jqpP+1lVUBnjxFQfccviJl+TDAr4WroK2389Umasn/xsZB6IXDIBkSNVNuqd+BkFSijiEmhJXR/Z2Oe7gehxLhemH4pVCTXNg6TVu1EB/0YNJUJiwp6ddCnkJ03CuG3Qys7dX1FBnQbs0H1giB2ysHs6depp8P5+MO5ukrwrX8qmta+nqR1WAKSmrdoRB7LOSqkwba3YlegUqPRW0Sfg0d0SGB1dhs+4frJswuvRlaa5/dh4C9KmU9QEuM/E3Fn07SYy1wTHpud31QhOtjhKrtKzfIkllsEA+kHrkE5wUMrp0faAjrGTsIkNexyWbPDiFQpCWZYlzH37iPpP+TVCdV7ZPAirDiVunUTsw7k9pAYZxyiMjhwFyRV/ymyirY9jT/1GzzeWZT7h2CY/T+BMT6rLdbAtlNcMfEaHB3WZUW7PftekTrfzC6Y7gk9cGXsn0sYBuFXxS+Y2sCmA8vnaXe3/MendHxtoRDnOw3SducAG0/wy6xrOJ76C/bU+bPdkpv9D6RF/iUMdw2MPlWpqMoUFTF6D1WmGKGkLelv1suhJc9xO5zdWbs24m4AppKGT86P8INDsMjhCZLMI/t2LBeVRxnPKzBWe3KDvsSfJ+c+1ySJr67IW7fy23GnFXD/BikTT0H8e+SsiJJqH/3f1cYbfvmlfe76TOdUh6vTYulWOinS2dN0z3hqjVWvie2raBkwvNaNq2sCMJZmVw9bJL9r1XUqjUcH0BeSWlXXnAc3n38+nsgq0ADVNNcsSwIAEoi1P90/JCuexW3+JaHxa/ubI+T/XEjtbUT5GiEufTE81bWGMK9lIRqWmk2Uj0h2C/0fsBVXpJFW+KYb5B249MnmpVUAddWB5TsmuOCadI3PM1TiUFw9U4pN2qNlJRXfcntECeydXrWSrI3ezG/IF0MJpyNbX8UdntMWfjyYEjnvvyGlUC0G8mgEDw5rORrt99dpkMcgO2tE5gLCAfNV8ElsqzAoFZdK0LqUCJtsbFohjPRHyd7kq+7+leVAK1YUhe/Jf+JqL52LLjqgygPO38OopINMUOmgxCON7GmTlLLN/tYdvRAH06XKEDBp5lR1fzF5H0Mcf0n2+q+FuQZOMCc4tX89UfKhG55uiO1W/ddNVuiOAG8we5zV+3yXj9jN4hCHv3f7b1s7P42EJQ37Dbvi7augEYpVnj6zX8c9gSIBEcqV5iTsqBbJfC7qfuDbj2BhIf0ltEz2PDATM/O7OeKFngn5KWRs7CbOV34SSD615XXppW4usBBqUxyh81/HPYEAZgsXSJrS/SCqllITDdHEZaJ2/eG4u/osHCqN3hytcY4AKetc+QzmuEUkQdINMTPd0H/a8ex5atJzPTW3kSTxEg6nTBHPjQ2l5HtqqoslbE54IRANrTMbneB27p+27c26LMt94ZtKuvTL+TdA4WAAM6EiSngvmS75fGbWqciSjY/1chjU0V1kwdKPygKulsRg0ufw3sqL+ewKt+yKi1Mt9xTOGZkZYMQYA4EyHzqvUHRMyqOr7xiQKQ+YWtfzqTYr8rcU9XMQM5AKorrQYMAtrwt8IBImcdfic9Hkz9MnsoB5PXYFaBM3GrFrwNjlDYj+ktp/FW2vyK4dFsoCYoLMiyihn9Zrh9c1aGf8xWSRCy++itk2SNg2rKvopo1Bh/cm6+CXBJlO+GxtuFFommYubIYspNzqftywSEXY0oVALqFVGPYspt4lpqCNBwURFdi4HykNEAq925bs8ouqL29JytwNPna0Z2ipx0W7A/4Lnq9bFYEOO6HXnmxME0WqFTkazYMwb9LBePqF4ILVRWpURzt8D9Hh9v/ho9jRGaN0HFxnYyGmDpjmQWxv380cqn9Aa3m/PZHw7wiPn4Jsi9+Gkus0T2ZFZbEIw7OCzKykCC41ywtBce0HSfkMploQPdyxyM4Zw9XQtCfRg0jI3by4p9skoRIIhhZOx1wGckgaLygkD7Fjq7pi6ve3RFPOo8H63Qxl/HFbbDx+7gqaEyXPEXkHkookt4LWSN4brLmXLHZG5IWIgMMz0ll/t0Pzd8Hz/CPvPphR27swoVekZT1ubWPFV1yATnhBZO+nJHhnzPUdXkH2v1e/Iz0XODqljGm9YnneG48coegysTsLbT6dyY4Fe+QSBCdDHbmwWR466dvJ1ce4goGkTygScFyysEk/rRH4NY9dl2Nc75PtcAx9u1LlWS+IgtSFion6wA6rtbLYczsLTjuMd9BDDGoPi64K1XTBZKzltXoNDiIeeg6VuBl8aN5dSMpDKDEfAMfcz1Vk4xavchFFpRdLXnupBjoFvxf9qYTJLJbBQROtFvRVk0MOMaDM+GQM6upvN/uI7QFX5HPanRoWGB5JhV0/fheWyqP7vLI5yZGp8C50K7HksaP+jyNz/8sKYEABz7DKTJt8ieCmDNZayf2h7KCPDStkaAedAEhP/MlWclI3RPvToU60AeUNOAEnreERTq2PdOR06sRzS4YKuRLLNGoIJWu3DUJS9ZzmfjPqE2WnwJgKOKMyDIcfe/vczCuZkmStb2SGRlrlOeB0Mxeqk7hSpRoIG9N2NQfbPkNBsl6dNXWV9XB2JC9l82UNAfpgzNTc2AtRb5Vdn1DaeTCXsL63EZpH/YNIWG2xdTOQz++tKR3+E+t947ixU0hE/jcxM6oifBLyJVcME2M7dNwT6UypCTQKJTrhjuv7Pm2X2hyHgpI7MGBuVhPsT5RPUr1/5UUoASt+Q9AiPvNOcIQWfrtdnTuil0s26GKBin+NVOUJ2oZNL9G2uwJXeXT2VXHpjxZno689PuOB0x+aAefSv6pfUNN04KRGZYTRZ5x6XjqJ3oYok1pICsArh+Iu20arsSeCdXhOjIPwtZUf/Be9zrb1YQINtQIitOkxE8SgY8kxI7PnBhaH0ybN+40nc9PY3sACyZGREnLzhyspoLdSzfv+D8/tkTp84Wy6c3dn6oI1sqJTyBZNCO+HfaqfnqXhKlyrLl2b9YOe4usDQ/gnvfnpmLOrET4zx7Akn7iSaV0aRpVdQR0M2fG6KTSY/FYavc20wMURz+ZNSX39JT5iDmYXO40vA38PGFKuF3/KHl6i4edEILF8jIPXJ3LXxGc44bjsn3wWGJ8AEXO1FKrIC0nW78+9ct+WVp0jBumGNjQRBuf11zV57gzKRDo1O8JdLYo49+PgOzGaY5ZmGA5rfkfEDV7Xa8oIQuq2NxPHsIQBvAJM2b7ijK3Dx8MuM7z84yrK0nuOxpdJ20YKKY1l0tjMsRilSvIvpI7fXG0M2j49WWuoIiUzKADD3iXKWjme7g1iQnjvWY/c8PHTg+pfGVhbDiQZswMF6B6nzXLCySbleWrgH9QUBoeJyQkoBdEOEYLRvgIXVjVd99t/pi70mGAQVV3DqmA6lIR6REMO8t94d+kGB1MbASapkUaCZqaolZIDJ+X3k66s08kxFaeV8tFDrwc+JACQXNhBhAHPwFHD68tl40AAAAAAAAAVvcDq6622mRbYWG4GsXowRc/7UDoLuOP3ZClLv4Fufr4HdF9Fox8T8i5jevk82e7JTf6Hd00TrKZLK1FgshjJzoB5NQ02QwtahD8NF0hQE/7FEZdx5E8WOEda44xRDB+Sp1710MDpz40G0dBRPqJyZ8qlAxfTX9xA5NKp0iK+4d71u8hyYrUNE6QTamNcNnBxfaAurRCmsk9p4qt+0Zt7bj7CSho4VB4q5hm/+s2yvIzTobw3LTU1uKSKLLSxtUOFmm8Y4SZAnN2R2PUr0e1vyVjGmltwESUJHxqnA7SHT58EmFJjDqk31rmiyzjCv9MVMU3+TEUdJ6PfZhl0lEmr0EmG3HtXvhrqqL+xTth9j4fYJ0wmbK04Fr2R3oqJKMbsilwbFfhJEG2IoDFEndQLFykw0J0p5omHdWJtFaNed4isUVJHUQrdnfoTu4KXekw7ygjjBVYu9zbWe5koAxrT9eL9AsszdptMSN9kFQghUkcOD7gkyNRMZ4QEgzLq6M7dcBx5zpVlIEMSUJ5gQjksE+G496DGvhcTdobmkeUnMUu/9WfaEbSrrzhiedq+JJU4+DPmLcy6Qwne9AAUAZsDYz/Cth1kuC3hkobjeyeMeM73J7Y6iwwqlu5LlCZ7qbHCvVgyjI/zeMmAusbFT68VHftBsC8lPiDrXoGfSYMrPnDXfwPfcc8TLTNAhvCv/PP3HtCc1nBJKAk/nupMWqoGiqj1FnvUuidDLQmXXeSH6TAe4Dmhfv0SLrHGoCTg05oY32nlQjfNgHaP1VDw8Eae7gIbW1j4lJtsKyhRpkJjaVI44VZGAwAUheLty9Eh/zcZnE+yCYU9L5Kwxus2qyVDxnmSf5EGuDu/QcAYVojqbjobuOBA4IriSgAkjldeusM0LZAIxsRWEjW73lLca/NUODMVKoxwDyAgHWzG/y5M13vjjzDso0S7SuVi7Wzd2lf14S2B4Mk8Qo1fIr5KwBA4JeF/ESkCUNkJLrMFpmquDiTe4ugpKZUorJNCQiOCCEx0CMaou4DZ4EJ/v9k+Cq0vq78b1Z7siLPOWSxDGL462jZkts3+yYQBca6GBdRZp7CwaxkXQua0LX9n4Zzyp22BHSvdA/HjnVdOF8xyS4OtPag68IlCAwrgkt33EMYcef3N0EYrUpn/gcMN6K29FUeRfQ5No5KWpyvt6z+7NeSa51kF928xNB9lJGfHXhvX+NL9gWg8h4CM28+1+3TjNkmo5zRJjtqQ2vXSHXmfh+90ONLZ+9tFTAVPXsJj+h9awa7ne7tSjz5y/tr2sYHWidnUwsRHJh3dzI/+2OmwRKbucLBQVN/t0x2ZoNB39Sr6G9ZmRLp0jb3v6NnTeonfxoFiNflbWU7LoWeHemqkGd/wGB9XH6fpgvRzELw9nGLPhxY2mfiek2Fjb4rUnKo+dkn1s14xFnIIO2bUHPa9zcVa4JNyJnTR6uMUEtNF+bYQ7g7I0zF71e6iVzMSushTwL+9nxz32Ln7dl2zBedTArRadTfVnqA9THuOkMB4PEz71rruqvOEQCwtusC8AzFDHBoD6CI2FqR+ssYHHqBKLk+xx8nHRUauTnYIKpL7NO+imr8zeWtlVwzYKqn0iKjjBU0NNmZYjHEvMQfQoXZOtjFJgGkQx0TnUQZ9zVu7lxqsrMq4NQSyaje468pHYQPZUc5zD8CEMXBKMGFA8x3BP9LuAH7+xZRZDCccH3N3xdSCpgRJaQQWXJAi3DV42BJK2dCEpqd6dWwnTiZYb7OsuFN40vd2aN//fVrNTXRpvE3RSJ41cXAGhQ1vA1bev75Zdh8JD5JODuC+CvGN3/eMBMRbf4F0tmwrAMXmJQ33Wzkpvl/BSHRJTSG4wrczR3tZC/e7q8gpAosTydccdUA8oTytgyZSx4va3BfYGFSYp13LHmk4ZgadEvvcUQu179SAmHlELoDWYYcF3S7iqaBAzdZRYas974DPEDeOKppinWnSwRtokALhvWKvJF921FJTTrnRc8tw227ObYqS5J7VW5IeXLmiTxI+IJXkrT/4kwmDXs3odmb9avU3lDvRQuexozQtKwmGJ2NEUF6+BPEI1ZQSWqw00Ik8QQLle6Bl5czxZhNI+O1sNQYmutoJYPFtrkNbveLORmZGG2JLnBVjhRqyKydonS6GxbeVNSPmtjpX3aS8pUksoE6K6hJJ5ErfwOzz3hDuN1Y+J0w3u7MH0GzfIZASgdWPcIz3xbfU6TB38dT2pOR+rEIPc5VcU13L+Bts3NQqK0qDYuCbDc2wc1V/ssxj0CNgU/UNzHg4hY4U5AmbDN69/fJXFzknKZruThA1FJ6d5WC/kQqloMZDDhCR+IBCg9p1iy1MsXxdd/E4yo90/rw/3zUBplEvDTx9JPw8GVxq/CHJ/MCG65fWP2FSmY+YiiElmKDja+uCpnFrWftTNqS8O9yFKxBEaGFg1VmH18VfrYQkLSiK5jxXAwoGRTJLtWekmQYLqkynxjc2Y0Z01zDOR93Laz6/KsS0IhF5PqmLeGB7A+NyRLlaOl/9VRxTCmSeFVrkQAc8lMFoD8dcAzF51PTLpolvd8ikEpTDy9XcB8QfugDYixPJU93nQ7Dw6po30T5Qec8xBHJGuBhVt+odUWebRFjC0Ey3FQ9t2EhGKtVxSlZcSscqOvuDZuvoOu4o/FU3FdlkjBt/O4LgqdjulcB9MxjC1Y/IhoMr4dkJzUUKmrXDEUnOF+UmHqve0OGgorhSafRKaw3fg1QrkFmCwVrMEIKDcIJY/DHJZx+m0MPBgLceodW01JydBSLFMUtaUKOCIzWtUhoqFqxYIXCM8H9LEa8GBq0eHdW8eMYhnva58DN+2tQcja/mv4Cb8oJl1VUWYKlAxTGIC62FS35RsStNl4qj9hh38QtN+nR1CX0n7IRTpSbMt2qtEy1fSp4gpN8lqkUd5/KCgWoVsqob2JH6nhVdMFKn4aMHYX5QWAn66UDwE37wxNvSvWDi9XBDqY5vy+YgMQhQGz7LKPcV+x6B7mfRPx4u7t7766TJclq0BJvihy2Q9IapGxeW6A33dUPH0wzzKPIzGGZALV+NN0ynXh9mfIsTUMs03sVDLNN4kjjBJSHk/5bCJy0YjxESoshVnCWd90lAZtw0HNa0mccndGHUAFcHhrTijVfzq0g9mNIlb3kvS/rRQ0p9TMBfrwLs1gr2g2SGUMqNPkSlcNIiD6WLJSqen2iBx3F7IuDDnIftOZTiEOZXDoZOtVdGx/jiKnK3pYymaRu84j5lkH5jbzbRGhvooSrX7ppNZuDg5E4eZHrm8NtaL/61FoatXBdC61zUN0Lfbvvj78UcyrE5w27yGw4LDd38P2/zPV0W0jHZTp2fmPLC8BjGAe3JYQ7VuKMP+bR0bQJm246nc+emvAZyvnLx/Pj2T06qVNpDnkADO7+0Wfnl3aLzS1um8ikztr5J0oe59CwBdPVoSXRFdAuy2/jrC/GJWg20TE087XB8UmddMSzPYJ15sDnc7V8fw9tYXevmEBBOutQanz2xCGKFr8JDa1ZE3Lu32EC4BFK4SS6i0LYvAKODCQJ23unIbXJO5BuAwEwIAwWedq5sZxQsufeVHXlfNMPi1bzpkfusn3Gx4kjHJoQUBeXcWGyF50Tn+4ScFlrukkEdSYahlqe7Z0NGG222PuLu2ON57arPmoHKP8B4ZT7xsYLUIqVw5azADysCt/1tuCEZFk2s6c8GhL1uSNHFCynpTzTPb50HNV6BCYZrG8fTc10sfevMrCqZ0LGoB1m8disa3M0b3+17TdJ8hgWNL3S5rgkl+9fNI/4gpDlkMk196dGcgfZ185p8BkSUFgXNZWTbgsqt7O0bGv7eXMkj+scnKf73ZYlFv0EM/LKIxzjk7mtX2DG/1LByH19eW8sTHRdBb4+t3Uign7Sam95jE2i3iN3ajujI7sEzgU6/B8J0lovEoPpKyU/UqdvVNbbN42yVX2iT96T7C5NjzFaWkxiX5rCGFTckQGHwl0BjPG85zWpJzfP2dadQUwvG0huMixmIrnRfPejfcLnGdHAPEuAsyDS+XrumKNKZLwdNC07X5CaLQ976tLE2pivm7XcZOUrh3cvK13lJ2QpG/YqcPLjT7ZQSAOL7/8Kwn0TLHRYTy95zbr55NOWp/pEiUUjyJ1/SyR4sbVE3SBBu+/vnKaXKq1x5/FUu0GH//d+yDLd/DW/5XRJbeTbXCGpQLm8DmT1Nee63zDJIkscyWkwlME4KRVmRaUWIP8XZ45yBHF/D7DIBRX76IY9/vddntrnzRQRdYOMQy1ltleY27U5E67cojrcbSa+1ShaI/eLKUP0tuuI8GT0h3uEDH2KSvJczr40Mix3aDcylScXO1mQs4H13cihIky17oC6tEKayT20d5E8oOF0V81h2N8V+01Em+ryGW+xEFSz0/q5qXu9EgDxuDFvyUdrZdp/V8FL2dhYUEww3LHpDYY1rI9AEDwPI++hsYDc7OG8Fx8U65eN81UTgusr1aM3i0KViyavflrBGsuTpKPJ3ixhypD7ZYuPWYrkV56Ubso1hb8JN2Yye8xHNtJeUnJGTr6wCq0WtAE+nR6W9QS50+4yIyEC0XRf8AAGo1s9s7yMewggdWetbY1Y9i9HpVAAAAAAAAALNHSTMoW1AMb2vqUoVHZ5BiuUe1NJEGvIR9Hozkn2GpCO8PRUF6+ZcdgBdgHkIa3inDZOYpU+xcm8h1UdghzB2KQDEAQL6YNDDE2dVKJgoQ8W9ER9F7eSy1GKHNMzHk3ystgKBnLu4PlSnDqVsPSiBl7oRXPFOzNMmmJloUg5uO3ijW6W/lbdezvaoELYNan1IDxwONJ/QSgpaxIa5rpJnfwNvdejZtcVO8Y+kL89kBarZtY9osfxwS4dZ5BGdXlvBfYMcLcjFiLttv4ZweSG5PLFtMK21acGklR6Nt3z2liQYnQpP6Jz3agTBRZNYoJ8+k2XiT8tYOfKvbomLHuDpf4isPa0CIxkSYxM3CoG0sWiQfIHtkVTC/aFDTET3f3yGQEoHVj3CD/jlXgPJBw0MGNlA0bWcXtf06MG6R0HP5dtLsyda5ih5r+NM6hXCiTFsGactLrhoYSIkXt4qbIUkcFIBBvC6VyqY98zpr1T11FSOkYj1PAGktslcmSNWnXP26eyPJ7iAEKvQqwaO05vbCoERGzh0d9fCrEVDi+43C9+qyLtjEVVnVYn4QiNYrjgA7/0AbBMRTjlMDeukdfM49tpetJb2cKCGVldv+NIuhT1roQpqugZcNV78aLV43mu+0YOnrbAR1dJsjvXKKOF8VQuStuBGpnm7tr7EAfZvLlropPG2yu3bZPJ/oIu3ke6ITJKh/VfatE/t5tYSIrMhInxhzrtVPVy5SKAHrM3xr54D4AkKOCIzWtUho3gillBAA25U1srQI43oEoGfp2Rt+qSgf8ikzaIDmV2PtScOtOF2qwhME5HaTk/cm7fnCJg+VZC7iDVoiXdIn7506VdG+1ZYuC13iiDwcZZDNy0y4QLsjHs3WmltlR/8BPOEill9FdJVXjN0h8tjzojqkpqHp5159K3zeZ075V7j/FVv2jNzBPgPkRKQfM5CgYC9R5IXCBIzKJW4veaBjUZnTDTuGsVeGlDCNV905J3G9gaQ50/Bg6nPhN70gTMP3RCJrTWV66GpefksrdqqcwG/TFZq++nbtfBsqLQZHe2V61ExfjPaL4euHfHXzwa57lLyQH2DU+s9EcU8F/c07YfG4zy7lkIATvqZqPoaQcFvUvDgUY7VHte1LmUxpng9yfPovIVu3v9Hy5R5K5gtlHutOQ/bJcsISh+5qOFM2tXsG1frIAoTreZBocZ26ZPknXk/vOY8ZZFsYG0hceknXABx3pgdyjIfCG+bwHuG2neIjOEtrgKTWJh0nI5Hy+2WWjhX64YOny9mVVyVNzmQlxegHADAngTG+lYHibuu81joSHa+tw4ZUQJRhY3bU5KjtNhAajPQwzpp+h41JjG3zfurkewtQ9Ylrc8yy5d/rksPLawVrWlIpnQOeoP0cRBCbBPtGdGXZY1J7/Dq4eQy2asFUGy1LDXNdG3O0Flq8aUSdUBl2VnvP/2i1Yq4SZ9Tw5DTkDNwrFY71xgI92szeWimz6Isxj0xXl9zvgkmc+Wjwkt2JqgKB+IrcofiSxCs7ZJjWVOsdhk/4db976oUouguJUB+7xQiiMGoNSJ+CeTR5FFxJA9p91nQ5VcWdWHdgmpkazabcBTHShBiKYhAB4nq5JRdhda43q3HYkV6BU1RrNHlkf4fbZoseF8TQJly9YVz0kg0p3j8Jwb1UGUc6aTdoEQ8KAUuvPKVCxaX20SRnpWdKTUTDpQa2VOQUAeLlKUsP8CBTdf+DTzVdM9j1ImpHfHESzQmShwcgqs+gLts8fzLsa7sx8MJwtwZoKlsa/7pY3Jn29oVWwAohezTvTrfrRiaAdVXXrA4odpmMotHnjjboXByZAGWI6YQRx9KqD8UPfRZ0lDxfenoSxTo8Shz1bhOtDwbjPgQDLZs4Swgd92EJAtbJSoOXCAo+CioZWD5wPJS/NqJeSAJ2Of2pQ582NGoRsO9Hu78VMdBb1WnrTXwcDK+jP3YtbbdZnEsFytWSt8INRoxRSVOW7V0qXkdoUxmB+u7sMm3wx5UKXASGbVZhaKrrca7AVneXXYhucYHPlV6LdzFiNxMTnDPZZ06wwmsobd1oMDhIMS7ct+nGFLAS+EXhupzacucAs2EqsKFo5DCENvGqRUEBY987T+RWIDhITfYp0s2KTFYAPM5Z7YsZnOoPB4mNqF+uu5WMWSFx4hn2/z2nE/Ccsm5tlRclC7jg2bfdVguN4FOGbgaZRIBg7PSEDLLUH5Fx+AQ3lFqCsP5UfDe4XkLWPihm30H0Rtt0a639W/4x36fPhGnodz+euh+U1+uz+mcxIjm2o6G0qGZBg70yjQRsbe9YmuY8oKrJpBP/Z1TmIanifFHu2t2/BhPNvcr5gimEZbxoyF8eOqXkR/hyRHHvP0KbGWQfwaV/0U8/pDCUSDHN6hI226oCzseIMA+T33/YUy6L+gDFqVTcLtl9e65fwAm9PqhsI1UXbLglhBfCaAeXQhTMtIccpszc2RSRCQzCoq2844iMPNv7W48+icDBOahggxTTptRRR7mcooQXrDjMDaOj6jsa3PZ3tuQwgwxE9koS0+VQZJrMF+UflBC2shIUKlujcHNjYO+o0j16tYd5qX3V/UeaZbx72HBHzBvgdgzvK6qXtwFInP0K1UdgKGWN26F3vzEzM5iCOpynYJoxAV8Btuoe02rmGKAh/IFzByutK+nqKctrHldUh8KgCa9rGUswvF7CqKBawWyqiZYnSnv4Nlwx6NnRf7KP2h/iPboI0y6m+yzF9015Z4YAKG1BxsFNsY5M5s3rIfiItKEYuTfieG3InNU2UVnoQQCLYAa6xqpuXfyFQpiJh1YvkkrjriOQgxCMZLd74bFLrtNUFUV6N8us3L2bLFB7dTEQZzoDsdf01MyyZtUx5cVGo9h2ShzfXDnvdsuAtf/tAf03B3Xa6ytPIJ55V5qH87jEZzFw7A6PvNiyXUcBOx2lJ6GyifQHh3UP9SrHFQqzELN3S0+YpJkAiYA9I1LoN1woHH2RLTAg/QKtZlfcXAljebQsue3CkftVLp8b7LOMuJ9F7U5Ryk+BoYsXbxyPrd7nhTgpx+IkpimHFLGXkvtXuglTql3m25FPF47V3muINhEpOmQQuhWMlo8kqMmliqTxorz8fJ3zRaaWmkINDdIF54LSPqgiYlW0x4QDAkcfifF9RwDc23auyzsnCHSCcTm1BTajoA58KQyR3vnyeT5PJBWlpA6FYGhXoiE/bNr5FC3cyDPNY9ig5JmahNYiIE0AI8FfViU4C17S58FMnMkWCb2y5o8HWdN5W08pmPhLoE0WjLTMRHrnwFT8yR3vGHCLDPh5a2cR9FQunE0YacRgzqlM/OIyqd/hoZo2jx3LksAMH81qYsZ7Ye3sAIZ5SxKYCKtirtLReMWoEDABlIhj9wzPlZAPHQzFbpZSuPz0HHkhLIjlrHfbCfb/TaMm3HxOKkJrG1Ai7MmQ34kX82a43604SCInhPfxIGxPJSjMwGyRVi77X+iPr5P2seAeOzI6Q/KTog8uOqKPZUF1pfBA9gGIvZdgvOVGkedfdAkW7PxqEGUG3HtUx/85RqwndC+b2d06PpvwA+e773dWwEOOtqxKVqjPksormi1ec1+BXcD6iAyBQDAqLbhcXtzz+hg7tZ5W0vXuAAW3CgIwNhUOx/1i/3Scw+YYMRhHPAmWDM9UMiNKmn/IWAfA5yHtuFl5KSW3TIERsa9Wd03fXp3MrG9hYbYj12yVqJNAU08/pjv0emAkCHdAfiJ8RE4rlTAZyoucD1dLLaoqSeZmGGmmg9llkGNMs+ePocP1i6Bb8zFc7E4JC85UnD29/Urcx1yXobRLkn4fLhrpGI4rLCtve8MeUWm3ghL77P0Qhe8NIcALP1n66E0BHxqSa5GrIi5/OPrDxSz3590Tm6cdFbF6/eyIPb/qjETwrIOsk5L2jPJRPmWr8ADsTpLDYWgTravAZPEb5OAW8+reN/Ko/tMs2NZuw3vsY1TlObtIgguTrPn27hLNGyb1WkaHXrmCSJjWwsa060KNakpc/8D+UseMcwx+vdu01ad3tnoJDNgyYkpUKtbI3HZx1lXLduUL1HvhM+tFc6f74BItYvftXaht2IYELwtwcZ8+Whdxkgsky/RLT1AGrGRNkvZVw1gfXi8XF4Y7y8mhyoLT1bYr5YrCibHvjTC/JtZX9gYeJtqnfVbzbP2Kxen3JR3DYTbDcxfsM5H3vHmb7TQ3FDVWIyJ4nUkDdiDM7A2EDLogXg4cs/VlETuRPnyqY0LKg4LtWT8d8gIasOmGQzkc7nw7GG+r634GdPXVrMX/17mdZZmRRTUdvsT780tYUOda1XKKoh8mlqnCs7Ytq3kkvDtobRnMuJvNxC4K2xUxcygod35ppCSQzHciMZLQYU98owexW6TfhWq6ZxNPxDD23zEVpZbBlKxzPLahSkAaYxqFIjCVeaIjrzPEz2L457uwmBJKX1lI99+SUNPrGanYooq5rWuWmSmrXMdXF6K8X2e20MPoxOkgE8+TApBpymJXSukAewybbXxoAV7PMQc5ebbAH4AVcDqWfW2Jaxw66GKAAAAAAAAAHzkPzwOMre0P/3mYNM3ApaHb/BORcDtgbDM+Zs6FrgkDoq4fRywX5IzH3LskYNplncTqM0+JuxorkDYh69CYgMe814yylgOwtnjDwiPkSDcyw3NWt7hKwuzrs1SRwdeMgAg7VPFY2C4YEXrXn/sS0wt94nySd9sR8Asqdb4HZPTf1YngOfMf/LoWvFqkYU9Izvix+g3mElt42JahZhNRzzZ0ZMu8rvWAzTNl/dudpE18Q7CoL+oqu1/DYgAMeb8+xDvW8qknmM3feJ6Xpch5Cqsk7wLMqEk8fOcniA4gCDrVZXvFPbkfxKdk61cPv63cLcc/MR7GAFLrnfES6kRHPNcOrU1rgfWKnYjFHqSsakb5CEF7o854EQA31sgTQxv20lRvspPgqRqfT+Ldu4NhkyDP7vNhystIdQZox7CTgLjaWi1Diw+Napdwn8OIAouVnu+vosibT96nAwLqIPgNt1JFgSB6fS6+6zhL6xap4QYxDT7NdwcjuL5wQGPNrhsTYrCHgNsY4LttOfHrd/mymwjV1ijh9bTouZrUs1IZV9dGBojIwy6IwICgyHJZ/se9O+k8OuNeqV2oJFY1krI2WRY0ngFQcc+/bLWlxubyTRh8NXR4bsF5GJdYrtqa9BcoInTTtwMnBdw4YYT6V81AV8VUyzktPj+PXYrc3XP/4vUgcfdoWrBkcVRWNb5MuuKdTf/OgTvFssVmlgKW03BBfy/ma7t2qn4aPkC2KpVzT9jzw54G8GXdccI9tpCY8ZniuG2bUxxcMLJ4p3G1LThD+2tTr0hnIDULagoPzIirntvxZy5F+1y0jeIFbvnltLgPk4JMdOntZnUqsujcWdITwmf2r2P0EtlcdVJbETpmi6tMmMT2MLpED2dbclhVQQ/RDIO/xwdObFiYQ+PG7r//8JzneF2RS1gPuZrULOwTdiZdkxDqR9y42TVXoP39uDcZDI0H5Ej3i2059UZvQVynUa0O0y5OM8YLve0hHtCDvFTy84qe+6voyPYnSM3MHlMvdUtjyNrl+DZadtsljP+T1U7N42eq/YJtnuL6z12h4NpfqKEHM90fsMHtIljRuWwoCRoDaDLyty6qVqb/e7cior9X/mi56zq5Ze+h7Kszzmx6aXPON+1Z0KfE+MNUwKaVJ+7aPWVVAdsKi8aL/yqEQ7x9Y9s2AMrObJc/zGFcqWfNYBcuehbWWy6Yn16r46ZQA7DzDQimHkX5faPvNa91Z1AHh/DGP6ONvC3DI7J7y+GsuwC5LMagFqO3X+e7XvXqSPwbLmLWXdcW58Zsb9u2SYt506A8yIlUXiSoMdAmQrKkhjgDlLEElpb/+5wqV1zHma0DV5+v39UYzBSTtJ2Sg4alGouQYJWtalHkhsOzoyFtmTrmhmNPfiBKocx5BXoRY8oW50n6iFQnh4mI/rM4tpJOndBD5qjZwflgDAQYB6DGd2wszxcTo0teEhk3+Q/6CzZ4qwIWIoxBMoWuc+1vO5lh3Xbsa3PZ3tuPd8LLb/Y95tQcZKsrZV6U3O70CqndEMJ/xv7cpQbQ7ndaRMmtbdQQvNhYvDS4LH15y741rofsmAegokKnIQI+nC8GVj1sqFrr1sOmwrBEK/K5u+nyKkuWde0lEo2Z8mqMIQa3hfFSSuMQNZl/SvGbc8VTJG9TZj4ZkumKeKMgmrXk9saEk8bCtmnIFnzYRe/9AX19vUYlB/HKQE3vpRszXem94VqT/7cPs0p2irLQVfRAQuyGKpkCvshaTs/iDwcyP56LDJCJiG1qvormYLOJDVbkQmqnm3kL2jEPh9bQsZ/GfIbyoaKYQcNegWVhECFz8cIiPdMYYmBLidRtSypEYhM9QFV0EkaHd1lzg3VH2JFzkARvGlqLTgT26Ufz8sy0u376AgPojQJ3jX9uByIfgs/E0yJdl2hNnDdZ+reC5K5ra3wne0GZXQZ5prLrf8s9RIsdJU/NG4M23icmluFEJbtzoeNvM8tSBhMDLS+zn8qR6pK5+7Y3FgJls8tvFmz8APe/aiQNaLWO8hVmpD3aR7AEKFj/pCXvw2bAQF6pNODgtS48G7pmi22NJ0Kk9iUst9iBlaqMIRVOy8M9uWrFTCJBE6ICh7d9KW7ViOdtAIn1gflOYLBp7zYeBkqYu9wLhBlKAfEJ8YgEAFNkDndvq3RNfHj3O+6xJtQmoK0DbvtPd5MpPp8hrTcq6cQgxmSXzdu/8vnGNv00nS4zArlSz6gfsy2/sMMpGnKWLSPlJQu6svCvpS/6Q/Jx7HItBx5rw9f6R8GnsRb5GTdX4p8nHIPq8yz89jozFCQBTWW7dis3ZguUVW1wRnLM6EbtIrt7OOsN5moyQkdUyFaBtTpYH4E4cbcPcrZ6ZXOn8YHub7AQGDC89NrsVmYA/AtMgf6/AshMMETXWcuMU6U1Bd56tdmnWkRik1bo7aW4MKb/eYN2ef9NXcGX2fFZ/FpPFZyWoxBXVo5agkxdsaCO8NDPFTmaQmdjZJ8/A0f5CUsGb6vNmJLSmrnvg7RAVsSc1q8dZVhl15A9iwbT55XnOZ/p9DE3T8BNBcLjznQnEjloODLM6CmD4rfGbqKJRj/viYDS7NET+pOs7ed93+y1T084+dq2dw4VMH7YehRP7fPMpvT5/6owjLuRNhpHm3rbtXJv8NxFFckTcbd0AmNiQ5EIGDK3blesZo2unOe8hZ4nbwB/lkewf7DH1nRwWXlVARj10VOCwPN0PuLmNl/BAhcjBJvR4Jxxv0u6dbo3xs3QdXbqDK5ul3srrXEQQmne3Pco93bFoulp2pDj3IMTOBdTB1AkeFCSv9T1d+6fJmPeD3iZZBXjlvhQ7HzFhbki1LLoYoakI9rDwyVXs52JoQxv25F+tI1e8TX6pv8orRYYB3/uQbPzUEy8wj8ffCj1OlgfgXkLQKmjIOWNYKMSPHCaWgAludI7DH2vRMXfSV1ZmMlVvNDaW3GUgEgraREl3rbnfd0mM4yiWpMkHcRaiHjd5jOwKY0ZXD1upovBtH/ZO9tBhNDINtDROiUIQJUujUSjallSHGC6GILlRwlqag86Z9NQEfNvTTIpbSrrzgZ3I5SkdRgeoO7YRMYjZ2+DNdC0ThtAuZqcnAqmj0xM7fmvxODYoKPWykBrqHVS1D8iQevsSOyrTIPyHN1JpTKkCbhAUjLA/JbeEAKz17FSsJCr45XeX+up71g+lsv69bkyZk4yYqa43LWNnZnZX7XDcf/wXzJDzJirr+WNUB2t6Ey19vghuTj3zm1u+aX29jPn7TkZDGVZd8zgmtNJhLP3Z4gQVyxsyqhsV3pUIjS2E5dcgHrN2zeHgRxv2GuC01C4UxEFrRZcqq56ZaADFtIj/QQsCByf87Yu+fCxo2BGKuKQF2uh5/ErMpBgkweCBR0dv5bbqItS+d5w2VADfxgbw2QndWozY/uLmdwt69TUBNIEMFSaFtG/BoijORXQ/9jIAJK0iFyJC/FDGJb4PniZdygWCUop2WFgiCdTcx3rw4yluSORYWcrXrvPXJLC7nTh54Up5hdfOpUKQEkZLQBmzFc1qWOKhHor+lbUUnwKliAkuV8cehIORb0QQhLiZqCcujuLuPsyLz5jMWY42MJ6/xwkyV4tXZg7og5KZ8Jrvx4+RP/mDxS85YTX1pLDr127W+EbaV1FHndJ/K/GCHYlOsLVY74PeYD3z/86afX1Bx3DT7o55/RZZ9afwXTx7z2kSLAd6IvQhK4fb/4kI/eawSsvB/d93Ecpshzfc0BRIeLYBjY8cMTIRKpI8cezrN1ro7/VM8YcsumCWUm51Zsk3QBe4Rw1d6F3kT+dr36lkw6adWccRgL29PGXVpr927G2LHrvGtBvMaHBIgTe/Qmo1qeHUt+mDxUBl/AsFBShg0HfUZ52YsoCGgaLLFGEWU6VLfr1mLKV/7JwXzI4p9MHYliEXazlnRhVYh0SL/hj224Pb4oJXRyqf0Breb89kfDvCI+fgmyL32L40wD+UPonBsOgHhy/Dn2c3feKquYQcuFbtsdhWN/MUp0aS8sVUwTSp6hJNRN3kRS3z3cqC3QElIf3UKLU+UR9CPc0WjGCD16DOY2oEN0+6DbZWw8jpUf0tiLxD+W6KKIrXNrcrBhXyullI0QreVQKrVyBC6QLKZOA2V5E+LvXR7y4Y+iGX19zkM4UlIc3DrIUXMMfIWgn+Np8XAuN0m+Bjt3RGanEQqY6KBl7UMoNhi813aHw77KXklnq0ZFbsRiHaIlPa2rNjICMkhOI73NfM2gptAdhdJs3Fp5lLZM4J0HIGJoOwkWpdaK+nzmyd2AnegrMIsKML+DB7OUAkrDVr1fzSYl/zD29rUpZIbxQwBNotBvyM56GHlUsmYMmqvsRy6aakRRujqIxctryZLa8fWZJOyCOrhN3UXwMhMOrPZZOIn8cYb0c5NTPzw2wd5SbAZ+CwMte0FGvTTv3leD2aQJezH5HHYITqsRdnhrKwUnRcwGoAr0rZ1eKpYo9EnCdhdxvkRy8UV5ijWepRl4skTzUtrLppCpr/esoZULgbOX4G6h9A4nq5JS3KDfqrkFqNqPMZbHdmemhf+DhXrVSRuSG8nRb0vtLrYlE70MIuy5ryWQ1t5l+90gdgfVtpQ3eu9mIGP5RP6w1nDs7S+/xXdNXqUr0+SdOjH4tq0gqNFM56lZAj4Hsqim7mqGsH6IsZARnU1J6+wMFjVrdCnZxMQkkkTEF/P1EmYJctuWH5POkLVhataUI9WUZGAyR7xdsIU9MWGKYiTr70XAx+PKGmyzeF5vp10YoHVSZx8BWYflzO7be2yhvtZreoMRexz53cHOAYmCdBKZbEzFP2LuahOAI6goyj9D4j2dwOqLJ7zCdXZ/JUvtmxGB2Z29nz1WJ51chYTfiiDSGobNaACFNqmObP8yCOfvrLIgnYYNDhUrJ7eZIqvRjZ7M8m+E6g16mWvXDTv12fYtw5lwGmmKE5LaM0aFfzdPWXOaxd8rD3Nta+UJQA4Ts0Re5z3YM2GykB+2oiYbTx3AQuPUthe5GNIL7WPLIUs1NRGjhsKjo1IOgTxgR9NWyseS1OhGOKFVrnwfYIELi+hp5kdwiwSHupxFSm/PwiA65eEmWnQ8sweV4VchMDPLeD3MqBlen07wBnP2r15l0z63sqlbA5GxWPMlXDvY566di2VHFe6dWoliJm6/U1ZayW8xFZ5oO0OU3sf5xsxpLAiNRofl6HirbBN2f4w4wiUuNHu7N2+UWHQZCr0mXLs3607doRc5ozGCu117TC6FqbJYfXDBSf5yZxEJkOil8rU+h95zJMILd4bSuVIX8UwNVNoysvAlsQvNkPFe2s1B77vKmQy2Sww3k+1qu9ESQirmxtgrHR93tsuuWNeqJvk0muMCjirrCuovvrRj+bw9VO1wVS7BM13El/Iq487tEpjiCW3z1mEcCkwRBQx+7zssoj+fGoPBF2uobI61a0rjSEyNOy/Z1SBMwRO9wByY0TCybMwEyjYq3Io9znLUeqELREOtB8VnUZq90PIQHmKmOZoG97+EzXL5tkxeFn3+2J+KmebOP1VR1BdaI1kBbzzWMg3S/Cbst7crvaZKFTEOjB+mjNdHSEqGXrmyevINx+RiTjZkkPoePHZXoedrOqMBE/6sD2mlmG//pfIxFluclRLCctO4WIHc7QVquZiXRoX3GHQLj0HcgyAEM0hjsuOi0UxsBJqmRRoAxpqJDUNAeVbrKdao/t+ODoO6CjOr7UnMKQAnY/YQYQBz8BRw+vLZeNAAAAAAAAAFb3A6uut7gyUXP27TG7ZPBgbv1jGpR3+X67wiW5HBGJwlRKw/xhzwyxEf4AojcY/4aEC6tEKayT2niq37RnAqMXyum1MrpiPlPCjt6oMyBNcfsGK7Eh/LenJPOQNlNeCq09ku0zu0MdHmm01xr6bshWMsZWYp9UqYz88/2c5By0zfTyASlPdECPtZK2CWzE/CUHO3x6qRftUx8nxpgJjRToPxhO6+1FwfsOk/UFd7dPTr7OikPpjFos4kVUhbPGHg+QjLUnZCkCvvwBD7hSV14A60b6FcUodV2v+V2ixGT2rB9E6XkJNx4AWvjA3UKiOlPCsVOSVWRFgDNtWdIL7t5iaFVE/p2sxY/BPIb5VNt8VZrBlkNVyqibz3aWIFaLnHMVLdh02Ww9/YJQ37VnG0KsZ52BJQ7Eu/RE8X3/+mWkuBREMptxyiSdWnlunRhF5gFAcBoQOdz1AeLJctDXqwuSKv+U2QYOIedJGHcAUcfeOUFd6e16ErxjQZdSag620W5MxWFdweJhc4plQT39nS3OmvWp2U4vVCleCU1KkYiU6kBMPKr4IRrvBcEIZHaOsqXQs2nISJcfDJl5qZXxQc4YfNvIId7yi0JGqgDFauxViNmWxJdS6EWnD7JJD5fQ66JaEL/hhfv/au7DkHVPiJwBP1jsLx+rWsw0uOMsVKekaj1jK1NwXbFpsYe/7ALpR8lEhJgWRloEmqxuTngOwIQ5qiK/3b7KpXVTp3qJzEDCSNbmrf82YUgrnPFlHAlc0YmHnXay4hEyW3zfJmlUHztBF1k9T8odZ59PN/L+l405/darJNADhz8IQZqp4IBGbB5RkqJaoL2rPyhd2vROgrwRoBvoCmZC1Dj8q7fZxAD1MrU7hkKwlIPyc6lQ/GMio+t8/M42fWdANN2VWZmL7tp60whKbQtC45PtzAuCEMjtHD40YgksC/pvTrh8YDSM9JAIH4jLZeYFUHfPgBfqY6IfcswmGW+6J4vHQurTgbNoayVli857xjtm5945g8vlkNPfWQvTZ1r9uj939aseo1eimslfc5bJQTbEREEZEJtIwWp8lZZHCrZJP43vm4rREk8gAko1WHMa4zAjQhlmbB59OLyFz3K8ku5+YRLl7mfE8/MTV4R1BdEWC6lYKSX5lm0FHwffF8CZEfsT85wxStIX+ebzz1IPzU/81pfzNW0TowVZ9Z/DLFYwJ5K8ENdyfvy2z/l7oGQfRzKzQ8AWKizMG/rUyOInR0TuXA3vaN/0KLBONNjx7dAUi0GhAqOwAUPyTwj4FqXrXpd8gH6E57nK1INTkVBt2DFdTY/WIa2IvezQfF2H5flHy2an1P6FvfTvWTIwEOfozQv87wJ/I484ooFlvtxwsjGe+uALrWjb6ay393Q7GHEOI9hcjrmPw6a7U04L6JPZ6VLGnekNVpnr48pBMzzZo4qLYOT28z/dN5PrOr//i1kZMnZKvchi+rT/2G75xlAj86Wphjmmq7x8JjW5OWfmqd36P4K+Gtka2pOrThoGRUGkY82bsUAiGSYK9l5HnaXNgCYptrvbH8EnAjZGYYWWiROqPlwBmAf9XC8di3OdRgRvcmvR3OLNa2s5HLrMNbfjbhOl1koG0fzLE3KAe5lpiV1HAwaYCOCsH2Rt9/M3XCCqjQoDlMQ297+jZy1TM03cpTvPlN9OTflFyKKHi+gyezDNxvpbIWRQKMCEuC7sa1l0NwjXInnpafxpGGf2an527eYktvQ0uJGImBLBRFhaDotiKSEHyQQcIdFUtkWSSEIXyIoae85Oq3K7Q346OHxRWSM/+w8f98xspvU9OL8x/dPDDtdui63G/Mb4lssEjaAxRVgdK3YiYg2EY8ddL1ylenMKCw1YUtwUgmvkJ220B1o4tDuWqLl9A5+NvV+LrPV8mvbxUqDtun/jQLEbKMiKul6yIsQg5jDuwll4kDGDf9fWcr9unGbcazhPMSBthDuDskoNK0tcb8W+cl7y1hXriE1duIvF2DPQ5EXvTby0yvCQMnshhtGTAXbYm8n2hqnBZzfLW4wmKoGv/8pcXgcMkeJ3bhrIe/lgD/Y8W7TSpCf/9+GKKCgMGzwIT/f9/jeSRW8KAx2+aGKno/9VHI+onkI+IR5ib1xfpbGLL0rI1uYSMsR1/L42caDgik+o68Kw/SbcupbZk0iIrgm6GOKkV6JC/tnCCISXK5SvTm2PluFobzqBrkM7fHostq+3AOfQIC9HpF5A5vzj1ICYeU1BVMVltm/uLW5vpFjQHkoxyhQlfiYt9uOFkYz31wRSVoubrENbb+1g/aIniFxr4UCgnS2OQLPg5GDPNUtZqkxPkjLPnw1LcZTjazuE3/fe1QExoO6S2QAiUEayT+k6xnDco65i9ZCyxyGRoAN1cJA5dmngw9L6awiAzTkhd+4OKpHSAjLM8N+uGeM1z47jr5FwDo8qDUm74SNYMbFxg/RtlqR2zBTi30+J2B0ewpW/UmXPhCboqtRyoWGdZxaU7VY9bmbRHOAtYRWBLo9LLR/keixmEwgaRAb2KufFQ0izonS8usUdCaILwNIIGSLRpUI6eE9kPmdWQLwhkpujAAjZnJeQbCCCqekAkg37ZBpKb1Rrv5HqT/niR4k15Zw/V2yuQumh4Up2aFTnrekF0UakEwHiBd29XZMKgcE3TiwrZvoqmNrfEwiVYRvqQEw8zpEhbzKIAnRKtgsWrPNQG+YZSc/RUrjZyOGgTv/JfLz5p3SBB8FrKeh5mBgLwX+WpAZD7egrEh6HqrDbnWWEfu7QXk7kaP40Oi3unfz+N7WIZzaXAvacLEgRIx1MgPvlccmoAyJMlAKKBQap1QsBCYR5d7xcn6SoI5N5uBZ0ZmON9uaCGMIInHDowf/ssiU5WP4p6mJKg2UlachytDg4BUwet4jQ2F30bTkVfQwfTrMSH7jK3oZszwe5Pn0XkK3b3+j5co8lcwWyj2etGSba5Pqv24XJdDDE2pvWb++2bEPwWy/CAPZUfuFsVmJKVxWD4TYPkwFRIieMWk/rsGoT6r3mX+4lsCCVbo/4pXWMDk3jJM0LySE0UF9P9IMbepYXgjdEgcSYEUR2Zwx77tQ1FiMfYE3wTL7A6Eq9BBx+RYDsxecU+IpxLNmaq418FzC+KyUDX/ujktzUtUnSjlZdO6OXFW6q/QgMfJkV33glHS4djNHDTl1SMgcRhCUglF1jlrjyGDtZp631gh4CKErpetJbpVYSpLk5kvdEnhRl+ke0nuBMaZdglZcaDCkqSuRbj6BrDekHb5fE2sGe7xJS9pJVqnwlU2VX3t3NG7dXr7md+pLwkS3SKDzHldgOH8iQRMAjzfK001mPqlunZFjDWvWXon6hPHvOJEQ5oQjiwLi4s9NSLyXpDrh8O19SlCWVP6Bn7zp0Ldtj4g7x6oCBcVWbBIqxaI1EPFmpMgX90VpiZE2/bQTbW6pTa+mECuiZ0zcLYYe8MITZB/+tfbMVUabGSY+YJKPG1WAWVLaiAE2fuS8c289UTz0NIs/0IIgYTTFQGv1D46Mq1FY321re12j8cmMKUYsjpFI1B4INlORqpkfDz+spAZ5n9XJixSK/WfTonbQvwGUjRzAy3TasfNwPn04dovD3gSmAMO0E9iLAXj7pEqmftx0Dbm0Y1wH72JSYe0frkUh1Sv4kwFOPtC0WRM+ursv4m1gqtQvDcPClSrVjcfssC/wrpedPjvq9bouMYRZ6Robni9wB7cviF6tYRulKb5ehgL0BeFdFzIeYTiSuMxeV6V/ou1jBTj8ZkErnMn1WbVMmV8AgXEheVuxexE8vex//aBWyg/Z4RMHl3sTX3avP+P7w/kvdgthwXfTWMcGDVwlrAEgwOjN+HUZbD88NTK78bzutg4dAc0pAdm3tiN0CakRKKuYdsTx10e1as7lGuBA35BPtgro0ORHrP9Yv77NzpRowj8NnX9zWGRcNWqgZCQe/G4hrdAM2oob+jRYMX2jm1saK7Ggby75ugYFSEXrhgdl4IjwfAo/RHe+Ky1UYCzPRUsDKEb7lICW7ZaoCrNQOY8HBCkKqkgy6v6NA/a0N89gzP15pnW5OxOuRWt8RLMb3LVmV+y8BVkxVZ0kuWOl27mGwIxzeKgg8busph7MjE1UFDRKL6U+ZAX1PptPoEUKXHhyKLOzwdjo9pLdsa3wOyj/R34ODi8bFHOHj8co3nL3FjjCGgoqJdYQaj5vGy/om4q1vKx01DAWKGocGwTb+fFg5ajcgCCbMdLbP9hqPqpc9VqazNmPn3SDsLtSMSi61eyCPqsRrdj/hZW8ClopWOw/xCWsY36Ab+skH9cbTzxMGlf1LMi9lZQQDOd6ynjoFkWoAmXwGLbYcR2YxkYorGSXEBnt1ClaN67ukWN1mNOu7wTFWv6z65dd13Rgfz6YTz4tn9L/WNHNW9j+1FH6/kepUXrg40QdzytK0+6u8O3nvI49uxka1diQY7hogRXTQUdWPefl69XJgmcaedAy8oHiamfmnI3gcMYSqIPYy0XO4m9BWzBrroEW2BZ4f0HggnCVzDO2/OV3W0+RusZCGDPcW+sGbJypu4cOBgeahiBTyPHFyGZRVE8q9jtuzM0bn0x6G92GZYRnLXUtrjAfVdkNTvA1W/rYcKbny5GWh5z9eWl9q9XLkIo6GeDDK5CzKIlM4Hr1iUD9OSBmlwxq/FSPrcBNVv6muVoXmFdzcQyb4PgNUOw1phzhFX3r6t7BxfRBgti+qGUYxtOBYjp/JWCPIYLJpoZjQ2BO74kXv+TLSj7rQdvPCml9kosZ5mCjyQZYexNMFboq14A7JL1pBsyaIh/Fsui0hWlpP1DPKsx3O0B7Gk8bzrWVbD5GufkmaqSznJ659tx4gBvcBmZYuFNjWKRMObQvugTcrUMK4TOsvnc7itMaNUhaEldWo0xKM8BBGQZxMQmzZf+cDFNNLCZwUaSK+M2a//zs9+PKIygCQzgUCursmcSj4RNiebMtDuM5jLKnN5LZb5qqtq5BLzKcj3VMf36VIshqZEnVnllyymOU3AaYKR0O32DxvzGJhRkP+VXNEtUWavK65mqW+2dEzAsCI8bXLw+cbdee72i+vKvlxN5z2qDEsx/ppyvp5AhjlLQBN5CixY61XxA1Sw7WEYsk539s/a98CByzY+dboLRPy0MYQos1Wr/t7Rk14aPEGLp4PcN3iw2xHrtohRX5h5kO3uqwIGtNXRChpP2gM07rdrLjc5Mf5yLTG3J1Mnxm7w0oh15slMQbESG9OvwD41myziWlFicEhgywZnqgf8lTmVm1VjX34qdJNYxU5GdifdDpPiJEFfRjliVylifWmhEHNgScXZenRnpezZG4DTyO6Po/0kCHy1yd3y0lGZ5z0reOHxT+rLB2ut6Y7tRS8JxSuFNVFhooRPJc4fsNlF5bqINPWWH7of37OfzMA/sdp5XCBNFixnOMP6luA3sP/aoSnckSh0eaVJBlGhibNBGdqjonHBRzg+JE9KyecsH6PE6pF4h03HA33AeGc3jG8WdW4kVDNxW8fVOo0bPcwsuJGVpjuWjxHqJ5Lns75xMjZMP8qpyc71M4QfUPOy/OkGE/6v6BVEpTvc4gsXBiJdDWHubF36+nsnGhMEI6egPNWG2EU4Tx4Y6UoNhIJ4eW+ab/r43yOLXqGf6/Ycr39XeHQYoSXJfNvGIjBm1WmW7+Gt/yufRO9pyvo47TBmANgaxfwKcIj9KopBCgeyiG5Uu3kCLhW88cR46NGARCn2ubT12ZKqQRsdh6zUSQsTlJNSP5+wZWM2BrpSkvYrgKQbOndYtfNxbvTyc2k+fKc0ed60sr4G/4PhcEBRHUBLoGLPD7kWO7QbmUqTi52syFnA+u7kUJEmWvdAXVohTWSe2jvInlBwuivmsOxviv2mok31eQy32IgqWen9XNS93okAeNwYt+SjtbLtP6vgpezsLCgmGG5Y9IbDGtZHoAgeB5H30NjAbnZw3guPinXLxvmqicF0uvsgq61TKbms3Haoe1HumcpRciLSxowgTRS+LTx62uL7XBO6vayDDgFI7vNQ+bGSr8VY39tdamIBiLrWgCfTo9LeoJc6fcZEZCBaLov+AADUa2e2d5GPYQQOrPWtsHsXo9KoAAAAAAAABZo6SZlC2oBjRlc7cibz0UgycTrWT8x1ZcfqiIJXt/NcyZ5sxrgyKbFOh3DyzIcwx3r2V+YiOmsahTrd6vwkClfyg8qy5eVsEgxOhSEt0y/W4OU2SSsFkTApQPqLMv29Ex31lGeS0Cx00tvExkkcXJwpO7e/yIo60eFPaK8GSxEOPdXvpFTf+DNp72AlKm1YJJyDtvMJaX0aN2j8B7ooPNmy53yzwVRYlrzL0lyQuquVUTeuP051GzzeXzMck5unMAlvL+6pwhrIOe5D1tOyQqABfxMTnEKGu5AEoHrhgUbyyKRacgGqdcJof0z6OaQcpFIQWMVMXuQO1UpcMPv9nMd2605013ChbKv4940A2ZIkKqU2PkG68y6lx76q1vLxiAx1ioElCUyK70m0PiYElSmisZAqhWDSjWzj8ktDQ1637rQm3KohEkxTztl3g1T8TBBMxeX8/K+kSGPTtDkCfOoxVLeK3Z1Q1XGivQDHqDCeB1I4ubI/GeJeppyr5/lco5QCJxiWMLUPDbptXK4GVOLV8m5tMEKJ89ealBIU8lEuINsPQZp3ncdCdR+iTs0Zgj8JIgEmjmdUe/A1ZXoUQUzBx59QBK8BeQl7lrK7P8aAawqymfy4gCBekXilGdwQQRPooKdRxih9zsjfjR3n+xZk6op7yCArBY3yjSHhVpCwCGzOIjEw61ob8nmXZ59VVyiKsNxG0brCWQBi6zQTfoyPbtRXt2kpikzXJJb2FGVudItSZv0RjsYC1txAZMUQFIkfhiWQtG5jAPonSiaJNCp93gF5I0CYfMFh/AggkVDsmj79GAE3ayobM98dR0BU0i9S06Yu/s7SPx6j0QLIXnZyRrSrlFrObIJl1n03DDSoNR3k4G5s0Cml6gNx8c4FxMgwXQ1vBI6KJNZW8Cgm3XRLT2JHrJQfD0te1fqItItbFLvOVj/+RkNRKZyYtYBr7GI3/7zYrjhq+htqXLjXotDbcdcR6uNHYD7h/vVRjC6fMNzHC3p2U050zQZk2/F+ZbbhcZNkJ7GLNPBc9SLawaiRdWiTuvaNmlfufmzzMtXcScfEmutCovCRp0fBYDcHavoSoKx+LR2m7g2AhKPt3dHgvQkoLtCJvVYA8uwpj6nzUSen6O5Lyqo8vlTcksXV3zpLgNSLceQXCFnNE4SklpO8oNK5+c7Zi37logGTiRwkUne64bEU3Kb92aOzOip7RO8aecUdYV60eeWdiwMTkPANeiJRdwNfE9/pITFBbTSgu97hzqUhZ3q0CpstrLbn0KVAYEM6gt7azYq/j6j56ZWNw4rjG68WzCmEZgheIA5Sojyjw+N16JiW9IKwMXk71ygNV+Z+fz2EPSoRTNEppp8DVBYGnInOmdx5LQGW82cO7wrhSJaP3vVzdvKU8arbhJzVmpVT7TAhNR3wZNH1OVH/8vHQw8U3fHYtPXDvMxkC2Of0qN/ftIn8auuCzVdmeLBOmqKRShMLDZBozt633o40Jz9Cpr3tGIJnWT8hvKzRbZSMW//q93djhr7raGxi7m6vOcvu3YInWD2J9htAReTun+HnXhf2w1D5/NquJnO5bdH8Xkuaf17FoTmNtdf4oIuATOXj05EP6CEN1O2qKSlIeChpibalfgKYqu04N2eNpMMF+DZMsy+DEheoRT1l4d4hRLJibcOFJcd2ghrUMbl70RK/i4ap4QXpu/nGfsCKm2NuhYCFX9+Ax6KIGbdIBQ4sMkiaMZaX+WZuknZt69+MBg/lQKLDn1djQigjoZiWvWlAxfinyccg+rzLMPTWxV0BtsMoUOvOZ7RJKct4A+qCRwIJaAsZhW0IZvi3vpSa6fye3C4ybKguoGE+8nzrAyHiQAzwmY5wbImTRRNWU3hTa+dOmswEbpC371bI1uDCmOEOlosT3/CUMT/BMXpbA9ExjZ662oQQQx5JHJcVbUpq2erNGvZHXY909MTzbSRqyp/bmP4jzqbVZ3P1BfYBa5stuznYGDIwTi9XgrLjtWh9QG+BQtlCkRwOAkOgR0cr6MAtvIG52ctsTVH+rgM6cyvrkaKIIt1/YOzZfvRbFdjMARsVcy0tQ6ziTqCp1/5sWZiEU2nbUSgSvnd/9KLswZgRpEghOvzlpfaVPNyhvYmPxS8X9M8sZlHqUbj+4tk3fxEUCduqG8uxpcYFxu86JEi+pEJOwTyhV2BFx0XwbvJxx5RLK1au4PyuEeyXzFipaSF+Fe4ijfsFG4f8U2hvKQZ1F6bk6ZhkKyN0eiqC39Airgp4cc7XjvqMWfQ3cViTGhhh0W99S0mObwAQFjHJBRaFar3W2kD8ktfl4mxjYiWLt9n4x2Fmg52MvKQIst9Fpi0JoSmBAxaqIjGLU04E2I0ArLRp/oUaVQN23pxArPuNkp54m3N5TXyJ+gHHBOF0ytdVgg8gXagrgoQsi0x3W/8s9vUCC19XiItKFUrvDnciPJVH2q+JwLwZG7nYORCoUxEw6sXySVxwMLQ7fMx5N0eGxU2Wj5ARug5n+FprrkElELvm8wIMYCbLddVfl8lvD59oJ0Ly6mPizcqh1wN95azgiLdJTzsghnevKnQdk0cbibolGZBphNR1pZl2q6s5UnHtUAs0KT8e53zoTvbNMh7eFByqnmqJpXfjPf9Tx5Ckk5vB/hvvgaph+HL1TLEre1GuIyGNDtbpf+gJibM2Z1UtQxjiwhMG0ajPmQVuV8GeIpJqTomO4MNCKs6jZ5vNIYJSVLM77wP3/cHQKZo2gNa66rw5ExauJM9TVxdA43AAPLZHFY+itKxZOu3ohVy04Uj1E7TNxrLeI08n4OdFEYeWWm9Aq3iGz+TH3q5qnO7MO4W/TBhFtTV6X2mRiNnMsR9kDDg4/r79wHnftXvXdooRhfsdFRVq97jl02RiDbzq5J236IuUc8bdNxegYbqrFv5oIvTfADZEOxPtoaG3uZw7lCz8SSy2B0lFvxLhOYllNoGeOt5XTYeRTV1VyMCg1VYla57dcpCHovqRf4lDHcQfFKn2FkfXWoqdpeQtUHA9Wj/cX8za6wgTJp3ILooWJYg3phvYBeeqHok8RxHfuSTWi4qQuiVSHhal0rzQPE2rZwUuiq9PBx/BC0JMfe6AlA0mTJ7JoZKMSItydbmfO1wzjnnDsnn5mhoD0ZvLj0J4RugsCqSWoedEC3KqR4HsHfPs00jrAFZLFhAhgsxuLTafNkQVxTcuA3xS9vW3cJ+BgeJ4xGhtCsunu4MOkGeSR5oRANpgXHECr6NmDh5KfJyO5t95ERo3dBi23rMtis+Qse/KDIZb4zV63jvYlPfL4K7vt6C+1rrAodnqK/PdnH76AjQRodmW91ElXwiMRQh213RcCx6A+S5a+H+urqPmDyIVv7/vndjgK3V6UCgunRZt2fEzbzgB3Ah7schK9/9eB4AXgjY0WVsxkQM/Zn9ajajdtfmkLc+j+Va8P+DENAG9y5FIhErkQdwr3ztqswWX6QuH0pmZqJjsE14BhCMksGDp+cKwzoSyXVZ0GTaaamwtF3LmEFeJ+KVrO//kMUPvXmd20PxsYW1u/84gj6eU2gXJFhGI5wvEDvo1xkqJK/poaFs7dYSE/NWaB8FsF4zGAqqUIqyXw1NeSl4u4sGF0OkEBOq4u6NA9vGsbz9Tuz+MfqPEZfY/3eg1UcJkoXVuQ7eraciYWB2lDimySPvV6BTHs9NGnbyC6wWT4bZ8fSX0qBbypN8HBVnd1BAzCglIhapVy3wEICCXGge/03ilaL1eKuH2cSo20Wzcc8aQGSTd9CaO+irbRHdeXaCyFwDtDYdmSfiolhtf4IHd2cuLkTEqnYUoN71NM3FTOBkG53plTGIzLbLeZd4bsyJdW65h4IQ/leVaxy5ZEMZWwYTnD1eHzPRq3h1jHQEJHhp8yJ/0g6R+jymYdKxU5JVIHidq42fOrK+mtR+XqLXgaOe3cBzxeV0Na6sc+OrEYum26eXn76k8htJ3+6itzNpodxHtkriWiQVZ7k2zLS7ggdQaitCvWb0BdWiFNZJ/UqbbOK0eoLPGfx46aF7P/vQU1NxrzN9RhazbLdIawVbBkmGR/QdT97HJI+2dtwICyUACaKwbxcAkvHaaRTl732SblXdvumUaTO4ZtYqMFKiHoO10wY+xytER7wpWYyOcAw2W2MRPv4U4QRQntBN7UKO6Yo0uQXMeqnUP+4SADl4D8WcxkUzR0nXBEnvtee0aecLK4YArck8D5EyO03+ImejJeYh8zeH9ypbIfm0BMqkgTz9p9QpM/Z8geLvbB41F5CDjU7eei2AkgR07R7lAuMg+kuCo4OCZG6IaVjXfWPp5vAbOqI5VUh7e6/Ww9HzfyYKP2d5S5XzPics3A1KxXEXuo/SMtMWF5lzYXA9e8XFnbkinr4QH2/Ys8PkQpqU3d0YxH6XvgR3ZnCAXp8DRzYGJG6hRuzbmyVkPv5NXWBRUOvbuwHJzTadJtaB+4G7E4/r73eqhlwBs3Nzd5fUyxVRZTJ5WX9cstgWFLaDuB6WiSP5BF63R5OOK46pTEoBSg/t7UBIHrpN4rtgo8qAfVUK/Q4+dm1WfK7NIraltuCFYkx9Go4ejRQHO4/bDeiK9k8UMJR17e6izNS5yrdSfrk9K7Ug7oQGv/Jh5NcmUjamfvHfVL3LAPbSHRGy5AQh4EyQwgBGEnpXapBHFOgFa6KpDzlI18c9azIhkt94tTCoDArlV5HlrBruEGEyWgCiOLWZz+PrPbdmlS7vN/0Sk9e74WPAOoM0T8OnbGJnOxBvcVTc85evosPEr1ICV4El0B7EwJ+TsU/UnZiQe+D0ik4v1tIBmOSjyYEhUFfY8F3Z2cdfxEsO6NbNfWOyQtC71BDxl1LbsZm4pfGXo/NSSXzbk/OlEoGrWLwY7hCLkS1hiVfqVyjZ9rj1k6rMohg2ouQlpV15wKSOIL8r8UIYgt7d6RLbSvotW0ocDg8uMsyYTmwAkYAOaWz5SKCymtYehBfbQYQ4382CRZLvkhYlRlaMV6Or+dq4EqmVvdXDV/0UW4KULaweOH0gaG55lhOZI1+7cDiLAOeR5dxne6KxZx2F254rBJci6MDqufrK8dpZmwX1DqcBlzFc1qWOKhHor9wwRBantRqU+x0lu9h6LktrvIh1LwsfxDhoUb28yLz5jMWY42MJ6/xwkyV4tXZgyhfh0wvOPSjlba5brAEN9u5/peqNrxBpem1TeVq94B4AjDUdIGTsSnWFqsd8HvMB75/+dNQKJVYSJ+46GXS5jBD7KMJ+R+ZSkEY35rWjnBoebUtslRTtTyS8RTa42t6FVJIbG+HU0IO1Usqu45+qvjZIvt8hbGCVqs7+vGEaL4xuTfSeRvj7QChVmrD59I3ysNPGN1gpp1Y1UvFdp0GZ58/Kj+bLI/WKD/VIa4JBOPj3ajBAc13a46sOG7B1gDzchR+JXV/ZbxG5qCmHb5GwR5NOgPmTHVw2dOEALeeYHEHg/23qysoLNZrsSgs3IP7bOOQqywCb7ODZ96OVT+gNbzfnsj4d4RHz8E2Re+xfGmAfyh9E4Nh0A8OX4c+zm77xVVzCDlwrdtjsKxv5ilOjSXliqmCaVPUJJqJu8iKW+e7lQW6AkpD+6hRanyiPoR7mi0YwQevQZzG1Ahun3QbbK2HkdKj+lsReIfy3RRRFa5tblYMK+V0spGiFbyqBVauQIXSBZTJwGyvInxd66PeXDH0Qy+vuchnCkpDm4dZCi5hj5C0E/O7a+TfAx27ojNTiIVMdFAy9qGUGwxea7tD4d9lLySz1aMit2KtLvRIe1tWbGQEZI6Nt0WVToIWefQSIau9gW5E0U5cDF3j+JUvg3z68gEgczQnoNfBQDOVMgxJTGqWY/ERs3heb5LZA2Yfl3FGAKX+LvRRmdTmbNQAA8D6mO6GS5X2UUKGSqtKUFeBus5LgNW5XRLsUUIh3gdR2nxXonzQTutnF2O4tdIAzdJmt2C1pN0AyDn5PEfqV4lHLGNdcnBkUEhRnwkUjTil0P+VdK8lsHks2Uc8SnoqE92EPdlE8HNTbDwNkiiMzEBX+n0aBZJZAgANTFtbvV8ns4/kC+anuBoN3I9+ZU2qxtPkweIoZNVR9islx5Naalxo7337uLcInxnj9/fztkEmQcrPsnojrHxg8VRwmyMzNWFsPA/ND6mQwLAly4MS2ZWOJ53MS+7bxrI9YesWQYAuATUzWRtCL3UA1GXoxIqqM+0AfBDPbErjTtx56wKD5R/1BWdnBXyla9UsQUI/ltrcyE3L/v921yEFV8qlNBdKVyJAXAsmyk5C1hNAqhfEnO4dw2BsGRqOARTTwGVe0z2867tivcYfAznK1NupB01GoQch2g3G16VXmrm9JTW0p6oW+UmEMHWB+my0PUCpZzaLFt0GeZkShLjDuYDYLz9KELXynHqrAqbeZb3uULTx6rFx/sBKc85rUBh+eOLUIrcDoEZyktix7G0jyJ8ge98bBVmftlmJffPC/c/plz5uoCOnih80SnUhSnfd33VCVabgmhLpXI2E+pbgortstKIudXBgYkQ7acFa+J9ID2OIDjsU4TIlKCopFXfck2zuWUCMb1bRO+f98/6JSpacmAPOqSQFNrpf1OSWiaL6Zf9jfpEL1kzGwFFK5X82ZbPF6l/2Z7zAEWmPNpLeCmttUf2/K5hAnb0pSCQJgAA0ji3ZQ1J9OKouxej0qgAAAAAAAAFlty+Zqwc3XXtyt6PZwoIY1Sr/J96OyZRvIuDHGG9FoeDa4h8Psxpcvw7xsstiTbbc/C6TIwkA9qYDoeLpTx+q1ngzyaJSn9hYT48rmAdEFC+jUhp3GW3FagvZ/96CtN6JUWG5buHYkUCX7lDbeYzJMMkFddW5x4zquP3R9WDN9FXd1o+WzELTX7hzDi0/mGLTR6+eszecuWXduV0ehMS1wjEebVBdw8+CCI090dFwRmMZ6ZqrUoOrZqLJdiYnyJGIFzr80fqjQykGYVpX4AI4RcY+15QfW17OnhfOERVzkFaFq8mht2Y2I4gmfBXIUsMyu+counzB1qPyOn0PqHi/0IYqsPIzhnKrXhKxkhOkTMNCNUXrR8TwigRrSTpWt7y7gUonEB0Swit314nLmn+18qyXkd4FQF8FovNBT57gpP77UA2inD4QAp3om4IoehaV2wUQFUIVZQfOu46vhm/olm9l/JXlTk0dusAI6AmWWa1hR7sa/OoNqdUxegwd325dArB78NbSsDCMUpG642NB3Q7F+eUcfQbmjOJA+cny2RGd75SLw7BiB1ujHl+uswC8wFbXSTifWkqnn4VwYgMi8IL18M6Anj3+kyg/pDCcD1yTOWt1upNmHwY0aji+ooJBasQ5WWvpRIHvAUbjMeUoWmPUaCxbl/K/HryDu421e5BqNdgTOHZHlqQ55+Ln8IrwLf5EueNosjfwSWbfWV+nW55shDJT/IPnhMKD2+TDOkqVSgt3K0tfvyRnoYvp5HIzVmZiade1iI01gtH+0IRa0QroET36Zvs3lm+Yz5mupqXi2kHN8xfX5ByYAse7rMBUMbnx8SwkM6Ymczwmn2lTWn5WUBnhsFFH2SMIMvpZxFgUdMxnLWP4VICHxGoOPQOfcErhZYN0llyraQ5p+Fb5rqJP9MA/cdwtziBoidh5KkGhfAs+z2YMRCdmkXhfkJAXSemeIu7Hs5UuXu3L9EpzsxGiiuDOmcLU70LhA6lYwZF6y7Qyk6FXlbVyTH9Nkbcw/spI+7rJNFvK8v79AeAfL2B1t3D067meMn3zKwt+HBN6TeuYcl1AeFdwloETmCl5+2h6bSBAL01lNSLYe9SOgNg2rQ1UTvvvDWtDFjj0nhjEE6DWV/71m4ivyFwIhhRtPfDVN5KHEMFNecbktPkLlSQKApWPXIdxFIhXgpnFv7EP65SwOTXXCoDh7X6B9QAGXM8HuT59M39NBZQ91SUSJ/JNNOfxrFpCLTZ9XB4WwYbKoGo7361TCj+dxEp2voXVLDMt5+ZRVjAg80tqPDyODiMjgqqdoRVnUbPN5uhFuH3D70TlsS8PeZ+KofZkMtXgoz5S75HBJIihslGLpX7jEzg4Q9GOFgEtq6VW5/YqBdoM6QiN112bPDS97iXSdk7VzCjarvKYLkBrYYrU/E783533HtQMXcI309krQ2BCkjSArFm4MKTqy9ACEq5Mg/EM0PDP/hAtQbApwu1/wBmbNCS5lqnRs0KluqGHdpcisLL6wjIgksaTefB/0SzSbx84nkArpMo1k5/5fEQe20gOdFpTIMbJL9OoKC1AlCc6pkP8ugHnW5NuqeVHnUJoAkcyCt9Eb3dvCPTgsVaoqPenRJdSc4YV/WnX2Ors3rWQqz5TvyovMZXQuAImWhJ7xR/Kuss0sGcD2VV3OVZ4595TP/eXkmuruf1sn5IaNp9khK/wP/ltd6cYRQYEKnsZujDM72HTj/PQWLOf3gJNbANR87+ik52OIYwXC8NpKyBizBsvicOkDoPZwoIZAxwU2ul0knoElZHGtOjJFU4plcL6csebQtJOuhR9AEJi0309r6BwLGct7uTeiqeU8cUVbwwDFPQ6w0eBqJU9SKMvDxD9YlqJq+bdYsjJxhQuFcLD5pEDSlOGMNCM9HWYLhgsq5PYzXZQlydKn9UUfD2Ul5x2RDgj6HDJ+Lz+8NlcQlrsOb1iRiLKw71luedZCxwSjF4SPuDERv3p4jHt/iFLzoJHAgkOMlSJLkK7frVG2uibgOOodCzAm2ZcQhHAlhsvfnl2cfHubJYW5aoxHPTju1eG/vDQv7jyjpQbIF0bUHrWUX8adVVwgiWweYlqyPjtaz/kIkjtg6SXlw7X2o8dxtEwIq3Nf89ZuepTWgKdzg9hz1XnWa2SXf6SbJj3JUCLsWSFBBKBowy+Wi3+GqYT0S6LW3o1NxwJpr0gBFBtkb9pl3xgJiLdHTsYjtcfnZnYw8CLL9YEntccmLNun8AyNSQbvCz1+lyZkJz7AfJPRPW3S5CnIP0SO9/+gp3Ezs/jGlyXGpSd01OVDE3RcdgIcRNEtdm34/2xPORMh0TB/XSY1oHjrKPJFQ/iQcixu65H/uX4d+UTadh6y++XYZiAsTFwgg+iPLRsGrbTpEFTQHqIpvGAmItqUaauiw5T2YVH3ezbceV4GfML7WknywbNRLPt5HB/LGTZjKmXGR5HCWSNKyAyanfQNBwoh0DXXwMuLLmK/cPHrsWbd3w3p+L9/+a3cCIC8MoCRyTDYw2lpNdfNJ0VwPSo5fDClBNFQ+Z6hDkYsfESvRKQXaETa3BMCLxIqD79Ysc4Djt9yawpW7uYPOTPxLYe1LgV7iOqv3Xry2/kZwSgZyic9fK+GWQB0OhxNfJAaFACOIw4K4PxGu/kvFtJcy9e8PMcHsIRrmItD7ctEhioEl6scWcjq24izsTN2zSPvMHTH07WMUwO5P6YYoRPs0CHGMJ+XJMyfcogGCnBQlhqWPpVaw0mI5a8KcbH1n+pF8mbpumByZq8oS4aN2DWK/P62VjMvQYjrWOVPD3NDSMDwXCc0vYlMtHOJM+wFONLhbh2uFGA8dk8SlkoZvkXUq8X8KbcAFe00v2mGP411AmkURo3vKxkYqW2IfdIL3Wuk9nzbbFPBQUALcdHLqMjGNvSpToVWwAohnkqrrt4S5+RuKFruMa6xFrmDlsGRY1K12jQgb+VAMpOkvWrbFNmv0Wsxd5wvtCwH3gSURsil7UDg0PpRN8ZpMS+lAvuZFxp3NZ+5SI+p8oVE7IdQt81X9A0DROOl1UDgZRdypOFz3pOOUeUz41POiGRM1915Ze8uP8barN9g93zcxNHp3u9cGkC9/OHAnpTjPj6FIQBOOUiSlY0SZMDdayWQkyzjrZCSijhfHhB9qeauXj76N71zAVMSg/85m3XGJHRrqo7LB2+9ocHmB3bVV95z5/sUpWOoZ7x9vq1dnm88UgIxTZ1nLmruqEeRPYSG7fffphx/dD9I2JZF2/xda9lF9JUL5qQLG8TZwOw/7yb6pA828niExb/IYG/Ej9ag0TK+MOxoriIxmtVxG+YVn1vxzRb4Pxx9l412J1FudAjxgO/JyRM/2eyNIlLZA5r7+vYKSRcgki2/R1CxU8hOgAyiS8S1bLOR/3R3YNwar/mzbpDJxDahvI34TLVkQHOgcQGJ7AqVLWXItjsybvrXOKSwlQKOJ/HrjObiUD9C+HOwGN5sNDR3NzW/XYN/ccZl5DgXIkPM3mBkxMTQUk5g+PTMf/OSV01SiclyYBavX6Cpgq2X8bIyZcUX9nS+DEbMqUcTdjxx1OLeSjn7kMbcCf+jKF+e/Q0u+4n/dHCY7Fa9AaC6agDNpT4/CZgfa3tFzBARUg7+9hdQKp3JwTSR2JdNxihfGSmPhMrmnyVMYhOD8xHTZI1UTtwKt507BsZyBKRV1XPETtVuLpJUhbFB/xVPgra30f8CMCR0f1mkTu7xM8iQU/uWhORVT5J4HtXb+4vfyVtX937ATjxQD3M9UMssVK3W6b/xTK2sbScMOuXLFt/qSgxffb6SJDIXspfx0Xqlb2QpAsWjkjBoUKEt732aE4jyvYWtq6+2pSzyU/KYFWM9uBXo6zkz7j8EaM4XUiS4QgTnaJEODzfZUsSC0nJGh3deUobZecw4XXggjTtJcIiJvlBYrxPzfFRTJBsFb/6AsZGSEOI9UiCvxvR4BgH109L+R7BZR+FYIG/NWAz1JFoWKooH+54JNyPLe6rvfj2KG0stdRQwKFGlAToVQI38PtKoZje87z9tqo16e5N5Kh3mDCE4yc02F0iCYtpslJT3HPEzNsp/oh1N+d3EMheR+fU5H25JZqSlf93GnTNrFiCzymfCIeDRJZsp1eAWWmMxoBT2ajQ+jxHADP7H+Q9CZKPlrPgKUFE+2WUILBidVzCMPzKNdvYXqm4Qywk4MGmdZyWKKOciLSLMCeRAO3ZrVsmF5+eqMbpUhRnSfg5kVDeeP2UGpkgdycJd49+OuydpMSzvhn0M82DcewYCsBRHrYEOVKy9nV/JM0kdKfuqRKmkJUEuzkUmZ+emCOLWUwSlMBdbdKA4TFzO5EGD1BDE4FkOGdH89dcgIPGS/N5VIwwh0P7Y3NPD8vwzf/Ut0YAPHoszlngwJTKjZQ1MJaN4hjBYhzx715Rl+kNOowl/wVkzZPOtKj1lZNM4Fj6nI4KEqHi5nicIONvUEWLAE5cHSylYHYSYZ941dELjvu6htPx9UT1sraOXhTRqlSjttNNXZE3qXNXcsezptOkY+EqFjEPCDgOP7mXdGbOAaAgoodZGn/YnnxC13jKcwpBypi111qTAAflm7neK/I3v/bpi1xQYbc1upLXf9lVnlEm9q9k9cLw6NESd6XPqOe+/PVoLtAu7syPUvqhBah2SvPzxjZnqGX9tL9PII5nMNVkeAxyyu9kWVIrsHTceDwFJpdddAdE9RRaBNDoyyQAU4gi573bMoZCtHLZiMhqsLf+/fwMeRQ8E1LY4sSBF8PsdLR3IZ8Ime9Z7xx+xr9tskIgJwijGMaa+QFRuRB6aQk/I0K0HFRqPYdkoc31w573bLgLX/7QH9Nwd12usrTyCeeVeah/O4xGcxcOwOj7zYsl1HATsdpSehson0B4d1D/UqxxUKsxCzd0tPmKSZAImAPSNS6DdcKBx9kS0wIP0CrWZX3FwJY3m0LLntwpH7VS6fG+yzjLifRe1IgBaZ/fuzDEGp9a3cUxQakyW+kwp8+iTtjh4eXKCQcHWuwDf/9nCg1FB2wargvQ/pWNHD8GGZBl0nJ+BP+Y522WCTU/8nuSq0ySZ9wPvBk5ImxENALAG8zh+YFgjdIpwIvA5cgmj3Fgwn9yKPnLi9BKr2pLQVr2smIigubGmohmphPPi2f2JxVXDaPk6Uo5VtPbmQKtEsUnIq3GfvAI8FfVYa0/O4Ftoc518FJpRfl2CXGpKREee4voe1WIbW9HHBzwlitZ0VJDd7FO1ncqteF4p0BW2LaF8AflxJ+RIdqagqHPmacwKfxkqeTaBcOM0aRq1nd0ISRE+YPFCqYcyc0kTtmxzPikPvLq4U1ub0lCDBoyk4GfrLo5N4MNwXtzd1ZNX6CVxwRqnIYJoDcwq9E9EJn2yeXIAd/ehMLirDScYK20M2cM8UafV//01P4utSYMqYv3McNVjKvNMgG8R+mCoxmZL7PVTNCV6zZMcr6I3EjoydPq2HOimqcdMnEaf2Nptmxl5/85RqwndA/J8UPfHfgcs2dhn+8QAONQ0QMF9dJgT/KMq9ceK+HgG4j+PSE8SCFGi4A/aIb4xWlwobXIYM+JWNv0nCgIwNhY/ecwDGgRHifYfTyWXsFJKYZA9n+RUr7ZM/7rJ6Sazn1qOlBvj/BjWILO6bvr07mVjewsNsR67ZK1EmgKaef0nY0bqiF+MHCgC4rvLuBMBnKi5wPV0stqipJ5mYYaUQ682S7dxSyU6wu2R7BNc5KNXOxOCQvOVJw9vf1K3Mdcl6G0S5J+Hy4a6RiOKywrb3vDHlFpt6GbXPhDJOWecMJRsRPQouiM/7Wmond+19AycAt6LoHz0345InTUfKsjOffS6ahQ3EomjFXipnF9pEuFVKsofQh+AAArH5ZFnme2NMNMEom4SG/l8rUWsGNivG/7uj2cZXTsCv+wx4VAS9cm73H1yPtlyQuesn/sZV/6GN0NjZKVz7d3gOorAMI8lBQLeein9z0N5byJASZ4Fnam4vO71BDiqPv4CDyIW2/AXeCAMHDcw1ZKiZ5F7u+eC09efNPgydNT3RZy6nuZIh+FteONQEOvAz9FwBe0RNpc+tAeGir7uP85HxIF5WbKvZo8PBdHGitHewmjyK1L6LLuoeeO82l9HxtHCKppMkvyY9PZajVLAIzXAo9pDrtYQzN5rrHKmOwvn8TQgKsP109UG07CUQD6nNf8LZvL+ytfP/ubCIBDVh0wyGcjnc+HYw31fW/Azp66tZi/+vczrLMyKKajt9iffmlrChzrWq5RVEPk0tU4VnbFtW8kl4dtDaM5lxN5uIXBW2KmLmUFDu/NNISSGY7kRjJaDCnvlGD2K3Sb8K1XTOJp+IYe2+YitLLYMpWOZ5bUKUgDf8HwuC6X+Q1nN7aywmpK8lzOvjQyjlxoNzKVJxc7WbhohtVAs3mYOK1wKGdyOi4t6K8X2e20MPoxOkgE8+TApBAiHQo5EWacTbXxoAV7PMQc5kgAH8AVcDqWfW2Jaxw66GKAAAAAAAAAHzeu9MRcpLgDU39yKuNxvRS1NdBRtI8zxdZcWBTk9VZHB4FEhyN6Ow0K51Pnp9Uivv1bRivyhxiZZG6mHCseYZw/B83rTLTsWbhJnjwn27Iax5uxlR3ahev1WW+poVzqiIKAKKgVWcU2HSSvggrqcwjqWY8qecfOzgMIdP1tO96Of4kGif7PCxPxY1/uJbAgl6IodHmnN4zJK7dTErZ8unY1LnuuXS9qU/s13T+9fP8VSBpCcbuXJb3N5Fz0yTtE04lFexiseaHH4sa/3B512DUJ9Vm0xUg2EwYXnpfcIm0k34A652QgRztgxHuM57XmVSqHTNgbBEcDAWLlhla5kTmWl5yXxqIS6s6v2q+zib4YfwK3dhPouCtuWUYeh5ixt4zgo/J0fvV0uqjuXSde70Q561kc+xiWyssTfaiu7S4BS+tau8sYSnUFbormZMn5JIHI3FSUVDDJPnpMAc+X7kiz+qNtiDEQCgPutAJ5SZn7L1PR+qngsDcar85TSAsX7B7UNwvc0xLf1hjzYUkZQvz36Gr6Tfq+vnuSPfZBP3aPPMsyruod3y7PAgUMaywsWgdsY4RGrwIAf1n/hHX+DWumnhsZBA0+4KmcWtYdcOegUveJFhXWUt9+Cho8IvIv6bMvcx0wEdKJnYML0gbT8crloErCWxI3QAATNodQYGYvT+8qv4fVA1wqcfCDOV4reUjCAIdnUPA7OBuzo7Qsy1Ic5T3ME9mZzOpVwbldn5ij70GzMJ1RSLjeLnbChpmR6rPctreJPEmSo/g7H2ts5uCAFfrBef/POtui8QEZo5DTHubbDa15egIxlBtLixXgboToOtyUdLw1N1JhWP6BUjaeO5lK9QFBMiflk2NkeoTQVp6HSxDqaVSYsbBma6r40MbMiOgqrAjvZ6ud7St1AvXx6ayt4GNngPAHSd2WWsVZSoqu6xCi7xJpmrYGiwo23SkulsGlyRwy4qcvh29UyxCuS3O51S5o5yYjjq3UQwlO2otHg5YaXBxNWzisP/omzpGFbEf/2GEinFXIytm8oXsj2G/j5BtVPj52TIQieobyxj3xaUmpBavkDIxFbE1UabPFWBCxFGIJlC1zn2t+n4w7m6SvC3HeD8fVUAE+sC5WK7FcgLqQEw8prfcprpwMBkavqwQbeZgUhwRpH3ATuEJ0MQiQn8XmagpvoCQ9UGWrKa+Jr1bdnPhXbsFMH38qzgra8A1B4Lcejl7PSZM0lYG6OMjATfdFaoMTXW0EsHi21yJlJw+jg1LIYF/S33L1cfqXk/TPJSBcplO55MyKYU89nN+5/5Ne/hmTOAPWv1nueuhVRDpKoCg/7MG37dv930UMDQb5AYOSDSJAibah2WV5XdnNjJLpsLqAvFPDF1uZ1s+BfWOFwlQi8rQOMXufQlE3bffsFCEgdS7uvXQUkwD6KrRmsPhiLW5BH2uJJMh9vlOG8FLn96sMw14jz+0AxtlJLBd2iZ9bqMMFO2kmYEjAoLJ1tntmKmlqp2VFKgT05pWOzQnWgaETn2xkF3aRlA68Xp+57QCniRfRAh+M04WGS0xQNtzi5deYhohTGJ7ILXrFQ4e6nMe9eCFYDvHvfg0+6TJ27QW7ov9LTINArKvf/jjloSvZh91lPn285wN7Z7lJHiSY7PVP6xKmloILhDJvUxKiPt7BA57O5xjGPRrGEaTEDch+bhFVVoTDr4kAvT19tYebP1zvGdnniMxqXaQktWbMHv+cb6utzRXso7V5XTv7n+loSpLXQrzMO9zZ8O7cq8Hg8oNcOy7lDSJlfTQmk1Phe6TppDsFmDWGaRQBqUTKdl2rapeO52nmd9R4GZ90C3S5aDHiftrMS6u+0VQUwySsN8QJuN7zV2RbA9NSfmY41RB8kAjpY0ZwMKjTPAAM54AfLkPH1q8yXoGgO2+U5I8OAbNe/sQ2dMdWyohGlPIQk9ZiyqYYt3ZIduB8IVWl1o2ESPmGvM9tcUd9Wf5SqlU9ekMkmRQ5g+hQy/d0Jx0+0ggDjh+hldbu2vKlKKQ/yGk/+ek8RjyFWf8vf5b9Ad4w+6kDaIfWEYFNpPvNP1Gtmwp28iJBpx7OinjcYv0v5+TzG9ujb/fmMBhN+4LlNGQFSdo8OpOkUGZGrqpe2+bYPNemy/T1vdvlel225vI+bwZfII+dsufTip3ZQC7fAhrZBz78hJCLW4cuYDonlVido6GGSKRgocARvNpPp/7bEZjlVwliGfR/yOhKepMvn5iNhmRfB1WWXFIwAJD3iBGN0uEtZE78Dnoi8aCEvqkpgj2WXzH+MfA+qSysA5bqrLIXuzDJ0AvaBafopfXp/RNhM8wsd9c9p2XPkhnqoPwIuJ0NVrEk9uCdS+qLivJTKG0O53KzkVSgHZ0Egk6UPI3R9JHPpr3vT/BK/bEnBl0FphEegPrHTWQ7SVLQa0hjPAlRnvZSLQw3sZzYVL6VWlPlojs+E+zD7D1ytAuma90bIQYZoHiond29qpzVw99c1GSqcSFRlwV86ydwvVEyvaxipgAHkmzRK+n4YZjZS1gvQLZNrYhavo20Yw4rLtpb/8IJP22v4JwQRfTNdRYKFeF6kJbLM2hy7Aa1j9scmoBCtbTH51K/xXSq3BypurQ/EDmYMgmDcRmiLlbRJ6KGG9u/P50aYfaN4s968EYLt2yY9IFFBL68LSS05cPyX/hfE0S67gBilsb3KGtAiQ6e7x9AIh9T30EHyXXU54UckaG3qCkSsTXcs7V0c/PgYwVprWoImLqigG4A95eBCgHMI1IRpWrqjYcTVAOA5LRxZH9ix1pR2A/7Tlnm/lbOSB9pFTA7JC0jopNf/g2XWA8a//eVSQfkZ3c1c0S21FrUS3/4QSekKXhN2rcXrCOFNoaSR3IuLfvFPvarMl5/ehc1t1UvMca2j1dWmHdcrDqJSLZp+WoxD1yzqk71YimRGnwuBMJhtxAewOo7RE6Uoqijw8ZxknZKompazLKJvtznvBOMXJD3DbFBd7ldQGXOECJ/yEnbSSqjwGDhqRTSAmcE7ls/t1GqLbU/encwwF7JxsZfkCjAL5vVqjPhW5V3JfO9cM6WW5T80RF6447dNqcwrzOYPiPCsc6VJ/uyKrTNyFXH4S8bG2C+Jacl4gm4siF4kw2fAQzFBmKBaPleVvOuGCrl6CSxXPzLz58Oe/T0gjk2+SKQMg7TmuLaHGcww0Zc73cifYUcO1UqDQtxMmih4rHNSyE1ohZ2CcxlcVdKLXZ/PlYpVtY/fFOjgEOo8X52Gfp3+wiGz+7Nf70tOXl6/aAsokA6BzFWE+qyolOWjzUcixmcPjKhvaZxOyKxSkqE2IevTSrv3NcPJqhuZQwaY4/OSNHtRn1eYZtlfmyrN4YIbwVyikcnk68fXZC3b+I+ePWScJ0zigJ29X+7QSikRl+We35msSC5NnzxVJrZEcd22xnLj1lBzO7CU6ZEc3Ah2+CaIb6iXuPwYoxMHkFalPoW9NtDIpAGWJ9esie/P7RV4I1JfvLyS7U3lYggNQ+ROXKjmPORFoNRXNT2A59czNOgkpza3xm6iiTHB8RuPeggO62fb9VB2t2LKx23tuT3jJjrcPAJ0Kze3nsYBaNMlb6iSwHJPOY2AF8Mv9qgq6wCdFFCsAIDLTO1+onPESuNZ0yYaFDMGdu13P1bw8eF7sHFVIIQR7lOuHs6G11F+/gted41PZg59Jhlk72nK+jvUfUaWXUdpLkN5FNlnpQIvFPR592rbkui2+49eH3IosdDNb7Ct0NWCH+dvcfCoRioHzh/TrS4KVr1/922ULRovI1qxMkYlQuaIGN4lz/Wekjq0+XrZ8d3m6fZlJ9j/VpZbsrgPy5eMcL0xfAKFJT13xpoBl9F0rnW1rvNCcrULLitwmJvkyPYwBsddBlCx/E7dm4jE94FrIjr2TufA6BMoT+Ir6tuI8cxUmWJeB7H58TNC1q0qp2TGIxPV4Us/VqHL7a1SHuBoXv3q7Z/VmjrIUgjnNI4MnSVpwQZ7D3jx6eb0DNnTwzDJxWmVdgTvXHEICYnACsEXrys3tq23s3NjPW9JzgP8LqPF+hTUwiYCEqNMUjSIHHR0d7URrGQN2yLkZFlT/nso7EA6RstKJkIl3H/Rq9ZOgqrMlrTa98yYbmarYTp9pnpq4iIaIY42ZpvFju1t72w6Jx1Hzp7dFOMJS0dH3qzocaYuIfC0OJjucAiPy4shv3BBMpGbmJ+0a5aHNE4TWQ1k2SLi6/ZYJbWG6nGCyrE5H9ePnDysU836IWysmwm4NTm3XJg5YCnimZkG5AoO+Rigz3VwjKch8ZaKNl7ScNVXgtbS6IJkpqCDL5OU8U2p6P5X4phZNrs81M6uvTsgJWzy6zds8GApQqHtRpPn/jjkvUZdtc6LSfMFAhr8kMFEb2UaB8Va4lmdkXh79F4Ng2fQOAF4QNPaQB+FKd8VQam8GzNcemMQkxdvUvGeK6oud2Gm1J2OTcop36IN/X0WYfLi9FeL7QLzMdonSRmGXjrekQ0sFqVF2UOYVZ0PVk/7CFAGakW8pANB8HRjKBQSprS0CZZ8nVkHBLl94qOIcPyYWKVTRlWOKyFiea3zz4xI4b+wSsJtSlXPuprUdU2qbzJzrcQ0MuUP7bGbHbMbSiXWyMqSNTbxYm5qK/qW8OYQ46qyCE0z0z+6BcQV2sJE/xwj7fgy730svaWdeLFg27PWZke0u0lGZ87wZ9a64JlU73PzAYAseVsFeRJLCH8a+JSpSz3I8c10Wmqzj0o5W2SxPGr8aRlPW5tXUBTIEcHzvblQ7F7uAsGt6pFrSzgiT/54IsDNfJ9APf1O2Ah9lXARsbyY8jVh+zX5lPk4tJNbUT+uOvZ5AtoC9KUOta3mCKuuRhgolCHbfIRE0BWxTeMTqYYmQiVR9XD9jnurHKs3fXd9WPOp5Zh0xhmKTdAGCShZPTsnXeRP5srKcFC4a753auWutE6YwEXQalr4p4XgDDwuxFI/Ns0kxM8gjYl1TGBXbOddGgwqRD50O/Wj8a4Q7fVme7cAH5jPFcdWATO23cKmj90J29QzKhFhPMPrBbjiQg6DTmBdK1b2G06+Wwx9u+4T+OBd2OaIZGmk9Es5tKRDP/xiu50fzoKoQRBw1Hb+nb8X1tqdAA9XfYzqw533Ax9dNkuM9nPGsptBQybAdtXZho9x/QGIf7OcHoty6ZersU+7hmSRI387FXwtoUBqBNGQ7uYaagf/vlXy/vT/aCFf98PwJWxEw4QQGbOga3UIg/35AWmSoKxw89S4gs4/SBjnSRe0VkWb/+qejvLySRkgDZQ7IylNF3+rWRnHw+eLaPVenpr7sEZTiI0qTCLCCcSrv1cQWzx9R9ZLsjoQiTth5/xjX7pNbeXflaCYv7b8VvBjPze6+vIAOVUAwfJo0/gxh5/6NUzICQF1hEGBRKRzfpQt6Zo29xVEdD5RNDSAuPVXm7VgZBbY2KaWcXgk4Jlyfre0p4Bc6vZxRQ6rVmlla1phsGapkYOymH+bEM3kEUUVA5g1Y7GDZgICEWLXKc8EV4zU6/4f6CapP8KAS0nWPJ+BUY+AfZchxOPWTiXQUqfsS2yjD5v7dGcop07doBN5iMd2al4pIJWGxRHeUAKJk6ERP5jIS+HizEZ2yo4sWKv/AGaMhRiwaUvLpjk0jxzMwo/0QrDeC5pLJVRrKgJ2PdylLuBMr0PRUcs+R21rAizwbBY0+UqqXkCH3IcA8C2U1dFNUkxVUeeMkVQpt4Ihgle34S7k1zH0wrxfLbp9LRaD4BMbaRi60JifrPW+yV9tg3/RMTJLX8yIVNSyVRBI33Q1RlQeK/mQt5U/wEwqxIcGmBBCkGamiyB2qZaLa6HYsfIGOTxyto4qa7YwINFhV1dix1hf1dSXkZdDx6zvYFeQpvt3ofqRj/+dJFrebOY8zo3YpvrFpwCRAhb0+YAFytQLGuV7cnz+i1hVuIT50qY95KsYp2/NvOVYDBAJ0ruRMwfzoIo78mDKB2iL8RBNDBwew3RK8JHHhRtqF83yvbTQhPKAZQCs7h+qM94Za/BbBqkOYU4+Jst86YAChpf0lZbSn12sAGEGgfYZ2ME/gAAAAAAAAAg0d0RWZUtIR7bp/40CxGuOB5Z9QFCfmphM1YO7dlDRXdSpJbfJH8ts9Ge+nNVBXA3xzwmwkwteSoY5hqZLkYyHApKNb48i++0iB8YZIwAlEjbsXdAVpIn+50oOxINH658CE3iE39NLL1sumkAnBV74Hmf3jdGjHzMYBrgfTXThNG4xRF7zn3BQqmxPwmAzNzHxliNISLL3YOlWJZlOwwQEVD0JqmJMJdridsWejFG+V+Sk/Wq4yA31Zxdghj1r5fujBmN3ow9OTPpby/Wzf4GByyAEzkHEf1odLYnsiW6VIdzjEjfv826L5o+n3cGPju0oXugZfOiZjqaykZmwVWuO52+sWVpWED5esmLWf/jGC6wgD06SFUxLkSobNN6dEJOQ741ApMz7ikADLS2dnH+P/wpOqQIyQZ/SLJe2Wyhrp/2YaHPV+3dvzzjfuKUDYg7vK3eRxLYynNODCxwZ7D1w0h/2xHRyT1NS72vV1w0qiyYubttTDGatIuT14/6bahxw95d89D/Y+6ECFLxteMqDGZrqWlfN08e0n3Zd+WnpyFaszapU2i+El1GxoPjK17yyo3a1NZo2T8STweurGrNrWohIEQt0DJytgW1DGcBqONl9t9ZwhUXIzPbOBkGWwkcEwJs6N4c6wvpZAFmRsR8hFOXCUT+0uC4ceBhawrzyDTGbf6NH6qPaGZ8LWxxZSYuehogSSykR4IyTktu3s46w3majJCR1kjcM641YQ9khPFZweR7SrxryqiFu78L0XIO87qGdcV4l5nF4AZn6Tf2QB2hkOFBg7SJfGQnvapwsMA1pSGiUw0KE9pShz5iFxw33yBLIpNvzu4hjrt2ChbMKIUwpYEFUKVX6JhK+mtZfTdZjMdR6cv/OLsTmAKJ1YTz+B8sB5SbDGGLRskpaO1xjS0aywkfzTPyywrbJ++yFWpuaSW205BHCUDf5JWQG0msc56IP2TECGGRW5XI+yEOdCD615XXn3DfdHc5Cs46WoGOXOJZGjY83kserl7h5QpzlY35STswSpt4X2BxpcpJylfzM7oRW072p1nHCeLPAgKJo0K7VaNL3xpgJjRToRt6G/kyuFZxqt3BujlqF0v26UfHh4DJhlt5qC0rfT2I3xrdvTYSaXWFlbHeml/+yX/znntNYwN5vAPl9AlmK5pFNSNab9QBjQBybBgLzWsPvRrIk4Wg97j4hFunV6PeetZI3sFUQw/m/eWmiQLn0EpOunwmukkiYhp76cQ1vECIqm8IvxtRsWtAg/liwE5QTxANbI5Ine/Ay7P4vvKxGgMwnKqPnioV60wGmgodLncJLANMElHGiVic5O6ClZTAp0CBWSGz+aOSF0D3BbsG5dfsfAerJUkQyaF8eGFAy93hC0e+nWnEx1dINwD0JkpUruxchYxZeOs85o68dlJbtFO40JVqE7CwMdO0+LEGbENkUz+3so3IMqfBKzTAjaGuudifzBXKCtvWL6Q2M+k83QNupcD0wYuRIP9TFibjNQIiTI18s8DI/N09actfqsuL/LP07G0Wlnh6Huc0gprDeSwfzLdMjRZpz/n4IGtz2nTmDd1WqLehzUkEqfQBqvMbC3HBFCvQeK7+aUbomu2pYofCovNiRj/hn0YGq4igrSi5Snf/RmS3mNKnv3y2hJx9xNE6b2amv7v8xjd0i1zbwP+PHojvp9CXqMfG1rhpvQnKtFdjI8xSBEcP9y7CY09SIDSnbl64hhUnhi9J7DTYpQNupe6FiEzk2Z0kxmQJyaibkmKtb1Ip8O29UQnsF1K8A/QJg7KlnWGbHXG4euLOvYNBXUMGW3nnevx3+tiB/6gtOFqroh9xKdt0fwrAhhDBa271TcTAXPrPI4XQIiOZyMmnHiKhB8oaNszvGxjnH8WlQ3oYBrMRSBHU0ELLCNBehy3Brf0DwXcxycFvz9FH0PGQyQ/GAwDJOHOlpN7RVxHjEUKZ67FDFErayFCGfxLp2kCxVbSRIjrjQ/LDcGCBobtVpKqek0ol2zpt1TF8h+sqnXqsrrDWfzT3k9PW1KMkFv9UfZD2Rpkug9wd771IbMTIpys7d2hPna7IqnD3zBTakjjfdf3ccgV3+GfA8d9NRv0Q0YSN8cXAh1X3CSX7e8VpaEeIsTeipJUaM+ghPp1/1AIJRN+twKlr75K3LVBhfN3+hxp8FB8gaBfONzaCcRCiqvyTcvWw4kOz+CnQxbHuP0ADslkXz7pK8K1/LRyBMpPp8pHfbJvfpcZoIWRwJYXJFX/KbIMHEPOkjDw63ZoDdAhO5TaK0RIoeBZYePRQeqlZee2iFDxbEZ3CxwQbVbt6bCTS6wsraI3BH9FLqP9CP4dZsUkF+u93ywJbrgLkvVqNwiC6pliEtLlzsSzaz6yzYTnGHj765qMlU71T2p5fhsfs624JpG4mHcHa/njCbAae1qLCWYydgJZTXPBJT1fSRLKdgryVPmdAlr7+2zI8fLp8J7LZQXBv3FliiRl3tVy4yt6YYrAB5nLPbEdnQ6WISSWubq716XLhLOHSbajwYI0kuVYWhJRgYLvA6FYXQflHggNZYmAx/MiJuKp8KA0OQA2Vayr/Iz8NoJOqzZWRxg1P7VE1Unbc0UJuF89GTL0FPqTB0STW+1qJzGI7/6uzhwHPM9Z/Ho0awLtLuIBrj/oT5RB7lPCBpPihXKMOmTUsEpdY7I8wfedc5h9fS4L4wyY2QRqPDvVpwpx2VZbqtDi3mwPd48RIEmvdkyabfctazo++CfW4zmEbED6g7QTsNYijr4OfXqATWQkOEqIHOWRqyHQud3BR+4vHr4jaWIFaLQbxYx4i/CNEsrv+/YChY36iWxUF3LHiGb2nA/GPUt/LH4+oyBj1Pzr8Rnafr0s0Q6TaW3cjMyd6bIvLm6KLOaPsRZt8zffi5JSOYPw2AImctFrRdi93qartoWC5AegEWAfBzj1y/APOOatX3CFjw68kFAdkaI6MaVe6NkF1NIxWH1QiTjBQ6pVg/blFtAQ0opHFLKESr1EUUzYXL8BYX6Yj/RNjYs8sUucYTnJT/0qd73R4u7zGpGxN3kiZ+rgzqbZjfcvQ7zgZdA8DLSzNfOoILDUFIJN8hPMxPRJBp+SD4uKUiXMqsb6sa7rHxss0TFoIZgyvm7IR0lQ1gTFOB3U1CjigbVuCfygnPc51DsIGOUV3meK6mx9GtO3lL9hcFz1U4jExb7ccLIxnvDbVwBfRmulWw2O7CV6r1qoywD2DrR293VNIt5E1divvAbfVslWl4d23ZdE6+OLS+KPVKKSltxF9UQIgLWfbi1AV3plhr8BDlAPkstw/bwiDyk3ln4hM2+KCp0i1Q3Rs04vfSUkCrqHUNva+px304+mHxg1Ursd6axbQLLm7sMwHlhPXjBCtIrJn5YuObgX0oBw3Z8UkMKoN9UtlghXg4o92s16oY/s13iERWwRg7HxtoRFg7p0nfsRI1mQVH1y/SQa2+0k9RYaaog6L8tDHeTbpPdju1GaIb5K58k994lmKi/1sfJNugacOUHNw5KIcuVoTNeO0zQZGQ3FdgFFfNDY69bjptFgfYCfM191h9Tz4iKaF40CxGwJiFEuunHyVtDkFsUrUGU2tTeVAG4Xsdwokh0N75ds6WSqtIviT1D0hPKzykuXdOzAZcw433em0yF09Artoy3K8TSxaMP85w4USk5AzI7Z1p7jIAaxxuJ/yC3FLJB+/GQi7F2BdYX4/5vo9O43lGM8tGDWRV+CH1OrwUCG7idEP4hc/Nh1gsoDFoocqa/Fq6jWWLfELEDSMFfWy78ZTqi/YK84IBPmZlrL5AQDn5nf/jx0bg36RsotQGJpKT+swxunbJCRcv5IakZ6+tUVFRSCf3Yw2u5GW0BsGHCsftadeOotdOpfcs0InVPXT4Ur24FJU43CFF493Q310cwPw7WNJz3Q02YHwWKrNjbu3MYAJRATCdjkifYH4hPHnMAPvp5JehHA9Zx2iY7sUNCVrMm37FxXHjNVe71A95RNOtqzuT4+UG+fnhwJTUwB8fD/4EpOwH5muuvAryb/ivnibSimtMxmzAVRcFkLaD60cBjOqOeXCs+C5Fg4uwZ/7sc4lqNtQYSIZy5KH1ebdxJ1IWuUvvhqeiPJfncqh+eYhHgY4XW9ftOy/WYiY/7lmAKLhtg7qYuJZM3RaoMDYKPxc8k/nmlDbE8VGuB3IJ32qiWBsPYxJZgCe/zowNj43/BXKmP26CalqsIvAPb57gXnP7UlbEcUeFxYsY0fMWyU7vjPzXIxpXqnVk/nU29jLqtgYrCCWSaB7XexFY0tkfUmCtD+Bla+geF0U56GCZmvGGTyXs85XZ26YEB/f7PgfEASy3FCpdufMsQOMZ+FyfwBy+oNZeaJToyOztN7/MYAM9Rw/HuXs3Cl5wDNu5WYKXAx9CQ5k6VQtUyAW+Nqg5Wyqh/M2MW/cmCWKsOohQDTz268QtsJ/wMhNUP5IU41aaEyA9tjIGZXS42z+lMag/83j7dqWM0iJiTgaHqEeDPMEF01KO/7MXsgSd6+LzkYM2HlAnZ2/P95SE4HLZGwOFFOApS+Ns+7gl6RrTOzofjVjylo1WBZdsLGdVoBTdEhrd1/lUYCotihv549KSQRN7iBKL+h2QWR3cv4htOMV9ho/oHXtPD/V8Nk1N8/CRyaQHxRvDkXrJq3aUcEsTPsVEeMj8QYcVBDYL4XVqYP77GsYxGBNfI3UFAWWu6SQR1LOmDmyitp9J8rTnStQKygn7qKufiVNfj7yxU5PO4Kz6K+NdhHh4HQq9HkTh53tggKiUwBSLRyU0lPMBwU34/AY69xk1TwpVC3pTm7G4c/KV/DrRux8qyGywgvn0/15TQf5wpDafsz9XkbUKMdFMzfW/eM6DvuNZF0TP22lO9Q2UBDiS4XT5ZDPHcaMdWtFppydpi8vLTNSSCTLhToeQ1o01o/Ml+yba/z47qn26BwZv/uuRakGfUd40ppfWd5lLCfySZR8ft9zZpDEZylyLcSILdmOUVvnw/dRmAjFb784tbQLkNTzItDA7sPlJaVWKzzCb96rGxHmQyqPncSXncIeWuoETLfaZd8NmhlHodgblHY9WuC/94GMQKm0R13W5IAEV2KbFoDjndhEJwVCN634J7H2myqL7oTGrQtp2//QBSBdDG58xEMSUpOrjaU9fPTZZunu7HsgVpUWyxXXFlXzY21EDlx4Z64fabKpiYx8f879AN472NlE9KwsjEuyUT+JCK9rAza9x6zBeyJ8ftjU9j7TZYkK4Qol4a+okbpn77uKR5rtR0arpZMaBGxpI/eGR2kDiJRTzip2GdpfonnqU/uiyUQVuOnzy8GGvpkOP3RrCcG6eiwK+DTv8i0Gb9iiF5ajKEn1oxzMSNnjdgmhjlw1nyc2icBWBpG9qLUjQbarGN+AkW4B4yLou56yQd+ABmzOEAgW8MFivPTbkOTp+ojcqr0n2FybHmK0tJjEvzWEMKm5IgMPvigy/Ep72lmvDBTcvqrEPO0q3KbY1M03FMV83a7jJylcO7l5Wu8pOyFI36TJkdDrCwvlsVjccblCmkSQzp2Qubc1TUvcEt+I2GBLDkHVbW3k21whqUC5vA5k9TXnut8wySJLHMlnIYRxfw+wyAUV++iGPf73XZ7a580UEXWDjEMtZbZXmiUUH+AxUNtcf1bk9cCG2yiyTDqcLC8AzCVrGyftenDO5ofJKFjE8qpZXnOa1JOb5+zsP+U1/fk2rryk+qTsb4r9pqJN9XkMtDFxnCqFkg3M/FSEp/T8C47DsYfWpOIf+hwkxA2QJw+HDmIFbci3x9k3phBO35Wf5EWGosSKx8fhiUbgC0Y7dIA8zpMzR1MPoJwSKRz/WbzIrNF0yAUVyJGVu2j162XThCRcZPaK3Dejei9SwHo4TjLLCyfRAH+pyDEv7WlhW5rWZdyj/Ow98Z0jgwWkz9CeM0m1oIMj2nK77q49wPwU1OBOrd0RZQxCWaK5yVvmvlhOjEAJk+Gc1Am1Jxh0SThZbWgX0ICdkuC28px+ethiRdGTBltUPfeEbqmZY0GCP1CgHiz++nwFfosl/3Z/Ucj0kXlNJvQNcu1suRaK7oAACAnFkc5RP1hRjQcSkMDJabKAAAAAAABkybBzC8BbK1cYk424uBeAUel4sX3dItphPS+BWEIUuFNcpcAEVIxCMqQ3LovhAeOKeqtkEC6KiGMXqtZzu7UGETXZay4zlcxisodpf4QFANhT75hhShyn+kOlliWubaGCi5wPC9lMcRpqpOA+7KZdexvT6fXdfwixjoNqLV2a5NOZnMG+B4JB7ARK18Fib0ubYjHX8e7i+5/BbANggpLmp+mok4sWqUdYp02Ct8Z29xV2pl/xK545oxMvkXChG4iFoJYJT3xQKLDn1dm16xEMAfgK9UTlHCYlZZojKs7qkNbHHvRAJTtj0OdutXNq93Xit+ejFTYJGoNAGzD/4oq90R/9nz+gu6SLOJ4/x8aF8fxT+wycpiP0Q0OHLqo0svS2/CptXTn7HUXpMj0qfvZpfm0NlkMQ9Pxp/6jZ5vNQLE3XK1a9CQACXp6xOLHCVRS+cjFmLul4DoyOOzv66SL4KaSifHdtf35tYPP6fx+IuVzaEoDnoevL3snqH/M4OwEorMDFzgLiwJ59Yg7Im9Ue8nqWn/lPRaGQuQtds1R0fj+6pqI+mwFPnleLrEhiBXPYuzoZWYqFfwFH54yRreVGTjpZzexHRHJ+60IOaO4esOvri8RBgYjv6EvKTRZlbWt7l7maaHLaGFV242MxGMMZpOu/4B9D+eK62mXKf3cRVCRz7AVg9fThU4YuNtvbGXDcbiMcSv6HChWHK5BUKC9MwHPA0kDu/3j6JE2/pJ9G0NQupB7hETunRP7+GtDDIhy+R23XpmeBNXrFSfWwK2rjlu4kQV5VEubf1ax9uithkYyZI7oQo1Feseln7M379qMmksC+Gz+LUBwismYjsWGZ1Vxle63nvhhkQ2+WaMF5KKyM4WuVlAZR2/bIziKCJ87roWBhVoaIM2/CFgwMsEPIlufaGTuv8JyvqQW9G4kAxSI69mxueIQ/8cMCKzIo2HbJltNW/e9nYwblBzDDtFvripc4LOqZwji/HdVOlWprfRSDGo5C3B7S1HrZNgZ2UhHs+iXQp9yhfiJ3YpM0yDBYb/0Qa/40AOi+KIElKkj7k9nsxPmBlGCOFfrhdtiu+lZRSX+nrgBC1WvN3UHrP0m2qZXYp4qRZGsd9sMbbyHFLZNcaGt+biL1f4D1CYUU4XYjfJ7m2fPT8KZA+jve3TYYSzo0YH2jsBlRlPGh0KPjFvhrnuP6bKrB56efZ6pu8ihgBalne2YqQcj5WMHceEhK68bDUppKOq2ts+GLla3gVKrhYnB9bopmjdy4umJyAdB+c+Hcp1SIUWYFRN7rCVRY+ayWEg4jrun08XHiZm+nR6eabH7G0X7UBFlAWYgLVTmieQgrBI8ICigT/7DFt3bTaLnhr8RONgz6Lc7MGu3N4MQf20SdvMFOodNxlwp/su6nBWt4JYm5AGhf2xSlqAdeCgH1S3gszbLmMuq4MajkqsDQHqPyl7GgKJW3UGngzC5xkl576tfJTG6ulhcFv9uD0fkp7u5A1hWD+4+WuqGcF/UaHoRZC7ZdfGzoSp6spxx/H24FVR3YIgkiAL8SUF2hE1+XxnfXsbnmBmhfLAN6d3NBKvk9YJkJh7MOGPaqPKZwMfP0J/m6SXGwn2tI/xd7SmHqm2NExY0bHm8lj1cvcPVhNwskD1+7MqYRVTFOXJocpHiJjJuTwB/oOMtRBLNmar+xzafUiFUPKngVoMZ6gclJyS4fnZaB0uRZy0cDHSPKObH0gSokWVKXalU/Z8AaT00c7kfoT/37OGyM0rixH5k1C71GWw/nn65J0rGX3LGeGmj3pLKDFhJgFdgVMbABCXUN6Xo5xUkJGBSrj6ihbdP/GgWI1xxIebm9XAbO5DlAQ2ev65CrO0dvjXVAEk69KCpiUIAw6useAs5zIHOhho7Zy4S7yEifGHOu1TZRBAAKormcj5p9aofbbloZk/ibSAztA+oAD1mb4188XV82J1QZnx+TOcGoxxvTIuQbEN2cr0yYOC6CY0ZMFhQ51SXTbuDCMHD3PD6V+j9oYf6tY3i5bcNCSwmW3y0Epsi4pLg/YBkDBoaSWZn2ZjkdIlz36pgIBytebQNrseV+5KBXvoxa8mJD63eoenF/TcVs+0gMHXe/mUcjOxVQES7LUxZuK6aTiZ4gvDGVU8k8l3RE5CWcJ4aHYcXEm6nUOPT+M3F9m7wrpT7HpdOswja0Lw7qYIZHsBJBioqDy7jYrc7PoRXCDGSJvJ/1l6s/fkn9pqR7ySUoDK1G9Kvwxut1Few2VtcHfdGY4XZ3+7IEKlseLfFLQ0uEpDsyR9+5gDDx2YCAR5hm7ZkICczgCsTyj/uZQbPjFzD3d6cA2DFUSt2vkElo00/95udoRl3Y3P58uncv6O7dh64nO0nBy7TU1xwZ8G+oG3uv3Q4odyC6p3tJkgVpeyS+pZQfBwed5a5IJRTj5Wu09T9DCljaGLwnNHvUldRiqyrc8Xey6bb8nNGGpzl4En321x2owqcvAdzzpVhM1NA+j68rcqPlK8CkOawnJG/H0O9OqjlQ2Oscoaz+rtAC3kxh8E00hfBB5gXaN8nWIgNXMq4yvdbz3wNx/IGBCF/RTnM0U3CifvcsewD/0i23DLLZMrz5UsYLeSmn/RNJaGud9iZK+GekIiNM55G4YcDBU4CVgTv+VRTnCS84sJTjY9o/7my1hKwsPUQGTRHQGxySuLN8dHXBrflkgojkZ2JLdGM9dhOjLIX+NyehWGdb2AlVo3EoAXbIQIhAcb0HNJcS49gXPsKCnPYwA2NfZx8cQDr9iXSPIXyOSaj6g+VdA0nmikU7b32Bzqkx+em3PFGdIutAhdzp2Kg2hQ4ASDKPHOoGFKQiuvihFK8evOr16QiPB8LueNwcxWcoCetI1wTg7zoxM+RSSrf6fis4BSkZQQd936R6m/JsDUZENWJhTJMbh3yOyoFlBjlnOf7EM4m34fsw/UYz5tcUtbvffkfeQbMhXl4xbnrZ/DbE6oOjVZ1VYK2Q1tiVPXOn7r1W8FT3SgC9jEMyYjExocaTykjPKoEWgZ9ltWbVa+OD71/ZsIC/hxxFX5xMtwjKh8iB75qFDGF/mj1Hdk1WLZIGAM2Z6kfHa2IrOLEwh8eIy5H1R0aq3DbTAPN8sBvvFPvarMlYuliRtCgj6/koSz/qR3ikRXvsp9w9emWycRIZO43bAMHnnjjv5aW9iVxbpaCPEBB9pIb8lZolgmx69QGPea8ZZTKzr0vSDC2Zr3smkF+FKNsksuiVcCpOPd4UjcNGXvpPHjPReLkrPkujCYkXzjupx7SfiYKHlsNolBdaVPSxTbeKg4SUt7hon6pHQ37s0U8iv0it16X7SLUprIVk9loGrl6am2w/5ogdTYziDtYxtP38t0i7alCO11c92q43HTZCmrL6/zUzDeVd5Qp1jBPVU6mEgVouyEIE8V4Laf3zwcQLHe+5DjjnwCABhyawkj9lOYiBWB/29lXhk5xsehomE7oUl7NYCX0MZBCyLTmd70i8ESVhyRixBCK3/YZ2smiIEFl2bXD1yLcoRv9rO7BeWQUMqt4nEh2Aj5fDMLc4KMISUrneEGPAXYtIDEhQc8EsYaF5Qf6d09UQNb31jJOUK5FMbFjJ7jAWJ6Ayy+DABZLu00KKAYlXDiU89XCdiKE5VtXDlhAJuTsYmAa06QP6Smfi6/IOLP/+S3Tc76YjeuvIHlR8SUhYZ57sw1EBSNuKGmy4kFXTCef0M428EXlUkH5Gd3NYTwVbcGNlZEa3Sho6KEG/UtJydMoTW0qrBAizgCCOOFPsT0+wzTLNsIvIihLwhqLnZG7vtgYKzr0OJoDsaPKfsSnEhAVTWpFgOYtjrMiFxDD/ElVGAVe8mljOSvWymlYP1Afap/BPaLicsh3iWSS73MZhf6gHbPshB3LtvL4AnSFJMp/Hert2TfTV3gXw9meNC4CpEnL5P4MKKuK9NkmlmWgYWBmpQDJNaK8FMIYQC/zyxNE1R4woo2B+9aahZGiyMemjcp/454iYXOWK1DqWmnxgHo1m9Y5WJPjkeczD3rVl0XKjy+oJU6aWwW1ND8zcQR6quR09J3izZN3qHlljT5va8zducWCpoPp7RwmiEAKokVJpOk7/4h0tpPGm6lvBU/PsEj/KigrcqXnc3eY5aJXYo6A6XhxkmkFsGjOxxkqMK6na2o2+MkvQ0FKyO8jC8I+HkAUamwSs7PTcoNxxAhs5acyPlQXM/AIrbF+rVFQT6sh6qjbaiDIxAOIzOHqByg9U9E6ZwxKwLeaVsGYZ9iThjZeMoUsNOb44gt4rAndE/bsR2i6Y60RzFaBe+Gr0w71jjA6L18nsx2xmlXsKbjdEHFn9taSnZr8TKmPNYuyyxKTmKPYoEzehkAqJrzyuO6paLCqs7qCKAP/xGVOzfoQH4KyTIto33/LoKaPhsl+3GP88khc0UkeaecAMoy/Q6oFb0/LKxYPqeOoTbidQNlZGF4L++dGzGZegdJhx2p2NmGGTXQRPfgpxN5hRfCPpgxUDnrB0bAOPNkBSxgMn1e+Naaap4Fglqu0ioDtF9Xd0osT0ZzLz52oMz8SaebZurfZqX4UELdNHLy/+Cb8JzHaHxQCaKrH8QZi5dxXalMEPLe5Ne39zKPWr0XRimi3Z0wCqH04oWu5vFpEEpXKT+aUg//l4PtEB2/UWadd0arRZCBgPsyceWUA1AXqhRgqM98qi//r2RcaOs/Uc614l0n+Yj3HCT01+LexkhhLHCrS3/G4i/inEPdixvN+Jk4mwQjgiRLg0rq+43lvcchtnHydB4eObBOqJbshu/vKJ+udMgnUficueTHK/48Bj7uYHn28HWyHtsFJQZ0JeYykULyRl6SyLKZw6E1SoKA/x+wWf/abTPqpp0GsMQW8aer1GsDX9557UQLL58VUZyn1RXrmOIzEJqaQiA+SLL33pmjlUZbgTG0BRXPm2HuqdPiFppOuDBvwMnuIaDz6DPJq0+8xLZEmuotR4VAS9cm73H1zgbcjJPT5mXmvNlxYDl23jdn4HjuI7xZsGpD8dGPOluEmSRhPH91EK2BN/AwPSgnvn5Y9AEueZtwtanA3Ufz0p/BAlrX6FrsdNeUzae/GI4EwBgCDG5p1K5kiH4WZVfYAMN0Nc33E1/quE7zUXDjW6KAClYFHXckt2+Hs0eHgujjRWjvYTR5Fal9Fl4e93cClOmsL7wZyfIaE+5GBqE1XxiCRf+AGCr9V3cMNgINVYjEbrrHKk/T4k/FDTHcT109UG07CUQD6nNfs9mLnEiYbBMbUVNBtcwiAwAvXvSFGfZnHGxNvuEamjEc0G4i6RFStHPvJ660I47KvzsXjowRTFJhDLHxor5NMMaDhxX4aalIMrzjVU7IpF1J6OsfrCrmFZJDMdyIxktBhT3yglOl9//W5Xxm9zD9qgjtOEc1lqmotHgmnltQpQQZDrLh/kmJ7jWc3zAQBaMoNfhFYx1Pg6PCWOvP2dNBWSsYYBhFQKLDn1dbTkdFxb0V4vs9toYpxn0NO3bki41iSdU+xJYkLJIBPPkwKgtiD8uRE566d++2mLwOr0lo5W5GhH0IBg/TkABFefZj6GKxK5z67WADB90vEaOXoDAAAAAAAAAAQ6O6DOSn1EGmE8/jT1KVA1Znz8YZcyv65XRcwvXpz/Y0H/bTqwuZfXrCK4UPoLHh4xv44+8geNnTJ1Ac5pOD7hBY1LhbAHIwiQQcirdtjzKr7xwdfXfMnohZ1AbDqzSsDQX3QKzpHyn+4r6En8OSf26h51+ALFqtLHPFMshZbDNiq4dvjbaeze7UJ/4l/+mEI6Tdcj44opZHwGT11Dm1mb7bf47o5DcSRG6f+0rMPwKNQ1GGGxmqoxBJOcPwZ+qONapdx8yHjsy7Cn8qOThKPXJvL9Lx0nRoUmNvJbW/8r+d+3x09YD+LiUBUJrDc6wsuYawBhvbh8ZpNiVg+0s47hqUxhxkByxbyJsRsNJyFoY7M57NuaphY63Fgrx1kRnfg3R0znfgpPsJO+euKNpxgTT/7AvUWqDfQ2qZJ+wmkv4PibMP3QzfLufYaW/IQOk1bNbESn/4otYhc7kAkQKXBo7wjzJDdR00QDfHz5W1EYTnw5DqhPWgwC3Wownt73Ly6+BwPS5OhOrI5wmL5Hbu/GM6JdeinzJB4OuqmTNhV9lonHKhv5MWYTUc82dGTLvK71gaRDdv5xW/REccVePz6X4YVKs646C2t8YQo2WlId+wXgyN3XMKyVq/hqzYjYaTkFKf/k5uZ8o3xDpM4PvGuVZvn6e5AHaUxFPuZUPpId99bulFHfsj9529DkC1UsMcd2jzFTUkq6bcl1k0wOAS+KYL0NiyIYuHeL4Aok0sWaeLLlebFxIcuMvUYl36HjVj4cmgAkpE1+z/70FmrzOuuhqFxOjA98JYLIXbAb1EDlVyqib1x+nOo2ebzdVianHXbpnePJAJGfhr13HaJK/64M5w4QPqoE43EgTEo6CMGkEWqgQw4pGFNDmtTw1ST8sFfCfBneuHpVdS1AC64AchAP+K9+a9cn3FNVDs1Xb1WoEP1+AanHlPedWYDqDO0ONJ2mEwkw5TDy3SwC3DpR4MJ3f0b1s0NdAJyH6xquAaG7f4xdVZZC92X6q8rhSZe7/fzYK+pe5yVixgENACxr4WMPeXCdyAjwcBtsBmXZvPPzlUxLPCXRLNNTFn7H3k9qpdbv+7jyJ4xoTFoDGc1ySNH7GrHrA+THHquDGS9+EhBPIvg5G/KS5dKmGGLmfNymYu9T/ovJk1jM4vwTuUJ3R1X9LFK0ymS3yPmiAFU/ZkmyZdYVHzdOLr7wwIm2xlCH4O+58XZFZrfTHgg3fggisB6J3OzaZwod4qkJrPbxKrxo0cKqBa2kEtLlyQSSVl4mNQK3cXp+lzS2PrK5uYk9nSziLA/HshlnI826vHbR65fPWRW7NthicDCaIRbqF9y6Izx7/gJIIt0rQuRSfXeLT2D/78mxRu/CBK+6HIMWAjQFRioU6+YNkFKMNgV8tPSUhzkzRlLp6M2btWGwBXACzPiNRALn4KnpXyZnuqvFV9MEIarWRJirLXBGUCZsBu5S9IImE2R1Te0XeCBMjT9yEDVHN9cbB0oHsvFvul2EMcdmFoJk9xjeXIKrKT0g88jIfoG2C7FbvaYgUEsl2KeTS/SXuMJLdjWmcDIN1IaahcMi9nUMmz7i/hTrHLahIBTvAsFUXNWCgIQAoTmNcLlBZLyez8X1dyQ/cFisN7gnP4tHmRU58IQUz8ED5rNYKsjjo3EfXD2QpgQSwesdHUgbTmm5mcF2tnTjsepZFMH4iDQ5WiLXcvvYWg8KplQLs2Hu0XP8RPWHGyn688uDIUN4Ikz6MAO+93zgaqKqxyQBxVR5B3xdyGnr6kxakz7S7ua8vj+DeUdqZfQ96pmrMEiOp+RDY78PJsm3soD0ECS9XQpCuRbcEDuLDAw4+ysR1PKm0sddzOeDxeiFNnhl3wJfnOa0QmDY0ThiUVLW5bz79S9aY/uEtrakt01Xj6KjiL9sz3H9fe8PoEaLV7/GJ40Hhbm3SPBfZjeMkmYEb/ggD4+1FwTPd2oZTsigNFKfoqWP1ODSY+XtKRhfMrRPnidmwsDfAR+hkSEnFKPJ7X2ZQSQNt36AqwN/CgRD99fzAh8VNTlvIAVstImmlwsmzHHwz5y94OSSBzXMT2/NqA5fEvDV/N7vR29S2CLz0d+cZ6LPI326l9+BmbX7pe1Pq3sa0K7x4jMLoTilKu5SxBt5AGEqZthzIv6D1uoW1cFIWRSWL2hXVGs2UAnBcB22G/Cm9aMZSuhI72R6uHePzeD7RW+lQrMck5ulCZEvi9EKbRUEef1GrFa/A1v4JMgDezaM7S/WlGVXQm0ceARw2FmH/TEIHFysYbiVSrnwBaCr9GxjK0o8j8IkJVOERJhVU3DoSGqPyRCznPIzfSbVbt9v12tQDKARdLELLf6WUOfGVjuH8QoehcR6qjJlJmX5iN7rEH43vE4H7WoLhZsDCyscgdRYbyzDRjxfwfn67vUWGiHQwXEon56qitvwpHWr7QU3zh+NW2yeon/ycXU8wVBZNuh+rFVjdCzhyVm/AA+D23Zy8DTw0/PWtmi+8qQExqxm8SdBMvWkcSxyMRBcyN0BXfasWDgReXineMOqQ7eGqBPjNBJIm3Dg6t1Ld2Ncy4GQQl/yITnwILXZzdEhUtfzgHaGw7FKbQGgSWs/ehdomT1hgpw0WcDmjOCIaT9Y+stsBHRzEK3enB6yA4PuXiTty1uHAC6B6RvJRLNLwXCI/LEqqIvKzQTVp8pVsjHgY5W1LbftyxBOE4lRHLeNf4yQrnNGcSB85Plr49Rxf9Ymc9Fd1EtpggeHOjVojgdpULmFbSXw7GHkY2CmYIXXTUwTRbFWydWG2L5lFWh2enV5eqdEJIgLGWjkO9FZmksScB4YL7ejkZ8QfJ4Rx/gUPdCC9krLuYnqvTF1tL0mAxraDpWzXKU/rzGrLpWobE4ZfVnlru8FScNE5GaT1eozp6j6JIRPsIZM0Hs9WShgMkoycYBdLujdUpCuwcC6yZSQAWXyV93FAZKcmLe++GN7ZTcWgrYF16RB1nPDzs49KAWRlTiNCu1JayWd8TW2NYp2A0YGT4qQE6qYCAs8GCfzEyTpYKYpIZpH8PWnZ13cK5Bgj6n/oLAdQmwFv8QkBCAXgh4IfBsIIFd3yEgutBf8V8K0igIm5Vsu+9E7NiscrV45rx5zdSpL4Yn/tm/A1U4XAkM9GYaqEwWfmXDp+JAaImsJWtyh+X93DqESmUp7vNU73DTjsouwSvxN5iEGU9A8bV4ynQpBX8MtYUZylggS1EMZ8GQCE+K6Y3cwafWJOi+PVR0zBEbtfeFXm2uJ5qDRtBaSf8lWloNS55mi4znFWkc3iDEPh8W1yjSVrQP0ZXuqKngjtM1kWyrIaeMv8iI7tQvX6rJueP7MP5+WJl3qettsd3i7km+zfvdSbu8imCnVu7n5PMbz/aTDr2TkgliC7GYqtYjdqta7W/FG3jWoWHkRkaq/elecJX9bIXZxuTfmaRTB/4L6eNmrRjM1HRd19nBOtmptwf60hUZcFfZ9w4VeqOsX9xNWhW9Y09idceXy14n3igi/YnlFI0R1ssSbV+/SHnybgWoai1hVEfSncQDyQ6+yxmNvGQ1gtjryHxzNxgzxMOULJlquOwp0V72xO/jQLEbBfRl+y/B72TEt7OFBDIuM3AkgntfX1nMt9oROapIRoE8uJTE6MeMbyR9ZvEzSiuF9OOcT6znyboyEZj4FTt0AvE/oXNwhEIhNIFoWSJZ40hvprPBwM9TCvdikJ6vU+eMAkryf/i7WqAzbKs9BkfPcMhHtDdXrhqOmgFHACeic4giV48HXyhW0uYkXYvRhms+DCq/pwLPP9Q9wpqraBtJYPWQxFT8NvBbSWjqqcluwfrHeMa66wlvTWsG21ALyNY5uC+RajQuSA560fZrfEkHOP25vBvI1nA831CgXANUlXR51hwFssLHWDBixdOMwtZAHOoS1mNk/+HZ5w4ZvY/N79/UqUe8w/ebDBGwILIQLCvOD3XmG0KozJDQ0CAsCMd13lmIJTLy2SoGtUjt0j322PL3LG3Cyr9W2jFWk7OVu2A8k7jj0hu5izoswrKdaEin82yOhonL3wVFlPwgz9xkEfh9ZukPA3k7gQxVdJjXSVXLMUiv3pLZs3HmuiRALqFq1VBNPQQGdyI1j2SzE0K+7nrxfc5ZLkSm+RjXtTfHqQEw8xW2pmrJ6kBMPKLk7hjLwsM92fhGUqbXNlHUVV+0VkcszBlQHH1NqqN78F3YgqL00ZKUkenBiPRvzSwiC1PajUp9jpLd7D0XJbXeRDpjbUE3zhPRApkXnzGYsxxsYT1/jhJkrxauzB3RByU0HDfecjOADAtKQKXnLCdm0TIZ+gaAKorpUvclKJQjpsOgpZDdhNbTXCjU3hFCl4GCbadDaC7ledDLpcxgh9lGE/I/MpSCMb81rRzg0PNqW2Sop2p5JeIptcbW9CqkkNjfDqaEHaqWVXcc/VXxskX2+QtjBK1Wd/XjCNF8Y3JvpPI3x9oBQqzVh8+kb5WGnjG6wU06saqXiu06DM8+flR/NlkfrFB/qkNcEgnHx7tRggOa7tcSEy5IHbELr5FiVy0IL6A4byqEld3AIuorr2i9rL65FkBXASDea1A3dm/XWoGeZ4eG6DFXrEeitdmHA6E/0JYCZ6Hz0cqn9Aa3m/PZHw7wiPn4Jsi99i+NMA/lD6JwbDoB4cvw59nN33iqrmEHLhW7bHYVjfzFKdGkvLFVME0qeoSTUTd5EUt893Kgt0BJSH91Ci1PlEfQj3NFoxgg9egzmNqBDdPug22VsPI6VH9LYi8Q/luiiiK1za3KwYV8rpZSNEK3lUCq1cgQukCymTgNleRPi710e8uGPohl9fc5DOFJErHi3GinGsn0gcu7z+Qmt2uksBGF8bbDfX4Lsc5iPVqG8T1zd38zaXWqREGvJcVaRz4HmVjeQCIEom2fEllxpuOidzFc1yhu93nTtZCxmzfDcojJHbf4WeUtRez0SF1xoLfQShm+OYRkQbmogHzSeCBZIDkKfkAGfebuQ6c5/W0Jl6UawYf8f7ueueA8W2WBwaBcLYIxrvNAmsuVzPgkeZSlAK/ngQWx9Fyraypkl0DKkeqSKeHYHa5SifujyAlUY/pcZ9mPTV4cc+QQqYDczZdxCySTUPmjyf4Ad3ltMsHdLoaoOgEDuNZSZvRf0GVieeGsX/nucMYMN1sdCH6SO8YYqJoIOc/j+4701J9OjsM+Ms0Bt2RjyFlxhtXaGboE48elZYw3Map37yvB7TVAJ7lHOcKmRe5yxN4Bz2AV0WqBKtu2zJflulrLzCZgiH2+l9aaRkYoUJHebiIohPPv3n8gaJf3D957kltgMVUX8xTQlpBINuTkk52OttU5Gog2j0zmgW4ihcv5YKYasw/Pw4nkeeNaQ0OpKqfL/l9C8FpKkEg4p68eyozynklFfHwho3ztge/k9/MadpANH14JsxIVl7aeBQxzeiT5wofvRZFdWSf2aB3guQuX7+2SMiSghyj5tQ+mAaWVevBOZJ2g0W3kBKb8/B6xLAX/kqIcb8nwEFtEaHufPc2v1Cjk1WONpyNjXDCCgAsRovTkUcmrHR/NQJm0QJ9EwyHboPPPiPc2sERU6HNBGHtN7jxWcs3+bNNVAroxB1BLui4FknOseXWKjSbIK9N2V4JdhBAeOjgEBVXPTRKp4lI4CYin3UVQLLMd2Bt2rEPGw6Z1lX0jscfpTG+wblLgaYG9QWc1NksQHaxHsTMsuczxWmjMb/bC4R4T0yA3KYwDz6H/I+/qmi+HsgEydA/9X4h5z7tvGsj1h6xZBgC4BNTNZG0IvdQDUZejEiqoz7QB8EM9sSuNO3Hny+nvUu4EJHxlgRRAkOVXXY+vp3YzvSrRmsTZ6dqnxxyoY5z3LmrxpBLJZtgOsJ4Hyk4pPtivbh9TlM3zRdU0OYPvjtPAztnDw7aOcgjff0CSMjvZvVeFKs1zM/76OgXHoO5BkAKsMCZe0fFIWrFABeqZmvi4QNCYoewamAbCfM3XHDA+rwuXN20HpBUmvxETL2r8EYA5SvSOmzFyKkOed8c0SvL2GIAP8ffHCbp8iujdn4eqnWTjrnkCTgox1cF3i4lOAyc1vyPiBrJ7im/7hImaay62QCMo9AyAFP1BuhTiSY8wxVBGwlNK7Mru6zhGx0/FIXLDItCa0wmuQcfADg/6rkoVMQo4kwmrLtncMj8sCD3BK5Y30kgKbXS/qxNROu3Z8AsC5OVv+xv0iF6yhVLksm/RshvBzzEPg3ziCG4EHnjAi+v5UzB/Z/aY82jkzOnNqj+35dYMx29KUgkCYAANA4t2UNSfTiqLsXo9KoAAAAAAAABZNzH7VxiTjbi4F4C2Vq4xSkCsn3mRCqIK2rpyCMT1DePYLE9CJ+JJyakvz5jNSTI739Ii3GZ2/hSZCpK+NrAvHe8qwld2cVjhpfkAlKe6IEfayVTAurLdXAJOb1gSLi4l+JJfRM5qnwXcmiSoC2fMPTrjIHGfG8H28NkGcjMx3XRcDPpRJ6qdsSyczj2VXERbC7aOwPbN5+e8vAvSZidmdlxPx6oCBfTBoYYmwG6elzYrtNmtSguhT5jacYmrL4N+hK7op3MtTkOKW6SmfkWZ6haQq5Rd8useaCMEmVo6Jrw3ZmY8sIEtanBJStNml0HgyUXP27TG7a2GFa8T+grESpYSH1oVHnni2vJxyCeBRi9k9itdLwUowIJaAsZhW1NQJDqzwx6xq2u3q/b9iw22eMfDUMhgKItPY8/J/5NzLkcq3In4oyld1wxsT1rM2akXktY+tPigKWHOshMP2JrADQ5ke002i0dreYt7L8d1QnWclTyU99awpeutkgA7TE41nCePoVKMTJLsnMu/AokUkh2MPlZWP2rKsDdJj8Hph25JiDNPPc9v3P5U5SUM3kIWToRF5+MEAuJk9dyhEtZI2i/fErpDj84OA36zfpK0ZqE8LqQYmREXdN8mGBePObqVJfDE/90AEk1fzKAnvLyJUHh1x4G+ovzdKMwHVu7SFRSh1Xa/2/M6aBvRWew7u43poxeQxFPIWa1tZyOZXDlYuLXcVWPw5rVtS0OD3eLzajEoBuVYHB64zLTdCxSQCKgwgcVc8ihktpdlVe3UoyqHBDT4ULP9JCUN51OuWeLAZ95ZiCUy8tkwgIzx/k62ow3+01bZyath68ViT+fABG2OR3TIfGxVnkX3YEFhGvG48IPMK6LKf39FqTyrwS2qictXxrtYJacYx69ob1wQLWyhISkJStGrOsPvsFHU+iYh+q9y5he9jsZ4gpbdhntchFYB79iGpj7JBqB3bBSNJ4oTlOVdUob6xgSoj1px+cPY6adWdzsZoSKPeztrxGF11J+LuMAhqpcCB09OfHtYJhBBRydczc98klRgB/XpXMebT9OR3MAa3RjBhccUWDS6hMVNnQ36PbsEVKCJUYfrmCVvLhH3lmy17WhJwAQCUxpOouxTarVwvXsZxqFauzgtrFx5tAyBGE2w+T+Ar/GLvqVSGyMF78izymfGNQGTRMcre6K4k3D/wwqkWpV9+ce+Pw/7XrCg29thDhdQAaZm7yeDMLKbDLpRPsAehpjE/lwoZiAnp64+ZjbTRYbTQa6QrXg3mlVFIAGfg7zMKtd6WKK9zEMwslIN9ROKuZjPvJwIcS8agfRZfJG2pnZYCWpF5ulojmaThhX9aOyJn307VmTU0WMxVSRqm0sm7CMf479VYaIgHKYQ4QJDHKdpLYwURe+PTDOYYHorhcKk7vCH87wJ+FC9GOnPwXG/s3ZhsY96TUuBQqyjXm/Icn7BJ8DGYiMBe5LjNxu35K+UW/xei9052DGT3JLQPKrWfBOMKEKZGgwlPRLYgmHCOVC0yftrEdd60GEsK998aiqTwGyR9+pIohw9M1Ss7vjC4rUe08KNu8NZBtSVyiqsnNtRzFRIoiWFQhtMpH2Aq2WdNkNNpnT1tmUbGoncTToEKCnCMZvX7BWn2/OjdTg/p2ujmD7znFmtbWcjl1mGtvxtwpKy42/nFkHCTb9X5ixVSV3iAtObDtCjl2KQ7M2bW55FDvbyQK1wOgBUBZvB5Rma9u4oNRtJ9RnsxrhyVUmpXpzYHc/84K1mp9uIltRwH62cGE81NfWqzdw665EplPKmcIwPpTMdxs/JAjp2kRjlRy2CkXI1CnjZnnbanhMy/CGz6vvG0LOyfgcjcKB06p3zPYnV/PxDfiwdYOFVJ0irqxucY79LQoNzr2V7ICh9OcQ1jeFQ/5RIv0xNvf7zzwvokIvmqzM47Ym5sAl8s0XHYwagIcxyiS29DS2w6oQziDmZDRbIvnzfrRuv140s08iKXYA3RLavUc1PXm49vty/mnn9/RkOReRNujFKyMUrSvqyq5PnwSfNbn8ulfn2LH3qmJV47Z8CLawOFpOs92Ouu2XlIQTtzxJa/NddZDgGEzYdrZhLzjSB14i14+4S/CqzOc2M2xDoR/FnH0T/zCr7hJL9X6jiQQtL/ctWh/JDv2YJrjKG/sfVklCxTKjx160XwdU+IO8phFoa5iid0ecO6yHkVvK9qJmD+p43SwiKMRx3sb7wWoXmqbhb0vz5h2rSnKRa6o2PEfKAMMBV9caBkfmGp8lZZXQePyjPjZ28l2Wdu29BSn4a+tG/8sqlIVqCvgwrkQCWy2ryvqQNFdLQMDdAcCEl/f2WU7Ajog2Pu4+Ii65fuhUiiLTPsG7/KyJkMM9mTwoEw1yRaX5KoIYIMOyFzoerlKheVNIXuPPTj7k9z8+Tq0fpzlTK9WXU4MRPZhUfd7s9Xbe6wEIk+qKA9weXndxPdyM9LW43H2er0GiOhltavcjRholOhVYZ01rZD4WUmF4/k7MQSmXlsq/8YGoevk7oesALZ4L2JOLoFgG3Ze3lRNRPZo6zXWvLLX/mTXK9msjvIK1vAyDRjR7CtcgT4zjsUS7RfIuRVjdyAQV8MQKVvKJkbZf3/8kIPpfb711+QG+xhFP3Y/sTyZ/kwGabNs8aq5Zrx4VpFi80/fQ++qsxRhrYeG3sZKjrlQK2E9FfTitnyrTK1nxgOno6QNJgYid1KRF+we73GePwqaodFxGnciU1bGRSXcr6MZHf2IpKGxc4X+Sdzl3qI4j6bPrcTxtCe31+8++a9ibST3Dq61h1YyrMJ2baiwOv/+WIufUbpdXmlq/CSIR5aKs4gZxxF7RkrwNE8r/Htq9dSka+RG44xsMCofS2ZoqsC31YCt6Xz64NOpFu9ldI53Fs96CO1sC+5IpI/tVSyqRDGzNUc+cYzwmHN+cdCke+Tt5dsEeTwt5OHdTBDFyCwR6+7WBQ4h+rvqJnSq8OujZKNs2HwsXn3O5LZUfLeT5QIzIZowWNw7pxAXVwc7Y1dxbRulIDujq3lJX8IeDYvHycjJag4U7KexTk9MaubsoslA3320R10EwoHIGAhMWrU3Sbc9KcHKh8/zacESrqlR9jFj3pzVOmGL6Qjt/iUU0ByttmJMsnk57Lzi15y9zNHsM5Hiu4MO9cwXjMhSUfA++PYkB3Lx4iPfbfppNN7X0hHfBfhGIxpSjD+2XZ1GNoI3o6rbypRYfo1mPp/PIb14eahukTrP1F2wtHi6dVadIO4ZSK7ypc8yrL39CLBMncCS9rPsMWAWYw/HvIBs5l6GzvNwuQh46IbbQNvsXiC6YcTv7dHIIr+WrUtvLzto2TD3IWfgPzxGDpYgUHRCrkq0WKpvb/S9XFDWaXAKX1rV3kPQB79idWszj+WGwaiVbonwBEvB3ByrgwIUwon1J58WYfabH8zS8QlWyvakgGq18ihyqUuYqzaYwV1JBw7MJeQR4SCcWrE/uF6i4QTLsXseey4EzcesmPdfhqJBROkvBKOcZ4ajNWJW+0Kepg1jjXJjeVDav1QpWsPXazderxVyq8U5b77d31zbfLI5S6DoMjOAulb7ZW1zW5eVmZeuxdz4rlyoWFq12+sTMNSNBNtDvE/2Op/duqTjfyRUVvzD/izxcKbdXUnlJdIxROKRWTidkBGiHn3GAxmvZPBZ15hOtgEolh0d9f9kCWDP3ns6NkQKRsPBNiUS6GgpYGDXQMCRthxuUbhML/wB97BurIyyJZ6KRfOMwRFXPfx3H7PKTP40MM4lt0YsqUEm9SfJbquRYDZoJO4okhBKVuk4XPS7qvEhBo6cOGJXhwLpI7Uaag6b/3uUXr1SJHXSeWl98dWZLNqTAAd8AGeoiKqcNefQIv3n0l0Pync9hxOjO2G0drglWnhsicSxzRed5HShjVdqwMKmX7lUjYK1FNwRI9JAMjneP0PKgPQRiTmMZTicO6WWkTH55UbkyXJZXCRRQqRHK6+uOUzDVQEpwFHnFrQsWUsaVDoKrTE1FpsKAH0IC/cIgcFsk2bsEnmISPo69hs0dCZXIUtEpVsFobqUwDJnAJl7/jRJxyxdHorpC5asynGbvJLTZ8c0cwkPr1HKxgi4dDN6NVFSwVfzU0ZEz7xCgbvW/VuZUO3xPpFI8/g313uhfmVotWNyPRHwW8DzaZm6AqmTYphqR9iKkBjNTvYZMVFEBlgOP7Z/o4k5oygw9OYBhARus4CisgCEDwye9U2OobNNUQvE0OSBcWmI4fLQJ7ZKF/8CDtgXM7hVYVIQI8dJDHW4G4lbrP1d1gPOO6rlqrU/17gEQwzbhTUfdV/2zFoF+Jx37cSyL7w+5Zqd/wERNhwCeUHCUHjIjYRRnNQ5TJcCB+LnUGsQNVHClk9+H9evr2jBW3FRWTW1XJ4w9r05qgtT/XzyhVGvoQAZnwObbt8n5qAdvfBD+0AxFS8u+YjO8HjXwUQQlZwVYbTqaHF+sgMLL3XXgg+nqM01nRV+nZa0FYZm4q/YlTLYG8z3QEqg8UKkM9Sd72Km6KfPok7Y0nXnpK6AUGWMRPfxTGi870RQMHlYH+Ef933qtF8Iq57t0dz6SbOjng8OdkqK0aWu67or8OPqrUOzFcrBkPJ5LvcHvCDuBFVxhqxXIXscD3CHXNViW7zFwEIA2r9WZenIcs4dOosxuQ5Ce+031F/hsrs9lNBrMIBdPcqz1jbfXC0cnzgadf/xBGxUnvlG5Hc7gwGE2frCEPxuPpg99tff2f3on1y7HTYyTX3fQ8PygM+721FP7OelvqstBlvLoGppL17JShbbuo1jqzwrimmF67nfq97g4DxANVBbzd6k5ckezPpMCaeC7kKhFzIOrLqGjZB11DjYxKHzsKdwsJxxSDDlRoHQCSv0B3lra0aPszmNIsgg+h2510F98x6jpnGVQ+NapD/SIAcUccDOhsOxFxdU7q2pLSXfLRaKWiDST/fPQ5ldzAb5QvtsulsToGY3oe7Qc5RuTdsXOqUGVgcFqdhGaOzjrZ4br0ayL0KtyFw6JnQfyPy7/DpRhthLP6YT1SYj38mDmnLNfduHRoB/SqBlqTN+8z3n7CHQp2zrYE6Ak9OCincs5D5YJ7zTxLd1XnxqaKnslWtHgHdxcQG7aMOcRT8Z0zhAIFvDBYrz025Dk6fqHaerTKz44cD67uRQkSZhQ2SjF0rfgQUlvOotXVf642wAKQ/EVfCn0p/jF8SqRXe3SRVpHohkio1YfRfHC5UCVS/SHCsNvVSuEGeHJ8MuIo5SHex5HVzwZa1zfsd4rNDO6Arv4txKHnAsnJauGspXji2HcF+6RhZhlwaKTlG/gp7oaLloivTDvQ0taBTQ+4OyTkLFzg+he2wTt3USGm/0JJxlehqmof13+OG1pJWhms3mRWaMbK2Z3JghIbkcSTzy4J1gvTPxxlTlPY5gbqRwPZcJeipaNzWVufcI6xYB3543l7itu6lzM7TegCKwb2UJTHmIfxr7u9qY8ythMHXkKTnLicIxKavv3y0GEQRgyfr8Kvw5ahx7as2CQ02xACNqf4jfZKU2hvjEuNYKMbVlvTa74Z2GtRh0QPQQTc2nng5LfyeGxzupoFGVFOtuXHEXpGq6QECvQ3JjCC9I2Zs6+cmZ7f/tR+MamD/MyMvGV51EPjvswm8Z8ix3aDcylScXO1m8ve7ABBE0Qrf7BS9z3MiKsXpudwIn+EJF/SNgAKXFL/60fpyfGEvENxyX/hnwLru10DzFwetQQAZMjNmBO6pmXaw/PIABld9yhUrN320aFPAVUAAAAAAAAADOtoqkvUDtKH6yQqR0LVGMwraF74a3fVxuBwsR+UcF0hZZo6LgjMYz0zVWpQdWzTo35jvYfs4UEMZPVrgY+se6kdwoD7pNvg0VLmIG5rgWVBfD10XKCl5e+2tFX1LFfUIicusIwFo9/jqET+VfYmWbRVjcMCvbxix17KpDbnFO6JpBgdeQiimUpd3rq+zZ1dL/9f89vcgWOJgHPawn7Ci3wM+yIGM3tfSELpAgDSQ0USEaSmoenn9MV1v/hEtujFmMHsFcMLl4RQ2oPmRoZLqyLbfJyuI4lY8TQpwci4VlvkuuGD4G4QXDQwkUsAoVyIH1H3EweIvxBy1lAklPpzC2LLhMUX7VdrypMGKUF9Z2rOxKhj1ts08nN9IblW81aqf4jsxtib9YGAAkb7Dk/MXmV+hRf05YYA+mhzsIACuDN+xEpugKsXzu0gNMxquH9swj2fERgNyoN1OX7K6nj04A3l1BTUcL4slB6IQ0edVxUm2tITQTT74zVwCg8dMi7WxJMgP5Sw6/MC5/6qwvmoWoLIe0eH43e4fTdRKnUamfE1K/NV/5n2a6QuPLhkb7H+axEc+H209DIotG5K1zeVb6o7shsBdXpDI/rr+QLdpr6W4mnBA7i6GAbUpcAhGB0vpqfRx49jDhzBoBOq6eXpZ4IAcSX9FirSOthRFpSY3zZMfFIVmDkiSaBxES/q4ice3VzTgyiZ0uWGFEbEjcX4hUS8yj/ubrfYbvnEYUHFKKScNtGKKUqeST+gIGT9SDgyrfgw+lD7ym7plOaSjosUbhKulcsalPPAE9Ru1Rr+Klm72aF1jc4eBWp1UICJgg8IsVl2R1bJ/5fXv5lrEk/xyl5dva4rQP8xgYT4yLCIk/tyGWu7hKzUZQc/Oh8QrH7cUigTU8Q4B46PXdKwlRvC+62vCVglyebAO+tA6cOPzY0jFNoHVoGMDUo2jN5ytQG0ZGBKwyThzWad7DQv9HQJRFjQQiaT5dulbTiod1swTKvTrlNvOjcnuBYNNxnGNV6OuRBvnYTGiGfRflehd9sXmY37LrH6THOY22ygFaYoaOiIFAQXqjMSOhg8BZNUOjHOfePERw5yvzYozPfqWtHRjPWHmT4v0aijOnUXUargX5ii70gg3sSXLH4UYt5OHcsu+nM3rK3okr4Xuacmx6+Yw/pgjs3aSdvZarKUNmzJkgmpoJi629NtT5NJ1S9Xggl8iwbzcQmBHEbjPuY1j3arIxXJW568NgE5ZnzYTEEpOH966C1zU6DVCA/9wdnxOqy1BxFZP9ZqWSv97j9hXpS2RPl+AgCjFYYsf0eAeFkWPaEogzKEsVFNL3KyaE6JAdt1R866rk6xdYpNE4pQY87OJLVf6Pi157vDf0SfoGKI/81Avy5nFoTFHumXfy6dP9OgGwtUni/Hqv7sImhvHCRFfcO96suL/9mW388WOTDV8ywidkMIdpW63+7N2I5i2d9QN9JsN0Ntx9iYl0kK3POB+0mK7G2RpubNewfwOk7sqybrqpxSJcSCAMpB4ASsmQ4dGVyh66hDTt0B201rtINDolIUbtHEirTWOWHvJCrNkNidooFtRYmrGZEX1BBfTPMzVtylnRsak4Sba7RqjnPfA5FwaESW+pz3Ba2qE1hudd29p8fSTvr6tvxV6JrIL5jivcPSIYCFIcClDc8viD6dIRNPYwfiVjppKHgjj5Ey5xzpb6TbLufd0BSLhRKBzltV9fwYbKPUo3H9z9VyvH5ZnBTYgkm6MVtCKj2CrsLMgVgnktNRXnqNMWWZ1U1hWj1zlZ347ndGTLvK71gNt9ZwvYYWWHdduy+PvYj27K3FOAjcPFOy6BAXgHdpUppdOQo6SvIqKGLmMi9iKUGrEXmFbOyi1q5P5EEVhVsaXUoOiywFwSwxMLFREES1QOv18MpXydTrKdmGdhIG8wTGcwwFt5ZhrkXHDIvhtuY16ZzhO1+iqxwIsuRCDzFznoxBXSL3q/jwcECLM6Myj1KNx/dzyL6NCxoTOx1zlb5BfBe5irkhXk2QuFEIufJ++/VG9Pq6wNJ5OD8Y9EmYj+SI9y3lmZ5sxBJZqrIBtxja6ySzq+7iDDkLghU97xq+d4Bvh8p+U0pJqrLF/IcT3odgYQcdUQpZR0jQ1oENS8Ca2QaBt7sKrYErbFINHyD8IJIeDBhS6WVFx9QAYjMXQ/4vPxXyAJachnAi1Q/3+b4F7HAbMmafYawYlBDQcK10d2uS4zp7Rj/Ev76FMOjRmzEt1W6Fvqm/a7TydEd6GnQviohRfVAH2mKPCOLzUarK2E4cjaBTfuZ938Lv+ewRF7NF3ZYJ3fKnLOpAArwU6YXP5i2Tt56//6kL36nLY103qANBdbr1Q/i1B0vSuRrx0+6ITGhz5cLFBC+mJ9NY3Q/q4GLDw6r+l9XzvAN8RcSfwlKkobe4YainvuFUbktA+BepWXjloRnFXPNHLTx4c0Tu1DH+qbXXe/pm2hrMy53kjuRUSQrERsC51frANrfmXHjYl6E7HE3EcQxebYL0q//b2IssB1aKPO+ZYQRnYoR2YnT/rf04uBLgMZBk+AgpFlpO3F0ir4szBogAhXaEte8nfMqVDN/pxGiRil3rUZLk1QQlGnjLTUSwMt0yIHs3dAmVV0dSEl5YylTFcW/3/r18tLexK44/NWBhUP60LcrbkZ2ZY22/QNQ0ez5iFClV/Q7cF30tudvMu5n/i971lUkI5AGwyNHVq7Zs9G1YuHDwU5APobPK3WfKWq56PVAeS7nqv1vOF1xelaGALb9AMdalp085hY2pgyNVEiWb+bWkBf+VA0ds6RrKsvfc969J/N4+kLlJxrLu/Gucty/RkkTQrfjWgRx2e1EvrQX4C5ErzuMtzZyHqTc4TrxUBpjIFtxZo/rVtFb//AIPk+v3fY1XxR3t8t57GxSXTH78ACOJezPN4aJpOk7/4h0tpPGm6lvBU/PsIbx0ujYEEdOQzN+72zUFBT6X97/G55f4eaF6/8N8NF8fsIj3PzzbIT127MY8S00+MB3/4igqMAkri1lgFtvWNl+nahIbXgoCG25AX0PyTjjTlYv5trmcgn1ZD1VG21EGRiAeAfQ2Fo/m/CJ1pZ6bSIIZdCLGodbxOUg7ss29awBO6IgInJPZJRrZ1kIOn37KB9FquO0QBeSrgpEydr7yznMZSrfZ2hyAMAQHsOlrYHTQPfXNYe9gCEd4BvrLP2/F5xgUazq7FWUf/jdYJQaqjzKmbUKnKibJU6Fl626lV7a+bB+nCfjB4faTNjPEgyOY58KTomIb58b5mVl8wMHI/pMnNhfodUCt6fllYsIEgTeRT81ZRS9r+B3ftiUay/X4Az9UJOYS5HzX31nUCXf10JndHu1hqQuf61/W+cxpbP3xn+68dZ1HkY1ixEKsLF3zI4xonAzpkeO0yCcxsRk4PySgJCknbWQ2xeOImwXYtolKzHFGuYgdWSX1eFFvdVKyVgG51gm0X3FWzKSjBMuum6ly2DQL2UFXw7uU5MLzABmqIZ4X7v0eERmhAk0WUo68Qyaz/5UUFblS87Nhh6aws0Pq3TWA0+1YbS10g5W2rXqEwhPwVmfRnMzx75Lpnl5LKwSlzz9bpaZJmC2JgzaDDyJxPwC0sQAcIiPbsTZl1nxeS4curx3hrO+BFKFiHYEVhNiMEBJhIDl3cySivs2913HFhFlSBldaCsVRJjwLWFEeiOcEihHShaYHm0i6HYEK22ddtyh7SPGR/NDVwrygMJfO7/H8SMnbP/QX17zmuwif39sDFr43syxvWJ9/UdPVPUKJGUPHE8s+A4NwqvlmBRL7Ef7mg/WsE3b6oSb6C2Jq/oTNINE2bRqfzrDItEAx12uxFkZVFen1FR7lHHLLoAEPfZBWSNGX2QVE/5n9cm00eT8YOqugpU/PFBmraqdT+BDub7zZBzUjK2aoDYdsPMg7hCf59D8Y4L3wt9lO7SzKeFFDHMd/+uH6vlJVZN9F1sTzbk4VueGk1GqlqgtYDtHNM89GzMJ0xRg5pYU6hmJng1Vv6+uhGcg4gEsq2np7EqCjvKHFDqm3Ka8GQm6HlQ5WINcFzeSZOdkiZ3RrA56wxhyyrwbLXw1DLpgNJpE5vyuVTR3nzxkitoP7YhgmlUEs7mI2QujyI7SazLk+hgu11p7FE+lDl1eTROTeUjoAKJtsda9niRKkX9cX7rGBjyTGrr54AxY1pY67ZGx2ro9TDVDdRBrxd1iaA+WAH5/D/v7gkCu0FmdfisRqNUw7f2N8A0FVzmkG8c4F7KyBpixOR9TXVaNYLNeR6WJDGEemjWhELWPcoLEn16Y9NoBpZP1SzXKTCOCoDQvkbP0qunNHGrNtJWojsOHyp8ROYiZoXyhwcYdf6Pj1lnXejg5iLCIQm6vnkpuOJt0gaWgmV1YH7JpsoOr2AA1WzLolTIGg9515QAAAAAAAAAB89EUjeXp30H0Rtt0a639O7G2MeQyEHRWiHFEve3FX4c31dI3K+QBLUPL65U6D17+0dci5Ict025V9oYf6tY6r1u0qZ1aOuuLyR9e/ovd0FSdkRc87MCRAYfXGlLCvQmZC15nRqygT6DSW/tzesyi8NonBSlR3CBEV/JrmO8DyMYFp3IBSjAgloCxmFbQhm98kLv/TpUfGHYPmxAp9y2aNuRFKnK1XvqUZYt4BA+UeddARmnP/cp0Md40j84qpRzlyb6xmchmDjTrpV5xCzfzPpI5EnbBkDJ02SLZq8Ul7ogywEn2huT5d9lkdkegANvIOTR9bIzNeqmqT6tIZwIJaAsZhW0PzOnp+f2YEJIVKlpcV4xlgYAQo4n3Xg5LRxejoTm/AVviMHL4NiLuu+fq5KUSkmjvyr2oUeuuSgdBLen/SyxgTkr1oUaIVXmQTqN4cJyDGog2CVfr0h1eMeLi7hVRajeCC/l+1yiffXxcl4A5ieNnJvzRjVvH7wNUvEm3EzlAz8deD9nhJVqnUmbBOD5vGoUNazKUBhFjEH5TIcjcC7qfqt3ATqBPaDRbLtEHfOzMKsjy3wSSk/oE4zgzigs5sL05jIW2xMOC6z1sBXHU+vuFThadOKYJ+anLLoZGbwGWDvmkF8nA8J1nbaJPhQ33dUf+YI3hSbEfpLVJ3d4I8ae1b/of4+cTC7LzhFzu7AykzHObo/2JdCDWAYdUbDQglDIRB42yNchZdNC5NvQoD8XOf+Jk5YvPJS5uEwFwxmIUP5mx8YrohUe2Eh0HZNHG4m6JRmQaYTUdaWZdqwVN3jXUHHX0x2ayiD0vcvzrC6W4VNmPhmiVlUbqNIs/aiy8H0tYMDWjb6ay393Q7GHF8A29tQv11909tMkGH+TGtM4GQbnemVMYjSgoIJZ8B/PVtYEYAxRgAEHAMY+QzMQrKIkWGzr3BsH9K15QFFL0vdTv6JhZ7NrQ1xJ6G7KWmyjjb5QMAHVYiKO8aB6O4egnOlOtJb2cKCGO6szVE+hief0gdD0gwzgapxZLIibC7ZrnNh503am9Qh2xj+bJ9umawmiQQ45DGkd9pmb0BGLVQ/qdCOAZotTjpfEZN0v3Fc0ZXGsenr+5ae/l2LghFDjAvMCq6eC6xYZe790f3LQnIqpUDqIwwygZ/GT5M6s4/jLtEgla2NM5SmMHyaiIbP7s1/vS05eXr/IC1qNwA5sVqMwx7240tqAv6Hn3XJbGB2p5xHL/bLJoKpFA+mLnIPADMGjyk74AzLfWLVSy5S1WbZbpDVnM0oUzQrtWNV80529x4hOAHof0DoU5bVcmTrbbUQS0usMSlfru4Aj2g48LupcXseUWog/XArr0uhkI6NcvwwAiThQ6Utmthg8apPhC7LT1nmH9ZPmdmuvMLr2DP/RtUYu6RxOsZK2P5EdG8dOoGUcXKV0EXE+qOIm3ndlBKJ08vwXOSrKao/PdlBx5ISOtAviwdaxgY1Hj0WecfgTwGjB3+DxAUfua4WJUZ8cBqtaxqvDMAtogxDnJeQk5bnpiCJt0a0mrZniAMNyHiVuUBnAkrII9DkV+oI0bs6U3s/wuFUIUOCQuDUdcz5RYO3ihGa6Fom14D4oTkF2hE1qXXwApkfpNoqNSIiRSSGyBEZfteUxjzQXLmP//KUED85jaSiRPhDahnEMj1XI64z4O+RkUDfsUn2kTS/F6pK3G1HViX/erLGOHov/4JIziRI3Mqr1OarmINri88nwllhfn9hpNaSvEBMOgRW+5Wv5fcIpfa0qldOhL0E7gajlcROf98nN1d7oEu7o3d/ZhyMAxA4nBqSH+m4f+xfhYJiiG2TKmP7hLaCfvFNZPR5v2ok/luk3YPdXPNT7jRCsWtjC4sidTIYkW4A+qZmX4HLawroRQDUx6+xMnKVqY/J8DiFrAsXc+Dt7BUKoDs0D7+QK+2tGP3ZP2CyJGMaB543Csnjhd+2q8LjoGJQaM5A1zbpA3PUIkqorgOAdD0gJB/x52BWNXAnvSYQKn3rJ1keaObdz7H6BR5pXKVrp+0AG4i253DrP6OSrtFvd79xoEeA4txjRkVgMqJFuiMYS8n0g3bxlFKsZJHeJlGZ/M2+6AhFZ4RlNzvvZedtm5YvIhfixqkDIyF3xf/nG8OK12qK95t8v9eDXlReFLrx9tZseckLNDm0ohWcIpVZhs6hHPdx49W2tROYvUiJoeRD93kGvDGGREIZVXRj3s1dfiGBG7YD/OD46QBP+ZdhJm3lY7kMYssgDUHt54A3RU9XA4czc0E4r95Ud0e3OApK8PfmI5cOIvDDPx4K+0uESOBY5hpcjD1zAf8s7xS+i5XkkbMv3dhO62PqBSYo6sAQ1v/HgcDGk1Fy4bzCetxJAT9tQsSxKYbWKSQtyZisK7g8TC5BTGAe7Skn40ScHMO96jrZPmtMNbMGjDssImOb1hemXfGAmIt1CAjPTSh3dSHNdObnYtNKSyMaVxvzpYQ5wbzlEcq2p8f0d2oXr9VhotftPIOWfucvnx/BoTmf2L9g3Obr+Pf+biqI+q9dW6W0q69KhR9s+gZfgq+6Uav9ER2RtHx1f0N4XGEq9pDmqgQu2vrWVYEbWiOeWvNRZp6AEz9KCcg7mC5sPKcXz0ebtjqZllncNeu8ul/nzWXQ0xA2bWXMkNXiVwuMksxUMJbV0lDEVpTFqmFuOCEr8lydOw9RzCH4ALk4Tktnri3mNO8DGT3ICVIY+9J8/EMlzkEyTZbkc5noW65wLHcRjZA0TNaUoNERxi6pmGdgYDa1NjvDmqH7N18JnwEC+xYLsdfFlsBdDmDwR/yjqnxbEztiQJW4zspuwZN1IA5qoD1bZB2yHCHijMy8NOqGC1NWwxkwXTQkb44uDWK26StLPnPy6zDpGaCZBA9YX2xhotH2qNJay6SY6pOGLtgdwk3vjp7WK0dZnhBM6JI6tNoUv+tU9TgwFCxUWdPb5Xt4V9FwqDCLra7zYsblKU58/T7/nYhRZa5CcTnz44swO7VE+Q4ksmGdvhMm5X4aC/6jYK4ndrEPVzYr2ViIR6HSiXPfmZor1JoTafA6FM43y1sOPsT7xmsQjNwAkofaRBZViNQrV6YpuUU3Jx+O4MgzwvBU4oUNmwI/sV8ila4UhabEPkh20Lf4AyvUcqtXGcS3BNxGKZrBE/HW0VzAXpFfgOaR0pSR2fYLuith0kw+aQBwwPZCCj7jWb+i9hrwMoQM4wWYae6U8M/tceP7sTwtQZMZkoNdHfJ8dJY63KM8KsYZNpYVZBir/oCDft28BSAJqolkhruzwh3MrcXzrNM7xfsxy6A+kttHn/nAGXLfIUe5srpcDUes18nZ6aNHMkAY/18t4rG0MTxw0vIf65Ve2UmLlx/KklRGxE2sGiTAQNa3M2EcyYXPS9MICShu4dFFoD1l/4kV6fp+1HqK2tZHud46oCXfwpFXADITVD+SFONWhctcYk9+ARMRaLzCa0Z4XQoggDgmBA7UEHXeyu8H1L5JuY+4Wr8KXIfY3qZfOGH1RXumNqxt3WTFXp8aftWAZDm4jQ3DL09PwuagUOHOdD+WpNEU8tyTn9PaWN1SxVlGuqdDXgcSw3t/819QW6QLFuMJBAlXPThJbN73YxAaO6iOtfzGbAXWr3939Vg8DQvYbZ3r0IzI7YwAnRzdJBXRcSMtOQjbRDLghZFHz4V36uqYzEC6NNiFHb/MoxguppHp8CHmE371W1CtZOMuXswibgOGCUtrJ4qEQsjI3dqFD1Im62xkDMrpccAfH+kZ9awZVqPvOV//eNJjKcbCKzWlObc4B4yYfNdn2RvnQP9UFYGRnQBrGmJGDBQMM/Fdt/VMl/HHjlrmefoVd1zxFG2tLusvq4UilwPuLEzcktT03hJnm1tRg/IiKYj+hvxwR1KNS1tWh9lhwe3XNnfoftmmr4brsjnzG9sEN5h/DgDSMmlx4BQDuv6Gp+P34867bBeh4FgMTkIQStoqaa3CzfHeB4LVIqdmCEUfEw/EW2yBLpjMroKff3aMgBbb6OAhd35ZNq7hwyMDbMS8Gxn9vesQ0CfEL3e3JTTJ0zDEWodtb2WU1CNCP+8MBWNzBbcY5qeXRhsJCXj0L5CyZp7To6UHnN9naOjfRwEOBCXwjtpU/FU2BsSRj2tYOWpbzY6b94Jul5nS8m59JpNJpH8ZiDIRGQVvSsdExVN/vomJhJgh3rDXHZimJ+CoU1DQRgEAx9EWrS8tWpDhdCt1M2d0+dRXaChHUJdqGCu4QRhzAbSdqD28JFweHeGtTWLS71oxlp3pZUtY9OmMMwHE2jXHxuL8DEjyjFqEVYGTaiDWUMBi4B3vvlob/a///3rqV0oQRmLWFpE9LrLCejTs+wDK1J+GH23BwtlIB+Po77FCYbCCtJcI4XAE6T7hRpWeOVwF6klTpbKI2B6INHPNliQrhCiXhr6iDBgnyL/E2tA8J5yZo9mP0WywF6nr1Z+Iw/AABBLjFWpSXMb76fRXIXDIxC+0ePdCx9GxEekRCRFTwqBNv1qD4uYiiTU/qY0SahvnD0cx6cbxGAfFnsegwHfF9vDbLdSonM7rr9gkD5BQZm8khvzvMdsp55IDZ31ro6NSzayEHy0Z00Iv4GUFvqP6hKOi7/ZyzAO6rGn5LZdOID3WAcuu4wLPUXDzohB9lAPxD6NPgGuu6/59WUsx3GyhbsNH0n4lmzuh9fTM/Z85c1iNnDspn6y+jcxCq8h07RIAVrf53myM+qcpYCzUJFN70jl06kORnWUhwNwJZflBzW/I+IGr2u3ljRvmlc+M+LOCAEwCavj681nZu+4n4owoXMM0M3YPc5y1G6T10+n/c7n0idsus21qvrEYpUryL6jBhfeF2+eBKqddYvUkV7c/yj6NKj4KOEVaK6UbDJcea8qvYGwlGjh90kuBTFGDkxLKyIW2i+KPmw6ExwYfRl5lSVhkMhrdVQXQwxjfJGrUYD+cjLzW+X6FmR07WW5yVEsJy1NOJk6iBQPlzO6AIwle8KXBimHxSRFH1Y2Ak1TIo0GmbXKbZIDJ+X3kgAAAAAYgAr82ezEgZoLu406SxgAAMWv+MQXe0p82c3uxgoieAAAAAAAAACE1DUAk0CBIuXdZIb/X3t9vZ7iMnD519qAfUAYpEL9h63r31EQBOIUw3SwKUYEERTWt8jclZrLmx5n2lNvQuweEeHgjoxHU1ecIkqlojMoTWiGaq0EfN1GWRGX7LYZyaxvdYKdmQb04miL+p+tGnNl+1JLD1jlyc6Mb64tOYdmhKSFgdl/p+sRQsYNJj+X7YMQ++JHaDQAD2BLqfyKyDeB/C3X9UQqSy64aqZ7wfvl/K/9IEHyFu9og3vSwrtiSukQJ7SrRwtb3nvKa0YRb9xgcj+A3mv778uVhHUkaySoH6xFJ3tcc+RWDKE688qdtgR0r3QPx450zkVR8KV6WYMlPofb+xb4CImdZmhk2ICioRyj6m90DxJPQNrp2Yx/iKjvDSaL5PZFdqAJW5dtJAs7O7b3Coyq7PxVKYwpHYnG/rR51tvJcG+4zneWJ/T6FkkIF4gLbQc8XRdbvq+UASPuPUkJxRWVeuaelXJ/G04hiApva383WMNXXjzs10F1SPu5Mi++tibOtnhmv19w1K+k0n7gyOeCkKAHWOnfNT6480cXz19+ch9vF6gzmsy8pz1+Jxb2HTjvIh5QHOR4HNlmCJgB0IBjY/zhNR5jyzjOancKoWuSEOtTFfEXwLPeiXAwim7REDst06vSUHOarbunL6ItcHJ8dX+PRlOgsgpNWfNNwfgK5D+gjKSLGnwhIX2PwWx2Y1DzFdk2g0ihJRUdyXFanH4q4BmoP/0q4N+Rex/2cZYIXvM7fX8TfDasiF6F0lUK4VLQBGFqv6Y3pL1pco5x7HrxfF1ve+pUr3z+1du6PMeWJuIkQin4oVUICcF4LAKuSbqu+rt4oRBeB5krl6VumkYMwqAoe1rUoI8cuF9Bl5xrK5uQPcqpI+Th9UgWTah5ABqg2l1f0EjCjCqrxTT8f9RZhGk6Y74AZjqcZ/+IBGkd7lJqUSpXdLD1gSlWxl9MiMKCIA3xYmqpGG81b924LiYy54/y2T9TNpfx4bwEEV8ZgRoQxxvaNTL/hybXoh6F9YjVSALuWw9JP4/gdjcDiQmENGnl/DhAbMeScHd9Rs83ldlakyJbHjimmlTkAeCdcNROyH5pw3Qx5SxkAg1BCZ77rbdZkAZ+8UnDI6NfI/XmVd+rk6FJ7jDnklRm3C4ybM3vCPvYOqaecXBcU+duGhya1g0d1qPRAtRWUFDd+f/qEh+0O+E8jt9Do3Bv3ArSHHRkuMmPXFSDo51gh2z7Xz+2jM5vIOqvpi+klonqffozB7HeEJAWlvSAqJuZMKC+0MvG2FCI79QyEkXyHgrDBfFQKLDn1djTy3l7h6v6pWsB2EBibrMl9pziAhvFkVfdlvS4vZa4aiP1dbTLlP7uIqgnCd1DV+Qv44lf0OFCfex+6VeIEFHrbVZvsYodk17f4LjDRRc2OZI4uALqEqia/IC/CdfAapDrutJNLosnMzcuAXRLCuEmobdqKOKYutvWaiucp7mCewUORMvueHojTSBEEwookmeZHUkuMCTs28WJNftMAia6WQX4XqLXW2GPEgvbQOOJ3rkdNrmPeg6btyeVtfiCRRbPmGJLDHLyh2rrGU5NRp2z9oZsD4dRaq2T+N/WtamaVVsMW6KOF1XgrxaryUK3BlAbzclGbhmsWTzaBZX8xYXNvvRjgbnVrr5ice1UOHtnWNZEqpLH5CmVKQUbTlXQmzZf1c1vxdIjq6IzUZv4BAWtun/ESNC2sxFb0iabGaGmsiZZTb6/sIfyT5C7cFhWnwtGhL8JWlNZq+N990qp6pVDd00lhmg60gzbTnsGU0CuOiTQJI2aKJyRk+wrEH2cq5UvuJypMSIe+ZNOZlMCNUR2uHjfFPUNBX0gkO7aXl6LhpvhRd/0wl66SdE66h8UxLBD+BPvG7ee32Kk46qpM2LlL5myage/PVRsKSCK1b202fsqzctxxI0FqHzcGvGbP3gCytPBK/ezsfyKrXW8u4ISiKxWS2yNNmqtuNYRK33OQ3ga9BLpCcqIMwpr8vv9QU4bB3DbleRAsXWdhG7GLlXmR8ry6idFhMN2VVG+WcpWChR8M/6tbeZV+lLcRaFx2MDYMSvirCOWhsecTq5lJ+xzhErACZY0Ln0rwpMe0lD23pWMKe1QIWwa1PqQHjgcaT+1kRNPDmyG7IxqLZhY2hdH9/xdW82gqpN4oHJlWQItBNRokeGchTmrsmL+2cXfOtEkxdODiGTs28TFhAgYas6kgWkhFaKj6r22g2yngFhgBMJdZNmby+gNg2suG4d5/fuuNCFILsUteSvCwRFAIMKsbarN7MU3jqNEZD67hsxXtdLD+0PxKGBO9t8T4A/taHt+jR6VyazYVML4Kr6cKCEwZJ0cWIwocljkZs0WIzRoD261CexoL7Qy8bXJjpuDvkegIiQIkORk0+i/K1A1JBBkuDlBskX/87AWLGJ/E2jcoU1Nw/AlT2yl+Yitiwu0EnP0Fnebhvb2g/tC3RRZfjPDcnzKfsDOTr3ypZi1vxcDCaVqMLvYmtDOBBLP/KMjrZgTincRFkwSE6w3kMe6dS0bF8AgWtslcBj7Cb1+faFOBWEhPcHVNCL5HNbFWb6wCS5Cu33LLAXsmFfjlZRX8hgHNApnmopXu5qidmE+8G47uQ8o7tXN6EdortYA8l9Bedr75U3EijGIVLSxAR2N+Lij6wmZCKf/ZYoACASWv3D/URz2d7bjRzr9SRRDh6ZqrUoOrZptRARniTlEisodpetTxeT6PY2t2pSd3ogjdiAvKfSWtwOlngYMO/PDNdzhvK/uBEgG700GAH5ToaWn/6cOBPjNrXNkfieW6RF/r1xhNxe4e84gGt822gXx//0SLce2kdmkL3RiLFjZ+cEz1w270fVYP8z8//fCBWanivBgDgyKaze8LF+TWoJAgsCL0ql7J7R2fP5VIabi44v3ZDoIcHNJAHo1fKVWImliiPO7HpJtvMANtfsPz/ddk3XkO2mvs4hRgyx7+Nq0WzOP/qzqNnm8ut2TC2Dt1Hlm+1vYoY4jUhwwaHNDHW/e/OG8OzVs68ZaPje6qTrzP/rUY0ISJ9z1kxddvAMVqich3Wou9RDUsbz8PlhJk+AoPx4TMgo0O82FldGALCIYva6o1W8ERoxZ7rSPTUEj1IG7h+qmIg0vIOw6dTcrskEp5Sav3L4owXPZ/bTHbjkd4NL84q1FwnlhcVe1UMRchHmjzR7cnpc1loIVB1gSfiwK8RtnYbL5+AkUleT2uDgOr58UpNFkyR/RyINafdgICuY9y7x6MEnwPmhPyfiZ1GcVLGNf07HspB5fXmXYgE8U8d8FqlnvBArlVZzDI6TM4LkqW0sk4HTJgm5IRmhBFlyX/Dzs25L271KdB2TRwt7z+/SiwC5c9C2z5tLx4Ir9B8tgL6whf10JGLEZzhW7OS8ItnZZBiNKakA6bEQrX5Fro1QrxhxAiaBDLGXrfQ/vREWj7ay5TaJOjW2wR2VvnIqqRWzyrdWIvcnCc1KQhGiqHurtYLXdEGkvDo/hEBDQat+cmQLHOeRdFInE5NBP/csz7ElaYvB9sKgOKhF2Ds6+jwEzsFi4qLpEaAuMj5IXDxwZ3cFzYoMzd95p/5DkajSqbTlNOGBHhn1Xrmta5aZKp6/HhGPMkYj/5mAJxY1EwRRQwRihzZ3Eiikro8tHYnyFXlpAX6Ul48Dm9+EfJweGzCOjsbPM3su3GqIGvBfytdIzwKmebPM22qAx7zXjLKWFbY1Yz9SxGObmIJmU3TLbklQk5MCLU5BIo7EZ4gl3nyD6tW5ty1mOA+AgOndsUlYLfRIdrmWix7P9egOtmptwf2uxvt/xE9J3UixLUWS2iwwVtm2p+DrVYd5qYagez/oZlBE7FD763AwkIadtntrOqJNnjETv44z7hw/f4YEd0APLQI7Jq4sfhm08OkM4EEtAWMwraEM3ro3JqjYjdvLzkomY335nZBoG3uwqtgStLeSfsykRKTNFRu4FjccgIseESKlnvt9uK7TDlk0Am3tOJ2lsdc9cfMXOSF1p9rrQKWSjkWzNOPEhHmVBE/JmS3O/PaOJtXU1gVNDuFo/Mc41us4XPA0pQ7a7GX3ChawcO1jkuqACwliUPqpliGxTTIuGuXFruGdj/z4GiYhgFMT9XkrGBOXpYhQDidtDw4CjSAtB2OoElmjl/ADtl7DnSYWqtPa5hSR/kpYXkvwM1VdaOwysvYyZn5PlWFmSISZeNpksollJSIO9kZ8DKTMdApbPp1IGrKWAji9fXoY7SjhScrLHDIodOEs++rvqrOBHHAySwXsEGyxL8XPP6IqHeUPQqwGvv3P02ya4nymzeFTJ1BxbNXJeGQL8wpI9V8CHiNAVBZi8uBvEOvs85jNyeT7xKNITvzbiJdd13TM5Yp9y0DQ8sszE+bRimc6A7HX9NTMsmbVMON/9C4cZo0jVrO7oQkwjI1q7Egx3DRAiumgo6se8/L16uTBM4Be5tUTgUhic3qBadrZzKBqiD2EuffvkAmmcw+34zz0YCU40ThqUKUyPGvzleXWnyH1ateM5kLqYtPdlogmhNsSw5shtqtUnw78s8HKHpLtjtuzM0bn0x6G92GZYRnLM2Czt6sB/3yBH97Icu6KFIRLP1TzzoVFl95yaqpSgqYVHOVrJmxAtvbZd3NZl94p0uIcNtkdJcjdwFEkwbues/+ZN8E3G6d+mkkOzeRInbPKusbwZUphqk5EK/N5Bc7PgO6mZmO1p+8fVrjI7D/WEo3WyWqr/UKPJ96hOAXtCJsE+D3FygaOIxIentHcV31oXguVrhdhrj9DwTa/UaiKijtaqabQtz56mWtd2LLfHSI2NjrAAkE0e0o08Yd82Ewqh3Kt4wkmGXkmau9Jgqgv0ildec0zq5qR3vnyd/eyfdfa62rmor4rg5/YIS53FB9QUoiGWE/w7RtaC6kSK+7uVYSGLuMahL643kqAa3VBMng1SwRDxslWY9VpcNovZZJZEUn6fTxwZSGym7YX8vpPzDUpC8KSXiiLoIzRRL0RHCo4y+vKrXheKdAVVJnyoR354MsOXUCMc55vc6pXEC/LbJhrQ0rGm76cHm2Jg1fx4cwTtAF9rjYXfosaPSQinHWQosWOtV8QNUsO1hGLJOd/bP2vfAgcs2PnW6C0T8tDGEKLNVq/7e0ZNbxSFTF1XanAoqS/j5mQQOmrRelgfFQ/PjVrA0NtOGncaPeIP2YwDU+AnYaxcGmxcEtSDP1khbPz5egMFcrvZmvvXYWhyptKLE4JC82eiKk9FiYa/kgm1mSUgiHo8PcOF8DznTFgqhMwekkaNS35h5vGkPToSMUKqYZit0be0oEwaJeOXRQt3tOqkZB1PIYPCNX76KzX/X46bOBS6thyTpRW8MijjA8CDFUVPh5lKDeRsNlGnvWkurlDJOTT9g6S3Qe2Y0GS0wWvwD9NZ9Bnk1afeYlsiTXUCUN2/KErthHN9lWIk+rkv6vXZ6HaOrefyDj7nabE5HWT700v/2S5CJr1c2GJM83jGpviRDMc8InAFtFT6PnCRh4pEtwxPz52uJ3z8T0r7xE6OiY2H2N/3Ttm4FBvxCYLwt9y7vujQqEHdqwHUJV6D48H5VMXIi/8AL7IvdrkuH2SRbuMQL1sg9N7ix91vufP+GVbFRUvP6gyrpE+jR2iet7SNBgukNg3MgqK3R/IpDG64oa8j32EHd35+XJyW/7j23XousMn8rBVLHw4fiXP4fydUiUTo9XUMMYkHZJDHmNjlvla9JbPysQPlc2O6DOdENZ6WNM8jmFfrFuc5C9Mv+wqyBDwk5XF4mOKTeV3kBgCS/XNa1y0yU1a5jq4vRXi+z22hsEXI11v7+V5lLKV0LdoyhwKIeodbuvLt+Z6MaQm47pLvVXHR01XhyV99UFtHzgDmbCS4W2w9C0hFEyGXAJ2Nh2VF7aRZeVnK1+L0BToQEPTcKmS8tdawoc63+5ZCVx80Z+hPXU6SXlp7GyepZwjQN6o/BnpFqkaJtlbKE0C9VBmj6CP59B2XbsFCElYKsUXhi7DhOYccL6zW6SphCOB4mLx3EAeAyAV/16AAXP2GrzTTzWT7Qm6cy4rYVsn2hN05lxWwrZPtCZpmK9NbAlABNVj2L0a0/AAAAAAAAAhVduYC/67Ve6xCi7xJpmrYFbBcF9l5BplyR9QrIPjoSe5DjlNGqQulF+5ARjW+TLrinU1OwZzNBvsjTGaHqXOQzEtHan3LoocV8+X/CdxyGtLYlqr+3MGDJRc/btMbtk8KxKaXUfv7xRRMSyFktmQfrDvXu4lnvXgi89/jjFaVbhcBsIF0Xq5JhKClrEiTC9yBnAceegbtXiBGHsjxABfXzPC+hiFvugSk/2gPJs1hv3rHQa7IDCY9MVuDsAse++hPnQu2MK+EPxLIK78yHuFcGnB/OhtEkIuja1/B8eJYQ77FPYHMYSWO2i13RKvKOTAJSk/GT+un90mQv3F96ebOwsFfSvuETdX3KIASdkhJf81bTD4zwzGPILwygIXcXsV5mG5wX2AkTrNxDBy+cpFQFp322uiC1s+ufpYfHixZ452HDbMnrEVMDVBYGnInOmdx5LQGWb6jx8t3jqTzdvKU8arbhJ1h8e+SKWVDoVbf6cpBedLsjQ5h3+XmQhBfU21if8jMztMBliNqgQ022yum0riiQVuNLWxwtxM75rmKAQlaks4bB0X3k2RGFiX0po0oKrMPr5ksNOvbr3Ido6ZXlkgAKUb+cOMRs29V6EJgY3vctZlJJ+lSEzqqE9rYZXFUU94SYxoEPnumjF+7qMSrga0oKWbHlo7Di1XXANS78zan8ViegznboVZRGBEOgP0e2bVtCJMFEe589wRAEU7wjSK6J0S+HbByvGwkDPJ1KcjChM7ADxcIjxvdWGAkOiHOqvee3pMNqh4iKYjP1LEZDVPuWLorRcTz4vFF2O2YczMXkatv12on6+G3LXMmGaLKtRZLaLIIZC3VboR5YRD7HuyGKpipWN3/vScjSSXKmcCGJBtGKmmMkVgWzT8tRiHrlnVJuw3+wei08Xlo9IzuR7xxAFVlhN0hDlzBfZwgql2MArvr+30AqItOZsEI81s+cQzlGBJWBujjIwE33RPcuIv1+gaugZO126EkjthmkyNHo1jAkWhgkHQCYBLPVLGzwZHYTHWO2qPc8koNp9HlXbGRb0pxweywmYudnuIycPnX2oU7It/jRqCVap9YRy+pWGaJ86ssV/8jtWKtqjG7T8SEsOmbhbOp22ZkxAhgwLpnBfzsS+WH2RYA4WqAGS3O0lx42Y65NPymyh9QHuY3bA0UOrbrqmTvImvot/tM3UJt9cewCRZbOu0D/CSolCOwToPt+XzmdePE12xoe6FChhHG94VjnSpP92RVXR37+fzQ+9up0/TYMP65VjJxLLf55MPVNmwH+K9i9SrRSz/a3Jlh/clw3wFJHpTgDX0WYPa84ASsmQ4dGacjxGeMNZeZKc6g1zQsmP2w5Q8nVYDcJ3h8jtkTgFXHDHX0QiZn77m/Fbnm7xWg5ySSw89vK7V2qDrXiBpbYBe+bpVdaHQHPSYx3D6Rrj5XEmlpnEmrKV8aPQgPifvXytptBL2+3sz3rp3FH0UUbFThuH12sIZpyoZR00D3TmkUvfN0OyWgWHbS4UagAgjCYB/bBsdMHeuJz0BYzJlJSgqXC/9PJw8FfQ1UdDnsZnmoEcP+8E18QPpDGrdljkNNwCkQbOd3UHqkohZ+SG4t5v387pbitj8KOCWrWaWny2g06hLIWNhNoyjTtjjfvQ70gGegPAsKabsY5bFsED7XFCR06rSREqWfaLGTNPoXP748jO6FmTkCOzhSP3JwdP5GObWXJOYrPU+m/E23RBbcPNLtKiwtljpSFxOYl03p5s/2W/mUcjDHr5RIMP8qLofHzbS92wcvmnj1V7XP29ZPAKE+0eDhYAjGnhn8nQiQCt2aXO8tCl1zy12HlbFCboA52OWAA3TcS43tu42jD+8rtuHyvtkj/HE3CKAVNlWYeYySDiRWYDGEPZZdgSr40sLpyLK6Du79WUi91F3nwZWjzM2/+5wHVcm2SN82g2hMFa1pJ/Lr6/5ItP9A6ztfwUnJlTx/crObR4cZEo8VnrLbiVTPd+QncgGelG2UIojDV+1lbTmu29YowvzI0SeAOqTo6LZ8rm04DK1h/3T8WoAxayg+OV6gfGXO4MKZoXKZk968Cg9LmYJo8oVbQwlsBTuQMnP83oIfXw4U+nhwK3r7Rw8HYNrlG+gEGICSEIigOoC9FWQdHRHR6EPUr6iBk9hCM49W5o2bfTD2jQ1I77IbVlYtf6wX5Pg9/ytngnYUwCbdnJpeE059PTLxFWkrAFqJxb8qSIAGqLtQMHEd7/kRDmqCuuoT0Aw2JmoXxlSsymgoubvs0Q/E4eSYQNZGKf8joSgwdOI76tFRwZdfYebFUhUfkWr9DQApAmi1Bc4Iu5PlUikN2pO2+4aLlW+ZfIyDJlg0++7JqkQOy4/5SlujbiBW755RIVkBtWokY87+84KmEjlxX9vq9hvYjpCavJGWxxI8ucrMAdSMLEwyT5L8fbzgqF7xwU3t+ow/1chmsApQXCscXjCijYH71pqFkaLIx6aNyn/jniJSJYrUOpaafGAejWb1jlYk+OR97Kz29IVwf5N2cPjV8kE0gKdqxC2t+aycftjTFGNN3gUGwFxfoW1rVmB8JIa08M+TLablGSTPdDOXV1O1RhkxVarDVE5H4ZKJK1145IliUjeebvMctErsUdAdLw4yTSC2DRnY4yVGFdTtbUbfGSXoaClZHeRdQjphagMBJf8OZbHft8GxEzJ4Wtaap/ap3LBFnQir8rqpP4VFE3gv9dDHtHx2Vi5Tak6hj1hoJuS6c4wLjtMurGYpVazim8qBoECFc1ncTDH7lqJ6IJtWEpsVXOkvfDV6Yd6xxgdF6+T2Y7YzSr2FNxuiDiz+2tJTs1+JlTHmsXZZYlJzFHsUCZvQyAVE155XHdUtFhVWd1BFAH/4jKnZv0ID8FZJkW0b7/l0FNHw2S/bjH+eSQuaKSPNPOAGUZfodUCt6fllYsH1PHUJtxOoGysjC8F/fOjZjMvQOkw47U7GzDDJroInvwU4m8wovhH0wYqBz1g6NgHHmyApYwGT6vfGtNNU8CwS1XaRUB2i+ru6UWJ6M5l587UGZ+JNPNs3Vvs1L8KCFumjl5f/BN+E5jtD4oBNFVj+IMxcu4rtSmCHlvcmvb+5lHrV6LoxTRbs6YBVD6cULXc3i0iCUrlJ/NKQf/y8H2iA7fqLKwts3ddmnxcLnC3DLjhGYzIY9F4eRs0kfuZMed17ck1N2fGsl5XQFFBL/cAiL8W9jJDCWOFWlv+NxF/FOIe7Fjeb8TJxNghHBEiXBpXV9xvLe45DbOPk6Dw8c2CdUS3ZDd/eUT9c6ZBOo/E5c8mOV/x4DH3cwPPt4OtkPbYKSgzoS8xlIoXkjL0lkWUzh0JqlQc0FssTsPcIKW24webSLodgQrbZ1zBh0g3fdZoxsQjI9vHiJJtOol4fvNLY9QaQUKor0+oqPco45ZdADpo78lRtK4QIIvbt3bOfwD8H7OYMXlB8qh9+77/GHiR0pvMJQNdN0m7jqNJ4t6hqpcnXvsRNKmvhufJjnoKxc70aZm3L33Y0dAwBiO6DrN5cdN7nOQEET+WanAJj/RCsN4Lmktgl7brWYy5noA8qHGEbTQ840wdHcsXsOX7GHLNvqdBMSc/iCUZBnW+lsvHRiW/njJFbQsy4T2FehBH64T+q5y1z4LKo/IxBLgdyhMNPfZsJ2sSrTWdtg3/RMTJKn8xOskqdTSYHe/8rL5AE4PY8Qwd5v6K/wEwqxOJRtQAXIz7XwRGM2VzfSs14u6xNAfLAD8/h/39wSBabGGjYu6b8/wV0XoS4QUJvcj2d7mRonU9P/QllAzcu1/tOhT7oDubxe8aAZ3W8Ezwch69eQE2GQjgbD3tinKqsOUJElGJLLOmZtcDYo4eJYxwlWQai/yam4N0W1pMnn9DPt9FEOtnyrZSpN/DCALf4esujkQArDcki+kztTFWYlfoAWt+s7h+nEseXWn+Db4R9eJvd5vKAAEIYcvNt4fjHEsSfSOkMsAFTju12oqlFBX6mfF4uyQ9l6qXDgJIr7dJ0R/kRaMw6PJq2iO8hk+W1f7NDZtuXssfYHdrtFnYcoXihVdktgLT9bVKuWPByR/fnofvk8ZkHn9VQFJ6sjZcHbtWJWfv+fbw9rQV//DbnCVfqi+xlXYPw+SdW+ONCA439QLSDSe09UUrC8HxRRZBSQNG+xlDIQpekcFgR3AVBRV5SF8kPwGrTxRw5gWx5zocRw833AY5JklkauorcM9a/1MP2ti+JXjbu0JtQ3FBZUYZVJIKS0+K0N0U8wZ+R30JGUYOiroJSICsrInWu7jYLCLisgOnEDjeheh4371SNN30Ho5QBK0sXIJSHyr2BooC4r8CClOqhpWGJ6Kt0vHEcnyC7LiqQ0wHSm6jDAVOR3lGmjbBlduuKAMU5hGmTR0I4023TkXu74xhKegstCNUrUYiVtfil5nB7ZWApprUVfcJdPeEkWQiNEY5/6Ce9tZw3rRS68xVTAtX4X6vIZ9Z2+IMwCuXwePVA89wXNCecn14rxeWHQIfjTlt3O/mJJEDUzfFNSaRBqL4jw9EM0jNwdJOpERQTJKdhj0qhEIlNUVf80ZY0D9tEfkZ6MKMl7i6NCAu3wU2Z1oDrdM1Sfg2z/7JBeE1UrkYQcg4vTYuUSerR0zeXftnZidmcNbJXM1SJJroNaWw1k3epeMbGyVK+BBrcaExj0cVyD2l8le9jdoRuvljfVe2FNdhkdMba9nf7vEh9oinTMNWgxX4c3+Jxfhee0mnWKx+5Hbz78VyWOyUqlLEb19wPT41mKrQplGNNBKFvN6NsLsjjjMlRSu7kYPR/euoad6oqm+4Y6UhHoszXXzPHU3x428Unoz1onFKri9tNvj6XZNHgqhMs6F8L3cYnzY2WuuMPjf5jXtYZo0OvUY3fFxKj+bYHTJ/8Za+xIfXLnnbajGUxd8Ngp8aUns9RqOxwggAJFg6DXt3HBU9XOUKAnYyFbybPstuougtTL9kZLVym+2g5k9xp66TPg9OwgrS7K0gAn1SR5X4vuntGMVz8JHpc8l3/+XbFoCStXg0CKSas2AmEi8VHSebAynGqhk9lMYWP8LqIbfp+yix/vvGvpMfCju+H4duh6IqCDERFanZr+2z6T0gx7AHDfB4n8RUy4GZi3ShP1uvpCfKcMbEit4QboBJg+FUyA3RTtREhgpW13K012M+XJg8PkQFH/OW/ej6cvtY4DV/4nIY8/UMUqY0ThwEx8CGsoiZTrFqIJBNfYpwwkWc63WaALps5ThSK1E6eiHnBqZAwwiyVaLTQBPt092KjiVrnC/51tZokULhBQGhKZG+FhxvWCh1SWRQqOQG3MdpbKGz7pDbAhd6i5jI8NU7UocKR/OLx1oheD4VMJIVMuWVrN0Bb4g/hD2VMhI+ijzpvLcgtlYfdZM/5To8SO9dQknHxYXfVf8kk7YEesRkgEtgwq53YN2q/QCwHYwfi4GXANMo3KycUIPb3bg9AOgzXGPQTSZg0A6elchtgICyjXPvezCCQgm6msuJ7wYG4IXn2qlS2DCrndg3arfwIXqwK3Cw3W53NyFBajd0lnp9pIDzag6VlGidMZibLOml9tyN08ad7gAFca0BkQ2CHeMw6uKvZi0deVFtE3LNr78Wd4b/WbdOEBDthWsgatajdqStzj4SV1L0IBrbkdXWIpPwBsSTi3W5cd0IzBSQXdkhfTn7FFta8pjz1GTsUk/GqKhuInzQckGoT+WO33nqAK7q4kujdhkBfz7KBdUT6ksDSsm4TbeasXBS4I5IiysJ35BgNW+RYf0QmJTk+pdnBXGcCCuxEPw7kLojkYBbfHcmlxjQv2acVfGLDW6GBCl/Ux/6E8lsl0lspfzrT8rY05UsDpGTbGsDnrinhwMO6PvvILgnfTSY9oaHUzCMlrA0lFG3KrZ5V34PEmoseAqtj4PGyXNbuhkGCXHTbS5xFYl8iSrjeAuCs8Saix4Nh2Op022z1ZU++6Su00snFCD280DtHypMXwAL/5KYgS3TwLMUuj4TpLvt5zXxFHAiV/soEHuSjgEJBsdB2mCOqx52BcAGvl1vZXpL6MGokrVbQOEophbdCryAnnEFGsqRfZW7EJBN2PJOATOHc71AyWMOJWxImwqoB0xGo9LIR34aBwrXW914NddGj3lpla6z6AihH6C62y0VxDOC/8TEEXQXrqPdeoFxHTQ+wSn8yh+N+5BOpRpvXwXzjUxD3Rwwb2qNN5yUW2be6UeK/W8pXKn3DfV+5RzruubSCxkURKpc7ohtxy8NRKm2OTt3TcHOFu9SUamdDDsA+WjyJHX0CsJfpfGiFlLvccVzDYNgwlldCtzhOPBBCmJ9F5o30owFHJn2YYanWKjtEbf8SLMFsXSY7alAd1/wKJ5Wm3a0+wU/2Epyjg/xVvAppeGSLxg3U5GschqUE3Yk/nyhZ2UNcJioCyQF34OgSaE5B26GaVlRsYTSZPIYYDMirBS9PHdwh2AIBuMUh3tf78zEIBo5F5dahUafy3cf91pJivoII8x6IVWfbwqLpzAKJi9ixHk6AMBG90xSoybo3dZy+fHb0Nq8nhuwaT1IpzvIW4oIok+wtpmq8kvTht6yDHEPW4Y8JOjmcNRTka3C/H7okhBymmhQpB/v/ku21NCYfgeqok/QDuin9EdrjYcvSasGMF3bin/5CoMa4uCwjmslQzXLvpRFquF1AVsNbKnbcS5cn/6jzfJD72YWWoX3fwWwqMvqllepWBdMglhCjd7rbeFAyaUdpUWIjQ8/Kiz9igeh3s0NhnGz9edGrUtp7nUlvZ5oyrp4L6g0JFxnI4hEdLgMSB+eBX2EEl5zVVzHyray2jwSPMASGfS5fg6CyVFolAGX4HatA7IAMadqofR4/Cel5V/gidmlCYAraDePrjMFEFq7yuzcZi2W/ImwxyAfVMPeBq8jmIA05+V5akmX7b0q9Efpv9Em8zXaDbPkEfDYN46TMQHXiJeI6lJ4oJUkKuDO3Htv8rFesT3LI4PU0He3fBC7n21Qzb/H/swJ2B/pTp6+561CDA4fbMh1tksby53UAJTr2/DfKeoHDL7AAAA=="
+      }
+    }
+  },
+  "analysisUTCTimestamp": "2026-05-15T09:28:49.544Z"
+}

--- a/tmp/perf-20260515/psi-blog_structurer_la_croissance_pour_liberer_la_vente_exemple_surfe.json
+++ b/tmp/perf-20260515/psi-blog_structurer_la_croissance_pour_liberer_la_vente_exemple_surfe.json
@@ -1,0 +1,6387 @@
+{
+  "captchaResult": "CAPTCHA_NOT_NEEDED",
+  "kind": "pagespeedonline#result",
+  "id": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+  "loadingExperience": {
+    "initial_url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+  },
+  "lighthouseResult": {
+    "requestedUrl": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+    "finalUrl": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+    "mainDocumentUrl": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+    "finalDisplayedUrl": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+    "lighthouseVersion": "13.0.1",
+    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+    "fetchTime": "2026-05-15T09:29:24.811Z",
+    "environment": {
+      "networkUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36",
+      "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+      "benchmarkIndex": 837.5
+    },
+    "runWarnings": [],
+    "configSettings": {
+      "emulatedFormFactor": "mobile",
+      "formFactor": "mobile",
+      "locale": "en-US",
+      "onlyCategories": [
+        "performance"
+      ],
+      "channel": "lr"
+    },
+    "audits": {
+      "redirects": {
+        "id": "redirects",
+        "title": "Avoid multiple page redirects",
+        "description": "Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://developer.chrome.com/docs/lighthouse/performance/redirects/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [],
+          "type": "opportunity",
+          "overallSavingsMs": 0
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "metrics": {
+        "id": "metrics",
+        "title": "Metrics",
+        "description": "Collects all available metrics.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "cumulativeLayoutShift": 0.006987,
+              "observedLargestContentfulPaintAllFramesTs": 147547064,
+              "timeToFirstByte": 601,
+              "observedFirstPaintTs": 147438909,
+              "firstContentfulPaint": 3001,
+              "observedSpeedIndexTs": 147530264,
+              "observedFirstContentfulPaint": 1037,
+              "observedFirstContentfulPaintAllFramesTs": 147438909,
+              "largestContentfulPaint": 5926,
+              "observedCumulativeLayoutShift": 0.006987,
+              "observedLastVisualChangeTs": 148637976,
+              "speedIndex": 4053,
+              "observedFirstPaint": 1037,
+              "observedLoad": 1519,
+              "observedTimeOriginTs": 146401976,
+              "observedLargestContentfulPaintAllFrames": 1145,
+              "observedTimeOrigin": 0,
+              "observedLastVisualChange": 2236,
+              "observedDomContentLoaded": 1120,
+              "observedLargestContentfulPaint": 1145,
+              "observedDomContentLoadedTs": 147521492,
+              "totalBlockingTime": 610,
+              "maxPotentialFID": 182,
+              "observedLargestContentfulPaintTs": 147547064,
+              "observedFirstContentfulPaintTs": 147438909,
+              "observedCumulativeLayoutShiftMainFrame": 0.006987,
+              "observedTraceEndTs": 151817448,
+              "interactive": 11070,
+              "cumulativeLayoutShiftMainFrame": 0.006987,
+              "observedNavigationStartTs": 146401976,
+              "observedFirstVisualChange": 347,
+              "observedFirstContentfulPaintAllFrames": 1037,
+              "observedSpeedIndex": 1128,
+              "observedNavigationStart": 0,
+              "lcpLoadDuration": 4613,
+              "lcpLoadDelay": 4289,
+              "observedLoadTs": 147921305,
+              "observedFirstVisualChangeTs": 146748976,
+              "observedTraceEnd": 5415
+            },
+            {
+              "lcpInvalidated": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 11070,
+        "numericUnit": "millisecond"
+      },
+      "total-blocking-time": {
+        "id": "total-blocking-time",
+        "title": "Total Blocking Time",
+        "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).",
+        "score": 0.49,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "610 ms",
+        "numericValue": 610.49999999999864,
+        "numericUnit": "millisecond"
+      },
+      "final-screenshot": {
+        "id": "final-screenshot",
+        "title": "Final Screenshot",
+        "description": "The last screenshot captured of the pageload.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "screenshot",
+          "timestamp": 149471832,
+          "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAICAwEAAAAAAAAAAAAAAAUGBAcCAwgB/8QATBAAAQMDAwIDBAYIBQICCAcAAQACAwQFEQYSIQcxE0FRFCJhcQgVFjKBkSMzUlRyk7HhNDZCocEXYiSCJSc1VXOU0dM4U3R1g7K0/8QAGgEBAAMBAQEAAAAAAAAAAAAAAAEDBAIFBv/EADERAQABAwEEBgoDAQAAAAAAAAABAgMRBBIhMXEFFDJBUbETFSMzUmFyocHRIjSBkf/aAAwDAQACEQMRAD8A9UoiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAi+OcGtLnEBoGST2Cr0WuNKzXD2GLUVpfV52iJtUwkn079/ggsSISAMk8eqrp1xpZtf7EdRWkVedvhe1s3Z9O/f4ILEiAggEHIPmoq86htdlext1qvZGPxiaWNwiHzkxtH4lBKoqF1rqv/AFSX+po5+DTtcyWJ/cFzeQQpY6v09ZqSgprvfLdR1ToY/wBHPUNa7lo5IJ4QWdF101RDVQMnppY5oZBuZJG4Oa4eoI7qFu+sdN2erFLdb7bKSpzjwpqljXD5gnj8UE8i6qSpgrKdlRSTRzwSDLJI3BzXD1BHddqAiIgIiICIiAiIgIiICIvj3bWkoBcG9yAvgkYezgou5XGkt8BqLjVQ00OQ3xJnhjcnsMlYFHqWx1tSyno7xb56iQ4ZHHUMc53yAKCyouineT7p/Bd6AiIgIiINb9cJ5n2ex2hsz6ekvF1goauRh2nwXElzc+WcYVjq9C6YqLC60PstA2h2Fga2FoLeMbg7GQ7491mau07Q6qsU9rubXeDJhzXsOHxPHLXtPkQVT5dF6zqaI2yq1491tc3w3vZb2NqXM7EeJu7488ZQUQ325T9D6OhdWylkl4FkdXtdhz6bxS3fn4tG3K24zQOlW2P6pFit/sWzZgwt3dsZ3d93xzlc5tE2SXRI0qaYi0tiETWg+80g5Dwf2t3OfVVpuidaMpPq5uv5fq0N8MONvYanZ2x4ue+PPGUEN1BqqnQnRQ0+nbxNVmOVtGyuc8OfDG55BG4ebR7oPcLYun9OWy36cZbo4hUU80IbO+Y+I6oyOXPJ+8Tlddu0bZKLR7dMikbNafDMb45veMmTkucf2iec+qxXaeulssos+mK9tNTbPDZUVr3VElO3thjeM48tzjhBpWnnlp+kXVCwNlfNbrNXPp6N7jnbH4g9zPwx/utz6J0pZqPSdJGaWmrnVdOySpqZmCR1U5zQS5xPcHPA8go8dM6Cn6a12kqCpkj9tBdPWSN3vkkLgS9w4znGEj0dqO00nsGl9Ux0VtDdscNVQiodTjzEbtw49A7OEFU0/VzaQ/6o2qyEuoLPF7ZQxfeED3xOe5g+AIzhWnpZpKxw6GttS+jpa6quNO2pq6qeNsj53yDc7JI5GT2U1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93cu+GOAFXaLQWodPskotIat9hs5c50VJV0Tak0+TkhjiQcegOUHR0+hjsHU/Vmm7WNlmZDBXRwA5bTyPyHNb6A98LaCrOiNIwaXhrJH1c9wuldJ41ZXT/fmd5DA4DQOAB2VmQEREBERAREQEREBERAXCcZiK5oeUFd1GKk20+xCuM24f4LwfEx/wDy+7j/AHUFZW3f60g9qGovByd3tQofD7H73h+/+Suz4SD7vIXERPJ+6g+wD9IFlLhFGGD4rmgIiICIsOquEVPVx07s73NLycHDW+v5oMxF8aQ5ocOx5C6KiqENVTQloxMXe9nGMDKDIRR9BXvq6qpjMIZHE9zA7cSXEHHpj/dYgvrvHqI3U4AikDGnf979IGE9vLOUE2ii667ezVL42xMeyNrXPJk2uIcSPdGPe7fBfaG6e01pgMbWNO/adxLjtdtORjA/MoJNERAREQEREBERAREQEREBERAREQEREBERAREQEREBcHxMe9j3NBcw5afMLmiAuqengqA0VEMcoacje0Ox+a7UQdUdNBHM6WOGJkrvvPa0An5lcTRUp8TNNCfEOX5YPf8APn1XeiDpFJTjw8QRDw/ue4Pd+XouTYIWyulbFGJHd3hoyfxXYiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIIi832C2vEW0yzEZ2g4x8yoj7YO/ch/N/soG97/rar8XO7xD39PL/bC1/qek1FLq+2T2t1ULWxsYn8KZobnxCXZYSN3u4H48ZxheXVqblVcxE4h79vQ2abVNVVM1TOPHvbe+2Dv3Ifzf7J9sHfuQ/m/2WpKGnvreodwmqWVbrI9rfZ3+0t8Jp8MB2Y855dnnHddGnrfqWHWte65VE77HGZH0znTBwk3luGluc+6M9wufT3fj7s9zvqenz7ueOO//ALx4NxfbB37kP5v9k+2Dv3Ifzf7LS+nKTU0do1HHcWVra57JPY5JKtrw4nft2AH3CMt7/D0Xfp6j1Q3T18gu00n1jJHso5DKDz4QAcCCdp3cn45Kmb92M/z8iNJp5x7Od/P9tw/bB37kP5v9k+2Dv3Ifzf7LSlRSark0ZcWs9rF2kqWOhjFS0SNjGzcN27Azh3n5q5WNs7bPRtq2Sx1Aib4jJpBI8Oxzlw7n4rmrUXYjO15OqNFp6px6OY3fNeftg79yH83+yfbB37kP5v8AZaj0vT36LVd7fdo6w0L5JDSSPqmuiDC4bWiMEkHGefThYWhaTVsF6mdqJ1S6nMbtzn1DHxufu93YwDLRj4j5KZv3d/8AOPs5jSaeZiPRzvz47m6ftg79yH83+yfbB37kP5v9lprTVHqmLWlfNdXzmzOkqDA10wcAC9vh8bjxjOOOOfVYmkaPWsWrpJb3NI62Ey790rHMd+xsaDlv5DhT6a7v/nH2RGl0+72U75x3/wDeLeH2wd+5D+b/AGT7YO/ch/N/stS6cp77FrG8yXOOsNte5xpZHVLXRBuW4aI85B78/NdGkaTUsOrLrNeX1TrY8P8AA8SZpbkvG3a0E4w0d+O/ZRN+7v8A5+TqNHp5x7Od8/Nu23apgqJ2xVERg3HAduyM/HhWJamW0Lbv+r6bxf1nht3Z9cLTpL9VzMVdzz+kdJRYmmq33slERbXmCIiAiIgIiICIiAiIgIiICIiCIvNiguTxJuMUw43AZz8woj7Hu/fR/K/urcior01uuczDVb1t+1Ts01blR+x7v30fyv7p9j3fvo/lf3VuRc9UteHms9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6Vy3aWgp52y1Epn28hu3Az8eVY0RXUW6bcYphmu3q707VyciIi7VCIiAiIgIiICIqL1q1bXaL0HU3W1RMkrDKyGN0jdzY9x+8R59vzIQXpF5O0z1O6mV8tNU091ttzjkkG+jAp/Ga3OD+jG15/DKlperGsIOttRZ2uqam1R3GSmbbGU8e9zBkAh2zdj/X37IPTaLRtz+kNbrffbpbJbDWPfRSywhzJgfEcxxbwMcA4/Bdtj6/0V1vrrYLBVQvbDPKXuqGn9VE+QjG3z2Y/FBu1Fpax/SBstdYrvdK62VVHHQGFjYxI2R875N+Gt4AGNhOSuWkOv9k1DfILXJa66inqXbIHPc17XvP3WnHIJPA4PJQbnReYekPVvV1211NR3qSouVB4EzzAyCNns+3BD3FrAcDG3nzcFbbb9IOhrrHeLk2wVLG21sTnMNQ0l/iP2cHbxjug3ii0FU/SRt8FNRzHTtURUxmQD2lvu4e5v7P/AGqWn+kDYaezVFfNba5rhVOp6aAY3TtaATIc42t5HqeUG50WlrH9IGx3SgubzbKymraOmdUtp5HtxOG92tcOxxzyOyaT6+W/Ud3tlugsVZFPW1QpyTKHNiBxh5OPUnj4IN0ovMP0qb9d7VrK0xWu619FE+gDnMp6h8bSfEeMkNI5V61F170/Yr7WWk0dZVPo2Pa+dhAY6VrfuDz5Pu7vI/DlBuRFQekvUmn6i01ymprdLQiiexhEkofu3AnyAx91VXVv0grDYb/VWumttbcPZZDFNPG5rGbgcENz3weM8IN0ItJ376Qllt9BaqyhtdVWw10bnkGVsboXNdgscMHnz4PYhZH/AF9sDLNX3Got9bGyGoFPTRcb6nIJ3AHG1oxzn1CDciLR9D10tGp7Ff6SGnr7Tc4rdUTwHc0l2yNzvcd5OAGRkeSq3RzqjHp7Q2oLnqWuu1z8GrhihZNJ4ji57XkNaXHjhhJycccD1D0yi0hYfpFWG4VYir7TcaGNzHvbNlsjcNaXHPY9h5Z5WLT/AElLJLV7XWG6Npdwb4wcwkZ9W5x/ug3yi0rfPpDadtt2uFDBQVtWKUOaJ2kNZJIDjaO5A7+98PjlR0v0jqCO0U1edO1RbPPLAGe0tyCxsbs52+fiD8kG+0WotM9dLHe9V0Vidbq+klq/DbFNKBt3vYHBpHBxk4BxzwexUZfvpF6ftt5qKKktddXQQSGN1SxzWtcQcEtB7jPrhBvBFqbUnXXTVosNpuNNDV10lyjMsVOwBjmAOLTvJPHvAjjPYqU6XdWLR1AqqmipaapobhAzxTBNg7mZAJa4ehIznHdBsVERAVI6w2i/XrRzqXS7aeSuE7HuhqNpjmjAO5hDgWnuOD6K7og8ds6Na9ut+pXy2CisrA5u+ogqIwxmDnfta9xz/CB2Vx1V0z1vbur/ANqNL00FbG+cTsmfKweGS3a4Pa4gnz7ZXpNdck8UTgJZY2E9g5wCDz3036eaptHXGuv9ztXg2mWorHtn8eJ2Q8u2naHF3OR5KO1R0o1lF1Tu98sVLSVNHWGpkZLJM0Bomie1zS0kHPvkDyzgnjK9Lte15Ia5riODg5wvnjR+Js8Rm/8AZ3DP5IPI9j6Iayn0lfaStt7KOsM1NUUrJKiNwn2CZrm5a44OJAecK7aJ0x1PqtU2KTUtBa6K2W5scZkfBSySGOPkNaW7nAn1BGO69AunhbJsdLG15/0lwB/Jcfaqfn9PFx398cIPNmjul2t9J9TKmejpqeWz1fiU81b4jCPZ3uBPukhwdwPJVum6N9QLbZ9Q26G20k0NU2JoLahmZtkocNmXDHmTux6DleuWVELyAyWNxd2w4HK1VfusTbT1Vi0WbIZS+qp6b2z2rbjxQw52bPLf2zzjyRDRVf0Y19LQ2qNlgJfDC5sg9rg90mV7v2/Qhbq+kD06vGsY7PcNOeE+utxcDTveGbwS0gtceMgt8yO6xqzrwaalvcz9JV8YtsjWDx5vDEmXhvJ2na7nOOeM8rYHTLWbNcaVp7z7IKAzSSRiAzeIfdOM5wM/kg0nQdPOodxt+oai9W620809HJFFTtZA6eeQt2j9Ny4DHOS/4dle/o36QvmkNO3am1HQexzz1QkjaZWSbm7AM5aT5q+6wv8AWWWCBlrtFRdK+oJEcbHtijbjHL5HHDRz8SVNipY2GN9Q5kLntB2ueOD5jPmiWgPpHdPdUav1VbazTtrNZTw0Qie/x4o8O3uOMOcD2IULe+lWvaDU+q/s7HSy2u9QzGSVz48ua4l/hYcctcXe7nt55XpxksbyQyRjiBk4IOAkc0UhIjkY4juGuBQab+jXou/6OoL7HqSgNE+plhdEDLHJuDQ7P3HHHcd1SK7p11G0vqjUb9I0VHX2+7ueHSyGF36Nzi4AtkI5GcHggr0wKqnIJE8RxyffHC1/1h6nN6cR2l5tRuIrzKBio8LZs2f9rs53/wCyDS2u+k2vbpbrDi20lZWRwyGoFJ7PTsiJdw3ALQ44AyQPP4LZ3XLp1dtYWCwy2PwfrK1Z/QSODQ8ODc4J4yCwd+O62bpu7svWnLTdXRin+sKWKpERfu272B23PGcZx2UhHPDI4tjlje4eTXAlB5nj6Za+1JeLzqLVdNSwV/1ZUU9PTwvjBnkdA6NjfdO0D3u5P9sDTPSvW9DoS82+awUUlTUV1NMKasmjc2WNjJQ7a5r/AHXBzmc5acZ57r1OKiEvLBLGXDuA4ZCMnhkDjHLG4N7lrgcIPLukumvUqCera6ipLbbfAmDLdU1LainLnMIDWsLn4y45yT6/JYVm6YdSoL1D9W2qmsFOXN8Z0Nbuglwe72GR5d8sY+C9YRyxyAmORjwO+05XFtVA4EtniOOTh44QeWbh0j1/aqvVNusUNLUWe5t3GQvjDpmtfuYwBxy13PPYcd+yr9R0a16/TNBSNsJNRFWVMr2e1wcNcyANOd+OSx35L0x1D6j2PQX1f9eCrf7aHmL2aMP+5tznJH7Q/wB1ZLTdqS52aiudPJtpayFk8ZkIB2uAIB+PKIeb4umGsG9WdP3g2ci20ptpmm9oi93woYWycbsnBY4cDnHGVi0/TbqZpGpvds0zQUNda7g8Znl8B4cxriW5bIeDzyMEL1Q1zXtBaQ4HzByomXU1liv7LHJdKRt3eNzaQyDxCMZ7fLlEtA6z6SayqKXTN4oDQVV9oYdlRTwbKZjXCR0jdm3a3/UQe3bKuXRLSer7XebhdtXU1tohMxzWQQwQmZznOBLnSMBJHHm4k557LcaICIiAiIgLyj9LsluuLKRwRbwR/NevVy0j136UX3X+orfX2aptsMNPS+A4VUj2uLt7ncbWO4wQg0/o641ts6gVztFXS43EyWuonqHzMcHOm9nc525p7kS4wT5+vnT/ABbd9mxeBfbh9r/bf1GHY8PGfE8T9rPx/DzXuiy6ctNnnqKm3W2kpquqO6omijAdK7uST3PPKrNvtnTev1M/6vg01UXxj3PdHCYnSte0+8S0diD3OEQ8264rqiLq/pa6agJgmMNrqap7xjBDYy8n5EO/JU2KRsr9ZSRncx9OXNPqDWQL3TeNM2O9VdPVXa1UVZUU5BilmiDnMwcjBPlnyUT/ANONHZqT9nbfmpG2b9H98bg7n/zNB/BBpf6MWh6S40NJqyatqxVW+smiipwR4WDG0E4xnJ3evkFX9e//AIrqX/8AdLd//SFeo7BYrXp6hNHZKGCipS8yGKFuGlxABP8AsPyWDV6M05V39t7qbPRy3Zr2Siqcz3w5gAac+o2j8kS8I2v/AAGof/0rf/8AREs2OenptPWeqtt4rvtDDVPa2ka1wbBHnc1zHepcTwP+OfaUfTPRcbJms03bmtmbtkAj+8Mh2D+IB/BZdDoXS1BNSS0lgt0ctISYHiEExknPBPx5RDyNruolu3Ui/N1vXVFHJAHCAEuAaQBsAAa7gjnsM57hRur5/F0FpiOO6VVxp4qmsbG6eAx+F7sBLGkuO4ZOfhle0b/o7TuoZ2z3uzUNbO0bRJNEC7Hpnvhddy0Ppi50dFSV1joJqWiDhTxGIBsQdjdtA7ZwPyQeetT6Un0b0RbfLJcLhLUX2Gh9uLnD9FEYycNIAIbktb8uFS+nf1ZRax0zPadQVsNdK+Lxo4YHTbpC7DozwzAI4/1cc5Xriiu2k6s/ZmkuFnqHRMNKba2aN7g1gwWGPJPAGCMcYXKy6J0zZK41tpsVvpKvBHixQgOGe+D5fgg8hdDtGUuutUXG1V1ZVUtO2idO405AL9ssYDTkHjnPzAWy/pfRCC36PhaSWx+0sBPngRBb00/ozTmnaySrsdnpKGpkYYnSQswS0kHHyyB+Sj9ex6IqH0cWuZLMHMDnUzbhMxhwcBxaHEegQeXdV1gn1Louk1Jcq23WOnslC+GamaXOj/8ADtdvaB5+IMZ+HwUx9FI7uqVwduc7NtmO53c/pYuSvTc+ldOXGntfjWmgqYaBjBRF0QcImgDaGn04HwXyxaN07YbhJXWaz0lHWSMLHyxMw4tJBI/MD8kHlrrOyo0J1hu1bQN2sudJJIzyx40bo3n8H7j+SjK+23LT/Qu11lN40MN8uL5Kp7MgmNjdsTCfQkSO+PC9dai0jp/Uk0M1+tNJXSwtLI3TMyWgnOAsx9jtcllZaJLfTPtbGCJtK+MOjDR2GD6IPJ3SAW2h6l2xlgv9aRKza+BkDpGzZYS9ryQzAGM52nGO5WvNOUftGntU1Hjzxmko4pAyN+GyE1MTMOHmPeJx6gL3PYdH6d0/NLNZbNQ0Usg2vkhiAcR6Z74+Cwafpzo+np6qCDT1vZDVMEczBHxI0ODgD/5mg/gg8Z34zVfTnTNZUOllfFV1lGJHuJ2xtEL2M+HMkh/H4LJuVXba+52C3T109NpqChiDSHPDWyFm6YjLXHmcyDIae3HGF62ntvTygpTpeoZp+GKSbxfq6WSMEyEAZDSc7iMBSc+gtKT22noJtP219HTkmKMwDDM8nHmMoNVfRWljFJfKaku9XXUkbmOEMtOWMhcd3LXEnOQBkYHYKRu//Tv/AK+U3tnt51Xujxj/AA3jbBsz57tu3Hl2W27LZ7dY6FtHZ6GnoqUHIjgYGDPrx3PxWPJpqyyX9l7ktdI67sG1tWYx4gGMd/lwiUuiIgIiICIiAiIgLxfpC2VN66qaytlAGmrq4LnDEHO2gucXAZPkvaC1JobpBJpjqPV6pdemVLZ3Tu9mFNsLfEJP3tx7Z9EFFvOtNS9LNNaT0VQU1F9eugdJNJM4PY0PmeGBpyB65JOArFoXXPULUFDfrfX2qOmuVPTPloq9tOfAfI0j9GTktdu8iD6q1dWOlVNr2robhDcprXdaNuxlRGzeC3OQCMg5BJIIPmVD6S6NVGnLffJItS1FRfblTupm1skR2wtcRucG78lx9S7hENX23rrra7OtdooG0f11UVhhdI6nG1wdsDBjPBB35PyWZP1s11c7lWt03S0E1LQkNLXRAyzDON23dkkkE4aOFOw/RuNNTUL6PU3g3OnqHTGqFIeR7uwBu/gtLXHOed3wWVdfo8GeuqZrXqia3wVmDU07Kcljj3cBh493OSAc49SgrmuututLW6yeHQxWqoqKES1FNU0xz4niyN3N3chpDWkD+q74ututYda3m0T2y3SvpxVBtMDjwTEx7id+feADDn18sKf1P9HiG5ttUduv76aKhpBTuM9P4z5Xb3vLyd4x9/GMcYWc/odK7Xt21H9fsDa41hFP7Ics8eORn3t/O3xM9uceSDX3/X3Vc2jZ6ljaCO409dFEZWw5a+N8cpwWk8EGPuPVStn63axpK/TlVqG2Un1HdcRtka3D5AHBj5G4PBBPYjt+aq3VLpXN070UCboLka+4Q8MpjHs2Rzf9zs53/wCyufSXo3S3e36Y1Lc7pUyUkcYnZbXN91sgeSfeJ4aSASAPxQa+st/ZpbrnqW9yRGUUdTcpBHnG92ZA0Z8skhW2y9ZepFdJT3Cns9FcbfLKW+zUsJc/APIw1xc34Fwx81dafoNA/W13vVyvAqaK4vqnPpG02xzRNuxh+48tLgc48lF0n0cvDqoIqjVtZJaIpDIKVkJY744O8gE+oag2F1a19JorQcd6pqQurap7IYIZwQGPc0u98d+ADx6rzD1jvuqL63T0+sbbHR1LqZ0tPJHgNnieQQdoJwR6HntwvWevNDW3WOkfqCrdJTwx7HQSx8uicwYaee/GQfgVqK5fRvlrKajY7Vs8ksDSwvnpzIAzPutYN/ugD59/JB0au6t6npNSQaZ0fTUIdSUsQfJU7d0jvDa44LnBoHIGO5WzOjOrr/quyVT9U2eW3VtO8BshhdEydpBwWh3mMc/MeqretOh0d7vUV4s9/qLRcTCyKZ8cZcHlrAzcMOBbkDkZKuHSnp9S9P7PUUsNbNXVNS8PmnkG0HAIAa3JwBk+Z7ol5K1K65S6rrqnW9Zead75HOhqYIvFYeTgsy9o2Y7bT2V3k6l33RWhtPRaevlPdI6iWq3zzxue8Bpj2tIfy0gOPHI5GCVca76PFc+Keko9a1UdskeXeyyU7nN75GQJADz8FIXH6PFtqNJW21U14mhrKSWWZ9U6EObK6QNB9zIwBsbjnyRCHb1b1QerFssHi0n1dUOpA8eAN36SGN7ufm4qF0R1Y6navrKqhslPb6yqjjEp/Rsj8Nu4An3nAHvj8Vc7X0GloNbW6/8A2lkqG0j4XmOanLnv8NjW437/AD28ccDA8lMdHukEnTy+1txfem3AVFN7P4YpvC2+812c7j+yg8/6at1bdevD4bqaaarhus9RWFxcGO8Jznybcc9mO2+WcZ4V1b1u19eqqsrNO223uoIZQ1tMI/ElIJ443b3H1LRgfBbH070bdaeqdVq+W8sqIp6iqnNH7MW8TB427957b/TnCr1f9HNpraltp1TV0VqqJA99IYS7gHIGQ8A48iQg3Po27VV80xb7jcKCW3Vc8eZaWVpa6NwJBGDzjjI+BCmVFaWsdNpvT9DaKF0jqekj2NdK7c53OSSfUkkqVRIiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiKMqp6r2mVkB2sZxwwOycA+ZHqqb16LNOZiZ5OqadqcJNF0U0kktI15aPEIPB4Gf91gUNwqZp6VksUTWStk3FriSC12MDjt8f8AYKyiqK6YqjvczGJwlkVfqLpWx01fPtibHDN4TCWcfrA3JO70J8guyO51JqaOAeFJ7Q0ObI0cYBO/OCR2xjnuV0JxFAQ3eqdNVNfHEGxztjadpGQZiz154HfjlcHXmq8KscwwOfDP4TWBm52PE25I35PHyQWJFFVNyfBZIqyR0Ucj2tPPvNyfIc/8rF+uphJL4ngMYyMvPBdsw1p3Eju0kkDCCfRQVDeJ6itpIXsjDJWbi5ozuPvdueMbRnvycKdQERYlbJLuEcJLTsc/IAJOMcDPzSIyiZxGWWixqKVzw9r3btuMOIwSCM8j1WLa7hLV1tXFKwMETsNbjnGSMk588ZxgceqnBE53pNFX6G+VFRVwQOga0mSRsjsHGAHFmPntOfkvhvVU19LmBhZNHTuL2g+66R2CCPTAOPioSsKIiAiIgIiICIiAiIgIiICIiAseWkilkL3bg498OIyshFzXRTXGKoymJmODjExsbAxgw0LkiKYiIjEIERFIIiICIiAiIgLrmhZMAHg5HYgkEfiF2IhjLhFEyJm1gwO55ySuaIgIiICIiAiIgIiICIiAiLpNTEKttNu/Slpfj0CiZwmImeDuREUoEWBcq72fDIsGTuc+SwPrOp9W/krabNVUZhXVdppnCeRal6kdRLtYamjt9mp2T11T72SzIaPl+BVOu3VHW9N+qhia4DkGkyM/NU11RRVszO9dboquU7VMbnotF5hPVLqZh8gpaYQtGcupQM/LlbJ6VdQbjqyyzSXBkMdbTybH7G43DyO3y8x+Cm3MXJ2aUXIm3GaobVRQP1nU+rfyWZ9YTvpGvpKYVE4e1r4zIGYBPLsn09FZVaqpjMqqbtNU4hJIo/2m4f8Au9n/AMwP/ou6jfVySSOqoo4Y8AMa1+455yScD4fkq1jKREQEREBEWDeaielpBLTt3bSd+GlxDdp5AHxx+GUGci6J52ikklieHbWFwLefJdzHB7GuaQWkZBHmg+ovjyQxxHfHC8uXDrJriDqPJYYzR+D9Y+zMj9mBcYy/A5z+yQcoPUiLzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiLqnnjgMfinHiO2A/FRMxEZkdqIikFW6FxdrKsye0eB+TVZFWbf/nKt/g/4aqL3Gnm06fs3Pp/MLMuuolEML3u7NGV2KOvb9tO1o/1O5WminaqiGSudmmZQ0j3SPc9xy4nJXFEXosCh1tD7RreqqZmgmJjWR/AEDKn2wsDQC0H8FjXOBzbxPI3hz2NI57jssaA1ranD9ng+rHE4/NfM6mfb1c31+hjGnoiO+Hy9QNdA4bRghV3pvF7FrK5QRjEc9P4px5ODgP8AlZdZNWVBkw1hjaSMOeW5Xb06pX/XVfUuydsLYyT6k5/4Vuin28YZuk4zYn5NhLvo5zTzteO3Y/JdCL6GYzGJfNROJytgOQCixra/xKKInuBj8lkrzZjE4b4nMZERFCRF01kxp6aSUM3lo4bnGT81ixz3M1MLZKGnbC5xEjxUklgwcEDZzzgdx3ygkEREEXdWWq2UVVcqylgbHBG6WSRsILsAZPYZK5UdDRyxxVNI6oZG9ocwNmka0A9vcJwPyUi5oc0tcAWkYIPmvqDGdSOP3aqob8iD/UFVd3TqwyX8XqWEvuQGGzlrAQPThuPh6447cK4ogqN96f2S/XKmrrxEauencHRmRrPdPHo0Z7Dg5CtcMTIImRRDaxgwAuaICIo603CeulrWT26pohTzGJjpi0iYYB3t2k8c+aCRUHq8kW+MjuJAf9lOKC1h/wCzY/8A4g/oV5vTH9G7yXab3tPNNxnMbSe5C5LjD+qZ8guS9GnhCkVZt/8AnKt/g/4arMqtSSCPV9a4gn3PL5NVN7jRzadP2bn0/mFpUVfc4h9Of+Fme2M/ZcsK6ytmpxtaQWnPK2Wt1cMNyYmmYhEoiLcxoa7scyujmI/RuZ4efjklR0tY2NznFzdreAzOPxTWd8bbq6y0JjDzX1Doy/P6vEbnD8yMIRDhxIDXHzwvndfTsX5x3731vRVe3poz3bkJT1kb6qZhe3a88MznHxU1oSF7frGY/q3yta34kDk/7hQNwmgppi7LS/19PirNoOugrLEzwuHtc7e09+TkH8Qrejrc1Xtvuhm6XuxTa2PGVjREXuvm0/Zxiib8z/VZqgKe7SU0QiFqrn7cjc0xYd8Rl+V2/Xkv/ue4fnD/APcXn176pluomIpiEhdal1Hb5p2AF7R7oPbJOBn4crr8O5fvVH/8s7/7iirjcZ6+kdTMtdZEZHNG+R0W1o3AknDyew8gpr2xn7LlziU7UOiWlrp2iOarpvDJBcGU5BIBzgEvOPyUgsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkosb2xn7Lk9sZ+y5MSbUMlFiSVn6N3hsy/HuhxwM/FULQNx1lJqfUbdTQUTbaKkeB4T3kt/RtwI8jluMZJx725MSbUNkIsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkqC1h/7Nj/8AiD+hUp7Yz9lyhdVTtlt7AAR+kHf5FeZ0xE9Ru8l+mqibtPNYYf1TPkFyXGH9Uz5Bcl6NPCFQqlH/AJsrv4P+Gq2qpR/5srv4P+Gqq72qObTY7Fz6fzCXXF7Q5pB7FckWt5qqakvdPYo81AdJK77kTO7v/oFQbpre6VVQ1tJG2lgDXOdt5c4YOBkjgrZWrdOQ36jxwyqjB8OT5jsfhytRXC21FHN7PWRGKXducCMAHPugeuSF6mlqt1xv4s1ymYn5MC/RvrrdM1gkkr97Z43l3vb2nG7J9B/VXDS9c+6WOCadofLtw4EgEOHfKrMrZI6hs0R2StccZGRggNPH4ZWTbRNT0kjoJ2sDow/BBw4k+Xx81k6S0E6nFVPGHq9F6+nS5pr4Si7vUiXUctK8NMccZkMbXZHcAZ9e5/JR0NbVNubqimMlO9oDQ5jiCRnjP+6z44HATOe4GSbAkfjJOCTtB/Ht81xZTnxmgYwHbTznLifX4bT+a26XT06e3sUw8/VXqtRcm5Ul9P8AUG7UzR7e1tXCXluXDDhjsAfj8VtHS15ptQRGSmDmmPHiMcPu/j2K1RpzT1Vdm08FLCcOO98h+6wcjJ/Jbs0/Z6ayW5lJStHHL34wXu8yVXqqqKIxHFXbpmZ+SSX1EXmtAiIgIiICIiAiIgIiICIqL1LqdXQPtH2Up6WSJ1bEJy97t2M8hwAwGepzn4KCIyvSLppDOaaI1bY21G0eIInFzQ7zwSAcfgu5SCitRf4Jn8Y/oVKqK1F/gmfxj+hXl9Nf0bvJp0fv6ea0w/qmfILkuMP6pnyC5LdTwgFUo/8ANld/B/w1W1VKP/Nld/B/w1VXe1RzabHYufT+YS6Ii1vNFgXW1Ud1h8Osha/H3XdnN+IKz0SJmJzA13c+n8viSPoKprmu7Ml4LeMd/PlQ0Wkr3FROiNGQ8YY3bI1w2g9+/wAfTyW3UWmnV3I+aubcS1DFoy8SvJNK1vOG73hob6nj5u/NT9n6esiMLrjVeIIyD4cQwHHjufwP5q/olWruVbuCdiGNQUVNb6VlPRwtihYMBrQslEWaZzvl2IiICIuipqoaZoM7wwHgZUImcb5d6LjG9sjGvYctcMgrkpSIiICIiAiIgIiICIiAorUX+CZ/GP6FSqitRf4Jn8Y/oV5fTX9G7yadH7+nmtMP6pnyC5LjD+qZ8guS3U8IBVKP/Nld/B/w1W1VKP8AzZXfwf8ADVVd7VHNpsdi59P5hlXm6UdltlRcLnMIKOBu6SQgnaM47AE+aitN6009qV07bLdIal0DQ+Ru1zC1p7HDgOPiuvqTZqvUOh7tarf4ftVTEGR+I7a3O4Hk/gtLw9HNVMstwot9tEs0EGJzNIXzbNuYHHsGDHGB/patTzoiHocVdMQwiohIk+574975eq+CspixrxUQ7XHa07xgn0C0A/pBqRuk4BR/V9Jeqe4GpgiineWRxubhw3OzzkN4AxwuF+6LXw0Niht3sFWynofAnhqJnsbHO55c+Ru3vy7HrwEynEeL0G6rpmvLHVEIeCGlpeMgnsF8FZSlwAqYSS7aB4g7+nzXnm+9HNTVlRdJYnUT5ZXUhgk9ocP1ce155ye+MZJK5UPSHVdPeKRzpKE00F5FeZhMd5ZluTjHcY7eqZMR4vREc8Ukj2Rysc9n3mtcCR8wqu3qJpV2oPqQXZn1p4/s3geFJnxM425247/Fa76V9MNQaZ1lHcbmaDwIWSNfURTSOkqS7OCRkDzHcHt68rGh6a6rp+ol3utOy2Cgr6qSQTSSEyRNduw5oHZw3Z+YUZkxDbupNU2rT9mq7nXVAfTUpaJRDiRzS5waOB8Ss613WjuduirqWZhgkjbJkkAtDgHDd6HBC85wdF9VC011L7NaIZXQCETR1MpdUnxQ7LsnaOB6eQ481Iy9H9UNprxTUUtHT0tVDSO9nE7gyeSNrQ8PwMgE7jnzTMmI8XoM1MDYRM6eIRHs8vG0/ivktXTxFglqIWF/3A54G75eq88VfR3VMmn6aJr7cQytmqPqnx5PZ42va0ANcecjB8/Pv3Xy8dHdS1DbM1lPbZ5aWnbC576uQxNG5xLdjgXHG4YIcPkpyYjxej1Bar/UQfxH+imoWlkMbDjLWgcdlC6r/UQfxH+iirgov+7lqD6Qurb3pqi02yzXmS2QTRyPnELR4ku0N2hri0jzPGRlVGn6s6xsVdXVVwq3VcLbFT1dJT19IYxNI50Qc73Mc4c898Lc+uOoVBouns1LVWysuVVWxPkjhpmtO1kbQXOO4jsD/so2PrRaZKq5MbZbuaa200dXV1Phs2wsfF4jcjdnJ4bj1+HKLqOzG5UdYdYdX6UmiiuNusj31FqFxgMMczmlxkwGElw7N5PxWJSdaNVXe9VFpp6G2000lPIIoRFOakO9n3tmHBYWF3YHnH5mfqetlJcaq0RW6lr7fO+5U9NUU9RSMle+OVu5mCJBtDgO4yfgu5nX2zOoKyt+zt6Hsr2xvbsi3tySMvG/LBx/qx3Cf66x8lAtHXXU1q0vbhVto7jVOoJ55J6mCQPM7ZnARnaWjhm08DzHKtVs6vavr7Zqa5wWe0z0tkhikfDG2UTSGRmQRyRtack/9o/FSlx+kFp6ipmTvs12kxA2aTYIiI9zy1oJ34OcZyMjGF2P+kDpuCvlp6q2XSGOOompnTbGFu+NuTwHZ548vNP9MfJWbN1s1beaux0NDb7C+ouVZJSMqSyoEDsNaQRnB4Lue/4KX6s6wvulepNolo3S1LIrJUVMtBG9whllaHclo7gd/XAUpD10tJtJrJNP3qOR00ENPT7Iy+czNc5hbh2OzSefUKYu3Vq0W3Q1r1RPbriaWvqBStg2NErHe93BOMe6exQ/xH9EepV017cb7T3SmoIo6COndE+kZK0SeIHEk+Jzj3eOB+PdbZWm5+vunoadj22m8PnZ4pqoGxM3UzY3Bri73sHk+RK+1HX7TsVU6GO33KVvtgo2yNDAHEjIcMuzjH4qcomJ8G40VS6c60i1zZjdKS119DROx4MlUGgTcuB27Sexbg5VtRyKK1F/gmfxj+hUqorUX+CZ/GP6FeZ01/Ru8mnR+/p5rTD+qZ8guS4w/qmfILkt1PCAVSZ/myt/g/4araoqptv/AKTNbF3czY9vr2wVxXRNU0zHdK23ciimuJ74x5IjVUNzqNPV0FilZDc5IyyCV7sBjjxuzg9hk9lRY7X1NiohGy828yMpGtBc1pLpg4AnJZ2LAXZx94+i2iWkdwfyXzB9D+S0MTXEtu6hVFmvUE9xoo62VsXsUkDw0RkOG/nZkZbnvnnyCwp7H1H8OllgvVOZ4XPaI5Hgt2FrACSIxufnfy4YBwcd1tTB9D+SYPofyQy1lqWya/rqihdbLvT0zRQNjqh4mA6fD9xADfPLcEYxjsouq051Ofdo6qG80TWQt2Rs8d+wgB2C5u3BPLck5yR6YC3Dg+h/JMH0P5IZVPRVLqyGapk1ZX087NrGwRQNbjO0bnOIaDnIPw5+StiYPofyTB9D+SIFBXvV2n7IS26Xejgl/wDyvEDpD8mDLj+S+a8ZcX6NvLbMJfrA0r/B8P7+7H+n4+nxWv6Kp0taZKKeyTSUlE5kT/ApaCR1bI8AhzZCGbiSdpyT3yomcOqacrJV9QHSRudZdP3SsYAS2epa2ihcAMkh0pBIA8w0qOqL1qm4Udwl+srRa4qUs8SOghfW1DdxGGgu2szzjscFYdLSXKrkndbNKXGfx3bnz3qpFKx5OCS6Nu95yQDjj0+CnKXS+p5nvfU3yjtLZBte200Q8VwznmeXc48k+SjfLvFMIW6WaqpaC6XGu1BqSmqKSmkqIa+oqmshEjCdrDEGhhDhtOOTyRxjmyyVtRcdK2WtrYvBqqiBksseMbXOYCRhc6Xp7Y2VTKu4x1d3rGkET3KofUEEdsNcdo/ABSWp4nuggDGOOHHsPgkxuZ9TMTbnDWfWO66bp36Ztup9NwXgVEE80Uss5i8Dw49xGQM4dxn5eaidFa+0C6+XOhrrNbrI240dJHLI6fxYqprowGRbdoAa1pxngKw9UbBp28V2mxqOtudJOylqmQey07nsLXRYeXkNOMDt2z8VGWXoZpa40lLXU92vNRQVENO0xkiNs0cWNoeNoPJaCexGPJSsoxsxlxoavpDR1tfbW01opqezzisD2yPcXStO1zgB94NyB3PnwByeojoXFQCMi0tgrJcgky7iW8Z3d2t97HkPyUw7oJYM3dsVyu8dPcGvb4DZG7Itzg4ke7z243ZwpDUXRqy3uezTurblSTW6kjod9M5rTLEzGN2WnB47jHdHWYYVDYukmp7obHRW611ddQRPp/Ajje0xtjeC4bhj/Ue+cnJ5PKqulr50muVohvF9tFvs1TJV1EzIKiZ8xe5uA+THbntgjnGBlbc0Romi0g+8voJaiZ1zrH1shmwSxzu7QQO3zWq63ovpCjuFs0/JdL9HX1kNQxkkLfdljJ3lr3Bm0AHkA4z8UIWKrsvSSzWKnpKuhttPbb0z22HeyQ+MI2btwd3GGuOBkdz6qL1ZL0x1HZNPaWgvtLbKSKeKspaaCMgPBB2tO4YG7cTzyc/FW3WHSiz6p0bZdPV1RVxxWlrGwVMW3xSGs2YJIxgjGePIKuHprpOu6kSx0VXeKS4UNPTunpoWFkD2sYGMw8t54xlrXIQi73e+izdNxyRUNtuMFqjNTDS08JEm10gae+M+8RkOPxUju6PXW826etp7bDerqIaxkUm9jw+RoLA7adrXHI48+/OcrGreh+kbDZjLdLtc20MNE+hc523OHyl4d7rclwc7jjyWVpTpVpa43G36gs18vFR7IIYpCXbPGdC0NZuywOHu7QQMAhDc2FpyWx2OvZo+y0stL7HTe0sibE/wmsc85xIeCdxJxnPKsqgqyiFtu9bqKqudw9jjoyx9FndAwNO4yNYBnfgYWRpi+0mpLPFcra2oFNIXNb48LoncHB91wBUuUqorUX+CZ/GP6FSuD6H8l8ltxrfCEnuxteHHPn8Fi6Ss1ajS12qOMxhdpqoou01T3JWH9Uz5BckRaIjEYdCIikEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBdT52McWkSZHpG4/wBAu1EGLV1jIKCpqfeDYY3SHc0jgAnz+Sr0FwrLa6BlVVurJTQiWZkgaNsxLWsA2tyNxLuME+7wrRPDHUQSQzxtkhkaWPY8ZDgeCCPMLGbare2mfTtoqYQPcHOjEY2kg5BI9eAhKHpdQVNW+OCnpozUOqXw7nFzGhrGBzn4Izw5wbj1Sk1DPUS0INIyOOoZGRI5ztri7khrg0jIHYOIJU3TW+jpn7qalgidzyxgB5xnt67R+QXyG20UEjJIaSnjewBrXNjAIAGAB+HHyQQVyvb6O/TxMbLM0tigYxrHvDX4e9zi1gJ+7s8vMdu6N1JUOpaWYUQY2UO3SSbwwEP2gHDCWh3cFwCnpqCkm3+NSwv3v8R25gOXYxuPxwAM+i+G3UZfG80kG+MBrD4Yy0DsB6YQYN5u01BVQxMp2mN4BMzy7YHFwAaS1p259TgLHF9qNhqnQUraFxkEZdPiQ7cgHbjzIxgZIyPkpiWipZahs8tPE+ZuMSOYC4Y5HK6TaLcTOTQUuZ8+KfCb7+Tk54555QV6s1DI+kcZg+nEFWwSOjD2ktZH4zhhwB7Nx8crPtWoX1U8rKmjnia2Jsvu08u5uSRtILAT8xkd/RSsVsoYXExUdOwk5JbGBzjbn8uPkuyko6aja4UlPFCHdxGwNz+SCLkvmxxHhN96tFLHl2C4Bgc52PgA/j4LDg1FWvpKWc0MUhqqR1VFDFLufxtwDx57/L5cqWr7NR1UdSWwQxVUzHN9obGN7S5pbuB9cHC5Q2e3QwuijoaZrHgB4EY97HIz688oMNlxqaux1U1OYI6rLoodxc0b+wDg9oIdnjBHp6rAivUlJBK10tRLUNlIkjq2tLoQ1gcT+iaQR7zefLdyfJWJ9DSPozSPpoXUp7xFgLTznt27rpNntpZGw0FKWR7to8JuG574488DKCG+08hFA5tKMT+ztezLiWPlIy3IbtBaCDyckeQXZaquqdeRHXVMwMolkhYzw3QSRBwDS0gbgQHMznuSVKts9ta9rxQUoe0tIPhNyC3Ab5eWBj5L4yzW1geI6Gmj3uDnbIw3JDtwzj/uGUQj73c5KS70zIjkNge8xknD3ucxrBgAk8bzgA9lzgvrnWOSudBmQTmnYwEtD3+J4be4y0F3fI4UnU0FJVEmppYZSduS9gd90kjv6EnHzKNt9G2kkpW0sAppCS+LwxsdnvkdkSiJLvcIp4aV9NSPqXylrjHOSxkYZuLj7ucgloxjnI5XS7UU7aVtS+mZ4E9FJWQiOTLw1oaWh2RgE7h8jxyp6moaSl2ezU0MWwEN2MDcA4zjHrgfkFwhtlDCyRsNHTsbJjeGxgB2DkZQQ4vlXFJPA6kL5YY3mNr3EPqNuAHNIbsOSRwDkZ7eS65tSvjo3ymOHxGb3ObiXLGNaCS5uzc3k45488+SnPqyg/Sf+Dp/0n3/ANGPe5zz+PK4SWi2yNYJKClcGNLWgxNOAe47digi33+o3F7KWMQRvp4pdzzuD5duQBj/AEh7T8V1nUk8VAy4T0sRo54hJTsjlLpnbnNawFoHnvGcZx25U8yipY2FjKeFrS5r8BgA3NAAPzAaPyC6orTb4WTNioaVjZv1gbE0B/nzxygwrZejUU1wmqoXRNozlzjG9gI27jw9oII+Xp6qPfqiopaenlraJn/iKZs7GQPdIWuc9jGsdhvmZByAex4KnKm2U8trqKCFjKeGdjmO8NoHcYJwuUdroIopY46KmbHLjxGiMAOx2z6oIu23+WqqWQSUxYTUOhLnNez3RFv3Br2g5zgYI+K67Xdq26XamdCYY6I0xmcw8lwdIRG7P8LHH8fkpl1soXQsidR05iY7e1hjGGu9QPXlco6CkjkhkjpYGvhZ4cTgwAsb+yD5D4IMlERAWBV3WClnlhkbIZI2RuDWge/vcWtDee+WrPWDPa6ee609wkDjPAxzGc+7z5keo5x8ygim6kP1l4Xs7n0TIpZpappa1kbWv2gnLs491+SB5DGVIWq9U1yqJoYWyMkia2TD9vvMdnDhgn0PBwR5hdI03QCERHxjGab2R7fEIEjOfvAdz7zjn4rMt9ujohJiSWV78BzpCOw7DAAA/L5ohFVWpoWSUjmxyR0srnu9okaNj4mMc5z24OccDuBnPGVkQako5XuYWTMeJImYdtPEji1juCeCRj1HmF1x6WoWsZHJLUzQxwPpoo5JPdijdt4bgDttGCcn4rvlsFNNbqiknlqJGzlpfJvDX5aQW42gBuCB2AQdFVqmgponSOEr2taZHbQ3IjBI8TkjLTtOMZJA4C73X6mFaacRVDmNmbA6cNHhte5ocBnOTkOHYHHnhcp7FRyVDZW+JCPDbE5kRDWuY3O0dsjGT2IXOazU0rNrnSj9O6oJDhy8tLfTyB4+QRLrtF6juEjY4mSSExtmMrWFsbWuGWAknOSMcf0WFWamjY6mdDFK2nlc9wqJGe4+NjHOc5uDnHujuBnPGVL22209vbM2nDtspaSHHONrGsAHww0KNZpejbG2N09W+KOB9NFG6QFsUbsZa3j0bjJyceaCNqtR3SL21zbfI4U7oqZuGx4fM/bg8yAgZe3jHzI8pKG+GLfHNFPU1W/Y2nhiaH8NaXH75bgbwCcjnjnzzvqimIIPiHNSKs5Pd4xj8BgfkFjyWCndI2WKeqgmD5XmSJ4DiJHBzmnjtkD4jA5RDGrtQtikp/DLY2PMbpBMxzXRNLXvcXZ7YbGePJZ1qvVNc6iWGFsjJI2tkAft95hzhwwT6Hg4I9F1S6doJjN4zZJGS5D2veTkGMR4z3+6D59ySsqhtsdI2UCWaV0gDXPeRnA7AYAA798Z9UGPbrw2rudRRujexzdz4iQBuYCAcjJI5PmBkdlxj1BTyVDWeBUthdNJAKhzQI97N2R3z/pPOMfFfbTYYLZMyWGaokcyEQASFuNoOR2A5+Pn55WHb9NNbbmRV9TPJIWPLmNk9yOSQHe5nGf9TsZzjPACJKHUTppngROqQ5kZhjgZh7yWB7j7xAAAfH3xyfiAuTtSB1dSthpJnUL6Z1TNUOLGiEAge8C4EY97PHlxnnGS7T9MJfFp5ainmy79JE4A7XBoLeQRjDGfEY4K5y2CglGwskERpjSOibI4NfHgjBHn3PPflEMdmqKF0c7iyceEGODdoc6Rr3bWloBJ78YOD8FlVl5hpBTCaGcT1DS5kADd+BjPnjIyOAcr5FZYGM2vlnlPiMkLnuHOw5aMAAYz8MnzJXbc7XFccNnlmERbtfE0ja8ehyDj5jB+KJdMl8po7kyjkjmYXEtEjgA0uDC8jGd3YHnGPLOVjR6oo3U4mlhqYGPZHJF4rWt8RrzhuOeOf2sL67TFI6RzzUVXLpXAbm4b4gIdjjP+o4JyR644WXPZ4ZJjLHNPA/w2RAxkYDW7sDBBB+8e4PYeiDlLdYoqCKqfDODK7ZHAGZke7ngDOPInOcY5zjlYlXqOCkohU1NJWxgB7pGPY1pjDe5OTg/DaST5ZWTLZqZ1BTUsT5YBTOD4ZInYex2CM8gjkEjkY5WJV6ZpaprxLU1mHxeC/MgcXDJdkkgnOXHtgdhjACD5dr/4EUzaKnmkkbIynbMWZibK8tDWnkE8uGcDHlkL6dT0fh7mQ1Di4vETcNaZQw4c5u5wGAccnGcjGV3PsFO6o8Q1FV4fjipEO8bBIOd2MZ784zjPOF8dp+k9no4o3zR+zQ+A1zXDc5nGQSR54ByMH0IRCSoaqKto4KqmduhmYJGHGMgjIXcuMTGxRtjYMNaAAM54XJEiIiAiIgLErblQ0L2MrauCBz/uiR4aT+fzCy1EVdrqJblUTw1EIhqYmRSslh3na0u4ac4wQ48EFBmi4UZrPZRVQmpyR4e8bs4zjHrjlY5vtqDS76xpdoaHk+KPunz+XB5WEyxTgMjdVRmKGaWohxGQ7e/fguOecbz2xnhffs+GRPjhlawNt4oIfc+53y7vzn3ePggkp7pQU8ojnrKeN5wNrpADz2/Ncqe4UdSGeBUxSb3Frdrgckdx8wo02BrhI10jSx9VDUbdn+mNrA1vf1YDn4rg+yVLbg6tp6uNsznzE74iQN4YARz3aIwPjkoJI3a3h8TDW04fKGlg3jLg44aR8yMBZqr1Lpw09E+AVAc8mmAeWdmQ7Pd7+ZDj/wCZTtOJRBGKhzHzBo3uY0taT54BJwPxKDsREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREH//2Q==",
+          "timing": 3070
+        }
+      },
+      "cache-insight": {
+        "id": "cache-insight",
+        "title": "Use efficient cache lifetimes",
+        "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more about caching](https://developer.chrome.com/docs/performance/insights/cache).",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 320 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "skipSumming": [
+            "cacheLifetimeMs"
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "label": "Request",
+              "valueType": "url"
+            },
+            {
+              "displayUnit": "duration",
+              "valueType": "ms",
+              "label": "Cache TTL",
+              "key": "cacheLifetimeMs"
+            },
+            {
+              "label": "Transfer Size",
+              "granularity": 1,
+              "displayUnit": "kb",
+              "valueType": "bytes",
+              "key": "totalBytes"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 327939.23333333334,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "wastedBytes": 196187.125,
+              "cacheLifetimeMs": 300000,
+              "totalBytes": 204717,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "totalBytes": 43665,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "wastedBytes": 41845.625,
+              "cacheLifetimeMs": 300000
+            },
+            {
+              "totalBytes": 29956,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "wastedBytes": 27459.666666666664,
+              "cacheLifetimeMs": 600000
+            },
+            {
+              "wastedBytes": 27037.458333333336,
+              "cacheLifetimeMs": 300000,
+              "totalBytes": 28213,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "wastedBytes": 26084.875,
+              "cacheLifetimeMs": 300000,
+              "totalBytes": 27219,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+            },
+            {
+              "cacheLifetimeMs": 600000,
+              "wastedBytes": 4617.25,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "totalBytes": 5037
+            },
+            {
+              "totalBytes": 2018,
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "wastedBytes": 1849.8333333333333,
+              "cacheLifetimeMs": 600000
+            },
+            {
+              "wastedBytes": 1647,
+              "cacheLifetimeMs": 0,
+              "totalBytes": 1647,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js"
+            },
+            {
+              "totalBytes": 1513,
+              "url": "https://player.ausha.co/ausha-player.js",
+              "wastedBytes": 1210.4,
+              "cacheLifetimeMs": 3600000
+            }
+          ]
+        }
+      },
+      "first-contentful-paint": {
+        "id": "first-contentful-paint",
+        "title": "First Contentful Paint",
+        "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).",
+        "score": 0.49,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.0 s",
+        "numericValue": 3001.0598112223079,
+        "numericUnit": "millisecond"
+      },
+      "user-timings": {
+        "id": "user-timings",
+        "title": "User Timing marks and measures",
+        "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more about User Timing marks](https://developer.chrome.com/docs/lighthouse/performance/user-timings/).",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "key": "name",
+              "label": "Name",
+              "valueType": "text"
+            },
+            {
+              "valueType": "text",
+              "label": "Type",
+              "key": "timingType"
+            },
+            {
+              "key": "startTime",
+              "label": "Start Time",
+              "valueType": "ms",
+              "granularity": 0.01
+            },
+            {
+              "label": "Duration",
+              "key": "duration",
+              "granularity": 0.01,
+              "valueType": "ms"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "screenshot-thumbnails": {
+        "id": "screenshot-thumbnails",
+        "title": "Screenshot Thumbnails",
+        "description": "This is what the load of your site looked like.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "timestamp": 146776976,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFwABAQEBAAAAAAAAAAAAAAAAAAIGCP/EAB0QAQEAAwACAwAAAAAAAAAAAAACE1KRAQMSM3H/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8A6pAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE5I3npkjeegoTkjeemSN56ChOSN56ZI3noKE5I3npkjeegoTkjeemSN56ChOSN56ZI3noKE5I3npkjeegoTkjeemSN56ChOSN56ZI3noKE5I3npkjeegoTkjeemSN56ChOSN56ZI3noKE5I3npkjeegoTkjeemSN56ChOSN56ZI3noKE/ONp6oGVAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXr+yf3w1AA//2Q==",
+              "timing": 375
+            },
+            {
+              "timestamp": 147151976,
+              "timing": 750,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k="
+            },
+            {
+              "timestamp": 147526976,
+              "timing": 1125,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAIDAQEBAAAAAAAAAAAAAAMFBAYHAggB/8QAPxAAAQMDAwIDBQcCBQMEAwAAAQACAwQFEQYSIRMxByJBFFFTYZIVFjJxgZHRI1RCUnKhsQhiwSQ0guEzg7L/xAAZAQEBAAMBAAAAAAAAAAAAAAAAAQIDBAX/xAAoEQEAAQMDAwMEAwAAAAAAAAAAAQIDBBEUURIhMRVSoRMiQWEFMpH/2gAMAwEAAhEDEQA/APqlERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERARF+PdtaSgFwb3IC/BIw9nBVdyuNJb4DUXGqhpochvUmeGNyewyVgUepbHW1LKejvFvnqJDhkcdQxznfkAUGyooKd5PlP6KdAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQF4nGYivaHlBruoxUm2n2IVxm3D/2XR6mP/2+XH+6orK27/akHtQ1F0cnd7UKHp9j+Lp+f9luz4SD5eQvIieT+FB+wD+oFlLxFGGD5r2gIiICIsOquEVPVx07s73NLycHDW+/90GYi/GkOaHDseQsWqq+hWUsJDds27LicYwMoMtFV0VxlqLnUU5ja2KJ5YHYOTgD1/VQ/bEgvZozE3pdTpB/Oc9Pf+XywgukVSbq99uoZoWxdaqLR53eVhLS7n9sLFffpOix4jibiN0khe4lpDXbTtwCT78+5BsCL8Y4OaHDsRlfqAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC8PiY97HuaC5hy0+oXtEBRVFNBUhoqIYpQ3kB7Q7H7qVEELKSnZOZmQRNmPeQMAcf1QUtOJzOIIuse8mwbvd37qZEGO2hpGxPjbSwNjf8AiaIwA78wvT6SnkZGySCJzI/wNLAQ38vcpkQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERBh3S5U9thD6hxyfwtHdyozq+HPFLJj/AFBVOsHPdentfna1rQ38sfzlc81qL0XU32H1uIpnSdN23kbdvoQT3wDjK825k1/Umins9yxgWvoxcriZmeHWfvfD/aP+sfwn3vh/tH/WP4XIr3Pcm3S0mE1ppHQEzGOF/L8txuDQcHG7g8LKuAuw1JTwUzpvs+o2SSSADEOzJc3/AOfkH1LXubvLdsMfWY6Z/wBdT+98P9o/6x/Cfe+H+0f9Y/hcnt0txOrq+Oq9r9k6h6GY39Pb02+uNvfd65yodOS3/wC2TFdGymj2VD2SFuBzKAxrvmADj3ghNzd9xGDjzOnTLr33vh/tH/WP4T73w/2j/rH8LkWm6m7ziVtayra6ChbG/qx7d1Rufkt/zcbeRx2U+hpa+W2H7U9r9qDWb/aI3t5xzjcB6+7hJyb0a9ynBxqtPtnu6t974f7R/wBY/hPvfD/aP+sfwuTXKa4t1jAxvtf2cYosdON5Zu3v3ZLRjtt7qaN9b96ZW1BuIi6mIWxtHs/S6Y5eSO+/d657emU3N3ldhj+2fOnl1P73w/2j/rH8J974f7R/1j+FyeiffDfWCoDvs/2mcfhOdgb5M+m3PZR2d92+3Q2pNacum9pErcQNbu/pdM474x2Pvzym5u+6E2OP7Zdc+98P9o/6x/Cfe+H+0f8AWP4XJNMTXJ8tybX+2dQOl6fUjcBje7bt3ANPGMYKk0NJcn0dQ26e1uc1zdktS0sL+PNhpGRg/Mj3HCTk3Y17+CnBxp0+2e/7dptN+pbjJ0mh0U3o13r+RVsuV0jnsqonRZ3h4LfzyuqLsxb03Ynq8w8z+QxaceqOjxIiIupwCIiAiIgIiICIiAiIgIiICIiCqvlmiujGku6czeA8DPHuK146SrM8TQEfmf4W7ItFzGt3J6pju67Wbes09NM9mkfdOt+LB+5/hPunW/Fg/c/wt3RYbO1w2ep5HPw0j7p1vxYP3P8ACfdOt+LB+5/hbuibO1wep5HPw0j7p1vxYP3P8J90634sH7n+Fu6Js7XB6nkc/DSPunW/Fg/c/wAJ90634sH7n+Fu6Js7XB6nkc/DSPunW/Fg/c/wn3Trfiwfuf4W7omztcHqeRz8NI+6db8WD9z/AAn3Trfiwfuf4W7omztcHqeRz8Ndsum2Uc7Z6qQSyN5a0DgH3/NbEiLfbt0240phy3b1d6rqrnWRERZtQiIgIiICIiAiIgIi5T4w63utg1DYLHbK6is0VyD3y3Wtj3xxbezQDxn5n3jsg6si5JZNX6lsVsv1fqmot16sVHT9aku9AWhs0mQBG5jCSCS4c44wV70V4y2Wu0XR3bUtXHRVUlQ6nmayF/TY8ueWAHByNjRkoOsItN0/4laZv9bbaS3Vkrqi49X2Zr6d7N/TBLzkjHGCrFms7C6ovsLq9sbrGGmvdI0tbDuBI5Iwex7ZQbCi5/bvF3SFxFUKavlEkFO+qDJaeSMyxtBJLMjzcD05VFoHxotd20tV3XUcraKWGq6To4oZHNY15IjGcHJODk/8IOuoqat1Na6LUVvsdTUFtyr43y08WxxD2tBJOcYHY91rlo8W9G3etZS0N13vdDJO5zoXtZGxgJcXuIw3gE8/+Qg3xFpml/EzS2proLfaq97qpzHSRNlhfH1mjuWFwG717e4rxY/FHSl9vlNaLXcJKiuqC8NY2B4wW5zuJHH4T3Qbsi57qjU9zt/i5pOw00zG224QTSVDCwEuLQ4jB7jsvQ8X9GG7CgF0cXGb2cTiB/QMmcY6mMfr2QdARQ1tXT0NHNV1kzIaaFhkkkecNa0DJJK07TfilpPUV2jtttuD/apWl0ImgfGJgO+wuAB7H9kG7otEtfixo+6XKKhoroXzPZJISYXtbG1gcXF7iMN4aTz6JYfFnR98vMNsoLmTUzuLITJC+Nkzh6Nc4AEoN7Rc6t+tqa33nWct+1DTSW21SxtELaZzHUu7I2l2P6hJxjGeyttNeI2m9Q1k9JRVckNVDEZ3RVcL4HdMd3jcBkfNBt6LRLT4saSul0pqGmr5g+qkMVPNLTSMimfnGGvIwSl+8WNI2O71FurrhJ16ZwZUOip3yMhcfRzgMAoN7Rale/EXTFlq4aa4XINmmpW1kIZG5/VjccNLcA5J9AOUtPiJpi6aZrL/AE9zY22UbiyoklY5hjdxwWkZycjGO+UG2otO0t4laY1NVz0ttr3NqIYuuY6mJ0JMfq8bgMj5qKw+KWkr7eo7XbrkXVMrnNhc+F7I5i3uGPIw4oN2REQEREBERAXLPGCtrKO6WsXXTMWoNHSNcKtsVKZqiCTnDhzwORyPceey6miD5u0LYZ59UanqtHWS72nStRaJYvZ61rmionc3y7GuJ9e3Jxz78KqoKWruvhroOxusl069qvsba1ktG8N2PkkcT25aARk+mV9TIg474o9exeK+i9Sut1bU2mkiqIJ3UcBlcxz2OAy0f6h+xWi19gv2qaLxXlo7RcaWSvmoammgqIjG6eNjnuIGe524OBznA7r6cRByTTeqDqO82Wio9D1cLqWjcyorq+m6PsRDcBkZI82TxgEdx81y2koLrUeBtxsEdlugutruTayWJ9K4b2F5/B/mI7kD0X1aiDhpudTqvxm0bd6GzXentdPSVETqiqpXRjeWOyDnsOWjJ7nOM4VXorR90q/+m282mCgmpbxUyySCKWMxySbXtOMOwfM1uB+a7BV63stLdb1bpZZvarRS+2VTWxE7Y8A5B9TgjgLxb9d2Svudlt9PLP7Td6U1lK10RG6MAkk+48HgoOMaOpKu9al0ZBO3VMs1nj3OFVQRU0NFhoBZuDAXtOMd89veVvH/AE4Wie2aNuPt9DNS1Ul0mfieIseW7WgHkZx3/wB11hU1g1HRX6quMVuZUOjoZzTyTvj2xvkH4gw/4sep7INA15Q3CTxs0ZW0dDPPDBR1IdIIyY2uLHbQ52MDJx3XHtRjUV90i6Ovo9Rm7Q14kltdLbOjRUzNx8wDW5e45GDknk/mvrlEGleMFmrtR+GN5t1oa59ZNCx0bAcF+17XFv5kNIWn6S1M+7VGlbRBoWtFRQU3Sqauvpei2h2sAJjcQc5x6Y9P07KqSq1PbKbVlHpyWSQXSrgdURMDCWljc5Jd2HYoOM6G0jc6vwD1Na4aGalu9XUzvZHNGY3yYLcDzY4IaQPTlV1wfWay0nozSVo0zdKC6W2ogNTU1FIYoqURtIe4PPfJ83z/ADX0kiD5zuNgqaiv8VxX2C619LU1dM+JtMDFI8NLj1IiWkO2nBwMr1oBmoX6oloqZ161Bp19ulZUm8URppWZa7bC2V/OSTjg45Jx6r6KRB8r6ep7/ablZqbSQ1KHCsaJbJd6EyQUrNx3OExAaBj1aAef3ytbS6hu/wB9LfcKS/U9SZ3+x26128Np6mMHiSWUNzJwM9+fT3L6eVfdbzbrTLRxXGriglrJRBTscfNK8+jR3Pf9ERxfRtorD4l6Bqqi3VbYaXS0UT5ZIHBsUoYWlpJHDuTx3Ws3zSV8r7P4hNobXVPLNRMrmU5iLfaommTdsBHmHmB49y+nkRXFrjeKjxAbdLfZNHVdJI+zzQfalwp/Z5IpC1wELMjkEnHBHcrSdK2+vuDtF2Oth1Uaq2VTJXUz6CKCCiMZ5f1dgLmnn1yfmcL6fRAREQEREBERAREQa74jVU9DoDUdXRyvhqYLfPJFIw4cxwjJBB94K4ZW3DUlh8NtNa+bqy5V1bLLE2ailkBp5IzkbNv+bjlxyc5XdvEGhqbnoXUFDQxGarqaCeGKMEAve5hAGTx3K0DQfg/aIbLp6pv0FcK2kijlkt8lUXUzKgDl+wEjOe+DgoKumF88RNc6wgOprnYaOxyimpaeik6ZJ839ST/MCW5x8/TCo7Nr7UF3pfDl9TXzMlkvM1BVyRHa2sYwx4cQODw7H55XUtUeFun9Q3ua6yyXGhrKiPpVTqGpMIqG4xh4HfgAKe8+GenLnpu22VsE1FS22QS0klJKWSQu9SHcnJ7kn15QaBrDUl3p9f8AiHSUtzqY6eh08aiCJkhDYZdjDuaPQ89/mto8ErZdpNPUOor1qG5XKouVGw+zTvzFEM8Fo/zYAyfXlZ1H4U6epZLpIJLlLPc6J1DVyzVJkfIx3dxcRndwOf8AZbdp60U1hslFaqHqey0kQhj6jsu2jtkoOJX2qnovE/xUqqSV8NRDp5skcjDgtcI2kEfNUUTLhqPWfhc194qqOsrbE4y1sbh1jxIXbSeziBjPpldurtBWetu9+uUxqvaL1R+w1W2QBvT2hvlGODgd+VVV/hJpuujtDZXXBrrVSCjpJIqksfG0HIduAzuB9f8AZEcmvut9S6Jpdcafp7rV3M0E9PHSXCpPUmgEvJDie5xwM+qvtFV2pLTqiOki+9dRZaqgldUPvjAHQzBjnNkjIJw0kYx810W1+F+maDT10tDqaarhubg+smqpjJNM4HIcX+8HkY9eV5054Y2Sx3F9c2ouddV+zmkilrqkzGCIggtZntwUHHbJd9U0Hg5Pr6o1Nc6qu2PpKelkfuhYHTCPqOH+J48xBPy9yvND3DU9v1RZ2sk1bWW2upZPb3XqMbGSbNzZISHEhuePyx39Or2nQ1ktuifum2B9RZi17XRzv3OIc4uPIx6ng+nCq9N+FtisN1iuEc9zrZ6eE09L7bVGVtMwjBEY9ODhBqH/AE+U18v9opNUXvU11q9r5qdlE+T+i5oONzh/idnOD+SytWzMpv8AqI09PLK2GOKyVD3SP7MA6hJPyC6JovS9v0fYY7RaDMaSN7njrP3Oy45POAobro603TVNPfq1kslZDSPogzcOm6J4cHBzcc/iPqivnmt1Pe6B9p1Bab/qq4Qz3NsL6ysa2CgqGlx8scO4nsCM/I9l3bxep7tLoK4z6drKmkudG0VUToHlpeGcuYfeC3PHvwqQeCmmfY46R1TeXUsEvWpoXVriymdnJ2NIwM/MErppaHMLXDcCMHPqg4VS6/uOrtTUVdZaiVlqstkdc7hBE8hs1Q5hLYXY74IHHyK1PTepNY1FvtGpaSfVtfcais3VEL4mm2yQ73AsjGeCAO4HfPuyu8aJ0HYtGwXGGywPayvk6k3VdvyMEBo4/CMnA+ZVHSeD2mKW4088brkaKnqPaora+qcaVkv+YM/+0Ro0Y1BqbUfiVT/em70FJaJS+lipZduHbXkDPcN8vYYzn5LVLk+56stPhNcLlea5tZWVb6QyxuALC2XAlbx+PGBn5BfQts0XardW6iqqc1HVvp3Ve54I7EeXjj8R96pKvwn09UaYtFjElwhgtUzp6SeKo2zRucST5gPefd6BBym83zUd61Tqungr9Wt+xHCloW2hjTEHtBG+oyRncW5/In3Lu2gK+5XTRtpq75A6C5yQj2hjm7TvHBOPTOM/qtdvfhLp+61UlSai60k1RAynq3UtWY/a2NGP6oxhxIHJ9Vu9pt1JaLZTW+3QiGkpoxHFGOdrR+aKr9K2arstPWR113qrq6epfOx9QOYmnGIxyeBj/dXao9J6YodL09bDbX1DmVdU+rk68m8h7sZxxwOOyvEBERAREQEREBERAREQcIvVDcL/AOMWvbJQ1j4ZJ7A1sG6RzWMkJhweO35gequ6fVt10ybVoix2j7wX6222OS4PNUImMw0dnOGXEk/7j54vLRpO5UnjRe9Ty9H7MrLcyliw/L94MectxwPKVrHiF4aV1br6o1LbbRab7DWUwimorhK6PpyNAAewj5Acfn70RaVPi5HHpC06ngs80tomqPZriRJ/UoHhwBJbjzD55Hp716pfFynl03f9SyWyVmnrfJ0aSp3+eufnb5WkDaMkck/8FU9R4e6mk0DbdKUzbTQU9bUda8zUYLGtZkeSNvO4kAZPHYeix2eFmoHaH1Bomerp5LMJRUWaqe8l8ZDt3TkbjseeR2JJ9wQbHZ/Eq4i7R23VGnHWiqq6KStocVLZWzBjS5zHEAbXY9FrzfHCvbp236jqNIzMsE8/s0lQ2raXh+T+BmMuHHc45yE0p4cXiG8ipq9O6atEcFFLEH0ZdJJPM5jm7gT+Ac8jn/fiOp8MNQSeCdo0s0Uf2pS13tEn9XybN7zw7HfDgg2W1eJdxOpq2yag02+11bLc+504NU2XqRtzw7A8p4Pv7FUlP4z3N+mqXU0uj52abMgiqKsVbS5h3bS5rMZc0HjPHPCudaaVuMviFUanZ0fsyHT09G7L/P1D1D2x2wRyubaG09rTVXg1btPUX2S3T9c8udWSPcJoWCYlzNnYnc0kH3HHzQbVS6pprP4w67vFbUyvtNLaKapa1riQQWR42jtkkgfqr7TfihX1d3sdPqHTjrTRX1pNuqRVNl3nALWvaAC0kEY/MfpVXDworLhqDVrXyww2m5WmnoaSXdl7XxNjALm47Zj9/ZYGh/DO8UF+sTrjp7TVFBbMOnrYC6Wape3G1zQcbHZGSfmfyQdJ8SdZw6KscNWaSSurKqdtLSUkZwZZXdhn0HC5fLqi6u8cLBLqi3S2P2S11E08IqBNE5gZI7eC3g4wR24IXQfF3SFfquz259kmgiu1rrWV1N189N7m/wCF2O2eP2Woz6G1bqrXdJetVxW2jojbqi3yQUkxe6Nr43t3ZI5JLyfkAEVmW3xfqpvsy53DTclHpa51XslNcTUtc8EkhrnxgZAJB9fQ9/XcPFdl8k8P7w3SxlF2MQ6XROJMbhu2/wDdtzjHPu5XJtP+EV6oZLZbaqw6YfBTVG6e7uLpJZ4gSQOmcYd88+gXY/EGx1+odKVlvs9ymtlwcA6CoikczDgc4JbztPY/mg+ftHVmnm6gsbLbftQ6Z1GyVntcN33SRVZ43MPIAyeATjv2yu4WPW/2pqfVto9h6f2CGHq9TPW3NLu2OO3zXP79o/xC13DaLXqunsVFR0U7JZq6B5fNKG8HaPTPu45wrao0jq60691RXaeits9u1DGxrpqmZzXUrgzaTtA83cnHrx2REEnjVL93dMXKn07JUT3yeenjpmVA3NfG5rWjJbzuLh7sLTNa3LVGpvEvTVuv+mammb7PJILXFdQwS43ZkL24A24zj1x81sNh8LdQ0Vu8O4JxR77FcJ6msxNkbHva4beOThpW8X3SVwr/ABfsOo4+j9l0dDNTzZfh+5weBgY5HmCDXD4xTtpqm70mmpptH0dUKSS5e0tEmAQ0vERGS3JHr6/njr8MjJoWSxuDmPaHNI9Qey+dofBy9Wz2i2Ulk03cIJKvqQ3asLjLHCSCWuj9Tjjgr6Ho4G0tJBTxgBkTGsaAMAADHCKlREQEREBERAREQEREBERAREQEREBERB5ljZNE+OVjXxvBa5rhkOB7gj3KC20FHbKOOkttLBSUsedkMEYYxuTk4aOByVkogIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIjjhpKqI6qsxHI/8DiMjYAMEgd8rRevxamImJnXhlTT1LdFh3WqlpKYSwxtf52tduOMAkDPz7qOlrnzXSopv6TmRDJLCctPHB+f5duPet7FYIqGW7VTaWvn6TAyCQxs8vfD9uc5/hJLtUU1LTOc1srpgY2OIxmXIDQcEjnn9kF8ioG3qo9vngdEzbGJcOIIzsGeDnnv2XqlvE89c6EsjaxrGu7dyWB3+b5+4oL1FT6fus1yEnXjazaxjxgYPmGexJyPn6rHkvcrYJ5GincGS9Nrw47eGuJ//nGfUlBsCKjmvUkbqgtjje2KnM5YHHc04BAP55Pbtj5qxtVUayjbK8NDtzmnb2yCR/4QZaIo6mQw08kgGS1pOEJnRIiwI5J4qjbI8vBcG4LcA5Hcfr6cqO83J1BLSsawESk7nH0Ax/vyrMaMYq1WaKlv13lttRTxxxNkbKx557hwwGj9SQFA++VDaeKRtO2RzmQPLG9zv3bgP24UZNhRYlpq/b6COpwAHl2Me4OIH/Cy0BERAREQEREBERAREQEREA8rGbQwtLSN/BBALzj/AJWSiwqt01/2jVYmY8PxzQ4YcAR7ivLYYmSOeyNjXu7uDQCf1XtFmjyYoyxzCxpY7kgjgr8bDE1rWtjYGtOQA0YB969og8GKM92NPJPb1PdefZ4d4f0Y944DtoypUQeWxsaQWsaCBt4Hp7l4FLAGOaIIg13JGwYKlRBH0It7n9Jm9wwXbRkr2xjY2BrGhrR2AGAF+ogIQCCCMgoiCGKlijeHNByO2XEhv5Z7KR8bJNu9jXbTkZGcH3r0iJERHh5fGx5BexriOxIzhfgijGMMaMYxx7uy9oivxjWsaGsaGtHoBhfqIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKGSqhjeWucQ4d/KT/wCFMik6/hY0/KKKojlJEZJI97SP+Vpk1xuTLfJeI7lK4OuPQgoyyPpyR9YRbfw7skAuByt4VNb9M2i3zRy0tJh8eTH1JXyCMnuWhxIaeT2Vj9pP6U82tOlNVAUbZYWQSzwOilLjJsc1oH4Q3zF7cYc7vypqvVFVS09WZrfE2WnqGwvPWc6NjTGH7nEMJGMtB4IBI5xyrGDS9ohxspOG4DQ6R7g0BzXhoyeGhzWkAccKarsFtq3PdNA7e97pHPZK9jiXANdyCDghoBHbgIMC/XuSls9tqg7oGokY+TaRJtja0yyYPY+Vjhke/hYlPq6olo6mb7LkD2RxyxsHUOWudgh3kzlo8xDQ7jOMrY5LbRysgZJTxujgaWRsx5Wgt2kY7fhJCwm6btbacxNp34LmvD+s/qNLQQ3D87hgEgAHjJ96DzHepJNMm6x0zZ5Npc2GCTeH4OBtIGSPXtn5Z4VdS6pqa2JgoaGnnnEbp5MVW2MMDi0YcW53Ehww4NwWnOFeOtFC62soOhtpWEFrWuc0tIOQ4OBznPOc5ysY6atJEI9l4i7f1H+fzbvPz5/Nz5s8oKe46y9lqqiMU0boGMnLJGyFxJiYXEkbduMjHDic4yF5tWq5RJBTVVPJKyI+zVFVtduMrGEvdtDNu0OBHfOfRXP3YtHUe80hcXbxh0ryAHnLgBnABIyQFkxWaghuDq2ODFQXF+d7i0OIwXBudocR3IGSiKyq1VTMiq5qaN01PTUTqtzzlhJ3FrWYIzyWu5+SjZqaf2yNslA1tJJUyUjJBPl5kYxziduMbcsc3Oe47K1uFkt9wqRPV0/Uk2tafO4NcGkubkA4OCSRntkrCtmlrfSwObUR+1TSCTqvkJ2uMhJeQzOATnBI5wivemb5Jd4Kl9RTspTCQHN6hJYSMlrw5rS1w/LByCCVS0t3rKa5g3OvmjY4zTx7mRmmqIAHFvTeAC1wbtJ3H0PccjardbKS3RyNpY3DqnL3SSOkc7jAy5xJPHCwYtLWaPqAUYLXRuiDXyPc1jHd2sBOGA/9uEFTT6xlkZVMkoomVMRiDG9V+1xfuODlgdkBpJ2tdkdlFNfa+5W+hrqNtRFTtMvtkNHsfOAHFjXtD28syx/oHduOCFeDTFqDC0QSbi8SGTrydQuDS0Hfu3fhJHfsUl0xaZIYYvZTGyFhjYIpXxnYTktJaQSM+h4VGVYZnVFmo5n1TasyRh4nazZ1GnkHb6HGFqrtYTUdG+odGyraZJZcF5aWxdUsjDQ1p5IbkF2B8/dttDboKIyinBbG8NaIwfKxrWhoa0egwFgv0vZ3dIGkw2NjI2sErw0hhyzIBwSD2JyVBLd7nNS1FNS0VMyernY+UNll6bGMZjcS7B9XNHb1VYNS1klQYobYzcZm0zN9QBulMYkIyARho3ZP/bwDni5ulooroGe2xF+wEAte5hLT+Jp2kZacDIPBwvMtkt8lMYDT7Y+sZx03uY5sh/xBwIIPJ7HtwgoTqieR7jHSSGeljm60EUgcxz2yiMc7S4jh7hgZw08EpJq+ZtNQTMooHsqC4GQVB6WQ7aGh23hzucB+3kEd1cnTtrMXTFKGDaxoLHua4bHOc0hwOQcuccjk5OV5GmrSDFilwI8cCR+H4cXDeM+fzEnzZ5JKCoqtZinqqlppWSU0cU8jJI5S4u6Qyc+XbgngYcTkjIU41LWe1+wm3RivfIxkUftGWeZhed7tvBa1vIAPcYWczS9naXH2TIcHNw6R5DWucHFrRnAGWg4HCyKyx2+sMpmgdvkk6znskcx2/ZsyHAgjyjHHogpDq6UVrKb7Nc5zHRMqNj3P2ufjhha0tdgODiSW8FZ+ob7PbZ3xUtJHUdKlkq5nPm6YYxpHHY5J82PyWUywWxlTFOyla10Qbsa1zgwFow07M7SQOAcZChq9O0ldd566u3Tb444mx7i0BrS4kHB8wJdkg8cBBWwayZPXhkNFIaLqGJ0xDg4ODSScbdu0EYJ3ZznhRXTU9a+gpmW2ljZXVVPTyjqycRGaQMaD5Tk/iP8A8Sr42K2mrkqXUwdJJu3BznFmXDDiG52gkcEgZKii01aomgMpnZDo3bzK8uzGSWeYnPG4/ocdkFw3OBnGfXCIiAq+rvFHSyzxTPcJIunloaSSZCQwD35II/RWCqauxU9Vem3J8kglZD0msGNoI3bX9vxAPeB6coKul1hA+okbOx3s7Y2yMmYx2JN8jmxsaMZJIbn9/RXMN5opbXLcDIY6eHcJS9pBYWnBBHv/AOfRU7tGUZgEXWkcxhgdE2RjHhhiZsHBHIIJyD6kkYVh93qYaefaWPcyNx3mRjWtO/du3YAx3A4xjHCDCbqyD7TqYJIZo44xGxjHROEr5XBzi0N9waGnPzWczUltfC+VsziGsjfjYcnqOLWgD1O5pGPeFXz6PgqHmapqpJ6szunMs0UbxlzGsI2kYwA0Y9Rj81lwaYooK2hqGukxSQCFkfAa4jOHnA/ENz/l5ifciPJ1baRHPIZpBFHE+YSGM7ZGNIDiz/NgkfnkYyvNTqijjBcHuiEMrm1Amic1zWtiMpIH+nB59+O/Cx6LRVBSxNjY87GCNrNsUbTtY8PwSG5dnaASfQfmp6zSlJVzVEks8/8AXMhkAxg7+mD6f5Yg38iUFg680zLdHWSNnZHK4MjY6IiSRxOAA3vz/wAcrXarWbmU9bPDT7mxOlbDE5jg+TZ02c+7+q/b+QWyXi2i4x022d9PLTTCeKRgBw4At5B4Iw4qqg0hSx7N9VUzFrmOJeW+YtmMxJwP8Tjz8gEGDQauldVSi4CKnp4XvY4mF4c/YwF5b37Pc1uP/JAWZdtVMp6N76WJ4qWNld0KiJzHO2MBAH5ufH+59VLLpOkkjIdPPu/qFruMhz5mzF3bnzNb+gwv2XTLKmZk1bXVM8zSCXHAGOq2TAGOBljRj3D3nKDKoL/RVdY2kjkc6UlzA8MPTe9v42td64wf2PuK/K69x0t4pqMhwY94jkeY3YDnDyAO7cn/AJ7j1gsulqO1V3tMBDi3eIx0mAt3uycuAy4+gJPZRu0pTPvguT5nukbUe0hpjZndtLdpfjdtGcgZ4KKzbpf6K2VLoKnrF7IhPIY4i4RxkkbnEdhkH9iq+TVEcd1dC4xupGmUFzGuL8tdGwMA9XF73AY935r1VafmuF2uc1VUvjpKkRQmKPB6sTBnBOMjLnPBx3CDSVM1xkiqqhkwc17H+U7XCV8ucYwcuec/IBEftRqyjiqKaMxzNDnyioMrCz2dsbNzi76mfo7KlGqrb0tzvaGvL2MbEYXb3F+dmG4zg7Xfsc4UE2kaaoMxnqp5H1EM0U7nBuZOrtye3GAxoHyGFNbdL0lFUxVAcDLHN1vJEyNpPTLAMNA4Ac4/mUGZc73S24U4qGz9SdrntjZGXO2tA3HA92Rx3UU2oqCGtFNKZmEktEjonBhcGl5AP+kE+7j3rzqGwR3va2eplZFgAsa1pwQchzSRlrvTcFWzaJpJqieZ9TLuk6+HBjA8dUOBy/G52A4gZPARWbHqy2PpnzB07WNZFI0Phc0vbKdrCAfeQR/9LPN4pGWr7QlMscGduHxuD927bt24ySTwB6+ixKzT0M8lRIyd8bphGxzdrXMLGNcAwtIwW+dxwfX8l+/d+BtipbZHPK1tK9kkUpwXBzHBzeMYxkdvdwg81OpqKmpevPFWMa3eZGmndmMN/EXcduR+fplRXHU9NFJDDRh80klTHT7zG7p5JBcN3vDMn9FjXPRkNzaRW11RM58LonvkYx7uXOcSzIOz8WOPQAeimn0pFLK7/wBdUsg6k00cLQ0CN8rXNc7OMnG9xGe2UR6brG1OgZMDU9N0XXz0HcRfEI/y/P1wcZwtiBDgCOQeQtcuGkaGsqY5XYa1sMdO5piY7LGEkAEglvcg49D+S2MAAADgBFEREBERAREQFjVFfSU1RDBUVUEU0xxHG+QBz/yB7rJWuVdnrX3yqnjFG+mqjEXyTZc+IR5w1rcYPm8wORgk8HhBbtutvc6oa2upiaf/APMBK3+n/q54/VeILzbKh7GQXCkke/Ja1kzSXY7459Fq40nW1FLRU9b7EyKlhjpS2JzndaPqRvkc7LRy4R428/iPKlrtK1c0Uxgkpo55J6moLuR5nxuji9P8LHc/McIjYo75apHNbHcqJ7nODGhs7Tlx7Ac91kOrqRrA91TCGHd5i8Y8v4v29fctcfpX+tJ0W08cJlpGsA7tggIdt7dy/P6YWAdJ3KopIKasfR9KKF1OdrnHqB8rHSvPlGC5rXDH/d3QbnSVlNWNe6kqIZ2sdscY3hwB9xx6qdVFqt9RQ19bJtg6NVOZDtcQWNbGxjGgYx/hJPuz6q3RRERAREQEREBERAREQEREBERAREQEREBERAREQEREBFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14fix/UE68PxY/qCCRFH14vix/UFIg5UiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiCSm/9zF/rH/K6iiIP//Z"
+            },
+            {
+              "timestamp": 147901976,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAICAwEAAAAAAAAAAAAAAAUGBAcCAwgB/8QAThAAAQMDAwIDBAYIBQEDCgcAAQACAwQFEQYSIQcxE0FRFCJhcQgVFjKBkSMzUlRyk7HhNDZCocEXNWLRJCUnOFNVc4KU03R1g5KytPH/xAAaAQEAAwEBAQAAAAAAAAAAAAAAAQMEAgUG/8QAMREBAAEDAQQGCgMBAAAAAAAAAAECAxEEEiExcQUUMkFRsRMVIzNSYXKhwdEiNIGR/9oADAMBAAIRAxEAPwD1SiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICL45wa0ucQGgZJPYKvRa40rNcPYYtRWl9XnaIm1TCSfTv3+CCxIhIAyTx6qunXGlm1/sR1FaRV52+F7Wzdn079/ggsSICCAQcg+airzqG12V7G3Wq9kY/GJpY3CIfOTG0fiUEqioXWuq/8ARJf6mjn4NO1zJYn9wXN5BCljq/T1mpKCmu98t1HVOhj/AEc9Q1ruWjkgnhBZ0XXTVENVAyemljmhkG5kkbg5rh6gjuoW76x03Z6sUt1vtspKnOPCmqWNcPmCePxQTyLqpKmCsp2VFJNHPBIMskjcHNcPUEd12oCIiAiIgIiICIiAiIgIi+PdtaSgFwb3IC+CRh7OCi7lcaS3wGouNVDTQ5DfEmeGNyewyVgUepbHW1LKejvFvnqJDhkcdQxznfIAoLKi6Kd5Pun8F3oCIiAiIg1v1wnmfZ7HaGzPp6S8XWChq5GHafBcSXNz5ZxhWOr0LpiosLrQ+y0DaHYWBrYWgt4xuDsZDvj3WZq7TtDqqxT2u5td4MmHNew4fE8cte0+RBVPl0XrOpojbKrXj3W1zfDe9lvY2pczsR4m7vjzxlBRDfblP0Po6F1bKWSXgWR1e12HPpvFLd+fi0bcrbjNA6VbY/qkWK3+xbNmDC3d2xnd33fHOVzm0TZJdEjSppiLS2IRNaD7zSDkPB/a3c59VWm6J1oyk+rm6/l+rQ3ww429hqdnbHi57488ZQQ3UGqqdCdFDT6dvE1WY5W0bK5zw58MbnkEbh5tHug9wti6f05bLfpxlujiFRTzQhs75j4jqjI5c8n7xOV127RtkotHt0yKRs1p8Mxvjm94yZOS5x/aJ5z6rFdp66Wyyiz6Yr201Ns8NlRWvdUSU7e2GN4zjy3OOEGlaeeWn6RdULA2V81us1c+no3uOdsfiD3M/DH+63PonSlmo9J0kZpaaudV07JKmpmYJHVTnNBLnE9wc8DyCjx0zoKfprXaSoKmSP20F09ZI3e+SQuBL3DjOcYSPR2o7TSewaX1THRW0N2xw1VCKh1OPMRu3Dj0Ds4QVTT9XNpD/qjarIS6gs8XtlDF94QPfE57mD4AjOFaelmkrHDoa21L6Olrqq407amrqp42yPnfINzskjkZPZTWi9HUembPVUhlkr6mukdNXVVQAX1L3dy74Y4AVdotBah0+ySi0hq32GzlznRUlXRNqTT5OSGOJBx6A5QdHT6GOwdT9WabtY2WZkMFdHADltPI/Ic1voD3wtoKs6I0jBpeGskfVz3C6V0njVldP9+Z3kMDgNA4AHZWZAREQEREBERAREQEREBcJxmIrmh5QV3UYqTbT7EK4zbh/gvB8TH/AOr7uP8AdQVlbd/rSD2oai8HJ3e1Ch8PsfveH7/5K7PhIPu8hcRE8n7qD7AP0gWUuEUYYPiuaAiIgIiw6q4RU9XHTuzvc0vJwcNb6/mgzEXxpDmhw7HkLoqKoQ1VNCWjExd72cYwMoMhFH0Fe+rqqmMwhkcT3MDtxJcQcemP91iC+u8eojdTgCKQMad/3v0gYT28s5QTaKLrrt7NUvjbEx7I2tc8mTa4hxI90Y97t8F9obp7TWmAxtY079p3EuO1205GMD8ygk0REBERAREQEREBERAREQEREBERAREQEREBERAREQFwfEx72Pc0FzDlp8wuaIC6p6eCoDRUQxyhpyN7Q7H5rtRB1R00EczpY4YmSu+89rQCfmVxNFSnxM00J8Q5flg9/wA+fVd6IOkUlOPDxBEPD+57g935ei5NghbK6VsUYkd3eGjJ/FdiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgiLzfYLa8RbTLMRnaDjHzKiPtg79yH83+ygb3v+tqvxc7vEPf08v9sLX+p6TUUur7ZPa3VQtbGxifwpmhufEJdlhI3e7gfjxnGF5dWpuVVzETiHv29DZptU1VUzVM48e9t77YO/ch/N/sn2wd+5D+b/Zakoae+t6h3CapZVusj2t9nf7S3wmnwwHZjznl2ecd10aet+pYda17rlUTvscZkfTOdMHCTeW4aW5z7oz3C59Pd+Puz3O+p6fPu5447/8AvHg3F9sHfuQ/m/2T7YO/ch/N/stL6cpNTR2jUcdxZWtrnsk9jkkq2vDid+3YAfcIy3v8PRd+nqPVDdPXyC7TSfWMkeyjkMoPPhABwIJ2ndyfjkqZv3Yz/PyI0mnnHs538/23D9sHfuQ/m/2T7YO/ch/N/stKVFJquTRlxaz2sXaSpY6GMVLRI2MbNw3bsDOHefmrlY2zts9G2rZLHUCJviMmkEjw7HOXDufiuatRdiM7Xk6o0WnqnHo5jd815+2Dv3Ifzf7J9sHfuQ/m/wBlqPS9PfotV3t92jrDQvkkNJI+qa6IMLhtaIwSQcZ59OFhaFpNWwXqZ2onVLqcxu3OfUMfG5+73djAMtGPiPkpm/d3/wA4+zmNJp5mI9HO/Pjubp+2Dv3Ifzf7J9sHfuQ/m/2WmtNUeqYtaV811fObM6SoMDXTBwAL2+HxuPGM44459ViaRo9axauklvc0jrYTLv3Sscx37GxoOW/kOFPpru/+cfZEaXT7vZTvnHf/AN4t4fbB37kP5v8AZPtg79yH83+y1LpynvsWsbzJc46w217nGlkdUtdEG5bhojzkHvz810aRpNSw6sus15fVOtjw/wADxJmluS8bdrQTjDR3479lE37u/wDn5Oo0ennHs53z827bdqmConbFURGDccB27Iz8eFYlqZbQtu/6vpvF/WeG3dn1wtOkv1XMxV3PP6R0lFiaarfeyURFteYIiICIiAiIgIiICIiAiIgIiIIi82KC5PEm4xTDjcBnPzCiPse799H8r+6tyKivTW65zMNVvW37VOzTVuVH7Hu/fR/K/un2Pd++j+V/dW5Fz1S14eaz1jqfi+0fpUfse799H8r+6fY9376P5X91bkTqlrw8z1jqfi+0fpUfse799H8r+6fY9376P5X91bkTqlrw8z1jqfi+0fpUfse799H8r+6fY9376P5X91bkTqlrw8z1jqfi+0fpUfse799H8r+6fY9376P5X91bkTqlrw8z1jqfi+0fpUfse799H8r+6fY9376P5X91bkTqlrw8z1jqfi+0fpXLdpaCnnbLUSmfbyG7cDPx5VjRFdRbptximGa7ervTtXJyIiLtUIiICIiAiIgIiovWrVtdovQdTdbVEySsMrIY3SN3Nj3H7xHn2/MhBekXk7TPU7qZXy01TT3W23OOSQb6MCn8Zrc4P6MbXn8MqWl6sawg621Fna6pqbVHcZKZtsZTx73MGQCHbN2P9ffsg9NotG3P6Q1ut99ulslsNY99FLLCHMmB8RzHFvAxwDj8F22Pr/RXW+utgsFVC9sM8pe6oaf1UT5CMbfPZj8UG7UWlrH9IGy11iu90rrZVUcdAYWNjEjZHzvk34a3gAY2E5K5aQ6/2TUN8gtclrrqKepdsgc9zXte8/daccgk8Dg8lBudF5h6Q9W9XXbXU1HepKi5UHgTPMDII2ez7cEPcWsBwMbefNwVttv0g6Gusd4uTbBUsbbWxOcw1DSX+I/ZwdvGO6DeKLQVT9JG3wU1HMdO1RFTGZAPaW+7h7m/s/8AdUtP9IGw09mqK+a21zXCqdT00Axuna0AmQ5xtbyPU8oNzotLWP6QNjulBc3m2VlNW0dM6pbTyPbicN7ta4djjnkdk0n18t+o7vbLdBYqyKetqhTkmUObEDjDycepPHwQbpReYfpU3672rWVpitd1r6KJ9AHOZT1D42k+I8ZIaRyr1qLr3p+xX2stJo6yqfRse187CAx0rW/cHnyfd3eR+HKDciKg9JepNP1FprlNTW6WhFE9jCJJQ/duBPkBj7qqurfpBWGw3+qtdNba24eyyGKaeNzWM3A4Ibnvg8Z4QboRaTv30hLLb6C1VlDa6qthro3PIMrY3Qua7BY4YPPnwexCyP8Ar7YGWavuNRb62NkNQKemi431OQTuAONrRjnPqEG5EWj6HrpaNT2K/wBJDT19pucVuqJ4DuaS7ZG53uO8nADIyPJVbo51Rj09obUFz1LXXa5+DVwxQsmk8Rxc9ryGtLjxwwk5OOOB6h6ZRaQsP0irDcKsRV9puNDG5j3tmy2RuGtLjnsew8s8rFp/pKWSWr2usN0bS7g3xg5hIz6tzj/dBvlFpW+fSG07bbtcKGCgrasUoc0TtIaySQHG0dyB3974fHKjpfpHUEdopq86dqi2eeWAM9pbkFjY3Zzt8/EH5IN9otRaZ66WO96rorE63V9JLV+G2KaUDbvewODSODjJwDjng9ioy/fSL0/bbzUUVJa66uggkMbqljmta4g4JaD3GfXCDeCLU2pOuumrRYbTcaaGrrpLlGZYqdgDHMAcWneSePeBHGexUp0u6sWjqBVVNFS01TQ3CBnimCbB3MyAS1w9CRnOO6DYqIiAqR1htF+vWjnUul208lcJ2PdDUbTHNGAdzCHAtPccH0V3RB47Z0a17db9SvlsFFZWBzd9RBURhjMHO/a17jn+EDsrjqrpnre3dX/tRpemgrY3zidkz5WDwyW7XB7XEE+fbK9JrrkniicBLLGwnsHOAQee+m/TzVNo6411/udq8G0y1FY9s/jxOyHl207Q4u5yPJR2qOlGsouqd3vlipaSpo6w1MjJZJmgNE0T2uaWkg598geWcE8ZXpdr2vJDXNcRwcHOF88aPxNniM3/ALO4Z/JB5HsfRDWU+kr7SVtvZR1hmpqilZJURuE+wTNc3LXHBxIDzhXbROmOp9VqmxSaloLXRWy3NjjMj4KWSQxx8hrS3c4E+oIx3XoF08LZNjpY2vP+kuAP5Lj7VT8/p4uO/vjhB5s0d0u1vpPqZUz0dNTy2er8SnmrfEYR7O9wJ90kODuB5Kt03RvqBbbPqG3Q22kmhqmxNBbUMzNslDhsy4Y8yd2PQcr1yyoheQGSxuLu2HA5Wqr91ibaeqsWizZDKX1VPTe2e1bceKGHOzZ5b+2eceSIaKr+jGvpaG1RssBL4YXNkHtcHukyvd+36ELdX0genV41jHZ7hpzwn11uLgad7wzeCWkFrjxkFvmR3WNWdeDTUt7mfpKvjFtkawePN4Yky8N5O07Xc5xzxnlbA6ZazZrjStPefZBQGaSSMQGbxD7pxnOBn8kGk6Dp51DuNv1DUXq3W2nmno5IoqdrIHTzyFu0fpuXAY5yX/Dsr39G/SF80hp27U2o6D2OeeqEkbTKyTc3YBnLSfNX3WF/rLLBAy12ioulfUEiONj2xRtxjl8jjho5+JKmxUsbDG+ocyFz2g7XPHB8xnzRLQH0junuqNX6qttZp21msp4aIRPf48UeHb3HGHOB7EKFvfSrXtBqfVf2djpZbXeoZjJK58eXNcS/wsOOWuLvdz288r04yWN5IZIxxAycEHASOaKQkRyMcR3DXAoNN/Rr0Xf9HUF9j1JQGifUywuiBljk3Bodn7jjjuO6pFd066jaX1RqN+kaKjr7fd3PDpZDC79G5xcAWyEcjODwQV6YFVTkEieI45Pvjha/6w9Tm9OI7S82o3EV5lAxUeFs2bP+67Od/wDsg0trvpNr26W6w4ttJWVkcMhqBSez07IiXcNwC0OOAMkDz+C2d1y6dXbWFgsMtj8H6ytWf0Ejg0PDg3OCeMgsHfjutm6bu7L1py03V0Yp/rCliqREX7tu9gdtzxnGcdlIRzwyOLY5Y3uHk1wJQeZ4+mWvtSXi86i1XTUsFf8AVlRT09PC+MGeR0Do2N907QPe7k/2wNM9K9b0OhLzb5rBRSVNRXU0wpqyaNzZY2MlDtrmv91wc5nOWnGee69TiohLywSxlw7gOGQjJ4ZA4xyxuDe5a4HCDy7pLpr1Kgnq2uoqS223wJgy3VNS2opy5zCA1rC5+MuOck+vyWFZumHUqC9Q/VtqprBTlzfGdDW7oJcHu9hkeXfLGPgvWEcscgJjkY8DvtOVxbVQOBLZ4jjk4eOEHlm4dI9f2qr1TbrFDS1FnubdxkL4w6ZrX7mMAcctdzz2HHfsq/UdGtev0zQUjbCTURVlTK9ntcHDXMgDTnfjksd+S9MdQ+o9j0F9X/Xgq3+2h5i9mjD/ALm3OckftD/dWS03akudmornTybaWshZPGZCAdrgCAfjyiHm+LphrBvVnT94NnIttKbaZpvaIvd8KGFsnG7JwWOHA5xxlYtP026maRqb3bNM0FDXWu4PGZ5fAeHMa4luWyHg88jBC9UNc17QWkOB8wcqJl1NZYr+yxyXSkbd3jc2kMg8QjGe3y5RLQOs+kmsqil0zeKA0FVfaGHZUU8GymY1wkdI3Zt2t/1EHt2yrl0S0nq+13m4XbV1NbaITMc1kEMEJmc5zgS50jASRx5uJOeey3GiAiIgIiIC8o/S7JbriykcEW8EfzXr1ctI9d+lF91/qK319mqbbDDT0vgOFVI9ri7e53G1juMEINP6OuNbbOoFc7RV0uNxMlrqJ6h8zHBzpvZ3Oduae5EuME+fr50/xbd9mxeBfbh9r/bf1GHY8PGfE8T9rPx/DzXuiy6ctNnnqKm3W2kpquqO6omijAdK7uST3PPKrNvtnTev1M/6vg01UXxj3PdHCYnSte0+8S0diD3OEQ8264rqiLq/pa6agJgmMNrqap7xjBDYy8n5EO/JU2KRsr9ZSRncx9OXNPqDWQL3TeNM2O9VdPVXa1UVZUU5BilmiDnMwcjBPlnyUT/040dmpP2dt+akbZv0f3xuDuf/AJmg/gg0v9GLQ9JcaGk1ZNW1YqrfWTRRU4I8LBjaCcYzk7vXyCr+vf8A1rqX/wDNLd//AAhXqOwWK16eoTR2ShgoqUvMhihbhpcQAT/sPyWDV6M05V39t7qbPRy3Zr2Siqcz3w5gAac+o2j8kS8I2v8AwGof/wAK3/8AsRLNjnp6bT1nqrbeK77Qw1T2tpGtcGwR53Ncx3qXE8D/AI59pR9M9FxsmazTdua2Zu2QCP7wyHYP4gH8Fl0OhdLUE1JLSWC3Ry0hJgeIQTGSc8E/HlEPI2u6iW7dSL83W9dUUckAcIAS4BpAGwABruCOewznuFG6vn8XQWmI47pVXGniqaxsbp4DH4XuwEsaS47hk5+GV7Rv+jtO6hnbPe7NQ1s7RtEk0QLseme+F13LQ+mLnR0VJXWOgmpaIOFPEYgGxB2N20DtnA/JB561PpSfRvRFt8slwuEtRfYaH24ucP0URjJw0gAhuS1vy4VL6d/VlFrHTM9p1BWw10r4vGjhgdNukLsOjPDMAjj/AFcc5Xriiu2k6s/ZmkuFnqHRMNKba2aN7g1gwWGPJPAGCMcYXKy6J0zZK41tpsVvpKvBHixQgOGe+D5fgg8hdDtGUuutUXG1V1ZVUtO2idO405AL9ssYDTkHjnPzAWy/pfRCC36PhaSWx+0sBPngRBb00/ozTmnaySrsdnpKGpkYYnSQswS0kHHyyB+Sj9ex6IqH0cWuZLMHMDnUzbhMxhwcBxaHEegQeXdV1gn1Louk1Jcq23WOnslC+GamaXOj/wDJ2u3tA8/EGM/D4KY+ikd3VK4O3Odm2zHc7uf0sXJXpufSunLjT2vxrTQVMNAxgoi6IOETQBtDT6cD4L5YtG6dsNwkrrNZ6SjrJGFj5YmYcWkgkfmB+SDy11nZUaE6w3atoG7WXOkkkZ5Y8aN0bz+D9x/JRlfbblp/oXa6ym8aGG+XF8lU9mQTGxu2JhPoSJHfHheutRaR0/qSaGa/WmkrpYWlkbpmZLQTnAWY+x2uSystElvpn2tjBE2lfGHRho7DB9EHk7pALbQ9S7YywX+tIlZtfAyB0jZssJe15IZgDGc7TjHcrXmnKP2jT2qajx54zSUcUgZG/DZCamJmHDzHvE49QF7nsOj9O6fmlmstmoaKWQbXyQxAOI9M98fBYNP050fT09VBBp63shqmCOZgj4kaHBwB/wDmaD+CDxnfjNV9OdM1lQ6WV8VXWUYke4nbG0QvYz4cySH8fgsm5Vdtr7nYLdPXT02moKGINIc8NbIWbpiMtceZzIMhp7ccYXrae29PKClOl6hmn4YpJvF+rpZIwTIQBkNJzuIwFJz6C0pPbaegm0/bX0dOSYozAMMzyceYyg1V9FaWMUl8pqS71ddSRuY4Qy05YyFx3ctcSc5AGRgdgpG7/wDTv/r5Te2e3nVe6PGP8N42wbM+e7btx5dltuy2e3WOhbR2ehp6KlByI4GBgz68dz8Vjyaassl/Ze5LXSOu7BtbVmMeIBjHf5cIlLoiICIiAiIgIiIC8X6QtlTeuqmsrZQBpq6uC5wxBztoLnFwGT5L2gtSaG6QSaY6j1eqXXplS2d07vZhTbC3xCT97ce2fRBRbzrTUvSzTWk9FUFNRfXroHSTSTOD2ND5nhgacgeuSTgKxaF1z1C1BQ36319qjprlT0z5aKvbTnwHyNI/Rk5LXbvIg+qtXVjpVTa9q6G4Q3Ka13WjbsZURs3gtzkAjIOQSSCD5lQ+kujVRpy33ySLUtRUX25U7qZtbJEdsLXEbnBu/JcfUu4RDV9t6662uzrXaKBtH9dVFYYXSOpxtcHbAwYzwQd+T8lmT9bNdXO5VrdN0tBNS0JDS10QMswzjdt3ZJJBOGjhTsP0bjTU1C+j1N4Nzp6h0xqhSHke7sAbv4LS1xznnd8FlXX6PBnrqma16omt8FZg1NOynJY493AYePdzkgHOPUoK5rrrbrS1usnh0MVqqKihEtRTVNMc+J4sjdzd3IaQ1pA/qu+LrbrWHWt5tE9st0r6cVQbTA48ExMe4nfn3gAw59fLCn9T/R4hubbVHbr++mioaQU7jPT+M+V297y8neMffxjHGFnP6HSu17dtR/X7A2uNYRT+yHLPHjkZ97fzt8TPbnHkg19/191XNo2epY2gjuNPXRRGVsOWvjfHKcFpPBBj7j1UrZ+t2saSv05VahtlJ9R3XEbZGtw+QBwY+RuDwQT2I7fmqt1S6VzdO9FAm6C5GvuEPDKYx7Nkc3/ednO//ZXPpL0bpbvb9Malud0qZKSOMTstrm+62QPJPvE8NJAJAH4oNfWW/s0t1z1Le5IjKKOpuUgjzje7MgaM+WSQrbZesvUiukp7hT2eiuNvllLfZqWEufgHkYa4ub8C4Y+autP0Ggfra73q5XgVNFcX1Tn0jabY5om3Yw/ceWlwOceSi6T6OXh1UEVRq2sktEUhkFKyEsd8cHeQCfUNQbC6ta+k0VoOO9U1IXVtU9kMEM4IDHuaXe+O/AB49V5h6x33VF9bp6fWNtjo6l1M6WnkjwGzxPIIO0E4I9Dz24XrPXmhrbrHSP1BVukp4Y9joJY+XROYMNPPfjIPwK1Fcvo3y1lNRsdq2eSWBpYXz05kAZn3WsG/3QB8+/kg6NXdW9T0mpINM6PpqEOpKWIPkqdu6R3htccFzg0DkDHcrZnRnV1/1XZKp+qbPLbq2neA2QwuiZO0g4LQ7zGOfmPVVvWnQ6O93qK8We/1FouJhZFM+OMuDy1gZuGHAtyByMlXDpT0+pen9nqKWGtmrqmpeHzTyDaDgEANbk4AyfM90S8laldcpdV11TresvNO98jnQ1MEXisPJwWZe0bMdtp7K7ydS77orQ2notPXynukdRLVb5543PeA0x7WkP5aQHHjkcjBKuNd9HiufFPSUetaqO2SPLvZZKdzm98jIEgB5+CkLj9Hi21Gkrbaqa8TQ1lJLLM+qdCHNldIGg+5kYA2Nxz5IhDt6t6oPVi2WDxaT6uqHUgePAG79JDG93PzcVC6I6sdTtX1lVQ2Snt9ZVRxiU/o2R+G3cAT7zgD3x+Kudr6DS0Gtrdf/tLJUNpHwvMc1OXPf4bGtxv3+e3jjgYHkpjo90gk6eX2tuL7024CopvZ/DFN4W33muzncf2UHn/TVurbr14fDdTTTVcN1nqKwuLgx3hOc+Tbjnsx23yzjPCuret2vr1VVlZp22291BDKGtphH4kpBPHG7e4+paMD4LY+nejbrT1TqtXy3llRFPUVU5o/Zi3iYPG3fvPbf6c4Ver/AKObTW1LbTqmrorVUSB76Qwl3AOQMh4Bx5EhBufRt2qr5pi33G4UEtuq548y0srS10bgSCMHnHGR8CFMqK0tY6bTen6G0ULpHU9JHsa6V25zuckk+pJJUqiRERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEUXNPVmeQRHDGkAe4D/wAhU3r0WoiZiZz4OqadpKIseOWR9C2VrWmVzA4NJwM49eVG227yVVXSwuMIdJAJXsGQWkjPGTz8sfHKtpmKoiYczuTSKFqrjWROuj2Mj8GladhLO52Ndyd3qfT8V1i61LRRsb4UxqTsY9o4Dg4ZzhxH3cnv5KRPIoCG71Tpqpr44g2OdsbTtIyDMWevPA78cr5PeKlklxazwC6nOGM25ceW8n3s+foPmgsCKIkukkdiZWyuijkdxy04znAGM8H4Z4/BdcN2mfUPa8Qta2MuIGTtw0HcT5tOSO3kgm0Vepr3NNLRN2xGOZxy9rc7huwMDdwccnvj0VhQERYlbJLuEcJLTsc/IAJOMcDPzSIyiZxGWWixqKVzw9r3btuMOIwSCM8j1WLa7hLV1tXFKwMETsNbjnGSMk588ZxgceqnBE53pNFAW+91FTW09O6AN3SPbI7BxgBxZj57Tn5Lpqr7VwwMlEDHtMLnuIB9127aOM9v/FQlZUREBERAREQEREBERAREQEREBY76OJ73PO8E8nDyP+VkIuK6Ka4xVGUxMxwfGMaxjWMGGtGAF9RF3EY3QgREQEREBERAREQF1zQsmADwcjsQSCPxC7EQxlwiiZEzawYHc85JXNEQEREBERAREQEREBERARF0mpiFW2m3fpS0vx6BRM4TETPB3IiKUCLAuVd7PhkWDJ3OfJYH1nU+rfyVtNmqqMwrqu00zhPItS9SOol2sNTR2+zU7J66p97JZkNHy/AqnXbqjrem/VQxNcByDSZGfmqa6ooq2Zneut0VXKdqmNz0Wi8wnql1Mw+QUtMIWjOXUoGflytk9KuoNx1ZZZpLgyGOtp5Nj9jcbh5Hb5eY/BTbmLk7NKLkTbjNUNqooH6zqfVv5LM+sJ30jX0lMKicPa18ZkDMAnl2T6eisqtVUxmVVN2mqcQkkUf7TcP/AHez/wCoH/gu6jfVySSOqoo4Y8AMa1+455yScD4fkq1jKREQEREBEWDeaielpBLTt3bSd+GlxDdp5AHxx+GUGci6J52ikklieHbWFwLefJdzHB7GuaQWkZBHmg+ovjyQxxHfHC8uXDrJriDqPJYYzR+D9Y+zMj9mBcYy/A5z+yQcoPUiLzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiLqnnjgMfinHiO2A/FRMxEZkdqIikFW6FxdrKsye0eB+TVZFWbf/nKt/g/4aqL3Gnm06fs3Pp/MLMuuolEML3u7NGV2KOvb9tO1o/1O5WminaqiGSudmmZQ0j3SPc9xy4nJXFEXosCh1tD7RreqqZmgmJjWR/AEDKn2wsDQC0H8FjXOBzbxPI3hz2NI57jssaA1ranD9ng+rHE4/NfM6mfb1c31+hjGnoiO+Hy9QNdA4bRghV3pvF7FrK5QRjEc9P4px5ODgP+Vl1k1ZUGTDWGNpIw55bldvTqlf8AXVfUuydsLYyT6k5/4Vuin28YZuk4zYn5NhLvo5zTzteO3Y/JdCL6GYzGJfNROJytgOQCixra/wASiiJ7gY/JZK82YxOG+JzGRERQkRdNZMaemklDN5aOG5xk/NYsc9zNTC2Shp2wucRI8VJJYMHBA2c84Hcd8oJBERBF3VlqtlFVXKspYGxwRulkkbCC7AGT2GSuVHQ0cscVTSOqGRvaHMDZpGtAPb3CcD8lIuaHNLXAFpGCD5r6gxnUjj92qqG/Ig/1BVXd06sMl/F6lhL7kBhs5awED04bj4euOO3CuKIKjfen9kv1ypq68RGrnp3B0Zkaz3Tx6NGew4OQrXDEyCJkUQ2sYMALmiAiKOtNwnrpa1k9uqaIU8xiY6YtImGAd7dpPHPmgkVB6vJFvjI7iQH/AGU4oLWH/Zsf/wAQf0K83pj+jd5LtN72nmm4zmNpPchclxh/VM+QXJejTwhSKs2//OVb/B/w1WZVakkEer61xBPueXyaqb3Gjm06fs3Pp/MLSoq+5xD6c/8ACzPbGfsuWFdZWzU42tILTnlbLW6uGG5MTTMQiURFuY0Nd2OZXRzEfo3M8PPxySo6WsbG5zi5u1vAZnH4prO+Nt1dZaExh5r6h0Zfn9XiNzh+ZGEIhw4kBrj54Xzuvp2L8479763oqvb00Z7tyEp6yN9VMwvbteeGZzj4qa0JC9v1jMf1b5Wtb8SByf8AcKBuE0FNMXZaX+vp8VZtB10FZYmeFw9rnb2nvycg/iFb0dbmq9t90M3S92KbWx4ysaIi9182n7OMUTfmf6rNUBT3aSmiEQtVc/bkbmmLDviMvyu368l/9z3D84f/ALi8+vfVMt1ExFMQkLrUuo7fNOwAvaPdB7ZJwM/Dldfh3L96o/8A6Z3/ANxRVxuM9fSOpmWusiMjmjfI6La0bgSTh5PYeQU17Yz9ly5xKdqHRLS107RHNV03hkguDKcgkA5wCXnH5KQWN7Yz9lye2M/ZcmJNqGSixvbGfsuT2xn7LkxJtQyUWN7Yz9lye2M/ZcmJNqGSixJKz9G7w2Zfj3Q44GfiqFoG46yk1PqNupoKJttFSPA8J7yW/o24EeRy3GMk497cmJNqGyEWN7Yz9lye2M/ZcmJNqGSixvbGfsuT2xn7LkxJtQyVBaw/7Nj/APiD+hUp7Yz9lyhdVTtlt7AAR+kHf5FeZ0xE9Ru8l+mqibtPNYYf1TPkFyXGH9Uz5Bcl6NPCFQqlH/myu/g/4araqlH/AJsrv4P+Gqq72qObTY7Fz6fzCXXF7Q5pB7FckWt5qqakvdPYo81AdJK77kTO7v8AwCoN01vdKqoa2kjbSwBrnO28ucMHAyRwVsrVunIb9R44ZVRg+HJ8x2Pw5Worhbaijm9nrIjFLu3OBGADn3QPXJC9TS1W6438Wa5TMT8mBfo311umawSSV+9s8by73t7Tjdk+g/qrhpeufdLHBNO0Pl24cCQCHDvlVmVskdQ2aI7JWuOMjIwQGnj8MrJtomp6SR0E7WB0Yfgg4cSfL4+aydJaCdTiqnjD1ei9fTpc018JRd3qRLqOWleGmOOMyGNrsjuAM+vc/ko6Gtqm3N1RTGSne0BocxxBIzxn/dZ8cDgJnPcDJNgSPxknBJ2g/j2+a4spz4zQMYDtp5zlxPr8Np/NbdLp6dPb2KYefqr1WouTcqS+n+oN2pmj29rauEvLcuGHDHYA/H4raOlrzTagiMlMHNMePEY4fd/HsVqjTmnqq7Np4KWE4cd75D91g5GT+S3Zp+z01ktzKSlaOOXvxgvd5kqvVVUURiOKu3TMz8kkvqIvNaBERAREQEREBERAREQERUXqXU6ugfaPspT0skTq2ITl73bsZ5DgBgM9TnPwUERlekXTSGc00Rq2xtqNo8QROLmh3ngkA4/BdykFFai/wTP4x/QqVUVqL/BM/jH9CvL6a/o3eTTo/f081ph/VM+QXJcYf1TPkFyW6nhAKpR/5srv4P8AhqtqqUf+bK7+D/hqqu9qjm02Oxc+n8wl0RFreaLAutqo7rD4dZC1+Puu7Ob8QVnokTMTmBru59P5fEkfQVTXNd2ZLwW8Y7+fKhotJXuKidEaMh4wxu2RrhtB79/j6eS26i006u5HzVzbiWoYtGXiV5JpWt5w3e8NDfU8fN35qfs/T1kRhdcarxBGQfDiGA48dz+B/NX9Eq1dyrdwTsQxqCiprfSsp6OFsULBgNaFkoizTOd8uxERARF0VNVDTNBneGA8DKhEzjfLvRcY3tkY17DlrhkFclKRERAREQEREBERAREQFFai/wAEz+Mf0KlVFai/wTP4x/Qry+mv6N3k06P39PNaYf1TPkFyXGH9Uz5Bclup4QCqUf8Amyu/g/4araqlH/myu/g/4aqrvao5tNjsXPp/MMq83SjstsqLhc5hBRwN3SSEE7RnHYAnzUVpvWmntSunbZbpDUugaHyN2uYWtPY4cBx8V19SbNV6h0PdrVb/AA/aqmIMj8R21udwPJ/BaXh6OaqZZbhRb7aJZoIMTmaQvm2bcwOPYMGOMD/S1annREPQ4q6YhhFRCRJ9z3x73y9V8FZTFjXioh2uO1p3jBPoFoB/SDUjdJwCj+r6S9U9wNTBFFO8sjjc3DhudnnIbwBjhcL90WvhobFDbvYKtlPQ+BPDUTPY2Odzy58jdvfl2PXgJlOI8XoN1XTNeWOqIQ8ENLS8ZBPYL4KylLgBUwkl20DxB39PmvPN96OamrKi6SxOonyyupDBJ7Q4fq49rzzk98YySVyoekOq6e8UjnSUJpoLyK8zCY7yzLcnGO4x29UyYjxeiI54pJHsjlY57PvNa4Ej5hVdvUTSrtQfUguzPrTx/ZvA8KTPiZxtztx3+K130r6Yag0zrKO43M0HgQska+oimkdJUl2cEjIHmO4Pb15WND011XT9RLvdadlsFBX1UkgmkkJkia7dhzQOzhuz8wozJiG3dSaptWn7NV3OuqA+mpS0SiHEjmlzg0cD4lZ1rutHc7dFXUszDBJG2TJIBaHAOG70OCF5zg6L6qFprqX2a0QyugEImjqZS6pPih2XZO0cD08hx5qRl6P6obTXimopaOnpaqGkd7OJ3Bk8kbWh4fgZAJ3HPmmZMR4vQZqYGwiZ08QiPZ5eNp/FfJauniLBLUQsL/uBzwN3y9V54q+juqZNP00TX24hlbNUfVPjyezxte1oAa485GD5+ffuvl46O6lqG2ZrKe2zy0tO2Fz31chiaNziW7HAuONwwQ4fJTkxHi9HqC1X+og/iP8ARTULSyGNhxlrQOOyhdV/qIP4j/RRVwUX/dy1B9IXVt701RabZZrzJbIJo5HziFo8SXaG7Q1xaR5njIyqjT9WdY2Kurqq4VbquFtip6ukp6+kMYmkc6IOd7mOcOee+FufXHUKg0XT2alqrZWXKqrYnyRw0zWnayNoLnHcR2B/2UbH1otMlVcmNst3NNbaaOrq6nw2bYWPi8RuRuzk8Nx6/DlF1HZjcqOsOsOr9KTRRXG3WR76i1C4wGGOZzS4yYDCS4dm8n4rEpOtGqrveqi009DbaaaSnkEUIinNSHez72zDgsLC7sDzj8zP1PWykuNVaIrdS19vnfcqemqKeopGSvfHK3czBEg2hwHcZPwXczr7ZnUFZW/Z29D2V7Y3t2Rb25JGXjflg4/1Y7hP9dY+SgWjrrqa1aXtwq20dxqnUE88k9TBIHmdszgIztLRwzaeB5jlWq2dXtX19s1Nc4LPaZ6WyQxSPhjbKJpDIzII5I2tOSf+6PxUpcfpBaeoqZk77NdpMQNmk2CIiPc8taCd+DnGcjIxhdj/AKQOm4K+WnqrZdIY46iamdNsYW7425PAdnnjy80/0x8lZs3WzVt5q7HQ0NvsL6i5VklIypLKgQOw1pBGcHgu57/gpfqzrC+6V6k2iWjdLUsislRUy0Eb3CGWVodyWjuB39cBSkPXS0m0msk0/eo5HTQQ09PsjL5zM1zmFuHY7NJ59Qpi7dWrRbdDWvVE9uuJpa+oFK2DY0Ssd73cE4x7p7FD/Ef0R6lXTXtxvtPdKagijoI6d0T6RkrRJ4gcST4nOPd44H491tlabn6+6ehp2Pbabw+dnimqgbEzdTNjcGuLveweT5Er7UdftOxVToY7fcpW+2CjbI0MAcSMhwy7OMfipyiYnwbjRVLpzrSLXNmN0pLXX0NE7HgyVQaBNy4HbtJ7FuDlW1HIorUX+CZ/GP6FSqitRf4Jn8Y/oV5nTX9G7yadH7+nmtMP6pnyC5LjD+qZ8guS3U8IBVJn+bK3+D/hqtqiqm2/+czWxd3M2Pb69sFcV0TVNMx3Stt3Ioprie+MeSI1VDc6jT1dBYpWQ3OSMsgle7AY48bs4PYZPZUWO19TYqIRsvNvMjKRrQXNaS6YOAJyWdiwF2cfePotolpHcH8l8wfQ/ktDE1xLbuoVRZr1BPcaKOtlbF7FJA8NEZDhv52ZGW57558gsKex9R/DpZYL1TmeFz2iOR4LdhawAkiMbn538uGAcHHdbUwfQ/kmD6H8kMtZalsmv66ooXWy709M0UDY6oeJgOnw/cQA3zy3BGMY7KLqtOdTn3aOqhvNE1kLdkbPHfsIAdgubtwTy3JOckemAtw4PofyTB9D+SGVT0VS6shmqZNWV9POzaxsEUDW4ztG5ziGg5yD8OfkrYmD6H8kwfQ/kiBQV71dp+yEtul3o4Jf/ZeIHSH5MGXH8l814y4v0beW2YS/WBpX+D4f392P9Px9Pitf0VTpa0yUU9kmkpKJzIn+BS0Ejq2R4BDmyEM3Ek7TknvlRM4dU05WSr6gOkjc6y6fulYwAls9S1tFC4AZJDpSCQB5hpUdUXrVNwo7hL9ZWi1xUpZ4kdBC+tqG7iMNBdtZnnHY4Kw6WkuVXJO62aUuM/ju3PnvVSKVjycEl0bd7zkgHHHp8FOUul9TzPe+pvlHaWyDa9tpoh4rhnPM8u5x5J8lG+XeKYQt0s1VS0F0uNdqDUlNUUlNJUQ19RVNZCJGE7WGINDCHDaccnkjjHNlkrai46VstbWxeDVVEDJZY8Y2ucwEjC50vT2xsqmVdxjq7vWNIInuVQ+oII7Ya47R+ACktTxPdBAGMccOPYfBJjcz6mYm3OGs+sd103Tv0zbdT6bgvAqIJ5opZZzF4Hhx7iMgZw7jPy81E6K19oF18udDXWa3WRtxo6SOWR0/ixVTXRgMi27QA1rTjPAVh6o2DTt4rtNjUdbc6SdlLVMg9lp3PYWuiw8vIacYHbtn4qMsvQzS1xpKWup7teaigqIadpjJEbZo4sbQ8bQeS0E9iMeSlZRjZjLjQ1fSGjra+2tprRTU9nnFYHtke4uladrnAD7wbkDufPgDk9RHQuKgEZFpbBWS5BJl3Et4zu7tb72PIfkph3QSwZu7Yrld46e4Ne3wGyN2RbnBxI93ntxuzhSGoujVlvc9mndW3Kkmt1JHQ76ZzWmWJmMbstODx3GO6OswwqGxdJNT3Q2Oit1rq66gifT+BHG9pjbG8Fw3DH+o985OTyeVVdLXzpNcrRDeL7aLfZqmSrqJmQVEz5i9zcB8mO3PbBHOMDK25ojRNFpB95fQS1EzrnWPrZDNgljnd2ggdvmtV1vRfSFHcLZp+S6X6OvrIahjJIW+7LGTvLXuDNoAPIBxn4oQsVXZeklmsVPSVdDbae23pntsO9kh8YRs3bg7uMNccDI7n1UXqyXpjqOyae0tBfaW2UkU8VZS00EZAeCDtadwwN24nnk5+KtusOlFn1To2y6erqirjitLWNgqYtvikNZswSRjBGM8eQVcPTXSdd1Iljoqu8UlwoaendPTQsLIHtYwMZh5bzxjLWuQhF3u99Fm6bjkiobbcYLVGamGlp4SJNrpA098Z94jIcfipHd0eut5t09bT22G9XUQ1jIpN7Hh8jQWB207WuORx59+c5WNW9D9I2GzGW6Xa5toYaJ9C5ztucPlLw73W5Lg53HHksrSnSrS1xuNv1BZr5eKj2QQxSEu2eM6FoazdlgcPd2ggYBCG5sLTktjsdezR9lpZaX2Om9pZE2J/hNY55ziQ8E7iTjOeVZVBVlELbd63UVVc7h7HHRlj6LO6BgadxkawDO/AwsjTF9pNSWeK5W1tQKaQua3x4XRO4OD7rgCpcpVRWov8Ez+Mf0KlcH0P5L5LbjW+EJPdja8OOfP4LF0lZq1GlrtUcZjC7TVRRdpqnuSsP6pnyC5Ii0RGIw6ERFIIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC6nzsY4tIkyPSNx/oF2ogi79cRRWC41se4Ogge9u5pblwBwOfjhVmSok01WULG3Gpq3GjfJVx1M7pRuAaGOHctLnnaAO+TwcK61dNBWU0lPVwxzwSDD45GhzXD4grEhslrhppqeG3UkcE362NsLQ1/wAxjlCVdotUV9VUso2UsPtTqvwNz2vjDWiHxHOLTzkZaMee4dkh1XVyi1vEFO2GqEYdJlxbve7AbkZ2Etw4bhg5xkd1Zaa1W+lINNRU0RGeWRgHkAHn4hoB+QXwWe2tmhmbQUwlha1sbhEMsDfugemPL0RCv6nvlRbb9C2nbLMGQNYIGZIdJNJhrnAcnDY5D/8A6uifVtZHbmTimiaWPkbM97XbWhpw1xaMua0ncC4g7S05yrXU2+jqhL7RSwy+KGh+9gO7actz8iTj0XTJZbZI2Fr7fSubCMRgxDDBnOB+PKDB1PeZ7VSwyQRRvLgXyk5f4TAOXbW+8W5IBI7ZzhYcepZ3iWqkbQw0UD3RP3yne5zY97i045APGMZIyfgrBXW6ir9nttLBUbM7fEYHYz37/ILrfZ7c+eWZ9DTOllYWSOMYJc0jBB+YAH4IlTanVVZO19PPG6mdFNA974mPjdsw+V7MOwfuRHnjO7sFI2jVs84e+vt9S1hhZM1sFPI97dxOGkYy7t94DHBVhpbPbaUg01DTRkHILYwDnBGc/IkfIrsoLdR29rm0NLDTtdy4RMDc+nZEICo1V4MZlMTBGauWFu4kHw4oy+R5HqC1wx8ljjUtyZG6Oakpn1jqaCojjhcXY3k7m4ONzgGucAO+CPipq5adttdT1bDTRRSVLXNkmjjAfh3DuceYyD813iyWttO+BtvpRC9we5giGC4dj80GALlJXaTdVMqoKWoqGOihnGQxsjnFjDhwyDnHBHB45UFQXae2OqoHurBcGmKI0dTI6qG524+JG5uXOBa1x28fd/0q6GhpDQ+xGmhNJt2eCWDZj029sLFbYLS2mNO220ghLxIWCIYLsY3fPHGUFUn1vUts/tUdNG6WOOWWVgZI7LWSOY3sMMDtjuXHjHYrsvVRVfWclUayqbRPkipo5aWYYo5twaWyRHAeC4jnnv2HdWd9htL/AA99toyI27GgwtwG5JxjHbJJ/Fc5LNbZK4Vr6CldVghwmMQLsjsc+vxQdepax1Bp64VUR/SxwOMeP28Yb/vhQdu1DUC80NsEYnp3vfTeMQ/cTGwlzy8gB3vNIIGe/fyVkgt1LDQspBCx1O07gxwBGd27OPnyuMFpt8FW6qhoqdlS4lxlbGA7J7nPx80SjKu91DLlVMibSspKSVkMzpnlr3lzA92zy4aQfjyOO6i2amujrfJUPpqKF8VALjJG9zjiN2drM/tHa7J7Djgqzz2qgqKk1E9HTyTlpaXujBJBGCPyJHyK+1FroKmSKSoo6eV8QAjc+MEtA5AHwQVSq1RUQNq6ynhHheM5rzK5zxC1jWjJYOWjfvaXAEDbkrJn1VNT3Gdk8VOymYx7o3bnESbW87XtBBIf7pbjcO/PZT81mtk+3xqClftc5w3RA4Ljlx/E8n4o+y2x8k732+lc+cFshMQO8Hvn5+aIVul1TXzzCkbSRGrdVx0zdzXxAbozI4lrhu91o/HI7LsotTVta0iCKiYYWB8sk0hayQOlexgZ6bgwnJz3A5VipbVb6QtNLRU8Tmu3AsjAO7btJz644z6L59T23xKd/sNMH04AiIjA2AdgPTHkggtP6nqLtc4YzROjpahkj43FjgQ1pADiTwQc+XbI7pXannpaueQwwPt8NZ7IdpJlcRHuc4Dt7pzx6A9vOw0ltoqSeSalpIIZZPvvYwAu5zyfnysS2WCgt73TMgjkqnySSOnewbyXuLjz+OPkiVfodX1k4Z41B4bphA6Nrmubt8WQNAOfvcEuyOPdKyoLzWXHU1NS0r4mUcctQX494ysjDGd/L33u/wD2KbZZLWynkgZb6VsMhDnMEQwSO3Hw8vRdkFsoKeWKSno6eKSIOaxzIw0tDjlwGPU8lBmIiICiq6+U1HUzU8jJTPH4QaxoGZDISGhvPq12fTBKlVGVNlpam7C4yeJ7S2Ewtw7gDn3sftDc4A+jigr0GtQyWSSqgd7D4bHxS4YwyOke4RsAL+PdbnJwOCTgYU5S6hop7HNdCXMghLmyN4cQ5pxtG0kEk4xgnOQsYaToWMLYpamPHgmMhzT4TombGubkH/TwQcj4LOkstNLZXWyR8zoXcmQvzJu3bt2fXdz6fDHCCDk1iKe5VMVbSSU7WeHFFBI5jZHykOe73i/ZtDNh7+frws+HVlBNAZGMmJMcT2MwMyGRzmBrecE7mEHy884Xz7KUvMntdb7WZnTGqL2mQlzAxw5btwQ0cY4wMYWXHYKFlwpKwNlMtLD4EYc8uGOcE55LgC4ZP7R9UQio9dWuRk8jGzOijidNG5hY4zNa4NO1ocSCS4YDgM54XOq1ZDE2QyQ1FM6mleJ45I2vdsZD4pxtfgcFvrycY5ysmm0tRQQth8aqfCwx+GxzxtjbG8Pa0ADkZA5OTgYyudTpegqZpZJTMXSl5eNwwd5YXeXpG0fLKDvkvLYrdDVTUdTHJPIIoaZwb4kjj2HfAyATyRgA5wq1V6xrW01bNBSkSMdK2CndGNxLXRxAOdvA/Wvd2zkA47c2y722O5xQtfLNDJDIJopYiA5jgCMjII7EjkeajafSdvg8PDqh5YWOy+TcSWyulyeOcvdk+uAghqHVtY2qm+tIzBBFI9gaIGl0nhtDX4LZDg+I5rR38h5kjOvOp56alcIqOalrgyVzYamMO37WtDeWuxgukYMjPmOO4zpNL298RY4zdngO3DLS+USlw477w0/gE+zFI97JKieqqJgQ4ySPBLiJGyc4GANzG8DAwAEHC1aqorhcm0MJLnkvY2UOZte9n3gG7twHBwSADj5ZXLUTKTUFJQbHbHvEUjjt5c4e7tG4O79yGkc9+Csq1WGmttSZYJahzRuEcTnjZEHO3EAADPPrnHYYXT9maT61FcZqncKj2oRbhsEm0tz2yeD2J48sIl9vGoobZVSwupamcQQCpnkiDdsUZJG45I/ZJwMnAKjn6pLLq5jR4tKHSsDWxfpHPa+ONrGndg5eX8nA48sZWXPpxtbdq+qrZ5fBqDEzwI3YbJGwZDX5H7ZeeCMg4PouX2UoAHlklSyUlrmyteNzHNkfJuHGM7nuzkEFEMOs1gynqYI5KOaFrHTGt8UszTsjYHE8O5+/GeM8H1XZDrOjmj/R0tS+cyRxsgYY3ueXhxby1xA+67OSMY5Xe7SlA/d4klS90kUsUznPGZRIWlxccd/dbjGMYA7LJo7DT080Mz56monikMofK4cuLCzsAAMNJ7Ad88lBxvV/itIoxPTTvlqc7Y2FgIwASMucAXc8NBJPOOyx6jVdFT3X2KaKZn3h4hLMZawvPu7twGAeSMZCyr3Yae8HFVNUNic3ZJExw2SNznBBBwc+YwfisKXR1BK+YyTVZZJ42Gbxhnigh+OM87jyScZ4RLiNYUopJ55qKshEcUMwbKGNLmSuLWkndhvIOdxGBypF17hjsrLjNDPG15DGwkAvc8u2taMHBycYOcc5zhfKqxQTyzSsnqIJpCw+JE4ZAY0tAwQQRhzuCD3+SfUFI2ywWyIyxwwOa+J7SN7HtduDhkYznnGMfDCDBuWq4rbRiett9ZC4by+N5jaWtZ3OS/Ds54DSSVxuGqA2SGOhp5XtkqmU/tL2jw8/ekb33ZDA7nGMjHlhfarR9FVMc2aqrT4kJhmPiAmYFznckjjlx+7geWMcLtn0pRTVEkjp6wMc6V7YWyAMjfK1zXuaMdzuJ5zgnhEMGTXdBHDFJLS1UYkhFSGyGNrhCRw/BdznnDR7xweOytrXBzQ4cgjIUPV6dpKipjmElRDiNkL2RPDRIxhJaDxkYJPYjuQplEiIiAiIgIiICwqu60NJVR01TUxxzyY2sJ55OBn0yeBnueFmqCns1S671VRBVRsp6sxmZro9zwGDAa0k4APB7cc478Bk/aC1YqCa+ANgaXyOLsANBwTnzAPGR5r5BqG0zytjir4HPJLducHIBcQfQ4BPy5UM3Sc8sFDDW1cL46KKOnjbHCWh0bXsc7dknJd4bR6Dn1XbXaUfUwyNFYGSSTVM5eI/9crHMae/+ljsfHHkiEjDqazTFgiuNO4uLQ3Du+44afkTwD2zwsmW8W+KETSVkLYiJDuLuMRnDz+B7qMl0yx80jmytZG6amcGBnaKDBbH3/aBP4rAGj6iSnggqq6J8UMPs4AhPvNMrHyF2XclwZg/MolZ6C4Ute2Q0c7JhG7a/aexwD/QgrKUZb7fNR11XMJY3MqpzNICw5HuMY0A58g308/JSaAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIP/Z",
+              "timing": 1500
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAICAwEAAAAAAAAAAAAAAAUGBAcCAwgB/8QAThAAAQMDAwIDBAYIBQEDCgcAAQACAwQFEQYSIQcxE0FRFCJhcQgVFjKBkSMzUlRyk7HhNDZCocEXNWLRJCUnOFNVc4KU03R1g5KytPH/xAAaAQEAAwEBAQAAAAAAAAAAAAAAAQMEAgUG/8QAMREBAAEDAQQGCgMBAAAAAAAAAAECAxEEEiExcQUUMkFRsRMVIzNSYXKhwdEiNIGR/9oADAMBAAIRAxEAPwD1SiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICL45wa0ucQGgZJPYKvRa40rNcPYYtRWl9XnaIm1TCSfTv3+CCxIhIAyTx6qunXGlm1/sR1FaRV52+F7Wzdn079/ggsSICCAQcg+airzqG12V7G3Wq9kY/GJpY3CIfOTG0fiUEqioXWuq/8ARJf6mjn4NO1zJYn9wXN5BCljq/T1mpKCmu98t1HVOhj/AEc9Q1ruWjkgnhBZ0XXTVENVAyemljmhkG5kkbg5rh6gjuoW76x03Z6sUt1vtspKnOPCmqWNcPmCePxQTyLqpKmCsp2VFJNHPBIMskjcHNcPUEd12oCIiAiIgIiICIiAiIgIi+PdtaSgFwb3IC+CRh7OCi7lcaS3wGouNVDTQ5DfEmeGNyewyVgUepbHW1LKejvFvnqJDhkcdQxznfIAoLKi6Kd5Pun8F3oCIiAiIg1v1wnmfZ7HaGzPp6S8XWChq5GHafBcSXNz5ZxhWOr0LpiosLrQ+y0DaHYWBrYWgt4xuDsZDvj3WZq7TtDqqxT2u5td4MmHNew4fE8cte0+RBVPl0XrOpojbKrXj3W1zfDe9lvY2pczsR4m7vjzxlBRDfblP0Po6F1bKWSXgWR1e12HPpvFLd+fi0bcrbjNA6VbY/qkWK3+xbNmDC3d2xnd33fHOVzm0TZJdEjSppiLS2IRNaD7zSDkPB/a3c59VWm6J1oyk+rm6/l+rQ3ww429hqdnbHi57488ZQQ3UGqqdCdFDT6dvE1WY5W0bK5zw58MbnkEbh5tHug9wti6f05bLfpxlujiFRTzQhs75j4jqjI5c8n7xOV127RtkotHt0yKRs1p8Mxvjm94yZOS5x/aJ5z6rFdp66Wyyiz6Yr201Ns8NlRWvdUSU7e2GN4zjy3OOEGlaeeWn6RdULA2V81us1c+no3uOdsfiD3M/DH+63PonSlmo9J0kZpaaudV07JKmpmYJHVTnNBLnE9wc8DyCjx0zoKfprXaSoKmSP20F09ZI3e+SQuBL3DjOcYSPR2o7TSewaX1THRW0N2xw1VCKh1OPMRu3Dj0Ds4QVTT9XNpD/qjarIS6gs8XtlDF94QPfE57mD4AjOFaelmkrHDoa21L6Olrqq407amrqp42yPnfINzskjkZPZTWi9HUembPVUhlkr6mukdNXVVQAX1L3dy74Y4AVdotBah0+ySi0hq32GzlznRUlXRNqTT5OSGOJBx6A5QdHT6GOwdT9WabtY2WZkMFdHADltPI/Ic1voD3wtoKs6I0jBpeGskfVz3C6V0njVldP9+Z3kMDgNA4AHZWZAREQEREBERAREQEREBcJxmIrmh5QV3UYqTbT7EK4zbh/gvB8TH/AOr7uP8AdQVlbd/rSD2oai8HJ3e1Ch8PsfveH7/5K7PhIPu8hcRE8n7qD7AP0gWUuEUYYPiuaAiIgIiw6q4RU9XHTuzvc0vJwcNb6/mgzEXxpDmhw7HkLoqKoQ1VNCWjExd72cYwMoMhFH0Fe+rqqmMwhkcT3MDtxJcQcemP91iC+u8eojdTgCKQMad/3v0gYT28s5QTaKLrrt7NUvjbEx7I2tc8mTa4hxI90Y97t8F9obp7TWmAxtY079p3EuO1205GMD8ygk0REBERAREQEREBERAREQEREBERAREQEREBERAREQFwfEx72Pc0FzDlp8wuaIC6p6eCoDRUQxyhpyN7Q7H5rtRB1R00EczpY4YmSu+89rQCfmVxNFSnxM00J8Q5flg9/wA+fVd6IOkUlOPDxBEPD+57g935ei5NghbK6VsUYkd3eGjJ/FdiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgiLzfYLa8RbTLMRnaDjHzKiPtg79yH83+ygb3v+tqvxc7vEPf08v9sLX+p6TUUur7ZPa3VQtbGxifwpmhufEJdlhI3e7gfjxnGF5dWpuVVzETiHv29DZptU1VUzVM48e9t77YO/ch/N/sn2wd+5D+b/Zakoae+t6h3CapZVusj2t9nf7S3wmnwwHZjznl2ecd10aet+pYda17rlUTvscZkfTOdMHCTeW4aW5z7oz3C59Pd+Puz3O+p6fPu5447/8AvHg3F9sHfuQ/m/2T7YO/ch/N/stL6cpNTR2jUcdxZWtrnsk9jkkq2vDid+3YAfcIy3v8PRd+nqPVDdPXyC7TSfWMkeyjkMoPPhABwIJ2ndyfjkqZv3Yz/PyI0mnnHs538/23D9sHfuQ/m/2T7YO/ch/N/stKVFJquTRlxaz2sXaSpY6GMVLRI2MbNw3bsDOHefmrlY2zts9G2rZLHUCJviMmkEjw7HOXDufiuatRdiM7Xk6o0WnqnHo5jd815+2Dv3Ifzf7J9sHfuQ/m/wBlqPS9PfotV3t92jrDQvkkNJI+qa6IMLhtaIwSQcZ59OFhaFpNWwXqZ2onVLqcxu3OfUMfG5+73djAMtGPiPkpm/d3/wA4+zmNJp5mI9HO/Pjubp+2Dv3Ifzf7J9sHfuQ/m/2WmtNUeqYtaV811fObM6SoMDXTBwAL2+HxuPGM44459ViaRo9axauklvc0jrYTLv3Sscx37GxoOW/kOFPpru/+cfZEaXT7vZTvnHf/AN4t4fbB37kP5v8AZPtg79yH83+y1LpynvsWsbzJc46w217nGlkdUtdEG5bhojzkHvz810aRpNSw6sus15fVOtjw/wADxJmluS8bdrQTjDR3479lE37u/wDn5Oo0ennHs53z827bdqmConbFURGDccB27Iz8eFYlqZbQtu/6vpvF/WeG3dn1wtOkv1XMxV3PP6R0lFiaarfeyURFteYIiICIiAiIgIiICIiAiIgIiIIi82KC5PEm4xTDjcBnPzCiPse799H8r+6tyKivTW65zMNVvW37VOzTVuVH7Hu/fR/K/un2Pd++j+V/dW5Fz1S14eaz1jqfi+0fpUfse799H8r+6fY9376P5X91bkTqlrw8z1jqfi+0fpUfse799H8r+6fY9376P5X91bkTqlrw8z1jqfi+0fpUfse799H8r+6fY9376P5X91bkTqlrw8z1jqfi+0fpUfse799H8r+6fY9376P5X91bkTqlrw8z1jqfi+0fpUfse799H8r+6fY9376P5X91bkTqlrw8z1jqfi+0fpXLdpaCnnbLUSmfbyG7cDPx5VjRFdRbptximGa7ervTtXJyIiLtUIiICIiAiIgIiovWrVtdovQdTdbVEySsMrIY3SN3Nj3H7xHn2/MhBekXk7TPU7qZXy01TT3W23OOSQb6MCn8Zrc4P6MbXn8MqWl6sawg621Fna6pqbVHcZKZtsZTx73MGQCHbN2P9ffsg9NotG3P6Q1ut99ulslsNY99FLLCHMmB8RzHFvAxwDj8F22Pr/RXW+utgsFVC9sM8pe6oaf1UT5CMbfPZj8UG7UWlrH9IGy11iu90rrZVUcdAYWNjEjZHzvk34a3gAY2E5K5aQ6/2TUN8gtclrrqKepdsgc9zXte8/daccgk8Dg8lBudF5h6Q9W9XXbXU1HepKi5UHgTPMDII2ez7cEPcWsBwMbefNwVttv0g6Gusd4uTbBUsbbWxOcw1DSX+I/ZwdvGO6DeKLQVT9JG3wU1HMdO1RFTGZAPaW+7h7m/s/8AdUtP9IGw09mqK+a21zXCqdT00Axuna0AmQ5xtbyPU8oNzotLWP6QNjulBc3m2VlNW0dM6pbTyPbicN7ta4djjnkdk0n18t+o7vbLdBYqyKetqhTkmUObEDjDycepPHwQbpReYfpU3672rWVpitd1r6KJ9AHOZT1D42k+I8ZIaRyr1qLr3p+xX2stJo6yqfRse187CAx0rW/cHnyfd3eR+HKDciKg9JepNP1FprlNTW6WhFE9jCJJQ/duBPkBj7qqurfpBWGw3+qtdNba24eyyGKaeNzWM3A4Ibnvg8Z4QboRaTv30hLLb6C1VlDa6qthro3PIMrY3Qua7BY4YPPnwexCyP8Ar7YGWavuNRb62NkNQKemi431OQTuAONrRjnPqEG5EWj6HrpaNT2K/wBJDT19pucVuqJ4DuaS7ZG53uO8nADIyPJVbo51Rj09obUFz1LXXa5+DVwxQsmk8Rxc9ryGtLjxwwk5OOOB6h6ZRaQsP0irDcKsRV9puNDG5j3tmy2RuGtLjnsew8s8rFp/pKWSWr2usN0bS7g3xg5hIz6tzj/dBvlFpW+fSG07bbtcKGCgrasUoc0TtIaySQHG0dyB3974fHKjpfpHUEdopq86dqi2eeWAM9pbkFjY3Zzt8/EH5IN9otRaZ66WO96rorE63V9JLV+G2KaUDbvewODSODjJwDjng9ioy/fSL0/bbzUUVJa66uggkMbqljmta4g4JaD3GfXCDeCLU2pOuumrRYbTcaaGrrpLlGZYqdgDHMAcWneSePeBHGexUp0u6sWjqBVVNFS01TQ3CBnimCbB3MyAS1w9CRnOO6DYqIiAqR1htF+vWjnUul208lcJ2PdDUbTHNGAdzCHAtPccH0V3RB47Z0a17db9SvlsFFZWBzd9RBURhjMHO/a17jn+EDsrjqrpnre3dX/tRpemgrY3zidkz5WDwyW7XB7XEE+fbK9JrrkniicBLLGwnsHOAQee+m/TzVNo6411/udq8G0y1FY9s/jxOyHl207Q4u5yPJR2qOlGsouqd3vlipaSpo6w1MjJZJmgNE0T2uaWkg598geWcE8ZXpdr2vJDXNcRwcHOF88aPxNniM3/ALO4Z/JB5HsfRDWU+kr7SVtvZR1hmpqilZJURuE+wTNc3LXHBxIDzhXbROmOp9VqmxSaloLXRWy3NjjMj4KWSQxx8hrS3c4E+oIx3XoF08LZNjpY2vP+kuAP5Lj7VT8/p4uO/vjhB5s0d0u1vpPqZUz0dNTy2er8SnmrfEYR7O9wJ90kODuB5Kt03RvqBbbPqG3Q22kmhqmxNBbUMzNslDhsy4Y8yd2PQcr1yyoheQGSxuLu2HA5Wqr91ibaeqsWizZDKX1VPTe2e1bceKGHOzZ5b+2eceSIaKr+jGvpaG1RssBL4YXNkHtcHukyvd+36ELdX0genV41jHZ7hpzwn11uLgad7wzeCWkFrjxkFvmR3WNWdeDTUt7mfpKvjFtkawePN4Yky8N5O07Xc5xzxnlbA6ZazZrjStPefZBQGaSSMQGbxD7pxnOBn8kGk6Dp51DuNv1DUXq3W2nmno5IoqdrIHTzyFu0fpuXAY5yX/Dsr39G/SF80hp27U2o6D2OeeqEkbTKyTc3YBnLSfNX3WF/rLLBAy12ioulfUEiONj2xRtxjl8jjho5+JKmxUsbDG+ocyFz2g7XPHB8xnzRLQH0junuqNX6qttZp21msp4aIRPf48UeHb3HGHOB7EKFvfSrXtBqfVf2djpZbXeoZjJK58eXNcS/wsOOWuLvdz288r04yWN5IZIxxAycEHASOaKQkRyMcR3DXAoNN/Rr0Xf9HUF9j1JQGifUywuiBljk3Bodn7jjjuO6pFd066jaX1RqN+kaKjr7fd3PDpZDC79G5xcAWyEcjODwQV6YFVTkEieI45Pvjha/6w9Tm9OI7S82o3EV5lAxUeFs2bP+67Od/wDsg0trvpNr26W6w4ttJWVkcMhqBSez07IiXcNwC0OOAMkDz+C2d1y6dXbWFgsMtj8H6ytWf0Ejg0PDg3OCeMgsHfjutm6bu7L1py03V0Yp/rCliqREX7tu9gdtzxnGcdlIRzwyOLY5Y3uHk1wJQeZ4+mWvtSXi86i1XTUsFf8AVlRT09PC+MGeR0Do2N907QPe7k/2wNM9K9b0OhLzb5rBRSVNRXU0wpqyaNzZY2MlDtrmv91wc5nOWnGee69TiohLywSxlw7gOGQjJ4ZA4xyxuDe5a4HCDy7pLpr1Kgnq2uoqS223wJgy3VNS2opy5zCA1rC5+MuOck+vyWFZumHUqC9Q/VtqprBTlzfGdDW7oJcHu9hkeXfLGPgvWEcscgJjkY8DvtOVxbVQOBLZ4jjk4eOEHlm4dI9f2qr1TbrFDS1FnubdxkL4w6ZrX7mMAcctdzz2HHfsq/UdGtev0zQUjbCTURVlTK9ntcHDXMgDTnfjksd+S9MdQ+o9j0F9X/Xgq3+2h5i9mjD/ALm3OckftD/dWS03akudmornTybaWshZPGZCAdrgCAfjyiHm+LphrBvVnT94NnIttKbaZpvaIvd8KGFsnG7JwWOHA5xxlYtP026maRqb3bNM0FDXWu4PGZ5fAeHMa4luWyHg88jBC9UNc17QWkOB8wcqJl1NZYr+yxyXSkbd3jc2kMg8QjGe3y5RLQOs+kmsqil0zeKA0FVfaGHZUU8GymY1wkdI3Zt2t/1EHt2yrl0S0nq+13m4XbV1NbaITMc1kEMEJmc5zgS50jASRx5uJOeey3GiAiIgIiIC8o/S7JbriykcEW8EfzXr1ctI9d+lF91/qK319mqbbDDT0vgOFVI9ri7e53G1juMEINP6OuNbbOoFc7RV0uNxMlrqJ6h8zHBzpvZ3Oduae5EuME+fr50/xbd9mxeBfbh9r/bf1GHY8PGfE8T9rPx/DzXuiy6ctNnnqKm3W2kpquqO6omijAdK7uST3PPKrNvtnTev1M/6vg01UXxj3PdHCYnSte0+8S0diD3OEQ8264rqiLq/pa6agJgmMNrqap7xjBDYy8n5EO/JU2KRsr9ZSRncx9OXNPqDWQL3TeNM2O9VdPVXa1UVZUU5BilmiDnMwcjBPlnyUT/040dmpP2dt+akbZv0f3xuDuf/AJmg/gg0v9GLQ9JcaGk1ZNW1YqrfWTRRU4I8LBjaCcYzk7vXyCr+vf8A1rqX/wDNLd//AAhXqOwWK16eoTR2ShgoqUvMhihbhpcQAT/sPyWDV6M05V39t7qbPRy3Zr2Siqcz3w5gAac+o2j8kS8I2v8AwGof/wAK3/8AsRLNjnp6bT1nqrbeK77Qw1T2tpGtcGwR53Ncx3qXE8D/AI59pR9M9FxsmazTdua2Zu2QCP7wyHYP4gH8Fl0OhdLUE1JLSWC3Ry0hJgeIQTGSc8E/HlEPI2u6iW7dSL83W9dUUckAcIAS4BpAGwABruCOewznuFG6vn8XQWmI47pVXGniqaxsbp4DH4XuwEsaS47hk5+GV7Rv+jtO6hnbPe7NQ1s7RtEk0QLseme+F13LQ+mLnR0VJXWOgmpaIOFPEYgGxB2N20DtnA/JB561PpSfRvRFt8slwuEtRfYaH24ucP0URjJw0gAhuS1vy4VL6d/VlFrHTM9p1BWw10r4vGjhgdNukLsOjPDMAjj/AFcc5Xriiu2k6s/ZmkuFnqHRMNKba2aN7g1gwWGPJPAGCMcYXKy6J0zZK41tpsVvpKvBHixQgOGe+D5fgg8hdDtGUuutUXG1V1ZVUtO2idO405AL9ssYDTkHjnPzAWy/pfRCC36PhaSWx+0sBPngRBb00/ozTmnaySrsdnpKGpkYYnSQswS0kHHyyB+Sj9ex6IqH0cWuZLMHMDnUzbhMxhwcBxaHEegQeXdV1gn1Louk1Jcq23WOnslC+GamaXOj/wDJ2u3tA8/EGM/D4KY+ikd3VK4O3Odm2zHc7uf0sXJXpufSunLjT2vxrTQVMNAxgoi6IOETQBtDT6cD4L5YtG6dsNwkrrNZ6SjrJGFj5YmYcWkgkfmB+SDy11nZUaE6w3atoG7WXOkkkZ5Y8aN0bz+D9x/JRlfbblp/oXa6ym8aGG+XF8lU9mQTGxu2JhPoSJHfHheutRaR0/qSaGa/WmkrpYWlkbpmZLQTnAWY+x2uSystElvpn2tjBE2lfGHRho7DB9EHk7pALbQ9S7YywX+tIlZtfAyB0jZssJe15IZgDGc7TjHcrXmnKP2jT2qajx54zSUcUgZG/DZCamJmHDzHvE49QF7nsOj9O6fmlmstmoaKWQbXyQxAOI9M98fBYNP050fT09VBBp63shqmCOZgj4kaHBwB/wDmaD+CDxnfjNV9OdM1lQ6WV8VXWUYke4nbG0QvYz4cySH8fgsm5Vdtr7nYLdPXT02moKGINIc8NbIWbpiMtceZzIMhp7ccYXrae29PKClOl6hmn4YpJvF+rpZIwTIQBkNJzuIwFJz6C0pPbaegm0/bX0dOSYozAMMzyceYyg1V9FaWMUl8pqS71ddSRuY4Qy05YyFx3ctcSc5AGRgdgpG7/wDTv/r5Te2e3nVe6PGP8N42wbM+e7btx5dltuy2e3WOhbR2ehp6KlByI4GBgz68dz8Vjyaassl/Ze5LXSOu7BtbVmMeIBjHf5cIlLoiICIiAiIgIiIC8X6QtlTeuqmsrZQBpq6uC5wxBztoLnFwGT5L2gtSaG6QSaY6j1eqXXplS2d07vZhTbC3xCT97ce2fRBRbzrTUvSzTWk9FUFNRfXroHSTSTOD2ND5nhgacgeuSTgKxaF1z1C1BQ36319qjprlT0z5aKvbTnwHyNI/Rk5LXbvIg+qtXVjpVTa9q6G4Q3Ka13WjbsZURs3gtzkAjIOQSSCD5lQ+kujVRpy33ySLUtRUX25U7qZtbJEdsLXEbnBu/JcfUu4RDV9t6662uzrXaKBtH9dVFYYXSOpxtcHbAwYzwQd+T8lmT9bNdXO5VrdN0tBNS0JDS10QMswzjdt3ZJJBOGjhTsP0bjTU1C+j1N4Nzp6h0xqhSHke7sAbv4LS1xznnd8FlXX6PBnrqma16omt8FZg1NOynJY493AYePdzkgHOPUoK5rrrbrS1usnh0MVqqKihEtRTVNMc+J4sjdzd3IaQ1pA/qu+LrbrWHWt5tE9st0r6cVQbTA48ExMe4nfn3gAw59fLCn9T/R4hubbVHbr++mioaQU7jPT+M+V297y8neMffxjHGFnP6HSu17dtR/X7A2uNYRT+yHLPHjkZ97fzt8TPbnHkg19/191XNo2epY2gjuNPXRRGVsOWvjfHKcFpPBBj7j1UrZ+t2saSv05VahtlJ9R3XEbZGtw+QBwY+RuDwQT2I7fmqt1S6VzdO9FAm6C5GvuEPDKYx7Nkc3/ednO//ZXPpL0bpbvb9Malud0qZKSOMTstrm+62QPJPvE8NJAJAH4oNfWW/s0t1z1Le5IjKKOpuUgjzje7MgaM+WSQrbZesvUiukp7hT2eiuNvllLfZqWEufgHkYa4ub8C4Y+autP0Ggfra73q5XgVNFcX1Tn0jabY5om3Yw/ceWlwOceSi6T6OXh1UEVRq2sktEUhkFKyEsd8cHeQCfUNQbC6ta+k0VoOO9U1IXVtU9kMEM4IDHuaXe+O/AB49V5h6x33VF9bp6fWNtjo6l1M6WnkjwGzxPIIO0E4I9Dz24XrPXmhrbrHSP1BVukp4Y9joJY+XROYMNPPfjIPwK1Fcvo3y1lNRsdq2eSWBpYXz05kAZn3WsG/3QB8+/kg6NXdW9T0mpINM6PpqEOpKWIPkqdu6R3htccFzg0DkDHcrZnRnV1/1XZKp+qbPLbq2neA2QwuiZO0g4LQ7zGOfmPVVvWnQ6O93qK8We/1FouJhZFM+OMuDy1gZuGHAtyByMlXDpT0+pen9nqKWGtmrqmpeHzTyDaDgEANbk4AyfM90S8laldcpdV11TresvNO98jnQ1MEXisPJwWZe0bMdtp7K7ydS77orQ2notPXynukdRLVb5543PeA0x7WkP5aQHHjkcjBKuNd9HiufFPSUetaqO2SPLvZZKdzm98jIEgB5+CkLj9Hi21Gkrbaqa8TQ1lJLLM+qdCHNldIGg+5kYA2Nxz5IhDt6t6oPVi2WDxaT6uqHUgePAG79JDG93PzcVC6I6sdTtX1lVQ2Snt9ZVRxiU/o2R+G3cAT7zgD3x+Kudr6DS0Gtrdf/tLJUNpHwvMc1OXPf4bGtxv3+e3jjgYHkpjo90gk6eX2tuL7024CopvZ/DFN4W33muzncf2UHn/TVurbr14fDdTTTVcN1nqKwuLgx3hOc+Tbjnsx23yzjPCuret2vr1VVlZp22291BDKGtphH4kpBPHG7e4+paMD4LY+nejbrT1TqtXy3llRFPUVU5o/Zi3iYPG3fvPbf6c4Ver/AKObTW1LbTqmrorVUSB76Qwl3AOQMh4Bx5EhBufRt2qr5pi33G4UEtuq548y0srS10bgSCMHnHGR8CFMqK0tY6bTen6G0ULpHU9JHsa6V25zuckk+pJJUqiRERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBEUXNPVmeQRHDGkAe4D/wAhU3r0WoiZiZz4OqadpKIseOWR9C2VrWmVzA4NJwM49eVG227yVVXSwuMIdJAJXsGQWkjPGTz8sfHKtpmKoiYczuTSKFqrjWROuj2Mj8GladhLO52Ndyd3qfT8V1i61LRRsb4UxqTsY9o4Dg4ZzhxH3cnv5KRPIoCG71Tpqpr44g2OdsbTtIyDMWevPA78cr5PeKlklxazwC6nOGM25ceW8n3s+foPmgsCKIkukkdiZWyuijkdxy04znAGM8H4Z4/BdcN2mfUPa8Qta2MuIGTtw0HcT5tOSO3kgm0Vepr3NNLRN2xGOZxy9rc7huwMDdwccnvj0VhQERYlbJLuEcJLTsc/IAJOMcDPzSIyiZxGWWixqKVzw9r3btuMOIwSCM8j1WLa7hLV1tXFKwMETsNbjnGSMk588ZxgceqnBE53pNFAW+91FTW09O6AN3SPbI7BxgBxZj57Tn5Lpqr7VwwMlEDHtMLnuIB9127aOM9v/FQlZUREBERAREQEREBERAREQEREBY76OJ73PO8E8nDyP+VkIuK6Ka4xVGUxMxwfGMaxjWMGGtGAF9RF3EY3QgREQEREBERAREQF1zQsmADwcjsQSCPxC7EQxlwiiZEzawYHc85JXNEQEREBERAREQEREBERARF0mpiFW2m3fpS0vx6BRM4TETPB3IiKUCLAuVd7PhkWDJ3OfJYH1nU+rfyVtNmqqMwrqu00zhPItS9SOol2sNTR2+zU7J66p97JZkNHy/AqnXbqjrem/VQxNcByDSZGfmqa6ooq2Zneut0VXKdqmNz0Wi8wnql1Mw+QUtMIWjOXUoGflytk9KuoNx1ZZZpLgyGOtp5Nj9jcbh5Hb5eY/BTbmLk7NKLkTbjNUNqooH6zqfVv5LM+sJ30jX0lMKicPa18ZkDMAnl2T6eisqtVUxmVVN2mqcQkkUf7TcP/AHez/wCoH/gu6jfVySSOqoo4Y8AMa1+455yScD4fkq1jKREQEREBEWDeaielpBLTt3bSd+GlxDdp5AHxx+GUGci6J52ikklieHbWFwLefJdzHB7GuaQWkZBHmg+ovjyQxxHfHC8uXDrJriDqPJYYzR+D9Y+zMj9mBcYy/A5z+yQcoPUiLzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiLqnnjgMfinHiO2A/FRMxEZkdqIikFW6FxdrKsye0eB+TVZFWbf/nKt/g/4aqL3Gnm06fs3Pp/MLMuuolEML3u7NGV2KOvb9tO1o/1O5WminaqiGSudmmZQ0j3SPc9xy4nJXFEXosCh1tD7RreqqZmgmJjWR/AEDKn2wsDQC0H8FjXOBzbxPI3hz2NI57jssaA1ranD9ng+rHE4/NfM6mfb1c31+hjGnoiO+Hy9QNdA4bRghV3pvF7FrK5QRjEc9P4px5ODgP+Vl1k1ZUGTDWGNpIw55bldvTqlf8AXVfUuydsLYyT6k5/4Vuin28YZuk4zYn5NhLvo5zTzteO3Y/JdCL6GYzGJfNROJytgOQCixra/wASiiJ7gY/JZK82YxOG+JzGRERQkRdNZMaemklDN5aOG5xk/NYsc9zNTC2Shp2wucRI8VJJYMHBA2c84Hcd8oJBERBF3VlqtlFVXKspYGxwRulkkbCC7AGT2GSuVHQ0cscVTSOqGRvaHMDZpGtAPb3CcD8lIuaHNLXAFpGCD5r6gxnUjj92qqG/Ig/1BVXd06sMl/F6lhL7kBhs5awED04bj4euOO3CuKIKjfen9kv1ypq68RGrnp3B0Zkaz3Tx6NGew4OQrXDEyCJkUQ2sYMALmiAiKOtNwnrpa1k9uqaIU8xiY6YtImGAd7dpPHPmgkVB6vJFvjI7iQH/AGU4oLWH/Zsf/wAQf0K83pj+jd5LtN72nmm4zmNpPchclxh/VM+QXJejTwhSKs2//OVb/B/w1WZVakkEer61xBPueXyaqb3Gjm06fs3Pp/MLSoq+5xD6c/8ACzPbGfsuWFdZWzU42tILTnlbLW6uGG5MTTMQiURFuY0Nd2OZXRzEfo3M8PPxySo6WsbG5zi5u1vAZnH4prO+Nt1dZaExh5r6h0Zfn9XiNzh+ZGEIhw4kBrj54Xzuvp2L8479763oqvb00Z7tyEp6yN9VMwvbteeGZzj4qa0JC9v1jMf1b5Wtb8SByf8AcKBuE0FNMXZaX+vp8VZtB10FZYmeFw9rnb2nvycg/iFb0dbmq9t90M3S92KbWx4ysaIi9182n7OMUTfmf6rNUBT3aSmiEQtVc/bkbmmLDviMvyu368l/9z3D84f/ALi8+vfVMt1ExFMQkLrUuo7fNOwAvaPdB7ZJwM/Dldfh3L96o/8A6Z3/ANxRVxuM9fSOpmWusiMjmjfI6La0bgSTh5PYeQU17Yz9ly5xKdqHRLS107RHNV03hkguDKcgkA5wCXnH5KQWN7Yz9lye2M/ZcmJNqGSixvbGfsuT2xn7LkxJtQyUWN7Yz9lye2M/ZcmJNqGSixJKz9G7w2Zfj3Q44GfiqFoG46yk1PqNupoKJttFSPA8J7yW/o24EeRy3GMk497cmJNqGyEWN7Yz9lye2M/ZcmJNqGSixvbGfsuT2xn7LkxJtQyVBaw/7Nj/APiD+hUp7Yz9lyhdVTtlt7AAR+kHf5FeZ0xE9Ru8l+mqibtPNYYf1TPkFyXGH9Uz5Bcl6NPCFQqlH/myu/g/4araqlH/AJsrv4P+Gqq72qObTY7Fz6fzCXXF7Q5pB7FckWt5qqakvdPYo81AdJK77kTO7v8AwCoN01vdKqoa2kjbSwBrnO28ucMHAyRwVsrVunIb9R44ZVRg+HJ8x2Pw5Worhbaijm9nrIjFLu3OBGADn3QPXJC9TS1W6438Wa5TMT8mBfo311umawSSV+9s8by73t7Tjdk+g/qrhpeufdLHBNO0Pl24cCQCHDvlVmVskdQ2aI7JWuOMjIwQGnj8MrJtomp6SR0E7WB0Yfgg4cSfL4+aydJaCdTiqnjD1ei9fTpc018JRd3qRLqOWleGmOOMyGNrsjuAM+vc/ko6Gtqm3N1RTGSne0BocxxBIzxn/dZ8cDgJnPcDJNgSPxknBJ2g/j2+a4spz4zQMYDtp5zlxPr8Np/NbdLp6dPb2KYefqr1WouTcqS+n+oN2pmj29rauEvLcuGHDHYA/H4raOlrzTagiMlMHNMePEY4fd/HsVqjTmnqq7Np4KWE4cd75D91g5GT+S3Zp+z01ktzKSlaOOXvxgvd5kqvVVUURiOKu3TMz8kkvqIvNaBERAREQEREBERAREQERUXqXU6ugfaPspT0skTq2ITl73bsZ5DgBgM9TnPwUERlekXTSGc00Rq2xtqNo8QROLmh3ngkA4/BdykFFai/wTP4x/QqVUVqL/BM/jH9CvL6a/o3eTTo/f081ph/VM+QXJcYf1TPkFyW6nhAKpR/5srv4P8AhqtqqUf+bK7+D/hqqu9qjm02Oxc+n8wl0RFreaLAutqo7rD4dZC1+Puu7Ob8QVnokTMTmBru59P5fEkfQVTXNd2ZLwW8Y7+fKhotJXuKidEaMh4wxu2RrhtB79/j6eS26i006u5HzVzbiWoYtGXiV5JpWt5w3e8NDfU8fN35qfs/T1kRhdcarxBGQfDiGA48dz+B/NX9Eq1dyrdwTsQxqCiprfSsp6OFsULBgNaFkoizTOd8uxERARF0VNVDTNBneGA8DKhEzjfLvRcY3tkY17DlrhkFclKRERAREQEREBERAREQFFai/wAEz+Mf0KlVFai/wTP4x/Qry+mv6N3k06P39PNaYf1TPkFyXGH9Uz5Bclup4QCqUf8Amyu/g/4araqlH/myu/g/4aqrvao5tNjsXPp/MMq83SjstsqLhc5hBRwN3SSEE7RnHYAnzUVpvWmntSunbZbpDUugaHyN2uYWtPY4cBx8V19SbNV6h0PdrVb/AA/aqmIMj8R21udwPJ/BaXh6OaqZZbhRb7aJZoIMTmaQvm2bcwOPYMGOMD/S1annREPQ4q6YhhFRCRJ9z3x73y9V8FZTFjXioh2uO1p3jBPoFoB/SDUjdJwCj+r6S9U9wNTBFFO8sjjc3DhudnnIbwBjhcL90WvhobFDbvYKtlPQ+BPDUTPY2Odzy58jdvfl2PXgJlOI8XoN1XTNeWOqIQ8ENLS8ZBPYL4KylLgBUwkl20DxB39PmvPN96OamrKi6SxOonyyupDBJ7Q4fq49rzzk98YySVyoekOq6e8UjnSUJpoLyK8zCY7yzLcnGO4x29UyYjxeiI54pJHsjlY57PvNa4Ej5hVdvUTSrtQfUguzPrTx/ZvA8KTPiZxtztx3+K130r6Yag0zrKO43M0HgQska+oimkdJUl2cEjIHmO4Pb15WND011XT9RLvdadlsFBX1UkgmkkJkia7dhzQOzhuz8wozJiG3dSaptWn7NV3OuqA+mpS0SiHEjmlzg0cD4lZ1rutHc7dFXUszDBJG2TJIBaHAOG70OCF5zg6L6qFprqX2a0QyugEImjqZS6pPih2XZO0cD08hx5qRl6P6obTXimopaOnpaqGkd7OJ3Bk8kbWh4fgZAJ3HPmmZMR4vQZqYGwiZ08QiPZ5eNp/FfJauniLBLUQsL/uBzwN3y9V54q+juqZNP00TX24hlbNUfVPjyezxte1oAa485GD5+ffuvl46O6lqG2ZrKe2zy0tO2Fz31chiaNziW7HAuONwwQ4fJTkxHi9HqC1X+og/iP8ARTULSyGNhxlrQOOyhdV/qIP4j/RRVwUX/dy1B9IXVt701RabZZrzJbIJo5HziFo8SXaG7Q1xaR5njIyqjT9WdY2Kurqq4VbquFtip6ukp6+kMYmkc6IOd7mOcOee+FufXHUKg0XT2alqrZWXKqrYnyRw0zWnayNoLnHcR2B/2UbH1otMlVcmNst3NNbaaOrq6nw2bYWPi8RuRuzk8Nx6/DlF1HZjcqOsOsOr9KTRRXG3WR76i1C4wGGOZzS4yYDCS4dm8n4rEpOtGqrveqi009DbaaaSnkEUIinNSHez72zDgsLC7sDzj8zP1PWykuNVaIrdS19vnfcqemqKeopGSvfHK3czBEg2hwHcZPwXczr7ZnUFZW/Z29D2V7Y3t2Rb25JGXjflg4/1Y7hP9dY+SgWjrrqa1aXtwq20dxqnUE88k9TBIHmdszgIztLRwzaeB5jlWq2dXtX19s1Nc4LPaZ6WyQxSPhjbKJpDIzII5I2tOSf+6PxUpcfpBaeoqZk77NdpMQNmk2CIiPc8taCd+DnGcjIxhdj/AKQOm4K+WnqrZdIY46iamdNsYW7425PAdnnjy80/0x8lZs3WzVt5q7HQ0NvsL6i5VklIypLKgQOw1pBGcHgu57/gpfqzrC+6V6k2iWjdLUsislRUy0Eb3CGWVodyWjuB39cBSkPXS0m0msk0/eo5HTQQ09PsjL5zM1zmFuHY7NJ59Qpi7dWrRbdDWvVE9uuJpa+oFK2DY0Ssd73cE4x7p7FD/Ef0R6lXTXtxvtPdKagijoI6d0T6RkrRJ4gcST4nOPd44H491tlabn6+6ehp2Pbabw+dnimqgbEzdTNjcGuLveweT5Er7UdftOxVToY7fcpW+2CjbI0MAcSMhwy7OMfipyiYnwbjRVLpzrSLXNmN0pLXX0NE7HgyVQaBNy4HbtJ7FuDlW1HIorUX+CZ/GP6FSqitRf4Jn8Y/oV5nTX9G7yadH7+nmtMP6pnyC5LjD+qZ8guS3U8IBVJn+bK3+D/hqtqiqm2/+czWxd3M2Pb69sFcV0TVNMx3Stt3Ioprie+MeSI1VDc6jT1dBYpWQ3OSMsgle7AY48bs4PYZPZUWO19TYqIRsvNvMjKRrQXNaS6YOAJyWdiwF2cfePotolpHcH8l8wfQ/ktDE1xLbuoVRZr1BPcaKOtlbF7FJA8NEZDhv52ZGW57558gsKex9R/DpZYL1TmeFz2iOR4LdhawAkiMbn538uGAcHHdbUwfQ/kmD6H8kMtZalsmv66ooXWy709M0UDY6oeJgOnw/cQA3zy3BGMY7KLqtOdTn3aOqhvNE1kLdkbPHfsIAdgubtwTy3JOckemAtw4PofyTB9D+SGVT0VS6shmqZNWV9POzaxsEUDW4ztG5ziGg5yD8OfkrYmD6H8kwfQ/kiBQV71dp+yEtul3o4Jf/ZeIHSH5MGXH8l814y4v0beW2YS/WBpX+D4f392P9Px9Pitf0VTpa0yUU9kmkpKJzIn+BS0Ejq2R4BDmyEM3Ek7TknvlRM4dU05WSr6gOkjc6y6fulYwAls9S1tFC4AZJDpSCQB5hpUdUXrVNwo7hL9ZWi1xUpZ4kdBC+tqG7iMNBdtZnnHY4Kw6WkuVXJO62aUuM/ju3PnvVSKVjycEl0bd7zkgHHHp8FOUul9TzPe+pvlHaWyDa9tpoh4rhnPM8u5x5J8lG+XeKYQt0s1VS0F0uNdqDUlNUUlNJUQ19RVNZCJGE7WGINDCHDaccnkjjHNlkrai46VstbWxeDVVEDJZY8Y2ucwEjC50vT2xsqmVdxjq7vWNIInuVQ+oII7Ya47R+ACktTxPdBAGMccOPYfBJjcz6mYm3OGs+sd103Tv0zbdT6bgvAqIJ5opZZzF4Hhx7iMgZw7jPy81E6K19oF18udDXWa3WRtxo6SOWR0/ixVTXRgMi27QA1rTjPAVh6o2DTt4rtNjUdbc6SdlLVMg9lp3PYWuiw8vIacYHbtn4qMsvQzS1xpKWup7teaigqIadpjJEbZo4sbQ8bQeS0E9iMeSlZRjZjLjQ1fSGjra+2tprRTU9nnFYHtke4uladrnAD7wbkDufPgDk9RHQuKgEZFpbBWS5BJl3Et4zu7tb72PIfkph3QSwZu7Yrld46e4Ne3wGyN2RbnBxI93ntxuzhSGoujVlvc9mndW3Kkmt1JHQ76ZzWmWJmMbstODx3GO6OswwqGxdJNT3Q2Oit1rq66gifT+BHG9pjbG8Fw3DH+o985OTyeVVdLXzpNcrRDeL7aLfZqmSrqJmQVEz5i9zcB8mO3PbBHOMDK25ojRNFpB95fQS1EzrnWPrZDNgljnd2ggdvmtV1vRfSFHcLZp+S6X6OvrIahjJIW+7LGTvLXuDNoAPIBxn4oQsVXZeklmsVPSVdDbae23pntsO9kh8YRs3bg7uMNccDI7n1UXqyXpjqOyae0tBfaW2UkU8VZS00EZAeCDtadwwN24nnk5+KtusOlFn1To2y6erqirjitLWNgqYtvikNZswSRjBGM8eQVcPTXSdd1Iljoqu8UlwoaendPTQsLIHtYwMZh5bzxjLWuQhF3u99Fm6bjkiobbcYLVGamGlp4SJNrpA098Z94jIcfipHd0eut5t09bT22G9XUQ1jIpN7Hh8jQWB207WuORx59+c5WNW9D9I2GzGW6Xa5toYaJ9C5ztucPlLw73W5Lg53HHksrSnSrS1xuNv1BZr5eKj2QQxSEu2eM6FoazdlgcPd2ggYBCG5sLTktjsdezR9lpZaX2Om9pZE2J/hNY55ziQ8E7iTjOeVZVBVlELbd63UVVc7h7HHRlj6LO6BgadxkawDO/AwsjTF9pNSWeK5W1tQKaQua3x4XRO4OD7rgCpcpVRWov8Ez+Mf0KlcH0P5L5LbjW+EJPdja8OOfP4LF0lZq1GlrtUcZjC7TVRRdpqnuSsP6pnyC5Ii0RGIw6ERFIIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC6nzsY4tIkyPSNx/oF2ogi79cRRWC41se4Ogge9u5pblwBwOfjhVmSok01WULG3Gpq3GjfJVx1M7pRuAaGOHctLnnaAO+TwcK61dNBWU0lPVwxzwSDD45GhzXD4grEhslrhppqeG3UkcE362NsLQ1/wAxjlCVdotUV9VUso2UsPtTqvwNz2vjDWiHxHOLTzkZaMee4dkh1XVyi1vEFO2GqEYdJlxbve7AbkZ2Etw4bhg5xkd1Zaa1W+lINNRU0RGeWRgHkAHn4hoB+QXwWe2tmhmbQUwlha1sbhEMsDfugemPL0RCv6nvlRbb9C2nbLMGQNYIGZIdJNJhrnAcnDY5D/8A6uifVtZHbmTimiaWPkbM97XbWhpw1xaMua0ncC4g7S05yrXU2+jqhL7RSwy+KGh+9gO7actz8iTj0XTJZbZI2Fr7fSubCMRgxDDBnOB+PKDB1PeZ7VSwyQRRvLgXyk5f4TAOXbW+8W5IBI7ZzhYcepZ3iWqkbQw0UD3RP3yne5zY97i045APGMZIyfgrBXW6ir9nttLBUbM7fEYHYz37/ILrfZ7c+eWZ9DTOllYWSOMYJc0jBB+YAH4IlTanVVZO19PPG6mdFNA974mPjdsw+V7MOwfuRHnjO7sFI2jVs84e+vt9S1hhZM1sFPI97dxOGkYy7t94DHBVhpbPbaUg01DTRkHILYwDnBGc/IkfIrsoLdR29rm0NLDTtdy4RMDc+nZEICo1V4MZlMTBGauWFu4kHw4oy+R5HqC1wx8ljjUtyZG6Oakpn1jqaCojjhcXY3k7m4ONzgGucAO+CPipq5adttdT1bDTRRSVLXNkmjjAfh3DuceYyD813iyWttO+BtvpRC9we5giGC4dj80GALlJXaTdVMqoKWoqGOihnGQxsjnFjDhwyDnHBHB45UFQXae2OqoHurBcGmKI0dTI6qG524+JG5uXOBa1x28fd/0q6GhpDQ+xGmhNJt2eCWDZj029sLFbYLS2mNO220ghLxIWCIYLsY3fPHGUFUn1vUts/tUdNG6WOOWWVgZI7LWSOY3sMMDtjuXHjHYrsvVRVfWclUayqbRPkipo5aWYYo5twaWyRHAeC4jnnv2HdWd9htL/AA99toyI27GgwtwG5JxjHbJJ/Fc5LNbZK4Vr6CldVghwmMQLsjsc+vxQdepax1Bp64VUR/SxwOMeP28Yb/vhQdu1DUC80NsEYnp3vfTeMQ/cTGwlzy8gB3vNIIGe/fyVkgt1LDQspBCx1O07gxwBGd27OPnyuMFpt8FW6qhoqdlS4lxlbGA7J7nPx80SjKu91DLlVMibSspKSVkMzpnlr3lzA92zy4aQfjyOO6i2amujrfJUPpqKF8VALjJG9zjiN2drM/tHa7J7Djgqzz2qgqKk1E9HTyTlpaXujBJBGCPyJHyK+1FroKmSKSoo6eV8QAjc+MEtA5AHwQVSq1RUQNq6ynhHheM5rzK5zxC1jWjJYOWjfvaXAEDbkrJn1VNT3Gdk8VOymYx7o3bnESbW87XtBBIf7pbjcO/PZT81mtk+3xqClftc5w3RA4Ljlx/E8n4o+y2x8k732+lc+cFshMQO8Hvn5+aIVul1TXzzCkbSRGrdVx0zdzXxAbozI4lrhu91o/HI7LsotTVta0iCKiYYWB8sk0hayQOlexgZ6bgwnJz3A5VipbVb6QtNLRU8Tmu3AsjAO7btJz644z6L59T23xKd/sNMH04AiIjA2AdgPTHkggtP6nqLtc4YzROjpahkj43FjgQ1pADiTwQc+XbI7pXannpaueQwwPt8NZ7IdpJlcRHuc4Dt7pzx6A9vOw0ltoqSeSalpIIZZPvvYwAu5zyfnysS2WCgt73TMgjkqnySSOnewbyXuLjz+OPkiVfodX1k4Z41B4bphA6Nrmubt8WQNAOfvcEuyOPdKyoLzWXHU1NS0r4mUcctQX494ysjDGd/L33u/wD2KbZZLWynkgZb6VsMhDnMEQwSO3Hw8vRdkFsoKeWKSno6eKSIOaxzIw0tDjlwGPU8lBmIiICiq6+U1HUzU8jJTPH4QaxoGZDISGhvPq12fTBKlVGVNlpam7C4yeJ7S2Ewtw7gDn3sftDc4A+jigr0GtQyWSSqgd7D4bHxS4YwyOke4RsAL+PdbnJwOCTgYU5S6hop7HNdCXMghLmyN4cQ5pxtG0kEk4xgnOQsYaToWMLYpamPHgmMhzT4TombGubkH/TwQcj4LOkstNLZXWyR8zoXcmQvzJu3bt2fXdz6fDHCCDk1iKe5VMVbSSU7WeHFFBI5jZHykOe73i/ZtDNh7+frws+HVlBNAZGMmJMcT2MwMyGRzmBrecE7mEHy884Xz7KUvMntdb7WZnTGqL2mQlzAxw5btwQ0cY4wMYWXHYKFlwpKwNlMtLD4EYc8uGOcE55LgC4ZP7R9UQio9dWuRk8jGzOijidNG5hY4zNa4NO1ocSCS4YDgM54XOq1ZDE2QyQ1FM6mleJ45I2vdsZD4pxtfgcFvrycY5ysmm0tRQQth8aqfCwx+GxzxtjbG8Pa0ADkZA5OTgYyudTpegqZpZJTMXSl5eNwwd5YXeXpG0fLKDvkvLYrdDVTUdTHJPIIoaZwb4kjj2HfAyATyRgA5wq1V6xrW01bNBSkSMdK2CndGNxLXRxAOdvA/Wvd2zkA47c2y722O5xQtfLNDJDIJopYiA5jgCMjII7EjkeajafSdvg8PDqh5YWOy+TcSWyulyeOcvdk+uAghqHVtY2qm+tIzBBFI9gaIGl0nhtDX4LZDg+I5rR38h5kjOvOp56alcIqOalrgyVzYamMO37WtDeWuxgukYMjPmOO4zpNL298RY4zdngO3DLS+USlw477w0/gE+zFI97JKieqqJgQ4ySPBLiJGyc4GANzG8DAwAEHC1aqorhcm0MJLnkvY2UOZte9n3gG7twHBwSADj5ZXLUTKTUFJQbHbHvEUjjt5c4e7tG4O79yGkc9+Csq1WGmttSZYJahzRuEcTnjZEHO3EAADPPrnHYYXT9maT61FcZqncKj2oRbhsEm0tz2yeD2J48sIl9vGoobZVSwupamcQQCpnkiDdsUZJG45I/ZJwMnAKjn6pLLq5jR4tKHSsDWxfpHPa+ONrGndg5eX8nA48sZWXPpxtbdq+qrZ5fBqDEzwI3YbJGwZDX5H7ZeeCMg4PouX2UoAHlklSyUlrmyteNzHNkfJuHGM7nuzkEFEMOs1gynqYI5KOaFrHTGt8UszTsjYHE8O5+/GeM8H1XZDrOjmj/R0tS+cyRxsgYY3ueXhxby1xA+67OSMY5Xe7SlA/d4klS90kUsUznPGZRIWlxccd/dbjGMYA7LJo7DT080Mz56monikMofK4cuLCzsAAMNJ7Ad88lBxvV/itIoxPTTvlqc7Y2FgIwASMucAXc8NBJPOOyx6jVdFT3X2KaKZn3h4hLMZawvPu7twGAeSMZCyr3Yae8HFVNUNic3ZJExw2SNznBBBwc+YwfisKXR1BK+YyTVZZJ42Gbxhnigh+OM87jyScZ4RLiNYUopJ55qKshEcUMwbKGNLmSuLWkndhvIOdxGBypF17hjsrLjNDPG15DGwkAvc8u2taMHBycYOcc5zhfKqxQTyzSsnqIJpCw+JE4ZAY0tAwQQRhzuCD3+SfUFI2ywWyIyxwwOa+J7SN7HtduDhkYznnGMfDCDBuWq4rbRiett9ZC4by+N5jaWtZ3OS/Ds54DSSVxuGqA2SGOhp5XtkqmU/tL2jw8/ekb33ZDA7nGMjHlhfarR9FVMc2aqrT4kJhmPiAmYFznckjjlx+7geWMcLtn0pRTVEkjp6wMc6V7YWyAMjfK1zXuaMdzuJ5zgnhEMGTXdBHDFJLS1UYkhFSGyGNrhCRw/BdznnDR7xweOytrXBzQ4cgjIUPV6dpKipjmElRDiNkL2RPDRIxhJaDxkYJPYjuQplEiIiAiIgIiICwqu60NJVR01TUxxzyY2sJ55OBn0yeBnueFmqCns1S671VRBVRsp6sxmZro9zwGDAa0k4APB7cc478Bk/aC1YqCa+ANgaXyOLsANBwTnzAPGR5r5BqG0zytjir4HPJLducHIBcQfQ4BPy5UM3Sc8sFDDW1cL46KKOnjbHCWh0bXsc7dknJd4bR6Dn1XbXaUfUwyNFYGSSTVM5eI/9crHMae/+ljsfHHkiEjDqazTFgiuNO4uLQ3Du+44afkTwD2zwsmW8W+KETSVkLYiJDuLuMRnDz+B7qMl0yx80jmytZG6amcGBnaKDBbH3/aBP4rAGj6iSnggqq6J8UMPs4AhPvNMrHyF2XclwZg/MolZ6C4Ute2Q0c7JhG7a/aexwD/QgrKUZb7fNR11XMJY3MqpzNICw5HuMY0A58g308/JSaAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIP/Z",
+              "timing": 1875,
+              "timestamp": 148276976
+            },
+            {
+              "timestamp": 148651976,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAICAwEAAAAAAAAAAAAAAAUGBAcCAwgB/8QATBAAAQMDAwIDBAYIBQICCAcAAQACAwQFEQYSIQcxE0FRFCJhcQgVFjKBkSMzUlRyk7HhNDZCocEXYiSCJSc1VXOU0dM4U3R1g7K0/8QAGgEBAAMBAQEAAAAAAAAAAAAAAAEDBAIFBv/EADERAQABAwEEBgoDAQAAAAAAAAABAgMRBBIhMXEFFDJBUbETFSMzUmFyocHRIjSBkf/aAAwDAQACEQMRAD8A9UoiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAi+OcGtLnEBoGST2Cr0WuNKzXD2GLUVpfV52iJtUwkn079/ggsSISAMk8eqrp1xpZtf7EdRWkVedvhe1s3Z9O/f4ILEiAggEHIPmoq86htdlext1qvZGPxiaWNwiHzkxtH4lBKoqF1rqv/AFSX+po5+DTtcyWJ/cFzeQQpY6v09ZqSgprvfLdR1ToY/wBHPUNa7lo5IJ4QWdF101RDVQMnppY5oZBuZJG4Oa4eoI7qFu+sdN2erFLdb7bKSpzjwpqljXD5gnj8UE8i6qSpgrKdlRSTRzwSDLJI3BzXD1BHddqAiIgIiICIiAiIgIiICIvj3bWkoBcG9yAvgkYezgou5XGkt8BqLjVQ00OQ3xJnhjcnsMlYFHqWx1tSyno7xb56iQ4ZHHUMc53yAKCyouineT7p/Bd6AiIgIiINb9cJ5n2ex2hsz6ekvF1goauRh2nwXElzc+WcYVjq9C6YqLC60PstA2h2Fga2FoLeMbg7GQ7491mau07Q6qsU9rubXeDJhzXsOHxPHLXtPkQVT5dF6zqaI2yq1491tc3w3vZb2NqXM7EeJu7488ZQUQ325T9D6OhdWylkl4FkdXtdhz6bxS3fn4tG3K24zQOlW2P6pFit/sWzZgwt3dsZ3d93xzlc5tE2SXRI0qaYi0tiETWg+80g5Dwf2t3OfVVpuidaMpPq5uv5fq0N8MONvYanZ2x4ue+PPGUEN1BqqnQnRQ0+nbxNVmOVtGyuc8OfDG55BG4ebR7oPcLYun9OWy36cZbo4hUU80IbO+Y+I6oyOXPJ+8Tlddu0bZKLR7dMikbNafDMb45veMmTkucf2iec+qxXaeulssos+mK9tNTbPDZUVr3VElO3thjeM48tzjhBpWnnlp+kXVCwNlfNbrNXPp6N7jnbH4g9zPwx/utz6J0pZqPSdJGaWmrnVdOySpqZmCR1U5zQS5xPcHPA8go8dM6Cn6a12kqCpkj9tBdPWSN3vkkLgS9w4znGEj0dqO00nsGl9Ux0VtDdscNVQiodTjzEbtw49A7OEFU0/VzaQ/6o2qyEuoLPF7ZQxfeED3xOe5g+AIzhWnpZpKxw6GttS+jpa6quNO2pq6qeNsj53yDc7JI5GT2U1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93cu+GOAFXaLQWodPskotIat9hs5c50VJV0Tak0+TkhjiQcegOUHR0+hjsHU/Vmm7WNlmZDBXRwA5bTyPyHNb6A98LaCrOiNIwaXhrJH1c9wuldJ41ZXT/fmd5DA4DQOAB2VmQEREBERAREQEREBERAXCcZiK5oeUFd1GKk20+xCuM24f4LwfEx/wDy+7j/AHUFZW3f60g9qGovByd3tQofD7H73h+/+Suz4SD7vIXERPJ+6g+wD9IFlLhFGGD4rmgIiICIsOquEVPVx07s73NLycHDW+v5oMxF8aQ5ocOx5C6KiqENVTQloxMXe9nGMDKDIRR9BXvq6qpjMIZHE9zA7cSXEHHpj/dYgvrvHqI3U4AikDGnf979IGE9vLOUE2ii667ezVL42xMeyNrXPJk2uIcSPdGPe7fBfaG6e01pgMbWNO/adxLjtdtORjA/MoJNERAREQEREBERAREQEREBERAREQEREBERAREQEREBcHxMe9j3NBcw5afMLmiAuqengqA0VEMcoacje0Ox+a7UQdUdNBHM6WOGJkrvvPa0An5lcTRUp8TNNCfEOX5YPf8APn1XeiDpFJTjw8QRDw/ue4Pd+XouTYIWyulbFGJHd3hoyfxXYiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIIi832C2vEW0yzEZ2g4x8yoj7YO/ch/N/soG97/rar8XO7xD39PL/bC1/qek1FLq+2T2t1ULWxsYn8KZobnxCXZYSN3u4H48ZxheXVqblVcxE4h79vQ2abVNVVM1TOPHvbe+2Dv3Ifzf7J9sHfuQ/m/2WpKGnvreodwmqWVbrI9rfZ3+0t8Jp8MB2Y855dnnHddGnrfqWHWte65VE77HGZH0znTBwk3luGluc+6M9wufT3fj7s9zvqenz7ueOO//ALx4NxfbB37kP5v9k+2Dv3Ifzf7LS+nKTU0do1HHcWVra57JPY5JKtrw4nft2AH3CMt7/D0Xfp6j1Q3T18gu00n1jJHso5DKDz4QAcCCdp3cn45Kmb92M/z8iNJp5x7Od/P9tw/bB37kP5v9k+2Dv3Ifzf7LSlRSark0ZcWs9rF2kqWOhjFS0SNjGzcN27Azh3n5q5WNs7bPRtq2Sx1Aib4jJpBI8Oxzlw7n4rmrUXYjO15OqNFp6px6OY3fNeftg79yH83+yfbB37kP5v8AZaj0vT36LVd7fdo6w0L5JDSSPqmuiDC4bWiMEkHGefThYWhaTVsF6mdqJ1S6nMbtzn1DHxufu93YwDLRj4j5KZv3d/8AOPs5jSaeZiPRzvz47m6ftg79yH83+yfbB37kP5v9lprTVHqmLWlfNdXzmzOkqDA10wcAC9vh8bjxjOOOOfVYmkaPWsWrpJb3NI62Ey790rHMd+xsaDlv5DhT6a7v/nH2RGl0+72U75x3/wDeLeH2wd+5D+b/AGT7YO/ch/N/stS6cp77FrG8yXOOsNte5xpZHVLXRBuW4aI85B78/NdGkaTUsOrLrNeX1TrY8P8AA8SZpbkvG3a0E4w0d+O/ZRN+7v8A5+TqNHp5x7Od8/Nu23apgqJ2xVERg3HAduyM/HhWJamW0Lbv+r6bxf1nht3Z9cLTpL9VzMVdzz+kdJRYmmq33slERbXmCIiAiIgIiICIiAiIgIiICIiCIvNiguTxJuMUw43AZz8woj7Hu/fR/K/urcior01uuczDVb1t+1Ts01blR+x7v30fyv7p9j3fvo/lf3VuRc9UteHms9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6Vy3aWgp52y1Epn28hu3Az8eVY0RXUW6bcYphmu3q707VyciIi7VCIiAiIgIiICIqL1q1bXaL0HU3W1RMkrDKyGN0jdzY9x+8R59vzIQXpF5O0z1O6mV8tNU091ttzjkkG+jAp/Ga3OD+jG15/DKlperGsIOttRZ2uqam1R3GSmbbGU8e9zBkAh2zdj/X37IPTaLRtz+kNbrffbpbJbDWPfRSywhzJgfEcxxbwMcA4/Bdtj6/0V1vrrYLBVQvbDPKXuqGn9VE+QjG3z2Y/FBu1Fpax/SBstdYrvdK62VVHHQGFjYxI2R875N+Gt4AGNhOSuWkOv9k1DfILXJa66inqXbIHPc17XvP3WnHIJPA4PJQbnReYekPVvV1211NR3qSouVB4EzzAyCNns+3BD3FrAcDG3nzcFbbb9IOhrrHeLk2wVLG21sTnMNQ0l/iP2cHbxjug3ii0FU/SRt8FNRzHTtURUxmQD2lvu4e5v7P/AGqWn+kDYaezVFfNba5rhVOp6aAY3TtaATIc42t5HqeUG50WlrH9IGx3SgubzbKymraOmdUtp5HtxOG92tcOxxzyOyaT6+W/Ud3tlugsVZFPW1QpyTKHNiBxh5OPUnj4IN0ovMP0qb9d7VrK0xWu619FE+gDnMp6h8bSfEeMkNI5V61F170/Yr7WWk0dZVPo2Pa+dhAY6VrfuDz5Pu7vI/DlBuRFQekvUmn6i01ymprdLQiiexhEkofu3AnyAx91VXVv0grDYb/VWumttbcPZZDFNPG5rGbgcENz3weM8IN0ItJ376Qllt9BaqyhtdVWw10bnkGVsboXNdgscMHnz4PYhZH/AF9sDLNX3Got9bGyGoFPTRcb6nIJ3AHG1oxzn1CDciLR9D10tGp7Ff6SGnr7Tc4rdUTwHc0l2yNzvcd5OAGRkeSq3RzqjHp7Q2oLnqWuu1z8GrhihZNJ4ji57XkNaXHjhhJycccD1D0yi0hYfpFWG4VYir7TcaGNzHvbNlsjcNaXHPY9h5Z5WLT/AElLJLV7XWG6Npdwb4wcwkZ9W5x/ug3yi0rfPpDadtt2uFDBQVtWKUOaJ2kNZJIDjaO5A7+98PjlR0v0jqCO0U1edO1RbPPLAGe0tyCxsbs52+fiD8kG+0WotM9dLHe9V0Vidbq+klq/DbFNKBt3vYHBpHBxk4BxzwexUZfvpF6ftt5qKKktddXQQSGN1SxzWtcQcEtB7jPrhBvBFqbUnXXTVosNpuNNDV10lyjMsVOwBjmAOLTvJPHvAjjPYqU6XdWLR1AqqmipaapobhAzxTBNg7mZAJa4ehIznHdBsVERAVI6w2i/XrRzqXS7aeSuE7HuhqNpjmjAO5hDgWnuOD6K7og8ds6Na9ut+pXy2CisrA5u+ogqIwxmDnfta9xz/CB2Vx1V0z1vbur/ANqNL00FbG+cTsmfKweGS3a4Pa4gnz7ZXpNdck8UTgJZY2E9g5wCDz3036eaptHXGuv9ztXg2mWorHtn8eJ2Q8u2naHF3OR5KO1R0o1lF1Tu98sVLSVNHWGpkZLJM0Bomie1zS0kHPvkDyzgnjK9Lte15Ia5riODg5wvnjR+Js8Rm/8AZ3DP5IPI9j6Iayn0lfaStt7KOsM1NUUrJKiNwn2CZrm5a44OJAecK7aJ0x1PqtU2KTUtBa6K2W5scZkfBSySGOPkNaW7nAn1BGO69AunhbJsdLG15/0lwB/Jcfaqfn9PFx398cIPNmjul2t9J9TKmejpqeWz1fiU81b4jCPZ3uBPukhwdwPJVum6N9QLbZ9Q26G20k0NU2JoLahmZtkocNmXDHmTux6DleuWVELyAyWNxd2w4HK1VfusTbT1Vi0WbIZS+qp6b2z2rbjxQw52bPLf2zzjyRDRVf0Y19LQ2qNlgJfDC5sg9rg90mV7v2/Qhbq+kD06vGsY7PcNOeE+utxcDTveGbwS0gtceMgt8yO6xqzrwaalvcz9JV8YtsjWDx5vDEmXhvJ2na7nOOeM8rYHTLWbNcaVp7z7IKAzSSRiAzeIfdOM5wM/kg0nQdPOodxt+oai9W620809HJFFTtZA6eeQt2j9Ny4DHOS/4dle/o36QvmkNO3am1HQexzz1QkjaZWSbm7AM5aT5q+6wv8AWWWCBlrtFRdK+oJEcbHtijbjHL5HHDRz8SVNipY2GN9Q5kLntB2ueOD5jPmiWgPpHdPdUav1VbazTtrNZTw0Qie/x4o8O3uOMOcD2IULe+lWvaDU+q/s7HSy2u9QzGSVz48ua4l/hYcctcXe7nt55XpxksbyQyRjiBk4IOAkc0UhIjkY4juGuBQab+jXou/6OoL7HqSgNE+plhdEDLHJuDQ7P3HHHcd1SK7p11G0vqjUb9I0VHX2+7ueHSyGF36Nzi4AtkI5GcHggr0wKqnIJE8RxyffHC1/1h6nN6cR2l5tRuIrzKBio8LZs2f9rs53/wCyDS2u+k2vbpbrDi20lZWRwyGoFJ7PTsiJdw3ALQ44AyQPP4LZ3XLp1dtYWCwy2PwfrK1Z/QSODQ8ODc4J4yCwd+O62bpu7svWnLTdXRin+sKWKpERfu272B23PGcZx2UhHPDI4tjlje4eTXAlB5nj6Za+1JeLzqLVdNSwV/1ZUU9PTwvjBnkdA6NjfdO0D3u5P9sDTPSvW9DoS82+awUUlTUV1NMKasmjc2WNjJQ7a5r/AHXBzmc5acZ57r1OKiEvLBLGXDuA4ZCMnhkDjHLG4N7lrgcIPLukumvUqCera6ipLbbfAmDLdU1LainLnMIDWsLn4y45yT6/JYVm6YdSoL1D9W2qmsFOXN8Z0Nbuglwe72GR5d8sY+C9YRyxyAmORjwO+05XFtVA4EtniOOTh44QeWbh0j1/aqvVNusUNLUWe5t3GQvjDpmtfuYwBxy13PPYcd+yr9R0a16/TNBSNsJNRFWVMr2e1wcNcyANOd+OSx35L0x1D6j2PQX1f9eCrf7aHmL2aMP+5tznJH7Q/wB1ZLTdqS52aiudPJtpayFk8ZkIB2uAIB+PKIeb4umGsG9WdP3g2ci20ptpmm9oi93woYWycbsnBY4cDnHGVi0/TbqZpGpvds0zQUNda7g8Znl8B4cxriW5bIeDzyMEL1Q1zXtBaQ4HzByomXU1liv7LHJdKRt3eNzaQyDxCMZ7fLlEtA6z6SayqKXTN4oDQVV9oYdlRTwbKZjXCR0jdm3a3/UQe3bKuXRLSer7XebhdtXU1tohMxzWQQwQmZznOBLnSMBJHHm4k557LcaICIiAiIgLyj9LsluuLKRwRbwR/NevVy0j136UX3X+orfX2aptsMNPS+A4VUj2uLt7ncbWO4wQg0/o641ts6gVztFXS43EyWuonqHzMcHOm9nc525p7kS4wT5+vnT/ABbd9mxeBfbh9r/bf1GHY8PGfE8T9rPx/DzXuiy6ctNnnqKm3W2kpquqO6omijAdK7uST3PPKrNvtnTev1M/6vg01UXxj3PdHCYnSte0+8S0diD3OEQ8264rqiLq/pa6agJgmMNrqap7xjBDYy8n5EO/JU2KRsr9ZSRncx9OXNPqDWQL3TeNM2O9VdPVXa1UVZUU5BilmiDnMwcjBPlnyUT/ANONHZqT9nbfmpG2b9H98bg7n/zNB/BBpf6MWh6S40NJqyatqxVW+smiipwR4WDG0E4xnJ3evkFX9e//AIrqX/8AdLd//SFeo7BYrXp6hNHZKGCipS8yGKFuGlxABP8AsPyWDV6M05V39t7qbPRy3Zr2Siqcz3w5gAac+o2j8kS8I2v/AAGof/0rf/8AREs2OenptPWeqtt4rvtDDVPa2ka1wbBHnc1zHepcTwP+OfaUfTPRcbJms03bmtmbtkAj+8Mh2D+IB/BZdDoXS1BNSS0lgt0ctISYHiEExknPBPx5RDyNruolu3Ui/N1vXVFHJAHCAEuAaQBsAAa7gjnsM57hRur5/F0FpiOO6VVxp4qmsbG6eAx+F7sBLGkuO4ZOfhle0b/o7TuoZ2z3uzUNbO0bRJNEC7Hpnvhddy0Ppi50dFSV1joJqWiDhTxGIBsQdjdtA7ZwPyQeetT6Un0b0RbfLJcLhLUX2Gh9uLnD9FEYycNIAIbktb8uFS+nf1ZRax0zPadQVsNdK+Lxo4YHTbpC7DozwzAI4/1cc5Xriiu2k6s/ZmkuFnqHRMNKba2aN7g1gwWGPJPAGCMcYXKy6J0zZK41tpsVvpKvBHixQgOGe+D5fgg8hdDtGUuutUXG1V1ZVUtO2idO405AL9ssYDTkHjnPzAWy/pfRCC36PhaSWx+0sBPngRBb00/ozTmnaySrsdnpKGpkYYnSQswS0kHHyyB+Sj9ex6IqH0cWuZLMHMDnUzbhMxhwcBxaHEegQeXdV1gn1Louk1Jcq23WOnslC+GamaXOj/8ADtdvaB5+IMZ+HwUx9FI7uqVwduc7NtmO53c/pYuSvTc+ldOXGntfjWmgqYaBjBRF0QcImgDaGn04HwXyxaN07YbhJXWaz0lHWSMLHyxMw4tJBI/MD8kHlrrOyo0J1hu1bQN2sudJJIzyx40bo3n8H7j+SjK+23LT/Qu11lN40MN8uL5Kp7MgmNjdsTCfQkSO+PC9dai0jp/Uk0M1+tNJXSwtLI3TMyWgnOAsx9jtcllZaJLfTPtbGCJtK+MOjDR2GD6IPJ3SAW2h6l2xlgv9aRKza+BkDpGzZYS9ryQzAGM52nGO5WvNOUftGntU1Hjzxmko4pAyN+GyE1MTMOHmPeJx6gL3PYdH6d0/NLNZbNQ0Usg2vkhiAcR6Z74+Cwafpzo+np6qCDT1vZDVMEczBHxI0ODgD/5mg/gg8Z34zVfTnTNZUOllfFV1lGJHuJ2xtEL2M+HMkh/H4LJuVXba+52C3T109NpqChiDSHPDWyFm6YjLXHmcyDIae3HGF62ntvTygpTpeoZp+GKSbxfq6WSMEyEAZDSc7iMBSc+gtKT22noJtP219HTkmKMwDDM8nHmMoNVfRWljFJfKaku9XXUkbmOEMtOWMhcd3LXEnOQBkYHYKRu//Tv/AK+U3tnt51Xujxj/AA3jbBsz57tu3Hl2W27LZ7dY6FtHZ6GnoqUHIjgYGDPrx3PxWPJpqyyX9l7ktdI67sG1tWYx4gGMd/lwiUuiIgIiICIiAiIgLxfpC2VN66qaytlAGmrq4LnDEHO2gucXAZPkvaC1JobpBJpjqPV6pdemVLZ3Tu9mFNsLfEJP3tx7Z9EFFvOtNS9LNNaT0VQU1F9eugdJNJM4PY0PmeGBpyB65JOArFoXXPULUFDfrfX2qOmuVPTPloq9tOfAfI0j9GTktdu8iD6q1dWOlVNr2robhDcprXdaNuxlRGzeC3OQCMg5BJIIPmVD6S6NVGnLffJItS1FRfblTupm1skR2wtcRucG78lx9S7hENX23rrra7OtdooG0f11UVhhdI6nG1wdsDBjPBB35PyWZP1s11c7lWt03S0E1LQkNLXRAyzDON23dkkkE4aOFOw/RuNNTUL6PU3g3OnqHTGqFIeR7uwBu/gtLXHOed3wWVdfo8GeuqZrXqia3wVmDU07Kcljj3cBh493OSAc49SgrmuututLW6yeHQxWqoqKES1FNU0xz4niyN3N3chpDWkD+q74ututYda3m0T2y3SvpxVBtMDjwTEx7id+feADDn18sKf1P9HiG5ttUduv76aKhpBTuM9P4z5Xb3vLyd4x9/GMcYWc/odK7Xt21H9fsDa41hFP7Ics8eORn3t/O3xM9uceSDX3/X3Vc2jZ6ljaCO409dFEZWw5a+N8cpwWk8EGPuPVStn63axpK/TlVqG2Un1HdcRtka3D5AHBj5G4PBBPYjt+aq3VLpXN070UCboLka+4Q8MpjHs2Rzf9zs53/wCyufSXo3S3e36Y1Lc7pUyUkcYnZbXN91sgeSfeJ4aSASAPxQa+st/ZpbrnqW9yRGUUdTcpBHnG92ZA0Z8skhW2y9ZepFdJT3Cns9FcbfLKW+zUsJc/APIw1xc34Fwx81dafoNA/W13vVyvAqaK4vqnPpG02xzRNuxh+48tLgc48lF0n0cvDqoIqjVtZJaIpDIKVkJY744O8gE+oag2F1a19JorQcd6pqQurap7IYIZwQGPc0u98d+ADx6rzD1jvuqL63T0+sbbHR1LqZ0tPJHgNnieQQdoJwR6HntwvWevNDW3WOkfqCrdJTwx7HQSx8uicwYaee/GQfgVqK5fRvlrKajY7Vs8ksDSwvnpzIAzPutYN/ugD59/JB0au6t6npNSQaZ0fTUIdSUsQfJU7d0jvDa44LnBoHIGO5WzOjOrr/quyVT9U2eW3VtO8BshhdEydpBwWh3mMc/MeqretOh0d7vUV4s9/qLRcTCyKZ8cZcHlrAzcMOBbkDkZKuHSnp9S9P7PUUsNbNXVNS8PmnkG0HAIAa3JwBk+Z7ol5K1K65S6rrqnW9Zead75HOhqYIvFYeTgsy9o2Y7bT2V3k6l33RWhtPRaevlPdI6iWq3zzxue8Bpj2tIfy0gOPHI5GCVca76PFc+Keko9a1UdskeXeyyU7nN75GQJADz8FIXH6PFtqNJW21U14mhrKSWWZ9U6EObK6QNB9zIwBsbjnyRCHb1b1QerFssHi0n1dUOpA8eAN36SGN7ufm4qF0R1Y6navrKqhslPb6yqjjEp/Rsj8Nu4An3nAHvj8Vc7X0GloNbW6/8A2lkqG0j4XmOanLnv8NjW437/AD28ccDA8lMdHukEnTy+1txfem3AVFN7P4YpvC2+812c7j+yg8/6at1bdevD4bqaaarhus9RWFxcGO8Jznybcc9mO2+WcZ4V1b1u19eqqsrNO223uoIZQ1tMI/ElIJ443b3H1LRgfBbH070bdaeqdVq+W8sqIp6iqnNH7MW8TB427957b/TnCr1f9HNpraltp1TV0VqqJA99IYS7gHIGQ8A48iQg3Po27VV80xb7jcKCW3Vc8eZaWVpa6NwJBGDzjjI+BCmVFaWsdNpvT9DaKF0jqekj2NdK7c53OSSfUkkqVRIiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiKMqp6r2mVkB2sZxwwOycA+ZHqqb16LNOZiZ5OqadqcJNF0U0kktI15aPEIPB4Gf91gUNwqZp6VksUTWStk3FriSC12MDjt8f8AYKyiqK6YqjvczGJwlkVfqLpWx01fPtibHDN4TCWcfrA3JO70J8guyO51JqaOAeFJ7Q0ObI0cYBO/OCR2xjnuV0JxFAQ3eqdNVNfHEGxztjadpGQZiz154HfjlcHXmq8KscwwOfDP4TWBm52PE25I35PHyQWJFFVNyfBZIqyR0Ucj2tPPvNyfIc/8rF+uphJL4ngMYyMvPBdsw1p3Eju0kkDCCfRQVDeJ6itpIXsjDJWbi5ozuPvdueMbRnvycKdQERYlbJLuEcJLTsc/IAJOMcDPzSIyiZxGWWixqKVzw9r3btuMOIwSCM8j1WLa7hLV1tXFKwMETsNbjnGSMk588ZxgceqnBE53pNFX6G+VFRVwQOga0mSRsjsHGAHFmPntOfkvhvVU19LmBhZNHTuL2g+66R2CCPTAOPioSsKIiAiIgIiICIiAiIgIiICIiAseWkilkL3bg498OIyshFzXRTXGKoymJmODjExsbAxgw0LkiKYiIjEIERFIIiICIiAiIgLrmhZMAHg5HYgkEfiF2IhjLhFEyJm1gwO55ySuaIgIiICIiAiIgIiICIiAiLpNTEKttNu/Slpfj0CiZwmImeDuREUoEWBcq72fDIsGTuc+SwPrOp9W/krabNVUZhXVdppnCeRal6kdRLtYamjt9mp2T11T72SzIaPl+BVOu3VHW9N+qhia4DkGkyM/NU11RRVszO9dboquU7VMbnotF5hPVLqZh8gpaYQtGcupQM/LlbJ6VdQbjqyyzSXBkMdbTybH7G43DyO3y8x+Cm3MXJ2aUXIm3GaobVRQP1nU+rfyWZ9YTvpGvpKYVE4e1r4zIGYBPLsn09FZVaqpjMqqbtNU4hJIo/2m4f8Au9n/AMwP/ou6jfVySSOqoo4Y8AMa1+455yScD4fkq1jKREQEREBEWDeaielpBLTt3bSd+GlxDdp5AHxx+GUGci6J52ikklieHbWFwLefJdzHB7GuaQWkZBHmg+ovjyQxxHfHC8uXDrJriDqPJYYzR+D9Y+zMj9mBcYy/A5z+yQcoPUiLzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiLqnnjgMfinHiO2A/FRMxEZkdqIikFW6FxdrKsye0eB+TVZFWbf/nKt/g/4aqL3Gnm06fs3Pp/MLMuuolEML3u7NGV2KOvb9tO1o/1O5WminaqiGSudmmZQ0j3SPc9xy4nJXFEXosCh1tD7RreqqZmgmJjWR/AEDKn2wsDQC0H8FjXOBzbxPI3hz2NI57jssaA1ranD9ng+rHE4/NfM6mfb1c31+hjGnoiO+Hy9QNdA4bRghV3pvF7FrK5QRjEc9P4px5ODgP8AlZdZNWVBkw1hjaSMOeW5Xb06pX/XVfUuydsLYyT6k5/4Vuin28YZuk4zYn5NhLvo5zTzteO3Y/JdCL6GYzGJfNROJytgOQCixra/xKKInuBj8lkrzZjE4b4nMZERFCRF01kxp6aSUM3lo4bnGT81ixz3M1MLZKGnbC5xEjxUklgwcEDZzzgdx3ygkEREEXdWWq2UVVcqylgbHBG6WSRsILsAZPYZK5UdDRyxxVNI6oZG9ocwNmka0A9vcJwPyUi5oc0tcAWkYIPmvqDGdSOP3aqob8iD/UFVd3TqwyX8XqWEvuQGGzlrAQPThuPh6447cK4ogqN96f2S/XKmrrxEauencHRmRrPdPHo0Z7Dg5CtcMTIImRRDaxgwAuaICIo603CeulrWT26pohTzGJjpi0iYYB3t2k8c+aCRUHq8kW+MjuJAf9lOKC1h/wCzY/8A4g/oV5vTH9G7yXab3tPNNxnMbSe5C5LjD+qZ8guS9GnhCkVZt/8AnKt/g/4arMqtSSCPV9a4gn3PL5NVN7jRzadP2bn0/mFpUVfc4h9Of+Fme2M/ZcsK6ytmpxtaQWnPK2Wt1cMNyYmmYhEoiLcxoa7scyujmI/RuZ4efjklR0tY2NznFzdreAzOPxTWd8bbq6y0JjDzX1Doy/P6vEbnD8yMIRDhxIDXHzwvndfTsX5x3731vRVe3poz3bkJT1kb6qZhe3a88MznHxU1oSF7frGY/q3yta34kDk/7hQNwmgppi7LS/19PirNoOugrLEzwuHtc7e09+TkH8Qrejrc1Xtvuhm6XuxTa2PGVjREXuvm0/Zxiib8z/VZqgKe7SU0QiFqrn7cjc0xYd8Rl+V2/Xkv/ue4fnD/APcXn176pluomIpiEhdal1Hb5p2AF7R7oPbJOBn4crr8O5fvVH/8s7/7iirjcZ6+kdTMtdZEZHNG+R0W1o3AknDyew8gpr2xn7LlziU7UOiWlrp2iOarpvDJBcGU5BIBzgEvOPyUgsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkosb2xn7Lk9sZ+y5MSbUMlFiSVn6N3hsy/HuhxwM/FULQNx1lJqfUbdTQUTbaKkeB4T3kt/RtwI8jluMZJx725MSbUNkIsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkqC1h/7Nj/8AiD+hUp7Yz9lyhdVTtlt7AAR+kHf5FeZ0xE9Ru8l+mqibtPNYYf1TPkFyXGH9Uz5Bcl6NPCFQqlH/AJsrv4P+Gq2qpR/5srv4P+Gqq72qObTY7Fz6fzCXXF7Q5pB7FckWt5qqakvdPYo81AdJK77kTO7v/oFQbpre6VVQ1tJG2lgDXOdt5c4YOBkjgrZWrdOQ36jxwyqjB8OT5jsfhytRXC21FHN7PWRGKXducCMAHPugeuSF6mlqt1xv4s1ymYn5MC/RvrrdM1gkkr97Z43l3vb2nG7J9B/VXDS9c+6WOCadofLtw4EgEOHfKrMrZI6hs0R2StccZGRggNPH4ZWTbRNT0kjoJ2sDow/BBw4k+Xx81k6S0E6nFVPGHq9F6+nS5pr4Si7vUiXUctK8NMccZkMbXZHcAZ9e5/JR0NbVNubqimMlO9oDQ5jiCRnjP+6z44HATOe4GSbAkfjJOCTtB/Ht81xZTnxmgYwHbTznLifX4bT+a26XT06e3sUw8/VXqtRcm5Ul9P8AUG7UzR7e1tXCXluXDDhjsAfj8VtHS15ptQRGSmDmmPHiMcPu/j2K1RpzT1Vdm08FLCcOO98h+6wcjJ/Jbs0/Z6ayW5lJStHHL34wXu8yVXqqqKIxHFXbpmZ+SSX1EXmtAiIgIiICIiAiIgIiICIqL1LqdXQPtH2Up6WSJ1bEJy97t2M8hwAwGepzn4KCIyvSLppDOaaI1bY21G0eIInFzQ7zwSAcfgu5SCitRf4Jn8Y/oVKqK1F/gmfxj+hXl9Nf0bvJp0fv6ea0w/qmfILkuMP6pnyC5LdTwgFUo/8ANld/B/w1W1VKP/Nld/B/w1VXe1RzabHYufT+YS6Ii1vNFgXW1Ud1h8Osha/H3XdnN+IKz0SJmJzA13c+n8viSPoKprmu7Ml4LeMd/PlQ0Wkr3FROiNGQ8YY3bI1w2g9+/wAfTyW3UWmnV3I+aubcS1DFoy8SvJNK1vOG73hob6nj5u/NT9n6esiMLrjVeIIyD4cQwHHjufwP5q/olWruVbuCdiGNQUVNb6VlPRwtihYMBrQslEWaZzvl2IiICIuipqoaZoM7wwHgZUImcb5d6LjG9sjGvYctcMgrkpSIiICIiAiIgIiICIiAorUX+CZ/GP6FSqitRf4Jn8Y/oV5fTX9G7yadH7+nmtMP6pnyC5LjD+qZ8guS3U8IBVKP/Nld/B/w1W1VKP8AzZXfwf8ADVVd7VHNpsdi59P5hlXm6UdltlRcLnMIKOBu6SQgnaM47AE+aitN6009qV07bLdIal0DQ+Ru1zC1p7HDgOPiuvqTZqvUOh7tarf4ftVTEGR+I7a3O4Hk/gtLw9HNVMstwot9tEs0EGJzNIXzbNuYHHsGDHGB/patTzoiHocVdMQwiohIk+574975eq+CspixrxUQ7XHa07xgn0C0A/pBqRuk4BR/V9Jeqe4GpgiineWRxubhw3OzzkN4AxwuF+6LXw0Niht3sFWynofAnhqJnsbHO55c+Ru3vy7HrwEynEeL0G6rpmvLHVEIeCGlpeMgnsF8FZSlwAqYSS7aB4g7+nzXnm+9HNTVlRdJYnUT5ZXUhgk9ocP1ce155ye+MZJK5UPSHVdPeKRzpKE00F5FeZhMd5ZluTjHcY7eqZMR4vREc8Ukj2Rysc9n3mtcCR8wqu3qJpV2oPqQXZn1p4/s3geFJnxM425247/Fa76V9MNQaZ1lHcbmaDwIWSNfURTSOkqS7OCRkDzHcHt68rGh6a6rp+ol3utOy2Cgr6qSQTSSEyRNduw5oHZw3Z+YUZkxDbupNU2rT9mq7nXVAfTUpaJRDiRzS5waOB8Ss613WjuduirqWZhgkjbJkkAtDgHDd6HBC85wdF9VC011L7NaIZXQCETR1MpdUnxQ7LsnaOB6eQ481Iy9H9UNprxTUUtHT0tVDSO9nE7gyeSNrQ8PwMgE7jnzTMmI8XoM1MDYRM6eIRHs8vG0/ivktXTxFglqIWF/3A54G75eq88VfR3VMmn6aJr7cQytmqPqnx5PZ42va0ANcecjB8/Pv3Xy8dHdS1DbM1lPbZ5aWnbC576uQxNG5xLdjgXHG4YIcPkpyYjxej1Bar/UQfxH+imoWlkMbDjLWgcdlC6r/UQfxH+iirgov+7lqD6Qurb3pqi02yzXmS2QTRyPnELR4ku0N2hri0jzPGRlVGn6s6xsVdXVVwq3VcLbFT1dJT19IYxNI50Qc73Mc4c898Lc+uOoVBouns1LVWysuVVWxPkjhpmtO1kbQXOO4jsD/so2PrRaZKq5MbZbuaa200dXV1Phs2wsfF4jcjdnJ4bj1+HKLqOzG5UdYdYdX6UmiiuNusj31FqFxgMMczmlxkwGElw7N5PxWJSdaNVXe9VFpp6G2000lPIIoRFOakO9n3tmHBYWF3YHnH5mfqetlJcaq0RW6lr7fO+5U9NUU9RSMle+OVu5mCJBtDgO4yfgu5nX2zOoKyt+zt6Hsr2xvbsi3tySMvG/LBx/qx3Cf66x8lAtHXXU1q0vbhVto7jVOoJ55J6mCQPM7ZnARnaWjhm08DzHKtVs6vavr7Zqa5wWe0z0tkhikfDG2UTSGRmQRyRtack/9o/FSlx+kFp6ipmTvs12kxA2aTYIiI9zy1oJ34OcZyMjGF2P+kDpuCvlp6q2XSGOOompnTbGFu+NuTwHZ548vNP9MfJWbN1s1beaux0NDb7C+ouVZJSMqSyoEDsNaQRnB4Lue/4KX6s6wvulepNolo3S1LIrJUVMtBG9whllaHclo7gd/XAUpD10tJtJrJNP3qOR00ENPT7Iy+czNc5hbh2OzSefUKYu3Vq0W3Q1r1RPbriaWvqBStg2NErHe93BOMe6exQ/xH9EepV017cb7T3SmoIo6COndE+kZK0SeIHEk+Jzj3eOB+PdbZWm5+vunoadj22m8PnZ4pqoGxM3UzY3Bri73sHk+RK+1HX7TsVU6GO33KVvtgo2yNDAHEjIcMuzjH4qcomJ8G40VS6c60i1zZjdKS119DROx4MlUGgTcuB27Sexbg5VtRyKK1F/gmfxj+hUqorUX+CZ/GP6FeZ01/Ru8mnR+/p5rTD+qZ8guS4w/qmfILkt1PCAVSZ/myt/g/4araoqptv/AKTNbF3czY9vr2wVxXRNU0zHdK23ciimuJ74x5IjVUNzqNPV0FilZDc5IyyCV7sBjjxuzg9hk9lRY7X1NiohGy828yMpGtBc1pLpg4AnJZ2LAXZx94+i2iWkdwfyXzB9D+S0MTXEtu6hVFmvUE9xoo62VsXsUkDw0RkOG/nZkZbnvnnyCwp7H1H8OllgvVOZ4XPaI5Hgt2FrACSIxufnfy4YBwcd1tTB9D+SYPofyQy1lqWya/rqihdbLvT0zRQNjqh4mA6fD9xADfPLcEYxjsouq051Ofdo6qG80TWQt2Rs8d+wgB2C5u3BPLck5yR6YC3Dg+h/JMH0P5IZVPRVLqyGapk1ZX087NrGwRQNbjO0bnOIaDnIPw5+StiYPofyTB9D+SIFBXvV2n7IS26Xejgl/wDyvEDpD8mDLj+S+a8ZcX6NvLbMJfrA0r/B8P7+7H+n4+nxWv6Kp0taZKKeyTSUlE5kT/ApaCR1bI8AhzZCGbiSdpyT3yomcOqacrJV9QHSRudZdP3SsYAS2epa2ihcAMkh0pBIA8w0qOqL1qm4Udwl+srRa4qUs8SOghfW1DdxGGgu2szzjscFYdLSXKrkndbNKXGfx3bnz3qpFKx5OCS6Nu95yQDjj0+CnKXS+p5nvfU3yjtLZBte200Q8VwznmeXc48k+SjfLvFMIW6WaqpaC6XGu1BqSmqKSmkqIa+oqmshEjCdrDEGhhDhtOOTyRxjmyyVtRcdK2WtrYvBqqiBksseMbXOYCRhc6Xp7Y2VTKu4x1d3rGkET3KofUEEdsNcdo/ABSWp4nuggDGOOHHsPgkxuZ9TMTbnDWfWO66bp36Ztup9NwXgVEE80Uss5i8Dw49xGQM4dxn5eaidFa+0C6+XOhrrNbrI240dJHLI6fxYqprowGRbdoAa1pxngKw9UbBp28V2mxqOtudJOylqmQey07nsLXRYeXkNOMDt2z8VGWXoZpa40lLXU92vNRQVENO0xkiNs0cWNoeNoPJaCexGPJSsoxsxlxoavpDR1tfbW01opqezzisD2yPcXStO1zgB94NyB3PnwByeojoXFQCMi0tgrJcgky7iW8Z3d2t97HkPyUw7oJYM3dsVyu8dPcGvb4DZG7Itzg4ke7z243ZwpDUXRqy3uezTurblSTW6kjod9M5rTLEzGN2WnB47jHdHWYYVDYukmp7obHRW611ddQRPp/Ajje0xtjeC4bhj/Ue+cnJ5PKqulr50muVohvF9tFvs1TJV1EzIKiZ8xe5uA+THbntgjnGBlbc0Romi0g+8voJaiZ1zrH1shmwSxzu7QQO3zWq63ovpCjuFs0/JdL9HX1kNQxkkLfdljJ3lr3Bm0AHkA4z8UIWKrsvSSzWKnpKuhttPbb0z22HeyQ+MI2btwd3GGuOBkdz6qL1ZL0x1HZNPaWgvtLbKSKeKspaaCMgPBB2tO4YG7cTzyc/FW3WHSiz6p0bZdPV1RVxxWlrGwVMW3xSGs2YJIxgjGePIKuHprpOu6kSx0VXeKS4UNPTunpoWFkD2sYGMw8t54xlrXIQi73e+izdNxyRUNtuMFqjNTDS08JEm10gae+M+8RkOPxUju6PXW826etp7bDerqIaxkUm9jw+RoLA7adrXHI48+/OcrGreh+kbDZjLdLtc20MNE+hc523OHyl4d7rclwc7jjyWVpTpVpa43G36gs18vFR7IIYpCXbPGdC0NZuywOHu7QQMAhDc2FpyWx2OvZo+y0stL7HTe0sibE/wmsc85xIeCdxJxnPKsqgqyiFtu9bqKqudw9jjoyx9FndAwNO4yNYBnfgYWRpi+0mpLPFcra2oFNIXNb48LoncHB91wBUuUqorUX+CZ/GP6FSuD6H8l8ltxrfCEnuxteHHPn8Fi6Ss1ajS12qOMxhdpqoou01T3JWH9Uz5BckRaIjEYdCIikEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBdT52McWkSZHpG4/wBAu1EGLV1jIKCpqfeDYY3SHc0jgAnz+Sr0FwrLa6BlVVurJTQiWZkgaNsxLWsA2tyNxLuME+7wrRPDHUQSQzxtkhkaWPY8ZDgeCCPMLGbare2mfTtoqYQPcHOjEY2kg5BI9eAhKHpdQVNW+OCnpozUOqXw7nFzGhrGBzn4Izw5wbj1Sk1DPUS0INIyOOoZGRI5ztri7khrg0jIHYOIJU3TW+jpn7qalgidzyxgB5xnt67R+QXyG20UEjJIaSnjewBrXNjAIAGAB+HHyQQVyvb6O/TxMbLM0tigYxrHvDX4e9zi1gJ+7s8vMdu6N1JUOpaWYUQY2UO3SSbwwEP2gHDCWh3cFwCnpqCkm3+NSwv3v8R25gOXYxuPxwAM+i+G3UZfG80kG+MBrD4Yy0DsB6YQYN5u01BVQxMp2mN4BMzy7YHFwAaS1p259TgLHF9qNhqnQUraFxkEZdPiQ7cgHbjzIxgZIyPkpiWipZahs8tPE+ZuMSOYC4Y5HK6TaLcTOTQUuZ8+KfCb7+Tk54555QV6s1DI+kcZg+nEFWwSOjD2ktZH4zhhwB7Nx8crPtWoX1U8rKmjnia2Jsvu08u5uSRtILAT8xkd/RSsVsoYXExUdOwk5JbGBzjbn8uPkuyko6aja4UlPFCHdxGwNz+SCLkvmxxHhN96tFLHl2C4Bgc52PgA/j4LDg1FWvpKWc0MUhqqR1VFDFLufxtwDx57/L5cqWr7NR1UdSWwQxVUzHN9obGN7S5pbuB9cHC5Q2e3QwuijoaZrHgB4EY97HIz688oMNlxqaux1U1OYI6rLoodxc0b+wDg9oIdnjBHp6rAivUlJBK10tRLUNlIkjq2tLoQ1gcT+iaQR7zefLdyfJWJ9DSPozSPpoXUp7xFgLTznt27rpNntpZGw0FKWR7to8JuG574488DKCG+08hFA5tKMT+ztezLiWPlIy3IbtBaCDyckeQXZaquqdeRHXVMwMolkhYzw3QSRBwDS0gbgQHMznuSVKts9ta9rxQUoe0tIPhNyC3Ab5eWBj5L4yzW1geI6Gmj3uDnbIw3JDtwzj/uGUQj73c5KS70zIjkNge8xknD3ucxrBgAk8bzgA9lzgvrnWOSudBmQTmnYwEtD3+J4be4y0F3fI4UnU0FJVEmppYZSduS9gd90kjv6EnHzKNt9G2kkpW0sAppCS+LwxsdnvkdkSiJLvcIp4aV9NSPqXylrjHOSxkYZuLj7ucgloxjnI5XS7UU7aVtS+mZ4E9FJWQiOTLw1oaWh2RgE7h8jxyp6moaSl2ezU0MWwEN2MDcA4zjHrgfkFwhtlDCyRsNHTsbJjeGxgB2DkZQQ4vlXFJPA6kL5YY3mNr3EPqNuAHNIbsOSRwDkZ7eS65tSvjo3ymOHxGb3ObiXLGNaCS5uzc3k45488+SnPqyg/Sf+Dp/0n3/ANGPe5zz+PK4SWi2yNYJKClcGNLWgxNOAe47digi33+o3F7KWMQRvp4pdzzuD5duQBj/AEh7T8V1nUk8VAy4T0sRo54hJTsjlLpnbnNawFoHnvGcZx25U8yipY2FjKeFrS5r8BgA3NAAPzAaPyC6orTb4WTNioaVjZv1gbE0B/nzxygwrZejUU1wmqoXRNozlzjG9gI27jw9oII+Xp6qPfqiopaenlraJn/iKZs7GQPdIWuc9jGsdhvmZByAex4KnKm2U8trqKCFjKeGdjmO8NoHcYJwuUdroIopY46KmbHLjxGiMAOx2z6oIu23+WqqWQSUxYTUOhLnNez3RFv3Br2g5zgYI+K67Xdq26XamdCYY6I0xmcw8lwdIRG7P8LHH8fkpl1soXQsidR05iY7e1hjGGu9QPXlco6CkjkhkjpYGvhZ4cTgwAsb+yD5D4IMlERAWBV3WClnlhkbIZI2RuDWge/vcWtDee+WrPWDPa6ee609wkDjPAxzGc+7z5keo5x8ygim6kP1l4Xs7n0TIpZpappa1kbWv2gnLs491+SB5DGVIWq9U1yqJoYWyMkia2TD9vvMdnDhgn0PBwR5hdI03QCERHxjGab2R7fEIEjOfvAdz7zjn4rMt9ujohJiSWV78BzpCOw7DAAA/L5ohFVWpoWSUjmxyR0srnu9okaNj4mMc5z24OccDuBnPGVkQako5XuYWTMeJImYdtPEji1juCeCRj1HmF1x6WoWsZHJLUzQxwPpoo5JPdijdt4bgDttGCcn4rvlsFNNbqiknlqJGzlpfJvDX5aQW42gBuCB2AQdFVqmgponSOEr2taZHbQ3IjBI8TkjLTtOMZJA4C73X6mFaacRVDmNmbA6cNHhte5ocBnOTkOHYHHnhcp7FRyVDZW+JCPDbE5kRDWuY3O0dsjGT2IXOazU0rNrnSj9O6oJDhy8tLfTyB4+QRLrtF6juEjY4mSSExtmMrWFsbWuGWAknOSMcf0WFWamjY6mdDFK2nlc9wqJGe4+NjHOc5uDnHujuBnPGVL22209vbM2nDtspaSHHONrGsAHww0KNZpejbG2N09W+KOB9NFG6QFsUbsZa3j0bjJyceaCNqtR3SL21zbfI4U7oqZuGx4fM/bg8yAgZe3jHzI8pKG+GLfHNFPU1W/Y2nhiaH8NaXH75bgbwCcjnjnzzvqimIIPiHNSKs5Pd4xj8BgfkFjyWCndI2WKeqgmD5XmSJ4DiJHBzmnjtkD4jA5RDGrtQtikp/DLY2PMbpBMxzXRNLXvcXZ7YbGePJZ1qvVNc6iWGFsjJI2tkAft95hzhwwT6Hg4I9F1S6doJjN4zZJGS5D2veTkGMR4z3+6D59ySsqhtsdI2UCWaV0gDXPeRnA7AYAA798Z9UGPbrw2rudRRujexzdz4iQBuYCAcjJI5PmBkdlxj1BTyVDWeBUthdNJAKhzQI97N2R3z/pPOMfFfbTYYLZMyWGaokcyEQASFuNoOR2A5+Pn55WHb9NNbbmRV9TPJIWPLmNk9yOSQHe5nGf9TsZzjPACJKHUTppngROqQ5kZhjgZh7yWB7j7xAAAfH3xyfiAuTtSB1dSthpJnUL6Z1TNUOLGiEAge8C4EY97PHlxnnGS7T9MJfFp5ainmy79JE4A7XBoLeQRjDGfEY4K5y2CglGwskERpjSOibI4NfHgjBHn3PPflEMdmqKF0c7iyceEGODdoc6Rr3bWloBJ78YOD8FlVl5hpBTCaGcT1DS5kADd+BjPnjIyOAcr5FZYGM2vlnlPiMkLnuHOw5aMAAYz8MnzJXbc7XFccNnlmERbtfE0ja8ehyDj5jB+KJdMl8po7kyjkjmYXEtEjgA0uDC8jGd3YHnGPLOVjR6oo3U4mlhqYGPZHJF4rWt8RrzhuOeOf2sL67TFI6RzzUVXLpXAbm4b4gIdjjP+o4JyR644WXPZ4ZJjLHNPA/w2RAxkYDW7sDBBB+8e4PYeiDlLdYoqCKqfDODK7ZHAGZke7ngDOPInOcY5zjlYlXqOCkohU1NJWxgB7pGPY1pjDe5OTg/DaST5ZWTLZqZ1BTUsT5YBTOD4ZInYex2CM8gjkEjkY5WJV6ZpaprxLU1mHxeC/MgcXDJdkkgnOXHtgdhjACD5dr/4EUzaKnmkkbIynbMWZibK8tDWnkE8uGcDHlkL6dT0fh7mQ1Di4vETcNaZQw4c5u5wGAccnGcjGV3PsFO6o8Q1FV4fjipEO8bBIOd2MZ784zjPOF8dp+k9no4o3zR+zQ+A1zXDc5nGQSR54ByMH0IRCSoaqKto4KqmduhmYJGHGMgjIXcuMTGxRtjYMNaAAM54XJEiIiAiIgLErblQ0L2MrauCBz/uiR4aT+fzCy1EVdrqJblUTw1EIhqYmRSslh3na0u4ac4wQ48EFBmi4UZrPZRVQmpyR4e8bs4zjHrjlY5vtqDS76xpdoaHk+KPunz+XB5WEyxTgMjdVRmKGaWohxGQ7e/fguOecbz2xnhffs+GRPjhlawNt4oIfc+53y7vzn3ePggkp7pQU8ojnrKeN5wNrpADz2/Ncqe4UdSGeBUxSb3Frdrgckdx8wo02BrhI10jSx9VDUbdn+mNrA1vf1YDn4rg+yVLbg6tp6uNsznzE74iQN4YARz3aIwPjkoJI3a3h8TDW04fKGlg3jLg44aR8yMBZqr1Lpw09E+AVAc8mmAeWdmQ7Pd7+ZDj/wCZTtOJRBGKhzHzBo3uY0taT54BJwPxKDsREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREH//2Q==",
+              "timing": 2250
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAICAwEAAAAAAAAAAAAAAAUGBAcCAwgB/8QATBAAAQMDAwIDBAYIBQICCAcAAQACAwQFEQYSIQcxE0FRFCJhcQgVFjKBkSMzUlRyk7HhNDZCocEXYiSCJSc1VXOU0dM4U3R1g7K0/8QAGgEBAAMBAQEAAAAAAAAAAAAAAAEDBAIFBv/EADERAQABAwEEBgoDAQAAAAAAAAABAgMRBBIhMXEFFDJBUbETFSMzUmFyocHRIjSBkf/aAAwDAQACEQMRAD8A9UoiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAi+OcGtLnEBoGST2Cr0WuNKzXD2GLUVpfV52iJtUwkn079/ggsSISAMk8eqrp1xpZtf7EdRWkVedvhe1s3Z9O/f4ILEiAggEHIPmoq86htdlext1qvZGPxiaWNwiHzkxtH4lBKoqF1rqv/AFSX+po5+DTtcyWJ/cFzeQQpY6v09ZqSgprvfLdR1ToY/wBHPUNa7lo5IJ4QWdF101RDVQMnppY5oZBuZJG4Oa4eoI7qFu+sdN2erFLdb7bKSpzjwpqljXD5gnj8UE8i6qSpgrKdlRSTRzwSDLJI3BzXD1BHddqAiIgIiICIiAiIgIiICIvj3bWkoBcG9yAvgkYezgou5XGkt8BqLjVQ00OQ3xJnhjcnsMlYFHqWx1tSyno7xb56iQ4ZHHUMc53yAKCyouineT7p/Bd6AiIgIiINb9cJ5n2ex2hsz6ekvF1goauRh2nwXElzc+WcYVjq9C6YqLC60PstA2h2Fga2FoLeMbg7GQ7491mau07Q6qsU9rubXeDJhzXsOHxPHLXtPkQVT5dF6zqaI2yq1491tc3w3vZb2NqXM7EeJu7488ZQUQ325T9D6OhdWylkl4FkdXtdhz6bxS3fn4tG3K24zQOlW2P6pFit/sWzZgwt3dsZ3d93xzlc5tE2SXRI0qaYi0tiETWg+80g5Dwf2t3OfVVpuidaMpPq5uv5fq0N8MONvYanZ2x4ue+PPGUEN1BqqnQnRQ0+nbxNVmOVtGyuc8OfDG55BG4ebR7oPcLYun9OWy36cZbo4hUU80IbO+Y+I6oyOXPJ+8Tlddu0bZKLR7dMikbNafDMb45veMmTkucf2iec+qxXaeulssos+mK9tNTbPDZUVr3VElO3thjeM48tzjhBpWnnlp+kXVCwNlfNbrNXPp6N7jnbH4g9zPwx/utz6J0pZqPSdJGaWmrnVdOySpqZmCR1U5zQS5xPcHPA8go8dM6Cn6a12kqCpkj9tBdPWSN3vkkLgS9w4znGEj0dqO00nsGl9Ux0VtDdscNVQiodTjzEbtw49A7OEFU0/VzaQ/6o2qyEuoLPF7ZQxfeED3xOe5g+AIzhWnpZpKxw6GttS+jpa6quNO2pq6qeNsj53yDc7JI5GT2U1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93cu+GOAFXaLQWodPskotIat9hs5c50VJV0Tak0+TkhjiQcegOUHR0+hjsHU/Vmm7WNlmZDBXRwA5bTyPyHNb6A98LaCrOiNIwaXhrJH1c9wuldJ41ZXT/fmd5DA4DQOAB2VmQEREBERAREQEREBERAXCcZiK5oeUFd1GKk20+xCuM24f4LwfEx/wDy+7j/AHUFZW3f60g9qGovByd3tQofD7H73h+/+Suz4SD7vIXERPJ+6g+wD9IFlLhFGGD4rmgIiICIsOquEVPVx07s73NLycHDW+v5oMxF8aQ5ocOx5C6KiqENVTQloxMXe9nGMDKDIRR9BXvq6qpjMIZHE9zA7cSXEHHpj/dYgvrvHqI3U4AikDGnf979IGE9vLOUE2ii667ezVL42xMeyNrXPJk2uIcSPdGPe7fBfaG6e01pgMbWNO/adxLjtdtORjA/MoJNERAREQEREBERAREQEREBERAREQEREBERAREQEREBcHxMe9j3NBcw5afMLmiAuqengqA0VEMcoacje0Ox+a7UQdUdNBHM6WOGJkrvvPa0An5lcTRUp8TNNCfEOX5YPf8APn1XeiDpFJTjw8QRDw/ue4Pd+XouTYIWyulbFGJHd3hoyfxXYiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIIi832C2vEW0yzEZ2g4x8yoj7YO/ch/N/soG97/rar8XO7xD39PL/bC1/qek1FLq+2T2t1ULWxsYn8KZobnxCXZYSN3u4H48ZxheXVqblVcxE4h79vQ2abVNVVM1TOPHvbe+2Dv3Ifzf7J9sHfuQ/m/2WpKGnvreodwmqWVbrI9rfZ3+0t8Jp8MB2Y855dnnHddGnrfqWHWte65VE77HGZH0znTBwk3luGluc+6M9wufT3fj7s9zvqenz7ueOO//ALx4NxfbB37kP5v9k+2Dv3Ifzf7LS+nKTU0do1HHcWVra57JPY5JKtrw4nft2AH3CMt7/D0Xfp6j1Q3T18gu00n1jJHso5DKDz4QAcCCdp3cn45Kmb92M/z8iNJp5x7Od/P9tw/bB37kP5v9k+2Dv3Ifzf7LSlRSark0ZcWs9rF2kqWOhjFS0SNjGzcN27Azh3n5q5WNs7bPRtq2Sx1Aib4jJpBI8Oxzlw7n4rmrUXYjO15OqNFp6px6OY3fNeftg79yH83+yfbB37kP5v8AZaj0vT36LVd7fdo6w0L5JDSSPqmuiDC4bWiMEkHGefThYWhaTVsF6mdqJ1S6nMbtzn1DHxufu93YwDLRj4j5KZv3d/8AOPs5jSaeZiPRzvz47m6ftg79yH83+yfbB37kP5v9lprTVHqmLWlfNdXzmzOkqDA10wcAC9vh8bjxjOOOOfVYmkaPWsWrpJb3NI62Ey790rHMd+xsaDlv5DhT6a7v/nH2RGl0+72U75x3/wDeLeH2wd+5D+b/AGT7YO/ch/N/stS6cp77FrG8yXOOsNte5xpZHVLXRBuW4aI85B78/NdGkaTUsOrLrNeX1TrY8P8AA8SZpbkvG3a0E4w0d+O/ZRN+7v8A5+TqNHp5x7Od8/Nu23apgqJ2xVERg3HAduyM/HhWJamW0Lbv+r6bxf1nht3Z9cLTpL9VzMVdzz+kdJRYmmq33slERbXmCIiAiIgIiICIiAiIgIiICIiCIvNiguTxJuMUw43AZz8woj7Hu/fR/K/urcior01uuczDVb1t+1Ts01blR+x7v30fyv7p9j3fvo/lf3VuRc9UteHms9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6Vy3aWgp52y1Epn28hu3Az8eVY0RXUW6bcYphmu3q707VyciIi7VCIiAiIgIiICIqL1q1bXaL0HU3W1RMkrDKyGN0jdzY9x+8R59vzIQXpF5O0z1O6mV8tNU091ttzjkkG+jAp/Ga3OD+jG15/DKlperGsIOttRZ2uqam1R3GSmbbGU8e9zBkAh2zdj/X37IPTaLRtz+kNbrffbpbJbDWPfRSywhzJgfEcxxbwMcA4/Bdtj6/0V1vrrYLBVQvbDPKXuqGn9VE+QjG3z2Y/FBu1Fpax/SBstdYrvdK62VVHHQGFjYxI2R875N+Gt4AGNhOSuWkOv9k1DfILXJa66inqXbIHPc17XvP3WnHIJPA4PJQbnReYekPVvV1211NR3qSouVB4EzzAyCNns+3BD3FrAcDG3nzcFbbb9IOhrrHeLk2wVLG21sTnMNQ0l/iP2cHbxjug3ii0FU/SRt8FNRzHTtURUxmQD2lvu4e5v7P/AGqWn+kDYaezVFfNba5rhVOp6aAY3TtaATIc42t5HqeUG50WlrH9IGx3SgubzbKymraOmdUtp5HtxOG92tcOxxzyOyaT6+W/Ud3tlugsVZFPW1QpyTKHNiBxh5OPUnj4IN0ovMP0qb9d7VrK0xWu619FE+gDnMp6h8bSfEeMkNI5V61F170/Yr7WWk0dZVPo2Pa+dhAY6VrfuDz5Pu7vI/DlBuRFQekvUmn6i01ymprdLQiiexhEkofu3AnyAx91VXVv0grDYb/VWumttbcPZZDFNPG5rGbgcENz3weM8IN0ItJ376Qllt9BaqyhtdVWw10bnkGVsboXNdgscMHnz4PYhZH/AF9sDLNX3Got9bGyGoFPTRcb6nIJ3AHG1oxzn1CDciLR9D10tGp7Ff6SGnr7Tc4rdUTwHc0l2yNzvcd5OAGRkeSq3RzqjHp7Q2oLnqWuu1z8GrhihZNJ4ji57XkNaXHjhhJycccD1D0yi0hYfpFWG4VYir7TcaGNzHvbNlsjcNaXHPY9h5Z5WLT/AElLJLV7XWG6Npdwb4wcwkZ9W5x/ug3yi0rfPpDadtt2uFDBQVtWKUOaJ2kNZJIDjaO5A7+98PjlR0v0jqCO0U1edO1RbPPLAGe0tyCxsbs52+fiD8kG+0WotM9dLHe9V0Vidbq+klq/DbFNKBt3vYHBpHBxk4BxzwexUZfvpF6ftt5qKKktddXQQSGN1SxzWtcQcEtB7jPrhBvBFqbUnXXTVosNpuNNDV10lyjMsVOwBjmAOLTvJPHvAjjPYqU6XdWLR1AqqmipaapobhAzxTBNg7mZAJa4ehIznHdBsVERAVI6w2i/XrRzqXS7aeSuE7HuhqNpjmjAO5hDgWnuOD6K7og8ds6Na9ut+pXy2CisrA5u+ogqIwxmDnfta9xz/CB2Vx1V0z1vbur/ANqNL00FbG+cTsmfKweGS3a4Pa4gnz7ZXpNdck8UTgJZY2E9g5wCDz3036eaptHXGuv9ztXg2mWorHtn8eJ2Q8u2naHF3OR5KO1R0o1lF1Tu98sVLSVNHWGpkZLJM0Bomie1zS0kHPvkDyzgnjK9Lte15Ia5riODg5wvnjR+Js8Rm/8AZ3DP5IPI9j6Iayn0lfaStt7KOsM1NUUrJKiNwn2CZrm5a44OJAecK7aJ0x1PqtU2KTUtBa6K2W5scZkfBSySGOPkNaW7nAn1BGO69AunhbJsdLG15/0lwB/Jcfaqfn9PFx398cIPNmjul2t9J9TKmejpqeWz1fiU81b4jCPZ3uBPukhwdwPJVum6N9QLbZ9Q26G20k0NU2JoLahmZtkocNmXDHmTux6DleuWVELyAyWNxd2w4HK1VfusTbT1Vi0WbIZS+qp6b2z2rbjxQw52bPLf2zzjyRDRVf0Y19LQ2qNlgJfDC5sg9rg90mV7v2/Qhbq+kD06vGsY7PcNOeE+utxcDTveGbwS0gtceMgt8yO6xqzrwaalvcz9JV8YtsjWDx5vDEmXhvJ2na7nOOeM8rYHTLWbNcaVp7z7IKAzSSRiAzeIfdOM5wM/kg0nQdPOodxt+oai9W620809HJFFTtZA6eeQt2j9Ny4DHOS/4dle/o36QvmkNO3am1HQexzz1QkjaZWSbm7AM5aT5q+6wv8AWWWCBlrtFRdK+oJEcbHtijbjHL5HHDRz8SVNipY2GN9Q5kLntB2ueOD5jPmiWgPpHdPdUav1VbazTtrNZTw0Qie/x4o8O3uOMOcD2IULe+lWvaDU+q/s7HSy2u9QzGSVz48ua4l/hYcctcXe7nt55XpxksbyQyRjiBk4IOAkc0UhIjkY4juGuBQab+jXou/6OoL7HqSgNE+plhdEDLHJuDQ7P3HHHcd1SK7p11G0vqjUb9I0VHX2+7ueHSyGF36Nzi4AtkI5GcHggr0wKqnIJE8RxyffHC1/1h6nN6cR2l5tRuIrzKBio8LZs2f9rs53/wCyDS2u+k2vbpbrDi20lZWRwyGoFJ7PTsiJdw3ALQ44AyQPP4LZ3XLp1dtYWCwy2PwfrK1Z/QSODQ8ODc4J4yCwd+O62bpu7svWnLTdXRin+sKWKpERfu272B23PGcZx2UhHPDI4tjlje4eTXAlB5nj6Za+1JeLzqLVdNSwV/1ZUU9PTwvjBnkdA6NjfdO0D3u5P9sDTPSvW9DoS82+awUUlTUV1NMKasmjc2WNjJQ7a5r/AHXBzmc5acZ57r1OKiEvLBLGXDuA4ZCMnhkDjHLG4N7lrgcIPLukumvUqCera6ipLbbfAmDLdU1LainLnMIDWsLn4y45yT6/JYVm6YdSoL1D9W2qmsFOXN8Z0Nbuglwe72GR5d8sY+C9YRyxyAmORjwO+05XFtVA4EtniOOTh44QeWbh0j1/aqvVNusUNLUWe5t3GQvjDpmtfuYwBxy13PPYcd+yr9R0a16/TNBSNsJNRFWVMr2e1wcNcyANOd+OSx35L0x1D6j2PQX1f9eCrf7aHmL2aMP+5tznJH7Q/wB1ZLTdqS52aiudPJtpayFk8ZkIB2uAIB+PKIeb4umGsG9WdP3g2ci20ptpmm9oi93woYWycbsnBY4cDnHGVi0/TbqZpGpvds0zQUNda7g8Znl8B4cxriW5bIeDzyMEL1Q1zXtBaQ4HzByomXU1liv7LHJdKRt3eNzaQyDxCMZ7fLlEtA6z6SayqKXTN4oDQVV9oYdlRTwbKZjXCR0jdm3a3/UQe3bKuXRLSer7XebhdtXU1tohMxzWQQwQmZznOBLnSMBJHHm4k557LcaICIiAiIgLyj9LsluuLKRwRbwR/NevVy0j136UX3X+orfX2aptsMNPS+A4VUj2uLt7ncbWO4wQg0/o641ts6gVztFXS43EyWuonqHzMcHOm9nc525p7kS4wT5+vnT/ABbd9mxeBfbh9r/bf1GHY8PGfE8T9rPx/DzXuiy6ctNnnqKm3W2kpquqO6omijAdK7uST3PPKrNvtnTev1M/6vg01UXxj3PdHCYnSte0+8S0diD3OEQ8264rqiLq/pa6agJgmMNrqap7xjBDYy8n5EO/JU2KRsr9ZSRncx9OXNPqDWQL3TeNM2O9VdPVXa1UVZUU5BilmiDnMwcjBPlnyUT/ANONHZqT9nbfmpG2b9H98bg7n/zNB/BBpf6MWh6S40NJqyatqxVW+smiipwR4WDG0E4xnJ3evkFX9e//AIrqX/8AdLd//SFeo7BYrXp6hNHZKGCipS8yGKFuGlxABP8AsPyWDV6M05V39t7qbPRy3Zr2Siqcz3w5gAac+o2j8kS8I2v/AAGof/0rf/8AREs2OenptPWeqtt4rvtDDVPa2ka1wbBHnc1zHepcTwP+OfaUfTPRcbJms03bmtmbtkAj+8Mh2D+IB/BZdDoXS1BNSS0lgt0ctISYHiEExknPBPx5RDyNruolu3Ui/N1vXVFHJAHCAEuAaQBsAAa7gjnsM57hRur5/F0FpiOO6VVxp4qmsbG6eAx+F7sBLGkuO4ZOfhle0b/o7TuoZ2z3uzUNbO0bRJNEC7Hpnvhddy0Ppi50dFSV1joJqWiDhTxGIBsQdjdtA7ZwPyQeetT6Un0b0RbfLJcLhLUX2Gh9uLnD9FEYycNIAIbktb8uFS+nf1ZRax0zPadQVsNdK+Lxo4YHTbpC7DozwzAI4/1cc5Xriiu2k6s/ZmkuFnqHRMNKba2aN7g1gwWGPJPAGCMcYXKy6J0zZK41tpsVvpKvBHixQgOGe+D5fgg8hdDtGUuutUXG1V1ZVUtO2idO405AL9ssYDTkHjnPzAWy/pfRCC36PhaSWx+0sBPngRBb00/ozTmnaySrsdnpKGpkYYnSQswS0kHHyyB+Sj9ex6IqH0cWuZLMHMDnUzbhMxhwcBxaHEegQeXdV1gn1Louk1Jcq23WOnslC+GamaXOj/8ADtdvaB5+IMZ+HwUx9FI7uqVwduc7NtmO53c/pYuSvTc+ldOXGntfjWmgqYaBjBRF0QcImgDaGn04HwXyxaN07YbhJXWaz0lHWSMLHyxMw4tJBI/MD8kHlrrOyo0J1hu1bQN2sudJJIzyx40bo3n8H7j+SjK+23LT/Qu11lN40MN8uL5Kp7MgmNjdsTCfQkSO+PC9dai0jp/Uk0M1+tNJXSwtLI3TMyWgnOAsx9jtcllZaJLfTPtbGCJtK+MOjDR2GD6IPJ3SAW2h6l2xlgv9aRKza+BkDpGzZYS9ryQzAGM52nGO5WvNOUftGntU1Hjzxmko4pAyN+GyE1MTMOHmPeJx6gL3PYdH6d0/NLNZbNQ0Usg2vkhiAcR6Z74+Cwafpzo+np6qCDT1vZDVMEczBHxI0ODgD/5mg/gg8Z34zVfTnTNZUOllfFV1lGJHuJ2xtEL2M+HMkh/H4LJuVXba+52C3T109NpqChiDSHPDWyFm6YjLXHmcyDIae3HGF62ntvTygpTpeoZp+GKSbxfq6WSMEyEAZDSc7iMBSc+gtKT22noJtP219HTkmKMwDDM8nHmMoNVfRWljFJfKaku9XXUkbmOEMtOWMhcd3LXEnOQBkYHYKRu//Tv/AK+U3tnt51Xujxj/AA3jbBsz57tu3Hl2W27LZ7dY6FtHZ6GnoqUHIjgYGDPrx3PxWPJpqyyX9l7ktdI67sG1tWYx4gGMd/lwiUuiIgIiICIiAiIgLxfpC2VN66qaytlAGmrq4LnDEHO2gucXAZPkvaC1JobpBJpjqPV6pdemVLZ3Tu9mFNsLfEJP3tx7Z9EFFvOtNS9LNNaT0VQU1F9eugdJNJM4PY0PmeGBpyB65JOArFoXXPULUFDfrfX2qOmuVPTPloq9tOfAfI0j9GTktdu8iD6q1dWOlVNr2robhDcprXdaNuxlRGzeC3OQCMg5BJIIPmVD6S6NVGnLffJItS1FRfblTupm1skR2wtcRucG78lx9S7hENX23rrra7OtdooG0f11UVhhdI6nG1wdsDBjPBB35PyWZP1s11c7lWt03S0E1LQkNLXRAyzDON23dkkkE4aOFOw/RuNNTUL6PU3g3OnqHTGqFIeR7uwBu/gtLXHOed3wWVdfo8GeuqZrXqia3wVmDU07Kcljj3cBh493OSAc49SgrmuututLW6yeHQxWqoqKES1FNU0xz4niyN3N3chpDWkD+q74ututYda3m0T2y3SvpxVBtMDjwTEx7id+feADDn18sKf1P9HiG5ttUduv76aKhpBTuM9P4z5Xb3vLyd4x9/GMcYWc/odK7Xt21H9fsDa41hFP7Ics8eORn3t/O3xM9uceSDX3/X3Vc2jZ6ljaCO409dFEZWw5a+N8cpwWk8EGPuPVStn63axpK/TlVqG2Un1HdcRtka3D5AHBj5G4PBBPYjt+aq3VLpXN070UCboLka+4Q8MpjHs2Rzf9zs53/wCyufSXo3S3e36Y1Lc7pUyUkcYnZbXN91sgeSfeJ4aSASAPxQa+st/ZpbrnqW9yRGUUdTcpBHnG92ZA0Z8skhW2y9ZepFdJT3Cns9FcbfLKW+zUsJc/APIw1xc34Fwx81dafoNA/W13vVyvAqaK4vqnPpG02xzRNuxh+48tLgc48lF0n0cvDqoIqjVtZJaIpDIKVkJY744O8gE+oag2F1a19JorQcd6pqQurap7IYIZwQGPc0u98d+ADx6rzD1jvuqL63T0+sbbHR1LqZ0tPJHgNnieQQdoJwR6HntwvWevNDW3WOkfqCrdJTwx7HQSx8uicwYaee/GQfgVqK5fRvlrKajY7Vs8ksDSwvnpzIAzPutYN/ugD59/JB0au6t6npNSQaZ0fTUIdSUsQfJU7d0jvDa44LnBoHIGO5WzOjOrr/quyVT9U2eW3VtO8BshhdEydpBwWh3mMc/MeqretOh0d7vUV4s9/qLRcTCyKZ8cZcHlrAzcMOBbkDkZKuHSnp9S9P7PUUsNbNXVNS8PmnkG0HAIAa3JwBk+Z7ol5K1K65S6rrqnW9Zead75HOhqYIvFYeTgsy9o2Y7bT2V3k6l33RWhtPRaevlPdI6iWq3zzxue8Bpj2tIfy0gOPHI5GCVca76PFc+Keko9a1UdskeXeyyU7nN75GQJADz8FIXH6PFtqNJW21U14mhrKSWWZ9U6EObK6QNB9zIwBsbjnyRCHb1b1QerFssHi0n1dUOpA8eAN36SGN7ufm4qF0R1Y6navrKqhslPb6yqjjEp/Rsj8Nu4An3nAHvj8Vc7X0GloNbW6/8A2lkqG0j4XmOanLnv8NjW437/AD28ccDA8lMdHukEnTy+1txfem3AVFN7P4YpvC2+812c7j+yg8/6at1bdevD4bqaaarhus9RWFxcGO8Jznybcc9mO2+WcZ4V1b1u19eqqsrNO223uoIZQ1tMI/ElIJ443b3H1LRgfBbH070bdaeqdVq+W8sqIp6iqnNH7MW8TB427957b/TnCr1f9HNpraltp1TV0VqqJA99IYS7gHIGQ8A48iQg3Po27VV80xb7jcKCW3Vc8eZaWVpa6NwJBGDzjjI+BCmVFaWsdNpvT9DaKF0jqekj2NdK7c53OSSfUkkqVRIiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiKMqp6r2mVkB2sZxwwOycA+ZHqqb16LNOZiZ5OqadqcJNF0U0kktI15aPEIPB4Gf91gUNwqZp6VksUTWStk3FriSC12MDjt8f8AYKyiqK6YqjvczGJwlkVfqLpWx01fPtibHDN4TCWcfrA3JO70J8guyO51JqaOAeFJ7Q0ObI0cYBO/OCR2xjnuV0JxFAQ3eqdNVNfHEGxztjadpGQZiz154HfjlcHXmq8KscwwOfDP4TWBm52PE25I35PHyQWJFFVNyfBZIqyR0Ucj2tPPvNyfIc/8rF+uphJL4ngMYyMvPBdsw1p3Eju0kkDCCfRQVDeJ6itpIXsjDJWbi5ozuPvdueMbRnvycKdQERYlbJLuEcJLTsc/IAJOMcDPzSIyiZxGWWixqKVzw9r3btuMOIwSCM8j1WLa7hLV1tXFKwMETsNbjnGSMk588ZxgceqnBE53pNFX6G+VFRVwQOga0mSRsjsHGAHFmPntOfkvhvVU19LmBhZNHTuL2g+66R2CCPTAOPioSsKIiAiIgIiICIiAiIgIiICIiAseWkilkL3bg498OIyshFzXRTXGKoymJmODjExsbAxgw0LkiKYiIjEIERFIIiICIiAiIgLrmhZMAHg5HYgkEfiF2IhjLhFEyJm1gwO55ySuaIgIiICIiAiIgIiICIiAiLpNTEKttNu/Slpfj0CiZwmImeDuREUoEWBcq72fDIsGTuc+SwPrOp9W/krabNVUZhXVdppnCeRal6kdRLtYamjt9mp2T11T72SzIaPl+BVOu3VHW9N+qhia4DkGkyM/NU11RRVszO9dboquU7VMbnotF5hPVLqZh8gpaYQtGcupQM/LlbJ6VdQbjqyyzSXBkMdbTybH7G43DyO3y8x+Cm3MXJ2aUXIm3GaobVRQP1nU+rfyWZ9YTvpGvpKYVE4e1r4zIGYBPLsn09FZVaqpjMqqbtNU4hJIo/2m4f8Au9n/AMwP/ou6jfVySSOqoo4Y8AMa1+455yScD4fkq1jKREQEREBEWDeaielpBLTt3bSd+GlxDdp5AHxx+GUGci6J52ikklieHbWFwLefJdzHB7GuaQWkZBHmg+ovjyQxxHfHC8uXDrJriDqPJYYzR+D9Y+zMj9mBcYy/A5z+yQcoPUiLzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiLqnnjgMfinHiO2A/FRMxEZkdqIikFW6FxdrKsye0eB+TVZFWbf/nKt/g/4aqL3Gnm06fs3Pp/MLMuuolEML3u7NGV2KOvb9tO1o/1O5WminaqiGSudmmZQ0j3SPc9xy4nJXFEXosCh1tD7RreqqZmgmJjWR/AEDKn2wsDQC0H8FjXOBzbxPI3hz2NI57jssaA1ranD9ng+rHE4/NfM6mfb1c31+hjGnoiO+Hy9QNdA4bRghV3pvF7FrK5QRjEc9P4px5ODgP8AlZdZNWVBkw1hjaSMOeW5Xb06pX/XVfUuydsLYyT6k5/4Vuin28YZuk4zYn5NhLvo5zTzteO3Y/JdCL6GYzGJfNROJytgOQCixra/xKKInuBj8lkrzZjE4b4nMZERFCRF01kxp6aSUM3lo4bnGT81ixz3M1MLZKGnbC5xEjxUklgwcEDZzzgdx3ygkEREEXdWWq2UVVcqylgbHBG6WSRsILsAZPYZK5UdDRyxxVNI6oZG9ocwNmka0A9vcJwPyUi5oc0tcAWkYIPmvqDGdSOP3aqob8iD/UFVd3TqwyX8XqWEvuQGGzlrAQPThuPh6447cK4ogqN96f2S/XKmrrxEauencHRmRrPdPHo0Z7Dg5CtcMTIImRRDaxgwAuaICIo603CeulrWT26pohTzGJjpi0iYYB3t2k8c+aCRUHq8kW+MjuJAf9lOKC1h/wCzY/8A4g/oV5vTH9G7yXab3tPNNxnMbSe5C5LjD+qZ8guS9GnhCkVZt/8AnKt/g/4arMqtSSCPV9a4gn3PL5NVN7jRzadP2bn0/mFpUVfc4h9Of+Fme2M/ZcsK6ytmpxtaQWnPK2Wt1cMNyYmmYhEoiLcxoa7scyujmI/RuZ4efjklR0tY2NznFzdreAzOPxTWd8bbq6y0JjDzX1Doy/P6vEbnD8yMIRDhxIDXHzwvndfTsX5x3731vRVe3poz3bkJT1kb6qZhe3a88MznHxU1oSF7frGY/q3yta34kDk/7hQNwmgppi7LS/19PirNoOugrLEzwuHtc7e09+TkH8Qrejrc1Xtvuhm6XuxTa2PGVjREXuvm0/Zxiib8z/VZqgKe7SU0QiFqrn7cjc0xYd8Rl+V2/Xkv/ue4fnD/APcXn176pluomIpiEhdal1Hb5p2AF7R7oPbJOBn4crr8O5fvVH/8s7/7iirjcZ6+kdTMtdZEZHNG+R0W1o3AknDyew8gpr2xn7LlziU7UOiWlrp2iOarpvDJBcGU5BIBzgEvOPyUgsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkosb2xn7Lk9sZ+y5MSbUMlFiSVn6N3hsy/HuhxwM/FULQNx1lJqfUbdTQUTbaKkeB4T3kt/RtwI8jluMZJx725MSbUNkIsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkqC1h/7Nj/8AiD+hUp7Yz9lyhdVTtlt7AAR+kHf5FeZ0xE9Ru8l+mqibtPNYYf1TPkFyXGH9Uz5Bcl6NPCFQqlH/AJsrv4P+Gq2qpR/5srv4P+Gqq72qObTY7Fz6fzCXXF7Q5pB7FckWt5qqakvdPYo81AdJK77kTO7v/oFQbpre6VVQ1tJG2lgDXOdt5c4YOBkjgrZWrdOQ36jxwyqjB8OT5jsfhytRXC21FHN7PWRGKXducCMAHPugeuSF6mlqt1xv4s1ymYn5MC/RvrrdM1gkkr97Z43l3vb2nG7J9B/VXDS9c+6WOCadofLtw4EgEOHfKrMrZI6hs0R2StccZGRggNPH4ZWTbRNT0kjoJ2sDow/BBw4k+Xx81k6S0E6nFVPGHq9F6+nS5pr4Si7vUiXUctK8NMccZkMbXZHcAZ9e5/JR0NbVNubqimMlO9oDQ5jiCRnjP+6z44HATOe4GSbAkfjJOCTtB/Ht81xZTnxmgYwHbTznLifX4bT+a26XT06e3sUw8/VXqtRcm5Ul9P8AUG7UzR7e1tXCXluXDDhjsAfj8VtHS15ptQRGSmDmmPHiMcPu/j2K1RpzT1Vdm08FLCcOO98h+6wcjJ/Jbs0/Z6ayW5lJStHHL34wXu8yVXqqqKIxHFXbpmZ+SSX1EXmtAiIgIiICIiAiIgIiICIqL1LqdXQPtH2Up6WSJ1bEJy97t2M8hwAwGepzn4KCIyvSLppDOaaI1bY21G0eIInFzQ7zwSAcfgu5SCitRf4Jn8Y/oVKqK1F/gmfxj+hXl9Nf0bvJp0fv6ea0w/qmfILkuMP6pnyC5LdTwgFUo/8ANld/B/w1W1VKP/Nld/B/w1VXe1RzabHYufT+YS6Ii1vNFgXW1Ud1h8Osha/H3XdnN+IKz0SJmJzA13c+n8viSPoKprmu7Ml4LeMd/PlQ0Wkr3FROiNGQ8YY3bI1w2g9+/wAfTyW3UWmnV3I+aubcS1DFoy8SvJNK1vOG73hob6nj5u/NT9n6esiMLrjVeIIyD4cQwHHjufwP5q/olWruVbuCdiGNQUVNb6VlPRwtihYMBrQslEWaZzvl2IiICIuipqoaZoM7wwHgZUImcb5d6LjG9sjGvYctcMgrkpSIiICIiAiIgIiICIiAorUX+CZ/GP6FSqitRf4Jn8Y/oV5fTX9G7yadH7+nmtMP6pnyC5LjD+qZ8guS3U8IBVKP/Nld/B/w1W1VKP8AzZXfwf8ADVVd7VHNpsdi59P5hlXm6UdltlRcLnMIKOBu6SQgnaM47AE+aitN6009qV07bLdIal0DQ+Ru1zC1p7HDgOPiuvqTZqvUOh7tarf4ftVTEGR+I7a3O4Hk/gtLw9HNVMstwot9tEs0EGJzNIXzbNuYHHsGDHGB/patTzoiHocVdMQwiohIk+574975eq+CspixrxUQ7XHa07xgn0C0A/pBqRuk4BR/V9Jeqe4GpgiineWRxubhw3OzzkN4AxwuF+6LXw0Niht3sFWynofAnhqJnsbHO55c+Ru3vy7HrwEynEeL0G6rpmvLHVEIeCGlpeMgnsF8FZSlwAqYSS7aB4g7+nzXnm+9HNTVlRdJYnUT5ZXUhgk9ocP1ce155ye+MZJK5UPSHVdPeKRzpKE00F5FeZhMd5ZluTjHcY7eqZMR4vREc8Ukj2Rysc9n3mtcCR8wqu3qJpV2oPqQXZn1p4/s3geFJnxM425247/Fa76V9MNQaZ1lHcbmaDwIWSNfURTSOkqS7OCRkDzHcHt68rGh6a6rp+ol3utOy2Cgr6qSQTSSEyRNduw5oHZw3Z+YUZkxDbupNU2rT9mq7nXVAfTUpaJRDiRzS5waOB8Ss613WjuduirqWZhgkjbJkkAtDgHDd6HBC85wdF9VC011L7NaIZXQCETR1MpdUnxQ7LsnaOB6eQ481Iy9H9UNprxTUUtHT0tVDSO9nE7gyeSNrQ8PwMgE7jnzTMmI8XoM1MDYRM6eIRHs8vG0/ivktXTxFglqIWF/3A54G75eq88VfR3VMmn6aJr7cQytmqPqnx5PZ42va0ANcecjB8/Pv3Xy8dHdS1DbM1lPbZ5aWnbC576uQxNG5xLdjgXHG4YIcPkpyYjxej1Bar/UQfxH+imoWlkMbDjLWgcdlC6r/UQfxH+iirgov+7lqD6Qurb3pqi02yzXmS2QTRyPnELR4ku0N2hri0jzPGRlVGn6s6xsVdXVVwq3VcLbFT1dJT19IYxNI50Qc73Mc4c898Lc+uOoVBouns1LVWysuVVWxPkjhpmtO1kbQXOO4jsD/so2PrRaZKq5MbZbuaa200dXV1Phs2wsfF4jcjdnJ4bj1+HKLqOzG5UdYdYdX6UmiiuNusj31FqFxgMMczmlxkwGElw7N5PxWJSdaNVXe9VFpp6G2000lPIIoRFOakO9n3tmHBYWF3YHnH5mfqetlJcaq0RW6lr7fO+5U9NUU9RSMle+OVu5mCJBtDgO4yfgu5nX2zOoKyt+zt6Hsr2xvbsi3tySMvG/LBx/qx3Cf66x8lAtHXXU1q0vbhVto7jVOoJ55J6mCQPM7ZnARnaWjhm08DzHKtVs6vavr7Zqa5wWe0z0tkhikfDG2UTSGRmQRyRtack/9o/FSlx+kFp6ipmTvs12kxA2aTYIiI9zy1oJ34OcZyMjGF2P+kDpuCvlp6q2XSGOOompnTbGFu+NuTwHZ548vNP9MfJWbN1s1beaux0NDb7C+ouVZJSMqSyoEDsNaQRnB4Lue/4KX6s6wvulepNolo3S1LIrJUVMtBG9whllaHclo7gd/XAUpD10tJtJrJNP3qOR00ENPT7Iy+czNc5hbh2OzSefUKYu3Vq0W3Q1r1RPbriaWvqBStg2NErHe93BOMe6exQ/xH9EepV017cb7T3SmoIo6COndE+kZK0SeIHEk+Jzj3eOB+PdbZWm5+vunoadj22m8PnZ4pqoGxM3UzY3Bri73sHk+RK+1HX7TsVU6GO33KVvtgo2yNDAHEjIcMuzjH4qcomJ8G40VS6c60i1zZjdKS119DROx4MlUGgTcuB27Sexbg5VtRyKK1F/gmfxj+hUqorUX+CZ/GP6FeZ01/Ru8mnR+/p5rTD+qZ8guS4w/qmfILkt1PCAVSZ/myt/g/4araoqptv/AKTNbF3czY9vr2wVxXRNU0zHdK23ciimuJ74x5IjVUNzqNPV0FilZDc5IyyCV7sBjjxuzg9hk9lRY7X1NiohGy828yMpGtBc1pLpg4AnJZ2LAXZx94+i2iWkdwfyXzB9D+S0MTXEtu6hVFmvUE9xoo62VsXsUkDw0RkOG/nZkZbnvnnyCwp7H1H8OllgvVOZ4XPaI5Hgt2FrACSIxufnfy4YBwcd1tTB9D+SYPofyQy1lqWya/rqihdbLvT0zRQNjqh4mA6fD9xADfPLcEYxjsouq051Ofdo6qG80TWQt2Rs8d+wgB2C5u3BPLck5yR6YC3Dg+h/JMH0P5IZVPRVLqyGapk1ZX087NrGwRQNbjO0bnOIaDnIPw5+StiYPofyTB9D+SIFBXvV2n7IS26Xejgl/wDyvEDpD8mDLj+S+a8ZcX6NvLbMJfrA0r/B8P7+7H+n4+nxWv6Kp0taZKKeyTSUlE5kT/ApaCR1bI8AhzZCGbiSdpyT3yomcOqacrJV9QHSRudZdP3SsYAS2epa2ihcAMkh0pBIA8w0qOqL1qm4Udwl+srRa4qUs8SOghfW1DdxGGgu2szzjscFYdLSXKrkndbNKXGfx3bnz3qpFKx5OCS6Nu95yQDjj0+CnKXS+p5nvfU3yjtLZBte200Q8VwznmeXc48k+SjfLvFMIW6WaqpaC6XGu1BqSmqKSmkqIa+oqmshEjCdrDEGhhDhtOOTyRxjmyyVtRcdK2WtrYvBqqiBksseMbXOYCRhc6Xp7Y2VTKu4x1d3rGkET3KofUEEdsNcdo/ABSWp4nuggDGOOHHsPgkxuZ9TMTbnDWfWO66bp36Ztup9NwXgVEE80Uss5i8Dw49xGQM4dxn5eaidFa+0C6+XOhrrNbrI240dJHLI6fxYqprowGRbdoAa1pxngKw9UbBp28V2mxqOtudJOylqmQey07nsLXRYeXkNOMDt2z8VGWXoZpa40lLXU92vNRQVENO0xkiNs0cWNoeNoPJaCexGPJSsoxsxlxoavpDR1tfbW01opqezzisD2yPcXStO1zgB94NyB3PnwByeojoXFQCMi0tgrJcgky7iW8Z3d2t97HkPyUw7oJYM3dsVyu8dPcGvb4DZG7Itzg4ke7z243ZwpDUXRqy3uezTurblSTW6kjod9M5rTLEzGN2WnB47jHdHWYYVDYukmp7obHRW611ddQRPp/Ajje0xtjeC4bhj/Ue+cnJ5PKqulr50muVohvF9tFvs1TJV1EzIKiZ8xe5uA+THbntgjnGBlbc0Romi0g+8voJaiZ1zrH1shmwSxzu7QQO3zWq63ovpCjuFs0/JdL9HX1kNQxkkLfdljJ3lr3Bm0AHkA4z8UIWKrsvSSzWKnpKuhttPbb0z22HeyQ+MI2btwd3GGuOBkdz6qL1ZL0x1HZNPaWgvtLbKSKeKspaaCMgPBB2tO4YG7cTzyc/FW3WHSiz6p0bZdPV1RVxxWlrGwVMW3xSGs2YJIxgjGePIKuHprpOu6kSx0VXeKS4UNPTunpoWFkD2sYGMw8t54xlrXIQi73e+izdNxyRUNtuMFqjNTDS08JEm10gae+M+8RkOPxUju6PXW826etp7bDerqIaxkUm9jw+RoLA7adrXHI48+/OcrGreh+kbDZjLdLtc20MNE+hc523OHyl4d7rclwc7jjyWVpTpVpa43G36gs18vFR7IIYpCXbPGdC0NZuywOHu7QQMAhDc2FpyWx2OvZo+y0stL7HTe0sibE/wmsc85xIeCdxJxnPKsqgqyiFtu9bqKqudw9jjoyx9FndAwNO4yNYBnfgYWRpi+0mpLPFcra2oFNIXNb48LoncHB91wBUuUqorUX+CZ/GP6FSuD6H8l8ltxrfCEnuxteHHPn8Fi6Ss1ajS12qOMxhdpqoou01T3JWH9Uz5BckRaIjEYdCIikEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBdT52McWkSZHpG4/wBAu1EGLV1jIKCpqfeDYY3SHc0jgAnz+Sr0FwrLa6BlVVurJTQiWZkgaNsxLWsA2tyNxLuME+7wrRPDHUQSQzxtkhkaWPY8ZDgeCCPMLGbare2mfTtoqYQPcHOjEY2kg5BI9eAhKHpdQVNW+OCnpozUOqXw7nFzGhrGBzn4Izw5wbj1Sk1DPUS0INIyOOoZGRI5ztri7khrg0jIHYOIJU3TW+jpn7qalgidzyxgB5xnt67R+QXyG20UEjJIaSnjewBrXNjAIAGAB+HHyQQVyvb6O/TxMbLM0tigYxrHvDX4e9zi1gJ+7s8vMdu6N1JUOpaWYUQY2UO3SSbwwEP2gHDCWh3cFwCnpqCkm3+NSwv3v8R25gOXYxuPxwAM+i+G3UZfG80kG+MBrD4Yy0DsB6YQYN5u01BVQxMp2mN4BMzy7YHFwAaS1p259TgLHF9qNhqnQUraFxkEZdPiQ7cgHbjzIxgZIyPkpiWipZahs8tPE+ZuMSOYC4Y5HK6TaLcTOTQUuZ8+KfCb7+Tk54555QV6s1DI+kcZg+nEFWwSOjD2ktZH4zhhwB7Nx8crPtWoX1U8rKmjnia2Jsvu08u5uSRtILAT8xkd/RSsVsoYXExUdOwk5JbGBzjbn8uPkuyko6aja4UlPFCHdxGwNz+SCLkvmxxHhN96tFLHl2C4Bgc52PgA/j4LDg1FWvpKWc0MUhqqR1VFDFLufxtwDx57/L5cqWr7NR1UdSWwQxVUzHN9obGN7S5pbuB9cHC5Q2e3QwuijoaZrHgB4EY97HIz688oMNlxqaux1U1OYI6rLoodxc0b+wDg9oIdnjBHp6rAivUlJBK10tRLUNlIkjq2tLoQ1gcT+iaQR7zefLdyfJWJ9DSPozSPpoXUp7xFgLTznt27rpNntpZGw0FKWR7to8JuG574488DKCG+08hFA5tKMT+ztezLiWPlIy3IbtBaCDyckeQXZaquqdeRHXVMwMolkhYzw3QSRBwDS0gbgQHMznuSVKts9ta9rxQUoe0tIPhNyC3Ab5eWBj5L4yzW1geI6Gmj3uDnbIw3JDtwzj/uGUQj73c5KS70zIjkNge8xknD3ucxrBgAk8bzgA9lzgvrnWOSudBmQTmnYwEtD3+J4be4y0F3fI4UnU0FJVEmppYZSduS9gd90kjv6EnHzKNt9G2kkpW0sAppCS+LwxsdnvkdkSiJLvcIp4aV9NSPqXylrjHOSxkYZuLj7ucgloxjnI5XS7UU7aVtS+mZ4E9FJWQiOTLw1oaWh2RgE7h8jxyp6moaSl2ezU0MWwEN2MDcA4zjHrgfkFwhtlDCyRsNHTsbJjeGxgB2DkZQQ4vlXFJPA6kL5YY3mNr3EPqNuAHNIbsOSRwDkZ7eS65tSvjo3ymOHxGb3ObiXLGNaCS5uzc3k45488+SnPqyg/Sf+Dp/0n3/ANGPe5zz+PK4SWi2yNYJKClcGNLWgxNOAe47digi33+o3F7KWMQRvp4pdzzuD5duQBj/AEh7T8V1nUk8VAy4T0sRo54hJTsjlLpnbnNawFoHnvGcZx25U8yipY2FjKeFrS5r8BgA3NAAPzAaPyC6orTb4WTNioaVjZv1gbE0B/nzxygwrZejUU1wmqoXRNozlzjG9gI27jw9oII+Xp6qPfqiopaenlraJn/iKZs7GQPdIWuc9jGsdhvmZByAex4KnKm2U8trqKCFjKeGdjmO8NoHcYJwuUdroIopY46KmbHLjxGiMAOx2z6oIu23+WqqWQSUxYTUOhLnNez3RFv3Br2g5zgYI+K67Xdq26XamdCYY6I0xmcw8lwdIRG7P8LHH8fkpl1soXQsidR05iY7e1hjGGu9QPXlco6CkjkhkjpYGvhZ4cTgwAsb+yD5D4IMlERAWBV3WClnlhkbIZI2RuDWge/vcWtDee+WrPWDPa6ee609wkDjPAxzGc+7z5keo5x8ygim6kP1l4Xs7n0TIpZpappa1kbWv2gnLs491+SB5DGVIWq9U1yqJoYWyMkia2TD9vvMdnDhgn0PBwR5hdI03QCERHxjGab2R7fEIEjOfvAdz7zjn4rMt9ujohJiSWV78BzpCOw7DAAA/L5ohFVWpoWSUjmxyR0srnu9okaNj4mMc5z24OccDuBnPGVkQako5XuYWTMeJImYdtPEji1juCeCRj1HmF1x6WoWsZHJLUzQxwPpoo5JPdijdt4bgDttGCcn4rvlsFNNbqiknlqJGzlpfJvDX5aQW42gBuCB2AQdFVqmgponSOEr2taZHbQ3IjBI8TkjLTtOMZJA4C73X6mFaacRVDmNmbA6cNHhte5ocBnOTkOHYHHnhcp7FRyVDZW+JCPDbE5kRDWuY3O0dsjGT2IXOazU0rNrnSj9O6oJDhy8tLfTyB4+QRLrtF6juEjY4mSSExtmMrWFsbWuGWAknOSMcf0WFWamjY6mdDFK2nlc9wqJGe4+NjHOc5uDnHujuBnPGVL22209vbM2nDtspaSHHONrGsAHww0KNZpejbG2N09W+KOB9NFG6QFsUbsZa3j0bjJyceaCNqtR3SL21zbfI4U7oqZuGx4fM/bg8yAgZe3jHzI8pKG+GLfHNFPU1W/Y2nhiaH8NaXH75bgbwCcjnjnzzvqimIIPiHNSKs5Pd4xj8BgfkFjyWCndI2WKeqgmD5XmSJ4DiJHBzmnjtkD4jA5RDGrtQtikp/DLY2PMbpBMxzXRNLXvcXZ7YbGePJZ1qvVNc6iWGFsjJI2tkAft95hzhwwT6Hg4I9F1S6doJjN4zZJGS5D2veTkGMR4z3+6D59ySsqhtsdI2UCWaV0gDXPeRnA7AYAA798Z9UGPbrw2rudRRujexzdz4iQBuYCAcjJI5PmBkdlxj1BTyVDWeBUthdNJAKhzQI97N2R3z/pPOMfFfbTYYLZMyWGaokcyEQASFuNoOR2A5+Pn55WHb9NNbbmRV9TPJIWPLmNk9yOSQHe5nGf9TsZzjPACJKHUTppngROqQ5kZhjgZh7yWB7j7xAAAfH3xyfiAuTtSB1dSthpJnUL6Z1TNUOLGiEAge8C4EY97PHlxnnGS7T9MJfFp5ainmy79JE4A7XBoLeQRjDGfEY4K5y2CglGwskERpjSOibI4NfHgjBHn3PPflEMdmqKF0c7iyceEGODdoc6Rr3bWloBJ78YOD8FlVl5hpBTCaGcT1DS5kADd+BjPnjIyOAcr5FZYGM2vlnlPiMkLnuHOw5aMAAYz8MnzJXbc7XFccNnlmERbtfE0ja8ehyDj5jB+KJdMl8po7kyjkjmYXEtEjgA0uDC8jGd3YHnGPLOVjR6oo3U4mlhqYGPZHJF4rWt8RrzhuOeOf2sL67TFI6RzzUVXLpXAbm4b4gIdjjP+o4JyR644WXPZ4ZJjLHNPA/w2RAxkYDW7sDBBB+8e4PYeiDlLdYoqCKqfDODK7ZHAGZke7ngDOPInOcY5zjlYlXqOCkohU1NJWxgB7pGPY1pjDe5OTg/DaST5ZWTLZqZ1BTUsT5YBTOD4ZInYex2CM8gjkEjkY5WJV6ZpaprxLU1mHxeC/MgcXDJdkkgnOXHtgdhjACD5dr/4EUzaKnmkkbIynbMWZibK8tDWnkE8uGcDHlkL6dT0fh7mQ1Di4vETcNaZQw4c5u5wGAccnGcjGV3PsFO6o8Q1FV4fjipEO8bBIOd2MZ784zjPOF8dp+k9no4o3zR+zQ+A1zXDc5nGQSR54ByMH0IRCSoaqKto4KqmduhmYJGHGMgjIXcuMTGxRtjYMNaAAM54XJEiIiAiIgLErblQ0L2MrauCBz/uiR4aT+fzCy1EVdrqJblUTw1EIhqYmRSslh3na0u4ac4wQ48EFBmi4UZrPZRVQmpyR4e8bs4zjHrjlY5vtqDS76xpdoaHk+KPunz+XB5WEyxTgMjdVRmKGaWohxGQ7e/fguOecbz2xnhffs+GRPjhlawNt4oIfc+53y7vzn3ePggkp7pQU8ojnrKeN5wNrpADz2/Ncqe4UdSGeBUxSb3Frdrgckdx8wo02BrhI10jSx9VDUbdn+mNrA1vf1YDn4rg+yVLbg6tp6uNsznzE74iQN4YARz3aIwPjkoJI3a3h8TDW04fKGlg3jLg44aR8yMBZqr1Lpw09E+AVAc8mmAeWdmQ7Pd7+ZDj/wCZTtOJRBGKhzHzBo3uY0taT54BJwPxKDsREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREH//2Q==",
+              "timing": 2625,
+              "timestamp": 149026976
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHAABAAICAwEAAAAAAAAAAAAAAAUGBAcCAwgB/8QATBAAAQMDAwIDBAYIBQICCAcAAQACAwQFEQYSIQcxE0FRFCJhcQgVFjKBkSMzUlRyk7HhNDZCocEXYiSCJSc1VXOU0dM4U3R1g7K0/8QAGgEBAAMBAQEAAAAAAAAAAAAAAAEDBAIFBv/EADERAQABAwEEBgoDAQAAAAAAAAABAgMRBBIhMXEFFDJBUbETFSMzUmFyocHRIjSBkf/aAAwDAQACEQMRAD8A9UoiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAi+OcGtLnEBoGST2Cr0WuNKzXD2GLUVpfV52iJtUwkn079/ggsSISAMk8eqrp1xpZtf7EdRWkVedvhe1s3Z9O/f4ILEiAggEHIPmoq86htdlext1qvZGPxiaWNwiHzkxtH4lBKoqF1rqv/AFSX+po5+DTtcyWJ/cFzeQQpY6v09ZqSgprvfLdR1ToY/wBHPUNa7lo5IJ4QWdF101RDVQMnppY5oZBuZJG4Oa4eoI7qFu+sdN2erFLdb7bKSpzjwpqljXD5gnj8UE8i6qSpgrKdlRSTRzwSDLJI3BzXD1BHddqAiIgIiICIiAiIgIiICIvj3bWkoBcG9yAvgkYezgou5XGkt8BqLjVQ00OQ3xJnhjcnsMlYFHqWx1tSyno7xb56iQ4ZHHUMc53yAKCyouineT7p/Bd6AiIgIiINb9cJ5n2ex2hsz6ekvF1goauRh2nwXElzc+WcYVjq9C6YqLC60PstA2h2Fga2FoLeMbg7GQ7491mau07Q6qsU9rubXeDJhzXsOHxPHLXtPkQVT5dF6zqaI2yq1491tc3w3vZb2NqXM7EeJu7488ZQUQ325T9D6OhdWylkl4FkdXtdhz6bxS3fn4tG3K24zQOlW2P6pFit/sWzZgwt3dsZ3d93xzlc5tE2SXRI0qaYi0tiETWg+80g5Dwf2t3OfVVpuidaMpPq5uv5fq0N8MONvYanZ2x4ue+PPGUEN1BqqnQnRQ0+nbxNVmOVtGyuc8OfDG55BG4ebR7oPcLYun9OWy36cZbo4hUU80IbO+Y+I6oyOXPJ+8Tlddu0bZKLR7dMikbNafDMb45veMmTkucf2iec+qxXaeulssos+mK9tNTbPDZUVr3VElO3thjeM48tzjhBpWnnlp+kXVCwNlfNbrNXPp6N7jnbH4g9zPwx/utz6J0pZqPSdJGaWmrnVdOySpqZmCR1U5zQS5xPcHPA8go8dM6Cn6a12kqCpkj9tBdPWSN3vkkLgS9w4znGEj0dqO00nsGl9Ux0VtDdscNVQiodTjzEbtw49A7OEFU0/VzaQ/6o2qyEuoLPF7ZQxfeED3xOe5g+AIzhWnpZpKxw6GttS+jpa6quNO2pq6qeNsj53yDc7JI5GT2U1ovR1Hpmz1VIZZK+prpHTV1VUAF9S93cu+GOAFXaLQWodPskotIat9hs5c50VJV0Tak0+TkhjiQcegOUHR0+hjsHU/Vmm7WNlmZDBXRwA5bTyPyHNb6A98LaCrOiNIwaXhrJH1c9wuldJ41ZXT/fmd5DA4DQOAB2VmQEREBERAREQEREBERAXCcZiK5oeUFd1GKk20+xCuM24f4LwfEx/wDy+7j/AHUFZW3f60g9qGovByd3tQofD7H73h+/+Suz4SD7vIXERPJ+6g+wD9IFlLhFGGD4rmgIiICIsOquEVPVx07s73NLycHDW+v5oMxF8aQ5ocOx5C6KiqENVTQloxMXe9nGMDKDIRR9BXvq6qpjMIZHE9zA7cSXEHHpj/dYgvrvHqI3U4AikDGnf979IGE9vLOUE2ii667ezVL42xMeyNrXPJk2uIcSPdGPe7fBfaG6e01pgMbWNO/adxLjtdtORjA/MoJNERAREQEREBERAREQEREBERAREQEREBERAREQEREBcHxMe9j3NBcw5afMLmiAuqengqA0VEMcoacje0Ox+a7UQdUdNBHM6WOGJkrvvPa0An5lcTRUp8TNNCfEOX5YPf8APn1XeiDpFJTjw8QRDw/ue4Pd+XouTYIWyulbFGJHd3hoyfxXYiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIIi832C2vEW0yzEZ2g4x8yoj7YO/ch/N/soG97/rar8XO7xD39PL/bC1/qek1FLq+2T2t1ULWxsYn8KZobnxCXZYSN3u4H48ZxheXVqblVcxE4h79vQ2abVNVVM1TOPHvbe+2Dv3Ifzf7J9sHfuQ/m/2WpKGnvreodwmqWVbrI9rfZ3+0t8Jp8MB2Y855dnnHddGnrfqWHWte65VE77HGZH0znTBwk3luGluc+6M9wufT3fj7s9zvqenz7ueOO//ALx4NxfbB37kP5v9k+2Dv3Ifzf7LS+nKTU0do1HHcWVra57JPY5JKtrw4nft2AH3CMt7/D0Xfp6j1Q3T18gu00n1jJHso5DKDz4QAcCCdp3cn45Kmb92M/z8iNJp5x7Od/P9tw/bB37kP5v9k+2Dv3Ifzf7LSlRSark0ZcWs9rF2kqWOhjFS0SNjGzcN27Azh3n5q5WNs7bPRtq2Sx1Aib4jJpBI8Oxzlw7n4rmrUXYjO15OqNFp6px6OY3fNeftg79yH83+yfbB37kP5v8AZaj0vT36LVd7fdo6w0L5JDSSPqmuiDC4bWiMEkHGefThYWhaTVsF6mdqJ1S6nMbtzn1DHxufu93YwDLRj4j5KZv3d/8AOPs5jSaeZiPRzvz47m6ftg79yH83+yfbB37kP5v9lprTVHqmLWlfNdXzmzOkqDA10wcAC9vh8bjxjOOOOfVYmkaPWsWrpJb3NI62Ey790rHMd+xsaDlv5DhT6a7v/nH2RGl0+72U75x3/wDeLeH2wd+5D+b/AGT7YO/ch/N/stS6cp77FrG8yXOOsNte5xpZHVLXRBuW4aI85B78/NdGkaTUsOrLrNeX1TrY8P8AA8SZpbkvG3a0E4w0d+O/ZRN+7v8A5+TqNHp5x7Od8/Nu23apgqJ2xVERg3HAduyM/HhWJamW0Lbv+r6bxf1nht3Z9cLTpL9VzMVdzz+kdJRYmmq33slERbXmCIiAiIgIiICIiAiIgIiICIiCIvNiguTxJuMUw43AZz8woj7Hu/fR/K/urcior01uuczDVb1t+1Ts01blR+x7v30fyv7p9j3fvo/lf3VuRc9UteHms9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6VH7Hu/fR/K/un2Pd++j+V/dW5E6pa8PM9Y6n4vtH6Vy3aWgp52y1Epn28hu3Az8eVY0RXUW6bcYphmu3q707VyciIi7VCIiAiIgIiICIqL1q1bXaL0HU3W1RMkrDKyGN0jdzY9x+8R59vzIQXpF5O0z1O6mV8tNU091ttzjkkG+jAp/Ga3OD+jG15/DKlperGsIOttRZ2uqam1R3GSmbbGU8e9zBkAh2zdj/X37IPTaLRtz+kNbrffbpbJbDWPfRSywhzJgfEcxxbwMcA4/Bdtj6/0V1vrrYLBVQvbDPKXuqGn9VE+QjG3z2Y/FBu1Fpax/SBstdYrvdK62VVHHQGFjYxI2R875N+Gt4AGNhOSuWkOv9k1DfILXJa66inqXbIHPc17XvP3WnHIJPA4PJQbnReYekPVvV1211NR3qSouVB4EzzAyCNns+3BD3FrAcDG3nzcFbbb9IOhrrHeLk2wVLG21sTnMNQ0l/iP2cHbxjug3ii0FU/SRt8FNRzHTtURUxmQD2lvu4e5v7P/AGqWn+kDYaezVFfNba5rhVOp6aAY3TtaATIc42t5HqeUG50WlrH9IGx3SgubzbKymraOmdUtp5HtxOG92tcOxxzyOyaT6+W/Ud3tlugsVZFPW1QpyTKHNiBxh5OPUnj4IN0ovMP0qb9d7VrK0xWu619FE+gDnMp6h8bSfEeMkNI5V61F170/Yr7WWk0dZVPo2Pa+dhAY6VrfuDz5Pu7vI/DlBuRFQekvUmn6i01ymprdLQiiexhEkofu3AnyAx91VXVv0grDYb/VWumttbcPZZDFNPG5rGbgcENz3weM8IN0ItJ376Qllt9BaqyhtdVWw10bnkGVsboXNdgscMHnz4PYhZH/AF9sDLNX3Got9bGyGoFPTRcb6nIJ3AHG1oxzn1CDciLR9D10tGp7Ff6SGnr7Tc4rdUTwHc0l2yNzvcd5OAGRkeSq3RzqjHp7Q2oLnqWuu1z8GrhihZNJ4ji57XkNaXHjhhJycccD1D0yi0hYfpFWG4VYir7TcaGNzHvbNlsjcNaXHPY9h5Z5WLT/AElLJLV7XWG6Npdwb4wcwkZ9W5x/ug3yi0rfPpDadtt2uFDBQVtWKUOaJ2kNZJIDjaO5A7+98PjlR0v0jqCO0U1edO1RbPPLAGe0tyCxsbs52+fiD8kG+0WotM9dLHe9V0Vidbq+klq/DbFNKBt3vYHBpHBxk4BxzwexUZfvpF6ftt5qKKktddXQQSGN1SxzWtcQcEtB7jPrhBvBFqbUnXXTVosNpuNNDV10lyjMsVOwBjmAOLTvJPHvAjjPYqU6XdWLR1AqqmipaapobhAzxTBNg7mZAJa4ehIznHdBsVERAVI6w2i/XrRzqXS7aeSuE7HuhqNpjmjAO5hDgWnuOD6K7og8ds6Na9ut+pXy2CisrA5u+ogqIwxmDnfta9xz/CB2Vx1V0z1vbur/ANqNL00FbG+cTsmfKweGS3a4Pa4gnz7ZXpNdck8UTgJZY2E9g5wCDz3036eaptHXGuv9ztXg2mWorHtn8eJ2Q8u2naHF3OR5KO1R0o1lF1Tu98sVLSVNHWGpkZLJM0Bomie1zS0kHPvkDyzgnjK9Lte15Ia5riODg5wvnjR+Js8Rm/8AZ3DP5IPI9j6Iayn0lfaStt7KOsM1NUUrJKiNwn2CZrm5a44OJAecK7aJ0x1PqtU2KTUtBa6K2W5scZkfBSySGOPkNaW7nAn1BGO69AunhbJsdLG15/0lwB/Jcfaqfn9PFx398cIPNmjul2t9J9TKmejpqeWz1fiU81b4jCPZ3uBPukhwdwPJVum6N9QLbZ9Q26G20k0NU2JoLahmZtkocNmXDHmTux6DleuWVELyAyWNxd2w4HK1VfusTbT1Vi0WbIZS+qp6b2z2rbjxQw52bPLf2zzjyRDRVf0Y19LQ2qNlgJfDC5sg9rg90mV7v2/Qhbq+kD06vGsY7PcNOeE+utxcDTveGbwS0gtceMgt8yO6xqzrwaalvcz9JV8YtsjWDx5vDEmXhvJ2na7nOOeM8rYHTLWbNcaVp7z7IKAzSSRiAzeIfdOM5wM/kg0nQdPOodxt+oai9W620809HJFFTtZA6eeQt2j9Ny4DHOS/4dle/o36QvmkNO3am1HQexzz1QkjaZWSbm7AM5aT5q+6wv8AWWWCBlrtFRdK+oJEcbHtijbjHL5HHDRz8SVNipY2GN9Q5kLntB2ueOD5jPmiWgPpHdPdUav1VbazTtrNZTw0Qie/x4o8O3uOMOcD2IULe+lWvaDU+q/s7HSy2u9QzGSVz48ua4l/hYcctcXe7nt55XpxksbyQyRjiBk4IOAkc0UhIjkY4juGuBQab+jXou/6OoL7HqSgNE+plhdEDLHJuDQ7P3HHHcd1SK7p11G0vqjUb9I0VHX2+7ueHSyGF36Nzi4AtkI5GcHggr0wKqnIJE8RxyffHC1/1h6nN6cR2l5tRuIrzKBio8LZs2f9rs53/wCyDS2u+k2vbpbrDi20lZWRwyGoFJ7PTsiJdw3ALQ44AyQPP4LZ3XLp1dtYWCwy2PwfrK1Z/QSODQ8ODc4J4yCwd+O62bpu7svWnLTdXRin+sKWKpERfu272B23PGcZx2UhHPDI4tjlje4eTXAlB5nj6Za+1JeLzqLVdNSwV/1ZUU9PTwvjBnkdA6NjfdO0D3u5P9sDTPSvW9DoS82+awUUlTUV1NMKasmjc2WNjJQ7a5r/AHXBzmc5acZ57r1OKiEvLBLGXDuA4ZCMnhkDjHLG4N7lrgcIPLukumvUqCera6ipLbbfAmDLdU1LainLnMIDWsLn4y45yT6/JYVm6YdSoL1D9W2qmsFOXN8Z0Nbuglwe72GR5d8sY+C9YRyxyAmORjwO+05XFtVA4EtniOOTh44QeWbh0j1/aqvVNusUNLUWe5t3GQvjDpmtfuYwBxy13PPYcd+yr9R0a16/TNBSNsJNRFWVMr2e1wcNcyANOd+OSx35L0x1D6j2PQX1f9eCrf7aHmL2aMP+5tznJH7Q/wB1ZLTdqS52aiudPJtpayFk8ZkIB2uAIB+PKIeb4umGsG9WdP3g2ci20ptpmm9oi93woYWycbsnBY4cDnHGVi0/TbqZpGpvds0zQUNda7g8Znl8B4cxriW5bIeDzyMEL1Q1zXtBaQ4HzByomXU1liv7LHJdKRt3eNzaQyDxCMZ7fLlEtA6z6SayqKXTN4oDQVV9oYdlRTwbKZjXCR0jdm3a3/UQe3bKuXRLSer7XebhdtXU1tohMxzWQQwQmZznOBLnSMBJHHm4k557LcaICIiAiIgLyj9LsluuLKRwRbwR/NevVy0j136UX3X+orfX2aptsMNPS+A4VUj2uLt7ncbWO4wQg0/o641ts6gVztFXS43EyWuonqHzMcHOm9nc525p7kS4wT5+vnT/ABbd9mxeBfbh9r/bf1GHY8PGfE8T9rPx/DzXuiy6ctNnnqKm3W2kpquqO6omijAdK7uST3PPKrNvtnTev1M/6vg01UXxj3PdHCYnSte0+8S0diD3OEQ8264rqiLq/pa6agJgmMNrqap7xjBDYy8n5EO/JU2KRsr9ZSRncx9OXNPqDWQL3TeNM2O9VdPVXa1UVZUU5BilmiDnMwcjBPlnyUT/ANONHZqT9nbfmpG2b9H98bg7n/zNB/BBpf6MWh6S40NJqyatqxVW+smiipwR4WDG0E4xnJ3evkFX9e//AIrqX/8AdLd//SFeo7BYrXp6hNHZKGCipS8yGKFuGlxABP8AsPyWDV6M05V39t7qbPRy3Zr2Siqcz3w5gAac+o2j8kS8I2v/AAGof/0rf/8AREs2OenptPWeqtt4rvtDDVPa2ka1wbBHnc1zHepcTwP+OfaUfTPRcbJms03bmtmbtkAj+8Mh2D+IB/BZdDoXS1BNSS0lgt0ctISYHiEExknPBPx5RDyNruolu3Ui/N1vXVFHJAHCAEuAaQBsAAa7gjnsM57hRur5/F0FpiOO6VVxp4qmsbG6eAx+F7sBLGkuO4ZOfhle0b/o7TuoZ2z3uzUNbO0bRJNEC7Hpnvhddy0Ppi50dFSV1joJqWiDhTxGIBsQdjdtA7ZwPyQeetT6Un0b0RbfLJcLhLUX2Gh9uLnD9FEYycNIAIbktb8uFS+nf1ZRax0zPadQVsNdK+Lxo4YHTbpC7DozwzAI4/1cc5Xriiu2k6s/ZmkuFnqHRMNKba2aN7g1gwWGPJPAGCMcYXKy6J0zZK41tpsVvpKvBHixQgOGe+D5fgg8hdDtGUuutUXG1V1ZVUtO2idO405AL9ssYDTkHjnPzAWy/pfRCC36PhaSWx+0sBPngRBb00/ozTmnaySrsdnpKGpkYYnSQswS0kHHyyB+Sj9ex6IqH0cWuZLMHMDnUzbhMxhwcBxaHEegQeXdV1gn1Louk1Jcq23WOnslC+GamaXOj/8ADtdvaB5+IMZ+HwUx9FI7uqVwduc7NtmO53c/pYuSvTc+ldOXGntfjWmgqYaBjBRF0QcImgDaGn04HwXyxaN07YbhJXWaz0lHWSMLHyxMw4tJBI/MD8kHlrrOyo0J1hu1bQN2sudJJIzyx40bo3n8H7j+SjK+23LT/Qu11lN40MN8uL5Kp7MgmNjdsTCfQkSO+PC9dai0jp/Uk0M1+tNJXSwtLI3TMyWgnOAsx9jtcllZaJLfTPtbGCJtK+MOjDR2GD6IPJ3SAW2h6l2xlgv9aRKza+BkDpGzZYS9ryQzAGM52nGO5WvNOUftGntU1Hjzxmko4pAyN+GyE1MTMOHmPeJx6gL3PYdH6d0/NLNZbNQ0Usg2vkhiAcR6Z74+Cwafpzo+np6qCDT1vZDVMEczBHxI0ODgD/5mg/gg8Z34zVfTnTNZUOllfFV1lGJHuJ2xtEL2M+HMkh/H4LJuVXba+52C3T109NpqChiDSHPDWyFm6YjLXHmcyDIae3HGF62ntvTygpTpeoZp+GKSbxfq6WSMEyEAZDSc7iMBSc+gtKT22noJtP219HTkmKMwDDM8nHmMoNVfRWljFJfKaku9XXUkbmOEMtOWMhcd3LXEnOQBkYHYKRu//Tv/AK+U3tnt51Xujxj/AA3jbBsz57tu3Hl2W27LZ7dY6FtHZ6GnoqUHIjgYGDPrx3PxWPJpqyyX9l7ktdI67sG1tWYx4gGMd/lwiUuiIgIiICIiAiIgLxfpC2VN66qaytlAGmrq4LnDEHO2gucXAZPkvaC1JobpBJpjqPV6pdemVLZ3Tu9mFNsLfEJP3tx7Z9EFFvOtNS9LNNaT0VQU1F9eugdJNJM4PY0PmeGBpyB65JOArFoXXPULUFDfrfX2qOmuVPTPloq9tOfAfI0j9GTktdu8iD6q1dWOlVNr2robhDcprXdaNuxlRGzeC3OQCMg5BJIIPmVD6S6NVGnLffJItS1FRfblTupm1skR2wtcRucG78lx9S7hENX23rrra7OtdooG0f11UVhhdI6nG1wdsDBjPBB35PyWZP1s11c7lWt03S0E1LQkNLXRAyzDON23dkkkE4aOFOw/RuNNTUL6PU3g3OnqHTGqFIeR7uwBu/gtLXHOed3wWVdfo8GeuqZrXqia3wVmDU07Kcljj3cBh493OSAc49SgrmuututLW6yeHQxWqoqKES1FNU0xz4niyN3N3chpDWkD+q74ututYda3m0T2y3SvpxVBtMDjwTEx7id+feADDn18sKf1P9HiG5ttUduv76aKhpBTuM9P4z5Xb3vLyd4x9/GMcYWc/odK7Xt21H9fsDa41hFP7Ics8eORn3t/O3xM9uceSDX3/X3Vc2jZ6ljaCO409dFEZWw5a+N8cpwWk8EGPuPVStn63axpK/TlVqG2Un1HdcRtka3D5AHBj5G4PBBPYjt+aq3VLpXN070UCboLka+4Q8MpjHs2Rzf9zs53/wCyufSXo3S3e36Y1Lc7pUyUkcYnZbXN91sgeSfeJ4aSASAPxQa+st/ZpbrnqW9yRGUUdTcpBHnG92ZA0Z8skhW2y9ZepFdJT3Cns9FcbfLKW+zUsJc/APIw1xc34Fwx81dafoNA/W13vVyvAqaK4vqnPpG02xzRNuxh+48tLgc48lF0n0cvDqoIqjVtZJaIpDIKVkJY744O8gE+oag2F1a19JorQcd6pqQurap7IYIZwQGPc0u98d+ADx6rzD1jvuqL63T0+sbbHR1LqZ0tPJHgNnieQQdoJwR6HntwvWevNDW3WOkfqCrdJTwx7HQSx8uicwYaee/GQfgVqK5fRvlrKajY7Vs8ksDSwvnpzIAzPutYN/ugD59/JB0au6t6npNSQaZ0fTUIdSUsQfJU7d0jvDa44LnBoHIGO5WzOjOrr/quyVT9U2eW3VtO8BshhdEydpBwWh3mMc/MeqretOh0d7vUV4s9/qLRcTCyKZ8cZcHlrAzcMOBbkDkZKuHSnp9S9P7PUUsNbNXVNS8PmnkG0HAIAa3JwBk+Z7ol5K1K65S6rrqnW9Zead75HOhqYIvFYeTgsy9o2Y7bT2V3k6l33RWhtPRaevlPdI6iWq3zzxue8Bpj2tIfy0gOPHI5GCVca76PFc+Keko9a1UdskeXeyyU7nN75GQJADz8FIXH6PFtqNJW21U14mhrKSWWZ9U6EObK6QNB9zIwBsbjnyRCHb1b1QerFssHi0n1dUOpA8eAN36SGN7ufm4qF0R1Y6navrKqhslPb6yqjjEp/Rsj8Nu4An3nAHvj8Vc7X0GloNbW6/8A2lkqG0j4XmOanLnv8NjW437/AD28ccDA8lMdHukEnTy+1txfem3AVFN7P4YpvC2+812c7j+yg8/6at1bdevD4bqaaarhus9RWFxcGO8Jznybcc9mO2+WcZ4V1b1u19eqqsrNO223uoIZQ1tMI/ElIJ443b3H1LRgfBbH070bdaeqdVq+W8sqIp6iqnNH7MW8TB427957b/TnCr1f9HNpraltp1TV0VqqJA99IYS7gHIGQ8A48iQg3Po27VV80xb7jcKCW3Vc8eZaWVpa6NwJBGDzjjI+BCmVFaWsdNpvT9DaKF0jqekj2NdK7c53OSSfUkkqVRIiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiKMqp6r2mVkB2sZxwwOycA+ZHqqb16LNOZiZ5OqadqcJNF0U0kktI15aPEIPB4Gf91gUNwqZp6VksUTWStk3FriSC12MDjt8f8AYKyiqK6YqjvczGJwlkVfqLpWx01fPtibHDN4TCWcfrA3JO70J8guyO51JqaOAeFJ7Q0ObI0cYBO/OCR2xjnuV0JxFAQ3eqdNVNfHEGxztjadpGQZiz154HfjlcHXmq8KscwwOfDP4TWBm52PE25I35PHyQWJFFVNyfBZIqyR0Ucj2tPPvNyfIc/8rF+uphJL4ngMYyMvPBdsw1p3Eju0kkDCCfRQVDeJ6itpIXsjDJWbi5ozuPvdueMbRnvycKdQERYlbJLuEcJLTsc/IAJOMcDPzSIyiZxGWWixqKVzw9r3btuMOIwSCM8j1WLa7hLV1tXFKwMETsNbjnGSMk588ZxgceqnBE53pNFX6G+VFRVwQOga0mSRsjsHGAHFmPntOfkvhvVU19LmBhZNHTuL2g+66R2CCPTAOPioSsKIiAiIgIiICIiAiIgIiICIiAseWkilkL3bg498OIyshFzXRTXGKoymJmODjExsbAxgw0LkiKYiIjEIERFIIiICIiAiIgLrmhZMAHg5HYgkEfiF2IhjLhFEyJm1gwO55ySuaIgIiICIiAiIgIiICIiAiLpNTEKttNu/Slpfj0CiZwmImeDuREUoEWBcq72fDIsGTuc+SwPrOp9W/krabNVUZhXVdppnCeRal6kdRLtYamjt9mp2T11T72SzIaPl+BVOu3VHW9N+qhia4DkGkyM/NU11RRVszO9dboquU7VMbnotF5hPVLqZh8gpaYQtGcupQM/LlbJ6VdQbjqyyzSXBkMdbTybH7G43DyO3y8x+Cm3MXJ2aUXIm3GaobVRQP1nU+rfyWZ9YTvpGvpKYVE4e1r4zIGYBPLsn09FZVaqpjMqqbtNU4hJIo/2m4f8Au9n/AMwP/ou6jfVySSOqoo4Y8AMa1+455yScD4fkq1jKREQEREBEWDeaielpBLTt3bSd+GlxDdp5AHxx+GUGci6J52ikklieHbWFwLefJdzHB7GuaQWkZBHmg+ovjyQxxHfHC8uXDrJriDqPJYYzR+D9Y+zMj9mBcYy/A5z+yQcoPUiLzN1W6v6z0tqo0FG6jjpnQslj304cXZyCc59QVv7RNdW3LStsrLq0MrpYWumaG7cPx7wx5c5QTaIiAiLqnnjgMfinHiO2A/FRMxEZkdqIikFW6FxdrKsye0eB+TVZFWbf/nKt/g/4aqL3Gnm06fs3Pp/MLMuuolEML3u7NGV2KOvb9tO1o/1O5WminaqiGSudmmZQ0j3SPc9xy4nJXFEXosCh1tD7RreqqZmgmJjWR/AEDKn2wsDQC0H8FjXOBzbxPI3hz2NI57jssaA1ranD9ng+rHE4/NfM6mfb1c31+hjGnoiO+Hy9QNdA4bRghV3pvF7FrK5QRjEc9P4px5ODgP8AlZdZNWVBkw1hjaSMOeW5Xb06pX/XVfUuydsLYyT6k5/4Vuin28YZuk4zYn5NhLvo5zTzteO3Y/JdCL6GYzGJfNROJytgOQCixra/xKKInuBj8lkrzZjE4b4nMZERFCRF01kxp6aSUM3lo4bnGT81ixz3M1MLZKGnbC5xEjxUklgwcEDZzzgdx3ygkEREEXdWWq2UVVcqylgbHBG6WSRsILsAZPYZK5UdDRyxxVNI6oZG9ocwNmka0A9vcJwPyUi5oc0tcAWkYIPmvqDGdSOP3aqob8iD/UFVd3TqwyX8XqWEvuQGGzlrAQPThuPh6447cK4ogqN96f2S/XKmrrxEauencHRmRrPdPHo0Z7Dg5CtcMTIImRRDaxgwAuaICIo603CeulrWT26pohTzGJjpi0iYYB3t2k8c+aCRUHq8kW+MjuJAf9lOKC1h/wCzY/8A4g/oV5vTH9G7yXab3tPNNxnMbSe5C5LjD+qZ8guS9GnhCkVZt/8AnKt/g/4arMqtSSCPV9a4gn3PL5NVN7jRzadP2bn0/mFpUVfc4h9Of+Fme2M/ZcsK6ytmpxtaQWnPK2Wt1cMNyYmmYhEoiLcxoa7scyujmI/RuZ4efjklR0tY2NznFzdreAzOPxTWd8bbq6y0JjDzX1Doy/P6vEbnD8yMIRDhxIDXHzwvndfTsX5x3731vRVe3poz3bkJT1kb6qZhe3a88MznHxU1oSF7frGY/q3yta34kDk/7hQNwmgppi7LS/19PirNoOugrLEzwuHtc7e09+TkH8Qrejrc1Xtvuhm6XuxTa2PGVjREXuvm0/Zxiib8z/VZqgKe7SU0QiFqrn7cjc0xYd8Rl+V2/Xkv/ue4fnD/APcXn176pluomIpiEhdal1Hb5p2AF7R7oPbJOBn4crr8O5fvVH/8s7/7iirjcZ6+kdTMtdZEZHNG+R0W1o3AknDyew8gpr2xn7LlziU7UOiWlrp2iOarpvDJBcGU5BIBzgEvOPyUgsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkosb2xn7Lk9sZ+y5MSbUMlFiSVn6N3hsy/HuhxwM/FULQNx1lJqfUbdTQUTbaKkeB4T3kt/RtwI8jluMZJx725MSbUNkIsb2xn7Lk9sZ+y5MSbUMlFje2M/ZcntjP2XJiTahkqC1h/7Nj/8AiD+hUp7Yz9lyhdVTtlt7AAR+kHf5FeZ0xE9Ru8l+mqibtPNYYf1TPkFyXGH9Uz5Bcl6NPCFQqlH/AJsrv4P+Gq2qpR/5srv4P+Gqq72qObTY7Fz6fzCXXF7Q5pB7FckWt5qqakvdPYo81AdJK77kTO7v/oFQbpre6VVQ1tJG2lgDXOdt5c4YOBkjgrZWrdOQ36jxwyqjB8OT5jsfhytRXC21FHN7PWRGKXducCMAHPugeuSF6mlqt1xv4s1ymYn5MC/RvrrdM1gkkr97Z43l3vb2nG7J9B/VXDS9c+6WOCadofLtw4EgEOHfKrMrZI6hs0R2StccZGRggNPH4ZWTbRNT0kjoJ2sDow/BBw4k+Xx81k6S0E6nFVPGHq9F6+nS5pr4Si7vUiXUctK8NMccZkMbXZHcAZ9e5/JR0NbVNubqimMlO9oDQ5jiCRnjP+6z44HATOe4GSbAkfjJOCTtB/Ht81xZTnxmgYwHbTznLifX4bT+a26XT06e3sUw8/VXqtRcm5Ul9P8AUG7UzR7e1tXCXluXDDhjsAfj8VtHS15ptQRGSmDmmPHiMcPu/j2K1RpzT1Vdm08FLCcOO98h+6wcjJ/Jbs0/Z6ayW5lJStHHL34wXu8yVXqqqKIxHFXbpmZ+SSX1EXmtAiIgIiICIiAiIgIiICIqL1LqdXQPtH2Up6WSJ1bEJy97t2M8hwAwGepzn4KCIyvSLppDOaaI1bY21G0eIInFzQ7zwSAcfgu5SCitRf4Jn8Y/oVKqK1F/gmfxj+hXl9Nf0bvJp0fv6ea0w/qmfILkuMP6pnyC5LdTwgFUo/8ANld/B/w1W1VKP/Nld/B/w1VXe1RzabHYufT+YS6Ii1vNFgXW1Ud1h8Osha/H3XdnN+IKz0SJmJzA13c+n8viSPoKprmu7Ml4LeMd/PlQ0Wkr3FROiNGQ8YY3bI1w2g9+/wAfTyW3UWmnV3I+aubcS1DFoy8SvJNK1vOG73hob6nj5u/NT9n6esiMLrjVeIIyD4cQwHHjufwP5q/olWruVbuCdiGNQUVNb6VlPRwtihYMBrQslEWaZzvl2IiICIuipqoaZoM7wwHgZUImcb5d6LjG9sjGvYctcMgrkpSIiICIiAiIgIiICIiAorUX+CZ/GP6FSqitRf4Jn8Y/oV5fTX9G7yadH7+nmtMP6pnyC5LjD+qZ8guS3U8IBVKP/Nld/B/w1W1VKP8AzZXfwf8ADVVd7VHNpsdi59P5hlXm6UdltlRcLnMIKOBu6SQgnaM47AE+aitN6009qV07bLdIal0DQ+Ru1zC1p7HDgOPiuvqTZqvUOh7tarf4ftVTEGR+I7a3O4Hk/gtLw9HNVMstwot9tEs0EGJzNIXzbNuYHHsGDHGB/patTzoiHocVdMQwiohIk+574975eq+CspixrxUQ7XHa07xgn0C0A/pBqRuk4BR/V9Jeqe4GpgiineWRxubhw3OzzkN4AxwuF+6LXw0Niht3sFWynofAnhqJnsbHO55c+Ru3vy7HrwEynEeL0G6rpmvLHVEIeCGlpeMgnsF8FZSlwAqYSS7aB4g7+nzXnm+9HNTVlRdJYnUT5ZXUhgk9ocP1ce155ye+MZJK5UPSHVdPeKRzpKE00F5FeZhMd5ZluTjHcY7eqZMR4vREc8Ukj2Rysc9n3mtcCR8wqu3qJpV2oPqQXZn1p4/s3geFJnxM425247/Fa76V9MNQaZ1lHcbmaDwIWSNfURTSOkqS7OCRkDzHcHt68rGh6a6rp+ol3utOy2Cgr6qSQTSSEyRNduw5oHZw3Z+YUZkxDbupNU2rT9mq7nXVAfTUpaJRDiRzS5waOB8Ss613WjuduirqWZhgkjbJkkAtDgHDd6HBC85wdF9VC011L7NaIZXQCETR1MpdUnxQ7LsnaOB6eQ481Iy9H9UNprxTUUtHT0tVDSO9nE7gyeSNrQ8PwMgE7jnzTMmI8XoM1MDYRM6eIRHs8vG0/ivktXTxFglqIWF/3A54G75eq88VfR3VMmn6aJr7cQytmqPqnx5PZ42va0ANcecjB8/Pv3Xy8dHdS1DbM1lPbZ5aWnbC576uQxNG5xLdjgXHG4YIcPkpyYjxej1Bar/UQfxH+imoWlkMbDjLWgcdlC6r/UQfxH+iirgov+7lqD6Qurb3pqi02yzXmS2QTRyPnELR4ku0N2hri0jzPGRlVGn6s6xsVdXVVwq3VcLbFT1dJT19IYxNI50Qc73Mc4c898Lc+uOoVBouns1LVWysuVVWxPkjhpmtO1kbQXOO4jsD/so2PrRaZKq5MbZbuaa200dXV1Phs2wsfF4jcjdnJ4bj1+HKLqOzG5UdYdYdX6UmiiuNusj31FqFxgMMczmlxkwGElw7N5PxWJSdaNVXe9VFpp6G2000lPIIoRFOakO9n3tmHBYWF3YHnH5mfqetlJcaq0RW6lr7fO+5U9NUU9RSMle+OVu5mCJBtDgO4yfgu5nX2zOoKyt+zt6Hsr2xvbsi3tySMvG/LBx/qx3Cf66x8lAtHXXU1q0vbhVto7jVOoJ55J6mCQPM7ZnARnaWjhm08DzHKtVs6vavr7Zqa5wWe0z0tkhikfDG2UTSGRmQRyRtack/9o/FSlx+kFp6ipmTvs12kxA2aTYIiI9zy1oJ34OcZyMjGF2P+kDpuCvlp6q2XSGOOompnTbGFu+NuTwHZ548vNP9MfJWbN1s1beaux0NDb7C+ouVZJSMqSyoEDsNaQRnB4Lue/4KX6s6wvulepNolo3S1LIrJUVMtBG9whllaHclo7gd/XAUpD10tJtJrJNP3qOR00ENPT7Iy+czNc5hbh2OzSefUKYu3Vq0W3Q1r1RPbriaWvqBStg2NErHe93BOMe6exQ/xH9EepV017cb7T3SmoIo6COndE+kZK0SeIHEk+Jzj3eOB+PdbZWm5+vunoadj22m8PnZ4pqoGxM3UzY3Bri73sHk+RK+1HX7TsVU6GO33KVvtgo2yNDAHEjIcMuzjH4qcomJ8G40VS6c60i1zZjdKS119DROx4MlUGgTcuB27Sexbg5VtRyKK1F/gmfxj+hUqorUX+CZ/GP6FeZ01/Ru8mnR+/p5rTD+qZ8guS4w/qmfILkt1PCAVSZ/myt/g/4araoqptv/AKTNbF3czY9vr2wVxXRNU0zHdK23ciimuJ74x5IjVUNzqNPV0FilZDc5IyyCV7sBjjxuzg9hk9lRY7X1NiohGy828yMpGtBc1pLpg4AnJZ2LAXZx94+i2iWkdwfyXzB9D+S0MTXEtu6hVFmvUE9xoo62VsXsUkDw0RkOG/nZkZbnvnnyCwp7H1H8OllgvVOZ4XPaI5Hgt2FrACSIxufnfy4YBwcd1tTB9D+SYPofyQy1lqWya/rqihdbLvT0zRQNjqh4mA6fD9xADfPLcEYxjsouq051Ofdo6qG80TWQt2Rs8d+wgB2C5u3BPLck5yR6YC3Dg+h/JMH0P5IZVPRVLqyGapk1ZX087NrGwRQNbjO0bnOIaDnIPw5+StiYPofyTB9D+SIFBXvV2n7IS26Xejgl/wDyvEDpD8mDLj+S+a8ZcX6NvLbMJfrA0r/B8P7+7H+n4+nxWv6Kp0taZKKeyTSUlE5kT/ApaCR1bI8AhzZCGbiSdpyT3yomcOqacrJV9QHSRudZdP3SsYAS2epa2ihcAMkh0pBIA8w0qOqL1qm4Udwl+srRa4qUs8SOghfW1DdxGGgu2szzjscFYdLSXKrkndbNKXGfx3bnz3qpFKx5OCS6Nu95yQDjj0+CnKXS+p5nvfU3yjtLZBte200Q8VwznmeXc48k+SjfLvFMIW6WaqpaC6XGu1BqSmqKSmkqIa+oqmshEjCdrDEGhhDhtOOTyRxjmyyVtRcdK2WtrYvBqqiBksseMbXOYCRhc6Xp7Y2VTKu4x1d3rGkET3KofUEEdsNcdo/ABSWp4nuggDGOOHHsPgkxuZ9TMTbnDWfWO66bp36Ztup9NwXgVEE80Uss5i8Dw49xGQM4dxn5eaidFa+0C6+XOhrrNbrI240dJHLI6fxYqprowGRbdoAa1pxngKw9UbBp28V2mxqOtudJOylqmQey07nsLXRYeXkNOMDt2z8VGWXoZpa40lLXU92vNRQVENO0xkiNs0cWNoeNoPJaCexGPJSsoxsxlxoavpDR1tfbW01opqezzisD2yPcXStO1zgB94NyB3PnwByeojoXFQCMi0tgrJcgky7iW8Z3d2t97HkPyUw7oJYM3dsVyu8dPcGvb4DZG7Itzg4ke7z243ZwpDUXRqy3uezTurblSTW6kjod9M5rTLEzGN2WnB47jHdHWYYVDYukmp7obHRW611ddQRPp/Ajje0xtjeC4bhj/Ue+cnJ5PKqulr50muVohvF9tFvs1TJV1EzIKiZ8xe5uA+THbntgjnGBlbc0Romi0g+8voJaiZ1zrH1shmwSxzu7QQO3zWq63ovpCjuFs0/JdL9HX1kNQxkkLfdljJ3lr3Bm0AHkA4z8UIWKrsvSSzWKnpKuhttPbb0z22HeyQ+MI2btwd3GGuOBkdz6qL1ZL0x1HZNPaWgvtLbKSKeKspaaCMgPBB2tO4YG7cTzyc/FW3WHSiz6p0bZdPV1RVxxWlrGwVMW3xSGs2YJIxgjGePIKuHprpOu6kSx0VXeKS4UNPTunpoWFkD2sYGMw8t54xlrXIQi73e+izdNxyRUNtuMFqjNTDS08JEm10gae+M+8RkOPxUju6PXW826etp7bDerqIaxkUm9jw+RoLA7adrXHI48+/OcrGreh+kbDZjLdLtc20MNE+hc523OHyl4d7rclwc7jjyWVpTpVpa43G36gs18vFR7IIYpCXbPGdC0NZuywOHu7QQMAhDc2FpyWx2OvZo+y0stL7HTe0sibE/wmsc85xIeCdxJxnPKsqgqyiFtu9bqKqudw9jjoyx9FndAwNO4yNYBnfgYWRpi+0mpLPFcra2oFNIXNb48LoncHB91wBUuUqorUX+CZ/GP6FSuD6H8l8ltxrfCEnuxteHHPn8Fi6Ss1ajS12qOMxhdpqoou01T3JWH9Uz5BckRaIjEYdCIikEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBdT52McWkSZHpG4/wBAu1EGLV1jIKCpqfeDYY3SHc0jgAnz+Sr0FwrLa6BlVVurJTQiWZkgaNsxLWsA2tyNxLuME+7wrRPDHUQSQzxtkhkaWPY8ZDgeCCPMLGbare2mfTtoqYQPcHOjEY2kg5BI9eAhKHpdQVNW+OCnpozUOqXw7nFzGhrGBzn4Izw5wbj1Sk1DPUS0INIyOOoZGRI5ztri7khrg0jIHYOIJU3TW+jpn7qalgidzyxgB5xnt67R+QXyG20UEjJIaSnjewBrXNjAIAGAB+HHyQQVyvb6O/TxMbLM0tigYxrHvDX4e9zi1gJ+7s8vMdu6N1JUOpaWYUQY2UO3SSbwwEP2gHDCWh3cFwCnpqCkm3+NSwv3v8R25gOXYxuPxwAM+i+G3UZfG80kG+MBrD4Yy0DsB6YQYN5u01BVQxMp2mN4BMzy7YHFwAaS1p259TgLHF9qNhqnQUraFxkEZdPiQ7cgHbjzIxgZIyPkpiWipZahs8tPE+ZuMSOYC4Y5HK6TaLcTOTQUuZ8+KfCb7+Tk54555QV6s1DI+kcZg+nEFWwSOjD2ktZH4zhhwB7Nx8crPtWoX1U8rKmjnia2Jsvu08u5uSRtILAT8xkd/RSsVsoYXExUdOwk5JbGBzjbn8uPkuyko6aja4UlPFCHdxGwNz+SCLkvmxxHhN96tFLHl2C4Bgc52PgA/j4LDg1FWvpKWc0MUhqqR1VFDFLufxtwDx57/L5cqWr7NR1UdSWwQxVUzHN9obGN7S5pbuB9cHC5Q2e3QwuijoaZrHgB4EY97HIz688oMNlxqaux1U1OYI6rLoodxc0b+wDg9oIdnjBHp6rAivUlJBK10tRLUNlIkjq2tLoQ1gcT+iaQR7zefLdyfJWJ9DSPozSPpoXUp7xFgLTznt27rpNntpZGw0FKWR7to8JuG574488DKCG+08hFA5tKMT+ztezLiWPlIy3IbtBaCDyckeQXZaquqdeRHXVMwMolkhYzw3QSRBwDS0gbgQHMznuSVKts9ta9rxQUoe0tIPhNyC3Ab5eWBj5L4yzW1geI6Gmj3uDnbIw3JDtwzj/uGUQj73c5KS70zIjkNge8xknD3ucxrBgAk8bzgA9lzgvrnWOSudBmQTmnYwEtD3+J4be4y0F3fI4UnU0FJVEmppYZSduS9gd90kjv6EnHzKNt9G2kkpW0sAppCS+LwxsdnvkdkSiJLvcIp4aV9NSPqXylrjHOSxkYZuLj7ucgloxjnI5XS7UU7aVtS+mZ4E9FJWQiOTLw1oaWh2RgE7h8jxyp6moaSl2ezU0MWwEN2MDcA4zjHrgfkFwhtlDCyRsNHTsbJjeGxgB2DkZQQ4vlXFJPA6kL5YY3mNr3EPqNuAHNIbsOSRwDkZ7eS65tSvjo3ymOHxGb3ObiXLGNaCS5uzc3k45488+SnPqyg/Sf+Dp/0n3/ANGPe5zz+PK4SWi2yNYJKClcGNLWgxNOAe47digi33+o3F7KWMQRvp4pdzzuD5duQBj/AEh7T8V1nUk8VAy4T0sRo54hJTsjlLpnbnNawFoHnvGcZx25U8yipY2FjKeFrS5r8BgA3NAAPzAaPyC6orTb4WTNioaVjZv1gbE0B/nzxygwrZejUU1wmqoXRNozlzjG9gI27jw9oII+Xp6qPfqiopaenlraJn/iKZs7GQPdIWuc9jGsdhvmZByAex4KnKm2U8trqKCFjKeGdjmO8NoHcYJwuUdroIopY46KmbHLjxGiMAOx2z6oIu23+WqqWQSUxYTUOhLnNez3RFv3Br2g5zgYI+K67Xdq26XamdCYY6I0xmcw8lwdIRG7P8LHH8fkpl1soXQsidR05iY7e1hjGGu9QPXlco6CkjkhkjpYGvhZ4cTgwAsb+yD5D4IMlERAWBV3WClnlhkbIZI2RuDWge/vcWtDee+WrPWDPa6ee609wkDjPAxzGc+7z5keo5x8ygim6kP1l4Xs7n0TIpZpappa1kbWv2gnLs491+SB5DGVIWq9U1yqJoYWyMkia2TD9vvMdnDhgn0PBwR5hdI03QCERHxjGab2R7fEIEjOfvAdz7zjn4rMt9ujohJiSWV78BzpCOw7DAAA/L5ohFVWpoWSUjmxyR0srnu9okaNj4mMc5z24OccDuBnPGVkQako5XuYWTMeJImYdtPEji1juCeCRj1HmF1x6WoWsZHJLUzQxwPpoo5JPdijdt4bgDttGCcn4rvlsFNNbqiknlqJGzlpfJvDX5aQW42gBuCB2AQdFVqmgponSOEr2taZHbQ3IjBI8TkjLTtOMZJA4C73X6mFaacRVDmNmbA6cNHhte5ocBnOTkOHYHHnhcp7FRyVDZW+JCPDbE5kRDWuY3O0dsjGT2IXOazU0rNrnSj9O6oJDhy8tLfTyB4+QRLrtF6juEjY4mSSExtmMrWFsbWuGWAknOSMcf0WFWamjY6mdDFK2nlc9wqJGe4+NjHOc5uDnHujuBnPGVL22209vbM2nDtspaSHHONrGsAHww0KNZpejbG2N09W+KOB9NFG6QFsUbsZa3j0bjJyceaCNqtR3SL21zbfI4U7oqZuGx4fM/bg8yAgZe3jHzI8pKG+GLfHNFPU1W/Y2nhiaH8NaXH75bgbwCcjnjnzzvqimIIPiHNSKs5Pd4xj8BgfkFjyWCndI2WKeqgmD5XmSJ4DiJHBzmnjtkD4jA5RDGrtQtikp/DLY2PMbpBMxzXRNLXvcXZ7YbGePJZ1qvVNc6iWGFsjJI2tkAft95hzhwwT6Hg4I9F1S6doJjN4zZJGS5D2veTkGMR4z3+6D59ySsqhtsdI2UCWaV0gDXPeRnA7AYAA798Z9UGPbrw2rudRRujexzdz4iQBuYCAcjJI5PmBkdlxj1BTyVDWeBUthdNJAKhzQI97N2R3z/pPOMfFfbTYYLZMyWGaokcyEQASFuNoOR2A5+Pn55WHb9NNbbmRV9TPJIWPLmNk9yOSQHe5nGf9TsZzjPACJKHUTppngROqQ5kZhjgZh7yWB7j7xAAAfH3xyfiAuTtSB1dSthpJnUL6Z1TNUOLGiEAge8C4EY97PHlxnnGS7T9MJfFp5ainmy79JE4A7XBoLeQRjDGfEY4K5y2CglGwskERpjSOibI4NfHgjBHn3PPflEMdmqKF0c7iyceEGODdoc6Rr3bWloBJ78YOD8FlVl5hpBTCaGcT1DS5kADd+BjPnjIyOAcr5FZYGM2vlnlPiMkLnuHOw5aMAAYz8MnzJXbc7XFccNnlmERbtfE0ja8ehyDj5jB+KJdMl8po7kyjkjmYXEtEjgA0uDC8jGd3YHnGPLOVjR6oo3U4mlhqYGPZHJF4rWt8RrzhuOeOf2sL67TFI6RzzUVXLpXAbm4b4gIdjjP+o4JyR644WXPZ4ZJjLHNPA/w2RAxkYDW7sDBBB+8e4PYeiDlLdYoqCKqfDODK7ZHAGZke7ngDOPInOcY5zjlYlXqOCkohU1NJWxgB7pGPY1pjDe5OTg/DaST5ZWTLZqZ1BTUsT5YBTOD4ZInYex2CM8gjkEjkY5WJV6ZpaprxLU1mHxeC/MgcXDJdkkgnOXHtgdhjACD5dr/4EUzaKnmkkbIynbMWZibK8tDWnkE8uGcDHlkL6dT0fh7mQ1Di4vETcNaZQw4c5u5wGAccnGcjGV3PsFO6o8Q1FV4fjipEO8bBIOd2MZ784zjPOF8dp+k9no4o3zR+zQ+A1zXDc5nGQSR54ByMH0IRCSoaqKto4KqmduhmYJGHGMgjIXcuMTGxRtjYMNaAAM54XJEiIiAiIgLErblQ0L2MrauCBz/uiR4aT+fzCy1EVdrqJblUTw1EIhqYmRSslh3na0u4ac4wQ48EFBmi4UZrPZRVQmpyR4e8bs4zjHrjlY5vtqDS76xpdoaHk+KPunz+XB5WEyxTgMjdVRmKGaWohxGQ7e/fguOecbz2xnhffs+GRPjhlawNt4oIfc+53y7vzn3ePggkp7pQU8ojnrKeN5wNrpADz2/Ncqe4UdSGeBUxSb3Frdrgckdx8wo02BrhI10jSx9VDUbdn+mNrA1vf1YDn4rg+yVLbg6tp6uNsznzE74iQN4YARz3aIwPjkoJI3a3h8TDW04fKGlg3jLg44aR8yMBZqr1Lpw09E+AVAc8mmAeWdmQ7Pd7+ZDj/wCZTtOJRBGKhzHzBo3uY0taT54BJwPxKDsREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREH//2Q==",
+              "timing": 3000,
+              "timestamp": 149401976
+            }
+          ],
+          "scale": 3000,
+          "type": "filmstrip"
+        }
+      },
+      "unminified-javascript": {
+        "id": "unminified-javascript",
+        "title": "Minify JavaScript",
+        "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn how to minify JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unminified-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "debugData": {
+            "metricSavings": {
+              "FCP": 0,
+              "LCP": 0
+            },
+            "type": "debugdata"
+          },
+          "type": "opportunity",
+          "headings": [],
+          "overallSavingsMs": 0,
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsBytes": 0
+        },
+        "warnings": [],
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "network-rtt": {
+        "id": "network-rtt",
+        "title": "Network Round Trip Times",
+        "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "20 ms",
+        "details": {
+          "items": [
+            {
+              "origin": "https://player.ausha.co",
+              "rtt": 16.960679999999996
+            },
+            {
+              "origin": "https://tag.clearbitscripts.com",
+              "rtt": 10.86858
+            },
+            {
+              "rtt": 4.8411449999999991,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "rtt": 4.1717249999999995,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "origin": "https://useago.github.io",
+              "rtt": 2.62449
+            },
+            {
+              "origin": "https://cta-eu1.hubspot.com",
+              "rtt": 1.2195824999999998
+            },
+            {
+              "rtt": 0.94635,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "origin": "https://forms-eu1.hscollectedforms.net",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "origin": "https://forms-eu1.hsforms.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "origin": "https://fonts.googleapis.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "rtt": 0.027029308824322511,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.0084016104308925789,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "rtt": 0.0039307950530968116,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "origin": "https://js-eu1.hs-banner.com",
+              "rtt": 0.003567677408714191
+            },
+            {
+              "origin": "https://js-eu1.hubspot.com",
+              "rtt": 0.0025394975262283577
+            },
+            {
+              "rtt": 0.0014671295046391308,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "rtt": 0.00086028984921191322,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "rtt": 0.00070740189339372507,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "origin": "https://www.googletagmanager.com",
+              "rtt": 0.00060794936930315033
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "origin",
+              "valueType": "text"
+            },
+            {
+              "key": "rtt",
+              "label": "Time Spent",
+              "valueType": "ms",
+              "granularity": 1
+            }
+          ],
+          "type": "table",
+          "sortedBy": [
+            "rtt"
+          ]
+        },
+        "numericValue": 16.960679999999996,
+        "numericUnit": "millisecond"
+      },
+      "viewport-insight": {
+        "id": "viewport-insight",
+        "title": "Optimize viewport for mobile",
+        "description": "Tap interactions may be [delayed by up to 300 ms](https://developer.chrome.com/docs/performance/insights/viewport) if the viewport is not optimized for mobile.",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "node": {
+                "nodeLabel": "head \u003e meta",
+                "type": "node",
+                "selector": "head \u003e meta",
+                "path": "0,HEAD,1,META",
+                "snippet": "\u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\"\u003e",
+                "boundingRect": {
+                  "width": 0,
+                  "top": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "bottom": 0
+                },
+                "lhId": "page-11-META"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "cls-culprits-insight": {
+        "id": "cls-culprits-insight",
+        "title": "Layout shift culprits",
+        "description": "Layout shifts occur when elements move absent any user interaction. [Investigate the causes of layout shifts](https://developer.chrome.com/docs/performance/insights/cls-culprit), such as elements being added, removed, or their fonts changing as the page loads.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "headings": [
+                {
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "key": "node",
+                  "valueType": "node"
+                },
+                {
+                  "label": "Layout shift score",
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  },
+                  "key": "score",
+                  "granularity": 0.001,
+                  "valueType": "numeric"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "score": 0.006987,
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  }
+                },
+                {
+                  "score": 0.006987,
+                  "node": {
+                    "type": "node",
+                    "selector": "div.mx_auto \u003e div \u003e header.ta_center \u003e h1.text",
+                    "nodeLabel": "Structurer la croissance pour libérer la vente : l'exemple de Surfe",
+                    "boundingRect": {
+                      "top": 0,
+                      "bottom": 0,
+                      "right": 0,
+                      "height": 0,
+                      "left": 0,
+                      "width": 0
+                    },
+                    "lhId": "page-6-H1",
+                    "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,DIV,1,HEADER,1,H1",
+                    "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark fs_3xl md:fs_4xl lg:fs_6xl …\"\u003e"
+                  }
+                }
+              ]
+            },
+            {
+              "items": [
+                {
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  },
+                  "score": 0
+                },
+                {
+                  "node": {
+                    "snippet": "\u003cinput type=\"submit\" class=\"hs-button primary large\" value=\"S'inscrire\"\u003e",
+                    "path": "0,HTML,1,BODY,1,DIV,0,FORM,1,DIV,1,DIV,0,INPUT",
+                    "boundingRect": {
+                      "top": 79,
+                      "left": 270,
+                      "height": 38,
+                      "right": 380,
+                      "bottom": 117,
+                      "width": 110
+                    },
+                    "lhId": "page-0-INPUT",
+                    "nodeLabel": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "type": "node",
+                    "selector": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button"
+                  },
+                  "score": 0
+                }
+              ],
+              "headings": [
+                {
+                  "valueType": "node",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "key": "node",
+                  "label": "Element"
+                },
+                {
+                  "key": "score",
+                  "subItemsHeading": {
+                    "key": "cause",
+                    "valueType": "text"
+                  },
+                  "valueType": "numeric",
+                  "granularity": 0.001,
+                  "label": "Layout shift score"
+                }
+              ],
+              "type": "table"
+            }
+          ]
+        }
+      },
+      "image-delivery-insight": {
+        "id": "image-delivery-insight",
+        "title": "Improve image delivery",
+        "description": "Reducing the download time of images can improve the perceived load time of the page and LCP. [Learn more about optimizing image size](https://developer.chrome.com/docs/performance/insights/image-delivery)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 272 KiB",
+        "metricSavings": {
+          "LCP": 1200,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 278377,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "totalBytes": 201358,
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"d_block w_100% h_auto obj-f_cover bdr_2xl asp_16/7\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,0,DIV,0,DIV,1,HEADER,3,IMG",
+                "lhId": "page-0-IMG",
+                "boundingRect": {
+                  "right": 396,
+                  "bottom": 581,
+                  "height": 166,
+                  "left": 16,
+                  "top": 414,
+                  "width": 380
+                },
+                "nodeLabel": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block",
+                "selector": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block",
+                "type": "node"
+              },
+              "wastedBytes": 185314,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png",
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 95745,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 170769,
+                    "reason": "This image file is larger than it needs to be (1200x528) for its displayed dimensions (380x253). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "node": {
+                "boundingRect": {
+                  "width": 100,
+                  "top": 6634,
+                  "left": 49,
+                  "height": 100,
+                  "right": 149,
+                  "bottom": 6734
+                },
+                "lhId": "page-1-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benja…\" alt=\"Benjamin Boileux\" width=\"100\" height=\"100\" class=\"d_flex ai_center jc_center flex_0_0_auto w_100px h_100px bdr_9999px obj-f_…\"\u003e",
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,0,DIV,0,DIV,2,ARTICLE,1,MAIN,3,DIV,1,DIV,0,DIV,0,DIV,1,IMG",
+                "type": "node",
+                "selector": "div.card \u003e div.d_flex \u003e div.group \u003e img.d_flex",
+                "nodeLabel": "Benjamin Boileux"
+              },
+              "wastedBytes": 65172,
+              "totalBytes": 66917,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size.",
+                    "wastedBytes": 26794
+                  },
+                  {
+                    "wastedBytes": 64007,
+                    "reason": "This image file is larger than it needs to be (492x489) for its displayed dimensions (105x100). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg"
+            },
+            {
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 10523,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 16260,
+                    "reason": "This image file is larger than it needs to be (192x192) for its displayed dimensions (30x30). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "totalBytes": 16667,
+              "node": {
+                "type": "node",
+                "selector": "body \u003e div#ago-wrapper \u003e button#ago-chat-button \u003e img#open-path",
+                "nodeLabel": "Chat",
+                "boundingRect": {
+                  "top": 0,
+                  "right": 0,
+                  "bottom": 0,
+                  "left": 0,
+                  "height": 0,
+                  "width": 0
+                },
+                "lhId": "page-2-IMG",
+                "path": "1,BODY,62,DIV,0,BUTTON,0,IMG",
+                "snippet": "\u003cimg src=\"https://www.ocobo.co/android-chrome-192x192.png\" alt=\"Chat\" id=\"open-path\" style=\"width: 32px; height: 32px; object-fit: contain;\"\u003e"
+              },
+              "wastedBytes": 16517
+            },
+            {
+              "node": {
+                "nodeLabel": "Ocobo",
+                "type": "node",
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "path": "2,HTML,1,BODY,0,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "boundingRect": {
+                  "width": 134,
+                  "top": 37,
+                  "right": 167,
+                  "bottom": 77,
+                  "left": 33,
+                  "height": 40
+                },
+                "lhId": "page-3-IMG"
+              },
+              "wastedBytes": 11374,
+              "totalBytes": 12266,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 6234,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 10452,
+                    "reason": "This image file is larger than it needs to be (348x104) for its displayed dimensions (134x40). Use responsive images to reduce the image download size."
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table",
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "valueType": "url",
+              "key": "url",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "reason"
+              },
+              "label": "URL"
+            },
+            {
+              "valueType": "bytes",
+              "label": "Resource Size",
+              "key": "totalBytes"
+            },
+            {
+              "label": "Est Savings",
+              "subItemsHeading": {
+                "valueType": "bytes",
+                "key": "wastedBytes"
+              },
+              "key": "wastedBytes",
+              "valueType": "bytes"
+            }
+          ]
+        }
+      },
+      "server-response-time": {
+        "id": "server-response-time",
+        "title": "Initial server response time was short",
+        "description": "Keep the server response time for the main document short because all other requests depend on it. [Learn more about the Time to First Byte metric](https://developer.chrome.com/docs/lighthouse/performance/time-to-first-byte/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Root document took 60 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 0,
+          "headings": [
+            {
+              "key": "url",
+              "label": "URL",
+              "valueType": "url"
+            },
+            {
+              "valueType": "timespanMs",
+              "label": "Time Spent",
+              "key": "responseTime"
+            }
+          ],
+          "type": "opportunity",
+          "items": [
+            {
+              "responseTime": 55,
+              "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+            }
+          ]
+        },
+        "numericValue": 55,
+        "numericUnit": "millisecond"
+      },
+      "unused-css-rules": {
+        "id": "unused-css-rules",
+        "title": "Reduce unused CSS",
+        "description": "Reduce unused rules from stylesheets and defer CSS not used for above-the-fold content to decrease bytes consumed by network activity. [Learn how to reduce unused CSS](https://developer.chrome.com/docs/lighthouse/performance/unused-css-rules/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "opportunity",
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "FCP": 0,
+              "LCP": 0
+            }
+          },
+          "items": [],
+          "headings": [],
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsBytes": 0,
+          "overallSavingsMs": 0
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "script-treemap-data": {
+        "id": "script-treemap-data",
+        "title": "Script Treemap Data",
+        "description": "Used for treemap app",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "treemap-data",
+          "nodes": [
+            {
+              "encodedBytes": 8288,
+              "resourceBytes": 45561,
+              "name": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+              "children": [
+                {
+                  "unusedBytes": 0,
+                  "name": "(inline) window.dataLaye…",
+                  "resourceBytes": 298
+                },
+                {
+                  "resourceBytes": 631,
+                  "name": "(inline) window.AGO = {\n…",
+                  "unusedBytes": 0
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 592,
+                  "name": "(inline) ((storageKey2, …"
+                },
+                {
+                  "resourceBytes": 520,
+                  "name": "(inline) window.__reactR…",
+                  "unusedBytes": 0
+                },
+                {
+                  "unusedBytes": 0,
+                  "resourceBytes": 35393,
+                  "name": "(inline) window.__reactR…"
+                },
+                {
+                  "resourceBytes": 53,
+                  "name": "(inline) window.__reactR…",
+                  "unusedBytes": 0
+                },
+                {
+                  "unusedBytes": 0,
+                  "name": "(inline) ;\nimport * as r…",
+                  "resourceBytes": 8074
+                }
+              ]
+            },
+            {
+              "resourceBytes": 2125,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "unusedBytes": 0,
+              "encodedBytes": 595
+            },
+            {
+              "encodedBytes": 156442,
+              "resourceBytes": 471691,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "unusedBytes": 200680
+            },
+            {
+              "unusedBytes": 754,
+              "resourceBytes": 9792,
+              "name": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "encodedBytes": 3961
+            },
+            {
+              "resourceBytes": 125385,
+              "name": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "unusedBytes": 70219,
+              "encodedBytes": 43336
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 927,
+              "name": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "encodedBytes": 880
+            },
+            {
+              "name": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "resourceBytes": 3192,
+              "unusedBytes": 1084,
+              "encodedBytes": 1562
+            },
+            {
+              "encodedBytes": 944,
+              "unusedBytes": 89,
+              "resourceBytes": 983,
+              "name": "https://www.ocobo.co/assets/context-HICI_8br.js"
+            },
+            {
+              "encodedBytes": 80,
+              "resourceBytes": 141,
+              "name": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "unusedBytes": 6
+            },
+            {
+              "encodedBytes": 685,
+              "unusedBytes": 467,
+              "resourceBytes": 1284,
+              "name": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js"
+            },
+            {
+              "resourceBytes": 15426,
+              "name": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "unusedBytes": 809,
+              "encodedBytes": 6232
+            },
+            {
+              "resourceBytes": 17234,
+              "name": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "unusedBytes": 370,
+              "encodedBytes": 5626
+            },
+            {
+              "resourceBytes": 3070,
+              "name": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "unusedBytes": 519,
+              "encodedBytes": 1256
+            },
+            {
+              "resourceBytes": 428,
+              "name": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "unusedBytes": 239,
+              "encodedBytes": 367
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 410,
+              "name": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "encodedBytes": 349
+            },
+            {
+              "encodedBytes": 463,
+              "resourceBytes": 525,
+              "name": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "unusedBytes": 65
+            },
+            {
+              "encodedBytes": 880,
+              "resourceBytes": 942,
+              "name": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "unusedBytes": 362
+            },
+            {
+              "resourceBytes": 349,
+              "name": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "unusedBytes": 0,
+              "encodedBytes": 288
+            },
+            {
+              "resourceBytes": 1866,
+              "name": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "unusedBytes": 0,
+              "encodedBytes": 794
+            },
+            {
+              "encodedBytes": 287,
+              "unusedBytes": 0,
+              "resourceBytes": 348,
+              "name": "https://www.ocobo.co/assets/url-Do_uLi_4.js"
+            },
+            {
+              "encodedBytes": 20674,
+              "unusedBytes": 32006,
+              "resourceBytes": 67398,
+              "name": "https://www.ocobo.co/assets/_main-9OzAywp_.js"
+            },
+            {
+              "encodedBytes": 93,
+              "unusedBytes": 0,
+              "resourceBytes": 165,
+              "name": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js"
+            },
+            {
+              "resourceBytes": 206,
+              "name": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "unusedBytes": 0,
+              "encodedBytes": 160
+            },
+            {
+              "encodedBytes": 33602,
+              "unusedBytes": 0,
+              "resourceBytes": 109016,
+              "name": "https://www.ocobo.co/assets/resources-NaHgTejN.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "resourceBytes": 605,
+              "unusedBytes": 0,
+              "encodedBytes": 543
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "resourceBytes": 826,
+              "encodedBytes": 753
+            },
+            {
+              "resourceBytes": 404,
+              "name": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "unusedBytes": 0,
+              "encodedBytes": 358
+            },
+            {
+              "encodedBytes": 428,
+              "unusedBytes": 0,
+              "resourceBytes": 490,
+              "name": "https://www.ocobo.co/assets/users-Cf70nLSI.js"
+            },
+            {
+              "resourceBytes": 835,
+              "name": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "unusedBytes": 337,
+              "encodedBytes": 777
+            },
+            {
+              "resourceBytes": 68826,
+              "name": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "unusedBytes": 47528,
+              "encodedBytes": 25833
+            },
+            {
+              "encodedBytes": 44681,
+              "unusedBytes": 31076,
+              "resourceBytes": 133936,
+              "name": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "resourceBytes": 473,
+              "name": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "unusedBytes": 0,
+              "encodedBytes": 426
+            },
+            {
+              "resourceBytes": 338,
+              "name": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "unusedBytes": 0,
+              "encodedBytes": 277
+            },
+            {
+              "encodedBytes": 389,
+              "resourceBytes": 435,
+              "name": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 255,
+              "unusedBytes": 0,
+              "resourceBytes": 312,
+              "name": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js"
+            },
+            {
+              "encodedBytes": 248,
+              "unusedBytes": 194,
+              "resourceBytes": 309,
+              "name": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js"
+            },
+            {
+              "encodedBytes": 2747,
+              "resourceBytes": 6431,
+              "name": "https://www.ocobo.co/assets/_main.blog._slug-CVkfQxlz.js",
+              "unusedBytes": 18
+            },
+            {
+              "encodedBytes": 433,
+              "resourceBytes": 495,
+              "name": "https://www.ocobo.co/assets/badge-i9dgPBIb.js",
+              "unusedBytes": 65
+            },
+            {
+              "encodedBytes": 644,
+              "resourceBytes": 717,
+              "name": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "unusedBytes": 65
+            },
+            {
+              "encodedBytes": 200,
+              "resourceBytes": 272,
+              "name": "https://www.ocobo.co/assets/optimized-image-BKBFj58i.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 303,
+              "name": "https://www.ocobo.co/assets/labels-CtAnB7VF.js",
+              "encodedBytes": 249
+            },
+            {
+              "encodedBytes": 230,
+              "unusedBytes": 4,
+              "resourceBytes": 302,
+              "name": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js"
+            },
+            {
+              "unusedBytes": 4,
+              "name": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "resourceBytes": 1208,
+              "encodedBytes": 541
+            },
+            {
+              "resourceBytes": 2543,
+              "name": "https://www.ocobo.co/assets/LayoutPost-BT26K59V.js",
+              "unusedBytes": 483,
+              "encodedBytes": 1261
+            },
+            {
+              "encodedBytes": 1339,
+              "unusedBytes": 721,
+              "resourceBytes": 3506,
+              "name": "https://www.ocobo.co/assets/PageMarkdownContainer-klsUvxsc.js"
+            },
+            {
+              "encodedBytes": 51203,
+              "resourceBytes": 138685,
+              "name": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "unusedBytes": 83667
+            },
+            {
+              "encodedBytes": 1252,
+              "resourceBytes": 2533,
+              "name": "https://www.ocobo.co/assets/member-card-Bn7bfGBT.js",
+              "unusedBytes": 9
+            },
+            {
+              "encodedBytes": 558,
+              "resourceBytes": 605,
+              "name": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "unusedBytes": 65
+            },
+            {
+              "encodedBytes": 491,
+              "unusedBytes": 0,
+              "resourceBytes": 549,
+              "name": "https://www.ocobo.co/assets/Container-AZtpvsXO.js"
+            },
+            {
+              "resourceBytes": 69550,
+              "name": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "unusedBytes": 28818,
+              "encodedBytes": 23529
+            },
+            {
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "unusedBytes": 12049,
+              "encodedBytes": 4233
+            },
+            {
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "resourceBytes": 78059,
+              "unusedBytes": 35974,
+              "encodedBytes": 26498
+            },
+            {
+              "encodedBytes": 27871,
+              "resourceBytes": 97992,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "unusedBytes": 56996
+            },
+            {
+              "resourceBytes": 72608,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "unusedBytes": 36142,
+              "encodedBytes": 25123
+            },
+            {
+              "encodedBytes": 42586,
+              "resourceBytes": 108995,
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "unusedBytes": 46367
+            },
+            {
+              "encodedBytes": 681,
+              "unusedBytes": 1760,
+              "resourceBytes": 2558,
+              "name": "https://player.ausha.co/ausha-player.js"
+            },
+            {
+              "encodedBytes": 1227,
+              "unusedBytes": 682,
+              "resourceBytes": 2495,
+              "name": "https://www.ocobo.co/_vercel/insights/script.js"
+            },
+            {
+              "encodedBytes": 4688,
+              "unusedBytes": 6501,
+              "resourceBytes": 12567,
+              "name": "https://www.ocobo.co/_vercel/speed-insights/script.js"
+            },
+            {
+              "encodedBytes": 156442,
+              "unusedBytes": 335778,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "resourceBytes": 471691
+            },
+            {
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "encodedBytes": 4233
+            },
+            {
+              "encodedBytes": 595,
+              "resourceBytes": 2125,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 202942,
+              "resourceBytes": 587832,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "unusedBytes": 337253
+            },
+            {
+              "unusedBytes": 73621,
+              "resourceBytes": 97992,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "encodedBytes": 27871
+            },
+            {
+              "encodedBytes": 26498,
+              "unusedBytes": 36205,
+              "resourceBytes": 78059,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "resourceBytes": 108995,
+              "unusedBytes": 68120,
+              "encodedBytes": 42586
+            },
+            {
+              "encodedBytes": 25123,
+              "unusedBytes": 49494,
+              "resourceBytes": 72608,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+            },
+            {
+              "encodedBytes": 681,
+              "unusedBytes": 2149,
+              "resourceBytes": 2558,
+              "name": "https://player.ausha.co/ausha-player.js"
+            },
+            {
+              "unusedBytes": 248156,
+              "resourceBytes": 587832,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "encodedBytes": 202942
+            }
+          ]
+        }
+      },
+      "interactive": {
+        "id": "interactive",
+        "title": "Time to Interactive",
+        "description": "Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).",
+        "score": 0.2,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "11.1 s",
+        "numericValue": 11069.870196174721,
+        "numericUnit": "millisecond"
+      },
+      "lcp-discovery-insight": {
+        "id": "lcp-discovery-insight",
+        "title": "LCP request discovery",
+        "description": "[Optimize LCP](https://developer.chrome.com/docs/performance/insights/lcp-discovery) by making the LCP image discoverable from the HTML immediately, and avoiding lazy-loading",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "items": {
+                "eagerlyLoaded": {
+                  "value": true,
+                  "label": "lazy load not applied"
+                },
+                "requestDiscoverable": {
+                  "label": "Request is discoverable in initial document",
+                  "value": true
+                },
+                "priorityHinted": {
+                  "value": true,
+                  "label": "fetchpriority=high applied"
+                }
+              },
+              "type": "checklist"
+            },
+            {
+              "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,DIV,1,HEADER,3,IMG",
+              "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"d_block w_100% h_auto obj-f_cover bdr_2xl asp_16/7\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+              "lhId": "page-4-IMG",
+              "boundingRect": {
+                "right": 0,
+                "bottom": 0,
+                "left": 0,
+                "height": 0,
+                "top": 0,
+                "width": 0
+              },
+              "nodeLabel": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block",
+              "selector": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block",
+              "type": "node"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "legacy-javascript-insight": {
+        "id": "legacy-javascript-insight",
+        "title": "Legacy JavaScript",
+        "description": "Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile [Baseline](https://web.dev/articles/baseline-and-polyfills) features, unless you know you must support older browsers. [Learn why most sites can deploy ES6+ code without transpiling](https://developer.chrome.com/docs/performance/insights/legacy-javascript)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 14 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 13897,
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "signal": "Array.prototype.concat",
+                    "location": {
+                      "line": 1,
+                      "type": "source-location",
+                      "urlProvider": "network",
+                      "column": 6239,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    }
+                  },
+                  {
+                    "signal": "Array.prototype.slice",
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1,
+                      "type": "source-location",
+                      "column": 12925,
+                      "urlProvider": "network"
+                    }
+                  },
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "urlProvider": "network",
+                      "column": 12813,
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    },
+                    "signal": "Object.assign"
+                  },
+                  {
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1,
+                      "column": 10857,
+                      "urlProvider": "network",
+                      "type": "source-location"
+                    },
+                    "signal": "Object.create"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 13897,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "wastedBytes": 13897,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "subItems": {
+                "items": [
+                  {
+                    "location": {
+                      "type": "source-location",
+                      "urlProvider": "network",
+                      "column": 6239,
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    },
+                    "signal": "Array.prototype.concat"
+                  },
+                  {
+                    "location": {
+                      "urlProvider": "network",
+                      "column": 12925,
+                      "type": "source-location",
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "signal": "Object.assign",
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network",
+                      "column": 12813,
+                      "type": "source-location",
+                      "line": 1
+                    }
+                  },
+                  {
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 10857,
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "line": 1
+                    },
+                    "signal": "Object.create"
+                  }
+                ],
+                "type": "subitems"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "subItemsHeading": {
+                "valueType": "source-location",
+                "key": "location"
+              },
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "subItemsHeading": {
+                "key": "signal"
+              },
+              "key": null,
+              "valueType": "code"
+            },
+            {
+              "valueType": "bytes",
+              "key": "wastedBytes",
+              "label": "Wasted bytes"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "resource-summary": {
+        "id": "resource-summary",
+        "title": "Resources Summary",
+        "description": "Aggregates all network requests and groups them by type",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "resourceType": "total",
+              "requestCount": 93,
+              "label": "Total",
+              "transferSize": 1471795
+            },
+            {
+              "requestCount": 63,
+              "label": "Script",
+              "resourceType": "script",
+              "transferSize": 820123
+            },
+            {
+              "transferSize": 336389,
+              "requestCount": 12,
+              "label": "Image",
+              "resourceType": "image"
+            },
+            {
+              "requestCount": 6,
+              "label": "Font",
+              "resourceType": "font",
+              "transferSize": 253260
+            },
+            {
+              "requestCount": 3,
+              "label": "Stylesheet",
+              "resourceType": "stylesheet",
+              "transferSize": 27849
+            },
+            {
+              "transferSize": 21889,
+              "resourceType": "document",
+              "requestCount": 1,
+              "label": "Document"
+            },
+            {
+              "requestCount": 8,
+              "label": "Other",
+              "resourceType": "other",
+              "transferSize": 12285
+            },
+            {
+              "transferSize": 0,
+              "requestCount": 0,
+              "label": "Media",
+              "resourceType": "media"
+            },
+            {
+              "requestCount": 33,
+              "label": "Third-party",
+              "resourceType": "third-party",
+              "transferSize": 895461
+            }
+          ],
+          "headings": [
+            {
+              "label": "Resource Type",
+              "key": "label",
+              "valueType": "text"
+            },
+            {
+              "key": "requestCount",
+              "label": "Requests",
+              "valueType": "numeric"
+            },
+            {
+              "valueType": "bytes",
+              "key": "transferSize",
+              "label": "Transfer Size"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "layout-shifts": {
+        "id": "layout-shifts",
+        "title": "Avoid large layout shifts",
+        "description": "These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "2 layout shifts found",
+        "metricSavings": {
+          "CLS": 0.007
+        },
+        "details": {
+          "items": [
+            {
+              "score": 0.006987,
+              "node": {
+                "nodeLabel": "Structurer la croissance pour libérer la vente : l'exemple de Surfe",
+                "selector": "div.mx_auto \u003e div \u003e header.ta_center \u003e h1.text",
+                "type": "node",
+                "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark fs_3xl md:fs_4xl lg:fs_6xl …\"\u003e",
+                "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,DIV,1,HEADER,1,H1",
+                "lhId": "page-6-H1",
+                "boundingRect": {
+                  "left": 0,
+                  "height": 0,
+                  "right": 0,
+                  "bottom": 0,
+                  "top": 0,
+                  "width": 0
+                }
+              }
+            },
+            {
+              "score": 0
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node",
+              "subItemsHeading": {
+                "key": "extra"
+              },
+              "label": "Element"
+            },
+            {
+              "valueType": "numeric",
+              "granularity": 0.001,
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "cause"
+              },
+              "key": "score",
+              "label": "Layout shift score"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "third-parties-insight": {
+        "id": "third-parties-insight",
+        "title": "3rd parties",
+        "description": "3rd party code can significantly impact load performance. [Reduce and defer loading of 3rd party code](https://developer.chrome.com/docs/performance/insights/third-parties) to prioritize your page's content.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "isEntityGrouped": true,
+          "type": "table",
+          "headings": [
+            {
+              "valueType": "text",
+              "label": "3rd party",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "key": "entity"
+            },
+            {
+              "granularity": 1,
+              "valueType": "bytes",
+              "key": "transferSize",
+              "subItemsHeading": {
+                "key": "transferSize"
+              },
+              "label": "Transfer size"
+            },
+            {
+              "label": "Main thread time",
+              "subItemsHeading": {
+                "key": "mainThreadTime"
+              },
+              "key": "mainThreadTime",
+              "valueType": "ms",
+              "granularity": 1
+            }
+          ],
+          "items": [
+            {
+              "transferSize": 352746,
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 306.45799999998417,
+                    "transferSize": 206376,
+                    "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+                  },
+                  {
+                    "mainThreadTime": 62.729000000021188,
+                    "transferSize": 28213,
+                    "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                  },
+                  {
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+                    "transferSize": 43665,
+                    "mainThreadTime": 57.928999999858206
+                  },
+                  {
+                    "mainThreadTime": 48.717999999935273,
+                    "transferSize": 29956,
+                    "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+                  },
+                  {
+                    "mainThreadTime": 31.475999999936903,
+                    "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+                    "transferSize": 27219
+                  },
+                  {
+                    "url": "https://js-eu1.hs-scripts.com/27107933.js",
+                    "transferSize": 2178,
+                    "mainThreadTime": 6.4709999999904539
+                  },
+                  {
+                    "transferSize": 1095,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+                    "mainThreadTime": 0.20400000002700835
+                  },
+                  {
+                    "transferSize": 1094,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=f13052b98de6b98526012e48a8c28503",
+                    "mainThreadTime": 0.19900000002235174
+                  },
+                  {
+                    "transferSize": 4082,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953&hutk=f13052b98de6b98526012e48a8c28503",
+                    "mainThreadTime": 0.19800000003306195
+                  },
+                  {
+                    "transferSize": 1706,
+                    "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&isMobile=true",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778837366446&vi=f13052b98de6b98526012e48a8c28503&nc=true&u=242475741.f13052b98de6b98526012e48a8c28503.1778837366439.1778837366439.1778837366439.1&b=242475741.1.1778837366439&cc=15",
+                    "transferSize": 1482
+                  },
+                  {
+                    "transferSize": 1028,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=f818c202-6895-4344-8fa4-fba3c9a8a470&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778837368003&vi=f13052b98de6b98526012e48a8c28503&nc=true&u=242475741.f13052b98de6b98526012e48a8c28503.1778837366439.1778837366439.1778837366439.1&b=242475741.1.1778837366439&cc=15",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1026,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778837367594&vi=f13052b98de6b98526012e48a8c28503&nc=true&u=242475741.f13052b98de6b98526012e48a8c28503.1778837366439.1778837366439.1778837366439.1&b=242475741.1.1778837366439&cc=15",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1024,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 1024,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1"
+                  },
+                  {
+                    "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+                    "transferSize": 1021,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+                    "transferSize": 557,
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 514.38199999980861,
+              "entity": "Hubspot"
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "transferSize": 157129,
+                    "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+                    "mainThreadTime": 236.88500000003842
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://www.googletagmanager.com/td?id=G-HTM5DK0W7S&v=3&t=t&pid=1695920956&gtm=45je65d0v9100339653za200zd9100339653&seq=1&exp=0~115938465~115938469&dl=www.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&tdp=G-HTM5DK0W7S;100339653;0;0;0&frm=0&rtg=100339653&slo=0&hlo=7&lst=3&bt=0&ct=3&z=0",
+                    "transferSize": 701
+                  }
+                ]
+              },
+              "mainThreadTime": 236.88500000003842,
+              "entity": "Google Tag Manager",
+              "transferSize": 157830
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 6.0969999999797437,
+                    "transferSize": 5037,
+                    "url": "https://useago.github.io/widgetjs/frame.js"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://useago.github.io/widgetjs/frame.css",
+                    "transferSize": 2018
+                  }
+                ]
+              },
+              "mainThreadTime": 6.0969999999797437,
+              "entity": "GitHub",
+              "transferSize": 7055
+            },
+            {
+              "transferSize": 2218,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 1.4979999999923166,
+                    "transferSize": 2218,
+                    "url": "https://player.ausha.co/ausha-player.js"
+                  }
+                ]
+              },
+              "mainThreadTime": 1.4979999999923166,
+              "entity": "ausha.co"
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "transferSize": 202020,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 67588,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg"
+                  }
+                ]
+              },
+              "mainThreadTime": 0,
+              "entity": "vercel-storage.com",
+              "transferSize": 269608
+            },
+            {
+              "mainThreadTime": 0,
+              "entity": "Clearbit",
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 1280,
+                    "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "transferSize": 1280
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 796,
+                    "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65d0v9100339653za200zd9100339653&_p=1778837365794&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1690179571.1778837366&frm=0&pscdl=noapi&rcb=14&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115938465~115938469&dp=%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&sid=1778837366&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&dt=Ocobo%20%C2%B7%20Structurer%20la%20croissance%20pour%20lib%C3%A9rer%20la%20vente%C2%A0%3A%20l%27exemple%20de%20Surfe&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1277"
+                  }
+                ]
+              },
+              "mainThreadTime": 0,
+              "entity": "Google Analytics",
+              "transferSize": 796
+            },
+            {
+              "transferSize": 103928,
+              "mainThreadTime": 0,
+              "entity": "Google Fonts",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 102669,
+                    "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 1259,
+                    "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "speed-index": {
+        "id": "speed-index",
+        "title": "Speed Index",
+        "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).",
+        "score": 0.8,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "4.1 s",
+        "numericValue": 4052.9953056172872,
+        "numericUnit": "millisecond"
+      },
+      "network-requests": {
+        "id": "network-requests",
+        "title": "Network Requests",
+        "description": "Lists the network requests that were made during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "debugData": {
+            "networkStartTimeTs": 146402134,
+            "initiators": [
+              {
+                "lineNumber": 6,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 1071,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 668,
+                "type": "parser",
+                "lineNumber": 27,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 27,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 16793,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 31052,
+                "type": "parser",
+                "lineNumber": 27,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 30,
+                "type": "parser",
+                "columnNumber": 18356
+              },
+              {
+                "columnNumber": 141,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 261,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45
+              },
+              {
+                "columnNumber": 360,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 460,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 541,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "columnNumber": 617,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 683,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 752,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 812
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 876,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 938,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 997
+              },
+              {
+                "columnNumber": 1066,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 1133,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1200,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 1257
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1319,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "columnNumber": 1378,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "columnNumber": 1442,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 1508,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1569,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45
+              },
+              {
+                "columnNumber": 1637,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 1703,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1774,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 1832,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 1892,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 1967,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 2028,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2086,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45
+              },
+              {
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45,
+                "type": "parser",
+                "columnNumber": 2150
+              },
+              {
+                "columnNumber": 2210,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 2269,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2331,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "columnNumber": 2392,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "columnNumber": 2455,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 2511
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2579,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45
+              },
+              {
+                "columnNumber": 2646,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 2707,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 2778,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45
+              },
+              {
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45,
+                "type": "parser",
+                "columnNumber": 2838
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "type": "parser",
+                "columnNumber": 2897
+              },
+              {
+                "columnNumber": 2967,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 3028,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 3094,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 3159,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 3235,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "columnNumber": 3301,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "columnNumber": 3365,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45
+              },
+              {
+                "type": "parser",
+                "columnNumber": 3428,
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "columnNumber": 3501,
+                "type": "parser",
+                "lineNumber": 45,
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+              },
+              {
+                "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+                "lineNumber": 45,
+                "type": "parser",
+                "columnNumber": 3560
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "type": "parser",
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+              },
+              {
+                "type": "parser",
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+              }
+            ],
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "resourceType": "Document",
+              "mimeType": "text/html",
+              "networkEndTime": 810.21900000001187,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 117975,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 21889,
+              "networkRequestTime": 1.1160000000090804,
+              "priority": "VeryHigh",
+              "rendererStartTime": 0,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+            },
+            {
+              "finished": true,
+              "networkEndTime": 854.94700000001467,
+              "resourceType": "Stylesheet",
+              "mimeType": "text/css",
+              "resourceSize": 122090,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 24572,
+              "sessionTargetType": "page",
+              "networkRequestTime": 828.26600000000326,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "rendererStartTime": 827.10700000001816,
+              "priority": "VeryHigh"
+            },
+            {
+              "networkRequestTime": 828.36199999999371,
+              "priority": "High",
+              "rendererStartTime": 827.58499999999185,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "resourceType": "Image",
+              "mimeType": "image/png",
+              "finished": true,
+              "networkEndTime": 904.55800000001909,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 12266,
+              "sessionTargetType": "page",
+              "transferSize": 12758,
+              "protocol": "h2"
+            },
+            {
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 29546,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 29045,
+              "finished": true,
+              "networkEndTime": 857.53700000001118,
+              "mimeType": "image/png",
+              "resourceType": "Image",
+              "url": "https://www.ocobo.co/images/partners/modern-revenue-club.png",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "priority": "Medium",
+              "rendererStartTime": 827.8300000000163,
+              "networkRequestTime": 828.45300000000861
+            },
+            {
+              "priority": "High",
+              "rendererStartTime": 828.006000000023,
+              "entity": "vercel-storage.com",
+              "statusCode": 200,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png",
+              "networkRequestTime": 828.52799999999115,
+              "resourceSize": 201358,
+              "experimentalFromMainFrame": true,
+              "transferSize": 202020,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceType": "Image",
+              "mimeType": "image/png",
+              "networkEndTime": 891.176999999996,
+              "finished": true
+            },
+            {
+              "rendererStartTime": 828.14200000002165,
+              "priority": "Low",
+              "statusCode": 200,
+              "entity": "vercel-storage.com",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg",
+              "networkRequestTime": 867.50500000003376,
+              "resourceSize": 66917,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 67588,
+              "sessionTargetType": "page",
+              "resourceType": "Image",
+              "mimeType": "image/jpeg",
+              "networkEndTime": 886.39199999999255,
+              "finished": true
+            },
+            {
+              "protocol": "h2",
+              "transferSize": 157129,
+              "sessionTargetType": "page",
+              "resourceSize": 471691,
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "networkEndTime": 894.54700000002049,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "statusCode": 200,
+              "entity": "Google Tag Manager",
+              "priority": "Low",
+              "rendererStartTime": 828.28800000000047,
+              "networkRequestTime": 868.65700000000652
+            },
+            {
+              "priority": "Low",
+              "rendererStartTime": 828.40700000000652,
+              "entity": "Clearbit",
+              "statusCode": 404,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "networkRequestTime": 868.71400000000722,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 0,
+              "sessionTargetType": "page",
+              "transferSize": 640,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "networkEndTime": 1120.9860000000044,
+              "finished": true
+            },
+            {
+              "rendererStartTime": 828.53600000002189,
+              "priority": "Low",
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "networkRequestTime": 868.77000000001863,
+              "resourceSize": 2125,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 1647,
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "networkEndTime": 889.80999999999767
+            },
+            {
+              "networkRequestTime": 868.835000000021,
+              "entity": "GitHub",
+              "statusCode": 200,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "priority": "Low",
+              "rendererStartTime": 828.64100000000326,
+              "networkEndTime": 927.16399999998976,
+              "finished": true,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "resourceSize": 17494,
+              "experimentalFromMainFrame": true,
+              "transferSize": 5037,
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "networkRequestTime": 868.92199999999139,
+              "priority": "Low",
+              "rendererStartTime": 828.74900000001071,
+              "url": "https://player.ausha.co/ausha-player.js",
+              "entity": "ausha.co",
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "networkEndTime": 1245.8340000000026,
+              "finished": true,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 1513,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 2558
+            },
+            {
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 24117,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 69556,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true,
+              "networkEndTime": 881.823000000004,
+              "priority": "High",
+              "rendererStartTime": 828.88300000003073,
+              "url": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 829.5570000000298
+            },
+            {
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "networkEndTime": 855.43700000003446,
+              "isLinkPreload": true,
+              "resourceSize": 927,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 1457,
+              "sessionTargetType": "page",
+              "networkRequestTime": 829.79099999999744,
+              "priority": "High",
+              "rendererStartTime": 829.01800000001094,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js"
+            },
+            {
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "finished": true,
+              "isLinkPreload": true,
+              "networkEndTime": 892.65100000001257,
+              "protocol": "h2",
+              "transferSize": 43927,
+              "sessionTargetType": "page",
+              "resourceSize": 125397,
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 829.94100000002072,
+              "priority": "High",
+              "rendererStartTime": 829.131000000023,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "finished": true,
+              "networkEndTime": 872.5789999999979,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "resourceSize": 133936,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 45263,
+              "sessionTargetType": "page",
+              "networkRequestTime": 830.05999999999767,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "rendererStartTime": 829.26199999998789,
+              "priority": "High"
+            },
+            {
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "networkEndTime": 858.65000000002328,
+              "finished": true,
+              "resourceSize": 110060,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 34187,
+              "sessionTargetType": "page",
+              "networkRequestTime": 830.30400000000373,
+              "rendererStartTime": 829.38300000000163,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/resources-NaHgTejN.js"
+            },
+            {
+              "networkRequestTime": 830.46199999999953,
+              "url": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "priority": "High",
+              "rendererStartTime": 829.512000000017,
+              "isLinkPreload": true,
+              "finished": true,
+              "networkEndTime": 880.64400000002934,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "transferSize": 1517,
+              "sessionTargetType": "page",
+              "resourceSize": 991,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "isLinkPreload": true,
+              "finished": true,
+              "networkEndTime": 864.72000000000116,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 4525,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 9799,
+              "networkRequestTime": 830.57800000000861,
+              "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "rendererStartTime": 829.6480000000156,
+              "priority": "High"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "priority": "High",
+              "rendererStartTime": 829.83499999999185,
+              "networkRequestTime": 831.18400000000838,
+              "resourceSize": 3192,
+              "experimentalFromMainFrame": true,
+              "transferSize": 2151,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "isLinkPreload": true,
+              "finished": true,
+              "networkEndTime": 875.97899999999208,
+              "resourceType": "Script",
+              "mimeType": "application/javascript"
+            },
+            {
+              "rendererStartTime": 829.96500000002561,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "networkRequestTime": 831.55200000002515,
+              "resourceSize": 141,
+              "experimentalFromMainFrame": true,
+              "transferSize": 672,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "networkEndTime": 860.62900000001537,
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "networkEndTime": 867.92400000002817,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 1284,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 1272,
+              "networkRequestTime": 832.03300000002491,
+              "priority": "High",
+              "rendererStartTime": 830.07400000002235,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "priority": "High",
+              "rendererStartTime": 830.20799999998417,
+              "networkRequestTime": 832.15700000003562,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 15426,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 6809,
+              "finished": true,
+              "isLinkPreload": true,
+              "networkEndTime": 854.39100000003236,
+              "resourceType": "Script",
+              "mimeType": "application/javascript"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "rendererStartTime": 830.33999999999651,
+              "priority": "High",
+              "networkRequestTime": 832.69000000000233,
+              "resourceSize": 17234,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 6208,
+              "sessionTargetType": "page",
+              "finished": true,
+              "networkEndTime": 861.35000000000582,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "mimeType": "application/javascript"
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 1835,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 3070,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true,
+              "networkEndTime": 908.9770000000135,
+              "rendererStartTime": 830.4659999999858,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 832.82500000001164
+            },
+            {
+              "transferSize": 956,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceSize": 428,
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "networkEndTime": 868.18400000000838,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "rendererStartTime": 830.6019999999844,
+              "networkRequestTime": 832.89400000000023
+            },
+            {
+              "networkRequestTime": 833.12400000001071,
+              "rendererStartTime": 830.71499999999651,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "finished": true,
+              "networkEndTime": 882.60000000000582,
+              "isLinkPreload": true,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 940,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 410
+            },
+            {
+              "finished": true,
+              "isLinkPreload": true,
+              "networkEndTime": 896.16600000002654,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 525,
+              "sessionTargetType": "page",
+              "transferSize": 1050,
+              "protocol": "h2",
+              "networkRequestTime": 833.2160000000149,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "priority": "High",
+              "rendererStartTime": 830.887000000017
+            },
+            {
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "networkEndTime": 860.99800000002142,
+              "isLinkPreload": true,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 942,
+              "sessionTargetType": "page",
+              "transferSize": 1474,
+              "protocol": "h2",
+              "networkRequestTime": 833.33900000003632,
+              "priority": "High",
+              "rendererStartTime": 831.02700000000186,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js"
+            },
+            {
+              "finished": true,
+              "isLinkPreload": true,
+              "networkEndTime": 870.52800000002026,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "resourceSize": 349,
+              "experimentalFromMainFrame": true,
+              "transferSize": 879,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkRequestTime": 833.4320000000007,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "rendererStartTime": 831.14199999999255,
+              "priority": "High"
+            },
+            {
+              "networkRequestTime": 833.68400000000838,
+              "rendererStartTime": 831.37300000002142,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "finished": true,
+              "networkEndTime": 905.6929999999993,
+              "isLinkPreload": true,
+              "transferSize": 1370,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceSize": 1866,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "networkRequestTime": 833.88200000001234,
+              "priority": "High",
+              "rendererStartTime": 831.50700000001234,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "networkEndTime": 857.98999999999069,
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 348,
+              "sessionTargetType": "page",
+              "transferSize": 870,
+              "protocol": "h2"
+            },
+            {
+              "networkRequestTime": 834.08600000001024,
+              "priority": "High",
+              "rendererStartTime": 831.73999999999069,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "networkEndTime": 896.95300000000861,
+              "isLinkPreload": true,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 67398,
+              "sessionTargetType": "page",
+              "transferSize": 21255,
+              "protocol": "h2"
+            },
+            {
+              "networkRequestTime": 834.52700000000186,
+              "url": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "priority": "High",
+              "rendererStartTime": 831.94899999999325,
+              "isLinkPreload": true,
+              "networkEndTime": 965.2159999999858,
+              "finished": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "transferSize": 704,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 165
+            },
+            {
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "networkEndTime": 865.570000000007,
+              "finished": true,
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "transferSize": 1130,
+              "sessionTargetType": "page",
+              "resourceSize": 605,
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 834.76100000002771,
+              "rendererStartTime": 832.19200000001,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "entity": "ocobo.co",
+              "statusCode": 200
+            },
+            {
+              "networkRequestTime": 835.04300000000512,
+              "priority": "High",
+              "rendererStartTime": 832.36000000001513,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "finished": true,
+              "networkEndTime": 875.60500000001048,
+              "resourceSize": 826,
+              "experimentalFromMainFrame": true,
+              "transferSize": 1348,
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "priority": "High",
+              "rendererStartTime": 832.49500000002445,
+              "url": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 835.16600000002654,
+              "transferSize": 932,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceSize": 404,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "finished": true,
+              "networkEndTime": 873.48200000001816,
+              "isLinkPreload": true
+            },
+            {
+              "protocol": "h2",
+              "transferSize": 1014,
+              "sessionTargetType": "page",
+              "resourceSize": 490,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 864.37900000001537,
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 832.60000000000582,
+              "priority": "High",
+              "networkRequestTime": 835.2729999999865
+            },
+            {
+              "url": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 832.72599999999511,
+              "priority": "High",
+              "networkRequestTime": 835.35600000002887,
+              "transferSize": 729,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceSize": 206,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 866.03100000001723,
+              "isLinkPreload": true,
+              "finished": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script"
+            },
+            {
+              "priority": "High",
+              "rendererStartTime": 832.90700000000652,
+              "url": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 835.43700000000536,
+              "sessionTargetType": "page",
+              "transferSize": 1361,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 835,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "finished": true,
+              "isLinkPreload": true,
+              "networkEndTime": 906.98400000002584
+            },
+            {
+              "resourceSize": 68826,
+              "experimentalFromMainFrame": true,
+              "transferSize": 26415,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "networkEndTime": 881.1809999999823,
+              "isLinkPreload": true,
+              "finished": true,
+              "rendererStartTime": 833.0690000000177,
+              "priority": "High",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "networkRequestTime": 835.56000000002678
+            },
+            {
+              "finished": true,
+              "networkEndTime": 874.752999999997,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 1000,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 473,
+              "networkRequestTime": 835.90800000002491,
+              "url": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 833.23000000001048,
+              "priority": "High"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "resourceSize": 338,
+              "sessionTargetType": "page",
+              "transferSize": 858,
+              "protocol": "h2",
+              "isLinkPreload": true,
+              "finished": true,
+              "networkEndTime": 908.53700000001118,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "rendererStartTime": 833.36300000001211,
+              "priority": "High",
+              "networkRequestTime": 836.0230000000156
+            },
+            {
+              "resourceSize": 435,
+              "experimentalFromMainFrame": true,
+              "transferSize": 967,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "networkEndTime": 873.1140000000014,
+              "isLinkPreload": true,
+              "rendererStartTime": 833.49900000001071,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "networkRequestTime": 836.369000000006
+            },
+            {
+              "networkRequestTime": 836.46900000001187,
+              "rendererStartTime": 833.62600000001839,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true,
+              "networkEndTime": 882.24500000002445,
+              "protocol": "h2",
+              "transferSize": 843,
+              "sessionTargetType": "page",
+              "resourceSize": 312,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "networkRequestTime": 836.63900000002468,
+              "priority": "High",
+              "rendererStartTime": 833.72500000000582,
+              "url": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "networkEndTime": 907.92200000002049,
+              "finished": true,
+              "sessionTargetType": "page",
+              "transferSize": 834,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 309
+            },
+            {
+              "priority": "High",
+              "rendererStartTime": 833.90400000000955,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/assets/_main.blog._slug-CVkfQxlz.js",
+              "networkRequestTime": 837.7609999999986,
+              "resourceSize": 6433,
+              "experimentalFromMainFrame": true,
+              "transferSize": 3337,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "networkEndTime": 1050.6110000000044,
+              "finished": true,
+              "isLinkPreload": true
+            },
+            {
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "isLinkPreload": true,
+              "networkEndTime": 867.60600000002887,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 495,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 1019,
+              "networkRequestTime": 837.948000000004,
+              "rendererStartTime": 834.08900000000722,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/badge-i9dgPBIb.js"
+            },
+            {
+              "networkRequestTime": 838.0570000000298,
+              "rendererStartTime": 834.25300000002608,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "networkEndTime": 908.28700000001118,
+              "isLinkPreload": true,
+              "finished": true,
+              "transferSize": 1240,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceSize": 717,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "transferSize": 804,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceSize": 272,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "networkEndTime": 911.0339999999851,
+              "finished": true,
+              "priority": "High",
+              "rendererStartTime": 834.37600000001839,
+              "url": "https://www.ocobo.co/assets/optimized-image-BKBFj58i.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 838.80400000000373
+            },
+            {
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "finished": true,
+              "networkEndTime": 875.10600000002887,
+              "protocol": "h2",
+              "transferSize": 833,
+              "sessionTargetType": "page",
+              "resourceSize": 310,
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 840.20000000001164,
+              "rendererStartTime": 834.48300000000745,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/labels-CtAnB7VF.js",
+              "statusCode": 200,
+              "entity": "ocobo.co"
+            },
+            {
+              "rendererStartTime": 834.61500000001979,
+              "priority": "High",
+              "url": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "networkRequestTime": 843.73300000000745,
+              "transferSize": 830,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceSize": 302,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "networkEndTime": 876.3859999999986,
+              "finished": true
+            },
+            {
+              "url": "https://www.ocobo.co/assets/LayoutPost-BT26K59V.js",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 834.80600000001141,
+              "priority": "High",
+              "networkRequestTime": 844.32099999999627,
+              "transferSize": 1845,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceSize": 2543,
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "networkEndTime": 1022.0690000000177,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script"
+            },
+            {
+              "networkRequestTime": 848.51000000000931,
+              "priority": "High",
+              "rendererStartTime": 834.95900000000256,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/PageMarkdownContainer-klsUvxsc.js",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "networkEndTime": 1047.2119999999995,
+              "isLinkPreload": true,
+              "finished": true,
+              "resourceSize": 3508,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 1934,
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/member-card-Bn7bfGBT.js",
+              "priority": "High",
+              "rendererStartTime": 835.10800000000745,
+              "networkRequestTime": 848.67800000001444,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 2533,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 1822,
+              "finished": true,
+              "networkEndTime": 1040.9610000000102,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "mimeType": "application/javascript"
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 1077,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 549,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "networkEndTime": 917.14100000000326,
+              "finished": true,
+              "isLinkPreload": true,
+              "priority": "High",
+              "rendererStartTime": 835.265000000014,
+              "url": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "networkRequestTime": 848.835000000021
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "resourceSize": 1217,
+              "sessionTargetType": "page",
+              "transferSize": 1135,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "isLinkPreload": true,
+              "networkEndTime": 895.80900000000838,
+              "rendererStartTime": 835.40499999999884,
+              "priority": "High",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "networkRequestTime": 849.8519999999844
+            },
+            {
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "priority": "High",
+              "rendererStartTime": 835.52800000002026,
+              "networkRequestTime": 849.95000000001164,
+              "resourceSize": 142638,
+              "experimentalFromMainFrame": true,
+              "transferSize": 51797,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkEndTime": 1158.4400000000023,
+              "isLinkPreload": true,
+              "finished": true,
+              "resourceType": "Script",
+              "mimeType": "application/javascript"
+            },
+            {
+              "networkRequestTime": 850.03200000000652,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "priority": "High",
+              "rendererStartTime": 835.66699999998673,
+              "finished": true,
+              "isLinkPreload": true,
+              "networkEndTime": 874.38300000003073,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "resourceSize": 605,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 1128,
+              "sessionTargetType": "page"
+            },
+            {
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 39127,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 58256,
+              "finished": true,
+              "networkEndTime": 938.46400000000722,
+              "mimeType": "font/otf",
+              "resourceType": "Font",
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 891.78700000001118,
+              "priority": "VeryHigh",
+              "networkRequestTime": 896.64500000001863
+            },
+            {
+              "networkRequestTime": 897.75099999998929,
+              "rendererStartTime": 892.10000000000582,
+              "priority": "VeryHigh",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+              "resourceType": "Font",
+              "mimeType": "font/woff",
+              "networkEndTime": 916.3070000000298,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 31480,
+              "sessionTargetType": "page",
+              "transferSize": 31975,
+              "protocol": "h2"
+            },
+            {
+              "resourceType": "Font",
+              "mimeType": "font/otf",
+              "networkEndTime": 957.59500000000116,
+              "finished": true,
+              "resourceSize": 57572,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 38779,
+              "sessionTargetType": "page",
+              "networkRequestTime": 897.835000000021,
+              "priority": "VeryHigh",
+              "rendererStartTime": 892.42300000000978,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf"
+            },
+            {
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+              "rendererStartTime": 892.7390000000014,
+              "priority": "VeryHigh",
+              "networkRequestTime": 897.90100000001257,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 60228,
+              "sessionTargetType": "page",
+              "transferSize": 40710,
+              "protocol": "h2",
+              "finished": true,
+              "networkEndTime": 1167.4519999999902,
+              "resourceType": "Font",
+              "mimeType": "font/otf"
+            },
+            {
+              "finished": true,
+              "networkEndTime": 1161.5419999999867,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "resourceSize": 97992,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 29956,
+              "sessionTargetType": "page",
+              "networkRequestTime": 1126.3699999999953,
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "priority": "Low",
+              "rendererStartTime": 1124.6130000000121
+            },
+            {
+              "rendererStartTime": 1125.4560000000056,
+              "priority": "Low",
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "networkRequestTime": 1126.9380000000237,
+              "resourceSize": 78203,
+              "experimentalFromMainFrame": true,
+              "transferSize": 28213,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "networkEndTime": 1145.890000000014
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 43665,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 109001,
+              "mimeType": "text/javascript",
+              "resourceType": "Script",
+              "networkEndTime": 1165.2889999999898,
+              "finished": true,
+              "rendererStartTime": 1126.1300000000047,
+              "priority": "Low",
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "networkRequestTime": 1127.2690000000002
+            },
+            {
+              "networkRequestTime": 1127.6720000000205,
+              "priority": "Low",
+              "rendererStartTime": 1126.7810000000172,
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "resourceType": "Script",
+              "mimeType": "text/javascript",
+              "networkEndTime": 1156.6140000000305,
+              "finished": true,
+              "resourceSize": 72678,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 27219,
+              "sessionTargetType": "page"
+            },
+            {
+              "networkRequestTime": 1279.4720000000088,
+              "statusCode": 204,
+              "entity": "Google Analytics",
+              "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65d0v9100339653za200zd9100339653&_p=1778837365794&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1690179571.1778837366&frm=0&pscdl=noapi&rcb=14&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115938465~115938469&dp=%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&sid=1778837366&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&dt=Ocobo%20%C2%B7%20Structurer%20la%20croissance%20pour%20lib%C3%A9rer%20la%20vente%C2%A0%3A%20l%27exemple%20de%20Surfe&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1277",
+              "priority": "High",
+              "rendererStartTime": 1277.9919999999984,
+              "networkEndTime": 1351.4740000000165,
+              "finished": true,
+              "resourceType": "Fetch",
+              "mimeType": "text/plain",
+              "resourceSize": 0,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 796,
+              "sessionTargetType": "page"
+            },
+            {
+              "finished": true,
+              "networkEndTime": 1285.3760000000184,
+              "resourceType": "Image",
+              "mimeType": "text/plain",
+              "resourceSize": 0,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 701,
+              "sessionTargetType": "page",
+              "networkRequestTime": 1280.8390000000072,
+              "entity": "Google Tag Manager",
+              "statusCode": 204,
+              "url": "https://www.googletagmanager.com/td?id=G-HTM5DK0W7S&v=3&t=t&pid=1695920956&gtm=45je65d0v9100339653za200zd9100339653&seq=1&exp=0~115938465~115938469&dl=www.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&tdp=G-HTM5DK0W7S;100339653;0;0;0&frm=0&rtg=100339653&slo=0&hlo=7&lst=3&bt=0&ct=3&z=0",
+              "priority": "Low",
+              "rendererStartTime": 1279.2730000000156
+            },
+            {
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "statusCode": 200,
+              "entity": "GitHub",
+              "priority": "VeryHigh",
+              "rendererStartTime": 1357.88400000002,
+              "networkRequestTime": 1358.8809999999939,
+              "protocol": "h2",
+              "transferSize": 2018,
+              "sessionTargetType": "page",
+              "resourceSize": 4371,
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "networkEndTime": 1373.7310000000289,
+              "mimeType": "text/css",
+              "resourceType": "Stylesheet"
+            },
+            {
+              "networkRequestTime": 1360.1570000000065,
+              "priority": "High",
+              "rendererStartTime": 1358.8970000000263,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "resourceType": "Image",
+              "mimeType": "image/png",
+              "finished": true,
+              "networkEndTime": 1401.0709999999963,
+              "resourceSize": 16667,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 17171,
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+              "rendererStartTime": 1403.5780000000086,
+              "priority": "High",
+              "networkRequestTime": 1407.2259999999951,
+              "resourceSize": 135,
+              "experimentalFromMainFrame": true,
+              "transferSize": 1095,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkEndTime": 1487.0879999999888,
+              "finished": true,
+              "resourceType": "XHR",
+              "mimeType": "application/json"
+            },
+            {
+              "finished": true,
+              "networkEndTime": 1478.0980000000272,
+              "mimeType": "text/plain",
+              "resourceType": "Fetch",
+              "sessionTargetType": "page",
+              "transferSize": 557,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 5,
+              "networkRequestTime": 1461.0580000000191,
+              "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "rendererStartTime": 1458.8930000000109,
+              "priority": "High"
+            },
+            {
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&isMobile=true",
+              "rendererStartTime": 1489.4500000000116,
+              "priority": "High",
+              "networkRequestTime": 1491.7200000000012,
+              "resourceSize": 61,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 1706,
+              "sessionTargetType": "page",
+              "finished": true,
+              "networkEndTime": 1654.3360000000102,
+              "resourceType": "Fetch",
+              "mimeType": "application/json"
+            },
+            {
+              "sessionTargetType": "page",
+              "transferSize": 1482,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 45,
+              "networkEndTime": 1628.3730000000214,
+              "finished": true,
+              "mimeType": "image/gif",
+              "resourceType": "Image",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778837366446&vi=f13052b98de6b98526012e48a8c28503&nc=true&u=242475741.f13052b98de6b98526012e48a8c28503.1778837366439.1778837366439.1778837366439.1&b=242475741.1.1778837366439&cc=15",
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "priority": "Low",
+              "rendererStartTime": 1518.8240000000224,
+              "networkRequestTime": 1520.7850000000035
+            },
+            {
+              "mimeType": "image/gif",
+              "resourceType": "Image",
+              "networkEndTime": 1938.5789999999979,
+              "finished": true,
+              "sessionTargetType": "page",
+              "transferSize": 1021,
+              "protocol": "http/1.1",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 35,
+              "networkRequestTime": 1845.8640000000014,
+              "priority": "Low",
+              "rendererStartTime": 1844.0020000000077,
+              "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+              "statusCode": 200,
+              "entity": "Hubspot"
+            },
+            {
+              "networkRequestTime": 2238.2530000000261,
+              "priority": "Low",
+              "rendererStartTime": 2236.9150000000081,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "networkEndTime": 2292.2190000000119,
+              "finished": true,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "transferSize": 204717,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 607831
+            },
+            {
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "finished": true,
+              "networkEndTime": 2437.0929999999935,
+              "sessionTargetType": "page",
+              "transferSize": 640,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 0,
+              "networkRequestTime": 2239.8630000000121,
+              "rendererStartTime": 2238.8040000000037,
+              "priority": "Low",
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "statusCode": 404,
+              "entity": "Clearbit"
+            },
+            {
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "entity": "Hubspot",
+              "statusCode": 304,
+              "priority": "Low",
+              "rendererStartTime": 2239.4290000000037,
+              "networkRequestTime": 2240.4820000000182,
+              "sessionTargetType": "page",
+              "transferSize": 531,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 2125,
+              "networkEndTime": 2257.4690000000119,
+              "finished": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script"
+            },
+            {
+              "priority": "Low",
+              "rendererStartTime": 2240.17300000001,
+              "statusCode": 304,
+              "entity": "ausha.co",
+              "url": "https://player.ausha.co/ausha-player.js",
+              "networkRequestTime": 2241.0650000000314,
+              "resourceSize": 2558,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 705,
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "networkEndTime": 2615.5020000000077,
+              "finished": true
+            },
+            {
+              "resourceSize": 2495,
+              "experimentalFromMainFrame": true,
+              "transferSize": 1868,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "networkEndTime": 2272.9839999999967,
+              "finished": true,
+              "rendererStartTime": 2241.4810000000289,
+              "priority": "Low",
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/_vercel/insights/script.js",
+              "networkRequestTime": 2242.6110000000044
+            },
+            {
+              "networkEndTime": 2276.0740000000224,
+              "finished": true,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "resourceSize": 12567,
+              "experimentalFromMainFrame": true,
+              "transferSize": 5314,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkRequestTime": 2243.8360000000102,
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "url": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "rendererStartTime": 2242.6290000000154,
+              "priority": "Low"
+            },
+            {
+              "networkRequestTime": 2246.5350000000326,
+              "priority": "High",
+              "rendererStartTime": 2245.1310000000231,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe%2C%2Fclients%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology&version=ba6d9b28",
+              "resourceType": "Fetch",
+              "mimeType": "application/json",
+              "finished": true,
+              "networkEndTime": 2332.4060000000172,
+              "resourceSize": 16621,
+              "experimentalFromMainFrame": true,
+              "transferSize": 2482,
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "rendererStartTime": 2285.0600000000268,
+              "priority": "High",
+              "url": "https://www.ocobo.co/_vercel/insights/view",
+              "entity": "ocobo.co",
+              "statusCode": 202,
+              "networkRequestTime": 2287.1420000000217,
+              "protocol": "h2",
+              "transferSize": 473,
+              "sessionTargetType": "page",
+              "resourceSize": 48,
+              "experimentalFromMainFrame": true,
+              "mimeType": "application/json",
+              "resourceType": "Fetch",
+              "finished": true,
+              "networkEndTime": 2353.7300000000105
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "resourceSize": 9346,
+              "sessionTargetType": "page",
+              "transferSize": 4082,
+              "protocol": "http/1.1",
+              "resourceType": "XHR",
+              "mimeType": "application/json",
+              "finished": true,
+              "networkEndTime": 2691.5770000000193,
+              "priority": "High",
+              "rendererStartTime": 2584.8410000000149,
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953&hutk=f13052b98de6b98526012e48a8c28503",
+              "networkRequestTime": 2586.3030000000144
+            },
+            {
+              "networkRequestTime": 2655.0190000000002,
+              "priority": "High",
+              "rendererStartTime": 2653.8540000000212,
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=f13052b98de6b98526012e48a8c28503",
+              "resourceType": "XHR",
+              "mimeType": "application/json",
+              "networkEndTime": 2713.4760000000242,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 135,
+              "sessionTargetType": "page",
+              "transferSize": 1094,
+              "protocol": "h2"
+            },
+            {
+              "finished": true,
+              "networkEndTime": 2756.2989999999991,
+              "resourceType": "Image",
+              "mimeType": "image/gif",
+              "resourceSize": 45,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 1026,
+              "sessionTargetType": "page",
+              "networkRequestTime": 2673.0469999999914,
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778837367594&vi=f13052b98de6b98526012e48a8c28503&nc=true&u=242475741.f13052b98de6b98526012e48a8c28503.1778837366439.1778837366439.1778837366439.1&b=242475741.1.1778837366439&cc=15",
+              "rendererStartTime": 2671.6689999999944,
+              "priority": "Low"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "entity": "Hubspot",
+              "statusCode": 304,
+              "priority": "Low",
+              "rendererStartTime": 2710.3660000000091,
+              "networkRequestTime": 2712.1440000000293,
+              "sessionTargetType": "page",
+              "transferSize": 1659,
+              "protocol": "h2",
+              "resourceSize": 607831,
+              "finished": true,
+              "networkEndTime": 2733.8980000000156,
+              "mimeType": "application/javascript",
+              "resourceType": "Script"
+            },
+            {
+              "mimeType": "image/gif",
+              "resourceType": "Image",
+              "networkEndTime": 3081.6350000000093,
+              "finished": true,
+              "protocol": "http/1.1",
+              "transferSize": 1024,
+              "sessionTargetType": "page",
+              "resourceSize": 35,
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2990.640000000014,
+              "priority": "Low",
+              "rendererStartTime": 2988.7880000000005,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+              "entity": "Hubspot",
+              "statusCode": 200
+            },
+            {
+              "networkRequestTime": 2998.0350000000035,
+              "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+              "statusCode": 200,
+              "entity": "Google Fonts",
+              "priority": "VeryHigh",
+              "rendererStartTime": 2997.0550000000221,
+              "finished": true,
+              "networkEndTime": 3015.1830000000191,
+              "mimeType": "text/css",
+              "resourceType": "Stylesheet",
+              "sessionTargetType": "page",
+              "transferSize": 1259,
+              "protocol": "h2",
+              "resourceSize": 3792
+            },
+            {
+              "networkRequestTime": 3043.0939999999828,
+              "rendererStartTime": 3042.2300000000105,
+              "priority": "VeryHigh",
+              "statusCode": 200,
+              "entity": "Google Fonts",
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "resourceType": "Font",
+              "mimeType": "font/woff2",
+              "finished": true,
+              "networkEndTime": 3049.8830000000307,
+              "resourceSize": 50524,
+              "transferSize": 51336,
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "resourceType": "Font",
+              "mimeType": "font/woff2",
+              "finished": true,
+              "networkEndTime": 3054.3489999999874,
+              "resourceSize": 50524,
+              "transferSize": 51333,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkRequestTime": 3048.5830000000133,
+              "priority": "VeryHigh",
+              "rendererStartTime": 3047.6820000000007,
+              "entity": "Google Fonts",
+              "statusCode": 200,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "priority": "Low",
+              "rendererStartTime": 3080.4100000000035,
+              "statusCode": 200,
+              "entity": "Hubspot",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=f818c202-6895-4344-8fa4-fba3c9a8a470&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=94e90095c6fe8f7b37bf7e653b97049c&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fblog%2Fstructurer-la-croissance-pour-liberer-la-vente-exemple-surfe&t=Ocobo+%C2%B7+Structurer+la+croissance+pour+lib%C3%A9rer+la+vente%C2%A0%3A+l%27exemple+de+Surfe&cts=1778837368003&vi=f13052b98de6b98526012e48a8c28503&nc=true&u=242475741.f13052b98de6b98526012e48a8c28503.1778837366439.1778837366439.1778837366439.1&b=242475741.1.1778837366439&cc=15",
+              "networkRequestTime": 3081.9770000000135,
+              "resourceSize": 45,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "transferSize": 1028,
+              "sessionTargetType": "page",
+              "resourceType": "Image",
+              "mimeType": "image/gif",
+              "finished": true,
+              "networkEndTime": 3198.5510000000068
+            },
+            {
+              "finished": true,
+              "networkEndTime": 3196.0190000000002,
+              "mimeType": "image/gif",
+              "resourceType": "Image",
+              "transferSize": 1024,
+              "protocol": "http/1.1",
+              "sessionTargetType": "page",
+              "resourceSize": 35,
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 3083.6780000000144,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+              "entity": "Hubspot",
+              "statusCode": 200,
+              "priority": "Low",
+              "rendererStartTime": 3080.8630000000121
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "label": "Protocol",
+              "key": "protocol",
+              "valueType": "text"
+            },
+            {
+              "valueType": "ms",
+              "granularity": 1,
+              "key": "networkRequestTime",
+              "label": "Network Request Time"
+            },
+            {
+              "valueType": "ms",
+              "granularity": 1,
+              "key": "networkEndTime",
+              "label": "Network End Time"
+            },
+            {
+              "valueType": "bytes",
+              "granularity": 1,
+              "displayUnit": "kb",
+              "key": "transferSize",
+              "label": "Transfer Size"
+            },
+            {
+              "valueType": "bytes",
+              "displayUnit": "kb",
+              "granularity": 1,
+              "key": "resourceSize",
+              "label": "Resource Size"
+            },
+            {
+              "valueType": "text",
+              "key": "statusCode",
+              "label": "Status Code"
+            },
+            {
+              "key": "mimeType",
+              "label": "MIME Type",
+              "valueType": "text"
+            },
+            {
+              "label": "Resource Type",
+              "key": "resourceType",
+              "valueType": "text"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "document-latency-insight": {
+        "id": "document-latency-insight",
+        "title": "Document request latency",
+        "description": "Your first network request is the most important. [Reduce its latency](https://developer.chrome.com/docs/performance/insights/document-latency) by avoiding redirects, ensuring a fast server response, and enabling text compression.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "uncompressedResponseBytes": 0,
+            "type": "debugdata",
+            "wastedBytes": 0,
+            "redirectDuration": 0,
+            "serverResponseTime": 55
+          },
+          "items": {
+            "serverResponseIsFast": {
+              "value": true,
+              "label": "Server responds quickly (observed 55 ms)"
+            },
+            "usesCompression": {
+              "value": true,
+              "label": "Applies text compression"
+            },
+            "noRedirects": {
+              "value": true,
+              "label": "Avoids redirects"
+            }
+          },
+          "type": "checklist"
+        }
+      },
+      "render-blocking-insight": {
+        "id": "render-blocking-insight",
+        "title": "Render blocking requests",
+        "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 640 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 650
+        },
+        "details": {
+          "items": [
+            {
+              "totalBytes": 24572,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "wastedMs": 162
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "bytes",
+              "label": "Transfer Size",
+              "key": "totalBytes"
+            },
+            {
+              "key": "wastedMs",
+              "label": "Duration",
+              "valueType": "timespanMs"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "font-display-insight": {
+        "id": "font-display-insight",
+        "title": "Font display",
+        "description": "Consider setting [font-display](https://developer.chrome.com/docs/performance/insights/font-display) to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with [font metric overrides](https://developer.chrome.com/blog/font-fallbacks).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "skipSumming": [
+            "wastedMs"
+          ],
+          "items": [],
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "ms",
+              "key": "wastedMs",
+              "label": "Est Savings"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "main-thread-tasks": {
+        "id": "main-thread-tasks",
+        "title": "Tasks",
+        "description": "Lists the toplevel main thread tasks that executed during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "startTime": 814.284,
+              "duration": 24.092
+            },
+            {
+              "duration": 5.067,
+              "startTime": 855.987
+            },
+            {
+              "startTime": 866.033,
+              "duration": 13.017
+            },
+            {
+              "startTime": 879.071,
+              "duration": 143.233
+            },
+            {
+              "startTime": 1031.481,
+              "duration": 9.733
+            },
+            {
+              "duration": 9.709,
+              "startTime": 1044.709
+            },
+            {
+              "startTime": 1055.41,
+              "duration": 5.372
+            },
+            {
+              "startTime": 1060.851,
+              "duration": 5.156
+            },
+            {
+              "duration": 7.781,
+              "startTime": 1068.265
+            },
+            {
+              "duration": 14.73,
+              "startTime": 1090.617
+            },
+            {
+              "startTime": 1105.359,
+              "duration": 7.597
+            },
+            {
+              "duration": 82.714,
+              "startTime": 1128.296
+            },
+            {
+              "duration": 8.745,
+              "startTime": 1213.05
+            },
+            {
+              "startTime": 1225.547,
+              "duration": 54.398
+            },
+            {
+              "duration": 8.026,
+              "startTime": 1279.955
+            },
+            {
+              "startTime": 1290.211,
+              "duration": 26.668
+            },
+            {
+              "duration": 28.323,
+              "startTime": 1322.924
+            },
+            {
+              "duration": 28.054,
+              "startTime": 1361.461
+            },
+            {
+              "startTime": 1390.776,
+              "duration": 5.633
+            },
+            {
+              "duration": 7.809,
+              "startTime": 1396.586
+            },
+            {
+              "duration": 28.605,
+              "startTime": 1405.676
+            },
+            {
+              "duration": 23.309,
+              "startTime": 1436.833
+            },
+            {
+              "duration": 20.934,
+              "startTime": 1460.958
+            },
+            {
+              "duration": 10.672,
+              "startTime": 1485.445
+            },
+            {
+              "duration": 16.793,
+              "startTime": 1503.531
+            },
+            {
+              "startTime": 1523.58,
+              "duration": 8.829
+            },
+            {
+              "duration": 11.955,
+              "startTime": 1532.49
+            },
+            {
+              "startTime": 1544.882,
+              "duration": 8.818
+            },
+            {
+              "duration": 7.016,
+              "startTime": 1553.752
+            },
+            {
+              "duration": 5.613,
+              "startTime": 1560.811
+            },
+            {
+              "startTime": 1566.435,
+              "duration": 13.236
+            },
+            {
+              "duration": 9.901,
+              "startTime": 1579.704
+            },
+            {
+              "duration": 6.348,
+              "startTime": 1589.639
+            },
+            {
+              "duration": 186.65,
+              "startTime": 1595.999
+            },
+            {
+              "duration": 6.055,
+              "startTime": 1785.427
+            },
+            {
+              "duration": 10.678,
+              "startTime": 1791.856
+            },
+            {
+              "duration": 6.449,
+              "startTime": 1804.388
+            },
+            {
+              "startTime": 1811.001,
+              "duration": 13.77
+            },
+            {
+              "startTime": 1826.321,
+              "duration": 6.247
+            },
+            {
+              "startTime": 1832.603,
+              "duration": 10.01
+            },
+            {
+              "duration": 5.253,
+              "startTime": 1844.833
+            },
+            {
+              "duration": 24.457,
+              "startTime": 1850.096
+            },
+            {
+              "startTime": 1874.714,
+              "duration": 6.134
+            },
+            {
+              "duration": 109.724,
+              "startTime": 1880.937
+            },
+            {
+              "duration": 5.29,
+              "startTime": 1991.521
+            },
+            {
+              "duration": 12.893,
+              "startTime": 1996.878
+            },
+            {
+              "duration": 5.718,
+              "startTime": 2009.838
+            },
+            {
+              "duration": 5.502,
+              "startTime": 2015.601
+            },
+            {
+              "duration": 6.01,
+              "startTime": 2021.136
+            },
+            {
+              "startTime": 2027.154,
+              "duration": 5.405
+            },
+            {
+              "startTime": 2032.567,
+              "duration": 5.398
+            },
+            {
+              "startTime": 2037.975,
+              "duration": 6.277
+            },
+            {
+              "duration": 5.749,
+              "startTime": 2044.263
+            },
+            {
+              "duration": 5.988,
+              "startTime": 2050.023
+            },
+            {
+              "startTime": 2056.026,
+              "duration": 135.627
+            },
+            {
+              "duration": 32.751,
+              "startTime": 2191.731
+            },
+            {
+              "duration": 13.573,
+              "startTime": 2232.921
+            },
+            {
+              "duration": 12.578,
+              "startTime": 2246.611
+            },
+            {
+              "duration": 18.766,
+              "startTime": 2261.66
+            },
+            {
+              "duration": 7.019,
+              "startTime": 2286.372
+            },
+            {
+              "duration": 5.516,
+              "startTime": 2295.832
+            },
+            {
+              "startTime": 2301.509,
+              "duration": 95.319
+            },
+            {
+              "startTime": 2402.529,
+              "duration": 5.219
+            },
+            {
+              "duration": 5.185,
+              "startTime": 2407.758
+            },
+            {
+              "duration": 7.133,
+              "startTime": 2412.969
+            },
+            {
+              "duration": 5.769,
+              "startTime": 2420.114
+            },
+            {
+              "duration": 5.243,
+              "startTime": 2425.901
+            },
+            {
+              "duration": 5.291,
+              "startTime": 2431.389
+            },
+            {
+              "duration": 6.418,
+              "startTime": 2437.713
+            },
+            {
+              "startTime": 2444.486,
+              "duration": 6.091
+            },
+            {
+              "duration": 8.046,
+              "startTime": 2450.632
+            },
+            {
+              "duration": 7.22,
+              "startTime": 2459.04
+            },
+            {
+              "startTime": 2474.417,
+              "duration": 111.314
+            },
+            {
+              "startTime": 2589.283,
+              "duration": 20.026
+            },
+            {
+              "startTime": 2612.359,
+              "duration": 34.989
+            },
+            {
+              "duration": 5.001,
+              "startTime": 2649.57
+            },
+            {
+              "duration": 22.443,
+              "startTime": 2654.679
+            },
+            {
+              "duration": 15.709,
+              "startTime": 2677.563
+            },
+            {
+              "duration": 16.902,
+              "startTime": 2694.873
+            },
+            {
+              "duration": 95.314,
+              "startTime": 2714.137
+            },
+            {
+              "duration": 21.028,
+              "startTime": 2817.321
+            },
+            {
+              "startTime": 2838.406,
+              "duration": 151.309
+            },
+            {
+              "duration": 42.135,
+              "startTime": 2996.222
+            },
+            {
+              "duration": 21.048,
+              "startTime": 3040.017
+            },
+            {
+              "startTime": 3063.244,
+              "duration": 5.88
+            },
+            {
+              "startTime": 3070.707,
+              "duration": 10.969
+            },
+            {
+              "startTime": 3086.449,
+              "duration": 26.157
+            },
+            {
+              "duration": 98.074,
+              "startTime": 3112.858
+            },
+            {
+              "duration": 18.316,
+              "startTime": 3212.574
+            }
+          ],
+          "headings": [
+            {
+              "key": "startTime",
+              "label": "Start Time",
+              "valueType": "ms",
+              "granularity": 1
+            },
+            {
+              "valueType": "ms",
+              "granularity": 1,
+              "key": "duration",
+              "label": "End Time"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "inp-breakdown-insight": {
+        "id": "inp-breakdown-insight",
+        "title": "INP breakdown",
+        "description": "Start investigating [how to improve INP](https://developer.chrome.com/docs/performance/insights/inp-breakdown) by looking at the longest subpart.",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "lcp-breakdown-insight": {
+        "id": "lcp-breakdown-insight",
+        "title": "LCP breakdown",
+        "description": "Each [subpart has specific improvement strategies](https://developer.chrome.com/docs/performance/insights/lcp-breakdown). Ideally, most of the LCP time should be spent on loading the resources, not within delays.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "headings": [
+                {
+                  "valueType": "text",
+                  "label": "Subpart",
+                  "key": "label"
+                },
+                {
+                  "valueType": "ms",
+                  "key": "duration",
+                  "label": "Duration"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "duration": 0.274,
+                  "subpart": "timeToFirstByte",
+                  "label": "Time to first byte"
+                },
+                {
+                  "duration": 827.89,
+                  "subpart": "resourceLoadDelay",
+                  "label": "Resource load delay"
+                },
+                {
+                  "duration": 63.171,
+                  "subpart": "resourceLoadDuration",
+                  "label": "Resource load duration"
+                },
+                {
+                  "duration": 253.753,
+                  "label": "Element render delay",
+                  "subpart": "elementRenderDelay"
+                }
+              ]
+            },
+            {
+              "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/reve…\" alt=\"\" width=\"1200\" height=\"630\" class=\"d_block w_100% h_auto obj-f_cover bdr_2xl asp_16/7\" loading=\"eager\" fetchpriority=\"high\"\u003e",
+              "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,DIV,1,HEADER,3,IMG",
+              "boundingRect": {
+                "width": 0,
+                "top": 0,
+                "right": 0,
+                "bottom": 0,
+                "left": 0,
+                "height": 0
+              },
+              "lhId": "page-4-IMG",
+              "nodeLabel": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block",
+              "type": "node",
+              "selector": "div.mx_auto \u003e div \u003e header.ta_center \u003e img.d_block"
+            }
+          ]
+        }
+      },
+      "total-byte-weight": {
+        "id": "total-byte-weight",
+        "title": "Avoids enormous network payloads",
+        "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn how to reduce payload sizes](https://developer.chrome.com/docs/lighthouse/performance/total-byte-weight/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Total size was 1,437 KiB",
+        "details": {
+          "sortedBy": [
+            "totalBytes"
+          ],
+          "items": [
+            {
+              "totalBytes": 204717,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "totalBytes": 202020,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/posts/revenue-echoes-14/cover-2.png"
+            },
+            {
+              "totalBytes": 157129,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "totalBytes": 67588,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/team/benjamin-boileux.jpg"
+            },
+            {
+              "totalBytes": 51797,
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js"
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "totalBytes": 51333,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "totalBytes": 45263,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "totalBytes": 43927,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            },
+            {
+              "totalBytes": 43665,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "label": "Transfer Size",
+              "key": "totalBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 1471795,
+        "numericUnit": "byte"
+      },
+      "dom-size-insight": {
+        "id": "dom-size-insight",
+        "title": "Optimize DOM size",
+        "description": "A large DOM can increase the duration of style calculations and layout reflows, impacting page responsiveness. A large DOM will also increase memory usage. [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/performance/insights/dom-size).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "debugData": {
+            "maxChildren": 64,
+            "type": "debugdata",
+            "maxDepth": 17,
+            "totalElements": 598
+          },
+          "items": [
+            {
+              "value": {
+                "value": 598,
+                "granularity": 1,
+                "type": "numeric"
+              },
+              "statistic": "Total elements"
+            },
+            {
+              "statistic": "DOM depth",
+              "node": {
+                "type": "node",
+                "selector": "div.d_flex \u003e a.c_gray.400 \u003e svg.lucide \u003e path",
+                "nodeLabel": "div.d_flex \u003e a.c_gray.400 \u003e svg.lucide \u003e path",
+                "boundingRect": {
+                  "bottom": 0,
+                  "right": 0,
+                  "height": 0,
+                  "left": 0,
+                  "top": 0,
+                  "width": 0
+                },
+                "lhId": "page-13-path",
+                "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,DIV,2,ARTICLE,1,MAIN,3,DIV,1,DIV,0,DIV,1,DIV,3,DIV,0,A,0,svg,0,path",
+                "snippet": "\u003cpath d=\"M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 …\"\u003e"
+              },
+              "value": {
+                "value": 17,
+                "granularity": 1,
+                "type": "numeric"
+              }
+            },
+            {
+              "node": {
+                "boundingRect": {
+                  "width": 0,
+                  "right": 0,
+                  "bottom": 0,
+                  "left": 0,
+                  "height": 0,
+                  "top": 0
+                },
+                "lhId": "page-12-BODY",
+                "path": "1,BODY",
+                "snippet": "\u003cbody\u003e",
+                "type": "node",
+                "selector": "body",
+                "nodeLabel": "body"
+              },
+              "value": {
+                "value": 64,
+                "granularity": 1,
+                "type": "numeric"
+              },
+              "statistic": "Most children"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "statistic",
+              "label": "Statistic"
+            },
+            {
+              "valueType": "node",
+              "label": "Element",
+              "key": "node"
+            },
+            {
+              "label": "Value",
+              "key": "value",
+              "valueType": "numeric"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 598,
+        "numericUnit": "element"
+      },
+      "network-dependency-tree-insight": {
+        "id": "network-dependency-tree-insight",
+        "title": "Network dependency tree",
+        "description": "[Avoid chaining critical requests](https://developer.chrome.com/docs/performance/insights/network-dependency-tree) by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "value": {
+                "longestChain": {
+                  "duration": 3862
+                },
+                "chains": {
+                  "46F803803BBFFD0226C53CFECB694E87": {
+                    "isLongest": true,
+                    "navStartToEndTime": 842,
+                    "children": {
+                      "112.2": {
+                        "children": {
+                          "112.78": {
+                            "transferSize": 31975,
+                            "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                            "children": {},
+                            "navStartToEndTime": 1026
+                          },
+                          "112.83": {
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                            "transferSize": 39127,
+                            "navStartToEndTime": 1027,
+                            "children": {}
+                          },
+                          "112.82": {
+                            "transferSize": 40710,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+                            "children": {},
+                            "navStartToEndTime": 1211
+                          },
+                          "112.81": {
+                            "transferSize": 38779,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                            "children": {},
+                            "navStartToEndTime": 1027
+                          }
+                        },
+                        "navStartToEndTime": 861,
+                        "transferSize": 24572,
+                        "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+                      },
+                      "91.208": {
+                        "transferSize": 0,
+                        "url": "https://trc-events.taboola.com/1658275/log/3/unip?en=pre_d_eng_tb&tos=40093&scd=0&ssd=1&est=1778837328692&ver=36&isls=true&src=i&invt=10000&msa=1371&rv=1&tim=1778837368786&mrir=s&vi=1778837328678&ref=null&cv=20251112-1-RELEASE&item-url=https%3A%2F%2Ftjanstetorget.se%2Fel%2Felleverantoerer-i-sverige&ccpaPs=1---&cbp=Cookiebot&cbpv=1&cbcd=false&it=JS_PIXEL",
+                        "children": {},
+                        "navStartToEndTime": 3862,
+                        "isLongest": true
+                      }
+                    },
+                    "transferSize": 21889,
+                    "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+                  }
+                },
+                "type": "network-tree"
+              },
+              "type": "list-section"
+            },
+            {
+              "description": "[preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints help the browser establish a connection earlier in the page load, saving time when the first request for that origin is made. The following are the origins that the page preconnected to.",
+              "type": "list-section",
+              "value": {
+                "items": [
+                  {
+                    "origin": "https://raw.githubusercontent.com/",
+                    "subItems": {
+                      "type": "subitems",
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ]
+                    },
+                    "source": {
+                      "selector": "head \u003e link",
+                      "type": "node",
+                      "nodeLabel": "head \u003e link",
+                      "lhId": "page-9-LINK",
+                      "boundingRect": {
+                        "width": 0,
+                        "height": 0,
+                        "left": 0,
+                        "right": 0,
+                        "bottom": 0,
+                        "top": 0
+                      },
+                      "path": "0,HEAD,2,LINK",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e"
+                    }
+                  },
+                  {
+                    "subItems": {
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ],
+                      "type": "subitems"
+                    },
+                    "source": {
+                      "boundingRect": {
+                        "width": 0,
+                        "right": 0,
+                        "bottom": 0,
+                        "height": 0,
+                        "left": 0,
+                        "top": 0
+                      },
+                      "lhId": "page-10-LINK",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "path": "2,HTML,0,HEAD,3,LINK",
+                      "type": "node",
+                      "selector": "head \u003e link",
+                      "nodeLabel": "head \u003e link"
+                    }
+                  }
+                ],
+                "type": "table",
+                "headings": [
+                  {
+                    "valueType": "text",
+                    "label": "Origin",
+                    "subItemsHeading": {
+                      "key": "warning"
+                    },
+                    "key": "origin"
+                  },
+                  {
+                    "valueType": "node",
+                    "label": "Source",
+                    "key": "source"
+                  }
+                ]
+              },
+              "title": "Preconnected origins"
+            },
+            {
+              "description": "Add [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints to your most important origins, but try to use no more than 4.",
+              "value": {
+                "type": "text",
+                "value": "No additional origins are good candidates for preconnecting"
+              },
+              "title": "Preconnect candidates",
+              "type": "list-section"
+            }
+          ]
+        }
+      },
+      "unminified-css": {
+        "id": "unminified-css",
+        "title": "Minify CSS",
+        "description": "Minifying CSS files can reduce network payload sizes. [Learn how to minify CSS](https://developer.chrome.com/docs/lighthouse/performance/unminified-css/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "opportunity",
+          "items": [],
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "headings": [],
+          "overallSavingsMs": 0,
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsBytes": 0
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "unsized-images": {
+        "id": "unsized-images",
+        "title": "Image elements do not have explicit `width` and `height`",
+        "description": "Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [
+            {
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "node": {
+                "lhId": "1-0-IMG",
+                "boundingRect": {
+                  "width": 134,
+                  "height": 40,
+                  "left": 33,
+                  "right": 167,
+                  "bottom": 77,
+                  "top": 37
+                },
+                "path": "2,HTML,1,BODY,0,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "type": "node",
+                "nodeLabel": "Ocobo"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "network-server-latency": {
+        "id": "network-server-latency",
+        "title": "Server Backend Latencies",
+        "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "0 ms",
+        "details": {
+          "headings": [
+            {
+              "label": "URL",
+              "key": "origin",
+              "valueType": "text"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "label": "Time Spent",
+              "key": "serverResponseTime"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "serverResponseTime": 4,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "serverResponseTime": 3.5,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "origin": "https://useago.github.io",
+              "serverResponseTime": 0.5
+            },
+            {
+              "origin": "https://tag.clearbitscripts.com",
+              "serverResponseTime": 0
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://player.ausha.co"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://track-eu1.hubspot.com"
+            }
+          ],
+          "sortedBy": [
+            "serverResponseTime"
+          ]
+        },
+        "numericValue": 4,
+        "numericUnit": "millisecond"
+      },
+      "long-tasks": {
+        "id": "long-tasks",
+        "title": "Avoid long main-thread tasks",
+        "description": "Lists the longest tasks on the main thread, useful for identifying worst contributors to input delay. [Learn how to avoid long main-thread tasks](https://web.dev/articles/optimize-long-tasks)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "12 long tasks found",
+        "metricSavings": {
+          "TBT": 600
+        },
+        "details": {
+          "type": "table",
+          "debugData": {
+            "tasks": [
+              {
+                "startTime": 11444.4,
+                "duration": 182,
+                "urlIndex": 0,
+                "scriptEvaluation": 0,
+                "other": 182
+              },
+              {
+                "other": 163,
+                "startTime": 8417.2,
+                "duration": 163,
+                "urlIndex": 1
+              },
+              {
+                "other": 134,
+                "startTime": 8580.2,
+                "duration": 134,
+                "urlIndex": 0,
+                "scriptEvaluation": 0
+              },
+              {
+                "duration": 132,
+                "urlIndex": 2,
+                "startTime": 3910.9,
+                "other": 132
+              },
+              {
+                "startTime": 4088.9,
+                "urlIndex": 2,
+                "duration": 118,
+                "other": 118
+              },
+              {
+                "other": 114,
+                "scriptEvaluation": 0,
+                "startTime": 7643.2,
+                "duration": 114,
+                "urlIndex": 3
+              },
+              {
+                "scriptEvaluation": 0,
+                "startTime": 7531.2,
+                "duration": 112,
+                "urlIndex": 2,
+                "other": 112
+              },
+              {
+                "other": 99,
+                "scriptEvaluation": 0,
+                "startTime": 5734,
+                "duration": 99,
+                "urlIndex": 3
+              },
+              {
+                "startTime": 947,
+                "paintCompositeRender": 0,
+                "duration": 86,
+                "urlIndex": 4,
+                "scriptEvaluation": 0,
+                "styleLayout": 0,
+                "other": 86
+              },
+              {
+                "other": 65,
+                "scriptEvaluation": 0,
+                "duration": 65,
+                "urlIndex": 3,
+                "startTime": 5833
+              },
+              {
+                "other": 57,
+                "scriptEvaluation": 0,
+                "urlIndex": 2,
+                "duration": 57,
+                "startTime": 7869.2
+              },
+              {
+                "other": 51,
+                "duration": 51,
+                "urlIndex": 0,
+                "startTime": 11626.4
+              }
+            ],
+            "urls": [
+              "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+            ],
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "startTime": 11444.380890245055,
+              "duration": 182,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "duration": 162.99999999999818,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "startTime": 8417.1794336669245
+            },
+            {
+              "startTime": 8580.1794336669227,
+              "duration": 134,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "startTime": 3910.9440414673659,
+              "duration": 132,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "startTime": 4088.9440414673659,
+              "duration": 118.00000000000045,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "startTime": 7643.1594965928216,
+              "duration": 114,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "startTime": 7531.1594965928216,
+              "duration": 112,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "duration": 99,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "startTime": 5734.0132913827356
+            },
+            {
+              "startTime": 947.01329138273525,
+              "duration": 85.999999999999886,
+              "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe"
+            },
+            {
+              "startTime": 5833.0132913827356,
+              "duration": 65,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "startTime": 7869.1594965928216,
+              "duration": 57,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "duration": 51,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "startTime": 11626.380890245055
+            }
+          ],
+          "sortedBy": [
+            "duration"
+          ],
+          "skipSumming": [
+            "startTime"
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "label": "Start Time",
+              "key": "startTime"
+            },
+            {
+              "key": "duration",
+              "label": "Duration",
+              "valueType": "ms",
+              "granularity": 1
+            }
+          ]
+        }
+      },
+      "cumulative-layout-shift": {
+        "id": "cumulative-layout-shift",
+        "title": "Cumulative Layout Shift",
+        "description": "Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/articles/cls).",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "0.007",
+        "details": {
+          "items": [
+            {
+              "cumulativeLayoutShiftMainFrame": 0.006987,
+              "newEngineResultDiffered": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 0.006987,
+        "numericUnit": "unitless"
+      },
+      "max-potential-fid": {
+        "id": "max-potential-fid",
+        "title": "Max Potential First Input Delay",
+        "description": "The maximum potential First Input Delay that your users could experience is the duration of the longest task. [Learn more about the Maximum Potential First Input Delay metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-max-potential-fid/).",
+        "score": 0.73,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "180 ms",
+        "numericValue": 182,
+        "numericUnit": "millisecond"
+      },
+      "bootup-time": {
+        "id": "bootup-time",
+        "title": "Reduce JavaScript execution time",
+        "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to reduce Javascript execution time](https://developer.chrome.com/docs/lighthouse/performance/bootup-time/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "1.9 s",
+        "metricSavings": {
+          "TBT": 600
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "scriptParseCompile": 27.569999999999997,
+              "total": 834.46799999999962,
+              "scripting": 528.03839999999957,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "scripting": 430.44719999999808,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "total": 452.2319999999981,
+              "scriptParseCompile": 10.493999999999998
+            },
+            {
+              "scriptParseCompile": 160.6176,
+              "total": 402.07559999999967,
+              "scripting": 234.50399999999968,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "scripting": 4.3955999999999982,
+              "url": "https://www.ocobo.co/blog/structurer-la-croissance-pour-liberer-la-vente-exemple-surfe",
+              "total": 315.25319999999994,
+              "scriptParseCompile": 3.8651999999999993
+            },
+            {
+              "scripting": 147.34560000000005,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "total": 288.90240000000006,
+              "scriptParseCompile": 137.9772
+            },
+            {
+              "total": 224.75880000000004,
+              "scriptParseCompile": 0,
+              "scripting": 43.990800000000014,
+              "url": "Unattributable"
+            },
+            {
+              "scriptParseCompile": 23.243999999999996,
+              "total": 102.20279999999998,
+              "scripting": 72.253199999999993,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "scripting": 48.0144,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "scriptParseCompile": 23.3808,
+              "total": 73.188
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "label": "Total CPU Time",
+              "key": "total"
+            },
+            {
+              "key": "scripting",
+              "label": "Script Evaluation",
+              "valueType": "ms",
+              "granularity": 1
+            },
+            {
+              "label": "Script Parse",
+              "key": "scriptParseCompile",
+              "granularity": 1,
+              "valueType": "ms"
+            }
+          ],
+          "summary": {
+            "wastedMs": 1896.1379999999974
+          },
+          "sortedBy": [
+            "total"
+          ]
+        },
+        "numericValue": 1896.1379999999974,
+        "numericUnit": "millisecond"
+      },
+      "unused-javascript": {
+        "id": "unused-javascript",
+        "title": "Reduce unused JavaScript",
+        "description": "Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 464 KiB",
+        "metricSavings": {
+          "LCP": 750,
+          "FCP": 150
+        },
+        "details": {
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsBytes": 475233,
+          "overallSavingsMs": 750,
+          "headings": [
+            {
+              "label": "URL",
+              "subItemsHeading": {
+                "valueType": "code",
+                "key": "source"
+              },
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "label": "Transfer Size",
+              "subItemsHeading": {
+                "key": "sourceBytes"
+              },
+              "key": "totalBytes",
+              "valueType": "bytes"
+            },
+            {
+              "label": "Est Savings",
+              "key": "wastedBytes",
+              "subItemsHeading": {
+                "key": "sourceWastedBytes"
+              },
+              "valueType": "bytes"
+            }
+          ],
+          "type": "opportunity",
+          "debugData": {
+            "metricSavings": {
+              "FCP": 150,
+              "LCP": 750
+            },
+            "type": "debugdata"
+          },
+          "items": [
+            {
+              "wastedPercent": 57.372344479375059,
+              "wastedBytes": 112602,
+              "totalBytes": 196265,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "wastedPercent": 71.186009485023035,
+              "totalBytes": 156442,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedBytes": 111365
+            },
+            {
+              "wastedBytes": 82854,
+              "totalBytes": 196265,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedPercent": 42.2154629213789
+            },
+            {
+              "wastedPercent": 42.544801575607764,
+              "totalBytes": 156442,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedBytes": 66558
+            },
+            {
+              "totalBytes": 49784,
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "wastedBytes": 30034,
+              "wastedPercent": 60.328802682337667
+            },
+            {
+              "wastedPercent": 62.498279737602644,
+              "wastedBytes": 26614,
+              "totalBytes": 42584,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "wastedPercent": 56.002711648123778,
+              "wastedBytes": 24267,
+              "totalBytes": 43332,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            },
+            {
+              "wastedPercent": 75.1296024165238,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "totalBytes": 27871,
+              "wastedBytes": 20939
+            }
+          ]
+        },
+        "numericValue": 750,
+        "numericUnit": "millisecond"
+      },
+      "diagnostics": {
+        "id": "diagnostics",
+        "title": "Diagnostics",
+        "description": "Collection of useful page vitals.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "debugdata",
+          "items": [
+            {
+              "numTasksOver50ms": 11,
+              "maxRtt": 16.960679999999996,
+              "numTasksOver500ms": 0,
+              "numStylesheets": 3,
+              "numTasksOver10ms": 44,
+              "totalByteWeight": 1471795,
+              "mainDocumentTransferSize": 21889,
+              "throughput": 16715943024.247349,
+              "numScripts": 63,
+              "numRequests": 93,
+              "maxServerLatency": 4,
+              "numTasks": 1774,
+              "numFonts": 6,
+              "numTasksOver100ms": 6,
+              "totalTaskTime": 2409.7110000000043,
+              "rtt": 0.00060794936930315033,
+              "numTasksOver25ms": 19
+            }
+          ]
+        }
+      },
+      "non-composited-animations": {
+        "id": "non-composited-animations",
+        "title": "Avoid non-composited animations",
+        "description": "Animations which are not composited can be janky and increase CLS. [Learn how to avoid non-composited animations](https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/)",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "Element",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "failureReason"
+              },
+              "key": "node",
+              "valueType": "node"
+            }
+          ],
+          "type": "table",
+          "items": []
+        }
+      },
+      "mainthread-work-breakdown": {
+        "id": "mainthread-work-breakdown",
+        "title": "Minimize main-thread work",
+        "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to minimize main-thread work](https://developer.chrome.com/docs/lighthouse/performance/mainthread-work-breakdown/)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "2.9 s",
+        "metricSavings": {
+          "TBT": 600
+        },
+        "details": {
+          "headings": [
+            {
+              "key": "groupLabel",
+              "label": "Category",
+              "valueType": "text"
+            },
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "label": "Time Spent",
+              "key": "duration"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "duration": 1570.3403999999821,
+              "groupLabel": "Script Evaluation",
+              "group": "scriptEvaluation"
+            },
+            {
+              "duration": 532.67640000000029,
+              "groupLabel": "Style & Layout",
+              "group": "styleLayout"
+            },
+            {
+              "duration": 459.57119999999992,
+              "groupLabel": "Script Parsing & Compilation",
+              "group": "scriptParseCompile"
+            },
+            {
+              "duration": 233.70719999999795,
+              "groupLabel": "Other",
+              "group": "other"
+            },
+            {
+              "groupLabel": "Rendering",
+              "group": "paintCompositeRender",
+              "duration": 36.81839999999999
+            },
+            {
+              "duration": 36.127199999999981,
+              "groupLabel": "Parse HTML & CSS",
+              "group": "parseHTML"
+            },
+            {
+              "groupLabel": "Garbage Collection",
+              "group": "garbageCollection",
+              "duration": 22.4124
+            }
+          ],
+          "sortedBy": [
+            "duration"
+          ]
+        },
+        "numericValue": 2891.65319999998,
+        "numericUnit": "millisecond"
+      },
+      "duplicated-javascript-insight": {
+        "id": "duplicated-javascript-insight",
+        "title": "Duplicated JavaScript",
+        "description": "Remove large, [duplicate JavaScript modules](https://developer.chrome.com/docs/performance/insights/duplicated-javascript) from bundles to reduce unnecessary bytes consumed by network activity.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "table",
+          "headings": [
+            {
+              "valueType": "code",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "key": "source",
+              "label": "Source"
+            },
+            {
+              "valueType": "bytes",
+              "granularity": 10,
+              "key": "wastedBytes",
+              "subItemsHeading": {
+                "key": "sourceTransferBytes"
+              },
+              "label": "Duplicated bytes"
+            }
+          ],
+          "debugData": {
+            "wastedBytes": 0,
+            "type": "debugdata"
+          },
+          "items": []
+        }
+      },
+      "largest-contentful-paint": {
+        "id": "largest-contentful-paint",
+        "title": "Largest Contentful Paint",
+        "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)",
+        "score": 0.14,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "5.9 s",
+        "numericValue": 5926.1246067131442,
+        "numericUnit": "millisecond"
+      },
+      "forced-reflow-insight": {
+        "id": "forced-reflow-insight",
+        "title": "Forced reflow",
+        "description": "A forced reflow occurs when JavaScript queries geometric properties (such as offsetWidth) after styles have been invalidated by a change to the DOM state. This can result in poor performance. Learn more about [forced reflows](https://developer.chrome.com/docs/performance/insights/forced-reflow) and possible mitigations.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "details": {
+          "items": [
+            {
+              "headings": [
+                {
+                  "label": "Source",
+                  "key": "source",
+                  "valueType": "source-location"
+                },
+                {
+                  "label": "Total reflow time",
+                  "key": "reflowTime",
+                  "granularity": 1,
+                  "valueType": "ms"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "reflowTime": 136.019,
+                  "source": {
+                    "value": "[unattributed]",
+                    "type": "text"
+                  }
+                },
+                {
+                  "reflowTime": 0.609,
+                  "source": {
+                    "type": "source-location",
+                    "column": 85503,
+                    "urlProvider": "network",
+                    "line": 19,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+                  }
+                },
+                {
+                  "reflowTime": 0.652,
+                  "source": {
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+                    "column": 85503,
+                    "urlProvider": "network",
+                    "type": "source-location",
+                    "line": 19
+                  }
+                },
+                {
+                  "source": {
+                    "line": 19,
+                    "urlProvider": "network",
+                    "column": 100773,
+                    "type": "source-location",
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+                  },
+                  "reflowTime": 0.484
+                }
+              ]
+            }
+          ],
+          "type": "list"
+        }
+      }
+    },
+    "categories": {
+      "performance": {
+        "id": "performance",
+        "title": "Performance",
+        "score": 0.56,
+        "auditRefs": [
+          {
+            "id": "first-contentful-paint",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "FCP"
+          },
+          {
+            "id": "largest-contentful-paint",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "LCP"
+          },
+          {
+            "id": "total-blocking-time",
+            "weight": 30,
+            "group": "metrics",
+            "acronym": "TBT"
+          },
+          {
+            "id": "cumulative-layout-shift",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "CLS"
+          },
+          {
+            "id": "speed-index",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "SI"
+          },
+          {
+            "id": "cache-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "cls-culprits-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "document-latency-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "dom-size-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "duplicated-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "font-display-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "forced-reflow-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "image-delivery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "inp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-discovery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "legacy-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "network-dependency-tree-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "render-blocking-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "third-parties-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "viewport-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "interactive",
+            "weight": 0,
+            "group": "hidden",
+            "acronym": "TTI"
+          },
+          {
+            "id": "max-potential-fid",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "unminified-css",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unminified-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-css-rules",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "total-byte-weight",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "user-timings",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "bootup-time",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "mainthread-work-breakdown",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "long-tasks",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "non-composited-animations",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unsized-images",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "network-requests",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-rtt",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-server-latency",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "main-thread-tasks",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "diagnostics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "metrics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "screenshot-thumbnails",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "final-screenshot",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "script-treemap-data",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "resource-summary",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "redirects",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "server-response-time",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "layout-shifts",
+            "weight": 0,
+            "group": "hidden"
+          }
+        ]
+      }
+    },
+    "categoryGroups": {
+      "a11y-best-practices": {
+        "title": "Best practices",
+        "description": "These items highlight common accessibility best practices."
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "description": "More information about the performance of your application. These numbers don't [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score."
+      },
+      "best-practices-trust-safety": {
+        "title": "Trust and Safety"
+      },
+      "best-practices-general": {
+        "title": "General"
+      },
+      "best-practices-ux": {
+        "title": "User Experience"
+      },
+      "insights": {
+        "title": "Insights",
+        "description": "These insights are also available in the Chrome DevTools Performance Panel - [record a trace](https://developer.chrome.com/docs/devtools/performance/reference) to view more detailed information."
+      },
+      "a11y-navigation": {
+        "title": "Navigation",
+        "description": "These are opportunities to improve keyboard navigation in your application."
+      },
+      "seo-mobile": {
+        "title": "Mobile Friendly",
+        "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn how to make pages mobile-friendly](https://developers.google.com/search/mobile-sites/)."
+      },
+      "seo-content": {
+        "title": "Content Best Practices",
+        "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+      },
+      "a11y-aria": {
+        "title": "ARIA",
+        "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "a11y-names-labels": {
+        "title": "Names and labels",
+        "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "a11y-audio-video": {
+        "title": "Audio and video",
+        "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+      },
+      "a11y-language": {
+        "title": "Internationalization and localization",
+        "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      },
+      "a11y-color-contrast": {
+        "title": "Contrast",
+        "description": "These are opportunities to improve the legibility of your content."
+      },
+      "a11y-tables-lists": {
+        "title": "Tables and lists",
+        "description": "These are opportunities to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+      },
+      "metrics": {
+        "title": "Metrics"
+      },
+      "best-practices-browser-compat": {
+        "title": "Browser Compatibility"
+      },
+      "seo-crawl": {
+        "title": "Crawling and Indexing",
+        "description": "To appear in search results, crawlers need access to your app."
+      }
+    },
+    "timing": {
+      "total": 20037.5
+    },
+    "i18n": {
+      "rendererFormattedStrings": {
+        "varianceDisclaimer": "Values are estimated and may vary. The [performance score is calculated](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) directly from these metrics.",
+        "opportunityResourceColumnLabel": "Opportunity",
+        "opportunitySavingsColumnLabel": "Estimated Savings",
+        "errorMissingAuditInfo": "Report error: no audit information",
+        "errorLabel": "Error!",
+        "warningHeader": "Warnings: ",
+        "passedAuditsGroupTitle": "Passed audits",
+        "notApplicableAuditsGroupTitle": "Not applicable",
+        "manualAuditsGroupTitle": "Additional items to manually check",
+        "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+        "crcLongestDurationLabel": "Maximum critical path latency:",
+        "crcInitialNavigation": "Initial Navigation",
+        "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+        "labDataTitle": "Lab Data",
+        "warningAuditsGroupTitle": "Passed audits but with warnings",
+        "snippetExpandButtonLabel": "Expand snippet",
+        "snippetCollapseButtonLabel": "Collapse snippet",
+        "thirdPartyResourcesLabel": "Show 3rd-party resources",
+        "runtimeDesktopEmulation": "Emulated Desktop",
+        "runtimeMobileEmulation": "Emulated Moto G Power",
+        "runtimeNoEmulation": "No emulation",
+        "runtimeSettingsBenchmark": "Unthrottled CPU/Memory Power",
+        "runtimeSettingsCPUThrottling": "CPU throttling",
+        "runtimeSettingsDevice": "Device",
+        "runtimeSettingsNetworkThrottling": "Network throttling",
+        "runtimeSettingsUANetwork": "User agent (network)",
+        "runtimeUnknown": "Unknown",
+        "dropdownCopyJSON": "Copy JSON",
+        "dropdownDarkTheme": "Toggle Dark Theme",
+        "dropdownPrintExpanded": "Print Expanded",
+        "dropdownPrintSummary": "Print Summary",
+        "dropdownSaveGist": "Save as Gist",
+        "dropdownSaveHTML": "Save as HTML",
+        "dropdownSaveJSON": "Save as JSON",
+        "dropdownViewer": "Open in Viewer",
+        "footerIssue": "File an issue",
+        "throttlingProvided": "Provided by environment",
+        "calculatorLink": "See calculator.",
+        "runtimeSettingsAxeVersion": "Axe version",
+        "viewTreemapLabel": "View Treemap",
+        "showRelevantAudits": "Show audits relevant to:"
+      }
+    },
+    "entities": [
+      {
+        "name": "ocobo.co",
+        "isFirstParty": true,
+        "isUnrecognized": true,
+        "origins": [
+          "https://www.ocobo.co"
+        ]
+      },
+      {
+        "name": "vercel-storage.com",
+        "isUnrecognized": true,
+        "origins": [
+          "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+        ]
+      },
+      {
+        "name": "Google Tag Manager",
+        "homepage": "https://marketingplatform.google.com/about/tag-manager/",
+        "category": "tag-manager",
+        "origins": [
+          "https://www.googletagmanager.com"
+        ]
+      },
+      {
+        "name": "Clearbit",
+        "homepage": "https://clearbit.com/",
+        "category": "analytics",
+        "origins": [
+          "https://tag.clearbitscripts.com"
+        ]
+      },
+      {
+        "name": "Hubspot",
+        "homepage": "https://hubspot.com/",
+        "category": "marketing",
+        "origins": [
+          "https://js-eu1.hs-scripts.com",
+          "https://js-eu1.hubspot.com",
+          "https://js-eu1.hscollectedforms.net",
+          "https://js-eu1.hs-analytics.net",
+          "https://js-eu1.hs-banner.com",
+          "https://forms-eu1.hscollectedforms.net",
+          "https://cta-eu1.hubspot.com",
+          "https://track-eu1.hubspot.com",
+          "https://perf-eu1.hsforms.com",
+          "https://js-eu1.hsforms.net",
+          "https://forms-eu1.hsforms.com"
+        ]
+      },
+      {
+        "name": "GitHub",
+        "category": "utility",
+        "origins": [
+          "https://useago.github.io"
+        ]
+      },
+      {
+        "name": "ausha.co",
+        "isUnrecognized": true,
+        "origins": [
+          "https://player.ausha.co"
+        ]
+      },
+      {
+        "name": "Google Analytics",
+        "homepage": "https://marketingplatform.google.com/about/analytics/",
+        "category": "analytics",
+        "origins": [
+          "https://www.google-analytics.com"
+        ]
+      },
+      {
+        "name": "Google Fonts",
+        "homepage": "https://fonts.google.com/",
+        "category": "cdn",
+        "origins": [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com"
+        ]
+      }
+    ],
+    "fullPageScreenshot": {
+      "nodes": {
+        "1-2-IMG": {
+          "width": 380,
+          "height": 166,
+          "left": 16,
+          "right": 396,
+          "bottom": 581,
+          "top": 414
+        },
+        "page-13-path": {
+          "left": 0,
+          "height": 0,
+          "bottom": 0,
+          "right": 0,
+          "top": 0,
+          "width": 0
+        },
+        "page-1-IMG": {
+          "top": 6634,
+          "height": 100,
+          "left": 49,
+          "bottom": 6734,
+          "right": 149,
+          "width": 100
+        },
+        "page-0-IMG": {
+          "left": 16,
+          "height": 166,
+          "right": 396,
+          "bottom": 581,
+          "top": 414,
+          "width": 380
+        },
+        "page-12-BODY": {
+          "top": 0,
+          "height": 0,
+          "left": 0,
+          "right": 0,
+          "bottom": 0,
+          "width": 0
+        },
+        "page-7-SPAN": {
+          "right": 0,
+          "bottom": 0,
+          "height": 0,
+          "left": 0,
+          "top": 0,
+          "width": 0
+        },
+        "page-11-META": {
+          "right": 0,
+          "bottom": 0,
+          "left": 0,
+          "height": 0,
+          "top": 0,
+          "width": 0
+        },
+        "page-15-IMG": {
+          "width": 0,
+          "right": 0,
+          "bottom": 0,
+          "height": 0,
+          "left": 0,
+          "top": 0
+        },
+        "page-3-IMG": {
+          "width": 134,
+          "right": 167,
+          "bottom": 77,
+          "height": 40,
+          "left": 33,
+          "top": 37
+        },
+        "1-1-IMG": {
+          "width": 0,
+          "top": 0,
+          "left": 0,
+          "height": 0,
+          "right": 0,
+          "bottom": 0
+        },
+        "page-10-LINK": {
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "height": 0,
+          "left": 0,
+          "width": 0
+        },
+        "page-8-SPAN": {
+          "bottom": 0,
+          "right": 0,
+          "left": 0,
+          "height": 0,
+          "top": 0,
+          "width": 0
+        },
+        "1-5-IMG": {
+          "left": 0,
+          "height": 0,
+          "right": 0,
+          "bottom": 0,
+          "top": 0,
+          "width": 0
+        },
+        "page-2-IMG": {
+          "width": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0,
+          "height": 0,
+          "top": 0,
+          "id": "open-path"
+        },
+        "1-4-IMG": {
+          "height": 0,
+          "left": 0,
+          "right": 0,
+          "bottom": 0,
+          "top": 0,
+          "width": 0
+        },
+        "page-4-IMG": {
+          "width": 0,
+          "top": 0,
+          "height": 0,
+          "left": 0,
+          "right": 0,
+          "bottom": 0
+        },
+        "page-14-IMG": {
+          "left": 0,
+          "height": 0,
+          "bottom": 0,
+          "right": 0,
+          "top": 0,
+          "width": 0
+        },
+        "1-0-IMG": {
+          "top": 37,
+          "right": 167,
+          "bottom": 77,
+          "height": 40,
+          "left": 33,
+          "width": 134
+        },
+        "1-3-IMG": {
+          "width": 100,
+          "top": 6634,
+          "right": 149,
+          "bottom": 6734,
+          "height": 100,
+          "left": 49
+        },
+        "page-6-H1": {
+          "bottom": 0,
+          "right": 0,
+          "height": 0,
+          "left": 0,
+          "top": 0,
+          "width": 0
+        },
+        "page-5-P": {
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "height": 0,
+          "left": 0,
+          "width": 0
+        },
+        "page-9-LINK": {
+          "top": 0,
+          "left": 0,
+          "height": 0,
+          "bottom": 0,
+          "right": 0,
+          "width": 0
+        }
+      },
+      "screenshot": {
+        "width": 412,
+        "data": "data:image/webp;base64,UklGRpA3BABXRUJQVlA4WAoAAAAgAAAAmwEAYSIASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZWUDggojUEADC7Dp0BKpwBYiI/EYK5Viwopikk0ds5gCIJaW78XbOUGAKHch1Xfjc1oSmkWVzSYlq26pzm7H/pc2+fmA84D0n/4jpofVt9ADpdv8TkvXwn+Vf5X+yf3n9hf///3fsR8n/Uf8x/cv8v+wf7xez/kT+Jfvf+c/7X+U+QT6+/3v8j4R/Sf6D/y/67/iex381/BX9H/E/6T//f8b5k/tv/N/zH+W/bz0L/Pf3b/vf6D/Z+4L+f/07/z/4z/b////n/H58t/zP8n/o/388VfVP9B/zf81/q/3O+QX2n+zfst/ofVi98/5H+G/0fsR+nf43/uf4r/N/ID/U/8D/3P8Z+bvzV/vf24/3Xmp/j/93+1//l+QP+d/4T/0/5b/V/vV9Mf93/+f9p5+vrj9wPgM/YT/9/6r/lfvh9AH/x////8+Dn8A/9X////fw+/ux////+XB3gOWOA5Y4DljgOWOA5Y4DljgOWOA5Y4DljgOWOA5Yv5R0JKbZEptkSlkpIN7cPyYayBAdSEU4n0/DiuMN8sqI0x1mXPA1gBe/1VBBRmO1BH7bbGePVWM5PnDSTnyuJ39ui/25zhcbGWG1K6QR7cOO4sj5HLRjQZ6NTv8YE4NauoZLJXDKLaZJQGxtDvr3IAonz3ODhCluFV27/bov9orOJq2Nh8X+3RqWfEBPTbIlNsiU2yI2xPL7ooY72y0LqB41qvWIM0lhsaYI6X5aPdZd5/ycByxwHLHAcss/aiE+/26L/bov9ui/26L/bov9ui/26L/bov9ui/26L/bov9ui/26L/bov9ui6nZxYnNRECrpvz7ulepWtxVx6kiU9r4tCMjocyZPcHALJ8cc2oRD88LBY49rGi/26L+e7e/ihwYUB8HFXNAp/3TXofX0gxDcUNtLMJ/IDAa2lqZJCQOK0z82aj77ipvSyrkTZVUOlM4WyJTbIlNhuqa8dIwjdV1oxWwegOWOA5Y4DljgOWOA5Y4DljgJ8/iN1Z9eiyy6zmFJMtqDOxxDwka8OWt7KqfjZ8JXuHH9wCQfe7A9QE+sxEnvrx3Pl75uaQ9IJid4KS1JGs7oWNXXxqz7TZ6N/LgDbOmvVJEIyg7TxYKix6Yk0JWzC4LqNWxXDKayBHP3RPqbdb+f/Y881SPdXPcDloFKy6mHcZ3eqfkzwqnyTDospUSEKbuvFOJ4xMmn5Jpn77o2hAlb5NQ5NkiL/ZjU4ggN7K2ULegFTrfgpqC3HayIdJvk+etvafSkQJRPGVHdTY/fRTE4azH4UlldN9NvJCAmLnk65xaoYaKyJBYwOOxrOVnajam/iOBXG+JYzVj2OYtPTGoVizZbcoxgklUSdw+TQ49sOXoSlLfXF0UcCzouO4oTpcST4BqKH3Vn5dF2Jlh+LOZSV4K2KSQY4xpme09yXj9qnhwmA28r85Fx+7FAqQM9/C9ExG1X0KLKHCV3cvtWZ3cIhtTSx/5naXgo0E1JyiUw75TEmZ0yfugKnLnZyyd0YeqitGNS1DK3cvXYffDtQzBaIZUH80JGa/hLO/aI+98+kc4izeUdyBm0eSmoLHsd/kDOl+HOWXt4OhfNalT6U6quRsfajiAJw9ksFIkfi6XYTVWxYSbOyfBgAPN4o5KjK6FofBG3Dr2vJqptAcscBR3GfS+mEqcqN+tNUr9uXC9kIh5AvXw2wMG34OycaOT6CIwucpM3gmRhSCk4Sw/MtAt+cw0YkJxEcd5Jc5XiDjrF5fcxwHLHBDQd2boP7XmeZqlt4DljgOWOA5Y4DljgOWOA5Y4DiBUK0kbBUY4OoP7fbXs5ldORSKtfrYHgXukm04Nh8S3MABSdQLGWNF/sd3v5X05SVm3BZyJPvmqq7NDfBbiUXDYcwZWGhmlyHO5+5jgOWOA5ZmVlt5mzLC2V5Y4DljPa35brqvqmXw8Wu9gACbUh7hONfbI5VuWOAohWYr0IUqW2qYFv/MVZpu7vpff7KT6PcrsI3K4+aI8GVnMzZj0YEX/HNovXM4j7VbtohPW7Wyri3eRTXl/bdZuAuSVYv9fZbJIDd0793nkQxXvOWDX27VtNne4JkbTCljerwYkLYpiALvz1Y5SGk0Nyk7vcI4oBgvo6Au6qkX1VFrLbwHGtx+CgCmj2tdlxZGAdBMqlCagKGeKps7pNyAWRYZ6fICn+x0cxTrbueAjDdpnqSpc0QjejY3/SquvzOYpugkGkvope9AgDetcnFATqXlZjumCSOfUPJuCZaZbXGgMMIwz9ka4B7ipAd2a3UL0AyJCK0ggqcorP3sP0eAhTFVaTex9WOqZMf5OA5cbk+SbdjRSDoIj9oh2tA1Hn49/eHjC+0X+3Rf2dBEazaGTkmTnmOqZxdJAgBAnB5C+Bjy3qulL3telL4wBjcH/YHgzUse8jaP5esLeTufqbaTKj1mvddTPJq/o5/kFJBEnzXiuEjgjkXvXl5ml5PdvnJKgURc9hN2awrKMPR23bWMRJJF/UW4dLe8aeuGI7K8PzgJDpVmnnTivk5YpQEZn6hR4djoh3IPh1HE4Ji2UdrSiMU7oGpdJDsX5zCQ9mrE0LAWpWDsW4y2BOHN7HJcx/FfNKi6eB/Px0v1UerT1VwILRsvs6p7A+tOg/lA15pRzCON6GjEUncH3ByaUO8f3i//tfdjqyo+jSua3abqr6CNea6Z3NeQhlHeHN0705/usPFxoIJrBvvz7nLOOmpr0Yq4U9o2IB8cGjf/gnq2mSwHEd8LrecBYNSrQzly+8p84FiN5musT29d7neAND4akIIaGTv8nia3IbDUE4eYoaWZ/rhoQrOjZ7U/t4K0qVtx0Ff6npfUpPgaSDZBchcuvkxhcTccx/5nh8XY0YH1IFjLGi/26L/b0UWZyO0pNyxwHLHAcuN2ujALSBZCXAcscByxwHLHAcshZ9uwOWOA5Y4DljgOWOA5Y4DljgOWOA5Y4DljgOWOA5Y4DljgOWOA5Y4DljgOWN6eRCBX8bbfthITFdsb0li+uLfzNL36myA3H0X1NzijIAtdGDUqQdfmDGxXxIkn5jvmQgbaEzevNwzO2G6nbM78t4GC8NWgrdJQG9IZXsG9BI5b/YKvGkScllb1yLix5a5SyffU4Aki+RermcZdastQS0dR9iu5y0U4miWeizmH3Up/cTDkUIejyPwJB/qXl0LfxJzsa7bx0MIdhOLl9WAJuK7Y6/Zfz/zvt8reBQsK5LXlTLL+onORZMQmKWH6XiTchRZwahqWusYh8c8FZWVlhYdMrBDITs5qxNAGR0/ckB5FxUwN95QlJBgmLBZa6pIOJxdDgYrUh7zGslTCXUEbU0tnyaxTGsMpf29sQetjKG/zT2zjBpavwCwelx9GdhhQ7vWno3q7ZPQyEhGbMeTvzXq07tlMx5mqXi4HMfzf8nAUbPhbkUdszKC6qEUda6Sxov9ui/26L/bowC1Ovv9ui/26L/bov9uiKPycByxwHLHAcscByxvJGIOWi4DmFIg0QnL1pv0G22A1je1UF1bP2DFBNsOPibR6jOwF6U3lTJtYgILYiriOmn8aJgiWZtsp0CXD5NgfG2yk9In0pPipK9vE1xZP80aezwWUP4uKXGA7MX5jLy1DTZCJAto3peHSySh7S0w5ftCQjPYdlBPbXGa5jq/h3SbXk3IIa/Ow5HG8YxAvZcdENw9C+w0ybQEWn/sl9Fc4x0qYpLhjO8mckaCkj76qH4nwKHpkBOIJAWNycb2xcdXUy4+JcuZFtLYoNGYbFAp/rvnKZ7QbJ0IstgcmH9nIakFcRCY3qUdJFa8QWzLhpLHQ1naHNT9QjXHGj1XK0JWXrQLkhg6OvDM8LKioDmmFikMrc5Gr+GSV5k7nHjLbtTBPAjsSDR6g88LH/vKUFCA8otrnw07sEs+vgSvr/OeenX3eznSSh3FhWf2269dXFHerIvqWJdtOdOdyszUdK5bjL164no9KvvmGszfO00pQCfIpXSiTmnlfz2Bja2lhFmzrFZtpGKIeP6TCcYj4EC/hKzXKO16Dsge3RXQYuUrk9uxCfk99qVt4n/kfruMz4e/o1ZXS+/kcJF8bg1/KKdCqy48XesnFKhEl8Yx4J97IVcXXpDXaLjjyZUQnW9n9n9XjzM7bm6rlez25frha8Bd3XmRGPYPkPsFrFjpvz4otlBy+WnOxjeyzZ59hM0HhCLhABqi3GgsxtB4T+U3eJ8peSZrlC4/2kmIyR7jbEG6QI5Al05WMJA9/W6GEcxrOMsNyxDq8VKY2gDb//vsZUeWYtQk8pKEvJ0nmIutLlTOxv7lGXlUWZTx5ONapDBOTCDOXEPOHF4zhf5ZcnH94VlW0VYUXTba+3sR+U8akmuNkgwF89niNF/twOZbb+TqiU6jibHsnJBz1AoOV1UGqKqGd/owuaMoMqBdWx/H3l+rh2exXaCp6RPJbJnhN4DljgOWWN/ycEM8sb/k4DljgOWOA5Y4DljgOWOA5Y4CJXWyOmgL0MonsU2wBObO+Uh6AtDAsEYs7LTQBn4ZqsUgCAG+bXz3xA4GHP0MVo3Y6ICMdJhBDnRW1wiACEqUZTNrkdxI/AvVzJtCEoifMm6R5dwHvFSiku9LyWECvaiGGYl8+RYfEVGex4i/uhg0TIZaHAn9hYreoPb80HPdOGIKkv1jYntu7cUJWIR2EcZenAe5riDmbZ7RkTqylyrAlXO4daK1wLGEcM+Br0cdV/XXa+SluM4xt3r/LXJpSy8rr2OeJ2eJ7hG8Y5fWf+q1gDKh9frwvsrcyxtdLucNQ0kHtIgrOmQLkS2rx/nH4OeeAxKpsl+yO715wremovpNvUo3CoM2Tz8c9LfF+JSR5KIo0SX5bYtKl4eR/qz4mEyssHcpKP/VWem1z/XgHPX0BeVZWi9/CliQSaWwicVdr+XmujUSN697TtfVA83ptZ6Qd9xgykOoiQHdsW4gBLlscBFaihFtY8Pk1OBdPWH0/dG+4ZDYPPaqPrbkJa2H9TuEenrGx2uSYnA9YQWSFUDmAlZBy+JDJRLYZ9B6uniV+LaUJs8LARgIWpxtCvQ/Ibd8lZryphzo8NdncTAsouXmhZwkPKGJxuapVTBzVJiJJto0F8XCD6ABRTirtxgvztpMDl66SRuw2iEVQ/fPwU+qzjaZXxNKHMywWI3u/njuxfqZBMsXMNsZ9o+nCAd/4tVoz3fB2AAlz5Z+O9L/TVx/97YnuKNSW3mbnljptgLQikfK3X20gD5B0FGRcByxwHLHAcscBLcrknR7O0FHgabimMrdvGbfsmTzQb8tlujx84lAgd1KZOFB7NfqmdmzGrkcADU6KRvjLsMTQMWiJuk5no4gc5wDas/9ibcSitR+nn+ov1eG/B2bzIpbK+Ytcl1JAlMecctBgUsofjIN2UdUMNr5E6wY07BoUGjZHcEjdeJTfxPjT46XEgs2EiCgl768dhiVKGPTr8zg697SuekgFAI1nYLyWVZjoMKzb4l5yOet2DXHFoHsUTmO26fdageLn3TPCNumRj5qETnxQGTd/9gjfd22/cY6Awm7HLgyhosVKsfDEJAfCp4ShkNV9DhVRs0mhlbXRf7dF/t0X+3Rf7bo9YdUn2r4OJvVgpV0/IuekthP3C2lPisyN0rVBHsmJqocx2zD0if7hHzgm2MQOXcEJiT8p2BrvzVopOWYypoi9IZMcdjKZ/tC0DdyBg7BsjaWxaJ4DBiWQ0ujDkdTOMPGjqYPgQbVquY3NZNSPAmKFNxHAsoZIiuoPOJYxBKpNoiy/BW7amfqzXVmttgE0h5nJ936PiasqIp5U6AtbhpqTLVrhFuTRH9N4FjP5I56UL72A/SeAKh1EoWGffAjJH4+FgRvTyLhVmry2cAzuovrc7pTufJQ1ve5asnI8mrYyQ1TWL699lQXTdyXamRTfkma/37UGR/8MidfJ5Rdyo8W6xbZ/k69FoW6Ul+nWqXgRFUaRlAt1vQo2COEmFtsV7OKmm96UXnAtBnLKiTfWB6IAVFdkQoQbgbl0XXnJjUIrvcSUymZkWSGgsudMKBgd9r9Mi069fhOn5q7OUkkscVYLD0IQQHiQKexn7YfldidXXsZLidboRFFB4wdn7N7Gui/kGJZLoVPf4glCZ6A0WtESvALlbl+Y5HLCImt2pcRqG+N646QP+2r7Z+Fg3avJ0cx3A5Y4DzyzXmeY3/JwHLHAcscBwe5IpOnp4hCyz7upPT3B3z2Uc2ZSluJ+naK/4X9G48y/jN4sBFesOT3AlfkLsp/VvPN1mr9LmRU6JuXKvPvAVNGQ18WNdWDv83X1FV+Cp5cYd9kSLWutrYVqJID6xv/fxfdH57z0/WeR5xliy5Gma8hZ4b6W0m9CnTohNAXOkIOP/DGtx4lN5aV+OEW46WLFq9YAmc+BgWMZcOeJrNKDBHVNPD126sJGit8ESJ7zAQe3lgNoiPOyN4b2deExPYdo9Z3dYffLSOA2ZH95xnHjLG0LcEp4iqtAwCgr9MOliQXy78WeYoqsk27HbdQud3tBMA3XkHCUmOxRZ85G4VncGMtmjQaFjd9ISgLNjyRN52+O7Til4sQtF4V2pn1yBMioITkSDX2u2b0xwOqnwkrqNei4962AtKa076ICv2n6OXxWgYhdUGUber+L+k0gly25l64DFJtnWKX5E7HN+YA6HQlPVDXVikmMnxq0VLxshNtFOpDkN+mSStzPvRbiGFccRP7910tu92fBprMQ2SNZXs2T9xtupzGui/26nMa6mlo41JuzvAcscByxwHLF7HZLEipMCj0PxSvqQy8zy9RCC4O0OnAkXw0nYY934haBs4c76dudj9lO268DBy6Ln4ckDtWc89DCDukbiRe4K2NR1/xf7yN4lAWZLGziodBN9XCAoeBkQMEx05FvAHrav88UjO5+M5rfkdkDUrsGisD/W3e6yHqB9v5nwLSaHPR/OQaGp/H+rLgE/fQFKnN4fS9X/d46ZITa42VbAWzqo2oGsFwWwxX40aivP0YnjzxnGyMz82Bf0lS6YkQon8UNrKgQ0YcC9Vt9GA2zXhKFobCzk0wgf/yME0KrbI//VcfYYpsNLJyMDN/MP4YuMeBIwBLXDofZVITYmULB8GdpnErdsL8y0eiYMZVJ4AQVkpFWtagIb9j3Pxga+NuWSw4VEofc3Ly7ggXPiOIvGcsWeJ+XmaDPaMfoAce+KFf/U2yzp2rygSZ5Y6X4+b/k4DlYmBLlc2QL2Vm7f6R6dQ2H+0PwZsd6Ra8VHoqr0UtbcTBq+7ZxGxRyIB0mv97scJEZ1b25NvWtC5Q9hQ0GjtmXhM4+PqE+AYDdEYlC/SV6kKpec3Geqf47UI9jmMWY0n3Ioyc9IyHQGpCNLClh/9IA6UtxkdOzgxPaVZYNnZ5uiOF8VCeJbtU5reLTZO+u5rLk6lABmRPWe9OfqgpkxRMnaWzvAL/ZYcPoTIrunnni6egn6BVDsDwxexjGIW3ZMrwpiY27xgX41PnLkzu95n3HLCfnAgFo1JvCgeBj8je1FgqkkQy1xcZp0hrGRqYkohYNtkWqhoP5v+TghnljgZXgOWL7eK5N4Ir1kTMnAeRqK3hgOq9eOxrsqF3muwqJkhC9oPfV5MWn/RtbJbA39HR6afOGBgGqHCGFg0/qCJtdF/twf8BQP9a1c263vPRX2w46zDUpfBmX/xKg6hMX2CeWWr2T3xKmt1/zlCGH/M3ULqKJIprrAcHuVn/4kDkEeibv9ui/jQ2rrcvqo8gwlMd0k6/LmzZSWfVJrqrLxNwZDOSsyWoEjp+O8IzXNSdCcXGNXPKfoWc/p3O4vYDZzQSmezwWEp5EIKv2+JWqhlNsiUjTlcM9xEyCUVUyFBSG4tAF9+xyO0YBAg30JRkt0tl+fDPExnqdtQdJhf7yHzWkMra6Lm1OrO1yB00LB51HxgZjDn2c7qYTw6dcWNodHGAiGz/IvNpEO7LpVMxNPVt4HB3w3jPkBw9DRWzZT3NBdS5SCGFcIeusfXi9An9w9nbstCcGrPXp8ra6L/bqcx3QdnZnmP5v+TgOWOAlvXNSWXgQyg4eRSGPM9acSJisNHDUVIsvAobbpVTNbBd9E+IFuUUmmJA9Teu4yClE91uO9KVZfv1uBAaLpKJZX2HIJws3qvgGR61TozDgIEE8CgkI7O7b31OfBK+jTIGtn+kvjIKLXomrXYoqhF1iEogc5J4X34HockqpLkkj/3HTP/w3APbWQmZH+AfVn+vCfpGxppFatERA6s/mndd+P789aXC9AlxoPNIVD8ISVO++bSDwp6Emytya9cMW1rBIP5X4qqD44Savp7CC9ixKiN7swznf2hlNocef03ezdDH+c3D/Sd4fhq4LmRnrJu7n59KZ7mWcK3MPoP0Grft/Pk6hrDL2J29oR6fkFJ+wHKHH+LOkfWl0dyDXTXT8veIUVPXpxhND3/gQrA4QYo/4EZ4xYQbqEHAU5liv7/pVTH4GW3YtYyBkmso8E5I1x+gzrTvuCwcVAUizGJ76lxpSq0ZQO3oEn6fFUuyfFtei984QA8lmEsvJgec27qmc0KdBLneGtMqYnt5BUViUP2yyINaCB9gqfeqpYKJ/gE4CB3kuVqYZwLgPwvT1dJG7+4TA3/mPi7iOr9204WpSTxQCEFseArAzLNAuKtrFMLLuoBQak3bzZAzZibjwVvz8KPKtya8Hpn6+54Mnn8DASt5L8rrKv11G7RAX/Xv+lWNqrU82Za955H93+H6W+TIZaSZxhLmDerv6Xlp7JQAkPCR9PrDO04uW0HMR7szFfbcBl/Rbrks+BpMhoEPWKohE6cEL7qknu7gmGtf9A7oVvkJIqH+OA3ju+f91K9/9gIMJmfuFf4/HcJxslobWjuFRm21gezlDSINPDFIDACRyNOWDsscQyquc49kFKP50MXDh+dhC4jdcnb2y7ickeYwJ0qFrmGkDxSSJqeN3odzBADCT0cXIUcC4JRwrWQHs3rE4zSIdomZJl5fZ/z6cjVxf7HV8+wHWywqgzlv4fgiaE4nwmY9g/Ns28VRp1M+4miUneTZzKkMsYQHR8zJnoQUtPJgPmdRwcOlg/F7t7On1XYvcCFZGWjtwwBGmnRVJHMeOMGGN+Qtws9GX4qQ2H4yzKJYN+lHzs+cDRd6E8BKQAnJJd2BsuWOA48NUpPKaDLFlyPoDo/xuJlH4fv4TouXrRS+ZyxHol/Fikf0lFqj0tg7n0vUH3vmZP/LsgIWdiSt9UvyTPod41CccTjY9L0aGEvjIhlAUpfaidtsvV5nD5k79pUL/IShk//8i4wzd/FDNwNOZMt3QkPvdMMe4jsJZOSKzHzu3iFirBfclFSu8Q/6ZJoff+Rq/xRJYms4B56capsVPVjSlwcW4O+NQOsF/rpaQnG6nie6a1cNOtMNfOjM6NjNtztcrzztp7hfGdp3ZAguatSGpOCNdFVTmCLkbSejkNo3zEwMrK0bfU/vR130eBXCgOvYXS9zKbNjpurFoaFR4KtDkFXJSsGyyzXmd3trM8jHfTNDhmUNYkx6IIx5pAIAXx06J5knO3pMwFjLGi/26L/YsSPBp0oa8u6DyDoeKZG1cyyZWZoLbDlKb8z7GXn7DxLJhJ7tRu0RvgPR1Bk+aIlK0mi6jZ9iOMGNkdUCYNGzFoR6+hAAtk7rPdw1MwNn59c2BWu5ZKYEENU11lIsOMlvD8YyPi8fhajsGMAd7zXsXAflH9jZg89tq7KFZDQVATbJa/ftiWEM8WHmhZp7J77uNYU9fabq384xSAy2LhWIbEsudX8mEpEXC98UBfw1Y6vMw/X5jPsnU5jk40n4dR/sWg/etGL3A/XJkSrYPvsKLI6eVcBCvxisDrsSScPRnk0C0hOHJiQ48Q+eP0tFFF8EseVYo4TthqecA1oucLbGOkakSS2Pp5WYnDAvfUwDYd1o2NC9zlZegXNnXkNlc4+9psBYw+UVldSitsX7sug6YytrkIo0pMP5d9Lu7aSN/+TiYTu6MARdc8ZSSRN1BhpnbVlB2+QNtS8ftt9uFPs78gsQv115Qbpy+DDpZI3vb6T1nZ1TYkPqpCpj5WpVWcxt7AGtZNNxonvjtsBMZqlKeX2Q+af355eEC8y4Z7vJcC9Q9Q3A9dJQuCbeAitYANlId7VymRs4TEo7RK03bd91SjyREFHgRRjEFAKl3uAwYecu+qCAdY6ME+6SUuVte9LdYkcvmAKQRb79xPFDDwqJzn1YCayBw+OCvPS1Gv5ChAvU/Y3mKt8xgrpMU7qBIUtDLKBVMtc2HQY/Bsa0vCHPKBUhcNbUHxPxfsmLK+V1QfCoH1V0Ys8j6gKVN5/uoXQ/dZ2lGtrCFr9JJHLw9aEos7o+wKmshr5y3fouAMglb1z0kE5rZROLp0RD5poOEL3AhukF4xl7EBPTbLSqhLLG/7/nS9bOkNwKN6qBER+Bomqh627o5Wuql9jgXkSfLjapFEEgByzJk5NeMX3yNS/S8Lc5iMkkjpSnIEH3rSGeXVeiML8uAZjCqvmR3wIKMxP8nMJuLWZDl/p9yijN39CWSDkel9f6vQp//h/1KWlGmsaAWHhpKqRDTLebCD9G7LG8LOYpoHA9cBrKNt+JeRi899RIDn6gsUzNyJ7Z+FX/ksRqOH0yJp5KOqkQLhXqrYB/t7KRTcEBYh0wGbVEz1CwMoKRuJrGd62GReQrYTKaJIESdMz8AluO77BVSsTRRNV6lj5hJquipZIrqTyAdwgLGP2Tmlaz/DUYN12fuI/fkoL2g59O4GQ1o+S0Jav4SRJeKngyMPPtxnW56AUOSFEe7Yu/iSLm6mGeCUz8qB1DmltpQsB220l54r6J8o/5DeMBnCF7Wq7+v6H/c63CCnvvjsueMZfav+Vsn8UEudlFDKo6bPfd5NdqVrZFz7jHvZY3OlATB42sESch5x9G4OV5oD2uLFkL60MgXCvdfsAVbNmgsntNYFPuR4E8GYInMO8dbFsSg0ixrAfwDDg3N1JhrCTSI582i5Q0hDUCi9fjw249O6vwV9Zb9owduOa8V3MtJsPXvoUP3Xv7Nm0NSt/+V9vsFMGgVJCNMsHV4Ssr2d915P8A/2/uj3KM5YaL1dNpe4j7WgA0JwfmpZN8olIxz6ZPvuR2clUYcaA1fHMvw6fXkqmdXUZ8rOMD+Ni7Z1u4oEhibwJnHYX65ujF/MJPo9/KmL+Gn8x2DDINWFu7xSnDrgQRiiEFmTgOWWOBpSQeo21jLGjUNdF/tu89kLu8dDV2R3QaW0skTEKer5PZXp8PicjzEys4whWQw0I1viKMn48xc+xlq9Q6Th0NxiDIoCWmRkfX+GjO5B9I///SEYXnzXbNPRnihj+Y3QULe/dOu3OYc0gY6pCWJkrtjd4bgNXiJTa9gV8oezUr7zc+Zm3LuPet0jDvqrswFj7mXIGdWBMUEpOfNw+ZoR6YCPBGc7pm1Qk5sfIbA4Mkkiv9CqYgOIed67tSAMKyAWxZnsRPFou2qcVFFuiO36yk5ACRlOTcTBO4kBmEhL7ry7snQ3zH0CvyT8pR/uFgYVFqeuYKUIAyrxgNT8QrtTXgRpvXvnBFzbvO66FMWFiUPjx31fxO0h4oO/KPHxMsvD415FD4LiBQGmmWByxwElGQ44/HS/zlJZXHn+RRzK0LFrvh5n5DTv7xOL6aBO20ou5lnzI3FKGRKbZEUQoxuPtq8UaUTKsJ/ynDXi1DI05tv/ZtmyAwBUrzJbzgS2Nk0d7I/eC0bH8C/WpCGwLZGFG/vaCHfx01WrDyQACX7v9ui/26MDSGWlr0HZ2XleptkSm2RGPlgV7EKNjKpV9ggmjtsvcXygCjmSpfhi2HAZ7fwN+OuSvoOsTdQHT1glpU5moFPhUn5SSGtxUJFYIEME//QOCXYljRIkwNSq/2FBZuRyWeXWk1LtjTH4Uhf9TusTXBF1b8zJIe+jHilDbx4+yqd6EK9ZlUoWdxpx+CIzLFKCAmrj1dNluOx2ZevCKqhvgGpfo5RomcSWKIJKFTVVB4PoBPM5bZcpJWqTp7XrQto/aVPBB1IOD/5yFdY2UM6VJZwAq6hUne+HpjlpPydMSpgGDDnWWJChTg9IvQzh01bgDNHBO2fsCrMaVrmuMM4ZuHG1lAcuxnYnwQ2kNV20AhgI0zHHT0/mZuMzUdv8aTLG5TWk5w/T+jNjVwtBqK89Xtd3gGjmmqxFJ/CsjVmNujRka8X/klGKfpRcWgOoUyqNUB7bkwR36J0jDr+31UgXsbQi/9cM0y6l8arB3dbMQqGp09uByZH47BeiIpYw39151VKF/Y7hKA+PcyWAOII2OID9weuoI0DvvAwkO52EVE1ptZua4LRVjpAlqKSMJFWxI/4iC0PyUAVMEWkgH3st+WgnIz/25Nwn6ejIfGu88p+hvvWigo8yVu0iDmDkgtJPhes5pS2KuoVfh9T5ZrrRln1YypCj+e7KvopeQBracxHv9YBD6SeJeklHa3Ch0+mdfCnsQXZE7KmUrOw4w4o6w4IrpFT/0knYyuIifMcqq/N5lGdCBfTwpFDmh166mMJnMmFmd5NQke5RVwuSFBPn0T3b2piE7rWSm5y1BSUuLpooDFWGPuI/bo3FDo1LPh/9TcUqm2WdNsiU2x+hx7Td7zO0V+ejXRQ0XrZeu9XRjWpdM7a4+H2HmceSks0oD29mwEjNdpc1rPiSvi16nc8vxqpBHJG18lvGoM6x2ag8gu4NtdpmAB6epRatkvP886AYXhQ/IFZRlJFXEMraGs7scWFYdZLON3fydgn2MlCp7512KEZDwu8D0HUWWM/FUJtRFESvHsK6jKJeSvMwvreMulmfbudu/0itCSMDrvnzn2Fz3/P0Pfgh+px1LcVhPseIjfi8ponYyC4Es9Sqr65jywSNkOOkjWZZCi0uuKaflaavwGcXna6jkL0U/BLcLdyuSPqyoctznoyhNA/GJ1XUoOeYGE7/24cZie/Lvg1+YAJGhfASY0UKHhXTs5oebHniFQxw3mjidTsd4WQNWvMOtIVOWbPd27ewlfTgkdEY+LEiJnK9ltJiV97C5CRuQ0S2yHdGTSqekS64k16dptmd4DmP5027sWlr4ZZ2XscG2yIzDRMkM2AkrPWfDH3IsxTo+y4uGORHhqCOHvgfW9/t8mihoZyoRK+ql8KLNhsCIfZ2ikQkbrNcDo9jYyWmpXxSsOqT2LR1s/boacABgJW/xP99uEJv8mQk7H6wycj8lY5SQOLV48zwJP4s7UnJpkUcbBuPXaGmm4ioyMgreElhpJ6Y2DAw7ckxnCqaqEOn4j/krXu6avo/TeN8hZZNxSlY6LKSg5Rk6N/vsbm80N6jZYBKbE3x1xzFGL+k/F7eKO8XMFj+Rou8kFhPnA3PqE+UIsTc3hEc+zvk0BehFEEzRDOMnPxT4Wa0OwD72ycrT+KeNeh+AQKIH0xJC2AaQl1xJlWosommwQ9xWul7rC0pAtwUzDPzXTDnGY+hsjwUDG4dYCFb+n17+Vcy01wEccluPrefn3dsA8SYuhVT7kLfdBI19UmPs4biPVwFL8cr+82vrQatnubGSda8L+FNN+YZBrwtDH9gzTJ6HqnjaXq+YQ0o0EuoEqCG/ATY7ra+lzhqdWozSq1B+wqaEZZ8SU8yiNeecSkeZwXfYSSiRP/f83/Jl4MpNqYerPkcm/26L/bov9iif2z0yhZUV/l1C6O53QXwfwyY3WGkLLEYkzmR7Q1UVmi1+4/85duffJx8VfN3mqN71k0LsGpA57PJ2LSKVsD1yLFlc8cBgvQxhJSbCSZTYCZG1rdBg3eOj4R8h8CyOcj1bODHfx01SHJOdG7jGCqrB1Jd7+eKqcxU7xo7DSs1JeOeN6tDzFuUyPMNfKdPXqIRrGoMy3wCmfUjGbwMx5jLAMhtPGfB1aj8RBgYAXksIboSR2kUAiuMiYgSYA2RJbKm7jSwH6foWSrSYokCq3D8Ptq+Q3jlwOoCRQNQ6MNaFakpxKmSYNOtVGuAwEGOGI2t+mf2EOw19aSDg0eAHJQttvj/86klBv6GuojP71IoyadYM/sIlSpjijTORreBAgo8Dr87Kbw94pbicMX7LC18hOiHFGFpjMponfuyVQJDiOhkELU5jvsNGyu5M2BITYVeb5LClmfQdwhnlmRJGAPPQZnzyzXmouzZY4Dh026sSz1+NoahA81e2VxsrV5rZoFkwamXbhQaZl0hWhjzjWMjMj+/tC+0kjqz7RB0nBrLGMWTD/ymyyb0+VN0HH5qPPHy/YK7olhldmXDDb8CuC2PK6XLnSB6JoU834Hj5+V2TV7i6Uc0h4hTwd5bhX5+X3kQJpQkfwZdSOb50k6Y8BQ58GKri+KhYyVEDv9Ud2CzzmjXfqB7pPEOlDga9+/3fwiit1c+6xwwQVSRrHQpq4lcbt+MJ53qzHx8YWynCfWoP2begkbcH1hMTe9oZEptj4BWhrOjQuF/Sw7SMRxqh87jGXMeB9PZPd3i1VfIJdEBUIk8zRZnzHjMcgcscBzH84GguByxwHLHAcscBysBqKUAkra++MAi6dls03yXrpNupappKcjImd4AnZq9lOhXzCTRLRmfaaL28se4ufSP2XKdGUc+LEVsctF6tlfDlvxHqHebmTi7BJR8GPHuAP23kpWAfjBlHrFTlZGxJiyPYXtUvg+wzLYckFqP7oGfpZExqQ/eMC47PaZQs9W8PBsDG+TUO8i64SatMeYk7eE7Kt4xzXFZiV1Fp6a+j6YuS9OCDkbHfIYyyb2RiRdyBaPkHmO31ZjJg5/s46HOHCmTl0iw7F+mQHBRJtTA9hg1t5YY0KgjA+d42tdaWbNagm0iCi+ATEBhamge4z1g6grfQ+ozM1+HMGW18aCMhRwKlQdnvGKsHAPpW0+OGztffYbGq2NB3CEhgx+6hIMYe+KnHRU+fBZev5mpQ7BUeBGHY2QpPi55qxUl9km8y/a7GKw2oojLKm5w9X9FWw5QvTcgkKHeA5Y4Ici5pOZBf0DzP6B3gIc0AeNLAXH1SSpWRoujAVi9QSPJnSAlyJ90Sqos/A/ceDVamrLs0pbHGmvL2JyPjPUUOk3g7RxE88UZFKuhxZsQYk6V+Gy2YQBBJqu0bcM4FNyWiWEF+7ZMdZNC93U83fdnv5xMIHvwl/yTI4620taR4if20cBNnJpJ/kErEceQAt7QTXC+5/qkrVeh/zkEboguyUU4LRglGbzdRqR+ot92ACwQyTUqZuZilc7kpRy8tr4uw3u1iruWfpr8OzLAwU/eISXmQKYymSNx509UlKFjXs5hGNFa40cEmaT7mN5VOLk0BqI/35OWdxVVnf/Oep0JebqkKiO0cIVD+EQS2ilkuJyhwJYTuQ6lSckB31H4YItI244SPDm+/AS0ElIcJ30xrEqDcOlzW869cgocjSp/gw/YKfM5tH3vs9jUyoQ+FP4pV0G6aHN4tE/BiUo/0RDJIO7FxlfX8xmH+hsMuaw6mjuGWjt0aliGWjt0X+3Rf7dF/t0XThzQwK0NFrsU5FNrfvvhWvf7dF/tw8cVuahwfbFVBAkyb+HGJRrzAOjeONVoGslHdzEeRtMCMI/36UHnnJu3sLeFkumfdDKbxbRviuaV6S/CCidUAvqtCq/hTT/dxU2H1iLgBURX3iSfTL0irUyA4+Uk2ZNw56KTHMANiDALGWNF06XMLxWlGz3z2D8gj8o5X9QDvg2tuKm/1KedcZgn1b3I7vsTGui/26GNNCAJpyn15YJIqPW4QGptZvxXxFwlhdQdQ4lUEIQspRwMFD9kdb3gV4nr9r0G9Mb1DRyI/NJhi26L/bov9ujA0hlzWeg7Om2RKbZEpq0a+p/E6zQUiQ9rSNKZhTSrYuS5SvySdASyDvLK9UgPFd9taxXLnjClU7+y4qc4mO5iWnCfh6rnAfxblGkr7IU5fD6XD02m8iYL9blwhnrRqTRViwp2mwO5/xHDQebMDg+D0Z0lW/RiMSH1ySAr2Vsr/m7fRZnAv1WbmzBAeab/GUKVaeZP5fgZTSo1lo4SAlSLCluui/qdvGrR7bB1Ri/5/MnN/4IrHfqV6dWu/w1FLx0L8RyvXUxSC1ybR50KsFkolRuKli2ui7qytBd/4j7GE5J5SYXEQkSl2QGL7R2y17vCV8H3J71MwfRDDZtuKQCUFeptkSm2PyeQq/AK8IUjeusrvqEZY0X+3QfViBt6s0AVPML/cfTSrr/7rcteIQuyr18EcnpqgxKHz5FVMYyIkG2Orv2FVbf1LpOg6w7Yd5M0FL4VZC6ES/V38Uqn7uL+lQ2dDSrnaEP0JOM6b5cXmx00/1HltsKTU1li0Yp2ExY7tqTkX23zCNG5yVk9cXW/KOHsXGO4IwDOpakBsZRQdNRVKWmjajTbg3XLpRxFX5vyw4Ynea09JtH2LorCBSit8ja4jRGEAMK5A9x7AgJjMzAl/ql6nK12R7FLC5ntWu4LmrK90a2JO7xxwpKW5gmTBvOIH4g+/nFbFnlcB2NlFaNGUv4qo+6yCAntyN6/sbM52i/MzA0M4bbVyDy269WVLQ84gG34y93qW1RehrxGz7U4opryfhS4YIAvAbDdoLyDJQEgpt8/LzdtXNq1okL10TzdzPyK/XlDzIqk7bfjUmocBB8zRDW5ez51oFTdze5e0sfq88FNkrVBLa8oL7MMZhmLzvrqwFMsGXK5grtbdURa+F6mb8g8/wL4u7vAC6AW31Wtg/Z+EDH/LifNT419vl5iuoZvrmq5BEJYnDsuwnaxWck3ocMei+kxWhcOERpCUAZ0FqvwDpVGNX6/P6E/zcT8Cd9dXUoctulqLRv8JxqnJzx/7oenW+23n0cw/cgYsi6pk3RpULwBUtN97gyUoiejtYTAXTl6Vk25kNogLhMn+fRzYRDpXjiBJr+sZbCVLzIW1rDFArfrgAM6CIWofOxj0PQgCJRwHbfpmJWEVVOuVOmgCCn+yUhPa1Knq5hbmSYXeZxUBjuT1Ds7M+g7gcNKxblEnXZiiQYW9C8BSFE8OCuaE5tFMah8ujGSoz1qwQWfM773DBQi9F/t0X84UJLz5sxF2LjGe3D440u+kQsY8nU/7sFX9XmRAG8li+Ye2X7TeExal7wxPywkczY3ZHNFADp3UjF/785C5IGjAP2pEL9SbBihEiK+MD7SS8wRb6RjyHXViw8BLOVgVDCb/4D2HnmKHNudxT4kZOvNeJSM/oWfDjRwmnbj+crKElxCUfdtL52AbUdJfeewGa0M4uOdsdfgXr6TUP8+IedlCIeacydLSMb5xuSSvT0ylqZ951UT70LIbukrrEIgiOfEjK6A4Xhd/aAXgaMVzy49WDUT7ouoUziGSYgljp5UDhpYO5B4qHRK0kvyQU1I0wr9e1Mu5tCQ8o+k17HNYp2vTAVfZKrEQhniDkLYLerU32/rB4lMckgEko+sptno8FpTQ0I5qktigGbTDHiA3M7XuOsFTcKinq017j5h8PY5VnSavqfOr/26WT8CgJFFfzf0R8VLMfn3NNAFjQn6ncgEF7wUTrzsmk6a7/0qpC3fJdF9kp9vaDNAWxYdGCNIXFGMIl0wVTcTWFuPBN6gCrTtxw/W6rsYLQ7K3wlTaHAc1AchmlRSzNu9Fq9cI6gDW6T+QVq2FFl7gW/Skk1TSyi5LhTlVgmU2DhbHvW6NS0bXViWv4YSD38U5QhixCssAulLdYKLTCwBqztkSaeyQDxRLSybww6JVI+FMaK1AdD5aYVy1TIdDbKyIYjitLqgaQihl7M5luUs0XW2cPkG3HpceiFnehLXGGD1jLjGH+/DewPdGHX88JvGx6kMpgnJOFtR6xbCKgZf/l5iT+g35B3MqUUDww7L8NqZCjrqW1K/A0CMs6oXpXE00r/BC/T7s4mz2RjKERkrCWdqUFBJxBp28S/Po1LRan4IJg0u7QSZHGlTMJhJRQ0W0JfL70yJTt0cTVRwrAdAeg7geeOZssXz3HsUGsZBq7bozjwZW10X+3Rc4ELb4Mv52c0Qz1gvStBmjqFafbrOjnE7W0SaR8+dj34vW2P3/XZ9taVa4E5Ek2UtMOR4fnMsC9dR72MG8a0h9DhhqBcirb9TljgOWOA5YvQ/43dcVE+uYioVooxXDByRetuXg6elS9KzGWSvUbLov9ui/2VWKqnzBmUFvieMm/9YGVOdfF/fgHp/XNE+a3MYVpfoojv3S3A0sSKNABXj8pIolBUIDmVLYku+5ef8nAcscEJZY3/JwQzxwHLHAcscBQyfI+UYzwLaViCkXH1xxbUc96SU09+Ucx8ErZXNDomeSeE79KU34VSvu/8H5V7Pt9jTBGqS0Oosw88XcS8WZtmN1m2ctTesllAqqVlqIRieWpeRp826bPSdqGfaRgbkptkYT8UIKVqwCxljRqcXzIjTpyBzsucBy0/88/RpU5hDR3qJfjArlhyuXv8kj+RyFaVmtd/+Js2zEBDe7HVH50Vg7xykqMof5vMM4uFOCyUGLNIkDiDbTDfXjMKgtyeBRQ6eBB8H/p7eWzWDN0n5R9eX/6Bq5KNWCqctgbv9DGcX8ANdhe53cXJ+WHhJAPolSfic4tVjTKYC86lvgsuP65YoA2sJHnbloI1VDLYGJhJl+YAlX3MJ3yZSA2BCvmr2I2idY0XLv9MRZ/qx80Z7KAYQXZ91TFgkprajdEyjfW6T1CVoeDrGSsUHxgBqfd2n6eXAI+gyeqt4ONEx45j+3YG8WnAjkm+RTOgLt6xrQLwJ7G8I5uw0kxEoC1VF2h9zvqDtpucVA3doOSB9ceoV0dL+U6pJvIleVm1zgaXghBJpVacBJ4xHd6ZguzRg1GUGYr1Y/MW5weAWYQCuVjoNa9Wnp07vu21h+m2NrsBk82xs7ZgxGsMsis9kVKds3QdwOWWOBoLtJLLNdJRU4GlgLGWNF/t0X+3RfzZI31qYtqiTHBqEb02mUEg91aBYW0R5cUWr0dp3vjiNCdkuvqm6QuM/y3vclE96o+hz9mKzQpOqt5sCPOcANZlxSX2ekslH1wEvwDQuw4nV6JZ10bfSxdcgJSeQeggWajSV4KksEd2tFxeYVDNAPQVhGBLHjzNA5lEBCN+/IdSuoCk/mHmOLG+X8EZaZy4luLKqLR50fsyKU6yPgRzm7oUNhxvNuWw2PJWHUWLj8SWcqKDjd4IM1Q1hRvvS1o654E/i5VgEmvAddIuY1aD6QN0QtGhkCAq2ft7TvjJefczaf4DxYpfJYHaoz5dDZRyOKTkw1+QjF+vviH9tj60IVs3P5pA7/22OgFYAhWbfRqLXZlaWUpYO9wGJ/SIIQ+jFtAqbKY1v0iVBOM9VRMaIdW5RzifheffAcubIiyhSYE9r53NldyVbvcszF4cVO/At3rbRiMAzhTCempQYl7JsCgGftxyIyGRJxsGFIJeCj+2xs0TxkHI6g7EC2dc4YZt9LDbvan1lfVD74HV+VeZ2xgmBVInJtLJ1ubjxIB9CxsBw4D9HRVni5vzpaVskEgCZqtng/sSh7FawK8ICSm9VlrDYkW0GmpFHgkluitpa1lwx+zCbsrK5qM3HDUpUZqjZCayxFHK/bD2ecCeXUJ9wdRoovAUBUxwDbdi4W3yef4vEoEnLftUvFwOWWOm2Asb/KL/bov9ui5qXgz139PToAsR0mWHCu+d0Vs1ZvXtZoRJPjL/2biAk29/NVQ4QEnjeiKNdLH9oRtdkOLag+Dde8S4BoT6QwyMEmOOn0nIoSBBjq+YYvSgjeA/sZeAHLJtTJYmNzyQIzOBAxov5tyPYj2wiazx6EpQT23+/bjAtKlRBg7NUJ0hfOW2tb1aRo6gdOiHFmQ8N3gYqOhl/plzZFFJGJVq+8NksITQnnnJY9byYl7IJo9mmeTNrp+foRg+bfA1U/CVuJWtH4CgNBqgvcQqyxImfYrxQa76p4hQVEy5AcV76QUvXrEpg/+UcH3IdOQHAbyt94fGAmBnfj96iM8Sr8k/+Btm4FDyGfNsyDc1wCoMZ6KrygwB7QVRzbpCeHMi75RkFu9OxlwK+L9G4aaEiU+WCzRKmNpBE4KcyXTdT4JrwnpHrBXHtLERjJesKoHKIKdacxIjtxdvcXb+ysRx9ByveBCpkHfj8IdtEYxahJr3eb5Eglm29JIdccw+is6PtU5LNKSzHcqH6ushXNCj5YaKB4sFZBCYMrYFMS5t29zWyxMXNV6sbAWFaFRCYp4o9jlsvbsUZqy84/xKA41bCk2KCE03DxTI+/jgUvwfo1SPKjaKlIPVkToHIPNNCti0Zq2tTVCf3a7T4+pxAPfZBu/G+xKhz6zqjLtXHaIVDRYLbc15ECKfJkNIik/7wyKD1abXcIpuCB5OmBvxZYaOi/2HiwYVKod8iLGlQYOqI0NG6yVYZS77u2aUXWJ68268x0juK2ETunhJPvVGSLlLoUsHCUAkKTFSdOp1o0Byxveyzfv5DfnvRD4hNlDB9IDQYKtQY7g61cQKUHvSUnBNo7yiwZo3aWld11tSDMkTBSbXRf7dGpafP/6qjI2f0DvAcscBTbOJpWzlBpORmdGbtGhR2JJrde4FaXwd58LXMU3n7EIKhJCI3yv7x3wGQE5ZVK3InTWg80kykqnuN3GptdGxQTMf3z92dyNjYTIjeKqCtIs5OGsa0mSRoBpRM4cdrcedmouujBsLCE908pGRakZ1JRpV+tHZlNLiVMO5qWArXBlJtTD1Z8AGQGz0W4ZeTFGvplrNrIXPVT1cX91l1meKvyatnBV8Y0x0TabncB6RbnUjUoy3xwa2Ols/uRL1IvMsfy+Z4CxkCWuPO4gfPZfBRMWqV/dgLmLcApyU9F+zBx6qWqZSPbjYtwgACIuzkmIbgpMSiIzISydtuaudAosXrI4RAjl8Td6Y9X7gD7Nrd2NsEwJ5zC2RKyc5O5AExHeQ7fzI47GgyQGKzy0d/WSimsBIfpRiwvgEsTVMAQwSJSafh2hBPbdn6/cJgtwjI7mjpRk7kwvR6M2GW5UdzfrjJmboQwHuZqN+o4JtL74cKgwsCo//Y8OkurLlYtewzTVaO++3VlUHZo0cp7wEgIQg7i0cRvy3Haby1slOQ4MJ3FBRizv2poGdSR5QJJY3oSo5k6JBnFa/ykmbDaAHiUYv6Oee+bsvOJNbflllL0FOCckjMXtk+rU0yvTFcgLiROraVYPg/3NyW1Jm247wEVqkvhomG96pQZAQW1I8Grhe80nVyRauJjCK0ZJCPwij6+D2pGwxFWEQ3POjjZknR9AAHSsdN2qyAfJekB64wVVGJwH7q158N7PGW54JtdCkZVwKgG3PxTJjRGwLz9ZhSf+Vs+VWdptc2pKVDuZ5l+oBir2f0tP/Lcmjvbo0WM4dxnDeMAHFQX2h99v40WUeNkMP42I4ILCWPgYPKXhSwLrgbhP55VH2aFLr4I1kR2oBIRcnYXAh/cN1jXT+0aCYdRz5tPVICfp1RoeyGeYB8TpZsasQLbaoj/uOi5LxOwXJt7IvCEUA38MFLeUCFY3FNTahxXgLlBibK2F+WQSN5DeCIaEx9S5/DmX+NQ4TqATN4oUnwww6JtyHo2AhNtClICjdAebma/dw2BrlgqtiKVMLP5Gy6PXlj4eKgOOd3y2FjUCTLScv8oJ7B9hltCG2HtbYr3u/a6RAuFgwBsmAYNLebN9It+H0cToL+WhWSJKYdAw1AJPblYaEFLnifJ/DgJBc6DiUjlKwYfDFY9XmrNrqYu7JWrWVIRrLZgSGgW5Y4OnZOIRYJzQJagznRpNQMvFMw+fkgt1xVg4Ntj800F6bbyphOdZFOyln1guFQ3PPrLHATgJFL4bOUATXKNYLo4ppE64gzvNR0YapPJ+dYoT/iXJqtFtR5UshhukmrN4mhQm0D1g6tM+ufRCjKYbMhwBrmQ/bxvyHsNaB4/OVJTug2zAK7a4q1W4mFFOG9mYk88ra3R6w5z52+GEFERcTmQFfLB83wnRpVoFG1ozpfeIUKGcuoTuuBSo6ax0rNTMbcEZo4EkOAPAdWEjnJ3t4Wro8qEP37Fqfj5G41q12BNSG1O6evYMDr5DqP4IswirMmKioXbwV5X0vGshIFH6qX8KDV1NzeLE4PbBkbUV9W9YdUluc/ITFCNrFKooffWFjEgHMGhfBW1aPGAHKCwWHj0z1y1PUn6L6IO+xWQyw5qNiCMPzzqKeCOqKhC3EtRYq7iCxltAA7dwoK0zHH8xeGJgW9GZ2r91KwXZ2mulIGvKxMsuJSQ7bF6ctH13d1hitBdMb7QO/VIacz/DmtxDLQhj1tFJyDWi6qUWd4eSnt5bjZHOTh/YERlsnBhIAOTKhwMfXkZGUCy85ylRf89Ci2FCg7gcscB544DljgOWN9rrGWNF/tu1dRgxv+4SBEJFw4P0aiD5uOD+IchVtVagIFV//K+GL0SQv2nXp31dFQffFm5clE9vgAexVAA3Q2kBTvsuYwnUVwAkgmPIrGPcGMc3mg1eoaHtRoPThy2alEWsbKN1Q28tuICVyI39sEfO7d92bpxv1KPio0sL1RzHdm6DuByxvoVKj5LBJDIlNsiU2yJTbH47hrZk26P302Lag6GLYR3cDn4/TPKigt1ldLP7hDsOia+hShY4fZi9N25rWMsYa2hdVGOSAfPVa8IYcQK80+aU1AItJVmH4NxDBkHyoEhKEhuxvSvd4HLUzdoKgGIbNFYXCjuMi7/42neXZcTWJhwQp8RhLRQyBd9eZ4d6Qabn3GpjHmNwtnvAug4mA+1DJUhq2u098ciZagQZvDqihCyw9ZgPCOGhymge5ycr9vINuhuOwVaDF/Z17CR/iOwl7e6q8+w+OIVIeOAPTueBcpBiDZ9ShIew4nRhT+MseRnvFfayjkQs6XVLpSG0RPWT4DEQrjWMT3U+4qqKbeopoR0cXDSPsFM83WyoSGx2ivsmjwtWBSyBNmhrPQjouY2C6JRQRMmvNf1mtYUnwooxA4TPaeM/CidpVHLHM2Y/tVLCPTg5fbnk6OWOA5Y4Dh7P6oWuwOACbjAO0NPxmRJdLQCbyEocgYk/jWu7FKvyQt+i22RLAeV15t38Q+5B23o+Zp8/GZcEWcdzVgZhpRY1viL6QOj6TCbtoknd8FQbw/ZG1F7LcSF0KGZfjtxCGuU+rlhfrT5SF0kGbbLrAowTaL7npZe5QwKXUoY/luxuR0hOJB6qdqC8WoNgVhjqdN9UcaOMOmMgaH9IK3KFDBELR8lloi4mgtALLFe/gY0hE5b7Dfj3RcH7JtrFZb1H6AwPumq74wK2QTprXadbtcroawC9dO+c7X2VCMgNtY1G0p51bbMhaMONGTmQX9LLshdBgHZ8zhEtU6tavYs27l6+fwokWPJlzZ0+UvOaNDWaXdZM2CNZdwjwwExcychBfKN1VUnYs+RUKgyjaxUlL2fQk/p9rIMuBBRq/Uowhc50S4HvOIKdEP7UUuLe4kGcetOhMsDljgKpUnByRKYXPGBLRC0IUjlaYpPaa1FSP4RoZh1T2iuArCIUsBFIQ96/T961oUzFg4NtkSmutWrjgLiamtuuTxOikEkOx///yXP0fSPEDZaIPx3LFjN+e6XuUlP/r8FcUOadVT1/OaoF4lceITFbKBa9JwiCKQXbR6pJlB+9bXXa1X2UL3+3Rf7dTR26nNZ58ra6L/bov9uhT0i4L8UBcd85Fd3RudAfKzt9rbES8nwo7B3utGaFGUvvNQCF9tuqlNGA08AQ1Y+FphIlKgUqQP26TxQpvIl/3J7ojKA4thRihPQe5DjRGH6Gn8MoTx0CogHkM+pNfP7/aclVNwtgGzOX7C24dT2athXRvnvEd1B25NLD+qXy6gGVY6gEJ97FjXSHHnQP6ue2GB2Os1ec7EKFnajP9aVgD1qXAPBpLgGQSAgfLS7axl6fQAcGUbmKaCLYGnLIAhw5cscBx/8KGVtI2/Gpn9zytbIYAJGG1cNWoKnsNkWmJmYyI/+EAYVRh3Ipxd0XqnIK189/R8BfPHEV4IVJhpLoKU+gqqFMOW++5ROwWUiDSsKxt+8Hn/57fysnD5+txmiKMebeLAII91S//0rHy+qSSf+dPReowuv5mwMBUjCr1DQAT4akMXJjhoioJ6tOqZAzU1KVd67J1Rrx2ZyoesEhUinBqwKHgIhsMjgffFvUK6E9mgdokNFQHS7i10KSALSBuwTW/CipvoAdxr70ESiwmyGacY0XSWNYOP2qtird6GRgD2VhwJqzkbbSFd8iuydAkWGDPJjvRLXm/O84ua/UCjfDibQHK1Z0/27jaJ8iDpoy3ZVSAY0Fr9f6B386wpDbid3RcyUYuWMdprZJ3dHCNGzuakoVUQM9FgxZzCxHz72k6Xw/me10KRlHsdzU9WlUI9WACbXRdJfIbXQuG0VbjNyJv0euOAwCFP+WcSb/kaWvVf+uGW4YfgEuJ5ZYwOnXLTvDDVkNOyYaOOToRhmnoNidYHj45SKjxiA9/xBlk1Z5Ls3giMa1Kn8RSij+gzVVPWirT4EUKEwTLRbht6O8pHC0Cya+cbFdUOQ4KYxNyvjDK1X/oPJ/dtp2+Rr7u/poMV/+FBpYiZNGjWurdYuq8Y5oMw7HsXxrDGpJswH8AzrnwyYvuq5htWWHGTPPu5DP6laWc7wU2Y41+RF21mX0irdv1hZmQlucCjfBBtBrtUGIlPJp5aoBfTEeytYBlRRMOYE0WmzlOXU7irpjVSi+qfWLsT6ADN7LOuA3Uh8QDLoEzWd2p5vJz3POrSBhdUfx75OYaHt0MU1nXTNljgKmuAnXkhEtQyzwRThutb0vfdlCk+Osn3KkKP7Gug7S2no5EetE6tBY4DljgOIIDa1suFB6jeW5uMA7Q0/GYkqioP0S+nL6o5tC0C5Qc/3U6l72ZEa6kXzm64ZvYCx3bs4LhHKK8AaIaTCqRWpQe7cGUoYM2fodiNTlLdmtz8jePWrBLh3juuKAsowBbopCmj8CWzUEHzG2J2HukYBhS414ZnPSSFqdSEtXRngmB14/LJ9ZSgUqpHo2H29f90fJg2b3mNUC9Fw6knTH6qo2TW+ZnJgcu3Hr7gr1lsspbwf9wO1FV63Cvfj+YZBq8hY5yaPVEh0SRV2Dw54RF7JpaQXGDL4CdSZ5k8YF6NZudLk79YrTmium3RmDwz4vlt4KCxwHLHBQWOBm5KSFoLrCxIseTJh/4USLHky5s6fRpU1HdHzUz/rLG1iKYC1nTturkqqSODvlWX8SM03p6E2pXdKAzqCOoWQuIGNq3A8fHdEz9dKOGckEmLpLquV7zRoVCU9bBpw6t15+0uKcwG3zrYzb74A4DBThhoIn/9r8jDVbBjDRN5adXFag0yOloTgWb2WYnX9p6NtkB5KfaSeBJkADHZ8GVgEAvk+tW1u3xXClLUFqXqW2e39Dj6RhH0fafK/omuZmOHKoY4m35X8UdplcuVCmUC3ZhWduGFZf7JUee5MldYxQ4UThb3rwHBGOdJes8UaNf8aLfNhbGxySvee6VVnPblZARzxBbWvuEfMvz2KTiDA8bb5gGABgNUvsEze+kZY9lNMgt3PU9gChN9phwv3JNjKVcvS/zodZEb+Bo7vYWkkgkVAsKXl2pnDpfz74J4MoL+uym0/SeJdY7ErlNRIVRelWv68T90CLvyUgzf/rNESlOA2LpyZFsS1fBYkfGLDglhYKNoV0wBZ7nERqL/bowC0igo4x3gPkXAcscBysgjzVUtmp5kGi8rYFHtzhkTKdJ9u/F4mUqcyQGoftIy7CX7W/G8Ox/8kiQH2UAsArVGNPlGI+8dMg1u2HDmM/ojmlBiMPFU4iTeAuA27ywxXg868n18hxaWtVpWRCRyhdkZOkaC9unpzAGYWF3pPdMA4STtQy/o7FGqT4M05JmhkDnga6VUUKAhjVowDPg0JXpyMVV3QnEDZ1Bogv/g6NEsx0OpHjAWWJDkwnCQdgy7nt0Y+lAzrAyamGSW5jE/xLlQcB+gR9Jv4UmmmHAY8Kl/hB5BAHMuyHgPg4ccsmsvC3lr60czpiBLsqoK/rtwhmkRKe+ApHW/XzOxeYD2Tldp37/uFNWyz2yXiMmXdYHLHAcscB6D+dL8fa9RtrGWNF/t0Kxctgt+A2bYfeEMqRZXkCqDLO3G60FjZ1lASVBIvwsTvfv851oQxzS/SNZY4DljDte6WZjfHOtv/F/ljZWDpTJm7A+IynsOu55y+MdJTzxBYAE2CpRma2ybsxYtX99xbNHXi8sV595EcVP/bf1sqLn1SUjy1JVvfihURB3J1ljgOWL/DdZfN2xDbadQcUJUHmlJQ7crU2EnTfLHMbMpfD5xmDSLphUrD+d7/lOzueCc6tiW3zIJnMxyWeioAnAcscBEU6jgZB5DaQEMA7H+2O9sWXEyCMMkjddodvQdoYxbb+4U0rw3zGu+AbWiWhfgX/HwH5K+WpKzZEry/Xaq7AfTKNbFvjGWNF/sBBcPmgz0QX4yBM0Eu6qL+oMheJdOpC/YmtW5GkGd/7ALcEaI1MFMwwcObIs1gTKC5HeEALI8nUsxG5rqP+UBLQEyJ6FslgJ1U1GPLh3AfD39ui/24XdVHwtOOdSiosdpN4yo5Mtfj/pba65uGiQi1m7tt3m8Jj9vQ382FLhnuIs0Ifk4DljgPPLNeo3Yuaz4f/U2yJTbH+D6B2QIe7OVXA5XGPuqeHuj3SVDmatJuGZu77ttG5v8qWOXNZ6b6ToEW8Soder5QFUgdjnv47djpiRXHD8bDJPyOunDqbWNrubwILX4RiNtyRpROv7JLhtTjN9m36OyQMgrfiEREKsBFBbp8FAsRoiYPOtayahhb2+3J9wkPbK61T77dUEncEDXy8tERNYTw7oBQwktgBMUND6rvBDI7T+ustecrDGTXrSGTB3gBb/FWZd34D9Heo+nBN4AdCqXrsSMYSvnK6xP9IcqyegLGQGgttPJWUhsclA3vjJbkNCvQB33PP2acSI/8kkATzDX4D2a0APOee273JVAE2BIqJhI25TD3Y2qlUR6Wq8OMFLORf7vCob0M3Fbc+KLq65bYLt+mt6/BRI24Orgj4Un8htUsMJYBo+Pp5rMZNVeYnR8Ai6vfNiqepcp3SluurOOqzzhW6Tr1/QOCe1KT0lb58WVTU/Qe1o/Y8vrSPDVlv2XZc+clqbw9iNXTn9pcRe0BaNYcjHEbNELhHtkUUITe2PXNxgGHGn4zIkuln1Yx/WXeNVwPyJ/Fix3gOWOA5Y4DljgJLiXIoPTEGWFXZFQwJo8MrGp5rcgSp7QL0K/67Q2KAKxJoTCV6QoxAoWdNm+X0gFI2rQDyGz9HoS9aZx7nadJiE5q2YFcVk7QP+bgIAZqA2BN3bV2KoXa4BgilrqYk9otpsTusdhsIdI00TEy/fy6DYqpB5Df4AQciAuCLoUI3txFHwi5iVhwrO7kKvGKpgsKChv0hQrIgzAHiuFkzxbssg8+jyZnIM+Qf194HWlA85BAlRyPn3vAYO8rApjzR0mCAQcsi0sDEymGKIqFFgU90sJ4NuhHUmPTXcDR2Bk7JzDrkAIMWCbPiRbJMLwLOOUujg9kQc4RJSYWYoYMCmrnxGe+nW1ulWceiyW5UYP0Ww3Dq/zxNl2cjrG0cy5rDov9wvqWCUgtBMdwOWOA5Y4CodpDN1i1PAhpiop3JHctyXfcl7sqF7D7X096fidy7jXvOruTmK2zJ+2/3cNkABTMEnx8ITR8xIaE58D8E+/6mUz7Py9N2jNj4bV+mskZGEcT+KL2qWBZKzPJfaxHcSMb7kWIpW/hWDkQ5ljlr2FkgntEj3DioVEvU/9Lc2Ra4usAYhs7SziJN4t+yOmmWJB9cR4T+a9K8hM2OtwukHvJCQ2VeoJPeMK3GMbWgpfl8YWRxUEZpdeUO7y6TDXCM18xrzQ4eciZdjf8mZT/pv0psexROMqUxQtdOZJrPI5ZBVbLDvSo0VZdWLZuMiGoj2dwfBSO7a4AsY0mjMLTG/faMbOYzQvYXoGA7NG9C6SdvyUBsszBS28BUOkyzLwWTjpWCGgKH0BOM0uw6DYVKiL4Ul/v2b8CwEV0Y1R0vOx9Am7wK4c3FiGvuzwz51LNn/e1mEqr9BFD7NhJWMshBvBmwvkKO+YZ5H4sCAydALT9Ev2sn0WzKLg87x4cmCaTY/6OrDwzhIEKiS0R7m8W11vJb+cfGYv/a+U2CVRZ4PMUqjQ6LWWLd9SqGXQeYmuAHkTwbKHpn9A9YjeklNGQgsxNkq8h/aeLFIlsReILjuAQKoe60pp9VlHsxAZQjkgpRiAzaDzYS+K4dS2M+aLmpe3NjK4c2ZLxg6AA+qrv+SvFv+3nCWqK0OSpk1gNrG69aWla04j++mtCVnbMe6scW+A7r7cNrgjR8OFKCv2EkscByxwQ5kSD1EBy5Y0X+3Rf7AQ4U4pFYhtBdS/MKaWMcDv8XyDQZa85CQl0aEmxz6/tkDWIF2dHaimu6MrVU7XDnhVruATWd08GzIrHiWuzo61D8vRAJXAathnEUX+VBvSWEphwQOnaiMHh1L82+WdbUKVUQeyFM5utPILdQ28fjmMjW0/MaOFkZ3WyuMnpb5kele2nb1skAO2/dC9Hoh0YgkYlTwGbhzCLL4qUjDYwnk3wr6yN6/xc4BGZ4lo37MWf1fmngWUvqqbTDcb1GlXZbT0rxsQ8QtkjHlLezJ4ebiWgDscsmix/ejEKFN3/yrL3I8JdYxPbvmdxF7gcZs1IsGk77sSD3YbbSjSfqjr5c4RNzAbazb4IfC/tXnV0d0qShyquZCTKjRJohNzFo8TDwQEEccCYbRaNwHC40asANZLEPe0EDUC3L803xuDB46BZvKYQbyzhw6mxbmyu9yVYeF0FV9TcFgdrHaYFhUlcuhFjH7qVy2gwKh+Vjc8oSuGtstf5Fzv+WWa5w+ru8yQwVqfSRfSb2qr6WXRCaJX6/dLX0G7FIkHm1MzrYKEOfIlkZaWvhkSm2WlVDPLNeogLGWNF/t0X+xOI4ByyyAmtiq8P6/C8C/NxlvMljyk3y4/Q9Oile+H0fAsW3Rf7cOlskqAN2dkjQGVq7xbCRV5VBP29FvpzAgb2ly2hJew27Ob84XXeYLA9w0Zo1h8geCJJh+K/8xa26U3PVHXBlRfQXBtVjw8lnL0gC63Ed/XaBYD/gvDL5KP1LaqoQfmOjN+ZO4ZXfWhVFU0bJPl4dyuVPjV6Hr4iQ/ll1FQFqwnv/39qVuMI9hvV0xjCpgDT4A8y+s3+3HI0XxMcOuiYgl7JPjgi+RUYZ1+npp6lBZ1qjMpz+DvyhcZJNQYNYhf5F3L0E20elh0rAC7Bty5i50FYukbeBOQ4fWRWR6t8s70tl0WGuneCcKg4M6Nr4fclf1ap0z+Ad78NVsoqNOfKW6HWxHCOubiQ33elTPgmZna/67UKyqp/i0UVoOA9ogOJYqFPGG0EEpXdi5rPQcWqhlXuxcx3h/9Rzj3ltvDYTIBUh8qyYft0X+3RfyH+8suv6B8MR7HkrhwSWpAe5hQeowM7frs7VUIVBN8pNCIuDv43kqAkCZC7lNVSTIMGIVvoNhN6oyKO2RVgFcc/K/9Y92IZjsz5ks5B0jAu/g1sDCmsPoEq8Tw+2RKPp7VQWht//Ep8LRsBUB+BQO6G4HYZkLSaxVb6xov9iF2kH7BtOrmsbJ/wjJ3KlXsqgRFzfil9dKlvd2eO3FDwKQPmBglcqw7Y7M9wes4FDptWQffMtXbMDK9RxpTdov5D9njGoHTeMDp0I/GJzd4t8hVyS81gL9VES6lU9knvxQ59kGFOrZ61eiQ17sSDPsVPd3zxZfBJZamVPAQ9NrP2Pwc3Ea7YAxxoPLRGW/8vXKYSsDoFU8Sf7HIgGPtQbrcjl1mR3Ul3JgjCOy36O3G3f8E0c7s7cLZEquHDOm3dfqHeGWdmfPHAcqwG4Gx7GmKdn2F4pBw4M2aA5mIF3+P9KwYgYt1PCN2uDy0IpeTHIqwsCHA20vxbAfNOTeBZIeNTaIHwnpc8tzv3G1SZQ/lhKUb/Bxr5F2yYF+iiDP6wvLyRZKyGkpWOnuX7Kxo56JbUxhAhTRnUiZ72eyK0cGutjWP1XXO0iB9jER0Spew4UCH24WKJXlf9cbhX0VZbaNXCnlg8asSMYy0d91mU8zynqmgv7m5FInE9pCUZv5kilzNdcJAjPYy8rWU01g6Iw6HodFCEldlDSagb1dviafKPKHt7lqjzpmFXIbnPkopG80GwQXVhdIza/5Tys1MwkyL8aQbMqjASsQWBkCiMfs8utaK8a9+a4r6gKW5mvNZlqBY4Dljghnljf8nAcscByxwHEbS1GjWhLklvsbgZDyyan5hDbWe9AqImdzxvGWuho6kt5Jd0PSi2FEzUMEuSShqWrRsaVls4BzfmdkE4njsEh75R2Xcu6WVp23sh5QM8EezsX511RTomLQWE4lIN29tVbSF2xqEyX1THHwq8tgRulAZF7468Cn2EL0J7jV9lE6lkPOpc4LmNjWTCJjaicY2VGuX/sUbipYtreIuNjWMl34w90FvQ3Sor2NldvOJdSJnF+dF5X9mMnYlfjIR9E5KEiyEVkq5o78wnHLX+1lPJwnkfyDCNi7AZ09bEMd3K2ui/om2MaJopctMX5s8saXYPn0hHwdQebYZZ55XkTNGLFgzFaJnHhu3R6PM7v7Z8Y8loX5U/tzkn877TtKvrlEoOrWi25JE3+7DoH/O7PERTenbJVdT7bjCkm4DiYmcsOzIyRfhUTuI+WYrKpmZk9IDsnZRkvzpye9pUOzaa/VaEon5y02CvIqG2fHCVmYIKhA1khpepvKRP8JPAF1ZgNIyWTtSvL9WLUhAL1EKDHwkMYA2LHLzSNI3cHIXifH9ukgMHixJSYdwMToYgb2CQINQOTYDTeuCvBWdAqxzN/E1n7H4q7Bmej6Klx0yT/CnrMi5aDnDbgePIdNAHsIMM7//f+NLzO1L8wcoMEVB3aF7pIujkMA334apmiDBr3stOZwybRknQaZk/qClQqAhxms6TeORQbEzJM9V/wroi67Oh2UIwxooWhwyQTuyJCVaey4PYk7xP6wKBG7fQn+zpfCr7gPFa6EeodYu4PtpHOfQN94jqQMKJKai8AdhlRVzIU1L3KGCOJoRc1fGMwZr9GnPgCZ0/Ii6Ij1qVesToorJiLQKvpAPoR5QLCQkNUGBO62kGUA7nidvIRu48cqPefBYksXZewYTUktMQUa8qcVIOwqjLL/alDNzN/kaKYDXd85YSkfYn1XJGjKD1hP5oOiN6r5sdIjP/hRhj0p5U5r0XsCNXNMv37Ef13EHL1ekfq8JEYE/6+J4dv9FJo/P4YDYB8PXkawI8sY6NcnCfTUx4D3Ij7ZK9sEeZ9IFizZTru8zuep/exeAtsZpbvxRjtbysgpRquYgEap/e1BTELTTTywW+qZOTAxWm8bEkODE4Ag0cgRiHIXeBde6TRkAFxAStXTigbpe40KYWzcE2gqOmJYzzPhRxdfLWDbbMI5vZqYa2juFbC+83z8U7wcatNzvLJiFB4HrzL88dsC0uwlrcpNkTDBwaJWvVcgDX25EbSAOvYM84m0WN2+0uHn9Qqa78aGE0TVLGT5VII/hOBRkAWZbauGxt2KagMCdP2xE9EDggR6LKBRGBqUmcBQRfC0xShp8ot+36Xs8a/JUqS5RRe97IuotL4Fy0bif5AAdl/99J/UwjBIqtGRBlhYR7g9wHNVjNc+plFFhQbVEYQfHsrrFfpO4I4I5GVpHoJmeL93WFSWE9wnmPaGqrF4SBnMiqClNt+1PjYtvnwKNH68GX+EamCbgSdqkUG+9Fq7wmFhECanVmwJit28twAOdpu20MOFien3TkGcAA4EoN9rS3Fkdx5CHtT90p4xsurOsq/Vpd6sgT2UjhFrh507ATNqnkZsPIOWn0m+7dFxlsbkKH/F9J2jsxKW2DvmOA+Pxfl1nudbaHba92TueBpFmC5iQFF8iNF2d324JNwOCdpkGJwPsRSXFznW49L18oEbstv8CAXcx+BBMP1hZBqJ+VGl3PXvGJXjPcSVm2ZG7A15fAggSo9lci0mbMIjgoF+Luc+S9j1YAalOW+B+aPXFgrEkAuLWOhEMZqw1GjNRr0028QbBrcNkL30aW8x71oD9+KtyqfxV4meCfk4LuCkwPAKjiVdL8+PbzeLHLLzyxwMsxwNBdmyuZCJUbiuw10X+3Rf7dF/sZAORSueu2RI6oWXYp2LPkrydcz7uvxyqTGU+pT93cvkd5e3lkm4mY6vBUoJ58tg7vBYw8F4Dx6O5bEDPII+JzRlI8zr9j4Groqk2T7rDZYF1gtC9v/2CU32/khwsSFbqxXeoIm3/WYFBZUYjTVE/h0Be3OM14ER28ENgmLsuwO248X5W2iGKfYlZBCgd9EMxZsJAdA/Khmi2EB4DC9lOhjHfChtQcNmgbIBPc/JRwVOnjphVLKlG5WLs1KhyeXTEVx/EgqznEZwWSHwqQ08RnZTh2reXhMC9nOII1cn+DqZBFx6GcNmThpE349O/SLTbYQgkrF4nIBnxwOhtJrIebb3APWdCXeEm90h/erKq45ZdxM1ZwBhgq4HOzW+mUU/QQP1xbwEQw1bb6X5PIDR8OWGIsZ8NnXllfBuAcQ4sEqtNLizAi/u+4R6nirwIj3q2yB89ckTsMORFa/oAK9AvJFfGxraOjvey1XkH8ourhyo7SEeBVF8r+cRN0oVpfEEcJJzFL2q2SsQDlFsyxT2spBo2M0D4aG+zFG8XtUooCf8JiQD9RZj231eyYU+o2O3vQpzN8hCQiDHGvdeLUMxhhySHe1YEDumqRAOTZ8yYyjB+YA/EEOSHIzfiFX3eAsY5oWrWPZcKNRRxRAMjLTiGIZW1utC5FUf7IQP8hpYn/j8gM5eZlpujFAJMcRBrS/6saZs8YUxwa7keTp7omEi+kedcLwLGF6m2R0Rpay0PVh0TFQzAD1Iz9if7g22PdVCkjlwNzVmBlWY6Jv19d7wPkdunL3mSQYurkHIB3JzTem5xysKO98AInMaNIj/6jdP7Fm13dHnLJ5jOiD7UYQE90TWzjHwjMTFEK1AcYGMWegvMZzDd+3s/yuexvAcrAr7XVlY2jEggKORw6/VcbRpUELXXA51WFaDxjZ2HoaXZwYijuIL7LSwJIQslb4HUg/Va2CybM7wHLGIAMmEoKX551X9zfTzNk0OuwjwTnQjQZhqY/xGXhbweDbZEprE9cIb8QfXcLX1hYO0R79e28UUA2GskO3gqNYqOoiOoCg+39DyYwBo1Er44PsbgEj6jEda92bMo656ZTf/mt1kFcA3LyWBa8QJmDRWDz4qp+QOarP1ZiHpBjPWGIPqeqocsDRymLclkgwwrSt0sH/mMcDIwE2W4AGBhyvUz6fiAdhIFwZd/umyfoDlS5eEfa3ao86omIh3p0GqqwS2RNzlWMhMiIHKqcUgd6TwA1Abmso7epLnN08MBvQheh6ZAKIgJh7g9EDcLD2ZLZpStb0RMwfhUHcsUrG8fN6T+7OHxALNLJjBf6gEMgCmvLcXz0dgW9MtFUgCdjiBhsP2UjEBmcUUzWzqNYykeaWPTnBd9QL3A06bane52+9JzQrZ9I/mzLWLqff5QK0KUSu6WVfk9vbJHMKv25I5jfnaEVea2hxX5R0GeN9CpUfJYA0udBF4qVHyWArXBmkSm10EK91G8u9uoDziFt2VyykVfKBoJGMbalH9PBqaRMTyT4DgbAvUeku591zGhWTIrNrtQaEeWMIOagExV+fWxwsvoeCEFv86IJEabHANgR91s+BzXJu2XUxuHbMo/KdBFa/IGcCA2FczS7ZS39UifIZCFNcPdfWZIG+j0+UKbdDLaaw8CmfKDsJiBC1btSZPmBsCOx+lDr/vNtfRC0YO69oAl6qIv0HTvQN6K2mY7oM12GmtWVxEpG8UTwIOuLhNowEju1lcsdXavWit/noqVu/AsLqMauD04X7N2vbPtaNsAgY/98Sh/hABUzyHGRJ/1+jw/PPx44XCF5e8YsGkmCBnbwqKMLpQ3/oAxDOOlQE4s8CzMj9+FA0qKPBiQZcRNusn04UMrIRtB4SKopFJjYrLtVAN6scQcNb1v8Nr3pJwdE4rPyqBHhciWjyyZQh43bwj+t4ssDw6ouAfh3xft8B4cNrHCfzRVNIpQ/6QxueGRaqEx/apbeA5Y4Dlljf8nAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscBxBxk/70uhkXVGxrT+2vsNPRY1rcx5bhFF9L/BA0cOT4qHJ5ov6xGU2yJTbIlNsiU2yJTcBPTbIlNsiU2yJT03MsuloBgugwDtDT8ZkPQrbmP11ZhlNsiU2yJTbIlNsiQ88dlSL8di0siRvya1tJ341Xy28ByxwHLHAdyka8hw9JI8fQErLF/3DSKoGZEptkSm2RKcyrUIKNBdBqUtpGvzPLC4UHzII5e6g7aFG5WH/mKui/26L/bpxMFZnak51dZ8Hed7lddZagJijDZjZI0JUZoQV2/YTlhFOuCAhX0Qpn/McByxwHLHIFYAHCntak5HkX8MXo2AbU+M66XR/UR98C9YGfwcnNvxqsFFY7C5XJZuvwJa8/5OA5Y4DuUjXluSwv00W519utZGs+N86D0i9zRwRlQ5hz0rFty1ZPdqqSBx4XqbZEptkSnMq1DY4jVKDy+RHCM1syvKYcerpddo+mTgOWOA5Y4DuUjYHBljPPlbXRf7dF/t/MYkew+dvFBdt6ma6u3gOWOA5fh8ICoE+sRc5dp2ZH9F7qG0PDLD9NxuZyVgzWJT7G5KbJBbEAJEET6jaeaZT6nK+ePYMt8pCP3yvpmFT8iShLztDqwOWOBnwlAruShMwuDyB+0QEb8IHao3FSpHBtsiU5lWoLtcEc/qC1OLUHKeibK1DUITsxuwDtDT8ZFwHLHAz4ShKbf/U2yJTbIlNsiVyNlK+DxdqJJvHUMPVZ/a0IJl7XAfej0ovpJ15SMfKsMXsn0oqI9lSClydwmQ9f54BE+d8Nf12hmKfjcdLniS7CqS2cQ4tDWNQPR6Jqfn6xCJeuRP8FEkPg/i+6piqS48zZGbtfsODBIL2BdcI6kB7A0WSc/XygMUrAMGDSE4cLkcUAxm0Bg3aosx/vw1uG2LZ09GkdrgV0faKDq+HJrbjDSBNp1J/cCmCWGyAOgt/zkBwUpAyrLngmcJLvh2xU2B89BRIwQCWQPvcl+DSMvCoXa/ibfKzgS13IqsJRd4IcM15obvaK3UVptCBnTZoLc01ACuHFVLsER3B18IJDaxiKYNs5KX2VAaK5pNXtiIdSWTbF6jzFb1DL4gdw6wkiwCovjiozgVC7IY788PNQReiQ9McZHzZxC4ayOASoJM5ehJOjruOA/g3OVbzQ8gVbTXy81GB3Afrh8H4DAW2WnAGfP27/oWYVgrRkxvAn1xd1f2wks/4SQvHgFwaHqA4K7oRHY6lnxFns5lWoS32ql21jLGi/26L/b+YxHnvmfI+FUX+3Rf7dF/t0YDmJfzcwcNKK/+Y4DljgOWOA5Y5AqyWF2PBtsiU2yJTbIlNshACM+6rE2nYgmNhxmRJdLQDBdBgHaGn4u5yP3TwRR+L0tAMF0GAdoafjMiBcKq9RMd2Ga5CBh0xvcJ/6+OHd97K5KuJwljA4mG6xcyAdWqY41R7PrB03Nr1goOSh5/8Z+fR3XZE5QmI6HpAYaeJAgMnsp2XcIDPD4btzu8/iNX1NfVLUnBYkbY5svxvNKU41g5gtgresm5iSCkMsYhlo7dF/zw/+ptIuPZDQdwOWOA5Y4DljgOWON4pIbbHuSEYKKYl+kyOOzze9aS1mCq2nb9nBSf8r4NdV6NHkktR17EcKFUgh5gRrxByjUUcsj3TUOGiJJ+cXrYH02Yh4wm3/oPTDX7IEzkWDZmKX3Yq15cE04AWs+5Jl0kj85PoWv158I/yvg22eY6ee2A16Ls3tLEpQ7g4bcNt68d40H5OA9B/N/ys1S2q8KHSXqGGU2yJTbIlNsiU2CY9ctH77xYhTj8d3doVKaduLuA0+WyBKRHPNcW4voZdFfhZrNsiU2yJTW3v5QsO5qWAJacOawdiKlSODbZEptkSKIWcdkHKIwLmAUwToz6qvBtAcscdhOfd2C+Zfu8byKU5/Zgs+o2WDV1mJLCPX5aNp2WaYyFh4HLbpjf57K1kKDsMx7XSHR9xD8m+yLAaDu0meWN/ysdNsBYyxl5eeGGgWXkFw6Uxmm0GfcvoWIb2gXbD1/+waKq7N2kKj7RMO3Rf7cwfDIv7NABcbMWnk40aliF7/bov9uTZDhnJxRszPS+q0QRKbZEptkU60VP4uFDmCXswUaiheEakela3o8bGMO9NorNhe53M3J4iU2yJTbIlmfQdwOWOaSWOA5Y4DkXtvmVg2ow7ETrun82mXv03/kfbD9qnPxoZqR14OD2icYOmRWSMsAHjB7um8WEf9ttQcEA7ONSR1dyxv34dTS0G4YpZnzthnRB+LWzKq8G2w+rMv7RVxO/Mlj9klKHD7hE/+SW4Gx+TgOxZ9awO480O2yeFj1iOkFsX711oAVfxxAMniAG4Yi640SBLf+YBi3d/+lIh6cRDwoCisXGWNGSdWI6G5WtuWR1SzjUKkK6bJTgz03VRLpPRNLImxLgoGMOkmXisXSLJtNJLLG/5OAzrSNPyc0mg7gcscByxwHLGq2Q86elo4MLbY5u14Tj5+fH5GEc2kLo8x/uY4DljgM5G/lpjQNK0J28xBR6oKJobMMhmzKKDMq3to+tmNGuDGowhwXXWkMra6L/CDqE4wcH7RDWricSHBpv8EK8QQ9cI7fLIOjdeQYt7uyUoV4tUjGhPoHpTreOttARC8cLnyvrBPKUw7bUPOxd+jLfnfAsyaPv1yjac3/eRmg8Q7CmmdBJyXqeh8nRyxzNlljf8nAcscByxwHLHAcscByxwHLHAS/3EGAaVRupCc2xq19iM3MDbhO2iR1WraK5e4Cfm9XRgFy6+TGGNJWdH/RL025EZiL9vrCFhRoHaGn4LJdQRP99qfs+uOmSqAVzVpFRfnvOqhLFYt9bqsFQphg9+Xw66Tseg+ptX4oS73511E2GPdkkSixvsoSKSDdugqexuMUVBai3SJ5vDHErmWOO1a+1j7PwBHuhnT+f7he51CJ0k4VhvyJRkngbfd3yuEQ9+sA6AEwiEF+ft4+qiw0Kf+1XuO50BjZWgf9DTIzPdqshd6Mn1GHs+X+hf0hOjcf3vtDjAyq44MghlqONCCduUPzxpRb9bqQpFYFsJKOnjRHo3gOiI+tQDPmfnwT+ikPmOQOO2s2APb5KDoff23q0CYEtEjwrWTW6M5mWH+mIEOSvLNsMqBcGAW+1/IiPC8jx7SjzlaxbKhbGEZ/Q+2dlUbMfMomzbZgWrLMW4XvPjY3SjYPx2nfpURN0u60LSwJDozMIIIihucICxtUM8PoCna3jLVLOzPnlmqW3gOWOJGaSOyvlPHGCse1R/YghN4u75YppOP2qPutvyKHp9LNgd9gnxwpQtiYMXTk1l06C0UF8VlVM6kAq1/ZGDnYj8ma2TQFH7LwLHkhS3gDNg574MgYHxv5ertAVIKz2lQGSafCUzz6yEc+b0mdLnorDH0Hwl6hXAUHyXs7dk2MFRAKZ6/ZU6o/nmvHSMI3VdaMV7VH4IQNe4N777hqSuqXXBtUGZEl0tAMF0GAdf1ALpN2rWcLWg1bSI/eVMLBgGlUbqQnNsavF74/ELkByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscBxU46DbynjXK+siP3lTCwYBpVG6kJzbKMl31LImwvcuvkxhcPq76lkTYXtIFjLGi/26L/bov9ui/26L/bov9ui/26L/bov9ui/26L/bov9ui/26L/bov9uhS+sX+3Rf7dF/t0X+yNiZm0Mt024MeDHVzh9TcqRaBEKcBQstsMa/o9M73GUVEZsZ0iSNxb6aZXTVdui/26L/bov9k+u685uKJ7tYkRKsMqdF6Cm+LjCZFWUlZX87474l4UJ/fX0X8G/xs9zSpa8/5OA5Y4DljgOY/teai4HLHAcscByxvTo+RG6SFvK+f8nAcscByxwHK0i0Iw14NDCvkOuct2grKrULXT3X8oSG6L/bov9ui/26MAuYVgNKui/26L/bov9ui9LH4vPLhS5Z+39ui/26L/boYBP42sCga78/8voKm9o0vSNXEOhUVlRVCP2TOZrIlNsiU2yI180WAKFlXBKjQveFyO5rtjUQueQkxijglx4Lu+Aba7HAgAVzbdF/t0X+3RevTh8OUgTGPMKSa4GJNHveA5Y4DljgOY7gc0Emzy0ByxwHLHAcscByxxIwytrov9ui/26L+ep7miSqRCg/qmh1+MxwHLHAcscByxwHK06It5b9Byh/kbcb72FhFTn0eDbZEptkSm2RKbZEt+ixwHLHAcscByxwHKsBvTLscNemrOwllRIBQIEV5Q0a1zwtFZ/ycByxwHLHAcx/a9RtrGWNF/t0X+3Rf6/LxouCFizBNf18WzrdJ114yiWQape7AGNDgwltlZVgoDljgOWOA5Y4DljghMfzf8nAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcscBPb3rLbO3IVIVG+1xkC9lK9FEVNF5qYqu3PXy28ByxwHLHAcssdNu2sZY0X+3Rf7dF/tvt5iC2Vd4f6ki6LOLzLHAcscByxhRXr02uEVKXJCw0/SeuLnZu6dC6LaBAfSS/ORqnsnPUJqzCK/9rYzICQg+uhF2v0BfPdo9IIskeqbZEptkRk6D/5ecZeoPEyzljgOWOA4qmj00S2nnGNA2ZYlE9un+NF/t0X+3Rf7dCVFVu004KPZA7+gFEvaxov9ui/26L+pxbh0Q4Ai40jz2FjlDohjokFSniMhicAv9ui/26L/bov99xosLljgOWOA5Y4DljgOXG7XRf7dF/t0X+3RfzggRzglaZBJ16Y/W2+fpYQ+oX2U5O3CUmhVKOjrKsRjmZrLbwHFTupQk14cDOcy8w/bKMfI5u3TiA7W3s6ZwzHc4GndbJXBUsENa96jaFyFj4JYmqb8NpxDn9NMMwxHCWgt2Y1fZlT8ByxwQzyzm/uWjVq76pk7jEqLLbwHLHAcscByxwHLHAcscByxwHLHAcscByxwHLHAcrSD+rZW3Bq2Zhg0lbkT7VUAnNmMmEvHjXKIPFYm6o20jADLKz7GRjsOd1z2dScayyvzidHY575YB2EdiSwTtr/u6Mg+bA+2HzPYXh+Mxb9LMPxuFcxnkplvcKkLgChUFDKjqh1/jKDdyONnXcPvTtjN6+iPksNG6wYBpTb/n+uTTeBO39AAcKJFjyZc2dPo0qdWtXsWbdyf5Qs3Rf7dF/t0XScQ0LBUVu6iVA/PgUR2Mgm10X+3Rf7dF/S2iYNBfAHajVIoosElTwZI2U83sdui/26L/bov9jiqmWCGK9mhRVtL4UgoFeHDt4m7ov9ui/26L/boWFYjbN2LPOWk1A5Y4DljgOWOA5oIwuF/ibXRf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+w+o1ub98SlVBoAXywFrx9y23GJWvSVlVK8dwZI2Xh7Zazj8RZqgekIztgyf1X7b86JodWNlMfaO1Ialc9YBse2K1L+ebZBqukL4Gvh/9TXWlyT1AlwuRRpmMA+Bc9zpHrsM0mKjqweh5TQwjEz/azRTdHytrov9ui/3C+BpDQms8+VtdF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3Rf7dF/t0X+3RcgAA/v5eTAAZeKb/o6Y43BOAwIOA3wgIGpoKvb81xiuRIRmSwOWu41zPygevCIRgw522bzGovoYd4PiVA4rR4SQ25AkBJR8Gq/vTdJfqxkxsgaJ1PFNGjUM++Wc4l+rJJ28VCFu3jcff9dWDpKm5DcRSav9EsI7bajA1zaQKkFSOmyrWA9Vqv4L2gQ7gdlQCKDYRveom33p/5tIf1gBRG5BuCm/Lv19R39l5cne98TlElrJJvmvP01YGxmQbz1s1AqiKPri1hK/e0v1QK5Qkj0sBzJkCouBDiAERrMeZqaMPrS6Pv8WI5izD1XhZflYh5WNUXNsQinDrGzuMTR+sQXAzNULW6O10m6ZT5Jf3LRcUzfvD8p46IkerWJxO9Wyn9C0PVoMd5WVpaXldANE0k+dQY10r3kW6LFcgyDMX6bu2W9MTffCk8W1vKdu0lbpowdKF34Avb0wG4/CZU30Da4WALUqqwMh4x8h94LxF5d6rVUJ3r+7pGGjyQ7QF2DQDIgQqlpk39CQDHrJyPitnySZia40A2IgOOazkB4ujlZiI7lXqt5K2PLy00IogPA2pjAdj4eZq/m9HGLJmQKIe3LJheh7SLhvLcWonOxKgtCbGopQ/vZmr3NuREqgiYY9STN6VKx65Mz6SA5T74vOlSUwh74S+OFhrQAwpJ2VTX30OGYZc1ipPGFqzGQhxXdmzaOmngE/7KJvcJxpNaAokjhxhpassNNT0OQvB/dIa6E+sU7Juc47KZmOW/5bt+njiiCXbJqFiDVRsChYf3IIHvz/DiF9dYe/dyonULC1dcsGzbx66F+Y5vAQIY9wi4oMmHuz6JaszbF6TGDz2wNI+G2c8SYD8FaK25k9BrCpIZoE58q6YFFNR4l/KzP3HXk4Osnlebz4QtmDsKfZealjup34/N7pRvduMJcXuDyTa0EOhORe89lUj6+mZv6057B6F6XMFkMY1ycf8M1S1cNghr5kBc/BMwbC2Tw3XPZvTAG/le4x90dZpf24OuLThvBQ5QtzVnS2VL+pp1Udo1AAAAABWbVdGCPGsrp4hX2EpBF779jtEbhIdSAu8vDL9vgL7TMsQNavN9rZiBzEfUth2EBUv8lLYMbsQLxAq1rg6t7VqFwjnFJpUc2667Z2QwDf0qFkKQ5gVrpCveRLTeD3GsUMUmjvswbjf1KvkodzY4wKQGm6vzhANbtxB1Ba8h8tq5s9zoGoo9HEX56cgDCFPOSVysfiecBQ3dkP1gwexndpOaFCXkErNuf6HFqEdaybswZA1EtufivK/Z9zgA5v5ssToTEsW2VQRublz5zPMgZ80d3KUlxMshdx287pMVrHgt4/HXKVsxa4+k5U7GB2EMTBODFYzALbwNQHX9TpWuH4A3K3jKRAiFJqfKnUm20ecljpWEGxQbkCgDVBbw708JGyQAIpuDw7hecj4Wdx8Ns+ZFXwvU93NlNGRXwro7TSOTivBf7EPIq+n9mrr4RjThIlIxQ/ZzSapMVK40WBoe+YpJyhtqq7T1zeSwTvRpRlO2UPmWYEzmtZqD5y2sTCC691/Abo94U5DQgshhJtcb7c6fWTboG9hcJ0daj4wRxTSi82+5u3CvhqwMsQbwQyfZkxFjTtcAPcWc1HocYFgp+03xTEU3zZOJOs6mk+jkfgokO7TUormYYqeDSy4eOXJ7wJdgL5iXiTFuMYlIudOjOVEafeRNSvKY6sCKcZSwVhsaWKtD32cvDVl8Z3OOy9SXG5ksJZHHq3PzQw2vCOEd9WXrajICmovIpHD/8bAOMsveDbzD87CPByJDC0sslWZUAhB/KfY1S7gpV123FOOiRk9rO2pJuTIwSTzGsHTjVX+CvQRwTESg9PF9boSRhFT+STURrY9c38j7/+GygKWAAAAAL54nuDn6Mv4OLm+VIRNfnpEa6oVhWhkj22/yN17N9Xspl6FYa2tpLnvwCLk10k42yajjsaPiWoyDYQ8HmUC23piwHbT4BFyaqPzg/SMy/uCXiIRElUHWzjGMx+NxZsu95VFJnFJSVHkcQVb+YbKfyB/nXo4gRzfuLD8A/5Zq3IqsXq1kpeyKdx6kPE+r9q/mQ8bJ+ARcpTSUjMawLeYAB1B4c4ERcQWJugSyZ/zgEXJa/uLDCRzfsDDfpH/VLFrfrn43FnCS/AIuShvPhDXK6IYO6Fdffy9rJX16TB5EqOQgCDvOxmVbdz7IdpfODzbIjmfRMABSYu00rpB7XQB/ulb3TdbGc1I0sonIweFAGoFYBMuus1hs5vRyjMyONXeXq/qDo/vlY3escvAmpfXTdyqjCajUUMPP/yT4P8mfLeQLGKR8rrjrZ3iz5ebMrx79EmJ4ZSQnOTi9yoZz0ux8tktus1hTwXDJ67O5nQS+lckpfRhrT59D8xqRxwQGHdNewV788mfpJpx9qvwQLJD2E4DbVFLrQ7XVHe0HLwtRHtHfR9aguz0NXxagbevkGVF8uy7YLl0+HY0l1Gs9vJAUfSs5fpDl5i/9qBaHHMzTQ48gyvn7mJ3cRz7ZS5yV+9U4QZbqMabR069anh/aLWrsbNpgpM1YUn0P/wQcuxf1TPgGBmA2fSfPHUcFBiV0Gevf1qLc8tlRrGhbhCVCswYDMWpu6JaMrOG9GbKs1n17+tRbnluPIcDWL1SWSqcKv9Wpf8jaEYw9x7bpiBTZGpL5QyUdx9Rkdo4y+WkaSCMJSDgNbCdFnuZJ2doo7byVly2KH0IPhn7FbwglvKNQgWiPBk8xmb64x0etMmZNKvrOsXC+sgJi4cMntO6DylVkzFDhYoc/yKSST0GPRffp/r3K7MKpT1Ir746esHLu+EL1NbpAyOLKNaua9nbtG6RZGXOTm/j7shAEexIyK60gfNvG3ISxChIwm8LuUdi7+99gyMsWFv2wlnuu6/2I+JmesDrYpMvCZPIOvp44HNWgybhWBd/hZS6g5FR7ifD0qZXZ1s6/ZATGLDX4GKxul4lOk/s9gDL/Pm+ZvJzjlXNNf2C8Ug0Vo6Sjum+aGxGW8+T0rhOyRpweB9QH02pMGl3P5oz9o0mzveB26GqAzS4YwrwAzzQLaSkejXG83Sm/tmOGhWY5L5rciPNnv59Nc7JT9oG43A7dBBAx0OV+jaQDDhm5bcwBYxAJYeUt5WZ70WW5OtJM65gMwnGwJ+Trg91uvWbZ4kjo28gcG3D5Kv3Vtz919EsHeIaU4z+yCrFQlu8x0ww3QcfhV04UnUK8+MC4pXO9YrqCfOvfgq5L25E9R9wZxU2DbLH1CC5KorGC1NnlWQ3mDVvR5JBWa79Yz4ZRqQmG91kWCJJPSVoRJxIeBeSFEJ8rS2aEmkqn7aiBXS7DqpuNpJdQNHrd8SK330kwQojBGSkphnGNMtpCEiFP3l4rcs6bsq+hdUYXphjeeqvM/wg8lMA+/dxYduhviVjTXkYE8l9jGFstNUo2rKhEKcGWpDDL/GXSrJ1Nl+ZnSVFT89T4Z7XBLIiBkWZUYNPLGtw4OOVkohXzU/0zkN57oC5SMBM1MNuEBRUBb8ySzjZ73bTdlgc49bkbHhS8i5cGgpH4e7Zaz8l7dkWE+LZuE2zocX2vgTrj2Cv53B8P12+k1qwHPce3v5DkWB4Ew2e9RUs9EomhEvUvveyHfXarJJ+GjxhUhNcky8ahQ2/oZx4DHEknOgmecAGgXmo5Uk0KwrbqMFe6TFDCiTZjbIeVF8/Vpdg+i9A7tuR7LMwPJYbfDgjS2pSIiSyKhyUObh/derrxScJi0Z6e3ZCFGHT+Z7I32zstVPkSRlgHg1Lwifwt+fKwTRlzw6SC9TK5qKr1SqgHbRCal6g59diUMhJRKiTbSHgBZNCpKQRSzxaVIfV6R/gEX4ogmqvMIPD/aL3x/aoWnIi4dQBjqvcUtGs3CSgVID7kmsQXthjaP6f9sL1qIEXXJ02ePpMc3+s8k9obEGCMAjypSqB3INSvE4H6Z8qv/dVH7PZWhDORk2jZXCoeYZ1/MtSG1G9UhE9RAlYml/isjBEWNHuVAVAOy2kywra1gmk0IemhnL0OKo9g0tIkVmPSedoAWKBHTH9C+qFLyUlHjPGM4Wkx6aSKR1v6V7LGpHBGo+ka6yW+HMZok2rG4aDXnej3KTIgwO6UlDCOf0BjO+3WOJKwpTMv/LQbH1kV8TnQMllHXjbNmNmswcu0EKuO/xYlF3oBfb01thsqPif9Mk1sNp34g02fyLc2Th6MJnyVrcMoxmcICBOJ5kQ34wbj9J1IMufqTESLGzisAj7rlXSbBG0QbOTHny52JoahbJSEGT9yTWdLLiJRI6xKarQw4Cg8aCyEfYll7ch7NIBuuLMR+EzCL6xYCiRcEKv+XWpnb+LWWZt7Y1JLvNUNApya/ZY3hCNIpSv3EuCFoCNEW1RvLc0mRT60JrkuKVyz0nppm/+0ioKG4l4rZVNUeSqjQfGOVk671nk8vrcW7Ka0GhGkUqos25IFl8iGqoaKF9CtYFMyB7GbwSlPO0+PL5QWUoxBs+STEOR1LNghYBQGNf0oAADsPYRD5KbrYmDU5Sx40Gif193KHGZG4314jd3DHTTiIaQ8uM1bWTICi92wAJL2FvAjj5mCtV7KW6KsjFWddXZvQFQ5OQiJZoBFWI/l4mTeLyg08Xpq6l2GB2VvsLc2136lEKxYZGKSKp1TJor3LsQsF5akAq+u/0rHKaIbCCy262V/Ite7kET9yDbh8lSwW2y7ASljRujwN/gH52uQJ1wdENU/w9y6Rl0HuvTUPk+bYxNtmTgmJCZCgerMsGq0dycuL9CxeeH7IYmqz7qYCKmlaj8X7+NilnvoHjF9SEHnG8w07noJucIp8atz5yLIK/2U73sJMI3xJbGbV60Sbwqr7JfQlfhhBf1t3vxIncQZApdHsDDe7VXDsHoY/TCUMperATlpCkDKuBP0nM8BJYAiEolaZOW/eyuVRp70n1spBsyXWSThhV5lSzAYRq+Ae0WnCqNOIoCChZqXuZC6OJ3yZfqWefrlfEYNinPgfdCrnQG/cvnhpJ7D/dnHvSe/M8qT/KISpXpI8P1IDfLIkyiz+nqspkTbSyVV2KfETVKQ4039Nc1rCACKFwMNtMvhKkgOmi619HJTS2otGENPRYp1aCQg1H4tI9eq+idJqvx0FId+Fhv6aOdf577chsDXYS13yLprMKbovuHTzjSXIZxWoypEiPyeJc/SzaQCpNiNTTt8WrkdChYzCzMO0vymdasvej2ht9KkroXh1bZoQ7UEkX15vMHNxJqjWEAMWqdvY4pZsEMiK9Aa62nORo6/hAWrShHarfHWTW33Mp5IKYvD3QH/L6sowGp+lXa3Z/gOe8vh312YYgI00p0nmIrTQ3zJc2MHdUmyn2ZHn2TWwKdruPYIf1DGV4fUnvkSngT+w2DcxOovOVXnFfF9igwi9hTeWzIcf8chNrC7I+kqL5+GMXXFb6+WBiK7Z6sF/eqjkoq6qOdkrlE9vgxGKjaV8Hn4QqkTtVi9w7WQKmMkS36/ydZhRYN6xfebpVB6K2zCRyTvKPR3gN9hU9HiUYuaiHZBCL+phqrtiSCfjhHC+VLqDxauj58ISuB182ZLAo0LzoKxlicPRFDA5Ai6mt1rDQloocxG6d+gajzlWp3YjrWmj2lqilGTll0An/iUEf/mEpDfjYsMq4720q+222iAn39k6ZMRShxA0GIzAg0e3cT6WBt2qYNWRrvhahCxwlscWIlNxnPOq9bK0vZu1IbQIwLsxoNKqdsOppaG0RClWe35YUVj+1Ouyzl73shPs7QzoWT5XuPVihThmLvb6dnoIPH5LNSGHCwEvPGV1aBiGf+J/Zgd3gCBtQzO+Oq+rMFwSvqJ2nx3JUskFkKbbWr5220j/XJHoaUL2WPLWuj55YMHnp9S7bhYnYlGfmKaMZ9aiSpLxd3+e5TbyXvXKEz1xK7iDaYT4Nwcv5YViTlOdu5OkrIUDZ8bdguVYe9fKoxr9WD4JVYPhddipdmELsgcJVsp6AeZ8ag6UjMtZbMipJkF7d768mwmV8UntNAplGdfOek6Xkp5GdIBXQhmhKI1Qk7Zf1CXB+1qIgz6nx7wlwVxf44iKc3sHT9qGlWmB5xTwk6vPe+mplVqm5bCeR2uF0aB/NHOH9S2FaCsScpGPl0dBFEkMsSwnxBkNg3uv3pyBpk7FS7O64SKboj38X4f7Zyu/wVEa/Mfrc8NP15Fubduz1gh1nsY0byJoPWG1lDcCi41xIFrrZyvPqI4MeLFfAuInmx6SeWiID7cO7H9sng2XOsBXraN2p92jDZrmIv/l0/fgKwiL9Q1I/MDrLF4gl6xvmYUfdxfQuhKZoF9VtDPWUJxCA3xSzIdBhye76Mlt7cMYbBbEPRNuTfrZUNsisSaKy5Z/a3Fklw4HiF1m9xSAQHl/xpmRoVQQyPmPt4ucCbWACh5Lc0tlfsRLAAAJUScqfgS8QcX2nTiyH6kmsruAoIv/5PshwKw1Dbuf/kX7DM2v5HDJtQmfIg9WgLvy/U5z+ED0cJVyPcublMrOfIRQ6NieLsMS//aB4lAQugxFY2VzsPAyAc+Z3UeC6RLnNnsIyOs6wSpoJF6y8mNSgLC0zLP24KKeOsbHETdoSmNEPwkaFWMRwlJ48iArQkoXJL3Yths/1mRCa5QrAZHT04S1/BK+X8B4YV/7RInxa9iKyXVzm+J2+xf1CR97GixOnFWrLtGPaiI2vGUKh/WaVgq8V33ELXl6A+92ApAUc/Ymp+viB92w4iRLos1jIHy0kyzY4i6PZ6dzT/BkMJWDYZ1Qs88K8sUc1p2hK6kndGFvHYW6kD2kMDdnigdvKupJo8B3oyDLx/TFaihXR5OSsYdAtjBaJP5U4VAmqqsukBlLWrDtDkX3wUbARwVANPn1IfMneh0ALG3cmg/j8Lg6lflCbqHXBtz3TVo9vm9CJdxYCpMGfJUaJu1Gkt8CvXwjRheLhhzAcsWiChdKNZ/cgk2+XfQxuTApK7GqplEBCfbmj7WXDATHzLY8ETg09IsB00PHqTQAgbSi1gMGPYYIqebVmmeJro8L+s4f1J3h1XX6jM31OHngr/EnrpTsMEVPOdV40+IZ4ScRm4G0yHmtyGyF+4T6qXd1BRXkHZSC7KIugsIgb4TAPF3kBOibNMxRq/KvkCEbDeu90JW2dff306Sc0Sv9VY8ZZCyHjqr4DqwZ8H4Fp+bsB0tNw35QfU3cTfqK2OJ/NkCVn1M6xvDMAyprja3MYQsNDs/PmCsOys7isKbIx2f9TsPlPt1ZatHbj3kpfSAPNyXaEszIpjKLE7jYA7tnLmg9BveZ3kX9SPIvAf0MBzqJZy3B6nrCzw1fzD6twwQKLh7oUSgGbXV5tjXPQ6e0xmWRazbI2SOPjbvkA2jBVyd08h3I/xMiz25nmjzG64A5Z+97vzlle0sikVuvtCVuQiqpLNcSbeYicFEvXOUTa15KFcTJq7l1zDdc/M6qZDI5SmXP9uuOao+9WVBdYx9NwZ0RlFaRPbA/Rx6CJjDQpg4Gbx37dyJClR8QvwWmoojheLLOb/2kpW4RtW7wD6tndEMbN2iu4YqjZInovmb1LwEU1xT/Db/FvcEAm7wrWBFwNGw5R1V8P89rDOUf5NuknVXl+S/Qy+6EoyN1Bo3lFycLcyLIb81mFUKYYLXFHrvE0yAt0GPpGYsEJEwA2e6ob2JYUTMFg2zs69aLpkaobx3/MaTb+QeJFAENgVqok6pW3+lg0UTxghuqIhhtlVkIxk4JVoz9SSxTEdgENQF41Q1BT6R3tfMLW+nMC7amvNPTBwCssdmhRBR3hiUdDn6uBNRshC2hFqhrtWf0CgkHcuiydH/BS2ESsU/JRGvJOg/nMEO8mbvbqLkYiW9Hmsb5khX8xIzVm8IFOvUBk61cQM3UFa09/gJwoQn1chI18eb4tGk1zXZuIN8/3BvZ0x6ksCroEGtsjRgO72aErYVlcHYWDQNIOsDUQGyG/JYccbPyAPcX0EXAZYpMhC2tqMa03wy5kJDCHTG2G9t9YYKJo3Vhs+Nyaux1y/RayoxFf29zvdySptogxjP3/o0EgxShAG7ODlaGzOKG0W+osAq9wokR8Og2GjO1GHwXR0oIZH/F+OO7H3dg6vAXOxBML7RS3I8nnEUvyeLAq8av3+nStXfogOd4abVsE/gZj6Q31tyMtxMKDj0DHSRSVH6+1qL83tFXu7iUuok2T8uIOdEimyo7tOxDrss7GweVVV41nb/ntGIRfOOT+6NghINZqoAABK/SQbC9AwIZ71stRLW8xffxcF09bG3Ns2w5205d/FWdg30rbrUUE9bJgAaihaNeqm6OKXuSVA/0mRCZvKyINqkgARJuDbCnWRCbqFMjBbFEVyJ+KuaBOxfpQ3R2sYvVOKGIUBPTsoj0J3Njr1mBqxZAayN6EZ8WZZiCk4CSSqA6R8fQ0OguFAeRcy9aTEKUyxNXc5SnECiNwMUIZPxHpeiGnhYrO2G4GzfuxymmKTEsgSZtkwh5rlfrEiaeBOgdJwncKHpJUjwDyeMhGyWonhZT+z6A1XRD5JJ0ugDo9hkBgEi/Ckl79ITBBZ4cCjzR7NUcz0lcgvzFECiQx2/Ra7pSDYWbQ2pIabkQ32U7WIPRV25OKkLGW5YfHQv2Mf1ByaZZFhpJATf8BMOLvqzSq6CiZwyPhTgQxx/9uNm3vms59AoRAaCqFPZhgRkC/VFp5L6FmZSwLVyo+TRwis22sDjNljHPJfSKUYIfqUtStGbXm51Djy0mtQGquTMmzEdRnlrlWXIQI0XpaluUw9X3urf6NPXEyUc9ixwID97rF0Y9HzbKtw7QwpbVMp4PPAvBi2iPZzluFCuQBKAwFMhDn9aqJLFC0Tz8uu9ilD/Kh9y6VQ7+whMfPAhZMNMgG6CrYnr1zT0+5BJmE1sBToTZ6CIo1Uy5jqhNFYX3AEzGQdEaJMreKx2tlGdzg+UTxrSqwuQhWWCypsjGYPqDa2qQawBc/d+i+kDV5HQF+/dqYGgTXT5uQDvLohBdcLf6U8gfc29GAFpe2ZO4/IG+iK37llKVxvbcQcniuuV57+EYdDzh2+wFYyacN4KkSxUvmMhFXh2eYSzkzJwfMVj7oURhPaAnmRi3lowunl0O2DRJavdC7u8lMF4q/8+XpcYyyIZkUw8SfjIqcrd1+MDJq8/mI0z7wT5AMhPcPgdQ9+c9Qt4iIolR5DhNq2Nj3JIZZv99hv460qx0ehd2utApVUTaZfH0R+PCFDawfkPXxtUyxdUK0T8DitwGxyXITEfXdgrEYns6Fz+jB9gFRrmVyK2veuZ5gMlwVY8f0g9q9sCU+EoiebeXwKLtbwg5CJ2aeastruK2EzfO8vUOVhR2ikeTytjS6nnhWrrxfGtdzvMsmYtEZsg6mhteYfmgTm1KIhfCjwUf+lUBWrHEu+EjrmnV1lzH9TZSyr7U4Hteok4hBnyDFmgEYl2O66imtc6l8ljqTBjqtnDO8LxRIUR97QdnkahNBkl3wQv9z19wWYLZFHfPJfR0Gf0NUoD6duEK1wNI8womZHpKF1AuEXDj2pExp7gF6XxSxXyKFHQmejfj1Nsadxeb6nLhgmmbaSS38ffsQix76O0y+e/mz6Fv9//82aWNzRIV1Sh/goq6d6MMG0iDaSpIPje0BVCA0dmkoxu8m+kZGFNG7BXS3Os1ANWyxH0wY8DLxEzp5U16UCCQDYNSJtA6RQukDeJeb03FBCBg9oKZNRr9/GgXAW2UPAYfcsMBaVyEJVregxTj7oYU22fEd9OGeuYu+97nwG4z8RMFQ+Mn01E996uZp+d+2oLhc0w4gHa2nMsRxPqA0nqvRg2cymbPfa01AwPdRmXLB8bzwXS/vtHydn2+5m/M4a8EavwQy8UPIAVZEjBnZfy4lhqugzCUw+TWbU9MP0yRRR3UlJAXRNsdIpytOQUWIjRpYgi2JEI8nJWMnxDAoIS2jgM3CF3mCTbErkL0JOeTSuhC5bwI7Ws1ryrG3Kx02HMAGCzq46H5WPD5stYU8dLj7Lf/lfWdD2oolCYakidVziKYAyFVK9qeHRRm5mYVWx7R/CdsphqBEH+xrZdrqZzYaUrMt/CknHFT9qOoPKCkL2vU9dd8zHmE+PpCVDSoNhtQEoIjPKdWua/8/kizxh1SQQy5GbVLasQpWIUmWBqNaziUWMuZqrWlkmN6jUBlWKLD2ZAEwpMRd9oQLeO7GjYwGk0HjohcWDP2jnAN0FrBz5ETW9JPFjvzNnL4f8T7M9UDO7K7UtXAa+DU6Rn8xBzG5pzcE8YVfRuZSERAwRRQtFqGDSliUAC7LVaf6LDYOff2+GURD7T5atqZDYGLHxGTK7AHVxU4yLVEMTtWmzLhpE2eDBkqJL/YxbvuYDg3WPvQfqiZ1PArthCROyqAyBP4azR8InIqjKSEZggg/rh+p8tEYAzly8JCP7Ew56sr1BsYxpqPOb+9tvtz7eE+HlREfpu5h/cvVEevlvReVBKoHN3zM7tGRpFK/qoHc+S4C+bRGsUKuyGcQqv0h5ufCqd7AbN3AyzJWorXpDZZEBLPix42SJsPvtoj+6MO/OfymnEAhtbDaNF6s16c4aM4qT5QUNlKo2Bf5raOYvWo+IdMTTHZxAJ+aNKEArWkOmFAosQ2kfvl5mpaqx+my6rwk81HTPHyXnKn/XIxbKUyTBLEDKQ2nZCPSFhnnNrHiU6KgjxXvprh64g44LoiOwf8s7pKgq6XWNGQW25UqeDtc4hP9GFM/razawbPpTQx2EHpumkVYWjLp/q5Q5xkEw0r8kJBibVHj9nIU19k/oTAkN5kBE7D+KiNd7DeW0GfsHE9vAaLyXSt0rQQpW8brH8HBap6uBJ1D1KSBApshJ3HIpHK852HvK4gmHM18u+w0piOnt37Jlf0gxznzjpEkWic595gh4+BqL+cvIv1l/eYC4TMrZ5r0m2rvhYxadRz5GkpYg1AXhG5JGYQrgb1nVGCrQQnF/VIvAJK8Pa8hoBxhGOHJr6ykEmkbJWpH2nt5pXNI8bxjhoz1rcEJxQxrnDLeuGI4zaYssoAl7ZfRcpIIaLv/EEXHtdXzDWETiYysRNPLGcDHmmKgoUVNUqRQpr+l85PKUbkKqrOwEV4QVR5rZBOVGDeSSytZrj5ojvcKFJLmkTi3oFXS5Lb6aVau3QeGoARfmAKKibPR4PfCWbxX3o7wBhJR4Treof8UAa3aDA5cb2xXrn6SoCc09n44eHM8X0QndYcIhYlF5qbCUyQ2Q7QT4rMuqMAlyK4koWlGTmM4THKbzNhy1oX2ioOxIbzAAes0/mZKHe2lHaKkF9VmY2Y2/jddLB+ljg2kuyWjbGS1sCmWbVYSGgL1foyqH+gaV66THdSbOfIYktqpPHsKtQKJgG4d9+LRvaeU81DV8hlwlRV4W1X1SVpEVed7l/HUnXtTnHu2ZFhQYMMN5Q9hGhpXSE2aymXEknczOmHQDgpjrSfMOaXgXApOHJeI/yb0QgYsiwlg2gztalAhDsCmPmaHJim0gAdIO82fh3PWfNF+obw947AVfkqtvSaBRnNM7MhnIWRVlOlwso+CkIQdNVRC4dj0N8oC4Ck6AxjL2+1XvEj/KRrV7D50xk0yTFFhxNuD6m6IGObhyMmsaxa4bF4Hj+pOqSe9NXtYYFF73k35b1TR2e/wnHjIeFrMYWW3RnpuCkqylEAUP4ac1UEdKz0HSN1XogNkf4kbzQSTWzd/ZU8SbBxxHqXNjk2HUJuu2Mu7usvV+wIf8mz0q6ZxgDmYFz98dtU2lIOq0EmAUvVA1AHjmXpXGbZbIIh3QQFtN5nbgxxXPDglEw7X6vqu90qSkg1+M+47SIgVigzbPSVSuTwIDSvyIo2iHqQ8eA6LsVnFYYrShxHcL6c17ZGm/XKCdU1ki53RN8gZBwayq4tXY1Ms/3czzp1lxOwReKMXx1gU7urVcQrBnH1FLc7WdpBcAIi7t5EOtaMUzXcLo2cKdT+SZfZuyeCJndA9KyfIdiGcFX4mloHAl0UZruUWlwKgAfXQDPHP/1H+BNl/gQXtSQPy9jfhENV/RWLe/t/AJg0YBsiolHOjJlocwwINWrXxRDgQAAABzjg5liQ6bzj73RodG7TDPX9ymoKv0TEpvnUuivkoRGnDFuU5qMpZFYQ7OtOastlhuJGXlw6CZ5ZMfrXUz5pH2ZBf3X71/KgO0211PKzTzFPzI/cddcN9hFAGcKCN0NmuVEqU8ZI2WUpIQsowoxlWsU11/S0xwgUO7ErQby43zW37UC7ueG9oq3/ckfNUJka2muM/5INnLhv73vKGiGnHRoiIyh6eP1Uaq+2QE10XmxBUUYmVvNSGxg1zPiAxHrQ1i083LW9MU2fMmt8N0XypZtEZXO/ElxrQC/tL0UATT9/g7TAY5/s9sEO+YxEQzaFmT6GWDK12pALezdvd34qU9yLYWcIW7EAlJBKDiu1w7F3KHSPwCcpAPO8qy5GgQKsyo611Bn8wWfZNuVJKK6ZSwnPOgGCqXqVdZYSK9925ry0yJV4/tga48gjkoK3fwWEKisIsksOlYSiOEg0hPhB4DNLIpBPiTgv+jvv3dhg10C7+VZlypZZfbGFkaUy2W38zIfxXdfdNYxM0trufV/Kz8ygmtcbFUf4uZgox3J37rZsKL/yQ0jwPuhM5Y4SUh0mqlOwS2Kh60HE866N9uHEtw6V3fEV9QBxM3TxoxztDRuoN3D4o2YwWJFOZuF1Kd4DXkF0UBvQ7XJQvjDaotQ0TJhcKpEQlJHZJFi0aEVI27vA2YjEnPpkEbFEqjF8QebrB4b8LUhxSkESLUNRDHvURB7GS/fTCyoaNIOP/X0aQ8x9YhoSRBLFOZPgcajsJt8i5QuXSuynDk/3XeppvQ+lcB4I5Jrm8C+AhAQll4odSk+4yfS+BxOmj1RFnakiPl2KhSlk5p7St7qyp6QmgFAqEx7WqEwo361au7TBixFR0tw3Txegvxx9Wux7ftL0bx1N6hgwO5r3Mh4z1UTndyrRMRR+Dzc7AovSBBlruQRpdf31pPtm3mcl8tVTxuIgfcLChBMOvmMydOKGUKjaCqwkNQeYhdi99EpdjBmD9EXM0YTcdxvc3Dlc7VFR5KoE1mnbX5dhV/3vsGNCibQJnkmzuVcGLCstUoEXg0IryrWd956q3uqw90vRaSucp3McbQgFhxtjg/6FsEykwPFjzxHqMaK2GT4gKR3nZXc3HntN9TuZaqcIe6bgNrZqDBpwOoDQdnNQHWNrTqpKHCfDdPpcioaA82f2ox9PERthHL0GbjpCpS+nmnte/016nKaiu6qC7oIF1plHMSf3ZyfEHnz1weriFx5S8th8FqVUUPw5coKDusFzeRNqZIgwWf5dax0qoxZAgtRe+AOlCqiiWtM+9nWqC1Bm1HQQd0JnLHCSkF7Cteq2w9L98jCKqan02dEwbKPQDAS9el6JSVsO+FvU7urrzbdjg6V0Lz1KPW732qK6GiVSLKDbAy5XIHkxsNzFhNLYxCIxd/2BMtZ/OXJ8xaHOydB4lbMQpmiZqmbbTZKvPtHNQ15BdFAby7AHeohzwj1ysquqQsJRMpyfd+cP+uSxg74eSnz2y16Ah8BBCtLxAQavkyPxX3Z/fX+b0jVq2gRpWKZXDQxoUdwydTmygVsRu3qLWGHPe++O0BtvvUNbm5wXNJbuscsOTVYtE5fU5ZglnPU7oZySPisy5X8oo6hKfme1Q2ZXmpMxoy4qZaYElbP8kVDlJjghbA+cDlr7TouMULhaw/Z0mo+6DSUyDOsmWdWTmf+Q1nAFp0lG+0g7Tsogea1szsf2w1Q9VGD316ZE5ug7U0n17U+vd8O6UuEax+ePzGn7Oz6a30jeOcrFqY4Z1ec6MgBEI/NAgwRRHvkYSZVWd7VJQ3Jwq4X6HdVC1q+hrpIW+6uOeSSsTWTXBOemQi3SOBX5BqC8J2ASCcZl3OLw74LRC9EUfMEmVRk3LZgsabgAqQGSlL0ujfpRgFa+HwfGMl2m9xRywp0U+gffOrwlhKVVzLhs08bEhD/Bv1+RnVFGz6ZJXDRmYz8tMxr/kgVkfyjsHT63HpnNlCRcGYYhuc6t6I6P/qQfDMjjG5zG4u80VlXWIcELYHzc5yyByb22MtnbC24UD6Iw2RVtYZLQKms4z+8ehWAj7WeaQ4PFGG9EuaWStAS6nfzafZNX0LKhu28lsDMWJlhnPrJlyYAcD5c2puo7cIcCRIf0Ne1yXhAA2jIcM/sgKXe3yMBAW5BcHHSdVG8QZETBE5ug7WVKH1bWz2WsvUTwkJnSjs9ipaoJrF46xUcFr5s/RfXWQ8BqJp8+1yG0OWtsl6n0JpUxYv7eN5DxBoe6xNbc0tovLD6LkobZh6tiiolUFj7nh0Qi7C/y2BvtVHSAIISZk+8tgPKmjDr/JMZAj2lO+K05ukuWYTUMz/bcmcXqD0B954yoxrGu+5bBWu2GJ3/VTBnYmEc3HN8eK0Dkb+PH348iUNTGIbY9Ml7k5VQE5rVUSbYM7EwkM9vCgZa1pSySnn2SlGF6SocLUQ33cNhbp62M6boB72A4RvY/46QxhX0Y/wst1ADG62IE1SZingst4cqEFZysjmuWrhNxds74oLfdMEL4xBijMOkx/+fd8Okgo/sBg30R/kcT1oC/gIfxd2xFipKy9sOPGmqfQN5A2ppT47ficB1cch+bYyh1t0OlXKzc9WXrtMEDbaooFNgRPowhMvOkorFldXGkl+e4qJoFKGL3VGcMi5HkoW8EZLYck11xUkiKhI1A3jwEzh5jaDiIMUGzq9+ilpIEaB/JyEI+oA4IMzWSZM4BDBFDliQQwdKoMCloyHuuBljVuENcg8JvXds4rRxLBnRHddf4EAE3Yx2qPmILVFeE3ysKGMfl15v6o62evO6WP6rpYBC8RRUD+AbOFeXj016w5Vwa/fqblXPS4VHhlP4hC9vQfOf+necGlkB1L2U1gMX/rtqeKUfYxlDN7N9ZHKb9hBOrVjM1Uh7ha5piTR+IxF5F+57BAoYSS3AYRbQ4/BxXDO9ikEh6Dvoei4/4hDFtHlmRrFzJnQw6MKSi30Dkj9i6DJwPhCfCOlClLcoz0HXPp+MRisBh4f17mUOmr0Xuo+P29q8M5C0VEjnoQXIvnSz/0T1Wz2sG6umcU0mwZhqIwdmO8l6DHuhn9yVJO7C3B+6DAqCY6gPFwNrCLL0XiU1kKLYdaTc0IC359Pxpc87aDyn4bNhKBqY9iFGcNcAPmm1QPVhgHhO1Lt+2x5b+NfORtN6RwbW7+68xBktiSIBpq40urxQGo6kEIkrBMv51csoYqKbYH4+7KU7LrphZZsqy8UhB2s5OsPwlinV+oIeEW1JvPsg8wkzLEjxf/n8Cy7g/feggn8D9LRPKyFa3Q+/1q/y7u0hr7WD+VtTZDLEdG4pXXhW3uaHLvzR0ca93/C7AGXgaHOc1oXWM86LdYGHjd1BWEOMNL8Barwo2LcpCKzdAKzAX1uPJVDxz5FfduOxQcYp9gdFd8JPPTIXKWZQv7gdj+q8w7mCQAAHtmr/AaQWZMdoUbCvzDON6cb45lzZ7jt0EKY0SyUo1obOueuLV7ORWstWPiDPdhNlJV8oY//s3zgfqdorfrtb0XT2zg5IuI6JfsVgwoefKuOxvNfVwBAxyEqUHiHQOoJmZw2xNmcWZH2YoiOLk3KAJiTvG3Aa/4b1RcFtztTpAmt1avqJHPQiBNAnV55yriI//fAz6YNU5MGeRyq6SHRweuIoL0R7NqgeReAAjkgHvYyWjhCj+pEQqd6CDeSmJTm/Za2jwRXW0JC0LLy831GbpFsjvThRVqHzPy70GlLkyqUvjrYahZmB/ZF6WsgRXpXoj9/TOuyvSADH2CvlpZ4YWD1hIlFV6IaW7A47o72ovcHICHVUPUv+GvZZsdSL1qJWuLPmuuTOG1/UetrtCVu4DgD/PcnqVg3vY0FpsKW4OMnPMgwejFG0I+II3IEZmCgaF64HEdzVOQrkFCaxkb/mnRf0eeeOKlw3Wh1NaR9U8wa7QaHbV/ibcQghAY974HvbkkZQ/8aX1EgbghUKqR7Jp/zxaxhgcRxqhfju3MtL/rfEiTNXBEBMTi0E8jUY0dj8TTyECFFkXnFLP1B31adk0opSpKe5N5YSVOt19Gfvbbq01+QZGvuhd2gbEsrhmxMF+E6xi+NfgqAsE5dqADCJVs4vT9PvQWW5A+s1I6kdOfT+4XAaIldAYz9tEzIMJu+9IycW+03d+xz3ymDzR7WgYqNhqrn/pOC5iJvZQzbB16YcM+J2EGVrLgBCOKT+m6f6vpAFzDHfUsm8d17a13w+gmid7JVtUExgKy/63eilrKnUVnlzhV5ToG0VzdU/1lV6wiRwxzRDU+ceSXYfRdc1VXjIMzPihG6kYv4OHZPKQJHvYpuO3GUV1i43408CLly/hk3ExwIBVl8FG+OIJT8car2e3WqYcrAdyyuhCBWNvJdYzOT+niG331CR2Y1d39jIGz4ZC+mDlsNmq+uhMpBlGSUtglljgwWT2N3G+tEn7ofdARje1uYC1e9iiIhh1czUlcodHQrvTJXL7MAK/5/6Is2l4mamhD3suB1O47SVuK6FXR8AGDdpIjdTk7R/HbqpJqU8FDvbZg9/kk1trmYSc2fM0lgtmfpLhP+s5fLx1JAcBGxSctmJ3YAu74I3x3Z618qbis/F7pv67nHHcctwisJJBWieqMPmpTeiOzNjUciFhYzjN739Cll/mDwwCXXVDknbQqtq6L4fNrU/1ZkmYpM9cXIHNtatUJZSLQ0AIsYSO+KMx1FfRGXLC4PL9vOVFhZRD2o1AQWcC29bqmu+BbOvrPiNKiautRqF9boDNvZehpw+hQPj2hCmjiWanQnAgOP3pRxtPWIL+1rpwBUXH/Y0Am4AzETwKHxbXhGofjCGjb25yOr3J+QwZZEfCHz2k60XHQ87vxUEn5cDZ3xLjn0gWGbdi5Vso8VEVRGIoadOeypGMte6C7HCPscH36MODZWn5C67duSFwW6l5R10CEG5w+GfNCK0nEaxWW1Ob7dfTCYPV2kWYAa2vrmzA2pQL0Acj5AUoxzJwdjjRGtvAg9u/Vp/8o3W6ODmmCmzIFfZX7YoYEm64Xfe+reiHvHy0C4Td5vQa/km9ykBgJ0flK315krZkmUlfCEmfCDaiisY+KoOhtG6foVnH6r2FK/vkbaWaYal+k9bnyaQj+05vwKemixw3CPOVM0Jhb7aLliP871+yMoccnABeVK6LkKGJ0TFyNDvEip7ae609h8Xhv3are2OZM7qERWRgZZCLPetHk84rZMn83StKYhudfvLsESFH4+ME5j3pUmridadZ/z4ALJQqGS2OMJ+B8aRnMaJWue1z4JfaxibZQKHVZCF02N0JQsvdCzri3f0xgrMgSDtly+xuJSkONZFmR+CsObSrfc3QOujSSRT5gKeVdjSeE7EbYN2PJ2IYIDdGGgaNRdz0S+f+q0CHepNr+taruC9mZ9HJoMUuKl2u3zhoElSIPBkqaWZan4RYL9wAZgQuDl4kuN1X1xMLMVRDSE48KFRC5rlFSY0t4QnI6bk1lE1altI9pzr7SuvwNt6QT8uDweSTicNv3Xayx0O5eQ6Z5DUNkyWrPfkqTbC7ajk1ExT14XiRvHFNrFxIdoXdDx7XD550RdkdjVHEIDloDoygwdEjCg2FJs0eCrGfoiMGe3pz2DNYhhmFd2YYhnBs3SxiqUs6eI4DvwWxwhYan3LV8IU0Vo2bwRs9cVvn6Eczs4AZ0aWyGO7h4aVltB2XDzThqhqEMNMrosxf54H2vkiflR+zjRi6oovAYAg4ZAh1kpxK5akgA4Q+HBSB/g89IllTL7hgYPkWA0HTsvHV0DekuQUfcu/lS+NLT2HzXeQ3Abrpiwg9XBaT1nkc7DZs/YlCxQZ88Y+TtmW7FjXjUBZmS0AXE18K7Siw2yXt0WDTDZBPZUnkyyeEZV/M/o0pXyj2XQXi59W0QwxbBGYbcFnsqAD9IfGDPP5Gsy9GLxg7ZzU3u2NwDKpZ9Jx1fJ6byc5NN1dggUVSzSNuoSzyY0S2RfPbXTkR38SEcH8pFR6Oo3E6CIZmJfRBNIA/MUS777QJsqAQZ44TKeLvYHeaO+d79HG/PeO2/MhkD+WyefsoJXQ4jYUmzRm15eMo1iMqm+zUyw4asS5xha2PKw08REpoqZuQpTklOz+zZhyk3jNDsf3paodbFjS8yPoCQIKzxCgWcsA0fG8D0wW65oUGLn2kF5bZ6KN3HKOhb9F08K8Gz50o05hYVDK/aZdTknPALwGd1HJbpQasrQL7und4IUtqAtzYYnAH4v3KqZobk5ncmvMXdcD9ki+TsArelmsgavW0edwh91j1mL8T/LTf9VrHXc/96IqmfHBt8DDmDTkTghDgFE7lMcT3gDxdrc6z6vRXxxfiA42zqJLezsSEKZ8v+6oJP+mFH40TBHx5xnScSXgbegKDG4uM7MR9al+tAFk1t5aE9UkGyl8Ms44I/KLJSgvIWy/TSyLbYMY9HuKCeJqAnUyFN2irJCyPUllT9Bf3e77pUQmaPxCof/NC99mTuPZxHnYKr42iNHRWqqk2sFT5Eho9H8+8hXf7zi06chNYS/ldfdAqBLEDohg2uaBWhRWXsplKE6O+3qOhAfYIqex+D1cQuqgx+Cv2Sg0WPxThB35ICtKNpNaq2e37LtX6hj4fm5qAW8GlBsmomTV9BAo585DjB2IuX4ZRguOs3M0q8bj+MsmniNeUPfY1zfOyftez7iewz60+681DCtSP+hYIkhLsS8oAjV2kJ3yP0V2gxsAiY8C5zDEglF+LbMSsqsHcg09pz9RfX8Jjhz7OEG45Z/iJTCLDBwC/cuKEamfIKpHydjyHiuvsGVWuxJ9sBVVyYzE43GlLjHZNnY6c6catMdzbukdKXXYWZiZu3W2aZ0DEfxG5bkAu3dzyLtL9o9qBM7BKp+ysC66rLXCHjAO1Ajt1dkpd2AkuX5sxIC8jAwjzzs3RLt4BF5z2mamtlP3w05wVtbfk+Iwu4RuUD1gZDnquBqqXK+qpHTdC0IHVetF1rNNnGYWU+OMqCXXatbWxxpGlcEkRzeWy3tPl6rznJTUGthYk1IlSWF9yq2DiB35afQ7wQRDyn8wYKCPV4cJzmTyAWyBeHUw6gSShQVUdkWljxWdOPBMLd0ExP/kmAIuCbIM/RKmyKjM1xjZ1GuiXxJoY4WgIJEFNz++0fUuHP1fW6588VsRBVQmkofg/VZ5Z652fIF7TnzPDyCgY4Yg88toI5D2sdOcZ9aXhop/8VxhVz0ZbgyTatHLB5UzjQDRbjXlPA2cG6gsi+r7iT3O1FzgwgpmuuUhTIfCSE7NAL9vPahddA2IZbaThBI00QDqrDHpaMVrmHhsZXoViuMxaOkxxpEVNiEXEVY8rzLmjRyFMmBg+wBdLmYd49iFQXQ1I9QZ5IeFTFeRWIsvt8ri1Dmp3mp9QdyT8ovBJdoQECkUy++rTOnb+2n/wW8tNpsZzxVe+oUR92vR39+UPw8aINxt73JmOqbdjKaJ6uRyBdFeR7K3fPqNT0nl7cWx8q+A3fW3UNCbJR29BI2tk2We+A1YD+1mSBg2e4Jr3bWMri43UbVhjr11viPYub3PjfT+GZVmwZRvRXULxICi9Y7BLx12RUMGw3HaSnlQSuRzOBvfUDq1DpSY+dGrNR4q/oNpe2/Tes4/PFC8B8q6xCTIkJaP5WyvFtjwiqz4FvROQX483DsklRMV1gGaBQVnPHMMqqEpfammHsUbxez/XjyIjP06xPxGADbx9reN2/MT+TeJkWH0Y5MK0kF+pP5401EbapnA0Qe0uTMstnkaiGZJB3U0NreMxRCUt8aEUHhKFUI199Gs8Vcdxs+nGwCR5cs2l4+iE1/qrdZHKht9gzQ/qn+zAjY6A9RnAHARJGZHHctMCcBVdh7PXDud+NbAQsWkXk8iISkJWO691j9GZZRkN2CJmd6pK+I4L1nUjPCmlDwMVknpfWw+Fy5lumOStnDSgGkgp7he6J8Q79/7kDQpFF5Gq++Cq2p8NXsiZV6T/tzyuO+un328R6C3YM3dzROScRk+MzygsDZTdRFvCCnoAplxSbdCEHEUAfef8RphkQHhKaIdLCZiFZrQmsfGcDUwhOYNF1AwYOrHVibm6flPxSvPWXeF9PLQnFygMhj2oetE3OTJBaGuLo0ymiN51qdzmn5a1B2We5VHz/vDeq34dlRsFi+AQHhVePPXUYA1X7SWMRBCWfM+wxgbSoTtDjwF3LYq5dbzSGZkb+/OO+OE5S4JDO8qkRzG6NxqDMgB/M7UwBLFdUm7akvONM/CkT/GoUMJctKD3sEKCJ9V00H0M/QUrj3/sL20LF++jPot52t/gdG+CuLN9sPSSC6qd5Fy5j17i+jbxd/WapW83VFcE2XP8ahQPSnZJqI84irw3Kil3ko4P5mxs8uyUERMYoZWakkAEKBlVQavWK+SEnn6e/0injOVjJBIzBH+NzRdBPv42y3WR1dA+isT2JXOED0xHc1i27b5rC7BhvEM0aBbCpc4K7fKgPOQh9G6s/0H0XelS2Lky3wlkIZFMsS3j0ZWs7hNvy/C6KSTFo5N2/mAvFgzgVWkDs0ssb0UCT11Qp/rHMwIZYQ2FHcOUlcb+piULAakGE5B5Sn18SNUtccerkKjNwcBAMD53TP47CG263z3ZTv5ymq6mfNJAPYqd/B/8/tnHms/XGeCU+F5eqpSP3HXfRTFfQbPP53u5oMo2BQZZAgk5g1fiDit1EqnpumBwK0VWvjaCPGFPtnXC7glscROjlHpDJ4AvYh16u0C8ycrg6N1si3QEXkyRUck0gTxlpLleLxklu5jP4Jy3jVZ/Gy5SAsq1jCvT5XmbCc/zFKd8HsBwJ9J0he9qTb0wLJQ8VBR9AnUGR4noagt6JnqVUZwMpNr4s2gKQH07XC0cvJl2FO9C4ULmo6Ei77J7fOuiWkvCBvrwOSKk45+R3X0gQYDlj0iZnOZD8XwPYT48/kd4vLlSQ3HU/CsTGxlnyS/iBTUrX+CAmcM6alQzMNsWsw+3PYwvCEawP3N4YqwMBWHWEJnJQ5jTKQKHtSrj0SQJkBL124ENefA/wqaZz9mzdz+Hu3f0SCMZpxmogPa6MSHOYrcuADMUZCWxHKzJYe76dP/piDIPNC1eFNKzJJMZ22LQUNLVLRuFw7NDTUL7mSe8SJh4qVlqpXHXhHAPEnS28l7FXy1Z98RJS1XMjnSmOGP75VEe7C/4mpuxLccu2OVHKadCkeiGnQsxxyo4my99JweMRLoCAiaDBZbeIo5vxiaSTxTuOD5u/GPqUoStuFZkB6Dp7gitBldpClknLwtVH+jTKn78nsUD7+W+8VkCaS1CWXtxJGWbPOaTmqr3JfCzTLEnUr1UgUh/Lxt7lKlFaI3DZZeWNveObtnv4dl7OJh05treOSWfqax3pZU4Ps2A/2A352KDzH63ZlXJKPgcJXX9qLxxWeiF3A4RGI1cuMhbVqv/TGwuEqY1q+NULdslJJBftNShoP/ojPHeHf0xmGV3wUe0BAY1JQCm4pFVv/gJhrZnF/EsRvRUqv9ClA4nfgUlcY9lTkKDCF9lhZwPluIGsp+W6dC+KzxdlkjXmWnLroQewgdt3K7E4rB74YeLhK/ySHzPRZJYiGR+THM7rB8KXjPSnaGTHlgArtvOHUvr4jo0mI0HtMO3zLzdrB7i3SYMGkKfTeKheYVuntLKe8Wnt16O8nH4AaefIZb67eLFvV6Mq/hfGrM85oIkeWnCBT31LUgZzFkYZ6LHKMXwVNHZUF5HBbkdurYFOKfykfVE6L6WV6gIpEM3ZCy+2DAVg0wFDvBxbYe7SW9H3ExD/Izl2QAaYB0SPWCWc3E3rakB805C0htiYp9B2TkcPRMZLIRN6cOgO2lqZ+RvPCU730ThIjqa8MueFlcjnqHw/Fd/+gYzDIVXh/Fi730W6uPmJ4gPnvJePF0gFR3Hgol5JrHdiDNCaSPTNSolUjBRVSaLn71hp0wRbqBRAgMhYRUYXpmmsGJvxGwtrbs0r6kg5BXZK6XZM7g8+vy5LJjKuQbHViH2Lp24b0EZyoipxc2vRAm5NNufRzj4YBucGjEpQd+YqSo23dmy7cBXb9Nt8QzzM1PawdRUa/NEdptx8R8bpANXlROSejcmUp+gQ0uKaPJD7CamflYdPEsxoyPJ33OfBJhp8WqcszGBckbzsSEUQ8S4dQIrXneYp5tyxuwygwGxlXBGpD5A2oBA3vcdSyfroEFZTXgNg6uFWJsbHYvsaCzAdGhug1PZwG/ReOxzlfOKGarnhUZg0cMbrrcxXtXhV1dVsN1Fr8C2uO9Z1wDR2YbsAE+G+V28HefamxPjzCluGYlb7JvYG/yasxMIcLfYcD056LdX78LrHDd/ROmajlccPhpNkEdhD90eli77t7CQhBgN7UjUu77Dv/wKRc+06phODyyqRyWVIeg7HFphU4XcbRltTS/tyYZ5zsp7v5GlBaHsVIEpnFmHTQOAHXzonxJ36rP3yNUgFFpn1LdFfoDfHzH8SZyRTT7dpkf58kJYhKLHLzgLPk6CHLEwa/H/YW5+M89zkC2M3NzClAHB8A0XK57a4YjlIH7qxL1Z5NIJlVFBa6981ps+Tr/ErPmZlQc3AKpqnEmcgJby8ImVOUF+ayuSKSpRPjfezL0Ei5zIf1yRGaatKHpP2UtPwhhUbgBVIfeg4b+qrliSAtwq/Cy1JLP7hb5i7dve3QoMuOBjCTh9FkA2tZuBVFZ6Ar3CL1e9EsLgTzgVWgFItk4e/XJGo2YmmPgst2PKa+NHGksFE5k2x4Wv4tXu29vuToCp/5c9gIovFndVk3rO21jp5iOTplSOIRQgikMIzTFiflfvvq+1RjwqQuNbihYjXCvyqWI+Z16+9uNc0QRuCjtavbozpXvm8y67gvLT1pk/Dq1XeR13Yd9xoKC4pgWKK6TLqI4zTsVCZeKr8asF3XklsuM0OFzEi719ekEKUNzlIqGFeo4sI1wr8qliPmdevu/b/Sq/CWNJUnPzZYeoW+3CA7pTypnH5glvmkqs/rHpzHBCHK0b4QKdhEXABbxPic8MTpaWTW6Bg7c/hXd6vVtGzU/AqSODnsAAALLHaf7Nbzld8wsY09C135ptbXGXtXCGzjuT9nJg6WqaXDDaZdkOKr6/DVN8/2HrdTDxUip4KigORhgzwK97/a50o1P8D3iGLr0orbMKVVV2BwLMF2+F+N25px94+vR+gAeNZgBFKSmmTWoKLFZlrkqBfyYdF+xLQ/VxzWaKN20N+AuYXy/2JVRz2OjBAx2GyOH8VhFAzGe6vkfugTXo6Q+7bmurytWnQScdKRhUeyW9tf2+LGUeHPZEzDzUv1yrErbc2PBPcDutml4h0TSIwni8dydGDKPtD56C2yEKzI0P6ozVVMORZ887oII3uvYcleyzFFRCW5t8x9XSDX6BPWbpcis5azZG3AcNzlzI0a1qegVTEzmeme8EdAcXxCuY9t8UzBAXEJ85da+/IxtEDpJDY8wiGkpxf08Umu7R3snmKNq0yGOKKRG5vFXpUe+O4KZZB18WvjZMSHTD58S9DvU7uJwib0X404s80soZdLLZMfZx9tUJqL819TXWo5w2StY5hHg0uUmfobSoIEShSFBZoi/xUtPz6HauEFj8sJJMcOs5nixTzeVe2rFlpcII7dIRM3zRFWHNYWvPSZbolaiUIweVEkN53pb46BY6fCCUCjJ1S8DKaBDHqiRpQogZJKygq6b8XbvcRVimeWYvg+4EtXT+/4gO17y07bXFPCdg76unoyrDMKzMfSFCWZjzAPHGRzOHOnPZFJyToi/PNuyoAxKqp06xNI+TMp39OJy96V+CWMEZOzVcq0wz4cJR12Z4BnXYkc6rLKZUlFdQlrSQvfFr9sTDima7Tx7mdrqB7QjWEpTF6Onxng8ZDMbsloNMeCvqL3uVvIr6MEE45FwN8ksWuPbLNwBhPxKLZ44cN7ePwynsK98gRXscDdp62umuKcjcbmPdgZLUbiaWP7Qv/Jytbepr0DI8EsGZSoKtM+aQ3xGVF3OCdMafEfcQOLCtZFUo6+/erRZoAV8Jj6WPe6L9vtZCffPooEMUcc+uMBW4OLzw1ySJUKpPZA8jNf1E2TiA+782WeV/rKK+79NRAL8Y6VJeoXovrbCvDp+JaebML2I1X+jhdszEUbdGHo85dYLxAdr4Jt8vzAhltz5zMHs6WIko4v+fMZRdi03OKKkL4DjhTlFRxdWtJ3oCLbQ6oHFrZdSMACDP7shCsx09YJqZ29UnqTr7Eq+m6aKcNPvTIS2zvaihzp5nRlVaHrpi6Spp1Ro8+azPjpyhxa66yk8UN1nLIXgkBd2fZiEbKCJFmzndEHwjKHDbsCOC91oAPazZ3QtvagQhP/cdN2DVzLh8vZcCobkZ/9F+PNeK/xksuasW90ubBWdvv1Wdl+K95aHM1ReE55hXDyP7EfYolSj4rWSvu1aZEZK80AF125qxJIuaJGvqEXeYT7PaKJoVxmTezz1/1qXM8YjVUcJSFh0KNGZD8EcD7nmcI8aB5Ni0aFoEe16JeOZmICmShuZ7dg38I1NNlgZQ+Km7YY8EwtvxZaJzkrtNcZ7Q6k00NS8NH8UPehPoGBb11oLki5FHysCBs371fGYFFvF/Kjv0tHbZbPxQsUnxJ0tce2WaFeEFnD2SfqWRDizRfsbsZFPL/5qC/tZlQnznAZtXqkV/9S+3mJ/IsLFCReVvi0mGdWK1v7P5RorKUxwB27m4g6aF3K4qFObT1WljyPtrH8ilhHTmDqI8KJkTOddYcLp15rT5mFzN//yoiVQKNvFsTuPE8ix7E/IQYWoHbZxV2jgMylWQw3sXGZ5yJlU4g+cHAvXpGLmUmeXS17DxU7K1OosYQFp6diOpsiVViwVjqBVfT2fWu5jTSDmz93BL14wBE/QsNRJYGqDOMkHQBF2JrKGNgrjY+Ak5AYW2aWbPxJ/4BuyYsU5LDu0fnetujkh6FqsuU/tZd3f7wB2DHa6daEKuA0U7UHS840nUR015K6xozpHbUFlocVLPJOcBbta1Gs6ikQNtG06oZa8PSeFGatLA+16uwX5JTg4/U6C0JwnBKh6BnFyHstxmNsol5roM+Dmo43wLDC+ccwg7ZtxzfrO2Of60tb70kMErmgRPmboXeNYSWEF5g4mA7Uo6RelR5dF/4DT7+5GYWfjr1Xjdmnl7+vaG99sBRov8mvaiyJfBToJmgxzNuxN9Z0mWEkAnlM5QCFVunLau3ayLjcnZb57Xs+5PkrvOtof5rNkClaqtN6P8jODIhU47glsqOPnNUET1G4zj/f3aP//Z99sB6RAg2+jMXCSV6hTzUQqGFugcjiH+AvZk1t6jMBxU7a662xc0WCwjU4ymYIy/pw4qa9u9R+FO9iYNcYyciCypyBd3J02gZtmcwTzQHJxmVVlpg0lMaVP2cbGYTNrj8WlcW/t5117IlyVlZO5tM0OpTNBo52p0LB6zkTUJJn1TPCb7AiUZRn5fHkjr0tqIdGSWe5bEFmSgpTSrHSCS11K5aryFIjCNbxMrvjuvxf4ZYZVsiAzKpb1NNZu6gHoQI4w20/H2bn4g0tywu94P9PsuUd4g8mpye3Ist5o5ZgcXWwI0C5uQZqj+yp5z5DQVZKw2ePfQxdiohn2OvjUFpRXXCKcQrDycaIt/ToVofrak1RsdpTqdXy0ud40uPpG1MiUwkpP2H6GgXjDIzJk9Ojh1zACvwdfdS9wcK4PC3Hoq1H0TvWCeo3loum2vZxjd1SnpzAS5uuvGFOM+lLmj4xAvS9JZc1Bw89CcBb9AU0qXvNs2zE3q/XU++vBAn9nkIhjTnbM5HCZsJAVbMJC1ZwHW1X27isfVMSXEp2dVKL4tDDfzifvTo8nJMBxf71QUEAHIBlrjcMZw7kUm0kD4gZLRKlBSX3z/7ZRsjQdLlKzY5tWR3wmQu+ugcWiCAdd/By9m8HtxZM6VaTXXEk3R9MSAm3T2CqT+e4J8KbQfY9cN0G+pmEu/ieRbcuAvueDx8u7G2VyUTqr3bLkyEWA/ZLNMZpF4tEDdi2LhGD2zYYVxROYZeFgUzQv97rf6yQblgFIhWbXveOEdrSjOH7L9r+YE8M4/LsdFWXPkzMbX+CTfeo+2hvzPazsDdg2gbV4B0YSjM/u0YCzti9W0H/QNob2EA8jovw3Jr8gyrkLdIu3+ZBZiH7R5DiLzfUpzBJdZpd+IRpFL3Mx+EC6ntdZaZDZ4Uw8JZJ9ag1mImu5xPLDHXrNy8vurpE28IvKtjdNH6kyDAep+PzfMO9lbTfrcVe27TCi0L0mJGl+ze3ws0wBOCqvVbrepkTvj7DHjHVWpd+7aVxfRc0vZerfL/dqsvhNfs8OL4VIm0yBKJeHjIeIq1ZyMwTGRl0QMDYhpXywvJd9pRe59D70/E7+Ca9/SREdPnqqT7SoVlu1JJoCr5d6JL1Ll1OAeB8zAqw2GaqZdct0fbN7tnsEJ4ZU1mkgPMohNAtEcO0tsrnfeCDGyypYWnTFZkj2cob+5AH2qTWQ4jwA0l8+3rxfOSr5wxp0FXAvnHWgcnFm0+ozgHQVDE2Fhegtx5n3H90QarEytRbt5rRXwe9V/Tv6KaQLxjeyb+dKjfUsRNcdBjT71qGkQQDhSF1pRaNfqbJAkVN1wAK4+H5gaY1i7PmZupSOACa8BKCbFh8q3owQ+uQ0oqUxopgcBKSCX2Z1ukYZ4r5T5g69fhW+O46qRmxMbr8oEQGY5teWRvW8WjLbJYldreG5Blw0WVXvECPN6ugh4Dfd+Ke/Mj0VmCKBBCXT267kKEdVHe0CfJkUDRwqdvNpcNHaGLfHVlHxQwhxBR63VnLujK2/BhN9ispY5H2JFsIB3iilxEWPf5k1MJ8Hy+grg7aCgZAkWXDi+w1nwBD4meknRcHV45HzOSQ1ktpExIfeO3QA6p9yWNoarmoiEhU85T/NrU92m4L3VtVCUU2fo+K81K0f25z+bmxPFyAUu+cknPVlzP1bqSha/30NrjszRpGxzAIWVlpUtTn1ZdX/NuhoQFNawwTj0Hukt1g7pKdXmCVQBSRoIRgLEF9DywLYt/9tpYJ6SxwYXZz2XLq8K4P3lQdpr1zprtVtxUJuGIWwMTpIY52kG810W8WPLxjeyf3KH7Gz6rIbWvqcE/N9Ai882s3EsxEc8wOJKqlPUuOYVhDKbNAuj4bLvks02LDUIOrfbfFIv8djH7Yp55DzQ+hIlp01j+xMjF180S/GslDozdD41iqU/LKUz3OFsLf9umRJsMhoOmoYfbB1xhfytJJ0q7mjN7ZzT207r6I7cllOL9AappRNshf7TOJv7cwANM9p1+Bej+xfBvtOXymuA/8L5h8UjsESfbV650CweY7Dhs/k18MwDodjHsUW+hZPGjZxkIIl8P6+/nqrQxu6b3u5TUZc3cDRB5g/xi3qMsYAO7Fr7yLzxPeG0Ei1s8bUUVUvKj3ok5SzrTGTA1Lxyr+LdLRtLcQshJ7IYfgDqC6IwHBffFCXOQF0cWc5uyQAZIsCwk+Nes6r2TXFPmfyUmE1TLjLnINH+2LRQCfsC/6kU76q7CPlnXRaoHjNPSgzAhQ3XMmbJh42YI1qQ7ahSAvQI3Gsj+wxMUEcVhmUDInPgJ9UCyq3TVhUGJ71+ygWsB6Z1qc2627jF0cWYTU4JEK7v6nUUnSHKR5b4IzYb3JbTsmQLgA/5cPIQBdPC1rLN5rAQ8JuOignMm4yyB65naBO04jMHxdamzpXhPEeLPsrNxSKOxd58FYosaZM4hqLrGbAhXzlTTaM0Xly/KgWS3vueBq3zIyGg/n4oPvPJIyVStkMEyanIOQbR5kA0zJoZZGMjiIFXV1XSnwKGJXb/ggvILMz+Co+ZiSRShSH6IdtBJpqMgpbVkAsVuyQAZIrQ/YgkmeYmb8wyZFajo1fmXAgJ7FXEYp1gdonmq8t2HQFIjKyST0BYhjPyfWw7LNZdpll/0t+slRFZv4Yvig3p8tdSNVKzx0F9WYKVZBjDkxBEe8Vd1Ee0f4ZSSXy4v3oTUxn+SIN0nenC7YaB+g1ulDUIz6Nq49MRL3RNxCA5hGDehDwLlCArv233aOeiCY+1wPsj4j/m1n3qap/JeVDINSQAPqLieYscoTQfg2IjpqTYHyVHufNLQQKMJGUpj4eFW6149pzqRVyv3Zcv6Tbw6btO5Ef/cYqemYFS2jyHTmkvxB4UqP2GO9xteSCXp6BHFP+QrnEdcevLgj+u88V4oy4tAsMPwRoamvnX3qBNUPzWugRxTTyB1GiUoOpikys2Zgn3l7gYkOeaABu2OgzZu1H/yIczMeAvvyo3MbhtaQV8wNcOusekncraAuTySetxwHzfjfW+LOJR1qjy+Sw+gWIvF+ktZvxoO44NdwyDPa7gEQh3FWaXbgvWeufPzG5I/JTIntwu7P6BL5YTW35OeVVN/dfyRfAt7pQECGhisSbLZumB0qmr9vZyiUWhFJor3Uu2ERRuRIJ75TNENO59mjsZxz4qtShwdmuAEJKNB/6bbSGms4gQo8mu7iwg/D2cqro3NrJQyla9gxEEQkeMoYBKjicQjSvMJDFaxuWTC2uDeoQcN1FiRZdYzcIuWnEPU4T+kmNq2lOSWpuoqCdPKeCeYPeQaQWU4okwOf8z2P7K7H15zzQwQlz/DZ1JkgycVnHZyRk2uTBdiolEE9N6GBQgNkoKp0c30KXhpQC8AvhB5gBNFHPmfpv5UhjfaK5i7vR4duEo7MElof5MYWHHMWXrxDeSCIe/YGHDgLcKVT4YTYo8EC+D0ryziU3fuRrSQtOsrKX7mVHJeVKVzxF7MwA+yFyfaXfMuqw2C35wTDJRa4cLYTLmV/YDUETQeiyLiXhn+e4MFa6kZUT0fFQ9JE2cPcMRHG9FevDMR0mJvJragsGV0YoKRQ7jTBrn5jcYR6P1iT94AMUOFLBhoRHizOH83yyQ7s6XQzbbU80LwPCmTGXGhO9sFP4pKwBLHCNstXlsBER4Y3oqPwuyJKXnWuQ+ovJhOAYw9y4AoHde08JfimCtaXP4BAehyM0CtrqzusQZxeEAuCVI6OW0j3Iz9ThHRCecz1xd2glUz2hAIEqo7dxeoc6hf3iuszPOsnGWLgLYybBOmt/UvUjOKqrpYNcWHLFGj24g7R3Tc2oGxZr/STl+w9mXjFXjwLLaaRmHwLF+158c6xzhjSpF/1/0c+BEJXXzKR6A1UDbVLD/Js88Kvv9/mai7RL8s50wik8BdsqmxqUH0rKEnW2eL/n6Jf1O8GE2DE4bpccP1JdwCvfyaYCpfRFpkivsjP2RDcbD0xikmjuyF0Yi8YjHgQBMV0kpxRJgc/5nsf2Xi5GJXt6IBihDEWN+NVyoadKzKjDvPj1IF7iNBOLXP5uLkEF57uDXIhkwczv2Exw5OY0hKBrR5/Ad2JUSM3OwWbhiQ9qyULzWS2mFjyoPM/3jZgqcdib7rZd0D2PAuUxYr3G8N2yj7FKUaeiDQ8JAqj1iAwicERe4jH9t9y+xnjNOmRes9NSJfH9xMRJZhFpbTl4hG9sR9LzSCAEr7WluSIpUhYJC21huWsKp3XcEp3/X5XE3ZImF8yYX4d+g4u9PDEZSkbddENk+PB5d9LzPXBWjHQS2zf57Tv8JEN8bM394PmnErCi65nre6oXOPaQnFcSCW7e8xRgQJG+RGUEJXXHsyBU5jnjzmyPOW349QkW7pD/P/xQo4/PeMXm1JaXpHJFO53yigAqg5CNrUpC7aY6IHxaDU3xX9t/YaaNpT4K4C1qJOkghCrsgDrUazC52zIhJJQw4yTAbyygRC7L1aRZIgFhs4Zyork9qUODrw4RmlZelXcJ+PqHHIq3cHChUPqDjdnMitN36a7zw5vKhI8AVwxBYvJ3+d8bstbHT1P4QATcId0DQAn0OsFBCVd4hSsk5hV9U36Cads8MpcPun5E4+1LOOMUKD59K8deUZoxT7ib95ou43EbVCi7Gphab50x7byDsUnGYncVll6Gq5/tpcri8gUk58KSrMIfbmdWEEimWRzS+/8Y62S7SMConY4iLgaEKHUORNCATTxVgX/1rxhZQb8zSxLVrvx4yB0pzUto8SopNMcRsnNhzBIqNpxrUwBEKawTEzv0um7RQzZr2Iwy1WTaE1pb3RFALw0KFrAhvZIkmEXMNoQHM12a36b5eciuOzKdsbdP/2BNpvWv6lqbk+FvjtoIkvE0e1QTVVAzI+LmjPeDNmjEmeKsVsEq4ZDmX8E6XeQvWX1kf3M7T6BBTx8iZCVV+Y2+1z5mDjCMHXO1UkXcveL1OGriSxsToCo9GQdqSZcecnJQO/DOK/az8yUDpZEJWeUxL/uTQv3sUnWqsj0dDkEmF+Kd/aMMTEmp/6uzglQV3p2bN5UacF6gUOtAjljJBkxAwVl72a3AHj9vdbEx7ALdGdDVS8hIlnbFvrQDX3VPr1rI7uxGG2RNg/BbuWdtK2rMnKWA8Z3RjiWhoT0CK/0DD2aEu3syFORG88hb8QmCdzftNL449Egf4oHeSlHI6dwvgOOgVO1JQKAbDy6SGYfZ2A4WSGeXI+GznwYlsxjFyWAwxdBqbmU0kwMo9P4ytBKNmRtz68wu1m4Rb4FZt/d3dpCPv2BkSgURk2RIy75bUIFMM9sTUcINdTUceQV9En5evbdALsm2Y8CahsTysMDoJ07aaa426cL6puuciD+850MrnSwDRIxd+vLELa3lx+58U5XwUMmCqX43RuB7zmO2+wDfpemuXZV9HMuvsyYWDFfKX2KScwmpvdrfFhru4K3d17vr8RSlS1Qt+8eC9L2ufEV/BIdMBSvxTK6QFk+JNd/cSAAPZIaK7+U0AzSFW6mZoa0I0gAIuZa+D/oMkabda6OqTT2c4iV/+CsGOuDAy6+TePa1v+ShVkGi4uUmNbeyen/I5rmGosoRemtUh6odfgNtqqK3ODecsYSUZNaF4kKwtnk0eWYn11yGgH7wVINV6pOf9Fi467zHZ88A8AIbkjcVMuBhbifnudVtNai4gc/QRyUauNr60qpq5e20K+2PkhDfFMZIlogxs+NvIQedxheIMq4S42YyLfm2J/uZ2JQT0MCzGMd3dgy55cRuGkhFCJHbckpy1OduuQWfU2JAoAhfUB+f6WwyC/xn9Du6fGokSOMkHRbfLK+ebIAk4QfAcd6f2YQCjMSV6zvPN2YXXUcockXPwxHUcgBrNSUytlknVpDxQby4X4ygm6nQWjJKq90BWn/p6MkcynmfbVDoYcHjNvwXLbYs5/M49fwyRxS/ouxTvGlhvxuRWPVlnbF1Z+JcOB374pYy2zkQrpyjKapChT4cKE9XrGxXY/edChVoIsaRXjAfbycQDlCN0ZeIMxKeSmuJQM4fxyKoSwP96K6GmihUKOOUlkmwPAy5guDtsYnpc6Bcxvno/YLWJUz9VF7oN+CZwhRjrRNCOcm5FOIS5HU9XGKalkZomc2c5Y2T5DADfsBNu8YCjvQaSvecB2JR7hfiQI33Ohya04MHXUva2k0A0Jeoyg4wU19tRoFJRbG3OGuubzdjOASbSuVYEzsguY6hHOP2D7tmDbaZhR+voZdm9RH6unNJxW59RM14H54FNRcPQFAr5gPA/P4hwEeCrP+UT/hYBLAs0BMfYQ623GxKUVxCdb3i3YoZC1qp9sjIWh9kDdVa6NktwLBVYYXgwGYtaj6KiyeiRnDrsPZgBuhoHaKjCf26P3Cbav4otl0DD2GM5U0exC9/KTq0+guYIlSTiKdnH4S3UdJinTRTM8uVYoywRtlpg73AbqT8udqhXqNfKFXrsvOa5dW5hc67LmENaFPNHwHQgO+S+zZdgqNxKoAoT1TsHl6ddKDNpr32hzIfbcc4yhnTo3Jhl76+QaNGGL+Ysj1XUBIvEm+XpPaH1izvG0dXIlEAzF3NwY+Iyiibn+2516DMr965etdtj7vGSaiSxGGXI2s0PT2b2D3Si8gSI21gsMkA4+ZeC7T5d7ZI9HLgFlmPECGQ+RWZWNqJvZFnSSB4mpOKbEsTG7vERJPClmQ4H+zhnhTd+RVFk+qpwCxS55Oqi+3NEaUc6kwd9KXRvflaN8iqc0w+PPfEnOY+yvkABfutwEbFJ9GFc/XSIYOw8/zmhuKBzL1EKdOlFEuDQI1CFrhMb5l1uKg2xEv0K+eveirLMOGcFvu1kq0MN47/LxehOHoI92nkQFSHBWFUAtrhAsms5lqr/Nb67QjHimGw10oqpYUPFWgjZgZOygkcHL5ssOjxczVilosCKLQ8iAaWU/fu59ScVyiowRWAIbUxMLTsuoJAQCzQFlo3xNRrJ1WdK+W4CCT1wWN981FMEQY3XtbjLlkjMly6pGtTEG6519pdobDsak6X1/F5TCgeXea3eVTXSrJWbecrERz7+YDyyeftMMfVY8yVIqcX5GPWoybZJBPA0E4V4xrptM9fPrrcispSJGmzdr+hL/JLe5++XluVqZEJBDQ3kbe3L2lCOBL0NHVLbIPBvX7Ceer6T2h4/v7ia7w7Dx0BpIswnEB1sEtKwGqyykXNeXOnL8wnP0c771oKg2PY5ToOryKxB/mte8NH2394eOt9Wh9RR8p1OUCyCAPM6EFdtTETD9LwetIMnZ1pzk5nwBysh5vuSkh/bwbWukl5ws1qedKegeXZWGMajTjBBDpV6nten6MvXgHk6WWbDa6VKlcoKb9YRxQFqD0Ix1azxh2+PpqNtZZzRxCBBuMeRuR3BkxC6SkV/njQ/76zucn8DafXCyWcibp9itgn+TPbqaPsdL35FElnv1WBBXMuVHtTC5Qwg963gvP5A0zyEe0tdsdUjUnONbe27Hb1B12lN+8XooXmiGP9dkXyklUHdcFK3xrHOVDwzZcnAOtCrkHbkfssvN6thtzVRTKv3w73CMv8wM+bV/eSkzsJgtk280LeDCAfHCeZ10dBFKKUPAft0Q5ou4KDhl120KiqdPv0ovd3tpU4sQccPFAYunF3bphCfV/TBakRWxLrUHunkwpRwsH+beCVkrMN7KZsZZaqN1DxRyfdTdWR0O6LvqBIEwmsBFHmyyMAqF26Qjbk0WK6enEthY1ys+9X0JVjFDi/WfIAk83kzAkVmwmpcLT/yPNrTkZ/8hYOkg3xpe/zYP/7Px8NbOBKuJm6VbhKGCa8QACRI9AjblA9JMdVkFxWkgTto8JFruQqoTmtEx9SblXsACyjXOCu9T/0LCkCp6sJ57zlE3a0mKPu08B2iOMxm/4E94QBll4vgA7cYvkHBk+m+gQrP7b4vAygr7dMCCVKNDyEI1IIxSb76GkVMhEh+IsYvvYUeCCNmBk7KCRxBz3l+1yMAKRJTPlryiUc3UaUBrduiFjDuyLRAq49TXoYYMYmLJ2JsLotmoyT0Obft9aMie89qDVdqucF3adc7cMsvo2C2dS6PU/MjZOIA3l1q4BJPRh3Ez30Qdpwp+r5qSqh+QYRonZ2mqjKR8u8kl4T1iv1Cbv3VE202mbvSSqx5kqRU4vyMetaI4eY7ZSkKDbHXaYnooyH/KWfTh9pYWYQNZEd6/bw3JlVVDerOkpQt9HCSBPy02EaaCVxuPBEfr7mvcpZdrSvj8HfL3cO3CJYt6Bov+zXPceyKGbwprla+MnIziliuW9zEWfIYALcXw22otleqrD/zrzDMXsZfsos9rxZ2bsbX3zytccwP+5YEkJw+5Gg0HHIM+x06HNe/z1TzaNqwwL5wolsCmHp70GPCq1zJX1XPnweMJjwI13QJ0v1QsT+r7kZnEOpPS1r3Isil+ifdAEcZcLqI7/05YgPluKFKYwq2jkfOgsyvVytMGaP/warb6BUidtce45YnuLUjreZWccoq+4pt8O94zIu3Gkg9yUO/VHo+xgt/Sj0W3VxhcX0UDfZ4nFYIJlZMo12yDlwPiBzSCKkL/Sg5zX+efxvSUhg9d+jA9R6BTqDAjSdrzrX+y+kzXdHu+DjW/sI8Z7VQMBoO099WMtnl04svvXuFv/GVUTeDwZ1JefqsE3Y4GJsQ004Kcz2ctblgL0zWhWHzViLbHHAjhAQVSW5hYHi+0JxoEzT37a8H0dg3RHbVlFmJZqmOeVOvSIb+JqlnubXPlX5ATlLf7YgG2e+Eg+hSMWjPb6ks/Zp5l4CD4EVkkUwa+DI+fLRz050FyNd6eYpAQqn2GiHGf07tNn0zT45NNwf9AF4pA7SffSEQ62zWiNWEaphKpg8e3VgXofaUkFaIkzoGzbD9Ff0z1eQiEuRN2//oTHCZlv3b3vFZ30g7EW/9LwsTQiMgG1mtt5B4cdbKF0pRpTK5srOVlWO47qevZh+/KpaNtjpXLB2ycU74V1CosVO3gK2RpCLPvlcRASkWIf7s7VyKym1y54MQl3aHRb7ESYTBb9e3nCxsnmO4yBS5ej+q1pjhkpXT70xwxT67ivVISNf++9tQYgruuAVKuZi8JM+eBUwY+7QZjJbJTU04upEdalUJM64n6tfCPr5DGWfg5Qpmgx873WEhzqjqDS2IwslOStAtTlejyHF2i49ooi3des3X79Guf9OcS+id7cuTK96pQLMcqyZMoVXKwuj5FZhWoZwCua4pmM0hSsD/ey40vK1c8ZLA8j5c+7DPROkVArYzKpXPu5vOHvaQ8ri2Ur4aS14z/9yhZpmHiiGLz4kvm2CFD4e+EyztwFnswtF9lMpcoWm28b1Oc4oBhqeSMPelfMqXD68b6yySiIbjsr0VNIFS/+MCTSNzocMyoNe/XF4RHrSsJvV9g3B+9l/Hd6TpuNh6bgwxF4WqK62g5Q3V10WHsuLwiHkCMn/pm4zO50zw86fzWLz16Xav9AK4YLwAT/fpyAhRAlDimYfM2R3vmY368sYMLq9BFEOrzmWczL/v9qQ4OMTdNaRmnyrG1fx8xuqA9tRPRX3A6+/MkYN8Tfy9WibKrgQ7De74Bjl3wb/mmzHn+z4QqpVxhV0re69yBNgXKjhWOA2bbTlnsFLWJHJKdjG1rRu4zWgo3B7Ucy14NuVcA5ovP+7bu5kLklSSrmxNLiyS1vAnXVhY6EmwzAL228jQiepeiWyf0Ks5Acu6IzEZaR2HdxYGssQrRw1kad6TKVUUoDVBlxGeFZozqqKS5zTEe0L+X2pHrhaD4nQjurC0QiR4ULmdauLUsV5tpDosEreMSyNGKUpkTZs2kRlwr94uQahQ6J8i83qLYaBgCwatRgzcpdx8xRd+Aj5qUqDB1WUu/95olKoz0A3rebMS0iXAuihaY8X/XdS5lr2HAT1vd7vJ+BO4sxLJO+3jcRETf08VvAd8vtsSQX16OtPkslVQ+eh5DQhpPP5zyqKGztz9vVhVNXml2qVNf3AnbrJlNn8KorSH1sjLlx76f5Ct+yixUWx0Ni++IRE5ajU+xTAlhBr+HNs4NyMrEQ9yxbTsBLdYR8IZUr0muoDEfZBjRbZJdqO1jqF95mRL8lmk0aQmMs0m9Es/kHtq3zrHdN2Wy+nCeGk16VsqaSgb+ib/ojWQSr6jU+9t3DQrKDd3DZffmsdq1839GT1RU0rMhzS0CUhoa5m0gRKFB4XBx5vveynrjv76VT7O0rru6loMyPQrIsoRy716EaSxbx9Lj6phr7GMR/2yiVTV1ipdj3Kz6ohw8EqRZHw3jPFPms1pi1wrNEeTWcqpWe9RME5MoyqDfVEXWVlm99+5wbHsCEKjGJUmWNFV3SAuywyUsmopRIMlrTM3HkqaAwiA4xVXAZkxcpQqDya62hgByNrunnFwtGG70XfA2FH7JfXtXvkP2GPkRWHaYHRrYPpvjII8IkTaYnItIOfi5wdJwOhTInVGGh+QZVTR/JwqvqRo/2BLRYpIRaYkLqd/6VDBj9c7cwzu890VSyDcACS/GFWPnZQkyiwJvyoaQvxtnVHHlhh4r2tiTepkhKdxZAOV7myWby+f1zZ8qmRbKlZKOLUuP5UXX7UOunGvH5B3W66QTHJTVUDTwzLhCHRNBELnXaktJjhv6/Uv6qCGGNmlbtwF42uUVhK2nfzYqaFSRBeNOCnM9nLWzXfD7HQyfwJM4DMmPyczAegaJfd9R5rY6dT26Vk0AQ+zBhmR69ddVNkG9VX1SXiX9432l6KTu7BNVouwcxlPYN7AncAJHRfFEEGfs9Vgn1c7IM+wXUmme7qavL+lUKFMKVkL3ierYToceLSqyB9gY32+aGHcolb0XuOhp8GRJrT+D3xpEE/h+9MJzWOyOaLcu+bHW+UIBv01SHkUHr+MDjSZ0TqMR6pSg/cxRDTcdmeSvaRyM2nqIGjiISyqabg8dIKz9EWdeTSLXrLDIkfFfeT5krtHfMWa45BQ9tEtp84D4JoIhc67zbqa2Xrcam0sPVfQdaHJbwkZBDM9YUEGSf1xRmnV8qZfPOCeWjPJqEkLw1F/qEbhzTaiLEanq3agg3vIlT2B/Ieb6iEzoHPlQDw+I1T1gcFQq4trex3/hFJAczV3Edj+TYqTSuE7JdFT/zmRYHbDf/l/DrqKkFYtJmuG14OygAIUqdmNLicjOgKJ39zEYCqFmc/04iy2WFTFrOyUEWBFozXDFZrU7pyRKvIGaR9szXSko3AJ0t2bOAucJyaAb5CcvJiM1gIa0L7A2eRLn6Q1b88APYkyJlovNmb2ChXPY3c31kQgPTj5gCu14EQ44WUF2YydvNuFenz1VT4nxsx2nwLWIHxXnuCAQ2EJEjxIiD8vgP78AziaRNU413AwlMqxikUo+k94dXrb7vM7HYEdmADNXW7sWBj2PP7HC7OPaB3IvUeQb23OzIrt2bDYc0Yn72M8NyW3D8XMHVJGSGL9/aXlebI281TgFoeWaIsAXvOoxTWxk0PltCfihrcnoNw9qNvtmLT/NGR1urS7NRjx+anh8ZcQ1nvNTs8esWdKO7i9mrjXT+Wm6+3zBtyjeu7EZC4OHPq6sjSi1jCygmJxylTk65P3nuhlbvujP1Z8YQ+XXv32HKxP/b9VjwXpB72ET+9Ta257On4U5TsEetAgDT9o3Jv2KIobDg/bcyrf8AyS2l+pCx/JxBxDo7izqbPM/GxguzhtbjRghY8x40k9/labPdmcrtAiWE14uOS3cyh16yX6diLdYRH67ey9BLdeQtjUTbfYT6YcoJBkWIZ+y1qGDDQeVyOjbYO0E4NqQs5sm0s1Z5MRNBd3p4X5n8rtTSh+kL+bLjPWdpIlCqSwmaOGe65aGCFEKOJMktlI6D7V+sbmBdU9qsK5/hpAhpEqs8WBfeJQBjaJx85xBF7d+rTldlu1jlzuoGISGmMjBeP4u8ynjKDLnmLha4PS6vL6Sc6KriDfJTwtiuIrnbEKvH7vB1OIPuURzbo6fJITZSqHAjgcRj9iFsxZ0LJosql2dSE1WbXC6+X/TeuoEGuUouxacxIKyOeZfKpJdFSwWgzsZ/F/amwDqBf4ZF+ctowaFflhMJFmg3vhIQqarrQZ7M1X9EMbLqGHnbw/4N0fGseRBfYzLZ7kXOaGPXPFRECdBuH580LyS4oGpMJXq72y10m/HqetdcqG3LsRTcNOCrtiVaDSHBjIFnxY4G7qun0aCIXzaJeDSXY/S5w2mVny5Gk6rrTSljncygHxoaHSIqu+60YFQ9rzgTKlh+rJvHSnRUBM3lSu7TdIUPBjS5tEwezm5JC/FVyMr7KP0JEYF3bdOgQsS6P8ueLifJfDK9XhKMMOqQVNbsxZMdchdii9NnewHdFGAcJHdo2iGWpB/SZpoIgjblQS445yquVoi8q5ZJDaRe06C7NnTapkZRrHfo5sRKbp+sLeNjNSXV3VdPo0EQK5X21GJVjOdt49r9e8mxd308BQQEXyaHfidMdRp2lC9BJLCXqrZoHivP3JetXeKyE596S6nLGxmk3PxlZpKGP2h8z4I61e4nyJpoqjdm5Vpf4ffpjv0RmPHltZViNPihpSgdZd5n0N5BKLJi5j7NwGABCZtPVrCRx51sXZQWRgIAtm71IwXUauIc8eM2lzeZpqhVZ/ZXbymJHjBKrDnMrN/e83pdrTVx2DALC8eFbeMscZl/Dd4hPfKruUBq4ZOPn1SsdumclDxxpXU1904h11Sh8NOlb4a91QJ9kRWq5Dz5S2wpHHfvEZVnmgPyNwIPHNhsCukXfiC2M5cZPO26zCYaxZy7OTwamegHOK5FJE59rCzEx2YVLSxM+kz/CKNbZiazymQkX6+ZdV/NWQD00kzDcixcmX9n+v8bZ2VmHNEe17tBJp3o9V7J/gc0b6jA4ARl5FUqYEhVpo3IN+5r8CDHJwv1UjNRnMyFtoBrv7EZyRjG09HgAp4SFadVCmiW5FvMDLZZ973EHw8IfzuU8JAb0sD23DAUr+IggTJp2wtc9MaWWK5qE303+U8ufTOqXsts8GqOUWN/fSsFiPUweRY33Csa4Yfckpxm18WTr/8KXdUCt6R9+eT0C0kbAXwXWZNRO9zo4HGqfi48E2fSX8ShEU5XcX/cJBjXIyqVV9s+zamUTgC1I6l/uZSKWcEGT4TkYedIIrCGocUEGArgLu3OiD5TgmAwEyfmaw3p9tpuHnonNCwkaFrIyKQySQAMf2LIEiy0MCjAbs6vZF3HWA2MwhSq2pk6cN8mi9T9O5awqND1e4aUZKk/dcKspwcYAHFqD166kw50DptfiVBz2tI+lbUPU1HNfES9bIJYpSKfG/AEYpXhuaz60FmhYu+pVAv5yAJwCd/QgQx7y1OAXr4cYSONMSYGErXxsqYkAhpW8TommSuNkJWh2oGyAqb33W5WNFKXsxJYJeJCQ5pow1m76ZHOXdhtjhiU4huFxrK7G2bMKw/h4pGXeOZUJDxdb3uk/dwS9eL+1RitmKPVmwRe2ojz14TgMo2vky8bsVEBOaMdATkN6W5zCHKv++sXaIe1q5A2E54ACi5DC9Iv3nc+NwF7b9LKVQYXKkMuicKgI+ZUU+Mv2XNPDEAJ5TOUAhfO8DSJ9CCoKovZSrwhQ4C50mtU/2zjQH7qvgZRolchyso5RcPld87mi/UY6oaaihdy/Pd27Ui/bm1F+l+0OD/91oKEIN8o0fmbsBk2ClrOGhYkd1MbnUDFT2kpvCpDqxBO3+SajmLQLOu7Vj710+KMJ70V0Fn5DUZBaf5fMuaMqAg873uWxcS0J+wGc3/r0NUhsyUELY+GdeSEOtLQT0huUPmXgGlsalJO4TWdQKVdQfDjtbPidsdoD/dbJhZGozBtHUScwWYOKJvH02rXd2n8aE4UM0xMalxK3dvBw4MeC7ssMA6dzaZodSs14fMUQdLjzHSbcEw8Js3WONIz/TpzQopGpsOHaN/gL8jf/Kt5POWQ36eCaLXEfPbfBoEO9vZHcGTC0dvT4oj3mvSoG9hifgznkfycgg/fhvv7+s4cnunyrKKe3YaqA7oLNVXAKt06JjY7uo0eFGJ8QJbKpzQtwOdtgUkabcvPXMg1dNGIApB6H/w1Qze+M/h/eoKWAV0GPAclZkvjKTksY4k2zM4gMjyb/d5xxyiYXkpKfhA4Dk4DWA87xH2YxEX4XtlHYiMdEFhjv8H4d9mtdJyTQ5Fp3Po6tRHmiF9Ji3vCbqBGn06SXS+RrCg8k6d89jVyqUsxFoPdPJhSjicUr95dsUIVDg+7ZgzwPWl+o0sXeCOAWuZ7FVaJ5VWU3uPEzuWmCLMzu2bOVRdzPZUWbC1dLPd91uYQ5sevfP2CFxUC/g8Ca8P90p6+poiPkyUEItPnawj/Xgt6hb133/qczu69GDyEjpRktybu9yKPc61QZ+x3lmzcdyyt+c7ZoxH6+5r3NIeL42ywpl+mEi/4YsRqpVP7b3Y2yuSidVe7ZcmREodAhOEimbWmYTgb4wbfIa4eUN41wyGnCgzXdfXYz2qx5PgVmq/CInpALRCtK08gMA2rABNGlnoGY/X5AgQ7xK1t06g9aIey2dHTfzsJjgDt3NuWXwEVBxxvcfCXkft0JF1PV1kjgY7dh20RA4r6Gr+McEIkzllEh8vtEuVwM2YKH+LLG4P+lCl/OMZuXnw+FL9I2vGxQZ40sHRxCBBvDk4kVZrlV7+7kbAaqF06xyQFomeKFweGIHa6CM0GT+BIn+vqI1W9HUbFZZ5JWVBSLSkYZ4t5wIp0Kp4fEYkmi1C/gQzPa0FY2mioGQJFl0Us28LIbNCnc/M0CfqmkNsknWamWXvgfiqI3bv0g/VBozLms83bxIgSjcbg5FjcwWoDjRasSnSS/z1Aa16FEk+uAaqGa1CXdWPdFt2HwSMfmuaVPalGb4GmAeUNKV7uKXYbVSz+KdTTKDU51dNvIosoz0KhGAqX73Et3jaHCRylLII5htt8an6Is/xi+wCkJhw7YCb7jtTJeB1gu6WIHgFFbW9cdqMsOeGIHa6CM0GT+BInXLSUCuEPskeojVb0dRsVlnklZVjv25nB+TtpDbwGt7mgO26cLch0QOcSLaaVh1kwuzr7bz3rHwE5w4fLgYEuN4x+abcFs1UBxMRYBJszxeGcItJJd7igJ+4a0+nlU/Di+FSJtMgSiXh4yHisU80MtwZToCoCCTWoo5GCOgiw8E6UW11ylk/mhpNuueuk2y+ZsoSikV6SUoEppRAtx2LZa+iOwXOP9Q+09nkt8HUydzhhZ61LRMpMBqF1DN4avDu6FdhVSgwyu2Ogiw770FZ1D9phFcOzJbWwg0RX6DKmOObETdVZn0MGbgYF303s9g0IbsuRnEnTKnEUWtJDnzbd2U3o3UKvGjKzO2edFahbZq2RHYijau4zTYsNQ0uI3s0ttsi2sgejw90BwoG75ruxDO4jvtLY7wCh7emdv5t2FZfdWzrMwC6gToscfYF3jxNAtEb1RnW0450GI4czM927YF1hI3cZSAOvCMqoyoQKAMK9eTZLORaq3F7M8qEvL1/PtjmskHxEV0qhpNiz9cDaWz8CBIVTfDMTeLz+43QtyJ72CH162C6yRPx1mal4N6oiFVG4aziCtPYA+sYbgZoDJDEj6GNMIiVtiGTfmRAML2oGkznY+OVxGC8/NV6GWxNiYKqzWatGeDLvktKtPzWnOzz5pHQI4p3H7HTeZD6fQGiFrMGoO7UKnCNl3BKBxNCZcsFfJQRWgXJZderhMY/xT22NPkiNX4Z85oRZljSC+jcz97Cbz8RLKOxVqZZaFRZ4hBfkHYi25fY1YD3pksC0FB/Kfprp63AWQWVl9loT/ixwWuK7IzbapCRCmYEcvMqRRnyKF75MN7g0k60q7mfZhDFb6/51cfKzRgmWt0L5G/3RM9yY+Bj1qwRVFAgCbnSo9k7LF52XAqDkD8KnG1D/5y3NaIqMtfAKbMeOVxFyYF1oWHtVFnrShsI9voqi2WrYtC3apo/ekdoB5IGh8lWGnGvm2jt2lZJ3eX/maFIZAK1pxMWPBkAfyPE0cMGf6g5hLbZksyYVJ6USvSugV8wo6KHp5QGjPlEs9SnsH7NvlGkzrHLzu4it/+fcVB0VH8G04M9EBlavI8uMUX27ZsQbn7ji2vtvhkAhDVX7D2ebeEQlrOGs9cJfyK35KCW+BUErv2fp7cbhSLG8myC20Xf4SCueDvWlDep0XnQvpE0NIKf3yF+656eNU4QS9IGIpC6Cdu3QEbbd/EVLNOV1g8v/GE8zJAwIV1aSuXytkgahHkogPCeH/DsQsJF/9v1miSZsMWaxGZKV3PvJUmAa+5PFBdqtBK1Hig+l7lSwFaUN+kN2EkKrjt4f5XJzViL6VYM++18dKSYNiTi+TcpcctSbU9kP8ghKtGBZENKHIhDXngFvT42ZF4bCQ5unUayNuxqDGp/jCTPa2+SsmmuKcd/YljSnaSKOiTgJQ9x3jjmssdyju+sqhRO10oWAMYSde2dYz6q243K6r+vT7pH2C9infkgHiHZkfp9ED4vDzHWwgfwTnQS9LcldSlCcuMuvchjeMe2KIF2+HOPUYOsenbhaGciN302EFcTcg1fic98kcWzCq6yQ3Q/cQpY3z1+2Hjrga1QhSTNltj6XVkeCcZuAC3/zmlYIoeDtoMwRQtUIDrdiuP4cYFJYEIwKd0z40sFRKg8zm/w2+BNrE6DdSg0PixZYIWRSs0Myke+DW/iEYRuIihKzkKcgWvCguee9Q3fPZJKIY8ZtywyszC07woByS+mme1mYNPQ75yd+WCeqyxFFJwAgighaWH8fIpbUMI18xt8HYlF6t86fcUoBikeJjli9LtQgZpvwWt+4WkTq47V+dRoqEdK5ucTZqaaxdduxXkn+EHncv8Dg6gSVTsRs7/sHGo1MFC+ciiAImqWaJ4v/a6tHuDGLWCQhNryW2/PXIkOKtH4MnJvE2jiRKC070eKy03UEEWouF0+2AIwZ43NOVsyLv+u/IxZTJx2aFsHgJNu8kcy5Z0gf5+WoGvBfeEw9tIDabWycHFPttVLUOkMm0L5yKIAiapZqmBm7Mb6iQylXE8mn/FpsvrojqTN3PN99gbAZoAJUcTiwV3Jo3S44rYKkXd0+0QGKfTE/4MT+xV8baz1EkXz8PPd8mdKFU+7QGp4s5E+3ovDkGM+F8v5bkcR50l3kwLuZCL4S8fZLgpGR3Hk/5Fy2dV/daEu8oIaj19/c3D5nrOvuexRi87c2mElVaEs/mpKX6hv2EjQTXo6fygxMqcHTIZioAjEp0bqLd7LHd2AVCwPVzIj/p9ghHi8z6AsGqGZjT9NdRQ7ovMf4pfb1QlT52SptuTVkerPkODYTY9gBRtjPxf4jCoGlHX515GzGFlSC9A/NOqq9DxGfTipiBdTjIWBicyBwSYylLcTz+pykmdMH33Figo5W3uAfkIROVbtxXYJGQEy5wjg2FwssR9sKH5jOpSIUEfmHceT/kXLZ1X91m+dor+dvJN2+HKtoa9UHzwEJBIFs0cg7cLw1rkeYxdfQMF2RsEPwisX0omIv/qhOR36aBPczieNS/uyXZk7Gd7zNdF5iMte95NVHPT8jDyPsYGuyeeG1QC9oVvuey98HvVRuotQ2VmFm3ZBCAmxmPJKAXTNRXnQ3wN7AHgUz73trSOHNoSirHjt792P5NmKAttWVckvYv391i7M3cgKhqapyDtIDDuU4YKCB1i0MzN1rXA2DLIVscKNDbBtA5hXfPvFZo9PN6UwoqWIzwUq7+oeodx3gwMvLn+Eo2dXHa+OI3bgGXdr//ebzahM8QuKI/Heu45L0Mb4qx0o7wim5aT5xzhEV+6ds/4pfb1OLwhAGYhjxm3Mz0Td9Jd5jwmv1lq9n+nnKFn3R3rmdX+FoeqVa5K/Ru0CBttrF2VYfs1slZSyjE00bhS/K6UmSorfjlst1ZxEklyXUJ2gG0xFa72iSQRhr+bSflA8XVmV81XCcOfoKunq32tU2n7ngDnhSTlp9MO3IQP7jFJIN2HlARf7LhV8oil1zkJV6H99TeLJTsg1f4rFtfr/Li4/D7BOMkjSct+v5PK79WCdf2qnPSQvix0eM04OQRhDLBy3Scr8WjvJaWyng2s4rTlE16urrsIP2RPLfnqpxN3xc5E/bl48hMwqKvmts28oEvfacFlgzaJxi5485sj4D7CCtK2VPljPpyBEfq3E11NATk3Os8adA5gE16eTy4iHnXkj5UlmJnbTHRNF7OUPjjiYr9BlS+42PqpPp+sjsMTFNHDVlPg5kezVuW8wSDqzBSrIQY8dVosbncIAZg/Id+xriG8a7wtJVBWbolJvzjpvE14GsCr8qSxtLkIfLbwv+a51ZsyVJDPbjBO+dz0BP/ZB/ayUoykv9kuGPZk98thhtIkDtx6qpMbbDtE0Qp7Wl1cm7E3mnBBRqHpiaoI7g4ETTElA1tR06fvKXaVwAp9hxQQ1JzXXgJPyEWtJx09lnq2/5WYu6hfRVr8mlws4ygrSAitVnrdd10HURdFgdF2Ug5MPPr84VsrlEUZXxffPucnxLn2cPPctw49frMBTpuynM3RlT9K2qs+NA4KRvRk0MEMUyKHLbXmznXZr1i1iDObsSk/MJopEVNnRSb7hkQ902KUwJOCZA8tqiw0bLWXTEKdcHla3S0gRqDI8LorXKm3PAdrd5HnEXnAYz7xTPFL5ZnPsMYJqZPV31+kfMgYF71UGsMEv09TYPpDVNuPokxmWCgu84DexruCJxJ//8N+C/Hwh2DgyHv/6txakiGO8ggACVeTV22bdK9qwjNkZJx06+l6mb4xRP0Wk4TgUgQLIO+i+AQY/Efd80b4BUoGiSVjuzKtJmDEDsXVXJ2O7z7rL7ZqYC+OhFdk3zEis3JHT/aSlH4bqboIbfDkG9i6Opunp5kACSh1+bRZb8dGUDK+/K+eWbL+pgmuVb/iCWNvyN8hHlf1uqA/VoKySHP8qwhILs6uaHvfWNmN9A7Ob8Op8epRaxrTQgScRDlFOKgTF0uq0phI83EiPjch4ZjMuAjZUYNBl8Q4yHrQ+DExsjVb7kabj0bOogqKxszB32zjOSPzihsiBdTZELIPsMdxheJn5sIzKsgz4odjJW5UBmT39keMmU/CYKKl+JwL08GPxbB2I65Y/3OHPMdnzwSi8jDPl2F1SY/MIuMfXhVnUgIqccTfq/xY45qLN6Eitiu1V0vEWXdDAl96Y6Kj4ATw/olaZhA/1xvG3h9BcBhx0xH7q+JkCzK5O92Lryg/+ZyP+sDyOjo5KjI5jtyaE7idSz+f1E6Ow4ChVdn2qIrj3XlnrQQQCEhQXigvq+W6jitMTnTBt99qqCvU6ZuDKd9GX3dfSLsCNT4g0MDIJI8xkwHbzSvAl+WOkAnLawJzUdKHloj9PvITJR9Wuy6G63vqij+x+DZnWd0RsRDm1L/sZ8RLRCPdQ6E9D+FkLQjpRzv8bVlF/TlLl7//88ULOo5jVfrckU50blf1KrLfgq7XOrz9fpWwrFLzU4QsQGWt29AgiOcZUEfBU4teG2MqxNIyc4rmfv8vy6005Oxgy8qqi6NPo8gBdFol0ENZTTns1lLH86eozZdu2qpxoInWA8UdApdIKHnbutFU4AClRCxdWwmU0x12/xZ7AywcIC5uH0gp4q2QZR4jvUVyvpDnt9/T6NmzHxB48+MSy+aZV51Xa+Z096ciFdOUZTWGTp3X4+KxYfHdQL4kq1uS9EFuUs43iMNyqEssoGXe4BcYaHuwkDeHukwQWDoFs+TVRu4Nic1zZZAeErH3AlcgC9O+UZP2nigYx+TGukVeAivJerIcKIOkZmWh2bP0ExZOmJ9E9ipRSVhGiEs7d68zGaCrX29P/aLGCBzKG2mLnLH+eY7Png+kGnzw6iVx4lX+M6+JMMuPGIKPHGGmiUO3CwXqeJFtgEcsH35aFnTc9v4EPLQ93DD+54qHM3sg8qwzOsDCq90fR85ZFNKxZJHsnTTogevAM5Ir09NpQBiu9/3N4mcDaGQ8cCstXtwxDS8MoBYMZQt2CrpjCnzHT0KoDES/f4dPYhwRZmJRv7oG3NBNCiMiXmEJWEiJ0Cyg3rMva99O58+PhHsSXWnBELjwHKGdJw2GA4NJj9+u7ihQGVfLYAdkdgFpTE08jVn9gEoZ4RuNn32uFpGC83Uju0svkiixfTQBjb5cv0siWnJ/YiI/pSPeXicTqEipKz3dXTfVs2scsHT4RFuel96pkPqiDwsQPGbjDed19OOD2K07wV3HSsgcpJUjskyl1L1TJygZxHActJ1afQXE1TffO6cL0cTbTkkd1PnmwIxKIW1LVe3H1y5dNmnuA8/BO3gMf5Pi1ewj/vaMSIEb3+q0gAt0Sx8dAVyWOOPAqFifBUNCrRMcat+TFnriLP7HYOuU5WcjFBk+eWo13wkPH3snt+eYcDlNJvnBF4FUrYQOTJVMX8z04eEYpC2jqMYwm3qME8W99sOK74GaKxs7gA8Y/fIQ8BOzFC2/ekToH0KU2sotzH2yvxFGC7yZO7thQWnjaJ5DTxKbeWsI8TEkMbHyUwoXVPbd91tG0Tnmj61Ue00MlKKHMEC0HzESss+IiY0PZzlIFe/RaPfGkwR8Jek+1EktzK6BZz5dq/uVIvFAsWFDSzPZaLRdDdT7FcTSDr6maMhn4dI2srALinbXVTJrcwsj9mYYsgpDKwj4IsJEegio++JSU55qDiAxQF6Y1zjpYXpKdPLipgGtr+x0uXA6TfV5FUN20z0M9/ENoTdX3lNPppNo9/KVJ/Eafmvfh55TjH5fVXZfHZnv9g8R15cTH6Gu1ha0k5f0vmTfrfjOggFyHFACIFuNwxtIpgywwgGXI2tIByEnic/A52bgKKKq0LF2znXxsmbSfBGheDsBp9VjyaVHZisdY7Tdlnh5F3HPuMDf3IVztlDoNRcPEMTBX6TC3vIi91XYAlt78QFA4wv1ovMXIyde+5JLjYaQbt9B0DMQYdF/5dRHnrwnAZRtfIwIRe2ojyuWuGQYC/OAncFjE4Uy3/DutVC848rTi/aestbLv05KIBnLVA8KCfZdqVDJYzgY1mY8F7UM26xNkh/RPOCAKhtsCjP869iazpzh1tJBSCjuL4Qod97mnRZ3w9uDxXsMkpMgCY8lgdZAHqX0dQlRhMrP7bT0tiK+3S8zeAYWh3QF251iV/ZRfgnVAOjbg2TbKGh1Ce3NjNO0AxSWFMtiLcxlMb52m9bYGcHCebuaGdtKakMOr9856UooayZe8poxcYqgL2dR6GasQuwWJard6SgDEuYQE8WsC7olUjhzRwhxDpWakZOjnfetBUGx7HKdB1eRWCOqLMwezKH8LeVNyxEx72wNtLaexdwGrI/Tmq5tBjSjBMgf0J6lGzlhh2Fo93xl6awNvCLy0oqV8tfMoad2NsrkonVXu2XJkGDps1bCQ4oMPZKGwgQBE9UN6s6SlDIUoBbXC/CI/m+5KSH6NnGRoYEjvf1NQaUkiN0Io9Ed+em1x+LSt7eqj4dEsoodFGiYWnO+wyBVaZa+SX6iqET/yqjn4OwGn1WPMlSKnF+RjwBsv+ymXUPTo2e8XUxahag5z3qFfg1Wr2kjZhANgbFbTo4y1D+YQNKQnFpPZsU8BMXj/wc79db8wHM9/aD3TyYUo3ywm0fSHJOoOj9z97G9eoayZe8poEiXG25/vD3B1ZF3SPCyfLqGIPOCgoHi1gB1pyDWVFDHkSL9f9bilBap4GpzCzMUQdLj5Guf98t1365Y0BEhp9+pccwrHE/YxWsEzxL/+QT6LZqSkt6cFVR7JUgftDnLFlrjo/k1Ey4GGMX38Zsr7A0LHZme6C3FuAJrHF606FFp/WjZQUy8etokyK/oQSVIIHEShP9eI0fq0+oX2cMrb6cN4AummZg9yOYNMUWSk0IJne5Ob2ijUrsz6D9ylr68Bt+Z7f/L6x44/AWc8naNpbkRw15kVklcXJGGvlXAG7C9QRob21KOk/m+moFRf51JxHsscEq6gQHC5jM7ig4IViWa5EHjIMTPOZn8COwjmJOzozdJpL2lQdXJ4ez+ZsTIHdok6sd9YpsupXrYdgFQbXABkXcMI5Cd0BdudYlf2UFV3M6hkAymbJGVIPbeUbdHKmMD8Y27Lnfkm/NL/pU5U+phROYhfDsg7cZWCwuiQrx9cvHTeZ+NMJb5E9KkOM4g1/xBF+p1qSEg2FSoY1Cu6q+PZlNWXN1My8ADdYQLp6HYJzpwz/l9YIUQZmN4Oa7HTDq1LRp2I2EYQTdkX7Si3xXSCXLGvEDSD5yEuy0gTeTl1NPxvzYoSEHbrlox/E4K6lM/C2Qe+zzOiU9VCEbPqogFQ7pRG/2fREcE/XsBum6lqfch45s+tSN0a0G1JVD0/l6MdXGCTUyW80HK6tddd9qGx9DRrjmV5Hi0uwqWuMTUhMs8xRJqFOyxOrAiQby3aQugXKeZxPZ3wxfFCpKHuINXCLqz0PSPMFEzn4d/l5zEV6PWYVU39ILS6apKyZsBSMLbmLHCvoPQUdxi5pB9zVKYWSyUklAeUzW8bxdrPZfTy5eucQY4NYIT0/r7554DShYdgEgXNm+jdcPXsiLB4OlrPlaTO+YqPFigo4TI0hq21CNFxGidXL6eufzbdcYkpWZXEgiTuZYf9NkFAITMea0ctRFyPNXSgjiUA92FYSemBy+yOCVw5mrIACoRd15rYuCYWMW/AsudNg0ESZOahWpV4cEP1ArEpAmID58QsXXi06Sz65owV4UKwl6hwDnT2U8Gzl6pq4O4xpzXA5mw8BfxGatowOZvxxqUGldfYvPMBfE5ue+APbyd1pUYmLdfRmsi+Q0kJOI+E12ocUa/2Rwr1zrpFvsGvYd+AHIC1KKovqaa+OoHsroSZ5c2SmPE/0Nk6GcRuh3xREgkqs6U/T9V0hRiaeRNmR6Iq3MWtziYH5p8+C7At4JaaDE4gPaarEnVBnvFwsdc8Ge4BEDepyiHnIFiVxftZmM1kdaY5th6ZmEoahvQMu/vfjItPXXsDtX/YFCjkpqfspBEOt/YjW7F19AwXYVGkvMXCJNf2MmKVb58TYL1mo2/TDfyfZrXbKGpc6WUcvWLhwIA9JONYh8QC0yhUXSn+0xHqIvScvepOER/ler1f8vV44ue54xTYfVGbRj0eMm5GxBQCtHiNgY28gYVFqG80Z+Qa9QqL6QwIeIga9pG6/s0lvrX64kHqDC25czHF5Amc421xMLyroUJtd+35FMxop6Z+3OoxLjRhtoGC7BR3/PY6slQUvDi9Zhza+eNNrFxHUbvwojhAJfdjHDtIteFZg5ehLofn7lfcDq5r4KGmUXB00ljFfhCXIRfz8M1l5jmaHKPIXEXHdRXPNQJrVNscw0xDj3BvRURxlGmBuVuMkpufDzmhZC6MRe9xlBSEg+2AIxIgDxK/ADL5VfzpCTn5L00p8EexwAOGBZoWV8jahbIc1Am/K+KYRnC8VlmMLRoXeQxF8lmh37MVRfOySH5DwTke2v1Ma9gAS5+woqBkCRZdEa9yvefXJQOAY3GdVg/UMNIOEC+9nB+P2Nvmnol8Pc2wTqxQexCA0UrBjMXGzqvk2dyu4Th9joKtm1r18f4SOn5trRm7u7fOuCN7mjKLH575JAFcnVmMYNCqag6iLLptXZ97Jyz8TOXcG8YxE99cTZ7u8E4gVI2fnX/FCBvgum0WD9QDCEgem2oz618rwZPgxaHri6Qzd01hl/jg8KQx86Tq0MI/kUtTXnHeihBX1pKL+pMnuROgcmCFJSEIbmFzcl0XuFyWpOgdYhrwglL+VAy7aawODg6iXe3x3vCrbr/rZKCoYmwrJ16imXPGF70o5aZuWMShc4EEGJmDH5rIsMkeAqn8xIyjViJuovorFbH1fLCwlbsycflpVVFSyui1oKxxOT27m8YOWHX0GnbOkxJnYcG3KzGMGQla2smLcSM1VoMwWLVhOpUI3rTO+FRXHpFinICGtL+8J+VyWGMT04fQ1jjGdDtl0q7HDtmEmBetMZInRhOvoNO2dJTI8HmwtVQV0Mecu9ASPWZeEOa0tAMZg1yWPoaxxjOh2y6U6acK8/+RFIxop8JZc4HSdwm+Mf+rEjkKSDat5rRNjMeUOlUGBm4G4yeIzNEBiVklkqvuaW2F528m0vJUACQE3c8woJW9TAahf6nc1jkdGjBOdtp9fiOXD5z0iSROO21jze2+QFeY+0rqMpj6pCBcpjmmMPEBiiyPaZmEIDtNtMNClO+ac14dUq/0Bm6tTaaEqtdvflg6+Ijy+LMjB/toNUGE/YeZ0ZbOsfkJ2paAhRJvgROjGZHqrOSh3SKGZSlBIDftzOD8nmsI8FkorO/U1bVhN6deTRZclG/4ECYR5VglXJooJGI5iDTzHAECiZqdcOpWDeur0Sx5YOq+vrc2mMw0FAoNM3v+hEpieyqWSulbt5VIpItXOhF+j1fRv28VQIpdd3QbruYbv3e8DkDwGFjEbVadTnnIt0a2m1AIbBbJQYLoh0bsBI3QkCNCFF9Yk68jp4Ng+Vns/oEi1yPb9fRdwIykkD/yu2ETNQeDE42CnpplciU2/sn6mS7umBz73dXjFLi+jKr2Z7hHZWqWyIZ2yAO3oGOGkX/IOJ2bg8o3n1lf+QSKmhthMIWieCq3QC9IWaGZSVGFgnox+tEzZn2F0wV/Fezo6JtJZcfBkxQRhQwglxCRhhEZtwT0gHnPeZhLsenkx9hhct/VkByeSUGChplAnyagJ1QwbNcar3r0K6ItnwI5QJZbxlEv16uB6h9O0Ym/GETQVuB82GJmrPxtUmsHInPM3VvfhssFCWW/fOwIz1MZLyOY/OvJEKTWqkntBw8uNRysNOOlt2RVqZqQNNusJZ4Nrg//zH/ttdp/XC1/8ZNXqVBuebedFz58AChDCPPU3FAjOzXT+WmkF6yN0S0wxofhaPu8BjPvFM8UvlmQrn5TMkNm7Hl3tl8XRYfBre2J8LNp/eVtw4BPN2aIBJL6Xc/Gd1O2YgkYKRG9jSEyMWkz+fI7OfjM2CLCntbLCMJQN8Ec5b0IhVAieI4Nk+pbHD3eubbNpc04WVylL/Dm8H4uZhiDQdbxQdZAaBhFajExbq0hZqTQRzKRQCBEWpahkdbubV/VVwJGQ288CU60C8EvMLAwj8O6CuhCrGd6tOasXntX6yrRlXu3Pizj2i6d/Wh3g95F2AOfmNxhfI2aNMzCbobfePEpvqJYfhPtlC9d4XczJDvUXQ3M8Zpz7RasbY4uCjkPjcsVINcrT6FQMeBEcew+lrOqFs7x+lkTb7/VH2t1l9veSSyUqqoitCDxS6fAy1UksaVL/QRgrTJCui5ZI3QnAN5HNIC9T4fWgfDwsSozQ7gPCfeDpYJ6BG7IlO+JLBifxgYN93N4ciY35A3JobwWCErDt6pjvAqJJKcuH7kjbiLXKUjWQttl5JLYs8YUA4+SFlQlplI0yskM0CLm2RfHGBFIHVQIOG6s4WbKsGRYIX4KCpav0pwGimNSntRh5YVv5g9STQjZUNvIcTt9nRSAxYZUY3OwqAVj9PxL9hoiUhU8q0QTnw/9RTGV6ALpCR421CnnTc2DclVkRohxVmSmWvcK9ULhfNYDUydSAVEq+TAD8DPwPQ3hqHF0dJCs24vLDqLwpDoDesSm7mgjQJfX3FHzPtjg6WmiXT//ESk4Gndo50beQfyM+VoIhWmdBVDmBDbly4B1LpTXxAMOoXRW+iv5gFKxIa6spbYSbKAaqhP9JofSaXYzbwOGDoP00jo+3+AT+dpp0UqYpLc+iPbWYESa7e2v4fSZlVh8vkTrxGiAF1vQQCj5MZ6B1g7eog0GRxau5gCpCItCniybUFbI1mXqjbor/QObr4wYu19GmxQp2dMoTVCjHh/F9vhs4ZcytmLZgxqciN/PW/J4zETzYYOEpz9Q9kzJq9owbrfvVd415gXghaUM+CwDzjC+XzBPle3L6HFi2rRNb+kDKX3mNmYP7IzRIgavAsOrazC3q5xlITTh01NzvV95yRef/n9HzqTYEKjRkRdl0D/o8X/k0HtAaVgrcGcnqtwdue1dMChpGIGDumbJ5XggXbq6GXmL/WyZp1lVhwXiCTAQNLFjIs1UKvbTFpF6oWbAp9sLvG3DqS7j+06TPffIn7pMhyqzv401s0F9MIgduEKm6JQFieeEeQlpK5ukkE9ukNkpMqFYlHzJgOJOqA3wuM/OpCclffQiDSTAI5knhV7eblFqkJ3YaxnHGLBZv3FilEjPrMK3k/83fH7a4jPsEeyXqYEgCj0Nk6ZGWmXtw3vorulfzNFyKD3WHnDwnObe9It6JF4CR4L8gRQ9aWPjqLVcXEHnJGje0/OEaKzuJwXvCeyqm+n4mnT3czAFdZSztUv6QIIYxOfilJEda/WanGY2kScLJ8dQP3i2O2hoVxEH6sVeUCUev1dI+1OH1tRbHCs6xbqmnrcRonXOko887Lk+K7+QjiqxrejgMkVOCR4jxLkYwhXqUjtH7zrRSrUHCDFpWim1EPtC46BFF8iB8qUJKu8QVgkKxZASxOn8HwnZuhmRbgiTWDY9wroNJya7gB9YASqbVf2jBBgNauYXzThu9UgYb2Q2NQkuXjco4G8QsXst88e9yoSfc2hvv3wOs0LDe5wwoCZVJj0jIsGSgIL/QdrRD3evhlWuFZgrykmy5pQHyVXC/VwAvAnBiDL4F0L8g6/Ty3XWSZFL04PKbvQrs0sMJEKbs0aeViuybnsyQI82EkbaNKpmeDoLlQWjpK3/XPqM7n/Hp2HpF1kcIHOab75c8qAcGLkIURO1NnXdpNeqfFZzOxEboU5J6RW6rsx+zj22UZmqngVI3RWnDam82/0AZROppZTmVw1qxujs1dJ6mpmbCCparZaM63i42UstLJ/s+6TXE8q3Onf1JRgv2hNW75xukFHprbObmweHLLqq5aTJbSpNz+Hpj7GescZBYO9ODCG2HEpnBzWiN5AW7wagiaiMp38gOIjYVenD5fv8AL32g23i7t0UWAtfRsBGnuYmYHQ/lTV2giLt5Cak0IgH3IR5uzgbSMYddOMqWqm5k11ZMra6e+QJde4eH0IuoRiXBoG7P67ZKSM+q+CVnnVrgposBe/rXfSYugSIw4YF4IU730skBKxNJ+zhfq5sWSv2ai6ZZ8AexGY+9NRYf3qXs4LoxpGU0Ybl34F+IWh72fVsohwERtqrZVXXRLz+uquQZbFnsVb87rt6vQ80nQCumPSR/fKIZ9UJlggMryz0f8WZci1NxszRNRjb32khl1GooYg81JwRF/mkBn2wzQdgDM4BmjpU+BHkUrYe3RyNLHTLcoGJbu4r20lqSJepWaOz4uf5WesA/GDPzUKxMzYUnomeE5SD9R8vWn3zyAs1ICOhJeBj0rYLs39vNixXSVSYk2S1C0WMU/MZkiTVl02vlSY4JhmYVrtnRlr00eH2oD42XpoYaA/C5b9jciVkXoEqqw+SjJtvDeHRp6t/EJWJ7Meft/tVsSbYFRAC6/hyXy8nHqNtKTMaXsC5xk1gGxc9oz5ktgL0SsfKWaAwDek7ljRNx0XCUAEqGOns4md2NnfTMjvv40AR3Rt3ey0a2OvtjE9Ab+vMpkaXO7kGta9vfgQOnHiLb9kT6pBn+/ts4Q9kAWlC4vUByFHcfqB34rdnZgDgp1BFr82hJr795LB1pFBGawDsZZstQeVQtaIiaC82ZPZ91e282sz1vMAp7aRIW6/QA7v6tz1xRpsBVaadR+AixBC8IDq0vex4exRvaYjOpBQkr0x/pHmiyCVjd83ZJzSB1032GCItBxUqkpO367xsvTQA/J7oQK8cYQ8SsGQAIcjqBQL7hk/wPO4W2sxdGEiewVgocKa60ol1RrmgD2Vg8hikKub9ueJTkzvPtVLLb1KIu/b4cWXCLhOdpaMbpVlP4+nqROaALzwDyh0g7ER+OS7AT/RU0UYVP2qR4Ie8n0/hVWLFL5LkXC3hY4uW7Sy0F4vfYsoQelbrZvuAFh8afG8Ec4Qf0PumNwADWlqQuyktp7FkGAlG93XnvTh4Cg+Uu0gFocm9KZT0bBLs3BVUGQy93WicCjBrEHONrTnQ5uSQYkGKV8WccHiS33TpMUvYkGWhW76XZOgUvOT6YOri7R7CZ9Tgfobl1xX84YBGJ/j567zaj2VNFbt/toQekn/Hzr7H2r4dN+agSZoDDrQikkGvztT4bYgShtU80APib82o9lSdvlcS2w5NVmtGlM9mkDvqYL9SJLISwqyW4KA3zjWFDCbyKcimJOaIOOH+f0jMdQudwkdJajNUz2m73B91EbgKX0WpNXNGTKchvMtHseFdBxrMDJd6flbqJ0pHASjwnXxzTbsoKgY9j/vRArCYqc6uzjBvzaFhjJLHohLggl1cB1B5Weu4WiRSDocvJaTdewOceJKXk00ifEKPiFaP4DX4fOPKEfPXIg8kd9u2xvqxSrACuXHAZfkw5/fUZ9R4pku291pM/N94qVcuLVvbH+Y4j5HKxablB7fyRQbkVB30lVbuaV17Ux3sMtJmCYNTYTZnNLW74v9VRNiPPdashGagez5ItmuUKIDilNTZAYQAur97Nbf3Zs+aCAmWNbeJDHRgC/sIbIKnR3GUO/IZBvLUkwj0gIvZHA/jkjX4Xe7cO0Uqf3AHGkAN18JWywK31GNyMq7Tj7yUCAAOA5jG5NWQoC+nTnzaREpf3e0lklE0a/qamV1vvJbx2VSiXusvCwSnJMwc3owmmSL/WGFU+YGxYmXdzd/tJzgM22hWuAFwVN1MmlzxlK7JC/TOiwWV+2XhlXvsQr7lqntvomA072WsdbEgxUGrOjgsX7A1Q9EaLAeMb8o6bQxbbW3Pm8F6SlxmSQXLTDoIzhmBxpbhmoqfqFmc/mveVnrmiaVKN95tkaJSwhrHAuR9ePeDulUXXsKwjcn/U89cuH9CPtCFnYf1lk1uOYM4Cd8hFMZa1yvHlO52rKk3sRo7If8KpnE6GNEaEM7T33E7gDkx/z7AfItqVpaMHiSev3Nzdq+0LfQTCFz6nHu0EZEhVHHgyrZkWN9kMv8ALhsfWtimbwbE1MlRMNd+TpZf/dwO3IjGmTZXBWF61svksYuAifpsSuvtlgwSydeWCZ60z1wET8LjZRaYyNsw0DqtTjuabbCBaD/YjZaeNqA/UlfP4f0V+H2baAjJ9YyrDi4GCB6c9vk7knKjTlnUFZEy5xBrhbJdGsVKwxzqwTCYQzIEdt2pZbhVGJHtliHXl8RryxTDusYpXZjqGlVEIxYvnYRE+AgbPXG137JfA3V7l7a43AqW9ZSzjlv6quroh1yPk0GmmPYbMJpgcRUrEYm/vl/sJMSo0bgpl+guqZULNRyWHGdqZB76L8C0NCmU7dLtFKb++5NDnRhsLTQthCB2I4AcRpa8lbdiupaTHdSXdwIcjPJmbKbOtNv8QEhv5+wmKl1qgGXqsVTarpPbU9njTUR5TLXZInPe0rHGlhQWy0DK7beM/UwCd15HOdR2gAdPoZmUDiHt58Aj32joKpRb/gFFdYUN+CByBVHBdb+W0f1niED1liBzlQVClWd0mgfjmlrvwq/jJ0NDt+wZgTQx8qrQSWKfpWN9FBc0966hbgrmyvXjx4O5fvMah8holaz2jAQoTMbpq3UiguLMF/t5XA8w7EbL+vuLPrOl07dpM9dTlb90HTqpm0FoFwjyK5ZKT+TAsM9OR3WsbyC7Tt8qpbuIrfnybTiIAuqGKXz2vS48hilqmSUMo8LoCPbqPnXCYQnZfAIDfUWPCnp3SjkauUGZxiAw4Fdh9SL5mATGZKSHZ3zXuJMo/DmckyQy+NNzjRh1qsc5JSTaNuFdzPRT4/CRrFKjSX5HBsPak9OdiBc9mWaxLIYCC+a6gPBdrjFcQ2HTI6RDfncvp/TMkpm53BSdNjh8fN05+6rY4TCLexX/Ptlyb2toRBNAgxl/XZQGCDtQEP1MwMoI65nLL/ji+kvAbcgGn7++GyucXGyCrsmKi2XzkG2kEqo+ccyPxDeeHTJaiPnWozR09CNW/9H9eET6EFMaGLXZlOpWKzIvoTKVnHVIUBWSqejGr3/j7+QlDw+ELfDgDqHLq6pmJLrgbV66k39KfH5ruEkEmhjryDcL0N6u/Y3ZxrrNX6VQdJGYZ9VpJ62JXhmKRYUwx+c9rdWNfwP0yTLNUE88wTF+hindT7rdJM8ZkY1FBMXbG9QQsGbca5ZNHHeV+lKctVuu24FfrWtwZkbiKUSt2bAf8E6VpOwIPbeXH6zRTNKFXOYD/ysRIIaPnTFXoQFbxn0DDgd8Ah4g76lw6/RM8npVujwv/8PKox+TLM5BfOBok4wRMt+pnfMcXPBbRNZQUdrnTeKvE75gmPQURbhzFAs8CxuvGyJFgr40JVwf1cHkNNvGky9yL8gDIOIrdWzs5lTPFNJ2t7G8c2YmpmdKvX3bPAcJbV0gtxwxFMImidOTcWkQqljPDpLTi2Pc9JIbY3b0Ruza6U6Jbr/8v/acElkxXFYpCdGu+8ANJRZc3D6PkzRQX/G+emHuuiGkhE8o6Zw6jS+uQLwBqMRPK3AmkipR+CTMOzTh8vui0SoXky4Vuty7FWKDGDYKNdORRWN2/F4hVb7BTn3esl5gS3KZsoXaRKc7s/r1K13w1lGuTxdQm3cQvbF76gI2SWEXV5rSWlBk+O3UT6bpUCqtTNX1ij/PyOq6884JoQHrNmQK36A3KH6ZqJS/T1MleqsU7XOUgZF8Ftti4q26oYwyc39BL8VyZYTKVXH3qNpP1PHdwCCARPru7QErA2ycMkvbO2UsZYBYBjwjFqX2JzLf3ML0Yt+NLrfT8nlR4Doyb84HES6/edkXBjRlGFRi2kpivyQrTln65LUlYqFrF6cqdnb3HzyrGrAtNnrEUi11kF3+s9oLtlhgXWjKHNm0p9pE7Ccg7AX83lMf3tCsM+h0f9pNVPPBiPhYbi5dZl1vzM/5ds7MOj6yGcjqZKhSWAwuFRx2YLOeWy4AYPft5DUbNMIOsD8xYrYiEqGGTOFuFG5tGw08kWhbsnY1jlvdb0U8NtUdk43g2igP7t5dHeLwhxjKdXhv+s9dDtG7xCuQCjwdKP6dsYLh1cj1Pab2wuZQa8qNmPXzWNVCRVYZ5J+flv//z2SbmDn2kVu1Fsrh1vzum1/K0SCdaul8uHUQjwTt5WVg9q4uglVoiurfgLQYVdVuve0gHrWO56YCEd6MMpprRMjjA+VTJkftMdTx2YpF5kwd3KXafaG+B72t0awgmIeDkKLnm+qaFo2UYBm2Szy9fcagfIOYcKAHDopHSCVQPFU7MJkeJSoZJ8a7IZiqr9RySKDGgjpDX/X54yCsPBged7+javWW42v88aA+4Nn3vQW5jASkMHS6fOq9LfgVWx1TzJWEIeAHkDqR+yXrPTEwpOynE1d30tlZmD1gTxawhGW4C+BapGnANcsr+UOQP4Z6A0fv+krKZnmlyMN1kj7NQaeZL7v5NWJ0N5ADuSwlep5QeWbAlVieTGvNrLFEnHfjqCkj/AVoU8A6lTpBuJ9pmSAu2wcNt1aERW1ekOdrnB/z7RC1NHaLPETsqRbWIZzZQ7yqh5AcFr878EXdr1sMl5War2sdCZsBUuX0LY2h9Dn3KQbqImufYsigYiV/ic2FjC7JRCaUV+W0tnJVhM+c1m+OO8yNN8evm2ACOhzfpkwMeBzRvqMEn8U7EOA+wP419yRwgjZzi0K2j6DCmbAkcmCSQ3HbaGq0DjkH+dR+/s2zGrDQ9qT/gykfuu6TZYdCJ3tlrTMBWdHnyGqT/T9mTfR0i2eKn2XqfBQvw4ffdm//CIvezaYGhOHGLzvQyhRDLrjuElfbzCwM/XqucOlAFiBmEK80hpd2IZEbHhC2yyZzdBjV6MavtbnLcw9XSUyJNgjDgB2Rs/dmgp/vFtXE8ACm1a1JutxIylvQ56FebbtxCmoAQ3cqOWIaXg0K+U2DE5kkWoCGknK28FvEaiBg1woqtuVguZHhT8EcsrgODWDTPiKeXZ27FfR3m+V2IO3nZzr56+TQrZT4ibRijjprT5rYf9IqmKakt05KvJMv6byo9EQZr74AGh2FKJW23gVxmnV+QRacSxov6JZExntXV4f+14Q2JOK6EYZXF4SSBw+Eh2+6BiNqm3DHdUrBKc3ZuMoNYsGw30y7cRgziw8YGJIvqskN1kfJ8TvbMuMrrLOIc8VvJmxNFC5iwWYyPas3Z+iW670c7xE8P/L7ywheH70OPHqt3uj0KFPN63lSqPBkSM6Ht3cxEnjW+uPQ+af29KicQOhYJZp246Q2Qr6myLwQ2AcZHLIxW7vlts6lsauqbP400ahVhgApXsLg9nm0rFuVWJAhCqKzhO0X7BnpPZsX/BjRLOD/cBSnDb38chIqm7eiaVLEUGrve0e9oN/yOIEUJZ+Z3d1fMdf0htW1F1YCY+J3NXgRl4rU2KmlvUdldKM7CXjxLCMXM9G1v3qcIuU/fd/NYeYeEc6FxYs5F8tsoj2W3fybLAzICFrIskVEha2sOJ6+HADQad7Xem/hKbxQ7AQCvcK7XnVVE8HA4rQCXBDyNH/Vw+qB2IzJp4v9GoewZHcgnkELV1XH4XLBIImcPRzcvDYRUZOaPuXYjJSnK8hG2G4rMMmqbOImPrKhlxDZZbim9XypPxwVth4qELgCmpC0cPtVXQwRKELp+q5B5qTWR8Hx2hZKovWPgjd4bzDYleGb5ZlFrJAkVRLjlSpDNUs/Bai2VwTyzFWuNXI9rYSQqVpWhTc3qV2zqoOxpaWrvCXXjMxphrjXgDoGa7gjXQfi1jfJR7OhPdHc105U8rrHVTZEQvR+VmYFHrcBvHUeQ5jwjZIOLTkLFbOUnhRqEnldLDx/v1bJZ8TZZ8YknyTaR6e27ifK5y8zGqj+jCJs45YRwYLOFhQJlLIWr4Ad47LzsJxbF0tbOURuZO29Cd49jbgZ3MxuJMeyA+wrCTPLZOIpWdDIqw4a8kpqq2FHbckqnI9PYRskiBJ3lzVnhD3FO2Z5zlQ/oFytJ5zzRxXy8XCEnFhEI1ur62ZjNTmkdxq6I6iT7dXUiZOweuX4NemZX/AJd5iMMwQPgBH10NTQHPD4hI9NJr8iPqm2tVSrjkTA0mnToOFxLAp8IrwumpsGwus7jzSHMXVFOZuStid/CImCcd7dJRLt5fzb3b4fj54fJCx/A03uJ+G34Dsx4FzLqpSqRWMArMxsougsGX2IiLBtvyFo7mx7udhv2tKYLsM6eHLQRIrNNcdXFLGbD5C4VV42f4bbxG/6xs9vJHbyDsk8+KlMi3vUhJ8szmGmMPKk6FAEZk08X+jUPYMjuQRK0Ljru5uOfYbgqkiL/mYT5/W+IjrjjQQbXhpF6f1/mWtrY1m8wgaW7GpvnzCaAMZL/GP2h47SnJxYSxABG6ePpnxcfex4JhTVoeBGNiER99qzEGvdSc3SRAvhwDRvFLSaMw0RTo5ejSXKZdMKMkM0RuVh6kVuJCo+rTJhcDdajkhO4s/Zc+5J6Qr/1PIoYGqqjnuIPa/ntZ9FObZLeFX4rLPoXdd1ZbLNKos7qGeoj/DSABAinrBYl+OrM5XLIzTWfzpwsyRrHdn43SRfITLFzKgS8Ii2KL0e218tY34tObsj3IAt3tpahnQgPhuI/9LmOv6Q2rai6sAaRs9jqDR1PBGzIKV6A0TdETi2+NN9/3kZwqYeyWFRtD9qhRVI4f38WVL17RYvfU6d8Dy3W5IXXldYC0L02937Jrnm+0mlInC08xdrKwL+oyYm+329Xo6lF1JlPbb005MrrcTZyqtMdWBlK5Bk3xfvBAnyhrB/Tx5EuSxcz1rtFcHSyftdW+TqS3u+ET5SdRRAzh3TYn1nMDt1D9ZepbhHFbVkrYJI6B0M2JVmMxFG+qhxvPtCVFWMtQSZuww42wQBXJbiUG7vUsX1okt4LBHkL4xFUsbKcWJy4OkpGvd3HhC3qNRl2OcK1Nulatlnb+p7XQbCMd4eyqC7AghMtaQw038+9xVxPVAVH9tEC7ck3c2EI36bq6NglG1PF61XlkNTmH5iNg9jf+6DsHYoCgKleub4hnhWrY73UA88eD/EycYSSRJJ47OV1DjXMmyu6AnVu8+iMxR27Y6Z7sIGpZooFTu7+V7ofvxdP6OvdtmK0TefIcmN4F2x0Q90G/iSZSz8+DaVIC9ImM3Hv3mrjyGbzXiXno9yCX89i2or/d6JKS738z4TFOg2ek5X7fIAxUe0Bj/i7MJSRCLHZqwbkjWD4pBcbc/jBConzb6M8NJTEpEZUVUOR1MJC2WkdS52IGO95oBBbsuJ7FiqoSwjd30YmnPje8XCEqlBXprFe5xVQHxpbSMUee1rrlp1nR0K4hFwuO8r/MRWK8jxZ1aBq9F5kDsVSIzJp4v8fC7L/gxGNPfkBXe3F8iaaSzd9EslRhkAEDq0cO0Uu5KZsSQiCxeSTvQg5223hYnYuoXot7yrcq5jNczXpspfUe2EWH/N9AuVpPOebyr3vxcIQ0CtYvCpA0VILOWWoyAR7mhY2FOXktO7xE8IkZ8OTZJ83EqtLpoSNYydUnvClRlX5l3WuHzRKdYTwxB0V3PSQpXS4w/1Ec1dy5Dr2EEMpxjYoHQ9j1gf2j1kk/3ll8WlTzrvZo65SuWBGDJrvqwYmNMbX5FTIinvodwJX+Zkr6FX1kaVoSuvgYFP5u9Ywl15s95VUzaHl8nLYa0N9ReOWINfhPPwWmqcN4Jd86FOyO47EOpGvrm+b5nd8Lxdgux6BCSzSp96NnmDCNi1w4V605EuLKJMjhx1pSigmYsDFWms/oGb/tBgC1+8Kk376FzmGWa0/lsTfdFc9g8hZWheBp14RWwvYnIN6xDY5ATngUdN/Nv6vrQiC+FQByT+CjDPLdHZzhy+bq+d29S/u26Gv0z/gUNCsBONfYK5w8KeN3YoDpabr8wBYbEyv3xcSOWkw0iQEl26pmtEwT+4/kaiKUVLT3wBMYxFEU6PUaQFHkqqRsPybJOgANwI/r4WWOA9aOQS4s8lGKrHYs9uwJpKpR+JZedTQm4FjQYsyzDEEqdGMkTDQN+77/rHgrw2hssv8lpq4G2r4wOwDAb1fB0ED5yblVtXmM00QTFfncCy5JgFheRAk1ZYwl/zH5zh8EZGxNxHUpAT0MK8IZ+468pQ8RGIJMnvICiE4m0JWFKtpGQ85HoIyPHsNbFpGUaBBeTqCqf9M7gtafRAehguuciTk4mfhGeEPdXGLEolU1F45mfyJDNbnm/HQdkPoRIbtHHg/6i8KFe/D7Hu0ZlxtJYPIDn5mIatlmqzOdrwpR6dB7N/tluVmeyccIJ7kkXVnUprwigO530ExPH3MEp1MumHb6quudhiuB2nFdpxc5Zbe3k2A1iaj6+65HxfugytTV+3ahWvLjIJg9w9x8J7Tf/a3uZEFgT6oquHPZyDb3wMirhHvftQH+UdoOgMcecD6HAR6V1XrCBSpU4CqNJKAZh+DbnY9HLYLj5eoPvfokfueCjysjRPitJVMn8o7AUxs/YT8afCrlaNGxEMbu4Ybq8s2lSC2anx0IvvHu/+cXbJjeNDIr4HPXhcnBNejqFt/npP66UOKU7Kjyv3i9fZvHLSyiyPn4FZa2Ar2g2YZTjiIZ72yJtvE9xwmC3adMM6Od/hXLve/qgUIoMm+uBCQnR3DYPQWgJcNfFweDuNnGzqIFWkq7qkFkpbKybQyE15RQg6eMT87UFTHMpox2p5+Z0Td5H9g9kPypzbssSrNi85rKBRn9L7J7ljAFlyViubCo79n8YJlSxNMVUa3MOtajdkoX1A8e9sT/szI4aCw10/Rz843bopnl/WgD+qYhZU1um43Bd5ZZuJytkP7QVqIl7cbICEDBYO8kSM1hP7xu24KzRLpmgE+wiUIbRiPq3HBdsfnuC4dqmV6jaZduM5UhwQEZWVO2lMSlQC4dbmMe9n1n9ce0fd2YUseuiBI2s3OVinyiUTDuJVkBAK0DRc0JVysjZEf4JNv9qcieQ7peKY43y2Nwh6dJs4mIJiXeC5Dbxsg8bmzTbJZkwwgIkOVFv2ZOMsfbm9piIa0qvKMC92imWFI6Vz6qnXoVINKbPsI3jP2rweCl+Memlobt4By1CrVx+a7g9Q1FiQepumFrWUPXj1H/Qs6Pj5MmLNWiA5GDVBSd35AjTknaSkOV2K3gktVkOJ6gdOZdgrFf3ky9KD9XnFR0WQNetu4X2QJAyih2gS+HuIfWyRZAUSidtm89aGd+1ApURXVKRVJGJ6dstQCv5ZAgZLzGxI1vDEVYqnqSzCFabY1PmaGCDOR03O/w1jM7jf7EY44vAMfxGBAUrdiVJpI0bA463o70vhA9b9ejeeZKHal/SL8K5UGRSe5hYSAu/P1JQBDe4CCt3V1cM/VYPAvHkPf8B5s/sgVLwyR7nBAw8b7dF2YQ0HDrLfiOQuVZh2akzp30Mr3144c9xA/O+c1MAkq3ilfTMdacJ2PJBI7bUTJa4aYEHNUe2twLWXgFmdL1HvKH8L4S0gzrygFbvc2mylSpPgTy7mJyJiZSDdcK2CbUbU3EjT4pPDunNbNrpCYndKuQmP3OUvlbjmmrbfa5Wq8I+vW3+4N/PaGu6Yltpd85qdpq2n04btc9T8FRygCOHT/lZV5rmMNcgiwnryPcSwXD8BDA5nnofn9LLjZSgIz6Ja866xkr7YFEPBSkAKGvEoVzz1SQ4MIf4+HKthZIvC0x0DYkkgyW8WuxJEepqrdrjN/1pMRldGRmNoABkBrqIiL1k0tbOyRBr670bGNpgTvfROrm0l4R5yt5Lq1oW5AZ6caNiEZaNeg1MaaQl5MTNpYxl4wkPc0Jw8dymP5Frthv69RdBbH+uQa2jDnFJPXznFWwP6f63oJj0TrLLYqi4VelZtb4buXUdTGyNywVQcPhJhHUQdGdC9IiZ4BLw4pK5R3+WsiibXQmBIRg2ddjyEsQYj0Dkirae+TNKG4GU97PZrFqDxryPMPcGhG+8ZqgtnauFSWYWPrXOUKg7esvyAFOhVRJnNE7TOQKhErXdJUQ1p00K0llH9Rw2xh+idZJiIBlkqMSxXWIYjV1b11Z5WJLkceRbHgpbLNRY6c0R5JggidaA+UhVfc+UHrVyVhfMuueA5DjTIaWLlW/PlErlj3NneNKkrzb5YVdj6qDlqexk932/+SBQKl/mFhUaemSrgs/Gh8a8PK2sQ3juv3pAsVly+JBL3fzSUxjo4pAmYECNgkkwQrkmY+hWMzQ1xDWkw2UdY1F4i3wzqxRc6N74bPcJQmHdS0NlojAARTnJ8Dv5SjPbpjJm8eNN64LxLPW8EBrdgIBUYbQBbSbq2ASOB3uaraBbK2lwsoDPUVsI3mrSTpxMyzzZT5nh+GbXPfA7AzScmZ0D9CO4mBryELdC2N+9Gn+uSwwoy9yInGDImjn06mvxlrOHrMB5yxFlCuQVzJC30DtezqEnF2TrqXEpgBUL4loVIx7qHAygTmKLE8lVuqezbLlqGgW+ESf7CuOSlXj5xPLVpaSuzBBoY9JJxZ56XFxhi0lpIiIsix5gWs6ZTWWaPpkXEWIG6Fd5vASLGZEDg/qC6EVsBt1NNVuhDUDgyw69DoJe1Q7SCZrv5zS3ijggGESRmrCRmloEIXaGwMvaF7V/ava+jGFeGaz4XdRByxfflVUfgk0ldemvGY1hOd2cZTPNGW75iWjjQuFoI+w3Xv5YWFyLPtmg/oF9XlNLvTZTapgbp6Gw0B0Pe7AorUZ0XsJM7l6XljGzldGetpSul9dezd3lW4IDTO/UY2RL1hG95A0B4rTpepdogT6NontGRMMHY/U+lOeq6hweboIvoKflkjbGs9dagLY8BIOIk7Z48A/UtsBJSpjIyQkiFyyqdSWz1q/nzI/tJ+iKpqpinBy8TizehpDOYNIoCp5IFrrH9PKtd/x9FvD24CoSgsUAIekUwcM+llae3SQcPSUHVpKMpWTgr82EBvITkfn+sm3HHIdPpXUcbWi8TRFuo0gRXqYoIFp04hEirm89JBW2Pqciv+sUbLk9NtGG07kaHzjnL9FdNOqpkFG7leg0QHI9RTnJL3ioBOXgWgsa6jHE50VIDg8zpZpv/MwLNxQuYkMvNMwzyPxBj4AqvNmhSCveidxDtle+D99QlGDhnrvErusgfInCM5fuRr1ufDoD3vfDjXnPPUHfKdO0Fhzs6nrWm8fbGL2v8n/4Qb+0YkM3abEq2pzBRUmSWhIvLo2zLuY+TeLGe/Vecd3I0+qzq/0be7r8XRpBVQhu4Vi8HBSy9wx65VTL5xQb0S06hFMx0I33OmjaRZ7Lq86HfPWznuCq5uRQO5TXgLnBCmK1U2ruimht2tfVbl9Cok5p3ICUVsfFeG1NDPZgv1+7RykWQ+UJl2UzBceWMztEC+pVZb8FXa4fjA1x3Okw4VvXaggPy1dCTDPcxNbqdcOgmBfAUNaesAx0dv/LL4WO2Q3lNgPpDwYzzNlsoci8GQXMKGZYlgW8LYIPzzWPotM863elxO/myOTC+ffVbt45d6MDPtX18AFv+f76k+0Z31cu/tiAVGpL9ZmeWw/Sv8/IHAraxRYeoA7R8ygEeRYH0jQEFR2B9Smg455PHVwyDeU2sJhQo9Are2fWMkwtZQdIFJRYkn55QZoVZVUeCnRhHtXuk9t6GP81V26EZ9qOUMDSDBzi3caEJD9hSX3EYoof7TJ7SCTJW0Y426K6s7lC/ZmaUGCpqNweY4BhZ/xp2jG8q7FESh9HB1srZxna6xU/1W+2plOGXN/vz83dDpQCw6yeWyy8nVJLkD9nmM50CkxJ11rZysuaPPO5YY3L9zaom787ue2+JrFqlk7lDkftMdT1XUOndXRRuRp9Vns6PyhvOefGsFMiJK0qVbjIRe1/k//CHPtfEgwLGJbWMmtQO94k7NQNb+hjCWMOabMud9whf/hD8p4353s+39dmBsmQgHn1cO5ASuqtfDVHmle8K7JfYSvBLrmrYELfFAy+ucZaqr8BxC04qmRPzuTlfE9F7jrydpdChGYLM7PfLBp9mFUw/McqtQaXwcDD3DHB8v8Qa7XHWTnNMB+p2Ansnvdu1lK4LgaEZrykD3H0jXg3+jLnjKdDLzdqTqAFx9MCo3y6G3XbY1VKjoSUK3RYkJXYr3/1jpZ1ERGrSP87ixn+UpWGYsC9NvSm9lWbMvYtrI7EZFyST78HjCuXnUpuC4NB3y8DaTBpbK5Yi+FNq2NATT66KuroUUNo/Pvb9fB7Q34udrTZzL1xJJbG27cT7IPgnTSDDZBwU3Ii77kDIoy+SLAvZHD2TGxmK4yGKFQz5FFPdiSqzELt/ylH5RL2oNs8V8HiLlzt64Khq/g028xeTxG/v6BikOBYz13eD23djxmPlBLT+uRPOVCVx4tutKlW4zBbo0G2sVxFV7pLbpnxD5tagSCvQ0McYUh1BX5LBuYmL995ULBD4MS7QL4xLMDMjlfO5FdW0xa7N+E5zVdDr8C4lcAlQLoU+W2vIbQ2i8t0ZMbH42BCUusz5+vk0eGWah5GyOKJMo6pVevsvd6XGwutt4w2s18wF90r8/ekIXzvB+ZTfeBDwzyyJ1dNzdTygy/RbfRUKnqUizMlnl4pXyWHPnHrau50c1yMcsOwJKPtd+K9MZ8pjOGgKJfqK2ymE76CMff0nVUnsgsvAKNebNkV5n4MviCD1f3FVLj+36GtgfQ42DVAbXNAXKNzRafUJ9Vu74++g5k2NASiOcP6+rWX7skyIvzLfpS5Fz9W/zqlQNQN9gkZmKXNsi/UJuMu/VWq+e4wNgXXy0Jkb4Rf8V2fghdkNDdPbJ9aIWtUgpwtCSlAZB0VLK+orMHYkMff1rNWEEFFQ2pPPo1ukSpDf87DkS/SCDt0TVxe/yut3srp+k/dMFl8GHxfTIhyB/XkWTm69wMhvctHM0xw1kKrjMmnndng2vigiOnuWYmbi2ICpECDwJF3WCj5dm+X1RZqYtpZv6Jox4RgnqXXKgZ+iYe+LGLgZCutcLUyeStWmz3EIZqp/GSbp/VDSuQmrHBR9/JXjIxCft3AEo0txCv72tHVeGGHNvHrTklW7E8O5nn8k1xlL7GkW64WC0Oi0nyxMiEFai6yEX9Q5ezyrk/EMqbmvY+0cRxLEGMVyqCkGbnUhlUzpyAF7N07cjrIzLMjvKkcOBEjFNWSk2HYKDCX9Mt7cVXhb2J3R3bRSnyyt5RwIiXMXPgIs2sTJXUYBhJpUXNqKVLo12ENLndBuZQ4uHCm4klEu23TF8EVAgjkn6Pa3vsulL7h9qpV71Pq45puFZhngpT3s28dstw6OJq9l7/Bkn7QKuGXXKgaa3mkzSpemupMW0XDmcTTH9Uk/jJN0/rsNEKpcUmhvJ9z0XIini6OfQIcN2rwcRBQPxvzzp3/S1WCueNad7dVryMiwDeAnC4TELqfJuCtcqYiwWoBE4M7KTe/ywQ0Dyfe1CbM8Vh7zTnOHVkJSIFzW3GoNZHW9xc5Y3/3pnhDPCT58vI/1znkIyXOYEQQ8nzfkm6kf/lsRL23YdWiMK2i5AoF3ADYWguBinopnbA1+XLXyU1uUH/eZNqFJ+V3sn267XIQ9dYsU9zAT22AWxi1Hy+c8CvxPPpIZhLwYMCsWJYg7PPumAsBsts0FX2rozdd8sBT+Lm6loWrQlAVkE8UfpxzS/T+JiZMNqY7Ln2RAD9V8xalMGp7WpaAEACwqU1G9b2UvLWGz6qpIQIWNyYw2TRFpBGI84JlO5lIotmjYsN0iwb0MR9aHM4yA20owkqi3k1q3Q6xmr2vNkcIedwRoHk+jqoLVpUSro/48pY1+cM5HqDcsJrMPl4kDJnlatUII/A/1SDuN3eCuEOS6OE8jhM+L1gurPBSmk2k8MO5ckTB5Ysl+91+ZOU1Cw8mFay+ZQ+y9/ghe1Jl8xlUjVPfAsaT7XvX+qpiUmd+LjGJj1eTkyviU/UZmY/1kPESmJsCvSYH9ojX4qLizBObOZ9KoK13GuxR1CJ2UA7SQRWkJ6YjE2WujNX4H8I6yVn4kFAWH7z/Ycsxld9DaxNFL2ydeWUxYLefPSwRczdHkKlICw+jv4XnItc37MT3f2N5xchn+dFba9lhi65g59SNgigzv+wnrZCkK9QotrSXLs9Bx2bcBS0H9Kb3EOFNmbUZqc5AYDAwFF0MxlXta9ahFqCXlU3l2GfeYBETUaefF5gp8RzBeDNuhrHcgV6q5wXzIgI1F3oPEQ2/I1kqRgu7VYMMHL3O4fen+awXhXEHLP1/wv6SDdH8a2G8o27SF1k6KaWZ399e2xh3Qbwbw6I7ZTW4t3J1e3fqcKgI+Z1iTGN6LZSPQDCM//MJ8Xudute9wRO3S7+cNI7MuiCm1Fz5lDFFQzh7UiyoLGwfsIOnziXIzBu9n1AxCPBXFxruFOtNdC+6Hk+ibhYZYrfgqoge9zJSFdMYdFWhHCKBcOT9uYFV2GjoZXsn9VKwDhdEZAeRt7hUd76lWs3IFAs3BKlAXPiNVFWSrlbRCm8x8CS9D3hH0aVxCT1skAyiwujJJZ7sfU17v0LhHwU9TjA6hFwp9yfJMCHFKDjJigAzQ6y2PGeGwSbusrLGas2Z/T+Ipye1CJSNmx19dW1NIfqVMMn2iPMRNxW9ggW6DCpLX4yKvFzxVOHa/aPvzQUcy1n8TMOuc8XKJgUbCVJPUWK9l1MHtmOD5q7IuzHcj3xcAQ0QpNN+mDPDIYGP28rjRxw4PSBSW8B4DYGCnUp4Kt314updCKPRHfnptcfi0rg9OHpYzx+dskzLSUBxbi+FmStEm5YWfk7oSJkMY8F3ZYYbrvm4AFDLOk/j06x2c0y/KFmrYMGm/4YmbVKPVoOGyM0j/YMZkRwYLBg38CxWv14A9FORAbNT4y/Zc0425NyuQAQhHREnGZVWWmDSilvjN/WMaJ7gg8HweZ/TGLPj3uAOpfzmj2jDmWpzW0Dvrdp/tnGJE0Lwf54tBJwMlxNhCJ2k0aCIXqgQQ5vWwUZQvlFZ0wfUrofJydqSsrjg5sINTavMZ92iDTCOG1nAY7YmRthAkE+AlHRgogUYUNBJ15MPyslPjOvmR5fPXvdyu5w7t+tDBoBMbLuMScA0Bk5cYO9e03MRNd1C80wFMWG4De1mVc05PYtpDn9DQU8PwWRqjARNXe0OQwgPca7uXzfrDTsrmuAVc0tsETYHXGNigREgxoXE3p/HcilfX2Kvv+2phbRNjE09P27//qlmPuFS0ICWmmLvtZE0tn43zc8jsvjNqeAYj9fc17mnVMWzNgY4/0QEtzClLFrLIIRL2uwcj/twLyNsraYfI8gnUnhq5Na4A+eTMbI1I3o5rUBWcAs+QcGT6JTBdz62CZeHMG6edvqlaF+iU7g1c50362JxvkbBdhycGnGCw4MN+QuXnJ7LY/k6PLxsTkqeL0Nr3O6Bov+zXXvVljiS5AZNDDrWjvYBPJl7ymlfpwO6kiJy39tMPkeU5WgtYtciClWTAOB1BzxxslyBrGFHGZT7IqyiyUm/jpxNIHd0Qqt05bV27YEL51fP0pkRZj7ep+E80bPwsfNgvi75pUaX9nt5VKUtkr5enB3E6k0xElEnvfsUe02YDgE3vxeqFoHX9SMt2of5nhXQedJ2eiRkQvv7rlTv7/Bgt1b5pv0N2c4E9Elp7PZbyZ4RfctveFhN85usDwva4limLAX5oU1ohsfiWYabaWFzv+/+Fi8XWjaX2Yl44YbdlKtMtcLrkcpdMgYMrEcd+3//kD2BYbS7ScQNuKm/eoBakYP71n9OQvBZYD14Ied3xRHCcepyOpWBeMuCeFPhnFg63GrEokWMeQqjaMESkfQE2vND/cLr5wQusfdlsf+3BXlsRAkJl55ihUEDTtlYV0s/+dhGLSCXu0Bx1OXWSX+hQbmk294qrDP/4J1Pd0d16g9z9C0Gw595ijp3MhmKgCMSnRupR6S8SEu8axRjPRltWkYiq8mg9sFA20U7CEfRPlVfuOzRLMMs3ay2bzQhdupwW9YDzUjzcPeVGKS5wC76fQDNWesDPxD/KMI1GB3u4uK8bxhlAopWQHBHZ01sSivmObVwSwJEn0lT82XS+kZo7/YD8Uqi48DKOR/YxCej6ejDCdwjKkWSivYUOd8wYo2E0KE7UfQ7octTE02UK1UIgJeBzC2ZtTIuzSYX/kkRVVypUSBF1MmYBvOPch9p+D6id3Qn362yjR/tsaBKnshKHvJzL3zM+dqScRSfb8GEBUNTRlJoojnWNHE5TO3j55QTkQ0oZyMASo4nE42cZKUj/foRwegIzQ3w9pFkiBQgvhZ42KTOl76WmIh/TBTw19h67iZcsG35h0o7Iawsz8TzdzMZESRWPGEHGgGKaascfaZBXXRYfQLQxCGemuy6iZ9mVRiL75n3zzeezk9QLxh3ZkNlkSCZZDBERk4akybcSv6nQWHl7VnHHISNVOHmx4eu0bgio9/8I5elA+Hhbe4YhTVGnlI26DWF1andp43H0wzMk7xxAHRXKzPRw19FYn2X1svw7Tz+amZHn+1ixk2hfOQTjPoX/8vRUlKuQpEO3eGdu4H/kqEtk9l2LpwXZMy2TX0Qtqi+Aa6NNtdbwSorUew7UiT+WR4Meb4iUIlmfc/jGpkqRi6QwVjre3g0NJrR/hTbPXuTnPC5B7mYrtg+PInj1Sw/5h7XL6C0IWZ8/nt08MDPLkEIYBQS0fOEjzNlDOXrPcuwqmAA2M/hneIRIyBBN9pLPs/uwlxKFP/I5ZxczUcTavABrV/Nk7JErAht+q3kH9WnZXTJSvWP/WPK0NUewFzyAUe9Ai1G7PZJsITkkvNfLgCh4Jooji+QuL507VDd6/bievlogNQAkySgPKZroJTJl8C72l4LFkOANDjCGvf+bRe+qMxrQ1VZlxBO5JfNNuWIFyILxvPjcazJC+42Imi0u393oS1B+xg+/2T+VuNOQcPYYTYMThulxw/Ul3ALD2Q+J6zyUmd8xHGqUYmvXlMxEIARnYAe+JmSHeouhuZ4zTlbtwXrmgqJKwCVNhlNxckZjWXPRnAfGV1pga782EGNyy8T+SQsjk5MDtvzaWG2UWc4QpKQt2niPJ68dVoENdGxjqvhV8X+PxIUWfQ98Offv0xzdTGyKqJiGhi6A8DpyGu0oWS8mVJTeGPJXnS4J1uyQaHAfRVMyssChFyFnPL5Z6hOLiBMPOkgoumWUONtQm7OXbShy56T0WBdS8i1TQPni9V/N93lVuoLl7UDzjfMpg6sezALSls63clAOXyVQddPFnwz3p+Kk4EKdnVsy6XOsSjtVRU3s9aIoI1Zkfyt1xHDLIeXZEx7gTEnr7wdHV+dzMQYwdzL0KMW0ujWe03NpHSBsisY5U/LiWT6Kc8rJfp3//i39SAQqyoqerZgCDHZB8//bp4E1SY/Lwr+CvddeVa13xzcmG1S3bWHAPynS4090XkQ0o+r1HcvWJLt08L/Th1TiaSsJ7vMN+jAYsygVzFTqPV3aA7WVDJjthbVnCN2Usz8TcR6bfR/txHSpPKETNgirxgtvzRjXZJhaFpZT4gOhOWFeK1kJOaiVSGJ2JXXMkYQBWnwt5cxdSrq2xyxcFHA8hNe+hVCDCEZM03i+GuEk0iMuG3+1Xo9NlRtpbTyHQl8FAe8vnSeiKgBl2KzuhituWgkQFFP074VF3Z66MTHDMX25rKDbb3LEM8vauaRX/ZxAIAhsOA6lmaFDy2VNw6nwMkjOxdpz1kLh7eWTujQMWYCUfrWRpJ6rUyRByDWjKMx8Ps1fM4sW43HuBSA05T4Ivqvv+4w0m+xqrC1AT3hzj39MDJj2PGmgyLBlREwJYawYPjVPK7sjr50LHUWhyAxhEZiEe+QMFp3q6v6PJykoHfGcMvCFY+2CpuJsd3y7PM3jEDkxTlqNvJmlA89cajmp/xEZvyEg2AdUBnVKGglb2+TfA9FtnAbn9cX+A9OG4qa3XYRbVxAo15T13l560hESGA4qkPU6u/5YxrDc1BAGvSd6A9ZSvvXN3riktuuhhhZkH3zrOUCXOVjeICSc2NjvsFUnZBwZV0xl3ulnPMoJ54rnrfqxfvDN+WFWg/Cow9Z4FsW/3MyHO3qCAlLUcopT5ZEx8Wft/rX3gcOogNKp/q1NBnVnt6irb4LaJrKF4MyKcFOJ4zGSftEhHQvfXDH8OihfZI+mzyCRE3onLoOL1IJM4q4JMW82oe5g9AEAblpvfgce5f1awXqiAUywB4R3YjWAyhdyw0A+TpNQC4UuY6OVd859dFhnuX9S3WnkCX8K8Tn+9dSoS/tgrg6BQ3FrexPJsTJlbz7Kg7s4ZLhYkUMJ2IraRB5GMIUHSRmGfIqFA9l5Z60EGQPmwgUXUiRCLf7Q0tpzesTnOy+tm2nol2EB2C4nufP435bOG/0+AoMcp1oBHCXNP54GnQNHJxOHH6QTgA72Qu5YaAfKUe30MghZ8mGRM8UUwCCJ208g5glweFOrQLt5zg/zWTwoNG7Wrh8wdKQiFRhHoqhS3hsMg9g80r3hX4d0IfLRnvGaZ+dNcUNrakWU2J9JSUL+HkahZeExm+XNf3krMLGrhllgfjwQ9GzuKSRADjd8RJ0u8HlW/1lFFE98SI3LCK+WjzQaPMi8wkTNHnzdsthq3b/IDEeIFFai364LKO3guvH2Z5UvWODneJqcthe5Sofltc+iYVx6F5Thj79QALBvxKoBjLC9L7iKwF4ZMau0k9uoCV18hsUg+HnSk1gL4/2Ee1Uzx6mikJ+jU/md+gU96TR3VUYaDM5Ltp9sJzmrQmIGLD1Ahe9iQIs577CxYJGwLgN6GI+G2WxopmqEPb3oRqPblEmgNIpXgLOdgjIGh+w9aoPH3OODihHVECsgufcpWIqlCELKfntkQekvuXTQzLAw0dJQ3xSi8i6B3purjTY7THob2ZOXui7rsKTLMhx752V3HXQZsU5LyF6QG4JAsricFOn/N6ZUBldeU6Xj0B0Eb34syj8uzHHK4aODs08flZkcNss1zKcf7uVQVqEhjHyzcLIaG//jwLyDXdKn/54finGvqdBjQ3UFl5ggO/Ksxk07uuoLIrwevhbM8TCWhYLq68AmE7ic+gbn+gMqJDE4c1w9SHxZKOu5lqGkUaQ1lrLNZhglqHZ5N+9ZwQGuPWp7RnrFnnUHiWsmzMayrBAEcF00Cn8uGaHKjz6iR6iOEiXS0xAAiNhKhUpbRaMSuvq5tGyWyGKhEYkCCVj2dB86Nb2k5iomhQCC1gYuEQVwLwYu2qrdPOo517qRWHl5P4i76FLEI5iAUcq56YAa5KOzTi2aioXia6RhkTS+J465cG4pv+oWQmJhF32+KCjiWIMYrlUFk87bg6wIPIwiCNxwiPQNuqSGg1g6bpGarGypTnJtUl4BLD85AnuMqpJvj9KE8iOQBLsOAd/tdxoNnyDlF7sakjBPk71qEAIxIL1pJ729Af3382MbMKsjRUQ4swu2gI3+3b5crR0fMvmqFg1cRgCMWQ7x4rl8c5iZyz3vmefw7JT5y2OuKYs5/1hMd4ChrT1rr/AzmX6Zmf9ldT1xezbBsANbWxDpG4l5VIVjI2oCQv+Lvcam5VFYpQ7U/gKZiu4AhPjdgscHQMJyV2Pchn4rQ9VgBt4uEIQEHpXOO2pmUcKxivwsBtUdPbETZw5IBlmfy4ZjdcPAj4Wz/9I4j59vGtkvQyWz+gdaZl8ox390v6EDXB0Q66F6Yke8oWqfTCWqjntTiUl7ojRVKmK03MZWxYK8MQ3D5Wt77wUkc52+AR3jbOvsZ4BaI2dM3P821cP0TPMEqpoVytWDpJW89VcfRKqtVwj07XhIio1QZ+lNJO6pUCRg0GQhlrgtzcL882GhWoWa390te3ii9aXEvep0l2ZV7OgWeGPYCJKx2e67v9PotnedHUqJA66evRvLyA8C0KvfOz+5MdeW0mFatOgCOqs31soCk2yOJIrFRzyr0TA43P7F+qm46BkKACRVfGdc8FiH/Xpo3QfiJRmax5/YaRl0uU35vzIOk7geSwyJeiYpmY6R9b+qmBPpdFR5X7xlmyLiSnoz+z/5MCtlHRZo0t4GBKty2uKi/qDY8JJej1/PAUBY9hsv0PFysQiAMM/nC3eholhIqj8trElF6cCgdDlsNSRc4rNV6bZ/+8yC/A4eiWHxOTiYuwj2SC6fLCFetnEoC+6BYEv/DjESffDtqza0ebPpV17HwJfdxWjAx4M/PJyfRZx1/pjiO6IBKUlVDLIbVQFLAVGrTB4Bzq+wix+awE5JXkrOGgFYGlFYn5VXGhE8DE1GWuNLWRkR/uRsIq1smgCHyYGgxQHO/zFwc1BmqXk1gigXhi1zktFJeCElzLUzzLWl/utQevHvez2ItiNDAJD4y1MQoTFDdZ1K2IjRSR59lAt1wQDkFj5gGT+sBtsS60neJY8YvI2M7K7DJqO/316OjqwHeGCooHz8HgjuHa5Y1FEGkjkGjsqYn7lKVCY/nTmUBPIwYL6T0d6tQzBeqGRDXfTsiKI4Sq52miFIt9n7McIFok9UX2aKFVisImtyp9Gm4JB3yn3bGgJRHN+oZGWuXed/Z4mbmQpxd+IuQiDEwg4/IU/HHpSYD/7pOCnLnK3j55WSSJgp59Wsu9+rSdq52uqi0ipFPEm8qhVNsJtAPLBmdubm/vI1s9JlTAMZYXpcWSffWA/eF5GdT1avn5ZABoTWz8oci8FnFOE35sAFovxniy4/g/TD0tRZbmvud1Bz+7Fe0Q2xnqSSgH019wXlR56KS/k0EAWheOjULO1pVRuEPcY6i8ziPJcZlLYcrw5NkqfMaURBx4eLg0A2HNL71VyYme8FWdaluHNSy5sPwC4SDYx7nzsKM/NEA80wXoAXNjUTxRrQYYlyoU6CvsEz39hP8nVAjALGTSY3GH6NKzuVf7mn7GqLB7fmyPMn9LOnIDUHqYfKffkPor58Pj7OXkp6blc/KCBjjZceGFvX8qWpWK4PTYbzSHts5KBdK/y/bTgjlV6wsa7kL0M+34NcLI6np8EAzlfLgC1jATsW397/oPz8MQgIywqn0o71qZ/mKJlCtShs85tSbvxZp9SFh4aY9dU+diXeqxvO80YlODHhGW85fc7Ukk4ZIUdsRQrJc3FucKKGdOkK6uOeRiWzG1G+yFM3yuHgR/Jtqbvq1TJV4T3SYd5MxBMW/QU6Kui3cJwM/3kEg0+RoYzCaLaA25zvVwOxcLoDlkHRPm7FNITcMlumn1GVIcWSs8sDSo7M50CafXRyoKEyPfbu8vL2nbf3UTNMMHmYvSM7/3Jsiy1bn2Sr+BROt9vyU/3zQYRVADFq58em4qzzAMyhLGfcsfNOYuKqIhJxkBd+9p3H8KOjtWQO2uvNnkZR2NZwyQAiNT6lYgz0U7vPXChP5vV+MuzMeWqXXez8jw/NkZlfjA5n/7LjNLuROooTniFXfeK1a/zu2Hph0EA1mpyl6rK/ngadA0bvtJNYC4NQBXuLbKbh6nJ4Ubqlv6wFqw7WXBeGh8AoU6cAM/TZCbJfbIy7HOFbP7Hzp+0Ts0Pv2TMkmbDiYhSjXIVH+5K3qH7IEZhC6g8QLQLXcdeGTZur9ebq5n9YQfsj8bc5pHt9eIQjc7QOIZyCl7QenbXucTmX0IZOfVqvGC13sin2GzCTnFFS/0xmlvMKE7ByT4DmEZCN7EYbaw/qSvs2wlZ2vRgqpfujeWf57I4mHjTR45eJgVkmoehG3g3Jl2X2eKkHBbHSBiEwEDWcw+fxgpxfDqj/gF9ry6WOzYxq3wIFuYiNc76nO5sek9dHeYWIlY1OQlsvsQs9iUok18hsc4obih2m07/Dkv0gf9jI1t9VwjHrJmsQ6jPcGR2VjcShlYy4uPg0fDjVoHV/f8imzSXvBsOIv+C2sL+Sb/WKyV9T/0s2fruddBmP5jPgO94or4C9UUAuDXycI39/r6mBlJVtHdD9KlxxS+FfkIiu/slNnQ0QSMgP9s3G0zG2pk8pAXMxUqI96eGHPIkPDGjzMfAf1e7t3zecaAvfZP+tTM+cBBk9GktpvQvjQHYXXEGowlgexXt/lRg8fE64cenTaAvQJxvf+9tNQW8KpY0UEzNBwQRsGwus7jzSHMmi2HAZUFjqQqpsyxr6czVSjV/DlksnzCyin3TAm44HIMeQ154X4IQ1H1z0ITZA+a9CyzcxxeCLYVL79mt9bhPGXyvvWGm0aWzVadfaQH8pug3b+kZRKI2yxEOMkaQL90/LJnOIDQ16KlG5ZgEQc7K+jzpO610eRNn/LEO1Js3FVel0oT5c9p/hqSq8Lw4vaab/9c/NgZ5Ouz9/YP5DOxOVoNcHr3T9HadQH4XBJa5YmCXxg5ITRD4a3A3lOWBXCHLAY/3meuF34r4oiXqaGU/uEEcVZ6v/LeIuPvY8EwpmF4lxcfEAskEa0TIGj899Ou9IoLBD9vaRKrNcWl8hoF9DF4UDKxSIYsrRP2+dFF7wOOREZgk/bsuvG0O8uk7rXR5E21xtpgS5pO5hFhyGhXB1E1NB+mYQploTGTrjsQTRZMZcp5fL8oufHQWkzwKMzbMALnZsQLZ/qYF0nTS+BU9RTC+cGe5F3J/kUh7jilX1Si06WUCHk56tWiOq8FGI1zwCPJaPJvw0r8iVphoX0zbve7HVIYq4DFdCG2/w5jOgLbKnh7CpL++qtIqNTKFR09X7i7x+DAHZqtrizD8uGT2qtTsk1wR13XRk9NMujrzzTyP6/toVlWACbAiSWsKaQkGpQeTGUzohlE2q4Wlv/daoZPnuuh4aQ+TampVFxoFS8PJU5q+ffg/UqiG9s4wI0ILDUmaiHhClpWaZJ8XlwL2JrKukQ9cgZ4HQ63I/Z/aYdw0/egQENl0aRsSSAlh9X+nHv/TTWF4xsYXb7E7PEJtdTfodONTeMhasGWdbt7UijyVVI2v1+aCjaWQCQsslM/Td5ZUswEnMUFMzfBfTnV1u0Ik9g/4Bb2BwPcCMBGanSxSPzSNa9T3OWI62y1cg5LMEWb8BpFVUenw42QCYf4+pFOD+W66yWA0GuqQsmQ6nDtB5Los778qk7+TSdSoOaoo/Y6BDnAdLI6V2issamZ5qhuKwGAxrNR2dGwqabSTpipliBkaeoKA14eAAg5JXXoMQdj/IznE5+rQ+4XUs7EjlrUPh5Pv/DDfm6hWKYb3/BOiLVPgCiS7AGKpI7njzNwA+95iur6pMV4UGjcHb11UbpG1yPJp4gFtt9pbqY8yB+fQSFV8MNYYNhMoCfRPbXSudcs+6OhRkVA/bcaadboAtQ70yWLFmZmy8DSiDmSqnZJDbiCEhsQAwK/cHYs9uw5P00jUNnJ5rfI2or1nYsQvALSFTcJUvwHD1ZOCcIM2umr0XuMvZvQmU1owkTnRssEQDefQ5W7+/FUejO6Q7Zy+IwSbH4O9j5cRnhWagRyDb3wMirhHvftQH+UdoOgMcecD6HAR6V1XrCBSpVqANZtsBgFG7igii5NM4g3vzbApmlK60tlFGM/+huLEpryjwMUU6T8h6QSDnaBengQVQuSz1JwUAYdWY7M92ksycXg9L3FnTHRzzCkAlXGCFSUju5y0p6vKf3Axb86eU8RnSeNopghfS7c2yQ13zf6fSrl/gPlqyXAoIfbxXY+5wkvaZPdQqccG2OHy4AeBnaM5AFBqM0r+68K53sqC1KOnPrpD0idGKlRNUFnXl52Nl9I06FuPxzeIvS/u7z1EUAGnitHsnZKRC3EYp1axgY98AAEWIe0GqfYj+M7LNqjJe2FoZCzK7ct/eEYMobpmT3hoUFMlQ6oPSgRQynjif5p60/1fGk3nuMSl6bmeHlPFbbuqw7nRuHYwAEWpVzoE3B2gRy7vJkfR3ip/qfqHCmzgRxcLUGgC3FIoiGE37E9/pBwKuYE6/UcLu24lV61lgdH9fgJkJ+9M6zTrNPL0KXdKVmU/dAesRxxHRV/zYa4uN6H6aTlcl4hr/SiIjbtY0GoNzITbl16AndMgTgYV4wqQg+QvqZoeuuOzQ5LzFWrcL1fRCOspymn/2bJDSKMF5fFRHNgyQxaGzYhSMWugcbxqtJHg6WSfR5Zj4dRc5To0s2HIW+C8oicQCqcQgqwF1poj6Ube0tL15nkwsMmzaT1alo4p9Y3TEooTFWrYuBTshLzEPCVaaNOUGgijvOoxm4WWCnZeQTuPJIyjWkdp7wNdD/soOnjcI6BuA/rjEd7CW807fSQXxbuIz2/1utEPCTBwad31mflCDfydpjHaXrZywV41GCyC6cSzUX6eIt/p5QJYaelWCHg9Z33DCcQzjCuPGjDVuylocPvfsGwfJP1X/r9X+mBjI88ZESSgsQTEIVEAW0gK7lbTC64eYTEh/YCbcF8CtvxvrO2KskOdAPQzysIKpQZfA4Fy+/cMdIJaP3TlWe0mqr5oW1Vwta5rQrNwkAdIFssgceHiZe7Ngp6Ep28TyyMLmFQO+jE0Yd8MZvcUqB0ivaNuXbg4JQGz629tWzAW7dWLiJaXUCxClGSBc5RhIu74Y1b2dH5VbpekVXd7yDsBiQFy6sxZxFwH5mc6Jg5UyLibDfXeeY0HFUAzRaNndjQcIAzNbyYdwdu7h2rktFT8R84zYlLhAkIjRfMiXJ6NB7sU6VyIQlOCti5b0rIFL85At6eIJiEKiALaLrSj2OwlJDWAoNqgrodABDjitA4xKRQ2oII0197Z6JIjl4QoNXMU7g4IEYEiadzbmVtyv8BL+s6K+tQSMepljwWaeyC0QzruJww+TsPj7DiLINHS4n6PzJaOKPHSttJd/r0HsVa/IuQ+1nAThAykvKO2Q0sjpbJDXVxjR+w2uSpXkEmu+GDxp+zReJSS3wYWOx7irvRyCKBCreHoWeR4S0tU3R42WfwspgtdGOWJi9/G3k87w4haWZABUMXlYgxsjx6zlDoNqY785HsWYvqS0w4muQNO/JOEiDjeNGbtBpsdR3VhcMayJjInqPNhsrj+FF+ySx2/VBxjyPVI+ZdR2ViQ6CMdkUQ9AN4LhoVbADNBtUF60VRFEj0IvoOKkvZSEXH3fn7L/Td2KxQWMRwCwW11IRIEYyZ2NfBBmfNPcp+jaqC2wWQ0dUiFriJJC3JmBHUUb6YBpUieaiWl61biN0aqgV6F0N7fnM4we4m/iNel98yu2dhTWgRLeJs6XG8825W+223/WMmbPPnx65Jf/vOhx6NIPz1MgxjHEJtpz6PtbqJTQIHem34UsblGsYPllyNzs439hHPnZzGlvVfXAy438UFijvLfyJ8G25TqDZwuIwtgkor7GIWbHfmBnoYA3V5U6OrQ4UOOYk12d2TtcH8nfj5izALILmq1WBrHyQGeLKndgsDFh3Nmcr9F5RuNEfwlOYwgge0xUEH8gzyqiS6fTxsoImnpgKhTxoNUwPAwLD+s3hPVHYdrEsFOUqs1yp9o/m6WxexNd2W8xIwhfCmyEhQbpj8ppR8LdNKgGbxw3d+m8UGnnoljaCQohTPFVcbT4/sEotcglW+T780Q8qQ4Ze/aWFwuPJSlx8g+ZOTvnes+9HJG38yYwchoiq6KieyB88fgAvbHm46QZfzKlVNZs13wzQSrVrXq6vVQF4C2WtGDmZBtxNLYGjm+BYTdiikDL9U3RrZrH1vD6of248CWUt91p8A+mmbUnH3cBp0wl2qxcMeV85/tW0yBTBKBbmWA4dGfIkOlciDVJOcXh1g4CzfUSeLrZtIc92jWZhwbYbpx8wx/BhLqLBpBNT4Bhzm3KkVDzUixKKVwSHxiBvBaFeInjVvJ6d0Gc5Y2doZp+21SeDJWJCeI6MNOKe401nnBCqep8NZZympoFuQtH0pz4ThLemy8mB3Aleg3Z2JWJBJakQHk7zr3MvbVa2hik6NOAhdHaBwmmtm8eg2Hq0TOfkZgCarmxX/b96YcLaxu6YmAKsVmItUIutXAmHjkKBdeKGwhcerIUiXzh4C5V1sJJ4zPUdNyZ7+lz/XauQjj1HxzZM+DN1VLzAnufY4gpLG+VUAFB8gPhlm7GreT3qdhsMYQuXl8oOtVx9MnXoo5xMM6YGZwL6lbfWeyCol2pHKmQJttuRbiIlUDIu0gwmsSayDdIYm2JMi9cgrF2xxAYO/fl0lBWy346IdOdQOe1AiQkwSOE9eaWgyK/TnWiZxRq9ZOsDKiEJSiGmYD/Fw8ajcTtzHGoRhYP1QMm3Of+1LXQV3YMsPCImd+9egCvJISpwX97uvPgN+UV8ja89wtDv+OfGm4HdN6mpeM4rpFGQj3w5Z6/e/zJClx4oeYzbpSjw5h/7CKSa6bBfDr8e7O8CKirmPUX0bNP4Uaui9YuqIMFauGYulaVXWHaz8vqnZ+Ov2yLlDMzWn+ehk1EuO5/EgcoriXlbsEbyyZx5pzZ3HXBS+9xGbicU2EFLjcrfy5Jaoqyf7AGi70/Qv/wxneAQMeVt0QM9Z/8X7KdR+D5AJmc1RGog/jSE4wdgKKCBrHyQA7Qa3f55YO8G9NH8ZWdxIbNBVJ20NC7Si8RD1fezbk0ZiKfvMxbmO3t3vzW9+52n0Fz4gj71xhCLk7p2ipb+YRg/N5FqhXSgz0TZ7CpTeWHVsrS9YxroHIiAYooJiBlm4d+48znyIzLEk+XHNXLFiG2Bhgg7zBDNcfYzrJ+WbotYaMHIZH0BcXNw5p7K5FDc26+aSULV1aYJ5RYiE+nbxVmhkGq/W5UbEkhAYu9DtbU+eEasRhoO7XNtGp/DbjoUyt2LolQqljyox9LLQ9/bDr/cTCnrWWrcOjNCdMRDP6LUGjvQnYbihzNKKhr/j7q7UN1A1N8nm49qz7V7HZCMYtrsiScvaV8oKuJ6YaYSOee3HcyDpO4HksMiXo8gT+wosFIDjZBeEw6FwCULfK+gTj/yOFBW62H/4nSRlad+PYjsMMEUy7tRFzKA82LXKgaa3mky/1rbfAal83nf3afbCc5q0JiBkRH+g5mC1Y8zUMu9281OXm1fZnpzNRXdvKSbdIzCJAFDV2lco08Xo7mJhcUBmdcpx5Kolbp7EApKsJPSZKX7010AjLpwCyshhezvtMxhLVnsbO1prMCJXQGEES02bd6tNj9DWHYf6FAy+zdfhwAvtb8cXydlYk0gw8veBsQSU7UbI2DSUfUaEIj/kE3mmH4bH9tUg/Y5PtlMDZu4rYRo4eL+ROwYbs9k9V+/wVLkNE+lEXS5oVZl1idXAlVIqgHlwIoQfDz1HLsXpyp2dvcfPKsL96KnEkaQCe/b+3/pTBQf/xXDgh43Qj8sKtCKvJgvmiLmKLoXv1FdeC7+6m4muV2wV4zWcMlFm+qyYPMl2HgpM0IsD+rFHGxWEs/407RjfVXTiCl5V6AX5XybJMkkkna0BW2wRAas5pRQSmHYElH2fGgnWAd/v47uTWPgSrF+lCeRHIAl2G8GoxPJtzxXQkhEg2+yasUnpqVYxNByC+yL4mhAcE9wA+z64ZSD+7mIwbvURuDHRISnTickCjnEtKspIrvQv3C3LRnjC03xkoOhmf68nT5E0AvlJSHEpcaJSOQu1vsT5oDv/93tg5QduhWZ2oH3CU4lLfx+dNQFwFue1srM5UI9JTVrmzbKSceLCjGv7ubUdr9atHAU1/OKB3kQapdQqbCbPIJETeidQtWC6Kx5xkMnlQ1KAx+m8Gs4Svd1A/G/POoWtGU2t+VYK0Q35UDAzXj9hA76Gv4v/MflgtrqoWto0uNK0agO3elLnxT/JRp6UpcDAlPyykj/gU1s3g1DPgGVDArF4ruz5SOEXMCcF8z2yrA9P/VpU7F1cFVkIjTJMs1nG9VhW5/7ekgjc8m1R9DQICEe4ww3jDalkW9xyTqQ+JwASdj7ESnbMTMRFi3aH6bI63+dov3D53HUv1OzZsmy3rjLUHZUBAxXh4xtyNkbfokaqqO7DQfj0iE68ecNNSxUsN4uN1hM1pHW/1W/AV1D9Xlp2Bj6LyEtdTIiTcmgStjLZ/2J9R8aWMhVkd1I0vKN2hOS31OvRfi66F0yOQOsKQCp8LuQUIqXKdTHygHDMHhCOolbWIr2/6m4mHLmpHOSxoxEhvPVerw9p90DxL1dK1g6QpztGTr79KyC3QU3RcwJDn6fd0zMdkRtZsAYpHicwVt/Wf/pIKic5sg8f19CmAtXsTpg2qvz0qrl12Zhix6ZxziSRrI+b+Trvm/0/4Ov2n+buZASh2VjN3XBEF2WUVi1LKm/M2xlqEPYMG15utq4gUbJyZBkmR/3qyiaoWL2Yh78hhnQIg+xe8LBPoPiF/QA/oV4nP96/aO7EN0HpRpFU0ZaOctNC5kg/HK+WvIRDaVZ8INY50dVgk7Uk9uGnL76GP1HyyyxY2HGbvSnCD/M8Stnaaa0Qp4h60xjZku7gfmyO81ZQAYwSrt6YjnFhrkkacUgkfjvv0mLB0puFEy0bIA3IOq5LzD3e20ZFw/o2nT/QvYWNdZxeg1/m3W8Zy4ltC536M2rpwZHogYm4UxePlhzN+lCJwVgZViQyxYLCHmzXAJoP4refuMEj9X3Owv+CtsvKW7dwi/Xxrz6SGx09f+xrVhCrziK3yzknIob6/1VMSk0qVr+ranxAn8cNy8CsSiYEbeJIcZUA/bdPWgISuk2KHzYo9pyIQxVzFs29vJsBg+VVVE7VngQYCHJf/VDP9kUliSG6m5iaGks33aVcJqx/MT7YUkkIkG32v3k0f2jPrk3iYZmUCwjhh3LiAV1PWKCpBmDG6BR/fpgGvYJ5LQ389uLAUmP6LR5/o3Vr7nG5EK21lFhgBzjntlz7UXYqxRCpHwiWMbW21/CfvT+L+DWCjmEjbZZ+1ToF9Bbt7NI0yqYlzCu7Z8jYPatWzR+1rFhM6PuQCZ5bW6GY55v5AREMLlRL6yXSKWk4SOQeP06x+EMgAkfTFs/gm0cS2Oh2O1eA8Kgtf74FD4k2J1Vo2lMyYnGjsXXijTJrHkOnX64GInLOyFJxlCD6lkWdegzQ4KK4WKIMVvhI04BrllfyCTxMlqWG3COwbE2dESYhkavqNySXOxUKqKax6139jqpXMAY42lo/4OUUSjdrtdgIQBh0ACMe6MxSHEUngTbJwtdbfzLUhtRvCFeYibGnrdtc0By4AOcBWRLNksjnJXY2ocw6PenbVh2suC8NDz5c7w1ZVzt3pX6NiKtP710rHHVytbWYxQJ/D7dG3AIfTHz8voyp9oA8RR8t0zeOJR3HDYyi3SStEIkMgjPqIAJ4domA7A/A/R82x6WXb9CxkqLOXbX2W566YIV7Bb12I0EbDoaIBeK1hTkKaJe5jm5oOyDJzUOUkyLHlquiTGW2Sr9XPtYeHKXn3XnOEKd+GolTrAkKWUA/0peIfgbFDzYqJdK2R52Vr9QmWHEC5Ihhr6mBlJVt6ir3Yq/gxY3GqGbNzz0v/ZPMN0g8ZkOyGdnytA6+/cifq//IoP0RNm3rFLVYTsbAHrL5dDUw6wESgLfYZ2JdiZwvk0vE601cxisJ+G+2GePzK4r12ytkushm3pIAj23Hg1s4ubaS5CXYcko31XeJ1REzxFEDIEifBWW2jsRhW4dc/F8+ymREI+x69pIZyvQ2DL+BNGkNuxRo0QyOfWgvJrDcTk/V6yybFOA/7/gy+OgE9E5c8m6dTOER/GxG4c1IRPFcjoo7RmmJbh7yN3GRdFI4c2aXu7MQ2LenPaoCw2g3JRpo8cvEwKyTUPQj7E72Ct1cugeW+YYauYxoLJ98HwHccIOP+13ZwjKzTJqVX9vgHI54uEH6P1UMwLqKCC10VzIGdyb5fRJFvNaQ39jE5xX5Q1/Mv/bEiJSDSwPGwSIg4L33ENWgRG2z9e8X7vPU/rt6WoZ0LLhAAVatmrIxMCEeJ4qG+tA1COpkBN27WE/dhZRAxd+tz0swo7/kJj06PQuf5brqzkc6Sbtb1mSUkS/qJ12N1uceTBZnbUPA0HmaohK6DbFRjDI55PVZnAI7YFRNBy1FKjlHuRoh5JMMYjXPALINX7oup1HzMfImOih3V5EnEaB0pr1MRhfoQWf8q9vWjXaVm9UeDyfIRZwAORfDuJldy5Ph5J9EXBelqIp4412lXC+7tdijOuACx8NH2GTPXNBoSwkrxCKcLtfUHbPD9RzrQLx3kb2fQFB4S64lNlCBBJjQXK0+3SboTwxpVxKQQ5jX3X93Sy/d0ihqAS+kxL9OXktO7xE8IsTwLUPHJ4GByTEJ9VjJ97DJfTBBS2nG75ENibaivG/o5sdaoC4waIdZuD0EZmh8n6MEEuvbu2eaoQnBDIBIR6Arsk85LSLg710Zn/4TYyaCOTxJBZZew3xD348E2lP1AG0fTh9gJtKU8dA1o240fAF03gnxQJQhVeQ6gtJSMRdrO44uOjfTl4nuMKQCHF6by5rBM8gmNuHUEpUDRaeMe57KSE/Kd7jnFwhHvSHowwLIMCdCPRfDJXHvqCCsPp2UIfSWd8eJwtC2CQWgP1zMTQvfNETRjNwsw8jlXGt9KkQGq+RmjnpxurroydY3zYGaywy/IBmMFF0sR6cxX+LcnO704kVOj0aciHqHxcaIQ00393A9hYQM+q+Udyui6dK7ueOVcjVoeBDhcKd+9AM4IeTkXJF9jtPadBo+BST/XnI2IvXhfJM42ANOJZackHXzQKjoSvZjYm0c9GUvS5sSF28Kk+OPvc7NCn0BAH0xw3z40lK/YJO5B57ZaPaMhsE5WK4B/w4WTEW0fqPLJssJaPZPtfQlv1k8HN6Tnmec2m3lJuQUM+hcfIvyIjPrm+qivzrjaQapU/YdWfjdgjN1hHKs/o948wdTtHURmBdfZQ+xyqYDnaSugpS5zWvp5L18nfztkxkV+iHWs6huZ4zTjnzrLxuzCkUmdPrlrkOiPwx+pKd3A6sIqMayJVP1LlIFy6yAl5FKeq2cW+rv2kUg7flcARGzefIhD8cacY8WmiXNidEOdzsttthoFLP0kKYI+fb5nLY8BBqyIKuMfARyXWK7JYO94XAGSAfNFU8YdEzcqOS3Xrd2IzCdenyUYc28zMko5zIs8aCUOGZUGvb6b7C/JKL/SoS/10rJ5LE5+gJcj8U7+Ts3dKPm8FZr0E1c8ic6jHUvlfBrWI29cSjsYMrt0l4+MVGlJVL36ShmoA64vLlQmUuCXLFTE3b1HpNMcyk7xDpruNZrLaV+f1pnYK6T80aOBE6NB0AoZc4f+OgV/PM5+HKoNiY2p9M69Q0jEnb8uBiLoxciQ81APRhUGlJHeVSiToLAvCRJYMwk125da2ge/6ROIFZTvJ2lB5Y4c/Ng9CzJLkYYUic256sP+S/GpUsE2HV50O1ewNCZBSymsC57KmHpzn7ccLAracGJT6SvXJ3u1wM7lrXDIiREbPe5q/P3DISlI8m6SPHUQ08U/6Z8GijHs5l1Lk20vqGjDbQMF2FCa7xoGONPHGGSIlcNHpVk3YmpG99+kmqsyV7xR50MgeVWlFoIJr63iMvt1ZeW4QdpD3EUO9btTf7hS98pqct9at+7FYu4UCrbW6XWqxdAF7VMcxTR2mAcWnpS053LmYxdfQMFXxtj0n9XsCW7urmOaiLTFIkAs6NDdyujwMfqToOzMjC9Ynt0WdjDq9y7WNpywqFok+IX7c9lTD05z9p9QdRF0V/vVWB6dTHP6KRTuSUUwXbmSEgAPUSiYcH7DGfkzblXGM/yPCbRzvSm1e0QPudpOYHabRsq6d4iraPT8GHlUe8rSTl1nzJGzQRoZawYuQEAHVz41iM/8SmBzgSlaQamPM5YhdA0CPSuq9nfO2GjPxsqtSYHwpQfoarvrWarlP9bsqEM7fBoUuFBlLmCQCODYVzoNPWEZpNQRj0+D34S/xRr8CkJNV1oP1tYlvJCFG4cxnAHR7UAmNVk4Yf/FAhU7GC5oCb69qBHpXVggIaG2H43Pc5GHrexciuLYZKb+MyvHPwCkdp+0+ynRmouHxFDFqEaqFe6GaR+XyE9cuUjE2vtM0IFxXwdTbvBXq17TwY/vJzylE+X/bY5/NuKasyyb81UT/ONinVqqUBjA9XXQrnjwEHF0z5c6EdrIrZoFKc5/Tdwj1kkEKgUCTGzusOlbn0NufrorB0pCFRwlcMqJCEvXLkU+hF0txyS+Wm7VY1ZjTSLXDtz6zJ3edBmaM8TXUhN8HFrKuLXXLUieITwLrawqhz2SsOEFncEkUdz4d22x7kWHxzoa/jxW4ZpX0LNcr4RXr9rj9yEZBNvTzrKGZATgt80sGKD9QD/JkCU52VMLzuvCHDi5mvKHM2rpGunHIbjhbz6gSguWtGoQh154HOo7jjK24J2s6/8is0hF5pMCQLTWf4TRG2eoGkZo5/lsKRNKeBJJFccQn/fxM0hfmVSTeX6EuzZrDQOOUFKJF/nYlTRVVAttxLZCqnqoCS363O5FBjyiHS0Yx+kEs5ubfNmAV49zrfgmiJAZKnJ2Se4imlmnoK1C0bhw9dTe17WZCVSFX9UHlx+HHKTLBFyJ6YPGYbi4QY4LIB7kQGWnVgIBCysyvSkiq5PhqEXee/0PDwX08aTZsUUK1kCVJPpCpma7ViDbTLiivMRmhg5YXlBh7I7IYQaDdok/+I3AxS+9W+JoUtZ4Gzwef0HWyaoQcGvxN0DKtty4sM+1X1jMofRG2QdkzL71eTJgLwv0u3kv5A9aqAkkyq7BrSM3/6g5+U5WmOQxJ6xZUYPO7h258OYBkaVxX3b7XkRfBKsRjsovxuksmQH3H0YB1GpHVzxa7eCRavgtaCdsDyIweDV+CukFOjgSC50cIylMpjG47ra75kV77Q1xDsDXdP/+O8Ed7pUD7pVsj7ESkNrKAR5vpy6RANGF0WAGkvTZRGgX+ChThDYJ4wgX0PrujzL2uuPeINyHe2lYXzcfnwHH7uk0gcoewUUWffgjf6i+Ig3u0IHpdWCJq/QnlDmQjZJF+22n0P8kj5j3tkP7UMxQG26IPmoqatp98T/2iCWoVh3ln9UCGZYenE5eHkvH3AiH2xDRl3nlazIEcwCQBq1pLviaDcDpuHppQZopL6MM3wqLBZ0BPj5qg3uUrr0+EfyDIXcbU7amRz9IgYX2IjuO9vL8r24Q4pfRDygn9ThVxt3vM2YJEm7H0L3zvIOXVuKHooJN1mrU8fNHE0VbWsXZGiRmu7IulGX4Fkb2iAdciBd2CTJ05qlTF+j1avrREt6jIQyv9LkcdQdNCr/oiP/piYZpGPBCVNYWyQcI3qTjSXtyNYNeEZJtcjaqzKw0CbWi+m99qA+7R6PTJhaOgGyWJo+YnD4N37VrU5qFyXx4AYu265jV8cSnxQRBOQJnLRI1PoT9GzjlQJiACliNbgpgARyKU39LuF1YSVbHXvTBZY2Nl0gKzgoWEgUzFoZVWdrwrGGkqzH7OcaV7dDs+ozrWvEHe84sIzAiIgz7madxIC5ccn7NjrYvB2BtHHZZ0lukvE/Dn3JpfmaM0OfEcYmZWTqDbXfY9F1+YFN3Jyb1LrSbxaVCKJN/6skZANYngGuWsnTfxxlgem5ZnefK2oAAx6MEP7KbDo0YSEN0/q++AvjvJeZ7A6gfsqASxetyzjeAgdCRW4LhTfY93MEH9gE6K5dnL8zZH5Jb71Y4NiFSXjWbG/y/g8ldFni+c90CJvEjOFgAcoj/jN2I3BhK7OxMcxX8wVVfJ5yAt3g2Zomoxt8IltspeKks5KTPtU2yaYGHZrlBxv62Pd+N5ZfgcTNXFvnGVsRLnGxi5lsdh45PLY84h/mrVpY2ph6B82LpdsKhT9qOpT/odX4MXksbOnFlnDmNYNreHccm7Krkn6/wJcqxbH56i9l857gRWgtuHWCmAB3OHsjT98v+REN4p0boez08KGGwuU2VX7EeMaOmICyl02Ka0ER6erkfCjpxT2HRmEhIQ4Qtc+NOx36o6f8SINwJbPfHkuSAVKSRjgZ5mUyYa91ybkEDSgm3/O5Lm+DiZsSwCJef01nx9MRTqZO66hImj6e5wUYl1y+pcOxRUHv6dfM7XdxeK99tcOs6FJzogf9cjkzcbBE71eK/qqw/UfVNNOC9Yj0R5ab7Z2x+ydhnWGqKBNPWoix+eHA5Jw+0Q5EHq/AmHeh1092yjJHbPgUFBkMRLwzJcjl0wnKJ+k/9zrIUZ6Vcu3p4PYLZAXa1Sb1+WqGnkiA37ng8ww1bl65CWB7QXqdaAgcoELEofapz5lo9BvRNHjeffAk+jxq834vX886FyDpqDLyLikg8QGMKeY6MpANq5mnhvTcMQyaw/UhXTDTiXDjk4RM6g5StSMEX3jhpEi3a9uiA1psdyYoAYqEZ1lNILY6DO0ip9dIki+64wEYzhK28vje8TGdgB6StVN2nSL+vRQiqnjxdnUq1F5GbNnJXjC/3R3TIV4f6edZNafJffQqX34Qf1C4K41XgS5CE9iVb515IF7MzayoCs2ivA24KP4tqLquz0AjGCp44GT86vZBt8eJ81GO7Q9NXUZhbsdgtUzRFgeEmo1GXxtdfQDgl2k8aEBy1gZXHMWQ61McYpP6/Y34L1+IMB+NyL8lK5HwpSm26evp4s91s1SSRmRAElsEC3of0J+gT/w1s6QlFQxQnWZqsOTzsFIwuQFu8HWSjm9FkDOljSMpowyCRIGqIQy06k8p5ZVjyRKO801Qev0w+GTsYV4QVRIhZd/StCxAbIctylJVm2kAutREFh3tij2a6LYsuoRu7IZfXhGXjZemphdfirXj+e/xHqjUXP+wmCKRZp6wPcCMBGgyYylLErHAYtWfjPlS+5zmHmLDawb5fQYYJq1N+quu4xOwPvLbxALbce03RMEpD/OQUfoAHGCUiOpAxyKPPskeH3QyKPk1AEQxeJzckON/Ga/qhQTGKpE1xNaWAoRvc1G3kg73rDZFnq2ktHcjR7nHBAsbvCqNcl3Ow6TcYRZnTL/7iuIAZyzyPFUKXWESM3+fhx2wdrFoEkeD0Mmfp6m38i250hqM19dmzTejVd4gWa/J1mM36ioGnGdqNOadV+p0kCrWzfvqFYCFaUwM9m0NSIrloSGp4zmieMunUM3Jxsj4xrUJZu3sD1StKtRHaAbUCaZnaSxOFSjBEWhIZPG9hCh/v6o1zSSIyg90/IHWmiqg2aLm/0cXOy7sZzBSDo01tmxl3IytSMw2a1zKNisILs+Gf35FTbr9cJB73L4gRBWmiv9nwUPyAxnkSJfX3Eb8oJmeORQDNdqkRM043WYPxWNdtmE2JLXWWIqT+Gz2S18Brlh1BNqe/RtZvgoYoBNXK0gM3Bg2bmAUPg6c+KxEEA2OuIQLemU5DYYaYS4+OMMiUdtr8g+mIrjYqK9oZqmwBzziGICXmQpaLGgozV9+VN5zbFZy70rv9G4ylCHPqqd3M4mHGQer+LA8tScuBPH/+x2t0HiwE8ncjHDSWdXsabZEEY9jAjGGMhGjC6dmg67fqn6mPTJY8/KTtA/DvO3OA1+l1EFyXJVxirzR2iTbSLScUZRSRiznGlOXssNXNYIS/icY7EAw2Uv6zEkpL1v52eXmZxQUfqAVee06kJ/YabyhB/nXDQwW0899TNyMGUfqbjHo6xlI7QzSVcdZtzsnhiRXUBgIg39Yn05DbPoHMLgEZW06MERJoIlGPGgoZv/dUCsSEwEql/E2vqr4TbDbr/PUZXvCc+ZPO7TG/4ck+tXHXGMetZTkh9hYciiMmyLi1ubASv1gHxjy1tQjSYvIdxtfjZST0a4hRsyicEdSmA+WJov9sBMVbuv7vBwLgbS3kSCvCVB0ypYHgXEz7SND+MzsuB9CsBorwsAbrtTkhcjlcQHnFc+1EVwzTKpaS9I2z8B6N+u3I7gM/Xu8rneqGY4dco+f1NWcmViIUDYdjNpEB+UVLuzVDezWX7HxhQ9GP6CV96FeJOu/XUxiUcZ9wqAwCocYqXEIAsk/NrO6pBryUZcxmkxXSLsG+AkGa7mEPfMJ4wamHpPEjHOVtHjMpSJP2k67e3+xU6F/ogTv7NB3LBtOfB3j17C7AWEYsu9zYzDFPIoLgwuJkFX+CUjs3hoVXKD3Seqr/SWr6091Bb/GNm0m0lFW/R9qqvJoFrDKv/SjasvilY284CPYK1BY4SnJqeVsxX2TGMPFPXrdtuKg2dMr3tc7S8lpnnKbFkLaCZu9QaltA0XEDBMjM39bIf72JgClF9z8OxRQ9m609h4/t4wH9vwS6O5atDPcQR5POQFu8HTxRY0A0mfvo+KxUT5teDFgfNeid36D+hSkWn3QC3NMao1zQSPbuMvT8k09P41dcoAwAXMp/sPJgYzfFCY8CGEfvozJFHbJS5jkOH5EBHklI/jbU6k1DtRFobqKOYSR1qvUmCYSRmulMD+/fuZJtod25XqEs7giTmphmDCKuHTC2/tPxlRKsd5ADFG0juBwl30qdVFJxCZo/GhaBlQwyvm2TasO7AUxV/Fk0BD/rqUjvW3ypDLqNRQxteAa/8AnYrOLMdO6Y/wtkIt8G2l9EjnTH6Ax9WENjZyTTMIYOvX4OnxrezyKO/RL6c4BHMBCItWLW0BfbnKq47CswTfopysTMU80CgMAeGhKMsYrq+/hhbgm6nARP/qSjBfsLvz04wydFgQOv2mu3CTyAt3eYuUW3VejXkqrpPbgFiI21gS09IrIas0VxRFEZyUodVQlY2ELdYEQWFcnakqqAO3UHZn9GBaQWUdgn/IdC9B+4/Xyl9tKR7gfDbCOa9HS4HmB+Ia/QxnEk4Sv4kYh9Q8UMNX8+F2OZYBheGobnU6iCaz7tHvpGIaptla2yNuYq4IaVsTk7pJfaETJEIxmPYhO1H4daTd/CJi7b6SNreOftIdwIlYtAeHPU99wmBhqwo8P2dKEWUp7TrEXewM3UPasXdzMus4Y3zaR0gB94Q5ZbSaxL3POq6mip8h+miPoly69tGZTmvFs5xiAzoEMYFzxaGiXhRJvCdf1JzJxt3GKyKgG+8FT7qaLfyLEzftll81GUESCPlgzNGQ4+hmkQyJOSS9B7Ggz+FMe/vYsrWmboogAaTbK/xfF1fRX8XDyqZyOguvzzSUhC3VeY6i2wmgERV7UV8yGjQExRhOc9rEgcOE2CefFF1pLRVxcXt/kbzy+SKCTknMnPZVW6BOuPQf4jMExyMqy8iXlvvZ0fsPzmpWkIRRgSUa2WrmMM4UIGLjyugqXK2T5m3cwV57Q7PyUOe4pYn8nbNIX0tbIHsdf1HUZK5tziDRgWrq0RZeLzWdTtAZ4gynBCWfdDnOjXe4yxA0quIxCg5QlRq08gYkt4qePJpuQTuUU9+E6il3htLi0k+7tJhSkb9V0vr2444BOUTzHmZkSNFb3pGgnMmDTveJ0pDlOcb21pXg7sV4aOvyt7c9EI0BPUXdWMjetGotrARsOWsjbJ4Aw7lhmtxZ74/T1bjueykgAsA6eRupH5FzH+s3CB6QFII69ccTzYW/FdvKNqkvd//l3aiyM+nLbNeU0AwHzwUf9vol8aZ9jKh7wSJWVglffNdEkfZoy0tLfLO3MwyEvXmJsmJcLcPTeKl1CanbKRC/W6jn1SHTeIE5XaJnVa/NyBD6MvOJX4g1J3v5Nl39+g7M7qB7wOLn44ADBe6OI9vk3d9g2t94q2lICRhw6NTU7IZ5/G1T6A3P6bQThzPpbe+xEzFGx655RY9l6KNJX1cSsXnvRyQYpovhkw6wDn8fDbWcSJDTA7gSvQbs7E8PCzO6fSuo418ur9phdwxNsogZK+agXC0Oi8188KcFly1eW75IL+BMLL1BZPeqEeLBgIareVLchDpk7ebBAUMSWGQTaKFhc+AZUY/WLcidfWRsk3ZYt2g9UK/hvzgkaM2ZkDHujrQq0f1ot8ulxkwhd2nNkgO57BASjBwz13FslRrhgFeap0/y6CkjlRKwqa0ERysajiWqE3ghoMxTwdYJNgTb30XR78EUE18mW+Iji+rs4RK3ZP5kmdJ1tkKqekpRlDLBqsjkgxTRbNXcHKM1O9zyOL4qNS+CGpsB+qsBSklr1hHj1okdsiHT7tXQHo4Z6RPFenWMVNqvsG2ym1cQDRDtpPnXWqw0kdNAFv5Ct0VgyC68UM3IFzkuNL9VDeHDCVMlSU1Ei29hEfyDTu+sz+TT79srdELwGOde05GqsYNs5+boa86w9KpHaGY1S4blaK/Bd8K6SQSNJY7gpE911fI6SI+d1jWLg4zfCxXwQzWRzTiS+MqBr8xTSF+z5GCMHWHStz6G3P11t17L8O846Ja0QvfnEqXRCh7BEZnWgmQgLSqJrRSUPDCikAjmx9/oNXMUawjyq3aOByHie7yohQOv+DD/k/xfX4cA4s+OdySDQRyRvsQvAkP1jHgyq5ozwQzM/OebPmG9WlYR2IG+Czt1y8cyL8drRhg2RCsj5kUOgbeD1VxyMT2nWXHAN3hZ+R4htHbktO3NB9OHuQ85Zr7k+m4PVYOsTwmYaWMvX3JIa+vZpmyeheogNBQ6Ko/KJ0X1T8HEm0jrPtpGvBdZsSlC/EoOZDB9S8PBfTxpNmdXKj7UJW4An2MYRSoxRyUGFPEAo+5iMEvUJGVQObgo9ptRkheGgPJT1aoJjGn3v5y4Lg2me9mfp79/0WybHxAWzJNa3TeZGluOheNWXl/mZ0GgsXWIkR+PWQK4wjKi4KunHV9ZKTwU3ugeU4zLhmGc4yyi6VwJWUkf8a0clcZxC9rJOGOOezTHPDBz3R5BavrrpqGo87Mo2iGr9Uq4lIfqmPSNQKVBcdt1Ydj/ye5B6Y5uinHsLqiDGPIlYJOTzo0HiwHWUySv2TiDkfdvfqkpnMYL2xqCdjridxyjEw12/oYtmhUMtkDcfg5sg8f7ZO33CFMsgUPRlSgS0Hy+zrOjky/MDqbcnclIK7PE4yT9xqz938yejUMIl2nUk2KJ6Zx3AMhWgxgPzl0IZ7l/VVd7U+0kXBL1ugUuLyw6+Ey3j8VcSKGANu0uKDOv2n+EEl40RIM8wP/bhi2833ELepZmCqDXfIEWK2x1XANwmEY4CtiSH2UWwEhi3X8XEWl3q3zl0XXy3f4W+9qiglaFcBp3980A6UUrK4PnswqtRBLchZsLtd7Hs5Fa4CDFT5ojH26lgQg9vkzNCBSO3WomgXhKup8fwbo+hgzcoQCg5zGU+OrYOevsRSDpCssm328cSnVPL81gJyHhmL40GxzKytcHe97Nndo2xFSnD5GCKOvlFrWp/9sgjvZZHq2JNGqUhuGZuhc2MRQg0EVMfgTJA1ybrR5X1ENJnkv2vasD3salLyKNm1KzNuN60PApqQ6pk4EkytXVWnsgsapn8IBKGmMvZ96Rltr3QYwKXDxsW00rl7VdfCtATlma5KPO/liOyjVBn6UjZcqsF89ncCsaQEZDzdzsPuP4paF68kbLHuSQDqy242jfuOP8J5TL2hSUmmrNyeog+i2Yr2r5Tm5tN9//hvEI630lvOgtpS4lV17Ht8mZJauqI4BQiCLzR8ju133gBpMcbmDVxue7mQjeCBXjijD9NdwPozpTIzvd8MlyJNDxcPoNMX1ZWFjC3mrkBZ2UDFYkV9pSwO45hRE0anqKiNHptnUvfsumyOVXaR9+9GbguS38lmkiZQRmmIIxcVfTaVf5aXLykp1EodJjEAUP+8y42K3sYVwnQFmrNgluQxjwu/6knkvRpcxf9fAD12rktFUxVXpY7oGOFyBfyRTepfB5Q9KUBdCTk/aUkGlh4swoK/mu9iPC9hy/t9/Lmh87JUwRbq7unrX036ss9aB+GeA8WppruI7YCm418qkgR2SLsqIbxj29esodiUe5mIEvTTADECneJsNWJIH7KRq5BHBvPjEFXn9SMleRn+DthRJZfzuH00RxWI4tOgDIG+ExE6Q+RL0Za62xj1Q8Qt9IRrR/+n4sZuStJTzwigZKXBYLnueqcQGjAspdbEeojRAqZXJlC/LJQ4CElGGBsVHC5H16Dym7l/Q5RJqLixqpHO+0zGEtWexs7WwCs62fhcnvPqHYv1iuzVL4KEmyPWpSSfS25g3a7XYTJInAD42/ADgYnVDS6Vz3R4yLFpYOrr7IZpxIGCa2s5n3TY7fkTCzaxtabN5801j6YJE2f1Ftj1R9pR2Caz+rC5XvTkJdfjFLmca4qz8LVZ7ryzOsvRZ5GGVwANooD+7baDEIWL00oDFGm5VuugBfbSxh779UxNlf1bU+INK7eUNJxIkCjE8m3PE0j4or+8dnJWi3EQR932FukuFI/ryi3SDZfivYywpjbU6PLJcb4lKPW5je30Gpr9odTxdg4jzFPZ+huIfGh0o9lq6t3LagIJuJ2WLaQDBDKgxDxrws2GSUtLG0VJsvcMeuU/O+rdtZ755sNO0gVXStxjvt6Z2p2OfmytmjkrhWXAi6k5izepfbKwxDLaLJn2Sxd4DUDuvas52tLvkA8QhmrIpSOnzXkO7bCOqDPs79Ow0oJZQyj3E+muPLzavsnW28YbWC9Tbbt0rnucuqDb3a29AWW2p2pfOZAEpeMtNI3laReYPUr7lrIdfbKU1/mITMbS6jgFqK/2lm7wtOuHXp01cOeCaVN2A4+SQiBCuTqWYkCRYvWGqCBhYNsuS7FCmgUEvRd6tP9khcB+9NVqsiv0vJq+snetA6f1SSXvjoN3laa4I+Gc4I0k7hiFCQnLhw9qISePbh+mrAxKEC+acE0DSDgUoCYfXOwrgp2pREm4DIfltc+i4U+IIk3dJYfO4Pb21VGSAQ9kO1/4lloJwRP/KB7EQ5uocxkOmG6Eud1w1SpJnXxOeTSpzgTb0kKk9m6wxsPx3YqeqrpQjlwAzLV47Mw4O5HoEQiYWk3vIokxJSxkPEZPNyYQSSaKG5tDsUvhP80LjsoKta1/A2TcpL9ZmeWxLcB19xdFI0uT7KuSkuMlvDuDR2q1MOpMOmJC3YLJUVget3F2GcgFIvaPeup6cCVbCNCk99NXO4j9goGZ85vPyg+uueU1F+BZzWAP/oxwKSV/im5tPq0bUqdVtqHiOaAkDadVfvVfNt7nEu9sraVgLZ2QY1fxGKv8I9PZ1nv+g93FlGqEQ0t1VZ0CsUGEcXsWkrNJbkSDv0wDXsFUbqC8tzyjtwbCkfoGyX37JNcGrjQ3eu03pfekh+tETby6Gph1gIlAW+ys86g5hlEKjDlZ8DbGG8uawTPIJjbgYUrmJsXICgAjxcIR70h6MMGASMetgh0/dvuG5KNNHjmLntAXcjSSFYGNpbb09STfuPqMTXAo++D4DuQcGIF/26fGh1znOMlTC2Ud9wbvs/CEL9ikY7alcE9F9s39xqPZQp18qumAceLyXElweZNR48W6TF/QLrqrQehb/dYKNxvZOBFlRuPfa7gRTPw43VZUCJ0jQ+oRCbQLpGf5CAarJtXsXs9SJ/cZ0y6q5jKyz/mp3pkvSIRZdNzNL7cTi53ch7xDXZWyXPfb3pRrj/0z1f8ChnbRTWOIoYbt+9l+v4mbvEHDJbH/V09LtsxxlTa4LjXzTH4Dqo8+aMAgr+jJDgICOD9RdkoUpTOSms+/Hito/ytT41v+rZSaOVku8xpFtLAf8EmtAXKyszfLN8V/rOpBJeFOAUEkaAR6dX4kMZuPlucspDk446AmhbDR8NEwiEpbnt8Sixoawao9uaKsdQmY0cu07sPTC+EMaiD5GUnVen3uZFyblFpiQfcJSKXGOty4NimDgjBZGJOCX453L3F+eE7CslaSDt7ueK+Q+qrM2UfD8yxLzOfnE7/7htngmrm23iwkR6uocBnbaIkcVrKEoLeitmoPIivE1pSGXGzigkkZ4FFaBX2RuRDzrdVM1NI3fsgQomlbrA56mAr/izDJq3TvwYSci8aRcFFlBqzqBIXyKG0su36LoYbEYJj6YAshE8VyOifbca3GpsaLHfTrYWjUZ8jwHfcenjJc0HnbGQwciErxOxnfYICSHNTfMdf0htW1F1YCeNAa9ouRhRQ46OrFQsHYA9GeMeyUQI0PwC6q10ZStS2SGNVgfUqBPRMLq0c3wFwKK2Tl4Ad3J71yPgC6b2EBrOjTLjm29RKxy2P2zUE/xJPEbm4Bv5LPvc6ioRk7A+Lj8+7MqtYiJKkspvVqbErxcIStaLsYqKSUI0G9o7LubJbyw9hiebmg0IGiUVwaBUhBrg7WjuEk0vLV363QxDaYIGirB4B8ewxf3o6KfdtellhN5KwL/wCzPakosWCXt3HJA+qf8U8TgCIw8h1nijBU0RS8xcGvgGYRsPMYD7Hcw30fWcKsFh8dnQRx/+iViATUJHZQnZXG0ZIKiqF7Qeb4YOjWzcUVONQEUIgUsF/+DKLhaMM692A5cgpcR7rTL9RTMKeRaJv24d2kySqnjdAHTzO4n/lbt1hG9j9aztZEqxfRo9Jl8wCtZP0wTRMdo/0ZII083N5t8P3SplkhRdI2daryx4kwz8oKkA9RBIw+U5iIHH0zVqpkCcbcRi3+OdMzlV/tsFy8aQ+ySwEwPI0dZ9fP7rUTKJ/JFF6yvegUwYFJ+JRR2hjehYOX6JHsNxyJvZZnkEgdxhQTYpXKNLAh8LmRKSGNvciHtwOVi2iVjbPU9cA/4TKce7Q9+Iar6TImWd7Crruk6r2doVU0gQImgl9dmAEWmoMhUg1piLO76R7mMLXKA4jsg2iDSS9w9+BaZ9P7zl76ggrD6dlCH0lnfJj4w9gEsq2aVhqN5lcj7gb6LOoR+RP0iorIqJJRIz7Y2UxnWTIt79TsvPBMngmxRKMJCRnoXo8+efyeUQmPSlaSM6BDp1tScx+ntqk8PzL2kQVf62dNsWUrxLJtZG2jh1GvRuyVVO2vpe/iZUGO6RT5Dfo6HilV/psokd22USCRkQhEyjnOWel/GBiJ/3fIyUiuUN64GXrW3HxZDTgOwL3T7kSZt9vXoiTdDadzUIENHLZDIm+JE6d8li6RLjMQRIyMr0PiiK8tyIyhoDkYARc3D8y1qUp713vg5nE2XfxjWui235jNCPdJR6dcp9pmGnlo0uC+OLucx08OwdpUlmQKBcHO8o35aY5cRUKVQfcrK3e0HMuWXIjYM/zgguXLj8Xi4KgVWFOJqlaoLoQRvrj5O4Ffu8yEr3AS+nEg0iDBVhiTTKzHUrWF0C3HfbTkqC5MjrWztj2UZyrO8umGtJepzbLRqv/a9oOL8IBmYPyPfWoO7yz0Wk6biO5JA6zcP/qWGeHi+Wh8INMRxZAV43yIlt9ocDvUzA+rkv/ENqRHmJzEaTODvMGEocML1cvILPWRhob3gCeuoDXud4zgMNUyGdN5JVDOD/j8goWtwWZ+kMSwdJwOj4k2iv9LKdO3GncTEU+Il/YkbxwHFYnZaBMkO/mXN9KkX5KFYzfk6sUxkuy2PIrU6Jk8vV0HkPXuPHGCy4pYJHEy8QZtJMpJBey3O8ETbSheV7yUgj/Usc//llEWZwwJ9RWPvPPSipOlvjsd4xfAQ3VNLl9aDm9zKp0ftCapDuBa73i/f8xgJqssZr/eOqVOgphem7SHiq5jyDCr7m2Iqwy7nnFwtGFnD0S3CcVlbLCjnkXpVQ2PkvEBMZVfuxxdGcEY7JHOKwmkQyJy3CfnXYyMwsp40zGQeegFEsTWRpDXtOEc4cLCEEf7KOijWRKI9eRZtBi0kZbqaK7uvtHmnWybVbG34LcjbGpqpU64uBJHO3gZJPElKJo5owZEouf5K7MQc5iiS9KrpaJWVVR025BBKZj4gIKgUypcXbCpQHDJXQpl5PAqp4upOPoCNfbRLafRFtiZmQeLP+MZ6CwWr82myMUGjvVsKwHCcVyC9OANmdK0D4rhK6l2j2s4bcMaHH0Lob3BdyuuSxMcWI63WG0537oKhFGQjRhKpvkNw3S0DqC5GgUlkOJZ49ghXNZcYBwzsv+QTE8eUZZ0vVPgAEIFsx5SbJkuzJPBiyvawKk8p0X59lEUHixpxWVp+6j7UJwQoczgCGAaDn3T+H3AKkiCr/WvDR7T4+Ls9vOhF57+w7hP5tcNNqgeh7y5AxxJ06UMi0w9bavB1q8LzAQEM89xwEUvYnfVqMOUF6lm6lvZQ5m1dI1043rZPcJGFX9hOrj6bm5mgVX3PnXRJYmZagFxSu8JFhiAeBgpCJA+UYBiYMNbXrPM5nm9G5gkKvWgtSpPD9yzKQaFJ+oXgRD64gFLdDdOo1CtTLqKN9kN8z2su7LKTa7mN8zJMXnwx6UOjUBiATYrI551XWiUGk4GKRfdK67RI74Fb2QqqQg6YjT/2uXt425SYY5UL5JjBJCxVWu9D2m9CcvAvjkYJfdBUC0U4+i7WEHwFYtiZGRLOxkjWYNQd2wWWXgbsvvBdZsSirOiwJRIpvUgPyrirokXJOp/ph8WEN2fVLJwx/NPzhu45JHojE2bvA2A1azA5FkMOUiV9GgQkie+lKhHhhcdZuzbfKj9OEfdlkQ6gHAL48923OLZhKdpBfeUoFE8UNsYMGuByWr/TJXiQ9VyFZyeLTuh+IcwiHWFaVhv8t0KRxj2Kx4STlLTY3l/XmWOCet6w8D7QAw9Pc7OW+Zj4OSh/sVVw19Oh5dZ+n82n4+ZZcQxN+NJAEP1GJ6iVPcPk1HpZ3v6iU67x33kMmVl7EoMpNk+yFKD2Wjv4aHIYGPeYJrGTdI6UnlN3f/o9J/fU7gVhReG/Hr4mFl/kIBAKzkJIOKXQSREZ03cZy7GCFjB297RhttpY9KVAQ14cW/isakOvsVeLUmiXjfuvvgJ7PKLMj3LDuPznWrQiouf8yeWIH6rZyQ5ak46YBwfQD928i41I6X58G+EJanaC84M2hmKWrC9JDRgzAZeWd+0SpZkfv/ttOOkDYrLSl5at2xt8pbiIufBQZ4+5k1qqcHysDPtzyTODr/+tggQ5wvRiTnSLriGignPA/EmBUloXNOiot58nYFr36K+e+OXPA51HccZW3CjBm2sTVghaisLupnIlYJ1tqVNHPuQxOIBe04JekppM4OA58wNtqooOEsxz76iv7mxj1FNf9AYrRDBerdIsCVfPrSSODDaecpe3uZB1Vv7q89FqZnQhxmWq6yPNYr1w6RUxBPPSTad/xbhXwi5HWPdRLKxgq61ifNiH+keENSzzjbmas6s1ycMiEKH1TbyjQUAiZGF3UzkSrheCK0LRD76ufYQRXDf+OC41gnsaE1QYxDhD7upD7jSc++oprdHg8d9FKCGpcOwr2YFqbnMy1+4Z2FDJJYQG0sfs5Nqkaom7pcijCfsKV1+tvPbyjuUcn4iBEBVOAGdIvQhaJmNItp0PSUw04RveIcNAqPOEnc+z+eYTMykvles4FQglhJ1+wPsBWe8HI6x7qJZbfRrnpCQPFhi7VfV0yq4t1MAW6PvQ+xyOvuup4PshSUadlfZVCsBgayJOV65jWtRlq4DKPy/pwhwrfyXYtakRR91GwMutCus9vR8ZB8C9ajiy7Wv0oF71ZFl/SAdy5WKvZ/fH5t81RDch2udBCB+P3003Ipc+9qgjDdPBQpV4MPEbODIylmj9LRP+C4yAC/yreZXRai0xkkBqTH+RrcaOMQIkiww4Eyz7qFIKrUQmhiIeZC/4gLUzdAkuy7lzduX001VSbOciwS3qtdigyS98F0MYR/ffT5ZX3Kkhn6KUPq3f7Wn0aQS7U+ELooovsjtIqIWllS2aJR4uCZCwqCBqedAOCiChvhKxhPCvjBZgNL/3GVhYLxiXmtKlzaPsnuXdSBzHoH6nfnYPZ7Aw4EUsW9TgwjSpMr09uJiIvwKlaYsFmcvWpdBI4CNpIvmKeXTqFIA2BPpNaDM+GYOygd6ggLP2l3Nn1erz0z8Bl7BCH6i2CAfMfoxox+lWtAnZo0LxV+wIgdO4r8ZPsv+ARcsl8dghkCP/oAg97SLTGx40laPv1jTy5L3IAjjPXEo+/Af4t88ggAKhIEMZnlUPxuLNPnrBOIym7RRekn+UkfbYuaLODJLtCQEbnXDA0t0TcNLXaVct3Sf55xT8m2z0SKgnHWsULX37W3mMDkysyRkJSD85wSY7BDv89DtxvKVoiETEhVBR6gSQZ6toE4tuZ7dSjOm51A81jrwEv2/apFPJFSfipUxkGuSSFkbvuW/l1DSW/Fi0hrADuThpHjWt/2d4un940CcnFkfCvjB6ah4TO8/39laMcFTTBh/tpN/Ft07ZMhnhCUn/rDSZ7cf63LRGxaEwrGpplcOF0hTuA/3eyViAmG10A5POH93c4ihw1K1FnCgQ4orY3bhLecSuT1xd9IhagW3aTMW2uOuIl43HZZGqnhGoJyQAYj63It+vu5IlYMRebfgEXLOFyePcgm6CuEeFpK0O2lstFtfFhfLzGDRQUH9xGo02MoFAQH8pb9ImGJM1/jLu3ORVELHfTnjN03WxnZnuLDDX96BtJErGCsNHaTnZ4Al9sTkiOjFgc8k0WNvKv2u1Yqnr+SUr22EBEzWhM8RI44Gvu/e6i+dOE8Y40Wad1FMJt2hUzxP/8PGybdsEdIiv++J4xDpebCQIzCE679vKv2vK/Iq97mo28kNxc+27sJfefiA5sVwhqI+1f6hbMUDGDjIAInkQDBaILybFZMYrLYloNKG2tKa4CRBRCQ6LcHO2G3WnN9HGRnZFATTefGQrwlNzzsDs8JD+Qo/SZauNl6aJdNvcBLIDoSYOpWCb5al4owpKlfh+Mu4GO36OwEl36WmRkpQs1hFnuAcJq7Tw3+7rsZ5bQI3/zPU54mhlCMDtNZtXb/VDYU2KLJue3220J5fqjZWlHbmVp8L6OwNXK2bMt4vx9g0QCMHZD7m31kgdEOhkBAXZ3FDVPQaAI7Qe1an0BLWLm/bnhv5aazQUYQpDU9JuVeyeGULGrjZemwQqIKD7/wi5H+IgswJg7VjWjBvKTYRiJxsvTQ9eSH0QusTRS9snXllMWC3nz0sEaJne468pEGfh6vbxQZnhtIUM4NJw2QbnYFIYm74gEPknyIRtTVpYroyNjYbYg4okrr8+ZpGTojosLehZOiOiwt704EYUKHXj/1yslrwOZZQQVrqDRgRsOAlp0CzKPkStU4mKRDhSd8adKwpVrbQsTMRdD1IrBhg5e53D70/zWC8K4g5Z+v+F/SQbo/jWpIev0bGUSwhMvM/9feUkoBxAzQdkfq2i9/rSy7/zfApjQ6hPbmxjmFaWN6L7B9iUK4Hqb0EHGF+wOR/24F5G2VtMPkeYPUT8Hcm/V83FgO7hwExcm5TWqIg8UXbCjHtuKRGg60DKRzXwuQmmyhesidFLeHamsK/+itMXmathRIjlDYeNWg5zN8ilRQEf82ySCeBoJwrxjXTaZ7iQmilMpbjU/rR0LRXx6wFb1bs9tu09JIXTeJvZkcibQ7aISnfv7hwjyBJ3uulPMOdOhtK6k2cT9QBWj7GKEJE0Jm01n1HFYIPL5DE7g6e7rXbM3+m8rA9KUBJ9HZ2g8hNmnDNVUHsIAc3YQH3nzuEELF+2/mZOljM3eRIyE23FZ6lTDMb7TF7BAhS4Gv+ro4hAgwgQTR++uix49LrQriZPtKLcZI8Jcx1PaVyySPjeVGMHqb0LyXEKBW1wvPMbi5kejcI0o/nuwotzsfonspi9i/Lu+p6KdrTX1lZAsI1JEGknuQfk9z96XGYPSyOeFS9Y/YxjoyZMAu6ffFwASrCYBOLMIoU2p0PZjTb9ipfoHHU00gJ9qWhrMkZRtbKyiSKUdRrXs86Y4YMY6TEGHggrtqAIoki9ZxDMDenP5qXnoTdX6DDpd533o6mwXivS1nfeWXXBoFZL51fP0nZpgtsUc757iPIJpxSSAjuw2xwxKcQ3C41ldjbNkRVb9U2qbzeSxi3uB+2kBuva3GYagTEn8enWOzmmi1XYPago3mPE5EPQeI+1z/UXi14aj+H98NAHWMNQOnIH31MwxBFlL0CckLib0/juRSvr7Ffj0LWeO2IuuLijwrfBuKzAs0kdBznbW1ImhpgIcxcF0+H2d4jnwllkg/tbPbH1cr8PJyIDCCTGOKMsoVyoJaI69Zl0mbgrWbYMuvOLKVEu+Go1g4cGPBd2WF/gsr9SBu2boVBWVP1G1Kh20CQriNGlnGgFxdumdQkj5Az9Yuk8smaoz+ApMiaJheSkp+EDgOTgK+0oucvwRBpJCOLs40IYacDY829jM5gjm83f81aNVslDYQIAieqG9WdJShXkbdrZ8b7Rgd2qoqHgp+KwE2Xe/ot2TEkx8s3aWOniJO55UWkFrHiINFtC4oZOKD3Qcb1I/aKIyoaXO/RSgBIEuFL7YV6j2mklQXu4GiuBi16BL7gey6wC6tHnfam16Zefds0bdHKmml9f4432/qtwa/tHt1laDGq+44s6vegNSlJl5G1PpK1SFZCGOilVuypBoKoLDuc3ym7nd1hQehjPjbLCmX7cIMHbYcp2RfW2BnBwojHr1g6xKhUw+tfFx723GVxIIk7mWH/TZBQGV/vgJ/qesx/wF/IbrllPhz3hJqABf4h6BdM3HMksnvsbSUgRqkiffeKzSBWAz0KgUZSV39YfJo8U+thR6+AImvkzAYxcHVDx2z8G8P0VSIqYI9f/DRYavhMarfjUJnBZVe8QBM7HISTvKfWLg55urDtrTQg3AdXb9JdOb6Ih8wyZDE6yBcjB15pXWIm0JAmmkQVEtsK+iTi5zVuUkvScbx7xfS+XszHUtWYYIHKar7a4Kl0DE/yAqYwEAu4CEgkC2aZ7/2KpPXjQSeNeLSUh4JE6B1SD7Y9DqzGpmnmeLgfaVuwRiva8IvUgNiQ7JL+QJnONtcS7mGhCLlnn7n1s/+xVQKTna3xPrIYZzyXcAr7VRiQr5ewEcGpSvLpBmBINFU4ZfUA51Jdfc/QlNCVdpQuaUvhB7e4gy+lbbNHqmijFZ1Bu03SW/qhvUHBXUEBTvxeqFrpc6rKtPSWnq971REJ9UVXBVSxA0vmcT4VLRJG9CfCNgv8uLj8PqHEZ3bmqvj8xI9rUK0CoaZUOsn2x9fWUlINWCtIZGZKnhO04jNAdCmFssxnLrAfEj9mY6lfOOC+0sFUnTywXsCUILriFdQHIVYf7BsZcCkfxhPHt8KcxaTfrDR6gbAoGVUjAuQAEvevAVKciYsFua7BtnfaBo1kMnRjGDdcdu3i1MDjZM/DFUFEvkdRYYk6C993/zVYLQMndF1ayUI3LhwNYr7rGjrTgqaFgsctPmZ2C9L58SNmoXqnfP5g+YlqCXHFngasH8lEb+K13m4Pk8RNZHV3me7Ubc/QE5DFe8YVUrJsyPp3+rj0ggY4kjPp34T3plWvWIaTrbZJUyLHmVUft5gUPpygK4A0+OYaX5iDJP8WiU9sKSDAki1sDQsKWLiyQaD9EYh15CPqmsJ170lkYmMG6XOax5Y+FnfcwH6Fz5AAxQO6Z73PR5xAH336wxtzhnVaR9i6rDYL0qJDeRX9NQo1lpHt1a1I7esdWA5QKiIKNJerSLJEAsNflfqGOD5wnB57jIXl10iPFcvCK9Yl8Vk0RMYN0uke3w4hIBdi6YHPR2XXVqIgZL66ioNCwps1UCH81Ix7oDUDYg33X7vjpCFkk+wdrQstdkYj6prCjUmQARiflpKRa6E2PtrUuSxwS6y1KH+FqgcEcn5vVMyy2mAGHUBiQYL47aNupNemTFDJfRsYkKOFh0O59ms1WW8WBbFv/px9sfkUeGcJuCxJzdTE/EJcCwWCtaUuO0UZoJCRByrZIPAB5AuyRGf9C7LbhZwaCd7hZ9XTK07dsEAABjmOTCq6zeBh5yIZSZdnRw4A2gU42kjDl5uAqAln8+HGEs8M7Uq9wuB6qITFFIIpxQWUCWep/hdaLYv9Q93C/X6Gccc+HsOQsGMwgQe3OrYmqzHib0ackiBL2dZeE+nTxw/jWi+0pJ/3U7WMx3aFv2MzdezKFwlDjncUJcD5jOFvPqaRhD0JzxuWPw9C3nVnQtd/KlNW40XWG2xKF1KaVXZa0rxLCAHmsuu9sfoONGu/mRAe9FCxtOn4jWQhmt3AWPglDa9XnZUHvL2RAWg8tj1u0v8s+bNonorZfguNeY8XrGGcLDAgQM4jwCPsEgWa8ocwoAOgSr6qw485jWquBMbszVnVa/DjZYPfiBRiqbWdf+NkseQaE33lnNkmrp6BT8zdfoEPJ7h6a3ZkbGQ+H8iTpNUwA/mBG5y30dWX4VcSf/xAWiOYdXeApbQ36l044zPQvR50Y0lxvRlKW9uT4Ld1omb8+Upb25TEhk88e3KHM50OAcWe9+LzWhtXyObbybCHE6ESXbLWZhpYy9fckg4m0R/KS+NaSX/WLwsvyknmFj4PhmxcMhPgpw7B7LRD6JufWOv+NvwOtb/uUtVv6uS50XPDRR0gHXZ3bp/FzEPtE/nCN63Xc85LumQqnADfX6JMWKD9QD/OHj9eWetbPK8u1oVK9lxZ04QPVWY8hAZq30KVs9iQxiQa7LJnjiATRdHlFa9MpivIlvpccWh0ej7GEu/tMfXkL9Jp3i7eNRrgWiwHYUOMfan+KGLGaTNV/N3XxrOgCjw8V6iTRQxjEsfqrAUpJh0Qotg/NIgdur7mO+jbouRVh6m1uKKQX8QQXgY4XIMB5R+KGZf7IyMf16+RPfo4Q1EI2Fh2S5ieMHeGXFiTrDcd9rs6OHNxx6Y6SMI7njRJFToQXWGzZD//CohvT2IjLS0UFnlhK78gzLOVF8U8RU9Baw9zq1xdw9IYXGVKkD/BHjoL5teo88FrMNJoQm37rP/L25ZgIZMPyczXVclTPqcJLCKSK3+ZmgOgnrfnbziiMskz8sBAzw/s6LBU9Fa4aDMc1bKle+0Ndx4Kwl3P5mASGRA+4373QOFodIRelXcGuDJ1lv5vy/qT4XCW+mei9MHHk2gxB9Qjut3LWx+SLx6XLYw4grVbAIsgsRBnrtnMBg2MyOd/+xo8pn6d+cG3W6pHQkjnYAfcfRgHUiuLkSEecp+R4Diwg1foTyhzNq6RrpxxReOMW9DiuDw3Hjl9omdVzvfQaVwp63TOFvPqBKC5aztH8qU1cZpZYQANEwOj4pOgRPLdE09l1e54wizEdHvnx849bV3OjmuRkfk1S5S5g76P/wp41BZyN/fowqAZwJbLt39x2rPuiZXj5XfVI0T2PA86WUAO7CAFRHTAFaW8PevUuFWGmDuueLIrwXof2PidiIx+KLHFhY/8bQg2IXvVjqKz6kFKW677cYcldOBvh2/WB4CnGcaZ6EOjAy6J7Lvy1cijQHB5lDbynXy7m9bjm9gSABI0EIFmCETi2+o6rm8N8/4aRReSCOIr10YPhz4py2VJitmHWRcE+WY2aqA8t0KSWMEWpNwUa1lQ6XMiVbg+GDrS/UH8n20r3z5K6iAI6jtfme7GX4qUdaQl1fNi4y4HpvTVlkK55KmwVO06qjbQlMwmuua2G7YVObu17MPsAu+5PbdEv6LPfjP2iCUFrmm/+T2hbjy5n7xQYpepZ1+n3B88cjppqzbdBprVqFlSeXPZyx5l9TkCUmbvbbmVQExPs4MXxgh686luANDK8qVbyEGIKppEmZp5SafzfEsOc7sEoa5lwX/sOeU4RFC30Xq0913+JOgx7BExd3z5TZTialfSjhlyhZfodHnOUbCzH4iwO+hQ7rCMQQNO4Qvx3IoKEzW0I7sQ+8MUXQvo0241ygEE+DH6NJvKrI634XChvusIIZCkIKM8jgWUqCSAIdHhNjI62KbmK8nzzrn+MYThEXiMDVHRgur3LZ9jnAUZfvBry0Zru1Nr/gMvoo7MW3waMKPPeoqM+UtP9rYYkAI/15ZdSq/TFVoLELcoUeZZFEEkXXzmhZYZ27WKjnTBUU2L+N+CAYMAq7+s1jV697zRO/HN8XSbN0xUAQb1XoKvsf70FNc9nDtnINRK2nkva3i/mw/fKrwKcsmode9evcUPhTOkXGxXBV2uHyMeQF6XA6E38K8pioUHliKrgTN1mLcZVfc9n7FTnYW298vqg1BrHv2FykgO7I1Ngi0qbO/DRpXwh/BW75PHp1/lZEBtA0xf77R09ZUO2wAqCLI2Ws1t5ikPUUFsFTu7hGG/ePvoUp4l+VHUmgo9tf6UbIM8SEcnbOUe+r82Q8hJMOTaKa0ZJlF/Wvl6T8pNzG8933F8zR5czA2Wa0fjYKu96tQQ5IaUtkSWxieTbx0WJ0bVOzODwTOnzOVfXPiozr9IgkzadBDdKmiaRSc+UYoVbsIEVCWSwoTI+M10VU7sxRSlnXy0IAHQ8am2cRBbs94Y3ArBdvGxOWJfoZneKZdywapQByxgATL1vEEi11jlyluk7AcRKz0Wt5ARBkQfSAlBvy2Er+icGi+DzOzO3PTAQjvRhjCDpMUntT4ix1HOlfwf4yjCoxbRv8QHtU3WPl3RxUjTbTEQnRjJag0cP4zqFqnQUfbrtdL/DUzE514+GqRXAF7AkX7Yo19emEpncL9sphAkk63fyymmz2it+mv01Q1wle9gZJjRtRaEliwGuS0XfvI4yPADlSikN7vhZIpXgC0+1/JRfC7BAdnEZ56P2AGFUcpyIe8VNk9RBN6Q0k2nY0g5og4NU0ss/ZHAQkowwNio41K5etuzOZjx8BpuafV9cEFGdqLN2uDKb6B0eLddpRoCcC/haEqlaPlZHD4gouTtXc0uFHR27FKJXb9a1WJcVjMIr/gO767TJR0GhvKFCEIuV7od5YDOyOgcsWzM7k7Fxi+Souze4ni0KrjJwtZAhMZJS0sbRUmy9wx65VfqeUYSk8UwS4yXyqq0Ly1PZ+2iWr1P1JcKYAtQZUxizeyM8/knMN5n23aCgBw6TiM8h10exinA7o8bFRt+07w5/VHxIKOcMXwUbYQlU4BEYRXnrPhaTnZ0m5fq+pXUwFSWQRPlBhP6c9/x0aIXJD1beJhmZQLR8+CG1xz3uRfZdN80RQQVknKpcnsc08RvfjfXVv6NrB5YMztywxuX7n8K4oAoYjvIZXEUvFHOlfwf5Cv6jI8xWl4MNqMSDioMUGpVg5dnBQJm0QnVYwdEA0i1LDc7LHagEjV+tvVeD0X2KjekU6qtCfld5uGqyZQwjX8f0+X1sMWCdJQCCkzcurMZyR9fWz5YhRAjNm5HwxTHJmuOhDk+ripFcqkafjxJzJ/pM8EkxlipB+5yvh8GCZXXBVXKfJNc8Yzz+S8Uwzx37fDYf0w70/eVOPPO+rgLvJolCx4QYVGRT21UnkNDpCjXN4Svkvw/h3oGXHVV3DT+QR9lJAlcpZRXsC0ienkhmF/9hyAtCUwFFM3hz/ol2jgzQ+9l/iD3DeDbFmF3lVLgPMgYUqa2DThVg2fVT7pl67aVLfaz9e5OvkSwSTusAS4b0hDAy2VZF0oY3HEcquiQTacj0zjmz4RovRw/LNlbLoSs4kiuf/qUEQ86DAJw4n/N4/BykCTHJNcR3k0KlKv8XhhBIYVVxjp6b8Pv0xNHxl/plgJVJUzo/kbgcewxf3to2T4ouqaFrb6lQ/iDoBL23nFq6ysC/qLf7dJBvF0yzBX6DEcaG6QycFlVaY3zXGunOXt74Yn/+oOTD7CWRBmrCw8k4Z98xM8a2YkvZrOr7i2sGMazTFCgHhXd49YuRUa8SEWaodSqyom8Iiugj4fyl4iUd84NUtREpjaRQp5JS0gHcBJil2h2/RQE7y1KbB48hzzlvUr17DaMQsCJ3GaKv3lj0037fr9YMBCJgGkauBC22PSG3xdZuFX0USI2GRaXhlc5ljx1eeh6iJs29Ypa+htjDeXNLco0oijgpL6tI85Oz75S4MvgdbwNe9+LhCJIWsv63x1LdbTT7B9O1lSausWB53qJJ5RMpj18E/jUkRbuDmiFY1uewfdQcT0L8KInpPNmVT4RsUIZOaGu05E9GpoeK6Ocb1x/DwMN057xd2wMRhR2R0kTpb5QnVBHLMOJ5zyUxZzqv1l7m3jlhmvX88nf/+xR0dbF2po0qII2GvfHMFRJl2OGgHfjVUckfkSanofsD9lGr2F23H99JRZXE29f0S+q/tLM/ThwvIX6QI3IJ28Mio4VMDITuN9Zcgymm9ndB/o8lWNON8nRy7TuxF701xHLREAT7bM5WA+HuN006fwAv186aAXitYU/KOLBXAhnX1K2U5xE8IsTwLUPFzHvupEyZxmTJrfctH3xyKtO612iuDozI0+uzYtBNAsEe9PWRMmVD+y+LqTCw/573R6fE/xfkM5lp42C7ysAxnrEd3DCAZEi4F9ruQF1nfcnyP/N/39PpfxFiUcs324bj7bUrNCvquzUp20dSFVNsINEhcp6qYdF10g0XwVsu8jzOc3XV4oAQLwo2x8M9ykZEQ5uJqThyDIGavmDzqEwQZNNJdOBhy7H5+gPwwdqiwjWUh2qNMw6dHugqSx4gZ0LixZyVVK2vasq6Ce153TXGua9jRvuBI7VvuczcguglxryCTJ4h7bcm6eNoxEOz9Pxg+oVZw1AOPIVbUy1P3SPcjRELFCWI6ZXmWWbeYZTJqOI9+9D1jGLvJp0idvsbogd1ByaXtj0SzHxnbe+GJ//qDkw+wlkQZx0N1QFjJyILRA7qDk7L31dPx2tFJKB8dFWyjJUNbpRL8ThN1HGT/gmFNgs7NMyVEPFj3dKM7CXnEobSy7fot2htcUYQuRfioeN58QykkMmXTRLdoJ/t37bUvSRkGvqZex4KMmgUy7ijZjCnibMA2WLOzRoSTbCYVsYwNt+a+e2gqMJb/ZhOzMblclyMD/4iqYHYI96kJPlkiEhZgOzNINPO9G87JCn/8CzaJRsPZLCo2h+1QoqkcP79sF05xnTBCvYG58KuqUdt2LYh+UTtMDOfCgX7B/fN+Q0RXia0o7DxmKCh7o08DciHm2ZYQ2kJcV5G4ujlVha38yNA9h6n3YgfN6LnaZbdhA6OOQWG7KgS0TYyh6xkyvWjYjOSftd8p5Uq/UInV0boJj7LWlVoPo+bBQIWMzjuMXIhGk6EfUabY6MQnwHmimTCzbcTckawfFH6Wt9gSboU7YgoZxgRN146jjaB+saCABQqEBYDId2pHkrn9icJZ20Y+RXNL8HHJ+rt2JwD9iMpangkxwIkTB1Z4OyaLCIZDq39RdECbw1didTqhzABRHhmemVGd/v2tJvoQUjhfO9aRNqEjskxdqBOoqsDfG5zud7uj5U/9Mtbw89sS5pSp/wUqHW0Gy5TJTgQ9Qd8D/4hrSuzXEMVAqGio+yh5DJLddC9qa5jbzTpZa1Ww+zKZTa8Xv7B5qWDGagZwMGzZjNI5mBp9dmyP+OYG8q1AlGsyI5w8WHsMTzgmhK4aiGXqTpAZYyqPsJCZEhaIvrXYGLfF/LMAiMxtQmWHNwcfw7ApPIkWQFzs7yHzUOPfNrIh/2Slvhbt9wo/a6612iuDozI0+uzZIUixZ1kTJlQ/svi6kwsP+e90fz2MQUkWbzBETTgT9lf+vIWlgBwib3CsJGi4bAP/6FNS6j5kc3rDFq3JM4WkMsWOAsTecaqvi4B/u3YGF8NhBBWC+pqVpMTywjQkIWmtRDMIvyN+9M7A5PAfBwTbVM4L9+PULcuOn1YoWsOeMgZ+RKQmSqysnnx0VpxMRe7iiatst2QmZjer4OghbDTWXhTWHcIVbrXj3u/z2ix/GZ0HmHEeV1Nx7YC50z2t9OpsOyuyMZSfl0P8ojh5tI5w3EEu2guYoiJt7kQ9t6WdGeovugFMrO6VB6H4elqWDLYStUghV11m9B2xcSvuPMOZ/FI8kK+fSojeuKhddrJCFc8ctVdoA6s0GSx5zb3RbYTOEr6DeS8chCCgWsciSXoM1rNFMpRstxYmwA4HHKdapm/PoxS4EpUBD/kFmR7JncyPmxAE9DorTs1d/ye7nALPINTF/3eMrJrmI9QlKpz5dCSNrTEWd30j3WwkRfkudMyVmzuRfjvwC1ZEZNCp+Q6OY5ZYvUnQEAkhYI8WITGdGm06m1BRsfduSOhVnm232aCHaujie5dwzBffZnbSXwgHTWwC5xCmQ+NaDrNMkZ8qiwKZV4OKrw0lE+kB3JEnfdumvMpPuRlIqEMKEZGHfaEqkzLjPEETxowG9XwdA/WUr4Tm8P8SXEeMO6SVm8Noo4HAiMJCya1mo57Jm7xKFWPoOI79kc/Sb9lHsf6bblRFuVjAluLpS0W6gB/n10k6NQ5NFkrmdv16WjVHqAFtuUP2MZAZdrJCFonBQy+bW56CisrZGopvlV9LEUOxeZ12UrIvBYAufNDVlesBKcqfH0/9vqyZSoCH/ILMj2TO5ig2l1/XebfLtoLh9QeLjP+eX/kyuUE0J3B9g7DOt6PM3Uy9QvDG8GKw0JRB5eaUPl1amu567yek++L8O7LB5GAqZ4be4PEX3uydtLwm32W0X0KXUmUdegoDWJVlreBOuoKgRqWkh+DaAJomycjLxNtjhiD7YRUKKLhoHcfTn6jGbhZZ3JSWkVJMO/Y+b+18/XVN4Qxkl/ojfkdEbuGg590/h8aAUN+l6LbfVyOn8Fj2HfFcC/VamoYZdWxEVte5Z7E4sjhoG6YhdxIa8vvNNmusIwsDoU0LL5VxV2LUcPk9pfnOlKHkooGL8cLZNBQ9fmljMw5dHLtVYQ61fFLyKvv+ATs+VF7QEweMdBzBaGfLiBq58yUjL1wAPTosutOCFDhOnbsWqRdVG9b5gg+1zpSN/uj05uMEn8Cvx3ruOSiFugOxWCQudQQbZRWIwjOomOp7EN4pN32WEX018wtt7O7R1CKFl5ALnp3UfJlqWqnXiqXkqsNyXNfp4i3+nlAlqYwEXQMwWVMnU66fuEJVas/UXqSnuxhY6RAkdn7F5IE1J6P1kwyOLD5KTo9G0SasdI5ZJocdfY250Isv0po+PtuydE6nRNWJEZ7RUTyha5g0E36DlCsEtF6/vY2x5bBjLW+afEbogl+IY23Q7c+WT/1GSXYGChEkmbdztDtdUFnIbVVgUHhwpmZgutFaVEoSSoH64gSnPw3p45pkOK57vB+tXfoxOticOE2Q/RBGhy7qNEUh7aqbpEgcYwk6+iroEL/NO4YRZbHM1raL8VlJb+spmBWmO8kKIrBWVAu2fYq1a7DXNtHOQ2H+H+4wrh9ryBWdgBFFB0O93eUEU/4R8zwrztANqINwIyUdjKOz+0uFcQeDjHBt2CKywDNnC65qFvJjAY7VHyDtRgheQ3ddo24iBKiJfYfEKZ/TQ3R6QtJozaS7DAHnXXAE2Leu46n+dsLEgV8dGGYqtvF5pOXSEvxV+TwC7vNZzGKi0k8Oy7f9MHhDAuXoGQQriCNSDQ/fLkHmSfcLl7oxhHoY3bOh722Z8JZuwpEojnIRPw4jp8XVPqSuVFReexyL6jVvJ3y/S0Zu4vFdfZ7Bi1td9wiLikdbfYi2JE8Er+Nca13uwh4Y0Jfs33nsfka4fdIdfyNgeCA/EwRkxLuajolYBB2YQO1hXd0x0j34mVlnx/H8rsNVq2kvSPrNHueAXi+0+n+eraMw0KtgCgdEIJmIBg3VAj9+7bu5rxcJY2XqQLGI4BYLa9fpzf5rgx82Wdos6uBId44I6fs99mj5kA/bdKMyuRPUHEyiBDgllLfSpnJ7uMA3Lu68bSP2IaLhPvCxeY5EKFEXuIx/cusnmsc/T7Eag4a/q6x9BBcltP4uT/TvqBUZVUkxumgZF0QmTF1KHoK6TBICVJOdk0qe0GVMiwY950nVYWxb0TCgt0n/nQEuwbjI47xqyILVOOwsV9IA191GDu0QIra0QZxGoQ58HlOjdmmzclQNYowUMLD2rvvpZ9rncauoWxh+idZKY3ff8ltLlbSvDtwV39w2Y/vq3YzzMSoYsN0GOr/BsdjlJ4vRaF12lkjbK0nEiQ0wO4ErlNvysRe//vyXiFv1yR7Hz1x7xlOEwWYWcfa0lz5IiIfhRG36AbJ79Nx2g0DRNIScNccYXMkI1Qqnr4mf7PPnx7d74LFdT+GXwmA8nLk2+1UNmJtc5YQtHp6pRGLvYCSMFdmh1HulfwCEdk/+YkflfoOxpiG+hu2J6ZW+95fJXwhnVXjNDeSIhyCk2k0vAhiDX2RbcYtkG12fxpF1xTMIZtLlzJlE9MyuTSoBm7VXALNkjyOmdd1mAMeco9gN8ey9MvmeiL7e4GTabij3KuV5f3GrEk/Sa37eQlMEknJ1ckxPai3zuoLTIb+fycE0N+VDWVl9yEfZ7Bi1tz92cpVpVuSuSm6nhpIwHOgT2TpPoiuMHIaIquiontcPifSq3Mvuf0E3TiV6fMgfkAHNyXLrvbH6DkAzq25AXgJ0HcGuL4NC/+IA1b/x4i+aGAWF1jZGG3Yf5OgJDXQUnu7NKR4dWVfVRRblegeH4QlKDOKwAcDYa6WIT/WCgs8ltcrrA7WUds4x+uHmDCjlT9xiSzhGi2SHT+46cnwfoCUdG1Bpp5T6DtsN04+SWXbgVagWHkBOgegnPK1GwCRoxrzo+znsb/ieKGHNBREpcpTWxiDUdAtUfL7y8BHWgm11oqSPe93oLGVMChqESkGlcrOI+M7LcjegOCE9ckF9Mn9IkTKZgenT/uHZcplNZZo+ofIohNvrhmG45PFIPAbZjkY2zFhqqO/bXZnDT9My2aPAv8ROD+/78MzdmY9Lpi+qkRkUcuY3J18pB8J58wUnyaNP7vSy5Rg9+bhg6KgLN12UtwTt+2CeQUsCTfNvxP8NDquUYPCUOSTj9st42lthVTgVBVdr3fYvZ+SWJu/K41Ws+YiFmvJ7e823cqcbQOlR2dxHY21ub+Fk6T9Rm3fwLoe5lY6raTFkPm4QR5WGLXSQGM9RQfyPczmWw6laqwVxzvkzs4yFdQQQZweyyByACqVqk+uXrHs3V9Dn88JvSdkiEiIFL85At6eIJkv/fPkZZkEWLv2QkPMJiRBKWsVNkBPVYOcsMgrwJWeCy1EhAOrumNv3rO7kYmTX8Yn2QzqVgX5UIwDbQzLpX2sTbdSWxGD1DfgduTd4Jv9Tv837nwqvfOz+5MdeW3fZjFk5T1xmSRaA+N6h9jG55jesnKJzAlGFJ0baOVwpJkffU9PpJQimoesrVTtaFXT5bGITObfdxAk2WLuWk6RphQzu8SdmoA8gqJm3NxXeohIgQNY96dhmL7eq8x/boNqzwEojN0zr+BNdtFR1N4ZJqNz13B9e6niC1f4fQ4hhjPEjH267FulHewWW/yxdsCn6GngQ8xWVo+rd6oA7jDV95kCH4YBjJRZy8zkp5mcCwRJJRCne6Npw8TifIh6EUlPYWc4POPOvsOG2k0NV6zRx5tPPSAwojL9ip/tBV5mKXsGzPy7niLR5ZuHytb39ZWsNP9UrVKqIBOauUDHnKmbIqVdok7tJeBD9LH3+ZN7DsaDj6LLl/B/j89vVhUOZpRUNUq4kEDWtUcs/+uAsZrEz532XYhbSdsrYVlIEePx6o0BMADwz+aFR2Srq86DPZnAHnFchmbWlCuLhtqUVHinq6p3DH2jXqiKYVE1M0bS9Okxql2Vv/ZdSwJusz/uhb0pmYOTyPxsVhLP6ZH121fDK8kHtmQdkHUgzEJZElzJY+7x9Qy8kn5Ka0GF8mCbZYo8wag9AGmchLIgsgiWTz4Ls0o/jXSzyErmbY6YtPFW73mYi/paAr6fUzcPieowd/tgZkJ64QqCyO8PgaFkfIpw7KmtLGZaUyhEWRwo2xrzaybB4/l7sPvxJ/8dILMiLGmGscLsI0lNshD8Sp1d9oAMwJ+LEYx+NDKPvDSPkrPom+GUz8eQL/vIQzjYocJJN3Lo/9LkR4+NdbNw5RzICO0przGr5xloimOjWdPuhVn/i+MSzAzI5Xb43+hR46/qA4CCr/KXRs4iAqFWSicoaZUuAaArFBQBQmVApQSJYh6uWX31UNJUn04tf8NiQPZ9/ygV98/VwsOir9g5awDw/TyTfmdBOHOh34ncSkSsQ2Lc2naN73KI9b3OEyXcUJ7A7/Uqspeao3tWwcY8igwDGGNPGApLbiXj6qp23MjbdvHywwjEFIFXTqGZTkyFuBmiGxpj3Pp5Mm7kN5Kem5XZBREj8eBmFeO7Ly7QXMCUzOhauvDeKnQoh2xCX1SfkUz0W7wP+YgEV3a/59n+6gPxCj1JztFBrISW7pJph4cQP7KNS5DT7gFQa+LAx0r6XnTuArrubBmMcdTFHAsN27oA1F3yu8TqMjqXa/ne22MBsYmTYg+xBI3y1Hnt+q2PHOmsD9OUCW2duiBd378Wy0Yl6HS3kI+/tM2jAfnz44+rqDdio/kVaZfJ0ph+R11BufIAWCj8Bc/tYhBaiwY+FnZBuREzLrhojoArlDMrzS7tovNKV5f4Q5gAojwzPSORrwx5z3zRhUGTgd/SqHbj+AB3KL4Gi9G499rYok5buDmiMEgntZqTpCLBHfxCJvnkEoTRC1NAtZj+vPJx0EzDAeqU+vwc2Cy0GgbFQ7Ypi2F1EK8tzllIWiC/LX+hw/cesaAbT7FupezL92rsuzQqHD2Vu527twxsSxN3burkUbgQKb/3MXol+3tvl3l62XObdmhidYSzO6hrIp6KKMcbReJZcC+J+tEym5pu6ANRd6voPqM2aXTNfargV9De+vUHHuRNIRKpTpcVYsjs0f/UHK4NhSP0DZL79kmtM/OcE2vldLcqhzTBKOuJR+trETVHhxF7Cj1qmKX1XuwA0e9SNgg1qqD3k+RXLhiVmmfrpSVF42fyBR80Gqibtt2aOht2HF4UtzyM2CAHpRQswA329aPJEMteLTmLVT+Ir0DwnWPK+bdkuak9kLRxpUl5ydfXHrhQbDBFFOYHOVLhBE/tmxSUMOHlucspDk446AmhbDxKOwUvUzLcRPosfh9f2LCawpigH7BYvQjGtbaLgaSNXAIZaQVsLr4A4N2Vslt4CcmdmotrYZu10BxMYCq0mGxTR0/mjlk73iDYeUxJB4bD2KgCb9D+uzV2h93OlTXCINGuWG/3KeIxnP3oesYRqZHh5j3qJM2r+2gb4hxLIuvYOWHfBoOKZDoRcL51r11V9s3G0zKGYJVHi2fzfge4GQlqEd+KFvW7eLSlA1sxJezWZwl38y1IbUbzcz1CCQtsMuzwUUHwTeXbL82XsXU+EsQC5a/WE0Z4n5Rt+dYA7x5le+qelEnatV6QkE4qjs4tSWAjiAIDB6WrrdcxWNM7RO2dKgeE7GbJo0H6XlekUtJwkctJko8918xrWhAZahrI/HVmcr6hpj5pdwEDRLQa6AIyzRy7Tuw83LI6H91CQcpFLQLlaTznkYYiefK3rjsaSRp/acHSJpK8HrssB/2iCcGdmKtaXUKj9Fheri29S6UJ8s64pevJhj7rIVGfo/CB1xd6wMkWEAQXwta6T+nay6WSOfEKRKitP9zKuD0pP55e/Vey8coBuqT2KaG7HaCDAyp19LUc80fYCKEZgzqZEY57PBCSgBgCr5RicSIJG2QuSEHYx7G27B6PsQJbiM5wyUfegtEGHjU3kyCAYtUJAUKyVEGXeai91OAxOv1giZtMdMi3RcQDfA4omhtEtJi/jzjfnw6kwsP+1eC80nzVxNwzQLCT5Y/Q+9Az7rznCFP9altkDPpm23MChgym/SoYt+iGcD4tPq1uqTOKFK8i877HJfKkHmvwTVEOBcE3pHBDYRK4bpP03AZ+GVNWmRAnCt7alJJkH6wdg2ZB361R7k87ao4kJKJ3HsRMP/H96PhCbCm5JuoKJwmRmGFdeI47HTY4F8NPwkglRBT0dfZkEbdw9tJVXMiW10eRNn/LEO1JspUcog/+RXMWGf70Uw7ZHoJb1VFdRYde55Jmurr3Cuc75GBD3lVUJblBtZm7k7pEsjHiF/Lnxv4N7lNVr8azmV+7OsWlL4e3vju5ljStHlHjOn4ZLIofICDsSi06WTaEtHuRohk7Zw1N8x1//bGpS6G6dmzNeRe2LpQPdD65SF+Ld066PlGCD2hNtZcF4aH9EFfDrVlXKRTt1p5jwOVEjPzyVIDpcQ8Co08Lr6gQ2UsTEXp47g+bdZUmrh7zHk/E23JDw6gV8GlmHEdTCPZwA+IEEdQoG7SLt4Jh1ubej1wL7XcgLrPqicWd92fjdCj/m27FGjRDF+xL8dWZyvqGmPml3AP7pCqZDx+5OrqG8zkbcAMu/V6yyZvWXziKSf7Mb7Kj88lAlfG2XWI8HS2odDAYaAkiBYW8Raavo9L3H4c3oNXMZ0LPxA4rQyrhylwZfA63ga978XCEQYAyotKQVg+ufkfJJ75Qft1c+i0M0eOXiYFZJqHoR1c+OVYGp3XuSIkslYP74PgO5BwYgX/bp7wkxtbejnPen9uX60DUIgdOS2I2YClWpvdnluXTKM7e8gCeyXJA6wABT2mm//XPi/cI+q9ioBCRugmPs5qzPxcA17MLTd5HpSfDHxGVeH2n9QVY34BHJT3kjt5B5zedVhGyI0EgvNivIHPRGZNPF/a3YFg9Bg0kAI2YtiiqHvAyZSdV6fe5hpxyFYcKNuqW5iIlLdrIU6N6fDL6MEKZ2XtjoxCe+TneOUIP8hNvdvh+6VMskKPDikFDOMDZ/wPOfbR0cxdlp8duljjPOE0jYBHPddDwqeojVNxLBM1Sj06EeJDbaTYkcLL+ZMN4ZFE2gyPGS3GpFgT2bREX3C6+hOrSHINvfB4CEuQ+CebD840uxpJ19icqCQFfTcwQwFlEiqp3eIm1zir5uZu4kRZiYZs4dxLSqjwetndbPOoV+vs5cszjNXtVEx2/6OtvO2Kv2/YvJAbwvY1qExY3ziQc8F8dFgcS4IpFVohFyi5nkoNZQX0bursOym3zCvjsV5yF5xFtk1SWzvIdpJ+ODW++KUozB56+cfMmHWoraaUXruk0jIsHyW4V1WpqF4XtFlaGgflwIdhvd8BdZU4VtMkzgWLzjcosPpjkY/SXhNvsvX+CToxSWcLQJ7HVAaxKkAZyEAq0OfMZ364GTUC4BgFWhZVHtkF27hLdF/K4ywH1sH07yd2NhGaOwdD0C8qEXSlez+BOyM14NefYlNFH+uE1dcx4wvfnkQLeMk43x8UKt0EQlfDkp24iJC1ExVqg8MfnhaiEe/VUqg5YpretoXiIhgYddgA7T0h/xterVIeQG8r065b2Yw71LRCUd2EnNMri5fp5+qWIxUCAi1UrCzVFogfZgqarCMIwDs2X5v0N+8J44KaGRJXRV76DSuFPrBjQaQwlekM3OkqX8NtTe8flRFfFgohgHAh+QlNdYTar04nLypLcsZvY+PLIce9unoRoUe9laY/JmXuadGFu2U2b2GSahcV4XrWLfgodwPifnHipEy3Y4LPR5Dc/N+qEo/7nVvXuYZ1uMZMKrXVb8ZWh561fd1Nlc5vnuz7Z+ZdjDzmWBGdFzH9ZckrMsS7qFl4g2nxy54HOo7jjK24J2s6/8MnU1LqE3KHsQvRS4Ht5+RFbhc/VXrHp3TkbGrl72b/++QvKTrDsSkYYkoAKefvKmTKPVJ3bQ7BQgw65ndhQMdyxqBw5mcKZTa2A+S15AhFEBfP/OutVhy/It1eR1z45mbMsXM0cl6PQownpx2SeKWjTthskzn24Let/GnBi7wnTyoBswwMfezmVCEe182T5JvWJ2s3MkBYfWLcidWtV2rZVtPsWHl5DP9FH8u4emt2ZGxkPrfOylHbyczBycYC9MG22Xm4Eurpvdft5T5m0EwpAgT90j7ESkMvb+pbXzWeydaYT+aW+S2nmjTqa4O0XqAQQvHYWwHYu3zNC/L8dKVf1wqJEg87/9Z/1yk/6rpgTlqqJGxF5FVuZmXrd0bUf5ruw/x+bznjRFXNr4o9glfw9o1cK8nS3/zUv6xUV/7DhGjAer/RJ8fzuz+91nCpXdPf3i7PbzoRee+2jTCeNRjWZhTnS39HSzT5x7GjXAkdamvivodLCX2e5wpo91/HYxb2INM4UAguv0Hw+1jrkhT2QWbbRvBMH/Zjj26cbcSHoD2neei2XMyqNX7uQo8AIO9IgJKsjZnt6YnILwEWqh4+knVgIA+0cHKk4EnS7eduQmH2qtzSKl6QzPqCfS3ZnoN5d/5hjvq6rHHwbKz/02pq27HQZfaWLfvvR94qcxTtKaAHxdsaaxE1ALfG6Cba9S4hEN56dxXZ3bp/V2IXetb5L011ANlUyOdMzp6BILtKQEjDc77pYWIvL2rQLZkT83BjsoZXue8F0XSyjlmPrkhi3e55G/DtQYNnfii/DieeQiy2WepUk2OuraPdBtsFj3yjvgPV9k89FSBWT3lrZeYfnaLMPuDb1jOWusRIj8esgVxhbAySXG4QvpWMF8OvimpFOzv8++OgrTLgrejpZALDu5fxdLjaxR24vYvvVkSp7x+UIMjopMnbFDHq5f86UhkxTVXbpOv83lkwOKhySIRcyJVmkZ1IZVK48KQrhrKHKXHJQWgqlyKSLvO/MOYkB5C6ihTmf8P4budFlRh9g8vPMSlDEMA8eF4aUmQAGmHq4/RWic6/954dE3jb8GckS0kXNG8B+uD2rqL7RTh59HrbPLN/yNOXZi3Hjcgz/CuzJqbMA0F8BrBsDf61zHpe/JI0Xi/yoh/ATXM8/utryb+iTOy/pGeRIIXf8eHNlI0kBkI0lli8jIoBrlrJ0xLJ3X1+CkzfXJXVPgVKzZ9Oj17n3EnDCKRYktYSZIZjNyOAv35D5XroI3J3h+aKBxG+f1PmH797r2jHUl2sRNPXdT/fPUhLHFeU18c6pXCdk3DumSd8hgqF2WdpCy+DM+jJ7M7TjSL8RLMj2uCJ5T+VOYQU0eV2KZ4oaV+j7luuyLceiIuFpJp63k+R0m+RJguZ6GZzaNh/TCqb4p3ew9rdyJLeW4o0hsE/2YG6kQ7wmZWTpiWTuvr8FJm+uSu0bUIL5q6zsPOYbUDFaqBhsRdsUgovfBocRiswsKm9g5cLfCGfB3xD6rNKQQOlaXL/4HJAulhiq1HJnl89try+wFnEPYueAvt3rHAEiQJO+x8JEmI3EHj8bBbxYwRSBQGZzZNVIpZJQDIiLSqZjKlVZUGvB+YF3f+/Mqe+oc9yPfTl+X5SX99MpDkOxfkLWbiv+PEXxOA8QYWhZIUSEwyOWSF9KOg+wilPH73WGLWc3N8iv0j2QwpS7HB8wakykkN6mw/Pu7ll4LKlx4hiIgZfvOdXLGw4J+i7Glb9oV7wvmD85Dlh47uZ1Y4UUuSKcyunGq3CX5ATUZKzGKt6qtwJuE+GSbvy5WCtKuaslNinf2O1SaHomHqDdICs4KFf3pNVXBSKkvdhmJmif3BO7dfsJGG4VajjNbePfZoHsIOZ8jS3h695bfmdQIlMnt/XSO4KOaBKkOIjZPNfaJ/S5ftDtQQp3ygiC6lgDHezwf8IQ5dJeXN7sUWJUvGD/c85+mSBk+Oq+g1MjXfaHjMmFEiINNlGVVrgnSNHpN+WEG1lUXkR/q33F8zR5cqzMGhQCKtNk1kUVLPJLqtuA8sui6tZdCVGGoWnXYO+0am79B2/iF94f4QfxG5EsQlImTSk3Vh2IbY2Ie4dGKd5eq2tGG5dfi72swGjqxk1PHFaHJndBtM1mf9bey6zQRMNvDG3LjXKsHYMckmyMEMfFdbHjvxRuacG6VXMEAfxEImQXz0gm3nAAX6Ba0rBCAeeOf9Wv541bfcoIXWOmOY/17dlB2GL6f/0DXOAwlS8mlZ37omgJ7phqPdk5n2xzA/ZDX3WfV9vGLjaaWv9fl1C4xKlcFEmaWNrK6Mvv+e4udZ8LZ5ewPMxzirKtviPTEdQNzt+BSDYty45FP/ASs0THGHMR0Wjz/E2UcGg+K9z8Uae2S9tMK7hF9J9O0gx3CGPhEBvqZOrRkltrlIEqofi809b4VGem6vCO3c+8hRZ0gty2bcnMvkzkmx0+f8tUZVC+qrjnsxXQqG74fYh1W3vG/4oqhSh9iBLy9D/7bVDW2qYxhQKPQegUBbaP0VNCuT98LorJ5qETC3BcnY8GaZygxiQ4tgNLEIiJ024TKLrwoln8hYk7wZatKtycE4bhEY8Ff7zu/gTJg+TWg4VWf64J6cq0a0ULzIDLzJpjeYaN9RgQ5zpiJwIg+n7huq+gEqZZ1STPt2uVQtP8x52pdEEY9qq39aKTVCugFlHiWQv50AmgZL8E6O4tWTfcGJzE3nLuw4nk2bAO1gKcC51l1FA1dLy+l7DnzKTFCVjUUJGQia8V094KC3pNldhHPwSU9SdzKy5zyH0DX78XfqHsj6kgba5r5mKB0PkHv7H159s4jKP1hBEmlhzN4NaING8ll/b9H/kIRBj0444p8roK74Sgpb3iRuNjNz2FND4jFXGtRjZ9MY+ZYrN8exw8XYodHot6UPw3TBy2JZG/kC/fTMG1uTseLrQdCbegWoElLTiEM3//pp+oq8qJrPStjQH2qToLluM+trLiZ8Ekaf0btbARe2MxEuPzan3YNLyyVPktTAVdLEk/16r4gqLAgPqwVT319ibq9kH6w0qXnO8vY3WQNkWE+FVUbLAsei57U3c+HpY37Eb6Zx9hPTLGAKPTUmWfb7U8Bh9TWESx8NAwyd7QeW8XMHmGFhor7ehjEfyx9fxIGkX8mDUN6bc8QxldBdK08BhXzsOb1V2orKXMpjz2Lto2NAUnRTnfwRI86pkB5uN5xO0QBUn9KtYcbF60smdnV5k6wlRuS2I2aseR5NWtlC1UQ4a99bXHYztggVNITHp0ehdQTrTYq5qIkWNqHMOj39oj6nN27NA44XlKdiQpQ7iVD//rwCOKjK4HUIE87E1GPe1YkuYp8L/TKaqfqkRA7VaXFUNe8HkktBGO+mKQ3VWuCB98P9DFArGFSYwhIEwkbdOHi4iJTWSt4Itskvih5DAOdw7UnAUMga69LeVboygSPEV+qUqysbh1R/vwlHxyDUD57b0kVTQ4le8XTrYuDE8I673IjqLGTy7nOLsTT3MYa30bJgLCM3ojLaNsdGITkyoaQtQwc/09U+1DwOjCexKUXiVaKZANX3oVdFGHnHAAd0F2NMuUeifOA45kORbRRg5mUO/LZWq5x8A984zHmZAoBknmxbJImUBTsipa0LUygyP0Owu9bV+M7htUv7JdmFZBsNe+OYKiTLscM74Nhrq07mn8nR1zwgnx9HZ6Btw+kosribev6JfVf2lmfpw4XkL9IEbkE7eGRUcKmBkJ3G+suQZTTezug/0eSrGnG+To5dp3Yi96a4jloiAJ9tmcrAfD3G6adP4AX6+dNALxWsKflHFgrgQzr6lbKc4ieEWJ4FqHi5j33UiZM4zJk1vuWj745EEi7rrrA3+m1VJuKcBUukcWzPaMKHONAlfMA2rVekJBOKnNEkT3yGcy08bBd5WAYz1iO7hhAMiQtlmlUWd1DHtXeofxAZ8fx1ZnKv/nFU+Os3Ck9FFGONo17MvXHOe9PpNxxmHUfxqAcEWfb8yB1DRVRsDW6mNeUAT5xUj0+sedY2iFV/tDcTzZ3KxuvzhvvETVlySF2s8UCC8T72aScvg2OBEB2bvRBe3moYzR7GdC4sWcma99gqMANBbZmupmBoqAG1wJGV6aAIcyPDeN3R6sW5jeAr6ad9TZVmx2vMJFhX0/AraIevGEmlctRSgwPFETOUp0Asj4+fVA0UKjWkSLL+e1GDkT9PwdL0gDWn0CcxhxaUjraXvQnBXyZlHSUodpLDYPwD/e8As5rlVy8j8RaUxqDk7L31dPx2tIF2H+evK7e1/Ab7omgUQQgXtZmGp3rk3PmUCZxKSK5uk+cxResWpg2gK0oWaKoCXs4r9GjXR1s/ih/Y53rUDPpoWfdHQmIAAWvCrglkUBvxkt4arLjnTm02PEv0cPi6dbFwYnpRTH0CB8KK9WXetMUR2ZJjT3eu+QsGFe7lYzQCYsKckhzim5bhSDVTAX1vmcQ5dwXtAcuMIBSq7lj4Cu9Zkht13grTIJW2V0wfFLRcB9LsnnRwYnm8VZoBMWFS3NyWohDqTFgRKTmyGLk17+4YGrV3b0kBdZkoRDxqfU1psB5MmJHBukV7v0j46szlbdzzpx6Cl5n0me02suC8NDz5c7w1ZV1bgxAv+3T4BscdXK1tZjFAn8PtzOb4ZOmuNc17HTY4F8NPwkYGG00Zpb5OpF7tLRXuhlLH3mxGylm+vSZK3/MnnIlRyCKL42el0F+fe8aLtKVqaaKWC0Dbrv7bC1tu2VmAAX5fpVCjp7yXbT0UqxnCbqOMn/BMKZmr/4ZbHEN5qQaCMHzHaDsUPufgw/2WwpgZSVbeoq92LUynlOEl3ZkpDCY0Rz3gn6qmkgX9Ex1SAezjO0qtpj2DEVcttbpl9W8Z6RkcTbLWRgpsaL34V5ZPgg8u2JuQ6QnTXGua9jpscC+GpcMkyGqBnderqHAZ4jEP4l0EFsjWnl+43kM4sZLEGJp3AGOJS+j6f2eiTTl23IyPaXCouYvhYfHZzzkjWG3/Bi4cLnTXV8qT9DOuqkeN3YPlamNLvMER8L74K57KMlwCKqSwqpCmf9E3GeHeguLHbteQjqqtGRCAuyUKUpnJTWffly9s7lM+oUpWu7hJHgOqJpEPgp0vcgjr7Mgjb8wGs6NMuOboEEqhPLmsEzyCY2yfDOoHueykhPxMKtji4Qj3ove7t1qTJ3BOMPkdQDqZ5H9KoUdPeW8+uxp0Ya7i0PWZ/CqGyjeIAyWSOOa4+mj+ZyoIILFYa9vK51F7XTJVokOHbZOVz3TiEi46LezRjbZGm4i81Q4SajQxOsJZndQ1M5s14VcEsjnPqnn9x6tHfZ4qQcETjm02PEv3a6Wy7rKjh9hClcwBHNC2s8Zin3FVzUC6+zII2+z4CBQxnwQJXzFig9sW64cqASVFiUrCnkj7bkvomye6w4SsOvPN6O0TdM1jA/Od9DLW+lOL63xE5HNG00vh75NRRY7Hlss0qizuoayKeiijHG0XBQ53L0WEp+l/EWKskh6irVfm9SIM7HOREGflOg8afeDGcYQceV5hTCKVpOGF7bLUWVNgtaGxH9s2TYgqb/5hB4Db89keWs278sDH9uLUNoh6YOerBRstyLNTG3cQw6Q5ExiaJNgF8/ezo2mX9W/aLTxozSezvHdQPoOPwRDr5UNy76A+J8gBh9DixlvyvifZOXD2VwuMu6lykR8hCvwg5wCTUIP1M81/CP8Vk6xWMUCvJS/PFB9wry2Hq+2y3in4/RT+UJPdrxyF10bqmPiaq5fGiCiQ29LAz/ZRVVpZTb5fQMaZG70dzrK8R6N+U1+p+gKWDdd3Hp0BqkLRs857ksr4wQWtRVOkDYhCETApy9eZyxXb/PxnU232KOJwyNO0fhKAZSfl0/NuvPxO/ljsc+T1Mnlzr8luV/JhpIloi8Jgy9CZG9oXkBGALRIAvJjWLtv6Glbnmz3lVpCMnE5K96wjF0nP+RmYGBrY2M08Ecz+yVWtSaQkGrPFVeJueFrVA/Of7TmQEzZFNjogsEp+cKlCUR+4Jq5AtF4A20ldui0EP+NSMhYs9CFb8sAhXBeSiBYYtWSU7JVpBt3WrWZyhgj7mpBoOmV1/KzeoJjDbYMXOBWQ+qGZekEJ5fpBLAsV4asBvV8HQP1lK+E5vD+eMdQC01BK4GYLjF6+fv3kYsf+Y/OcPgjI2JuI6lOwPNO/IzN5lI2Wv8/UBOVDeghSIknEEUvTIhRBfvRnrpqu42N6V/yus3HpLdDDYpHnoL5PuSPDELZIvrI0rQ3edToo0cesIOAXEF9BWzevnn9ggPSYVUCze2PK32ZWAz7OZTcGnWHOsibTRjjq7n2vJ3YeLaBiclLG6L6qV2BEkXE5xt83oTKa0YSJzo2WCICdCvlCN9FGLMRyBd3NR83daQqWLEAWPuBvos6k4gHsW1Z/O6UoEtN+xQIPdDiEG9CqEVIMW3ramf5OKlkudqARvakdyKgkOHZ5VuLOIqeJyXDD4Ul3hcyQdGOm1UMqGCPn2+EBcM2d3sPtL0YwbL1iLIomedqA/BkAPNjZOglTQZhR8E9Kti+RYTk6rak/W4DpkUqGVD4Zc9XPoaf1G2RyJJugUL80LmIPMKzvCJtiz0aVoeRxZqeeFd9QCYie5ES5uGB/RNtOAxVmw7QDabpFPoo6Cj9ISGZ2fxdo/EsWli5mISWw9ihdQMpbM5LZwIcPZ+XWk/zs/ta5fR5xz2qFklcdjTfk2cgaICYdjYgScPdrkbgNzTnFgfzCkAlXGCDakuNjWhX3nowG1whsaZfoMGKOiUOmp9smfoNjz4gw6onR4I3J2VkpQWBXJ+8IrSIpywOlUHJR3cBG9gueo5rnMgXgVMGU5q31XJL9VUa8W+ncKiD4Mk40bVsIqda3RxTrcJnIIVaxmCzIK1dpRaLrzthOJZ49fvb0N+DRtAfP9eEd0HmIsKPU6O2yglE+kmOHN61tfISMxtO9AZlZjxc2OihvPbRlnZXJ6pygV+smGEBylvT1EwVXLwgmyPZZGMjAHoGxhPSuyS8GITdcRtuVqagK5ujKLb8g1pFXiQDYBcFH+S2YHLPGNAPIJ+GgmJGizlxuuqMDs9rr3PgSJnYkG/Cw3BJryn/s2hMcOD61dCigKrAqMa0uUztpydTD3dQ2XXofP4jaEl0MM0aFYwsqrP7G4fEvtoqeFP2xRpDYDW1AHP+fNeuzkjrzLIp1uRK7LoQFhR1iVCi8Q5yIcBpaBtAoYx2l63cLw17DfG+Dhd9U+7FvC5POkfOf7fNDzFjnN/eydIm3djCy8IFSLEMuRZ26VIPFT3O2B7fcx9QKKzhr3m0vPjpUUfYShgz0gIsVtbX4JtN1tA6+z1ofsXeHsTPpZRixoVyl/di0B8YTuS2W8zVsjvDuZT/Ssb6YPhJcFNRXdVh81v5wbXJldmWA6aW4mSLuIcYOPlprcWrdwRogElcZ7ESm//XINbRmmkBYU6mfmp+DQOmaM0J1mCuIkcLs7+gZxrVRV4Qn7qDB/BYkFecvEjfLWONxthTd+CZEnB33QpASah0y5cxik/pYYiycNgr5LtABwBaXK2k0NkyoML1j2bq+h7aIOjFTSOkEF1bWwyMiJJQWIUDsLX0axhASBjZS850EmUJSkPUUQuorEAJqsOpeOQXTMg2ieVKEqbIgEuDAKB0QgmgWwL0eewPIpfn72g2BWHM9ONBXxv1bk6KchrIumkpHIX4Si1kQuSs0fBrlVURPlfyNNhMoWb2DOTH763ItuIwkBkRJGwsu3d+ufGEgCxE3wAK/U3UR6xksPeGRQ8yNwY+8mcxiNdY4CxTdjy8Hg1YFNfX39UshIReEzKOKuETNjLdbMrrAu7lQZfIB9OSM69MdB8Dgxu8anr9CHDLsMHXkMoxlucDqCvvbvr25Fu5rhF4T7Jjv1jIn+beGMYJq27HQfKB1p7ZwrjnYji9FyK7vuGdl7duMxpsclpEoLSnOYJtyEsgNnrAJj79IPsqQzFhRB6jEH7Z5W/p9KoK8JODzl3AIfuagP3AYwnabmhC6nSsL+t6yeK6peA0cSEpin2MOg/pzZM3lWDyACb2HDHwqD2EQUkzT4qayFs7L2oCBWnS9OrnWlla+kFp7bQUNYCg2qCuhyaoaTK0H41pgkS4xA92/sQ0PtGVoeLG0UQqIAtneQ6v0Ohe2AS0cUxXoOJ4qcq7OWn+AUryyZQIwONFzWOfpsCNf8cv4QX8RhP2uaf+mRsfGvm0qOQ21w+OIlzNyYBBX2l7t3V4OX+MEyXvcE8YQL6e/ZngnZWKR0x7R5uOWi9tm6itELAdnEDNy/yHX37NjrwOcQR7efBLQeyB9XqByWOAufGvkbRGoXvcA20aTHtdaTmDxIHDjPmLRn44QI8FsJTYXkFdxbmw7RZtQ/wTVEbDRzWwc4QoS/le7/dqTu0tPzhT74g3OF6z6hGTnUqrfKlLX3uASzHaKBirRyReFS5kKjfAODzDq0ywiaEd93HoC3nqGXQt6HmG3Gg4604pGNf3pu6eTT3Wh/srJkmrceOZHRbiAy+FvF2vCw6mRSBI27mTsFmPXlhxtje0aRu4TZRJR4s1HQG9zXY6U0RGs27Xo0ruFEB5HBKmkhT6VK6a63fqbNLs7IdQMoG1sFARqcbPXjSlxryhSK0wQg49rwOrWVyNj1vXEyrQvFFMMdQyMVkFTRDyCYBnSMfO5srXxZVP7LiX3qaLr7mAqhOLU4zoTRT6tjQE8sE4OFjHgqogGGACKFxieIJe0POekF8MQt0bo9Iaf5cqimevQjpfktoDMRK0SF7NHN1pqqgpBROzFgJyIClvGrisnPWcSk8uD+V3DNHgB6ga6EJZj8W98ltqMGiVkih8M6HJnJo8AFRh8ScMbWlPdiIClvGtdOafPaQRFsgVcww7PUAAs1tOA4RycnH2LisMCmwo4h/T3iRuNjNz2FVgMYnklBNGv/NZh+WLZalCQAFIuaOqXOWsgeh9+O/sekiYLKBMD64aOJgATV2XQvSgtvHIkMw+DnWT+7gEpns3D+ArSsq/+jhIZoqeZxX0AA3/Ndwj2Mi1Bkn5UEzp+fR5OxPhvhJibCELYV+9z7nN83yrj3qY13bbmBx1l0uTvvMbXIC3eCOqgfaychrpIEIxEoit8HqZZZodMqo7Np+XsezZ0EHSsluZYuJT611Pfeu3875BYlctNn5P0kEWteb1S+3R0+6fcGTh8Z0rKGcU7tbT9C9XcRqHIov0HeXOYVCEbaEkeU/4TYZ0HF1gu80lcg0xVpYtRmtvTk7+maUqZhVEIMpegr4bB/qCZtVVd8CxyLO773AC9dKON/10LnfOYp7frUEf5vjhOVD0vSjOheaRIIUEt3xvgc2sNBuBqbEOAv1P4cRVE5mhYkRRy2hYwkZh9bip+TmXI4+vLxw30hBKZLLCrL3Ba2/j6Em8pyyysqEwtls0H1ZmlNba7ejlXX8Y9nMZKkOxJwnTpM8o9KOJRh/bfWDFt04d9N0oNvVCiXlUr2s9IyLBkocuPCZqOVJNKV+gFdMQnZ4oTxfIc4PVuk7RzDDJdo1hrgfw+/8Rq09bo7d/aF5xyvgnGoUNv3Vd2x48q227y6IvmhcWMmCJvEDehGRWax8Q7BO+Kbue3PnF0ByAOJTFlB19pr9+cQ7rFw80QmSob2rYLqDb4dUVTEj0cEkeaqjpiDiO6/wt0xfgBvMER9AK6ZMY4jO3uKujDAv+kPkSHgo/bMvxj4PksgJxAZfodZSkpXOjpNKgUbuecgTFLJDQlyLdNtZjvDyq6nhJOejCEQ/QCh/JINeVLjU18ThDwxFcTWCvaa/fnGMaEyW06ST8ZybT4hBV43hOTIrgCcj/WXAJ4gJGt9MjomoSSfSTnc+z94vu7qphfsvs158PdFfkmLKR57ran2SAUCgtAnYsdQMiaLz8e0wJ1gbYqxPkMiXXpC1YSmOGlZz4pdx+txIjs9+x5kj4SKgRjJUacfS48R4/izpoq6JgtDhdUNzIRy1SG9IyLBkoYF/l5hjixxwlv8a7I46FWgtXM8krqrRh0BzkPksioktLpbRiWR2oqdt1eEE/ZIIIK2dTnf7ueGLXJM0A0vy0W6/N4BDsaLaSyBYSDWm9XQGOUy2uooVeg+fxTyadHWg4vuiaKaEC/jO1dwFepfgU1Lt8oQIL5p4t9Obaz61TzWekEb0k+R+VHRkhbKqAJkzApsnSoKIYFzEqBU1JkBHXDA0b3qli1v9c7tPiZWIUnassQ9kROJgsZ80zZ72CVeq3nGbPVBoSfflYWOt7ZF84P0gZ/WrSveKFFHwLJvYAHWhNaXMOq4LlMpWH1q8PKrrdwrl6XxMUM1UEnaZKZ6wJjh2Rc1zqslvDvcd6M7glZ9J4zGK0xmLjHZSu39H6sEV8+zESXoeD/Op+81UEaj6Bt5jcJfyp32aneryDUDsn4zee6AuUyrzg/SciyjeluKxOYi+RlhMpAZZp2O2zQESdPxro+9ZczZr7yPXFCTcJ++8wddDH4DOesuZ84DQQJAF190yowI6hNysJy1h5+t3YPic9rAfeFQzE8tv/AIuWS+OwQ2Denp8/fEtgZreCGo+r76/SjIxhm60ouMvfF+BRRaBf4oEbIXPnnpkfw2SO6thw29Mx/rhZUp0Lt5V+2EY3BVU3xUj7yAjEKjtD+xKpPL+uLaKTBE62ZOPEOGdBT3EpgK9Iq9QlvQ7mv+MHKls0i/PCvjB8WrWWfRIpV+6lnXXwRaU2uRc8m0HaompQCcuu1z7EG1uVsNLqH/RDlJhQwQGPtFWaJ+HeIy2YoW+0jvPFNOGCtIpNmcXwx8UfSn2QRZGfDVmpjpMx0yqfBGIwWbzfKpS2eQRcAPaxXjdXwxpznLE0pcTTdS2hdsAELCuPMdfI8F1MFIF1pNeLuJbv42XpoBGYXOpbnrLoAoTLihH+INqBH7nEy8AwBXh7zB+RScNlQ6RLbKrU629kTIabMCmR9CVGxejoq/iRQ0mtwuA11ZEtRaDYKrkUIqmiNyotqMMFBm6nDE5ogcOSIzpikqtAMGCeaEtPKVbiUwFk90LC/BOdiLtNs6wv6AY1ypFLkc0zuoJDoLJOd+0C1n9LZykae55koa/IscApNDu2iVHU6On1RrmkkLjrl8rBIIXekLxdeTxjCmhuKOQEgOPTxYJ+yL0+bl7GbiUwGvJZ/zquOZp3LXJfBdnnGJvJco2njlFdTNakABUERP2RLPWFwLwaJ3L6QRWqcTFIhNyEzFZLiSIMz2HWNv/P7efmtdanowcvc7h96f5rBeFcQcs/X/C/pIN0fxsSLbqyMVaNBmdkH8W73iRyN6nTthNzO2IvpzUepr77iQvWHKAEueHs05XfJdaIhSlWrhnL9CHD4UeMNO4CQbjYd57trPZ0tpjGepYxA5HZAiqE7QPvw9L1OvaL/cZpiQh8c69UhzYTheHUyJCR9TO+zUm7s4k98FKfzllqqZ0MMIDtOC1dJiXbHaWWbDa6WY7oy7Rl7xNHU/IHAcnAaqY9Ry9iJ5FISBdsZGC5p9Il0fWhaR9DGfoPlfgjS00KE6y5XO4ApeJ04abBdWZb6xiE5409GE/U3/whxH0q+UmxRjKPj/IYQHuNd3L5v1hSOOHB6QKTSKW5zID6atVJcNOumGDr/6THLFJQe+jq4EXSvhqSi3Yk1byX58XOK3B6K9rjuQx/4G4Fn+yl0I/QU9HyHj/zTmrc8wQ52QdazTGnF6jg2TdNokjQHkCJJJp+uZBNPuNi8NlbAby1vEMnrmrrRezbEyDdCGP0xe/DRkUGPhU98yUow3ZofgRVgkfHVgnZFIYGuu06JysWcNQJAzIeKURgL7YptNqYEcJLGLe4H7StmATlAsjc9HVqI89eE4DKNr5E0XfGUhKZutOo3ljqF2stj3nny3EDZPuu5Mc2WMdEZcU6qzuZNLh3AElBfyTU5wZPKSK6mmqnTyvxGOSr+tidfc17mnVMWzNgY5B3PkVrYgbbuWdej62wM4OFEY9esHWJtqSAhLkIxqgNT2ReiopBXZg1xCLUAlEu9l/9c56FY6xwjk+DbxRr9lh/N+uEMa3Ai+24RrmUXm4G/Ar54JYefuq+Bk/ZYxIpUV9R5/UTnfo7/vp7+SuhwQBdlYYxkA/y5tBmcqftoJCCedcj+godFGiYVJL+J64h2/rJGX7LmnhSUX5CuLTdynSM5R+cJMNjCgBIDDvFboUZDx1B+MMTfKpUQiiw0ajr8DGr9FnF0J6KO2aWB1HS81B2MGG2rme3L/MOd8yMSyFoqf0iBXXgGqUQbr4x2kc5mZJXC7ANp+YQzqTPX3/y84sZapO9sxYbvPAVplIRKbVarpt8feT9GqTC3cSR+3E1Ot67chC52boINJtwp/xFULNAJDNgJdGdhQI5PmFVH8RQb2UVCzhxzz1NSdyt5dKZfka2wKgmfKjNoACb18QcqGVE3Ak/v3pc/3dU3GBi5aCy7N5ReKrv9lwsuGdViLHIdd/+O5y04Hz5n3ZEIkqmMycgTENzxJhh0vRSfw0s2q4Km6wALJkAFc4yQLAY/pLGLe4H7StmATlAsnqZuJTFgxs6hBW0vl1pvbs7UTAxyDufIoj0vW2BnBwnm7mhnbSmvvBIC1CxX9cQYl5j4TtM3G9PsDtLO4S9C1jr01XfWWvf1csnc7dzq20t5H2yjq9/LYIVXlM0qQGIAASxjv10WXQVD7eDOJEgNkMf+gPV6yz2BTSsiC+lFPxrcD0Iths50W37bk2ECQT4GVyevitjxWOgJyHXn2xbsej0nLj4XBQJLlK5PtDOPxEBZN0T89Gwi2hlhRgwx15uiDo1qJpmwkGX6JzHp0Oqv/PcIiqWhGipyJ9NxBpCnZIA6PuWrPv1ja1kkQln8yRVN0kD62kFCS2Amm4foRLJqwfq/kCYLvzewoIeEyM81UBmATWoCO+YvSP3FhflIOrJr+RzNFLc5kCI9W4bt19mryIcPM1Ma0OPq5MYFgBNxCBpff0C1ljMBReG7dAKReCjexbypKTfEm29OgRFPcVbTYmdDwMEfpXXZ+5+9ngDqlpdPIvjPx3qvSyOrjZHPWLWenzq4uQ+yEwGCqg5ohRGpB3WQoiqAqfbjRf8xb507BE7u6ndeYGtSx3Zi43tDAN9DFDXb2leehBoIJ/+2SXrThUjIuA+YbYMdKPUtWEadRgoSzkl5HUgwPG+UckJ9vNB50xgv+NLkCsqMqYcz46OD3iFGgH7GiM+xYv1+l+0OD+6xA23TmazZvdjbK5J4pVHIO+Z4sLMTyr66IJ55YUy/TCRfN4HCuDzJFZr6oXDKqr3bLkyIlHcZbHNLqA+uJxNhdbX3IPye5z/B/F6OZaE3Tk9i2haGwlrgtLf743cjnyC9acx3ZQMH3dy+b9ZJ6WUbn+Y1BHWw2YvXOlSluGus40+zKqtZ/73LYBvfu9Hqf3u5GV3DVWMw3iZ5NsySxi27adZ5KxlZeTiz0kvjM1A2UWPLWShvtQmZ4z+HV7P2YyIW2HeRx4iZPi1DuWjQnAzGhYjwWck4+a8SNigNWZYr7/3gUcqABMLg9JQJfKpjkAJ2c/3XHAfvnK/BGk7Vtyjwrj5wnc8qLSC3ScYIIdKvk94i7Jhdd/j2r7+lGA6bKQBWIsel/v5gNP33Szr+qu4PAGAS297cp+vy22CD//e+qgi3DcDMSQ6ruRSmNdFrQCc+hhd0M7AzZWjlZhRoq4Z+wdBqBrKrYEHXvNsyklLJP6Te24pEaDuQLwOdtgURJhgB7ptxjBqn1tR8hLEu83IF/KWRd0nwuQ9bii9zvAXNwUnqoO0L7voKrJXzqumCJS0HPL2OLvsiamWl5m+IaHY2Lz79ARCD5CRPRfYPsSglTovgnZ2+C0/W2BnBwojHr1g6xNtQVokD29YpFU8QbLd5Tv/VCFjXBrNT9QZIWY4xcGvCE0kBj02KdpsyMPxikq+B0jBRkzoSRtMTVkD0eHugNNUlb1hY+bS6nXnu8+CiAHj3Mh6XyKI8x6V2mV0WtBWOMEvjzMO2d/2FxU0y/2ucr/A/2BzMxQmxkiBrBezocLAyBSmR4PNhaqf/b1FVPyF4AR26H8TSmhNdTGdTlCT3eKTurJ+3hMUq12SPBrlTfvw7/p/nxhsRHhG+upfAKhjPCnCohAXo98hO/GWxZ3su96sC/qidVUMCQc8hvz4sAJs1Vd9H3hiN8AcjQEahPfAVsefBZq9K6uCL84D2zrtxiomZ0lx5IY/aHjVoKXH3UJdXqTadEZyTOUXmQiLl5V3o6c0UDO3DrvXE4K/8jWIrY2E9HQ50ZwGaxZ98/TTRNw9k+XZXZLvBJ2Qk5FcvVsS0uO64k4qzeUyVWFlh5gvF+sw/OIGZ48ppaovyEAlz9iovT6ijWnPa7PqidDIZwF5XN4wh+x+NMC+vGEi1JITkMS31QvSovvvRefJVt9B6ahgLGLr55APgILZoe/wS/RPQp1fZhGZKZMlteap0Co2n6bCkkkuS4KY81iOIduabS3fiQhRNA75k3V9gO7LjlzcSHybW9aWC9/SzzjAc8f2Kfsy0Ud2adQLvDCvXoLZXYF2SfR5Q8DhEcrja+pFb82y+w5/hNYs8vjvS8t6MWBEFqQEYifgMnMOADZJXeAysPPZdQFIwUYhpv2PCLv+pBSu7wy/XVM3ekU76q7QmeDqU6S1Y39sognjHhgL6hDay6xxCaEu9Ovg42buHdi3AAbUaxt/xCt8kJJXDUY167M0D67JaLkTMYybNQaQoaxtzMtmH91BVX4D+eM47bK+M3XqzWatQBIBCYb4oLzJZ5424t7PdSIg3ZnfqwTr+w0ExxS1rj7aEqhp0NrNFwTUxSQ7k03h9gG9L3odUo7s/O+BXCF8AQBp8sH6IH+fBisq14IjAQxsdM4hG1k9MaqfdlDDp4PLlZNR2+X6Dgp7rXgREak0/apuIiPxS8i/Kq7hc5XLyuT9iVXc+ttxUeEWZOHIu/G9MZAketQxH2o3p6eo3mlmWs54PLMD4O5u+91AXBoZKKTsDjSXQGyuN+xxXLv57x91WKlSVMBdi5OUdSpelT3ERa+Ko9pRVfBax9zTxCJn92fIs9FpwpdgsDBD/kALD0k83WNR2Wj6lntHe326mf2Vb/RCE2YnBOnvITD7VZQEipetWULmLyC0QhfXaXVc2t6WE8amEpAvpUAKW8Tq7OUOcm/nsuUkeHksSOPADlgR7rdRSdCi1r7janPqD+DUZ8/CcFr8t3c7BdXSYlMMYzI53/66H2hmKPim9y5CYfarKAkVL6azDs3JXxnwpXJoRcsY2oV2/omK84EUOJcTnrKSOgkJTe/7Lyv05/HE3C3KfWmsL4fgbPmvivSWVkFQSIk806VtbXCBQAwRcQvWfFKgWTlmEeT3So0uGmbrbcXwGz629GgQXZU07chZPyp5jdlzcISb8qfEtjdI3MFfjm8m9ZORND3mU3IKXEDQ/lD+F71ManP8HtIvDNGupXtuZDiT2uwNTY4ulHLYqGVToVI6l7Khkcs7MaHxXzsW5kAMbSdsmFkDKPtrvhuZ/CCWc85Mzbc3CBA9b+bzhTlQoFAigbHuKu9G+H4n6PxrW1+p2QijwWtfdvy3J/MTYCNdrvhCkZsnKw0vU7f8HMAPl2XmszmFErNG3Fqv6h6ROt0kRQEk0AS3uM8t8U0lOWVYDD/CfR1wT92ejjq1oTCzgmyaq0Oh4BO+D2jVPXTvl73HAduXuk1L38qpK8hsEuPhIkxdNPDC1w/QSFukIcX7narxauqAjTopwg45QBNyVA1ii/kfxH8taTGg4qgGaLBUgD8PsfRI25V8IZ2VjRVcyHXRRryjByzJojTit6nI3kzDBSskjBLEnIkLuNK/xCJe5ZJiwaT9qBDH57cCMfd/PsF1/wf2mLEw+SAzRC0uRWZIg0rkBJJZhFk1bOon9uQe0eZf6yQBHr8qoKKcyyEGap8/Ij/Lh7K1+q+v3X3wE9nlFmR74soMVrYKSlaj73g/04W7hI6ZrMhSa4d3mjYPG8pZp1JqdrPCv3DitjYGn2f6vXTfeSz/aMk1EenlYou+t+GiDGbxs09w+uAcMKK6YK4eR0FsRsITS8tz6sQAc7Ht5oSKh2O+aj6VnqqOUO2cR+umR59OZhHdXqYfVSaXUy610ULfygE2Re/lR0xDS+DbBWWFb+AfDvt8btLjWuoMyikLEk5MyvzUQy9zgmyaq0Oh4BO7oDBg3JoFOYYNKIIU/iwsndvAqXoS13/ogbdaK4SurSCfjgXiPWoRJ2NUIKH/z+BZdpm01G/d8WCqjFUFFgs/ePx7vs5Nnzb3w4zAs4nCezaLFyirfZ+9KacK9enG+2mIq3QdPfvaEPnSpo47OOrNWWRb3HJBSE3tCaYnYJxOdXHidEmO/yxB4077DzBZ8U/os9LPgoX3WYd7bV19GZNQlNGWnc8kHVu3xgxDVAMj7OL0sIZ6MXX/FI8g4Vs9CLCZmIAQ8BYKosWmYsoT16oQaDUlRWEnyN04eQ0JT1fTV42zRWeeOYuraUS4NdWJmTXvmLEylh1X43fLUSh/+gBTTRbbj7igscPej9O1FCFWCzlwL81pT3YiApbxrJqCdj77PK5TYL42Axb0owzM35inUsl3CpvyQgMHsfWZ39/bV4tCLG1TlynFeOSKPuCKfKqACgtDqV7p/o2XHhSFcOQGvgNw2IA8oe/Y59W/IVG8REFxLh/yC9sr/sESJsMBFccgT+wtl/Y/9+892Bpqvy8cX8Pu7xGpHMQs9CY61XMTEM1Mm8RFlyzBRnl2ZFC6uzugN1SobXGX12enZMRjlTRRgWDeq4ttyqHb7IIFti0QB8SrOj567lKtPnP9OrG+CrGslAGARc6jzUGn6b73wVUQDC1LRMns7Kg6b1MTTvS5KZAIEZmqv2zi43IR33puSkLsvLd1VThh4dqbKhqSZfdl0UX9z9dHPPZEiYH11EJT1MD/LWq5rmskmDpv+MBhDxHBuLPpdlT/vrYq37C9XxrlPr031jT9GwVMiqawYMf3URvxSeQI/J4xhcT6rJA+9+YTOIA+7JvdOKspnr2jSlx7t17mVHTzNZh8uK/Mgx55ltijNj1gT/C79EC0ikW1/LCZB7hZc1kgi/DHWGZCg/+WbxApqNPvS+s2vzQBsPQrWQ51dD+YyjqTV1G1T4/CBsJzKbR4bV5TSr8rRI98qHID8CW14dj81StHGkW7JFCKE33DvWlX2/BwSdqa1Hz6cYBtoZt5q/2qCG242XUUDDneKzKeCuR5/CnsQCkqwk9JkpgegxmdDA/llACMVjMIsup+tivV4UfoqRE7osWbFOl1bGgJTZF/Ff7fYUgfsqVMTIwMp1SAE7y1qaDflErZmGWWR8ykAcmq0X06YFhs7MI52wURELeT2Ph1ULVaUS6Ec4rtnBwIEb00wN5vzMycBaxXZqMTVkePLQn7JmAqlkkR2OC8vhJ6IviNOhoLCTYM9rLrZGFh8BSSIDaBIWNSKG55tjJzSTTHsTV0+DTVFWFpXaR/RBsg2oOHUgqSVU6jBEaBrvaLCxzStN/TAMm3PBf7QYXnhfkErjKm/uQN0BVp2IgKW8at7gcm9Bqs9ZTeTyQLn7ixV1X0hUT60yCsUGCY+bxvSDxznwuNI9LcNNuwpusemowvWFVjNDgTLM9A8/s4Az3a3nWjDMd4MYr4TE2zcCwsWqfLMuOfzn4iV5QW+cle8Vpf2Equ8JRvRd4yUgPQTpnoOYZyxUPq0lfFXKdSVG408DKSA0dGud2ww1+m/RwwH9BsLHL2Zs4XO4T8OARFVQ0v9Mibup5qOtO6jRXB8+IjTt+RuhoAwvIRtxVs0tkzTgw5fIGW7sVAlWc/iucLrvVSUu9vTaI5gNW2VF5vxCbq901FakHFr5ceAA1hIKyS+ruybcGhiHPEC1n2ZOQ7wrgXAvfpcPwDm2nuUusZsV/0wVDyG+0r5SQUwmcfS7Kn+b4vhhSFA7hoJLN87+x2qTPjmviJeuiYFZihv3F9k2JJWtYYuPmOMo3tv/bzV399rmPj+JGCq/3JJ2SgL2ago89IPUjPEgTAtYP6ePIlyICuFU1MUQF3UeBisPGitztRriy4KLKIca12Bi3wkZnsdeeTjoKdBK8+dFkJaqo8jeT7aka4Wn4KBEYfWtHn01lnSI04QblTULKTnf35urQXIKkdf4K6U0v3XcCKZ+HG6rYXaHzoXFizklKjy4wAz6baS+yz26n2W8OKQL3nb/LmI0P/9ofb3ONMvlIc+1A1J0faxqFA2Bm9SZfsUNORWrrhvXOGmoII2DYXWdx5pDl//l9VzS6/Z7HZ8tXlRAd0MW+LX3npdPLMb2STSuWopUco9yNEMnw+/JwzNHjj0hHAOFnfdn43gWQYD5DxL+GW2xtip4WcQ4VunClKs7kigNRhxmwDBSiqko4jZ84ZmjxyaYAiDc3mSXzpl8a9GGFMpOq9S7wZjEmhbObb77nbd+kywJV0KY9gxFXK5xT6PdJS1BmpSBzFZOBQlucMnEvXHbU9zrz4DLbOF9QlkcHdMo1d29JAXWX0yMCrpHV3uRHUWdoLGm8ApeaL2L8u6ANRd6voPqM2aXlGUVxBtTxCdUBMkcGoHxaQy9lE9PxI5CchgUz7bMJFbHtu3L+SPc2KDuguxplyj0T5v+IAZCkqqqjGpsv+rL1W+6ykjGY89fXpJJZ3Dup3ODQ1rb9vPSageuKrhHQa/v2VdIx+VPVIpKCoJJ8vkKkEqIKejr7MgjbHvXo7aXAWrqdX/rMMrDsSQD2ziRXuqtdZpwc1c6uSpUkYdI1/WI8mcR/6XMdf0htW1F1YCLXhoJhmct4Obc78EckBCVxKqMaip9A8oeR+o2GcKCFEeb2aX4k19fsYurVFG5onNi3tSOoKVHmdi/5mE+f1viI6zfQrTg7ufFC6UbUE0sjrIj0WrVekJtySSRbhT2LuCH7e0jcVY4Sb5GZh3KyW3kvjiWXtcz0aUiCviwUQwCmLSmNQcnZe+rp+O1o8wKTy0KsnVyvC3mVX3wtN9Pt5fjl/+EaiaxxFDCMjRXnLOAzgTsbcXaIjt2YpqUDeniGMroILEC50xZOOLjRzj8agvYao1NfqOCwudTXXW4sWyMNDvbK4i0uJ9AAsuP9FUP+Ksxdlp8cqex98P4bFgeQ5pd74LTy+m1CR2SYu1AnUVWCEsH98HwHabTSp+zCunVyTbJGHAb22ROLaPvQb9L38zQJHrSXgU/ZoeOQym0KUImIaT+1+BYn2eKkHBbHSBiEwEDlTM3eGLm6ZuURoUvzFpK71ZdQz9rsO32AH352lo/4OYV36PZEGj8VHfrq4FlUd0uYOQcs+i0Dyc+ZV4OUJU7C5R0XVchbICYib7Kat4jv0j46szlXzBiKOHtE17bInFtH3nEb5cCjInBH5Fj7K2SgNQ6xNY4dOjCexKUXiVaKZANYulR/Iq0y+TpTD8jruG7FCAsZRuwn4bfgXDocvCo5d+E82FIfEzRcA5yjWdKttkTzJ3EKo7OsQ7UmylRaEt2/auPGHObRk3+4tNHU8EbMgpXoDRHLa+OO/z44dtP+5ULd6txxd3yrfCt18MKrbWbdaBoPMKZkzfHYmQ9B9tPlEbwXMIWeBAoGr7Mt8ww1cxl4XAjFo+SeYIs9Zh6TZY9NsLr4A4N2VslUuOkwE8cd64kFOp8929QWhTnGyCFvd8Inyfgz9yfuVs9g0exYaNOymQkc48hVtTLVB5OerVohie5Kk2czhncCNMnE40k33M2RJBz7Q1DrnVNWN3HgUXQaaaWmGxtip4xrMdikuvFgp5uQroj+x8/INMChP4iokm88MJHPqlFp0sj0TXnrQBphO/7sWoWpNON59j4b3EGw5LvJz1atEdQAU9ppv/1z4v3CPqvYc0ZQOA5thtYg//v6XJi8DBKzGk5YV4Dhrk+Ad2bgI4qMrgecWxWUgkB4zIddHLnkqw4pmuCLlfdGt/1bKcoFdZKhGgTHd+i/ZO+geUtNnTxid2y7y8dtkN6YXNzXRzYlCB+If1TKcleMfclDtdFn5I6MMWJOu4JXIOCtycbwxthO2iTn91Eq1XcFqqT+cxMjKZi2PMJqwYBQthQCFnBJuYBeXvHFkAUGCgXd3IXIbdsQZp0uQ1Te6auaL4Me3y/avG/JIspkatBVcn6O7G4nvUpmEBFUZLBl9XYiQVuaoE9wXvjiX4W7fcKPRuN111gb0WbJlVZc5Dj0znl0N1L74lFjQ1gjCG2Qbb09JQVPUqF9Pp3l8K7ef2r7CPcZOs7iFKzVyyQr6M6Jxo1O0dFOj2uo4icxHB4DnxXKICT+ktxffpTmSp8Ft9tDw85Jd5hWNrmtESHr0zs+JlhrtrTwZjlkzBouBBgF0BdZ97UrNCvquzUp0Q+q89HOEFbkl08F0ixL8dWZyvx+ObTY8S/S3a1+FCAs3eNGXGtOMHBCpqGNMpLzQHb4kx2EP6I/zzQII9ZW8trlTYSiPD2NgDkqOahI7GeXOWvzrrmaUzC3clymFeRxwzqhxkjJDNEbn7SZoYM9Aw4GasKjqR3xUEnsTsw8JpS9PkbwaYSsGPhZ2QbkRMy64b9lrfctH3xyQpYfeMKxyYu1AnUVWDyfp+suqcfxBQn7rrrA39QM83uqmW4jZNZzA7dRTpW5sgU2kiBfDgGjd3WD8rSiXRRsW1p4szgKusdN5q0mXFXYbEVQVZ3Gy2zN5twLxoK8L5BoS9qk/5m65cKiPrL/m+geEl5uvAWYpsMpkHc2hvnKebsDORn2INP93R0zNWCzDW5b/eblMNn+g0c6jfePF4rJOjOnkbFsCUndAatladlEIOEbMs2GtqkumJeQxK+T1xq5vwssyIi4BZYSO+X2jhcbmW6eYKjq3uqyRBWNmc4WnewaYVVPiCXjscYKGVQWWnsWpF+8keb3EF60KKxBgxFy67VMWwQLb0JD3ZYShannTMruchK0VNlKSsrCb09W4clfc8c01U1Xt4fX/hJ6t48OYMyu4XVHvSErYkxkRHZnX9B94c4MQA8rV1hqRerVr5URLNy3S7lEBHoMyp4MNjwLHLmuykReuyDR4IV+g68kRUcbIylsIGxdqb/cKXvlNTlvrVv3Yq3qdBOr+mwN/zrGYvJ3ujxKGb6tPHxYvNrwm3sj/f5wOIBZg4wTnQS81fFXRLW+8TaElvN2yw5bXKwGNNus9KCJemsaDpAg5X4pc9JZ9i/fwsS6XxzJXd8qnWkYvJtvAMhVNbyo4VO25fY0pGAM3V/PtzhOevV6WD/9rGDJH7TWzPjetU+2FxPsN1qMb1WpqFvWTNA3z64n37IduKXdE+INLMAmI+NGDNqcncZ4qlpQmB1M6v8C2mvbo++ejf5tsI9ngNovSVGQ8qDiclp/2eavChScSUutrWgzUzSYJqfoN948WRZTcKhxnB3Dc6aXelvBTRUjp1KJGxlBn4CFAqzSvHfDojdBJXFxV3wuB0+XFAKuNcpjvXGTCIvyw5cIDmiqds+NpKPvlpIMAwW4+u2YYZHvHXALy0kK4FypqLlC034XNDFGcVO30nm3RYAKdGkdCbUvijFSomjES83w2JgSRGNLuBpceWq5wuRpNntj3xCFBGPcLdPb2TMVSw9AX65hr4R5X5uQw07jCwYo6LGBV8/MXedBOEAsw4VKz8wZxs4Vv5bNXlh+OHFwxdZZCjD8SXqB4dtUW6BO/ib1WpqFvWTNA6B164sw6JXQKIej3onZSOLDpvjZIXZ01zjsG7wPtVyPet5Q1zz92LG2F1mBedifTbKQeOj+z1xl5IyaewcHKmDeJA81q2bPv5TFCHnnGa3Ogjt2L0xyxnDiEcu5wyXn0BWD5sB/mKQiTQJFVqJ793ODj4c1R3DLqT9T5ItKwS0Ej+DoK6vhqobcw1e0YBhzXtab75Xzn/BPnQDGRCutXv57KJVrzBy6HInBsAgETGWFGuPmj9fUOnsdEwkwrzPUDD8M966Zt89m1feW5czBPj3YMsY/R6XBl90DE1ey4vJz742h9Ay2mltMO68FS6sOzstN9gEV+JPsed8oyp1Aq58Itb52zHmT05+Srmtz3GZUJaUqGt9Mhn0RcPB+THR5GlOiCagFHAxO7zxiNHOU1Z2QHuRfP0g231cjp/BY9h3xW7lYFa31YeQxK7aB1phTNDkQ7M+zFJLVCZo71LNJIxshYbD+R2Za23VJjJmPWOQbTB1tweUqeDiWy8LqCAvFW39vVhZSQ3XZa0rxLCAHmsuu9sfoO7qwzs5pizcB++Jqg7mrAfxgOX7hzI+yzMVcxhhmDQ6CAlCOUIC1ry5obB1xMK2gch15l/0EKS+kGU69w7Qa27EzNylCNGY28tCNoLXExs8C8o0Ovjz4+avxpzqdP8LGMT9VGdIGI043k2eF5w4OyDCl0AA1lnVtyAvIXmElHgTVJj8vdC704YPJobnNCWcMFInJHIlTAEK7ONN3+7VA4owgFhr9iiuccqtEaylZPu1ffTu7hCmqXWpXT9xNYbUgeG9TwxErpI/0XVIReEzKOR4AQd6I+H7t6h8Xxcg0HaN2ZMSmGMZkc7/9onzRfVPvggvRxWoEmNndYdK3PhS7QhQP4vAhkWdMdqbqyvbV8D7xFpFqNPG/fJKzg7WCUkVKGCByuUQxqsqe6umts+pR2wZLtRIsvPq9vjZ9grNi5MeCT8ixW8cDepOvl2svB7J+evA3z4vrCvCxoAko08N63uOsTuJZWhpigTLswStVNI4Z+tDiDqwIRVl1zrGIfUrODJxK7kE1ck7iIKm4mS3ffVmsjGML5wNLv+7fxCqxRCI3zTkus6S9CMoa8iIkBkqcnZOoSGq16CdWmrKuRu6eUKVqrMd7SSoPHtUk68mU3PERciemDxeQz/2iCSnbGF2MzuSyS1e9AT/2Qf3jRruU/4+ftsxI0uI8+rLbF/bE7HIaqkTPidDNV3tTZfjPqe1HDBceC0VpN+mjUXGWbEVWQ3Ph3JyW1Sli0ElO1gbEIVQzbSXqrqZbFOEfrVm78AmWLKu3da2ZAVL1CNhbLOxVQbgNavu83Qe5jx6ctziWwbWeVO6uwXQyVHo+KF6sGvreegbL+FpBMRJtcb3qsv8dCutoU4c08nJsRXa6GIGX7znVyxsN+CXAMO7k5/AhI+I09uO7Uy1VuBNwnwU91J3E6zeI0A23HnsJn6bJuGNsR94WvW2rZO+JUc98BWyu9VxZd+1a+VXjyVcstjdAvJFqc2nW1rRyGQFKclDPFGsghp5YKDq3hpHm+t/4CH6Gs+R32lftyjNouETuEKk6qzKw0T0EvnWQDAOxXxO88Z3CfDJN35crBaY539EMAQCNUE3ISYnWxJyW1aMHvKZLh/M2yGx1jaL+MBLieGpb2qA76aTcJn/MJlXFE+eQBkHETVIN+mveJqAmesXJfN+GUpFUuLRTc63V9eQjNICrX4PKrMwVoCBnG1CUnKj0EsOH2ngMTEaXBqABc/m2UDjH/VdytAGDNBZ8Zomk1w/7iXvzeNdGVYaj2xcZfXZ6dkxGOQX2RfE0IDWr1H2gpJ54oo/RpaEr4RN6eWlHze0sRc1gr8f30jv43co9EKz96gGFeMKkSDCCAbEaBVz9SEnkEsMxqOwFLrgQszIPXHWgPI9uMKkp21Yq1N7Os7pFQsfdjOFCsitGnbZLcVUkt/YgTJnsq/RSJn0VH8wASvKMYWJfdGf/pQ4dmh7BT+HD5T/5cNS2ZsqRknl3ee5CKVyidG7pWYixSyYsfSEhmaYNVc/Mnn3qxdxqD6HRcIDvj3br8JrnTwL2N+fNMwYWgovECVIb7ipmPi1j4kpyctsgRRITArWucj1ofHokFLOPUjmLfXo6CJFriRCv7K1/DKg0+v/MaKe1Fh+5YXDttDObZacgq0x/WGsiUanAdPG+gH7fnurg843k2L1oL3zSg1+ry8bfMUKKU2Uy45yFF3m32t1ps6+ssNkm3FKcxogRnVzUQfP92kuCuwf9LVohPCmGeO/b4aQfx0R0pqI6QAbpVc7nm93FBBqtTDqMie9XpiO3gfMCslvGpGeE6rqPE9XH9KBxYIxGDb3KyixIj6TroixOvIcM8m2Tha5p4A28bAYk0BpFK8vzzbrjU6OI48vvol/2BqCZl4qoKUigf2X1wR6P6soDPSXWD7AXspd4AkSHmhVsQMqH3bLSdm4mmfQS17ddvNRdGuG6M1+cMcXt04fTNk672BWULjsex+wn1UReZIqyORaIxAdhFzz+tzULNVNi1MCcxXqkGrYDpMmLdxS6h/TcM9ZV2xILUBFVgQt8UDL65xlqqvs+4gztWeYhZsw9xVRJawiyLB9+GZxqN5DbDDWudbecwUjm2hwG7mxeABVdllqqT/unAX/E1DdE+DLTetux34O3NduWsZeZTw7PPpIZhLwYMCsWLkyiU1fsoEXpq5LwLMdjRp7gn6cu2n2xc/8nQ9ngXWMlr0e0QrdAD4DKhBcgnpGyMDH5jn6iD/sfVvLBrO2V+SMrkXMHZiE5Je2s8b8JqykywXa5G8A+iASE3EhTX8+oetTmZ98CiIVpqsCATPJ8t7UcORdYFaV/GAPTMc7Qca1CEiRy/3zYbpNnjWkuwpnYSJgcgufblvZuwr8JjPD4ZewOc+2y5jcTiXnpzjcQ9gLnSy0zHkxo1W6zfWT7CPIVuqa6ZpLVg/F1hpRu4vocpLcm08+cU5MdgJryukyI2DS1mpA/6+Gem7DFG6xaO3PkV5wHMXDmcTTH9Uk/jJN0/qG5lij1upToROYgZ8ywHl5tX2W93Ye0GNSDVkjRdy1Q1a5LwLMb/j/iTBnX/YFwZgJ9k43YhUrRAeJ3+HxGuGEiT2WgJ7i2Dm34Rr08vLCAu+bJ8q7qF1oGxuLVzpxEgyPBFVmrwt4PUwzcsfL+4B7hb2tyOp16lcI6nxevzMcbDvvgR0MbJouB+yGvuswX25AREYEu78V/L8dyKesMkeQzym1RG/hsIkNBL7Cqpii8hMJSUJFYUJ7DHH28O93/Twvh1D1PvVvqp/f72gdXHYmh8DwR3Du8iQZvE+OxjHG8OZ58WNrn0abxH2bDleDBeRdA664uFTKGVUzkC9L6/V17FE4+Fsi4mjtn65LUlYojTGjl2ndh689HqNc+sxJlfQfUZs0sZYaaBY8VAAw/QVfdA59f7KtbhyPZ4r12ytkmWjga+oUQKBVg5+9WGah7dPKRs68QcZjhr2XaMliB6wY9u3izIJAsmNDmD7HoWqfTI3e1R8nmcFFC/kLQsElgKZjwqDvdRtodP13kkVvc40zIXOUhNAy3z3/FEci6p3T/YRs5rZmhnZ/NzJWRvKvbsVox+YC464ssbv/e/rwCOKjK4Hnue56fjwJ7rsWrnWAM3aiYlpxQeKDYtC8DL/JhI6+0TnD7LQJBeZXf/Y14EgEcwFQ5RupWjCbUKCNcP2HzpYbDy3p5C1LHTHU/weRZ0W9uLtZYTM0/Fj/HXueSZrq67wVn+JvitBOGD2JhrKY10xKDbfbBk+6F3JQUNFmWaTeZb9DUVCMnXpVjTcwbX+DssV8vFwhK1hWrp1elbO0g1efvAHi3wu+HvP28GFCD+0E+bY/lucspDQkzbLuKZFnhQWmYyB26N0ixYIG0+suqcf8SaZEw7yKlmE//nyrhTAxWfvIjWDESGiAzWo+aoonLVqvSEpBL1bmlUjpRWz3BDK3Wy8nnKyWZneLa7hmpiecwc8VUtAkzAEE+ej0cazHRQ7q8ML4PVzHH2BBgF0BdZ97UrNCvquzNSVcqDNyxlNTr+l/EWKskh6irVfm+BeXBiU62j/JiGaPnU85d++oit7ZYFFscfV1CDIHysdLKkxlVf2RqbyWP9iVQD/FBVxefNiol7brrJBrFsR5m3zqL2umSpd2hinmpk8Bl3XiSPGea7/m0y9s8znOgbS/6VpTXyX0aZohm9SD3ZnwJJ/MVpwetvPQDBBlbV76jdo+qdtdw8Au680TNPCWyCGNxl6PLWbZypAI536o3ZIN7u/D4ihlN2LJxy30tAK6C+IaK4Sb4OnsnJhFzE/G9xIInbOlQPCdjNk0bZHvsSnB+sDii3bM12EqPFqXDw5ZqRlpAot8/BEA3/okS5+o3aPqDSTbDeZMIDTz1dowb7o782STRCwU4iWbCGOlBHirEO3JDVVnq60G60UKmZRU/tUyVnzug+vjefKt8K8N4X8CJKSSaflOn7wZwqTL8v08Sb+2Tq3yTm8hCLHJgAEv2AKYjLWscG3cXhGQhM46hks6FhJtNWuYaDy3qBSmAwVfwxseJ6iPKHF35pwUtnbiegoH6jZ7TqVfhTejdmIqQqeB2IzJp4v67Ry1NsatlbCxOpkwsu9NCvHHJYp4D3he59ApJFdAFHYOdEYSeVlyNGW2O+14IOBtoU1ugV6y7+mZJR3Xpt4WJ2LqF6Le8q3KuYyslGu2QOHrzXr/B9gON8jP3NwDfyjeoAjxcIQlYQr43+puyXKBlHe2lqGeE+Ob4TiRgx5nfTpQuCB0ZPEBFx3sLZGGp3U6n/Cstum1/fzd3Y2NbAa4AQjZODdLmTqrgcfLc5ZSHJxx0BNC2HeapP9gR61YMSr29vCig9Qvaqye9SYWH/UT1jYfpo0d/mtJZM47s+3CssW3IO+oDGmFm+975jyUGUPOsy7xViJ2glTC0Ql4Ike00f8W2kSfzE5xkRLQrefuMEtykJ65su2LQCORPAppsSDY09pAW1OaR3GnxH4/vR8IQLUl5zphSThgFe4MQNPTI4vR5Tu9Tr4hFjr7DjURSDK41uRNpedTUjxa/H9D1fg02LQ+LhOCOG2pCaspSQqIri0KHG89SqqVp9YXzHPScjuOa/EneZ2J0Zdzo4MTzeKs0AmLCnJIgvP0S+F8gPugWSlATenrzhmaPHJpgCINzeZKI+pfjqzOV+PxzabHiX7AojWebdykjwfjNdlsIPtt4WJ2LqF6Iff6U8A8AoVVta0T/T082WPTbC6ToS/PO6Lfu5g15c1zpRWdEDC/95T1H6JPs+YmIgy0b3i4QkfmH5DOA9PC5KFPi0Y9ZLy9TPsIUrl/rqygw4gEGOFyidzWDsTpiWPZ76C0ZtIdZuUnTMKY+FnXHYGrVGWK0NvsSVvN93F822bpyWxGzUZDfFQhcConyni6JCF7iugE2NBPe/xhWOwY6XpAGtPkPsUBpL5QZbBUGTgd/SqHbj+AB3L1eCGZWR/3X+R8ag5Oy99XT8drRp4sw+PFk7cNgKt+fULBKTjBKjAJzcU9Y2KhHPeJ6a6DAnf2IUi4/4QnyNhFpu/BwYAxDyVU0SkzbQU8s4mA1STqz/foQJo0+90u62nnI9ZUiKn+pJHs58SphMT33R35t7b4HnPto63VXOPgHiMc9CZfrOzaCGzbZunJbEbNWPI8mrWyhaU/oeGfVS6Ge89oRllb4VwPnzzEWepdSSmLOdV+xAdEdFM/5HKknc/JLeWoPTFGlQfKhWpHEk8VdvWPjpKrTNqTdhbpx1I/2uqBFlRK6P1xIUk5N7CrTV/XyrwBDyk27TuLNJAB+/XRi6e/fE1Q8rwEgO52/Q1vww+hdDe3tBc1jthE01SJxx7PRau6K3sW1eJwvyN+z2FGcMgkYNb+9RBINt8Myy0LfIB6NNrKYIuXUir6Iq+j3SUtPkUyKxPtszlYD4e43Tx3xo6K/c2+j4/vR8IWv+QbiklCZwbacFv4xjLO4rrxAt7u2Axj/tg2sCj9l1w1W+LEzPUhOgTMDIuQpAA3BIR9k2UQXmV4CZ6KX5pYtJP5ggpjNUAWyrGWyIZN50adLhBwrcDnGN0u+qf06yj/ySw2qOKQCOAsogM++j7GDdRGcIjr3vskgnFzT6116HDgdkaVVkCeLZkWg7bi2+AUli6ukVm2yFrEpAMLjx3uCpB82lPGpGtqLrKlWS315CFfdf8iZ+uLO71xrtL63Z9z1kbDCYI5Yhm3s6grOFZpamwIqhJCIpMeUGyEprdJ2dDPtRf2e2JuMDeTUCdB6wFbKsgq7BB+3m0RmMC8pTow+jQiUDXbqInpETvh/gGYK7pX8oeeVmBhzzE7qmWVtxSLH1WXbAZNKVht513XpJ4Jbo4eQ+q31sLx6XH1uQdxyknOTkIJbH0vvb89G1+o5LWBtEEw+5HnY7leNaZtMXZgHFYZBZXYJWkldsRDiNK2Pqsu1oLyxS2hMDYDkTGJok2AXz97OjaZf1b9pU5HAyRNhl0uUhksdeAM5A6xQIY15zTGa+ceLRnk09lsGagZpFzV00REDutR9UWF9JcRZU30G/J10+e66HhrS6aE3zohNPBZW7xPfNnQV33qAWmQG2IOKIYAFBYUupM/+U+GOFmNBPWoPxLLzqaE3AtUXAZblLT6orNRzM1JVn0Ux5VFBK5qNRIGJ1hm95wr0sdhGhHp1TaSU7Y1p5ifX3vE69zy3B9SEGm/lYi9clGNVrncL8K7bcdm8uKgZjnBhXF5ymqSSaB2VvcwjYoKDExpja/IqZEU99CLeMQcWGY65SMtYzxobJ8+qrBtOK3ALkA8PoOapZawj2EgCJmKgzgl+qbUePZ+66M3s3hL3b0tAZE40/bNzc4JT/EoRCpzHgtF+p0soec21JCkHfJf31SngkQXYWUD7IzFDduc9SfDlZYo2v1SLDjKsTeu6JE6TMMSMp7yFpEAlGx5PYK1VYwmcfU/a2dmqzGvt1yyqFzrLzXOk6Zs4/9cHvyUFWJMHcAOyuv9D5ZFWdDJgm8TWIifuahQ4BSEhtjG/Gp75RCCX8THcBXO14fs/oXzJXtrw5g6aXMJvRxSmxVoRGVY4bmSZ/qaXo5mVAuFewHtTwb2m/ZGOT+1gK/zT2/O3WWbyF3/PR5KNHRiM6biORxxXkR2mM1m/eeOkFNFL+kyo3OY0VIqxCeK/G60OqwFE6S39ZUD6F5ki3Y/TCu1hyJbgQcEKU/6AbMl0dVXMGgm/QcoVg0netLR36eIt/p5QJYawGKcjJk842S5RFxjNUHMDRIuOFGhxjCTr4D8wMvyhEphLt79AnMsCg8OoqYZu+OEmUmR/A9im/72L9EdoAlermMXXz2hmRStia1gqFuAJg9OREwcwVFdpGmnpc0Q8663+a9rwnIeCcwZonL9ZMMIDlLekUKG94L3jxFx0kuqMCu980gFavg9rQkAeOXtTwb2nNsR6lyF81x0fjJtbec3ZIAMkCfpQuVZl78JbkC/hhV5q2fLkKlDqCXLYoonLxisLpR914mMciiy9EVla6NMAbWMKhdpqk8sNUECHy6kBkRR77sO4kQpXEl47hBlMxtj0i4lX7jmzndOggvnLFJ3OMDK5q1/zbl4BbVfNTI38g7wjAFdtPTGuFgcmV4yNVjNE88/8xmPT+kWES+tspHTqTVV0lPhk7au8AGjvygIoWEeosH/6ytOJnwMRmD5vSkjWy8iGIkqmaAT6wcz6vL5xEgzun49Uy2BXXUwX8KxLjy4Vq5O7Q2h/Qj7e1NgM7bNascC2fAs+Zw4MI1c7/8I+4zj408Y69VMNNH8gBFJ9+dpMxMQnNjQ4J5deBf3VAU2myzP4wrf3d4WVrXOwLs/AViI3qD/aksl3hj2foBkOGLP2gLIjRF5hUECEoAMAHrB2TKCKFuetMlI7VDXoDOUML0ur38/mYHA4P3DsuUymss0fUPkUQm31wzDccn79k0KkvX/STZy7ZDvufpQt8j5kiuVhPquhdY/WS7RGGNvBTUBvuhWU0XHMNvbe0YXd7vBWCULji9yKa/Nr++ag/AZHeo8sGn+xWFLOaWZhsXFna++St+DSJYJ9Xl5yAGGzityAuqxxSEV7NOO9l8Kap6ZvnV5vBzPPzxjuMai53iz+jO8fSlw25kRLBi/LwGHD1qnJrZTtzSMPA6tNE6bC8Xlik75D0NVR6etP9wYg4RMj1LjoXqjr+RsDwQH4mCMiQMHL2Zde9fRifSr3xUv/LAOAtkwM9OMxrwAshu2Id4NFs5kMyuKOc5lwRl6FBJf15lvq5ZG7ImnMVwjoA08PJimazEUWLBaRndc1LalNRU62hqn4sjTFW5qk6kNdmzil+gzmGwUZ1EDPxtmtmcBopRkjrhvU1FbM3sOFvF0N3uD+2IP4lvaaW4mSLuIcYO4nk0d4kQoaXZhydVpxCGfbVrJlodCrYBbwd1BmfGh/njYVhl0WJw4mHdqq52OuDhBzQPdouy1dNKoS7fHhCO1NJCVTwnnzBSfJo0/u9JN9Cph9FCV2tUwdA5xnCe06IfzMg5B3MNl/XdhgY+xwUlXYODMtPrWvpcuMSpNxaA1bc80A29IuT3saPYO2K2D8Rm6ip2QuvbeSG8Yr/RxJO8zlUjHmf9us2zl8bNrKHPA6ataBKEt8DZ81D0CsWcWt1CskzNtzdUkD1Io+E00QWv8pLVKZkRsYtTUhKGxURApfnIFvTxBMl/758jMJzG3GsD+JF/fbPuuAhLSTqwEAhZWZXpSQgt8WAg8xuyPDwX08aTZsUUK1kE11wxMmv4xPshnUrAwEDgb/8EajO4VwA0+g/XZ+SIiH4TyrLllJXye3WFQMERyeK8nPXLTJP4qFaACFv3X3wE9nlFmR76csaCAMhgIcDeJvY4AMHGgLbK4HfheBLwoC4znc9muq3l9cmUvuh9QdiY4kf9ddGue8mgylTLiy6Oj1kMCwEntXr3+8vuFBzV8LscvvP1Ozf2YaFq9fI3Ek9Nj2WYIQrDiee/aKOwfJ9PnPilYLLs/PhkOs/Fg8UhPb04JBgnh4Ia58dNKe2KPf6072f78sKQKB1HsT2Nl9l+QJ2rlS+4qqxlDkiLnpUExKzFio067w4MhclJ3XvDH7attH3ewFkZkiqqUqvK8zsOeDD23pYaNK9QcJXCeVHBm4qnXXiQSTZmQYOXsAQUU5lkIM1T5+My2fNUvMqbiqFFPg5L/950RAmjz79L0UO9JmaPoP5kRSm+hWMzQ1xDWkw2EtJFsLg9UL1yjhHyFSx8M2D3z5VOvBaK1rliV/UADUlxbuprNFzu5MxO3hPqiocqC/NljggRgU3hs/OD+ceC8acrf0dnaHm6H4JtN1qGJ63QQsHdANWxShPKMYT4JXjzfeM9DpzW/tfcf1/lW+tLwsVauLL4EreHM9uq7c2TwHvlrNborzh4IJTiYnBDrpAB5peKN0iajguVfzNNkrPWNHMCvpn4wg3tn5MUvta5ThCIQCZIOpNQpVw4RmCeCRsRL2RkAOAJBDOJ4essR1o/c59Bbc7YCDmQ+1yKC9FwUGowFLn2QnEKgRBt9t+x/AizGORpCjfwyrn70zQ0qw7MYD2Ve5v+bht8HnmdEmHrftQF0/CXD+b854doZT3y2fns/D/TjDoLnZpzlmsD7Zt9KZOgbG5n0x4lobX5y8qxChFnhIupP4bczVJ3v4JE8WuX11ifsSdiT1RpSM6nNUtpE1Zkb8LRrWlP86mL7/ZLIDsdw+GaTjNJduuG6CXbSPkHVdtQDSBkYN+VSfZwX+zzmvu9lchmfyTyAOzgQRHGjNanmUfBLpxAPaPjhj7snw1IWlxviUpYJ5nv5Nqo/mN+dKrc24uKY2OTw0pxpouJO5b0O8kKtXh+LW1KziRi4DNw8ium4J/7XKXqIJbfpNkAj3+2kYdkT6IL8L4NvNo+o1oAo322lI3sJB+TXMNX6fDSX1r4lp6cD7Ljsn+L73ngET2rEYaDt+8vZnAHnD8UvhtdLurz7238oCO71yeSGrDzwPLA9aofvOX7owRVqvbVTcy9HD876C3v66VKRNQka4LDYtp8wg6OwxwmU2YlGqKFSZH7IUkaLuXHyaPDc0p7sSV5KziOuCCTVb56XcVArbBtv5n5D2aSkAQQ7VB2xdy2JMnY1yT5UJqC2FqxIImpJcc+m1sESYFoccJzRwyjjtebfYfNZ31ey/BuJpT1QLdUTQoAwGpvuCSVvIupCEVlkEZXT8JPxL0L/GjTnNpxPFhn/VxaJ8+tCtOYdDgKIibqf+f8uEK9xXKY+xxJ1RPpKShewjKbsLY8tGw8EySuEgPJbbmZvncO22OBstfhd9uiz4UaqJqQMahAt8FpRoiDO6jYVH23b8mVFUhh+1KQFIA0rY4I+HpY46qac+CLXc1T9Ath30QPP9FntYzk8ucGnt3zyn/LKXFZBtsTJr5zXUqDZWTS3SUyScNI67EqQ7hY7MyIqaZJGoLY2ktMNJeQ3J5nOVhC9sgoziOxXZOwopB5rBTcVVrhjUOw6rOjCBYmzzmvu76DKMqNacYLdsDMhPXHKH7bxxNbMojKO6GF8zgxSgxTXnscpPDXq7QhN09uU6VosqPpbz+MIpzAXdlB2vzJAdBCuLKs7M7dAwHCHTC7mpdH+Uuj249vQMljVN6cQ7gUEMfpAcCxnxjwf5Q3oX+NGnObTi10ws/D2/gGPdVJwa0AUb7y0m9z3FKmVKJ8dCkD2xCEcbhrkoowvXlxTY0HvkJ5X2UkXZqmx6Kt0mUINVaMFVpF2UpNpRoCcAfK0TqLDNJ3wqwfE1JYWZxvo4rnbg5yJwhCndg429eAREz7dvQWM00wvgPlwGuHLy34b+PpJcvPEXLnpejvLs9ISkmrif5zLjgsXXYecP6+rWXf0Ojzv1LELKRYHKwW3Ndns8U9Ft6J/D5dmxn1/zTdIwqjPOwfFo1YAkDuAhvp0LMBVjrQ1N2lEhGzdmjspjFcluOY0wRL5f78/wZ7eiXkSAZFY8p300vWra1HNPJbUPCX3BlkOKa6cTzdFrIvh+gf0BIRh61WnMOhwEJKMMDYqOeCzaoWrMa1rWVgvi2zmYwlqz2NnZhalu5fWRCSHt7X+qN92J/i0sPzACVTar+0YIMI9Df2AQLPPW7sRqrZHr24nWDvXqQSjJpGLNVKE5IOZUxP4mlNA8DqcDRvNYA1Pns38scF63Oy7GX7FpGPI4MetMZW4WV++LftTOGey2UKZVbo4MuEZX1sCCDTlCtWAV+P3pFAT8417rIh0xhHyxL8X1pf3BjaWjc/g+vvBQBuNEFIdsl3b6lbmnHuMS1j0jno7s83x01y+iH2lTaBeGLKT03a9XlDco4jwCluOSWfitD++L1Qe5aped49mJlpee/+3/XaxXscD2MW5yXDUpuLXMH225dXPBLp6eMl4sW4zWqZn3mnuecofWY5gKW7/ishToBVoBeTGxV50SY2IoM2LsSyaLwIIE0yM22Li/sjx8nKzUSfEzrApJ71IKUiqKxdpAFLlzbY9fkhHCm+oDD2Te0JlOehHmorZsKeWR8HRuDLFJlLrSnJKWhYQ6ZA+VQGQUrtxUJdiiwR6B02r+WhvPHMLPnZ4gdUApZIND7Z3BCx1UOYrxZoQprbgH5DRFeJrSkb0eGOUy2uonu9KVr2wpv+GgumcyVrwa3AsyKPemMNjmV9mu9Blm1UtCZoC6AV0zmRgRUIZbyOzvMQIHeHnaF3B5kZfTNFAnVp7m2GQEkF2nIoH4/34QE67gpf3pcOF4nrenPLEW72pS2tu7OOI10Js92Q1DRKdcu3IP/58cOLpWmnYeYtzL4+2oYAQY7w7KJoJlRHfDEdgQYbwLjwXBB4A8avkKPJw+o/FsUfTb9jwwlbyh3mfL6jN2vADYeha5f7xgRqmiJLGnlyZjPG4s0y5936K1dWAVeeogGeRm5U+6yjZ72Ca7++TwRwTZzX94X02VzzeSi2MaNP0kZ1Z//PuI1DfGcmnDrtkqQs5tkscIDZO7E+qElhQpIRLBXZ0kTWGwXbo1TdsMiM3VVOTUb52F/AIuWS+OwQyBH/L6/GuaHQF46SlhFn4LwGyexd9NLk/Hq3cIn+grg5HtZm45V8zdnW5sGQPwQLA8QUORangX83YTyCdgrhO8Dfo00s6D/Yxm51tAHUakL53b4tNgJB7InBeW6ZhZAJ5WE5aw8+852OhNNva4/gAFyuj+3evedyuiG1q/GUbvU27x/CbhTPi7ALL2UgTL/18BZyJTroFUH3aFlVNPfaLr+QmdftRdsWH4JuK/y2jemwvK4Tg2ig6VNVtYDaUh38Mar+q4jlxi7xtlzdSAhUzGiVMDIeIIPv+iaCZDU4B+gE/oa7MxIJDo06/fbvILNSAoFJHrF7mF7jE7p5caJB1RzTLmoabt1mkxN0oWJFKB/McTm7Z+30cQ288P4G+HWwEyZgiJxsvTT+gn64d6AY7EkG/biWnZ/BxfrEmLIeMW1c5YSw2qR0YnvADPb0ku0/isMcyBC3EijpKfmqLVon4yK5Lk1HarM4gashkQBF0YRlvrZAWakg0MXghMsCEZCw5GZFoctxtbMJAMBlWQczs19UAmACKU/FbypA0QRZs4FwUJrosOQ8nBqwg+YnQjvcCcNysmQpEvuW4Sw2Ih0LXM8sAHcV84XUc5ebqrgtsk3mMzAjErpgocyW//6cRcjl6ub9ue6cimlWYXwCYBhWIdVWaaUbXPMW7/hlTFpHKxeMmFLKXgBfXYCAES0MmK+JaU7d2n7isN8QQ9l/vZISB/tHOmnEew5b+A1tvVNXM5wZLpAuIASEhYhU98W8wAx/0Rsxi36yWWselhemHmtKBsXfd56lL6TTmHA+fsURa0uyH2NcMZIjYZFpeDFM6jt1Uy3FLLsHOkmMON3yWg0DQ4Hi6+LJjKRqQFLT52L54KAxo1EHDmMCvzs7YEGAXQF1n3tSs0K+q7NSnRD6rz0c4QVuSXTwXSLEvx1ZnK/H45tNjxL9LdrX4UICzd40Zca04zbV5HpAEMlt7y01fR6XuU8tdaauYw/hpuYNr/BoUuWb7kgsiQ84Ek1yG5g9ucMnE6PFZjD5yvK00wLcvOxGKsS07vETwjxo6wZoAsU5QMnpiDhYGndDD4SF/HjkBuwiLanu/uAHxDn7BMfm54pXmM8SaJrvo1yALTqusbmHyZScCKZUI/Q7SGCMZPz76d4RNexNule/ao/zzQIBIikABm4QwSRfgK76MSmXndgh5A9pmRD/kEOetEQamlUXXsKwhQMG6m80eHVjDJs3V+9c9dZXbHP5sX8ga3DT3aJ9fBVRoHDGRjkaIEBjgcbtTv/+GasCuoq2cJmMjRM8ttvHwJ8q6x5uGhSqgCScaagw+adsGRaZy/vzBSx5W2oc324aIAIiF7G4P5zPOx3A2nk57Myr4Gq+lJUnnz3EyBIsJAv836LLqqyOuHslYWjAREH8yXO08t8LiYV2uAqOZMX7lfcttWeNuKL0e217nAspfPiIOkvbDbG1wWXWl2DiOICFUDwxFMRrZOsQUkWbzHqEY8QM+685whTLp3dAnyjxBrVaERc62SnbyMzbKr9yO268m2SY093pSTPXEgp1uzmb4vj4Th4Z77M7mAw0FxpyNC/gCBn9LW0ZEIC7JQpSmclNZ9+Xq2efeu07uYE3Al7vKInZKYu5fHkrz8EBI6gcfUGdqbVTSQL+4Mnh5mtSDXRsZRTafrPiLsfc8YEV5bAS1Qnff07vlnW7eLSkyfP1LEJ3tpahnbwwPsJZEGasW3Tgi6PZRkaw3VAgeU+unxdYfnhRyKjsoxhtMAWI9hfCGNRBLPYGfrMMrDsEPClOwFkV3W6G+I3B6LrfM6sisF3l6VnL+q8GX6ZruBohisbLlZLcBdZ8dP/tVC/xWTohNAydb8dWZyvqGmPml3APsX3vFw3W3asQ8PrMMrDsWMEsSIbQ3o3KgsX3TLYqrBN28kq3e0CQPHaZo8cwdH/tVC/xWOgnazvXV79v0j46szlfUNMfNLuAgDQSRmMTHUyeUgLmafEtao8a42bTQt4arLmklvDKnjjDPdSXifs+UPxg0h+JWwYnm8VZoBMWFTeVtmwgjFkwFhGb0RltG2OjEJ9h2PPdkSFKiH5efUxh5UnQoAjMmni/z6IP7z0QwBxbREB5BJhmCue3W8DqyY+hzK6k+NZmvRZK01gsK4W+AAM65xVLbs9V/evUhH4+fPM5lCWKkl4Jbj0oeKZl2lAq6AC+1JB50xg5e53D70/zWC8K4g5Z+v+F/SQbo/j1PxUPG8+rRVqqKnXcnqFeLRkccpM4aEDgyG2By287K/qPcdlg/ARaELlrm4U7sUeLR980hyILZAnx0qu/iiXyTj2AM98nDWzH9TqQx/6fgd3P107Qvtgg//333t54h4qql74z+H96gUm4Fn+wQuyJ7KYpNgCbkLm30PpZtEDBxW1MIEAJkMY8F3ZYY91ouSv+VrvmAPcC4PTeRZ041FKp6bWteyxooY6H/8O9PYofi/Hu8DqN4dCz3t4Ap6kEhLI7F3V241OsgJqxL+9vszUWLpJjcsTABYTd+rihrrQhrJVee2Jrl3GwqIIpPc2reC15KQnQAszFEHS477M1n8x1VsbsMo6Cb/3k+0++fplOiv/3h7LhXjPW+LE3ZKubK+HOn1FNiJcmhaC+gnBEGZY0aWRz7wMik7YkPj1R1Ir+ulFv00n4se9ur7tTUwguW4ObzlE4FrnlkcpfS1OxbT520rV/smkl4MBGWkjp0Aavl76G4Eq0oryAux3MSyiZjkgZm7xtEWSehzb9v10C67747DVEXPeEt+q5wXdp1ztuNMmIN7LE8pXhdRmryLlbZjMadVDueNv6cf3Q9YWUQcqk8qOzFY6o+8LcQwp6LMQV99S87a0bHWNvlOA1a0CZEqCP4nec3mEwYgE+MyevedB7LShJvCFFtjiCEXtqI89eE4DKNr5KRDVHWKY+Wn94k6Oo5fcf42J19zXuadUxbM2Bjjo/y9ji77a0dF8E7O3wWn62wM4OE83c0M7aU1myhbBNXps3yYKrNaEeGRL8iVlnnm4KZ4dx4iNkC0deEuN1KNihWXSOooSA1We2uygVjv7V2sQxtDP93pNnVKmGSWbLt1T1Oc6klIYyhXJJtsd2nEsePS63ak2ECQT4FuoRoR4ZEv7jZfw/VvSRxvacCW8nBNM96XCG4CRcwUNBTLJB7YvTPu0QfGIGQa5lHntcP5Ubi7lpvkTl9FqDHUPKEaNujB2+8ZCyC03eB7G58+0ajN8AP9BWHfxWy6anPfWv9f3V5wNZOtBmx4rt0DCua7beFzA3uQXo405MW4XRhcRiHWqMVsxR6q1pU/ZxsX4BCwrzKh3j6LeDNFflaxNjTi0z+FEuhWvNh5Dj+uCWH7aXopTCrG0SxGVDS6K15cO0Peq3reC8/kDTQIev5ZkiV9jhE36AGvtD2dP4yycEGyf8YjEio1bBxBzBcy7rOJmhijWFERqr5KldVaNptbMkhIujlNy6A2XgUpc47pj52BLwfQQenNSGw5LlNi77a0dF8E7O3sjDhgHXTtK5TkUUbBLhbGSIbqomK+CPlcXfbWjovgnZ2/RdExHzxEcN1tyWETuC2Mxp1UPcP9CzdJa8K4WAzyTzT79vYqi7qsqNT0YfF9UDfbDuWLEffP/j19/0LafrIlSEb75Krz0AhZwEAf7ZjNBRYRphHX6w2LroMb9RIdUctuDVdZ8AQ2FtRlHHCzCUWHhwqY5KytU7KktMgAYziE1r6DKWW2/sFrhL/FxaaT6gMAXRaJRNm6f8ljFf3FpO+SY3D+0n+G4sUbBxSIdoZ+3Zj5bZA3v/UHIvfiPOYMp0ly/gLQ8v+ECGTwi26xZ13P+lcb0BAMlIqz1vlp2IaG7LTVoUH74AtfcElmULrHHOJKmjJRH77Xm2v/MxC/fZ+Blwlc+drMd+FYjyYABc0trdndtszyU62pLKugOk7taeS/yl2SX69vPVAuuE/GZUsNAf75UmJ3eevwt93ggcYqQ4U2Y0ykDo5FwQGKs1NnmrEUwGHhMxH+O0BK1yTX/OAcs+cQO9oOfWBX+tgOldJ1LPgm3CHwI0DPImZeZFSEOgbIC3pt3MKLr5zdib0KvOp6ajOwJr4pJhY8r36/svtkC81TCzQvxLM8royoq+0nnjJchrf7lhtZR5Fk+rHJpKACn6z6gTnHJB2Hh7DC5cFbKuZ6m6WrNSUyeV+RdaSTG3Y8/6FZVnHFM3fdHCDSd8kxuH9pP0bVo6aH0oqQyATMwTggEV3IYVrrzYd2gpCaaz3AdkSGqwqORuJ0vxiGLalo5EDlHhE3/zitxaMO7ohyPfWlK2oepuVVisvLglZmknCfVdd6fBoLDuYeSmvecoLZxFtVsOP+Z9xOjtu/VcGGqfoK7xW9F90MK8zMJptWOhNiIUHon++QFRcWoKoRxL0fLQnctGlKRopNAWjD8YpKvgdD/X+VQHjq/n2YYqx0S/fPEJgw5QyaVsqcl5SqCH6Qt89LiOBGbbszujRyZ+YvFHhnCbgsSc3UxKg74Ux33u3qJPOIT8iymVlrvCxvnUwI4rkUTsEvADQ6Y64C8t+dQLwmBp4MmhqpwUJCUvKWewhHFg6e8YhAiOmJ0Eq0i7i0jS1C2WtPPjM23TgEVk9QoJzha4dd/cMJIyJEfv94gr2jT2mRKM8jePxlLVr/MNpbTKHrudlqwLioZuWfTL6ymdPRm6HzCTfSt5Hwcewvm3hWSS4BpTkP7cLvgHB1OIRz7nJS0OkftpX0GUsttZQIrHOCmT37bfPuUXGrKcfZPxK884GNJqhb0AskwbVTu7hGd/50kfl7zwTLRMubpzE5RTk7MR6US2gTbGmEAi7mWTAEEfQSodMQj8iIdBZ1HLhDr4PlzQ2iRK6EFYwHACh64sdPMvUhmRh0MipftUccXekygng4rHYefg6+q8Nv5QyON+mu7S9j3NsZZxEP5gXmLnuWgsWMq3dX2DlIa4NsIGik22HPAvB3iN+j60QtHVBfCK5FpFe1utAyAXRCsHksglhxwUgv4hVD8iJFdetmhvbSXSSYYHpabNObMuNGqtoJVdqpaUgjqP0ocX5zWZLqPPlFvlTF+OUF0gmlXeX9W42KPlpCpD8ZA19jB5F3lbxK6KJZubNi4uKbph54DqG7xj/VTdi3BDwE0Q/I6G6jbs1I5Xn6C8Bqp5tDVeSKx/mnu1p6EMlGKsmLP23ulT1SEDw+76Ig2pzaKXi+QJmNDUbWQ403gUiBAkaQkeaqWYK3dTULaXnT4XeVQiU4/Xy9VLwUGDNUaxsMTpyTMph9dWMBKzIx1bM5uyP/ubi/pO9/INHRqJY+yO7sqmnw1MEKMDr74LnHN68FnvSOFcwQhl0wdwQvpJ5K0G35mtsC8E1NYLUpUM6RuVMTV/WDCerHSVsFVUxvistwO7XBEw6svvXkAGGplCQ8NRs+hW9fIumpj/aQMiEd2s+YTOqhG16E2Kud6rLrA7YAjkXDffEcjaXW7SLBru7AsdKbV+jhZQrhThztpjomMLR7t12DsAqeqmpRhf7WcN1y5bLgLYKHOLYqXoUu+SThxxBffvsA7Nv9p5Y8O9CGaHUEdZgzdM2Sb9DA0QZ6br3zvMJnsV1EmK1fz0C3VGT8a7soT9Wm/SU8HmxhA5rzAOmhVcGE88zrxbxCvA8G3X7cjH0g7u68fXcFv8jBpjv80SJCONgt3cetfP3drV1hYuSYYQhFJc/9G0/JVoGshlq+odq1vhc9LMpMF61Zu61yrTSGw2wY2avGJhhFhJBH+z+UpTZvelpLCCnH95YpnCVHVU9yUJFA+t+wuP41h5xf62ATH56HXj8QG/jUbXGZIrhgYaD4GZv+nnYgAtFbi0a0TRyG6J6nZD/AZBJudpDVmKF6xpYwcmOSXDLnjium2adP0h9HXjOZwnQxAFAgfNmciaGHjjw+VJQSCUjdAAV6N22L9TfrEw82+0N+X0OP2jtJisYK7tY5cjteIVmhlrZ1HLB7Qo9BSrhhKvwTfSl3I2sBlLHHzmZsItdJvlZyqtbbp+uKlGEzKVwN/LHedHoO/cdrT7D8ZHByUL47GN4iL7SqEN+5uJQBuXcDl6nm7CcErhr0MwxWUmTy5FOhEDx/pXdl8FuaiP4/EO13Du4oUxzSfEpk6wAsrkyTGQBJ1U4YcxDTnJyTDCEImHwPvEWkWPYUaJCKy2T63jUYrwed8jNI/k70I2AQrrBAoPEz0xVBy0xFQqOfhqDa8zj/ybsEWXJb34K5GRmrCM2RoqVC1IoQw7f2WnBnXW5wA+mh7bDVyqhDR/UqnO0Gc0ZrUiNCuH5nSdDQUOiqPeYSX2UprdQV7Wcb8xl6tX87Gq/W0iE185CevTjn2yYnb0tqOWevXnwr3AteGe2jlsgj5mjwBGIZ3TKNBNO1eNezfkZvcfnrKrmmHAsA8X267euEIEPeoa+7RKFczRQmiNQDj4QS+Bkcg875GaR/J/bJVcyktNTED9NBnHTSJ6Ij60c/lO7xlfE6ZRAazvyTdIhQJkF7It5wRruhplrT2pyOWDkaTUwXmEMdT3dAob/qQIh/VQy/UziyBQbe+1sY04Dgv/R+BbSn4NQya9aR0Om+kaPS0xdHBu2iitmS+k64d4sQnfOyJASigyieIwnLLyNFfPyx6oZ9+mwjkQxIxMAuxI+Hw2IfbkoQp8xJI5esROZVRfFK5cCEDjO0MpRfPQ/0rlAW3mscE85OWJ977Vw+uH4d2mzqAf1lDuCKR3WMIAt0XUEjYhq0Qn9NEmJKEYLPLE/bG/KCYb60xJW1zTArSKDZdc/suJsUjrZKY404fhfov7O5aBv35+p++0SYCbgpBlGVzJDeMM1jWohOsDrLTYlng62FKOmmJMDCP0NMFUIQM9tLPHxn9szRitsABUwhSZU6ZAJbZUh8eu1LVzr9EZG4gklN45ssXLPTZo0wMsIxvxNcAvU7J4napdOzoEtoRQFYbegA6VEC1xIKjnpsvP1MKFMXAk3vydujeOZFhjy+WXNvPcxbBkeXL1UlXf2mRdCPJQ/J/1++JP7+ANiuviHc1QhfqB9WDIBX1jxOqSOCd38qSRH6cS0jYGElIgGDcPSZmGYX4j97FbPDS/Iq5s1hzLe4S6g8ZiIvGYtbYwXKO8jl5e774aUtiF7rwLZcWE3Bubc5uTlqx3bKA6W1hTw8r1iRaYb8V6KWgTFbuyAWSramHxHn0L/RCxf39R+shv4IkwKWYRxHCZlSwjiWKgsphAUYDZbGiHbn6OFFwAZETJQWgovEDiwraWyVEjDGKyODvcJi4bK57vKSaU/So90dFeMadDH6KxAvgVcGs3R/Ug1+gTdrNSdsRcYwTobUd3N9Br5dmpAtCP08ddmoF1QxHR3C7eDHKdIfWnGrw30IXaeoN9HbZOis6eB0sZvuX8L+XMDv/tdHE3Co9kxhbrwWOFmx/DDBz9YQJd3McWhPyLqiXJyrcYgU0X1Kii853gGYsC8ZGyIE15CAE91S1di49b0KVxENPBxE6m7+OFRNZcmRY6rqX7ftWpWDbaH/UEW31ZHqkaK/XOZLleiXb9XUau30KHHiMx8dpWZQ5Yi8zifQr567XLZ8RbUndc9BkEUl02SnuqJtGhQY5yMMcnxutayX3v2LdGpAIlTTEhen7KN2MwBByl92i4ld17E2Q9czNPSI50T9R0R2LOy14x8hM5uuxdwucrG8QElBfi7t6nMCd/LrMIxe2ePB1FylmLibCSiThLIZVMGFPP27YlK9R0DauBBQv3x5CN9Z8KyzM+FjnfQRj7+lCeRHIAl2G8BeQU+eJJTVkngt4sYIx169K2h10DFTBg871Ahe9iQI4T2NTY3Yysi+cr283QryK/udr25hhrwfmBdg9qFBzx/ex9rC9fKojjcRqOY6RcSaCSPHSO63gKIGjidbzEXMSH+H//4Dp9B/lrwEIkBYiKHoRFLOUiA7hNR15Z60EGQPmwgjezi1OhNu/uyK0QYd+ql2HHtngOEtqoHJa4Exjat64xV63s/C4k/AUvYmexbP2cnyy3LRnjryz1oH9yymT2pD5SUhr/ErCvi6tJDIX9zJalzHpvPjgC49NZBuEr/PKm1rtC8gcAIdNa6hVHtDhnd115m1i13P4L1FBY/bBt/B6OSLXEiFf2Vr+GU4t5JvFKGm0I24ij7cw+FdVw9e1+/gqvhb8qyGiaGVJsGD1jtnTiNNsdQSzwC6rfCdbf8GA7CcQw5H3o+VBTXYF6BO99DC8rCSzKPQzpY++d1AtcNS2ZtlUSvH9XFrSlOe6N/g2yBRsHfn3KvZ6GLxA1gPg8dJ7vuGYsLIUtDogO+ovs9F8R1uXdKAj5e0h70U7v/ShatmpF75vgRhAxV7SlFHT8WM3LEmPCWK8JZE11HOyGezn6W/ZItcSKE88E1HGH1YV5kdNlkSax25m5Wj30og3D17X7+CGMVBp9f+Y0u0KqOpGqhiTBnX/YFwZgKXV+O9+laUxHiNtlIyCpaqAUNlQ9Q/0dMznUOyftsH6K2OCyhx31Fiyi2ZFIEvPF5lP0I0F1UcTnawkGEEA2IwrlqHqb9EvF8cIPQCwR/5vYTwxKkyD+pGILlVruHPPkSWZR6GdLGOycvgc6RxAl/fWCoLhF9u+nY8G2cEPDO1YN7yLQ5gigpD6BDhu1eDiS7K1DaE+MsUwDWFQ/HW9fGuW440R73+1d60taeXCp9GxM92vXlhg3xipkj/iZCPqOAYUhoeE/Ay+mRSd1ZAu3aODND72X/4gez1fhQ7UtUunaVx0KJW062Pa2FeAHyIUcqkrL0MIeHGVIitPHGhxEN5hPN/C9x45zhCUa6ffhPkVBYGvl9n+TSkMpEwO+ebEqzWJhJzLBIR3N5L50DlqbY1bKvumtBZwApGDRIFZ2EDIK9A4YWp4NJ4jyspCrDKGJ+NltV0Csd3b0ZxYdEKiC5Z3iNKOalbaV1+yfLEFWueCZYRjDW/Hyn+uw3U3MTPIwtWjU9f7wwj/cu/TbwL2LIaZazmf+9ounVy45FPx3o1cLAkLfTdrDpZCi23VnCWngSqoChCFICvRn99p5xsc+dHZzQR459JDMHAfIc0u98FmqxGBWLOsJulKzBVdFiaazY22CIyV0UTOWS8qyWlUQRehQq/cbO+WHrWWTpaaoj52lo/4OTis5NxjTcUS7y8Klh5jeRWyW5ddj2BCiGtcpjwE/eHMRkJKoDL7v5UIuhcdd3Nx1yMpxYnG4R2wXHh+5X3VxQLKVnXHFj6JFi54ivhD+n4XyA+6BbBeMR5RymsgCFdP8J2NRlPUPBupIME+eixUv6zH/5evwjHbDPccW756lE4rGKjlirWFCr92DZq1LVSJrzA6MbCx9++PqYvb8obW+5Z3D7mLkc0+qOyycl6XpLL0OSY9qOoE4A/7mS+LceURdCx347oYY3BYovLMdQP/Ic0u98FggFZBOB9249+/m0m9wX4g2OrnKGK4emDR2q1MOp8hvk5wjvXWm8mWoUPct5oWi84fRxgwzKsYq9eQisw/uOmSZsrYmtFJaE9CBkoog8lYWov37YiypS0B/5IynJJ8yulQNcuMlvDuFoOGwSzPlexdBnoDQkKr3TLUKHuW+OqLLay4Lw0PPlzvDVlXQUi4jhnVDkSxNgzzjBHY+dP2idmh9+yZkjg1ssbKMRCWujyJsoEQUc/24fxWNWOxiOqgqdNUP5MsGBpYm9KxoMDRqhcU7zFgI/Un3S1LRV9cvuCGLl8JCsH6IQNXedP13oa98pEBFUaorewVhxhepY1VHJWBCQX+k03t5MT+mL95GygVfRwX7oI74wcRUyNtqSXoqTTDrTbGkNzLu8xxl6PLWbe2+B5z7aOt1Vzj4B9oBMWc7WzPMqtTPxmqHygFW2D1wAyrKwDiUGehFiK3aK5liKEEFag4HmtvixKJvOncFZsKwW2dWfPk7euQo8yfAp7dCJ2hD1iqF8f3o+EIFqS8fvI59uetcDO6KvHA9fzuqewXddwhO1BklAgj01LeYL8zr/hM9kWNUH9/XsoZvWq8se3uNwAt51Q9fq+N12uVEopCyRf3u7jLc3DAWSocf+BilKEJv3HuFeuQSxqFA2Bm9SZfsUNORW7aVVR9dXgLn3DiNqYeeTMoBx9lxhk7+ar7oDX7/k0iZxv+CG/Faph+aqaiGQ0cufecbC1RmrDTHVBPJd9GIyvp42vAIUH/x0qmaJECk7uWj745FWnda7RXBgz2rYA0c4vLdP2UabCzKmYvF16IrzFxzMRnq+lr3TdxL34ZLIofH1y/kk0rlqKVHKPcjRDySYYxGueAWQav3RdTqPmY+RMdFDvlNabFXNRFSg+Ei/Qgs/5V7exsNwmyxE87EmjDDngzJJpXLT9xg7GPFXnlmgApxVzX57P3d083kX2FKlRHvTwwznnai4KNaJGxRA0Gel/UQgUarOOhuEgfLaxYd1ZRj0aROPIXo7w0zsJxbF0t+CAM8aeAS4xaRYdANqU+pDfPfZk6Ee/M6uu3RDgHgN3qz3zkrQ+dQBdLyK4NuFi8beXSRtjDRA4U2fAfGExgG1fVk7Hc4IQ2DSH3qvvGy++NsGyCFvd8Inyk3yRdBv1uFplbLssBwXZNiSbEcz3FInQMXUDdzH6wINrZQrjWhCKtjIgqocmDinL0HoQJo1jdQwEWkmpIE1BYUAR2YSAorr3L5/QrUvcWuX7CEkGBqi9m1ikUmCedSnzV/+DKNcul83dEy/Khx03Ns9zhOahcyd2WOkWIlFuYiNPL/U5pHca9xZL0C9uk3XcsqJYrckf1CcOVF7XxSChnGBE3XjqONnqWTbl7NeZrvnoeyB59VnOXC8uaf2n0aanUMVI++liTqpcqWhPdOsfoibNvWKWvobYw3lzW7s17we7uxRT03MG1/g28p4veVvXw+1d5xzpcVG6U2t7cc0D07vETwixq/YKWsSKwni9R5PjGHFtr0WWQgF+aC3uCMzN/RYSVZVXr3omJj4MD/2tarnleSv17z2k51L5Ls5M7aYgeNvbphgSOi7hLdHYrakrLbZ3ZxPEU7KieAY/kZr45fGZ58BKUJUcQPT177eZ29xhd7MtgODf0e3hK+oBXXayQhZw/bUPFE/uk/sVgD4PxZP9zE17sq60Tj8FzktoEeQKCMZT1RhuGEMSvwMd0gtKJb7ZSa6nwr+us+V7ziKnaUWd113a7xaO0KVgEGxkuNfkCeaHVkRRolKeFQbzRnzqveEliaKBnXanAQM3s9Aympe+U1OW+tW/ditGr58r0Pc6FggYCiQ9iZrPoiCH0GzSZE4IT1NA20DBWrCqd134bkUVFEZqxPj7mimUWVoaB+XAh162a0NvW5gKUdLPUycfqu3xelrCx2it4hoyufxkNOhtNRhjQ6jedEemlzQVhKPhDx00Bz8jJ/IqfZqFcwJuTp06VBqDIfnNXm5L8D5kJrHuNv89KAvEdj+XWFH9aAkbn2ZQ9zEqF7866ReAT3C3xO4BlNprbR2wPCtBirXWNJ5MHLQgnsirTpdIDyW2stCTNdJ7HSDiu0IEg1QVGw4lVoytH5nebxZfqTGJVrdAou6sNWfu+0MkG0R4h55pvH1yjYnN+oViXMHLTUwYzzeBywRcG9qgIT2W4cJAW2HpKKdRJ0vv+DhHU7/2WYSmXQxzdkf/c38Mex7PNlzhELxLNEKHyHlcVyrdWXr24JgxLU3W+6twyzUNRujwgZqKzCth0x2v7kvK7TJPKJGYCiqYoqOhE6iVTAfhjPyjle5Cquwya1Vlwh/UVXVxq/MfT1XmfaT8EE+4Dw6M/UlXUfyqZajV10WHsuP9dc0Nw2jIBdxwHN8bHuCCEIG7NP0Mu5TNCW1ZNdX+41Z9GVapctofBJ64hheKXJOJlDWqu58LuPWB7Ev44RUjY5AviIds47tPf0jmtInisCRLVhph1Npn+8mYIsLDjFpVpP2oTp4jtEtWtevs3t6XNlcyeLwmmhIpY8ArbgpC1Excrw+fDs9cdfqTv0k/yIm3k2GhS9padn+hXAS5iL+Fc4Q+6QER4UmZFXsYhVMGY8vHPQAPQPTAbEQ+jZ1M1AwxgJ//1vE1W8xu1a2bFXT/j4PBIfYfjpSCjDhd99Gqz9nqeF1q7wuwwcZLb7RFNskX3q2q1xGW9/z0JUNaESfbUZzQIg3Y1GB1m44LR5aDysCJ41oyDV+rje1mYyB+rbvz5ffWJaDT6Wj/7+GBxzq8PsqQZZKP6S0Bgb/qHfTnD7X86+O7D51LjRafGLXdyGZhdwcZKTVHBtgCe8+vYR5VbtQvpCQtRrpC1qMPDMs6eaSR0zZQg7WpPr4U+2aaud/+D80oXOwc5e27hisL1w3WZAx7o60KtH9Z5U2CP4Q1upavMv3rQbxu8YzcEWbSSNL3FnTHKpLxRkwhdBxsGNhi2SVQdMNYW8LdtsKjctqvOeWwDpxnAInmtu7FuLOJXX0uOt1hvKmyEiDZbA5TIZ1WMTsQIOER9893iC2cIkRoahtC7tfKWhptFzRWdEQ336b4CGwqD6QjcZJIK1zSvhOuAb71HrSRPfhahlHN7IXuG+tMfyciGnsZF4SF/CbxL6+Sd5AsDUwggxZL6dfTG3V8i/9Dx9gPy575evwnlA0gDqLuuJSEzBukSN0isBWANZKDgc9BNCBi8wgEZ4rpqXhJUxXMnhx+/0yOeKVfMq1n35ueC8Okyp6rE/b/VMex5keZ5btRjSmFv0E+qtmFRRzXU1QjX3o/ZIpBM2hz/nP57fryThhIsFcmQo12pPizGSLdQOYF939fs9amdgQYE+txB+eRq31437DZO0Hvo76mVnUnRKI8sPNoc2XkwO4Bj9+CXVdwXPvG7k4CU8io10lIq9aRcFCWPtBUAyLF8JPU9WqCYxp97kh/LX8C+w3QY6rmG5ZnPqYVUGdc/i1xmOjDbpnw7AfqrAUpJagXtDGWxMZgL6BaCNu/VpyDbNb/iEIRbTvAtCVNOlCf6c4lgKa1sIftPqNErX4PTpQloabRGfkTuSyS1emlgGRVHVVC/i1c/X2dkGFLoABHbYv7YnY5L2S31quUULGJne83KlWmCqtJ7RkoIPhOGe9VfdMKk+VS7iyPWtR/Y+hYlm3IQk974+u34SE+vMWXpwWmGupXiQBuFRf/trhm5PKyQGIR0kstHgL5HpWE4JPitAGElBMWT6g/2r8quRUyhJ0Rka8ZGJfY82L9DCLYHaE1iayySD6ZcUKBQRPWMtu6ICgj213snA5awJHlkj2b0IuFi6sG168ES8V9+bYqJSqywz+vJD0s1sUyhzIRski/fbKwhWpll7jAIlAFNT45c9QV+k3Z7EERHOhq4BXY6RjKP/zXcIsKmk/j+Kcs3Y8vB4NX54D0vNQL8aWTh3p6UIvCZlHI8AIO9JLuHRk32ji2KK9FSBWT3l68NWzj8idyWSWrvkLOLQOr8mQmbZh9qrc0ipjT6Hgvp4z1r28S4CaBrTEy8DBlfUswDEN9QVZ0djzoLDqkYNPnxnU5MhbgKEB+NaBVJ20M281f7VAHqjgCJs8H8xawa8z6x9w9qkPFyPRfjaax6t0TxNxwYdqhSyFsomiT6DXwSWXH45wL9UjhzzTXr8IjkyDJM7anK7BrInuv5jXjF8X3xvUt6uzEV7Jbv82PsNumw+Y350vnFROR/ueDN1qzjIKARn1fSJzbFh/pU56VQvgv/PTeWIFuwfRwQSdZy65Itwbj1Fc02Naf8aZxKXy0ZHtWn5v9PhMraDrY+E1sl4EeG5KzFeTvOvcy3y/iVt8T1QgseA6uJrbNVF6ki5tVRg3ieTpJGY3wHj05bp4GLRQTAI1uKvfHWuM+Hzjdzwu3PIpfq5oeznl2WOanNFKDIKZITK/qW9K7wd0l0K201Qzenzd8QJDogb38MXoc5BvRHL/JuGm3oYPDKl2s3ESdqSTD2+hkCAEDDLshSI+rZNg5dbS7vamy/HvNPKVHDMS1RjQDbcZgAhLLeUw4i1iPKqNbVyBk7fct8uUnx/Sw666ErgXWEDiYlznhUJ21U0a24wwrqTag8XzXdy/1EtcwoKFlF3WMfoNHBlXeLCv0HUYojXhIzSqx8iLUiA8n0fBuAaUFEEBGGjqXcIQC7uNLDxLIkYFStqc/FecFa9T5hiY1hC63M03krog3ZjgCRIEndYAmKYU36MbqdCWAxluZ5ErBJyedGg8a5oAbFAgl3v7HPjHL7q4pCb7LZD17y2/M5wbe3Bfqk5HmUnQYYB4zXAO6zyp3V2Bh80GIMyH7NhVBbIw882N0xza5h8vaz9tY/xfJTACPAl4UzL+8YPxzx6vl/9ZiGUIqsc2HgLs3OrMoOt9tSv61UTqgpGuOJEOGqwDKimnykJIQXXtKMkDceoDOJWta/gbJuUl+szPLYgXC/Ei0EYCTsI1KefPw/X0ZwLAG1Q/pUsPSr6WBF0T2KHyI4V+XiKvRX8tR5G3lTI5C+FywHXTphzDOgUM+3XDrZTk4nfrG+UvcNOCxYChkH8zo2Q3fjc8re+BGVn7gIJcmFkn3UB02tnGeNL4yWCZTeCiaTW7spwCh/zQLwi2abB+js8SmxwRy3FE4f11xp0xzBA767qOi2ufRJ6xk9DSFmXDlLa5MRrNTe/BfYUlMwm1K63xBC5tcaY3fZvMEUoKL0wZfz+EJe0GtRhk1UFQsjlwajPWw8u8HuZAzsCqT5hNxYnxjflBspntYGw0b73Z+mlVNmOzW2DeBYg98lMow96hg5c60bTFDE7FGhG0ZpZrl0QCWOXy6WBvV36epoV9QZTYqWG8XG6wmc+AwWn3NjJFWIP79rUzjZchUZp5AXOcc+u9IhWfHGcDOpW1TUDT0RpMLg6u/74ZTvS4L/jcj5u2HJERNt5hkq3fndz24Uc5t4hE1kzK9XepdofGkWI3nAsZ6UP8aalN/9i6DPfOhnFpsimkajesFTSIwkyrehtOF6qGnwSoee8eiMpmPA36SxmkI8ZTb3ra87EgimuezhxK2ygSAE1pn8jQJTnZwS6/TdAkPVuyqTHs4D0Y7av/K5rcajIY7Qo43b5mlFbfcGwKdGEe1e6StQpitvw/7HuSWSOpGwxBxfQHd4gnvw1ogRbI16NxMAY/Q/JIpIEQcC42dPrkrWoL0H9rXcZhZEWJIB9U3ccRZgrFYSwy5VDF3egyE1kUV5jvI4SgbuLd2qD5CbS6nzdF7MjG3NxmOv1DRXyp2jGHY1Z4mgCEU4q7ZFDvecAFW4MfQp/D4xXmll6Ifkn4dhhyYaQjFrEnjmgFmDLoQiOBA8EgAusRd24XzxPDiU6peb1xpIk0nwCZKGE8LSRPpEg5nkEYyHrAsmE0BJITQpCLhoI7zo6lFpM0BMLuSvgGk05T78h9ExF2TYRTmNsskJ5sHAKdCfUpkD/EziPE9whz5kiOlhvs8pShJx3YHJQBqwjnR4ijq4ZRV4IKr4XMW9fc0Xhty1RJcpMtohxd0AdoXyyYrsigoP/VrMi32LDfCTyOmFnagFupMGfhMkorqGw5yNHrsJPUDXtDoQ6mRTSwj1W0JGt9Nr9Nh4Me/IzvNrkvfuswJi78e0TyKeClJEpC/lFs+/ozppO96wVvv9Dx2megeIfTkDRwo1FrxS8BYOW36FjE4cTBGOX5jR1K9EfqID8LDlMoR6l+vY+BMCoSO4+zTE0Knes9irdVt6aNs0XPm0ChvYHJoar6jNd9ZpM4hpEV+gJaXXcdkVeBWrwZ4aSblhSvBR19NgZ8/qEfQJx/5GolLZ/Kwrx5Iu48gGqEgWIJZhk18uuvm0gZGnXiHJI9WHubbSDehf4y48FvS5LwxF1SMm7bEqiAJCNZZnUWvS0OwLUwWpohCSLXRCtdL6kdOM5Yy83FbmyWgir9FqhXSgz0TZ7Xeocc1zbBMOzKWgLOFJW1w1lJwbAymxIl8beW6eWx8QgdKGdQiDgLuajBUx1eJk1azP5VNyQ36QO8lPTcrsgoiR+PK2QiJcdiXuuYEQklTP+NRAkCwLlsQx1V7jrWzpxGlJkYIyzZs1I1XzONKoSbfsGvZcPjwelVGDaWvxjeH+rSUG786SExegtOsgwxE9pA4W+KoT8MJl100D8m4aJaulm/AZwEhlUK/Px8bN84St2QDKjI2cCStDp9o9qsVioLlMyXOEKPC34kg00fmtFoahUUY3gatYxPKKidPjvS1tomOvbBBtFAf3by6O8XhDilk9xHE5NGdiKQyPMeiyqU9FS00mfvqj5dm+X1RZqYtpZv6Jox6IxFo1+YZlK+nWPwaSBAMmQkZi2CeSkvjxd3uQT9OXbT7YTnNWhMQMTeOhE5iBnzdwBVwKmrjsj7y1LAiNdZjUsxk6GvxgjizwUZl6HfcmdAcIXuP8FJJJCupbd/9uku0ke3igDlup2jhgorqLDcR/6XMdf0htW1F1YAKt08fa6NmAPRnjHslECND8Auqs5aem1/QigrileIC2pH3JXUvV/hNbrVxwbCtx/XYPpx4tUcOEl8WOM6f55FKHo4pDKjKgMPOebCzAf3lpXvtkQFDTLoSuhcx1/SG1bUXVgBwU5F18GD73D54eQWlh/LLluOnoEBJobzgOKA11Nh8tOhCHcpEm1tiD9Tkrmsj0qIG00wbzbcFcuAPZBxMMc2cyE+F9Jj7Cq+GqNvtkObAKVZjoob7yGY5ESJ4jwlNtaqlrMgNgp9mIbKQxSND6hAFzK9XNydio5VXonS8JCSSMumhuafA1owa+cycPEETF4y7892CZtE+T7i+85DlTMPqT4bjCC4L3xyOqcv9+1pPsB04MpQ7SWGwfgH+93wC96H8xTiel8r52Yz9mjSSB0bHp1JHT46K6OXEvDz4irQGgLrPqicWd92fjd6MEH6NkNjlDT98HwHccIOP+13Zw8s+2YX9j0m8+eXReM7jKzAdTbVjz2hjb1vQMqNwIFN/7mwpun6mWMCkrMTrMQVOQOkGMvRgvQ+HxkvdrOZF7DPTCOmV5le9jcgU5pf1s1RE4STDTXxaUoGtmJL2azq+4trBjGyPsaTbM/Ml/AtWQ3JtrY6pAPZxnaVW0x7BiKuW2t0y+reM9IyOJtnHLqRr3zhq0fb+j3SUtQZriPDTTCU3ih2AgFe4f5Y3+nwVky/8f3o+EEExuzlBZkIaDkvrNUAVg0tkKzTRJunsHNMsVU18h4aZz6H6zDKw7EkA9s4kVzT49O9JjovjtqtItOY422TKSQgeRfxKomfm+CvMshzRcUcltd7vYAizAzVt1Bydl76un47WjCndyOubScGqrOEOf/qgcY+/YWAPmfk8u99NvjEf7a7+qUnipsW+ZKmtjbj+q0oSbgGNiM9puyyx3qnJO+rpiUns2zv1nA+65WkG0eOyUk90YoA93tPaWg0++dvEuyjxfaOJuTMAnmXq6UrF+eWJhNM/rweRtBWp8XB2s6wrz5OjF9rZcLckngaIM+IsEIa+oYiOCN572XAESPx4wg0gdD6uphH7duNdCASGl5kW6Gn6fiKqOTknlUdtUbB1ZOPXTdatY/cT5UEkXQIukpu/ZchlBPmFuw6zb0xHSm62XvadVzHc/EkCzpjfMEsVK+it0o0B57rU7H32kShfOoSfiIn7TlaUIxoJVC9nzbU321ByEGhi75qF2cvQ82J7vq98ieV3vhRIGPRYPUJ9EvuzbAhN1fqyDzZCJBhXCEl2cdcEVkX1McUc2hWMVLQ+6ll6g6fv29cCEu1yGOdiaOuIs1nK9gMdvRzZLrtPuRyjtY3fegK7uXsGe/R1KsW0zKyeh0IUGE/YPVerGC+fvn9nDs4KcWcSGcY8vLfKcYIJ6L0obZleOrbSw0dys7o5uE2sPlvzqbvuWkPQB9QC0vboxDgmFjzPRPrbKsEE83PTDuDOu719bIZyD1yuq4Eyk5LCHCxC4XLqrMGacPgeJcSSic/kfvreb78fiOefhXMZuTFm3bUMJgN4kmk6n5mYTc3xwsYBKlfVS8suZbzjyk3tDJzTWJ5a/F+TE/okb9WOrlPX2V7wunEBDD++F28o526D7hcLNLliLZ6ciQGkZWXjjbMXtYqrgMyY/JzMB6Cq5BJJ+mK427GiIPufg9LItAZk3NBkYwz117SivUCWZCbFxMbBG1AYJIGil7+dzVlz5V55+tJTDfBNDuElcvq1zik9O5ZTSP8Ns9R1I2J46rx7QL2YjE4JJLOwLHFspyOSgcOk3+R8Se8UUxGOHat2+TPGVMteQOuvFwqk+FZofWCAhL6PLCddO5sPmdBEudaQiUU2m/hnIK8FE1BF6ol4/rmUrcTKdFf8fNIXw+Zpr3FqmfKz9Es7WVvJpm5ixaeNc8AJJ19HH6zgCZNTca0KnxSdxRUZniql6l+V3H/ZrcdhbD3qGYwX5PBGJjS7DwgCwVYuf5ybiIfHnWMvPeuL63wLCV7aOrmGKIz7Li7LRj9OAQbFGIh4nzKvC0eedqei5wDjTCoG18niCduidaMAEK7kVSgxAlMxqQGMdizEdFfi/MkoApI+vtLAQBDbGACTlrwdXg2ewuUsLToqmsZsQcUQv9mMglampT/cEfY0VkwR/iXfkrAP2JbPut5mGP5mV68rQS+klRm+nEePnHHHr7rkfAW58OVhQ+fSCGb3nC0V9PvtxrffX+cyCanMGfwgsLZVSJ4AEEADKfQANHVHZXXmBJpYC2rQAO/cJS2abMjfOuIORm68cg+x6z9CKVH6W6dcDBHhLXmWj5oRmHarQ4flibFr4eaQrGjbhlCoecXFnoSTHnScffIM9MWxFcDcoLPUqSrnQZgRpWZ72syzbHN0bMpJ3ZrNPykuEDqUERhCEGCX9DxRhgmayPznkdwYl1UrWR9TRvdm5ZGUSc6gUPi3ofwZ2DP0Gx58QYaZbWYqmBW9fAggLLgSnU1/Gjkvi2YSnaVzW0fC2l1eK3aEGBxHXyZZTbiwzlKVpBtnlSvkMfPvw+9pMPmpT1u4RU/4l9N02r/xmEWiCEbgnmQt/yfEQu9gnUy040iFgkZJCUYYooW7gtyzLRKVwO2Gtjr7VflVV5bUCHbE6mac3qzE08QN7CMfeEvnZS8MBbEiu5lPhpJgjQ+BQMNi7UOmUTgdekzGFEHwbLYO51CQ/UXsvbSyR3vlRhR+YIsVnjEstswNslRx8csEBWOlhC7nV4GafUzTbvLh936Fnlx2rtitvSJFjJff7zW2wlHRRgmqQ4j58d8dz3j2byJyZIoc2G1YA+/UbIC4C6Ji1/Sl2mlLP1Ej/Yu72E0yOM5PsxQs0vWPaimDrG3Ad4WF3DG2Y1sFA6+KzDnb1Dvr+/G/lhoiUsCpUdVpil58xEo5PkoaeY7W9ykQ26oXyAMuuCsr+AdPu1cvIRs0NN3WtbzVe5sz1XVTbOnhItcjJyokAjn7OC+3mn0r2qAmW1+ZGOzLV9j+Pmqfzjox6fDryZEh1hAEOXqRvMJT47aEdveEMiSy1KVgz6/w5qdsMql5oSC0aKRpbir2oVg5CikSjt6Tajoh3akzlnTFNYbdMPStiHH2JNhIEAsPOZBB0YyrJ5xFqtQ/ckH66pngpmheLkCEfvEYp1d8lBdwzU9H0kRApekmw+Gw9wBcsNS8Iw0xSHu/ZHZzlrQfnJnmw1kawHFpKIwq7tCq66K2heNqS0hQEC4STeIN/SbCJKSlzZKAO9dSc6QriYgs30ABdVr8WO6B4o9sWLS3yzt0nGp3yrlJes0TGDUutuuHSu2yeKw4jjl6sfsn2FvxEUiIgJ4lkzDaFJ1fJ5UxGwS7zSmnsMvYdAb42uhuehCurK/swdbCV6ClFXHNVgBeJaiAJZCh6UwHwxkqgr0g06NwHIZg0XXUl1QCgg9SO8O5lP9Kxvpg+FJ48UnxQQTWcdSa7rXsecNV1sIrTyQpPOX4Oq1QA2dgt/09xIdmy3Eyq2nf1vruYss9qlA1vIG4TCKbvs1on6qdslm/O1poKDnzpQpOWsBaIRAwTywbs3j3h/BG8Gd5zTbog0wJ/ztyZre4lgOaoUN3DGs0ggSG8n8HLZZTFLmCwZPR9jCXf2mPryGaRjxQxYzSNLd6ZyEbxl43QjYyaHNl5MDuAZ7A5yN4gDcI+M7Lcin/0F4NGdTdiihMWknzb+ZIWkGej22Li288G54M9VCpjNQ5JJXsXOhM6r4et6Kz12sRNPcDtbabJRxIvqY13TIg4BqaBbkLR9Kc+E4OqvqA97vQWMqXesZSnSq83GDvcLL1YFqwqAfbFgXWUC+mQ937I7OctaD9E/rm392sCOf9+nCmLSURhV3aFV10VofCfJBADFMf5uxlRzAqCOvkL1KDyqovxaPhxPmO3IO9U8S9ZaZmBEcJejQPIMHm2Ah2zeCk1FuHJfi7xY0p63tgSv8WjKHUv5/qcRJwuW0ZSVWWILC9xnSm74bPuZ2DVT5P3/FZAzRZyfvTuyEswg5iZu7Z2h5uh+CbTda7AgznSv32z2En37TwwjFQLRj69juOj9+7kVFSoa/9h0F9JHS6YSj8b4dSlgxZ8tlH8zuruHmDCjDEOQ1tqdljaOtKhAjIX0pxTIa6ZobpzzI/LFQygbdAYTRnZ9QbFJuCFI0mAbh/2RX1JWb+w94jhpn5mt0HiUWdr9DWoiMCOStz4L4+xR+yLSgKZdKGHl7U4Y2r+WAhsnaiPHK/eqVmaOluCxXSwNDKmQVnR5xdrO9zS0O+gQZpO/H6HdscFZv4i8oKqloNscFmn00qAJADPFm5GufuYARUri2Je0NPzhu45JHojE1s+2c+F1cER4rHg1DRMxD3JYya8QcAgphWvubSHdFiWwNXW5DwMy3o3izz7KQvG1JaQn/wAg35Y3PHanpqfAIZ/nVrPWs08IDmvaEz5BhdySL2wAzQbVBjBo6SqqnnZXgFsjRKOA6FDE7mPKxy/TUads5QImDKFaXwLIAPlXYarVs+Yi9sYJzuQvjEayF/Pj6CSR0MNLH327szeeP9KWwvGJsCRTBp8nPI/vy0hYl/5OI6bwFu9PPOZNPnh3evmipWp6UOWHHqkbmVy9jJChFkKxbMZMTW7p7UKAo2iSbGmmAFgqteg49RduHkWmuLCAinyRaH3q67Z3tsQBTstL0w0Abwtpn243KpSjNoM/TOplFOTkkaCblRsSSEBiD9sPrIJf7Ok3MA0qMPCOJ6tC/8gPCqHE3vEqZVOZsjMr8d8Nw2UNg02jp/cf9pz9rau49QvZQAW4gfGg3OTBqFkzyGuPdrCB52S136HGlXHfW2CyFUcXuN0UCSazUqLv3WvrvNySscrEmHOu+2K9W9a98nPn8cZ8/N+c8O0Mp77L8tZzwPvMSuI34Y6xfYCy2zXvc1FELTiqY9Q4dx25nfMcGfmcI5k2NATT66NHiLaRW03e2EM3cFLBULQ5/cvvauu92shPhDfn264219W8LmUELr4axPQmVOK2+i3D6GsFuAq4IgST0nBt4lhSkZ9DBgM421jwBTCrkCsF/6QQdrK0laGkl8/8xAQkKvBUqQdKWWYbAeWrp8+IMRZD6g/nuLpb3GSFC5qZoGGIaalSoXzH3dE6v18BSnuzoFzD5BnwjxtINrEX6L6R+hwyOumalQXWWgotpYTe0GKhBs/85M+XA0RZhqdvd15uY38WCKemFJuFJfZcSKp2+8DhLa3Ctbazym1RHAKw85vofC1yoeuYk3npt47fgUg2LcuORT61uEejwD7a0lu/6PjG3xHUxrtTaKhMLmsp8M8EShqHVUOKSGH8n2B2Afk6M9FIFiZYHVHmSPk7Hf6JejOZKADlHzC4cAL1awSkD1VRuE6Df1ZuaK15CiQAyKx5TxLQKjjboTYry+Pa5kNqrH2ec1933BB1cTVvNfzDAQVqpS2c1ArteBRwtrVAR1zod89bOe5CehJPWMGIH8ogO+dOh5Mo+hXYeCkYwV5ZL4WnaML5giGQSPHfFe7uHFkP99FQRn/3m8cWSV4pqqY8WL9b/h+ZmVdPaIIVsJ0baOVwo7vmhMg5p8LoE/rx8d1dthxS9WsY0eKxmnEgy0Eq/gCtKJu7hE3mMjHszjRYS2XNSSBE8mGoL1+EEp67y8rHKueMZ5/JeKYZ479vhfky6/XnZFBwEaCdmEGq1MOo/k430ORy4D25Q5Rtmbye0KIcCzr0kNGcZJFJnocv34Vw5+9lp3CvIMGc5XV/xwWCOq1cbe4YU8EC2SX1CXB6GP5nhnUMDbmPkFgozali9uCxZu7cPeLJoQr0aqEgHdKIzgHBx5rg11Kv+jmVsFoFoGsquExncjR63K+pya09KqV2EXVwBqrtTwWDo9kISBuPxr+IRAVqtgISAhJ3I7KpXJYFByyHt968zg1Tx4fHXgIDih5pmihqnkQdSMkQh10lW1eBrFiRQZNnomih3anADHPxaS/mui9rxWVxF3FPgc0KyaD6ybNA9hB0i07BBh4DRSth8cageUN14GNiEQ4M4mmP6pJ/GSbp/a/gu5wsBYQOqj3FRNZq20IewDw+I7me4pWVwXrRWZO59Exo+dY9vbdD1i00zlsxgh5LN9jbvGY2HFjdemdPTUVrk9nr5PTLirGHXmIhsJhYZuIk7UkmHt9DIbhLecffSnLnF/TMosdqVfng13EM9NxmzokkJIOPDsrdYlKABUNVEactWXcbRAiiHtB+VkY+/pPp2kGO4Qx8YB6TWABrNp1jpFdqF1LQaVmz6dHsUr3bWeU2qI4Bi4fwbkhSAFqAPvOuprp0f7cJxD+DvXUp8ynT4zTCanOhyyRhv4HJAuqltAsiTKGe5f1VXe1PtK8zOx2ophOtymoZM5/VWA/GIM5ayknq/CxQ1hP8Lp+mjmHKqfiH45UX5zTOAAgYog3ukhWOQjDW5vvnkqEeZonWDpYzdfy/LfEY5HfrbgeI6/342Zp4NmOlq/1XgmxTxiKgAmvsR87eYbh+NFH46U7HOwtZ8Bz9ktgY8HKr9tkbC9Oiidm0bJn0E0D3eVWIVXa4fG2LorJloNdC73+kytaJvpS/gWMPLLa9QUdUghuKaD8Hz7dKX9ohsnorZx4dldkk2zn0Qul+678jHqUyfl5z6UAlpBjuEMe2h/CGsi7H3rG7lPfqouVFVUYAhmvbtbTpWIEEg3zfhfegBHzjIg+EzgpxRpQJe3+kA+k/fwkYFHETVIN+mxBGzSWEmblfv8P7o8mkNZbi2tJH/5bDxwhfgzAzHZg7CwFnzQHmWgRw5ZSM7iIHx4PSqYEqclBEJ01Ok3GBYvgUr6SH/PQrzV3WENQ7QGB78OLg0IMgu1IWAyj47q3yEQnALH73uBG409VaKLZo2LDdIsG9DEeWTq1wplm+KfIVAAa383ZWR+GWYvaErZ6XULJGowu8AeBtFPJUggGGvADtuind0csofP/JxNxmkf0DSc16FWdoLY4i5UDl16ubRsmX5p0pwq+vbjBg6/P9VuEoUjATh1GkywlUiccglOPW+FRnpu2dNE6Lak1PG3FzRq8d9Z8ip9qZn/vaLp1cuORT4LnFP/UQmE6z3PnrT3IplGtnoY5wBCqnVrPDllLyD6WV7eJiPVDNVnxIf0qWEquz0iuefw7z5t3u4cRQwfT7PVLWrVyfoc4CTjTZO8PiCPQdrrzn2buhJN69ks+1krTQIS8kYfEgV5U26hZwZjeIAaR2f4FfUv6t+bC3wg7iqJlv3C+xTCtOp4IVPjkJeYpXH1ENQSGfEMnxy8XrpJTsBZV3tqkPoWVSp3MpoZZY57+QQ56BbLzN0zRpEPxt2zmQgFndjowA5MuLARdQCxn4NFYIsRXyzrtktQAHlsY+vCrKvIMullS24AlQZDAwMH8+ob957RGcXE984uDgx6otBUFl96htYGk3k0O1PTaq1K7X5hoBZQPNOTcWj4URXWwxNoNumxAmKZcxApoDnYDditN5oXxN5hGnMMcV9Kf6sSO9TgvNaYFpeHMG8MA00DNqHQZ/SfLjpt1ZBGbhf4O25IIKTSJYmjcFEEUEhbShOUQaViCTJjl8ptGlZCoMhVV8mlwckR/8On/QNG/SwAt3BBuT0fYwnXGryxhFZGSs3N6GAEx1imS3vkLvpGNotQvygqdlSVotDRnzNf68fwxUkBi2sbEwCTtPkjUaihjbbn2ApioQLTjre4qdXSjnkmwyTsohLgfw+/8Rq8/tUDqJDwL8BMvRXuEjUguuDbWLgM4Y2ausEpSLnm2RxlMV//rHnIEbLTPyX6WdwHLJraIR4WCDyfswSRfeVJc4XjoyVBeHqH1d9yBk4NqsTW3W5NEcxsTaBeVadgKYp/odABVyPbeUUEe22RikKia0iSJH+7qphfsvsoJtwoeKKCpyYXDAQuA2GCKLPuyzDVzZVDq72qujp4MCs4cyvMq5IIIK2dNUdpUKV+5aFQWuhDsdVQzRcNBbiYSZcbAt5mCgSLZc6DFD53jnwjIl/6IyfjIOMViM/6P39+LfaHH57TC73ejuDW9gVEQxaB3TJo718ybmJ4ohSzr3/k4xHgAtPAU/gVmeF3zODInVHlI+LVUi/V5nDGz2P85ZVhVAKFVEAwnf/jueSlPOkbSrQD8Oa2rM0prbXb0csqE+KsXAHOCnXjIq6UrNjUcSjEyIDRPNCtBL0iCeLIRtoucMs9GrsDuvhpsUZN63UYTUaihjXfxhbq16G3bPMgYdg1h5US6KerJKC2bpbg2JTH3BUQEtUTHU+DaGebLGOCGx4knJiNy15z16fagFxSXPu9KM3ByW1Mbr5Abrx69qa9MNRKRne9HbfPKEspZ2d4abw7aAq26/R8YqyH3jLvN0hgtDdXes12wEQoudq/1RxafJy/bH3Iue3QERre2ZBeIgChuBgZw2EyFGysfGVSURU7NzS1e/IsqGoQlLKiG8hfW/5OXFSNMEXTCnuhScbsxzMLRCqObxk6XSdKHJ4vJ11T81+Kjb34PFWO0GpShEStepf8uyCrrBxx4NZxg6Ay24qMbn+S4AiOZusUmyExidjBZ3+zE6815PTf3HMkmsxMJvtyzgyjQ8IIIUXw/xIdB6OvK5/FRpPAwypKfAl7h1fAjgVCbqvkkHCaBSa4GPpm1KtH8Dtfip+Q6pOCBKD54U1bfBVRAMJ4TxtuLkQ1QMYlvnIQN7tquJyfp7R1oxaRDE5dFD+r6QA3kh4owutcAGYT9zL8QCwsQV/JeQA7E0OxemzfcRM0FtmndJVpZgv8/3UZCqljLupX36SMc73EXEGaxSyEIuxWPMyIEgS/dDSQV464oM1lIX7fKLfingBfMXWn4hTCXBl06XzwDYcVH+PAM/eTL6MsS13vVsP7eyG1GkghEnqSyEjF5lCMAwzFR87/+IadgsVCJpfK0yptV1QhkwYhRAFK8zabxQKXuM0W3g71DidNlUHTDV3nn5y+QXZXi4jNDBy7HCkfIbQ0QtS+IWbv9GLiqAaWOwq9fPh1U6B3nMeAFQh0azBqDu4HpQ5sb+vkneQKz8/FdS95Y1NM8skFxOeqoyj6bqnfGkjpns47PnI+OpWNfFDLhdHZJCA/ZshZkE5kK4r06xkis9IzfwAcJYOonIgo12Z5Teu2yNNGR3lcRxskKXSKWLIF6X4piK6Mp85kOR45ffLpxOg1uauW1YTZTsoe4emlBmimMGyJFNVFdImi8bkrElt2o/LuI0L6MbTtbc50w1jG91rwftqWovXtZleGRu4R9lEGlvQ9mULhKDBEzry+MlHlC4SiFTK1xaup5UK2e2WsIZdGT6XMGFtiLJBAOAsfBKG16vOyoPeXm2HfJ9D9i6Z9NkGgqgJpFT3yu/ABm+JqAnUwFUfYD1XD07grVKFaRCcso2A38IV+WXJKzmwMiuUGKM0Ie3Mr/a530yHkjbx3z14+IWb0syplVnB9GNxybTS6R9iJSC73qzyKqqlIhmVA9R5PaekSDDgtaorO3+MNi5nWJGiTDL3rjFpHPho5cFuqyYoIuigFarhRstaV4lhADxt/4hfUejnTbEPOAMYGluamJByFd0sdqKBXhmywIRZ2SxG8bkkGHoA/gbO6na/BD3z9WTIBj50TVmGP84tLDHGB8onbR4o6a/uHvUEGm5jSW3s7RsjX/us1MeijJpUMKlh2tmlu//SM5DqiaUuk5jIsUEaCYxp9/eJlXTRTaSS2j3Qk+YD4mkDx6MvswxbqTWFyKV9gEbqRUnVBQvg1qJJ39zd4QYHK+NXO5yIb0LwZnyxO7pc0N/E4BKXaXCaDe0p320WqOM5FeaDyqvBRBqY2mdpidlJfIslBYoAQkuCmorZm9TgYMrkTzrRtxVavhDOysaKrmQhPzbOWWleXYcTl7+SmEI+sdfwSeerVBMY0+iEVWEZdl/m57ws41G6LusgZO33LfLlE2N6oELLw+Iuajtr4ate4OuY0fyR9iRh2EkiEXMiVbkjmsWoLu7rbN2Y1wzUTkhnGpbxxK80LguDi6sSqK/KnXtWV7pZQA7YpZyesx5h4UC/eObQdLVjU2s6/8Qs3GaVvD4sJGUX+1gLay8YEeeTuSumjF9r3czY358ojcmStAqEuNAG57lbRVUKHe2F+2C7ec/ud6zRbUcWJLzi2CbQq5exy2oyiZ1+G36JbVFwuDO8LwibUCAVOH3c8AxDTQLsI4wWkzMtpKVFuzqZemDba+Ipb3Bj1mwLrJobv14hl6Uzi5kSrckc8VfqhVoCKWVyHjztZ1/5OKA6njdMo4tn3x285VR+opcfK7rbo0XgCQ02/ogZns8ibg06fe1xSxFU8OgG9epLkSTZ86JeGpHH9/MivfaGsXRoR0UufzMAkNJWJAXMIYyjWy/VBLZcNCX16EKGRmwGmPWOQYYiHXaJRfnUwB1LJ+/XLrXdbgWxbbmMDT0MPNrE8PtI3iY+ipf4M7EW+I+ORaSWiYO5emjUXGWbEVWP73GGewNmaTZypFEfGJO7zot5LoY/tPRR9JIhwQuT+CuxON4eIyJfQl/Q50kdgTAbizj4p0UzkJh9qsoCRUwNLy1okg+hJrYJQdHAgbqhn2ekbzsSCKa4SfVibZ+l3XTx17Bc5Ri+C/Djznlg1UvUDLBrTqSfcherob35nk6++yIUu2PVJKZCFT2JZg+AY48t289cUjn/zu1A49SX5lOLFAyIXN/GU9vjrN42CSXgL6nw05sRX/qGuJIv4JmFkqucxELx0M44u7fibyL23C+eJ4jzNdJGdRbxMtXeO2Z/ltz92Hg0koNnqAfC3MiTapWfqbBd0bEPA0NeC059HkfwzLWBaJ7K+Q0oEdSBLPOjpzsS5sM4b8dl/SubNvGw9MKW7frFEuHOoeN0B9vOvalMqSQFfnvmkSp9cJK62r7P8eDsLF/6v8CEJqWjPvIHOcopTpjcQBUSG19emEpnTLFyACNHCcYj0nAUoaop1GwoLKDTqgtYfHkjzqt5j7VCPH78BIwaDKDAfEQ+F0eZCRuGGip4WX2nAHtvE4VTGHFFP4EUxNvNOJL1YvVcYAmz8NsWPQCNax2HtlRs8upaOBFdKiSYOejOlBuNg/RJ8dE2793k3e3fsV4A1pqbysD0d50dSkiynmoFsb7VbUE/hQ1YYQEhM/OBTzwPV5c7IXmw4I1g5uNl+A0YdvLv9YZYWdL10H0exuchpmN16F/jKV7rXvg67bznQS7WRuaRsK+mxCruH0cWICHxcuu0AZcRJv1SmeDvByJ7gvA5PLYgpLZ+ez8P5F5CnesqVwVmWBGx8WxXu/pK9VgN0NRtWDpJXEAJhkZP9FlCMtyeXJXTS4yJOReCYTsGfuMSgosAd1oKcXkouNIPEEmEjnntyvp2qU6CnOvVgILJY07RjevTcwRJ7+9lte/boPSX9gjCY519oH8CgympU8OjxNabU1mxeQg/2VZcabW0jpi5WEAVNMO1QpZDgW8oLcbXH3ekcvujai645/r+Lv6wCDY0p4yTpZRZFA57QKYAv1xGO5DaHdjovn/OL797e2HhQ5A0xnGPWcYCEaz/XsuspOsuWwdirrlposCQrzpc1pn8kHrerUxX6YQg674DqeMjnfaZGQPlF13P/1dXFe3Dh5E8++vCIC1x+3DWsMTRF4ZiK/RlV7KU5bLlvrQ19hmpM0BMHI+Ozf3KwKsy62/ODE2Cjdod3TCd/bRVKmVL1HcWzDlsSZOxrknyoTUFsLViQRNSS459NrYIDmh9QfyH2Cqub6KxA2JAQyX54L5khQezd9jjU6Y0L966cKeypQK356UYKdhSyxBf+GSfFX+JUnQQaH5bX9RG3ZGzga4lQZkAqnZ8CfT50/JukBqZk26cEPg3MCVh64/GGSuLbmXOynJkLcDSexLL5plYGMNz1OZyXT8zwvOfizNWsul3bVRXksfxlGlMerocCxnua0HZkSsvXQ/Wgx+TXOgSozgHBpk73wsx/GlC0YNPy4z/BJwk2G5UFtdz9PIK2624LqXVwBqq8Y4sICKlfTq+WE7Rad90AOrH37wDCUlzQQA2iXXShnp/eFjafXXtF8nsJ7NDZxcGBlhd4efQxpt6BksapSMbOAoGQcw4j8N3iY0F60k98vChnbx7rfUsKe5LyVcqDNyxmtIC8/nDnD/97bmwD6mFdqHFIVYHEA8Dw4FwuajNm9DRtqUia4pw8RXaAGfrkyCBhwO4kfAnXgEocoQsHDwfaQlidJZaffNrvNgfAe2E+6OcQ/KK8PElCn/NrzOHxvlAS802O48ziimy+97tgkjoHFUoSwBNaHKb/Q8wep3Iq4nIlZzSVm+j1i8UyvR2hrhSKHUNA1fZlvmGGrmMeAXMAmuOLZZdiZwvo5PsE+VvXwZDcw6urZkHft75ATAbxsOZqdsrFT/KSlIddviHpikMZ7Jq1TlpsEqLCDVTYGrqrQehcgAtzMLsdr8DjtC3wfy8XFeIm7iZtOYuNr8ZoO18E64CBui0Q2g9SxbyjQAN7jiipxqAihEClgv/wZRwLOgy8AbVolJj85ugMLNEybyAYqr8zVz4WWHJOqLQPM1vel6OD7yhgAY//6RLlg5iSdi9jyeKZd1vWMoptP3EtASyIMzC5Tjwag5Oy99XT8drRdqzBBgF0BdZ97UrNCvquzUd6O2lwF1PTij725122nOn46szlfj8c2mx4l/EV63npr+NELU0C1mCuhkop1bbZPOfmBEPXlC7m08/LC5Te7W+ccljGBSB/h7DnkSLIC51mpIf4GGcYMUMZ7Da1/Gf6p99Q9tG2OjEJ6fknxC2Dd+ZLWMVtsS2xBQzjA2/TFSC3owAnjd+Na00S29PjyRXolppz1atEkUOjpKUO0lhsH4B/veX+1bsor/Xovb8Yj6Ey7H5c9QcnZe+rp+O1o39SQQCRBXpL9YcUwwfaaPHLxMCsk1D0I+RWsEU8XaBjyzv7PFSDgtjpAxCYCCHPJZatYqJZsGpZjJ0NfjBHFnZcElIqBspcdTRKluFVA6RvGYK9aSPbxgAn2tj+Nl7F1PhqZ72gUXBOeM7JdsMEvZN7alJJkGmBlBCZMvd2qRKHQaW2FSe+9XUOAzyJT6hLh9UBnRptjoxCerKx7nN7XWDtvtvh+6VMskKPDikFDOMA/foQPcPttSn4bfgUH+HV45lr70d90VCGaz7MOs6rXu0USGyZbN+BhWx/npI6HxwmYqDOCZGQifQFGtUoI+Ls76lSUk/zsslz/F/4/cn7pIW7/xm+8vhSO8OY2jrF3AQbUMfVh4z1F9sEF+jR7nENJxwtLf+7+1+6HGAaBfwYvZpbbY7TC0VTNIOE+5I8MQtdlvdcdFmR3MMfzMr2Z66kpQAtTuwKs81hocUEhsE7LajUE4gyDH2OfdmTLzG/LAIVwQjI+z4wpR6dCNw5ptRFhb4WdyFONVXxcA/4Bs1nNObesYGubGhLNuUy/UreizmrnOTy0dt0QeTerrJ281n9AzeQMsoSjYBiPCEmGVEfOb+AS49dWA2JDNP6iTEp14fVWiY9QqzMb1fB0ELYaay8Kaw4GCx5epe9y2cym4NOcyIGTTdsOMqWVN8IGqbQtFE60ZoSmHn9k0dhBmER0+7DzbQQskpY+U7ftyafkp+rVuODE9U6jmchPcfDUgSW+E/6Kke6lVfSpA+RJFuBwfyzQPvqkbsCeeN65QbHIg6v9OnmFYd9lQWaQzF12kwgQAJ+hS5PXrHGz7J2W39tu2/9uqNWK7Rwg9lhJqizhqi9C+1er2XChmcUONEPn9tVrst7rjos+geeqcBrN+Plof6B23qqdutbTBnsOnMirhKxCh3cE7DoUa0HWeg6Gel+Sxe8F0RaYdtC3Vyb5RYO0MGUW0SRs3xCelNeN4yYG9R0t7uNpUHxKvLPcu6vUUBc7TT27UK15cZBMHu0DovhraUSgLuZEFgT6oquHPZyDb2AZXVQi/Kx6ZldugU3oe1CH6R3+4yxvbnC1HJqqJf+zzh3ZMXnAY5CpCWdvQJAkIedddIgUH/5lWkqmTdh2ApjDSJQSC0T21vdWNOg6TmluQJJti8vQX2UQUZMnymtUbW1qP6egTcdjk7XhcnBNejqFt/npQHy5iTMQPWqAYW2cLNTc6oDcQhzoR3cv2aaJaewz3Pz2R/tnY+GNmrgXdnovH2Znd7m7n7CcziXW3knv/hF26mVxPDEMBqcpFu+hWfH/NxLT5483jLPiUG5qPcWJTXlco9ZvorDjQ+YZIGjmi5+PeMfmBl+ZFph62wue5+eyfQok7wMvgYFh2qxKjsVJaDBXxBx+IWCVmV3iOUK3WQL7v2fhdfOERwwzo7dZGmhP25IcjH8or1FamfFeToTkfRvTSagbg0d8xblNenV8XoBLDfW0XVmkJvBVfRBFGWkXJSLty93HrQC45/dFy+LzAsQ9oT1QvQzBiJNZsF3lpLsBsPcAXLLA1PPSFYa4kGtgYvFSwxjYz3xUyuxkNCArQyDINHkDCMAorsgCW5vu1AtBuoIy1jtaHCIuf9IrUGUxp4Prdr/ccsiTCTv5VK+QPTbWPKpwNCrMlCxB2aKdrDkReJc0ixc7LOHN1ket58BukZvB81FzmhCs8dLsbXt9Jeemwk5LR0z2s4bLQ2MrO2nQJljDMD2fozLVBLaknPuD6pNTz87YWJBA80Yzj+K/t14Sslyg1FC2nQMcZ1l+hhAXwZe5ylOODLSHB3POe/DV+QMS8x+0DQvcDaWr7/rMOWKu+RoUZKnxX7vU8+a6z1y1g8PQGUIuFoToQERQdjNNfKeNjLKUq/rRlhZKI+hFxXxPsnChKpLVMqDrPSd2LZZDmZk+L12MQPnTBaCHgnDXHR4qNDwF4Nx2d6PUNmwpl8rJTjfzu3+s/INP+ByGLuqCIwaQ3Z/m3/fZ4+z8h15qj3jC/ozqIMKiBMlbIxfioxyyF/3+1IcGm2w7uPOfp/0WEldYd62E3H7eukacu3+z4QqpnBaF+32X7SUQT1Cz0T8Z347TRIS7HEHigXjATdXazXzI7yBEzhj1raePJ+Nx1yerdB9VyEnIARGBX8FbXOMsr8yKBFe3yeLR9aKv3CthNSjwLBZ7rc3pVMnvUTHl2r5xS6vBEh1Xb4vS1lK9cSFahR+DhAOUIZSq43m9QRMIzXDO9W4bzmBAdDy+MVImSGmHqoVyo5g6Q8lUML1HhMmqLwvwmo9AljsMFwZJ1D/m+h8mzyDO3JCtEoNBWLYwbe9bnpvYPkgH470DI3CL7U2LU1msib7/PRM8atv8mpnZKR31wbnliIaqP1h2JcdRcLVUVgY1afySj3KKIG7LlyU6RkhnMt+ay8vVLO6JW0S+xpnPu7J0Tzaiop0YGxAOCg+fdZ+Qaf8EP92pOgABygFHUdBUU0drxxGVr95FnsuzUXrjCc6CXpeSYwKSFdTvZt6pIFFF2kOrdIx8dJVQAhxD+Erd0XK0+DbXT8lhnJ7g5wQWNLciQmkRVAUkn3kMw+55uo9CAFTZZKTDtBRSV2xEOI0rY+qy7XA3CEW2hfYjZjkFrz8AYV54kJ6NP8FbWAXbL3s37P7tEezBTTBwVsNVZJ9moV3i8oezOGVe2+3zzWmocIJAIV4bitBdv89KAvEdj+TCEmhv1kHgbW81CHQtsQ4MsaEwB4nWEjTHpByvDL5wfUsv0Yp8aJkCJvkYvAfRfmdlJUmK7FPoRxtgwOjISiW47fzUXsb0+C6ypwraZAHoXYhXxMZy5Hn/I/1/H9Mgf8ebSGYeCtptdC7o3Q7C1VqjkgyILCQzm+vnUY6l2CFw0HDzzKaTRwRIdV4AZyEAqrwKsNm0kqNDKVWoufiAUCjHvHouxK2IACnC8C1l/aOz3Qtc9ELhSCqkaQamkLW/5t6dDV7Zi2+cSjrViuVVvNT9ZndjnwgyaxHq1Bqkkc4lsmzWc/tvBwFKduH0km0fITEauapQRoQi5HKeKTZCK4WucnRwbmEn15lXhn2+c85EUA6SPa3xE64YzS3I42ip6mEHFJ1rRvBt+yy53LQShthRDo/L7ttdlavuc99fds+wpgH3eSnm44RhD2SIWd1Dbx45AdH6mDNerrOXm8Z0LHBNkQAlfCd/0IB8CAujv0NvM4H7xTl6WlkdX4HyieeTgLNDBlykIgk/6VFUN2ZtGbGZueCSX4PdS0y3O8rLNHnrr8/WKsHxpU9jv8w7vduED5sZzgn0Uh27BcXmeHHSo+kwZzh5kPLlS+2VP1nxwX8euTE8wdwdAglQR5Fv67xzM2pNbqVqaYuen4R/TsiNlmM5dYDcA1lBfRuLnK3pSQTuFhRWLV3/UH2Q0YefPIGASk93tOpkGvQs3noO44yKyigtqvWit5VHioUxyYMv4hw1lALTaJnQl+WYqH6lNyXDz0B+o43QgNhoWHp649MHozEOVaztt9PsRo5rBBNZ1+eVFY9sLujq0qopuQUuIG1Wi1VezkxcRhbBzGdS7hTCEAqoy4yPMrbU7LGzNV7c1aCO4hddazL4fFSX+Ca+k26AwBChCPX/SBluG6DyMk+iUA+tr48F4Vw0XB28gbq/BqpwO5KFyrMcrRoIl1b43PSToPV2ksqsDLfnUFh1ycYUmQlUEnla0EXfK7VVJA8PMGmG17ahcxIx8i+cr3NUuOPbpxtizgJShKjT0EJ74QMu0sfU/okxYoP1AP8wuETbBBTDbtqgQnooJN1mLcOUg/z1cGdTq18RSL+zFWnPo2eNIddDF26gC3RKOA5DjTIaWLlW/PlEriEr7ocaJ7mCTvnuJX7SazNzEiTcdeToGlpoXn+rtj0X1yVcdyxRjKhOTm4ksroTFhG9Jj8LyxDAlDIlLcdXr26VF/9vmBCrtp65YN0PmpqLZ6unaduz9+/kdOJBg8aBKsb5+3AB/BhLogXlq4cqrTptew+OksRtz5nCdCT4wN8uVTq14Is9U/s3mZS0KJKhIsk8CPOop/p91K+msQ9lhL7yF5RKm32rXt19o8P/lnH96FLdrWqVnVrbrdb9xi+uzXHaQnH2IVJZkbxgeteiyIsL4NAL2wLoMhoOjKXfWoYtpioAg3qvQVfY/7d4iS43xmav0IcMvkWJv6A/vFzNUX2VbrBqjVEi660+WtfvRyFnoGIczOR7hBEJbf/xvFvAcQFyono3izz7JMA8CcyNUka13UmfLjycmhUj3f51az1rNPCA5sL7l6kCxswJ/YR+g4aI6YvAOSvms9NefoWy4geId6BwdlAffW9Ls25WQUThbda45tr233Vz33LZ+YQgFVHAB8GeFFtbwqHewWprXRMn7cma2Zh+cWFuwkWwEDcl3QfA0KFmHN6b7AS3uU55hdYMLj1/wNC9zAvR8R4pUsHZf1I9kgO542D9HWI+kU1opINie3Uq9x9PvJWv3CEJs1LhDDFysAG7a+37ms54PLL+7ezqRNBozkdqOxC1hjuMG7MS//edKP0bS0hm14wxRIDKym2+zdNk7RfqjD5lBkn7pHJqmvdV0j/yzNyK916NTpKfM6b7yWf7Rkmoj0tk7wgmx0+M2KctxQ0BlyJh71FiwW0HNDCJIuwJZSyUwhm0uXMmUT0zK5NKgGbtbXtj0NNJUJevGuxxiJBYIHs40UHixpxVkyLZRaIloro3VSAGF59KABiJ961wNWHUU8SlC261xzS3OubFa8TsmJ2bJjdykALEt57dIyHyXGLy6/5LiO2TsYI/iQwb1Q5otXDPRnLRJdaZQPmCXoqrGeQvigKG5ZpIxynwb1Z+owyOVBXpBp0bgOQzBpFOG/lqYgaXCSmUwLijnI0Dw4Hokn70JzvP9oAWVnUur/GIDHl6RGVxtqkQGofwI/OslUllWQGsIgp86d2X05S2VkLuLZ93Z+/IKKqWvaqBDt+UyULFjGvMSH5xuYzvPe+58uigM8CYbwdY8iAINs4qKPQx/ynTbqfoKKuM1Jmq7PCYTRnZ9dDXvphT6JNas2Luc6k5eSCOIrr8aiB5BOnGISnbY6PhsncX4HW/gAt/2ydvuEKZZhljNz/dCA3w014nG24yHdPAuqBrF/Rfy2Gia8ORQlM3c9T0uly/Xl4+9obndcITVocit1wgHUwszTfvc3u1EEW4PKh/Jz6jv4X+iG+hd85asu56aFT7M4G+Q+Y6JKi7kbm6ItxARte4FQsoCbqxKvDSv2ZahgnuSjXOlPd7mlJkIe5rSLFhftiPw0ZYv4QZfnLoPdY2k6vTX9mSEXzM7HaimE63Kac63ZQX8C9I0jSoJU68zWBVmv1oYO8b2uSna8c+JhbNn3gyxi2ki57h9maOFD137nJDVn/SmxkYsWs2ASwLY4xD24WXWe02I8V0ZfZqHykIShgQwi3+cR1M7fuqFFcLmu2WCVSY/C4Awy0lu3GEG6Z0CYLIWKiEY0L1cExXLUPU5reaT6Nn68F9KHlEP8qCRQfRu93eXtI4YlO0fE1MVgopcA0XnRDmykNcrwPdE19yv6gBVqmUlYg1Vvp9kIJxKVMD47L/us6y7Yq9NZLDg4Wvy8YAjs1nmL7tPthQ+Vs+e855C2XvoVx30SR9ROyR/NnyiGeUFqyEHL42UYDOXGFl7XmORIPqWQ9vvQBWcA4Sb8aHkw1tXECjZOTIMkzLKWt4J/Jk4pet3RsH5s3bEfxQmmsxvWMSguCsTIhBWAsCqCbpg+VEG06Svqha6CH/WjVru2c7UJvDXbl3/L8t8RjkbXvKFqn0yqQtgwjjgfZp9PRsqGa++uEDuT67vcgDQAYn/z133dS1YdF3TGMRQ2bXQbU5FD8HvCRWW6bT7Gw/ryrPNYi/htiB5MNbVxAo0GtV1j3xhmRmZ+W24k3v7wzTPBGozh0nK95+3nrgDEjOw82yPsDAEQaMH1RKfEmEkHEF7UVVGs09/IjOAcHC02mHxjDY8nzByfIS+R81TDvCJOLpc6MbKZ/DEAzePQ+mj5MNNjnoj7zFhd6FtFUNA9UAiJGeCVarpZb+aRR4rxXDhCtrCbJe/dtWQ86ksFNivAgQ1WBAJnk+W2QBPHFuPMYF3daZitqW0VCIxIQD12s+3fRpjDTp0xaY+N50I9n47oYAMdtCUj9ZRSbp32mh/H+layAzHCNeXpVtov56QFHBql6/tU2i/81evXx6Czl2xPr2hDDEJI9P4gLXwUuctQtLTs3/V1rBlDVARuJm7XHOrTkgcoZd7t5qcvNq+yIsEsApZD8YQquZ3v+cxboXZczTaRp5QA6A2vG8JudDMPevYGf3kM/QIWUNAiCwVOVMQD0/o4esadMc2nm3hdqTAP9XInUa4m9u6Wf2/M/rpo9V+t7KXgqYkMlPnxg3xkEDX9Rdccdm7v3xB/w9wyAzqY2ygBia5wGRZfMJuLE+Mb8oNlM8slWJzB0NyzdR0SmoETLd9npmABEKZeg1B5f3SntSIbqm4tysOPBad0FT9/Qz+Q3abKcM0riAIkPKoi77LfI3wfKWdiaqU8sOREKZgXZ5dMvIPM9aBsihfWzq+/pdpDYSB2YahhLn/B+4lHX/f/vYt50DnOY+x4S8ENyFgpxEs1v7vciOosCFgDgNX5aaS6pCaJqokF+Fme7J5a05bBmfzXK8C7PzjLGJ2hWtQsuZJ3I7/vi/xIAoSDz8/kpXuUaWaRExtWBehc6mhqSPXQESQWgXH8CO47/u07RKEk1glCbwQmdai3M197GMld8mja3+AFsPelq/XXekIr0S0056tWiSKf2owLBMXKkD27cHcoiI9+9D1jGLvJp0idvuz2lMag5Oy99XT8drRRA816ZXpijS3HuAW0/XsSc6CCn4oep98TrhC4sTIaTOHdyPzHgxoxEqlOlxVuIKDIbfg554mtkd0A4QYABrWwfOMCYYt4qu/R3ZblavfP8Ck457g5TpIyDXJwCTr3eypzOyiv9c45lDMblQ2Pc7EzwiclQM5JqvmPsaatGp0cvY8LK8z7LHdPEwHbB7xzDT0OHey/X71DrFNLidGO/g9xXwR/1LyRn6Bs3XY0y/WoisYX1gDqRUtPCkUOoaBq+zLfMMNXMZu+bHAiA7NqMyQGqNZmsuCn4HW8DXvfi4Qfk/9GonUo9ZbzehaK0s73vZfr+C8BMNRF7vZelsHWlkRd5cMXl9oKg4n9OOpkTdiwEPapDNJ2UZKC0ZtIdZuUnTMKY+DVAqasIHqeLtHxP6trPJ7p2uLQocbz1KqpWn1hYu3t2vIR1fRx3paneiS3RdgKK8mE8L1YvJnPA8mZ2Zfe5sKmjTfGw2JR9PHkS5FQUA7a+efsdE44vBTM7juYrh+BL8hhoWny+s8iltG+zShR8K9yjt6y3EZIUq5AIk4PZc12rVekIxoaOqu+fGFPF0SEMadk+WjAwME2AibENJc8CG5kRhVSJB/1/7McsFFRqn7t/P5abYu0XjbKp5sqKqHI9nivXbK2S4C7HaEEFBTSe2joVxCOPyDVWcNCevDidaFw5N3EGoMRSi4e08afengyGZvSjshuL9nW4cDaYRJeLvQFoAb8nru9A+lkCwNy+SuitY91VG8LZAGX6tB2k2k7uaukOVn93/EfpEkv+T5/fsXUL0W95VuVcxhGRsmtZcFPwOt4Gve/Fwg/m3z1JTTE7jqhUHe6jazXdHuyjXn4SQzj7UCV3aMrWxe9iMJOSXqEDEkVcEGh4nVjbnu3Br9rcInto6FcQkGZDvMfmbGPtfrIj8YxLg0O8umGGBkk3Ulk+Fyk5rY3J76qEJwQx6yFYf14qfD61o8+msrhZHlhP5LbnZl6asGl0M1bdQcmnnYDyFvd/yUszG2UZLgEVUlhVSEvvmMspZgSHapmSoh4se7pRnYS8blsr8gFgoIixO7khlTtsiPMq4yNxVC0HS7BdE3CfDeR7oDM8nQu9XCTbwI4FO85Ztdpl9pu/0fWf6T4Q0k4aAdmFtt5jCrCxDwO1/TgQXm9Q424uHnGPtZCTo4ym+FoDJ7zb3ENPL4+KcCe6wb3PCdwlZB/in5n/ScGNMmB1x3jVPQyPzulvUBgClpQQq1ZiADakk3dh/ilTc0jHlzSxV2YbY/ZnT5kTfFOH2MAyy7DzfaGDlOfRXU1vxnh+mKZXMPmpT1u4R2q82jWLEV/VawnPFsHOwhj8yfCAsTcLBLessY/RaD+nveWK9sLsD1JcYAwH8RhUtzKrdZKzHCxoc+lzuZH957Ok/Ve43qZhwClWqVhKgP+YT52vj8zsHhmsqfoo6aEXFCwYqpYgVHUzIfRQGzGJUoD2tyL1Ln+obtxmZyiCx/AzOK8Jutai1i4hF7smCKYbzEZMAvIp8N+UWq2gmkbSg86QZcBO4KF6Uvsmz9OHqK7llo1DN1B9EeVZLggPasxxjKjY7vL+duGmS3KelGU6JjZVbPDsZvYQwb3qczWbxj6SWuUpCAJ8xizR8UeJ4AwQJ0RIMw9JYyFQtjJnGjKXHZz69VWymBEQfuOwk9zVCJvDrc3Gtl9nTQej56x4x4b35xUjxvFGbP+bvqZ6dFRZBWRdI+zO67nv93F9RBW+byS9NbC3Fi9c7eycZfLYZPN9sH67ce+XYhAg2JCi+gYd7NL2zxAn+z06XDa64gQjWDK5HrVOetdfzCtZnZDr0tPrZ2ZtQbBbSynU0SMn30e1506pRADHtJQ0zgG1lsNsuYSYJDw42pokhSZKBIoCxwjl+zZieUvL10G1aF7Mz4WSR4O+NGGSUyYqHz+wGqE6t3y6klJTo9pRyVFCdI/CPiKiv2RLnOyCO1CZOBk+3LRgjHZKaF53HgnWcETfBrInaiw1bHd3m72gaaC387yX7RV80hgJWqc9a7AWUupzd9NRiNvjEEC9VMg2CzKypcPjmwcrrsr/rBsDS0N4i0DB9B27IhPZlZSp1yiGMUsIjhcbBijQJi+y4+yTc7oF4SxtUMLzGwTFiqhiUUz5Hmorwro3WXcRFDRydf7sSNLiZPL1dB1q+CcqnqjMH/yfbCjFwnGo4f4Lq8eXWLBZ2HcQStseFbeW8637ETGQl/M3xEDqjotVw/beeU8jFOJBUvUoiUyZF8SOR0ZBjTTPpibvFs1t41yp+/8DRST9cF+nv0CXgq9WlbQ/Yb7GHrehDiW5TZPLwddZiwy9zcEpWgf7/zlAPgBBeY5rOR6XF6lVygFJAnnMeB5VpOW2lYbylpvCbuzuMWGclblbfHArsyWqK62+H/uwC+y3Nmp/N8n/za3CrkjrjXMb6nim2vRdr6VbxmCdlZgARSZAU2giM6OfRaTjZsd53M7yeJselCEMEk9KtYa2nQ2eeDkk0et4sq3pch0wHnFBZS+aAzCaqlEEP3xr0fBvhFLObluHQxyq1ZDW3RBaNuLh6XWOP1NXDFs2CmGPFPMDSn2/9a3y7WNQjVQr3NuEWmJxMVhD9oagBJklAeUzW6sO61fnDN+qIzAu+0fFnVwGnRydzjpBlHwN9nbcmSCb5JyW+rGXFYv1OIz1T6deOVysmNiL14XyDOvhQPlDBEOKnhHdb+mju9cl3JUrGSRcvkjchg5je5Mnf5ZPy9V+CGBmq+QemSIlEN+CnQOFHkOuLnTcbxldoc/joKVGJBhwWtTgX4C+BX5NG83AEr6mqVKvkMe8QEQVAdB454h2U7mHhMsifxEyN6G+ROihnBaPsv3snYtw5o+0tgijNV4uRvhsvV6mOFLMYQTjDmLuGanjFdAFKaRfxP+NSMhYtBWeY6UBFc6NolBQKDom2Hcg1cbL39EPhR2urBlwhWefi8ZdIvWePIzeDVqOJ38z23bVcwIiLZZi3NIhluYjKm3xIDxmWxByBWEK23LUnrvEeipDOhIhfNX5+4ZCVsvORnxPMQ5JlKTaObM03xFWDNE/ILWtM5qaZWZz0AXMuO0ypijnTaGuWyCm4tNg3MnRd7AFIqPTOOmkdTUDiSl1uI6RlOy8g5vT1ZSiRg/S2zVFKbgrSlfCc3iEBj+CX9BTomB98lglnEDTjssuXGAKq1AlPindjc6d7vDbcn3e1umSftb707eT0YGw6r4Zi9TFvYIJvGqMzN0d/v7lcDS03xD+B59bCkbNkYHp7tCjAv60TASvu4aOHT48zcAPveaYATB9hE4FkNpDgt+ebZzzsBUGr8SEUUPBMUb2D/gFwi6Idf5CNWv5zGHO5WTDNjqAC6azroYUi9Ue0T2rroGs+eomxjvVSAwdBFD0b+c0JmcVwQwRrZAREwJ7RzbeiimzkZ9iDT/d/rH4CG6tdDnxBwZhp0jUxBRFHhIbJOtzmwW5BYQx20ZfFK2waKRvlV5d5JrPnnmF+YbDt+k8W9aENQ0yAKLkQvEW42ksHkBz8zENWyzVZnIfFJzeJt4YirFmH5Ga2WTgJaDhP4/s1AJn8vLO5/Qo5n9kqtak0hINWSmgHcTRRVGMMxyPmrmicel8aub+65Nwkh9Lh1oxXl0GluzQn8+3ZPXLkj0KZ+IkMGDlsVLAp6jAFWoEPWdeUwfAZHZ5w4E7YRWZWnSmnTp7FyK1gLGFZHKUVQYjE8i0lT10lTqJVO8bQcyhdVUIjr2TmljQT1qD8SyiDQMQYwQOFPIFO9z15RXiQ6EUm1QySXVmNL8WyYT1VLDmEVyQrflgEK4MAD4OiBDRztjxYR+/qLogTeIxiyZkwny7+lf7PFPbX8VIIiqTWQ5Fcrs+JfvCjt4aYBWFOv0m/ZR7WgMNQY0xtfErdOQ/YzofHeyV5wnQSy4va480cbR7/HaKKAy8IcMhwjKjp/ULVkzpWccaVzcL3Dj+u/TdezRZyykiiXF73pXEaWVOwxLN8+1ZOJtC0lPx7uuR7ule/aruQZh5rjbO09qqgUPM8kxNPxkS0kVAMetM4Iz97+wbWJIKs0ysc78Sc+DY6n1PNuXjwKuAI2ALGc7eoKyD5Y1/v4QERfZwTZNVaHQ8AnbXBjpB2ncJvT1JBX+6OR2S9kxsmrwBajPHnfWTnkz7hv2sLqWvpgvG7KUPLCVU+P8roo3F/umQDf7P+fFTQ+0gVQtCQEvXI/u5uEEctXONc4RMZZSH/io+Hyjoeibg3VaqW51Y2DGfawJXVs2qfcDmPsHsvmZOowhJ191aDiBw6SbrwuubWeqoH5dqPFWLgruK1M+KQpcDCwSEFRjCTr6Kue48DsG37F5ilGy9BTEPDZ9lyyvqvenGHCEUjFHZz8ZhwTvdglA8YkwaAiKdvWClFfjLCrIqXFb29XMBdDuruzB9pVUekK5+0EZbAjExrBA+yoJjLwAR0uMhjo7oBjI5UOm5g8NOKODDFrkbUtagkxKneigYG65QSabxrSGYUvnMuGIpjlAH2DT58Un0ZK1maEue4WwS8cdu+iSO0KpKP0Vo34BEbtMcHuVcQucgOl4ccs0DEDaUsW6H3hLPRZLC12ztiBRYVa4wjP6D88ezWrWZoIlX/edmIt/rboIiIeddb/JIRTSiqqCchU0qYyDHPDu4VH8GMZF+V9lnyXdxbrAzWmxZwaus7lfdFFFsmRcAZcIkZJKIJ6WDF2z9pwIpe+YP+0SqFKBBNlwW2lQa1sbOH73igal7RdDWrYj33NdAnm/uC0G/z8G5cG441Dy4LI0xVu5mnyaqrBXoVexa8VgIPmID0xQY4UzFdDNUguabdEGl4WKtXFl7y6OmTOpJ5gwzTig0QQxY4+MiiAycAwGfzr1IfCETjdlLD1KtDpdZZ2kGlMAEIaFbDgyJbjbtqSmbfHwNGestJTz81rqKWbOOyuI1SAWzhWMH+oVonGy9Fv9t8m1BGUShK3OH6c1aHwWfmsuSs1tD1JwJzQBQBXyPC+QkqIbCcvG2IyEGapHLiJsHpRIJUvpeUmLMzKYUkst0LevBhKfaRLkP5QYIzl4dpdzV1S1nCD8GoQhzhuEw17jLz705xOogoWWOS6NDq/85f4n5UCNzGF7d/dgWsH01ZIlfApa+KEoh3SyqyhHlJHTYc2qU05CQhvPM7bfzIwDkx7B2XBAOQRcbGFmvfFb3rhU3qJ9+ZpOJldmVbfFOhX+FxWGK4czozPSe0JOb8pgIe6OzKp1cnl82O6bh8rWlrwVC2rP2S3jiwyJVWh0htSc9y+Q0KsS9tEIppyMljTlPoka3AeONo5QHbVyhODAWOtBl2/ynZVI4GrseISuVndWiG0vQu0fNBhEKhqcrD44pztj/k5s7G4p3WR4UyZC8gXjoqVwoxU4QRaFKbvGNgpAZTiHVqlORU17p7u7BRqoWp7E0GqTzM7rcF8DQuInG+TGKKiFyQu30MhulFJUQLCyJ03JOhNeezsTcfovcli3tnwQKbzbDhCuuYRka9vM1nFIkTbskUEZ5+jjy38RjOqc/73LpEBtAcO4a152f0SKFZA8DAhznATOqNjBt4h3stb+gZZzahyf0Q592Qd4NE+hsdh/clM0cX9ffHlYKNU0oS7enlFwLT1N0EEb3XsOQFD9aX7YqPkL7302TCJ9YRx310mq4oC1r1XhD+R73I6WIk39G3igdfMRup3I+eGisC/1uW8Zv4zeDZHD2CfZnrx5YPi7SkgQ3z8LXlJ5EqgJ7ns/MAEsBreL8gd7K41bFFQEgrAdJvEBq9R7P+OsizC3c0yrdO0Lmv8qwOjkHh1TytyDZZpx8CiqsmVYMyPx+KYJidGM+q85J47AX6H/Wy4ePIJ0AqPEZO+xGuvVPj6ceLWqlUwgs/SZWsRmmmWA2NxCb+8O+hnc5kItVyHtAlK8jtr+X5n9O95atczOkTen3K9OtBtfn1sl5W2o56VJ575/6R7HGxnKtzh1jknmZnEzOR/udvssF3XgagKLlWQW48bp52aghILnQCL+BATvkh6FJKfixRmyxCPOuJtgsAFZEMMo5pX7O3KVSqZg+aIfhjjScpc+Lu9g0vy/l/cgWky4vMvnL1fSlx3V7Xyi58uqz0LCDCm5MD52AsGKgUr1e/k0Fhnon41H4IPwyHj71fkhWnEAEG2X16kP1BnkjPvKTR2omRvrfJqCPSnoZVgJDify2wNAop8P2X67hFosrGwlj5R5T9LhVYEGiNeqa0eGIQ+sgU/3sM6xhIV0rdUXqTWsgGp2De2fXQZsWDFHWC0dQfa5m0yXVImrqyJ7z2qBN89ZMs5+6tzzCrhFczIw97hergBdks0+aLuCuYVYWw82064w1BJoBq0dqcqBTinwZQ80oWkER09wSr/49zW3IieHx79uarSbe4qbrCDZ289AxqYEVM6ky8ImBPk/nktbG9kWWL9bO7zgqCia5YwQQehjPjbLCmX7PBfuwsJE9+bpZoDXdjbK5KJBMTDLepfbhbMJFbIHDbS7i95ZzegqrwB5tnnOIZzKR/z8HqZPoqq5bPjgrgJR5taPDm7riDgJLsArkhsCkZxDZ48n8iKb0uq/nXsTVnxo50gnNOLa9nM1A9cn58sowNNXg+D7iX+LNlEJoF1mPt7O/L4nBpXNnPuTUNGYyUBfrh7Q/ro6tRHnrwnAZRtfIwIRe2ojz14TgMo2vkpRk4rmNACxDkg6EiiS5B3PkT7ZfW2BnBwnm7mhnbSmsTsrzux0ZeehGFdwJa4EHuQXRhwxAGy7n1TgKGdGAAVife2hoK507zU3qp3IPh34+lb7Ml5Aybf3YqXy3jv2rbOAC0/vnSG3uRD23/EZjVJL8igrs2Kjz6KYaGDuqeXkFoXXWUbFbDYvNfbxXWejCQjs9UmR9StqIMrf0aNaE4UBGALRIIRm+XS3n7BmGTgKtNEyxUwtYtOXqFRIHM4PDUX+oR4k1w+KktX+UV/oaP9i14S929P98SJTRSJzPINTF/3P/xpgwC5bkK73XQ8NPcj715/VlVPJI6CmThxf5ciPWuaD9jwkCOXEVClUHmE9pF1DOIq8HV4NnsLlLC06MvvSuADMQDxXTgeDOAiy9YPCT292q2a3QjJVtOry+ufrEeswNXz28ZMDeo6W92HkjtJ7nosO3CyyU8pCGqtiU0TeTifPPEzKX5McqT20KHX/yGMjaRJQQZ94Thu1sZF34gN7Vx4G9vZ0RqL/UI3Dmm1EWKRBQCgvHFboFfcT9xsGakqWAtp5qtIa2DnI4ZV97Of30wqBtc15xPZqZpxL9s3S5mqzOdrwpR6dB2vxjejEPBcA6WR4k675RIdkPeEvduoGiOau5ch17CCGU4xsVOIquwPqfpS9FeGDxRE2CDknnQrexSMOAGLyJHiw5atYB6OymvANCIbKSpV8htp+jXi5xf6cdf6ce/79LqAVPiIg0ijvC3wvNjm/NSKIIA9Y4a8eEdqRsRevKkUlI0ksc1Vj5p5mqEzrxosMmr6MIhQQ35dvu9Y2UCucEI8u56ia/ApCTVaqWcQ9/3rxPYpzBbAm8lkiV9N96dUOiBdBeDrZcZ4SD/r1vIY03/rx5H+SeE87zo2ync0BDGzVycMMJu7gnl66tBCaDQHb3SyNV4crPxXiXY73fj0qRKrJ4Clbs5hnEXOhPBcWqK61AfV6eyRKDeTkOdGhnFq0sMuEv8Mcj1TK9RixIAs54HmKjvj5CqvExEef+VrjCbE42Krmc14N7hKxYSP+Jdz4mFooSmgPI9vTWCXTbcSvNNQGLWyOKOzs+H6bggJZ/9tiNIhFNR6xOyda6+zEs2GJaKhz0kJ9/oi+4XXzg2JSXQyXUGfQ/2xspjOcux97JELnbpL8K1EQ7exJA3wop5o7sgkxizr7fqLlQ/emk1A6aK7ngqvWLGMJOvbs+eXnZrTojm1ZMX5Nhea5D7zdx2Xb/pg9wtKXPqQSeWcAFp/fNZaDHhRJu5RsmdA58qAe6YazRExaL4gLRjIdW0mjZq4lKKQzlQ7wVn/3IkQIWAJ6M83lHI5sKTskvHzv/eQ4R5pAEeWYKWQpHUljZrzteH7P4k0Ht3481LwAdNSk8Rc6E75atlCT1jEkGHv6tHEvSMzbMRIRHuO1zlGfxQGkKw6EOyyu8T1Uon3ClMEMmIpjAI9K6r1hApU03ul7ummZ/6J69cWYcPC+VvGJXF6y0gg7/CZUspyvUemWdr9Jf36N7/4Gij8CHJpEiGU9hAw5C63PT7FMY2fPjsvL4smELHtpc+Zw4DHJpf3f7YixEWwgt/8NAcdtoDIel+ZzKbg1IQJo0803jwOh1uR+KnibUnK4xMEI45hcatSqQr6hQKs0rx3w0UrU5fPgfoL0cm/nDie03/2t7mRBYE+qKrhz2cg298DPOQMhIWT02dBoBAdJhn+nZ26JaIqqOqgP2VR/jGI0TIo4hF9JTK1zaC+B+hoZRbH5PYeqt5pwIC06ePjUl+/onzj/KoA8IbD9qmUHGrMM5E9rVRCMDhh9v+SH5GpGTVSCG+cp5uwM5GfYg0/3uCfw5PSehHRkb6sx6Fn2Fd14OOWmWDDSk8IA0Sbqaot+K1c91BzJGE8pVIyk5EzqeRzsPBay2ipa3sCUucRVAPrG3AUGCilVilCR45w6RyBbEYZ/rg2znbqy6vizUASEny4L0LpYwBpwRWVJSIkNtyYhe29pLBCzFjI7pApRH+p4+lbeLsXUF1KulFNdRZBI0qXtneWyIo3O41Hg31UVKQwXOD6J560BfyQ/I1I68AvvlJWD31vsF2ubU8RP3zWfaMesTli+aBD9xzwRKqMavvLc1Wg1iWHWNF+BpQ5jQvIOQK/wvkWTB5R+ldGg+J0I3I+NrYXI8Z6Jlt0ZUtPopMGcJPrMUzMPhD7aP8jNtOZXrYrWf0Ns4opnXxiXCdeQdz2lyTuFBcu1XHX3n6iJlITjxhp48kRGbiBHk9q137BWGPzMyLcRinVv4WRVk2zNCHMaav0/5weusLf6nBv+u2ZVtfq/SyOr8D3GCgzN5ICnrvt8iAfVb0zfWYORL0RF0O4+asBfw4rMy6UuZ8Rw83rfBrxiBgR6QYUhpqRPL6vmJVEVN+ntulcYVAV/61otEsCgQA+pZcT3orYz0yHy3tcXgHxUo/hPG23PWR+nLTgY3Kq8fb4DEk8gA9f8Ipmfw3ooqYLoiJHr0DrRoHNGmJVAuSpw2yauHwKexFA0P7OG6ojSmWC0yRt5VjLtlMwiGxCzdicT2E1KPAsFjn2/bPFSyXwGgCMKVNkjzs+EKqRr2zGOY20lV17pdTBPcXFpBRKC4yZNRtCGoluDEDv2SF2dNdPLJSuCEp+tBmidDpJoEHcRFpCvyUwAyZFiKHPxDnIhwGluLeopVRccRdne3Dd4mGtcQMvtjFuPcR4UuxcyfMVFmNKs5sbwp4B83ELLFV5SrvXlOQMItjg76E0iPTstA7g9S+QejC4V0lpolzQuUZZXgyKRgj59vx8/22KQrCK3v5zRm6J+YHMGOV4G7anx/UIDJQ2EzKAYfNzbDIuNfjugxqvDuEICWdRCDm0WpRHN3phcC8FGdYgjFNt/J6+bLi84i76reK+/hF9CFUnrQgo+H6CJFNWPDlIj5Bn55dUGLI1YfLShZi4HR06gBa6V5MeVzSwnK1KTSUEsY2QCa1ihemcsEnD1mCCeBu0AxYQZ0mgkUPLSjZsRvYFSC75gXngLZ1Z+a1/DIm06zzA02KpSls0mQa9/oct0jdrMbrr533AsiEIG7NdH4Bvm4IiRfiSL1B1vfcjObMFp6nmw1ZDVkHQB+cKihqkWdJXF9TNRKcsMr50UnmYHkhPbkcJWCZ06uQ+HNbKhQJ5lyb70JlNaMJGbTHXE5t1VlInZmgnuM1zVEItOy1WvNfsE2gh8qtKuVjvqZg30v43zM4JqC/TIe65Zeon9hJ0iVvXCrOGPKOzvr20+x/Ql7Xvnfen1lKV6syLjKnkG96zFjYyudtdhc3EnRNWKZHKCoeZvFeJpfcbW2i+1ZODB9v7yrqAt8MEubGlxzmCZAvNATmcjyH6mclrvdOXv1v6pC5iCiXlfsAuY5LwaM6m7FFCYtJPm38yPnh6RImrXzVw432ZHjWhjUmxNFTqTXda9jzhquzHRq6imC7iHGDrmbPMSeM0e/9dNi3oz+zB0EfO2z6a9Y9lTvWaxdm7dEGl7PtGL/T5JQItWoO1CqhfzEACwvmOtW5OW4yF83PbC1+fkY6H/Wriy9wkpVw69TTEFSzouadODmZ8kWU1ygtuQoDEahqhEh4LS5zG46sz3AEguhJODJMQ7a30LHJJ9L03nxvhGLaVEBTVWGrxBUXCJlqkfaZq1/eidm+fhcftaD49sG8Tey5LP9cPB8nWY0cFmHh/Foupv7nvcT+e58TvA2jcmUA49cgsMiiPxWgx95NOVD4oaCdlVZGmjIyH6/gTHPFc1fSwWsBGUg8Kp892XgF2qsm6qr/n+d165D6FBaCzUFkXGc5PAsWnFAp3AksGyXvzST4VU7u/TgDkA2eDCezPNHcu28heUSpt9q+DgGOkfgaqcDvLsZfsRPrzP8jlZervQ+Do+nwpnnVQHr5M1TR0tjllq3yTZbA7WFd3AtjGcJKe+FVfo4L4QzvVNkJjhOAPMXXhj+cIojwtz0bG1Rpybm/gvDmtdSLqLDdIDKAMc1NAvShC76qYuHwjVFjk1TVMQAdKfMrlQ7WoB6+MUO1rMm9UWprPEqI52ALFLTjbnHEO5KzUo+FumzMzkJ9uKeq166Q8kD/TOyLgVBHXt+qtHeJDp3C4KP+xO3V5O0fCndHx2eH/6R7LG2JBP6BBRj3oPzx24FtXiD4zIx7Jnufqdffz2ktPlmmwmOdW6xUz90Dbnap71T3iHvVPeqe9U96p71T3qnvVPeqe9U96p71T3qnvVPeqe+FRIkkvcq6qSl+ZI+gJ9Cw57laOPSFxRKmYsLjhUcWZD2V0Xq1ABOsZrGG5IVe9FFLJ8LjuV7gDuM59Q3n0dO5RGVlwL09bG64aVUFFPxwel+WW/EDzgrDIC3eKF3Y5dm4BBxv0no11PqkewqcFJo/eJT8bKqZ+zK8h/xeVhJxNTM2pkjlsuoHKdsRQD+dLsBe8K51tW9HNGgA4R7X/RfocXbS090GyABadoRbb5gsJHbMoOt9tZDBfn527REdEHFIlbOZpaLlRTbBJ05cQENFfcGzXVxHTu3MTeGX5hLq6BWWXR7pRnGrjq2nPcYCHMTuOOpacd3K8+5tVtCipXDSNUffLodYPjStJWO/YT71jC3l/zQxxPr6O3mqHzmPzUL4ewzzNG5FoiVI0PZdnIODXcbH03ioR88d7ke9Hhr2jDeKPHpaMzouEBGPb5ekGZgPLUSkBTAmwW9kIgYe44CxrnSnvIs0SrWYtm0mNeCdX8BDXbus8AZx1V1hl9lmL1IfCpVx3ZWXDU08frE3XZWBTIoCeHkVF/yradYuJ7eWTepc6Cu0BmJEqjLl9+tFoqpD5qA3dZBISYhdYUqpGh5b8ShmkzRhpk8qFh5TgSqDtaBL3YiqQb4ck8sVI3WSo/F8ICbxoiQVRlzqRkT0+1vGXiKfS8/DyNlYaV7mSK6iHG9DYF/jNHZp2mf6+2oLgTRZAjqnfFb6bi2WnJSWZmaXH2cDx2Lce3D9NU2Flj3LsPD635Rt3Gt+tTuaL0B8EHz7nCKauGYuN+PUFufut5B9AaKD4l0v3pdHtx9EVg0OUDuFGUP0fcrVps9YikM+p3jCOJM/eC8xnZRQNFbFOcIR+bVLc6urZiREhdiAPvBteGFSuwVD9yx2ND4/nduGASbOSzWKhRmqels3ytRJG22i+7sNtiMYD+T6hosztrpeH9nVpwPTa6s0lNlmOcCg+7lF1Hg1SWVdDx76qwf6joZDO7L1OcQ5WMWpsyBDWA4jr7UgP/JGU45ZrUZDty2JQugOPBoIktWX64jDP0OawsoKET65VmkUyLg1MtiBzlHD1F40wl2J+yAtsxPUQ//CCywaeLowL5L0KNSWLaNdoQxNgQNUzGigakpET0Jj0AnAB9zgfnKk7m4c7gBHQ1rCI3Nukhx6UlhJfriMW0XAIZQbDZ21cz/S4V1YxbtlxO2kuwTe5r6K5ke4BaelNYGQiO41bzfl4Y3LjFrdwOOn2UjBTF5h5q+tt4O9tArwz7UyNOKQmS34mOfWphwBpXnlN/kV0ilpOEjfEVZiHEqWqc7nSec5m5UcMPzMWuQXf2gKgiaEgNctHPN2MQJI3HCHasCMzdQx2b1kUkSzQTPm/Fsb1+KI1aCAX6olwggpx1FNY+WLvCuD1upHUDfQJHQb+EbIwwoL+oFxZ4rugB8BlP3VY2YhQxIEpVzrnKHzFX+tnV9/SvpIiH9mApMyxKD2KZDHaSmIN8kXQb9bWTDU3tQv0xTTDQwRfaZ+R7eTGZ+q2BVv3/Yyd/ZdixQ6bP/YlyChF666hgFLBnPa6S0RPhUexBNVLGUap8N2qvO1l+KneUM3pzcdgGINeokpQmsrcP+PVU2PyVUjcU2TeCVkQNNvfNxaeCfOxjTVjwbs2/Z3n47eWJ4E67aX8Oy+3E4ud255OG4nmzS55j0w7i2mB80SByUePpR9bUyOwKi5IbXOZYybnEoalFaq1NRhXb+C2BVFjj+5JoYk+gH6eLqdwAWyweWvuRJlJF+ngUEGhpnutPdLQM7ewu9K7CzA01ogLMUwVAIGRnnwx4QTfAgIQTE6L+d51tKvRuw3jOGTsA4SixsFfUAeos1DR/pytNrLgvDQ8+XO8NWVb5Tr+l/EWKpf7dyZHWiRKpT5S/S+higPfJ5FFR+ATq22lIjU2rS+qWCNLAasyvlucspCphYk+2hcEwsgs1/j2zUx6XilkdZVBr8PMWa6PBUYK6EdcDrG8g7q6OI4QFxcMq6eFbVqvSEgm+OIkp5TBHDqk3ESWkwJkiu9lxq4jBjzOP6nQEUQ1FmQf2F+JaSK5G+X9lkTt3uCv+Q+nUQEXbYEMimgtcsU/TFqH6DBrkgnVrLzgk6FrpDRueh5qrEcCUAL3kU28A4sMR6M1do0rqTUY8OA8Pxvu3nQ1LU53KAngd2uVIwi3bO1Tp7i0hl7KJ6fiRyE5DAsWihEKVzC4sPoLUSSAUPRWFSGIOS+s1PT2ekZTTGdGRTHfUZdTdvWT/2pg5x8A9D7+/A+KnpxDPwC+LJx9IVn4BWnYXO3WVOpirpKpVKjExEKKBvY9gZTclwZZJTEs4bWWLPPSDhhB8do+690vMvTcoMJHmtuzD36vwyVyWUmTGOLt4lv7h9gv4335DGcj+5TNCPMMCWKxAjUUqkMsuOb3Le3hxZFrctaN/GjqVKdPq5dT0kJwNd1fY0lpdjsE178eeHxXOKArDJTdkpTcHVK1EyJrfy4QKHD4q1SFl42dELd8l5gDN6YnJBzKK+IY51WX7zPj0wMhIvMJJEjJOak1tGRLgynjoHFKj6yekR8xoj4+CbX5LJqlrW70I6VyC6lpfpl1rmTsCO5ym2EMPupDeC/JEiHLmBE87k4PA3HkjZE28s2vXjZd0cOxEoyNk7WVDT0qJRpLtkQuwWh2YImlVNMR9tn/dDdxfR1XaYDX3HaNRWjhOVzVQrRSn0odW2s5La4wUlntzYT4f3toY+yYuCxcgtMEJbwWP9xpM/NO4uKeeV3TJsC+DnrNqpt5y0X9lWoNr/zW+x3+QbD3HbqOb5ipM0BLjhc7hGiq+ZQ1cwyh4ZIDlv9bZUQTYMjUUyNZvm2jli/rPV1a7VvhdKw92Vl6QSZAf1O12YJHPZuuTsR4egU1GxJKK3V9hgNV8FEpzHtLyHb84QfRHkM6Ut8u9eT99ZKRuJew+nnMGFUOhd3Xc7Vgn9MDTAzFwo1m4+okZvbRk66sAAWkk1c9jdApEY57MPvVLz0DYhoCsisKD0ajZL5BX2d7rq99sgler2pwjK4kt0sjqUm39SywPFndZWXaEC0ISgJmSG7ticgU/5Advpd8ITNC3t8k4qNir9hSPwq4sEY+YYGljJgN2uLSPoo1bcDoH1ZDQjG5N9Qt+uCFmY4vJ/xHx/H0jX4eVyO3wOpPcpJQHjSz/jY+dYLFFIb3Wmcm7EF2qjCTn520EEvI5YCADLukJ3HPujoUDeeMQ8reHySssjY4DRacp42qq7BmlCe7VVLEgE4bGKeNQobgZOkbdQMOaKT5QFD5aWrsB1PYMeJKN3O573RcKDVpA9XWqmyUfLRWqPPXIJw6yGTwwzHCRDAp9RmDIrDwipc7IqXsj244nBpQ6Etttn6OBw90yWd3L4/RYT6rZ6MMbQpyDEuME0p5n9t0GPxmTcEYoaV1ooI1WTsZWeyOvFxs7mKEOVuJ4zZD7mS6cKUrFCbCj1HKUQgFPM4BK1vFh3lwiv8z6iDcRGwNiIwr4rJuNolBK3KbRnWZaRz/1TSu4jrhF05rXTdRRBpiSoTUcKu9Tw3FPKd78aRXKtzIvGJjr6JkS8Aegrp0qZ1eda5BLSELhRL2CKSpBLtcdEc2sB+rTXF0VqKVwYbntKdV+HOt1fuc4F3goR6ErckKvhTb/hMS50mVjMw+xtnQ9MoZUN9huWkE9dMSgR02sEtjVWcRamPWwmpK8vBvcBPYe/xbtlxO1uZtjzuzgrnqgS+OWTQ5plhIfOmoj2JVtzyz0dskO0LlBp8fz5XyhA0/2AvjJktVBvdeGxsMNhz+VP78HfHfpzmmv5YdiszJ73PYsNAHbFJAYhk5MqNTSvFvRU3HepwK4X4xAzpipo1Q2WNmdTPT6/LeJPrOE23af0NIw3lwcj3qjgFVQlL9jopVn39uyCuxCNIkrO3NHtH4YiHiDgk+PDVqo/dB36boNrzUnK4EH5vpwg+Tg72awpJX9yV96aqI+yE3znr6FsXL5yteYKw9+bv0ISn+SEeWHaLGWPN2dootolQzRoDm6xORZkZsDx7FEU3QYUfI2BMEi3ym89RN3+6N0Gp6eGhLocqwtwUPF/hLKk+4izr+AC7nXu+rG7cDbhbCPA/1qfkvnjU/6Q8pgowxi9Py5Qq7RDxBx/VPcF9+s/3CH4f7aMxGnUk1WDWt+c4+UIGnoweNHtkvMg6ONhgZyCFc2yCfwbBQ9JXX688rmzvc9i9SHNG+C00IpUemWxvtrZuWCQQGmjKVngivy+mehprRKPdwshjTynHcF/JbhdiHtfGJ2GgKFzRQp9bfOM3L/UEXHvxAfcU/UWCQkriVKuwIk69EpWw3idA0FbarytmRZuDf2sVT6NmhqSvM1T/8qQNi48EK1nuO5T1Kq1/g85aDgmp0Beu6OYbTaG5V/6d2jDlgMlg5JuScqksO0vcdSRc1k+WUcAbQSjw+7jXmCPe450zfnV31CfdMzHMCdQ2A8TKHxWlUcW13YCyCK6VBnL9nIN61GsYJsCkulby4232Z9l1qUec/HdNlH0g1V9Ya1Fhe6/k4FPxMfYqSibmSg3a5CtsfnAAdqYQYR//mai+q6M0dXO/HD/K+RHVBQuVTIYB1TU3T2ibJ5LE7WWQKTvk1PKjeCWv367p0raDckxKbxwhZ1ZqbWTKWKJS9/Hw0hnQpMcafLt/nFKBYLk0R2Cl6FSOnzT9HZmIyvtuuG/nZPt01zvnVAePnBFT0CRv3jvHhKmN+73podDtFVAtvoIcSsECRCx48geM25TscOxPpgaFWzIVGd/UvsV46K5Weubpj4jOOFg9W4XtJX5XwJS1pF3Mz47/A+fz7IWA3sd9nShakjBZ3ebzOD4DGIE78EA6rYsvx0rHpy/GInRPFMU5yV17ymoDEDqXDNZecNIof+yT7oAHgeqIjuzioITqOB/11AOXaN3emEuWPRGSk2+A10A1f5Sb2UBP6YUVN12Shchu6tsvVvA79csNKcK05HhH5V4fNmtLo+AGJgmiOEkCkTJjh/3JVYd6apowa2zb05N6ZaPXPcChucrNAuj4bLvks02LDUKWSYY7kIVa1K+H2NifRsezTqBd4Xp24JgtNMiqTMuPFC/thdxTHw4u2cSrBNWx5B/hk9+jAtEugt5BQl+KOyGHEtuobSXdgdmAI48S8mtmrZEdiKbGlmmxYbECiLKt8I7zfpb5Iv9LOBV01OJPaVQgVT+YkZRqxFXs7jXz54zZ1dXEBAzK+LCt2Z0dPxm4RJkXPa6GoI1mP51UtNAZI0VddIwP02w8t1yXVT3j+EVNUDt6hhpFhnbNuvM3cWwmFYAFw4Y/N8w7dkYI5UY/MEEWQkLTpKCDATNtiKWDhJcVZcZxz3VvbZn/Hn/QrK0immAJwVV6NcZGcZrheUZS8mdtwsoQtl4TnwYll8ijJd58PtRcfLjvyliMXtdaECqbp6FGtd9jwLb1O038Olpms+TZ/XDl2uD4ibqMmtF8Rff+Ysr6Zd1lxulYkD29YpFU8QbLd5TGHb8aKVBoAHzBeL9O09s5ma6dZAL8tf3NyjDwyTfotLsLFwpMmdCqjh7n23KWMnYo1lEqphSmUw/iL1DqCh+2J/VI3kT9pIjbctQSRggoqMbzAM4hoEEdiR5eJvbnEjM+xNcToBUJcEqhG3/fKVHIhDREZRleagsgSaLQXTNePUCDLC5PLqdBgeF5ZmsMv8cHhQDlAUi1Sp6KQraB2NusOjpqQ7OiR4E1AD2JN9H9Nnkt9pzIQwPwALw5IZiSxw51N+WouM8aIqyFne7JFD+82vp4w13m8iRPkRj3L9/q+SeDV3NjRRUma4DHSW33BzY3xR/k+D9Fs0jAC9QfllRwC52FRcznp2MjPPAD2YA2CMK2wP2zh0SwezrTLEWZhZu4R4WcyP9YP7H++3aZYGbj+aGk3XFeplnEIUzWkubCAR13Iq/xxGLxAaeuQ+cn5eopfvraE92Irr6AdBiKtdg7f8vW9oqWCF3cFvVsiIKFPyhXmcTk8xyXZliGc/XvQRiiOmA3pGUeyBqme/YmoiVKnc4o/VlLHI+xIpzISeLUFwP6pPQ77FSOVe5EA/wyQcqzWWjnaUboIRD2XxH0n05YHap97n2vnGTrqCJe7qX1oqsfor7gdetLs5tSlwDW4CR7ay1PD1z3cGuQ6KIRZxLjJAblZXsyjWh2D8a7R8zoRmkCY3GSH4mDYUChdCH07fAxUs9jnFsr2ZSsAUanKT9IU0KeA3vyGy3s6gybXSlhprW1FRXRZYHbx3yXnw34LMtR5MVA38+9Pulk8ev8JfL3CjWUJtonVyww5ecZlZK39M5oRExGYBXmPnipmqlKx+ZuJaLUYewUYl1nvH3jZwaDCSCv+AWSfR5Q8DN1Zvk3UQdFams7uGCdu/NCD5QBspVANtxVfgaUPAgAMImgrOj07EgGJLmaRhCvzoc+i8+hddeYeEwD+1RxFaEHil0+JI5dAnYL6rOfGshiJtlgXQ0PWRYU8AydwEqyck1hJ6bNTo5Z5wWANni81vKlPoo8zabbrMVgcWaHAbXV4BMYzcLLC8nzYYuUaxD4plFHjgb3CViw23vB4QmYG2in8id1miZAFaOjjno1SojXV0zkpajfZocAjVVr5tEzNnO/MEfTQHA/RSOvuMN8CIrk6PHp2Ax/K9Sihd80wlPwgknZfMBXoLBuDVzRaW2OcogCHNuXqtTULoHF1AlqwGTll3PthbNBO+EhpjjB1kDAeTp9Dwn/AsWpVM61omi2WJBdwr1QuF81hSYlZKgGYmb8wyYrhQbIm0PHBZPNBFZUlIji1lBRaqFs5OWJbUjh8sLpOZ+gh9bQHEjqkMrtRL1Kjm6GGKXQ89dcoGVu1oEplHuUVGB7A2z5iO3AAcIX6ugtpy0MNxKGrBwmmsohMlaaEjDaDGPyjMdX2R7mkvXyF2hLyMtPV8Ky2FVHdZ2v0l/EXZ2bBzQhEoRVg7pkd+9AKn4eHjgZdgckhsnlUnN4dRZrHjEFlj2HZpXWIm1mjWvG0hVifU9nLgA2qjx8b5cT+C+TEXq/vx89bTElwDl3slhscMRhAAuOaWR4Md3FUmZcZ4Pnie5F6LKQU2NDKYhhPUiaa1v1XN3Jq3ZIGEDODyi1M6zeBh5yIZSZdnRw4A2gU42kjGFtWpiUA8O93TOHGrIFd0Y8YlsFQWPXbxEB07y55OizSgWT448Z2nMotnEbu2VJPOURBfhBtF/ZFG6zN8Ub7ODLD/skXyacVWrArEyu7x8PZWUD2pjFBkBwLXqXRbmVAmJnbCHCo0HtN4xgAvyFPmwyLH32YIZVy0lR0EUN9//YK+Gal/ZxUu8WA9W8bQSdp30ptpidlJfIslBYoAREuLATrP8pgIpQAmla7/zhqu5bdBSdY3k7k/Zh59dAxqia8LaaE/6P8gMcQC67gwFr0YUTfXjowgkQC26mrkxACwBTOViUgGhgCPURUHW75Z3bckA5ZzrUZp5stbi2TVt6DjK7LhfLxSwETDGoAcC8Nu7iq5kIQhzpX77Z7CUWuFmFz0BnvSeDTXXhWzz97QbArCGz8tpm0TRHMj1MtQuudjrg4Qc2c4nk0WOgXC6c6NOwpNdHPkjRNlkPgDcryJW5sPfCFpGYA39svvkYJldEzCGRDutl2MBaVzXa+vuS+GPz24EHlsrXL64pMg3UlZhodYPywR6r/SuZsZdxr1TaXmGyFmZ6Q5QKMVtj39KK+IR9vs1e2WqmBcryD8bio067w4MhclJ3XvcIr1H9j6FimBMjdbQTM4RMAEJZZahhXJdhJ7XwPUXlS0E7pTbacb+VdZowMXKKCZHbRc0mZqLFIejTSoVvXC71mmowNUdGDA5JuhE31pjTMDh8YNM0JcHjLx/xeY4TJGlNesFF9VueltzaTsyjL02/8RFN4B3JdjXtuHfXZyeO4UQ7wleP7zcA4NNjAHw7I1Sv8L5PFbq04c+ODDyu80c8tBPUOOllIVyzkU+MOCNhQtTtBecGbNtqbsscaYgosFZCBYLjx0EMMF/oAG3f0vjKjSVIaY+i2Yv4qryMcAd3r+VFY+ZSmvfQotLNvkzBRij9qjkqBPPGYititnYu4peEcTI0zbAAX0dRh6+UM18F0NBPfrbevBK/jXKAEoRmIdTU/tcQ+jFKjd9zik93tOpk++l40znHRdlNMjCOzCB2sK7umOke/Ex0I7NKoibUCAVOcAcOnzGLb/iug9B+gFRhsva5SfYo9zjRgCGMArVUTQhB/ASSMqGGtli1NVNG/Rt8pbiIq07rFhZo/fAVE3/G7DG7L5Ogg2nrmmY//uRk8EsV/pT9hG3QGE0Z2fatQdqFLaJP49J8efdLyQRxFdYN+htSy+YDPYxbQo8R2puqQQ7r1hlCzhZQhSvMi0oCoAh5dn89QdQGaSfSz/UaWg3x9198BNzjxpWbRYHZyfXFfgLHSiCnRplLbImUC3qYRWERt5tM6AbMj4hlFxqRhsg5u55h4zH5N5ivdE1aRqqz3v+RsDwQH4mCMkr4o4SkZSyGbS5cybWPYQKjMeB0DtpCCygcumPOjalICzVAGYqfoj8p6gK5x+nAIZtUGKjouF3mW38RvOxH/fWvi0RpxucpXkGEg1rv4UmZo2//uhhK38aIYFPYgFKfox7vjNuZFSIi4SwUg0+r63vVrG+X1fDor3LDViUFSR/vjeX1cSn/nur1YbNnjq4ZBu1if1fc0e+E2coBNxZfsB7WM1gX8Z8ytbzwwkmYIKgFeEseLCjGv7ubUdr9hovVZDFVwhpomYMmzELrs3dAXMeASURDEGf5SlYZiwLvHjq9NMB62eeJbhyAzIT1xFP5egWYJFcgXS35a88Z6hWopwPOC3wSHGpEH33gKGtPiiO86OpE9JpM2+DvVS6PJsgDRktyE4fHWpieIjEmkydh+ufmDjfF1gv3ckcTgSTJ85hgW2PmBEJShvHXgN34BArQWjhHnM855YNVL1AywdD7okrntlB4s1odsHfaK3FRsPBMkjyvt9u9ks3ldNuYP3yVl1i7WbF3jFBevmBntnDUJZtQYsQFp6m5YZ8buli8WQApyvFDfklqo9KYHdpKkK6rpPbjM7lQlHKqSfCoelGfBNlT/vVFMkMvuRXqk25IQ6xt0GdpgyVG/57Uh7fmyPNMMHRhheVAEbYo6LbkB+WrdJopaavQueCx/4uilhkS89tDIXktTvQvrW7jryaiXEOLwkW4JbYS1gH+EwzvrV9fWr7b9tnaV7dszLTcnrGUHqNEe4WKQ9aeUz2PbOLOaUO/V0eG8fsjMVPuABMMQO/7vsLdJhkAau5pcfZwMwgfJ88e5c1N/kM4J+gS48aOCQNEvr1ONwV7GHwmtoKr8mmJlELHH9hM8lsmaOWgEcMiSPM7MKwMJp4lqmUlWrIXel5kFO/H7Gy4hOY1mHfz7JgiSJ9G97Dh77PoV0oAFB/39SpbSVkUZ4Mz6vZ0RcYkP41lcNKbrtnu1nAVcikUp5nRrdSgP90WuZAUBqDzrF6cqdnb3HzyrFktWD8XY+2BesneQd3KXafbmOEaNnEme6UvuH2Zo4UPfmlNOhWkhxrz87ck95JMrGu/UAHn6rd0be9y+ZApQjPwxB6PgS3IX2W1ekzA1n91ExypRmthvHUKB5QkAtXCeoLvVJJHC6sknfS2p3xMUGJP7sE1BEm9YSF9sCAMl1Iv/wpqaSfEuJ/lRV135lMYrktw8zsQzY2fatm3jYaD9D0gNAM+blpjQNUxxHdEDLJB5kVYmi8ppGidMcpLp2ELj2Tz4ravllKao5iyUgyda8e+0DAFp6m6BgOEOmF3YeYcvE/76Eidjj1quENzpD3e/aen8fWrjbTHmtyO/bpii62D4eBuM5T96Tz4l4d/BkyKAUseYuJsMj9LAqi9R+zpzkoJyyoHPVpmP5GprlvyAt/hRzMl+eC+ZIUHs3fY41OnGVUxV0n4Fus31k+Zgb6mUHWLzfevqqhoXwuFjl7M4A84K2yyf2IS6ILTZ6xFItdZBd/rPV3sJfKq/I1lKCW9JgAQqyS2ltJTS/gKjmTGnTQN3KBeGNOq96tTDUIpOTg15c0bL9zxnO8jRDk62qAa4eflMIfMvMsgCQ/EKRYpPC5o8cwdH/tVC/xWbYbwxFMRrYiVaokt0GFev5lqQ2o3kGYcH1gNXjjz+GrUC8wwVUQnirbiO1kCkfk7euQo/lRVxR11+epzbSXIS39JIkvox7LltNrf4tWztqVwT4s52tmeZVamfjNUPlAKtr5RIhtbvmJWHo53LVSznQ097y3JYps2afVSeYCj9gEKCjXxfMxhR+bxqiOvRH+/C1YFzpyNC/gCFNaP58ym2PDtcAFnxK3wmmWyP1oHWHtvzI/nRuHVpB7OvkB7pbA5gP7yz6fvckp9SflH5Fik8Lmjxv+Y0yXQ4Qv6ii5OZuStifZH3JflK9+ewmQQuLC4tolXJpqfLV363Q7PuNCJk+XOWBjXWcXoVnVxIRyqZB++9RAP0ggFitdaX4A/PuzKrVWU+D1UMbJuHr0yXfllwN7XiTVxbItXRwRoI2HP9/hVAfQXikwlWzrVkNybpFSElhMioKE6uSpUkYdI1/WI8mwAcKHr4J/xIxCIDwv05a03EDbEIqQGjKrgjKcQZ6gAD3/CIUOPce2Qw/v3dG+kpSHXndycPvNUJ2TNIejL6DEukpq0yIE4VvbUpJMg0wMoITJl8Mus6OhXEHimmg8QnZjRBIu22Ll/JClczfHYmQ9B9tPlEb2jLy1KrYXXwBwbsrZH1ghS85CqfJSLTnsghZcEuhNLJ98HwHccIOP+13Zwz/l6fArCAtkcIvqMykgJjAdaom6rFk10RQPzn+wdWvH96PhAgKiLPTlNtvlmBegTjfQapo9AbeM1Fe9QAzT+9wTSCBPQhfQBO43oqFMCK8tgJaeGhSHCF96QLpn2DNSIv5aujFHwtBTXQp9Wt1SZ/J1MExCTCbcXtkiCTzzg4bKLdk+TpsCBg3nQ2Bu2MmgjjimPfbRVzpsPFZ7P3wfAdpJq2KL0e218/X0gQ9Ynsnv15GXs7hZfiywZCGVYqc6nZhRJunf0ZKyIk4AUV5MJ79ifsCqWLhEF+P0ja7T+7vnE9T7hr9lJYGHWAobIMBNCQirI4QYJ3G9FQpgRXlsBLV0e7Yo704RwASu/LnsFiekyitrIzYbfFwP3MoNXwHedepA3JsieuosNLDDT8dhBcO35dizKOwMXfwI8cbYd/Prh8SMp7yFjBKAMysGlshWYcqdo13JTNiQGABE00ZNZYOGRQd9UKUbVC/0e5kOagKma2pNc/yAfLcUKUr0us+AIHOtCGobexorq1eOvIfXQO+1xJdRlZruZ7UWgzrwL56ejmM9RfdAamE7F6qkvJ7BkTMeQkAkbQBVjPhuFq0GJXt/zEP0G/UxFu/tRUHKjj/Rky1zqByXHV/9RhatIW2ysdiprg53HpEADyeLp92JxUmGmywlo9k+19CW/w/0JsEt22ljCimuosgkaVL8WJauYa9jvtG5PuP3zNXdHglHNdanFbJBBl1CZqL3BLa5LCMTErEz4w6ASF160ucigoiFRhO1wuMpjl2LxnY8wBgOfGI4BSghjEsSvQuQuWAuFEZmkRgMTIQhwEQiuYrENve2nERqBj3TugqtvD09CHazSpf8DRSWB8OvmlFdgIsbY6dll7cps9L2JBQGw+/6zImDjE3r/YATzlcB+jXfIyEd23wmZhBAWunNHGEBqAEmXuhf6IlWCUQT0yjZQiJEZqxHqHCSmWq/s9yrIR5XFFYLy+2uoht8ROuHxUuFZmHjVT1MOhj0vK88Ftoe0v1c5tyWKizuGLbcjVtrPFwYHPe2VETrxFB/D9Jlw62Igv/EI5gvLDzmkVQcHWnor7gdHJS21qhl0zjFQG5hLTHgL4FeUQNBOZ2tGlColNkOd3w4bsFro4+2SOiEpHVPpoPCWfZ/dhLjDZb+ZKWFtJ2OeXsLOCSbh/ZDDZyK3C2kWOhhA4P/dO43t2B9OtWyiVa8vuTa8VlWNzJ1sGa/tFnUi2/tb2S29Md1IinttV1VUk3eN0GWwZSorRTfodPfFv/JUL9VkptenRu0wLmpC5OhLj8sT6EUlxqoAPbblu2bruwu8LUexZAASCBOTIZSt80yLxq1Ktz8EmsLQfE6EbkfG1svEFnlp9KByCnQiT4fGTilzgxrPg+pGXDAFYiN6g/2l4T5NInkfFYm8IgzbEODLGhMAeJ1hI3T7U4DBlMxtj0i4lX6TNnUR+OlQH0X5nZSVJiuxT6EcbYMCViErAzx9jdAZIBySJsFnaCs3iukm34fquK3l3yXEZ4VlIsgNqDw18QTAL2DlxFQpVB96wUZM6fm3Xn4nfyx2OfXM4FcFYK9Ex5fUL9GjWcHdULb+GLXZi3SqQr6hQKs0rx3w6I3QSVyZX3OWvIuqmK77Q9vx1Pvr1UB+xk/2Vfi1quLYQ997OOArGjx8v3jz7qa636GvZEap5rnpcUUNdkW6bSxK/+ZGTnV4+/VzJYNVG3tiP6eGoKGmVYofGWt8v6/cK7bW+qYGrycs4I5pMg17uKW6RfXWiveQQjoUuFBRKThK9/7wtOTJaorrUxleVpJyCaRrZOk0gC4I4Ca4opLavGm/jiSsh91PNPTW3SQf2aUU59dIekToxUqJuOA2kUHO3ZHXv0VaXNLKEUUoinRhFT50X540yXLDragoM4XQmR/A9im86COl4uP1RdDc0hZ7ZB2An8q2p9PR5KNHRZRAze3b3Rm60gHQLG7lUYmJUDW5txOzRMQ4k8Xw7RpMSdsds5Bhk/QugSQnpOsSA4oiFzlF+yb/DFIxI2ybQDZcW6aeZpEYEKVZU3A2daJLJ7OLen0cw9jhd8NLyEQoNkEtFau3ulfeJJ9gNmiGxu0n80UdBojahuUfeCVQT9IXENduz5niwiSLrRIiGyR+H/NYNcaEKfZ+UWoARjUx44ALVdyN6TvBQohurt0fG7eU8jFOI/PubL9eXpfrPQSR2Y4FkghX5N7yOoQXuRv/A0Ufm1/VOX3HVYFwa9ySXCzOvt5wbkBOqDINlzW+leWTq9c6zLSg1YAMdSDc+ycPP1KRQm8E7Cx2/3AchH4uDJuycnjxmYKXQNGY+SkUevoOIgup9sG3NpLvKUdOp3xfTE6xR4UkuzkztpiBLPt+4oUKCncziFKBHiaK5qifpA0wBC6t6khBFSlgWQyV+1xMv3sAR7Hxg7AbF2pwEDN7PQMpqXvlNTlvrVv3YrRq+fK9D3OhYIGDWtY9uxToXmbf+JFLTxan1H3P0JTQESV9wOndL8cFUg4/sab3QGifi42MrBgOg/qoHFI/8+Be1ehPNOx4A4umbKBWr0Y5HvNivhcx78b6ys3gfb9+1O2pa1E1Ipq+27b/Y26MYaglysKNW1Rclzsiv/rx3ynl/5roT7VaYrs7K1/2lqvo7jYN6HglbbaDjhm7/YzJwx5Urom4TQ4XjOUGu1TUvv/kTKHrUK5FGqc0DeGPtlyU0Cbrh5GooFz7QUwvTdpDy2KACPnFntCYVWExome6RaUfJoJK+TEQOrjmlcrF+7AxNvuKOIln1TO3GDGsTi0vAknx9NDpXlg+e9p3wTdMLWkb+YHLp1mzG8jXqOGzE8woPjP9fKTMFcfuO/AUsku9PsntQSSvQ/ZRh+zQ+l9siziIOuXLdrgXo1BIt7WiWHX+mPGSklOUJLfDXNtjVWJd2T+4n98tXMST2pmfmpm6mqLpkrkcq4yTFopTbuaUQ2YPK/2CVn+9V6BV32WiSbOKQ0tTS695rvdF6amROuYas0rXvTRwAl8wPRZxKt2Ux8onYtO8yNGDudQG22Olcp2bJ4NMu4AljSEx0N9erD4OxpOhX7DkcZCXgtZPzcLrY8JNLQu7uFmJWy94zI4R/H05vdxCQOBdwlS8bdCloEFBFOp0gxJgN1ynWXNpD/giQ8+nwppr61mTeI6M1Dkt07+LsIWVXfxSLQT9GPgS3QXqgwaVcMgQslPvxeuws70fOXb+PkvgqB9y+B1D36Q8w1wvGfVYIacYbnBo6L00CwOuogV61eMnVXZQSBZodGP+exNhguDLt+g4dowITV2qnCeohQC5fIHRwXlFGPfpDIynYVhE+AyA4ul6q2HUGXyIm2CAhiNR6SY0jJlyuxvdywCei6+lmVWUl1KMfU1ebo/9uqxgIbxE2v+Eg97vhkrhxFoNgrLC4JKAs0OjH5MO1YYGBhaJbJ/2uuopN7Qyc01ieWvxYgi1ivpY3HWyP3jL7tceQAhdyWLKFAZSqo3+BdEoYGCfQnWpJbtahdq0akNhs5vRy8FC6RxnFzF/q0SXYP2+BYeGQUqmqRFasQ9BuINGBIYjpl2JvvOLxTYmNwC0x4O8+9E5XsxhkWLCXht+r/fe6AU6eyqHcPocKBpgpqsuCVJE/y+/x3uYlgp4GlsnDYQYJBP+EjsVMoR5kgdsyRDl0m2IHWab7wfXiL6Ws0eForMXg/wSEY37jjee5HIFLe3BZU0T5nw1ZAgsn1OAu7A7uFyF6+sXQFrxXcXZOd4CBv14TQ4vbumkNUxnJhUUF5igf5LP6H5AwL7ECeOfEAuBtLer0VuRCJ9ZHShI2MaCKBfyrMaO+8l8CEBQbdjkxK7ehyiDu20qy6g9YZIxOgVXVKysoR+7o2mQD50Y4Z+DP/pv9P7AKYSNef6rb4ydnAxYpD3lkaUWsYWUExOowm9cWSvG8HwFt2xUMoftBENN1XNSiFnN8PrMmaYyPdIxBP8nysMu4sDM1KSjts85owk4S5+TsT+EREv4VuyJ6ohsWPiwtGXTk9dI1TEHAXQbkF2kWLzIpS1aTOWn1fUBPqIMMWJGvNu7ElBp++I+96hz/3BkjHsQj+2plV4a75tJTL2kNKCJmVfduo050umGuhLWGjRyyr5f+rTbyeMwmfRXMratjkD+tUlDVLjI52WgrirOivPYW5s6V52+AqwVBKajyHNnhToA3Hol8Z10b/HaUYNKcWb3X9FUr2F3yDXqS3eXmzMAk+mL+60zuPFAlDK4VyYDPKZnGOf4z4AKWzVqusBRYCheHCXcIpGKut9jOJK33UJ1qnO3LGyGQtatzQhQOiJ6Q98PLIRfWzq5u78Fc2yOSrZw0Ol3PhOQsCc/MCukW1LfhJafYW0SHiDpAWnf3HdtwC9KJ1RjiHtOBmc1imXB0TM2sOY4i5Si7Fp4LVK37CF3dKBw1v1/6r14/+Wgm5NKnUb57AwVoqqoJRS4aLZtQFJE009abnJTMqUDWV0S4oCXLFryyoyb7DGfFrimZ3+U/4KIEl+I+xgCJRBIrKnwncJ1aKGwei+B9BW8VFURehUN93PhoQ2iloZ8rh0UKR218ru3cawJSezHT16m5I9JBvxNETPk6Hg0HJELySv1F/xXfumV6PyMIf/dDWeq46PK4kLiQuJC1yVw1XEhcSFxIXEhcCAyGdXl3q/qWo2VcX5m0XtldLBGJWTFXrgqNXaYQU+G9sOitO+BKY7IU5Uz1WAnGcfV1SEOX3MlSpDUori90gfQNTaVmeRjAYvrMUY9B/xCrpCozgJrkfHTWXYVXXTQqYKZvIkQh2i6CMy+VRXWeEGta46W79XGo1kHiHA2MlO4jqtUedQ/k+C8PiffzHgno2XHhRO1jjF8sb8DTlNMuiQv5UDAzBfBqHqIBRyx/5+plQ04Xedq0c4+bgp2qDBNSie7ME6cNfeUGPASN2a1fQNja9dMzN5DwaQ+xziNrk1rRrLIm1LkLDMjkzGhWZgz7o2POUxxdnbXGvBnBD80gJ8ChepyLstXArqwMjnJBwSrguSWp2FKsY3jy9pwB+lBLZQBk9xjDPHOs1bskDCAGNE7DMXbsXIK7bWIUC+A1g19UrhRcv4QXU7q1kOXlVS0TJbH048q3O8a1a2S2tCLkuRR1UGB71/8RKPDLF++PIRvjwKHcM+GkPu1Kh/iALwuok6KW892pVfPBzG9z7n4z7Rl5byQuQejQcGH0PnfukoPJ7GsGYVVGF4Tx0dJUzhK1jEWshnTFCcmEEm89VpySH+dRwN5R0okJhqWtMcw3UfcecgPvXBjSEtTqzXcniN2MPgu0lzd8+FWI5jul9kZQpzqoPMaxRWWQfzJX6yN93mSpbcVaYUFJSxMOwuCEX/QUYchEavvxCeRIWyh1mkqnSfNfQ52hQEus3M/iDldg1YqBJ2piDhqk4G8dJf1Z2M943oIrXpUDg7apjGFAo8qxDQy2y/41qgMHjyar/8WKAOt0mc8K++FyBY8pCwW7eFslXMlUX7aoDE0RqbZ6nISn0zm6gFtt7cXrv2p01c/V7J+qsUMinm3q5gkb9o4R4nNpwZ9lISeBIiP/J4uwjXTDgfT+JRyj9GpAcCJcTaPijHd9P/cFSp70Y7mSXCuhwSYjfuAyZIDADXepZDShnHy2bgA/gJdhxUbQd/LrD7IxDK4Kh+LzT1vhUZ6UShQEnilBLEDAhxGJ1zjI35TPZidPmMUbnFqywImyQRnFBO8HLGmK6vNXhMS0BOHdaWMjagJC/4rPafT7EHXRJPwadMyiotuiwSMuJVHdyMg0rpMS8Ub9O1SVldbLKy7xCOYZmfoCkb+5YAxx8XNAhn4OWi8jB2Ysu3i0Q3kepuiTjj9JmflaGTRNDktLtpR/vNJxmkvChjz/fuqMP22zMgrNNGyQkQy3+3wzfittNPMskcI0hXEFdkvsJWrNg/fdratY7aiPfI235RjFLECRweegniN+GGTaGXkf4Cs+QMUJ2apidI7f5qFop8TE0md/SQbGZUzWSWfnu5hJnptGfwUUE5IzXuwa9U2Jx0XX7JOU37054KTbI4kisB0Le1kDQG81rvabSoFhNTZC8TsQx78HKnnLtaI+2TZYgKvsWgzrpWPrnjUtYRorkl6i4WlqfHXU2v+rhljb60vWvEEIQQeZvo7Qky4bEKaFcrVg6SVv01+lfEhCNHVJTFdmhZ17lIWNACO/BCvxoUjSCOQg12IwYEWQsQNEI5Iy+V4cK3ApOj5ZdlAM2tFSap2r+LOolW+ExwY58oxtDDgY7oxt40o2IKq0cpGZHgXTGPy0bBpoVEpRCR8Ft9hIHKy5JSru7FoHl9QTShyVtaAJX5S20dAi4++D4Er6Bqlptqq5eB8S16COmweznV/WgagbUed8ddwapPt1s2YB96hE5z+ryz+MKxnMDF9xAXx0mTrhzzRRac5c6CMjGrCkYC5YsZKasEDYSZIEbabsNSw4zs1zHMQ6nZB8G+j/6g7dzrrYZf57hF0dWDchX/3n6KHEh2a+LSfjDmJL2L9YkO1TMlRDxrt6TWE4ajVm/t6D2bKBQFtsOqQMyz3Gp2E4ti6WldU+AwzV3PHOcfRJaMNOqwdS+qhZhX0/Aad6faAiPDM9Mp31ZLkgc/ZT0DlZ63mVFlb4VxzjPxTzRAbhhUpmkXQvc9lxp5d8IyEN8wiXaeVKGFZvkHdXRmEbfZ4qQcETjl/o7s4XitrZ0lxYUn+eywv04geRIHJR+SRhMPun9b6wIVdYgsP0InBMcYQH1bkWcZTYcYIiojYz8xn5qsgIJg+A5f87Dtr916XmWAIElCdG+xb7tkSm+yAK/di90uYOQcs+i0CrFrnAVMUGlQ6EJKdg9WuUDOl0C/OZlXwNV8SeW4cIHfC+WU7IgcqYfz9TYqTa6C08bWPMxKLU6wyOJB8rpe4xs+Jgw6KfgT5V1jbl6CeZe8/AM6PqTVkC+dG9RwkCkd3qMUs1/2eKkG/fB3h5ztrcriFkbnEBHwJxIjcpFN1yATFoBS2j71QTLqEKUAdP4XpWPN2i1a9Go05tWDdHCavlrX8qNh5nh/LLluOnoEBJobzgELjsQYE3W6ZLFYbcTO1CP4f/0NmR09jYbhNliKEwP5IWsFhPOIx0wY7/oHR/WPbYC/jlucLk4Ab9zqmrG89LpUVjfOomClsrfM2B5vhIPfkbhGYBZS+fEQdJe0WDLIoUD3PZSQntfSa6YygW2lUJ5c0dImob7aGf/kKBp0s+S2V+tEaF4AWcaukwpBCo3udqxizrl2RWKxWKxWKxWKxWKxWKxWKkcuBtXrXkAqL+LesZ9hvf8umuIKa3gNzBPLw35q/OmLvVKeiCqEALFglVqa3oxEUCYaRLrjweVRH0/NOiDFa9X2H4SsFIpfdoEd7MQ1hibCDEkcBXvkBW7c/Yc2qYgOQBz1i9AigcSUutxlx/OQ3xoxDGsesD+q9J2MuprExP5R2ApjGpr1SXCGxh594FIOav4I1bJwTQMQknAvX7IPw9fB0ELvSmUN4xPjICAwCwnD3mX+mWVt1tHnWcXjxIJKEvGAGNa6La/T9IbylGjF69sgJmVeP87nUaXrzyAt2vdWFFMI9BY8EX/GWMH/zmaDKMjBMJ+agyInoRw82kc4bhy8m+O/VUmeds+JQZQmkqtbBWksq0IIw+xOnYZ95fk2+c058VJbY4QWXv4fGnSze0zDLZzihRVjtXpme690k7JsoxcENLTcc+lkXeLtXv4612mJ2d/Rf5CLEn73dWdqopbrkj3uQ7b7QVPzq7eKSCVOjGSJhoG/dOqij40jVMDeFqKe4jG5nhHRD8tC4qd3f2dMAu+LaNA9djcofsYyAy7WSEKy1nHbYcTL9Ec6YyU8miY0Od4eI5JHpnVrkYNZ0ksaLlizBvuEz+WiVa//oAi+tz60rKQNczlP+wqXGIleZ4YdTsR3SKfIcA8vnflX0T689da+AgDHn3mp+sztWTak5WqVaxxgnoF1+LGFzW+f8WzylR5oifIm5NbKC0LaQWt1qtNobO/j4gsfHCZioInLpYcXqlD9vtuxSOInqfF8IXWRBpFFvyozkMimAEl1R7VpETYSI0cjJ3f9No7DWlVpFw8btUfARDc5tRABaXLT5RKJjA3f+8JcmH+SpdkDqBlZxlR353mfxIjKMQj5/IqbwI1G42PPNTOgvaspVFM++ESWTTCreE7hPq+3VAvKw37QqSwAm4LBJvukgYoQPZKB/DFhq6d35nWfO1vfHpX4mPJDVuS0PLH+XngfrU97PSAuUBrFzyGlu6upnBL9U2rjvCVkwjDtcFIBQ2og1o1Y6H3KctT3an0KSSTANvGF74yB//TyEZ9iYCv6FVL8e2BWhb6aap5nA2RquEVfdDpOnd2TYaGTBXVayJxrNajCwr6TKFt2NjP5H3rzsM+8vybZ20FUSM3Lgy+V/4Olo1R6gCqrOUjW+JpQCyu7RQBQ6oWMkvbC0Og+nJIXtXXOZBdGdue7FY5kzlP+zy6SJNomQ4lu1BBIMTI93+Z7GKbLgO+gnBoK+AuztDH05WO1+llHidYSNMjI61R0OOWdtcEC/iwxxfjgez20TpEvh8jYcMioIR3FoAVzC9Yyr2WTJtIYLj6V5vUn+FxOD6IQUZW8xNQCjdod9hjzbmCsw5kCR9jJrW6e6V0fHwu49YJpMwppo5hk0QaGM3RmvBrz7EeLRtFt5EILs23454wG8O8kJDCZfYcFgea0nuKuwDd3DBwHGCKxMsH4pe3EYmgXJkda2djrDVU7DEs3gqWyijGf/Q3FhGFRsOiiaz5G1Fes80eEZkzqePpHUzgjP7bJ3zJUKN3gX91XX2j3ey/9d/vWNbtK3NGQrh+gC3SnKFTFKtZwNd7DelVdYNbEd2zaz5RrENLYCu0NldZNFPYhXERUDC//0J+SSb8kx4pgY85FMgg6PPV+Im+vpZTOFvB3HWAeqZhVBiEwL5VVNGfsI9M0etCiS4p+kkZi4w8iY6M1ezOr6VUSARwEYN9ilMyFklsJQEm8eOqwAmcRrADcCLyCtXKf64EHSuZCZGcC/1Gvon7BrMZBMFWQ4wRtk8HN6Tnj/mn6HmKpI2QQrMqVnXe6u5yErnRX3A7JvecpopzID7IZ6wFX48hw/5XULSpb320xGoKsr9s4Z10+5WbtsigvCvebRY+nU8aanwslLRuHxlDhrd9r/FhSEwmfaD9lrVSzyMycuKCBxAedNZ6ufYOUyPMdP51hqND1lcTSeIBaxJB44x9OgANqwk8jpK1wqjgEN39mh61hXYpym80ZYaXhdsH3fvcdVEl1n+dKBm/d4FPMPKuhuZ4zTbmJZjlrt6rh6U57m5clEro4IvM+2OEoLtfOox1LypPeMQdg+5aquTBCf9DE4GFfr7OXT2JudmOLTv5XzgK3YgzOZEx3BkNWRfdeD5df8UH6MFyqOqNCCfFpQ9ljYMgpLMlzerRNlVwIdetmtyYjVjdt1Moi2F7U193WrVE989Q7pfARFAy99QQVh9KG2WVBm+NHiFvYd1KXAcsRao4XevqR9e14DPH2N0BljkauZq4emeX+MVXfWAxCq9vborI8dAuKzaKWDFBgBjxpLqe1rxcw1X4pfjvRc9TEK8USqqHljp6ASH8IBJ2giOEIGdAKXv67o+DgvaQqSrCvLJ/YxJ2/LgYi6MXIILY8oMUunxRIu9Mce1BHIuWBBxs4Zbiq/Mk2Nzoay/CXrB35q9l8Fz5J7XGED+O/7nZK+g4jv2TzNFwvrHEDPhHqCwGMiwKdfm3b5rvddDw0cjr9wBSgu5A1gFXl1yBm4utaZYtTHw15Gbd/wEYxoWDsFL5p89SQRDvP77dItavoa6H4xr3RgHU2hGDaXhePpDagaA1wNh/NF2T6z93s8W6L56h0U1RWqfw8clc09peF0PtR2Etyvlaboov2nW/8cMXM1jWqEaq8jj9wYvwypp/3BALHGWt7AnU7bfkjEhmB+0EZEyUTYg6yu7fpRch6z+njVdza/hzfNdWVWxCQ+OWUW0O/N5fv4slCNAGu8Fb8Myo2UPBfL/UaT9wIxH2z+01c8PB39kamEDhl+cQMU4eXALlCTc2YCYBrraBkBpBo3/+cti4xIT/HDQA6ggX+rX/UYVl1LFOcUMXYZbAbK2/8sGuHAjq/gXE02Upygl2WOGw6F1MwzyjL6Sr3G7TocjzIShKmF77RCm+PzN9xWiiH7c+d7UnbsesICmRz3daBtzISxRViR40yXTmEqrctVNeGqag0UsOwwWMf9FLuQWiJ7kfqf8p/5VxpdDQZ3QJLSi7N7j2KvZZQC4vi6Thdae/C24l7OjphpHQnBker74iIluIRLpYx2mggiayphrcZEyUXuH8KgBjUfPd+L13thcb3HIg4q3H45vEW8O+fCPtml1WS4Ey1xZocBtdWbTIqAygi8y4pZZslLDgIYtAZegSvU/8sgkiDuwZuunyQZMH0gH2dbqGZi5nzytqaBiDcvmV7ut/2taUR4SjEdheJEc3V35R88/yEAX5S/BocTDZQLMnqnSoP93IDBR0oF14cnWVY0du+WKCs8MeTti/P/o52PvNbLMpMLxslGmOWrO4u1eZ5kYjpv1ocQUkUR76FMhZNOc3Qs4yiK9DjmYV2+oHDZOY+1sGZrFKwPQFgPVJvrq4DpXXJAutsuf8Fi8pJbnKbt4axwwK3oKIU27Knc0IDO/bDYyZT2OkbxGAL4bo7Xx7PtB8hchVyRThuon+BjmtzV4vcLZxfNnAji4WoQ50I7t/0VS/u/2GH4RrDTRs30/jBQQA8Jsui8QEt0Ujiqr4SGWlZ3UaIMRTSiqp5YToofSqiKgZDgoRIimiOpT+EqNb5kBv3lVAMR2G1zufNCvZzFpQJfR84n/uWs4w6uUTlNTgCDn0l/eLJfi7GvMHuR6/NH8F0CAm7QSE06TMNQJb67NUv8F/KzXh9M5qMcSLn7YRR11fZsQxdVlQqJtNjIGl4iMMKTgNmRbo41YgQY/B2ynkwozHBA7GNTiHPnIJDaiyY3hawbBKfnTmiOS0Oiv0gJhCRZfCSwHgRydmDG/ikSUgClDq94CfIQNsmbLHSEEb6e9fqlROQ1+9LVtEr41AIYH1whGnTXyK7OMGbseC9IvCrnx8MWOEvRFiS/olGGwtZJzBxu9bJ7u8OeOaSRPDo7j5V0s9ZHrG7JMwZC0HYFMZx7pgcLLNAXwcCSIfh1mrvRyYOZa/fCJF5AUXvK6+6JnLo2Po/w5ugaF3CO2Jy7qAAMDBlKZ7Ri6s36LANVMsXRK7OCkKTAngklhMz1p1yTEH0CBTdDcOOry10HbhmAsnQbFpwS4qAg/JwSJqigRMGi2fLvR+jCVolPxMw3GKe2k1G4etqucbEzrJC6sbrPwEnLFD8uzysSWhP1jcdkdhHgXo3rWLK/i0Mj0k3ce0xdBOx7ZgHjFnwUtPMCpDTRb0a6Tlx/RIafBhGxU0LBeHGMHQn1mSN6tJzvDrgg6Os2Wz8lFSDFv0Wl4bRlCTJQAgmmPiGwDyPHnCFUdHXURwAOVMrNaVVlnzfLlJ49gBR2LQcVxh2YQCs33GpeNmQyWt/aEJXQe7Eql1fSH9WvWZ/eySCG+0CTvujcF94+FEU722fP3yMJ48dtBeLibKRqXDgA4xpFudorCWtLcjk0Kx8mHyjYhERdjXqzhC5TuW6qNxi68f0bg3eEUPPX3Ei/K2t0UggshSRwxRw/ZpzZnS3DJ0g2mbIyPOWzKtCGfDWT/UlXBeMUesioh/Z35CAvR7F/r1G2pRwpJidaBvXQsiwlylHknzbFujST/WfAUuvPM/swM42PCjrz0N3t+x7zRQKZn6MKiV9jLBDWlFokvFBDEYDyxwYsU13tklAb0GVdDm1iXyl53F430gPXCjsZC27WhzZBhuYZ9HeCKNDrA9nO9WlCFuB5ZZyPVKlpd5geqFhfTP5jJl9g4toFgdjkhsPLafmATSkU4ADQt2+JhW7S5wKiSXrcbtjHyDAXgcmzlRJyu0iPJYW1yPh1+HxgJsgk6SE6c8o49OZMv0OzxfWMAvJOFe2v7Oizz3WgJweqQhtro0NCrSJ3yS72sqeJATO9bLjX77AMByhFN37HZVFJ+q7K1ApVV+ONbO55yfwmErcO9+mxzcpJxJYMgW6UVEWftAIUmyDhxw67FbHi/p6yhXDBGxyVFbIcV0JyQpZwf8cdRUeR2VmMNuj2kVXO7GIdYI6z1bva+jcVEHXWbWFHqIsvih4jUAaJZUvPO0aWLmed16HpO2ilPli2Ggq4dzwnKgYxT4OZd6GA9E+3ewIcEc1Jz8UIrEK9+C/LsHXRwbHqKc1m9mWwKtH0Tgqaaow6cJb5FBH8Mm+WiyHffzAFqhMRZ7bd/dh9yIkGznzpBt0WAAI8S9o8Rq0aPl/9/F8vmcrHCVQFCZvJEEbOikN0DFlXN1gUCh0PxksudWGRKq0OkNqTnxfdCAoQ0bCRphy6C63WfzDjTZ/8kYDS6/0fcVjZmD3oMPnY9mB1srWDxwqRpN4B5FCmed+5kkVNsMPMdIv8rA4H0oQnv32zjN+tTw8PEyRBHg3VhwZ8i023BlpD9p2Dkg8OJlvlNr3g5S9Vt+yKRxvPOXeaflKz5Rl61BnnaUCmkBAwsidNhSA43R7DXittL9pc6i8uFMuqLJOwe9+zY4m0JUhj5vn5Bz7TvkkPz9A7yNQM3AAjr0wYuTuXu/GvyqLo4BO5tP70bIyQ1e5YdwZGnuxlRntYwbIeNh1gYYeWsLBXhALL5ljTguwvcGKfB4W/dhnPmMYP5N2/DEdRyAGs1JTK2WSdWkPFBvLhfjJILKk9GfOrI7BUtFRhM/RBID7OhU6O29ZG/BH7DBmzTtazLgUJ32WVHIlZJX0UVDdDoxugWk6N1n/49IT7Bllos+fWSlXSe23/h4tPzEkadiOXAF5EhxVivXLzOhEOZuOPNjTFvv2tLcC8Wtv1iTxwe9T6XoIUd+cAFp/fO1atHTQ2cKSa5Qa/wqWFtSi034REeDkCWJmVARvRG94DtKugR9aXPh29pR5USVlPt48qKjfxXTbjT9CQ3YXsWBM3P/Yn5sQfYecYwc8iV2CvV5tvOyRyJt+1AQDiDdyy8HtTP+I/pz78oB8xSNQ+oTJeRzZsftmBM4fvsdGaIFxAlRa+a7VFM6Mq9l1wgwiUIinBNjFContBRu9qYKEBvrSGzkUBw2c408dJ5FLyBhGe7Arja2fEq2CFZSAs/F1Ds3FG/lO0IUhVW+zO4XIlAaqSJHoyd+QYuuPKvWNzIXtSQ5KFFnf2k/8sO3aqKJae6BbJIopKC1fMxYOHIuOq6X3r2joym6RYLBVk4MlDfahMzxn8Or3oULEeCzCA4GPHtsT5MfRyX27NNFQYdyrDTOBkEkVhDbAJxvv/PkRlGKByifUji4TioeQUwYlcA/as+KN9J800cGoxrfmbFhknoc2/cEADeRzDO5W+WR4cgK/Vly3BzfKwOqG4r8Gvu4zy1lLjMvJv8cKqiQoAZ72ohXe5bFxLDetSp15ovJLspijs9GfYpx7Ftzp9mwJqDAiUofnUMx761IiMK2LVqFx50ONX+ALuEfusE9HEqziQnPgYI/Su6uxRKF7cRTDv8jMExkexmrCfscDrEqfqAu0NwTUt2VINBVBYdk0DKMOD3iFGgIcdqPWWp09iM5goFOKQyl3CH3dBvqvGCiBRhQoPiVI3TA58PLupaJeqJFZRZKTfuhH6Cno+Q8f+ac1bnmCDJYBaKORtZsF6g6KMNk6jJai/lb8ISYFSV4fV1XQHwqN3sQe5RqCuT68k6iHt+/Fxs3BjfQXgy9COL/mATYz9ZMDv7QMSWeT/V/JbzwW+AVTUtPnbGo+J3xtIyLZRyNkkE8DQThXjGum0zwXEMCKYBVynrW4cBGMazokdupzp/TPWgb7HeI6CbnExumR6XdXbjU22rXMo89rr5m4CiiqtCxds518c0ajEwhYVy0rQkzrU8xK9Wd7BAhS4Gv+ro4hAg1eeInrQ3uGjGv8KkZQAYDJp1Pbxrf2MLjHjIJLNHG9pwJaUvM26nzIl1Zre7w70HUvuVXU7KzVpRhO9GP36cNJGDlXCP86cKlUbhzGKk2dvUW6OIzpbiPDaWvsak+KE1FOCLsKu4GDVv8zBUtsAeLfeePGQzAeN00tlxakWCPIeELVkV9sOaAtEzxQrpbk9n8CcWuXCS09cL1s1OcWfcguCyatIBaO/8NQ0O43YdN6tDRSOgDP/VJfIHJs7pMQV8OQ7Qxc0Zt6K+IOAtErM6PoctiECbD6NdWfIfYRCk1iAy7iRU4bopZMoUrMwb3zYiu9ngPfCyZiZV3ZLOh3XQEa08iDmUxjLpvJ8cYTfaiFAUvRXKzPaU/N7J0Xqt6yPI5HziLsUV5vNwq3HjL4S3SLFUeK+1sP9vrDhNHzvvkvbtWYLyapVf2qlldygaFBoTPHGTR/AuvLAPG1sKb8CSPD3HJxwXvqZKiwkuIBXw21zdLnnf0vaJliNkCxYlCkPi60Al4eAInYk93EpwZHwyWdH7nVrRdiMBen9twX4SVU7j8ZbdynuxtlclEnYmAA+RWHdaSxjYu21kC1tssJe5mshtoX6eyY37HdmLjez2/PQgmI0Z6+7lYxs73LnpHQGuZ5OA/Zx/n0f7qx5ZeJdxTL0ydttAg1t6Bov+zb1vmhVBD1I1VSJVn0qdO9d9CTKJ3UycW+LsHpr3T3lkrocAriQkD0nWhvEDRlNCx2Yxfmz2e8nF/jMSEhyTapw/RjRR/yS3ufvl5blamRCjLzWnzMLmb//lRERLrSTLHJRDUORFJbOb97Ul05vZCVpBvzy6RSOFuIYX93HQCVutrQx+Br/jfWti49J2KnBLBseYzMLmc3jMbZRMPfQTGXnAnfcY+jVfD6uA7EIktg7unYIneElCDSQ8t2sg0NUQefpXqdGhDIDBEoeDKhh09mwnNShpKB4QtWRX3FY5mUqolhSVIEGwM0e3MeFt5PdSvYVO56np5Bj7BqA6GFl9KxKbr7c3IuZfUGr/FYtRUAYV6xiiC4IMsblegWcMmPXRIiowuLfIcExIyNIattDRNNWVnretUDX2V4QjxfSjg+gMYNWn0dDr9vPbZOiIQnBXyZSItT1Y+VH2OYrWxhRc6a3fhXmnG2RsVkSy/Hjn8QM9gH3CPDZda114wKx7WmEaNTMPO5zlChjjMqCTzcyu8TbNTPH6sbvXJWkTzP+HVYhEAH9o/6q/U/Cx/bmAx7i42Q5oOpPzpcbHLGnx81I2bPxI52iZyoV6X4oEmSKHNK+/eTlz9x1QuPpLeGm34Glt2tO//Lv+ZBblFolCyUYqEREepP0si4ni1TEvT+j8GGJOGYjg6TkxwtMYeIDFFqNQ8eKZ8Fkao4axE1qPRQQDTEtu8/OiwTGkdPKeIzo+b4Yc3+niCytjsQcYUB4wo6eMnDUWK7mwUL0etHyvvxGpwbHs4+pfOieTS008YeCWj9F25RWN7zfbB3Td60q1T1/G2pLnXnTkCI+6/MfE8le3QdHw69sSuEkqHPq1w0KaNr+6UCzuaGjXHM8W6IKkOcWY8QFFALEW9ZpRRYfleABb3jKr5BveBGT3UOXyb5AzkdiRLV3e+FBJibFI2lV5Gz8QHXN2txbouxIbcpCl6Upp1V3N2A43ekvwXkMCE/RLxBMuuDy4Gta00ajbg85wluGoU5Z/2J8okVlhd/7F9ErTUhANkDREPcdW0zuLhqEKfFRQqx0aqWwN6okJGkDjkdqzUgoHUcAoimaqUrv4ODAWL77TjWRS/MYLAC2kOzoI9BlvXHTE1gQqSkX8745N0DkCUpMrR9lXTlI+zLINXkVzrJpONwv3zgYBIYmwmHx/KcSvTAOdSaCKBoQSduJbbeF1q8Wvy0uZ1tNEM1XSYQTrvzzm1hvBcohSgGfkngPVSSDnJDkz6QVwwysM+MpD8hO6FTHKTOzpLFq1V97IG+t/j0/DkTF7ODMRjNdFP0XOo9h1oPLNkpwb2mjjfBduzTDU2C+PY8sp81vCPm3vp8hjW/8/TwkRH/PWcK8Z9z4iQ+aJMasb+zveTB5i10wc5gkcc+8f1jPnyTio2KX6AKXCOZHgl8dghgutkfVG6ed/N9LCUnfxC8m1PVMeF9nSjVJesvjKZ4gvUpWYNjwl3qPI0FITawuyPpKj1I/3qtZb881KK7UIOkGhk0EYTv9tZNYlH7U3S/BGJyUl4dZJ8BHx+bCAuebn+NUh+GIn8XVKpHafsDhPA4yUZg8Js3NYzTfMoFYHgwxtEnbWeiXn1AqXC6fGWW90GJ77Fg81NiJVykPe7lzPTw4IM/Q6kuhEz9wwNEBu50soC2yrVBNVn9VjAHwmPVU/IwxfwHx9A1M92VzB2FRlajUNDEz+Shqp/2v1U+/1uq7cKDCANMEV3yhjPoFELtZPfYsHmpsGGI2xP0QqxSRWpj1igA+uqjz0N4dEKTVPt5EhjEIbfLpMs04qx5cZf6Cjj2qOANOz7gnxfuB3PeVHzIHRV5sryAwvzYGSBzjkExco1/RkdBhmBJh9/QWYGzEEhwwsUZoMDu1nOVTTsqu/l0/WlqU0AJ8cPjeVME/m4moeRgOgZuzwXcw45l+gV62voy2gYTJeqPA4JJaB1Yuy/IOXHlqK5IiS+feoIriR6i/XcRGc8x8+e8rH3XG/kE5zJ8tmpsY0xElCBo6SUG12pedSy3Loa2JoacEaA6kDllxhd/cnTXHDWrIgxvSFx9mFdd1aTEArlYGG8kfsMizTXyTnsUjSpJ5ofVbszcJzdeNSa2iAzgwgMTJYunivEuaNcoFWJMu2hPHTGzxvRWkHxxfUQ5DHgtjA10Qlz9nw8f1m29OcexUFjw53eN5Cmpc3SzULk0imb0mKxEhZfwnOKY3jIdoDVDtBgd2yBxfTrYzt6h8jJkwVQoBlnS+ZTBIgbIUE2AwpzVUUrh1z6wrC7lyyOtwfOMAgjVMgn1wZR51zXUO6nVFwMLsBnoBYAo1jyRCj6HWUZuLd/MoWQv5gxfjXSCIq0EEYTSFUW9RhFWZZV/H5HcQgN+ATtTwMEoSEa35Q2kXma68C48FwQeAMYe49vcpujGc0Ec0KWuP4XaSEfhya9OEaONlvMWiX2JRaHfPSy6O9ZC6s5iGxzvq5iKu/ylm2ZXwZFXOu67mnuiLkSdtBDNhXjZDhIypm0aCBArLmW4qQnQfwzh+oUxFiJXijVBvMiLUghP5EKhprnwowd7ZuNp1esHWeF4tvoVmn/Ohtgt7OflCGT9mtrY+oPiwoUNqTYcjDkwM5Ymcc4YURHxqyDL4yQgGUyZ4ja6Txy8sqoDlds2wQHzZ3DX652NphhFhzPymRC4V797NAZ7V5lxVwyS8mwbGRNXYQEBNLaup2suTyIxV1wvYDpmNy5XEc+awDdw01nR7Xced4YsYo1RQjV78TnunN0811Iy8TLdspKUNEANJ/9SwdCrd/0BnH3gEXLOtd438oFm2TPnR0CWgsD25M3CZxkZtHT2hBNHd/K6ocaqXaQIqQAqYSgqhZ9KrE9ZkzUAhunUNVDIAVlr2A7MKyY0y1agRu6O0yL7/o3SkF2PV9qWruKDAgLXtg0VwWkBXoaQ93Gd/c5zFXTt2BxcEW/fzMtxR8dNOe5Nn/srhlpu3zhgOXOU/i8ztgzHG4zhMCK2BIiv+182PLsUqvQ/RUUCCW30KzU5zwmi0J2O4rPup2krQW/uigHS0L5FPBoLG7Vc31AZyh7HYjrnr2dcyUg0IdRpjEHhnmpoHn4sIrArk9QRbsCC1DgguhrGlUHjDWI837J9zqTDucsnGPh2Qqr1CEIdx+oPIqn283KMNl+oQvbpDHp/TXInViKm/AEVid8WKLkZA+dbTUBL09kekspwE+/2qqXeFrZopff0DUBJhH6nqHHPuEGF3MdOTnFtnL7Or8iy9VXmjcquJk6rsGLpNja2DsinTqAs4gOBJ4DGnbThDhuYYwFaxeGZvKQbfsJj1k0svu384NoGPyF3LFyAUPYr19VKHkfW6l8p62ohfv77WQgIzrG/GRfyQZgeKt9nVMYszHd+GXaKKHjZDxoXnoQO1t9vDFlNJ3xpAwm3JfT4xZVi0mo+w7ruKngIFLKSEKhRhwTH2dicYk16UvbefkES6ILP0QM0nKDMCxsBgqEDQQxC94b8lJAuTBjY+jfPY593CdUgTzTjPz2MJcaxEl1Hn/uiBRb/QSSJAHYqzSbi9d3k6i/XaHdtJgeRHngD3sDOKrQem0twFTuoiGGgE7CI+oWbIbr9yfucFKH2WWTPqY4sWTd2RCex/GE20K+2KH2mCrVvxxIUsB3ljUdlHtQ4e11Q9qHsAuskdV4r7xuHpAi3M4O1CDzOUE3F7buF9KPYi85ZMyWjWGV2aSPNhVJ3Umw9y1sBLRs1tVMVSFZN3NhinqGfyUAzSaoF9cI/qPqZzsyZHhrYzfgzvO96BeWUbJ8bcji7y/3wPn1rxmwCy9lIEy//43K2xJmSrTB6Y8mFwXyiZaPcWxUj8zmcB2XKaTiXgwhumX54RRgAZoiYGyXke56yu/zpSnQQxkQnjTjUCXQP2yfNHqXYTgXNwgIPtiqDZUY/3vbYu+jr7+kHlS6k2SRjPDoV5K6rIbfou+Xkhl1GooY2259gKYqyPp5TpCghTdCwS+DCpWUxK+C6E0DY2NcqZEdlafClkuntAB+1Rz38FDi9nCXF8Gso9c9S8ugsmC+619w0lBMZVdOQZulg+2ZdtQLekQXroY/Ial6d50vEj1iXC04hTwweqxKQcrBARVRKJq4QQmrlZzdznnYcFu8QL/aMiWuLUaWiL6x0PJqDnPmeF9SYsaLl+b/Bs94qj+u+bf9fSdZAoHp/TB/6CePjBUhNvm99HsGHDiq3gLLfEKBVoR9W+TNku3LlowzC4hpwVGpvN4hn1QnUXatjshiV7V4SEs6qAC1PSaWZe+H3yHY4b5r9otaBFL8ci48nozGiFqaBazK4wj2nHYRLzo/1d0GbUT8MjbIhEptBGfRUyT9f4EuVYtj7RjG8NPJPrJcZNOoQB+Sv9LLVfKlc6PgwmvUbohtAj2bf3gfesc8u6R2EYke5gxApE3TjRK1Fv2bvHAZfe2zqsn/VwOgCbKSvf0ozErFUZAbUQDDTHVgWfZscPZOLivu3L4gv5+LNID9oNSjYBds/7tGAv9K3xAEQejrDs/u107acbeGmOqEwTV2tCPr4ctX/wVwM9nTX7/HzHQGPrGAmyowPA3zt1/CIgRJgcbXv9NwAAjWVvT9suvRcN9q3e/Owj0WkT0ZH6ETXKKFjzivSXke7YcVBeSdIujvitWEEmrDYqRsVUrF4MKw4pt5WSb2GQ93DlTnDYxH00sg1Iz3FqpSbQzRiACZ8ZR3wlxF6r0IBqbvaO0Y5irg9NpMBNBZnl/omgmQ1OxHAQpL0zTsdfQgAaYVIDs51oNXs6Gnvug+gMD+J+nb8zoQibL9Q6olph6ni6OoPpXvTO2i4Lsp5eNl6aLoDnS92YZ+NZeuHd28Pgo0Dds5hftLm97OzCmDxlzFUCqD7iye6XmxIdvUEUJwc1iAxVVuam+GTQ7gehKU4mgZMd2BjlwahibfQ5CP+t4etllP3L9v6Xts+wExegIPMCisCAXoCnxn5BXsGn+pai1HTY3B+9gUvq32Ip5qF4aGzWyAAjfNM2e9rwWsdOqEnrDMYXOBYEADL10acGiWbuM3zJseMy5O1L2IAmEM7fS+X65rlIqHTman2sysPdTwAS2GjHJX7g1j8H311eSXTkCStjyTOpz6HQ+4O96GQGxdj9QAJGcc/HglezgTCnEiFXH9E25cXUQ5khuZJ4aAbktxn70ND8rUrX0D9PpUvHZLZd1WvHpa38MOTI4hALLLIQV60UAJBp47HbJ7O2zPNCuBKDNkQ3V7IMIg8OLDegHAr9KOFuTlT3scRBCzI7B7CLD/vrgpDXQwAgqcLLoTqnfXzT36qgUKl/71oI8qIP6ElMef9atB9cueGhbN9o6d5BKOTS5zMLIAWgbJYo8ca2z/uhu4vo6ropVu2+EyzhYjnIQjg158ATEcZL7Gp/npxhk6LAgdftOuKEdcNETF/cRf2gySffHFJf9DZwRntld0OknCVs9qfBSLSbZpmADgIDKde3xC0NLuN5P9rbMpveDVbt0Hy/ebB3c2YBDeiO7WXSimJrQKPXwc5zd/JbfDRbs6Nl80QEDF6wsduBYA81SrVsaAluEXJIVaiQByu3wRQpEY57P57dt5lEQGgpcT9Q4kki/KEalI5M5x1n0FrguXLRllQz0MDEIfmQb4Rb8hG+ldFGhl3R0aHJlPFZCs6anFhxMh0WRCQULRcskdkf02RnfgvGA+EJC09VtYYKsg6QsZsulg5JiYMuqlhH+8Vyziq4zqZgiEcx3wiSxemzj6p5ZDKUiqXGy6u097CzKilNW4ClGHtdbVIvfx6Oaskf7S7JjjCAsnr4L83uHGFoxacLKSnDNMsi8DIBc1kig0ef3mxSv2WR/UuXOz4kI5oIfZ8+ScVGxjL4aPfB1UX6h4cP8BzQzYZmFh9q1Cvy1QuwgoOntdfqowH1jlA8TX6V5Ta09jjZhGwbTZ+WQ/3MGhsWKSdb5SQeWFeQf7vb0oSoOAFhUHHPFbTTH1uZeP0za6npPhdITrOSvfCJTAnZtpwspKfbUlJznmmjqXG9vE1DlWCje+v+hhFZS+TMFfjoKTjR3EuinW30Hqi0f00YEpNR6BKxLMxoY0zNjZDalNKqxsgajVokjaph+pqsJ5V2agehJJTBlo3Ug9cfXy8r7g4DhRD2ZEVX4clfRB8IhrkiS+FL3kVYqLSuttTSfRAdJ+3GXEJlk7xQW8KTOoRI2QPqgydBFaAwMD2rawiCRusQwJ/IYA8jmYaHPDyoTMT2TBxVM1nS//LE5pxbyO/KwZXd0DFVFkTsZKEyE2ucLjBYUhg/FoNr16wx2q40lB2SL+KgRIK86xMmHbtxOGK8+HL3mEDLomvzHzg51E5QJk0CKZU7WBaWGxMYOciG4ivgB4ImSM7j342qP6WNTq8Emm4ISvCSOEpC2wyfY9C3Q+nIZcA1SI5k6KJg7b+3MMdm/iFOsHysTQQKRRHX0TIO8yhvySD5HAAhiYyb5tBtlQQ94UJhLXOtRFe4vmv1B5cyG8iiOvomL54LbfOQQgLAvbC9enWjE/YGAVV6llwU8Q1NS7WcN5B149KCFXhhxvcO6tfdQoNARf1wNaoQbFkS0NDHYIm6ZQCJUpqqIKzdmMWgMI9Q459xYgq/3lySsuq4sBQoMccb2PvbqMwZFAyjwTi86chy+4pkSkgOocurqmYkud7IXcsNAPlEwiRqqNYJOljN/A/R7W93GzzIgd3t2tqDTHEdvPZtyV5kmFBifWB7gRgIpsquUqANGl8ILsaxr9xlbn74gCMQ93svlfk0kZvcMO9dS+EnjX93NqO1+kHGh5MJJt2MlyYyOT+5uJ4alvaoDvjJHcrMlOx1X6i+43Fb0gvByvCce5LFnrRm0Rhbblk64bnBRqNGpqJj5Kh0GVaLu2oKOY9O/ZD4xk1q8deaFctQ9TfomHwZjH20+E0UGn8Vc0igybPRNGb8ff33T/iAavvjpI8mgmLtjeoNXAHtnlRzleE49xFhsW09crzI0e6Pywq0F42P8I4818FZ9j6nIokwyRssdr1Vm626rdaUfN5W42Ukzxlh1XPryzmVEJMRIa/9XVPTLrKLpTsWXyuf4uMWq/Bup/AcKQfmBeCDNdct1PhXGLG1ldGX3pRyAIPSnDvpXOT+lv2S9DJbP6B1pmXxrcxfUJEtOEFV/RYFMp+LV7hhHVZBRie/Hdo/Bi6qsVTscjacSkvdEaK5UTR/XqlnNCcVjHpih5Y3R+8mnpWRm0Duj1wzd7dNraRSDowppTu4lz4LKJiBBXPw3DD6QSgjm9tkehfH+xtHAkNUf9LVohOxiwSEdzeS+4dA8QUVFPL9NHQOIuWFHKY4OgchOOh2A4F7EFmufKORNCXUfJbmEsTCydgbLiyNieKZGhW+fYl8wRDJUy3tUHu2MQ+r9MuQwm6ZW/PV+yY0GBPh/qxkf7BQfuJBVz19IFeIWPOynWXORtygQ9R+Px9bcLVUWf2M7Rf19485UoJZLX6EsMqfssKGm6SUxp2ozpwKPMXE2GR/Jsa08VZoVBCniS6iWvASbYFByyHt968zg1Tx4fHXgIDiY0JYJlN4KJzaXMDjIfaU1ixp2eJ+z1b0VzRDqniWenbmCrdw/QrZLcn2Rvwy1Ni43gLvYXFQJZQC1vHK+OFXQXqESYeV8+FgRwQl4HY7lnM/97VRpcsIFvUXp4TkwqMv4YbJyGWDXDJ5/M+5u0e7ciy1jf9ecg3IVoLyAn9BniHRyUZWkyKedF1GZ78OH/8mTmJruhRUHPSEISRdoZuJV/D1bLw1JrJ15dGECrFQDWhavZHiYzOH/EZv/HYBPYuN0X3OfKfzGytl0beMNBmcl20+2Ln/k6Hs7/XiYknaYV3qpPvxQLJoELKGguNBYt6vu84UT+PuRnGJ8WU+H5ZwkRfmrbea1zpYpFf+ko6LYT1AbSHhJJx3CXOiYfghGKQexPzIWEPfo+hoEBHAjaCYoveLBc9zz3bysqfT48usYaIPeBEvWWtYlOc3ymI8RtswtVgHILK9OE8INgn1xnk+tunelQ/rl6B4jn5EEcIWE1/fVugddcXCplCxuciOXQJUiG8B5NAqYSExA37Y81UDdAfbzr2pQep3QOTOTvHDUJeWWlUx/iDaiMZlCtyYDd8O2WW1+XGTbQDR6AkYwtVGT/D/CD+I6vl4w9cCVNFPgT6UJ5EcgCXYbzYGXMjFyOm+5NV+3rxSempVisl5w/RshtHTyKppZhvyaRJztUPmDdWCD5/RkrIiTgBRXkwnv16n9u30fefrrRBYsgvRpLlMukxNU4RdRf3c3+7eH+fFyIXef8S90arwrJ4hVxaSLYRjw1pZ06FrF49D8cjwjnYWn5HNZbMVV+Zq58c19vc40zD46n/6InBgCd+TvqXGjawzsRGiJxbfEOljOrc6iImFlNnTNMeQGw6sTKGCufmJqYkl9BnkafT3aL0yHoCmq9kHdo3WWhaWB48wkuiyw5J1RaB5eusqzHogVzHqDwQSgKSYOXMUFCyHTyzNoF3sfDaO+ka9OFCis7R1ZCNsKx4qLRs1s2RKHA7FialIOMx5TBABPcurbbNK45nbE0/EnClQHiegbpxyiEGsDRcOZDXG7qtTIbSBTdpkuSoKz5rYW/TGA6mbwyP880CPcfNCrCEdJSzMbZRkuARVSWFVIj1zvHvS+/G/YNiNw59xHVaZvNDY93SjOwl47Lc5ye5qVulNSwYgqtwrml+DjPYQnGOpVqgCkxFXsmWKHnKeatIWSGPQ7zl2rftrU2f4jq+Io/vGphqEUnJwa8uajPHted01xrgv/ZVrcOR7PFeu2Vsl1mlmpXd60D5HIDaB12Lgmf6RkF+f6lrQqEQWjcEIFSdKGa/efQaGtvkLp9/Bc3j3mGydG91VRh9gti0YUPXwT/rq7fbiRFnl8y+u0+WXvqaTveGb/NaPC7r8Cyl8+Ig6S9sNsbXBffnaWj/g5XSSjEA6K3sF55jApBLmtVaAVbYUnR3JYy1lJiVtHw8l6z2b80PFBDd9HmF8PR7tijvYbTt8zSZYLe1+RGmYwOnMYVuMesr/UbPae1bTTdhmnFyeEy1zar34HdWgDG3HSRp6ZHHD7InwfGKVits8e+qsJGvGrqlIB8OlF66+/bz0YyN1XbpaLyZCp1DDJOE1s6f5Np3Fh0bKPMOFbpwpSrHVqfGtCgA9xIpcY63QFL6iPpQ8eM8ehUbEIj8kiYup7DsYSnVNp7MrUmVfKqS+qAAzZk9WMhxnrfF5LOYeZPMdbuc0ZzPCUOIxYV6sNCcGac/YJj6vja2ozxCq4gnJGsNvXyDZakKfs0QEbZ1Pm4U0RyTcoxRNvt8ri3sh+YR7SuU0pY/zD2dWD+VXyUCZwRZICdyO/75EcL5j9i6hehf78wDiM5IC4vQUi1yIwRZ6y0kRlRVQ5Hs8V67ZWyVUPxeAxaJu9YKHqYKHvT7IA0VLLV7u5hvo+s2HDZQoar/5YQ4ZiyZJSAyFtELvLIYqj/uFtg6j7czGXVmeXWngdybDNEYG76Zf0CgFTBi43e5Jv32APDySNZ7WhAFoP6edtRymwgqNaRIssVAi+PJFeiWmnPVq0SRT+1GBYJi5ecob0N/RvvtRg5E/T8HS9IA1p9AnMYcWlKBrZiS9mszgdQD6ekVv5bNXlh+OHFxAIQsXYFY6nbY1kj4TdIAQyVwNJ+vCxJ/AikfT57S3HVdKq54/DavHpbWABeRdN1yisQ6EaD4B+L436es2PYQpml9+SgpnHFeFjDryG67F5Kqh5Cp2ZKbSoE/PD52tUWen4akRV2HTso49pEzEN5gBxnFENsYAKdzBtpQFnuomax2nP4djFJtgcuaFHn6gLhQEIbTjvGYjrknmMdkC5MZiB47pBaSg2Gxjf8ipav0pCUtoV6SUiAMJfR4inf0rGgrBu2dBxULZWkyGSPZq8ZqfBAfi/a7LfylSZQ9b4vGpPWlzJPSzyY1xl8ARQopKDrvesTXt4vWAM0gk0do2j14o1kQTpG3Ta2T5olOiWE2ldfVvqW8TpRJt6/khuP5CbQx2xxzLLk7Epm5BRAI4VCzQsr5k8XeMGfrT4TYljg/1DySMlEMYAuWCDSXggRi0zeRC+Bv6cL3jAreOu5yhzWgdK/43yg2JBMtL1NzVljN6P1vcdY6P1Hpp03QRhgOUOZgfl8sIqwM3qBzAZV2WssfkNH7+e7cpAD6WIF8CyW11ppPUvlM0WWTI5t8slpkryhP0dA4fswd4QPg8rPuslxrX/9p3fWZ/4bXb2tUrsaO6enjeB0apeSdsN8cs3VEHEcWrev13bnVozo2dSC4SY2Ssju7W7bqi8dUNP8kb0AKSgB5ZgIZMPyczXVclSxr12+ZoX5fjpSr+sWuIUgX8f8NTyyN1fe/QY6vf6067w4MnWW/m/L+pO3bpUnDmKoeNSEh6b0sCTHQOzvwTptTVtKsvLmP04R92VhdEFEc6BICUoLw/IjLjAMgDJKjn2U8QJwU9/QW3dWnZI7JIQH7LL/qkP1603PWiN9D8zLh8YNRrUzOEdI0DdxySPRGJt2fapsXTlXU2hvH0DKAR5vpy6RANGF0WAPV7M/LAQNKj4TnoHL3e17izpjn0B7doQe6txjp2wPIjB4NX4K6QU6OBILnRwm9hfz/rlItC6XupIoAwF/eiE64b0CQDKN93F0dd7HwmUd4QdPiOIET+dVoDCwfIE9FbSNJSDtMwms7onlwrBavALcKtyRtHlQxl8OVzoJ+1GcOJegJM3fYy2t2BrJUYHhUXqrHKeenyz/yDXwSVZXSHr3gq6cRYvhAy7Sx41nfTZHC8uIp9b6gLbyWrZDYmlSShqAyOOdRMNPoKEkASsp/StEYFCHXnk2YNhGDZeVDakF/Yvbjc0SbHWTqHPhTDbxovkfYiUg2SrUD/84Ek2gyoefMGSnPsI6dCuTksLfVEzPPgo0A23HKs45IICwzbXw1a9wYSmK6a5DsjiTgZnk1zNZOma3CVDon/LJAUoux2C9lsorzlRSxgci6HY21CExwwOSrkJMtq9chJlts8EU3bM4NFgQiueISdHiFZkrQd2fFhmeoFViogbF1L3d4hzuuAYT5u57cVQMh33rEO0Al2Y8rvoRyyx6Bym4uN4h1W33rZWU1U45xU1m3B9zo2V2si2zBxWY/0PgFbYdb8Ckopx02zW51eZo0xlpaYLkNqZ3DT/z1EcIXhEuSgLW0hV/Na76BT4E+ChYzSjMRJk1NM0w8wEABIxOB5Yo35gz9yZy8DDTZVf8FNvRCJrVZ3bg94oDLzXOIA0DUjQwT83J6Esyk0Er1EYdzexGhMT1WKtEDKgINC9X7PRn/9X5AU23yyxXfb+vJX0WD6X2PqVc+MHkZJgHZqphfCmRqoCJ3lTO1DxSIfwMjBrtLt+syGgzwQFzi3E3n7hodQX5yH4ohaXxPOeJHIXCNskbS4b1Ai5qQ6IgaaBD1I1lSj1pInvwpLKQ2X0hnFXzAHjbDSBoWSPY+eaQE7W5te+QiQFwkGViGGP0H2LLTUlNRvKrTpmXfV8NvUMbpYQorYY0hQkm50STN00fkj5CHqXAa0sam7AZW+oH3GrEqx5KEP4/rVJQ06YZZHKF5qCAUemt6m5X0Ync1KDlIXUTxZUIjEVrfYNUA9qEHzeCa1/fPufYqhYuZW1bBLAB/nRsd+F7vnal8tQNmk14v1L53s/ZaWcBLWbpszM5Cfbin01MR/LlKSzeGFhC76qYt+L+Phz4+9kWQLi60xGiBK6sYZktALYuaKjufaHv03Hq5+tUIZrPhd1EHLFZEngR520l8RMXcikmVIz5+VbI0JMu4Y/6QZwNilceZiu3QdVJh9ioFWjkE2t7lImIQYYzm5VTFD8L89D6q3EhAjjLTmeXPUSajT5asnrAqFQqPyLWVmp74oScPxvQJllO8Qjy3hefXFet0juDwMHDKOwGxB5REamXaI6qSYsx0QQrjd//wnSGE2wvt4DTV/ojtQRZVHioUxyYMv4hw1lANFbcdMvveeF+c/FFiaVEIZL+YitFaMdVdJPO1pcBDQfiN6wCSSzA5WU8aDQ6HWozT1L4EdklJehq3wBBArzKVVPoYPcRpnlW9OGdkpUekuzprXdBonxd4rE9BGMbrOL3WzYqdwi5NBKh9lPKkelN3qcG2qzezwKyijzl7XHDZ7fWCjhEJEx9nie6ULIFBQX0zXF9VIoATJrsZxYT5Y01uOef3eomD/G+BP8GLAl/AO2G0yhKCzEVoYDx2Hipz7KibLtog5a66T+Rx+9PrKXEExCFRAFtISktvM4cS1ZTCSSf8bYPhKyJwT1HAhZ76a+xssODX2QHWs361ZE4VMImIfN/sN4gRn0xInAoVlPg4q83AOkZJIA7X96gYxhEOL0DV9oeLHSily/Ysqgl9zTTG80T8fUpnfKwLxTcUlTUp+CGIgll6krj7Kh3r63Sq00qFfoSFS0Eje/fbqIGzfJFa+X92KKESOstZm1freBL75R9Um35qb+AfF1oK36+dTmV+cG2MgIT92+B6tAN01rN+tWUtzsVk/LIwuYVA76MTRrLHWUORmvRaV7+5+mgZFzSu1iJp7flaIdzHp1rvKQTuOVuA+rNnNnJOt7h1dWmkgkxnr+Rqx2gvASnguqLxsKw5npxoK+IaM7Ioz1br59FnvzH/9XhCsjqRUBAQ2DD8EC92LJAzIsoJeGWzWzMqtr6EYP17ubhfY7xptBFXGRKfO2l0Kqw1srmKcx2ha5jm1NjjamWJa7lIrXAeZ15tkbBZ5HMwimSM5vLVDHIpUdJDOn0QgRsdMRFPFLLFd6In6dKXnXo+WEgjzAvDdmLzsTtFYr7a3bhf8Lz2ZC6mRzI+SiMgeHmyEaqHEoHBz5kJAYdRAaFJUoaGKAG5QDOAtrCTKkKiiHJpwtKL+vBuOMIQvXBfKo4p+PWZ+vtss1zyiC07iflxHbQ2Z4Rozbl0yL1s6zlGl90rtyZ6EL5Wmjou5DPuFWCFWZp5LCwHsMhFQbeqfIX5GWwmiIb5nSOThEDoTjTR3Vq7zNFivD6Zyj4XnpEjU2gF5AUzO+Z7Fn54ImEzDX5zIqMFjDRfUSiMgaS27KHZ4GV1gCk/IE5EHLIdn5ZplrmZgDCc9S9T233J0tAkvK1T0H6vZ2yFiOmUNVaJtzRVxz5Oy+7CYqu1cVUu5Es5HXSyb/jaY0HHVgK0kO0Wv5Mf40d5mMV2GQTOClHVtpkCzfuROIDMloMxPf/LnkOKDYaPwOQDFackGehC+V5qXfuQ+3C8zpKAEbf11c+2tZLFn3EDW3xCm0DMZzoEqM4Bwj5bxQueo57dHGLGuAZJRujBH9CsEyKt3k4gDLuDpjQSY3MyzvWF/3+WXDKJ+zOWN4SrHBeinJafSkk8+MkUqAfqZNlVeEH5w0Phwoh4vTQ//bJrUOCHHpksBh+0gjNhl2sibifMjMJfkkSikRn4Fjdey87BMzL5vh/W0xnKWGeIKb0X8L2piRgcfuri9FHv+6dQIdaAyiDk3eeKXFsGRhmNErurbhTZinf0MDvlabJaMo9czdvg3z8ZSeP7DiFP5l4HvKRDuvtPA7ycymHtsyUsf4y/Nck7aGOiXih6mKF3Bd/+szpP19eg3UNyqlLYUVzUYhIcK7HY1EMXNwS7LxOQopjoCi643yzdp0DPmRhL9fkk+dDbn+FCW7i0wdb2W6ZfAXPfBnBwyyDC3CRlBnrtclSFipKx2u8G7U3bs2tJgU+/jfFNjR+aTTC/J5vcQCnbx2DI7tf5IkgRAvrtq1SId17C/T1OSzL76m4VAcJ29PcNNULovY9iCbgGdFgyWoe4U9YxCFXBXPvOZpFIl9zpuTVlo10dMGKO15iSRE6W5DAnXQsUqT2ANM7Rse3a8k2VMOs/ei1R83h01sgUqUbUfCSaFZJVHeIiskvf9Ax4+BSvufil8BpKaZpS7Mdlgvw8CGRSNWfu+0Ty5UU+IFsxFUTm72mQ4QuH9RglA7c5xB+qXgrMwLgdkvZ5fcV47DbE5SSsg+Bsc8zZv61Y+NilUHj1HHx2sccs4GPLNn/iUIHL5sin69PtUIQA9GQfjxkS0kVOzIzz7Hl+Cv+pW/kR9U21qqVSsSpKcJ64VqcZy7YEgZgaugr7Bfd3Ulou1UO58bekxIT7EO+zGtR+J78w2Ljnaa7kPeIa7K2S6yGBfhQTcM6ociWICYDeOmL67vZr8+fHH1dQc01zChOwfQXlmD6wJMfB+gwUsnAqab0AKEXb67RjmX48+pUF3UTlSiYs0DlWTrkmkoXeo24wjvKMkzmizO9PkMv49KRaF+WXA4G09AUcoZPbjqgb5MmPwMU9UN5pN2EK2cT1TgFOd/6DPUGwu7vnE9ToS+UAbfRpCauYOl6pMe70nIzSztphH/5A7b5hNlshJaHrkyL9f4gvd1SWZJVP1DDATfQnlnOgXnu76CudR+8sTwJ15CcoAlrRMBIfUT0BmopOdqMOtxKSIx7nspIT8TCrY4uEH7PLSSIkdAB2qzr6dKFwQOjJ5UGSLRxNDDqL1P+HfmqD+O29k9ou4tlmpocr8cQLGPmSuUeOIuL13eel02QS8Y8EmbptZSHao0zDqp5V1a3N42ULgxgAEuwwJXKdKQ4QcxX8+yY0iH307wicfiugaLDTOZiaobi8p8lv207stHkHnagleo0Kc3TtNf1jptxo+ALpvYQGs6NMuObcjLaeVcxkdMoc/HDntAc2VFVDkezxXrtlbJNdGpQ18etG0+x1iwJXeaAQW7LiexYmgGzjUiHM815mQ769dwZsCSAWHOHYW1drET4U5gsCM9Cn7qvgZdUe9Zp7NEgclH1rqv1B64szS/93gRe510P3o/nuozXFi22F+JfBemSCLNYvytTGl3mW6YzF2qMXdZ2M7jSqLO6hrIp6KKMcbRme6AEkGlLWNKP46szlfj8c2mx4l+RvUTGiw2CtY8fj433g9ftJvyhodSLkyitZuM7qGpnNmvCrgllINUI3dnMsu0eJpg3McDmsT7PFSDgicc2mx4l+lu1r8KEBZu8alqeCSvdwW81AnsilOrBN1xZNK79/NPD7FlPAG7r7AJ7QiILPiUSGC+m30eE2MmgjjbqPHklp+OzSmYW7kuU3u1vnHJYxwQ9vJHbyBaAP0wr62NdeaJmnhLZBDG4y9HlrNk/FTdpAF+r9I1GfI8BT80KsIR0lLMxtlGSrRvoXdB9fG8+Vb4V4O5GwbEbhz53yMEWSsEno11Nh8tPssqebWZapuXLKeNzzof+QtSwNYeC7vtyXn02XcznJPpfrywjGqFr4DQJsrWhGkbtoxEm1FH2fGBagySgQS1fShe0yZPwJkeNc10TcKVbT7MiN3BU0Fp7BFjOkEMEUarNTcGxRs8as332sswXBUAqEpSuJ/0VI91JyACvpCc8+GgsJ7U/AAu4keGanbLOZTcGo1AGNdAKYJdsj370Mj2DrxSdx+Kvh01MtWN4DHzPNZiz8f5OHY3btr2GoYIKNj7tyRQ21R8BEfbnCc9er0sH/7WMGSRkMSRREcgJj6sWq0tn1hUKkHCaQ2Jsvf0Q+FHa6sGcNwK6r4b+jmKCmZv6hNlZKkVWZ2a06I5t2xlohiZtKLeLR7S2KvuS/37uzd86xk/ER89004lek3Wi6KfUc2O8oDT78dOlVDbk1SIiiG61knMOg/W9tpY/XBdlj4fJ4ZXDNgpc7EZYzK3zSAafAgZZzmnzEj71oXwBK73MB+K/h0YGIn/d7rJE0AuN5o32WIpBZfy6rdKkScnCw40PmGSBo5l3CBjYyt+GF9bDT1DU4ihy2OKNUQV1nbJv7TMMtnOKFFVu/o0gkS4GeLNBPcZrsPBnj4/zD30454xl3/Dq6V7OJH7bC+Ub46FiJhIUMIXVHNRCWBXpT1VbwwiJTOamQVexgB/gSZwGZMfk5mA9BONTooM+NWswEE+I2VtibaULyveSkEf6ljn/8OpPsak0QWMlY1hEmh43n0igJP4QIdqv14QHFvPVTvBFTKzC2S8sz8x9hEMf4qHjefVFwhwhfRrVqVuRXi08wm1XY/xNyHwbuXYcSOhsDoRzumERjGqnXDLY/h7AufyF7Lkiq4heHndpThG2kM0KxLUeGOSqIqK2Mn2EdtOQNaBxSKC2c7vfS1XAQa4Sne2U2owqpqJ5aX0wvW5mpmKDRIHdaUkSzVMc8qdekQ39XcMj7gpoI2+braX2275tH+AVaW7q3jOOeM2DBQYdb9IEl54cGzNXivUP9kcoRIWUto9PK+FpNH2Lhs08APFhKGGk6ufdQvE44kbBvm8tvSnjWMYNf3Gkyj8nLwzPWFBBkn9cUZp1fKmYB0hJH+G2eo8G3fJbMoturHFfSFzw/DlSpTgof6To/j2RUPHl79YnZkpvHXZBqdE8IT2VK05B4rpGyQJRYiOJ9M6X/jA8l2RlJPvN8JjDI5l9QF8C+1UHTizef3f355Z0vFcsgCNRIYWZPqPZNCxhlkk145ffMpBuXt72KTIQzcSTj49WWhpN4ZpxIwhYIYg6FSq84XhSmrBHVXbef++iSAEEuTo+Q4FacLVLWqM03M2IOvQUrBpdWo+TaITF/LGgm8OrKrYhIfGQoiJWplBvyLeLJfi7F7GKVK6Z+TiQ1LwR2CIe3UR06Ug9jyEGtasf3LToDXUTeImuCX9ltIfq3IhE92khowbAD36qlUK/zTHX8gZ4WMG3ZtAE7wx6yGjxvSfO+T5uB7qzPah4UyabN10/GEtrbAjWJN9Z9KlsRP1R/zqcyLRJL+6sGy9jOMb4WzOHlCjoy1vSxo+PWS91Bvh797aHiQaViGhKQ29BkV22CJa/uT+tWtwCxRAxp0iEbMZ9Pd9PQQbfYXf7Z/xMH2CSRBqws5L7RqEHvrJvVGG7fJPTB7B8E00W2Ghi0cJDHgxp8XUnjQAF9xtCkVd8VkTSevEVtJeM4LyXvurWI2mXFNhlUNFGmb3/O4BUfWpF5BiMJT6opmxZ5ixS4V9iLmf0P3VRAXmkUwIXmShtvtzbezvBEuFFa2oa2Ouq174T9fTwu+tqtjfGLCbKcAQIQqYbcUbshbLdl1ULWbVWnML2Hth4l9p53/MRentvE2b6kkBLf8YsDhGeymO7uBNeH3glp7VLhoXNCYOnIWP4F2Ht4+M1b+tdJMm8lkN/sjsLEqiTCVEONMdcCwjLCinEJKP83o+GZd79MRcnXZ021RaazZyvfyC2nx9SlDv1f8Gfd1PyNU51mxtzUUEgl+szlvdbZXsos4JWDCO4nrBVi5TZOuSnxo6AKozUqRDDxS7FkiW0s8a3JL/qd4ghlVZKEWF1kMAIr0MnOTR56iOCGp42WqCIcfYsBYLeYEhGil3tj9BtxDydC49FoPSQuhXF9OXe2fUo7UzH80/OG7jkkeiMTYeVJ18v3MQ3zQBwRHiseDUNEyxgGIcCAZI5aWlyk+xR7qV5KWzzhsLu+dfiPnuUl7Hmp6UdRzMBA0ckg1+TIWYvJJ32azFIzMQm/IMkryRZBBR4K4AJAI/TFXa4XHO6WPx46BclSaJ2OOJ+3GWbnw7uEOjkpC6YL0JM9TTbsDUgGLfuQjIK3yUpCAmcTgCOcl5GGGIMEl9eAtwjsL0TIvdhoeHD1d+MB8cAoVuN5wh1lywIL9K1/vRacSsFPG2j+9J2cjRFC4nSb4dIfvdHdcnZGjVmQf8xdajK4/Wpfa3LnDlX69T+Vs9vDwIhtIWXh8Rc1HbQRPoRlHFhwDiz453JIM8MR4Jazo1JZIUryFylr80HP11tsUGEebqblUB24YTBWtloVC6EjKP8kU8wCwNo8kFPDodk7V09H2THx2tyO/FVygOI4uLoo3F/umRDKmTKPUg2bttIft8G/cGbTDjlHhrgvMJdvUnp230c3cnzYbkwqKSTCE8ks50A/GEYdiFYS06282uLmrYSMlEdiqt4MmcQH7OEPrPOwKMbJzr+OcGc7be8k+MKSAF+D8rv68kvAtDyy5M9AvnLlYgexh5jOm+rSH+bmB1sK4SjgXCosFnQE/5wCavsdUirEdQ8XZ7edCLz3vjzaHWxjh30X4LgFD1nSZvKDItZosHSkIR/+CJm69inWTjAAwgx21mO9pJUHj5fWZO7zr30PHD+OG1LwN1OJsdi+0r3njXYm23ZhMUmZts0LCI2zwg9M894293yeD6Vvnpt4gKICdrT1WPLweDV1tDO5HBwefnPWvNpztldD98r21k55QTSLIwnPhPAZixYNjHo1PkvTBtttjMq0g1LACueYcnsFcZ92/irzdtdbLvsdk2imCxODOfR/oMw2Kbh6a3ZkbGQ+t87KUdt4+1wUziuZemDbbLzcCXV03uv28p8zJ1Zaej457IQ3aMTmD5Z51oJcMj5MUDUtmr9kEukZsFvFjBEhPJB9Mt1i9yTl7mTGUauVDEv7Xj7xFhauvK5GDvSljdkvKLqVYqc7C23vmJUZZVhrM7wfFRi7pd0sLNLEUZPA54Z25n08D/kE3mmH3ydeUYwsS+/YDhFAxqRxISsSN7peWHlEYvSLqqU1Ri4+vn+UHb7Obg4l3yZkvocLAijVSt3qE3NulFLgIMAM2vX4OiBfxwdgeWcHlixtiA0X6+isnWmQqC3uzUdKHhntDouEBGlSLEzPsBLjTld4fC3I4Oo//XpMmx0Gg3BLSedyp35JTsSgPSs8Zw0/8oLZcT/l+rFRtT0gHfutYBjSJdukZHiJelW3O+WVLOW3lvzt5WDXdrllJ0GA+av2io9HJkPMI0qQQLthdR09ewW7EF+IDSAEev5G6dCISsYBx/J9ludE8z/Wxe4/97wZY8JTTNxKV0VUCmYtxdDzHhpka36esshZEXQAjb+upx++QLASb1P+DONKEywlMZfGPK9uIrBR0j3Sh/ATXM8/utrz4+mgQzurx/DQD923GWTE2IirF2MhLuSTzuSpsE2tTYP6mM2ixCjxoCtkBXmYGSjWnGBQPX5IUf7wHnN53vLBpo1ymafF6MIhkRWfdiRGUw07bvSQZJmgJSyfKOi7HPeq+jGNa6KeEdP8fUeZJtbnh++BzJaPPdIKltOJdkmwOn3cKY8epY2ihgl8b0Ry/ybgI5AzQvAgYtHRWgv1+IRAVqtgIScPhdueNMw+zjET2ca6x5wk6i7+FgaSeszL+RPZ65/G7tk/cpSoTH86cyStUE7S6tZ1jFG4mPLqor9QbIDjaUUlC8iJisx9d52JC3ungZjPmg76pt9NO/UCnFagYf5K6DZyWJVFWz1K08QlC/hfdwdvvKKSGTDbEU7ZhnVuwLjiz6mW2RxPakSgqWG8Hmle8LAWQ8SljOuy01G3blKgQ31zakbHq+X/t7SjJ9ZmXy/WDaYZe3jpf0Q1LfBlm4d6EtTaQKl3kqg6XGs+i6InN8a6KD6Mv3UP0O7AiSK9MZ7tIPsRp25T/B7nB5nZnbnK6amLn0hzjLSArK43LqNV+ftMdUSpIwtrGaYwNfjVB/RRHczBuNtmFqoYAWOXSC+4EVC5qWGd676EwcQSlBG/jQ1NeA4xaefOyq8tp9Xj2wo+rhKAuZtu+yamutwXjSrJN9xGgwcOIzn+GTJQc1fyLtyvEuW9T3um4vukC0SesMcuFlQglJuANbP9EpWvC1E0cgF90En4MgWeTczcrR76T6dpBjuEMfHDX/3O/fQBiWlLGcbd033J6kT5QP+vhniBHInq0ZNR3XBl8Lm3rUvpX0Qd+DTI8UynviAb6PGySIGxMEF9V8m19emEEZalElssljRkYizxw4D2jEBgHn/kp/Oz0v/7q+7wy5A5FH5922Yt1bg7HhnyipdKEP/EZw9YLddzqC2Ebx7oHDzvXfQl2WaH05rG4vuBgzFxGirtX5feleUVo/qoleP6uLWlKc90b/Btp1z3S/b++WZrVuh2RQcBGgmqsqVDmLVjnWq8UhCh5g4D6YMJMF/yaFdk8MVRCO1WPvFtv9vOnvLMhZoFRcsd36uw5Ya4ZH6U4kfUpNZVra1caggGDq5tGyNs0TgB8bzXUP84Q2gkFQYybDXZ71pChIal0IBFEQWqarOUReWSqGqboK5wD62ItM7Y6o+v+dEOjbmfHcIgnI1GUjeuWznW7ArcVNGr4yfy/PbDFWKPDOhSXaGMypK1ndkqUpe6k5ZJ1ML6BLFhb6orMzxKYA9zvZHhDVQcSBh3LiAh/CaEGxTBUa2FnaDTmfu6Lo8joUa80FWJvRbBDerIMb3+21/jhQzkjIrH0T1NzQjvXOPAbQW2Y8SGshVVzSGf3oPVF9mihm8kC1qVOJjaiXTySOghxuj4P7ah7U9rjQg5QVHatdgNzbr5R8DWOGxEDYfSV9Cf5NM6BL5T435VZOWuINkWJVrgEEbVvVyYx/IUk4XhmRj5I5F1fIZbvVuFKkSLb71Qw6QhVl07N/1dvgyi0edS64micIIBRWYeyd0D1HtDzOF7x4jGX8dRN5fa8eKoPv00WPhCmWgv6501xJ25+kmm1wrZlpbDnMFkUKr36ShCLQdXHzT3PdI8HVLg+Gu3Z94Btn3NSxccOBuLaGyXuYzFjjF1aoxW2N8EcsP6qA3Z+lCXlD2/gSzqj0nGEW/UwgaW7FfsU70+dax7OAN3KBdAu1xaFDjecfsCs9+qHF6ag+aslZDZ5Rr++7rvBknnsJkELiwuLaJVoy6BMiHrpD8IanKJI+xpgQ/dBSG/FBzRy/Z0MQbBUZWey5py4OFCJu5kRhVSeYw6cq5jFP8/DKSRGVFVDkdQm0Lzyt6wJBxegpFsloJaFw0KiWD2dDEGwVGVnsuacuC0CQiw0LuGakWIUNFmWaTeZb9DUVCMnYHjV5+8AeLc/N8uBRkTgS0e27K2S6zsEuWoa/9EApC+u392730WQT2uUGhN5sf8CymuwoZ2jNmL1HgST8sLk4xOxmyaNZC4lgUWnE9aaZFCKc8JDLMnrmOo/E/ugwhIMfglijMOHcLYuMdBcEgo/qow07QQlTO8FmfFgLAixFNv6MZNBHJtIQe9Osb4sA7c8ObtcRnL4MuAe+nMMGbykIbfp6GwWEnj12Hxx9vnNF+jeq+8Si1m7N4RZe+NSG6Tej7suPmhX6wAoZdtJ+ihaQBTMHb6xxY+wVrLgTcOkJm/18GJQGnIIM1YJJACZAtDyFt4i32QSUJek9CSeGYE1poCvBwS8Qs6ycizP3+iM9lWYF6rCxjyeFiVe+GxAA5G1aLW2i4ty8TrCRu4sbTCjciL680F+YKM7wFMCbRaG+a9NdDZ9izdI/fCQtC/2XFSaTNt7ebNFao2pnoTYNNBLBCqCOvmr88yGMqo10EdrVfQhOr196fINgq8dJGAzbZe1Q18Wh5dVzA0uaV9ZywNp43CAGG4VnKVqYrh6LRJTTfOgX65xHeOjtwKqgqxI2MGEJ71Uk2RjThCj2yC7dwluiVFG1Mef7zD7tHmzckduilgfv78kQ4SBONtIWCK5A+crvQF0lnihsNNArmz2yLCRmC6qxbYMh3JO7rGzMT6ysorqPekOQ+tMRX32sR5g8WthkvNymGz/RHsVx4jVnZaV39YCwhTU6bdDVxvxg933de1lEfsSGR1qjoccqmI8FPtRilrfq3WPbROkS+HyNdg59L7Q1NLe+31kokCFI0sjwYp8yCBd//TpoIsk4wyWhnyAZfHZ/6Bi2jQPXN+QOKayjYLn05kWHHtDy3B8JtE2Xnyq4iwyK3h/WwXyugJL1pD4hX/gM1ucRZaxTbEu6V2rfPdeh/6l8FyjhSC7vYNNatst5Vw71hsglGYrc34fhFz+RZ+qQZCrwi81RO997SFnICMcz2Svv3vinmtYiT4XjM6JIZWl5s+g2VyR5LAR6+WcmiLdqw5Z9x2b+4VK+zp7AZbTkL+MDET/u+P1LexX0usYWI0Rh7/JShA5zOwRtiwRW/yqcH0JdUQMU82UDa64MPXBGgHCr5U+Iz8r2s1Ob6MTgOhMVrlzehMprRhIzaY64nNze43tOsEZq2R3XKRxTNEYEqq39Qu9VLDAhdH4OrlBreEbgeIm3AAhoZOihuA5PeWmhy8STRfp2Pef5JYw+NooLvp6U2jzae6I2eMpcNqzY49iGU1Dz48mTsMsBfPq8aCfOZWGfeX5N4n5DKekUDXAtk3OvRh+TOaHzJQ6KOBnubE01XhVWLDZ9aoR08r4EVd/J0h5Ws822+rDfhdtCeZ8++LP0br0NLmCso7kgVJ+O/zlme8QDnPEth7kHPxac9EjisEMiuqNqEpiE/35fUTxGQ5lXaiJw76+E87zo2DbpIvNs552ApdonxRhcxBB48zcAPveaYATB9hE9J9T/LePXo6SZeeL8SWXKwYw/iH8DgEGdmzPHAbxuxz69X9EoDPciT2v1y5NfwzvoQPB0L7g7pva2zNJu4fei1Q9Sq0SUCuEZK7nLFMbxKGYkEcbTeKUmcrKPih0e6pX3w96tYJbwpQ5cj8lSAy6ZxxXh0G8mMycIIlkfXvb8uz98SNI02/LI2ffxvirodkSOF4LuswoiWdUR5qKQI4Uk9posFAFulOBKMAHcgue39B14fQkI8eyq5dX0y+u1Opb320mlvbcPP1998nW8KPY55588L+qpj4CuWXgyuqfQdW0+6dlRMuVt/F5SqW5Y0zwasHp8iwl17LjyyIW8LTvX8oMIX2WD5My9+QzmJ5U51wse+EUsoqdrncH4LUtzOljlg4WgT2Oh2RRuLhPyqgZ5d6Ecq4RiJINYqnUO8mNetHtZmCr2wv0MJ5jV5/EUeycG8ynYTFaEzogvhyhsjZeYKlXVVSL5aKYoyHlPEZmdVy0lbRPuz1cas/d9osf+WIhpUsq69P2/MBM60rMRCSYYb3m01xrVx/rcrSFEGqNvhn5wAWn981HMzUlWfRTHlUUErmo1EgYsM9uldBsxfJ9x++Zq7ndMpK9JX/ASiTPuptM/3kzLv3FrEbfoZuBIYKlGF8N3IrSnTUtHyeZv8hA2QyEhUT5C0wFGii2TiHRVtQz9bWbFPIEGBHeBHZwrnZg9gP3T8VblsSKsqvZ2ovIxF+/TYbCbH5JyUq7MgFTIMOfM5tzsv2q/qmIWVNcL8XW8Pxw4uIBCFi7ArHUnGE6Kv1rrmmupy2UGCim3Lp/GnHQfo6pqBkCRZcl1nAX5OqCWuwL/IDthlZqUxbqnZlq4BbbmI0fGM37sP/Q9mk23FNeZYOwoRnVbanJMpSbRzZmf+plgglm/hUHu0mYpIMu3GfZKRCw5bSPOsc+EGTWI9WoNUkLzjYrLXPGfIXoM6+Ic0RLVkJRqnJPLrBqjmLRxmh5/uT72PXsbd1qhEgwO60Mr6nVhumiKmwYk9bDTGo8e/lRnOmgdKYUzQ5DeyIqCUAj5HUx85pVtAeUpiI667UQPdSVPiHG7cHNBIrAVgvsZmC805KkFAcb1aJsmMt3P2s6uN7dSwSqxe0SqmWdmDSt1b/UPTZP+dFtfYYCDrDoNApW+eq8nW8mxRWkwDQgFSDMF4hzkI7CQ5/dQkCYw/hQ5NsggHDuY4zw/nXxGdLVntbtTAebnR4l19z9CFYHKd5A0yMjrVHQ45eUAueY9GSUgvlJbzVEQtxGKdWt3AtEyvHe5l8sSFLaDkzRZyZCi+9uXBH5/UQ4yHdD4Hes6uVdEoXDT3jgWN5AAUWzZoptmQn+k5yOVc6h9v+6z4AgYNdM1+4tvL94NczlP+wpsXPbz8lPGofy5crVvkhPsUjJnSmi5gdBje3HQqIPahr43NgAQHVYn4ia5Fph62mPKda2vRSQFocb2sUgmXRm2HwUnhJfbMxi7cZ9kjHO1cuFRJNZ6EVg1Im7F+rSsILKM2ZZJqrPAiZfUyphHFGe2XQ6X3FLNAhpEPolEjjr5QqKx8e5KbyC85AbVftCq4azVhz7UkN1VuKDfc4MnawjoeP4nMtc47n04a9uMBOE+J0raT15AYB+FFcIm02865KDhXRF0zqYGuARGyno/kxTmDp4D9eQJ8nyFapZ2pjq8TBcQnmtfdi/y0hz0rtPuwpRUNOAaOk6umUPTZCNYRdGVG2VumCXQlE/jWo/aZRALDzmkVQcHWhJoJEcxIiqcN4vMCxD2ouPcQHJZUFbAxMYyhaAAe2mMOZd3nPtvy7b0Cv4UfpgqvWLGMJOvb6K4G3KsFM5euvt7/qFr1kuhvoAIdY+rMqJU/P5jvOgO6J66cnyyD1L44e6PCXGgPErd/+G9FWmjPa7cO3kDdX4NVOBvpNNoDwFTYmOZrc6Bon8Sr4RUQE9tJgudPKeIzo/yBgF6mE5dIIpJoILSk/v7JQ/hkTIP7PLwgiK11ZOj3TkJiyCbXZzNy8kXaK+SkjEm3BkT3yjoitnwkhwFb0E0rqBRUOxUXDpw1/BYa33HFeBdU4bvFhbKO+qbMlZsPOp4YQxkgwP5yyZMr8Hldc53VT5cz55f3EVrKgBUdmW0j6fYFXHI4gay1SKx8iF0jObvY8XeADff64LW8VQSoj1LupBR7HnLmJybNkcNnA3EIc7ZW72jzjeD7LUbYO3BgNtB8hchZt/72OXBJdpy0LLxp8Lj8q8Orr+SViGqJnJaWrLIXjg6g3uJASR08dNPa4hr3nbSD5yjBEn6WnWnRrM6aj7cn0YjpMY9pSee3nChkLQhnjVdq8SYByu18+BcohlHM88CWyGoUy7eHEYgsta4KbAlsGt/eFptgXCYYZcBMEhZ/tvj0oKBof1PSnvZ/csVnL7tr+KyHS6/anpZ+DK9WgQu7h2rktFUuqia+jOiCPLDTnrp10BIuC1mWCLo3TbhaJtfT0UssXROvheQqWPGa6hbANerTP8NUlw1gjG7s0te08uYTZAUZibAtLaL2gqAJDwXt4kqRiCwdCMTEK0WM0wJ/ztyZroKYrjdKEJvT7rGctrk0bAZJC5TNNY2xzoU0G7/5YX8tNIkNMDuBK5TbEMg5eD3JHsfPXgGQrQosurpy3OzhlyXjfH9nsl5SAsYR1HiRH1AMrjzXz/tRrmugTAVvxV6gxNcTI5nKBSXel44raL+5u8CiiRfe/pPut3PyoX3iI8aZuwE1weep8G80ur32wQuzSwKkjXJZoD2uTqRkhI2aQgZrPhd1EHKx0OI3iKhcN/djHZ2x4+dIrlYOh3E+en7xMnqJsoeKPf6072gcBcoUgUDqPzisHfm5P0azmfGTx9Ku809G+4t/7jyRyQYpotmruDlGOKoBpfS/Il2Bej6Vkm/6oKmmW0lwI5I0qkiK4I9Obf+A+KXhE/HAQjK5MxO3hPk43fDRdySL2wA8aWWdnnFmMzUS46P37uRVxSFVzJJ2rktFUxVXpZoPTSSXhOHQzEjrcB5EvqfilDOxauJLI7uoSdKCAz2iIDcctEl1nIVROgYpTV+ebJiJ5BpmadVZt/ksxtjQzsJdO9YNHgKgIqnzlcVRbEx7J5LHuTF3gXRDhxvsyMgRfO0CpG3Vwp/endpSVeEJ+7PGCr+3uxwmGk/Q7fX16PKT9vhkK8Jd5kaO0Ijai9C5CU+EWeq3jSP/LM2/SnHPaQza8YYoeC2fHxG8E6/hdxpaow+ZQZiv18lZhaMwfzmj13HDU8ORS3I2WUMbei/pcjQtptjTPx05XQ/3My4A2GCKPwUuwbjJ0gMRS1papujxwAvTcekruU27Ja0r913fQHeVP90mXWxUk1S+Q1TOvmid76yZuSa1guaKqk3FpLVqnkXrOFj0xqSre3Em+hUw+kcClcpY0qIgrfrGJyD47sX0F0iKTyHgIMCNITWwwRR+Cl2DcZhmbzx+Sq6EgG5uHehUDCDvz++2fB3nuVWp/BCf0WgyIn5v+/ejLwrbmwOJG7G6TmCTc5m7rQfo1ELmkNRwJCCX6pJhA7WFd277kYBOShnTEpLlLovuOI9BgCV8fEl73AWUN4pcS2VpL3awvJbArmnyqYFuwmTOjetOnAcxTHyK6z9M3GxoSy9SP0Ot9x1EIGKbaCDo8m3vxWhYUnyiZY8dtGzeBBvyxueLpmNoOxSmNNcmrmwDnsmg4M/9FhFh32R7GF1YnqFZAfnK3/KiP9mkFimp1bAAa5WKGJ4nFV73QeunP/Ww3ROuCj+eSafwoyYVg1WVike9bARLFesxAR9MBFyljQuZS2sjwTsbg/Za2byIdiMyz/XsuspOsxrukrvxpvQfnCJlUShEDCD0U7yAlkT/VAF+6I/Cd6bGava1sekq89w9yMsTJQWg3VeV8keGtYwfYAoChSvUTRvc35gNaAZRYefRBaIUgeiH4HgjuHd5EgzeLUHxrvTzfN3l/rUooHcpqkwfG+1eAEzDD+b3dKpv1K3T1rK1VgrFCCsA8xyqGC08CQL77/VdSXI5m6LWlGi0cfheweaV7wryoEYLaegXvJTed1vhFr9AFw0gs7766cl0JeuIzWv9sKm9aiYsEnakw0kMkIvJFXBUXJDxuUxNvOPvpTiR9Sk1lWtrVxqBWqm7CvwlsGZEStbXS1JMczASzQWwjMMqMB4ZRWhXFLBrv32UnWY8SdJzY2kCz8ymZkzZLWc/BkmMX4jiiCw6aU8GPcBR8DiuadsvLxhLYx3JTN4XZKd8mnXYSekyUvnHl2lwzvc3lcZdB5vWt6UmBzduNRkMRrdqiI5IHXvxdP6kEm//i+xmaevGD5ShrbR+0x2qIlkgecNbljUCMoR/X3r9FEervYWENbqLYgQhqrV+sk9/xYV3KamCNvzHKObL/bV1Rc64TvCdaJ8DPm68SzwIcNcczs/mEYdNjQe+l0g7gXzgQUH5KD2CMieg/YnnXZcVIeu2RFtbR6onWZrLL1MHsABQM1JjEDraq5DRUF4spExH6+MFdT9cnhC+HRiim3P/f296Tf47hfDI/c79kTg4HzkAAwM6qbCHklU4kEo1n5Plp7AID4iFDE3ZTc2xclftHjkQWyBPjo2Z+zMCMjuu9h+XdZ27M5JwrRecFarndGP36cNJGDlXCP9ern9ROd+jkWkzz+WO6FuB1Q3Ffg1XQSYo2LCLn7WOfVWPFs8MQc1PZVrzdEHRt2LL3XgzGfFC3CvMqHePl+ULNWwf1ufXvq7OTxPI1Rn71N5JyoMg5npp1j/lAas/lub4oiUZdhXtdEANkNYWtJpXip8G6jKSXTi7t0v1szqGOBvoOuHCwZKYfwLWyPBJApejtCOBL0MJbzAx7XsEXPgJ3qolik9yD8nufvS4zB6WUolu6Ha6yRQV4L7mGg2xBxRJXXxupF2pWXM97Bek7d8prw9ZwmzrrS+RWR8MSP6uIRaUKP1dV/sSJhGuxetu2Pl4T/0DmrjXQmU0x13BWVGVMOWnb22Lkr9o8ciC2QJ8dKzd0KTPkpLzy2JFWevEj1odx5LwkEVeT4shIPwP93KffAq2W1HZ3vi04U+5PicdSLAvQkbuPGTbWEDpOtX3LDoSA1We2uRCSb4ept9h/uedIex3G1voJJatiYvI82yh4pmXaT7ca8Kv0xOyM9Mr1QJnoQtUmshxH63t3SSX8jlMB1ZNzOKS3mCamNaxKzwa4nclMeZe1dh93AAMdrytKxNuPRsU5RiUoZORI06lCuVR7JU0OhK30gZEFnyrx1vq0PqFdKW8L+coCtOnzuBrDQx7pvUnNtZs0pN0pDnapHZ2K7OZTcFAK3RLnLuunBfKi1Ice7wUDgK/tFX83bL5V2E71FZBp0X7h+q/t6xYGuYC34XIR2PRXAAXTcRaDXTv0DCO0UiFd+pC+5VNFKjdnbA2RcoC7l/ViCymt8MYeVCJFnIWaDdEqR5v7UEjQow5R1dLx6j80FHMtZ/CEdyPfFwBDNxtHm7/aVb8rA/bysfN4+t6Cw0ZkwlGzhhAwUCJIksxeEUbe1i2mTWPZkCsjs/0kbL54IE/s8hETufH6TnPunGMLrHHF8P3gbGTZ3K7gAYmteLMLLm2HAJtxjBqn1v5l9Nz0G1JwUkegPkcmqQZq8bCsZ22/KhFzenC4AxRokmhUhJ6v3EueTos1b1LYGgFNJDG19cNc4bMlA/AkpeRiP2ui1oBye/C+oCZGYpil5TnF53lQ5dDIRdYHahniGwEAQ+wkw5T8//1UNmeHVbFNksZ32GQKrT6WqEjxI9QIPo4HG1k6TUBNNG2D9Axlo38s/jM5Dg11nG6laIrXiiGDROig8SUlxsY2jsn+rAIVQ7bp+c+2OayQfCL23ncly0lItdCa/q4UKi2cGJmF+1aOVDX489AN3NsDOsuv63E+lv1vW9kwEPGE2sL7+6H705L+cq0n0GrE9ZWyrse4pZXT57jKcdoqsQwpZWTaF85BiG0eKnNq97sUYIp7ZFdoMM1JkDlfnI/q3on2dM9rOG2VTbJXIO8nWkoLWnOg57p+xdpoFi3GJEIiIv0TJaxaFdwoWHlq4RlcWld59AcqHuuVVOco3YEhYLL+uqBrYfAtcMSI4kwOf8z2P7LuCh8X49O2OsG4gE/5waTCBCZfyXTQce7IegEtwXrTXIiKQTcjd2somvFHS1Y0jSRZt2f4jpOTG2KCjNGvTkPHim3cozVG9yiwMrrB/odEIqr2cFCqu5n2lwlSXHmLoB15Q1piZciUpFMxoqTR6YpjJ2RwbYOizK1Af6s1HGlAqG5ovFdPLTyL4/qzDM8XD/KgHzkj0/7uDF9gt/KFEQYbbbVoun1f0kcJ6QN7KgtShoRb1mmbeuLAhttEf8aqs+BVIAXb5h2SbERTl4WdnH8EqvualoWYttGPijApzPVPGg9O94eg8+KdoacQ4xW4bYeGPhj5/8hrJcWkHS+NELh0MMD0awqCQdSnbK85rMZtt3EQifOdcA0SRlYWdIzVjOHqbP1H3kM4wbikW95EldnD0dTD9y4ebuL8b+YImMQh09I6RNljJqIO5IHkFWlZWMOMN9JYM4WoBlXiJCZpUFLw4vWYc2vniEKg2h3ahVYPULfPgDvzIiFQjiLBLS2ISHybATtOIzKh2rBXL+k+unZLwP/KUJ1c0Nxa3JcHYz05FOkCtWJ25KOwRqi1dmGpMdeNdXJXUsgZAUjOFzp5TxGZFQPnz1n/CUZXR3yipMOMKMpqSRaUaT+LAGBzrnzCLy5ou52n1WwQCOWYSljpR3hFNy0nzjnCIr907Z/xS+3qcXhB7ajlspY4/ibqRCSiDhTGi/NXqhwOS7aHVTC9diJxmQ1i0p8e3eN46BerRNkxlu57HyfpJG9CfBNSjLaMnPAUAIjbxtILFnU2Na6qBuXLK9WazVsXuJ1j7/3ufFLMKtyubCDgztbhoT958UcPB0tZ8rSZ3w/oFT5tHWIARDgI4Ynjwmyo5iNs+TmKM8VfKoUlywDQVVtPbSltQwjPRr7o84YzwhWru6HDQEFdrScEiPNATiy7a0usfp3Rua3C3cG5mbFROrAbXPGgGQod7em0vVRpf+t0U4inLGsOqosx/p+Vs4bsh87WoNAQBPgjQhF2RDq7tVWJt19PcffdnhWUd5Z9AsorqPTwD/mOg8jxE8AzMXshZySFrTfGfu8/jzyhNSKi9+OhEqyKhp0NrLwh5+UxmlHujac9w/rby3xSSS+J7CFPsPEmBmNwC+vONVIh6zQrZqGRbjVlrYOdtNly1ZCYHAAhWWef8OQt8WziYyf5Zt1Jrz1GL76xpHoMIaP9Liv2CwqMRnInGVc9qocH6WQXpLvJ79HLqxu9USFOsodQb4rLNC7s/8JuKJ/ZzUdwY4aI6kC73mLwR2MwkrA+3yIbJVUITcqi6MlKR/vUYnJ0PAMzdJVxr2BqrbKfuo9xEPOvJH0BNxTbemdz7QLjryBNaFI2SFS1htT/S8ZBV3cjof0AXlykumSKUHblyK6sEtOXWSzRLCHYyzWyZwM3cOmBqy+dPKeIzMmyuK6vS9RS/fhzWe54k3WwC0zKhRsXvK7tRkRAp+3JqaBYtNt32QsSLGQHmr1Q4FgPDoz6ObUvv9XggZglHNXxMQjffG6no1VUFGmxZUrbl8BNavGLO3nehV0kNEscsNuKm/TgbF3f2Di4OGvbLIu7Q1RQEwoqyOiV1dSYAgighc0efb70+D5PS8YJvo4VyhNWh8vEv70MrcAC2lR8yUjLhdwpIKZaCthgphe+omeODrEDn+GXmLdYfYUTPAN1/MuC3TS96h9Q0xNlVSJzD5eYYOPfz5g4BvD7AtHOGMvIi6OF1ycGc1fExCN98bqejVVQUabFXQa5/lMsIT6GjWzM/3lpLwnq3afHe+I1hZFIKnVkCa1PHQZaavuH2aJZhhKnzslT0WMj8rLKvJoPDPeKLYM75KjCw9YlpUOhiBUns4G++NRoVGjX77ClVnKK/F1Lphtu6AyrnfX5Noa2m0dXiPdpC984CsMo9YgMInAgJ54z6W5dSZSBTmLwSQr4U6IByfVqzvztJppmGUbO5EWdscj+d4NxhDSe6qbmIpB5jiOhBykecd7V9d9QCMxRpQx8Vi1/yYl2CDKnyxn04qYfnCSypn/B7OInvD8UbXsYNMQ3b1o9rOG3DOSfdp+M7siVMLcXrTxVweHXxt4L9XDQ626eWIzJaxDvPGdNI7dMAiy4wyK4c1ekxcPVHndo5jtccgFp0KPO/R2S1ecSg/fUry+fans5bcOByGFuSehJ+ulzqsq09JdhdmdEFKaMJ/JbBB4kUwHUJ9xlSlPivIYpJaCIXDtEZ9OKmIF1OMhYGKOZii3ey8FIZS/xvWrl6J80V3SqDAywsABlwwQeGGHy5eS0HVs6eufz7VfUYXnrttPrrQOayWQXpvfk+XziUdao8+UDPIQCHbkY9PMCQ88cG1lm81gIDBK+0ioHtXNe+cd3Ysjj5Fe3qzWatRmhwZ6iRGB2BG8rX4suDobLTKcXfNkmQt3QafMSora0gJMsGT/EgdqoDCJtt8cZVHoK1Mm6M5v6dMWvFkNNUr12TthfcAzbfurcsFUUb/V861gUFviUfPVJwDHsH4Qe1Xa+AgHf7YV7C2j7CbErzz/C1NTAEKLNRqkBZV4GZRXUengH/MdB5HiLYwZGIHKfuUd31lRVF4X5yXZsUqJG8LPPGP91pS4iu+VpHAquGi1GC/52EVhjAnbNFvEmHZtiPTZEpsRQx91ebYBVUzO8Nv9G8Ks4igUc4n44q0Z1PTEsmx8Vi06IPM4HVMYlsV1KJpRWG1uXaTB07vdqJke8e6d+kU+0eFLU/8Z31Zysi2z8gonV+DpOo6zin+k4mpCZVMpMdYcmjK9pPADPy4xUXWM3xzzj1GiJBTMyI0HUEN3XhrszKqMg0AR6Ecc6uqPmU51uG/jgZeqVIrhZcWwq1ZZxHPuq9JxXW1BkjIqdM1AapvP4b0bVuchK3XgMrAg9q+3T5Trf6rfSbThH2aP3moMfBAHH2otqsmO4wMAAIGPNVR0xBxHdy1ByRP3/Jrj7R8vVLFrR1XH0L5dxb7QqAFDHvEp+BDIQcXlvd4xVLIpPDFhxtowuqw2HQfyTNBQ32Lv/M1Ibs22edTzcytGZXEFNNiAkm6sdNwOqRlEtXvA5XeWKddTG6qSHrFM9g7TPzXVJM7NRWaatvnEogpbSEOCvB1WJqm6pHUnRy1mXU70E2yOrOAbgQVy70qSGPDLTDlVnBGxRu1RgHPveGSJtuw05/M8/o5NJJxdZwbl8o1qgbWb2BbfvFRKu2/6qH12O0OMOo9DgJ5awgmSVVDqJF/wFKEwROLADDZygKoKXIS+OS11IbG9BMFk1vMx/6KCHSKuGOCTwmY5rHeqUqziZMNIHg1uSvBsViR6rSxHix64NIiEL+8el0gByEg0v68Kmy/uOEsB+RuGojxZXu8eDZJdmdy+lTVBUrE5H9bvTSl5hZBZX/nq0ijBV3Vr3l0jkf4Odf2VnotBwuTAMWpVOTWsHvSFcDZS5nk3ToCuKKeR4Av10HsrzzWEi5o4RlyrMChqcoconT4/2vlT084Gv7c9a5ZTOzXdA1QL1EMN15pL4yd9YZTVbQy4kGKeR9QtoZrmcn7XJdpg5GHNxzrHInCsp7UulG4dXhF5zyMEvtu9q3ikSP2MHmFJTPraBHv6JtGCde82OfmN7O5ufHPwLsMMFRO+JDvSFoWzcvbWBglFKVn3wMdu6pJ1UPxZ/sR05qBO08sr3JpmbtwldGiDVHUQIN3sAY8ZVTgVx11nfZ3f/8teSmMundbzQO0oSd5sNNk6coPpPRw7BPBK/KKlYGMb8WQ/mb0b9a96+k8IT9RW22GKg7cWtigSDx30R10d+VZMMmC7N+f5X3JeLXFdMs6xmEnksN8jTqrUo8T6Q7MDUI9LaLWK+hWf5N0X3gWP913ymwEIrYDnCJSQM/szq4b50T617Oa7/RadHYl5E0OY0+mh2srzNx3GkpP3SlPOHmyQXPdXUY9Q/u8G0gO4EHSfiZ9vtsxFJXi8EHEAW2+NnkkGCc9tE+wb2+tRPEiQabwq4M+aq46He2aSEs8/Jkwspn3wOt1UlhWWKzW7gTYOKrw0b6eqdF+OnQzYRvzHuV6wfEcDrI09bYGT/+PM72iyKQI9s8xLFzKoS2kV4Yw8uikYvHQxzk70ecKthw1efn7kaAZ/110J11CKb3yAyMlWVCggwH62ndQaqxItnpEyHinBahV/Vj+hGx9Eeb/4zWt34RdK/bJ31Z+6nSDibg/3cdKdVMtaFlpA6psbfgdmp+yxazYOdVXWVkwMcz7KUgTO6rtlEpHCwfztrbv8RcGyNk1xlEJesRwK4vjSQAgbHnT9uC7HECPRv4OZ+FbgBeuh8izDOq4xNPOm1wlEIuSZg5vRhSNBGlL3t1WZTSiIGTS0dDR6VYxELMRU7XsWZSCX5tyDR6YfE3n8Q2Qon/WVtlQ1mGUKyRIzPTtmYgUe2bZpbjqi+irUmYOQ3Q8Q4VunClKxQmxaaq4TImQ/WGKB4pfDBMocni8nXVUyA/+tmM4yxtyDztmB5O+b/W4HNvH8AcvFfxaB3G+NYUIVD1W0W6UJvuaGh8tuPiOWaYB5kiP6U6erthMJk2UwA92fASyQ0BMSEb2RLfrv9j/K20g5hu796Qwyd83/gJq3fON0go7FmKTaYBdmDwPWv7tIRmlxD+nW216P2JsfaTM3MyclVz+eujYaE7XLUmMRmynD6iBEr7EbWUDFUrQkza0ex2DSx/cms3HcStn1iDfQFd3LUrz5CIqwt8WB9N5cPfSQErE0v8XC/VwAvXOLi5PWV31mBT5Jzjm90s67aVSIdD/9wNCyOBMuJI5OYr7Igj9Q6X0R1tdwb0lD83tWhGVylAOuatXnAm+3mW/aJgUt7b0fbNZXpPKJGYB6+43qWMoAufPMwe6jLSJ/Xi2+UhPP0r18VZxPyAwg1oa/xCYVDmQkL3LrcUEKwIy5JQ5tguQmGGzdS/RRh1MTOXQ8EKV9t+tM/X8gssTIRW2vmkjMzE+EeTrLKN7Wl/FMblsOfg+RxNb3uAmRG53MOLtSsNlgWifV98eXwsXJwmaAoIDWh7LLbmjWTmRFW2Cg22j8WM2rlvnxwQxP4Bet6pOnHaDvXjRHU6BHsFW/vKAZEowivmvxTRdwVcFFsZVH5xubAFpj5SWZyn+QFp7rgJMv/trhQdNCTf6vKB4S00SZ5H+QjHG/yfg8Y5x116Ma4sLUvIrsbHBMGLcVy8vYCH2bH1GgBUkhMN2RU23fCrWSEhk/S5wzDt+FFsZ7QPg9vXe00rPlVWBU7InSJhUHFJYO+eqjSixs4sU5ejj+uIN68Z+r7/L6JVEFOypa+HQHXSQJ/nhDFt8r+/fDZSCy1yj1PU5h+RsUEJoK76Z6g6qGXj+yZlJYLINqjm+ux+SEn5oZ0SH3Dt6QbDx+b6b92UxgMccvznZLfYq0wLPs0uoPEss+PyeqC69Myq/Qn3BZa916cwMaUp00res19XJ8D4bS/ZVLt2dTa/aC8O2LFKrNFOVq6pBh5tBfaCunlAugwEdGAWYYu/Lt/KNUGPmRXxPpbqphjxdJrKqo1rJRROSF2kL3XRC9yV7bI1JRuuk2qiBzu68LYNAnt9wfV9t28vGnjp2pCVcJzuYY9Ua5oyUQZbQ89BhNALTT0zh2UjBwiwocN1n2AOHVOquaOhh931Jo9cqVVFx+mP+HeY9ufYCmKbaW22DiO2wd393EpgLBy2wxjaZc3mhNm7Dt+WS5JM2VkzL0AjZMHSiWEN8hcHLu3Vt7Fv4uvtnQ7jYxj1Dc/RiNhJowaxSxDi8YXGJopdT8te0PR/Gm8JBU/ZMVg3IIbYD+2yXg4lykbFa/8od6zuIQeE7UJ3/ombx1DpgRX1JxMol+nE3CEETeLFhiAlKA+hFsOkbHPKBwe29mV7qKzD97zkqobQoUcot2Sh0gE4ZEj+pzpUHa7rfU1Nd/Y6C/PIRhJDTghMGcaQGXUs+vaENGhHK6I93DtUuR5QSHw5JBDoNkqPKkdV127gGbQRtT8dLLLiPr63VWQmUSjVmA9PIuRn6uNsmZLXTKvGoAAJpuxkuXBDP5XMJQZoTgoctIqr03+mj1E0w/t2LLYoITekN5W/WV1/o6tkQILQpr9tL0ownC1WfilSNFG0Ll9bEDgv617ujxbsyBQLTDWQy/UL8Xk45r+bv+iS7LqEXLhgDSBFt+Y0bsZ73y7ckX3PyUMiJG+YDW1hn1jl4lFv3R/HRGUkDh+ulR/8eETaS6bn9a/Kyk47MdgquxaZJ1PmQLb1hoDgrCn3O/NrINcVSTRjSKkmHZJWkhvjRp1YIDHWuFKrLfo2V6ybAuFHlj4sgQX2JZ3yNCjIfaM0xadHjf/b4PLFI/M2O06pi9Lhc+GTn4Ne36dVr3aKJDZMtm/AwrZAVsZ/XeW2DRSN8qvMWH6bBFmMTJx9cvbbjnWJP4GBT+bvWMJftRppKDb8PXTcCx6fhP+WzlE55u7iqwJKNaR3DhgEYBg60tdEhFbZe9sSriv8lsvTTaWABjMQatG2vXmOT/aSM9rlQTiF0SyUpjC9sSsT7XojMLsV/brwlZz+GdTKmFvWXUNNxlkLrQ9J14F89PRzGeovugLIgqvS6T9T7eHEqz2Ra65BFFFVYCUe3StCd9Qj8hZ7qCsU6Wb2mYZbOcUKKrpp3erOYCFY29c74g148I7Vz5kmR3OszB87NFesyUaUq7MgSXuaKIaYzlttyWJ+WgNhKvZ/EoR9+qREiaKJ5KmFPkJsIili5VD7eLkXQTt3QDmcE4e8bzCIpZv6ivBjUfttrxGHty587NJbzTk3Fo3PS/NaPlNovILhq+dtO7LqDLGJB3dqQYKn+sk3rVeZvvzoWvffXgbvpNWi4af2hqaW99vrJRIEKJ6G8vNLsrfXU9QMCUWazA+L3mckLFBvUqa0HeHdc1onkWastLC3j7DmDt+w430M2O35zvr3UpHY9WOgYn7xCLY7MJ7A4XCyOwIWAFqyaGbetNOMA0PYXWEjdxKD2Az33fidmq2uL2uPLGHXkN12LS8Kolt/V1dZs7kX13IBNT2lTgvMXqAuE/OJ+g0zgonGCHsOOKhXTiu04uhki3GURzaG754evg6B4U25oA9zo3BaRWo7TjgaYLKm8BXjrcPSAs48noF2Qe2/Qr3JYb2GGe9WQfROrd0OLKEXJ0PHLd5XUkIjuhnuYoCArKm6HyBxpbKjpAg5bN+r9BFurCjGeoD7JDIfyt+72R21Z04og4saTtamQpR/HcJ2u6tnLEdd5YLLIl+jkHu5tvrKtRW3hS/Blb5WDwqqeK93LT6yU15nqIEHgNsGHiCus7ZN/aZhWrWebbfZTprh9r9JSkJxGx4jc3S9bzDZZ2hm11tY2nl9QkMTnaKQdlvNw+CjyvH00vce8J2AMAEVSLcLD9lrSvEsIAeQz8oqh1XOS3CaUFmR1YccigjH9O2EPcLMhEx/j6cpzii9wdtp04iPGmZ+BKjhWqNDp3sLHuj/9BeDRmTJe9Gn+rue45ZKdG+xir1szkspEpntzB4vwBvMUBGS7rLBQfBNReFbPbLWEGXXBXyRSQUzKSUd9XVY5UFe9wuhqGys/83zRfVPwcSbSOs+wTr3DyFxr48+E8oyJzIcgOgsxmwI9ISrWffm54LtRw5FPoQSeBmAzkyIkdn7F2YveUCEEKmnVri7h6aUGaKds164h07vr+k4W1fYuvoGC7IdKIJ6mxK882daLgZNVbM9Csk9P6Uc7gN1lLQckvFT2J8LV0L7GrAe9MkKvebGj0CFoocSjXTHiB/Gasu9Vuuc7//pMQWssQWF7jAZpG/T4+jtE6cu9Ir7lLVLj+JGmvgvXOrBC2PSJC16dsAZFOhtNXqi6G5njNNt+2IPTYJbpJF5tmOiCFcbv/+E6QuzQOrYiK11ZOjyrUbNfKVRf5toRSlbVUVXlB+E55uAxzOr/CwPSWgoP+j/tBMLGpO+TU8oO19ZSTRGn/q5R+5hOPsXm2PDJB50scGBkC80fySblC+QvmgMP7Nht9x4RcR4DHhfilNYIAB65tSd+7+gANUg2hKkCcldeLzh30MXeZUbYjf87ubdiihMWknzb+ZGzOKTI5wzCnuG104lIwRUADGpBxCvFv5YBnBKpv3JDvqBwqstbwJ11Ifx6Z0h4WFjRcDx+Yd0YYhFauuqIMDyLrrcATA1LRwvpnqmkA1m30tpwrOqXxbVDDsO0oXpz10QV5n5KVaMQrQVOdPUTPwOX2R+t3hGUL9CzBPTau/O8J/ICTAXSKtIEZNTQ9u3XHtXJVf2p+xISD0ZO7YaQi0Qq/2LBDvJvc6RNbQEGbJkze5EpmK7wWnAgt1q79HXna6y7HcKmT3Q8663+t1oh4SYAsRL9tm6tmNUhb4ftBGU11ZAqCcyqxlDU5p2It8SO9pTJr3z9ccHBGer8dynxKwMs4NMzZxPJmOCeGEQb+eVzMV0RdVUCqUrkMZIErAbbim3Fy38FWBasKgDDRhrLnqNGxavqwuu6qaNbfUC+jaEsmh1Xh8TZrTXrKkLA8x8hf8Q22qig4UxAIJWK6Ecaz3nm/jly9jphH9ttdTI2Y+wcOmOQaQuXP+C8O8H0QykvKO3ERpRXP0u84Et2SIFXbgghEG6RR7QeLMTvhF0bWwEBy4cYULAYqQEyxCAhyheYopcav8YWJTpzwDdsw4EQB1RHKdYkkQi5kSrbvJVOirOyjrqSrqkUZIzjAoLWOEpsCNGVv461EIdeeg2DmzgR4QkJ3J/5W5+Wo1VWPSsnRLFiOfkGWnu1aM3z/zrrVYzVvPXEHLl7JUocMDDhQAFFZC0VPL533JJf0iq/C0llY528UjvdvZV1xDN0bDjsFvDiLRZGukEOS0a//1X5xtz9kvnez9luVCMAnJRFQD/NY1/XSugmYY4fZAzPkg3peb23oEFVhtEvyq7UhHzrAYErTd3pWi5lmhT+4K8sXL8w8KBfvf2Y0MZldzadWKzy69o7hC4qCPrTVTYu4OOoOmhV/0QFCvQjKGvIoj+cO1dqKpFkT/IM8BD+QIjILSmYmBLnPDRXIPfs+KC5xtkSZp/4RAd1lcvRGlhkl6vxzfAqfG/rmZO33LfLlE1vyF/6EePurjSrHrjMX9azW9rpd3fGC6R+4LUZRSy+snGmclayt4SxL6H+GeVZ76Ahtf43avkEE580Ey9G148uIFJSkI8RQ2in6fYL3JCi5u1oaUyDFy39OZeIvn5OMpEQFKPYj7wq5fTDN+3XjHtzbsrQOIHCxzZ28TrMTAeprOJnZSchiYruXXepEuj4fbMz9jnKQSSrOvWYMDrTE7KS+RZKCxQAh6RS+1Crv5RKbT8JOEmAwpUWvec3bYOzOW9dkHhPBqBSGx9QRSOiH91fgqyPtX2q0+mBNQ5UdNvLf63HAFBW1egF+V8myQtffxQhjGu1ZA7aFZ653Bfvfk0hBfgRODmU6KQDpPoLmikrNJbk++vGUCCoKO50H9C0cckVPDwfc3sUis416Ndt/QB1R50F6aMGlq2B9s6CtVxuXiXNxKYuPJoKRc5eYDK2uKjJh8DJVZR559M6lXFq1thfi2cq9na4gqQvHRUrhlaiYaVbgx+aeRk/mLU8cEe+Rt5auhJhnuZUlD6wxFSkbapTjceOfTa2CLPRf5vElX+LyIF+WrMOuI2Lx25x7T/Zu87Lx0AwsyWfvJOg1M36JJkhh/J9gdgH5RUC+ygXtBQ/cq6qIS3EF0jdsKxQloQ1Y+LnmPKX68cI3/64+y6y13ZGcI6M0X7PMIlCIpQrF0joYNy3foaslwqGcMd9BvrqKMZ9zyM1mTQWUDxcdJvJr8wzDwq77SlxVvJ00+9RETbu39gZFZxR3MTL8YITINtzbi9LwraPxA+GBVsAnQ7AgTLN3RNuQeiBrvOUp32mYwlqz2NncCAjAnlmAv3wtHAlYu+Ifp9eEL1PTVgvWLpZRfTuzNUSRZj3FCdzN2vSg9BM0tIKQDuq5qMtMrZoq9dKRjTYCgCCpEZdixHtkUk1AqfQSOIP770gePhkSURDeKe1T5BW0p4eMYAcAenkQDZh0dDYkWJdneksbCzAvyPQ5jrA23UPlBvfshpT0QjP6e61ztB048QvD0Pkh+fIFGz+1fcejN3UqrKPuwGk5K5hX9GeQrKNKksd2EUMo5wa7No9ljXtv3unIZ07LJfhIeLkDIMbYsz/7nj21TPMzSiPJB0QmRbtIMcjMSz0X1LK4cPICbZ/+DXvuH4il0E3nzME/IIThrBRHprFexmFl51nOJHfA8NIB9SlweBD7IPh0rlaj7kGdTUH6Os0R4Gs6h0QmkTT/I2kUNGMkHzRvwFUwhqzeb1osHCTr/3DNmhCY7c7L5fQYBEVtz6mfBS/BEVhs3WlEysQDhpVrXJOu8HtDiRDOdR5FZUTC3QMw+ks5WUdT5RJnzeogPdeC2P7e/bv0L2RVEyKkhuuP3nD3VDVziJmOxWbWQrSCv0txqQdv2HG96Kp0dEOT/HQXy+sqNyjM76D10jZgR3OlGUkXd3sXfvgeyhNoZIT9R1D+VkvQ7Hk1K6kwp4SLohXX3fVpJWC146xSCEmSj0CmTw2TONxFnIAVRDLNMFClio/TLtxGDOLDxgYlt1xSDZykCTsoLMLysw345A3cnab2lmRRDjVQ/8IzuWC9r21F+gpdT0CLp2f1zsuiIJyNheuUUC+YU1i8WTRpcYROEk1WLniieDDnMNoQTIwlK0DL0fWOZmQCHHc+p3WxmFl51tbW5rggDobHNfK5OP1QExFEfYpnpSMY5Fn2M5/8/lNhQ1A7fXHofNPHg3KH+DPspAxDsPUorm9ROU5V3jafsA9XuoBV25/VhaGAiKHOdTAvpCcV96vmKuO61UWLbFrdyeb5WsxBiDU/uN4yXBgfjj9ZSUqTWJEgKm1TurJd5cb+bVFG/JGT8SA34eKqkVL3XnSgVvglj/KXQes1sUuX1xbyPG2fRnBhJRL9U7U+d51mPrytvZIBCRoefAhy/NiPHC/DRosF9WwKIlJIdnIUwtBw7txuJoaCCTcoilznpcGWvvqQGQYBuxO+RBWMjvKxQGRaAVduf1YVK/lbhp3rpFt6T0Vkq1pG+LLZ1kMeNTQDtM9VtL1mKYAgc8inLmAzCNpRO36H4NCv43ezOlV3U9GuHnTVoZ8z0IPOrcZtcL7EQG86wBAL1iX5uMpHmxPdY29vqyN6w/c3iZjI8KFszsu4s6zb69J61IBeyUJhlQT3D/PT5YooWcNeSlJSFfP5Okdg7EKdqsVnsFt7qUnwyM+KcDrfw+08hlhYHJeQbZyOSyNw+evsW1yeH0r7BwH2GOVGcz007yZRIzUVeD1ba5+Bnz7CGk9oEyDK9K0aP4vomd1ZLvLjfzaolNqLMZWNj32af5JuN1eRFz7whJm8zwhLdt6cK8hAg4p7YEVKq40lH9Ckyi0KAmYETs/oE+llMZd7zn7rvG1dHYbf/9MM8DEU9rKBFtA0V3EPyRXp7TDr6/8WUXBGYOgvkQqvsCHFYZODGceUPwC5SxyI5eUsRAaDflaFZc7h3PGUs5QL9Dga3dY4b4bm2xJBfXo60+SyVVD56HkNCGk8/Z0yUyQEL2XeoXdW4/jNWvdNe/3JJKXXUKSQhrzTlX7bxiRFOrbdaGStCr2n0QdGMDH0YJ0wRkXHox4Hi4/jk8Tv3W1wxcosJUMogG36VJhgLfPgnGoUNvS9GO4TRRRFNc5anIY9Gyv/mMOU9wlwaLti02UiRA1l8msMgX1vEo3YC70O0pgj1EiVQH0/2gphem7SHjvOsj04UowT+SxHyd1Ov8klzGndG3AVfvbbAFPdjyh+AzI7sDr8gMvs5lUhEh8X0N2v+E7rdHlp9JlCCrgSFQDcMChjvtCZUqKWoyAW0HD4+l1lT2b4Emby0krLME5HLM+YNeUIRYcVWUdyIJtCp0WHHeRlBo8L/OGpu3pLnH5wyE+CXYnz2ZfxWizEs1THPKnXpEN/sU6uFpFdA2MBsoeIpkxK+jIm/tNdVhg54PqyybVbQZYBy0hSaD4srDYeZ5qVyMV1anFdYc2SbRCJrziNf9uLUtKb2sdFHutqQ7CR55lddEkd0PRES1qUm3m3Cv+yOR+VXR6rQV6jeMf6dbGAhtDIu21QmQaufEjO1dtT28zaxF0GHDUsKTZyxQRQ+XI9StPepYFqvtKkz87ZmulsQQG9J/nxxuQ7qwvKcYcGS5fDjj5TsY2NhPH/FTfMPQfSSFmoY0yU5MTlp5GLw+3cjj3e1AjjWl6YFy+mSxfHTQD61LnQ7AaraJHoL4HvCkRkMtxWm7fJIGZycroS7tdNIVKvilJSSxYO1OVT60XkzccQUaF+xBgMQ3MNxOdRGmLGbZTwuNV3rR2rcBCFZM+XNdfYTKBmLgmO8i542zGz3/zv6XQUhAl/vBjFXI2ZLNzFbAXvSmC5xm+Qh8HVYDhOK5BenAGzOl2oopLlvVrrVdIKBk2ujpodqccff8x+fA3KQnd8rLiqvt68nSvAx/c2r2is+HGlIas85cvAhgJAGTqYK1ClfLALddDAZpb2N8jRjjvy02ZZIB84A6FuGrPTUE4LC0+XiOI/U+gREIz0JFjoBmyDsbYeig49VIjmUkBoKx2qKj/XV2vPzr01DEM4IUOHMCywD5raLRHIphjxwF2fBe05YWqzGz7mrM8/Nh5EJ80IvsBawO8CxTfDW7y2gljq/xN+b5TlJ8Ygc6MPBZ0MRCw6USTAAIH/2nf+ap9YylbqiwaosAvwrZ0WBIdQ+naL4mwLQ433R5OqfkfTq4fxuP2syAkZdYUTFJjR5P0Ngcg/NKZQPm0G39VyHzk+/TTnYyGbFfhItJbI57E2lvdFzy9pOOjUB2kFn3sspQdRC3g1St7GBry9LHMNAADy+O7cFnV723k2eWHG5ki2Otmbu33tuGUnyE8gQEyk6AfG2NOttOvUeU1dgi6jps6UOpIPyEsaO4BylXEji+aGv+P2t5unmbKM94V6MR1EV0gmOSpYfFhMoQD6T6oSjoo88PT5NLUrei/A+Pncv4Y7EHmemNEzuvpnqiog6RuM6fVCd+c2IYYKawU+g326mBrm6h6zs5fF7XfZGY8EOYt29kAgNVu7jFFJqxtDfd0PjNlHbEsyyT6r4T0Ez1OGPHHmV09ugKYy5Lcn7vtnPH2SaSDIT2ofQcXIlZcAG1zae3mxs6yInZsbWcjWralw4CsPV4RhuVE1g3NnTdMQxV0XOV4WJGTJ69wuB2xIczbfn3fTlXam4doIzqq6LHo4mVuCzSzxEgescMUbbV13sizk02ogON7QAK6pHqnuIHNjlOgnb73zCXEomXvRihpyZGMtNqdAm1j4imTEr6MhgmDatrkxmpOWXWvJO0khWD7UhI5G8XFc7lLUEO9kbKZNbCA2/1yUk47ZPMgB6OSArGW4Q7huewRk01J9btOwfJOtqxmf25g4oWDFQ2iiJHFIXigmLIUzUvVPcQObHLz3c7JtVs9lvA2jX5h/IarGq8jFUHRP6/vUglcCM4CPkTRmCcJ7PE7O6QrEByEEOl1NDJQTaaNu5ReI4KTeyYKcz2ctavIm3k6QfAkzgMyY/IZJrnc+q0DaH/k+2FKyPMoi6xvnkeKZEybS6ETWVs9PKMsy3CqVZaVLvX1shjJMlb4/3TfnzKqizQrPQs1HMZXfIBgBnBGH+gMHwnorl6uDZQnOGud1NvyE3WIbzn7dD0VrqrbYSCnPYzAJ/8khZMDRdWn93jTG+LrAePaBezEYpoo3KrZturldlYOVHVjGMlgAzDiT48YbOuNJFbts0rUBv3DKvCOAfBYIHvwzabPbUMJfOblHGHG/ud/p0m7yfgTuLMTr1myQ+hSeslmYZJ9Nc5u40wA8QuEfRa7f1F9CKBt5HvrUHd5Z6LSdJxrebiEW7QI7FnzY6dZeFXM7FQs9zsHfBDbDRlkZ7NSLAJYNTrKLgq2gfwbkqx91c3W5m229IoRnvGqgQMGZzYH46TfrNlktw47rlJ79ceAIjEFa6rVOasAytT2ZjqNeMbjbnjRJbJnr4UojX746Q4fQ4QiLgYtnF2nUAYczOxPJR3l07Jvz03nWP76WXUkry9Atd9SwAopYqPNy02l9DoNb7bSCaK2wLlUCa0Lx7UTbN4GIB0NMy2lxathiObC6YEam/aG7k3lvKSDQyTV+lfRL37euaVYC8ho88HTQTQZnhGRyFHZOC/ZnzgC9tWbmqefoKFVEAwoJZx5ws4EH0wtpdVFWOSWvNyuNumx5751jb9+EMkh0/6Y8jak6fTbShnG3t5K+oL50btqp/5iCLfjMMlbjWC6nNEYlbbUqUARzEaA9Z8BGO5+dC7+kxnT4/SmviD/IdFdQLbOiGnLmJYp/g69xPdcclY09QHjxN5oR3Kbu/GrJWJxxqWy20yRPEJFIPW4YvvhmF5sBwSmU5N5D34Qyqh4M9XA2sIn2Pqch8l7M06XmoXsGjxX8uUnhRqPN1AXBJdaeOL2VBL4lYOBU78H869NQtsCJEei4RopEK4tdfHSlFKx+ZJk/rvePtLOr9+94X+cIUe9ZTt8GJr6N+Kk0ga1Mk+jTLygiET0mTp1chKqdC1IuTF4m7ctqRFLX3rXLRtEbMAnR0TDHq63UY7V92w8t9GPbZVqAABUKMC8h6tLN+F3wEliKRJC3a8WuU+sn6iICoIokgUBkovwa/N06w61Sz6PP/22D33NWYJdv0H8FG0Qu4Gw6aKnYIi2qrvkGvUlu8vVYEHj0+OyArOlNjaleP/jQfM90mT17ZhFhKZmIcohigTDjLGYYVC4jYhq0VeaDCURWeuvfVjZICmqxQ23Q4ed3jIIlIkLfBSHc2oqclleQqgRjGdloHrN6oybZVCV3lbYDBHQlhXDqqg2gKCaphHj8XrqQZRVbHLDWBaZ8QHwsk5RRit58ixeX2augsa8lIbC+8QphdcFCbhEJHlHr4abQvtxDX6vo5hWYOxiksPNx8D1aD9DTsA2Eea8UEcEchKGGNrFppLZ3r/uK+gHFnN5JIM2EHxwsXL2RY1a2z/9KMcsdR4uXApzxnhG2pY+cYeBDManRUQG0a9g4lOr6wqiJ0dCYMB3dt+AVgugAO+BcMCTSNw3uxyZd2nYinDszMggRIxKbWkR/5+8XS854KteZVsCE/RjmxzkNDxZ9mlBOV198nOmSoBSqqieINJKyl0EdY99At9kAoNGkQiiGqK16OuBEbz+jgLDv9Q0/nt6mS8JmeklzRY28q/bFcpbt6dgd8ungvZoRlsNPrb5YEUKPr7tgknEEtPapTTluFGf+gk3JuzsI1HAY9FoXQ3iYI8V0eI3eJGJAmpG5au4TIVF0Z8auRVOsNY2RWDepflGAH5haRj2Ia9qA4EHp9OFP9Q3yPmFGlnU2WUmPkWqJ5v/ZOYfht1uQahTkEClCVqPzJqXhZWExBjKWWz7OXmCdNjwqWpL5tmjmzIXQXlpm272kikH08Zmq0hVclDW0yasWSqACyPET75zRpUauNPw1Ljmw2BXSLalO41JN4FNTphvA7i+ln8APIqxY1AjvM2NNWok+OChQoBkYICn5AyM7YA+XUP3Z9hVj9IDm8zTVCU9LnWrRcNfL/pvXT8JCFLdT3h6QElvXO/+ab0D+abq0SzMUcjVeWMrYlQnN7eMfw93MzRny6QkQl1pOdGTGVuvg2wRBHHTCIgRncE3vnIfCmPcrY5UpB7sFWPEtlJHUbKuGOozmr6pxdv194ApuSiRc3maaoVvxbqe+erTD2LIUVO2hqiGOR9Aks176lOUfSrdTVSpcMrOO+Derkc730z+R1D4uWFn7/D9QuSQyQAKm8CITy3O4Dc/QOYOcUFS91Rk7rvOJLIC7aDTUUJUk8GM5ToUTSE5uyr1CByA88k9hT7b4kAGtvVy22A4r6rIArsMr7hJZTvo5fx8+rnpXI822yyhdHT0hyhDxSgEITiUqlD37RL6RuIS4lXPt9VYka4kcK1/Kh+v+mjtMaOIPKc6lP55FNP9SbaygkxUSzzyHUamvYoAyQzAp+6WAYZCcWje0O+BBCFcdWBUbTEFJbz97kXfKln1OixSvDudTNPHPDuHmsQX4ByaL0NEsnSRmRcg9vSOpw2qjrHQIyiH43UPJWZ5uhvFG9g44zcyCmojGjvi7oik+ZtT+Yoew8sgpo/tJ43oMpnJ+l6XYaNP7o8bemQCKyN6T+eVcc06NR64roH0sMk6Kuu/T68SF0fBImzCNOPGrJN1dbpj77KAixSddrPZPihlzzAb2kxOio2mPYpLUpd0d+gjUm5na6qbWNOxv2qE1fhNSHI/ztBGWGo9sGsi+Abe8S9HFdRphOqvn8RWHyP+fPeTChoIPRAJjS64HKRTWGiWzVuot+MxOjQxjsUujouQeRWQu53oHhs/fX9RQkAhR19prq+yBFCORyHPUfcP2U/yDXd6uuai/OfKPFy9Prxdix2hj4Z78hFpkmWaIZ7OfnU5tTI2Htry8D5a1jiDbtlT3S0/gLkxiE+P2hfZoOPCrt2zPnzXzTE0zh6ExR1HoRZRb7g72pkvYVagFgo3+v3AxW8vsYqNI5fKXyeb6mmzb1YADGUfEc3wBAwo+F4pCzXz8Mj/A3BV8I6GsxDC4/gWNYcU2I0w2+tE7wJDlissoKMH3FMfCYbJe+uS1rA0oKY0g5YzTFx4gzuoMJvvfgPueE/XsX4+2JWoJ1K2p6fntSUIf8+o9Wrqr3xM5Gm3o6f22c9MhEPK9OGD2er98eaxeiAjTf3GQt8HSCXxvZ4QdRw/9P2JPdUCPz3NRQaKJD/5pQCwLqERvh20n4rUvsOOUvjbcuv91NA7/vfcIEzv694x7iN6F2VfBNSz3XcnnxvwBGKV4bms5h6of/CSiq4H5/FiVXHNbf99BXjIIRf9fvAzN9oONxyIwjW5TCAhaivmpz+p+8+yPaiFS578QT+3GUR8lX1ltMHYULQ6alX5BMXlNGr7w/N7ckBt3Dgew+SCcY7PE7L2y9NVgDVS4N2uXvmSFqALxxbcyvKSflx3uGd/T7SkWgE6bgTZm/9J7O15SioCfkfV8X9eHdRqKgCUHg/3RC37IrFHG9zRWcbhTk7BLUlUpZPvRs5gvIC+YZ94pHsN+20/sIiaf3FTzWTbP9FLXm3Y+HV/kUyqWkMpYFbHfGRx+bozFimoz9DVzB12aqq04APSeQW48sfLEaYFBtmGqQTujt4GskLaGJFe9W6ToZTFJOiaO568nfhSCQ/bVyialFcXukJRa0Pzh0JKh6h5L2H7nIsQmtE4ugFoJ5hoKdHDwvbK8+N58VYr7ihtfpY44LYynIG/8udzLj8QS33RZcwTUv5brUVYuzSgZJ5d3iyMyG0peGYk1dnBpWIub7ruTz43nxVivuLxbk+ztpMMpRXg64HGzAvGbzVzWoTyFhz/YD/FOKscyjnla5PkDZF5Vsf25jIMXigbHxH5T6cduVw03LcV+/0DVdyrJ9eCKRmpz8RjAayIf8IscvFpncnul0Bklc+6L1bfCWaZy2UbIQpqmkPQSr9Bps9eV877F4Z0wxl86x24uV8G1ZuFj4lcKquYxYV25lMCX4bLIKLHKQL+T/dAroVsflo0cogKCgUm45WiOVukJrSk3hSFBrB7C0zdrYfEwZyaaqYJETSjcNxMvK48uqX1rJbjOWErQnOYI3IcxIgc2zzTeNviCsyNmreqL37tmn8KNPAUjkfZ39L6gZe9lO5737SnI66xKOAnYLmQ8rd3EYYA3APyg9eP4PL5Q6oMQex58m1gHz6hVmxck3Myaywz/TPpAV+8F17PbWyYWH4JjvnZF+TQK2pbuFwzkATex2RGuYBb23/t5q7++kndMs1DZ5L8636KoD9uo3qT2atp/8m0qsXxSXIZYk8KI+x7hRsSuhxlZWSfC5zgc5/xIQxSUD/c0Qq32J5NqVOjyxFTJElsJlpo1uSDh7eyYkfyezTJA6pQv05/VW59Be2SvCzdpuiTAC7YQGrUKCxZcfk9RXhTru5vOuPlZKhFjU0dkAcT16O3z6ZUMs48sX6bNJ0P1ygC9xuo8jyQsB5HES9w//MsKFuBISjWjL04vPxoft5VfGH8IVOiA3fa5O3P3gb2cFzRg3BrMLmehY/oiMJYJofMCco+0paRIncjUpUTBZwbQ+hmPP8Z7FDnqNeWfupK3aR4rX6cE7UBTtLmHdrBLLZxtjXUmWkSJ3I1KVfgPG6zVWJL8Ih/sK+SPu9sGvLynvO8FT0KOdyJtka8esb54k9pk2j6+AC9fmU7tBjUzZj6FB04/4x6Gl+92sVdWN5d/Y1jaBN/sw1ylppMDSxDuVnIxznTeBKyy5PwQDN0m4Y3nPlbhp3qxErJVEwmcg0ZDowT86ezTUef2+2kuYApxExPi346UvdVOPVYFWkFuqOe9S173vM3AQtgegWW5/sxJ09eKsYwUGSlIt/Y+o0OWfKvODNsnLuLSXcK3spikEGcLjoFJUx56q9EthWQb3k1tT6pRHr8y7zSaXf9maxkTv4Xf2cTJihswzkaHBnBCQetv4/mEk+CYsPhMFhqy36EP3NLeg5lKG6wvIRvWH7oULgJUv6/iyMkP3GHMc3fhxeCPXleXdss4BI4lQigRL1F500dVGC6qWj0UhjXcDZXaQzAKmgKwxlK+3mfArvSHjeq9YTK0jBqMQF7vXrYtXZh5halrid9Bp0tyJLLK+gFQ05h5AF7aAEfo8Ryy4aiPyRgtp53Y43/2xGnFLyv279C9kVRMqoRyfsuRZT6z1SievyzRpNOtUOqwQDA41OKWaoU4W8dqt7Sv7rGLpJtXhhngsb65X2gITQH/tvD81wQB0J1wZ5SvShCfTA2VlaCD8WMywtHfaRQ0YxRnquUB3Ti7qpF1PNyds3vNnfvdoEYraEh4WO+owoKgtAig6jK501nCGu4hiz+ZccEIGQn5iRv8RelYgA7YKZG3FkmS4pQIvdz3FW7XRlcow8HknovC06WAmZw4+if4uefqycdr+ttd71DAC8YfoTB9/Q5F5hbsOs29Q94+YjtsKntDoCXvfUupvTrP9dWIJDQMiim+jZl7a5PBIPeyOw47JfDrhHW/5LcKMpb5MiiTBXbwzUbvuBe2dwyB8ET2pIlZ/FCGq6QgK2gAbUcg1xFPcyq+O8SPVQIocAT0lIxghk3ht9TO9r8/mfSCj05oLiNeCp9iUg8TjLfTY0SrgOxKr18mhWynvNrC/X25lumWyfPcVRCvz0uvbiPvw+daovmmcglLukcKCQOh9XUwj+BY8AQ5eggb/EgrXdojg8rIVwyC1sHeJ+ifcJQPKaVQjYQETloPC6m90BkuKohuMQkqfuEVWAm18HoYF56xgrl0/+kb7I6mSsukyvQwqMsQFoWPaNa0BoUT7da7KAiG8GYZyldld8pUc8JvNQbTY63j6aBQk2UtUNDJrlyTS4Rwtr7Myazhth6UB5JLpQAQtPkYnV407qLII3MMHNVeLZdrFLQBVnR1BQg/V2mFo85/tPpttPc+vmcD5AP5dUJmGSTuCF45bvQI52lXOuX+gK7uahurdJvGeF53tccLvdOCesd6JhFs36fO2+YbvN6gMER+2O9577ZFliUjzobI61TlwjKbZ2V5QcNDmUlMYWqMGsqltm02rOEQEn8IEKbBcv9wWSoO/Ctg6Z1k6PYuObm8OmldEyeXq6CYYypTz7g+eAn8yfP6fvt/gh9gUmyqeJY8VpJG8H9pslFXGZAEuR0kFcGxb+93wCR4BNfvAo+2Muq6TGn78el1izf6purvchQZUs1L6OFGCVjMhvKitjQAmd6HmgA6HCPXTXggqUdS9RfrRk4n5hmsni4glz3SDw7S3S8OT+D4OZnbX/Cd1yFG1SxAEBzLt3rSiWH1cWaqIqYs6uJB9WllWNH1AcJXAeoI9l4/mSMZ41fyElunRqnx4S4i6oj7eV2+VsNHvzt2TGbwadFq42cMjcD2j19UUICixBL1EtB3rJ/s6+0RSFNAHPOmuc3caYAeIXCPotdv8MrZ1nZxnFsMAdXZLSmTeQzXdNcrLJVUPnYRz9U8Wg09KHiKZMSvov7Dsak0QAfFQOxAE29eZADWAdmmHEU2Ki9r5cYaacHM69qLUCyrR1kAX2gSpX1UvMu0I3ml5JbxvTt9xwuBkCftKthWzbdXQTDGVKefcDDHxa2xqWIYCUXteKPT3xwz4fxQXEmMMR+foSvjCUnsx+LfRDkjy3ZwCwr6ovEjDbxxaIjEogt0BYJqWAeafOZmF2yRByh4iyQJMvkgtYvOBYpbBDvmuskxPjradc7I9p8K6EWsFTL0WSA8gz2oY+MTaTvLfwRJ15OH/8PYhKSti8GDnlnBqUYV8tl6Pw9NdQOEl3EZPwisv1XMJPMGtG2Wn/BL6OrnIR0UiSEwJGUCxM9dk2yRZPvXLC51Xrdw7wAbB9Wv0EbA+31psIteyipKa7FNG9j32lkV5mw9cFQFaTkrtM5Fq6jbthka8kI/G39SSr0PTnf8UbvRBRyZ1gUn4J7aqpGYvvDTI1wiK6qL1nAmtrUN48//HTqzNY/NsDr8ORTLpGOdt6xD+bzWmxCMwiDEufsJ4dCQ5yWN+mfI2zOKf+iJWlpwjnDhXkXOZ4IvEyrHiDfKX7EhzNtz95vndY8cx8vgcHlZSxpDsoxU40oKDrT9hsxVxcGW40gKLxufg2AzGNY/NlNdXUWFCCP6JdUkAvuLlE3sn4jqzLdVVxbZwqnXhC8g+LPUP9F6UO3r9PTe7dl2BHt6Mj1KGAC80pDyzmHHyscGdPUBTi98m6GWTisKC7EnLAtgNYJeMpaYPyZuFkI3U+I4Mj/9WNrOK0xXm9HDD1DHs9rvun6Gg5j46PomKJ7x3vFjfKZvdxBg0w5gUVsvol++iMbF/Ykw7nZxIVcSd5o+0kWW9az5gFua0J3uP0nWksAkHO4dDJ2oBP08qOJiw8W2sk37Ab1DkfBCIBdIzDitC7cM9Vf+x5wn+1OHtD2/sQFaTjM+JGDWs5bcs1eGYz85msY5HZnTHRIZcqbmPEmbVHAlo8mNRw1VR8S7kUXOWX20u9GeqJgqP2kjNjX/f3Dx1nuAwlVjqmE2c/bJ2hWD8VDxvPpEgW6T/yNz8U3xbI67npOnPfzV1ViwusF3XxmJtttUnHjfP4satNi4Gc7UW3LQs93X3OxromQH7+i6kLF8Dqcw8tDpH9U0bpnWKJWn/3sx3286916Pz+4r06df+szUOxPsdtti6EN9xq/VkJH2tpcPh33/HiSMnuFCsC2/z8SuFoSG6gi2rKShTwzFgEyyYlfRcbGTfvzeuxKevcBh1JbJFmMooBMKy65w4SjUHrmVdZl/geR2TBzst2H9/KCkyilgFnFRtS43EURsfd1hCodm96Gn64b8Y59k6Rn4B0UTDzWVY4aiNkfO18vdJBZvtTEppR4omQfCO789khz9kt1INx3K62sLIdxCsYjV+p5fTzrf8KCh1fi+rlhKvpsNf945GN+YhsGmpVbZ55SYEmNeBnIM0epPImyCl1k+3uJIezSHYUicaKHo4fGlTz0ZHkm17aeEYil/4zc271VSe227qop9pqFdMaFQDfbjjTUJNFaazP7Kt4z6nA/pusbnHWIqYDlJ9gRLENmPvBxrglEgvED4s2ilIWhQNl9cT2PotRvLBK/k1XEoIcEjLrgrDtTAmyhyw8qEgjZ39Ly+x6hkbLjJgxAzec8NX+mUXHpI/5dCD8gPSY5/MiKBPFUQqHJ842nJNN+yfStlzZOsulQhd+woNRZM7pBloPVG80N4pabA97LuAxpaKGASfk7jbXZD2H3XnEq9WdKfqXMpaO42ymJuiZGID3iq1D5sYTbTUXxYW9HbdTDUSwqJJSG68kDhFIy8H5lcuBZQ+pwUEE6bYDIDo2+hlh3A5Q6z8Aky7Izi1gPT69aofiGIKStsznmNdQDLs7XzRg4yrEAiaMzVU8Li1j8dYE1mrCiPtg0pcMDP6Ub2uDjEegvJMrb04SyuVEK8HxxYvEgkxPicADWEoqEiWEvVneZGJdQiPOWEfCGSqFvoADESnESxMoZ8Z9cvHB339hWhlShm8rccXsapqe2qaLHS3oslMumgfU1zQ1MHHcudG2HfjVyAVmkkAK1vbMzcvvDyOoUdk7yG81EysCP8UmR0IWD2tomovzNPd9wZgEMKgIuxXxYNSSWWCWQUOqz4xNGKI4NtiRLjSHTs2mkPyp+1azRJSKsLyYMbPs8wlo8kpQhYUCGmjPBc+4JAOUsJRILmxmLhMwMThDf8q7LEon7tNHcZjDMof4NVllmZMEiNZtlers+ec5DOEEw01x2ztnUOv1TYiTJlfOwaDmCgE/pa+8nKV3Qvecyd2apAwZPTp7pxTRpXX+v5nYe18PulguBRz2oyqH+peZ/0nBjTJgdcd41MfY6LX3uWAdvUN6XqKtzTxeXKK/4keKkGF8LrifdOTg6nMik+LJ3/GE6oVKNtz3018eWIo30ePAwVDjf7o4dEG+DZLXzx4snb/u4PIuYBJ4U/RUKeAdAld4LstjX5OuzMT4oaoon/1gvGfKFmYjGJJ4T7rJUJDCY+hCnlubT33pfU3tANkr/3uQsPnkXWtEPTsSBhdICRxT4oPgNpD5EgLV7e0wpXI9+4TL8BfgvjMFRx9ED9gNU/hfqGyn7Wjwr/u+C6M3YGPsMTGLmXVEnvIK9tmKPV5BvccjdJ/kxW5BfFb3U/cmoygDGceOSm/nrN/TPhYOrT1P1fw0xDXAVCajNDKhY2Ag/Xilv3cWZnshYT5O62Yp/S+hSrB/LH59WyMOaqNgsajyBI8JqCGUSDi28yf5w5jUZX+b4Zp2oc4LLA4P8Yauei3JYPM7cN4QTLrPDZYML+8I3iGcxxAsynQnux3Fbz8BjL6dxRvyE0IIHT/RT9Kwxrxa5AVVEHegfc15uMSGBA8r+BmUngXlhqzRUJ8iST5g9xQzupTPxXM+w9aeywfbl3ou5RfrDsJ/qRciki/s8/TO7qAlhdcrNhhRk3qoQHuWwZ91jjo3W8Rni43Id1Hb35GCJIgg0B1XbwkxG4jIQxofsgtC8FoEGm0m7nF+Q48mjheEcTIsAuC9kH0NfcMefAdh4UUsWQmwMQJvZAzGquirChmHDXncV0VIBYQt5LlR0CfmzuXBKiH0Jg0o1Mjp9SRC2xTqo5bS9H+I1d3got7vG3mQr65znZSxeJXVLd2a/S0gADglO0SbB28e/nEMe1MyK42fwNq9t9ulyVewypGpavQ4hii9Cxu+9AV3ctliG7YjB6o93rEd0sFiCYT0Y6I01ivEVMU4Dt6vuI2tODoYL6wihd3Pm/gH//p6t5v3jU2DbgDKZNbI5bCXap5GkhmrDBHqRck0iTj6rFj/zWy4i+V/HZdX+RHRhx8nYaB0xfgBvKwaP4J0XgmoMy6GjglDtfbZyWfbHV5GKhCmICpXl6AccIkNhf0UXxEG75kvjgVDM4SI75FUiDGajg67GiqdGOJyntu/zn2AU/RTdk4yNFrYpUVLmKCMhso6vgX3hcJC657kUpZIMaQ65bQIrvsy/eg70tHfgpfKMz8eyUmFkM2H1QiOzzz7thqNkkHMO95IvCM7L/UtW8EgPluKFKXvm1vJQ63GXKjoFAqv24JOK2H+UC5mwm7ARlZu0duWIWr/zSumY6TGf3XIH5yHyDVFOVJNNvSmty0JPksL3Ja6GS7x+WMggqO+mPA8yJGc8oixP3YW2oHB4DLJsyJ75ViEdr75veI7S18xARu3XN+pODQ4sqxNoS/nh9GEXmVH1j6f+gyD4OesGCEoMji0a3D4DAHlrDw2BwXRSD4vkAH3ver5zZDHq0rxP8mZLKEHrWOyWul+Cw1AuSjLWK4Y8N2QC+phDTXYU5pSK2wy9mZVbdwHWyDtlSZXJRUMz4V2YQlD7y3bU77Uz1uyDlpZEOrny30os5HwubzNNUKajFqkSrNMup2ykhiydnQNNkgTeJBuzWcxWSR0+GBsvqX+YIms839XuZUREdG4G0507uDVxSwefwYHbFiNHW3pWv487U6KSA6RxFY47uAPIUWDyiSWm3qOyUOrzB3vaU8U66uumbDIi5Pp4qdW7JAwfqgInFlfA9Ub+4HsukXzWgB8NDEUNuda/Y9cXRSlFuto1yinQl2pmhR71wGdwSuUg6BrnI9lZGr6dPhZ3tY5NBcB5fnosYVK4RxLz5LAxVVka+FkdToIIc9InxttBc7Z70ycPfuw18rlfL28Sr1Du3OCPpw32fBCmdQ3+4JhdWux9PpXcyBeaJcaNV54ICF0ms6wyy8UzYHJGRL9/zwgdxc0ihaD0HWULo6ekOH6C38GT77V3SCalrDl9F4GVcjzYIansYQcwu6bVHrnchF714ed7xsIHbjbXrr/s8CyZacbFnUwKy9uyVWOsJqt2Tm8xmSDJbCU8DQEhdKFNfydX+KD3fdub0Pwrk0cySBdvTerpgLMCnJlCCJm43Obevp+Mw3zD1DpFw7tnBXh3sbmqzQwi2umb0MgGOfEd0kGJJrcw2SXRu9H1Psq8p2PAOA5izGL2RTITL/LjftZlp/CDD+FLWObbClvkz8ncLvMV+bmu+0BKcOZGIclHyYUDPPseU9DR4tzlWykInUTY7Z2o9e0bA6+1YsckkfBdduNlNjsS7WLFA8vit0nfQsMu39O9rVS7MX3zMnxU7FVunNW0dQgdEQ466s6NAdrfcQexJT1KGV3X7EOcSq/JB6DgX3UvzfHq83GgLjPRUP7TTMccm4XzZYVqCPeZCV1/bOG3ddhdBDU75AduWfvyEEd+R/WsEoZNL+bZW2/gXImNQMIhdUUhnK9XywYxf7NtFL8YJGSfdLEy6sZIJi9Bf7m0JdBOKWJRvRd4yUgPQTqONR6HT4rIOtdDWh5vbxErDrpohA3zxfuaaBDSBQlZmabxQS4BJpcfUedTkVW6PDdVTTdDCWOACpFeRjM+b3oiuu/oNI+XrImPlEsWgDPl6AryHBhNZcm8qQxu0TOPzaSuXbiVOFchYFCagJm8rGq/FPc+adwxl0kwy9mz5iZ5JZKTyka7/GJaRpNsd+lDKYCV2wKmh5HCXhPCmGwhcerIUiXzjOROhkbPvre3zRDX7pSf56uzjcv8YPF06L30eQYkUHIB1g3+b/kJ/23UklTYn5e3b0Fp1kGGHoTok3NxzHJjcJIUOOp1kGk51Srqb8W27ODkNiz1nXvJLAtQWyF2+hkNrSnuxFC6GH8/ebuR7RB6vAQCost3sqaauJ1ljYbUU35e37pIeWIR2gTQAygMWC53CGFqnceEqYqTjzP15+rKJGegiXwgP9kDcmoyGRNmdirT94pw8CBEZHyPF7dvQWnWQYYkT6qL/8YKh5DfcD8CTy4P5XcM0eAHnThhSFBbHLLG3o6tPnP9O29d3R6yTLBDsmWLU8stdTaQ7C3hUbhDTyl9urtAu0bW/nnAqONQsqcA7O/9HJUCYmJQtxEOuHAneZYaFz7J7oAyIXBETSSbfmVPR5dAFurE/Rm0NN2kzMetQpQVZAZfdbOfjriINbs6XQnW+ANhDhOUx0p5B8TlULT+9W8SEPydiUzmuKvWPsqGTVBO1AQH35SGA+s+Z2M9zuPSN5gxqbrt5OCOYxgtiT97NYBccUG7yMP4WR33QPA9i5sXGaSjwQgjBJFDgxHjjK6PatTf7s6xdKo4O9R+weXhWyG4AhPl418sWABOVIgIIC/rX+iqXVroWwteElxRsTrBcdcIAeucd+3Lr615z4n3QD7ToORCpwdvs9sYGyJ0fT5l/VOkQnpU98tOxJtga1ieHdVaeHvBjBMkelx2KD/0fuhe95OAf01cZHgDJ8euTZRicA+Hf9d9QeIpqhUIQuk2w9kNohON8qVOk9U3/l9Kon7f+L7oUE/lNCaiAXYbJgDwxFjMuOqmEVcj/DT6x/ME2ZQFxfpq5vWEKvP9LI0q75R4nGvRxoJcw51ZJQ4lFvbT4BKd9bTOfN76wERn2wW8Sm/r5/0xAP0Gh5Z5nFRq9XGIML+YvITSBnt925jcd1v97vJa+TU/OGgYWlTlIR/5XRYjNyhiTyog1EMEpv57zvKvPVv+ZV6YqtdNgvh1mg1Pg/ClSrFkq+jgxB/4y7Mx3pHG9kcshYOK36O5d3AZ5yifleUJkiHqciztR4i/QiZ0FtnEI1f8lotAoj6WHkN+hveCoFUyolRRKW047rb9yllivk6vOVWA7hNqu28/9+jVGqHgzr/BkH6dChWszb7e82eyx4qCaNmgq+xV1xMv6zEKL72+0Gix5wcwEaXbSSfgtD41gCYH2NdZu5HtD5/RmiP6N3tR4JC/ziLy7Zwzerc/7F6+cGO6/PUKWhYTcQr09qdBrXwdB3jmmAdHvoJli6fumfMdeW9wjNP5Cl/gz3/FJ33PdnCgixSDBKj2Jy3V7fgrEiz8N/lEltuJDEktnUiHni4YPyMifefSI4YYXum543YKYaTY5+CycX93M0ldjo/TXznKpkch0hRcrp1uJQFLpeLE5ETDHaPwFDR9kxQ2YZyldld8pUdJoNeszq0nC6Bk5fGMTZ9OJ/FfD41W6XDioZ9ndHbpj/jOef772tYV+F1x6dYUxbag2BrfCMH5SUr0PDrhdlPGxt5EgyJkoZRMop0gvgyrc9ZRTX+csx8bnevtmUARvUAra5+ARcs5F9CYpOf53CaWCs43TbrDL9FD7BFSWE+vK8zzlmcB/SViKNY50A1ys0HEUF4WVXiIPuGAIJMMkgHMMIh7fBnOFsrbGfBrBO/p12cjic7GJQOZlzbIQfdmAh649/CZ0cldAjqwFvmj5Be5BkCJfQNaImiHCzckFXHRg59+bc6sBwdwBJSQdRpvekFCo0pnq90M50MgVneh2wX6PTxP4aggR++s6kPK+ECM3NX/o2df3D+Z5+ucEPfe1bicX0cokzz3B16/Cue3wFIenfwVGLqZiOYGSTIY2yOdCk8MmzttfyhTPHy/iR6uBPDX8mqa4f5ZQN0e2gH7reB5JV61EHMQ5jIVOCRVk23dPsNG20G4yvEgw5uIRa6D19C7+ob6PGa2I/pbGggdKa9imUnRE7MFQn34p78ya6yqkwwtwMbbQbjR4gzt7A5fMTbwFPlvnuusctmQ2m+SMCcUNQZQCxHyT+3asqbbvJxLxxtYKZ9dlY8LgWhE5zf52GyTGpAV8Z+7vkY0VrYRguhmHUFlUyp+yzhwJNbJFLIOCwdO/govvkn5tTrumDqlB24tODKJcnjVMJy4PX8U66+nwsSfkee7NT4x9fsOdPlrbvziwJYjSDIzR9NhQ+6Y6ViJRBX2ciV2c0UiiBkJflj68SJwQsl4uCylRJgUzr1vnU0qglGzXrwr0DJsk5XGOb4SlyxwznkEi4J4qqfO8EiWsCkZ78sVIPrI5I3WbeXnf8mcCjBiodLno9kqCHZjfvI5NUr6ZE/2dYzK3iWBHpJTBhGkvh333s4g0lpNrLGDO4r1y7y13UywuDvkjiFb0KvPPdfdlbNu0274ddpImBY/BI9ESCr0PldwdNOJl5YwuWi9zvs8OL4VIm0yBKJeHjIeK0q/rK+LM4EXVVV6tH9TKr/z/xqZA6Zbu/BRmNreLRlun10pO28T3UXo/24jyi0qG3eBZog5QE3WOuRANzFaJseY7bR49tRNAJmBefoJi25dHht+CCNqcFB/LRSg/+xPYKM53rU4xumiSZsQIJgh7t4tSF/DBhREaiaI96E2Q18zbYgi1lepMFkCTSr3NwsWW5r79yDcd6Wt/Lqt5IvYkReGlehbtewHnpB5KbHcxXd8tXG86hA1i1VhcwjlrPpnUX9SDwEvY1tc751vo1nT+cHUhkZqsD2yWiRH8RvyN09q0Ot5rOmXRJcR/xL2x4MdMxPY1JyZug1HlRqahCXqG+hlAEuS85eoIlzojSiYiJafDuhaiTGHvkl3zLxrjB1j64hm5p49EdsXZi95QHaGr1buH1u5uuAs51jEhpPftuF9AZIyJov0nkUzCBdfQMF2Dz1O68DGCc5+Kq6dTL8x6/AYum8inhF6v+9+5oTNIyO02bHJEOrDvjs+fQFHgl4HQYvi1QWkiN8uKego1TRYK/1PynvtL2GySrKfKPnqlIpeq02L/FrP4gRgSGgFVrdeKsYI12KHxFXXl5QkBBD+ibRJXJZP9AZuoDxj/dakxRhtoGC615pcj3+xMYoa7pSXRFBq1IAjGoJwAdoRiaxq0eSOImFt+cFiiJqAkHUbdQvAIBNWqR6LxT41T3Ue5rozfTR82O4LaYlUl8xnk/YqEbHuddTIy8NPKXPa2oKL6MRzY1R4hrLYLCHmZ8xZAWiZ4oVDazv0A6esXqThn2zt6CZ29hNEGsoL6On8eigbaIqJ32xL+EAUvII24LzAsYeaONOo72Z9iMgQmqzIP86y9t+oEATZjqtG1HCcqGHCRNBAZWvjxMgy8zC1rEQqEceXk603VBrrL0pS8uWp90HR6iwJho0/ss9qbH2ELreN6O4weeMNIof+0wUBjJi/r+3elEctWSkMYN78iC7d+kDlzuSAlqGybJO11v58WLEBAvShCf0ch0HhN1qOMLMhOJ7Xhff3MbkcUOKYwZtL2hZlFQOSJbuLNyfC7U3Qbh7pOzcSrCGOSf5GHaMDFNsMJnBl1gTVSnSl4xuEijnFkW9KBLXWKKzeaoJ08qFmE84kUzGilm9ZH1yc9DUu/JG0JLMFutc183PTmE+/K8quE3S19Y0EbnJFXuIgsWkaK9ZPofwWWT/ucrruQBYwl3bmbs3urYTrAxYAVPb7Q2alWwZ5Dz3JeFj+ztUsGSjBLCltquf0ov7GdtFObharrB5DFsSQsEX+B931wGQNGtxIM9hUBqbAntee38ZJ0idmYzJXJ4xACbXUMFk13GSi+jyzHw68ZzjSkFyV/9mUIozd4vSeDMFZil5RWG/H9YX9gkMInZmMyVzCykc+2XUByFWH+m82uJnmTHw8Q3JwTjXVlVsQkPimWI6u0BD5ZF1+sNi66C5Uza+1c2gcoLpBMs8KwFV4GoWSddoj51Gz6GoiKOXWTHRE3eh+rPdKBZgm9DeVt5R3U3M6r2M+4Z8TzfV5Ygf0sKFlUM7ilCk1s18k+YIZnNopT8AmRN5ouL4XdEaThht25rEg2DT1XglYRMh118w/MLreEzlxJaF9rgZ/VQOMNa1TiafrC7aY6IPGLG6wj/epPPI98HvHQyr0s3jKobu4sJ2tl77YhwaiZQZ2dTPIvZyicyN2nGsBxlQrx6kRsbdNBr5uNISga0efwHdhrFFgq1C6cLJLKAwsZGO4wUj9cMXNvTGCNgMBWgFX4U+Y9MuQz5YaM7M4VcMhs6CdpbUnXx5H8x44Edx10fs7glbb6DjueEL+0fy5PuP23GPHV4EQuQ4E1o1+oMf8Bh1fX9sOxZUK3rP3OaYJYRRriaibmX95lFGufPzG42n+9LAHPMDSpqXtWYBA98bwrAjSBtNo13MqY/AQJnHM3fR8All1q9bmtcpZCaxrML27gKSY0i5aHgP70Qtp+siVIRm1QClbj12nhMT8nIRmjrppRL2IHVKRT6tPGkJrRLWjp9ZgCWZIpbjf2+bQ35iR7WpLCs3hpxcwCB7yDR41GBX0Omcahr1QfPAQkEgWzRnuBkdNA20DBdaKtaJBEncyw/6bIKAil8HL/hSqfYJmaURd0APofafg+aYpN7SLXNjtds65EFaY+tsYWpYGme1nDbSnOwuRagV28XajWiKxxPVOJxwoHzuPm7oCoppfEaSQkW4QPOWtPiMYtTVGDyUi10Jr+rhQqLWwpl0kbNBpA5waWQDFZpo6ETPVIC9McmRfb18RpJBNEsMtFA0QeY0y8pEhZRuasrgUPRuVGCRtt2Cv+f+NT/PrUx7egmoj+OVe2sh9uGJEFHUvk41QXdL03hJdHI/12+oNKPm8okWN1IAu7pYUOx7bXKBCRbFVN6GNjoyRaBnE4pY0E14C6B7/9s/4caQ9bOvag8ZUAYZY0TADruSckAtmlDkoiexFhuinNph2mnEpmm2BZ8erWvGHFP5x8FtW8LJUzNPkogY05zo0RabVayc8Wk/XfUDYtZ2l8vH2I4zILZnXtNkP3KH8zteXZREWfo3Nba9vKfJdJSdBaZxEoovPhsFdPnuMpx2iqxDBDBuuBsd+DWAYpQI8CHCCxuSw4V22LF4VLBkowSwpbbLWoKex5zcNY5WlU+wTM0onPYglleIFdsz4x87sEKe4UynsV2po0vTuw0SxKvJPXLkZQsAdMvBmYDr+3C/dJFT0h3fsaS9WkWQzzwYxvG/g6tbyaLJh4+HOsxJZZhfmJ2CWTB6TFDJfLZ8Im7zXRP2rhcKsYyMDOxqoTIb/ngWFZNAl7v6k6w0rQeKGy85MQC5yW4bU6E0y4DpaqB4Fa8OrehwJsWaBi8ZRSAf5Xx2sVsTzP4P3KX0BOHdSpYXMYk+fPrgjRLvy9HbO/iG+Sgd58ZApocg/SKrMcl443eNfAH+kCAow2DHU3Mo/ZxnZlzv7diqMzkUkz2q8JIXVYY796E1X9vkbHvprdsPKzeVYJUaMkiXAOJFKlQXrCIBfnxKXh89/vGEH1Pp/CpuCd8kSzww+hyo1lQZyQWXOWxh+0yDOx062M7y921uxlkKmdl5UuOLQNw2jgt0ZziOGpP+V3EEk/CclnomP3HNIBL+FZJI7wpd0C6HipG5EpbX5UXgmxlux3a3wk2FQfLat0Im4QNNH27wz8472k4qF5hI3+zG746bmy1kQgOC5cUuSTC1kVeBYNZY00DFH95CIOkMLFes1fgFuk/lada1iyIEZGc3WoKYa5Gm93n3cYQ4dKZ0HUhThEHdTfZ20vhvGVKzHYDlIU8Fd1EwPhVdSnHbq3B2U6oR4sGBN0G7v2rnm45oPOrJ2LgPLk0R2w/ZKSGxRRga2TgAAf3qFlmorleTJcPdm6b754Xc9EW3KBoZFj5pl+e4it+gpa0M057deViLSVj5ByE6saVbgYaD4GaXp8OxNQikrDfiucHfnbOtorDD67W7xUXnJRh09G/m6WD6VKjNNmIKrLFcSvc1pBRxa+QQOSLUvM6MKeTMzMAAfgWnzjtGpU3ghnJR+LClgVL4SRKi+yyq0Zu5ar+bAJMEVcJ8Jm6ksDFS2XfaMfQAO/24qrMtV04EUGb37eK15Q9Q0GV1wHxGnxW50GTD/kC5UdFHlrTkX/+Cmpq34Y0GaRrAHRss/02SOAwW3eEIr5vNQ0uR096gDomecliNupi3pAho8yTvt5KdixAAfZ9otO8KnsN0w3pRd3f9WLyyyqHLtamSowy1YM5EVdGPH21KVpf4RgsNCLur+zvNEKLlCYyFPywCECZcUoEr/mZKvASA2Cqvvc1e2ALNyYefP+G00WBndFkzoEJN4oEDnBKdXe9qXvdEUAv25rLR+AZJiPGUQPPp3ahSDSLA6o47Hjq6r8GxADVcmvPO1c1C1Rp5rgM7BSGKHVDkb6Pwp6lvIDCcQ7RsK3L2yyvgLWZvllpVR40pY3Y8GVztHGK0Zu80ODVbDigNlikr0+ZBRGDRfwF2iTr96wKfDFbYACpg8TXCli/+RCSu1O/NKJiOqVZJLdUM32zFgvLkoyO9WldNxTppK9ruWpilophpk+uoF14g3xouH5i4GqJZoByp5VLHKJyQO/kpSSNRnCECHvHNdeAk/PsDEtJmzof3atza965jKxsB+ueIv81+gpa0M057deWjqmGY9YleWkdrFGnhe/DFcLpdzpaP9cXmcJtRAJQtl6E9IienfBB6CiuswOWfm6sO1iHHYdbsyYrsIvAANw2ch+tpVLb152PXZ+Y6CUn89UbsTUIpKw34rbtJYiceFf5u//UKqL7Tk1HqsXyhaxE9edqgBZSVhs341swtjJfN0WsgfakVKkDw3CX9V2lNNs9rmRGzeGQ42eHc/om89pDY6Uihzz46M8iWTX1S6Qx88x2fPBzCanCFiAy2Q9pRLVoO0vBtNnIknwqLpVpSMRjkF9m1Ei+InmAZsWYQeNXh28+9LcXQeBb5BWIRN8KlCHj4J7UaXmUUXz4AMus9az23geKop94oeszNGdMdRp07ombPemP45Rn0wzD75PRuX8bzNN/hk6YR5YluIccDUjYrfMyIaGzIvqpeKS0FQhLeKa+fkHmuJsff0l4lyVrqDUgLqnaA91IwZBq8B1YRgXVXwNWrwqKKTQxLNkRc1mtedigMGYOMI8ZmbOlEi7l7xepxFDpQGmu8ziZ7JM0aXoaGGhfeB1CzTrMjdUv31Um84hsyuoSI9Mr8QfVPorIe0I0PfbFPdCVfzM8vQC7JrBbzOHumBmGdZOYbg0GNsletq1h/uwZ60p+L+qje80G4kHEbV0gLIXNVVyjHYMCfIM7QQIoZZuQ1J2fFLZudPhd5VrSeyzx9LJwsZc6fvw5v5U3s09TqdWR8Ym1l86kCOrNXyieD/F+Sx9DMPGaHYJzpwz/l9TCkn++GHWS7xJdvBY8myKpIqkDOh4UH38A8VzuEtwChWq8FdQ7QL1JVIsEEnjJAgxc1oRRQpXXi12YHENY0pdO+9ht/0FW+rruNpVBG6OJAZr2DIVA3/CSTGrQFaf+aZU6R7+vcyiJ/x0GgNI92PDiAabpu47MqRIbuIH2mjKpMf+iY7fwIeWhgq4hchcczD082fMLRrc+Y/8WxB8Y4Rb4FOxOvoNxIOH//2ulmof3Xnjc/vI7KvzFUXnj+5GC9cfwmjkiyoTRSmVgyel0utzA3+tc+nZWrwX7HwsjwKYblIBAAXY4hFw4r9SOoqSO14gl33/gJmsMpPEAAA69a98oCDANK79qnxQuWIPQYv9PoMeDgkNjUUou955mLTN5GoqnQWjJLD7naxHIuYK7fcRWpSvyLsMjP27qKLLDon5PGbFucaunLh1P9GmcwaFR4RZxOeuUaxmwclaoVmXOFi95Lkm9LcEbxN5Y+6mAHuPcA1YU/eiC+zaiRe/CkS+ebm4IpEP3cnoH4j3mPiffge88hcgwVe5GXyYi1plRvZ6cDpmMPcmQeLmibD5PcQpC8YXW9n7QtzLj1x7rW1hsDLGkkkddhVMvRtN87u5bwra9QlfdJE+aYBOOQyDIkgjOURcOr9JyPK7gsgG90Z44KegwZYJVHPkWJB9m1iMxFZVyhZZj1py2UlnkJCEF/XeFp9O9RG6UCO03HLhKujREqf0GhRMxnxImCT1abvPIn5M6Bzk3Ip7XW8NKhEBmcjyu4LICiPZxTAuXyKn1g0BQ/7ATkq/EFHxH/kQ7B2Hn4DbwK5l+8FXdQqitkfvJ6d8orbXZlAxfCV3pP3SlCm06ZaBDCOLo+fc+WcrmjFEDIjK02e2AcRw5y0dGa+PW7KopC2IUDCAccuaHS1wCToHDtLsXCIcvMNpWVg5v8c+tXXtz6iqS3uwFo0Itp6cGutn0SX0+fV2qf4/iGaReBnGuWQskRj2u9r0RpTTNepokq+F4MrXv+x82gftAoOejPnYoBSLxihWdt5xNXioz3Leul8MT3CrCZr4KNhcFM3e2iRnffr74Jjf/qLTzzYYi5EMHYef5zQ3FA5n0h1nuiYzOuw1mqnWCYmUequxYncYK9o54CkIOuqYZvLexwGYFSbI8CR7wREMu5T+o8NUj22BOhUSNVvwyve8NobRKWKA3QK6dOlyHCfjqDjl496feTf44VVEhQAz3eGtf7IBlBg5bREDivoav4xwQMKMmSqYv5nQdhn3mARE28pCMWP1cpECTVocQUXSVrqDRgWdsdEQzL+wBsQOWX1SjePRtmNsMe7eiUm/JqzHym3mHaBjZQh9Ft4cZBelZ3RVdATfayl47oGKUClXT7DpqztL0P4yi42rqv/OOIr3sTjWG7I2gdiY3beXSmX5GtsCsPJzBRxpGkcahMhjHgu7LDDdd83AAoZbYOGg6GVtA6UlR4L+P6yWZRgPN+iRY2j1+Cn4rATZd7+i3ZMSL2r318618kv4Xt8G/TcB8wLsrDGLvjdD/nzcL1mXSZuCoA5faIa8pP9MiPBFWsFpj1emVJ3sGk5mj2jDaOMaTMlf7UHnGKKhjPTmt5qY4h7vDoVTO9OZ7cRKo6yC9PJR9wBw/mYKgZjtaAwVUGrd4LV2mUlskhbBW4837K3hErxdYxapvNv9MtG22esCr/z3CIqr5m3U+ZEvNXreC8/kDTNkCRQ7D3fuhSHpCAEjrj768JRBA3grY9QWd15BJcBzuaZNhpMOBjj/NrIrqyKzsMDu1VFQ93ToGi/7N01pKDCoJ9wfggD7sRK8SLWqWCqC8krTI1om+onxP/NIMW/Rwqm/j7xwMjaZ/DjJXJjjBmYC38Ub3NjMYbssRDsXSlWWCJ2IBF8c0E++qiOiJrYbXoRj4UxjrN2DDZR9E7Enu4lMS7WEv9amxopgFeZCzsyZUOSR+LLeLl2YlJr2+e+yrRJpvofSzafCII8tn6MHJfoWxdan2AU46xwjk+DbxRr+qD4PAmvD/WZ9t0WtKqV2hXO2UUzcuD0DKT6KvKSwVLYR4tYyGEESL9f9b0pN7hp6eiXawuztRMDHHit7yQe9eSmDeDIGX0DRf9m6sHVhTglXrFL+G7oD2GXsyurYat1NrpUUsQTbpFYVaNPiT82mlFu8RLa3FwBDMdmLQpxgXkBGEFcHJVjJPgaIq4sQccPEl9ecGY5/DFtyvhed3mL3Yudgh1mS9cvbpfTV03VEPQe4f6Fm6S1ZyrjefqsTbW/ItPyDjFLkbPxHkGbWFNlxwRAkQzOxZYbkIwyCv+k7HUXHgBiH4gi+lujcbrZyrCVJGJqENbHixUqWkFzV/pnDiZNN5e6dpY7Wz4nbHaA/3WyYW7bRNDHbov5di4B+tPUShzujgrWbYMuvOpihbIHZMDiJulX89y5FK+vsWHZfkuY9jfRlnKQ6oGIeFMgIyTpYfwlwM5jZ3ftp+YF7S9fQi9b4dAxBtlx2Q4iMQrWdfB92ilDKK6j074wNUVddlxKBIF9o5PVGjicpnb13seVvEQ0fqBYAnacRpJQS3wKhj63W5K8QLIo+0I0de1Z1KRCghxo8UJaazvmNsLajNGFw2r5Qn+8/47Hdm6aH1Oa2idsKxFd8sO8rK5ohQljUjfZQojuJ6zLxkQAXLtn0GvsZauzDUmOgTVjcQq0cDHzXQ3M8ZlL3uG9FWnI5FRbHvOSh2gWhCR5PXPGEWJ0/MeZMnHBqsSQzFk0VQ28p5eH92w+oAxdGLKXPy8bsEQOXf6MBKjidAlfMJDFbX35Fc4UIN/Y4T5RIlyqE5Od/w5aoPJmG/A6jgdRDZgMEEl/nHQgSxhWvtKu8zlEMAg85q8OCRJY5VqEaUrM8OajUyOJ278YVlZqQWlZI0cIYIAXl1Mcme1KlYnwP8IkMsGykONSnS3/eLYKuiFmf3SICQJPsHfnmA0Ta+zPC/czDpev9PnG+FqITv3ZTVA7Ik8nZeiCuCgDOx/v+2KGz5QkS3lauSv89w6LUuxZmh0Lo9wO4IuHZTFlb7MsAn0023E8EeBGzoZ1WK1IwfJQayhPjJo50wO4XdVf5eNhfYgboOx0L9SH10UY1VG2UeozN6lxZzHp1jj54aKv1XlmwyVPQ4nglLnAyNo2qNdBAE7n0tdub8abbcq+bkSKODWNRtqkpIQlu7R1TL9+50wLD/Cy8LHXPCcPV6I2GwK0aV2sI+U0oP2PsRiYtN2s9mRlAwJ4slme2UTn35T72LsN7FaDtn/zFHTuZzS2ZtTJvRgHL97qA5CrD/YpunBzMIp6ZvQ8iNtvsEaskV2a6G5qwHvTJcYFRdFc6imoDEETmaIHoB59BI31rzRId8arz2Pu4gop8+v35Ha/Ra/bsI+JjMOuDUReAtaNpk4aiIIXwES+dHb1fWdcal9/Sxhn7sk5KG+HA+ejJI0ppTkpYJlpO8L9b8jwbyZKU58UsrJtC+ciiMOeacwMDoIn5eUzaA9xkHZZKn1TGkxgKHq5Z5pPZ7XL9S6B2gCU/6+hAbNnqYlqNBzV5uRjdUt52tEyxjQUOPloh35ZSXTJGG9Qj8cmqm6laJmIQBK7fHn3yFvipG7yFKLPvOTUzslIK+eek8lu+RYRwWDCt8036G7OcC3HpsDPmL2z3a/atFLWB+23u98DklQK7nIStSm7NwRtSToRIB6ahgjEcAafHMNL2oYaymNuukqwTUW5X2VXlnpUrAavx6OTeRChPw65HE+rbYVU1X9CeLzWuAWgV76yg9femP0LmcQSIl1YetW8xc+/Kj4C+UgvtEybi66Fivxh7auGhQM75bo6txL+DbNpu4lWEMcpGXbjPslIcfcboETBY7BRhjta9KI6a3s+hzcATS3INbuv8RJAqTRq1foc74UVdlMICtEge3rFIqniDZbvKfe3fNqpdb2a9hb6oRFLCZLAPh3QtRJjD3yGh/TjgcP5DDPew2D5ySivE3H4mByZ+hauKVRQSJ5RSGPPVUKrxcJDY9j6oIbUiDRryvM6BIO4ufaqm/CafoGsmZrDL/HB2UHQ0/id9ycS7NsRZjauB1oVZL5Ozf0vRyAMcskjyUtoLEiGq/rDjLuHD5cHrPFSKEFc9xtbxaMt5VUdg6ewCMs2F2kZ9au46bqXZXE2smMsjDJuGK262j68tlK6Wf/OwePxYwz8VI0KLcuq4PZGjCuNIdb+x9NNpt7EHMHK+bme26qoYEgoaCPtNt66nQYHheU+LJNwOgsMtm5Lvc9SZjdLJVyuE3ktUNJYZv4oKcDh4flejl3cfTjmAXQMhgAMFAlOgyXgfDRf5zLxlkT2IQKI4ilxz8qQGLAPkx4hvLBAXSevt1SAl/hFiUAIWaCzLFoialzS6L2Dh5BdVY7pmXX7kYtq/VWKhSEUkxeez2zUhsni5WFaJ6r19DYo9j/CZsJDGoxl/jg8KRMmOH/clWWp7oE/J96mR/rF7MVoB0aPXLzTODtMVQt2Jntfqzj5HofV4T41I4gzR2y+nSdy3n23lInTVIZS/xvOErTOi9ndxrczOY9aPBlGXWzmj7LShCkXvkhjNYZTmadaV5r8GCYJZwU+IreFF1F9tVyrgLaurd/m9k6p5/yiO6Ri01IQDc3/jgsIxtv/Jr14e0vfoWohOyZ6ht+Ucdsyik8plbofU2GM0f30NrjszRpGxzAPBXdTuZgHxaSNZ8Qt9vaGeXYYmKCM4OwHYxkg2XgKRTKvXNwbFVDGvXMTFgnGm5JPRhwtcdBjT71jAFy0XuchA3XIoXcj/fZM96hJzX6Z4fyVfuHdMNpbiFj8wBLjR1WhcCYgcEqne72mHjMQruOJbhvp7p+J1ReYO2Qask3QVYHcun0///1wmRlN04IUOZpz2uz6onQyGcBeUUd4Ll8KKt1H1BmIxUMO0NotBgQaAbe4zcJZ29AkB0NXZL9cs6EM3NN0iRH8DHZNnIXg29fw43RSTTVYS+QQcOciq5jP26zAPxFul4ioARqmLnIhd23LAEWRgJu/HhbaFw9DIPAg5rU/7R7Vj7aMKYSQ4EeDHXSaRrWsn2cqq2+MX1WdWC9rRfH1SF/XnH0dxGVbalsh0mgT3wKE/uLxc9b32r5mQYwKS/Oyl5tn9af/uGPEncduCU+WaS+w0G+HEgiUQydodxo5BD2VBL0NotCIOd/BkbhL67MZvfOIZnbKcFPiR+LPAfF2Yhq358jRgJ+P2FEgzNeXigOqQWEH7ZCBxqvFD+jqkUKo3EP8JG0MJlmmmXNBqxYHsCEqvtTFwShfvrrloTgEM5rR8KplUS938d5n0rwvKeE2H6eqt7of7A744AqZIyce8UQdwtK+R5Uruv+z/TD8xSvUqDc829V7THWfsZhrZ2ZSy3cYXzq33znl7qW1YypLJeqdRvWnkjiT/Fsnl081XDjXLiIawsLzOoNnb5PXxIm885agbVF3Sc+mIjtqWKvsXmie5AgD01O3gTMqdn5GMjLY90IEb1v7YHMMnpbnkKIbKhOwF757AK+RC7Xc03cPUQS/IF0rNn8BFZVb0cACsWzKXQ4Rf7IKUE+T1tMXG9mDu+ekkcBxqlCvJ9eRKU1OTQeY9DMdr+fupP+UOXr9a1uDFpWxLH75CxXz2avzHtBQn6JJZPtZGj6A1EJLpLWbgCu99jVfD3mz1mKd8HG0d1qMHX/qa61EYoyrQT/3bEfJsuRT94jZdZrdQOt5Wn0N9O8iyy98ldBJTIw9X87jq+vn2UegTMROthkgBwTlFSaetE9ZW/Jot5suaZFyj6Du/87LErPTD9EOkeI1P7sSYEu1fU6srlPafq9BmlGXCjz02YueShDCPPWQ6xhWEEsRwLzk+HnecOZ2CekYofCfm1i10lK7xA1ahTy0w5BX0woc8490IEb1v7YHMMnpbnkKIbKhOv+/t1lefa1QD4DExdqtGP4k+c1BlLBAvPHQWdrkLqp7IN7zmBDoSreLAj0M5Sk9HXhOFvvD0cdz6rTDCKqJJTOSefABFKPaXro2IRcn+AZhFrvclHSZ/RVfQhYbMIkoGH/huc69OUwo9P9DEEPk1kKCt2PWT46kDtuMUgY3pQVtcoxX/myCXarEy3PZ247Renrd/01J+gNkDqbsAF/fwNHOkiZndyFRlJ2QCKHuAO4eGB3h1lABxhs2XT0NEdVhNeQdMIJcVZgqwn5X/Pqfe5cXjPpYunBxM3JkRb2vhi1OhdwafQ0oJtFcyVEFw3zZ++ceQvG/kFxIw5gh56lC5VmHVr9UAmDM6BjQSKBQjYn4xmDxyukS5StvlQFXS85LNmf+GDiwNJTXaNA8G79tk35EkmAlCWnwXtzP0IGWnjGmQSwrVodIhqgsRwhxJDWHjrHyJCCXN8ot9Vlx+enS3YnXBIqIqB++d0GcjJGnPbrzDzuHsXa1etCZTh50WnnrbxznYhOnnKzy1xUrmrVJrJSdRhy/IV5PmdG+KRxHoRVOKQ6DjStRiwa79LSgZFOjXQYhx1LOl8wyYPSNdijeMWfBSsfKipuc02hNQ3eXUSAkWJzp01qxMrUzdr3laEp37i8EU4PaI1dsZxmIxYZdKviN6eQ5rEftjUzm9DhATsBYsnWRXPi3bxCrqE1a0FUJ2x81iGIsr3gYcczPuQ0iYeCi23qTeDQRSb8Gq3ageJCVqYaJxxpiYjsrP+KZql4WQEhcizMoLADoFQOyomJRVN9PxugFvUZEtoCbGzOHKkjrX2cV/yG9zncbz2rjGHSi4ic4KfzJVl73K9oTxPBDL750irie6AeTZBwnrgg9P6rXAfSEFFfoIzJnu1s4Qnr5o4c2UaSvpfy57jLhHRB/Ke0ulNeOIeJ7FSmWTwQvIyz3hLxT0oa6o6/7QJJe7QN2Z6zSaeJl+qGYeo+UTiNoS5wQsF1VvoacX6GzK1Yr49mYqHqS5ZKw8Iwfg2hW6p1aFq31k215QFb+OW1Ug7KRHiJhEr6ukQdmu4ODnhj2I818xJuksV+3p8irTF9yJaniRLy/pzq3n51k2kAskkx3IjynYH7hTUJFw9uwdQmrmNTqPq2bJW+hSBvGhP4Wkf2BBuKCQqzbzptHu2qTKuzfR34tdYI6Tk13ooytHYuhpbOx29MJBMF9CdIlRpyH0fkag1YeYe30MitTefx8li1/CZ0dx/nNS08S/EmLZp3U/igZhxixvF8OHNtvm2M+m1sE2YUshLqQGHisfMAy+AGtofrQuCyuw6M/UPeOfAbQRMpqPSBL6UM47nJASX+V0ZrW77ImdaX+87IuDGW+0tZvX7C5KILykwgLyIhkAKzMrKNbNd+rtsBPIkrSB/WLrrHiMB34hdJSjkeaWBNNdYZ9ohRs5zrBlSWSRjsETNZeFH5H42yx1emmA8wUMD5YCgsvJC9RNG9zfYfNZ54D7jMCVaRyT35hVjVkSdjgbd9bZvEosem1MuDCYQpmD+w2iONG9N+Q/nTtJNoghWcz1ZDMYVBr+2qD7nlohDPplxbpMCqBYtv0m3E9Z9916Wo/kb5t5xX1zAX4tQceEqgvfMgWKizFiI7BcAxxwED8ho/Wlpxh4YD5eqhapEs/WVAZppw9xzaIoYEXrp7e0k7SYQDPZSYoSkxpTdds/K7QML8dYloRU01quwuNEBaepui1zICgNQbE8P8IP50BtSdX/edkXBjRlGFRi2isGmD63yPQEyiE/myGoPUu5Ce7c+ddcXCplC9cXl/A8uf3QHtU3dMWm7K7kDdc7Ct9IJpvO2emlM4TxrgUWParWehdwfRUqCpil96vsohpMhd/MLUvRD7T1N9Xx/mJhC6fPzAuAWHA1eU1YuilhkrpPpjTphGggKdtWKtQrjHsFOzhBTBRnnIOd3g7WOCpvIbO761OR6TWkD2Pc/gfdzneuGUo95Ig7Hs5n53sl2Ptc28ibQ23lHn3nTzV3gkQdLSMa3tXrGk3MiO+J4tD2g3NVl1BvzyX6iQEBU9kJ8GSRJzr6I34xLGGivUClVfC6Qs1EZzJ+25aokuWKB9HHY+yX1YVnNWcwggSH9WsyLfSSPQ/0EcC4e2VubckLbBrGg9oIkRyBS4bH/pguGYpI/whAMpQFPNohfQSPmJ4JFN/LOYAfMArdm1o82nvQO5TVodQ7kQKiOlu5SvUpLZJtMEjCSDQiHx8k5oOr82JYkJRl2BGj1hPZlyg1VvuRCrPKTbpRS4CC6JB2kBuGaiH7JvAS9jBrgzXTAsDdXyiI/pStZnFW3cdYDbBZEEbl0tTnKBBUdq12A3NuvmS+g7RiRVVSjQzOr8Bm+TAOE5IkB9pXOtlWGqJ0jbXkLWKcLG+npG3/+9HedHU16u03waMjQhvV3NRc7ernkd/OLdzmiJNtn47y9J7trXf9nSVnPQFKasQspDtHxz9ChU8fFa/Vq+20IZXXL7BjNRJQzx3P5CSh9Scv8cXxjomCZou9BnszgDzh+KlHVcCx0tWVV8Er409JILF/AB0J1Lc1DHCrdUDu/+TGmXZYAowTXtXmc8VhFh9UkyNmHeo++o8cDYJBn6qByuIlWe+jIGnCLMY5GtPCK0fiB8PUYaIZpcj40h/M46nCn9zzeiIWnFUyIR21l9EjdujCB0zRjPUN6JpJeulhjeSBmBkae2pV+HbALorVsB+BQ0noG84aUUkPpTBQf8854boPsUeKXFsGQhvHE/NI0TpjmIIbc2TM9c5EcugSpEN5zODXTRFqLL8AfTiomV6e0+sEv5iSDLkmULa6D7ieEbMEG43Tjnz3KIZaUWq6YUwIDoudDaQk4NfzYOEJeUGl1Ojmz6wlRQCof7xU37GntIq+Q9iQUltFMfLg6+Jpd0GkhUlhLzh+jZDaOnkVTSzDfk3igm7QFK1hySUMRa6VeNS6neiS3gsEeQvjEVijXcK9A3Zuw1TS4YDNGbMs0m40pOTg15c1NI3HSv5EPlg7WzlEbMrNlRVQ5Hs8V67ZWyXPff0JXtadCUGXLFN7N1eNW0FkljlMnO8A3qyQ1fZwiWm1VdO+rJA81ocjRy+7eIfFGic2sn31BR3Meftjv9DeBAESFQxZH2EgkCoy5VHjOXt7n21gUpg+b+8KBlYo/QGbMwpfWpoHRyLpCeIiTyHtnjtzlhJp/hSBzede/4YnZYw6Np+QPW3RtAcWTCKRxpNkLlUR36nKghIu0UPwOCI0O7ib3pIV7sjkZQiXsp7xW25xUo69QFRg/FBwpeVeqedbpxGwdoeLEn+6j5WZgUettgkyGe+m9y8HwKIw8CeXaUamvpT6UR4ZnplRnf79rSeWh/uKWtaNuJUoX/f8d/vf4wrG1DkaAxt6jhEYxN3wrhGSy9kQ6RvATUdwEjHF4hP3s37ghYKcRLNXqAaRHoQGjI2QyXf6H3e/mV7XVzGYVOtsSgwPjwjWsuCn4HW9+qSXsrZJqk+e2lL/84s1C6hPjz+nmdxP/LEv3Fy2EUUEJScu2okWaYys3Qjja8uXx8SxBWVyP0Iyp8P9DZDVl9tiq+oiHhHPuvOcIVAMmrA+ruz0dmwP8yUT29tfaUHujvLYtqexqgf4wYcKNsTwYpFUZcZgYEC2BaJ85hW+BtOH04jyzBS6PjH1Cgrc+IYghtrkPMRGpm4/LUr0d1287S/bG4dUf8BXesyQ267waq3rNwKabEg2NPa04ebZux6Tg3JGvqeuOawemsj+k2eeshQQ0v9TmkdxrZ2zoApKMICZW8VS+LOdrZnucbYd/PrV8fGaxWn2Aruy0+OZckuCt3ravvj8OkVt79ww7ckNVWeud/gix3NEn6StFXVT5Z4LXSfA6LlWG+LXFhO9DuTwwfKj2+3Eh9g0EzbPv9D7vWIQSDWo/G/madQXjdbLy41naXA9ljmNckb3i4Qhs9bXZvTiupn9suQUm1w7aIUjUqupA2ImU4UDY/SvhcdvfsGpLYJ4TfIO3YeIoT5Q3RouR2NuD8QQDtC/OS6TkjgEv7gls5PeuR8AXTdZaVPQxtqc9Q+wSWf2Fn+Jip1lkU3iAhQIRnGH0vHSGnBbM1qH9upLbAPtWcoDWHbFrkx2QqTOG4RgC83viv9czXVSPG7fw2+KcPkgJMEpv5AHSRQAwRXkI31ujSksIN1EI+zJuGISI16xKdHr3m6UbarjMud+K6mM6nKEnsn2yfymdufOHD5cD3rNmeMi61Nw/I5PadVvQq88+ykn3sMxet/LEGW+PuEJq0+hvEI5/ciJAhIg5lXODiN1FizPP5RmLWadSUCuEPtU4YgdroIzQZP4Eif6+ojVb0dRsVlnklZUxYE/sKSxQ20eXq2JaXHVhUaJHRZ8HRebeghH1Mn0QQviAawm2lACLEVpVOnvpEfBINjHrMLj6wEibnrC69y/5gENnkzG9UOTP2YEyLxrqz3kcmq+D5eZD7yhftvzrYDtaEH0Ep7na4j1QECLGDv/Hv1iV2kProzZoF0fDZd8lmmxYahSlLbgzL6rQyUcpZ5MxvVBRIaGxhlUvXIjnIcQ96K3Tkvgcb6wJ9dOTuTa+1zGK17ZTk4Tdd1GCNxsxqy79MwQd3nW5Q/Y2eIsi65L9yd8qQnDW1ybNAuj4bKlpwCT3VjtYbMAKqtSYN89LyZ23Dc3AqrdFO+I7BciIiGPpUtS7TefsKOJY7mREi2IKhibCx1j5NTxva/VNIbZJOs1MsvfA+/9vNRjwySk2JOTESvpNSS6TF3woIZA4O/OEY8QHML5+xUg+sjkjdZt5ed7+oqwCgXT38yP6dvlplp1PkphduUVb675qb07F8O9ehwEpIJfZnW6Rhni3d9euYEfD4rBqefVCjLTogOS++XomN6WaHfsxVMaFdmIi/8HXr8K50dcyypD/1D+U/trLu7zFLu51y/Y4Ip7TPeii40gKQjubWO5TUfNdHcSoXqE7S3oqzQPhov00qxzgKN8ztoXySgQFswH0mxdVnf+Ec0N2GUD9oqXJCCLc9cWYzsEfqoPG4hBlP/yTE9Jm+fO84TtANp5FOXSpWB6ChpzzKeDwOkAM9ONm3EU3EO3flbATBrWy6FKxKfMVCdbskpjT3WuYvXg48Kl3WgYt1BErPMAMfQCKERNkqNwy/jhs88UX0eWY+HiG62sazC9pjArz/5EQaAlqP4ZKNTAk15qN4Q2Ia1spnRlWWHVTFeH8KmhxvK+D6bZR8XJmV8wNcOu9a5tTMT2NScmboNR5UXGLwuoPo/ebsm2/GQ6RWxO4jYZ99pcy4URXSZPLJJf12VJSItAjS6MjBkBKcdY67j6+6eyF6U5Y1h1VWK7ymOk/djmGBmDF19AwXX4lTQhAFcLwC7Fa+PEx+v/YMGVZFkosO/Gg7jg4/tgwPbA5kj3SLPn/ky1cVuo7sNyJIK+YGuHXe75Si3xtyONKXkTLpE8HYfR8OvZ6LztzaYR3ptRMmhFpB5VGaIomUCaSV9wOnkR5Srw5ZALEN7PAESQv/QK/Ccy+Jo/KsNjxahvnFjh7L/3TZUNlYiJT4M1eX8JjhzfDLnFQnGuu3wNSt8CZ9R3fWVfZe6To2pJyceKy3VlunPoaxxjNwTOl0M23JEgAeQVcpmDgvAJZu5Vpx/HtTHlcAZnHZlVD0/15YWG6vQgJzrwgiwr1QuF81vJhYZNmRMNWJ+iZWZUBxe0Nz6Ah9kWpwJzOrrEAZSvoTF2S0HVw8IFxhA0jjorbpkKG3iFoBFWNjGhfuEkMQDanmLkfTwDWUF9HUTLEw4uFA8mgtWlcw5bOsfkMNGbDXKFGpgS6+jhEyR2gG02tk4OJxdkpYTFf7V5poGHeERXzA1w66v6qA5j7yOzn40tHjwsD0GdOlpw3ZOFPBX8hhnTguNUS+I8w8k1yFdmn8VLabgoIES81Ys2vDALhR4apG/ABJZer+0iYtO2IAf0hhLFIHZ+hZmthymicu4qWJw6jGAwQbAxmG4lDUv/MjyFcJDfVMYjDNLSJgBwArj34bn6l+6pMy48TIHFHhumuVGX0rbZkyey1NmfDfD2kWRRgJ0cyhqXKVlsiUmjZJQA9LEVJ9s2lDFUXlN710xQyq+yf3+C5ATcNY5U7FS79ShuRP7rF2QoctKLAeGrWQxlxIr3q0w8Vrh97vvv9/R7rKpXK9xpiXAHPzF5HHzTkNn1a6t7WwRa5g+fjwsO0/QAbOMGrT6Oq+RBv4yTpE7MxmStTsYWj3brsHYBDlAW+J9ZC/kdAfUX3uB5eAdcRvwBQW+JS6xgIBdka8ympavUDQ1aZvICanOF6Lr6BgrCFAdI/ebm2PiwojYI/g9B1jRdyIx28QdyoTgWyDNRp5jwuLX+1o8twzDxqs1mrTgljQTW9Rmt92Y+AUdsAPgmRT65NJ0XoApqSVBSLwdETKja0JkrhNjmi4hCwOGN8blh8/sA+0M4jSotb6Y4MNVhXjJIEaknXRDLfBrx9YxW+WxDYKAkXiKU3gZXHS1j9XAvxonmeijeXtWgYyMe5aD/5HOEx3q59cOsR3TOHdWYziGE6Nt9TxLllGOCEEQErxZehvDcX9CTv+M85799x5Ln4OvrdzkJXXI84pwtzywGyerCWugXYz+QW2zhhpiLB5E2Ljre4kAdG3RakRBReS6F/jZhAinY4k1CmkdXvK7tSty2RNkJhcnuAwxOXTqdgK6fVSp5UPjodCNH2wwHqr3HLg3UYBngwmsdcDx+iE1V1dym1j2EvN5ucp5uo2QQiwJFrpJDv5v+Hf+5HMVma3RFJQvdWqrLonIcKb61nRtSv7iO301ore5pMRzq9+Uw4NroliEgsJ4j3qYE+dzRbVvF0/XFbo8xe2BzrsZuyGpaFsom3bTbS1ePwXrFrD0mxIjXG5AzgAROOnOi5ELwkbS/4zFVh9wMNQLuEKpD2m6JvyLybcRFuBlKrR6INZQX0dQIUsZYn15W4sDLY3E2ITxP6JybEZ7aHyL8eu1/FRvLwBy6SIvVq0vQRoQi5Z5+61C+STh4/M5+GfTkCI/oRrJNGL5YWPXQDbFthR76bIfYZDz9cB9vgFbZz/RDOa2DWJjEAG1zg7hSQUzKL4QUyAVGfNljBRBYLVPKgqXlnGtddWXF7aSc8ljuqLpol3w069IJBlUvRNQCjgYo6VPC61f2LGBxdHm8V3x6JkoKnLdb8EqfDdTcTZY4RukR2K7mO2MWUkLHYqzhfLJb7HAtFUf8Tb+J3dpc5IMMmIrvkMdsxmp4DsbqMe6YI9RyFCmfM5E9OmAnZSxEy+tPDUsqgKt6UQ564vLlQmtX1DIkUcGsKdJPsOmSR8w3nDkm63tb9KIJdyprt22XKatP8g2sbeSEytWp/4zvo9FA20DBdbyR+z76GfTM9j+y+LES0B/ROTYjPbQ9/okHsQfAXkR1ZaRn5cxdyiUQT03oYFB9eYdk73TVYqxusDJGL39pSDO1qSPCJTXq6uusYSKfaJibSa+laNmdXwoiROZkh3m+7ngeIpvSiqlF2nC9i/f3WLszdyAqGprfJu59eeTsH0mZMqO9EUlWrXpMYCh6uWfxWLQTp8yPD2Iq0YfUL4iMv9Snue6Zy8C7NKbQ6BAQRzfXuafIauDtvzWwjeYvbA512M3YtyTnIHKRwmi4auuL02GKgxQQuOydcIX2FPdMM3CE7/15xNelS9r3Kz8Ed50FuqGSZgQRFasD8ZV36uKeKzBknirvAg4cp/t4dexaRVToMAlGBjwfyR5rX5DBKeggYYkPTNYVrmvIcSBKk3+YdpC4+qENDYcGX18mvaspDMPtY6MLi3TJ7m3Gpwhg19lpsAWyWbRN7iOx+yFecjy/bw+JaaeuMpGFTKoIdXE/vY3ndfFCVExmhedkBIg7XyORY0k/kBuevg3LMlNqK63bfMP8U5PPT5tE6DQnZ19EAEcsuOxa99ptQi66YXTo7OCWndCT2VxQRA8qLZNFViVJt5LuscqmT+QWzd14YwOZmnOTDI+ocfXAVY94a3Lc15UepcGrRQig6JlDFsZvOiXgY3G2GG0j74oSBKLgwnksQnfO5/RwuwY7/+8bxr+17JrfyRzs6woO5ANUss09tnzOPHy60e66p6plWuQcBKck9AjmUiXcBDmM8rEAj74BOvOcvP+jf3GYQfYDMesGcOYR8RV0bRepH8PUshE35U8JLtNSZhX8+SYWGJdKNEheP1i0nQ68enRbnsmRnymJKBy7t8D/5dlOmQD17yMUBvMKqZj705WXQveEgX9TgbDfVKaKYjg/oOky0PpRrqa0ojjp34DjnKlXXEZig2P6VL1NAgwAjT8vRp+/xparwKVqxC3ZB+QMEvtQvANy09XmiSGDDpe9vTBMJxl8YSaSnPjeqZjtul2h5ZIPGADOtT2Oi4liz0L0mnZ0uCGFumhxJDaQiASmCX+GN2e2wswLRrI+7U4iXH+LUErl2UDWQy2P0/Iu3L5kTLOBQseCtaFmxvqPm3KlP6dG9I21PTvjYPLTotgTnLSrfHZ3K6RY1mje1ZzHLmuv1F9L5hPOkjC/rqCaGtW1UqVJ9SKZFPmOCSUYr/4TpEgJ7WUgyn1dxamF0OwZVJpGqxc18Ic4iD/BNE8DILXWdRlzEU29bBu/9FApkTY0IIWYVdLv7ibXsW8MVdYx5NLkLTHlOc+YA2E5qWBLvcgSlfgKRl5z7a507HZHYmZBCJHEhEA4pSw7cm4T60OlzQ5YwAzWfMakgKODaofVCgG2v1BTVWfjzXrRB3hS76YAOIttIchYWHafS1K/QW3aUBflS3rVBzyUWDeaZTintfysP/7AKqdBf1AUU/SRdWXnTOP2mkdkIDCYsPHw6xYhahIpTlqMRJ2/gZYCo+CFx/KxO6P7rvE6icaU8Wz67xOSZeUvLiXtnKV2WmjiNu/6rSYELvuaNG9o+ae8UTT2PCyI//PIRE4l6P6kK6hjBfDIvXOOlkGNhu4kZRkLBoAawQhDCmtk5Fha4OD6t5g2wZR9PjPB+DYCRUbTjOjjDuvOoGN9IbUzv56hSVz7eaMReaMK4tHe8Z7+a9UC9NSwL+FMMkx007otasdCJuEDaW/9HJfJyPwaM2Nu+MLx3d8eJ2dPsGnT7X8MPCj7ISjWmjQhpKY3cclA6o80uxrcScIsuyS/Sbwy7fQOvlDxP2P/WNb14P7A8gCTS5j76EPAH7lDUNJswncP8EPEUit5guHUSVd4EG4Mx2LEyXA5F3SNZL6h5mI5Ckde5kX1W9bUw+I8+tey2w+8U7ym2FbqOhwEAH3vw5u7LUvX9GmCU1hMS+ifd4ZqYMslbBIglbSl2ohMC54+SzpaCzxCX+HRpnOgBTBH1UJqyZbIguIRgiNcuZebtYPfH5ruD8xdFZyz27FEUVnCXhi7dpgDWXIKnv9YCfwPCYuO6B2tK4wRhcAJgHSeux1jlq2qhmkM5haHfeaTigEowHq54hIR00snuXNwsx1Nibb27tvvXGekPvyTViDvzlsDbt198sOuNNvMa4ntaKM84R+CIhV8o4CFLunnfMwE1IAAAAAAAAAAAAAAAAAAAAAAAABCaN2EMlcSrKz2bVI6HBQHutCoGXE4NeMPLRZQjh6JwzX87kZ8DCCbLA06ebkZ2AQHbkA0uBC3i3zDYmFg4jrLjXQDx8cvQwlJ1aopl38Vc+wU+ePEQlHBHVJV683f4yHyZ+nF83582eDtjYJN75Q8Hze5wPkoSaoudR0KRoInkhXPHLuNLZ4XHzwzre67gmf/cjOiI6tVa21LvionUTelkih0PTT2Bpr6NXMWusK0n5SV2B3+n+ZSi6Q7JWCUBBIGoRKGmhlxFnORxs4elo83apnwojPeqH+lGsfRPHfkeq8w0P05rrtmI+eR0J1ilZ+8GldXA5Z5NMj8cxnfKzhVXRZCB5VVAAAfbAbMA3dh5+CS4cczdKAPuXgmCmQ27TRS+B76raeAk+TqnU3JHoSHM5VWb+BtyGX8y5CuNcL2CZTtFTUM5AqHchHi/T/uG4xGSStttPswRC/RUZQ6+6hc/D+OT6PYt/i7qs2fQJOmImZ6+HpEuoU6ABQ49FOb8su4MXxeIx9HmZji2k1+homogasdSN+zsqAIoWc09F6GtJ6syJmHLWsJt/Cq6yI6wzHLKZqHRNEGV6TbfY5xj0CyDfHkq6sLID/w4/L+MFmNjyZrMh8I73LasqSJbvIKgay/cQe5bo0MLLU7AxIOlIoiOqVDFEDPn4NWfnvoA7Nl1ISRfvM+qEe31PNkINc7KT9q2dtzsM1p+hUZqinonQKcXPwFwJ4eIwylAL2o1lDSDfYMkJJERSm4Y0eDrx4kPn2P+288rxfWy8kyM2KS8NIboIZTh1MdyIDyiRoLz6euvvoE0joENZXDr0ykUKNIM4JzZxVd7aunBj5+rGgdL3pAFJIY8kMZhSNil7q2FcDZE5XMEgFpKIs8g3psL+TS4O8EVoTr3Ea/qSmEc9XLR7oEUqefbXr1I2Gf2AdD1PdbTWcQUbjt5oNoqcQXWQD7GPC0qL4Y2uEJ+yEXc9JoxfNPdyStzJQo42kMdIdAv2nubcXzLdnU4g2JvhpBx07E1YIwVL1IeJUxo8astfAOXv+bO5cXNZU/d4uTpGH05aJ4lmOIM2VRsK5SJ0kwvSz4xhjjWfBZcGAf1B+5MaPy4+vjLM0wuTXgQ0A/dYQPXVvfOacWsqVkI4zkXUQBMJLlA/RrvgNj6mdbVEa/4RwzAMhFzrs842QDsGlW5mZR7wKrF09BAdDbkqFKgYQcWu9IwVnwJESHKxMVudCL5hedzKDIO9tLjmVKF8k3wwqhRTwafzO9SIRZlFsKew70X3v1Loxir6NrdDJbK+C34XuhuwWxy6t1PNhVxYQAC5/uHqbn1pBpTiLgNo9NawxyV5HfeMwW3GzkX3c0qjDXiKRSgPiGCqb6kva4be2T3mnfnYpAoQ7pNIBX5IPG423Cgn90+beynwg4A6/MZnRICOvP6ElBDSABBW/gQ8tBH7+mY30DvxOKc1z8iQy8vzpsNpYwK7XghxVeLecN72oOKZBxjcbatEcae0dmDPsh2+q5/qrsu+yHuwLozBV4gGGC6pAzSpFm+X2PmmUGwdJKzlOFJmCz6PNW8btR9hfwcefAIuSRxoqhqyCyjx+rImid79ZmIvKyAeWVJsqKiwxDp5CXq6hy16TWIj6QfekJbbGuNyHD24StVu+dygIgNnJtufPC2KpGznSveTuDBZgJl2xcqRanTzQItA1UDQ8raEW9d/EzQhaXQ5LsZKx4BeJp9csChJNxwQVUlfCvyICIxEgZ5KYlr7eI7vLdGdZ1X51ryX4kmLgM++t6MOiKDIHm9uwRI4XM8F84l02MjhdHTY7yVH1GL9pzkaOv4QFrq6xtztaseyPp+Fl7fC30qd7JFCgNjvNAf/KTBuzwL7fnxWyIZJLy7jk0LNOcJZpn6a4eK6F6mZ0pWkl71G+5MA78WUMoOjzVchdd/EqNoBAcJ0dIc5zUXt4bTW1PsiICeDiuBClRp9SCZqCaLsXr8iwm8+flYR+xcX0sM8HaQjvaBlj0p611IIrzUrlULx9dbKlIhEoi3HWef3/1LiozQj9jsaJq2G7dbH+FX+SNpRDrj8u+aSGvKn2SEQIDjymweB1iCGrhbTVk0CRFLd9313pa5B3DDAide1P6RV73iAYz8eiCCzv6e53OeaqtQLkx1VRKRsZQLp5t8VKGX4kfaCK0gK9LKQigg1+xExU7FxmoihveKRUWZqIxK9hjvHM/ZgnZ2Vaz57LKuKc0o0uNQpdgtacfFrWd6Ce1I2Z1ooO93MtywDsGn3EhxZ4fC6dn4WzwX/4YRv4gkC/BOgtHp6XF1arbmgyOm83Q5rab3VWyI4VXKfKsTI049KHsAAnmclm8/+tD/4VOkuZpJpnLJKoqIMMUqykZ2ZJkULJgMF9QwNeqPBTxFNzb+e2vZFkLOKpm3YyXN8H4qx+qTDNVXyXz/WAQaHJjP9T1iiMh8J2dK1HibX9Q3WnMcuJ7q/DE3UxC+93HnqJBLlA8wFzPyIWeYbs+rwbNwY4jPzXPdKKSVzAfnkcw072+gqosw9k5t/9gomnYUCcAZEloWXgC3cHTkhKflEB3yXEvehafOgBgNBoLWx+84mZ7Q+1LOgDlGX/zqCCR/OB3GjVH1NeorZB4JxcW0I9AGdTwZ/ElTklSd0ZeN58NqgaNjcaMusnuyA1izCkqxLR1iPAQGz81z1P7JLBQ+pV1lMjlW/bcJqseHnxiLhvwyU3pXQQwVcDqtu1LjuQ+wlFTNXt6QxgiuQzOSb2JIQ+MZ/UL0BfI6u26up0f0seNW/9rJJfD4xrVWLNidQtOFZ2/sYXG6QbU/Ez4uW7hg0BKtwka0L9YhvodoHv1tg+kOMWO6ws/EgQPKgrtHvVLbYzxjZkscBO5uTpblGpeFn0zu44lmdK5OAs25NPxXi4W9Toyu7YNJckh0n2rjYbvS7yDdzKs9zSu/3dGjTmygkifFIZI9kVBWdnU6qZamKsPxUXGo1F0GY/kbUUkrmBjEFuECG/CjWlHTCAdhrDq5j4OHyMhyBNtiKb15a0DzIxRwzAEUJlbXYPcanUuAMKLTxCDDc0vI87qIUeoOc8XtQEMx01m+QiIzL9Z6Y3jcC1xKw7vF8bPT/d2NyO8tROPmXo+kn2cGKCA/VLA/Vx2eaPP2VH5ox7YYqSn8Q8ZTjZ+t8xMFc2ac2nHWQbS/dzIc4PQ7/pZU2hk/3233lzDGuIvcCclstkAg9b6HqJ3RYs2KaKWEW9fi2e4U9ryAU/LOq9kwDLrJy/yKxKDLOVE9SQvlQhEnKcxUdJzYGC3GI8o//LuZ1RBPwdkHf8K/QDn5+IDUPcFIXfhZekPx/irJva/XCEJ07SdohVAes5WD/osuRwrNBjJQdq9k3JJ/d1t04maGVDZw8jsrKECJol8Hr2yUJ3eZzsgREIroe8TQZYZgV3yGX8u89mdVAXru8RyYDUbBuHS3z2YQubhFpFE1V43ti5JXsg7wEEdsPOET5eYroq81CSEaDGowNh1XwzFtXPypBJgpLOdd+NQ9adwXNv+XwId7HVkZjT6L1YC+oFJkBj3F3k5kcWtp4sbhtLpe13SEQVf612QLQ8sV7JPLh6WWBvamkhCxs8Ogd9rgfU2zPGRaAwDrC2nEuyUV+lx9bewenC6W0nFfNfTI1B6wyRg8pflaxS2xvdcPJ/vcZNkRYbmF6XLTaAVGEVZ+rxpCOz6Ilc7eF0XzKH+KxTu4XOKRHyK1dMmvS2hSAylspjeDxcquwkDwG9A7JLc3CGPslzxhdMSJHxwpLpLkteYpiYDtrKeXWpdz2RHoE74zSDNnXzNV7oKND8PgUhMtHvUgpHAltZbTT9oV6qEcNOmGdfy5sxm0EyKOVN7sZNAeZr/rKp42+cWhgy+WLhzXtZfpXbtMxbRoEX8feCzmUxBgcywFJfnIn/JfLZa3OI6DLdH38WvoOuTEOnpdYYOnVb0ExjLWQRx8AswV/KI9CW1EKOuOuGL8d7ve4PSeO4sLEadCYLr5Adgkg1S8yCUcElHRG2EF8pMGV0Eyq8VOBDJUfmUrodewFKtMV2bw/pceWvWxIeOIZBfRNQUcKfvrkoqB8OGgQkTDL0UlJPus52KZkbBQR4+7X7pU8vWSkjlZS9Z4pf0jddzQby/B8GgDTou3SS6dPIHBtzGvssm1Dkt2WcBgMgaFQtW+u/MNY4wKNO4506MU6148hU/C679Ep1+FjU5v/jIuX1VYIgx0Vmi0+qtmv7lLCdi8fvxkBIZESKLYKMOs0ZZEVkp9gFdzkJV7oTSt+xvqhQGSzQ+B9sPZlODPTMhiSlN+Y9cNdw7iaRWfQCMas2vmtoQJWCJRYK02Pib/pKpBZlbEOcF2yxIsoT5r2f8jlzI1jD6LPR5uhVtUoe+wXKHsnKZ6C/XeQwXeGECPlQHRdoLZZYZTpPMvj2HU7vO0/Pw6I6R+02k/PChyrTjpGsRhLpEDNCW+loqwHXgxbQWL2NSXCtZZsdgXfxaLcgv5krfWLGbJ0rP2sJSXZ+2nTjEJwOcSR8KkHLmf7qeMTZJnVCiAeSlKYL1SwHgBCj3fAHZKv2zM/0CDfkgdSShaA/8ABPCBdcsR0cRyUPo1x6LTBvmK7MsmPPVDGRYOqy51RmKEPf2LpxSmVVTHVbuER6cvXDFYZ+oVtR4hs4gJS47Fe+PaZGEBM36GFgakwLQjc7fZ0LFTYs0wFEGTVIl+DnkV8BS6ptbo0LovsYPwFf9RE+puzJ7QlJV+ippKVlbrKSDAf4QdbNn7TThACCDnpkyxCXr1IH80e9vtrZcQZsDV6F0gCYx9o8Sz8tlkCFv8kr2eOxtFoXuA2b2V/KMefELy6/VufawpoBHXiE+bdUt6TI4hv0KVMmlNTyx1HCrZ2wMi/HACHR7KaFjAqmdOgCA9Q34Wytb3xRw2Y8kdhb0jkDcsRLQhgE+jTaFfUMq+jyP8c1fp+Cz28tiF7WePVwg7RKAPBzupq8d46DeroqVP5zRNSrG490GElbHam8NaMpzhbqbIJOfPc3m89m9hTW0eo6s8p9uamaolOWIyke/YGRhQ/d3YHODf2E64/svxEyd/46VxG9ipRbgBJveZb3UtNKZw6S7XlZODSm2dto4HNvLbmXLQrGkTh7FGwzrdckSWec1pByjezr5vhOYxZs+63KY9iOGe4uwrW7OJ122Jot7bknWrF7iys4oioWkDNjUZVP+8LkHXb742AiJfSlKdWAjfFpuT+kplRN3KOwCn0XVdJ7alcSeMRDoVKJt9pxpK5cLK2sJLQd6+T4Vq9qib9cr5ytbw54VHHK2hjmDHKy3kL81cYfWvfJz5/HGr6Fdh4KRjBXIX9ks+YBdko8D7zRTCb3rnSiQd/OG+92u29/TigzQEGUwQWPxTcmO4TIRFBhiFNwLAKjZQ43yrYL3gpeZcYhn4OpVKC0JntvNYlcP+gxpVJatly1v09ZZCyIuvbNzUIkFk2G96UWTZv2RSKh7PcxJ8J4GMAXIRurmIMFo+pXeZX5v3Pq8Tl23viBSz/140pv0lXaR6ByJH67F/E31ywf4UKWZHyZ0kwAjJ7AsAiCqr6chhOCyu0UEXYQVquNy8S5uJTFijPL14MkKRiE7ARQ7MYHR/KO3PyXA/qa1jqmg6+qnRM99FwnO2dF5HfxO04Dv2WklE56/jDUUKvA51exVGbQkFk56BNPcyJqIeziIDx7+cxHSz9D8VMjoD2gr4bD3zsruQ0xuf2L9c0eDVcB4i7kjrsI8iAcxH2hiXhfjYXZAFcaGlZGLCxxG0xMFdhjQ1xaM/hYQgekKhiQbyQAfGTW39njhhMwO6EYtYuF+IgGJFCZmjQObmd0m6FtMwWLLFT1z4QzEH89TnqqFkaOkwZc4wUOik+Wt5W6QFMwL/Qmiqg6AMRqDZ/jhgBcVbb31aNqVOb0L4VvXIaZuXpMRAQZvbd8BqMM0Gh3769p9lv8OW8vU6WKCosCA9ioAVSfczVlAouzuKjBnTeJtvcBJyScxSMKPTaD2B2khPs5logpVhoEp2bN96XkO5T9lKsGXziWkS+Gb2vLLAWHfh1GGUomgxNo/j1YUp+6aTTyW0wOisY+ZcWrWHF7h62SjICOX2LqIQDgiv1rKwok3D2iOPyQSZUC9vwFkiGCZTtWCNfIXb9egHNp0EtaCff4GkXOn6WMTsQkfn9xVZhStgpcxPgewwDU3XSXxHb+iFushFtpUrKLcTZZf04g8886S/q2fSphCyKL/8Sepo/Y0C/dgkXeM7sY2I5O47QKAE6Z31FANj8PzQ4j759XjR+0w5mxpydB7cITMU2TaXI3Pmx8taW+2ICjvb894f6QvCz+15AJInQYzxmzUiPS10jIOLH7wF29y1l9WDYU7/zkeBvLZb127oTA3F7ymRaorgK3YgzOZEx7iAYm+0xyHc4KwUpx+DzSaHDoucHweFqIR79VSqqu3BetGrwVG/W8kwuHZieAAhl0RNXXNKQPKAEns81yGHhGcgAqvGYYpzQu0J43h4v+FqPEoWCsldiZdWAUCdqX4zRA6ydU0lX/tXiCdN3/NRytvmCOlIFTzMyQIGTQMxpHD5MoYj7Vg4BOJ0yUBpkz20Kxcz3SNQ+nNewe8Ak+Az8g0YUDxUJPUQFN4zMNw/Ez8lqXgWAtC7XjSWPd93pPEhCfILi5aUWc4ePt7mky8tVaUvKYrT9ynWmA+w/xJ3Af1G/cp9t+AKNffLZYf65pXwPfF0X3wNjRREcdB9juB/3BD5U8LC0wIc4IrJqGpvYJFfIIMaZHUNL6fyf6ZBE1QsddrPnovZMVHLyAKuq5wbEoSYTjpLTvjsTlOCrrpnZTpO/hhtTI4JXvXLOeIBNBj+iNJ8LNuGkkQ2yrKZB2X3n7z+Q3mfRzeaULwX3bImjEVMPwbmSkT3TJvFPco0NjV/NRfoczaRYnUeqw+RDMfVLAL3F2E3fyiTGuela8O2IOC2luaGUOrJ9EFthoQ48SL5KdD4kkYNKDBvixh7Dht5wP+iSizCWqr19BLbjtqeU5alaOKm67fHHZckWsn8ZOnhsad0PKG0NAYJGVZs/uaapbYDddWuK4w7NOa4mSZFXFKDI1/o4USBg0Gyt4iy6V8bTHQJL4wUBgUK9GYyDUmmlyT3ZEXHij7nDH4pDYxs4kXY9nOGS6+e7sQzxixHXXyz/hfSPTdPXa6RCRiq2Jp9o/2z8P4tKYQSgkE+o+GQ8nawaJjhBCuFmRqLO6AHA2nQdIHsjdN/cNikEcSmxc33YffhpFZMZhjaYkoWd//SxkDih8YpnTnWj9ikOqGrRma6OAje2vBHD9R8sKeji7s9YPSJTWm8P2xhjajZ2r50w+4RSNctWkcKpxIZUWejWepvavcEPQ6m14OxfNGTs4WASVAvolIeehnPyzNqPjsuqSYzb0VeYujS6t7JErvQJDD74pYrPm+WbGxdZ+9iwLKcshoXytVCMTIoYQWyK9fmKewgMy/kWGP+u8FN+uN3K82sA1gdaCtUzd9F/tD1m7MMjyF9/JLbUunnQtTpF801TIAeH+fsASlLVBQTN+Px4jDkNjy8QvSLYaCgxYoLZEnB/u58PjDFvAQFxwY8Ub+2G1DdBCA5mj+W7F+gR2NpXr5IIe0YY8t/18b7X9ig7BWeYr1MskcMnW6pgvSBYVAe8cMH+oBhTWAJ+WcLCZZAG+FtgBE62EEXNS3iroe9DI9cwSuY7RQEzF7lLSd/wi6JVdSbRsYV6+sVsERVEuf2syI+LRMl861t+OruXGQbdaHatOWyNLItVBQTgIVMs2W1ajES9bcbe8Yyu2qaH/3aEnh3PlL1ywO44fAW9M1BCVTaKC6/vsDbG56QairpUHfTRq7qu4hw1GxqnJpMKblaJlynJycSeOP38f23RK1HERe1J9jK606es6HZJYsozIKLQ4eGuxjK/qcIAAPgicwHHYxm8I8fCy6vDjrQRgl428zg9wttPl3qezBg8YHTdCtz3mVvD4JN2Hp/eLcaSUHZdJbJjdfJ/eZvJmH87RW9ICL5IwjNXyjUHr3SrRzNA1JYsQx4TofEM3Rn0aSx5yXApf905phHcdFF8VyE0591RySI/etDBoPWxJ/iISBHVoJ+K1F/KjL5pGdyYPKC6xCW+nak8x7sCCPX2zT7JC5y8kY2a4WLv7OURePpf8NR/mL4R4RgEhO9btzx8WKV/LlmDCP5e7DluEq6uu3e5NfVN9OMRLh300HpPW6AQ7afuA7lU/OoMPPceplaLt56PLHZZfGPEkHCUWIfLeKPcgvqf/th6U50ofYM+Rss7bCd30o+FFwJFEoZlbajgnMkNDhnsJ2i/nRi7SYdwmlHVhSav4ufzr4JW24jDOKwxONyadxKOAiphxl2nhWP+PxxFIiO8XoD+uV2L6HfT7fQWuyuZJBrlTAIPwFo+Fn06lv6YstbjWBEpZKks7B5VuC9OMwifLG3cPkWm6zsfVMnRgWQ6YOSM0rukAtWPdey06s3VC6kzCa0J/lr2j8YQG6w4DRL8aw9/vjN49QzF2z3XVMiQOYH+6/LdR3uDT/5plQmD+6cnTNgYCb3IXuEfq+iBMD3nTJB7Hd+Qan5/SPd74imXIgFOEBFJqwVn1ixPRo/DKy/uvwVn1ivXYRB+LLlH5IwC5iC2UHAY4cWL/19zCh5d6qwSFMhLQAVDT8OMLvA71ZHlLF4BAzosmod2967heSBXB9KOwphBJ/GXkYSHPcpZEvnrQgCWofUDeQXQIs1bTGjGIGGLa9aTDtR2e6m/DQ6t9DJ4OyFHJO5AWhLtVyKMaZZ7Z1Eaxg8odEogQ3wqKHqQkyYjrPENfInmdcDKYSHVmCXNWmG4kAWJI7ofOFJnlUj3RtgJcypGt6BGEtVAPtllck3UYVTd61HrQGgqSZm4fuP+u0W2oC2G397O/heK13F0KQf7eedIypOjCD4UII8yY2EjcijhBlzZR6S+DoY20xo5WUK8mvgB2LhUoZ65TOOa7aKsAILXr0AnxSHrot0OS10rtY/oHhJiONDQBfrQ7rt1VYhg43POLFmq5ryG+StQHoVUoEJ95mdk0YZiZvG2pmkmCQJrBbES44jAktv64EWikc0IZTi2Xwv00kDQWH/lE27AAAvb6ZdoddcukhRIQZYoLCr8ue4wbteeSiNd3Ifyo1kAnKLVFh0xYff2Au5f43qOVyNGouEH5NEzabQ4nXbsusS0o2y4fL22LIXO6vwv7fpYhOm0L76HWRi3T77wx26h2CZNmLZflxgeGLsaQqhvKaU8nyZ8rKDw+yoYWBv4Cr3IlNwBGKj8qtjIV1u1okDIDIoxEhDfOe1308HOkGxq2LCq0LvzdYtRvnlJKkgExBSQHIVmNoKrCtr8tecyFfCbrbXtyYF6JSZCDOdZz+x2mXVVuk/8oNY2miE13aAFS1jh2RPojcVC4dnqWOPcj7MPCW2xxdCz55qS1MsJ784ZhJgzGADA6X1j5Pmt+hu5xDPq81oPQz7BkbOXid6VOi8E69PDcuS6LcCQj2jIR2IrIc6OG35gh3rgxqXYtinZZEiWPfQwA6zQVfnrGjpHdX822AFd8hHg++GIyBvuDcYDx4DX+nyqZCD7t+MJ+v3iLGAkBb+Exz0EQq9aQ8dt4xjKSjh+ZZaFsKRe8c7SluqfoxDQ/a6rpC5jZg4ra/Gwkf81lzB+mV9noalTa5sEEHdZ72N/tw3xG6cgw2iIJ08L25553j0f9P5yrNp/LoOVPHOlKqCuo2aYjeYBU1CxHYgrjzLuxgVh2OD1CAyMf9ARx9dn3A6/k1gn1cp5EgrKGNbJVlk6fKRP1Qv7CEdQl5n8XX1tbLHQvD/YRVy/i8q8cahygA3sXDg4wJneBbbsPSDjTQqkcr7FsUTLxi6YXhS6UHDxH1tThD1nDD8YB0AgdoTIxK8uyHBUE5cpwABdVCnuWlFnHNSvbAYoI/NaAYVVboM7XRtUwTQfbOQVKoBSXZaEHmr/OdoOpZ4pdeWw41wA9HcJVoxZIBXLo2qYJn+IzwWiQxBqscWD3gBOV4RbxVTvktqcOSY/CQhwBFBmLt5UhU+dOD5hQtwq6wNd1TuBSUrAyNZLCCGKVPpVuaQ3F3+mnr/5rHCP2G3VCh2JcLskOjxrQsGbeeS01Lnp6S75bYCarpgXZpMVlLhG2NxjPhWKI3WxdtKKpRq6mkHCJ1EXjihJjY5AJsKlueJ1AW+NNQwcDx6YS+cTsbWUN7HNNTRn7TKw9ZVsl6yw0MF7q2BZE7lIdQBUU6va0IWMyMZ8dONDxpg/BbfLlgp+b8t0fwPMq7RDMIuBFqTtdaYE4I47vU1HpaNMcKnt9Nv+xzEoFcWM2xuNs14AAq9Pgys0tbdGL6dGaPFBK7QNnB88UGmpAbMjy5zHoBje/AsTSQczum9ck1tu3zPUyN96B+s4lBpBRWBQvQImBKF0oqMWDfLJp+pgmiNbXL7tVcMuIA/zJgkH4v1WInM4qEZT37YQFMZkS7Umomq5H7lNs0Gke2SxPPvRBFotaqfXXeBq/H4rkR+rFnEGRWzNDYLA5r/9k+Jw/zoAyUksSRGbvqZ4AKJzmbbb0lq2aFlsmxGT1h1ur60tAz1AnaZJp2RAxxnNP0cunx3jScRDEXw8yOCZUWnxkD4QSCGhBuC7SyADCj40ZyrXbobOTNpcAHyqv7BDOZSOMZLA4d2MqNtQzq0+CKSTWXIs+zqAtmdinkiSiqPLJDdS81Qyi89s9NWxXG6bL0qfDCiBhZmV6aVGWhZYVEy9+CAyK3aprgsBJx6blpRXD/Zw2jeXbNGeEoa7DlDdfAO3NTmrBbBld68wS7qa/RlhnEgYGUceWIPf6H5uida/9CPKO06exxUHXf+sI+5kkuVwoTDOywEXcb0ig9FWUXqdqlAowl74sYQ6PSmWVSrdgTp1Anmt4RnViFEBibUziZKCh42PKlX8QGwL+hDWzL6pfblx8OgwdLQsBhS1RetOL+dCNPywNml/TQqxTafTQMWPsdeogImBHga7+ncxSJLYixCUnO+mBJL5JcvrbPOnzf37wDM81tMfDPGb+GUtzRO+VGyagK9yS7QRGd5eXgPGR62qxsmmu5ZMnbTfkjeRNUrjSQc4vHDacxLSJ8Dvq0vw+l/QeUycc+FZSyoby4CgEZO2m/JG8iapM//pTCfdCcJl2oQi7G4kxi1d/Gti6p3XEhSNJtjkpZ9sTSIEfrlpvs2FyPsZKzHeM8/JhS8es2gjKbjlKiCu59twCZnG4TJfvir5PkuYBd8TuLoqRYzMDc6fVGKONqdNVGyJkcfmgBL3ml0Il9h0FixKxGkzZisI5yGffqjHwk1s3axOpAtFu1IORDAoT4MrNAkPtAg6wQYzGGQWMmMlZyLQip5p1v65r2A1/setXVfsmo/ebC0JEWW9xeZ8L7ANmo0poACmSJo5GohKQxpY7TvUHXnfIhds2X66T23o7R3CVaYI7jooqTojMzc47BVsWTHCbsZKldagcWL2pSJ5dWw4xiXPatR4Wg6/8saAgnTABwuIp7YBIfcdguPC4McE/uyZk2Zza9DwgoCKftJxP1Y901WVeYfBBAieYsdkgbsfdp/PPBNfo+zPT5Z+a0z+6M4zc48zAUl0AFeONO5wzzXOLFvvmgah/IF4mh8EyuFHMjZWzQsrg9xebK2H3wedM4LAKuJGzC8WRVA7Q/3QL7w9oftkobBd71T9mcSP4KiyTVFH9Qq6jZWfQZKDOjS5qr9USSLnVE4Sio2c08LRDn6hrnEm3K/T/CNxNiY7GWe5LL9sEps5z835bn34izNiyvHrHfXIuE+S5YgBDpZ0CNCICtHb7lKh3QC7F+uvwjKDkh6Mp7r5EFZblRvjYsDQw89aaxxKot7eW1YWFBeSQCwOa//ZPjHG/ZNNuzBSgiC9hS8ZM82w/8nBkgmX9jmUyvD3uD0Wr41PmcAqmfiuSGiwKD3IOJLL4AAgAnvA25rCjR3BVjT9g/ZaFGfngxFdAIWIGTjkqa6BkDhQHty83tumgZscX7sJhGuhjZOiwTdPyAECcWUSikqdqs9jsAAVCRI0QcS00zJY35icHB5PZ2TJR5i8Vca2cNm5lqm6xT7c1lZdl0EG0iqNifhcnG+I/niL4v7XsmLvhr5L0lZcP3IDheuaHDGUBf/8DcEsnFyB7NTf6L8g+kHZP5rW+u3HplNuUcl9NSKAkbpyhAbxEOuFPsK3jDg6QYFbG7KAU74xIGRHJI0Jbb0XTXpG5XyfdxkKEAoQ6KJGYTCnvYPqjh/p2xYEB8pJghnPTRJIlL6VO4H/tRz5tmoy8NL1bFhvhxb1Z+aGAhjZLiQCDlKXUNXHXOAcbayqe0TlYifCKp41WEFAQQDb4zgjvvsWznW/RVLV2uNVn4BlRoZbBumnLvX/Y3hr4hP1U7zhmBhFQDqGvyvPao4M6u65RCbJTZj1MsaYv5JhRAv/aGFjgErXB/zyDcYskw5hXfxMyRtWVVMHc9dyTHMhP3GIeED8CDPclR52IeU7x09vCBIWQOxZn0vv+Zm1vBnY9KeJOI41RMLnRhy+VQa88/rhdw6ptnVZzEr6Q//eVvcGJJcJmSDho4hn+pigQzNKVgIM7Gv6OGEG8o1kaRQTU9tKOw9+mtbDLzMP440mVL0cTajqOkNBPiDisoysiKpO0g4gd2YChBuOgJidiRCeIkFgGbwwvyDqVtFqzyMBn/0pk1Rw2zHSWs/DNGi9ANYpA7wm8Rx9aWUE+SYdyhTtP1N4k+VbxQ9AxkwfhMn5g+p4p/RQLWpcs1g19yNwpyckNx6gTvTcbxwUG3uwYeQglpZ3/6dV8arqeV1LFdCmdySRWcqZEm3d7sZKWJNRwa90B6G1QGgoZE40r7NQzGtixG2TJXdu/FKDSKL71BYFAD6oqbji2DAhz7jT+qwZOqS08MxHbp+e0IwAuByHfDmQ6KVILiqP1pOszRHipAZQ6QUYOeGoo+o8ZphVj5/YRg/isH3acTzEzp8NIyJjJIBQtxGUxbV0BmM0tOovey6CLm36CFGtFug6Pz/asgeQhadRAU7cWEHpyEvorgG2rHR5DAQPl1xsaB92VdIc2yhPVltEc4jnCdvE15Mi1knbiuhMf+X4Bi/llK4B7KqgZIMGsEheIPIcrB+Wj+oaB13lzTN+1rw3DDMPvTwxQr9OOjHTrqBmNvrbnw6IAWdA9h74gTccZmIStvTuqbHKZerEp6LlhscOaKeQPkZ78m7OdJ9aRQ//3QcJFs/W8dAZg7a2y4pEr29udCFlKwcNVAe/hKKFK6x+/HZphH3k7DuZ86y5R+BMfX70pdBkZYiLALjXga+AWg1MHZEU1+AZEmhnX28mia/N4zJkTqIbLPkQLyi+KEu7Wob6wReCOfH9XbWIugXJ1WgXq3hMV6A9Req5mDl1dfNNod6tvzVk+4z8IGobDqJHBcDsbPloV1KkYOwUcUoo7sk8xE58DO9VHiDWueeb0g4ipkflLMEV/Xjka+4nppkBO536YwSxZGESHyBwCnEZoXTmuFxYzcNKyj+nGM1a1MwtYGykAes5onoXJpAMXpvldpKwHGsFls3IrwZJYVW2rCUgBEVn6dSdcRaOJ2Hmcunkz8xeZJdtnBqV2RLSmnusAWZrVvqlDe58Xvx9pz67jeY5jXEA+BP/pxjNQA+d7I2ltZwzQIW7NPvQ9SY23drCtskMojwkG5cBa09akvsOUMlCHLNwTTtQQfrXU0UiEVFukMNRn8Gs94ajaKd/4dYAidiVnJyEyoxFeSPbUZIT0iUt0ljQhhUk+2SqbJN8TMy/LSRjHX5GyQjVc27SG+s2eqUgyJlFhF0i3JGFwsfIttD+zukgKdD1yvq8uMCY/g7RwLFi4NyVRBX1i9mwYKTRAOmKVRL0PWil0sliLiApHt6dt4Vj7isR0hC+lJFHqWL2iAj3oBvtsxqQVlAjX9uPJGOmxk4jdOm9XFvc/EDeFyGNKztGVf8QQ08G1HnpNkkipYQEIXGiZ4NRONlZ2wKSqn+MeI4NmBoPcXSjXc8CAJhDcAQUwNNMkwV1oitOze9MNFujku7ZAn+EeuRDZAnDXWg+XcCK8QxNacdL0+g2w+Y9orNpWA3p5jMVg18HfGJh8YO+A8lcIHSfjaOcGuCVr89xdE/NuN0QvT2lBHBK23EYZxywbfEtRuTAZWspKa/RGD/1dyUfTpRiFXwv92wZ6M5UeUmW+2PQzH9MV+J2oY/ua/YB8OV7wnjgM6g9nZ8qXoQSygbTisnvxDlgqPvCvHtl7UAAQvyFD60vgDMLovQbzfhLB43Y6yYdisprrNh3H519N1N4ZE08rl9H88F5j3X+qv3sUkctlhbmtpwl8UbbwHjXv0UjD65EupIS8V+/rQf0uLu1y6fndAiilFfn6CmnHYOSFgKOjViWX4Kqaf+aHlgVqZ/9Xwo94NzvsHMLeBU4jTTmgQg8SCfjxhTutDZV+ieeTeuQcqiKttVI5XIKreDtEv8qg46LQscxSk8s8nPoCvdmfkqHguXI9mvzev8e/yd/G7eHfocoHCiyQynPKEgy0do4BHL4QALdzK+8keKiDUZ+CcNa/1V+9iiduNfi9YhGjT3GqS4Eh8P6ea/6Ovgi5xbnIiQXggofgMsaebDOjGDyyJQjKcuyGlluAAk5ziESP5rnOWLZPxMuwNEZVb/ijw1ZuCNJKPKM1nBdWVK9QKUDc5YMHNm1xak90bi42WREPx02TG/rbUzs0CDvy0dVF4hFLx1siAo0ezxD0Jwn+WqlGIFSGRlYBFVvMB5eRtHPz+OAq1c8o3theI4TukNniI9whiIxoD8RsalXsd7U165kzDa0gHA8ya0W/0oMMOKPU/X2wOF8oKAy5CR4R+2tb3mCXSXNWl40287XFJ8wdYFlQOd8NcNwhFMRHU/ddw5ZUfo+1mCIok+BSWdeGemujC2aOyVJdThLozdRaJ5hTSKMTSYFRZSJbdCFFgNCwqVmytc9Y/H2KyDpWwLWfby2eaXKE36ejxfZ49eTwH5clMCWnV/17DI3+44bl9QwITFgKxVMEqqR/RY5WUK7xFr6jRytBloYrRAgOucMqPjRrhRabSFm1N4GKFGVdcn4nWQuI03Ll0NdhP5m1yp5TKeLF4EpYs0TqhO7eIDX65LgJjLDrd2Bu3nEEqky0t0ucjTKpHnX5yUQjevQCfBrH9V5fXzMmB6y/UISUx4MONwwB18PPRsnFnNMzkmByX58fEVbqHOHwpfD9JXE6yksqAqoydNgTIhc/JQLMdfrVuFoA0K57ID4W8KT7zM7JowzEzeNtOddHrB4IVYi3R4u8y3zR6HfgFLDh7CML/nBIcVBS4t/CBTuF2WaFlRFOnjZnEBqnaxa5Bn/Eqmc7p+KIEUmBGIE+dywtgkwgQIZM3wuC94nbkXYap4OD5zw3hh0VN3VKOTEGuymO6ZI2tfHUFpBrgbEjswVjJ/6K5N6Fql8zDOlEckYE5cnrh8m7wAikslb63yGFnzu5t0FTFhntykoBT6666z0j8d7qpeoGGOWeqr9uZ9HTE/jY9ARW3qeD93wFOdP/i48363QejJiXo9nM3f75g0hMhn++C6dzj6+dxz+YnDHSwNJ3UNYLAg67xH05oc51kfhBxdrNiYDfsMQtXOF9RCHfjc4DQp1vrUHYFcB/98IdnyRUW2TXJq7xlwxRNTXKGdYygjlrS9WzsCZ7DIQDIkpcDnyrYKowTj90ZroWuqLIR63ZamXYtmM6l552dQaFPbvaG71fVnMqgV/Gitw8+dxEiQLORpkXTQKhX/X5a/UABtEtyT0REsOAOpJ+7VOfVe5YSZZ3C4eHwBnYHcRMFp2tmYlMq81g9HUm89ajfpJzUIMvRSWwLH7uPVpwBDAAAbaX8dwmOoPK1gESMFDhjlM/hJMjB+LSGDU0PlmvyiBzsvPL8TQI1krzgCZulHHYnvUCeBjFYp7MaKezEt41D5Isf1zE3Qg2Pdqq4CJdhAZc2iBcfCrEJc8afLSkncQITPvDSDgyfcweyFPgItTL/sSil0qZ9AH0ZD/cpQUebYHHwlFF04HxXlw7LQHDsQuI6Tu6hoHFdhsctdZfeRH5cIbaadX/lRZI26cjG8N5vU7ugre0G/oJU6X1KmdoGWMfbZV+2d9qxPY6oSu2YoPEFQQfgHakR6mUZ7V8s+0bhXHZZppkqBPGcvQwsgEnh+Nm0HY1RBhgQ/5KUNTc5udTL63qA48dtRc0EyZoPW+Oi6ZquaOvOotrMWCTP+IQfo+0xbvWtdNEN0YsWEEwBg5w7bjKHOibANlX/R0bXFBRLcR5qhhGCca51IvxKSqWJp/wqEaB4J8mPYNI65aj/9bw+w334HKQhOLDreWFPYvOfwLQuf0HRWBOmx78t/UMUo3m3+MpCQuVwHocZydu4PSdtmE34jlBp47SeBqKQpjVegZtx/D8M191Gy48GVnAVGgBjcs4+wp7GDzDeUTc8Dk72RJdA7+4WNTA8hZtXxTBXOzzbxSKtmIgBKIFDun817yEaESmjLIe0CLus6imOWeENBGw9t6LpKKpEoC6EKJ2ZymvV/bMDVUX1mvjA03mDmF0bD/JW7gJNk8LZGjH/UcEDJUvCQvGosz1Qdm3re4PZCexE1oKNm/Ii0yM48pIWKzXJPRjEtBPC7ndI8bAxaqV0CgEOPsJkp+GH6tZHjhPqsTPWQEPtxqZ/3JRkc2Ac8RYWwApepV4vPithjCthE/C/YEKVUxN6AkqdWPVndQ64uDA3aR/Z5biF5nCrdAFVCjcfyQtVmyBdj0QAyPdhiogkFgzTYDK9iTWZjpzWfSHS3CewCVqgz9fRM8pmn+W7337vyF9HmWOj24BEviiOxFUh5Pyy6XgGX0DVygegd07sTJI18VVpHa6NlaUSK33GKlXRYFXg5q8J4FuciSoIRm9UvoiFksp46S7MYNk7JwRs3SfSyhgtB+seB6ArIAVspZKhxinG7zqUJbK2+qEKPEm5FD88fawhQZt3lL78SwCVrc90Jny+/K+dasobZx+nBhNzNBWT8XMfLpH5FjFhthXWNRFE6omfELVjtpgPSZay0riRy4LclfrM0RW/QiaZLcG1SkXA0xS4GLetWGth0S02xK41PjZ8ArhbrL1z4gAlnEHFqqLCVhFcy+ZvpOBSKplshezTOpCH8G1XFwPF7UqwVQ2tX6wrxFX2axx+rTwulFeL4dy4GD+gk1Inv39saAe57X5TN1863e56O8PACtqf9wS8UyjnaqmylyZy6vm+RuZpBbR7PdqSN4UtfHFr8Y/falLEGPHvF2azKBbT01/u8ogNU0/TRkR7TM9JsFRW1/+a100QuRQFs27VHPZwx1Q4Pf0VYOsn3a/CxZUOjgMS5tJenVAfK/kIBxkCq6lKrr1uDGooAi5sBYQ+2iKENqPV+tGwSw8YRjTtj2JtasTyfjTxGKii7eGBYjHto+loZnkipGpikk5qyB0e0zkWuHvLbYCI7m1rBSY8WUOZkGLFHSh33pCwtaARs9Egz+PvKBTWfMBcXd6TWbXkx2qTcCVHQVQctvD5v9DVCfSCczZn+RELszV+a2LE1htuaDfz/nOmDvKML+5gIjOSYM/tuN+g0cDCZSmWkTjMVHP4XtRSZnDhSeeigFlO7hSXZvCdtFB+9QAwr/oEfw+Z8B0Vr3NX7T1hjqpsOFWKSc+V/HdNqsvXPUl9i0fAVsUe/LLrA2Ulj8X6EIvtMt0a2vyQbT8qavdOIWVTWIpbQoCMUuIv9+FQaMpC1e5k7HLQZOe80NiS0zCQC7/YG8/5hIHF7rYmVzIOJkYeJrwAvXTVC2BpfdHtEqWn50iiwR2zW16d+DNIwhvY11/2OKGnhcZIpkfq422W2Aun/ozOxw2JUJ8Ibr06ysMaPRFEDXx/OcHVf4FDeuxJjrwXtOafWKeRoHgLXlr510r9HnCLbe+kKMxxEMu6z1obkqsiPfxb3UzgkaZMaWds3JA4pHGCQLLv6Vm/8JxgwVkqW8lgq8/H3GO0nIQyWeHoIIb8I91pjmYTJNUkfY9zVuYuSfmhBh5yJu6GePm+DuWo2/ZNLwlE9l7v+PJBFULa9smTrQ/L64CMKYYREsyVJUtlfWX+HNPaUCYYX3VEVOxgmkYavm036rbORJrFbqhq9zq/SunHZJuihJX4cUmB8Mgd7Nj/CfrPto3AgiK8waNHTDbE6GMu44ov2KlLYNGXwFz4UJPeeQ5gSrn3Kvz+xww9IkzVxWcbI4T3aiLCVLP1Cr+4O9nokdGwPurljXtfmh9Y+mFcMMr9w5Agvm+XUKwzt7k5s3cnafNgZC0LH9sLtsM7dw1xB5JMNwDfFuaavvnpScAaQyiD/RBCkKEaL3en4aJIwvqoz+PbXHlUvLd/j4bQ5PfIH2EbbUTPi79Op0sjvFSgTOZb43xysCHLLWs4Ibag2t44LsZEo/gEhegszs53jLU1pcXFwfX95S0sVOG3igkfm5xNCPnIkdDRoYzw+hltGSmnOgKYcLDl2PBvsogoBHwHvAfOtoSWfSaK1b9O1KvDmMCnj+cHNOcyyS6wU2VaDxaxJChpmI1sjYosfs/TAgHF/rs0KtUKQ7KUoRhBHPS87ShO0pRlqTo+ToljS2hjn4sU0bOgmw1YesKHRHjUTq06hB+9Si6fUhDEt//r6zVa0uZNU16f3iS1heIxql33rHxNdLmm3yR/LDdFroIbIQULhkgHWQ1QApWWZVaxCym8MEZTrBMpP48TnhcOqhRE29esZ1qM/nximcQG9tsYuFyUrhZmD+QlTZ3d49/2jygxZpDjjWbpqeTRB0c+IMwIjf/UrfK0NkVaQwmc2aTaB0nFVN9JJ8r6qY4FZ6nzhAPyqIH8xP9R2Myz5yICkaxXPIF0PvTXzbsneGHQz5rt8dqd0t2JtnvSyxNR4ZC2W8XS0CWWJkIBkt1nY3iBT8ln6ci0TKbwSTtRqrssCNISgB3e2+kcxkRmkkZaviZbTI/CH1TbpUEOrlXBZJJdlCY37raxlXsBIg9YDxZ5HgJCCOW5sI706PyZ+dlVR+7s0iyy8gFOJEtF+HnL2ys3VKWQ2YIQti58X6rMPR5uylygmaniuCjPSnY+9a+Q+q7fuBUUMH99gN0fHOXZahhjlffxTjQtrloekGwYVSr0rfSLJfGq1/+c3y/npF4aWR2uGPQVnK/wvHhyPi5mKLRA3cYMrYQ8uIBODIQWxfmNW8A92Psjgm2kQ5nW+Tsh3Y8qmmyoO3fCdvFepZIwXcFsgviAbNuO+43iTX7KD1y14l5Hk3yESoXCpi05hWFxMGGZe+JxySD0KR273IrdZfwOr0SWuFwpnYY3u1+dXQ1WiH7VYAjK8kEf0qjbS4PO8oE2Wch9l1u77F80BIHR53VqyGNbCOTygVUChHjm5WfhuMOKgHQCSPyKo3XaZb5pRWzKqJCRpB0bbQ5smvQ9Kj4Xq3+jqZi/OANZv3KLETl7SdQIdrFhgjgV2incT/51vwEHIjwp4YpW7/ZP6cFoYWFOh5uoqfYZ38NRZYGPjP7mnreLgbieBAjzW3qb/9vHoNWAkcIxFWzrBEkJZVRoLVXi3X/h82VuRpq5vfSfFimeJzRlb/XGhZrLb1geTVWWmYCrsOF//NclL0Ns6ZvayPGszBQgFXHe4s/II4X0OiZ+Ke9pfQYfpU3mhuBeDSYMFZP7pScl33Vb9DO0JKZ9bU7JELxzf42xgzPzOhY7uA53dUdu4jfPycO71I0rHO4lsWVOMFkZ4OrNIoxtUyeziZrP7nPq8FCJoYnO5uMLZUTPURi9XgUXEERZM0KmnFSTPK//ld+A6yi9NleSUp9jpVbFO1QMD1JNNOfMLe+I8XJ62H6jwgorR9fqRExQTqux6nVpSXocMDdKrZN4O/qk9YnV1JLH0ZQp0HHH+A1FUyoGMrBjAHmtDyEGdXpEcgI+pJH3qxIMKaQinjqvPvbh7FX+OioBqkQ+OxDi5u4jj4wAoYtXtxPrSV4DwUszdxUutn+x6gH8dgS2/yi3CUszJbfd0px2W3o5c6E4+S4beI4L4O0bNDQ5ucQhOjgcD2QNSUUflLXFWxhAnBkbzSgDScYLxBVdUdQY6Rjab7JYxPvGswTFIlwt81I+jUyILvRQA53A3nph8O0LGMZpAyNu216NyrES4yXZ9xAEZFzB/kxDKv3AtmsTZd1KJXDLNkWCOmseRjSuJuDk+ZjIEL1dH90nAEEBUpxiRgMEC+InVRfL0lnZeogxWTxbVuhzT6oWyQpd6BVoN87yaZE1+RWRrqxgjB/WSvCPQcbwYGoOKyzhYhHKV8Sj5LyaeAd4qVYefNeK4dpzvtTFon9+Xa9QkWR4tx2Nw4WpOFZilXsYFemy0EsSuKkTcILTksU2vZAlSKXoQNXeblUCww/7VHfMSBftVxKVXWUK7tuWf/X1yokt3pGlbg7KZvYJvmW/j5SUxRLWqT3K12E12E12E12BIJCiSMgoBYL7YL7PIR/YTXYTEu1yEVW9ZQ8n7FFMZAFVaJdM1GWdI4VDYOEnZZfmnHH8Qzvztl+wVSiWR1nECb2dQf1qmd/Cs48rXFPkaLQbTKm/HjoI/FW4oNXt5whFcJwiGEO0KclSO1SZgzN1FmwAAAAPWNptGggCKB7PetoEAAAAYiedshQEOR+e7y5aoM8navgLtnwAO7y/mXLicgHArbg0apvff6e2DrkPuc+nxuGALAkL5BL/luW0bbMsVnNozQc0L+IMWZq9LQoGktovfEY+234+2+RFFGQN7FZJURxWsfMMbPndSYFmmZAUn93bsOZhRBMid+FRlISukJ3BNmokCxh80YrNTh6bPVJ5yieOEDdsvB3miXDlzBz1pmF4fbyA9qug7U7KNQ8qMHQC24ARc+TvCiWAjEMVHeU7UjgCSGTWj69Aro5RmXkSBQh0MN/PmD01ttllcP+ZxVXg/WX2srH6O+1k9rBy5WAB3CRjUX19ZNTR/glZzFu8u5AdgJsWVWg7Hsq6/MdCQIWTug2ZVCsPTg6I1VPlIAeO3a6e9xwdH7MiynBieu1VI1V8AwzHNdOSXJRKY+i34j8qnSWrYGbFtE1zPDFH8VqEwEkXIlYRiGXF3yCgeUpsuxndksycV9dFrbMbmEL/WG+Qk4ublVl72XpDj6C1gb54m/gcVEUxv+ma6VvOj6x9se++MvcVwE/GoQ6P2E80rzZv8NQ9DnhfQZsPID7xGVDFHKO4Ohk5dFz7wZ57IQ1AnI0onMAxW2bVs+Zht3I5VCWLfoJ1y2+VDb3aYRqOxjadEr0fDyV4pgQZN+eEfAvaI5CGlC77Ki8tXs4Qvb5cWhAHeR2NEqCJyVOwaf2oh8MT6UDEqWhNDxYBskz+m4K3N8PH/PPdF9jeFOB8olaqBw7aRB0dlz0VFqIBJMOb7tdPzKlkPCK/9Z5wUCy/5GR7MIo/9c35TgAAEEo2i3yt2BlX4qL1YuwQnuuuqzLj5M3aQfX1/Nf7RqJGWIjCIUf+leFNvpOmg2gvNFgGQjweKefO08ridPSUutmiVzvn8te4l3MXD30cSfchvmeO6ls4tujB6lps+UB7u4icekXgaYtyDCI5mex49Lu27exGCsSvYeKCoKZLh1m7ICTKceFP3QBpficmhU3FQOHYfHyGITpXtQF7dl3pFT9BP7xvUn701U+AUWgHP9kGS5qMrTByffQJMB5213P4fzaXEaduf0jIplxrOcApkCvpiav0NOXIjq2thmNaJCtcVna1jIFZZSs97fOsdZzt3zAlSdm2p1JpGIZQd95dpKsYfKNblEee7GRxjK+bICy7lq+wy6wdt5grVk9Sp5LVACzIOBYhlB33ltUvh26QE0QhFVVmlfn26ojW8S6Rmb9JzNTvpl5q6/lrgYRsg1PDuUWt/t4tiP7Jf4OvjRmNyN79YsEt6xwTBdGm4RQJucpAAALY39tRcGiuJUk/Cl/EJJVCO2ACbvgAFdF7B7Q+non/Qx8AI4SbsoRceQ7D3lydnidNO3nPWQqauHVUacLpVebVP/03radtkQx0l0EOAkHxAwh/UKMyf0LJCTBKvdhuibPsiHo8HmCG6BpbVXfxrY2FRTrRJhQ+Yznu18RxLO7QV9uYZ0l0bbwYJbv4BC5N+PM+XAfvC8pEoCVZf+Y6CmiOEwgJUahHVUJyP+1mPo2F3J3ubh8VKacWezbQS7Y8yV19HjiX1dEkcsNkDOslEpb+aODEB5Rd1NVIlfKw/TR5pcFYy6QLrLtOnXpZFywqq5FgpqlBb8N+vpGfEkKjcoQAYe3M5HbnFXunCW3vSfP+MGUbbuMCXgDFme8TzrsGoU87p1qAAP8CAZl1ZSzfY6FMx4P6IOeHcAztJ2Mgy0Z3ix9wlJXBEtizrEOuYJeX7BKun0PcP9seq007U01jDcLp7ClsNjy1UTPnq1aAxyC3G2V1LseJSABb0XT2DQ+ocs6Hfj1pRvriSAUDAVTUvHcz+zm94o1NEqP7TFHX2sy+dwkK/2Z4VxVwm7pNIzW8FkG8jIleIgoZtpj9VADbjR0Uw6GaxGCgCYC6xraIT983j1JQUkge4/rjbqpBnoA3N93exqArJ77uERlp05EAYEkMZEA9ZAg696bwSzcTaTjSRNd/LKRG12r7RukFk5XM4M9Mf/3FZNxLVnK57/E0hTjsLSCXublFYoxBizc+cQ8FaPTkLIt+GZf6uzMARpjxO0GAbJBpUIkcNsj/Up/5oNVwWTzc7SzQqkxETiLX97uDafoCygwLgSKIbccSGjzYRKZ9AKyN5xZ/TnDz16/I34ZJpEKZ9XGv/jem9VSrRmth+MbqooUBf1JjqAl1ycKNghEQ/uvVB0ww/aJQNkfTOuBQR/62xlA6jKYNEZGSJUZzvjnKdXUgeQ/CYiJxFvCVNkev2jH/30PUdiig4xVt/XWLs9Qj5nLsLOL2B6/Msor9MRE3BGQ0wnaXcX/l8MJsPmV05JlKCC2m6bvqvZOVmXLqqDSVQOASH6bgrNRr5FMNUEoZapFjW4LRx9pESD7gAdS3mbURh3db/LpTsIHmXYTRz92iHU03RovGeRgyisVFje2X6COta7cWrNVlhooi9zBYZfIeVR3aSRz7SHKyEBPu8NSu2AP/ZM5lBdheThgK8igjJMeX5rNBzRauTASrmeV4fyEYYPXGndU3SijqgUqVjNuHkdKN11pQ3dzwQogq95djlUG9cETIrJSjhm/xZbIlU8cZbOJjLm0X36gjMUupUOMIljA3xukl44NvgNdXaB+XuGvX0kRVynUH2ELACT6UNUaPwSbVZknCN0xaaa3qd4M5NK5BU4qW9oIuYf3yZfO+HVODywsL+jYAs3yn4UhIY5BliTU2Sl6AAAAAgQ6hH23l1y9xRQwV8MCeQ6BO6lK1O2YF8ZejxrfyDav1jDmcJ8rxGyunOSV7IqaAlq+MYIgzg5b1gRH8Y6HNrFOc5waswnvtIbctNOqKzGPafLbSAvjXVTlHHotr0zvUddYp8UseGOWKhBV4FP1ZO/RHNHmv4iugME/uYoRaZkLZEuuYWJSBuBQjvOHSbtjFc5aqp0d3Vwtj6Rvj4QlsSWaQB0WdRUDBmZEJ25L4wxNih63eLtRs5Q1aAeFYRzsTjM2OTl1kdo5HoTcij4JpcbUTke6B34MDXy9MHZMow0cnIBW6B4g/PepGzmpNzorqE3w5cBV/uSyJx5+iC7946/FtPw6HFbZQ/rDknT8aGhXuu05wSLkB816xSc04LW0eYTQajWL3dVZHPbhBBRJTL69D13YncrDp9l5xspHK1wYtuIBdx0yZiB/PKErQEjHQliwl2m3sO3T2YKh2GgUcJn2uKdrrHaXnmR7Ktumfjt/zQASlKhEeybNIX/BL3oh561tuIyKNXx7+5fGFXB414L/NLvxp6nUT/29aQyGeWhxqkbHtCMkyFLGLumhK4vKZvx30vZixou/vpDnorbEwDJGpM7N6qE+VH38IQVdB1D0irczCg89dLflnHSg/lj79cJaAg0Flx9H5LEgI9TGOw65Vh9TxjoN5+KYxQsg3PDRcQtX6vKjpGRfAQM2PwXoZkiCi1i9vPX1ZKDGLz8zUhunSHPzRILHyGMB9zSkX2U04bM8Yqws/XQCPXQQ5AF6Hx0VkMkGH+WCXsAWAgfeRkUTxh/IRisGMB9z1lvv1h/ulp6dPFc1MWx+n2GzgCTwL+/ZH9aJmtmN1TT5DYbSiEI1xehzfNQtWysFfdsjEPOGg+ag/xh8ZYy1+46kyh5UPE48OABQLRyt5YEaKZrf2CzsNJRLOFR8GWm6IEZ53ntfkV0jeBOQCBGLdUvhm8z9W78pHRD86BL9C1D+jJS798QAW9D13YncrNOkCwws78JuTU5x6dtYkbn2Qk8NpA9ThX9KLr+QqVN5WRl5wXZrvn204qt40deSWHIwoLpMVqcNXpKB+kVY8pPIqDgFJWZarzhOEAr2JZEv8XVQtdnIIzp8BGEpmn7NY2x2WKJWm9EXwTZTJAlE6/gFnfWhMNrh8T1cMHTzq/xghFFOWHhPO8hKH3z0MgM4sDwAEacK5LPcfL3w3LrvtU0etnVljTic+kXy7pXk1xYzQHUt3zcqDM7BUzC1u3eJ0pNYneeolG53lOxkESd2fTwKidfSqW2IkK9A6z0N1eOPCCkWghwuC4+FkTB18igsAH0Kwb66L2PnVcCj9BVNZQ9xV+jvoaPrDmi/Z2RGq1Vk3tT32pb0Q3OzEldHQdfJpB6HSul3HkMmqy1M0aMEnouM/g9JY2UyuiJVmBvnESIB2tWrsZ23IwWM3sxfrZIuG6f8be6Wo0Dp4f5Lr3Qc/2PUkN5uJqjeekJBlxJ+pv16Jr+jtSILbh6KH6k/l2fkMiB8S+tesnE8QiDeyWcduBP0qs1EzJNMDjypTdwiFZAfaQhyK0helM6oMpbN+C9Nyk7kIX/ftNkA3045irDeHf3xopSZBGNphhriX6cYcFduESna4z4/h/FT1k8ERr1oIuaTFS4Y9esSaJ6xT7t6/2m4qLXv5f8l+rZn8CYoTYmxTy6htfyw47k3OKt+s3Y81alYNEAMRGekwWhA5erpZnJxK6dm3NWv6LxMvEyq5KMLm2Bl9XjINTvx9dzKkD5GKmzrGLu0h12BLxjBHDB+SUxDWid9RNDwZ5UQUfrRmwaUArahfKg7J8df64BvP1xPk/a8JCx8QeXN4VVPHnYiQOCLemE7AK3UxJFdRlWlnJLYWf32sZgUR6iPIXfUCMQ4EAGO1x5y5a0Z1wu1Fi4Sxlt3x2BlqcY+KfP/hddikAuZ9y4zTEiurhN7r+Av3jqDsjDE3Wlh/dT/BZYwkeEYin752ooWqN11bMX2CjYnOenywVsGWd+WCKUvO4iEKP1ULxYriGUpLiZZNYq9Z8pI3QBFb21ZYgGi/JMqnAAYLVBlYBScRsO511YLujWYz68UiYbpBTVvOPVfg0eOEPK7YkFfnPl8SzJbINNydgjupfvBY53wYQCZ6ojeZYF4UqqG3ZK0IP8ms0sn4pt3oV/AV/RhP8Aj+rJFQp0E7wcCCN1OEc8klz0+WCtgyzvyysnDj4PhL40TOHPDbd1Aw4OtGLcUVFoYPxyp9HI5Py7/a4p3g0otbVyQ2570QP1F5SsmvhfigiWS06zjE/pqatkn/uBFOSrwECyRP3BDeAt+tF5sAUI1yGbQuWvRrCsNoAzxgJxrHjjwsLrL3BnUQMMvxVGk+3//f5h2OTV7hDFQskP0brFT3g6ySkm6cPkp9VNRVHOW9edCqPKq4Yuw7Mcur1xhrUDYSGIsiBZ+oCpirobB3ghXBmRg7w2sr9Xr32bWWMwzX8rkhhGKUJyq60sVVY0hEaJ2UG+iiN8PZJzPuCxbpv0E1Wf47atUmMxsv+eoqP/JevYOTknY3Mx3waDr/8NAvJa4I2gF6OY8VZNeJZgUOfFwmorLe7XipfXcK5EOeewZdJtNs0FImjNzEbnZDdQX8J8ggmA+khgu+3imU4z9yHfjb2ys4EqT0S+1nkGPR5ZluhTBvzaXPiDiFqXnv3kUNE8MmXQWu1aSq7UpKnqLv9tJvSnkccX416TQj3HRUFvmO7pF5ZPwG7dovKcJudyD/5imjs1Xz8d83Yl9WpTWkSKEGdnAXw6ZCz9aNIaEHO+nZ2Bgun3tq8q5b/simrzuALMc+OpTfaX990OMwQCQMd6fwBfy1VwHmpNi+5e1GbYvauTzXG7cyjIKL1+60UyJdsdgVJffQB0c3R/TSdlUAAABOwAt84+bbv0mGlTIRz5HOtGBRYKx8zhMMtppdJ5JBdoOu483CntPnuAk7M+JZ+Q1RUkuWLflsYctpvzkq0RITZHHyNxhGuXViLuCe5D3eCWK349YUNswQBOBtAx8ClU6oF8v6Dkxc0bCugwZXfPYoELN2iGxONEiHZ0a7VXpQ0B5wYbQyMglFRDeCQu8okM+sISBWiI4nJgHuK8hSu/tkq0qAleqzcqT131lEWn7GOmEutpnXuO6fauykQmOdWlX9+PlSSSn438xh7smTXHzbfwigSFDi/ldcirOYGSJrgrr1xi9XKut19W6DAIT7+S2I1CPyVq8ati+hcR2XAplr0D3p2XPgRQaD6GcOBTNn/6SSMX/mwrSxuybd8hc8q5qT8Bo1c3Sj1uIujavfoSySIOCDVMOxBbwj4KAri4t4kkRb+U0TuLm3P4VG1vQHma/EnZEjm6uhXhp73bOLDFYOMQH2nHfyypKTUasSeGw+AGd9cNKyY6OSv3EG6MnxcBFWw25DQP2KL6eFWt8mXv8pVxp8esOEyR7mQ3LjoKxGFWfP1M52xGIrNsw029ACq4i43gYgbc5r03b93W8FeK4HqcsngBTO3vvNEy+nnbEsJTU6jnwlVjuEToo5ixVADHTIpiMX3XBbz/AaFeKj0/vsTo5x7U6BAQgq8j1oy/DLsD3sn9j/orCIMYaSQMNcp5iheL+IvqCAvGgPwhb+Fgf9d3ixRaMNoP92BEptArkCY0A38n1QLJMugg7m5CTtV+oq8T7SuQzFdf2vgdH8WKIlXA4Tzz7wAqEn5tkt/11Yg07zKjaL2sCul0jgv3nnsjJUWI15gXJB4OexXi5mVBOJ0+5CzzqjNIipJtVsZ9VGImJZIU+c1LeAYWmL8G13uUKwIYdcfGD7YBzO4pRj5sb941xfIywBtAMKWRnjhgIQgAu+kyxpAVXGGBiMcdHEtwMUkC6E3kAI77X/eh0YbQOFMVclOockRuGo2zM5MdPPMZlfD1APChNzINdOhNYgPoFrpiuacgBsPXpS3iCphiD15Z2x3MC/30bTBAdQPQukL+xSrlT/H4xJaG9IRgG2hoIg152pQBljIEg39ZElSJfhkIT4EAAAAAAAAA9KkiwPKZwt40PliZfY1yvPZe9bj0XGsAtFAZktPT8RSMbrreaPUjdKQzhMeR1xI6bFzhuF9bKYUCXhWTD4A5+sO5lG2SyqCWyfmQYsxgEdMRT9te9kEGRLpXVVb0BU7aEfxYA9IAWlI1maNs9i9yjZRzspN4A20RCj3aPq1g2GCyf8jhJAbXMLW2DcTwLPA/rkQVLPszgOiAw6z5guIXfbh7uuPTC7Nkax/2KDllWNQYa+VA0kS4jHRpzSRx4r8kB1beXqfXrEOjwSx73mFF/TQXSwMWm3q5yI89P8zQ+0+AF5uC6jCjfdapQDhAgdBQMqbdaMIkYhIhcRAIrf24pe3m2AEo14sWmereK4HOp3t09/0Qlju8yO6jJLoCJr9u+6vkjqBIolnmapN45Wmk67c9jWtsa0miFcAoMYD2eZncAB0ModKLpZOnQf4q7qi5i4tzZhhOsEbZEDsNcZ32KGeJByOxu8tCrIJ5Iclh3lDwdT1sgRCV28RpFz9A6txKBr/LvMRhRI/u/s89fZ8ANRo5PquIl9JgnOwdxyV+WaGDgZipfN4vfkWWl+9WHzrvFX1S0bhvwgfvP5yZvaRsNvfvVm5uwe+qYB/ZNd7VjzS39uZpQFswlhxV/xRx+EW7UKcRPmNqfD/B4+eS82fsfeUJfSxfOnyY+rBGB3ugm3oDmomO6XLHv2UUHTis8x7+LfpQO3OogAXM5RJgjuXMRUK7FfJ0PTPlBNIT8LoQ0jHudPvL0p33PgCHiymds+nGqpni3yYysbAQkyK8tJjkFFly1NqndG8EBMUMI8EAS1+Z9vUzsQ9M7SuVyvFGOeRvhI4WGbhIrAAZVXpEApIwWjgfslhCpuIfSndPEjVfxJjoAAx5cBiwTxfpEk4eJJXo6mWCn4DODA8dv4RIGFmoABdO/b6nZBBZP0GESSIqunqDOb/bcoURJTD0GNk0FoMlXcLLDANhDZCRlUDDr8pOfQ9OQ+AarfJ6mWEk5L7x9VwfL95Wn50PQnk4tPWH36Rj9tv1VGi0edICyNiuw7vt2fY3ETqdVZYGN5njp4/E8+1ZsTo+HBolTIL6uSLiofJ0K05jQrTj1Sllke+5ojP4gnWOHPNPNj9t98bx3BqhXfp5/jStKkVKX1GGrKVoJ8pILX77vG3F1I3ZWXM57ClhN26Ea0rN4ZgVUlWyEkqIKyFIyluqtP6cwnzFHG/6ejSj99iRvTz/T5WxeCkb6336rHknhafzdtmCSkgqoLSrozrTgif3DWL7TZS4HOzUzfmhiNmLezip38mfiX3A8nIio66Vke/cKNxTn1toOah4NVi0U2hPpCMY07W2rcjWuHkIvU7Z7CuQWGz2uq9Z4DwZ/8BJQfGRqORwrD99tCSoa24542bHPh03qTulgqseCBKcCJai6X8AUAAAAAAAAA==",
+        "height": 8802
+      }
+    }
+  },
+  "analysisUTCTimestamp": "2026-05-15T09:29:24.811Z"
+}

--- a/tmp/perf-20260515/psi-clients_ekodev.json
+++ b/tmp/perf-20260515/psi-clients_ekodev.json
@@ -1,0 +1,6225 @@
+{
+  "captchaResult": "CAPTCHA_NOT_NEEDED",
+  "kind": "pagespeedonline#result",
+  "id": "https://www.ocobo.co/clients/ekodev",
+  "loadingExperience": {
+    "initial_url": "https://www.ocobo.co/clients/ekodev"
+  },
+  "lighthouseResult": {
+    "requestedUrl": "https://www.ocobo.co/clients/ekodev",
+    "finalUrl": "https://www.ocobo.co/clients/ekodev",
+    "mainDocumentUrl": "https://www.ocobo.co/clients/ekodev",
+    "finalDisplayedUrl": "https://www.ocobo.co/clients/ekodev",
+    "lighthouseVersion": "13.0.1",
+    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+    "fetchTime": "2026-05-15T09:30:16.362Z",
+    "environment": {
+      "networkUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36",
+      "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+      "benchmarkIndex": 467
+    },
+    "runWarnings": [],
+    "configSettings": {
+      "emulatedFormFactor": "mobile",
+      "formFactor": "mobile",
+      "locale": "en-US",
+      "onlyCategories": [
+        "performance"
+      ],
+      "channel": "lr"
+    },
+    "audits": {
+      "unsized-images": {
+        "id": "unsized-images",
+        "title": "Image elements do not have explicit `width` and `height`",
+        "description": "Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [
+            {
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"ekodev\" loading=\"eager\" decoding=\"async\" fetchpriority=\"high\" class=\"h_10 w_auto obj-f_contain d_block\"\u003e",
+                "lhId": "1-2-IMG",
+                "type": "node",
+                "boundingRect": {
+                  "width": 113,
+                  "right": 161,
+                  "top": 532,
+                  "height": 44,
+                  "left": 47,
+                  "bottom": 576
+                },
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,0,DIV,1,HEADER,1,DIV,0,DIV,0,IMG",
+                "nodeLabel": "ekodev",
+                "selector": "header.d_flex \u003e div.d_flex \u003e div.bg_ocobo.dark \u003e img.h_10"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png"
+            },
+            {
+              "node": {
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "path": "2,HTML,1,BODY,0,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "lhId": "1-0-IMG",
+                "type": "node",
+                "boundingRect": {
+                  "top": 37,
+                  "width": 134,
+                  "right": 167,
+                  "height": 40,
+                  "left": 33,
+                  "bottom": 77
+                },
+                "nodeLabel": "Ocobo",
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all"
+              },
+              "url": "https://www.ocobo.co/logo-ocobo.png"
+            }
+          ],
+          "headings": [
+            {
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "bootup-time": {
+        "id": "bootup-time",
+        "title": "JavaScript execution time",
+        "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to reduce Javascript execution time](https://developer.chrome.com/docs/lighthouse/performance/bootup-time/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "1.1 s",
+        "metricSavings": {
+          "TBT": 250
+        },
+        "details": {
+          "sortedBy": [
+            "total"
+          ],
+          "summary": {
+            "wastedMs": 1129.3524000000004
+          },
+          "type": "table",
+          "items": [
+            {
+              "total": 308.53680000000008,
+              "scripting": 216.86760000000012,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "scriptParseCompile": 21.674400000000002
+            },
+            {
+              "scripting": 146.34840000000054,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "scriptParseCompile": 139.1052,
+              "total": 303.6384000000005
+            },
+            {
+              "scripting": 269.5487999999998,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "scriptParseCompile": 10.461599999999999,
+              "total": 301.22879999999981
+            },
+            {
+              "total": 299.73720000000026,
+              "scriptParseCompile": 0,
+              "scripting": 41.77680000000003,
+              "url": "Unattributable"
+            },
+            {
+              "total": 212.43,
+              "scripting": 98.498400000000018,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "scriptParseCompile": 107.09039999999999
+            },
+            {
+              "total": 149.64,
+              "scripting": 4.0295999999999976,
+              "url": "https://www.ocobo.co/clients/ekodev",
+              "scriptParseCompile": 2.4899999999999989
+            },
+            {
+              "scripting": 53.810400000000037,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "scriptParseCompile": 17.6508,
+              "total": 76.915200000000041
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Total CPU Time",
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "total"
+            },
+            {
+              "key": "scripting",
+              "valueType": "ms",
+              "granularity": 1,
+              "label": "Script Evaluation"
+            },
+            {
+              "label": "Script Parse",
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "scriptParseCompile"
+            }
+          ]
+        },
+        "numericValue": 1129.3524000000004,
+        "numericUnit": "millisecond"
+      },
+      "lcp-breakdown-insight": {
+        "id": "lcp-breakdown-insight",
+        "title": "LCP breakdown",
+        "description": "Each [subpart has specific improvement strategies](https://developer.chrome.com/docs/performance/insights/lcp-breakdown). Ideally, most of the LCP time should be spent on loading the resources, not within delays.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "items": [
+                {
+                  "subpart": "timeToFirstByte",
+                  "duration": 4.335,
+                  "label": "Time to first byte"
+                },
+                {
+                  "duration": 2181.013,
+                  "subpart": "elementRenderDelay",
+                  "label": "Element render delay"
+                }
+              ],
+              "headings": [
+                {
+                  "label": "Subpart",
+                  "valueType": "text",
+                  "key": "label"
+                },
+                {
+                  "valueType": "ms",
+                  "key": "duration",
+                  "label": "Duration"
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark fs_4xl md:fs_5xl lg:fs_6xl …\"\u003e",
+              "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,0,DIV,1,HEADER,0,DIV,0,H1",
+              "lhId": "page-0-H1",
+              "type": "node",
+              "boundingRect": {
+                "width": 380,
+                "right": 396,
+                "top": 165,
+                "left": 16,
+                "bottom": 438,
+                "height": 274
+              },
+              "nodeLabel": "Accompagner la création d'une business unit durabilité : comment ekodev a struc…",
+              "selector": "div \u003e header.d_flex \u003e div.lg:w_2/3 \u003e h1.text"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "unminified-javascript": {
+        "id": "unminified-javascript",
+        "title": "Minify JavaScript",
+        "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn how to minify JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unminified-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "opportunity",
+          "items": [],
+          "headings": [],
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "FCP": 0,
+              "LCP": 0
+            }
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsBytes": 0,
+          "overallSavingsMs": 0
+        },
+        "warnings": [],
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "main-thread-tasks": {
+        "id": "main-thread-tasks",
+        "title": "Tasks",
+        "description": "Lists the toplevel main thread tasks that executed during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "startTime": 1278.712,
+              "duration": 18.949
+            },
+            {
+              "duration": 12.508,
+              "startTime": 1409.102
+            },
+            {
+              "duration": 60.342,
+              "startTime": 1421.644
+            },
+            {
+              "startTime": 1483.296,
+              "duration": 8.64
+            },
+            {
+              "duration": 8.698,
+              "startTime": 1494.817
+            },
+            {
+              "startTime": 1510.236,
+              "duration": 61.015
+            },
+            {
+              "duration": 5.441,
+              "startTime": 1580.592
+            },
+            {
+              "duration": 38.442,
+              "startTime": 1587.067
+            },
+            {
+              "duration": 5.147,
+              "startTime": 1629.422
+            },
+            {
+              "duration": 14.58,
+              "startTime": 1645.157
+            },
+            {
+              "duration": 23.934,
+              "startTime": 1661.194
+            },
+            {
+              "duration": 9.405,
+              "startTime": 1687.727
+            },
+            {
+              "startTime": 1697.266,
+              "duration": 8.041
+            },
+            {
+              "duration": 5.169,
+              "startTime": 1705.424
+            },
+            {
+              "duration": 15.561,
+              "startTime": 1714.525
+            },
+            {
+              "startTime": 1730.428,
+              "duration": 12.054
+            },
+            {
+              "duration": 9.626,
+              "startTime": 1743.125
+            },
+            {
+              "startTime": 1755.037,
+              "duration": 8.365
+            },
+            {
+              "duration": 67.347,
+              "startTime": 1763.516
+            },
+            {
+              "duration": 22.457,
+              "startTime": 1844.425
+            },
+            {
+              "startTime": 1870.949,
+              "duration": 28.758
+            },
+            {
+              "duration": 11.156,
+              "startTime": 1900.799
+            },
+            {
+              "duration": 8.251,
+              "startTime": 1912.569
+            },
+            {
+              "startTime": 1920.879,
+              "duration": 6.973
+            },
+            {
+              "startTime": 1933.536,
+              "duration": 33.981
+            },
+            {
+              "duration": 8.42,
+              "startTime": 1968.35
+            },
+            {
+              "startTime": 1978.473,
+              "duration": 5.569
+            },
+            {
+              "startTime": 1984.064,
+              "duration": 6.915
+            },
+            {
+              "duration": 6.53,
+              "startTime": 1991.485
+            },
+            {
+              "duration": 5.259,
+              "startTime": 1998.71
+            },
+            {
+              "duration": 6.555,
+              "startTime": 2004.085
+            },
+            {
+              "duration": 6.617,
+              "startTime": 2010.669
+            },
+            {
+              "startTime": 2017.295,
+              "duration": 6.784
+            },
+            {
+              "duration": 5.679,
+              "startTime": 2024.119
+            },
+            {
+              "duration": 5.48,
+              "startTime": 2029.807
+            },
+            {
+              "startTime": 2035.294,
+              "duration": 5.706
+            },
+            {
+              "startTime": 2041.02,
+              "duration": 5.48
+            },
+            {
+              "duration": 5.42,
+              "startTime": 2046.508
+            },
+            {
+              "startTime": 2051.935,
+              "duration": 5.266
+            },
+            {
+              "startTime": 2057.23,
+              "duration": 13.587
+            },
+            {
+              "duration": 5.157,
+              "startTime": 2070.952
+            },
+            {
+              "duration": 5.155,
+              "startTime": 2076.853
+            },
+            {
+              "duration": 83.673,
+              "startTime": 2082.062
+            },
+            {
+              "duration": 11.614,
+              "startTime": 2165.775
+            },
+            {
+              "startTime": 2182.118,
+              "duration": 7.685
+            },
+            {
+              "duration": 8.08,
+              "startTime": 2189.858
+            },
+            {
+              "duration": 68.318,
+              "startTime": 2198.162
+            },
+            {
+              "startTime": 2280.557,
+              "duration": 5.515
+            },
+            {
+              "startTime": 2286.145,
+              "duration": 7.439
+            },
+            {
+              "duration": 5.27,
+              "startTime": 2293.597
+            },
+            {
+              "startTime": 2298.873,
+              "duration": 5.453
+            },
+            {
+              "duration": 5.318,
+              "startTime": 2304.444
+            },
+            {
+              "duration": 5.225,
+              "startTime": 2310.149
+            },
+            {
+              "duration": 6.045,
+              "startTime": 2315.412
+            },
+            {
+              "duration": 5.966,
+              "startTime": 2323.917
+            },
+            {
+              "duration": 87.456,
+              "startTime": 2333.487
+            },
+            {
+              "startTime": 2422.932,
+              "duration": 23.712
+            },
+            {
+              "duration": 15.909,
+              "startTime": 2452.124
+            },
+            {
+              "duration": 14.983,
+              "startTime": 2469.818
+            },
+            {
+              "startTime": 2485.154,
+              "duration": 7.744
+            },
+            {
+              "startTime": 2496.315,
+              "duration": 36.279
+            },
+            {
+              "duration": 9.873,
+              "startTime": 2533.727
+            },
+            {
+              "startTime": 2548.775,
+              "duration": 12.756
+            },
+            {
+              "duration": 27.398,
+              "startTime": 2562.719
+            },
+            {
+              "duration": 6.7,
+              "startTime": 2591.121
+            },
+            {
+              "duration": 106.664,
+              "startTime": 2597.955
+            },
+            {
+              "duration": 22.691,
+              "startTime": 2708.1
+            },
+            {
+              "duration": 12.753,
+              "startTime": 2731.878
+            },
+            {
+              "startTime": 2744.962,
+              "duration": 12.774
+            },
+            {
+              "duration": 96.913,
+              "startTime": 3776.158
+            },
+            {
+              "startTime": 3873.449,
+              "duration": 5.148
+            },
+            {
+              "startTime": 3880.759,
+              "duration": 7.473
+            }
+          ],
+          "headings": [
+            {
+              "granularity": 1,
+              "label": "Start Time",
+              "key": "startTime",
+              "valueType": "ms"
+            },
+            {
+              "label": "End Time",
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "duration"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "lcp-discovery-insight": {
+        "id": "lcp-discovery-insight",
+        "title": "LCP request discovery",
+        "description": "[Optimize LCP](https://developer.chrome.com/docs/performance/insights/lcp-discovery) by making the LCP image discoverable from the HTML immediately, and avoiding lazy-loading",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "metrics": {
+        "id": "metrics",
+        "title": "Metrics",
+        "description": "Collects all available metrics.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "observedLargestContentfulPaintAllFrames": 2185,
+              "observedLastVisualChange": 1941,
+              "totalBlockingTime": 199,
+              "observedFirstVisualChange": 189,
+              "observedTraceEndTs": 36019963200,
+              "observedTraceEnd": 5190,
+              "observedCumulativeLayoutShiftMainFrame": 0.002315,
+              "observedTimeOriginTs": 36014773287,
+              "observedLargestContentfulPaintAllFramesTs": 36016958635,
+              "observedTimeOrigin": 0,
+              "observedFirstContentfulPaintTs": 36016263797,
+              "observedSpeedIndex": 1511,
+              "observedLargestContentfulPaint": 2185,
+              "cumulativeLayoutShiftMainFrame": 0.002315,
+              "observedFirstContentfulPaint": 1491,
+              "observedFirstPaintTs": 36016263797,
+              "observedNavigationStartTs": 36014773287,
+              "observedDomContentLoaded": 1504,
+              "interactive": 10599,
+              "observedSpeedIndexTs": 36016284342,
+              "speedIndex": 4072,
+              "observedFirstContentfulPaintAllFramesTs": 36016263797,
+              "observedLargestContentfulPaintTs": 36016958635,
+              "observedCumulativeLayoutShift": 0.002315,
+              "observedDomContentLoadedTs": 36016277077,
+              "cumulativeLayoutShift": 0.002315,
+              "observedNavigationStart": 0,
+              "timeToFirstByte": 601,
+              "largestContentfulPaint": 8028,
+              "observedLoadTs": 36016693539,
+              "observedFirstContentfulPaintAllFrames": 1491,
+              "observedFirstVisualChangeTs": 36014962287,
+              "maxPotentialFID": 128,
+              "observedLoad": 1920,
+              "observedLastVisualChangeTs": 36016714287,
+              "firstContentfulPaint": 1801,
+              "observedFirstPaint": 1491
+            },
+            {
+              "lcpInvalidated": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 10599,
+        "numericUnit": "millisecond"
+      },
+      "inp-breakdown-insight": {
+        "id": "inp-breakdown-insight",
+        "title": "INP breakdown",
+        "description": "Start investigating [how to improve INP](https://developer.chrome.com/docs/performance/insights/inp-breakdown) by looking at the longest subpart.",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "script-treemap-data": {
+        "id": "script-treemap-data",
+        "title": "Script Treemap Data",
+        "description": "Used for treemap app",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "treemap-data",
+          "nodes": [
+            {
+              "children": [
+                {
+                  "name": "(inline) window.dataLaye…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 298
+                },
+                {
+                  "name": "(inline) window.AGO = {\n…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 631
+                },
+                {
+                  "resourceBytes": 592,
+                  "unusedBytes": 0,
+                  "name": "(inline) ((storageKey2, …"
+                },
+                {
+                  "unusedBytes": 0,
+                  "name": "(inline) window.__reactR…",
+                  "resourceBytes": 520
+                },
+                {
+                  "unusedBytes": 0,
+                  "name": "(inline) window.__reactR…",
+                  "resourceBytes": 16537
+                },
+                {
+                  "unusedBytes": 0,
+                  "name": "(inline) window.__reactR…",
+                  "resourceBytes": 53
+                },
+                {
+                  "resourceBytes": 8723,
+                  "unusedBytes": 0,
+                  "name": "(inline) ;\nimport * as r…"
+                }
+              ],
+              "name": "https://www.ocobo.co/clients/ekodev",
+              "encodedBytes": 4915,
+              "resourceBytes": 27354
+            },
+            {
+              "unusedBytes": 12049,
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "encodedBytes": 4215,
+              "resourceBytes": 17494
+            },
+            {
+              "resourceBytes": 2125,
+              "encodedBytes": 581,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "unusedBytes": 0
+            },
+            {
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "unusedBytes": 204200,
+              "resourceBytes": 471691,
+              "encodedBytes": 156441
+            },
+            {
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "unusedBytes": 46367,
+              "resourceBytes": 108995,
+              "encodedBytes": 42586
+            },
+            {
+              "resourceBytes": 78059,
+              "encodedBytes": 26369,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "unusedBytes": 35974
+            },
+            {
+              "encodedBytes": 27533,
+              "resourceBytes": 97992,
+              "unusedBytes": 56996,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            },
+            {
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "unusedBytes": 36142,
+              "resourceBytes": 72608,
+              "encodedBytes": 25121
+            },
+            {
+              "resourceBytes": 9792,
+              "encodedBytes": 3944,
+              "name": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "unusedBytes": 763
+            },
+            {
+              "name": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "unusedBytes": 70219,
+              "resourceBytes": 125385,
+              "encodedBytes": 43334
+            },
+            {
+              "encodedBytes": 854,
+              "resourceBytes": 927,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js"
+            },
+            {
+              "resourceBytes": 3192,
+              "encodedBytes": 1560,
+              "name": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "unusedBytes": 1084
+            },
+            {
+              "unusedBytes": 89,
+              "name": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "encodedBytes": 944,
+              "resourceBytes": 983
+            },
+            {
+              "name": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "unusedBytes": 6,
+              "resourceBytes": 141,
+              "encodedBytes": 80
+            },
+            {
+              "encodedBytes": 685,
+              "resourceBytes": 1284,
+              "unusedBytes": 467,
+              "name": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "unusedBytes": 809,
+              "resourceBytes": 15426,
+              "encodedBytes": 6232
+            },
+            {
+              "name": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "unusedBytes": 370,
+              "resourceBytes": 17234,
+              "encodedBytes": 5613
+            },
+            {
+              "encodedBytes": 1245,
+              "resourceBytes": 3070,
+              "unusedBytes": 738,
+              "name": "https://www.ocobo.co/assets/grid-DIis54sB.js"
+            },
+            {
+              "unusedBytes": 239,
+              "name": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "encodedBytes": 380,
+              "resourceBytes": 428
+            },
+            {
+              "encodedBytes": 336,
+              "resourceBytes": 410,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "unusedBytes": 65,
+              "resourceBytes": 525,
+              "encodedBytes": 450
+            },
+            {
+              "unusedBytes": 362,
+              "name": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "encodedBytes": 893,
+              "resourceBytes": 942
+            },
+            {
+              "name": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "unusedBytes": 0,
+              "resourceBytes": 349,
+              "encodedBytes": 277
+            },
+            {
+              "resourceBytes": 1866,
+              "encodedBytes": 766,
+              "name": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "encodedBytes": 276,
+              "resourceBytes": 348
+            },
+            {
+              "unusedBytes": 32006,
+              "name": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "encodedBytes": 20663,
+              "resourceBytes": 67398
+            },
+            {
+              "name": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "unusedBytes": 0,
+              "resourceBytes": 165,
+              "encodedBytes": 108
+            },
+            {
+              "name": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "unusedBytes": 0,
+              "resourceBytes": 206,
+              "encodedBytes": 134
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "encodedBytes": 33589,
+              "resourceBytes": 109016
+            },
+            {
+              "resourceBytes": 605,
+              "encodedBytes": 547,
+              "name": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "encodedBytes": 766,
+              "resourceBytes": 826
+            },
+            {
+              "encodedBytes": 343,
+              "resourceBytes": 404,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "unusedBytes": 0,
+              "resourceBytes": 490,
+              "encodedBytes": 426
+            },
+            {
+              "resourceBytes": 835,
+              "encodedBytes": 760,
+              "name": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "unusedBytes": 337
+            },
+            {
+              "resourceBytes": 68826,
+              "encodedBytes": 25833,
+              "name": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "unusedBytes": 47528
+            },
+            {
+              "unusedBytes": 31428,
+              "name": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "encodedBytes": 44668,
+              "resourceBytes": 133936
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "encodedBytes": 425,
+              "resourceBytes": 473
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "encodedBytes": 275,
+              "resourceBytes": 338
+            },
+            {
+              "encodedBytes": 387,
+              "resourceBytes": 435,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "unusedBytes": 0,
+              "resourceBytes": 312,
+              "encodedBytes": 249
+            },
+            {
+              "name": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "unusedBytes": 194,
+              "resourceBytes": 309,
+              "encodedBytes": 248
+            },
+            {
+              "encodedBytes": 645,
+              "resourceBytes": 1400,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/_main.(_lang).clients._slug-Cr9mkmTq.js"
+            },
+            {
+              "unusedBytes": 11379,
+              "name": "https://www.ocobo.co/assets/story-article--3yoMqOg.js",
+              "encodedBytes": 6369,
+              "resourceBytes": 24633
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/star-BI6vQnwF.js",
+              "encodedBytes": 592,
+              "resourceBytes": 656
+            },
+            {
+              "resourceBytes": 446,
+              "encodedBytes": 372,
+              "name": "https://www.ocobo.co/assets/zap-C3uzvT7-.js",
+              "unusedBytes": 0
+            },
+            {
+              "resourceBytes": 435,
+              "encodedBytes": 372,
+              "name": "https://www.ocobo.co/assets/chart-column-CxnbmN-k.js",
+              "unusedBytes": 0
+            },
+            {
+              "resourceBytes": 717,
+              "encodedBytes": 655,
+              "name": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "unusedBytes": 65
+            },
+            {
+              "resourceBytes": 302,
+              "encodedBytes": 228,
+              "name": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js",
+              "unusedBytes": 4
+            },
+            {
+              "name": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "unusedBytes": 4,
+              "resourceBytes": 1208,
+              "encodedBytes": 550
+            },
+            {
+              "name": "https://www.ocobo.co/assets/check-D95Zi0fi.js",
+              "unusedBytes": 0,
+              "resourceBytes": 303,
+              "encodedBytes": 242
+            },
+            {
+              "name": "https://www.ocobo.co/assets/LayoutPost-BT26K59V.js",
+              "unusedBytes": 483,
+              "resourceBytes": 2543,
+              "encodedBytes": 1261
+            },
+            {
+              "resourceBytes": 138685,
+              "encodedBytes": 51204,
+              "name": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "unusedBytes": 83667
+            },
+            {
+              "unusedBytes": 1829,
+              "name": "https://www.ocobo.co/assets/member-card-Bn7bfGBT.js",
+              "encodedBytes": 1237,
+              "resourceBytes": 2533
+            },
+            {
+              "resourceBytes": 605,
+              "encodedBytes": 558,
+              "name": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "unusedBytes": 65
+            },
+            {
+              "name": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "unusedBytes": 0,
+              "resourceBytes": 549,
+              "encodedBytes": 487
+            },
+            {
+              "resourceBytes": 69550,
+              "encodedBytes": 23529,
+              "name": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "unusedBytes": 28818
+            },
+            {
+              "encodedBytes": 156441,
+              "resourceBytes": 471691,
+              "unusedBytes": 335778,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "unusedBytes": 682,
+              "name": "https://www.ocobo.co/_vercel/insights/script.js",
+              "encodedBytes": 1227,
+              "resourceBytes": 2495
+            },
+            {
+              "resourceBytes": 12567,
+              "encodedBytes": 4688,
+              "name": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "unusedBytes": 6501
+            },
+            {
+              "encodedBytes": 4215,
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "encodedBytes": 581,
+              "resourceBytes": 2125
+            },
+            {
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "unusedBytes": 337253,
+              "resourceBytes": 587832,
+              "encodedBytes": 202942
+            },
+            {
+              "unusedBytes": 36205,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "encodedBytes": 26369,
+              "resourceBytes": 78059
+            },
+            {
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "unusedBytes": 73621,
+              "resourceBytes": 97992,
+              "encodedBytes": 27533
+            },
+            {
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "unusedBytes": 68120,
+              "resourceBytes": 108995,
+              "encodedBytes": 42586
+            },
+            {
+              "resourceBytes": 72608,
+              "encodedBytes": 25121,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "unusedBytes": 49494
+            },
+            {
+              "unusedBytes": 248156,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "encodedBytes": 202942,
+              "resourceBytes": 587832
+            }
+          ]
+        }
+      },
+      "duplicated-javascript-insight": {
+        "id": "duplicated-javascript-insight",
+        "title": "Duplicated JavaScript",
+        "description": "Remove large, [duplicate JavaScript modules](https://developer.chrome.com/docs/performance/insights/duplicated-javascript) from bundles to reduce unnecessary bytes consumed by network activity.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 0,
+            "type": "debugdata"
+          },
+          "type": "table",
+          "items": [],
+          "headings": [
+            {
+              "key": "source",
+              "valueType": "code",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "label": "Source"
+            },
+            {
+              "label": "Duplicated bytes",
+              "key": "wastedBytes",
+              "granularity": 10,
+              "subItemsHeading": {
+                "key": "sourceTransferBytes"
+              },
+              "valueType": "bytes"
+            }
+          ]
+        }
+      },
+      "max-potential-fid": {
+        "id": "max-potential-fid",
+        "title": "Max Potential First Input Delay",
+        "description": "The maximum potential First Input Delay that your users could experience is the duration of the longest task. [Learn more about the Maximum Potential First Input Delay metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-max-potential-fid/).",
+        "score": 0.9,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "130 ms",
+        "numericValue": 128,
+        "numericUnit": "millisecond"
+      },
+      "font-display-insight": {
+        "id": "font-display-insight",
+        "title": "Font display",
+        "description": "Consider setting [font-display](https://developer.chrome.com/docs/performance/insights/font-display) to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with [font metric overrides](https://developer.chrome.com/blog/font-fallbacks).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "type": "table",
+          "headings": [
+            {
+              "key": "url",
+              "valueType": "url",
+              "label": "URL"
+            },
+            {
+              "label": "Est Savings",
+              "key": "wastedMs",
+              "valueType": "ms"
+            }
+          ],
+          "skipSumming": [
+            "wastedMs"
+          ],
+          "items": []
+        }
+      },
+      "cumulative-layout-shift": {
+        "id": "cumulative-layout-shift",
+        "title": "Cumulative Layout Shift",
+        "description": "Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/articles/cls).",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "0.002",
+        "details": {
+          "items": [
+            {
+              "newEngineResultDiffered": false,
+              "cumulativeLayoutShiftMainFrame": 0.002315
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 0.002315,
+        "numericUnit": "unitless"
+      },
+      "unused-javascript": {
+        "id": "unused-javascript",
+        "title": "Reduce unused JavaScript",
+        "description": "Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 465 KiB",
+        "metricSavings": {
+          "LCP": 1500,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 1500,
+          "overallSavingsBytes": 476145,
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 1500,
+              "FCP": 0
+            }
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [
+            {
+              "wastedBytes": 112602,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedPercent": 57.372344479375059,
+              "totalBytes": 196265
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedBytes": 111364,
+              "wastedPercent": 71.186009485023035,
+              "totalBytes": 156441
+            },
+            {
+              "totalBytes": 196265,
+              "wastedPercent": 42.2154629213789,
+              "wastedBytes": 82854,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "totalBytes": 156441,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedBytes": 67725,
+              "wastedPercent": 43.291052829076662
+            },
+            {
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "wastedBytes": 30035,
+              "wastedPercent": 60.328802682337667,
+              "totalBytes": 49785
+            },
+            {
+              "totalBytes": 42584,
+              "wastedPercent": 62.498279737602644,
+              "wastedBytes": 26614,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "totalBytes": 43330,
+              "wastedBytes": 24266,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "wastedPercent": 56.002711648123778
+            },
+            {
+              "totalBytes": 27533,
+              "wastedBytes": 20685,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "wastedPercent": 75.1296024165238
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "valueType": "url",
+              "subItemsHeading": {
+                "key": "source",
+                "valueType": "code"
+              },
+              "label": "URL"
+            },
+            {
+              "subItemsHeading": {
+                "key": "sourceBytes"
+              },
+              "label": "Transfer Size",
+              "key": "totalBytes",
+              "valueType": "bytes"
+            },
+            {
+              "key": "wastedBytes",
+              "valueType": "bytes",
+              "subItemsHeading": {
+                "key": "sourceWastedBytes"
+              },
+              "label": "Est Savings"
+            }
+          ],
+          "type": "opportunity"
+        },
+        "numericValue": 1500,
+        "numericUnit": "millisecond"
+      },
+      "network-requests": {
+        "id": "network-requests",
+        "title": "Network Requests",
+        "description": "Lists the network requests that were made during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "priority": "VeryHigh",
+              "resourceSize": 89117,
+              "mimeType": "text/html",
+              "finished": true,
+              "rendererStartTime": 0,
+              "transferSize": 16444,
+              "url": "https://www.ocobo.co/clients/ekodev",
+              "resourceType": "Document",
+              "statusCode": 200,
+              "networkEndTime": 1274.4660000056028,
+              "networkRequestTime": 4.3010000064969063,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "priority": "VeryHigh",
+              "resourceSize": 122090,
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "text/css",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1295.2560000047088,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "transferSize": 24572,
+              "rendererStartTime": 1291.1970000118017,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "resourceType": "Stylesheet",
+              "statusCode": 200,
+              "networkEndTime": 1402.2290000021458
+            },
+            {
+              "finished": true,
+              "mimeType": "image/png",
+              "priority": "Medium",
+              "resourceSize": 12266,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1296.0170000046492,
+              "statusCode": 200,
+              "networkEndTime": 1384.7530000060797,
+              "transferSize": 12760,
+              "rendererStartTime": 1291.5850000083447,
+              "resourceType": "Image",
+              "url": "https://www.ocobo.co/logo-ocobo.png"
+            },
+            {
+              "networkEndTime": 1394.9030000045896,
+              "statusCode": 200,
+              "transferSize": 29548,
+              "rendererStartTime": 1291.6810000017285,
+              "resourceType": "Image",
+              "url": "https://www.ocobo.co/images/partners/modern-revenue-club.png",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1298.1550000086427,
+              "entity": "ocobo.co",
+              "finished": true,
+              "mimeType": "image/png",
+              "priority": "Medium",
+              "resourceSize": 29045,
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "vercel-storage.com",
+              "finished": true,
+              "mimeType": "image/png",
+              "resourceSize": 11321,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 1384.6070000007749,
+              "resourceType": "Image",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png",
+              "transferSize": 11989,
+              "rendererStartTime": 1291.7720000073314,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1299.0600000098348
+            },
+            {
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1408.7260000035167,
+              "statusCode": 200,
+              "networkEndTime": 1462.5170000046492,
+              "transferSize": 157129,
+              "rendererStartTime": 1291.8580000028014,
+              "resourceType": "Script",
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "priority": "Low",
+              "resourceSize": 471691,
+              "sessionTargetType": "page",
+              "entity": "Google Tag Manager"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1408.7790000066161,
+              "networkEndTime": 1636.1340000033379,
+              "statusCode": 404,
+              "resourceType": "Script",
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "rendererStartTime": 1291.9230000078678,
+              "transferSize": 639,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 0,
+              "priority": "Low",
+              "entity": "Clearbit"
+            },
+            {
+              "entity": "Hubspot",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "resourceSize": 2125,
+              "statusCode": 200,
+              "networkEndTime": 1450.5930000022054,
+              "transferSize": 1642,
+              "rendererStartTime": 1292.1760000064969,
+              "resourceType": "Script",
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1408.8790000081062
+            },
+            {
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 17494,
+              "priority": "Low",
+              "entity": "GitHub",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1408.9230000078678,
+              "statusCode": 200,
+              "networkEndTime": 1446.3490000069141,
+              "resourceType": "Script",
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "rendererStartTime": 1292.3150000050664,
+              "transferSize": 5015
+            },
+            {
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 69556,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1299.1350000053644,
+              "statusCode": 200,
+              "networkEndTime": 1393.0440000072122,
+              "transferSize": 24117,
+              "rendererStartTime": 1292.4320000037551,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js"
+            },
+            {
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 927,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "finished": true,
+              "entity": "ocobo.co",
+              "networkRequestTime": 1301.1550000011921,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1292.5160000026226,
+              "transferSize": 1457,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "statusCode": 200,
+              "networkEndTime": 1384.1740000098944
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1674.0260000005364,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "transferSize": 43924,
+              "rendererStartTime": 1292.569000005722,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1305.081000007689,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 125397,
+              "priority": "High"
+            },
+            {
+              "networkEndTime": 1733.5230000019073,
+              "statusCode": 200,
+              "rendererStartTime": 1292.6140000075102,
+              "transferSize": 45260,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1305.195000000298,
+              "entity": "ocobo.co",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 133936,
+              "sessionTargetType": "page"
+            },
+            {
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 110060,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1305.2950000092387,
+              "statusCode": 200,
+              "networkEndTime": 1708.4340000003576,
+              "transferSize": 34184,
+              "rendererStartTime": 1292.6850000023842,
+              "url": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "resourceType": "Script"
+            },
+            {
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 991,
+              "statusCode": 200,
+              "networkEndTime": 1395.1870000064373,
+              "rendererStartTime": 1292.7310000061989,
+              "transferSize": 1517,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1305.3400000110269
+            },
+            {
+              "rendererStartTime": 1292.7840000092983,
+              "transferSize": 4522,
+              "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "resourceType": "Script",
+              "statusCode": 200,
+              "networkEndTime": 1626.7680000066757,
+              "networkRequestTime": 1305.4020000100136,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 9799,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1610.2420000061393,
+              "url": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "resourceType": "Script",
+              "rendererStartTime": 1292.8360000029206,
+              "transferSize": 2148,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1305.4580000042915,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 3192,
+              "priority": "High"
+            },
+            {
+              "entity": "ocobo.co",
+              "resourceSize": 141,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "rendererStartTime": 1292.9350000098348,
+              "transferSize": 672,
+              "statusCode": 200,
+              "networkEndTime": 1383.6100000068545,
+              "networkRequestTime": 1305.4930000007153,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1385.6050000041723,
+              "transferSize": 1272,
+              "rendererStartTime": 1292.984999999404,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1305.5430000051856,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 1284
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1305.5800000056624,
+              "statusCode": 200,
+              "networkEndTime": 1395.6400000080466,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "transferSize": 6809,
+              "rendererStartTime": 1293.0320000052452,
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceSize": 15426,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co"
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1646.0950000062585,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "rendererStartTime": 1293.0760000050068,
+              "transferSize": 6205,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1305.6160000041127,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 17234,
+              "priority": "High"
+            },
+            {
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 3070,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1305.6620000079274,
+              "networkEndTime": 1385.7380000054836,
+              "statusCode": 200,
+              "rendererStartTime": 1293.1310000047088,
+              "transferSize": 1835,
+              "url": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "resourceType": "Script"
+            },
+            {
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 428,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "finished": true,
+              "entity": "ocobo.co",
+              "networkRequestTime": 1305.6990000084043,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1293.179000005126,
+              "transferSize": 953,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "networkEndTime": 1633.1930000036955,
+              "statusCode": 200
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1513.6350000053644,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "transferSize": 937,
+              "rendererStartTime": 1293.2400000095367,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1306.8550000041723,
+              "entity": "ocobo.co",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceSize": 410,
+              "priority": "High",
+              "sessionTargetType": "page"
+            },
+            {
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 525,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1307.0200000032783,
+              "statusCode": 200,
+              "networkEndTime": 1540.749000005424,
+              "rendererStartTime": 1293.2860000059009,
+              "transferSize": 1047,
+              "url": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "resourceType": "Script"
+            },
+            {
+              "networkRequestTime": 1307.0850000008941,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "rendererStartTime": 1293.3440000042319,
+              "transferSize": 1471,
+              "statusCode": 200,
+              "networkEndTime": 1617.5710000023246,
+              "resourceSize": 942,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "entity": "ocobo.co"
+            },
+            {
+              "networkEndTime": 1385.4150000065565,
+              "statusCode": 200,
+              "rendererStartTime": 1293.3900000080466,
+              "transferSize": 879,
+              "url": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1307.1190000101924,
+              "entity": "ocobo.co",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "priority": "High",
+              "resourceSize": 349,
+              "sessionTargetType": "page"
+            },
+            {
+              "transferSize": 1367,
+              "rendererStartTime": 1293.4369999989867,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "networkEndTime": 1631.0830000042915,
+              "statusCode": 200,
+              "networkRequestTime": 1307.1970000043511,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 1866,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "finished": true
+            },
+            {
+              "resourceSize": 348,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "networkRequestTime": 1307.2510000094771,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "rendererStartTime": 1293.4880000054836,
+              "transferSize": 870,
+              "statusCode": 200,
+              "networkEndTime": 1384.9910000115633
+            },
+            {
+              "networkRequestTime": 1307.2860000059009,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "transferSize": 21255,
+              "rendererStartTime": 1293.5640000030398,
+              "statusCode": 200,
+              "networkEndTime": 1387.8120000064373,
+              "sessionTargetType": "page",
+              "resourceSize": 67398,
+              "priority": "High",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "entity": "ocobo.co"
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1384.5180000066757,
+              "rendererStartTime": 1293.624000005424,
+              "transferSize": 704,
+              "url": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1307.3300000056624,
+              "entity": "ocobo.co",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 165,
+              "sessionTargetType": "page"
+            },
+            {
+              "networkEndTime": 1386.7070000097156,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "transferSize": 1130,
+              "rendererStartTime": 1293.6710000038147,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1307.3780000060797,
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 605,
+              "priority": "High"
+            },
+            {
+              "networkEndTime": 1601.8440000042319,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "transferSize": 1345,
+              "rendererStartTime": 1293.7460000067949,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1307.4310000017285,
+              "entity": "ocobo.co",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceSize": 826,
+              "priority": "High",
+              "sessionTargetType": "page"
+            },
+            {
+              "transferSize": 932,
+              "rendererStartTime": 1293.8200000077486,
+              "url": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "resourceType": "Script",
+              "networkEndTime": 1387.5310000032187,
+              "statusCode": 200,
+              "networkRequestTime": 1307.4699999988079,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "resourceSize": 404,
+              "sessionTargetType": "page",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "networkRequestTime": 1307.5270000100136,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "transferSize": 1011,
+              "rendererStartTime": 1293.874000005424,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "statusCode": 200,
+              "networkEndTime": 1601.4470000043511,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 490,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "entity": "ocobo.co"
+            },
+            {
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 206,
+              "priority": "High",
+              "statusCode": 200,
+              "networkEndTime": 1384.3390000090003,
+              "url": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "resourceType": "Script",
+              "rendererStartTime": 1293.9519999995828,
+              "transferSize": 729,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1307.5730000063777
+            },
+            {
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 835,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1309.4640000090003,
+              "statusCode": 200,
+              "networkEndTime": 1616.8630000054836,
+              "transferSize": 1358,
+              "rendererStartTime": 1294.0040000081062,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js"
+            },
+            {
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1309.5220000073314,
+              "networkEndTime": 1388.2470000013709,
+              "statusCode": 200,
+              "rendererStartTime": 1294.0630000010133,
+              "transferSize": 26415,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "priority": "High",
+              "resourceSize": 68826,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co"
+            },
+            {
+              "priority": "High",
+              "resourceSize": 473,
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "networkRequestTime": 1309.5670000091195,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1294.1530000045896,
+              "transferSize": 997,
+              "url": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "resourceType": "Script",
+              "networkEndTime": 1594.929000005126,
+              "statusCode": 200
+            },
+            {
+              "resourceSize": 338,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 1309.6130000054836,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "url": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "resourceType": "Script",
+              "transferSize": 855,
+              "rendererStartTime": 1294.2200000062585,
+              "networkEndTime": 1611.57800000906,
+              "statusCode": 200
+            },
+            {
+              "networkEndTime": 1622.637000001967,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "transferSize": 964,
+              "rendererStartTime": 1294.2750000059605,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1309.6570000052452,
+              "entity": "ocobo.co",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 435,
+              "priority": "High",
+              "sessionTargetType": "page"
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1624.9420000016689,
+              "url": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "resourceType": "Script",
+              "rendererStartTime": 1294.3330000042915,
+              "transferSize": 840,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1309.7010000050068,
+              "entity": "ocobo.co",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 312,
+              "priority": "High",
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 309,
+              "networkEndTime": 1384.4400000050664,
+              "statusCode": 200,
+              "rendererStartTime": 1294.3880000039935,
+              "transferSize": 834,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1309.7520000040531
+            },
+            {
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 1400,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "transferSize": 1246,
+              "rendererStartTime": 1294.4350000023842,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/_main.(_lang).clients._slug-Cr9mkmTq.js",
+              "networkEndTime": 1561.2680000066757,
+              "statusCode": 200,
+              "networkRequestTime": 1309.7939999997616,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "transferSize": 6967,
+              "rendererStartTime": 1294.5020000040531,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/story-article--3yoMqOg.js",
+              "networkEndTime": 1660.1890000030398,
+              "statusCode": 200,
+              "networkRequestTime": 1309.847000002861,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "resourceSize": 24635,
+              "sessionTargetType": "page",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "priority": "High",
+              "resourceSize": 549,
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "networkRequestTime": 1309.8940000087023,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "transferSize": 1077,
+              "rendererStartTime": 1294.5620000064373,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "statusCode": 200,
+              "networkEndTime": 1386.1210000067949
+            },
+            {
+              "entity": "ocobo.co",
+              "resourceSize": 1217,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "resourceType": "Script",
+              "rendererStartTime": 1294.6110000088811,
+              "transferSize": 1132,
+              "statusCode": 200,
+              "networkEndTime": 1627.2040000036359,
+              "networkRequestTime": 1309.9370000064373,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1773.5040000081062,
+              "url": "https://www.ocobo.co/assets/star-BI6vQnwF.js",
+              "resourceType": "Script",
+              "transferSize": 1176,
+              "rendererStartTime": 1294.6550000086427,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1309.9890000000596,
+              "entity": "ocobo.co",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceSize": 656,
+              "priority": "High",
+              "sessionTargetType": "page"
+            },
+            {
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/zap-C3uzvT7-.js",
+              "transferSize": 965,
+              "rendererStartTime": 1294.707000002265,
+              "networkEndTime": 1606.7600000053644,
+              "statusCode": 200,
+              "networkRequestTime": 1312.4360000044107,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "resourceSize": 446,
+              "priority": "High",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true
+            },
+            {
+              "entity": "ocobo.co",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 435,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 1627.6130000054836,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/chart-column-CxnbmN-k.js",
+              "transferSize": 963,
+              "rendererStartTime": 1294.7730000019073,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1312.4970000088215
+            },
+            {
+              "networkEndTime": 1405.0020000040531,
+              "statusCode": 200,
+              "transferSize": 1240,
+              "rendererStartTime": 1294.8250000104308,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1312.5590000078082,
+              "entity": "ocobo.co",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "priority": "High",
+              "resourceSize": 717,
+              "sessionTargetType": "page"
+            },
+            {
+              "transferSize": 829,
+              "rendererStartTime": 1294.873000010848,
+              "url": "https://www.ocobo.co/assets/french-text-uaZ49VSH.js",
+              "resourceType": "Script",
+              "statusCode": 200,
+              "networkEndTime": 1513.3870000094175,
+              "networkRequestTime": 1312.6000000089407,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "resourceSize": 302,
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true
+            },
+            {
+              "url": "https://www.ocobo.co/assets/check-D95Zi0fi.js",
+              "resourceType": "Script",
+              "rendererStartTime": 1294.929000005126,
+              "transferSize": 827,
+              "networkEndTime": 1384.0170000046492,
+              "statusCode": 200,
+              "networkRequestTime": 1312.6499999985099,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "resourceSize": 303,
+              "priority": "High",
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "finished": true
+            },
+            {
+              "networkRequestTime": 1312.6960000023246,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1294.9930000081658,
+              "transferSize": 1845,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/LayoutPost-BT26K59V.js",
+              "statusCode": 200,
+              "networkEndTime": 1509.7230000048876,
+              "priority": "High",
+              "resourceSize": 2543,
+              "sessionTargetType": "page",
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1312.7320000082254,
+              "statusCode": 200,
+              "networkEndTime": 1565.2620000094175,
+              "resourceType": "Script",
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js",
+              "transferSize": 51797,
+              "rendererStartTime": 1295.0410000085831,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 142638,
+              "priority": "High",
+              "entity": "ocobo.co"
+            },
+            {
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 2533,
+              "networkEndTime": 1531.9149999991059,
+              "statusCode": 200,
+              "rendererStartTime": 1295.0880000069737,
+              "transferSize": 1822,
+              "url": "https://www.ocobo.co/assets/member-card-Bn7bfGBT.js",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1312.7860000059009
+            },
+            {
+              "finished": true,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 605,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1312.8770000040531,
+              "statusCode": 200,
+              "networkEndTime": 1384.8650000020862,
+              "url": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "resourceType": "Script",
+              "transferSize": 1128,
+              "rendererStartTime": 1295.1490000039339
+            },
+            {
+              "entity": "ocobo.co",
+              "priority": "VeryHigh",
+              "resourceSize": 58256,
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "font/otf",
+              "rendererStartTime": 1428.8780000060797,
+              "transferSize": 39129,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+              "resourceType": "Font",
+              "statusCode": 200,
+              "networkEndTime": 1467.0530000030994,
+              "networkRequestTime": 1429.6550000011921,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "resourceSize": 31480,
+              "priority": "VeryHigh",
+              "mimeType": "font/woff",
+              "finished": true,
+              "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+              "resourceType": "Font",
+              "rendererStartTime": 1429.1300000026822,
+              "transferSize": 31977,
+              "statusCode": 200,
+              "networkEndTime": 1463.5240000113845,
+              "networkRequestTime": 1429.7300000041723,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "finished": true,
+              "mimeType": "font/otf",
+              "resourceSize": 57572,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1430.1560000032187,
+              "networkEndTime": 1661.0310000032187,
+              "statusCode": 200,
+              "resourceType": "Font",
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+              "transferSize": 38778,
+              "rendererStartTime": 1429.5720000043511
+            },
+            {
+              "statusCode": 200,
+              "networkEndTime": 1592.3480000048876,
+              "resourceType": "Font",
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf",
+              "rendererStartTime": 1429.8500000014901,
+              "transferSize": 40710,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1430.2450000047684,
+              "entity": "ocobo.co",
+              "finished": true,
+              "mimeType": "font/otf",
+              "resourceSize": 60228,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page"
+            },
+            {
+              "mimeType": "image/png",
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 354013,
+              "priority": "Low",
+              "entity": "vercel-storage.com",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1481.4450000077486,
+              "statusCode": 200,
+              "networkEndTime": 1572.1750000044703,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-avatar.png",
+              "resourceType": "Image",
+              "transferSize": 354683,
+              "rendererStartTime": 1480.6040000095963
+            },
+            {
+              "networkRequestTime": 1506.3270000070333,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "transferSize": 1996,
+              "rendererStartTime": 1505.8260000050068,
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "resourceType": "Stylesheet",
+              "statusCode": 200,
+              "networkEndTime": 1548.2090000063181,
+              "priority": "VeryHigh",
+              "resourceSize": 4371,
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "text/css",
+              "entity": "GitHub"
+            },
+            {
+              "finished": true,
+              "mimeType": "image/png",
+              "priority": "Low",
+              "resourceSize": 16667,
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1507.5120000094175,
+              "networkEndTime": 1547.8300000056624,
+              "statusCode": 200,
+              "rendererStartTime": 1507.0600000023842,
+              "transferSize": 17173,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "resourceType": "Image"
+            },
+            {
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "resourceType": "Script",
+              "transferSize": 27946,
+              "rendererStartTime": 1508.3379999995232,
+              "statusCode": 200,
+              "networkEndTime": 1543.9850000068545,
+              "networkRequestTime": 1508.7280000001192,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "entity": "Hubspot",
+              "resourceSize": 78203,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "resourceSize": 97992,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "entity": "Hubspot",
+              "networkRequestTime": 1508.9409999996424,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1508.5670000091195,
+              "transferSize": 29750,
+              "resourceType": "Script",
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "statusCode": 200,
+              "networkEndTime": 1567.6410000026226
+            },
+            {
+              "entity": "Hubspot",
+              "mimeType": "text/javascript",
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 109001,
+              "priority": "Low",
+              "networkEndTime": 1534.9180000051856,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "rendererStartTime": 1508.7700000032783,
+              "transferSize": 43679,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1509.0860000103712
+            },
+            {
+              "resourceType": "Script",
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "transferSize": 27210,
+              "rendererStartTime": 1508.9500000029802,
+              "statusCode": 200,
+              "networkEndTime": 1568.0580000057817,
+              "networkRequestTime": 1509.468000009656,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "resourceSize": 72678,
+              "priority": "Low",
+              "mimeType": "text/javascript",
+              "finished": true
+            },
+            {
+              "networkEndTime": 1644.0870000049472,
+              "statusCode": 204,
+              "resourceType": "Fetch",
+              "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65d0v9100339653za200zd9100339653&_p=1778837418057&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1517412233.1778837418&frm=0&pscdl=noapi&rcb=4&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115938465~115938469&dp=%2Fclients%2Fekodev&sid=1778837418&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&dt=Ocobo%20%C2%B7%20Accompagner%20la%20cr%C3%A9ation%20d%27une%20business%20unit%20durabilit%C3%A9%C2%A0%3A%20comment%20ekodev%20a%20structur%C3%A9%20son%20organisation%20commerciale%20et%20d%C3%A9ploy%C3%A9%20HubSpot&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1623",
+              "rendererStartTime": 1623.0980000048876,
+              "transferSize": 796,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 1625.8300000056624,
+              "entity": "Google Analytics",
+              "mimeType": "text/plain",
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 0,
+              "priority": "High"
+            },
+            {
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 135,
+              "mimeType": "application/json",
+              "finished": true,
+              "entity": "Hubspot",
+              "networkRequestTime": 1709.8660000041127,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 1709.2250000089407,
+              "transferSize": 1095,
+              "resourceType": "XHR",
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+              "statusCode": 200,
+              "networkEndTime": 1772.444000005722
+            },
+            {
+              "transferSize": 558,
+              "rendererStartTime": 1740.8480000048876,
+              "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+              "resourceType": "Fetch",
+              "statusCode": 200,
+              "networkEndTime": 1780.16400000453,
+              "networkRequestTime": 1741.6120000109076,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 5,
+              "mimeType": "text/plain",
+              "finished": true
+            },
+            {
+              "rendererStartTime": 1841.7180000022054,
+              "transferSize": 1712,
+              "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&isMobile=true",
+              "resourceType": "Fetch",
+              "statusCode": 200,
+              "networkEndTime": 1948.968000009656,
+              "networkRequestTime": 1842.3360000029206,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "entity": "Hubspot",
+              "priority": "High",
+              "resourceSize": 61,
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "application/json"
+            },
+            {
+              "networkEndTime": 1995.249000005424,
+              "statusCode": 200,
+              "rendererStartTime": 1919.0160000026226,
+              "transferSize": 1482,
+              "resourceType": "Image",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&t=Ocobo+%C2%B7+Accompagner+la+cr%C3%A9ation+d%27une+business+unit+durabilit%C3%A9%C2%A0%3A+comment+ekodev+a+structur%C3%A9+son+organisation+commerciale+et+d%C3%A9ploy%C3%A9+HubSpot&cts=1778837418567&vi=281d5f8dc9415ef31077dbdd1b865f92&nc=true&u=242475741.281d5f8dc9415ef31077dbdd1b865f92.1778837418564.1778837418564.1778837418564.1&b=242475741.1.1778837418564&cc=15",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1919.8339999988675,
+              "entity": "Hubspot",
+              "mimeType": "image/gif",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "resourceSize": 45
+            },
+            {
+              "mimeType": "image/gif",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "resourceSize": 35,
+              "entity": "Hubspot",
+              "protocol": "http/1.1",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 1977.6610000059009,
+              "networkEndTime": 2072.9150000065565,
+              "statusCode": 200,
+              "rendererStartTime": 1976.9640000015497,
+              "transferSize": 1021,
+              "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+              "resourceType": "Image"
+            },
+            {
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2184.3450000062585,
+              "networkEndTime": 2226.8100000023842,
+              "statusCode": 200,
+              "rendererStartTime": 2183.5520000010729,
+              "transferSize": 204717,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "resourceType": "Script",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "priority": "Low",
+              "resourceSize": 607831,
+              "sessionTargetType": "page",
+              "entity": "Hubspot"
+            },
+            {
+              "statusCode": 404,
+              "networkEndTime": 2420.2480000033975,
+              "resourceType": "Script",
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "rendererStartTime": 2184.7280000001192,
+              "transferSize": 639,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkRequestTime": 2186.2370000034571,
+              "entity": "Clearbit",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 0,
+              "priority": "Low",
+              "sessionTargetType": "page"
+            },
+            {
+              "transferSize": 856,
+              "rendererStartTime": 2185.0060000047088,
+              "resourceType": "Script",
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "statusCode": 304,
+              "networkEndTime": 2211.7530000060797,
+              "networkRequestTime": 2186.2990000024438,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "entity": "Hubspot",
+              "priority": "Low",
+              "resourceSize": 2125,
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "entity": "ocobo.co",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "priority": "Low",
+              "resourceSize": 2495,
+              "sessionTargetType": "page",
+              "statusCode": 200,
+              "networkEndTime": 2227.8410000056028,
+              "rendererStartTime": 2185.9380000010133,
+              "transferSize": 1868,
+              "url": "https://www.ocobo.co/_vercel/insights/script.js",
+              "resourceType": "Script",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2186.5680000036955
+            },
+            {
+              "url": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "resourceType": "Script",
+              "rendererStartTime": 2186.5410000085831,
+              "transferSize": 5314,
+              "statusCode": 200,
+              "networkEndTime": 2237.0720000043511,
+              "networkRequestTime": 2186.8910000100732,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "resourceSize": 12567,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "mimeType": "application/json",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "resourceSize": 16638,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2188.75,
+              "networkEndTime": 2257.2140000090003,
+              "statusCode": 200,
+              "rendererStartTime": 2188.1429999992251,
+              "transferSize": 2462,
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fclients%2C%2Fclients%2Fekodev%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology&version=ba6d9b28",
+              "resourceType": "Fetch"
+            },
+            {
+              "entity": "ocobo.co",
+              "resourceSize": 48,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "application/json",
+              "resourceType": "Fetch",
+              "url": "https://www.ocobo.co/_vercel/insights/view",
+              "transferSize": 473,
+              "rendererStartTime": 2272.2019999995828,
+              "networkEndTime": 2317.971000008285,
+              "statusCode": 202,
+              "networkRequestTime": 2273.3180000036955,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "finished": true,
+              "mimeType": "application/json",
+              "resourceSize": 9346,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "experimentalFromMainFrame": true,
+              "protocol": "http/1.1",
+              "networkRequestTime": 2424.0360000059009,
+              "statusCode": 200,
+              "networkEndTime": 2507.9200000092387,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953&hutk=281d5f8dc9415ef31077dbdd1b865f92",
+              "resourceType": "XHR",
+              "rendererStartTime": 2419.386000007391,
+              "transferSize": 4083
+            },
+            {
+              "sessionTargetType": "page",
+              "resourceSize": 135,
+              "priority": "High",
+              "mimeType": "application/json",
+              "finished": true,
+              "entity": "Hubspot",
+              "networkRequestTime": 2452.0210000053048,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "resourceType": "XHR",
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=281d5f8dc9415ef31077dbdd1b865f92",
+              "transferSize": 1095,
+              "rendererStartTime": 2450.5060000047088,
+              "networkEndTime": 2492.0200000107288,
+              "statusCode": 200
+            },
+            {
+              "entity": "Hubspot",
+              "priority": "Low",
+              "resourceSize": 45,
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "image/gif",
+              "transferSize": 1020,
+              "rendererStartTime": 2481.4400000050664,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=cc605c99b0b7ed4f7cc24253c97a8e87&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&t=Ocobo+%C2%B7+Accompagner+la+cr%C3%A9ation+d%27une+business+unit+durabilit%C3%A9%C2%A0%3A+comment+ekodev+a+structur%C3%A9+son+organisation+commerciale+et+d%C3%A9ploy%C3%A9+HubSpot&cts=1778837419127&vi=281d5f8dc9415ef31077dbdd1b865f92&nc=true&u=242475741.281d5f8dc9415ef31077dbdd1b865f92.1778837418564.1778837418564.1778837418564.1&b=242475741.1.1778837418564&cc=15",
+              "resourceType": "Image",
+              "networkEndTime": 2587.1550000011921,
+              "statusCode": 200,
+              "networkRequestTime": 2482.4270000085235,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "finished": true,
+              "mimeType": "application/javascript",
+              "resourceSize": 607831,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "protocol": "h2",
+              "networkRequestTime": 2542.597000002861,
+              "networkEndTime": 2578.9300000071526,
+              "statusCode": 304,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "resourceType": "Script",
+              "rendererStartTime": 2541.843000009656,
+              "transferSize": 1661
+            },
+            {
+              "networkRequestTime": 2704.3980000019073,
+              "protocol": "http/1.1",
+              "experimentalFromMainFrame": true,
+              "transferSize": 1024,
+              "rendererStartTime": 2702.9610000029206,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+              "resourceType": "Image",
+              "statusCode": 200,
+              "networkEndTime": 2764.749000005424,
+              "priority": "Low",
+              "resourceSize": 35,
+              "sessionTargetType": "page",
+              "finished": true,
+              "mimeType": "image/gif",
+              "entity": "Hubspot"
+            },
+            {
+              "protocol": "h2",
+              "networkRequestTime": 2708.343000009656,
+              "statusCode": 200,
+              "networkEndTime": 2721.6130000054836,
+              "resourceType": "Stylesheet",
+              "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+              "transferSize": 1259,
+              "rendererStartTime": 2707.691000007093,
+              "finished": true,
+              "mimeType": "text/css",
+              "resourceSize": 3792,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "entity": "Google Fonts"
+            },
+            {
+              "entity": "Google Fonts",
+              "mimeType": "font/woff2",
+              "finished": true,
+              "sessionTargetType": "page",
+              "resourceSize": 50524,
+              "priority": "VeryHigh",
+              "statusCode": 200,
+              "networkEndTime": 2747.2560000047088,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "resourceType": "Font",
+              "transferSize": 51336,
+              "rendererStartTime": 2732.1340000107884,
+              "protocol": "h2",
+              "networkRequestTime": 2732.7520000040531
+            },
+            {
+              "entity": "Google Fonts",
+              "sessionTargetType": "page",
+              "priority": "VeryHigh",
+              "resourceSize": 50524,
+              "mimeType": "font/woff2",
+              "finished": true,
+              "transferSize": 51335,
+              "rendererStartTime": 2735.3980000093579,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "resourceType": "Font",
+              "statusCode": 200,
+              "networkEndTime": 2747.9430000036955,
+              "networkRequestTime": 2735.941000007093,
+              "protocol": "h2"
+            },
+            {
+              "networkEndTime": 2831.7070000097156,
+              "statusCode": 200,
+              "transferSize": 1022,
+              "rendererStartTime": 2751.3540000021458,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=c75cc00f-738f-482e-b234-92636d28b702&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=cc605c99b0b7ed4f7cc24253c97a8e87&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&t=Ocobo+%C2%B7+Accompagner+la+cr%C3%A9ation+d%27une+business+unit+durabilit%C3%A9%C2%A0%3A+comment+ekodev+a+structur%C3%A9+son+organisation+commerciale+et+d%C3%A9ploy%C3%A9+HubSpot&cts=1778837419395&vi=281d5f8dc9415ef31077dbdd1b865f92&nc=true&u=242475741.281d5f8dc9415ef31077dbdd1b865f92.1778837418564.1778837418564.1778837418564.1&b=242475741.1.1778837418564&cc=15",
+              "resourceType": "Image",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkRequestTime": 2756.6540000066161,
+              "entity": "Hubspot",
+              "mimeType": "image/gif",
+              "finished": true,
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "resourceSize": 45
+            },
+            {
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "resourceSize": 35,
+              "mimeType": "image/gif",
+              "finished": true,
+              "entity": "Hubspot",
+              "networkRequestTime": 2756.7220000103116,
+              "protocol": "http/1.1",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 2756.3650000020862,
+              "transferSize": 1024,
+              "resourceType": "Image",
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+              "statusCode": 200,
+              "networkEndTime": 2818.4590000063181
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "key": "protocol",
+              "valueType": "text",
+              "label": "Protocol"
+            },
+            {
+              "granularity": 1,
+              "label": "Network Request Time",
+              "key": "networkRequestTime",
+              "valueType": "ms"
+            },
+            {
+              "valueType": "ms",
+              "key": "networkEndTime",
+              "label": "Network End Time",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "displayUnit": "kb",
+              "valueType": "bytes",
+              "label": "Transfer Size",
+              "key": "transferSize"
+            },
+            {
+              "displayUnit": "kb",
+              "granularity": 1,
+              "valueType": "bytes",
+              "label": "Resource Size",
+              "key": "resourceSize"
+            },
+            {
+              "label": "Status Code",
+              "key": "statusCode",
+              "valueType": "text"
+            },
+            {
+              "valueType": "text",
+              "key": "mimeType",
+              "label": "MIME Type"
+            },
+            {
+              "label": "Resource Type",
+              "key": "resourceType",
+              "valueType": "text"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "networkStartTimeTs": 36014774320.999992,
+            "type": "debugdata",
+            "initiators": [
+              {
+                "lineNumber": 0,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 1600
+              },
+              {
+                "lineNumber": 21,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 668
+              },
+              {
+                "columnNumber": 16793,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 21,
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 21,
+                "type": "parser",
+                "columnNumber": 30105
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 141
+              },
+              {
+                "columnNumber": 261,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 360,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 460
+              },
+              {
+                "columnNumber": 536,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 602
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 671
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 731
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 795
+              },
+              {
+                "columnNumber": 857,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 916,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 985
+              },
+              {
+                "columnNumber": 1052,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 1119,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 1176,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 1238,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 1297,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1361,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 1427
+              },
+              {
+                "columnNumber": 1488,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 1556,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 1622
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 1693
+              },
+              {
+                "columnNumber": 1751,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 1811
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 1886
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 1947
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2005
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 2069
+              },
+              {
+                "columnNumber": 2129,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2188
+              },
+              {
+                "columnNumber": 2250,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 2311,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2374
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2430
+              },
+              {
+                "columnNumber": 2498,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2565
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2626
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 2708
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2776
+              },
+              {
+                "columnNumber": 2840,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 2903,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 2962
+              },
+              {
+                "columnNumber": 3020,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "columnNumber": 3087,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser"
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 3146
+              },
+              {
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 3212
+              },
+              {
+                "columnNumber": 3272,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 3337
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "columnNumber": 3410
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 3476
+              },
+              {
+                "url": "https://www.ocobo.co/clients/ekodev",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 3535
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+              },
+              {
+                "columnNumber": 1811,
+                "lineNumber": 36,
+                "type": "parser",
+                "url": "https://www.ocobo.co/clients/ekodev"
+              },
+              {
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                "type": "parser"
+              },
+              {
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                "type": "parser"
+              }
+            ]
+          }
+        }
+      },
+      "resource-summary": {
+        "id": "resource-summary",
+        "title": "Resources Summary",
+        "description": "Aggregates all network requests and groups them by type",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "resourceType": "total",
+              "transferSize": 1564450,
+              "label": "Total",
+              "requestCount": 91
+            },
+            {
+              "transferSize": 821894,
+              "label": "Script",
+              "resourceType": "script",
+              "requestCount": 62
+            },
+            {
+              "requestCount": 11,
+              "resourceType": "image",
+              "transferSize": 432746,
+              "label": "Image"
+            },
+            {
+              "transferSize": 253265,
+              "label": "Font",
+              "resourceType": "font",
+              "requestCount": 6
+            },
+            {
+              "label": "Stylesheet",
+              "transferSize": 27827,
+              "resourceType": "stylesheet",
+              "requestCount": 3
+            },
+            {
+              "transferSize": 16444,
+              "label": "Document",
+              "resourceType": "document",
+              "requestCount": 1
+            },
+            {
+              "label": "Other",
+              "transferSize": 12274,
+              "resourceType": "other",
+              "requestCount": 8
+            },
+            {
+              "transferSize": 0,
+              "label": "Media",
+              "resourceType": "media",
+              "requestCount": 0
+            },
+            {
+              "requestCount": 30,
+              "resourceType": "third-party",
+              "transferSize": 989413,
+              "label": "Third-party"
+            }
+          ],
+          "headings": [
+            {
+              "label": "Resource Type",
+              "valueType": "text",
+              "key": "label"
+            },
+            {
+              "valueType": "numeric",
+              "key": "requestCount",
+              "label": "Requests"
+            },
+            {
+              "key": "transferSize",
+              "valueType": "bytes",
+              "label": "Transfer Size"
+            }
+          ]
+        }
+      },
+      "cls-culprits-insight": {
+        "id": "cls-culprits-insight",
+        "title": "Layout shift culprits",
+        "description": "Layout shifts occur when elements move absent any user interaction. [Investigate the causes of layout shifts](https://developer.chrome.com/docs/performance/insights/cls-culprit), such as elements being added, removed, or their fonts changing as the page loads.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [
+            {
+              "type": "table",
+              "items": [
+                {
+                  "score": 0.002315,
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  }
+                },
+                {
+                  "subItems": {
+                    "type": "subitems",
+                    "items": [
+                      {
+                        "cause": "Unsized image element",
+                        "extra": {
+                          "selector": "header.d_flex \u003e div.d_flex \u003e div.bg_ocobo.dark \u003e img.h_10",
+                          "nodeLabel": "ekodev",
+                          "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,1,HEADER,1,DIV,0,DIV,0,IMG",
+                          "lhId": "page-3-IMG",
+                          "type": "node",
+                          "boundingRect": {
+                            "top": 0,
+                            "width": 0,
+                            "right": 0,
+                            "height": 0,
+                            "bottom": 0,
+                            "left": 0
+                          },
+                          "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"ekodev\" loading=\"eager\" decoding=\"async\" fetchpriority=\"high\" class=\"h_10 w_auto obj-f_contain d_block\"\u003e"
+                        }
+                      },
+                      {
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      }
+                    ]
+                  },
+                  "score": 0.002315,
+                  "node": {
+                    "nodeLabel": "Accompagner la création d'une business unit durabilité : comment ekodev a struc…",
+                    "selector": "div \u003e header.d_flex \u003e div.lg:w_2/3 \u003e h1.text",
+                    "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark fs_4xl md:fs_5xl lg:fs_6xl …\"\u003e",
+                    "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,1,HEADER,0,DIV,0,H1",
+                    "lhId": "page-1-H1",
+                    "type": "node",
+                    "boundingRect": {
+                      "right": 0,
+                      "width": 0,
+                      "top": 0,
+                      "left": 0,
+                      "bottom": 0,
+                      "height": 0
+                    }
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "valueType": "node",
+                  "key": "node"
+                },
+                {
+                  "label": "Layout shift score",
+                  "key": "score",
+                  "granularity": 0.001,
+                  "subItemsHeading": {
+                    "key": "cause",
+                    "valueType": "text"
+                  },
+                  "valueType": "numeric"
+                }
+              ]
+            },
+            {
+              "items": [
+                {
+                  "score": 0,
+                  "node": {
+                    "type": "text",
+                    "value": "Total"
+                  }
+                },
+                {
+                  "score": 0,
+                  "node": {
+                    "path": "0,HTML,1,BODY,1,DIV,0,FORM,1,DIV,1,DIV,0,INPUT",
+                    "lhId": "page-0-INPUT",
+                    "type": "node",
+                    "boundingRect": {
+                      "top": 79,
+                      "width": 110,
+                      "right": 380,
+                      "left": 270,
+                      "bottom": 117,
+                      "height": 38
+                    },
+                    "snippet": "\u003cinput type=\"submit\" class=\"hs-button primary large\" value=\"S'inscrire\"\u003e",
+                    "selector": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "nodeLabel": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button"
+                  },
+                  "subItems": {
+                    "type": "subitems",
+                    "items": [
+                      {
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "key": "node",
+                  "valueType": "node",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "label": "Element"
+                },
+                {
+                  "granularity": 0.001,
+                  "subItemsHeading": {
+                    "key": "cause",
+                    "valueType": "text"
+                  },
+                  "valueType": "numeric",
+                  "label": "Layout shift score",
+                  "key": "score"
+                }
+              ],
+              "type": "table"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "server-response-time": {
+        "id": "server-response-time",
+        "title": "Initial server response time was short",
+        "description": "Keep the server response time for the main document short because all other requests depend on it. [Learn more about the Time to First Byte metric](https://developer.chrome.com/docs/lighthouse/performance/time-to-first-byte/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Root document took 20 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "url": "https://www.ocobo.co/clients/ekodev",
+              "responseTime": 17
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "valueType": "timespanMs",
+              "key": "responseTime",
+              "label": "Time Spent"
+            }
+          ],
+          "overallSavingsMs": 0,
+          "type": "opportunity"
+        },
+        "numericValue": 17,
+        "numericUnit": "millisecond"
+      },
+      "third-parties-insight": {
+        "id": "third-parties-insight",
+        "title": "3rd parties",
+        "description": "3rd party code can significantly impact load performance. [Reduce and defer loading of 3rd party code](https://developer.chrome.com/docs/performance/insights/third-parties) to prioritize your page's content.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "table",
+          "isEntityGrouped": true,
+          "items": [
+            {
+              "transferSize": 352597,
+              "entity": "Hubspot",
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 218.18099997192621,
+                    "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+                    "transferSize": 206378
+                  },
+                  {
+                    "mainThreadTime": 47.950000025331974,
+                    "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                    "transferSize": 27946
+                  },
+                  {
+                    "transferSize": 43679,
+                    "mainThreadTime": 37.274000033736229,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+                  },
+                  {
+                    "transferSize": 29750,
+                    "mainThreadTime": 31.75500001013279,
+                    "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+                  },
+                  {
+                    "mainThreadTime": 16.997000031173229,
+                    "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+                    "transferSize": 27210
+                  },
+                  {
+                    "mainThreadTime": 2.9350000023841858,
+                    "url": "https://js-eu1.hs-scripts.com/27107933.js",
+                    "transferSize": 2498
+                  },
+                  {
+                    "mainThreadTime": 0.16199998557567596,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+                    "transferSize": 1095
+                  },
+                  {
+                    "transferSize": 4083,
+                    "mainThreadTime": 0.10600000619888306,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953&hutk=281d5f8dc9415ef31077dbdd1b865f92"
+                  },
+                  {
+                    "mainThreadTime": 0.070000007748603821,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=281d5f8dc9415ef31077dbdd1b865f92",
+                    "transferSize": 1095
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&isMobile=true",
+                    "transferSize": 1712
+                  },
+                  {
+                    "transferSize": 1482,
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&t=Ocobo+%C2%B7+Accompagner+la+cr%C3%A9ation+d%27une+business+unit+durabilit%C3%A9%C2%A0%3A+comment+ekodev+a+structur%C3%A9+son+organisation+commerciale+et+d%C3%A9ploy%C3%A9+HubSpot&cts=1778837418567&vi=281d5f8dc9415ef31077dbdd1b865f92&nc=true&u=242475741.281d5f8dc9415ef31077dbdd1b865f92.1778837418564.1778837418564.1778837418564.1&b=242475741.1.1778837418564&cc=15"
+                  },
+                  {
+                    "transferSize": 1024,
+                    "mainThreadTime": 0,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1"
+                  },
+                  {
+                    "transferSize": 1024,
+                    "mainThreadTime": 0,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=c75cc00f-738f-482e-b234-92636d28b702&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=cc605c99b0b7ed4f7cc24253c97a8e87&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&t=Ocobo+%C2%B7+Accompagner+la+cr%C3%A9ation+d%27une+business+unit+durabilit%C3%A9%C2%A0%3A+comment+ekodev+a+structur%C3%A9+son+organisation+commerciale+et+d%C3%A9ploy%C3%A9+HubSpot&cts=1778837419395&vi=281d5f8dc9415ef31077dbdd1b865f92&nc=true&u=242475741.281d5f8dc9415ef31077dbdd1b865f92.1778837418564.1778837418564.1778837418564.1&b=242475741.1.1778837418564&cc=15",
+                    "transferSize": 1022
+                  },
+                  {
+                    "transferSize": 1021,
+                    "mainThreadTime": 0,
+                    "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1"
+                  },
+                  {
+                    "transferSize": 1020,
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=cc605c99b0b7ed4f7cc24253c97a8e87&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&t=Ocobo+%C2%B7+Accompagner+la+cr%C3%A9ation+d%27une+business+unit+durabilit%C3%A9%C2%A0%3A+comment+ekodev+a+structur%C3%A9+son+organisation+commerciale+et+d%C3%A9ploy%C3%A9+HubSpot&cts=1778837419127&vi=281d5f8dc9415ef31077dbdd1b865f92&nc=true&u=242475741.281d5f8dc9415ef31077dbdd1b865f92.1778837418564.1778837418564.1778837418564.1&b=242475741.1.1778837418564&cc=15"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+                    "transferSize": 558
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 355.43000007420778
+            },
+            {
+              "transferSize": 157129,
+              "entity": "Google Tag Manager",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 171.81799995154142,
+                    "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+                    "transferSize": 157129
+                  }
+                ]
+              },
+              "mainThreadTime": 171.81799995154142
+            },
+            {
+              "transferSize": 7011,
+              "entity": "GitHub",
+              "mainThreadTime": 5.3439999967813492,
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 5015,
+                    "mainThreadTime": 5.3439999967813492,
+                    "url": "https://useago.github.io/widgetjs/frame.js"
+                  },
+                  {
+                    "transferSize": 1996,
+                    "mainThreadTime": 0,
+                    "url": "https://useago.github.io/widgetjs/frame.css"
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "mainThreadTime": 0,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-avatar.png",
+                    "transferSize": 354683
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png",
+                    "transferSize": 11989
+                  }
+                ]
+              },
+              "entity": "vercel-storage.com",
+              "transferSize": 366672
+            },
+            {
+              "entity": "Clearbit",
+              "transferSize": 1278,
+              "mainThreadTime": 0,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+                    "transferSize": 1278
+                  }
+                ]
+              }
+            },
+            {
+              "entity": "Google Analytics",
+              "transferSize": 796,
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 796,
+                    "mainThreadTime": 0,
+                    "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65d0v9100339653za200zd9100339653&_p=1778837418057&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1517412233.1778837418&frm=0&pscdl=noapi&rcb=4&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115938465~115938469&dp=%2Fclients%2Fekodev&sid=1778837418&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fclients%2Fekodev&dt=Ocobo%20%C2%B7%20Accompagner%20la%20cr%C3%A9ation%20d%27une%20business%20unit%20durabilit%C3%A9%C2%A0%3A%20comment%20ekodev%20a%20structur%C3%A9%20son%20organisation%20commerciale%20et%20d%C3%A9ploy%C3%A9%20HubSpot&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1623"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                    "transferSize": 102671
+                  },
+                  {
+                    "transferSize": 1259,
+                    "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0,
+              "transferSize": 103930,
+              "entity": "Google Fonts"
+            }
+          ],
+          "headings": [
+            {
+              "key": "entity",
+              "valueType": "text",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "label": "3rd party"
+            },
+            {
+              "label": "Transfer size",
+              "key": "transferSize",
+              "granularity": 1,
+              "subItemsHeading": {
+                "key": "transferSize"
+              },
+              "valueType": "bytes"
+            },
+            {
+              "label": "Main thread time",
+              "key": "mainThreadTime",
+              "subItemsHeading": {
+                "key": "mainThreadTime"
+              },
+              "granularity": 1,
+              "valueType": "ms"
+            }
+          ]
+        }
+      },
+      "render-blocking-insight": {
+        "id": "render-blocking-insight",
+        "title": "Render blocking requests",
+        "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 490 ms",
+        "metricSavings": {
+          "LCP": 500,
+          "FCP": 500
+        },
+        "details": {
+          "items": [
+            {
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "wastedMs": 164,
+              "totalBytes": 24572
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "valueType": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Transfer Size"
+            },
+            {
+              "label": "Duration",
+              "valueType": "timespanMs",
+              "key": "wastedMs"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "total-blocking-time": {
+        "id": "total-blocking-time",
+        "title": "Total Blocking Time",
+        "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).",
+        "score": 0.9,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "200 ms",
+        "numericValue": 199.00000000000091,
+        "numericUnit": "millisecond"
+      },
+      "redirects": {
+        "id": "redirects",
+        "title": "Avoid multiple page redirects",
+        "description": "Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://developer.chrome.com/docs/lighthouse/performance/redirects/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "opportunity",
+          "overallSavingsMs": 0,
+          "items": [],
+          "headings": []
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "user-timings": {
+        "id": "user-timings",
+        "title": "User Timing marks and measures",
+        "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more about User Timing marks](https://developer.chrome.com/docs/lighthouse/performance/user-timings/).",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "details": {
+          "type": "table",
+          "items": [],
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "name",
+              "label": "Name"
+            },
+            {
+              "key": "timingType",
+              "valueType": "text",
+              "label": "Type"
+            },
+            {
+              "valueType": "ms",
+              "key": "startTime",
+              "label": "Start Time",
+              "granularity": 0.01
+            },
+            {
+              "label": "Duration",
+              "granularity": 0.01,
+              "valueType": "ms",
+              "key": "duration"
+            }
+          ]
+        }
+      },
+      "document-latency-insight": {
+        "id": "document-latency-insight",
+        "title": "Document request latency",
+        "description": "Your first network request is the most important. [Reduce its latency](https://developer.chrome.com/docs/performance/insights/document-latency) by avoiding redirects, ensuring a fast server response, and enabling text compression.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": {
+            "usesCompression": {
+              "label": "Applies text compression",
+              "value": true
+            },
+            "serverResponseIsFast": {
+              "label": "Server responds quickly (observed 17 ms)",
+              "value": true
+            },
+            "noRedirects": {
+              "label": "Avoids redirects",
+              "value": true
+            }
+          },
+          "type": "checklist",
+          "debugData": {
+            "redirectDuration": 0,
+            "type": "debugdata",
+            "wastedBytes": 0,
+            "serverResponseTime": 17,
+            "uncompressedResponseBytes": 0
+          }
+        }
+      },
+      "diagnostics": {
+        "id": "diagnostics",
+        "title": "Diagnostics",
+        "description": "Collection of useful page vitals.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "throughput": 25260877103.982452,
+              "numFonts": 6,
+              "numScripts": 62,
+              "rtt": 0.00078164928590083,
+              "maxServerLatency": 17,
+              "numTasksOver25ms": 13,
+              "mainDocumentTransferSize": 16444,
+              "numRequests": 91,
+              "numTasksOver50ms": 8,
+              "maxRtt": 9.3081599999999991,
+              "numStylesheets": 3,
+              "totalByteWeight": 1564450,
+              "numTasksOver10ms": 30,
+              "totalTaskTime": 1515.0329999999894,
+              "numTasksOver500ms": 0,
+              "numTasksOver100ms": 1,
+              "numTasks": 1694
+            }
+          ],
+          "type": "debugdata"
+        }
+      },
+      "speed-index": {
+        "id": "speed-index",
+        "title": "Speed Index",
+        "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).",
+        "score": 0.8,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "4.1 s",
+        "numericValue": 4071.9450049519482,
+        "numericUnit": "millisecond"
+      },
+      "unminified-css": {
+        "id": "unminified-css",
+        "title": "Minify CSS",
+        "description": "Minifying CSS files can reduce network payload sizes. [Learn how to minify CSS](https://developer.chrome.com/docs/lighthouse/performance/unminified-css/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "overallSavingsBytes": 0,
+          "overallSavingsMs": 0,
+          "type": "opportunity",
+          "items": [],
+          "headings": []
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "network-dependency-tree-insight": {
+        "id": "network-dependency-tree-insight",
+        "title": "Network dependency tree",
+        "description": "[Avoid chaining critical requests](https://developer.chrome.com/docs/performance/insights/network-dependency-tree) by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "value": {
+                "chains": {
+                  "0EE9CEC18D6DF7DB5C64B0C5EA618CB5": {
+                    "isLongest": true,
+                    "transferSize": 16444,
+                    "navStartToEndTime": 1300,
+                    "url": "https://www.ocobo.co/clients/ekodev",
+                    "children": {
+                      "49.2": {
+                        "children": {
+                          "49.92": {
+                            "transferSize": 31977,
+                            "navStartToEndTime": 1481,
+                            "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                            "children": {}
+                          },
+                          "49.97": {
+                            "children": {},
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                            "transferSize": 39129,
+                            "navStartToEndTime": 1482
+                          },
+                          "49.95": {
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                            "isLongest": true,
+                            "transferSize": 38778,
+                            "navStartToEndTime": 1685,
+                            "children": {}
+                          },
+                          "49.96": {
+                            "children": {},
+                            "transferSize": 40710,
+                            "navStartToEndTime": 1625,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf"
+                          }
+                        },
+                        "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                        "isLongest": true,
+                        "transferSize": 24572,
+                        "navStartToEndTime": 1407
+                      }
+                    }
+                  }
+                },
+                "type": "network-tree",
+                "longestChain": {
+                  "duration": 1685
+                }
+              },
+              "type": "list-section"
+            },
+            {
+              "type": "list-section",
+              "value": {
+                "type": "table",
+                "items": [
+                  {
+                    "origin": "https://raw.githubusercontent.com/",
+                    "source": {
+                      "path": "0,HEAD,2,LINK",
+                      "boundingRect": {
+                        "width": 0,
+                        "right": 0,
+                        "top": 0,
+                        "height": 0,
+                        "left": 0,
+                        "bottom": 0
+                      },
+                      "lhId": "page-4-LINK",
+                      "type": "node",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "selector": "head \u003e link",
+                      "nodeLabel": "head \u003e link"
+                    },
+                    "subItems": {
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ],
+                      "type": "subitems"
+                    }
+                  },
+                  {
+                    "subItems": {
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ],
+                      "type": "subitems"
+                    },
+                    "source": {
+                      "selector": "head \u003e link",
+                      "nodeLabel": "head \u003e link",
+                      "path": "2,HTML,0,HEAD,3,LINK",
+                      "boundingRect": {
+                        "top": 0,
+                        "width": 0,
+                        "right": 0,
+                        "bottom": 0,
+                        "left": 0,
+                        "height": 0
+                      },
+                      "lhId": "page-5-LINK",
+                      "type": "node",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e"
+                    }
+                  }
+                ],
+                "headings": [
+                  {
+                    "label": "Origin",
+                    "subItemsHeading": {
+                      "key": "warning"
+                    },
+                    "valueType": "text",
+                    "key": "origin"
+                  },
+                  {
+                    "key": "source",
+                    "valueType": "node",
+                    "label": "Source"
+                  }
+                ]
+              },
+              "title": "Preconnected origins",
+              "description": "[preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints help the browser establish a connection earlier in the page load, saving time when the first request for that origin is made. The following are the origins that the page preconnected to."
+            },
+            {
+              "type": "list-section",
+              "value": {
+                "type": "table",
+                "items": [
+                  {
+                    "wastedMs": 309,
+                    "origin": "https://tag.clearbitscripts.com"
+                  },
+                  {
+                    "wastedMs": 229.861,
+                    "origin": "https://useago.github.io"
+                  }
+                ],
+                "headings": [
+                  {
+                    "key": "origin",
+                    "valueType": "text",
+                    "label": "Origin"
+                  },
+                  {
+                    "valueType": "ms",
+                    "key": "wastedMs",
+                    "label": "Est LCP savings"
+                  }
+                ]
+              },
+              "title": "Preconnect candidates",
+              "description": "Add [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints to your most important origins, but try to use no more than 4."
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "interactive": {
+        "id": "interactive",
+        "title": "Time to Interactive",
+        "description": "Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).",
+        "score": 0.23,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "10.6 s",
+        "numericValue": 10599.244515757597,
+        "numericUnit": "millisecond"
+      },
+      "network-rtt": {
+        "id": "network-rtt",
+        "title": "Network Round Trip Times",
+        "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "sortedBy": [
+            "rtt"
+          ],
+          "type": "table",
+          "headings": [
+            {
+              "key": "origin",
+              "valueType": "text",
+              "label": "URL"
+            },
+            {
+              "key": "rtt",
+              "valueType": "ms",
+              "granularity": 1,
+              "label": "Time Spent"
+            }
+          ],
+          "items": [
+            {
+              "rtt": 9.3081599999999991,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "rtt": 4.2859349999999994,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "rtt": 3.849525,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "origin": "https://track-eu1.hubspot.com",
+              "rtt": 3.3933149999999994
+            },
+            {
+              "rtt": 1.87677,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "origin": "https://useago.github.io",
+              "rtt": 1.6837650000000002
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "rtt": 0.033347018655069081,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "rtt": 0.0022786683533463268,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "rtt": 0.0018691624173309625,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.0016301439922367031,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "rtt": 0.0016225071940567551,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "rtt": 0.0013065401555697681,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "origin": "https://js-eu1.hsforms.net",
+              "rtt": 0.000782081379109482
+            },
+            {
+              "rtt": 0.00078164928590083,
+              "origin": "https://www.googletagmanager.com"
+            }
+          ]
+        },
+        "numericValue": 9.3081599999999991,
+        "numericUnit": "millisecond"
+      },
+      "total-byte-weight": {
+        "id": "total-byte-weight",
+        "title": "Avoids enormous network payloads",
+        "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn how to reduce payload sizes](https://developer.chrome.com/docs/lighthouse/performance/total-byte-weight/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Total size was 1,528 KiB",
+        "details": {
+          "items": [
+            {
+              "totalBytes": 354683,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-avatar.png"
+            },
+            {
+              "totalBytes": 204717,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "totalBytes": 157129,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "totalBytes": 51797,
+              "url": "https://www.ocobo.co/assets/markdown-container-Ctj4E3W8.js"
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "totalBytes": 51335,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "totalBytes": 45260,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "totalBytes": 43924,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "totalBytes": 43679
+            },
+            {
+              "totalBytes": 40710,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-RegularItalic.otf"
+            }
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "valueType": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Transfer Size"
+            }
+          ],
+          "sortedBy": [
+            "totalBytes"
+          ],
+          "type": "table"
+        },
+        "numericValue": 1564450,
+        "numericUnit": "byte"
+      },
+      "mainthread-work-breakdown": {
+        "id": "mainthread-work-breakdown",
+        "title": "Minimizes main-thread work",
+        "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to minimize main-thread work](https://developer.chrome.com/docs/lighthouse/performance/mainthread-work-breakdown/)",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "1.8 s",
+        "metricSavings": {
+          "TBT": 200
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "Category",
+              "valueType": "text",
+              "key": "groupLabel"
+            },
+            {
+              "granularity": 1,
+              "label": "Time Spent",
+              "key": "duration",
+              "valueType": "ms"
+            }
+          ],
+          "items": [
+            {
+              "duration": 889.441199999981,
+              "groupLabel": "Script Evaluation",
+              "group": "scriptEvaluation"
+            },
+            {
+              "groupLabel": "Script Parsing & Compilation",
+              "group": "scriptParseCompile",
+              "duration": 369.74640000000005
+            },
+            {
+              "duration": 191.63879999999992,
+              "groupLabel": "Style & Layout",
+              "group": "styleLayout"
+            },
+            {
+              "duration": 188.25360000000052,
+              "groupLabel": "Other",
+              "group": "other"
+            },
+            {
+              "duration": 136.9032,
+              "group": "garbageCollection",
+              "groupLabel": "Garbage Collection"
+            },
+            {
+              "group": "paintCompositeRender",
+              "groupLabel": "Rendering",
+              "duration": 21.075599999999998
+            },
+            {
+              "group": "parseHTML",
+              "groupLabel": "Parse HTML & CSS",
+              "duration": 20.980799999999991
+            }
+          ],
+          "type": "table",
+          "sortedBy": [
+            "duration"
+          ]
+        },
+        "numericValue": 1818.0395999999814,
+        "numericUnit": "millisecond"
+      },
+      "final-screenshot": {
+        "id": "final-screenshot",
+        "title": "Final Screenshot",
+        "description": "The last screenshot captured of the pageload.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "screenshot",
+          "timestamp": 36017527817,
+          "timing": 2755,
+          "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAEwQAAEDAwMCBAQEAgcEBgkFAAECAwQABREGEiEHMRMUQVEIImFxFTKBkSOhFjNCUnKxwRdidNEmNDWChOEkJSeSo7KztMM2Q0WDwv/EABUBAQEAAAAAAAAAAAAAAAAAAAAB/8QAFREBAQAAAAAAAAAAAAAAAAAAABH/2gAMAwEAAhEDEQA/AJU0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUr4pQSkqUQEgZJPYVrzWuNKvXDyLWorSuXnaGkykEk+3fv9KDYqUJAGSePetdOuNLJn+SOorSJedvhebRuz7d+/0oNipQEEAg5B9axV51Da7KtCbrK8oheMPOtqDQ+7mNo/U0GVpWhda5X/skv8mG/wAGOlSHWl9wVJ5BFZY6v09ZokCNd75bocpTLf8ADfkJSrlI5IJ4oNnpVONIZlMIfjOtvMuDchxtQUlQ9wR3rC3fWOm7PLEW6322RJOceE9JQlQ+4J4/Wgz1KpRJLEyOiREebfYcGUONqCkqHuCO9VaBSlKBSlKBSlKBSlKBSlKBSlfFq2pJoBUE9yBXwOIPZQrF3K4xLewZFxlMxmchPiPLCE5PYZNWEPUtjmyUR4d4t78hw4Q23IQpSvsAaDZaVQjrJ+U/pVegUpSgUpSg5v1wfeXZ7HaEvLjxLxdWIMtxB2nwVElSc+mcYrY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvr3q81dp2DqqxP2u5pV4LmFJWg4W0scpWk+hBrT3dF6zkwjbJWvFqtqk+GtaLehMlSOxHibu+PXGaDRDfbk/0PhwVTXShy8CyKnpVhS43ilO/P1SNua64jQOlU2P8ACRYrf5LZswWU7u2M7u+765zXt7RNkd0SNKmMRaUtBpKQfmSQchYP97dzn3rWk6J1oiJ+HJ1+7+GhPhhRt6DJ2dseLnvj1xmgw3UGVJ0J0UMfTt4ellt1MNE5SwpbLalkEbh6pHyg9xXRdP6ctlv04i3NtCRHeZCX1vHxFSMjlSyfzE5qnbtG2SFo9OmRES9afDLa23vmLmTkqUf7xPOferVWnrpbLKLPpiemNG2eGiRNWqQ5HT2whPGcem5RxQcVjvux+kXVCwJdW9brNOXHhrUc7W/EHyZ+mP512fROlLND0nEbMWNOVLjockyXkBxUpSkglSie4OeB6CseOmcCP01naSgSXG/OgqfmOJ3rccKgStQ4znGKN6O1HaYnkNL6pbhW0J2tsyoIkKjj1Datw49grOKDVNPy3tIf7UbVZCVQLO15yC1+YMLW0pakD6AjOK2npZpKxs6GtslcOLOlXGOmTLlPtpcW+twblZJHIye1ZrRejoembPKiF1yfJnOKenSpABXJWruVfTHAFa7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNBQ6fMt2DqfqzTdrGyzIZYnNsA5THcXkKSn2B74rqFazojSLGl2Zji5b9wuk5zxpk5/87yvQYHASBwAO1bNQKUpQKUpQKUpQKUpQKUpQK8PjLRr3Q80Gu6jEk20+SE4vbh/1LwfEx//AG/Lj+dYKypu/wCKMeaGovByd3mhB8PsfzeH8/7Vuy2SD8vIryGlk/loPrA/iCrqvDTYQPrXugUpSgUpVnKuDUeW3HVnepJWTg4Sn3/egvKV8SQpIUOx5FY683M27y+1nxS6opxuI/0Pf9KDJUrD/iz6kTlNxUFMYrHzOEbtvf8As0k3d1hpBWwzv8EvrBewNvskkcn9qDMUrGN3ULfS2G8EulvBVyAG9+cfyrza7uJlsemOteChsZPJII2gnuB747elBlaViYl5S/EivKbSguvFlY35DZAUe+Oew/eqf42d9vT4CczBlP8AE/Lzznj27e54oM1SsdcLiYkyOz4aShwgFalEYyQB2B9/XAqiL0nw1LLOQhlx5QSrJGxWMfr/AKUGXpWJN2cS2kFqOXVuBtO2QCgZSVcqxx29vaibq4uVHZQwg+I2HFKDm4DkjggYPb6UGWpWB/H1+VLvlkBYXtKC4flGCcn5fp6Aj61e3O5GHFaebbS4F9zuIAGM54BP8qDI0rEvXV5l2TuYaLLTSXQtLpyoKJA/s8duTmreTflx2lboyFupd8MhtwqSfk3DB29/TsKDPUrEzLutha0IjhakvIZGVHncjdngH7VUjXJbtyMRxpLfy5Ct5O44BOOMevvnjtQZKlKUClKUClKUClKUClKUClKUCvC2kLWhakgqQcpPqK90oFeHWm3ceK2heO24Zr3SgoiJHS44tMdoLcBC1BAyoHvk+tenI7LuzxGm17DlO5IO37e1VKUFPwGvGLvhI8UjBXtGce2aCOyltTYabCFd0hIweMdvsBVSlBTXHZcStK2W1JWcqBSCFH3Pv2r4YzCu7LZ4A5SOw5A/SqtKCm4wy44hbjTa1o5SpSQSn7H0ohhlClqQ0hKl8rISAVff3qpSgoCHGDKmRHZDSjko2DaT9q+qiRlKbUqOyVNgBBKBlOO2Paq1KC38jE8Mt+VY2FW4p8MYJ98e9VHmGX0BD7TbiQcgLSCAf1qpSg8lpslRKE5UNpOO49j+5qmIkcNhsMNBsZwkIGBnvxValBRdix3gQ6w0sKIUQpAOSBgH9q+txmG3PEbZaS5t27kpAOPbPtVWlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArFal1DatM2w3G+zEQ4YWEFxSSr5j2GACaytR1+L697LfYrI2rl1xct0fRI2p/+ZX7UHXtM9RdJ6nuf4fYry1LmFBcDQbWklI7n5kgetbZUGOn7zuh+qunHpaihJMdbhPGG5DSSc/YOfyroOqdZ6+1p1QuemtI3FcFuI8602004Gcho4UpS+5yR2+vaiJTUqM9m171H0tojUMjU8V17wEJRCmSkpOx0uBBBx+YYUSM/3e9azarr1guVnjaott1nSosiQWkIQ4hWVAnP8LGAnII7UVL6lRi6i9TdcSbjYdLW1Bs96ksMiYE7QtT6zgAK5CU9jxzz9KwsfqFrvRt6vWmNU3F2U6YT6QsuBbjDhYUptxDg577eD/KglvSoWaU1zr6ZYtTvxtRyVohw0uurkvKWtCS4lP8AC7gKOe/tV7bOpPUGb05vj7d5CmLfIjByUs4kpDhUAlJA5BKRknn96CY1Khze+purJvTKyS/xuYzObuMmK4+wvw1PIS20pO7bjON5Fe39YdT42jLTqtN3dbtDavKoUXUrU8sKVlTiVZ3ZII59APvQTDpUS9WdYtWapk6ftenJP4U/KZaS8WlBBcfUoj85/Knt6+pzmsJqnW3UC3a7FtvN+kx5bLjDTzUOSQ0flTzhJxkjk/UngUEz6VFhrXvUPX/UGY1o2UmNFt6lPNxCtLaFNoVj+JnlRVxkdufStCjdR9YvvXda9RXVGGVrSgSlYbO9Pbn0yRQTkpULLXrjXzugrzcmtSSTHiy46HHHHVKfyoLwEE9k8c+/FZid1t1X/s5tjDMwJursl5l6dsT4hbQlspxxgH+JycZ4FBLulRU0VqHqnbNWW9tx+bfoLpQt9vPjNltR5wsjgjnkHH3rWtJar6hag1m5Z7LqKa5LfD7baJMpWxICVZPOcEAEj2OKCZM+UiDBky3QotsNqdUE9yEgk4+vFaF066t2HXt6ftlni3JmQzHMlSpTaEpKQpKcDasnOVD0q609Avdr6SPxNVSlSry3DleO8XS4VZLhT8x7/KUj9KiZ0r1TK0c7qO624I86LYWmVLGQlSn2Rux64GT96CdtKhrI1h1Lb0Au/P31xVrnSw2h5MgJfbWnOQkJwUpODkfQHFdv+GW93O/aBmSr1PkzpKbi42l2Q4VqCQ22QMn0yT+9B1ulKUClKUClKUClKUCuDdYej+o9ea0VdY1xtjMFDLbDLby3AtKRknOEEfmKvWu81rurda6e0ihpWobozDU6CW0EFS1AeoSkE4+uKDieufh5mTryxI0tcYzEVLCELE591bniJyMg7VcY24GeMVW1X0DvE+9G9WW+xodxkgOSUErSEvFP8QoWkZ2k5OCB3rqll6oaOvUWa/br006mGwuS8gtrStLaBlSgggE4A9AaxrPWrQTsWRIRfP4TG3eVRXgfmOAACnJ7Ht7URp+kfh+jW/Tt7iXu6mRNuTIZDjCMJYwsLBGeVHclPtwMfWtVR8OGoStMN3U0T8KS5vACXCQfVQb/AC5x9a6l1M6hW2DZIKLfqqDZ356EPh5yMt91LC05C0NpGQo8Y3D39qyXTvVmnn9Jq8tqv8YRbmyqVMmHw3Ep5O5YIBA9Mn270Vo2uugbFzt9nOm7kIdwt0dEbe+DteCTkLJTylWSeQD6e1Y7Tfw/TY/4pP1BeWZ11eiPsxgCsoS6ttSAta1DccZ7Yro/+2HQvkpMtN+aUzHWltzay4VZVnBCduSOO4GK0nqV14gwLFBlaFlRZ0l6QptxMqK6EhCU5JGdvOSn96IxOk+hWoLPYtUQZFxtS3LrCTGZUhbmEqDiVZVlHbA9M19snQvUEDQWprG7cbUqTdHYi2lpU5sSGlKKt3yZ53DGAav3+pF11N0LkX2JeYdnvMWSGZrqGHAhsFZCUp4WckKbORn17emb6Ma2QjpzMumrtUxpzcaWWjKWlaNg2pIQSpKStXOeAe9BxLqnoW4aA0FZbZdZMWQ8/c5MlKoxUUhJaZTg7gOcpNZrQ/RWdrLR1huMe/GJbJKFuPx3Ape1xLq07kJyE8pA7/XvXbI2t+m2vZ8e2uyLXdJKVHwGp0Q/mPfZ4icZOPTvXuy9TOn0SadP2u4RoSoxdT5dERbDTWzcpfO0JHZR+v60Gl9Qfh+jXhm2q0zObgvQ4yIqkSEkpeCc4WSOQrk54OfpWsSPhvvEe8x3bXd7euG0WlEyCtLilAAr4CSAN2cc9sV3nSGu9N6vceb09dGpbrI3Lb2qQsDtnaoAkfWrvVWq7HpSIiTqC4swmnDhG/JUsjvtSMk/oKKiNr+Npq3dRrwu23i5WtKZbiJUdtg7sbvnDS0qwQecBWMfWsP0s0bcNb3e62+07Gh5RRLz5OxHzpwFEA8nB9PSs38RN4tl41tGnWFyI9AlQWng6y0kFaipYJUcbs8AEHtiul6L6hI091KvGmU22z2vTVvEl11yLFUHSlpBVuUQTuOB7Zoila+hWoInT6+WFy42oyp8qO+24lbmxIb3ZB+TOfmGOK+x/h6lPaC/C59ziN3pia7Jjvs7lNFC0NpKF5APdvOR2+tdPgdWtGXC03O5RLspcK2pbVKc8q6PDC1bU8FOTk8cZqyPW3QIipkG9L8FSy2FeTf/ADAAkfk9iKK53pL4fbqjUUO4auvrMuPEUhSWmFOOKcCTkJKlgbU/bP6VkOmHRe+aT6jR9QTp9seiNl4ltlSys70KSO6QP7Q9a6Avq7oZHkfEv7CPOI8Rrc2sYTkjKvl+Tkf2se/aslqvqFpbSimkXy7sR3XUhaG0hTiyk9lbUgnH1oM9eYq51nnRGlJS4+w40kq7AqSQM/vUe9G/DzcIYvEfUNygqjToJjtriFaltueI2tKsKSAR8hzz6127SOttPavQ8dPXNmYpnBcQApC0g+pSoA4+tbFQRdPw0XRMCXtvcJyZ4iRHyFob2f2ivgnd2wBx9a7D0R0RP0DpKTarpIiyH3Zi5IVGKikJKEJx8wBz8proNKBSlKBSlKBSlKBSlKBURviMQiP1piyNQMyHrMpqOrY2cFbI/OlJ987v3qXNc915qzp23cvwXWb0F2YztUGJMRbuzcARghBAyCOxoI3Q39FTL5fF6Vtl/jK/D5io4W+gttp8svduGCrb3/tHuKvvht0hY9X328R9RQRMZYjJcbSXFo2qKsZ+Uj0qVFu0fpy2xJUa32S3xmJTZZfS0wlPioIwUq9xg9q9af0nYNOvOvWO0Q4DrqQhxTDYSVDOcGiIfdSIMSxdYp8e/RHDaWlpS02QtY8uGwlrGFpKgAAPzDt3rEtx7bKsOoHNNRr2XWmwuQslIYEfxU8KSMqHO04Kj27nGam1f9MWPUPhfjlphTy1+QvtBZT9iaqWfT1nssJyJabZDiRnf6xtllKUr9Pm9/1oIHPS7C5otiLHs0lN/afK37j45LamznCdnYen7d6z70FC+g8acmMhTzeoHG1PhA3JQY6Pl3d8Zxx71JN+d0pZvr2knI1nTNkSEpdipi4Qp4cJSVBO3cMkYzwTjvW8wdK2GDZ3rVEtEFq2PqK3IoZHhrUcclPYngfsKCL9qvFsl/DFfbXCYLdxgPMLmueGEhwuSSUHcOVEJSBz2wBXPHWZqumER5tKzb0Xd9LpH5Q4WWdmf0C6m0xobS7Ftl29mw25uFLKVPspYAS6UnKdw9cHkVcQNJafgWqRbIdmgtW6Qre9GSynw1qwBkp7E8D9qEQov67Dc7rp1jp7brjFuHhttvB1e5TknIwpHJxz68DtwKzHT21xbx10/D7ww3Kjuy5vitrHyqIQ6f8AMA1Luy6M01Y5Qk2ix26HJAIDrTCQofY9xXmDorTUC7/ikOxwGLjuUvzCGgF5UCFHP1BP70EX/hRUR1PdAPBt7uR7/Misx8VrLrev7DKuDby7QqKlOEHGdrhLgSewVgp/lUibHozTdhmmZZrJBhSigo8VhoJVtOMjPtwKyN5s9tvcTyt4gxpsfO7w32wsA+/PrQQL1+9p6TqFT2j4EuDaFtJ8NqUSVFXZRGSeMj3PY/apd690ZYmdI6ovEG0R03p+2SSqShJ3qKmlA/vWwzdAaSnFgy9O2x3wGgy3uYT8iBnCR9OT+9bNtTs24G3GMemKKgZpK8Q4WgdcW19axKuDMTwEhBIOx8KVkjgcEd6wDv8A+mY3/GO//I3U8E6F0qlmY0jT9sQ3LAS+lMdIDgCgoA4HbIB/QVpGqEdItMXBmz3yBZo0hRDgZ8qVBG7A3KwCE5wO/tREaNdW2HC0roiRFjttPS7e44+tI5cUHlgE/XHFfL7tjaxtkjVDLr0J2BDdwpKlb2zGQEkAKSSAfZQ7Gpd3KwdPnUQ4VyiafIithEdl5TYLaFHcAkE8A5z+tZq56Q09dIUSJcbLAkxoiA3HQ6yFBpIAASn2GAOPpQR3+G5Nid6iSHLJHvPjJZdKnFFCY6WiRgKT8yhzjAKjyO5xUpaxlisFpsEdbFktsSA0s5UmO0Ebj9cd6ydFKUpQKUpQKUpQKUpQKUpQKhf8SKijrLcFAbiluOcD1/hpqaFRk629LdYan6lTLrZLWH4DqGUoe8y0jlKEg8KUDwR7UFa39btWwNbptmq7Q1CjTFgNMrZKHWEr4bVk/mGcZyPft2q36b9YtXX46nFxkxVeQsUqextjpTh1vbtJ9xyeKubT0f1nfOobN01zPafiQlpCZPiJUqQhHKAlI7DPJzjue9YOw9GNf2KffW4AhpjybdJiF4OoV5hChw2kEgpKiEjJwBzzRFXTvXnVadP3ydcG4055gstRwGQhDSlleVr28kfLjHuRVOxdZOp9xQqZAt8a5RkKwtDUMqx+iTuFU9JdJuo9ptN1REiMQJTq2VBL0hlxEhtIc3IIBUk8qScKGOPpVo10Z6iXO/tSXoFvs60EYksOtMoSR/aCWec/YCg8aru4j/ECwtu2W9t5U6GoqLRyFOJbUokZxuyo8kZrI6S626+ubl1ShqJcFR7e9JCfCQ2GgjBLh/vADPy+pIrK6r6Waxm9Y273Ht/mramXEcVLMhpJWltLYWraVbu6VcYqx6ZdJ9aWSTqJdzs4ZTLscuGyfNMq3OrSAlPCzjPueKDP6A673GVpXUs3UUSO/KtbKHmSwPDDpWsICVDnHzFPI9M1qh66dQ0st3dUKCLW66UIHlT4aiO6QrO4/vWS6c9FtS/heqLbqOGm2ouEJDcd4vNujxUuJWnIQonGU1h7b0o6q28ptsBtuHES9vEpmU0jn+9vSfFx9P5UGz9Q+vV8hR7OmxW1uCuXDTKdXLbKlBRKklKQcDAKTye/0q40f1W6goddf1HY0ybWmG/ID7UZSNxQ2paQFpJTyRjtXrXHTvqKfIs2+RF1HFbiIbd/ES08rxuStQ8YcAk8EHOAKw3Tno/1As8i4zvMtWZ5yI822yiSCXHFJIRnZlIAJBzn07UGNt3W/qNfLg6LNFhPFPzeWZjbiB9Mncf0qRGiL9drx09Yu16hiDdS06XWPDUgJUkqA+VXIzgH9ajdeekXUm8SGW5lmtSVJVzLYMZnd9VFGFK/YmpJ9P8AT1wsnT+DZL1N83NbZW248FFQAUTgAnkhIIH6UHDem/WLV19OqPxGTFX5CxSp7G2OlOHW9u0n3HJ4rX2Ouut12CbLVLh+M1JYaSfKpxtWl0nj/uJq9sPRjqBYp99bgiGmPJt0mIXg4hXmEKHDaQSCkqISMnAHPNYWP0W18jT06KqxgPuymHEJ84xylKXgo5347rT+9BnJfXDXkXStnuSo8ENyHnkGUttJD5QR8oQCNoAUOfXP0rX+surW77dNNXv8Jt/jTbS3Id3oJ/iB11BB5GU/JxnPFbHe+k2tJPTHTNoYs4VcIcuW6+15pkbEr2bTnfg5wexrH6p6O65nW3TLUWyhbkO2eXfHm2Bsc8w+vHK+flWk5HHNBpvVdd2d6ly3Ln4HnVqZUz4QASGyhJaGB/ubc1OCxicLLAF3LZuXl2/NFv8AL4u0b8fTdmo7dXuj2p7xqCLe9PNMyXFxWEPMKeQhbbjaEp4KiEkfKPX3rvmim7w1pW2o1KsOXkNDzSgUkFeT/d49u1FZqlKUClKUClKUClKUClKUClKUCrW43CFbI5fuMuPEYBx4j7gbT+5NXVRM+JB5c3rBAt9+lvRbGhpgJcSnIbbUf4iwPU5z79hQbZ1M6z6h051HesloRa3raDHLbjjSlqUHEIUTuCwD+Y44rtkLV2m50oxoV/tMiSApRaamNrXhIJUcA54AJPtioOajYtUXXYj6euT1ztTTzKGJLwIUpICeOw4ByBwOBWZ6VzI1s6kvvXB9uM0licgrdUEgKLLgAyfUniiJho1xpNxDim9TWRSW07lkT2iEjIGT83AyQPuRVZnV+m3m2Vs6gtDiHnfAaUmY2Qtzj5EnPKvmTwOeR71Ayyf9l6h/4JH/ANyzXZfh76b23VlhF8nzZ7ci23QlhlpaQ3lKWl5IIPJOAcHsBQScdvFsZuKIDtxhonLGUx1PJDihjPCc5PFaJ1I6m2206Iuly0pebLcbpFDSkMokIe+VTqEKJShWcYV398VFKxSLVO1Hd5+s7tdIM4Bx9l6Ijc4ZO7OCe45+33FYiw/9lak/4BH/AN1HoJZdF+p7uqNNzbjq6VaretuYIzJCvASv5ArHzqOTye1XHXLWeoNK2u1yNLm17JS1hx6W82nsAUhAUoA5yckZ7VFO0RLDI0VeHrleJDF4juJVAgJSS27uwFqPHfA9x2Hetg1BJmSOhulxMWtbbV0ktxys5/hhCeB9AoqoN71N141faXbc0hmwrW9EQ86WwXk7ypQOFJcx6ducHI9K2y39TtVJ6rO2i7L07HsjclxpwKmNJU22nPzZ8TO7jkY/QVGe8/8AU7F/wZ/+u7W9ORGLh8RkmHLR4kaRfnWXUZI3JU4oEZHI4J7UHadH9eo2oddxtPu2hmHHfecZROVPCkkgK2YGwA7iAAM91DvW19R9T3SDPj2qx3LT1qW6ne7Ouk1CS3z+VDROVE98nior6BFmtXV2Ob0UsWyFLeUkrUrCFthZa7cnCwj7+tYm3IhXu5XmRqm5OR5qkrdQ46tXzO5Od2EKJ+3H3FBPmA+mTCZeQ+zIC0A+KycoWfUp5PH61rl06g6YtWp2dPT7q0zdnSkJZKFEAq/KCoDAJyOCfUVzz4W0xmNOXaPBva7nHQ8hfhmMtpMdSgcgFX5s4Hbtj61caxidMHOrcNy/SVo1PvZPhAr8JTnHh+JgYzjb6jjGaK7LWGXqvTzczyjl9tSZWceCZbYXn225zWv9b5kyD0q1FItylokBgJ3I7hKlpSsj/ulVREsdn0hL0g5Lu2o5EG++a2JjJjF1PhYHzcdz35z6dqCdsybFgxVSZslmPHSMl11YQkfqeKtrTe7VeErVaLnCnBH5jGfS7t++0moadRpq3bboq1Kvcmdp5uJlEpTKm8/x1pUdhOSUpSkD6D61X08Lfp3rXYWun12k3KC5IYbLqklJWFkBxB4GRjPOOP0zQS5g6u03PkmPB1BaJMgJUotMzG1qwkZJwDnAAyauYd/s86G9LhXWBIisp3OvNSELQge6lA4A+9Qf6b2hi+awlwpbj6GTDmOHwV7CSlpagCfbIGR6186cWtN1iavQ5JksojWN+XtZc2h1Ta2ylKx6pyc4oibb2qLAxb0T3r5a24K1+GiQuW2G1LxnaFZwTgE4r5/SrT/lY8n8dtflpKill3zbex0g4ISc4JB74qCEV5w6DubBWfCTcoiwnPAJakAn+QrJ6ks7EXpvo66pdfXImrmtrStzKEJbcTtCB6fmUT7k0E5ZV6tcN6OzLuUJh2SMsocfSlTo90gnnuO1fbrebZZ2kuXa4w4LavyqkvpbB+xURUGdd24QrHo2WJMl52ZbPEUHnNwbw6tISj+6nA7Vc6jmr1BrqF/S2Y+iMYkZJcUsp2oLCFAg7VYBJyTtPcmgmynUNlVbHbkm72829rHiShJR4SMnAyvOByR6+tW7OrtNvxHZbOoLQ5FaUlDjyZjZQhSvygqzgE4OB9KhpAj26DpzVrdr1GqR4kYJVCRHc2rQH28LLhCRkcc7R39M1jrTaGJPTC/3Rxb3jw50VttAWQjCwvJKfU8Dmgll1W6oQtCWa3zozMa7OTXdqGUSw2S3tJ8QYCspyAO2Oe9ZjpfrVjXmlWbu0y1FeK1odipfDqmSFEDccDGQAeQODURJkRqR0Ot9xdSpcuLfXYTThUfkZUyHCnGcfm57V3/4VXLN/QBbNvcQbsHS5cEBSiUkqWGyQeBlKfT2oO00pSilatrjQOntbNsJ1BC8ZxjPhvIWULSD3GR6fQ1tNc26p9XbP0/lMwXoz0+5uN+L4DSgkISTgFSj2zg8YNBRl9DdEPz2pYhSGFNJbCUMvlKBsAAOPfjJPqcmr5/pDoqRqF28qtYMt1S3FpDhLZWrOVbO2cnP3rQx1us+tdKamtDkF+2XB20yyylaw4hwhlZICgBg4BPI9K5b0J1gzodrVF6kMeaLcZlCGA5sLilOgYBwfTJ7elEd6jdB9FR2ZTTbE/ZJbDTmZJ/KFpXxx7oFbloXRtp0RanrdYkPIjOvGQoOubzuKUp7/ZIrnts68WxzRj2obva3oSPMmLFjNvB5yQoJClEfKkADI5NWekviJsl5vLMC52uRa0vrDbb5dDqAScDdwCkfXmit3l9J9GytSi+u2hHnisuqSFHwlrP9oo7Z9fvzWEi9CdEx2ZbLTU7bKaDLgMoklIWlfHHuhNWmruvWndPanVZ0xZU3wHfClSGiAho5+bHqoj17dq4P0ZukSJ1pYukl8NwGzNkLdVnAQGXTn9qIkQ30L0Mm3piKt77iEveMFqfVvzgAp3DB28Dis5qbplpnUVjttolw1s2+3EmO1GcLYTkYP3rmcv4mbQ3PU3FsE16GDgPKeShRHvswf86zur+ucKy2Ox3i2Wdy5226Ic2uGQGVNOIICm1J2q5596KvpHQbRT7cZDjE/bHb8JGJJ/LuUr291Gsq30j0sjWH9JktS/xTzZm7vHOzxCrd+X2z6VqGp+v0SzqsyIdicnruMFqWUplBBaUskeH+Q5Ix34rqepNSxNM6Vevl9BjsstpU42g71bzgBCe2Tk49P0oNYvvRzRl7vi7tLtq0S3HPFd8F5SEuK9ykHGT9MVS1J0W0XqC7PXGXb3WZLytzvlni2lavVRT2yfpWkL+Je0mBIdbsUrzKHUpaYW+E+Ig5yrcEnBHHH1710zpRrlPUDTTt3RAMANyVR/CL3iZ2pSc5wP73bHpQZvSumrTpW0ottihoixUncUgklSj3Uonkn71hLz0z0xedXMalnwVLubSkL3BwhC1IxtKk+pGB+wrnepPiPs9su78O22aTcGmVlsvl4NJUQcEpGCSPvisF1C60vaj6cOyNMQ7rbZAlIaflNulPl+yh8yO4VyOcfrQSPlxmZkV2NKaQ9HdSUONrGUqSRggj2rmS+g2glSy/+GSEpJz4IlL2fbvn+dcz6VdW7tY+nV8uN9jXC9+VnNhEmTKV83iJA8MKUlWNu3dj/f8AT12Wz/EXDucm1xUafdRKmTBGUjzWQ0klASvOznJUrjj8vfmg6bqPp3pfUFiiWi4WtoQ4adsYM5bUwP8AdI/n7+tWWi+lek9Hz/PWi3qM0ApS++4XFIB77c8D7gZrStG9emtSu3dCdPLjfh9tfuJJmBe/wgDs/IMZz39PavulfiBtd2hXeZdLS7bY1vZS7lMgPKdUpQSEJG1PPPvQbPp/o3pOw3Rdwt7MwSVtOskrkFQ2uJKVcfYmvlh6NaSsSLmmAzMAuMNcF/fIKstLIKsccH5RzWixfiZtC5wRJ0/NaiFWPGS8lagPfZgf51pfXzqLfDrdpOnrndbbbBCZUytiQ42iUlY3+KAMf3tnryg/YEdhR0I0Ui3vwksT/AedbeUPMnO5AWE849nFVez+jWkp1gtVmfZmGFbVPKjgSCFAukFWTjnkCtUu3Wx7SukdJyblp6S/KuURS1pelFtaS2rZuOUEnd+bP19e9VdY9eW9NGybtPLk/idrYuQxMCPDDm75PyHONvfj7UVst36M6Su0K1xJjMws21gxo+2QQQjcVc8cnJNXOoukekdQRbczcILm+DHRFaeadKHC2hISkKI/NgD1rRJHxGQomopdtmafdbZjPOtKfTK3E7N2MJ2epAHf1q4uHXW0SenirhNiT4Eyc49FYjw30qeTtSnLgWUgJ/MOcHn3oNutnSfRUSw3WyQYh8OZsbmOB8qewlSVpSVf2eQk44qnF6M6SjadnWVpmZ5GY82+6DIJUVIztwccfmNc66LdT9HRLwLRGs021yrm6lK5kiUZJfd7J8RRwQST6DGTUjaDR7b0t0rB0lJ00IS5FqkPmSpD7pUoOYSNyVDBHCR2+vvV5oPp/YdCiaNPsPNmYUF4uulZO3dtAz2xuP71tlKBSlKBUWfiP03ebd1Fj6riwXZluWlk7kI3pbWjjarg4zgEE+9SmpQQ50yi76iXqW5NaQhMxBbpbjs55p1TjZ8BYAQtSsFZOOw9TXP7VpadcLJeZyGH0qtyGnCgtn50qXsOPqMg/vX6DUokQabs141F0zitW+3yHXLDLeU8020d5afCSF4xlWFNqBx2BHpV7JY1B1TvdigwdNtQPKMoirfjx1IQEgjK3FHgY9B+3epsUoIfOWjUnTvq1PWxpz8a86463EL7KltupcVkKCuwV6H9fvWo6G01dLzrV+1oiqjypDExtIKClAX4DmE57AZ4qd9KCB8Fy8WKDN05M0y5IkOSEqLT7TmQoY42pwVduOcc8V2TWGjp8v4d21zbJEtdzhP+fTDhNKTsQTtO4Ek7ik7jz6D2qRlKKhH0Q01L1B1MsrU5h/ykI+ZWXEnAS38yU8+hUQP1qS/X3T0/UvTWdDtDSn5jbjb6WU/mcCTyB7nBJx9K6LSgglMVqd3p8m0P2Btm126WCqSYZRI8Ve47Co8n19PQZ9KkP8KTLjPTWWl5tbavxJ04Wkg48NuuzUoINakXKhXmVKa0tc7JfQ8opdjLWhnJPJ8JSCcEZ4Csc9sV0K32PV+oeh2pG59j8OcuSw+xsiJYflIScqJSkDdgdjjJ578VI/VN6a07p6fd5DLz7UNouqbZTuWrHoBWodJup8XqILgI1skwVw9u4uKC0qCs4woevHaiIu22ddmul180w7Z5CGEy0Ty+ppYUHMto8PGMdgT78V3L4Wbak9OLl5mIkP8A4k7sLrfzD+E1jGR713OlFQd0dbtQ6XvOpYbmn5rz7lomw3QpBQGkFHLmSMEDbx75GO9WGj9JXe/2DUTFuhyHJMdtmSGQg7nQlRBCR6nCs4+lTxrR9N9VNJaj1A3ZbRcHXriveEtmO4gHaCVckY7A0RF+23y+vWS0aZa0JCmvwHFEF+3uKccKifzAEe/J+g9q2b4htJX3Zpe5C0BDDNpaiSG4LRLUZ1KlKKcDOE/Pgc+ldb0l1ogak16dMs2aewsrcQl9zHBQCTuT3SOPf2rq9BD3qk3ftWaB0ZezZZLbcVl2E4lptStgSUhKiMZAUEk57VqnUY3e5DS5mWaVD8vY40ZoKBUXUIKwHMY+XPPB9MH1qdtKKhjoWA8v4gmC/EcUwbs+SVtnaRlfuMVv/wAUujbjIk2m+2eCp+FGZLL7bDefDO7cFFI9Dkgn6DNSPpQRB6fv3jVfUC2vx9HQnQhbQflS2nVhlKTkr3bgkHHYY9sCpfUpQKUpQKUpQKjT8Rt31yxqrwbM/cWLEyyghdvUoALIyrxCjkH2B9MEVJauQdRejkjVOrn9QWvUsm0yn20IWlDZP5UhIwUqSewoOT9PtVajsi7ldkaubv0OHAedXEXKdUoL24QSh1IJAURkpz96wTNx6g3vS911sNVyERoMgNuNCattRUSPytp+XHzDjj1rtGgugNt0/NkS71c3Lq48w7HLYa8JG1xJSonkknBPrx3rXJPwyIM5fldTLbglWUtri7lgexIUAT9cURyvWXUvU17j2OSq7T4shuGWXzFfWyl5SXV4WUpIGSCAftWT1PrDWeltX2p57UkuSoxIknw0rUGihTaTsUgkg8cEnk966tq34eI1zTaWbLd0wI0GJ5ch2P4q3V71LU4SFDk7u2PSvWtugr+pbrDmI1A1HEeFHibDEKtxaQE7s7x3x2oN763armaO6fTLla8CctaGGXCMhsqP5seuADj64qM79w6gWzSdu1wrVclUaXJLSGvOrWsKBV+Zs/Lj5Txz6cVLvWWm4GrdOS7NdUqMaQkDcg4UhQOQpP1BFcKjfDIkTE+Z1MtcIKzsRF2rI9slRAP1xQc+6r6/v9zm6fuMa6T4Bl2hlx1mLJW0gub3EqUEg+pT/lW/ald170z01etQXe+tT5N3cbjRg2644iIpW5ZUlCxtHypwMfSth6hdBW9S3OA7ars1bIUKC3Cajqjlw4QVHO7cO+6tw63tWxvpZche4r0qG0GshhQS4k70pC0k5GRnOD37etBG+7TtfW3pxDv8rVDzttvEkBCUzlmQ2tO/9gcHIB9siref1F1QjRmnbPFvc1lcjxX35SpCvEXl5SEguE5CRtPr6/StNuosLUAt2l+5SpKnQpK5LKWUtIwcjCVq3KJ288Yx6547xpXoqjV3SnT67hIetV2b8VxtZb3ZaWsqSFJyD9Rz60HMeoN/1jZbtFt03V65i48RCUv2y4LUhSSVEbyCMrGcEkZwBWTsd91XcOsSrXb9ST2Fu3F9lrxn1utNjK8fwyrBwOw7dq6BcfhmbcTEFv1CGShgJfLsYr8R3colQwobRgpGPp35rP6d6Gv2jqO1qhV+adQiY5K8uIpBO4q+Xdu/3u+KDj/T/XWpxK1LbZl7nymnbRPILr6lFtxDK1pWgk5Scp9PerfQepNaL01qRNhuNwkzCY6SC8pxxKCXCotgkndwM45xk+ldXsPw+SLXc58s6iadEqJKjBIiEbfGaWjOd/ON2ceuKoW74cVsWqbEf1N87zrTzbjUXbsUgLHOV8g7z2x2oOS2e76vXJCXdbyrbc/E2iJcJchpRPpypOwfqRW0am1drDU/VRyyQtSCyphulhsuyvAYCmh8ylEfmKlJJ5z3A7VuLfw4PS7g27fdXSZrKAE4DB8TaP7IUpZwO/pWZ1v8Ptr1BqEXKBdHbc25s8djwg4FYABKTkYJA9c880HGtL3zVF+6pJtMzU89Kpsp+OtyLLWplKlBY3NpCgNoJynGOw7VZdEbY9N6xWeM3OdjrYkreU6jOXA2CpSDyOFBJSfoT3rtmlegY05r2Jfol7SqFFlKeaiKjncEc7Ule7kgEc49Ko3H4d46tWG62q+rhxTI8x5dTG8o+bJSFBQ4+47UHMrfrC72nrXeZK7hOfjQ5Vxd8suQstqS2h5SUlOcY+UcVaxLp1A1bZr9qxvVLzDFrIW8yJime/OEIT8uPvjP1NdltfQzy3UeRqWZeGpMR+TJechGMRuQ8Fgo3bvZffHpWv3D4Zml3B1Vu1ItiAtWUtOxt60j23BQB++KDn2rOpOo730705Icuk2PPjy5UV5+M8povpShlSSraRkjeR/P1qz1FqbWdpsekrgdU3AplxFuMoQ6oFAS6ofOc/OSfU+nHpXbNUdBIlw0rYrJZrr5JFuW86688x4ipDjgQCo4Ix+QD7Y9qtdSdBH7xYdN25OoGmjaIzkcuGIVeLucK8438d8etB2HR9wdu+krJcpGPGmQmZC8DA3LbCj/ADNZesZpe2GyaatNqU6HlQYjUYuBO3fsQE5x6Zx2rJ0UpSlApSlApSlArUdddRdN6I8JF+mlEl1O5uO0grcUntnA7D6nFbdUSfiNYNu6yRLneoTkuzutsLDe4pDraOFoCvQ5z/731oO+aH6q6V1nNMK0zXETQkrEeQ2W1KA7kehx9DWJvPXTQ9rua4Sp0iSpCtq3YzBW2k+vzcZ/TNcN0g9YtTa3ntaM0nOhzHo0jyryZ5CIpLKkhRQE9iT/AHu5rSLJPslnsWo7ZqKwOyL28nw4j6lFBiLGQcj6HB+uMURLXUnWLSVit1qnuSZEyHckuKYciNhY+QpCgoEgg/MODVpI656Hjuwm3p748yyh4lLJWGQoZCV7c4VjuBnFRNvVtnwdEaeenIcbYlyZbsZKxjKNrAKh9CQf2rLdU4UWFG0UYkdpgv6ejPO+GgJ8RZW5lSsdyfeglY91e0a1qdmxG6Bcp0oSl1CCpncrskrHY8j6DPfvWMh9dNGSLw5b3HpkVbfib3ZDIS2nYCTyFE87SAMckgVGfqtCjWzW8Jq3x2ozfkYTm1pISNxZQSePUnnNX3S+FFuPWby0+O1JjqXOKm3UBSSQ06RkH2IBoJKWbrVom6w50hu5OR/JtF5xuQ0UKUkED5fRRyQMA55q+snU/R+otO3K5tz0IgQgBLTKbKSgK7ZSc5z2GM57VE3pPb4dwc1d56M1I8vp2bIa8RIVscSE7Vj2IycGsbp23z7ho7U34ehxxMdUaRIQgEktgrBOPYFST+lBIq2dS+j67ygM2uHFeK8JlrtSUpz6HcBkfcgVtmr+smltKXw2q5eeXIDaHAuO0laClYyCDuHoaiZGuOnHbXaor9klSJrSiHvLOhgvZPHzELKj+gx6VmOtUfy+tYUcxXIgRbYSPLOueItrDSfkUrAyR2ziglJbOrmkZ7F8kJnLZiWhaEPyHUYQsqKgnw8ZKs7D6ZrE23r1oadcERfOyo+9W1Lz8cpbJ+4zgfUgVqHxFaGttk6dpe0tZ2ojQmtOTPLpPKAhYSVfQFf86403e9Gv2axQv6Hy5FzYSUSnGZpaMlZIx2Son7YGO3NB0fqLqO5W7rqGRq64sxW5MciOylRQhC0oVsCQdqgQrufeux3Pq9o226nFik3TEsOeE44EHwml+yl9hzx649cVGPqY0WOsrDRYXHKBbk+Cte9TeGGRtKvUjtn1rF2xSdPa2u0HUmmfx6c4tyMmM44ttQeUrhYwCVZ9PfPBoO29Qet1mv8Aoa9xNKyLtDuyGm3G3wnwSkB5sKwpKsjIJH61b9AOoHkdH6hu2t79KejsSWm23Jby3lZKVHagHJycdh7VHezf9TvX/Bj/AOs1WRYt06T08kTIyFrhRLiBI2jISVN/Io/ThQz9frQSysHXLRN6ubUBubIivPLCG1SmShClHsN2SB+uK6PcJsa3QX5k59uPFYQXHHXDhKUjuSagzCmacudwssaPpudLlbEMrZiPiP4rmR2+ValffI/SpVdc7bNuPSG8Rbcy4uQlppZaR8yilC0qUPrwDRWLHX7QhneX85M8Pdt8x5VXh/f+9j9K1Hrr1huNhvFsh6MuDaUrj+YecLKHEOJXgtlJOfTdXBINxsCdPMQ59pffnofKlOMLDSlo9ishX2wEgVv3Wu1qjaD6fyGLTJt0YRn0lp5zxVt7lJUhKl4GSRkgYGO3pRElulOpzq7QdqurilLkraDchSkBG55PCyAOMbs4rba5x8P2oIl/6a25MOO4x+GpRAd3gDe4htBUoY9Du9ea6PRSlKUClKUClKUClKUCrafAh3FgsXCJHlMn/wDbfbC0/saua4L1t6o6itOs4uk9GNoTPWG97pbSta3HPyoSFfKBgjkj19MUG53LqDoPQ9+dsCktW6akoC2osEpTlQBTylOOxFZHX9w0Xp7ZctTQLc/PXwwgxEPSXiOwQMZP37D3qI/UCXfJvUsu6riJiXoLjNyG0kEEpQgBQwSOQAeOOa3nU/VvV2odXzVaXMCHHgFwMKcbY8TwwcE73fVWB8qf54oiTjtrsmpIMKVcLRElteGFspmxEqU2lQBxtWMp7DI+lJeldPTAwJditT4YbDLQdhtq8NA7JTkcJGTwOOajdceruvW+m/mpSHrdcW7gy23PMNKUyGlNukpwtJTkFCTkD/zs2eqfVJ/Rzd+jKCrXBdLUqcphk+KtShgFOBgDKR8o7nk+xXaOoGo+m+mb2zE1XbbebguOh1BVbA8fDyUp+bae2wgD0xW5WvT2nUONXK32S2MvuJ8RL7cRCHMLHPIGeQTn71DLq/q5et7jYrw+ylmSq1pafQj8u9LzwJH0PB/WulXrqjra86oZ0r09bQ2uI0GchttTjqkI+ckufKkAgj9PriiJDRNK6ehF4w7Fao/jNqZd8KG2je2r8yFYHKT6g8VWten7NaFOqtVpt8FTo2uGNGQ2Vj2O0DIqN1l6ta2uVg1LaJL4jajtTKpbchDDe4hpYDza0EFOQCTkAflNYT/bnqn+gnhC7/8ASAXDJkeXaz5fw/y7du383rjNFSdlWrSunEPXl+3Wa2hkFa5nlm2yn/vAZyf51jNPOaR6gsvXhqxRZe1zwRInW5IU6EjhSSpOSnHb/SuBam6q6wY07YLI87GlXW4sImPvyYzR4cWS0gJICBhISokjufTFbN0k6i69ka0Ys+pIyrnbnFeC5JjsIUlg4yFeI0NhHYH/AMqI7vfr9ZbKhpN+ucCAh/cGxLfQ2HMYzjcecZGfvWvM3bp3bFsXBmZpWIuQCtqShbDZcAJSSlQ78gj7iuS/GP8A1Wk/8Ur/APFXBb3d2J2n9OwGkOpdtzDzTqlAbVFby3Bt59lDvjmgnYmy6Yvy27wm2We4rfCXETfLtuleOAQvBzjAwc+lXtyjWxgru82JHU9DbU55hTIU42kAk7TjPbPaog2fqZq6yTrDZLXdyxa0NQ0JY8u0rAWhBUNxSTyVH19azut+pmrkdTLxp5N4Is/nXInl/Ltf1ROCndt3dvXOaDsGh7z0x1jcpNu07Z7W7ISwXXUqtSWwWwpI5JQAeSnit9j2ix2WBJTHt9tt8JwZfDbKGm1DHdeAAePeoU9IZ2qoN5uh0NF8xdXIC0qVhJLLYWhSlgK4J+UDHP5u1bTeNeao6j9MLhb5LZky7fLZffXGRtU8wUrHKB32qCScDtzjjNBIy0XXpzAmKVZ5mlIso8FUVcdC/tlPNbmy62+0lxlaHGljKVJOQoe4Nfn1bGtOOQw1dnbtDnZILzTaHWhzxlBKVD68n7VvkjqRqvRdwt1ksd9RJs8RiMWkMx2yl1Cm0rIBUjcM7j35GcelBLVOl7Amd51NjtYmbt/jiI34m733YzmsjMiR5sdTEyO1IYVwpt1AWk/cHio0R+rHUDS+vIUPXMVpEOctK/K+GgFtpasAoUn29lEnjn3qhO6rdQ9aaluTHT9sNQYYU4lttptSy0k43KLmck+w/nRUkD+DaXtLjhFvtFsaIK1YQw0gkgAnsBkkD9q92W+2m+tOOWW5wrg20QlaoryXQk+xKScVFq+dRb9r/o3fI812M1Itj8dyatKNvmo6l7UgDBwoObCcY4H6HZPhAZuWL6+JDf4QNqFMY+cv8EK7dtuR39e1BJKlKUClKUClKUClKUCuJ9a+klz1VqKJqLS01qNdGkpQ4lxam8lJylaVDOFDt+grtlKCKl16E63k6kbnv3CLcllTTj0mRIVvUoBO4cgkgHIHuAO1ZLU3Q3Vdu1XOuGhrmyzElKWpP/pCmHGgo5KMgcj2OakzSgiL1M0DddFdJ2V6guq506VdWR4SXVLaZSGnuBu7k55OPQVZ6F6Zap1foKKuwXkNWqU+4JcOQ+tDQWhQ2r2gHdkY9O4/aV+p9N2jVEBuFf4Lc2K24HktrJACwCAeCPRR/eqmnbDbNN21NvskRESGlRWGkEkAnueSTQRx1t8P98cVZo+nHIb8eJASy86+74alvF1xaiBg8fOMVktXdEtTsamRftEXNqLJeQFOjx1MracKcL2qA5STk+nepH0oOLdGuj0nS0u53TVMpmZcZzK45bbUVpCFnKypRHKjj/Pvmo43PRMmF1N/oiHW3nlTURgto5G1ZGCfqEkE+3NT3rU4vTzTEXVKtRs20C8lxTxkKdWo71AgnBOOxPpQc66y9GpepJttumk5DEaZEYbjFh1RQnaj8ikqAOCO36D9bbpf0q1hb9YM3zWF+ccQwd4YalrcLygMJ3k4G0e3PbFd6pQce+Ibp7e9et2EWERcwi+XfHd2fn8PGODn8prmt66D6rlWDT0WK1a0yojDyJKvGxuUp5ak87eflIH8qlXSgi3eOgWqHXLNMt0u3olNRmUSErcP8N1sBO5J24UMBJ/ek/ofrR/XD12elQZja5ReVIW7sW7zkq2AYGfapSUoIn6e6E69ti5r8S5xrbJMcobVHlKHi5UkFtRAGAU5PryB96zkXoDfIGii3BusVvUS5jcorQtaEIQhC0hCVgZ3ZcJzgD0+tSUpQRQn9EOo9/lRxfrrEfS18qXpEtTpQknnHy5NaN1R08zZOp34A08tbUdEON4vZSv4LYKvpySanRWqXnp5pS83td3ulmYkXJZSpT6lrBJSAE9jjgAftRHH7H0O1HL1xFuWsb6mfb4LoLSlvLceeQhWUJ+YYSD6jPv96sb70N1daNST5WhLu1HgTNwwJCmHEIUcltWB8wH+lSZpRXDNI9DFW3p1qGz3Ge0bteUNhTrQJbZ8NW9A55PzDk/8q+dDOmmrdC6llLus2KbM40oFmO+pQccyNqtpA7AH967pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpmvmaD7SsJftU2LT+0Xq7wYKlDKUPPJSoj3Ce5rBI6raGX21Nbx91Ef5ig3jNM1p7fUrRjn5dT2r9ZCR/nVy3r3STn5dT2X9ZrY/zNBs+aZrBtar089/VX61L/wAMxs/61eNXe3Pf1VwiL/wvJP8ArQZDNKoJlMK/K82fsoV7DqD2Wk/rQVKV5zTNB6pXzNM0H2lM0oFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJrlHX3qQ5oeyMxLSpP41PB8JRGQygd149+cD9fauqqOKhr8TsxyV1VktLUSiLGZaQM9gU7z/NRoOX3CbKuMx2XPkOyJLqipx11RUpRPqSat6UohSlKBSlKD0lxaPyrUn7HFVUzZSPyyX0/ZwiqFKC/bvN0a/qrlNR/hfUP9au2tV6ia/qr9dkf4Zjg/1rC0oNla17q5rGzVF749DOcI/mqt00V121XYpSE3WR+MwMje3Ix4gHrtWOc/fIrk1KD9DNJait+qrDFu9od8SK+nOD+ZCvVKh6EGsyKi78It7fReb1ZFLJjOMCWhB7JUlQSSPuFD9hUoQaK9Ur4K+0ClKUClKUClKUClKUClKUClKUClKUFus1Cn4iF7+rd5+gZH/wk1NNw1CPr0vf1Z1B9HGx/wDCRQaBSldE6FRYT+s5EickrVBt0iZHQloOqU6hPy7UHhSgCVAe6RRGgyIsiNs8yw6z4idyPEQU7h7jPcVlNRaefscSyyH3m3BdIaZraUZyhJUpIBz6/Ka6fN1JbLxo7Usa4X3UWoUFjxWTMt4xDf3DYvxAs7Ek/KRwOayztujOQbDKittXDUtv0tGet9tdRlC/mWVuYxhakg5CPXGecYoOX6YiaLbtXndU3G6uyitSU263MpSoAdlKcXxg+w5q7nQdBXK1yXbLcrrabiw2pxMa5oS62+QM7UrbGUq+4rIaPkosuhr1rBMGNcL2bgiG2uU0HERQpJWp3Z2yT8oJ4FVb3PTrTppcr/d4cKPebZNZZRLjMpZ80hwKyhQSMFSdu7PtQcwrJX2yTrG7EbuLaW1yorcxoJUFZbcGUnjtx6V0fWV1i6BnxtNW2wWmSyzFZcnPz4odcmLWhK1fMeUpGQBtxjB5rZrtY7VqjqfETMYSxabVpdiaYr7xQNqGklLa19wBvTk+wNBwCldm1Ba7PdNJXd6cjRVvuMNkPwXLLMwXtp+ZpbZUdxKc4PfIqwkaKtdx6gaXFvZTH07doLVxdAcO1ltCSZAKiSRgoV3PGaDlFKurq5GductyAz4ENTqyy1uJ2IydoyeTgYq1oO3fCYn/AKe3Nf8Adtyh+7jf/KpZoNRT+EpP/Sy9L9oQH7rH/KpUoNFVhXqvIr0KBSlKBSlKBSlKBSlKBSlKBSlKBSlKCxdPFQb6zueL1S1Gr2lFP7JA/wBKnG72qCPVRZc6k6mJ9Lg8P2WR/pRGrVdWq4zLTcWJ9tkORpjCt7brZwpJq1pQbRqLXuotQW7yFynJMRSgpbTLDbIcUOxXsA3frVkvVV4XdLVcfOKTMtjTbERxCQktob/KOBz3Pfv61hKUHWtGxtZPMS9Q6X/Cbum5qULlaEJQsfmOPEjnAweSCn3PbmvOvbZre46cXJ1BbbdpyxwP4jNvbSiIhxw4B2NZKlrxk8/XHtXKWnXGlbmlqQr3ScGvTsh55SVPOrcKe29RVj96Dp8jUE+PBZj3Ww2O/S7Sy2w1LkZLrOEghtaUrAc2nIAIP5Tn1r5CumsrnqqXqxm3x5TrDPkZjSloLclKGQlxG3dlZKU7iE5wT9q0pjU89svOrXvlL3FL2AkhShtUs4HzKx2J5B5qnbNTXW2WmTbYkhIhyCVKQtpK9qinaVJJBKSRxkew9hQdBv8AbLiq1u2yw6Fh2o3DaZD4miU4gJT4uNylYZSR83OMgd6pRdQ3my9MpEB7T4cLCZEBq7CQFeXbecHiJ2jPcoUkKyByf1w03qfeHbx52GxEith0PBlDeNyg34aSpadqlEJJAOfU+5qwu2v7xdbBItMpEQR5DhccU22UKUfEU52B2/mUeducYGeBQalSlKDvnwko/wDXeoF+0dpP7qP/ACqUDZqM/wAI6MydSr9kx0/uXP8AlUl2/SirhPavYqmntVQUClKUClKUClKUClKUClKUClKUClKUFg72qHHxD6afsnUCXO8M+SuZ8w0sDjfgBafvnn9RUyXBxWuaw01bNU2hy3XmOHo6uQRwptXopJ9DQQJpXb9RfD5do8harFcosqOSdqZOW3APbgEH78fated6I6xR2YhK/wAMgf6iiOY0robnRzWaO1uZV/hko/1NWznSbWqP/wCFKh/uyGj/AP6oNFpW4OdM9Yt/msMk/wCFSFf5GrZzQGrG/wA2n7j+jJP+VBrFKz69F6mR+aw3Mf8Ahl/8qoL0tf0fmslzH/hV/wDKgw9KyDljuzf9Za5yP8UdY/0q2chymv6yM8j/ABIIoKFK+7Ff3VftW+6A6W6g1bMaJiuwbZkFyW+gpG3/AHAeVH7cfWg678JttcZsF7uK0kIlSG2kE+vhpJJ/df8AKpAN1hNL2SHp6yRLVbG/DixkbUA8k+pJ9yTkn71nECiq6e1exXhPavYoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLZYq2cTV6pNUVJoMe43VstqsmtuqSm/pQYtTNUyz9Kyha+lePB+lBjSz9K+eD9KyXg/Sng/Sgxng/Sng/SskWfpXzwfpQWAZ+lVEs/Sr0NfSvSWvpQWqI6CoKKE598c1eNIr2huqyEUHptNXCBXhCarJFB6FehXwV9oFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJFeCmqmK+YoKJTXgoq5xXnaKC2LdfC2KuttfNlBa+HTw6udlNlBa+HTw6utlNlBa+HX0N1c7KbKCiEV7CaqhNfQKDylNewKYr7ig+ilKUClKUClKUClKUClKUClKUClKUClKUClKUDFfMV9pQfMUxX2lB8xTFfaUHzFMV9pQfMUxX2lB8xTFfaUDFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFct1P1fjWHqTH0gu0PPOvPR2RJD4SkeLtwduPTd7+ldSqHvXa4iz9f8A8TLReEJyHJLYVt37EoVjPpnHeg751a6pw+nTttaft7k96YFq2NuhGxKcDJyD3J/kayfSvXsbqDYX7jFiLhqYfLC2VuBZHAIOQB3z/Koz6z1K91L6s2J6Fa1yEhqOlFvDyQV8eKtG9WB6kZOO1bR8KNzctusr/p6UC0p5rxA0o/lcaUUkffCj/wC7RHSNZ9a4GldeK03LtTzgQtpLkoPhKUBYSc7cegV7181D1tgWfqH/AEVFqdkLElqMqUl8BIUvb/Zx6bvf0rhPVqErUfxAXC2oXtVLmx4iVexKG0VrOpLfc9PamtMu++Km6SEtz30ujC0kuqxn64SD+tBJK29e7S/erxDn2qREj21t1xx8Ohe/YsIACcDlRIA59axDHxMWRUnD9huSI+eHEuIUrH+Hgfzrh0NcZOptZqnRXZcYtvhbbK9q8GS38wODyPzdscVafjzlsEaFpm53CbCWTugT4iC2FE9g3uWlWfcAGglF1F622bRlzbtogyrhOU0h5aG1BCWwoZSCTnnGDgD1rGQ/iAtMzTV1ukezTvFt3hFxhxxICg4vaMKGex9xXJurMyCNdiVdBdbBfm4cRanoSA4grMdBIAKkqSUklGQTnb6c51yHfLzd9Baq/EG0yYyER909TIDu/wAdG1CnAMqyCo/MSRigkN/t5sLOjIl9nQZTT0t5xpmC2tLi1bMZUTwAOR/51Yac+IvT9zujMS5W2ZbEPKCEyFrS4hOTwVYwQPrzUcrrZJ69B2K9NsuOW8KfjLWlJKW1hwq59shX8qur/LXrifpW32C3SVzIlrj21TYQMuOoKsqGPT5hycduaCScTrhAe6hvaVctLzSm5bsMSvHBSpSCoA7cf2ikDv61m+kfU5jqP+K+XtjsDyHhZ3uhzfv3+wGMbP51FeRb5Y6sXpiMsmbBlTZCFD1WwHHB+5RXWfg476t/8J/+agknSlKKUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVaSLZAkul2TBivOnutxpKif1Iq7pQWbNrt7DqXWIMVt1PZaGUpI+xAr01boTMgyGYcZt8kkuJaSFc9+cZq6pQWhtsFUnzBhRjI3bvFLSd2ffOM5r7Jt0GU74kqHGecxjc40lRx9yKuqUFqzbYLLqnGYUZtxQIKktJBIPfJxXlu1W9p5LrcCIh1JyFpZSFA/fFXlKC3lQosvHm4zD+O3iNhWP3ryLdCEYxhDjCOTkteEnaT74xirqlBRZiRmGCwzHZbZPdtCAEn9O1eY0KLFJMWMwyT3LbYTn9quKUFoLbBTIU+mFGD6iSXA0ncc9+cZ5ya9xIMSHv8pFYY343eE2E5x2zirilApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlB//2Q=="
+        }
+      },
+      "network-server-latency": {
+        "id": "network-server-latency",
+        "title": "Server Backend Latencies",
+        "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "20 ms",
+        "details": {
+          "sortedBy": [
+            "serverResponseTime"
+          ],
+          "type": "table",
+          "items": [
+            {
+              "serverResponseTime": 17,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "serverResponseTime": 15,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "serverResponseTime": 4,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "origin": "https://js-eu1.hscollectedforms.net",
+              "serverResponseTime": 2
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://useago.github.io"
+            },
+            {
+              "origin": "https://js-eu1.hs-banner.com",
+              "serverResponseTime": 1.5
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "origin": "https://js-eu1.hs-analytics.net",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "origin": "https://cta-eu1.hubspot.com",
+              "serverResponseTime": 1
+            },
+            {
+              "origin": "https://perf-eu1.hsforms.com",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "origin": "https://js-eu1.hs-scripts.com",
+              "serverResponseTime": 0.5
+            },
+            {
+              "origin": "https://forms-eu1.hscollectedforms.net",
+              "serverResponseTime": 0.5
+            },
+            {
+              "origin": "https://track-eu1.hubspot.com",
+              "serverResponseTime": 0
+            },
+            {
+              "origin": "https://fonts.googleapis.com",
+              "serverResponseTime": 0
+            }
+          ],
+          "headings": [
+            {
+              "key": "origin",
+              "valueType": "text",
+              "label": "URL"
+            },
+            {
+              "label": "Time Spent",
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "serverResponseTime"
+            }
+          ]
+        },
+        "numericValue": 17,
+        "numericUnit": "millisecond"
+      },
+      "first-contentful-paint": {
+        "id": "first-contentful-paint",
+        "title": "First Contentful Paint",
+        "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).",
+        "score": 0.89,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "1.8 s",
+        "numericValue": 1801.3256536936919,
+        "numericUnit": "millisecond"
+      },
+      "long-tasks": {
+        "id": "long-tasks",
+        "title": "Avoid long main-thread tasks",
+        "description": "Lists the longest tasks on the main thread, useful for identifying worst contributors to input delay. [Learn how to avoid long main-thread tasks](https://web.dev/articles/optimize-long-tasks)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "6 long tasks found",
+        "metricSavings": {
+          "TBT": 200
+        },
+        "details": {
+          "items": [
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "startTime": 11281.391060308642,
+              "duration": 128
+            },
+            {
+              "startTime": 1045.1302614774768,
+              "url": "Unattributable",
+              "duration": 116
+            },
+            {
+              "startTime": 8111.6933992071963,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "duration": 105.00000000000091
+            },
+            {
+              "startTime": 8552.7910953153041,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "duration": 100
+            },
+            {
+              "duration": 82,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "startTime": 6918.4328762522427
+            },
+            {
+              "duration": 73,
+              "startTime": 5741.1302614774768,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "granularity": 1,
+              "label": "Start Time",
+              "key": "startTime",
+              "valueType": "ms"
+            },
+            {
+              "granularity": 1,
+              "label": "Duration",
+              "key": "duration",
+              "valueType": "ms"
+            }
+          ],
+          "type": "table",
+          "skipSumming": [
+            "startTime"
+          ],
+          "debugData": {
+            "tasks": [
+              {
+                "startTime": 11281.4,
+                "other": 128,
+                "urlIndex": 0,
+                "scriptEvaluation": 0,
+                "duration": 128
+              },
+              {
+                "urlIndex": 1,
+                "duration": 116,
+                "startTime": 1045.1,
+                "other": 116
+              },
+              {
+                "duration": 105,
+                "urlIndex": 0,
+                "scriptEvaluation": 0,
+                "startTime": 8111.7,
+                "other": 105
+              },
+              {
+                "duration": 100,
+                "urlIndex": 2,
+                "other": 100,
+                "startTime": 8552.8
+              },
+              {
+                "startTime": 6918.4,
+                "other": 82,
+                "duration": 82,
+                "urlIndex": 3,
+                "scriptEvaluation": 0
+              },
+              {
+                "duration": 73,
+                "urlIndex": 3,
+                "scriptEvaluation": 0,
+                "other": 73,
+                "startTime": 5741.1
+              }
+            ],
+            "urls": [
+              "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "Unattributable",
+              "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            ],
+            "type": "debugdata"
+          },
+          "sortedBy": [
+            "duration"
+          ]
+        }
+      },
+      "dom-size-insight": {
+        "id": "dom-size-insight",
+        "title": "Optimize DOM size",
+        "description": "A large DOM can increase the duration of style calculations and layout reflows, impacting page responsiveness. A large DOM will also increase memory usage. [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/performance/insights/dom-size).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "statistic": "Total elements",
+              "value": {
+                "value": 524,
+                "granularity": 1,
+                "type": "numeric"
+              }
+            },
+            {
+              "node": {
+                "path": "1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,2,DIV,2,DIV,0,DIV,1,DIV,1,DIV,1,DIV,0,A,0,DIV,0,svg,0,path",
+                "lhId": "page-12-path",
+                "type": "node",
+                "boundingRect": {
+                  "left": 0,
+                  "bottom": 0,
+                  "height": 0,
+                  "top": 0,
+                  "width": 0,
+                  "right": 0
+                },
+                "snippet": "\u003cpath d=\"M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0…\"\u003e",
+                "selector": "a.d_flex \u003e div.d_flex \u003e svg.lucide \u003e path",
+                "nodeLabel": "a.d_flex \u003e div.d_flex \u003e svg.lucide \u003e path"
+              },
+              "value": {
+                "type": "numeric",
+                "granularity": 1,
+                "value": 15
+              },
+              "statistic": "DOM depth"
+            },
+            {
+              "statistic": "Most children",
+              "value": {
+                "value": 64,
+                "granularity": 1,
+                "type": "numeric"
+              },
+              "node": {
+                "lhId": "page-11-BODY",
+                "type": "node",
+                "boundingRect": {
+                  "height": 0,
+                  "left": 0,
+                  "bottom": 0,
+                  "width": 0,
+                  "right": 0,
+                  "top": 0
+                },
+                "path": "1,BODY",
+                "snippet": "\u003cbody\u003e",
+                "selector": "body",
+                "nodeLabel": "body"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "label": "Statistic",
+              "valueType": "text",
+              "key": "statistic"
+            },
+            {
+              "key": "node",
+              "valueType": "node",
+              "label": "Element"
+            },
+            {
+              "label": "Value",
+              "valueType": "numeric",
+              "key": "value"
+            }
+          ],
+          "debugData": {
+            "maxDepth": 15,
+            "maxChildren": 64,
+            "type": "debugdata",
+            "totalElements": 524
+          },
+          "type": "table"
+        },
+        "numericValue": 524,
+        "numericUnit": "element"
+      },
+      "non-composited-animations": {
+        "id": "non-composited-animations",
+        "title": "Avoid non-composited animations",
+        "description": "Animations which are not composited can be janky and increase CLS. [Learn how to avoid non-composited animations](https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/)",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "type": "table",
+          "items": [],
+          "headings": [
+            {
+              "subItemsHeading": {
+                "key": "failureReason",
+                "valueType": "text"
+              },
+              "label": "Element",
+              "key": "node",
+              "valueType": "node"
+            }
+          ]
+        }
+      },
+      "forced-reflow-insight": {
+        "id": "forced-reflow-insight",
+        "title": "Forced reflow",
+        "description": "A forced reflow occurs when JavaScript queries geometric properties (such as offsetWidth) after styles have been invalidated by a change to the DOM state. This can result in poor performance. Learn more about [forced reflows](https://developer.chrome.com/docs/performance/insights/forced-reflow) and possible mitigations.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "details": {
+          "items": [
+            {
+              "items": [
+                {
+                  "source": {
+                    "urlProvider": "network",
+                    "type": "source-location",
+                    "column": 85503,
+                    "line": 19,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+                  },
+                  "reflowTime": 1.076
+                },
+                {
+                  "reflowTime": 0.206,
+                  "source": {
+                    "value": "[unattributed]",
+                    "type": "text"
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "valueType": "source-location",
+                  "key": "source",
+                  "label": "Source"
+                },
+                {
+                  "valueType": "ms",
+                  "key": "reflowTime",
+                  "label": "Total reflow time",
+                  "granularity": 1
+                }
+              ],
+              "type": "table"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "viewport-insight": {
+        "id": "viewport-insight",
+        "title": "Optimize viewport for mobile",
+        "description": "Tap interactions may be [delayed by up to 300 ms](https://developer.chrome.com/docs/performance/insights/viewport) if the viewport is not optimized for mobile.",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            }
+          ],
+          "items": [
+            {
+              "node": {
+                "path": "0,HEAD,1,META",
+                "lhId": "page-10-META",
+                "type": "node",
+                "boundingRect": {
+                  "height": 0,
+                  "left": 0,
+                  "bottom": 0,
+                  "top": 0,
+                  "width": 0,
+                  "right": 0
+                },
+                "snippet": "\u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\"\u003e",
+                "selector": "head \u003e meta",
+                "nodeLabel": "head \u003e meta"
+              }
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "cache-insight": {
+        "id": "cache-insight",
+        "title": "Use efficient cache lifetimes",
+        "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more about caching](https://developer.chrome.com/docs/performance/insights/cache).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 319 KiB",
+        "metricSavings": {
+          "LCP": 450,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "totalBytes": 204717,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedBytes": 196187.125
+            },
+            {
+              "totalBytes": 43679,
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 41859.041666666672,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "totalBytes": 29750,
+              "cacheLifetimeMs": 600000,
+              "wastedBytes": 27270.833333333332,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            },
+            {
+              "wastedBytes": 26781.583333333336,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "totalBytes": 27946,
+              "cacheLifetimeMs": 300000
+            },
+            {
+              "totalBytes": 27210,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "wastedBytes": 26076.25
+            },
+            {
+              "wastedBytes": 4597.083333333333,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "totalBytes": 5015,
+              "cacheLifetimeMs": 600000
+            },
+            {
+              "totalBytes": 1996,
+              "cacheLifetimeMs": 600000,
+              "wastedBytes": 1829.6666666666665,
+              "url": "https://useago.github.io/widgetjs/frame.css"
+            },
+            {
+              "totalBytes": 1642,
+              "cacheLifetimeMs": 0,
+              "wastedBytes": 1642,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js"
+            }
+          ],
+          "headings": [
+            {
+              "label": "Request",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "key": "cacheLifetimeMs",
+              "valueType": "ms",
+              "displayUnit": "duration",
+              "label": "Cache TTL"
+            },
+            {
+              "key": "totalBytes",
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "granularity": 1,
+              "displayUnit": "kb"
+            }
+          ],
+          "type": "table",
+          "skipSumming": [
+            "cacheLifetimeMs"
+          ],
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "debugData": {
+            "wastedBytes": 326243.58333333337,
+            "type": "debugdata"
+          }
+        }
+      },
+      "legacy-javascript-insight": {
+        "id": "legacy-javascript-insight",
+        "title": "Legacy JavaScript",
+        "description": "Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile [Baseline](https://web.dev/articles/baseline-and-polyfills) features, unless you know you must support older browsers. [Learn why most sites can deploy ES6+ code without transpiling](https://developer.chrome.com/docs/performance/insights/legacy-javascript)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 13 KiB",
+        "metricSavings": {
+          "LCP": 150,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "column": 6239,
+                      "line": 1
+                    },
+                    "signal": "Array.prototype.concat"
+                  },
+                  {
+                    "location": {
+                      "column": 12925,
+                      "line": 1,
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1,
+                      "column": 12813,
+                      "urlProvider": "network",
+                      "type": "source-location"
+                    },
+                    "signal": "Object.assign"
+                  },
+                  {
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 10857,
+                      "line": 1,
+                      "urlProvider": "network",
+                      "type": "source-location"
+                    },
+                    "signal": "Object.create"
+                  }
+                ]
+              },
+              "wastedBytes": 13765
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "column": 6239,
+                      "line": 1
+                    },
+                    "signal": "Array.prototype.concat"
+                  },
+                  {
+                    "location": {
+                      "column": 12925,
+                      "line": 1,
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "location": {
+                      "column": 12813,
+                      "line": 1,
+                      "type": "source-location",
+                      "urlProvider": "network",
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    },
+                    "signal": "Object.assign"
+                  },
+                  {
+                    "location": {
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "type": "source-location",
+                      "urlProvider": "network",
+                      "column": 10857,
+                      "line": 1
+                    },
+                    "signal": "Object.create"
+                  }
+                ]
+              },
+              "wastedBytes": 13765,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            }
+          ],
+          "headings": [
+            {
+              "subItemsHeading": {
+                "valueType": "source-location",
+                "key": "location"
+              },
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "valueType": "code",
+              "key": null,
+              "subItemsHeading": {
+                "key": "signal"
+              }
+            },
+            {
+              "label": "Wasted bytes",
+              "valueType": "bytes",
+              "key": "wastedBytes"
+            }
+          ],
+          "debugData": {
+            "wastedBytes": 13765,
+            "type": "debugdata"
+          },
+          "type": "table"
+        }
+      },
+      "unused-css-rules": {
+        "id": "unused-css-rules",
+        "title": "Reduce unused CSS",
+        "description": "Reduce unused rules from stylesheets and defer CSS not used for above-the-fold content to decrease bytes consumed by network activity. [Learn how to reduce unused CSS](https://developer.chrome.com/docs/lighthouse/performance/unused-css-rules/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [],
+          "type": "opportunity",
+          "overallSavingsBytes": 0,
+          "overallSavingsMs": 0,
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            }
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ]
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "screenshot-thumbnails": {
+        "id": "screenshot-thumbnails",
+        "title": "Screenshot Thumbnails",
+        "description": "This is what the load of your site looked like.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 36015148287,
+              "timing": 375
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 36015523287,
+              "timing": 750
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 36015898287,
+              "timing": 1125
+            },
+            {
+              "timing": 1500,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAcDBAUGCAIBCf/EAE0QAAEDBAAFAQUFBAgEAgcJAAECAwQABQYRBxITITFBFCJRYXEIFTJTgSNSkZIWM0JicqGxwRckgtEmNHSDhKOywtIlJzZDdaLD8PH/xAAVAQEBAAAAAAAAAAAAAAAAAAAAAf/EABURAQEAAAAAAAAAAAAAAAAAAAAB/9oADAMBAAIRAxEAPwDqmlKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClfFKCUlSiAkDZJ8CteazjFXrh7C1kVpXL3yhpMpBJPw8+flQbFShIA2T2+Na6c4xZM/2I5FaRL3y9L2tHNv4efPyoNipQEEAg7B9axV5yG12VaE3WV7IhetPOtqDQ+rmuUfqaDK0rQuNcr/AO6S/wAmG/2MdKkOtL8gqT3BFZY5fj1miQI13vluhylMt/s35CUq7pHcgntQbPSqcaQzKYQ/GdbeZcHMhxtQUlQ+II81hbvmON2eWIt1vtsiSd66T0lCVD6gnt+tBnqVSiSWJkdEiI82+w4NocbUFJUPiCPNVaBSlKBSlKBSlKBSlKBSlKBSlfFq5Uk0AqCfJAr4HEHwoVi7lcYlvYMi4ymYzOwnqPLCE7PgbNWEPJbHNkojw7xb35Dh0htuQhSlfQA0Gy0qhHWT7p/Sq9ApSlApSlBG/HB95dnsdoS8uPEvF1Ygy3EHlPRUSVJ36b1qtjl4LjEiwqtC7LATB5CgJSykFPbXMFa2FfPzV5l2OwcqsT9ruaVdFzSkrQdLaWO6VpPoQa093C8zkwjbJWeLVbVJ6a1ot6EyVI8EdTm869dboNEN9uT/AAPhwVTXShy8CyKnpVpS43VKeffzSOXdS4jAcVTY/ukWK3+xcnJosp5vGt83nm+e917ewmyO4SMVMYi0paDSUg+8kg7Cwf3ubvv41rScJzRET7uTn7v3aE9MKNvQZPJ411d+deut0GG4gypOCcFDHx28PSy26mGicpYUtltSyCOYeqR7oPkVIuP45bLfjiLc20JEd5kJfW8eoqRsd1LJ/ETuqduw2yQsPTjIiJetPTLa23veLmzsqUf3ie+/jVqrHrpbLKLPjE9MaNydNEiatUhyOnxpCe29enMo6oIVjvux+EXFCwJdW9brNOXHhrUd8rfUHub+Wv8AOpnwnFLNDxOI2YsacqXHQ5JkvIDipSlJBKlE+Qd9h6CseOGcCPw1nYlAkuN+2gqfmOJ51uOFQJWodt71qjeHZHaYnsGL5S3CtoTytsyoIkKjj1DauYdvgFb1Qapj8t7EP+KNqshKoFna9sgtfiDC1tKWpA+QI3qtp4WYlY2cGtslcOLOlXGOmTLlPtpcW+twcytkjuNnxWawvDoeM2eVELrk+TOcU9OlSACuStXkq+WuwFa7CwLIcfQ5CxDLfYbOVKU1ElwkyTH2dkIUSDr4A7oKHD5luwcT8sxu1jksyGWJzbAO0x3F7Ckp+APnVShWs4RiLGLszHFy37hdJznWmTn/AMbyvQaHYJA7ADxWzUClKUClKUClKUClKUClKUCvD420a90Peg13IxJNtPsQnF7mH/kuj1Nf+t93X+dYKypu/wB6Me1DIujs83tQg9PwfxdP3/4Vuy2SD7vcV5DSyfw0H1gftBV1XhpsIHzr3QKUpQKUqzlXBqPLbjq3zqSVk6Okp+P8aC8pXxJCkhQ8HuKxd+ujltSyW20r5wonYJ0Ejfp/rQZWlYePc337iY4aQhISkk/i0SnetjtXhN0llgFSI4cXJVHSSSEjl5tk/wAvb60GbpWB+/VezlfSQFBlSwObspQXy6HxHrVWJd3X7wuGWkhAUsBXcHSdd+/Y+fTxQZmlYhy8oTeVQQkFIQdK3/b1zcv8Koi+KMRx8NtkNsNPFIV5K97SPn27fOgztKxiri59xpnIQ2pxSQpKOfQ7nsNn17/xq0N+UmL1Chsq6Drh7ke8hQHL3G/Wgz1KxbVxcXOcbIYS0hRb5VL04ohAVsD18/71am8vi3e0lEZSl9IoQhZUUhZ17w+P+vegz1Kwj94eZfiIW20EOAFxRJ93atDsNkfU9vpVa23NyTcH47qG0hPMUcpJKgFa3vx8PmPhQZWlYZi6PvXGRFCGUlPN0iVE83KQD47evjsRVL74lGLFX046XHmFSTzqISEgA8o+fegz1KwLd8ccubUdLADaygAq2COZHN58bHw819h3l+TJjNhpCUuNIcUe51zEjX+VBnaVirRc3Jsp9p1DaCjukJO9p2Rvfg+PQ/pWVoFKUoFKUoFKUoFKUoFKUoFeFtIWtC1JBUg7SfUV7pQK8rbQsgrQlRGwCRvW/NeqUFBMKKl1LiYzIcSNJUEDYHjsa9LjMLaU2tltTaiSUlIIJ+Oqq0oKK4kZfS52GldL+r2ge59PhXoMNBQUGkcwJUDyjYJ8n61UpQU+g1vfSRvm5/wj8Xx+vzrw3DjNghuOykFQWQlAHvDwfrVelBTLDJZU0Wm+kre0co0d+e1eFQoqkNoVGZKGztCSgaT9PhVelBT6DPX63Sb62tc/KObXw3Xj2KL01o9mZ5FnmWnkGlH4n41XpQUPYoo6WozP7L+r9we59PhXpuOy06txtltDi/xKSkAq+pqrSgpIjsoeW6hltLq+ylhIBP1NfHIsdxpDbjDSm0a5UqQCE/QVWpQU1MNKJKmkEkhWykeR4P1qmYUUrQsxmOdvXIrpjadeNfCrilBSajssrWplltClnailIBUfnVWlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBVOQ83GjuPvrS2y0krWtR0EpA2SaqVFX2j8jXZuH67dEV/z95cENpIPfkP4yP093/qoN7xjKbJlMd5/H7izOaZUEOKb37pI2AdgVmq5t4cRP+FvF+JYFyQ7bb7BaHOFgj2gJ/8ArCwB8Fit5yrN8luXER7DMDat7cuIx15k2eFFCNgHSQP8SfQ9z6a3QSzSomGfZPi+DXy5Z3ZG25tvcDMZ2OsBqaVK5QQNkpG9Heu4PYVaWe/cVgbJd5drtNytVyKFOQ4W0PR21DYUVKIHj5n4UEyUqHLnnOXZPnN1x7h4zbWWLOeWXNnhRSpzeuUAb13Ch4O+UnYqyj8WbycNzBu4w40PLMeA6iUgqZcBWE8wG/8Af1B9aCcKVzxd+J+f2fEbDmE2NZTZZi22lRUhfWcJSSVE+E83KojW9dt7rMv57nGP5ri7GUxrSLVkLobbjxeYuRtlIAUo62oc6d+Qe+qCbqVBkHN8/wAjzvKscxtNnbRbZCkolS0KCWkBRASQN8yldu+vQ1l8G4i5HfrDk8Jy0RncwsbnRVHQ4EMuqKikK2T20Uq2N99dtb7BLlK55VxPzDHchsTOQ3HGLizcJCGZEO3ucz0XmIHvEHWxv4kHRHzrY52b5hkvES7Y/gaLUxFsw1JkXBKiHF70Ujl7gb2P0J36UEx0qBLXxTyl+28Q3Z8eFGmWBCeiylHMEL51JUCd+8O3bxVpP4i8SI+AwM1LFjbtB5ErjlKlOu7VylZ9EgnwAdgEeaDoalQzmXFS4G54/ZMY+7Ic+5w0Tnpd0c5WYyFJ5gN+p7H/AC7d+1vZuKt3Vb8vtl0Nrdv1lgrmMS4CupGkJAHfz5BKf4nsNUE3Vib/AJJaMeMQXmc3E9rc6LHOCedfwGh86jfhFkmfZh92Xm5otTGOOIcS4EJPWdUnYCgN9hzdvoP1rHfaa/HhH/6qn/5aCb6VE3ELIs3g3+Q3bZWN2GysthTUu7SE80pXroAkjv8AL9fSsxwRzeXnmHuXC5MstTI8lUVws7CFkJSoKAO9dlCgkGlKUClKUClKUClKUClKUCoWz7h/ds/4rwzfIbjWHQIxSh1D6Ap5ZGzoA8w94gdx4R86mmredNi2+OqRPksRWE+XHnAhI/U9qCBc/wCBEa32mPP4eMSTfIslt1KHJQ95IPoVEAEHR8+hrIXLHs1sOeJzrH7MzOfucJDVyta5CEqZc5UhXKreiNoB2CfXtUxxr1a5NuXPjXKE9BQCVyW30qbTrztQOhXiNfrRKlNRo11gPSXkdRtpuQhS1p/eAB2R86CKH8NzjOMFyKLmcuPElTXUvW6EOVSYpSrm0pae+j2Hk6Hf5VbWr/i5KjWSwJt0axMQChuTdA8271m0jlACTvyO/jyB4re4d+ulx4jybfHn2dqxxGU/s0vNuypDpB3pKV7QkevMN9u3nY2e7Xu1WcIN2ucKCF/hMl9LXN9OYjdBEL+N5jgOe3694famL7ar0rqvRlPhpxpzZO++u21K8b7H01WOj8NsmlYfnN0u8ZleVZEEhENp1PK0gLCuXmJ5d/qeyR33Ur5jmtqxrEJGQKfZmRkAdFLLyf26idBKTvR+PbfYH4Vq1w4gXOdg1hvWMLsJlzFtiWzMmIShnmRzFAJWn3x27eflRGt55geR3TgVjGPQbd1bxDdZU/H6zaeQJQ4D7xVynuoeD61nuKuJXq+5Vw+mWqF149qmB2YvqoT0k87R3pRBPZKvG/FSXc7pAtUcP3SdFhMk66kh1Lad/DaiK9NXGE9BM1qXHXDCSsvpcSWwkeTzb1qiub8Rm5PbOLnESZitrYuwRKUmRDW8GlKBcVyqST27aOx86ybPC7L5WDZjLkLai5LkElEhcRt0AdNK1KLZWDrauY9t67DZ7nUpWZjCcfu828QLjbmJd9X1HHVTwRIUFH8AKteSfw1uoIIBB2DQcxXDAsruNrxoW3A4FnTaZLa30tymi/KI1tZJI7e74JJ2a2AQMgxvi9kUvBFWa7feg55cJ+YltyKvyVKTsK0CSewPZVTdOvNst8lmPPuMONIe/q2nn0oUv6AnZ/SuWs4lR8jZzzIpNoioulkuDUND8VbrXVbLim+ZwBfc6SnuNURfYRZr1fG+L9vT0p95kFDSiyoIbce6iyQkqIAHY62fSpBv2F36V9niHjLEDmvbbLKVRus2NFLgJ94q5fHzraeFUHH8dxq0QICYcG6XCI1Mfi9bbzi1NgqOlEqIHf6arcPvW3+3Owvb4vtjKOo4x1k9RCex5inewO47/OioKyvhvemJ+J5DCsEK+uQ7a1CuFplKQQopRrYKvdJG/TfdI81kLPhuQTMby52Ridgsb06E5Ht8KEy0mQOYeFupIGjodj6/DVS05k9gbjsyHL3a0sPKKW3FS2wlZHkA70TWRelR2IpkvPtNxwnmLqlgJA+O/GqDUuDtkn47w5s9ru8f2ecwlYda50r5SVqI7pJB7Eeta/xzxS85OvFjY4ftXsVwD7/7VCORHbv7xG/HpUkWy6QLqyXrZNizGgdFcd1LiQfqCau6CALhhuTweKV9uruKwspYuB3BkzJKA3DG+20q347DQHp2Pets+z5it7w/G7tbcghpjuquCn2lodQtLqChKdjlJI7p9QD3FSnSgUpSgUpSgUpSgUpSgUpSgVAvEdhjIPtDYzYcj/aWMQy81HWrSHXCHPPx2UpH6a9anqtOz/DcZzNUWJf+VM5vaoy2ng2+kevL6kdvgfFBG2U2HDsctPEOJjNxW1cnLapUm1Ic/ZNDSSFBOvPf4nXMRWu2fGYNi+z05ltsjqGSOxFpM3nUVobW501BI3oaR23rt3qXrHwmxezWO622KxIV95tFmVJcd5nloPoFen6Ctjs2MWy1Yq3jrLJdtSGVMdJ88/MhW9gn18mg5fRjVwdwDHp1nxi3WmaFtvMX9V7aQt9fckFKtdz393fbX1rdsmEDKOJMiHDxP+kGSx4LaZpnTuSFFJSnfKnvvRV6H1Ot+a3W38D8Phz2Xy3PkR2HOq1CkSSthCt7/D6/qe/rusnkvCrHb/kS70+Z8Sa6gNyDDkqZD6da0vXyAB1reqI56sUBqRwX4hszWmlm2XFt2MltRKGXCrkUUb9NbHf0rLZ7aLfa+B+BO26MhlybLjyJBST+0cLJ2o/OpssPDfEI1oyC12rmdt11ITKYRI50tkb0E67pI36n0FWUfgpizNiRaSu4uRUSxNTzSPeDgTyjvrxo+KDSnbdDzP7Rl4tmYD2iHb4gMGE4spQr3UHevX8Slf8A+Vh4LLeP5vxQxzHVqOOpsr76mQsqQw70k9gfjtSxr/tUz5zw2x3M5LMu6sPNT2U8qJcVwtuAfAnwf1HavuN8Nsdx3HrlaLbHdS1cW1NSn1uczzoUCO6vkCdaoIEtWF2R/wCzTLyB+Gly8BK3G5KlEqbCX+UJT30Brfb5mp/4RPuSOGOMuvLK3DBaBUTsnQ1/tXqNgNlj4EvEGxJ+51pUkguftNKXzn3tfGs5j1oi2CyQrVA5xEiNhpvnVzK5R8TRUDcOrFac14ncQXszYanzYkksssvq0G2gtadpG/QJSN+n61X+zLCguS89hpS3Mt4mtoR1QFhxAU7yk789gDUhZbwkxfKL6bvOZlMTVgJeVFeLYfHj3x9O2xqsxhWC2TDHbkuwsuspnuJccbUvmSnW9BI9B7xoI1v/ACNfanxtIAQn7sUlI8D8L3YVj0Ood+0ZnPTUFBNiWgkHeiG2dipQznhzYsymRJtyTJYuEUcrUqI8WnAne9b+u/puqFg4W41YLrIuFsZktPyIioTm3ioKQrXMo77lRI3vdEQdw6wqx3TgLkN6uEJMi5tIklh9ajtnkTtISN6HfZPx33rFXWfcZvD/AIWWt1tc2BIedC4q3+imSpD3KhtTh/CNHQ+G66NtuG47jOFysbQ+ti0zOohRffAUS4NKAUdd9VRk8L8ZlYVExeRHect0RZcjrLv7VtRJJIUPqaCNsKsd4tHGOBIhWC341CdjFubbWbs0+XE6VyuBsEK8geB/ZPzroGtJwrhnj+JXJ25QkypVzcTye1zXi64lPwB8D/Wt2opSlKBSlKBSlKBSlKBSlKBSlKBXP3Fy5PWn7QOITIsF64SEQilqK0QFOrUXUgbPYDZGz6DZroGoI4tMXyJxsxi+2ixTroxBhlTvQaJToFzmTza1zcp7Dfc6HrQbTi3E2ZJy9/GMrsKrHeOiX4yOuHUPJAJ0FDtvQPjfg+CKucB4juZVgl5yJduRGVb1PJDAdKgvpoCvOhre9VpVmZuvEPjNDydNln2my2qIphK57RaW6shY0B9V+m+yfidVr+Byb9imH5Thj2K3l+7ylvlhxtn9hyrRycxX40Nb7b34ojd18a0t8P7NflWcKn3aUuLHiCQEoBSrRUpxQAA8enrWx4dmWRXK/wD3XkWJvW5C2es1NjPiRHI+BWkaBOj6/wCoqKrZaZ0PgVZId4wmVd2ETHlSo6gtqVGSVnTiE65u43/l6V84U2abG4mQXsJjZNBxUNqM9F3RyI3pXupHhXfl16igy2E5pbsawfO79ZbB0DAuKUusqlqWH1KcCObZHu/i3oVkrhxru9vtVsv0zDX2sbmKQgTFSk85JGyUo1vXZWt62B6brSoGO3tPCPiXEVZ7kJUq5tLYZMVfO8kPIJKE62oa77FbTxTslzl/Z2xe3xLZNfntNQepGaYUp1BDJCtpA2NHse1BuOWcSpETJ4+N4lZF329rYEl1vrpZQy2QCOZR9dEH08j41ZxuMkJOJX65XO1SYd1sjiWZdtKwVBalcqdL8FJPrrtr17bj7OMXXZuJTeQXmzXq5WC4QGkOKtinEux3UtoTpXIQde54Oh73xFZPGbEtOIZXc4HDyQRL5W0Q7lNdU9NZCieYoVspUOxGjsnx4FBtuOcR8mnzrSqfhixabkR05cCWmV0gdd1hI7DuN716/DVfLzxRujmZXPHcSx5q5ybboPqkTkRypWu4QlXdWvH/APRUPWyxvqyCzPcNbPltluhfQZzUtJTFZT/a989yPkryK2nipbbVNza4f0qwu9MqVy+yXax7dMjXgrBHKFa0PG+30NBN+DX+VkdgbnXCzzLPK5ihyLKSQQR6pJA2k/HXxrC3vO3LbxSsmIiAlxFxYLxklzRRoL7cuu/4Pj61h/s9Qskg4fJRk/tqW1SCYLc0/tkM6H4ge47+h+dYHi3HuVk4u4tl7VpnXG1RWCw/7G0XFoJ5x3A/xjW/OqK3JzP3EcU5WIfd6ShmCZntPV7nSQeXl18/O60q18ar/ecamXez4U5JjwCozHfawlttIG/d2NqOu5AHbt8as8ebvV547Tsgk4/c7db5NpWhgyWCO3IEgKI7BRIJ5d77irjg3ZbnB4H5PCm22bGmvKl8jDzCkOL2yANJI2dnsKI8cTc1smScMcWv06yOTI8u4BKYypJaLLoCwTzJHvDsfrusc9lWWH7RT8dFpekpjtFhqAZQCEMEpBkD02RpWvPfVa/dMbvi+A+IQUWa5Kms3hbjscRVlxCdue8pOtgdx3PxrcskduGMfaJF+cslznW+bCRGbchsFwBRCUnZHYaKe486oJ5pSlFKUpQKUpQKUpQKUpQKUpQKUpQKUqC+J3tWXcabHhMqdKh2MxDKdRHcKFPq0s+f+gD5d6Df5GdpZ4qRsL+71Fb0Qyva+r2HZR5eXX93zv1rda5utVk/o79pGPbm7hLmsNWxwsqlO9RxtBaWeQq9dHevkRWR4Hy3nOCWXuvPuLcQuXpalkkaZHrQdAUrkK6zp6fs/Yg9HlvolKvLoDnUO97XrZ9fSpCzXErLhGKmNOy6/tOXaS2p8NftpE1SR7yEAa0CVbPfzre/FBPZ7CtK4YZ2jOot1eRb1QvYJRikF3qc+hvfga+lQxw5cfsHG6zWu1xb/arRcYji1wrs7zLc0hwhfKPw90Dz37H0NUODGCxszgZWm43W5R47M9QbYiv9NIcOz1FD+0fGt/A0HQGeZBPxuyom2qxS75IU8loxYxIUEkElfZJ7DQHj1rFO58G+J8LDlW5Qckw/avaS7+D3VHl5df3fO653uuTXe48AnGZ019123X1ERqTznnW30lkAq8nW/wCGqkt47+1DYifP3N//ABuURvEPiGY+LXe+5XY51ijW97pBDyStb4OglSRyjyTr4fOtus1zbuljh3RpDiGZUdEhKCNqAUkKA0PXv6VyN7F96cFssnzJMpb1vvQLQ6hKTzciSFA+Ro9vnWxZOuRieD4Lj9mlXj2TIFJmzjFXzyV7Q0C0147d+yfjqg6Bwa93i/wZE272RdnZLpTGaeWestAJ99aCkcm/h5/yrZa574bm72TiTAi2G0ZlHxOW0pEpu9xlcrLulELSruANhPw8n5VNWZWBGT43MtDsp+IiSEgvMHS06UD2/hRWapWPx62JstigWxDzj6YjKWQ67+JfKNbPzqDmYLvFLi1llryC5T2LRZtNR4cV4tgnm1zn4nsT+o9BQdA0rn3O5d74acJZEK35Qu6uyLgIjEn/APNhtlKiUc3Me/ua321s69NY/PsVkcKcdteVY7kFzduQkNolpff52pXMCTtPw2PXfY/HvQdJUrnJi3u5lx8vtvlXG4wre9bmn3mYr5bKh02jyb9BtWzrzqsVw+xR3JXc6x+5X28Gz49JcbhsIkEDn5nAFK+Og0O3jZNB1FSuQbpf7tK+zpaHnp8hcmNf+g26XDzcgaWoAn1AJ9flWz8QcamYlnmHN2fI70mZflmNOlOSeZStqQklI1odlnQ9O2vFB0vSucYaHuG3Ga5W6zzJ8q3Ksz05TEp8uc7iW1LBPz2jz57mtMs790yLHZN/LGezcscdWuLOgMlUNvR7IBB8djsAdvh2ojsGlczZdKv9+yjhcxcpFws90mxy1LKAWXUnn5VK5T4UQCR27bq/hWD+inHRjFrdc7muz3m2uGSh6QVqJUhzvv4gpBB8+aKmXEsytmVXG9RbT1VC1PCO66tPKlSzvYT66HKRutlrnH7NeLw05blE8Py+rapq4rKS57q0nnTtY13PbzXR1ApSlApSlArQOJHDdnL7jb7vBuciz32COVmawNnl2TykbHqT6+p87rf60/OeINow+VDhSmpk65ywSxBgs9V5YHrrt27f6/A0Gu4twjRZM3jZPKv8y5TwwtuSZKAS+tQKebe/dABACdHx5rHxOCZgqukG35Vc4uOXBSlu21tI7kjWive+XwCAASBon1q8yDiBbsp4YZc7ZXZkK5QIqw9HfSWZEdWuxI328HuDWMwXiTBsHD7Dodx9vu18uTZDcePp15XvqAUrmI7enc+nyNEXz/Bdh3ArNjP326EW2aqYJHsw24SVHl5ebt+Lzutk4m8P2c3j21aLg9bbnbXetFlNJ5uQ9t7T23+EHz6V5zXiZZ8TmxLfKjzpt3koC02+C0HXgPmN69D6+lV8M4j2DK4s9yK69Det4KpcaajpOMJG9qUPGux9e3rRWAtfCqTHza05XccomXK7xEqS6p9hIS6kpUnlSEkBAAUfj3O6w0PgfKtSJy7Fmdyt8mc6oyFMtaQttX9kp5vI2dK361bZpxktN4wjIEWmLfI7SmXGI109mUlhTvoAsHaSfTevPpWTwziBb8W4QYrMyB+XLnTW1IZZbBefkK51DsCe/keT8KIurnwWtb/DiNiUCe9EbblJmOy1NBxbzgSpJJGxrz+gArPqwBtXEyDmH3gvqRYfsgi9IaUOVQ5ubf8Ae8a9KtLVxXs1xhXhaYN1j3G1MGTItkhgNyemNEqSknR0D8f9RV+1xGsjnDpWZgvfdaUFRbKR1eYK5OTW9c2/nRWvW3g7Di4NkONPXV55q7SfauuGQgsqHKR22djaR8KtzwbMrDYtnuuSTZM+BID9vuARyriAJSkNpHMfd90HWx3qScZu7d/sEG6sMPx2ZbQeQ2+AFhJ8EgEjuNHz61oN441WOBcLjHi2q+XKPb1luVMhxQtlojztRI7Dv3oL7DOHUqz5Iq/3/JZ98uga6DZcHSbQjv8A2QTs9z/EnW+9bVmNleyHG5lrjXF+2uyAkJlMb529KB7aI+GvPrVfG73ByOxw7tanC5DlI521EaPnRBHoQQR+ladf+K1rtd+nWiFab3eZcED2r7ui9RLOxvSiSKDc8etzlpsUC3vS3JjkZlLSpDv4nSBrmPc9z9a0LL+FX3nlDuRY1f5uPXWQjpyVx08yXh2GyNjR7D+APnvWv8TeLyP+GLV3w4y0PzXSwH1MD/lSkjmC99kqIPY96yMLjHabRiGOzL7Du7JmD2YuPMjmKkJRzOHatlJ5tgje+9BkbXwdx+LhE/HZjkmaZ7okSZqyA6p0eFj4a79u/k73usTB4LOOzbcnJcruV7tFuUFxre8nlQCPAUdnYHjx47eO1ZKJxmsz6rUHLTeYxuU0wmOuylB5vc94jm3y/tE9/rWy37N7dZcxsuNymZK5t1BLK20pKE63+Ik79PQGgtLXgTUDibc8wTPUpc2MI/snSACAAgb5t9/wfD1qnh3D5vGrpl0xFxXIOQPl9SC0E9DanDoHZ5v6z5eKsck4vWOzXmbbIsG7XeTBG5Zt0bqJj688xJHj1rR+LfGInGrI/hj0tDVwcCnZKWR7qQSFNbP4XNjx8O4NBnXOB8dfDxnFfv10Nt3L7x9p9mGyeQp5OXm+e97rbc1wJvKMjxi7LuC4yrI/1ktBoKD3vJOidjX4Pn5q2tvE+2S79j1mXb7pGm3lhT7KZDSUdMJKxpY5tg/sz6HyKyis4tyeIP8AQ8sSvvH2f2nqcqely63re97/AEoLOZgDMria1mDs0koiGIYZaBSoEKBJVv8AveNVpx4JPR25dstWYXODjUp7rOW5DYJHcHQXvsOw9PQb3WRsfHHH73OhxLfbrw69IkBhWmE8rOyAFLPNoAkn59jWuZRxBxW8ZhAusleQSbDZnC0p6LFPsXWJHvuLB2oDtoa/jvuRvV04aRZeS4pdWLg8y3j6A22ytPVLw/vLJ3v596u7jgbc3ifbsxM9aHIcYxxF6QIXsLG+bfb8fw9K26DLYnQ2JcN1D0Z9AcbcQdhaSNgj9Kjm68YrREn3KPBs99urVtcU3LlQonOy0pP4tqJHjRor7iXDB7GM7n3y35BKFumvOPu23p6StSubW1b76KiR2qS61CVxFxyLhDOVPzFJtTw03tB6i19xyBP72we3y3471hca4w2C83mJbJMO62iTMAMU3GP00v78cpBPn0oJJpUb3bi/ZLdkV0sf3fd5d0gqCehEj9VTxI2eQA+APJOqznDzPLTncCTJtKZDK4rnSfYkoCXGyfGwCR30fX0NBtlKUoFc48XGXbHxytt7uN1mWa2S4fRbuUdoOdFQBBTogjvsb7f2vrXR1UpUZiW0WpTLbzR8ocSFA/oaDmSExbLjZuJF9tdzvd1Wq2rjvTpcdDTEg+7op1okgJ+Hj61g8Kt0vh3Cw/iGtwzrbNK401Bb2YzalFKSk9/QE+nca9a63bjMNMBhtltDIGumlICdfSvpYZLPSLTZa/c5Rr+FBz9cLvDwzj/LyfIedVhvMBIhXBLZcbRtDfggH9wjt6KB8E1iWYT/ABFzfPr/AIqw8LU9aXITTxQW/anihIAAPx5f9N63XSr8WO+x0H2GnGda6a0Ap19K9sMtR2ktMNoabT4ShIAH6Cg5ah55ZGfs/wAnEVsSP6Qtsux1wvZ1bSeoVlwnWgEjud9wRWKuMWRBx/hVkD0qVCtTLC2HJsdsOKir6qjzaII8H4f2TXWogxA+48IzHWcHKtfTHMofAn1r2uOwtgsLZbUyRotlIKdfSggXhuzZ8j4ru3GHfb5kD0OIpl2a9GbRGcbUkjpkgA72o67d9fAVocix3VrMHeE7YWLS9eUzkr339n5dn6jl0f8AEmumskv9hwWzImXRTdvgKdDKekySOcgkDlSPgDWcQhlxSX0oQVlPZfL319aD6wy3GjtssIShptAQhCRoAAaAFcpT8uk5JacsRk2RTrTcEOOsx8ft8fpl08vbnUEkqG+x2fAPxrrGqHsUX2kyfZmfaFDlLvTHMR8N+aCO/s5LSvhDZOVQPKXgfkeqqovz1ONt8Sb46xkV7wm+ghS3ltqLEs/vJ5DvRGj37HfjyK6MbuFtZuabS1IjpnFsveyoI5wgEAqKR4GyKw9mveNZlJntQ0sT3rY90H+tH/ql7PYFQ/unxQQFdLzkOSfZvu8i+pU/7PPaTHk9HkLzIUn3tADYBJG/+1VM5vVryeBwnVbXfaGGZbcR4KQU6WkMBSdEd/P0rp1TLSmSyptBaI5eQpHLr4aqizAiMNobZisNtoO0pQ2AEn5D0oIW+0kpVvu+CXp5pw2+BcOaQ6hJIQOZtXf9Eq/hWFyTKbblfHrBJVjcckQWSWhJ6akoWv3iQkkDegRv610S8y2+0pt9tDjahopWkEH9DXhuJHaS2luO0gNDSAlAHL9PhQc58PcptvC7Is3tmaJejSZEoyWFllSxKRtWgCB67BG+3c/CrTive/v7hRjV6Rj5scJN2BDCQCOQJOljSR2Ojrt6V0rKhRZZQZUZh4oO0lxsK5T8t1UfjsyGCy+y26yRooWkFJH0NBzvnGUWv/i1gGaoeWrGlxXGRN6SgkKCnUK2CNjRUPTxVbHr7DyT7TIuNsLi4K7YpDLq2ygOhKNFSQQCRvY38qn1cCGuKIq4rCow8NFsFA/TxVVLDKFJUhptKkjlBCQCB8KCAfs321U/hPlzEUpRLlypEdLnjRLCQnv8io1HeNXC323h/cLFf8mvdtlNvLYfsTERCi7zK/slSf47I8fSuw2mm2UlLLaG0k7ISNd6orgQ3JSZK4kdUhPh0tgrH6+aIwfDa2otGC2aE17YG2mByJmJCXkgkkBYHYEb1qudcicx6HkuRyrLk97wu8NvLcdgSWlFqQvuTy8h8E+h357dq6vq1k22DKeS9JhxnnU/hW40lSh9CRRXMmVvZPkfCjEMlv0FyUi2XBTkltLPKXmNp5XCjWtdinetdwfWsrxPyi1cU7piNmwnrSp6JYkOSAwpHsqO29kj9T6e6K6P5Ry8uhy61qqEaFFirWqLGYZUs7UW2wkqPz15oIW4boSftG5+sgFSWEgH4bLe/wDSvX2fQE5zxQSkaSLr2H/rH6mxLLaXFOJbQHFfiUEjZ+po2022pSm20IKjtRSkDf1oPdKUoFRRxKzLIDnVqwjC1x410lte0PzX0c4YR3PYHtvSSe4PkCpXqK+JWD32RmdrzPCnogvUJssORpWw2+j3vUeulEenp3GqDH2DMspx7iAMOzaTFuC5kVT8G4R2g2SQlR0pI0P7Kh4868g1gOFuU8Q8ugrvUq9QmbJbJSvawYyOrJbSApSRpOhpPYHt3PyrY8YwnKLznS8wzwQo8uPGVGgwYiuZLewRzE9/3lep7n00KyXBbC5+I4NcrVkaGQuRJddUGV84LakJHkevY0RqOMZXxFyuwXfMbZcbbGtcZTvQtTkcK6iUJ2f2mtg68HwT6AVc45meY3vg7FvEe5Wpi5uzVtP3CeUMtsNA62E65Sfr/nWoY1HvlpxHJLVi+WY49iYDzq5a1H2ltJQdoCDrSlAAd/Xwao4pgl6yng7isqzIjSF2+4vyTBlq5WpKSsDv6f2SO/oT3oNs4ecRb05xUh4xMyWBk8CWys+1x4wZ6TiUqVyggAHsj5juO9W2G5LxJzWLkn3ZfIENFskrSh52KhS3Nb5WwNaA0O6iCe9Zi0YRlzvFTHcruVvs8GFDZXHVCguaEdsoWB6AKO3Ce1Zzg7hV3xS35QzdksJXcJi3mOm5zbSQQN/Cgjm+8TL1duA0S+Pphm6N3YQnVuRW3UOANqVzciwQDojwPQ/Gs1xG4jXu2Z4mwm+M4va0xG3W5y4HtPXWoAnto6GyR2H9k1jjwiyg8GDjPTh/en3z7drr+50+ny/i1536Vued2DNXr225CgWTJLAplKPu24toSWF6AJSsjZ8ed+pGvBoL7Eb9lM3h7dJhuWO3i5NFQhzGH+VpQ/eeGgEEDvr9DrzUaPcTMnx6+2JMvMrPkPtb6G5kCJHQRHCiAdOoGiRs+vkeKytr4M31OB5ZEU/Dt9wvLrbrUGOtRYZShZUGyr571660Ktbpw5zi72HH4gs2P2xuzvtr6Ed3S5SkjRcUoDQ8eO5940FvjkDJlfaVvKG7xHTLbSl2S4WBp2Nts9IDXY8pSN/KsjjPEmVY7HxGu01mK8u33ER4jbUdDPOpS1pTzlABV42Se/Y1sM/EsutnGx3KbBHgSbbcG2mJPXc0ppv3AvQ2Pe0jt5HerCzcIrjKsee2u9rYjpvM0SoTra+fkKVqUkqHp5Gx8CaCyuGR8UMbxKJml0uNsnW53pvP2sRwgtNOEculgb33Hqdb9e9XuUZ/k07iLi9rw6VHah3u2IlIRLZCkoKg4StRA3tKU+AdEirOdh3E/IMbhYZeVWePZGem29cGllTjrSNco18ew9BvQ2fNbO/w9nx+LeKXi2tsiw2i3CEeZz9oNJcSO3r+JPf60FngOU5XD4s3DDMsuEa6pTF9pZktsJaI7JIGkgdtEjvvx5qY6jNjDbsjjvIytSWfuhcERwep7/Pygfh+HapMopSlKBSlKBSlKBSlKBSlKBSlKBSlKBWPvd7tliie1XmfGgx98oW+4EAn4Dfk1kKgTiKiJN+0bjELKA05ZPYiphqRroqcIc8g9iSoJ7fJNBNFgyC0ZDFVJslxizmUHlUphwK5T8D8P1rHozrFl3U2xOQWwzufp9H2hO+bxy+db+VRNl4xGywc+RgDhZyUQdymYhWGmmto5ygJ9wEAnx3BJ8Vr7tiwcfZwTcEtW/729nCxJBT7R7Vzfg3+Lz25fGu9BJWSYDwvTkCPvqFb41ymcz4aMhTQcA2VK5QoDXYk/rWz2bLcNYszv3TeLQ1bLckIWGnkpQyPAGvTfp8agKXFevuS8Ho+StmQqRCHWQ736iAslIV8dpCd/HdZ6Lilic+03LtyrVC+7W4IkCIGUhnn5EjfJrl9d+PPeiJui5dj8uyP3iNeITtsYOnZKHQUNnt2UfTyPPxqinOMXVOiw0363GVKShbLXXTzLCgCnX1BGvjuubmI7UGx8cIMRCWokeS2hppA0lAEhwAAenYAVUz/ABy0wPs+YhcIkCO1cX3WVOyktgOr50LJBV5I7Dt8hQdJQcwx2feV2mHeoD9ySSDHQ8kr2PIA9SO/avt8y7HrDJbj3m8wIUhwbS288Eq18deg+dQlxHx+1Y3n/CU2ODHgqdlpadUwgJLgC2R7xH4j76u579613G4VxvGe8QVyrdjNxlNylpe+/nFhTLQUsAt6B0NAd+2tJoOl7nkVntcKNMuFyisRJS0tsPLcHI4ojYCT67ANUIGW4/cG57kO8wXmoH/mlpeHKz5/EfA8H+Fcs5XbpMDgPaYbt1t9yZF//wCXdgvKdQhBZUeQkgEEKKjr51vHH/G7XiuIWGHZ4SINnk3BpFxLA0XQlJ5Ss+vbmP1oJrsWYY7f5bkay3qDNkIHMptl0KVr469R86wHDq/3Ca3kL2QXuzTGIclQQuGsAR2xvYdOhojX+RrDSbdwytmbYy5GTFiXladQEW7aUub0AV9MaO9+VeRvzUWYhd7VZsD4kv36C5cITl2DRiocLfVUVK0CodwO2yflQdCWnPMVvE9MG2X+3SZazpLSHhzKPy+P6Vq2IZjdrnxjyzHZjrRtduZSthIbAUCeTyryfxGoVy+BLt83AJjtqxuzNvS2VxmLZtUjk5kEF1z+16d+/cnvWavb02PxC4wu2wrEpNr7FHkJ/ZcxH/TzUE/Rs0xqVd/uuPfbc5cObk6CX0lRV8B37n5VsFcgxceen8JbU6lGFWyOtxJbuzshxuWHeY7C1BJ0exGvAAFdTRVTk4e0outv3IQQeo2rmS470/IPqCaKt52aY1Auotk2+25ifsJ6Dj6QoE+Ae/Y/WtV4pcUI2F3ax2xv2ZyRPfR7Qt1zQjMFQBcIHnY5td9e6agXCLRKvHDa/vvxcSUlx9wSrjdXVpmR1kDSgQk67nY+JJ3WazS0Ms2vhJ97u224vLkezPzGVdRt9hLqORJWQOZISSNH50R1HAmR7hDZlwnkPxnkBbbiDtK0nwQar1b25iLGgsMW5tluG2gJaQyAEJSPATrtqriilKUoFKUoFKUoFKUoFKUoFa/mGG2HMIjcfIbe3LS0SW17KFtk+eVSSCPp4rYKjPiNxBudoyq14piVtYuN/moLxEhZS20jv3OiP3VHz2A+dBmsTxvDMPlO2WyNwY8+UjmdYW91H3kd+5CiVFPn5ea1268NuF9ovsORcoMKLKlO/wDLxnZCw28vY7Jb5tHyO2td/FaJbbzcHPtIRZeUQG7XLh2pwSEtudRspS0tXOk/ukH9NGq72d3a8Pq4iQ8MgybLa+eO2+/KV7SGub3loTvkB79zyk+m+1ETXcsSslzv1svMyEF3G2jUV0OLSGx/hBCT+oNfW8UszeWOZKiHq9ONdBUjqr7o0Brl3y+g9KjrMeLku3TcQ/o5a27lHyBguNtLJS7zkgJSDvQ946O9+tXNh4i3+HnkTFs8s0OBJuCCuHIhulbavOkne+/Yjfbvrt3orP27EcHuyMkTbW40xN3dH3r0Ji187gUVaOl+4dknQ1WTumCY5dMZg4/Ot/VtMIpLDHXcTycoIHvBXMexPk1C/B3KIeG4nxAvVwCltMXQhLaT7zizsJSPqf4DZrOucVc0s1rh5Fk2JxWcYlqRpUd4l9lC/wAKlAnvvt6D9N0RKl7xKyXu4Webc4fWk2hzqwl9VaekraTvQICu6E+d+Kw2VcLcRyi6m5Xa1801YAcdaeW0XAP3uUjf181i7RxEkyOKv9GZrEUWybCTNtctvm5n0lIUN7OvHP6D8NYZvjA62/ms+TCYVj9hcEaO41vqSXyrlCdk61sE9h2BH6lbPccbwO5NQsLkMQj7CRKZtrT6m1tnR98hKgT2Ue587ra8htdsvFnkwr5HYkW9aduoe/CAO+9+mvO/SoSs2Z3PF7tGybJcTgQbdk7zaVz48pTr6OZO0dTmJ0nlG9DlGh49KmvKP/wzd/8A0N7/AOA0GpcP8CwK1yfvnEo0WS4CUIlIkmQGz6hJKiAdH696rWbEsFkwr/aLWzClsy3ue5R0SlPEO7Oir3iUHYOta7j5VDHAvipY8Owg2y6Rrm5I9qcd5o0fnTohOu+x37VW4OZMqCxxdyW3NBZQtM1lt8Eb2p9QCgD8+/eiJZi8GsFjMNtpsvMpt0PIdVJd6iVDxpXNsAfDxWWbsuJWnL5Uw+yM3+8t9N1DsklclHbsG1K0R7voPStak8Rri1wQbzURIhnqbSvoHm6Xd3k+O/HzqOs8yCfL4i8ML7Ht6ZVxlW9DyIja+RKnF70nZ3obV5PoKKlSLwbwWNdRPbsaC4lfUS0p5amkq+PITr9PHyrZrtl2OWaUIl1vlshSPyn5KEKH6E9q0THOIl/Y4gM4nnNoh2+XNaLsJ6G4VoV5907J7+6Rvt3HjvUOQfunCsgvsTipiMq5OTJS1JumivaT6p2QO/nYO+/yoJ1k8KMBv8/76FsZf9pV1lKjyFhl4k75uVKuU/p5rPZVgeOZRaIlsu9uQqJD17OhpRa6PbWk8pGhr08VGOE3W04VwgyC8YVd13qNHd6yI8xBR7OolIKCkEEdjv5+a+OcWM1YxWFlsjFYP9G1BAeKXyHjs8pWkb7J5uw2CfFBNNltkSy2mJbbc2WocVsNNIKirlSPA2e5q9qKcr4qve22K0YNbUXa83eMmW0H1cjbTShsFfjvoHtsa1VGycSMidvFyxW+2OLCy5ERciClDpMeUoJ2Bvex4Pr6HwRQS0lxClKSlSSpB0oA9x9a9Vz79ly4ZFLN7Mplp61uy3HJEtx0qe9o5Ue73PdOvWugqBSlKBSlKBSlKBSlKBUMcT7Lf7JxQs+eY9anLwyzHMWVEZP7TWlDmHr4V6DsU/OpnpQc8Q7FlGW8YPvq+4/JtVsn2t+KnfvdBCmloAWr0WSSdfMVqNrwebZbbIstx4ZPXm/pfKWLiX3BGcbJ8qKVgeN67jz38V1rSg5n4n2+bj2W8Lolmt0ZFwiIKm4LTqi11OdKi2FrJOidjZ+NbJDgZJxC4sWO/XTHpVhtFiQSEyz77rmye3jffl+Wh571JmRYRbL/AJRZL9NdlpmWhRVHS0tIQokg+8Ckk+PQitooOa7Dw0vl54f5xapMN6DOkXQTIQkJ5Eu8u/X4EEjfxIq5yCXnmZ4bDwZzDZNvfV0WpdweX+x5WyDzA613KQexPwG910XSggLj1Y14li+IX+yOhudjxbhIcV2LjfJob+PdPj+8a923hnKm/Z1FoipH3zO5bmQs8vO4SFBJPoeQAd/Wt5yzhXacrydF2vVwujzCFIWLd1/+W5kgD8Ou29d9a33qQEpCUhKQAkDQA9KDl3H8O+8nbLbE8KjGlIKUXKbcJD6GtAaK0aWO5867/AD1rpPIGVvY9cmWUFbi4rqEJHcklBAFZClBFv2cbJcrDw7MO9QX4Ur2x1fSeTyq5SE6Ov0rUcMwm+ut8XokiA9EN4cUIK308qXtqfIIPw95Pf510BSg5icZzSXwYcwhGGXFEmIAHZKyAlaA7zgNjypR3rt20Cav8gxzLY964aXGzWN+VItFqb67axypStIJU2pX9lRGwPmRXR1KCCrZbMj4gcWrZkl2sUvH7VaI6m0JknTjjhCvw9h6q3vx7vzqhAv3ETDDcrNkGMTswjreKo00L5gpB7AK0lXbtvR0Rs/Kp8pQcvxcQvNh4ScRbxfYSLYu8FtxqAjQDKQ6T4Hge/oDyAK9x52ZX7g9asNhYnJc9sYaS1c0uDoFjmCgT+6e2js/OuhsssETKMem2a4LeRFlpCHFMqAWACD2JBHp8KrY3Z4+P2GDaYSnVxobQZbU6QVFI+JAA3+lBCV3wnIMEyfGMmx23m+t2+3It8yMyrlcOkFJUkfA79N+PnWSw+0ZBmPFlGb36zPWODAimNEjPn9q4SFDZHbt76jvXwA33qbKUEG/Z9i5Bi9zvOOXfHpjEd2U7KFwV2a8JSEjto71ve6nKlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlfN0H2lWVyucC2M9a5TY0Rr9+Q6ltP8SaxCM6xNZ0nJrIT/AOnNf/VQbJum6wrWUWB7+qvlrX/hltn/AHq8aukB7+qnRV/4XUn/AHoL7dKoCSyfDzZ+ihXsOJPhST9DQVKV53TdB6pXndN0HqlfN03QfaU3SgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSg+Go1438Rk4Dj7fsYbdvM3aYyF9wgD8Tih8BsaHqT9akdR1XHP2oZ7kvii7HWoluHFaaQPQbHOf81f5UEZ329XG/XFydeJj0yU4dlx1W/0HwHyHasfSlEKUpQe0uuI/C4tP0URVVM6Wj8Mp9P0cIq3pQZBu+XZr+quk5H+GQsf71dtZdkjX9VkF3R/hmuD/AHrCUoNmbz/MG/w5Re/1muH/AFNXbfE/Nm/w5Nc/+p7m/wBa06lBvbfF3PG9aySWf8SUH/VNbphH2hsgtsptrJ227rCKvecSgNvIHxGtJP0I/WoQpQfopYLzBv8AaI1ztUhMiFITztrT/oR6EHsRWRFcyfZGyB8Trzj7iyqMWhMaSf7CgQlWvrtP8K6aBor1Svgr7QKUpQKUpQKUpQKUpQKUpQKUpQKUpQW6zXFX2iV8/Fu8/wB0Mj/3Sa7SWa4j49r5+LN/+S2x/wC6RQaBSlb/AME7Zbrhl0l679Ix7db5E9KHW+qlS20jW0f2gN83L68tEaBWVvlhmWaNan5ha5LlFEtjkVs8hUUjfwO0mpUvV8st7xS+R77lMC8Poj9S3FqzOR3Y7qTtKQpKAkIUNp0TruKyM+zwnbRYrq62zdLhaMXjSGLOoH9rtayXVjWlIRzbKQdnXfQ8hGeM2LGX7SLjkuTexbcU2mFEjKekHWu53pKQd9js/wCRq8m43iU22SpON5StMmM2XTDusfoLcSPIQtJKSr+75NXeIi32vELtmVxtMS7ThPRCixX2/wDlmlKSVqcWhOgRoaA7Cq19Vb8w4f3HI02eDaLta5TLLvsCC0xJbd2B7hJ0tJHp6GgjSr27WqdaXI6LjHUwuQwiS0FEHmbWNpV29CKkbKHsfwSVHx3+jMG7vpjMuXGZMU4HFrWkLKWSlQ6YAIAOjv1+ezX3G7dlvEu3RgHhZ7bjMeYppx5LTi2kNgpQVnSUk86AVHQHc0EDUqZr7hcGfiN4nJx6FYJluZEllca8tzG5KQffQoBaiFa7gjzrVYeVgcGbxDxuBag83ZLzFYnBRXzFtrl297x/d5V+fHagjGlXV19l+85f3cHBC6q+gHFcyuTZ5dn1OtVa0E2/ZMT/AOP7kv8Adtyh/Fxv/tXWiDXKf2Sk/wDi68r/AHYQH8Vj/tXVKDRVYV6ryK9CgUpSgUpSgUpSgUpSgUpSgUpSgUpSgsXT2rhzjQ51eKWRq+Enl/gkD/au4nfFcJcVV9TiTkyvhPeT/BRH+1ErVayFhvE+wXaPcrTIVHmMHaFgA+Rogg9iCOxBrH0oNuv2fXO72l22oh2i2RJBSZKbbCRHMkpOwXCO5799dhv0q3ObXgXuy3VlxtiZaY7UWOptJALbewAob77BIPx3Ws0oJXxpOVM22dfLXjkC8Y7eln2y1RkF9ttSVHW20krbI7kH0BHyqhljGV3bE3AziaMcxeAr2hbKWyyHHD7vOVOHmcV37a9Kju2XW4Wp4vWufLhOnsVxnlNq/ikiqt1vt3vBb+97pOn9P8PtUhbvL9OYmgkO439tcOOrK8Si3q522O0yJwmrbPKEgpS+hJ94gHXfROj8DRrJMkn5jPyb+jypDCIYt1yiAENrbDIS4g6HY6SVaAPL+lafHyp9BlPvMpVMdJWHEBKUqcUCCtaeX3iAdjuADs6OzXqw5td7JZJtqhuJ9mlKUskqWlSFqTyqUClQ3seitjt4oNpv9oZj2v2CwYHeGJd0KSiTcFe0LbCffKGQlA0Nf2j3KauoeSyrLw1VEuGO3RFxitSrZFuLjZSw0h5Y6iTsfiGnAB8zWPm8VJP3u5JttrisRluB1bZW4FPENdJPOQr0SVDQ0DvuDWHuudvT8emWlFptkREtfO45GbKCdOqcA1v0KtfQCg06lKUE+fZJR/8AbmQL+EdpP8VH/tXUCDXM/wBkdH/N5Kv4IYT/ABK/+1dLt+lFXCfFexVNPiqgoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLB3xXGH2gMfesnEe4PqbIi3E+1Mr9FE/jH1Ct/xFdouDtWpZ7h9rzKzKt92bPY8zTyOy2lfFJ/28Gg4TpUuZDwHyeBIX91Li3KPv3FBwNL180q7b+hNa87wkzdvzY1Ef3ZDR/8AnojRKVuDvDTMW/xWCX/0lKv9DVq5gWVt/ix+5fowT/pQazSs8vDclR+Kw3Mf+zL/AO1UF4xfkfislzH/ALKv/tQYilX7lmujX9ZbZqP8TCh/tVq5Ffb/AKxh1H+JBFBSpX3lV+6f4V80fhQKUra8EwK95lPQ1bYy0ROb9rLcSQ02PXv6n5DvQTZ9kuA41Zr/AD1JIbffaZSfjyJUT/8AGK6EbrXcMx2Hi2PQ7RbkkMR06Kj+Jaj3Kj8ya2NAoqunxXsV4T4r2KBSlKBSlKBSlKBSlKBSlKBSlKBSlKC1WKt3E1eLFUlpoMc43VstqsmtuqSmqDFqZqmWflWULXyrwWflQYws/KnR+VZIs/KvnR+VBjSz8qdH5Vkuj8q+dGgxaoTS/wAbLavqkGvBs0Bf9ZBiq+rKT/tWYDPyr2lr5UGFRjlnKgo2mAVfH2dH/as3GZQ0hKG0JQhI0EpGgKqJbquhFB9bTVwgV5QmqyRQehXoV8FfaBSlKBSlKBSlKBSlKBSlKBSlKBSlKDyRXhSaqar5qgoFNeCirkivnLQWpbr506uiivnJQWvTr50qu+SnJ8qC06VOlV1yU5KC16Veg3VxyV9CKCgEVUCaqBNegKDylNexTVfdUH0UpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgar5qvtKD5qmq+0oPmqar7Sg86pqvVKDzqvuq+0oPmqar7SgapSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArWZuYw4mfW/E1x5Cps2MqUh4BPTSlPN2Pfe/dPpWzVDWVSGYv2lsYdkvNstC0O7W4oJA/rfU0Ey1H+E8U7Ll2W3SwW9t5D8PnKHVkcj6Uq5SUaO/gfpX3izmsOxcPrtMt06O9NWgRo4ZcCyHHOwPb4Dav+moAjSZ2GDCrwMVvFsNlUW7hMkNaRJQ6r3u/x95QG/iPhQdR5rkLGKYvPvcplx9mGkKU22QFK2oJ7b7eta1ZeKdpunDm4ZgmO+1EglaHWFlPU5hrSfOtnmTr61T47PNyODWQPMrC2nI7S0KSdhQLiCCKgVMd6PPYwVlDnseSvWudoeA2WwXv/wBwH8vyoJpicabVJw+PkItc5Md65i2BoqRzhZSFcx7613rIZFxSYt+QTbPZrBeb9KgAGYYLPMhjY2AT6nVQS+kI4VhKQAkZsoAD0HIK3+6Wu3XniHksnEcum4rkMdYTOZkBKWZCkggLAKu6e3rvzvXeiN8TxYxtWC/0pCpXsvW9l9m6f7fr/l8u9c2u/nWvWqGP8VI87IYVmvVgvFhmT9+yGc0EoeI9AfQ1GDOTWvJeFs+JnqORuPeBEbutpZSlKngCUvnwPG9nXcEdgav/ALyveD5hisN3KIWY2y5SUsttPISuQwFEAOJVsn1GjvR149aCTbZxMs0qFk8yWh2DEsEhUaQ47o86gSPdA87I0B571rzfG2GhlqfcMXyGFYXlAIuTscdPR8E6Pg/LdQ9kUeS/hfEpUdCltM5Ml2QE/lhTg/hspqauIeX4vJ4OXF5ifCXFlwC1GYStJUVlOkoCR3BB19NUGUyPilY7DkVgtsrnXHvDSXWZyFDpJSo6ST66Pbv86y87MIsTPrbiqozypU6MuSh8EciQnm7H137tc8s4eu/3Dh1jt752nZFgkFJP4mjtxbZ/T3e36VkOG93us7jbjlsyJpSLvZIUi3vrUd9UJSspV89pI7+vn1oOnaUpRSlKUClKUClKUClKUClKUClKUClKUClKUCtZyjA8Zyma3Lv9pamyW2+kha1rBCdk67EepNbF12fzW/5hTrs/mt/zCg0yLwowiItCo+Px0lLiXQOo4RzJ3ynRVo62f41tN8tEC+2t+3XaMiVCfADjS96Vogjx38gVdddn81v+YU67P5rf8woMbJxy0ysb+4JENLlo6SWfZlKVrkTrlG977aHr6VQTiFhTdrbc021kT7cwI0V7attNgEBI79+yj5+NZnrs/mt/zCnXZ/Nb/mFBrasBxhVu9gVaGTE9sM/p869dcjXP53v/ACrxlHDzFconJmXyzR5MtICettSFKA8BRSRv9a2frs/mt/zCnXZ/Nb/mFBiGsUsLWPLsTdphptCxpUUNjkV8z8/XfmsZjfDfEcbnidZ7JGYmJ3yvKKlqRv8AdKidfpW1ddn81v8AmFOuz+a3/MKDF2vGLNa/vL2G3sti5OF2Wk7UHlHeyoEkd9nt4rAROFGDxLkmcxjsMSEK5075lIB+IQTy/wCVbn12fzW/5hTrs/mt/wAwoLCRYLXIv0S9PREKucRtTTD+ztCFb2AN69T6VRVi9lVkyMhNva++kN9IShsK5dEaPfR7HWyKyvXZ/Nb/AJhTrs/mt/zCgqUqn12fzW/5hTrs/mt/zCgqUqn12fzW/wCYU67P5rf8woKlKp9dn81v+YU67P5rf8woKlKp9dn81v8AmFOuz+a3/MKCpSqfXZ/Nb/mFOuz+a3/MKCpSqfXZ/Nb/AJhTrs/mt/zCgqUqn12fzW/5hTrs/mt/zCgqUqn12fzW/wCYU67P5rf8woKlKp9dr81v+YVUoIqpSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlBUjf8AmWv8Y/1qUaUoP//Z",
+              "timestamp": 36016273287
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAE8QAAEDBAAEAwYDBQQECgoDAAECAwQABQYRBxIhMRNBUQgUIjJhcRWBkRYjQlKhM3KxwWJ0gtEXJCUmNDVDhKOyJzZTc4OSorO0w8LS8P/EABUBAQEAAAAAAAAAAAAAAAAAAAAB/8QAFhEBAQEAAAAAAAAAAAAAAAAAABEB/9oADAMBAAIRAxEAPwCVNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFK+KUEpKlEBIGyT2Fa81nGKvXD3FrIrSuXvlDSZSCSfTv3+lBsVKEgDZPT1rXTnGLJn+5HIrSJe+Xwve0c2/Tv3+lBsVKAggEHYPnWKvOQ2uyrQm6yvdEL1p51tQaH3c1yj8zQZWlaFxrlf+iS/yYb/Qx0qQ60vuCpPUEVljl+PWaJAjXe+W6HKUy3+7fkJSrqkdSCelBs9KpxpDMphD8Z1t5lwcyHG1BSVD1BHesLd8xxuzyxFut9tkSTvXhPSUJUPuCen50GepVKJJYmR0SIjzb7Dg2hxtQUlQ9QR3qrQKUpQKUpQKUpQKUpQKUpQKUr4tXKkmgFQT3IFfA4g9lCsXcrjEt7BkXGUzGZ2E+I8sITs9hs1YQ8lsc2SiPDvFvfkOHSG25CFKV9gDQbLSqEdZPwn8qr0ClKUClKUHN+OD7y7PY7Ql5ceJeLqxBluIPKfBUSVJ35b1qtjl4LjEiwqtC7LATB5CgJSykFPTXMFa2FfXvV5l2OwcqsT9ruaVeC5pSVoOltLHVK0nyINae7heZyYRtkrPFqtqk+GtaLehMlSOxHic3fXnrdBohvtyf4Hw4KprpQ5eBZFT0q0pcbxSnn39Ujl3XXEYDiqbH+EixW/3Lk5NFlPN21vm78313uvb2E2R3CRipjEWlLQaSkH4kkHYWD/Nzdd+ta0nCc0RE/Dk5+7+GhPhhRt6DJ5O2vF331563QYbiDKk4JwUMfHbw9LLbqYaJylhS2W1LII5h5pHwg9xXRcfxy2W/HEW5toSI7zIS+t4+IqRsdVLJ+YndU7dhtkhYenGRES9afDLa23viLmzsqUf5ieu/WrVWPXS2WUWfGJ6Y0bk8NEiatUhyOntpCem9eXMo6oOKx33Y/CLihYEuret1mnLjw1qO+VvxB8G/pr+tdnwnFLNDxOI2YsacqXHQ5JkvIDipSlJBKlE9wd9B5CseOGcCPw1nYlAkuN++gqfmOJ51uOFQJWodN71qjeHZHaYnuGL5S3CtoTytsyoIkKjjzDauYdPQK3qg1TH5b2If8KNqshKoFna98gtfMGFraUtSB9ARvVbTwsxKxs4NbZK4cWdKuMdMmXKfbS4t9bg5lbJHUbPas1heHQ8Zs8qIXXJ8mc4p6dKkAFclau5V9NdAK12FgWQ4+hyFiGW+42cqUpqJLhJkmPs7IQokHXoDugocPmW7BxPyzG7WOSzIZYnNsA7THcXsKSn0B76rqFazhGIsYuzMcXLfuF0nOeNMnP/ADvK8hodAkDoAO1bNQKUpQKUpQKUpQKUpQKUpQK8PjbRr3Q9aDXcjEk20+5CcXuYf9C8HxNf/F+HX9awVlTd/wAUY96GReDs83vQg+H2PzeH8f6Vuy2SD8PUV5DSyfloPrA/eCrqvDTYQPrXugUpSgUpVnKuDUeW3HVvnUkrJ0dJT6/rQXlK+JIUkKHY9RWOvNzNu935WfFLqinXMR/ke/5UGSpWH/Fn1InKbioKYxWPicI5uXv/AA0k3d1hpBWwzz+CX1gvaHL6JJHU/pQZilYxu6hb6Ww3ol0t6KuoAb596/pXm13cTLY9Mda8FDY2epII5QT3A9ddvKgytKxMS8pfiRXlNpQXXiysc+w2QFHvrr2H61T/ABs89vT4CdzBtP7z5evXfT07ep6UGapWOuFxMSZHZ8NJQ4QCtSiNbIA7A+vnoVRF6T4allnYQy48oJVsjkVrX5/5UGXpWJN2cS2kFqOXVuBtPLIBQNpKuqtdO3p6UTdXFyo7KGEHxGw4pQc5gOpHQgaPb6UGWpWB/H1+6l33ZAWF8pQXD8I0Ts/D9PIEfWr253Iw4rTzbaXAvueYgAa3voCf6UGRpWJeurzLsnmYaLLTSXQtLp2oKJA/h6dup3VvJvy47SuaMhbqXfDIbcKkn4OYaPL38uwoM9SsTMu62FrQiOFqS8hkbUevMjm30B+1VI1yW7cjEcaS38OwrnJ5joE66a8/XfTtQZKlKUClKUClKUClKUClKUClKUCvC2kLWhakgqQdpPmK90oFeHWm3deK2heu3MN17pQUREjpccWmO0FuAhaggbUD32fOvTkdl3k8RptfIdp5kg8v29KqUoKfgNeMXfCR4pGivlG9em6COyltTYabCFd0hI0emu32AqpSgprjsuJWlbLakrO1ApBCj6n17V8MZhXdls9AOqR2HUD8qq0oKbjDLjiFuNNrWjqlSkglP2PlRDDKFLUhpCVL6rISAVff1qpSgoCHGDKmRHZDSjso5Byk/avqokZSm1KjslTYAQSgbTrtr0qtSgt/cYnhlv3VjkKuYp8MaJ9detVHmGX0BD7TbiQdgLSCAfzqpSg8lpslRKE7UOUnXceh/U1TESOGw2GGg2N6SEDQ336VWpQUXYsd4EOsNLCiFEKQDsgaB/SvrcZhtzxG2WkucvLzJSAdem/SqtKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBVndrpAs8My7tNjQooISXpDobQCew2elXlR69r29eFZrHZGz8Uh5UpweiUDlT+pUf0oO12jLMevUv3W0Xy2TpPKV+FGlIcVyjudA711FZqoNcLpT2G8V8ddlq8NLpZDhPQeHIbGt/YOA/lXTcu4n57fuI9xxvAkoa9zecZQhDTalr8M6WpSnOgGwfTy86CTFKjlYeLWb2fEsgk5dZnjJiNpMSS/FUyhTilhBSrQAOubY1rejWswOIPGObbGcghNuy7U88WkJahNLSpQ7jlSOfXQjfb60Es6VG/PuMmVF+xWPHbcbffZjDSpKHmduIeWdBtKV9APPZ8iKxMDi7nWO3S8Y/mZT+IJhvlp0tNhyO8GVLbV8I5FJJ15Hv+VBKalRAxvi3xHnWbIZDVyZlCFFS8t15lpJYSVhPMhIQOZR2B12O9Xlv4zcQJeBXiW0uKtcF9gOXHw0BbaXCoBPJrlVsp766DfqCAlnSonXjjNmD3DmzXKLcURbj7/IiSHW47ZDyUobWkkKSQD8flqvD/FTiizjFsyPSBZQfd1SFstESXQo7KgACO3L0AHT1oJaUqL+W8cskvT9it2FsoiTZjLZdHhpcWX1kjkTzdAnoOp9fpWEyLixxJt2ZJtlzmC1vtrZaeiIYZWkEhO1BRST8W+bv030oJd0qMz3FjPcszyXFwKG27b4K1L915EbeaQrRK1L7c3okg9a0yPxnzx966qN7W2ltpbjbZjMnwzzpAG+TroEjrQTMpUQLfxb4jvYXdLmi5sOtRZTDa5S2Wg43zhWkpSEaIOupPUaGqzE3j5kKeHttWwmML6/JeYdlFsaCEBBBCO3MfEH06duvQJT0qLeG8TuJUbKoMa8NKvUJ1SPHbjMNulCFHqeZkaCh30fzrDY5xR4m3zKnbRaLiJ0p3xkMsLZYQBpKvi2UjqkDfU9dedBLiZIbhxH5L5IaZQpxZA3pIGz/AIVqGFcTcZzS6O2+wS3npTTJfUlbC0AICkpJ2R6qFUrCMhHCaQMyPNfvc5XvB+D1Xy/J8Py8vaoo8H8sdwuXkV5jNIdlItZbZSv5edT7IBP0HU/lQTnpUR3uKXFNrCl3x5xKbZLkBti4JZZ22ob2gJ0dpOj1I7jvXZvZ1yi8Zbg8ufkMwzJaJ62UuFtCNIDbZA0kAd1H9aDqVKUoFKUoFKUoFKUoFR843cLMtzrN/wAQt/uItzLCGGQ6+Uq0NlRI16qP6CpB1isgyOzY6wh6+XOJAbWdIL7gSVfYdz+VBHbOuAWQO3yPIxu4KmsJjtpU7cpW3UrT0CQQn5QkJA9Kusl4K5inJ3Mhxe6R4k2YPGfSmQtpbLqx+9SlQHxJKidHp37V3G15xjF1hy5VuvkGQzEaU++W3NlttI2VFPfQA76qwZ4n4U9GfkN5HBLLHL4iuYjl5joeVEcxxjgfeV4tfYWUX5Tkqe0lDCEOrdbZUlYWFq5tbJKQOg7b69a1aLwQ4jssNWxu/RmbW274iUtzXQ2lR7qCAnvXbOIuat2qww3bPe7HCkT0pW1IuDpAS0pOw4hsAlfl30OtZLAL3Dl4s2peTwr67FSfepzfK2PM7UkH4dD19N0HKM/4GXOY3ZZ2M3crvMGOhl52S4pCnlpJIdSsbIVs9vQDr064yx8CsllSrtd8uubMu5uQ30R0+OpxTjymlIQXFkdANjtvt9K7UeIuICFIljIbeqNHcS064hzmCVK3odPXR69ulaRxK43WuxWSFMxR+BeHn5BaUhSlAJSE7J6a8ykfnQaPh/BXK7Tj+WQ5f4f41zgpjscj5I5g6lXXp0Gga9WHgtlcHh5lVlf/AA/325PQ1scr5KdNLUVbOunRQ1W1TOJ13v3BN7JLDIttvvDL/hSkrV8LAKyAAV9OYgoPXp8RrOcFsym3PAZV0zG8W5xUaQpC5KXEJShHKkgLI0nfXy8iPOgj5xHwu64Nw+s1uvnu/vD10kyE+A5zjlLTKe+h12k1mcU4TZVl+EWJy231KLBJC3lxpDy+Rl0OLQSlABB6AHfTqTXfJk7h1xJkR4EmZa7w/HKlMsF4hQJ1spGwT2HrVxjOWYJbS1jdhusBj3YupTEStQ8Pl5lr6q9NKJ2aDlmf+z9KfTaXsOmsoeiRkMOpkKKCtSf+1CgDonfb6dK1yZ7P+Xov7ElqbDnNpU044+++QtSgElfQgnQOwNnqAKkrjuU2PJA6bFdYk/wteIGXASnfbY7irm+Xu2WGH71eZ8aDH3yhb7gQCfQb7n6Ciog5ZCtuPcRbw5juYKszfvLjUlsIeQ80kq+NKeRJStPp8Q8t61utY4b4tccwu9ztlkQlTyoi1BTyuVIHOj5j5VsvtHPWt7PW5VjTDVEmw25RejpGnVKUraiR3J0N10zh3mdpxjiNd8VhWO22m0RfHXInJUtTqktJKuZZJOx0P2ojFWngrlcXhxf7I7+H++zZkZ9rT55eVvn5tnXQ/EKptez9epGAJhyJENi+xpzr7QDhU060tDQ5SrWwdoJHT/Hp3GJxFxGZb506NfYjkSCEKkupJ00Fq5U76eZ6VbHiphAYS8cjheEpRQFbVokAEjt9RQcjxDg3nK8jgScoyFbcCKUbSzNcWtaEnYbHYAH/ADq44UcIMnxfibGvt09x9xbL5V4T5Ur40KA6a9SK7CeIOJJ9x58gt6PfUc8fndCedO+XfXsNgjr6Ve5FldhxxLar7docHxBtCXXAFKHqB3Ioq+vkZybZbhFZ14r8dxpGzobUkgb/AFqNWHez/f0IvUa/vQo7UuCWmHWXS4UPB1taSRodPgIP3qRmP5JZsjYW9YrnFnoQdLLDgUU/cdx+dZagiefZ7zD8GkMOXOGtTbqTHipfV4St75lnY6Ht5bO67RwFw26YPh0q2XvwPeXJy5CfAXzp5ShCR10Ou0mukUoFKUoFKUoFKUoFKUoFRG9owtucaoreQuSW7MGo45mhtSWSfjKB675/0qXNaHnw4eXaWm3ZpJsqpjIHK3KkpaeQFaI0dhQB6GgjPCZwpi/Xz9lbnfnP+T5iYyFxUBtafdl8wWsqCtd/4B5VV9n3BrRnV4u0S++8lmOwh1AYd5Pi5tdenXpUn7Pw0xCzRJse22OOyiYwuM+rmWpam1DSk85JUAR6EVXw/h/jOHSZEjHLb7m9IQG3FeO45zJB2B8ajrrRESuIEKHC4vzbdkSn0WqIURmytxQKWENANdQlR1oJ7J69e3esS2LfGseQjHbld3XFthL7QihDBj+KnqpfOVHry62kd6mbluBYxlzrTuQ2lmW82OVLvMptYHpzIIJH0Ne8fwbGcftsmBabPFZiyk8r6FAuF1PooqJJHXsTQQceXjn7HMIjougyXxiX1KKPdi111r+Lfb+tZyRb46uB8O4hhJlpv7rHja6hBYQeX7bG6ko9ivCVufIxlbNpbmy3UqciJlLS4Vj5U7Ctp7/ICPtW227h9i1vxuRYI1nZNofdL7kZ1a3QV6A5tqJIOkjsfKgjla51nd9l69wrfyi6R5DLlwAQQdrk/uySeh+BIHT0rnDzs1PDGG22Vi3qu75dA+UuBlnk39dFevzqZMXhbhsSyXC0R7Khu33BTapLYfd24UK5kfFzcw0Sexq5tvDnE7bj8qyRbMz+FSXfGdjurW6CvQHMCskg6A7EUEOMgRj8W6Y6vh5KuT1wLbanvFTpSJOxoI6Drv7jt1NZXBLPFyDjeq23houRn5c3xm0rKdkIdVrYO9bFSsxzhhhuOXBE6z2JhmWg7Q6ta3VIPqnnUdH7UtXDLEbVkQvsC0+FdQtxzx/eHVfEsEKPKVFPUKPl50EcfZRWpPE55CVEJVb3eYeulIrL+1aXVcQLCi4rfTZ/dUkcnXX7w+IU+XNrl/pXecU4a4nid0NxsFq90mFsteJ7w6v4TrY0pRHkPKsvlGL2XKoaIuQW5iayg8yA4CCg+qVDRH5GioK583jjWQrbw2RMkWhLaeRcoaVzfxAbAOt/TvupXZ3w+xyFjeV5JCtyk3x+2SlLf8dxXMVtKCvhKuXr9qy9w4P4JcPdverA2RHZDDQQ+62EoBJA0lY2dknZ6nfU1vbjLbjCmXEJW0pPIpChsEa1o0RBHELrCh8PM7gSZCW5c5qGI7Z7uFD4UrX2HWtdd/8AVmN/rjv/AJG6m0nhNg6GJzKMfjobmpCHwhxxO0hQUAkhW09QD8Ot6rV75gvB+yOx7VeWoEN1ai42w9cXkq2rQ3/abAOh36dKCNeb2mHb8YwyXFaKH51vW7IUVE86g8tIPXt0AHSqt+eTMza3Ly114xFwYhUtS1J/dmMgpIISo62d9AfP71La4cKsJucG3RZlnS7GgNFmKn3p4ciCoqI2F7PUk7O6vL5w3xK+QYES6WVl9mAymPHPiLStDaRpKedKgogAeZNBwb2bWrKzxHkCzXG6vOlh0Fr3VKWC0CNFS+fmPXl1tI61KesBieG4/iLLjeO2xmEHfnUklS1+m1KJJ/Ws/RSlKUClKUClKUClKUClKUCoX+0isN8ZrgsgkJbjnQ/92mpoVFXjxgeVX3ilNuFmssyTEWhgIfbRtOwhIP6EUGyWbj9cl5eLXfrAm3xpK+SOVhaHW+b+zKwr5gdjZGu9UeH/ABxyTIjkYmwbQ3+G2aTcWvCacHM43y8oVtZ+Hqd60frWJhcNc+y/iXHn5s2hDEBSELl/AlDqGztIQlPU7PXeh3P2rAYzwz4hY7cMhYi2ZBbk2yVDW8tQUhxtQ3pvR2Vq5QBv160RtNg9oi8Lsd4n3i1W9xccstxm4qVtgrXz9VlSldAEHtVvA9oDNHWDPXi0R+2JVyqdZZeCRruOfZG/yrWcR4f5/brHeURcdUXXlsc8ea02pD7Q8TmAC+hIJQemj6VTt3D/AIjvX9l6y487jzgKdrjvKZaBB+Y8y1b+w9O1Bc5PdIcfj8w4zZIHO5cIjpUtbxPO4G1lRAWBsFRPbX0rYsa9oPKriu4h2w2+WY8JyQlMRtxPIU6JWslZ+ADZOhvsOlWeYYFlkrjc3dEWiVJhpmw1rlto02rkS0FqH02k1YcK+H2WWuVkyrhYZscSLDMjNFaNc7q0gJSPqaDomCcefxTGchuGQW5pmRaWUPJTFUeV/mVyhOlb5TzFPXZ7/StSPtFZUALgrG4Qs6nfDC+V3qe/L4u+Xm19PyrGcNuFGTTLPllsuttfti5sJsR3JKdJU4h1Kwk/flrE2vCeJ9vbbtEOwKQlt7mQ8thlfKfo4rYCfPoaDpGc+0Ku3xrUcbtTTrkyKmStcwkpbJJBQAkjZBSeu69YvxwyP39xnLcYEVlMV6SFtNOMlXhtqXoBe971rv51huIWH5+XLY1JscDKGGoaErdWygFLvUrCSgoWANjXkdb71j+GuDcTrcbm8yw9b4iob6G4cl1JQ64UEISG1kgaUR1V5bG+tBcxvaDzK5yn1WfGIciM18S0NsvOrQk9uZSToffVd2wbKn8l4fx8geiJiSXGnVKY2VBKkKUn6H+Gotz8B4gSpTIjYam2zUqO5UD9zz/chzkA+wFSkwC03qHw9hW3J5Pj3cMLbecK+cjZPKCr+IgEAnz1Qcf4f8cckyI5H77BtDf4bZZNxa8JpwczjfLyhW1n4ep3rR+tYNn2iMrXY5k026yeKzIZaSAy7ohaXSd/vO/wD+tYbGeGfELHZ+RMRbMjw5NrlQ1vLUFJcbUAdN6PVauUAb9etYKPwxzRONT2FY3cA8uXHWlHJ1KUoeBPfy5k/rQdBke0Jk8fHrXPXj8HUh11C31JWlpzlI+Fsc5OwCNkk9+1alxryi3Xu+WC+t2OGtVxtbUl3xnHd8wccQUHlWkEDk1vQNX194e5Y/wqxW3M2GaubGmTHHmQj4kJUUcpP30f0rG5bw3zGVbMVbj49PcXGtXgvBKPkX7y+rlPXvyqSfzoMDxWl3WTxLlvT4jMaVzM+Ay0fgLQQnwj8x7o5Sevn5dqm/Y3Jz1lgO3ZlDFyXHbVJabO0tulI50jqegVsdz9zUZeM/C/KpuTxL7ZLc5OadixwtDZHOy422lOiknZHwg7H1qRmEvXeRilsdyRsNXhbQMlAAHKvZ8h07aorN0pSgUpSgUpSgUpSgUpSgUpSgV5dcQ0grdWlCB3Uo6Feqil7R1wmXXitAx64XE2+ypSwAtRPho5/mdUN9ddR+X3oN14kca7tivER/HodsgSIrZZAecK+Y86EqPY6/irt7VwhOr5Gpcda+p5UupJ6d/OoHZVDZt+fCFFvab5HjusNNzknYWkBIAHU/KPh7+VZnhC83G4mvLkOIaQI04FSzoA+A560RNUXS3kEidFISNnTqen9a9puEJSUqTLjlKlciSHU9Veg69+or8+bJ/1XkP+pI//ACWa63wG4bftfZmb09eX4zdqupW3ES0FJUpKWllW9jROkjt5UEsVPNJdS0pxAcUNhBUNkfatN4m5sjFsIuN5tS4U2VF8PlZU5sEKcSg75Tv+Koj2W4JvuWXS85HlUiyXFsLkMSPCW6pTu+jY5T8IA6emula/Yf8AqrJP9QR/+VHoJh8FuIsjO7DOn3ZiHBWxKEdAaUQFfAFfxHv1r3xnzS/4bAt7uOWZNyVIWpLq1JUsNa1ocqevXZ69hr61Euz22LNwO7y5ORtxH4D6HI9qV3kqVpJWnqOoA8ge3lWwZRdJ904I4ubi648Y1ykMMrcOz4YQggb89EkflQdKybj9kVkfgMO2CA08/EbfdbdWsqQpRII6Hp23o9RvR7Vtdr4nZVI4oKsM3Gm49nEhbSpKioFCBvThWfhPbevyqKt5/wCh2L/Uz/8AfdreJMFq5+0RMgSebwJV8dYc5To8qnFJOj66NBIDFONtnyPNmcbYt0th511xpL7i0eHtCVHyO+vLofcVsud3/IIEqNbsYtkV2S+OZU2fIS3HZG9aI3zKP0A/WokcOIdrjcXoTNzkJjQIUx1xLjroQApoKU2Co9OqkJH13qsezz5hdLzPyG8qZnBKnkqfWgBStn4fjWkgDsAgKPoKCe0dSlsNqc5OcpBVyHad666PmKw87LbBAvrNlmXeGxdHtckZbgCjvsPufIdzXMvZgceRjNxhLv0W7MMOoU22x4p925gdpJWlPQ63obHf1qrmOKcPZ3FuHOvN8VGyJa2XPcQ8EodUnQRzdOhOk9Njf50V2SqBmRg94JkMh3tyFY5v0rUeM91m2Xhhf59sWtuW2ylKHEHSkcy0pKgfIgKJ39KiHZsbtdzxR29TcxgwLqJXhe6SQtSynoeclO1eZ7JI6dTQTwWtLaCtxQSkdSSdAV4YkMyElUd5t1I6EoUFD+lQz4l365y7Vh9hk5GJtqMULXOb8QNukvLRzK5gFK5EpA6j19a94yTgXGWzwMUyBF6hvvsMvORujbqXFAKQQCQSN73s6OvSgmI1cIbznhsy47i+/KlxJP6bqo3JYdaLrbza209StKgQPzqCXDe2Ku+YTIiZkmGDDmLLkdXKshLSzy79DrR+m698N40y4W7MI7F0lw47NleluNsq0l/w1I0hX0Oz26+XYmiJ0LmxW2UurksJaUdBZcAST96+CbFLaFiSwULOkq8QaUfQHzqAcebIc4e3GGt1ao7d0iuoQTsJUpqQCR9wkfpWQyK2rjcOMOuRnSnfe3JqEx1K/dsBDifkHqSokn7elBPBb7Ta0IW6hK1/KkqAKvt60ffZjo533W2k+q1BI/rUFM9bnMWjDJ0i6zZbsm2eIgOr/sAl1SQlGvLQH1q7yy7zszzaBHyO5vMRvdY6UlSkBLe2EqJAWpKRzE7JJHf7ChU3veo/gF/x2vBHdznHKPz7V4RPhrbU4iXHUhJAKg4CAT22d1Ca3NKteJZdDjZNBlRXWEhVvbLilL5X29OfL4YI9Qo9D51irTbC/wAML/cffJKBFnxUiOlWm1lQWOZQ8yNdPuaCYfE7iDb8AtMSfOjuzEyXgylthSQr5Srm6nt0/rWQ4fZbEzbGY96gsuMNuqWnwnFArQUqKeuvXW6h3c2Pf+C1qukp552VCvDtuZ5l7SllTQd1r+9UgfZWj2xjh4pcOShy4vvKcmMh0KLRClJRtPdO0p3170HZ6UpRStI4i8M8fz5Ud28okNSmElCJEZYSvl78p2CCN9e1bvXNuKfF2z8P5TMF6M9Pubjfi+A0oJCEk6BUo9t6PTRoMJJ9nnEV3BmUxJusUNBvTTTrfJtAA2eZBOzrZ69ye1X8ngXhsrI37upuXzOrW6qKHR4PMrfXl1voTvW9fTXStXHG6z5rimTWhyC/bLg7aZZZStYcQ4QyskBQA0dAnqPKuW8CcwZwdrKL1IY96LcZlCGA5yFxSnQNA6Pls9vKiOzxPZ2xaNHmMoud7KZTQZWS61sALSvp+777QPy3W+8OMGt2A2WRbLTIlvsPSDJUqUpKlBRSlOhypA1pI8q0W2ceLY5hj2Q3e1vQke8mLFjNvB5yQoJClEfCkADY6mrPEvaJsl5vLMC52uRa0vrDbb5dDqASdDm6ApH160VsU3gfhsvJzenIsgKU4XlxA4PAWs9dlJG+/XQOvprpWGh+zzisVicy3dL0pMtkML261sAOIc2P3ffaB+W6uMu49Y7j2Tqs6Ysqb4DvhSpDRAQ0d/FrzUR59u1cH4M3SJE40sXSS+G4DZmyFuq3oIDLp3+lEdzb9nbDk29EZb90WpL3i+OXUBwggDkJCAOXpvtve+vWthyjhFjl/wAatFi3LgW+2KUplMRaQSVDqVFSVbJ779TWhy/aZtDc9TcWwTXoYOg8p5KFEevJo/41ncv45wrLY7HeLZZ3LnbbohzlcMgMqacQQFNqTyq69fWiqUn2dcWkNRELud7AjNeEjTrXUc6ldf3ffajWZa4L2BvPP2sE66G4e+md4Rcb8LnKubWuTet/Xf1rX8n4/RLOqzIh2Jyeu4wWpZSmUEFpSyR4fyHZGu/Sup5JksTGcVevl9BjsstpU42g86uc6AQnts7OvL8qDRb/AMCcRvOQOXdRnxXnXfGcajupDalE7J0UkjZ9CKo5LwBxC+Xh+4BdxgLfUVraiOIDZUe5AUk636DpWuL9pe0mBIdbsUr3lDqUtMLfCfEQd7VzBJ0R06fXvXTOFGcp4gY07d0QDADclUfwi94m+VKTveh/N215UGSwfD7PhVn/AA6xMKbaUrncWtXMtxXbaj//AIVr2QcJccvucs5TNMwTkLbcU0hwBpxSAAkqGt9kjsR2rSsk9o+z2y7vw7bZpNwaZWWy+Xg0lRB0SkaJI++qwXELjS9kfDh2RjEO622QJSGn5TbpT7v2UPiR3Cuo66/OgkXc4Ea6W+TBnspfiSGy062rspJGiK5Cv2csNVL8USLulre/BD6eX7b5N/1rSOFXFu7WPh1fLjfY1wvfus5sIkyZSvi8RIHhhSkq1y8vNr/T8vPZbP7RcO5ybXFRj7qJUyYIyke9bDSSUBK98nXZUrp0+Xv1oN7ybhLil/x632h6GuKxb0FEV2MvlcbB7jZB3s9TvfXrVngnBjFsNuyLnDEyZObB8JyY4lXhk9NgJSBvXnWt4bx6ayV27oTjy434fbX7iSZgXz+EAeT5Bre+/l6V9xX2gbXdoV3mXS0u22Nb2Uu7TIDynVKUEhCRyp69fWgy+L8Dcdxy8uXKHPuzj62XmSl1xsp04gpUeiAd6J1XzGuBmO48i7ph3C7OC5wHLe74rjZ5W1lJJTpA+L4R32PpWqxfaZtC5wRJx+a1EKteMl5K1AevJof41pfHziLfDm7Sceud1ttsEJlTK2JDjaJSVjn8UAa/m5PPqg/YEdOb9nfF27XIgC5Xvwn3mn1KLrXMFIS4kAfu+37xX6CshcuBmO3DGbNY3rhdkxbUp9bK0uN86i6oKVzHk10KRrQFYS7cbHsVxHE5Nyx6S/KuURS1pelFtaS2rk5jtBJ5vm39fPvVXMePLeNGyc2PLk/idrYuQ1MCPDDnN8HyHeuXv0+1Blb7wLxy82+zQ5Nwu6G7VGMVktuNgqSVFW1bQeu1Htqq+T8EMVyFi3JkKnR5EOM1E95juJSt5DaQlPPtJBOgOoArVpHtGQomRS7bMx91tmM860p9MrmJ5ObWk8nmQB386uLhx1tEnh4q4TYk+BMnOPRWI8N9Knk8qU7cCykBPzDro9fWgzdp4J4fDsF4s8N6W47MShmTKLyFPtpCkuBI+HlTshJPw9R+VfIfAvHImLXGwt3C7mJOfakOLU43zpU3zaAPJrXxHfStK4LcT8OiXgWiNZptrlXN1KVzJEoyS+72T4ijogknyGtmpG0Vze3cHMaiYRJxZ1U2XAelGYHHnE+K25ypTtJSkAdE+nmayXDThtZ+HouH4M/NeM4o8QyVpVrk5tAcqR/Ma3alApSlAqLPtH43ebdxFj5XFguzLctLJ5kI50trR05VdDregQT61KalBDnGUXfIl5LcmsQhMxBbpbjs55p1TjZ8BYAQtStFZOuw8zXP7Vi064WS8zkMPpVbkNOFBbPxpUvkOvqNg/rX6DUokQabs14yLhnFat9vkOuWGW8p5pto85afCSF61tWlNqB12BHlV7JYyDine7FBg421A90ZRFW/HjqQgJBG1uKPQa8h+nepsUoIfOWjJOHfFqetjHPxr31x1uIX2VLbdS4rYUFdgryP5/etRwbGrpec1ftaIqo8qQxMbSCgpQF+A5pO+wG+lTvpQQPguXixQZuOTMZckSHJCVFp9pzYUNdOVOirt06669K7JmGHT5fs7trm2SJa7nCf9/TDhNKTyIJ5TzAknmKTzHr5D0qRlKKhHwQxqXkHEyytTmH/AHSEfeVlxJ0Et/ElPXyKiB+dSX4+49PyXhrOh2hpT8xtxt9LKfmcCT1A9Tok6+ldFpQQSmKyd3h8m0P2Btm126WCqSYZRI8VfMeQqPU+fl5DflUh/ZSZcZ4ay0vNrbV+JOnS0kHXht12alBBrJFyoV5lSmsWudkvoeUUuxlrQzsnqfCUgnRG+gVrr21XQrfY8vyHgdkjc+x+HOXJYfY5IiWH5SEnaiUpA5tDsdbPXv0qSOSXqJjtim3e4lYiRGy45yJ5la9APWtY4Z8TLPxB9+TaWJjDsPlLiJCANhW9EEEjyNERTts67NcLr5jDtnkIYTLRPL6mlhQc22jw9a12BPr0ruXss21J4cXL3mIkP/iTvIXW/iH7prWtj1rudKKg7h1uyHF7zksNzH5rz7lomw3QpBQGkFHVzZGiBy9PXY13qww/Ervf7BkTFuhyHJMdtmSGQg8zoSoghI8zpW9fSp41qdj4i4pfbwi1Wm8sybgvm5WUoWCeUEq6lOugBoiKdtvl9esloxlrBIU1+A4ogv29xTjhUT8wBHr1P0HpWze0NiV95MXuQtAQwzaWokhuC0S1GdSpSinQ3pPx6HXyrs+McZccyPM/2cgMzxJUpaG3nGgG1lAJPnsdAdbH6V0ugh7xSbv2WYDhl7NlkttxWXYTiWm1K5AkpCVEa2AoJJ32rVOIxu9yGLmZZpUP3exxozQUCouoQVgOa18O+vQ+Wj51O2lFQxwWA8v2gmC/EcUwbs+SVtnlI2v1Gq3/ANqXDbjIk2m+2eCp+FGZLL7bDe/DPNzBRSPI7IJ+g3Uj6UEQeH794yviBbX4+HQnQhbQflS2nVhlKTsr5uYJB12GvTQqX1KUClKUClKUCo3e0bnOZ2HKG4FofkW2z+ElSJDKNeMo/Nteumu2hr18xUka4zxL4XZTfcrmXnGMnFuRLbQh2MpbjadpQE907B3rzFBoOAZ1m1q9/utzvce/WWJBdfcbRKadUlYT+75h/aJBVodq11GZcU7xY7hmMa8Ot2uE8EOJaUhCEEkdA3rqBzJ777+ddG4eez8u0y5UnJ7o1J8eM7GMeIFBJDieUqKlaJ1vYGu4B8q1972c8kaefhQcliCyurClJWXEqVrsVNgcpI+9EafmfGDKbs1ZZUK6yrc97n4clEVwoQ44lxY59fVPLWQv3EzPcZyy1rn3lLraosWQYzY5mltrQDpXMN8xG9n1PStuzH2d58lFoj43PgJjxInhPOTFLSt10uLUpWkpUAPiAHXy/Oq2f8DMiyO8wZcO4WlttiBGiqDrjgJU2gJURpB6bHSg6txhy97CcEmXaG2hyZzIYYCxtIWo9z9gCfyqN7mZcU7dYYWaP3l1VqlPlpsLU2pClAnoWtdAeVXl5VKXPsViZnisyyTlqbQ8AUOpGy2sHaVAefXy9N1wBj2c8lccbgzclifgzbhWhKC4ojfchsgJCj96DAcVOKWSSp9jnWe6zbYzNtTT7keO6UoDnO4lRH5p/TVbndsi4i8P7FfMgyeQ0+u4rbj25kPeK1HWrmUSE+QCUnXqdbqrxJ4DXK93O2fs1Lt0e2wbe1CQmW4sOEpUolR5UEdebf33XQ+OEK0vcLZyMg8cRGfCIdjJCltL5glKwCRvRPUbGwTQR/umW8UIGBMX2fdnxbLrIT7vKQ8kOoUAr4QE9kqAPTX8I7efmZxby5nDLBbIV1f/ABCWXXX5jhCnVAuqQhAUr5QOU9ft1rn93MFmzJixr5KuPI8DHZ5FtstIIPMSlXZRPL0Tsd+tdgxvgxIzThTj01qUm33VsPFAfQSh1lThUneuo8yDo9FUGr8Qs04k4/dolsvd7fiTGIiAfc5A06klRC18p1z9dHt8o+5vrPm+czeLKrTbb++oruDzLLMp1RYGioDmSO4Gu30rM3T2ar2BEFsu9tWfAHvKpCnE/vuZW+QBB+HXKBvrsHtWy4vwUyC08VGcmkT7WuCic5KLaHHPE5VFWhoo1vqPOg0HCOJuVzFZNabxdHZrTtpnLQXQCWnG2VrCknXb4SNdqxXDnMMrtOLZQ9jvO6+nwOYtshXgIUV8zgSBonokbIOt1v8AjnATJLZd7lKfuNnU3JhTIyAhxzYU8ytCSdo7AqG/p615sHs/5PAts5o5BBhS1usvsPRFukgoDgIJ0kgHxO4327UGi41m/EW5Oh23ZalUvxOURJUtpC1n0CHNJO/QVtmR8Qc/yTiecdxeaITsR0tJY2hAW42P3hWT36hXTtryq6Ps9ZReLumRk2TxXkABJfSXHnSB5fEB/iazWe+z2u9ZKbjZLu3GjyFJMhuQkqUk6AUpJHzE63o66nvQc8x7M85vnE02WTkMyG9LlPxy208VNMLIWBygHqlKta0fIVg+CMGbJ4xWdmLNVHfakrccdG/3iEAqWj/aSFJ/Our4bwHvONcRoN5buFuctMOWp1tBcWXi115djk5ebRG+uq+SeAF3g5sm645fmI0L3gvDnK0PNpJ2UApGldCR3HSg0OzZXMs3HS8TXHCtiLLuC3G0pSCtDaXVBJOt6+EfpVRrNOKWU2+8ZRbrq4xbrYeZ5thaG0NjvoIPzaHruug2vgdd0cUJd+ucu2O2eVKluOMIcc8UtvBwa1ya3pY31rBzPZ0yFiXKi2bJIybM+oc6XVOIWoA9ApCQUqI+/wClBgcu4uZNdsBx2dGuT9vuKJUmLLciq8MP8qWlJUQPos/nurC+cROINos+Kz15AoNSoq3Wgn41OcrqgS7zD4j0+2tV0jLOAUp7D7BZccnw/Fhuvvy35hUjxnHA2NpCUq0AEa19BVrlXAvIrvjeK2+PcLSh60xXGHlLccCVKU6pYKdI7aPnqg7zilyXecXs9zdSEuTYbMlSR2BWgKI/rWUrE4jbXbNilltclaFvwoTMZxTZJSVIQEkjejrYrLUUpSlApSlApSlArX8rzLH8SbbVkN0YhF3ZQhW1LUB5hKQSR+VbBURvaMShnjTFeyBqQ7ZlNRzytnSlMj50pPrvm/WgkhifEDF8sfWxYLuxKkJTzFopU2vXryqAJFY+78WcItFyXAnX+OmShXItLaFuBJ8wVJSQP1qOmKKxSdnEv9goORRriuPI/DwXUFtCvAUPiHVWt/6R7itHx5/F4+PZCxkcGe7fVoCbc40rlS0sb3zjY89b2D09KImXkHEvEbBDt0u5XltMa4JUuM602t5LgTrm0UJOtbHeqEjixhEZ2G2/f47a5bKH2wpC/kUNpKvh+HYO9K0ahldGZzWD2BcoLEVyXMVG5vNOmAoj6cwP5g1leJtrhWyPhyoEdDJl2CPKfKf+0dUpzaj9eg/SgmM/xDxRjImrE7e4oubvIENdSCVfKOYDl2djpvzHrWNg8XMIm3RdvZviBKR4hUHGHW0p5ElStqUkJ6BJ86idxNt0WyZtCatbQjo9zhP6ST86mkKKvuT1q84cWqFeuMCoN0jokxHHJpU0vsSlp1Q/QgH8qCV9o4n4bdos2RBv0ZbUNovP84U2UIHTm0oAkbIHT1HrVWFl+H5Xj1wlN3GBNtDCdS/eE6QgHtzpWB0PlsVDzhdaYV2XlYnsh4RcfmS2QSRyuoCeVXT03WOsTc53CslELnLCFxXJIT/7MKWNn6cxTQSNtk3gUu8oEVuziUVgJLzDoa3/ALY5K37I+J2HYrdfwm73QRZbaEK8JMZ1YCSNp0UpI7fWocRncTXabaiazcEzEFQkmIgBS/T4lrKfyCB9zWY4ztpRmMBpKJKEC2QkhMojxQPCT0XrpzetBLq38RMUnovC415YLVpUEzHVpUhDZJUB8SgArZSR8JP9axtv4v4JPnIiR8hj+MtXKnxG3G0k/wB5SQP61yr2gcCtGI8PA5i1vXFZfnsmaUurcBSlDgQTzE6HMv8ArXJxJ4eOWKyNOW6/puqEET3Y7qAHF+XKFbGvTQH13QdbzzMshtXGf3BOZxYdvRIZHuRYdUEtqCTyqAbIUSFd+bz7iuyTeImJwchRY5V8iIual+H4WyQlX8qlAcqT9CRUTuJaeTjHHTqQNC2jUgguj/i7Pz6/i9frWGtj1rgZfem84tE26SFKdaDTLxbWmQV/MfXrv9exoJFcQuM9hlYReP2Kvy/xxlttxopiuJKR4yAo7Wjl7KP61acA+Isyfi+QXXOb4gsRH20IekBCAkFJ6DlA2SfLvUY7N/0O9f6mP/vNVfIZmr4fOushZgN3IB/XYLLfwE//AF/rQTMsnFjCb3cW4FuvzC5TquRtDja2udXkAVJAJrdJD7UaO4/IcQ0y2krWtZ0lKR1JJ8hUEoisQkyrQhMa7h/kQh1uAgJWp3Y0drWrmJPoEj6VKnj0xMe4OXlEJLqnQ00pYHVXIFpK96+gO6KuBxkwEzfdf2ij+Jvl5vCc5P8A5+Xl/Pdadxt4yS8Ou1ug4wbbMccZL0j3hpawlKtFspUlSQQRzdt1G63O4wbAy3cmpguKXyXFxkfEpv05lL5R5dOTf1rdeMttiR8L4fy4EOWyy7EeR4sxKfHUkKSWwtSRo6SfhHkDREp+G+TIy/C7XeErbU880BIDaFJSl4DS0gK66Ctjz+5rZq5zwAu9ruvDO2Is7HgiClMSSPCCAp9LaCtQ132Vb33NdGopSlKBSlKBSlKBSlKBWLv2PWfIGUNXu2xJ7aDtAfaC+X7E9vyrKVxHjTxcumMZLGxrFYLUm6OJQpxbiCvSl/KhCRrZPQ/mKDZ0X3hrgF8etTKrbaLp8CXG2oqgs8wBSCoJO+hB71c53ZuHlpS7fcttlobWo7LrrIK3VegSOq1fkaidn93uV84le/X23LttzUuMiRGWkpKVJQhJOj1AOtgfXzroeacWLzkOZSFYxjtult2kueFIeh+8OpQlWivZ6JBIGv8AGiJDS8XxXKrZbHZVpgzYTTO4YU1pLbagD8I6aGgOn0rzceH+KXJMQT7DBfERhMZgLRvw2k70gfQbP61wd/j1kb/D5c1mLGi3ePPaYU8GSpl1pbbp6AnooFA31q0Rxyz5eOR7pGtLLkSMsomTVRVFlSyr4U7BHLoEDv1J+1Fdazv/AILLRe2W8wj21q5GO2pvxo61q8IbQjqkEaHKR+VbRZ8IxOJNbu9rssFqU4lS0SEN6UQtJBP5hR/Wojca8ubze8WK9Ns+7rdtaEOtb2ELS88CAfTzH3rp+R8ZMlN7j4xgVsbkvxWktLWWS844tKBz8qR0AGiPPtRHa7bw/wAUthlG32GDHMlhcZ7kRrxGlfMg/Q6FXFkwvG7EJItFmhRRJR4b4Q30cT/KoHuK4TaONuUXXGb/ABjGjRcktTXvQUGTyuNoWEupUgnopIO/yPQarF/8P2QfsH4wdh/tALh4ZPgDl938Pe+Xffm6boO9owPCbM6bn+A2iIpj96X1tJCW9debr0GvWrCDbcB4jOybyxAgXZxtz3dySto7JSBrW9bGtaPauL5Vxcv7+KWSzz7Vb7pd7q2mU4h6NzoCFLPgoS2D1UQkK2fUdKznCTi1kDuZRcUySzxo7az4KRFjFlUdWtjaR05T27DW6Dvd5etYimNeXIQjvgpLUpSQlweY0rofKtWh41w8tkpmdGgY8w8TztO/u+4Otp2ddD6Vyf2x/wCyxP8AvSv/ANVcIv10jTcbxmEwpRfgR3m3wU6AKn1rGj59FCgnBMwvE75chepNot82Y6UrEvXMVcoASdjvoAfpV1c8fx1NwN/n2uCZsVJdMxTALiQkfNvWzoVFvH+LWUY87YMetzsQW5DMRAC2ApWloQpXX7qNZ7NuLeUN8QLzjCXYn4UZTkLl8Ac/hnaT8Xro96DpWJQeEeTTZMDG4NqlyCwVvNojrTtsKT35gBrm5a3m3YbjdqtkyBCs0FiDK0ZDIbBQ5r+YGoZ8Isgv2OXi5ycVti7hc3YCmwEtlwNJ50KUspHcAJ19yPtW65TxSv8AnnCm4R1seDLhy2TNchhSUuR1JXokbJA50pB666igkJYsZwO1XJMizQLGzOR8q2igrSfp12D9q3JQCkkKAKSNEHsa/Pi0wbDLgj3u9SYFxJPRyHzsfT40qKvv8H610w8VsqwWTbcejSYEu3Q2I3xNoDvioUhKzyrPffN0oJIJ4cYamb70nGrX4/Nz793Trf27f0rO3my2y9Qfc7vAjTIuwQ0+2FpB9QD2NR9tXHDKrbm0aBmdkRCt81xPI0plTbrLa1aSoE/MB59Ouj2q3vvG/L71kU+JgNpbegw+ZXMI6n3FoSdFxWjoA+mvPvRUg7VarLitrWzbY0O1wAvxFhGm0cx0Nk+p0B+lX0OdEnJUqFKYkJSdKLLgWAfrqouZVxOuvEHgxeWlxo0eVBkR/wAR5PlcYUv4FIB6g+IEAjr0rMeyB+J6vug1+D/Dzdufx+mvy5d0Ek6UpQKUpQKUpQKUpQK4Pxw4X5DecwhZVhakKuDaUBbZdS2tK0H4VpKuh6aBBPlXeKUERMg4ScSbjlybncoouj7imXHpaZDKBsJTtIBUD8OuXt5dKvsk4N5tYMsny8NjR50GQpZaWVM8zaVHfKUu9lD+Yf0qVtKCIXEbE8pxvhIwvMLq/JffurKWYapBeTHSGnt9d62d+XTpVjh2F53kvDtiJjUtLuPz5CzKjLcQ2ltxChokn4iDpJ6eY6ipW5liVnzK2NW/IIypEVt4PpQl1TelgFIO0kHso1VxPGrXidnTa7GwpiElanAhTilnau/VRJoIw5vwMypg2SLYIAuTce3pRJfS+02C+XXFqAC1A6AUkb1WbyThRnNgzBORYGUqffTzrCXW0rZWpP7xJCzyqBO/Xv8ATdScpQcH4McJLtarleL1mym1TLgw7HLAWHFEOnbi1qHTZ+m+5qPFzw64W/iB+yj6U++mWiMnlUFAhZHKroT3BB13HnU/60WLwtxyPm6srCJTl3Lyn+Zx7mQFKBHy68genpRHNuNXB663S4Wu64Y2085EjNRVRFrSk6b+RSSr4T06EH086+8JcE4ixsuaueUT3bZbWlc7kNiQgJfIGgnw2jyBPr9vrUgqUVxP2lcIyHM28eGN2/3wxDIL375tvl5vD5fnUN75T29K5VeuCuYuY/jzcHHWxOaYeE0pkMJUVl5ZRzHn+L4Cnr10OlTBpQRIvHBLNfHsk+2w2FSUxo4ebXIbBYdbAT166UNJB6E+dLnwl4gyuIMi6yrY3KS5MLzkpp9lCF7OypKCvmA+hG6lvSgiDh/CnilYZE+Zao/4VL91U2k+8sqL4KkgtjSjo6+LZ18vcHVZu18E8ys2FuP2uS0xkTstt0ssyeQoZShwcvP2JJX1HbQ71KOlBDy48JeJ2RS46btaYbXh7SH+eM2NHuVeEdq/ME1qvErHTYuIybAJBWuO1Djl4DW1eC3tQH3JqdtaPkHCzEr/AJG5fLpb3HbktSFKdEhxIJQAE/CFa7JFEchgcJM6yPPoU/OprT0C3uJQJBcSVPNNq2kJSntzeqtHqe9Y+fwo4h4dk9ye4fueJBmBbYdafbQpLSjvlUHCOo9R6eVSmpRUesN4H3KFw1ya3XKQw1erwhoIQlXMhoNLC0hSh6qHXXYetXHs+4RnGF5DOj3qO3HsTralK5XW1hx4aCSNEqHTfpXfaUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClK+boPtKsrlc4FsZ8a5TY0Rr+eQ6ltP6k1iEZ1iazpOTWQn/Xmv8A+1Bsm6brCtZRYHv7K+Wtf92W2f8AOrxq6QHv7KdFX/ddSf8AOgvt0qgJLJ7PNn7KFew4k9lJP2NBUpXndN0Hqled03QeqV83TdB9pTdKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKD4a5rxv4jJwHH2/cw27eZu0xkL6hAHzOKHoNjQ8yfvXR1HVQ59qGe5L4oux1qJbhxWmkDyGxzn+qv6UHM77erjfri5OvEx6ZKcOy46rf5D0H0HSsfSlEKUpQe0uuI+VxafsoiqqZ0tHyyn0/ZwirelBkG75dmv7K6Tkf3ZCx/nV21l2SNf2WQXdH92a4P86wlKDZm8/zBv5covf5zXD/AImrtvifmzfy5Nc/9p7m/wAa06lBvbfF3PG9aySWf7yUH/FNbphHtDZBbZTbWTtt3WEVfE4lAbeQPUa0k/Yj864hSg/RSwXmDf7RGudqkJkQpCedtaf8CPIg9CKyIqMnsjZA+J15x9xZVGLQmNJP8CgQlWvvtP6VJoGivVK+CvtApSlApSlApSlApSlApSlApSlApSlBbrNQq9olfPxbvP8Aohkf+EmppLNQj49r5+LN/wDotsf+Eig0ClK3/gnbLdcMukvXfwjHt1vkT0odb8VKltpGto/iA3zcvny0RoFZW+WGZZo1qfmFrkuUUS2ORWzyFRSN+h2k11S9Xyy3vFL5HvuUwLw+iP4luLVmcjux3UnaUhSUBIQobTonXUVkZ9nhO2ixXV1tm6XC0YvGkMWdQP73a1kurGtKQjm2Ug7Ouuh3DmeM2LGX7SLjkuTe5bcU2mFEjKekHWup3pKQd9Ds/wBDV5NxvEptslScbylaZMZsumHdY/gLcSO4QtJKSr/R7mrvERb7XiF2zK42mJdpwnohRYr7f/FmlKSVqcWhOgRoaA6Cq19Vb8w4f3HI02eDaLta5TLLvuCC0xJbd2B8BJ0tJHl5Gg5pV7drVOtLkdFxjqYXIYRJaCiDzNrG0q6eRFdGyh7H8ElR8d/ZmDd30xmXLjMmKcDi1rSFlLJSoeGACADo78/rs19xu3ZbxLt0YB4We24zHmKaceS04tpDYKUFZ0lJPOgFR0B1NBwaldmvuFwZ+I3icnHoVgmW5kSWVxry3MbkpB+NCgFqIVrqCO+tVh5WBwZvEPG4FqDzdkvMVicFFfMW2uXb3xH+XlX37dKDmNKurr7r+Jy/w4OCF4q/ADiuZXJs8uz5nWqtaDtvsmJ/5/3Jf8tuUP1cb/3VLRBqKfslJ/53Xlf8sID9Vj/dUqUGiqwr1XkV6FApSlApSlApSlApSlApSlApSlApSlBYunpUHONDni8UsjV6SeX9Egf5VOJ3tUEuKq/E4k5Mr0nvJ/RRH+VE1qtZCw3ifYLtHuVpkKjzGDtCwAe40QQehBHQg1j6UG3X7Prnd7S7bUQ7RbIkgpMlNthIjmSUnYLhHU9euug35VbnNrwL3Zbqy42xMtMdqLHU2kgFtvYAUN9dgkH13Ws0oOr40nKmbbOvlrxyBeMdvSz75aoyC+22pKjrbaSVtkdSD5Aj6VQyxjK7tibgZxNGOYvAV7wtlLZZDjh+HnKnDzOK69NeVc7tl1uFqeL1rny4Tp6FcZ5Tav1SRVW63273gt/i90nT/D+X3qQt3l+3MTQdDuN/bXDjqyvEot6udtjtMicJq2zyhIKUvoSfiIB110To+ho1kmST8xn5N+zypDCIYt1yiAENrbDIS4g6HQ6SVaAPL+VafHyp9BlPvMpVMdJWHEBKUqcUCCtaeX4iAdjqADs6OzXqw5td7JZJtqhuJ92lKUskqWlSFqTyqUClQ3seStjp2oNpv9oZj2v3CwYHeGJd0KSiTcFe8LbCfjKGQlA0NfxHqU1dQ8llWXhqqJcMduiLjFalWyLcXGylhpDyx4iTsfMNOAD6msfN4qSfxdyTbbXFYjLcDq2ytwKeIa8JPOQrySVDQ0DvqDWHuudvT8emWlFptkREtfO45GbKCdOqcA1vyKtfYCg06lKUHfPZJR/y5kC/SO0n9VH/AHVKBBqM/sjo/wCN5Kv0Qwn9Sv8A3VJdvyoq4T2r2Kpp7VUFApSlApSlApSlApSlApSlApSlApSlBYO9qhh7QGPvWTiPcH1NkRbifemV+SifnH3Ct/qKmi4OlalnuH2vMrMq33Zs9DzNPI6LaV6pP+XY0EE6V1zIeA+TwJC/wpcW5R9/AoOBpevqlXTf2JrXneEmbt97Goj/AEZDR/8A50RolK3B3hpmLfzWCX/slKv8DVq5gWVt/Nj9y/Jgn/Cg1mlZ5eG5Kj5rDcx/3Zf+6qC8YvyPmslzH/dV/wC6gxFKv3LNdGv7S2zUf3mFD/KrVyK+3/aMOo/vIIoKVK+8qv5T+lfNH0oFKVteCYFe8ynoatsZaInN+9luJIabHn18z9B1oO2eyXAcas1/nqSQ2++0yk+vIlRP/nFSEbrXcMx2Hi2PQ7RbkkMR06Kj8y1HqVH6k1saBRVdPavYrwntXsUClKUClKUClKUClKUClKUClKUClKUFqsVbuJq8WKpLTQY5xurZbVZNbdUlNUGLUzVMs/SsoWvpXgs/SgxhZ+lPB+lZIs/Svng/SgxpZ+lPB+lZLwfpXzwaDFqhNL+dltX3SDXg2aAv+0gxVfdlJ/yrMBn6V7S19KDCoxyzlQUbTAKvX3dH+6s3GZQ0hKG0JQhI0EpGgKqJbquhFB9bTVwgV5QmqyRQehXoV8FfaBSlKBSlKBSlKBSlKBSlKBSlKBSlKDyRXhSaqar5qgoFNeCirkivnLQWpbr54dXRRXzkoLXw6+eFV3yU5PpQWnhU8KrrkpyUFr4Veg3VxyV9CKCgEVUCaqBNegKDylNexTVfdUH0UpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgar5qvtKD5qmq+0oPmqar7Sg86pqvVKDzqvuq+0oPmqar7SgapSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArneQcWrHYs8YxOXEuS7i86yylxttBaBd5eXZKwdfEN9P1rolRA44XFq0e0Ki5SErWzDehSFpRrmKUJQogb89CgkPxK4mWXh6qAm8szX3JgWW0RUIUUhOtlXMpOvm6fnV/wAO84tme2V25WduS0008WFtyUpSsKAB7JJGtEedRi4mZPH4icVbEuHBmybelqOkRG0BTy0n94tISDrela7+VbR7Jd1XCyTIMff5kF1sPpbX0KVtq5VDXrpQ3/dojquUcY8exrM/2auMe4mYFtIU822gtJ8QAgklYOgFDfSvl94yY7Zs4GLSI1xdn+O1HLrTaC0FOcutkrB6cw30qO3GKG5kHHy5W+OrTsqXHitn0V4baB/WtXvSbnb8ptV3vil/iE0t3FznGlD96QN/cIB/OglTbeOGLTLvc4DrVxifhzbrj777aPD02oJOuVZJJJGhrrWLZ9ozC3JBbWzd2kb14qo6Sk/XQWT/AEqO0YwhkuZ/igfMNSHkrLGitO5TYCgD0Ojo62N61sd6s1XhFmZahW6VAvVtWSSzKt4Ck9exJHMkn/QXQS2zvjDjGGTWodwMyTLcbS8WorYUUJUNjmKiANjy3usdF464pKsFxusdq5rbgeGXmfASHNLVygjauU9frXDuLEi2Sc6/EFyn7He0Q4ji2X45fa5jHQoDY2QQDykFJ7b311WvRL/Ju2E5W3Jt0ML8KMpc2NHSyTp9OkqSgBJJ2SDrfwnvQScTxqxROIx8gkqmRo8h5bDMdxoF5xSNcxCUqI11HUnzqyx3j5ht6ubMEqnwHHlhCHJbSUoJPbZSo6+51UVrzAmDDMeuBQs29RfYSvXwpcDhUR9CQU/p9Kusqlwsik4tExuGv3pm1x4T7bbXKp2SFK5iAPm3sdaCVkXjPjr+cu4t7rcm57cl2KXVtt+EVt8wOjz70SnQ6eY7VlOGfEq0cQ/xH8GjT2PcfD8T3pCE75+bWuVSv5D6eVRJkxprXFi8eAomdAlzJW+/MpgOOEfnyGut+xx3y3/un/7qCSdKUopSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBWEumJY5dpi5d0sNqmylgBT0iI24sgDQ2ojfas3SgwUDD8at01qZAx+0xpbXyPMw20LR010UBsdOlVoWMWGBclXGDZbbGuCiomS1FQhwlXzHmA3131rL0oMM5iuPOXUXNyx2tVyDgd96MVBd5x2Vz63saHXdLti2P3iWJV2sdsnSQkIDsmKhxeh2G1AnXWszSgwcfEcbjSHn49gtLT7wUlxxENtKlgnZBIHXfnVNjCsWjykSWMbszUhCuZLqITYUk+oITvdbBSgxN3xqx3l0OXezW6c4BoKkxkOED7qBrwjFMebtjtubsVrTb3VBbkYRGw0tQ6glOtEiszSgxkfH7NGthtse0wGreSVGKiOgNEnueUDW6p2vGbFaX/ABrXZbbCe/njxUNq/UCsvSgwqMUx5FxcuCLFa0z3SsrkiI2HFFYIWSrWzzAkH12ar2XH7PY/G/BbVAt/ja8T3WOhrn1vW+UDetn9TWTpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQf/Z",
+              "timestamp": 36016648287,
+              "timing": 1875
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAEwQAAEDAwMCBAQEAgcEBgkFAAECAwQABREGEiEHMRMUQVEIImFxFTKBkSOhFjNCUnKxwRdidNEmNDWChOEkJSeSo7KztMM2Q0WDwv/EABUBAQEAAAAAAAAAAAAAAAAAAAAB/8QAFREBAQAAAAAAAAAAAAAAAAAAABH/2gAMAwEAAhEDEQA/AJU0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUr4pQSkqUQEgZJPYVrzWuNKvXDyLWorSuXnaGkykEk+3fv9KDYqUJAGSePetdOuNLJn+SOorSJedvhebRuz7d+/0oNipQEEAg5B9axV51Da7KtCbrK8oheMPOtqDQ+7mNo/U0GVpWhda5X/skv8mG/wAGOlSHWl9wVJ5BFZY6v09ZokCNd75bocpTLf8ADfkJSrlI5IJ4oNnpVONIZlMIfjOtvMuDchxtQUlQ9wR3rC3fWOm7PLEW6322RJOceE9JQlQ+4J4/Wgz1KpRJLEyOiREebfYcGUONqCkqHuCO9VaBSlKBSlKBSlKBSlKBSlKBSlfFq2pJoBUE9yBXwOIPZQrF3K4xLewZFxlMxmchPiPLCE5PYZNWEPUtjmyUR4d4t78hw4Q23IQpSvsAaDZaVQjrJ+U/pVegUpSgUpSg5v1wfeXZ7HaEvLjxLxdWIMtxB2nwVElSc+mcYrY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvr3q81dp2DqqxP2u5pV4LmFJWg4W0scpWk+hBrT3dF6zkwjbJWvFqtqk+GtaLehMlSOxHibu+PXGaDRDfbk/0PhwVTXShy8CyKnpVhS43ilO/P1SNua64jQOlU2P8ACRYrf5LZswWU7u2M7u+765zXt7RNkd0SNKmMRaUtBpKQfmSQchYP97dzn3rWk6J1oiJ+HJ1+7+GhPhhRt6DJ2dseLnvj1xmgw3UGVJ0J0UMfTt4ellt1MNE5SwpbLalkEbh6pHyg9xXRdP6ctlv04i3NtCRHeZCX1vHxFSMjlSyfzE5qnbtG2SFo9OmRES9afDLa23vmLmTkqUf7xPOferVWnrpbLKLPpiemNG2eGiRNWqQ5HT2whPGcem5RxQcVjvux+kXVCwJdW9brNOXHhrUc7W/EHyZ+mP512fROlLND0nEbMWNOVLjockyXkBxUpSkglSie4OeB6CseOmcCP01naSgSXG/OgqfmOJ3rccKgStQ4znGKN6O1HaYnkNL6pbhW0J2tsyoIkKjj1Datw49grOKDVNPy3tIf7UbVZCVQLO15yC1+YMLW0pakD6AjOK2npZpKxs6GtslcOLOlXGOmTLlPtpcW+twblZJHIye1ZrRejoembPKiF1yfJnOKenSpABXJWruVfTHAFa7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNBQ6fMt2DqfqzTdrGyzIZYnNsA5THcXkKSn2B74rqFazojSLGl2Zji5b9wuk5zxpk5/87yvQYHASBwAO1bNQKUpQKUpQKUpQKUpQKUpQK8PjLRr3Q80Gu6jEk20+SE4vbh/1LwfEx//AG/Lj+dYKypu/wCKMeaGovByd3mhB8PsfzeH8/7Vuy2SD8vIryGlk/loPrA/iCrqvDTYQPrXugUpSgUpVnKuDUeW3HVnepJWTg4Sn3/egvKV8SQpIUOx5FY683M27y+1nxS6opxuI/0Pf9KDJUrD/iz6kTlNxUFMYrHzOEbtvf8As0k3d1hpBWwzv8EvrBewNvskkcn9qDMUrGN3ULfS2G8EulvBVyAG9+cfyrza7uJlsemOteChsZPJII2gnuB747elBlaViYl5S/EivKbSguvFlY35DZAUe+Oew/eqf42d9vT4CczBlP8AE/Lzznj27e54oM1SsdcLiYkyOz4aShwgFalEYyQB2B9/XAqiL0nw1LLOQhlx5QSrJGxWMfr/AKUGXpWJN2cS2kFqOXVuBtO2QCgZSVcqxx29vaibq4uVHZQwg+I2HFKDm4DkjggYPb6UGWpWB/H1+VLvlkBYXtKC4flGCcn5fp6Aj61e3O5GHFaebbS4F9zuIAGM54BP8qDI0rEvXV5l2TuYaLLTSXQtLpyoKJA/s8duTmreTflx2lboyFupd8MhtwqSfk3DB29/TsKDPUrEzLutha0IjhakvIZGVHncjdngH7VUjXJbtyMRxpLfy5Ct5O44BOOMevvnjtQZKlKUClKUClKUClKUClKUClKUCvC2kLWhakgqQcpPqK90oFeHWm3ceK2heO24Zr3SgoiJHS44tMdoLcBC1BAyoHvk+tenI7LuzxGm17DlO5IO37e1VKUFPwGvGLvhI8UjBXtGce2aCOyltTYabCFd0hIweMdvsBVSlBTXHZcStK2W1JWcqBSCFH3Pv2r4YzCu7LZ4A5SOw5A/SqtKCm4wy44hbjTa1o5SpSQSn7H0ohhlClqQ0hKl8rISAVff3qpSgoCHGDKmRHZDSjko2DaT9q+qiRlKbUqOyVNgBBKBlOO2Paq1KC38jE8Mt+VY2FW4p8MYJ98e9VHmGX0BD7TbiQcgLSCAf1qpSg8lpslRKE5UNpOO49j+5qmIkcNhsMNBsZwkIGBnvxValBRdix3gQ6w0sKIUQpAOSBgH9q+txmG3PEbZaS5t27kpAOPbPtVWlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArFal1DatM2w3G+zEQ4YWEFxSSr5j2GACaytR1+L697LfYrI2rl1xct0fRI2p/+ZX7UHXtM9RdJ6nuf4fYry1LmFBcDQbWklI7n5kgetbZUGOn7zuh+qunHpaihJMdbhPGG5DSSc/YOfyroOqdZ6+1p1QuemtI3FcFuI8602004Gcho4UpS+5yR2+vaiJTUqM9m171H0tojUMjU8V17wEJRCmSkpOx0uBBBx+YYUSM/3e9azarr1guVnjaott1nSosiQWkIQ4hWVAnP8LGAnII7UVL6lRi6i9TdcSbjYdLW1Bs96ksMiYE7QtT6zgAK5CU9jxzz9KwsfqFrvRt6vWmNU3F2U6YT6QsuBbjDhYUptxDg577eD/KglvSoWaU1zr6ZYtTvxtRyVohw0uurkvKWtCS4lP8AC7gKOe/tV7bOpPUGb05vj7d5CmLfIjByUs4kpDhUAlJA5BKRknn96CY1Khze+purJvTKyS/xuYzObuMmK4+wvw1PIS20pO7bjON5Fe39YdT42jLTqtN3dbtDavKoUXUrU8sKVlTiVZ3ZII59APvQTDpUS9WdYtWapk6ftenJP4U/KZaS8WlBBcfUoj85/Knt6+pzmsJqnW3UC3a7FtvN+kx5bLjDTzUOSQ0flTzhJxkjk/UngUEz6VFhrXvUPX/UGY1o2UmNFt6lPNxCtLaFNoVj+JnlRVxkdufStCjdR9YvvXda9RXVGGVrSgSlYbO9Pbn0yRQTkpULLXrjXzugrzcmtSSTHiy46HHHHVKfyoLwEE9k8c+/FZid1t1X/s5tjDMwJursl5l6dsT4hbQlspxxgH+JycZ4FBLulRU0VqHqnbNWW9tx+bfoLpQt9vPjNltR5wsjgjnkHH3rWtJar6hag1m5Z7LqKa5LfD7baJMpWxICVZPOcEAEj2OKCZM+UiDBky3QotsNqdUE9yEgk4+vFaF066t2HXt6ftlni3JmQzHMlSpTaEpKQpKcDasnOVD0q609Avdr6SPxNVSlSry3DleO8XS4VZLhT8x7/KUj9KiZ0r1TK0c7qO624I86LYWmVLGQlSn2Rux64GT96CdtKhrI1h1Lb0Au/P31xVrnSw2h5MgJfbWnOQkJwUpODkfQHFdv+GW93O/aBmSr1PkzpKbi42l2Q4VqCQ22QMn0yT+9B1ulKUClKUClKUClKUCuDdYej+o9ea0VdY1xtjMFDLbDLby3AtKRknOEEfmKvWu81rurda6e0ihpWobozDU6CW0EFS1AeoSkE4+uKDieufh5mTryxI0tcYzEVLCELE591bniJyMg7VcY24GeMVW1X0DvE+9G9WW+xodxkgOSUErSEvFP8QoWkZ2k5OCB3rqll6oaOvUWa/br006mGwuS8gtrStLaBlSgggE4A9AaxrPWrQTsWRIRfP4TG3eVRXgfmOAACnJ7Ht7URp+kfh+jW/Tt7iXu6mRNuTIZDjCMJYwsLBGeVHclPtwMfWtVR8OGoStMN3U0T8KS5vACXCQfVQb/AC5x9a6l1M6hW2DZIKLfqqDZ356EPh5yMt91LC05C0NpGQo8Y3D39qyXTvVmnn9Jq8tqv8YRbmyqVMmHw3Ep5O5YIBA9Mn270Vo2uugbFzt9nOm7kIdwt0dEbe+DteCTkLJTylWSeQD6e1Y7Tfw/TY/4pP1BeWZ11eiPsxgCsoS6ttSAta1DccZ7Yro/+2HQvkpMtN+aUzHWltzay4VZVnBCduSOO4GK0nqV14gwLFBlaFlRZ0l6QptxMqK6EhCU5JGdvOSn96IxOk+hWoLPYtUQZFxtS3LrCTGZUhbmEqDiVZVlHbA9M19snQvUEDQWprG7cbUqTdHYi2lpU5sSGlKKt3yZ53DGAav3+pF11N0LkX2JeYdnvMWSGZrqGHAhsFZCUp4WckKbORn17emb6Ma2QjpzMumrtUxpzcaWWjKWlaNg2pIQSpKStXOeAe9BxLqnoW4aA0FZbZdZMWQ8/c5MlKoxUUhJaZTg7gOcpNZrQ/RWdrLR1huMe/GJbJKFuPx3Ape1xLq07kJyE8pA7/XvXbI2t+m2vZ8e2uyLXdJKVHwGp0Q/mPfZ4icZOPTvXuy9TOn0SadP2u4RoSoxdT5dERbDTWzcpfO0JHZR+v60Gl9Qfh+jXhm2q0zObgvQ4yIqkSEkpeCc4WSOQrk54OfpWsSPhvvEe8x3bXd7euG0WlEyCtLilAAr4CSAN2cc9sV3nSGu9N6vceb09dGpbrI3Lb2qQsDtnaoAkfWrvVWq7HpSIiTqC4swmnDhG/JUsjvtSMk/oKKiNr+Npq3dRrwu23i5WtKZbiJUdtg7sbvnDS0qwQecBWMfWsP0s0bcNb3e62+07Gh5RRLz5OxHzpwFEA8nB9PSs38RN4tl41tGnWFyI9AlQWng6y0kFaipYJUcbs8AEHtiul6L6hI091KvGmU22z2vTVvEl11yLFUHSlpBVuUQTuOB7Zoila+hWoInT6+WFy42oyp8qO+24lbmxIb3ZB+TOfmGOK+x/h6lPaC/C59ziN3pia7Jjvs7lNFC0NpKF5APdvOR2+tdPgdWtGXC03O5RLspcK2pbVKc8q6PDC1bU8FOTk8cZqyPW3QIipkG9L8FSy2FeTf/ADAAkfk9iKK53pL4fbqjUUO4auvrMuPEUhSWmFOOKcCTkJKlgbU/bP6VkOmHRe+aT6jR9QTp9seiNl4ltlSys70KSO6QP7Q9a6Avq7oZHkfEv7CPOI8Rrc2sYTkjKvl+Tkf2se/aslqvqFpbSimkXy7sR3XUhaG0hTiyk9lbUgnH1oM9eYq51nnRGlJS4+w40kq7AqSQM/vUe9G/DzcIYvEfUNygqjToJjtriFaltueI2tKsKSAR8hzz6127SOttPavQ8dPXNmYpnBcQApC0g+pSoA4+tbFQRdPw0XRMCXtvcJyZ4iRHyFob2f2ivgnd2wBx9a7D0R0RP0DpKTarpIiyH3Zi5IVGKikJKEJx8wBz8proNKBSlKBSlKBSlKBSlKBURviMQiP1piyNQMyHrMpqOrY2cFbI/OlJ987v3qXNc915qzp23cvwXWb0F2YztUGJMRbuzcARghBAyCOxoI3Q39FTL5fF6Vtl/jK/D5io4W+gttp8svduGCrb3/tHuKvvht0hY9X328R9RQRMZYjJcbSXFo2qKsZ+Uj0qVFu0fpy2xJUa32S3xmJTZZfS0wlPioIwUq9xg9q9af0nYNOvOvWO0Q4DrqQhxTDYSVDOcGiIfdSIMSxdYp8e/RHDaWlpS02QtY8uGwlrGFpKgAAPzDt3rEtx7bKsOoHNNRr2XWmwuQslIYEfxU8KSMqHO04Kj27nGam1f9MWPUPhfjlphTy1+QvtBZT9iaqWfT1nssJyJabZDiRnf6xtllKUr9Pm9/1oIHPS7C5otiLHs0lN/afK37j45LamznCdnYen7d6z70FC+g8acmMhTzeoHG1PhA3JQY6Pl3d8Zxx71JN+d0pZvr2knI1nTNkSEpdipi4Qp4cJSVBO3cMkYzwTjvW8wdK2GDZ3rVEtEFq2PqK3IoZHhrUcclPYngfsKCL9qvFsl/DFfbXCYLdxgPMLmueGEhwuSSUHcOVEJSBz2wBXPHWZqumER5tKzb0Xd9LpH5Q4WWdmf0C6m0xobS7Ftl29mw25uFLKVPspYAS6UnKdw9cHkVcQNJafgWqRbIdmgtW6Qre9GSynw1qwBkp7E8D9qEQov67Dc7rp1jp7brjFuHhttvB1e5TknIwpHJxz68DtwKzHT21xbx10/D7ww3Kjuy5vitrHyqIQ6f8AMA1Luy6M01Y5Qk2ix26HJAIDrTCQofY9xXmDorTUC7/ikOxwGLjuUvzCGgF5UCFHP1BP70EX/hRUR1PdAPBt7uR7/Misx8VrLrev7DKuDby7QqKlOEHGdrhLgSewVgp/lUibHozTdhmmZZrJBhSigo8VhoJVtOMjPtwKyN5s9tvcTyt4gxpsfO7w32wsA+/PrQQL1+9p6TqFT2j4EuDaFtJ8NqUSVFXZRGSeMj3PY/apd690ZYmdI6ovEG0R03p+2SSqShJ3qKmlA/vWwzdAaSnFgy9O2x3wGgy3uYT8iBnCR9OT+9bNtTs24G3GMemKKgZpK8Q4WgdcW19axKuDMTwEhBIOx8KVkjgcEd6wDv8A+mY3/GO//I3U8E6F0qlmY0jT9sQ3LAS+lMdIDgCgoA4HbIB/QVpGqEdItMXBmz3yBZo0hRDgZ8qVBG7A3KwCE5wO/tREaNdW2HC0roiRFjttPS7e44+tI5cUHlgE/XHFfL7tjaxtkjVDLr0J2BDdwpKlb2zGQEkAKSSAfZQ7Gpd3KwdPnUQ4VyiafIithEdl5TYLaFHcAkE8A5z+tZq56Q09dIUSJcbLAkxoiA3HQ6yFBpIAASn2GAOPpQR3+G5Nid6iSHLJHvPjJZdKnFFCY6WiRgKT8yhzjAKjyO5xUpaxlisFpsEdbFktsSA0s5UmO0Ebj9cd6ydFKUpQKUpQKUpQKUpQKUpQKhf8SKijrLcFAbiluOcD1/hpqaFRk629LdYan6lTLrZLWH4DqGUoe8y0jlKEg8KUDwR7UFa39btWwNbptmq7Q1CjTFgNMrZKHWEr4bVk/mGcZyPft2q36b9YtXX46nFxkxVeQsUqextjpTh1vbtJ9xyeKubT0f1nfOobN01zPafiQlpCZPiJUqQhHKAlI7DPJzjue9YOw9GNf2KffW4AhpjybdJiF4OoV5hChw2kEgpKiEjJwBzzRFXTvXnVadP3ydcG4055gstRwGQhDSlleVr28kfLjHuRVOxdZOp9xQqZAt8a5RkKwtDUMqx+iTuFU9JdJuo9ptN1REiMQJTq2VBL0hlxEhtIc3IIBUk8qScKGOPpVo10Z6iXO/tSXoFvs60EYksOtMoSR/aCWec/YCg8aru4j/ECwtu2W9t5U6GoqLRyFOJbUokZxuyo8kZrI6S626+ubl1ShqJcFR7e9JCfCQ2GgjBLh/vADPy+pIrK6r6Waxm9Y273Ht/mramXEcVLMhpJWltLYWraVbu6VcYqx6ZdJ9aWSTqJdzs4ZTLscuGyfNMq3OrSAlPCzjPueKDP6A673GVpXUs3UUSO/KtbKHmSwPDDpWsICVDnHzFPI9M1qh66dQ0st3dUKCLW66UIHlT4aiO6QrO4/vWS6c9FtS/heqLbqOGm2ouEJDcd4vNujxUuJWnIQonGU1h7b0o6q28ptsBtuHES9vEpmU0jn+9vSfFx9P5UGz9Q+vV8hR7OmxW1uCuXDTKdXLbKlBRKklKQcDAKTye/0q40f1W6goddf1HY0ybWmG/ID7UZSNxQ2paQFpJTyRjtXrXHTvqKfIs2+RF1HFbiIbd/ES08rxuStQ8YcAk8EHOAKw3Tno/1As8i4zvMtWZ5yI822yiSCXHFJIRnZlIAJBzn07UGNt3W/qNfLg6LNFhPFPzeWZjbiB9Mncf0qRGiL9drx09Yu16hiDdS06XWPDUgJUkqA+VXIzgH9ajdeekXUm8SGW5lmtSVJVzLYMZnd9VFGFK/YmpJ9P8AT1wsnT+DZL1N83NbZW248FFQAUTgAnkhIIH6UHDem/WLV19OqPxGTFX5CxSp7G2OlOHW9u0n3HJ4rX2Ouut12CbLVLh+M1JYaSfKpxtWl0nj/uJq9sPRjqBYp99bgiGmPJt0mIXg4hXmEKHDaQSCkqISMnAHPNYWP0W18jT06KqxgPuymHEJ84xylKXgo5347rT+9BnJfXDXkXStnuSo8ENyHnkGUttJD5QR8oQCNoAUOfXP0rX+surW77dNNXv8Jt/jTbS3Id3oJ/iB11BB5GU/JxnPFbHe+k2tJPTHTNoYs4VcIcuW6+15pkbEr2bTnfg5wexrH6p6O65nW3TLUWyhbkO2eXfHm2Bsc8w+vHK+flWk5HHNBpvVdd2d6ly3Ln4HnVqZUz4QASGyhJaGB/ubc1OCxicLLAF3LZuXl2/NFv8AL4u0b8fTdmo7dXuj2p7xqCLe9PNMyXFxWEPMKeQhbbjaEp4KiEkfKPX3rvmim7w1pW2o1KsOXkNDzSgUkFeT/d49u1FZqlKUClKUClKUClKUClKUClKUCrW43CFbI5fuMuPEYBx4j7gbT+5NXVRM+JB5c3rBAt9+lvRbGhpgJcSnIbbUf4iwPU5z79hQbZ1M6z6h051HesloRa3raDHLbjjSlqUHEIUTuCwD+Y44rtkLV2m50oxoV/tMiSApRaamNrXhIJUcA54AJPtioOajYtUXXYj6euT1ztTTzKGJLwIUpICeOw4ByBwOBWZ6VzI1s6kvvXB9uM0licgrdUEgKLLgAyfUniiJho1xpNxDim9TWRSW07lkT2iEjIGT83AyQPuRVZnV+m3m2Vs6gtDiHnfAaUmY2Qtzj5EnPKvmTwOeR71Ayyf9l6h/4JH/ANyzXZfh76b23VlhF8nzZ7ci23QlhlpaQ3lKWl5IIPJOAcHsBQScdvFsZuKIDtxhonLGUx1PJDihjPCc5PFaJ1I6m2206Iuly0pebLcbpFDSkMokIe+VTqEKJShWcYV398VFKxSLVO1Hd5+s7tdIM4Bx9l6Ijc4ZO7OCe45+33FYiw/9lak/4BH/AN1HoJZdF+p7uqNNzbjq6VaretuYIzJCvASv5ArHzqOTye1XHXLWeoNK2u1yNLm17JS1hx6W82nsAUhAUoA5yckZ7VFO0RLDI0VeHrleJDF4juJVAgJSS27uwFqPHfA9x2Hetg1BJmSOhulxMWtbbV0ktxys5/hhCeB9AoqoN71N141faXbc0hmwrW9EQ86WwXk7ypQOFJcx6ducHI9K2y39TtVJ6rO2i7L07HsjclxpwKmNJU22nPzZ8TO7jkY/QVGe8/8AU7F/wZ/+u7W9ORGLh8RkmHLR4kaRfnWXUZI3JU4oEZHI4J7UHadH9eo2oddxtPu2hmHHfecZROVPCkkgK2YGwA7iAAM91DvW19R9T3SDPj2qx3LT1qW6ne7Ouk1CS3z+VDROVE98nior6BFmtXV2Ob0UsWyFLeUkrUrCFthZa7cnCwj7+tYm3IhXu5XmRqm5OR5qkrdQ46tXzO5Od2EKJ+3H3FBPmA+mTCZeQ+zIC0A+KycoWfUp5PH61rl06g6YtWp2dPT7q0zdnSkJZKFEAq/KCoDAJyOCfUVzz4W0xmNOXaPBva7nHQ8hfhmMtpMdSgcgFX5s4Hbtj61caxidMHOrcNy/SVo1PvZPhAr8JTnHh+JgYzjb6jjGaK7LWGXqvTzczyjl9tSZWceCZbYXn225zWv9b5kyD0q1FItylokBgJ3I7hKlpSsj/ulVREsdn0hL0g5Lu2o5EG++a2JjJjF1PhYHzcdz35z6dqCdsybFgxVSZslmPHSMl11YQkfqeKtrTe7VeErVaLnCnBH5jGfS7t++0moadRpq3bboq1Kvcmdp5uJlEpTKm8/x1pUdhOSUpSkD6D61X08Lfp3rXYWun12k3KC5IYbLqklJWFkBxB4GRjPOOP0zQS5g6u03PkmPB1BaJMgJUotMzG1qwkZJwDnAAyauYd/s86G9LhXWBIisp3OvNSELQge6lA4A+9Qf6b2hi+awlwpbj6GTDmOHwV7CSlpagCfbIGR6186cWtN1iavQ5JksojWN+XtZc2h1Ta2ylKx6pyc4oibb2qLAxb0T3r5a24K1+GiQuW2G1LxnaFZwTgE4r5/SrT/lY8n8dtflpKill3zbex0g4ISc4JB74qCEV5w6DubBWfCTcoiwnPAJakAn+QrJ6ks7EXpvo66pdfXImrmtrStzKEJbcTtCB6fmUT7k0E5ZV6tcN6OzLuUJh2SMsocfSlTo90gnnuO1fbrebZZ2kuXa4w4LavyqkvpbB+xURUGdd24QrHo2WJMl52ZbPEUHnNwbw6tISj+6nA7Vc6jmr1BrqF/S2Y+iMYkZJcUsp2oLCFAg7VYBJyTtPcmgmynUNlVbHbkm72829rHiShJR4SMnAyvOByR6+tW7OrtNvxHZbOoLQ5FaUlDjyZjZQhSvygqzgE4OB9KhpAj26DpzVrdr1GqR4kYJVCRHc2rQH28LLhCRkcc7R39M1jrTaGJPTC/3Rxb3jw50VttAWQjCwvJKfU8Dmgll1W6oQtCWa3zozMa7OTXdqGUSw2S3tJ8QYCspyAO2Oe9ZjpfrVjXmlWbu0y1FeK1odipfDqmSFEDccDGQAeQODURJkRqR0Ot9xdSpcuLfXYTThUfkZUyHCnGcfm57V3/4VXLN/QBbNvcQbsHS5cEBSiUkqWGyQeBlKfT2oO00pSilatrjQOntbNsJ1BC8ZxjPhvIWULSD3GR6fQ1tNc26p9XbP0/lMwXoz0+5uN+L4DSgkISTgFSj2zg8YNBRl9DdEPz2pYhSGFNJbCUMvlKBsAAOPfjJPqcmr5/pDoqRqF28qtYMt1S3FpDhLZWrOVbO2cnP3rQx1us+tdKamtDkF+2XB20yyylaw4hwhlZICgBg4BPI9K5b0J1gzodrVF6kMeaLcZlCGA5sLilOgYBwfTJ7elEd6jdB9FR2ZTTbE/ZJbDTmZJ/KFpXxx7oFbloXRtp0RanrdYkPIjOvGQoOubzuKUp7/ZIrnts68WxzRj2obva3oSPMmLFjNvB5yQoJClEfKkADI5NWekviJsl5vLMC52uRa0vrDbb5dDqAScDdwCkfXmit3l9J9GytSi+u2hHnisuqSFHwlrP9oo7Z9fvzWEi9CdEx2ZbLTU7bKaDLgMoklIWlfHHuhNWmruvWndPanVZ0xZU3wHfClSGiAho5+bHqoj17dq4P0ZukSJ1pYukl8NwGzNkLdVnAQGXTn9qIkQ30L0Mm3piKt77iEveMFqfVvzgAp3DB28Dis5qbplpnUVjttolw1s2+3EmO1GcLYTkYP3rmcv4mbQ3PU3FsE16GDgPKeShRHvswf86zur+ucKy2Ox3i2Wdy5226Ic2uGQGVNOIICm1J2q5596KvpHQbRT7cZDjE/bHb8JGJJ/LuUr291Gsq30j0sjWH9JktS/xTzZm7vHOzxCrd+X2z6VqGp+v0SzqsyIdicnruMFqWUplBBaUskeH+Q5Ix34rqepNSxNM6Vevl9BjsstpU42g71bzgBCe2Tk49P0oNYvvRzRl7vi7tLtq0S3HPFd8F5SEuK9ykHGT9MVS1J0W0XqC7PXGXb3WZLytzvlni2lavVRT2yfpWkL+Je0mBIdbsUrzKHUpaYW+E+Ig5yrcEnBHHH1710zpRrlPUDTTt3RAMANyVR/CL3iZ2pSc5wP73bHpQZvSumrTpW0ottihoixUncUgklSj3Uonkn71hLz0z0xedXMalnwVLubSkL3BwhC1IxtKk+pGB+wrnepPiPs9su78O22aTcGmVlsvl4NJUQcEpGCSPvisF1C60vaj6cOyNMQ7rbZAlIaflNulPl+yh8yO4VyOcfrQSPlxmZkV2NKaQ9HdSUONrGUqSRggj2rmS+g2glSy/+GSEpJz4IlL2fbvn+dcz6VdW7tY+nV8uN9jXC9+VnNhEmTKV83iJA8MKUlWNu3dj/f8AT12Wz/EXDucm1xUafdRKmTBGUjzWQ0klASvOznJUrjj8vfmg6bqPp3pfUFiiWi4WtoQ4adsYM5bUwP8AdI/n7+tWWi+lek9Hz/PWi3qM0ApS++4XFIB77c8D7gZrStG9emtSu3dCdPLjfh9tfuJJmBe/wgDs/IMZz39PavulfiBtd2hXeZdLS7bY1vZS7lMgPKdUpQSEJG1PPPvQbPp/o3pOw3Rdwt7MwSVtOskrkFQ2uJKVcfYmvlh6NaSsSLmmAzMAuMNcF/fIKstLIKsccH5RzWixfiZtC5wRJ0/NaiFWPGS8lagPfZgf51pfXzqLfDrdpOnrndbbbBCZUytiQ42iUlY3+KAMf3tnryg/YEdhR0I0Ui3vwksT/AedbeUPMnO5AWE849nFVez+jWkp1gtVmfZmGFbVPKjgSCFAukFWTjnkCtUu3Wx7SukdJyblp6S/KuURS1pelFtaS2rZuOUEnd+bP19e9VdY9eW9NGybtPLk/idrYuQxMCPDDm75PyHONvfj7UVst36M6Su0K1xJjMws21gxo+2QQQjcVc8cnJNXOoukekdQRbczcILm+DHRFaeadKHC2hISkKI/NgD1rRJHxGQomopdtmafdbZjPOtKfTK3E7N2MJ2epAHf1q4uHXW0SenirhNiT4Eyc49FYjw30qeTtSnLgWUgJ/MOcHn3oNutnSfRUSw3WyQYh8OZsbmOB8qewlSVpSVf2eQk44qnF6M6SjadnWVpmZ5GY82+6DIJUVIztwccfmNc66LdT9HRLwLRGs021yrm6lK5kiUZJfd7J8RRwQST6DGTUjaDR7b0t0rB0lJ00IS5FqkPmSpD7pUoOYSNyVDBHCR2+vvV5oPp/YdCiaNPsPNmYUF4uulZO3dtAz2xuP71tlKBSlKBUWfiP03ebd1Fj6riwXZluWlk7kI3pbWjjarg4zgEE+9SmpQQ50yi76iXqW5NaQhMxBbpbjs55p1TjZ8BYAQtSsFZOOw9TXP7VpadcLJeZyGH0qtyGnCgtn50qXsOPqMg/vX6DUokQabs141F0zitW+3yHXLDLeU8020d5afCSF4xlWFNqBx2BHpV7JY1B1TvdigwdNtQPKMoirfjx1IQEgjK3FHgY9B+3epsUoIfOWjUnTvq1PWxpz8a86463EL7KltupcVkKCuwV6H9fvWo6G01dLzrV+1oiqjypDExtIKClAX4DmE57AZ4qd9KCB8Fy8WKDN05M0y5IkOSEqLT7TmQoY42pwVduOcc8V2TWGjp8v4d21zbJEtdzhP+fTDhNKTsQTtO4Ek7ik7jz6D2qRlKKhH0Q01L1B1MsrU5h/ykI+ZWXEnAS38yU8+hUQP1qS/X3T0/UvTWdDtDSn5jbjb6WU/mcCTyB7nBJx9K6LSgglMVqd3p8m0P2Btm126WCqSYZRI8Ve47Co8n19PQZ9KkP8KTLjPTWWl5tbavxJ04Wkg48NuuzUoINakXKhXmVKa0tc7JfQ8opdjLWhnJPJ8JSCcEZ4Csc9sV0K32PV+oeh2pG59j8OcuSw+xsiJYflIScqJSkDdgdjjJ578VI/VN6a07p6fd5DLz7UNouqbZTuWrHoBWodJup8XqILgI1skwVw9u4uKC0qCs4woevHaiIu22ddmul180w7Z5CGEy0Ty+ppYUHMto8PGMdgT78V3L4Wbak9OLl5mIkP8A4k7sLrfzD+E1jGR713OlFQd0dbtQ6XvOpYbmn5rz7lomw3QpBQGkFHLmSMEDbx75GO9WGj9JXe/2DUTFuhyHJMdtmSGQg7nQlRBCR6nCs4+lTxrR9N9VNJaj1A3ZbRcHXriveEtmO4gHaCVckY7A0RF+23y+vWS0aZa0JCmvwHFEF+3uKccKifzAEe/J+g9q2b4htJX3Zpe5C0BDDNpaiSG4LRLUZ1KlKKcDOE/Pgc+ldb0l1ogak16dMs2aewsrcQl9zHBQCTuT3SOPf2rq9BD3qk3ftWaB0ZezZZLbcVl2E4lptStgSUhKiMZAUEk57VqnUY3e5DS5mWaVD8vY40ZoKBUXUIKwHMY+XPPB9MH1qdtKKhjoWA8v4gmC/EcUwbs+SVtnaRlfuMVv/wAUujbjIk2m+2eCp+FGZLL7bDefDO7cFFI9Dkgn6DNSPpQRB6fv3jVfUC2vx9HQnQhbQflS2nVhlKTkr3bgkHHYY9sCpfUpQKUpQKUpQKjT8Rt31yxqrwbM/cWLEyyghdvUoALIyrxCjkH2B9MEVJauQdRejkjVOrn9QWvUsm0yn20IWlDZP5UhIwUqSewoOT9PtVajsi7ldkaubv0OHAedXEXKdUoL24QSh1IJAURkpz96wTNx6g3vS911sNVyERoMgNuNCattRUSPytp+XHzDjj1rtGgugNt0/NkS71c3Lq48w7HLYa8JG1xJSonkknBPrx3rXJPwyIM5fldTLbglWUtri7lgexIUAT9cURyvWXUvU17j2OSq7T4shuGWXzFfWyl5SXV4WUpIGSCAftWT1PrDWeltX2p57UkuSoxIknw0rUGihTaTsUgkg8cEnk966tq34eI1zTaWbLd0wI0GJ5ch2P4q3V71LU4SFDk7u2PSvWtugr+pbrDmI1A1HEeFHibDEKtxaQE7s7x3x2oN763armaO6fTLla8CctaGGXCMhsqP5seuADj64qM79w6gWzSdu1wrVclUaXJLSGvOrWsKBV+Zs/Lj5Txz6cVLvWWm4GrdOS7NdUqMaQkDcg4UhQOQpP1BFcKjfDIkTE+Z1MtcIKzsRF2rI9slRAP1xQc+6r6/v9zm6fuMa6T4Bl2hlx1mLJW0gub3EqUEg+pT/lW/ald170z01etQXe+tT5N3cbjRg2644iIpW5ZUlCxtHypwMfSth6hdBW9S3OA7ars1bIUKC3Cajqjlw4QVHO7cO+6tw63tWxvpZche4r0qG0GshhQS4k70pC0k5GRnOD37etBG+7TtfW3pxDv8rVDzttvEkBCUzlmQ2tO/9gcHIB9siref1F1QjRmnbPFvc1lcjxX35SpCvEXl5SEguE5CRtPr6/StNuosLUAt2l+5SpKnQpK5LKWUtIwcjCVq3KJ288Yx6547xpXoqjV3SnT67hIetV2b8VxtZb3ZaWsqSFJyD9Rz60HMeoN/1jZbtFt03V65i48RCUv2y4LUhSSVEbyCMrGcEkZwBWTsd91XcOsSrXb9ST2Fu3F9lrxn1utNjK8fwyrBwOw7dq6BcfhmbcTEFv1CGShgJfLsYr8R3colQwobRgpGPp35rP6d6Gv2jqO1qhV+adQiY5K8uIpBO4q+Xdu/3u+KDj/T/XWpxK1LbZl7nymnbRPILr6lFtxDK1pWgk5Scp9PerfQepNaL01qRNhuNwkzCY6SC8pxxKCXCotgkndwM45xk+ldXsPw+SLXc58s6iadEqJKjBIiEbfGaWjOd/ON2ceuKoW74cVsWqbEf1N87zrTzbjUXbsUgLHOV8g7z2x2oOS2e76vXJCXdbyrbc/E2iJcJchpRPpypOwfqRW0am1drDU/VRyyQtSCyphulhsuyvAYCmh8ylEfmKlJJ5z3A7VuLfw4PS7g27fdXSZrKAE4DB8TaP7IUpZwO/pWZ1v8Ptr1BqEXKBdHbc25s8djwg4FYABKTkYJA9c880HGtL3zVF+6pJtMzU89Kpsp+OtyLLWplKlBY3NpCgNoJynGOw7VZdEbY9N6xWeM3OdjrYkreU6jOXA2CpSDyOFBJSfoT3rtmlegY05r2Jfol7SqFFlKeaiKjncEc7Ule7kgEc49Ko3H4d46tWG62q+rhxTI8x5dTG8o+bJSFBQ4+47UHMrfrC72nrXeZK7hOfjQ5Vxd8suQstqS2h5SUlOcY+UcVaxLp1A1bZr9qxvVLzDFrIW8yJime/OEIT8uPvjP1NdltfQzy3UeRqWZeGpMR+TJechGMRuQ8Fgo3bvZffHpWv3D4Zml3B1Vu1ItiAtWUtOxt60j23BQB++KDn2rOpOo730705Icuk2PPjy5UV5+M8povpShlSSraRkjeR/P1qz1FqbWdpsekrgdU3AplxFuMoQ6oFAS6ofOc/OSfU+nHpXbNUdBIlw0rYrJZrr5JFuW86688x4ipDjgQCo4Ix+QD7Y9qtdSdBH7xYdN25OoGmjaIzkcuGIVeLucK8438d8etB2HR9wdu+krJcpGPGmQmZC8DA3LbCj/ADNZesZpe2GyaatNqU6HlQYjUYuBO3fsQE5x6Zx2rJ0UpSlApSlApSlArUdddRdN6I8JF+mlEl1O5uO0grcUntnA7D6nFbdUSfiNYNu6yRLneoTkuzutsLDe4pDraOFoCvQ5z/731oO+aH6q6V1nNMK0zXETQkrEeQ2W1KA7kehx9DWJvPXTQ9rua4Sp0iSpCtq3YzBW2k+vzcZ/TNcN0g9YtTa3ntaM0nOhzHo0jyryZ5CIpLKkhRQE9iT/AHu5rSLJPslnsWo7ZqKwOyL28nw4j6lFBiLGQcj6HB+uMURLXUnWLSVit1qnuSZEyHckuKYciNhY+QpCgoEgg/MODVpI656Hjuwm3p748yyh4lLJWGQoZCV7c4VjuBnFRNvVtnwdEaeenIcbYlyZbsZKxjKNrAKh9CQf2rLdU4UWFG0UYkdpgv6ejPO+GgJ8RZW5lSsdyfeglY91e0a1qdmxG6Bcp0oSl1CCpncrskrHY8j6DPfvWMh9dNGSLw5b3HpkVbfib3ZDIS2nYCTyFE87SAMckgVGfqtCjWzW8Jq3x2ozfkYTm1pISNxZQSePUnnNX3S+FFuPWby0+O1JjqXOKm3UBSSQ06RkH2IBoJKWbrVom6w50hu5OR/JtF5xuQ0UKUkED5fRRyQMA55q+snU/R+otO3K5tz0IgQgBLTKbKSgK7ZSc5z2GM57VE3pPb4dwc1d56M1I8vp2bIa8RIVscSE7Vj2IycGsbp23z7ho7U34ehxxMdUaRIQgEktgrBOPYFST+lBIq2dS+j67ygM2uHFeK8JlrtSUpz6HcBkfcgVtmr+smltKXw2q5eeXIDaHAuO0laClYyCDuHoaiZGuOnHbXaor9klSJrSiHvLOhgvZPHzELKj+gx6VmOtUfy+tYUcxXIgRbYSPLOueItrDSfkUrAyR2ziglJbOrmkZ7F8kJnLZiWhaEPyHUYQsqKgnw8ZKs7D6ZrE23r1oadcERfOyo+9W1Lz8cpbJ+4zgfUgVqHxFaGttk6dpe0tZ2ojQmtOTPLpPKAhYSVfQFf86403e9Gv2axQv6Hy5FzYSUSnGZpaMlZIx2Son7YGO3NB0fqLqO5W7rqGRq64sxW5MciOylRQhC0oVsCQdqgQrufeux3Pq9o226nFik3TEsOeE44EHwml+yl9hzx649cVGPqY0WOsrDRYXHKBbk+Cte9TeGGRtKvUjtn1rF2xSdPa2u0HUmmfx6c4tyMmM44ttQeUrhYwCVZ9PfPBoO29Qet1mv8Aoa9xNKyLtDuyGm3G3wnwSkB5sKwpKsjIJH61b9AOoHkdH6hu2t79KejsSWm23Jby3lZKVHagHJycdh7VHezf9TvX/Bj/AOs1WRYt06T08kTIyFrhRLiBI2jISVN/Io/ThQz9frQSysHXLRN6ubUBubIivPLCG1SmShClHsN2SB+uK6PcJsa3QX5k59uPFYQXHHXDhKUjuSagzCmacudwssaPpudLlbEMrZiPiP4rmR2+ValffI/SpVdc7bNuPSG8Rbcy4uQlppZaR8yilC0qUPrwDRWLHX7QhneX85M8Pdt8x5VXh/f+9j9K1Hrr1huNhvFsh6MuDaUrj+YecLKHEOJXgtlJOfTdXBINxsCdPMQ59pffnofKlOMLDSlo9ishX2wEgVv3Wu1qjaD6fyGLTJt0YRn0lp5zxVt7lJUhKl4GSRkgYGO3pRElulOpzq7QdqurilLkraDchSkBG55PCyAOMbs4rba5x8P2oIl/6a25MOO4x+GpRAd3gDe4htBUoY9Du9ea6PRSlKUClKUClKUClKUCrafAh3FgsXCJHlMn/wDbfbC0/saua4L1t6o6itOs4uk9GNoTPWG97pbSta3HPyoSFfKBgjkj19MUG53LqDoPQ9+dsCktW6akoC2osEpTlQBTylOOxFZHX9w0Xp7ZctTQLc/PXwwgxEPSXiOwQMZP37D3qI/UCXfJvUsu6riJiXoLjNyG0kEEpQgBQwSOQAeOOa3nU/VvV2odXzVaXMCHHgFwMKcbY8TwwcE73fVWB8qf54oiTjtrsmpIMKVcLRElteGFspmxEqU2lQBxtWMp7DI+lJeldPTAwJditT4YbDLQdhtq8NA7JTkcJGTwOOajdceruvW+m/mpSHrdcW7gy23PMNKUyGlNukpwtJTkFCTkD/zs2eqfVJ/Rzd+jKCrXBdLUqcphk+KtShgFOBgDKR8o7nk+xXaOoGo+m+mb2zE1XbbebguOh1BVbA8fDyUp+bae2wgD0xW5WvT2nUONXK32S2MvuJ8RL7cRCHMLHPIGeQTn71DLq/q5et7jYrw+ylmSq1pafQj8u9LzwJH0PB/WulXrqjra86oZ0r09bQ2uI0GchttTjqkI+ckufKkAgj9PriiJDRNK6ehF4w7Fao/jNqZd8KG2je2r8yFYHKT6g8VWten7NaFOqtVpt8FTo2uGNGQ2Vj2O0DIqN1l6ta2uVg1LaJL4jajtTKpbchDDe4hpYDza0EFOQCTkAflNYT/bnqn+gnhC7/8ASAXDJkeXaz5fw/y7du383rjNFSdlWrSunEPXl+3Wa2hkFa5nlm2yn/vAZyf51jNPOaR6gsvXhqxRZe1zwRInW5IU6EjhSSpOSnHb/SuBam6q6wY07YLI87GlXW4sImPvyYzR4cWS0gJICBhISokjufTFbN0k6i69ka0Ys+pIyrnbnFeC5JjsIUlg4yFeI0NhHYH/AMqI7vfr9ZbKhpN+ucCAh/cGxLfQ2HMYzjcecZGfvWvM3bp3bFsXBmZpWIuQCtqShbDZcAJSSlQ78gj7iuS/GP8A1Wk/8Ur/APFXBb3d2J2n9OwGkOpdtzDzTqlAbVFby3Bt59lDvjmgnYmy6Yvy27wm2We4rfCXETfLtuleOAQvBzjAwc+lXtyjWxgru82JHU9DbU55hTIU42kAk7TjPbPaog2fqZq6yTrDZLXdyxa0NQ0JY8u0rAWhBUNxSTyVH19azut+pmrkdTLxp5N4Is/nXInl/Ltf1ROCndt3dvXOaDsGh7z0x1jcpNu07Z7W7ISwXXUqtSWwWwpI5JQAeSnit9j2ix2WBJTHt9tt8JwZfDbKGm1DHdeAAePeoU9IZ2qoN5uh0NF8xdXIC0qVhJLLYWhSlgK4J+UDHP5u1bTeNeao6j9MLhb5LZky7fLZffXGRtU8wUrHKB32qCScDtzjjNBIy0XXpzAmKVZ5mlIso8FUVcdC/tlPNbmy62+0lxlaHGljKVJOQoe4Nfn1bGtOOQw1dnbtDnZILzTaHWhzxlBKVD68n7VvkjqRqvRdwt1ksd9RJs8RiMWkMx2yl1Cm0rIBUjcM7j35GcelBLVOl7Amd51NjtYmbt/jiI34m733YzmsjMiR5sdTEyO1IYVwpt1AWk/cHio0R+rHUDS+vIUPXMVpEOctK/K+GgFtpasAoUn29lEnjn3qhO6rdQ9aaluTHT9sNQYYU4lttptSy0k43KLmck+w/nRUkD+DaXtLjhFvtFsaIK1YQw0gkgAnsBkkD9q92W+2m+tOOWW5wrg20QlaoryXQk+xKScVFq+dRb9r/o3fI812M1Itj8dyatKNvmo6l7UgDBwoObCcY4H6HZPhAZuWL6+JDf4QNqFMY+cv8EK7dtuR39e1BJKlKUClKUClKUClKUCuJ9a+klz1VqKJqLS01qNdGkpQ4lxam8lJylaVDOFDt+grtlKCKl16E63k6kbnv3CLcllTTj0mRIVvUoBO4cgkgHIHuAO1ZLU3Q3Vdu1XOuGhrmyzElKWpP/pCmHGgo5KMgcj2OakzSgiL1M0DddFdJ2V6guq506VdWR4SXVLaZSGnuBu7k55OPQVZ6F6Zap1foKKuwXkNWqU+4JcOQ+tDQWhQ2r2gHdkY9O4/aV+p9N2jVEBuFf4Lc2K24HktrJACwCAeCPRR/eqmnbDbNN21NvskRESGlRWGkEkAnueSTQRx1t8P98cVZo+nHIb8eJASy86+74alvF1xaiBg8fOMVktXdEtTsamRftEXNqLJeQFOjx1MracKcL2qA5STk+nepH0oOLdGuj0nS0u53TVMpmZcZzK45bbUVpCFnKypRHKjj/Pvmo43PRMmF1N/oiHW3nlTURgto5G1ZGCfqEkE+3NT3rU4vTzTEXVKtRs20C8lxTxkKdWo71AgnBOOxPpQc66y9GpepJttumk5DEaZEYbjFh1RQnaj8ikqAOCO36D9bbpf0q1hb9YM3zWF+ccQwd4YalrcLygMJ3k4G0e3PbFd6pQce+Ibp7e9et2EWERcwi+XfHd2fn8PGODn8prmt66D6rlWDT0WK1a0yojDyJKvGxuUp5ak87eflIH8qlXSgi3eOgWqHXLNMt0u3olNRmUSErcP8N1sBO5J24UMBJ/ek/ofrR/XD12elQZja5ReVIW7sW7zkq2AYGfapSUoIn6e6E69ti5r8S5xrbJMcobVHlKHi5UkFtRAGAU5PryB96zkXoDfIGii3BusVvUS5jcorQtaEIQhC0hCVgZ3ZcJzgD0+tSUpQRQn9EOo9/lRxfrrEfS18qXpEtTpQknnHy5NaN1R08zZOp34A08tbUdEON4vZSv4LYKvpySanRWqXnp5pS83td3ulmYkXJZSpT6lrBJSAE9jjgAftRHH7H0O1HL1xFuWsb6mfb4LoLSlvLceeQhWUJ+YYSD6jPv96sb70N1daNST5WhLu1HgTNwwJCmHEIUcltWB8wH+lSZpRXDNI9DFW3p1qGz3Ge0bteUNhTrQJbZ8NW9A55PzDk/8q+dDOmmrdC6llLus2KbM40oFmO+pQccyNqtpA7AH967pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpmvmaD7SsJftU2LT+0Xq7wYKlDKUPPJSoj3Ce5rBI6raGX21Nbx91Ef5ig3jNM1p7fUrRjn5dT2r9ZCR/nVy3r3STn5dT2X9ZrY/zNBs+aZrBtar089/VX61L/wAMxs/61eNXe3Pf1VwiL/wvJP8ArQZDNKoJlMK/K82fsoV7DqD2Wk/rQVKV5zTNB6pXzNM0H2lM0oFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJrlHX3qQ5oeyMxLSpP41PB8JRGQygd149+cD9fauqqOKhr8TsxyV1VktLUSiLGZaQM9gU7z/NRoOX3CbKuMx2XPkOyJLqipx11RUpRPqSat6UohSlKBSlKD0lxaPyrUn7HFVUzZSPyyX0/ZwiqFKC/bvN0a/qrlNR/hfUP9au2tV6ia/qr9dkf4Zjg/1rC0oNla17q5rGzVF749DOcI/mqt00V121XYpSE3WR+MwMje3Ix4gHrtWOc/fIrk1KD9DNJait+qrDFu9od8SK+nOD+ZCvVKh6EGsyKi78It7fReb1ZFLJjOMCWhB7JUlQSSPuFD9hUoQaK9Ur4K+0ClKUClKUClKUClKUClKUClKUClKUFus1Cn4iF7+rd5+gZH/wk1NNw1CPr0vf1Z1B9HGx/wDCRQaBSldE6FRYT+s5EickrVBt0iZHQloOqU6hPy7UHhSgCVAe6RRGgyIsiNs8yw6z4idyPEQU7h7jPcVlNRaefscSyyH3m3BdIaZraUZyhJUpIBz6/Ka6fN1JbLxo7Usa4X3UWoUFjxWTMt4xDf3DYvxAs7Ek/KRwOayztujOQbDKittXDUtv0tGet9tdRlC/mWVuYxhakg5CPXGecYoOX6YiaLbtXndU3G6uyitSU263MpSoAdlKcXxg+w5q7nQdBXK1yXbLcrrabiw2pxMa5oS62+QM7UrbGUq+4rIaPkosuhr1rBMGNcL2bgiG2uU0HERQpJWp3Z2yT8oJ4FVb3PTrTppcr/d4cKPebZNZZRLjMpZ80hwKyhQSMFSdu7PtQcwrJX2yTrG7EbuLaW1yorcxoJUFZbcGUnjtx6V0fWV1i6BnxtNW2wWmSyzFZcnPz4odcmLWhK1fMeUpGQBtxjB5rZrtY7VqjqfETMYSxabVpdiaYr7xQNqGklLa19wBvTk+wNBwCldm1Ba7PdNJXd6cjRVvuMNkPwXLLMwXtp+ZpbZUdxKc4PfIqwkaKtdx6gaXFvZTH07doLVxdAcO1ltCSZAKiSRgoV3PGaDlFKurq5GductyAz4ENTqyy1uJ2IydoyeTgYq1oO3fCYn/AKe3Nf8Adtyh+7jf/KpZoNRT+EpP/Sy9L9oQH7rH/KpUoNFVhXqvIr0KBSlKBSlKBSlKBSlKBSlKBSlKBSlKCxdPFQb6zueL1S1Gr2lFP7JA/wBKnG72qCPVRZc6k6mJ9Lg8P2WR/pRGrVdWq4zLTcWJ9tkORpjCt7brZwpJq1pQbRqLXuotQW7yFynJMRSgpbTLDbIcUOxXsA3frVkvVV4XdLVcfOKTMtjTbERxCQktob/KOBz3Pfv61hKUHWtGxtZPMS9Q6X/Cbum5qULlaEJQsfmOPEjnAweSCn3PbmvOvbZre46cXJ1BbbdpyxwP4jNvbSiIhxw4B2NZKlrxk8/XHtXKWnXGlbmlqQr3ScGvTsh55SVPOrcKe29RVj96Dp8jUE+PBZj3Ww2O/S7Sy2w1LkZLrOEghtaUrAc2nIAIP5Tn1r5CumsrnqqXqxm3x5TrDPkZjSloLclKGQlxG3dlZKU7iE5wT9q0pjU89svOrXvlL3FL2AkhShtUs4HzKx2J5B5qnbNTXW2WmTbYkhIhyCVKQtpK9qinaVJJBKSRxkew9hQdBv8AbLiq1u2yw6Fh2o3DaZD4miU4gJT4uNylYZSR83OMgd6pRdQ3my9MpEB7T4cLCZEBq7CQFeXbecHiJ2jPcoUkKyByf1w03qfeHbx52GxEith0PBlDeNyg34aSpadqlEJJAOfU+5qwu2v7xdbBItMpEQR5DhccU22UKUfEU52B2/mUeducYGeBQalSlKDvnwko/wDXeoF+0dpP7qP/ACqUDZqM/wAI6MydSr9kx0/uXP8AlUl2/SirhPavYqmntVQUClKUClKUClKUClKUClKUClKUClKUFg72qHHxD6afsnUCXO8M+SuZ8w0sDjfgBafvnn9RUyXBxWuaw01bNU2hy3XmOHo6uQRwptXopJ9DQQJpXb9RfD5do8harFcosqOSdqZOW3APbgEH78fated6I6xR2YhK/wAMgf6iiOY0robnRzWaO1uZV/hko/1NWznSbWqP/wCFKh/uyGj/AP6oNFpW4OdM9Yt/msMk/wCFSFf5GrZzQGrG/wA2n7j+jJP+VBrFKz69F6mR+aw3Mf8Ahl/8qoL0tf0fmslzH/hV/wDKgw9KyDljuzf9Za5yP8UdY/0q2chymv6yM8j/ABIIoKFK+7Ff3VftW+6A6W6g1bMaJiuwbZkFyW+gpG3/AHAeVH7cfWg678JttcZsF7uK0kIlSG2kE+vhpJJ/df8AKpAN1hNL2SHp6yRLVbG/DixkbUA8k+pJ9yTkn71nECiq6e1exXhPavYoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLZYq2cTV6pNUVJoMe43VstqsmtuqSm/pQYtTNUyz9Kyha+lePB+lBjSz9K+eD9KyXg/Sng/Sgxng/Sng/SskWfpXzwfpQWAZ+lVEs/Sr0NfSvSWvpQWqI6CoKKE598c1eNIr2huqyEUHptNXCBXhCarJFB6FehXwV9oFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJFeCmqmK+YoKJTXgoq5xXnaKC2LdfC2KuttfNlBa+HTw6udlNlBa+HTw6utlNlBa+HX0N1c7KbKCiEV7CaqhNfQKDylNewKYr7ig+ilKUClKUClKUClKUClKUClKUClKUClKUClKUDFfMV9pQfMUxX2lB8xTFfaUHzFMV9pQfMUxX2lB8xTFfaUDFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFct1P1fjWHqTH0gu0PPOvPR2RJD4SkeLtwduPTd7+ldSqHvXa4iz9f8A8TLReEJyHJLYVt37EoVjPpnHeg751a6pw+nTttaft7k96YFq2NuhGxKcDJyD3J/kayfSvXsbqDYX7jFiLhqYfLC2VuBZHAIOQB3z/Koz6z1K91L6s2J6Fa1yEhqOlFvDyQV8eKtG9WB6kZOO1bR8KNzctusr/p6UC0p5rxA0o/lcaUUkffCj/wC7RHSNZ9a4GldeK03LtTzgQtpLkoPhKUBYSc7cegV7181D1tgWfqH/AEVFqdkLElqMqUl8BIUvb/Zx6bvf0rhPVqErUfxAXC2oXtVLmx4iVexKG0VrOpLfc9PamtMu++Km6SEtz30ujC0kuqxn64SD+tBJK29e7S/erxDn2qREj21t1xx8Ohe/YsIACcDlRIA59axDHxMWRUnD9huSI+eHEuIUrH+Hgfzrh0NcZOptZqnRXZcYtvhbbK9q8GS38wODyPzdscVafjzlsEaFpm53CbCWTugT4iC2FE9g3uWlWfcAGglF1F622bRlzbtogyrhOU0h5aG1BCWwoZSCTnnGDgD1rGQ/iAtMzTV1ukezTvFt3hFxhxxICg4vaMKGex9xXJurMyCNdiVdBdbBfm4cRanoSA4grMdBIAKkqSUklGQTnb6c51yHfLzd9Baq/EG0yYyER909TIDu/wAdG1CnAMqyCo/MSRigkN/t5sLOjIl9nQZTT0t5xpmC2tLi1bMZUTwAOR/51Yac+IvT9zujMS5W2ZbEPKCEyFrS4hOTwVYwQPrzUcrrZJ69B2K9NsuOW8KfjLWlJKW1hwq59shX8qur/LXrifpW32C3SVzIlrj21TYQMuOoKsqGPT5hycduaCScTrhAe6hvaVctLzSm5bsMSvHBSpSCoA7cf2ikDv61m+kfU5jqP+K+XtjsDyHhZ3uhzfv3+wGMbP51FeRb5Y6sXpiMsmbBlTZCFD1WwHHB+5RXWfg476t/8J/+agknSlKKUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVaSLZAkul2TBivOnutxpKif1Iq7pQWbNrt7DqXWIMVt1PZaGUpI+xAr01boTMgyGYcZt8kkuJaSFc9+cZq6pQWhtsFUnzBhRjI3bvFLSd2ffOM5r7Jt0GU74kqHGecxjc40lRx9yKuqUFqzbYLLqnGYUZtxQIKktJBIPfJxXlu1W9p5LrcCIh1JyFpZSFA/fFXlKC3lQosvHm4zD+O3iNhWP3ryLdCEYxhDjCOTkteEnaT74xirqlBRZiRmGCwzHZbZPdtCAEn9O1eY0KLFJMWMwyT3LbYTn9quKUFoLbBTIU+mFGD6iSXA0ncc9+cZ5ya9xIMSHv8pFYY343eE2E5x2zirilApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlB//2Q==",
+              "timestamp": 36017023287,
+              "timing": 2250
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAEwQAAEDAwMCBAQEAgcEBgkFAAECAwQABREGEiEHMRMUQVEIImFxFTKBkSOhFjNCUnKxwRdidNEmNDWChOEkJSeSo7KztMM2Q0WDwv/EABUBAQEAAAAAAAAAAAAAAAAAAAAB/8QAFREBAQAAAAAAAAAAAAAAAAAAABH/2gAMAwEAAhEDEQA/AJU0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUr4pQSkqUQEgZJPYVrzWuNKvXDyLWorSuXnaGkykEk+3fv9KDYqUJAGSePetdOuNLJn+SOorSJedvhebRuz7d+/0oNipQEEAg5B9axV51Da7KtCbrK8oheMPOtqDQ+7mNo/U0GVpWhda5X/skv8mG/wAGOlSHWl9wVJ5BFZY6v09ZokCNd75bocpTLf8ADfkJSrlI5IJ4oNnpVONIZlMIfjOtvMuDchxtQUlQ9wR3rC3fWOm7PLEW6322RJOceE9JQlQ+4J4/Wgz1KpRJLEyOiREebfYcGUONqCkqHuCO9VaBSlKBSlKBSlKBSlKBSlKBSlfFq2pJoBUE9yBXwOIPZQrF3K4xLewZFxlMxmchPiPLCE5PYZNWEPUtjmyUR4d4t78hw4Q23IQpSvsAaDZaVQjrJ+U/pVegUpSgUpSg5v1wfeXZ7HaEvLjxLxdWIMtxB2nwVElSc+mcYrY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvr3q81dp2DqqxP2u5pV4LmFJWg4W0scpWk+hBrT3dF6zkwjbJWvFqtqk+GtaLehMlSOxHibu+PXGaDRDfbk/0PhwVTXShy8CyKnpVhS43ilO/P1SNua64jQOlU2P8ACRYrf5LZswWU7u2M7u+765zXt7RNkd0SNKmMRaUtBpKQfmSQchYP97dzn3rWk6J1oiJ+HJ1+7+GhPhhRt6DJ2dseLnvj1xmgw3UGVJ0J0UMfTt4ellt1MNE5SwpbLalkEbh6pHyg9xXRdP6ctlv04i3NtCRHeZCX1vHxFSMjlSyfzE5qnbtG2SFo9OmRES9afDLa23vmLmTkqUf7xPOferVWnrpbLKLPpiemNG2eGiRNWqQ5HT2whPGcem5RxQcVjvux+kXVCwJdW9brNOXHhrUc7W/EHyZ+mP512fROlLND0nEbMWNOVLjockyXkBxUpSkglSie4OeB6CseOmcCP01naSgSXG/OgqfmOJ3rccKgStQ4znGKN6O1HaYnkNL6pbhW0J2tsyoIkKjj1Datw49grOKDVNPy3tIf7UbVZCVQLO15yC1+YMLW0pakD6AjOK2npZpKxs6GtslcOLOlXGOmTLlPtpcW+twblZJHIye1ZrRejoembPKiF1yfJnOKenSpABXJWruVfTHAFa7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNBQ6fMt2DqfqzTdrGyzIZYnNsA5THcXkKSn2B74rqFazojSLGl2Zji5b9wuk5zxpk5/87yvQYHASBwAO1bNQKUpQKUpQKUpQKUpQKUpQK8PjLRr3Q80Gu6jEk20+SE4vbh/1LwfEx//AG/Lj+dYKypu/wCKMeaGovByd3mhB8PsfzeH8/7Vuy2SD8vIryGlk/loPrA/iCrqvDTYQPrXugUpSgUpVnKuDUeW3HVnepJWTg4Sn3/egvKV8SQpIUOx5FY683M27y+1nxS6opxuI/0Pf9KDJUrD/iz6kTlNxUFMYrHzOEbtvf8As0k3d1hpBWwzv8EvrBewNvskkcn9qDMUrGN3ULfS2G8EulvBVyAG9+cfyrza7uJlsemOteChsZPJII2gnuB747elBlaViYl5S/EivKbSguvFlY35DZAUe+Oew/eqf42d9vT4CczBlP8AE/Lzznj27e54oM1SsdcLiYkyOz4aShwgFalEYyQB2B9/XAqiL0nw1LLOQhlx5QSrJGxWMfr/AKUGXpWJN2cS2kFqOXVuBtO2QCgZSVcqxx29vaibq4uVHZQwg+I2HFKDm4DkjggYPb6UGWpWB/H1+VLvlkBYXtKC4flGCcn5fp6Aj61e3O5GHFaebbS4F9zuIAGM54BP8qDI0rEvXV5l2TuYaLLTSXQtLpyoKJA/s8duTmreTflx2lboyFupd8MhtwqSfk3DB29/TsKDPUrEzLutha0IjhakvIZGVHncjdngH7VUjXJbtyMRxpLfy5Ct5O44BOOMevvnjtQZKlKUClKUClKUClKUClKUClKUCvC2kLWhakgqQcpPqK90oFeHWm3ceK2heO24Zr3SgoiJHS44tMdoLcBC1BAyoHvk+tenI7LuzxGm17DlO5IO37e1VKUFPwGvGLvhI8UjBXtGce2aCOyltTYabCFd0hIweMdvsBVSlBTXHZcStK2W1JWcqBSCFH3Pv2r4YzCu7LZ4A5SOw5A/SqtKCm4wy44hbjTa1o5SpSQSn7H0ohhlClqQ0hKl8rISAVff3qpSgoCHGDKmRHZDSjko2DaT9q+qiRlKbUqOyVNgBBKBlOO2Paq1KC38jE8Mt+VY2FW4p8MYJ98e9VHmGX0BD7TbiQcgLSCAf1qpSg8lpslRKE5UNpOO49j+5qmIkcNhsMNBsZwkIGBnvxValBRdix3gQ6w0sKIUQpAOSBgH9q+txmG3PEbZaS5t27kpAOPbPtVWlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArFal1DatM2w3G+zEQ4YWEFxSSr5j2GACaytR1+L697LfYrI2rl1xct0fRI2p/+ZX7UHXtM9RdJ6nuf4fYry1LmFBcDQbWklI7n5kgetbZUGOn7zuh+qunHpaihJMdbhPGG5DSSc/YOfyroOqdZ6+1p1QuemtI3FcFuI8602004Gcho4UpS+5yR2+vaiJTUqM9m171H0tojUMjU8V17wEJRCmSkpOx0uBBBx+YYUSM/3e9azarr1guVnjaott1nSosiQWkIQ4hWVAnP8LGAnII7UVL6lRi6i9TdcSbjYdLW1Bs96ksMiYE7QtT6zgAK5CU9jxzz9KwsfqFrvRt6vWmNU3F2U6YT6QsuBbjDhYUptxDg577eD/KglvSoWaU1zr6ZYtTvxtRyVohw0uurkvKWtCS4lP8AC7gKOe/tV7bOpPUGb05vj7d5CmLfIjByUs4kpDhUAlJA5BKRknn96CY1Khze+purJvTKyS/xuYzObuMmK4+wvw1PIS20pO7bjON5Fe39YdT42jLTqtN3dbtDavKoUXUrU8sKVlTiVZ3ZII59APvQTDpUS9WdYtWapk6ftenJP4U/KZaS8WlBBcfUoj85/Knt6+pzmsJqnW3UC3a7FtvN+kx5bLjDTzUOSQ0flTzhJxkjk/UngUEz6VFhrXvUPX/UGY1o2UmNFt6lPNxCtLaFNoVj+JnlRVxkdufStCjdR9YvvXda9RXVGGVrSgSlYbO9Pbn0yRQTkpULLXrjXzugrzcmtSSTHiy46HHHHVKfyoLwEE9k8c+/FZid1t1X/s5tjDMwJursl5l6dsT4hbQlspxxgH+JycZ4FBLulRU0VqHqnbNWW9tx+bfoLpQt9vPjNltR5wsjgjnkHH3rWtJar6hag1m5Z7LqKa5LfD7baJMpWxICVZPOcEAEj2OKCZM+UiDBky3QotsNqdUE9yEgk4+vFaF066t2HXt6ftlni3JmQzHMlSpTaEpKQpKcDasnOVD0q609Avdr6SPxNVSlSry3DleO8XS4VZLhT8x7/KUj9KiZ0r1TK0c7qO624I86LYWmVLGQlSn2Rux64GT96CdtKhrI1h1Lb0Au/P31xVrnSw2h5MgJfbWnOQkJwUpODkfQHFdv+GW93O/aBmSr1PkzpKbi42l2Q4VqCQ22QMn0yT+9B1ulKUClKUClKUClKUCuDdYej+o9ea0VdY1xtjMFDLbDLby3AtKRknOEEfmKvWu81rurda6e0ihpWobozDU6CW0EFS1AeoSkE4+uKDieufh5mTryxI0tcYzEVLCELE591bniJyMg7VcY24GeMVW1X0DvE+9G9WW+xodxkgOSUErSEvFP8QoWkZ2k5OCB3rqll6oaOvUWa/br006mGwuS8gtrStLaBlSgggE4A9AaxrPWrQTsWRIRfP4TG3eVRXgfmOAACnJ7Ht7URp+kfh+jW/Tt7iXu6mRNuTIZDjCMJYwsLBGeVHclPtwMfWtVR8OGoStMN3U0T8KS5vACXCQfVQb/AC5x9a6l1M6hW2DZIKLfqqDZ356EPh5yMt91LC05C0NpGQo8Y3D39qyXTvVmnn9Jq8tqv8YRbmyqVMmHw3Ep5O5YIBA9Mn270Vo2uugbFzt9nOm7kIdwt0dEbe+DteCTkLJTylWSeQD6e1Y7Tfw/TY/4pP1BeWZ11eiPsxgCsoS6ttSAta1DccZ7Yro/+2HQvkpMtN+aUzHWltzay4VZVnBCduSOO4GK0nqV14gwLFBlaFlRZ0l6QptxMqK6EhCU5JGdvOSn96IxOk+hWoLPYtUQZFxtS3LrCTGZUhbmEqDiVZVlHbA9M19snQvUEDQWprG7cbUqTdHYi2lpU5sSGlKKt3yZ53DGAav3+pF11N0LkX2JeYdnvMWSGZrqGHAhsFZCUp4WckKbORn17emb6Ma2QjpzMumrtUxpzcaWWjKWlaNg2pIQSpKStXOeAe9BxLqnoW4aA0FZbZdZMWQ8/c5MlKoxUUhJaZTg7gOcpNZrQ/RWdrLR1huMe/GJbJKFuPx3Ape1xLq07kJyE8pA7/XvXbI2t+m2vZ8e2uyLXdJKVHwGp0Q/mPfZ4icZOPTvXuy9TOn0SadP2u4RoSoxdT5dERbDTWzcpfO0JHZR+v60Gl9Qfh+jXhm2q0zObgvQ4yIqkSEkpeCc4WSOQrk54OfpWsSPhvvEe8x3bXd7euG0WlEyCtLilAAr4CSAN2cc9sV3nSGu9N6vceb09dGpbrI3Lb2qQsDtnaoAkfWrvVWq7HpSIiTqC4swmnDhG/JUsjvtSMk/oKKiNr+Npq3dRrwu23i5WtKZbiJUdtg7sbvnDS0qwQecBWMfWsP0s0bcNb3e62+07Gh5RRLz5OxHzpwFEA8nB9PSs38RN4tl41tGnWFyI9AlQWng6y0kFaipYJUcbs8AEHtiul6L6hI091KvGmU22z2vTVvEl11yLFUHSlpBVuUQTuOB7Zoila+hWoInT6+WFy42oyp8qO+24lbmxIb3ZB+TOfmGOK+x/h6lPaC/C59ziN3pia7Jjvs7lNFC0NpKF5APdvOR2+tdPgdWtGXC03O5RLspcK2pbVKc8q6PDC1bU8FOTk8cZqyPW3QIipkG9L8FSy2FeTf/ADAAkfk9iKK53pL4fbqjUUO4auvrMuPEUhSWmFOOKcCTkJKlgbU/bP6VkOmHRe+aT6jR9QTp9seiNl4ltlSys70KSO6QP7Q9a6Avq7oZHkfEv7CPOI8Rrc2sYTkjKvl+Tkf2se/aslqvqFpbSimkXy7sR3XUhaG0hTiyk9lbUgnH1oM9eYq51nnRGlJS4+w40kq7AqSQM/vUe9G/DzcIYvEfUNygqjToJjtriFaltueI2tKsKSAR8hzz6127SOttPavQ8dPXNmYpnBcQApC0g+pSoA4+tbFQRdPw0XRMCXtvcJyZ4iRHyFob2f2ivgnd2wBx9a7D0R0RP0DpKTarpIiyH3Zi5IVGKikJKEJx8wBz8proNKBSlKBSlKBSlKBSlKBURviMQiP1piyNQMyHrMpqOrY2cFbI/OlJ987v3qXNc915qzp23cvwXWb0F2YztUGJMRbuzcARghBAyCOxoI3Q39FTL5fF6Vtl/jK/D5io4W+gttp8svduGCrb3/tHuKvvht0hY9X328R9RQRMZYjJcbSXFo2qKsZ+Uj0qVFu0fpy2xJUa32S3xmJTZZfS0wlPioIwUq9xg9q9af0nYNOvOvWO0Q4DrqQhxTDYSVDOcGiIfdSIMSxdYp8e/RHDaWlpS02QtY8uGwlrGFpKgAAPzDt3rEtx7bKsOoHNNRr2XWmwuQslIYEfxU8KSMqHO04Kj27nGam1f9MWPUPhfjlphTy1+QvtBZT9iaqWfT1nssJyJabZDiRnf6xtllKUr9Pm9/1oIHPS7C5otiLHs0lN/afK37j45LamznCdnYen7d6z70FC+g8acmMhTzeoHG1PhA3JQY6Pl3d8Zxx71JN+d0pZvr2knI1nTNkSEpdipi4Qp4cJSVBO3cMkYzwTjvW8wdK2GDZ3rVEtEFq2PqK3IoZHhrUcclPYngfsKCL9qvFsl/DFfbXCYLdxgPMLmueGEhwuSSUHcOVEJSBz2wBXPHWZqumER5tKzb0Xd9LpH5Q4WWdmf0C6m0xobS7Ftl29mw25uFLKVPspYAS6UnKdw9cHkVcQNJafgWqRbIdmgtW6Qre9GSynw1qwBkp7E8D9qEQov67Dc7rp1jp7brjFuHhttvB1e5TknIwpHJxz68DtwKzHT21xbx10/D7ww3Kjuy5vitrHyqIQ6f8AMA1Luy6M01Y5Qk2ix26HJAIDrTCQofY9xXmDorTUC7/ikOxwGLjuUvzCGgF5UCFHP1BP70EX/hRUR1PdAPBt7uR7/Misx8VrLrev7DKuDby7QqKlOEHGdrhLgSewVgp/lUibHozTdhmmZZrJBhSigo8VhoJVtOMjPtwKyN5s9tvcTyt4gxpsfO7w32wsA+/PrQQL1+9p6TqFT2j4EuDaFtJ8NqUSVFXZRGSeMj3PY/apd690ZYmdI6ovEG0R03p+2SSqShJ3qKmlA/vWwzdAaSnFgy9O2x3wGgy3uYT8iBnCR9OT+9bNtTs24G3GMemKKgZpK8Q4WgdcW19axKuDMTwEhBIOx8KVkjgcEd6wDv8A+mY3/GO//I3U8E6F0qlmY0jT9sQ3LAS+lMdIDgCgoA4HbIB/QVpGqEdItMXBmz3yBZo0hRDgZ8qVBG7A3KwCE5wO/tREaNdW2HC0roiRFjttPS7e44+tI5cUHlgE/XHFfL7tjaxtkjVDLr0J2BDdwpKlb2zGQEkAKSSAfZQ7Gpd3KwdPnUQ4VyiafIithEdl5TYLaFHcAkE8A5z+tZq56Q09dIUSJcbLAkxoiA3HQ6yFBpIAASn2GAOPpQR3+G5Nid6iSHLJHvPjJZdKnFFCY6WiRgKT8yhzjAKjyO5xUpaxlisFpsEdbFktsSA0s5UmO0Ebj9cd6ydFKUpQKUpQKUpQKUpQKUpQKhf8SKijrLcFAbiluOcD1/hpqaFRk629LdYan6lTLrZLWH4DqGUoe8y0jlKEg8KUDwR7UFa39btWwNbptmq7Q1CjTFgNMrZKHWEr4bVk/mGcZyPft2q36b9YtXX46nFxkxVeQsUqextjpTh1vbtJ9xyeKubT0f1nfOobN01zPafiQlpCZPiJUqQhHKAlI7DPJzjue9YOw9GNf2KffW4AhpjybdJiF4OoV5hChw2kEgpKiEjJwBzzRFXTvXnVadP3ydcG4055gstRwGQhDSlleVr28kfLjHuRVOxdZOp9xQqZAt8a5RkKwtDUMqx+iTuFU9JdJuo9ptN1REiMQJTq2VBL0hlxEhtIc3IIBUk8qScKGOPpVo10Z6iXO/tSXoFvs60EYksOtMoSR/aCWec/YCg8aru4j/ECwtu2W9t5U6GoqLRyFOJbUokZxuyo8kZrI6S626+ubl1ShqJcFR7e9JCfCQ2GgjBLh/vADPy+pIrK6r6Waxm9Y273Ht/mramXEcVLMhpJWltLYWraVbu6VcYqx6ZdJ9aWSTqJdzs4ZTLscuGyfNMq3OrSAlPCzjPueKDP6A673GVpXUs3UUSO/KtbKHmSwPDDpWsICVDnHzFPI9M1qh66dQ0st3dUKCLW66UIHlT4aiO6QrO4/vWS6c9FtS/heqLbqOGm2ouEJDcd4vNujxUuJWnIQonGU1h7b0o6q28ptsBtuHES9vEpmU0jn+9vSfFx9P5UGz9Q+vV8hR7OmxW1uCuXDTKdXLbKlBRKklKQcDAKTye/0q40f1W6goddf1HY0ybWmG/ID7UZSNxQ2paQFpJTyRjtXrXHTvqKfIs2+RF1HFbiIbd/ES08rxuStQ8YcAk8EHOAKw3Tno/1As8i4zvMtWZ5yI822yiSCXHFJIRnZlIAJBzn07UGNt3W/qNfLg6LNFhPFPzeWZjbiB9Mncf0qRGiL9drx09Yu16hiDdS06XWPDUgJUkqA+VXIzgH9ajdeekXUm8SGW5lmtSVJVzLYMZnd9VFGFK/YmpJ9P8AT1wsnT+DZL1N83NbZW248FFQAUTgAnkhIIH6UHDem/WLV19OqPxGTFX5CxSp7G2OlOHW9u0n3HJ4rX2Ouut12CbLVLh+M1JYaSfKpxtWl0nj/uJq9sPRjqBYp99bgiGmPJt0mIXg4hXmEKHDaQSCkqISMnAHPNYWP0W18jT06KqxgPuymHEJ84xylKXgo5347rT+9BnJfXDXkXStnuSo8ENyHnkGUttJD5QR8oQCNoAUOfXP0rX+surW77dNNXv8Jt/jTbS3Id3oJ/iB11BB5GU/JxnPFbHe+k2tJPTHTNoYs4VcIcuW6+15pkbEr2bTnfg5wexrH6p6O65nW3TLUWyhbkO2eXfHm2Bsc8w+vHK+flWk5HHNBpvVdd2d6ly3Ln4HnVqZUz4QASGyhJaGB/ubc1OCxicLLAF3LZuXl2/NFv8AL4u0b8fTdmo7dXuj2p7xqCLe9PNMyXFxWEPMKeQhbbjaEp4KiEkfKPX3rvmim7w1pW2o1KsOXkNDzSgUkFeT/d49u1FZqlKUClKUClKUClKUClKUClKUCrW43CFbI5fuMuPEYBx4j7gbT+5NXVRM+JB5c3rBAt9+lvRbGhpgJcSnIbbUf4iwPU5z79hQbZ1M6z6h051HesloRa3raDHLbjjSlqUHEIUTuCwD+Y44rtkLV2m50oxoV/tMiSApRaamNrXhIJUcA54AJPtioOajYtUXXYj6euT1ztTTzKGJLwIUpICeOw4ByBwOBWZ6VzI1s6kvvXB9uM0licgrdUEgKLLgAyfUniiJho1xpNxDim9TWRSW07lkT2iEjIGT83AyQPuRVZnV+m3m2Vs6gtDiHnfAaUmY2Qtzj5EnPKvmTwOeR71Ayyf9l6h/4JH/ANyzXZfh76b23VlhF8nzZ7ci23QlhlpaQ3lKWl5IIPJOAcHsBQScdvFsZuKIDtxhonLGUx1PJDihjPCc5PFaJ1I6m2206Iuly0pebLcbpFDSkMokIe+VTqEKJShWcYV398VFKxSLVO1Hd5+s7tdIM4Bx9l6Ijc4ZO7OCe45+33FYiw/9lak/4BH/AN1HoJZdF+p7uqNNzbjq6VaretuYIzJCvASv5ArHzqOTye1XHXLWeoNK2u1yNLm17JS1hx6W82nsAUhAUoA5yckZ7VFO0RLDI0VeHrleJDF4juJVAgJSS27uwFqPHfA9x2Hetg1BJmSOhulxMWtbbV0ktxys5/hhCeB9AoqoN71N141faXbc0hmwrW9EQ86WwXk7ypQOFJcx6ducHI9K2y39TtVJ6rO2i7L07HsjclxpwKmNJU22nPzZ8TO7jkY/QVGe8/8AU7F/wZ/+u7W9ORGLh8RkmHLR4kaRfnWXUZI3JU4oEZHI4J7UHadH9eo2oddxtPu2hmHHfecZROVPCkkgK2YGwA7iAAM91DvW19R9T3SDPj2qx3LT1qW6ne7Ouk1CS3z+VDROVE98nior6BFmtXV2Ob0UsWyFLeUkrUrCFthZa7cnCwj7+tYm3IhXu5XmRqm5OR5qkrdQ46tXzO5Od2EKJ+3H3FBPmA+mTCZeQ+zIC0A+KycoWfUp5PH61rl06g6YtWp2dPT7q0zdnSkJZKFEAq/KCoDAJyOCfUVzz4W0xmNOXaPBva7nHQ8hfhmMtpMdSgcgFX5s4Hbtj61caxidMHOrcNy/SVo1PvZPhAr8JTnHh+JgYzjb6jjGaK7LWGXqvTzczyjl9tSZWceCZbYXn225zWv9b5kyD0q1FItylokBgJ3I7hKlpSsj/ulVREsdn0hL0g5Lu2o5EG++a2JjJjF1PhYHzcdz35z6dqCdsybFgxVSZslmPHSMl11YQkfqeKtrTe7VeErVaLnCnBH5jGfS7t++0moadRpq3bboq1Kvcmdp5uJlEpTKm8/x1pUdhOSUpSkD6D61X08Lfp3rXYWun12k3KC5IYbLqklJWFkBxB4GRjPOOP0zQS5g6u03PkmPB1BaJMgJUotMzG1qwkZJwDnAAyauYd/s86G9LhXWBIisp3OvNSELQge6lA4A+9Qf6b2hi+awlwpbj6GTDmOHwV7CSlpagCfbIGR6186cWtN1iavQ5JksojWN+XtZc2h1Ta2ylKx6pyc4oibb2qLAxb0T3r5a24K1+GiQuW2G1LxnaFZwTgE4r5/SrT/lY8n8dtflpKill3zbex0g4ISc4JB74qCEV5w6DubBWfCTcoiwnPAJakAn+QrJ6ks7EXpvo66pdfXImrmtrStzKEJbcTtCB6fmUT7k0E5ZV6tcN6OzLuUJh2SMsocfSlTo90gnnuO1fbrebZZ2kuXa4w4LavyqkvpbB+xURUGdd24QrHo2WJMl52ZbPEUHnNwbw6tISj+6nA7Vc6jmr1BrqF/S2Y+iMYkZJcUsp2oLCFAg7VYBJyTtPcmgmynUNlVbHbkm72829rHiShJR4SMnAyvOByR6+tW7OrtNvxHZbOoLQ5FaUlDjyZjZQhSvygqzgE4OB9KhpAj26DpzVrdr1GqR4kYJVCRHc2rQH28LLhCRkcc7R39M1jrTaGJPTC/3Rxb3jw50VttAWQjCwvJKfU8Dmgll1W6oQtCWa3zozMa7OTXdqGUSw2S3tJ8QYCspyAO2Oe9ZjpfrVjXmlWbu0y1FeK1odipfDqmSFEDccDGQAeQODURJkRqR0Ot9xdSpcuLfXYTThUfkZUyHCnGcfm57V3/4VXLN/QBbNvcQbsHS5cEBSiUkqWGyQeBlKfT2oO00pSilatrjQOntbNsJ1BC8ZxjPhvIWULSD3GR6fQ1tNc26p9XbP0/lMwXoz0+5uN+L4DSgkISTgFSj2zg8YNBRl9DdEPz2pYhSGFNJbCUMvlKBsAAOPfjJPqcmr5/pDoqRqF28qtYMt1S3FpDhLZWrOVbO2cnP3rQx1us+tdKamtDkF+2XB20yyylaw4hwhlZICgBg4BPI9K5b0J1gzodrVF6kMeaLcZlCGA5sLilOgYBwfTJ7elEd6jdB9FR2ZTTbE/ZJbDTmZJ/KFpXxx7oFbloXRtp0RanrdYkPIjOvGQoOubzuKUp7/ZIrnts68WxzRj2obva3oSPMmLFjNvB5yQoJClEfKkADI5NWekviJsl5vLMC52uRa0vrDbb5dDqAScDdwCkfXmit3l9J9GytSi+u2hHnisuqSFHwlrP9oo7Z9fvzWEi9CdEx2ZbLTU7bKaDLgMoklIWlfHHuhNWmruvWndPanVZ0xZU3wHfClSGiAho5+bHqoj17dq4P0ZukSJ1pYukl8NwGzNkLdVnAQGXTn9qIkQ30L0Mm3piKt77iEveMFqfVvzgAp3DB28Dis5qbplpnUVjttolw1s2+3EmO1GcLYTkYP3rmcv4mbQ3PU3FsE16GDgPKeShRHvswf86zur+ucKy2Ox3i2Wdy5226Ic2uGQGVNOIICm1J2q5596KvpHQbRT7cZDjE/bHb8JGJJ/LuUr291Gsq30j0sjWH9JktS/xTzZm7vHOzxCrd+X2z6VqGp+v0SzqsyIdicnruMFqWUplBBaUskeH+Q5Ix34rqepNSxNM6Vevl9BjsstpU42g71bzgBCe2Tk49P0oNYvvRzRl7vi7tLtq0S3HPFd8F5SEuK9ykHGT9MVS1J0W0XqC7PXGXb3WZLytzvlni2lavVRT2yfpWkL+Je0mBIdbsUrzKHUpaYW+E+Ig5yrcEnBHHH1710zpRrlPUDTTt3RAMANyVR/CL3iZ2pSc5wP73bHpQZvSumrTpW0ottihoixUncUgklSj3Uonkn71hLz0z0xedXMalnwVLubSkL3BwhC1IxtKk+pGB+wrnepPiPs9su78O22aTcGmVlsvl4NJUQcEpGCSPvisF1C60vaj6cOyNMQ7rbZAlIaflNulPl+yh8yO4VyOcfrQSPlxmZkV2NKaQ9HdSUONrGUqSRggj2rmS+g2glSy/+GSEpJz4IlL2fbvn+dcz6VdW7tY+nV8uN9jXC9+VnNhEmTKV83iJA8MKUlWNu3dj/f8AT12Wz/EXDucm1xUafdRKmTBGUjzWQ0klASvOznJUrjj8vfmg6bqPp3pfUFiiWi4WtoQ4adsYM5bUwP8AdI/n7+tWWi+lek9Hz/PWi3qM0ApS++4XFIB77c8D7gZrStG9emtSu3dCdPLjfh9tfuJJmBe/wgDs/IMZz39PavulfiBtd2hXeZdLS7bY1vZS7lMgPKdUpQSEJG1PPPvQbPp/o3pOw3Rdwt7MwSVtOskrkFQ2uJKVcfYmvlh6NaSsSLmmAzMAuMNcF/fIKstLIKsccH5RzWixfiZtC5wRJ0/NaiFWPGS8lagPfZgf51pfXzqLfDrdpOnrndbbbBCZUytiQ42iUlY3+KAMf3tnryg/YEdhR0I0Ui3vwksT/AedbeUPMnO5AWE849nFVez+jWkp1gtVmfZmGFbVPKjgSCFAukFWTjnkCtUu3Wx7SukdJyblp6S/KuURS1pelFtaS2rZuOUEnd+bP19e9VdY9eW9NGybtPLk/idrYuQxMCPDDm75PyHONvfj7UVst36M6Su0K1xJjMws21gxo+2QQQjcVc8cnJNXOoukekdQRbczcILm+DHRFaeadKHC2hISkKI/NgD1rRJHxGQomopdtmafdbZjPOtKfTK3E7N2MJ2epAHf1q4uHXW0SenirhNiT4Eyc49FYjw30qeTtSnLgWUgJ/MOcHn3oNutnSfRUSw3WyQYh8OZsbmOB8qewlSVpSVf2eQk44qnF6M6SjadnWVpmZ5GY82+6DIJUVIztwccfmNc66LdT9HRLwLRGs021yrm6lK5kiUZJfd7J8RRwQST6DGTUjaDR7b0t0rB0lJ00IS5FqkPmSpD7pUoOYSNyVDBHCR2+vvV5oPp/YdCiaNPsPNmYUF4uulZO3dtAz2xuP71tlKBSlKBUWfiP03ebd1Fj6riwXZluWlk7kI3pbWjjarg4zgEE+9SmpQQ50yi76iXqW5NaQhMxBbpbjs55p1TjZ8BYAQtSsFZOOw9TXP7VpadcLJeZyGH0qtyGnCgtn50qXsOPqMg/vX6DUokQabs141F0zitW+3yHXLDLeU8020d5afCSF4xlWFNqBx2BHpV7JY1B1TvdigwdNtQPKMoirfjx1IQEgjK3FHgY9B+3epsUoIfOWjUnTvq1PWxpz8a86463EL7KltupcVkKCuwV6H9fvWo6G01dLzrV+1oiqjypDExtIKClAX4DmE57AZ4qd9KCB8Fy8WKDN05M0y5IkOSEqLT7TmQoY42pwVduOcc8V2TWGjp8v4d21zbJEtdzhP+fTDhNKTsQTtO4Ek7ik7jz6D2qRlKKhH0Q01L1B1MsrU5h/ykI+ZWXEnAS38yU8+hUQP1qS/X3T0/UvTWdDtDSn5jbjb6WU/mcCTyB7nBJx9K6LSgglMVqd3p8m0P2Btm126WCqSYZRI8Ve47Co8n19PQZ9KkP8KTLjPTWWl5tbavxJ04Wkg48NuuzUoINakXKhXmVKa0tc7JfQ8opdjLWhnJPJ8JSCcEZ4Csc9sV0K32PV+oeh2pG59j8OcuSw+xsiJYflIScqJSkDdgdjjJ578VI/VN6a07p6fd5DLz7UNouqbZTuWrHoBWodJup8XqILgI1skwVw9u4uKC0qCs4woevHaiIu22ddmul180w7Z5CGEy0Ty+ppYUHMto8PGMdgT78V3L4Wbak9OLl5mIkP8A4k7sLrfzD+E1jGR713OlFQd0dbtQ6XvOpYbmn5rz7lomw3QpBQGkFHLmSMEDbx75GO9WGj9JXe/2DUTFuhyHJMdtmSGQg7nQlRBCR6nCs4+lTxrR9N9VNJaj1A3ZbRcHXriveEtmO4gHaCVckY7A0RF+23y+vWS0aZa0JCmvwHFEF+3uKccKifzAEe/J+g9q2b4htJX3Zpe5C0BDDNpaiSG4LRLUZ1KlKKcDOE/Pgc+ldb0l1ogak16dMs2aewsrcQl9zHBQCTuT3SOPf2rq9BD3qk3ftWaB0ZezZZLbcVl2E4lptStgSUhKiMZAUEk57VqnUY3e5DS5mWaVD8vY40ZoKBUXUIKwHMY+XPPB9MH1qdtKKhjoWA8v4gmC/EcUwbs+SVtnaRlfuMVv/wAUujbjIk2m+2eCp+FGZLL7bDefDO7cFFI9Dkgn6DNSPpQRB6fv3jVfUC2vx9HQnQhbQflS2nVhlKTkr3bgkHHYY9sCpfUpQKUpQKUpQKjT8Rt31yxqrwbM/cWLEyyghdvUoALIyrxCjkH2B9MEVJauQdRejkjVOrn9QWvUsm0yn20IWlDZP5UhIwUqSewoOT9PtVajsi7ldkaubv0OHAedXEXKdUoL24QSh1IJAURkpz96wTNx6g3vS911sNVyERoMgNuNCattRUSPytp+XHzDjj1rtGgugNt0/NkS71c3Lq48w7HLYa8JG1xJSonkknBPrx3rXJPwyIM5fldTLbglWUtri7lgexIUAT9cURyvWXUvU17j2OSq7T4shuGWXzFfWyl5SXV4WUpIGSCAftWT1PrDWeltX2p57UkuSoxIknw0rUGihTaTsUgkg8cEnk966tq34eI1zTaWbLd0wI0GJ5ch2P4q3V71LU4SFDk7u2PSvWtugr+pbrDmI1A1HEeFHibDEKtxaQE7s7x3x2oN763armaO6fTLla8CctaGGXCMhsqP5seuADj64qM79w6gWzSdu1wrVclUaXJLSGvOrWsKBV+Zs/Lj5Txz6cVLvWWm4GrdOS7NdUqMaQkDcg4UhQOQpP1BFcKjfDIkTE+Z1MtcIKzsRF2rI9slRAP1xQc+6r6/v9zm6fuMa6T4Bl2hlx1mLJW0gub3EqUEg+pT/lW/ald170z01etQXe+tT5N3cbjRg2644iIpW5ZUlCxtHypwMfSth6hdBW9S3OA7ars1bIUKC3Cajqjlw4QVHO7cO+6tw63tWxvpZche4r0qG0GshhQS4k70pC0k5GRnOD37etBG+7TtfW3pxDv8rVDzttvEkBCUzlmQ2tO/9gcHIB9siref1F1QjRmnbPFvc1lcjxX35SpCvEXl5SEguE5CRtPr6/StNuosLUAt2l+5SpKnQpK5LKWUtIwcjCVq3KJ288Yx6547xpXoqjV3SnT67hIetV2b8VxtZb3ZaWsqSFJyD9Rz60HMeoN/1jZbtFt03V65i48RCUv2y4LUhSSVEbyCMrGcEkZwBWTsd91XcOsSrXb9ST2Fu3F9lrxn1utNjK8fwyrBwOw7dq6BcfhmbcTEFv1CGShgJfLsYr8R3colQwobRgpGPp35rP6d6Gv2jqO1qhV+adQiY5K8uIpBO4q+Xdu/3u+KDj/T/XWpxK1LbZl7nymnbRPILr6lFtxDK1pWgk5Scp9PerfQepNaL01qRNhuNwkzCY6SC8pxxKCXCotgkndwM45xk+ldXsPw+SLXc58s6iadEqJKjBIiEbfGaWjOd/ON2ceuKoW74cVsWqbEf1N87zrTzbjUXbsUgLHOV8g7z2x2oOS2e76vXJCXdbyrbc/E2iJcJchpRPpypOwfqRW0am1drDU/VRyyQtSCyphulhsuyvAYCmh8ylEfmKlJJ5z3A7VuLfw4PS7g27fdXSZrKAE4DB8TaP7IUpZwO/pWZ1v8Ptr1BqEXKBdHbc25s8djwg4FYABKTkYJA9c880HGtL3zVF+6pJtMzU89Kpsp+OtyLLWplKlBY3NpCgNoJynGOw7VZdEbY9N6xWeM3OdjrYkreU6jOXA2CpSDyOFBJSfoT3rtmlegY05r2Jfol7SqFFlKeaiKjncEc7Ule7kgEc49Ko3H4d46tWG62q+rhxTI8x5dTG8o+bJSFBQ4+47UHMrfrC72nrXeZK7hOfjQ5Vxd8suQstqS2h5SUlOcY+UcVaxLp1A1bZr9qxvVLzDFrIW8yJime/OEIT8uPvjP1NdltfQzy3UeRqWZeGpMR+TJechGMRuQ8Fgo3bvZffHpWv3D4Zml3B1Vu1ItiAtWUtOxt60j23BQB++KDn2rOpOo730705Icuk2PPjy5UV5+M8povpShlSSraRkjeR/P1qz1FqbWdpsekrgdU3AplxFuMoQ6oFAS6ofOc/OSfU+nHpXbNUdBIlw0rYrJZrr5JFuW86688x4ipDjgQCo4Ix+QD7Y9qtdSdBH7xYdN25OoGmjaIzkcuGIVeLucK8438d8etB2HR9wdu+krJcpGPGmQmZC8DA3LbCj/ADNZesZpe2GyaatNqU6HlQYjUYuBO3fsQE5x6Zx2rJ0UpSlApSlApSlArUdddRdN6I8JF+mlEl1O5uO0grcUntnA7D6nFbdUSfiNYNu6yRLneoTkuzutsLDe4pDraOFoCvQ5z/731oO+aH6q6V1nNMK0zXETQkrEeQ2W1KA7kehx9DWJvPXTQ9rua4Sp0iSpCtq3YzBW2k+vzcZ/TNcN0g9YtTa3ntaM0nOhzHo0jyryZ5CIpLKkhRQE9iT/AHu5rSLJPslnsWo7ZqKwOyL28nw4j6lFBiLGQcj6HB+uMURLXUnWLSVit1qnuSZEyHckuKYciNhY+QpCgoEgg/MODVpI656Hjuwm3p748yyh4lLJWGQoZCV7c4VjuBnFRNvVtnwdEaeenIcbYlyZbsZKxjKNrAKh9CQf2rLdU4UWFG0UYkdpgv6ejPO+GgJ8RZW5lSsdyfeglY91e0a1qdmxG6Bcp0oSl1CCpncrskrHY8j6DPfvWMh9dNGSLw5b3HpkVbfib3ZDIS2nYCTyFE87SAMckgVGfqtCjWzW8Jq3x2ozfkYTm1pISNxZQSePUnnNX3S+FFuPWby0+O1JjqXOKm3UBSSQ06RkH2IBoJKWbrVom6w50hu5OR/JtF5xuQ0UKUkED5fRRyQMA55q+snU/R+otO3K5tz0IgQgBLTKbKSgK7ZSc5z2GM57VE3pPb4dwc1d56M1I8vp2bIa8RIVscSE7Vj2IycGsbp23z7ho7U34ehxxMdUaRIQgEktgrBOPYFST+lBIq2dS+j67ygM2uHFeK8JlrtSUpz6HcBkfcgVtmr+smltKXw2q5eeXIDaHAuO0laClYyCDuHoaiZGuOnHbXaor9klSJrSiHvLOhgvZPHzELKj+gx6VmOtUfy+tYUcxXIgRbYSPLOueItrDSfkUrAyR2ziglJbOrmkZ7F8kJnLZiWhaEPyHUYQsqKgnw8ZKs7D6ZrE23r1oadcERfOyo+9W1Lz8cpbJ+4zgfUgVqHxFaGttk6dpe0tZ2ojQmtOTPLpPKAhYSVfQFf86403e9Gv2axQv6Hy5FzYSUSnGZpaMlZIx2Son7YGO3NB0fqLqO5W7rqGRq64sxW5MciOylRQhC0oVsCQdqgQrufeux3Pq9o226nFik3TEsOeE44EHwml+yl9hzx649cVGPqY0WOsrDRYXHKBbk+Cte9TeGGRtKvUjtn1rF2xSdPa2u0HUmmfx6c4tyMmM44ttQeUrhYwCVZ9PfPBoO29Qet1mv8Aoa9xNKyLtDuyGm3G3wnwSkB5sKwpKsjIJH61b9AOoHkdH6hu2t79KejsSWm23Jby3lZKVHagHJycdh7VHezf9TvX/Bj/AOs1WRYt06T08kTIyFrhRLiBI2jISVN/Io/ThQz9frQSysHXLRN6ubUBubIivPLCG1SmShClHsN2SB+uK6PcJsa3QX5k59uPFYQXHHXDhKUjuSagzCmacudwssaPpudLlbEMrZiPiP4rmR2+ValffI/SpVdc7bNuPSG8Rbcy4uQlppZaR8yilC0qUPrwDRWLHX7QhneX85M8Pdt8x5VXh/f+9j9K1Hrr1huNhvFsh6MuDaUrj+YecLKHEOJXgtlJOfTdXBINxsCdPMQ59pffnofKlOMLDSlo9ishX2wEgVv3Wu1qjaD6fyGLTJt0YRn0lp5zxVt7lJUhKl4GSRkgYGO3pRElulOpzq7QdqurilLkraDchSkBG55PCyAOMbs4rba5x8P2oIl/6a25MOO4x+GpRAd3gDe4htBUoY9Du9ea6PRSlKUClKUClKUClKUCrafAh3FgsXCJHlMn/wDbfbC0/saua4L1t6o6itOs4uk9GNoTPWG97pbSta3HPyoSFfKBgjkj19MUG53LqDoPQ9+dsCktW6akoC2osEpTlQBTylOOxFZHX9w0Xp7ZctTQLc/PXwwgxEPSXiOwQMZP37D3qI/UCXfJvUsu6riJiXoLjNyG0kEEpQgBQwSOQAeOOa3nU/VvV2odXzVaXMCHHgFwMKcbY8TwwcE73fVWB8qf54oiTjtrsmpIMKVcLRElteGFspmxEqU2lQBxtWMp7DI+lJeldPTAwJditT4YbDLQdhtq8NA7JTkcJGTwOOajdceruvW+m/mpSHrdcW7gy23PMNKUyGlNukpwtJTkFCTkD/zs2eqfVJ/Rzd+jKCrXBdLUqcphk+KtShgFOBgDKR8o7nk+xXaOoGo+m+mb2zE1XbbebguOh1BVbA8fDyUp+bae2wgD0xW5WvT2nUONXK32S2MvuJ8RL7cRCHMLHPIGeQTn71DLq/q5et7jYrw+ylmSq1pafQj8u9LzwJH0PB/WulXrqjra86oZ0r09bQ2uI0GchttTjqkI+ckufKkAgj9PriiJDRNK6ehF4w7Fao/jNqZd8KG2je2r8yFYHKT6g8VWten7NaFOqtVpt8FTo2uGNGQ2Vj2O0DIqN1l6ta2uVg1LaJL4jajtTKpbchDDe4hpYDza0EFOQCTkAflNYT/bnqn+gnhC7/8ASAXDJkeXaz5fw/y7du383rjNFSdlWrSunEPXl+3Wa2hkFa5nlm2yn/vAZyf51jNPOaR6gsvXhqxRZe1zwRInW5IU6EjhSSpOSnHb/SuBam6q6wY07YLI87GlXW4sImPvyYzR4cWS0gJICBhISokjufTFbN0k6i69ka0Ys+pIyrnbnFeC5JjsIUlg4yFeI0NhHYH/AMqI7vfr9ZbKhpN+ucCAh/cGxLfQ2HMYzjcecZGfvWvM3bp3bFsXBmZpWIuQCtqShbDZcAJSSlQ78gj7iuS/GP8A1Wk/8Ur/APFXBb3d2J2n9OwGkOpdtzDzTqlAbVFby3Bt59lDvjmgnYmy6Yvy27wm2We4rfCXETfLtuleOAQvBzjAwc+lXtyjWxgru82JHU9DbU55hTIU42kAk7TjPbPaog2fqZq6yTrDZLXdyxa0NQ0JY8u0rAWhBUNxSTyVH19azut+pmrkdTLxp5N4Is/nXInl/Ltf1ROCndt3dvXOaDsGh7z0x1jcpNu07Z7W7ISwXXUqtSWwWwpI5JQAeSnit9j2ix2WBJTHt9tt8JwZfDbKGm1DHdeAAePeoU9IZ2qoN5uh0NF8xdXIC0qVhJLLYWhSlgK4J+UDHP5u1bTeNeao6j9MLhb5LZky7fLZffXGRtU8wUrHKB32qCScDtzjjNBIy0XXpzAmKVZ5mlIso8FUVcdC/tlPNbmy62+0lxlaHGljKVJOQoe4Nfn1bGtOOQw1dnbtDnZILzTaHWhzxlBKVD68n7VvkjqRqvRdwt1ksd9RJs8RiMWkMx2yl1Cm0rIBUjcM7j35GcelBLVOl7Amd51NjtYmbt/jiI34m733YzmsjMiR5sdTEyO1IYVwpt1AWk/cHio0R+rHUDS+vIUPXMVpEOctK/K+GgFtpasAoUn29lEnjn3qhO6rdQ9aaluTHT9sNQYYU4lttptSy0k43KLmck+w/nRUkD+DaXtLjhFvtFsaIK1YQw0gkgAnsBkkD9q92W+2m+tOOWW5wrg20QlaoryXQk+xKScVFq+dRb9r/o3fI812M1Itj8dyatKNvmo6l7UgDBwoObCcY4H6HZPhAZuWL6+JDf4QNqFMY+cv8EK7dtuR39e1BJKlKUClKUClKUClKUCuJ9a+klz1VqKJqLS01qNdGkpQ4lxam8lJylaVDOFDt+grtlKCKl16E63k6kbnv3CLcllTTj0mRIVvUoBO4cgkgHIHuAO1ZLU3Q3Vdu1XOuGhrmyzElKWpP/pCmHGgo5KMgcj2OakzSgiL1M0DddFdJ2V6guq506VdWR4SXVLaZSGnuBu7k55OPQVZ6F6Zap1foKKuwXkNWqU+4JcOQ+tDQWhQ2r2gHdkY9O4/aV+p9N2jVEBuFf4Lc2K24HktrJACwCAeCPRR/eqmnbDbNN21NvskRESGlRWGkEkAnueSTQRx1t8P98cVZo+nHIb8eJASy86+74alvF1xaiBg8fOMVktXdEtTsamRftEXNqLJeQFOjx1MracKcL2qA5STk+nepH0oOLdGuj0nS0u53TVMpmZcZzK45bbUVpCFnKypRHKjj/Pvmo43PRMmF1N/oiHW3nlTURgto5G1ZGCfqEkE+3NT3rU4vTzTEXVKtRs20C8lxTxkKdWo71AgnBOOxPpQc66y9GpepJttumk5DEaZEYbjFh1RQnaj8ikqAOCO36D9bbpf0q1hb9YM3zWF+ccQwd4YalrcLygMJ3k4G0e3PbFd6pQce+Ibp7e9et2EWERcwi+XfHd2fn8PGODn8prmt66D6rlWDT0WK1a0yojDyJKvGxuUp5ak87eflIH8qlXSgi3eOgWqHXLNMt0u3olNRmUSErcP8N1sBO5J24UMBJ/ek/ofrR/XD12elQZja5ReVIW7sW7zkq2AYGfapSUoIn6e6E69ti5r8S5xrbJMcobVHlKHi5UkFtRAGAU5PryB96zkXoDfIGii3BusVvUS5jcorQtaEIQhC0hCVgZ3ZcJzgD0+tSUpQRQn9EOo9/lRxfrrEfS18qXpEtTpQknnHy5NaN1R08zZOp34A08tbUdEON4vZSv4LYKvpySanRWqXnp5pS83td3ulmYkXJZSpT6lrBJSAE9jjgAftRHH7H0O1HL1xFuWsb6mfb4LoLSlvLceeQhWUJ+YYSD6jPv96sb70N1daNST5WhLu1HgTNwwJCmHEIUcltWB8wH+lSZpRXDNI9DFW3p1qGz3Ge0bteUNhTrQJbZ8NW9A55PzDk/8q+dDOmmrdC6llLus2KbM40oFmO+pQccyNqtpA7AH967pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpmvmaD7SsJftU2LT+0Xq7wYKlDKUPPJSoj3Ce5rBI6raGX21Nbx91Ef5ig3jNM1p7fUrRjn5dT2r9ZCR/nVy3r3STn5dT2X9ZrY/zNBs+aZrBtar089/VX61L/wAMxs/61eNXe3Pf1VwiL/wvJP8ArQZDNKoJlMK/K82fsoV7DqD2Wk/rQVKV5zTNB6pXzNM0H2lM0oFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJrlHX3qQ5oeyMxLSpP41PB8JRGQygd149+cD9fauqqOKhr8TsxyV1VktLUSiLGZaQM9gU7z/NRoOX3CbKuMx2XPkOyJLqipx11RUpRPqSat6UohSlKBSlKD0lxaPyrUn7HFVUzZSPyyX0/ZwiqFKC/bvN0a/qrlNR/hfUP9au2tV6ia/qr9dkf4Zjg/1rC0oNla17q5rGzVF749DOcI/mqt00V121XYpSE3WR+MwMje3Ix4gHrtWOc/fIrk1KD9DNJait+qrDFu9od8SK+nOD+ZCvVKh6EGsyKi78It7fReb1ZFLJjOMCWhB7JUlQSSPuFD9hUoQaK9Ur4K+0ClKUClKUClKUClKUClKUClKUClKUFus1Cn4iF7+rd5+gZH/wk1NNw1CPr0vf1Z1B9HGx/wDCRQaBSldE6FRYT+s5EickrVBt0iZHQloOqU6hPy7UHhSgCVAe6RRGgyIsiNs8yw6z4idyPEQU7h7jPcVlNRaefscSyyH3m3BdIaZraUZyhJUpIBz6/Ka6fN1JbLxo7Usa4X3UWoUFjxWTMt4xDf3DYvxAs7Ek/KRwOayztujOQbDKittXDUtv0tGet9tdRlC/mWVuYxhakg5CPXGecYoOX6YiaLbtXndU3G6uyitSU263MpSoAdlKcXxg+w5q7nQdBXK1yXbLcrrabiw2pxMa5oS62+QM7UrbGUq+4rIaPkosuhr1rBMGNcL2bgiG2uU0HERQpJWp3Z2yT8oJ4FVb3PTrTppcr/d4cKPebZNZZRLjMpZ80hwKyhQSMFSdu7PtQcwrJX2yTrG7EbuLaW1yorcxoJUFZbcGUnjtx6V0fWV1i6BnxtNW2wWmSyzFZcnPz4odcmLWhK1fMeUpGQBtxjB5rZrtY7VqjqfETMYSxabVpdiaYr7xQNqGklLa19wBvTk+wNBwCldm1Ba7PdNJXd6cjRVvuMNkPwXLLMwXtp+ZpbZUdxKc4PfIqwkaKtdx6gaXFvZTH07doLVxdAcO1ltCSZAKiSRgoV3PGaDlFKurq5GductyAz4ENTqyy1uJ2IydoyeTgYq1oO3fCYn/AKe3Nf8Adtyh+7jf/KpZoNRT+EpP/Sy9L9oQH7rH/KpUoNFVhXqvIr0KBSlKBSlKBSlKBSlKBSlKBSlKBSlKCxdPFQb6zueL1S1Gr2lFP7JA/wBKnG72qCPVRZc6k6mJ9Lg8P2WR/pRGrVdWq4zLTcWJ9tkORpjCt7brZwpJq1pQbRqLXuotQW7yFynJMRSgpbTLDbIcUOxXsA3frVkvVV4XdLVcfOKTMtjTbERxCQktob/KOBz3Pfv61hKUHWtGxtZPMS9Q6X/Cbum5qULlaEJQsfmOPEjnAweSCn3PbmvOvbZre46cXJ1BbbdpyxwP4jNvbSiIhxw4B2NZKlrxk8/XHtXKWnXGlbmlqQr3ScGvTsh55SVPOrcKe29RVj96Dp8jUE+PBZj3Ww2O/S7Sy2w1LkZLrOEghtaUrAc2nIAIP5Tn1r5CumsrnqqXqxm3x5TrDPkZjSloLclKGQlxG3dlZKU7iE5wT9q0pjU89svOrXvlL3FL2AkhShtUs4HzKx2J5B5qnbNTXW2WmTbYkhIhyCVKQtpK9qinaVJJBKSRxkew9hQdBv8AbLiq1u2yw6Fh2o3DaZD4miU4gJT4uNylYZSR83OMgd6pRdQ3my9MpEB7T4cLCZEBq7CQFeXbecHiJ2jPcoUkKyByf1w03qfeHbx52GxEith0PBlDeNyg34aSpadqlEJJAOfU+5qwu2v7xdbBItMpEQR5DhccU22UKUfEU52B2/mUeducYGeBQalSlKDvnwko/wDXeoF+0dpP7qP/ACqUDZqM/wAI6MydSr9kx0/uXP8AlUl2/SirhPavYqmntVQUClKUClKUClKUClKUClKUClKUClKUFg72qHHxD6afsnUCXO8M+SuZ8w0sDjfgBafvnn9RUyXBxWuaw01bNU2hy3XmOHo6uQRwptXopJ9DQQJpXb9RfD5do8harFcosqOSdqZOW3APbgEH78fated6I6xR2YhK/wAMgf6iiOY0robnRzWaO1uZV/hko/1NWznSbWqP/wCFKh/uyGj/AP6oNFpW4OdM9Yt/msMk/wCFSFf5GrZzQGrG/wA2n7j+jJP+VBrFKz69F6mR+aw3Mf8Ahl/8qoL0tf0fmslzH/hV/wDKgw9KyDljuzf9Za5yP8UdY/0q2chymv6yM8j/ABIIoKFK+7Ff3VftW+6A6W6g1bMaJiuwbZkFyW+gpG3/AHAeVH7cfWg678JttcZsF7uK0kIlSG2kE+vhpJJ/df8AKpAN1hNL2SHp6yRLVbG/DixkbUA8k+pJ9yTkn71nECiq6e1exXhPavYoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLZYq2cTV6pNUVJoMe43VstqsmtuqSm/pQYtTNUyz9Kyha+lePB+lBjSz9K+eD9KyXg/Sng/Sgxng/Sng/SskWfpXzwfpQWAZ+lVEs/Sr0NfSvSWvpQWqI6CoKKE598c1eNIr2huqyEUHptNXCBXhCarJFB6FehXwV9oFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJFeCmqmK+YoKJTXgoq5xXnaKC2LdfC2KuttfNlBa+HTw6udlNlBa+HTw6utlNlBa+HX0N1c7KbKCiEV7CaqhNfQKDylNewKYr7ig+ilKUClKUClKUClKUClKUClKUClKUClKUClKUDFfMV9pQfMUxX2lB8xTFfaUHzFMV9pQfMUxX2lB8xTFfaUDFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFct1P1fjWHqTH0gu0PPOvPR2RJD4SkeLtwduPTd7+ldSqHvXa4iz9f8A8TLReEJyHJLYVt37EoVjPpnHeg751a6pw+nTttaft7k96YFq2NuhGxKcDJyD3J/kayfSvXsbqDYX7jFiLhqYfLC2VuBZHAIOQB3z/Koz6z1K91L6s2J6Fa1yEhqOlFvDyQV8eKtG9WB6kZOO1bR8KNzctusr/p6UC0p5rxA0o/lcaUUkffCj/wC7RHSNZ9a4GldeK03LtTzgQtpLkoPhKUBYSc7cegV7181D1tgWfqH/AEVFqdkLElqMqUl8BIUvb/Zx6bvf0rhPVqErUfxAXC2oXtVLmx4iVexKG0VrOpLfc9PamtMu++Km6SEtz30ujC0kuqxn64SD+tBJK29e7S/erxDn2qREj21t1xx8Ohe/YsIACcDlRIA59axDHxMWRUnD9huSI+eHEuIUrH+Hgfzrh0NcZOptZqnRXZcYtvhbbK9q8GS38wODyPzdscVafjzlsEaFpm53CbCWTugT4iC2FE9g3uWlWfcAGglF1F622bRlzbtogyrhOU0h5aG1BCWwoZSCTnnGDgD1rGQ/iAtMzTV1ukezTvFt3hFxhxxICg4vaMKGex9xXJurMyCNdiVdBdbBfm4cRanoSA4grMdBIAKkqSUklGQTnb6c51yHfLzd9Baq/EG0yYyER909TIDu/wAdG1CnAMqyCo/MSRigkN/t5sLOjIl9nQZTT0t5xpmC2tLi1bMZUTwAOR/51Yac+IvT9zujMS5W2ZbEPKCEyFrS4hOTwVYwQPrzUcrrZJ69B2K9NsuOW8KfjLWlJKW1hwq59shX8qur/LXrifpW32C3SVzIlrj21TYQMuOoKsqGPT5hycduaCScTrhAe6hvaVctLzSm5bsMSvHBSpSCoA7cf2ikDv61m+kfU5jqP+K+XtjsDyHhZ3uhzfv3+wGMbP51FeRb5Y6sXpiMsmbBlTZCFD1WwHHB+5RXWfg476t/8J/+agknSlKKUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVaSLZAkul2TBivOnutxpKif1Iq7pQWbNrt7DqXWIMVt1PZaGUpI+xAr01boTMgyGYcZt8kkuJaSFc9+cZq6pQWhtsFUnzBhRjI3bvFLSd2ffOM5r7Jt0GU74kqHGecxjc40lRx9yKuqUFqzbYLLqnGYUZtxQIKktJBIPfJxXlu1W9p5LrcCIh1JyFpZSFA/fFXlKC3lQosvHm4zD+O3iNhWP3ryLdCEYxhDjCOTkteEnaT74xirqlBRZiRmGCwzHZbZPdtCAEn9O1eY0KLFJMWMwyT3LbYTn9quKUFoLbBTIU+mFGD6iSXA0ncc9+cZ5ya9xIMSHv8pFYY343eE2E5x2zirilApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlB//2Q==",
+              "timestamp": 36017398287,
+              "timing": 2625
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAgDBAUGBwIBCf/EAEwQAAEDAwMCBAQEAgcEBgkFAAECAwQABREGEiEHMRMUQVEIImFxFTKBkSOhFjNCUnKxwRdidNEmNDWChOEkJSeSo7KztMM2Q0WDwv/EABUBAQEAAAAAAAAAAAAAAAAAAAAB/8QAFREBAQAAAAAAAAAAAAAAAAAAABH/2gAMAwEAAhEDEQA/AJU0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUr4pQSkqUQEgZJPYVrzWuNKvXDyLWorSuXnaGkykEk+3fv9KDYqUJAGSePetdOuNLJn+SOorSJedvhebRuz7d+/0oNipQEEAg5B9axV51Da7KtCbrK8oheMPOtqDQ+7mNo/U0GVpWhda5X/skv8mG/wAGOlSHWl9wVJ5BFZY6v09ZokCNd75bocpTLf8ADfkJSrlI5IJ4oNnpVONIZlMIfjOtvMuDchxtQUlQ9wR3rC3fWOm7PLEW6322RJOceE9JQlQ+4J4/Wgz1KpRJLEyOiREebfYcGUONqCkqHuCO9VaBSlKBSlKBSlKBSlKBSlKBSlfFq2pJoBUE9yBXwOIPZQrF3K4xLewZFxlMxmchPiPLCE5PYZNWEPUtjmyUR4d4t78hw4Q23IQpSvsAaDZaVQjrJ+U/pVegUpSgUpSg5v1wfeXZ7HaEvLjxLxdWIMtxB2nwVElSc+mcYrY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvr3q81dp2DqqxP2u5pV4LmFJWg4W0scpWk+hBrT3dF6zkwjbJWvFqtqk+GtaLehMlSOxHibu+PXGaDRDfbk/0PhwVTXShy8CyKnpVhS43ilO/P1SNua64jQOlU2P8ACRYrf5LZswWU7u2M7u+765zXt7RNkd0SNKmMRaUtBpKQfmSQchYP97dzn3rWk6J1oiJ+HJ1+7+GhPhhRt6DJ2dseLnvj1xmgw3UGVJ0J0UMfTt4ellt1MNE5SwpbLalkEbh6pHyg9xXRdP6ctlv04i3NtCRHeZCX1vHxFSMjlSyfzE5qnbtG2SFo9OmRES9afDLa23vmLmTkqUf7xPOferVWnrpbLKLPpiemNG2eGiRNWqQ5HT2whPGcem5RxQcVjvux+kXVCwJdW9brNOXHhrUc7W/EHyZ+mP512fROlLND0nEbMWNOVLjockyXkBxUpSkglSie4OeB6CseOmcCP01naSgSXG/OgqfmOJ3rccKgStQ4znGKN6O1HaYnkNL6pbhW0J2tsyoIkKjj1Datw49grOKDVNPy3tIf7UbVZCVQLO15yC1+YMLW0pakD6AjOK2npZpKxs6GtslcOLOlXGOmTLlPtpcW+twblZJHIye1ZrRejoembPKiF1yfJnOKenSpABXJWruVfTHAFa7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNBQ6fMt2DqfqzTdrGyzIZYnNsA5THcXkKSn2B74rqFazojSLGl2Zji5b9wuk5zxpk5/87yvQYHASBwAO1bNQKUpQKUpQKUpQKUpQKUpQK8PjLRr3Q80Gu6jEk20+SE4vbh/1LwfEx//AG/Lj+dYKypu/wCKMeaGovByd3mhB8PsfzeH8/7Vuy2SD8vIryGlk/loPrA/iCrqvDTYQPrXugUpSgUpVnKuDUeW3HVnepJWTg4Sn3/egvKV8SQpIUOx5FY683M27y+1nxS6opxuI/0Pf9KDJUrD/iz6kTlNxUFMYrHzOEbtvf8As0k3d1hpBWwzv8EvrBewNvskkcn9qDMUrGN3ULfS2G8EulvBVyAG9+cfyrza7uJlsemOteChsZPJII2gnuB747elBlaViYl5S/EivKbSguvFlY35DZAUe+Oew/eqf42d9vT4CczBlP8AE/Lzznj27e54oM1SsdcLiYkyOz4aShwgFalEYyQB2B9/XAqiL0nw1LLOQhlx5QSrJGxWMfr/AKUGXpWJN2cS2kFqOXVuBtO2QCgZSVcqxx29vaibq4uVHZQwg+I2HFKDm4DkjggYPb6UGWpWB/H1+VLvlkBYXtKC4flGCcn5fp6Aj61e3O5GHFaebbS4F9zuIAGM54BP8qDI0rEvXV5l2TuYaLLTSXQtLpyoKJA/s8duTmreTflx2lboyFupd8MhtwqSfk3DB29/TsKDPUrEzLutha0IjhakvIZGVHncjdngH7VUjXJbtyMRxpLfy5Ct5O44BOOMevvnjtQZKlKUClKUClKUClKUClKUClKUCvC2kLWhakgqQcpPqK90oFeHWm3ceK2heO24Zr3SgoiJHS44tMdoLcBC1BAyoHvk+tenI7LuzxGm17DlO5IO37e1VKUFPwGvGLvhI8UjBXtGce2aCOyltTYabCFd0hIweMdvsBVSlBTXHZcStK2W1JWcqBSCFH3Pv2r4YzCu7LZ4A5SOw5A/SqtKCm4wy44hbjTa1o5SpSQSn7H0ohhlClqQ0hKl8rISAVff3qpSgoCHGDKmRHZDSjko2DaT9q+qiRlKbUqOyVNgBBKBlOO2Paq1KC38jE8Mt+VY2FW4p8MYJ98e9VHmGX0BD7TbiQcgLSCAf1qpSg8lpslRKE5UNpOO49j+5qmIkcNhsMNBsZwkIGBnvxValBRdix3gQ6w0sKIUQpAOSBgH9q+txmG3PEbZaS5t27kpAOPbPtVWlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArFal1DatM2w3G+zEQ4YWEFxSSr5j2GACaytR1+L697LfYrI2rl1xct0fRI2p/+ZX7UHXtM9RdJ6nuf4fYry1LmFBcDQbWklI7n5kgetbZUGOn7zuh+qunHpaihJMdbhPGG5DSSc/YOfyroOqdZ6+1p1QuemtI3FcFuI8602004Gcho4UpS+5yR2+vaiJTUqM9m171H0tojUMjU8V17wEJRCmSkpOx0uBBBx+YYUSM/3e9azarr1guVnjaott1nSosiQWkIQ4hWVAnP8LGAnII7UVL6lRi6i9TdcSbjYdLW1Bs96ksMiYE7QtT6zgAK5CU9jxzz9KwsfqFrvRt6vWmNU3F2U6YT6QsuBbjDhYUptxDg577eD/KglvSoWaU1zr6ZYtTvxtRyVohw0uurkvKWtCS4lP8AC7gKOe/tV7bOpPUGb05vj7d5CmLfIjByUs4kpDhUAlJA5BKRknn96CY1Khze+purJvTKyS/xuYzObuMmK4+wvw1PIS20pO7bjON5Fe39YdT42jLTqtN3dbtDavKoUXUrU8sKVlTiVZ3ZII59APvQTDpUS9WdYtWapk6ftenJP4U/KZaS8WlBBcfUoj85/Knt6+pzmsJqnW3UC3a7FtvN+kx5bLjDTzUOSQ0flTzhJxkjk/UngUEz6VFhrXvUPX/UGY1o2UmNFt6lPNxCtLaFNoVj+JnlRVxkdufStCjdR9YvvXda9RXVGGVrSgSlYbO9Pbn0yRQTkpULLXrjXzugrzcmtSSTHiy46HHHHVKfyoLwEE9k8c+/FZid1t1X/s5tjDMwJursl5l6dsT4hbQlspxxgH+JycZ4FBLulRU0VqHqnbNWW9tx+bfoLpQt9vPjNltR5wsjgjnkHH3rWtJar6hag1m5Z7LqKa5LfD7baJMpWxICVZPOcEAEj2OKCZM+UiDBky3QotsNqdUE9yEgk4+vFaF066t2HXt6ftlni3JmQzHMlSpTaEpKQpKcDasnOVD0q609Avdr6SPxNVSlSry3DleO8XS4VZLhT8x7/KUj9KiZ0r1TK0c7qO624I86LYWmVLGQlSn2Rux64GT96CdtKhrI1h1Lb0Au/P31xVrnSw2h5MgJfbWnOQkJwUpODkfQHFdv+GW93O/aBmSr1PkzpKbi42l2Q4VqCQ22QMn0yT+9B1ulKUClKUClKUClKUCuDdYej+o9ea0VdY1xtjMFDLbDLby3AtKRknOEEfmKvWu81rurda6e0ihpWobozDU6CW0EFS1AeoSkE4+uKDieufh5mTryxI0tcYzEVLCELE591bniJyMg7VcY24GeMVW1X0DvE+9G9WW+xodxkgOSUErSEvFP8QoWkZ2k5OCB3rqll6oaOvUWa/br006mGwuS8gtrStLaBlSgggE4A9AaxrPWrQTsWRIRfP4TG3eVRXgfmOAACnJ7Ht7URp+kfh+jW/Tt7iXu6mRNuTIZDjCMJYwsLBGeVHclPtwMfWtVR8OGoStMN3U0T8KS5vACXCQfVQb/AC5x9a6l1M6hW2DZIKLfqqDZ356EPh5yMt91LC05C0NpGQo8Y3D39qyXTvVmnn9Jq8tqv8YRbmyqVMmHw3Ep5O5YIBA9Mn270Vo2uugbFzt9nOm7kIdwt0dEbe+DteCTkLJTylWSeQD6e1Y7Tfw/TY/4pP1BeWZ11eiPsxgCsoS6ttSAta1DccZ7Yro/+2HQvkpMtN+aUzHWltzay4VZVnBCduSOO4GK0nqV14gwLFBlaFlRZ0l6QptxMqK6EhCU5JGdvOSn96IxOk+hWoLPYtUQZFxtS3LrCTGZUhbmEqDiVZVlHbA9M19snQvUEDQWprG7cbUqTdHYi2lpU5sSGlKKt3yZ53DGAav3+pF11N0LkX2JeYdnvMWSGZrqGHAhsFZCUp4WckKbORn17emb6Ma2QjpzMumrtUxpzcaWWjKWlaNg2pIQSpKStXOeAe9BxLqnoW4aA0FZbZdZMWQ8/c5MlKoxUUhJaZTg7gOcpNZrQ/RWdrLR1huMe/GJbJKFuPx3Ape1xLq07kJyE8pA7/XvXbI2t+m2vZ8e2uyLXdJKVHwGp0Q/mPfZ4icZOPTvXuy9TOn0SadP2u4RoSoxdT5dERbDTWzcpfO0JHZR+v60Gl9Qfh+jXhm2q0zObgvQ4yIqkSEkpeCc4WSOQrk54OfpWsSPhvvEe8x3bXd7euG0WlEyCtLilAAr4CSAN2cc9sV3nSGu9N6vceb09dGpbrI3Lb2qQsDtnaoAkfWrvVWq7HpSIiTqC4swmnDhG/JUsjvtSMk/oKKiNr+Npq3dRrwu23i5WtKZbiJUdtg7sbvnDS0qwQecBWMfWsP0s0bcNb3e62+07Gh5RRLz5OxHzpwFEA8nB9PSs38RN4tl41tGnWFyI9AlQWng6y0kFaipYJUcbs8AEHtiul6L6hI091KvGmU22z2vTVvEl11yLFUHSlpBVuUQTuOB7Zoila+hWoInT6+WFy42oyp8qO+24lbmxIb3ZB+TOfmGOK+x/h6lPaC/C59ziN3pia7Jjvs7lNFC0NpKF5APdvOR2+tdPgdWtGXC03O5RLspcK2pbVKc8q6PDC1bU8FOTk8cZqyPW3QIipkG9L8FSy2FeTf/ADAAkfk9iKK53pL4fbqjUUO4auvrMuPEUhSWmFOOKcCTkJKlgbU/bP6VkOmHRe+aT6jR9QTp9seiNl4ltlSys70KSO6QP7Q9a6Avq7oZHkfEv7CPOI8Rrc2sYTkjKvl+Tkf2se/aslqvqFpbSimkXy7sR3XUhaG0hTiyk9lbUgnH1oM9eYq51nnRGlJS4+w40kq7AqSQM/vUe9G/DzcIYvEfUNygqjToJjtriFaltueI2tKsKSAR8hzz6127SOttPavQ8dPXNmYpnBcQApC0g+pSoA4+tbFQRdPw0XRMCXtvcJyZ4iRHyFob2f2ivgnd2wBx9a7D0R0RP0DpKTarpIiyH3Zi5IVGKikJKEJx8wBz8proNKBSlKBSlKBSlKBSlKBURviMQiP1piyNQMyHrMpqOrY2cFbI/OlJ987v3qXNc915qzp23cvwXWb0F2YztUGJMRbuzcARghBAyCOxoI3Q39FTL5fF6Vtl/jK/D5io4W+gttp8svduGCrb3/tHuKvvht0hY9X328R9RQRMZYjJcbSXFo2qKsZ+Uj0qVFu0fpy2xJUa32S3xmJTZZfS0wlPioIwUq9xg9q9af0nYNOvOvWO0Q4DrqQhxTDYSVDOcGiIfdSIMSxdYp8e/RHDaWlpS02QtY8uGwlrGFpKgAAPzDt3rEtx7bKsOoHNNRr2XWmwuQslIYEfxU8KSMqHO04Kj27nGam1f9MWPUPhfjlphTy1+QvtBZT9iaqWfT1nssJyJabZDiRnf6xtllKUr9Pm9/1oIHPS7C5otiLHs0lN/afK37j45LamznCdnYen7d6z70FC+g8acmMhTzeoHG1PhA3JQY6Pl3d8Zxx71JN+d0pZvr2knI1nTNkSEpdipi4Qp4cJSVBO3cMkYzwTjvW8wdK2GDZ3rVEtEFq2PqK3IoZHhrUcclPYngfsKCL9qvFsl/DFfbXCYLdxgPMLmueGEhwuSSUHcOVEJSBz2wBXPHWZqumER5tKzb0Xd9LpH5Q4WWdmf0C6m0xobS7Ftl29mw25uFLKVPspYAS6UnKdw9cHkVcQNJafgWqRbIdmgtW6Qre9GSynw1qwBkp7E8D9qEQov67Dc7rp1jp7brjFuHhttvB1e5TknIwpHJxz68DtwKzHT21xbx10/D7ww3Kjuy5vitrHyqIQ6f8AMA1Luy6M01Y5Qk2ix26HJAIDrTCQofY9xXmDorTUC7/ikOxwGLjuUvzCGgF5UCFHP1BP70EX/hRUR1PdAPBt7uR7/Misx8VrLrev7DKuDby7QqKlOEHGdrhLgSewVgp/lUibHozTdhmmZZrJBhSigo8VhoJVtOMjPtwKyN5s9tvcTyt4gxpsfO7w32wsA+/PrQQL1+9p6TqFT2j4EuDaFtJ8NqUSVFXZRGSeMj3PY/apd690ZYmdI6ovEG0R03p+2SSqShJ3qKmlA/vWwzdAaSnFgy9O2x3wGgy3uYT8iBnCR9OT+9bNtTs24G3GMemKKgZpK8Q4WgdcW19axKuDMTwEhBIOx8KVkjgcEd6wDv8A+mY3/GO//I3U8E6F0qlmY0jT9sQ3LAS+lMdIDgCgoA4HbIB/QVpGqEdItMXBmz3yBZo0hRDgZ8qVBG7A3KwCE5wO/tREaNdW2HC0roiRFjttPS7e44+tI5cUHlgE/XHFfL7tjaxtkjVDLr0J2BDdwpKlb2zGQEkAKSSAfZQ7Gpd3KwdPnUQ4VyiafIithEdl5TYLaFHcAkE8A5z+tZq56Q09dIUSJcbLAkxoiA3HQ6yFBpIAASn2GAOPpQR3+G5Nid6iSHLJHvPjJZdKnFFCY6WiRgKT8yhzjAKjyO5xUpaxlisFpsEdbFktsSA0s5UmO0Ebj9cd6ydFKUpQKUpQKUpQKUpQKUpQKhf8SKijrLcFAbiluOcD1/hpqaFRk629LdYan6lTLrZLWH4DqGUoe8y0jlKEg8KUDwR7UFa39btWwNbptmq7Q1CjTFgNMrZKHWEr4bVk/mGcZyPft2q36b9YtXX46nFxkxVeQsUqextjpTh1vbtJ9xyeKubT0f1nfOobN01zPafiQlpCZPiJUqQhHKAlI7DPJzjue9YOw9GNf2KffW4AhpjybdJiF4OoV5hChw2kEgpKiEjJwBzzRFXTvXnVadP3ydcG4055gstRwGQhDSlleVr28kfLjHuRVOxdZOp9xQqZAt8a5RkKwtDUMqx+iTuFU9JdJuo9ptN1REiMQJTq2VBL0hlxEhtIc3IIBUk8qScKGOPpVo10Z6iXO/tSXoFvs60EYksOtMoSR/aCWec/YCg8aru4j/ECwtu2W9t5U6GoqLRyFOJbUokZxuyo8kZrI6S626+ubl1ShqJcFR7e9JCfCQ2GgjBLh/vADPy+pIrK6r6Waxm9Y273Ht/mramXEcVLMhpJWltLYWraVbu6VcYqx6ZdJ9aWSTqJdzs4ZTLscuGyfNMq3OrSAlPCzjPueKDP6A673GVpXUs3UUSO/KtbKHmSwPDDpWsICVDnHzFPI9M1qh66dQ0st3dUKCLW66UIHlT4aiO6QrO4/vWS6c9FtS/heqLbqOGm2ouEJDcd4vNujxUuJWnIQonGU1h7b0o6q28ptsBtuHES9vEpmU0jn+9vSfFx9P5UGz9Q+vV8hR7OmxW1uCuXDTKdXLbKlBRKklKQcDAKTye/0q40f1W6goddf1HY0ybWmG/ID7UZSNxQ2paQFpJTyRjtXrXHTvqKfIs2+RF1HFbiIbd/ES08rxuStQ8YcAk8EHOAKw3Tno/1As8i4zvMtWZ5yI822yiSCXHFJIRnZlIAJBzn07UGNt3W/qNfLg6LNFhPFPzeWZjbiB9Mncf0qRGiL9drx09Yu16hiDdS06XWPDUgJUkqA+VXIzgH9ajdeekXUm8SGW5lmtSVJVzLYMZnd9VFGFK/YmpJ9P8AT1wsnT+DZL1N83NbZW248FFQAUTgAnkhIIH6UHDem/WLV19OqPxGTFX5CxSp7G2OlOHW9u0n3HJ4rX2Ouut12CbLVLh+M1JYaSfKpxtWl0nj/uJq9sPRjqBYp99bgiGmPJt0mIXg4hXmEKHDaQSCkqISMnAHPNYWP0W18jT06KqxgPuymHEJ84xylKXgo5347rT+9BnJfXDXkXStnuSo8ENyHnkGUttJD5QR8oQCNoAUOfXP0rX+surW77dNNXv8Jt/jTbS3Id3oJ/iB11BB5GU/JxnPFbHe+k2tJPTHTNoYs4VcIcuW6+15pkbEr2bTnfg5wexrH6p6O65nW3TLUWyhbkO2eXfHm2Bsc8w+vHK+flWk5HHNBpvVdd2d6ly3Ln4HnVqZUz4QASGyhJaGB/ubc1OCxicLLAF3LZuXl2/NFv8AL4u0b8fTdmo7dXuj2p7xqCLe9PNMyXFxWEPMKeQhbbjaEp4KiEkfKPX3rvmim7w1pW2o1KsOXkNDzSgUkFeT/d49u1FZqlKUClKUClKUClKUClKUClKUCrW43CFbI5fuMuPEYBx4j7gbT+5NXVRM+JB5c3rBAt9+lvRbGhpgJcSnIbbUf4iwPU5z79hQbZ1M6z6h051HesloRa3raDHLbjjSlqUHEIUTuCwD+Y44rtkLV2m50oxoV/tMiSApRaamNrXhIJUcA54AJPtioOajYtUXXYj6euT1ztTTzKGJLwIUpICeOw4ByBwOBWZ6VzI1s6kvvXB9uM0licgrdUEgKLLgAyfUniiJho1xpNxDim9TWRSW07lkT2iEjIGT83AyQPuRVZnV+m3m2Vs6gtDiHnfAaUmY2Qtzj5EnPKvmTwOeR71Ayyf9l6h/4JH/ANyzXZfh76b23VlhF8nzZ7ci23QlhlpaQ3lKWl5IIPJOAcHsBQScdvFsZuKIDtxhonLGUx1PJDihjPCc5PFaJ1I6m2206Iuly0pebLcbpFDSkMokIe+VTqEKJShWcYV398VFKxSLVO1Hd5+s7tdIM4Bx9l6Ijc4ZO7OCe45+33FYiw/9lak/4BH/AN1HoJZdF+p7uqNNzbjq6VaretuYIzJCvASv5ArHzqOTye1XHXLWeoNK2u1yNLm17JS1hx6W82nsAUhAUoA5yckZ7VFO0RLDI0VeHrleJDF4juJVAgJSS27uwFqPHfA9x2Hetg1BJmSOhulxMWtbbV0ktxys5/hhCeB9AoqoN71N141faXbc0hmwrW9EQ86WwXk7ypQOFJcx6ducHI9K2y39TtVJ6rO2i7L07HsjclxpwKmNJU22nPzZ8TO7jkY/QVGe8/8AU7F/wZ/+u7W9ORGLh8RkmHLR4kaRfnWXUZI3JU4oEZHI4J7UHadH9eo2oddxtPu2hmHHfecZROVPCkkgK2YGwA7iAAM91DvW19R9T3SDPj2qx3LT1qW6ne7Ouk1CS3z+VDROVE98nior6BFmtXV2Ob0UsWyFLeUkrUrCFthZa7cnCwj7+tYm3IhXu5XmRqm5OR5qkrdQ46tXzO5Od2EKJ+3H3FBPmA+mTCZeQ+zIC0A+KycoWfUp5PH61rl06g6YtWp2dPT7q0zdnSkJZKFEAq/KCoDAJyOCfUVzz4W0xmNOXaPBva7nHQ8hfhmMtpMdSgcgFX5s4Hbtj61caxidMHOrcNy/SVo1PvZPhAr8JTnHh+JgYzjb6jjGaK7LWGXqvTzczyjl9tSZWceCZbYXn225zWv9b5kyD0q1FItylokBgJ3I7hKlpSsj/ulVREsdn0hL0g5Lu2o5EG++a2JjJjF1PhYHzcdz35z6dqCdsybFgxVSZslmPHSMl11YQkfqeKtrTe7VeErVaLnCnBH5jGfS7t++0moadRpq3bboq1Kvcmdp5uJlEpTKm8/x1pUdhOSUpSkD6D61X08Lfp3rXYWun12k3KC5IYbLqklJWFkBxB4GRjPOOP0zQS5g6u03PkmPB1BaJMgJUotMzG1qwkZJwDnAAyauYd/s86G9LhXWBIisp3OvNSELQge6lA4A+9Qf6b2hi+awlwpbj6GTDmOHwV7CSlpagCfbIGR6186cWtN1iavQ5JksojWN+XtZc2h1Ta2ylKx6pyc4oibb2qLAxb0T3r5a24K1+GiQuW2G1LxnaFZwTgE4r5/SrT/lY8n8dtflpKill3zbex0g4ISc4JB74qCEV5w6DubBWfCTcoiwnPAJakAn+QrJ6ks7EXpvo66pdfXImrmtrStzKEJbcTtCB6fmUT7k0E5ZV6tcN6OzLuUJh2SMsocfSlTo90gnnuO1fbrebZZ2kuXa4w4LavyqkvpbB+xURUGdd24QrHo2WJMl52ZbPEUHnNwbw6tISj+6nA7Vc6jmr1BrqF/S2Y+iMYkZJcUsp2oLCFAg7VYBJyTtPcmgmynUNlVbHbkm72829rHiShJR4SMnAyvOByR6+tW7OrtNvxHZbOoLQ5FaUlDjyZjZQhSvygqzgE4OB9KhpAj26DpzVrdr1GqR4kYJVCRHc2rQH28LLhCRkcc7R39M1jrTaGJPTC/3Rxb3jw50VttAWQjCwvJKfU8Dmgll1W6oQtCWa3zozMa7OTXdqGUSw2S3tJ8QYCspyAO2Oe9ZjpfrVjXmlWbu0y1FeK1odipfDqmSFEDccDGQAeQODURJkRqR0Ot9xdSpcuLfXYTThUfkZUyHCnGcfm57V3/4VXLN/QBbNvcQbsHS5cEBSiUkqWGyQeBlKfT2oO00pSilatrjQOntbNsJ1BC8ZxjPhvIWULSD3GR6fQ1tNc26p9XbP0/lMwXoz0+5uN+L4DSgkISTgFSj2zg8YNBRl9DdEPz2pYhSGFNJbCUMvlKBsAAOPfjJPqcmr5/pDoqRqF28qtYMt1S3FpDhLZWrOVbO2cnP3rQx1us+tdKamtDkF+2XB20yyylaw4hwhlZICgBg4BPI9K5b0J1gzodrVF6kMeaLcZlCGA5sLilOgYBwfTJ7elEd6jdB9FR2ZTTbE/ZJbDTmZJ/KFpXxx7oFbloXRtp0RanrdYkPIjOvGQoOubzuKUp7/ZIrnts68WxzRj2obva3oSPMmLFjNvB5yQoJClEfKkADI5NWekviJsl5vLMC52uRa0vrDbb5dDqAScDdwCkfXmit3l9J9GytSi+u2hHnisuqSFHwlrP9oo7Z9fvzWEi9CdEx2ZbLTU7bKaDLgMoklIWlfHHuhNWmruvWndPanVZ0xZU3wHfClSGiAho5+bHqoj17dq4P0ZukSJ1pYukl8NwGzNkLdVnAQGXTn9qIkQ30L0Mm3piKt77iEveMFqfVvzgAp3DB28Dis5qbplpnUVjttolw1s2+3EmO1GcLYTkYP3rmcv4mbQ3PU3FsE16GDgPKeShRHvswf86zur+ucKy2Ox3i2Wdy5226Ic2uGQGVNOIICm1J2q5596KvpHQbRT7cZDjE/bHb8JGJJ/LuUr291Gsq30j0sjWH9JktS/xTzZm7vHOzxCrd+X2z6VqGp+v0SzqsyIdicnruMFqWUplBBaUskeH+Q5Ix34rqepNSxNM6Vevl9BjsstpU42g71bzgBCe2Tk49P0oNYvvRzRl7vi7tLtq0S3HPFd8F5SEuK9ykHGT9MVS1J0W0XqC7PXGXb3WZLytzvlni2lavVRT2yfpWkL+Je0mBIdbsUrzKHUpaYW+E+Ig5yrcEnBHHH1710zpRrlPUDTTt3RAMANyVR/CL3iZ2pSc5wP73bHpQZvSumrTpW0ottihoixUncUgklSj3Uonkn71hLz0z0xedXMalnwVLubSkL3BwhC1IxtKk+pGB+wrnepPiPs9su78O22aTcGmVlsvl4NJUQcEpGCSPvisF1C60vaj6cOyNMQ7rbZAlIaflNulPl+yh8yO4VyOcfrQSPlxmZkV2NKaQ9HdSUONrGUqSRggj2rmS+g2glSy/+GSEpJz4IlL2fbvn+dcz6VdW7tY+nV8uN9jXC9+VnNhEmTKV83iJA8MKUlWNu3dj/f8AT12Wz/EXDucm1xUafdRKmTBGUjzWQ0klASvOznJUrjj8vfmg6bqPp3pfUFiiWi4WtoQ4adsYM5bUwP8AdI/n7+tWWi+lek9Hz/PWi3qM0ApS++4XFIB77c8D7gZrStG9emtSu3dCdPLjfh9tfuJJmBe/wgDs/IMZz39PavulfiBtd2hXeZdLS7bY1vZS7lMgPKdUpQSEJG1PPPvQbPp/o3pOw3Rdwt7MwSVtOskrkFQ2uJKVcfYmvlh6NaSsSLmmAzMAuMNcF/fIKstLIKsccH5RzWixfiZtC5wRJ0/NaiFWPGS8lagPfZgf51pfXzqLfDrdpOnrndbbbBCZUytiQ42iUlY3+KAMf3tnryg/YEdhR0I0Ui3vwksT/AedbeUPMnO5AWE849nFVez+jWkp1gtVmfZmGFbVPKjgSCFAukFWTjnkCtUu3Wx7SukdJyblp6S/KuURS1pelFtaS2rZuOUEnd+bP19e9VdY9eW9NGybtPLk/idrYuQxMCPDDm75PyHONvfj7UVst36M6Su0K1xJjMws21gxo+2QQQjcVc8cnJNXOoukekdQRbczcILm+DHRFaeadKHC2hISkKI/NgD1rRJHxGQomopdtmafdbZjPOtKfTK3E7N2MJ2epAHf1q4uHXW0SenirhNiT4Eyc49FYjw30qeTtSnLgWUgJ/MOcHn3oNutnSfRUSw3WyQYh8OZsbmOB8qewlSVpSVf2eQk44qnF6M6SjadnWVpmZ5GY82+6DIJUVIztwccfmNc66LdT9HRLwLRGs021yrm6lK5kiUZJfd7J8RRwQST6DGTUjaDR7b0t0rB0lJ00IS5FqkPmSpD7pUoOYSNyVDBHCR2+vvV5oPp/YdCiaNPsPNmYUF4uulZO3dtAz2xuP71tlKBSlKBUWfiP03ebd1Fj6riwXZluWlk7kI3pbWjjarg4zgEE+9SmpQQ50yi76iXqW5NaQhMxBbpbjs55p1TjZ8BYAQtSsFZOOw9TXP7VpadcLJeZyGH0qtyGnCgtn50qXsOPqMg/vX6DUokQabs141F0zitW+3yHXLDLeU8020d5afCSF4xlWFNqBx2BHpV7JY1B1TvdigwdNtQPKMoirfjx1IQEgjK3FHgY9B+3epsUoIfOWjUnTvq1PWxpz8a86463EL7KltupcVkKCuwV6H9fvWo6G01dLzrV+1oiqjypDExtIKClAX4DmE57AZ4qd9KCB8Fy8WKDN05M0y5IkOSEqLT7TmQoY42pwVduOcc8V2TWGjp8v4d21zbJEtdzhP+fTDhNKTsQTtO4Ek7ik7jz6D2qRlKKhH0Q01L1B1MsrU5h/ykI+ZWXEnAS38yU8+hUQP1qS/X3T0/UvTWdDtDSn5jbjb6WU/mcCTyB7nBJx9K6LSgglMVqd3p8m0P2Btm126WCqSYZRI8Ve47Co8n19PQZ9KkP8KTLjPTWWl5tbavxJ04Wkg48NuuzUoINakXKhXmVKa0tc7JfQ8opdjLWhnJPJ8JSCcEZ4Csc9sV0K32PV+oeh2pG59j8OcuSw+xsiJYflIScqJSkDdgdjjJ578VI/VN6a07p6fd5DLz7UNouqbZTuWrHoBWodJup8XqILgI1skwVw9u4uKC0qCs4woevHaiIu22ddmul180w7Z5CGEy0Ty+ppYUHMto8PGMdgT78V3L4Wbak9OLl5mIkP8A4k7sLrfzD+E1jGR713OlFQd0dbtQ6XvOpYbmn5rz7lomw3QpBQGkFHLmSMEDbx75GO9WGj9JXe/2DUTFuhyHJMdtmSGQg7nQlRBCR6nCs4+lTxrR9N9VNJaj1A3ZbRcHXriveEtmO4gHaCVckY7A0RF+23y+vWS0aZa0JCmvwHFEF+3uKccKifzAEe/J+g9q2b4htJX3Zpe5C0BDDNpaiSG4LRLUZ1KlKKcDOE/Pgc+ldb0l1ogak16dMs2aewsrcQl9zHBQCTuT3SOPf2rq9BD3qk3ftWaB0ZezZZLbcVl2E4lptStgSUhKiMZAUEk57VqnUY3e5DS5mWaVD8vY40ZoKBUXUIKwHMY+XPPB9MH1qdtKKhjoWA8v4gmC/EcUwbs+SVtnaRlfuMVv/wAUujbjIk2m+2eCp+FGZLL7bDefDO7cFFI9Dkgn6DNSPpQRB6fv3jVfUC2vx9HQnQhbQflS2nVhlKTkr3bgkHHYY9sCpfUpQKUpQKUpQKjT8Rt31yxqrwbM/cWLEyyghdvUoALIyrxCjkH2B9MEVJauQdRejkjVOrn9QWvUsm0yn20IWlDZP5UhIwUqSewoOT9PtVajsi7ldkaubv0OHAedXEXKdUoL24QSh1IJAURkpz96wTNx6g3vS911sNVyERoMgNuNCattRUSPytp+XHzDjj1rtGgugNt0/NkS71c3Lq48w7HLYa8JG1xJSonkknBPrx3rXJPwyIM5fldTLbglWUtri7lgexIUAT9cURyvWXUvU17j2OSq7T4shuGWXzFfWyl5SXV4WUpIGSCAftWT1PrDWeltX2p57UkuSoxIknw0rUGihTaTsUgkg8cEnk966tq34eI1zTaWbLd0wI0GJ5ch2P4q3V71LU4SFDk7u2PSvWtugr+pbrDmI1A1HEeFHibDEKtxaQE7s7x3x2oN763armaO6fTLla8CctaGGXCMhsqP5seuADj64qM79w6gWzSdu1wrVclUaXJLSGvOrWsKBV+Zs/Lj5Txz6cVLvWWm4GrdOS7NdUqMaQkDcg4UhQOQpP1BFcKjfDIkTE+Z1MtcIKzsRF2rI9slRAP1xQc+6r6/v9zm6fuMa6T4Bl2hlx1mLJW0gub3EqUEg+pT/lW/ald170z01etQXe+tT5N3cbjRg2644iIpW5ZUlCxtHypwMfSth6hdBW9S3OA7ars1bIUKC3Cajqjlw4QVHO7cO+6tw63tWxvpZche4r0qG0GshhQS4k70pC0k5GRnOD37etBG+7TtfW3pxDv8rVDzttvEkBCUzlmQ2tO/9gcHIB9siref1F1QjRmnbPFvc1lcjxX35SpCvEXl5SEguE5CRtPr6/StNuosLUAt2l+5SpKnQpK5LKWUtIwcjCVq3KJ288Yx6547xpXoqjV3SnT67hIetV2b8VxtZb3ZaWsqSFJyD9Rz60HMeoN/1jZbtFt03V65i48RCUv2y4LUhSSVEbyCMrGcEkZwBWTsd91XcOsSrXb9ST2Fu3F9lrxn1utNjK8fwyrBwOw7dq6BcfhmbcTEFv1CGShgJfLsYr8R3colQwobRgpGPp35rP6d6Gv2jqO1qhV+adQiY5K8uIpBO4q+Xdu/3u+KDj/T/XWpxK1LbZl7nymnbRPILr6lFtxDK1pWgk5Scp9PerfQepNaL01qRNhuNwkzCY6SC8pxxKCXCotgkndwM45xk+ldXsPw+SLXc58s6iadEqJKjBIiEbfGaWjOd/ON2ceuKoW74cVsWqbEf1N87zrTzbjUXbsUgLHOV8g7z2x2oOS2e76vXJCXdbyrbc/E2iJcJchpRPpypOwfqRW0am1drDU/VRyyQtSCyphulhsuyvAYCmh8ylEfmKlJJ5z3A7VuLfw4PS7g27fdXSZrKAE4DB8TaP7IUpZwO/pWZ1v8Ptr1BqEXKBdHbc25s8djwg4FYABKTkYJA9c880HGtL3zVF+6pJtMzU89Kpsp+OtyLLWplKlBY3NpCgNoJynGOw7VZdEbY9N6xWeM3OdjrYkreU6jOXA2CpSDyOFBJSfoT3rtmlegY05r2Jfol7SqFFlKeaiKjncEc7Ule7kgEc49Ko3H4d46tWG62q+rhxTI8x5dTG8o+bJSFBQ4+47UHMrfrC72nrXeZK7hOfjQ5Vxd8suQstqS2h5SUlOcY+UcVaxLp1A1bZr9qxvVLzDFrIW8yJime/OEIT8uPvjP1NdltfQzy3UeRqWZeGpMR+TJechGMRuQ8Fgo3bvZffHpWv3D4Zml3B1Vu1ItiAtWUtOxt60j23BQB++KDn2rOpOo730705Icuk2PPjy5UV5+M8povpShlSSraRkjeR/P1qz1FqbWdpsekrgdU3AplxFuMoQ6oFAS6ofOc/OSfU+nHpXbNUdBIlw0rYrJZrr5JFuW86688x4ipDjgQCo4Ix+QD7Y9qtdSdBH7xYdN25OoGmjaIzkcuGIVeLucK8438d8etB2HR9wdu+krJcpGPGmQmZC8DA3LbCj/ADNZesZpe2GyaatNqU6HlQYjUYuBO3fsQE5x6Zx2rJ0UpSlApSlApSlArUdddRdN6I8JF+mlEl1O5uO0grcUntnA7D6nFbdUSfiNYNu6yRLneoTkuzutsLDe4pDraOFoCvQ5z/731oO+aH6q6V1nNMK0zXETQkrEeQ2W1KA7kehx9DWJvPXTQ9rua4Sp0iSpCtq3YzBW2k+vzcZ/TNcN0g9YtTa3ntaM0nOhzHo0jyryZ5CIpLKkhRQE9iT/AHu5rSLJPslnsWo7ZqKwOyL28nw4j6lFBiLGQcj6HB+uMURLXUnWLSVit1qnuSZEyHckuKYciNhY+QpCgoEgg/MODVpI656Hjuwm3p748yyh4lLJWGQoZCV7c4VjuBnFRNvVtnwdEaeenIcbYlyZbsZKxjKNrAKh9CQf2rLdU4UWFG0UYkdpgv6ejPO+GgJ8RZW5lSsdyfeglY91e0a1qdmxG6Bcp0oSl1CCpncrskrHY8j6DPfvWMh9dNGSLw5b3HpkVbfib3ZDIS2nYCTyFE87SAMckgVGfqtCjWzW8Jq3x2ozfkYTm1pISNxZQSePUnnNX3S+FFuPWby0+O1JjqXOKm3UBSSQ06RkH2IBoJKWbrVom6w50hu5OR/JtF5xuQ0UKUkED5fRRyQMA55q+snU/R+otO3K5tz0IgQgBLTKbKSgK7ZSc5z2GM57VE3pPb4dwc1d56M1I8vp2bIa8RIVscSE7Vj2IycGsbp23z7ho7U34ehxxMdUaRIQgEktgrBOPYFST+lBIq2dS+j67ygM2uHFeK8JlrtSUpz6HcBkfcgVtmr+smltKXw2q5eeXIDaHAuO0laClYyCDuHoaiZGuOnHbXaor9klSJrSiHvLOhgvZPHzELKj+gx6VmOtUfy+tYUcxXIgRbYSPLOueItrDSfkUrAyR2ziglJbOrmkZ7F8kJnLZiWhaEPyHUYQsqKgnw8ZKs7D6ZrE23r1oadcERfOyo+9W1Lz8cpbJ+4zgfUgVqHxFaGttk6dpe0tZ2ojQmtOTPLpPKAhYSVfQFf86403e9Gv2axQv6Hy5FzYSUSnGZpaMlZIx2Son7YGO3NB0fqLqO5W7rqGRq64sxW5MciOylRQhC0oVsCQdqgQrufeux3Pq9o226nFik3TEsOeE44EHwml+yl9hzx649cVGPqY0WOsrDRYXHKBbk+Cte9TeGGRtKvUjtn1rF2xSdPa2u0HUmmfx6c4tyMmM44ttQeUrhYwCVZ9PfPBoO29Qet1mv8Aoa9xNKyLtDuyGm3G3wnwSkB5sKwpKsjIJH61b9AOoHkdH6hu2t79KejsSWm23Jby3lZKVHagHJycdh7VHezf9TvX/Bj/AOs1WRYt06T08kTIyFrhRLiBI2jISVN/Io/ThQz9frQSysHXLRN6ubUBubIivPLCG1SmShClHsN2SB+uK6PcJsa3QX5k59uPFYQXHHXDhKUjuSagzCmacudwssaPpudLlbEMrZiPiP4rmR2+ValffI/SpVdc7bNuPSG8Rbcy4uQlppZaR8yilC0qUPrwDRWLHX7QhneX85M8Pdt8x5VXh/f+9j9K1Hrr1huNhvFsh6MuDaUrj+YecLKHEOJXgtlJOfTdXBINxsCdPMQ59pffnofKlOMLDSlo9ishX2wEgVv3Wu1qjaD6fyGLTJt0YRn0lp5zxVt7lJUhKl4GSRkgYGO3pRElulOpzq7QdqurilLkraDchSkBG55PCyAOMbs4rba5x8P2oIl/6a25MOO4x+GpRAd3gDe4htBUoY9Du9ea6PRSlKUClKUClKUClKUCrafAh3FgsXCJHlMn/wDbfbC0/saua4L1t6o6itOs4uk9GNoTPWG97pbSta3HPyoSFfKBgjkj19MUG53LqDoPQ9+dsCktW6akoC2osEpTlQBTylOOxFZHX9w0Xp7ZctTQLc/PXwwgxEPSXiOwQMZP37D3qI/UCXfJvUsu6riJiXoLjNyG0kEEpQgBQwSOQAeOOa3nU/VvV2odXzVaXMCHHgFwMKcbY8TwwcE73fVWB8qf54oiTjtrsmpIMKVcLRElteGFspmxEqU2lQBxtWMp7DI+lJeldPTAwJditT4YbDLQdhtq8NA7JTkcJGTwOOajdceruvW+m/mpSHrdcW7gy23PMNKUyGlNukpwtJTkFCTkD/zs2eqfVJ/Rzd+jKCrXBdLUqcphk+KtShgFOBgDKR8o7nk+xXaOoGo+m+mb2zE1XbbebguOh1BVbA8fDyUp+bae2wgD0xW5WvT2nUONXK32S2MvuJ8RL7cRCHMLHPIGeQTn71DLq/q5et7jYrw+ylmSq1pafQj8u9LzwJH0PB/WulXrqjra86oZ0r09bQ2uI0GchttTjqkI+ckufKkAgj9PriiJDRNK6ehF4w7Fao/jNqZd8KG2je2r8yFYHKT6g8VWten7NaFOqtVpt8FTo2uGNGQ2Vj2O0DIqN1l6ta2uVg1LaJL4jajtTKpbchDDe4hpYDza0EFOQCTkAflNYT/bnqn+gnhC7/8ASAXDJkeXaz5fw/y7du383rjNFSdlWrSunEPXl+3Wa2hkFa5nlm2yn/vAZyf51jNPOaR6gsvXhqxRZe1zwRInW5IU6EjhSSpOSnHb/SuBam6q6wY07YLI87GlXW4sImPvyYzR4cWS0gJICBhISokjufTFbN0k6i69ka0Ys+pIyrnbnFeC5JjsIUlg4yFeI0NhHYH/AMqI7vfr9ZbKhpN+ucCAh/cGxLfQ2HMYzjcecZGfvWvM3bp3bFsXBmZpWIuQCtqShbDZcAJSSlQ78gj7iuS/GP8A1Wk/8Ur/APFXBb3d2J2n9OwGkOpdtzDzTqlAbVFby3Bt59lDvjmgnYmy6Yvy27wm2We4rfCXETfLtuleOAQvBzjAwc+lXtyjWxgru82JHU9DbU55hTIU42kAk7TjPbPaog2fqZq6yTrDZLXdyxa0NQ0JY8u0rAWhBUNxSTyVH19azut+pmrkdTLxp5N4Is/nXInl/Ltf1ROCndt3dvXOaDsGh7z0x1jcpNu07Z7W7ISwXXUqtSWwWwpI5JQAeSnit9j2ix2WBJTHt9tt8JwZfDbKGm1DHdeAAePeoU9IZ2qoN5uh0NF8xdXIC0qVhJLLYWhSlgK4J+UDHP5u1bTeNeao6j9MLhb5LZky7fLZffXGRtU8wUrHKB32qCScDtzjjNBIy0XXpzAmKVZ5mlIso8FUVcdC/tlPNbmy62+0lxlaHGljKVJOQoe4Nfn1bGtOOQw1dnbtDnZILzTaHWhzxlBKVD68n7VvkjqRqvRdwt1ksd9RJs8RiMWkMx2yl1Cm0rIBUjcM7j35GcelBLVOl7Amd51NjtYmbt/jiI34m733YzmsjMiR5sdTEyO1IYVwpt1AWk/cHio0R+rHUDS+vIUPXMVpEOctK/K+GgFtpasAoUn29lEnjn3qhO6rdQ9aaluTHT9sNQYYU4lttptSy0k43KLmck+w/nRUkD+DaXtLjhFvtFsaIK1YQw0gkgAnsBkkD9q92W+2m+tOOWW5wrg20QlaoryXQk+xKScVFq+dRb9r/o3fI812M1Itj8dyatKNvmo6l7UgDBwoObCcY4H6HZPhAZuWL6+JDf4QNqFMY+cv8EK7dtuR39e1BJKlKUClKUClKUClKUCuJ9a+klz1VqKJqLS01qNdGkpQ4lxam8lJylaVDOFDt+grtlKCKl16E63k6kbnv3CLcllTTj0mRIVvUoBO4cgkgHIHuAO1ZLU3Q3Vdu1XOuGhrmyzElKWpP/pCmHGgo5KMgcj2OakzSgiL1M0DddFdJ2V6guq506VdWR4SXVLaZSGnuBu7k55OPQVZ6F6Zap1foKKuwXkNWqU+4JcOQ+tDQWhQ2r2gHdkY9O4/aV+p9N2jVEBuFf4Lc2K24HktrJACwCAeCPRR/eqmnbDbNN21NvskRESGlRWGkEkAnueSTQRx1t8P98cVZo+nHIb8eJASy86+74alvF1xaiBg8fOMVktXdEtTsamRftEXNqLJeQFOjx1MracKcL2qA5STk+nepH0oOLdGuj0nS0u53TVMpmZcZzK45bbUVpCFnKypRHKjj/Pvmo43PRMmF1N/oiHW3nlTURgto5G1ZGCfqEkE+3NT3rU4vTzTEXVKtRs20C8lxTxkKdWo71AgnBOOxPpQc66y9GpepJttumk5DEaZEYbjFh1RQnaj8ikqAOCO36D9bbpf0q1hb9YM3zWF+ccQwd4YalrcLygMJ3k4G0e3PbFd6pQce+Ibp7e9et2EWERcwi+XfHd2fn8PGODn8prmt66D6rlWDT0WK1a0yojDyJKvGxuUp5ak87eflIH8qlXSgi3eOgWqHXLNMt0u3olNRmUSErcP8N1sBO5J24UMBJ/ek/ofrR/XD12elQZja5ReVIW7sW7zkq2AYGfapSUoIn6e6E69ti5r8S5xrbJMcobVHlKHi5UkFtRAGAU5PryB96zkXoDfIGii3BusVvUS5jcorQtaEIQhC0hCVgZ3ZcJzgD0+tSUpQRQn9EOo9/lRxfrrEfS18qXpEtTpQknnHy5NaN1R08zZOp34A08tbUdEON4vZSv4LYKvpySanRWqXnp5pS83td3ulmYkXJZSpT6lrBJSAE9jjgAftRHH7H0O1HL1xFuWsb6mfb4LoLSlvLceeQhWUJ+YYSD6jPv96sb70N1daNST5WhLu1HgTNwwJCmHEIUcltWB8wH+lSZpRXDNI9DFW3p1qGz3Ge0bteUNhTrQJbZ8NW9A55PzDk/8q+dDOmmrdC6llLus2KbM40oFmO+pQccyNqtpA7AH967pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpmvmaD7SsJftU2LT+0Xq7wYKlDKUPPJSoj3Ce5rBI6raGX21Nbx91Ef5ig3jNM1p7fUrRjn5dT2r9ZCR/nVy3r3STn5dT2X9ZrY/zNBs+aZrBtar089/VX61L/wAMxs/61eNXe3Pf1VwiL/wvJP8ArQZDNKoJlMK/K82fsoV7DqD2Wk/rQVKV5zTNB6pXzNM0H2lM0oFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJrlHX3qQ5oeyMxLSpP41PB8JRGQygd149+cD9fauqqOKhr8TsxyV1VktLUSiLGZaQM9gU7z/NRoOX3CbKuMx2XPkOyJLqipx11RUpRPqSat6UohSlKBSlKD0lxaPyrUn7HFVUzZSPyyX0/ZwiqFKC/bvN0a/qrlNR/hfUP9au2tV6ia/qr9dkf4Zjg/1rC0oNla17q5rGzVF749DOcI/mqt00V121XYpSE3WR+MwMje3Ix4gHrtWOc/fIrk1KD9DNJait+qrDFu9od8SK+nOD+ZCvVKh6EGsyKi78It7fReb1ZFLJjOMCWhB7JUlQSSPuFD9hUoQaK9Ur4K+0ClKUClKUClKUClKUClKUClKUClKUFus1Cn4iF7+rd5+gZH/wk1NNw1CPr0vf1Z1B9HGx/wDCRQaBSldE6FRYT+s5EickrVBt0iZHQloOqU6hPy7UHhSgCVAe6RRGgyIsiNs8yw6z4idyPEQU7h7jPcVlNRaefscSyyH3m3BdIaZraUZyhJUpIBz6/Ka6fN1JbLxo7Usa4X3UWoUFjxWTMt4xDf3DYvxAs7Ek/KRwOayztujOQbDKittXDUtv0tGet9tdRlC/mWVuYxhakg5CPXGecYoOX6YiaLbtXndU3G6uyitSU263MpSoAdlKcXxg+w5q7nQdBXK1yXbLcrrabiw2pxMa5oS62+QM7UrbGUq+4rIaPkosuhr1rBMGNcL2bgiG2uU0HERQpJWp3Z2yT8oJ4FVb3PTrTppcr/d4cKPebZNZZRLjMpZ80hwKyhQSMFSdu7PtQcwrJX2yTrG7EbuLaW1yorcxoJUFZbcGUnjtx6V0fWV1i6BnxtNW2wWmSyzFZcnPz4odcmLWhK1fMeUpGQBtxjB5rZrtY7VqjqfETMYSxabVpdiaYr7xQNqGklLa19wBvTk+wNBwCldm1Ba7PdNJXd6cjRVvuMNkPwXLLMwXtp+ZpbZUdxKc4PfIqwkaKtdx6gaXFvZTH07doLVxdAcO1ltCSZAKiSRgoV3PGaDlFKurq5GductyAz4ENTqyy1uJ2IydoyeTgYq1oO3fCYn/AKe3Nf8Adtyh+7jf/KpZoNRT+EpP/Sy9L9oQH7rH/KpUoNFVhXqvIr0KBSlKBSlKBSlKBSlKBSlKBSlKBSlKCxdPFQb6zueL1S1Gr2lFP7JA/wBKnG72qCPVRZc6k6mJ9Lg8P2WR/pRGrVdWq4zLTcWJ9tkORpjCt7brZwpJq1pQbRqLXuotQW7yFynJMRSgpbTLDbIcUOxXsA3frVkvVV4XdLVcfOKTMtjTbERxCQktob/KOBz3Pfv61hKUHWtGxtZPMS9Q6X/Cbum5qULlaEJQsfmOPEjnAweSCn3PbmvOvbZre46cXJ1BbbdpyxwP4jNvbSiIhxw4B2NZKlrxk8/XHtXKWnXGlbmlqQr3ScGvTsh55SVPOrcKe29RVj96Dp8jUE+PBZj3Ww2O/S7Sy2w1LkZLrOEghtaUrAc2nIAIP5Tn1r5CumsrnqqXqxm3x5TrDPkZjSloLclKGQlxG3dlZKU7iE5wT9q0pjU89svOrXvlL3FL2AkhShtUs4HzKx2J5B5qnbNTXW2WmTbYkhIhyCVKQtpK9qinaVJJBKSRxkew9hQdBv8AbLiq1u2yw6Fh2o3DaZD4miU4gJT4uNylYZSR83OMgd6pRdQ3my9MpEB7T4cLCZEBq7CQFeXbecHiJ2jPcoUkKyByf1w03qfeHbx52GxEith0PBlDeNyg34aSpadqlEJJAOfU+5qwu2v7xdbBItMpEQR5DhccU22UKUfEU52B2/mUeducYGeBQalSlKDvnwko/wDXeoF+0dpP7qP/ACqUDZqM/wAI6MydSr9kx0/uXP8AlUl2/SirhPavYqmntVQUClKUClKUClKUClKUClKUClKUClKUFg72qHHxD6afsnUCXO8M+SuZ8w0sDjfgBafvnn9RUyXBxWuaw01bNU2hy3XmOHo6uQRwptXopJ9DQQJpXb9RfD5do8harFcosqOSdqZOW3APbgEH78fated6I6xR2YhK/wAMgf6iiOY0robnRzWaO1uZV/hko/1NWznSbWqP/wCFKh/uyGj/AP6oNFpW4OdM9Yt/msMk/wCFSFf5GrZzQGrG/wA2n7j+jJP+VBrFKz69F6mR+aw3Mf8Ahl/8qoL0tf0fmslzH/hV/wDKgw9KyDljuzf9Za5yP8UdY/0q2chymv6yM8j/ABIIoKFK+7Ff3VftW+6A6W6g1bMaJiuwbZkFyW+gpG3/AHAeVH7cfWg678JttcZsF7uK0kIlSG2kE+vhpJJ/df8AKpAN1hNL2SHp6yRLVbG/DixkbUA8k+pJ9yTkn71nECiq6e1exXhPavYoFKUoFKUoFKUoFKUoFKUoFKUoFKUoLZYq2cTV6pNUVJoMe43VstqsmtuqSm/pQYtTNUyz9Kyha+lePB+lBjSz9K+eD9KyXg/Sng/Sgxng/Sng/SskWfpXzwfpQWAZ+lVEs/Sr0NfSvSWvpQWqI6CoKKE598c1eNIr2huqyEUHptNXCBXhCarJFB6FehXwV9oFKUoFKUoFKUoFKUoFKUoFKUoFKUoPJFeCmqmK+YoKJTXgoq5xXnaKC2LdfC2KuttfNlBa+HTw6udlNlBa+HTw6utlNlBa+HX0N1c7KbKCiEV7CaqhNfQKDylNewKYr7ig+ilKUClKUClKUClKUClKUClKUClKUClKUClKUDFfMV9pQfMUxX2lB8xTFfaUHzFMV9pQfMUxX2lB8xTFfaUDFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFct1P1fjWHqTH0gu0PPOvPR2RJD4SkeLtwduPTd7+ldSqHvXa4iz9f8A8TLReEJyHJLYVt37EoVjPpnHeg751a6pw+nTttaft7k96YFq2NuhGxKcDJyD3J/kayfSvXsbqDYX7jFiLhqYfLC2VuBZHAIOQB3z/Koz6z1K91L6s2J6Fa1yEhqOlFvDyQV8eKtG9WB6kZOO1bR8KNzctusr/p6UC0p5rxA0o/lcaUUkffCj/wC7RHSNZ9a4GldeK03LtTzgQtpLkoPhKUBYSc7cegV7181D1tgWfqH/AEVFqdkLElqMqUl8BIUvb/Zx6bvf0rhPVqErUfxAXC2oXtVLmx4iVexKG0VrOpLfc9PamtMu++Km6SEtz30ujC0kuqxn64SD+tBJK29e7S/erxDn2qREj21t1xx8Ohe/YsIACcDlRIA59axDHxMWRUnD9huSI+eHEuIUrH+Hgfzrh0NcZOptZqnRXZcYtvhbbK9q8GS38wODyPzdscVafjzlsEaFpm53CbCWTugT4iC2FE9g3uWlWfcAGglF1F622bRlzbtogyrhOU0h5aG1BCWwoZSCTnnGDgD1rGQ/iAtMzTV1ukezTvFt3hFxhxxICg4vaMKGex9xXJurMyCNdiVdBdbBfm4cRanoSA4grMdBIAKkqSUklGQTnb6c51yHfLzd9Baq/EG0yYyER909TIDu/wAdG1CnAMqyCo/MSRigkN/t5sLOjIl9nQZTT0t5xpmC2tLi1bMZUTwAOR/51Yac+IvT9zujMS5W2ZbEPKCEyFrS4hOTwVYwQPrzUcrrZJ69B2K9NsuOW8KfjLWlJKW1hwq59shX8qur/LXrifpW32C3SVzIlrj21TYQMuOoKsqGPT5hycduaCScTrhAe6hvaVctLzSm5bsMSvHBSpSCoA7cf2ikDv61m+kfU5jqP+K+XtjsDyHhZ3uhzfv3+wGMbP51FeRb5Y6sXpiMsmbBlTZCFD1WwHHB+5RXWfg476t/8J/+agknSlKKUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVaSLZAkul2TBivOnutxpKif1Iq7pQWbNrt7DqXWIMVt1PZaGUpI+xAr01boTMgyGYcZt8kkuJaSFc9+cZq6pQWhtsFUnzBhRjI3bvFLSd2ffOM5r7Jt0GU74kqHGecxjc40lRx9yKuqUFqzbYLLqnGYUZtxQIKktJBIPfJxXlu1W9p5LrcCIh1JyFpZSFA/fFXlKC3lQosvHm4zD+O3iNhWP3ryLdCEYxhDjCOTkteEnaT74xirqlBRZiRmGCwzHZbZPdtCAEn9O1eY0KLFJMWMwyT3LbYTn9quKUFoLbBTIU+mFGD6iSXA0ncc9+cZ5ya9xIMSHv8pFYY343eE2E5x2zirilApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlB//2Q==",
+              "timestamp": 36017773287,
+              "timing": 3000
+            }
+          ],
+          "type": "filmstrip",
+          "scale": 3000
+        }
+      },
+      "layout-shifts": {
+        "id": "layout-shifts",
+        "title": "Avoid large layout shifts",
+        "description": "These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "2 layout shifts found",
+        "metricSavings": {
+          "CLS": 0.002
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "score": 0.002315,
+              "node": {
+                "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,1,HEADER,0,DIV,0,H1",
+                "lhId": "page-1-H1",
+                "type": "node",
+                "boundingRect": {
+                  "left": 0,
+                  "bottom": 0,
+                  "height": 0,
+                  "width": 0,
+                  "right": 0,
+                  "top": 0
+                },
+                "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark fs_4xl md:fs_5xl lg:fs_6xl …\"\u003e",
+                "selector": "div \u003e header.d_flex \u003e div.lg:w_2/3 \u003e h1.text",
+                "nodeLabel": "Accompagner la création d'une business unit durabilité : comment ekodev a struc…"
+              },
+              "subItems": {
+                "items": [
+                  {
+                    "extra": {
+                      "selector": "header.d_flex \u003e div.d_flex \u003e div.bg_ocobo.dark \u003e img.h_10",
+                      "nodeLabel": "ekodev",
+                      "type": "node",
+                      "boundingRect": {
+                        "top": 0,
+                        "width": 0,
+                        "right": 0,
+                        "left": 0,
+                        "bottom": 0,
+                        "height": 0
+                      },
+                      "lhId": "page-3-IMG",
+                      "path": "1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,DIV,1,HEADER,1,DIV,0,DIV,0,IMG",
+                      "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"ekodev\" loading=\"eager\" decoding=\"async\" fetchpriority=\"high\" class=\"h_10 w_auto obj-f_contain d_block\"\u003e"
+                    },
+                    "cause": "Media element lacking an explicit size"
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                      "type": "url"
+                    }
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "type": "url",
+                      "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff"
+                    }
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "type": "url",
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                    }
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                      "type": "url"
+                    }
+                  }
+                ],
+                "type": "subitems"
+              },
+              "score": 0
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node",
+              "label": "Element",
+              "subItemsHeading": {
+                "key": "extra"
+              }
+            },
+            {
+              "valueType": "numeric",
+              "granularity": 0.001,
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "cause"
+              },
+              "key": "score",
+              "label": "Layout shift score"
+            }
+          ]
+        }
+      },
+      "image-delivery-insight": {
+        "id": "image-delivery-insight",
+        "title": "Improve image delivery",
+        "description": "Reducing the download time of images can improve the perceived load time of the page and LCP. [Learn more about optimizing image size](https://developer.chrome.com/docs/performance/insights/image-delivery)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 373 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "type": "debugdata",
+            "wastedBytes": 381442
+          },
+          "type": "table",
+          "headings": [
+            {
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "key": "url",
+              "valueType": "url",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "reason"
+              },
+              "label": "URL"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Resource Size"
+            },
+            {
+              "label": "Est Savings",
+              "subItemsHeading": {
+                "key": "wastedBytes",
+                "valueType": "bytes"
+              },
+              "valueType": "bytes",
+              "key": "wastedBytes"
+            }
+          ],
+          "items": [
+            {
+              "totalBytes": 354013,
+              "node": {
+                "boundingRect": {
+                  "top": 2981,
+                  "width": 126,
+                  "right": 269,
+                  "height": 126,
+                  "bottom": 3107,
+                  "left": 143
+                },
+                "lhId": "page-6-IMG",
+                "type": "node",
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,0,DIV,2,ARTICLE,1,MAIN,1,BLOCKQUOTE,0,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"Benjamin DEKESTER\" loading=\"lazy\" decoding=\"async\" class=\"w_full h_full obj-f_cover\"\u003e",
+                "selector": "main.grid-area_main \u003e blockquote.d_flex \u003e div.w_32 \u003e img.w_full",
+                "nodeLabel": "Benjamin DEKESTER"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-avatar.png",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 247346,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 329619,
+                    "reason": "This image file is larger than it needs to be (800x800) for its displayed dimensions (210x210). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "wastedBytes": 346663
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 10523,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 15421,
+                    "reason": "This image file is larger than it needs to be (192x192) for its displayed dimensions (53x53). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "wastedBytes": 16208,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "totalBytes": 16667,
+              "node": {
+                "lhId": "page-7-IMG",
+                "type": "node",
+                "boundingRect": {
+                  "width": 0,
+                  "right": 0,
+                  "top": 0,
+                  "left": 0,
+                  "bottom": 0,
+                  "height": 0
+                },
+                "path": "1,BODY,62,DIV,0,BUTTON,0,IMG",
+                "snippet": "\u003cimg src=\"https://www.ocobo.co/android-chrome-192x192.png\" alt=\"Chat\" id=\"open-path\" style=\"width: 32px; height: 32px; object-fit: contain;\"\u003e",
+                "selector": "body \u003e div#ago-wrapper \u003e button#ago-chat-button \u003e img#open-path",
+                "nodeLabel": "Chat"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 6234,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "reason": "This image file is larger than it needs to be (348x104) for its displayed dimensions (234x70). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 6709
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 9533,
+              "totalBytes": 12266,
+              "node": {
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "nodeLabel": "Ocobo",
+                "boundingRect": {
+                  "top": 37,
+                  "width": 134,
+                  "right": 167,
+                  "left": 33,
+                  "bottom": 77,
+                  "height": 40
+                },
+                "lhId": "page-8-IMG",
+                "type": "node",
+                "path": "2,HTML,1,BODY,0,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e"
+              },
+              "url": "https://www.ocobo.co/logo-ocobo.png"
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "reason": "This image file is larger than it needs to be (400x143) for its displayed dimensions (196x70). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 8610
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 9038,
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"ekodev\" loading=\"eager\" decoding=\"async\" fetchpriority=\"high\" class=\"h_10 w_auto obj-f_contain d_block\"\u003e",
+                "path": "2,HTML,1,BODY,0,DIV,1,DIV,0,DIV,0,DIV,0,DIV,1,HEADER,1,DIV,0,DIV,0,IMG",
+                "boundingRect": {
+                  "width": 113,
+                  "right": 161,
+                  "top": 532,
+                  "left": 47,
+                  "bottom": 576,
+                  "height": 44
+                },
+                "lhId": "page-9-IMG",
+                "type": "node",
+                "nodeLabel": "ekodev",
+                "selector": "header.d_flex \u003e div.d_flex \u003e div.bg_ocobo.dark \u003e img.h_10"
+              },
+              "totalBytes": 11321,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png"
+            }
+          ]
+        }
+      },
+      "largest-contentful-paint": {
+        "id": "largest-contentful-paint",
+        "title": "Largest Contentful Paint",
+        "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)",
+        "score": 0.02,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "8.0 s",
+        "numericValue": 8027.67711652251,
+        "numericUnit": "millisecond"
+      }
+    },
+    "categories": {
+      "performance": {
+        "id": "performance",
+        "title": "Performance",
+        "score": 0.69,
+        "auditRefs": [
+          {
+            "id": "first-contentful-paint",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "FCP"
+          },
+          {
+            "id": "largest-contentful-paint",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "LCP"
+          },
+          {
+            "id": "total-blocking-time",
+            "weight": 30,
+            "group": "metrics",
+            "acronym": "TBT"
+          },
+          {
+            "id": "cumulative-layout-shift",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "CLS"
+          },
+          {
+            "id": "speed-index",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "SI"
+          },
+          {
+            "id": "cache-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "cls-culprits-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "document-latency-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "dom-size-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "duplicated-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "font-display-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "forced-reflow-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "image-delivery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "inp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-discovery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "legacy-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "network-dependency-tree-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "render-blocking-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "third-parties-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "viewport-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "interactive",
+            "weight": 0,
+            "group": "hidden",
+            "acronym": "TTI"
+          },
+          {
+            "id": "max-potential-fid",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "unminified-css",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unminified-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-css-rules",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "total-byte-weight",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "user-timings",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "bootup-time",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "mainthread-work-breakdown",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "long-tasks",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "non-composited-animations",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unsized-images",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "network-requests",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-rtt",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-server-latency",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "main-thread-tasks",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "diagnostics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "metrics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "screenshot-thumbnails",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "final-screenshot",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "script-treemap-data",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "resource-summary",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "redirects",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "server-response-time",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "layout-shifts",
+            "weight": 0,
+            "group": "hidden"
+          }
+        ]
+      }
+    },
+    "categoryGroups": {
+      "seo-content": {
+        "title": "Content Best Practices",
+        "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+      },
+      "a11y-tables-lists": {
+        "title": "Tables and lists",
+        "description": "These are opportunities to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+      },
+      "a11y-language": {
+        "title": "Internationalization and localization",
+        "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      },
+      "metrics": {
+        "title": "Metrics"
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "description": "More information about the performance of your application. These numbers don't [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score."
+      },
+      "best-practices-trust-safety": {
+        "title": "Trust and Safety"
+      },
+      "best-practices-general": {
+        "title": "General"
+      },
+      "best-practices-browser-compat": {
+        "title": "Browser Compatibility"
+      },
+      "insights": {
+        "title": "Insights",
+        "description": "These insights are also available in the Chrome DevTools Performance Panel - [record a trace](https://developer.chrome.com/docs/devtools/performance/reference) to view more detailed information."
+      },
+      "a11y-best-practices": {
+        "title": "Best practices",
+        "description": "These items highlight common accessibility best practices."
+      },
+      "seo-crawl": {
+        "title": "Crawling and Indexing",
+        "description": "To appear in search results, crawlers need access to your app."
+      },
+      "a11y-audio-video": {
+        "title": "Audio and video",
+        "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+      },
+      "a11y-aria": {
+        "title": "ARIA",
+        "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "a11y-color-contrast": {
+        "title": "Contrast",
+        "description": "These are opportunities to improve the legibility of your content."
+      },
+      "a11y-names-labels": {
+        "title": "Names and labels",
+        "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "seo-mobile": {
+        "title": "Mobile Friendly",
+        "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn how to make pages mobile-friendly](https://developers.google.com/search/mobile-sites/)."
+      },
+      "a11y-navigation": {
+        "title": "Navigation",
+        "description": "These are opportunities to improve keyboard navigation in your application."
+      },
+      "best-practices-ux": {
+        "title": "User Experience"
+      }
+    },
+    "timing": {
+      "total": 15788.900000000001
+    },
+    "i18n": {
+      "rendererFormattedStrings": {
+        "varianceDisclaimer": "Values are estimated and may vary. The [performance score is calculated](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) directly from these metrics.",
+        "opportunityResourceColumnLabel": "Opportunity",
+        "opportunitySavingsColumnLabel": "Estimated Savings",
+        "errorMissingAuditInfo": "Report error: no audit information",
+        "errorLabel": "Error!",
+        "warningHeader": "Warnings: ",
+        "passedAuditsGroupTitle": "Passed audits",
+        "notApplicableAuditsGroupTitle": "Not applicable",
+        "manualAuditsGroupTitle": "Additional items to manually check",
+        "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+        "crcLongestDurationLabel": "Maximum critical path latency:",
+        "crcInitialNavigation": "Initial Navigation",
+        "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+        "labDataTitle": "Lab Data",
+        "warningAuditsGroupTitle": "Passed audits but with warnings",
+        "snippetExpandButtonLabel": "Expand snippet",
+        "snippetCollapseButtonLabel": "Collapse snippet",
+        "thirdPartyResourcesLabel": "Show 3rd-party resources",
+        "runtimeDesktopEmulation": "Emulated Desktop",
+        "runtimeMobileEmulation": "Emulated Moto G Power",
+        "runtimeNoEmulation": "No emulation",
+        "runtimeSettingsBenchmark": "Unthrottled CPU/Memory Power",
+        "runtimeSettingsCPUThrottling": "CPU throttling",
+        "runtimeSettingsDevice": "Device",
+        "runtimeSettingsNetworkThrottling": "Network throttling",
+        "runtimeSettingsUANetwork": "User agent (network)",
+        "runtimeUnknown": "Unknown",
+        "dropdownCopyJSON": "Copy JSON",
+        "dropdownDarkTheme": "Toggle Dark Theme",
+        "dropdownPrintExpanded": "Print Expanded",
+        "dropdownPrintSummary": "Print Summary",
+        "dropdownSaveGist": "Save as Gist",
+        "dropdownSaveHTML": "Save as HTML",
+        "dropdownSaveJSON": "Save as JSON",
+        "dropdownViewer": "Open in Viewer",
+        "footerIssue": "File an issue",
+        "throttlingProvided": "Provided by environment",
+        "calculatorLink": "See calculator.",
+        "runtimeSettingsAxeVersion": "Axe version",
+        "viewTreemapLabel": "View Treemap",
+        "showRelevantAudits": "Show audits relevant to:"
+      }
+    },
+    "entities": [
+      {
+        "name": "ocobo.co",
+        "isFirstParty": true,
+        "isUnrecognized": true,
+        "origins": [
+          "https://www.ocobo.co"
+        ]
+      },
+      {
+        "name": "vercel-storage.com",
+        "isUnrecognized": true,
+        "origins": [
+          "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+        ]
+      },
+      {
+        "name": "Google Tag Manager",
+        "homepage": "https://marketingplatform.google.com/about/tag-manager/",
+        "category": "tag-manager",
+        "origins": [
+          "https://www.googletagmanager.com"
+        ]
+      },
+      {
+        "name": "Clearbit",
+        "homepage": "https://clearbit.com/",
+        "category": "analytics",
+        "origins": [
+          "https://tag.clearbitscripts.com"
+        ]
+      },
+      {
+        "name": "Hubspot",
+        "homepage": "https://hubspot.com/",
+        "category": "marketing",
+        "origins": [
+          "https://js-eu1.hs-scripts.com",
+          "https://js-eu1.hscollectedforms.net",
+          "https://js-eu1.hubspot.com",
+          "https://js-eu1.hs-analytics.net",
+          "https://js-eu1.hs-banner.com",
+          "https://forms-eu1.hscollectedforms.net",
+          "https://cta-eu1.hubspot.com",
+          "https://track-eu1.hubspot.com",
+          "https://perf-eu1.hsforms.com",
+          "https://js-eu1.hsforms.net",
+          "https://forms-eu1.hsforms.com"
+        ]
+      },
+      {
+        "name": "GitHub",
+        "category": "utility",
+        "origins": [
+          "https://useago.github.io"
+        ]
+      },
+      {
+        "name": "Google Analytics",
+        "homepage": "https://marketingplatform.google.com/about/analytics/",
+        "category": "analytics",
+        "origins": [
+          "https://www.google-analytics.com"
+        ]
+      },
+      {
+        "name": "Google Fonts",
+        "homepage": "https://fonts.google.com/",
+        "category": "cdn",
+        "origins": [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com"
+        ]
+      }
+    ],
+    "fullPageScreenshot": {
+      "nodes": {
+        "1-4-IMG": {
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "width": 0,
+          "right": 0
+        },
+        "page-1-H1": {
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "width": 0,
+          "right": 0
+        },
+        "1-3-IMG": {
+          "left": 143,
+          "bottom": 3107,
+          "height": 126,
+          "width": 126,
+          "right": 269,
+          "top": 2981
+        },
+        "1-1-IMG": {
+          "top": 0,
+          "right": 0,
+          "width": 0,
+          "left": 0,
+          "bottom": 0,
+          "height": 0
+        },
+        "page-3-IMG": {
+          "height": 0,
+          "left": 0,
+          "bottom": 0,
+          "top": 0,
+          "width": 0,
+          "right": 0
+        },
+        "page-0-H1": {
+          "height": 274,
+          "left": 16,
+          "bottom": 438,
+          "right": 396,
+          "width": 380,
+          "top": 165
+        },
+        "1-2-IMG": {
+          "left": 47,
+          "bottom": 576,
+          "height": 44,
+          "width": 113,
+          "right": 161,
+          "top": 532
+        },
+        "page-6-IMG": {
+          "right": 269,
+          "width": 126,
+          "top": 2981,
+          "height": 126,
+          "left": 143,
+          "bottom": 3107
+        },
+        "page-4-LINK": {
+          "height": 0,
+          "left": 0,
+          "bottom": 0,
+          "top": 0,
+          "width": 0,
+          "right": 0
+        },
+        "page-2-H2": {
+          "width": 0,
+          "right": 0,
+          "top": 0,
+          "id": "la-mission",
+          "height": 0,
+          "left": 0,
+          "bottom": 0
+        },
+        "1-5-IMG": {
+          "top": 0,
+          "width": 0,
+          "right": 0,
+          "left": 0,
+          "bottom": 0,
+          "height": 0
+        },
+        "page-12-path": {
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "width": 0,
+          "right": 0,
+          "top": 0
+        },
+        "page-10-META": {
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "width": 0,
+          "right": 0
+        },
+        "page-5-LINK": {
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "width": 0,
+          "right": 0
+        },
+        "page-14-IMG": {
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "top": 0,
+          "width": 0,
+          "right": 0
+        },
+        "page-11-BODY": {
+          "left": 0,
+          "bottom": 0,
+          "height": 0,
+          "width": 0,
+          "right": 0,
+          "top": 0
+        },
+        "page-9-IMG": {
+          "left": 47,
+          "bottom": 576,
+          "height": 44,
+          "top": 532,
+          "width": 113,
+          "right": 161
+        },
+        "page-13-IMG": {
+          "width": 0,
+          "right": 0,
+          "top": 0,
+          "bottom": 0,
+          "left": 0,
+          "height": 0
+        },
+        "page-8-IMG": {
+          "height": 40,
+          "left": 33,
+          "bottom": 77,
+          "right": 167,
+          "width": 134,
+          "top": 37
+        },
+        "page-7-IMG": {
+          "height": 0,
+          "id": "open-path",
+          "left": 0,
+          "bottom": 0,
+          "width": 0,
+          "right": 0,
+          "top": 0
+        },
+        "1-0-IMG": {
+          "top": 37,
+          "width": 134,
+          "right": 167,
+          "left": 33,
+          "bottom": 77,
+          "height": 40
+        }
+      },
+      "screenshot": {
+        "width": 412,
+        "data": "data:image/webp;base64,UklGRvLjAQBXRUJQVlA4WAoAAAAgAAAAmwEA0RYASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZWUDggBOIBAFALCJ0BKpwB0hY/EYS6VqwoJjKj0hq6UCIJaW7/12x1M4Dcei/5isVLD/O9bk/+r/h/Tq5F8K/kMrh390p5zP+F+yXvC8wTx1vWb5if3D9W70l/3bfWP3a9gD+Af6/rhf7vkvXxL+ef5r+3f4j/i+a39d/0X95/zH7E+m/k9+PfvP+m/8X+V/ff7IvuX/V+9b0G+qf1v/w/1v++9kP5t+HP6v+L/0f//+J/8F/yv8t/nf/X/svQ35I/9X+j9gX2v/4vz/+CT6L/w/6v/Td7bsv+5/83+s9gX3O++fs76YPxn/Y/yv+w/eb4K/V/8d/5f8D/sfkB/qv+G/83+S9u/95+2/kw/kv+R+0/wB/zf+///P/Qf8L93/pt/x//5/wvP79h/X79iX7If/7/df9n39P///+fhH++X////vxHfvd////+TftPvYDnYmDyrk37T72A52Jg8q5N+0+9gOdiYPKuTcG3nvbjHOxMHlXFHT13qyXNcZHoTYSng4xc9ljCTCoytZZiSxjhccOlMQnMU7g7OEb0PbpIKpUH91QWKrHMuweVcm/VmmzVlFU9yFQq4Mw1pnx6bOPFkE596vI7Dntxw4y9YUYxu6rj2YlWh/2IAonmUvTlKSgamL3sBzsS2V7t0twE7/PRPw+VfD5Vyb9p97AczxMamLH1EjWg0QuxMVI/WuO7SAHGazcuCct4+rUcdxUI87Qbh5BnRrXVEId28XSHYyx+ngElcncOJ8UsnIiI/XjvSKFp+nFwHIQWfXA/VwrT645nsubxmERe68a8JPlXw+Vcm/afewHOxMHlXJv2n3sBzsTB5Vyb9p97Ac7EweVck2hWmcdmWVm41i69CkaTpTXroTMXisxWKiL54zTh9K0RvOP8UoFLFLASCgz7Z7LheO007GGEWewskbbkCmAQ/n36TWgUj6jgSTl8q0kekAfhtuEQ7v3oz+VAN1QSyXdPVBw2U+VWUKk8Nn6eTYQElTcZWsFE8kWaLcCRhPRFM40HVosdEX947K1riNoeX/JHlm8WnFlFaSLM5FyJ30mygRKDam7Z6c660LD3mB1AJPgANXKGFoV3QUsKe1vkTpb59m6xNdgOxW4c/BgkvTra/gdnlXJHt8Ke1athHc+O68ryd4RpeayETrU4LjVcio+hvHb/BYDaWASTfNzE5LcPIsG07ZIvZzSI45HlgwYvPOoEdeUGThNnMV5BAy7Uh8sGaaD/tGSTBeDt+G0aJauKxrMLdmOdiYHV/7KyrMSTBTeOhD07LFk7LctL1Hu0YwE3siiux0cbdtmwtYL81YMbP+FCJuwF9EsOy5vFt5ToGzU2b6+Nj5+iKSCFIH/RywW1eC5XHm3wCr0kR/JGRXlZ7XU48NrbK3wo8plXrAAd+jFOi1nEtIEq9z6qnZUrRZzfKCOYdipeti8fbfvYDnVgPse5DCRCNhukfsjbmxqvIap9jBv6vS/el/uS88EtMa6T6ihlEvNjZyBDSZr2H7k3ZszBGuKzUh1OAt8FxelCYPKoat6EazsMsPR1sPxsXeOgEP24trgEccIdhetGSDvwO9Gp6PFQ90kZ/uwM8fgJ4arq8VTMj9qGTbjsaSQoYC8df7FPjQ5fMP2hNKqlrb3Hke0DEr364mXcBY/J8632TyZt10s2yJG+Bup7ABGpT2uwVhvE6WWkn0b0GiYrcwMw5pPqEruL/HB+NpRImeW6sBj38wZdQzMRaG2ocBLQ3fMqxX8nmJ/yxmri01oD5/voBYmVp0M4NGyDq/7l4Ikt8zXHQZu8MADN828Re+z006ptrmgeI/j+uhHeTK5zuGxLPVzGdhWv4fqRPdLDauJxjqhoTNwTxlg8EG2q7RKdSWV61vbVkPHkHlg2Uc/8flQnTaDbGu+UEkCGR+5KqmBfn9IY1Sy0mUfkaZoK5DiCfxzwrrt+yUQHWATIshXSF37wWzFJ1+nHbwiDNr3C/tS2QGVJ5L2E4GpFTiNHIB0SEeYMJ1BhdAT7OHH1nrrf7OY51R3dbTCVbnLEI+XbtZHJKMoOdPSyqwy5aKku7CUN65B4NIYeXWJVg33CxRewOXxXajyiCUTDwWCYc+kubDVx56axPpNzcS0qdS5+VQxWw6wo8QtpQJ2IqpBN2e91SrQwe4Eoo5YDfuwn/WfRD/0RU4n2D1SEmXWGBgvuyf7R/Sr0ugExC1wkjnuQRvNMdntHGVxuA/GcLqYDepwmp9O6EWwfrbbuXf+Pslg0FPp55y8UszKrozOrgUVTMQedbVuspKn8IySgAO9T0SHeNSxn1zWE2nKtGIzRFIqRazIETZt+9f5C3io4BYv9RLKeJBLLvfHX6AMrpYOFCGitV0fIouC4WC6+jDhiSVQHS5AgVq1vcKIyV0wjX+2ZyyY0942fe5bwfyS3MzdGxRcWJVyb7xc9Puy5NQdhp9vwGifX5VwPtp7NO5wY3g0qHOQjBriNW9WXuCujwTY1m+EFq6t211+acTVmrs/Fc9qere9nEkKVa2ovRiOiTF/vPQ+bsKSYtlqHh0umCjXhZZcYpl7Lm8WXG22d1hgnt/dWxeOks4bjhSO2ZBa3pg3zaG9qS/jwFNQaKQwvf3DdFuDSBv/73WKhahLX+9forTp98kUDgdlwiGMXWXVZAYjjelaetFPIekfjzrtFOG6rYjgHymL7BCV2KTJrXeHO1E/IMNJIzoTLsQ/HtYEDRzkmakU51ryZccso6i7jHtNcFsLJ0IquWj1YZohHaKHNx5TsV7LEoTmVNRVxzSbLM0gsXYGGRGJg7ZCMNUceEry7P4xsOzsoXBbF3ZXmClRpozb4IJmP4tcprk37T72A52Jg8q5N+0+9gOdiYPKuTftPvYDnYmDyrk38PAdlzeMweVcm/afOp1F7SX+2Pi/Wip1nvVfVdzpbYiLl1zOHp//7XXf55Vyb9p9GNIMGW3vF4ktaXnAkRKuTftPvX/Eln7bVr/ZH26YCU3OhJWYCWNTqWdHnEq5N+0+9fiz2WdWzUspE+ldugy75BB66a95lmAVujUsPORNEDr8nNvtUUJRle8+7BuVWy3YTiwVOqbAJdTp1FVEl32hV+nAuA7Lm8ZgdE+fP5Oigtm7ZVp3Gu8nKS3sm+oXe6XooQq0Wau3pIAfZL5ha/z9izj30kubxmDyqSiXXcdu7Jq2sBVNvgVjTnlXJv2n4GFA99LINt9kTAc6msdrIA1KDkAWOrKr4i0WCv67Lm8Zg8rzMnwrnr8m6ff0F9ZRzsTB5VybsLWCslfj0Kl6/zyrk37T6umNuN/XXW/aMc7EweVcnBB8Y//ISzDfgWxMHlXJv2n4lvSsQtPvYDnYmDyrk37T72A52Jg8q5N+0+9gOdiYPKuTftPvYDnYmDyrk37T72A52Jg8q5N+0+9gOdiYPKuTftPvYDnYmDyrk37T72A52Jg65ocBlelF+weHqvFhRtarT+4RntPgu5tn7vct8s5q4lqjoGkq+Ax5NhyTl1rT72A52Jg6+R25+oyP9/o4eX+fMBJvYa49FfdGmsCc0oaXIPG5SJN6bA1c6v/HPDIotxnBjqTQwSVcm/afewHWgoj5YnN+0+9gOdiYPKuTftPvYDnYmDyrk37TXXw9pQiPAgpnUrHQoxbZB3WgBJI69s4+WmagSmQcJaJ4fezB6slG1PzkeX2c4B5YtSh8k7w9NE8vcPv/T39BJLXvZ2D4h01GNKn3sBzsTDDb2SVdC0MMFRK7GnZc3jMC29eU+AttWWcvKVQnXbxsw/OGPdXAvXEfXb0hqNhkX0CuGuJYBBg14hahCpWB+r6P8D6R50B2YjMwvfIsnAcgY3tnXgZxeghc4QfzqVpNIGeg1FoCT7CyXcslIPz1rDeuUopb0wbFRJoAE4YqVsyngI+Xyl1zWJBA6czuL7Clomlq37WtxIoXe0SbBPxIBq2iNL8IR9zZ8kG8gmKWUcIhDRv27sys6SxqaK1lp33H2pfDrsAWqLnZO8PVhsUTrVxwNo4hMzYKmBNozDQLQ0A1EA0fzAn5mzfj+YF/v+ojLj7hWGb62A3m8ewsJize0Wy5u49ylQnwFAPAkEd4JkRicPLaCwc1psXRAKNChYQhR+eVcMVXZ3roSPsubxmDyrk34qyd2vW+QBmivijWdoIAQmzZgOyHqbexBpNdJ99uJ27ynOmqNARcDEJDQ76rJFtsWMbgTaj4XySIWQ1sfsTEBdZNdsoF8VHqVSpoZhx/eBk1v0Et9f0cEI7Rhirl6Jcq2+uNjnUP0XJoBYO4ph9p+Gv9yhH4VypzJHB3ru0NGu1BWQ5FEYu6ZUL/07im/sTqBSDaYy4+h27nTBJWHtNXSGubr56WNMEDwk21Ibe2K9Ct1DO0Kkcr2IMHVoiyU8aqm6QX++rHXfOvzPV3lPNgOxoHtm65UfPK3tR3Eg1Py+6Yr1aSaifMqk7A3++jCHe2moHHpw9ILA8bzak5rDubUomhDmQhFV3aMnOD3lg6Vo58eIHaMwDWoYSafq94rTY60sPBEvaIo5pPb4Mn/DCKDEX5WxpoHX/zStJRj5DlVCLCZfXS+i2Wvlu5SK7dVoz4s1nvTK0LwnJmHeQxlPvTGdd++JFAkkvBKBzh4v/J7415UPvEDIdk/+z+AQA1SFhVbrEsgAQFBAKXgQHC6Qx6qsItgzxipTwR3wOgzzX1cXMISyVUUQt2KKFUTQeVcnBBBj2Q/L7WeVcm/afev82PgMJXTVvCHaI0UvdL73uksuyVUvcj0r99c2g7HtAN27bhM+md/XqDs+hsFGpT7TSvbWGRw3+OchTlcXxAiCYkN+03RzaqfrYR4C2+AUTOjzYOuEgXfKaBBn5f0rM70nsg/nEzoLyEYIaFvmBE/92O25CYsTB6J5fCrk4IHiWXNh2It4zAyuqyacQzWCIZ24sFYZkPPUnFI5BOOPGKyLrtmXp/H4MVKxpc3+Qcj80Jhchpl4qfK0PbZugZMBHMq2TB8BjnYlfl38czfDNDhOTBiKNPyHTeGgwE+6qZzEUzpLXJ4OjWZCczNFIbhKtGqaZ2eX0xLoFAAMQ/Jg8q5Nxtwsd3ZYJ9uQycXO+uZGDev7N0FnlffvoLXjPEN2mo926guGB+BWHiE2p64WsxOcZkdYsZdUI8A+WgvFGperU2JpDII6uHsxM7VpnZ7f4Fv/upLD6AZeEjFWfkzWX5C1Fx8cLiHsRePExnPKpqHjJ7w46pn+W766OhxToXVNNjnxhsnnESP2MomGfRQgDGphLC5d8uBLBo6LGDgooqoMOkQlD/IpLLm7UptjjplgMorIXDukc3zDJeDpxKOuIhVSbqwVBpFBjqdlUqV0sKWm3tPYnagHMj36LUNVGloc0fQwL7RtUhBUq24keHeNtSCsWVCCgPXEJZDgzvmvrnPSFKAK6OStfuCRhFD3V9kzB8Mr980w9gxYI792vrriKqdrCIIlQG2bUBV8BBKHMu2o13+eifj2Ljf20WsQqjJLnIHm9lzdrEhtXn3LJ1HK4GQ+OE8s3jMHlXJv2nyip5nk1FoP7IBiyzqXOaYR3HlUkYPMxumK6tzUhBVfOFsDbZp7SE0KAxpjhEn3sBzsTB5VynS9grmUcDsubxmDyrkpmRHe13JSCt6mvLmtGF63Yg84lg0zc57lpjozPCYm9OwqxrZ3Y9LC7Ip89bTl8rUBB44qGpfJ+g8v8j3i5/SvG+v+Bx8XJZ0OwEyR1teRQ0Eg8Tl2KBE54iid7sTByG21MtgB4A2maP61Gu2aaVpUJu2/4+xBuy7DELsiltQTR3KP7CyKppOVdm65vwwlBTOQLmkVFz5vzti9PmqWeyL7Z3LtUXfQ40dWCfnSVx1svlX0h8qjgUJ6Sl9dfZd2G0VGLG1eqnPPPgCYwV9ftOon9r/hvGisYujBjcchaJGC250aU6cm8VK+HK8BrQSxsb/qhfaUAU0n+/w7QLA2J4g3dhWkNdxmvg/W3evcpURJ7MkmvmQBEQUqeSvOr6tnqq7ZefDjSn0hR4ETdh/7dn6FrJMc1fmV5SWlyEnDqrt68vMhw2LT0YUCkcSXT8yaFmiMc0LyS232RHRWKq2Z7y03pEq9RTwSEF8/g1ku6Cv+DOYwbDnhF9cV/B1wq+mgWEvfx3Xie9x4mNA5JcHwHZc14/mxY8wGw1XocPqnlTNffLMErxpvdJo9+RG5NbIE1uU0i1UpSGREdZ6WMukDjQiSN/Qe0Tx02SZ786U8JKem2zJJWwURJw0ni4lS3EjABUEE3hQOw5kZqO0DwgULIAd0ffPxm4n8kfO6JYmgoqgKGFhh+13+H28PpuGyzph+nWHV4SQsHQf9yPeJN/GWEkqjFb082vhn7/f+hOODma4pDZFt8RuUAnAA+9JdXyv1zRBKNphC9sJqK6TeZjTS1HVPmqh8U8D6hihFXLF8tRfF1HsFdEpstcm/cUzEtrZc3jRUAOaDyrkm9Kx/wRXJ7TJkarHMbXFSN9Ebi6szyohnHH7ek8LL0UPULVs5bUqwCTIZMLK9H7CeuBJJg2XVyHE3xWkOzrsQ/PKuSihtanv6H4mFbKHMvMVRSaO3RB+L1UF9SdvHyZE3zQ0lcASx1L6tl1n+AeOgaMVcQpleehcE5IkymnXFSf5ZvGYHValL4jD5aFTx3h5NhcZ4O2B80WDUvmDqUfquvlru4npNw8cyTz23J2IrxRBdXS0hnr5zvafZZbJN+0+9f89Yh9msD+heSqk+TU21a53Ih+66kTFUD3aV2sMMDOBbuhF1zFH04iHpV01y8dD+Ks47Z7Lm8ZgS05Z+Du2oE3xkTDgOm/vQCvdfN2TpSieBY5A5KQLUqxrzBLI0PQYAnbt28SivY6Lfm5F5d81iDhHYA1HxT61TzMtzTAT1uMgoJma81oqnINkWK1BDClxADprPWwdDm7+z1Zblg52JYtdwFUacZa6ZeiPxfQrj2M+bolXRHWVMpf0IFDjWGVacOtl0cpS7zjR3bqovd0brnHYZ1nlW/FsXDhkIxA8B5kFCwyCg7LmoOnZop8Ysgsu7J53pAJLFXIci4YT/cBVWZJzAtDLxf9X5ATeMm0dl9SpdTdsZVysRzsTB5Vyb9p9/qY491PlXJv2n3sBzsOG/JzIVwH4coMLQ6K9Sn9/nkjQ517TG955qQq80udwZ56Rh44gO4QpYhHb9mnIuNPvAc9+bcp/3M02kjSLzuOKmbiO8LGpWPMwxBU0BC3+Awn9u+U4dYSw/v2WRZk4hUe/xU5mIrS/zjXkOw7wjnSahINm3Z5q9uYCAe9Tq75UWVBJyW1Km3ftBtlAJ6ikcnGukB/yCdjfQV5qWv8JUAyO3ZgTm6l3iaCAMiKpldbnKIZ6QVKVCipJj0CmMk7horH2TXiFZiQLyLAnJs/F82DBOAlkXGFC9hg8j0ZnqmM5JiyZbV5YXXlg7ElfEggcW0NDZz6WwJ54cZecMuGI9i2mlV79lR4/3YtDx622ZD9dvA2gN0wePQT7dIJNtaHeeX38O6jnZRlkQixJhHlT/yui7bvNhIuFh/f6Mv//hsTlBYRkdhDhyEWuWqV9TJgfqN4RB7pmrSE9z8r8kikjqxwQNznclUF30q6GIJHJaY7HVe6otMtg16e1eXIs7l47NSTIvHaAiq2bZ+vXopgbmFitnRtvfpDsM+IZX64MtDbOeD5XcL8M+Fd7yTyGzY2TG01Zc3jMIhR95ZdSD7Rrb3TlTjOoeUeHEWcWNyOVI2U42053YSH/Ul4JSKHnuWC/ZP0K9e17oIkOEpcl8Zg9X7ivfHuZjRDNwKkW9jRvjundN7BfP7GcgBVHrbI22iiv5jPBGiIUoa3E63uG2dCawjmS+V5JasjJ+4XOsk374hchga+nbi273gNnZDrC93RnbyYz1V2N4AkVEvaSFzweVugcReCG7YCUUuGAYSE1bN/EY42xTMSp+0OkW1uokg9fuiP7fXX4qDyzeSxxvlUTlCqJyPlXJv2n3sBzsTB5VybvdxYDnYmDrmhwHP2ww2a7vxkPLbXixLnD0bhKVIFuVjOflIDzEQI5MezJPc5JcovyktJ7LVMo628WVuWIzPPfwUvy+dxulzIAsh6MDVnQw+0iYHJqilwV9Qvaq6dzf6a1tvk4uaGV2EhODTcUA25d9NraBec/pqzXa/8XqtgGRrtzbwaFBRCrxQ2c7DY2Fq42RgvqZuAKphoEf7IB+iVYxln+jjI4Q9feJwoO9p6WF4kWQvkNY/UxUFqX+JLFiFQ9hEXuvKomhEXvWDXf55Vyb9p97Ac7EweVcm/afewHOxMHlXJv2n3rUSzglQAJ+sB1Lh5EEIV3xXrZgq9JV7HdXEfY9JyyfnbB0LjN5KciAnlO8sm9j2HYK+TpJtd/iahAq30GDdCfNMn7B5r74VHBLwrIxlLEoWTIa0U1vCr6PdJQFRJ2hEerFvclXxEM00fc3EviX7D/L10S0QK1JurzxqUOw3Ck8mUFITpItpvsP/0LfxSFJhp4Y2NQIqM6KMjW348qi1t9ti0rb3kk+FSG+q17Ss8WU1N5Zy1W9RNHUdK21TvVRrFnIFO9XlqhHMivIrnVpFqmaOIwjFgrC0Z6CBWqt/vXfqYlB7y4LabKVcTTSfZb3jb3+eRiKvn26pEjflwp2kgr1Mgr32tv/NEQYsnbarcBeNh9uqRIxhPMT/D6VxfyxzHbpKtlf1J7i23Nfx4I0ElTCpwpi4Wkxph4/pXdghoMmkWbxmDyxYPonl8LFiFUTQeVcm2FD2oLnid+SkMXBJUbL9Q/Ob1K6hCLIg3YGY5owEni4AuMQDf3BTJUv/pkxtWyf+QHUt49JeT5n/fL1MFi/XaO2nMo7Meeu4yv/SgNJdk0bkzDL6ZD0Jrmd8R7hFa+yINOj4pcR8jmeRYM1q4QOIC7OKUVLf+zEC1kVa7BzTGNYJhoOjUwipDMBVBYpIV+AS9StAJ+VSQa3zWbFTLGH4Oe/FoEZf99kwAt0jyXMC++mKYpO9MPP8vQYHPdVflX8u3/4lBzFLrl3oP16VTDwEmiwEOXI2yhi8rDZCRMQ9gfPdK3k5Itb9dCiFnSutT2PmQIJN/psLAH3qSvJmZQRhL2LxAzJLSblt88Xk60EsTAGheudAsAdGj2BrSsqLoYvxnhyf9ONcpuMtFIQphMGxliV5RIuSmDMM65BsFLD09/SPq8LzY5bvfoJaA/1p7OWi/TqoryCgNY3i8DuXmHy7qtbqa58legKi07xNdBjlZwdbjU8HBj/T2hZxaKmfWhMlFUU60p19OtY4YfPXUbI2ncBHehfqSBFgWheypwGFQ2z5LGozBdho7g5MCnl5P/wB+zDMlB8ffcry0C7Y3U9DBM0jDE8CiYmcjKAVIyRNywP6qTMNy1774yQWEXR0C0E1vmdgWhFomGLyf18gt2FgGHgam1lZjrEAc4EP/Vn5LLoHqmJ9JP+mcrttr2uk9n/gl8So7UhLvXx9I7cY2+UutyDPGA7ggDu3B8J9a8NMp3L8O7g5Ofhirni3zOOIymxuRWruJ6DmGG0FZSnaK5x+pOgcUtD7odQwbrzPuKOo4ViYDjhXhxfw+cfqToEjMLiRWZ8NpWAraitxSEe+Uma9hZRxt3edl9kYBF8Qfj4IoOn1Zf2QkuW9lI38XNEunwGbVk4z89XXw7ycIJ84Y1rU4tCkynpx2K220RBsi6i8LNzZbsdWOxJKRnIEAyXxTbQZN6jvirxYXOEq+K3JtfRoC5mvlbiXR3i4ufQPVNCJmxjSh3gqDw5jo+LSmxxxSX6tru5Qn9m975lmvqmfgynvipRlP1vmSrdA3/cCYmQ889/ff/ivGw3wkx4yHQvTU85e5MaMuoFjjYhh35CwOgRM2wk4rHhflrJzboTgXS/0pRUC2kD0E4ijWlOW7hQMSJsELDnHXcwjiSdKZcrSeN9ksrWXVPOcPooQweOW2Ri5lYL2sfbCNy3ZiLwDwEUBlIVEP4IGbSC4YxzGKWdvcygtkWSioC4NW2g2j2QLQusi9ith/wRBeIp79WOi97v18DZZ4fVTquxD4O/Zr9PC2OMQRG3PqYdW5uOTUJfZc3SsiCOB5EddMdddsXZGVkiPnJPm2DYArqvq1Arc34ehHQMwjSQCh5TTgbByv7TUkPQCsB/wd+FqYUVwMAMPg305yFMX5wyPS71AACXSyBEwNxlw7egUQGBQlYaKFlj/uAOdiYPKuTftNXaqlgfkcHDaQSu0Rm03IOdFZ9b2d+x8HlXJv2mg5ey77kKpJvb+HBfjI90dhC3a+6H7tUMsfx+/g6vLCnA4EpNMlftmIfTiJVJwdcv11R4OkCkPn5zfzWgE9Z8KVRwmRUPlx0KCxLYJFqb3WuAub4fnCSFQgOSbnRT6mr9zwbv3WxMHlXAGLyZqpxcSS9oRbFmxNejr3XVtI8GwYYd3MF4PBiRmpDhbeahZn+rj9siKvJCnMvs5kXbcFXFVfTQkPkS+0+fklWneHL1MG3DS8w1cHf4NCb4Xqb2Pw/obQYj/wRysUP/Nxm669FYdkpVImddYSnYySHJAHmenUW/iK0acPdN6oXkhOv6xcxdNN9fHXnoloBYJNUlvxyvb+o4FT6I/ALudstqCkOETsX+jLWZPVHWptEC8eVRa0+95jeWW+kjXeRBW0nmG1ev1rn+lJrqQ3ku3BdaA69/FUkcyt3QLKL+LycKdKcJohyEmaBUJHu1AboN/1PJKuANf5Ztfixavcmjivd+x1cV4K/b2U8AX0Sy4WpyPC7Qj0rppg/fXGNoRXelGRuivfKQXUmMj6xPStYrTRb/P8jbfnUhpzMTJMglvS57X5yd8EhPyEeuHAx6QycsBu6dqz0hvfpRcDTAvhW2DdjYWBmiWJPxbAKn4H2icRod+0Y52JgQXcJ8jBXjT1uWbRk4GmG9xn372QC6H4yszxdEScfuANDGx7SqzKSmpD7+bX3BpmlXCRCURcZQS9dj1jD0XCsjybwWOt0yuvsxgZuaC27Hs8TdOnWrTBABJ3HmQHT9MsUkKMV27JoA8yskv1mjUxQLbsbGpGe8E0UYbBIQ16kQuGlFV92Ph76EEZ5dOnRf65qaGyu0qCdixJBXfnYrO1vPgwgF5BgqEAUv6hL0Kj0f0+uGArqSbhQSz4tWW594QifQRgnY9hquszWmb/W6uxuGkDC0gxZsGDtvDUXy8/DY/cmvl5Xss3zds5SMS1gmgW+DB79jI8/r4qnxJfNRnDQckIRCZ2hLoM6jTtPOuWGRZ6Mz7YthoYe7zSb6/ipdaFlElKsoxONujW0dXUJ+viPpeP9/XMZEh1eq2dO7jXQ0/PeNo47r8FMRJ9FGyG4Msd81WXC1v3bCJDNGuopNsCiB5euvJUaWPALlqRdW6nGfIH9wOKKi9ESuypIxiphgUQIRwwku8C6ZEQK8CjZMTFBPId002QGGmByQKV75qpaOrHOJAmrjO7jyVNdP1l207SDV+nwLdY83gmQ5b+Kff/7cfrl/P3r1/7urKDNrxwPWliHM18nbXf8VMk+hUL07bMwDK/80dEAMw0a7wXjm6mgrGHI+VmmHIj+VwoccrW9r0nNRDw4QCF6lkflTj5hBPNzfJYM/LU99IZR8n5p3XoorwHYbLl3hPFEHBMuoKk3QybCeaZraw2UmJjMtcLBpRpworMoLYxJVGnhHkYQ/8LCGROqGFSij4INLjtjS5S72T9L7vvpCJza2bxygGXbtLnzKgp3eEBM9bDfKfWjuXjr2Jc4Qe+SHtAlWVz5Qj6/MaNg3DWwPTUZul//UHZzPOZ2nC0qqpSgFDBc+NjrprFnME5jkeL4k0Ab5bqWTwKW5Z107z4c3ZfhGoFL6nFtFMpcLE+GBsYfvMWamfptmpMOoS1OsgJfjq00XsqcgDfX1qgBepjCHkCgUevAwM9RjcaEYyXkLzWkwt/Z5GRr+cUIX+EAYKVKPNvMeQ2aA44LnaZ4p4Rx+MPD5J79nBMRBobyIYgHjJ3FoV9zHFsgHza7/Op4VJOyLLg24oDUyHOu/SRRVMxR77MyDy9cdXjGXWcEIzMjBJ/qelZj7LJrjtgizwdMvSUO3gFc5l2ZJaHrTew7TCshi19k8/JXmG5Ckz3VhC4/+hUk5c0Y0mwFmbSCg7umgI5+08MtkETvWSNPnIIjUsCPFvwiZgWSNRRzYAOPNYmSilXwMkDGtWRpO85oBHYyhC1krrQo/NlyUcp0tiL4dZ28JrlJNc5UGIgBWtLbQkieEN3xwDjbsXc7XRhnAlb4U4aUV3MGG9x6v+gzdyogcKGujQEkEN6Whp1Y0gvmYtUL3v/PtRbgQ8RaCEU1V2p2jMV03/zID6XH4OJEdYNQXWuYOFuaZ3K1AbC/X62MkshcZK0F9kxFBiYeSThRoYwQDtMq9TW2Yur9rZteFW8rQyf1FZeQ7ZDKBVydzXJyVl9yTRa58Uq+br0mp5Yovbu9/3yL2BVo8BsEQu1hydmIihUuOCyIqWA7vNvlCo67Zb2D2SL1ALnjJ6dk08+Dg4B6BixWVIwbV+ns9lzeMwPo58YDxt5BE1hGiuChj5zDGE0GXWQHu3NTouByWFFiO5NUKYWfwVE5axeCA7YL8qJY4FbluC/Js/xLS3oFrolFsMweVb3CWVgZiH92BMgeqsdEORKXdILmNvAiMBixumYAIUsq67K5fa4vgPd8Vjnpt7vR8MC9Z6HPs4lXYblHoAeskeXQ8p9QbNgydtE7BDqV3+eVcm5VWqTleCUGNwhLsOfIFHKaa1QtdwBH29aHnuAF4hVyWbE94z7chpDgp7qcDxoRSjreGYPKuTggtVqGzuHiWdPJv2n3sBzEIN6U8bhQ+uidbmoWbzgt5yg9cVGfzTQwoAuTHhVLt23rrasHgC8ishdrDkWgQJ5gFa/Xy0HSo1FUcNLmzeNcvuDOKVtjAm4+dF2goHwDlEVtbVIAFoQBf8/qKfGh9/j0WWcdZV/a3cXjqi8hGEZljPzp16Zh3CpV8BfsgaQHymerpWNRBYHrmHuB33OVDR9r8m/kx+jB1tZG4KcOo7w1E0AEnnl1mJtpIxYRr2UQIAi4ZYmhNC/wgzjSMpOAyNwnonmZQ/y7pIwTf+JrEZrAjAx6oKmi33gJts0KI+QdgZJbi1BLIxgdHo58BxubCF6f03Ysq12UYCO7JLsZXeqYA3JTD+QQOLkj93fTiu3n/M4dFbxjoRhogsatkRUrZHYwaoplkA8W4w36NYiv/xeVwCkhcM2gph0rASqAThlfmIdynPxJFsHdQymQ9yFD3Q+3XruAgRIxTfVH1yNp8Y+SpCosHlW+C2aAuLNujlQKA9lQVnnnvtnSAhExdi6e6ARQPimpfH/bYZTnjlHuAS9jPY8kvBTm2aDaoT4GU5EdO64CfjR4/OqQJ9gVQPP4g95C6aIV95XzJhKtj3VTgyhPHLENiEgcRJaQLAmGJyq2FFi1FXqcTT3F3K5r+xrk6Zz5GfYbmVzvLjeXBw4Q59mrjw57DhxNETo7ZDu2WmolYHTuGdCzZ7xJimHjR/gBk6fsO0mxCoUudIkNypseF5PgFSib7Snf3cjubR1UkOZd0o6Po6B8VwKwtsrngBMgkyrFsVDDi70BHpGfUf3Xrt5Y61EMnER03RHafWoEKoTofGNVKwiRGSBkc4HmBe3+kLsAVx6HRistpTQ33Vq2wsfaP2sb9Ox5HGJoih9KF32IVLBp0Xl8IH6AMSQPC6l8oCuWtWAvl7ZieOW5kZUuu7lyqVhi4gUsoHwXsCHbo4jraMMPvdKYKwrHG+VTUW1HN8iDgCYPSAAMzHxf1BV+Qe8UEzgMMldlARN961WImEVgtCqMRQkqVHbI/ZquOziYuI9f2PVfAhQJK4YXuzR0pFbszwUFGYC3eA26j5MbepRldScEu4WHswAD3l73lUBjdInmBCR8YDZ98DN49zwxrfnjVI4xzR3iPR9Cwwdnw7+JXt04e1YvQa5X3mJvQ7tB9l7yGbDI7xdFlZtOSFQM2yvYtUy17baKtbkcmBn+XNw4EG3Br11fx6nfTIbyV94DdVbf4NkUC3KHgGGyEXXKCZdxQgkpqPab2HvOGucuiyug9QFwFZxKPQVMCW1yz2XN/vZujrxtfWNyCSkujf55VynS9gOdiYPKuTftPvYDnYmDyrk37T72A52Jg8q5N+0+9gOdiYPKuTftPvYDnYmDyrk37T72A5tdAQrJX5EoBlwH/XX5mzhc3ktD/rr8zZ5cKyV+RJ/zsIJKuTftPvYDnYmDyrwmjDyzeMwUB27Nc2czsB2XN813jnlXJt3zXZhDQPm7eEQxDEtITH40oGlVLk37twBWMweVxz4U7Bv8ksBmfv++U5O5oq/Z8SzPXElFQYZVd4X+uy54jIPg8q7hmDUFf3eRxRCI+5kaAJXEDZzaN7xoAUPRgk05Za4K13+edS8JnsudoTvKpGSaAUFahBGVcft9xBlwdYK6VmjEu/0Eld8s9l3v7Ijlrz/DGfPr0GzmDph22j7M9W6Q4nC6Kf6qcimNnGOdkHxHv2n4M2cD0xdkPTzDCrG2hG1LYaKsVoMWiDzB2JUkq5Oh92372AmYxXrQ6OOZUF2zRHMFwcAiFuY4iw8EJ/l8HlXhNGHlm8fAHCe5s4k6A3MpKGQwefx6jDHOCjfJmWy5vIHxHv2n1QTTKllwrELT72D+QSVcm35VKIBLayRDLXJv2oBWQPgdVOxGWIrHzgpTL5qdrd6Lo5ogjJ7UZfEYX2OSSOY1FF0XkdGTgj7Bw3L0ohsL9+OcjJXeK68HaziRtncBWj4o6jXuMry+GRcBWhqN9DJXZwBWQPglK7DsqYQme1XZXmClXQQVznAWXj1hmBfM3+6d+TdLR4w9+lJdR8IL6Nuq2nupAq5OAsvHrDMEwdGaj9LktXUpRwOy8etNaeWKT7Zls8gSKxUKfS5a5p2C+nsz3xPRmeIp1IJF0/MVZZnl7R4SZSE2HwFnIQSfUEWK63i7UEjRft0kSHYB4PQINnBzjfcCP1kVhZb++7fP8J5nN4RuVJpkH4HY5jNEqJj7j+BXeWLhAdSqZcEY3CcqfWW3RWPkjiQNq4ziBQ1ayqp3y9rO9XI5jmd1faNXdr3NxoCl2leC520acaD9Z/XRXHyqUbWwJTWCA//PzTDoIt7VQ0fPEZB6wRWHU0qClXHWbWoYDcfqu1KFo9zK1oUZVo7+8MeOyBbhWykeuaNDnvPkJVL5rW3zhwoUL6pdIVvUzS1M+A9r4sHObhbZe/DAGs7aL/HYzswBhedeeOoLg3RKnLIpLAJnRMbM88Td7Z5Q77ksDaJAKyB6mLXrilnwWpSlQojhwBCp4Rs3JbgV3iZPICuHHNL5JHZCpa8L6+MJ3BivRIY8lHUu8MczLr41hx+nWBdeR6o4gc7/jkFTB/HwFeddiuCQ+xXbdEngLKW3fnwMCXuUi5qHOFYBdYEaVH0gddvIHxHRYRzAhEBW/WYNH+XkTmdOMGY2cqD7t022uIP4yZlIs1kZ2kB8jWf2OkQ+wUsrHOtYiuX0IcHN1njHVKMEMkp0jgV3xwAcIjrDaoBH7Ylw6U7FKh3/aNXdMO7gHJJ9ejP3dvppv4HmdoC2OnUlml+S2HaViIgDkwuD9eDVlSQmA8DYNJ0wKzsg+I5U8oUKF/MO0Ekkgs7qS90rQhcOeHw+d07RdX1L7BuXUfBIHxHR8bSXlyQaUtQhF0IauS3acVnkL5SyH6Bgwm7AW12pffT7ry1b7Lq4km2Vle74VMgfEfBWJxu1t5hRrONJUZvTSUVgGsHr7SdxvUb0GO/lLwVB2Z2UEqbc8FOQ8SkYr7oJZsaA0seyWFwPfBMmIYrUyMH9Q+VBBxdeDUJyudJFQbq94JnJb+jcGRrISJzEwNpUQfDu1+MCHBnkitpUpGneGhjjIlnEIadE//XYgWPRth6Mx56CCtfZEEWQprIHrw5Q/b83Gemw36M6b5IeQCsgfB5VXMsL2/ZLWSW8wFfkvx/CiuFetW/f2QHBU09l813jnlXJwPkEE6u3jMHnUvCZ7Lm8Zg8q5N+0+9ukEChwD/rr8zZ5cKyV+RKAYaBksaq/EPfSXWOzeQ2SuHZvH6Qtpzw51rm6XBXjLB1GrzCWe7UY1nGl0uCswDOhbokK79NUfV9obyrk37T8dN2Q7KQDn4JpNzCD6b5tY5Uk4m2hF65KNaDWk2sUUxzvp40yKs9DpESRewfOMm3kTLJXtULh1kGBq7pBivXSm4CbIzzJrhUlJaWfteJi6Mc7F7En3tgxGDGy+0+9gOdiZwBMHm/Rlm6+oRjfZPgvQWXScGROc9qrHpWJWkKHmFutV5EG4WMETWQ2Q2agQGRRhMRJq2FGEejv8D7hu4nm4wd1l0G4kGIhGn2AnLgx2+Sc08MeAdsNFeug+r71NYIngvmyASVfL4VQM6jTDpqOw90bkTYnxBkg2DPXy2lJYNDpeZMOHpecELnf+Xn/NyqC3MWx2JntE6GlJgpEZZuTVijEQKynrxEghy/+dgBzkZRLJI663hc7LL4IVEEisiQCvLm8ZjG8TCI5eZIERgVXYd3IYsbTzJx+0JEf7P3L/cGoHB4qZlR5/LisOw8ei8GiPDQV76YNdG3BoQd1TN8abrQjraGEKU9dM/a67KSmKAoHNiImbKxwh0ULPOzQHrF9gETB9os0QcapI04ui5TKPmClXQKoAL3M0PQc4vNCNwtNaz0qR+ApB2XN40R8mO1UmJjytrUufqVA0p7kub2ILpdy+tvqw9t0g11AOpqp/0Ggx7OcD9Kn098adt3uAJNIlKXTHhT5fu29s3RMAN9MppoKylRdB2itebMD+n/Y2aw6jeSZthQFciIBSTBUxecoMEHKVY+J/W25jYKhEPlO5nIcpmb20Ik1PhjfuYt8vM3gi4AUMuXDRgYiJcbPb8V8JrlsDgvSAhGj83VQ+Qf/P6yAxRcxKYMdrM/kiPe3MIWvQnt9+ghRvxMGFhA/TlINIkv82UDyz7igyGD/l7z6+aPYcg5cKnUywehVyOsHBo1y/inoBQHyfxChiD5qniysA9cPFSgmD0T8PaoyzdfUIxvsnwX4oB0CIc3AO9ISNA9jtW+uZkGC1zGzBwzweO1kM6mNRdIRcYsJ46Aqa+DxJvVEzCAleQ1wL9p9NIaC2XPZczdYOGeos6WIE7RLdPYPlQCsekP83ondS54+SCaO1gQB8pgUH2WLN6wlFJM73SPPrMGOdrOwE2cbg8Isp00saC3M9E8m/gBh5cfiOWOn+/xsW7jIJ+Jwx0w0SsorcDomgL7SXYmu9t9T/N+jTj655bzK7ybWxBhXLylkoJCx5uTGBNtNAyERiNFov43DKGyq0VQ8mO1UmCH4UB/ejWm75iGhq4ZOnY0/1cn/hY/IKchFBPdpzHhwDQiiblOegkeSSUjlzd5lvDGyu8kJGXk2eMNtlvrxJVp97Ac1eVQW5nlXJwYz72A52JgkCIwKrYzhWSvyJQDLgP+uvgWZeDnDBIKyV+RKAZcB/11+ZR4bflEglXJv2n3sBzsTB2qMs3YgNiVlLrbm3ZxBzh8JXqLitzPxb7tTOemLrITCWkd+RBZLV4FDTqBVBgcjhs/iUeOi62tsYtOD8Er5C212XN4u3WY65OAXW/Ssldlr7Igkkdm8ftVHcQ9c4H6UyoA2S5sHvMGXAf9dfmbPK00a7yjgvfiDJDQWjv0l+dUWOqyrFoEGRfDHk94OsEbMxayjBXDQ+6VPI7rfN3iRrnkIoh4LKfy6hpVj2ZUwEfnzbOCNbKdE/Ep7Xwc4T4WjwovHoPR5sMQMOy5rH013ZwACnSap4SfLXKgGwHhG/YcC6x2byGyQW5WrL9p9M3bioxNhr8n42R0ulwVl9yJn8HLFZVrt4MbAtWq/35LIZwQuuK/bXSVgOkusdm8hslauJ6N9ngNbCCHQUwcvvyJQDLgP+uvzNnlft/uOn1fEoBlwH/XX5mzuQHJUyGh/11+Zs8uFZK/IlAHNB5OONobPLhWSvyJQDLgPy4f7bEweVcm/afewHOxMHlXJv2n3sBzsTB5Vyb9p97Ac7EweVcm/afewHOxMHlXJv2n3sBzsTB5Vyb9p97Ac7EweVcm/afewHOxMHlXJv2n3sBzsTB5Vyb9p97Ac7EweVcm7ERFcKESAO9dQiQB3rqESAO9dQiQB3jaXKUsr967n6OMXVoy4r5uvSnSYT1qtRlxKS95gIavJPcwK+IxMHlXJv2n3sB1ZfLSCXE/K00Dggd2Jg8qsc5TfsxXEAiFCDNMIGWe/VAudMyN2PJzjhvI2F0bGOmMJjBcEw1OSiSJqca1ouaXeULlIQZoGoCeGs4/G8SNPR55Vmzc1ryBlTun8X05VVxDyey4lhq9bLm8ZuXA66ZE+w10RoLrqtWqAfyO0+fd+Rd1NOs2V7crs8WKBuY7TF7C7wULfk+gvG8ZHtMDiVR8eSt/GfI0xrfjMiasOIWzziTD5QhUkQg+cdGz69vRMXRdZbIRjR4op+NNZyGlDoBvGKimGU+lbFIhJYOUCAE2XCJ9GDWGoqgZ52lbhNZDdiPoJqYzl0P+RDDTHjL5iUMagFu0yvL2cyYXLjnaFevpFFFdSxvRyHMZHwrB3cqEbsvEqmdR9X/nk7euCwTzJShjUAt2naIcc9nxvDxqLOsP432q7ilotlBixIAgIezqhXck2X79If3Xl5661xAuL/GJqzd54yoeIA7J+BGK7Ir1BDVA+Tjl7ug7frUOiWdbGozJ9YfELFiKZ2P35nNfN5nvf96lYxlV3SFBpVEy+eCecr2As8mTaMBvN4zG/R4XvcCAM97AbU6/n0Bb+ArpEBjGiYl5yerM6zGSwg06jXa5viZQM5eFG4nxiknuldCnh4Grt0NG0hCMIxAKsk3Sao+MX4u3+MTVyUrvKPRP55SDgdTM0DVUk0gvyJ8EEfIiSs9/9TlllZ+aDV6vcjggT68NJY09XqEwh6a9YsIGGTYzQxW3s1nazPju5jF17i0EZVzqTSVYmLosymh9/Zk0dCkbOtHL1jG5YkT4gNb8B3cz98ZTKa2JIMlSZV36mpeUXTAJyvrUP4+iUKk4q2evP3z/OVc1uLmdNC9nbqQojAOdiqUDFgTqVOHozn0BR9/z7cwDdfrtmdZRvnw6ch3w0EdO5cX7vKsFGQe1wAR6Sc9RPyXWvnYwtLZPgJ/udGYWNd5tR+BkBaDrz1GdHmVJ7nFkjT0eeVZvFna1d9+T7GdgqRJJ+9cX0cQgXsRiuIeT2Wn3aJ4JHAdAwKZZjp0kZkep5HutE8EaVQzwzTbJcpW6Xjr1lV5IgtNMS2AAKmK4HWn3bp6zq/Z5IH2rmzlwib7JF/hax1Jt9xcZrbvSdlPsVMq67/O1mfHdzFsMwiL3WjeH55Vwt3yyEyJPvYDnYmDyrk35GmNb8dixTBzJYhdQiQB3rqESAO9dDgsSQd1PP5QAVMVwKWVvskMHM0qqbZkhAH/XXsYgUrA4UUpB4f2+NtW8CEDtGAl838xt3HqKtTdQ7SGCKqGHDes+z+jooD6+u2GHxr1A1S7sf4rLSZPGzqT14aOAcDLjZWkTbxR0KTJrL9jBRmgsgM7g3WV8khm5mfHd0MyGA3M/3j+kCKH5frVnJYUYu3CjGbml193DaA+vsyA8kXdy4U68WS5argLxzZOtbFIzNKLD2PXZr8l1MAwR8a5N9+AIgPpnYg4riHktW3m935I2MYE2FczNq6el4g1fTGnAMx1dzMxjQhB8C1PsIBSy6fz30ob1qolt4amsEHwRhOKJuo4UBkrFDmf+6Yqyco5GMOrNp7OOe2vSQLPNpwCL+nqP00Ad66hEgDvXUIj+16x+bhIw+843hmMweVcnJWX3Il1jcgkpLpbdp97Qb/PKuTftPvYDnYmDyrk37T72A52Jg8q5Sgoq68c/qQ2SuHZvIbJXDs3kNkrh2bySY11jcgkpLpcFZfciXWNyCSkujf55Vyb9p97Ac7EweVcm/afewHOxMHlXJv2n3sBzsTB5Vyb9p97Ac7EweVcACR4TftPvYDnYmDyre96oXu8vPeXm7SWNljV2pjL5xQateMMBuoKr6i0xrUCDq7THoIC7wNWfYWAw5Sz2XN4zB5VyUoRZ2tiOSKJN6DDVKPSVdlbVf64t3fzr8WFk/13AJ1ysOTxRD9m+fwAwQX8Tkuv88q5N+0+9gS7M9m/tIOdiYPKuTftNVLzdK5d4hnYmDyrk37T71/pn+shyn3oNXGHsedw4JKtdPQ5100HlXJv2n3sBzsTdL6TejftPvYDnYmDyrktxscNlB/q3ZglnsubxmDyrgYzkDkPdXPL34flja/Vz6cK40LWXXPZICXBwOy5vGYPKo/XzWY6Ln02QI8mmiuuA9RuhIAsIIFfACEUOm4vwbA7V8HlXJv2n3nffuE0Y/sc91/Bj3BO99p97Ac7EweieTftPvYDnYmDyrk37T72A52Jg8q5N+0+9gOZpVeC2Il20c/HYyUiYPKuTftPvYDnYlajr5u5l3MGMBSe0SfewHOxMHlXJv2oIJyzeMweVcm/afewGiykgHiEzH22shyOxX4qBpjIm4wrrqevCdYhD/72A52Jg8q5OCCBiwxAw7Lm8Zg8q5N+xogzFwH/LCCpiXsGEgFMVBAqv6E+gV7MofBSd/7GgO9wfMLv88q5N+0+9gOdiiQ5K/PKuTftPvYDnYmDyrk37T72A52Jg8q5N+0+9gOdiYPKuTftPvWoPf2Z/rYoSdod+C3t5CP7cNhnXZ+7QUFp97Ac7EweVcndrmUfKuTftPvYDnYmDyPz2DkU8yPW8OsvlYEey5vGYPKuCJcCT+pKTNJ71JUCRGzdp7joHhEHtVNqbWTPmkE8qU0RS7GnN7H/jUepWQ1zXtWUSvfy4myjDxlK3fa3wLfDxlcOzz7T72A5l3K5fu1jNKFaJX4hEyO9a4ZvGYPKuSmuWCD4c/A6teXVFbIFEYmDyrk37T72A5mIfPvhqT8FJGuAs9AvIICBzsTB5Vyb9p9CFAuwER0t/gV1rhj+VtgdEfsi5Yg+a+Dyrk37T72A56JMKHqCno1ZvGYPKuTftPvYDnYmkE+9gOdiYPKofoJI6SxS65Py0bz8zcJD2OnypZXPvm55aelEyvdCGXI3/afewGwSsUosNvTrjO5LJkhMzlfIgTGmI9ymRDo+1GV+ukCaN12ulW/MzSQJzDqqvMElVDtk0TtqKWKmUh3kzDCvisG7Lm8lMwsIe0cmNWqiHUqU4Sx7/PKuTftPvYDnYmDyrk37T72A52Jg8q5N+0+9gOdhvHXpVrKGCDgQq7wjUXIbJJVDsba6SXGNrzlqjIc3Ffr3o77I+7rZp65bkoDfS33lfG0++8l/N+rIX5BmM0FutFg3tVM+ghLmXDmma38Na4agdrPQCgosDIoa0KVf8gQGxh1P/L/Tkld9M3Apx7btVz9tdJV/Kuggsa3GyVw7N5AJX5bsGxFY+XIy+eZ6c2vwmtJuQSUl0uCWwU92r1subxmDrDS6SJPWSeANHBipZ7Lm8Zg8q5N+IAabVB+GZcAc9yQSqs4GjH6W8yh7/PKuTftPvX+yjIDBnM+QifBIPw0Bmouj3LMHlXJv2n3sBqzpnkhWyo+Mx7Ik+9gOdiYPKuTftPv9MTB5Vyb9p97Ac7EweVcm/afewHOxMHlXJv2n3sBzsTB5Vyb9p97Ac7EweVcm/afewHOxMHlXJv2n3sBzsTB5Vyb9p97Ac7EweVcm/afewHOxMHlXJv2n3sBzsTB5Vyb9ksEj6IMhoTXoHXHIoMjOhcFNTRSTR+DNB5u9bj6gqi8UUIPucbzLFEaA303h7Zh6Ygju+wKYpdtB2qVsx3fhEypnxYGtOba/NFGJBIFufmiFH+VEkuIhHItDCS5SskLQdBtTZNzxoJ2yx0XI884ajrbhbzQgNpC5KgfJHOC+a1jQ/YDnYmDyxOb9/gV5c3jMHlXJv2n3sBzsTB5Vyb9p97Ac7EweVcm/afewHOxMHlTgAA/v5a2QIBAJgQm/ZsbOoWVHuVnlyBvJ6YQhKzfgg5pICF7C6galo/IXxAocBV3J52pbbQZaeStwS16aoJY+W+cfKbCaqAG/l3earSmO/FNXLy+Ym37ecivy8ozTXy4Yt3m7EV8KVKTidmPW6slLnSf4VR4vloxUEnR9MfzCgiHjgDl/Xqgqhs7RnqRkSx+kfcZQf6go2h++bMoPWipe8Ri0YzoU8B1T7dYEXTOXtiInVZJBN/uMvQ9KAW5+m9x8UrMbibNSZ5SGh1WL81i4vH2SKjN3ortJa058cYny+sp9YLRlUtrpOlmx4OZqfaThdqFQ9IrwJD+/MznITGMD0PZ7r29rUTZP8d2B+fpUlbDkUfcKCt3dfSsR3sDXBNsS0JuZwqKpuvM3jGTfVmzfruOMMNXvACXI45BhwJGAXqUrDS6T+PFS6kiWtOoRJyjB4QwS/NmkFncs7Z3M5hpSLFha+w/iHr6B0/1ef2Z+HG6XgF0CNtWpKqLHFZGVppGMUyawuZ60FvPAmvYGbI3I4SPW0GFVNOUj0vIPVdfsVQ6nKrP6LyxNQYf1g0xuLs23EeyPDWlOqWwJL9cCO167brSnRN1M2x9yLKynlVVRMDVjMa8i52IYfP+66tchH134llUEnIvNqcWGMA7GOMIlHVNzfCaKjJqtY0nQ48HUeAw15hxBekLoJmpkI9rHD3pC5t3hfMTcG4VGzwKwt6z6WRsWE2pwFfSu2/hMkMscVZADKSzp1WAgVs3LnV1sjzf/4iJqEqsOO8w8jzRh12h28lBkaabfhCoYw1VZXf7/AhA/HbxCgB4cYZVm2AdGLvr2Fnn1dS+AoTWRNFSnj6h4oj99zPOYDTAVR2WiwOyygBO8HZGiTTHF0UQUUxZt5IOucEhgmUrJj2qjgVec8NHV7xTBCDePmOv+2Tp+LP6QgRrG1YNAVvCYhnSITefR6IEl+NXhtGe5QTkY/R8A8/c5/gJOWyzDEEO6tXSTrAvEza/ZZ8MUXwiMaFBs5TS6crj4poWpM84ruYv1WnutkkWB/uuqKtNSB6O57gdTwFTTjwRBVurgac8icJjyQKSuVPmOh4+5bU0ywvcxKZUFdtP90M/lgYijanhFbO5oHf27CrgYgCvlnHY7WbNms5prKMXQHtqt6WILjjIEqby9ldfdRrG87bgYwzypSvPrCEFQflTPZj6TzZGb+OURDqU01zNfTKobyW4zHx0yF4gyNvSRSjrPEJ0YLohgRF1CPqLk4+86ElmQGau8C5BWpIZELHjzYcIyJZPkKmuvddPjYrGC4wRcvNoxFBdCHUCu3R4sPhq48bB9dCTTIYXmQSrk8RSXza35G9JefueBevoVxMYoD/IYfV0eqqB9NFwkapdYwSaVeQLXjtkrIoNKIpD+ScV8I3CNO/Wv3gAAAABDEcIIfwVNsgrOOWjPyJ3utNsvDOhFBFVspDm0JIvE7vcsht5zew3LvV1K4YFRmtxMBAs96TZzShQN/dfSoOdLCQ0tQcZQYmVvaXx93mxT5geLxqFr7brX5e+C4jmUdVJPunY1oRruHup6xrST1EkoLe+/Zaf2CTXQlvxAv92GG9o/JDXKqtms47gYPE78tSB+VU9lSWdDV81G6R4qLl+hwONT7d7vhe6IqJTKgxxEdiH/EYrd2RrkjhAwqLENTQ1cCO2SwDwSn4x9JgJNs81yzWw+zuUt2utyErbjytgrFl6Or4grHU4Cas2hwk9r7AHVKuHfcYU5E3Ggo9+zXTjcZEFrfocKD8Htz/90w28UuqGijAxxUgMcVZfSipEhpna2V3hOJB0fY4N2xChI/K/JLrGmaWN0izviKwuw2WCYNHiVyLcbyr36OR6/lYIQNDX9L5G2xte2rC1LH0jJ8OM9HIOqVTsP0JlKa2vEmFVdS8/GrdIP77o1pl/lqHES+68fJKzWDTkNQqg+u6g2Lsp3IounAOzjbKTRsKBqdslHuNo2UDkLgo4mXh7AG4+imQ2+Xj4HxySQ1kqM41iUdL2/In4XRJS5nYwldKKHVnsjHLbfGZsO31OhMBaJvtzpOl1+iwkcVoFYl/X7XICDx4Lb9aIudmK9cZB0L7004xjsrCMH6vEileu6BLEzuVjzMDsSdNisUB169LbDalfilUfPQHgMrI5Wcpn7MEgEpXGelQLWO2uXafDK01FBrUGG7OAZ9ww/YYFdXpdcyCoo198iiBCp7Ak0F4cn7rIHur0mNf69ZvxcvqjwaWZG37KgmMUZYVyY+qN+kYZ4PeBVvmIGrn6CpXzmCWw05G67LO7fIbxjEke7fVvvFWK9Jrj0NiL8r1IS6PsqnYq1lPxcG4xGgLHuXNS0NNcvcb7l85KNFwUUFAp6od2uq3feyRr5CVyyfK9bbRT1A0g2gd+ioJuvvFM4kIDdvVsQ2AuCL7fgeLSeZOv+C1ShiCy3YDQR4CN+qdxjB4pCURr3F7WZmGgNS/noLU1yc6wUPVYRkNIUy8L1rRkgedJJBAIHwBgfBi7Maz8HHF/NFO+PcnfM3H7PA3+HMZWFGfw6cixY9ndcXU1uyCcP6PMtQ50iFG+5xWtR7d2U0go0ZalO0BCzqh5/TNyB4IYa42eS05bVx8Q7rZWxEZCq//aTt5YMxFnBQmZ99I+u7NU7yIQtQ9VTTL5fbxBxH1Fj3hccVNdcgIN0IV92hKTtxRmy+pN3/n8Ft+XFT626235VzWXXGFORNxoKPfs15dBRM5Ju7AU3YDHr7oHHO4gIGmTeQaweK9LALCNqeOWe8YD+rfiOb8q5rbjpDXIDeO8qWjFjAX0p+zLed/z73KrAMNMyv4KooAChT6pv4fQhDrmaU7dd4Z38Bs/xhsll1IJyMI833m8+GYjc145RlvvpdlQR5M15mUHAIqj1FcrBxCF3wetWmwqWTkwgGwdhaATKCix6JwhGh8i1D3D8bOALcgiFQ66mBboMoIlDVQhmrXszfCTcNCbwvYPnN+t1d7Nxs3Dk/6Rc3WsqzejLUPTMeqw4WwJHctKBvmNSFE7aAHMYE7BhiYwSF/T5UPjKSAzACXFHR2TJUeOk7oYUZzmZ+0pg5QV2DKat8ISWl2Kueotl5T1Jcg3OzcH7S/UevJ6tqDcTrf3Y+J158Uc+cH/pLokxA7+53Ya+OVRBp2awDE628a+EINYkLwjtR4Ddg94LZzeeALEvxCw3mLCMtKx7IhiHOhg70usFOaf8dYBIbh21B1BrFicMqdjs7WFPkRsnWbmN4YJmAGjqGqXBDzpMwzj/ABe+wlCXpFQOB8Ba1Wzcl0nKZwQ8+/TAtdqpglKbHi1b3WJWfifaPAoZt6yIw9tPq9WBixKO+ywghp34KCIFuLC12C7YUBOjDr3sYTGw3DUDa5D8XWQFBwxK0kHjrIjMAEVawfcWhoqiAm7A1Sf6fXnFDf3Jq8XFGw/swf7ei8zy8tzv/hvupDH8hfpT/djuJyZr9/HB9gJVS+0B7SxD1G8KGHZem2vtLvYZxKDC03cSM38rI4Hp2o4etnNluMQBhOaWn3kZfCj1ZfkVqIKyrn3+Tnz6BUmeAlYF917VF2CrnC6UiScElktZ5lDQ13YEtwwVQG+MeI2QLBb2pb/cX8h1yBl0cI5uQDlTbLmAzpubpQfhmF9Jeqgsnjey55NXYlrvmoZHD2qNJrAujFoP/YSPCJ9P3T560yfi8MvW7+wEj1kcQcNe3XeupOTbaPVoIicnX6BwRoJbLIadK6VYBXTET8oP/gxrREbLRz40znj8Xy9bCFpgPw6l/SVBJB9ddAoBpQgA/TPiWykBtg1gY4NaxCVcnNOPrw4TYgnJx71J+xNSvonmzmJjawzhDapOmqmUJcqxo3flGcKWfDbmJSzqKEz6HDl7i5oxjbkK1RwCh7/87tVWKZml3h/50cKgahtk0iSrJ/bd5EamCk+lTf6yecWFJ3jYz8mANKwKZONyu7joQbv1ZzvLbQWtKRQA9znyxqSJHhLp3+z8zg6vehCJMjSKeYl/tkZq41ECeg+IYmEvHDw4KJS0vSWIWKG6nJOHo3CHyNK9Aageen4UUxauqxY1mMiAFMC9pvPyoN2IoolGJy+Wbns4GHeo5taXFTlMew7QUXRKnihXjWge1TMKqf6P2N4JLRzu48iMhADiHzWQVi7rtQUFHDs3sTBCl6s9cWvi1wMgFu7uXLx/pYSETKgspG1otlNYJNeRYMQhtGw+up//dN8mKvQUGw4/nK6lc5tNzrkok/KdkX3mqKY+TGMqLl/lmwpZARZ6bO8aXjA7mpv4qEcMJZUq4CY2h4shhCNKymo1KAfFIONfyEeipaKQGK53IL3KZMD/TJjoB2vQPlbuL7qi8FqIz45kevI8bGFBR87d/N8pvqLzGgf413QJcp1YQFqqNoiVWWsksey9xLZKpV7Z8uLInOpJW6IDwy7ZcSFMzC4TCwWYg4IRhTZFicgO/DXIALNp4CUnRO8AYWBZLjXLIhRd5XdqqLo6g37gVQA2BPOSlHYw0paG3CSM1sldq4PHQcdKFCkQ9fy9ZKdcAUft9lEoxzcV5+r9Y37f4vIMykPtX0iNJzwmUIMwxULDj4A57pbmyM67ffPiTzde6TNnEchHE515Q2Pvs5Wc1Hoa8aAR2ADvgbdfmSezR6XG43iw7beHyUnS1dWRNQGSSBQPhNLLwBD0TXP/WZ2n7qXH1l7wRc/VRl36s9wDYsI7G2csRvx4TgH3Ro22bn4iHHkLbh5kPL9t/UA0iJDjAKLh5tC+//u+eV0tS7mQIw6aX5PB+EpIBeKAetqgb/kPUGytlsbG5ijDPWyIFxjCR5BL6Y2FFLiLpl/+NcEgNii9TiKXXqCbIzZUUR8Lir+qom7YbJzg2EuBaCEoqHIKthKR6cDZLcNbbvfrOX3hnmd5sXpbQYyp11htq0LNQimjSIFL3ccEURFpqyXYhqvzdifppuT+JD8RkMqGisES4cwoBMvYYPtuPgUReZFQHA+UyGjmNoXqjOByUgBBwOOrUNlmCvkD2WPROD5YJCYbXEOto0XH76rQ8kvcBaS/d4Doc6I+2dR0jsvSLlu/3aqDZSR0RrjB6jK1Ul4g3Enmz2dCuyB76naAI4XcW/JiFw6D2+hdB6PCx5mYYWM5nrDlIu7RmcmnTjIImJhhduB+RU9b9RwbPCMg1dsOR4nvegao2bcmqKp5+2GE4LwKbN466y6CtrMUNncXT01uLKwIx4G+X/3KvnCynRO8PhrjH14dIgdTDhO2jSNgM4J7Zs2JheSo1gzfM5v0ZypY/tp9psMrHMUwrRh+QzDyTo9kKECUc41hm9aXswJU7nsEbQDXX8iM5egNYUjO+Rk+RawBlL9RCHog2w+mSveeoikzHl0U+IN12i9dYhVlolV/B4E2ifnTQf0Aca3e7vfInv4VmVgDdeU3shQzfn3+TnYvDfTrri3scD60NZfLi8QzP+Zanu6p0TU3UQ4NZdry5noTfRKNk1x2U+zmpnuIrjsu+qLkvhdJZ0TcWnhKyLHYwY6COg4U12njl7caosC4s6ZxRGQY+hr6QO9jatVXTeY17ndL50yjnLIfWZeBrny1kYLrtCWX+9f9aQp9ALJUYvuAydYbtKN7DMEO12TA7Ng+hXRhEJjxXwbBK1uEQO5TVV1DcMRbi4Dpgbf/VOOAARxUBMWtKoaPxXfeJtq5kbQEJba08MmsjYKjPN3akuSH3fAAbTw0C4YfAkneBPdgsut5MjBpbhaey1VledDnGdavQlmvuKk32nPfcCN0f/rQ+Z0j64LiovNwGGixsF7uqqPT9ljb3i/VrhQPt00JTdf7HLgQZo0YJBqeKoAZgop1OkyzXd6tfGMGNOGJbvvN7zfc9ZkVnwVVEiTcCotd6jqg/nRY5YP+SV9BEU4mttFuFrWPETeKi3f6vRsfyPJRLlbglziKZYnISjgh/TwiMlcSe2cQnDjjL/bKf4Z0TMHyxF0+f/sRA6ORviN3KMteArd4XCt1+rqhR02x//UDyS5qNo16OnR+HAxip/ANOitXLuGzjfNVMnjx8AOh74Mz9iUIbUUXhXBMxusfUx2I36ZrVdvHbsCHYEurMERq5T2n4LaBx14uaIj7YKNGYEMFPxKxCIbzQ2rmAFMI6QH/wSlcwgTw8jZC+/FK9QyXnJTx7SoJSOKanOJlvajP/gYfhnBSpCBCjbFLImTgzLJYmx24RBIT20l2l6Iyx3aI5Fe5DJpNBgk5VHMj+KoBnrAsjbyYKRcQKhhcAGw9hHbjjsIyzDKDUGJnhxVQ9YFSQenSy2cdivZpbfaDkEXhembEwoJPEDatNQovDJ0eMMftA3btbUYXG4P0wN2vs47nMlPvgyr+P1G9kqRAOmK04uovF+9sVvNzg4SjbbfLJOq4/pHW8Qk4pcTk496k/YmpGdsNzg4O0OSeOm11BMKzeY8dzjuhTut8tBCrZUugXan/VxwEpcRGn4b5u5Se3kwHuECkoXknaB5MELHO51PIHYUlZjyv8PVN6XInhP0mgNiz0vkj0h038lQd7WruTgWujrZ+H40ur8C1tPNIChwAltlPgpjxd3DsgUuC1DU+i/7z9JqlMy0yMIvWYLOA2KJaIkeCN4Uk8AV3Denc/9gd6CSb9xPJkvUZ3eBdPMtSV87R42wx+YE13qyECzg/dbBb2/4LjJ9sNzg4JXCdus2ofG41Rav1JUHspxoQY3dAZVCfSLteHCNvZ6Ie+nFhSd42igmw6EYDueALE6NmAB65aEvAhDeHIOFXMBoTf3EDH/BdundcoAkbZ36IU7kwY8amiB7MdoHLoSPn/0FL75vowR9F6JFJnxRVhmqzu8UOVXr5erRILqiPNjfyQvp8DOM4E9/DJDr6iO+HvIuS2xjE/D7qduq/1oNJZ86xgyq/IPB43/ANOi8N90vhEEIGpk5B/HdWeY5U2lkSPWAzlNw+Ak6UO4EaFWKP8dihj3IkkdEM1XUTACF0bsKztb8wSrD1tIs/OGCtXM28BjzZOBItXAmJBAyKzXzVGTp84RhUPC7unbRSODY7zmGIz0oJc5/hcDo1nVADW/+iQI0h+sjwdrHazAoXTKfdcTwkJMn2fr1TjfL4gqUFuu850L8lB/moHXOWd/EZ9waqjkJmCJ8Jg1OFs2Nk2b2ij15eurgvf3xCHdgbwikxNUAxGzJDA+rV+RONNeQyjbYoSD//7EZIkfAoVFXqYtETJ6bBjhhCXGVYJvIXSMs3UE5jsoA26IHH+hPJAVWC+DD0xhLY303pSJihAoVdbm2IL5Ej+nj/ybRlBIZ4dWNuSelBQu+FOaHe12Dq8LJkjP+Pn9fZ0L+2QmaN9qkgTT97Zdmmxcnw9NwqtFX0v7IjGdogqA2ryT5b9R2WBGACk/USXg1Kk2Y6dpWNxHxckEAJnFZwwvZt8RDQ9BsgfwGD9X/ON9RfKzfH0/+myey7UJPj8ziVUFE0jFO3iDOJ/i7bIQQIe1V0MUS5Mp27V3lC0+jIrWA7ArXJW+0P0qbCOvYT+FUbrtxRJ39cRKx27bjrpnHeN8EgP88i4Nv3eFWiOz/60BuqMbstro6gG8b/yj1PQKO3p5miw8Jo7N+kOEFt2/BxFDjvghtFoslqq/K1BVRm5QOsn2EiH52qaJuND4OkiqYEUKFSSVkGYsEFSQTOhY4Lhu+y4iPQrtEhDqzYjhzs+wO2P4cID8kqXenwBZ0yHPb2eeybaLvndVDQm1/6JJ9wg8VPXjGk7NH/AWGzaXBoOmruwuwnWf4iDDwe42g7B+mzcussto6P7YNK2ZAvyJhfkdFPfYLJvZHliDinWp1u4J7bnUwYBvuJCv5xPVtcJAj8TTjRJRRAo3v7NvDdLl8khAu8T75peZwd7dFlb9FRNBsD3ik6nFaxL83583w1ZTViw5qsyaUCYNK67JkLbaGMYt16r1f/dX/5DOmWM9tvt2vU83Y85yVQadqWyx0CbGKKCdBSZ0UBQBinJfFa/EsqQqucicCcgX3M/0XRhPOXJ3mIhaMkvC03NisLIfH4rBvY67Msz6Y0k3LJ05XAEscgRk8wjrBY8tug1gdT3R+WAZhOXSUUmoLJzLLwu9k8y+XMZmkcG570+BFp9Ju46NCrATcE+IWmN0cWbb3DywPkjxwOCsD/t/gpDZnNq9vD4UzPpYo+Ayt5d0C40fBpGNPpzdWAwInUm8VRBowmWdA/CIZ2CYKVbiAUrpEvjTBSeVpFb9GCMc712HRI0NNiq4TEe+1YoEDzIXFY7gwBDMzATSZUzTljLFu5IZ0n9L3skdI8/GjHBgjaHdEECZt9gIDBGa+rE+BNYzaB4kOvnZY/CBSMl0VtLfqb6nJll8WXEu9POs9XCRnYsSVFZzkia0pM5uTSRPF57Ht37XqDprsQ/1zcFeSJc0v5lhegm6HQv9nyOGZVvIsEW38SPPB0UQz8U12jkGj6f8lLOvHeXauQuRk0uUmLMpEMEqtRdgc12OPkoQ+vfrA/1wNJ936oYbRLT7yMENtFCXy4UwcNIGh4gbissOpd6qw4HZAk1jpAWESMrhVZ8ZxQiM0D5nTX6uj9ipDd3QAZ3Td3XE/vBCDIiIJenEENuA0jBBJccNQ5A7lTHtYXxVzIovmoULVEAey4CB/aAp0XXh2P8Zte/8Z1fOnLnFm2BJbIyQ99nRlih9dajyLMUuTfswAmG5m87WL8TrvdZ/20n9LDcec3FcVqml8OieuQfcICad4LGdwInL1CxB748yiyWEw2neJkV86cucVH9hlIS/pKb/bnb/V6+cqNiJLwPI58GnhJa5ZBWc1aCNXKn1H/mTGiSkXSH3FSb8goG5Nx+21tTMW8BFr3JLyiTU4BT1LmAGzi7hInx+SOJT07MuFZJ7MQy2VC41Uo/KLgz7oRQh7jnAWOkm1+uzWmJ9xPg95dAepTtVtC/kg9phv7cFqNlIvVo1SwTZh/yBn3es68RRMZwLPok0Kkvmfarb/w5aH+U2up2CooOC+V+FJRFfWZOZAcaOdUzSugZBsc71oxrgSKo/BYjFP49ZaK1gE06Y6zvHoU3Tg7S+N6tteVhMzH0wFG9XyY8T7EA8siMpopu2I0lq1K+7GlOHe9DYhrEkqSkLFHSpVSpTX6o4OGguATD/qVyzkUDoL3bClaM57q6I/fQxIalwiHaGtGr/+5ulANVI0JtFvhL684QeJR/6aj5B/fBxMlfAxDImsx5scEBl2k03c1dVixrMZEAJ1S9kQmpyV6cK51GtwYtQMLuOID+rSERWFfsBw3vP2VKOYlhMQu6nyzIKNX8Y1BU4txYrSyEWNG7Ma3RbB+manhGhDqmpMfWK8V/XsBznf/ttxLzWxb2Wjp1mLRStlSz7ZtGSKV/3XXhiMbmh+oUn3UT3sbOQUH7/Yk72MWmX+byCS+SWV6J84KJf6TEkPdHnkmGwYHSzRYJsdnEK//eex5Oey/GtJ8ZfyEiCmHUNq2A1PeuFvjlzYwVpJ05oZ955G3WtWjBodFjzTkTWgmB2NDpJzdMMgs37y7HLmAIuOASjYPVggbyKYL+uRF/Kxy3IAFMwRVI3X+S4cqGfO0KXbrTr9jDUCSHNKpmtEbDs2yzPz/9LD453RUIJuvWaCKEM1pPHzxUoHza1ZNERXM+E3wiWioIbyO44a2+ULfduHyX2gDQ0DtqqSESzJhYyost48ZxlOIEHYBoT1CBi8KNa5sImVPAkbka8s89H1S1py9+4r6VhidFdSmMqtrT22x/zIhbj7A240opHnPb4uS6/hNJ53RaR5D20jdIi42MSdYZwdgiT3x8TUszFlRFuYqko4MzzKUD/aKr5rtAPAz8Lsr/KKwdWGCdapjaMtg8RnItdZ8HsNxykv1Zb9nWn14+3fuvoC+ErjQ2if/S5WNXhJMQp8vYbjpV3eYMFdaSmX/kgqkeXX7MNiPksGMBkGeU/A0naeatkG3j++Z7rSgpn3a0eF5lRFA9TqAYA1L5m5ymidGPrCIaWODjq1VyupAcBFnY59ACJUDcyS3x3qn0tL4TYf+W9ga+08OyIIWXJCTaEHgQFHAKq2ZshFQVcCxFm8x+oJzuzCm8psqzewa16+PEUPcA+tSaGBD3a6bv/qCrsAVaNti2qNAUAExno9cTjl2ZXVswCAeLI+ndIaLDwQ1T/k4+vGBdWJsT68wMLjGWBS3Ayi4saGQi0nO/w26u8sd3n/0VhxB+tL4gCxGvFHRgamarX1cmwLomeksBBsN6mbGb2weifaQiBRLyVfWb5+4PX0RPK+2ciUC7evNOe4s447zL6wVkwH4V+2rtnes5gqdu3cuSuZLvipyXz80D7PC6XKjpUM9ZBqEEPx+pel5zWDsPEk/YwuvbXYFTrDIEqkvoN72aH5HkrwGd3u5OjyTho7qaz73ip9eqcb4LiiiIH9QtVO6e9qvpWGOr8Ry0RY9o4XGQ+PTDqhJKdIoaMSC3kwqqtt7ZlKXqz1xbFUoNOnbQmmxcnw9Kn0MfW09w6Hwwd4VaI7Y7VTY9B4VFCSOj+wv74owHsHCjo48cIZ+Tc9zWGbIFbbQnTPmHPwPAoe8DEpHDT7a1i48XyCFBR6nLT3oqQOeoEV1YAMFqHVU5p2y46eiGXGDtkhSWaGPTXZeNVFV8v+2zJ5PfgyR0J3MGLwxnI7R4Sp86nF4K9qbM6OTjGQpJ9sPOuqkM4gkPWHd7D6f56PBiZsG2Ffx5DGioTP6RMfDc5NLY2yy0JPJ0alkFCYLN1PE8oXYbfJqZEBv+Dyd0WjiwIgECrxDC/Oig6COxo29lEC3YLqdoLS7IgPABwhkw2WPLCFTOyV2ZBGC0dmeqmaVFErKAyMUB/ctwXe9TxFNUMCUMJshiQS53R+WAYfrcgXyZYwI0iUemtumXc6DeADus2yXWVREIeC5iCK1n7ogCQMrq4uB+nP6IibzcGhjrQeXoyTkRPXC8CAGlJJLX3PPDixn3elcKtWgWwzqNRLdrwoJfg4D0RmaY2CovzcYJhiBansisYJlw4ByMeY4PsyJeioM2NBY3jCBVplc/xC0OXLvT9LcCzdzm7dVdJCj/olLAsUKtWgWw91RgS5lIY3gkscZk8X6Z0kBK3R+h5udKA2/75bzCp5vVQVZviKQdbI34l2RY/EoC5wNIFgBAICqATDyjdxxbcDBGGqKC6LAdKaWYDhGl1Il3TOQ549FDnlt0Gxl+dNrIM/cq9oLsJ5En8KQ4Y4/sf6ycWOPe6kLQx/Og3ZW5AbI5fU+UajrfyAUGwebrOSjezh5bzTnEEM7bfyOWkMBqOta0ggayF/a9ah6dSmXgr3INFgqRI1XolLrYMy5Nm8kM/m4vT1se8nQc5uEMejQaxP3NzzLWrmVt4WW/HBunxvgkB1XWdeI0Img5hSEKhfKA6GZUAjPArkr20S1MvM7WUzB5/wCvyDWISRJbI9CL971LCvEewCGReQSlWWqDqLzxIr7cMWrKY2WaJ5x5Cnq1IkJnnTe952ciynEDj98fF3jt9HjZfU9qKmyarA1ImtKFv5NbvBFzy1NgmGzdq6LklrKX3bNzEzBb96+INXzbv32+qIxcg5BgxmxJXFhtXLD9/tbsmR4EUNfrw+zrDBiDkN3CVhB5IOn3mC7yvwqdJWQLeRhmORr92uZl/XqUQ/oFSy+4Z0g77f8Cq+4p5U37EOTkjZ1oCclNAseF4Jwjg4IgJyU0Cx4Xgmxv1hVN3NxBGUlj01Gujh974ZFpF15YDL8b4JAeRuGHZeP9C8doJlg9be1HrbVpaKXp5LOKqvIlgUoyAzCeuGpyvbd+xlPhgQRJ17Md+lwD2BBpkJNpnQpVuuBv/bwqyeg5TIqvCwkQquK6kA+x+5tbFo/X1fWlJ4yJwiAmblRkx1aaF0kuSd1Gq5D3ss1YALmiTPSUOAmcn+3Rq6t3bY+34nr7Cl6EvYHFoxRVIcZuzGOSe+N9o6Mm6h8+NgJh1UNpkQQJzMSuBHlozkrlzoliEQZiU+5yVEXrBJOEMIYtmOrCN3RgVX8xzYcxisljGnENMk5hMY4XeBQ2xNJ80xdkqlFoBMtNBaPTolyAqGu5Gwx1RCwex/4YQqXE9azN5dTq9ilEO4OHUbG3RQoXnOtqkK7aGsdJ7JDVfWkoTgbOlmedh47OVTG8a5AoCXflpjqORRk6TlTrobgjOVX2FdXOSEAf5jvvWKi0hZMVO6WLxM6MxO4brl/EVeUL8BLRY3uytI4BM+1+WFZO5qAySGVeZY9ztw4Mp7klmCnHt+VyioeWwJ1KmEmFuV4j3qphWn7xJwPlueCxA+v/e4oMp1rFEPLQWQyNHR+aKpWhstjlKa2CbtxRKHpU9uKI7UxCgDqHVOtw5Jm/lHqoHU4acjGq0aDojS9Aur9AotlYWaCDaGLqmFC9uR7eDEAIgFZl+JjIGfZrSL2qryIbXcgSeL6EydwhNC7/ebZBIIfS0e/QVFqKl0Oa7E/Rsf21ASMpv1BxjzimNMH+0OFppARDZLOCmALqyZPOdpYsI+wB7/UExzqBl9ob64AKzx12Z1iWUgjaoAIn4e/uNodqGoFiWvDOiozV/g2nTorZDbtHvJe+NiJ5i3ov8plMaDJTnHIzIZvntlkD8ZIumFO3XrGfyWuTxT4VW5pg28K0JO2X7VFjNLeEPjE+VqRlMiv1MQetWkNjeI8W46ZPAVHJ67Bp9RdFFmIFPsY+r+eA1+6AKhPCXaEPM5r6N/PiSZfs4hnsCJOOTLk+Ty0rDhgDWKF9zVBf32HvaGfIB22Ia5wp2Xzw7UmxRCJBq6KAPzjnQ2mmbtutPznRlq6A08gznnM653eeJIDRP0H6GJTKhO7c+/7o8u2okAAC0ra/91YmErNWvyg4LGM9KQcSx8j0QYGfxJnuIbikacwt4CDLoc+xbobkOdH4TTgKJkxplmwOCat68Jnu0kzub0uZTN1coZ/zNtikAx3Bb+xRkkuwvYwDRoYmrJ8CuP8loyKSJTleaRchkqxuU5A++Hs/VhF0ItmOoTwhu/0kwVMyZUubbSgzWDRc5Y38+5WqHP9rX7+RIaoBo5p7/avWzAsW/RtKiHJcBQfrbKaOC4yLArjlDyb5oYCNCns4jqvkShTnCo8XF4VK9Fq3MdYzJq6mJYvcca4uA8OTa7swLOiER2qpz5Wp6OBtnYH7JrVgO6KR86s6cEHs16UyaXh9WPsdSGQsPEVsg1tLz10SapD/UaT9g2J9guoPPHllJM3/gOWChvRdVH3keDx4HwyxwcgYYXXOMHP+8j/3ScvG5k89uB4mi4eGUuxVro3lD7hB+w03rhaZtp9Lm4GFZQdDk+ZPtXDAA2ScqR2DquBkB/ZCcXLDhWhsVMHawsb1biwqgzIPGldWSs0cF4pScwG20skABlY6uj8V8x+VDLFWicxXHZfj8aT26ClQRYQ6Vrl57YzNcGYmJVo32McdzbT+Z+VU1gtw7bNqb/J57CJ+v48DmM0IVsuaMow7eQdy0GtqYKE1xMkp+UrlKqhGAKsf4kGlc5NZoyhXABxjzVE9eQmo84Oq72J35H1hBePkVomMx4tTUGLieFg9lkQYwvi5P4Qix4ggVlqMg53243dSJ9HDizQ9P6nowcENF0QzicMulWhUcIDeYtVAXzJnBTFYDB0Iu0FPzWaY5Wlep7yYm6NNcXNHOO4nNjvj4dQWrrygb5XMGDejjVLyl5wvBarLVxn4XAeCK9nxm5UxwBvygwWIC20bOkNc3n8OXT31rlkkqkrJu2PkKoLplKSs1CLfTS0h6H5y/qysMcR5emVZlIMm8dk+O3SVI2aTQ5NdE8MWIChKs8jWkMqRdxAr4zqAvCxhZyXPCY45JWoMnl53UunWsEOlsvUOs4OlqUQwC9jmXSBe5FXIV4FxhTpQp3SwFgZcjzR9OBUnXKm7DJIymOPAOTGKBzXTG2PJqe5LeIHLiLS8Bqy/A7woKgmY3NxStL2B7VaHKj3DAUOa8lhM8MT70lCxsDLF/2oTj916GFO1goViLgIm6zSUT1IvkLxAGj7tdU6/UV8FqsMCJvnSjWSVRSiOCf+e6PUiV+ekgE1i/0WRffl7tgH3o5kYx4TfNNRPL4fZkLeOmtQhD+AswF+CrHFeCCQoylfN1iOjqiKWrSuQgnacJiuV4AzRirMKWPe44hDAGYn/CDrzP4nLbVwYWLcMSlT/wQPaheT3BBi03Ik5zlleN7MrIs/fDgNfjIw5VUh6Ja05gRI892NtES441pB9Jx4XcCOlI0JOBYMb7Io6WBpi+TABJtVSULJLTDZiIT/Zt+Zp4om5kuOKOg8yZkD/MMYvrLgDs0bBFkddN9LpSdgcPQTHNEWO3Ni3YqhLMi/yTvgJgAKMAAAAAAAA8ukMN0H7TCGa+6JQ169yi3M5C0Iv1K2nTBtftFKrf+GNtXgVgdkhptWtw2LHkH3lDBb6FYf+2cltBJcnShbI14FZSRAaeol1I4EaKVW/8Kh1dvuUaiDrtZqv52rPGWe3GRm9nhYSbW2QW6H8Wg1ZnwbSniF4HY2OS8uf4mr5/n6FLwCzFTH/6pxLP9GMP5fIMOFOeHrT7PlxMtAzTupumlKC0pU6Ip3mtu/4i4cd7fIgYVMe/Jjk0mI07kotBLvpllMO5SyyU+e+A1PXZjPmoswXKMciLhx3uA7ktXRc/HeVoqOcSDmlUkMIOpBaVIsP1dv+kySTIYEL2g87DZKV/Xy2zqhHv5rdteBE9ym41kgLSTmAIejjn2hJjYgOggxvwFW9VTq3Pe/ObEL3/qTgt94lrkzF6I5zACPSbCWbCkIr6h7SmZ+qTSQ4Xz//DS+EY33FJ197glPubFMwNcAHlSdvWRx8igldP8oMfoAmFT8VkCcO4117a8NiC80L7MQleIrHvHYJqRYy3SS7hK9xrvy58+BsnNsG9mBSrIkEagt6Nsva7GO8XsiTJnQwVxVEvVgHbH9fIPiSphuj6f7584Xm7ZVHtMrLyXWCu1q0gRamG4rgqbZjpnE4uaHIICql2aNR+f3DAF/pwZzVi7MCwMgZP3LcnYBk84apRKLLxrUfal5YlBirHol2wxK+iBdx7x9jewaCLrqJjeR0tZkj+/sWoaSICQ+l6ou9iuBCKfSSvHaeZdJKpT7FTheehSR5yn6+8jJHI+PrRNPjgA1SAC5inR7QNTsR1P0QRnm/9kNoP1EayjK8UFgAAAFGHKH+A7+8IZXOiGC0LR68KKNS4U56jHfrnWht+3O2UgpW1n6rvoAdUde7WZTHWczT1aq/ak/iKrMt0G06Aj1tl9IAFWIe3hQ7xzNcAq/R+h5N7BZRI3QMkZQvEoX6syvM8Ne6sdco/F6hqF1flpdv9RNqLJZqA1wJm9Ix8LtTTAKli3qNLD7QFCvx9cVOzGV3b0De9pSi1YsClqC45WEeva0rSEI3To18VKT8iwBXAMYKidu/TSFOo5i7n3MI0ZkCo0/htI90nqQ9+eA4ES/Ig61kFHGjP+0PORN2wjVDAkVyyj8ZolZ2ZKhjwz6GUI8VD+sRFXxCi7U3g5RST3CpOzNybm2bAUyPknqVSHJ7vwJTd4cnP1VNOD7LBEkbeaXJT7PHR3A3jA/f7t1EAtYWrL0VpNxPg8K3Ju7S3KqN5iPUTmHBf3I9TKJG6zbS5JIhVhHKTQ7Yyc4NlKyj331Sfi8qwJ4g0def6TnwqjYbjk1Zp6z6Xu4+j8yidzg7oCMgOo0wb8I7w26Rr+9Rm/GkuzP79rzS7WyVCLMGqCoAOD2pckIoX8pJtEvP7/wE/ybZhSCSDhy8S4zRx59KVOQm+6YY2PSReRNLvEWWyF2AXcNH+Qax0arCDZjr+jlLkJjQGEDQsu8fRHa4woXHbE4Z+dC0klPuZdsydDSCRc+ej+6pThHiMVBWtZm+ZKN8hysyU4+lI8YPfuTcBxE5gBJOcUFXqpB3fZGRGnd6pRdpHjwyvlEZIS1lUYiDU/LcZ/FfCi8Y1eHDtLEFrqr3xLtvcEXJm3oA+FwRbQtK1EKP4BupEppbXS7emPSJSNh/O9/mYFviBTV8YZYQE7uirfH9BiI2FZPIsDU4mNRdfOV4NC/PHqH6Lq08G6a4SRrYDYVCHKsF1HGl1r8sBSUHysqGMcnQ3EygDNnQsLsxZSMInbM3EFFfnS7oZ12YzWCPS+pwW4fNTfwEstzFtrQFhIjVtpJp5kgoPUnQkqA86tdS2i93i14VQ2DumIedwN+vS4l/sIqAg6fGZMarP2+XOyL9u4vjjzVDWt9RO6YhShTHSap/uKTXctZzEHRVtVBlzsXa1/AMiwvR7E30ltLpSrh0zcb9qBQ5GoLPPKeeo5XMakbd4vTkp9epgm2vG6Uuj92hoXdEjKmaXqk6/idOVwK4nGtZWubVq9A15cL7n9RcYhVlE6dLMpkDG11Mspveh/FXfa9iwuFdBY277xeBwkNzps8RfMaDKtpK4qhOhbeZKEIVro88K1mWqKNypzSWovESKsvWz2jZdgYBAhuqUHmMuDWhXpmHcASTLdkuzxYehOMU5qQLuERCAvVknXeDihxkmAyErM862EqhYwtLu34Fxy96i78Aj8owURUI9njMgXo2Tk//YpwDmCpczyh5j5gzKGsDujMs+KA4iz35Uq0y5TbwxhwmLYGYeTaqgXUYCZ8eaJQirjqd8opSS+MOyg42vJWKAsVS9pVSLK0W6hCCZ7TBBS+2GkPSq+PQRcPvvqltmQsfRBa4GqxrQpkZp/9jmFOZRuYADrkNnrhry7DmOaERiDAOjh9Ci2HSK1tH510Uso2AeuPxm7QCcxPZtKgsaYC1DzUSW9bVR3P9ec1kmuRYfnCYyoxLkr8sN/HsPkbTmapF+jAfx8n2BtNecz11zlEiK/ou0HfrQSzaIMKltyJbZKAJ/7uIv4k/CxXexjye0Fhgi74Cl/QWvojH6AWHc2M3euPA0MRJhX0HBLaO54S0hm23dyuWYpwYD5cOzv5VwTMqjNeyiOcyLCJeUtNN7IwTdpQjnCOwKrRHYbPPvcfdXFTmsxRho/n8UUAXV2q4JY+Jbmfr3OEdS6ViavVQafS5bzoGO3cAlwMno6vUy9j9u4xaT8OS6RzuhwSpvKOJ14BV174GBwkWXD9WDFICcCrspZeUok/ejGr9/Vmq3BO1Ic0H+UOmZvE66GseAmjn8EdNspMHktlcLJ2KHmBWWIAWxAtWsVpHrwagSmOk1AeoPRm1kHyargEdvHtUFt7Or3xFqZDK6B3N4sRpcZ1bTrpOQljPB5SeEg0rcJiXJOnbvQopZWUyIXElv4etO2QhXOgYWNSYSOyi2PwkegAM6vw8hEFLUjF5RXe5vmzoIsnZhyRpqldT11ymr9FwHPerkagoJOxsFFPkrX+BQMnDwbWLvmGSCe57Ume+Cl2ewK87B7Hg74LMj42RCji3CzhdZoIi0GBQBU7SVwMfGgUmbJhRTmZCeuy0Rsb2pKc/4l1PiptdsEZxSHNKkhdF8K1DrpADJbhVzyl2ghzo+XUoXZS0JyIdAb5Y9E4fsoLBVJkQtLV/MEKW8iCXC5jve4hKGxTyDx0cskmjtxMYWZyGsKKsmfEisW38h8MYlSpBLlmuypbAaWn5vI3GiymqAglmPnx8T3m8ixeQKeyQou4R3yQHIx56MntE3puVpBNHQnbhnu7su04CcmkNtGfjxe1qgPFhyR/Siksi57WR+YjOOPwSHe4cTZbXFnU9XwjZ0bsksbwR6sKRVsXKGH9i9r/WCqboCpHlpB+qNqizAR7QGgZPrwx2rE+1SJmQ5iG4zFQl21qWjnk7LoUK5jRfqM6HMT/88w2z8QI5UOtySleQre1o0nG0DUSyCyeYBRhyQtrvHFFg6d+1jPfTwHY/0XWmoMSETBrr8qfAgnfZEhJLkNS4zvUXY+O0kn22OLQFLqwaxTmfgaPC7UEnI0D44RdXO8DpExjt8Y5Qd4HWiVQoInhRh/75z9nlU3+b3bRsdpUhuT93BqiaXgbR/QPWGyKFJN07rtPHp548KAiTLbqjzYPKCDXwqERwe6Na9hhPddbQ7cS+8t5Wl2xZ+oqVj9zNw3sqagDUxyhOn2Yk4zFLjvKH8zDadG2wCV7qVFDHHT4EtaAjk1O+ulOyICEoZ/2N6MDwF4RNWix0MwEQ+RCtZHLS1OM+LOUpTfM8Jjul3/XzVjL0pJmwevngW0Q1q5fgH3NpdNqAMO9EAYQBn2n1p3HaCZmiHYiuV738xXWEioAUxtQyP8ejs/cm7L397pWISPRzCWzjRgnfMuyl6qQnwiPVAYQ1HlJmIA2SXO0KP2uy1Xv6Y9gDO0TuJ9OuEspxgn2yOcfOoJekHO/dvd9wtizVOhHvCndyFd3lNuTW8lU8KlE/6ehEtDj6hi2+6MD5jVP8Wl1mskujN63oolxwLBcPW1YXy0POwMxAkxN9xY/pgPbtwlQ73pdEWriFx4U5M/n+m+IUqiBzn4+Pa9CsLQcd1K61Sz5Wqaf9GpX/gD442p5Dbzf/JO5XiQE8Z3GrWyhS0aNw/e/own/yTym+oVHXN0ivSlu0pqIf7XEV83041hDv3v39tdS9zbHBQjIhezF53H2u+mUT3/B0dFMrZCuRHqUW7utVksSGkYuq0tZHLS1OM+LxMR25mb9dd8thV5vnXADmj6Ejo8HCq4RJbXST/EZF78QQK00vIYUJKW8gD4fy1brFUMZh5j5pjP5hLyTS65DY1krZjophLh3/LAjxJiv5AbtJgdNca38RAXnJdkREXU/+ms/6DhAz2IpZMXDYDvE91YnRHN3N/QoZHYfGL6X3O0hlejKP1bwTK3Dgez6NllFPf4HoQvkvyPZwLcqfTuq76PdLB7axqtWDyX7huF0dm09yIBgFgcDO1Nbl5h2t0XdvOr6xFkhUdOXv+z+ntq8a/qnj51aj5vXBwy8yiPaZcwcBW76HKWqk18yudE52VfS455VqFgV2nkvLLRR0rCd58y4OGzkLpJrEB1sSiV+WUtPAjvvtgMP+82Sa8O3hRC9DUKq7hMhLtwKnnnTyuEwy6FjgXkdlpi7qyWn+c/bmaAWLc8QIUSOMCLJgq0R1kqcH8Jjc1yqvLLfZgClSD2lF5WM3RIEJZVoNNkY1vs8Sl1Md3i+E5sVCSwrTbA1UwGopLv04pVwgYXJQt9UilvtybAZ6+7Blq8MgfFsnX9rO5N8QYOMlS9mnUaq2LB+vWyPt9CaxovIWHj0osnaEEftP3Qevp6uQhZQHAQpGu66u8eF5j9MlOI4lZhjZH1qJpeGGHdL8ZUp+YG62F5q6kVJSC7eQ5ISjN/O+v5K6hU1bRMeG996A6SelqPV6erXtbPduAn6Z3wSz2uttf0Q2f3RxlZuPfuf33a7HNXnRd+iKJrAE0ZEfG6KP4Pw1DlcHlKn/NOBR+UXCHfnHHB74U0XTHmKdhU1OdIjawAWEkszKz4AE5T/094kdU3DC4fDHWY5J2wpJnuckIT6IukbGyPobhxRfH8mSc1qUjyHX3sDB9poaJpGg7ofeWsZLIGm8nM0EnC/Of6DXf3zJWaN1HSigkFQhH77F9qdo2fgGpyeMZi5LOFHE43nuapdnS7Q6Jj1zme3GrGh/ob09Os+qsXHO6Ami9g6qmOHDLtIIP52UDfCDUhHip4ItuaUHFv5kb+Z42TDvUcoEhE029ZcpkWnOpzoqnnByp7YQDnw6JCpNPdyKyM93YjG6uoHZRdACPW1EG5INT2iccGAA5ZiEI29hn4pXtedkwPQLGZVs6Neh8bSFHOghF1sN0mElYgwn6L5Cj7h6Sp6NYTg7sSsAQEYmGYue4qJp4R4I9HkfJjYJSBNq/cpr6DS5skDfqSMhMUIdmpwan5/d3PfDph5dLdOM4C1eHWojYIxiJS4oAxa77w2uOC0SUJ7b9RG1bH0xypCINuev4ODC6Hn8K+3mPecb/5nQQOATn0WmjXMDb+M5i0acQcEWB19XhqVriGDi3D0lT0OJC09bjs+TUpiBeEymjLBfmDlsBgf6SyPW45kksCGBqq85CoSDK6sXK9lFfeZc381wJKXtZhwHZiHa/FuNjTV4CeI/1McvDJgTyBEU9TNAC9uEbRuahUKexhGLiFmTfhc7iGIOz7puLqfbDqR+ev/i2eVbNJFQ5BBtwDB6e/Px/bHpuNbUH6lQeVSdl9GFXsfSCHpHqkzUWz3GiIaXapFIeJJYCYcyTJ+QenDyL8wKRQq3YcotGbB/c9HZFczeeSOfvhifm3FdfcJ9K/1LjpxnHhhMTMhDxVP19IuHbTZBjR+Sk3i4FHMNLJRBR7xpUey+JzQTa4TyScGJ00eWSzl83RoQMCsbWC68Z9rwor4iaE2XZSLF3oC/1wegCo6dvKqHte3xg8Ij+D2Ee/cstdgSqj/x4vkojjIDKIEn+uouu+8JEX66MnPA6bfPHWUQ+aVOch15wuHPMHOw+hmVsudCiqwtCornNFyolZZL4H56t7oeyq/Fywd/SlnIbEZjtl/hh4vq6UVQBru6pEET75vRWPtsSQAt6pj1jD+0NjbzrVVFcVWdie3KzOvJXY0RpkYfxHNhikwmkv5j1enFqBM1RD3BYiBTQtp9cOKc6L6R+YBxUPCjTrzkvem/P6RJBBohB3QPKiDsUg+qUSK2nKHqNPo2BQj+CgaEBSQA3pzgzP3X9Sw8GtsMjxR4bQOZEK34PxZEHlms/DJCHcy6Mf7UaFOMnK1Vkyxax8oyxVj+PIlWf2WH+6FYmwsNKvVeMlgVjIgBKooZGB4EDdF2XSzUAnCnkAGnhfkQwmvkjQAYbERasmwCiP1U9fQfyTG4/dRYUR4fjmTregQ8/coZFNkFyVpvEXg727AQIanu4nCnnsIdH5+XK+6vKEXY3wbbPubO2yq8iC/wGFks2Xi6kXHme3vUjEYaVDoecfT7wNGYNwj5YOflohyXFpWr4Uwm759i80BY2+zoLf3fAJ8WNuerB+r6JM7Fnq0zt862z9LnYj90wjiAUpAgj4U/Rfaq1t85iD4rHD2A0Wl94bwZNz3TprNqN1y7asmlig3RnFLPbWTkDuTRo2n6lzhKwRRyFrBF57Q0BH587QZZtK6zp6ILrLH4Ug84igNjTUS0SzjIDPTsvm+Fn+a8640ksksrUUIe2OgTM8Av8XnBl/zH56jIL2mJSAxj0RJJFTJc93pPfKkQFKxo2Yk4Tj7f3n8ZAcs9yBSfd5gZFUgmlkEcQ0YAleDnzEZdX2QKnQh5MTwg8YlSpP0OtzmzmFaoT9OGFfcDSng/G0lz441iNx49zmoj/QCxaIddB+XtyvIn6QvCEXAI57+xiYLq5XYhpHlxUJw1ZV/Nkw9VQtQV5m8sMjpIDERCx1wh0unRd3E8KQwmzj1VyUBu8WDWOCd3KoryZSy/f36VqehKoK67GZ06MG24rWAV8k2P/OMYkLnRrrrvpnamzjVdUe2LulkphdUhHpOCv7hDmaawpi6/w+RZJ7XgW4oyQPI59OBWkvGBsA6L+b+x3wycXn7DjKWqmVnlb19uVdYDL9lOiDNgcLYVGV1woyv9koWAaqvKxqqB4y7mqnTHYyFwU9uuEBwy680Zi6kn+d+swWfvGCQou4EQu4BKXq4iGsY1faDcNiPxG17kWFrSwH7H/VqxcRw1C1fLfizgwV1SDiLfzUGjta2hWiX/t0DZoHc+qMIDC3vN9MgumYkSMu6akbzj83y0QvijuyHZ7KN251O91cmSDvuylhyfiYyDLhva2ALWQ2RIghGJf1pVfisvSbbmUt8QofPuQLwTRp6r+sZYUrhDj4fXZrtx8b6hRfjKuO8bp0NRFL0SJCKF6CfkKkVycRtdGyfpp8Bu2RKpg52H1S/G65U6G15jkM8KvQ9RvbXa6zf5LREy89FOLx6LRI621o/mHzL7PFrwSeN4gLFc2Wxu7Urg/N+Hq6xu7V2CYIYQZm/Ast3t/hY60lnOSLbxq5DPCr05FwDLjHCalTHIQd8tNZYCEOoP5X+FDgrc+m2UnFufeDlFEQWepIjvzCXTYJMbuv5Re72J5cNA5puBHwI6PeRHGGQquWLCiuTiz9K7ObO/qUhftTsVieBRQ3qbrxVHvoTma556pKtDWXEGRAvjoEi6rt2OyggYYf3a3FujvEwTl3JxAbpetbKZfM6Vn59v0SjIncfbY3/gp1fOGmIPm/REEhyYmdsLDFNf7BUnoEQzJLacSy6ej+suKeHQvlf90PRuz74jULHpGSjjvQymXn2jXi6M1IpyQNfHdaNn+dFTHlbzyBkLhlk/063dwd3agG55Rn/kfV1h44GQJq+fEzB9jZDyLN6543p5tpVk+X5ZmFl+IUxZjh1ZKVqZLFT2IET0YnEPeXxfyBovOeg5i0V4bxhKNkeA0lY+xr7Ob6mGCL/eIOPH8mCLlMx0Npbqw3tdhQ/3Omi178mQxtaY6S7zbquHEqDxcQjQoowQqukWX6wS7wPA8BhAM5GJPpacDaHeNJsboSAK6PkupOqhYxlKTWBgs5OXSvAA13JHqXP8/wEHnu+zDvz0wVBAzEl8YPva4Sq9bU5U6s2xGeoYZ2GNPyEWOtVHLxub1NkooprPT4gWmajL6/C3lWEJf1CzMC0MFPR96p3ebkaDB+WbbVcNcWhx6RZ1c8kbZBm/8Fnly0lBFleM2nLiMS9lM+KBXzhrClkRsT0C1kJFd3HT77TlMGhbPJ0YX/L2OfKYxRWLXSzGDzSi43p77k6QNOWu31yBtvQQrCuEZZq+RRFBVxy5Fb2Y6ai5EiAJ90VYx9sPzl/hdnzkaDGQQMT8x6ZPi//jNx7Q+fwR/Mfn4jdu+FcV31kYOE5VHHfRcSsijQCqg9/MLjZhA5amNxqynCZLE6IT2mNP8i+nvm3H1dCDf3ALKYyAECBQXOVPQoPoVMbL42WaEguvnzQ0A9eRCu2V9+nLTYXfCMDwedyWvuAoEO7Va1Yq3pZKA27zo0SrzuS+w/DKmyVjcQIDsO6ZxvEQn05NP4Hz3nlkMCEvwkDC5J0X6nmz7W/G5skbQRICw+FR1YjPTribcYS530oF3BVnBx/cje174ifkNDN/tZlMTEPJYahP63Q5g+CscynW4L8rTcXN3JFdfe6Pq9vS2PN1q/hJCKshU4RgF2QMBgtN+pybF80wbs82EpVeiccoFdWvb8jhTdKdswChWKByRigcdrAkTP7qE3XA5M7J+sx/bda8jdswKeKs1EFwCWa0ichMypEFHY9InkuKldJ4wauQuxsAwb3o7MMLMDdLntsnq6BUr1DE+Wk1jczFn7Z6mctQvHexkDFObjzzHprbjScU2/nAkyE/+dqcd60Z1+ZHso/ajxMEZFT7MiDWE6G+T+pE90yepKUyELxW5YU/YtmSpPbClLSn/qNwkGGR/1TPOiAI6NP2hKWYJ5jgRU96kDjCMfUBAdEYpewhxMc7dHAoDZXrCMSEGb06Wq3nr86UgzeXJRIMMOcZE8HKVyRELln9y3lSwBKIhzS3tdxMgvCpQES4zMhG6EuIyaMD1pZvu6U9sNW9mn+RjTwLo/xKw43N6U6vbu/5MEPXQKkQt31+8OrgrqiWO8LaMOydkwtmBaSsRnkwwE6nX4JMEenHpBSPpLr+DK0698CzKgEALMcEdnzCsMrADIGAtu8BPClck84dR/Z+ztYnfpd7wciSPrtrQupYDW9P9ktkgHtI6BmtGwjMq9aV40CQmvCiOX1fWcuSqhlBg5v1+cytnqUs+/i6NtOUiL13btl0LFzD/kPco9bpg1Y2eZUcbhmyCZzeExuRva5vzdVamTQ0vVhxQm+Tbqbns/XMUE4BHpHkaFb6Hq+buFwlD4V6A7yC6LAqIkbg3RIuFnTz62XLPVyWghQ1kLr6Bb26PNncRJjLrm9RazQq9//om7UciE4/wuNJ0piEDA/LlC86gUUzirDcUBpGR9g0/Opd4VHvUBqdZya7svl/vdn0kwj0YblCkAZN2vZbSPkUaUY0ic5DosEEmMwbW8xvr7/LoIDdpXN8DZFndKyNZRmKNdnPEM6dOG4mbWWlYVKpKG41nY3Ze9FdnhRzh0yacNvxinKyA4CE3LwN0xwzjb9XbEe8saiVRw8rHXF5ziINOr6QagkXR+wf/FPiQlqKq8FtYIusioxOVfyYpk6Orn1aWcu/vpzAX/SUeotE1zwgwoZEZaDVfF2ysgBHyxbBeu3o6kDezzQv+sY+uZLKdzfSGaok6B0gEZPiveNzjpyKh6daxTyS2Coof5va2Kj47e+0fP7DOL9Jmz4WmmbBGoPfJ4FIMkko2VIusZlyA/J9CGBMGqHignO4btpM4xBAII1WrdRysPfOUiyHmC4SIJ5RLKZS1ih2yFzA73HHhQQPD55tXfCJPCgPAtXUpJdSVm1etAMk3cqFI4KaKbcbG45cttJ3xiWx9J1mfsCryu/JDTAMxx2uHaIQCAVOUt2PJX1Nf0bxsGugR18N5RFr8KBJ3POeux3xaXzWCHnj26KyoGcpUQ/bY59w3or4jGoUDCy7iOusANj0O3bk1VnSAaw4UXC7DqBqKl5piIjt6XE3X+LsAnWom5IxCXs+M/t8JO8y2Io9f4r8+rsxMcRonji93OT2g/mTLSCCbVGO1+BgXjJCF0QXxwPMTQ4I5EB7TalueA/nnzCgBAEGqgtr43/Jc/HOFnVMLc4OvBsD7ysuNbiw6BRPhl4s4i8Bp41CSLSZ7i7O85u6QYaVZRrZ5e/Ep0HvjYeknoffHoZ50G3TU6Kiep1kBBzDD0sfVsJ7vg9HwtQ0MB4hxRu//HddxeiAYElD5m0fmvxaO85lMrInFmzJkE6+rqJP32zk9vWCHxIoi47Qj/nvrfDXbp5gAWBcYVmUnyvB52eotZzXJya96Sr+PCE5SbkeTdCemZAVvvuWvD3TGDBJ3nyZzxvRow5NxuCys2hMLXrlCDWq6FPlagzzGj4fN8I3LnVnfyovPuf+bGe/t7TyVTF4R635FInq5R90j/BPgUsIRWoUchaNyhFzaNH8IaSV7sk4/dSNPWFATCLXmVa/IjO7zxvIrNsSpBXynKEGtW8PfSl3svbW2RV7+u9ECiOe0Sp0+rUFHpuSEtwEVZJZ9yG6tuQluQyFk8OyX5dzNMZOAuGMsGEqVLfvPMKcyjbJrZcqxbCVE1m16Tf9fBq+V64An8jAZrtQd7b317BdpM/j709izgwUNHErR6HsUqEocujDNyUgxCZ5XHJ5IRnNYIdR5cos0e+eESbWbaprGlf64Wur5sIXEgoKxWvSHEqQL34ZZJidZQKXEe4dQaf45HGZWyS2m0vkY+HU5QPhPgBVMb8RwPXfCHoHJuq2xVU/cwhdqKUk/tpbbA+3J0oZS8GT6ssINDp/hRELIZs1HRWTDBOnQQbZ5qQXjDu3+QF41JMHhp/qGE+MlFsAiURQUxAW9YNb6F+aNwMKtMGA7SgbBngK3S1N4A/I2C9sGBFcza2NTJtGi+iGkMs0ziDOB790sKkjr2swgmZgEZ1PtNshk1wFm6uzLg4bOQBDULnXahB9Pvuymkpiq5ytZ25e1UfVyLAWRlRQYMJ97L/cUOoyLDJK+7gRznU8ZwA364vTkIb0svsSHSeR8Mx3Hy97hq9DqgbCJ4ZAIz9bPJaCvh+oa2aAMpUf5l7D844WXuoxsv1GoVjdjrBra3zElDlimkNAZZP/ysVjS66E0yCpiXcQvU7HGHQd0B7rvulNV+d12tavB9bW9/B4DYkfTgaaH2jWeMu3JUAirD17hExPCFNsBaOlGrndoaA4eowpIdVmvCoItP/5cSAlIz9NVR/SP1cOiJkoRaj3T41t3ydRHvWhqkBaHGALefPuZJSGzukOPQb0DwF+rXgbNNMtXbkcb1x7lg46K+IsGHGwBR2EkXewP2c4CpYDBk91iCf/vR/LZFCOsMsN3DdLNbPEKHRDwHAPDlY4Ga6d8YGbSlQoiJ02REYVobLN5MC1qM892VrP7RCeVi64N2Ld1baKMK70sGpmCsBBlpJQfR2IBJH3QuSVZys340Bmf7+AcyfYC/TzPyrnuOoOCXaBxfyhfMaAvnjwu87xoS3jZgWBqD9QTbZ9AgDx2BrmGS/kDgyM9/R4j825HIVOIRai7sm6H9FsprBJr0LOHS/g27OuplurdR8PdZpp79zisLoI22+6szY83rzsBY/trqav/0hVueMlr2SWMEh5aisE+COj2zwD3GQxKAbCncXMpln1taNWF+o9BkVD3G3j0QOYX9BrndwK9aoVktACqBWaGSfH6Z2oV9QnlXv6pfAyJad4BnIDu5kZ/WBM5dRa+UnQwnwod9YBVu1GvnyISJU1Wwvoz70uC4vAzy3dZSc/41F1TDSBJamXmdu6v1WYOUHn0vk2IO/0u/N8misEtnMzV90ny3CLcXZdWGyz+a+hvOnEIGhyYWN0+mxj+4EyezUHwRjSyagSNzttJC1D3qinVIxJ0ezXyHLfseqI66mTm69BrJI3O1ksdbJfKJt1tF0NjXnYByKE6Ei4jdyefdgbs6fB09t/qGE9NJf6ZuUgZn/mcB6Ibaz+VmMgCNTsJkC15Vq82Wy7tQeTPtOEqawh0HCj9wWLTukP4VqBL/Ngy5f3XCov8zbddf5cnCk82DfumbNvxfg4+ivlVecSpsN9cu3XkbmJUk1/0iHkX7fSFHCy8MQTMmWBSU4xU4aXqZQuypkJOtOyjcKTkDl8rfz5zAFrZ2dDw4USq9G265iQ5MnGbYV4JV1Z/ztVwCYhJsfgKE3XcN/I0wl8zf2QCArUs+V3YK3DJmbNQ2KWI3lp1W0MSXsiqst0vkbKZNH6meGqITXKrPIOto0rtFGECpdbqh17nXv3v89eMFd8tdaKyEyM8ORMavfUjiXqVAUsrWC7KjkGpuEU1KJNThAioZBPKleSiU1toN+jwJjbo+lYTj/f0Pu7TniXoo2BkLN/ZBEAqcKKTPCMW9wCzcuugHa9agFti1gjQgUdIK99VdIY0K+y03g4YMJ2XbXedG0vrjx1smVxLJ8LY4E8PZJX5lVSz5Pf7Y42PrXlASi99aTMUybmDlbFedl/Fbfk+McIC7dNxoi/9FnZdrYHU3zRbPuTryWgj0/30gTEEREfZWXwrxr4COdKoDfsoBr1Ev0Xie7a/SqehWOX7z3/xTwWfnKaDf+Gvuftd/f9zV34ym8jU/XIeL0QM6OhtBD53LBNl94n/1VgoH5UMyp3PUv+V/H5/b5Xoc9eyP8utsBAhhOPGhXGb+86FOo4xhDLNKDwYFrTNgSE0bL3rwY/vUHwkjsycRqx1Hg/QF0kH+DlcmcmUfsvN6JUTYtz5OrN3c6r8bzjJi+0VbUAuQVlhKEH1E3C67Rn8hRbtW+zSFXBBVHkFw3g7A7qLA0lDocwqY1+gSv/1Vik4UhTttiehn//EfEelyFg5d932zcTqq6OeHjdOTxtoWnocrJg/Z66Ah+Kb4FrLYf0Mqa/JAUazesX2vbOds+bk+kwt5LZSMuhw0Er4fWHY/Sna0eTPB5w6mA+9mXUO7NknRtQO+vuDiAFyviVQrdMKfvYmGuutPGT7EKhDY1FGl/I0VYVwf9SGg7d1kO9a243T9XpUHzOPZ0/yzM6fn4W+ted3kDnyIegI9XwGHd7Ze58DuPFY76t5hrq3Zb69zLAlLo6rI3HeSkyIzlGubNn2Q0hQ2lETEsdXXOynVQgyFvgqpebDdlBPGXnkJ2DwvlO+9igszjYcWWAUBYcZlf12PanJ/VREKC0oemQoK8GgDVvkdHMuwuWG/qnFjHe8DIHBBberTNYUdkuYuVr8PAxhduVPbS3IrcPJyb0gVQg3FrqpksRx9eecVxI6Qe4xI4gAnnSHZZjBv3/TDFVRSTSvD0lDEAKEpMyRJhhGTOr4NNWJGmkeql1uCygmLiGuUFm2V1jFUDvZ3/GcLUx22GSuUGkxnUhRZ+o+ZC/+2SN2VeYKWVHFoy4Uwtn/IaZgWUZw/IzTRYLYEns/n0gvjPvA7HhRIgd4klRNwBX3BlgaSbx5uIbYu3y/fGdtf2PEBKE4TsL+XHktUWAUqcGCirojOXv/1Y7uYC+MXpmFQ4zXOSqyWCJGTnDezNEhDXBENG/LBNv5LK0q7R4jRiKL9okfSjFuGhzOWNqMqDU4qhLPYA8VKKcQL/36PlHmyoghRDayxU0hidtGilx3wsX2j54ouhoXZZhI0sCH83XxGXEhAtCYkDWsPL79GNdcTTB7/LmiWM4Tk03VT1zs426EjCRmX2GqwVEmMfLWoUovwo4rTBQcr8Cw8slj7fBO6jIB5vJ1dGViNWK+LJASEyjQ5AsvLp3j6AvbAWcy8JdMWUAwMHoG7DSeDg42YZpKxxK5tG9b2Q9Oh94o5k0fUvyrji/A5vUTg5kP/mg96OA8z+CcqiMAIwmxir+E+BJdBuJZf3M5tO3BG4tXHI+OsnKpzSqumYAODEGe1bUXtnEHY1XdohnD0mDUEDnnoQkpn6Zu6Z/yjowGoJMuIDY5JmLIbakTB45j1PYMdzi9LwnV04KuwOb5Ch0IkDnLnv4t/mAHY0zFmCBTyGXsWlABdBHhkr0OMEtjh2zEEhaRzHBePNUUwx68ew+DUKbCh5yb95sVj3U3ekOpAsmUySsc9wQ4iBzV/FsRc/9c60oAFZBDTVU+6QJn0x1Z331yvRxzugLtQBQHrk0zrzNjI7UcngVyW9vqHHeoeZSsstW6x5UL5pS5E3+IPEkNsLteKrYFZUGj95fLVKY46D5qm586OTJkzJSKUjGxjdZbv24tjms5YWDdnMZb+7ZWU/c2dBh1Ne53G3cTyWz+GH4zGKiY1w5vazX0wJ1FgkCHKf6P/Mf9iramAwU1GUIvOcZjgdIojSUSuDx7vVKoir9P/fllzjTeI6cJegeJYfKqIVrzAZDdO72ywLoCSrcNTm/opjJBUQAbYNRpR8jHXW7A5iIOqxA9pS0el3q+fQ+cSFTaA+Od5cTDQJ5x+iD7pXD/IZDhKb3Bcl06sZtT6WX3EYLotQAVskFMF4SAzPK4u4rgiCcwLcd8Ig1neUIa9LB17lKI9xLJ9PErtma5gpIidPZGYB4kjsoVm3W7lrZHXSqoYQNuqiAPO1LZ+DrpmR7Q9L7LmYPAQHaAQDacpqUJ6vDy9BzQkMSmvg1HDiQwOgLtP+AfKEQ1cqMvhDLmCA0YxtGrMqMLY7iQ6jDZKc66GcAsIbI5B81Tc+c6FupqcCPEDAp6kxUbyL8/jjSV/PwTqPyYeuWbI08FB0fMH32PkOJcZU3vfYVqa6SUV9D2wQxlxkfkOfVT+d0ZV+HKQYo3CeydcnKd3RThrL+GWCLKZWPgrh6F484u7KuG84aBXW0lilTYUS5IdNSQ031BW7WAE9UrgDYBcUiaI1RF5SOCub4vk+gsuftef4t0ksZLbv4wtrTJt00BjZF/TiSyFs9iKIXv0Gn/5cTAQIpcJjDdwv/FDgNjmakYcECaXkV4bbPKKZmq9IwaUDe1zkfb9BE55y7BhyL/og+X11aSzGf7hh69qZUyxVPrt5a8lo7x4Y4rudpDgY1xQSbA+Szj1UfEqDDSolTEgtDtbykNc1IpdlWHv5Uh3kXTQPyklnZxED4TMe5YcPtBPHdclrT6Kwt5v0tA8bx9U7BdPTopsHxfZ74kDP0x1YQjM3sRfjQe4gn3Fk/Nszu89cuAVfNkNQyjfPcib8kefaQ9KK9Ed7JrxvK1b5Aodh0htCr5LNhUjgax68glY8KRmTTKoZ17GfMGq7uw5q5ZPLfPZB6JKlxEjsLt+TAJx7iZw3X8ahd2FoXP8mZwcbpWc82R2ZMcX93cFOXtZ7QG5CTUWfieUHJc/g0dXTPpgGxnSEKH3CYvgxDnd8PIGlHaraHijGzh8YVLA+WZlMlcA7UPJEWqKJJQCvABHhcDpSeX12k4Tssr1ojYvB9A6jpU2IzA9F/TJNf+I3U9uhIXzZfXzQV50kcdXrSkRJ82ohrdTQRCUIplpcueVy5HpZGEJ7oxuUKy+/dssumHwSkpRV7b3G6ZQicRN8/i2d83lFefQy2z8yqNZsHYLOlrWPwIJt+5CbLb1jxHDRy/bm73Jz4gLgeJ1jd5Tkic/Bw/P6DFZFY3v30ygGuob0U8/TFFxwpN93tHNEQl/RhuL7rjtEKdwWjz646N/qRhlYnDRaCLgvm6p/8MuSCF1SArwIvFL5C9BJmd11pV4PQwepbGDfXBb1mTf5H7u4YEPOJ6y/pODnIjmcM7oCiVrw+qcLudPIH62s9e7T8wTUZwxb+YAi+qmiuQL0HtsRSoeUKsuhI5qgBBuPcKxMLV3gFvaDyMNcFRMW2aoZ4BMkdVYwRScu5UzTyM0ZpMbGgV5G1T7iNIst+2FVfY6y4G4MVP9qxnOMQkpQkwct5VsGdJzn0A20Hnuu0HjHC2YotoQ1Zb3IFmv5lI8MwLokUNSLhIO7y7acGGFcCZ4FG5nm0YxzZeLMCINSa82gJ2dskDA51tRTaQ9nVMIATzfhGkAq2JO+Bp34Q2h1qmosq39A9JUTBB/KbXBDts2bOQ5/F/+d5y0/1A61dXFi3WARqibo+f1Od3TDCvtl/cRl6rIBPXWChX5v70aBznSFSs3uJYrYm2hXHrTNSy2O41tKssBiKg0UAKxKR3YplzrQO+Do+EI223NrWAKTZiBzx20EtCCP1G8pukyk+K1YSJ7D/ZVXoWt4oTVBDil7mZbUCUTLAJXHthHgVMYtVtSD1l+Z/5Bg1a3cpokWW1pHxQld1uhQG493/2vJ6FvFOGxut1Ui67HbBbCFt4P56K9EoBity+fkVF/1sWxdsKgWIkiRR7UK7Ml/EzmgJra6iyWwLC/jYJ9rvr3Iz/uJKliucs6SC2p+v+F8giNtTrtlEWbZbS5cfjxL/lzMRdZZwe5D5VJWtIuylIhnvBtUWelWfsNLli4AqdG1sJBfX443XyOkCTW+BSvX0fB8PyVF8raFhpYs8HLUIATbjbfOe4+XLZR1EaNi44LqJoIffOvkITZiBcDZhAQ0+RzP8SvaMY8PYuPUOTOx3CoQrLvRnY9fBkajjbtO5QEazge4kDbsYszx00wadCt8+qNo9oKMIiBkKICYK7R7Lhnidbnl2DpTXHDAV3nKix01I9DJ9JdZc5+m3F+rEHj6A8od8cyF/AjDUBrpr4plp1RGC4vuqFqmKWF3JMz+86OXcU33llGj4uY3Jrlsd13l/zU4c64CR+fC7TO2l0rkN1kzPnE/s3KJ4+OPplPgkDwfBWFNivROUnwwIZM2U0bWy7apsJTbupPh3/voDCOEElTkshc55jbJhML3LDTRmVg/rGUA5LUmEwU4NoNoTEOISZHn/Ux3QAqBbtwRmyCHUOlM6o+WQlMj7WQQQnz4JDAkaZSHwbldxOftQ3ioo9Fqq/twm5OdXQgadye+IfaXjWZJqcB1mUr7dXe4jdTonZfclIej1qLMNFhwn2hXpg80U0v5V3Q+q6Ft7huHn6uOfi4a+AJ2pvuw4+iNUfpynXIf5TImcdk4Qdk0Iq3N4PgXtQxtGuWvYpfrsKL/QuxBtAkKj+iFYzbHk0JkBWNudc+SPnN9Q6zbpAXXfLVr9JmZhCZFrAxSe/XJwc/Q99zNfQoHmb+CEtRrXSEcyVxQnyUTCKjeEwxIgKYL5cz3Jo/7QobOuvAmccQZt9n+9DbBKHrYhaMCE21IyXxPDSccFP4bG4YFhPZO8tYG/tmXxQ4H09GcIQM0Mtp1RErQTECFDoH4yvW5ArzF0e9AbR/sFc0TqJFuLcFss2ppA/kua+bb26D8/94xZe48iZDQbZJti4UaPEPS3zLPGbikCQmKRc/PgkMCEQohUtKQ2eXbmeOG4nGN4/n2IcRYUmA4DEPm3d6/sqEYORy0QK8g1varGyAoWUdMWnafuj2bEkJWct7SDYrr2D+lVqUo5wGBZDurq1wyBF6cykvA02bWkSZoGL+YpnwZB3YxFpAAv3l+p/fMDde63BjOCmn9VuLmZlV4Jt9xdqoZB0xadp+59oXazP9l/NSDg7MK5RZZ1oVud+fwPwP8HSmPbNghPYUVtZuoXf6DufR/p1SQszEpsxc+v9sG3/SyT5u/XfXra1HewHF0j6Pdq9mLUKXB3Y13JURzNAQtBNXLcvFAmcAp3i63ltvbYPhEAqkCgj/qW7crlwQTK9FXdrsEzeG0OCzC8qn/ShbEF0KeeF1NAa2+daE7Ubf3LNH5I7l3agkwp8Z/KJobeodfFNkEjYLuG7s3zY7XE6o10YbAcqPJ6gXwHjDH8rFgvcqYGnYoCgBjnDN0x7BefAoScCwELcEKUnbWOhgxdTrRgIIVBiMJyNoqDMcfbLi2Wn7owp8Vk0u4TGWiaZy7F5yANusbXAN+P0PcL9ZwAoT3US7idyB2YmPaziVmL3IDj3oaAjJbozqJnjCA+e2NA1LNRpiogERY86+NwL6ymudXV3jwvMfRp6fCuw7Ns8REzHh8TMPea7S7xrIpMymlghd25EPDEaiOYK7Dz67CYWnuMuNVP7GAKae3DNjy4pOlpnT0Ox/ChTvIoPrEdQDjbtO/vKj29ZtVSFFigCHY7YZu5/RIPJzimDowmoA5wYfwAAMgnJ6cBj/kI9CnACHqyJmbkI3G3adygI1nA9uFOojaVUin9CykXSQ6+aTdCDx9G5LkmHUYiF2IpF9cyHfBO74A3VRsp8Wjpfrbl2VWG/HJNT27Ds2zxETMeHxI3UC/zm8U4BNFiPqw1AUANLk60WvI7FH+0wF9ooTOuggNYnZypQ4jzseLt49+CDvga9BYSyF1H3V81Kd/WTKIHoP7nEmif2e39WEq5ONcsL2upr2EgIoH1G8jegQusW3BwVzm2ixOzuZEbqeYL/MBJIvDeAatVD53v/GhEHLHADBV5pWwDDPBGVM+8UKUrRQ+8QLcAPZ8KZf2GeEQBuKAYKey9sqt8V7auhlqgzO4EjNfLWNShrX+dDUU/Ghe6jp5AsbHvBmdxB4Qj/CHQ/otiU61txQB4Fb+ErTZZnjnuMxYiRSSi5VejEuSFzp85/v7zmHu5jeTsdyAgiK2fGhwSDn38xG9dLgyrgtE9VuzgK5wD08xe6pW9PIJUmSXnGLsp3xrv7T4fPOd86+e1JHx3QD82ulKAa8yulkgfp+F8dE+Riu1gykrV0dhh9u/SZ6YWxLHB7rEFEVXMH7IchxMKS3KtGgwj3pKNtmJhhIXT1SeBXpatX6FwBkXQVIeuWEWrEShTqWyGZ+75BQIRxQlx4E11hcgyvEqHEeFUspjwJOPikEI+GlMT63WPLYqjVF/n1FmMUk3YTWfNyN9aIYfNmVGIkqAKZlnJQg61SaMpRODC13flr5RMHJNL7N0comWQQG7PBKBD48iCxAGma3whfnuv65/FwIzlsJ6OyBlc7ONCsFiubLOpqMHf+LSkF3hLP65JYGcTTxnVuQkVoCl3mjixnnfYSu29JeG4EQ+Y+CXpz6wDTnY6q1CgBR94qgsEvuaVwUNUdBcCXp8Oe31FZWq4jmkf8FAm2zI9Zp1BucQWyCa23ew2XOgB4ItpsL4NIzU+MBPl1aXPQ1rdH2eIlktY4gd0tUhi133ihVT8E+GK/Pj6UVRs/iWaO2V8pTN2S4VpHoXAesfKNpiOxEtyca/S8NkVG0DZv9gNw7riZ36ADiJQek7nRCoPE6/2YAkvirUvlnTBycaITaS2LyX/s8k3qUE+LiFk34+fu18XZ+j7BVbsNw3oGVp39/EuvDPyl8ML7lLvdUNJQBbWXfNEUVu4dOtQked9ExVxRiHi+RtY9GTXCdBUJz1beZrxo8tggtdE3WzrojLGyRAG4ui6EXBDit2RQYi9mip5Zz0SVUUufeNNqqpGGst5nmZl5eJDvVCm8mMSS4Qq4VsWv1qGyhlo2S5jX3wBlE18w5XE6Ra4BzZSlgFyYkuVdX6wg4DyEEZ7mQtKaX01FWlzxJBgZ+K0Fasg39Yh3XzBho8xDTcyzZn9CMw2zlW2Cq2yziFv0pSNVZp5pHSPh9zYNLnIZr7iG2gbCFua/77OwISgr96wpOvrm+rdFPc+wRnxPj7rb5lVbolM+yDoq7YXsScUXAywOkOkScv3oKSGE8AQhvW+EvELSrT0MNfmhsue6DUZ/6iwOYICKhphWP5stTfOX/MVeW8wpu+ff2Bona6tY/Ju6UNRan4UugKJmexr18HEQ/FdIB1nJY5ZZEnhDydPsjZzyRH9Kp6uiBeSJ2DWC4F6NMJ2jucpJjghuaeOeJQVw3oxxFnTJa+bjhUwikc0Z0D2yNvHIusiVv2YLXssPxfEfuWqW6SQC0Q5anH1f4HvpaTjWPSrmIQTCzXcJKgFpQJXOrMXD3WGst5lan7lyq7ktG6tczXD79pbYIYKK45m/gRCRKHY/5CL29Cj/Nq7h8RlU7GsPq8VXzXYqeEvab5CVJAUW0zuzLzWIixA8tcac3WFoGzhDWvKMW4hbxcE9BBBAR3qxOOXhGEBDiU+mtjybcyu8V7VUikAbAK85HhlKYyuXjERToHbElvHyp9b0xaUYT/79y9ogJh1qGbThgfCV3dyLgAzBKqYzXsPwiQwc1FVn65YpYypUJ7YT6/eujBmV/escCsdEu1RssB6VjvpfOjdqc7Fo/jjESh78XwZweIfsSgjTlX0BcDn++/Tmgg8T4x+1AYJfO23uB8+4At/dBRkdYZFGqHa/k2gdKbJ7I/Y/oELe6d1QXhir91/3eTkSo3VI/EnLbeBG/gEfgHlWSUtHHPh9jhxqilU4rSMVYiRxk8pkSzHDjMDlprAJJOLDUakaYQm0ZkNcHaoEqVQzLgrlrtd2SWhsdNiso/YGS4HHtEqC46pT/UAmE7HoiyI1iFq6txH0Aarx8XH0FimXltHR8ZY9ucDPsElm73XfWgzCnUh8fJYCDu9+bGxVaSMsmoa5d9I/DU7x0VTSy9zZMtr+3ySyyXC2Lifo/gWP7Q9kc0ZxUi+z8oGana9R86KIJFJ2Mr3PwOE7UhzQf5Q6Zm8SG1oKfjYvhrXq9UNHxh8Ekztf3PICPkCwETIzAp54kb/McrpzEF/NPU2PxOGIw32POHlcq2IPiIwN6boFtM/jShMgJbO4IBbdMuhc6reTvlEjl2+ah6c+/tYvUipe0f3vo1idEBHK2bPcsSxUPuRa2S8KXywOjG0AF77/3EvcX1zrM4Gf0lIt81bbYkhq/bsNrLQVRE/pbtER3Sptj5ygKMdysRfNYJuw7sC1JRVxBa0nDCm13SjudUmokamZoo7QZJ9uj3Tmms8qdA1TiutzrlmOCLu9wh6Afza01xqB0ipnBw8idT9vJ3uKeEO2AyIFjKmZLHHb7cw0zJ19BEMbG4Ul/8UyXuIiwKpUFCC0Lno4qxUqdC8c/5Iuf2DvE/56DSiwG/jlIjtTlioWcxSX0fn7rywu4Sl274l+qnfsCoi3nCCyb8W5uCOPX5vKVr7QYIlroWp0lQ/2cpkL7lSeWP+Ha2Vkf+zGjjWb/9ivWZ14dd4VgUNSZgI0Td3Br2fHx6DCh6T1X9BEVHaO7XtKEgMyOryfCUkY+rFC5jeA5XvUqZjx5+RM48nXGK/hrsg/3hyCkg8npiP6bMekz/+YzpJkUCwjGhe1uxI0sljEZV8NmxTJMCDcZsW1EwI3pD84WQyhuEyXNCI40NBWA+xxKUHWe6fylNnGq6bYb6DQ5yXr/T1dDczNDMb7dkTgHqr6XsOPsT+Ir4yvrySE+vG5yULCbW6b+m2ZbM1fDzqErIlLop83nZuj9uj4tqjZOdIhRW3JicHXmwuEGoWTrq4BNzMDeYcLsY4EigvMb+roZSdcEEEaMHwCbCiPjCkDlItTf7hOwhjfU6+88CrR4YN3B5OmAy62C/696OwvZxEy4/3fqQ7172AbKdhORBLbhZk6x7Dm99XQve+JlFPJqgO3PUdP28SFMuVW30mmjaFG1Bxlm93SJBJ5PRg1pVld5N9oq440//BDYM9vu4XWiPjh4RxgdfP7oVr4TfPJvLgiLx5NCLCL5qekTQ0dRe9qOTkjCv2KXFAVcSC9Vss1vmndhUKUTteNIvduOc1WjVB5U/nJ1YxdXnt6Vn77Fb8KX0LdBEjuWc2o1RT5MogpjKTXUJHE8U/5FO7cMSmZhksDGFRMAnOTnOiCZHisV0Vw5fdhm4WPgqW+GFkI+VFimkQ5CfLkDspbYLMgATWhyAH8OCvaFW64UpnabO8D0IfPkvDVtrQ8wyfsiABW7qhKc/lErGUr2abqQbcoh1fqDNYNFY+WtZy/PuYsCPsyhmzW0uwJPCiNunyjen5W/JmkIOKRHnHD12803xbGfW43mfIAelqKD/kM0+2UmZ/z3vhARWmTH0kdHuVtT3/EJORC0OSYEJtTNugwUfInnpyDX7rxsWXhRoyXcs2HqQ3kEiHF2q3RrGcbPH68X5USU4wagzIr72q3tX8tVrq4LjtBsD6zLOpMDK/YnPuiIZTydhTfzIomq2hsiut8+TnsUpGGBI/lvVATVCXwk9k/OO553GrsvcxdTs1PfjTn2n3S+pqFa8VNdECJsRcFb2cHZMUkcMV4KLDSSW1t7lThG+tgYn9xpkKLXU0TIWYSoii9h9p1iNsxpGDkctEFU1+lo28EYUjCaIiJUxxgZPD8KhFZ+/5tvZSQBwAO6bdMn0VLCwCaNqLrgidi0R8anOVpqKL9hjsaV4TEQExf1RmsPbI31/4UHHhDpK0bd7NWIKRY32KMIClRmkGv0v155z12NtKa3vb0Vzv98q90MMtbDiN4N3vs3HP+4GG4fK4hh+OMi+O39IKp/0iApSFF7XCgZB5o1Kuv3mvOA2fbeXGL7EEfXl2Un6411qWGHgQpOKgHMBxAZJUP+ioVP5wiSlHmpk85wyH2FEYo50SLiE7J8Ac6gGwel8JAeEEJKyZ7hM5SoQ2aFjURNcPkOu9Xdkdin9e68XARIWgPpK6up3rNx7O0eBrvxJGQ703t80W/8pS9X1p9nwIGxxTeUiANim433Il4jhw1awwuqDQ3IRe1oO7LYZqSEvQBslcmsEK4JfObvUzWPS6vjG5HafucTQyr5faSBoifFK+wSpbJsxA547aAzDCcsnVCmHydUbXnalM2Urdy2frrJ8Syb70dKbI+7gctvDDn5w67l3F9aDD/iezkIQoG5SxxuCQVk93XOGh6BlDiBA9Tl+6Mrwx5nc4Ag0Jw/dU+55DU+NUH3LskCBPhqXq1EYMzJQZRfPexn7j7BoHtXRi8u83awDbq3JYAovuxaLhsfRAbaZE3fnzgfib1G5TwIMAF0aZwHEUOZmSGfgN5A+szepb0/pg4Zyj2HjL2SFTDmFraNN4KnKzmhQfO8k+GU27gVr800XVGYD/ExtwOfIRVotp+5YTWZvZRP4BUbLu+BeY/TJTiOJWYQbHMxwr504XBsF9l+9W8d+6b5VJTf85jc9j7zgqR/BcNjkosMQpPKoGQZX/2iyunL1CyQOPvQMkmUi9sPQUN6HJf5J2CN2meecx5zrZV5PPfMAj2kxaxYHqMohKWnfiPV5d8nlQ6x9060RkkjS/pTCE9HhgrZ4bPGDM8f/dVWByiLlMExlNLBC7tx3xdoNMM4OcB7zT9vkqMn9MXiYYTGi2ubfeb7Th3ObvUzWPS6vjG5HafuZjDXmgZtL/+zSHEeLnic5v8Ssxd5oOTnCwMPvC5r1mMxJmnl0tw1XlaParVcYWfXTKTu0GMrvIDdXbAgfMxs9X2fvnAW4jKJDfQcPdvpHpIy2QmLnOPR025cSg/YN0wieR9ELhkoz0HAt72fr750NLkw2X52ZhHlbrvVTkDNtTXFTbumCjY3VrMRlU9QOtXS3wsDf9Qyx0y87kRxybyrPTBQM/148ViWxNcfpLrUZNzWdqD01i+jPutcFqUoBr3kRYIgyfL4w3kAcXNtVBUUx0uXnoO81tiq0w0wsvfczSuga5amUd69yitFZ9t1+R+9UALqvxziJRCuNgDZN+y/hXSP5a0URA/p8hs5TIh9hVkW7c7OcAjALJLKACT8c2uw4wcmL4EmEUyZ8tMT6RA/p0gTTHZtgulnMUiH+Zug41J1volJsWJV+DXaApOCUbTpMpNtEqohqNdatUk+1R0LGLWEZXXfji/euCB52WjgSE7PJVNbH1XAfZxlsLpv8+HPYsb4a4hn6tgNJWMT17LswtWxfocAhXZuvEI44PkNt+ER/9i1toDv/XnLEV6qO3T8wJw5y+S+XBz45I7bYGLhnLID7dR7Z5EP+z2emSNFTyqBDvcXmPID5k+Q+aA617yvEtxjBZoyh8iFaxkVfpZvNnhXaLqz1pzAsyBRiGgEEV5+4QY9aCNx3jfQiAeeGoEL3OsYpLTDlFkY6lzMG8HMtK6pVEjPK1wyh1H4g3O7trgh0oLMGW1nzbQtibsh8cxHTssCDLq6MZ6hNwjpROcb4b26kz02rnnFsOSgcPiwh1b2H8FNb52CzlVbM2QhrdrCjWqpvpY+JkXNA0aZ2PMQvDpwUIl8iS2mytIjhTC4ycDRDuQ/yHDK9AMQv7jNNviaAIzj1CH0AEx/gR8yP6RUo1apc2Y9dQ33gD+IJofugws+p7dlgfa0TF9tuSEHCvdf3BiX9fBEumIO5h8FXzOOut6b5nMatOEULCIrFzY0M+l/iagamKxwtXITC3cm98bDIq6o2tp23w3P6y/qY2N2m4TfykkU9pvNUgRkDpXD/AajB7hzllsMyuXsD2oBCzEetQIZRyiryP7S2+EFZqVzy6+5appf1k7voqBYXpJiPVWJcx696pu6znD2h8bAZQNbzfrUeqPGA868QVE03MtuNrM0coHgPHPyx1or8qkkROHQOBKZb0kgFszuBsKdKeJaGgRr+z7SlvtGlSlyU/ZFFpWO6DFl3+x52xvx9ESCNLYM5jnv62Bp7HyQPg1kKM8pwLwZ7RU7CS9eB7MBvIZ02v/LYslgIkqULymQgHxVdE2vjuZLVRUWMXsrcx+zGUtAyr0Rp9+I3car35DWtIiX4VNQe1NA1HWwuKbwJhZhC6gFvF3uBaZjIwMxbNlFhmCYVrorfRHB8A7svS6mzqTg4n7icUPjbojnXlKhREHVAsNLlVbM2QiLShqOd+LyIb2e1LpoXlzRVGSlSIMUc7xmqVenl8ZczzHYEGK6N9EG8wH1ybbOIEjXrZJXV0E4ifnTMjjGhCqYR1FpXX+OnxQAlonGQYaJsVcyv1G6Km5xUVhZP8j5uY/H7+FhyrFmXgIQxmcXQcBmcbz+qCwWhNTunnPt+QER83hOGejX9TjAjwfYwrPVEL+ySmvBBaLzYPRYGjL9bfr49fErZDy3kz6vi29ajGLlZhyOstCkt18ST3wfRnkyLeitRJaC5nIspxA7EGs2aFQs0Fjetc5ED1gtIDudCxp3z7jb6vZKbubjm8G8kn0o7Nj0h6/7Iqiu6OYA5jc4we0FKo2Z5DKWD7Z2+aYeE0gK01+QCalX0HtXtP9oGnzrexcKn5wGZj/MAPAFipczy1wmjXWAlp6eHVBmA3f00Ui6XnKgTT0UlBtBlywPCxFZ0IrtPC7h9a1WlEzDaPnbBVB0VvTbj/rj5v/Qaj5M5j6cQPtSooPnFzEdPeCVncYfxrKQX7nT2waENsLqW4eOiRz/mVKC0h3wyLU9zfz1i9Uly4T9brjziEtOWlG2Z6WKMOz5quta7xC9/Lf0Nvn1Mei5BRVjOd8vy/fqlpy8ZAeDuSo552pVa2uMpKF0gqf5nqHiP5JMoPBV3K8rpF2F7AvxyWJ7zi2I0JbWIiEckDnnubReyE9Uv+3RAiFZu2ZtDa9ESkvuc0Pwzq20aFApKCgh4oeFc8XcLMZsfK0hrAdc0+WBkyvhxZdR/tMk9mEnvBNufb58cVTjE+KTBpUXvJwnATmIrHFYAiZgoPyXvLyuBWoZg2CpJ003OvwJZm0TXRXJOcSPArz7uW7RxsosKAMaHJTW0QzJ7Ocl5Eg6pnJUlBk4J+I/CtmH1SrpEotbI+/nqR6hEMofSvAeBBxkJihJrW0robrO81CBdfKXImSm3PHZw4PL799C3thzDQXZjVVtso4eOG+BAAuh47ujYtsL3Rbz74+BoOf6y3pHL5HaT0BCMfvNjA8P7evLlcWqSkEqCZlKnwQs9KqjHEOoQ8JNFWfkiqsyB2dC5Hm1+kxAhBjQV/iBUY0tOv/DDiB03Z5xXNVN7g1R9ZwgCaNRubzv/ANOhtnjbr3in6nNi3zyGi0AXVomXxZZ/qn4y1R8lFfmjdTN6uiRBM3ZeAfidHxWcMUIFLcyhhtHA0cRFxkehfniw0V4FVUQTKNtHI6CRJpFk++BEYiFMLXXf7Q9SbRTdi0rtsEPzFR0FUI+h3a7HXZ6DyKhon/aQOu2Xg+ODPnbGwsm/fo9aOKziUepZ08anJq+zjs/6Adr2arxOpOC34yolcpnu/fF9m6qdImmPnAlzs3+dMzq2j4UMlipZgeRPNprrsYJvjqSGaogu2jejg7PsOySGa+gTFxzSr8fJeOWN0nzRIWPtVJWYbmusa29bGHVjsC1lLLP6JRzxLVzfQSE+0/RYKtl4wIc0d+u8cqpHtBG2YLbs5F7nytzvLLUUwYjTO3OYXcvn1bmQXgRi/egACTxaHTh9vnRkYXffkzLYHCgOqhB/oo63HTU4tXHTBP4SCmk8Lux8jCFQchyNBo7LPT3U9EuoB3QB75TqvLXlRqcs31rn25J1NoA2bSbRYckYNtH/HMX/mQjvZNeN5WrDwLCSbfmpd/JwOEgc7lGOUZAiiGYPF8YFPFfDqVvGkd+QLnLzUaaE8kBvR79ltvr+Vuku6D/J1OyZ+WduVkGVgaGYkQ+CIOmd5SGoVlfcqz7+hshckxFluVeFwDWSqJByK7Qas0pD+HGMFmkP77+zXJrnlNFWMgB2o1be80iLWmZpeOXGNpNsjBYqWYHkTzaa7dDvwKCu0Ez9exL0EI/we/o3uzqOg91jkdy9Rx/M+2+ED4jk7RxPTOr2LcDNUzpbaLE7fqjJRX3iyq+W/XudxRhc69muPwm5aW4FjQczZGDrckwY+NK4gL/rJsVUWabbi0ejSKO+SQK0MwokD7h3X1SW1yBC850mK0wwI+KTmiAfjAGS4Onq8xnTRxEA5pLBvDCYoUJpj1HHddEXj2W2VWyrFJHKU2sBpN/wM27FOCyRUMtSjzX7y6+rqj+xp1LAGCkyKAFS8JlOHImb+Yi1MfSpTdi4y1sMPWwK+xPdGlBWHtd4CzXa6nZLCGkLM+IyHiam9rScUcto0WYhupEOoF8sxOy5Ex4HyBDfgqCqXsR5ZZtzd8nDggY6eIh3MXmSCpsiTbszf4g7POcYPWfkNrgWx0hidtGilGMzOKwqV3b+tbj5Y9E4RQ8NRHCsoetOkBKMdwQd6R4tlgzLwZwtkU0DOSrjRD8b2YcbzbD8axj151L0mZtvDSwjCTveXbivmFwcCXIzEJypqiEuXeiD6Ro6+yAhcJQy40lCX2ng7oKKOIODNee/FWe2C/DoCqoRf1hluwMrQ4hug8UXvTgndu5qAGccM5U/kWMH36PlHmpQPQFD2spJZhfzgBKrSxmAg8z6pgQ9HUkgFP0jhYaP8fORaJYMoiZNFFYLCdDW5kU3wGzql6oHVjw7CEdpH+CNLJo4UdWyVAgdmt8ltZFUM7gjHXHSFurLR2lVijYg6cgcQ1x9rNEgS7OdaRxzi2997Q8KtTqfsBMCzlIQpNXtS2A9Q8t56TP+zv/4bOJwbqWfPfMXuhbXpBr8Hz9LZnIjvrVCeX812LWGLgm4pCctrB1utDHTStF9Cfdiy5Z+MPBD4YFFEx5RxyGIKlmDohy9Uj2UNhYZvfmIpWPTh3maCYvCDWZtN4VTfsODzRe00kyEWAIezlMt4QiDSk0BxOGANkI89EYN72vhRELh2xwiS2BKJhlzzSRN9imcj4GbtBk34wYYeL0TuXOXJ2uylOMaMXNlzliJhLRQX4b4Nijz6q4qh57Lkup4OyBGxEt87ApuoskMHafDmxQLL46xFgajgDfz5sfD1uI76dte4JPgSDNH9QcFi/zIyoPws7f8Y5sy/5HKa0AGffUJ2FM3RL7Kue7hWoeJECgeHNtzkdcxudru3/aRrC/KWfOmJhdK/Y9MIiJ+s7mDMf5FPNNokpOPfKgf72XB9NwPhaOVcFHTWa4oXMEHRVs07TrtdHSwZwbJACuWrq9V8HSY+nunUZuf7uHw8YUhQ4U7aLKjpApq/KwLSViM8+jsyNqvb8lirxKsxCNsc2wCYRb3LhqbdTEjOrbniqIxz853yf4WtK09+o2MxaOooMobF4oCBGU1/yCNI9DZlAnFOAMZKVFveb1E4RGRsONEmIcyBEYHWUyTMeXSG3cKL7FCdrBAnEJun8kL5vQkl4ZoQN8rMKX0t4VqHRld+IViw5dHIhOQWHtWiQfiFS8PaEYGXKruOyGCAMnxruEK1BsaSguhkNRDnHjOqUBUjVBxCNsaLH+e5eUOVqL9nTLg0xulrpl5OvDE70K7romI41+4uXP0n3oXxcsCpfYaW8mb3xaWj3MTpTydUV5CKNnaBRc7zpcsKDzkFU1pZlo/Xa+0I6Cq/NkWrlYJYNK1AyfYyFlGgv//TKNCC+y5CTdoJ5eKq5r+eSw/0k30O9/HhsadeYBwa8Wd/WTI2qmKmG0CjzpwpE/1lCI7upzRSYSOytYuT6AelAZs8kMhJ0aXRh6hFuEAcoMvKHR4gK2xAr6fOOyicdkJOd59vvUJZjW8EG5vEyJoMr9X5kZVsfvVFc3W4PIglvYRqAos0O+r4PXe8Cv3yZVaGJdJUBkVPQaSSeUE9H4LlrabfXCnZzr0NVemzR0P8Z21HDLSddt4dcQ0s/rp6EQyS7bHPQ0+CT3CyWrLk0dmOtxWM17M450Z++SouBeAk5FEqE4f09h7UDIHB4Ra8To7YUAJCtAkI3OBRusvRLfsDz/37dN5xHf4Z2BJlLXmoyEd0WbQygkc+IRAS6+zC/0Eggz0uzT6abgcJogYVGf2KnsZnUd6/xjcdi7WcWuIaJc5YsdPlRXx0yn5tZvvAkpRhk4A2i6llQ3fMAJHkfr/DfIbbtB+FzN+uGLSi9r8dslhFtJmAPEkjm/uoxdsC5kQlxbJaqrnXrbSIOMrcUO75CdmvATO9TC/7OhvJ0HbrkEyGsJ0d24lt8xH9nT6cdH7zIhDE6/lDCtIbANRUvaJ8h5iHcCqVGhIYLdf1lvl03iUWqokFmVypxD6rqT2cKDys1pQcSWbnzgny2Zn9AwIVbasN5OhiiIoh9rJnQmjzSL54mAYf5tHuobq+4WDm1PMUHH6NbXZLWYCCMhBWAyf9KPuoUisCvCUk03+PxJ1Lz9O9kJST+WxtM7i/UvXHY5HDOGo+T/AHf1Z2GqSVHy6HYyqLc1uspWPoEFGLwCYIgxrBMAwELiMjEXw7os4GP1GxL21c6Gp1vhfDqmHBKjc3YWYwApRMJ+ZTz5/KB8JeAzmVM5+0Rh6m7MlZdrBX2OpVqUthXfNOES96KrRZAHLRd2mNo5GXQecWLaQJydlTXnnfdblADZ1X5c5gXCDX0uFNSaFtD5L6e2ydxy5DeNsTLe5K5T5kc1nQGVmlDWl0Vs6YdXh2ShosuJ9hAXe3i02QGojiOQ7RPdjcSPrAdMdcu+lp3iJA/UyCCjiV/+M5HpLAGb5josEVdqZ23UrrdPzM78ZDX36RCY/0RsUZg4Ewhcn8+PrHgktACyQ1KgpuolgVkvGFzwGpQ7ahdJzaFlVgjKL/yBIunyRTtdAhd0hwPW9x6phiAGGXg3Sz3v9hR6zH+tHD95qNqV9Zqa6XCyocDPMiS3AY/3NNygCJanzeIUiK5JEEHjTSBjccm72G7xH4TGXKUeKDm2/teTNngDMyjUwX1Rmo26zTHOJZ3Rjj4iXs5SOuX8DgZ6eWRumMNhHnmTIamWwXz4m1yOCFHiMvM9aYdMNvSVLGWK9Fct7x9yV9SlChaI8UtoTJ3gLakvIQacl70mUYJTQy+UuAlGYGPH4Zk3FZJwVc6TV/jPpQwL/T1edA/oAOoNMMYPnISqimzuIlAX9TMGq2r4B/xAtUs5E2fv1P6FmtSswmow5zcBAyCuWYugf67O71EKZnQuGV5R+IodCpsbJbLcmzHplkFFHi0xhkdxJ288mWZibnLCzRDiUylctOXWhv7UyyfNWP24K2SEmJ1TsOZTTnLxrJ+LbxG8HX65cORb8BthhCI/lzUL9Ymw7vceIlXhm/V537vme7ujOtp/uEA2D67JccxAuLDNYPqn4OPoHc29W50mqVlzhPc413sXxuBa4DEG3EGcDV7GbqvkbMBeUMU/P+44YQit4dwtyRlaLvTTApehHhX9JEao4Z2etTXmU4CJrpnRKtjvq9l0S+SwI72AIFz0yg5uISJsrZM6H/LLzmkIK5qz3zgdwsDxHUX9SYqZc+6jP4WVVMNptIDOo/KUA6++dYnBaMGMIPU+vV5swW6IUfxAueGmLaWjSbokbBJUY47u112zPmVlf5OVr0kQfmVUu3fEv1UA3J4QqiGcMFOjDJR71QeAyFQaQSMwfMzuy23Y4Oi3UR8mX5s/xzTDE1RXaxSOCiH66/3ElRJ+SX9mYO5JfG9Vz0QEYZ/7hvApbSPkRAm6B6vCZKFnM+tU5yByHZqEzi8jwHWbf313enYMK1jPrd9z98x9P+JdKeSRfXIF+SdDeLFE5TUFQdUgZxVNnGChaDsO9BYU55L/GyiOfDzqErIlLoqDafXmLrAxa61MtCQb187NIDKjNCvZqYYZmI9Ywe8JRkTBSvWywjR2roU7F0LsznIOPJq+d3oK8OQwihgOko+LQOe2Einwh0dn+9uuEfJKLtedileco9X2zesbF3t/ZVmSCCQqDMSZEve5A9wm9Kd98WgKO1TD4PdMoObiEh3Mbczi0cf4XL43sCLi64LLcttKGULRq4ujI/y7iiVTfxvvDhkAzl8G8NFjl3P6RN1AEpG4fx5BhZSrI7eI2HWBjTfdCW/ZSju2Psq1CfPLlHybVdhBcBzhz6XdSKxGeowME+y6jJV51O+0YLgsMSHUZNPq9lbgLOkx+zKQlYNUMulYI5iZVojmGG0dz9pda0XQ5r3C3/Tm4fMzvD4TVGfqWzuO3T3MCf86e1/djlzvK5Bym1oSoI74ZkC4DtPobp7Q35kRlElMT6TmEMA0dIKN0v/xXfTqHc9ASFtzG9GwsZ9yxWLSnhVzTBaPw6DDqqDyJZku874+Qz8Qiak2+2APT8WpdcyuAIa5vE+2fEh0ddmcP7R+y+4Gvucb+LZHGzpDZZU0/kluMgqYlh9Gy5kPoaEc2pU0clp/IeuZVlOObPircHTFp2n7oPX09XIP7i4WAg61enXfIwYpQfNcQFcy5jStzT6NkZ/lTileQy8wQw3LVyJ3icXokYKjLEuE3VeRb3hJ/ctuwz9ucWV5m3WlB3K2JhnNASUkneM89va8qSqMPXpyuMZrJOP+1sGUTQL1YCVXnqc7umeg63P9i7Svo4Z3wMM/ScUZzrvDYH3TfLQa4Fmwtt7ac3Qt7/nJRFypS0PuKPxpBuNXvcoh+n+i6EHwRYhaN92FJx/OZtnarT9DYdU8zskTba5gdZjmD3c9E7hgQq3stxSnNQpF91QtUxQ/l7u9q+B2hHKc1jNiR8igUyN+5vYycIgtFYd1sf2LhkV6xgtDy1amlFPTelVZ1l3P63nJSumFlNwhlY7X+wPseT+KzyEvuyDogjV3g+VAbYwxFu+p8eEwXewPu/7YtrhixWc3jnZombH3zCRzP6ytpdiRN4qrXOD/sPpmdBVHOg4qZbzQTPU8gIKa9544bicY3j+fYeTPhGIia5XlTzOZfBSeptnW89qaUU7Jqwn7WADPU1qb9Lhl+Uj0iWbwpCTkBQ3ZY5eJMysoRmhr7yIpuNntlAz5TVzlKt7HcJsJW04pE7TcbXO4e56tyRiegD3xHaqEuFjFmkH91ZTrB7t1kyozgCsrrjc4s72P14Df8CIqAF7kPlUlepu7JI5zqnm6v7n+9tMne9LoUjJAwRqEONM+kB8NA/dI2Vb+gdtRLLZe8GnGD+5ZFQmfJNJ/fAetNpLt/CaJIU1I3Oq9yKxP8nU10czxkN9hMdowg7PfmKX625dlVhvxm1kv/pxKzDGxj8ssVAKZtWq7F4DsvBWB9axZy59oH4ltMUfJMOksjJN8/nFKl4cSDxT3jjfmpNQVDJkntgvwJM11WAMr8a+eBxqCTammneHDi+8Zke3rNpUd9qQQoME1Otx3xdoNMNL6Yz7+6F+9O2CedrvQp8tP8e6xUninWYj/XuMUZ5OGHmBQalMJs/9TZBstg2C1DGWi7oLfgWX9BfaorPXYhkOAUgGwDLHP7N9Zq73ki2GTI5pp36kh+ahlqkHVYM4nh85UfhKe/n7t0e9AbR/sWM0TqJD7ZN3rHq3dpszGj8EqDJWEzWQ85C4Poz1WE0UilvtDoVAf5iNRxt2PqBAFHAPcueAQnbuqPL/3r90cmYkCQUPqnZiSurFDOpahOAGoQlBawIJe9V0yN5ZgkPLro+KXbchG427Tv7yo9vWbSKWDyHTRCrlR3sj8FY+blrANRJqqNtvq1EYMy4HyoqhBrkps8HOcodB5ybFXnaJwItAG0GgfOaRBd6aibQUQeeiY60DxKaxHca7+wVEmNTxrqvA1trH9onRg/BcCwbiEJrZ5hBXau7FLBuFkMhzJ+zPdbjoCfqrc6Cqt7PnwKQLD1nwHZ0+AWQTpmgX63O3H4Ozo2641e0BGBK5DWJLw5zLwYIaHxYLaJSsf+v05hD42Qm2lVVqWvT2yv+FIcNhMz45ffaG7GtzM7AmZM/McsNLnrAdbFT+z+V3rUARLqSGUdWL92DKHiv6PMVEJ/BPSkfD7s91F8sPfjezIGtSLHbeHTsXnpeqYWsCchOewDBIDtVzPkNedKUMiAXK9QbZAFzJtEaxqFrCYP9mEtJ8MeqXbXsqY9zgVQUJGNdF+dVpBCUG9OTNqVlb46PUbEUnKPZ2MBz/cNiciMebmigCZZMqYAPjFpEQOhsGZ7ON8eCuZvPJHP3wxQNCApIAcAnTGBYcMuuc56cxogRhsbLW2HReI8B7OPpTfYj5KJf+eCx/HkRRDvre+HwE0NRAJsQKheUKo2kYU/6TShFU09deRNVUPprcmWbIoHR90uUVT1RwT+q4vD4Hr6kyP8tOfxh9g7RaHyw2SGamia+v2pB4THDFd0yoSIxcMVapFyor6NblqZ6nUuoiEquf3PR2RXM3nkHtiGiP+O2E/sZutEWBwt6RkPQa4v1o7/OzyqDN/HoKdrCyb2eCs5b3cqnmmLVgxIXBVo2KwK/DCPF+xtQYjQdzDeHO/rssGSylTNLnykIwHCWBkosGYNjfaO9Q9XThFo9vbr2FA7DJtjw5cZZNLOlx3Mc/e0CImZU8uK350U4yRPYz9C/lqsvy0e1pkGiXT4Hqd6k9cC9b0ndlJWTmKe7jrEWaH1vXEkeNYtO006lIBW1FA4JBfTlKaYfpzpV63xALUb0M/dFpZoPmNOsl9LYIBYGa8btzOd86+e1JHx3QDvM7mA5RT7mb9Hd8T0z7fVphr7Zlp9dyvdjuJMbj/qtwKCYP2Q5DiYUluVaNBfeDGN6/5Tu3g7VqyaC/gvyMDVrjOXZZNOblcH9T0UAK04eYQbqPMEb+T6kXMzopA7262o5eE5qRL1OwhYSoMAD2PuzbZ2LB2Ao4A8FMFI0svQvyKaDcNg/xgv3w4PHySt4qTT3cipKLOsVMrDNk31DJWDWUo6WKyN5L76WW25x1SdKNqtDphNVjMlxOEFfJ7dnEsYvZqxVvQI+CXp0xHRvgMGU1WKkNPV7IpcwGXoL8gqr93JdyzqikyW3yaCpkr3+sID/Z1RCoeTbB3z563OMKsbqPaqdpGi7Z23yyfMFaxZy5/LJOeNM6V9HFyy179sKOd4nDeBbsuIMnYHl1q8qINqoC+I0W341h1j+GFhmfJyKo5NVz/GApmFnphbEsAxV3ENTlTwsFH+CkgPIl8ajutOvcuXg//0gwxJnjoCDPmQry4nIx1OtHsXFO1OBDccfaXWN5a1gqOTVc/xgqMfqgvsRK/DnFq9ZhLktCY3rR4IAnjdNemMKFW2xttkapA0vlc4S/xxQDtytFN3CWfj3TBx5sCDo+zcqYoOfmrFmKqt2bYcy9uZUq4PEs6A/0x0rimARot30BXBq1V4mmaoGYoA0+mZTzLBpbFQMBkoAJrLamISlB1/eLB7ejKTrVD6qdzQ+QDbHbPbkH1SiLEvbV/kluiJ4FaNQeGqfBYKK4iMNc2XfdRObDQ8CuRLAcclHvC0lG2zXG73z+7QM4x4xwBYjoWUdGkgi90q1vMqb4wc7DZjFPRpVSFWPoJkwYCAjEwy9xnRTAYzfCmth81BRucC8fQ8ImpmVaUXbWwEhzLoufWqHjqRh6ZIacsykwhbWtkGUCU6N/hmNh64YwLHX9MtwWKuD36XPYHvTYhws6nW6qHLDS5gfXlMFIaHYLbd5WNV19Fj5uRszPxGziHwdMoz54u24pPnhwRn22YmCEShHawOlexAVfGtssnWADkpa/C/eesGrgqEXCE/c44naYaOHZIf2XL25otifcNcd0P9/4LPKslUTpIvxH7Kmb7v4ymut1ojrJT5wpOceWBcWKRYt/ptvH8AlQqmWJVAEvujl5cJZt6OWWDAvDhWRerxpHcQtyDIzCqwZnjH55iX264jwG7VEeIZqeXqEGMriG01ZbZhYlB2Nfzpb/0/IAKfTbj3vaJUpwbGviQj738SiAeT7On/HAS9u8FO4q5B3MtuHI2rYGvjp5pcRkmkA1Zy5qtqyS+Y5a/AmLd8WBY8uUY50h89aU5Bu687ZHoHgZYvy9lGdIpyTKFrkM19VZtjQoUOiZ+dERqgNjLfvzi2RtBR3ilzVzt/nCZMrXCUh6zkdGyunOZ8dmh2JtKCmuNLiuHUqLJfDJBNf3DwoLFVtGcMV613+dxuxL7oVLUU026AbsfPuz8YiXOs+r8BjOkx0yxvto7rwNfeMSs0vpvV0mNEr0bYpuwnQNG9YLSVgWVscNBLx1V0nvSzi1OA6T/peab7NhwwglURG8k439cUEToO/id9kfE9+m2U+1L72/q3I+nT5HQvQnsyulprK9IN+9hrhizwGoPwobamSioeaCNMMa7SEuAk4Yab59M/Runirh12WUXrE3y128cYtyBVuVlaQaLndlXUsFq8C9HZ1ycHt6jbd/HsmuI02uT3wnEr8SStHJNwt17w3HmrqSyYp3HULPqCxQc/o9VajPpiXe78EBCTbECmciqBv3GjUtJ56KTcQQdPIZm9S3/j+NJWjFF3S2TBG5SpfgdqgSpVDK1/6WunuHqlFGKdnFJ/8HSnDSRbt/MhnqF/I+qAaWm7xSdjp3eoeAgqM+WLCvmj/IjGr9TrMTwvki6RMGF+mtJP+RDK7PHOUA5OFe9p+Wq2ApHcjccvEHP9HmBZFbD9YNz5neRdulOWXMUBqmO9PYM5+WNVl9HKJbd/zbrnFu0c2e7hI99XCyO/9r4D1GHHOAyX+s3grc+c2FjjH7VQ5oWjEO7xS8zaitbCdb8CVdQaEtHP8koi2sCyC7eLqa6+JJExxItnwy4plyiOx6CfomWP3ltihkVcNFYL3wDcaZo2UMgrOsBdQIlGLNxmbwV1Oiin3GW/9NKZGsPVVhkldRrQBKXKxUOxNpQXkTIp/fH7WFpScIbAU0Q4zokpeMU6ufC74LFH+tX0tev9utPm+qxdQE2q4aD3Q0dUGIKPGlAAsAm3KY/Xf/8H6L2SZ0ktfNfHL2zpCHlL/WZhAMPivrQdOkFbXAAAr5NgYRO+iEYvsHzshFve7yRug//IuWPEdmrtDRMUseBroWhg+im5N8EBRpDRbTqoKg3bCUgQ9+XnDOWQH24iYhkbfM0La2pR7gQbP9Dx8e0S+N8EgNXMnCps8TW2uVfsz4yKuWZ/AlqfLq7KVUQAmWM+1SqHJjMTOqk9f1hTfrdfM6cGTmInmgVBxPvYWEwQThfSEayDJduGfMqWsIplfxfvU5UbQLzAsvxwDGzpe9EU8FpcnQLVe+++Q22dIYboP2mEM193BnPmhMloVbWgXf2RVWTO7yWwQ2OfKWzJTLagXg2c14fc6RCRxNqIyhqF4z3crNLv5Ah+2A2Zd69bUpTou6Ee+L6aTaVC0PNidiSdZerTtdChQct+e3IQ6OThn8+sG3A74xgs0h75eQH24QFwUg40nQPVkzAhtAjs79mKM5LFVK2ys4OoI/2a+As1rO/Z6zoZulx7lVARlrWIVHRsWJOurMdEF8FXH/vn5NVp13WxaFTsDRuRRW9R74U47YUdzUEuKrnebXHQFt7LRxrgkB4XiiyAhpYbaV7ria3BZ2obUsCi3QQkf5Bxf45PdE5hZoegLKlM3Y5luuSx2GjBTfRp8q77gL7oQtTXTS00nyh7XUhm3DhnWrYFGM9ZrKGu3LLjMX7+TgAjDmLL7FewhAlHUOz1zJEzbsoFsqO+0NiY8D0gw/W+VWQrBqwMgIYS1Pl1dlKq2p0nr+slcZlH8ebsO50Js6WX5MuZ5TLbU1W+4g9sybFD8TetjiaPr76xE226O4lJM4aZ5EI9CWKJEYTpgI5cwQbE6NGY10CV73NTxVbon490K4Hy8YftgNmXywa2C1dRLJ94MfaEHeVPUWBtktu+AYbXkmpaw6xhuUVnKquwp+HaqwRyyg40rQAbPqiY+GvxrEJUzHsIQLc/KIjkhX3YMYvQWyIkQt6W/2g2SpPChGWV4NVh9ORFtqklTzdietcBeWtj75los8uuD4ng83u5MDGSh3LQGbvyFLyZLu9A9fq/Z3SVrP2w/5S6Xxh6MkDqzdn4BekjHJaoADoiBdzJJgrDuia7/9JA7eEWXbBxt2rggpFm+dO8p7V+fQiP3XlBotJh9qdfkLldDifFWC8GlZLaW9jqK8co+gce7MCZ5bwMQSC0LkY+Wg5k8lCJR6H/tKN1HFKLM7gf/xKKBiV0NendimGjgfCqcbQ7oRYePuBNQNHiLsXZA1I1kYyX7rAqAYzuqPaYdbd3+DmSM7jVTJtD1NZS9lhYRkE4yX36XpCGaEd83/skaJgKW8UntmPYckoCm/qgScqtdSRdmJU5vK/C3fOixxKfu3Q2MBVb5045ljQz0iR2UiP4kLPFSL5NHuG0SieTcZa2GHiD9WZeTg84sqJIUvJgoBZnT3Wlu2BZO+A1Yxx8UxhJz19UtqqKkXKfA896En90WXq/S6u6IyxXn7ZxSHKFxR894NVh2KKmwumN19HRXzMUJmTqf0yxqmPMIOAWLpyze0hJozAuJNRH0ZgipGsFi7dN7OttRZQ2jPl6t16sZwCZd4IM4qzekU3xrNBgs0U8DYCsX2OPrRM8PetMObeUX0Preh70p/g58VioiqQnL/wov4mDSrVXfxAMx6yJIeAAAAAsTbBx3cgIbO1nDyfTXoDWUVxPtxfT2/3Tw1xFRmP0+BFpV1n1jCw+FtGskHSFrIojrVMBuZTCVlrLFvRXB1oJh5D4JMOpLHKCvCbkgWeC6yI4Zd2GO0K6LRKcEd4q1GxUc9d2iT+4x8bIf19ggAg2b/Ei9nb/DOnWpg2Oi/Hm98P1xZB4usfZwArsIdynOmfiIzrX7K3Ky2PoBte01tMe/FJdJI8GFSNbAzQXx2n/tatneE9hvg/vzfZoh3bX1qJlpINgO2i9A9sFylDV96O+vS/sx7isjX6tlHpMUsk7xjbNz8PDxROi9kbd8y+ntmPQihzPuZJSGzukOP0KHYYFeZEEOAe8mPDxUmE3iYd+dlg/pIliAq1LUfRik7UqVBmGePXF3GVY8UeFeQD8QGP60Kk+61BL1Tc0ntWBjHA6McAF/180Ax/gJzsut0X5G1ytUx/dqMkaI0MjCk+h1LWI72ebZqUjQazwf+McEQyBysIcvvRe2SCdirXljo2gm7kIDnqDTx+blrlrqK2Mi7ED3YRh/ShfVOON190vgwfTTkjhuIeneqzpzYv8++QErLAkSuxDkGBXJp2hPphqRk8D+NcQCVMhIRnTYhWEDJzKUDNrHyU/uxixKksG0XwWsXE5EiIAeNBCrKtd/RlREJdcXik70mGSSBpppiBcZXQpe12xE3xeVmShzWlkQuVAIGzuo2n6eoBDq1IVqCJi3N5qZJeMKPplwpkqr8TRnHpC+TLG+TweJ9pX6mtoeFu0KyCcUOY6wxYKJpYSs+2adhcfC2NSVHId8g62jSMKcIQ9w/G8RHir1rN9HkkN2LVZSsQWLKTKzdQoCyMO02wtvxmMF1mzWe52u4tObpmS87+FLpcBpxgZLxPwWVszYQPVN0289gEG3pVZMUk/fqBJ8AjXwu/7W2KHBRxobMHEJS2wpuwD+nupHFAT8zRKKQ4ZPLqTJHLLw8WUXk2SMreZ+K2ErdymsQ/deQJ5bHgeuWd6jABrRJBihc0ptJH05FxZOfapYhTZa5EdOpQjyyVbEY5s6r1O27XFW8Ky3Rd8JVb7eFmDO0Y+K4OXZxi64GkYU+lusweygahBKDUuus98l7VpytiKUDdSboR+4a5+W6TNrhnYexfmywSO1oTtdxQzjyBeeSJEPeFmCXP+XCYcF3C4DSFxtHK6TIcZa2GJgaE+WCelKVEmXTQFCZxAVydhoAi60mJXJEVziLNvMOfvkUSSfnGtAcp3q3W/w20jGBLz8XR5TVrPHDWJfehjOcn7oVw7RfDeCRyonYWAxHxCjOEmLPjv33IDWW+62Oo4NYtWrYbP1LM3xCtz4Vyugn8MdISOMqgqxeYshZdWZfNvxVxzmmAPIaPApsIf1vl5EAChOCxQ0pfZOB9+e4Mr/LAFFDPrh3y8ZEbXbiOrDwBPoGpy8vv30Le2HOGTEkvrnQmqmoWA+Yz3xZIN++yCLZDxho4MaSoBxHYu7LUAXHxIMKRHOG/xxSxqR8llb3UBhGyLHFaTgOg9yqf+KcGeYIm/RWdntp02xpPVdHAF4GNnlhZF95HNLuYoGWnAIYcJ1AbIr9Th5ZxrDquWAqRaWkM4q+DI9YLbH5dEXo+4fka1Qeqo79L3dCA1VYeWIO2hyBoUUg7cxFd8e5aWeiUmWOhX6w+86iESlfJa0xuGN+/8q1dLVkOnmkv+FQ0XfznrzkBoVCwykx4wtTNQgqWM4k/AsELdqwKXMhcK3VEnaraFmui0zxNlCQIzSmKpn4yXX5jG6Adr2arxOpOC35enYGBu/DMp6f40DACkWqY+q4rVs2ZOkJm7phtjpwnHcOnuJGCRHmU+C7npToZUkeM3oJOSSg5oyQ4XoNZtBKnc38EjxG8hxySgFv1WA0k9D7xhBCAEopx8EBD/6Pn4AAK5Q5grlz1szNrnKLOylodp0z2zT1Qy9TUUCaQY/MCbsp818b0Ia82WUuzJPLo5t5TtZ0yKWVEMO+kGFt2o8Ho+BTm6celx+3iF7+W/obfQ48vlph90Dk74JecYTccwgNeoviBSo1f2LR5U7agQz4Zl2brHMOllQ9tDKEHPN6UJ7Ke7bWxfTOP8yp/iPdj570PQIdmSI2kC1KHelSzh6yw3FuJYnOaNKkvYMP/Sk1ADLXSIcPJaDEofsMSZW67eT5/neXgQ21UuQyMZplakvhf0OP2bxik6dil7sj4Ih6Rn1pKtZtvIWp2J8KAicIFkNZEN3xV3212iuIxsHOaSiYg38qWJ9yBZnMBZ/rGvgj3L2jtKvODRQ+WAsyztv/CAHV7CdzGuF1Kypbjwk76Efd4b+92CvQLUhL5tlFzG8HnnOVq3UbPW0K1EAkheZ4jpPYHQU05ESNSSLb1xdXw//RxuFzVmcmlGXR5Hh8yizi1is00YypwrjsGoCjsln46Hdl3T8V7zEAMleToX8K/iTWo2lUZgbCkNGwAnb8DsAri9sPBrcWgQ0+u69f97CFpTvH8MQ4hoH54BJ5sFfdJiMjJfNb7s01ARW1/zjcDYlpEGZ5NbIRPE/8mBxQz9rUXssQonG0O6uTT6+tJxIhvKsjMtslyL1mNSrYuvRfxM8CZVeDVYFC2LzeSHdAB6B8xwPOTynOni2O2rDOE3lT46kbnbuI4/JG1QKye5guAMzVhFGnweV90cBaVAf/+bwYwbrv1mbBtV/0PX4RucjDZ9/Ra6wDTWdcwXZf5+N4pdAXym7jfyO5YxEbU0Y76KZ8A1m+ToFcWVvzxcJ+x8OFduUYS7XK0/5ziWaKR9brdC3CEZbpb8Ta6OQp2h4T0qoBfqyCrB8qdpbwusIrg98lL4xra9uUnaHrV1T83yo86BBo33gcB/6XvCKCwUpL15uSVqALaiNWzCNG+QauIkqRu+Ep/cqVYPCZ5Qwab1KF7SV4hKGZkiOWEmI2BS6ssG3CN04/RIrte5de/HCavQF61aOXv59Nmhih070d6AW1xATPRrgWxjCpYRLrxpdp9Cq9+74zcPweq172JiRYVenZ8bMloQKXeqsaUP3Pb+AiR6OGD2OoSoEXWyZucf7aqfpDQ4Jxpz3bxdqSgCMkb2jvjWxXVz5pFZHl6lwY79ic6QyOV2EqPd3dsOBDKyTfs8iIUNdRz0vxb7sCD1dClaO5p1VJuoYpigkwnfgtBWARdrvBud69R2CVVwMavS0QOt0hM+c1F1QYg8YQJ6NoKAAkphtt82Y3+s0ZB2fV5+MeeaJZfcUsSjAevKyNH7ohL6SOT7TraXxwlmUlS7vGv9O1oVwGZMpCYEeuUr/bgomj1UT1jV1nS2MYtMiNaL+OLm0kRCS4rnj4R1aBeYwteUTyW8LfQDuNbmkSsxw5lWFv1qrYCIKBmSdTsXw2hbogdfcDXnPH4/aTl8ZFZy1vUj10w4mZ0zfbdOeyQ8sikDCB5EsZ9usFo4jNUFfBQPA+NAKAFmrwv6YVULwBdzjD+nRSactYAlqf3craroMD+bA33XVVuatQe/AOs1GJU7iVslqpkVmxGpDTl59czPe2+3U6w22oazkJRX8Rf/AmN3sGPYAOMl0CXwgbnIok7hNl9Vl3r2l0vE5h4solB6OY/kFpE57AeK12udtUrj3averJxrsQwCM7fX6aSI2qrHqLNTMcz/KmSS2wQ+eJ+kosKm2W8HHaTC2Xaz35dItkX9qYmxDJYxTMzedRwrriJH3JV2uDhYdU9vsV4xSP4ohFRY/O9vHo+xkaOQzFtGBdKpYvYBGv8mwkJsl1lDQa5sjIEWlXMM6KgokFd4C+53zC8EjsZOXHY3a7ZLC+AgBgZPwwQWwNivgB67itWpqw60YID4NnxxToHF+hYyss+migqMylMkUyjabd8HFvEj2Fz1gjBFJxOCI7iS+W2hccWIoo/mh/jlFCzuaa+514AZGdxuJTIIWSfcN1mD/TsSwSpBDOKpxAMTEqT4AsowJgpfEHZDNdQPRC9rLecGl7WgEN9todk4Sxz+YZLeGNe9TY3OqvaGzhxBLoTuZrwmxTh5yW6oKCgyzkg0TOyBOjlCKJU4CVtyUpnxw01kQ/DQ+SADu9IyUgvu2VrH/T7hrnofq2/FF0Z3R+NkWbcZ6713mpmI8SKqhLCapPXiq4q7e9F0nudlrJHVE4LiY3l+Ckz96bqEgDICBt+EY+cyOwcs6yQW47ZuQRI4/EVOb/zPTC4ubXV7Fn2eE6Tu+VYX4MK2kaCse3vOYf5NXCSPlnIOgjEx1z5O2O3vp7cyNrRVtGq+GMC8wse0qUQKPBD5JpL3EpBnR9LzKe4n0tW8PReeBJOyjINczZQ+rG32GYoZEjF93HYgzI4oaIMoTvh1gXxxiQakvA981+EzLwPfNfhpcxPNEQGZykP8Pqx9AkARhC66RRFG7PPHxsZw0GT+muEGUaI/0RVB709d3kjPIVhbGell/hXU2jqGRRICjiqLo0cHYjLIXXEh+h63YgziMrnYybnOYV4YU9JhCsXzxaLJG7qGlIYBfwo+7Zz2SCIKRyR2WLz+BvNcY7ByPYnG8FPNs4crD3qOmUbU7RK/ptrUbKBkk48egk7UGZUNy2qYjNLRHq3J5pScCVndU1eWI3nV0iN+IBWXjOJNxRtK/EZXSArmpEXc/RKwx1NqaQGE/h99IPAn55Gp/cFkBx58ttPNjmWOggk33YFDiBOVbgnG9UIQ4XgSf1Kuv2J3Ma4fJs2bLDpzYIXsa0kioL26XGhrErEhzavlVhF3SaUdUIeVsmWRPoAbmAuEMebMMk00ooMXc8fyRaGQKe3/zvShgQt21G1xx4UR8kzXFFF5Ogu4XSH1zeNsM3IFpPvSilMX7nfpWSrXlM7d8eUBjBIWy1jbVlkqvtPpcw6tc4gHN1ExvnoCK7aPU5mk1YSKXdpsukdBVH+tsasgjXaSLbMXxVR3jIUWWpEVXs8KFXky7eTCSsItLpO12qbLuRKshRXRUYP8OX8T+vV+mfzWcmFChzwOkd/7DERdxcYu/bqDL3gJZIuE7wArLU783DWALx3o1oYmXtrL861vswR30TfnuC6ObRJj7RHHKqV7uogth+NK1EO8yxzT3BwzpvJiyZwbXNP5T10nXY0V3MX2m5L/zw+krg5wGCzkkbGUwZ6kdYpNe/AQS7TOwKPBoO7aJf4WLGk5flMpjcRmGr3h4R68owKTB4cCFwwaCVTRdwn/hIfq3IbpGjn0KFAtD4miWUW/VLTNbT3YtXEZP76v8XdA9LhAVYhE/r0eF/vYVdfvVY/F1wwg/fdGyRFWDs3OMRDUYoKK6CsKPDK+TdmX5HkO5b15FN0KEN7YQM9SAXE0ljwkPFiIPil1rGWYkcYJ3fJXgQ4WchD4UyshhrRn7cYcvmc7RyCyrgoU3UeEUIb2Z6n9wQJI/pRzHcKZzo2xS5aieTclKt+POfWNpXco78qy1fOzFvF6FtDV0IYibc8ec6V323iTn35d6PJn1PaOSePHRYL0i+dXhX2SzsqFqqGDprvlYWmOOgW4B0JYKbJpGP/yMkcZJMesLq7yIfRSx5IpzxDGYuAlNYzARBjia9j6ZrOT/ZvPC6ymnT0Nh8wJ8K1SQVGMl0+Qbs0i/GDceKdD9i62jxHkFQePGUpMgDQii3i3LHKBY1ukFIup1nj3rO2UN2R6iBFJU53UnD0ns13CNh5KP9cJhC3yafCcQoLPc8knxxrHsQ6ttjCp3HqeIb0cemKb4OIuqrMy+PGEyZjoGewS75YP4yO51iDrdjIxV/EN+GVEErci6boHx+QVGLm47kpN2gbKGSLOU/lY8POIYFEKovd7o9ZHaOSTyUCDjd2d+9EhWmo9UwTwa2lFje9ucdEULtvlH620utEMkvXWPRa2ZlUlOUUR67p+D+lTPZpmwOVwsNi0jwRHNxiuOLDZYR8XUcvn+QFc2BUCDGdoKkWUyhkkdxZmovRRkh3VZaOHyLT8MSuEcVpQcsxlXvuIuZXLqezksIHugvLHMBUhKJWFhcdpS3SPOOzJpnvxLZbcLsVwUn4GZczYG+rTS++oihzMtm74zjkrjO+len/7OB7mJ4bkHg/z1WyJUB3N9uCTLgoV3uyHWT8MGhZIhx21vYVBjYEs59xHSl6Bz4R0Zbx/TC0YjK7rPnsiNcaQ5ZD8+aZMGDRVHLMawgqPNeiG6qYrwt7YT3t4Hu4rVqasOvOVl9GGsORW9vbrSwf8r+nwxUKMU5iAvBMSQ052JWxp2dX2m2EJL+MYPvROWBNzZD84lI/Edn/jM1cveVZn4pre1HUq1CBzgPUiR0N5ESPWyDOj6a+tF2ZT6wdH2tWbadhbC+RI6W5cwbRFCn5Nnt7c+a/+HWyDOj6Te+kA/tPkNpNZClJFoD7rBb/9IiQRC3WLmeM76V6uE1tGXMJnW6HUzgBnbUnVUwJHFu7Q7eoHE6n+tBhsTR7g6b72uzSongYU7LtLN+d5Idp0C1X+TRqJebcuwtBHQn2zTLKgAt6qrZ25AFKVyAVFOorlUiu47ju/N3tW9LLPopHKTiMShdh23h62pbLm4llA2xEyEuDvNuqAYjM/3qi+W/+euQTUgRfrhGVrsUARtNBuPnHdn3DRlGxC9KqQKe0d1Rt5c77MHI0JcZzZXx1K+8+dHS+/AuCS/uenWomh5y4w7yTMbJLo/GNYcmWoxKO9BP2US7+FItGvzXx6dY0oFtnDFifN06KozqSV5QEOlJkPQS1hm37rj9dsOixMjATzBxgoxCJgWxg5B5+kU827ov+FySEcBU/RODaDOYZHJWsiZZwjzFYtgJxGbTnok5g6woHMzqPV4hEPh8iuwBR3AD+55Ddx/xbmC5ElsCO5olTDPk2L/d6pK/HBjhI2uMfEaIb1MBa+vI1S24RaOnsmRFOXN4dXEOPM9sl7gCyNVSh2ssJm9CWBdp2Q1mQOeeFRPp+W4/TigCvvmNFh384PNfdwQDsbcrxXqdyDWZFqrx1wSIOLsQqz4xxcX6UP5e6GxtykdcnM8BNPK06PGR/BpwoUjbRBvlC+sqpDcAZY/zaclXYr+jmrtsHqYTOYfBwgP80D8GPNQFJ76w7TnasVPgRxXVU0MgTo5Qix+QxXP8nhoUYxkBAjA4d7Y9V91QbKATt6O0GJqGqTkKAsWEpO/sf8w7oibJVo9SJSkihHp6TihTUge6gLKm/wKmiW+IpxI4FieFm7ezceGEMyoJUHrkM0IU05xi9dsqbHtTtg14ijHFPmlj76gVfkQTLpQwymk55CQi5kA8nZ+Fd8Gqjl4th7qW9qDjL9bNAzipuL3jduHEzabCfgDBpik8Fc05rNMhhR/jf5UOyMyQ/aR/KHL8pFtPc14OV3BqdGqYpfs/B+rwZRH9Nl8VNTjqj0k5/WDKX8HDLDstMA6t7HEz+RwLKiUkNDYlSgV5QeRhjkQUMVOjDv5wM82LM6Fgu7oJVoAAGdWY3cyfHBNSU2vHoRXlA5a0V4gVcnCEXFolLC9k+ajqk+a027/EsL3STMHUa+Sp4yXrw7Pe9N0wt2BuPvIq3Nk6EeSyeWlbiNLRbVxOny7BovIkybP8tu104FoRRmzC9QTh145lSrP17nuW6UGnOdLPKYzcn6VMZlqFhER648BxyLURSsaRVbzwnvozCdRvSpSznGU/yHT0qOb6dsqro5fP8gK5sCoEGM7lASRqJ0IvFO1B7ppVUSYiRMEIFjXZvZZbmmEEIQvxsMrMl1yLT41mRt50XX0f8JlG+kTWr0X2AZBb+GEW3dFcjQZUnBkxRm6Iq1/BA5KRZCQR/pokWZ+U9aZf+rjNvltlXwdIWLsDyGpTsk+JXLKZhcISulPSIqY2dsPMXZEo7PqPr9sPm6xfyx3LllsqXgX6hbHA5KdwsPYLM4y2y/+qRads3vinRxt6cUgRC6h1apQztcKJpP+lrp1gpx7JqSV+oi1NZ+ZoWEsAK8E5stj8PQkQp+yIhezRwk46eYFAE3wFcZreEYVnHE1sywPVqdASHZgxvdR/gLVjGfb5MaT/P06/Iao84ke2o4U7YlpT7PUxHuvpXx+Ptca54Ie2a/PdkgbegHYvUsxvkvLAKRRau8nP/wuKpSTWe+FcSKdrak8MPc3qoYsg5WT1HHHw7T0b17vAUgf+Er8O99QAznHIFVunjuvnrTdlSsrb0gaacTpAZhQ0sCcDZfMttsqmAgfAWGG1cQ85AQ07VOPLtRAoyGDjyibwvqkdnCZBpyuy2WM+b/Vp31xEwKSMLndOcTjMl2t0K0j0+GckxrTHLDTO4bLQdIq80nRFxC4NSP+S+xPCj7ZZnMmd5rqoDHajO4kW/J3fYeVZp2m/omFRVQU7H5zqZLpEKqwyIXZ2KTWc/osJpF9uYPfdX4Cx950MkqX+OgGCYCYCroD+unWQ62FIlE4FT3uM2y3g1pv+FR4RE4BD3LPskKZCtREpbZwloKS3kV2JgS20mRi8rqpBdj/Iu/8B4wXg+//aia+KAaUOVrjQtm/CDtdVf4KZPYseV9hDhSPuwgsLJXVJlvNkGxjJ78qonYRYg6c9xIrniw/zfi3grRO0Ae/L/SMl7D+yhzbsoFu5ZyiS5oWUAr5E4s4R7cXFp98j4ebpJEfUP/VSacWUOjx8sb2lCaH12LFYvGdyDXW98Q3VSaWsQHZ5zt8Aee552f2LmDLxC2C58RnNhHY7ikM8acT46h7C7XUxO9/fV+IHeMEammt/r20/IgE1/KyvuSgA4UNkNCgHqwcO8RlEKGRJfal7xC+P9N4pgaqZbfWAzoxa9yRj3auR5ZL8FogN205tEpCdRW83/UihGNCKwuf6XJbV40VfODiflb7FSDeNkW/EebnBF79mU5YtO6C5mBzY6wArJ/wLkhU4JWL3Y2oFdCjwQtXK50f9Xn4x57HdDvIrXcttg7wwA0vlUPFv9PDt0W6ez327dGOl/uW1g4/LtMmbZW9OTmEjGstWud/MqgyOissiFZItCYdlq3ggg+J7hpKYN4dAUeg9wZqEEvUNu7z3dHuoOuMsZbYgrS9l0ysC9NwDF19+t0doMTUNUm+t6Rg/s/ILTS2UqVRsdUMT5TORqWP6EjRt5K+wl4I3xGJAKO4Af3OBTrImFhiGndO7tlRcNx9mKJPrVYGRE/Ir+dMIrDlBqVCWzXQ7Dic8LpbG+K4Xh9QNr3Nr+2PAD/6mx+XdJR4md51YZjcjJjmf2pO+VuDHDZM/fWGsrNOKfZ/TCa7OWOZwOGqjzxnfSvVwmtoy5hKEWIQNuZRZ8ApUAbccf6BXfKaUdty82NSg+//5gqIrHy0Aac/4ZYgptsJKObAz1uC4ZaaZXUtgBOaiiBK97oXNmgbisFPKe2UcrEJJ1Eulfm3gEWW8wnPGzmBeIkIRCH2obnOIxfKmJUszkI3p0tAvhc4zda+hMCGdCpxfEQJpiMnYm7dHylYO6H/OCe254erWd9GBHc0WhgAWbLGPoXOv5W40Ffmmd4dIrM0q0kvhXQ1SUjeAyqpt56Qm+QA+MWQn9ANu6de8IkyYzD/KW8lAK6ENtcAyAGgB2YEMHqlNF/oS/Hmw/KN8HTxHMUKZxfAJ1g01wbQtO2VSaw4aax1FMAV0CInBkos1LRsLylYSOG0nv6ywf/8JLbGNxwZlNItZ20cRTaVKMhs42WpaoF3DmQV141X0lpO+/1UbSDw7AylO/ixJZqNPCbT4td8gv29FuTToqIeLPl1VWztyAKUrkAnMz4Tslk1EQGYtMs+7CHO0tNxFObXqk59SZMCzOw43Te7/94xohtG4i7NfJKyiMS144psLHEEVQAvJhOcSzFDbXmQxYSRd7Qt9X2Yw6/3i6Kn+m77mnOGPTfRvz2Q9vKPSKriwx0VJ7B66m6guNse9sfd49TK9SzbGfYSEZUWy+/GL+RH6jg2k0z9rL+ehxFanAAsW81FDSuMPPGDkHn6RREmR8o5z3MTo8oLob5N9eCoetIoRHLTz9Fg+MoYt7dKVHZypB7s2em+VyrF02dqfEVhc5l6ZAeQwPll1weKzH7kkr3haPXkjpg8JCNBDb/X4IWvIg4EkHYjTfkwQDRokWyW2Y7R+aEQdigjNVr4iMfGmKuB7MKUY4nIxwZ5vk2ESHOjo0IMM1RvbbCSi/Ejv0kh7hflYRDFzqvGt4D2qQsrLspkxC/+pxxW+6AIxYySaI9TsfM93myVshVbxqVUVWTQqspCAIZkphNRVJp6rm8KFqQcJj0Rju2OOkX4T6vu3w4Is+lPk5W3LFNX8un4D7d6pytne8buOUy43UgVe6J5+EulEhnX3fozCc2EjcV1EnE8fPQhNEv0DpwvJnUZ+XKc2zwohEL5yZg4VJlIBN0/wQlV/S9fHakQU1/nfcKVyScsowOYCXIWEFn1YzfcQRWVfex27b4BXkvTFW/Qk0WBrgxdzhyHv9rxkjneViCgLCG2ClvscauUQS+GijSsQjLziGG+ymwPO4NbkON94LJRsLqZoaqIZXJ6k57y4Zt2Vb3tHAnF7wlnGHo57KE4DTAX013I8WkZazzgWgrYM8/ihAuxyGVEErdgAfrFpY18IeMcJ8sF58TJsbg807sSfoWUlCoVqLhnD+lRLAT5jfMQZgZtevZ2r12lCFYVTXQpu2dQz4XZ/Zkq8Q+OmraSRmrHr6hgBZ3hMcZA1QAMz6Xc1rZIBoRdM/iBGbNBGKXH93vR3k4es9+/MjJvIbEYOJGdng3dghEgXXuyEVW0fMoD53IQK5mz9AYVuuktKu0J1XEDOvL77qnDdpVpqmkNoOfIc1tGDld43umGbD2glCCOImkHUqMdI1FZbMZV77iKN5ReP9Jo5MnIu88jeIzMG/gVznXfdcStEQvrGhdt2993vDvpV/8PUbW+vsopcICvy7aBFO1O2daofFuOHWqdT0DfaFlhs2m4Nomou7Mr0dSaxPWqfJklG2ICxN8jptqfh73UIoAYZ712ndbkE65K1tmUqH+dmOnf0Rb9EunjWl0wGgoO1Ch8eoBJkv6QDV+wwt6TcBidBlZ8T0Ft6bcNZCY/RWvd2mLCEhcQshXYfpgfkvsLgcWD9bMYTrf0INaeWbsTohAS6i9DXlqMZApqlj9egh2pOQ0mY07udgDsKYJR7FfM6h66gh37dWzyvnwqgyZMH70SmqWretHOVs2iJnVvhny+gR8jV9fDrD76zuq7dFUfi9mSS3XnAkXfYpulkt/XtnpbvGKYpXfdEW/JrV6Hh1ySjMVezmP9xsMtrn77eHdX3CSiQC0klPKrh+F67+7kbCKLUP3YHjBrxdQkDMVWL3ssPVrHZMbjYe1PrirK4B9nrx315qvRUvirj3qI3Fd34JZyDoPFTs+jl8xQyA2Z6OxmjKVFMGqVIDepINgDzppUcq9WmB7laPdZv8pXmcKuMfcvhN/XCRywEQGCgM4paYL9mBrSEf6Vhc4eo2H2mOUMVLRL/nVVzoBYczaBHsYryrDOStdM596U1ctRt0fa1TsHXuVyhgWGtLgN/AI88DmD5lDmoOO3ih+vgns+nTsgbrSGABJKpKJy/hD0v/n+Fuhe6S4XsQ4evt3JyFJ4IBP+qJTBPQB5L1Lu6CVefenaN62rPK9//iMqUqiyziG14QkC0UU2HxJiDjFGBbYQ+J/FR5a7ToDLu6d2GcYGZxoCQXxh6Koi00XCaUKEnzadQXElSywnZ6JH+YTQ4KApVvJx/0pTv2G43EnxAhB2wSX8IqmsgbYv/1ASVqnBYEhVtg9J6f5c+QmvNbZ5R+4sWaR7FmvYGOpkp3B38yufpSWN/nb76xCJQfhAGxwvrZKQt9wZBSLEWesnMV2udi9kJKYhflVPSIXRlGoLyyHp+SDlgkLfEm57TkXFqwV7zSp8HYel/9alcsyNCiqeusBzTDTprjMtyVKoOtBZTV+kWWEFfIFEFJBKj+W3Tp6cBQtE5lbhwJl5MPOtPkeLAmRLYHAFUQTFNiy8vIgAQijHoMlZiUEQv7Oh5B5lip8y+QsuYgTYrwKPA4wEpCfF4eZfOJJCBRGNseic5LZhnrUJowS/mIBrFSUSDVH5qeqfaMTvvloBuw5RUXD6CBu7HzgiQdIJd4XheitdqPjT0IWrrErf5KimsvC+bIHHynobGXF3a5tyRBh5i8m+KqRq0/EeVYrikpYo0YDzc2WyPaOIC9xyE5q3qANEI2Vyg7a3/6lWTD3bJgdlsdrgSWC0vg0fh41fwP/B2FC/nbwlRIy4vqhvcBpbcWek8/DfQnkjOIx6dy/wz2wHjqWQ9DTfZ9N1Unl72taKne16FtiT0WYCfBz39flgdbF4P8znGrTr6CI5yh4v5VrjGT5FggMOc2ZeBor99BOPS4l1zkB50wzOOqbm37ERXwoCW4086h0TJ0ZeR9wyAGKITQJO67Bi6T/h0R2MHxIzKw1rQSmNbxSwtjjdiEjmvM+6jbrX0+FV43OmeT9KMX2/NKrA/SSA7N2b/XYoisjIknY316pBU6k0ZDm2wfDBILnVGlHSc/Bh5LKUJkyXaKLH78f2FAVD1k24Ct4AkOUPdcDXroWeRRkFYNJLMK+10cj/+xLzTTVzM1ci4heeleEAyUNu80v0daWvuhWQqipoxiP2ZE2Vj8sxJzcvYhoSUSUzSafyD5oxz/iZojTCFT+AokDm6AqypDL1Nz3Y89RP8avAzHOR2zLk/VtZoOE4zUmkAfHYMDIpVzjlHPQnuJ2VtrHCjX0qk9sGI2sysQ6kEwBWY+wkM8PpUa0NwTweAgkSHwJO2K0XKF2gLEve3rtRAvLugs/5GWZ+alacfJoOS3ELb3TPUZcucEnJ30EloFfE5gFXQXa41C6C8ASbR8RSi3EuDFxacLa7OTFczZCURIFNDdXGSCEs9FFe2K1YaPHQtlYvtBWXRbBUsLW/5Xby7eOFYWwXxhSM0LEpBLGBKID4NnxxToHJ7wsSnBNsyEs7t+UQKPa3JJsY0I5DNDzhktRjVF6yCKzUcHemC886JwDXgZcnz3SuzVa+511hOpldpU4iRV/Ve2cY7dwQLWZ9nmo9NsBiIEFmPob1jTidFDEAzPYPLxKBDzJAC4BJBZTHBI+DidcrzUkQ2jcRgVloyU9hJa7DjtVE28W+pIxOCZLR/aDTZNQCsIvseMq1mI6/3i6Kn+m77ml7TRYuoTt5sntaRHdFLcNzJXEnyempf8m1BBodF8foH+CLQOmaIDsNPVb18OBKm2wko7Ys6/3wagOJyd9BJ8w5gWnfU4rfc1nk3FYKeTdY32htPP7wdFqnItH9EVQQu+FwrqOAMDEVzwZ9FshrSgyphGYfaf2ddP7tuDAp+jGHOmc/rbv6ucMMsaHsHsovtG9EgV89uiowmP6xqck8soVjWU36OISHwSTZa5+ODTBGdGg3T6hEte+RUHc7vah8/XyDi+gO5olTE934vXyIHjniYhqCRgFnrunTgZhThkfIyww2D7KIm2oAs4dumvkrC8tVo28N3jQvFxRzlEthQYCOTiztyWyui1obW1Kj7aKHEFOuXvRIxZH/XiYfyi8B+SHxF9XttM/0H+3y9mcwKn4fgYOtdMbqkXovr/GCg749lAmLNTsN+Kswxnywu8oEV6gaX/4qZrTn/df15U7yqYZsPYOR0fMQYEnNLnvufOQRd0T6+5hmvyHUJ1rvp7EuttbtHS3ivy4ZXAR4KWOtrtXt2L2ZmceIiuxjpnVSw4m1e7f8lj5En4FM1U7XSon0a0x+MjDOByOFp1qinLKGi/uTCh/TjE2GSbYHSAFJCKV3VEupzPDqwNksViiJi9tOZcBAOX6IFSKQXpxhbtdBaTcZVEwIIWs5YDfAuXyVQu4xDZmzJ/hVUZCzW87DI6FbsqDarAMq18NoVjLyQUe/hItXyzanStugFX/++6XDKBA7nwOmJikT3ddAGB2WqrfLtnYjYYhcuHzCwju23zLwoeZccA5fogUjXyZPSVlFzRtp1q1FWI7c6xT8RQMfYlSGGxDrjf5BcT2Ul1vFSRt4fxThdt+rBYNdLla/VSe7yNWOzrbeJYtokhVc73Pd3wYJtKKCDcZyeqALmnwRJMXTeT0pYttteEA02FTvjYKHzHwCaMOaUZdfaQrAVGqqv4+xvt6rHjfONbS4A3LFGXqZL06WQFOcoYFhptt1j9qBCA1y6B/+9pXfd/rvPEyFFQEr5tSJeLn/BBM4daQZ6CUxnXwuRenz8ZNLr24y4YpM3k3P299J0c0w+NNpEdfrvoc+KqYD/3h7TxKb8HtWizZeSwgqGIfjhisDDcNdAF1Ugurm/vi04HvmMObWqPF6jm5YVhDSswAXkZPemUW0QGdXCNCItAyxORVEdGahPwMxIHdmCqy/kqutuSg0GSfDL/iC1EeOORjtaq7H8UFMwjtxR1cICrEIn9ej8C7x1aVB7tJvXaof/xpb9ogidOYjf38QhUnmvSuehb/8EhS230coEV4+jlQJzDmRTbYLz73gGwIXoKP8YPgdfxnMwPs2TqmTyIi/oQo8Hu2ToDV/VOsx7XHox1/1up1UmzjuUdHJvRfsvPByGcJ0LsMHUeD+RNT89YH+8Bwqcybt5q2IFksDm3leW2dfqK+9i7myw0vSs4JJGQhBFo6GgH6FT60RrmL230VGyfGrFiWYhDLevZnRSvdY5C9HSriW7vsA40EgfiSEerb3Ay7B2O1Ff7a0GmMxW9h4+VzxC8lp6UcN3k/m2DSJzGocqIbPSJ6f8A6THMvOAJaW8UiCVRw34qGv7g2w+i+uVPYYTJguknVMax3nUK8hnU7A17e/bbLEKziysn28qAM3Ry2pISussgKnubQJALeWlYj7wSIIQBXfQV0AP0qCH0cXr84oFtEpDdMNkm+8fkCrlElrRNA6IySJWlFj0LZ3o3JjvFROfB/JO3RX9+l5JxKU7FiwmhpAPDvem3GneX/XnXJJJM+U6jb8V6a9+zw6Gc9T++bxHo3nmEaTd0PQEZkyi1oqZw4py4HOswWihr58BdF9Lzze6G8A491qE7hZNRkwH/TS6784/258KZtd3Vu5t/pbsVb+5LcThb84qU7acisVFPlEBLCAcKnNvQWwwwK8uEuadHm7hGqSFnpRs1R7ga2M+A7lMeal01RjDlOv7t3khVIf/lDh7tUlTFE3JZAv/ZN/Y+afJ6Jk1s0lgWEX2Z2AUhRDX/PIm+phjo+8q5SayPPzQiDspZGJX63k2sdhA0s7gNj2zF5/yAE68hdlGdx/kGCxvBPsbLm93/qZDn0Q+d6aumdFLcAjYXmqGD7ZVWQpYqb/V/6qNdkqQehKTYvRWwUZgAGdjReNOoEswvbUhywTj6DoAhptmWbuCFMDqPe+e1rOqAelp6YWNY6iJa9AZhocdudemU4dQZGh1jbvtx3ErB1PjPhJxgBKYJesmQmdh/8xXIT0ke/gMJbA1R7RE1PRxcO7BmloVM+vFrbgIiKVQkHxCuScDcXgmRSWhmVkyR0X12sfXlWStY/tHPegthhf6z5KcbddbMcyZMci7DdPN87J6hbItzIa///klW3OTo4Z9vMKf5CFmd6ejYXfse0NxpefoH8t2ZULkKFIuJJtDLTkM6MgckjQpNoGKHHYhVfn1y08agqN2inKalf/MkryjPSoegeUfWO46vDqtjKFnGoC5f86r/MYcjmhoDs9kCmsElXaIG1WaMjiNiLU47thyw2O5U9ryDdIWDkYLy2RVY9G/nXJCes0BpnAZq45K9CZ/Lp0QtGjB6T2eY/wdqrb1pcGHh8sWuk3I6+VzBEVmipC5X5YCpyWFbNRAEgeIZnG/I7/zfi+lvFhCiOLGjNLl5d6/uya7hckrovcJ+3aWL9yfJE5uWF3FRjcuX6TPLnviCBQVo5aaouIh4cSGbkCogDy8fwgRPUiJ0A7gPfTLR/J6qamMQ7aZhaH4wH+dd64IOKuQCczPhHgNtWuSzWY4xAMz2Dy8SgQ8yQAuASQXhAaI1hOuNnbH3VVGuPvgVU51J6B90Rg5xeRYYwbgGxuGmUuRxhtKIrNUVCwEAdAxxXzQGjgO2fxiypYwViBS5Q8BKpmNkar4R8BZDhTI1cXCWG/b2LZNJY5pqi4+X/Bfiojd++K3gpSRaA+6wXAAUUwhSw5hjdfAoaOk2Tj2eKRr7vBbcCTHOM+KTK7j24Yleuo7posncDXB6qni49bjn6AH8aiSDf2m86yxrEUz5NjM+wzTk1Qqp4TrV2t3fvBgOGdlm2cUIzs0zHVHQuWVWfn9MhkgSZZk+F3iofvWvBG285AYbrMN8eMqSxDTqq+dUiD87NNOm5VLAuFoumnvN5MWoVE1E4SN+FtIIzaOXJPLgpQS99W6PxfUQyqRmnVoB5f8z+KAKj2ma/RM9J52moG1wisDL1Dp5EJpiTe/9rQGYSwDIAyTdZgOm6EWJFKw+9CrwONz2P+ICkJNDe1Ub513NlOABQFSGDDAxiFYRGTc9K2eGLKFJuWb/ap93EhiXl69Pz+AmABnVmFdOAAjG3IJzkiBGAS4LqAqNPqPVqdXhBQdhZoZ1ujSyqEmXVWUL8EWZv5oWotrBVLfyZJkF096Cd/VJgmbi0cKMZvjH8Ce3+hKbfR8WyzgL3h8bxQUsGqLcCW5qx8qdhY1U602bQBAQc7Q+5r8GdHVBwz3sAOQZVp8kzuJ/fP4I7S6TfmzGSSxQ14N/72HPAHGIVtnDulzs5bHf0AXqNm7g8UIYwnc4aXxVB712DHbATtS2QRmljiKIkeH0o5ncEhf8dOw5pQjNpDQgI1+dFT1QupHy7diHBrpHFKH2UbUu4eOMDRnGfOcrITvtMs+iWjcMRfgLJkQiQAJ5fut2LPjDRr0sHOOkoBGjHC/kCvyvmrhn3EeOA5tbe1XVr9oSzf8uf1NIxtqae5/mdSdRkF3dYInUqH8hAJjxYIKRmnNN9NvStGy3om17CZaoYx8jTZ7Tza648t5lbokdYZ9Xdg6PlnUsrobQa1qaVntdcQigAiWqyidQSXrIS8BA4aw9Qx1YvGpwLw/wsJoRNu8anAvEOEhCzcKIiLKY1PXOncyGlTWk0AzjcpKXS5VWzNkIi0oajnfgOl0BLzAeN5EAB/156se2faT0iiFi65bix3Sptb4kZPjHufeWMi1Pc389YvVJeh2rDdo2FL+d/k/RN48NaGqqhHMQO9ZATczph24ffd2xb4UsfNWrkUJzALF2nvCTnnsMMKUM7r/5HbEYK/MREibLjWd7NN8EDwxRQmqcI9PK0YFeEMXexxZQ/txY1O/LBKe8N5h39e3ThGJSwJLpg1ALop3Q/fckOv3dqqfZCLV0GBpVJBauzJ206qugaab+6AZ0EUcS4NWqYL+b/ec9SH3v6oj9P2vim9vdgM5EbL9ihBuM2wYidOVhgv9vLVKY5r7lKLrogYkrLd88z4bs3zgTHul+LYFsqQYUHcfi/Yt3XlPfrSnf9vsREct6f0khH1q6HTloZR4DpIdKr5Jam2oETQXLwVHY6cV0GSNdaNZ4+4F5FIKgU/k6uKCisLBlAxF6GUoLsc7sm063Pq6TgBVY2ankI6tCNb6Sq7cyo8Rc6FN1ymilMHhFAp6DGaekWOzayAUFAwIWlyq/4Bp0W7IRvzmgU7NLL6Imx78s9FsOHIAMQSgzcYLptzG/O/EZa7Su+RgBuZ/3Xdisv5V5iPRYkRyuYuZib8emQq7OSyL89LylBlcdJPP7FWvMVx8TEapHCbGlUdt9ogZwyM9jge5oBNpnchQSfRDw0AvZ/EfsqITFb1E+ztK7eYi+gtAcu0cDImEY8JumX7l+FiYMPD6t1KorujmK1WuHIDeqXLg6rnWladhi6KNOVy+IzA4ry/Qj5M/xm0KVTtgee9vTpEKqW+y6HjO8tXVpiFC6OBaAxwzILHXoMO//hJyxjqS2Ttcehuo6F8a6O5q5+sjyfy8QKclCPMcYJRop5AB3NXRC7E0Onp4W48dpseE84Z4tKifBdEzyF0dQdTOF3LgvmNHcXCkZf072nYW6CzhY8524ECO/1agnXU5I+sAZpL2TW9wCstXCh0eOVZnyOc1Be9VwUkD3kwUD4mndku1A1x8kW/pevxoQOXvrOwYmAqMaU6jIPTwplYb/h1lB19g+dkIt73iTpJx5hL4owfhsA/07vX8DXmLK+Vfqspu27H9scv0NsKtmZXaSQ+zwO21MOlRiwtb3ssTU0dk3Kms2g+zASQX8fpR7N0M1ti4oqnWae1ULYHKgTx/046iGB++8qjDXyZb+SC2V81tlsRs+xyVWdEY+tyGoPz5w7c3W8crmvZ3nzTHv0vk2gmsSU3NTD8+mHXCdCgbVr2ZvhUYd21St4F0ALi0VeIuMVqn5PDQ77MI0f0EP+7ah/AGZKMEiBA5YLcpoPfhOpfG0KRjELiZ4ykQ9An9vtUy9gFhxaj+VZ8Jzm/Vnx5KHnr4iDmDa+Kpu5uRGkol/pznO+8Mj14JOUxc1aNO0NiY89US+e1Vqj2VDfPdYL/3gxQcqKn/3swe3/LM4ayka1ygYGOs0Me4uQiAqRKUwt8lUkEl+AcO01zQp9niHHcrVNTMMHoc1h143SSdJwPYn+rmtYfnPICalGWj+50XgEdgedeqwp/GGmwIoZADRbmgx4K16zE/FSAmNpbz1brgAqAljZQ8FwEjKl/cmm6rbQmIhN6BFAPrjQWGirBS0hkIrEXkqU77rPgfJq/hgrArcdJ8zj+t8IongI0bW8kAbWobBkFqI5ywDTDJa0Mzc0Ll/jU/QRiN3Abv0hPQeLKhlnObQQivrKm2rTlbESDTfTHiAQ+o8UUNrqWyjx4QfOOFEndxtkzgVq5CQjXGGD2jA8M76SlPOe1iR1CqOjhbBAWIVZt19kT9+fwhZEr9kFZcwkoT7YGXCY+wOrUtP7jjR/Tq2MUWrYfKvRmuVLrOyfVXS3xlq91khlElxxPN3Ipld78CrTV7yAylZ9vM2lNHhZSZCxhxEF/x4V589sUTg7v610I5DYFkRNkhUe2uiL/FJTpPmwYYy+fdgT12TRFjjydjnKNx4yoEln/tKqAuX/yDAAp7SXHtDsqdOC8zWtSH6m+gI8SozKk0sX2vbOdzw/FtnuGXFalADYZ3t8B9e7MDOW9FFBLQbK4Z0bii6I2MqF6PB/kb/OWp6TkAkBqR0q0UHU8ziT4aQEDWxL6ZxVSHKUC01OP0HX/5r1+xDFkwneyInoUiDbx24Ap0U3GwJ7H+iPz7J5ycwgAplRI+QttoHcHO/3P5PCGOS6A52bgYBVGWgxz10wykpqbyK+qSx7vLnmeJ6yBMD5ZJSlvfLQa578Jzwi814rRKZ5ZvR9cI8lHyGnjXdKVekXSgyx4QLcOsGylIaVbtVdpPKS0T39zKpcJX8SrtHiNGIo6FTvQhscwFevkXEhRHwwz+VRXoo7uY3Cqrx7tNB7oBzp4762dAeF0xpITAIWxTvGZkyc7O+Ejt+8PEM1RC/ou0dbQY2PdVaSCZQ1+V5hEZCsJDZYsgu3if1F8+KE57qibvuhmJEPgkw4YS53EoxnxZ1GAAbqnX9j2aQyKZmrX5vxJh+Y8FyJhKZ/6QP5rRkOF3R64QJ2jbV0MhKeLEVNBlZ2YNcHICitzuNdZ+gK15e0fw/t3kulcc2kmMFn7grx1H/fkts0LlUILfeAbJoHCCmJv14vmMUkF/BzNMibdbROjFV8SeetbYuKKp202iW44ygsFRdfMVpmilu8eiHcNrDcO+Tp+gHa9mq8TqTgt+DNd2dJbGbliprtn/WZbuIJlVuULYOiMzs79KTTsh0vh0lbQas0GDRr9Yxv9cJNW9ROEq4prUFRQAMdl6b5joxB/GFQnWIfWNDvhkWmFiooLhKj2/X3Q9xLz6gvrJG4/aFPODsqUhUUpiNGiHBxcstZtd/e8OZuvK2PyfNK4yjvXuUeF4hAef83DCb78XIpMDUJ63c6xaHxE72vl+oyR1FUzsuNUw3YYIQtj2M/WjUQVvMREibjzBy7NEPXbRiSlxzvGqR/47tihRCPceLAUXluMBPAWp7Db6e+bYl4HfrU9VI9lVyV7klyAbZYaxgrTlSsLeohcuBwSXpYrsmn0HqhnEgEswwdk9x6UaeB/AKibOVkNU9PxhNrRPfUgja9BmyFbqOpActWKw+bNOSxwO46U+/jnYvBylEdp/vGXTIhIgzAJQVBWYWfyEESk/EfvomeuDZVhVseiojLw3hoXMU6NPrF+D/KsgvSpzKeFISYu2N66HdLNiNe29at5YczHGxfGzcnrGmUG+LMQNw3xbsO29FDcDCNLoYd3YMI57QOLXcqSlMnY5yjlar0r0NIogaQgmtck/uMfHKWlW53lCEmPpLewHj8/jCKJZO3bOb1wqO8ponTkcV9F4F7RwI/No0ycukL9nJaRHk5a4dyYuOaXIgCBubKokE92dal6RaqISvYo/19VLwPhD0FgkQIHKKoxh97l5p0OkJVvIv72MrB1LRalavr6uxLtoYfPbooyA7KpDdIU+/pi4ULLUBNHd+lKK8yQOyzysfn/9dIu4nCK6dcsoBC/VDi9oPEKcLXw8lwNfOYK267jnEYZTxO2jRRwlUDU3GwLmhKf2ucREmaxspviDgoplfV+6bbHgbecnvIdbn1X8RyprOSygS6j4HnJw6zlp7aFSWaxZYHuKY9E4Omh/vC1CrsUFdEzDT2JeHZji7BOTYWssD6OtNYA8VKKcQGlnAB4zLATUH3EgyvLegT33HIAtkA/galE4OMhnOKZacQp2Z+Axt8jkpQxfbUKFMeicH49n9sSvk25sNDZbhNn1fGKzjP5UwL4tq3Vn5DbWbr7hcPyh3Wz5MmOwg6Gl0GkK2r17ifBW97hxxvvf6H/6FtxjY/xygaEqGAgZMZAB8t1ZwDqOSyvZoTmm+NWfAsDzzS20Fv1EnvEpQu3nhlKhUm60EEDI83ilRRl7wVuW2s8xpWT1n+Igy1fFU/T32LE7qRgtSlLPR9xwlg4AeXJyyyqEhaSJdCmQeY/SVDRueqlWTQIme8RE7hbqEY/Tz5ips5yDgZxFPKF1fdOCszrh0RYeCLq8sX+AEa3qJwdNDlopgMcx2GBxSaojd14xIEPtPY3c074l2yLsE5CwEFJqEtBvIhhP+cqMmiyR8XYIrl4gqjsJqcMzTImWHeMtOQHXUGiOk8nE1851pxu1SZIQyPL1Lgx37E50hkcrsJUe7u7YcCGVkm/Z40pF4aLjV6kZOlhuVEB9+9gX0CzBjpnnd/HUFWzR8taUcGYb9y2Fba4t7s7xtH4UnANxsgdlvIUVKiroYJ6XArPTKOaR4ZESEOcL9JCe+XRSPRh8JxORBaQUmDBuGCarGaCNBNSOkScnPHJkex1p95vPYMboQ9A2IEJ291ny0XcXTZynuJ6dTh8jynisjgco3nyAv/iOoaG/aJLwU8tPbTG9nIWV9ajVCKJSaQmcnYQCqrVe9+q+eBVqmw/4AdiCtbxYBRraxhSQM7QY9VSg00KsFkshIXW59XV3BfztfARCIiMZuGhj3jWT6URWPHih1x61hlMWYXFXx4bJiq1eaKGjfulvoX4FNSIMhved1B9dKaYlSKL0RPKTuRb6khungyTt9mItt2MUY4fQvCEoWYAvNhNEOZI5gzhnwtMD6mn4btco2OeI96mQJRUrKlmiR8uTfZa28GQPrFh4ntRJ0JJnAMA2i97BBbA2K+V1EeyF6B60ynKKwYn2i20TTWjlXeUeCoXGnNt3d56/qooNnYfbvpO0QcsXVi3g26FzcQfIL7ctdW2MC0DAE2oiM8r8TsvTb5cUXmWK0w8nAe4nGFJ+j6oL2nvq6Fq0Ss9hvor9lmRFC7jzzJ9jFgYjAe6KeSybdeUOHu1SVMUTclkDF5gXD4Ie+tCz7a5N9kSRd8YqycNFNCXcujYZcj+zWq7bgbJetMETvsEIrzoAkdxX6TQNOekMHExMW0tmf+VK+o8YmCbz+1tERlQQBsX+cxkovcc9yemRLbR+ky3jGw/NTtBKrNXpwi3bJiAelqObY97/YIxrAUHmlA+szLknMWzU41oODUDQroxTckMkBvgFKl3Pxr24567i3t7c+a/+HWyDOj6eiJaw2HqC42LjWvIFCX62aBpz0hg4mJZEkrUkYete9CAanxAY13WAow+mqLiIRmRDYNf9sFh8byuu0xj1AqZZ1oQU5f3KR/Qfs+IKUFBwFvVVbO3IApSuQCop1FcqkV3HchcayTv0aNkitNxFObXqk59SchQFizczEluqPLpiqFG791avrmkTQTdbkk2MaFCK5s2aYNVC+LpHWRVmtDnu9ER1+0SFd7xDgdHF3HJOUTUtGkbt4J4WgvCBFlRECRB4HRhVrg83LrPAKKQxdmoDi2nNve6OiD+BA4/XHC3SrcApQRhIWifjhC6qcaxg+FUhVC9ro40k9G0FJ3JaUOnenGGFoHbLMheX2BqbfW5a8W0sl70+JSh1G1aDs3p/OA8xktOVeUXCXSckoe8Miuo4NmCiSqR4bFhHuQ8xZetXNjP01O4ltBwS40ZfDHTdBn7l5Twaqv4cCFpzQpbznpSxcy1TihvkiX5gTQEH8X427t5cMB4OMe5DzFmM3INoeeBSBH0a+sqb/x1MOX07cKz7I3KjCCVkdmS4JknBQ/+NcfoC5MFUU7ACXPtuj/G7jp5Ou8lOF4ji9G5BEUoNI7czHwhV3ZpOwPvGTk+PmRYk2wrE/aUdN0mLPlz//f1icE2JjRgUxJZM/sBwPruoG5OOlb70BODq+YnsJeT7gNO2zFvqSWFMlpEwRbrOhiKPQzjgVB5Ny/jB7M8Nr0Rc2x+uGxnjM5XzFkpxf1+GSRM5TN7PyBbEvNSTmx/wF2aU/0XOAhwfpMRZQ0JhPnLM1KcZejBoJaFfHfmli1tCJGFs/vYSwg9zm5X4E3KzlzBZ7Ovg4c1cnTdqFel4NzC2R/7Vi0KkJcI3BJ9SVLeKpU3TrReDRyuzPEycaRpyRSbZ8bJUh7g72Ny2wDRamllOHrVAFr4JcDjS45KwLK1wbilMS84Mb/+hM7fR/i5Ax54FAQUmmFi3y/FOC5nS46TmY0bMBUa9KmlrHn4kNKAD+zV9kBb/VIdplVFL177mcD/Q5dzOejpYofww9LNOII2WuehrXFY2t6KphZkemrKDabi9XyF9/Pq9vBvPpPmfLQ6HZ0cOsRChbNgKYKMw0Imgl+vsKHy39d8q43sherEThnXyYHdpsukdBVH+ujMJBsDeUMMlFKY3rfoHIMrxEgmFhh6RR3mv3JTqXawqLto+zLUhJwFDvpE1q9hsj+RGgXhG8EUVqMMri1vqUu5WKCmsepk61t+jr3LUpfRr2TkkD/ge50lajLdiZAQGylO1Xgv4e7YDwu/x+vdYCRJUlZtbv7ELT4eGp4fjiKJDkybXnMk6N/0UZs79tg2T7WyjmtQWXsYffaD36hakkG6oNJy95K3fsxLLAqrGc06ZLktSetvpqeNNohkJqblic1USuxMabmluT0Qmcgxg7ZaMVgVVoaE7LNgqNsvkriz7tVYtx0jEWPRf+1DLUXEkCmNbZZta7LegloV8d+aWLVjJBYYbHaHjj8XXDCD990bJEXcKKqqy9yMerBvMtNE76uwniTHyJVkXfuqvkqTW1g7LYmHMEzp+W7Q6SO9PDKeLnz9L/8VnQpdmvdg5+n7hdkT1w4PKhoUe4vKMIyJhkf+l841rP4B5nfJSBAnUpjFEfzo0qEuoIkXHSxy+uYrs2wqQ+a5ab687NQXcam/wpCb1tv5yVdg8V7X43wKvL/T6pSQOoOpPFu3u1iQxvefEMMySysK5h7ASUG/UDrF65DNJLo17meVYcOmWbNV6g7ror3XYt+/62rkfWy9agFWnuQQLTJWG7tnkPbu4kuqm7gIs9ff/hNHx6XW0yvHIIUUG7G2f/80150tNPaoNGNu2A6Qks4njBFuDEQRKQ0GLA5Lj7dubYz5aLuLqLoc9D/30R6r/5aIFMGIMBJU0HR97W8iljPddlekSyfcU09XnN7FzEYzc6Aignbm2m/l50GhiRwTvedXA8wei2Jb3XbSVw69r95Vyk1kefmhEHXzjuRnmcA8HagZD1HqalQl9HZJdnuEvDUYRCihoeP0D53X9enmxRdgHgTD+ZenKPfBeAirmR1kcQDU+IDnmthBZ6tTjwTj3d+MzcvQS4+ZygUs2v4vWdITh2d5FV1oFtIdGhDP7X36P0ac/98pkE5qtpL05j0SpE4YmaVNTFvf12hUTQJuSyBjeJnx+8J6kVSOP6yTPR77cXtPc41uL8HHgZQl8r4S9XhX2BVL0VaOdcMWPFi4hcY7hspXmFkKDmMvsnsCoYkVo8vsbDvvlBN53I8Frx1WX9JuxgOa5coB8eQfjG1vsj1viCPsyYtVmRIWd5ij7pSQe2ybfIkeL3+Nu/vFx1jLkzedW+FgE2ukJ6Z+BjYcnQy1SDt8vi5zEeJFVQlhNUnrxVfc5Q+l7Rhb7XU42XbV7XYTYNupsll/O5HI00X+4qk0N01RjDiwCb7d5IVSH/5Q0JIC47sVTSEfi9gPNZIIcDMaeQmVtT9hUeErSok437Irzcc8olExTzx/EMxO64GsLvn47MFIpDYnh722kX19adUdze0ByNCXG2gd+Fd7sh1k+4V+dpvrJicS7UooPZpa+pTBGdGqKekNrgT8X8ZQJU6CKXa/v3FTq51b3Roy7eO3xgf2Q374Iy5NKYVruoKTyrkA85COA8bJVd031QUrNKzaMUpCnCpSlCnVYqsUtcFAwqxJtDN6yBE9KTyyCFUnzMKt+XWdKccq6z8nD4Y4hgUVFKdWdsPrB9HmWyd1/giJR1vq7hQQonBRlW3yXnZDNCFQlGdsWu1gxjkzvKy5CwTXNZ0ol+q3D91Tr9gOizDSAZwy7eoF4Bl9/OH9vkAGvsrgh9qvExWMrMmS1EdQrIgbsUOq7oFdcZLykEDDA0b/eI1CqEr8cGOEjqTDZQnhqz69GKKB7LzkOEJAS6HD2/KN1+mvLQ+GpPPccZ7yS2ze4a36aGC0N/K4AJqpK7ACWq29U2yHibhJ1DPXpltmwzek4buy0t574f33vKHPrF0Hrrryc2nP4uw55ARGp58ctQb7oxyATGlfjbaT+9f22ewAwE9GSZcGHMqwt+tVat5vBJI8z2VggHF89ZNMwbBN1CmEZoj+4ye8H0V0KYA9yDDUcTT0TJrZpLAsIvsgKeFQn1er+hKNU9/CjjUCoGxjyFQDUwLT077xGh3dlDxmhcgxtbusHOQYjw8VVgThZ928XVz4FwLpxALn1kkoB7lw0PrR2D82NJ68/5/LB/nOuomtbWCHacDPEIgFhCqM0XWA6j3YBn+tabGHp1Wddvo3ziJT8v04RNWbpOe9BtZft+yr4Oj6NOCP22d9xz872IzBKyZ36dYp+xwDiDewSsn2shCviQ0RWHTObs/lQA9pwUoHj05JtDc21e2P5ycYRszKpKcoun4Z63V6JJNRXJASURZvjYHEVGR6F93zJjtR5T+lowFKJNKN6pQBoIx0A/yX511dEUxQFZRc4sD+9kSDeJ2NMlec9uctyxMEPQW8b3Ef6aJFmflPWmX/q0UUw1OpTvGpdTmMfBusWkiQ/T1i8X5UVQ1jdeAcwMR1LtXfU3/8osVthCi++at6oFohLQt5aiB1so70dB7/8e3XoErCWv1SINbUk+7wS1QoT0UEGgke6fXlcIbBgCx1ZsbYUEX58yeS4KZv3s0i+/Jy1QVefWuq6ex7ZVAMXSgAesqBtVcSg6+fPw8IPYNoeh/lgNPm4IM9t1OS31DGRQ+INY3kFzgTUZTT+UEuVgmgeRh5kPX1fpeLJDky3REmJQ+xmfdZBAnSTPNC8Z9rUGBGu4DDytTFznp4LQwX3tczar8UiUTgVUlSP4NkJlZTuaSf3oWok8gElhsCMSy+1opZhw5nqGOPpOGdhRg4O/L+PVrSSKg1Wc+KPNdfwWHz0JC3xgh2LNVnJEmB4A7oChKixsn7ccWdHrk1P5wT4TBO/Au0nc5ICLlUyzBXVDNl3WJapxQ3usOWJ/lcJI/pHumQ+WSkd0yKv7bbFc50VkygPsKgaKO5mDJz6mjm6NoHyi2rmyOfXi0dxOuT6yseJgldZwFRr0qag4+aO6tkcTkmRnjhRH+ao3jCi6lS5+nk5JF7+bno6WKKo6m/VMH1cQ75QRr3lhwSAeXFEhjYeurfP1i0ruqDF9kb6ryTr8yfERCNfBJHdNNrUFg+rgIz92dl4oO39XyAuxvG/ARHjtB5PQ/Q+jeglB6HbrB/yf0A/Sv/HGHfmKUlC6OGj1KgtdLuHz73vCcZmF/Dzy90u7mElLywCkUQ1GqEYv5BnOAzAWDDhkb5JhRUBH50Rh/J/DZ0mH5dBMFLdqNoNSMo6bRvEeoju7D3CTGd24jXc54WVEnDfjNt3VwcVfbJxOWXtS1VDEiSpAkcWkNnveGAO5/nYcRSzlqGYw90UxzGpLBAo5UeePc+k+Z5nlGbrS0r0EBBTBRmGhE2vvIc66GkNz5z1yHS4YVIf0tMa3YZznziehhI9ACatVteluooSMyIC58sQ8NnPF2eQIXB+513v6byYq4Fas6C8rsqWc7UV/+T5Eo5wW6HCJQG+Z70dXbgY0GFiFUkr19Y1ft6qGLIOVuF4nU3ynDPDWVzsWZSQKhLtXzytht1kx+VnSz97u2Qjlfazz/GaQFMF2wS7Hr/DovyzSDVnurmLakpwCpdqBOZFtcRzKp4IYYTCg4VD6A+X2MTbiUvBKZGIMNIoRJPvq8EYWVN/B7ykaqtkfKfUiVJSMuo5sz6EfDyjTwFC4QG2XsmQevqRF0XZ6MhetkwxonOAVx4cHLk8S291P8icdaCMcbmOcfucRXR1xLPPQmWwu6be7zQxchn/5mpSs176YMDQVAy9CESMBY7cnshDY/u0Wgkldye3N3An6Hvw7hYYaPOEf5FUGRJy4CAq2h5ZaHXXiMeWxLZ0ApmxDFlg703/siogeH0YrVtAMN+vmGMO3DwLEl7X0M349KeVaqN3CtV46G7pKvYNkIFR4P3dKR9vWJaUQ1yza2OvZoJ+BAXFJugB2neADt55JQSPXY07U+WV6AQaddyIFkbjnV8ggmn5Kz/5go4Jr6iO4PLiGoaxd4Ygdn3DRlGxnyGoDbaJvlbIM6PprNrEDSzuA2PbMXn/vS6ctSb71gjM2WIYqduUH3Jqt8zGoJ9Y53mOXO3N6B7oxYo8zr8K9fWo5uzMl/ECKpS7+ZsGF9wW3/9FzIl6nKokQcHV/BuJ3Maejuz2e8cc1YoLjetho721qwe9Maik+r1f3fUgriUYocTO6YUE/h/AS8ucZislF9tr5veasoip1wkgYLd46+kPV0nIwh/SgkJZ2xn19acHNriW8bGk59NtJDjMKM4LTFqt+dBVQEjB4LtQ+zBJO2nN2C/C0co31r3TljU9xFS9NGnVPY06d5tM1WkTJyaKR6MPhOJpgxN/qTGJKFIw30Pg1sSALkkkPIYm2hc6c4qf3BDqEvU5th/7aMDf2ZLFwpXjlfjgxwuQ9NlE18yswFuR0LNUTApHPiacXtrOk+SxnDbVjatm1oAJy1hGwBdRwMbNeKEI/1xQzcjAYM8Mzr0cguKWvZBOaraS9Obw/qvbOMduuw62H9TzF1UKMs433WApFf7SB0f9xRaj9GZckdMHhHleE088vuq3I03EU5vhI0SLZLbTBH+cDSAQwehney+pNGQ5iWgBHKqYzfka4CX/VSps3G9ItFMel4WgXBRNJuKB9qqFpg6pEcfKvKte+Ajaw0Y4TLHX6G6F4+EFR5r0Q3P1/qfmT3Np66louTi7rBzjgU1hBCB1jn3dySZbDaCKrr74fy+61pq/WIdy4Ict3M2KA5oqkCcHkBmjm/RCXoWFgCjuAH9j1+yzAijoWCGXmVOJ2ZT1hiFrWj/iDFm2FqR+lkrWdC5ZVZ+f0u0vWuoUAU5NndnjfUYYPDyfxhkOBjFnljUqQ4D2btiRGzkytuzk7q6XNJKy0cxiWSPBWY+wkM8PpUa2KKC+RaOAZIamLyMKwylN20f7Jp6QnLRN+jN4jduKzfGulwiTGXRgkFGH6VkvA16A5Y6qG9AvtDzdGrtliNaYfY1E1iyTQIUXmxozu2hO58t6iTLisIhi51XjW8B7VED4JszBif4zQuQJF8a2EGDUKrWZErLWKX4gzgqh4/iyMsds7cGDMjcye81Bh51zwgHfuMtin5OovA2Qi22PL90IJ3QqLDxRCR5l8o/r8AWRahTF/dnF7ee984b58Qvvrq7crp09pbxdnaZ8O2fIAaAKeGD28kGVmVj27QFvloqBZYJKzZv3ingRgp++YpzEx6csEDSMJ1LoO63Dwqh1QISBwoZhG9gUmePpfegHjOX1trezh3m2FvqwknlSWxifqjRs0yyoALeqq2duQBSlcgFRTqLEzet86hrmKCC0aM87erCpjkxZHobzH5YIGkYTrLWEhidbztVePq+5W2PpEMvMkJkljkMYpng3NZHnpL30JcNiKYVVenZxDc0+wEuL/xzYAXn1sfG5z5ir2bkqLZfMwn1cRbFkTnPgWrG9jtLGx7TxbFSJLwFhZc0hbaOf/cLuKEnLMCG6XPKYNc65QlDaE9I4K47s3fauAT6euVwbhA8mAgDfxykJwceji5jzzvp1ZpE+x+APxqCXSyW/r3Fs+NzjX2G3r7hEnRwT3UJRjqNXoeHXIyzGSTuLQKlcOdkOM6633xjKh1OhqRK4sFpp7x1ppCYnn08TVWTFUyS5Ymaoz1YDbIc/ux7vaKzvwYMDCrexXgZdbRDlnhh4Jl1992YeXDlp1pb0J6z1DqcF+jgBbgFfT4DC09XVAzg/3GAOKCNgfYrTDGXuqOfOFQKB40CcKaSpNcHs4+tb/P4UsyAPhcDbUwMLObtfAWBvtXyWsSI1qt5yKBvxA7ND11ZuXaaaIybqe/frGZ+nBuWmQTlj9uO4JE15CnxKEHsJbwX5rkxGOmEMMQP7MdkNjVJPL9GtJpgjD6UEIFjrjhUmbpe6dayda1JVGUeW6fqYSorlX7XyMr/xdN5P2gxlb0LXYfr3GAjU9Va6FgXu1hJjnt3UT+HxG4nG5zlunrAqSYJWoLaJaxPMJlXOGTH82Aa6kIYSme6iax27CDkx8nJojpoYOO4tAOYLGRp0LSaFtEfGVShHSxr66iyt0N5Rwb8qmGbD27EElT04b2kDKJy9WLm35ci6Z2W1qkSr2YUuOSHrWiTOpcC/Y94jGOchaAim84r7rG9s6ZYvNK1zOp8BQQFm7fU/GTDq+0vahM8jAcZqtuCSZE9GJxD4AHTekW30GMdPS+cQZdNxNfDxcRVngLw0aIeCF2rPjE3KuxIADE1v7Uqw53gAHAztvUoV7wNEMY2FOvKChd0SMput8zW3JbeaUIURLXADtbxFAIQ3Z9pdSfilzkPcoAATJVOQFU+OYvd0aChBbd0hzIx7fWdeH0cTFOD7zBy8ypZYwwsuO4zbLe01+itjUeuEaIEE9yUW+g+YMAfy2I62kMpskCl1Opq4TDMAEQ71qr+f1U/ZaZVIVXJsb79rE9x8rDVXj27cpwFBXCaHAZy2ZVAzhugZ/tsqYi8R0cIVRXvxAbL/V8VcUoJhLfk+hGhTMfb4VrVDR61nYVtANaXVwrQQEWTv7pK9GUokI6rHLV4cfo0hjABORrnk+a7imY+3wrX0CF4r7BCo0YNTr0tDOkYPUXCwX5fM4QQq/0cMV/Jjd0RWLgFr5RTfTgSL5wcjHSAyMC6g7An+UcpjJqJLdRlW/TfyXMsv+Zyy23GxCAxVKW4811Alu+AR7xsQ+ykiXraqqU3AmKbFl5eRABT3zds9LBUYbUSkSR0pHDCnPyrwj7mtXdN0aPa4llj00LXWZsBvvZJqo9YbmXBkCB1JWU99GIW3C5quqS2JvVmhytSbO2uNWJ0fWRyGxyO7sX5P6SW/7VlkLM04T/6tVvxEmmA1B9wLKsl9hnIcHgdKeHqo03OkyfDivo7SRGCNOtIPoPAgEbp9kKH90ViFxu6+Dxgs9DWiMSLh2uQRjnRfLe5KAmPYs63Xjl6Cej1nmrR0IGhCxUjOPMqpovVK+Fx8DWlrOmd+4nJmZt/z4lvuDIKRYiz1k5iu1zsXshJTEL8mlZKmItb+MsiFg2S1cl6pWgCOox0WuBddpS3SPL3SrWrVnfXKSfw8nMKmLcEpNlK7CDJXjZrUHc2Jf2DHoJavvR+3AHmEmu1JyajsBUntkSZAvvH3pSqcCmUIPmHSSZVTxpCZFgCDlflGkWzmqFiqF7SkqSsw0bTTZcZrEi5z6A3+6iILmGAa0iUzpwl7XbggPqFq5XBDli7o+BeeAdzq5MrnlT/JSPGdbMslH6EGTD9rQfTv6pRIOfuNjKr+mKDJhwONgVLVrFHp3Bbf+0qB7Jwt/AldAdMQS6PKUUotaw/D7q23JXcNaIRjpT/f8V81kAWws6RY7ZyyQyGiy0Pnu4VDWcg5vxO7ecLKiPFBUHa3nTAakB4kVVCWE1SevFV9WmH3G6o7FzHvbH3ePtOvt3UlVUqhmI7UckiKulYyGklYa+v3xGOJ0A44GGKphx5kbd8wntbHW3ss1LPN2dtTwBpLbNtjliwSA1QhSlVPfuFXaSa+9hSAk6Jb/zOpThY/uaMMTMF2ItLgnliah78DwwNumw2tI9UeXTFUKN37qGD1zEfM4gxR2S/XZM39m5nmXSOsirQZn0ELizC8LoQhJJWnUS3m83FgJWmFS5kouuPw+RaFRx4Q8jmHzvALJ9glrmkmkEjpoobvQIldNwNcHqqe8+PKrSL1w+tV23A2S7X7AMDg0fFW5oesg9w8uLVrZuROirKMcNi7IvCtqxXzz/Jk0WuRJea2NJ8+XKr/FSFPBTBODpTjizyYQ3hO37H7SdfLPAuNsiBh1lYSufe4UH8wmwF36vey0QP3cyHWUMwjewA6Clp1a+dqryOAC7UtEZmz9sUBIMc11+ekgHs3xUUfeP6Iczi+l3jsJGCfn+xTwuDrmmvtWSlMcYWX70n/RE+U4WK5ec7+ut9LoIXK2vBk6W32MtrmVu74356Nm4uQatHuNUCV9V6LkwixvuJJJQdSS9s/qt6+Em+3OVhq3FEW7PBd+MrTjH+vQJSFEN1C1ANoVb8JbhlBHt5NBJbn43l8dyDwlBj2uR6jYuZlBUOOYpTet8D8YMwcBbgqjqogaERHUH9eWmsiHFYRDFzqvGt4D2pge36vbPUNJUW7LLFJxdlnXEFNK0UcnF4StKiRAjWLucSPoZYNu1AzLBQxFs9/6F6vjJijc3qNqnAdot73yx7w1kQmPnzbjJAlwg2/Js11/T0BoO35WGy9GUhZ0tlvob3JnHJsgcp3VbD1CbkOCKAGWViU8v6GBFEgbm+MZPCPu6eVaUjk3bNn/UnLmi+cWjRLjvwT9ItwfrHrlzlalIbcrRL/3fOMQ8ApUUem0OuVPqdq7LIktj6aYnprhBnBRbVh5HWYUkpQcjiJVvZuALxM8p6oA09LLqrl+sjVr5uNpXZhUERrqBT+Ag/he89Lahyt1I/1ak53mu8teLsWPf4kSNKTtc5HEmF0+ddBCOq6nyniM9+EqB2I2NJGSQLCdKpZxNimIaUV9fkbQ5itLnetljNM5pK5rOm6iJxnVCUC3tYQ6fxELd9247eXhQ8y41HF04Vwzsk0XVWMyAIR4UPr6amEqYUVEuEmitXYRlrXADFND8hVZ+AMy/m8XU1ggbM3tTaghMKb3MbsOI4rg7hcpA0NX7hUhi1QVcWFkeDElmYjF2nphlbVfNYi0DhcAXe+BKES8+QVSsgqJrCx9gSmcLs6spVGIWGbk+Ep7HCTwxHFsACK6nebVgLLrep6b3lsJSwlHCj9BJMIr5lnMXhouNYY/ZwuUvLWtQICiD54YqKdrJKcQCxOlh99MR2aQPTwxHKgg0VKBqj00dj8NuEOlJuZcVi5LzC3yvBLHttgAhgkIDmu8QACXc0qXUExSDpTx9SQFQHDDtnSI74Iyrb0AHXZYtOuNv22iVOb4vjeWSdB2vdKF4jrj+K+aJDP/D7SwahyrYZ+zGxYpWOSnpvO/rlcmVxOD2ZBWFIBgeAEmu6977pEclH2oMcA8OjMMuiu/0R3J0V4Nxz8757HCTjp5kVwu9Fil3SITLB/qfqKtRC/xv/9WCmV8uUX4R37lZZoehI5nEFlGxU4X/qlH7cLMScC/mk9rx0rfCfHx0L+SvRnDUzt54pxro4V29FbRKaO1s0OkIFcznEkSYy7XNsUuWonk3KS2jOntQDGcyMXobExA8zMBkqXXeEpWe7uuxc6HqGYkHGYjvf1cdiyRDbLZP5xjWr8IlZShHuZwQsMRYVxvqguCsBrj1G0WlQC+LXjN5Jp6yND0MgbOK5KiRPZuAXLGy3vizEclPZ03VJw3jDD8SedMHPmZSz8eM1UG1sianMkxXk/uTYFCOCpQLE2upxpE8/+Pho2Wvypc3AHr4bBzcxM3WFvadszej0cyehtOJeXBo1kD2fw3yDXJfRWfWJvgvPG9KiqC+yazzlw3LWjaFWFg2OJ6t5prsKYHooRor7qXAyHVvOqbj4uhKVvguoizkC9oCjrwRPlr0EtX6CWBavaJL0vnDoTCY6JUc1IhH0wLNMQtle7xn7EPl0RtPjCkDjHDZJeS0+vLM6uQj2EzIsd4DCJATk8Js9KBJVw32xyckzjFPnIFKBWyKnmy8VbrExiCLGyftxxEp2whJ/hZniIY782bbXAKqHpRCXxsYTYXcU5vFNMTRWc9eAzgibactbn+7iUD/+tCKWGmMJ/4HZnTXUTixH0KkK2dnM66GCQrtzd4Kk/odhKnoWX8ONuoBWoZ/AQAYZ/F3PUQCSf/EtaSv3stETAHYyyNqSMWOXjwqVOp5Ny7pgzLkLjbMhZnNQtrOESwp4JdSBwatevV4WxxM3d+8GBAevyk9AlAUv1NAb3HUslazoXLKrPz+mnAD5opUcdcFAwtmhHAWqE2DWbzP6aouIhewafrX5GacXnRgPnFAv2O06+yA4G6CtFmF39ZSP6ED1CH21+MvTQC1mfZ5qPTbAYiBBWy49QM2d+rYyG+VRovy8SgQ8x4OLF+5hVTx9K4kExAPwqoSI8i0T8Sr4EeVGOCJS0xvcFmryHIG31btmm9o1E/mtovKdAZ/Xif65ffghVR3gIz/OL0E6wZ9NUYw5S7PxFG139btFvvZGVybpzKYvOBLeG07Z2sagmV3hcJZeXFuSRki/aLwPUavVhz+VMYQ4WNOl8VcLPUn+ktRUf4+PX07Ky+4Xntm37ctZX2idHh6tNSI9dds1f1d69nnDIKs6rLD7V9cQnI+HQp2nlY9vecw/yauEkfLOQdBGu32KkmOXAqGMLhbAd1iIN7pkFXNi0IrNNFynZ3MXgUrILGh9pYlxN0E42LjWvIgMsAYazMk9QhpxyQnfJuvWehqgXyxWMz9ps6qpANgiLspFeuXOAQx5ca8HTP5Milm2gpfiDNy80flE6ZF2pXGwxIRMJS9RSoq8AZgHkQbf0h9lHvgvB0g1teRpVXgkmfIXa8Da3VuNlSis098zYeHt+Ubr9NeWh81iG5AAn+ZKZceCqw00c/TqAR2tDkU0v9hI+TCRDVUzmSc/+DjlaNG8B0YXKoh3isBRFEodyzL3XJ7qNum1WecybNM90BQ3Pnje4DS90xZnG4Mg6M2jXLjzlH1tz8M2j4NUspFCa8VTz+Qq3xz9GUvtyT6Gku/1B2DfGN/PmxS38gBK7XdXmfvTdQkAY/iWcyYcuNq88gS44+LBr73Ba/m5N0wRveSvVQVZApqb7U0OB8/jWITUQVCohRGiKLm1CiKnhFJFbXH7XE8yj/xkH/w2PJJ6NoKAAkphtq+8NpAgK9Gmg11q6qh58drUw7WRL+5d/GJ0K7/wLnnGjGb4ZgQzYTXtY0qsy1nOPvAX9K8DkZZv0RYXgf/TTHDAdCYgm3f3i6LSd64x2YjhtiT8NWfXoxRQXB9/A6yw92xcfghwdsJZl4G9xRZclQ/xHkm/3Le7+jezTTVsl9Yi7ZFDq7j0OVK3ipTQoCeCPZKsjGR+BMoWTL0XSzteqL5IO5NZjRyX9DUZqw5zuJlmgYwoX6/hmu0pQRZRgFh7XIaOV70sg2FgYjoP6X8K8V2mzi6SeZd+sD0lXJXz9RvRp0kWsd8JpiHoEzpmEwnbnVw1YJsJGIRDSIiYpxn7/mzhpd/7WgMwlgFlX+YA8YkNC7okZS45/13TfYyoAwHNeSQMzVOKG93KVSRSgFA5j2VFgnxDsYlKmhlh0Lt5cMB8JbHWTjLlvldQkYT2sZjh394riJHjq5inVj4hkRkmNerivWgRuFaik/tFlygkw4hdPQnPmrybuDQO+9N0wqIw8VtNN3SighlTAySdgAn2Zlk8IlMDiozGN/N/VhhbHRumBZrjGQbullc46fLgX7zHMnciOGhU/JGgtInGWTuokZC/jTJrW9uuZ+jr2xQHNUi5JDttpXcfvkDNLi9SzSsslUFM5wwh8IWV0ehuzt03oC7dOH/uEscAHzP/Tce7+Nu8DjJBYYd6EEcoFb9VPYzopXy3QP2xq0NEZhNaNHj9v7V/f0yT6S3RhS+k1tIegfSTnf4bSM161FtXlhEv3ZsaVwDgcdUN0RWL3ir7lYLwGAjUQ8BaqSNQ9n1s9zRcNhz1Fw5LUqkJrkZy5HvV9XgypS5ftKrlqyNuwU7vpwUn0gHhuhr55rTzrw8i0oGjLi8P638/S4E18iL8H7DqXep71rcmdXNdZGqQyrr6zECL3wjlCuq0UB+b3rUq/vfQFzdMp+ljsH/ruDRtBojKHFZrj1EXTejcghNgMPxC11uzaRdToeflRZOio2T+9xer0+NXJzhpXolRI5C9HSriW7vsvZMD9PWLz9bYVANzYMxVP9AzOpEmpvUQWRIyn+PJlFpi8GjleQjggg8ZUmDw4ELjMVvL42jqJukqVBFROXPka2qxOMJmmQYdPUhYzmnFksTIg8KY0UYyJ33qwxfZ7/nFhTBg20CNuhQBQYHsFwevPmhYEEVxDPzOc5nganoNKpaHwP+ee77EXvvQ6zDT2Q3IBeVT8i5Idz6veePWOv3qns9bDoP6YGZnbnlVBbd75/WL5bQk2Gbu9AQmo/lHPwMF5uAHZ0OuujRtZAYTlQqJxCRslm4k/VO6Y7/flh09tFCDwUxrtUzUwSV9DpVQmTS1cgVSLwOMGsis79z20JttRCIIsF2WyxljB16go+SawGmv/dZ2FEPxEoMc8dfLbh4BtaQdyHqi1GvHu/7ZPv/7C6AwEfyJvVct0LyAnXeFYvE9atFM7Dgku8UVzSpMeG35POSqoYArvv7xlwhvHk49lWodrCyySC2muSi5vsJetTKfOBYD4fK8oeOuWY3RQ0JNIc9xXcy1aKQEvtMKhZOlFntjJcFhaeyTx1RaMa2NRF29e1WVASfcgJ0gUsauQ3RZi6BosTivAkSzwy0asRiDdPmWHL1UHNARaaS0uQYPUeb8VoK0x34oLgFARPp/5S3Cwr5S2DgUcKA3z/6iLUdi+P4Sm53809tKzjW0M4n0eEfKJqcRDQRe0cCc95KcLzHe5dP4r75EzjmZhl0WBRTKcdFRA67v00FnJsoz4P4G23DhGxFsfgtLdQo3H/pJO3dCpRtCdJuCGiDnWU/MEgZAT6X57o5uMVpRIjebs29zMCKzHjZ3UZc2I66bWoMZnXzxKUUgqWlIFpUwzJJd+qvkqT75Ui2zRthZdhAT0+fjJpewCAb6lbGQ39a6HF7gz8HnuOO1bwN8ELIBtXxcstuEersJ3+QgTpcj6GmIi1umqIZ7zzLquW9FDlabvMPhvsf+z6TGrR+gqNoC3NMemL7JVOFd3oKTJwEitIliC9yjkrLUpBRB5/YwSBXXGCnMUYRBKuMIcWiQDAz96cFM8yt41KETSGSNrhpcyxNtd+nkObTtEU8lvC30A7jVOeQEW6bpD7PfMjwMWE427YDo68uYw1kYgedbjdO7FnJEPGVyh7O1ul6E7+dLiF0WIT/0ETYn4/b+iJr0tVQiNly7B5VJBtM1qDgSXsxzQE0hLvo08xUZPFhhkHF9UDbk9pZbztnv9yV6C6btlf8pTptIjy/YuIqW4d4jKXl8a7tlqdHGRTXQn05RQdPqWw2sY/H1tnAQDbmUWfAKWL+7itWpqw685WX0YawwskdIKCZ5lbysqmPoir5/F+o6iHOHLrKejW4FpXkgdkEn01RjDigtz8n6NlqCSk3kefEszDLWiBqiN7XeI0UEUTO26fUtkLzacAkY+yDO5ZIbjUlRcyHLBb6ijuDxdwDghhKOP8hpukUv8QBzDIG1bZmmsdRdZxtNaXYMZ30rwl5j37eaoHVth3Jw8PswcQkPPsMNTFeZYXwyDfbWUndiyRFNi0T0yJbaPyv0gMFCICGwNDxgCSLWMJblZBhj2RboknqdXtR68cSQwI72aUzzrGrslVYqhRu/c44KEQ9SqSPUirBk84yO9P3UsC7CDJXj7VyXFtLfIHMwswccmy+qy71pVrHK/wrKwVZAYW3ajyhvj2j8n+TTLeFvoB3TU5O3Ixc5g9qpm/RScZQISNDCaecFi6sWtJJCV0op295odafkih6VF0SFXPPOWk34s6pdFMircBx8+q0Wiak9hFE9Nszs9wq0DpEO1CoREv+VLut9IvIl7WcIUeezbaBTKi5kq7MspLrFH0DuoKLe56rEtN9hA9r7AE8iNFTfKyC4aj3vdN+A04eb3mfY1V+2P5kqefXVXpmlME3pGi/8iglpdHk7MGADXAwRviUCHmPOqOtrwNRuy35OIXJTpxOTHkobd5pYZQJccUOfJbxGiG9TAWvryNUtoUlEcF7ocv2R7UJaN/tuJU9sYibJHCpVaxe7G2jDmL8xOdEJfST4CTVrIN3NNtmLpva8Z5PvdjMIRvIstzu849tBuAbGIgLkIXwFrK8IMPvOJ4Wbt7Nx4YQzK0ZCvX7QWPrWFcOiqxQXkX4sFEVtr7hssf5jqBjC3ypTFtM2f8PL9gdXGV43ddXDZhXryM4aqsj6NQMBXBZWsNXUPRMZ8f+E7HaFjhCb6t1Wj00HjJNha+wdykMRZqGqTkKAsWcqS+L3pAOMyklHcAP7GuPwtFf3gQYWZQWh5V+H0LwggTUOzbKeV+qXE9NOi8eMabeQPSk8sghCatqa4W0gya1vnT3ppqv7t9wGz1/ycIidprQ8JhjT0eZ3jMuihRUpQIY/GNcy9CZRLFZc9SpQ5gcDCPdZoyQhbfICI1yziVTo7YcpIFLtDYmO4rnUMhDqpVlsgEIP2A0unHg6/YmTpThTUyftkxN8ExMSVOt25P+tSruHn0dc0dGzovyTXNk5RbMiU05TkX2OXU4A1imsvTC53NNFKlJhhH+rU/buqC+6qrz6Ugobc/rPl4XhflB1B8PloKxeNTgXiDejAmPom4XJZaE9F+ODU53Ezo9PHrgInbr0oPj9pFtaH1m1UuKft8+DPS1wp45ZjlLbvgGYYIJr7ICOoTwHSBRA1nE8u9X5lrZlmgqNTye9QnIKpyemtvjcMK++vmcj9TzSyIKxpzezpAdxnWf2jhzA8Xn3+jGEEcw+MmoxDhjMh3MfO4PfhjFnlYz7VKooiMVvENvRufW8o7dPxNbkmTVJ7vd9cynAY+nWjRLRDhiLMP9i1u5NUpqUFp+rOOKvXv2i5A/xiyuBCB67XmcxU2IpuWjrDF+Z/vL0g4UHMJlPn1Ry8VaKFSwCeVGz+IeYqzuKdSSHGiz8dpFOyRC4oqm8ds7ILb+XQhb5nv7KjY/dwwKHBlHl8sJqHTq/YYT0Zrgb6qV9Yjc/UZCQsIAAATNaVPmY4L3W3L1Rl9A22ofK68j9zP2fq8wzJA6pBqssSzveBQoAOOep5Sfjp36f4pC4m2gU/YiLLSLLHHI4rSYE3mIYaCfZzY+3AG0KLREZ5smYvGORT95MEAIymZmP8bFB3D9kddkafw4wKeJCcrVHiB0QUSfUpcDEDPvQYJpVe1T4aTZh8rgdUTXlK1uPrhwd4mnIQyYU+FffFEm6XhgYOtnlp77ACLXUE+IXDorUFqMOYsgO0BDv6TU3SP0nU90iqPcdc0OOLz5Gl4y1HKbaEV9hZC4Y+bwNmOYubmTlY/aAPfvFmr8TcyXSMo1cCN/EjFA/ZkmVyDeJTD2h8a4d/QG5W8n11Xtttjkn/IEhVW1Em2TXVZpyUAuBgzpBdeesvo776hRpK2ysh3ilku6QRKg5Sfv+ASjDZt07U7iFevoDhGRdjECRUk/RXCEPVEJn/ZiFUz6EYdxRaPCI7A/EhLIdQnTA3yiqnhqu7vdr+am+Ny11wchKzf6GYtueEVdytGQ3GYxpZxDS344mvUS/K5JfdaYRjQjZrxTtsC+UC7vLAk6TqDAS/tvLPLclwRKOg206hhXdhQjgqok/1oatjbNiqJ9NnaAJ9gSkt07cJXGwu5+YYbXmSi5M53jDkZofNA5+d/Y+VwtHXOguAFOEObQmPqR9MtWOQ6xa5RLYkeQVNscgVvawuJJMtdOwmsMCpHggSURjHJiuqDbLTwcXFSl0hSJFY8myL8s7RrS1q8OTbC8FYcG+oxoI/4Br7p1PXFByLWofp9kfrP24QLN6FgqTqUn6HXBpIO1Iu8BuRc/1SfhhSJ97Zwx7obIq9RIZAVn/H16GQhVaOTQe2a5hly7Mlz+IwxuA6x4kw0cS0Oxk1eMp6trvqYqZrPqv6hg5nCuSECqE/vkOFQH4JsiXFcnVl24vgas/F3QZ9QWPt6cFP9VFkpSEbR3BS3MME9L/JkPoL5N+rfi7JtVcabFLpdtldVk7u0D0QO3eCbG6zc8O/GEqvM0wjo1YimybD9NZ3zaLT6lNXUravJQ2B/pgxffGvCWFhOmeT8qtko+i8aaHnc7L3jHgBbDhlSuHZ8tsn/GgMHzrt1gQcJIaGS6gcyoKKPQKs+cRzuFYKqjyt7K166pQSJDoXShS4VEESfCWjhGVw8OZt+6htUSxYBJk0im2++zaUFVr3agm+GQSIyl6tvcSDoXv2sxEGS284cXZ5AlrhTX2ROQdPf943nsU1oaIN0j1hYTHVMXTVlV/vU5BDQbf0FTWbJGcM51xcU5r9jdWrPtZ8HgCgWKN6u+6NClYg7aaqP75aiv3TTYTCQ9EX1YrTg44XhAbF+hwBsfZo3g3Is1L0I/3OHqVI1OAxbqWujhjV5PwnjcC45YFwk3g0qD8iaNoP/39whglz+0BcGsznlJk8D8aMJSUJ8NylwA9iRA6vk86HXdqtb16S6MBKGg5nWrhuzLI4XOCnI3HGJdDyeHlFJLt8J6Cbu1SPS7POLuClbhnekDXzG3zh090cJGxMLbr2swEjzIGPNrVHcEAjkjOc7oA9wJkM6nOkzQhy+V7GdYrD/3b3q04y4Eiim3QDHHl9oJ75X+kcWbW8qZ8P5NzcfvLPjv+mbOrHWQXa4W5gK6V5DDUUCGfmSpb2rc37P05gpaMN8eJ4iZXfkB1ZMF19hZiGXtWKRUJA5i4CkAV+Z1bbM6PYUqsET04/65IBOOf/EPUqvdlEN2CFnC2ICMCmWd7gliAAFaQ2VGM7wQsJxJLSOkCw1/UpLp72QrQqZh4j/Ha1nOQhGBej9NsR8ccKkzm377foXbGAszxbLNlLlI13WS22s68meHlr09UD3/f3bitapXVcIF2dpqUpZZefZOJ3nmPinXxt3/i5/dSKi6yomCih3tO0oZxdav1lCYL3yJ251n+zEXrFBavotW7XSaFO3dotXob0HXGI/EuhlSw7hsMY/5sBAS/OfbC+f+RVu1zMfPXT9jUEBv81Ed8LjWioaPm/7AsnGYMVFKWGbdIumB8jbbTLxj8nLzjfjCCcMk3fDU7xYiNKXddURUUVqVUOfa//yMItmTXEl3qbGBykJoWSvCQ1jvxhR507AUPozAZA9mhz+4gef1+kOMO4LHWKy2iUETAp5HvClZ6LwN122pNlXySTKTZ22zfxuOXhju3KrcflftLbUo0fa5kJIrnM+qYyDxq1QZiS5h6oad3vSRKn1CkDq+jgUUerqcomUl1pLpx5F56oh8cZnJ64iakIcSsMffB0c9TGsVlWXRlhe/D0hvLDAje7lf0dX8VZyk/x5mFPMt23MrU/AHlWOofp3H7CNtgZDhRtubC9hrtdDmyLtipd+vN58FjUW+3s5lyimoOatKuSAecgT4pXP4fMSOTSIXdwRKlVzFlP+X5+5p/qDvgUtQCzhjwzA6HTk1QUwReYnxE9N+Q51TFe8i0j0vGyKBbkmxdpT2Iuqxt4HcN8nYmnRg092pQwCBn62LVwhI//fVJzgS1b0flP7nCGQfvomrA60I+2yite7xBkalJtoOYmWM91Qpdnk+pSGMMKDHlQxfdaB+rSyuIJ0FRzCxHyjTFLK4j2S2zSIqW15er+di6oWzSoy8ynC1vEnbsnmi8WAivNsFvfXN04Fpq3HpFIDJV3k6jKQ6CFQAQimCqjWFyx5Mc1zbtd16ukz/Wxndam5DHnzuHBmXRqnmlJdpfQVVFoitkuJGim9Oqy2AJ+tEHBDiBWOVGSnpEPBnAKB2Mx9vMfx4ns4SlR7vJ6D9XepBesPwyZ3ZArlvkAROMpbuzijlKUiUZtsQqoNQjLQt9ufAgt/7BFE6hBj+/9e/E0CBWh9KJn8YVdQ4CZmKpa2qGFb8H+gb9VhKw2jb/w6Um5TTUpyiHvZ2ROaEp9qagwBPRZrHw1FmJPnpdh2Chuj+sVUe1GLAAmLmbIistn1N1YHm+6T+fWr5/n6fZ6ncb//TnkaiqBpyNTajyksTHYlmPJtqu80NS1lNloxYCLFnQabctdozAlzv5heHC5/aWq2ijswWJnrPOPx2pXo0tlyW3yTcVzmp/aAJoIjVdBoXvqOeFAS2is6lb49j7F1UZgTK7y8o8/jiCqDUvLQeo0obg74cklhutlQvYsgzudBZQnsgxhC1ALTNDz82lE1vzPD5Qv6aysDdOotln3E1hNLbu7AN/KqdwEwMCMN3Qewgb2O0zuYrn6J6BUy4K+PfQdnuTRrGvvqSEaLzFfIjHMzeHSPuRwS5VGUa0CzSira576fzaw8NCQXeA3U9DWwrXvKrMtzwz3NYLufL3HfzF5HnAmDiKfzNthVOIEwX0ERJQ0fG/5PAs15V9PM47zlCDSgq8vVSnf+9KTvGozz9VROIq1br8pbPlwkcGMT/b/quSc8axxD+h7pBA1m+G9ujzbCxKCNEi4bNWWcPmkfjwxMts/EYAhXiDG0KDsgV40+62z9SNJaAHQ0ZuMJGWgSPk49Lg4lRcKbONVy29HLX9P4oAzqeXD77J/8hfFTCannGM1GcsYOcIY4EcNU7+y4bH8gdMjxbwPxwujsuYo0Sc8ayNreAbzvwlSElfYhSCG0RN/5wUW/q3tZWBz1pQSfYk3rXMe/eAQkar8smR+l5qXWC7yGP3E9HLX9QCaUcVKsb4RiVdn6wTBureTVR47aTFSqcJyIE53xsCdPiGSCQJDBuy3tZar1/ihcVY1C6ros0s3ajukqxD4UlfjNoT7ADNebCqGR1t0xtTO76W/JJdzvIfXvMqKflMIPHJsEOp4eG0NeC6uIW9ll+ZdMt2+fJlO4o8f2PiTNSuqMW2ITJgEaue5ynvvDQJEyON4nBOdjeepXKUiUn3j1gxoag5YQkMIqR6crcNKUOmDU1E8BAeaWp6U63pL40ljinPEcqMjX0va4Oozis/2Zil2Ds1MMWySNEEEnRWYpGNcltUcnA4bHtg7Sw+jt0DYcRXgEl7TBG6ZGNde3GDqy9WhvySlnqWMSqMwRDbsZofqUijr4zKk670cZ0X0Giw0I8S3YH/OuTwXeINwMVcJYB2tu8LhbhOE5SSJ5opyQHP6T8GCqmIQlN9IpoLUUJUFSO/uzERTIuK5S5MWWQArLoaKs8sXB1eu5ly8ZRfFV5Ws4BXDZsprFHm3bUKSn6+bgTSScpJ4EigJl02q/IQzNnLS9luLImqwjxJ2+5sohAavSeltGukwiBrtcD255LNB1XPAm4TJN3OxJNKjhLkS2WqcxPGBwShLseUOGrfePA18B8Tne5m4SZ2NaNQ87+p3jvizI1zJLCFOFBIWfX8Xh0hToublj1CRJm8OjjqJp6s6dPBX3OkOgD9p9qihW0v0yq+cwvjiCQD1kIyR8zaNvNtByL7UV2wFtKvZgHgbX3rfEDWBaLoLnYMvtNkFHSuylebk51eHwx8kNt7oOO83sRJyFfIC8w9ygzdZ8hQLdsDvgMXsSZblraXcqJbEAjYK1Y1AKTjxXjijFVg72GBgTAuY2m4ZYmvvlns/qUH3XatcFFFNJ75ufiJGZovb3XfGZJT5Cxn3lY598SSemkq7gA5kkIVuyh5rGTtiymciGqatHSfNeRJjKrF0KC86Htp44eq5XSvL0jc9dUr1xXC8MXVQBAfTR+r3vArHd9A6LA0HnFohqLiov09R1ozb6I7Pc50P/DBP3MmnWfiWlZpPqOGhv+xUZlT5yCbcRHa+S2gi3Na87mb4W3A7YuDtmkNvRGYLHyUs5KchjgvAT9GYK7zcv7vI1HX+vZK03VtOfJ30/yKdcu1rOsRkDHTrYS2XpDL6ufVgN5lthgfBUp/RR0oCGA/txaa6nXykVWNyswbxrAlfhvLrZpEy6KFypJ0/IkFGmmF6kDJG47K9q2RfMMQ5lDQA/i3jiS8S2olRreL7yKgx1yhZC9RZRnK0oDoufVW6TIS3zJA+C+lQTS+48zkRoDXyqoffpXL+TT/TwBiqbgFB0PZiakShmb8Fa7z97xOv7B5uHBG7WQxK8KPJx43M96S6mxuiRrPFE4dtnr/b2WwNSNWHb04/tj84zg0Nr04L3hnYZ9HwCuT+BctsocLcExPWowY6ick4yrCvIc1eHoAbwgJa3Fuw0QjgqYscg3ZJT101XjHhVeGsF/IXGqT4bMJ6U83o97LY/ZR83Z+/IPqdcrRlXhbavEkP6HzUDdfN8ecHXPB/bq1F7sbEKsdYGuG8E5hFYlAyHmYHIzseL7WY+tmC0fsBjH/NgPqv3rqmNmuAnqeYL+XYc1h0QLy55oc5V28iSahJUM5+egB32h+2OrzdI07sDEu+kgnnOWwL3wlahdwAGs95rx14PmaQ2q0bjXoZEkX0mkAEAQ5SXHA8qFi+LUYmyQxc6ZsGoleCQAKqQKePb9LYWXy5YlJVCxxefchPQFMJ3rcxLJgHwDUIck0/lGsVWqmWU5/ibcrCj+Ba9NnVx2Kn3Vf9f3buyH9cAaPQhdFdm8HX4vou2Obdg85jVAxzdRHOkhf/TymfadNA4yZWouhmaRRUuWFTd3KVYWVlfJIqATGLirmthcCRlcmUtfqUG3fB8NhZxJx4pOaI0ZaaAIAhykuOB5ULF8WoxNkk3az+oJOF0O4mUWa0EZq4ecwBC17Iw5E98EplXQCh9oOwSk5sky0flccH+uNqGooGgBovk4Pq9Xm6zPUJdVAzDG2s7JJqTmutMGiVBkBxVbTva5xdM4FQdj5GDvK31Xl893NIaER3J9PNQvqEOLJIhZagERYsXNDF+e+34+fW7GFsUeTjHG4tfA5KTIPu0Bx9aJBTqusNNib/V/kOjQplUaVJnXTeKKSJakQd5SI+4gD6ACg2nHdUO1S3jI4NamBxKeVMTjNgM93610OBjt8oPRE5XKUtm7clb22qZqFYwjOzww42on9oJmGeUSC1LUihIIhR0A7E9ZVlQ8Xj2UCoFFeczMX70JDRxFXeSKs4oUySICBwOgkVnpRDm/l0L2Y4/cPzgAAzpnFQD7QNR5JRUON/tL8TIrCZhe3O5vVz70ttwR0a+rfhVCn3Z7FboPPH+Icqb09OZJyqg4+8ZyDVjxzNuqXkYLuE5aCI8AzPk+mbBUhCqc9ZRhSOWMjoHcBFyThHHsv8+rfNGVxxrV/uQrIFT/HJE5g0q4JQsoG1v8VDjoJcg+UKxuRmzIgmKx/xqF/E3wvbeNUJCOYwuDQ/SDMFhNuc7B2eeo/zVVEC0KOqUoaPd8gUVfYAeybS3SH5axslbX9W0oppf/lJ8HZnOdvPbe7OtViMXaE9ahghQH4K57ZlRtczu3l+bg6LGlmOVmSmYVaENBxWcJfBxo/vIrcK3qMJB2tyCiooVKEVzViEELeAqL3iSkeP6yF1/4K7aupTuPxl4Ips7iJzKMITE92cd4vbnhfN6Bt1bd5rroRrc4WZid9MSWccLakXyxvjRVGCbxZhChYfxU5s68BClHjM3MUUUaUhWMTPAPW7tNNvdxxMqZF3MYyyn/Gt0rr1vyitIvzbfwX7/cw+cgEQTzZwgOvoJeRK5aJzVBudxnWaIoJqAo0DxTfUvR+t7dMAgBso01MY+Y0B4YeLkzTQgTdpOiXirlVs+HM31UL3mnOlnX+Djbbcnjj3BPXg/zmibJD4xS1vp1sKD2WrIVnhr5acNY4WA807ptNCay+gGKlISkpNkE9Vy97ctz0qgmul3pXP4fHENHZPcnYJVF+SYfY4RkoW7ZKbx3TlOjs5SC/3LF+rdNX7Um+FGitOlbxAcgJzG/aaSmAE2GUIK/vLWgpb95GMcnqOX5Eg+1aFbPilRtzav928Cs1snHoBHpZI6fifRNGp3KZOOvgbmht0CkxaB1D2Hgc2oS6FJq+hhuiezhGjnaZeQ9AB+15d8NvYsbLs3EakXItKCAIedQTki5hwSKGD/fARsFPDILfU3gtH7pmKvPGs+7+k/yF0Ry6c84KmIHOUl3+ccjhcFLV5Fgp0RsQoGmSqUk96oeXFmQJFmi9aqNC67MfP9vcCCGG6/SQS9j76n2vD3wzJehBTBzbdgy+YbG4UuE1LaKJbU5Y9S08Titi0YqSNK789M1bOLoBzgM7ntugk7TnAQFFEQcxKAXzYaIaXYUg1v5ixAEJJVr6/uevltwuEvIlctFP8EPCdFyV1jZ8+1ntgAz5lvt7yHxLMzhXcNxtouhaCiGAzfS1TpvIFxCMPDBRP/5wpXiQfpyb4c3OAoKch6or+xrlFuqZk4hiPC5xKp1mSlp5KsVADeqO98WTq/g2RxLnlHXnTNwitmy5NI2lA7Va7uCmz0MyT8Ju8D/r1ntbeoPu2C++9gPD2PQQOFMnHA7aqV7D58CRaFAJOSEw3yUaYTXngVT3gCnvbx099Oqnkfm1vVNaRwzNBmPsIC1v1nAwkGe3pv5L7/NN8kq3KrqDJlTwcIpP7Vh7JKmV3Q/JV9zKBAbz+Nrf8VOAEsYqjWdkQ92HltPqXo/LhMbhYe8hnRDEm6eSCDeOagREao4226O4bMgcB/QRIYuJ1T6L0pDDjqQo1jasAHvnolzTSNIAQ206hEnjBLrBd5SaY41z0g8kPmXbpjhRPDBY7MuoGgxj9ltoiqMGZZoS0LSxgoC/KQ2seWJz8j1j/FPkJU6zoAxIi/YlU6sByatSRVJhfOADbnd6qtDwf/D0Wf8fbOnLEONHtZa6vkTVbGpXpV2usc1AiKOsh1cSPC4UTLbleG9b0ULSc/2wxGov+BnHarIDD4h0FB/f5Guka6iFEICLBWV8lwCHWRDyvnxGb/0/kzKOz7gpEzfLU5uz/ziBnQsHAvpsnj1eccRYZzeC0biquKUNUYR/JEI+1UHMaWNvrnkxArVKLKu9vnd3aNKIt02VmFPbLEdI0giTU+wJoSLKSN4FShHKUtm7cla6nyFoKn+fn/iXo5MxSEo5J4z49AyCvSDLzPXCvUrR/1YjMrx9LDvIrybEVmQcTyXRzSUHs0ZFq7Pju08UMzMqk48FQyZJ9hz5NsHyfWDc1gB/LY5NQLVn8joWrsWFIysvz7HwKA+mi9kFIH9nXg6oX/ao3glXEpARwmZ8KurT97FTQzGYcFjzONa2bXbpf3AriNJkbZmVIoPdY828vJpRGFTsGFQOgRI6J1+9BT+Uw44xHWPCA7yZyudU3tOd4mIXvthwLC5C9vdKutmRS48sSSfYZoRdswOEO3/wefttow+ftVRCfolkAhxcGw+fb47ep8ESSsbRnO55OwqE/S/U/oU8N7wNNd1MlioOecaJ/J3YFMMwf/fQIHI2hMEPGsW3kkZWX59j4FAfS/b9emjUAjHzeS4sftCsBhlZ4W+frmCCPU4dOx6sc8sIaGbg6bmd9sn4bb6MyBTaRmZ79arr5qBECTATRsCfbXQAe9hARO/K4qM6eWqtOlno+R/tZnQ0OPTwa1YJUxTvD1Xwc4660kwGZXYY4JDfcjDCp7E8e8KTGkrlVwSwtX47S1TgtVr2sU26poVDZGzQsKgA0fYSuyUpQbTV1FEZr5l6uaU1BCHUUxpR/Y18gS28x/pb8cS2puymqZmRHw0JaZGvamsKYR5d37GCTakPDJdgR4ArQuBpCNh7aFBeqUzqMV+gccCiKKK1+nOCbJIY6zIOI5VoOmc/dw93N1+ktbzVIH67rZEhZ5+RxpUfUO7Hw1fo3tWQusR23CYlSFrm3hsQs5qmv6sz/L5xydnn/nDSodhNCdbfL0FMqDH2vgdUBFmMrwDjfZkry7wjx6OD0/WdayfXGzgzoaINwiD9fEqygjFjyR6JNl35vTwn6zx2DnInsPKYlH19RAJNUyjolTVR8R8+A6o27cegmP8e9hoq9tl328Xq5eEoBvNeCeSPnsw3ySLyaPersBtLQqwMByZlAfKFwRb1fUUwCNA/F//GGHLt0K+tHG0fwwo/Ctoju4kODBjNWdLRubRTTMgCPXKZX3fPhalwdfe539nqVVjp7SzIozgyVSERmU0k/Lk8Uc7MYjOUAQ79jK1tX4sImfvnrDqiehCGHhEgvbeLOf2XrOzVPMwFZC3i6P+C6Z+W74sqVuhewWA0LNdyHQChEv4WsnPkuKiuwPYt7tyHJQAmQgwVYzl5FI01KiVbRv21grK2KnYnavBdN5/mPmHsEv5kNzmXsA+x1h1yhs5fdyDZSYbduPNk9ITMFSl7OYW2OZyuXU5J2WBTQKmdRFLE+3RnN8cnz7w/M8YeLrcFHzwgEVhR2eOxvAZyTwdSUWQlXism8z7Zx3SO5LSBDZ6Lj36VuoNrrN8BYzJUjvhtXNyNB1CUsVinkiRom4eJnXGMZl2l+aBg3Ixr1HqIeddEoN6YY3Xp9DPjDQGw2W5Md0eBO2pBnei9Nk17jR2o7cJzbBcuxXJk+yT1gMSlERsCwnJuQ9MCjFmVTD8jZxerXzqG4+WGevke682Ai5Af0zDI6uep+ynoWQj/vr8L23nGOWv538mSw8NapdSXOkMRq+kEBt8k6Bl77Ft5clHkxzXNu13+F4+iopiSo2RL3zL7rYumvW/aB/o4r8sXG3SmHNsFy6p/B6NUtX71fnXiNgWE5SKkZxYAgayO6PbFXmCc4kMo1/+ix0w9Ht9Frg+N/STO15g8tXrLdars1KoRZHb98Z6OfQeeyXT/i8QGMvqZk447LoAcwM4q3aUUMuLz6mp0naoiPl11knaXjiBQXXbzzp5CrLVVrUn+uXEOsBXYfuiOTJ3O8sfD1/ABVXGNleoTvjs7BVDW1WBw+iaZYvoM327wKj2qnGx3UeHGOksnEUF+NwHs7yp2MtFY2442k2KFD9L9K3iAwttzd793wBn75s22N9CQAmGziQN1T+v14xmVGffrERAaAsF0O9Y1rmYsW+iEW6kPwVZi7Cx47k4loNQKmc/YUlPiV3/UzqBWI7N3ZWOAfn8TOKjar9Vtg5Pbid96jNjnhVTNT7gR6/EUoAC6HtfC0Ck1oB3X09LLY4F/kmqRM1IMJObV5QrNI63e1Tei1bJJPUgJjEpLwVKEl3ru63EFBnU8rnBunxT4vU/dny6MZ+AHy1l3EJdqmzMv5NQ6IzRxH2pPGNUCObocaMY171WXnGZS/fVlV/hjSwOg/9FLW5qf4zlGqDz4GxDQUXOTH2XM1JqIXIg4qYxfSsJoTGQ8VDqsAoUvVrMKK1PsqLIkhkN49YGUQrf03Ddg9Kw2taz77y61l+0DISdsAGfOVHKxdMCiMw/mcQT9T+43cgQgE+KoAmlnCTe0qsfUObQn1Z/aQpwE3UvDII1iCM+R2ZuHBLlPyGAkqJAKEXfDZ3eZb8lDGWF8zhptv5EmfSSE0vzyDhUoqpoStu8QqopzNG+O3Sp1mLezQR3vRdaUrY3ON9597ll6w+pg6PJ3PS315/Mk1M9TIGSRGCoL4hzcuhWWA5RozyytoBlzf86BqaKhyrWiGg6QrGJnbZhgY4VawzJgUoanC88HogKzJZT5EbMgLt/iQUpav9hR6lrZnZV3C7H/Zz0qjOkhXlC9JjI1hLD+G6KJkF4PoSxSTue91fLqteqAQGM4RjYZKWCGnxX4NlhWLVbJzMdIL61XJkNDNaUSjQf9LJxg0cKTzrEdXuRWqLIsdqb8wB5yQUm7J7bVh+52YrSjrxCbEIp3c+2qfyX/WY4ZGrspgFDd3iOdz4Up99urOWyOqoR+2TubrGEa7LNg1l6tLFs0WFjag5mwyN5B8jBFeQr61LROCsNX9/stSWQR7awUVMUoXYHI6J2k7JO2E9mHheudFkPP8r3V7W70UGE3Xa+EXrX+pjBkWI51tIKH7lKoFaB3lvK7EaNFRAatkCvGrM0fYxXvCW7MSfbMQt6Pc34nR9AYH+yoHcw9uzb6ihC9AFpTiVehTQ7Eb714a8rJVP2wglNywJkR2+WOqWzYaavHvL9ZNYnWJgGDzmn/EcJyyBuaKK8FKBp1T+b8ql8Jq7sXi6HFV3l204u2oVoEpkofFXRHPpeyjyQv6Zb+VAWwzIfrAqe2/CEgexjiO5JSdPuU+0uRaJw3qmvckTVZUpkjTzU21q9U5PzkIx828C2b9TI6VPXOk2koBxGS3ZFxZDzmHDRYPbX4PvEp6niFIFhR2tjficvfAl2fYSM9T1Fg4DmeA2KQaVYBSLmmU5Y/B6e3dfT7Fi9iMTmuA1cCyNuNX0vyo39Bi01v4S41c/W4XGconesBYsqoNCWxgVFUutoAepRuSc12n3DMvLFjs7fru+YWOAfyRSweuzZUkwFgY5vxEO6ljBOpCpff7Si8pKa/JaeSOZdvK7TuBlSNbdWINr88Pp3+9to3UTb/+roOn0YUMul60UdnFerIvJUBi6FDRtofj15r/RVuNWiJ+kUwJ/yHi4xDwcqV45ZndTaMKDFf7+LR4b5rfDMMJjIcXl5p7QukjM4tNdS9MXXNGNQw/kY7adcmfYlz+/kdwwmJ490hbaZHYfuHztOvBBh/tIcwEYne6usUjAJyD7PAnf8FFSiJCH2V+0Y535K7JePokqs4vdgX2YXbb6hzTIG0Pu/aqcYv3Rypdi3tid5frbqzjjYTTYRXEWcbzJRkRf5Z3Nexq64dhIxUlavqTWXSSRixx4+sS/fCNYoDhu4930Y3vf9gLPDN/hIdpqUbU3mozHseL97bqr3EdvSl+FcW7iUDypkFZvbra5Za8bO/2EFwTcqphllPq74gFBH5DuALEMQE2faUHh/SeSrN4o2rnPGKkZO4WLdC3jrhU86yFu+0JpBXllQbkDW+qTvlMN6J0L/y2Hije0pHTmaKvbZd832yAK5c1cbbc66+cAw9qIo/YUzsyyuocBMzEOtkLCkeSDrjEkSsYcR3rbHAcW4KBWNQZ2K9XtVEDWWWSGItyWDV3ZDKfJNq8xge3yH2TpMIROL9iE15PDpPpX2CmE7N1d05rK3afjTUguiapTWUqsJ1lEzJDJGGGsOSSFPr/ih8sN2ZvCGrxBL5eE9PbNmTye96vnUjhfQUujN05/9Oz60o4hWj5zcHoGXfSZghBkKn7GWR86h2JO4CYT9oN/0XCp6/xNAZXwyFwRTfukQwUwQgE2z+Wtu0OcYeK80qcK6UnnnOIWq1hyLOYJJe2p7NnTXzlw5sbthLteI/hr0YHAP5IS4cUBiu6s/0XunrIM4IL8OAmfj9hIVLFPsAiIxsFcRQ6E7uvdg9rqHx9VwIc1ynli2m9eM5C2yFpAjvhmwUsHCXzF9aKqW84+GkpY14i0WoOZPqdpT1z4xTVuibWDvYadBD4OxWyQ599qLcE9JPKdr1kvcMmLlPHa1si8qphH5O4a11sEKTunPh7Mk5dFNJPOfXjIw1T6IKbb18PzX3vbqwp378X4EP0EIRdeALFMLrwecod4Q8B9thyYne1ARMIklkSG25BuiGhAgx+GrnEqfID3tJbHvacjD1oUX1HBj+Pg81xxBV36rG6jdwLTmJQMr3abJXwBXYrPQ01GXlCLeER5g/fvKDHKRgn/Jh5QLN0RSQjCPq3jvymUzcrXQsFXdo5ntYCTWu8Fr56kikK/hVOrR4AFQ7G4xsZPoU5+Ylru3XyOQ9bDGrsTdPBqoKVqMpgJCwHUo7jaYS8t18oINggudHRNFTLfZg1neJDM8nRgwOVB3SfwXQKsw6C8RqrwTButE0CreDSuqrRF7rFJC1tN3frMtMgMSNlLBAxCtqUAFQxlNjcYJl7lPVccr7X6UVoxC2pR3TNBFslutVVTJ4CoiTp5CBC9Io2eOqYD1DvghFQ8N8siqRcmAFasW3Ed0LhkhLR0vnqHsPu/o8Rkkh21yUkp95Sl29cxWsbZFMCZBA03CpEpliMi+0n2SiSKTnVisAFiPJyF0pDnxzZ4zrhnbA2A+eROkQt/5AKMWvWJydrJLicyOlPXbrEIlwsC3Zog9TyUWHmzZIDtPDY3VMlIFzK+i1hp8XowHNhF3z3+mc1R3rG/h/9s4KyU00iTWD+7wd03gcH9XAa/v2VsdU0l6+YZ7jn25wtMr8eo2fpbocDjhS8nXcnC+bK58DgT5GHwrwUWucNTZl654zrhnbLINqmMVlyU3Q5FY6OOzFfcReIhn8ofhp/aSZWg8lchyu93ODJH9nKtzNqmx7bc/YSCk6o4mZRp4A0JEir5FYBiQjJrEbu38mS/JEXYj3plMhndv48zTwhJ+IvHaRDJxnQY+MIVFZuVXStSuaPi3eAW56qFPqa/SrnPpiBQOKq0Re6xShsrIKMuCbhPALRdndQxakmUHaujFT/pOJ2YwvHA0/B4T+zm8Ahu0PsylSmjeNbupkH5U0rMGk+RljzZ4E7F6Kp3+GwGghtUzyIboBfzVhKYAg1pXxSrfuQJ3Ujj3GJrWgKuOf7GB59WJ7jtrK5EmelpJX5MJ4hx+3SjwFmrNRCjo311GTKCyWU0V08odfUTRyEoAU8UZ7xai1pOF2VR1Lh3wVghlEVXEXnTesfHm4aQdOYIoLZsvD0wYpo6kJVT64eTmPOMXerJuKQ4V190VtYlFbV5VbrCUZz/+W4+/ieAhJlQOS4rVgpa5CaEzopi/Zvvjz6NH64kJKJD6lVJ1eH1UK5xa+pBsttZmTsEZ1OC+qn5d/geTzdk63pMW+Uf0qwkQpHir4hmAUVb4KSZs1mV7BdPpSfdzTckC7FoT0sqVN6Zfa2+S6EvqnEcGA/umxgzicxu7KFb7bEqdmSLjdIOkTMnhTXBKz/5d4hxPbq+EV3XVtLIuuXE6ZdacvknVpYE1phBO/AN59noIy+SbWhX6J+K9PR/UIcVU2MCaocGSVm/ifsvjCHDBCHkR2v/OagynT1nyRC+99vo3U/cWgCDPeSXt/mTNuEunH0tqZnJ36tfvUVhgTCZmHwIu13VoQnSxmNR6DBVM68tPoLj2orn1QwCYhekiweqB12fwEjluB4wSXdH2hAAAAAAJCTjORJPyvNJDhu0cPejrFe/SjbCYIsC5OjpPzdlIAKUJSWMs9vHwl3VDEpqQg+5IumsO9ghVYwUN3Wl1rht/bIly1cpeM67sgmhqy/OHPD4GyWnIB1e6BRe5R+3Bf1xaEnheTtmMBj3i7tLsguGbUsqBJItjl/cUBMAgyuaCPnQrzii/CyT0CI73e8QGYI53YAA7bt7hAHCLCwDn6z8HcjJuYjUNCcgbeQyY/hhrS+E8FOxDFOimJFGNv2wb9RtuzSjgCToazMJerUdbRUnJOurmH+sql8cxWPemDbbip86zqr+LmIrL1hSe6+SjUFVVTnxtieM4qDmuaBLYeqb0Cg43O8AQ7FVwCcHh/kEBP+PxrgMMX5UWUW9jfSMNMe023Yb1smsHfr6Op8gzwOeDzoTxtJLkDXuk06ihI+sipSjNdYs6odlc8VFf9X+9cAu3JcIbwsNbPnGactM0VgGjoyVGyywRe9kAnqtiowXsM/8cmu1af9LHK4o2TB4QePaS+jA2Dhw1kF7vjSzIlG6K8fMwEwFzBG5vMLQ2Bn+aqoBODmgOIR7fsUpNojQ3A/iyTIduQWWZWwtnkhrll2osenKqgYSq/DxmiKLqRbOu9VQWnVJI3zhynn8NPauMK8nF2Y3yrqtepUIBfgSBT0PX3yvxuAt8LI+Cc14o4YC8gk0N5maQ7YjD+e9T4xgIWyqxyUyIz9ZySmzQcJFmO55sFkC5Ni85Sjrq35XvmnOdC80kAPKRgB9S38fPRG3HOWmAR4yJOxDIgD/jn+AR5VTLL3xE3cuR71iA9oIekhEH+8dB2JwOXYfrzCDY+rz8OahFHr8zJuLlQDvgWOsxuEDivsMTgY53544xJDwbx4aCs42CuhiDp+fuTjw/AHLPV29uN0P66A7swTECN0e/ZOuu1jPMi9f8Z2OSqm+5MOGwKZRPLPQiM+xtjYq3xArZzfDzLYWAMx+UeeSIXELHCqR4Mk6yDAmIn5EK1k9A3S2m7roI7Eq6qx5Hv59EuZeLCsf/hclYBioJl/8NjtpQRwAGRvQtZRmejwo7xfcmAZmN87yu3hleAg3Ln0aAHv9qdSkJ/bbwjZa4XRsggoyj+9RVkrwJP2qCkuQf0SOgUl9F4z9IeK2lHxiherN3IBJMAvlLDYUsRFgR11u01+49EyonWneR2aFXILAv7getXKB67zQnj370cDQkyu+iZ0WUeW8/7Zh2b+jg+SkK+5utMl9FUfpmrhTjquAO+/mpr4psVhhYXPvd6ztVJ0aDRK6nSa9S9Yf7GEgkmlHqGmdIErLsAY02ZORPs8xRKP8xQ0Ht75hi0R+Cv19en3wbGf23LGKJeX1E3c2LvDZQ1w4yhnv+Ra1WiSMNM3PjiDTnXM6EQkc+iDvrQmM9WlgkwC7X0qPEdARi96rMrQbUm4LLlT6TPc3GqneIWciSEsVAHW7nah7yI9qcuwG+cZjNe3gbwsfyEuN1MSUrS9jgU6CvTsx+3kBK6BD1ExftV84JUsJVK8QOMyvXWW9u4T737x5fd+oHnWFDRp0DlLYALVoFAkMlRqOBN3iFDX68CZlY+FqAXNHYQ0adEsGbOh8x7THFx4hyTFrckrAm0HTqg8KgQhgJ125KFp0S1eTEwFIpfSuqpzdgPCV+WO6+/Dc4hqVvaGtZ3I5IywSBDtSOfMvvPwYuxUVYzuQpiIyR9SJhaWhqyW2tyD9x7kU9nT3vIeugaWC7j0F/xbEHmw2sQtQJQXFkjpKfXFAj7h2jmB9V3bfLRYvwmk1lJnkAy0bZk0kD8YdFOGkg0fs0vljrFaHd8vpIc+xhWexJxBVk7XOGsRPIXzhy8D1vrog+cCpOj7XoHIK2xqHvvCq+ROwVntbdNAAA4T8n1TV1WNZlkxjVV6Ba47ykBXH9lD7GuLa+HnPeQuCWX+IPSAG1V5CWdpGTBlwGi5PJtCfb1aimOj3i/Do5oea3yQb2BZsaBdmD5h1i9toe5rawi7T2AE/UHRrppj4c0svns51201NGZ0yZxs0DA29Os6HK0lNnPzq6vDAlksu8NnXmdgNO/MAvX2wHIqf3hwqhqIFtKcAuAAAD/Ji8mNQ0PdqLTriuAPk5etRfYwpGPhong3WV8NZwkEnQd01tnWG0JO3EjqSQKr/qK5jkscKdTA2f4RfKWWU137vm0bB+Zs/2GWkO3Bp71nxOQwRIeVoWf88ivf7vxNpfm5T78yDaJ7PDUmKDfxo7C1bLIyuukWjH9OUChmZX3SJSZeemVs8raLHfyezR+6z3QoKybXH2P0RfuqF5Jb9jQITJV+R5JfMxVi/bj3yLUi2Y3uOYlig0u63qVXBOU5A45tVcKN71rUlorY71nTWrgD1XvNZItvlid9rMkFCbg9jMOHJq01MGwk/oPE5DA7xjTa7ngWe8VUmW/1xgHT3OBun5hntgMQ5K6h7bJmuhxrKG/lrQrhygGZDgwAyejCft0m3kCBVSW1p2GTDF9WT5JQ8+lzZC3pXfSdUV6tzqZaLcqkci0RF2cMv2khDNLZ4K0dOx5sXZGrBTRMvva4mT0h1yk7jNaIC/WESWjisDONz2TTQwgMKHLOwkqUZbqCsFRSnoFLlx8baJ71Jib6EvRto7VI+Q0BaDzZdUdPDyBqWpvKmX1Ziidhc5Y/bPU4rVYJf0Esmq3nNp4YB16r4iAZD0BGGL/r8NkhBcDwDlpGaRxj6iLC9Og1WqzJnd7TXWWQfPDHlaRmYwJSBi78QJALTkqS5qeuq2FMbanO4AnMsTRPzZrobtjsXzDMMs0zuBjmToIN48rmB0kcmdjiWlXs5LUGhudt3p27FVK5LUB/116+lWVwIh4hhLBMTMUMFRLMMEse3fQ6j+odCmoGtbvGGWXV59yRIRwXNnjKKWZgr/vEsg5am/lRohYh+zVYbJPB21Ss43A3h0dxfYxwFN3OII0Tl2IWiCGucUeqcpbg2k8UONTx4NN2NMJRnKHvvcPkEMkjsG2Emyb/rWW1YOTXKXmKwi1CQAdQtZ8Bjt18HiaTy37Qs68A9y20i9YUrrru1Wl5PyUXNBtZ1utouQzjm1Fg9eLYoVUmvO988FuS3y/IYiD+G9vZJc/ZegdHFzRdsqTW229o19kUfEDI/Rw/MlEfKSRtQLh+6LTB1SQKrfrz1+7KuJnruZx/0POxgkHSCLrH1ptsxyzjFWuA00ck2BV6Jf377Qd8rOU5HBPtF7t2zePXedgG9fz6NmPp9aBTJP0cGDR4HUKghPeADx/gX5EWo66yB5ZHBPtvfBwEc1g02piR+cxb9FmUyXs+d6Gd8BxBUK3u/arfcJ//CIiIdQfhaUcOHgwGPcwjReCDObCCeeWWR9CpzyuRNA+eg3zsSUs/hWeULVXUW/NtNQhT5WXN++HmpK6bz6bjybrZFMC9+u0AccbE4nGTGskiTBHgZtNZe4gD1iqS6inC70sERpudlFAuJYHLoOBRqvoFReFa19xI9rkykEZwWeIzlfPc6MCmmf/lsTpyqYirbhE0P6eAOvha/dh3qKCpM1OkTvTZD90kONOnWrGpsQxqtpk7KIUC+i2hbZ0OG/cIGkfpgL0yQdBxcDFJO3xZMIPIAnLmQ7SpvKOzpcnSeAQerYlkGI+KepeiDK73H00z1V3zIh6d06m2Nn3INNBE/13BylXGTp5YeFh8GWWM6SLGiPahE30+3Z4iiEMY9NInEKP8ZcAD4PRbz9n53wxGFT/Nq2ZaquvL3ji07hgzti0liUkX/pGdqh4cHWOOc3Oj5LQbACZ0+EEA3mAZsSXbPuncRDv9SU5Cv4WhCYRI8ZVMI2BmniVCGS5FgiatEyYjDyfqSV7wrp+jxCsYhGi24/b9RWce3gTl7UvmchKSKRsLkYjMw5HgT+L7t3KC4uSvC8F7HLrEV0ttE8SNxCTspVqB1QfFoOLLd7fhc8AdhC960w9xcCutm+x2vZhvi5Kza0Nh3CrtEmk5PbcJ+OOF6LK3nQRbIkVC87+YMV7c8CtaBQxvedV8tm19lKt0IFIJRr0cUw8pwF0reLpDvoG/R49UCpnYuC5Gsqq1igUAZ6212cYA0SPn6ZPdZ14ZZYSfzshYll1ueWEkV9EkOTrYWF2GMUOIyWs1+a3zUAHuzTMhPBx7KwKA04U/uuYORaSU1d7NFNeEtyKiamWNUmbctvj/Wr1lHN/rlUDjQJlO2BGL1GTPYSqXd7XboGFyMdIGOG4Gtn+kbEwzT5uLhqUsk1nTRzOvWDiw+Zv8zsRuVgPdeb0mzEqzPwtaLsjBIJ1czjmU40kMoUdYINUTjJFM7S/EysPaviJOhXmDsYxgZMigs8xu1/SdnHgWY42PixCsPqOotsPLBXDyk1H4+ofGj6WfEYczA4PtLNU49uD1sYZirPNrTgC6M0+qRU+jmi5AMt16eE5SD8U/eFUaRC91ULOQt27yKLSAvSc8SxFSs8+jVuRUqlTZ1pI1hCJFiuWEt/z1XnyL4sTErN/9XdHzE4eMGYADV+bXZ+4mFaTzCxNXKuUmzNycOq2iCP7mkEB1djhWE14pIDMRyVNttZM89LgRDxLfg5bwB3RvaMVBwFR+dK6ZLqMFxLv5cixXLCam19emmEky6tUvvdVYutThRG+WB01voeovA4+PvQKMZx0iOiyOOamqbQz8g0iHz5hr485h3k29IMlD2Lbjm3/tw3OXY534Ey8lQxw4mOAEciCDbRzQGFo0HmnbPoT9caujZB9HBFkkclQHfLCZrFB+wbx6e46lTO+/2L9zG6imPjSYh3lCppVOR1D4n+0GtpdQRaR5pJQE07pXSl+eGS9V+MNKT4zR+xoJA2/Cz9dPcDQIXGaATCFRcXPh/fMuFgCX+ynFXfiHuoLWqVRH9oGQwUhXRlEptxgPTAyY5lllJVP38dn0ccQG3xtUtwm8I8sBuicTmGMCrdSL9PpgzsVv9rveLTTiICZ1f8IPgarY9i7t3/aheVTcvZzQGGds4M9b+Z5kJI/o63pZpphxPEi4Ldh6TPfojBWWvY4iOHmgkJidc3wc4ryF1bYfFH0qv6Z7GWrlLbhNnHlkFUIyeUOynfrbZD4xhDsbTw/PTslr0S4wtkK7pn8zuHF6fUUkyACJRj9bhikHOVGVxUtTkxNu6jcIIZWMG/568XHGunVqmxl+3WESoWBGuzA6T07Wu3a5h0VTZ4DaxK8MmX6tWyd7JZU24WNZiA2rVKY2uCJrNW9QjfHc6rLasubqdk6qmisHjHzIdFq4oesVpWAp6G4LC1GnyC0IB/GBn9SYgItyk9Id2ejxILZKrRsYMUT9+y0aqih+020I5gDffzED3CX1fUMMUMpYPDXItJmrwrn1pUJh0WDHNxkPkYPLw6Ik+e6W+RcBUOBv+nXCYCd7JZg7eC5mLUuVWC/sl8djHNlFW706T02tAm1u4HZ+Hoyu2k8E1crUkQqOBQs/v0zBrBSB/+3hDYHX6i9+sLoAJ5v68zbwZczAjXBoZHUruiXr/EVic/GB7ZcYGcOUqOC6hGAl8mAVUUidSCVprwjgesxRuTRRQFDQ5PImg8HKH8zkyeSsNUwMPZMNEvwcgAGVxfxogClNrbnldrI55G8wwBKUxP4tELYPw2DORzoNu7VCRX4lg0Bt2jXYNFpFdEiJC73lq1TOGfoAxCYC+rbEobteFM1+WLMpecg6oJDMs4cDMiLSncRZzgbJqckBbt0sIrGKDW6GQzbq06+DSwvorHrl3rP12WGh2ApLZdiH9TDuw7QxhN1jlg3ONgkOFgyV542BKGoMTaWxhzKh7yW0u1x9XWH433pSx0Vr1q4lRQ0cMKRQU35Vr5O9hJN+fqMLIC210wJiZtKKJYUfAXAn7VyJpGSyIe3dtYaw+o9qNpf2m8Ab0IlgJR9qhL2TiGwvhwemwnwFxkYAC1d1SN58q8PCUhx0R2Hr0W1snK4Yy1jcftCFmHgf71xBxVar5jQidV2Cx6zekb8wcbOGaOVrfQOzb2/9ARAaiO6rlLG6ehlUCpX7sCewC3R3JodC+xcHzKJFe8KE2OeQfsKBG5cGA7YgX7BWBhvjN8opRGAgutoYnEXPDwFuEHZV7fzz9YGhPK5YVUkRNgFlnldQ+AisM2ngKWqRKMU9w0tCz3RJSq8AakrYCsbcTiUhxok/+zmpK8509Lm7eCFM5mBZR6sKGZ4+BLNhs4YXlOY0mCcc7I0XL/ECeV/WGtZUBT7ExBVWYMWD24zuk4Tu9lSH6Qp0XZvtcTxwPsuo8vfH3U6ndiaHqUIsz9QVI0TL9pelmsxGJL1aTsHzn/6tgtBklszTt/YTLNTGDF0c7Cd/2ulEwJrNQ5yPRxgwufszNfhAPogESLmRhaZgyjwzbIC5airkTSMlkQ9u7aw1h4YS47w9Qa1hIlxxoJZ98lgZx13JhCCXWpPtQPVOHZK466pwkFPYSUA1GRe85NnAyPbFlh7MmaD2AW6FNTInOd/fWuDs3hqC3M3Togc2GlmS/X9gmogFr3r92xkWBbFjrNznv50qtWbc31n7VABq87HlxZeZHGohQPkTqb93HWcNqEg+jOaxM3CDCVW9z9xzybVxDoMSH5M23QLAnnUMKxzVoL1Pfz0NkOJLvpiCUiFrUFhQSvbqXXv0OfZw44rpjmY7DZN80Uhh3cn2azrUcOFYz/xk62tq2YUKZWSbOVuHXG95oAj1MWzYRWWOlywWbiAymxLoZrAThei6Xzxd43y/SB+ZdLROLfkWLXbQayRrLL0lV8QC5DRN1cTAmYWoTuD1sZtgupO6TVuiDF/FVm/tDlqBbkCyYUW5muHVxvFmWeuIL+fVhmf50rkPlN4NK80embgxCDMl7FwpGzZ73gxphNKIOOwATPPOFURWpAVNuTWkK8/jQYwmmOMnRKEFg+Gv8blpiJ3NE+QaxNseoLUgDFZgj37kjgt2HpOimRID5rdhrXfolWpTxwehiEp1hox2D8SClKQ8Yj09tuIiggGW6sESpy90+eSnhSCjjpdFnA1l3mPDlahDliVop+7zjFqFXZV/WlHsKMSEDoVFnAPGk0kR9F56gxBh/ueCh+p0TGBciOPTSDd7otnEyQ+LZK4k8BdbtL2myAWjz6xVFNYqgeJRQo9nwUzDdAONmyeSkaBQSxRpqIFxfkH9VXVwE1kFgeGPL8UY47iDqlqojVQBvIhNp41O4KH+2YaJzp+xMIivPnNmKWit43BQKRkZUx1wa5sbNAoRWVzKU/mzhAxyJg/NWimsCqHqD35HnrRlVsXMy1+e1Jj6CkKRLKDTz9UFAzpuN3sjVQKP/i913hBY53JNv27GdvKoUz66zvP8lYOpm2QVgsTdbo6znmS1w1G4Fq1vFrI3h5UiHUEpbCNvgCEqxgcJo9SIvdErbtLV/SpR1dyqvhZhvIAz5mQHIQnsHfC6V2+eV+08WN3UqNoMw3xj5FXDYur85PriAix1EoMq8iQLul3Zm33Fgic/dQwZtrrrbgH+SXr4cxeOQPZyucEdjY1PRGOhx9g0FlONyAvkvlIqUe22V/UaX2RvVR/xOkMPeqe8ESJSmTdT17pTPsbCww7fYnvQq8/vS9TtYmF/0udh3LtjRyapJ6Y7zLDbm0dnvGFM1DZ5ewRFcJ06/JHzthyIVNebl8JFcLbsQzck7CPGK5FqHvAtqoacSnvaCzc8Nbo/L5tRP0A1Yh+Smyj/QzEnPHVzfmc/3zbwqMRKpAgY6uAOMYy4nxNy6vByeq5i2sUglfDP6Cv1b9o4xB15cmkXGm1NjgCNhaCAEYloqe3+FXSX+EaEpVIJ6jtYu9nLr3g1zXHbKGDjsnOS1L4dOkWhXqfpffLPHPSKiK/Q4MAeMX3uB+AztT5ifc4i0SpEZ81QWdmoiNVkOVMM5n9wel7fuJ1yzQBiTueaLmTJ0hZ0trvpYO4GbbRJwdqAenUm18ImBohN7TL3RhOCvSrA9/bpKaWfY02sXG053J2KmZWmCkHmvDYMsiBzxEvhjhUmc0EXOWBh8GdPAZeqHyYNKOyZtcmEXEYfurNETghhhbfm2nPUcX+uqbp58ZW5mymLjznkURLgv/X+FMOzev+9WQw+lRN4xZxGmHM3nEtXIGGh0XEZSDnQyocBHqexAXNLBvxbPFivRBVWforoeHC+JB3mImKs6NI/GdaFeeZKamOtTYL5W8QsG41dcEsCOAH/zGeTJK4bd9uKUCeKwTNBTofQOChjp9jR7j5VhkDurM2vy4QJRwpICsgp3ssUbOnZ6YsMcojec3iLXWnKerN8nvsSTGqi83FpXsD2oSDPA3/pVWP4EVBHLbBF0sMCrmCXLoKL6s3ye+xJJJ91BXa+36nM5gNV3Q7x9i4npJ+d7XTScQ0AjLqdvATWxEjR/+Q05oYT2LfEl5vGi1yIX3xNcboTMGG0r9CMta0emgkaxaktl2OApttzKmxsiJ5W9pi3Ovg0sL6NzQFggXO5JmkA/e3X9fcMg4D021eiPHCuLSQpYH2kE6qIO6tYbwzF+y2TNunqN8YTkB/8QmkF24XA7mGAe5+a9PPhwPffEBnfwKvLbyDKaKn0UQRlDj/xSnEQ8p8lfgJDto9JceEKVDy99eFCLAhlA002ES5SDO0vCZ5RRW7Un3Rl5iVGLE5pxjUwSDXBqzMbLOE6w2xnYLYl4KnmFmF0fTL81hksbAARK3flVd/+s+QpV+mlYzQdG8/GS3YmTV18xBiSsHKXCQA+uHwvV35oyVtTeqqI3KC5oT5nBA7Ti5Uy2/CgsQZRrOQjRh2hONRhFwTMUKDh1Lw775hJbliAT44dkLyLb6yCOiisTPjqdTZAjzODiqNU7CKAUW52eONK8JuNEXjfvF6eIc3JPl5id781tPHpKAAo0rYkIfS3oKodShXfdoZWr+NVqgpPbTpCPC3oonlt/DcEloIlAf1x+GThiduGCZKvyhyhDOBWZsiB/O4X9Xl2Y8nqFzpTgjJkjopsRCyVxppeCdAB8knQfkRYorKLMl2d4C+uL3/1+ABdNHY/V79L6gI4zbfLhdF6NHFkrjTS+3wIopopgevz/QmK0wKosAnwNc2NN6JIyvVmxmm/f47QGxqlkcQombVCMXBzHajbWL+hOI6gMjjLJahs+m8BY6bXQV9VFT5MDb626HO3gvvf90E/JkhFKPD3e5tTndKqyI6BHHrYASZ9/tgxXj7Y83EzvfYOsi427z36joED/R1Ks7AGfn9P9q2ViDKoqQZGkOjuL7GOApvVjPp2e5eZvtJ9eQ1t3IThsS70E6LbbuQRhwA2CLFBP5W0ax6QxWkeRoHUmAsAP6uQuIHgFSNzk5ZOXHsFmo2aha+LGad+r4ajJDN343FYEp7YtBuMs4UfJFyIIesD5GE3AlFg7AhMJyKxXvT2U1WiWoB1KdJf4mSYt9DSA6u4pvu7KSDK5vfum99U37EYYyXhptf2E2c9Za9Djom4Ios1MoOGoU+ExgaBE5Ej6boAsl6w+xNSQJMSyTPyevW+Z1ij16/chLdxQ4SmkOuyBVjmpw3h0PFyXN01j4STEzECb0CgSiG7e8CYXqHUITURgKwMv1Ox0CucVqGz9BLWQQRM+uLt+Y3pEYkQqqsJ//kydMw4Hg2IMYjTRPl+bJ0+Um7z+EDvrMyaCsQwfaCk++znKlOCXPSstz6CCVrMm8wGv5ahYoIRepr4CAr+pZ6gkXxNXSLfLb0axNjyaRTagHymPD40DLzcz5k8vQ4bojlky3PUVsXGS7hgORFFnvrAncx/gGSAG9JluCWgotu7MWLkSXUXmG3/w88AWxonquoPVF3Me8XM+NcP9p8tgVsBg6z3jcWaJwo8mb0mt3ioACQXKd85nAbnHf5gANhNfsGCwDm5ZmhPCszN82T5M6L6wIHLfo4jMZtUt9rgIdS/K9Kr9zLauA93D0lMm/f11IwXf5pQc+69t9v/c3hHZzRKePp2MRWsiEillvvzqrYafaKc5RfUCsLWz438W3av4TnGW99CqyHLJgbFOkkDXmhuAZIAb0d1DqdyyPdx25WpTbWwIYuMlzwCbGRNjQBsRgPsVdC2bpc9hxsna3PdQiwMES3Dt8WrxQteDHKR8lS37bZs6s8Ew74YFluk55lBHvEFELu0WGVAHRrjDd/3zC+lxhV2gBuY+MraO5+Tcxq8giCPThW4HJPx2Bazw4y16pt6w2QklY3BLvgHZvPR6BpRQIkpYS7zQKSnK/Iqw0FstKuTOH7s4DNxyFwAdg8kqvNHCOPYZJjzgoHJbj9x9eDd1bRMx6jnFXi6nOylxMtSqoRCC9MHE9MzChZlAIgJrswS7/ZGiWWfjiMvwFckl74KCcnxH7rZfU5C7sGFp2UXbDUF96xTbTV2HXwJk5ZLRM8zbBXCiXwJbS5TQsgo+8q8kMzL7rC5OYlfECTuaDYzyaCqaEndrivTne5W3YdiIMvYZATaiE+86cF3QfPubt+OQcJarzdqZXPiVpAa70EpN9HmfNneiubOJkXvrotIP5NvMPBQr1j+SblWdtLmwGUXu+yHKGQA7rwbdDeeCJmUb3nszJzNEg4FJ327vGxeJJEiCurGX1z5U9/vm+ausLsxs4O8d+u8ehEWW0gXRB46tvtX/bXMOfj7WtWhSpCBYokxbBSqdPKzHneCrXOlP56OQ44OSvVLG2eD4R7qH0WbZ4U0sG4EfKldAYBw0iLDFXWS0Wt7NUKIq3O4yjhePPSPl5uQHY4q7ABLZ1eEILvAxzJrGtNa0R14W51vaVTI7lEo8r/0JXPZ+vxirKHYkQvxut7tYRjjH/Khg+ZsVrHLHj2BiucAy21xgJQ7Z8kve4WP/jJXdZBCbfIrE9YXLYE5Uatu/7dowgzVyVKsWTUnm8rXvF7E1419UCjZTAMtTKhh7UELtYincCN94GXMwJuZTGj/C5rtk0uN4EcP0NMI3dzedjUvyKQJijPh/v198qLf2IzstivnyR/82lPHNqKiHNEugWXaa2HLyz+4tkP5JUu5PW3Rom+W/RoAhL0UbXzoGHsHCp/GTIXqGRHnC75OLKD/KfJ44vaV/LYUC+R5VWBqbx3cuFRlJUCpmjEtxPVYq0AipSDtVWqPAoCPZC1v2CGfD1Co7SHjeQtKg2sohyyoXWbPtojm0OdtsmiEMS59D7UAFiRUi0kdI9CXQ4655EbZxYFGPn87BI5l+kIkSYqdqEr4EE//PG7tNp1oYlrtcCWfyEI7QWX7CFeICdPAAEkUq1V+Dt2hW7F1U7NY9HjRlSTNQicHrMqpqB0BQwmD8DLBKhEV5ybfYOgGdofaUMARJvnNGaR9937jm964Uz0WzkC5HTQ/uO/rlLBitL8owJMRBKAQkMoMx2qRvpF9EDUiA3gh6b5gHBT/tqoT0qs1PvXRxOggFzEdR1GjsElNzUPqVgyp5fDbHSOrpp3WlJxYS/s3DIeersrURCKDBnQH3pZ3yXYMStjefCFWXe/Fn4H+xGnbC82EI9EaQ43mXCW4F2GmwkDN3c4g6myjhT7RFXgrTxuX3m3HE79Q+nbAc+TXlTJX3GzXRqOaMjyPxXtzA5EKzQlpVU1sELc7rP9+rnhmwSIVVV/sIY06f1yf2699hrk8jx40IKoVFphhgYpAAABiMZo2JmYOFSai+c46eBK/hve3Nt+GGWHCAsFwToogzA0BhZ3hoTBrL5Yo2gQbq6V8b7wWU1ADk5i/zGe8uh50Oa39q9VRaYRz/T5zHRmGxATNXeAwkOVC+ez8HvtHJd7/7cU/04I2g1t7U8U3X8MiOcMad/OFKelVtLMeUo9yTabo3vT7ZjUNcGqN4TkYw80n62CSodhuOGVK3Ts/N1TUO607eYW/qGwKv0KKarIUgzDQALU4Pb33MUYrYYMrnyWw1g7H9g2sdgv4l/7KiD/Nq0zONA70gcDlhD0WgaucSnuRJp/zFgt/WFzYBn86lU/Ycq4krvPqj0lRdoYyW1Hn4gLCSTaLS4KVHCF8MsKiCL/JOKZURD23YwqbpcAySp3wOa7KLDzjxjd8yv/5sWLVP9DVbSGD/N+uyM7x9UAVnNdo0UJC5yrNMFW6jybo3u+jqZ6I5UfVxQ2GjSnwMyZuN1qHuPIVSgfh4TgS32eb6rVjLKHiGUJJk8C0Hg0hk45mb5NA0Tt9lh54emCWZx48/L9NKGwfz0bxXOziG607FTd7W56IiP29oXewuBFFIRBzxeUNtGxu0ytsEdy8YE5uynPwOkPkhUqcByKWJwBp5PG04B1KoBL4jaDsGTDFtYADaDBxqeIOoXu+9lg0pD9T4TeA1sQgfDvAgN5ML4ryqo0aiGpIjAjqjFz/ZrEz2CpHBdEB5Oer4xPc/qr0vOwnaU3DK77aQGCDbzuIjb+YYkG1ILdM3bv4z3Jvux0sM1GPVB9mhWthKfrB5bk/WBQ5JlDtXUwEka5uXyqcFD9JIel7Ue02snsQuqVWC2cFpzViYlvH6uKe9+UMvp/kuoWvgaxHYO8WuC98mGNAnIrhBWuYo95XA0DCwbESYdZ1Jle4irwab8AHsIhepvG7Jr8JwzRO4/y/ePUv+gI0WhIyJDKYnL4cdfwtI8CpQCLUcDJZVfweAZypOVGVbGEwLFPjWwtVIzhv82NC9qAY27ZA/V4hS8c8+xIw/letRxw/3Nq5iO8MyiylesUWZ3/Nm9jhzXGuk0qquxcRindCdz4sFM17A2ZHQQANCjTmvs5CBJqKquyeVdJnNMwmXjQrfZoAYV1anpgG6a3I7mUb/DPvGhZWX0N8jmHSsOw44HaQk56TmMlBdzddFQ13H7eYEHYxj4JRRY9ChHzJu/lIoATAwc8y/zTXhSU3fmMRsEqmS9LLpG6ZGQNtzZ2xxZCjxhwc1otpef/M8VGePI1JP8DRlimOCYfrind7HoupFtNQW/C4/sGHZoJgZRzeDSJKKH0t67F5mOBo5qlHTT28y8G8znMwrmmB42+nR1RXs4ISjJ9J0Gk8gkKETymOUuyvsObMdh2m0FDaoVpZZAbIcSNmQTx14OeXfRUVbOLAwdeMQSFzQHcpOo69dicwS6muaRjbfkf+uQrITumOHjKeQ8VCyOmoB3sCVPdUz/lXnVvXVaSS5cyvT6AO/MuIDvrLdOvh0DRARaEQ63MD1yEvzMMxVEPFdLyhQOACdpnDJjYb+/ghDvdW7bDRdVJYL/NJD7UI26/MKrSrcEPqT7qyzjcurqMB9GYAHRV+7uXlgfOtSkEyqKIBWMKakVpAt66ku1Y1hBWdwl4Dkwxf43mFRamQqe44BfL/NV7Yh/JhwVEZDyYYgpZFQVQPoVYwfApdAgG6V92dx5K4VniZOXDpNGLdjRGfyT7uTbNMQyLWeWo5jZR2eW+++Lk267c56JhUxuMMXTpZyclbPr9KRJsfnxtCL/swOg0dJiKwR5PIRozGKumHmh20SYSwDA8N/vRJdIbqmzvKs7LORUQhjw8CetqDGDz1LT2GcGP2SDdi3HE2MHuOu2B0OIcqB7+y0B/pBf2rE8fpM+uCHddtacd3SrxbcKR5hEbhr1sfzMi7xCxb8rxX/gNKbQ47s+o6YtQaWgxgQA33hyrN0kF2Ra9t+vBAdehw3TGB0J0U73t1xD9kJ+M2TZg5xHyfFKXyyFTGID+fHkAP2ko9gjNJzRXmJKMTt8PPRH5WMC0MXJzT/tL1o1XgZPd9Mw3qVfXrj3A9WwxgyTPx1Ym1e/RJAMeXy1y9CkDcaYOfF5f19NS74QD8ofJw4guDuEEhs1H2BLFBCv2q+ykNE02h4SMIBju/ihI6c5bwTsTZNpdDfmIimJ+PEdwiOXJtaAFmjUM/A2BmzwAnXMNkbBWkVVNW3KhftE+V5801QxwEXfdfLP+4SgwzXEIj9lBzGpV69lJ8KALcC4TwfSrOp4FtAk2j/HLRZtS4A5nXyXDfunITEcnKX0YlLjVFuKOdMKN9/19v9/PeJtEGVPDTbRBZ+Fmt4iPKdjXX5Kf/ox2fdyfLNJvX2elY9nrU6bBNovbxFqvDhAJO/hLRQi0mEE3GSfwFGzXdFBUvZB4phLDRGFsZ5JVtZDdmgFcZ8coMpM9dN/R5FnGZHZBa2BJS0QKRrYWyPHKY0sTv714rgPAvzinq/ndEKB0pzQ9q0/Fev8EFD439ezMyy3jRgJ0SoWWFZLF3FWC5rbaFbOvb4NClS7PV8SJeX+tr7iHTo/KgWcv9ggti1HwvvAobLdxRYUpxL+EXFXuzSvWK817bspTO1kEX08hoWiLEgFpmmdJNH6lYtmbIIX8w18Xso0WOq9iwH1dESShAlLSQsvZ2SUFb+IgcbSIgwew/1xTwY7VvF964KsV8hRpg/psgbESZNy/pIa5T6nIbIUf8ldt8cDlyCcgsKnAQhj+DSDVxdhayN0ISRXMKScWsGTo4YRPIbW7iskdS55fmREe4M2AWzsa3jqhJ4YPZa/3q+0NKchEDiW3A5hPWxSlINpWJSPOIrdiS6d5NwVxcnB1imZ00RrSnDiVlsLiUF0UcVHP0lt0u9T2qEJCF9dmt+mJlv2LQsbHKAUx7pgy0gqQAE/4Ki17FHlytydwLV8/sEZZKr69qeZ5HI9BM2CS6UFKyQs2j+Bpf3XZOQdFl/Va6Ob3tOHLMy7q7istjGkqOzkHCTjHNEmxFdLYtw4b7VO2m7T1iwat/LBms41IsNGefDsuHZVeC2c/MalW1V5G46Zwc7eOi9CoTWo1ugpmuQYq+KBXywIDeTPxhLrjJKIvKKfhtxQVAb4ZDL/i9JK3jBSRKDCpmLUvQ5ZoPE/rc1w5DE5ojSF3xbQtNCCB5r+aRJIyfR2YXytIBLTMfYhgwataxa5gIRCqQspthfAxi82n901l6udwuvHFlV1YHFn703+VBKR+I99xKj5Fm/OFzfLAwSr/428p+zYuPKltU06Oy07oTWWlr2+VZYwEvXRIXyrYWixyacKKGOjNJEIX+QGTtoHVXrvllNOl8FnoldiAALX9qYD0KqNEZXfIOcfVhLtTJXa7OgBbLDqhzBxaBRxri1FnLoxzYvGYWJOicR0jj1vVir9R1gdtZOksWE6QdJLTaKMkvW5BwCAbEngQMrmIgHfy212Xs1sFMB3Rr5fRnweQLKrKMEQhEHAMPm/yoxsobnsKLID7HBre63+LWfKjoRs52k2t4tsPhj5Kbjs4cT9QT3pLobMw7Gokc7XBd11vJ8NK/aHCUoLHx5YaJstdBrupI/IQdnc40jQai5zpis4plcgmv0MatZKul3/0xnnLxd38LSaIRx7PUP4kQyRHpHDlcVlRvIEcK39Mvx3nw8PqZmoOgMDxgJ1IpfLwaQXOWEKViSA3n/q9p5YDWsVLBmFpLvIjzOKek+LNWpZw9UK8XhpoGTRuSZ3XpvWxYRvlV1oh0q0zgJv+FBIUHu8eCD6tdnWAnQULwaCIwA234MmTiCPqtwj6OzGZ9VTDj9ombLB6dludF8gd8RHpZtHm70Ub0Mr58tEm35iv3tLH+14jMXtlm8IFlASmcb77gU/WDVnBXsq+zzEKujsS+Tw+tUSfgWa/crKRnc8A8h7UXK6eguJgDZaRzM+kbSxz7D9WeqEWU16lCZzvB7+6GaXjHhQTC9TYCOyoW2fuhsXNvSfHKcGgQBWJyy3V9vBqGLkXRpHqnpyfddwH9gC3FY8czNLkZ+8h/DFVR07DVwxLgmwncvNbumkWZxmeh2YNjylhj1tRi0ep+oZ1Qd0jhIpv6elxjYxxRlj/l7AgGIxmJ/EFsxp2ValCsx2LAnN+LjNy57gDC8kbnyy4J7L5CiuK26dTX9mIbUjQMIavaJLgT5tsxDY4ENIjDtdDamgRH17Kd8xwgzhE5NG9N9PNnUuDnVCZybhufA0BfBG+D8GRpCJpUFE7JNxdCSwnWUzjSw08iyRfUTSErxIiBR1zrPy2hyBq6HdKUDuhLuC+Dn8E2qjHfIU48tFa+AYL6AOY+uPlUJIVm4Eq6bMTfQkIsbnDnCZppcjHChfuRA1OeSlwiaB4cd6ABHfziWtgRrEZjf/0oOo6rprP8FSSLCChGfIrHcW3E6QSG2Conp7BuHY6j6fYKf/vn+QguHpOD0pU8pIgWqdFOPBoH30ar0NVbEBuPj+O8p3CuGh6M+YPns0BhlQxrjGzYGRagGHH8z0xVyJNCZV+ENuwLD3takSY+FWcFmYokwiEpCIx+x2ivVciTNnyEAK7jOK+Rq/XEZgqiHGQ+sXU0a/kaRJh877X9MjkBqg5kUGyrz2TuyS+RXsWx0oYJEsU0L7+EXt+ITJpE56retNk2oB60Q+jAvzN6gQmnhGL4Dr+v4kojYGlzyuwRwcHduZedg3ktvejbDum8avlaASmOhQE9waTDi5k7oO/wE7gTWSkHoj2THI9UW4rmnEh4/aEd+FpBXlal8gkIKgdhZAAw5RhUjzDeYZww4jbx7fWwpbgoC6SFNSZD9WaQej4sMg0DLfygNNPlm7wMu661tpfUyhvd8nvaF+NihHCNQpLU+/0hjse3MwuBcFKgrptQEDt/Uy6/De5qWh6oiuZsBMqRkrOg0d5s7RVU5WCb67CBjYpmhiWbld3KqjD2cMO8vMJifcuDJNU+g7fHsCdBnhFxYcFYPhL/aLg6N115JYVncD4zReSaJOz/mfZcP5c7QeF0Kp4+vjo0mNsrI0sWGq0lyo+LYIkCLmXtw8nXEuOUDYPe3fBvKIVe2kPoWhCgO4xHkmXnpc0V5IAKzXk/7Ces2jSYAOIPdfL8VnFdIk3ZsmL+tbRpErC7tHwBptzigAUazcgB2HkRMrT+BmlQUCOCRx2ibz4EBxQpie3upnE+Lj0+gUrRsMTjJQJTEF6kBx8H1lDgbOfc389YNGLNs+N8NBQ/I0XyIbsKRU3+v4gTuQsFCibM8DEJtAg1kRWPhB3HYKgL29MWuMhQiy1+P+o5uMTE1w1sLOBAW3PgzygrGiuxSYsLMRu3xhLCZa9ILm2pvPcgz03Mn9QrcN5QgTdI96pBDXDu5djiE/GhpCtRH7QoVdD+t9IMmoa19feQ23d/simrfDwS+iakadfYBN5kB6q98bl5Qm5k/otzmOuPEEL0lC0t56aURGPiXACb/VFfwKwAewzwc6KS6ehYaFWFmrkgflkNjaM0YWM/Nld00YH/DAcqPP83J28SamMBrJFlEoWPNA0jum1p08k5nMKdNebkiTcaXYjX/Uksfk3FXqow7NVIKwlAHBdz8ul+eW5jWxlFLv0lJTkNadfeH2aboj/TzMO27aqWdx/l++uqAbDgifGqb0/jO2SL7jK3wBQtrQVFErNyH7radAZw8FW/o4LK2jJFPyj/nj19kSK8jGjWiuNslIKa2uKHR4PlZ9o8wRcpzxgm5lUlUOLt8VtASriXUgXMU9YFmhZufqjlN7PDX7eQz3zKGjKmMYSwL0vYoZSpBurXyungPY1m9ec4dPzPHWsu3FfQn/pFNlMYDWPAdo/HkyyK12web7+kf/d1PM/+FavAT50EMb6ftMDpTnwuuMSfdKBE5Md/hthwuZC508JlBDEzzWOlZKaJL3sqOYxFpnADSL4aMoFzy18BZOtLb8C3ZVgHpC5dsbeyXT8zgsDLGwU4PHPsWW93A0/G8u5aPddBdqfDT/W2vPXB3MsDWb5zYskWVbfd0XBURTszxGgkJzK+sW/dxPkZZ+vCseDuOgXSNyGg71Fcofj5moygYA91TazR1EUv/axMAzoCrqmV9acVST8xnxmN1nEfIMJctkYdlBoOkjMWsfAJList+LS0EpNW23DcXCuYQlPFR2z/Pm5Xtxw4Qz1aYKMDO6uJTNTB3mTGczNOcr5DJwJUN5iGLMmbK0+eV8faESgt+Fx/YMO80gXKXnl/Sg4X6nHjgVjmmTVbeEQru9kYnZsB9OzSk5EkrfBOq1iyhRM23fJH1LBtgZN+HfHiVQ9reml7XlFCb6OsTIDenNfJwGjM9hoQ98NUh9uvrThKRkO1C5JG6YDFWBaxkr0PIdNI4ZbptU2JwuxIMefiE5ihs3TTgCCombBroq5NQaX75Zt7yhk/GzeSaUvtyXxMwzGW+fW3jMnWU1Ep0YLLqjM3bXCBSbDkHbysII9Wk4HLapGTbjH6w9B/TMx1wBcvLkeoIAahbsM/m0cEq28hsakrqzUZGaCJa7gMOPb3l/uIUiE0Bey6BT1z91iMr4guMnvkjEvOMhJnQeHWgtdAXuEIuo9CkgkKnH9E3FhoKLy7KD7UscphUvGJnDCx4n8iyZ/OmPhnoaQPELUs1ch4+uPjzJcLoySvqR1c6KiT6TKmNwT5lFWo5q9bEOPxUZ1c5FxLj+Eg8ngF8OU9zvEVpXsWW3OU8yLF14YmZDXiI7+RhG5HqnMf/lvSXIQn5j0n+t39/6iHyCa/9qrQ/7mQVN32DG20gAAZYN5ML4ryqo0aiGpIjAjqjFz/ZrEz2CpL+K5BhgZIxplJEJNezzCskcdmrACxmI45gcY31tkAsuUtEJBOo0KN49d7nN5e1+sIPyVSs16L88nBq2LiG52ORkKM0IG8iC7IJ468HIVXO+qZt8rDAFvWfzgaslWrdWmKNRq5dDxJ0G4bRHJtyCBY7cu6HPgXMFSC4gatftdSSY96YMqaUXPhqTVN0xHELR4hvMrEzbAe/hbqDgzOi+D8u6OjnNaoo4W6pa/OrD9/c5aG375LYug+q1AUVbEayG3B8jBdg19N1b1unOFmSYr+MIqU0LStuJ+ANZE78jJhtc/49W4AZczqTYXjwO2aVfexkPbyaiz5GgHZ8jFV5ZIKSMNbidUmATxOWFe8Au43b+pQEZWwOlHfpz2ENOPwfgaigSgMt9xYgXDgnQ/F/IENUCXzs2nWGh7g5YpOolyhFpfD4ouFH2rifoBZ0aTg4BSrIEktTGyRspjyhR1imNyT+o4CpmCKjfODAGlNRhuOk8IFMXK9rfnpH3DKuD4hewkdoo9HrEYd2vBpVPKalzMYziJ/pkXjLzwqtsxiQV4CNjYarEHe5SU+PWQnTzMwTR/NR7kQRYCewYPRrWs1xQsn0sRGnKbcIAxaC1phBVyCNc8aReSMxQVlVqdhpNyxLuT3lzk9v6BTFGrF3flP7UlZTb+HqmRLJl40K30W3L4wE0jimi86OMXaboXiOu4nchCfnks4oaFWhbJJzCgARwcak8PdHXtCejBXk1CAy5YvnOg8u5YGXUj7Sz9J7+Gq3k7KP131hWisfLKATpey85sWCYnXT+2I3Sxl9mr7QqWoJjyBExYsivscMYv8ejtBb6RqrjwzGxyPA3r+dzWnXQFx2VD4uDXD6lT5gLSQ1rFt8THetj+ZjwKTcsfQ5SYtby6kAA56keU0Mnup8MH+iAIVjwf5PY6OVNzlrOheGX8P9sgGIsNuaGX2Fmr+/fbAC79lYktpV0fnqtXvbwImMlH8u66w0f5CiWgJoDNGgwV0tBhKEiYgw+9jbL4DA0bMuFkrxOnXR8iGXUaQLIbLvPwqfhBsGDvK25c/Q3sFiOyyUaOllzITYJX88ipOkViBIen8JbdJ39e+kjiaWr5S+q+DqHzsgHX2iqT8k3VHWf70aUW5fE9hFubOqK0l4YMDng8EG6fqeaOE7fMUHEJa4Uidg36fW/RlrbQWJKHAl7yMhcNurZ3IzUVu/QpPITEQB7mW0pqFPss4bPlfLhAIx1/T4C+yNH52bxkyqobfXgMWT70cMTzqy2FGBQcEnT/RaimjsK5q3Itx2ZizUuTTAgh1FX/S/HYHohNU9OMO9mpxK+F+Bxm3lHvICFY6AUt/7AV03BcGlSenrmPmULfVV1lrmy8lBONh2hromkSWNEBBGLhZt81hmSumzbyxfd73PvVaDNV4GReSCaJcxLg+vTkVtlO8RzynR+YRkrN0QLw/STAp+JQInR6MQwQKwgWfxvDlgol8j/6uD1mTZ2CXgmuAa/n0QgA90k/alzL/d7DY8wgQkE3qBF9HpkAwMDlhl/t/53Ue+vav/fDe+U9AiGtxHbt8G2yYZBLAc/Tw9pVlZc1v6MhzrX/+4MUg7gpidMvwvKYfsAqOQNvOtJHnAqX7vNUhaznVdAWvBpIxvykjXC+1mwUkpKqcOh3JbEkl3NFWEbs9AfqqNKRj5AAiriwnxdq1QI18L1oBgYPX7+pV1JEDYxgQRopTh9wBgYZADgsA1+/00fh8MrWE01rxl9ZQtgB7fgGeN1YRqA83d6drTwKCp8e4/1oX9+8irEHXezQtgE//R/6dM0dtCFaCUHxAVDZ/HBo4LdLsnfCuMPcX6K41K5hcyfUaui/MStMJD/yb7ycMBh6I/vmC6mFElOviV76G1yInS6u/iQUJYGmXFXuzKywu0j3AfumvilxpABbr+k4IEVG6Lt3Ip0lh0rncl5s7VMItyMOxirGnFq6aY6hXmVOih6D7wUTgkRuTLavvlCYGy58Ebyqj0mlI6hwG0nr/wdvdRH2m/lHDXKfVJv1hzosTPkgGjyv7Coz5ddU2eG0ypi5BE5W2OTisPFcwk+BYn4lUkvBTRxR0rFhy7B5scv8BFRxSEeUIzvCRa+mEx0tzihyFltNUjEMwZbAevSdIXQ3vJS0r9lG1o8B8/+ONmCEZxV6wE831KOePailN+tsTgxwWM536l3woMLVd3UN+MOmfPd/jtpPILnJbQzqNK8pxAkr42Hz3v7l9vyhEOQqZ4EasFwlrfrOS0T81jypTsvggJMidogNYc4NU/77dPjkfWiLo9GBItL4mOIJnY6ASXKRzj7H98pxpGKO2AJ/LK6QwHHYpc0ZQMJmuOxNksfh+kRLdzXkGF+wsoVq4YiivWLlnTMfkQ+XRkmp3B0SXbf5i9ZQPRWwGHkVp+QkCkwgrTrOFnMHGm6zPYedMJ+oCuIoFLbJiyeaOfRJuzoZid63RfgGzSXoAQXfpRf+YKO2OBwlrfrOS0kbnnG3VADuA+fBl09N8bacYyzLW0hU3bdNTD7xdGmCx1jIj/uts9CN/7XuWpPDBeMCE3HPUnXcdmjq2J5n2GCRoXoWwHqHKPe03KPowjwhrc+yhFe83k7hWEOS2/sVIb7H5RppggHZE/gG1fVOdofRNeICldT6IabMLS3/Pawf4tIDc5f8CsKn7GY2JYsy9HxIg6YbKkazKxEJIBfJP2+QeHzb4HuPZ84i2myJts8Xny+2NHFnBiOmTixcLet5aZSJimJwcGmqYGO/42Lu3zOJX8NGXGEuuMj/WAk3VDtd1VlLcA/zM560bTrhzUgjzlnndB3w3+MkGznkqmXEyV67/ygyGySpDXApoRCi3U+7Cp5LM6G3+f9kGx3RKn9VGKfrPbvNfqZUbvmfKo7aoAijAgrZ408yJTz+ZeONo9lLr7EQz4vg2d/tldmXIZSk/L2ZQWsIukBAP7ffWAVUrb3LjlWBO0LtrYfJRsXp0qvM7RrgOn7/tAvFlRMADs7Nx2GnHP8MSM6PlDIq+sreG5byRFfZCy7agAADyRVxgAAAHC+sVRGoTDMZEUexZTQallC+qy/KE/3brdi1IzH9mbAWPIiBOv0+9BisodDv3YF95gy+kEA/wjZLvurMv2agpuKqkRWYap40p0zP/3CmX1RRdZyUJGUgid617vDLLeXDiI5gi9/No7nocyd6L8S+gSpYpjOiYZFgdcNvmpHY9mkdSwKtgOmoJ67+OaP+vF/JYJPDNhyDrtnadJBGqNHmfuSNbTqAPWR5Ff5sdpnMlKUBClDx/K7yNtgxfbrwTV+szcHdFHR8NUloAxKvlKV/2Spexr5ol0qBORLXdOwsTZsK+RMmEaQHACnX3Dz/htXFIH9PjVUoNmkG+kTJLl4L6QZhk073u7I1omIpFPJo9N9h7yPK0a0sEEA5w1RKgRcZ6L7cDbWAdhzvS2QK5LDXnb8bKbxj6Uzh9Pma/6ugHZ61n/stv6W+WxdMdi/krv3gz7Xn720+qMiFbMvDAwvuVKWVMN6nEUvRDvBTMy2/aEnb+SQMnD4KTyIHXRVjQgLlvr12yEsvbhdBI2FJCsdQ+HZE6gYk3IRp67KAOXr2wf4Eu+39LHy/WPHTp1WQbeb4AX1ZkcvHQso2MR2emcHEqP14xUz1rQ1Ku8hcycSojQ+2bAn1B/Mbu/Yp2lUJL7h7VwBsK5Mk6JrRcQi6gEiFwK7aSJ1fdWeS+GruTHf1UuFMwXd4Nj0hTetglCD34ECxgWPqrvoBc3Gfs4gz4dYiLOiaVbK6qaI+pKlcBj5xOqeTfQmFEOc6JdgYTviimA7/jBeA/l/V90tmAcewZnlTVJUza9GEgB/qn9UOoACi+YKIvyEJY9lx7yVQ6zN7u5Uqw3ND1/QAYLEjsmGvmxcZVNHAlMVmcTu+F4SS9Hj/vsnuEmx+3E2/tGfytscGKH+6QgzyfoWtaBbpfnWNACJTiNswrvLN6cwaPH/W9ElbcgpZia2HOInCgI5D/DLegUlVJ7c85hUzEEGzlEbo2U8W+LybhnIlN1qVXmyVN98AF3w4R9N4DrOYB3+x1rkcEt8OvEJsb0FuQGgeY7yzaYvEhJ2uVTyzCF0yT0PvYB7FDW8y3/Zs6FoELjt6KBEZm/3RanEwqHB6adkIh94salQttK5EmmDzclx81AFQsBcCfnNhJefafgH995GVj3ntlj1LGHQ+pwMWqTqNP5SflZ8PJrcE0gBL2ysouZl1l9M+0fThxlx8eLZB6mYOFR3qBiDnHNtipx+pjG2sAVgp/f3PLu78u0nLx0XWAMX0uCpSbZIZ3K/AjxczqjXbyFyfIrfLKoaw48jlaCwFvTv/X7Nb2IGlkJwUkXjbAlHN4rDXQmOB8e3ZUjb382EbQ9mgZFKOaOsYEZQ8cLzujXxQUg69U0Uu2HULgBdJegB6e6dBGjLrEKawqwWk8KcGJE23/b31W0oApG370VIP47mG8ymGC8l4vMDvk2DikVM1YMCA55BIxCyosRBAuaQRFRJsdCp9FpBteX1PpRV+QTKumzgYWrpJejOjMNYrrHRHpUEvg00MiHUe3YdasCRUQAAAAAAAAAdHEG06jXHALWHxibKIsv0kKUVx/Zc3Tqd/BL+CX8Ev4JfwS/gl/BL+CX5vyQT6Xeh4FC/jwMQPcqwzYTdHEv44iwzszAb2H7kRAPcopAAA7cY4W85V3cpjS2eq5gX071o3iXtF/HptO/GIowcYo+pWe7YWBMM++x9RBF5r2Sr8LL2UL8jL2Tr8jL1aED6xq+/5rX5HXsghUqRuAkx7aHCUoEIHxTqLR7UVFanKTauNu0gvn5V27yEki+UdyWDChmKGpEB3MFFyRTlh6GUzsNbNNyei9U+n0yetfRx2Cab2TR4OVrJpvcSGAwEsE2tF8nvhpLIlUA8RQ8vCotbTgn8fozLm43bx1k5PRSCg9bEuv4njnHdOMl6fJxAEAq3CpJiGmTHNRhmMrMwDjwNsk0hXB7omVsJ2q9Qa5AyJxSDUr20s8SZmRbAv1Ynm441r1TCLIPfUU0B6LIDTka9R9gvenJRsFoC/wUMx/keg2FCYzYdeQlUuvVGspdfaWLbtMXLYr6Ls0htUibFm31/RJlDx/a6v94q+q9Qut/2PRUXro+BNaN0AKCAxhDaeG9NSb2yg41UCW8l3gnLheVuJH50dR61W0PfTskUUIBc1feDnGIYJm5wU40jgyMjOD/nxbEKDtVuVb6XV2zocCdSXxWQAJX+DO8BSmVHokcFJg45BbJMF0WQ2EvUIlCxdEP2viM1/NuZ/1bxI1Wr8lpHzp3U8IMknQquG70lgPMgsIYCd9+4HklGWr9wkx9Ewh27oIE8wGigA0DNJ9rFIw89VIFZdflzbnJnwjERDjjG4+k6L812bbtJnbOvgq0fzCehLgqeyGK5u365e9vBzh9FknldfwfSdIW5y2e1kLQG6bYSd715qmJkQnAWGbCCn6vQK8VafxQbiBoJljRxJUMBKWMdUIrJLpSP5G/0/g0UkNjt6r2wXTl8K+96r9xZenH/qxbFxcBzbk9a5REVrB/REYfPYCCOmkM/7nu+DfFVStxoF28M2epgEt01Dh6rnrjJ1qteKbBeFNUs4WA/kUWNWuci7tsyzNmVcNCGONmCglVTqNRBDkZ4ySHKxdLc7y+A+P6hZH3Y+Mp0ILFXVFQkI8GlTLF9h9xwikFiLceULd1JmTLe6qUAZJSQBbco7iLTSVZIQec+nSsVQg1UsZpjAuveFfYMxd6peB9Xpb0CKFMaXjA8OGISlso3zjsDQTleHBtn2Gzaogl0YEyUUCSy4YtlUW0nZQZ6OynA1oF/YS6Y3VQFNe3MvYrzF+7UaEc9cy9nKerSEUnGSNpj1mrLjXuzMcjNxBCLMXo3K7M2k1ZHOHeNRVcKYErd69ayN2gDbnpDjPxBTbHdPIWUhV69rWoshFXYt8D+W0EzCX/u3klQFK7uekjNnrUIgFYl1WqBrLfQbdKZ+4B58AQ2yiniUiwzOXvfdHtDcKbDu4cFg7MpM01DmqOz0pFMdpRLxjdY2QP7MrrrJ1CYFYfSkrFEl2wc+t70eaq2qu2ZxYYxFFnlH7bfl5fnU7Zc0GYlAw64YUdaYVkMZJNbhehLOV82FIBVJSOJ1EsOP7iLyFEX6pPLxNQPotTJ7KC00zEW+FeMyYw+wZM04MDqcEerpEuOPKIyFGu3EyAMF4wPTLTWBULojm9cox46s2RqGNsmUjUO4DwIE6sd+o7Vmmv7fJv2OPUSg6L3CMH3tAEryIHI1vvsE2RYRKUHvnDHVydSmUNN6MOMDVE/vwa39Soq4vBSk3miRJHpPSUEVeWOalBPcDnWsbC1UWRxAZVPszio3E/dNj/pCVsIJPV1uwmy/xED5qilnMweVpbLeb4bBaw8HuPch5mKXeP6SDhRkuPqIHoK0SvEsrTDS2e2WPcqs18oGY1ManEDblVtkBm5s9RM1zeG2q+udLDA2Kvh7PTwI8LOpSeQrYDaGbdPSZnLETPsdCkLX+JRCSBuhnhkuAKYJfyVglcqtZjBq158VDaOOxWukmed4vmxe1hJvF/QrBcJaELNobShI65URxn+SqV269UGWA01ICbauUQA92Oazj+vesCz8xXUwr5SXSLw+O/jPYQrCe635NUuEp3QtGwcCXaM74bBLKFt/PtGVWmsMWdu8PT7DRie8rERR5v50QwkZGexbaDskIFbxE+eEPQKLfMXkQjzR1XolRwxk757EBL3qXmPDtROPY6lcZlkHjHcij3KzQaeBM13IIGXQoZbw8og/QGwGwrpIQy7MRg1+5A4gxPUxiL1iOzJdNSRFwDmKm/0ix4EfZmKutpiBGMowx69UJWsrY8PVefvxXvC+tSbubTF4LKvIEz1nbpE4bu9YxTMun3hSwv0ZKjMMkfTGqJASPKiZRMDOp3FJWezGmtQLdOAO2bKM7h/Nb5LNYOoKrTgl1j3aAWnV+v1WS6f74CRHFs/afVWPRDJFCSuMismSMUPHdtBCiBUPUjScorzmBboVlgJTxMDI4Hthf3eOPdUgglBmOHvYuroc8WyHIg+EJabkDmys5ktVcGK7RHzmy+nMP1WLpkhtoUbFXuoxeqHrB9WOHurYthExXO1h9b9AZO9Cvvxum+hYPu6Wtq3K/JgoxRdkRyL7ysbAldfA7Lmah1+UJ9DCfZkcYLsE0PFseLC/rOBnoNIQ0LFo7rfM9/BUuMDok1sPX5HikJkSzsswLL5N1ROBh6mPJ6NvZc1KDdpvqM9U6jG8rP2b6bShBgJtjL2TL8jL0t+aYP3PYqF6kbDQEwC2wdxoH93eZ55wc8cz3MvmYkQDTU613F3siXNWVGKyrqrb3bKs/C/ar0XISdys09ez3oPTfFzITNMqx+or9n37KX5yV9MutxKWbzWCo7GiDVVJwJfA3jz601WPznu+Xq4em7Vb3OaVlWlqSelGDiufknXOF1XAQJN37WC+/9xN9f2rNT1am/YvnwQI9vqC0LIuTOUoI8zAuw0aHUIMuIFokaDMvW0/gBDLCf8LHdzCkbPiysvER28AzT323pBc+Rchh7dTKN514n/YEktCcXe6pmWrv7VUc1UIbCb5OS7JE5pX7H0O9FtrfeHTAFevF9BOv0cXfGi0yk6nCSFATs8HMC8WsiNSw1Kxnr9RVmSWy273jUIDfdcsg7tSA28BjevI9YLIRwHbKOB52hZAIRMwI88mYMBUQzFUYIuF7MtLFyRDmY/099lqoJTVmcl3jTV1vFkM1hDMys4JcISCMSjvXZJTRPS2H1lgCJQK/GgAHCFTo338aNndmN2/z7ZwC9oq1VfkZexcCbFR7wMK93KHWtMrFIlrW8GkvjkFrvAZpHJvn0S0Su6/n37HTjH1xrr/ODA3f+BAxePGLA5V7CuUxE4IAkb/VASf7lI3eu2GnchDJp8xD6rs4cFfPuWCcEai8O8QTMjI8tfiiVs6hn3dX597eUm6eWYnT97nXv+yJIPFx81za+qk/l+hxtuTFGF2oRvM5iUwNu/jEGL2GkKkbnb0UeMiFfmgvZ1dX4chYZ5MeLgvCHDKvBvW5mGC2QZdlRnU3BCq+VkO2LB1HWpN/UgFKv4CUBAz+yZM4xCqrbfhr5mQK/3etHFX6hHgjJOejosS95EPjvzr3kSUHEuMvzvm3e6gLE7i6qWFbRGqhCidfgTajJmpU04xIK5tC15U12FybggMr28NigUavdwyDSJhhGw7oA7J3LMhXfmZic/miQUwJz+PK1c/VHIkumPxRQvl+u4ft359KH3wR4ZCVXPIljDB9xnauDy7mn/WfGbPlvPZ9PDkr7M97Z/yV5ffdT9cn98ZDjEoy0yaKeS/koaVARVEHTYe/+gnvOBbAR2i+lsCX9tFzx98k9E/B/S+7Nrx0KkH2mGvVZThEWsBtjPxyY0l9FC8cLaAa+ChlFi3DOMzxj3VpXtJWB9d2naTf1wCizWxtUcAu3F0CpXr/bzIQ1Wq+kO0OxZsobT6lIylgIY6cKUbQFA8OUFNXS373b6cBsylu9epMPCcTWXp77UKQqSp1HeqAH40WoEghMYhqaKQG3+SSRzJo2F2+HSOvFkzG57YIa7OVRQftUrL8D564QHhSNljVj36oT2JRbFJrz2MOOwVz7seXd6v6y0VsxCEXVH0SyRfHQJ4mpe+//hw8RFWYfTJW3j0dKef6FTZI1wuJxglJOeJk0D4DWJbioJs4IcGvKrvOk3enBatCXuR79zbi7tnPuZr32bju/YyeQz1B9PAGMYHcu/LUFfKGSDWK9NF/Cp+TMx5f/n2qy3MUpNgo+opgesY4z+o/9djT52Lr0Uw4wPXtuNS9hmf9s6Yb6wk0AAC+8UQyvDp/EGBJ4eI8zoqrn9Pxq7XsqzQuPZm3OpQGTPuPrbvNq5hmvZz8bWHkSyR1h8TIfQUSTlcSH6F38Cg1+ze+5rRjePJ2w1klXzCuWQykLfFGXnvjw03iLSyK1J8Oy0wCiN4gvbRo6WpWLp8J7eVu/+pNt3R+Vv7GxMF6y/J33LqS3eYHlGzZqxYjC6fsaydK1KX0xvGDe6UNEpyQb6ncWwZ93qT92aP8eZx8Zu9V9nx5ozdByx4tussnGrXlg3q7v9HJoLHYXBCSq14Y8PTuI9BrZKF1DIbv48tz2ZcFm+4SHjmPQjiGJQiK9cOh/ZL/XDqOoTKxXll5PtLj6T0yeUsWl2uc3vrNHTojLWNKAHczHx6L4Z0V566fsqmLstOvUA3k7ZFkJVvo4VDnCyUe53iZ9ChTQl5Eaq+Rrw9R46MV0oHGrS+2KTnxkh7pEC4I7Ueuf5APD+EOkeQkjWuT6tDBOFZJo3NkEXWz6S6/nsJIudLTRDMmMoJoqm17OVR8UTLGLEa5bk44xuuwrEgAAx3wKB3KRTsqzQ/aXiI/rBaZKiR+eS8L8qcxlgMOuaaSngN1jU46rkCWoPvVtzrGkREJgewSBvSWcCx06doKPtSSiiDw3p2TFsImDwPSrH93s8c05o69XxMNan74cGRDvAvaeHI2s0XCGgslnHxP2oftR8By6VwbvQGe+CHoJjhAyXiVymGHkGK9+xMsDTpmlMjwX53NexxBeg17d38WXx0wII1xhQ1/kTPhLD+SKw5YYcPOicP7IKuUHpuH740Yv9545+hV3KHdiA/0BgLp62VjICQpeo7Ekq4zv5bHEC67OX1usBlHQh3qbDo11kE3wilRPw1YpvK9iJUuXgPByZ/VN7NAhLitF/KORQxuVXQOztnquXl9jTlaI3df0M1J6e10L1oZ6tIQ421izmtl/T7zl/DBpc0/IBvahgHcAps2Uf0XZdQ72UH6g+YeT9+n1MU4Lsw/7WLOEl1NC8Wrr+OHd40hOsHiHrPPVr4svIYJqyL4TDs7prdUSgX9iwnikz7H5tt4nndUkwalTwhRq3CM9/bF+eC0zG+9xKHHT49RGtwfI8RR1NMtGyvNZOoHKGdJSOg+spy/NlQt+qys1cM3bHqW2oRY8xRsuZTQkWro82GmHkfEQZucQRHG8cxPV4r4erJgbyQtWCERNR0n2bKacvMoIB3igPu+HyK4F3ND40Bo7Znyyov/qjA5wvs9XUMrPtiZI4XGE12WUNKy49EGecL1Ubby7Oy99PPX55vfwrYPowxEDM1WegfKIKVYBO0ulrkaUTdYr9IVo4vZKvyOvU71vks1gcE2q92VRBj6p1m3te9OsdmAcRFltn/Vo5AzxJH3s9VmD5/xKuauLH6ySk3SWRR1ca1QkdxX0Rewg/u1ABIUt2XJEdL0kvvDz6E2TCxs92fokxQuVnE/3Hgk6HsTTw/X8AqJ1sMH+78pLTmDdeIuiVE7ZOVJxerQgfVS99/2ni7sozq/I69kGaJnaqOibAbdcuMW/qDKDxiU6IN8P8vqEchoZxAxM8LrpfT4ff7jppJPBRcogv+V+QKwhC/bR7irNGbd8fRC8nVg4GOwsuYCrIS/DF+lNSw4PBnlVBOmbRJJr8cbBDNxCPFsQgNzf94l1UcdZcrrgoIflCnbMUilElMkhCn4b65qLyyefv/SPh0aHImGsPB2BLocGZ2X2BXzgKrkXWDz7ZdltOvGp3uyp+S5oAparpwTXfUWHGl8aX04YRXqGjCC0DqMh5sIAczKdoXaiuSjJaD9O76uD78VB+EF9NoAg0Qm3wmXMA9ZD4hyxD4tMYa7bOkabTmfyopwh1DcElceH62T2T+nHoCOFNeRurnzcIKVCAVAqB9zh7gy39dtAuLFj85vOfC9nyEeCI7Q8eF490xf4cL4k/jUzZheyyPRaXdO0AnlM0VD9VIbCZCsVQgeNE9K3dyR9RZ414yJQhW8k6TpdbIeEyS+Wms/hv5M1O6rvWcTzGw34VJhOmJt8NzkRj7Tnas6pMXxRdIOPjUR6vgzNMo9XPz7L+n+OBeh6CFj1+mrBYqWinKApranyY0rvJHXYH9aHoGndpW+6AZwPlWI0ymBRQBT5DuxWMWyM6Hyt5g8RkGH3uX+4oaJhK1mD66POEcHyhlFjNHHishsJeyZfkZeydfkZeydfkde16/Iq9ky/Iy9jiyGqInwjuGej0jYKZEAUsIjHBdQf7GLmsvVzaVfboxR8M1MRD0A7fJKG5s5n1D5l8WmDJ3ETuIncRO4ic4sJyMjIEzqD/KZtiU3v3X4j0AodcCf5YePKQbqD5uBVZpmaxw6l8g8ac4J8ulplKYCMOQ+/Z/8uQTv/1XHM2Nq09m32XhCobuZ9wVX5AcjiEDhRm+k5ErHfz3uobrsyhlctKqKi4u6r/uDvtSDrIqx8pbkRF7SO3ZNIE6speV+Lzh8XEAOwBwVWOf9kXQihjWOevNbv6dR/8ziPwueUWcUliInOpvRGycybeuSOXkn1qFDHuixhvB9U4DsDRTx+kuVElhskRlwiTFrei3UaeY0X9ulxwPJgi85QeiQrqQjlxzRTDnG3Gk97O662Kt1pB7bRywaxnFm1nc0W4JGhtDcnrhAyqkHaeJ/IyhujArr4Qkk1w6VMrRrOHsiVpaTvDd5PoL03HOILmK6AqtPy3YeYRIWzy+4xJp8B+CO9ZOHXo5/KwnC8nYMJldHl0nx72AJxLt+WhLwHIVoKWcU+JYxb+akVOECHhrVng6tSJzgWreh7juOmt0GPlsGEdN3Q0TlShkPMKpgi0+aCg4QTuzwcltj5OXv1YONoj7tfPWRxBs8tfFqGUGgMMxYtoq8NP93EM+mCM38ICq5uRHRKXNpKfsaYLxfT82xLYXtC0CbH2Uc/8Ri3r/VUuTUKplPQHeXEFqMzIUUEtJoKfc5bW/FHVNxxbNPQGsKnuREW9Vbzoi2r6XrE+/Twi7041nDzrF1ZVHgRZ57ZSTCjrxBOnBiPMr1xCFZnnRhuP0Hwrd5GdkUiZiTM1mVayaqiPhMLdgMY29YmKGnsClU1yGVcviORpMVvjU3q+cmhRNF5LpMoaTF+Yks1kquyykaxS4+zd5T+mWMMHijePvW8Adml4yEjCauW2YmoG2dAH7b4GDFcxSkIQQRmbqe0icYlj+mljj3xSVRseSF0BJ7KKr0Lu5eAfRV5V0j3S5O4C7CvOtWewcJLXg/OxP1wKotCJ5HFoCmV7YO7SZUc7k9AgvN3j2//qJlBn7+SWJPfvGPzZ/hXp5AiQRmUAAl6r8XFhmS8bWhgdIYYEpTFTsdn9D83o9NedEwxUPdJgS21EG3IJic4BjbE6lVLZ/gq2lqDsYKNAI5HIz4HdwqOc+Ds6UHPhY3OonkUjLqF2XHoUdndO/8YeXVBdPswDj4oQoZcLk9zFhlIVlFIdMEBxUOWTqfOVFYogb5JV5HXHEXEzxyegaDvJrNoPlnZaASMWOvXWTpmmZ0PHNRMa9BV7lPVFoPjgxAtkGMSygbVxgKOAiHApzpP+SqkcsYHa6HM029kmzc7hRqURW4AcSoCTGC3ILa3Dabb2j1BKYal7pR8dTzvu87KFe7bgD0yl1NOq/Em1T1KF0zM4jSSsR0h/4hDJ9sVQzDxVuflj8bXj3z0/zpvtMvsNOmmpmuEcLRZlJ/+MLhHjdcYjv/soS7z5PgWhSZ2Nx80aX9liqAGRds53k/WKnvce578Q7+X2poyW8iS70JoFwDYG3vftEnrc964R1D7iJTWaiuv+I2PeBIUs+2MrxpDo2YGjZ6Vv2npuUqqv8KqvSewauwsqKq+H/AL2KMhR/YeG2Mu7IG9oeUh5SHfxbPrfwS/l9HBAdNHzn4n4YZ0Rbm7hwUYM/UJAQDcquAf0j8oACaKMRxnuOIytzZqYsNv6NNeqMHSVpku8Xi2XKAKus/MymVwm4TyNuK4VuXBOzyHMNuLCuqgFsZl7L9qvdHT5X36CXynZngdmsMbyXo1lteemjt+C1Mkb9ExB8rUR/fUWPacgZwo+VsFLGNbZc/uW2LyQQyPWOSknBRoCQiAnxn6HuScTzWhGsul0ul0ul0udbDQSHCEp8SG4pf9yuJTVWmxwKXhCuh6aBDo2cJSCgAMBQMSIfA7HjErNifCAAAAAGxSC2iqZpGv3a7gtjhtOivsQA8WljguxO7Ety6VjLhNakKvHaM+5LBMevwG25wpHBYho8FH9ThDmM1iCn46hoDKSAFZSX8HMIU1zY2s28WnnG+46Ornr+gO1tbtvMV6R8xm4eQfmBh5BFYU+sj+mIrLTigbk1jOt44hCuda38pIsxVYqVbfvqqVqjCpGypZJ+TFk/JdhUuJRzokCy/w04vaV7Hj0lmvOE2iScJdfpyQGHHIn3a5/TL7qURjGsC1T2Vx6yc6l2GYCCKL9UKcv9N/UuxS743tRD99dCMIiSX+JA8T13VRqgOu6uRP/rp42cZF/Swx34hFQExgSVr5VBhyV42QIr2+K9r0A8aGSgjUD05vkB69YYoMUehsZknrYBmOKj5T39804BPhGvFJSZ6Ol+AtG95TLmD7pt+24h4FyWFZMi27lCgN5zlcO9/JCjSbpHSKNYF4iEDzGq2zXiC+AT/YP/xfx9mTJbkxiLgVDqpH5esDV5ptfsVPUNciC+WqXkkIYl9TSkWMFUIRPlFl/6FAKi06evb1qea9XTcT+oY/DrDD+WRjRJ5bxqYxWs63e/tSUbgR5UlhnDlRDArHTkovkdY1M4LCHOf4dQd/MS2trpn0+vtdPWDhuNs6/m2GJcbugze91lnp6mY0JTyrM2eO24LY8XxlgQseoIv3oM5y/jYy4IVRxFRC4QOCrKhEuG8KdujeKVtob8Z8BQfqCg+iyT0rdJJr9lwIfiUhdAABpXtifcdnVIKFFqn+rwJecTQQT/tSpioHgaSoeBd7pc6OT+PL0Tty02cN9gqnX4+EXFI/c1O1KfTWNbkvwxpmJUCUknWG5iC4RSHM4F/KU4JwJiHOV+7oHqvoAf6cE4P40HqQr2nf/H8cpYOBAw48ldUPVGuuv8oNB4/n7ibl4/p5Qj0PdCJY7IC+BgasB4u68baooCUijmBSrEPe86mO99IPgwuZ6tZZ1U7ZgQqCbruLDzt6DFuk0ISvW+C7yxBdc8k8QXbU8uaH1UfgegAVbp+l3ByYCLDB3vb3+AeqJimup2MVEu7fSEYxrwsruPc4s6Yf7BH/XGVFpwOAa9KavUWj6V8+ZVlFbZ66yJHQbryNJ9UM1bDmsnOy3vYz4URoxRmDIN9Si365crMjsQ3XRrJwP+q/wD1O4nJ2uogWLeiuDPTu+uVGZWFrSaKxMv6/K5MEMoSKoKcahjF57u+iurnnMSGCw5ReX9cHiRStrroCU8MBbcXBMIxs9GIo03VzwIaOcXi3UDJyM0iNrPJ8IhIQww5DgdTwk4U/3Nwadq2iR+u1NM4z2yXqLweH92T0aiG3TADl2z9qT/lyQFrJ8uFHjNOQmMCaOQWqpuFTom97ac6hxYtQDaPNAl66pWPJc8jePBuz8z5C3Kd7NVkM1E4598bTZDcG3IHGBjH2m6kbpQ+IBmgTW8T+F+aoKjcXf5xO03M4VSdC4ntLMsf0ayrQmiCCRMVtgqiSV70CdiFwQM1qbL32Lvh45dmV2bRotXVxMPmCwpq/+FVhpBYNtzbWNojADpKTUPIGBwPPZ5t+BJ5it/LnuyEdbLrLmmK1gx8trgAr20ap9giVIlM5S5GFq/RwLua7kMI0ql6LOVyD4AAAAAajPGhroksXPXqVfF5EsluyHgROaLA7VzEwH2nwQon5MPU01MHJdj83NN0wkfQPY4lhqjZ9sH22+2+DhifRrlvrnAJWKIG+ZLW3nzCJhLdu+UI/Pfpn7phy1wePFaq0qrwQ1RNgBppvjH1+CuZIB4IgnjAiV/DAO5DbQzSd50v83bKQcAQTNJ3nWCv6oyUty6m+sg6DGvJTP+y6EPLHeAAF6aAJI+82aNgYEX6tePj7V3cmx/0/ShhJTYhRb1BXAR6fBVoBssF4vUm68LMAtZkE69y8zPhUuR08AgizGLLlpF2NQMa/4zgp4r6KtRkdPN2VRe0lP7JcNIanxrwNZosyppPXuADWAIk4KXZIj68GEx0vwEwwA5dFG9tZhw24i2pGcuGkH7uVNK5E5JFlEqthZ85ZTLEa3ulToutHvKW6tivCuBtXk8p6bGbP9HK1iUaJ0ycs6xOoSb4+Ef+4xH+/tgYFA70Ku57izOJQLsj/s/SlMYJrgkohKsemlb25S/Zdtqwzycgz465J45Y9rfobwhK1D8vRS1Fuag033gJYtjdC0GkrXA2rnD2Zi/5RVJkLXqpBpcQvEnBY2unYQoQiFX5XI6bwUcKH36y2qLD1Zy6KFRouO1s5WsY1/xiwRJie5O0t5j22Cx/IhmkrsK2UPgRpEVAMUGNrSLtuAAwAUSwy9pP8YZeLv4KkynYt/olxUmidRrzhkVR7zU8Qy8LAT+cmqJfy1DypfCkp9Z7ZK/MZqnMV90cB9h00xxJixhkTQSHxDp3IE7Gv8ZL+zyhZ0Me/TbNm2sLQuorqQqrEB27eKQ5JnYybyp+h5E30JzrN0WAV6e+aJKMsNoOPyiuxKDdnG7cttHAgedjFZlkPLOQNvr6Jq5yO7H8lvCW0VMTyjljBbsXSfEN3kW+WuIM187VV0n84xg8rnjB9CUDdxsbdl3ZDO110K8wbgHXq0x4CUbNm2sLQuorqQqQeDOTIzpH3Ix2qA6YdwqZJ74DGoAAAAAeSoEXmGugOPOLZNjeq8OG2OhMSX2pyegj1/wAHAEgy6vsrA4kp48oYJy59yy2tc1m/cDzxHRB+cxWKgs0tsgbRqrbIWvQ5fCAqPVgWyf6EKSdhOxJ4ZYJxCWXVGdpYpxOv/Irf5BV5t3pF2fvz9BSarajyehzhgkV8F3K5zDkAQeewySmWJpA+uKyLkH2csDKPgK5JgqXQ/cLoogRbD9jyieZVMwcY+YInblrGguUwqi1VxlTfnK+z7rhOEWhCn3hTeBZnYOC1j4mFAdS+AnX/IVCS52ZqeYTQBtq4Jv1aAdWEJQuBgmS0ehwUdTYllaemJBJu2GyoFjqFaZExK6e2oHLq8foF8fojgHuiHSn+4/9FSLOIX925qV6ZstjxfikhqCAgkPg6IppcijP6hEJMiUBjndc28Jt+xPu/GMtkRF5lxrfuPoCUlfuFS2+wB7cajct7YBgTmApli9GwWL7F42zNkFdTs4hDBqxQs/uBKKZS1zEpB4KZ1i47sfw3omHf+dcYPGm6Juq2ETxaPM6QpIwCRZ/FfhoGguLoIoaAUxkjfKQE1B0II0xiBy6QRE46xTH9tDb7rOut4G1FhZEVtSEDVyY3t6YnjBKJL2bpkOl1W6xZjb53tlm+IfD/2YsM3LZQxzF5RagwXk4sKYHmxTEhx+hP39DjOA55hCepibHXbKoN04wWDsFMpSbDs15k9w7D9DdVt8qZkup11CmStDYOxSLCA1z7+3f2Gomol/U68QIFpijvAIAor1PfYYlX/1x3guAGbCpSpa606DM+0fVM+tj5W9hLkzuY35XaLPoZNiiWgVhvjN9eCPw19b6LClFvsTvy+81I9vUUu4jzBYS3n1bUhPOXtF/sRuZ9pMe4JfNg/ggCANnBdGg4CPb7HYRLwnrs/cwuec9FnnXnGLEm6SNp0g2ddH7q+oTySxNA7OowISPQ1tmgkTgd0FzO6DrJhKi7cUu/Bv2o4EDyGf3uUQD9clEYzC4NAmK7UdSh/oj8Au69hJkHtnG1sDAFBL30XrKd4gUClUhfggPGbBX4ygX4PYn/f6E8xdlaDJRfYcxoDsqmwZE2NJwce/04UenSq0sm8xEzxkHVgLBH2vW8AVxQjCYcJ0a81Uw6SLwM+B7Pew19RUKqxCKFh4VvAgrQuo6YRyZ+3/549HS36Jjg9cpYQdR+Sh6gVrQPjxAkJLl8DJWSKpd3lojRNSJBpCnq8ICsdIxq+jEsCQqhENEVmUgviApcIJ/6GkKerwnMlqFkhsJ7l7029FMfxUahOZJvse1LPK0jUVzvTB0ufNPtULzSG2m7cAMjetiqcFpBd9GYF6dTZiXnzUgkcACbMCCMdlYemb40ADCGhVpsjm5xAACbhV8eFE8o/+J6cEATajpbXOrcFk4M0Zfa7oGHBQlejvrQbMQbNdZ15WwRiHoNnCuDp4tkRBM6UOYQuu2wny2EA/U3Xs1Oj65TSyqoonQ/ZNzw+2J5nwImM7zA+Dnm4cWmkaQjrw/HB+egXXGGXfkr9D4USXzoR1N7+fTSuJySRNm+BTh9aQK/5AJj0Uo0t6RDJFXXGBgjdYLwcK5LmjMCNBHe4A/4P43Mk1r5P82tR7gAC2mKgIpFaQP++TT7TBN1fn2ZaJiLiZh4O+ZXzFgG1WjLtd747CbF4dazp5BLH4uCLV8pMhi2xrVF2SbUEVRJold9yjMomrcQfZBeHcuJOLo6m1QD/UUldixS/ZiuzJxuawyTMp8ZNpUVCiOQkf/ih9ZkXGfTeMY806sY0afoUbsVNHxWYmaiKxoOhioQ0T6w+7QrmNRO3H0Tp5B+DgBDih1QrZMMD/lirThTV6budI6JkjzvpyGUmWiIY+17mStqP3XT2etibc7UdllMmgARH60onK723P24bUkXZrB288df2zEizuGfa6ThyTVeDKBWC9vmA9xkWNFVUeQqH+M7LYkGOOIA+pxftHnwFrAL/cqZzgnaOFspI2bK5RKBARH60o513iCiz5tQ4KLCd83H1fXkn1NdmpqiX6Acc3zm4WKW/V988g2s/bHtwvM4PNrYmL70AiXu+AvgVWEMllWKmd9OQyk00LKAxLkKwCsYpAIiHm7+7QB/AHOU0kRkS0yrFTO+nIZSZH0K86kavswqkR6yjOJiI7X2tWdvFLPUa+jxBGBz9GBFqyPwf1LGUvNRuVOAsrmY36klh0Ya0vaUmmYTx+tl8eGKKUe7Err4uCU7R0Ml5g3ELvkNKzUgy/zWEgWaHm0dbJi0PtYaSYv+94SxIBanXeqtKhgxxTkOZAKSL/PhIBwajqeO6YPz2LJyTPJ2zDL9I3CRVK0EOYGjlPBigTYReks9C0Alo5dwE8TN6Hza11vs9gX0W6u9prYBYJbK5g+WNGRDUhp1iLOokGzp+6pFpHF33PCgVsYnR5/80wAewCpthq06NC7V0or3M6uoLhdFyhK0xkIDk8u1/Hq9fZP9+XYF00irJFLBrMNi1sVwA5LMLdaUxcdu75DbRKIEfMv0DWsUdxFZNV5SyS1IvIxmDMg5UweqJj/E5faqmRORn0/yBB2HSHqkaIjuTtAwT5oTsd15ZNDYo0xC0uViuWgRFA49Qnfgr7oB1IikxzNeq127Nz0bGFVnpv4wy2+ICC28syzkguLvpDzD3P8lOkhFSYyQIq2UL6A0FRX8GsZ+wSMIIOFk/JilceBVen1V6tq5HD98LSebMgFHtF5I3cxmaKsQYrOvRbxK6+K7hxu9RhbSuQVdlDanDHHUqyY7BkDYNGGXDz4lKG9xVGQE36xCteAAAAB4iru0FDgUOfDJUjqj8sYlLIS+0/gOgoLQbPf00p0qOTtepHZZcF12SWruCf1CuOvEMywo6QjnHhYoc1UmRgJlhQ4Qzu8j0cOfsAIJd6ndpgUhbNFcYHseUpD2/l0wJzL5Vl0QmEE/ado1IqKHEJg8JStWRDEc7IebLRn4YuEM05ndLOKVAamiOG1CJdwsZNnkb49XurJTSqq/XrkWiMdgZTY4CcZB7L3I0IYNQllsWWYkns8RdYPkK17tMoEWPoFMjCwYvcj+aNmCzZxUgSmWKoriUhae44hlugiNAU1Jfs/TRU1nPwEfSHWFSYgsVVyL+Td+zbsIVlX94lcLd7ebw64C18h9Kql4Ej2fSGMvGcrAGJR2FoLccKty064GnOD1I71vLpmXTwHQM9iE3nBPDkOBPL3pRQWpX+CW9NYPmDaByGHtDAz1kRLkJZwa2HqZxr+upe9b3gj5o7Y2at6PUKrgMPlS5MX+hxLmS4FU1fywtWJ4brZixPBteYxDrVAroiz4WLogxfdOarGfBl33IDRyQQhNLJnU0vOTTEEQaBEAA7gF6T7l97MbVeKJoWl7w1rcZuT2WZqhNIuBBpIfweccOQcbHdDTvK2Ja3Hv5QAv16MJQCAjiEkaFiVjvwvzVvT7/7aCnL80jNFNB1Vd6IGRNPDRR2pkzc02jeXudrZJoT7pnSHgDL4E1ikUqmJuMvsWEVbVLok5S1rfAt7sMQL8/Z7sLrnR4L2GyP4jhO/CgQefqlYf9WNnNKac8Nt8oaplHhLxlQC4uwxrj1C+FA/c85yTsR5fI7mKrLj8CnF/n7jj4X8tAPv688yPhNvMnRPf2SI/g2vJMbjrzO5+CQ7+wNTeU4gvd2CXDaUKPQosVrCSHGQAHzM0q8MaNfleUJ9aTWp91m6jFBWI3B9xzZv3W7cD6M9vjW+EDkiOr41vhA5Ijq+Nb4QNWDW0ybuJBQeLOF0md2b8jGWDyuayyTAC69tRMCGmMW4q7v5Ux4/dAHEVlV7mjdLyjnKi2ycGMPOxiWPw12wyS1bLQHVle34HCUdfjcdOAAAAAAAAAAAAf1v+Oay3p5bkJ67s6wZkMaBrZ32PtCSL6KBtaeBaS5aZ5DKlrgZK83BNPG3HpXbJsY3RFN+gaR2BxALzw25TSSlMY+n8oURF/qlVGOg9WNvpiuLGtyabq6BWqKlFeMQOvnVxr2vH908dp3MBrCnfodwy4RSx9dyD0A+JfYAjJA+SzHrp4Tltp4fOexxytLA5ArCmdFIOzDUvd9OWrkEkMwCqE3ekvfMuW8A2pdmvVyXCs9P+HfG1yyosWE+be1o3Ft65bNmSrYzyR0NzbgR9+1wOdSt0sgQjDYsczNrydiY6mZl4ja1R+ozERsNxtZwzZda7O0IZYvSaqCXFBHH0mGkVNoMxMA46ABT9t7ap5MRU6uj5wsLRTD0Wxl3DUgkko8uWZXjAiZSpXUrDAjz0V+s4EzuAEQTsllxePFqRBh7+FhH28/xspMXtYzOTsAWzkGtL9x5hEHMwhMOCovYgPceJk3gJVxScXG++WqkukzL5sVsD46mmA1gde1tVj9aCEWz/2oOQSHp0dIXUjRa3cHMLJImxYK3Y5AIX0CwvZZjsc7hogsbc6dtWgd2s61YOW4IGoz1LFuWfu1visjhuxpG+KtImL4lKbaXotLuuxBvvkZAs2zrRLsl3EyeF2rQi1GwKfh41xoBa4EVbUHRZ8s53PI3ypZzLIHY4wf1jF18DkoJwBUy+9fq2yfxtImquKdmf3mDvCmq+ew7TBvN94vSVZrPyoMGwSoLyrAxVpAtX1o6kaOGUuORcI51Q1pJ7LQ3shXsednuMri69Q26/LMgNZ1DYy+5jgdZwYECOpOtyZhV26CH3P03j2J7FPryQ0COvSiaA4cdrL/F7mqi6WIyfxtGyTGNAyeHErBefCznlsYP9siCRUz3D7cRLwwDTAGbbjjoid1ln1A/pNb2f8SBqQBacoiaaXBL/wfpAhTXuF3y3Blb+er20iWEEwfX3dib/WAIrH9kRyfH6ineZ+dui+kqOmbXCbI+BCFG78mGKl0OdVng8uUCNcyDGqn/B+EmYx61U/Lnt03GjpMRBEmroi/ONsoL9rn2oK6tMMUUi5O/AnojDJIkkCCEJMYbN8MzCbTIHY/M7umj//eewqwLGnSrEOrcPdGfSHZWLySBBCEjdF1db1OxAITIX14X0hRetW8x7wOrtK2W0aQsJ/wrS8qM/JgaVU2Htmm8CFKcV26MA5PfP6mVHmbM72Q/rZntzTGKKklS73SYtBGb0llK50x+P0uxxlUR1+sBSYX3+twAt/qpiztDXhl6ODBccGTIT8iyX77HymoXUTax8zYmANp5SZZeMzb0rH23+i/VO6Dli16u15Zy0ZksuHYQv+/4nDpGj9BHcCmBmwj/FAAAAAAAAA==",
+        "height": 5842
+      }
+    }
+  },
+  "analysisUTCTimestamp": "2026-05-15T09:30:16.362Z"
+}

--- a/tmp/perf-20260515/psi-fr_jobs_revenue_operations_manager.json
+++ b/tmp/perf-20260515/psi-fr_jobs_revenue_operations_manager.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "code": 500,
+    "message": "Lighthouse returned error: Something went wrong.",
+    "errors": [
+      {
+        "message": "Lighthouse returned error: Something went wrong.",
+        "domain": "lighthouse",
+        "reason": "lighthouseError"
+      }
+    ]
+  }
+}

--- a/tmp/perf-20260515/psi-home.json
+++ b/tmp/perf-20260515/psi-home.json
@@ -1,0 +1,8580 @@
+{
+  "captchaResult": "CAPTCHA_NOT_NEEDED",
+  "kind": "pagespeedonline#result",
+  "id": "https://www.ocobo.co/fr",
+  "loadingExperience": {
+    "initial_url": "https://www.ocobo.co/fr"
+  },
+  "lighthouseResult": {
+    "requestedUrl": "https://www.ocobo.co/",
+    "finalUrl": "https://www.ocobo.co/fr",
+    "mainDocumentUrl": "https://www.ocobo.co/fr",
+    "finalDisplayedUrl": "https://www.ocobo.co/fr",
+    "lighthouseVersion": "13.0.1",
+    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+    "fetchTime": "2026-05-15T09:28:01.261Z",
+    "environment": {
+      "networkUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36",
+      "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+      "benchmarkIndex": 538
+    },
+    "runWarnings": [
+      "The page may not be loading as expected because your test URL (https://www.ocobo.co/) was redirected to https://www.ocobo.co/fr. Try testing the second URL directly."
+    ],
+    "configSettings": {
+      "emulatedFormFactor": "mobile",
+      "formFactor": "mobile",
+      "locale": "en-US",
+      "onlyCategories": [
+        "performance"
+      ],
+      "channel": "lr"
+    },
+    "audits": {
+      "lcp-breakdown-insight": {
+        "id": "lcp-breakdown-insight",
+        "title": "LCP breakdown",
+        "description": "Each [subpart has specific improvement strategies](https://developer.chrome.com/docs/performance/insights/lcp-breakdown). Ideally, most of the LCP time should be spent on loading the resources, not within delays.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "type": "table",
+              "items": [
+                {
+                  "label": "Time to first byte",
+                  "subpart": "timeToFirstByte",
+                  "duration": 1308.633
+                },
+                {
+                  "label": "Element render delay",
+                  "duration": 3089.796,
+                  "subpart": "elementRenderDelay"
+                }
+              ],
+              "headings": [
+                {
+                  "key": "label",
+                  "label": "Subpart",
+                  "valueType": "text"
+                },
+                {
+                  "label": "Duration",
+                  "key": "duration",
+                  "valueType": "ms"
+                }
+              ]
+            },
+            {
+              "snippet": "\u003cp\u003e",
+              "boundingRect": {
+                "width": 401,
+                "height": 83,
+                "bottom": 743,
+                "left": 0,
+                "top": 660,
+                "right": 401
+              },
+              "selector": "body \u003e div#ago-wrapper \u003e div#ago-prompt \u003e p",
+              "path": "1,HTML,1,BODY,12,DIV,0,DIV,1,P",
+              "nodeLabel": "👋 Posez vos questions à l'IA — Ocobot vous explique notre approche, sans pitch …",
+              "type": "node",
+              "lhId": "page-17-P"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "unused-css-rules": {
+        "id": "unused-css-rules",
+        "title": "Reduce unused CSS",
+        "description": "Reduce unused rules from stylesheets and defer CSS not used for above-the-fold content to decrease bytes consumed by network activity. [Learn how to reduce unused CSS](https://developer.chrome.com/docs/lighthouse/performance/unused-css-rules/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsBytes": 0,
+          "items": [],
+          "headings": [],
+          "type": "opportunity",
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "debugData": {
+            "type": "debugdata",
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            }
+          },
+          "overallSavingsMs": 0
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "inp-breakdown-insight": {
+        "id": "inp-breakdown-insight",
+        "title": "INP breakdown",
+        "description": "Start investigating [how to improve INP](https://developer.chrome.com/docs/performance/insights/inp-breakdown) by looking at the longest subpart.",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "network-dependency-tree-insight": {
+        "id": "network-dependency-tree-insight",
+        "title": "Network dependency tree",
+        "description": "[Avoid chaining critical requests](https://developer.chrome.com/docs/performance/insights/network-dependency-tree) by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "value": {
+                "longestChain": {
+                  "duration": 3036
+                },
+                "chains": {
+                  "831A815F3B6C98AAD7BE9053ECB2D01F": {
+                    "url": "https://www.ocobo.co/fr",
+                    "transferSize": 20686,
+                    "navStartToEndTime": 2628,
+                    "children": {
+                      "831A815F3B6C98AAD7BE9053ECB2D01F": {
+                        "children": {
+                          "51.2": {
+                            "isLongest": true,
+                            "children": {
+                              "51.134": {
+                                "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                                "children": {},
+                                "transferSize": 31974,
+                                "navStartToEndTime": 2933
+                              },
+                              "51.139": {
+                                "navStartToEndTime": 3036,
+                                "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                                "transferSize": 39126,
+                                "isLongest": true,
+                                "children": {}
+                              },
+                              "51.137": {
+                                "navStartToEndTime": 2955,
+                                "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                                "children": {},
+                                "transferSize": 38778
+                              }
+                            },
+                            "navStartToEndTime": 2692,
+                            "transferSize": 24571,
+                            "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+                          }
+                        },
+                        "isLongest": true,
+                        "transferSize": 20686,
+                        "url": "https://www.ocobo.co/fr",
+                        "navStartToEndTime": 2628
+                      }
+                    },
+                    "isLongest": true
+                  }
+                },
+                "type": "network-tree"
+              },
+              "type": "list-section"
+            },
+            {
+              "type": "list-section",
+              "value": {
+                "items": [
+                  {
+                    "origin": "https://raw.githubusercontent.com/",
+                    "source": {
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "boundingRect": {
+                        "height": 0,
+                        "bottom": 0,
+                        "left": 0,
+                        "top": 0,
+                        "right": 0,
+                        "width": 0
+                      },
+                      "selector": "head \u003e link",
+                      "path": "1,HTML,0,HEAD,3,LINK",
+                      "nodeLabel": "head \u003e link",
+                      "type": "node",
+                      "lhId": "page-20-LINK"
+                    },
+                    "subItems": {
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ],
+                      "type": "subitems"
+                    }
+                  }
+                ],
+                "headings": [
+                  {
+                    "subItemsHeading": {
+                      "key": "warning"
+                    },
+                    "label": "Origin",
+                    "key": "origin",
+                    "valueType": "text"
+                  },
+                  {
+                    "label": "Source",
+                    "key": "source",
+                    "valueType": "node"
+                  }
+                ],
+                "type": "table"
+              },
+              "title": "Preconnected origins",
+              "description": "[preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints help the browser establish a connection earlier in the page load, saving time when the first request for that origin is made. The following are the origins that the page preconnected to."
+            },
+            {
+              "description": "Add [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints to your most important origins, but try to use no more than 4.",
+              "title": "Preconnect candidates",
+              "value": {
+                "items": [
+                  {
+                    "wastedMs": 305,
+                    "origin": "https://useago.github.io"
+                  }
+                ],
+                "headings": [
+                  {
+                    "label": "Origin",
+                    "key": "origin",
+                    "valueType": "text"
+                  },
+                  {
+                    "valueType": "ms",
+                    "label": "Est LCP savings",
+                    "key": "wastedMs"
+                  }
+                ],
+                "type": "table"
+              },
+              "type": "list-section"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "layout-shifts": {
+        "id": "layout-shifts",
+        "title": "Avoid large layout shifts",
+        "description": "These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "2 layout shifts found",
+        "metricSavings": {
+          "CLS": 0.01
+        },
+        "details": {
+          "headings": [
+            {
+              "subItemsHeading": {
+                "key": "extra"
+              },
+              "label": "Element",
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "label": "Layout shift score",
+              "granularity": 0.001,
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "cause"
+              },
+              "key": "score",
+              "valueType": "numeric"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "type": "url",
+                      "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff"
+                    }
+                  },
+                  {
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "node": {
+                "snippet": "\u003cdiv class=\"flex_1 d_flex ai_center jc_center lg:jc_flex-end\"\u003e",
+                "boundingRect": {
+                  "left": 16,
+                  "top": 720,
+                  "bottom": 1100,
+                  "height": 380,
+                  "right": 396,
+                  "width": 380
+                },
+                "selector": "header.pt_8 \u003e div.mx_auto \u003e div.d_flex \u003e div.flex_1",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,HEADER,0,DIV,0,DIV,1,DIV",
+                "nodeLabel": "header.pt_8 \u003e div.mx_auto \u003e div.d_flex \u003e div.flex_1",
+                "lhId": "page-18-DIV",
+                "type": "node"
+              },
+              "score": 0.009571
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "extra": {
+                      "type": "url",
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                    },
+                    "cause": "Web font loaded"
+                  },
+                  {
+                    "extra": {
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "score": 0
+            }
+          ]
+        }
+      },
+      "render-blocking-insight": {
+        "id": "render-blocking-insight",
+        "title": "Render blocking requests",
+        "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 600 ms",
+        "metricSavings": {
+          "LCP": 600,
+          "FCP": 600
+        },
+        "details": {
+          "items": [
+            {
+              "wastedMs": 152,
+              "totalBytes": 24571,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "valueType": "bytes",
+              "label": "Transfer Size",
+              "key": "totalBytes"
+            },
+            {
+              "valueType": "timespanMs",
+              "key": "wastedMs",
+              "label": "Duration"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "total-blocking-time": {
+        "id": "total-blocking-time",
+        "title": "Total Blocking Time",
+        "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).",
+        "score": 0.32,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "890 ms",
+        "numericValue": 887.5,
+        "numericUnit": "millisecond"
+      },
+      "network-server-latency": {
+        "id": "network-server-latency",
+        "title": "Server Backend Latencies",
+        "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "sortedBy": [
+            "serverResponseTime"
+          ],
+          "items": [
+            {
+              "serverResponseTime": 6,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "origin": "https://js-eu1.hsforms.net",
+              "serverResponseTime": 5
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "origin": "https://js-eu1.hscollectedforms.net",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "origin": "https://fonts.googleapis.com",
+              "serverResponseTime": 1
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "origin": "https://useago.github.io",
+              "serverResponseTime": 0.5
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "origin",
+              "valueType": "text"
+            },
+            {
+              "valueType": "ms",
+              "key": "serverResponseTime",
+              "label": "Time Spent",
+              "granularity": 1
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 6,
+        "numericUnit": "millisecond"
+      },
+      "resource-summary": {
+        "id": "resource-summary",
+        "title": "Resources Summary",
+        "description": "Aggregates all network requests and groups them by type",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "requestCount": 117,
+              "transferSize": 2080423,
+              "label": "Total",
+              "resourceType": "total"
+            },
+            {
+              "transferSize": 974744,
+              "requestCount": 63,
+              "label": "Script",
+              "resourceType": "script"
+            },
+            {
+              "transferSize": 833122,
+              "requestCount": 37,
+              "label": "Image",
+              "resourceType": "image"
+            },
+            {
+              "label": "Font",
+              "resourceType": "font",
+              "transferSize": 212550,
+              "requestCount": 5
+            },
+            {
+              "transferSize": 27829,
+              "requestCount": 3,
+              "label": "Stylesheet",
+              "resourceType": "stylesheet"
+            },
+            {
+              "transferSize": 20686,
+              "requestCount": 1,
+              "label": "Document",
+              "resourceType": "document"
+            },
+            {
+              "label": "Other",
+              "resourceType": "other",
+              "transferSize": 11492,
+              "requestCount": 8
+            },
+            {
+              "transferSize": 0,
+              "requestCount": 0,
+              "label": "Media",
+              "resourceType": "media"
+            },
+            {
+              "transferSize": 1298013,
+              "requestCount": 42,
+              "label": "Third-party",
+              "resourceType": "third-party"
+            }
+          ],
+          "headings": [
+            {
+              "label": "Resource Type",
+              "key": "label",
+              "valueType": "text"
+            },
+            {
+              "label": "Requests",
+              "key": "requestCount",
+              "valueType": "numeric"
+            },
+            {
+              "label": "Transfer Size",
+              "key": "transferSize",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "unminified-javascript": {
+        "id": "unminified-javascript",
+        "title": "Minify JavaScript",
+        "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn how to minify JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unminified-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsBytes": 0,
+          "items": [],
+          "headings": [],
+          "type": "opportunity",
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "overallSavingsMs": 0
+        },
+        "warnings": [],
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "interactive": {
+        "id": "interactive",
+        "title": "Time to Interactive",
+        "description": "Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).",
+        "score": 0.13,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "12.7 s",
+        "numericValue": 12723.911206024808,
+        "numericUnit": "millisecond"
+      },
+      "unused-javascript": {
+        "id": "unused-javascript",
+        "title": "Reduce unused JavaScript",
+        "description": "Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 390 KiB",
+        "metricSavings": {
+          "LCP": 1350,
+          "FCP": 150
+        },
+        "details": {
+          "items": [
+            {
+              "wastedBytes": 112602,
+              "wastedPercent": 57.372344479375059,
+              "totalBytes": 196265,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "wastedBytes": 111354,
+              "totalBytes": 156442,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedPercent": 71.178801376324756
+            },
+            {
+              "wastedBytes": 82854,
+              "totalBytes": 196265,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedPercent": 42.2154629213789
+            },
+            {
+              "wastedBytes": 67725,
+              "totalBytes": 156442,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedPercent": 43.291052829076662
+            },
+            {
+              "wastedBytes": 25095,
+              "wastedPercent": 57.9279818160067,
+              "totalBytes": 43321,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "subItemsHeading": {
+                "key": "source",
+                "valueType": "code"
+              },
+              "valueType": "url"
+            },
+            {
+              "valueType": "bytes",
+              "label": "Transfer Size",
+              "key": "totalBytes",
+              "subItemsHeading": {
+                "key": "sourceBytes"
+              }
+            },
+            {
+              "label": "Est Savings",
+              "key": "wastedBytes",
+              "subItemsHeading": {
+                "key": "sourceWastedBytes"
+              },
+              "valueType": "bytes"
+            }
+          ],
+          "type": "opportunity",
+          "overallSavingsBytes": 399630,
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "debugData": {
+            "metricSavings": {
+              "FCP": 150,
+              "LCP": 1360
+            },
+            "type": "debugdata"
+          },
+          "overallSavingsMs": 1360
+        },
+        "numericValue": 1360,
+        "numericUnit": "millisecond"
+      },
+      "diagnostics": {
+        "id": "diagnostics",
+        "title": "Diagnostics",
+        "description": "Collection of useful page vitals.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "numRequests": 117,
+              "mainDocumentTransferSize": 20686,
+              "numStylesheets": 3,
+              "numTasksOver500ms": 0,
+              "rtt": 0.00060091452607359541,
+              "numTasksOver25ms": 23,
+              "numTasks": 2395,
+              "totalTaskTime": 3737.7760000000026,
+              "numFonts": 5,
+              "throughput": 3217931104.3631124,
+              "numTasksOver100ms": 7,
+              "numScripts": 63,
+              "maxServerLatency": 6,
+              "numTasksOver50ms": 11,
+              "maxRtt": 8.66556,
+              "totalByteWeight": 2080423,
+              "numTasksOver10ms": 51
+            }
+          ],
+          "type": "debugdata"
+        }
+      },
+      "cumulative-layout-shift": {
+        "id": "cumulative-layout-shift",
+        "title": "Cumulative Layout Shift",
+        "description": "Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/articles/cls).",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "0.01",
+        "details": {
+          "items": [
+            {
+              "cumulativeLayoutShiftMainFrame": 0.009571,
+              "newEngineResultDiffered": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 0.009571,
+        "numericUnit": "unitless"
+      },
+      "unsized-images": {
+        "id": "unsized-images",
+        "title": "Image elements do not have explicit `width` and `height`",
+        "description": "Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [
+            {
+              "node": {
+                "nodeLabel": "CybelAngel",
+                "type": "node",
+                "lhId": "1-11-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cy…\" alt=\"CybelAngel\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,9,DIV,0,IMG",
+                "boundingRect": {
+                  "top": 1466,
+                  "left": 1252,
+                  "bottom": 1498,
+                  "height": 32,
+                  "right": 1386,
+                  "width": 134
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png"
+            },
+            {
+              "node": {
+                "boundingRect": {
+                  "width": 134,
+                  "right": 4116,
+                  "bottom": 1498,
+                  "height": 32,
+                  "left": 3982,
+                  "top": 1466
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,25,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cy…\" alt=\"CybelAngel\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "type": "node",
+                "lhId": "1-27-IMG",
+                "nodeLabel": "CybelAngel"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png"
+            },
+            {
+              "node": {
+                "nodeLabel": "CybelAngel",
+                "type": "node",
+                "lhId": "1-43-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cy…\" alt=\"CybelAngel\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "width": 134,
+                  "right": 6846,
+                  "top": 1466,
+                  "left": 6712,
+                  "bottom": 1498,
+                  "height": 32
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,41,DIV,0,IMG"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png"
+            },
+            {
+              "node": {
+                "boundingRect": {
+                  "width": 99,
+                  "height": 32,
+                  "bottom": 1498,
+                  "left": 413,
+                  "top": 1466,
+                  "right": 512
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,4,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/co…\" alt=\"Combo\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "type": "node",
+                "lhId": "1-6-IMG",
+                "nodeLabel": "Combo"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png"
+            },
+            {
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/co…\" alt=\"Combo\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "left": 3143,
+                  "top": 1466,
+                  "bottom": 1498,
+                  "height": 32,
+                  "right": 3241,
+                  "width": 99
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,20,DIV,0,IMG",
+                "nodeLabel": "Combo",
+                "lhId": "1-22-IMG",
+                "type": "node"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png"
+            },
+            {
+              "node": {
+                "boundingRect": {
+                  "width": 99,
+                  "right": 5971,
+                  "height": 32,
+                  "bottom": 1498,
+                  "left": 5872,
+                  "top": 1466
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,36,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/co…\" alt=\"Combo\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "lhId": "1-38-IMG",
+                "type": "node",
+                "nodeLabel": "Combo"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png"
+            },
+            {
+              "node": {
+                "nodeLabel": "Jus Mundi",
+                "lhId": "1-9-IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ju…\" alt=\"Jus Mundi\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "right": 1014,
+                  "height": 32,
+                  "bottom": 1498,
+                  "top": 1466,
+                  "left": 933,
+                  "width": 81
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,7,DIV,0,IMG"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png"
+            },
+            {
+              "node": {
+                "nodeLabel": "Jus Mundi",
+                "lhId": "1-25-IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ju…\" alt=\"Jus Mundi\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "width": 81,
+                  "left": 3663,
+                  "top": 1466,
+                  "bottom": 1498,
+                  "height": 32,
+                  "right": 3744
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,23,DIV,0,IMG"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png"
+            },
+            {
+              "node": {
+                "nodeLabel": "Jus Mundi",
+                "type": "node",
+                "lhId": "1-41-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ju…\" alt=\"Jus Mundi\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "right": 6474,
+                  "bottom": 1498,
+                  "height": 32,
+                  "left": 6393,
+                  "top": 1466,
+                  "width": 81
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,39,DIV,0,IMG"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png"
+            }
+          ],
+          "headings": [
+            {
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "metrics": {
+        "id": "metrics",
+        "title": "Metrics",
+        "description": "Collects all available metrics.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "cumulativeLayoutShift": 0.009571,
+              "timeToFirstByte": 1309,
+              "totalBlockingTime": 888,
+              "observedTimeOriginTs": 21988894653,
+              "observedLargestContentfulPaintTs": 21993293082,
+              "observedSpeedIndexTs": 21992735380,
+              "observedLargestContentfulPaintAllFramesTs": 21993293082,
+              "observedFirstContentfulPaintAllFramesTs": 21991836537,
+              "cumulativeLayoutShiftMainFrame": 0.009571,
+              "observedFirstContentfulPaint": 2942,
+              "observedDomContentLoadedTs": 21992084108,
+              "observedTraceEndTs": 21996569824,
+              "observedDomContentLoaded": 3189,
+              "observedLoad": 5151,
+              "observedSpeedIndex": 3841,
+              "firstContentfulPaint": 4436,
+              "observedFirstPaintTs": 21991836537,
+              "observedNavigationStartTs": 21988894653,
+              "observedFirstVisualChangeTs": 21989258653,
+              "observedTraceEnd": 7675,
+              "maxPotentialFID": 296,
+              "observedLastVisualChangeTs": 21996559653,
+              "observedFirstVisualChange": 364,
+              "observedLargestContentfulPaint": 4398,
+              "observedTimeOrigin": 0,
+              "observedCumulativeLayoutShift": 0.009571,
+              "observedLoadTs": 21994045576,
+              "observedLargestContentfulPaintAllFrames": 4398,
+              "observedFirstPaint": 2942,
+              "speedIndex": 8102,
+              "observedFirstContentfulPaintTs": 21991836537,
+              "largestContentfulPaint": 9246,
+              "observedFirstContentfulPaintAllFrames": 2942,
+              "observedLastVisualChange": 7665,
+              "observedCumulativeLayoutShiftMainFrame": 0.009571,
+              "interactive": 12724,
+              "observedNavigationStart": 0
+            },
+            {
+              "lcpInvalidated": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 12724,
+        "numericUnit": "millisecond"
+      },
+      "main-thread-tasks": {
+        "id": "main-thread-tasks",
+        "title": "Tasks",
+        "description": "Lists the toplevel main thread tasks that executed during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "startTime": 2583.251,
+              "duration": 38.822
+            },
+            {
+              "startTime": 2685.068,
+              "duration": 7.901
+            },
+            {
+              "startTime": 2702.528,
+              "duration": 12.356
+            },
+            {
+              "startTime": 2714.898,
+              "duration": 208.699
+            },
+            {
+              "duration": 13.597,
+              "startTime": 2939.994
+            },
+            {
+              "startTime": 2982.115,
+              "duration": 49.138
+            },
+            {
+              "startTime": 3042.201,
+              "duration": 14.499
+            },
+            {
+              "startTime": 3060.173,
+              "duration": 44.127
+            },
+            {
+              "startTime": 3104.577,
+              "duration": 12.524
+            },
+            {
+              "startTime": 3121.197,
+              "duration": 10.232
+            },
+            {
+              "startTime": 3134.79,
+              "duration": 10.169
+            },
+            {
+              "startTime": 3146.088,
+              "duration": 5.716
+            },
+            {
+              "startTime": 3152.982,
+              "duration": 10.644
+            },
+            {
+              "startTime": 3164.81,
+              "duration": 7.171
+            },
+            {
+              "startTime": 3172.304,
+              "duration": 13.123
+            },
+            {
+              "startTime": 3193.395,
+              "duration": 31.999
+            },
+            {
+              "startTime": 3227.751,
+              "duration": 24.709
+            },
+            {
+              "startTime": 3257.095,
+              "duration": 7.113
+            },
+            {
+              "startTime": 3273.344,
+              "duration": 124.32
+            },
+            {
+              "startTime": 3399.116,
+              "duration": 8.202
+            },
+            {
+              "startTime": 3407.946,
+              "duration": 89.452
+            },
+            {
+              "startTime": 3521.21,
+              "duration": 9.983
+            },
+            {
+              "startTime": 3534.003,
+              "duration": 11.616
+            },
+            {
+              "startTime": 3548.767,
+              "duration": 11.665
+            },
+            {
+              "startTime": 3563.172,
+              "duration": 7.253
+            },
+            {
+              "startTime": 3572.366,
+              "duration": 5.541
+            },
+            {
+              "startTime": 3580.588,
+              "duration": 5.263
+            },
+            {
+              "startTime": 3587.207,
+              "duration": 16.262
+            },
+            {
+              "startTime": 3606.328,
+              "duration": 6.132
+            },
+            {
+              "duration": 5.913,
+              "startTime": 3615.347
+            },
+            {
+              "startTime": 3621.355,
+              "duration": 5.886
+            },
+            {
+              "startTime": 3627.251,
+              "duration": 5.118
+            },
+            {
+              "startTime": 3636.273,
+              "duration": 5.203
+            },
+            {
+              "startTime": 3641.573,
+              "duration": 5.357
+            },
+            {
+              "startTime": 3649.343,
+              "duration": 5.204
+            },
+            {
+              "startTime": 3656.371,
+              "duration": 5.336
+            },
+            {
+              "startTime": 3663.823,
+              "duration": 5.318
+            },
+            {
+              "startTime": 3669.194,
+              "duration": 9.939
+            },
+            {
+              "startTime": 3681.458,
+              "duration": 5.934
+            },
+            {
+              "duration": 5.644,
+              "startTime": 3687.478
+            },
+            {
+              "startTime": 3695.651,
+              "duration": 8.245
+            },
+            {
+              "startTime": 3703.967,
+              "duration": 38.266
+            },
+            {
+              "startTime": 3742.301,
+              "duration": 45.327
+            },
+            {
+              "startTime": 3792.661,
+              "duration": 7.777
+            },
+            {
+              "startTime": 3804.277,
+              "duration": 6.895
+            },
+            {
+              "duration": 6.525,
+              "startTime": 3811.27
+            },
+            {
+              "startTime": 3817.912,
+              "duration": 5.343
+            },
+            {
+              "startTime": 3830.442,
+              "duration": 6.017
+            },
+            {
+              "startTime": 3839.873,
+              "duration": 5.28
+            },
+            {
+              "startTime": 3851.783,
+              "duration": 5.5
+            },
+            {
+              "startTime": 3857.971,
+              "duration": 5.216
+            },
+            {
+              "startTime": 3865.594,
+              "duration": 10.693
+            },
+            {
+              "startTime": 3877.343,
+              "duration": 5.629
+            },
+            {
+              "duration": 7.223,
+              "startTime": 3885.647
+            },
+            {
+              "startTime": 3892.933,
+              "duration": 5.453
+            },
+            {
+              "startTime": 3901.42,
+              "duration": 6.838
+            },
+            {
+              "startTime": 3909.335,
+              "duration": 7.79
+            },
+            {
+              "startTime": 3919.63,
+              "duration": 12.671
+            },
+            {
+              "duration": 6.736,
+              "startTime": 3935.071
+            },
+            {
+              "startTime": 3942.006,
+              "duration": 6.188
+            },
+            {
+              "startTime": 3948.493,
+              "duration": 7.335
+            },
+            {
+              "startTime": 3955.863,
+              "duration": 9.581
+            },
+            {
+              "startTime": 3965.465,
+              "duration": 5.694
+            },
+            {
+              "startTime": 3974.578,
+              "duration": 5.371
+            },
+            {
+              "startTime": 3982.523,
+              "duration": 5.459
+            },
+            {
+              "startTime": 3988.043,
+              "duration": 5.946
+            },
+            {
+              "duration": 5.138,
+              "startTime": 3996.62
+            },
+            {
+              "startTime": 4001.837,
+              "duration": 5.342
+            },
+            {
+              "startTime": 4007.207,
+              "duration": 8.306
+            },
+            {
+              "startTime": 4017.931,
+              "duration": 6.967
+            },
+            {
+              "startTime": 4024.94,
+              "duration": 5.514
+            },
+            {
+              "startTime": 4033.293,
+              "duration": 9.918
+            },
+            {
+              "startTime": 4047.538,
+              "duration": 6.294
+            },
+            {
+              "startTime": 4053.892,
+              "duration": 6.249
+            },
+            {
+              "startTime": 4060.151,
+              "duration": 5.25
+            },
+            {
+              "duration": 9.758,
+              "startTime": 4068.029
+            },
+            {
+              "startTime": 4077.837,
+              "duration": 18.846
+            },
+            {
+              "duration": 37.221,
+              "startTime": 4101.994
+            },
+            {
+              "startTime": 4145.044,
+              "duration": 10.606
+            },
+            {
+              "startTime": 4155.67,
+              "duration": 5.295
+            },
+            {
+              "startTime": 4164.187,
+              "duration": 31.825
+            },
+            {
+              "startTime": 4213.372,
+              "duration": 23.578
+            },
+            {
+              "startTime": 4239.526,
+              "duration": 9.267
+            },
+            {
+              "duration": 23.309,
+              "startTime": 4253.333
+            },
+            {
+              "startTime": 4281.225,
+              "duration": 98.319
+            },
+            {
+              "startTime": 4386.021,
+              "duration": 269.385
+            },
+            {
+              "duration": 5.958,
+              "startTime": 4655.504
+            },
+            {
+              "startTime": 4671.242,
+              "duration": 28.609
+            },
+            {
+              "startTime": 4704.227,
+              "duration": 12.722
+            },
+            {
+              "startTime": 4720.318,
+              "duration": 24.496
+            },
+            {
+              "startTime": 4745.068,
+              "duration": 139.266
+            },
+            {
+              "startTime": 4884.379,
+              "duration": 5.297
+            },
+            {
+              "startTime": 4889.782,
+              "duration": 7.455
+            },
+            {
+              "startTime": 4909.987,
+              "duration": 175.817
+            },
+            {
+              "startTime": 5085.882,
+              "duration": 7.532
+            },
+            {
+              "startTime": 5095.955,
+              "duration": 59.582
+            },
+            {
+              "startTime": 5167.75,
+              "duration": 19.429
+            },
+            {
+              "startTime": 5187.197,
+              "duration": 7.028
+            },
+            {
+              "startTime": 5194.479,
+              "duration": 8.589
+            },
+            {
+              "startTime": 5203.174,
+              "duration": 5.06
+            },
+            {
+              "startTime": 5208.358,
+              "duration": 53.137
+            },
+            {
+              "duration": 32.99,
+              "startTime": 5263.285
+            },
+            {
+              "startTime": 5296.42,
+              "duration": 8.273
+            },
+            {
+              "startTime": 5304.861,
+              "duration": 209.216
+            },
+            {
+              "startTime": 5519.559,
+              "duration": 246.681
+            },
+            {
+              "startTime": 5766.466,
+              "duration": 10.164
+            },
+            {
+              "startTime": 5778.029,
+              "duration": 18.608
+            },
+            {
+              "startTime": 5799.375,
+              "duration": 47.487
+            },
+            {
+              "duration": 33.446,
+              "startTime": 5849.058
+            },
+            {
+              "startTime": 5887.155,
+              "duration": 11.645
+            },
+            {
+              "duration": 10.836,
+              "startTime": 5944.434
+            },
+            {
+              "startTime": 5978.691,
+              "duration": 5.007
+            },
+            {
+              "startTime": 6092.878,
+              "duration": 5.385
+            },
+            {
+              "startTime": 6243.039,
+              "duration": 6.374
+            },
+            {
+              "startTime": 6349.723,
+              "duration": 5.374
+            },
+            {
+              "duration": 5.738,
+              "startTime": 6411.105
+            },
+            {
+              "startTime": 6443.089,
+              "duration": 5.836
+            },
+            {
+              "startTime": 6461.321,
+              "duration": 8.76
+            },
+            {
+              "startTime": 6476.239,
+              "duration": 10.614
+            },
+            {
+              "startTime": 6492.858,
+              "duration": 7.076
+            },
+            {
+              "startTime": 6511.332,
+              "duration": 7.974
+            },
+            {
+              "startTime": 6609.643,
+              "duration": 5.429
+            },
+            {
+              "startTime": 6643.065,
+              "duration": 17.156
+            },
+            {
+              "startTime": 6660.28,
+              "duration": 5.079
+            },
+            {
+              "startTime": 6710.798,
+              "duration": 10.068
+            },
+            {
+              "startTime": 6745.894,
+              "duration": 8.062
+            },
+            {
+              "startTime": 6826.569,
+              "duration": 6.649
+            },
+            {
+              "startTime": 6876.525,
+              "duration": 9.296
+            },
+            {
+              "startTime": 6943.567,
+              "duration": 6.317
+            },
+            {
+              "duration": 5.196,
+              "startTime": 7077.71
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "ms",
+              "granularity": 1,
+              "label": "Start Time",
+              "key": "startTime"
+            },
+            {
+              "granularity": 1,
+              "label": "End Time",
+              "key": "duration",
+              "valueType": "ms"
+            }
+          ]
+        }
+      },
+      "viewport-insight": {
+        "id": "viewport-insight",
+        "title": "Optimize viewport for mobile",
+        "description": "Tap interactions may be [delayed by up to 300 ms](https://developer.chrome.com/docs/performance/insights/viewport) if the viewport is not optimized for mobile.",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "node": {
+                "boundingRect": {
+                  "width": 0,
+                  "height": 0,
+                  "bottom": 0,
+                  "top": 0,
+                  "left": 0,
+                  "right": 0
+                },
+                "selector": "head \u003e meta",
+                "path": "1,HTML,0,HEAD,2,META",
+                "snippet": "\u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\"\u003e",
+                "type": "node",
+                "lhId": "page-21-META",
+                "nodeLabel": "head \u003e meta"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "max-potential-fid": {
+        "id": "max-potential-fid",
+        "title": "Max Potential First Input Delay",
+        "description": "The maximum potential First Input Delay that your users could experience is the duration of the longest task. [Learn more about the Maximum Potential First Input Delay metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-max-potential-fid/).",
+        "score": 0.37,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "300 ms",
+        "numericValue": 296,
+        "numericUnit": "millisecond"
+      },
+      "unminified-css": {
+        "id": "unminified-css",
+        "title": "Minify CSS",
+        "description": "Minifying CSS files can reduce network payload sizes. [Learn how to minify CSS](https://developer.chrome.com/docs/lighthouse/performance/unminified-css/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "overallSavingsMs": 0,
+          "overallSavingsBytes": 0,
+          "items": [],
+          "headings": [],
+          "type": "opportunity",
+          "sortedBy": [
+            "wastedBytes"
+          ]
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "font-display-insight": {
+        "id": "font-display-insight",
+        "title": "Font display",
+        "description": "Consider setting [font-display](https://developer.chrome.com/docs/performance/insights/font-display) to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with [font metric overrides](https://developer.chrome.com/blog/font-fallbacks).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "key": "wastedMs",
+              "label": "Est Savings",
+              "valueType": "ms"
+            }
+          ],
+          "type": "table",
+          "skipSumming": [
+            "wastedMs"
+          ]
+        }
+      },
+      "dom-size-insight": {
+        "id": "dom-size-insight",
+        "title": "Optimize DOM size",
+        "description": "A large DOM can increase the duration of style calculations and layout reflows, impacting page responsiveness. A large DOM will also increase memory usage. [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/performance/insights/dom-size).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "debugData": {
+            "maxDepth": 14,
+            "maxChildren": 63,
+            "type": "debugdata",
+            "totalElements": 883
+          },
+          "items": [
+            {
+              "statistic": "Total elements",
+              "value": {
+                "granularity": 1,
+                "value": 883,
+                "type": "numeric"
+              }
+            },
+            {
+              "statistic": "DOM depth",
+              "node": {
+                "lhId": "page-23-rect",
+                "type": "node",
+                "nodeLabel": "svg.pos_relative \u003e g.anim_float-very-slow \u003e g \u003e rect",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,HEADER,0,DIV,0,DIV,1,DIV,0,DIV,4,svg,0,g,5,g,0,rect",
+                "boundingRect": {
+                  "right": 197,
+                  "bottom": 830,
+                  "height": 4,
+                  "top": 826,
+                  "left": 70,
+                  "width": 127
+                },
+                "selector": "svg.pos_relative \u003e g.anim_float-very-slow \u003e g \u003e rect",
+                "snippet": "\u003crect x=\"0\" y=\"0\" width=\"200\" height=\"6\" rx=\"3\" fill=\"currentColor\"\u003e"
+              },
+              "value": {
+                "granularity": 1,
+                "value": 14,
+                "type": "numeric"
+              }
+            },
+            {
+              "value": {
+                "granularity": 1,
+                "type": "numeric",
+                "value": 63
+              },
+              "node": {
+                "nodeLabel": "body",
+                "type": "node",
+                "lhId": "page-22-BODY",
+                "snippet": "\u003cbody\u003e",
+                "path": "1,HTML,1,BODY",
+                "boundingRect": {
+                  "width": 412,
+                  "right": 412,
+                  "bottom": 13078,
+                  "height": 13078,
+                  "left": 0,
+                  "top": 0
+                },
+                "selector": "body"
+              },
+              "statistic": "Most children"
+            }
+          ],
+          "headings": [
+            {
+              "key": "statistic",
+              "label": "Statistic",
+              "valueType": "text"
+            },
+            {
+              "key": "node",
+              "label": "Element",
+              "valueType": "node"
+            },
+            {
+              "label": "Value",
+              "key": "value",
+              "valueType": "numeric"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 883,
+        "numericUnit": "element"
+      },
+      "final-screenshot": {
+        "id": "final-screenshot",
+        "title": "Final Screenshot",
+        "description": "The last screenshot captured of the pageload.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "timestamp": 21996560324,
+          "timing": 7666,
+          "type": "screenshot",
+          "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAFQQAAEDAwMBBAQLAgsECAUFAAECAwQABREGEiExBxNBURQiYXEIFRYYIzJSgZGToVXSM0JTVFZicpKUsdMkNnTBFzQ1c4KistFDs8Lh8Cc3RIPD/8QAGQEBAQEBAQEAAAAAAAAAAAAAAAECAwQF/8QAMBEBAAIBAQYEBAUFAAAAAAAAAAERAgMEEhMxUZIUU6HhIVKR0QUVQXHSM2GBscH/2gAMAwEAAhEDEQA/APVNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFK+KUEpKlEBIGST0FV5rXGlXrh6C1qK0rl52hpMpBJPl16+ygsVKEgDJPHnVdOuNLJn+hHUVpEvO3uvS0bs+XXr7KCxUoCCAQcg+NRV51Da7KtCbrK9EQvGHnW1Boe9zG0feaCVpVC7a5X/6SX+TDf4MdKkOtL6gqTyCKljq/T1miQI13vluhylMt/RvyEpVykckE8UFnpXXGkMymEPxnW3mXBuQ42oKSoeYI61C3fWOm7PLEW6322RJOcd09JQlQ94J4++gnqV1RJLEyOiREebfYcGUONqCkqHmCOtdtApSlApSlApSlApSlApSlApSlAripaU9SK4PrKRgdTUHcb9aLY+GLjc4UV4p3BDz6UKI88E+ygsCVJV0INfahLXd7fdAtVrnRpYbICyw6F7SemcGphpe9GfGg50pSgUpSg1v24PvLs9jtCXlx4l4urEGW4g7T3KiSpOfDOMVY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvb1rM1dp2DqqxP2u5pV3LmFJWg4W0scpWk+BBqnu6L1nJhG2SteLVbVJ7ta0W9CZKkdCO83dceOM0FEN9uT/YfDgqmulDl4FkVPSrClxu9Kd+fakbc1txGgdKpsfxSLFb/QtmzBZTu6Yzu67vbnNc3tE2R3RI0qYxFpS0GkpB9ZJByFg/a3c586rSdE60RE+Lk6/d+LQnuwo29Bk7OmO9z1x44zQQ3aDKk6E7FDH07eHpZbdTDROUsKWy2pZBG4eKR6oPUVsXT+nLZb9OItzbQkR3mQl9bx7xUjI5Usn6xOa67do2yQtHp0yIiXrT3ZbW296xcyclSj9onnPnWKrT10tllFn0xPTGjbO7RImrVIcjp6YQnjOPDco4oNKx33Y/ZF2oWBLq3rdZpy48Najna33g9TPsx+tbn0TpSzQ9JxGzFjTlS46HJMl5AcVKUpIJUonqDngeAqPHZnAj9ms7SUCS436aCp+Y4netxwqBK1DjOcYo3o7UdpiegaX1S3CtoTtbZlQRIVHHiG1bhx5BWcUFU0/Le0h/0o2qyEqgWdr0yC19YMLW0pakD2AjOKtPZZpKxs6GtslcOLOlXGOmTLlPtpcW+twblZJHIyelTWi9HQ9M2eVELrk+TOcU9OlSACuStXUq9mOAKrsLQWodPochaQ1b6DZypSmokuEmSY+TkhCiQceQOaDo7PmW7B2n6s03axssyGWJzbAOUx3F5Ckp8geuK2hVZ0RpFjS7Mxxct+4XSc530yc/9d5XgMDgJA4AHSrNQKUpQKUpQKUpQKUpQKUpQKUpQY8kesD7KqOpRczcE+gi+Fruxn0EQ9mcn+W9bP6VdHEBacGsZTSwemfdQV/SwnBuR6eLoDkbfT/Rs/8Ah7nj8assYeoffXWhlRPPArJSAkADpQfaUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUrg86hhlx15YQ02kqUpRwEgckmg50qrwe0HSM+YxEhaitj8l9YbaaQ+CpaicAAedWigUqsXvX+lLHcTAu1+gxpgxuaW5yn+1jp99WKJJYmRmpMR1t6O6kLbcbUFJUk9CCOooO2lKUClKUClKUClKUClKUClKUClKUClKUClKUCvI/wAIXV2o7T2pXGJa79dYUVDTJSzHluNoBLaScAHHWvXFeLPhM/8A7vXT/uWP/lJoPS3ZZPmTux61TZsp+RMXDcWp91wqWogq5KjznitM/Bi1Tf712gzI14vdznx021xwNSZS3EhQcbAOFEjOCefbVw+D/wBoVkumn7PopLE34xaiuBxSkJDRAJJwoKz0PlVlmdnWnND6c1JdtJ25yLdPiqS2hwSHXD9TdgBSiOqU/hRHdc+2rRFvvotTtzU48HO6ceaaKmW1Zx6y+mB5jNR957etHWm6y7e+Lk47GdU0pbLKVIUQcZSd3I9teVNBs6ZkX0o1rLnRbZ3SiHIidyu8yMA8HjGegPOKh7umGm6S02tbzkAOqEdbwAWpvPqlQHjjFB69m/CC0bDmPRnm7t3jSyhW2OkjI/8AFUvbu2HTVx1o1puH6U5KcJSHwhPdAhG4gndnjBB46ivGep/94rl/xC/869J6i7JtOad7OZ+orM1NRdWrYp1KzIJAK28LOPcpVBZL58IDRdsnORWVzp5bVtU7GZBbJ9hURn3jis619q2lta2W7Q7VKdan+hPKEaS3sWoBByU9QfuOa8p9nLej3LrIGu3p7UHuT3JiDP0mf42AT06e3rU3pNOj29RoXbZuo/St6xFSY7QSQQQAshWcY6kDpmgrvZpKZhdoWnJUtxLUdmey444o4CUhYJJ+6vTulO3/AE7fdSJtT8STAQ873UeS6oKQsk4Tu8U548+vNeYezSKxO7QtNxZjKH4z1wYQ404nKVpKxkEeIp2jx2YHaHqOPDbQwwxcX0NIbG1KAHDgADoBQbZ7V4fZcjtBuybu9qSNcu+3ykQ0NqaUtQCiUlXIzmojtd1oq1P6etOg7rebZbIlrZV3aJC2twcSHUE7Vcq2rGfbmqX2vurf7Q7m66oqccRHUonxJYbJqwdt0Vhm2dn77TDbbr+noqnXEoALhCEgFR8SAAOfDFBtv4O/aNHkaRujGp7vKclwFqlPS5zpWlLStqUgLUSc5B49vtqef+EFoVqWWUyJ7qAcd8iKdh9vJB/SvNEi4W1HZHDgxlRk3Zy6uOSQlIDqmQ2Nm44yU7irAz1rHsls09J0pMlXGe3HuaFkISZCtxHGNrQaO7394n7qD21Y9ZafvlhevNtukd23MAqedJ291gZO8HBTx51ryf8ACI0XGlKaYTc5SEnHetMAJPtG5QP6VoCE1AgdnuphYtQyZq5DccS4hhKZSlIeThRWVEHk4x7fZWBoBvQrkC6nW790alBI9DEMZB4OfA85x1wKD1XD7XNLXnSl3ultmPFUCOXXo5b2voB4BAJweSOQa8s6X7SdSQtTWmVddSX1+3MS2nJLRmOL3tBYKk7SrByARg9atvYnE0lI1WY8V28ypT0OQhceVFa9HcR3ZJC/WJxkAjjqBWsdFLhNaysS7sGfi5E9gye+SFI7oOJ37geoxnIoPW967d9I2eamLLbuhdUwy+NkdJG11tLif43XasZ9tSWpO1/TenrTY7jPRcDHvDBkRu7ZClBI2/WG4YPrDzryx23y7fO7S7pJsi2V2xbccR1MDDexLDaQEjwAxj7qmu2CbGk6F7NGo77TrjNqUHEoUCUH6MYPlyk/hQb1c+EBo5EBmYpu69y86tpP+zpzlAQT/G/rp/Wknt/0ezaGJ6E3FwPPrZDIaSHBtSklRG7AT64A55OfKvJkr/dK2f8AGyv/AER63T2A9lumtbaMlXK+tSlym5y2Elp8oG0IbI4HtUaDcupO1/SGnmYxnz1qkvtIeEVlsuOoSpIUNwHCTgjgmunSvbRozUk9qDGnuRZbpCW25bRb3k9AFcpz7M14+cjML1q9FvC1NRxMW08pbhQUAKIwVbVEYxjO048qmJ1m0k3qBbKNSKhw07Slxhlc0JPjhe1sn+7Qe8KVg2JfeWO3rL65JVHbPfLQUKc9UesUnoT1x4VnUUpSlApSlArTHaX2Go1vq6VfFX9UIvobR3Iid5jakJ+tvHl5VuelBpzsx7EUaF1W1ek35U4oaW33Jid3ncMZzvP+VbicQlxCkLSFIUMEEZBHlX2lBo66/Bx07LvomRLhLiQVOb3ISUhQxnlKV5yke/NRt6+DVCm3aXJhagMGK66pbUZMLcGkk8JB7wZx516DrCvj02PZpz1pjok3Btlao7K1bUuOAHakn2mg0Nc/g1tTrjJlfKlaO+cK9voAOMnpnvK30zb2haEW6QlL7AYEdYWnhxO3acjyI8K0DovWXa9N1pCi3ayui3uPhMlLsHukNN59YhfsGccnPtrf15uDVptE64yMliIwuQ5jrtQkqP6Cg0hffg1WSXMW9aLzLt7SlE9ytoPpT7EnKTj35qf0T2F2LS65En0uROuTjDjLb7yQEs70lJUlA8cE9Sa0rc/hB61lXFx2C7DiRiolthMdK8J8ASeSfbxXqrQ1zkXnR1luU3b6VLiNvO7BgblJBOB4URqHSnwd27Bqa13calW+YMluR3RghO/aoHGe8OM464r5qr4O7d/1LdLudTLYM6S5I7r0EK2b1E4z3gzjPXFb7rX/AGy3jV9m0+w9oe3emSVOFL60t96tpOOClHjk+POPLyKo2q/g8t6gvr9yOpVxy6ltPdiFuxsbSjr3g67c/fVy1T2S2fU2jrJZLk+6JNoitxo85pISvCUJScpORg7QcfrVZ7N9d61jWK/3btFtUhFst7Aebd9GDLy1Z5SlJIBGOc8e+prQ/bbp7WOpotjtsG6sypIWULfbbCBtQVHJCyeiT4URXtM/BzsttkSlXe6P3Nh5lTQa7kM7CcEKB3E5GOKjX/gx25UoqY1JLRHzw2uKlSsf2twH6V6GrTED4RGlptzjwWrbew6+8llJU01tBUrAJ+k6c0VatK9lOmNPaXn2NuKqWxcE7Zbsg5W9jpyMYx1GOh561rq4/BltTsort+oZkZgnPdux0ukf+IFP+VegqUGvezLsnsegVvyYa35lweR3a5EjHCepSlI4APHmeKpeqPg42W6XR6XaLrItbbqitUfuQ8hJPXb6wIHs5re1KDR9++DxZrlbLazGu0qLMhsBhUgtJWHgCSCpGRg844PQCsW6/BvtMm1WyLb7w5EfjBZkSFRu8VJUrbzjeNoGOBz1/G/9sN31ZZ9NNv6ItwmzFO7XiEd4tpGPrJR/G5x548vKu9h+ou0C9y56Nb21bEFtsFl92N3Cy5keqBxkYyc44x7aIrDvwbW3LTGg/KhYDLzr2/0Ac70tjGO88O7/AFraHZNoVPZ9pt+0puBnh2UqT3pZ7rGUoTtxuP2OufGrpSitR9onYXYtX3Z26RpT9qnvnc8ppAW24r7RScYPuIqL0n8HSwWm4sy7vcZF27pQWlkthptRH2hkkj2ZreFKAAAAAMAUpSgUpSgUpSgV56+EX2q3fTt5a07pp/0R1LKXpMlKQV+t0QnPTjknryOleha81fCY7N7vcb8jU1iiPTmnGUtymmU7ltqSMBQSOSCMdOmPbQa5uWue0SHpCGLjNvcePLkekxbip1xtTidpBQFfxk9FAe/zr7A1zqtfZ5e5StSXgyW7lCbQ6Zjm5KVNySpIOeASlOR/VHlUJqK76qumjLdFva3fia1OpiRkONBBCthwM4BOEpxz0yKktDacn6k7NNYNWphyTJiS4MruW07lrSEyEkAeJwvOPZRF07INW6iuOle0N6ffbnJdiWdbsdbspayyvav1kkng8DkVVuznXGqpmqUsy9SXh9r0OavY5McUNyYrqknBPUEAj2gVjdnbeqYNq1jEtdoUqPJtjiJzkhtSe5bSlROPNR5AHn7qjuzGDLRq5ClxX0j0GcMlsj/+I9QT/ZVrfVM/tH07Fm6ju8iM9MbQ407McUlaSehBOCK9O9tUObO7LNRtW2T6M+mKp1S9xTltBCnE5H2kJUnHQ5weK8kdj8GW32n6ZW5FfSkTmySpsgDmvZnaMlS+z7U6UAqUbXJAAGST3SqDw1oC3XO76wtkCxTfQLm+4UsSe8UjuztJzuTyOAelbR7V+0zVlvvEfSlruj7K7YwzFkyI6iXZUgITvVvI3fWyB0J6nrVS7DIUpvtY02tyM+hAkHKlNkAeoqrJ8IDQd9tevp1+t8OU/bprgkIkR0FRacwMhWOUnIyD7aCI1lrvtGgwLPb75JvNplR0LKXu8cYXKQduCvGNxTgjPXnn2yStZ6m/6DEXH5QXX0/5RmP6R6WvvO79GCtm7OduecedVPXEXWtxg2a66sVOlCW2sRA8CVpbTtydoHAO4e04z5VKqhSvm/Ib9Gf7z5TlW3uznHoo5x5UGbpy6ao1X2Y659K1BPkJgiK+sSpTi8tfTBaB16+rx0O32VVOye2XS76/tUOwzvQLgtS1If7xSNqUoKlDKeeUgj762L2BaenXnRvaNammlNSZkNhtnvUlIKvpcDJ9uPxrXVlZ1boTVjMqJbJkW8RitCEuRSvO5JScDGFcE8ig9zamiTJ+nLpDtkj0We/Fdajv7inunFJISrI5GCQcjmvz4tbEh+9RI8Z7upTkhDbbu4jasqACsjng81+htldffs0F6YCmS4w2p0FO0hZSCePDnPFeGNV6O1HonVKw/b5OY8jvY8lLRW24ArKVAgY8uKDZXaz2mar0u5C0fBuRRNt8NlufPQSt2Q8UAkhShkDkc9TmqWrXPaZpSZGeuF0vDS3RvQ1PJcSsf2V5/wCVNa6V1nf4cfWtwt0mUu4pzI7mMUqaUg7AVIAyElKUkHGKxbfctd3edEYscGUxIaGxKbdATHBPHKyhIBPHVXSgn+1PtP1Fc5lhuFsulytKZVrQt6NFkrbQHQ66hRAB8dv4YrFv+rtf/wDR1pqe/dpbNsW6821KRLV6RIcC1ZK1ZzgD1QM/xfdXV23WbUES9WJm/OP3C6JtLZkPJTu9YuunbkDBwCB91SerYklXwd9DNpjvFxM6UVICDkfSOdRQfHO03VE/she7y8zW7jBu7DQmNOlt1bTjLx2KUnBPLeefZ5VW42vdXK0rcXjqa9F1E2MhKzNcyElD5IBz0O1P4CsSBBljsyvSDFf3G7QSB3ZyR3Mr/wBxUfFgTPkhc0+iSMmdFIHdn+Tkeygt2kb/ANpeqbVd7dYpt4uaiplTzvpiitlI34CSpXG49cfZr1L2QxbzC7PrXH1N6T8bICw96Q5vX9dWMnJzxjxrTnwQIz7EvVPfsuNbkRsb0lOeXfOvSlApSlFKUpQKUpQKUpQKUqr37VyLPcVxHYTiyAFBYWAFA/dQU/4RWjb3rTTlriaejIkPsSy64lTqW8J2EZyojxNR3wb9B6g0SjUI1HERGMwx+52vIc3bO83fVJx9YVsK4avjw7bAliOpz0tJUEBQBTjrn765RNXRHLUufKaXHbC+7QnO5Thxk4FWhZaVSkdoEMu4VDfDefrBQJ/D/wC9cNc3mPL09G9EV3iJK8hYONu3GQR99KF4pWotH3cWm5OOuNqdC2inAVjHQ/8AKrTG19FdfSh2I40g9VlYOOPLFKF0pVWtOsY0xmW9JaMZqOAclW4qznAAx14rDX2gRA4QiE+pH2ioA/hShdaVG2O9RLywpyIpQUjhaFjCk1JVApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAqidp8HLcSckfVJaX7jyP+f41e6w7tb2LpBciSd3drxyk4Iwc8UgaVcfceaYaUcoaBSgeWTn/M1YNX29y3QbOwoEISyc+XeE5V/mPwq2xtD2tiQ08HJSy2oKCVrSQcHx9Wp+5W+NcoxYmNBxs8jPUHzB8K1aNTSnLMbCyiOy8LoCN6yTj2+OKyYaHfkRPUoHufSW9vv8f+VXBOhbSl3cTJUPsFwY/wAs/rVgFviCAYQYQIpTt7vHGKWNTacnsQPjH0gqHfxFsowM+scYrp00w1JvsJl9AW0tzCknoRV/XoW0qWVBUlIP8UODA/TNdtu0bboE1mUy7KLjStyQpSSPv4pYhtfWmLb7SyuBGSylTwDhTnng4z+tVOGq3i3PCSP9pz6uEKKvuO4AfeDW5ZUdmXHWxJbS40sYUlQ4NVpehbSpzcFSUj7IcGP1GaRIjOzkQvTZBiCX3oawsuFOzqMdOc//AHq+1h2q2RLXH7mE0G0k5J6lR9prMqSpSlKgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpWuO0W6yDc/QGnFIYbQCpKTjcTzz92KsRY2MFpUcBQJ9hr7WoHbBeISY76UKBc5QW3OR4+dfdTPT1Jt4uQWiQlkpJKuVDccHj/84pSNuqUlP1iB76+1qW2WO7Xm2NLjrbMZtagkKXjnjJ/yr7erpcblc/i9lxYQlYYQ0hWAojjnz5pQ2zVHvsbVS7q6qE4v0Yq+i7taUgDwyD41Vi7d9NXBKFuLacwF7CvclY9vh4GurUkoybzIfQpQS6ELAz0ygGrEDbtuEhEBgTlJVJCB3ih0JrISpKvqqB9xrU+qJE/0e3NuKdTC9EZLeCdqjsGSfbmo62wpMgByHLZQ9nhBe2L+7OP86lDdROBk18SpKvqqB9xrVGrnbqhyMzOU8lpLKAAScKVtG4k+Jzmo+2wpUgJchS2kv54b7/Yv7s4pRbdFK1Tqu6z1ymoC3XEBlpCVpCuVLKQST58msO+s3aDGhxrnuShIUWfXBODjIyD7BSi24qEgDJ4FaZUtfyaQdys+lq8f6grnb0TXbDdHGZGyO0Wy6nnK8kgDPlzSi24wcjIr4VJBwVAH2mtN2a+zLW1JQw6rDje1IJyEqyPWHtxmlutdyvYkPxyXS3ytS3OSfvpRbctK1ppuVeLQxKdebdXDSypQC1AhKgOD1z14486gVP3C8SVqelblj1vpXQgD2DJx9wpRbdNK1po2VeI10ZaU3KdhLVsWFJKkp/rA+FbLpMKUpSoFKUoFKUoFKUoFKUoFUbXOm5c6aJ0BAdJQEuN5wePEZ9lXmlBp1NhvklSGlQ5RCeE95wlI9meKzr5pmfFbgssR3ZCg0S4ppJUAoqPH4YralKtpSu6CivxLD3UplbLneqO1acHHFVjUul7ixdXZlsbW62tfeJLZ9dCic9Pf5VsmlLVqmPp2+XiaFzkPIzgKekHkD2A8muOorDP+OJAiQZDjCdqUKS2SCAkD/lW2KUtKa4nQNRR+5cgofLCo7ILYIUAQ2kEFB8cjyqGFgvU+UVKguIWs8qUgNpH+Q/CtwUpZTXN0tmo4Uj/ZFOvsd2hJ2kLSSEAH1T7R5VDI09ep8oqVBcQtRyVLQG0j7uB+FbfpSymttUaUuHetyIyTKJbQl3b9bcEgE48QcVFzNO3n0WM86xIeW5uHd4KlNpGMZ8s5PHsrbtKWU1MqzXL5Poa9Bk96JSlbe7OcbAM1nWe1T2tMXxlyG+l13utiCg5VhXOBWy6UsajtOmLhLkOMvxXo4LZKXHEEJCh0BrqXYL5EWttMSSN3Ci1yFD3itw0pZTXWmdISll9y5JLCFNKbQnIKsqGM49lRarFf7RLX6I0/kgp7yPyFD7v+dbZpSxrzSWnrqLk3LnKejsoVvKVLO5w+0eXnmsE2fUXx/v2v993mfSN3qYz1z5eyto0palKUqBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlU7UVylWu5TobT6+9ubKPi/cchD24Nrx7BubXj+0aC40qpxrxPbDTxVGXBTN+L+5UFGQSHO73le7BORuxt+rzmum23ea/3cO2iJF2NOyFrlb3AoB5aNoO4H+Lkkk4yOKtJa5UqE09NEyRcHNiM/QqKm3S4lW5pKvVzxjnwAz1qJTqS4NWVN3kfF6o78VchqMCpDqMJ3BJJJCsfxiAMe2lFrjSqlNvl1twksPegypQZbeaW0hTaBucCNqgVKPjkHPODxxXVNvd9gpvC3vi5bdrSl5ZS2sF5BTuKQN3qEAHn1s8cClFrlSqg5er0pxDjCLeI7lwXBSlaV7gAVAOE5wfq/Vxz5iuhzUl5MwWxiPHcnodeS48hvKClAbIwhTiTkh0fxjjB60otdqVUEX28TGmfRGoLDvoSpTne5dTuSop2pKFYwcZzk48jTTFwuVx1DNdclsegrjxn0Ri0rcgLQojB34z5nbzjwpRa30qqyb3c0XCeptMQQYc5iIpKkKLjgcDWSFbsAgueRzjHHWuqLqK4LRAluJiGLPdcZajoQrvWilKyCo7sK+pggAYz1OKUWt9KqS9STVQ7WqKxHeky7aZhaCtuV5ZAAyen0iuCecAZqTsVxk3KBMC1tomsuFo7o62whW0EbkKOfEdFYI8aUWmqVR7Hc758T6ebMmDJfncKeW0sFtKWyo59c7lZGOo613s6mmKuJQRHciuokFlSGlp5b6eso+uOOcJAB8TSi1xpVNTf7022yl2PEfkSoaJbKGUlOz10JWk7leuQFgjBTnGKj570rUE2wtuOQVoRNebeZfhOY3paUr1kKWMHB468kHPhSi2wqVVmL5PU6zJV6IYLs5cJMdKFd8khakbt27B5TkjaMDPPFdMW9XuSxa1BNvacuLziEZQtQaQlCzk+sNxO0ccYz40otb6VSW9T3ViBHuE1iK5HW5IYUwwlXeb2UuncFE4wotH1ccbhycVym6julugvPSPQJLi7c9PY7hKkpQUBPqqyo7gd49YY6HilFrpSqlJvV5iyJMMsxZEpAZcSplsjahzvM+oV5WU934EZB6cc9lyuTk3Qc2YlzD3dLSVNoU0QpKik+qr1kkEHj/OlFrTSqqrUMoahZjJ7hyE5KMTKWlgpUEKUfpCQCcpwUhJx51aqilKUoFKUoFdL8SO+8w6+w046woraWtIJbJBBKT4HBI4867qxZNygxZLUeTMjMyHf4Npx1KVL9wJyaD4LZBE4zRDjiWf/jd2N/TH1uvTiuEmz2yU021Jt8R5pslSELZSoJJOSQCOMnrXJy629ovd5Oio7gZd3OpHdjOMq54545rim5sPCGuGtqSxJWUh5t5BSMJJyOfW6YwM/pQZTTDLKlqaaQhS8bilIG7AwM/cMVjM2m3MSXZDMCK2+6CHHEtJClg9cnHOaN3a3ONPONz4im2eHFJeSQj3nPFfHbzbGozUh24w0R3ThtxTyQlZ9hzg0H2PabdGZW1HgxWmlkKUhDSQFEHIJAHga7nYcZ1L6XY7SxITteCkA94MYwrzGPOuqRdbfHfbZkTorTzhAQ2t1KVKz0wCec19FygmcYQmRjMAyWO9T3mP7Oc0HYIcYBIEdoBLhdA2DhZySr38nn210S7RbZiFolwIr6Vr71QcaSoFeMbjkdcADPlXOLcoMyQ6xEmxn32uHG23UqUj3gHiki5wY0tqLImxmpLv8G0t1KVr9wJyaI7EQ4zYSG47SQlvuhhAGEfZ93sri3b4bTzTzcVhDrTYabWlsBSEDokHwHsrj8ZwPTRD9NjelkkBjvU7yQMn1c56Un3KDby2J8yNGLhwjvnUo3H2ZPNFdhhxld7mO0e9Wl1eUD11jGFHzI2p59g8q62bbBZlrlMw46JK87nUtgLVnrk9a5qnREqWlUlgKQpKFArGQpX1QfacjA8c11s3W3vS/RWZ0VyTz9El1JXx14znig4Istrb37LdDTvSUqwykbgSCQeOhIH4VkQ4caE0W4cdphsncUtoCQT58Vixr3b5MmWyzKYWYgy6oOoIT55wcjHjkD/OuTV0jvPKDTrK46W1LU+l5BSkg4IIznjxPSiO1i3QmFhbESO2oLLgKGwDuIwVceJHjXULPbAsrFviBRUV5DKc7jnJ6deT+Jr6zeLa9EVKZuERyMlQQXUvJKAo+Gc4zyK+G82tMJMw3GGIalbQ+X07CfLdnGaDtetsJ5CUvRI7iUt90ApsEBGQdvuykcewUYt8OOloMRGGwyoqbCGwNhIIJHkSCfxrhJu1uipYVJnxGUv8tFx5KQ5/ZyefurIlSWIjBelPNssjqtxQSkfeaK6U2yCiaZiYccSz1eDY3njH1uvSuxEOMgMhEdpIYJLWEAbMgg7fLgn8a6BdI5cSoOMmIWS96T3yNmM48849vSuCb7aVBBTdIJC192kiQj1l8eqOevI49tEZKYUVCW0pjspS2tTqAED1VqzlQ8idysn2nzrpas9tZafbat8RDb6drqUspAcHkoY5HJrkq629MtMRU6KJSjtSyXU7yfIJzmsVjUFvVATLlyGYTSnnGE+kOpRuUhakHBJ/q5oMyTboUorMmIw8VhIUVthWQnJT18txx7zXIQooh+iCMyIuNvchA2Y8sdK7gtJb3hQ2Yzuzxjzqq23WTM+Y0hkQ1xnJbkYONSwtSAhLp3rSE4SD3XHPIOfCqJ9dpty31PLgxVPKUFqWWk7iodDnHXgc1m1hSriy1GDjK2n1qb71tCXUp3oyBuBJxj1hz7R510XO+wLepTS5LK5QUgejpcT3nrKCQduc45zUVKUrEauUF2cuE1NjLmIGVMJdSVp96c5FZdApSlAqs3GzzjPua4jNvks3ANhZllX0W1O3ASEnenxxlPJPnVmpQVZenHkR1LYEYyhc1T9qiQh4EqASs4zkJI8DgpFcBp2Y5MblPeioUuauU6whSihIMZTIAOBuJOCTgdT99spVtKUtjTM5Md5lxLRjhLQYYMtZLakKJyl3YFgDjAO7pX06evC2GW3ZDCxtfQtW4JWAsgpBWGwVDA5A254yTirnkUpZSlJ0tNXZrkw76KJcm2Mwm1hZIC20rGSducZUD086zmLNPZdXGDUBcRUtyV6S4pReTvUpWAnbgKG7aFbug6eFWelLKU/S2mZNrlwTJbYCIMdTCHUy3nFOZwM7FYSgEDJHrc48q43rS8qXdbg62hl6PPU2panZbzfdbUpSQEI4X9XI5HJNXKlLKVh7Tz6vSlNlgOu3VmcFZOdiC3kE464Qoff1rhqSwSp12XNittPh2KIqm3ZbrARhSjn1AdwO7kHH1RzVqrClW5uS8XFuvpJ4whwgVz1Ms8YvCLn96WIieavp01JRebbObMbbAabjobKlHvEBJClqJydycnbnPVWT63EfZLLPl25hhTEWNGRcJEn0hKlB7+Fc6J24BOcFW7p4c1aviZn+Xk/mmnxMz/LyfzTXDjbT5cd3s1u4dfRVoGkJrML0ZxEZJZt7sNp4THnN5UkJzsV6qE8ZI9bnGOnMjedLrmxVRoymmGRBTGSlJKRuS4lYHHRJ24OOcGpj4mZ/l5P5pp8TM/y8n800420+XHd7G5h19FeRpeU8l9b7MZpx2REWpHpTsjchl0LOVLHXGQAEj2nyyXLDOYvj9zipivEyHFtx3XChO1bTKSchJwoFo+B4UeamPiZn+Xk/mmnxMz/LyfzTTjbT5cd3sbuHX0VmZpae4tTqWIC1PxRHcZRJejtNeutXAQPXB7zkHGdvhnieu9oVJtMKKyhLi4qkKQS+topKUkZCxuOefHORnNZHxMz/AC8n800+Jmf5eT+aacbafLju9l3cOvor72mLhJtq2JT0d1xcN2Moq6EqdChnCQD6vBOBk845rLumm1yl6jWymMlVxgojNE8bVpDgyrjgesnpnp7KlfiZn+Xk/mmnxMz/AC8n800420+XHd7G7h19FZjWifLXd46I8NDD9yDy5K1KDqdmw5CduFH1eDkYz7Ofq9Kzm3I8hsMyHW/SkFoy3WEgOvFwEKQCTxgEEffxzZfiZn+Xk/mmnxMz/LyfzTTjbT5cd3sm5h19HGwRX7dEj25bLYjRozaUuocUdy+QpICskAYTgknr7KjDp2QpmC2pbIDM6VIcIJ+o6HgnHHUd6nPuNSvxMz/LyfzTT4mZ/l5P5ppxdp8uO72Xdw6+iur07dn4sdh8wkCPbjCSUOKVvVuaO4+qMDDZ456+Ndk3TtwcRMitIgrYfuDc4SHFq7wYcSsp27eoCdoOemOKnviZn+Xk/mmnxMz/AC8n800420+XHd7Ju4dfRXrRpaVDuUUupZXHjSXZKZBlvFaivf8A/C4Sk+vgnJBweOeLpUc3aWm3ErD0glJzgukipGu2nnqZf1Ma/wA3/wAhJiI5FKUrohVH1NqC4w7vPaYkMxW4bba20O7MSCoZ5yd2M+qNgzkHrwKvFRkwvqlBQtTcjuzlt1TiQR7sjIrnqa2OjG9lEz+0TP8AqJWMJy+EIayuOp1neGZN2WVK7txuEvuxlBQOUjG7APGR99YM/UE9qZfVouUZBt0ptpmCWxufCkIO0nOcqKiE48euelWb0q4bt3xUN3TPfp/9qwYsV+PLkyRZwt597vypb6CUK2JT6pxwMIFcPH6XTLsz/i3wcusfWPur/wAYOx5BmxozPfx2LspDTaMBakPoAyB1Jxz5nNfb7PnO2O9Ro16E0C2rlelRkIBaP2OMjChkjxG08mrWl+alQKbQgEZ5D6fE5Ph418admMpUGrM2gKOSEvIGT+FPH6XTLsz/AIpwcusfWPuq9+1HIgQHHbbd0zxFiGWXEoZKXfWUAFKBAI9UjCBnjk9K6XrpJhTtUy4VxjoUxKbdbiFAUZJLDWE56+twE7fHz6VbVLlrKSuytKKQQkl5BwD1A4r4DJCkqFkZCk8pPeoyOMcceQH4U8fpfLl2Z/xODl1j6x91YVdJkRLUaM8IiJM2ctb52ZBS7wgbztyck+PCT7xadN3T4wtsQyX46pjjRcKWlfXSFEBYHkfvHPU18dVKdbLbtlaW2TuKVOoIJ88YrJhLkLfy/b0RwEbQ4HEqOPLjwrWG2aecxjEZXPXHKPWYonSyxi5mPrH3Z9KUr0sFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKVBtassrurXtMomZvTTXfrj90vhGAc7sbeih40E5SsGJeLZMmOxIlxhvy2v4Rlp9Klo96Qciqqe1bRib25aV3kInNyTDWlcd1KUuhRTtKynb1B8ccUF4pUab/ZxIkMG6wA/HSVvNmQjc0kdSoZyAPM1gzta6YgxDJk3+1pZDXfAiShRUjONyQCSRnjjxoLBSqlp7tH0jqESja75FWIqC693u5nYgdVHeB6vI56c1Nx79Z5DTrse6wHW2kJccWiQhQQlQyFEg8Aggg0ElSsCLerXLgPTotyhPwmQS7IbfSptAAySpQOBgc81GT9b6ZhWqRcXb3BciMNh1xcd0PkIKtm7ajJI3HGQOtBYqVGfKC0BURDlzhtOS0JcYbdeShbiVDIwkkE591fF6hsqJT0ZV2t4kspUtxn0lG9CUglRKc5AABJ91BKUqvad1pp/UVjkXm1XJpdsjuFp2Q8lTKUKABOd4GBhQ56c1nx79aJLLzse6wHWmEBx1aJCFJbSRkKUQeARzk0ElSopjUljkB8sXm2u9wkLe2SkK7tJ6FWDwDnqa5ov9nctjlybutvVbmzhcoSEFpB4GCvOB1Hj4igkqVDfKvT2HT8fWnDTaXnD6Y36iFbdqjzwk7k4PQ7h5isy3Xe23MrFtuESWUJSpQYeS5tChlJOD0I5HnQZtKjFagsyTKCrtbwYgzIzJR9COmV8+r99YcjWemmIkqSq+21bcVgynQ1IS4pLQA9bakkkcjGBzkY6ign6VRW+1XSr79saiS3pHxlHekx1IYUApDRWFZ3YIOW1gZHOKzbD2haevGkvlIJZhWkOlkuzAG8KBx5nxNBbaVgTrzbIEVmTPuMOLGex3br7yW0ryMjBJweKxFapsqb2LSqe2Jxh+n7cHZ3G7bv3424yPOgmqVGtX+zuwHJzV1gLhNnauQmQgtpPkVZwKiZuv9LQ7jaoLl5iuSbo4G4iY5LwcUVBI5QCE8kDJIHXyNBaKVWHdbWlrXSdJuekC6KjmTuKB3QRgnlWfIHwqUg6hss+WmLBu9ukyVJK0ssyULWUjqQkHOPbQSdKUoFKUoFatn9nt7V2xq1hb7pEYhPNIYfYUglxTYQlKgDjAJKRzW0q1zrTtTj6Y1S3ZFWW4S3FJQe+QpCEEq6JSVEblewc0ED2Zdj0vR2rm7o/coUmNHQ6hotxyl53fnlxRPgD4eQqGX2IXhOsLlfmLrbd8i6+nNNPMFxIbK1qIIUCN4ynB99W5/tci/KeXaItluTzMeWqAuchILaXx1BTnO0Hxqs6Z7cXPkZAuF8typl0nTH47LEIBtJS2lCiSVK8lj30RkaQ7E3rJq4zplwhS7aPSODHPpDodSUlK1E44BPI9vnUNbPg8vIs97iXG8suPvtoagPIQohlKXCshQOOpx09tT117fbZAWwFWG5KDkMTCFKShSAVFJBB9o6+PFSV07aLdFdhIg2S6XAvQWrg73ITllpwgJyCeTyOB50FMi9il4stl1LOkTWLjc37QbfFjQ2ykKwhCQSVY5wgffk1z072IXJWn3nJcm3x5cu1sRRFVGKUhW9Di++KVZUoFJTuHsPhV2Z7Y7ZI1emyRLTcnm/SkwlyglICHVeaM7sA9T7DXLX/a/btH3idblWqdPdgsNvSFtFKUN71AJBJ/tDnHiB7g4aM7Np1h7NtRadkTIC5d0aebQ4wyW2297WxOfFWPM8++q1oPsOfsOobTMu79qnwY8R2PKjFkqD6lLcUCQoYONyOv2fdUlcu3e3QXJaF2WWsx7dGuJw6n1kvBkhPTqO/H901IaI7R5upO1GbYywy1a02hi4sjb9KFOIZXhSs4P8Ljp4UEVrfsYkX7W7l5hXCCzDkdwFsvRipbCW0hOGsHABAHHFduluyObau0V/UEqVaVwlrfWWmoxLjneBQ5KidvC+dvB8ua72+3SzuuSSi03H0YMyXYshW0JldwkqWBzlPA4zWVE7YY7ukGL+/p+5NMzJKIkFoKQpUpxRUMJOcADYeTQQ9t7NLxpXsg1fpxl9q5uTSt2IhhJSskpSnBzxn1R+tQdh7C7g/pqV6bcI8CXNtTEVDLMfbsWFIdV32D6ytydpI8OfZVihdvVrlNp2WO5GSuYqI3HSpBWranKldQBgEce2uDHb3b3rbZ5iLFOV8ZTXYSG0uo3JUgNc84Bz3w/CgibZ2H3WLD1K07OsyzdW2UobQwtDSChwLI2gggcYGDmrHZuymZG7Jb1pKXcIQlXB3vUvR4+1CMFBSCOCr6gyTzz44qItPbcu/6x01FtUPubXObeMpt5G55K0BZwkhWOiR4eNSMbt2ti4VzlSrFc4zMJsLwtTZWslaUJSU5ykkqzzxgGgrLPYRe0xr227eLctU+1x4DakoWAgtLjnJHPGGCPeRwKtnZZ2WTtGapmXJ+bEcjSLY1C7qOlST3iUthS+RjkoUfP1qselO0BOo9OXm5MWacxItgVviulOXSElWEKGQc4I99U2J8IKyyYz0hFonlplhDiyhSSQ6te1LXlk9c56A0ETC7AJTSpqHb5GDXor8dhxqMUuOlwkhT5z62M/oPKsnSHYjcrVNu6rndYLzE+yrtQ7ppW5CilCQvB4ONmevl0rM1Z21PxNDvXmy2ctzotyFulxp/IZVtUr+Irnpj8asNn7U27lrCZYGbLLWYIC5UtC0lttGzcV464zgePWgplh7E75An2F2Tdrc41a4kmKkIQsFQd74g9PAvH8KuWiNC3vSfZobBEl2p65CQp1LslhTjG0qBwU8HOBXPQPaxB1lfU2+JaLjGbdbW6xJdCShaUkg52k7TwevlUez20w1OaicdsVwTAsa1tyZSVoUncFFCABwcqUMD9aDI7VuzifrN6yS4k23okwGnGnGZccuML3pAKgnwIIyM+zyrKufZhEndm/yd7yK1dBDRE+M0Rkhe1Lgc2DxCCofVz0NRP/TZFGm5t3c09cm2ob7LbyVKRjY6DtWFDg9ACPaK4r7cbb8UtTmbNOeEqa7DhIStI9I7sAqWCcAJ9ZP3n2UVDx+xS4t6MuVqXNsypMyWy/sEZaWQltK0gcEK3HfnPsx41yZ7FbnHh6SdZulsTcrLOVLcUmL3bbgKm1Aer1I7vxAzk1m3Tt7tsBcIGw3JXpMIzdqlJQpAClpIIP8A3ZOfIiu28du9rtyomy0THkSbam4pV3iUkJORtI8+KIz9V9mMy/dok2/C4ssQ5NqctxQEkuoK21I3Dw43Z61EdmHZBc9Ia2i3uXPtrrLUMxi1FZU2ScABR8CTjJPiTW1dKXpvUWnLdd2WlMomsJfS0ogqQFDODUrRSlKUClKUCqnfezvSl+vqbzd7O1JuKdv0qnFgHb0ykK2nGPEVbKUFTe7OdJvaiXfXLKwq6rUXFPbl8q+1tzt3e3Gc81jHss0WbE3Z1WNpVvbeU+hsvOFSVqACiF7twyEjjOOKutKCjy+yjRUso76xN4RHEVIQ+6gBoHO3CVAdec9fbXbcOy/Rtw+L/TbEw96AymPH3OOeq2n6qVet6wH9bNXOlBVF9nmk16ibvqrJG+NG1BxLw3ABQ6K2g7SR54qO7S+zCya6ivLkNoi3daEtouCUFS0JCwrG3ICuARz0yavlKCgnsm0lLt8Jm8WtufKYgswVyStbSnUtJSASEqGD6g9uOM4qbsuidPWS9qu9st4YuKoqIRe75xWWUJQlKcFRHAbQM4zx161Y6UFPHZno5MufJTYYyX5za2n1JKhlKwQsJwfVyCeU4PNYmquzS1XjQDWk7ctVrt7DgcZKU98UHcVH65J5Kj45+7ir3Sg1jpTsW0xZ7AbbdWfjlSpPpZdfT3eF4wAkJPCceGTnxqXY7KdFx2IDLNlCW4EhUqMPSXj3bqtmVfX5/g0cHI499XelBSLX2VaMtcuLJg2VLT0YLDSjIdVt3ghXBWQcgnrX239lWibezNai2COG5rfdPha1ubk5CsDco7eQDxjoKu1KCE0rpSyaUguw9P29uHHdXvcCVKUVq6ZKlEk/jUVA7M9HwbdcoEaxsJiXEpVJbUtawspJKcblHbgk4xirhSgqg7O9JjTS9PiyxxaVuB1TIUoErHRW/O7PtznHFd2nNDad05NkS7NbUx5EhlMd1XeuL3NpAAThSiOgFWWlBV9O6A0vpy7vXOy2ePEnOgpU4gqOAeoSCSE/cBXODoXTcFi8sx7W33N4X3k5C1rcS8rJOSFE45UemKstKCowOzbSUCx3G0RLKy3b7hj0pvvFkuYORlRVuGDyMHivsjs40lJ05EsT9mZXa4ilLYaK15bKiSSF7t3OfOrbSgpEnsp0VJLHe2Nv6CMYjYQ86gJaO4lOAoZ5Wrnrz1r7P7K9Fz2IjUuxtOIiRxFZ+mdBS0DkJyFZPU8nJ5q7UoK/p/Rtg09NMuz28RpBjoib+9Wr6JGAlPrE9MDnrxVgpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpXxxaW0KW4oJQkZKlHAA8zQfaVpXWnwhdOWWS5Fssd68voOFONqDbIPsUQSr7hj21TFfCdm5O3TEfHhmYr9yg9O0rzF852d/RiN/i1fu0+c7O/oxG/xav3aD07SvMXznZ39GI3+LV+7T5zs7+jEb/Fq/doPTtK8xfOdnf0Yjf4tX7tPnOzv6MRv8Wr92g9O0rzF852d/RiN/i1fu0+c7O/oxG/xav3aD07SvMXznZ39GI3+LV+7T5zs7+jEb/Fq/doPTtK8xfOdnf0Yjf4tX7tPnOzv6MRv8Wr92g9O0rzF852d/RiN/i1fu0+c7O/oxG/xav3aD07SvMXznZ39GI3+LV+7T5zs7+jEb/Fq/doPTtK8xfOdnf0Yjf4tX7tPnOzv6MRv8Wr92g9O0rzK18J2VvHfaYZ2eO2Yc/wDorZ3Z72zaZ1lIbhJW5bbovhMaVjDh8kLHB93B9lBsylKUClKUClKUClKUCvOvwqddyIaWNJWx4t9+2HpykHkoJ9Vv78En2Y869FZrw/8ACHW4rtfv3eeCmgn3d0jFBrmlfM1aey6TFidoFkkXBxlqK2/ucW8oJQBtPUngffRFXpW6nxpHUepHJNzfiOoTbYxipckttqfUSe9LygppIcTkjGRkAHB6VC2a16HMhyPKUy83IvEiG3IdnbDHjBtJQ7gEA+sThR4PP3Bq+lXq723TrWmIT0L0NSlMsKcli4Zk96SO9QY/PCecHCeADuOcVYpVk0K3PZ3qhIjpXJ7pLF07z0phMdam3HDn6JwuBA28ZKiNvHIajpW37avSzdtvbECFaFOXC0RpKWJNxKEtu94O8ZStSxgjbvwTu8ORxUVabfot6bpyHMDKA7blSpcj0w4XIwvayr1glsZCc8pPPUZzQa1pWybtA0bb3tSusNsy/R40Yw4/p3q98s4cCShR3hPXAUrHmaxtB2TTt0ttvfu0mCytubITNTImhlSme5QWdqSoE/Sb+U/fxQa/pWwG4GlF6PSkhhN3VaVTDJ9MO4SEyCkNd3nGSjnGM9CPb90dZNOT9IS3LrIhN3R0SRHW5ODa21oaCmgUFQAClZGSFA9MpxyGvqVtF+36NXqO7xbdGguohsNiIiRdC2zLWSkuKLu4AFIJwkEZx4mu/To0ou1JtF1EJUZ+/utpX6dgxmSykB0LwkqSCOCoBJ54oNUFJTjIIyMjNfK3DZpllU3Ihum23F5/TUZDZn3EtoS6lxBUyFlaQjgE4yCNuB1IOE7ZNB/Je2PqmhDznopffbkJLoUpYD6S1vJwkFWD3Y6D1lZ5DVdK2xZzp2ydo9idVDszUJTriFFu6GS0lPRDqznCTyeCrHmlOOVtsmjHrRc3boYUa4JdfCmo9wStMdKWwWy0ou/SblZ6Bzy9XrQanpX1sp7xPeZ2ZG7b1x7Kvqjpj5Bzd/xhv7w/F3fd13nfcbvq893jGc+OMc5oKDX1tam1pW2opWkgpUk4II8RXHNM0Htn4P8Arh7Wmix8YL33S3rEeQs9XBjKF/eOD7Qa2dXlz4Hy3RftRJH8AYzRV/a3HH6FVeos0V9pXzNM0H2lfM0zQfaV8zX3NBwJrzP8KzRbxmR9WwGitkoTHm7RnYR9RZ9hB259g869JFVdEpluVHcjyWUvMOpKFtrTuSoHqCD1FB+c9K9Qa0+DtAnynJOmJyrdvyTFeQXGwf6quoHs5qlL+DjqwKO242Up8CXHR/8A50RpSlbp+bjq39oWT817/Tp83HVv7Qsn5r3+nQaWpW6fm46t/aFk/Ne/06fNx1b+0LJ+a9/p0GlqVun5uOrf2hZPzXv9OnzcdW/tCyfmvf6dBpalbp+bjq39oWT817/Tp83HVv7Qsn5r3+nQaWpW6fm46t/aFk/Ne/06fNx1b+0LJ+a9/p0GlqVun5uOrf2hZPzXv9OnzcdW/tCyfmvf6dBpalbp+bjq39oWT817/Tp83HVv7Qsn5r3+nQaWpW6fm46t/aFk/Ne/06fNx1b+0LJ+a9/p0GlqVun5uOrf2hZPzXv9OnzcdW/tCyfmvf6dBpag5OB1rdrHwcNUKcAfudoQjxKFOqP4FA/zraHZ32H2XS0tq4XNa7vcWzubU43tabPgQjnJ9pP3UGb8HLRr2k9GLlXFotXG6KDzjahhTbYHqJPt5J/8WK2xvrGyr7J/CmVfZP4UVk76b6xsq+yfwr7uV9k/hQZG+m+sbcr7J/CuuXMYgQJE6aVpjMJ3OFKSopHicDnA60GeFZr7msC3z4tyhomW9wuRVqUlLmCAvBIynzGRweh6isrdQdrSAlIJ61zpSgUpSgUpWJcZ7cFtKnASVdAKxqamOljOec1ELjjOU1DLpWJCntSmC4g42jJT4gf/AIKh7HrOy3ncYz7rQEdMoGUypkKaUcBaSoAFOfEVcM8c43sZuCYmJqVjpWOmdEUtpCZLBW6nc2kODKx5jzFdLt4trLYcduMNDZUUblPJA3DqM56jyrSM6ldDkyM2VByQygpCVEKWBgKOAfvPArh8Ywtjy/TI2xk7XFd6nCD5K54++gyqV0uyo7LAfdfaQycYcUsBJz05rg3cIbm3u5cdW4hI2uA5JGQBz4jmgyaVi/GUHukuemxu7UvuwrvU4KvLOevsrCj6ktUma5FjzEOOtuONObejamwCoKPhjIoJelYarrb0tNuKnxA259RZeThXOODnnkj8a7mpUd15xlp9pbrf10JWCpPvHhQd1KwoV0izVzEMLyuI4W3UnqCBnPu5/wA/Kom1azs10kxmIj7pXIz3e9pSQcNB3qR9lQP6UFjpUXpy/wBu1HbjOtD/AH8YOKbKtpSQodeDz5H3EVKUClQF31dabTOciy3Xt7IQqQttha0R0q+qXFAYSD7fDnpUsZ8RKnUqlMAsp3OAuD1B5nyFBk0qL+P7Z8ZtQPTGvSHWQ+36w2rQVbRtV0Jz4CuVxv1qt0d56ZPjNtsrS24SsHYpRwAQOmSaCSria63ZcZpSkuyGUFIClBSwMAnAJ954FdSZ8NZUES46ilYbUA4DhR6JPPX2UHeqsK6QUXO3SYDzzzLUhOxa2VBKtviASDjI48+eMV2pnQ3HG20So6nHM7EhwEqwcHA8cEGu4igjbVbY9jtbVthOOqjNE90lxQV3SM5CAcfVHQZyceNZma4SeHE+6vmaCQpSlApSlAqKvlrVPbKkLw4keqD0qVqpTNbx2bxcbcxAmSHISVhTiNoQpaWw4UZJ49Ujk4GeM1x2jQw2jTnS1IuJb088tPKMsecJHT1rehRpCZBAU7xgHOOv/vUBF7NrdC0zEt8IsonsCOVTFs7w8pogjegq+qSCdoI/SutHadBct8aezbZzsN+O9LC0lvKWG1pQpZBV7c4611Ru0FxE15uVH74d4+0y0wjCnFJmejtjcpWBnIzn2n2VnZdmw2XSx0dPlC6uplq5znlzl9Z7NyzNt8hq6d2WMl7u2CkuZccWUpG/alOXCACklI6GsNPZa8i0sQEXWIW0OtrdDsFTiX0tpwhKgXfvOCAcAYwKl0dosIsOuLgy21NIK1IUUZGJJjkcHGdwz7qk9NaviagemJixZTbbCStDriRtdSFKTkEE4OUng4OCK9Dm+X3SbV4vVouD0ktmHgPtIR6skJIWgHngJWkKHXxHjVdT2YhMJ1j4xaJS22ywoRighKHCsKcKVhSnMnG8FPjxyazIPaRHmNxw3aJ4kygwqMwVN5eDqVqSc7sDAaX1I6DzrHY7Su/mOCPZ5L0VfozcfatAcW48VjaoE4GCgjOccHnpQSk/R70jTdlt6bg25JtiwtLsiMFtukIUghTeR4KOOeCB1qvWXs2lptlubmXERtiI632ENblBxthTXquBWAMKz0PIq2aa1fFv8+VGjxJTQYCyHXEjYvYsoVggnBBHQ4yOah2e0qHJeLES2TXnzIbYbQlbWHN6XFJUFbtuPolePlQRyuy1XxM1ERc2W5KF59IRHcBx3aW+ne9cJGc5SehTWXN7NvTH5xdugSzIckOAJjgKBeSgHcd2CAUdMDIJFZEbtKt8gtragTfRVBkF87AEKdQVISRuzngjIBGfZX2J2jRnkRnHbTPZadbYecWpTZDSH17GlEBWTk+ABwKDFkdmiJTcoyZ7PfSWpSFd3ECW0LeQ2nchG71cBsHGeSonIqW03o9dl1LNuaZ4WzISsejpbIG5SgoqJKiM5B+qE5zk5NYU3XbzkSDJtlqfW1JmtsN96pvMhtSlpJQN+UnKP42Otd9n7Q7fdrlDhxYU7L6UFaylJDKlhRCVYOf4p5GRyOaDnpLRr1hulymvXISlTGg1gMlGMLWoE+sRn1yMAAcdK6JmhHXbFZbfGuxju22K7GD4YyVhxvuyoDd6pAzjk1L6u1TH0wIapcWS83IUUlxsAIaAxytRICevGeODURN7RoEW4TYghSnlxsBKmlNqS6e9Q0QDu4IUscHHj0oMzTGi2dPG4sxbhLct8xttPcrVtW2tCdm5K04IykIHA42jmpJvTcNtxK0ybqSkggKuT5H3gr5qDY7Q4a50CK9bpsdcl5cdS3NgbbcS6popK92CcpzgHoRjJ4rNumso9u1Au2OwpKktqjockpKNiC8SlGQTuPIxwDQdF+0a9cZl2VFufosO7toanslgLUoJG3LasjYSng5CvOsF3s9K0z2kT4yY7z5ks7oSVOJWXku7XFlWVoygDb6uU8HoDWLYu0Z+WG0yLW48p5mH6P3CkpLzjzRcIwpWEgBJ6k9OpyKkbbrdx7UztulwHUR3JDUdh5JQdi1x+92rwo5PChlOR05oIuR2Xl5zd8aMp71CkPgQhgbn++V3XrfR88DrjrzXY/2Z72n0ouTQUN3o6jFGRmQl8l47vpDlAAPq4BPnWXf+0BFtvQjphuiBGkOszJSgkj6OMp5QQArdkAJ5Ix1qUi6wZkaan3j4vmNohHLrKgncU4CipJBIUAlWeD4EdaDnqDSjN6vlquLshTfoh+maSjIkpCgtCVc8BK0hQ6+I8arzHZquOhss3RtL0Ys+jLETAw273gLuFfSKJ43ZT4+ZqQR2iW92fHjMwpryXlkJdbSlQ7vvS0HMZyUlSVdM8DPlWC/2klxmOYNmkFx5yPsDziAFtuPFoqGD1BSRg46g9KBa+zpy33O1TEXVJVDUVOlLBSXsuOLxjeUgfSEZKSRjgjNbCqvaU1ZF1K5JESNKZQ0ApDjqRtdSVKTkEE4OUng84Iqx4oMGX/DJ91cK7Jv8Mn3VwoJClcGXA4gHx8a50ClKUCouVp6zypb8qTbYjsh9BbdcW0CVpIwQfPjj3cVKUoK3J0TYJNyZmO26Oe6SsBju090VLUlRWU4+tlI/Ws9/TtmfQ8l62RFh4KDmWh625feKz71+t7+alaUFdg6LsMSI1HNujvoZW4tsvNpUUb3S4Ujj6oUeB4YFScCzW23vSHYMGOw7IJLqm0AFeSTz95J95NZ9KCJd03ZXY/cOWuGpnYhsILQwEozsA9icnHlmvqdO2dElmQi2REvMpQhtQaA2BBygDyx4eVStKDAhWa2wZUiTDgx2ZEgkuuIQAV5OTn3nn31DzNCadkhhPxaw0228l5SGkBIcKUrSkK45A7xWB4VZ6UFdjaMsTF1cnpt7CnlJQhtKm07WUoRsAQMccGs9en7Qt6G6q2xC5DSlEdRaGWkp+qE+QHh5VJ0oImPpuyxn1vMWuG26t0PqWloAlYJIV78qJ+8+dcDpiyb0rTa4aHENlpC0tJBSk54HH9ZX4nzqZpQRcnT9qlQ4kWXAYkMxUBtkOoCtqcAY58CAM+eK4DTNkEl2QLVD751W5a+6GSdwX/6khXvGal6UEUvTlmXJbkKtkQvtrLiV90MhRVvz79xKvfzXSvS1qd1E5e5EZL85SW0oU6AoNbN2Cnjg+sf0qbpQQjulLA6jY5aIRR3aGtvdDAQj6gHu8PKspix2uOptTFvitltaVoKWgNqko2JI9oT6o9nFSNKCKe07Zn7iue9a4bk1fCnlNJKj6pTyf7JI91d9vtFut0JcSDCYYjLzvaQgBKsjByPHjis6lBFK07ZiYRNsif7EkIj/AEQ+iSCCAnyAIBx5ivj2nLM8wGXLZELQSlAT3Q4SlW8Ae5RJ99S1KCKjads0V1Tke2RG3FOh8qS0Ad4JIV7wVKP3nzqVpQ8daDDmD6ZPurhiuTyg47kdBxXLFB1EFJykkH2V8Lrvgs1kFNcCigxy8/8AbNfO+f8Atqrv7uvnd0HT3z/21U75/wC2qu7u6d3QdPfP/bVTvn/tqru7und0HT3z/wBtVO+f+2qu7u6d3QdPfP8A21U75/7aq7u7p3dB098/9tVO+f8Atqru7usC6T2oCMEb3T9VA/50TLKMYuWSX3gMlwgVhu3lpo4XLGfZz/lVYmzZEsnvV+r9kcCsTZUt48tr+WFuGoI5OPSlf3T/AO1ZTFw9IH0MgL9gIzVH2V9CSDkcHzFLZja8v1hfe+f+2qnfP/bVVatt4dYUEScuNef8Yf8AvVoZKHm0uNKCkK5BFW3r09XHUj4OHfP/AG1U75/7aq7u7r4UADJIA9tHR1d8/wDbVTvn/tqot6Oj677SfeoV0LuMFHWQg+7msznjHOW4088uUO/vn/tqp3z/ANtVYK7zBT0WtXuTWOq/Rx9Vl0+/ArE6+nH6ukbLrTyxlLd8/wDbVXYzIdSv1yVJ8a4RVokx23kDCVjIBrhLkxoTKnpb7TDKeq3FhKR95rpE38YcZiYmpSLr4SgFHJPSsUqcX9ZRIqBj6w01IfDLF/tLjpONiZjZOfdmrE2UrAKSCDyCPGqj4hOK7cVySmueBQfSK4lNdlMUHXsrqkONR2VuvrShtAypSjwKycVE3Qd7ebSwr+D3OPFPgSlIAz7t2feBQcU3QOJ3NQJ60Hoe525+5RB/Svvxiv8AZs/+4n96s+4SUwoEiUtDjiWG1OFDadylADOAPE1EQdSsTNHDUSIc1Ef0dUj0dbWH8Jzxt8+OKDI+MV/s2f8A3E/vU+MV/s2f/cT+9WP8pWPkb8o/Q5vo/o3pPo3c/T4xnbt86k7RNRc7XEnNtOtIktJdS28natIUM4UPA80GJ8Yr/Zs/+4n96nxiv9mz/wC4n96pfFMUER8Yr/Zs/wDuJ/ep8Yr/AGbP/uJ/eqXxTFBCv3J5LSi1a5ynMeqClIyf71VR9i6Puqcdtc1S1HJPqfvVsXFMUctTSjU5tb+h3H9lTf8AyfvU9DuP7Km/+T96tkYpipTn4TBrJ5L0YpEyJJjBRAC3Eerk9BuGQDXLZWxZcduTFeYfQFtOIKVJPiCK1nblqVaYzjiipfcpUSfE7akw82voxp1MEmVGjECQ+22o8gKVgmvjOo2Y30bE9CW1ckJPjV30lAZYssR/YlUmQ0l11wjlSlDPXyGcAeVZSLvbF3xyzolMm5ttB9cYfXCCcBXuqZ4b0VdPbsunGhnGpPx/soC9QsL+tcif/wCw10qu8FRyqYgn2qrYrF3tj96k2hmUyu5Rm0uvRx9ZCVdCf0/GpDYnyH4V552SJ55S+tH4jOPLCGqfjW3/AM6a/Gnxrb/501+NbW2J8h+FNifIfhU8Hj1a/M8/lhqn41t/86a/GnxrA/nTX41tbYnyH4VxWlIB4H4U8Hj1PzPP5Ya21Nr2Bo/QHxotSJDhUpmM0lX8K4ckDPkOpNeRtYauvOrbkuZe5i3iSdjQJDbQ8kp6D/PzrZHwppu/XcWC2lKGWIqXCEjG5aicqPtwEj7q172e6YRqq/OxZElUaHFjOzJLqE7lBttOTtHiTwK9WGO7jEPn6me/lOXVWc1sjsr7Vbtoqcyw+65MsalAOxVqz3YzypvPQ+zof1rD0ExYtQ6pa07Jty0QbiosxZKlgyYzhHqqKkhIWM9QR0PBqmXGGu33KXCdILkd1bKiOhKSQf8AKtMP0Os9wjXW2xp0F1LsWQ2l1taeikkZFZ2K0p8Fi6vTez5yI8oqTBlrabz4JIC8fio1uug+0pSgVA32bHg3y0uy3UtNlD6dyvPCKnqiZ/8AvFaf+7f/APooHyktH8/a/WnyjtH8/Z/WpXI3AZ5NfaCJ+Udo/n7P60+Ulo/n7X61LUoIn5SWj+ftfrT5SWj+ftfrUtSgiflJaP5+1+tPlJaP5+1+tS1KCJ+Ulo/n7X60+Ulo/n7X61LUoIn5SWj+ftfrT5SWj+ftfrUtSgiFajtG0/7e109tUSC4l2xxFIQlKfRUdPH1etbRV9U+6tXQXVrsENClZSiONo8spqS8m18obA06tHyftnrJ/wCrN+P9UV3JhQE3FdwSxHE5bYaU+EjeUA52564qI0/YbSuw21SrdFKjGbJJbHPqis/5P2j9mxPyxVetkNwoDVwenNsR0zXkhDj4SAtaR0BPUgVld4j7afxqN+T9o/ZsT8sU+T9o/ZsT8sUEl3iPtp/GneI+2n8ajfk/aP2bE/LFPk/aP2bE/LFBJd4j7afxri4tG0+un8aj/k/aP2bE/LFDp60Y/wCzYv5YoPMvwrbI41qC23tsbo8hn0ZZHRK0kkfiD/5TWn9J6im6XvKbhbw0tRQppxp5O5DrahhSFDyIr2ZrzRVkvEaDbpEBlDMl9SFKbSEqT9C4QQfMEA/dXmbXPY9qTTcpxUKK5dbfklD0ZBUsD+sgcg+7IoIbSeo7Npy8uX9iC8u4s7lQYZVlhlZGAtSydytueE48smqjIfclSXpD6it11ZWtR8VE5JqRj6dvUh8MsWi4OPE42JjLJ/yrcXZb2HTpc1i46vb9HiIUFphZyt0j7ePqp9nU+yg2f8GuwvWbs8ZdkoKHbg6qUEkchBACfxCc/fW36xYUdLDSUISEoSAEpAwAPKsvFApSlAqJn/7xWn/u3/8A6KUoJJX/AFhH9lX+YrspSgUpSgUpSgUpSgUpSgUpSg+K+qfdWq7d/wBiRv8Ah0/+mlKkvHtnKGxdOf7v2z/hmv8A0ipClKr2FKUoFKUoFKUoIW+/9oWP/jFf/IdrvkAc8ClKDGAGegrNjgeVKUGanpXKlKD/2Q=="
+        }
+      },
+      "speed-index": {
+        "id": "speed-index",
+        "title": "Speed Index",
+        "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).",
+        "score": 0.21,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "8.1 s",
+        "numericValue": 8101.8289171122506,
+        "numericUnit": "millisecond"
+      },
+      "cache-insight": {
+        "id": "cache-insight",
+        "title": "Use efficient cache lifetimes",
+        "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more about caching](https://developer.chrome.com/docs/performance/insights/cache).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 510 KiB",
+        "metricSavings": {
+          "LCP": 450,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 522467.08333333337,
+            "type": "debugdata"
+          },
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [
+            {
+              "wastedBytes": 196192.875,
+              "totalBytes": 204723,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "totalBytes": 204723,
+              "wastedBytes": 196192.875
+            },
+            {
+              "totalBytes": 43670,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "wastedBytes": 41850.416666666672
+            },
+            {
+              "totalBytes": 29750,
+              "cacheLifetimeMs": 600000,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "wastedBytes": 27270.833333333332
+            },
+            {
+              "totalBytes": 27964,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "wastedBytes": 26798.833333333336
+            },
+            {
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "totalBytes": 27218,
+              "cacheLifetimeMs": 300000,
+              "wastedBytes": 26083.916666666668
+            },
+            {
+              "wastedBytes": 4598.9166666666661,
+              "totalBytes": 5017,
+              "cacheLifetimeMs": 600000,
+              "url": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "totalBytes": 1999,
+              "cacheLifetimeMs": 600000,
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "wastedBytes": 1832.4166666666665
+            },
+            {
+              "totalBytes": 1646,
+              "cacheLifetimeMs": 0,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "wastedBytes": 1646
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "Request",
+              "key": "url"
+            },
+            {
+              "valueType": "ms",
+              "displayUnit": "duration",
+              "label": "Cache TTL",
+              "key": "cacheLifetimeMs"
+            },
+            {
+              "key": "totalBytes",
+              "valueType": "bytes",
+              "granularity": 1,
+              "displayUnit": "kb",
+              "label": "Transfer Size"
+            }
+          ],
+          "type": "table",
+          "skipSumming": [
+            "cacheLifetimeMs"
+          ]
+        }
+      },
+      "non-composited-animations": {
+        "id": "non-composited-animations",
+        "title": "Avoid non-composited animations",
+        "description": "Animations which are not composited can be janky and increase CLS. [Learn how to avoid non-composited animations](https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/)",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "key": "node",
+              "label": "Element",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "failureReason"
+              },
+              "valueType": "node"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "script-treemap-data": {
+        "id": "script-treemap-data",
+        "title": "Script Treemap Data",
+        "description": "Used for treemap app",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "nodes": [
+            {
+              "resourceBytes": 17296,
+              "encodedBytes": 2902,
+              "children": [
+                {
+                  "name": "(inline) window.dataLaye…",
+                  "resourceBytes": 298,
+                  "unusedBytes": 0
+                },
+                {
+                  "name": "(inline) window.AGO = {\n…",
+                  "resourceBytes": 631,
+                  "unusedBytes": 0
+                },
+                {
+                  "resourceBytes": 592,
+                  "unusedBytes": 0,
+                  "name": "(inline) ((storageKey2, …"
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "resourceBytes": 520,
+                  "unusedBytes": 0
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "resourceBytes": 10054,
+                  "unusedBytes": 0
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "resourceBytes": 53,
+                  "unusedBytes": 0
+                },
+                {
+                  "name": "(inline) ;\nimport * as r…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 5148
+                }
+              ],
+              "name": "https://www.ocobo.co/fr"
+            },
+            {
+              "encodedBytes": 3946,
+              "resourceBytes": 9792,
+              "unusedBytes": 749,
+              "name": "https://www.ocobo.co/assets/root-HtXVBFii.js"
+            },
+            {
+              "resourceBytes": 125385,
+              "encodedBytes": 43325,
+              "unusedBytes": 72633,
+              "name": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 869,
+              "resourceBytes": 927,
+              "name": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js"
+            },
+            {
+              "encodedBytes": 1577,
+              "resourceBytes": 3192,
+              "unusedBytes": 1084,
+              "name": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "unusedBytes": 89,
+              "resourceBytes": 983,
+              "encodedBytes": 929
+            },
+            {
+              "name": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "encodedBytes": 69,
+              "resourceBytes": 141,
+              "unusedBytes": 6
+            },
+            {
+              "name": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "unusedBytes": 467,
+              "resourceBytes": 1284,
+              "encodedBytes": 685
+            },
+            {
+              "encodedBytes": 6234,
+              "resourceBytes": 15426,
+              "unusedBytes": 1144,
+              "name": "https://www.ocobo.co/assets/cx-DiffRdtV.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "unusedBytes": 1545,
+              "encodedBytes": 5639,
+              "resourceBytes": 17234
+            },
+            {
+              "name": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "unusedBytes": 1266,
+              "encodedBytes": 1254,
+              "resourceBytes": 3070
+            },
+            {
+              "name": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "encodedBytes": 382,
+              "resourceBytes": 428,
+              "unusedBytes": 239
+            },
+            {
+              "encodedBytes": 349,
+              "resourceBytes": 410,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js"
+            },
+            {
+              "encodedBytes": 450,
+              "resourceBytes": 525,
+              "unusedBytes": 65,
+              "name": "https://www.ocobo.co/assets/button-0H_j6y7x.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "encodedBytes": 882,
+              "resourceBytes": 942,
+              "unusedBytes": 362
+            },
+            {
+              "name": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "encodedBytes": 277,
+              "resourceBytes": 349,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 779,
+              "resourceBytes": 1866,
+              "name": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "resourceBytes": 348,
+              "encodedBytes": 289,
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 20674,
+              "resourceBytes": 67398,
+              "unusedBytes": 32058,
+              "name": "https://www.ocobo.co/assets/_main-9OzAywp_.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "encodedBytes": 108,
+              "resourceBytes": 165,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 160,
+              "resourceBytes": 206,
+              "name": "https://www.ocobo.co/assets/lang-PH2TSE5M.js"
+            },
+            {
+              "resourceBytes": 109016,
+              "encodedBytes": 33602,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/resources-NaHgTejN.js"
+            },
+            {
+              "encodedBytes": 543,
+              "resourceBytes": 605,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/layers-CQ3InJLS.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "unusedBytes": 0,
+              "encodedBytes": 764,
+              "resourceBytes": 826
+            },
+            {
+              "unusedBytes": 0,
+              "resourceBytes": 404,
+              "encodedBytes": 347,
+              "name": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js"
+            },
+            {
+              "encodedBytes": 428,
+              "resourceBytes": 490,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/users-Cf70nLSI.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "unusedBytes": 337,
+              "encodedBytes": 786,
+              "resourceBytes": 835
+            },
+            {
+              "unusedBytes": 47522,
+              "encodedBytes": 25822,
+              "resourceBytes": 68826,
+              "name": "https://www.ocobo.co/assets/portal-Clm-6X_X.js"
+            },
+            {
+              "encodedBytes": 44681,
+              "resourceBytes": 133936,
+              "unusedBytes": 31128,
+              "name": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "encodedBytes": 412,
+              "resourceBytes": 473,
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 292,
+              "resourceBytes": 338,
+              "name": "https://www.ocobo.co/assets/x-B1I3g_bH.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "unusedBytes": 0,
+              "encodedBytes": 378,
+              "resourceBytes": 435
+            },
+            {
+              "name": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "encodedBytes": 240,
+              "resourceBytes": 312,
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 263,
+              "resourceBytes": 309,
+              "unusedBytes": 194,
+              "name": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/_main.(_lang)._index-BJmsIfGa.js",
+              "unusedBytes": 158,
+              "encodedBytes": 6977,
+              "resourceBytes": 27349
+            },
+            {
+              "encodedBytes": 461,
+              "resourceBytes": 521,
+              "unusedBytes": 65,
+              "name": "https://www.ocobo.co/assets/section-CAd8zqOP.js"
+            },
+            {
+              "unusedBytes": 65,
+              "encodedBytes": 642,
+              "resourceBytes": 717,
+              "name": "https://www.ocobo.co/assets/text-DlkbtvSW.js"
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 502,
+              "resourceBytes": 549,
+              "name": "https://www.ocobo.co/assets/Container-AZtpvsXO.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/check-D95Zi0fi.js",
+              "encodedBytes": 255,
+              "resourceBytes": 303,
+              "unusedBytes": 0
+            },
+            {
+              "name": "https://www.ocobo.co/assets/hero-split-DCf1X66c.js",
+              "resourceBytes": 551,
+              "encodedBytes": 476,
+              "unusedBytes": 0
+            },
+            {
+              "name": "https://www.ocobo.co/assets/badge-i9dgPBIb.js",
+              "unusedBytes": 65,
+              "encodedBytes": 435,
+              "resourceBytes": 495
+            },
+            {
+              "encodedBytes": 556,
+              "resourceBytes": 605,
+              "unusedBytes": 65,
+              "name": "https://www.ocobo.co/assets/card-C2t40nZ4.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/plus-Bvz3jpuZ.js",
+              "unusedBytes": 0,
+              "encodedBytes": 263,
+              "resourceBytes": 337
+            },
+            {
+              "unusedBytes": 0,
+              "encodedBytes": 364,
+              "resourceBytes": 412,
+              "name": "https://www.ocobo.co/assets/panels-top-left-BeWfuLW7.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/zap-C3uzvT7-.js",
+              "resourceBytes": 446,
+              "encodedBytes": 385,
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 342,
+              "resourceBytes": 405,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/target-DyzL19b9.js"
+            },
+            {
+              "encodedBytes": 361,
+              "resourceBytes": 435,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/chart-column-CxnbmN-k.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/modular-stack-grid-DBlYkSNY.js",
+              "encodedBytes": 1196,
+              "resourceBytes": 3009,
+              "unusedBytes": 0
+            },
+            {
+              "name": "https://www.ocobo.co/assets/flex-pair-BLQ5DP05.js",
+              "encodedBytes": 493,
+              "resourceBytes": 568,
+              "unusedBytes": 0
+            },
+            {
+              "encodedBytes": 554,
+              "resourceBytes": 1208,
+              "unusedBytes": 4,
+              "name": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "encodedBytes": 23529,
+              "resourceBytes": 69550,
+              "unusedBytes": 28818
+            },
+            {
+              "encodedBytes": 4217,
+              "resourceBytes": 17494,
+              "unusedBytes": 12049,
+              "name": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "encodedBytes": 156442,
+              "resourceBytes": 471691,
+              "unusedBytes": 204200,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "unusedBytes": 0,
+              "encodedBytes": 579,
+              "resourceBytes": 2125
+            },
+            {
+              "unusedBytes": 6432,
+              "encodedBytes": 4688,
+              "resourceBytes": 12567,
+              "name": "https://www.ocobo.co/_vercel/speed-insights/script.js"
+            },
+            {
+              "resourceBytes": 2495,
+              "encodedBytes": 1227,
+              "unusedBytes": 682,
+              "name": "https://www.ocobo.co/_vercel/insights/script.js"
+            },
+            {
+              "encodedBytes": 26371,
+              "resourceBytes": 78059,
+              "unusedBytes": 35974,
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            },
+            {
+              "encodedBytes": 27531,
+              "resourceBytes": 97992,
+              "unusedBytes": 56996,
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            },
+            {
+              "encodedBytes": 25121,
+              "resourceBytes": 72608,
+              "unusedBytes": 36142,
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+            },
+            {
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "unusedBytes": 46367,
+              "encodedBytes": 42582,
+              "resourceBytes": 108995
+            },
+            {
+              "unusedBytes": 335744,
+              "encodedBytes": 156442,
+              "resourceBytes": 471691,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "encodedBytes": 579,
+              "resourceBytes": 2125,
+              "unusedBytes": 0,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js"
+            },
+            {
+              "encodedBytes": 4217,
+              "resourceBytes": 17494,
+              "name": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "unusedBytes": 337253,
+              "encodedBytes": 202942,
+              "resourceBytes": 587832
+            },
+            {
+              "encodedBytes": 202942,
+              "resourceBytes": 587832,
+              "unusedBytes": 248156,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            }
+          ],
+          "type": "treemap-data"
+        }
+      },
+      "cls-culprits-insight": {
+        "id": "cls-culprits-insight",
+        "title": "Layout shift culprits",
+        "description": "Layout shifts occur when elements move absent any user interaction. [Investigate the causes of layout shifts](https://developer.chrome.com/docs/performance/insights/cls-culprit), such as elements being added, removed, or their fonts changing as the page loads.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [
+            {
+              "items": [
+                {
+                  "score": 0.009571,
+                  "node": {
+                    "type": "text",
+                    "value": "Total"
+                  }
+                },
+                {
+                  "score": 0.009571,
+                  "node": {
+                    "type": "node",
+                    "lhId": "page-18-DIV",
+                    "nodeLabel": "header.pt_8 \u003e div.mx_auto \u003e div.d_flex \u003e div.flex_1",
+                    "boundingRect": {
+                      "width": 380,
+                      "bottom": 1100,
+                      "height": 380,
+                      "left": 16,
+                      "top": 720,
+                      "right": 396
+                    },
+                    "selector": "header.pt_8 \u003e div.mx_auto \u003e div.d_flex \u003e div.flex_1",
+                    "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,HEADER,0,DIV,0,DIV,1,DIV",
+                    "snippet": "\u003cdiv class=\"flex_1 d_flex ai_center jc_center lg:jc_flex-end\"\u003e"
+                  },
+                  "subItems": {
+                    "type": "subitems",
+                    "items": [
+                      {
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+                          "type": "url"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "key": "node",
+                  "label": "Element",
+                  "valueType": "node"
+                },
+                {
+                  "granularity": 0.001,
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  },
+                  "label": "Layout shift score",
+                  "valueType": "numeric",
+                  "key": "score"
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "items": [
+                {
+                  "score": 0,
+                  "node": {
+                    "type": "text",
+                    "value": "Total"
+                  }
+                },
+                {
+                  "score": 0,
+                  "node": {
+                    "nodeLabel": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "type": "node",
+                    "lhId": "page-0-INPUT",
+                    "snippet": "\u003cinput type=\"submit\" class=\"hs-button primary large\" value=\"S'inscrire\"\u003e",
+                    "boundingRect": {
+                      "bottom": 117,
+                      "height": 38,
+                      "top": 79,
+                      "left": 270,
+                      "right": 380,
+                      "width": 110
+                    },
+                    "selector": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "path": "0,HTML,1,BODY,1,DIV,0,FORM,1,DIV,1,DIV,0,INPUT"
+                  },
+                  "subItems": {
+                    "type": "subitems",
+                    "items": [
+                      {
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        },
+                        "cause": "Web font"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "valueType": "node",
+                  "label": "Element",
+                  "key": "node",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  }
+                },
+                {
+                  "key": "score",
+                  "valueType": "numeric",
+                  "granularity": 0.001,
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  },
+                  "label": "Layout shift score"
+                }
+              ],
+              "type": "table"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "redirects": {
+        "id": "redirects",
+        "title": "Avoid multiple page redirects",
+        "description": "Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://developer.chrome.com/docs/lighthouse/performance/redirects/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 750 ms",
+        "metricSavings": {
+          "LCP": 750,
+          "FCP": 750
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "label": "Time Spent",
+              "key": "wastedMs",
+              "valueType": "timespanMs"
+            }
+          ],
+          "type": "opportunity",
+          "items": [
+            {
+              "url": "https://www.ocobo.co/",
+              "wastedMs": 754.67991725642173
+            },
+            {
+              "wastedMs": 0,
+              "url": "https://www.ocobo.co/fr"
+            }
+          ],
+          "overallSavingsMs": 754.67991725642173
+        },
+        "numericValue": 754.67991725642173,
+        "numericUnit": "millisecond"
+      },
+      "user-timings": {
+        "id": "user-timings",
+        "title": "User Timing marks and measures",
+        "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more about User Timing marks](https://developer.chrome.com/docs/lighthouse/performance/user-timings/).",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "valueType": "text",
+              "label": "Name",
+              "key": "name"
+            },
+            {
+              "valueType": "text",
+              "key": "timingType",
+              "label": "Type"
+            },
+            {
+              "valueType": "ms",
+              "label": "Start Time",
+              "key": "startTime",
+              "granularity": 0.01
+            },
+            {
+              "label": "Duration",
+              "key": "duration",
+              "granularity": 0.01,
+              "valueType": "ms"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "document-latency-insight": {
+        "id": "document-latency-insight",
+        "title": "Document request latency",
+        "description": "Your first network request is the most important. [Reduce its latency](https://developer.chrome.com/docs/performance/insights/document-latency) by avoiding redirects, ensuring a fast server response, and enabling text compression.",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 1,310 ms",
+        "metricSavings": {
+          "LCP": 1300,
+          "FCP": 1300
+        },
+        "details": {
+          "items": {
+            "serverResponseIsFast": {
+              "label": "Server responds quickly (observed 41 ms)",
+              "value": true
+            },
+            "noRedirects": {
+              "value": false,
+              "label": "Had redirects (1 redirects, +1308 ms)"
+            },
+            "usesCompression": {
+              "value": true,
+              "label": "Applies text compression"
+            }
+          },
+          "type": "checklist",
+          "debugData": {
+            "uncompressedResponseBytes": 0,
+            "type": "debugdata",
+            "wastedBytes": 0,
+            "serverResponseTime": 41,
+            "redirectDuration": 1308
+          }
+        }
+      },
+      "first-contentful-paint": {
+        "id": "first-contentful-paint",
+        "title": "First Contentful Paint",
+        "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).",
+        "score": 0.16,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "4.4 s",
+        "numericValue": 4436.1192553077954,
+        "numericUnit": "millisecond"
+      },
+      "mainthread-work-breakdown": {
+        "id": "mainthread-work-breakdown",
+        "title": "Minimize main-thread work",
+        "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to minimize main-thread work](https://developer.chrome.com/docs/lighthouse/performance/mainthread-work-breakdown/)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "4.5 s",
+        "metricSavings": {
+          "TBT": 900
+        },
+        "details": {
+          "sortedBy": [
+            "duration"
+          ],
+          "type": "table",
+          "items": [
+            {
+              "group": "scriptEvaluation",
+              "duration": 1801.7759999999855,
+              "groupLabel": "Script Evaluation"
+            },
+            {
+              "duration": 1026.1116000000002,
+              "groupLabel": "Style & Layout",
+              "group": "styleLayout"
+            },
+            {
+              "groupLabel": "Other",
+              "duration": 691.43520000000024,
+              "group": "other"
+            },
+            {
+              "duration": 555.3432,
+              "groupLabel": "Script Parsing & Compilation",
+              "group": "scriptParseCompile"
+            },
+            {
+              "groupLabel": "Rendering",
+              "duration": 298.16759999999971,
+              "group": "paintCompositeRender"
+            },
+            {
+              "groupLabel": "Parse HTML & CSS",
+              "duration": 56.857200000000056,
+              "group": "parseHTML"
+            },
+            {
+              "group": "garbageCollection",
+              "groupLabel": "Garbage Collection",
+              "duration": 55.640400000000007
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "label": "Category",
+              "key": "groupLabel"
+            },
+            {
+              "label": "Time Spent",
+              "key": "duration",
+              "granularity": 1,
+              "valueType": "ms"
+            }
+          ]
+        },
+        "numericValue": 4485.331199999986,
+        "numericUnit": "millisecond"
+      },
+      "forced-reflow-insight": {
+        "id": "forced-reflow-insight",
+        "title": "Forced reflow",
+        "description": "A forced reflow occurs when JavaScript queries geometric properties (such as offsetWidth) after styles have been invalidated by a change to the DOM state. This can result in poor performance. Learn more about [forced reflows](https://developer.chrome.com/docs/performance/insights/forced-reflow) and possible mitigations.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "details": {
+          "items": [
+            {
+              "items": [
+                {
+                  "source": {
+                    "column": 61324,
+                    "type": "source-location",
+                    "urlProvider": "network",
+                    "line": 16,
+                    "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js"
+                  },
+                  "reflowTime": 40.592
+                }
+              ],
+              "headings": [
+                {
+                  "label": "Top function call",
+                  "key": "source",
+                  "valueType": "source-location"
+                },
+                {
+                  "valueType": "ms",
+                  "granularity": 1,
+                  "key": "reflowTime",
+                  "label": "Total reflow time"
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "items": [
+                {
+                  "reflowTime": 244.497,
+                  "source": {
+                    "type": "text",
+                    "value": "[unattributed]"
+                  }
+                },
+                {
+                  "source": {
+                    "column": 61343,
+                    "type": "source-location",
+                    "urlProvider": "network",
+                    "line": 15,
+                    "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js"
+                  },
+                  "reflowTime": 40.592
+                },
+                {
+                  "reflowTime": 0.854,
+                  "source": {
+                    "type": "source-location",
+                    "column": 85503,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+                    "line": 19,
+                    "urlProvider": "network"
+                  }
+                }
+              ],
+              "headings": [
+                {
+                  "label": "Source",
+                  "key": "source",
+                  "valueType": "source-location"
+                },
+                {
+                  "valueType": "ms",
+                  "label": "Total reflow time",
+                  "key": "reflowTime",
+                  "granularity": 1
+                }
+              ],
+              "type": "table"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "image-delivery-insight": {
+        "id": "image-delivery-insight",
+        "title": "Improve image delivery",
+        "description": "Reducing the download time of images can improve the perceived load time of the page and LCP. [Learn more about optimizing image size](https://developer.chrome.com/docs/performance/insights/image-delivery)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 453 KiB",
+        "metricSavings": {
+          "LCP": 600,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 195765,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 216338,
+                    "reason": "This image file is larger than it needs to be (438x438) for its displayed dimensions (98x98). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 226138,
+              "node": {
+                "lhId": "page-0-IMG",
+                "type": "node",
+                "nodeLabel": "Louis Vannereau",
+                "selector": "div.d_flex \u003e div.d_flex \u003e div.text \u003e img.w_full",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,2,DIV,1,DIV,2,DIV,0,DIV,0,DIV,0,IMG",
+                "boundingRect": {
+                  "bottom": 2085,
+                  "height": 59,
+                  "top": 2026,
+                  "left": 48,
+                  "right": 106,
+                  "width": 59
+                },
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vi…\" alt=\"Louis Vannereau\" class=\"w_full h_full obj-f_cover\"\u003e"
+              },
+              "totalBytes": 227739,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vizzia-avatar.png"
+            },
+            {
+              "totalBytes": 59662,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png",
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cy…\" alt=\"CybelAngel\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "right": 6573,
+                  "left": 6439,
+                  "top": 1466,
+                  "height": 32,
+                  "bottom": 1498,
+                  "width": 134
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,41,DIV,0,IMG",
+                "nodeLabel": "CybelAngel",
+                "type": "node",
+                "lhId": "page-1-IMG"
+              },
+              "wastedBytes": 59534,
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 59534,
+                    "reason": "This image file is larger than it needs to be (5064x1211) for its displayed dimensions (234x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "node": {
+                "boundingRect": {
+                  "width": 96,
+                  "right": 7229,
+                  "bottom": 1498,
+                  "height": 32,
+                  "top": 1466,
+                  "left": 7133
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,45,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yo…\" alt=\"Yousign\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "type": "node",
+                "lhId": "page-2-IMG",
+                "nodeLabel": "Yousign"
+              },
+              "wastedBytes": 27609,
+              "totalBytes": 28606,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yousign-white.png",
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 27609,
+                    "reason": "This image file is larger than it needs to be (900x300) for its displayed dimensions (168x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 21796,
+                    "reason": "This image file is larger than it needs to be (1102x436) for its displayed dimensions (142x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "node": {
+                "lhId": "page-3-IMG",
+                "type": "node",
+                "nodeLabel": "Jus Mundi",
+                "boundingRect": {
+                  "width": 81,
+                  "right": 6201,
+                  "left": 6120,
+                  "top": 1466,
+                  "bottom": 1498,
+                  "height": 32
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,39,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ju…\" alt=\"Jus Mundi\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e"
+              },
+              "wastedBytes": 21796,
+              "totalBytes": 22161,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png"
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size.",
+                    "wastedBytes": 4229
+                  },
+                  {
+                    "wastedBytes": 16635,
+                    "reason": "This image file is larger than it needs to be (400x206) for its displayed dimensions (109x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "node": {
+                "nodeLabel": "Wecandoo",
+                "type": "node",
+                "lhId": "page-4-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/we…\" alt=\"Wecandoo\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "width": 62,
+                  "height": 32,
+                  "bottom": 1498,
+                  "left": 7484,
+                  "top": 1466,
+                  "right": 7546
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,47,DIV,0,IMG"
+              },
+              "wastedBytes": 16948,
+              "totalBytes": 17962,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/wecandoo-white.png"
+            },
+            {
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 10523,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 15421,
+                    "reason": "This image file is larger than it needs to be (192x192) for its displayed dimensions (53x53). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "node": {
+                "snippet": "\u003cimg src=\"https://www.ocobo.co/android-chrome-192x192.png\" alt=\"Chat\" id=\"open-path\" style=\"width: 32px; height: 32px; object-fit: contain;\"\u003e",
+                "path": "1,HTML,1,BODY,12,DIV,1,BUTTON,0,IMG",
+                "boundingRect": {
+                  "right": 389,
+                  "left": 359,
+                  "top": 776,
+                  "height": 32,
+                  "bottom": 808,
+                  "width": 30
+                },
+                "selector": "body \u003e div#ago-wrapper \u003e button#ago-chat-button \u003e img#open-path",
+                "nodeLabel": "Chat",
+                "lhId": "page-5-IMG",
+                "type": "node"
+              },
+              "wastedBytes": 16208,
+              "totalBytes": 16667,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png"
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 13185,
+                    "reason": "This image file is larger than it needs to be (1536x497) for its displayed dimensions (173x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 13185,
+              "node": {
+                "nodeLabel": "Combo",
+                "type": "node",
+                "lhId": "page-6-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/co…\" alt=\"Combo\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "right": 5697,
+                  "left": 5598,
+                  "top": 1466,
+                  "height": 32,
+                  "bottom": 1498,
+                  "width": 99
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,36,DIV,0,IMG"
+              },
+              "totalBytes": 13354,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png"
+            },
+            {
+              "node": {
+                "nodeLabel": "ekodev",
+                "lhId": "page-7-IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ek…\" alt=\"ekodev\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "width": 90,
+                  "right": 5339,
+                  "height": 32,
+                  "bottom": 1498,
+                  "top": 1466,
+                  "left": 5250
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,34,DIV,0,IMG"
+              },
+              "wastedBytes": 9860,
+              "totalBytes": 11321,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png",
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 9586,
+                    "reason": "This image file is larger than it needs to be (400x143) for its displayed dimensions (157x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "node": {
+                "nodeLabel": "Ocobo",
+                "lhId": "page-8-IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "boundingRect": {
+                  "left": 33,
+                  "top": 37,
+                  "height": 40,
+                  "bottom": 77,
+                  "right": 167,
+                  "width": 134
+                },
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "path": "1,HTML,1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG"
+              },
+              "wastedBytes": 9533,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "totalBytes": 12266,
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 6234,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 6709,
+                    "reason": "This image file is larger than it needs to be (348x104) for its displayed dimensions (234x70). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 9455,
+                    "reason": "This image file is larger than it needs to be (400x158) for its displayed dimensions (142x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "totalBytes": 10812,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qobra-white.png",
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qo…\" alt=\"Qobra\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "width": 81,
+                  "left": 5777,
+                  "top": 1466,
+                  "height": 32,
+                  "bottom": 1498,
+                  "right": 5858
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,37,DIV,0,IMG",
+                "nodeLabel": "Qobra",
+                "lhId": "page-9-IMG",
+                "type": "node"
+              },
+              "wastedBytes": 9490
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 8696,
+                    "reason": "This image file is larger than it needs to be (600x194) for its displayed dimensions (173x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vibe-co-white.png",
+              "totalBytes": 9486,
+              "wastedBytes": 8696,
+              "node": {
+                "boundingRect": {
+                  "width": 99,
+                  "top": 1466,
+                  "left": 5418,
+                  "bottom": 1498,
+                  "height": 32,
+                  "right": 5517
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,35,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vi…\" alt=\"Vibe.co\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "lhId": "page-10-IMG",
+                "type": "node",
+                "nodeLabel": "Vibe.co"
+              }
+            },
+            {
+              "wastedBytes": 8658,
+              "node": {
+                "type": "node",
+                "lhId": "page-11-IMG",
+                "nodeLabel": "Resilience Care",
+                "boundingRect": {
+                  "width": 101,
+                  "right": 6038,
+                  "height": 32,
+                  "bottom": 1498,
+                  "left": 5937,
+                  "top": 1466
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,38,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/re…\" alt=\"Resilience Care\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e"
+              },
+              "totalBytes": 10304,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/resilience-white.png",
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 8061,
+                    "reason": "This image file is larger than it needs to be (378x120) for its displayed dimensions (176x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 7282,
+                    "reason": "This image file is larger than it needs to be (360x120) for its displayed dimensions (168x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/citron-white.png",
+              "totalBytes": 9310,
+              "node": {
+                "nodeLabel": "Citron",
+                "lhId": "page-12-IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ci…\" alt=\"Citron\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "width": 96,
+                  "right": 7402,
+                  "height": 32,
+                  "bottom": 1498,
+                  "left": 7306,
+                  "top": 1466
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,46,DIV,0,IMG"
+              },
+              "wastedBytes": 7742
+            },
+            {
+              "wastedBytes": 7665,
+              "node": {
+                "boundingRect": {
+                  "width": 101,
+                  "height": 32,
+                  "bottom": 1498,
+                  "top": 1466,
+                  "left": 6650,
+                  "right": 6750
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,42,DIV,0,IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qo…\" alt=\"Qonto\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "type": "node",
+                "lhId": "page-13-IMG",
+                "nodeLabel": "Qonto"
+              },
+              "totalBytes": 9311,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qonto-white.png",
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 7284,
+                    "reason": "This image file is larger than it needs to be (378x120) for its displayed dimensions (176x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "totalBytes": 9049,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/tomorro-white.png",
+              "wastedBytes": 7481,
+              "node": {
+                "nodeLabel": "Tomorro",
+                "type": "node",
+                "lhId": "page-14-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/to…\" alt=\"Tomorro\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "height": 32,
+                  "bottom": 1498,
+                  "top": 1466,
+                  "left": 6830,
+                  "right": 6926,
+                  "width": 96
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,43,DIV,0,IMG"
+              },
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 7078,
+                    "reason": "This image file is larger than it needs to be (360x120) for its displayed dimensions (168x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "wastedBytes": 7299,
+              "node": {
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/st…\" alt=\"Steeple\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "left": 5067,
+                  "top": 1466,
+                  "bottom": 1498,
+                  "height": 32,
+                  "right": 5167,
+                  "width": 101
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,33,DIV,0,IMG",
+                "nodeLabel": "Steeple",
+                "type": "node",
+                "lhId": "page-15-IMG"
+              },
+              "totalBytes": 8945,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/steeple-white.png",
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 6998,
+                    "reason": "This image file is larger than it needs to be (378x120) for its displayed dimensions (176x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            },
+            {
+              "node": {
+                "nodeLabel": "Qare",
+                "type": "node",
+                "lhId": "page-16-IMG",
+                "snippet": "\u003cimg src=\"https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qa…\" alt=\"Qare\" loading=\"lazy\" decoding=\"async\" class=\"h_8 w_auto obj-f_contain op_0.4 trs_opacity trs-dur_300ms cursor_default u…\"\u003e",
+                "boundingRect": {
+                  "width": 78,
+                  "right": 6355,
+                  "left": 6277,
+                  "top": 1466,
+                  "bottom": 1498,
+                  "height": 32
+                },
+                "selector": "div.pos_relative \u003e div.d_flex \u003e div.d_flex \u003e img.h_8",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,1,SECTION,2,DIV,1,DIV,0,DIV,2,DIV,40,DIV,0,IMG"
+              },
+              "wastedBytes": 5738,
+              "totalBytes": 7009,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qare-white.png",
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 5483,
+                    "reason": "This image file is larger than it needs to be (292x120) for its displayed dimensions (136x56). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              }
+            }
+          ],
+          "headings": [
+            {
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "valueType": "url",
+              "subItemsHeading": {
+                "key": "reason",
+                "valueType": "text"
+              },
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "valueType": "bytes",
+              "label": "Resource Size",
+              "key": "totalBytes"
+            },
+            {
+              "subItemsHeading": {
+                "valueType": "bytes",
+                "key": "wastedBytes"
+              },
+              "label": "Est Savings",
+              "key": "wastedBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 463580,
+            "type": "debugdata"
+          }
+        }
+      },
+      "long-tasks": {
+        "id": "long-tasks",
+        "title": "Avoid long main-thread tasks",
+        "description": "Lists the longest tasks on the main thread, useful for identifying worst contributors to input delay. [Learn how to avoid long main-thread tasks](https://web.dev/articles/optimize-long-tasks)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "11 long tasks found",
+        "metricSavings": {
+          "TBT": 900
+        },
+        "details": {
+          "items": [
+            {
+              "startTime": 14226.494569612702,
+              "duration": 296,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "startTime": 7890.8642989650089,
+              "duration": 251,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "startTime": 6837.7454806753767,
+              "duration": 211
+            },
+            {
+              "duration": 167,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "startTime": 9631.1427743774566
+            },
+            {
+              "startTime": 7580.8642989650089,
+              "duration": 162,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "startTime": 9361.1427743774566,
+              "duration": 149,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "startTime": 1121.1331954273696,
+              "duration": 125,
+              "url": "https://www.ocobo.co/fr"
+            },
+            {
+              "startTime": 9510.1427743774566,
+              "duration": 107,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "startTime": 7826.8642989650089,
+              "duration": 64,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "startTime": 1385.1331954273696,
+              "duration": 59,
+              "url": "https://www.ocobo.co/fr"
+            },
+            {
+              "startTime": 14528.494569612702,
+              "duration": 57,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "key": "startTime",
+              "label": "Start Time",
+              "granularity": 1,
+              "valueType": "ms"
+            },
+            {
+              "granularity": 1,
+              "label": "Duration",
+              "key": "duration",
+              "valueType": "ms"
+            }
+          ],
+          "type": "table",
+          "skipSumming": [
+            "startTime"
+          ],
+          "sortedBy": [
+            "duration"
+          ],
+          "debugData": {
+            "urls": [
+              "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "https://www.ocobo.co/fr"
+            ],
+            "tasks": [
+              {
+                "other": 296,
+                "duration": 296,
+                "startTime": 14226.5,
+                "scriptEvaluation": 0,
+                "urlIndex": 0
+              },
+              {
+                "other": 251,
+                "urlIndex": 1,
+                "duration": 251,
+                "startTime": 7890.9
+              },
+              {
+                "other": 211,
+                "scriptEvaluation": 0,
+                "urlIndex": 0,
+                "duration": 211,
+                "startTime": 6837.7
+              },
+              {
+                "urlIndex": 2,
+                "scriptEvaluation": 0,
+                "duration": 167,
+                "startTime": 9631.1,
+                "other": 167
+              },
+              {
+                "duration": 162,
+                "startTime": 7580.9,
+                "scriptEvaluation": 0,
+                "urlIndex": 1,
+                "other": 162
+              },
+              {
+                "other": 149,
+                "scriptEvaluation": 0,
+                "urlIndex": 2,
+                "duration": 149,
+                "startTime": 9361.1
+              },
+              {
+                "duration": 125,
+                "startTime": 1121.1,
+                "urlIndex": 3,
+                "scriptEvaluation": 0,
+                "other": 125,
+                "styleLayout": 0,
+                "paintCompositeRender": 0
+              },
+              {
+                "urlIndex": 2,
+                "scriptEvaluation": 0,
+                "duration": 107,
+                "startTime": 9510.1,
+                "other": 107
+              },
+              {
+                "duration": 64,
+                "startTime": 7826.9,
+                "urlIndex": 1,
+                "other": 64
+              },
+              {
+                "styleLayout": 0,
+                "other": 59,
+                "urlIndex": 3,
+                "startTime": 1385.1,
+                "duration": 59,
+                "paintCompositeRender": 0
+              },
+              {
+                "urlIndex": 0,
+                "duration": 57,
+                "startTime": 14528.5,
+                "other": 57
+              }
+            ],
+            "type": "debugdata"
+          }
+        }
+      },
+      "server-response-time": {
+        "id": "server-response-time",
+        "title": "Initial server response time was short",
+        "description": "Keep the server response time for the main document short because all other requests depend on it. [Learn more about the Time to First Byte metric](https://developer.chrome.com/docs/lighthouse/performance/time-to-first-byte/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Root document took 40 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 0,
+          "items": [
+            {
+              "responseTime": 41,
+              "url": "https://www.ocobo.co/fr"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "key": "responseTime",
+              "label": "Time Spent",
+              "valueType": "timespanMs"
+            }
+          ],
+          "type": "opportunity"
+        },
+        "numericValue": 41,
+        "numericUnit": "millisecond"
+      },
+      "network-requests": {
+        "id": "network-requests",
+        "title": "Network Requests",
+        "description": "Lists the network requests that were made during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "mimeType": "text/plain",
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/",
+              "transferSize": 370,
+              "networkRequestTime": 3.2710000015795231,
+              "finished": true,
+              "protocol": "http/1.1",
+              "experimentalFromMainFrame": true,
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "networkEndTime": 1308.1689999997616,
+              "statusCode": 301,
+              "rendererStartTime": 0,
+              "resourceSize": 0
+            },
+            {
+              "finished": true,
+              "entity": "ocobo.co",
+              "mimeType": "text/html",
+              "networkRequestTime": 1309.1039999984205,
+              "url": "https://www.ocobo.co/fr",
+              "transferSize": 20686,
+              "networkEndTime": 2577.910000000149,
+              "sessionTargetType": "page",
+              "rendererStartTime": 1308.1689999997616,
+              "statusCode": 200,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "VeryHigh",
+              "resourceType": "Document",
+              "resourceSize": 120704
+            },
+            {
+              "priority": "VeryHigh",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 2603.3379999995232,
+              "statusCode": 200,
+              "networkEndTime": 2683.3640000000596,
+              "sessionTargetType": "page",
+              "networkRequestTime": 2605.1369999982417,
+              "transferSize": 24571,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "mimeType": "text/css",
+              "entity": "ocobo.co",
+              "finished": true,
+              "resourceSize": 122090,
+              "resourceType": "Stylesheet"
+            },
+            {
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "statusCode": 200,
+              "rendererStartTime": 2604.007999997586,
+              "sessionTargetType": "page",
+              "networkEndTime": 2806.5969999991357,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "transferSize": 12757,
+              "networkRequestTime": 2605.320000000298,
+              "entity": "ocobo.co",
+              "mimeType": "image/png",
+              "finished": true,
+              "resourceSize": 12266,
+              "resourceType": "Image"
+            },
+            {
+              "resourceType": "Image",
+              "resourceSize": 29045,
+              "finished": true,
+              "mimeType": "image/png",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2605.4350000023842,
+              "url": "https://www.ocobo.co/images/partners/modern-revenue-club.png",
+              "transferSize": 29545,
+              "networkEndTime": 2865.472999997437,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2604.3519999980927,
+              "statusCode": 200,
+              "priority": "Medium",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "resourceType": "Image",
+              "resourceSize": 227739,
+              "finished": true,
+              "networkRequestTime": 2705.785000000149,
+              "transferSize": 228410,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vizzia-avatar.png",
+              "entity": "vercel-storage.com",
+              "mimeType": "image/png",
+              "rendererStartTime": 2604.6309999972582,
+              "statusCode": 200,
+              "networkEndTime": 2870.1809999980032,
+              "sessionTargetType": "page",
+              "priority": "Medium",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2"
+            },
+            {
+              "url": "https://www.ocobo.co/images/partners/hubspot.png",
+              "transferSize": 37618,
+              "networkRequestTime": 2706.0879999995232,
+              "mimeType": "image/png",
+              "entity": "ocobo.co",
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "statusCode": 200,
+              "rendererStartTime": 2604.8569999970496,
+              "sessionTargetType": "page",
+              "networkEndTime": 3156.0610000006855,
+              "resourceSize": 37130,
+              "resourceType": "Image"
+            },
+            {
+              "networkRequestTime": 2706.3159999996424,
+              "url": "https://www.ocobo.co/images/partners/clay.png",
+              "transferSize": 50337,
+              "entity": "ocobo.co",
+              "mimeType": "image/png",
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "rendererStartTime": 2605.1620000004768,
+              "statusCode": 200,
+              "networkEndTime": 2918.15700000152,
+              "sessionTargetType": "page",
+              "resourceSize": 49852,
+              "resourceType": "Image"
+            },
+            {
+              "finished": true,
+              "entity": "ocobo.co",
+              "mimeType": "image/png",
+              "transferSize": 19377,
+              "url": "https://www.ocobo.co/images/partners/salesforce.png",
+              "networkRequestTime": 2706.410000000149,
+              "sessionTargetType": "page",
+              "networkEndTime": 2947.9890000000596,
+              "statusCode": 200,
+              "rendererStartTime": 2605.4230000004172,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "Low",
+              "resourceType": "Image",
+              "resourceSize": 18886
+            },
+            {
+              "resourceType": "Image",
+              "resourceSize": 11406,
+              "sessionTargetType": "page",
+              "networkEndTime": 2899.39999999851,
+              "statusCode": 200,
+              "rendererStartTime": 2605.69299999997,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "finished": true,
+              "mimeType": "image/png",
+              "entity": "ocobo.co",
+              "transferSize": 11893,
+              "url": "https://www.ocobo.co/images/partners/notion.png",
+              "networkRequestTime": 2706.5269999988377
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 2866.7870000004768,
+              "statusCode": 200,
+              "rendererStartTime": 2605.9749999977648,
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "ocobo.co",
+              "mimeType": "image/webp",
+              "transferSize": 25724,
+              "url": "https://www.ocobo.co/images/partners/vasco.webp",
+              "networkRequestTime": 2706.6420000009239,
+              "resourceType": "Image",
+              "resourceSize": 25236
+            },
+            {
+              "resourceSize": 95311,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "statusCode": 200,
+              "rendererStartTime": 2606.14999999851,
+              "sessionTargetType": "page",
+              "networkEndTime": 2935.4749999977648,
+              "transferSize": 95799,
+              "url": "https://www.ocobo.co/images/partners/aircall.png",
+              "networkRequestTime": 2707.3339999988675,
+              "mimeType": "image/png",
+              "entity": "ocobo.co",
+              "finished": true
+            },
+            {
+              "finished": true,
+              "mimeType": "image/png",
+              "entity": "ocobo.co",
+              "transferSize": 2958,
+              "url": "https://www.ocobo.co/images/partners/qobra.png",
+              "networkRequestTime": 2707.484999999404,
+              "sessionTargetType": "page",
+              "networkEndTime": 2954.9959999993443,
+              "statusCode": 200,
+              "rendererStartTime": 2606.362999998033,
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "resourceType": "Image",
+              "resourceSize": 2473
+            },
+            {
+              "resourceSize": 3071,
+              "resourceType": "Image",
+              "entity": "ocobo.co",
+              "mimeType": "image/jpeg",
+              "transferSize": 3558,
+              "url": "https://www.ocobo.co/images/partners/modjo.jpeg",
+              "networkRequestTime": 2707.5980000011623,
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "networkEndTime": 2918.9189999997616,
+              "statusCode": 200,
+              "rendererStartTime": 2606.5999999977648
+            },
+            {
+              "resourceSize": 12757,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "rendererStartTime": 2606.7829999998212,
+              "statusCode": 200,
+              "networkEndTime": 2900.02499999851,
+              "sessionTargetType": "page",
+              "networkRequestTime": 2707.902999997139,
+              "url": "https://www.ocobo.co/images/partners/planhat.png",
+              "transferSize": 13245,
+              "entity": "ocobo.co",
+              "mimeType": "image/png",
+              "finished": true
+            },
+            {
+              "entity": "ocobo.co",
+              "mimeType": "image/png",
+              "networkRequestTime": 2708.1889999993145,
+              "url": "https://www.ocobo.co/images/partners/dust.png",
+              "transferSize": 9441,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "networkEndTime": 2903.7120000012219,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2606.9749999977648,
+              "statusCode": 200,
+              "resourceSize": 8957,
+              "resourceType": "Image"
+            },
+            {
+              "statusCode": 200,
+              "rendererStartTime": 2607.1550000011921,
+              "sessionTargetType": "page",
+              "networkEndTime": 2891.202999997884,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "Low",
+              "finished": true,
+              "transferSize": 19683,
+              "url": "https://www.ocobo.co/images/partners/hyperline.png",
+              "networkRequestTime": 2708.297000002116,
+              "mimeType": "image/png",
+              "entity": "ocobo.co",
+              "resourceType": "Image",
+              "resourceSize": 19193
+            },
+            {
+              "mimeType": "image/webp",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2708.4230000004172,
+              "transferSize": 3291,
+              "url": "https://www.ocobo.co/images/partners/lemlist.webp",
+              "finished": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2932.5509999990463,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2607.3509999997914,
+              "statusCode": 200,
+              "resourceSize": 2802,
+              "resourceType": "Image"
+            },
+            {
+              "resourceType": "Script",
+              "resourceSize": 471691,
+              "rendererStartTime": 2607.6240000016987,
+              "statusCode": 200,
+              "networkEndTime": 2756.7939999997616,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "finished": true,
+              "networkRequestTime": 2708.5039999969304,
+              "transferSize": 157129,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "entity": "Google Tag Manager",
+              "mimeType": "application/javascript"
+            },
+            {
+              "resourceSize": 0,
+              "resourceType": "Script",
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkEndTime": 2981.2180000022054,
+              "statusCode": 404,
+              "rendererStartTime": 2607.812999997288,
+              "mimeType": "application/javascript",
+              "entity": "Clearbit",
+              "transferSize": 639,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "networkRequestTime": 2708.6790000014007,
+              "finished": true
+            },
+            {
+              "resourceType": "Script",
+              "resourceSize": 2125,
+              "statusCode": 200,
+              "rendererStartTime": 2608.0419999994338,
+              "sessionTargetType": "page",
+              "networkEndTime": 2875.7540000006557,
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "transferSize": 1646,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "networkRequestTime": 2709.237999998033,
+              "mimeType": "application/javascript",
+              "entity": "Hubspot"
+            },
+            {
+              "resourceSize": 17494,
+              "resourceType": "Script",
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "rendererStartTime": 2608.1789999976754,
+              "statusCode": 200,
+              "networkEndTime": 2733.0169999971986,
+              "sessionTargetType": "page",
+              "networkRequestTime": 2709.4890000000596,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "transferSize": 5017,
+              "entity": "GitHub",
+              "mimeType": "application/javascript",
+              "finished": true
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 2680.394999999553,
+              "statusCode": 200,
+              "rendererStartTime": 2608.3589999973774,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "transferSize": 24116,
+              "url": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "networkRequestTime": 2609.9719999991357,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 69556
+            },
+            {
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 927,
+              "finished": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "networkRequestTime": 2610.4000000022352,
+              "transferSize": 1456,
+              "url": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "networkEndTime": 2664.7799999974668,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2608.6150000020862,
+              "statusCode": 200,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High"
+            },
+            {
+              "rendererStartTime": 2608.7870000004768,
+              "statusCode": 200,
+              "networkEndTime": 2679.5800000019372,
+              "sessionTargetType": "page",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "networkRequestTime": 2610.7280000001192,
+              "transferSize": 43926,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 125397
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "High",
+              "rendererStartTime": 2609.0280000008643,
+              "statusCode": 200,
+              "networkEndTime": 2697.6330000013113,
+              "sessionTargetType": "page",
+              "networkRequestTime": 2611.3990000002086,
+              "transferSize": 45262,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "finished": true,
+              "resourceSize": 133936,
+              "isLinkPreload": true,
+              "resourceType": "Script"
+            },
+            {
+              "statusCode": 200,
+              "rendererStartTime": 2609.1989999972284,
+              "sessionTargetType": "page",
+              "networkEndTime": 2691.929999999702,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "transferSize": 34186,
+              "networkRequestTime": 2611.6070000007749,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 110060
+            },
+            {
+              "resourceSize": 991,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "networkEndTime": 2673.10000000149,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2609.3850000016391,
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2611.8420000001788,
+              "transferSize": 1516,
+              "url": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "finished": true
+            },
+            {
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "transferSize": 4524,
+              "networkRequestTime": 2612.0879999995232,
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 2688.2640000022948,
+              "statusCode": 200,
+              "rendererStartTime": 2609.5460000000894,
+              "resourceSize": 9799,
+              "resourceType": "Script",
+              "isLinkPreload": true
+            },
+            {
+              "resourceSize": 3192,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 2657.9539999999106,
+              "statusCode": 200,
+              "rendererStartTime": 2609.6869999989867,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "transferSize": 2150,
+              "url": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "networkRequestTime": 2612.3509999997914,
+              "finished": true
+            },
+            {
+              "resourceSize": 141,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "networkRequestTime": 2612.6209999993443,
+              "url": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "transferSize": 671,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "rendererStartTime": 2609.8759999983013,
+              "statusCode": 200,
+              "networkEndTime": 2686.44299999997,
+              "sessionTargetType": "page"
+            },
+            {
+              "networkRequestTime": 2612.8799999989569,
+              "transferSize": 1271,
+              "url": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "rendererStartTime": 2610.0379999987781,
+              "statusCode": 200,
+              "networkEndTime": 2681.8449999988079,
+              "sessionTargetType": "page",
+              "resourceSize": 1284,
+              "isLinkPreload": true,
+              "resourceType": "Script"
+            },
+            {
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 15426,
+              "networkEndTime": 2844.9890000000596,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2610.2010000012815,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2613.46799999848,
+              "url": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "transferSize": 6806
+            },
+            {
+              "resourceSize": 17234,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "transferSize": 6207,
+              "networkRequestTime": 2613.9259999990463,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkEndTime": 2814.2589999996126,
+              "statusCode": 200,
+              "rendererStartTime": 2610.4780000001192
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 2835.2860000021756,
+              "statusCode": 200,
+              "rendererStartTime": 2610.6609999984503,
+              "priority": "High",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "transferSize": 1832,
+              "networkRequestTime": 2614.1339999996126,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 3070
+            },
+            {
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 428,
+              "finished": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "transferSize": 955,
+              "networkRequestTime": 2614.3480000011623,
+              "sessionTargetType": "page",
+              "networkEndTime": 2682.2100000008941,
+              "statusCode": 200,
+              "rendererStartTime": 2610.8150000013411,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "High"
+            },
+            {
+              "resourceSize": 410,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "transferSize": 939,
+              "networkRequestTime": 2614.6380000002682,
+              "finished": true,
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkEndTime": 2681.515000000596,
+              "statusCode": 200,
+              "rendererStartTime": 2611.0940000005066
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "rendererStartTime": 2611.2430000007153,
+              "statusCode": 200,
+              "networkEndTime": 2796.6479999981821,
+              "sessionTargetType": "page",
+              "networkRequestTime": 2614.9210000000894,
+              "url": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "transferSize": 1047,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceSize": 525,
+              "isLinkPreload": true,
+              "resourceType": "Script"
+            },
+            {
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 942,
+              "finished": true,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2615.2719999998808,
+              "url": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "transferSize": 1471,
+              "networkEndTime": 2792.6090000011027,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2611.3929999992251,
+              "statusCode": 200,
+              "priority": "High",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "resourceSize": 349,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "transferSize": 878,
+              "networkRequestTime": 2615.6589999981225,
+              "finished": true,
+              "priority": "High",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 2703.5389999970794,
+              "statusCode": 200,
+              "rendererStartTime": 2611.6490000002086
+            },
+            {
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 1866,
+              "statusCode": 200,
+              "rendererStartTime": 2611.7869999967515,
+              "sessionTargetType": "page",
+              "networkEndTime": 2692.785000000149,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "finished": true,
+              "transferSize": 1369,
+              "url": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "networkRequestTime": 2615.7510000020266,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co"
+            },
+            {
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 348,
+              "rendererStartTime": 2611.9939999990165,
+              "statusCode": 200,
+              "networkEndTime": 2811.6540000028908,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "High",
+              "finished": true,
+              "networkRequestTime": 2616.2609999999404,
+              "transferSize": 867,
+              "url": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript"
+            },
+            {
+              "resourceSize": 67398,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "High",
+              "networkEndTime": 2672.4979999996722,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2612.1790000014007,
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2616.4780000001192,
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "transferSize": 21254,
+              "finished": true
+            },
+            {
+              "networkEndTime": 2704.3850000016391,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2612.36799999699,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "High",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2616.7670000009239,
+              "url": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "transferSize": 703,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 165
+            },
+            {
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 605,
+              "statusCode": 200,
+              "rendererStartTime": 2612.589999999851,
+              "sessionTargetType": "page",
+              "networkEndTime": 2687.6999999992549,
+              "priority": "High",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "transferSize": 1129,
+              "url": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "networkRequestTime": 2617.137000001967,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkEndTime": 2688.644999999553,
+              "statusCode": 200,
+              "rendererStartTime": 2612.8370000012219,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "transferSize": 1347,
+              "url": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "networkRequestTime": 2617.4030000008643,
+              "finished": true,
+              "resourceSize": 826,
+              "resourceType": "Script",
+              "isLinkPreload": true
+            },
+            {
+              "resourceSize": 404,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "protocol": "h2",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "rendererStartTime": 2613.0480000004172,
+              "sessionTargetType": "page",
+              "networkEndTime": 2674.3880000002682,
+              "url": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "transferSize": 931,
+              "networkRequestTime": 2617.5379999987781,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "finished": true
+            },
+            {
+              "transferSize": 1013,
+              "url": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "networkRequestTime": 2617.8020000010729,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "statusCode": 200,
+              "rendererStartTime": 2613.1909999996424,
+              "sessionTargetType": "page",
+              "networkEndTime": 2685.1260000020266,
+              "resourceSize": 490,
+              "isLinkPreload": true,
+              "resourceType": "Script"
+            },
+            {
+              "rendererStartTime": 2613.35000000149,
+              "statusCode": 200,
+              "networkEndTime": 2667.5630000010133,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "finished": true,
+              "networkRequestTime": 2618.1289999969304,
+              "transferSize": 728,
+              "url": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 206
+            },
+            {
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 835,
+              "sessionTargetType": "page",
+              "networkEndTime": 2795.042000003159,
+              "statusCode": 200,
+              "rendererStartTime": 2613.535000000149,
+              "priority": "High",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "transferSize": 1358,
+              "url": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "networkRequestTime": 2618.43200000003
+            },
+            {
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkEndTime": 2704.8819999992847,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2613.6860000006855,
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2618.7099999971688,
+              "url": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "transferSize": 26414,
+              "finished": true,
+              "resourceSize": 68826,
+              "resourceType": "Script",
+              "isLinkPreload": true
+            },
+            {
+              "networkEndTime": 2663.6680000014603,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2613.882999997586,
+              "statusCode": 200,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "finished": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "networkRequestTime": 2618.9760000035167,
+              "url": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "transferSize": 999,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 473
+            },
+            {
+              "resourceSize": 338,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "High",
+              "rendererStartTime": 2614.0630000010133,
+              "statusCode": 200,
+              "networkEndTime": 2684.7439999990165,
+              "sessionTargetType": "page",
+              "networkRequestTime": 2619.8809999972582,
+              "transferSize": 857,
+              "url": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "finished": true
+            },
+            {
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 435,
+              "statusCode": 200,
+              "rendererStartTime": 2614.2060000002384,
+              "sessionTargetType": "page",
+              "networkEndTime": 2680.9770000018179,
+              "protocol": "h2",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "transferSize": 966,
+              "url": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "networkRequestTime": 2626.5260000005364,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript"
+            },
+            {
+              "statusCode": 200,
+              "rendererStartTime": 2614.3579999990761,
+              "sessionTargetType": "page",
+              "networkEndTime": 2690.5100000016391,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "transferSize": 842,
+              "networkRequestTime": 2626.6759999990463,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 312
+            },
+            {
+              "resourceSize": 309,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "priority": "High",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 2614.5059999972582,
+              "statusCode": 200,
+              "networkEndTime": 2666.84299999848,
+              "sessionTargetType": "page",
+              "networkRequestTime": 2626.8489999994636,
+              "transferSize": 833,
+              "url": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "finished": true
+            },
+            {
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 27349,
+              "sessionTargetType": "page",
+              "networkEndTime": 2798.4270000010729,
+              "statusCode": 200,
+              "rendererStartTime": 2614.6760000027716,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "transferSize": 7567,
+              "url": "https://www.ocobo.co/assets/_main.(_lang)._index-BJmsIfGa.js",
+              "networkRequestTime": 2637.1150000020862
+            },
+            {
+              "resourceSize": 521,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "networkEndTime": 2871.2640000022948,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2614.8580000028014,
+              "statusCode": 200,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2637.4150000028312,
+              "url": "https://www.ocobo.co/assets/section-CAd8zqOP.js",
+              "transferSize": 1044,
+              "finished": true
+            },
+            {
+              "resourceSize": 717,
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "priority": "High",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "rendererStartTime": 2615.0089999996126,
+              "statusCode": 200,
+              "networkEndTime": 2848.5340000018477,
+              "sessionTargetType": "page",
+              "networkRequestTime": 2637.5659999996424,
+              "transferSize": 1237,
+              "url": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "finished": true
+            },
+            {
+              "resourceSize": 549,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "sessionTargetType": "page",
+              "networkEndTime": 2702.6420000009239,
+              "statusCode": 200,
+              "rendererStartTime": 2615.1460000015795,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "transferSize": 1076,
+              "networkRequestTime": 2637.6810000017285,
+              "finished": true
+            },
+            {
+              "rendererStartTime": 2615.375,
+              "statusCode": 200,
+              "networkEndTime": 2800.0260000005364,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "networkRequestTime": 2637.8209999985993,
+              "url": "https://www.ocobo.co/assets/check-D95Zi0fi.js",
+              "transferSize": 824,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 303
+            },
+            {
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 551,
+              "statusCode": 200,
+              "rendererStartTime": 2615.5769999995828,
+              "sessionTargetType": "page",
+              "networkEndTime": 2813.679999999702,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/hero-split-DCf1X66c.js",
+              "transferSize": 1077,
+              "networkRequestTime": 2637.980000000447,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript"
+            },
+            {
+              "resourceSize": 495,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "networkRequestTime": 2638.1119999997318,
+              "transferSize": 1016,
+              "url": "https://www.ocobo.co/assets/badge-i9dgPBIb.js",
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "networkEndTime": 2802.2380000017583,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2615.7259999997914,
+              "statusCode": 200
+            },
+            {
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 605,
+              "sessionTargetType": "page",
+              "networkEndTime": 2827.1689999997616,
+              "statusCode": 200,
+              "rendererStartTime": 2615.8890000022948,
+              "priority": "High",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "transferSize": 1125,
+              "url": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "networkRequestTime": 2638.2239999994636
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "statusCode": 200,
+              "rendererStartTime": 2616.0869999974966,
+              "sessionTargetType": "page",
+              "networkEndTime": 2859.93200000003,
+              "transferSize": 857,
+              "url": "https://www.ocobo.co/assets/plus-Bvz3jpuZ.js",
+              "networkRequestTime": 2638.417999997735,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceSize": 337,
+              "isLinkPreload": true,
+              "resourceType": "Script"
+            },
+            {
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "rendererStartTime": 2616.5560000017285,
+              "statusCode": 200,
+              "networkEndTime": 2793.7690000012517,
+              "sessionTargetType": "page",
+              "networkRequestTime": 2638.5430000014603,
+              "transferSize": 943,
+              "url": "https://www.ocobo.co/assets/panels-top-left-BeWfuLW7.js",
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "resourceSize": 412,
+              "isLinkPreload": true,
+              "resourceType": "Script"
+            },
+            {
+              "resourceSize": 446,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "priority": "High",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 2660.5859999991953,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2616.8709999993443,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "networkRequestTime": 2638.6790000014007,
+              "url": "https://www.ocobo.co/assets/zap-C3uzvT7-.js",
+              "transferSize": 967,
+              "finished": true
+            },
+            {
+              "statusCode": 200,
+              "rendererStartTime": 2617.0439999997616,
+              "sessionTargetType": "page",
+              "networkEndTime": 2791.8409999981523,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "finished": true,
+              "transferSize": 927,
+              "url": "https://www.ocobo.co/assets/target-DyzL19b9.js",
+              "networkRequestTime": 2638.8090000003576,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 405
+            },
+            {
+              "sessionTargetType": "page",
+              "networkEndTime": 2813.2190000005066,
+              "statusCode": 200,
+              "rendererStartTime": 2617.30700000003,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "High",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "transferSize": 963,
+              "url": "https://www.ocobo.co/assets/chart-column-CxnbmN-k.js",
+              "networkRequestTime": 2638.964999999851,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 435
+            },
+            {
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "resourceSize": 3009,
+              "networkEndTime": 2835.80700000003,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2617.4509999975562,
+              "statusCode": 200,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2639.1180000007153,
+              "url": "https://www.ocobo.co/assets/modular-stack-grid-DBlYkSNY.js",
+              "transferSize": 1773
+            },
+            {
+              "resourceSize": 568,
+              "resourceType": "Script",
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "transferSize": 1093,
+              "url": "https://www.ocobo.co/assets/flex-pair-BLQ5DP05.js",
+              "networkRequestTime": 2639.2950000017881,
+              "finished": true,
+              "priority": "High",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkEndTime": 2795.8460000008345,
+              "statusCode": 200,
+              "rendererStartTime": 2617.6380000002682
+            },
+            {
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "transferSize": 1132,
+              "networkRequestTime": 2639.422000002116,
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "statusCode": 200,
+              "rendererStartTime": 2617.7949999980628,
+              "sessionTargetType": "page",
+              "networkEndTime": 2957.2259999997914,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "High",
+              "isLinkPreload": true,
+              "resourceType": "Script",
+              "resourceSize": 1217
+            },
+            {
+              "resourceType": "Font",
+              "resourceSize": 31480,
+              "statusCode": 200,
+              "rendererStartTime": 2742.894999999553,
+              "sessionTargetType": "page",
+              "networkEndTime": 2902.859999999404,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "VeryHigh",
+              "finished": true,
+              "transferSize": 31974,
+              "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+              "networkRequestTime": 2744.160000000149,
+              "entity": "ocobo.co",
+              "mimeType": "font/woff"
+            },
+            {
+              "resourceSize": 57572,
+              "resourceType": "Font",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "VeryHigh",
+              "networkEndTime": 2936.2619999982417,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2743.2669999971986,
+              "statusCode": 200,
+              "mimeType": "font/otf",
+              "entity": "ocobo.co",
+              "networkRequestTime": 2744.3139999993145,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+              "transferSize": 38778,
+              "finished": true
+            },
+            {
+              "resourceType": "Font",
+              "resourceSize": 58256,
+              "finished": true,
+              "transferSize": 39126,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+              "networkRequestTime": 2744.4670000001788,
+              "mimeType": "font/otf",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "rendererStartTime": 2743.4890000000596,
+              "sessionTargetType": "page",
+              "networkEndTime": 2989.4869999997318,
+              "protocol": "h2",
+              "priority": "VeryHigh",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "finished": true,
+              "networkRequestTime": 2919.4419999979436,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vizzia-white.png",
+              "transferSize": 4855,
+              "entity": "vercel-storage.com",
+              "mimeType": "image/png",
+              "rendererStartTime": 2916.6689999997616,
+              "statusCode": 200,
+              "networkEndTime": 2965.937000002712,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "Low",
+              "resourceType": "Image",
+              "resourceSize": 4187
+            },
+            {
+              "resourceSize": 8945,
+              "resourceType": "Image",
+              "protocol": "h2",
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 2966.4339999966323,
+              "statusCode": 200,
+              "rendererStartTime": 2917.0300000011921,
+              "mimeType": "image/png",
+              "entity": "vercel-storage.com",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/steeple-white.png",
+              "transferSize": 9615,
+              "networkRequestTime": 2919.6550000011921,
+              "finished": true
+            },
+            {
+              "networkEndTime": 2955.4519999995828,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2917.2320000007749,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "Low",
+              "finished": true,
+              "entity": "vercel-storage.com",
+              "mimeType": "image/png",
+              "networkRequestTime": 2919.730000000447,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png",
+              "transferSize": 11990,
+              "resourceType": "Image",
+              "resourceSize": 11321
+            },
+            {
+              "entity": "vercel-storage.com",
+              "mimeType": "image/png",
+              "transferSize": 10155,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vibe-co-white.png",
+              "networkRequestTime": 2919.8059999980032,
+              "finished": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 2997.1730000004172,
+              "statusCode": 200,
+              "rendererStartTime": 2917.4230000004172,
+              "resourceSize": 9486,
+              "resourceType": "Image"
+            },
+            {
+              "networkEndTime": 2977.9050000011921,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2917.7209999971092,
+              "statusCode": 200,
+              "priority": "Low",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "mimeType": "image/png",
+              "entity": "vercel-storage.com",
+              "networkRequestTime": 2919.8790000006557,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png",
+              "transferSize": 14022,
+              "resourceType": "Image",
+              "resourceSize": 13354
+            },
+            {
+              "finished": true,
+              "transferSize": 11481,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qobra-white.png",
+              "networkRequestTime": 2920.3080000020564,
+              "mimeType": "image/png",
+              "entity": "vercel-storage.com",
+              "statusCode": 200,
+              "rendererStartTime": 2917.9159999974072,
+              "sessionTargetType": "page",
+              "networkEndTime": 2965.4589999988675,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "resourceType": "Image",
+              "resourceSize": 10812
+            },
+            {
+              "resourceType": "Image",
+              "resourceSize": 10304,
+              "finished": true,
+              "transferSize": 10978,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/resilience-white.png",
+              "networkRequestTime": 2922.2089999988675,
+              "mimeType": "image/png",
+              "entity": "vercel-storage.com",
+              "statusCode": 200,
+              "rendererStartTime": 2918.2709999978542,
+              "sessionTargetType": "page",
+              "networkEndTime": 2962.8909999988973,
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "h2"
+            },
+            {
+              "resourceType": "Image",
+              "resourceSize": 22161,
+              "finished": true,
+              "mimeType": "image/png",
+              "entity": "vercel-storage.com",
+              "networkRequestTime": 2923.6160000003874,
+              "transferSize": 22833,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png",
+              "networkEndTime": 2980.2119999974966,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2918.4910000003874,
+              "statusCode": 200,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "Low"
+            },
+            {
+              "resourceType": "Image",
+              "resourceSize": 7009,
+              "finished": true,
+              "networkRequestTime": 2923.7219999991357,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qare-white.png",
+              "transferSize": 7675,
+              "mimeType": "image/png",
+              "entity": "vercel-storage.com",
+              "rendererStartTime": 2918.6230000033975,
+              "statusCode": 200,
+              "networkEndTime": 2959.0559999980032,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "Low",
+              "experimentalFromMainFrame": true
+            },
+            {
+              "networkRequestTime": 2923.8030000030994,
+              "transferSize": 60335,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png",
+              "entity": "vercel-storage.com",
+              "mimeType": "image/png",
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "rendererStartTime": 2918.7780000008643,
+              "statusCode": 200,
+              "networkEndTime": 2961.4189999997616,
+              "sessionTargetType": "page",
+              "resourceSize": 59662,
+              "resourceType": "Image"
+            },
+            {
+              "resourceSize": 9311,
+              "resourceType": "Image",
+              "mimeType": "image/png",
+              "entity": "vercel-storage.com",
+              "transferSize": 9979,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qonto-white.png",
+              "networkRequestTime": 2923.894999999553,
+              "finished": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 2974.3520000018179,
+              "statusCode": 200,
+              "rendererStartTime": 2919.2030000016093
+            },
+            {
+              "rendererStartTime": 2919.3759999983013,
+              "statusCode": 200,
+              "networkEndTime": 2996.5740000009537,
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "networkRequestTime": 2923.9730000011623,
+              "transferSize": 9718,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/tomorro-white.png",
+              "entity": "vercel-storage.com",
+              "mimeType": "image/png",
+              "resourceType": "Image",
+              "resourceSize": 9049
+            },
+            {
+              "resourceSize": 4455,
+              "resourceType": "Image",
+              "entity": "vercel-storage.com",
+              "mimeType": "image/png",
+              "networkRequestTime": 2924.0610000006855,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/epack-white.png",
+              "transferSize": 5122,
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "networkEndTime": 3133.515000000596,
+              "sessionTargetType": "page",
+              "rendererStartTime": 2919.7490000016987,
+              "statusCode": 200
+            },
+            {
+              "finished": true,
+              "mimeType": "image/png",
+              "entity": "vercel-storage.com",
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yousign-white.png",
+              "transferSize": 29277,
+              "networkRequestTime": 2924.1409999988973,
+              "sessionTargetType": "page",
+              "networkEndTime": 2988.8800000026822,
+              "statusCode": 200,
+              "rendererStartTime": 2919.9499999992549,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "resourceType": "Image",
+              "resourceSize": 28606
+            },
+            {
+              "networkRequestTime": 2924.21799999848,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/citron-white.png",
+              "transferSize": 9979,
+              "mimeType": "image/png",
+              "entity": "vercel-storage.com",
+              "finished": true,
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "rendererStartTime": 2920.1649999991059,
+              "statusCode": 200,
+              "networkEndTime": 3145.0650000013411,
+              "sessionTargetType": "page",
+              "resourceSize": 9310,
+              "resourceType": "Image"
+            },
+            {
+              "statusCode": 200,
+              "rendererStartTime": 2920.7430000007153,
+              "sessionTargetType": "page",
+              "networkEndTime": 2988.0449999980628,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "finished": true,
+              "transferSize": 18633,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/wecandoo-white.png",
+              "networkRequestTime": 2924.4269999973476,
+              "mimeType": "image/png",
+              "entity": "vercel-storage.com",
+              "resourceType": "Image",
+              "resourceSize": 17962
+            },
+            {
+              "entity": "GitHub",
+              "mimeType": "text/css",
+              "networkRequestTime": 3273.195000000298,
+              "transferSize": 1999,
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "finished": true,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "VeryHigh",
+              "networkEndTime": 3300.4970000013709,
+              "sessionTargetType": "page",
+              "rendererStartTime": 3270.8579999990761,
+              "statusCode": 200,
+              "resourceSize": 4371,
+              "resourceType": "Stylesheet"
+            },
+            {
+              "resourceSize": 16667,
+              "resourceType": "Image",
+              "priority": "High",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "rendererStartTime": 3272.1280000023544,
+              "sessionTargetType": "page",
+              "networkEndTime": 3440.4550000019372,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png",
+              "transferSize": 17170,
+              "networkRequestTime": 3273.8579999990761,
+              "entity": "ocobo.co",
+              "mimeType": "image/png",
+              "finished": true
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkEndTime": 3516.6759999990463,
+              "statusCode": 204,
+              "rendererStartTime": 3493.8980000019073,
+              "entity": "Google Analytics",
+              "mimeType": "text/plain",
+              "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65d0v9100339653za200zd9100339653&_p=1778837284159&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1157999218.1778837285&frm=0&pscdl=noapi&rcb=4&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616986~115938466~115938469&dp=%2Ffr&sid=1778837284&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Ffr&dt=Ocobo%20%C2%B7%20Ocobo%20%C2%B7%20RevOps%20%26%20Revenue%20Experience&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=3493",
+              "transferSize": 796,
+              "networkRequestTime": 3496.3299999982119,
+              "finished": true,
+              "resourceSize": 0,
+              "resourceType": "Fetch"
+            },
+            {
+              "mimeType": "application/javascript",
+              "entity": "Hubspot",
+              "networkRequestTime": 3519.3650000020862,
+              "transferSize": 27964,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "finished": true,
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "networkEndTime": 3563.6610000021756,
+              "sessionTargetType": "page",
+              "rendererStartTime": 3518.0940000005066,
+              "statusCode": 200,
+              "resourceSize": 78203,
+              "resourceType": "Script"
+            },
+            {
+              "statusCode": 200,
+              "rendererStartTime": 3518.75,
+              "sessionTargetType": "page",
+              "networkEndTime": 3576.7789999991655,
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "finished": true,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "transferSize": 29750,
+              "networkRequestTime": 3519.8669999986887,
+              "mimeType": "application/javascript",
+              "entity": "Hubspot",
+              "resourceType": "Script",
+              "resourceSize": 97992
+            },
+            {
+              "mimeType": "text/javascript",
+              "entity": "Hubspot",
+              "transferSize": 43670,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "networkRequestTime": 3520.0610000006855,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "networkEndTime": 3651.277000002563,
+              "statusCode": 200,
+              "rendererStartTime": 3519.2619999982417,
+              "resourceSize": 109001,
+              "resourceType": "Script"
+            },
+            {
+              "resourceType": "Script",
+              "resourceSize": 72678,
+              "finished": true,
+              "entity": "Hubspot",
+              "mimeType": "text/javascript",
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "transferSize": 27218,
+              "networkRequestTime": 3521.6589999981225,
+              "sessionTargetType": "page",
+              "networkEndTime": 3628.0590000003576,
+              "statusCode": 200,
+              "rendererStartTime": 3519.8040000014007,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "Low"
+            },
+            {
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "networkEndTime": 3908.3990000002086,
+              "sessionTargetType": "page",
+              "rendererStartTime": 3708.6920000016689,
+              "statusCode": 404,
+              "mimeType": "application/javascript",
+              "entity": "Clearbit",
+              "networkRequestTime": 3710.18200000003,
+              "transferSize": 639,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "finished": true,
+              "resourceSize": 0,
+              "resourceType": "Script"
+            },
+            {
+              "entity": "ocobo.co",
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/_vercel/insights/script.js",
+              "transferSize": 1868,
+              "networkRequestTime": 3712.785000000149,
+              "finished": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 3738.9279999993742,
+              "statusCode": 200,
+              "rendererStartTime": 3711.4189999997616,
+              "resourceSize": 2495,
+              "resourceType": "Script"
+            },
+            {
+              "rendererStartTime": 3712.9670000001788,
+              "statusCode": 200,
+              "networkEndTime": 3731.6860000006855,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "finished": true,
+              "networkRequestTime": 3714.7609999999404,
+              "transferSize": 5314,
+              "url": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "mimeType": "application/javascript",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "resourceSize": 12567
+            },
+            {
+              "resourceSize": 15297,
+              "resourceType": "Fetch",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "networkEndTime": 3804.0450000017881,
+              "sessionTargetType": "page",
+              "rendererStartTime": 3717.0049999989569,
+              "statusCode": 200,
+              "entity": "ocobo.co",
+              "mimeType": "application/json",
+              "networkRequestTime": 3719.80700000003,
+              "transferSize": 2410,
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fclients%2C%2Fen%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fclients%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology&version=ba6d9b28",
+              "finished": true
+            },
+            {
+              "resourceType": "Script",
+              "resourceSize": 607831,
+              "networkEndTime": 3785.9639999978244,
+              "sessionTargetType": "page",
+              "rendererStartTime": 3738.7890000008047,
+              "statusCode": 200,
+              "priority": "Low",
+              "protocol": "h2",
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "entity": "Hubspot",
+              "mimeType": "application/javascript",
+              "networkRequestTime": 3740.2419999986887,
+              "transferSize": 204723,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "resourceSize": 48,
+              "resourceType": "Fetch",
+              "mimeType": "application/json",
+              "entity": "ocobo.co",
+              "url": "https://www.ocobo.co/_vercel/insights/view",
+              "transferSize": 473,
+              "networkRequestTime": 3826.5769999995828,
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "networkEndTime": 3867.4900000020862,
+              "statusCode": 202,
+              "rendererStartTime": 3824.9829999990761
+            },
+            {
+              "resourceType": "XHR",
+              "resourceSize": 135,
+              "rendererStartTime": 4154.2080000005662,
+              "statusCode": 200,
+              "networkEndTime": 4200.8080000020564,
+              "sessionTargetType": "page",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "High",
+              "finished": true,
+              "networkRequestTime": 4156.4089999981225,
+              "transferSize": 1095,
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+              "mimeType": "application/json",
+              "entity": "Hubspot"
+            },
+            {
+              "finished": true,
+              "entity": "Hubspot",
+              "mimeType": "text/plain",
+              "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+              "transferSize": 559,
+              "networkRequestTime": 4236.5690000019968,
+              "sessionTargetType": "page",
+              "networkEndTime": 4258.26099999994,
+              "statusCode": 200,
+              "rendererStartTime": 4235.2270000018179,
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "protocol": "h2",
+              "resourceType": "Fetch",
+              "resourceSize": 6
+            },
+            {
+              "entity": "Hubspot",
+              "mimeType": "application/json",
+              "networkRequestTime": 4245.3229999989271,
+              "transferSize": 1706,
+              "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Ffr&isMobile=true",
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "priority": "High",
+              "networkEndTime": 4327.6310000009835,
+              "sessionTargetType": "page",
+              "rendererStartTime": 4243.4900000020862,
+              "statusCode": 200,
+              "resourceSize": 61,
+              "resourceType": "Fetch"
+            },
+            {
+              "finished": true,
+              "entity": "Hubspot",
+              "mimeType": "image/gif",
+              "networkRequestTime": 4671.30700000003,
+              "transferSize": 1021,
+              "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+              "networkEndTime": 4778.2809999994934,
+              "sessionTargetType": "page",
+              "rendererStartTime": 4670.0659999996424,
+              "statusCode": 200,
+              "protocol": "http/1.1",
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "resourceSize": 35
+            },
+            {
+              "finished": true,
+              "mimeType": "application/json",
+              "entity": "Hubspot",
+              "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953",
+              "transferSize": 4083,
+              "networkRequestTime": 5087.1259999983013,
+              "sessionTargetType": "page",
+              "networkEndTime": 5204.0219999998808,
+              "statusCode": 200,
+              "rendererStartTime": 5083.9699999988079,
+              "protocol": "http/1.1",
+              "experimentalFromMainFrame": true,
+              "priority": "High",
+              "resourceType": "XHR",
+              "resourceSize": 9346
+            },
+            {
+              "mimeType": "image/gif",
+              "entity": "Hubspot",
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr&t=Ocobo+%C2%B7+Ocobo+%C2%B7+RevOps+%26+Revenue+Experience&cts=1778837286602&vi=22c3cdc0eeec24d104de95e7238b0bcf&nc=true&u=242475741.22c3cdc0eeec24d104de95e7238b0bcf.1778837286589.1778837286589.1778837286589.1&b=242475741.1.1778837286590&cc=15",
+              "transferSize": 1526,
+              "networkRequestTime": 5151.4160000011325,
+              "finished": true,
+              "protocol": "h2",
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "sessionTargetType": "page",
+              "networkEndTime": 5244.964999999851,
+              "statusCode": 200,
+              "rendererStartTime": 5148.2509999983013,
+              "resourceSize": 45,
+              "resourceType": "Image"
+            },
+            {
+              "transferSize": 204723,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "networkRequestTime": 5291.9010000005364,
+              "mimeType": "application/javascript",
+              "entity": "Hubspot",
+              "finished": true,
+              "priority": "Low",
+              "protocol": "h2",
+              "statusCode": 200,
+              "rendererStartTime": 5291.9010000005364,
+              "sessionTargetType": "page",
+              "networkEndTime": 5292.8579999990761,
+              "resourceSize": 607831,
+              "resourceType": "Script"
+            },
+            {
+              "resourceSize": 35,
+              "resourceType": "Image",
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "protocol": "http/1.1",
+              "sessionTargetType": "page",
+              "networkEndTime": 5842.070000000298,
+              "statusCode": 200,
+              "rendererStartTime": 5764.73900000006,
+              "mimeType": "image/gif",
+              "entity": "Hubspot",
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+              "transferSize": 1024,
+              "networkRequestTime": 5768.2670000009239,
+              "finished": true
+            },
+            {
+              "resourceSize": 3792,
+              "resourceType": "Stylesheet",
+              "priority": "VeryHigh",
+              "protocol": "h2",
+              "statusCode": 200,
+              "rendererStartTime": 5800.125,
+              "sessionTargetType": "page",
+              "networkEndTime": 5812.3239999972284,
+              "transferSize": 1259,
+              "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+              "networkRequestTime": 5803.6280000023544,
+              "mimeType": "text/css",
+              "entity": "Google Fonts",
+              "finished": true
+            },
+            {
+              "transferSize": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "networkRequestTime": 5853.4289999976754,
+              "mimeType": "font/woff2",
+              "entity": "Google Fonts",
+              "finished": true,
+              "protocol": "h2",
+              "priority": "VeryHigh",
+              "statusCode": 200,
+              "rendererStartTime": 5851.29999999702,
+              "sessionTargetType": "page",
+              "networkEndTime": 5858.7750000022352,
+              "resourceSize": 50524,
+              "resourceType": "Font"
+            },
+            {
+              "resourceType": "Font",
+              "resourceSize": 50524,
+              "networkEndTime": 5870.2829999998212,
+              "sessionTargetType": "page",
+              "rendererStartTime": 5860.9230000004172,
+              "statusCode": 200,
+              "priority": "VeryHigh",
+              "protocol": "h2",
+              "finished": true,
+              "entity": "Google Fonts",
+              "mimeType": "font/woff2",
+              "networkRequestTime": 5862.2980000004172,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "transferSize": 51336
+            },
+            {
+              "networkEndTime": 5979.75,
+              "sessionTargetType": "page",
+              "rendererStartTime": 5897.1219999976456,
+              "statusCode": 200,
+              "priority": "Low",
+              "experimentalFromMainFrame": true,
+              "protocol": "h2",
+              "finished": true,
+              "entity": "Hubspot",
+              "mimeType": "image/gif",
+              "networkRequestTime": 5898.6070000007749,
+              "transferSize": 1074,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=4730ddc3-b73a-4ce8-b84d-c9d9f13b654c&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr&t=Ocobo+%C2%B7+Ocobo+%C2%B7+RevOps+%26+Revenue+Experience&cts=1778837287350&vi=22c3cdc0eeec24d104de95e7238b0bcf&nc=true&u=242475741.22c3cdc0eeec24d104de95e7238b0bcf.1778837286589.1778837286589.1778837286589.1&b=242475741.1.1778837286590&cc=15",
+              "resourceType": "Image",
+              "resourceSize": 45
+            },
+            {
+              "resourceType": "Image",
+              "resourceSize": 35,
+              "statusCode": 200,
+              "rendererStartTime": 5897.6180000007153,
+              "sessionTargetType": "page",
+              "networkEndTime": 5964.8759999983013,
+              "experimentalFromMainFrame": true,
+              "priority": "Low",
+              "protocol": "http/1.1",
+              "finished": true,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+              "transferSize": 1024,
+              "networkRequestTime": 5904.4780000001192,
+              "entity": "Hubspot",
+              "mimeType": "image/gif"
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "label": "Protocol",
+              "key": "protocol",
+              "valueType": "text"
+            },
+            {
+              "key": "networkRequestTime",
+              "label": "Network Request Time",
+              "granularity": 1,
+              "valueType": "ms"
+            },
+            {
+              "valueType": "ms",
+              "granularity": 1,
+              "key": "networkEndTime",
+              "label": "Network End Time"
+            },
+            {
+              "valueType": "bytes",
+              "key": "transferSize",
+              "granularity": 1,
+              "displayUnit": "kb",
+              "label": "Transfer Size"
+            },
+            {
+              "label": "Resource Size",
+              "granularity": 1,
+              "displayUnit": "kb",
+              "key": "resourceSize",
+              "valueType": "bytes"
+            },
+            {
+              "valueType": "text",
+              "label": "Status Code",
+              "key": "statusCode"
+            },
+            {
+              "valueType": "text",
+              "label": "MIME Type",
+              "key": "mimeType"
+            },
+            {
+              "label": "Resource Type",
+              "key": "resourceType",
+              "valueType": "text"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "networkStartTimeTs": 21988895182,
+            "type": "debugdata",
+            "initiators": [
+              {
+                "lineNumber": 0,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 1727
+              },
+              {
+                "columnNumber": 695,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 16793
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 53552
+              },
+              {
+                "columnNumber": 78250,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 78790
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 79339
+              },
+              {
+                "columnNumber": 79886,
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 80428
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 80972
+              },
+              {
+                "columnNumber": 82088,
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 82629
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 83747
+              },
+              {
+                "columnNumber": 84287,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 85408
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 85957
+              },
+              {
+                "columnNumber": 141,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 261,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 360,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 460
+              },
+              {
+                "columnNumber": 536,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 602,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 671
+              },
+              {
+                "columnNumber": 731,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 795,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 857
+              },
+              {
+                "columnNumber": 916,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 985,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 1052
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 1119
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 1176
+              },
+              {
+                "columnNumber": 1238,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 1297
+              },
+              {
+                "columnNumber": 1361,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 1427,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "columnNumber": 1488
+              },
+              {
+                "columnNumber": 1556,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1622,
+                "type": "parser",
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 1693
+              },
+              {
+                "columnNumber": 1751,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1811,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 1886,
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 1947
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 2005
+              },
+              {
+                "columnNumber": 2069,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 2129
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 2188
+              },
+              {
+                "columnNumber": 2250,
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 2311
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 2374
+              },
+              {
+                "columnNumber": 2430,
+                "type": "parser",
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36
+              },
+              {
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 2498
+              },
+              {
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "type": "parser",
+                "columnNumber": 2565
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 2626
+              },
+              {
+                "columnNumber": 2701,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2763,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "columnNumber": 2822
+              },
+              {
+                "columnNumber": 2886,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2946,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 3011,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 3071
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 3130
+              },
+              {
+                "columnNumber": 3189,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 36,
+                "columnNumber": 3259
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 3317
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 3378
+              },
+              {
+                "columnNumber": 3445,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 3518,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 3582
+              },
+              {
+                "columnNumber": 3645,
+                "lineNumber": 36,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 81571
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 81571
+              },
+              {
+                "columnNumber": 81571,
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 81571
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 81571
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 81571
+              },
+              {
+                "columnNumber": 81571,
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 81571,
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 81571
+              },
+              {
+                "columnNumber": 81571,
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 81571,
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "columnNumber": 81571
+              },
+              {
+                "columnNumber": 81571,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 81571,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr",
+                "type": "parser",
+                "columnNumber": 81571
+              },
+              {
+                "columnNumber": 81571,
+                "type": "parser",
+                "lineNumber": 21,
+                "url": "https://www.ocobo.co/fr"
+              },
+              {
+                "columnNumber": 10242,
+                "type": "parser",
+                "url": "https://www.ocobo.co/fr",
+                "lineNumber": 183
+              },
+              {
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+              }
+            ]
+          }
+        }
+      },
+      "legacy-javascript-insight": {
+        "id": "legacy-javascript-insight",
+        "title": "Legacy JavaScript",
+        "description": "Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile [Baseline](https://web.dev/articles/baseline-and-polyfills) features, unless you know you must support older browsers. [Learn why most sites can deploy ES6+ code without transpiling](https://developer.chrome.com/docs/performance/insights/legacy-javascript)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 13 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 13774,
+            "type": "debugdata"
+          },
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "subItemsHeading": {
+                "key": "location",
+                "valueType": "source-location"
+              },
+              "valueType": "url"
+            },
+            {
+              "valueType": "code",
+              "subItemsHeading": {
+                "key": "signal"
+              },
+              "key": null
+            },
+            {
+              "key": "wastedBytes",
+              "label": "Wasted bytes",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "subItems": {
+                "items": [
+                  {
+                    "signal": "Array.prototype.concat",
+                    "location": {
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "column": 6239
+                    }
+                  },
+                  {
+                    "signal": "Array.prototype.slice",
+                    "location": {
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network",
+                      "type": "source-location",
+                      "column": 12925
+                    }
+                  },
+                  {
+                    "signal": "Object.assign",
+                    "location": {
+                      "type": "source-location",
+                      "column": 12813,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "line": 1,
+                      "urlProvider": "network"
+                    }
+                  },
+                  {
+                    "signal": "Object.create",
+                    "location": {
+                      "urlProvider": "network",
+                      "line": 1,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "column": 10857,
+                      "type": "source-location"
+                    }
+                  }
+                ],
+                "type": "subitems"
+              },
+              "wastedBytes": 13774
+            }
+          ]
+        }
+      },
+      "network-rtt": {
+        "id": "network-rtt",
+        "title": "Network Round Trip Times",
+        "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "sortedBy": [
+            "rtt"
+          ],
+          "items": [
+            {
+              "rtt": 8.66556,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "rtt": 7.4927249999999992,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "rtt": 4.7345849999999992,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "origin": "https://track-eu1.hubspot.com",
+              "rtt": 4.208895
+            },
+            {
+              "origin": "https://www.ocobo.co",
+              "rtt": 1.2272400000000003
+            },
+            {
+              "origin": "https://useago.github.io",
+              "rtt": 1.0584
+            },
+            {
+              "origin": "https://www.google-analytics.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "origin": "https://cta-eu1.hubspot.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "origin": "https://forms-eu1.hsforms.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://fonts.googleapis.com"
+            },
+            {
+              "rtt": 0.0076905029634281932,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "rtt": 0.0037347180379697694,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "origin": "https://js-eu1.hs-banner.com",
+              "rtt": 0.0032435296867860544
+            },
+            {
+              "origin": "https://js-eu1.hs-analytics.net",
+              "rtt": 0.0014934664469663556
+            },
+            {
+              "rtt": 0.0011411014630549319,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "origin": "https://js-eu1.hsforms.net",
+              "rtt": 0.0009384876060737127
+            },
+            {
+              "rtt": 0.00078164943343538116,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "origin": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com",
+              "rtt": 0.00060091452607359541
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "origin",
+              "label": "URL"
+            },
+            {
+              "label": "Time Spent",
+              "key": "rtt",
+              "granularity": 1,
+              "valueType": "ms"
+            }
+          ],
+          "type": "table"
+        },
+        "numericValue": 8.66556,
+        "numericUnit": "millisecond"
+      },
+      "lcp-discovery-insight": {
+        "id": "lcp-discovery-insight",
+        "title": "LCP request discovery",
+        "description": "[Optimize LCP](https://developer.chrome.com/docs/performance/insights/lcp-discovery) by making the LCP image discoverable from the HTML immediately, and avoiding lazy-loading",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "screenshot-thumbnails": {
+        "id": "screenshot-thumbnails",
+        "title": "Screenshot Thumbnails",
+        "description": "This is what the load of your site looked like.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "timing": 958,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAII/8QAFRABAQAAAAAAAAAAAAAAAAAAABH/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8A1SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAf/2Q==",
+              "timestamp": 21989852778
+            },
+            {
+              "timestamp": 21990810903,
+              "timing": 1916,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAII/8QAFRABAQAAAAAAAAAAAAAAAAAAABH/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8A1SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAf/2Q=="
+            },
+            {
+              "timestamp": 21991769028,
+              "timing": 2874,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAII/8QAFRABAQAAAAAAAAAAAAAAAAAAABH/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8A1SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFKAFASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAf/2Q=="
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAYHBAUCAwgBCf/EAFQQAAEDAwIDBAQICgcECAcBAAECAwQABREGEhMhMQcUQVEVImFxCDJUgZGTlNIWFxgjQlJVVqGxM1NicpLR0yRzdMElNDU2grKzwic3Q0Siw+Hw/8QAGQEBAQADAQAAAAAAAAAAAAAAAAECAwQF/8QAMBEBAAIBAQYFAgQHAAAAAAAAAAERAgMEEhMxUZIUIVOR4YHRFUGh8DNCYXFysdL/2gAMAwEAAhEDEQA/APVNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFK+KUEpKlEBIGST0FR5rXGlXrh3FrUVpXLztDSZSCSfLr19lBIqUJAGSeXnUdOuNLJn9yOorSJedvC72jdny69fZQSKlAQQCDkHxrVXnUNrsq0JusruiF4w862oND3uY2j5zQbWlQLtrlf/CS/wAmG/yMdKkOtL6gqTzBFbY6v09ZokCNd75bocpTLf5t+QlKuaRzIJ5UEnpXXGkMymEPxnW3mXBuQ42oKSoeYI61pbvrHTdnliLdb7bIknOOE9JQlQ94J5fPQb6ldUSSxMjokRHm32HBlDjagpKh5gjrXbQKUpQKUpQKUpQKUpQKUpQKUpQK4qWlPUiuD6ykYHU1o7jfrRbHwxcbnCivFO4IefShRHngn2UEgSpKuhBr7Wktd3t90C1WudGlhsgLLDoXtJ6Zwa3DS96M+NBzpSlApSlBW/bg+8uz2O0JeXHiXi6sQZbiDtPBUSVJz4ZxipHL0LpiRYVWhdlgJg7CgJSykFPLG4KxkK9vWszV2nYOqrE/a7mlXBcwpK0HC2ljmlaT4EGoe7ovWcmEbZK14tVtUnhrWi3oTJUjoRxN3XHjjNBBDfbk/wBh8OCqa6UOXgWRU9KsKXG4pTvz7UjbmrcRoHSqbH6JFit/ctmzBZTu6Yzu67vbnNc3tE2R3RI0qYxFpS0GkpB9ZJByFg/rbuefOo0nROtERPRydfu+jQnhhRt6DJ2dMcXPXHjjNBpu0GVJ0J2KGPp28PSy26mGicpYUtltSyCNw8Uj1QeoqxdP6ctlv04i3NtCRHeZCX1vHiKkZHNSyfjE5rrt2jbJC0enTIiJetPDLa23vWLmTkqUf1ieefOsVWnrpbLKLPpiemNG2cNEiatUhyOnphCeWceG5RxQUrHfdj9kXahYEuret1mnLjw1qOdrfEHqZ9mP41c+idKWaHpOI2YsacqXHQ5JkvIDipSlJBKlE9Qc8h4CteOzOBH7NZ2koElxvvoKn5jid63HCoErUOWc4xRvR2o7TE7hpfVLcK2hO1tmVBEhUceIbVuHLyCs4oIpp+W9pD8aNqshKoFna75Ba+MGFraUtSB7ARnFSnss0lY2dDW2SuHFnSrjHTJlyn20uLfW4NyskjmMnpW60Xo6HpmzyohdcnyZzinp0qQAVyVq6lXsxyAqOwtBah0+hyFpDVvcbOVKU1ElwkyTHyckIUSDjyBzQdHZ8y3YO0/Vmm7WNlmQyxObYBymO4vIUlPkD1xVoVGdEaRY0uzMcXLfuF0nOcaZOf8AjvK8BgcgkDkAOlSagUpSgUpSgUpSgUpSgUpSgUpSgx5I9YH2VEdSi5m4J7iL4WuGM9xEPZnJ/rvWz/Cpo4gLTg1jKaWD0z7qCP6WE4NyO/i6A5G3v/ds/wDh4PL6aksYeoffXWhlRPPkKyUgJAA6UH2lKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClK4POoYZW68sIbbSVKUo4CQOZJoOdKjEHtA0lPmMRIWorY/JfWG2mkSElS1E4AA86k9ApUZvevtK2O4GDdr7BjSxjc0tz1k/3sdPnqQxZDMuM1IiuoeYdSFocbUFJUk9CCOooO2lKUClKUClKUClKUClKUClKUClKUClKUClKUCvJHwhNX6jtHalcYdrv10hxENMlLMeUttAJbSTgA46163rxZ8Jn/wCb10/3LH/pJoPS3ZZcJk7setU6bKfkTFw3FrfdWVLUoFXMqPPPKqa+DFqq/wB77QJka83u5T4ybc44GpMlbiQoONgHBPXBPP21MOwDtBsl009Z9FJZm+kmorgcUpsBogEk4UFZ6HyqRy+zrTuhtOaku+k4DsW6C1SW0L7w44fibsAKURnKU0Rk3Pto0Tb76LU7dCt4OcJx1psqabVnHrL6Y9ozWuvPbzo603aXb5BuLjsZ1TSlssJUhRBxlJ3cx7a8p6DY0zJvpRrSZNiWwtKIciJ3K4mRgHkeWM9AeeK093TDTdJabW485ADqgwt4ALU3n1SoDxxig9fTfhAaNhzHozybpxGllCtscEZH/irb27tg0zcdZtabhmU5KcJSHwhPCBCNxBOfDBB5dRXjLU//AHiuX/EL/nXpLUPZLpzTvZ1P1FZm5qbs1bFOpUZBIBW3hZx7lKoJPfO37RdrnORWnZs8tq2qcjMgoz7CojPvHKs22dqmlta2S7Q7TLcbn9yeUI0lvYtQCDkp6g/Mc15S7OWtIO3aQnXb85mDwSWVRRnLmf0sAnp09vWt3pNGj2tSIXbZ+oe9b1iKkx2glQIIAWQvOCDzIHTNBHezSSzC7QtOSpTiWo7M9lxxxRwEpCwSTXp7Snb9py/akTaXosmCl53hR5LpBQ4c4Tu8U55efWvMHZrFYndoWm4sxlD0Z64MIcbWMpWkrGQR4inaNGZt/aFqOPCbSwwxcX0NIbGAgBw4AHgBQWz2rwuy9HaBdk3eRqKNcuNvlIiIQppS1AKJSVcxnNantc1qu0v6etOg7reLbbIlrZVw0Pqa3BxIdQTtVzO1Yz7c1Cu2B1b/AGh3N11RU44iOpRPiSw2TUg7bYrDNs0A+0w226/p6Kp1xKQC4QhIBUfEgADn4YoLc+Dx2jMSdJXRnU93lOTIC1Snpc50qSllW1KRvUc9QeXtrfP/AAgNCtSyymTOdQDjjIinYfbzwf4V5nkT7c32RQ4MZcZN2duri5ISkB1TIbGzcepTuKsDzrHsdr09J0pMlXG4Nx7k2shCVSFbiOWNrQaO737x81B7bsesbBfLC7ebbdI7tuZSVPOk7eFgZO8Hmnl51Xk/4Q+i40pTTIuUpCTjitMAJPtG4g/wrz/Cbg2/s91MLHqF+auQ3HEuJ3JbSUpDycKKySDzOMe32VgaAZ0K7Aup1tIubMpKR3MQ05CuRz4HnnHXAoPVkTtb0teNK3e6W2a8owI5deYLe15APIEJPXmRzBryzpbtL1JC1NaZV21Je37czLacktGW4ve0FgqTtKsHIyMGpZ2Jw9JSNVGPFeu8qU9DkIXHlRWu7uI4ZJC/WJxkAjl1AqsdFLhN6ysS7sGfRyZ7Bk8ZOUcLiJ3bgeoxnNB64vPbtpG0TUxZabnxVMsvjZHBG11tLif0uu1Yz7a2Oo+17TWn7TZLjPTPMe8MGRG4bIUdo2/GG7kfWFeWO3CVb5vaXdJFlWyu2KbjiOpgYb2JYbSAkeAGMfNW67YJkaToXszajvtOuM2pQcShQJQfzYwfLmk/RQXs52/aNRAYmFN04Lzi2k/7OM7kBBP6X9tP8aSe37RzNnYuCPSDgeeWyGQykODalJKiN2An1wBz5nPlXkuV/wB0rZ/xsr/yR6unsC7LNN620ZKuV8blLktzlsJLTxQNoQ2Ry96jQXNqTte0hp5iMq4XBRkPtIeEZlsuOpSpIUNwHJJwRyJrp0t2zaM1JPahRbg5GlukJbbltFveT4BXMZ9ma8euxmF61ei3hxTTAmLaeUtwoKAFEYKtqsYxjO048q3E6y6Ub1AtlGpe5xE7SlxhpcwJPsWEt5+ZNB7wpWDYl8SyW9ZfVIKo7Z4ykFBc9UesUnoT1x4VnUUpSlApSlAql+0vsNTrfV0q+G/mEX0No4IicTG1IT8bePLyq6KUFN9mHYinQuq2r0L8ZxQ0tvgmJw87hjOd5/lVxOIS42pDiQpCgQpJGQR5VypQUZdfg46el30TIdxlxICnN7kIJChjPNKV5yke/Na68/BqiTbtLkwdQdyiuuqW1GTC3BpJPJOeJzx516ErCvj02PZpz1qjokz22VqjsrVtDjgB2pJ9poKFunwa0TrjJlfhQpHGcK9vcc4yemeJV9tW9n0Oi3SUpfY4AjuBSeTidu05HkRVA6L1r2uTdaQot1sjot7j4TJS5BLSGm8+sQv2DOOZz7av68z2rVaJ1xkZ4ERhb7mOu1CSo/wFBR9++DVZpcxbtnvMu3sqUTwXGg8E+wHKTj35rfaJ7CrHpdciUZkidclsOMtvOpAQzvSUlSUDxwT1NUxc/hCa0k3Fx2CuHEjFRLbAYC8J8ASeZP0V6p0Nc5F60dZblN2d5lxG3nNgwNykgnAoin9KfB3RYNTWu7jUqnzBktyOF3Lbv2qBxniHGcdcU1V8HdF/1LdbudSqYM6S5I4Xct2zeonGeIM4z1xV+VAO2W86usun2HtEW3vshbhS+sN8VbSccilHjk+PPHlRUE1Z8HpGoL8/cjqRTHFS2nh9y3Y2NpR13jrtz89TLVPZLaNTaNsdluL7qZVoitxmJzSQlXqoSk5ScjB2g48POo32ba81oxYr/du0S1Pt2y3sB5DojBl1ZzzSEkgK5c88q3WiO23TusdSxbJbYV1alSQsoW+22EDagqOSFk9EnwoI5pn4OVmt0iUq73R65sPMqaS0GQzsJwQoHceYxyrWP/BjgGUVMallIj55IXFSpWP724D+FeiKpqD8IfSs25x4LVvvQdfeSykqaawFKVgZ/OdOdBJ9K9lGmdPaXn2NEZUti4JCZbr5yt3HTmMYweYx0POq5uPwZbY7KK7fqGXHYJzw3Y6XSPZuBT/KvQlKCvOzHsnsegXH5MRx6bcHkcNUh/HJPilKRyAPLz6VC9UfBws1zuj0u0XZ+2NOqK1RyyHkJJ67eYIHs51e9KCjr98He0XK2WxmNd5MWZDYDC5BaSsPAEkEpyMHnjr0ArFuvwb7XItVsi2+8LiPxwsyZCo3EVJUrbzxvG0DBwOfWrA7Ybxquy6abf0TbRNmKd2ukI4imkY+MlHjz9+PKo72H6j19fJc9GtratiE22FMyHY3AWXMj1QOWRjJzjlj20EXd+Dahy0xoP4UKHBfde39x670tjGOJ4cP+NWh2S6FHZ9pt+0puBnh2UqTxSzwsZShOMbj+p1z41NaUFRdonYVY9XXd66xZb1qnvnc8W0Bbbiv1ikkYPuNarSfwdLFabizLvFxkXbhKC0sFsNNqI/WGSSPZmrypQAAAABgClKUClKUClKUCvPfwiu1W76cvLWndNP90eDSXpMkJBWN3xUJz05cyevMV6ErzT8Jns4u9wvyNTWOI9OadZS3KaZTuW2pIwFBI5kEY6dMe2gru5a87RIekYguE29R2JUjvEW4qcWhTidpBQFfpJ6KA/zr7A13qtfZ5epStSXcyWrlCbQ6Za9yUqbklSQc8gSlOfcPKtHqK8aqumjLdFvS3PQ1qdTFjIcaCCFbDgZxk4SnHPpkVstD6dn6j7M9YNWphyTJiS4Mrgtp3KWkJkJOB4nC849lETbsh1fqO46V7Q3p98uUl6JZ1ux1uyVqLK9q/WSSeR5DmKivZ1rrVc3VKWZeo7u+13OYvY5LWobkxXVJOCeoIBHtFYnZ0nU8G06xiWu0KXHk2xxE52QhSeC2lKiceaiMgDz91a/sxhSkauQVxn0juM4ZLZH/ANo9QSDsq1zqqf2j6diTtRXaRGemNocadlrUlaSehBPMV6c7aok2b2Wajatsnuz6YqnVL3FOW0EKcTkfrICk46HODyryR2PwpTfahplS4z6Uic2SS2QBzr2Z2jJKuz7U6UglRtcoAAZJPCVQeGtA2653bWFsg2KZ3G5vOFLEjepHDO0nOU8xyB6VaXav2m6st13j6UtVzeZctjDMWTIjklyVICE71biN2N3IdCepqI9hkOU32s6bW5GeQgSDlSkEAeoqpH8IHQl9tevp1+gQ5L9umuCQ3IjoKi05gZCsc0nIyDQarWOvu0aDAs9vvcm8WmVHQsh7ethcpB24K8Y3FOCM+3n7dkrWmp/xGIuP4QXTv/4RmP3jvS+Jw+7BWzdnO3PPHnUR1zH1pcoNmuurFzpQlNrEQPAlaW07cnaByB3D2nGfKtqqHJ/J9Q33d7ifhOVbdhzjuo54oM/Tt21Tqvsx1z3q/wA6QmCIr6xJkrVlr88FoHXr6vLodtRPsntt1u+v7VDsE7uFwUpakP8AEUjalKCpQynnzSCPnqxewLT8686N7RrU00pqTMhsNs8UFIUr87gZPtx9NV1ZG9WaE1YzLiWyXFu8YrQhLsUr5qSUnAxg8ielB7m1LFmTtO3SJa5HdZ78V1qO/uKeG4pJCVZHMYJByK/Pi1sSH71DjxXeFKckIQ27kjasqACsjnyPOv0Nsrz8izQXpgKZLjDa3QU7SFlIJ5eHPPKvC+qtH6i0TqpaX7fJzGkcWPJS0VtuAKylQI5Hw5UFmdrHabqvS7kLR8K47Jtvhstz56DvcfeKASQpQyBzHPrzqFq132maVmRnrhdLu2p0b0NT8uJcH91Wf+VcdbaX1lqCJH1rcLdIkquKcyCzHKVNKQdgKkAZAKUpIOMVjQLprq7zojFkgyGJDQ2JTboCWNx5c1lKQCeXVVBIO1PtQ1FcplhuFrulxtKJVrQt6NGkLbQHQ66hRAB8dv0YrFv+sO0D8XWm5791ls2xbrzbctEpXHkOBaslZznAHqgf2fdXT23We/xL1YWb849PuqbS2ZDyU7gFF107cgYOAQPmrZ6tiSFfB30M2mO6XEzpRUkIOR+cc6igOdp2qJ/ZC9vvExu4wbuw0JjTpQ6tpxl47VKGCebfj7PKo5G1/q5Wlri8dTXgvImRkJWZjmQkofJAOeh2p+gVgwIUodmV6SYz+43aCQOGckcGV/nWviwZf4IXMd1fyZ0QgcM/1cigmGktRdpeqLVdrfYpt4uaiplTrveyVsJG/ASVK5bj1x+rXqTshjXmH2fWtjU3efSyAvjd4c3r+OrGTk+GKpz4IEd5iXqnjsuN5RGxvSRnm7516UoFKUopSlKBSlKBSlKBSlRe+6uRZ7iuI7CcWQAoKCwAoH5qCHfCK0betZ6ctcTT0VEh9iWXXEqdS3hOwjOVEeJrXfBu0Jf9Eo1CNRw0Ru9mPwdryHN23ibvik4+MKsS4aujQ7dBl8BbneklQQFAFOOufnrlE1dEcta58ptcdoL4aE53KcOMnAq0JJinKoWjtAhl3Cob4bz8bIJ+iuvXN5jytPRu5qLiJK8hYONu3GQR89KE45Uqo9H3gWq5OOuNrdC2inAVjHQ/8qlMbX0V19KHIjjSD1WVg4/hShM6VFrTrGLMZlvSWjGajgHcVbirJOABjrWIvtAhhwhEN9SP1ioA/RShNKVrbHeol5YU5EUco5LQoYUmtlUCmKUoFMUpQKUpQKUpQMUxSlApSlApSlApSlApSlApSlAqCdp8HLcSckfFJaX8/Mf8/pqd1h3a3M3SC5Ek7uGvHNPIjBzypApVx9x5phlRyhoFKB5ZOf5mpBq63uW6BZmFAhCWTny4hOVfzH0VLI2h7YxIadDkpZbUFBKlJIOD48qkFyt8a5RixMaDjfUZ6g+YPhWVoqaU5ZjYWUx2nhdMjeok49vjismGh38CJ6lA8LvKNvv8f+VTBOhbSlzcVSVJ/UKxj+WakAt0QW/uQYQIpTt4eOWKWKm03PYg+ke8kjjRFtIwM+scYrp02w1KvsJl9AW0tzCknxFT5ehLSpZUFSkg/ohYwP4Zrut2jbfAmsymXZRcaVuSFKSR/KljTa+tEW32llcCMlpKngHCnPPkcZ/jUThqt/o54Sf+s59XCFFR9x3AD5wauWXGZlx1sSW0uNLGFJV41Gl6FtKnNwVJSP1QsY/iM0iRrOzkQu+yDEEvicLCy5t2dRjpzz//AGp7WFarXEtUfgwmghJOSepUfaazaxlSlKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKrjtFu0j0mIDTq22G0ArCTjcTz5/NirEWLGCkk4CgT7DX2qgdsV5hJjvpQsFzmgtucx/GvupX7gpNvFxC0SEslJJVzUNxweX/8AuVKRbqlBPxiB76+1Utsst3vNsaVGWgxm1qCQpzHPln/lX29XS43K5+j2XFpQhYYQ0hWAojlz8+dKFs1B79H1Uu6uqhuK7tu/NcNaUgDwyD41Fi/d9NXBKFuONOYC9hXuSsfy8DXVqSWqTeZD6FKSl0IWBnplANWhbtuEhEBgTlJVJCBxCnoTWQlSVfFUD7jVUaokz+725tanUw+6MlGCdqjsGSfbmtdbYcqQA5DltJezyRx9i/mzipQuknAya+JUlXxVA+41VGrn7qh2MxOU8lpLKAAScKVtG4k+JzmtfbYcuQEuQpTSXs8kcfYv5s4pRa6KVVOq7tcFyWoCnXWwy0hK0hWCpZSCSfPmaxL43d4UaHGue5KEBRZ9cE4OMjI8sD6aUWuGhIAyeQqmVOL/AAaQd6s97V4/2BXO3pmu2G6OMyNkdotl1JJyvJIAz5c6tC4xz6V8UpKT6ygPeapyzX6Za2ZKGXlYcb2pBOQlWR6w9uM18t1sud6TIfjkulvmtS3OZPz1KFy0qtdNy7xaGJLr7bq4aWVKAWrISoDl4568vnrQKk3C8SVqdlFS/jfnHQhI9gycfMKUWumlVpo2ZeI10ZaW3KdhrVsWFJKkp/tA+FWXSYpSlKVApSlApSlApSlApSlAqDa603LnTROgI4pKAlxAODkeI+apzSgp1NivklSGlRJRCeSeJkBPuzyrNvmmp8VuCyzHekLDRLim0lQCio8voxVq0q2lI5oKK/EsPClMrZc4qjtWnBxyqMal0xcY92dmW1tbra18VJbPrIVnPT3+VWVSlqqhjT18vM5K5yHkZwFPSOWB7AeZr5qKxT/TEgRIMlxhO1KFJbJBASB/yq2KUtKVvOg6hY4DkJD5jqjsgtjCgCG0ggoPjkeVacWG9T5RUqC4hazzKmw2kfyH0VcFKWUrm6W3UcKR/spdfY4aAdpC0khAB9U+0eVaVGn71PlFRguIWo5KlIDaR/IfRVwUpZSttUaVuAebkRkmUS2hLm3424JAJx45xWqmaevPdYzzzEh5bm4BvBUptIxjPlnJ5eyrepSylTGzXL8HkNdxk8QSlK28M5xsAzWdZ7VPb0xfGXIchLrvC2IKCCrCueBVl0pYqO06YuEuQ4y/Fej5bJS44ghIUOgNdS7DfIi1toiSRu5K4XMKHzVcNKWUrrTOkZay+5cklhCmlNoSTlWVDGceytUqx360S191Zfzgp4kfmFD5qtqlLVXmktP3UXJuVOU9HYQreUqWcuH3f51gm06i9P79sjjcTPHz6mM9c9MeyrRpSwpSlQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUqIagucq2XGfEbfVxbiyj0fu5hDxUG1Aewbm14/vUEvpUVjXmc2G3Vd3XBTM9H7Fbi+SHOFvKs4PMbsY6c810W28TZARDtiIzKkNOvrXKUtYUA8tASDnP6JJPPGRyq0lpjStLYJomSbg5tSCOEolDpcSrc0lXq+GOfhjPWtUjUk9uzJu8hEExXoy5DTCVlLqcJ3BJJyFcuuAMe2lFpfSopNvtztwksyEQpEoMtvNFkKSj1nAjarJJ8eR8efLlXVMvl6hC7LebgLbtiUuuFIWC8gp3EJGfVIAPM5zy6UotMKVEXL5eFOIXHZg8ByeuCkL3bhgqAcJz/Z+L4+Yrpd1Lde9i2tRmFz0OvIcdQgqbKUBsghO4HJDqfHlg9aUWmlKiSb9dpbTPdI8Rl0wlSnA6SsbkqKdo2nocdfDyppm43G43+a45IY7guPHfQwWzuSFoURg7sZ8zjnjwpRaW0qLyL5cUT55Q3F7lDmsxVAhXEWHA1zBzgYLnkc48K6ouop60QZbjcXuk51bTTKQritkJWoFRzg/E5gAYz44pRaW0qKOaklmHbFxo7L0iXbTM4QVj1stAAZPT84eXjgCtlY7jJuUCXuU0mWyst82VoCVbQRuQo58R0PMeNKLbmlQqy3W9+iNPoU7CkyJ/JTq0KGxIbKiT6x3K5Y8Otd7OppRuBbUmO5HcTILSkIWObf8AaPJWfHAGPM0otLqVDk6hu7bTQdixnn5MREtltnI2DehKknJ9YgLBGMZwRWBPkS79MsLa1wlIEx1t5pyO4BvS0pQ3JKgQcYIHPng5pRawKVGGL5OU6zIWiL3B2aqElpIPGSQtSN2c4PNOSMch48q6It7vMli2KS1BbXcHnEIyFKDaEoUdx5jJO0cuXWlFpdSoW1qe5MwWLhNjRlRluSGFNMhRc3spcJUCTjBLRAGPEc65zdSXK3QXnpKIT61292cwGdwCdgSdqsk5B3j1hjoeVKLTGlRSTe7vFfkxVRo78lAZcBZSrCUOcQH1ScqKS34EZB6cq7LlcnJmhZk1DgS9wlgqaCkbVJUUnkeYOQeXhSi0npUXVqGSnUDUUBhyG5KMXKULylQQpXNZwknKcbQDjzqUVFspSlApSlArokQ40l+O8+w247HUVsrUnJbJBBI8uRIrvrHkT4kd9tiRKYaed+I2twJUr3A9aDrFrgCd3wRGO9Zzxdg3ZxjOfPFdcmy2yS021Igx3G2yopSpAIG45P0nrXcu4wm+LvmR08EZcy4BsGcZPPlz5VwFxZc7oqKpEhmQspDrbiSkYSTnrz6Y5ZojIYjMsKWplpDZXjdtGM4GB9AAFYrNmtrMh19qDHQ86CFrDYyoHqPn8a7UXGEtt1xEyOpDXJxQdSQj38+VcXLpb2mG33J0VDLhwhxTqQlR9hzzorjHs9ujsraYhMNtrIKkpQACQcjPuNdz0GK8mSl2O2tMlIS8FJzxBjGD58q4vXGEw8hp6XHbdWQEoW4AVZ6YGeea5CfEMwxBKYMoDJZ4g34/u9aAIUYJSAw2AlwvAbeiySSr38zz9tdEuzW2YlaZUJh0Lc4qtyAcrwE7vfgAV3Rp8OU84zGlMPPNclobcClI94HSj8+HHktx35TDchz4jS3AFK9wPM0H1uDFaCQ3HaQEt8EBKQMI/V93sri1boTLzTzUVhDzTYaQsIG5KB0SD5eyvvpCH3sRe9x+8kkBriDecc+nWkyfDhFAmSmI/EOEcVwJ3H2Z60H1UGKri7mGzxXEuuZT8ZacYUfaNqfoFdbNrgsTFymYjCJK87nEoAUc9fprtVLjJUpKpDQUlSUKBWMhSvig+05GPOuDVxhOye7tTI65HP8ANJdSVcuvLOaDobsdrb37IEZO9JQcNjmkkEj3ZAOPZWVChRoLRbiMoZQTuIQMZPmax493gyJMplmS0oxhl0hxJCfPPPljxzXJu4sOvqS0ttbCWytT6XElIIOCDzzy+iiOTFsgx1pXHiMNKStTgKEAYURgn3kV1CyWxK94gxwrcV52D4xzk/Pk/TXa1c4D0YyGpsZccK2l1LqSkHyznGa+G628QxLM6KIpO0PF1Owny3ZxQHrZBeShLsRlaUN8JIKQcIyDtHsylJ+YV9YtsKOGQzFaRwVFbeE/FUQQSPaQSKP3KDHDJkTIzQe/oyt1Kd/93J513yH2YzRdkOttNDqtagkD5zRWOi1wETjMREYEonJdCBuzjGc+ddiIUZsMBDDaQwSWsJ+JkEHHlyJ+muv0iyXRhbZjFri944idmM488/P0riLxbCEkXCGQpfDTh5PNX6o59eY5UHamBEQhpKY7QS04p1ACfirVu3KHtO5X0muhqyWxpp9pqBGQ2+nY6kNjC0+R9nsruNxhJkpjKmRxIUcJaLg3E+QGc1ixr7BcgiXIfaiNKecZHHcSjKkLUg4yfNJonkyZVthSlLVJitOKWEpUVJySE5Kefs3K+k1yECKIRhiO0IpBSWtvqkHryrI3p2b9w2YznPLFRe3avYnTGkMojLjuynIyXG5IWU7EukqUkDkDwjjnzBzVPJul2e3LfU8qEwXVLDhXsGdw6K9/LrWfWJKntMx+I0pDyijiIQlxIK05A3Ak4xzHP210XK9QoBKHH2lSApA4CXE8T1lBIO3Occ6itlSsZufDclriNymFSkDKmQ4Cse9PWsmgUpSgVGLlaJpuNxcjxoUtueGwVSlH8ztTtxtwdw/Sxkcyak9KCKOacdTHW403HVJ9JKnFCjhL6cqASo48AQRyOCkVxTp+YuW1JcTGb3zVyXGEKJQhJjKawDgZJJBPTqaltKtpSEx9NTExX2FtI7uEtBlkycqSpCichwIBwOWArNfTp+7LjsNOqjqG19KiCkLSFkFOVBHrDA54255VNc0pZSEjTE1yz3Jt5EYTX7YzDaXvJ2uNpWM5xkDKknNZrFmnNSFMd2hLYVLcld8Wol1IWpSsBOPjDdtBz0HzVKaUspDdK6blWybCMlptKIUdTIdTJWsuk4GdpACQcZIOeePLNcb3pmXLu1wdbQh5maptRWuStvg7UhONoHrfF3DmOZNTSlLKRd7TzylSnG0sh526szUrzz4aS3uGcddqVDHtrr1PYZU67KmRmkSEORRGLa5KmQjClHPIHIO7mOXxRUsrClW5Eh4uKefQT4IWQK16meeMXhFz/eljGJ5o8NOSkXm3TUhgogttMBsqUeKAkgrJOfWTk7c5/S58+Wusdnmy4DDXdY0dlFwkSe9BR4v9K5yCcdTnBOelS30Q38plfWmvnohv5TK+sNaONtHpx3fDLcw6onb9JTmYao622UKZt7sRt3vS18RSkhIO3ACRyyRz5+6tleNLuSoqo0MtR2RBTHSlJKRuDiVY5fokJwT7a3fohv5TK+tNPRDfymV9aacbaPTju+Dcw6o23piU82+p6Oy0p2TEWptUhT25DToWokkAZxkAY8OZ8sl2wzWL09cYzMZ9HeHFtxlr2J2raaSVZwcKCm1eHRRrd+iG/lMr6009EN/KZX1ppxto9OO74NzDqi07S89xfFTGiLL0QR1MNyFstsnetXIAHcDv59Pi+3lv7zaVybPCjNo4rkZSFJPGKCClJGQrB58/HOedZXohv5TK+tNPRDfymV9aacbaPTju+Ddw6o69pq4SLatiQqOta4Tsc9ACVOhQBwkA+ryJwMnwrKummlSF6iUw1GSZ8FEdgnltWkODJ5cvjI5+z2VuPRDfymV9aaeiG/lMr600420enHd8G7h1RePaZst27MoiRQ29cg6qUpRDiNmw5AxzPq8jkdfZzO6WnoXHfShuQtHekFnvKmgA68XAoKAPhgEY/lUn9EN/KZX1hr76Ib+UyvrTTjbR6cd3wbmHVwsEaRb4ke3OMoDEaM2lLqXCoKVzCkgHngYHMnx9laoadkFqC3llIanSpDhSf0HQ8E45cz+cTy99bj0Q38plfWmnohv5TK+tNONtHpx3fC7uHVG12C7SIkdh5EVsR7cYQKXSd6tzR3dOQw2a5ztPT3BMjtsQ3EPXBuamU4s7wA4lRTjHUBO0HPTFSH0Q38plfWmnohv5TK+tNONtHpx3fCbmHVHLRpeXDusVTqEKZjyXZAkmSsqXu3Y/N4wD6+DkkcunPlNa1zdqQhxKhIknac4Lhwa2NbtPPUz/AImNfW0mIjlJSlK2IVCdSahuUS7T2oy2WGoTbbiUu7MPlQzzJUCBn1fVBOc9elTatVOC1ywpVpbklo/m3VKTke7PMVr1NbHSjeyv6RM/6iVjGcvKGqsrsj8MLu1IueQeG43DUEg7Sgcx44B5ZHz1hTtQXBqVfHETYiU26UhpuGW/XfCkIVtznOSVEJx4+dSLvMvicT0T6+MbuKnOKwY0RTEyTK9D8R997j73HEEoVsSn1TjIGEitHj9Lpl2ZfZlwcv6e8fdovSTkeQZrEdviR2LqpLSAQFlD6ACQPE45+81yv1wuCrLeIzN2bkkW5coSYzaQWiP0eRPJQyQevqmpOl6SlQUmzgKGeYcT4nJ+k9a+MuPsJUlmyobSo5UELQAffV8fpdMuzL7HBy6x7x90cv2opVuhOOwbm3NMWIZSlJabKXRuUBlWQMeqR6ozXQ7dJUGbqmXEnRkiPJbdTFUncp/LDXqg5zz6DHifGpQourKSqxtqKQUpytBwD1A5dK+ALC0qFiaCkHKTuRkHAHLl5AD5qeP0umXZl/ycHLrHvH3Rw3WbFS1FiLDAkzJqlPK2Hbsd5IG8gZO4n3JNSnTlzNwtkVclxgy3GyspbUCFJCiN4GTyOPaOfU11PF19otPWRtxsq3FC1oIz54x1rKgqcVIBctyY+1G0Obkkgfq8vCrjtmnnMYxE3/jlH6zBOllj5+XvDYUpSulgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpWob1LaHNSu6fRNQbw03xlxtp3BGAc5xjxHj40G3pWOzOiPvrYZksOPI+M2hwFSfePCoz+MnSIvC7Wq9x0zkPmKptSVDDoJTtyRjOQR1oJdSsU3KCHXWzMjBxoFTieKnKAOpIzyFYk3UdlgxFSZd1gtMJRxCsvpxtzjPXmM8qDa0qOWHW+mr/x/RN5iSOAne6N+0oT+sc45e2ty3cYLqFramRloQApSkupISDzBPPkDQZVKxmZ8N6MuQzLjuR2wSt1LgKUgczk9BWBcNTWW321+fKucURGUBbjiHAvakq25wnJxk4oNxSsNN0gKEc98YBkJC2kqWElYPMEA86+qucBLrjSpsYOtgqWjip3JA5kkZ5YxQZdK0tg1TZNQWp65Wi4MvwGVltx/mhKVAAkHcB4KH01sGrjCdQ4tqZGWhtIUtSXUkJBGQTz5DFBlUrDbutvc4nDnRV8MBS9ryTtB6E8+Vck3KCqIqUmZGMVBwp4Op2D3qzjxFBlUrA9M2zCz6Rh4QkLV+fT6qTjBPPkDkc/aK74s2LLKhFksPlIBPDcCsAjIPLzoMilYhuUEF7M2MODzdy6n83/e58vnrGlahs8aJJkvXOGGY7JfdKXQopbAzuwOeOn0ig2lKh6O0jS7r1vbj3DjGew7IjqQ0ohaG9289OWNivorLset7BedNm/R5yGbUHC0X5I4QCgcY9b30ElpWM/Phx2G3pEphplzGxa3AlKs9ME9axDqC1C8i1Ga0J5jd84XP+hzjfnpjI86DaUrFRcoK4ypCJkZUdJwp0OpKQfac4rVz9YafgT7bDk3WMJNxXw4qEK38VWQnAKcgcyBzoN9So85rC0N6xTphbzguyme8BHDO3ZgnO7p0BrbR7nAkvBmPNiuukbghDqVKI88A0GXSlKBSlKBVWzdCX8dsq9W2+ZBbt77SI7za9xdLexIVjljOU8udWlUA1d2n27TWpm7I/bblJkqSlW9lsbPW6YJI3H2CgjHZh2T3PSWsE3ObNgyI7KHUpcbCw89vz8fPLx9vQVpldjF9TrG53xuXaXQ/dTNaZfC1JCC4tWSMY3jIx1HM1On+1e2jUkq0R7bcnu7yVQ1zEM5ZS8OqSc56+NRvTfbcyrR0K532A45cJkt6OzHgo+MlsJUT6x8AseNEdOkexqfadXOTblNgzLervAU5hfeHkupKcK8Oh9taS3dgFx9DXmNcrrGXJW2hm3uJ3KDaA4VkKBAxnl0z1NS659utigLZC7XdVByIJf9GlJSkqKcEE5zkVsLn2w2aI7CbjW66TjIhtzl92ZCuC05jaVDPXmOnnQV9E7HL7ZLNqW4S340ua7aDAjRYCVHiEIQkE5A54QPeSTXbpzsbvS9PPuvOwIz8y1MRkxVJcRlW9Dii9g53DaU8vIe6rBb7XLK/qtNjjQ7i8rvCYqpKGvzaHD4EZzy8TiuWue1m0aRusy3yIU+Y9EZQ8+Y6AUthagEgkkczuBoMHRXZ1c7H2aai0/Ket5m3Jp5ttTCVBCd7WxO44yffj6ajGhOxObZ79a372u2TLa3DcjzI6SpXGUpa1JOCACBlHX9WpDcO3CywlykuW24KLECPcFbdnNDwaKUjn1HGTn3Gs3R3aM/qPtKmWJEZtq3ItTNwZUofnMuIaXhRzjo7/Cg0GtuyC4XrXKrvAmQEwHOAkNPpXvjJbSE4b2+eM9RXZpjsouVu7R5N9nLtLlvdVIUptKVrcXxErT+l05K5jJHsrat9tmn3HZQRDuJZbakOsPlsBEngpKlhBz1wPGu+J2u2x/Szd9ctN1ZjvyERYjam0lUpxRUMIwcHG05oI7a+zy96U7HdYafUpm4Oyit2KmKlRWvKUpwQR19Uch7a0en+xe8v6alqemxrfInWliOhhCFpO8KQ4rjZPxvV2HHh9FTCH25WKU0Ci23TjKlmIhgNpK1EDKlYB6AY5dedcGe3Syu260zEWq5lNxluQ20AIKgpHCyT63jxU49xoI3a+xa+RYepmnX7P8A9KNMobabLqW0bXAojzA5cuZqRWbsuuMfsivWlJUqAibPd4qHWEENpwUEBXifiYzjx8ax7b20tXvV2nIdoiEWye28ZHGR+dQpAUcJwcfoj6a2ETtvsT0O5SnbbdI7EJG8qcbTlZK0pCQM8iSodccgaCGM9iGohGviHZ9rK51rjQGykrASppcc5Pq9MMn5yOlS3sp7Mrpo7VE2fKlRFQ37azE4bClZ4qUNhS8EAdUrPz1KdM6/iag07dbpFttwaVbgouRnUALXhJOEnODnB8aikXt507IYceRCuPDbYS6shKThal7Ut9fjHr5YoI3D7Crs2qeh27w0oXFfYQ62hfEklwkgvZ5cvZ5Cu/SPYteLdLvBus23OMTrIu1o4QUooWUoCVkEeGzPXyreao7Z24WjF3q0Wl5chi4C3yYsz82WF7VK54z5fzreWvtRhXDVkqwNWu4KfiAGRIQlJabTt3FROc48OnjQQOwdjeooM/T7sqdbFM2uJJi/m1LyoO8Yg80+b30CphovQ150z2YKsGLNNuPeFOgSkKcjlJUDzGAc8qz9Edqdp1fevR9vg3FoLQpxp95oBtwJODzBOOh6+VYDPbJaVvX3iWu5txbMtbcqTsSpsKCilI5HqojAorj2r9ntz1e5Y5EJ227oLTjbsWUlfAUVpA3JCeeQRy+asi6dmbU3s79DIXGYvncUQhcEIPJCXA5sGSTsJyMZ6GsUds9q/B+Xdl2e7NsRX2mnUrbSCA4DtWDnBHL38xRztrsibYmai33F1D0xyHFShKSZBbAKlp5/F9ZPXzoI1H7HLy3oi52lT1n7zLltPhCOKloJQlY6jnuJUD0xy8fBH7G7zGjaRfZl2lNys05Up4pbUlDiSttQHIcyNh8APWre3LtzscBcNK7XdVd5hmYBw0pKEhSwQQT1yg+zpXZd+2+xW5cUdwuDyZFvTcEKSEj1Dn1Tk9eRojnqvs3uV77Rpt+ZnR48ORanIAwVcVC1NqSFYxjAKvOtP2X9k140nreLeZ0i2KjtQzGKI28KKsAbsEdTjJOep6VbOmbwzqCwW+7Rm1tszGUvIQ5jckEZwcVs6KUpSgUpSgVENQdnOmtQX1N3usJx6YkoV/TrCFFIwCUg4PIVL6UEOd7NdLO6jcvi7ce/uOF5RDqgguH9PbnG721ijsn0h6CZtPo5fdGXlvtHjr3oWoAKwrOcEJHL2VO6UEBmdkWjpeziW1YCIwiJCH1pAbBzjr1zzzXbcOyrSM/uHerapXco6IreHlp3No+KlWD62PbU5pQQ9XZtpY6jbvgtiUz0OB4FLigjeOiijOM/NWv7TOy+0a2YkPHEO8ONoaE0AqwlKwrCkggK5Ajn0zVgUoK7X2Q6XmQIaLvEVJmNQGILshDi2+KlpKACQD/YFb2xaGsVivy7xbYzjc9UREIrLqlDhIShKRgnHRtHP2VJ6UEIT2WaQRJnPotQS5LbcaXhxWEpcBC9gzhJIJ6V0ao7NIFz7P4+lLS8bdFjOh1hxSeKps7lKOCTnqo881PqUFV6V7FLBa7H3G8lV0eMrvXGOWtqsYwADnGOozzrbR+yTSEePbmWoDwbt8lUuOO8L9VxWzJ68/6NHL2VPqUECtPZLpG0zIkqFAdS9FCw0VSFqA3ghXInnyJr7C7JdHRGZ7abYpxM1sNPcZ9aztCgoAEnlzAPLyqeUoNDpPSVn0pBfiWWMWWn18R0rWVqWcY5lRJrSwOyvSEG23KAxagYtwUlT6VuKVkpJKdpJynBJ6VOKUEOPZrpU6YdsBto9HOvCQscRW9Tg/TK85z4daydN6EsGnLhLm2uK4iRKZTHdU46pe5CQABgnyAqUUoInprs801pq7uXKz2/gSlJKAS4pQQknJCQTgfNXKD2f6chxr5Hbg72L0viTUOOKUHFZJzzPLmonlUqpQQyF2ZaWhWK5Whi3q7lcdveQp5alL2nKfWJyMHpij/ZlpV/TkKxuW49xhLU5Hw6oLbUo5UQsHPP/KpnSggMrsj0dJMffbVgMRTDbCH1gBslRI68zlaufXnX24dkuj7gzDak25ahEjCI0Q+sENgkgEg8+pqe0oI9p3R9o07KEi1tPtrEZEUBT61pDaQAAEk4zyHPrUhpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpQ8utApVZ6w7adKackORUPO3OWjkpEMBSUnyKycfRmoWv4ScIKOzTckp8CZaR/wC2g9AUrz9+UnD/AHakfax9yn5ScP8AdqR9rH3KD0DSvP35ScP92pH2sfcp+UnD/dqR9rH3KD0DSvP35ScP92pH2sfcp+UnD/dqR9rH3KD0DSvP35ScP92pH2sfcp+UnD/dqR9rH3KD0DSvP35ScP8AdqR9rH3KflJw/wB2pH2sfcoPQNK8/flJw/3akfax9yn5ScP92pH2sfcoPQNK8/flJw/3akfax9yn5ScP92pH2sfcoPQNK8/flJw/3akfax9yn5ScP92pH2sfcoPQNK8/flJw/wB2pH2sfcp+UnD/AHakfax9yg9A0qgmPhJW5TgD+nZaEeJRJSo/QUj+dWTojtM01rFQZtcwtTfkskbHD7h0V8xNBNKUpQKUpQKUpQKUpQKoz4SuvZFmiM6btLxalTG+JKcQcKQ0TgJB8N2Dn2D21edeL/hAOuO9rF7DpPqFpKc+XDTQV3SlSfszZiv68szVwbZdiqe/OIeSFII2nqDyPz0RGKVcj+mtPag1AtQG1pFujvMtw+FHVMKyd69oSUpKfilIHUZrT2fSGm331x5EqY4p+7v22O6h9tKW0JbCkuKGFbuZxyIB8DQVnSpxddM2uLpqHNYMhfFaYWqf3potb1kb2w1jflHMdSeWcAVIJWhdONTmUOPzGWN8gJzLacVMZbYW4l5G1PqAqSBg5+N15UFT0q2rdYNPC3XhuJb35r0q0x58ZpyW2HWsuDelKijqMEkgDKeWPGtXatLaclTdPw335aH5tvVOfV3hASteFbWUDbyJKRzJPXGKCuaVYt00vp62u6jcdXOcbgR462Y4fbCw44cFKlAHIT16A+BArH0Po6FqC3QZTzziR3x9maUvIRwmwylTRAPP1lFQ8c4xQQKlT1GmrGvSaJAdlC6qtSrlv4yOEFJfLfD2bc5KRnrXPSGjrfedJSp0h1xE494EbbIQkFbbQWlJQU8yo5Hxh7AedBX9Ks53SWnTqG62+EmfLXAYbUhjvjTa5S1FO4pUU4ASD05k4zyrtsFg09MtabbObcS4/fXYbMht5riNJ4SdpWsAhaQfAEA5JzQVZSrdtVstktD0SVFVdJbmnI7sdAeaZUlXERuSglBwoDJ3HngKBznIwXdE6cTpq2zTcn2lSO7FyWXUKaBcUA4jbyIKAT4n4vMAHkFYUq1LVYbHa+0OxxptteTEfdcbLUuaw8leOSHDtT8U56Ec+WCa+QNEWORarlJmGZEksuvoUwJTSu5hCApJXkAL3Enpt6YGTQVZSuSAkrSFkpTnmQMkD3VNhbdPnRU6QuZILjTn+xPLhJaW67y3NcnDuTjBJx6vnzwQg9dsWQ9EktSIrq2X2lBaHEHCkkdCDXVSg9rdi2tVa10e3IlkekoquBKwMblAcl/OP45qfV5o+CS86LzqBkE8BUdpavLcFED+BNel6KUpSgUpSgUpSgV5l+FHpF5i8R9TxWyqLJQliSQPiOJ5JJ9hGB70+2vTVY1ygRbnAehXBhuRFeTscacGUqFB+elK9D6z+Du6ZLj+krg0GVHIizCQU+wLAOR7x89QxXYPrcKIEWEoeYlJoiq6Vaf4iNcfJIf2pNPxEa4+SQ/tSaCrKVaf4iNcfJIf2pNPxEa4+SQ/tSaCra+Vaf4iNcfJIf2pNPxEa4+SQ/tSaCrKVaf4iNcfJIf2pNPxEa4+SQ/tSaCrKVaf4iNcfJIf2pNPxEa4+SQ/tSaCrKVaf4iNcfJIf2pNPxEa4+SQ/tSaCra+Vaf4iNcfJIf2pNPxEa4+SQ/tSaCrKVaf4iNcfJIf2pNPxEa4+SQ/tSaCrK+kkgAk4HQVaX4iNcfJIf2pNPxEa4+SQ/tSaCrKVa7PYLrZxYStiC0P1lSQR/AGrO7POwWBZpTU/U8hFyktkKRGbThhJ8znmr+A9hoNh8GvST1g0i9c5zRbl3VSXAhQwpLSc7M+/JPuIq36AAAADAHQClFKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUrEuE9qC3lw5WfipHU0SZjGLll10uy47X9I8hJ8iaic26yZRIK9iP1U8qwKluTLa4/lhNhc4ZOBIb+msht1Doy2tKh5g5qA1zbcW0rc2tSVeYOKWxja5/OE+pUbtt9WkhEz1k/rgcx76kaFpcQFIIUk8wRVdWnqY6keT7SlKNhSuKlpT8ZQHvNdK50VHxpDQ/wDEKkzELETPJkUrAXd4Kf8A64PuBNdDl+hp+LxF+5P+dYzq4R+bZGhqTyxn2baldbDyH2EOtnKVDIrqmTY0JhT0t9phlPVbqwlI+c1nE21TFeUsmlR2PrXTMh/gsahtDjpONiJjZOfdmt+hxK0gpIIPMEeNBzpSlApSlApSsO5S1x+C0wEqkyF7GwroORJJ9gAP8B40GZStMq0TXDuXfZ6FHqGkNBPzAoJ/jXz0LL/b90+hn/ToN1StL6Fl/t+6fQz/AKdPQsv9v3T6Gf8AToN1StL6Fl/t+6fQz/p09Cy/2/dPoZ/06DdUrS+hZf7fun0M/wCnT0LL/b90+hn/AE6DZzpKYkZbq/DoPM1CpL7kl5Trpyo/wrdy9NvS0pS/fbooA5A/Mj/9dY34Go/bNz+lr7lSXNraWepPlyailbf8DUftm5/S19yn4Go/bNz+lr7lKaPC5tRStjL0w/Djrehz5EpSBuLL4R6w8gUgYNalDyXIoeaOUKRvSfMEZFSmrU0stPmF9PELaEuurHVLLSnCPeEg4rKjXedFTw2I88NnnzgunB/w1KNLsIYsEHYPWcaS4tXipShkk/Oa4NahgOanesCVOekWo4kqTwzt2E4+N0z7KmWO9FW9DZ9KNHKM+c/ojjl4uC/jN3L5oTo/kmuhc2Uv4zV0PvivfdqVRdQwJOpZliaU76QiNIedBbITtV0wroeorb1qnZ4nnlL0Y2yY5Yx7K5Lzh6xbh9je+7TiL+SXD7E992rGpWPhMOss/wAR1Okfv6q54i/klw+xPfdpxF/JJ/2N37tWNXFZwKeEw6yfiOp0j9/VXOq9fwdGaFVcX/zspKiyxGOUqW4ckAg8wMcz7PmryDrLV961fclzb5MW8STsaBw20PJKeg/mfGrM+FXclyddw4PINRYaVDA5lS1HJPzAVXPZ7phGqr87FkSVRocWM7MkuoTuUG205O0eJPIV0YxuxEOLPLeynLqjOasnsq7Vrvomcyw+85MsalAOxVqzwx4qbz0Ps6H+NYWgmLFqHVLWnZNuWiDcVFmLJUsGTGcI9VRUkJCxnqCOh5GoZcYa7fcpcJ0guR3VsqI6EpJB/lWTF+iFouMa626NOguh2LIbS62sdFJIyDWbVJ/BYur03s+ciPKKkwZa2m8+CSAvH0qNXXQfaUpQK1c7/t+1/wC7e/8AZW0rSXoSTerUIa2kObHubqSRjCPIig2k9p1+DIajPFh9bakodAzsURyVjxwedaqFbLozpL0c/d1vXXgKb9IFsA7znC9vs5fRXfw718ogfVL+9Th3r5RA+qX96g6PRd0/BD0b6XX6W7vwvSPDGeJj4+2tlamH4tsiMTJJlSWmkodfKdpcUBgqx4ZPOsTh3r5RA+qX96nDvXyiB9Uv71BtaVquHevlED6pf3qcO9fKIH1S/vUG1pWq4d6+UQPql/epw718ogfVL+9QbWlarh3r5RA+qX96nDvXyiB9Uv71BtaVquHevlED6pf3qcO9fKIH1S/vUG0V8U+6q0hqQqzRdiNgEZIPPOTt61NlN3raf9ogdP6pf3qhEBxS7BDQvb6sccwnH6NSXJtXKEwsN3tqbHb0qnxQRHbBBdTy9Ue2s30tat+/v0PfjG7ipziuvT7DJsVuJab/AOrN/oj9UVsO7s/1Tf8AhFV1sMXa1BZWJ0MKPInipya++mbZ+0In1qf86y+7s/1Tf+EU7uz/AFTf+EUGJ6Ztn7QifWp/zp6Ztn7QifWp/wA6y+7s/wBU3/hFO7s/1Tf+EUGJ6Ztn7QifWp/zri5eLYQf+kIn1qf86ze7s/1Tf+EV8MdnH9E3/hFB5P8AhS29peorbeob7TzL7Hd3OGoK2rSSRnHmD/8AiaqbSeopul7ym4W8NLUUKacaeTuQ62oYUhQ8iK9rdommbfqKFCtlwYSqPIkKSSkAKSeC4QoHwIIzXlzXPY9qTTcpxUKK5dbfklD0ZBUsD+0gcwfdkUGm0nqOzacvLl/YgvLuLO5UGGVZYZWRgLUsncrbnknHlk1EZD7kqS9IfUVuurK1qPionJNbGPp29SHwyxaLg48TjYmMsn+VXF2W9h06XNYuOr2+7xEKC0ws5W6R+vj4qfZ1PsoLP+DXYXrN2eMuyUFDtwdVKCSOYQQAn6QnPz1b9YsKOlhpKEJCUJACUgYAHlWXigUpSgVq53/eC1/7t/8A9lKUG0pSlApSlApSlApSlApSlApSlB8V8U+6qxt3/Ysf/cJ/8tKVJcm18oWBp/8A7Btv/DN/+UVn0pVdZSlKBSlKBSlKDT3v/r1m/wCLV/6DtdsgDnyFKUGMAM9BWbHA8qUoM1PSuVKUH//Z",
+              "timing": 3833,
+              "timestamp": 21992727153
+            },
+            {
+              "timing": 4791,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAYDBAUHCAECCf/EAFIQAAEDAwIDBAQKBwQIBAUFAAECAwQABREGEhMhMQcUQVEVImFxCBYYMlJVgZGU0iNCU1aTodFicpKxFyQzNmR0ssE1c4LCJUNEs+EnN4PT8P/EABkBAQEBAQEBAAAAAAAAAAAAAAABAwIEBf/EADARAQACAQEFBgUDBQAAAAAAAAABEQIDBBMxUZISFCFToeEVQZHR0lJhcQUzgbHB/9oADAMBAAIRAxEAPwDqmlKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUCleKUEpKlEBIGST0FR5rXGlXrh3FrUVpXLztDSZSCSfLr19lBIqUJAGSeXnUdOuNLJn9yOorSJedvC72jdny69fZQSKlAQQCDkHxrFXnUNrsq0JusruiF4w862oND3uY2j7TQZWlQLtrlf8A6SX+TDf5GOlSHWl9QVJ5gissdX6es0SBGu98t0OUplv9G/ISlXNI5kE8qCT0qnGkMymEPxnW3mXBuQ42oKSoeYI61hbvrHTdnliLdb7bIknOOE9JQlQ94J5fbQZ6lUokliZHRIiPNvsODKHG1BSVDzBHWqtApSlApSlApSlApSlApSlApSlAr5UtKepFfD6ykYHU1g7jfrRbHwxcbnCivFO4IefShRHngn2UEgSpKuhBr2sJa7vb7oFqtc6NLDZAWWHQvaT0zg1mGl70Z8aD7pSlApSlBrftwfeXZ7HaEvLjxLxdWIMtxB2ngqJKk58M4xUjl6F0xIsKrQuywEwdhQEpZSCnljcFYyFe3rV5q7TsHVViftdzSrguYUlaDhbSxzStJ8CDUPd0XrOTCNsla8Wq2qTw1rRb0JkqR0I4m7rjxxmgghvtyf7D4cFU10ocvAsip6VYUuNxSnfn2pG3NbcRoHSqbH6JFit/ctmzBZTu6Yzu67vbnNfb2ibI7okaVMYi0paDSUg+skg5CwfpbuefOo0nROtERPRydfu+jQnhhRt6DJ2dMcXPXHjjNBhu0GVJ0J2KGPp28PSy26mGicpYUtltSyCNw8Uj1QeorYun9OWy36cRbm2hIjvMhL63jxFSMjmpZPzic1Tt2jbJC0enTIiJetPDLa23vWLmTkqUfpE88+dWqtPXS2WUWfTE9MaNs4aJE1apDkdPTCE8s48Nyjig0rHfdj9kXahYEuret1mnLjw1qOdrfEHqZ9mP51ufROlLND0nEbMWNOVLjockyXkBxUpSkglSieoOeQ8BWPHZnAj9ms7SUCS4330FT8xxO9bjhUCVqHLOcYo3o7Udpidw0vqluFbQna2zKgiQqOPENq3Dl5BWcUEU0/Le0h/pRtVkJVAs7XfILXzgwtbSlqQPYCM4qU9lmkrGzoa2yVw4s6VcY6ZMuU+2lxb63BuVkkcxk9KzWi9HQ9M2eVELrk+TOcU9OlSACuStXUq9mOQFR2FoLUOn0OQtIat7jZypSmokuEmSY+TkhCiQceQOaCh2fMt2DtP1Zpu1jZZkMsTm2AcpjuLyFJT5A9cVtCozojSLGl2Zji5b9wuk5zjTJz/z3leAwOQSByAHSpNQKUpQKUpQKUpQKUpQKUpQKUpQW8kesD7KiOpRczcE9xF8LXDGe4iHszk/tvWz/Kpo4gLTg1bKaWD0z7qCP6WE4NyO/i6A5G3v/ds/+ng8vvqSxh6h99U0MqJ58hVykBIAHSg9pSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSvh51DDLjrywhptJUpSjgJA5kmg+6VF4PaDpGfMYiQtRWx+S+sNtNIfBUtROAAPOpRQKVGL3r/SljuJgXa/QY0wY3NLc5p/vY6fbUiiSWJkZqTEdbejupC23G1BSVJPQgjqKCrSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBXI/whdXajtPalcYlrv11hRUNMlLMeW42gEtpJwAcda64riz4TP/7vXT/yWP8A7SaDpbssnzJ3Y9aps2U/ImLhuLU+64VLUQVcyo888q0z8GLVN/vXaDMjXi93OfHTbXHA1JlLcSFBxsA4USM4J5+2ph8H/tCsl00/Z9FJYm+kWorgcUpCQ0QCScKCs9D5VJZnZ1pzQ+nNSXbSduci3T0VJbQ4JDrh+ZuwApRHVKfuoitc+2rRFvvotTtzU48HOE4800VMtqzj1l9MDzGax957etHWm6y7e+Lk47GdU0pbLKVIUQcZSd3Me2uVNBs6ZkX0o1rLnRbZwlEORE7lcTIwDyPLGegPPFYe7phpuktNrW85ADqhHW8AFqbz6pUB44xQdezfhBaNhzHozzd24jSyhW2OkjI/9VZe3dsOmrjrRrTcPvTkpwlIfCE8IEI3EE7s8sEHl1FcZ6n/AN4rl/zC/wDOuk9Rdk2nNO9nM/UVmamourVsU6lZkEgFbeFnHuUqgkl8+EBou2TnIrK508tq2qdjMgtk+wqIz7xyq+tfatpbWtlu0O1SnWp/cnlCNJb2LUAg5KeoP2HNcp9nLej3LrIGu3p7UHgngmIM/pM/rYBPTp7etZvSadHt6jQu2zdR963rEVJjtBJBBACyFZxjqQOmaCO9mkpmF2haclS3EtR2Z7LjjijgJSFgkn7K6d0p2/6dvupE2p+JJgIed4UeS6oKQsk4Tu8U55efXnXMPZpFYndoWm4sxlD8Z64MIcacTlK0lYyCPEU7R47MDtD1HHhtoYYYuL6GkNjalADhwAB0AoNs9q8PsuR2g3ZN3e1JGuXG3ykQ0NqaUtQCiUlXMZzWI7XdaKtT+nrToO63m2WyJa2VcNEhbW4OJDqCdquatqxn25qF9r7q3+0O5uuqKnHER1KJ8SWGyakHbdFYZtnZ++0w226/p6Kp1xKAC4QhIBUfEgADn4YoNt/B37Ro8jSN0Y1Pd5TkuAtUp6XOdK0paVtSkBaiTnIPL2+2s8/8ILQrUsspkT3UA44yIp2H28yD/KuaJFwtqOyOHBjKjJuzl1cckhKQHVMhsbNxxkp3FWBnrVvZLZp6TpSZKuM9uPc0LIQkyFbiOWNrQaO738RP2UHbVj1lp++WF68226R3bcwCp50nbwsDJ3g4KeXnWvJ/wiNFxpSmmE3OUhJxxWmAEn2jcoH+VaAhNQIHZ7qYWLUMmauQ3HEuIYSmUpSHk4UVlRB5nGPb7KsNAN6FcgXU63fujUoJHcxDGQeRz4HnnHXAoOq4fa5pa86Uu90tsx4qgRy69HLe19APIEAnB5kcwa5Z0v2k6khamtMq66kvr9uYltOSWjMcXvaCwVJ2lWDkAjB61LexOJpKRqsx4rt5lSnochC48qK13dxHDJIX6xOMgEcuoFax0UuE1rKxLuwZ9HInsGTxkhSOEHE79wPUYzkUHW967d9I2eamLLbuhdUwy+NkdJG11tLif1uu1Yz7ayWpO1/TenrTY7jPRcDHvDBkRuGyFKCRt+cNwwfWHnXLHbfLt87tLukmyLZXbFtxxHUwMN7EsNpASPADGPsrNdsE2NJ0L2aNR32nXGbUoOJQoEoP6MYPlzSfuoN6ufCA0ciAzMU3deC86tpP+rpzlAQT+t/bT/Oknt/0ezaGJ6E3FwPPrZDIaSHBtSklRG7AT64A58znyrkyV/ulbP8AnZX/AER63T2A9lumtbaMlXK+tSlym5y2Elp8oG0IbI5D2qNBuXUna/pDTzMYz561SX2kPCKy2XHUJUkKG4Dkk4I5E1R0r20aM1JPagxp7kWW6QltuW0W95PQBXNOfZmuPnIzC9avRbwtTUcTFtPKW4UFACiMFW1RGMYztOPKsxOs2km9QLZRqRUOGnaUuMMrmhJ8cL2tk/4aDvClWNiXxLHb1l9ckqjtnjLQUKc9UesUnoT1x4VfUUpSlApSlArTHaX2Go1vq6VfFX9UIvobRwRE4mNqQn528eXlW56UGnOzHsRRoXVbV6TflTihpbfBMTh53DGc7z/lW4nEJcQpC0hSFDBBGQR5V7Sg0ddfg46dl30TIlwlxIKnN7kJKQoYzzSlecpHvzWNvXwaoU27S5MLUBgxXXVLajJhbg0knkkHiDOPOug6sr49Nj2ac9aY6JNwbZWqOytW1LjgB2pJ9poNDXP4NbU64yZXxpWjjOFe3uAOMnpniVvpm3tC0It0hKX2AwI6wtPJxO3acjyI8K0DovWXa9N1pCi3ayui3uPhMlLsHhIabz6xC/YM45nPtrf15uDVptE64yMliIwuQ5jrtQkqP8hQaQvvwarJLmLetF5l29pSieCtoPpT7EnKTj35rP6J7C7FpdciT3uROuTjDjLb7yQEs70lJUlA8cE9Sa0rc/hB61lXFx2C7DiRiolthMdK8J8ASeZPt5V1Voa5yLzo6y3Kbt71LiNvO7BgblJBOB4URqHSnwd27Bqa13calW+YMluRwjBCd+1QOM8Q4zjrivNVfB3bv+pbpdzqZbBnSXJHC7iFbN6icZ4gzjPXFb7rX/bLeNX2bT7D2h7d3ySpwpfWlviraTjkUo8cnx548vIqDar+Dy3qC+v3I6lXHLqW08MQt2NjaUdeIOu3P21MtU9ktn1No6yWS5PuiTaIrcaPOaSErwlCUnKTkYO0HH86jPZvrvWsaxX+7dotqkItlvYDzbvdgy8tWeaUpJAIxzzy99ZrQ/bbp7WOpotjtsG6sypIWULfbbCBtQVHJCyeiT4URHtM/BzsttkSlXe6P3Nh5lTQa4IZ2E4IUDuJyMcqxr/wY7cqUVMakloj55NripUrH97cB/Kuhq0xA+ERpabc48Fq23sOvvJZSVNNbQVKwCf0nTnRUq0r2U6Y09pefY24qpbFwTtluyDlb2OnMYxjqMdDz61rq4/BltTsort+oZkZgnPDdjpdI/8AUCn/ACroKlBr3sy7J7HoFb8mGt+ZcHkcNciRjknqUpSOQB5eZ5VC9UfBxst0uj0u0XWRa23VFao/BDyEk9dvrAgeznW9qUGj798HizXK2W1mNdpUWZDYDCpBaSsPAEkFSMjB545HoBVrdfg32mTarZFt94ciPxgsyJCo3EVJUrbzxvG0DHIc+v3z/thu+rLPppt/RFuE2Yp3a8QjiLaRj5yUfrc8eePLyjvYfqLtAvcuejW9tWxBbbBZfdjcBZcyPVA5ZGMnOOWPbREYd+Da25aY0H40LAZede39wHPelsYxxPDh/wA62h2TaFT2fabftKbgZ4dlKk8Us8LGUoTtxuP0OufGppSitR9onYXYtX3Z26RpT9qnvnc8ppAW24r6RScYPuIrF6T+DpYLTcWZd3uMi7cJQWlkthptRH0hkkj2ZreFKAAAAAMAUpSgUpSgUpSgVz18IvtVu+nby1p3TT/dHUspekyUpBX63RCc9OXMnrzHSuha5q+Ex2b3e435GprFEenNOMpblNMp3LbUkYCgkcyCMdOmPbQa5uWue0SHpCGLjNvcePLkd5i3FTrjanE7SCgK/WT0UB7/ADr2BrnVa+zy9ylakvBkt3KE2h0zHNyUqbklSQc8gSlOR/ZHlWE1Fd9VXTRlui3tbvoa1OpiRkONBBCthwM4BOEpxz6ZFZLQ2nJ+pOzTWDVqYckyYkuDK4Lady1pCZCSAPE4XnHsoiadkGrdRXHSvaG9PvtzkuxLOt2Ot2UtZZXtX6ySTyPIcxUW7OdcaqmapSzL1JeH2u5zV7HJjihuTFdUk4J6ggEe0Crbs7b1TBtWsYlrtClR5NscROckNqTwW0pUTjzUeYA8/dWO7MYMtGrkKXFfSO4zhktkf/SPUGf7Ktb6pn9o+nYs3Ud3kRnpjaHGnZjikrST0IJwRXTvbVDmzuyzUbVtk92fTFU6pe4py2ghTicj6SEqTjoc4PKuSOx+DLb7T9MrcivpSJzZJU2QBzrsztGSpfZ9qdKAVKNrkgADJJ4SqDhrQFuud31hbIFim9wub7hSxJ4ikcM7Sc7k8xyB6VtHtX7TNWW+8R9KWu6PsrtjDMWTIjqJdlSAhO9W8jd87IHQnqetRLsMhSm+1jTa3Iz6ECQcqU2QB6iqknwgNB3216+nX63w5T9umuCQiRHQVFpzAyFY5pORkH20GI1lrvtGgwLPb75JvNplR0LKXuI4wuUg7cFeMbinBGevPn7ckrWepv8AQYi4/GC69/8AjGY/eO9r4nD7sFbN2c7c88edRPXEXWtxg2a66sVOlCW2sRA8CVpbTtydoHIHcPacZ8qyqoUr5PyG+7P8T4zlW3hnOO6jnjyoL3Tl01Rqvsx1z3rUE+QmCIr6xKlOLy1+mC0Dr19Xl0O32VFOye2XS76/tUOwzu4XBalqQ/xFI2pSgqUMp580gj7a2L2BaenXnRvaNammlNSZkNhtnipKQVfpcDJ9uPvrXVlZ1boTVjMqJbJkW8RitCEuRSvO5JScDGFcieYoO5tTRJk/Tl0h2yR3We/Fdajv7inhOKSQlWRzGCQcjnX58WtiQ/eokeM9wpTkhDbbu4jasqACsjnyPOv0Nsrr79mgvTAUyXGG1Ogp2kLKQTy8OeeVcMar0dqPROqVh+3ycx5HFjyUtFbbgCspUCBjy5UGyu1ntM1XpdyFo+Dciibb4bLc+eglbsh4oBJClDIHMc+pzULVrntM0pMjPXC6Xhpbo3oankuJWP7q8/8AamtdK6zv8OPrW4W6TKXcU5kcGMUqaUg7AVIAyElKUkHGKtbfctd3edEYscGUxIaGxKbdATHBPLmsoSATy6q6UGf7U+0/UVzmWG4Wy6XK0plWtC3o0WSttAdDrqFEAHx2/dirW/6u1/8A6OtNT37tLZti3Xm2pSJau8SHAtWStWc4A9UDP6vuql23WbUES9WJm/OP3C6JtLZkPJTu9YuunbkDBwCB9lZPVsSSr4O+hm0x3i4mdKKkBByP0jnUUHjnabqif2QvcS8zW7jBu7DQmNOlt1bTjLx2KUnBPNvPP2eVRuNr3VytK3F46mvRdRNjISszXMhJQ+SAc9DtT9wq0gQZY7Mr0gxX9xu0EgcM5I4Mr+orHxYEz4oXNPdJGTOikDhn9nI9lBLtI3/tL1TarvbrFNvFzUVMqed74orZSN+AkqVy3Hrj6NdS9kMW8wuz61x9Td59LICw93hzev56sZOTnljxrTnwQIz7EvVPHZca3IjY3pKc83fOulKBSlKKUpSgUpSgUpSgUpUXv2rkWe4riOwnFkAKCwsAKB+ygh/witG3vWmnLXE09GRIfYll1xKnUt4TsIzlRHiax3wb9B6g0SjUI1HERGMwx+DteQ5u2cTd80nHzhWwrhq+PDtsCWI6nO9pKggKAKcdc/bX1E1dEctS58ppcdsL4aE53KcOMnAq0JLSoUjtAhl3Cob4bz84KBP3f/mvjXN5jy9PRu6K4iJK8hYONu3GQR9tKE4pWotH3cWm5OOuNqdC2inAVjHQ/wDapTG19FdfSh2I40g9VlYOOXlilCaUqLWnWMaYzLektGM1HAOSrcVZzgAY68qs19oEQOEIhPqR9IqAP3UoTWlY2x3qJeWFORFKCkcloWMKTWSqBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBUE7T4OW4k5I+aS0v3HmP+/31O6s7tb2LpBciSd3DXjmk4Iwc8qQNKuPuPNMNKOUNApQPLJz/makGr7e5boNnYUCEJZOfLiE5V/mPuqWxtD2tiQ08HJSy2oKCVrSQcHx9Ws/crfGuUYsTGg42eYz1B8wfCurRqaU5ZjYWUR2XhdARvWSce3xxVzDQ78SJ6lA8HvLe33+P/apgnQtpS7uJkqH0C4Mf5Z/nUgFviCAYQYQIpTt4eOWKWNTacnsQPSPeCoceItlGBn1jjFUdNMNSb7CZfQFtLcwpJ6EVP16FtKllQVJSD+qHBgfyzVW3aNt0CazKZdlFxpW5IUpJH28qWMNr60xbfaWVwIyWUqeAcKc8+Rxn+dROGq3i3PCSP8AWc+rhCir7DuAH2g1uWVHZlx1sSW0uNLGFJUORqNL0LaVObgqSkfRDgx/MZpEjGdnIhd9kGIJfFDWFlwp2dRjpzz/APmp7VnarZEtcfgwmg2knJPUqPtNXlSVKUpUClKUClKUClKUClKUClKUClKUClKUClKUClKUClK1x2i3WQbn3BpxSGG0AqSk43E8+f2YqxFjYwWlRwFAn2Gva1A7YLxCTHfShQLnNBbc5jx8691M9PUm3i5BaJCWSkkq5qG44PL/AP3KlI26pSU/OIHvr2tS2yx3a82xpcdbZjNrUEhS8c+WT/lXt6ulxuVz9HsuLCErDCGkKwFEcufnzpQ2zUHvsbVS7q6qE4vuxV+i4a0pAHhkHxqLF276auCULcW05gL2Fe5Kx7fDwNUtSSjJvMh9ClBLoQsDPTKAasQNu24SEQGBOUlUkIHEUOhNXCVJV81QPuNan1RIn93tzbinUwu6MlvBO1R2DJPtzWOtsKTIAchy2UPZ5IL2xf2Zx/nUobqJwMmvEqSr5qgfca1Rq526ocjMzlPJaSygAEnClbRuJPic5rH22FKkBLkKW0l/PJvj7F/ZnFKLbopWqdV3WeuU1AW64gMtIStIVzUspBJPnzNWd9Zu0GNDjXPclCQos+uCcHGRkH2ClFtxUJAGTyFaZUtfxaQdys97V4/2BX3b0TXbDdHGZGyO0Wy6nnleSQBny50otuMHIyK8Kkg4KgD7TWm7NfZlrakoYdVhxvakE5CVZHrD24zS3Wu5XsSH45Lpb5rUtzmT9tKLblpWtNNyrxaGJTrzbq4aWVKAWoEJUByPXPXly86wKn7heJK1PStyx636V0IA9gycfYKUW3TStaaNlXiNdGWlNynYS1bFhSSpKf7QPhWy6TClKUqBSlKBSlKBSlKBSlKBUG1zpuXOmidAQHSUBLjecHl4jPsqc0oNOpsN8kqQ0qHKITyTxOSUj2Z5VfXzTM+K3BZYjuyFBolxTSSoBRUeX3YralKtpSO6CivxLDwpTK2XOKo7VpwccqjGpdL3Fi6uzLY2t1ta+Iktn10KJz09/lWyaUtWqY+nb5eJoXOQ8jOAp6QeYHsB5mvnUVhn+mJAiQZDjCdqUKS2SCAkD/tW2KUtKa4nQNRR+C5BQ+WFR2QWwQoAhtIIKD45HlWGFgvU+UVKguIWs81KQG0j/IfdW4KUsprm6WzUcKR/qinX2OGhJ2kLSSEAH1T7R5VhkaevU+UVKguIWo5KloDaR9nIfdW36UsprbVGlLhxW5EZJlEtoS7t+duCQCceIOKxczTt57rGedYkPLc3Dh4KlNpGMZ8s5PL2Vt2lLKamVZrl8X0Ndxk8USlK28M5xsAzV9Z7VPa0xfGXIb6XXeFsQUHKsK54FbLpSxqO06YuEuQ4y/FejgtkpccQQkKHQGqS7BfIi1tpiSRu5KLXMKHvFbhpSymutM6QlLL7lySWEKaU2hOQVZUMZx7KxarFf7RLX3Rp/JBTxI/MKH2f962zSljXmktPXUXJuXOU9HZQreUqWdzh9o8vPNWJs+ovT+/a/wAbiZ7xu9TGeufL2VtGlLUpSlQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUqHaiuUq13KdDafXxbmyj0fuOQh7cG149g3Nrx/eNBMaVE414nthp4qjLgpm+j+CoKMgkOcPeV7sE5G7G35vPNUbbd5r/Dh20RIuxp2Qtcre4FAPLRtB3A/q5JJOMjlVpLTKlYTT00TJFwc2Iz+hUVNulxKtzSVernljn4AZ61iU6kuDVlTd5Ho9Ud+KuQ1GBUh1GE7gkkkhWP1iAMe2lFpjSolNvl1twksPdxlSgy280tpCm0Dc4EbVAqUfHIOeeDy5VSm3u+wU3hb3o5bdrSl5ZS2sF5BTuKQN3qEAHn62eXIUotMqVEHL1elOIcYRbxHcuC4KUrSvcACoBwnOD835uOfmKoOakvJmC2MR47k9DryXHkN5QUoDZGEKcSckOj9Y4wetKLTalRBF9vExpnujUFh3uSpTnFy6nclRTtSUKxg4znJx5GmmLhcrjqGa65LY7iuPGfRGLStyAtCiMHfjPmdvPHhSi0vpUVk3u5ouE9TaYggw5zERSVIUXHA4GskK3YBBc8jnGOXWqUXUVwWiBLcTEMWe64y1HQhXFaKUrIKjuwr5mCABjPU4pRaX0qJL1JNVDtaorEd6TLtpmFoK25XlkADJ6fpFcieeAM1k7FcZNygTAtbaJrLhaO6OtsIVtBG5CjnxHRWCPGlFs1SoPY7nfPQ+nmzJgyX53JTy2lgtpS2VHPrncrIx1HWq7OppiriUER3IrqJBZUhpaebfT1lH1xy54SAD4mlFpjSoam/3pttlLseI/IlQ0S2UMpKdnroStJ3K9cgLBGCnOMVj570rUE2wtuOQVoRNebeZfhOY3paUr1kKWMHB5deZBz4UotsKlRZi+T1OsyVd0MF2cuEmOlCuMkhakbt27B5pyRtGBnnyqjFvV7ksWtQTb2nLi84hGULUGkJQs5PrDcTtHLljPjSi0vpUJb1PdWIEe4TWIrkdbkhhTDCVcTeyl07gonGFFo+rjluHM4r6m6julugvPSO4SXF256exwEqSlBQE+qrKjuB3j1hjoeVKLTSlRKTerzFkSYZZiyJSAy4lTLZG1DnEz6hXlZTw/AjIPTlzqXK5OTdBzZiXMPcJaSptCmiFJUUn1Veskgg8v86UWlNKiqtQyhqFmMngOQnJRiZS0sFKghSj+kJAJynBSEnHnUqqKUpSgUpSgVRfiR33mHX2GnHWFFbS1pBLZIIJSfA4JHLzqtVrJuUGLJajyZkZmQ7/ALNpx1KVL9wJyaDwWyCJxmiHHEs//O4Y39MfO69OVfEmz2yU021Jt8R5pslSELZSoJJOSQCOWT1r6cutvaL3EnRUcAZd3OpHDGcZVz5c+XOvlNzYeENcNbUliSspDzbyCkYSTkc/W6YwM/yoLpphllS1NNIQpeNxSkDdgYGfsGKtmbTbmJLshmBFbfdBDjiWkhSweuTjnmjd2tzjTzjc+Iptnk4pLySEe855V47ebY1GakO3GGiO6cNuKeSErPsOcGg9j2m3RmVtR4MVppZClIQ0kBRByCQB4GqzsOM6l9LsdpYkJ2vBSAeIMYwrzGPOqUi62+O+2zInRWnnCAhtbqUqVnpgE8816LlBM4whMjGYBkscVPEx/dzmgqCHGASBHaAS4XQNg5LOSVe/meftqhLtFtmIWiXAivpWviqDjSVArxjccjrgAZ8q+4tygzJDrESbGffa5ONtupUpHvAPKki5wY0tqLImxmpLv+zaW6lK1+4E5NEVEQ4zYSG47SQlvhDCAMI+j7vZXy3b4bTzTzcVhDrTYabWlsBSEDokHwHsr59JwO+iH32N3skgMcVO8kDJ9XOelJ9yg28tifMjRi4cI4zqUbj7MnnRVQw4yuLmO0eKtLq8oHrrGMKPmRtTz9g8qps22CzLXKZhx0SV53OpbAWrPXJ619qnREqWlUlgKQpKFArGQpXzQfacjA8c1TZutvel91ZnRXJPP9El1JXy68s55UHwiy2tvfst0NO9JSrDKRuBIJB5dCQPuq4hw40Jotw47TDZO4pbQEgnz5Vaxr3b5MmWyzKYWYgy6oOoIT55wcjHjkD/ADr6aukd55QadZXHS2pan0vIKUkHBBGc8vE9KIqsW6EwsLYiR21BZcBQ2AdxGCrl4keNUhZ7YFlYt8QKKivIZTncc5PTrzP3mvWbxbXoipTNwiORkqCC6l5JQFHwznGeYrw3m1phJmG4wxDUraHy+nYT5bs4zQVXrbCeQlL0SO4lLfCAU2CAjIO33ZSOXsFGLfDjpaDERhsMqKmwhsDYSCCR5Egn76+JN2t0VLCpM+Iyl/m0XHkpDn93J5/ZVxKksRGC9KebZZHVbiglI+00VRTbIKJpmJhxxLPV4NjeeWPndelVEQ4yAyER2khgktYQBsyCDt8uRP31QF0jlxKg4yYhZL3eeMjZjOPPOPb0r4TfbSoIKbpBIWvhpIkI9ZfL1Rz68xy9tEXKYUVCW0pjspS2tTqAED1VqzlQ8idysn2nzqi1Z7ay0+21b4iG307XUpZSA4PJQxzHM19KutvTLTEVOiiUo7Usl1O8nyCc5q1Y1Bb1QEy5chmE0p5xhPeHUo3KQtSDgk/2c0F5Jt0KUVmTEYeKwkKK2wrITkp6+W4495r6EKKIfdBGZEXG3ghA2Y8sdKrBaS3vChsxndnljzqK23WTM+Y0hkQ1xnJbkYONSwtSAhLp3rSE4SDwuXPmDnwqjPrtNuW+p5cGKp5SgtSy0ncVDoc468hzq9qylXFlqMHGVtPrU3xW0JdSnejIG4EnGPWHP2jzqhc77At6lNLksrlBSB3dLieJ6ygkHbnOOeaispSrRq5QXZy4TU2MuYgZUwl1JWn3pzkVd0ClKUCozcbPOM+5riM2+SzcA2FmWVfotqduAkJO9PjjKeZPnUmpQRZenHkR1LYEYyhc1T9qiQh4EqASs4zkJI8DgpFfA07McmNynu6oUuauU6whSihIMZTIAOBuJOCTgdT9sspVtKQtjTM5Md5lxLRjhLQYYMtZLakKJyl3YFgDlgHd0r06evC2GW3ZDCxtfQtW4JWAsgpBWGwVDA5gbc8sk4qZ5FKWUhSdLTV2a5MO91EuTbGYTawskBbaVjJO3OMqB6edXzFmnsurjBqAuIqW5K7y4pReTvUpWAnbgKG7aFbug6eFSelLKQ/S2mZNrlwTJbYCIMdTCHUy3nFOZwM7FYSgEDJHrc8eVfN60vKl3W4OtoZejz1NqWp2W83wtqUpICEcl/NyOY5k1MqUspGHtPPq70pssB126szgrJzsQW8gnHXCFD7etfGpLBKnXZc2K20+HYoiqbdlusBGFKOfUB3A7uYOPmjnUqqylW5uS8XFuvpJ5YQ4QKz1Ms8YvCLn+aWIieKPp01JRebbObMbbAabjobKlHiICSFLUTk7k5O3Oeqsn1uWPsllny7cwwpiLGjIuEiT3hKlB7/audE7cAnOCrd08OdSr0Mz+3k/xTT0Mz+3k/xTWG+2ny46vZ12cOfoi0DSE1mF3ZxEZJZt7sNp4THnN5UkJzsV6qE8sketzxjpzyN50uubFVGjKaYZEFMZKUkpG5LiVgcuiTtwcc8Gsx6GZ/byf4pp6GZ/byf4ppvtp8uOr2Oxhz9EeRpeU8l9b7MZpx2REWpHenZG5DLoWcqWOuMgAJHtPlcuWGcxfH7nFTFeJkOLbjuuFCdq2mUk5CThQLR8DyUedZj0Mz+3k/xTT0Mz+3k/xTTfbT5cdXsdnDn6IzM0tPcWp1LEBan4ojuMokvR2mvXWrkED1weJzBxnb4Z5Z672hUm0worKEuLiqQpBL62ikpSRkLG455+OcjOauPQzP7eT/FNPQzP7eT/ABTTfbT5cdXsvZw5+iPvaYuEm2rYlPR3XFw3YyiroSp0KGcJAPq8icDJ5451d3TTa5S9RrZTGSq4wURmieW1aQ4Mq5ch6yemensrK+hmf28n+Kaehmf28n+Kab7afLjq9js4c/RGY1ony13eOiPDQw/cg8uStSg6nZsOQnbhR9XkcjGfZz9XpWc25HkNhmQ633pBaMt1hIDrxcBCkAk8sAgj7eXOS+hmf28n+Kaehmf28n+Kab7afLjq9k7GHP0fNgiv26JHty2WxGjRm0pdQ4o7l8wpICskAYTgknr7Kxh07IUzBbUtkBmdKkOEE/MdDwTjl1HFTn3Gsr6GZ/byf4pp6GZ/byf4ppvdp8uOr2Xs4c/RHV6duz8WOw+YSBHtxhJKHFK3q3NHcfVGBhs8ufXxqpN07cHETIrSIK2H7g3OEhxauIMOJWU7dvUBO0HPTHKs96GZ/byf4pp6GZ/byf4ppvtp8uOr2Ts4c/RHrRpaVDuUUupZXHjSXZKZBlvFaivf/wDK5JSfXwTkg4PLnymlY5u0tNuJWHpBKTnBdJFZGttPPUy/uY1/m/8AkJMRHApSlaIVB9TaguMO7z2mJDMVuG22ttDuzEgqGeeTuxn1RsGcg9eQqcVjJhfVKCham5HDOW3VOJBHuyMis9TWx0Y7WUTP8RM/6iVjCcvCGGsrjqdZ3hmTdllSuG43CXwxlBQOaRjdgHlkfbVjP1BPamX1aLlGQbdKbaZglsbnwpCDtJznKiohOPHrnpUm71cN270UN3TPHT/SrGLFfjy5MkWcLefe45Ut9BKFbEp9U45DCBWHf9Lll0Z/i73OXOPrH3R/0g7HkGbGjM8eOxdlIabRgLUh9AGQOpOOfmc17fZ852x3qNGvQmgW1crvUZCAWj9DlkYUMkeI2nmalaX5qVAptCARnmH0+JyfDxrxp2YylQaszaAo5IS8gZP3U7/pcsujP8U3OXOPrH3Re/ajkQIDjttu6Z4ixDLLiUMlLvrKAClAgEeqRhAzy5npVF66SYU7VMuFcY6FMSm3W4hQFGSSw1hOevrcgnb4+fSpapctZSV2VpRSCEkvIOAeoHKvAZIUlQsjIUnmk8VGRyxy5eQH3U7/AKX6cujP8Tc5c4+sfdGFXSZES1GjPCIiTNnLW+dmQUu8kDeduTknx5JPvEp03dPSFtiGS/HVMcaLhS0r56QogLA8j9o59TXjqpTrZbdsrS2ydxSp1BBPnjFXMJchb+X7eiOAjaHA4lRx5cvCusNs085jGIyueeOUesxROlljFzMfWPuv6UpXpcFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKVg2tWWV3Vr2mUTM3pprjrj8JfJGAc7sbeih40GcpVjEvFsmTHYkS4w35bX+0ZafSpaPekHIqKntW0Ym9uWld5CJzckw1pXHdSlLoUU7Ssp29QfHHKgnFKxpv9nEiQwbrAD8dJW82ZCNzSR1KhnIA8zVjO1rpiDEMmTf7WlkNcYESUKKkZxuSASSM8uXjQSClRLT3aPpHUIlG13yKsRUF17i7mdiB1Ud4Hq8xz6c6zce/WeQ067HusB1tpCXHFokIUEJUMhRIPIEEEGgyVKsIt6tcuA9Oi3KE/CZBLsht9Km0ADJKlA4GBz51jJ+t9MwrVIuLt7guRGGw64uO6HyEFWzdtRkkbjjIHWgkVKxnxgtAVEQ5c4bTktCXGG3XkoW4lQyMJJBOfdXi9Q2VEp6Mq7W8SWUqW4z3lG9CUglRKc5AABJ91BlKVHtO600/qKxyLzark0u2R3C07IeSplKFAAnO8DAwoc+nOr+PfrRJZedj3WA60wgOOrRIQpLaSMhSiDyBHPJoMlSsUxqSxyA+WLzbXeAkLe2SkK4aT0KsHkDnqa+0X+zuWxy5N3W3qtzZwuUJCC0g8hgrzgdR4+IoMlSsN8a9PYdPp604abS84e+N+ohW3ao8+STuTg9DuHmKvLdd7bcysW24RJZQlKlBh5Lm0KGUk4PQjmPOgvaVjFagsyTKCrtbwYgzIzJR+hHTK+fq/bVnI1nppiJKkqvttW3FYMp0NSEuKS0APW2pJJHMYwOeRjqKDP0qCt9qulX37Y1ElvSPSUd6THUhhQCkNFYVndgg5bWBkc8Ve2HtC09eNJfGQSzCtIdLJdmAN4UDjzPiaCW0qwnXm2QIrMmfcYcWM9jhuvvJbSvIyMEnB5VaK1TZU3sWlU9sTjD7/twdnA3bd+/G3GR50GapWNav9ndgOTmrrAXCbO1chMhBbSfIqzgViZuv9LQ7jaoLl5iuSbo4G4iY5LwcUVBI5oBCeZAySB18jQSilRh3W1pa10nSbneBdFRzJ3FA4QRgnmrPkD4VlIOobLPlpiwbvbpMlSStLLMlC1lI6kJBzj20GTpSlApSlArVs/s9vau2NWsLfdIjEJ5pDD7CkEuKbCEpUAcYBJSOdbSrXOtO1OPpjVLdkVZbhLcUlB4yFIQglXRKSojcr2DnQYHsy7HpejtXN3R+5QpMaOh1DRbjlLzu/PNxRPgD4eQrDL7ELwnWFyvzF1tu+Rde/NNPMFxIbK1qIIUCN4ynB99S5/tci/GeXaItluTzMeWqAuchILaXx1BTnO0HxqM6Z7cXPiZAuF8typl0nTH47LEIBtJS2lCiSVK8lj30RcaQ7E3rJq4zplwhS7aO8cjHPeHQ6kpKVqJxyBPMe3zrDWz4PLyLPe4lxvLLj77aGoDyEKIZSlwrIUDjqcdPbWeuvb7bIC2Aqw3JQchiYQpSUKQCopIIPtHXx5Vkrp20W6K7CRBsl0uBegtXB3ghOWWnCAnIJ5nmOQ86CGRexS8WWy6lnSJrFxub9oNvixobZSFYQhIJKsc8IH25NfenexC5K0+85Lk2+PLl2tiKIqoxSkK3ocXxilWVKBSU7h7D4VNme2O2SNXpskS03J5vvSYS5QSkBDqvNGd2Aep9hr61/wBr9u0feJ1uVap092Cw29IW0UpQ3vUAkEn+8OePED3B8aM7Np1h7NtRadkTIC5d0aebQ4wyW2297WxOfFWPM8/fUa0H2HP2HUNpmXd+1T4MeI7HlRiyVB9SluKBIUMHG5HX6PurJXLt3t0FyWhdllrMe3RricOp9ZLwZIT06jjj/CayGiO0ebqTtRm2MsMtWtNoYuLI2/pQpxDK8KVnB/2uOnhQYrW/YxIv2t3LzCuEFmHI4AWy9GKlsJbSE4awcAEAcuVVdLdkc21dor+oJUq0rhLW+stNRiXHOIFDmVE7eS+e3kfLnVdvt0s7rkkotNx7sGZLsWQraEyuAkqWBzynkOWauonbDHd0gxf39P3JpmZJREgtBSFKlOKKhhJzgAbDzNBh7b2aXjSvZBq/TjL7VzcmlbsRDCSlZJSlODnln1R/OsHYewu4P6ald9uEeBLm2piKhlmPt2LCkOq42D6ytydpI8OfsqRQu3q1ym07LHcjJXMVEbjpUgrVtTlSuoAwCOXtr4Y7e7e9bbPMRYpyvSU12EhtLqNyVIDXPngHPGH3UGJtnYfdYsPUrTs6zLN1bZShtDC0NIKHAsjaCCBywMHNSOzdlMyN2S3rSUu4QhKuDvFS9Hj7UIwUFII5FXzBknnz8cViLT23Lv8ArHTUW1Q+Da5zbxlNvI3PJWgLOEkKx0SPDxrIxu3a2LhXOVKsVzjMwmwvC1NlayVpQlJTnKSSrPPlgGgjLPYRe0xr227eLctU+1x4DakoWAgtLjnJHPlhgj3kchUs7LOyydozVMy5PzYjkaRbGoXCjpUk8RKWwpfMY5lCj5+tUj0p2gJ1Hpy83JizTmJFsCt8V0py6QkqwhQyDnBHvqGxPhBWWTGekItE8tMsIcWUKSSHVr2pa8snrnPQGgxMLsAlNKmodvkYNd1fjsONRilx0uEkKfOfWxn+Q8qudIdiNytU27qud1gvMT7Ku1DhNK3IUUoSF4PI42Z6+XSrzVnbU/E0O9ebLZy3Oi3IW6XGn8wyrapX6iufTH31IbP2pt3LWEywM2WWswQFypaFpLbaNm4rx1xnA8etBDLD2J3yBPsLsm7W5xq1xJMVIQhYKg7xiD08C8fuqZaI0Le9J9mhsESXanrkJCnUuyWFOMbSoHBTyOcCvvQPaxB1lfU2+JaLjGbdbW6xJdCShaUkg52k7TyPXyrHs9tMNTmonHbFcEwLGtbcmUlaFJ3BRQgAcjlShgfzoLjtW7OJ+s3rJLiTbeiTAacacZlxy4wvekAqCfAgjIz7PKrq59mESd2b/F3iRWroIaInpNEZIXtS4HNg8QgqHzc9DWJ/02RRpubd3NPXJtqG+y28lSkY2Og7VhQ5HoAR7RXyvtxtvolqczZpzwlTXYcJCVpHeOGAVLBOAE+sn7T7KKw8fsUuLejLlalzbMqTMlsv7BGWlkJbStIHIhW47859mPGvpnsVuceHpJ1m6WxNyss5UtxSYvDbcBU2oD1epHD8QM5NXt07e7bAXCBsNyV3mEZu1SkoUgBS0kEH/wAsnPkRVW8du9rtyomy0THkSbam4pVxEpIScjaR58qIv9V9mMy/dok2/C4ssQ5NqctxQEkuoK21I3Dw5bs9axHZh2QXPSGtot7lz7a6y1DMYtRWVNknAAUfAk4yT4k1tXSl6b1Fpy3XdlpTKJrCX0tKIKkBQzg1laKUpSgUpSgVE772d6Uv19TebvZ2pNxTt/SqcWAdvTKQracY8RUspQRN7s50m9qJd9csrCrqtRcU9uXzV9Lbnbu9uM551bHss0WbE3Z1WNpVvbeU+hsvOFSVqACiF7twyEjlnHKprSgg8vso0VLKONYm8IjiKkIfdQA0DnbhKgOvPPX21VuHZfo24ej++2Jh7uDKY8fc456rafmpV63rAf2s1M6UEUX2eaTXqJu+qskb0o2oOJeG4AKHRW0HaSPPFY7tL7MLJrqK8uQ2iLd1oS2i4JQVLQkLCsbcgK5Ajn0yanlKCAnsm0lLt8Jm8WtufKYgswVyStbSnUtJSASEqGD6g9uOWcVm7LonT1kvarvbLeGLiqKiEXuM4rLKEoSlOCojkG0DOM8uvWpHSgh47M9HJlz5KbDGS/ObW0+pJUMpWCFhOD6uQTzTg86tNVdmlqvGgGtJ25arXb2HA4yUp4xQdxUfnknmVHxz9nKp3Sg1jpTsW0xZ7AbbdWfTKlSe9l19PDwvGAEhJ5Jx4ZOfGsux2U6LjsQGWbKEtwJCpUYd5ePDdVsyr5/P/Zo5HI5e+pvSghFr7KtGWuXFkwbKlp6MFhpRkOq27wQrkVkHIJ617b+yrRNvZmtRbBHDc1vhPha1ubk5CsDco7eYB5Y6CptSgwmldKWTSkF2Hp+3tw47q97gSpSitXTJUokn76xUDsz0fBt1ygRrGwmJcSlUltS1rCykkpxuUduCTjGKmFKCKDs70mNNL0+LLHFpW4HVMhSgSsdFb87s+3Occqrac0Np3Tk2RLs1tTHkSGUx3VcVxe5tIACcKUR0AqS0oIvp3QGl9OXd652Wzx4k50FKnEFRwD1CQSQn7AK+4OhdNwWLyzHtbfBvC+JOQta3EvKyTkhROOaj0xUlpQRGB2baSgWO42iJZWW7fcMd6b4iyXMHIyoq3DB5jB5V7I7ONJSdORLE/ZmV2uIpS2GiteWyokkhe7dzz51LaUEIk9lOipJY4tjb/QRjEbCHnUBLR3EpwFDPNaufXn1r2f2V6LnsRGpdjacREjiKz+mdBS0DkJyFZPU8zk86m1KCP6f0bYNPTTLs9vEaQY6Im/irV+iRgJT6xPTA59eVSClKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSleOLS2hS3FBKEjJUo4AHmaD2laV1p8IXTllkuRbLHevL6DhTjag2yD7FEEq+wY9tQxXwnZuTt0xHx4ZmK/JQdO0rmL5Ts792I34tX5afKdnfuxG/Fq/LQdO0rmL5Ts792I34tX5afKdnfuxG/Fq/LQdO0rmL5Ts792I34tX5afKdnfuxG/Fq/LQdO0rmL5Ts792I34tX5afKdnfuxG/Fq/LQdO0rmL5Ts792I34tX5afKdnfuxG/Fq/LQdO0rmL5Ts792I34tX5afKdnfuxG/Fq/LQdO0rmL5Ts792I34tX5afKdnfuxG/Fq/LQdO0rmL5Ts792I34tX5afKdnfuxG/Fq/LQdO0rmL5Ts792I34tX5afKdnfuxG/Fq/LQdO0rmVr4TsreONphnZ47Zhz/0Vs7s97ZtM6ykNwkrctt0XyTGlYw4fJCxyPu5H2UGzKUpQKUpQKUpQKUpQK50+FTrx+GljSVseLfHbD05SDzKCfVb+3BJ9mPOuiN1cQ/CGU4rtev3FzyU0E+7hIoNc5pmvKlPZdJixNf2SRcHGWorb+5xbyglAG09SeQ+2iIvmma3S+NI6j1I5Jub8R1CbbGMZLklttT6iTxC8oKbTxE5IxkZABwelYazWvRBkOR5SmXm5F4kQ25Dk7YY8YNpKHcAgH1icKPI8/sDV+aZqdXe26da0xCdhCGoqZYU5LFwzJ4pI4qDH8k88HA5AHcc4qRSrJoVuezvVCRHS5J4SWLpxO9MJjrU244c/onC4EDbyyVEbeXMNR5pmtv21Wl2rbe2IEK0KcuFojSUsSbiUJbdDg4jIWVjBG3fgnd4cxyrFWm36Ldm6ciTAygO24ypcjvhwuRhe1lXrBLYyE55pPPqM5oNa5pmtk3a36Ot72pHWG2Zfd40Yw4/fvV4yzhwJKVHeE9cBSseZq10JY9O3O3W9+7SYLK25shM1MiaGVKZ4KSztSVAn9Jv5p+3lQQDNM1sBuBpRekEpIYTd1WlUwyO+HcJCZBSGuHnGSjnjGehHt90dZNOT9IS3LrIhN3RwSRHWucG1trQ0FNAoKgAFKyMkKB6ZTjmGvs0zW0Xrdo1eo7tFt8aC4iGw2IiJF0LbMtZKS4ou7gAUgnCQRnHiaraeTpRdqTaLoISoz9/dbSvv2DGZLKQHQvCSpII5FQCTz5UGqSCnGQRkZGa8zW4LNMsqm5EN70dcXn9NRkNmfcS2hLqXEFTIWVpCOQJxkEbcDqQbJ2yaD+K9tfVNCHnO6l99uQkuhSlgPpLW8nCQVYOwfNHrKzzDVmaZrbFn+Ltk7R7E6qHZ2oRdcQot3QyWkp6IdWc4SevIqx5pTjn5bbJox60XN26GFGuCXXwpqPcEqTHSlsFstEu/pNys9A55er1oNUZpmvW9vETxN2zI3beuPZU9V8WPiJN4nf9/EPo7jcLicblu+bz4eMZz44xzzQQHNfTa1NrSttRStJBSpJwQR4ivilB218H/XLutNFj0g5vulvWI8hZ6uDGUL+0cj7Qa2dmuW/gfrdF91EkZ4BjNFX94KOP5FVdQ7qK+80zXxupuoPvNK+N1e5oPqleZpmgtiuuavhUaMeMyPqyA0VslCY83aM7CPmLPsIO3PsHnXTPd0/SNUZNuYlR3GJKEusOJKFtrSFJUD1BB6ig/OLNM11/dvg56SmznH4si4QkLOeC0sKQn3ZGQPtqz+TTpr61un3o/pRHJmaZrrP5NOmvrW6fej+lPk06a+tbp96P6UHJmaZrrP5NOmvrW6fej+lPk06a+tbp96P6UHJmaZrrP5NOmvrW6fej+lPk06a+tbp96P6UHJmaZrrP5NOmvrW6fej+lPk06a+tbp96P6UHJmaZrrP5NOmvrW6fej+lPk06a+tbp96P6UHJmaZrrP5NOmvrW6fej+lPk06a+tbp96P6UHJmaZrrP5NOmvrW6fej+lPk06a+tbp96P6UHJmaZrrP5NOmvrW6fej+lPk06a+tbp96P6UHJmaZrrP5NOmvrW6fej+lPk06a+tbp96P6UHJma9GScDrXWXyadNfWt0+9H9Kz+j+wrSmm7m3cP8AWbhJaO5rvSgUNnzCQACffmgtPg6aOe0po1cq4tlq43RQecbUMKbbA9RJ9vMn/wBWK2vvqp3ZP0jTuyfpGiqe+m/21U7sn6Rp3ZP0jQfG+vQuvruyfpGvQwB+saAFV9bqprQUc+or53UF1SlKBSlCQASegoFKiNwvbyJqvXUltKsbR5U1pqKXatHt3OCEpfcfZaGWi7gLcCThIwVHB6CvBsv9S0Nq1MtLTnxxb6uz56WMZZcJS6la4ga5usOCU3e0SJM0rkOtBDYilcVoJJdKHFZSfWwE5yceFVx2oW0SpiHYclphiKZSHHCEqeQEBfqpPM8j4Z6HOK97BsCla/HaPvhx3WrJKW+9JEVLAdRuUsgEFGfnDBySOmDms1qPVzNhnMxJMR5bshtKo4QR+mcLiUcMf2gVpPu91BJqVA3O0dhBeV6InLYKJCoriClRklhW1wBIO5ODnGRzArIRdbQ39Fv6i4C+EySlTKFpWoqCtoTkHlkkdcEZ5igllKgzXaEz3iTHlWyRHkRg+XEFxCsFptKyAQcHIUAKoo7TIjk52Oza5zyW2ioqaAUSsM8XZt9xxnz5UE/pWuG+0d2e3al263gJkyXo74W6lSmdjXEzjIOfHBAPI+YNVrZ2jNvMQVOwJDrKxHbkS07EJQ86gKSnZuKiOYyRnGfGg2DStep7TWvR7kpVlnDDDcltIUle9tayjcdudoBHPl0rKXLVqFaIavcDYhcnalkF1tQCycYJ3YV0PIc/Zmgl1KhsnVjsrTFhu1rbDYuUxhgofTkpStRSroevKo/dtc3iyRL1HujttTc43c2GFYKWuM8FFROTnaAnPuBoNpUqL6c1fBuGjoN8mvtsodGx0pBUEugkKAxnxB+yruLq6xypLcePPSt5xQShPDWMk/ZQZ2la71Dqm9R5Op5Fvct7UOwBBXHfbUpcnLYWfWChsGDgcjzFX/x+ZDVwlLtksW6FvQuQFo5upSklAQSFfrAZ6Z8hzoJrStcy+0Cd6RhxI9mcTLD7jUqIt1BVgNcRJSsHb0/pVwx2lRZYYeh22W5DcLTSpBUhIQ66nchBSTk9QCRyGaCfUqHWnWLq9D27UF0g8FMhbaXUtqBDSVr2Bf8AdGQTVkvtJjcFMhu1zHIqWkyX3QpA4TC3FIbcwTlW7aVYHh91BPqVB3u0OKiNxW7dLeUWpLobbwpR4LobIx7Sc+4Gs/pK/M6kszdwjo4aVKUgo4iV7SDg8x/kcH2UGZIyCDVhuq/rFk86DKUpSgUIyMHpSsVqqfJtenLjOgRzIlMMqW20BncQPKgXCxxZikq5tEcvV8auH7XDkQmoshhLrDSkLQlfPCkkFJ94IBrVr2vdQtWmE+hMV5bslbS1pjqUEsjbl8hJOAkkgjPOvm5a1vMp29Qo7zLiWxOYCGGVpcaS20VId35xzVgY8zWGnsujp6mWrhjEZZcZ5u8tTLLGMZnwhs2+WC1X1LIu0JqUGSSjeOac9RkeB8R0NUfirYu+OSvRcYvOIKFEp5EEbT6vTmOXTpWuPjbebXHdHEQy2ZKwqTKbW6PUiMrS2BnkVqUrp5HlmryPr+7qTFQqO05JfVDWhpLSvXbcY3rIP9/kD4Vu4TB3QmmXm2UO2eOpLJKkZKspJxk5znwH3VmZVrgy3YbsmK065DXxI6lDJaVjGR9lQ3QGqLxerVdJFyaZC2GwtsoQU7VFJJbIyeYIHt9lYRnW2o2rehU1MVJkMQn+892UEREvFQWVJz623aPL53OgnnxQsHeJj3oqMXZgUl4lPzgo5V7skAnGMnnVzH0/amLQ9a2oLQgPbuIyQSFk9SSeZPtrVa9Z6mEgyw6yAYGWGTHUG5ChKLfFAzkZRhWPI1JLZqbUHx9FkmojrjtqDa1BooLg4e7ip5nlu5Y6e3NBloXZ9p+OiU07CbkMPPqfQ24M8MqQEqAPUggc89ayfxUsRkqfNrjF1TXBJKeRRt24I6fN5Z645VCNT68utt1NcIcNDS4sdp0YcYIKVJZKwc7uYJGOgHlVintBvBZYK5cBMd6U0138xV8NAWypak7c5JSoAZz40GwmtIWFplppu2shDT3eE8zkObdu7Ocn1eXPwr1vSNhbmR5SLXGD8dCW2lY+aEjCeXTIHIHqKgkXWmqH7ZOnKisNphwYz6mjHWSpTpWCvrkJSEheMZxyodcXoR2d8iI3G7w+2Ln3NxTUgISgpCUA5BUVKGcn5hxQT13StjdYSyu2sFtLSWUjmNqEq3AA55YPOqrum7Q7aGbYuAz3FlQW20MgIUDnII55yTz9ta6j6l1HbZFyeQnvzDsuYGo62lb0ltkLTg5+aTy24qTdn+qJN2ibLytjvLrykR1NoKQ6AhKlcskAjJHWgkjNjtjMCLCahtJiRXEusNAeq2sHII9xJr5csNrcunpJyCyqdkK4xGTkJKQfuJH21AZ+urtB1RfYT7aFRIzLy4/Bjlwp2JSQV+sD4nwwfA1Zw9b6lnQkJYEVLyVS9zyo5UFpabStGAFY9bJHIn2UG04FviW8PCEwhkPOF5wIGApZ6n7auq1rpnWl3uGtGbdOZaTDfZStCWmiSg8JKzuJORzJHQjpzzVvc9Z3f4x3O3R1R3W2ZDsbu6GVh0Nhgr4u8HHJWB9tBN7ppSxXW5In3C2RpEtG3Di09dpyNw6Kx7c19PaWsb8+RNetkVcmQhTbq1IzvChg5HTJAAJ61rC16r1BEQ+H5qEIWqCgLfYUtMRpbG5Th55V6w25PiedZNjUN9RfVzWX0PQnBbW3GlMLSlfFWpKlIBOUdQeYPhQTP4k6c7kiKbTHLCFlwA5zuIwTnOc4GPdVwnStiTcGJybXGTKYSlDawnG0JGE8umQOQPhUL7S7/d41zVb4TwisDuq0bWlFyQVPAL2qBwkJA5++shoPU95vd9uMW4sNMstJWUoCNq2VBZSEq5nOQM+H3UEsj2G2R7M5aWobSba4lSFR+ZSQrqOfhzq3laWsct+G9ItkdbkNCW2CU/MSk5SnHiARkA9KgsvWepmrfcl9ybQu3utQ33SySniKdIU6kE/MDe1XXqrmeVU/jpqdUdt8NREoZisSHEhlSuNvkLaO059XKQFeOPdQTr4n6f40h30VG4kgLDhwfWCiFK92SAeXjzrJWm1wrREEW3R0MMbivanPNR6kk8yfbWo0601Nb4jTXEalPKmS0rcdZI5odwhnryyDkHmcY5Gtv2+a1OZUtlQUULLbgwfVWOo+yguaxJNZasQetBl6UpQKUpQAAOgFWsG3xYPH7oylvjOqecx+stXU1dUoKb7Lb7K2nkBTawUqSfEGvmHFZhRGI0ZsNsMoS22kfqpAwB91VqUAADoBQgEYIBFKUHm0eQr3AznAzSlBQmRGJsV6NJbS4y8gtuJP6ySMEVRdtUJ0Qg5HQoQ1BbH9g7SnI+wkVe0oGB5V5tTgDAwPDFe0oGKpqYaU624ptJcbzsVjmnPXFVKUHm0ZJwMmvQAByAFKUDAznAz51bRIEWG9JdjMpQ5Jc4rqh+srAGfuAq5pQebQc8hz9le4FKUDA8qAAHkBSlAwCOlMDypSg82jyHnXtKUCsVWRecDaD5noKsdtB4XHvpqr54r301ffVwUV88Ogo8V76aqcV76aqrcOnDoKPFe+mqnFe+mqq3Dpw6CjxXvpqpxXvpqqtw6cOgo8V76aqcV76aqrcOnDoKPFe+mqnFe+mqq3Dpw6CjxXvpqpxXvpqqtw6sLpPagIwRvdPRA/70TLKMYuVyXnQMlxQHvqzdvDLRwuWM+w5/yqMTZsiWTxV+r9EchVpsqW8eW1/phLRf4xOO9K+1J/pV2xPEgfoZAX7AedQfZXoSQcjkfMUtzG15fOE94r301U4r301VGrbeHWFBEnLjXn+sP61KGSh5tLjSgpCuYIqvXp6uOpHg+OK99NVOK99NVVuHXhQAMkgD20aKXFe+mqnFe+mqi346PnvtJ96hVuu4wUdZCD7udcznjHGXcaeeXCFxxXvpqpxXvpqqxXeYKei1q9yat1X6OPmsun34FcTr6cfNpGy608MZZbivfTVQOvfTVXsVaJMdt5AwlYyAa+JkmNDZU9LfaYaT1W4sJSPtNaRN+MMZiYmpZFh8LR63JQ61QdfWtXqEhIqPR9Yaaff4LF/tLjpONiZbZOfdmpA3tWkKSQQeYIqo+UpJOSST7aqba+0pqptoGyvNlVcUxQUtlNlVcVjrq+6lyLEjK2PSllPExnhpAypWPPoB7SKC82U2VaJtDIT6z85R8zLcH+Sq99FR8f7Wb+Md/NQXWymyrX0VHx/tZv4x381PRLH7Wb+Md/NQXWymyrX0Sx+1m/jHfzU9EsftZv4x381BdbKbKtfRLH7Wb+Md/NT0Sx+1m/jHfzUC5SUwoinVc1dEjzNQd9a33VOOqKlqOSamb9hhPgB4y1gdAqW6f/AHVR+LFs/Zv/AIl381SYebW0ctSePgh+ymyph8WLZ+zf/Eu/mp8WLZ+zf/Eu/mpTHumXND9lNlSW5aWj92W5blvNSUDKAt5S0KPkQonkfMc6i7L/AB4KJCAQFthYB6jIzUY6ujOnxGm5MkqECDJlhBwpTe0JB8sqIBPuq7jjUMdJQxaZqGzzI4rPX/HUu0u0lrTlsSgYHd0KPtJSCSfaSSaotXtxzVr9kNsmJbbjCQJxT+hUScbAfpUyxjKKfQ2fSjRyjOPGUYWNQr+da7if/wCdr/8AsqiqJelHKrLNJ9rrP56lsS9uSNVT7MbZMabisodE1af0LpV+qk+Y/wCxrNYrGdmwnjb6OO3amPCvo1v3K8fUkz+Kz+encrx9STP4rP562RimKndNN18R1v2a37lePqSZ/FZ/PTuV4+pJn8Rn89bIxXyvkDTummfEdb9ms9Va8i6I0W5JuDK03FBLbMNzkpa1ZI6fq9ckZ6Y68q5I1hq686tuS5l7mLdJJKGgcNtDySnoP8/OtmfCrujsnXEG3k/oIkQLSP7S1HJ+5KfurXPZ7phGqr87FkSVRocWM7MkuoTuUG205O0eJPIV6McezERDx55TnlOU/NGc1sjsr7VLtoqcyw+85MsalAOxVqzwxnmpvPQ+zof51Z6CYsWodUtadk25aINxUWYslSwZMZwj1VFSQkLGeoI6Hkahlxhrt9ylwnSC5HdWyojoSkkH/Kq5fobZ7hGulujToLqXYshtLrax0UkjINX2K0r8Fi6vTez5yI8oqTBlrabz4JIC8feo1uug9pSlArEz/wDeK0/+W/8A+ystWCvjDki+2lDMlyMrY+d7YST0Ry5g0GWuEVM2BIirW42l9tTZW2rapIIxkHwNYiDpliHo4adRLmrj93VH7wt0l7Cs893nz5Vc+jJn1zM/wN/lp6MmfXMz/A3+Wgtviyx8Tfi53ub3fu3du8cU8bGMbt3nWTtEFFstcSC0466iM0lpK3VblqCRjKj4nlVr6MmfXMz/AAN/lp6MmfXMz/A3+WgytKxXoyZ9czP8Df5aejJn1zM/wN/loMrSsV6MmfXMz/A3+WnoyZ9czP8AA3+WgytKxXoyZ9czP8Df5aejJn1zM/wN/loMrSsV6MmfXMz/AAN/lp6MmfXMz/A3+Wgyivmn3Vq6GsLssUpQlAEZI5ePq9anirZM2n/4zM6fQb/LUDt7jitPQm1rKktxwE5/u1JeTa+EJdp++QkWG3JPesiM2DiK6f1R/Zq/9PQf+K/CO/lqrpz/AHftn/LNf9IrIVXrYr09B/4r8I7+WvfT0H/ivwjv5aylKDF+noP/ABX4R38tPT0H/ivwjv5aylKDF+noP/FfhHfy18OX6Dj/AOq/CO/lrL14oZFByT8KGCl7UNuvcZLxYeZ7s4VsqQErSSR84DqCf8JrVGk9RTdL3lNwt4aWooU0408nch1tQwpCh5EV2v2kadhalhwLXc298aRJUk45FJ4LpCgfAgjNct657HtSablOKhRXLrb8koejIKlgf2kDmD7sigw2k9R2bTl5cv7EF5dxZ3KgwyrLDKyMBalk7lbc8k48smojIfclSXpD6it11ZWtR8VE5JrIx9O3qQ+GWLRcHHicbExlk/5VuLst7Dp0uaxcdXt93iIUFphZyt0j6ePmp9nU+yg2f8GuwvWbs8ZdkoKHbg6qUEkcwggBP3hOftrb9WsKOlhpKEJCUJACUgYAHlV3igUpSgViZ/8AvFaf/Lf/APZSlBlvGlKUClKUClKUClKUClKUClKUHivmn3Vqu3f+CRv+XT/00pUl49s4Q2Lpz/d+2f8ALNf9IrIUpVewpSlApSlApSlBhb7/AOIWP/nFf/YdqvIA58hSlBbADPQVexwPKlKC9T0r6pSg/9k=",
+              "timestamp": 21993685278
+            },
+            {
+              "timing": 5749,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAFIQAAEDAwMBBAQKBwQHBgUFAAECAwQABREGEiExBxNBURQiYXEIFRgyUoGRk5TSFiNCU1Wh01ZisdEzNnJ0grLBFyQ1c5LwQ4OzwuEnN0RUw//EABkBAQEBAQEBAAAAAAAAAAAAAAABAwIEBf/EADARAQACAgACCAQFBQAAAAAAAAABEQIDBFESExQxU5Kh4SFhkdEVQVJx0jNCgbHB/9oADAMBAAIRAxEAPwD1TSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSvilBKSpRASBkk9BVea1xpV64egtaitK5edoaTKQST5devsoLFShIAyTx51XTrjSyZ/oR1FaRLzt7r0tG7Pl16+ygsVKAggEHIPjUVedQ2uyrQm6yvRELxh51tQaHvcxtH1mglaVQu2uV/+kl/kw3+DHSpDrS+oKk8gipY6v09ZokCNd75bocpTLf6t+QlKuUjkgnigs9K640hmUwh+M628y4NyHG1BSVDzBHWoW76x03Z5Yi3W+2yJJzjunpKEqHvBPH10E9SuqJJYmR0SIjzb7DgyhxtQUlQ8wR1rtoFKUoFKUoFKUoFKUoFKUoFKUoFcVLSnqRXB9ZSMDqag7jfrRbHwxcbnCivFO4IefShRHngn2UFgSpKuhBr7UJa7vb7oFqtc6NLDZAWWHQvaT0zg1MNL3oz40HOlKUClKUGt+3B95dnsdoS8uPEvF1Ygy3EHae5USVJz4ZxirHL0LpiRYVWhdlgJg7CgJSykFPGNwVjIV7etZmrtOwdVWJ+13NKu5cwpK0HC2ljlK0nwINU93Res5MI2yVrxarapPdrWi3oTJUjoR3m7rjxxmgohvtyf7D4cFU10ocvAsip6VYUuN3pTvz7UjbmtuI0DpVNj+KRYrf6Fs2YLKd3TGd3Xd7c5rm9omyO6JGlTGItKWg0lIPrJIOQsH6W7nPnVaTonWiInxcnX7vxaE92FG3oMnZ0x3ueuPHGaCG7QZUnQnYoY+nbw9LLbqYaJylhS2W1LII3DxSPVB6iti6f05bLfpxFubaEiO8yEvrePeKkZHKlk/OJzXXbtG2SFo9OmRES9ae7La23vWLmTkqUfpE8586xVaeulssos+mJ6Y0bZ3aJE1apDkdPTCE8Zx4blHFBpWO+7H7Iu1CwJdW9brNOXHhrUc7W+8HqZ9mP51ufROlLND0nEbMWNOVLjockyXkBxUpSkglSieoOeB4Co8dmcCP2aztJQJLjfpoKn5jid63HCoErUOM5xijejtR2mJ6BpfVLcK2hO1tmVBEhUceIbVuHHkFZxQVTT8t7SH/ajarISqBZ2vTILXzgwtbSlqQPYCM4q09lmkrGzoa2yVw4s6VcY6ZMuU+2lxb63BuVkkcjJ6VNaL0dD0zZ5UQuuT5M5xT06VIAK5K1dSr2Y4AquwtBah0+hyFpDVvoNnKlKaiS4SZJj5OSEKJBx5A5oOjs+ZbsHafqzTdrGyzIZYnNsA5THcXkKSnyB64raFVnRGkWNLszHFy37hdJznfTJz/z3leAwOAkDgAdKs1ApSlApSlApSlApSlApSlApSlBjyR6wPsqo6lFzNwT6CL4Wu7GfQRD2Zyf33rZ/lV0cQFpwaxlNLB6Z91BX9LCcG5Hp4ugORt9P9Gz/AMPc8fbVljD1D7660MqJ54FZKQEgAdKD7SlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlcHnUMMuOvLCGm0lSlKOAkDkk0HOlVeD2g6RnzGIkLUVsfkvrDbTSHwVLUTgADzq0UClVi96/0pY7iYF2v0GNMGNzS3OU/7WOn11YokliZGakxHW3o7qQttxtQUlST0II6ig7aUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQK8j/CF1dqO09qVxiWu/XWFFQ0yUsx5bjaAS2knABx1r1xXiz4TP8A+710/wDJY/8ApJoPS3ZZPmTux61TZsp+RMXDcWp91wqWogq5KjznitM/Bi1Tf712gzI14vdznx021xwNSZS3EhQcbAOFEjOCefbVw+D/ANoVkumn7PopLE34xaiuBxSkJDRAJJwoKz0PlVlmdnWnND6c1JdtJ25yLdPiqS2hwSHXD8zdgBSiOqU/ZRHdc+2rRFvvotTtzU48HO6ceaaKmW1Zx6y+mB5jNR957etHWm6y7e+Lk47GdU0pbLKVIUQcZSd3I9teVNBs6ZkX0o1rLnRbZ3SiHIidyu8yMA8HjGegPOKh7umGm6S02tbzkAOqEdbwAWpvPqlQHjjFB69m/CC0bDmPRnm7t3jSyhW2OkjI/wCKpe3dsOmrjrRrTcP0pyU4SkPhCe6BCNxBO7PGCDx1FeM9T/6xXL/eF/416T1F2Tac072cz9RWZqai6tWxTqVmQSAVt4Wce5SqCyXz4QGi7ZOcisrnTy2rap2MyC2T7CojPvHFZ1r7VtLa1st2h2qU61P9CeUI0lvYtQCDkp6g/Uc15T7OW9HuXWQNdvT2oPcnuTEGf1mf2sAnp09vWpvSadHt6jQu2zdR+lb1iKkx2gkgggBZCs4x1IHTNBXezSUzC7QtOSpbiWo7M9lxxxRwEpCwST9VendKdv8Ap2+6kTan4kmAh53uo8l1QUhZJwnd4pzx59ea8w9mkVid2habizGUPxnrgwhxpxOUrSVjII8RTtHjswO0PUceG2hhhi4voaQ2NqUAOHAAHQCg2z2rw+y5HaDdk3d7Uka5d9vlIhobU0pagFEpKuRnNRHa7rRVqf09adB3W82y2RLWyru0SFtbg4kOoJ2q5VtWM+3NUvtfdW/2h3N11RU44iOpRPiSw2TVg7borDNs7P32mG23X9PRVOuJQAXCEJAKj4kAAc+GKDbfwd+0aPI0jdGNT3eU5LgLVKelznStKWlbUpAWok5yDx7fbU8/8ILQrUsspkT3UA475EU7D7eSD/KvNEi4W1HZHDgxlRk3Zy6uOSQlIDqmQ2Nm44yU7irAz1rHsls09J0pMlXGe3HuaFkISZCtxHGNrQaO7394n6qD21Y9ZafvlhevNtukd23MAqedJ291gZO8HBTx51ryf8IjRcaUpphNzlIScd60wAk+0blA/wAq0BCagQOz3UwsWoZM1chuOJcQwlMpSkPJworKiDycY9vsrA0A3oVyBdTrd+6NSgkehiGMg8HPgec464FB6rh9rmlrzpS73S2zHiqBHLr0ct7X0A8AgE4PJHINeWdL9pOpIWprTKuupL6/bmJbTklozHF72gsFSdpVg5AIwetW3sTiaSkarMeK7eZUp6HIQuPKitejuI7skhfrE4yARx1ArWOilwmtZWJd2DPxciewZPfJCkd0HE79wPUYzkUHre9du+kbPNTFlt3QuqYZfGyOkja62lxP7XXasZ9tSWpO1/TenrTY7jPRcDHvDBkRu7ZClBI2/OG4YPrDzryx23y7fO7S7pJsi2V2xbccR1MDDexLDaQEjwAxj6qmu2CbGk6F7NGo77TrjNqUHEoUCUH9WMHy5SfsoN6ufCA0ciAzMU3de5edW0n/ALunOUBBP7X99P8AOknt/wBHs2hiehNxcDz62QyGkhwbUpJURuwE+uAOeTnyryZK/wBUrZ/vsr/kj1unsB7LdNa20ZKuV9alLlNzlsJLT5QNoQ2RwPao0G5dSdr+kNPMxjPnrVJfaQ8IrLZcdQlSQobgOEnBHBNdOle2jRmpJ7UGNPciy3SEtty2i3vJ6AK5Tn2Zrx85GYXrV6LeFqajiYtp5S3CgoAURgq2qIxjGdpx5VMTrNpJvUC2UakVDhp2lLjDK5oSfHC9rZP/AKaD3hSsGxL7yx29ZfXJKo7Z75aChTnqj1ik9CeuPCs6ilKUoFKUoFaY7S+w1Gt9XSr4q/qhF9DaO5ETvMbUhPzt48vKtz0oNOdmPYijQuq2r0m/KnFDS2+5MTu87hjOd5/wrcTiEuIUhaQpChggjII8q+0oNHXX4OOnZd9EyJcJcSCpze5CSkKGM8pSvOUj35qNvXwaoU27S5MLUBgxXXVLajJhbg0knhIPeDOPOvQdYV8emx7NOetMdEm4NsrVHZWralxwA7Uk+00Ghrn8GtqdcZMr9KVo75wr2+gA4yeme8rfTNvaFoRbpCUvsBgR1haeHE7dpyPIjwrQOi9Zdr03WkKLdrK6Le4+EyUuwe6Q03n1iF+wZxyc+2t/Xm4NWm0TrjIyWIjC5DmOu1CSo/yFBpC+/BqskuYt60XmXb2lKJ7lbQfSn2JOUnHvzU/onsLsWl1yJPpcidcnGHGW33kgJZ3pKSpKB44J6k1pW5/CD1rKuLjsF2HEjFRLbCY6V4T4Ak8k+3ivVWhrnIvOjrLcpu30qXEbed2DA3KSCcDwojUOlPg7t2DU1ru41Kt8wZLcjujBCd+1QOM94cZx1xXzVXwd27/qW6Xc6mWwZ0lyR3XoIVs3qJxnvBnGeuK33Wv+2W8avs2n2HtD270ySpwpfWlvvVtJxwUo8cnx5x5eRVG1X8HlvUF9fuR1KuOXUtp7sQt2NjaUde8HXbn66uWqeyWz6m0dZLJcn3RJtEVuNHnNJCV4ShKTlJyMHaDj+dVns313rWNYr/du0W1SEWy3sB5t30YMvLVnlKUkgEY5zx76mtD9tuntY6mi2O2wbqzKkhZQt9tsIG1BUckLJ6JPhRFe0z8HOy22RKVd7o/c2HmVNBruQzsJwQoHcTkY4qNf+DHblSipjUktEfPDa4qVKx/tbgP5V6GrTED4RGlptzjwWrbew6+8llJU01tBUrAJ/WdOaKtWleynTGntLz7G3FVLYuCdst2Qcrex05GMY6jHQ89a11cfgy2p2UV2/UMyMwTnu3Y6XSP+IFP+FegqUGvezLsnsegVvyYa35lweR3a5EjHCepSlI4APHmeKpeqPg42W6XR6XaLrItbbqitUfuQ8hJPXb6wIHs5re1KDR9++DxZrlbLazGu0qLMhsBhUgtJWHgCSCpGRg844PQCsW6/BvtMm1WyLb7w5EfjBZkSFRu8VJUrbzjeNoGOBz1+2/8AbDd9WWfTTb+iLcJsxTu14hHeLaRj5yUftc488eXlXew/UXaBe5c9Gt7atiC22Cy+7G7hZcyPVA4yMZOccY9tEVh34NrblpjQf0oWAy869v8AQBzvS2MY7zw7v+dbQ7JtCp7PtNv2lNwM8OylSe9LPdYylCduNx+h1z41dKUVqPtE7C7Fq+7O3SNKftU987nlNIC23FfSKTjB9xFRek/g6WC03FmXd7jIu3dKC0slsNNqI+kMkkezNbwpQAAAABgClKUClKUClKUCvPXwi+1W76dvLWndNP8AojqWUvSZKUgr9bohOenHJPXkdK9C15q+Ex2b3e435GprFEenNOMpblNMp3LbUkYCgkckEY6dMe2g1zctc9okPSEMXGbe48eXI9Ji3FTrjanE7SCgK/aT0UB7/OvsDXOq19nl7lK1JeDJbuUJtDpmObkpU3JKkg54BKU5H90eVQmorvqq6aMt0W9rd+JrU6mJGQ40EEK2HAzgE4SnHPTIqS0NpyfqTs01g1amHJMmJLgyu5bTuWtITISQB4nC849lEXTsg1bqK46V7Q3p99ucl2JZ1ux1uylrLK9q/WSSeDwORVW7OdcaqmapSzL1JeH2vQ5q9jkxxQ3JiuqScE9QQCPaBWN2dt6pg2rWMS12hSo8m2OInOSG1J7ltKVE481HkAefuqO7MYMtGrkKXFfSPQZwyWyP/wCI9QT/AGVa31TP7R9OxZuo7vIjPTG0ONOzHFJWknoQTgivTvbVDmzuyzUbVtk+jPpiqdUvcU5bQQpxOR9JCVJx0OcHivJHY/Blt9p+mVuRX0pE5skqbIA5r2Z2jJUvs+1OlAKlG1yQABkk90qg8NaAt1zu+sLZAsU30C5vuFLEnvFI7s7Sc7k8jgHpW0e1ftM1Zb7xH0pa7o+yu2MMxZMiOol2VICE71byN3zsgdCep61UuwyFKb7WNNrcjPoQJBypTZAHqKqyfCA0HfbXr6dfrfDlP26a4JCJEdBUWnMDIVjlJyMg+2giNZa77RoMCz2++SbzaZUdCyl7vHGFykHbgrxjcU4Iz1559skrWepv+wxFx/SC6+n/AKRmP6R6WvvO79GCtm7OduecedVPXEXWtxg2a66sVOlCW2sRA8CVpbTtydoHAO4e04z5VKqhSvk/Ib9Gf7z9Jyrb3Zzj0Uc48qDN05dNUar7Mdc+lagnyEwRFfWJUpxeWv1wWgdevq8dDt9lVTsntl0u+v7VDsM70C4LUtSH+8UjalKCpQynnlII+uti9gWnp150b2jWpppTUmZDYbZ71JSCr9bgZPtx9ta6srOrdCasZlRLZMi3iMVoQlyKV53JKTgYwrgnkUHubU0SZP05dIdskeiz34rrUd/cU904pJCVZHIwSDkc1+fFrYkP3qJHjPd1KckIbbd3EbVlQAVkc8Hmv0Nsrr79mgvTAUyXGG1Ogp2kLKQTx4c54rwxqvR2o9E6pWH7fJzHkd7HkpaK23AFZSoEDHlxQbK7We0zVel3IWj4NyKJtvhstz56CVuyHigEkKUMgcjnqc1S1a57TNKTIz1wul4aW6N6Gp5LiVj/AGV5/wClNa6V1nf4cfWtwt0mUu4pzI7mMUqaUg7AVIAyElKUkHGKxbfctd3edEYscGUxIaGxKbdATHBPHKyhIBPHVXSgn+1PtP1Fc5lhuFsulytKZVrQt6NFkrbQHQ66hRAB8dv2YrFv+rtf/wDZ1pqe/dpbNsW6821KRLV6RIcC1ZK1ZzgD1QM/s+6urtus2oIl6sTN+cfuF0TaWzIeSnd6xddO3IGDgED6qk9WxJKvg76GbTHeLiZ0oqQEHI/WOdRQfHO03VE/she7y8zW7jBu7DQmNOlt1bTjLx2KUnBPLeefZ5VW42vdXK0rcXjqa9F1E2MhKzNcyElD5IBz0O1P2CsSBBljsyvSDFf3G7QSB3ZyR3Mr/MVHxYEz9ELmn0SRkzopA7s/u5HsoLdpG/8AaXqm1Xe3WKbeLmoqZU876YorZSN+AkqVxuPXH0a9S9kMW8wuz61x9Tek/GyAsPekOb1/PVjJyc8Y8a058ECM+xL1T37LjW5EbG9JTnl3zr0pQKUpRSlKUClKUClKUClKq9+1ciz3FcR2E4sgBQWFgBQP1UFP+EVo296005a4mnoyJD7EsuuJU6lvCdhGcqI8TUd8G/QeoNEo1CNRxERjMMfudryHN2zvN3zScfOFbCuGr48O2wJYjqc9LSVBAUAU465+uuUTV0Ry1Lnymlx2wvu0JzuU4cZOBVoWWlUpHaBDLuFQ3w3n5wUCfs//ADXDXN5jy9PRvRFd4iSvIWDjbtxkEfXSheKVqLR93FpuTjrjanQtopwFYx0P/SrTG19FdfSh2I40g9VlYOOPLFKF0pVWtOsY0xmW9JaMZqOAclW4qznAAx14rDX2gRA4QiE+pH0ioA/ZShdaVG2O9RLywpyIpQUjhaFjCk1JVApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAqidp8HLcSckfNJaX7jyP8Ar9tXusO7W9i6QXIknd3a8cpOCMHPFIGlXH3HmmGlHKGgUoHlk5/xNWDV9vct0GzsKBCEsnPl3hOVf4j7KtsbQ9rYkNPByUstqCgla0kHB8fVqfuVvjXKMWJjQcbPIz1B8wfCurRqaU5ZjYWUR2XhdARvWSce3xxWTDQ7+hE9Sge59Jb2+/x/6VcE6FtKXdxMlQ+gXBj/AAz/ADqwC3xBAMIMIEUp293jjFLGptOT2IHxj6QVDv4i2UYGfWOMV06aYak32Ey+gLaW5hST0Iq/r0LaVLKgqSkH9kODA/lmu23aNt0CazKZdlFxpW5IUpJH18UsQ2vrTFt9pZXAjJZSp4BwpzzwcZ/nVThqt4tzwkj/ALzn1cIUVfUdwA+sGtyyo7MuOtiS2lxpYwpKhwarS9C2lTm4KkpH0Q4MfzGaRIjOzkQvTZBiCX3oawsuFOzqMdOc/wD5q+1h2q2RLXH7mE0G0k5J6lR9prMqSpSlKgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpWuO0W6yDc/QGnFIYbQCpKTjcTzz9WKsRY2MFpUcBQJ9hr7WoHbBeISY76UKBc5QW3OR4+dfdTPT1Jt4uQWiQlkpJKuVDccHj/wB8UpG3VKSn5xA99fa1LbLHdrzbGlx1tmM2tQSFLxzxk/4V9vV0uNyufxey4sISsMIaQrAURxz580obZqj32Nqpd1dVCcX6MVfqu7WlIA8Mg+NVYu3fTVwShbi2nMBewr3JWPb4eBrq1JKMm8yH0KUEuhCwM9MoBqxA27bhIRAYE5SVSQgd4odCayEqSr5qgfca1PqiRP8AR7c24p1ML0Rkt4J2qOwZJ9uajrbCkyAHIctlD2eEF7Yv6s4/xqUN1E4GTXxKkq+aoH3GtUauduqHIzM5TyWksoABJwpW0biT4nOaj7bClSAlyFLaS/nhvv8AYv6s4pRbdFK1Tqu6z1ymoC3XEBlpCVpCuVLKQST58msO+s3aDGhxrnuShIUWfXBODjIyD7BSi24qEgDJ4FaZUtf6NIO5WfS1eP8AcFc7eia7Ybo4zI2R2i2XU85XkkAZ8uaUW3GDkZFfCpIOCoA+01puzX2Za2pKGHVYcb2pBOQlWR6w9uM0t1ruV7Eh+OS6W+VqW5yT9dKLblpWtNNyrxaGJTrzbq4aWVKAWoEJUBweuevHHnUCp+4XiStT0rcset+tdCAPYMnH1ClFt00rWmjZV4jXRlpTcp2EtWxYUkqSn+8D4VsukwpSlKgUpSgUpSgUpSgUpSgVRtc6blzponQEB0lAS43nB48Rn2VeaUGnU2G+SVIaVDlEJ4T3nCUj2Z4rOvmmZ8VuCyxHdkKDRLimklQCio8fZitqUq2lK7oKK/EsPdSmVsud6o7VpwccVWNS6XuLF1dmWxtbra194ktn10KJz09/lWyaUtWqY+nb5eJoXOQ8jOAp6QeQPYDya46isM/44kCJBkOMJ2pQpLZIICQP+lbYpS0pridA1FH7lyCh8sKjsgtghQBDaQQUHxyPKoYWC9T5RUqC4hazypSA2kf4D7K3BSllNc3S2ajhSP8AuinX2O7Qk7SFpJCAD6p9o8qhkaevU+UVKguIWo5KloDaR9XA+ytv0pZTW2qNKXDvW5EZJlEtoS7t+duCQCceIOKi5mnbz6LGedYkPLc3Du8FSm0jGM+Wcnj2Vt2lLKamVZrl+j6GvQZPeiUpW3uznGwDNZ1ntU9rTF8Zchvpdd7rYgoOVYVzgVsulLGo7Tpi4S5DjL8V6OC2SlxxBCQodAa6l2C+RFrbTEkjdwotchQ94rcNKWU11pnSEpZfcuSSwhTSm0JyCrKhjOPZUWqxX+0S1+iNP5IKe8j8hQ+r/rW2aUsa80lp66i5Ny5yno7KFbylSzucPtHl55rBNn1F8f79r/fd5n0jd6mM9c+XsraNKWpSlKgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpVO1FcpVruU6G0+vvbmyj4v3HIQ9uDa8ewbm14/2jQXGlVONeJ7YaeKoy4KZvxf3KgoyCQ53e8r3YJyN2Nvzec10227zX+7h20RIuxp2Qtcre4FAPLRtB3A/s5JJOMjirSWuVKhNPTRMkXBzYjP6lRU26XEq3NJV6ueMc+AGetRKdSXBqypu8j4vVHfirkNRgVIdRhO4JJJIVj9ogDHtpRa40qpTb5dbcJLD3oMqUGW3mltIU2gbnAjaoFSj45Bzzg8cV1Tb3fYKbwt74uW3a0peWUtrBeQU7ikDd6hAB59bPHApRa5UqoOXq9KcQ4wi3iO5cFwUpWle4AFQDhOcH5vzcc+Yroc1JeTMFsYjx3J6HXkuPIbygpQGyMIU4k5IdH7Rxg9aUWu1KqCL7eJjTPojUFh30JUpzvcup3JUU7UlCsYOM5yceRppi4XK46hmuuS2PQVx4z6IxaVuQFoURg78Z8zt5x4Uotb6VVZN7uaLhPU2mIIMOcxEUlSFFxwOBrJCt2AQXPI5xjjrXVF1FcFogS3ExDFnuuMtR0IV3rRSlZBUd2FfMwQAMZ6nFKLW+lVJepJqodrVFYjvSZdtMwtBW3K8sgAZPT9YrgnnAGak7FcZNygTAtbaJrLhaO6OtsIVtBG5CjnxHRWCPGlFpqlUex3O+fE+nmzJgyX53CnltLBbSlsqOfXO5WRjqOtd7OppiriUER3IrqJBZUhpaeW+nrKPrjjnCQAfE0otcaVTU3+9NtspdjxH5EqGiWyhlJTs9dCVpO5XrkBYIwU5xio+e9K1BNsLbjkFaETXm3mX4TmN6WlK9ZCljBweOvJBz4UotsKlVZi+T1OsyVeiGC7OXCTHShXfJIWpG7duweU5I2jAzzxXTFvV7ksWtQTb2nLi84hGULUGkJQs5PrDcTtHHGM+NKLW+lUlvU91YgR7hNYiuR1uSGFMMJV3m9lLp3BROMKLR9XHG4cnFcpuo7pboLz0j0CS4u3PT2O4SpKUFAT6qsqO4HePWGOh4pRa6UqpSb1eYsiTDLMWRKQGXEqZbI2oc7zPqFeVlPd+BGQenHPZcrk5N0HNmJcw93S0lTaFNEKSopPqq9ZJBB4/xpRa00qqq1DKGoWYye4chOSjEylpYKVBClH9YSATlOCkJOPOrVUUpSlApSlArpfiR33mHX2GnHWFFbS1pBLZIIJSfA4JHHnXdWLJuUGLJajyZkZmQ7/o2nHUpUv3AnJoPgtkETjNEOOJZ/8Ajd2N/THzuvTiuEmz2yU021Jt8R5pslSELZSoJJOSQCOMnrXJy629ovd5Oio7gZd3OpHdjOMq54545rim5sPCGuGtqSxJWUh5t5BSMJJyOfW6YwM/yoMpphllS1NNIQpeNxSkDdgYGfqGKxmbTbmJLshmBFbfdBDjiWkhSweuTjnNG7tbnGnnG58RTbPDikvJIR7znivjt5tjUZqQ7cYaI7pw24p5ISs+w5waD7HtNujMrajwYrTSyFKQhpICiDkEgDwNdzsOM6l9LsdpYkJ2vBSAe8GMYV5jHnXVIutvjvtsyJ0Vp5wgIbW6lKlZ6YBPOa+i5QTOMITIxmAZLHep7zH+znNB2CHGASBHaAS4XQNg4Wckq9/J59tdEu0W2YhaJcCK+la+9UHGkqBXjG45HXAAz5Vzi3KDMkOsRJsZ99rhxtt1KlI94B4pIucGNLaiyJsZqS7/AKNpbqUrX7gTk0R2IhxmwkNx2khLfdDCAMI+j7vZXFu3w2nmnm4rCHWmw02tLYCkIHRIPgPZXH4zgemiH6bG9LJIDHep3kgZPq5z0pPuUG3lsT5kaMXDhHfOpRuPsyeaK7DDjK73Mdo96tLq8oHrrGMKPmRtTz7B5V1s22CzLXKZhx0SV53OpbAWrPXJ61zVOiJUtKpLAUhSUKBWMhSvmg+05GB45rrZutvel+iszorknn9Ul1JXx14znig4Istrb37LdDTvSUqwykbgSCQeOhIH2VkQ4caE0W4cdphsncUtoCQT58Vixr3b5MmWyzKYWYgy6oOoIT55wcjHjkD/ABrk1dI7zyg06yuOltS1PpeQUpIOCCM548T0ojtYt0JhYWxEjtqCy4ChsA7iMFXHiR411Cz2wLKxb4gUVFeQynO45yenXk/aa+s3i2vRFSmbhEcjJUEF1LySgKPhnOM8ivhvNrTCTMNxhiGpW0Pl9Owny3Zxmg7XrbCeQlL0SO4lLfdAKbBARkHb7spHHsFGLfDjpaDERhsMqKmwhsDYSCCR5Egn7a4SbtboqWFSZ8RlL/LRceSkOf7OTz9VZEqSxEYL0p5tlkdVuKCUj6zRXSm2QUTTMTDjiWerwbG88Y+d16V2IhxkBkIjtJDBJawgDZkEHb5cE/bXQLpHLiVBxkxCyXvSe+RsxnHnnHt6VwTfbSoIKbpBIWvu0kSEesvj1Rz15HHtojJTCioS2lMdlKW1qdQAgeqtWcqHkTuVk+0+ddLVntrLT7bVviIbfTtdSllIDg8lDHI5NclXW3plpiKnRRKUdqWS6neT5BOc1isagt6oCZcuQzCaU84wn0h1KNykLUg4JP8AdzQZkm3QpRWZMRh4rCQorbCshOSnr5bjj3muQhRRD9EEZkRcbe5CBsx5Y6V3BaS3vChsxndnjHnVVtusmZ8xpDIhrjOS3IwcalhakBCXTvWkJwkHuuOeQc+FUT67TblvqeXBiqeUoLUstJ3FQ6HOOvA5rNrClXFlqMHGVtPrU33raEupTvRkDcCTjHrDn2jzroud9gW9SmlyWVygpA9HS4nvPWUEg7c5xzmoqUpWI1coLs5cJqbGXMQMqYS6krT705yKy6BSlKBVZuNnnGfc1xGbfJZuAbCzLKv1W1O3ASEnenxxlPJPnVmpQVZenHkR1LYEYyhc1T9qiQh4EqASs4zkJI8DgpFcBp2Y5MblPeioUuauU6whSihIMZTIAOBuJOCTgdT9dspVtKUtjTM5Md5lxLRjhLQYYMtZLakKJyl3YFgDjAO7pX06evC2GW3ZDCxtfQtW4JWAsgpBWGwVDA5A254yTirnkUpZSlJ0tNXZrkw76KJcm2Mwm1hZIC20rGSducZUD086zmLNPZdXGDUBcRUtyV6S4pReTvUpWAnbgKG7aFbug6eFWelLKU/S2mZNrlwTJbYCIMdTCHUy3nFOZwM7FYSgEDJHrc48q43rS8qXdbg62hl6PPU2panZbzfdbUpSQEI4X83I5HJNXKlLKVh7Tz6vSlNlgOu3VmcFZOdiC3kE464QofX1rhqSwSp12XNittPh2KIqm3ZbrARhSjn1AdwO7kHHzRzVqrClW5uS8XFuvpJ4whwgVnsyzxi8Iuf3pYiJ71fTpqSi822c2Y22A03HQ2VKPeICSFLUTk7k5O3Oeqsn1uI+yWWfLtzDCmIsaMi4SJPpCVKD3+lc6J24BOcFW7p4c1aviZn9/J+9NPiZn9/J+9NYddxPhx5vZ10cOfoq0DSE1mF6M4iMks292G08Jjzm8qSE52K9VCeMketzjHTmRvOl1zYqo0ZTTDIgpjJSklI3JcSsDjok7cHHODUx8TM/v5P3pp8TM/v5P3pp13E+HHm9joYc/RXkaXlPJfW+zGacdkRFqR6U7I3IZdCzlSx1xkABI9p8slywzmL4/c4qYrxMhxbcd1woTtW0yknIScKBaPgeFHmpj4mZ/fyfvTT4mZ/fyfvTTruJ8OPN7HRw5+iszNLT3FqdSxAWp+KI7jKJL0dpr11q4CB64Pecg4zt8M8T13tCpNphRWUJcXFUhSCX1tFJSkjIWNxzz45yM5rI+Jmf38n700+Jmf38n70067ifDjzey9HDn6K+9pi4SbatiU9HdcXDdjKKuhKnQoZwkA+rwTgZPOOay7pptcpeo1spjJVcYKIzRPG1aQ4Mq44HrJ6Z6eypX4mZ/fyfvTT4mZ/fyfvTTruJ8OPN7HRw5+isxrRPlru8dEeGhh+5B5clalB1OzYchO3Cj6vByMZ9nP1elZzbkeQ2GZDrfpSC0ZbrCQHXi4CFIBJ4wCCPr45svxMz+/k/emnxMz+/k/emnXcT4ceb2ToYc/RxsEV+3RI9uWy2I0aM2lLqHFHcvkKSArJAGE4JJ6+yow6dkKZgtqWyAzOlSHCCfmOh4Jxx1Hepz7jUr8TM/v5P3pp8TM/v5P3pp1vE+HHm9l6OHP0V1enbs/FjsPmEgR7cYSShxSt6tzR3H1RgYbPHPXxrsm6duDiJkVpEFbD9wbnCQ4tXeDDiVlO3b1ATtBz0xxU98TM/v5P3pp8TM/v5P3pp13E+HHm9k6OHP0V60aWlQ7lFLqWVx40l2SmQZbxWor3/APwuEpPr4JyQcHjni6VHN2lptxKw9IJSc4LpIqRrbXnsy/qY1/m/+QkxEdxSlK0Qqj6m1BcYd3ntMSGYrcNttbaHdmJBUM85O7GfVGwZyD14FXioyYX1SgoWpuR3Zy26pxII92RkVns3Y6Y6WUTP7RM/6iVjCcvhCGsrjqdZ3hmTdllSu7cbhL7sZQUDlIxuwDxkfXWDP1BPamX1aLlGQbdKbaZglsbnwpCDtJznKiohOPHrnpVm9KuG7d8VDd0z36f8qwYsV+PLkyRZwt597vypb6CUK2JT6pxwMIFYdv1csvJn/F31OXOPrH3V/wCMHY8gzY0Znv47F2UhptGAtSH0AZA6k458zmvt9nznbHeo0a9CaBbVyvSoyEAtH6HGRhQyR4jaeTVrS/NSoFNoQCM8h9Picnw8a+NOzGUqDVmbQFHJCXkDJ+ynb9XLLyZ/xTqcucfWPuq9+1HIgQHHbbd0zxFiGWXEoZKXfWUAFKBAI9UjCBnjk9K6XrpJhTtUy4VxjoUxKbdbiFAUZJLDWE56+twE7fHz6VbVLlrKSuytKKQQkl5BwD1A4r4DJCkqFkZCk8pPeoyOMcceQH2U7fq/Tl5M/wCJ1OXOPrH3VhV0mREtRozwiIkzZy1vnZkFLvCBvO3JyT48JPvFp03dPjC2xDJfjqmONFwpaV89IUQFgeR+sc9TXx1Up1stu2VpbZO4pU6ggnzxismEuQt/L9vRHARtDgcSo48uPCusOM15zGMRlc88co9ZiidWWMXMx9Y+7PpSlelwUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpUG1qyyu6te0yiZm9NNd+uP3S+EYBzuxt6KHjQTlKwYl4tkyY7EiXGG/La/0jLT6VLR70g5FVU9q2jE3ty0rvIRObkmGtK47qUpdCinaVlO3qD444oLxSo03+ziRIYN1gB+OkrebMhG5pI6lQzkAeZrBna10xBiGTJv9rSyGu+BElCipGcbkgEkjPHHjQWClVLT3aPpHUIlG13yKsRUF17vdzOxA6qO8D1eRz05qbj36zyGnXY91gOttIS44tEhCghKhkKJB4BBBBoJKlYEW9WuXAenRblCfhMgl2Q2+lTaABklSgcDA55qMn630zCtUi4u3uC5EYbDri47ofIQVbN21GSRuOMgdaCxUqM/SC0BURDlzhtOS0JcYbdeShbiVDIwkkE591fF6hsqJT0ZV2t4kspUtxn0lG9CUglRKc5AABJ91BKUqvad1pp/UVjkXm1XJpdsjuFp2Q8lTKUKABOd4GBhQ56c1nx79aJLLzse6wHWmEBx1aJCFJbSRkKUQeARzk0ElSopjUljkB8sXm2u9wkLe2SkK7tJ6FWDwDnqa5ov9nctjlybutvVbmzhcoSEFpB4GCvOB1Hj4igkqVDfpXp7Dp+PrThptLzh9Mb9RCtu1R54SdycHodw8xWZbrvbbmVi23CJLKEpUoMPJc2hQyknB6EcjzoM2lRitQWZJlBV2t4MQZkZko/UjplfPq/XWHI1nppiJKkqvttW3FYMp0NSEuKS0APW2pJJHIxgc5GOooJ+lUVvtV0q+/bGokt6R8ZR3pMdSGFAKQ0VhWd2CDltYGRzis2w9oWnrxpL9JBLMK0h0sl2YA3hQOPM+JoLbSsCdebZAisyZ9xhxYz2O7dfeS2leRkYJODxWIrVNlTexaVT2xOMP0/bg7O43bd+/G3GR50E1So1q/2d2A5OausBcJs7VyEyEFtJ8irOBUTN1/paHcbVBcvMVyTdHA3ETHJeDiioJHKAQnkgZJA6+RoLRSqw7ra0ta6TpNz0gXRUcydxQO6CME8qz5A+FSkHUNlny0xYN3t0mSpJWllmShaykdSEg5x7aCTpSlApSlArVs/s9vau2NWsLfdIjEJ5pDD7CkEuKbCEpUAcYBJSOa2lWudadqcfTGqW7Iqy3CW4pKD3yFIQglXRKSojcr2DmggezLsel6O1c3dH7lCkxo6HUNFuOUvO788uKJ8AfDyFQy+xC8J1hcr8xdbbvkXX05pp5guJDZWtRBCgRvGU4Pvq3P8Aa5F/SeXaItluTzMeWqAuchILaXx1BTnO0Hxqs6Z7cXP0MgXC+W5Uy6Tpj8dliEA2kpbShRJKleSx76IyNIdib1k1cZ0y4QpdtHpHBjn0h0OpKSlaiccAnke3zqGtnweXkWe9xLjeWXH320NQHkIUQylLhWQoHHU46e2p669vtsgLYCrDclByGJhClJQpAKikgg+0dfHipK6dtFuiuwkQbJdLgXoLVwd7kJyy04QE5BPJ5HA86CmRexS8WWy6lnSJrFxub9oNvixobZSFYQhIJKsc4QPrya56d7ELkrT7zkuTb48uXa2IoiqjFKQrehxffFKsqUCkp3D2Hwq7M9sdskavTZIlpuTzfpSYS5QSkBDqvNGd2Aep9hrlr/tft2j7xOtyrVOnuwWG3pC2ilKG96gEgk/7Q5x4ge4OGjOzadYezbUWnZEyAuXdGnm0OMMlttve1sTnxVjzPPvqtaD7Dn7DqG0zLu/ap8GPEdjyoxZKg+pS3FAkKGDjcjr9H3VJXLt3t0FyWhdllrMe3RricOp9ZLwZIT06jvx/6TUhojtHm6k7UZtjLDLVrTaGLiyNv60KcQyvClZwf9Ljp4UEVrfsYkX7W7l5hXCCzDkdwFsvRipbCW0hOGsHABAHHFduluyObau0V/UEqVaVwlrfWWmoxLjneBQ5KidvC+dvB8ua72+3SzuuSSi03H0YMyXYshW0JldwkqWBzlPA4zWVE7YY7ukGL+/p+5NMzJKIkFoKQpUpxRUMJOcADYeTQQ9t7NLxpXsg1fpxl9q5uTSt2IhhJSskpSnBzxn1R/OoOw9hdwf01K9NuEeBLm2piKhlmPt2LCkOq77B9ZW5O0keHPsqxQu3q1ym07LHcjJXMVEbjpUgrVtTlSuoAwCOPbXBjt7t71ts8xFinK+MprsJDaXUbkqQGuecA574fZQRNs7D7rFh6ladnWZZurbKUNoYWhpBQ4FkbQQQOMDBzVjs3ZTMjdkt60lLuEISrg73qXo8fahGCgpBHBV8wZJ558cVEWntuXf9Y6ai2qH3NrnNvGU28jc8laAs4SQrHRI8PGpGN27WxcK5ypViucZmE2F4WpsrWStKEpKc5SSVZ54wDQVlnsIvaY17bdvFuWqfa48BtSULAQWlxzkjnjDBHvI4FWzss7LJ2jNUzLk/NiORpFsahd1HSpJ7xKWwpfIxyUKPn61WPSnaAnUenLzcmLNOYkWwK3xXSnLpCSrCFDIOcEe+qbE+EFZZMZ6Qi0Ty0ywhxZQpJIdWvalryyeuc9AaCJhdgEppU1Dt8jBr0V+Ow41GKXHS4SQp859bGf5DyrJ0h2I3K1Tbuq53WC8xPsq7UO6aVuQopQkLweDjZnr5dKzNWdtT8TQ715stnLc6LchbpcafyGVbVK/YVz0x9tWGz9qbdy1hMsDNllrMEBcqWhaS22jZuK8dcZwPHrQUyw9id8gT7C7Ju1ucatcSTFSEIWCoO98QengXj9lXLRGhb3pPs0NgiS7U9chIU6l2SwpxjaVA4KeDnArnoHtYg6yvqbfEtFxjNutrdYkuhJQtKSQc7Sdp4PXyqPZ7aYanNROO2K4JgWNa25MpK0KTuCihAA4OVKGB/OgyO1bs4n6zeskuJNt6JMBpxpxmXHLjC96QCoJ8CCMjPs8qyrn2YRJ3Zv8Ao73kVq6CGiJ8ZojJC9qXA5sHiEFQ+bnoaif+2yKNNzbu5p65NtQ32W3kqUjGx0HasKHB6AEe0VxX24234panM2ac8JU12HCQlaR6R3YBUsE4AT6yfrPsoqHj9ilxb0ZcrUubZlSZktl/YIy0shLaVpA4IVuO/OfZjxrkz2K3OPD0k6zdLYm5WWcqW4pMXu23AVNqA9XqR3fiBnJrNunb3bYC4QNhuSvSYRm7VKShSAFLSQQf/LJz5EV23jt3tduVE2WiY8iTbU3FKu8SkhJyNpHnxRGfqvsxmX7tEm34XFliHJtTluKAkl1BW2pG4eHG7PWojsw7ILnpDW0W9y59tdZahmMWorKmyTgAKPgScZJ8Sa2rpS9N6i05bruy0plE1hL6WlEFSAoZwalaKUpSgUpSgVU772d6Uv19TebvZ2pNxTt/WqcWAdvTKQracY8RVspQVN7s50m9qJd9csrCrqtRcU9uXyr6W3O3d7cZzzWMeyzRZsTdnVY2lW9t5T6Gy84VJWoAKIXu3DISOM44q60oKPL7KNFSyjvrE3hEcRUhD7qAGgc7cJUB15z19tdtw7L9G3D4v9NsTD3oDKY8fc456rafmpV63rAf3s1c6UFUX2eaTXqJu+qskb40bUHEvDcAFDoraDtJHnio7tL7MLJrqK8uQ2iLd1oS2i4JQVLQkLCsbcgK4BHPTJq+UoKCeybSUu3wmbxa258piCzBXJK1tKdS0lIBISoYPqD244zipuy6J09ZL2q72y3hi4qiohF7vnFZZQlCUpwVEcBtAzjPHXrVjpQU8dmejky58lNhjJfnNrafUkqGUrBCwnB9XIJ5Tg81iaq7NLVeNANaTty1Wu3sOBxkpT3xQdxUfnknkqPjn6uKvdKDWOlOxbTFnsBtt1Z+OVKk+ll19Pd4XjACQk8Jx4ZOfGpdjsp0XHYgMs2UJbgSFSow9JePduq2ZV8/n/Ro4ORx76u9KCkWvsq0Za5cWTBsqWnowWGlGQ6rbvBCuCsg5BPWvtv7KtE29ma1FsEcNzW+6fC1rc3JyFYG5R28gHjHQVdqUEJpXSlk0pBdh6ft7cOO6ve4EqUorV0yVKJJ+2oqB2Z6Pg265QI1jYTEuJSqS2pa1hZSSU43KO3BJxjFXClBVB2d6TGml6fFlji0rcDqmQpQJWOit+d2fbnOOK7tOaG07pybIl2a2pjyJDKY7qu9cXubSAAnClEdAKstKCr6d0BpfTl3eudls8eJOdBSpxBUcA9QkEkJ+oCucHQum4LF5Zj2tvubwvvJyFrW4l5WSckKJxyo9MVZaUFRgdm2koFjuNoiWVlu33DHpTfeLJcwcjKircMHkYPFfZHZxpKTpyJYn7Myu1xFKWw0Vry2VEkkL3buc+dW2lBSJPZToqSWO9sbf6iMYjYQ86gJaO4lOAoZ5Wrnrz1r7P7K9Fz2IjUuxtOIiRxFZ/XOgpaByE5CsnqeTk81dqUFf0/o2waemmXZ7eI0gx0RN/erV+qRgJT6xPTA568VYKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKV8cWltCluKCUJGSpRwAPM0H2laV1p8IXTllkuRbLHevL6DhTjag2yD7FEEq+oY9tUxXwnZuTt0xHx4ZmK/JQenaV5i+U7O/sxG/Fq/LT5Ts7+zEb8Wr8tB6dpXmL5Ts7+zEb8Wr8tPlOzv7MRvxavy0Hp2leYvlOzv7MRvxavy0+U7O/sxG/Fq/LQenaV5i+U7O/sxG/Fq/LT5Ts7+zEb8Wr8tB6dpXmL5Ts7+zEb8Wr8tPlOzv7MRvxavy0Hp2leYvlOzv7MRvxavy0+U7O/sxG/Fq/LQenaV5i+U7O/sxG/Fq/LT5Ts7+zEb8Wr8tB6dpXmL5Ts7+zEb8Wr8tPlOzv7MRvxavy0Hp2leYvlOzv7MRvxavy0+U7O/sxG/Fq/LQenaV5la+E7K3jvtMM7PHbMOf+StndnvbNpnWUhuElbltui+ExpWMOHyQscH3cH2UGzKUpQKUpQKUpQKUpQK86/Cp13IhpY0lbHi337YenKQeSgn1W/rwSfZjzr0VXh/4Q63Fdr9+73PCmgn3d0jFBrmlfM1aey6TFidoFkfuDjLUVt/c4t5QSgDaepPA+uiKvSt1PjSOo9SOSbm/EdQm2xjFS5JbbU+ok96XlBTSQ4nJGMjIAOD0qFs1r0OZDkeUpl5uReJENuQ7O2GPGDaSh3AIB9YnCjwefqDV9Kvd3tunWtLwnoQhqKmWFOSxcMye9JHeoMfnhPODhPAB3HOKsMqyaFbns71QkR0rk90GLp3npTCY61NuOHP6pwuBA28ZKiNvHIajpW37avSzdtvbFvhWhTlwtEaShiTcShLbveDvGUrUsYI278E7vDkcVFWi36Lem6chzAygO24ypcj0w4XIwvayr1glsZCc8pPPUZzQa1pWybtA0bb3tSusNsy/R40Yw4/p3q98s4cCShR3hPXAUrHmaxtB2PTt0ttvfu0mCytubITNTImhlRZ7lBZ2pKgT+s38p+vig1/StgNwNKL0elJDCbuq0qmGT6YdwkJkFIa7vOMlHOMZ6Ee37o6yacn6QluXWRCbujgkiOtycG1trQ0FNAoKgAFKyMkKB6ZTjkNfUraL9v0avUl3i26NBdRDYbEREi6FtmWslJcUXdwAKQThIIzjxPFd+nRpRdqTZ7qISoz9/dbSv0/BjMllIDoXhJUkEcFQCTzxQaoKSnGQRkZGa+VuGzTLKpuRDd+Lri8/pqMhsz7iW0JdS4gqYCytIRwCcZBG3A6kHCdsmg/0Wtj6poQ856KX325CS6FKWA+ktbycJBVg92Pmj1lZ5DVdK2xZzp2ydo9idVDszUJTriFFu6GS0lPRt1ZzhJ5PBVjzSnHK22TRj1oubt0MKNcEuvhTUe4pUmOlLYLZaJd/WblZ6Bzy9XrQanpX1sp7xPebtmRu29ceyr6r9GP0Dm958Yb+8Pxd33dd533G75vPd4xnPjjHOaCg19bWptaVtqKVpIKVJOCCPEVxzTNB7Z+D/rh7Wmix8YL33S3rEeQs9XBjKF/WOD7Qa2dXlz4Hq3RftRJH+gMZoq/2txx/Iqr1FmivtK+Zpmg+0r5mmaD7Svma+5oOBNeZ/hWaKeMyPq2A0pbJQmPN2j5hHzFn2EHbn2Dzr0kVV0S2W5UdxiSyl5h1JQttadyVA9QQeooPznpXqDWnwd7fPluSdMTlW3fkmK8guNg/wB1XUD2c1Sl/Bx1YFHbcbKU+BLjo/8A86I0pSt0/Jx1b/ELJ967/Tp8nHVv8Qsn3rv9Og0tSt0/Jx1b/ELJ967/AE6fJx1b/ELJ967/AE6DS1K3T8nHVv8AELJ967/Tp8nHVv8AELJ967/ToNLUrdPycdW/xCyfeu/06fJx1b/ELJ967/ToNLUrdPycdW/xCyfeu/06fJx1b/ELJ967/ToNLUrdPycdW/xCyfeu/wBOnycdW/xCyfeu/wBOg0tSt0/Jx1b/ABCyfeu/06fJx1b/ABCyfeu/06DS1K3T8nHVv8Qsn3rv9OnycdW/xCyfeu/06DS1K3T8nHVv8Qsn3rv9OnycdW/xCyfeu/06DS1BycDrW7mPg4aoU4A/c7OhHiUKdUfsKB/jWz+zrsPsmlpbVwua13e4tK3Nqcb2tNnwIRzk+0n6qDN+Djo17SejFyri0WrjdFB5xtQwptsD1En28k/8WK2zvrG3K+ifspuV9E/ZRWTvr4V1j7lfRP2V8KlfRP2UGRv9tN9Y25XkfsrhLmMQID82aVpjMJ3OFKSopHicDnA60GcF1y3VgW+fFuUJEy3r7yMtSkpcwQF4JGU+YyOD0PUVk7qDuaRtSCetc6UoFKUoFKViXCc3BbSpwElRwAK42bMdWM55zUQuOM5TUMulYkOe1KYU6n1QkbiD1A/9g1EWTWVlvKnExZDjZQyJGZLK2QponG8FQAKc8ZFXDPHOIyxm4JiYmpWKlYyZ8NTjTaZTBW6nc2kODKx5geIrrN1tyW95nxAjcUbi8nG4dRnPX2V0jNpXUuUwgkLfaSQAo5WBgE4B+uupVygpS8pUyMEsnDpLqcIPkrnj66DKpXS7LjssJedfaQyrG1algJOemD7a4omxVhJRJZVuIAwsHJIyB9nNBkUrE+M4Hdpc9Ni92pfdpV3qcFX0Qc9fZWKxqG2SJq4seUl15txbTm0EhtSACoKPQcGglaVh/GkDukOenRe7c4QrvU4Vzjg555NdzUuO6+4w0+0t5v57aVgqT7x4UHdSsKHdIsxUxLLmVRHC26PIgZ+sc1FW3WVluMmKxFkOFySNzW5pSQR3fedSPo80FipUZp6+2/UNv9NtL4fjb1N7tpHrJODwf/eMVJ0ClQF31daLTPXEmPPBxpKVPKbYWtDAVwkuKSCEA+2pb0+HvdR6UxuaTucHeDKB5nyFBk0qLN/tYuDML01nv3mu+a9YbVp3beFdCc+Fc7hfLZb2H3Zk6O2hhSUuZWCUFRASCByMkigka4mutcqOgkLfaTgBRysDAPAP111pnRFrWhEphS0LCFJDgJSo9Afb7KDuVWFdIKLnbpMB555lqQnYtbKglW3xAJBxkcefPGK7ROiLdbaRKYU64CUIDgJUB1wPGu4igjLXbY9jtbVthOOqjNE90lxQV3SM5CAcfNHQZyceNZm4Vwk8OJ91fM0EjSlKBSlKBUTfLWqe2VNrw4keqD0NS1U+drqPHv8APtbVvlPriBQW4nASVhoO7cnp6pHJ4zxWPEaMOI1zq2R8Jd688teUZY98JPT1rfhxpKZOEqe4AznA5/zqvs9m0CLptiDEW0Lg13JVLdaLiXe7VuCVIKvmE/sg4rrT2nQ3bcxPjWyW7FeYelBQUgEMtKSlSyCfbwOvFdMftCdROlIkxw8hCnEstso2qWfSEMtjcVYGd4zx/lXPCcNhwmnHTr7oXbsy25znl3y+RezIx7hbpSLolBjpKXe7j7SvKnFEJ9bCU/rCAMEgDg1iJ7KnW7WzCbusQtoebW4HoJcS8ltOEBQ7we84IzwMYqca7Q4amHFuQZLam0FSkFSSQRILBHBx84Z91ZulNaRdSOzExYklptlJcQ64PVdSFFOR5HKentFehm5X/STd5utqmuyS16KAmQ0hHqyUhQWlJ54CVpCh18R41Wl9l2+K+0u4RydiWmVJilJIS4V7nClYK1843ZHj51IQu0diXHaLdpmCTIDBjMFaMvB4LKec4Tw2rOfL21jRO0syprqWLO+5HPoyGNriQtTju71Tk4ABSRn2H2UErP0c8/puyW9M5p2RayFJckRgtt4hCkYU2CPBXHPBA61XrH2bzBa7aiZcBGCAy68wlrcoOIZW1wsKwBhWeh5FWnS2s42obhLjMQ5LKWNxS64BtcCVlCufDkfZUS12lxn3e5j2yU7IVISw2hLiML3IWpKgrOMYbNBGq7KT8UsxW7o0h9t7vA+I6uBsSgYHeYzhIznIPlWZO7NfS3bgTc0tNynX3RsjYUC6hKTuO7ChlOcYGQSK72+0yE7tcRbpZjYZ3u5R6inUFSBjOT0IyOK7Gu0RlSIi3LTMbbebYfcUVoPctvK2tKIzzk+A5FBhK7MkvtPmTNjd681JSUtRAlptTqUJCkI3ert2Z68knkVKab0Uuyaol3ZE9K2321JLKWSMqJSdxJUfo+AGc81hTNfSHI8F+2WpakSZrbDYdcRl9tRWCUgKyk5R+1WRau0WDc7rBhx4UvEhDaluEDDKlhRCVY/2eT05FB3aT0Y9Y7pcpj1xRJVMa7rCWO7x66lAn1iM+tjgDpXRN0I69ZLJBjXX0d22xnY3fhjJWFtd2VAbuCASR1qU1jq1jTAhKkRX32pKiC43gIaAxyongdai5faNCjzbhGEKQ6qLjaptaFB3LqWjg5wCFKHFBmaY0W3p8XFiLcZa4ExDf6tSsONrSnaVJWMdUhIxj9nrUk1pxhp1Dgn3ZRSQrCpzhBx5jPIqAZ7RYqrjAhvW2WwqS6phbiynY04lwtlO7OCcp+wipG7axZtuoDbHIUhaUqYQ5ISU7UF4lKOM5PI5wKDGv+jpVwnXVUO6IiwruhDc5pUfvFEJG3KFbhtJTxyD51gyOzsrE5tqfHSw8suN7oYU4FFxK9ri92Vo9TG3jg+ysSydpMiU0jv7Wp1bqYyY/dKSjvXHUKWchSsJACT4npUlb9cOu6jXBkwFpiOPsx2XkKSShbjPebV4Uc9DyOOlBGO9lxdCN1zYTvStLoTDGE73u9Pc+t+rxjA61ykdmHfJmJNxY9cqLKjFyrl9L2XTu/WEFO0HjgmszUXaALZevRkQ1+gxpK2ZclWD82Op4hCc5zgJ5Ix1qSga0bl6anXc26W2mER3rKgN2zAUVA9CAk5+o0HbqDSTV5vFrnOSS0IoCX2kI9WSkKC0JPPAStII6+I8ar0bs1djLbdaujKX46m/R1JiY3BDpcy9hX6xRzjPH86zz2jwVTojDMGW8iQokOoAIDfeltLntBUCfcM1iOdpKnRDEOzv75LjHd964kBTTjpbKuDwQUng+YNBwtfZu5b7taJyLqhS4JPeERyFOjetWPnkAfrCOhPHB5rYtVnSWsIupZMpuNFkMoa5Q44PVdTuUnI8jlJ491WjFBgTP9Mn3VxFdk0frk+6uGKCQpXBlYWgHx8a50ClKUCouXp+0TJbsqVbYj0h1BaccW0CpaSMYJ8eOPdUpSgrcrRNhk3Rma9bo6u6SsBnuk92VKUlRWRj53qDmpB7TtnfDwdtkRYeCkuZaHrBSgo596gD7xUpSgrlv0VYYkRmOq3R5CGHHHGS80lRb3uFwpTxwAo8e4VKQLNbbe9JdgwY8dyQcvKbbCSvqece0n7TWfSgiHtNWR6KYztqhqYKEN7C0MbUZ2D3DJx5Zrk3p2ztSGn27ZES60lCG1JaAKQj5oHuycVK0oMGFZ7dBlSJMODHYkSDl5xtsAr5zyfeSahZug9OyvRki2RmWmXw+ptttIS6QlSQFccgbzirRSgrsfRtkZu79xMBhx5xCG0BbaSllKUbAEDHAxWa7p2zuvwnnLZEU7CSlEZRaGWkp6BPkBjjyqVpQRTGnLNHkLfYtcNt5bofUtLSQS4M4V7+T9prgvTFkUpCxa4aHENFlC0tJBQkgjA4/vH7TUxSgipenrTMiRI02BHksxUhLKXkBewAAePuFcU6ZsiX3nk2qEHXjucX3Qyo7grn/iAPvGal6UESvTdlXLakrtcMyG1lxDhaGQoq3E589xJ9/NdS9MWt3Ubl7kR0PzlIbQhTiQrutmcFPHB9Y1N0oIVzSlhcaU0u0QS2pCGykspxtR80fVk4rKZslrZKCzb4qChaHE7WgNqkp2pI9oTwPZUhSgjH7BaJFxM9+2xHJhGC8tpJUfV29fcce6u2BZ7db4TkODCjsRXM72m0AJVkYOR48cVnUoItWnrOswiq2QyYQCY36ofqgOgT5DgV8c07ZnGkNrtkQoQlKUjuh6oSreAPcrn31K0oItjT1njvLdYtkRt1bofUpLQBKwSQr35JP1mpSlOlBhzP9Kn3VxA9lfXld47kdBxXLFB1kFJykkH2VxU474LNZJTXAo9lBjF176Zr53r301VkFuvndig6O9e+mqnevfTVXf3Q8qd0PKg6O9e+mqnevfTVXf3Q8qd0PKg6O9e+mqnevfTVXf3Q8qd0PKg6O9e+mqnevfTVXf3Q8qd0PKg6O9e+mqnevfTVXf3Q8qj7rOZgIwRvdPzUD/E0TLKMYuWSXngMlwgVhu3hlo4XLGfZz/hVZmzJEsnvVnb9EcAVibBUt48uL/TC2C/xicelK+tJ/wAqy2J4kD9TJC/YDzVI2CvoTg5HB8xS3McXl+cL53r301U7176aqrdtvDrBCJOXWvP9of51aGS280lxohSFcgiq9evbjsj4OvvXvpqp3r301V390PKvhQlIycD30aOnvXvpqp3r301UW9GR899pPvUK6F3GAjrIQfdzXM54x3y7jXnl3Q7+9e+mqnevfTVWEu8wU9FLV7k1jrv0cfNYdPvwK4nfrj82kcLun+2Ur3r301V2MyHEL9clSfGuMVaJEdt5AISsZANcJkmNCZU9LfaYaT1W4sJSPrNaRN/GGMxMTUpB18JRlPJPSsXc4v5yiago+sNMyHwyxf7S47nGxMxsnPuzVhbKVgFJBB5BFVBCcV27a+pTXPAoPuK+ba50xQde2m2uzFRd4W4uRDgtLU36SpRcWk4UG0jJwfAklIz5E0GfgeYphPmKj12GzJQVu22CQkZK3GUn6ySK6kWjTzkUSUQLUqMU7+9DLZRt884xiglcJ8xTCfMVFfFGnvRfSvQLV6Nt3973Lezb1znGMe2uxuw2N1tLjdrty0KGUqTHQQR5jigkcJ8xTCfMVgfo9Zv4Tb/w6P8AKn6PWb+E2/8ADo/yoM/CfMUwnzFYH6PWb+E2/wDDo/yp+j1m/hNv/Do/yoOy5S0QoinSQVdEjzNUh9xT7qnHVblqOSauZ07ZT1tNv/DI/wAq+fo5ZP4RbvwyP8qlMN2mdk9/wUnA8xTA8xV2/Ryyfwi3fhkf5U/Ryyfwi3fhkf5Upj2P5qSEg9K+7atlw0vbHYq/Q4jEOSBlt1hsIIPhnGMjzBqnRny/b2pGNqltBePIkZxUphu0zqcm0SZClCBAkywg7VKa2hIPllRAz7qyo51FHBQxaJyGzyQHWOv3lW/S7SGtOWxKBgejoUfaSkEk+0kk10NXxbmrX7IbbMShqMJHpxR+pUScbAfpUyx6UU9/D6o05RnHxn5qwr9IV/OtVyP/AM9r+pXSqNelHKrJOJ9rrP8AUq2xL4uRqqdZjbZjaIrKHRNWjDLu79lJ8x/nU3isZ4bCe+30ceO2Y91fRrb0O8fwKZ96z+enod4/gUz71n89bJxTFTsmt1+I7vk1t6HeP4FM+9Z/PT0O8fwOYP8A5jP562TiuK+BTsms/Ed3yaz1VryLojRbkqeytNwQe7ZhucKWtWSOn7PUkjy868j6w1dedXXJcy9zFvEklDQOG2h5JT0H+PnWzfhWXR2TrmDbyf1ESIFpH95ajk/YlP2Vrjs90wjVV+diyJKo0OLGdmSXUJ3KDbacnaPEngV6MY6MREPHnlOeU5T+as5rZHZX2q3bRU5lh91yZY1KAdirVnux4qbz0Ps6H+dYegmLFqHVLWnZNuWiDcVFmLJUsGTGcI9VRUkJCxnqCOh4NUy4w12+5S4TpBcjurZUR0JSSD/hVcv0Os9wjXS3Rp0F1LsWQ2l1tY6KSRkGs7FaU+CxdXpvZ85EeUVJgy1tN58EkBePtUa3XQfaUpQKiZ/+sVp/8t//AOypaoK9xW5d9tLbqnUp2PnLTqmz0R4pINBLzYrM6G/FlIDkd9Cm3EH9pJGCPsqNiaatMTTH6PR4iUWjuVMdxuJGxWcjOc85PjXZ8Rxf30/8a9+anxHF/fT/AMa9+ag6/wBGrT+i/wCjvoififuPRvR9xxs8s5z9eaz7ZBj2y3RoMFsNRYzaWmkA52pSMAc+wVifEcX99P8Axr35qfEcX99P/GvfmoJSlRfxHF/fT/xr35qfEcX99P8Axr35qCUpUX8Rxf30/wDGvfmp8Rxf30/8a9+aglKVF/EcX99P/Gvfmp8Rxf30/wDGvfmoJSlRfxHF/fT/AMa9+anxHF/fT/xr35qCTV80+6tXQ1hdlilKEoAjJHHj6vWr6qxxdp/XT+n/APde/NVCt7izp+E2pRKG44CQfD1akvJxfdC3afvsFFhtyVGRkRmwcRnD+yP7tZ/x/A85P4V38tdunP8AV+2f7s1/yipCq9aK+P4HnJ/Cu/lp8fwPOT+Fd/LUrSgivj+B5yfwrv5afH8Dzk/hXfy1K0oIr4/gecn8K7+WuLl+gkdZP4V38tS9fFDIoPJPwoYKXtRW69RQ8WHmPRnCppSAlaSSOoHUE/8ApNao0nqKbpe8puFvDS1FCmnGnk7kOtqGFIUPIiva/aRp2FqWHAtdzb3xpElSTjgpPcukKB8CCM15b1z2Pak03KcVCiuXW35JQ9GQVLA/vIHIPuyKCG0nqOzacvLl/YgvLuLO5UGGVZYZWRgLUsncrbnhOPLJqoyH3JUl6Q+orddWVrUfFROSakY+nb1IfDLFouDjxONiYyyf8K3F2W9h06XNYuOr2/R4iFBaYWcrdI+nj5qfZ1PsoNn/AAa7C9Zuzxl2SgoduDqpQSRyEEAJ+0Jz9dbfrFhR0sNJQhIShIASkDAA8qy8UClKUComf/rFaf8Ay3//ALKUoJMk98keG0/9K50pQKUpQKUpQKUpQKUpQKUpQfFfNPurVdu/8Ejf7un/AJaUqS8fGd0Ni6c/1ftn+7Nf8oqQpSq9hSlKBSlKBSlKCFvv/iFj/wB8V/8AQdrvkAc8ClKDGAGegrNjgeVKUGanpXKlKD//2Q==",
+              "timestamp": 21994643403
+            },
+            {
+              "timing": 6707,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAFQQAAEDAwMBBAQLAgkKBAUFAAECAwQABREGEiExBxNBURQiYXEIFRYYIzJSVYGRk6HSQlNWYnKUsdHTFzM2VHSCkqKywSQ0c+ElNUOz8Cc3RMLD/8QAGQEBAQEBAQEAAAAAAAAAAAAAAAEDAgQF/8QALxEBAAIBAQUGBQQDAAAAAAAAAAERAgMEEhMxURQhU5Kh4UFhkdHSFTNScYGxwf/aAAwDAQACEQMRAD8A9U0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUr4pQSkqUQEgZJPQVXmtcaVeuHoLWorSuXnaGkykEk+XXr7KCxUoSAMk8edV0640smf6EdRWkS87e69LRuz5devsoLFSgIIBByD41FXnUNrsq0Jusr0RC8YedbUGh73MbR+JoJWlULtrlf/pJf5MN/gx0qQ60vqCpPIIqWOr9PWaJAjXe+W6HKUy39G/ISlXKRyQTxQWeldcaQzKYQ/GdbeZcG5DjagpKh5gjrULd9Y6bs8sRbrfbZEk5x3T0lCVD3gnj8aCepXVEksTI6JER5t9hwZQ42oKSoeYI6120ClKUClKUClKUClKUClKUClKUCuKlpT1Irg+spGB1NQdxv1otj4YuNzhRXincEPPpQojzwT7KCwJUlXQg19qEtd3t90C1WudGlhsgLLDoXtJ6ZwamGl70Z8aDnSlKBSlKDW/bg+8uz2O0JeXHiXi6sQZbiDtPcqJKk58M4xVjl6F0xIsKrQuywEwdhQEpZSCnjG4KxkK9vWszV2nYOqrE/a7mlXcuYUlaDhbSxylaT4EGqe7ovWcmEbZK14tVtUnu1rRb0JkqR0I7zd1x44zQUQ325P9h8OCqa6UOXgWRU9KsKXG70p359qRtzW3EaB0qmx/FIsVv9C2bMFlO7pjO7ru9uc1ze0TZHdEjSpjEWlLQaSkH1kkHIWD9rdznzqtJ0TrRET4uTr934tCe7Cjb0GTs6Y73PXHjjNBDdoMqToTsUMfTt4ellt1MNE5SwpbLalkEbh4pHqg9RWxdP6ctlv04i3NtCRHeZCX1vHvFSMjlSyfrE5rrt2jbJC0enTIiJetPdltbb3rFzJyVKP2iec+dYqtPXS2WUWfTE9MaNs7tEiatUhyOnphCeM48Nyjig0rHfdj9kXahYEuret1mnLjw1qOdrfeD1M+zH7a3PonSlmh6TiNmLGnKlx0OSZLyA4qUpSQSpRPUHPA8BUeOzOBH7NZ2koElxv00FT8xxO9bjhUCVqHGc4xRvR2o7TE9A0vqluFbQna2zKgiQqOPENq3DjyCs4oKpp+W9pD/KjarISqBZ2vTILX1gwtbSlqQPYCM4q09lmkrGzoa2yVw4s6VcY6ZMuU+2lxb63BuVkkcjJ6VNaL0dD0zZ5UQuuT5M5xT06VIAK5K1dSr2Y4AquwtBah0+hyFpDVvoNnKlKaiS4SZJj5OSEKJBx5A5oOjs+ZbsHafqzTdrGyzIZYnNsA5THcXkKSnyB64raFVnRGkWNLszHFy37hdJznfTJz/13leAwOAkDgAdKs1ApSlApSlApSlApSlApSlApSlBjyR6wPsqo6lFzNwT6CL4Wu7GfQRD2Zyf471s/sq6OIC04NYymlg9M+6gr+lhODcj08XQHI2+n+jZ/wB3uePzqyxh6h99daGVE88CslICQAOlB9pSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSuDzqGGXHXlhDTaSpSlHASBySaDnSqvB7QdIz5jESFqK2PyX1htppD4KlqJwAB51aKBSqxe9f6UsdxMC7X6DGmDG5pbnKf6WOn41YokliZGakxHW3o7qQttxtQUlST0II6ig7aUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQK8j/AAhdXajtPalcYlrv11hRUNMlLMeW42gEtpJwAcda9cV4s+Ez/wDu9dP/AEWP/tJoPS3ZZPmTux61TZsp+RMXDcWp91wqWogq5KjznitM/Bi1Tf712gzI14vdznx021xwNSZS3EhQcbAOFEjOCefbVw+D/wBoVkumn7PopLE34xaiuBxSkJDRAJJwoKz0PlVlmdnWnND6c1JdtJ25yLdPiqS2hwSHXD9TdgBSiOqU/lRHdc+2rRFvvotTtzU48HO6ceaaKmW1Zx6y+mB5jNR957etHWm6y7e+Lk47GdU0pbLKVIUQcZSd3I9teVNBs6ZkX0o1rLnRbZ3SiHIidyu8yMA8HjGegPOKh7umGm6S02tbzkAOqEdbwAWpvPqlQHjjFB69m/CC0bDmPRnm7t3jSyhW2OkjI/3ql7d2w6auOtGtNw/SnJThKQ+EJ7oEI3EE7s8YIPHUV4z1P/pFcv8AaF/216T1F2Tac072cz9RWZqai6tWxTqVmQSAVt4Wce5SqCyXz4QGi7ZOcisrnTy2rap2MyC2T7CojPvHFZ1r7VtLa1st2h2qU61P9CeUI0lvYtQCDkp6g/gc15T7OW9HuXWQNdvT2oPcnuTEGfpM/wALAJ6dPb1qb0mnR7eo0Lts3UfpW9YipMdoJIIIAWQrOMdSB0zQV3s0lMwu0LTkqW4lqOzPZcccUcBKQsEk/hXp3Snb/p2+6kTan4kmAh53uo8l1QUhZJwnd4pzx59ea8w9mkVid2habizGUPxnrgwhxpxOUrSVjII8RTtHjswO0PUceG2hhhi4voaQ2NqUAOHAAHQCg2z2rw+y5HaDdk3d7Uka5d9vlIhobU0pagFEpKuRnNRHa7rRVqf09adB3W82y2RLWyru0SFtbg4kOoJ2q5VtWM+3NUvtfdW/2h3N11RU44iOpRPiSw2TVg7borDNs7P32mG23X9PRVOuJQAXCEJAKj4kAAc+GKDbfwd+0aPI0jdGNT3eU5LgLVKelznStKWlbUpAWok5yDx7fbU8/wDCC0K1LLKZE91AOO+RFOw+3kg/srzRIuFtR2Rw4MZUZN2curjkkJSA6pkNjZuOMlO4qwM9ax7JbNPSdKTJVxntx7mhZCEmQrcRxja0Gju9/eJ/Cg9tWPWWn75YXrzbbpHdtzAKnnSdvdYGTvBwU8eda8n/AAiNFxpSmmE3OUhJx3rTACT7RuUD+ytAQmoEDs91MLFqGTNXIbjiXEMJTKUpDycKKyog8nGPb7KwNAN6FcgXU63fujUoJHoYhjIPBz4HnOOuBQeq4fa5pa86Uu90tsx4qgRy69HLe19APAIBODyRyDXlnS/aTqSFqa0yrrqS+v25iW05JaMxxe9oLBUnaVYOQCMHrVt7E4mkpGqzHiu3mVKehyELjyorXo7iO7JIX6xOMgEcdQK1jopcJrWViXdgz8XInsGT3yQpHdBxO/cD1GM5FB63vXbvpGzzUxZbd0LqmGXxsjpI2utpcT/C67VjPtqS1J2v6b09abHcZ6LgY94YMiN3bIUoJG36w3DB9YedeWO2+Xb53aXdJNkWyu2LbjiOpgYb2JYbSAkeAGMfhU12wTY0nQvZo1HfadcZtSg4lCgSg/RjB8uUn8qDernwgNHIgMzFN3XuXnVtJ/8ADpzlAQT/AAv56f20k9v+j2bQxPQm4uB59bIZDSQ4NqUkqI3YCfXAHPJz5V5Mlf6JWz/bZX/RHrdPYD2W6a1toyVcr61KXKbnLYSWnygbQhsjge1RoNy6k7X9IaeZjGfPWqS+0h4RWWy46hKkhQ3AcJOCOCa6dK9tGjNST2oMae5FlukJbbltFveT0AVynPszXj5yMwvWr0W8LU1HExbTyluFBQAojBVtURjGM7TjyqYnWbSTeoFso1IqHDTtKXGGVzQk+OF7Wyf+Gg94UrBsS+8sdvWX1ySqO2e+WgoU56o9YpPQnrjwrOopSlKBSlKBWmO0vsNRrfV0q+Kv6oRfQ2juRE7zG1IT9bePLyrc9KDTnZj2Io0Lqtq9JvypxQ0tvuTE7vO4Yznef7K3E4hLiFIWkKQoYIIyCPKvtKDR11+Djp2XfRMiXCXEgqc3uQkpChjPKUrzlI9+ajb18GqFNu0uTC1AYMV11S2oyYW4NJJ4SD3gzjzr0HWFfHpsezTnrTHRJuDbK1R2Vq2pccAO1JPtNBoa5/BranXGTK+VK0d84V7fQAcZPTPeVvpm3tC0It0hKX2AwI6wtPDidu05HkR4VoHResu16brSFFu1ldFvcfCZKXYPdIabz6xC/YM45OfbW/rzcGrTaJ1xkZLERhchzHXahJUf2Cg0hffg1WSXMW9aLzLt7SlE9ytoPpT7EnKTj35qf0T2F2LS65En0uROuTjDjLb7yQEs70lJUlA8cE9Sa0rc/hB61lXFx2C7DiRiolthMdK8J8ASeSfbxXqrQ1zkXnR1luU3b6VLiNvO7BgblJBOB4URqHSnwd27Bqa13calW+YMluR3RghO/aoHGe8OM464r5qr4O7d/wBS3S7nUy2DOkuSO69BCtm9ROM94M4z1xW+61/2y3jV9m0+w9oe3emSVOFL60t96tpOOClHjk+POPLyKo2q/g8t6gvr9yOpVxy6ltPdiFuxsbSjr3g67c/jVy1T2S2fU2jrJZLk+6JNoitxo85pISvCUJScpORg7Qcftqs9m+u9axrFf7t2i2qQi2W9gPNu+jBl5as8pSkkAjHOePfU1oftt09rHU0Wx22DdWZUkLKFvtthA2oKjkhZPRJ8KIr2mfg52W2yJSrvdH7mw8ypoNdyGdhOCFA7icjHFRr/AMGO3KlFTGpJaI+eG1xUqVj+luA/ZXoatMQPhEaWm3OPBatt7Dr7yWUlTTW0FSsAn6TpzRVq0r2U6Y09pefY24qpbFwTtluyDlb2OnIxjHUY6HnrWurj8GW1Oyiu36hmRmCc927HS6R/vAp/sr0FSg172Zdk9j0Ct+TDW/MuDyO7XIkY4T1KUpHAB48zxVL1R8HGy3S6PS7RdZFrbdUVqj9yHkJJ67fWBA9nNb2pQaPv3weLNcrZbWY12lRZkNgMKkFpKw8ASQVIyMHnHB6AVi3X4N9pk2q2RbfeHIj8YLMiQqN3ipKlbecbxtAxwOev53/thu+rLPppt/RFuE2Yp3a8QjvFtIx9ZKP4XOPPHl5V3sP1F2gXuXPRre2rYgttgsvuxu4WXMj1QOMjGTnHGPbRFYd+Da25aY0H5ULAZede3+gDnelsYx3nh3f7a2h2TaFT2fabftKbgZ4dlKk96We6xlKE7cbj9jrnxq6UorUfaJ2F2LV92dukaU/ap753PKaQFtuK+0UnGD7iKi9J/B0sFpuLMu73GRdu6UFpZLYabUR9oZJI9ma3hSgAAAADAFKUoFKUoFKUoFeevhF9qt307eWtO6af9EdSyl6TJSkFfrdEJz045J68jpXoWvNXwmOze73G/I1NYoj05pxlLcpplO5bakjAUEjkgjHTpj20GublrntEh6Qhi4zb3Hjy5HpMW4qdcbU4naQUBX8JPRQHv86+wNc6rX2eXuUrUl4Mlu5Qm0OmY5uSlTckqSDngEpTkfzR5VCaiu+qrpoy3Rb2t34mtTqYkZDjQQQrYcDOAThKcc9MipLQ2nJ+pOzTWDVqYckyYkuDK7ltO5a0hMhJAHicLzj2URdOyDVuorjpXtDen325yXYlnW7HW7KWssr2r9ZJJ4PA5FVbs51xqqZqlLMvUl4fa9Dmr2OTHFDcmK6pJwT1BAI9oFY3Z23qmDatYxLXaFKjybY4ic5IbUnuW0pUTjzUeQB5+6o7sxgy0auQpcV9I9BnDJbI/wD4j1BP9lWt9Uz+0fTsWbqO7yIz0xtDjTsxxSVpJ6EE4Ir0721Q5s7ss1G1bZPoz6YqnVL3FOW0EKcTkfaQlScdDnB4ryR2PwZbfafplbkV9KRObJKmyAOa9mdoyVL7PtTpQCpRtckAAZJPdKoPDWgLdc7vrC2QLFN9Aub7hSxJ7xSO7O0nO5PI4B6VtHtX7TNWW+8R9KWu6PsrtjDMWTIjqJdlSAhO9W8jd9bIHQnqetVLsMhSm+1jTa3Iz6ECQcqU2QB6iqsnwgNB3216+nX63w5T9umuCQiRHQVFpzAyFY5ScjIPtoIjWWu+0aDAs9vvkm82mVHQspe7xxhcpB24K8Y3FOCM9eefbJK1nqb/ACGIuPyguvp/yjMf0j0tfed36MFbN2c7c8486qeuIutbjBs111YqdKEttYiB4ErS2nbk7QOAdw9pxnyqVVClfN+Q36M/3nynKtvdnOPRRzjyoM3Tl01Rqvsx1z6VqCfITBEV9YlSnF5a+mC0Dr19Xjodvsqqdk9sul31/aodhnegXBalqQ/3ikbUpQVKGU88pBH41sXsC09OvOje0a1NNKakzIbDbPepKQVfS4GT7cfnWurKzq3QmrGZUS2TIt4jFaEJciledySk4GMK4J5FB7m1NEmT9OXSHbJHos9+K61Hf3FPdOKSQlWRyMEg5HNfnxa2JD96iR4z3dSnJCG23dxG1ZUAFZHPB5r9DbK6+/ZoL0wFMlxhtToKdpCykE8eHOeK8Mar0dqPROqVh+3ycx5Hex5KWittwBWUqBAx5cUGyu1ntM1XpdyFo+Dciibb4bLc+eglbsh4oBJClDIHI56nNUtWue0zSkyM9cLpeGlujehqeS4lY/orz/2prXSus7/Dj61uFukyl3FOZHcxilTSkHYCpAGQkpSkg4xWLb7lru7zojFjgymJDQ2JTboCY4J45WUJAJ46q6UE/wBqfafqK5zLDcLZdLlaUyrWhb0aLJW2gOh11CiAD47fyxWLf9Xa/wD8nWmp792ls2xbrzbUpEtXpEhwLVkrVnOAPVAz/B91dXbdZtQRL1Ymb84/cLom0tmQ8lO71i66duQMHAIH4VJ6tiSVfB30M2mO8XEzpRUgIOR9I51FB8c7TdUT+yF7vLzNbuMG7sNCY06W3VtOMvHYpScE8t559nlVbja91crStxeOpr0XUTYyErM1zISUPkgHPQ7U/kKxIEGWOzK9IMV/cbtBIHdnJHcyv7xUfFgTPkhc0+iSMmdFIHdn+Lkeygt2kb/2l6ptV3t1im3i5qKmVPO+mKK2UjfgJKlcbj1x9mvUvZDFvMLs+tcfU3pPxsgLD3pDm9f11YycnPGPGtOfBAjPsS9U9+y41uRGxvSU55d869KUClKUUpSlApSlApSlApSqvftXIs9xXEdhOLIAUFhYAUD+FBT/AIRWjb3rTTlriaejIkPsSy64lTqW8J2EZyojxNR3wb9B6g0SjUI1HERGMwx+52vIc3bO83fVJx9YVsK4avjw7bAliOpz0tJUEBQBTjrn8a5RNXRHLUufKaXHbC+7QnO5Thxk4FWhZaVSkdoEMu4VDfDefrBQJ/L/AN64a5vMeXp6N6IrvESV5CwcbduMgj8aULxStRaPu4tNycdcbU6FtFOArGOh/wC1WmNr6K6+lDsRxpB6rKwcceWKULpSqtadYxpjMt6S0YzUcA5KtxVnOABjrxWGvtAiBwhEJ9SPtFQB/KlC60qNsd6iXlhTkRSgpHC0LGFJqSqBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBVE7T4OW4k5I+qS0v3Hkf9/zq91h3a3sXSC5Ek7u7XjlJwRg54pA0q4+480w0o5Q0ClA8snP9pqwavt7lug2dhQIQlk58u8Jyr+0flVtjaHtbEhp4OSlltQUErWkg4Pj6tT9yt8a5RixMaDjZ5GeoPmD4V1aNTSnLMbCyiOy8LoCN6yTj2+OKyYaHfkRPUoHufSW9vv8AH/tVwToW0pd3EyVD7BcGP7M/tqwC3xBAMIMIEUp293jjFLGptOT2IHxj6QVDv4i2UYGfWOMV06aYak32Ey+gLaW5hST0Iq/r0LaVLKgqSkH+CHBgfszXbbtG26BNZlMuyi40rckKUkj8eKWIbX1pi2+0srgRkspU8A4U554OM/tqpw1W8W54SR/4nPq4Qoq/A7gB+INbllR2ZcdbEltLjSxhSVDg1Wl6FtKnNwVJSPshwY/aM0iRGdnIhemyDEEvvQ1hZcKdnUY6c5/96vtYdqtkS1x+5hNBtJOSepUfaazKkqUpSoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKVrjtFusg3P0BpxSGG0AqSk43E88/hirEWNjBaVHAUCfYa+1qB2wXiEmO+lCgXOUFtzkePnX3Uz09SbeLkFokJZKSSrlQ3HB4/wDzilI26pSU/WIHvr7WpbZY7tebY0uOtsxm1qCQpeOeMn+yvt6ulxuVz+L2XFhCVhhDSFYCiOOfPmlDbNUe+xtVLurqoTi/Rir6Lu1pSAPDIPjVWLt301cEoW4tpzAXsK9yVj2+Hga6tSSjJvMh9ClBLoQsDPTKAasQNu24SEQGBOUlUkIHeKHQmshKkq+qoH3GtT6okT/R7c24p1ML0Rkt4J2qOwZJ9uajrbCkyAHIctlD2eEF7Yv8M4/tqUN1E4GTXxKkq+qoH3GtUauduqHIzM5TyWksoABJwpW0biT4nOaj7bClSAlyFLaS/nhvv9i/wzilFt0UrVOq7rPXKagLdcQGWkJWkK5UspBJPnyaw76zdoMaHGue5KEhRZ9cE4OMjIPsFKLbioSAMngVplS1/JpB3Kz6Wrx/mCudvRNdsN0cZkbI7RbLqecrySAM+XNKLbjByMivhUkHBUAfaa03Zr7MtbUlDDqsON7UgnISrI9Ye3GaW613K9iQ/HJdLfK1Lc5J/GlFty0rWmm5V4tDEp15t1cNLKlALUCEqA4PXPXjjzqBU/cLxJWp6VuWPW+ldCAPYMnH4ClFt00rWmjZV4jXRlpTcp2EtWxYUkqSn+cD4VsukwpSlKgUpSgUpSgUpSgUpSgVRtc6blzponQEB0lAS43nB48Rn2VeaUGnU2G+SVIaVDlEJ4T3nCUj2Z4rOvmmZ8VuCyxHdkKDRLimklQCio8flitqUq2lK7oKK/EsPdSmVsud6o7VpwccVWNS6XuLF1dmWxtbra194ktn10KJz09/lWyaUtWqY+nb5eJoXOQ8jOAp6QeQPYDya46isM/44kCJBkOMJ2pQpLZIICQP+1bYpS0pridA1FH7lyCh8sKjsgtghQBDaQQUHxyPKoYWC9T5RUqC4hazypSA2kf2D8q3BSllNc3S2ajhSP8AwinX2O7Qk7SFpJCAD6p9o8qhkaevU+UVKguIWo5KloDaR+HA/Ktv0pZTW2qNKXDvW5EZJlEtoS7t+tuCQCceIOKi5mnbz6LGedYkPLc3Du8FSm0jGM+Wcnj2Vt2lLKamVZrl8n0Negye9EpStvdnONgGazrPap7WmL4y5DfS673WxBQcqwrnArZdKWNR2nTFwlyHGX4r0cFslLjiCEhQ6A11LsF8iLW2mJJG7hRa5Ch7xW4aUsprrTOkJSy+5cklhCmlNoTkFWVDGceyotViv9olr9EafyQU95H5Ch+H/ets0pY15pLT11FyblzlPR2UK3lKlnc4faPLzzWCbPqL4/37X++7zPpG71MZ658vZW0aUtSlKVApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSqdqK5SrXcp0Np9fe3NlHxfuOQh7cG149g3Nrx/SNBcaVU414nthp4qjLgpm/F/cqCjIJDnd7yvdgnI3Y2/V5zXTbbvNf7uHbREi7GnZC1yt7gUA8tG0HcD/AAckknGRxVpLXKlQmnpomSLg5sRn6FRU26XEq3NJV6ueMc+AGetRKdSXBqypu8j4vVHfirkNRgVIdRhO4JJJIVj+EQBj20otcaVUpt8utuElh70GVKDLbzS2kKbQNzgRtUCpR8cg55weOK6pt7vsFN4W98XLbtaUvLKW1gvIKdxSBu9QgA8+tnjgUotcqVUHL1elOIcYRbxHcuC4KUrSvcACoBwnOD9X6uOfMV0OakvJmC2MR47k9DryXHkN5QUoDZGEKcSckOj+EcYPWlFrtSqgi+3iY0z6I1BYd9CVKc73LqdyVFO1JQrGDjOcnHkaaYuFyuOoZrrktj0FceM+iMWlbkBaFEYO/GfM7eceFKLW+lVWTe7mi4T1NpiCDDnMRFJUhRccDgayQrdgEFzyOcY4611RdRXBaIEtxMQxZ7rjLUdCFd60UpWQVHdhX1MEADGepxSi1vpVSXqSaqHa1RWI70mXbTMLQVtyvLIAGT0+kVwTzgDNSdiuMm5QJgWttE1lwtHdHW2EK2gjchRz4jorBHjSi01SqPY7nfPifTzZkwZL87hTy2lgtpS2VHPrncrIx1HWu9nU0xVxKCI7kV1EgsqQ0tPLfT1lH1xxzhIAPiaUWuNKpqb/AHpttlLseI/IlQ0S2UMpKdnroStJ3K9cgLBGCnOMVHz3pWoJthbccgrQia828y/CcxvS0pXrIUsYODx15IOfClFthUqrMXyep1mSr0QwXZy4SY6UK75JC1I3bt2DynJG0YGeeK6Yt6vcli1qCbe05cXnEIyhag0hKFnJ9Ybido44xnxpRa30qkt6nurECPcJrEVyOtyQwphhKu83spdO4KJxhRaPq443Dk4rlN1HdLdBeekegSXF256ex3CVJSgoCfVVlR3A7x6wx0PFKLXSlVKTerzFkSYZZiyJSAy4lTLZG1DneZ9Qrysp7vwIyD0457LlcnJug5sxLmHu6WkqbQpohSVFJ9VXrJIIPH9tKLWmlVVWoZQ1CzGT3DkJyUYmUtLBSoIUo/SEgE5TgpCTjzq1VFKUpQKUpQK6X4kd95h19hpx1hRW0taQS2SCCUnwOCRx513ViyblBiyWo8mZGZkO/wCbacdSlS/cCcmg+C2QROM0Q44ln/63djf0x9br04rhJs9slNNtSbfEeabJUhC2UqCSTkkAjjJ61ycutvaL3eToqO4GXdzqR3YzjKueOeOa4pubDwhrhraksSVlIebeQUjCScjn1umMDP7KDKaYZZUtTTSEKXjcUpA3YGBn8BisZm025iS7IZgRW33QQ44lpIUsHrk45zRu7W5xp5xufEU2zw4pLySEe854r47ebY1GakO3GGiO6cNuKeSErPsOcGg+x7TbozK2o8GK00shSkIaSAog5BIA8DXc7DjOpfS7HaWJCdrwUgHvBjGFeYx511SLrb477bMidFaecICG1upSpWemATzmvouUEzjCEyMZgGSx3qe8x/Rzmg7BDjAJAjtAJcLoGwcLOSVe/k8+2uiXaLbMQtEuBFfStfeqDjSVArxjccjrgAZ8q5xblBmSHWIk2M++1w4226lSke8A8UkXODGltRZE2M1Jd/zbS3UpWv3AnJojsRDjNhIbjtJCW+6GEAYR9n3eyuLdvhtPNPNxWEOtNhptaWwFIQOiQfAeyuPxnA9NEP02N6WSQGO9TvJAyfVznpSfcoNvLYnzI0YuHCO+dSjcfZk80V2GHGV3uY7R71aXV5QPXWMYUfMjann2DyrrZtsFmWuUzDjokrzudS2AtWeuT1rmqdESpaVSWApCkoUCsZClfVB9pyMDxzXWzdbe9L9FZnRXJPP0SXUlfHXjOeKDgiy2tvfst0NO9JSrDKRuBIJB46EgflWRDhxoTRbhx2mGydxS2gJBPnxWLGvdvkyZbLMphZiDLqg6ghPnnByMeOQP7a5NXSO88oNOsrjpbUtT6XkFKSDggjOePE9KI7WLdCYWFsRI7agsuAobAO4jBVx4keNdQs9sCysW+IFFRXkMpzuOcnp15P5mvrN4tr0RUpm4RHIyVBBdS8koCj4ZzjPIr4bza0wkzDcYYhqVtD5fTsJ8t2cZoO162wnkJS9EjuJS33QCmwQEZB2+7KRx7BRi3w46WgxEYbDKipsIbA2EggkeRIJ/OuEm7W6KlhUmfEZS/wAtFx5KQ5/RyefwrIlSWIjBelPNssjqtxQSkfiaK6U2yCiaZiYccSz1eDY3njH1uvSuxEOMgMhEdpIYJLWEAbMgg7fLgn866BdI5cSoOMmIWS96T3yNmM48849vSuCb7aVBBTdIJC192kiQj1l8eqOevI49tEZKYUVCW0pjspS2tTqAED1VqzlQ8idysn2nzrpas9tZafbat8RDb6drqUspAcHkoY5HJrkq629MtMRU6KJSjtSyXU7yfIJzmsVjUFvVATLlyGYTSnnGE+kOpRuUhakHBJ/m5oMyTboUorMmIw8VhIUVthWQnJT18txx7zXIQooh+iCMyIuNvchA2Y8sdK7gtJb3hQ2Yzuzxjzqq23WTM+Y0hkQ1xnJbkYONSwtSAhLp3rSE4SD3XHPIOfCqJ9dpty31PLgxVPKUFqWWk7iodDnHXgc1m1hSriy1GDjK2n1qb71tCXUp3oyBuBJxj1hz7R510XO+wLepTS5LK5QUgejpcT3nrKCQduc45zUVKUrEauUF2cuE1NjLmIGVMJdSVp96c5FZdApSlAqs3GzzjPua4jNvks3ANhZllX0W1O3ASEnenxxlPJPnVmpQVZenHkR1LYEYyhc1T9qiQh4EqASs4zkJI8DgpFcBp2Y5MblPeioUuauU6whSihIMZTIAOBuJOCTgdT+NspVtKUtjTM5Md5lxLRjhLQYYMtZLakKJyl3YFgDjAO7pX06evC2GW3ZDCxtfQtW4JWAsgpBWGwVDA5A254yTirnkUpZSlJ0tNXZrkw76KJcm2Mwm1hZIC20rGSducZUD086zmLNPZdXGDUBcRUtyV6S4pReTvUpWAnbgKG7aFbug6eFWelLKU/S2mZNrlwTJbYCIMdTCHUy3nFOZwM7FYSgEDJHrc48q43rS8qXdbg62hl6PPU2panZbzfdbUpSQEI4X9XI5HJNXKlLKVh7Tz6vSlNlgOu3VmcFZOdiC3kE464Qofj1rhqSwSp12XNittPh2KIqm3ZbrARhSjn1AdwO7kHH1RzVqrClW5uS8XFuvpJ4whwgVnqZZ4xeEXP8AdLERPNX06akovNtnNmNtgNNx0NlSj3iAkhS1E5O5OTtznqrJ9biPsllny7cwwpiLGjIuEiT6QlSg9/nXOiduATnBVu6eHNWr4mZ/j5P6pp8TM/x8n9U1hxtp8OPN7Ot3Dr6KtA0hNZhejOIjJLNvdhtPCY85vKkhOdivVQnjJHrc4x05kbzpdc2KqNGU0wyIKYyUpJSNyXErA46JO3Bxzg1MfEzP8fJ/VNPiZn+Pk/qmnG2nw483sbmHX0V5Gl5TyX1vsxmnHZERakelOyNyGXQs5UsdcZAASPafLJcsM5i+P3OKmK8TIcW3HdcKE7VtMpJyEnCgWj4HhR5qY+Jmf4+T+qafEzP8fJ/VNONtPhx5vY3cOvorMzS09xanUsQFqfiiO4yiS9Haa9dauAgeuD3nIOM7fDPE9d7QqTaYUVlCXFxVIUgl9bRSUpIyFjcc8+OcjOayPiZn+Pk/qmnxMz/Hyf1TTjbT4ceb2Xdw6+ivvaYuEm2rYlPR3XFw3YyiroSp0KGcJAPq8E4GTzjmsu6abXKXqNbKYyVXGCiM0TxtWkODKuOB6yemensqV+Jmf4+T+qafEzP8fJ/VNONtPhx5vY3cOvorMa0T5a7vHRHhoYfuQeXJWpQdTs2HITtwo+rwcjGfZz9XpWc25HkNhmQ636UgtGW6wkB14uAhSASeMAgj8eObL8TM/wAfJ/VNPiZn+Pk/qmnG2nw483sm5h19HGwRX7dEj25bLYjRozaUuocUdy+QpICskAYTgknr7KjDp2QpmC2pbIDM6VIcIJ+o6HgnHHUd6nPuNSvxMz/Hyf1TT4mZ/j5P6ppxdp8OPN7Lu4dfRXV6duz8WOw+YSBHtxhJKHFK3q3NHcfVGBhs8c9fGuybp24OImRWkQVsP3BucJDi1d4MOJWU7dvUBO0HPTHFT3xMz/Hyf1TT4mZ/j5P6ppxtp8OPN7Ju4dfRXrRpaVDuUUupZXHjSXZKZBlvFaivf/8AS4Sk+vgnJBweOeLpUc3aWm3ErD0glJzgukipGttPPUy/cxr/ADf/ACEmIjkUpStEKo+ptQXGHd57TEhmK3DbbW2h3ZiQVDPOTuxn1RsGcg9eBV4qMmF9UoKFqbkd2ctuqcSCPdkZFZ6mtjoxvZRM/wBRM/6iVjCcu6ENZXHU6zvDMm7LKld243CX3YygoHKRjdgHjI/GsGfqCe1Mvq0XKMg26U20zBLY3PhSEHaTnOVFRCcePXPSrN6VcN274qG7pnv0/wB1YMWK/HlyZIs4W8+935Ut9BKFbEp9U44GECsO36XTLyZ/i74OXWPrH3V/4wdjyDNjRme/jsXZSGm0YC1IfQBkDqTjnzOa+32fOdsd6jRr0JoFtXK9KjIQC0fscZGFDJHiNp5NWtL81KgU2hAIzyH0+JyfDxr407MZSoNWZtAUckJeQMn8qdv0umXkz/FODl1j6x91Xv2o5ECA47bbumeIsQyy4lDJS76ygApQIBHqkYQM8cnpXS9dJMKdqmXCuMdCmJTbrcQoCjJJYawnPX1uAnb4+fSrapctZSV2VpRSCEkvIOAeoHFfAZIUlQsjIUnlJ71GRxjjjyA/Knb9L+OXkz/E4OXWPrH3VhV0mREtRozwiIkzZy1vnZkFLvCBvO3JyT48JPvFp03dPjC2xDJfjqmONFwpaV9dIUQFgeR/Ec9TXx1Up1stu2VpbZO4pU6ggnzxismEuQt/L9vRHARtDgcSo48uPCusNs085jGIyueuOUesxROlljFzMfWPuz6UpXpcFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKVBtassrurXtMomZvTTXfrj90vhGAc7sbeih40E5SsGJeLZMmOxIlxhvy2v84y0+lS0e9IORVVPatoxN7ctK7yETm5JhrSuO6lKXQop2lZTt6g+OOKC8UqNN/s4kSGDdYAfjpK3mzIRuaSOpUM5AHmawZ2tdMQYhkyb/a0shrvgRJQoqRnG5IBJIzxx40FgpVS092j6R1CJRtd8irEVBde73czsQOqjvA9Xkc9Oam49+s8hp12PdYDrbSEuOLRIQoISoZCiQeAQQQaCSpWBFvVrlwHp0W5Qn4TIJdkNvpU2gAZJUoHAwOeajJ+t9MwrVIuLt7guRGGw64uO6HyEFWzdtRkkbjjIHWgsVKjPlBaAqIhy5w2nJaEuMNuvJQtxKhkYSSCc+6vi9Q2VEp6Mq7W8SWUqW4z6SjehKQSolOcgAAk+6glKVXtO600/qKxyLzark0u2R3C07IeSplKFAAnO8DAwoc9Oaz49+tEll52PdYDrTCA46tEhCktpIyFKIPAI5yaCSpUUxqSxyA+WLzbXe4SFvbJSFd2k9CrB4Bz1Nc0X+zuWxy5N3W3qtzZwuUJCC0g8DBXnA6jx8RQSVKhvlXp7Dp+PrThptLzh9Mb9RCtu1R54SdycHodw8xWZbrvbbmVi23CJLKEpUoMPJc2hQyknB6EcjzoM2lRitQWZJlBV2t4MQZkZko+hHTK+fV/GsORrPTTESVJVfbatuKwZToakJcUloAettSSSORjA5yMdRQT9KorfarpV9+2NRJb0j4yjvSY6kMKAUhorCs7sEHLawMjnFZth7QtPXjSXykEswrSHSyXZgDeFA48z4mgttKwJ15tkCKzJn3GHFjPY7t195LaV5GRgk4PFYitU2VN7FpVPbE4w/T9uDs7jdt378bcZHnQTVKjWr/Z3YDk5q6wFwmztXITIQW0nyKs4FRM3X+lodxtUFy8xXJN0cDcRMcl4OKKgkcoBCeSBkkDr5GgtFKrDutrS1rpOk3PSBdFRzJ3FA7oIwTyrPkD4VKQdQ2WfLTFg3e3SZKklaWWZKFrKR1ISDnHtoJOlKUClKUCtWz+z29q7Y1awt90iMQnmkMPsKQS4psISlQBxgElI5raVa51p2px9MapbsirLcJbikoPfIUhCCVdEpKiNyvYOaCB7Mux6Xo7Vzd0fuUKTGjodQ0W45S87vzy4onwB8PIVDL7ELwnWFyvzF1tu+RdfTmmnmC4kNla1EEKBG8ZTg++rc/2uRflPLtEWy3J5mPLVAXOQkFtL46gpznaD41WdM9uLnyMgXC+W5Uy6Tpj8dliEA2kpbShRJKleSx76IyNIdib1k1cZ0y4QpdtHpHBjn0h0OpKSlaiccAnke3zqGtnweXkWe9xLjeWXH320NQHkIUQylLhWQoHHU46e2p669vtsgLYCrDclByGJhClJQpAKikgg+0dfHipK6dtFuiuwkQbJdLgXoLVwd7kJyy04QE5BPJ5HA86CmRexS8WWy6lnSJrFxub9oNvixobZSFYQhIJKsc4QPxya56d7ELkrT7zkuTb48uXa2IoiqjFKQrehxffFKsqUCkp3D2Hwq7M9sdskavTZIlpuTzfpSYS5QSkBDqvNGd2Aep9hrlr/ALX7do+8Trcq1Tp7sFht6QtopShveoBIJP8ASHOPED3Bw0Z2bTrD2bai07ImQFy7o082hxhkttt72tic+KseZ599VrQfYc/YdQ2mZd37VPgx4jseVGLJUH1KW4oEhQwcbkdfs+6pK5du9uguS0LsstZj26NcTh1PrJeDJCenUd+P+E1IaI7R5upO1GbYywy1a02hi4sjb9KFOIZXhSs4P+dx08KCK1v2MSL9rdy8wrhBZhyO4C2XoxUthLaQnDWDgAgDjiu3S3ZHNtXaK/qCVKtK4S1vrLTUYlxzvAoclRO3hfO3g+XNd7fbpZ3XJJRabj6MGZLsWQraEyu4SVLA5yngcZrKidsMd3SDF/f0/cmmZklESC0FIUqU4oqGEnOABsPJoIe29ml40r2Qav04y+1c3JpW7EQwkpWSUpTg54z6o/bUHYewu4P6alem3CPAlzbUxFQyzH27FhSHVd9g+srcnaSPDn2VYoXb1a5TadljuRkrmKiNx0qQVq2pypXUAYBHHtrgx2929622eYixTlfGU12EhtLqNyVIDXPOAc98PyoIm2dh91iw9StOzrMs3VtlKG0MLQ0gocCyNoIIHGBg5qx2bspmRuyW9aSl3CEJVwd71L0ePtQjBQUgjgq+oMk88+OKiLT23Lv+sdNRbVD7m1zm3jKbeRueStAWcJIVjokeHjUjG7drYuFc5UqxXOMzCbC8LU2VrJWlCUlOcpJKs88YBoKyz2EXtMa9tu3i3LVPtceA2pKFgILS45yRzxhgj3kcCrZ2Wdlk7RmqZlyfmxHI0i2NQu6jpUk94lLYUvkY5KFHz9arHpTtATqPTl5uTFmnMSLYFb4rpTl0hJVhChkHOCPfVNifCCssmM9IRaJ5aZYQ4soUkkOrXtS15ZPXOegNBEwuwCU0qah2+Rg16K/HYcajFLjpcJIU+c+tjP7B5Vk6Q7Eblapt3Vc7rBeYn2VdqHdNK3IUUoSF4PBxsz18ulZmrO2p+Jod682WzludFuQt0uNP5DKtqlfwFc9MfnVhs/am3ctYTLAzZZazBAXKloWktto2bivHXGcDx60FMsPYnfIE+wuybtbnGrXEkxUhCFgqDvfEHp4F4/lVy0RoW96T7NDYIku1PXISFOpdksKcY2lQOCng5wK56B7WIOsr6m3xLRcYzbra3WJLoSULSkkHO0naeD18qj2e2mGpzUTjtiuCYFjWtuTKStCk7gooQAODlShgftoMjtW7OJ+s3rJLiTbeiTAacacZlxy4wvekAqCfAgjIz7PKsq59mESd2b/J3vIrV0ENET4zRGSF7UuBzYPEIKh9XPQ1E/5bIo03Nu7mnrk21DfZbeSpSMbHQdqwocHoAR7RXFfbjbfilqczZpzwlTXYcJCVpHpHdgFSwTgBPrJ/E+yioeP2KXFvRlytS5tmVJmS2X9gjLSyEtpWkDghW47859mPGuTPYrc48PSTrN0tiblZZypbikxe7bcBU2oD1epHd+IGcms26dvdtgLhA2G5K9JhGbtUpKFIAUtJBB/9MnPkRXbeO3e125UTZaJjyJNtTcUq7xKSEnI2kefFEZ+q+zGZfu0SbfhcWWIcm1OW4oCSXUFbakbh4cbs9aiOzDsguekNbRb3Ln211lqGYxaisqbJOAAo+BJxknxJraulL03qLTluu7LSmUTWEvpaUQVIChnBqVopSlKBSlKBVTvvZ3pS/X1N5u9nak3FO36VTiwDt6ZSFbTjHiKtlKCpvdnOk3tRLvrllYVdVqLinty+Vfa2527vbjOeaxj2WaLNibs6rG0q3tvKfQ2XnCpK1ABRC924ZCRxnHFXWlBR5fZRoqWUd9Ym8IjiKkIfdQA0DnbhKgOvOevtrtuHZfo24fF/ptiYe9AZTHj7nHPVbT9VKvW9YD+dmrnSgqi+zzSa9RN31VkjfGjag4l4bgAodFbQdpI88VHdpfZhZNdRXlyG0RbutCW0XBKCpaEhYVjbkBXAI56ZNXylBQT2TaSl2+EzeLW3PlMQWYK5JWtpTqWkpAJCVDB9Qe3HGcVN2XROnrJe1Xe2W8MXFUVEIvd84rLKEoSlOCojgNoGcZ469asdKCnjsz0cmXPkpsMZL85tbT6klQylYIWE4Pq5BPKcHmsTVXZparxoBrSduWq129hwOMlKe+KDuKj9ck8lR8c/hxV7pQax0p2LaYs9gNturPxypUn0suvp7vC8YASEnhOPDJz41LsdlOi47EBlmyhLcCQqVGHpLx7t1WzKvr8/5tHByOPfV3pQUi19lWjLXLiyYNlS09GCw0oyHVbd4IVwVkHIJ619t/ZVom3szWotgjhua33T4Wtbm5OQrA3KO3kA8Y6CrtSghNK6UsmlILsPT9vbhx3V73AlSlFaumSpRJP51FQOzPR8G3XKBGsbCYlxKVSW1LWsLKSSnG5R24JOMYq4UoKoOzvSY00vT4sscWlbgdUyFKBKx0Vvzuz7c5xxXdpzQ2ndOTZEuzW1MeRIZTHdV3ri9zaQAE4UojoBVlpQVfTugNL6cu71zstnjxJzoKVOIKjgHqEgkhP4AVzg6F03BYvLMe1t9zeF95OQta3EvKyTkhROOVHpirLSgqMDs20lAsdxtESyst2+4Y9Kb7xZLmDkZUVbhg8jB4r7I7ONJSdORLE/ZmV2uIpS2GiteWyokkhe7dznzq20oKRJ7KdFSSx3tjb+gjGI2EPOoCWjuJTgKGeVq5689a+z+yvRc9iI1LsbTiIkcRWfpnQUtA5CchWT1PJyeau1KCv6f0bYNPTTLs9vEaQY6Im/vVq+iRgJT6xPTA568VYKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKV8cWltCluKCUJGSpRwAPM0H2laV1p8IXTllkuRbLHevL6DhTjag2yD7FEEq/AY9tUxXwnZuTt0xHx4ZmK/coPTtK8xfOdnfyYjf1tX7tPnOzv5MRv62r92g9O0rzF852d/JiN/W1fu0+c7O/kxG/rav3aD07SvMXznZ38mI39bV+7T5zs7+TEb+tq/doPTtK8xfOdnfyYjf1tX7tPnOzv5MRv62r92g9O0rzF852d/JiN/W1fu0+c7O/kxG/rav3aD07SvMXznZ38mI39bV+7T5zs7+TEb+tq/doPTtK8xfOdnfyYjf1tX7tPnOzv5MRv62r92g9O0rzF852d/JiN/W1fu0+c7O/kxG/rav3aD07SvMXznZ38mI39bV+7T5zs7+TEb+tq/doPTtK8ytfCdlbx32mGdnjtmHP/RWzuz3tm0zrKQ3CSty23RfCY0rGHD5IWOD7uD7KDZlKUoFKUoFKUoFKUoFedfhU67kQ0saStjxb79sPTlIPJQT6rf44JPsx516KzXh/4Q63Fdr9+7zwU0E+7ukYoNc0r5mrT2XSYsTtAski4OMtRW39zi3lBKANp6k8D8aIq9K3U+NI6j1I5Jub8R1CbbGMVLklttT6iT3peUFNJDickYyMgA4PSoWzWvQ5kOR5SmXm5F4kQ25Ds7YY8YNpKHcAgH1icKPB5/ANX0q9Xe26da0xCehehqUplhTksXDMnvSR3qDH54Tzg4TwAdxzirFKsmhW57O9UJEdK5PdJYuneelMJjrU244c/ROFwIG3jJURt45DUdK2/bV6Wbtt7YgQrQpy4WiNJSxJuJQlt3vB3jKVqWMEbd+Cd3hyOKirTb9FvTdOQ5gZQHbcqVLkemHC5GF7WVesEtjITnlJ56jOaDWtK2TdoGjbe9qV1htmX6PGjGHH9O9XvlnDgSUKO8J64ClY8zWNoOyadultt792kwWVtzZCZqZE0MqUz3KCztSVAn6Tfyn8eKDX9K2A3A0ovR6UkMJu6rSqYZPph3CQmQUhru84yUc4xnoR7fujrJpyfpCW5dZEJu6OiSI63JwbW2tDQU0CgqAAUrIyQoHplOOQ19Stov2/Rq9R3eLbo0F1ENhsRESLoW2ZayUlxRd3AApBOEgjOPE136dGlF2pNouohKjP391tK/TsGMyWUgOheElSQRwVAJPPFBqgpKcZBGRkZr5W4bNMsqm5EN0224vP6ajIbM+4ltCXUuIKmQsrSEcAnGQRtwOpBwnbJoP5L2x9U0Iec9FL77chJdClLAfSWt5OEgqwe7HQesrPIarpW2LOdO2TtHsTqodmahKdcQot3QyWkp6IdWc4SeTwVY80pxyttk0Y9aLm7dDCjXBLr4U1HuCVpjpS2C2WlF36TcrPQOeXq9aDU9K+tlPeJ7zOzI3beuPZV9UdMfIObv8AjDf3h+Lu+7rvO+43fV57vGM58cY5zQUGvra1NrSttRStJBSpJwQR4iuOaZoPbPwf9cPa00WPjBe+6W9YjyFnq4MZQv8AEcH2g1s6vLnwPlui/aiSP8wYzRV/S3HH7CqvUWaK+0r5mmaD7SvmaZoPtK+Zr7mg4E15n+FZot4zI+rYDRWyUJjzdozsI+os+wg7c+wedekiquiUy3KjuR5LKXmHUlC21p3JUD1BB6ig/OeleoNafB2gT5TknTE5Vu35JivILjYP81XUD2c1Sl/Bx1YFHbcbKU+BLjo//wA6I0pSt0/Nx1b94WT9V7/Dp83HVv3hZP1Xv8Og0tSt0/Nx1b94WT9V7/Dp83HVv3hZP1Xv8Og0tSt0/Nx1b94WT9V7/Dp83HVv3hZP1Xv8Og0tSt0/Nx1b94WT9V7/AA6fNx1b94WT9V7/AA6DS1K3T83HVv3hZP1Xv8OnzcdW/eFk/Ve/w6DS1K3T83HVv3hZP1Xv8OnzcdW/eFk/Ve/w6DS1K3T83HVv3hZP1Xv8OnzcdW/eFk/Ve/w6DS1K3T83HVv3hZP1Xv8ADp83HVv3hZP1Xv8ADoNLUrdPzcdW/eFk/Ve/w6fNx1b94WT9V7/DoNLUHJwOtbtY+DhqhTgD9ztCEeJQp1R/IoH9tbQ7O+w+y6WltXC5rXd7i2dzanG9rTZ8CEc5PtJ/Cgzfg5aNe0noxcq4tFq43RQecbUMKbbA9RJ9vJP+9itsb6xsq+yfyplX2T+VFZO+m+sbKvsn8q+7lfZP5UGRvpvrG3K+yfyrrlzGIECROmlaYzCdzhSkqKR4nA5wOtBnhWa+5rAt8+LcoaJlvcLkValJS5ggLwSMp8xkcHoeorK3UHa0gJSCetc6UoFKUoFKViXGe3BbSpwElXQCuNTUx0sZzzmohccZymoZdKxIU9qUwXEHG0ZKfED/APBUPY9Z2W87jGfdaAjplAymVMhTSjgLSVAApz4irhnjnG9jNwTExNSsdKx0zoiltITJYK3U7m0hwZWPMeYrpdvFtZbDjtxhobKijcp5IG4dRnPUeVdIzqV0OTIzZUHJDKCkJUQpYGAo4B/E8CuHxjC2PL9MjbGTtcV3qcIPkrnj8aDKpXS7KjssB919pDJxhxSwEnPTmuDdwhube7lx1biEja4DkkZAHPiOaDJpWL8ZQe6S56bG7tS+7Cu9Tgq8s56+ysKPqS1SZrkWPMQ4624405t6NqbAKgo+GMigl6VhqutvS024qfEDbn1Fl5OFc44OeeSPzrualR3XnGWn2lut/XQlYKk+8eFB3UrChXSLNXMQwvK4jhbdSeoIGc+7n+3yqJtWs7NdJMZiI+6VyM93vaUkHDQd6kfZUD+ygsdKi9OX+3ajtxnWh/v4wcU2VbSkhQ68HnyPuIqUoFKgLvq602mc5Fluvb2QhUhbbC1ojpV9UuKAwkH2+HPSpYz4iVOpVKYBZTucBcHqDzPkKDJpUX8f2z4zagemNekOsh9v1htWgq2jaroTnwFcrjfrVbo7z0yfGbbZWltwlYOxSjgAgdMk0ElXE11uy4zSlJdkMoKQFKClgYBOAT7zwK6kz4ayoIlx1FKw2oBwHCj0SeevsoO9VYV0goudukwHnnmWpCdi1sqCVbfEAkHGRx588YrtTOhuONtolR1OOZ2JDgJVg4OB44INdxFBG2q2x7Ha2rbCcdVGaJ7pLigrukZyEA4+qOgzk48azM1wk8OJ91fM0EhSlKBSlKBUVfLWqe2VIXhxI9UHpUrVSma3js3i425iBMkOQkrCnEbQhS0thwoyTx6pHJwM8ZrHaNDDaNOdLUi4l3p55aeUZY84SOnrW9CjSEyCAp3jAOcdf76gIvZtboWmYlvhFlE9gRyqYtneHlNEEb0FX1SQTtBH7K60dp0Fy3xp7NtnOw3470sLSW8pYbWlClkFXtzjrXVG7QXETXm5Ufvh3j7TLTCMKcUmZ6O2NylYGcjOfafZXOy7Nhsuljo6fKF1dTLVznPLnL6z2blmbb5DV07ssZL3dsFJcy44spSN+1KcuEAFJKR0NYaey15FpYgIusQtodbW6HYKnEvpbThCVAu/icEA4AxgVLo7RYRYdcXBltqaQVqQooyMSTHI4OM7hn3VJ6a1fE1A9MTFiym22ElaHXEja6kKUnIIJwcpPBwcEV6Gb5fdJtXi9Wi4PSS2YeA+0hHqyQkhaAeeAlaQodfEeNV1PZiEwnWPjFolLbbLChGKCEocKwpwpWFKcycbwU+PHJrMg9pEeY3HDdoniTKDCozBU3l4OpWpJzuwMBpfUjoPOsdjtK7+Y4I9nkvRV+jNx9q0BxbjxWNqgTgYKCM5xweelBKT9HvSNN2W3puDbkm2LC0uyIwW26QhSCFN5Hgo454IHWq9ZezaWm2W5uZcRG2IjrfYQ1uUHG2FNeq4FYAwrPQ8irZprV8W/wA+VGjxJTQYCyHXEjYvYsoVggnBBHQ4yOah2e0qHJeLES2TXnzIbYbQlbWHN6XFJUFbtuPolePlQRyuy1XxM1ERc2W5KF59IRHcBx3aW+ne9cJGc5SehTWXN7NvTH5xdugSzIckOAJjgKBeSgHcd2CAUdMDIJFZEbtKt8gtragTfRVBkF87AEKdQVISRuzngjIBGfZX2J2jRnkRnHbTPZadbYecWpTZDSH17GlEBWTk+ABwKDFkdmiJTcoyZ7PfSWpSFd3ECW0LeQ2nchG71cBsHGeSonIqW03o9dl1LNuaZ4WzISsejpbIG5SgoqJKiM5B+qE5zk5NYU3XbzkSDJtlqfW1JmtsN96pvMhtSlpJQN+UnKP4WOtd9n7Q7fdrlDhxYU7L6UFaylJDKlhRCVYOf4J5GRyOaDnpLRr1hulymvXISlTGg1gMlGMLWoE+sRn1yMAAcdK6JmhHXbFZbfGuxju22K7GD4YyVhxvuyoDd6pAzjk1L6u1TH0wIapcWS83IUUlxsAIaAxytRICevGeODURN7RoEW4TYghSnlxsBKmlNqS6e9Q0QDu4IUscHHj0oMzTGi2dPG4sxbhLct8xttPcrVtW2tCdm5K04IykIHA42jmpJvTcNtxK0ybqSkggKuT5H4gr5qDY7Q4a50CK9bpsdcl5cdS3NgbbcS6popK92CcpzgHoRjJ4rNumso9u1Au2OwpKktqjockpKNiC8SlGQTuPIxwDQdF+0a9cZl2VFufosO7toanslgLUoJG3LasjYSng5CvOsF3s9K0z2kT4yY7z5ks7oSVOJWXku7XFlWVoygDb6uU8HoDWLYu0Z+WG0yLW48p5mH6P3CkpLzjzRcIwpWEgBJ6k9OpyKkbbrdx7UztulwHUR3JDUdh5JQdi1x+92rwo5PChlOR05oIuR2Xl5zd8aMp71CkPgQhgbn++V3XrfR88DrjrzXY/2Z72n0ouTQUN3o6jFGRmQl8l47vpDlAAPq4BPnWXf+0BFtvQjphuiBGkOszJSgkj6OMp5QQArdkAJ5Ix1qUi6wZkaan3j4vmNohHLrKgncU4CipJBIUAlWeD4EdaDnqDSjN6vlquLshTfoh+maSjIkpCgtCVc8BK0hQ6+I8arzHZquOhss3RtL0Ys+jLETAw273gLuFfSKJ43ZT4+ZqQR2iW92fHjMwpryXlkJdbSlQ7vvS0HMZyUlSVdM8DPlWC/wBpJcZjmDZpBcecj7A84gBbbjxaKhg9QUkYOOoPSgWvs6ct9ztUxF1SVQ1FTpSwUl7Lji8Y3lIH0hGSkkY4IzWwqr2lNWRdSuSREjSmUNAKQ46kbXUlSk5BBODlJ4POCKseKDBl/wCeT7q4V2Tf88n3VwoJClcGXA4gHx8a50ClKUCouVp6zypb8qTbYjsh9BbdcW0CVpIwQfPjj3cVKUoK3J0TYJNyZmO26Oe6SsBju090VLUlRWU4+tlI/bWe/p2zPoeS9bIiw8FBzLQ9bcvvFZ96/W9/NStKCuwdF2GJEajm3R30MrcW2Xm0qKN7pcKRx9UKPA8MCpOBZrbb3pDsGDHYdkEl1TaACvJJ5/Ek+8ms+lBEu6bsrsfuHLXDUzsQ2EFoYCUZ2AexOTjyzX1OnbOiSzIRbIiXmUoQ2oNAbAg5QB5Y8PKpWlBgQrNbYMqRJhwY7MiQSXXEIAK8nJz7zz76h5mhNOyQwn4tYabbeS8pDSAkOFKVpSFccgd4rA8Ks9KCuxtGWJi6uT029hTykoQ2lTadrKUI2AIGOODWevT9oW9DdVbYhchpSiOotDLSU/VCfIDw8qk6UETH03ZYz63mLXDbdW6H1LS0ASsEkK9+VE/ifOuB0xZN6VptcNDiGy0haWkgpSc8Dj+cr8z51M0oIuTp+1SocSLLgMSGYqA2yHUBW1OAMc+BAGfPFcBpmyCS7IFqh986rctfdDJO4L/6khXvGal6UEUvTlmXJbkKtkQvtrLiV90MhRVvz79xKvfzXSvS1qd1E5e5EZL85SW0oU6AoNbN2Cnjg+sf2VN0oIR3SlgdRsctEIo7tDW3uhgIR9QD3eHlWUxY7XHU2pi3xWy2tK0FLQG1SUbEke0J9UezipGlBFPadsz9xXPetcNyavhTymklR9Up5P8ARJHurvt9ot1uhLiQYTDEZed7SEAJVkYOR48cVnUoIpWnbMTCJtkT/wAEkIj/AEQ+iSCCAnyAIBx5ivj2nLM8wGXLZELQSlAT3Q4SlW8Ae5RJ99S1KCKjads0V1Tke2RG3FOh8qS0Ad4JIV7wVKP4nzqVpQ8daDDmD6ZPurhiuTyg47kdBxXLFB1EFJykkH2V8Lrvgs1kFNcCigxy8/8AbNfO+f8Atqrv7uvnd0HT3z/21U75/wC2qu7u6d3QdPfP/bVTvn/tqru7und0HT3z/wBtVO+f+2qu7u6d3QdPfP8A21U75/7aq7u7p3dB098/9tVO+f8Atqru7usC6T2oCMEb3T9VA/70TLKMYuWSX3gMlwgVhu3lpo4XLGfZz/ZVYmzZEsnvV+r9kcCsTZUt48tr/jC3DUEcnHpSv+E/3VlMXD0gfQyAv2AjNUfZX0JIORwfMUtzG15fGF975/7aqd8/9tVVq23h1hQRJy415/wh/fVoZKHm0uNKCkK5BFW3r09XHUjucO+f+2qnfP8A21V3d3XwoAGSQB7aNHV3z/21U75/7aqLejo+u+0n3qFdC7jBR1kIPu5rmc8Y5y7jTzy5Q7++f+2qnfP/AG1VgrvMFPRa1e5NY6r9HH1WXT78CuJ19OPi0jZdaeWMpbvn/tqrsZkOpX65Kk+NcIq0SY7byBhKxkA1wlyY0JlT0t9phlPVbiwlI/E1pE33wxmJialIuvhKAUck9KxSpxf1lEioGPrDTUh8MsX+0uOk42JmNk592asTZSsApIIPII8aqPiE4rtxXJKa54FB9IriU12UxQdeyvm0DrXbiom8Zfm2+Ao/QvqWt4fbQkfV9xJTn2Aig63NQWZtZQu5xAodR3orh8o7J96RP1BUq+qNBhuvPFtmMygrWojCUpAyT+VYca9WqTYfjpiYwu1d0XvSR9TYM5P4YNBjfKOyfekT9QU+Udk+9In6grJ+O7T8QfHfpjHxV3Xf+k/wNnnWXBkRp8JiXDcbejPoDjbieQpJGQR+FBF/KOyfekT9QU+Udk+9In6gqb2J8h+VNifIflQQnyjsn3pE/UFPlHZPvSJ+oKm9ifIflTYnyH5UFem6pszEZa27hFcWB6qUuA5NUx+9Qn3VOOzWlLUck7q2psT5D8qbE+Q/Kox1dHic5ao+NLf/AK2z/wAVPjS3/wCts/8AFW19ifIflTYnyH5Upj2SOrVseZEkr2MSGnF4ztSrmsnZV8u1sjXGG4y+hOcZQsD1kK8FA+BFa9hvLetjL68d4toLOOmcZqTDDW0eHXe7GkuPuqbiRpElSeFFpGUpPkVHjPszWawL3HBQxAmobPJA2df+KrXpZlDOnLalAxlhC1HxUogEk+0kk10tX9pzVr9gESYHmowkmQWvoSCcbQrz9lTLDeinu2fSjQyjOO+fnyVxYvS/rQ7gf95P71dKolzUcqts0n2lP71WmJf2pOqp1iTEmIeiMoeVIW1hlYV4JV4n/wB/KpvFYzsuM85l9PHb9THlEfRrr0K4/dcv/k/ep6FcfuuX/wAn71bFxTFTseHzdfqWr0hrr0K4/dcv/k/er56FcfuuX/y/vVsbFcV8CnY8PmfqWr0hrPVOvYWitEuTJbazOQotMw3AULWs5IyDyE9TnyFeR9YauvOrbkuZe5i3iSdjQJDbQ8kp6D+3zrZnwrLm5J1zBgE/QxIgUkfzlqJJ/JKa1z2e6YRqq/OxZElUaHFjOzJLqE7lBttOTtHiTwK9OOO7EQ8Oec55TlPxVnNbI7K+1W7aKnMsPuuTLGpQDsVas92M8qbz0Ps6H9tYegmLFqHVLWnZNuWiDcVFmLJUsGTGcI9VRUkJCxnqCOh4NUy4w12+5S4TpBcjurZUR0JSSD/ZVcv0Os9wjXW2xp0F1LsWQ2l1taeikkZFZ2K0p8Fi6vTez5yI8oqTBlrabz4JIC8fmo1uug+0pSgVE3AgaitJJA+jf6/7lS1QV7iR5t9tLUtlt5sIfO1acjOEUEw8GX2VtPd2ttaSlSVYIUD1BFY7MC3M2z4uajRkQNhb9HSkBvaeo29MV0fJ+0fdsT9MU+T9o+7Yn6YoO/0C3fFnxb6NG9A7vuvR9o7vZ027emK74yI8aO2xHS00y2kIQhGAlKRwAB5Vg/J+0fdsT9MU+T9o+7Yn6YoJLvEfbT+dO8R9tP51G/J+0fdsT9MU+T9o+7Yn6YoJLvEfbT+dO8R9tP51G/J+0fdsT9MU+T9o+7Yn6YoJLvEfbT+dO8R9tP51G/J+0fdsT9MU+T9o+7Yn6YoJLvEfbT+dO8R9tP51G/J+0fdsT9MU+T9o+7Yn6YoJFTiNp9dPTzrWENYXZIpShKAIyRx4+r1q+q0/aNp/+Gxen8WKoVvcUdPwmyfUbjgJHl6tSXk2vlC2af1FakWK3JVNbCkxmwRg9do9lZ/yktH+ut/kf7q79Of6P2z/AGZr/pFSFV60R8pLR/rrf5H+6nyktH+ut/kf7ql6UER8pLR/rrf5H+6nyktH+ut/kf7ql6UER8pLR/rrf5H+6uLmo7SR/wCdb/I/3VM18UMig8kfCgiMSNR268wnQ8y8x6O4Uj6q0kkfmD/ymtU6T1FN0veU3C3hpaihTTjTydyHW1DCkKHkRXtftI07C1LDgWu5t740iSpJxwUnuXSFA+BBGa8t657HtSablOKhRXLrb8koejIKlgfzkDkH3ZFBDaT1HZtOXly/sQXl3FncqDDKssMrIwFqWTuVtzwnHlk1UZD7kqS9IfUVuurK1qPionJNSMfTt6kPhli0XBx4nGxMZZP9lbi7Lew6dLmsXHV7fo8RCgtMLOVukfbx9VPs6n2UGz/g12F6zdnjLslBQ7cHVSgkjkIIAT+YTn8a2/WLCjpYaShCQlCQAlIGAB5Vl4oFKUoFRM//AEitP/pv/wD9KUoJJX/mEf0Vf2iuylKBSlKBSlKBSlKBSlKBSlKD4r6p91art3/ySN/s6f8AppSpLx7ZyhsXTn+j9s/2Zr/pFSFKVXsKUpQKUpQKUpQQt9/+YWP/AGxX/wBh2u+QBzwKUoMYAZ6Cs2OB5UpQZqelcqUoP//Z",
+              "timestamp": 21995601528
+            },
+            {
+              "timestamp": 21996559653,
+              "timing": 7665,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAFQQAAEDAwMBBAQLAgsECAUFAAECAwQABREGEiExBxNBURQiYXEIFRYYIzJSgZGToVXSM0JTVFZicpKUsdMkNnTBFzQ1c4KistFDs8Lh8Cc3RIPD/8QAGQEBAQEBAQEAAAAAAAAAAAAAAAECAwQF/8QAMBEBAAIBAQYEBAUFAAAAAAAAAAERAgMEEhMxUZIUU6HhIVKR0QUVQXHSM2GBscH/2gAMAwEAAhEDEQA/APVNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFK+KUEpKlEBIGST0FV5rXGlXrh6C1qK0rl52hpMpBJPl16+ygsVKEgDJPHnVdOuNLJn+hHUVpEvO3uvS0bs+XXr7KCxUoCCAQcg+NRV51Da7KtCbrK9EQvGHnW1Boe9zG0feaCVpVC7a5X/6SX+TDf4MdKkOtL6gqTyCKljq/T1miQI13vluhylMt/RvyEpVykckE8UFnpXXGkMymEPxnW3mXBuQ42oKSoeYI61C3fWOm7PLEW6322RJOcd09JQlQ94J4++gnqV1RJLEyOiREebfYcGUONqCkqHmCOtdtApSlApSlApSlApSlApSlApSlAripaU9SK4PrKRgdTUHcb9aLY+GLjc4UV4p3BDz6UKI88E+ygsCVJV0INfahLXd7fdAtVrnRpYbICyw6F7SemcGphpe9GfGg50pSgUpSg1v24PvLs9jtCXlx4l4urEGW4g7T3KiSpOfDOMVY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvb1rM1dp2DqqxP2u5pV3LmFJWg4W0scpWk+BBqnu6L1nJhG2SteLVbVJ7ta0W9CZKkdCO83dceOM0FEN9uT/YfDgqmulDl4FkVPSrClxu9Kd+fakbc1txGgdKpsfxSLFb/QtmzBZTu6Yzu67vbnNc3tE2R3RI0qYxFpS0GkpB9ZJByFg/a3c586rSdE60RE+Lk6/d+LQnuwo29Bk7OmO9z1x44zQQ3aDKk6E7FDH07eHpZbdTDROUsKWy2pZBG4eKR6oPUVsXT+nLZb9OItzbQkR3mQl9bx7xUjI5Usn6xOa67do2yQtHp0yIiXrT3ZbW296xcyclSj9onnPnWKrT10tllFn0xPTGjbO7RImrVIcjp6YQnjOPDco4oNKx33Y/ZF2oWBLq3rdZpy48Najna33g9TPsx+tbn0TpSzQ9JxGzFjTlS46HJMl5AcVKUpIJUonqDngeAqPHZnAj9ms7SUCS436aCp+Y4netxwqBK1DjOcYo3o7UdpiegaX1S3CtoTtbZlQRIVHHiG1bhx5BWcUFU0/Le0h/0o2qyEqgWdr0yC19YMLW0pakD2AjOKtPZZpKxs6GtslcOLOlXGOmTLlPtpcW+twblZJHIyelTWi9HQ9M2eVELrk+TOcU9OlSACuStXUq9mOAKrsLQWodPochaQ1b6DZypSmokuEmSY+TkhCiQceQOaDo7PmW7B2n6s03axssyGWJzbAOUx3F5Ckp8geuK2hVZ0RpFjS7Mxxct+4XSc530yc/9d5XgMDgJA4AHSrNQKUpQKUpQKUpQKUpQKUpQKUpQY8kesD7KqOpRczcE+gi+Fruxn0EQ9mcn+W9bP6VdHEBacGsZTSwemfdQV/SwnBuR6eLoDkbfT/Rs/8Ah7nj8assYeoffXWhlRPPArJSAkADpQfaUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUrg86hhlx15YQ02kqUpRwEgckmg50qrwe0HSM+YxEhaitj8l9YbaaQ+CpaicAAedWigUqsXvX+lLHcTAu1+gxpgxuaW5yn+1jp99WKJJYmRmpMR1t6O6kLbcbUFJUk9CCOooO2lKUClKUClKUClKUClKUClKUClKUClKUClKUCvI/wAIXV2o7T2pXGJa79dYUVDTJSzHluNoBLaScAHHWvXFeLPhM/8A7vXT/uWP/lJoPS3ZZPmTux61TZsp+RMXDcWp91wqWogq5KjznitM/Bi1Tf712gzI14vdznx021xwNSZS3EhQcbAOFEjOCefbVw+D/wBoVkumn7PopLE34xaiuBxSkJDRAJJwoKz0PlVlmdnWnND6c1JdtJ25yLdPiqS2hwSHXD9TdgBSiOqU/hRHdc+2rRFvvotTtzU48HO6ceaaKmW1Zx6y+mB5jNR957etHWm6y7e+Lk47GdU0pbLKVIUQcZSd3I9teVNBs6ZkX0o1rLnRbZ3SiHIidyu8yMA8HjGegPOKh7umGm6S02tbzkAOqEdbwAWpvPqlQHjjFB69m/CC0bDmPRnm7t3jSyhW2OkjI/8AFUvbu2HTVx1o1puH6U5KcJSHwhPdAhG4gndnjBB46ivGep/94rl/xC/869J6i7JtOad7OZ+orM1NRdWrYp1KzIJAK28LOPcpVBZL58IDRdsnORWVzp5bVtU7GZBbJ9hURn3jis619q2lta2W7Q7VKdan+hPKEaS3sWoBByU9QfuOa8p9nLej3LrIGu3p7UHuT3JiDP0mf42AT06e3rU3pNOj29RoXbZuo/St6xFSY7QSQQQAshWcY6kDpmgrvZpKZhdoWnJUtxLUdmey444o4CUhYJJ+6vTulO3/AE7fdSJtT8STAQ873UeS6oKQsk4Tu8U548+vNeYezSKxO7QtNxZjKH4z1wYQ404nKVpKxkEeIp2jx2YHaHqOPDbQwwxcX0NIbG1KAHDgADoBQbZ7V4fZcjtBuybu9qSNcu+3ykQ0NqaUtQCiUlXIzmojtd1oq1P6etOg7rebZbIlrZV3aJC2twcSHUE7Vcq2rGfbmqX2vurf7Q7m66oqccRHUonxJYbJqwdt0Vhm2dn77TDbbr+noqnXEoALhCEgFR8SAAOfDFBtv4O/aNHkaRujGp7vKclwFqlPS5zpWlLStqUgLUSc5B49vtqef+EFoVqWWUyJ7qAcd8iKdh9vJB/SvNEi4W1HZHDgxlRk3Zy6uOSQlIDqmQ2Nm44yU7irAz1rHsls09J0pMlXGe3HuaFkISZCtxHGNrQaO7394n7qD21Y9ZafvlhevNtukd23MAqedJ291gZO8HBTx51ryf8ACI0XGlKaYTc5SEnHetMAJPtG5QP6VoCE1AgdnuphYtQyZq5DccS4hhKZSlIeThRWVEHk4x7fZWBoBvQrkC6nW790alBI9DEMZB4OfA85x1wKD1XD7XNLXnSl3ultmPFUCOXXo5b2voB4BAJweSOQa8s6X7SdSQtTWmVddSX1+3MS2nJLRmOL3tBYKk7SrByARg9atvYnE0lI1WY8V28ypT0OQhceVFa9HcR3ZJC/WJxkAjjqBWsdFLhNaysS7sGfi5E9gye+SFI7oOJ37geoxnIoPW967d9I2eamLLbuhdUwy+NkdJG11tLif43XasZ9tSWpO1/TenrTY7jPRcDHvDBkRu7ZClBI2/WG4YPrDzryx23y7fO7S7pJsi2V2xbccR1MDDexLDaQEjwAxj7qmu2CbGk6F7NGo77TrjNqUHEoUCUH6MYPlyk/hQb1c+EBo5EBmYpu69y86tpP+zpzlAQT/G/rp/Wknt/0ezaGJ6E3FwPPrZDIaSHBtSklRG7AT64A55OfKvJkr/dK2f8AGyv/AER63T2A9lumtbaMlXK+tSlym5y2Elp8oG0IbI4HtUaDcupO1/SGnmYxnz1qkvtIeEVlsuOoSpIUNwHCTgjgmunSvbRozUk9qDGnuRZbpCW25bRb3k9AFcpz7M14+cjML1q9FvC1NRxMW08pbhQUAKIwVbVEYxjO048qmJ1m0k3qBbKNSKhw07Slxhlc0JPjhe1sn+7Qe8KVg2JfeWO3rL65JVHbPfLQUKc9UesUnoT1x4VnUUpSlApSlArTHaX2Go1vq6VfFX9UIvobR3Iid5jakJ+tvHl5VuelBpzsx7EUaF1W1ek35U4oaW33Jid3ncMZzvP+VbicQlxCkLSFIUMEEZBHlX2lBo66/Bx07LvomRLhLiQVOb3ISUhQxnlKV5yke/NRt6+DVCm3aXJhagMGK66pbUZMLcGkk8JB7wZx516DrCvj02PZpz1pjok3Btlao7K1bUuOAHakn2mg0Nc/g1tTrjJlfKlaO+cK9voAOMnpnvK30zb2haEW6QlL7AYEdYWnhxO3acjyI8K0DovWXa9N1pCi3ayui3uPhMlLsHukNN59YhfsGccnPtrf15uDVptE64yMliIwuQ5jrtQkqP6Cg0hffg1WSXMW9aLzLt7SlE9ytoPpT7EnKTj35qf0T2F2LS65En0uROuTjDjLb7yQEs70lJUlA8cE9Sa0rc/hB61lXFx2C7DiRiolthMdK8J8ASeSfbxXqrQ1zkXnR1luU3b6VLiNvO7BgblJBOB4URqHSnwd27Bqa13calW+YMluR3RghO/aoHGe8OM464r5qr4O7d/1LdLudTLYM6S5I7r0EK2b1E4z3gzjPXFb7rX/AGy3jV9m0+w9oe3emSVOFL60t96tpOOClHjk+POPLyKo2q/g8t6gvr9yOpVxy6ltPdiFuxsbSjr3g67c/fVy1T2S2fU2jrJZLk+6JNoitxo85pISvCUJScpORg7QcfrVZ7N9d61jWK/3btFtUhFst7Aebd9GDLy1Z5SlJIBGOc8e+prQ/bbp7WOpotjtsG6sypIWULfbbCBtQVHJCyeiT4URXtM/BzsttkSlXe6P3Nh5lTQa7kM7CcEKB3E5GOKjX/gx25UoqY1JLRHzw2uKlSsf2twH6V6GrTED4RGlptzjwWrbew6+8llJU01tBUrAJ+k6c0VatK9lOmNPaXn2NuKqWxcE7Zbsg5W9jpyMYx1GOh561rq4/BltTsort+oZkZgnPdux0ukf+IFP+VegqUGvezLsnsegVvyYa35lweR3a5EjHCepSlI4APHmeKpeqPg42W6XR6XaLrItbbqitUfuQ8hJPXb6wIHs5re1KDR9++DxZrlbLazGu0qLMhsBhUgtJWHgCSCpGRg844PQCsW6/BvtMm1WyLb7w5EfjBZkSFRu8VJUrbzjeNoGOBz1/G/9sN31ZZ9NNv6ItwmzFO7XiEd4tpGPrJR/G5x548vKu9h+ou0C9y56Nb21bEFtsFl92N3Cy5keqBxkYyc44x7aIrDvwbW3LTGg/KhYDLzr2/0Ac70tjGO88O7/AFraHZNoVPZ9pt+0puBnh2UqT3pZ7rGUoTtxuP2OufGrpSitR9onYXYtX3Z26RpT9qnvnc8ppAW24r7RScYPuIqL0n8HSwWm4sy7vcZF27pQWlkthptRH2hkkj2ZreFKAAAAAMAUpSgUpSgUpSgV56+EX2q3fTt5a07pp/0R1LKXpMlKQV+t0QnPTjknryOleha81fCY7N7vcb8jU1iiPTmnGUtymmU7ltqSMBQSOSCMdOmPbQa5uWue0SHpCGLjNvcePLkekxbip1xtTidpBQFfxk9FAe/zr7A1zqtfZ5e5StSXgyW7lCbQ6Zjm5KVNySpIOeASlOR/VHlUJqK76qumjLdFva3fia1OpiRkONBBCthwM4BOEpxz0yKktDacn6k7NNYNWphyTJiS4MruW07lrSEyEkAeJwvOPZRF07INW6iuOle0N6ffbnJdiWdbsdbspayyvav1kkng8DkVVuznXGqpmqUsy9SXh9r0OavY5McUNyYrqknBPUEAj2gVjdnbeqYNq1jEtdoUqPJtjiJzkhtSe5bSlROPNR5AHn7qjuzGDLRq5ClxX0j0GcMlsj/+I9QT/ZVrfVM/tH07Fm6ju8iM9MbQ407McUlaSehBOCK9O9tUObO7LNRtW2T6M+mKp1S9xTltBCnE5H2kJUnHQ5weK8kdj8GW32n6ZW5FfSkTmySpsgDmvZnaMlS+z7U6UAqUbXJAAGST3SqDw1oC3XO76wtkCxTfQLm+4UsSe8UjuztJzuTyOAelbR7V+0zVlvvEfSlruj7K7YwzFkyI6iXZUgITvVvI3fWyB0J6nrVS7DIUpvtY02tyM+hAkHKlNkAeoqrJ8IDQd9tevp1+t8OU/bprgkIkR0FRacwMhWOUnIyD7aCI1lrvtGgwLPb75JvNplR0LKXu8cYXKQduCvGNxTgjPXnn2yStZ6m/6DEXH5QXX0/5RmP6R6WvvO79GCtm7OduecedVPXEXWtxg2a66sVOlCW2sRA8CVpbTtydoHAO4e04z5VKqhSvm/Ib9Gf7z5TlW3uznHoo5x5UGbpy6ao1X2Y659K1BPkJgiK+sSpTi8tfTBaB16+rx0O32VVOye2XS76/tUOwzvQLgtS1If7xSNqUoKlDKeeUgj762L2BaenXnRvaNammlNSZkNhtnvUlIKvpcDJ9uPxrXVlZ1boTVjMqJbJkW8RitCEuRSvO5JScDGFcE8ig9zamiTJ+nLpDtkj0We/Fdajv7inunFJISrI5GCQcjmvz4tbEh+9RI8Z7upTkhDbbu4jasqACsjng81+htldffs0F6YCmS4w2p0FO0hZSCePDnPFeGNV6O1HonVKw/b5OY8jvY8lLRW24ArKVAgY8uKDZXaz2mar0u5C0fBuRRNt8NlufPQSt2Q8UAkhShkDkc9TmqWrXPaZpSZGeuF0vDS3RvQ1PJcSsf2V5/wCVNa6V1nf4cfWtwt0mUu4pzI7mMUqaUg7AVIAyElKUkHGKxbfctd3edEYscGUxIaGxKbdATHBPHKyhIBPHVXSgn+1PtP1Fc5lhuFsulytKZVrQt6NFkrbQHQ66hRAB8dv4YrFv+rtf/wDR1pqe/dpbNsW6821KRLV6RIcC1ZK1ZzgD1QM/xfdXV23WbUES9WJm/OP3C6JtLZkPJTu9YuunbkDBwCB91SerYklXwd9DNpjvFxM6UVICDkfSOdRQfHO03VE/she7y8zW7jBu7DQmNOlt1bTjLx2KUnBPLeefZ5VW42vdXK0rcXjqa9F1E2MhKzNcyElD5IBz0O1P4CsSBBljsyvSDFf3G7QSB3ZyR3Mr/wBxUfFgTPkhc0+iSMmdFIHdn+Tkeygt2kb/ANpeqbVd7dYpt4uaiplTzvpiitlI34CSpXG49cfZr1L2QxbzC7PrXH1N6T8bICw96Q5vX9dWMnJzxjxrTnwQIz7EvVPfsuNbkRsb0lOeXfOvSlApSlFKUpQKUpQKUpQKUqr37VyLPcVxHYTiyAFBYWAFA/dQU/4RWjb3rTTlriaejIkPsSy64lTqW8J2EZyojxNR3wb9B6g0SjUI1HERGMwx+52vIc3bO83fVJx9YVsK4avjw7bAliOpz0tJUEBQBTjrn765RNXRHLUufKaXHbC+7QnO5Thxk4FWhZaVSkdoEMu4VDfDefrBQJ/D/wC9cNc3mPL09G9EV3iJK8hYONu3GQR99KF4pWotH3cWm5OOuNqdC2inAVjHQ/8AKrTG19FdfSh2I40g9VlYOOPLFKF0pVWtOsY0xmW9JaMZqOAclW4qznAAx14rDX2gRA4QiE+pH2ioA/hShdaVG2O9RLywpyIpQUjhaFjCk1JVApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAqidp8HLcSckfVJaX7jyP+f41e6w7tb2LpBciSd3drxyk4Iwc8UgaVcfceaYaUcoaBSgeWTn/M1YNX29y3QbOwoEISyc+XeE5V/mPwq2xtD2tiQ08HJSy2oKCVrSQcHx9Wp+5W+NcoxYmNBxs8jPUHzB8K1aNTSnLMbCyiOy8LoCN6yTj2+OKyYaHfkRPUoHufSW9vv8f+VXBOhbSl3cTJUPsFwY/wAs/rVgFviCAYQYQIpTt7vHGKWNTacnsQPjH0gqHfxFsowM+scYrp00w1JvsJl9AW0tzCknoRV/XoW0qWVBUlIP8UODA/TNdtu0bboE1mUy7KLjStyQpSSPv4pYhtfWmLb7SyuBGSylTwDhTnng4z+tVOGq3i3PCSP9pz6uEKKvuO4AfeDW5ZUdmXHWxJbS40sYUlQ4NVpehbSpzcFSUj7IcGP1GaRIjOzkQvTZBiCX3oawsuFOzqMdOc//AHq+1h2q2RLXH7mE0G0k5J6lR9prMqSpSlKgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpWuO0W6yDc/QGnFIYbQCpKTjcTzz92KsRY2MFpUcBQJ9hr7WoHbBeISY76UKBc5QW3OR4+dfdTPT1Jt4uQWiQlkpJKuVDccHj/84pSNuqUlP1iB76+1qW2WO7Xm2NLjrbMZtagkKXjnjJ/yr7erpcblc/i9lxYQlYYQ0hWAojjnz5pQ2zVHvsbVS7q6qE4v0Yq+i7taUgDwyD41Vi7d9NXBKFuLacwF7CvclY9vh4GurUkoybzIfQpQS6ELAz0ygGrEDbtuEhEBgTlJVJCB3ih0JrISpKvqqB9xrU+qJE/0e3NuKdTC9EZLeCdqjsGSfbmo62wpMgByHLZQ9nhBe2L+7OP86lDdROBk18SpKvqqB9xrVGrnbqhyMzOU8lpLKAAScKVtG4k+Jzmo+2wpUgJchS2kv54b7/Yv7s4pRbdFK1Tqu6z1ymoC3XEBlpCVpCuVLKQST58msO+s3aDGhxrnuShIUWfXBODjIyD7BSi24qEgDJ4FaZUtfyaQdys+lq8f6grnb0TXbDdHGZGyO0Wy6nnK8kgDPlzSi24wcjIr4VJBwVAH2mtN2a+zLW1JQw6rDje1IJyEqyPWHtxmlutdyvYkPxyXS3ytS3OSfvpRbctK1ppuVeLQxKdebdXDSypQC1AhKgOD1z14486gVP3C8SVqelblj1vpXQgD2DJx9wpRbdNK1po2VeI10ZaU3KdhLVsWFJKkp/rA+FbLpMKUpSoFKUoFKUoFKUoFKUoFUbXOm5c6aJ0BAdJQEuN5wePEZ9lXmlBp1NhvklSGlQ5RCeE95wlI9meKzr5pmfFbgssR3ZCg0S4ppJUAoqPH4YralKtpSu6CivxLD3UplbLneqO1acHHFVjUul7ixdXZlsbW62tfeJLZ9dCic9Pf5VsmlLVqmPp2+XiaFzkPIzgKekHkD2A8muOorDP+OJAiQZDjCdqUKS2SCAkD/lW2KUtKa4nQNRR+5cgofLCo7ILYIUAQ2kEFB8cjyqGFgvU+UVKguIWs8qUgNpH+Q/CtwUpZTXN0tmo4Uj/ZFOvsd2hJ2kLSSEAH1T7R5VDI09ep8oqVBcQtRyVLQG0j7uB+FbfpSymttUaUuHetyIyTKJbQl3b9bcEgE48QcVFzNO3n0WM86xIeW5uHd4KlNpGMZ8s5PHsrbtKWU1MqzXL5Poa9Bk96JSlbe7OcbAM1nWe1T2tMXxlyG+l13utiCg5VhXOBWy6UsajtOmLhLkOMvxXo4LZKXHEEJCh0BrqXYL5EWttMSSN3Ci1yFD3itw0pZTXWmdISll9y5JLCFNKbQnIKsqGM49lRarFf7RLX6I0/kgp7yPyFD7v+dbZpSxrzSWnrqLk3LnKejsoVvKVLO5w+0eXnmsE2fUXx/v2v993mfSN3qYz1z5eyto0palKUqBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlU7UVylWu5TobT6+9ubKPi/cchD24Nrx7BubXj+0aC40qpxrxPbDTxVGXBTN+L+5UFGQSHO73le7BORuxt+rzmum23ea/3cO2iJF2NOyFrlb3AoB5aNoO4H+Lkkk4yOKtJa5UqE09NEyRcHNiM/QqKm3S4lW5pKvVzxjnwAz1qJTqS4NWVN3kfF6o78VchqMCpDqMJ3BJJJCsfxiAMe2lFrjSqlNvl1twksPegypQZbeaW0hTaBucCNqgVKPjkHPODxxXVNvd9gpvC3vi5bdrSl5ZS2sF5BTuKQN3qEAHn1s8cClFrlSqg5er0pxDjCLeI7lwXBSlaV7gAVAOE5wfq/Vxz5iuhzUl5MwWxiPHcnodeS48hvKClAbIwhTiTkh0fxjjB60otdqVUEX28TGmfRGoLDvoSpTne5dTuSop2pKFYwcZzk48jTTFwuVx1DNdclsegrjxn0Ri0rcgLQojB34z5nbzjwpRa30qqyb3c0XCeptMQQYc5iIpKkKLjgcDWSFbsAgueRzjHHWuqLqK4LRAluJiGLPdcZajoQrvWilKyCo7sK+pggAYz1OKUWt9KqS9STVQ7WqKxHeky7aZhaCtuV5ZAAyen0iuCecAZqTsVxk3KBMC1tomsuFo7o62whW0EbkKOfEdFYI8aUWmqVR7Hc758T6ebMmDJfncKeW0sFtKWyo59c7lZGOo613s6mmKuJQRHciuokFlSGlp5b6eso+uOOcJAB8TSi1xpVNTf7022yl2PEfkSoaJbKGUlOz10JWk7leuQFgjBTnGKj570rUE2wtuOQVoRNebeZfhOY3paUr1kKWMHB468kHPhSi2wqVVmL5PU6zJV6IYLs5cJMdKFd8khakbt27B5TkjaMDPPFdMW9XuSxa1BNvacuLziEZQtQaQlCzk+sNxO0ccYz40otb6VSW9T3ViBHuE1iK5HW5IYUwwlXeb2UuncFE4wotH1ccbhycVym6julugvPSPQJLi7c9PY7hKkpQUBPqqyo7gd49YY6HilFrpSqlJvV5iyJMMsxZEpAZcSplsjahzvM+oV5WU934EZB6cc9lyuTk3Qc2YlzD3dLSVNoU0QpKik+qr1kkEHj/OlFrTSqqrUMoahZjJ7hyE5KMTKWlgpUEKUfpCQCcpwUhJx51aqilKUoFKUoFdL8SO+8w6+w046woraWtIJbJBBKT4HBI4867qxZNygxZLUeTMjMyHf4Npx1KVL9wJyaD4LZBE4zRDjiWf/jd2N/TH1uvTiuEmz2yU021Jt8R5pslSELZSoJJOSQCOMnrXJy629ovd5Oio7gZd3OpHdjOMq54545rim5sPCGuGtqSxJWUh5t5BSMJJyOfW6YwM/pQZTTDLKlqaaQhS8bilIG7AwM/cMVjM2m3MSXZDMCK2+6CHHEtJClg9cnHOaN3a3ONPONz4im2eHFJeSQj3nPFfHbzbGozUh24w0R3ThtxTyQlZ9hzg0H2PabdGZW1HgxWmlkKUhDSQFEHIJAHga7nYcZ1L6XY7SxITteCkA94MYwrzGPOuqRdbfHfbZkTorTzhAQ2t1KVKz0wCec19FygmcYQmRjMAyWO9T3mP7Oc0HYIcYBIEdoBLhdA2DhZySr38nn210S7RbZiFolwIr6Vr71QcaSoFeMbjkdcADPlXOLcoMyQ6xEmxn32uHG23UqUj3gHiki5wY0tqLImxmpLv8G0t1KVr9wJyaI7EQ4zYSG47SQlvuhhAGEfZ93sri3b4bTzTzcVhDrTYabWlsBSEDokHwHsrj8ZwPTRD9NjelkkBjvU7yQMn1c56Un3KDby2J8yNGLhwjvnUo3H2ZPNFdhhxld7mO0e9Wl1eUD11jGFHzI2p59g8q62bbBZlrlMw46JK87nUtgLVnrk9a5qnREqWlUlgKQpKFArGQpX1QfacjA8c11s3W3vS/RWZ0VyTz9El1JXx14znig4Istrb37LdDTvSUqwykbgSCQeOhIH4VkQ4caE0W4cdphsncUtoCQT58Vixr3b5MmWyzKYWYgy6oOoIT55wcjHjkD/OuTV0jvPKDTrK46W1LU+l5BSkg4IIznjxPSiO1i3QmFhbESO2oLLgKGwDuIwVceJHjXULPbAsrFviBRUV5DKc7jnJ6deT+Jr6zeLa9EVKZuERyMlQQXUvJKAo+Gc4zyK+G82tMJMw3GGIalbQ+X07CfLdnGaDtetsJ5CUvRI7iUt90ApsEBGQdvuykcewUYt8OOloMRGGwyoqbCGwNhIIJHkSCfxrhJu1uipYVJnxGUv8tFx5KQ5/ZyefurIlSWIjBelPNssjqtxQSkfeaK6U2yCiaZiYccSz1eDY3njH1uvSuxEOMgMhEdpIYJLWEAbMgg7fLgn8a6BdI5cSoOMmIWS96T3yNmM48849vSuCb7aVBBTdIJC192kiQj1l8eqOevI49tEZKYUVCW0pjspS2tTqAED1VqzlQ8idysn2nzrpas9tZafbat8RDb6drqUspAcHkoY5HJrkq629MtMRU6KJSjtSyXU7yfIJzmsVjUFvVATLlyGYTSnnGE+kOpRuUhakHBJ/q5oMyTboUorMmIw8VhIUVthWQnJT18txx7zXIQooh+iCMyIuNvchA2Y8sdK7gtJb3hQ2Yzuzxjzqq23WTM+Y0hkQ1xnJbkYONSwtSAhLp3rSE4SD3XHPIOfCqJ9dpty31PLgxVPKUFqWWk7iodDnHXgc1m1hSriy1GDjK2n1qb71tCXUp3oyBuBJxj1hz7R510XO+wLepTS5LK5QUgejpcT3nrKCQduc45zUVKUrEauUF2cuE1NjLmIGVMJdSVp96c5FZdApSlAqs3GzzjPua4jNvks3ANhZllX0W1O3ASEnenxxlPJPnVmpQVZenHkR1LYEYyhc1T9qiQh4EqASs4zkJI8DgpFcBp2Y5MblPeioUuauU6whSihIMZTIAOBuJOCTgdT99spVtKUtjTM5Md5lxLRjhLQYYMtZLakKJyl3YFgDjAO7pX06evC2GW3ZDCxtfQtW4JWAsgpBWGwVDA5A254yTirnkUpZSlJ0tNXZrkw76KJcm2Mwm1hZIC20rGSducZUD086zmLNPZdXGDUBcRUtyV6S4pReTvUpWAnbgKG7aFbug6eFWelLKU/S2mZNrlwTJbYCIMdTCHUy3nFOZwM7FYSgEDJHrc48q43rS8qXdbg62hl6PPU2panZbzfdbUpSQEI4X9XI5HJNXKlLKVh7Tz6vSlNlgOu3VmcFZOdiC3kE464Qoff1rhqSwSp12XNittPh2KIqm3ZbrARhSjn1AdwO7kHH1RzVqrClW5uS8XFuvpJ4whwgVz1Ms8YvCLn96WIieavp01JRebbObMbbAabjobKlHvEBJClqJydycnbnPVWT63EfZLLPl25hhTEWNGRcJEn0hKlB7+Fc6J24BOcFW7p4c1aviZn+Xk/mmnxMz/LyfzTXDjbT5cd3s1u4dfRVoGkJrML0ZxEZJZt7sNp4THnN5UkJzsV6qE8ZI9bnGOnMjedLrmxVRoymmGRBTGSlJKRuS4lYHHRJ24OOcGpj4mZ/l5P5pp8TM/y8n800420+XHd7G5h19FeRpeU8l9b7MZpx2REWpHpTsjchl0LOVLHXGQAEj2nyyXLDOYvj9zipivEyHFtx3XChO1bTKSchJwoFo+B4UeamPiZn+Xk/mmnxMz/LyfzTTjbT5cd3sbuHX0VmZpae4tTqWIC1PxRHcZRJejtNeutXAQPXB7zkHGdvhnieu9oVJtMKKyhLi4qkKQS+topKUkZCxuOefHORnNZHxMz/AC8n800+Jmf5eT+aacbafLju9l3cOvor72mLhJtq2JT0d1xcN2Moq6EqdChnCQD6vBOBk845rLumm1yl6jWymMlVxgojNE8bVpDgyrjgesnpnp7KlfiZn+Xk/mmnxMz/AC8n800420+XHd7G7h19FZjWifLXd46I8NDD9yDy5K1KDqdmw5CduFH1eDkYz7Ofq9Kzm3I8hsMyHW/SkFoy3WEgOvFwEKQCTxgEEffxzZfiZn+Xk/mmnxMz/LyfzTTjbT5cd3sm5h19HGwRX7dEj25bLYjRozaUuocUdy+QpICskAYTgknr7KjDp2QpmC2pbIDM6VIcIJ+o6HgnHHUd6nPuNSvxMz/LyfzTT4mZ/l5P5ppxdp8uO72Xdw6+iur07dn4sdh8wkCPbjCSUOKVvVuaO4+qMDDZ456+Ndk3TtwcRMitIgrYfuDc4SHFq7wYcSsp27eoCdoOemOKnviZn+Xk/mmnxMz/AC8n800420+XHd7Ju4dfRXrRpaVDuUUupZXHjSXZKZBlvFaivf8A/C4Sk+vgnJBweOeLpUc3aWm3ErD0glJzgukipGu2nnqZf1Ma/wA3/wAhJiI5FKUrohVH1NqC4w7vPaYkMxW4bba20O7MSCoZ5yd2M+qNgzkHrwKvFRkwvqlBQtTcjuzlt1TiQR7sjIrnqa2OjG9lEz+0TP8AqJWMJy+EIayuOp1neGZN2WVK7txuEvuxlBQOUjG7APGR99YM/UE9qZfVouUZBt0ptpmCWxufCkIO0nOcqKiE48euelWb0q4bt3xUN3TPfp/9qwYsV+PLkyRZwt597vypb6CUK2JT6pxwMIFcPH6XTLsz/i3wcusfWPur/wAYOx5BmxozPfx2LspDTaMBakPoAyB1Jxz5nNfb7PnO2O9Ro16E0C2rlelRkIBaP2OMjChkjxG08mrWl+alQKbQgEZ5D6fE5Ph418admMpUGrM2gKOSEvIGT+FPH6XTLsz/AIpwcusfWPuq9+1HIgQHHbbd0zxFiGWXEoZKXfWUAFKBAI9UjCBnjk9K6XrpJhTtUy4VxjoUxKbdbiFAUZJLDWE56+twE7fHz6VbVLlrKSuytKKQQkl5BwD1A4r4DJCkqFkZCk8pPeoyOMcceQH4U8fpfLl2Z/xODl1j6x91YVdJkRLUaM8IiJM2ctb52ZBS7wgbztyck+PCT7xadN3T4wtsQyX46pjjRcKWlfXSFEBYHkfvHPU18dVKdbLbtlaW2TuKVOoIJ88YrJhLkLfy/b0RwEbQ4HEqOPLjwrWG2aecxjEZXPXHKPWYonSyxi5mPrH3Z9KUr0sFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKVBtassrurXtMomZvTTXfrj90vhGAc7sbeih40E5SsGJeLZMmOxIlxhvy2v4Rlp9Klo96Qciqqe1bRib25aV3kInNyTDWlcd1KUuhRTtKynb1B8ccUF4pUab/ZxIkMG6wA/HSVvNmQjc0kdSoZyAPM1gzta6YgxDJk3+1pZDXfAiShRUjONyQCSRnjjxoLBSqlp7tH0jqESja75FWIqC693u5nYgdVHeB6vI56c1Nx79Z5DTrse6wHW2kJccWiQhQQlQyFEg8Aggg0ElSsCLerXLgPTotyhPwmQS7IbfSptAAySpQOBgc81GT9b6ZhWqRcXb3BciMNh1xcd0PkIKtm7ajJI3HGQOtBYqVGfKC0BURDlzhtOS0JcYbdeShbiVDIwkkE591fF6hsqJT0ZV2t4kspUtxn0lG9CUglRKc5AABJ91BKUqvad1pp/UVjkXm1XJpdsjuFp2Q8lTKUKABOd4GBhQ56c1nx79aJLLzse6wHWmEBx1aJCFJbSRkKUQeARzk0ElSopjUljkB8sXm2u9wkLe2SkK7tJ6FWDwDnqa5ov9nctjlybutvVbmzhcoSEFpB4GCvOB1Hj4igkqVDfKvT2HT8fWnDTaXnD6Y36iFbdqjzwk7k4PQ7h5isy3Xe23MrFtuESWUJSpQYeS5tChlJOD0I5HnQZtKjFagsyTKCrtbwYgzIzJR9COmV8+r99YcjWemmIkqSq+21bcVgynQ1IS4pLQA9bakkkcjGBzkY6ign6VRW+1XSr79saiS3pHxlHekx1IYUApDRWFZ3YIOW1gZHOKzbD2haevGkvlIJZhWkOlkuzAG8KBx5nxNBbaVgTrzbIEVmTPuMOLGex3br7yW0ryMjBJweKxFapsqb2LSqe2Jxh+n7cHZ3G7bv3424yPOgmqVGtX+zuwHJzV1gLhNnauQmQgtpPkVZwKiZuv9LQ7jaoLl5iuSbo4G4iY5LwcUVBI5QCE8kDJIHXyNBaKVWHdbWlrXSdJuekC6KjmTuKB3QRgnlWfIHwqUg6hss+WmLBu9ukyVJK0ssyULWUjqQkHOPbQSdKUoFKUoFatn9nt7V2xq1hb7pEYhPNIYfYUglxTYQlKgDjAJKRzW0q1zrTtTj6Y1S3ZFWW4S3FJQe+QpCEEq6JSVEblewc0ED2Zdj0vR2rm7o/coUmNHQ6hotxyl53fnlxRPgD4eQqGX2IXhOsLlfmLrbd8i6+nNNPMFxIbK1qIIUCN4ynB99W5/tci/KeXaItluTzMeWqAuchILaXx1BTnO0Hxqs6Z7cXPkZAuF8typl0nTH47LEIBtJS2lCiSVK8lj30RkaQ7E3rJq4zplwhS7aPSODHPpDodSUlK1E44BPI9vnUNbPg8vIs97iXG8suPvtoagPIQohlKXCshQOOpx09tT117fbZAWwFWG5KDkMTCFKShSAVFJBB9o6+PFSV07aLdFdhIg2S6XAvQWrg73ITllpwgJyCeTyOB50FMi9il4stl1LOkTWLjc37QbfFjQ2ykKwhCQSVY5wgffk1z072IXJWn3nJcm3x5cu1sRRFVGKUhW9Di++KVZUoFJTuHsPhV2Z7Y7ZI1emyRLTcnm/SkwlyglICHVeaM7sA9T7DXLX/a/btH3idblWqdPdgsNvSFtFKUN71AJBJ/tDnHiB7g4aM7Np1h7NtRadkTIC5d0aebQ4wyW2297WxOfFWPM8++q1oPsOfsOobTMu79qnwY8R2PKjFkqD6lLcUCQoYONyOv2fdUlcu3e3QXJaF2WWsx7dGuJw6n1kvBkhPTqO/H901IaI7R5upO1GbYywy1a02hi4sjb9KFOIZXhSs4P8Ljp4UEVrfsYkX7W7l5hXCCzDkdwFsvRipbCW0hOGsHABAHHFduluyObau0V/UEqVaVwlrfWWmoxLjneBQ5KidvC+dvB8ua72+3SzuuSSi03H0YMyXYshW0JldwkqWBzlPA4zWVE7YY7ukGL+/p+5NMzJKIkFoKQpUpxRUMJOcADYeTQQ9t7NLxpXsg1fpxl9q5uTSt2IhhJSskpSnBzxn1R+tQdh7C7g/pqV6bcI8CXNtTEVDLMfbsWFIdV32D6ytydpI8OfZVihdvVrlNp2WO5GSuYqI3HSpBWranKldQBgEce2uDHb3b3rbZ5iLFOV8ZTXYSG0uo3JUgNc84Bz3w/CgibZ2H3WLD1K07OsyzdW2UobQwtDSChwLI2gggcYGDmrHZuymZG7Jb1pKXcIQlXB3vUvR4+1CMFBSCOCr6gyTzz44qItPbcu/6x01FtUPubXObeMpt5G55K0BZwkhWOiR4eNSMbt2ti4VzlSrFc4zMJsLwtTZWslaUJSU5ykkqzzxgGgrLPYRe0xr227eLctU+1x4DakoWAgtLjnJHPGGCPeRwKtnZZ2WTtGapmXJ+bEcjSLY1C7qOlST3iUthS+RjkoUfP1qselO0BOo9OXm5MWacxItgVviulOXSElWEKGQc4I99U2J8IKyyYz0hFonlplhDiyhSSQ6te1LXlk9c56A0ETC7AJTSpqHb5GDXor8dhxqMUuOlwkhT5z62M/oPKsnSHYjcrVNu6rndYLzE+yrtQ7ppW5CilCQvB4ONmevl0rM1Z21PxNDvXmy2ctzotyFulxp/IZVtUr+Irnpj8asNn7U27lrCZYGbLLWYIC5UtC0lttGzcV464zgePWgplh7E75An2F2Tdrc41a4kmKkIQsFQd74g9PAvH8KuWiNC3vSfZobBEl2p65CQp1LslhTjG0qBwU8HOBXPQPaxB1lfU2+JaLjGbdbW6xJdCShaUkg52k7TwevlUez20w1OaicdsVwTAsa1tyZSVoUncFFCABwcqUMD9aDI7VuzifrN6yS4k23okwGnGnGZccuML3pAKgnwIIyM+zyrKufZhEndm/yd7yK1dBDRE+M0Rkhe1Lgc2DxCCofVz0NRP/TZFGm5t3c09cm2ob7LbyVKRjY6DtWFDg9ACPaK4r7cbb8UtTmbNOeEqa7DhIStI9I7sAqWCcAJ9ZP3n2UVDx+xS4t6MuVqXNsypMyWy/sEZaWQltK0gcEK3HfnPsx41yZ7FbnHh6SdZulsTcrLOVLcUmL3bbgKm1Aer1I7vxAzk1m3Tt7tsBcIGw3JXpMIzdqlJQpAClpIIP8A3ZOfIiu28du9rtyomy0THkSbam4pV3iUkJORtI8+KIz9V9mMy/dok2/C4ssQ5NqctxQEkuoK21I3Dw43Z61EdmHZBc9Ia2i3uXPtrrLUMxi1FZU2ScABR8CTjJPiTW1dKXpvUWnLdd2WlMomsJfS0ogqQFDODUrRSlKUClKUCqnfezvSl+vqbzd7O1JuKdv0qnFgHb0ykK2nGPEVbKUFTe7OdJvaiXfXLKwq6rUXFPbl8q+1tzt3e3Gc81jHss0WbE3Z1WNpVvbeU+hsvOFSVqACiF7twyEjjOOKutKCjy+yjRUso76xN4RHEVIQ+6gBoHO3CVAdec9fbXbcOy/Rtw+L/TbEw96AymPH3OOeq2n6qVet6wH9bNXOlBVF9nmk16ibvqrJG+NG1BxLw3ABQ6K2g7SR54qO7S+zCya6ivLkNoi3daEtouCUFS0JCwrG3ICuARz0yavlKCgnsm0lLt8Jm8WtufKYgswVyStbSnUtJSASEqGD6g9uOM4qbsuidPWS9qu9st4YuKoqIRe75xWWUJQlKcFRHAbQM4zx161Y6UFPHZno5MufJTYYyX5za2n1JKhlKwQsJwfVyCeU4PNYmquzS1XjQDWk7ctVrt7DgcZKU98UHcVH65J5Kj45+7ir3Sg1jpTsW0xZ7AbbdWfjlSpPpZdfT3eF4wAkJPCceGTnxqXY7KdFx2IDLNlCW4EhUqMPSXj3bqtmVfX5/g0cHI499XelBSLX2VaMtcuLJg2VLT0YLDSjIdVt3ghXBWQcgnrX239lWibezNai2COG5rfdPha1ubk5CsDco7eQDxjoKu1KCE0rpSyaUguw9P29uHHdXvcCVKUVq6ZKlEk/jUVA7M9HwbdcoEaxsJiXEpVJbUtawspJKcblHbgk4xirhSgqg7O9JjTS9PiyxxaVuB1TIUoErHRW/O7PtznHFd2nNDad05NkS7NbUx5EhlMd1XeuL3NpAAThSiOgFWWlBV9O6A0vpy7vXOy2ePEnOgpU4gqOAeoSCSE/cBXODoXTcFi8sx7W33N4X3k5C1rcS8rJOSFE45UemKstKCowOzbSUCx3G0RLKy3b7hj0pvvFkuYORlRVuGDyMHivsjs40lJ05EsT9mZXa4ilLYaK15bKiSSF7t3OfOrbSgpEnsp0VJLHe2Nv6CMYjYQ86gJaO4lOAoZ5Wrnrz1r7P7K9Fz2IjUuxtOIiRxFZ+mdBS0DkJyFZPU8nJ5q7UoK/p/Rtg09NMuz28RpBjoib+9Wr6JGAlPrE9MDnrxVgpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpXxxaW0KW4oJQkZKlHAA8zQfaVpXWnwhdOWWS5Fssd68voOFONqDbIPsUQSr7hj21TFfCdm5O3TEfHhmYr9yg9O0rzF852d/RiN/i1fu0+c7O/oxG/xav3aD07SvMXznZ39GI3+LV+7T5zs7+jEb/Fq/doPTtK8xfOdnf0Yjf4tX7tPnOzv6MRv8Wr92g9O0rzF852d/RiN/i1fu0+c7O/oxG/xav3aD07SvMXznZ39GI3+LV+7T5zs7+jEb/Fq/doPTtK8xfOdnf0Yjf4tX7tPnOzv6MRv8Wr92g9O0rzF852d/RiN/i1fu0+c7O/oxG/xav3aD07SvMXznZ39GI3+LV+7T5zs7+jEb/Fq/doPTtK8xfOdnf0Yjf4tX7tPnOzv6MRv8Wr92g9O0rzK18J2VvHfaYZ2eO2Yc/wDorZ3Z72zaZ1lIbhJW5bbovhMaVjDh8kLHB93B9lBsylKUClKUClKUClKUCvOvwqddyIaWNJWx4t9+2HpykHkoJ9Vv78En2Y869FZrw/8ACHW4rtfv3eeCmgn3d0jFBrmlfM1aey6TFidoFkkXBxlqK2/ucW8oJQBtPUngffRFXpW6nxpHUepHJNzfiOoTbYxipckttqfUSe9LygppIcTkjGRkAHB6VC2a16HMhyPKUy83IvEiG3IdnbDHjBtJQ7gEA+sThR4PP3Bq+lXq723TrWmIT0L0NSlMsKcli4Zk96SO9QY/PCecHCeADuOcVYpVk0K3PZ3qhIjpXJ7pLF07z0phMdam3HDn6JwuBA28ZKiNvHIajpW37avSzdtvbECFaFOXC0RpKWJNxKEtu94O8ZStSxgjbvwTu8ORxUVabfot6bpyHMDKA7blSpcj0w4XIwvayr1glsZCc8pPPUZzQa1pWybtA0bb3tSusNsy/R40Yw4/p3q98s4cCShR3hPXAUrHmaxtB2TTt0ttvfu0mCytubITNTImhlSme5QWdqSoE/Sb+U/fxQa/pWwG4GlF6PSkhhN3VaVTDJ9MO4SEyCkNd3nGSjnGM9CPb90dZNOT9IS3LrIhN3R0SRHW5ODa21oaCmgUFQAClZGSFA9MpxyGvqVtF+36NXqO7xbdGguohsNiIiRdC2zLWSkuKLu4AFIJwkEZx4mu/To0ou1JtF1EJUZ+/utpX6dgxmSykB0LwkqSCOCoBJ54oNUFJTjIIyMjNfK3DZpllU3Ihum23F5/TUZDZn3EtoS6lxBUyFlaQjgE4yCNuB1IOE7ZNB/Je2PqmhDznopffbkJLoUpYD6S1vJwkFWD3Y6D1lZ5DVdK2xZzp2ydo9idVDszUJTriFFu6GS0lPRDqznCTyeCrHmlOOVtsmjHrRc3boYUa4JdfCmo9wStMdKWwWy0ou/SblZ6Bzy9XrQanpX1sp7xPeZ2ZG7b1x7Kvqjpj5Bzd/xhv7w/F3fd13nfcbvq893jGc+OMc5oKDX1tam1pW2opWkgpUk4II8RXHNM0Htn4P8Arh7Wmix8YL33S3rEeQs9XBjKF/eOD7Qa2dXlz4Hy3RftRJH8AYzRV/a3HH6FVeos0V9pXzNM0H2lfM0zQfaV8zX3NBwJrzP8KzRbxmR9WwGitkoTHm7RnYR9RZ9hB259g869JFVdEpluVHcjyWUvMOpKFtrTuSoHqCD1FB+c9K9Qa0+DtAnynJOmJyrdvyTFeQXGwf6quoHs5qlL+DjqwKO242Up8CXHR/8A50RpSlbp+bjq39oWT817/Tp83HVv7Qsn5r3+nQaWpW6fm46t/aFk/Ne/06fNx1b+0LJ+a9/p0GlqVun5uOrf2hZPzXv9OnzcdW/tCyfmvf6dBpalbp+bjq39oWT817/Tp83HVv7Qsn5r3+nQaWpW6fm46t/aFk/Ne/06fNx1b+0LJ+a9/p0GlqVun5uOrf2hZPzXv9OnzcdW/tCyfmvf6dBpalbp+bjq39oWT817/Tp83HVv7Qsn5r3+nQaWpW6fm46t/aFk/Ne/06fNx1b+0LJ+a9/p0GlqVun5uOrf2hZPzXv9OnzcdW/tCyfmvf6dBpag5OB1rdrHwcNUKcAfudoQjxKFOqP4FA/zraHZ32H2XS0tq4XNa7vcWzubU43tabPgQjnJ9pP3UGb8HLRr2k9GLlXFotXG6KDzjahhTbYHqJPt5J/8WK2xvrGyr7J/CmVfZP4UVk76b6xsq+yfwr7uV9k/hQZG+m+sbcr7J/CuuXMYgQJE6aVpjMJ3OFKSopHicDnA60GeFZr7msC3z4tyhomW9wuRVqUlLmCAvBIynzGRweh6isrdQdrSAlIJ61zpSgUpSgUpWJcZ7cFtKnASVdAKxqamOljOec1ELjjOU1DLpWJCntSmC4g42jJT4gf/AIKh7HrOy3ncYz7rQEdMoGUypkKaUcBaSoAFOfEVcM8c43sZuCYmJqVjpWOmdEUtpCZLBW6nc2kODKx5jzFdLt4trLYcduMNDZUUblPJA3DqM56jyrSM6ldDkyM2VByQygpCVEKWBgKOAfvPArh8Ywtjy/TI2xk7XFd6nCD5K54++gyqV0uyo7LAfdfaQycYcUsBJz05rg3cIbm3u5cdW4hI2uA5JGQBz4jmgyaVi/GUHukuemxu7UvuwrvU4KvLOevsrCj6ktUma5FjzEOOtuONObejamwCoKPhjIoJelYarrb0tNuKnxA259RZeThXOODnnkj8a7mpUd15xlp9pbrf10JWCpPvHhQd1KwoV0izVzEMLyuI4W3UnqCBnPu5/wA/Kom1azs10kxmIj7pXIz3e9pSQcNB3qR9lQP6UFjpUXpy/wBu1HbjOtD/AH8YOKbKtpSQodeDz5H3EVKUClQF31dabTOciy3Xt7IQqQttha0R0q+qXFAYSD7fDnpUsZ8RKnUqlMAsp3OAuD1B5nyFBk0qL+P7Z8ZtQPTGvSHWQ+36w2rQVbRtV0Jz4CuVxv1qt0d56ZPjNtsrS24SsHYpRwAQOmSaCSria63ZcZpSkuyGUFIClBSwMAnAJ954FdSZ8NZUES46ilYbUA4DhR6JPPX2UHeqsK6QUXO3SYDzzzLUhOxa2VBKtviASDjI48+eMV2pnQ3HG20So6nHM7EhwEqwcHA8cEGu4igjbVbY9jtbVthOOqjNE90lxQV3SM5CAcfVHQZyceNZma4SeHE+6vmaCQpSlApSlAqKvlrVPbKkLw4keqD0qVqpTNbx2bxcbcxAmSHISVhTiNoQpaWw4UZJ49Ujk4GeM1x2jQw2jTnS1IuJb088tPKMsecJHT1rehRpCZBAU7xgHOOv/vUBF7NrdC0zEt8IsonsCOVTFs7w8pogjegq+qSCdoI/SutHadBct8aezbZzsN+O9LC0lvKWG1pQpZBV7c4611Ru0FxE15uVH74d4+0y0wjCnFJmejtjcpWBnIzn2n2VnZdmw2XSx0dPlC6uplq5znlzl9Z7NyzNt8hq6d2WMl7u2CkuZccWUpG/alOXCACklI6GsNPZa8i0sQEXWIW0OtrdDsFTiX0tpwhKgXfvOCAcAYwKl0dosIsOuLgy21NIK1IUUZGJJjkcHGdwz7qk9NaviagemJixZTbbCStDriRtdSFKTkEE4OUng4OCK9Dm+X3SbV4vVouD0ktmHgPtIR6skJIWgHngJWkKHXxHjVdT2YhMJ1j4xaJS22ywoRighKHCsKcKVhSnMnG8FPjxyazIPaRHmNxw3aJ4kygwqMwVN5eDqVqSc7sDAaX1I6DzrHY7Su/mOCPZ5L0VfozcfatAcW48VjaoE4GCgjOccHnpQSk/R70jTdlt6bg25JtiwtLsiMFtukIUghTeR4KOOeCB1qvWXs2lptlubmXERtiI632ENblBxthTXquBWAMKz0PIq2aa1fFv8+VGjxJTQYCyHXEjYvYsoVggnBBHQ4yOah2e0qHJeLES2TXnzIbYbQlbWHN6XFJUFbtuPolePlQRyuy1XxM1ERc2W5KF59IRHcBx3aW+ne9cJGc5SehTWXN7NvTH5xdugSzIckOAJjgKBeSgHcd2CAUdMDIJFZEbtKt8gtragTfRVBkF87AEKdQVISRuzngjIBGfZX2J2jRnkRnHbTPZadbYecWpTZDSH17GlEBWTk+ABwKDFkdmiJTcoyZ7PfSWpSFd3ECW0LeQ2nchG71cBsHGeSonIqW03o9dl1LNuaZ4WzISsejpbIG5SgoqJKiM5B+qE5zk5NYU3XbzkSDJtlqfW1JmtsN96pvMhtSlpJQN+UnKP42Otd9n7Q7fdrlDhxYU7L6UFaylJDKlhRCVYOf4p5GRyOaDnpLRr1hulymvXISlTGg1gMlGMLWoE+sRn1yMAAcdK6JmhHXbFZbfGuxju22K7GD4YyVhxvuyoDd6pAzjk1L6u1TH0wIapcWS83IUUlxsAIaAxytRICevGeODURN7RoEW4TYghSnlxsBKmlNqS6e9Q0QDu4IUscHHj0oMzTGi2dPG4sxbhLct8xttPcrVtW2tCdm5K04IykIHA42jmpJvTcNtxK0ybqSkggKuT5H3gr5qDY7Q4a50CK9bpsdcl5cdS3NgbbcS6popK92CcpzgHoRjJ4rNumso9u1Au2OwpKktqjockpKNiC8SlGQTuPIxwDQdF+0a9cZl2VFufosO7toanslgLUoJG3LasjYSng5CvOsF3s9K0z2kT4yY7z5ks7oSVOJWXku7XFlWVoygDb6uU8HoDWLYu0Z+WG0yLW48p5mH6P3CkpLzjzRcIwpWEgBJ6k9OpyKkbbrdx7UztulwHUR3JDUdh5JQdi1x+92rwo5PChlOR05oIuR2Xl5zd8aMp71CkPgQhgbn++V3XrfR88DrjrzXY/2Z72n0ouTQUN3o6jFGRmQl8l47vpDlAAPq4BPnWXf+0BFtvQjphuiBGkOszJSgkj6OMp5QQArdkAJ5Ix1qUi6wZkaan3j4vmNohHLrKgncU4CipJBIUAlWeD4EdaDnqDSjN6vlquLshTfoh+maSjIkpCgtCVc8BK0hQ6+I8arzHZquOhss3RtL0Ys+jLETAw273gLuFfSKJ43ZT4+ZqQR2iW92fHjMwpryXlkJdbSlQ7vvS0HMZyUlSVdM8DPlWC/2klxmOYNmkFx5yPsDziAFtuPFoqGD1BSRg46g9KBa+zpy33O1TEXVJVDUVOlLBSXsuOLxjeUgfSEZKSRjgjNbCqvaU1ZF1K5JESNKZQ0ApDjqRtdSVKTkEE4OUng84Iqx4oMGX/DJ91cK7Jv8Mn3VwoJClcGXA4gHx8a50ClKUCouVp6zypb8qTbYjsh9BbdcW0CVpIwQfPjj3cVKUoK3J0TYJNyZmO26Oe6SsBju090VLUlRWU4+tlI/Ws9/TtmfQ8l62RFh4KDmWh625feKz71+t7+alaUFdg6LsMSI1HNujvoZW4tsvNpUUb3S4Ujj6oUeB4YFScCzW23vSHYMGOw7IJLqm0AFeSTz95J95NZ9KCJd03ZXY/cOWuGpnYhsILQwEozsA9icnHlmvqdO2dElmQi2REvMpQhtQaA2BBygDyx4eVStKDAhWa2wZUiTDgx2ZEgkuuIQAV5OTn3nn31DzNCadkhhPxaw0228l5SGkBIcKUrSkK45A7xWB4VZ6UFdjaMsTF1cnpt7CnlJQhtKm07WUoRsAQMccGs9en7Qt6G6q2xC5DSlEdRaGWkp+qE+QHh5VJ0oImPpuyxn1vMWuG26t0PqWloAlYJIV78qJ+8+dcDpiyb0rTa4aHENlpC0tJBSk54HH9ZX4nzqZpQRcnT9qlQ4kWXAYkMxUBtkOoCtqcAY58CAM+eK4DTNkEl2QLVD751W5a+6GSdwX/6khXvGal6UEUvTlmXJbkKtkQvtrLiV90MhRVvz79xKvfzXSvS1qd1E5e5EZL85SW0oU6AoNbN2Cnjg+sf0qbpQQjulLA6jY5aIRR3aGtvdDAQj6gHu8PKspix2uOptTFvitltaVoKWgNqko2JI9oT6o9nFSNKCKe07Zn7iue9a4bk1fCnlNJKj6pTyf7JI91d9vtFut0JcSDCYYjLzvaQgBKsjByPHjis6lBFK07ZiYRNsif7EkIj/AEQ+iSCCAnyAIBx5ivj2nLM8wGXLZELQSlAT3Q4SlW8Ae5RJ99S1KCKjads0V1Tke2RG3FOh8qS0Ad4JIV7wVKP3nzqVpQ8daDDmD6ZPurhiuTyg47kdBxXLFB1EFJykkH2V8Lrvgs1kFNcCigxy8/8AbNfO+f8Atqrv7uvnd0HT3z/21U75/wC2qu7u6d3QdPfP/bVTvn/tqru7und0HT3z/wBtVO+f+2qu7u6d3QdPfP8A21U75/7aq7u7p3dB098/9tVO+f8Atqru7usC6T2oCMEb3T9VA/50TLKMYuWSX3gMlwgVhu3lpo4XLGfZz/lVYmzZEsnvV+r9kcCsTZUt48tr+WFuGoI5OPSlf3T/AO1ZTFw9IH0MgL9gIzVH2V9CSDkcHzFLZja8v1hfe+f+2qnfP/bVVatt4dYUEScuNef8Yf8AvVoZKHm0uNKCkK5BFW3r09XHUj4OHfP/AG1U75/7aq7u7r4UADJIA9tHR1d8/wDbVTvn/tqot6Oj677SfeoV0LuMFHWQg+7msznjHOW4088uUO/vn/tqp3z/ANtVYK7zBT0WtXuTWOq/Rx9Vl0+/ArE6+nH6ukbLrTyxlLd8/wDbVXYzIdSv1yVJ8a4RVokx23kDCVjIBrhLkxoTKnpb7TDKeq3FhKR95rpE38YcZiYmpSLr4SgFHJPSsUqcX9ZRIqBj6w01IfDLF/tLjpONiZjZOfdmrE2UrAKSCDyCPGqj4hOK7cVySmueBQfSK4lNdlMUHXsrqkONR2VuvrShtAypSjwKycVE3Qd7ebSwr+D3OPFPgSlIAz7t2feBQcU3QOJ3NQJ60Hoe525+5RB/Svvxiv8AZs/+4n96s+4SUwoEiUtDjiWG1OFDadylADOAPE1EQdSsTNHDUSIc1Ef0dUj0dbWH8Jzxt8+OKDI+MV/s2f8A3E/vU+MV/s2f/cT+9WP8pWPkb8o/Q5vo/o3pPo3c/T4xnbt86k7RNRc7XEnNtOtIktJdS28natIUM4UPA80GJ8Yr/Zs/+4n96nxiv9mz/wC4n96pfFMUER8Yr/Zs/wDuJ/ep8Yr/AGbP/uJ/eqXxTFBCv3J5LSi1a5ynMeqClIyf71VR9i6Puqcdtc1S1HJPqfvVsXFMUctTSjU5tb+h3H9lTf8AyfvU9DuP7Km/+T96tkYpipTn4TBrJ5L0YpEyJJjBRAC3Eerk9BuGQDXLZWxZcduTFeYfQFtOIKVJPiCK1nblqVaYzjiipfcpUSfE7akw82voxp1MEmVGjECQ+22o8gKVgmvjOo2Y30bE9CW1ckJPjV30lAZYssR/YlUmQ0l11wjlSlDPXyGcAeVZSLvbF3xyzolMm5ttB9cYfXCCcBXuqZ4b0VdPbsunGhnGpPx/soC9QsL+tcif/wCw10qu8FRyqYgn2qrYrF3tj96k2hmUyu5Rm0uvRx9ZCVdCf0/GpDYnyH4V552SJ55S+tH4jOPLCGqfjW3/AM6a/Gnxrb/501+NbW2J8h+FNifIfhU8Hj1a/M8/lhqn41t/86a/GnxrA/nTX41tbYnyH4VxWlIB4H4U8Hj1PzPP5Ya21Nr2Bo/QHxotSJDhUpmM0lX8K4ckDPkOpNeRtYauvOrbkuZe5i3iSdjQJDbQ8kp6D/PzrZHwppu/XcWC2lKGWIqXCEjG5aicqPtwEj7q172e6YRqq/OxZElUaHFjOzJLqE7lBttOTtHiTwK9WGO7jEPn6me/lOXVWc1sjsr7Vbtoqcyw+65MsalAOxVqz3YzypvPQ+zof1rD0ExYtQ6pa07Jty0QbiosxZKlgyYzhHqqKkhIWM9QR0PBqmXGGu33KXCdILkd1bKiOhKSQf8AKtMP0Os9wjXW2xp0F1LsWQ2l1taeikkZFZ2K0p8Fi6vTez5yI8oqTBlrabz4JIC8fio1uug+0pSgVA32bHg3y0uy3UtNlD6dyvPCKnqiZ/8AvFaf+7f/APooHyktH8/a/WnyjtH8/Z/WpXI3AZ5NfaCJ+Udo/n7P60+Ulo/n7X61LUoIn5SWj+ftfrT5SWj+ftfrUtSgiflJaP5+1+tPlJaP5+1+tS1KCJ+Ulo/n7X60+Ulo/n7X61LUoIn5SWj+ftfrT5SWj+ftfrUtSgiFajtG0/7e109tUSC4l2xxFIQlKfRUdPH1etbRV9U+6tXQXVrsENClZSiONo8spqS8m18obA06tHyftnrJ/wCrN+P9UV3JhQE3FdwSxHE5bYaU+EjeUA52564qI0/YbSuw21SrdFKjGbJJbHPqis/5P2j9mxPyxVetkNwoDVwenNsR0zXkhDj4SAtaR0BPUgVld4j7afxqN+T9o/ZsT8sU+T9o/ZsT8sUEl3iPtp/GneI+2n8ajfk/aP2bE/LFPk/aP2bE/LFBJd4j7afxri4tG0+un8aj/k/aP2bE/LFDp60Y/wCzYv5YoPMvwrbI41qC23tsbo8hn0ZZHRK0kkfiD/5TWn9J6im6XvKbhbw0tRQppxp5O5DrahhSFDyIr2ZrzRVkvEaDbpEBlDMl9SFKbSEqT9C4QQfMEA/dXmbXPY9qTTcpxUKK5dbfklD0ZBUsD+sgcg+7IoIbSeo7Npy8uX9iC8u4s7lQYZVlhlZGAtSydytueE48smqjIfclSXpD6it11ZWtR8VE5JqRj6dvUh8MsWi4OPE42JjLJ/yrcXZb2HTpc1i46vb9HiIUFphZyt0j7ePqp9nU+yg2f8GuwvWbs8ZdkoKHbg6qUEkchBACfxCc/fW36xYUdLDSUISEoSAEpAwAPKsvFApSlAqJn/7xWn/u3/8A6KUoJJX/AFhH9lX+YrspSgUpSgUpSgUpSgUpSgUpSg+K+qfdWq7d/wBiRv8Ah0/+mlKkvHtnKGxdOf7v2z/hmv8A0ipClKr2FKUoFKUoFKUoIW+/9oWP/jFf/IdrvkAc8ClKDGAGegrNjgeVKUGanpXKlKD/2Q=="
+            }
+          ],
+          "scale": 7665,
+          "type": "filmstrip"
+        }
+      },
+      "bootup-time": {
+        "id": "bootup-time",
+        "title": "Reduce JavaScript execution time",
+        "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to reduce Javascript execution time](https://developer.chrome.com/docs/lighthouse/performance/bootup-time/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "2.2 s",
+        "metricSavings": {
+          "TBT": 850
+        },
+        "details": {
+          "sortedBy": [
+            "total"
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "granularity": 1,
+              "label": "Total CPU Time",
+              "key": "total",
+              "valueType": "ms"
+            },
+            {
+              "valueType": "ms",
+              "key": "scripting",
+              "label": "Script Evaluation",
+              "granularity": 1
+            },
+            {
+              "granularity": 1,
+              "label": "Script Parse",
+              "key": "scriptParseCompile",
+              "valueType": "ms"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "url": "https://www.ocobo.co/fr",
+              "scripting": 17.075999999999997,
+              "total": 1322.0987999999982,
+              "scriptParseCompile": 4.092
+            },
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "total": 856.4891999999993,
+              "scripting": 520.42199999999934,
+              "scriptParseCompile": 18.1116
+            },
+            {
+              "scripting": 343.5491999999993,
+              "total": 656.58359999999936,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "scriptParseCompile": 212.7876
+            },
+            {
+              "scriptParseCompile": 13.850399999999999,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "scripting": 509.08439999999808,
+              "total": 566.64959999999814
+            },
+            {
+              "scriptParseCompile": 203.1276,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "scripting": 229.42199999999946,
+              "total": 438.13559999999944
+            },
+            {
+              "scriptParseCompile": 0,
+              "url": "Unattributable",
+              "scripting": 43.853999999999992,
+              "total": 321.635999999998
+            },
+            {
+              "scriptParseCompile": 14.698800000000002,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "scripting": 45.228,
+              "total": 63.871200000000009
+            },
+            {
+              "scriptParseCompile": 6.3599999999999994,
+              "scripting": 0.5892,
+              "total": 59.9256,
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js"
+            },
+            {
+              "scriptParseCompile": 15.968399999999999,
+              "scripting": 33.062399999999975,
+              "total": 50.611199999999975,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            }
+          ],
+          "summary": {
+            "wastedMs": 2231.2835999999961
+          }
+        },
+        "numericValue": 2231.2835999999961,
+        "numericUnit": "millisecond"
+      },
+      "largest-contentful-paint": {
+        "id": "largest-contentful-paint",
+        "title": "Largest Contentful Paint",
+        "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)",
+        "score": 0.01,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "9.2 s",
+        "numericValue": 9245.8396161220753,
+        "numericUnit": "millisecond"
+      },
+      "third-parties-insight": {
+        "id": "third-parties-insight",
+        "title": "3rd parties",
+        "description": "3rd party code can significantly impact load performance. [Reduce and defer loading of 3rd party code](https://developer.chrome.com/docs/performance/insights/third-parties) to prioritize your page's content.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "mainThreadTime": 562.39100001379848,
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "transferSize": 409446,
+                    "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+                    "mainThreadTime": 407.40000000223517
+                  },
+                  {
+                    "mainThreadTime": 60.630000002682209,
+                    "transferSize": 43670,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+                  },
+                  {
+                    "transferSize": 27964,
+                    "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                    "mainThreadTime": 37.513000000268221
+                  },
+                  {
+                    "transferSize": 29750,
+                    "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+                    "mainThreadTime": 32.058000005781651
+                  },
+                  {
+                    "mainThreadTime": 18.398000005632639,
+                    "transferSize": 27218,
+                    "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+                  },
+                  {
+                    "transferSize": 1646,
+                    "url": "https://js-eu1.hs-scripts.com/27107933.js",
+                    "mainThreadTime": 5.8909999951720238
+                  },
+                  {
+                    "transferSize": 4083,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953",
+                    "mainThreadTime": 0.31000000238418579
+                  },
+                  {
+                    "transferSize": 1095,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+                    "mainThreadTime": 0.19099999964237213
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 1706,
+                    "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Ffr&isMobile=true"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr&t=Ocobo+%C2%B7+Ocobo+%C2%B7+RevOps+%26+Revenue+Experience&cts=1778837286602&vi=22c3cdc0eeec24d104de95e7238b0bcf&nc=true&u=242475741.22c3cdc0eeec24d104de95e7238b0bcf.1778837286589.1778837286589.1778837286589.1&b=242475741.1.1778837286590&cc=15",
+                    "transferSize": 1526
+                  },
+                  {
+                    "transferSize": 1074,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=4730ddc3-b73a-4ce8-b84d-c9d9f13b654c&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Ffr&t=Ocobo+%C2%B7+Ocobo+%C2%B7+RevOps+%26+Revenue+Experience&cts=1778837287350&vi=22c3cdc0eeec24d104de95e7238b0bcf&nc=true&u=242475741.22c3cdc0eeec24d104de95e7238b0bcf.1778837286589.1778837286589.1778837286589.1&b=242475741.1.1778837286590&cc=15",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1024,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 1024,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1"
+                  },
+                  {
+                    "transferSize": 1021,
+                    "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 559,
+                    "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+                    "mainThreadTime": 0
+                  }
+                ]
+              },
+              "entity": "Hubspot",
+              "transferSize": 552806
+            },
+            {
+              "entity": "Google Tag Manager",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+                    "transferSize": 157129,
+                    "mainThreadTime": 361.50300000235438
+                  }
+                ]
+              },
+              "mainThreadTime": 361.50300000235438,
+              "transferSize": 157129
+            },
+            {
+              "transferSize": 7016,
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 5017,
+                    "url": "https://useago.github.io/widgetjs/frame.js",
+                    "mainThreadTime": 9.2870000042021275
+                  },
+                  {
+                    "url": "https://useago.github.io/widgetjs/frame.css",
+                    "transferSize": 1999,
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 9.2870000042021275,
+              "entity": "GitHub"
+            },
+            {
+              "transferSize": 475057,
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 228410,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vizzia-avatar.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 60335,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 29277,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/yousign-white.png"
+                  },
+                  {
+                    "transferSize": 22833,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/jus-mundi-white.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/wecandoo-white.png",
+                    "transferSize": 18633
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 14022,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/combo-white.png"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 11990,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/ekodev-white.png"
+                  },
+                  {
+                    "transferSize": 11481,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qobra-white.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 10978,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/resilience-white.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vibe-co-white.png",
+                    "transferSize": 10155
+                  },
+                  {
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qonto-white.png",
+                    "transferSize": 9979,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/citron-white.png",
+                    "transferSize": 9979,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 9718,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/tomorro-white.png"
+                  },
+                  {
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/steeple-white.png",
+                    "transferSize": 9615,
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 7675,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/qare-white.png",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 5122,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/epack-white.png"
+                  },
+                  {
+                    "transferSize": 4855,
+                    "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vizzia-white.png",
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0,
+              "entity": "vercel-storage.com"
+            },
+            {
+              "entity": "Clearbit",
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+                    "transferSize": 1278
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0,
+              "transferSize": 1278
+            },
+            {
+              "transferSize": 796,
+              "entity": "Google Analytics",
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 796,
+                    "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65d0v9100339653za200zd9100339653&_p=1778837284159&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1157999218.1778837285&frm=0&pscdl=noapi&rcb=4&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616986~115938466~115938469&dp=%2Ffr&sid=1778837284&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Ffr&dt=Ocobo%20%C2%B7%20Ocobo%20%C2%B7%20RevOps%20%26%20Revenue%20Experience&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=3493"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0
+            },
+            {
+              "transferSize": 103931,
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 102672,
+                    "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+                  },
+                  {
+                    "transferSize": 1259,
+                    "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0,
+              "entity": "Google Fonts"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "text",
+              "label": "3rd party",
+              "key": "entity",
+              "subItemsHeading": {
+                "key": "url",
+                "valueType": "url"
+              }
+            },
+            {
+              "label": "Transfer size",
+              "subItemsHeading": {
+                "key": "transferSize"
+              },
+              "granularity": 1,
+              "valueType": "bytes",
+              "key": "transferSize"
+            },
+            {
+              "valueType": "ms",
+              "key": "mainThreadTime",
+              "label": "Main thread time",
+              "granularity": 1,
+              "subItemsHeading": {
+                "key": "mainThreadTime"
+              }
+            }
+          ],
+          "type": "table",
+          "isEntityGrouped": true
+        }
+      },
+      "duplicated-javascript-insight": {
+        "id": "duplicated-javascript-insight",
+        "title": "Duplicated JavaScript",
+        "description": "Remove large, [duplicate JavaScript modules](https://developer.chrome.com/docs/performance/insights/duplicated-javascript) from bundles to reduce unnecessary bytes consumed by network activity.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "headings": [
+            {
+              "valueType": "code",
+              "subItemsHeading": {
+                "key": "url",
+                "valueType": "url"
+              },
+              "label": "Source",
+              "key": "source"
+            },
+            {
+              "granularity": 10,
+              "subItemsHeading": {
+                "key": "sourceTransferBytes"
+              },
+              "label": "Duplicated bytes",
+              "key": "wastedBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 0,
+            "type": "debugdata"
+          }
+        }
+      },
+      "total-byte-weight": {
+        "id": "total-byte-weight",
+        "title": "Avoids enormous network payloads",
+        "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn how to reduce payload sizes](https://developer.chrome.com/docs/lighthouse/performance/total-byte-weight/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Total size was 2,032 KiB",
+        "details": {
+          "sortedBy": [
+            "totalBytes"
+          ],
+          "type": "table",
+          "items": [
+            {
+              "totalBytes": 228410,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/vizzia-avatar.png"
+            },
+            {
+              "totalBytes": 204723,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "totalBytes": 204723,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "totalBytes": 157129
+            },
+            {
+              "totalBytes": 95799,
+              "url": "https://www.ocobo.co/images/partners/aircall.png"
+            },
+            {
+              "totalBytes": 60335,
+              "url": "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com/content/clients/cybelangel-white.png"
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            },
+            {
+              "totalBytes": 50337,
+              "url": "https://www.ocobo.co/images/partners/clay.png"
+            },
+            {
+              "totalBytes": 45262,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js"
+            }
+          ],
+          "headings": [
+            {
+              "valueType": "url",
+              "label": "URL",
+              "key": "url"
+            },
+            {
+              "label": "Transfer Size",
+              "key": "totalBytes",
+              "valueType": "bytes"
+            }
+          ]
+        },
+        "numericValue": 2080423,
+        "numericUnit": "byte"
+      }
+    },
+    "categories": {
+      "performance": {
+        "id": "performance",
+        "title": "Performance",
+        "score": 0.39,
+        "auditRefs": [
+          {
+            "id": "first-contentful-paint",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "FCP"
+          },
+          {
+            "id": "largest-contentful-paint",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "LCP"
+          },
+          {
+            "id": "total-blocking-time",
+            "weight": 30,
+            "group": "metrics",
+            "acronym": "TBT"
+          },
+          {
+            "id": "cumulative-layout-shift",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "CLS"
+          },
+          {
+            "id": "speed-index",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "SI"
+          },
+          {
+            "id": "cache-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "cls-culprits-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "document-latency-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "dom-size-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "duplicated-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "font-display-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "forced-reflow-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "image-delivery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "inp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-discovery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "legacy-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "network-dependency-tree-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "render-blocking-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "third-parties-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "viewport-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "interactive",
+            "weight": 0,
+            "group": "hidden",
+            "acronym": "TTI"
+          },
+          {
+            "id": "max-potential-fid",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "unminified-css",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unminified-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-css-rules",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "total-byte-weight",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "user-timings",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "bootup-time",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "mainthread-work-breakdown",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "long-tasks",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "non-composited-animations",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unsized-images",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "network-requests",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-rtt",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-server-latency",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "main-thread-tasks",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "diagnostics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "metrics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "screenshot-thumbnails",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "final-screenshot",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "script-treemap-data",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "resource-summary",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "redirects",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "server-response-time",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "layout-shifts",
+            "weight": 0,
+            "group": "hidden"
+          }
+        ]
+      }
+    },
+    "categoryGroups": {
+      "a11y-names-labels": {
+        "title": "Names and labels",
+        "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "best-practices-ux": {
+        "title": "User Experience"
+      },
+      "seo-mobile": {
+        "title": "Mobile Friendly",
+        "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn how to make pages mobile-friendly](https://developers.google.com/search/mobile-sites/)."
+      },
+      "best-practices-general": {
+        "title": "General"
+      },
+      "seo-crawl": {
+        "title": "Crawling and Indexing",
+        "description": "To appear in search results, crawlers need access to your app."
+      },
+      "seo-content": {
+        "title": "Content Best Practices",
+        "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+      },
+      "a11y-color-contrast": {
+        "title": "Contrast",
+        "description": "These are opportunities to improve the legibility of your content."
+      },
+      "a11y-tables-lists": {
+        "title": "Tables and lists",
+        "description": "These are opportunities to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "description": "More information about the performance of your application. These numbers don't [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score."
+      },
+      "metrics": {
+        "title": "Metrics"
+      },
+      "a11y-audio-video": {
+        "title": "Audio and video",
+        "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+      },
+      "best-practices-browser-compat": {
+        "title": "Browser Compatibility"
+      },
+      "a11y-language": {
+        "title": "Internationalization and localization",
+        "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      },
+      "insights": {
+        "title": "Insights",
+        "description": "These insights are also available in the Chrome DevTools Performance Panel - [record a trace](https://developer.chrome.com/docs/devtools/performance/reference) to view more detailed information."
+      },
+      "a11y-aria": {
+        "title": "ARIA",
+        "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "a11y-navigation": {
+        "title": "Navigation",
+        "description": "These are opportunities to improve keyboard navigation in your application."
+      },
+      "a11y-best-practices": {
+        "title": "Best practices",
+        "description": "These items highlight common accessibility best practices."
+      },
+      "best-practices-trust-safety": {
+        "title": "Trust and Safety"
+      }
+    },
+    "timing": {
+      "total": 31075.8
+    },
+    "i18n": {
+      "rendererFormattedStrings": {
+        "varianceDisclaimer": "Values are estimated and may vary. The [performance score is calculated](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) directly from these metrics.",
+        "opportunityResourceColumnLabel": "Opportunity",
+        "opportunitySavingsColumnLabel": "Estimated Savings",
+        "errorMissingAuditInfo": "Report error: no audit information",
+        "errorLabel": "Error!",
+        "warningHeader": "Warnings: ",
+        "passedAuditsGroupTitle": "Passed audits",
+        "notApplicableAuditsGroupTitle": "Not applicable",
+        "manualAuditsGroupTitle": "Additional items to manually check",
+        "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+        "crcLongestDurationLabel": "Maximum critical path latency:",
+        "crcInitialNavigation": "Initial Navigation",
+        "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+        "labDataTitle": "Lab Data",
+        "warningAuditsGroupTitle": "Passed audits but with warnings",
+        "snippetExpandButtonLabel": "Expand snippet",
+        "snippetCollapseButtonLabel": "Collapse snippet",
+        "thirdPartyResourcesLabel": "Show 3rd-party resources",
+        "runtimeDesktopEmulation": "Emulated Desktop",
+        "runtimeMobileEmulation": "Emulated Moto G Power",
+        "runtimeNoEmulation": "No emulation",
+        "runtimeSettingsBenchmark": "Unthrottled CPU/Memory Power",
+        "runtimeSettingsCPUThrottling": "CPU throttling",
+        "runtimeSettingsDevice": "Device",
+        "runtimeSettingsNetworkThrottling": "Network throttling",
+        "runtimeSettingsUANetwork": "User agent (network)",
+        "runtimeUnknown": "Unknown",
+        "dropdownCopyJSON": "Copy JSON",
+        "dropdownDarkTheme": "Toggle Dark Theme",
+        "dropdownPrintExpanded": "Print Expanded",
+        "dropdownPrintSummary": "Print Summary",
+        "dropdownSaveGist": "Save as Gist",
+        "dropdownSaveHTML": "Save as HTML",
+        "dropdownSaveJSON": "Save as JSON",
+        "dropdownViewer": "Open in Viewer",
+        "footerIssue": "File an issue",
+        "throttlingProvided": "Provided by environment",
+        "calculatorLink": "See calculator.",
+        "runtimeSettingsAxeVersion": "Axe version",
+        "viewTreemapLabel": "View Treemap",
+        "showRelevantAudits": "Show audits relevant to:"
+      }
+    },
+    "entities": [
+      {
+        "name": "ocobo.co",
+        "isFirstParty": true,
+        "isUnrecognized": true,
+        "origins": [
+          "https://www.ocobo.co"
+        ]
+      },
+      {
+        "name": "vercel-storage.com",
+        "isUnrecognized": true,
+        "origins": [
+          "https://jr0deqtyc8c5pvr8.public.blob.vercel-storage.com"
+        ]
+      },
+      {
+        "name": "Google Tag Manager",
+        "homepage": "https://marketingplatform.google.com/about/tag-manager/",
+        "category": "tag-manager",
+        "origins": [
+          "https://www.googletagmanager.com"
+        ]
+      },
+      {
+        "name": "Clearbit",
+        "homepage": "https://clearbit.com/",
+        "category": "analytics",
+        "origins": [
+          "https://tag.clearbitscripts.com"
+        ]
+      },
+      {
+        "name": "Hubspot",
+        "homepage": "https://hubspot.com/",
+        "category": "marketing",
+        "origins": [
+          "https://js-eu1.hs-scripts.com",
+          "https://js-eu1.hscollectedforms.net",
+          "https://js-eu1.hubspot.com",
+          "https://js-eu1.hs-analytics.net",
+          "https://js-eu1.hs-banner.com",
+          "https://js-eu1.hsforms.net",
+          "https://forms-eu1.hscollectedforms.net",
+          "https://cta-eu1.hubspot.com",
+          "https://perf-eu1.hsforms.com",
+          "https://forms-eu1.hsforms.com",
+          "https://track-eu1.hubspot.com"
+        ]
+      },
+      {
+        "name": "GitHub",
+        "category": "utility",
+        "origins": [
+          "https://useago.github.io"
+        ]
+      },
+      {
+        "name": "Google Analytics",
+        "homepage": "https://marketingplatform.google.com/about/analytics/",
+        "category": "analytics",
+        "origins": [
+          "https://www.google-analytics.com"
+        ]
+      },
+      {
+        "name": "Google Fonts",
+        "homepage": "https://fonts.google.com/",
+        "category": "cdn",
+        "origins": [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com"
+        ]
+      }
+    ],
+    "fullPageScreenshot": {
+      "screenshot": {
+        "height": 12829,
+        "width": 412,
+        "data": "data:image/webp;base64,UklGRqxLAgBXRUJQVlA4WAoAAAAgAAAAmwEAHDIASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZWUDggvkkCAJChDZ0BKpwBHTI/EYa8WCwotC8icXnSgCIJaW78NOf7dN3Bs4/ZPd017dN1O7Mn2ypGq4eS/lt/XHoZLvd2YP7l3vP+/61P7DywHvu8xPm6+k/+7en/6Ynqrf5j1C/Ob9YD/Qeml1f/Sv9Tv9B/ef9D7gvmH7f/sv75/rP+b/lP3Z9xfzL7F/gf4f/Tf+L/J/vr8kn/H/sPF17B/f/uJ6r/z78gf2P8f+//xU/kP+v/kv9P+vHoz8svqX2Bf0H+s/f/8K31//x/yf+r75na/+D/9f9z7Avvf98/aH1Fvnv/P/jf9b+8Xwh+4f63/3+4D/YP8x6hf8z9sP9d50H5T/q/uP8Av86/y3/4/zns/fY3on+0P/9/1vga/qv+c//3/K/8Xcy/P////Fh+9g0HZGeONMPTExvoulQy5jfRdKhlzG+i6VDLmN9FvGPTbH2RnjjTD0xHIEjfrHMAyoBsnL/rK2+snyo6VPiqThcNyl/LaOeheDv9rVJqxGXUW34rhyfOGkj1bq6YemJjebRipjUWvwMmcZ8w4OshOyJJ7uScPAPqY8HT3qBcaVvgrvQa3iX2fKOb7RI0sXGb57uKoehwSdIulQ6PWjyccwJUQVIWf0w9MTG+lpqpiY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmM4NG+ynIi2BBS/8R7B4ORPwOO+BIpA0Xm+sn4iMzH+qc31K3e/YbPZoDd1+rjnb62X027tpLnohqbIk1WhVjhGFQ4ZcUAI2XsZk5NH7WBAkdaM959d14bwYjIOdX4XQWEnzc8PbFkMyPhXBLRX62cgxA/x84CKAc74DJiz3xLwi0e/C9qix0Kb5VLY1DLl13+DL1P+MJWhVGM1lqtQlo6XD86mKnzXGyqKsG9NqWOgykmvBohNS6Vi3fCE5HEvVA+feSUfCyqUdDVFcsdLAzOHw6YMpmzjuLjXKgbuZUgjtLESCxMfir3PCVvgBRrUQSL0C2McctunUTHZtO7Sl4m86noNaU9vYG9wITbFngGvYsX5lGtwkvIC59xQHke9qeUt3nR1uN7uf5qM33ur8e44kSfE/RgpTqhQm7IsklVawz04MDsr/CDVY60wyRuDDlgOig/ftO6u7xGVw/72k1IRK/XxYAuvwcbB6LZCujRvO3S9e0sDO26eZOOh/TDuTHBaRbMhRDI5ki9pDAYi8k7v4Z+jguxmT9eJ6VgS3iFNTHBBDDVobh3czdUXSoXuT10cbo+R29+G41e3rRz9rKYiA5cGloujIzxxqhxlzG8d4vpMmBrxGQsh1neoXmGzEoKiFZbqCiPcydf3wmPWy/vsuca930XSoZcZCrnGtd+yxV1BhJBr1VzG+i6VDLmN4SKL2VA5csPL+drSfNEWjHm9rPjhAzpUC8sT4sZkl4QL8fMgTU7iGcsnwG7g0UJrxfjcQwyIV4EUt4y4wPARv91rsvhQ7Izvjsq6ydRXH4KKL41UOPsijqOXHcVnhUB8M6qi95eKSlH7ClmOnJH2+W5irpaPPAnmAyqnuGCpuhozOnm8PlJI+ulZtXSthvmvn4Vuf9YfJiYRsFcbP/mrC9GXMcm1k9rgzzC6tvytttTNYLP6YemK6kqGXMe/XZGeONMPTExvsKOAWf0w9MS+jrPD8yFJa/gnH9tuLebfaZQppRgTdfbW8xOpTWbG0Qf3PWdNcrAHdcgnI6R+VpcDlqtvpxAaingdDLLJGRJnGvBYZh4MRF7VkD2SHoIGn3pqjwZl7VHirN7wWdYBKvmwXsGfAZMyx68eUdw6vBpWNN5uKlPvxcQnN+06XKZCX3AxKfOQj2oEN//jI/MNxM7/tM3R/sOI1Uw8RxmX00utse2FhAYhTJaNqnpGERYPN5dSGEojFLWXjYvYtg1dlDqwGcOE+vaDGcqsm3lrRXSLfZcZ4uZNtEMOGy02Eyg28CbSYe1M0+0CQHbKXZTAxpBw6/c130yyy/GcTqt4tzug+igvAMFJ7llmNndGUDK9T1b0ewh8gqs8EPpGMAYQkw++YbOvwRbeAl1OVB/Iage6cdEO5ctBmUqCxJ3ZIcYWK6a0cbS0RWVkZSmMihVg9HtzassuGQ1XzrppRKe4bZmZjDRTIH2xCWPnApzoXu/xJiUjnw/CA5oIJvUqVI9hcGTR6YDtD8mqGIE0NVV61wue0hrOGzNQkmF1SjCNvugNmgTE3Htoqi4AtkvH3vcgub3T4bwyEv52A3elqH5r/UBasZLB+Z9uwDz/Kv20a+PL/AGdqlt45Y4CGG0fGZ6y2opG6h6SizZwhIzyf95kgm7lJUfX67xGmHpiY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN8vB09ySucbx28vJBCAp6rkZirBrDNWXp/AvuUyr3ezbqQ7M+lIlcJwK4kuvkzvg9lKCWQ/BTWieGHtb2ny1T4JfcruMyx1F5mGDOpDSwWVJEIrMVYK16sNc2zwaLRBJ8FyqvP8G9Qd+EOPUkD/pTMnYRDTpe1G7CHpQrCErXr0YJZ9U6sg2WOPf9H6Z2PQEzIpUhhnMtiiMhiZ83pOw0SgeSSkKwZLk/Ax53LpgdRnwQ5QhKoD5yBUutXJIJyJUuqSaY8u+7yF6hS7cnLZ6wFOgjwSWx0zFIkeMaLfd87NvQHdf8oAtx7lFu0vRsOnKy96HHojG/9XmTnFpCcmjQxRPiEcf6ayS1+8GXWJT/Mz5+CF5faSWduE/2dzLmTZlKyCY8a9Off3EdcqHMb6LpUM9xGf8j/q0FkGlQ6YmN9F0qGXMb6LpUMuY30XSoZcxvoulQy4idfmAyxPN4jDNUGlR+Fx94iO7aMw0jALP5w/xL4PZ6oxA5GFYOrTCgatYekHejdmBR5WXE6qwyfYdkWJVI+j/lwWJvYJpMyy9JafMHugCkPUF2xxmf2MdUI9ClhIWY1PTGGBKBUWHjzF1/g4NUGvnPejSTRRqsmEcglhB2IkUxcJ4GXbFkrSpMoOdXT63KZfpMVk5jNcEfC6VAxg/efWsDHFFSe6i6P1O8Ah+iklNc32/mesh2fbLiR94kfeJH3iR94kfYKDjfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuNfDijPVLP6YemJjfRdKhgwwcbJe9HjbPNawwAquKEefFTjqc+7l4AFH78KqnUOikD9vEYZqYOF7UYFNETBAMLJGo8kN/l1J/lZvH/d6zRbzB1tvHSxzqJwuHzLjM6zWO4iHF57Bjw3AJiDNjGYQm/U8u6tk6S0UU6eqaTRStAs3o+8QHwkzULiR94kPTEv3ZkEIJqalzqj8LgmHY5ypijFx94kfeIuXzzO8RE1C+35txyhVNwBEBRtTGekuq+Ol9W0DBoSQNku8GlgQ2OP/8un3bFwM0ZghW0YxucuPDUFzAJBkZxiQOTbTzcGaSol/t0Ns4TfYNjh7YkkPhnwWzRaSHMyXKocC5N8wknwsw19Nz+4SPuxnGLUIwcwfC2Hz15AmV4VflHnjHkViVmqjjUHHa3X9qLi4Aw0r1ypfzv/WN4kfUDCHKxS0yUIAw3X0FxQqD1WKUHrz/3EDvVTzl6YVDovnl3R3cCYOyU9FdkQ5zT0sS78qj75Wm36XoXRkKp55nie2T2Ef9YGtN1RdD3/LHKsadxt34l5JfRJGgrRNzfuzN4fhDb4OkVFQ7/RwXzcuJaKKxbshtZxkA78yzMqiS2SjC4kfJqZ9DAFm3U9CwWAv2P/vxMGampr+IKbdLmt0OlrNxUoG5ZIsjFpz84C4I/CuS755DL7dj8vS8e3uKfdJbqAm0E8SZg9dVVXZMTDVJWsMfAvUXlycJjyP3qD4fKo3MjqN3dhxJhCNR7f4urIs5OlvW1X6ixoCC971xm+ZIBoPQWRP3DzUjeskgU034Hw5aB0SB9hjWgM4HhG6yOoFXFDh3f00sURx9b589yJDAJeOfYfEmEi/7c2Uo/UBk5A4EwnOlwUg6hD+smv4ehyJkMAQ7tznaQbJW1t+USYQ/N+AyHcI4+jhZBjqnTWurlohHjDhrI6tQHCdY3ZDACGCVi5soRSq85QTAOKwwbrbUenZ/h6Yy4as82snhJsVAEbBxQaq2/lJl8aC+fpc/9XPJ4BVggWdq8mRgstHVmxTC50hCR2WOGbbU5bYTC51iYeUOmJj367IzxoJn8vGddUwE+iv/cNBQiJPHGmHpiY30XSoZ/vD9TExvoulQy5jfRdKhlzG+i6VDLmN9F0qPfoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9Fvp/FS0GlR+Fx94kfeJH3iR94kfeJH3iSNP1WFWEP2N2B7DnugsZR3d0Dw/UxMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoky2lTOCuzfo7wTcE5122SieA84bgW9YBh043IlFeOC/Bwkc3Q3g2QzCRbM1e/SgpZHYbiDHwQjdjGrFzE3FKP8EnM6MPTExvyqduBxeUfoKiFcxvoulQvWhWLs2Y8fwPCPN2NGu1vSiwwHyk1tmT28m+pJ4SnfrULUaubX1depiY30XSoAmFGFbtl3Jpy+iobHrOpLGE2r6yC4cBAKu70TZyfwjRiCwccIcMlaHzzJJvUg4ZKhlzG+i6U/qcAimp7pHHcys9MTG+i6VAI7fh6d/Nddvpm1T4JfV553eGQrFvrT7mYmdhRkofeROeCu8NssvUxKtqLn/dSRpPZ5GRMHfQR4QUcWc9EOn5M3SyFmc2SvKkMlFYwJtn0FZJhUOpvfKHNGnHGckZqCV61DpiY3zL3JlExNIhfmMNvM/pL6nFDNjRV+PwW6sJpVUKvHIQCKlJATzcQaUjmZEJPHGmHpiY5CIUeGOLt9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUL1s7rhd9rqGWGq++YemJjeJPe9DkHH+P2T+OHpSWPwLwHITYy5WuUoNOFgRs+/nZ+m7l4j5aAn83tsqK4+xUG6dnx1yFfFZ2RnjiB2uQheA7Ixqgh1cFO7CsgGwuDgEdZakOtn7SHhRNkFAcs2HDUEjbWa5tUtBBOEwnxt0njjTD0xMk1F0qGXMb6LpUMuY30Yvv6tBS3SodMTG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6Lo5m55v8LoDqbB7ij0B1Ng9xLVbPTJGffjIXgHXUOmJjfRdKhlzEuNjZduwGPepgPGl2BZ/TD0xNvAIpnfLnRQ4SAR5QA9VsxsKVOPTExvousWR6ENpq9tDGGs8k0ZAPrpsoF0fc7opHpibX2wduPqLw/u4ZGJAynirn+Pk855eIJwfAy74yEAtJgkOqyZcuiGaxQ+xLtn8jmC5GVnxG3aqiR+hrGPwH/priXVscLCgvXDOwca9/G578msBBRxWPs7NeHbvFdaJlUKwMOPyROZYo3bLXqYm19sfcG8OG2RuNtnwQkCemVquCla2LsUnfKjso9mtzLWxlBD+GKZhoLGs2Usq1srjHfhN159KgYPXN6puqZ5HFVm2nqKd+wdpg5NzQFhcv4ryLrtUkE39llmSY0DIXp/rfDhds4BnN3pU918+mdv51RaFgJj0XjqRgp0FoUJ3vZInMgTvQB98kCLEUQ3ClAMw9P6HWtF0LUFh2LYo+khfa9IcHQT1zzQ4K9+5pISeaX2thTC2RhBBxqSVXeZzrymcSxdsc844Fu9y7CSrvm3SicAwOVgPfnWOjtz4HNdi8XvY4VGI+scD26sDED6utP25mLBD3B5ADqQh/DmenmoQI2uqjnsW1zEYf9a2Q4bVoDYbwCUy9ElylVVCBS7zi2G34+T+484Hs8PKfXZuPEMAJcCm+d0johihpotsUvr2LRmw9p23QnZPLrVyQa1/L2bmbJUclpZ+Vk46dfevk/4n2dak5/Fr1lje0lKPui/ziJHjYxstfc4k09+QtfEjfbiBXyt54ipUh1bmupObcu+ZzmmxV4JxegdGTXD2df6MKfKGS+N6T457YY8iL+QF6NM77+BrEte6GTMXZ76vcAtR1xJJCW4KoTKLwBdRBnov1ebP0SgvnTgxsoDcTAW7Cr1Sof8ZaAYcwTYkf0NrHqWnGhN/p8nLJQoLRUDb2ELWsj3aUPWNBOVX5LbmGNhFnYiO6ukjwQicmKiUmKdXw3ZukG2wQVpCZtQxSszo2qy6hpF4QVQWwerJmLNO5YwuJdQF19x7Nz4rIyRJ2Sr3eWEWqvw3HWDlVv9c5m6+4InOrVJwHfyn6i3lKfoUZ7ziFBLBFeyCTdKUfm1Gl0h2C08NC9oIGdFquLfDOKagFaRkZNB3W1HXNA4RHRI2ot+GTkOgYIv+vClK3Vh+zfyF4twvAnTAfbUDwX9hw91lK0JebbKz2EKeZYgQck1PUlm9toJVhigZNewXOT52VFDV9TrDPojSXVXXCTz9cMeRsxBnG4z9x4cnXLoWSXtb51+KIRJwcuCwT0KjO94tYvJA8tt+BEqmZ/g7YdEb3/zaOs8fwuqKcWgmN2YoZ9PQEDZasHYHodseKAZi4H+oRxdVwJnIXaNJ/oRBkbYPOB8UzY4FC3x4GAjACf2W07H+fYmVdyDqUabrEwMzy3jNTewwYC/yWHC2wCKGMmfzLoCXnP0JlWtp7K2xyIOk7Tf+w6GTlFqIOxcJFs1+nw9iTqPD2s1rGevgIfDdVWQmbwQRC9zsp7bQ7JGyeX/ayQLzetXZRdpXfjZvMfTfj4K6uk1UCAJYLQKz1Tc2QaP26yv2rA2GveHNvG24Ck/IsPV81hSJth+piY30XSpZGT9Qy76i6VDLmN9GCCa6d0+Gi6VDLmN9F1iyQx6RprzRdKhlzG+kgNcoKV+/dx1EcYgfZDnHUdpiB6sm2oFmLLSc23y6AeD+/qPQHU3sy3BlViRULiBxaWdoT6WFxvas40w9MTG+jBBNkV53SxqSpBDo8QReYE9qtP3Pf4jWnFZDfJlkCdXx/Qs9s30qWvXHalq5EFlE/FQDofcEDbvZubIiY33WJevA+eO0B+/tph3JVPvzj1bIOQWtNEh3XzuAWu2vl9jLAOwQHZm9mgTrFAi9t8Ayft8oIV957ZQCPJo13oiXC2sIRmPDyTKCXrzKn7QCW+1ezKXBhbpiZSeCtK867PE2S2mKDNa8r5ioelQTG+jBBNj8W5Hlmga95M2AVRMshKb3QymxWfN9F1iyPRO6FcxvoulQy5jiF8gWWK3DMWI6P1VQITHNTyUcLWIPXie4C0bcuCcPIOB+MfjhvStGgLJWuvGdhBzjLNFhR7hiV32Mi6g1RPlDprUFDcRuG53RjjMvCRQ6a1BQ2BZ/TD0xMb6LpUsjK0JGeONMPTExvousWFYeH9NVTRdKhlzG+i6VDBmn8eJVLeL9oLJ6zy/q0Fk9Z5fzaXVipoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGhYWf0w9MTG+i6VDLmN9F0qGXMb6LpUMuY30Smt9ZkzaebxGGaoNKj8Lj7xI+8SPvEj7xU30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6JKzGVAjt+jVyDAeKnIkORaejMW/DsjPHGmHe3W/eSSHVLGsG52yo7FbklRAGf2GwttF4aQxr/spfFYQkUwJ4IETL7pT5Hg37WXAqzviENlwouBdyYgfYt3k5o4UL0mFpunwU7LLCZfph6YiC3uBst91F13iloAI2AULyDQ/92wneG2DyMTp3gneznZkRUiuTURcTQ5RzMwRXaLmSsJ0RdJD/5r57HmNcUOmJjMKeCUZibtbnHgjLzWpf/WDoN1aRtWP6M9aIdGk6FVV19bBOTbZFa7IzxotRRSsB35Z5Z9muxdUPAT1WGzl7eyaS9NxKIboVEXock6F4otmqfANMPYxumg4eJj5XJipPlguWBGKOFyCc8Xyp4S8zI+fOCpV/pUMrFI6YWgxZ7RNnNsM+T2QXyFm9xKBkAtE8iroy+72ExiMefZUCWOlpDEpU9UJhP33qZbWn4RBSW0VhMi1Y0uJt8uX2dFI5v8+FhPlWt+CvzlW9zfxSoYDXFDlDTz+xfVH+E7Fx62FjHSl1GcBMzmVRO0k0pjapzQwZr1RNnV8rJc+f/QXPUsdyM0BdWxujdKbFzbppa6m38zLZq/Cpe4+GEFrt+Ohs865Q28dIzyciW/37+lkywYKA4J0GUmoDUeLnS03NJb8jYw5OXgfqHwfcpFb+240CVtofisi12rHAXDFxWV/ZjRmBR6BtedHljqLM8NB92pTO+jAHf7r5MJ8066//oLXgPlMwU2c0oX6qPs6RldpXUrgEJ4X+6Bya35Rv/qQQjoYB0NUd8k1b4Mw2f8QihP3zvsZqIymw6rSR1IHxIjyF6mmisHV2gHPzokzoB4JBwqnII8/oBzzUtAaXib0xAQZiYac3SM25HvP98OX5ziF90V3qG6kl8RiQd7Ts8aaO2sY596N1KmOB/6NPNGl2Fh4VLrdBsX16hFDBJZ3DMCKv2CeMTOdWzB4ojBWNPROd2qquUftk/f2YAOqlWkdIV8HYWXlLjz8XRQ9DtYnd3GlYnk2wHmjaR7YISQNXrH29172YD96dvvaiMSByR4mSWfMOXKl93PMIStiP26x4W97tDKRmcYY6a0Ck8cQWidEQPq+2T1uZW2vol9dUxVMfuSt3ijIqhQHOg3LfKnDMcGb4KEuy4ImBbuf+lD/zSW7lEL0ibO5Wg9Ynp3Ncm4gYwsDiaygrp/5y5drCAd5lrpUMuK8WbuR7Be5cx+GLLdfza12GtT7fmYpZhdJMg2XCwZF5ZxTcZXnHdRfgaxxXa5LZjHfd/KFr6c5jF8tbuSYxH+ngmZOq1vZvqRPE8caVazeS3B26We1uMltbHJ6AJxPtoXhcGz6sXkIAdPTKIUHUulQ3MvkM5dSkD+Ds5d354+yl/H7XARs3JhYG50xQX1WXLazABa+4+7X2Zt0z0DifNqctf3JZm/UwYky927acKNhSSBL2I9ra5cPWnolfHrphLtE1NPO7gFm1+EfJxxJg0KSDEWhwIfbHrYthiusAWPjHo0N0Y5n6KK3S8xVat1pfiYg7U8jrCNzLL7u3CjBxR9b4GKMmYTtJsPVwgNMf+UfWsWp4FlB/s5lY3vqe0TdMTG+lpqpxyN1vJ2uyzP6zf9iWTOiWbClQ6YmN9F0qGXPS3SodMTG+i6VDLmN9F0qGXMZsMZPRy12UmFV5EGhbxR8mzVdpZz/WJIkLTvT+HWrvkSGR9fDiCfFtdBnwOwJ81Jd99rFEdt0gHKNJsWPPBGZWQDiAYb3ZqzxK7m1MRRJ54Dt1GFZ+ygH9TgD+fiTE//C5EFPxHtJVbLMoJzR0SlrQuue9otLoprdu+JQj3l5Nvok98z1w6iHgNMwSDcvEmOPfkVvnGazuN0XAw9bC3KE99HAL31XOB5Q6i920kilhEP5ECRtDgrw3aeFQX+b/gBmt4cSiC8ImXcD+2DT1AHwaaQ+7OtI1MF3DhUh4kQdGVGLqHvKDdxQ0wars4dxN2e4wWvP9DlQvzpy9TSgrZjZcEFMeA5bXXeO+iTenSzRz/4ySbN/P/oHsZEUs7wFWH73VFVxxbEDtoLX/Ff8xOTnZLcX+n05FisCyCFDwJsuCvSya22jauOgqSjVScJSlDV/qgrGxBVGlN4UW0UiKzNMDNV/Atw50+iAvs2rBPXGdsGhH0eErrEPy7LxWcwuMp933wzkGJ2YeBsDaJjZfcaIbXZUniHjeEqyKKQ1ieriXTDn2RVeMZ04cGDMJ/bcZIwSN9jI0srVp8oPLT2Tvo98XFA3p3ewvu2CCnh3iSaVJXxPIlb8BSqMb4x2LN71gsGIrLxFnZ24TWE23GaEwyviTqROU2CnghLAHJlYRj/mhdka6vSPaRTnbR9YALhpntJY06GxfXAoSQUY6+IF+GpvWlbWGgMKJJOOy6Q74URqD1rflDfBqEAcmwA4d+ahmfaeytn8TubUgZEgyMohuIfmaAaeMEBU9YlAxkSXW2LNSQ4Xmk/NoxPJXOgwLOE+Pg0jeOR/FjXadkQoEJtoJ6VmHPvg7QoERtoGZAXEcuvaMpyZCDALBvXIVvErhLSRMMXNJZp+XiULqkF2E+1fIaKg69dth2nszM5me8g+ouDRdRdKJBhoQVuxnFHHkiBrEOzJHpdPvgQg5x/bZDQeB9MaRJOg23uU0X758hT1y8wE6inN1ESSDMMFpx2bvpZIm54POcvuXwOvHD0Wld//O8NOBZHGCyhPogjKLu1uVzCMHmehKp/yHo61uYpRD/ynnsmW+EjTWRBhFN4uvp60N9RYmXr8M5yFwQNkVzoiGaixJoqkcqavzzxc0t9VucHeAO5+/cpDEzC7v2YLZifQyOouF7HSVb7CMImEeSgAALZ8Qdiog2PYE/ucLKEFTms+pidCxOEh16hs6U7cFSFn9MPTExvoulQy5jfRdKhlzG+i6VDLmN9F0p/khfMFQKzWWS81k2083iMM1QaVH39sMVpxnUXSifCllUJNveqbFzPxK5YUDJqp/5942h95jOo7GTsPnuoD1YZos8T4uovF5Wz8GG16oV6HaXv+s3v4tUuNUu288Ep4T7L/4xPAA4120tyGJjPsbi825BtkDZ+7aaPvclGCaEVCTiydWRQZtuNMK8UFHjTXIDqbC3Yin9iQK+i4dI66mwe4pB/doK69Kh0xMb6LpUN7BdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDQ3oDqbB7ij0B1Ng9xRoJ1HCTR/OoulQy5jfRdKhlsptyCoogp66PTExvoulQy5jfd2X5Q6YmN9F0qGXMb7uy/KHTExvoulQy5jfd2X5Q6YmN9F0qGXMb7uy/KHTExvCABMpJ36YemJt46E/ph6YhymAwFRltb2JnrnjjTEE8GaJjfRdDmGO9gbPhDOH6mJjiNFl9Q6YmN+VH6mJjfd2X5Q6YiAh92u85ASHI6WdDEmRw+jjWPe9dQy8AaJ76LoiKnhLRwka84qvnXQ7IzyKMvyh0xL5NPNkN+JYg0qHTXVsV440rm/qe9iyYa9XBpyAJZ2bNzxWbBapUWhKM+B4fwXvzNnEc80IHiVYdMTbx0J/TDuz4llo0GjHL6unNVNoR5LjHbNol2xoaLUFpOGNj4Ft3rW6qmSYemurYrxxpk8TDdJ83z3EZ/TEE8GaJjfRdKhlzG+i6W/vHcjPGg5CVVBzAhLerTfCXz/Kv1x3K56Q8tXUILQZEvJFaIwIgURKqwsGC6h0xNvHQn9MPTGu5C8odMTIYCHoP1MTG+i6VDLmOI0WX1DpiY30XSoZcxxGiy+odMTG+i6VDLmOI0WX1DpiY30XSoZcxxGFc391bb/M2XMb6LpUMuY30XDW+dmQShb/o/el5nIdxR6A6mwe4o9AdTQgeB15GTCrPL+rQWT1nl/VoLINGKcnrPL+rQWT1nl/VoLIQW+xvoulQy5jfRdKh3OoQVpUOmJjfRdKhlzIYCHoP1MTG+i6VDLmOI0WX1DpiY30XSoZcxxGiy+odMTG+i6VDLmOI0WX1DpiYyg+D9ME2awhgZuieJuNMPTGANE99F0qF4G7FpEc8Oo8tUF0qHTXVsV440w9McSk+Gi6VLdEU7PHFBbB0S3Jx3bI3Z7ZBmb6LrKFIDExvAkxO9WQ9SLPGzoTRDLD1D2FhEzpF0qWirQkZ441JE5uh3UMubeOhP6VYktjh5+gSHH1WI7tHcpfX9fwmmyUuUpq6PmTK8sBNV11hA3w3zT0eb5UQn6tLZyCRqSQ6ouihc/kcmsZ3jc6Sirkxj9FdMVYOKQiK67UVeiX+Pk46K8CfMdZxR9qmJDJsst1ceLOorDs2ch1446deDlMg676HU+fPRy8B2eRRl+UOmJjfRdKhlzG+7svyh0xEivOaTvkeH+eHIzgqcolswOTtfsKeeoWOAAoKH9rS42clbqHTXVsV440sbi+31L6KpH6mJt46E/ph6YmN9F0qGXNvHQn9MPTExvoulQy5t46E/ph6YmN9F0qGXNvHQn9MPTExvoulQy5t4z5WiF1MTG+i6VDLmN84YV2Fsy+yYIGZgI92gsnrPL+rQWT1nl2yMbeSlnjjTD0xMb6LpUMudCulQ6YmN9F0qGXMb6SPiwtgWf0w9MTG+i6VLdEZU0XSoZcxvoulQwkkWMAZomN9F0qGXMb6LrF2cdyM8caYemJjfRdYuzjuRnjjTD0xMb6LrF2cdyM8cZl0v2yvzgctp9T9TExvutOTWQ7IzvFpWzANZhFUXcU93TdR6YmN91pyayHZGeT/tf0w9MTbCCHoP1MTG+i6VDLmQpts0mHonK0LhcPraj+PCmTFw8i7ArUHi6X2ki7Kw7I1GCj+g/U4oWhKVB2RnkSpyayHVcr8wDb0R1TQgfZT2STEi55U/qT0+du7IRpNHF4ml4LrTD01qwZU0W92GdyQK6EhBhMGjbSQw1wcLRZt49ow9TM9anYAB8YRp+OYrpQvzCs0Zw9xnZJGeRKnJrIdVq0FxgYWNZeF2CVi8xexxngkcK1F3R6Ym2EEPQfrRuI2hTtsuY33WnJrIdjYmLKamfwbmmnBVFyby0QwRO5dQ6Ym2EEPQfqLq7hb6YbojqQ5Ll3phokKkHgVm5/33UmRnjjgUikBiY30sf8v9jfRdYuzjuRnjjTD0xMb6LrF2cdyM8caYemJjfRdYuzjuRnjjTD0xMb6LrF2cdyM8caYemJjfRdYrgWYvrvHuKPQHU2D3FHoDqbB7ZQ8Dg+ZtaFgPcUegOpsHuKPQHU15svxZPWeX9WgsnrPL+rQRnu1qJyNuT8sjPHGmHpiY30XR+TNg78CrqHTExvoulQy5jiNFl9Q6YmN9F0qGXMcRosvqHTExvoulQy5jiNFl9Q6YmN9F0qGXMcRosvqHTExmt8cbDyPoulQ7nYbAs/ph3TXR28JzGvi4KZuodMTIYCHoP1MTGbk6s5TPPWf0w9dnjfY30XSogbY30XSpboinZ44ejPvVAJdXeOqpYbMU5yFSvICo3qBn+wJUMvAGie+i6YKUH6PuodMTbx0J/TDt7Ncm1tLPIy9b/TExvpJDwL1MTAHGQjtqIk2iqmYQ1fsHt0NSq+c1yWXVrPAoqMMx1fqFtcmV0za6h011bFeONKs3b2xN8jxBiYLaQsRaF984PXxIewsnoY9MTHEaLL6h0xszAqmHpiY33dl+UOl/KYfNHMkniX88bepWyjTDpjAGie+i3vVrrIe1wm1oeFoVGS6TmFu3R0RxN/GidNuIzVDc0XRaPQSKovcXz1AOuY1YzR5w6jjTHoq0JGeONMPTExvoulv7x3Izxxph6YmN9F0t/eO5GeONMPTExvoulv7x3Izxxph6YmN9F0t/eO5GeONMPTExvoulvx+TAVB3MTlNvoHMax4fUi0G9vhiQGkxrHh9SLQb2+GJAaTGseB1kM2Anj+nDiIHuKPQHU2D3FHoDqYDUnjjTD0xMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulP3C79SUauEVn8j/lNg0dFcqPjvPprdv7bWWwtCsGrvZ4GRWUWmV0SGfNV70X4nBfth5RDxxph6YmM4DTVug9uud6ooUCyTCKwcZ7T33Sew/wNJFboO18y5440w9MTJhjbknpbh/LqUzKV4emJjfRdKhlzG+i6VDLmN9Fu4u2Ww73zl98AtmZAOw4n3H8q9tamzRDTVJmP1UTX8EIgBYgnPRyeLFnNml/NOrVtJh6NRUS8FtCLj/A/043yfuhxU7k5ytuoFhKlLeBNgRiKl+pzthj1WyM5asL3C8cJ/WYzyZQScAH/Sx6BGALb6kwPVfO0wdHvev3rGQvBYzeEy+PBYHFouihudPkgltKzjdRyIvcrdKHZFYS9KSECGvUwSpMirQDtamITlWvYMF6ChOl1YHQN1ifjmzZ46iEhCJdi1JiHpjgfDOyMzZC+fJIHUyI5+tP2VR2FNGEaj7xnu4m7dkP6yn65i/Q5rSddEVoKSZLgkKdyG+XLCSrjQGXFNB522Bo9VDz6wTVoVg2SRaV1dXzNRpaP6EtrdhDwdcln/wgGCpQYw9WOkdXfJAmlOh1TdCvs5jMrWRIp+G0xydA9fVeov6BL3ALjSOVGnfVQQGfE3r9ryjgXsKUQA7NawjeHUHdXrOVvq0M98n22q12Zuxh2wqBsDQ4sJFSE5E+yPROomXTsmIdE4+EKiX06r9QDjP/feL5YhILMFpuRgM5LdG4GhF0JkWEf8wPE6skxGE5kp8MpsURzfTUdrLiKATG8FJwulQGVDUelkt9Fvk+BFFUaVKfBNmbahY9SFfwh1QZEQRD+qIofXQKoBdjZErLu1AgfBhlGnKi/TE9kJWSI38DwB/GcJa9BOIcpi40UZeS6n3fCquEpBM/MISrA+whOEGOBHbh6aWEZ2kO6/z1RGVFkkC1idxr5ery/+fellEXs3aRrLhMMPjF6yJE3npRtC9Q3r7h8bEy2pJZxlLHQX5i2FTWleVFq5fRFXD2dq/ue5Tddpi5BZa7+gpXlO0bKSFknLH2BwqnleIZ1xrO0hoflEKvB5QyP6eMqybu1NnzSC3neaYlhoOCNC6YHYJEMG+B0Wc3cT/wPztVglYBUJXiiVCAA3p5XiGdcZLvY3jtR/V4b0QjIX1QECvluhhJg6jPHEkeN+Q+5v3CiSFxwxoiu4OSai6VDLmMz7J1sH+Cg+OtWC+QFr8Bhyqn7dEjCCBzpKlLzL4WLqVvH1QTlR8pSSEzQtql3oYHGE8caYemJjfRi6dGg8+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxy+Ip/doLJ6zy/q0Fk9Z5fPIzxxph6YmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRbrMBYulQy5jfRJ4jlHgNcI+Afg3FqOGzijQ0E/hzG8SrPHJfbfY7yS/pGSPQT1VwQAWnkWxMtHdEMDB2jILbVSsw7IyROXcDnEMlJidVnVzEsVf7hD8Q2gLwcXsnO3Y4nj94Ff/kNb4M6BmR4CB2emGLXdiqWEtbfvCokCTzVdZxire8jLXbD/FyJkfSqw8jb5v93uvrKjH2MUXOIcJnYrqvM+HJ85cRgoFmKAPVUK5/n8Eee8T7s4l7ikravvadigDyqKRlAwlrkz66ckSQIprtC2ljF/+EP8pbodB04akNO6tElzw8n9t9Cddh0WVjjTCPyev1Y0XdC9ISrw7HiYVTyfa8eu+8nzT3V4Rrq3jbl4QwDnpWprptJW8uOm7F7LnAMIOz3aTcRf4b/COWKtDUb0nOrm/+eBEz0AwdyyMP3NQpb/ud2yGngBKBj6Y0fnkBe7L0DXMbjdpYWJ4oZEcSZXtw64qA+MEwWEnG4NBx66S4WxsTuVr/wAeWeqnsWMWTx1rNwb8jdnxESPicO3MhGRXBOtKyHfOMqoGeRyAeaW7OMSEa+QVvF+6wFWbgE6QQj/ymnYwLjwzvgTFH1snXWWxlKGcyu/PqKXkWiY30ZQv6tAlU84eArXNE/swih5hXREXr8ZTGcjWEf5udnE74JfDNDG3IX5FrlH4fJRtpFCCH3lxXkqcZLC/24Jo6F4HJqn4SLC0gcvxehgyYgqLtMaaKWalMNlkdtG2NFK1Muaj2EfIo69LVJuWsSTtZHIBUXRVALTW8XVUo7KnnI4jxkgilIpdOHp2TvM4meAMOBJAqtLWWQRXD/aIwF1+LoIe1PUDy0r8dOiEWdQaVPjGSyKhho7+NthEiCn9uG++QMXSogbY4/ohEUPMwKph6YmN9F0qGXMb6LpUMuY3y8C3ERRosjE8OTSKQqhAiaA4stDmJwICpwxP3zVagNCUOB/MNQy/aHY1wLMFzjYGdJWdZFL0dbkgAEC6OIKc8uIilk5WTxaD8np29irodSRdHhigbVGCji7lpOEgUx4uxAdQDc4IDDFAYDHDeWZsuArl0fRTaQr558tgm0cGHSivb6Il+ewF0KUu3nyK7z3SgHny6aX7Lzm8MGuyJghy6a8FJkpQwzE1PSuSNCh0pAY6rBkEnOYN2nxvE+CVA4pgLU+t4oFWdEeg0MG9+aKFoOKfAM0JccNZdX8NEZnx/yzC2D/TdKVhxuq9I9IXVfPBk9ToNmdLlBEtejztlQF5TTLfbzAbEUOr1z2x6Lt5/PK08tiJHnypb4dxyNMtQHOvC7qSXGxTxwBiz1EVJrxvtodth1UOw+lwjJHUtT16zurJrVC/QCOPsGfUgONdcSpHlHqqtY8rnhc9/jSDhbWBtifRBSs7VMC6vDGl6kLcs78PSCDWDithGZQECyZ5LQAs1s4MP6MIJc5kwEiofOLzLg94HF00ot3/UqmcExbvWIuQwBOYAfkQEXCNaA+vT4jkXclJVXXXIBOXpNxbSeM1Q7qGXszA1SoOrMNyR0sF+3tILh1cAZdwGCR4DKgMKzeQGfKk/jJI+GRxph6YmN9F0qGepbmkfqYmN9F0qGXMb6LpUMuY30XSoZcxvWiLlnDrunZTHis+lly4FZchpuOiWVQIJIC1a+YMRSj7LjIA7C67xMb6LpN7qA/XIQqt/o3+t6/NIVPL9KvXwQC4pzRthkEkD6DfRfteO8ocu/oBuwKoi6kEvOghA3Vxi1440w8qbcOj4qhPz6SE2rqSxrfM2MS4E30dA8L1ozzDI+g3Cz1+8h3xqGimUeFpmF6OG1XGaRTGgt4Zn9fAkueoJXcS1wq5/u5KHl5VsvtEDKW0DSWT+C4fprrSas3cc81jrBTp5Qr1KdtYq0/G6jZ2QstbvSCklAT6gbVP68ndOS2Lt/b+p9/FDcvtWjG+6jhckBMc+4BZpWneQRnTBwRj3DwzWkswBPHQjQWTO/wYsHzY0xR9X2pdVZfEUu/fKSmaCNM78HQeuwQlKSwQfllgqpXP7qI/9y4bv8DPzJRZZPdAIFn9K85gAu5IReaAKocnZzECn8y5qUXTfSI0ZKl8qRXA2xvouxDtB59F0qGXMb6KG3shODacN4Pnf+YxR1ZRi/81h6LNLL9JQ9FTqeFlt5byYIKg6anWqLNCaiEAGACE6hd9FXWKYdaVcIJebwlfRWlTga+J0jRJJCPBmm7mS+1Hu6EORzxlC3f5Pmj73kssaAv8OBwCNZwiT6/5/NR3Wa4/m9Q2EwjZxhxlQ2CLCTptXqSYic4wymYpMQyru6re88nmeSwHnP7Eoc8aoZUKy8r7t6RZXtcHbggh3IBel0B5o+xQnecOP1pE9OSpboSXZHCX5EInQknVgNpi65RgSKPNXPgBUNBE8auRn+v8Z8IDlP8EXIk7IjXLNTrAdI/cgkoorBQhZSTQ5A+XdQj5bSPDB0Akh08JnKxpNfkorCG9uA9+DKSlUNQVr1SD+QQMmof7wliF1EMuVDpezRC0lKzVeEvpedJdTejK5tv/C2dokUKnAJ+50KmnhvVyzuMLuIpDxga8x//640HgNVbkZoJftk7z8GcpeWUwN3E1bPg7sCy+Nuw8Fccvn2lOS58u4h4ZcxvBjHdRcldU5xUdAh6mlPYKKaxKFj7iqVNmByN36h2eOM7Evo0ddkO+4LQCxph6YmN9F0cYZCHZGeONMPTExvouRFxSeEa343EbxAuLRpI7F5wikhTTFdVZDgF7zdKqljM25coBh0Yvl0DbXYZMXPmfdn7edOtO/Eek3Ke9cYYRokqU+1HEVUf/LZAklCVDGx9zCtwCa5vRmec2Qfe9COobeSCbQi1OvNJ+ZUlW7pYlfRi1HfrbRsbvWyFmKGeev+butkIn4IHmDlmVQSXztL/1sK0kei5QL+WE48Wrb7ObRsDIYTvBrj0wuIG6GUq6Qd3mjZgds9GJokfAEzShrAvQmC76XFzLCJHEHwToaE45zKp+jsJFbUNFviP4XkIoFAFDALl+XXUAHpWYaq4A4MOoeOYxFOQgImLtejjMI0F4UZFymrLj+MoLwJfYa2Q8XrmPnSlKdnhGoSBcPiHCf4fdPidjCN3q+4ffIFiySAgGLCfIJZ7UtRccxxDgdnjNZVCzxydQHlKveINURZXJNR5wr5+MQdh4RzT5AwyrWs4irJMwW8DdlBO382KwReONc0R1HRj7nI2Zo4FHAi/vsbvqkM3gNBbQBFUp/GgWj3JfXX4ZUgiEInFr/EnKOMuY35UfqYmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+YtQ7ED9igBksvcoV156VrFADJZY/D3+1aoX8hwdg1sVQmF0dpiB+xQAyWXl0K7pw05yE/+Iw2yygnKX5xyrP6YemJpWgsGZToat0EpGY2o2c+16oY4UsfvqWxowS8QMNvyFp0pUO9MBy8ucXJDfvuTHFu8QXCPpj0eXZHRSQltTXL5DPOXKTH5HVs8E4nyFQICm0sMWqNTC707bJvD6ofp/lcmMKFSbw2QISScRHZb6ftGv9KAjtdGMwqmnv0XaCw9RVvNIzAHZiXcO8GLZSyLb/f8/o0KGY6izbjWX84AA0WX3jFjkdG6S6YLT0krVq8wZrsBlOhUXNU2LSTSaS8dUmmEFEJDPvRsNsycWolybBSbOQ/6ClndUtYWh9zrDTS9qW6pdeAWA871I+VbtkxkI0qqhJnEOXELYgk5PUsaGe2N6oazrV+ie3phZPHND947kqXy+itnuRuEH6uzxzbCEHpiY30XSoZcxxGizkzrmdOr5KEtGYluD3yUJaMxKeBOch97JsLTCTmLM+lWKhFiZVFIAKYdPGPyyhV17QKON8/+c+wP94YEqGXMb6SGqMv9Fspx3ZVnkTrriLaSP1XSXPPCH3XFZ2a3lDDEv+RP6/agcA6XNlwMoMXfFva9HQEay9BoryDg2/W+4dVgqfzscbPrZf9W9D4YaU4+Gno8+Ty+hcRmAWHiQi2rJK4AZqHRVLPYO5qsEVyHrskJInJB3iG9nKa8iGlNQTR5GKPQSCrEXksy3J75KCezt1q2O9kZK3kbx27SuR2S5jENpYkrjyTYN9TExvout0KBoryKXm50tP2feATQGxat2AVjr9AR40c0nSc+n5ZTWcRYgVuyS7yaA0x/qU37lOPr7z3MjK1ZnnffsbVIq+VylyPyDZRm6RKE5GR5SWVHLMR8ipdWqut1LrzzSjHu1n/Td91LCFCEctgP187sZDLp53HRJ4iclGwhtBZPOl39RIUCtSI7oq1s/bHvfJQlB/fJQlB/fH8wLSGtEosbOixv04IU4i8lmW5PfH/fAgvB0S5DouPdWdeZPOFCkR90TFGpsNtkXTwJOLBiMRWWfZzfh4Ec98tXtJcakH6mJjiKDFoaY/RWz9WmZ/kgh22kCnkkVuhm0BdC8Wf6LyR6SvStx/Iu3dSFJ2q7ZPwOEqhtkzDfRU/aGLdyRBx4SrBSNyYy40oxyGTbuQwVrxW5gBgUvyEb94KDcz5CcT9OIvJZluT2kTkhMwqXYWx2RywEkq0dmW4PfJQlozEtwdL+wdFVP2jwWXa4T5+bRT89Pl1H0Sl7Bo1d6VCEdvc67zbuikfJZluT3yUJZmYoGivISGSX1lgfD8+AuXgNl8/C9MmWcxrPxGOtDY0loBkSeAhHKGmjOS1Rl/ot4zyf5JATWxQ6z0MkL1HsYZOYwAaZgL+zwI1BPMYpkG6KBC5X7REibkOoP80VlIhowmdatjsZRQ2KJfzSKxIhxYN/M89SWE2sP3WQ7I/OieyNIxnG6MqBos2ooCRjDmwoo6QfvVqgYyThViHryMb+MW/1YP9SqHAJp/C7DZMhiVR9l4TdY8teWnI0ZHsMRGJjMvugQx+equoe/g/+oQPBH3ZJaOx34uTQ7BX5DaG2/8N4VYvU+ADJNZ/JYQrOlPHLPc5b/Ut0RlTRdMSDFIhafrtnUex1rIk1Z2InZtRvtvReUWbbx0UzxdUKtjfEYZqft9S+ioXEjwHya7ISpJDuwI9LfUVAx3WUVnfjlbdZJyYJuy5YG5lpJDu17w7RIP37Ly3c3FLkPN+E8BmUq6Ms2bCATTQrrwbmSXyPXBm1RBRKrKAiERqOwJ2b55mV4fDCVDTMQmMwRBtljR5VDcExu+p226N3BGqvcbYBfj/SGeB4utCkXbqw/xn9o0LZV2MSyFMhUvA8GgNJR9VPPLgLNGLqGJTumCK1c8PPJUkh4DGb0aXwSF3Z5NtPN4jDNUGlR96nwg4LwBosvwD2XMb6LpUMuZC//7nzt64+8SPvEj7xI+8SPvEj7xI+/fiXLqAK+ynvduJAVpxGGaoNKj8Lj7xI+8SPvEiB5A7s1d/SYT1nl/VoLJ6zy/WDgkFd2gsnrPL+rQWT1nlqMjPHGmHpiY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6Ltf6tBZPWeX9WgsnrPL+rPm+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5fSzzMiSqZZc8zuvw465qe4vzd3TSsvmJM516CCmugeofGsCDx9+U63llecnwYfd9ecKM37JGd8Zjj1zYMMPGw/CJ26Ag9l7ALqXbTbxkn020W4dga+FwYNvS0bB3Uqo/rqtpJY97NvGs7q4Gcxl/ZMpJ6F1TaR40706Pf33FJ8o6g/3qyCK+JAhL4ElTJLiCM4IKwt70GwzrE/pXopeFgAiMKTBwokRLQpBiwbGvfQJPMaCJbRZmWtTZejZ34MNrqCqUMzqgLB5CldAF5xDIs/066UHKWJyn9h2h7cAs2Dj8baoS+DfCMw1PEvmnt0w8WOWWKLmmv+nKfeKVLEgKdcfd5F2IKlhkZi7p6+F/vo2XBwx9VoiwyamGHKJn4vTYp1ZrrlhGawUUUM98yhnXnmxKz/VWepXRAPB4zux4MkIpwjHwA7QztorHgsUkLKvTG/LvltTNZpttk92q9VsQ/1Awht7v3tYCAYQzD/KBbEgV5QxiIhmVCeHOjWzbzOjTcEfhb/eIWlGkDsReQAJnRlwdkZn2OcX2NWlIIBA1qOgkhCQ6Uypvy8cMiBtskU6zDcBenSDqCi2PXhf4oGr2S2i3IzILQwLP6ZPZ6hZ/qF1m47OwWf0w9MTG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhiA+66A6mwe4o9AdTYPcUaCdRxktSafqGXMb6LpUMuY2DG3BS/zsW4dMTG+i6VDLmN9JIcE6AblT2tq/x+UYMtr4A54ThzDz2AGNU1VUQ/Ajn0a5t56mJjfRdLf2+UWxx0aIQVdnuR4o5rAUIKXwg2dTF7IDl5V67DPlYJNGc0w9MTG+7sg9z2RFcAyPIuBbN4FH+KptE3MWFzdQ6YmOI0PecvHRDAUCjhQ5eFH4SLMjYvYVMLr8qkY9ho4X9CLTyv9a3VT1bb5biuaYemJjiND3nMC0JFoVzG+rYFn9MeiiCnro9MTGaA1Tspx6YmOI0PecvHR8Fxd3hedo6KWWNIv5/p4N5gSV4mk1olRT63kpau7SDi7A39W2HPyujtzYbwHYpy66s5HncnXu8BJGeOODPk2hmf4QGpoHx2rOtemuF6BG6li8c7WlaWa4b3ozoQnXz+JsLXqAjPpATdvgFn9P4VM0SZhMaOKPJEOEU62fUJ7pD8lt76GL7tFrAPgyuuR3bz7BIa1I7PEeUlZDBleaaaqEFVWvqN9F1lCA6Om78FK8GGghmsf+W2QKAYEfImoLUFre25bn8hLYbgaO0AXZxB1DNbIAlh0LBUjkxvN7kE9O07o0g62R2M+kRs+c+0MZqV98WKHTE28Z8pr60tHovWx/uqzGc4EyZKqtbDKjdiNMPTGAMXClREBAXIQtL9l1hp8NRX2ajMyWseQGfG4q2zwFUuMN1R66p3vKtuNspJe/+D6ES0SrQ9sohLiPniFxO2Pq22ShCOzyaQvbhRAYLnTPFkLHeF/16mJkMAok5DmmBL1vc+y2qEmahJmoV1i6VDrs7LDAObgFn9MPTExvousoQHR1f1DLmN9F0qGXMcRoe85eElTjDikcrqO3anO3Dj2HlmrydeuaYCCNfFapaTcoBg81jT+FTNEms/NgvTpyvCjrHuxQe3crAA/crMBb+KjQVeeWz4yA9MQ7hM14nPIqWqhctzU/QbCwrQ19vvPIUcGkLtq6OwqagsCnGlPLnaqhQdESe8hkk5DdEJxGR4yfGTX31QsaVgHuIO9REXDwzbNRE7Gd390DpIDK9VEB21WWIgOgjyLLFAGaRmJIXhiZrPkMYELvZyshGbk+pFOnB7ZoJuFQ+qXDyc92TpLHAaYcmle6nOLUQrHMp8L4OE8EYMHPnh1gvLPT0ZHWc7NnFqIVJAsUYHGKmgvm6GiRsb+2A/KWK5I3YCMAcqax2pdsYPKbIfdep8slSXyFq6Q2EukL4e11cCRfOdo20zI1WtDtgiY8kn68TTvCWmc4NBfz0bMhndwanIwjk+dB1GOoPD/FRDThriLfl62OXAxR2XVYOzXjx6wd2tt+kkp4hjnAVnJM1V1wSNJeG6dUCrvxTDgzzS4RGNkZEZ7yGSTkOAlerwrwMBjulf4LNjHwSqO4PoNpiBl8FxXHH0ozTTzHQajXubd9w8Rlig1dBaBp323jPlNbrr7DPXrEuz0VMwHPRVYDy5+zlCoulQz1DZx6W/t8otxHXuIz+mHpiY30YKPk2hrdKhlzG+i6VDLmQwCiTkejjTD0xMb6LpUM3qwkwrJ2eONMPTExvoulv7fKLcOmJjfRdKhlzG+kkOCdAZJh6YmN9F0qGXMhgFEnI9HGmHpiY30XSoZvPy6xfhyUDk2y/q0Fk9Z5f1aCyes8Qf6XXvvPuOupsHuKPQHU2D3FHn0IP1zV6A6mwe4o9AdTYPcITZmdPIxFP7tBZPWeX9WgsnqaZnmqpXAwnMb6LpUMuY30XWUIa05cZKfzNixXdxGYiCQ5z8xvoulQwkBsiImeF4vNOLewZ7kokBGDyRespUKGhV5CQhGFBS6KKb60oKmuZ2hnjjTD0xNvHQVZkru9mnKOf+yu/Vo4XwBZ/TD0xgDRNOuaTA+r0CB085GDn755zq1JRSp8gDvH3PcqlNmf0P7WcbJc5qmMO601kTm5FfUMuY30kh4F7yvZgGYN0bws/ph67PG+xvouliAXSodMTIYCHTpyvydkCAddcpLEVio6aZI87TqerI93QDijAlzKHNVTlEPSodMTbx0FlTi2sViqxHtgQ9HofiNeDL9DdP40dHyA+kFtgrXwdjMehDxJvOVgclnHFDLsjPVeiVU01oo/ZbmrK3S1Ozxxpj0VZnuU6Ixn8A8be6TGZTroOqOmJjiNFlXGHiok60ee9HZRokf7h9S61CqZ3RwCussILrLCX3pH2bJK/MC3RUeDlL3ZmhMHJUHEbcA+ddCZV70SybhjU7Bm5zqKOCQ68vB9Qf0OvFoU7hUp4FYCy5Z/THoqzS36NRBby56kMDDoaILOKldAjUF6FEraY/fzjbXJJCOX8w7Enjmh+6H3rYE8Czh37SC6s83HSjXEDcevQTrath3hO6O1j+yLcyYm1NhH3nyPTueCyQHETKE3ZGpJDoSe1rjO2hVRPi8k6w0SIbR24CxnMEmHvvuNOJZyIJb4HEc5bdQ6YwBonvyo/urmN9F0qGXgDRPfRdKhlzG+i6VDN6tivHGmHpiY30XSoZvVsSElASpjqinptltoh3+O7ln0V8VqOHRqAqL/IcVRVvplY88dWOwbAw3QpSNnZv/kZeV64VGSDQfsk86GF5mppHMSs5V426QBM9XCaV8WvV2eNt5TA424ukBQIGqjiEi8akNHTkw5/v4+5U6K+Ok3HOKhNGscGgMGhZ84faQpIYXDas25pft/AChyYbHKKsGeA1g93+KtobqUkJ8BdmhSj9ekqYFEkgscYw4OWGQBldBUNhcFIpIChWCTXD+GiSm+oSzQR7JUJKg2PXZYqdNB6bZ/kDq8+Je0OsT395syU9PIppT3Ae/dEPBjzd3XToVDPoeRRl9nUnom8+u2DcX2+pfRUJM1CTTb7uy+1/QHlwwPPvY+nFM6vWeX9WgsnrOIeIpIKlH3UOmJjfRdKhm9WxXjjTD0xMb6LpUM3q2K8caYemJjfRdKhm9WxXjjTD0xMb6LpUM3q2K8caYemJjfRdKhm9WxXjjTD0xMb6LpUM3q2K8caYemJjfRdKhm9M2d8AS0LP4in92gsnrPL+rQWTcLg6VagwX+9Z5f1aCyes8v6tBZLU88uQHU2D3FHoDqbB7ijnyvUi8PFk9Z5f1aCyes8v6s+hgHPHGmHpiY30XSoZvVhJhMEykPNKS3FgkRYNP5GhCbmqxrBKJKQ8As/ph6Ym3joKywdcMw5iIbSuSObRstQTMxLIs941hK3wBeVhXSodMTG+kkPAuJqUzKN6y74BZ/TD0xgDRNps1c/qDKNZpT2lqHhQursMNu290WXw1ghnVbgwYjlop3tUPJ5HqHTExvu7L8qCMtB/O2y5jfRdKluiKdnjkZm+i6VDLmOI0WVSJuHnr8m2OJTsG94JJKs/EhDOjsje8OBKjuxvGb9C24njRevRjpgYEszunoE3cTG+kkPAZSubSvkTDLDo7igPLX8XmU7iEaDE0uCHTOsTqdgfKVZfUExyrBc1K/7/W225C8jSBVHMt/Libxohxdh5gPe0Cfi6VDN6tiNFmIV3QjoosJO/Osi4SB5nnRT8VhOiC+aIRnk4qerIzHUaLRKwgBml2BZ/g0BgrA1jqgOygHnawwUa2MlZ8rTAIvv6UyRebHZJSs3Lt8c/lt1/PkQ1L3vDmGLPTZuu28XdtpsONQKLwm25j01UNbjtWw53TMoUwtsIZEU8ucqpdWRftsOyNSSHVLTquOAlIPP8PMwNO6hlzbx0Fdc3WGIJmvdpQljgRME0nVJDpxjeyukoqbyfSL74LF6s2MFOWn4gcfdxgpZNTcBoxFgvFvH7KYIYYC2RRX+8ZUk0wfudzLB6YmQwEOo+4MIvfD52T+JNWsLXzY8dpIiLHfTj9dDYTZcTSsElxctZVSehhsEyJ+5slaYjACxdKhm9WxGC1PWs3MvtmS9TrfrY65tMZgAhKd4dXvRzKvgRIJGeONMQTwZbwA8tlokgcKtaglzdWors/jZ6c/Vq5bgNWrzfGXZFA5XlBTHcwWK5HkX1omN9F0qW6Ip2wRAUR1cxvoulQ7nYbAs/ph6YmN9F0qHc7DYFn9MPTExvoulQ7nYZJoCnmMp0fnQMtRhQN2exeLGQ/V/OQ61zUw6wAGP2NkivI3+fb35IhMrUzBZHisNcFt0q+6db42tlo+/ZgYDpt6reYAEML5I8ruVnqNy8H23usEQx2ent4f2EMk+e7qMgspkS46svvD1fq7PG3p/isVgNZ+uoBwSRBtKgFcCprAVL6geRD5acP17UM570P1Bc5cGLBEzUicCoWMZ4i4lvFCcyxVS6NgNqu5OFc1TdYt8OaccIkTK2kBUzQVT9eVL7J415WJgGrdgfkzHjTVpHRe7bF7UkzqxvC0+uFzv3hG67kNVXYyh6p3qMQVEK5t46C2wsvDZw+ciMcM8n7B+2k8FMII5AIL1YxE1iRoCYUuIIzxxp/C60Z6hbOF0Hs3PHGmPRVoSM8caYemJjfRdLf3juRnjjTD0xMb6Lpb+8dyM8caYemJjfRdLf3juRnjjTD0xMb6Lpb+8dyM8caYemJjfRdLf2GS/aA47Izxxph6YmN9E8Ph4THhvtOGPiHoDqbB7ij0B1Ng9xHyAdlx2BHpiY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jM6FmMnwkIrJjeJH3iR94kfeJH3iR91h8d/o1xxUvjVzA2t03DrEZRnZHMAz0RiN35LIFAPJoJLgliSx9nWpdpP1tZbH80mbrTJBi0UWy3CgrDZkd7Mk6XuVcp2JQTmA4I8ehgThBIQf5fn4IVSe7jDg9DGECjPF3AKEGMCZRdeilijTIAA5eKyLh2qpRsEEFyvU0NzHN2JACntsKdnZGQgZX8l9lbolWh3DtxyH7tehfWoZ+poXEJORCTNQkzULgsHcJ5ePcy5kpEBQ6Y2mT1nl/VoKW6VDpiY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy4rGPNTusm2nm8RhmqDSo/C4+8SPvEj7xJGo/uLTnqUFWIvJZluT3yUJaMxLb4aYemJjfRdKhlzG+i6VDLmN9F0qGXMb6LpUMxiQ7Izxxph6YmN9F0ra3UOmJjfRdKhlzG+wo4BZ/TD0xMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQvMfUiyJyCfqA0FtACh9LLuZXTdcFPMJJI7na1TtRgP2x2hTwkI14ykTgbAhPdmaA3GoAdyhgajnmDbnBCRrHTZNy1KCRi/hCqyFfF+A5zEH5C5VA7+oXZvoERU8D3+DgEk16MO4i98Hp0jpPPGZHpYpH+rx08LR6AAaZU4KJZ/rmnqC1UPRy7on9DdUenrYoajgCmqIJinkOjEqejr0hLUHnhAv/WP4qi0uCg5JIBV0AOYHbVbJbEaKLLPRKiCzQPWDrJmAZ8hEBs5C6Dzxn2t81vjbpd6VDpiY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuLCH9dm3aoOt6YdcJSOYYBUGjNlOoZ7CNzanvH3mrq2nm8RhmqDSo/C4+8RoOGZbis+k+wfCTcPTExvoulQwGuBHx/QR9I0w9MTG+iYiEUyN8yT0bBAxWASHLICfoj2440wpY03wBLZbaf83GrtXxGLVVEuIPRxAMF8pnngyznOY6eqYCf/JGks3k2fE0Xw0T6w9MfP8ZTooVxzNXVOJ4+fb0LWCS2yjJ7y97cN2bbVUbyoZ14HRvUuh6U4vClW+YdrNRx9v2nWtJ/dAn1Gtuoh04pbcaiu+edDVnjjTDvgjjf6hlzG+i6VDLmN5S4gj0mEtqOspjduKZaT6Auq+ecyRPsx0zN5OoOIRGv0/b7jL6dKRIjhubYBGknJB/GG6y5l+ULoe/V0yqwsWOVdHKyvRUmj+e6Ri/mna7Qvv78jru9Yrg8cFaFIBRXE0euiBU4JXZenhdP8wOWN4x2p9BHG/476nHphqAhp1A0n9Bmjqhj+mHpiZJsqLMHYL6oIVzG+i6VDLmNDeXeY6gLDC0gGJmWNw3KkSI+iQ1EPEbc2I6QJpVsDjgEBfNFzTq5hIdjBpALONDb5miGm8wkBk9z8abMEJYmp7hCo+IExFd1vrA+DXlB78hoNIuTDffYgFROyeQQdcNSUiuar3jAW/aHPjabfM6C45MP1yDMK32jkg8Fkpg32VA7gouXD9bM8g1UNQqeIwNO6NmPUKgM9Y+2RcWyriKhsB608NobYP7e4tC+MzpiY30XRct0NdEfdwAtJUssfUI0x+IafvMSiEDmdSyNKMGXeo7xIrPuERRwRIUB4XT++ygJyo4ZE+vliWh6ytnFoHf0IcQb6QSnpFZlQUS21fYkGnYXR4UhHI+Y+6sGOwoMIppWCBFy3Q10TGWUUqGSoYyji7T4yH2BrCZvyo/Wf128pcQR78xl6mJjfRdKhlbhEUc2Tdj4S4C5uE8g9fDROEgTa8kXQPQ6XcIqfxLfWEjwQE3DJLAmJZVMIhH8I6uzcBofdh4BjfNbksujHADgPyNILbHBJmyArZ+zxBFS7rNQUJercIIQRKNX9vlcA+5sX8GGZeN8JIqwB2kRwrc+oVfnVUSypnsFkp9BBFY+9RnhuLIqj5jAAEOGsBdvuCol1pPTFti3dhkSyrWlr5ALV6CAqmORPyKDGO48+goCvUtdBGRG0wdoL5XDC8rmuBBDKJQk/1tjTgna+OOkkKC619kdn7VfopIFTCiYjCiXETFn9CbkAFA0Sxf581f5mJEfi7GKaKim3fBH+TRrLo2qV4PcllgRF3xRlXEBJir4HyzAHxxkDR+x4FOmaoTJmNGOB3oBeK7fDdwVRlHEUz2VHbFERSFezKBCrxr7Kj9Z+YBzE39jfRdKhlzG+i6UbMeCoxqClR+Fx94kfeJH3iR94kfeJH3YgDmPMfUSxPWkzLcnvkoS0ZiW4PfJQkARwmaIP6tBZPWeX9WgsnrPHAHFJ8CSM8caYemJjfRdLdg/6VDLmN9F0qGXMcQvkU30XSoZcxvoulQ7SRYwetDgOUFyBEtzCqwjMiq27rAQbxw0Mi9j0inYCZv/WtFwNIn30LoCN78cWlONlMIxpvuceZU2p+i6VDtJFjwOwPQDIVMZXVcNazadPCG29pTcTgMoCjI9ratjnccGCf40tkUtm61bR51gEeW4AbtvIQoEtpWLpnZGeOZo7SVqlTvw7uP6CPTEyFKV9jfRdKhlzG+i6VLIyZsKlCRwcRObS+G/2N/Ja5IBs9YVgHQmJZFb8OYkEq5UDxbOJTLl0tETPXycy4QtKg0fw4Rol9VIKYGfWC6vOB6vk9lYjaFO58PEK0z9oo8OzW5luF0L/RfWAVNzUt6MeDxsjeH1mWrCJDqSSab5EaN1rskeh1sC7rioiQBGnzPnBTZhS86lj1B9gACTPZE36hjFW74GhPap7wkWV9xjl/zkryplR9ksajl6Jpjvtr7B1cvsBQww7FZzQ5lfzXNMLP8CTVr0u8j5uEfyltHsohgihwRG/j8QWbrAAbIXpx9vTzOR+JeCy3R5CdeaDeDC7CkzFCi6hTdZgHCKCagFyiNh+5XXKgTfOZlwVDl78XWrp0pLM4OmLJchCnubX2ye/3Q7SLrPoRH2UIY3rzEuIm5wmuaSq+Wst5foutxBrvzYqzmJoC81p3UsjJ+oZeeUDgEyTIdjzotdkZ444EmrSQTRmwC9p8NbYa34iiMkBGgRJxBB3YptnNw32CZ/Ql1keJ4Ltm7spOAj7y1SeqHEuxzaNml5jrnxBnXsHG0OQrbSMQBYCYp1mTAd4EKL7i0N0vsFperE/+gKlpUswSVnEWZUcagY3i1rw6RKZOI06ocUE3O5mLs6MOGOTHfbVSmOuSHVAF/0jvoNCHPQuFfZN/wkpQa07Y4Ra0VLYUcCKcwvI6pK4ccy5RiJ/QxLqiirAwMy7AeNxSTfUDoebTR3eMA+ci2k6piC3orn2UxXeiz4LpbJ31g2RMnji1EaHibld5IL3TbL14IHnTdZXODQ/QSdUQvULP6Y77a+iTL9Y/pHONMPTEyFKV9jfRdK2t1DpiY33WCTOjv5k9Z5hpfxFP7tBZPWeTeeM8caYemJjfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvot3FzoNaDSo/C4+8SPvEj7xI74YA3y7gBC/Kd5Qz5MJ6zy/q0Fk9Yak2p5mOSyOjEUuFdjiyDUj4JjYFcWP4isUtSq7CSEmzZRxSoYysDLf0xqRjalENmDhfRyFVS+ob59gNSA5Bzq09lJklTGSjFj2hxo4DAy2sDIAxJ0ksNYCkAK3zakcupQhAC/mu9LOUmtgFLQAunkvosexR6Rpf0UGPGxb9ieQjQlKmppYoej2z+Ckl6UMRPOSqzNRcfeJH3iR94kfeJH3iKudSs2Raka6od+xwdYQ/Y3YHsOe6CwZGeOUgHdQ6YmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb5n9WPkyOl9W083iMM1QaVH4XH3iR94kfeKm+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRbvFHWZgcGDLmN9F0qGXMb6JT+bzyoDG5/3YIllmfgSz6EIdh+KH5SF833RHhjkzSiOIusnrRo6g+4vTmGQkzH0qJ25XplyaG7EZ440w9MTGcwQMo4biSDdU5dVIUkHdimE5sGsMAkh2QV49AaOuhjLltlzG+i3eKPCgIY1D2mGhCJKsGMGrpZTmXPBYnxlstUL1MRFglt46BoS9gGHBDiYmSY5WvtgsCnJ8TPf2uscNXHtnEjO9TWgL10a7s0zh0MO6wzpCtc4jiF7fSE9Z85NqpVFQE+MqnjhGetsUHg3t51T5dRBofBZg3wTp21+JnqEIVOXWTjH9CcXJuRq4yZKVS6oZ69W8Y6cZWS5/CH812mVnnP5i7rEXFhMiiJzt9djs8zsI2Ej4Ad+6vahOv18juSAEAQGjfg/TtxGUpU7EaUODl5NH5M1sslXSJ2+osi5v3tFWf72h2uXNc6Y7m+lp1MDsLG5sVKx4FsW+p0ZoLWJYzJ7WXL5EveaifGJKN2AUq2wimZiwCOVcsrXmEy2WuF4OIUUBb4NRrjEPv+UAql/A/crPzwQInhuuhGy0U4wNR6v9Dxv3UJapBsamxPr6N2w+2zft7dl26zyPayglRm27PzaYeSI0w7it3UWO7SCMVAxgksRCSLZuJIFDZB+EFwpyDj2VpXmxJYIfMtkXGEprKquulFqhoulEXZph0b47t9VYPTEHigz/6/9zv+K49IHgQJrY2EfC2Lyyb1clkQmEGDTD0Xt85t7q9HyqY+9xef82+qQ+yVYIDHTde7OLKgbNYsQxLbuSBFrhdf+G4qn5MZOoPWSxIyhLzMVOP/EXdHwAlhBGV1TJ/y0REW7ZgO8Dsjes1xlNwSTF+eThb+tVLRZbK7c6wk9mLNWXSoZWMwIIliXUmzg5NcZLo85Iyl8g1UUsiehURu3W0KLhurk4eKATOMnKD9fBZh0CpYTdxph6ccjdcy9TtndW+aqYl8BpzWQPOkQaL1Ub10QaJI4N5pJpTNbQyMgFfpmRQHPsGoZj9xl30xFRTnzvVDkgXN1IjZvwp5eLLA7YMKH7UVAhiPtSyhe6T51HEHOeR/0OxwYdfsUJWmTp9Yp6979NC6ISTRjiEnXTd0tSs7KoHMeEY+Cjbgl4X+BJgmmgq/lx9PaYa0pqFlyjkcBdo7kvP6f1EIRbDUAgCtqjvaS6o/n7qq5clU6FBXLmoB3srodpIZecfkZRvmomMtf48erd2BsO/3UofnryFEGKrEbeKkIjgtAmVH2mex2OWXa2bM2RE6gj+HblVJhTlAu9+7VjFcDAmaMWYbDm+/HGcz9qlcuh1hc6QNClJfBXB0GUXHTbbAe24kEM9blXRhgtOXkAxEv5+WXHlvsRfn8jbkrlJk2HvsJ7kR5t1o2MOIHiktbYmZ2Kso4DLhlQ7zRwMpXp3QErJBnGwMLR2gUBmRTwDStsHmXqfPgv9znx8EKV/hQYUzzle1n6AFFWTEO76SC8XetdiAcZKJpFv9UD1VzVGlaDa1uP9j7uNpsxB28Z+ke2kBULt5LpgIbXWZwybllkcBwPANUMwO2uGvhS8ICP4PprkAo/RGpT4HuEQJbUJQHi30iG/LWAsHT9hHgnHDq5jfl+d0K9mYGnpDzxnjjTD0xMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRcNhZ/TD0ThKH3FuukLuBEz0ek09rmUoT1EJI4kw5pe1DvsLIiEEfC7ziQuqGXDRrea5Ol0O4jY7dbjL2ESXmeYvyEJQJ78hxvy5zqCAIqsaSGKincs+JUi63LT+mHroR3148ppp2kl6vYzt5kBf8jxd9uLMn3ifWA6U/RYgU8oEvzQbYlPqC4ZMh8sHoYbtKaodE2EX1sYAPJkkmn3s//okmDE41IUMbY30XTCKDjj92ycyh+9Ixt+c8j+eTE34Ch04UjKkdHzDDbHq2xIpIguBqdMl5d3xMbwi5GI8IQHZH/m7oGjNYs2gZH36DgQtGMyD3llYUxfC4lwqKd69Ltp2Aiu9sk5QO+YINF2XBnZbzUL1j9LSLk6ZVNkH/kbl5GBg3Qn4F7sMMI2AZNawIZw3TMj/+W82QIDPfe1HqEGjEpTLYFDfNwG06yoyV7RDO7sAfpSGEfKSMkBiZQsRzDifcv802ck7MgkqOEYQ3aTPiNMK7rGIDHNWgwWYqRkOinh+7gBCpoOTdxaBPt+y5jMg+eoDm+uirK4QwOPqkjO+ageIRbot3mxwz4EdS1s/pfGqrfuRfQNq5yUEmxmV7k4thmdDHaZcN75qFqY8+imv2FEVn2AhD9hPLt+RRXU1fb5uGbB7xRQe45YjT/v/CGPcbtop1qon9DRRGRfg9fu40uBSrvIC+YD/jTGjBET2EUcOBHYUB3F3Ehl+OTzDAYmSj7qnIIeOVl/AZl4Mk7RNzIo66qDJH9/Olkp64OJdjfdYckfqSzigvy3C89xAG77mSa2tVvU+aJkOCPXX+7NwAZJlKFNwgVVSD1PNv8KWvMjxNayEmjLXYFdNTF16d/mMAqBr1/FwNs2MMhD4DH6A3r+UPXxUV2gFnetOxSoQxnzyfj8biaffAJUDps4nRBKhle+HuCJsjPdZD2RcCZeE4Fq2Tdp06IyC27KlyeONMPTExvoumCkjPHGmHpiY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuYzVK2yqCrl1pbMBmqDSo/C4+8SPvEj1yvJUcOH9Tkel8PDbrhGaKn5bibYqQclKhId5x6QUXbk1m/S3sk7C0I7R9u23UHDUvA2nMZPTR1bk6C4Rxy5eILlCzV9LLzzxLMzZyKx9caxxd32PJqvfeeOIZ/zd6npY3vJ+L8Xfcya7doR/pDPEpYvZEQhvNTfijvhqbYwwPVL1oBjq8wWxhU3VZ4zSKul8L11C9jC/Qjzay5a96KhJmvqZqEnIhJxSSY0OmJjkICh0xMb6LpVBXMbvZrnkYZwXnxNinSFNRHX6Heq2j9ilV+CNKsuLemozNrQCI+yU3bOrvL4mNdgWKHJOEU6q+hGqz8IysIUMZe38BE5MkqeknpYocfpOuUQrvMLtnF1CtYPvZQJNlleOJft4NlHhYJiMjjCkf995w9Yusy7p/zdyfKd+yGIrxCjKgoTOrqcU3/244kSrkQkhubm7RNiPgbg+ntU8xiRS9MkmuPOFlfKvKxpTJ0Egt56bNcGVkvyAW3/ZwpjRwAMEFAvp+I4y+H5I6bpCKMUnL0mcLZPJiDOyfksgGufxGU9QCrYhuam5supkjQ6jKkxkEvWQ88q7CyHyPwlEWu6KI2z4V67clKTYqVLytmkyvial598gUQXQ6pSbPWAIN7IIP9i8gdnjjTD044jP6YemJjfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGVj0damI05zjqO0xA/YoAZLL3KFd3Eac5x1HaYgf0k7qi/RE/TghTiKpiLxkryWISWlpyXG7A9hz3QWMo7u6CxlHd3LBZ/TD0xMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb5daDqccTiiBvlbgvgK++bO2046KAndyVSt6i8dPuP0EuxTf+df95Z7z0ALkw/DJaSd9uAWf0qWBg3cwkDQLOPoNtOuIvDxewAN0oTLOOAYDmW2ZnEXJ6SKYgG3EJZXv/FB5OUObfDIuUFZKoYxsJrEQwGMnN7aKM8ywMS8srGmj5T+UxTiLaqA0CpE5wjSzlHfph23mgxsr+SoTM/v9JyeSYk5oMiKeR8wgce81qHecpXegtyQq8AZ1kRqTWk7OvfPpZUuXn2TM2Ab6/UUxVI4CnbImyzEChGjwDOX52ZyvqmaMBPyTYsgZz1Ui1jgnDl1gyY7GlJlTLkchJuwCpKmGKw3LEuA0eeywot0uv+SvypfANtQvZdfxMckoQelJAsx8PPyVwtsDU40Za5JHbj83C5h1BeaBcoHn7RP9WTZKCrsuQTFLIxXMAw8mLnweaChZds7JSKshRcck+vwg0HhMPYNaBK45W8GQ76mNgXyEu4f/ncg6XMpkfEApkXvhwyzokqpiY30XSoZcxvpaePj6LpT+r9RvouE1bjz/SqdU0lPubmLtiVZMu2Hwghp2clq8j8/e/PYoiilImmovr5Up1D6yacpnn0LwdtQC+wBj1gR8Sf2VZyAhOzX9g1dNKdDK06Zbxz+VxbBs2ceh/LUmOhTqfPxZzWvXuI45bqb/Hywf8HBG/itbD8GphuxJwolt5WVP8M3NyqVWTjAf+qGEQ9LxT7RKVtWFqKCU+EuRdOclZOVXPS1AaVDuco43gp6vrxlGqj3R/opiQgBFmUiITGB5WSGEk0gCHH7NQP4/Xnc6KNlUXGxkMGCp2M/pcY00bPG44p6SjO9zLAsVxABS7OHgIkVWcN9jjqGV8dSt9crfdgAKc7G1f47f/tP+WsDAu3sAHl5Q3ib6XGOcmkQWTwx3/sbwdmuW9rkzOUP7E1fX3T98SDPOH/DmGbK2UFp/n73/xRHmjne6mFcKGB4SrmI6iZs/8MqQL/hJddnvzUR7SjVnHUKgmErzqBqxQKUo39V4ABrBJsizN0XBbTOgCFr1NcgQK3iPyiN/tvC5Up4AJ8fvfssAj1vyB2gYzLO5AVDkZ7MS0xMdzkaHwQv8sUVIth1+XMb6tgWj+xvoulRhAHBxOK/McHEJGeOUXEyjgGBVMTG+ib0wdejS4EiJF0dpiB+xQAFUNCXaR+0JvvSodMTG74UMQfFwR9B35VmCrKckbbAxsY37JocTDORIj7Sp0fZXSolD9PY9xdiQ7rVe3ALP6YdqU3bKj/ZN0Td2EpabQVdnMEq93SsdXS8WFpnIUkiGt5vGJSq7G+i6VDNN106oughiphjev+wfBtlZzFBtUrFn+t/7xKhlzG+boiQrTr3yUJaMxDhXrQkZ440xe5e35LMtye+Ld9drqGXMb6PXYHsOe6CxlFUxMb6LpUMuY30XSoZcxvoulQy5jfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulQvzVLYHreF0dpiB+xQAyWXuUK7uI05zjqO0xA/YoBDrEO3Q9DNKyBoyqS5lYFaB8ngGBVMV4ySeoRj6PXRSofbHGmHpiY30XSoZcxvoulQy5jfRdKhlzG+i6JGT8As/ph6YmN9FvKxW8GLCn3KXB1F3FZWI6Z0LeRLWr89xP+hZMnbFjXYMrkZbGTYSIPj7TJfPHGmHpiY3euYJsxJpvvuj7Ggusg69OUTGK3Ly9agYcMb//C5uV6QLIkDHgYdVvAKXJbpzVqM4AwJUMuY30XSogqS7hE1UxMb6LpUMuY0q8ET2RnjjTD0xMb6JEZ5+zN5QBPATgh4Q81k0Mo3RZoulQy5jfRdKhn++PVKHZGeONMPTExvoulQy5jfRdKhlzG+inSKt9mAn92ggUfUnjjTD0xMbq6R5FIgDa7h7MGHkhpAJbv50i4/bvPu/n0pDHP3rXz1ix62aoQLWyYCnX2XMb6LpUMrEavIx3uQ96tAmAEdiBN2ssiz+mHpiY35fwHuKPQDwfqYmN9F0qGXMb6LpUMuY30XSn+eaIG5VpFmqwy/TD0xMb6LpUMuHMtQwN7WhH9S1OjtvLzjTfnnJiAs/ph6YmN9F0qIG2N9F0qGXMb6LpUMqjApy/kFbbfhAmvukoE4lUJd0mvXUMuY30XSoX7ZDlJdXtVLeLCxqN5FNRfQ1TYDN04B9Ts8caYemJjd6jKwZgX2x1l9Dan6aMg1VjxVopL0xMb6LpUMuY35UVZYz6mJjfRdKhlzG+i6VDLmN9F0qGXMb6LpUMuY30XSoZcxvoulEIhr7KcioPIOsBYqiK7G+i6VDLmN9Fu7JYJRDAWD381ohC4Hd6VDpiY30XSoZc6FdPI+i6VDLmN9F0or9d2Y0IuC2jrVsgek70t0oTdrxZWaNbybvmyb8VjPOmgvfa1sb8jBDQGqAPFsUqMtgaRXPpfrMigBFJ5hM74eC1RMjTD0xMb6LzIRetwe0Ed3NUMuY30RXDXzSRJb8TDIQ2A7i1xWNDf7ooIqmi6VDLmN9F0qBm4smFgnHCowqYpdKhlzG+i6VC+Z5G7cqRZNOiiE7j8ftZf2QU58YT4clAt+Gb2n+nZKr2TDKhlzG+i6VDLmSkYikNbqHTExvoulQy68ZJPHGmHpiY30XSoa7XUMuY30UULmpiY3zOwfgbvxotq/wgjb+QI6/oLJY7B0kJdYdvBg2TijNLGzArHdd8BXiVzG/SGQF2xW7jopAmzJHYDdGRk8zF6ENqtlwsT8pSO2Z5n3Gav4KalhNTMZDsjPJj2LpPKu2X53QrmN9F0qGZvviwWf05Ab6tgWf015oulQ3sF0qGXMb5mNv/okJcfeJH3iR92nH1E/rzeJH3iR94jQLswjsEj787Mri2uvOLQUl1wrCFHb5XewYigddpm3FYErvYNgn8Dt13kPOpWhGo2wL2cF4S2jKWvm0P4oyqO47LqclO4igLbA7ljxwNR5xnqb+Z+i+46X6K+pmoSd3R2wbi+6o964+8RHbS6bl63pDYjTD0x42OzLb73KHDxyizY32FHALP6YdwoL4qDVBqg1UWRDUGxwIYBZ/TD0vV0vUPGX1YavWaZ7n/cAA/vwy0AAbhA77pyHH2+Ach75utk6Nap9oWd9jzRHtiG72MGwQ1wue5YvS9F6fxbrXw2ttwSCeqLwqTkMWksF8oL5NtrwQ5jUPtzVGGXM16ZyACP5eMDZOm6d8LNE5RkYwsgnIWo054fGMJ/oBdUwS2jnXsgT+9Y3Rw4/M6uBKbHJNlylpuu4dH4YI+0vj7fXjYuVDFHb0sbS8YW5m7rE6kMsWJjsrvDoi2YT4oHXOAMr2YhNLokynkgIROKTGnWaHQe2QS4oyGhT+OxOZnRRuWLzfeUbtXtk5ezDTwaqK/ARbwLMnkBYzyiUx6v8udZ9+cMOThAsXQz6r0/H4G4U7LuAFy+ldaieihZasKoQeQBdaOfKUIbIFgpsR/xqUWdtkW45KnHvLNYlunbRJzGRuHc+/5l11DrHj0luCI6JDefWFjxunK2EMn+JfnIBHa3/hFfNgWXXbQGJGqxvY2yw/qSDV8Bwuv95QqYuzjfgQLgWtuOIn7qFHv+pdh4JE99DEnr1eNtPjftJ0n2cEsejvF/3FoTVNFFpiLkxhZ8DdxdLvJ0yhxbgMOB9upzr+jB9b+0o6KG6/b6a/au+yImjNJHwxO6+MHas+jZ0ozyKrWvsEDl0woqH0R4WIBu0/MA3fvdae1Nz5EyNrGctJ/73+akiAwEzzKruMaCcPNrL4m6RnmbZRtYNjRS5a5z8ZYxdeL/bCBNNaGUpJe/oA77fz7CGeVDLWoJLAn0y2J4D2dYAwwmpYRSugAAApoSic5BndwR9V9ZoGjfJXAaJRuHW9MYkNdkFIUYUkRQrQIGcb6RsIspKZZ6ocDhyZQ/k0yYZoMkIPm56888nuyFcvWEHIPCUu2Fw0EyHgNtbFad8ks0UJfYSHvVCsyH67eBIya0sTx89yIorfgPYvMfQXgWvOhNcY722EJQfpgYvtQ2un/6UHj12ML8FHua5IuGtsjCoC/rnzJrNG4+6ICIFdG9CRsz/LMVSHfDh478C5zLEQZLDgxkuCYawaTFOrCVE8e6d/VZpJtSrOzSmuy/mn/uohziCgPwlJvQdD14GWwIXC6znzaD2TN3YxQKBHvlIgpuEqzQK158cvD0QE03yE8N089ZfURrVRzZukyuaO0eB6qfk3Gdq/T5FB4YlwdcDbszvCgxvtm+gzJu00cUbJpGtsJpAiNFjdazMjqwl1O+dQv/tZzm+TCJLoEo6txzWfiLjBtvU1Yv/IrHPcvr4oqkAQXFosi4Zrnfsny/uqUqPpuOEkKjnT1HqyBpbl8HkduFb2G2aXpDcZL5DhG7JDRRCwuo8xPgpOrNa9yEDHwIxubb6C/6KXq3ZiyvpZDA9UPJ/9uJzqYKPM3hZYZZzSluxZ43k7TvreUldSN5iFOk65AAek539W86r8lNS5UP5uaf3j4HqeR5EFWKLKPQWFvXHrEw7aJWQ7wnbNbSLhF3l2vEkT6V2ilXnbN3TCEuuBGSXm3FBh7w/M+7I+kqll4tMhKQ00FObKO3CqrvO7GSmQ9eWdDlLE5brt0vbcOqawMCLWH/hlQ6JzRPZRDdDRW0jUSd9frMQO81oqopDvtFg/caTn53bC+HVd+vThGNOcuhk4tsZh0lB/ti9yPxQAomCrHX27QMCMoUMAg+MX3ZEMUPm98bUfSKWCce3AFRpYJOxdMygwcEKzYhmJO2WI2CxAW0MerKC/liG2jd4qGFApe5++VlgbMHDt28HYIV5z0p+3O9jzZCxt+V5Cx7x434NYugqvYG+2i9Kf+U6fiWicL5OxSzUZ1oultA/M0cJafxeluVxVQC7ECN9BetnXLiHhuoH4GdNp6onU4L6V4hfcpJ3eRHsdvoHiM3emhoT9BvMu10UQ2I0S3IwBdU3J2ydPpWZ7Pu5JdgK440RQwKBuW3B6gF24rXW1n2AfCFggH8X7KCwU5UDYPWo/5Bl1hB9Yz1HWg33wCRQygrfI+C8IgSz68Dr6t/JBmDV0Xsh3evvt+BB2TTfMQoeEKb/vx3N56ctfI2Dc2bV7y+0oYLibx/HEQ+8mynGhR0w1jcnN8fmw7q59a2dSuWNGbjV9ASJ8D3PdKQI+u+kKG9o1GI8LqWa7vqTIhyoBRhwJJcklELgbsAs/5p/1MCJ9PponQX6EQmZL+rzCFH0YFgqGpyUAGb6CQc4VBJAWqXZhHHZ1sT28qLb1QboVd7jpTqzBiRwJOB/N4yJhwm7Ks6jcA4+jFOd4B/umcPkZCRGxDFJtNJZcNCvYVIHRhgMmkDtM6RkLgJH8fau1cjvoiJ9jeJNeXQlFjgULumYcOnPWJUmHYLh9e9rAZQRJUsE3G+dxdnrlxSLgYRdX7I8+ER3BCW0sezykIRXI1+xUKddC3LZVG6AY1/ah/G6g67FZHwYEGZch7PgUkir46l2gEzYuV5+fjY0/0Lv5+f2CDOkC4smx2eHQiP+DkDupR469j02IHFVONmpz4ib4uE2xKeG9ajhd/PzSAzQMcjkg4zZnaUBg9+sDWzYfdEkQT9oJBv01ZN6ysi6EtTwyS54MNjr5zQhjSmkx/f87RhBTldB7WQkaL+/+ewQ7k5fbum7NLKhkYWyhqTHl7fyy/tnOSTqBd/eEadJKeNIHZHuU99ilT2FqtpbqUULD62NqCXSDP9//f44szZMkXVmhVCbJWlRPZn1dgnKhd0gGPa1m+Gv8ZHwYVah2B513fRd77NIqUOlklptZZPdikKg6AC/W5wkDO2rpJWEKzp9ixVlNQSrDwWzL71Uo9OVooLuKdbi/oI/DFkCEKn6u1cJAMfLvHASt0j2CTWPeW7oSfIrypWRQAgy9rJhup9JaJEFkoTPn1k1ty8k9HNAew9Cu4KTcR568hz24UdMa0ExbcRKJtt3ZD03vcau70BrtrkiCCAMLMHVAGI7fE+RRONYOeL6zMF2PthABhLi9qT/IJXgLHjNhF5y2hxWVc1FBSIsrfDi1IGhlvCTYXi8a4g/gKjzvVuWFDHaWzk1/tyuEXEQIHdaNisACSbaxeVtGLHN81e/eNB5PqFRZkKji8cFaGCRPQLHQE6z+M5TXiyyXKpKIv50gwfSp7+YOzOtSkGkrf3kpRDjzkIhADH9o8xFWUKEMvBsN9i7L0A77hHpKKtRqEY6sqOiHmO1z3FZoWrg8tGpWtwAGwW3+9K5LmSrzGmuXNPVM20p7Y9LB7nu3iZmner63nIiw1Jx8LeXVn1ua8cIYrxjaclWYa2hPSPF/iHcxTgDQWxlZosE9ki1RNuJEe3rgfypZ27JExbW6vUvmT4vcT8CAHTaoRgfD+3RykJqOLZa1FHQ0E3H8rGEuErEKKgK2ezLplowSFocKjf9eJpnkJiQrFtyQxMhd0m0GICRICwOHuok6nqEuorYrjfCpbkB8C72asVdPWycT3QjPhdBj7bqEiw+gm/lSWLKeVFetudUsy5WFtqalp4fMWEu8Dqbt9BfxEtG21PkJJjjdAwP9Ea8uXfzd3zMKQqJi852uEL5ay6EAIVLS19zRQFw0yIDsJqyHShD2jwZthwfiPFaR5BKXOEZHOXFRs1Z1kagDNJlk1mI3UpJoL58ZXdivX9tKwxRaxeHDGZhQzJU5wGqCyGwozjZxuyyXw7eEw8GwywESB4G9OOsHxxavw8GnAH8E72vwi6S7ooHKWNRAbhjrpYEd43v6XEwiwitaJvpP7Tdfle0wIibkAUJcyK8iac/fcwZUUF/jUa7KlTKld1mKZwgHmloXy3Y6QFfrVlW3oys6Q7HAVNlu9JScnoHiKvxYEYSzH8f12Ov9Hlkdsfgm0/YIMsOIAMipZHNfhdYd8mklo8NFj69trUnw1QwHVE4iGU9Wiekw2Excj+FCnrEoWu5A7awAKjKmQGC/4OyD8EbVb7lhriucp4t2KvctuFBR2/Qo5bdfQP/UWgZIf21sUc+HgpXJHyDwFJRKqg3fXwiMWPAGuI1YFi8hbJa0+0IS9abZUu0iE2qUfh26JiJJPjrG0vUG+Q/Jcfym2m7lMGp2RABWf7q6wDrUPSWIPi4queChp0NQZT9RCr5JB9tOSUHy348E8qfv1ANLwM+6GJeTAeUcPLUXK2ejI8O4/UmaNJPtRQuAZaT6QLS8Z77/0lJAcKuykCjJp087+qb0QVJxF/7EGYhLcZsHdryLWoXEk2b3TFSWsLQwlNHhvCYuCXRQ+kiBvOrZZpMdQ2hYNkboImSMDAtO/ni9e0MvJJeL164mhdUDxMFqR+K2RpMH4HSMn8ROO6xT0BozxZOPvZRqCKuvPNALYpcIwj3GjeTm5T8TKv/eiDu2CajGSjd3R0kJBYTYj/LCCXrM5ksljEJ/ZDio/yh2+l8c3N0BlcOURVH0r54+PcVhNwZiuBvhQf78tQ1wtgmuw0IUCPBAi2GhQBO9nwunFJ9B6wLIqw9RMAhmDKlWXvTiI9Q+aFk0O+yCdSCq873UHMIxWdDMUaClcRGQabjahEAJcw0x0Cp6csp1ApqLqXnZwNp8RePqeos4zFQlPf5X1pqa0o3fEv4dBIu7hNmjpdKyYKsgT3HNu6zDcOn5YoBGM8uSZ3z9bsD0kj8xOZCxBn4fBmk/ZQNwWdI8gBx67AWV6aW5eETXES235ppPvb/B5fVYAwg7ioZVZdWTvg6GnO+dUe7J3Vo2gHPEdFpyVIsoPJEGw5/h5huANZBtLG+gQACTuRnb5BmqPJNGiOFaAmE7DBLrri4F9tSfLo/6SCChuj8+ZZIq6RMpSkSpZVdNdrcbz7YcsSp6EwmK4igeUh8FMWhUVrZDgn0lCmX5Bj7st3TcF7EK3/hFtHGpPy33+FLIu0UyGwKl/le/EFsqP0v8AxP4AXLy1TwxS/2WC7x9DL7ll09tznY0UOXrZnR0wNKQA1H8EreDTCpUfqw03WikQnGrnN/O8SKNppqKq7tpEdPyNxodpbQfMVDBW/CAHAYl2ksPQc2sra0hn+EU+XtUGD2w7xazTlzESsPoVGRpIMrpQSOGMnStyKlBOdvrO9FdpQPgwQgGS67zgHpIaUbwIE6t33Oo8kiWSeWOIAvhnxeUwdJTydEEFt0/Hs94c4I81lh6/PYZ2Y2NURqv+7qgaCRJtqKpTO3/4povgLQmPofphOylwLvwthAOaNKnwdJCD6Ut6OZWejT8Oyd/ile/yDchedJ1tcno76WasHpK8F+xzyWVZdAN/bSs2wfD1e639rZVmG5/IvuBslmmzAldyhc1Xas46x07UBYZ/tBEF59WYxAgXYgyiuHAmxhlgxK+7vTaeFXANW6sDgT3ZBPjNMkQ3tfRdsnqL7YrNOqe1JWGn8M5XKwBCDjFR72Uy22zoKmpjaiCwv9PCGg5twxKIte0bfxLN3ercLif5Ch6neAdw6cnS71nEqPPjxOYsFuc6UG1a3bj9kOHGtzGFSkZmfDBOzlzmne+TC5SX2Dv21LUCdd+KGG8dWSm5Zz/UuinO9I+i+zXCeSctKMbHiI7yqv7bTj2f6BF74/eZet1MBgXJjffsqPQGTwz0OdQfVHnMObrQ41Ii6OREOMlrdjDLBic12RkfGVszQojCCsV10zzuox/GriSnMBnq7+tayLhwmS/0R9P90ww8VWs5sVYQ5vNSVx/7eQFze1ElqL//cgu5nj6Evk19Wsf1YchN6cqfsKiNiX0k+dEp4bfSa6HAZ1RV/BnUpyp7xs38vRV5dazWN6Jv9BByQBD8Ela6bfSF1CXVBK/DdDB3+zcuQDYj2Ou8jhREg9com7vNmXHCc3V2TevBKlHdfspIUEEj1cQqNdOuL4bxwNKYeqd0xHPYz1ISjJ1C3KAfH1zX/eF1qXvB+ZaK1IWDCJU1eFiQGW1V7xZdmDHAnNWom4E9m0mNbzi+eg9oVr9E5z37IhNwAXeruk25IEiIi/9CQID6cJn04M6a7ThtyBcneGv1VL4ZzaFXQQBkUCdVrVSKr/p8Q0Mtrh3bVpGkOSPfls1TeMfehCW64Rr7z1pWDE199T9Y1qgLY/4Hwo6hapJuek9TyHDIcnYtSBhqo56gwsf9XParYw+1lyifufoPUSSUSw4kZjSQHrdo4v594LoczZROOF9GCE+eWoDzgGLXpqHCE3zqQsEwH/D7WEtZxb4QWO1zI8clEN139oCXqmgXCJXIRsf9FYKeOUyZUIwhqmaoSLxZf201DOzRg3WkGDmTFP/R6NP01DYAIPopD1A7awlerCMDyw/XY2x9KiRGAnsCWUt+yL6ddckcs5Y8e/NUtnH4PebqV/uRKZFUSMnWZSTMXlyDCozM+rN1ztzOXOzSe0ElaCRwXwzkb/PKIYG5rJSMyvVlUdaWBw9Agfx1J0pAFjTdl8XZ0IE4duHCK5SaKpYHP/EQyh6ibSz0lydurwhLsKwoSpHxBQntZ7THBRzX/aMq7iaIDDJXYHfWfnbbFsakwtcMrslIdPrH7dol148q9hA9PLCWTdRuIbqpWp6tK7Q4BJkSLwd/yVrrq82VAcNBd5RtephahbDWDluoRM63oswG4KxP9Dloxt9tmFAWMEKl3df4192eC8PLjzSBE0ZbSf4u0QvXXm+Vc/eN1a5SK529NLxE0pE8F7/FeDTyKEdMc2s9A/Me3c3njQK6lNjzQCDY1VxTeIah2K4vsZS27NiesKxHEylaFp6yUjMryelmcHFZo2/OfNm2+vOM0Yc6MU2OM2/gqF4QSmJ1UtU7AqTmgSWJJiYvG0rHH7MxHFChPmujBVNPN+fkp1AP0l8AgWx0a2vol2ObcDL7bQiA+Aeq2At1lHTp7OM7t4zDXR6oqdamu0qB+uSvCYlbnQlIHwsleuuqLH0GFRmZ9WTwVeAKnk23380bZsy7oGCA4Su1C4YdvY+r6W/zvkebK6BOtjtveQA/2r0q5wdqU031cyNJrz6psbpsNXlvE6rKwxCplE9sHDdTyBPWcThuB1c4saf1hupUY0K66y2qJut7SaB4l4OWl3ExM0U5pmfPcv/Ikhie9wufad4XXumZMGPjTMpwUFaOzeQUZThudjVwCj+RIT2t1+Ofm81NUHhgagG8xTPnZjUAdpZkQm8YERpDLwM/SDQAGp55rzHDOLfKDIB+z5tMLMO8KwjkpGOSqqK3vDnMgBuL/1zkRO1TAkXCnU/Vx3kdvHNIuc4i2Oq+HnJX18+IZmR5KNLfLH1DuLRyNxOypKIobRD/faw4ZW25/bJNZ3OGJUWAtj5tNMSmbzus7BqZB1+kld/R7fnuWajS6+lAGB9MlbcGGDd1XDoY40uHPPef8M1rwkqYTtLU2RBH/kBgGjHo5ph4ZkylfF38iZxwPFF+Z2DwL21LYXrM/JsIQdOUohQaQXr8HLXaEwVPyFX9R4VXn9Nu2eDbus3WmAH+T2tpkmXp0/4mexBfB9DHOmITNu+IU6C8Qj92pqgmHiSpqVA0LB3BTy3C0LiPchnUi0ebQIHgeQaPAQxJfvCKiFruTczrFNwUbjwtkl9UUwU09NbKNQ0YwpJA03jxc0xI5U701Va5ICtRHfDIvH4pkM4eVzEEuHcEftse4R0apN5Rqy3k8DuugxIqd0oh98oAwVqEUd8KBpnySjWFyLP7GfvVl+43sdXTVP90qf+7+xzKvP5qcusJ98nuXY2qrl/KmVGxhAHdia3JqowU4PKOQMfdemk0su8F0xtn1szzRLyI125I4MWbCTRLoFCTwavjL8/u2LTLieNWyjVTLewfk3xJaPRY1k/R0PbLbjwcw5nuvlL89teyygE19mWHV6nmLz9CdYPzLY/kmkz3jMjyUaTZ+NhdxEWfzyyZFDRCadgOjY2YFnCRcVsERcrYB9raKtvT+ssFIrRfQM/vfuegLkVPBWaNZ4+VLUWYyiE4iNaXFmyv5hfW8vv199A0IsxsLkd8HEahiKZEulZCvnsO2vxt+tvdSkaxqY2It+x4BBC+WVqLkASBicVw+thZ4MeTUxDe+SOc/Q1eIGwVt2pDHIIRL7vdquGHZoY4GgjzklcDCkJdrGOkGkfW/t/NdeBH9ZpMfChLsrSIwZVuqP6OVz/d7sGG8nG+YPpSAvNqzHX+b1qjEMRVhfqCVuhl7Dy4qxYvdYtzJGwUIEgzLtlkUI6YnKrRuyE37GLslws+bp5Y1ldyIEmih2nMvl90OnrozCLrFpxy18ruXjwGZ5RorMhwNoys0Zk6GY/hRuFtUMpBHI1rEEFruvN8q5+8XBoPnOKm/DU3WyfQrYjwcfEJYeFQpp96lAS8jD05guGiifFZLSpTIa4JGMTSjbOkFiEv6LNwhL7SQvgDK5fCco/MuBBb03+4DiDjGfEHFnpbxfbLOGE6Paa4ICQP3Dm0fNG/13bOZ57gs97uU/I969DVehvZL0jYAXzk7OPfHjcA8M+9ABjyVm1+1kaUBI+aHMh52kA382UPw1NdU324d9j9VhEBSIO6kO/3MjXAH5Sc3anTP/bRPvvJGBfEr4hDR9UhdFPSAOimtIEoM4gT9tH1kTAoMUVqKRTdfT/pt+eWUfNAQ3RQAbzxcwOF/PSksTqYZuZEjfQOvJAxNE+BUCakiW0G/BtPNKeriXGVFiBAAABqr6XKeHWeJfBuJrxAU3AlGFniy+AjTcQtT/3F0uXZWkXztHxoYHpl50ngFXw5k6O9A3W49Ex7B19YgPmI1tWa0pmt44dIlAGtp+Q50/4/68dWgLA2HfAZteVTfFKY5oAQyn4z1MAZFhWcTDf5+U9f5h423SPCQjB2xX3oel+JRNqSdGEIYrrbV7K2V5uYTjCZwcKolV/KTFOyF9sqaI9DJ1qqTE7j5khzYEQz9G+D/Jm38No/OXjLJBYdK4npdilxGoc6Dok+sdH5xqK5rvcnWlcGcsJyJe0f+coa18S6NaPQ916uVhyQ6d09gFR38Mc0Vc8KvrVxopbxtrWwWGXsKAERu9ygH9BeRDHW6XYJK5UTnUXb4sItuyQfdbEoBGnYvzehu+T6DxFbIh1ZMZVTuFoBzZTKPJ5+7uuntqo/J/okDGoxGfWx/yVb7kAbaoMXUa6AzJeacqbpKBmK++nb/jqYE25mdVi7D7Tj7J/48Tv7dul0vdMm+Aq3W+hJVo70VcT+CUScu4AZ8DoLbwAbapHYcq4FuUg5U+IndHsKYEPoy9LNFQoP2DnCmn/MtavgY3CFQiUZPCoPQt7Ji4Fb3SV95rEh0C1soR/8hzv3chPxzojR7rN7rmk3HS7jykYkQI1viqgTeMWGA72L3z56a88F1fQiqLm8Ic7QyRwxXAY6x28/fDRqZjFB9boyQ2f4L0B7oQSqHEpY8wf5DIcb6zj60AtaX7tKmZ9fN/VIYG8+T6XUsIITQrPVuYcYUtYHrLUc/6400XHprfBzTMn4zOJELsCS7uzeMM6up3BmD9fBEpf55BlNeRE01iR0XMlnJa89zX0QzQ7mIJ2f0SyRVc/Z2lmEan6EoWIMBUxWEl0DKuswqlGcm0jRIaOayMti7KEuS2JB6sqauezClINuNP8fcPww5dXVb6BEOXSpf55CvoFzeGIeanm22nGu+CX5QARYeoJPGAQOHyWV66CLRL8c0bGhXKX6DhVJzQ1o9pOYBf5uwGOUXjfuPKdRvq/WfcD+oYbkM+PU+FXfo3bG0FsmIOK0K1aw9f4zRvd7YRR2+M5yJIO9OqrUnlW7o03y3572LLLNalr67a+ylAkKxWDaWiw0WXGG+QE1fnxlOIxjCfavswhLSfuQE95XntCFCRe3730QjRtxK1fvbtcpk2LpEhcJ4EtajcuUQuBzYzW+gIMv4hBqJl8uWj8o0u6EaEzV2T/rzVErlC4mKKXge3uQ1YXCfqaazRots7tfMaHt9VKxsnStBH81kL1xSzXK5FaqWZkfgaFnqmXBpbuTFT3xrylt2lG6geyC9gLq7vfixh1HP129UL57CzJ7BTue9kYk2grTKvaKb/YVyn9/5jWqGGy+jygDR9W5nWW0BJGN4nkgJEgT8LdLPtud3Wbp8rV3Se8IxFwonl0JGr2SPYdffG9g0WAFGPVb3sCOyJGIoBkKTTrXiFCHTAAIPTCLicLwslqILXD0Y/vcLQ3u898y0z2+lKn4tbHV9hT2d2kfJmPXPOgK3T71Dkk/U8r2PWx4tOXIAlPxkatzYM2gI6nJQ/L3BdgquJ+SKdCLwK3u5z3RDBp9DXKL1Y6JrxwXyyoDgRfZh5fn6ppR9bNNHDStUcvWfM2CvsPCWKIs7rUcg0ygpzXRk0phzXxQG5ayDv7aiirrwNIHwVITJGVa6mAfAT7yJCdKoWEejBOhFqZRT/oogubahI0oIkYCCXEXqZfQ8aJ6uIKtrYmIlnR0SSl0lzGLqDSOBvq+2Pk65duGORNI7kSjAYIUiREI9dWNLBD33pt+hl8dCMjtO05jB7lUziB+VCJmP8PLDT1pOjqcVa1YwDtWqs5qGBU4+fD0rHLdncTWnmRB/7qNtC2CWJHoDZS0mmMAuBl41dQPozI1jnEN6aKtt+OfGT0qa2oxYe5yFw8KWxR+MAbZ1EC8uY80Zy1rN8EqD6X9oiRO/ANp//7XRjekUenB1V9Xy5X741hPU4tioEdQQL5RLiXjOUHHDbrpZbDNwLtBCSTMjz9m1OXxVjdtev7TQ14lw0w4h7rxEW0JDCLORpR78VqgXl+dkjwRRJH2kpGBwFg71jFoOIOlkxrA0/TdFGf7i7XuRakHspYjcKfR0xfOI93eorpasKD90fS7JvHDvabdvokl7P/dnQtbXE9ZvpLZS+2HkKYQZ3EtxUJ3VZCK31D0h06RHX/u+ZEU2YdJvWjVWCtcrtYsSAkICEVsbRWTpD3+wqpxeLc/W+jo3Y/uZr8alVpYT9vY3BPVjcxh9SvDTJ0Ce0uzesRpaR085tbIKHqSUaGG05N8NcmjuDoc+Zm9aVLUgy3l3tXZM7SPhhq3MNMtxv+Rf53zxzHO+Ra+APZKwXboOOZAHrDuliIgPkwmDPncc4lv34vvu/DQR1wA1CuppTvy0Gu/B9vAEeVV4I1CODfLJzLcdYS1Qfns46Wj9+8ObRaxjQ+gsVG0PF9hevyd1Lg3C+wG3vjtd3jmcR1YuwxTmgvkJ2fj4aDHlfJQSWMAz/Ohj6OhupL509005MybsIT+baWlrVbfsGRBREIxRTDh3+fycgoswMF9bbFRsyhCPu2GPx6VIEBDrMAGGsLYBbuOnrpr2s/YzOPg4UuBqKXIWncOFjJT1q8/FOxP8BHFtvWoQe8uxccCz/QQfmkqXxIGhrP4lZD4+6FepjllYsosFo1HOF4MroN//Qo6DBFREQWgPcWBflxjnzUdnF4u5QbFQgWC3K++jfraVIIqmH7Bqna9cxTaZzChNKzHQ7CaVWONJnBBK90lbzjr/4SmH15YPGt670enmYUTh/ukzEme+pAAAA5r0VByt+fMtI+Lz8JNxBAsIeRwQMN/vu1Uj3JKvTHHLvu/unrSXgDsWru6lcrgu91spN2M26XIY0fRdsFcx6ZG9DXUfekK21oWb5FnR7v0BeXAKcWvnS7sLxDwmxrODzi70IooiQH2E/UbWpZQqFgrLLGC78Y9ti8Dm46qtgdCEyu6RRYueBzwPB66y3Cn2KG3Ou5U9KhQ2hwixy4bX67EqIVFPURQh6ddKumowVqSdp0tR3YveZAyZlPbJavLPXkH7bAqt89ti5SYjG/xtDgHunTEE1eSO2+OdHLn3O/88gDc5I5RyDBBq5rmV+Dj7cGK8gGj92hTdAGkv1JvUr2CHjuMjSmd0GhUYlax2Fgtn1/g8wWdGicn/WD6PaVizL53X5pMnRBNAJjNyxtDU027X1BNHL0CIWElAybrpA+OJG5FSJ2cRCkfrViTIkKXbQosvQYnaZGpFDXi+FJirrXJJji+jWgXjjYjyww7bOXL1LJAsnGUB4vID+CzKE8DtjrsPjVUUe0YRAN5xLiybKTfb2PwYX41Gd3J72f6mN+vP7mc/FCR+4UOHjrvUo5M2dhuykywtH6kPHhBALhOXiWnXejTuqZF2GotYSB2tIi1goFvOLTHf/OVXLQn/C5VYZ7PkQAFP4LlAgvZkNn/TWw2gNXqzeYvusiD8fhPy6swlxEf6W8PM2yaxPrPUqLjH768KcbQ4ETTBT7FMW5N9k45f0+VqllLeYx3tXgpUVNWBRG+T0xzlhMF5JMZkyqWgAcR8LT0pKPxGnRUX5V7VSj+f/pHtqwddCKzJJmISOjgxycYuPYuDE6SbG34lqIXZnNflUl/IU5OpIEZ+cnSsmfimRu72RKZ3QaHvGP6/fdpqTi0bzCuFXrgZu5Epo0h0cZ2SFFqVChtOSwV8sv4Q+Z1cgFdjn+63OJXiLx5uhuxugVzlsP9+Af2t82RUPDTSyMiIG2/1wNe0R5DTLg0W6jCC+kXwW8R2g9LHVf7j/2DeOgUSFEUlqj1uTIqWgzCXgte4yzWbxJcRV742dIAfnyS5IKa2rwaRjJap5Pp6V2AXZiiRHmWbGyT+TTO8u1KbSRZdQGKL03YDWRqX8DAUu/N/CYgxDSwvyU+fSRi5ryWGwLp9o2S39pIC+L7/7DMV894HXJhPR035QFHoYLlr1vDBURrpNn74tNC2l9WO648JURAuO2IjBoTYIjxxcOTILudxsg21OB5S7R9fxjTgYmOzIBf11tPnlNMLgU6lsPOIxDeCjuJSAAAAAAAA1Uai3h7FaA/iUvk4c7VoAYS9PXBp1Ywnhn2WGv4uGvGLh5QFlXglVQxTgJJFNobgZ3VMKzn2aXSg5pSIOTQlV6UQeF3zN5srfAqaB72BsUSGtI6ie2Y2R7mIeTfqauOBP+swdDia4FqXNKea/VmjmqMXIEwtsvqtagXYJB2vp6NpRIuBh0P5d9KPvw0Ah1yW+EDcMbpzFhnsecnU9+Dfxo39SqDhVubWz8O48kglcLFC5UGYSzppd5XXkwWkTYzpTktIA7i341CvvndyNHO2C+4W4YwBdYtuiYPVevrCHKLdo/IXRuj7Qgm4le2ZEmUR1Urcfqu6YUC+Pu++JP85vGyyC3h/0Ot0zvTr7pGlQcnNzI1ZuWQ4slj2hrJ8ka2YMBMf0V3aHH8Hk8v78o84IH7NyNmbuBBaI7ehT7C5swH2ozwHNrMLhsyWQfC73dOcPt4JlGbDqd2RNcFbF4sSWZnLBorW9E/wWHnAdNS7qkludCm3lWMqK5ZWbfqG1MVxEjn04RU99NrvFXkIFmH/iN7t/YgFdOmJooHAomEjhRUJI4XySEJRP/iRNPoNwYGAUkA1F7gxHw/KKxwFZYD5imTuTcZ0ha7ZNmU2nCkEiIeP2kKVX7acg9T8LCEbVdPe1ARgQstps602QZUkUt5ojUyKQwxSgQY0XKO1CivP7tq3c7OkK0JLOLfPNElmjvG7nBo6UXqxela3gGjB50AzF0aKRkJvAd1mFT9z0U430CvZj03YBLjpeZdgZiJd3gKqEIBSe/mND0ZhusE5V7JVBFnM5eyjoNi/1bKTIiww4B7P+ysSzazndYjiGbu44SqJTAwK0P4J0rBu6ufwJ3uNDcxbjOpEhMex5PMgjfEB9wd9zdfTL30ZEkssYT3UZierUVpcRKnYt62UtnRxEAD8+tZvX7HpdUwl2orUsN9IoF9xVuOL6xQWpTIAPH8HK+F2D02DN2NyiWGVZaxNqfOq51BFD3PBlfnS4Ec0ZCOyK+F4QnMPyplLjHgbmF714JxGngWoFTCATwvHbk6Q2EgHZ6yGOF2GOQseyER0h1SwCo9QQuYW3DTsdpvCAQD6C1Sa98OFEM8+XSXQd6VnHs0gDCM1RKEyCzlaUsFP6yUjggeTglfVOG8gAdlnUGKU2i2KvZZdeAt3vGOVluxyg9Lr9G0S4EO25MQoLR6vyKCJE70jACDCI2Nfpxf+3MdZtqZWHsE65nPIbvV8S1GlD8UtAERt3sDt/+u258ugf4Sme+u5wjairm28F2HF/Ok6tGy6Fqu/teEm7kDMpPh5I/J9TLSe/RE39EYbyQtKkOCi/0BaAqalhBK74652fIKHzCkQPAawH6DkZZqyG/30qWnTPC6CeM7dfLbZ2XgYUAb7/mKzxa1a0fD0NQ4HKpx7qj263e6Dl7YWuKf4chO/YzgIrMqDh3EFTxYHwvKo5hlC1L7ihsQs0a2nxfjjUkg44xg7Zlt4rgKTP6MMMBzztW3OFdKYjU0KvPl/N32YXhslS+yWTk+btyKFU64BSmh0EYFpMcg43If0/ZX++/0S6I+1zoQLd5S7nY0P84WN1KwmtoLV0F7hR6+Rr/xqEZC6w8ClTbOxs4nF9J6XM3+YYOoypq/JWxYSDPEVbtNEzf3rc24g7sGylfNWZnEsGVjTCDlLXOdQ9w2p5+BYsWX1fsXajKURdEjRxtpsL/o8rvfQdTyn0MkMxa6uIv5vktjuo4pWQQq0RwKoDc+1Hy/tQAM2r8DsG+/VZcFw2SXn3K+oNRNrY9OMLDA6jXMAvvnj7kxkSq7sNkM7zBj3uB6kJGxkrXhAgctMsbKwGaS+eN4cP7VgPbHEGBI4mP9c+y/b2Xb8lPnqXVCI4my1T58OC9mn66SS2JHArVMziL8kasPGLZdQ4WvJ2gvVJt8KRex3GhrGoLl+oBy47FFW+qF8mgtziEwkLF1fTQ8BynzqDaWYqVHQB2bfURDQqlLXUZxRgycqjZNJVbFWsY1uKwT41kjT94DJChjriLWSbFZMbotRi9tXvFN6udBjTZmRM8Vg/s44HXVhVQLQVTsxZyacKxMvd63Nli9VrW9nGUOx/l7yIA+L3xOaMUGBgEw0c4DCwh6pQO2nR2HzDXl86eP/KnJC46qU1uUyoBg4WNlzf0HPeGMC5DhIFiBEP0G5glHp7kVBRgq4fEf91uaVdEAJC7NXrbwi3f6IZMPWQ8SpY3mTDlfCI8mA8TKFVTLRPeHpQ0UCmXgEw5xnI+7S25Pvn2dNDRvwi7QvP6sZ2ON6hxYfxAh9nKl1lAfIpmdJURIjBVw+cj9yQDm8TZyyGkfMOH4SiN0bSDHAnyXg+BfNdWswU1YAYm4JzvwkMVZAwnHA2Sz8KTXywjtwLlsMq4dWBp9XiB8zYGa+HkmEFkWXfnHM5zWtdYd1MH4VmvxgcL2/Jh9Hzd9r8XSt+utsyu1QjU5MGNTZeGL/atHdMmvqMQIvO6/Sv3dQZkTYbAfa4FnWDbd9BANBrwyHts52Ah0IrOOjkyqg1MT3zdl+juAUhDHbVeIFhbpMy+sb3wDsbZzJLRE1fe8qthoCg5yvXs0cQf2K+Wmc9CMxkS3lFDo0yvh/idvEbuNg52G5wSaWrBZa4lXnpAl1RhgiixYsD6JMJaRjRen5HWmDwXmFqLsD3CzSALJCTFmgAAAAAABY7EwPuHcYFxgR2igAATUZw3SKCfU6y/7tWP8fMDRAjxhx3MSvGV3ajACDGBa2KXVaDQtVZGp6GZJ3HMbQrlvw/7ooWchjqJsHoowtZJbTcg8lz0ka2x7m09T4xbePEIQH+BZBzJ8Bfvf63CzjL044jw33YGcnN0IUQ43RzNHXyTzW5OBTpbnW/w74dvBjMR9LttCEtVKRRYydQRk9njmP9ZznDFSvjySNGk7KjnMdm5ypNvc5zJrUhIC+FobK/pKCbRJLoKkwny+tzonXlMtWbz5Ls0i391ezkhuA5GGOEPELUGSeXVoxFe0VZrBUObXfvYZTcFO++QGLJji1N+8D3N9nD/WKKlQTgz9R/X/sB4qCmr9EvQBuV3VKZxtkHQ3ONY120L4H5QdaiCzkndo9y+vwmwDziRFp775f/uuaviuBezPoxHYeMG5xvLIN5tsM9KFlwp2rYpKnBuyd48tnqSuT+gsnS6QGpx8mBNadWiJgARCFE2Kc8FQ+ipZ8GlCHVVYcpuuZZSoDTr75FSFtZyyYQNqprxhct3YTaGkde8ryABbePoVUp6ZaPc7yASOcEpLTIACVaEnMjYKcEZyDmmPymC0irz9vTLP7VL79sN127OWScn0eJ7liRdxzVQjrUbMj8wyETckK1TP6bCWlwbaNXjXe67l89CG8mzhMgkNTIovZK4u1SWSSmOvt9kV3ndjJT4JxfTWQURkJ+74W+PJrmKdetkDKgOXDxWiLEZ0Xd0NHnEpCtM6pUiipAu7kaOKJmpjbMnUokvreut6X5/fB1tS/fn6zy/kyX9yo+bgV5gAOJxdxpe1HVK8JPtrzgPpCUJ2dEH70vqrHkFNuQzhC5nMXbpE97gqmomjLvyjZoSXbZVbcC/Pe5N4zH4674QZprUfqPC01meeI/XZ4l2A1GCu656UpvRUs1yxLviI0thSYU5J4pAWrezADZ2qCAEah4C/0VQEykXNs1wqe+XB3IDvTDO180ThD11ASBtZqOW2kb6uP3/Q4FRfCTHlwci24O7zvgbAds74TOzOyvslHaFM0L7raXPSmou1IMyP13T3V6Kh6G8lWHheIUMgEiRFidQW70KDVB5Atff3gw+DAc78GnYMEPFsBuql/wtLLk2jeKYSJ2LT1ICDhvD7BQ8tTM3redhadmIw/MkabuP5CdoaitGnk0yYAPuwhEMyxXYaIVZdL6zRHnKAp4TGYrQPI1t4d+d3HGvDSLGHtXwi9uyu2mj4y7LpKYdlgloMytq7Fy4bV/E03gQO4nnWpeM3hjMvRtvLHMUK8XkLxRrP8oNaE5Y/PVrZEDoxvf+o8U8CnNU7hmqqFiKJSE33PR1jgHUCsrlNiswlHZz1QatyN45JIhWWAxgUN4DI3pciM2RP17XXq5P2LmUArbgR8O2tixN9zP1an6+Z/GE0tOAaSFaAxx0OW3mC9R/wW69NeOVaO6Xf2SR2eSEFohxpsJcoVky/Ukm+eWt/oypfk7rBem1Suzb5R/bnCATWwLa2TkEgwotsdJOBSdt5o9xNOaKrdrGrbA8dP27ey0W48UO1mB+L0gpd/n6uufittGDaKxg8oSNBLVFFo/uiEmmih1gFquFpTSdWcxe3exoPzYO4kEzoRVTuAhaXABGUAmRo5y05rOIhUdYDIMAR9RDjHOLiChG/B7pEdVnw62teWTDmvrATChaQusMuWzEN4Ycz51CHpHx1GMPwmitFHFnO5c1qVj33+TD01UWORFAsZDNhH8cxOMc3zLUfsv2ild5k8QVqOFAQ5+/6RU+p+3fTNRcDhK6t3qpv+ANjPn2bdfnwZLxQMlGu2djubw9mlyPl/PP1U3080idnGCTotl7gwdV9refeBuBtHjrZhkJsIHuL1qnpqZA9pcZMA4mhkHey/EFDxJ0Ee56bEHzvAPSV1WKQoKf9ThNLkvOeM+kXqWm0ml10Vg0Ke3+II9JRBSyAJr1D9cR/VNxX8ZVE0vxQPKPj0u77773TWstUlduKk8CpYqJanpI2nKt50yVsY7BUttk9B3Rqq290Tfa35xGw9m+2vui/daFTq4ELmOk5DdCF1luvcPKtE/6nIrMElYzX5nkIvjPmbyaKWCKeht0zywfe8/wXhUddvG+lGNtaDahCryXg5lPzQr5b6zvpyRsDeNOnN7PrmGgyKr/omSM2CHpzCA6ZPKO4Go0UjWcTAlTjzSSNndCQ5AMNq/o8AX7jaRaeVVZkezu+mUfG40K5iuO4+YEQ4Sc24gkOXaxHWf5sehb03Pn3tXChHFdEJrlQcAAAAAAGTZ1ON1ICoetLvzGWffoSsG93wVCxYcHLfLdkq/J/BtfqGB60oBE79tJMDK/Yqa3mSmkU8gmWUavCZj0SAKHDT16QObO8T/FeuF5zJ4vBGvAYKY49VDCU60zySSwkVD82lwaCh2OBIdLx/5po9eeAkF1M1n9BcQimycQpNphfYy/OrNDrSohKDwaOx1ALO+9KFWjsOZEWPuOP2dNrhFZjLznMtf/jTwz3kESbfFT+Kv2L1B3ppCw3eEJD/oRBs/MZL65nkGSkTSj6Y4XpcNTcTE65qiBEnUOTVeFiC6wg5dWX7pvexmQVhDS7R06wl7InEV5bhaZjtFiHj/D7vTsalOQZDy+K4dBVBFmNbLJY3BSYkWaaIkKcpHisNs2Nm1TcwNY6iEITl3VYa1n9ln6TzREKyAAAAAAAKZbQiFLwvbSwSoBSADHdNihgJWUhkyb6qf13voNFz+OuRtnyhG2bchD6kvVGTFrHk57zEbGm7QKlWLHF7ZQh05x0hI4TFIGHkW696oZ5CziSJ2QE9bnDTYRRLgdVww6hcvRiYIErieo9QiPSkXls4A3zIaoe73TUXc0d6MKsdBojAZgMAIvywbB87DMfvrGGOSfxmncmGVtiZ4TFbG+izA8014j8oqcnuk7+ZDUxGprplsn63XZ7MFEte7kdypL8hD1tkYa3qjWcTFCwZxYVvTeyUPNFe1FTeUcCdCwxeLysNhzBVchWiWE1FKGhfee6UF/gHaivqpNwsX5HcrP1IlpEKyYEIKa+AACiTFpq5dqiqCyO5cZJ8MaHMsDoPSCG3wYevGXB1M7k1zrTaAGcXKFtzZq36nLwTt9t/QOuhpraUk/FDnLsTt4rPm/9T0ZWlNlHrfISnz2XEvo4HOLUpdd6DOG45Z9FA06tU6/7CjbQWIoD6cE5/gt2RnioqQGCLdXr4lyQ9M0Hl7LhNotQgIm3B+sn0faEfALBrfplWfhy4avH/iQ6nmWOB9P5DxNFOsNPVj/2iP+oqYGEfKHBaUBvpTEFYtOjy/NT3nMPgtsrkOslMwUoc3lxzA41a8iweYJ6TM27JpnDiRPqRho71A77yPT3BALxxyvEBvorVfbM6E+9ILadVqMsOyPZIFe32+sShulGwkmwKWLEjBTw6ARyt1ZR04gkJuzxKHnel5MAAIze5WuLRWy698J+FWKfSVXkv2TQLggrdnd4mSNi/DbMVjqi+XQhqUA4JA98255wHvk0uyjmZe7wMUCzPqtzSIKk05wklBpNtKjhq4hreZnJhNg5InnCWdAD0Lj1waW3bv4XecBx8HBlC575ydcZdJYQ2mxg1dBI0GQCyHhoZ+zvXMsQFqUuAX88fU69rATl5yQj1Sqkz7k6C6b94jHW+Oh4/rlMvB2ae0Puzj7w6vsMVsqVv9i594GfuoQYMVrH5KaogKeEyCvF7BpuPvk73BcMPcQ7HHEbYFjij5Pdq8ht9vhESSyTkEPWB4sEKm9eYnnEGJxDHJ57O97WxMh2QQkj4kPrl5jGP82Mf6MUTuS7+b9mCp4UaDh6E6YcV6mPE3ZiaNQ6fHsFflBxYCvkBr4xt6LEa0TvNIgM6tmgwS1g44d9axG/IF+85cEYxezHaYtIar23wIU2IE/Iwk6R7ig3srgXHXh1C2mEhRZIxJ8DKyZsPpliUzstm4+iRZlexv4L4K7imM7WBbNunGazxrlSdxNLj7ZNfPcvVUN0Ha0q/Dklqr5xJLh7P74ruFxfjZRcYX/yaCcbdrOhNknFkluKR4leS1P4cWoJ62GjOBvowX12XrFrp4GSGJdQqps1mtgH3U0IJ4oEkZR1X8j5ncq5A3ZLO3dEUvCE7f6KZljS+hm2QxplfdZWlaUd7NB/RqSAERoQFanrr3fe3WSlsyVAGMM/C7IZPl6jKypSnXUgi4xd6uoP74qbfJHDTIm0xoNlEK48/rPGe8PUgpMQJlmeRHbz2rbwohiDy6FiajYuAWU26a0PpxuazVBrIP91GdGDc8/SmuMr580gmGgTYCkR8JpPcm5egJXqCigAXikBowcozhnIkE10/xMRb6DmCnDFycNJ9xw+tOwVcAxD6bZXPvIafy8rjVdxxDpKwIVSKvY7WXvFX7GMoHr/XxX6l4jAcPToChf9ZxlDJXTPMpD/Ev1XiTBFLvcvCPEgsfYbJylpMZ4klPHujQfalKM8BVw3u8EKxgAmPktsf+11CTar3TIHjY1To0PZ9dejXbX2J6zclqQtrFoAOyJtMNItpx5u48oH0+cz88CuGPvwygjErpfusj/LeoIqRFk+cbOmikF++hBuzVpn8BS3SbzHriAZcD0wgLS+0G1/ZnRHtb7YdOvDC91Txt0Pncu0myAXFanzabjmZYl3jmLhHQGkkEvasx3xoiUHFVmHbL2XFBMbBhHc/KHj3P3IR8jjgh7rKQgyaVNnumztPy7mzgUw+3VCopuEAkPnBf4e61uRkFlpT9Vww6V+tDdJ1NmT4xIYscqJc8gHfgCLrYFpnXtkpDUX0aiDkS+/WMcBB67rQq3utFZYrbV1XDUOGTEhvX/nd4Fplk9qBfkgp1hITPVRjDeSk8KEgZnC7SeKxMja+SuqvQBLmKdhwLyFnEagQV0iTnNHRfmPJEiHS8M+mg5EqgJL1/g+qzB4pO0vZhLdgRAn1+5sUl8IXBdLSKHj/L53npPA9X59D0bUJVwWCI8jpIAuSj6kYdlQVtsUXYUIaKyZl9GhxtwGuxxG2BYyO6814F5fSw6dBprz7V8MlsL45qsFomvK/I1IGb6lpq5MVqyUsZ2417OUXhCRRGaUfDIz56ccnyhWxLPfi594S7iICh/WKGVZwypWloiRyA8jN7ad/zCCfjBfi3y2bKWoDbdlWGR6zzoL3I5pSs3Crvtjk5wLR7RSRkzTRXozy6H2LKNPqQAJ94/7z3ujtmIdYC4kTFSglxLpLaCegx3jR97oKUnXY/Wmx8YW+X8gow66hSKs462wI7FfbHsMjVgrVWIUnPoyuTNcrQQA9nAEmDSTl3/stDwfVH0c1uDAtF94Woz+sEHWkDc7xARGq5M3rcRpkCfRlcma5YGVwcYnLjfLNDI4jeJFYJrbdIEAA3s+B0oiVZoOo/wBfPn/SOISlcpWz/Eyy/U0O9CWt3TPVi4wPQOa1fv3wCk0jISDCLjNf0QKfE9Q19SZQHjodtsCbuEDj+l73aIpC6bJI4WdDjuhXueXfjS4s7agz7fSLUNFbzlsfKQrdVY3ZQeBMKnUEF2vL3gc0OePCFo/2jfbPvG/JqR3WLprIYAZIrTxMBc7wlIuQzGaKvnS6OJ8XG02GV9XAf2mnUAaf4vqukd3t0E8GK6RttN3JC+7HnwqrP5FJ4rYumH07p77wPpFmG0P8jiyk+pAp/tbYu3vOYy7VfHa0ys+ONxn/v3SyNoQjMwNhTgD8WqsYSCGqcoZhz/+tc/u7xlxMMz/Qp7NGePO9HVctbf/YSKE1peR4ZnO5xeIUqC/QgGKphaAlbvMjENWP0NMVKjAr3l3HyQSwPpYcOJlAjsafpwQd6e4sa9xdXIVbqEl+PZ80Hq701BtRSAawxDa0S7XNUxuIqzjMk7joRJWjKwFCb2Zb+z2RanZIdzPtT//nZA0GHO5GY2xivlcp61ZWUP4zdd54Ph9QRyTLRQvanZ3NunaV+Df+kTLDsrVQJF5uMD4F6nNryQ/6t0zmwKL2SY75Ld1XFDYlD66qTnzW5smSYPY7wEtZ0/hErRfivAuhIh4thvplkuNpqI9vmt6BFfZrEp4wXdhi6QDUD+yR2GLODcg9xn//SkVBVPJ19KTZuXzw3R+kqZqgPz2VoWT1xkRhZQuAk/inUkxPNzTG+P7fGxo906kIgcHJvcKOr8OfbBcVld8TkKNmcLWSHvumOwrT34Cbnf/NOeE8121jeLXxq8MiRzdtAPapj/eu4mLxPQMdbFr8pOIJp0BPP88I149tpmwhk8J/nfrjvTtPhdxDHogCtp+fekwX+ietQopiYf+MwqK6DFEUjfJz4e8+x9YNQMKXUyLZzR7O/B8CMUntSDtReUohRfsgVFd7KsvrgHXxP55Dkyk6lKq3THt3GzykD3icou3K0f+TxBLiZgOJ7eoAzVUqNO48uAdNY+n5C1EPBmo2At32Dn6XAbohSBOGZwA/phkH/eIXsCv9SdhmEm8CQDlGCZBJ7M4Mpbgw72Y/9yIc8lO9EDyBFIEodaUHF/11F96+JItEjXEqVtpxMAtdMZ5GFS6v6Qa6k00xt+1YD7rvM7CTp5/febTgAQE7Tz0xd/MmkSh4AelmK6K8jSx53TzHhYCTOYcCmSU0wDcV9IKJqlpNfutcRRknEqFHJrYvmZhrfnqRPQg+6lWU6qL7WtrW+1QB5sEZul6qTrk3yHEFgZdJRvqCVtyFtNAm932Ro52P1f83kT50wYNq5eTWIF5CtkHq+MKeb922aRF6ckmKpqACzXwk5JGvB9XcLdckVFFPgUiKdPVxvlguhnKoKxWCgtDXGUb81m79KYhZXJUVQtYX11zdnEdHpneyPeZTzg74ANsZL0M8sc+IEEXgU5uAEihjkx4ba5VcXV4Ld+UMTzAhUuORVJeKWzJ8YdsQJRYA/WTCwME9fTA+WtSGKsCiV7mGYKon/kJv3+Sgq9RTlX0FBwlQLp56Yn4gA+/7ZcNniX51kMyNxJz0jnGIqPJ2Q+eCznhaw5XlfUfk77NMCs3CW+LRogGkegljuZi+wSWCQpXW2SaPFCDzeasSdT1CXXBbQXBdtryM6/XEW3mW+iNjkOg4Ks+q0xEmBLp7CUavU1iztnAsuvv4W5HjZPyQHkogyk4nPOVEVG9xt5e6ZApHl2XgkZXJG2rXqUnon1DCOIhzt4Nt8J6bzdprhzA6cPnSaa1bfmYQC6i2uUncM7pqeTARxt9gvCIS5wU39x8X/rDMuIfURMd+L/Yz4SueyMr6h4F1fYq5AUL6ZUd1E2IVNz0bb3x0IXOneV+LmeewvYRkngrNpdaPJ79nVF2IMeqOGdD9pOY2Ps00JR/j3f2GBFhOWdE2VSUXhQSzSPv3h+db00prJ421ZIsGUaCdrefB7Ce9akQDZDh4WmwMZD6Wuyyt+pOgp49im/GBJjq9t9dvy8FLsUXyz4A12Ly9vMVPv5S3Pkm2CJDYMpijWQ+l71Dj4sLHiy7PRbsvzh5Ju2tTkK/YE9IAi2AqtRYmeGAOn3f6ZtIJ2kZUxiQ12QtAFWcdcNi1EpWFh7/WvxD4kEZ3yGliZ11WhQ4e0s5Oq0xv+rSV8IW7v4VXRMY5D4U36XcYbqqyvvatyXBLQYRBqrSNJOYEG1d7bBLORtoD0IYR/270XCVImFjAn2FZWgqM3ZtT/FzOU/CqB9D1uiF4MFOA1+4IYLYHIHv5z5WYWmvKl+Wc8z7uV9fejqPbbbk+HhpSNubyK8aJ1eF4lBDK6Oc2Q8Dfyxe8rdNDgIPdnFZZQ/Sx9gsj/h2mwq2qm6UnQC2vUGRMUAj/qp7K/U97wSSpdAGf0PtTfVRdpU31dbBIUdaCJBHi3H8pP4G8KIcE01YYs7PULAbdjCCc5tDz1AEo1Dm3DKtcSimMc+lbB1sZqu597s40VV9ZWhEhe4ftMTP9HeVB5FydIXvPxS4Skr6lm9N6ZcxqpSixjf8189saX2C+obw698UuEpK+pZvTlEFVQO8Znc1MdIE935eU6exESg5OnV+JP5I/Xwbn5fHX/y3BMaMt2Deqa8VQgiKhYhBsnnIRFpRwfdckKwNfadflfK4xGydi+bu0y/rCCYtXViHvWMJT31+TWP0n/quSD62y8GPaugneYdUOQRcLJCAf7QHlpk4Dlk3Bg+bbVdO8pGN3Da6Me93j3WK7rtm85VnKWc72Dod/gr525z0pkm/UlYN+ffyXzRD/xTMv2szxtwrYjnjdIVtQEUDu6IrhcYE53KnyqcW8nmD6Uep2Hle25rF4yIVAbvtvTq8AGG6+hfXwN83YL48IJxGT6KoETtx1FR9HH8wss62SUBT+4SE+CZexywiifx2ojUCg1PbOniegpdDOl/5zmoAszjahBPoy9QyepkP8cRZnnixkqkCECJXfNcYcH42TIXda8Dlakt99Qy0OIR0VKyZyVhEbsPVuTmpAm+d4noHm4cRHThxadxLqd85a5+cz1D1eFwjeqAZIHtO/cpxdWlgiHIk7+vOU/SwLZQVaVqd/MbQ0e+GL6tKM5oPY23fBpnVB1nCjgfuCA+2FioaXDNOa+47ABVjLjD09ayS2+XZqkjOqPObhNbBTDDuBdPw9HzHlkqK95Gwtroo5gYTQogoKmMYFLzQtL8lD543P5OWpCEpYVnWHlY9cn9GRvsRYF0ConRAloCv0rdBLwX2eyoYt7EO/xQK6DFwizetB7EbMjMix7iy6JfnTJiCe57WjBHo/90bP/YaiX9NW6CXgvaid6mcW6QYecOa5srMqA8+7Py0G87WYF0BrY2XVE+tmjVym3EF1jyalLTaStMAxPYVTKifT7GngaZWw39nv3++je/oqICDek3kLSFMU1h42a5575TdFMkBxmmbS45ooI0F31nILD6xHJ2erGi6io2nPF+xd4tCoIhmbikzjmORdyYagRdBUtMNc/YsMJzsbaAwn4Yz5mFHy+i7iAnEgB4I9wOTK+R+GjaHyTYnMUhmbb6Hqx8hI9+JoJuNTVn2ROPEsz8/7HOcBUhwasqlkjpbDojL8iSmk1/HD60b60gbWaMutVYFA/Vb+U+DbcPem2fdp4W60HNpHIzEy3UG+H/AS2kxCqd5N+RYGh6hrOZ976keFVpDJrdRTsof+dMPXwDOu8HlwNRIzy99L/El5jDHGEfzvcISPjtMkWfW6HJt/R2e9ZnMhKrtmVL6HwLJ7U1vc+ktSSN2zTuSDt4V5ez39I9ULQFnhA9xetLwV10TurKgvX3u9MWYtKMrOlru8wXaUzB1MuT4aY14blYxhRfaXAeDEimYfL20hUFSDBFoQ2l/6bUzRMLMmJuN8/EDk3Joeyerqkq8ud5p2jln0o7DpbXrMML2AGYv+GhsWdIAYZVB0aMjoK+kSkRfIKCb8TAvjEwvUnAE2z3nJ9PoxOY2ocpm+sWgGBEtnSD074jT05xQVTbteuILYerdrqwaSrHofxnSGF15jLKewwnbsmmsBLL7/SlSNI/ijfkz8ugWRvYwp59DtJihRQX3n6Z1+xMyeT3u6l2Rs4UG2mGUL8KLi6918qQjzHndTnwYivCNLT07M7b3Z9j1JIDSecudvOWwcmDS6/e+O9M2kE7R+SjJ7bYXJutgSBaRkQqBNk+Sr+NGNyz+Er55KOXgV0UupUv+X8XeGiqqGTrXkTjqReaRuylqFxRCriR9MRg48pxoxMe1gZ9d32RfCMtqGrIAmMDLNNfwB7niqp5DJkMnrUEVNGKRCUobhgaUVSHLdQ5hddN7XZuF+5TFc6frNbVahnbuMAW3GpSinypZizILXLe8EYgE15g2ULT9hBq6foPOfVqPGU0bOsHTi3Ja+OLVVUAegXaD88BNedaNmgB1shJqx1Nx/9A32QjlOHf9JvbbAoygPNEn3fabaW+13RHO6OcXLeLPCyBYljpt+RagKoWsT5kEwtAKzzP4Pk0XzK4ItDRqp5pOqhKgyExagjOpdaBGpdXs/8RLJgtJZvg3+A3LpFaFWY09RzG+ZMbNiZz2wc28bYNadArJTNgtH5GE9ASWEx7lUzNuG/77Wjh6sQSS8++/1CjB3RpKHEMD+gMJAz0oaWjBn75YKuKyPIeBqZc7MjYamHER1E6SdT1CXXBbQXBdup+l7Zo0FUEJo9i0J33g0rbR6S2wH7PAKRSOGYlfcorVgYprF1gFj/+GEThGOjC+B99+eN/1bjIx7FF5wRkyGL4hvCbfTNymeUV1rE2NbWT2AVQiZK5Z1rn0Xz7YlohqeQ8BWZBM3jzjEBHK3VlHSAWsmog7dFLjVuNJsHZ9MdP3zIfQZANi7sUHad5Nu1vnXlpGgC84t0a+Iz2UUDtwbge2PqtiVky3EcA0E50PXPkHj2Cjmay8U1vAHSe8FI67gqxPu2dAWKvhA58b4E4hr+5mLsZwKUlyuiR5Ew0h32dRtJX5AvEihYk1O2we7t3jTlMdKT46S/EPFzD2zVN9kZfGpnsCqico5k9qDi5g9OKBJAxKC7YMNX7tu6VYxgqbYoMvBV12AunptedWflesnzmhin6bFei9BILmgdcw5s7BFVP8CIiqzq/bem7xPJz30NpCAx4+Dopy0fGgJfxOIwmRp/7lGNNsB8hv38i9n0fvQSsnUfU/Jo3iPOGYjQrM/njXRp2/XbwdEFjZq3fecV/kSiia4msqUazty2jbWSrhpv99ES5ncR2yswzSQd3IdcG9PpEuVQPE1woH/vCyehyCaP+Nv5oWWTtSh0qShJCCYRH3u9UdJNtdXSR3RWZ+3LokqgiIsnmJADi2Zi8JD5oHQBvzE1llmc0S3MGMjM9Vo9UPB2h5OdEF5yxgB1GC697YK3VU8pgts9xYRxxz1JwedDJROqBZFdWqXZpgt5SK2hjPoz+5ZWQ0/fJC6zkElCaoDl9/y9Kpv+om5P2RYWwv63mtxYZeuLZMoC75Zhjne/ReddAiuhNEFYx3DpYIkq4R3QVjiEXveGqypEK/6jbNKaI0yJ6tw8CHzmyK4Z9X32AsvMKI3cyyNpRgKfwKnOwIclnu1JV4T8Mjtl4u6fDqI0WN1rMnTL0z733CwPGrGC0uqGRxHYjCjLYcvankfDmxAnC59flio/jGOI+PqZymPb9J1ycukJ483SA/b4X6CiCqrvnRe4Rn5P5/ZmJ51Mwwv6YBe5BzkrCXcQ0CZhHbdYY0D1/82/t25FxvZ9mSEVSCf2FOynT2Cc8GarvTohAZdEQbh2XYhZXsWD1y8WXDfk/TNzJ6CavjHgApjqH1DlTXpeRnP9Bf/ou1czd8PGcb5YOOU8dqQvhMWytsv6oX5MNZ9HJTWYCeqpfEkAHVVBnVdT7HkD3Oedp2uwG8KBs+CtJ4Bb9DRKaw8QWFxqo1Lvn0UDLGUqkD4j5BUwy/7vSeAsZbY3o1L/91SoeEdvZyNhKDaCwUE/Uq+Esutf36Lu0tPQPk8LcP5PZLUgMkNlTKRJ35uGRjCdh780kmgSw91H6gRXfvbRCMiIHBnyySCod/4YV2Ena3MSQ/FIdXKNubsKodr983JETE0YQ3DyTE2jnlbI70U7c8uc/WzIxrg6/JJk/UeGa2OhXP8v2tBCmbiwD/PCGh86gX2nVxPGBYuz1yW5j8a9BbmYIqFpGeZUZZP1pH2m7Z6N4E27Hxwj9+0SPu8/PIDvz+IpduHvxG/h5+yvJY1z95PJR640gl0lXtbiLMaTu7bG3H27lEjMceU4K8Gg1+f9VzqjXxzN3jhWwErHa1FBu8H+XaJM2thtz1WbEVx3KkygPFujZEGm+fytrX7Y/jcr12jNrZRsopDn/B671svFv2FithPytKwEXnoN9/QHRPR6woAvMfZUSPO07xNRHkM9Lb3PcC/7yvrfT3AElrYst6OiGvbWlXpZuOK/Isrg7k+sIb/FXEJu5S6/gZrJy8yyU3tcoZysBxr5g0HD53Ln12ds/IT673vNdzmEMdpjJQdBzRS6/4rmi7sPtnXWoO71GfpyjTYlavPSW5RiLUZ1qYJp4g0O7ft/ZxN/1QTEfev1CkvO0EDzWZz16ay5+kkFCbQJWpmrHvb7kBXuLLeJVKwsCA2L8Eo0kDUhnxG9kbgmNBy/ikKCGv1s5oZjGd+j+Imxe+yASSjBlcLHu40wN3nNRyYdmdQOZuE8DljtwmJGcEhtfY3LUDjfdwkHEdgFe80iAzUTWK4nCP8+0PMGPhtM44/lYxa4NTKglZqMiDtzmu/lrw3KxjrpYrLqhJYnZtJJtRZGjkfZ1WtIB0KZtWFOmwPCKRAwisnyQtGIcDxF/QXkfxwOPf8jlxx11U2qve/VWYcqewEHNtPAbX1sF2QCvBhQnxaqKwhBfJeNyZ8YTzQSVqqAvS4npK1cDMK1XZ7QbEFZJ4ETTnZkir4nBlek8Ncgu+neNMOYLn2X7ecq0Aao6mWu0ZURrhL7yYgQ5152051TBAtLWd+xTlLOtJiJ8SEeArGXcqOJiAobWhLfYgBwzS6ghTWP2Lsfnp7mxGFtR8HgEA2CNr6SkjPdTmo9jrS+kPBMRmQtXCajAOVj6EgF//eyTf5syuGRABOJF2L/V0CPj/FJcwTQgJVCYqlCoJBSAGMUNdxk4ZtYuM6zNWJP0nijXVg/JLlXLqM9j6H3fxMRD386vb7NcPdjpoSqwPWC61NiMyBcCAD5b7GrhxQYTxyjANZFr7tTvvaBGkeObEWV5DFwmn2qDU8+3TZ6iFU6i95DWodPj3oLPTdQEPmAreoMKxy+VgTZmep49j4PwhXo4aW8SgpGPZOak1WfmX9MAWo9fx49X/htgHzPM8Av97T0Xwc7kjWDV/bkLOkoaMWl3yeKm8pvqhfcaeEgQMySucGPawvA/jpFPB2pS+qtHBwrC0MkoPkuXu4FWmJgErH2qUiBTMAvzgo3yZ5oLw6N/5ORxTrm14WDy2orplEG4o4tZ7gEfWOp6XJxVl6mlYgSLetABTldM189DqVIsJ1Z57hTOJa5zdt4UNhGbKwXOgghbOvRuqnGBDIxSe1vUj7hn68EKe0UszqG8dH+dMFTw8dn7UZyWMG5a8/A16cLYxX23w4HWN19Zowu1vu916fd99Oz0d5xoQZBbQCWUV4G6JTKLJ59cdnwe2DJzFNEb3suGRuFt9DtOz4d1cp507gN0i4KnhiYsyysxN5mTaDi3d+BPJO683No/6LHYQpdYl4er/AKsuGFnlobVaxEx8mdIpx3SrErFQkDmlR+wFLDbVL219HLWrzgn2ZQPUfOtxzVrszEkQK3oLOwZoSzmeo2yoI0lt3KCHdA60VTZVduzi8vXdHtYBLaA9AAKIjl0qufbCjO42lTkhQJRvOB/hPPa4jvrHGGNa/gF9zPQvHrV138ZNkbbESsgJxtTCoSmlBlQbpYMKBT/u03c6zzgkAxuCERJ8v9augqjE3G+fiALiZ1yh+4I9sc57P8F3CU6jEGdLCx5UsQR1LFgulaTQ0Ju+UeyVOkCLprIA6iBtUdacM8U9vF5NKORdv3ydbEB4SCOHAQdtwX8aKi8E6lSNLF8htWCA7dS3HhLLGmxH1XN650yK7bah/P7IL8AY71i53J84iLrOCZeOrYXLYkMld0+Yo1i+dpif1lRaYAZm342csXXjGFWj9QXP/EZL1K7RU5x/Y9rvNsSQdixVLDExI76q9M0LI01nuxG9f2du72OL2NtaGe7zfv0Lmu+0mJT1N+NQl+fIWSaBZe+G+i9Cc0162SfVhgdBh4gJ/wKNtLP5h0wHXemwwh6trUzFqt3PAbiVKy8RzE9EdgdZQ6lzdn5+PhLQZo5hcf7YR7Scbj2R1Y/t+BEUddjM878Npvgq43jHiOn17YDX+Mvvcud9mNa35xLzF/oIU1/VAcGJpWxSdMC4GYwgqlGtSxncSRK4K9ssSeGcwGW/8/oxiBABgpu3UJsFqAcyc+r92J0s7bPjZqvoFsOfZkV4R4s9kAdXKhNmds/mQj1tVvD00Zb9+/Q1HYDU7Y6dyRxfVwiknlMz3PgLuRrAI1dQZpwB5H4poiaRVk/eSWqfsh3hAVSLHZDLx407eXq8ZgSxq6RNlNMd2zrsBnO6g0VW6tx4WQwvAbHMgcDzpvWeYjxfQCNn/Oj/W43+9lyxwDgUnki1q1+zTMBH0TEGVZVouTjK7oCxVWlFg3UQL7UgGxVwyPcyjCyz0ZwvwYF2y0Q7Iwdow6Hl6e19nnx/rcqj7V34MSD/1Zanwm8v0XjOPhCC2zKnQdzdr4gof+/m33Wdx/kH/EHiQLJyQo9JakZfBosu/8L1xjkEBKAroSzATsEHwiIt3msvTPtqiw/BCG3Z/5wZxC+/5xas568ngNjmPOrwgzQh/VEcg2V5VsKE5hOR/pSFvvAlsXQS4AAcXwGdzs6tHfQ0zB0bdI62fhzNIjES08LPDJx6mcae4yv18PDAdBk3QfIj24ueLip6kr3siF6nF1xSNup32UilUrgLYbwAACBHprD/EeXAaaItRyuvOQ3eh2q0QwwSMjcCxq8ZDELE7mID1wAAGrYe+SzSsZmsFAAAAAAAAQ06lwc9+vHERdF9ETlmgaN8kFlrB42Vsy5JuYHddgGlZnKXKeaNMwmv6AQwL5lTCkByfqf7f3Sz+mb6lok9SSMWtBKUxEn8i87mPTE40SjMNOXo3Ix7pz7ZdkdGoil44iUM03Ve23cHbbOhfN6k1VrczZ7nzPwANK8rVMOqrmGbFGtlQienTGq9kk4LMfo0V3lvEoxQPkkQYK/hzAUADYJq1FjdN+fzRguRr2RW+4ZCUAQqtNnZFf8X+GJYxn+YY2DxkyAPz889CtmD8X5nXhYH3pARrxgaPpCe1sEqpQCH9HH6+QeHkrApKY/zSjNPjmMsJCsCw8DaTyi8rdsWb1+moPClfEcPbSFwokYfZclazXSGSLoLk/wRMJU03x7bQlCXhfHstNXbOpOywGE7k6fEzE/Z2yVOy8rYkx1aGqBX5AtS5WWSzD43uGj3Dhxy+E3XxSIWoAE0NeDImOOXsjIcExwLP71LKkzQb8393Z7l8+aFuaqk1U4LFWjZRJEEUNQU3eeGtT6Vti4+bIKIMJtl5erYckv1+g+RSNskZFCUoP9GCoaXDOPWhax4/5NpHl2NDJS9YPsjZrGj6liUHpQF8yCDqi4+AUX760L3SAO8th7CTpiq4atOqiVAKTVhcMZU2vjkh7kpku5AOarhbUxXGP1csloD66ZDsA0Dpr7iIg6UYOC0a/UE+7yngOgaGzoA8QN9byhmMgAbPo82NMSZwvXAwQVx+/h4wx6af9PYh9sbukqtluzl412eAeqGXqFS3AHLjsLrrVZNbEGcVkC3TKO0QNlxvvBUryz4UuP4Sa2iLlWmN/vBD0x5AED5rhRii7Fb5QGNHYLZcqOr91l4+YnjDjFcX9dF+1zYU3ic9T/mAigiizEHFpRmZJ7vSbta3JWVrzHqPOKg29TXJg2DhYeGiSNpO7mEA4zAuUKtd9wOwWcUDRrfvC7PZg1M8hHB76AMk9LgI99l5enJlVWd+vN07Ct4EpZ9IOAmwD5pFUYtqkBMaaHFwa0GBEGCTJAgxP1WDOWqKmd95b0vpQP3AbuK4nOmq0emftPiLC53CDPRWAH3Cz0b4MnhjSKBFBFFgsfbUQYFQDBzH8jdNsBfkMEXy//nxyDOO8IP3Po3VFQFLPhNm/fOZzdOovaubwK6Jo6TjRdLpUK4XACi2ESV8pQSimUFUG1CE5f9Xmo5fUU1iOyLwlEdq8MMRrRO81KtYumsgZ9b9i5nhi4PRavEHYdMD0PxwA5MPD8i/wn7TEpwjb4/yxjFmLrTuIJgSA06/IPrVU1SMZMtrwoBnA40yq9ysmJIgcsvdftqEprgTS+TD13+UKdNLwO8C521Op9JIxiAtKh1lOYKP3bQt0SQJyFGoGbjlnuNZa7TTWG/ZilJ961CgE7PkpeaV7y2qvpJuPQ2dvidVtP1IdiBzttqE6Y9eUCEZJ7K/CMRpNU0kPwBilzDzEjQiYsKwbFjVUk+6lKol/oQTMwPdZSD/Ft/aYuw4eSARv3PlRcm7IPTFIhEpJ9thPndyCNAE9AEpby4IZVEpNBP+PaMG87nvSaQCfCG6MZYOS9UjUqk83H7tmRcr7OCnNQMW81K/nk2ri+uhboTpdAGGARmrCRUfhkiQDHqUVw4BhSp9jdA1QJfPuYl6xxOOHnbt0rSM0M1+fYJJZmyGOlY49U05QtoFvXwtnMGuuuZXlcCRpkefhWvZw/M1uelehPOL5vnyypn65YI8AJ6R8Ys7DYU9l2OVSh8iSIMM8AY4//GwhdI0Ij9o4FzmW84I422vWPHTo4b7C864Ph6xtRwh7+mJwrprDqsrCZd/oQXK7aSHCvBfl1vS4WlWBDWPUNcIDHsVRbdaBDdFu9igjilOE2m7CXJkIKoY0SoteIU2Rx1r37xoPJy0d+f1Bd/Ne7jdk5e62pb+amN+ooLND3KAIebkH6pJ12U2K0cwReIKug1WC4LBQynefBmPMHwvIEAHffdX57rV77TRlLtHkiUHtyYNSq9IdjGWfI5PEEWSySQ8R3EVmuKrMCXkVhUXMhOV9I5SRUfOrA+JlYQQmAf90RHSTTsblixDXBO+uwyUQmIDNzgIpIEvXgV+Lt8NhkwZ0xLFDf/qcGYwd40peMjcQQ+1m7kDkNfvuSzqNvd8hTRvpOz4PZdtVClVXDjdzECDcdtcI5a1vEhqcj/kxGsI8++wAeVIkAFI26HqckUbP3Vi6/miDurrun0ZoN7UknKVelUX+FObx7IFAtAE5uZBS6wKsmlzIgvBUbtGUmVFttww+YrPhsntU+HfqS+RNm5WNTUPyYB45tYxQUs+XWoMfpETN7pwEDoOu7UcVoaoJN/VtqW21jcNUkYJvWVVfaami8kRs1opM/FNTvqQUVtFGQoMkdcLwS+ml5zdAA6PNTWvNkps7TRDZD97S1Ea7x9pfO0e1vNgNVAIo+2E38QedorvIIXaxE/g2FN2HjtirNXFWnfpFOdsNaKsIXGpojMa+Qxj6cHYoUonprVDiGkbQq/eOrymL/FMADhUm6l6uLDwk/jRW05arOwMhYU3PQMHn7TDJZTDeVgluJWhBQQKI+1RtHwHlkkZol5pnUQmElcbFXHD5tI/kZnVjoa2ze83Qvm7bqnkSKbhIQOVl3lNFiktZF9EqwsCGi9HMHo/mj+iTbuNxPU1uHvuzGRe+wvp82D1Orw2XEu7I1Kyb39xpzV4yDLnOzo15RELuMEO19/f67LjHMgWg6kJs+/ciaWTVrYtR5mo/BAAlLLAClPKc0yliGD9TGdB37Bv/Igb+kAs6d28/TtHCSgpK5TkHLLVRQ90nGMbzu/+j+MXyTdcDp336id2NBsEH8Si+4eooClZZwI3vl88neP6RqM2eW0vFW8QSfWRphqT557tDHe51KSM5WVTAlR7om/0tfCgzwGWeEMY3LGN9x3PqTRw9VCX0U8QYtHpf0Ys8/zoP0Of3gT750NkmGYVVePA8uf7KkSCpwygRoAJPL963ARxMLad5RpLDGBM9NAFissfQXB8R+EyGG6LGQwsMCMxmUrYInF/kJGbW8HLqytbdmS+/E7MbUT3bZP5QX4EgQVaU+WVyxFwrbIch96gNR5nFXIS3bZuLyr2VgpCpUufzvjUCxTkLt3AxcUOlUUwgiduUH0s8FsxMjhiRfWizNMMmi1TjgrBUew2irOTbl0FRKSR+bCsxDSfzSmcdXFoG0ppruAwXYtf+3F+QAA9APhsR29/g+3a69EKqj1I9TSiqnEriJ7GnAU7HLDj5ZrwVt9FqASQ8TY0bsgHDb0EIw3Fkaso3Ru2dRFCeWpVuur6fAX2SSMfFujSxDyxQBQeHu9MUfG3j8+MNKYG0ETIQK7/ABLeSh+YxFE114x+IvZ1/YwMXkfZbSwR7oe1Z4jI0/9xSCh9uTYfnrW/PczmRZaSx6id568N1trJCejGRU/Sn/i1zY5s2iDqIsHqtLVw8+/LxC4YvLBKd86RniTonj+slECYQUsxuV/lIbYdTvdzhR/yVhX0d38uzaHC+ehJLhOO1z81HRHQKDW+VVMXj7S8AQ+iRJXbOX68OCmu9E+EmEwzhP6zSKaIlsq20m5ypmfkup1CQ0mTS9f8eYHS3jEqDOgU9dCDFDGcvODoX+Vch4aal85Ot/VqiWWUMTjKb0FPvnq3kkA5QzU/JvfNHEj2htkFUGCOZZacV7Ma98gXstYKhxGqH8ADrJY63yHM2B/COMadPT3Vc3AdNqmCBwwL140T/5n8i//MO9rrDxzKzeNo9BFoY64EN0vjqUoCaHrB/otLrLYzeuW7JLNEQOlh8cloKvhpqRzLoIqZ161GRkc8Ctz087zjx2pDq7cqL84H6j741TcaP/wuvYs7wI0Kvw3H3iiUa82cLecG5E+LJOJUed3LBUoP77Zlf78YA4ad1xniRXxTJl3UmTAHbsRIza+FjeZkl5NUWrCvrpSKyyKKHZ7QanQYPeu/133/5hVPpYnqLZOXX7rwkR11mAob9uET6Xn0u6OtoH/jvJr5xv5Ua4j1CgyYyS1jFjONT/wqVb+IE9aRVZp6t86wICvyJ/+GlgPBY1NnQzQuS82DD+PRjLWbxsr0nTS/8Ckamh3BzLjX4XqYMFvr4oEhK0qdB4m4Krcty7wFgcV3uhpgZq59prB//gyCSajH2zobc67NkuVD0acmQitgZXFbxVNVTEDmClooGdFhnvvwF3wpBn9p8DVrGzqn0iQAAnpqXvpBzQFa7iPq7YHuYFRz4MfycCn2wB4H4nCzRzPCDNlJMzU8F2fJdbyXDIFqnk+0RcyX+Cla1fMeq9ZT3whd5NtXJKo17lDRFcdVDM57dpRgjN0SAc4aOk/3wuQqBUdTDDX9tQ41HD/rbQe5WlO/8g14r0uVsCtDXVyLU85G2zVZt0wEXthAUAAWRtuFahWA51Jh/ZEuss0IPCmnJaqpEFpyZeaxFKBEKPUIexBnxAxxPTtKtfJW3pcuiXLSrFeSbVBs2e2L6ZnApfLEwCafTmqJwM3gEliD+oVE0IWJ54YjLe55kbtTIKlR9JidJWbHypLAtJGWkqjfsLiHFU5VTvP5I7MYNKtmKGmNbe+57mZM4kIlTVM8dcWTDmZ0ztRhDhq3CWHg10fdCRRWJae2hHGgCtAE4q1gS811ryuEVxExTh1yw5TmcD3mtCLV5UBLz2ncZhBtOo+5YnHACTQ/wlHdnmeD3ykLGdP1+26gXR5pPI3z5uIFpG94RT0b/UQITNjY2rYaCV3rLD/o0E8hfKgh7ydBFEfubUr9BebBbk9HYJJ4EuLqK+tAaB3QEIxXoy4paHGaIOScPaEQjJfvXG1UFei55Z/5di/qjUaIt7U855+K9EJwtJlxUAQylP8BRxOsJtuCC7norrKttJucqZ/aW21DyIR2TDm1RKV2lMMXenHDh94NsZiRCaxWu+gBcdHGfab/YmxxoWVFjMpIhdYLjAKNaJOmSTsk8fPXb18EyDE9QRGy7S5uYdGSYqZ6qBhWFUAs0K7S+Js5tEH0qIUOgnCK+0FC/N9CpoE2nXxabk7AskERr3OoSHFXYz20BdXG7DMDi6zlmSMv1uglYxmqyw7gfBGqIymEau/+YkYJuACkOnLRLjISWAjyF+btJaFvJ7HzQ6Z18SsZxVgSCXroGpFAhjBGoRePSO3qoQAsheP9yOx66hNS9/gHYSo2ebMmi3qte00C5XyfCizrZlIcPkkybJHuBFpF6ntKt1gfc9GzYajFwNP8j0m4Et7j189qMKLLorWgguXucpsfddDtWXP8Yw3/bJFkkW0V98XCaSioqjJkyN8QC0mLQFwnsKxUln1jH8bzHO52+P7oAr6sZQZ6/ApHlOsa8dJHPEJlLUtIdUmThdt7w6Ybag50/hHeX6/6FU+yKZtEUnl74/yI3JsyWHBcZoPNCMFeuPkuefnPzXN4yGeQJC8AySFYkJm6G5WS5NG/GnTav/w4i1Z5jUzp4C2KQI5jT4KJgaD+Tyi7EOQ/WoI2HjwGOPnv41nEwfmBPY9/3AbZHJvG1RNZjmxbuAizw+j11JdtQkYoz7dmE1lrm2A7d9SjIFZ2NQ6fHsn4zIFMUXTAtN651uqx8nf58EgtZplMfMlnIDtJ9PNiQTO6KdSR+wV92LXda85sWbISIGv4s3rxibAb32KVPYWq2lupRQsPrY5IMpG6t/GoI5+HJtwNmYFfNwE8UiCYN9gpbb1qOK0subKjTWWt/CwpURNshfpGUZW1vQYdk+Onb3XyqfAMok5lwuuqrnnzK0rApSjsxI2x7wecvWToOdewZascl0GZu83ryXddMXjhHPFPJtr6wc4My3APeqMmMsO8npfQ+f22qDAGMWCG/1SYvRbMK2J7/hdmNYT4HRN5WzR1XJsEPZ07ZcF+t/EhAEXguE/5kYXOGJDaw5VynTP1jrAmJ7yeYjCwaNZGbfgy0u+dDZIT/qCwnlWGxMXWGLTWHZnesnRwb+xOwa/EJMdwSSnv88kK4eLWXk4Cv0JdtYXFACcuB+d7NSiV97n+d6dYTrMLNt5aCaBKAf/Y+zEqk0yJgdA+PD+41lB7OSRmsfZCt6blsbFFtOUvUattEEk6OWpKoTRrRSQl2InXVZd52AJNmRjtiJt86CuwoxEVr87jEASp3WI38q1Kr1MDN7mHI0NXIoDs/kUB2fyAiQ3WBjXwr2oJLKpaMZTVV2E4sMO1PdwR7I1W6cmsV/LLTwO/Kl6meQMc+xbATa8scmUp1LnjtY48MLnYbXSRWzq0SCl02fkG0g6M7ahXu6l6OKUUWyT/zotmJXnPzBHv/WMbwLR8fAO/OfjzDGoo1shSgk9QDhd6VkPYuG7ysD/SDYSND5cHYFhfez44CEcu9FB5cAh9Xb/CebJRf228iDoZ96IqiL+5WKlvMWVW1HCoiDGUO5j6YwWYX1dTMUdsFcz8tH0I7cdFwKLVsKaXxVCwkuxpLsRwS0dhjvkB5PkMdelNRZjk/SQurh1zHUTDy7Gx4KOJL0mXdQvOqn5Nxnb6XzoUz74eyvJXRlVb2+qn5Nx20RtvYk3wwjxPAIG3RgDed8coT+kTcwEh4Af77zeVJB2I/Iqwzrfwdn7Sufh5ItDweewk2O0SUyqUhuIz6vfRNjjN0XnWEJ6+qtDlpgcdc6nWCyzgd1fuD2za+W2F7mEJCwKZawv7nB+3hTW0IJve6BI6AV+frENoHX5FfGADsBejubFVzHQCktMYjxRwIy4PRzIj5N4sc0kkWuqHvBFeY03J5viwii8Tqs3UssJ+Ndg7agjDoBLNUxQFKiuvr4i+RIMiAsCbnH9KM7Ldtxwt7BWP+QzEIDNKp9md0p1ulEtsiv9kZBO9lYQKpcF1DX3tqW3/xA0GeAOOrl214R7iAFDMP7Hov8te/0kjFYrh3dSmbrrdPu6v7HY/z8J8NmDeuuAuXP5V+MVXM8O3f2Z6Cl9A/TsGK4alVLA+SsXpYmjzNEcRCNSvByZqO5q93tFbsHEnDG0wnmMgDTR9JNeYC9itc/0h7bWktoIEPnzJJXDkJWKG/fZxmIFUxj8gfFXu5swa7rV0xcUcbDgfsiH9CLGi9BNlvGopywF5F3ibHk0V6Mik/9QFVZgF9No7baOGTaszF5N3THIo8I9y4ONXKd5VYuENeNFHMylm8OPxyLHxy9gyxo2Rgx3ty9WaMdXwczkxnhn/ti2EoRmdoUHCPr9Px24JzP+LpRKb25EKRb6R65EE0cuRFDggAVUTI5YZjUAe/eJPX0A08vvzOhhzg8pjTXvE55uUK641jTv3Svcay+4djHKw4Rbu6q32OIvTc+krbA1wU1yZL1DfTIsXuovCAfphQJi8X7IDqt4tIgO6See93wjnic1PAFY8X+5cW4crYgrpeqq9sU5XbcI54nNUziRs5TDoXRjwQqp4y7OzopBh8SwFCVzg9rcIJAYS42uB5sfC+ai2vNY89vZobUwjElKz7E7Qa/PffTIMA0+h3oBcZ0ihu/X1jy9OUmwnbmEu3Bg8af+N0/NfU2tZB8p+rbyPA6TKjJ0im4kp6s8ryxWlN+zI8dF9gEzFUgLc2WjXC0uROWz7Ahc3ISIcNDaUqs42Aqk10NGgSQLQuueYigXTDsggwTi6+O+7T0rlXgzCl7SIJeo55SU6M+gUSFNHAv9byfJXTRFNn8hRbHXdLnIDR5z520F7Phfq42/PUJcYTLMYCHvyGaPBprSKqphL2CX+icHYQE03yvuxlvlTYYiUYkaNr7rYQp0NW5hGu/lSAjPgeDBoLlTk3kzcd0SmkKTaCGhvRAABGeL7G3ZPkx6/ZCS+vlI6H8nGYGzLXy6tiDmrRWFpiNMgLm4hQADzoU7w+nWoSQXVAw8qtzow3Hjh6b6B5acBBPciUvGgqEbk6F7Y29+DeEgOtSP2n1FBiyRg3tz5KobPVpc5AujIdQ4qf06JTua8+mF1Zi7KnUeeJGS6fRPSwQdRg3lPnkIg3OKcLl63RXa1Y/1TMu/T2fj8HV4eEBJ/8WXxTQ/2+LxZwJNquvMqUtiEsk06/it1bzDNAUq4O+A7tpQnpsHzN9jp2h2s4MFIHZWtHEJRqWNTEAzb/jaUaUfssEKEV1qKvjb0aCSroHpIHvt9GBz+tdJZHtetiEY+6vrE0ra3+VvrEjWPgteTXknPQ8WwfjBPsxpS+C+5qoOpA9EOParqgLsJgjjhSYVnzUdfRbcD+7phDKzxNWnqo4UYIfD6s8ISjrvhyRUWpxqwxMMqbC9BB17ngr8/KHQvyE8tcQpAsfPE5y32zBNCsQ0LYG73fICFHdnWeCcWsz9UIYDgajlxFrq7T9qTGnodMv2s+5201JmVUPPxUWPr65a6vsip3EGQPmW7KbAGdmSSNGQuzDmuEOrPPOSYPLB2sMcB7LOPceF1LXxiz3RdW1cgftV1jbmVJBY40kfBTRwtKtkThwat9MD44l41PXSWW8nbQhBrzeqnDorQzSkP9QBDFhhpFYlR+31n45b1Kp/q9qwZk4omdBPy36twHMpIkFZfljOeqUoP0lWq1oSUjgoDl6yE0oOuoxVqFIFj54DOWeUzbAtOdHA/O0Yf/SLQWuIF7Mk3U+kBuQdTKKeyg2JkrUsMZsuNXqaYKhZtaQNhCyhxEE0LwQI0pB8KRaJDsVA6/nL1DzfTfAdOrkHcLBP3AtHgtXk1LEfifggyYERuNqYBwbtUFRbtezNiKJpmrZutAwD7Uekv6dUfmnsj+TtW+SheCBGlIPfiC4A7Wca9ZsBGeqAbpWP6YvAL+NGoD8uopdh5/To+YG+dZyOMvGAiv35OGCY9HqsRUSBtPPpTiZkNFOymJ0yiEFIiC6iB+AArUQuKpyRfgQpK3qC6VH6fkboC0PcyHpILDsE9kCjVNHmrpHk5dBqz+diFlJXiAvyfd33fbZ67Zo+sRc8YrONgTvRpc5KLftCxuA0SpzA4NlhJuUNf2/++cMoUXMxM1sOY3nrEaxtZpN8X4W+3Ba0AyAFvTzevsxl3wgAd+Tjin23dZxlB5CfH58pYrDHTfsP4rHA8c/A2/6KjGAOKsk+JulhN1MBSjLPI/C55JEvyxkd3MgufHgYaor4uD4jiSQZw9S5b+fCRBYtn8Z75UsK8Yuxy/lztTwOZwv1pFP6k1KzQd5I/efVtImcGfYeOJTLI2a0ufere2aJbPZXPO5N66edHvy7TPNNb7nmN/t5ZQZULAVIyaHhU8ZGgQ2yslpfKR6ObCBZsWYWMxI3WUwe5jk+TDDW4xoEPOXfxAcqev5SsMy1ZRfF1mkOwfNVjnOJypxPaPrEl/IU5Xi/+wiIoO06Zb9DtaX/YWnVtECpWOsU1Exfmx4nKmbpQgnpd+wjTREtqHhFyN8WcPTd1Bjlcu64V8o4rRIkv68aU15Seh8Z16mh21vKeoXTKd/GPGV+TSgsGNun8eLnXXdM04G/G1BLuwVrpmbN5HfmMyqxMfU5U3YIiI3CYJN/uqOAytO8xaPG+ODGdQjcnQ6VQE/dUuTSrVaqrch9I5doK2Xamw0NTOe+7ICV3soPNC80bdW+XkEK/DvMUm0rc0tWabosUc7EhLLyqyl22pIniEfenHy5HEYN5mulwCFH2LAqxwPDoYIr0+Dh7Ob/ApS7XkBZHngh+ffaLk/AP47WFnJa9EJnf/yfK7XVWyNyqt1f5vApBgKzNjEby1t5DeOU+UqcNGzOtV/yQpSalFjTAkmkeDsFc1zV3JtICxzUavkBxyoUoR40zJgxb70rVfC0JapxaMLrOtOhewIcZdI1AVvg5im5UXSDXByBh1OTtF/tugc+TtWbOwsqFdqUT1SH9YRlUjkLgvxlZbTm+IKpon/vUQFmmkqMGTK7Xos5dAICk8VpkK1qqRbK4mnhmUAchTIbHZDblR6V2g4c9yKBm6LWqDN56E88Ew8Og8pdSi3lguai1PaV6nNsREJwcKa/R7qkm5DqARekmqs26C2XLaSI3gawNsLeC2niotKjdYKQCA5hXXGNk4Y/4c+xDbzOQ+YBdD0wl+Xl2O/DzJhTgh4dFmPZgQpuYvN1k+WPS4walMf5xeFQk6ass4ayp5IDumDhOcAFt1Pnf0wZ3OA0q5Ig0vPF+YJryPTZxj4vA4hND6Y+oLmRZuWUVYhy2fS6iDBliOXTEAa+WKKlNuJRMcJnLYovlAPHoNn83y2v1gQPZEE3a0rvZeDhAZ9io2u345MZ4XDpSREbvIAEVcajxMYpKS29y0RjRdG+19FMxNfsxglrjmIMO8P/mNXRLaxEEfZSvEGshnLTw7ke1NlJWKBKQXVPPAKTals+KUlvF52fvd6WFRQd1GN1KSP4aCMthAT4w1S+vJb6edUxQRHdQFa/p9iNtVpXJT0dcPhmloAM5vB2E5kUCOppOoO9p1FUduIRUlGDtgENwdmDvbYnhci6uIzsBff9xXjDxc286WSUp5VwFkSaaw5Q7Ciag05k3PjPkMfr3EaC6SfYU4QBRBdpACwb6K1j9wNmuHPhC4tRF5S40Z2UfTadxKVy231YcU7/OZXw8Cuv3X1Ftp8/xphawBf4992oXegFN8mv87sAhLPrsX7eEPypcnt0PEOCcp3nL28nVsBdBYCB4iKZUMKUcF5o8Dy+Uo9yadxKWYnSFNmI6JlOSpXLNpgaGNSG6xpfaZjcFQhdgoyuFKV3DPN7GTK3nmtFux4d6EY3vnC4c2m+TCV34Apt8SejSg8Gxz7owMpJtkESs/n/Qh1bhOqPlZrRagq3xaLDRY5ZYRYU1PPRH1U/jwGZ36d5Ig5YPvwo60FiEcyLb4clk6GoD/O5OY36zDVbsikH5voaqfnM5pj6nDugb+i7nlJ8+3CQpfb/gYteN98NoOi83R4s+jfp49SbvmmH5o2zvSazjpJJQ0hRAIpK21WeOZBDTpVTEGYyyCPjEDeb4dt2AloFNhzIbgYaPyJRBD+5oldTyk/JlsV/S3h7oRqGj2BCMp4v8hXZW0288URMRm5eN2skkEt4VECKEuFHbQCGMPD22U9KLkr8dikdVrPMPYt82GBQtKhMZlbP2Xe5K7U4My3naxmw7RXsGqtnn9Q3Jtn1hPOutiwuQXsRfN9HjoGAX7qj/bxnVyUpLywXTm6evtZ7gVDmKm5UJWT+SQcLkFEEiG6bsGP3GekL0ApSiHnCgbjnG4nm9WGTwGQ0dJt2W52lTkVxZZA+/u5RgP/8Eg/zH2qMAt0cj2K8hWG4mrTP2m6gxIWj9lgiPuqFdHQb3abu4q1CtUYHqCOK0wlHG9k8oqm28p8g++kGCbPRVZympjaWLOsMugoKbNLM7fnJJ8fcym7tVpBx2l9jI2iH4A/FJrMst9w9mgQQ7MW6R+vm3xwcuzWu/kCXO/RjXcPM6kEznkZBk00McFyhOAPPOXhZW8EXCeYP4F9swrPQbLmRNnxzopADRZfsyKLH7F2zN3xy/lvrOjcDxRZwOWJWCxQLcsX6URkv/CBxzkpfAx7s27EorLlpPEn+QpcgEvu6rJSDm2WXrt7htT9RM7ich2phy1ZCMcjkZ8kpVQQfBsaPub4hJWeRhZ+DUqfFyFN2eg5xtevcb2CMw247l6B3ApV5qAJz/3qXMCXQ8lsWwegtiW/mDv6ydCuWWRNswUVqJ7G2NEeEz3xLnziq4GysoRemN902f4x8Hrhy9X3n9UHJXEwnx0OhOGX9zvV9VkSwlwiGrTUG2Fmkl4O2St8w+iEIlPnZyu0C2MpLhQPJset5OQvxS8WaZlPa+PXMj6d/NMJdYnMVyYzArOHLjGkVTRmYTAVkUQ7PpgqHqWCcKXM49jaUhN/VIERudbK4HIwn/lkNV1+7D0l8or3xUNK8OTg9QTsqynj4ko/R62eDvCIlws3hVhM7SuqEV2y5yJwdg6YOwlC8wnuM3ZdrNvfJWkWoEQeaLEblZnC24IjDdv6koeTyGPUPyuDRLfu6eMaayP77rL3KQs5BygjlXt5A1cYXuDQJ5kl3TG+EDVIAscbAgiwYWcvpS0TeSaD5Et05HEA9hjrlsTP5PSwKfyoQRcmv2nLVDDjnfe2dNhbiYuOpNnnXjmmFqrBFzo4y6OQng1QFX5ojyxogw7MvOcb5YxlxNoSCLk7H4T7/1b9txilYmz14DXQvoADfmTSDzvc/R+UrKRMAPxnCQ4hd1pOOFBg8DQr7K0eLvPywZ4YEdMXPU6P3guSioH3Q401nvmpacTyZpR3VHq0zwarU2ETWLG4x7OYtetYx/kgiF6c2/E4od96+hx/W/b4XPL0y+J8x84+UJsu/kzSjuqPQlMVeFY53CgjUWRe4lKlREwJrfNMPzRrmGXiwWA603shlkThZyNyCqv6tB8v69CFPOqlYs68MzylZOfa57CMAPugUssaICQEBL5B0+VOeO2yZIkBeny9RLsgNUsoLmwcoeGqmPiCAObKYrQp/4nfOnQqG/HgBsihRnzltBpEoXW3H6SGU6+4GUooNnIqq2ne5Mr+ZPifHih5lsmaO8HQ0ZkI9dngrTzdfPp41d4GJxE//KOfAqXJr5R414fMGTtKLBQbtJjlopcxgSpnH6DZ1bHzslCfX5+Bi3nqyKNGdD33GwxyW9jSy7IUGhklaCKSvYEawfXoto6hbxlEWQU4G58Qq0L/0Ii8jG7j4E5EyoUovGQBbSytnU6wEVbue09kcjO4ATD+lnYW7udEI3QLtFHyyZFL8zJAoOcFRePtMB7vqsp42P4znEkMlG1Tfa6+OAGZv4BEYhsAk2lO0eHQoCa80h4me7Ucm7VyNhxtMa2vkcf0igYNgA/182+ODl2a10RtW+O20usYHkDT6YuKH/rBG40FAI/JPLVU1Io7G9n6Qc5xvuVSxTgutsDURW0iUnOt/COdBndwEUWjFtiyYnW/+2beKZuWw1iy6YoYWglCMuKLwJtAjz5ItYP0ORKkl1/dTh33TUhpBKKT2HsRBVLM8xuaXTL4hmiTga5Ekcp1lEEdNEpOa5Z+ys0pkZSSyRUnthUNg6mRg9QusTpqUXGEO5/2xdRGyFk1DmnQFTaqvHvNHDk9UZTVhyadjV/YLRu7WTMk7Si6NRjP/f0cGJaZ+cwkQgjPUOo/kW6TPLc0vCQPzNFamWvLGkeTjoCrTQFyh64IwS9M9MnCn5b26bMjdKiH48bMta//N6acE4HgWb7IM+OONVxi57Xg79dPqCEUAyMBR4UFOgy9hPx8UMt6rz+j7Eg1K1wtQNKg8ZUCm9YT9K0QsHZSkyLKKaWMueMDAvPWU9nSph2C7YBUv3oNxQggl2AdEin1djRGrEB3IyvATJgA0prCbPN+c47P7bUXAeACXd2/PLVfebbi4r/OMbz1Zi8LhrKBgTlYc1c9YcL7se7GYc1EbUKl0rqlfU0X3Rl7bZIGsuDJNjNfN2qv8xQLNq5oqWqmnm5+nOS9BCHpuLG7E/bbZqUjt7zYhrAWq21rHDZVyaQpdXod0rH0N93lURmN2aGHOQEyYANKY5CTHsesnZDIZZm+yDQGSeGQf2u43gQ7I/RJ3KdTZv66xpRq9tdnMSR9Bi83dCKIGI+ijaHWAu5fSxVlpg2qeKkThB1+vgpXvFgC0bEzC53syvzyjuWCZj1NmEsgCM4pSvU8oviAdEcDnKF+p31BR8pzTqPlzSH7uZteSNhzt8LfE9+0B0Wx00Hgs3STIpTcjEG0YCpZwu5en42EzxiluTcRfWSzy8qw4/WFYHIdpctghlfIvofvQv5Q5RtWq95u3wz4tCChaY2AHz+aOCPaMohortK3PggmEhb2ipk9I5fjr8dVSXY4xKIVPxho2CtegLVCVk0vzBGqRUI4TTUPO+MHyGzWRhUqtk4GbqWt67Xfe8cQGLASncEgcMsZbwWpgQeazFPSu78gSf1MgiET6CC+rltgJ2FKAenpWyHCn2vddN69BwYOGWsDfJAZo3+YoCBEKIJpTajrLxHDFWly2CGV8i+h+9C/lDlG1ar3m7gLX1MsyyF9Ef5GIlonAmhOHtGUQjKp144Va/qC6H6EgqiJlK2k0cFb8Y7ctGMY96yB1/swB8nCD9cCxTWniU3I9nn9gGVnpHA/vtbosTUfJ9v3mQvGsc+9E6zLnOpKZy24Ky0IYxsU6y2p3BkamfO2hszupTKbSL+0EWjB19OAG9EIPMDLllW/x5XtkdINQl4ZkLpiqimKeGaRdqk0L+e1i6vmKf/1ejW+zJRMb45tQ8PR68xjnhWJOhI7M80d99TZrAQigCMJYYQhRh75Z8QZ1mH6X5T8pA7pSJJ6kwvldm5z2E9Epv7Y1wO4BRNE0ZOf7PmJExKrjpKRhKe97THAhNf3bO40/d9BRQLbgxELiwGNKvHRFaWX1xPW4agOjjy6uiCtwbe1G841Zh5mMn17yiY5xmeS6sWQ/Jrr5PIklx9eyB17e/6cm9gUpBfAL3VoyakIg4m7bR79Ll/2JeCc4RkAurpEoVPhktNzcrqdvwRWs1/bo/lDaw3X8GuZrpH/D0i4VOnAXFfqJmgMvGrEk4Qd6BHJEyBd4pTnhYOuLkwykf+iQ6y/9dyQ7HWHlBeJS4WO/uB4jwCBgmoYhx8TpLsfDjaWTK774eQLrtg2A+07m4DqSnJSpo3cx1x0SWzb035drmafMRrFPMa9WAvKFmkb1NZytE5DMjQc9ounfqcZ+dfk1SnNK9UYzRcGkfLzCSnA5Svkn1QWbF3RRzJZYB5ZBympv/tEUhh6RVGiKCOgbHL81+WXxoJudw4soblb4ChJ0ZwSRi0hupBMjoPbFCAUo4CXRBi+dNMdKOcG2/2OIs2lT2P7I9Gm3SxhJTq5Px/cveqt07Qru6O3bfnc4+k3vlO2mjB+Yw/9CMslxstcfiHqLQ0VtgXXVOZQeFyLaD+tSXPV8luxPS1BCj/y0JR70dBDslI+bWhH4SaU4LpTqb4olL8ItLFEi8hQ/TEjgARwCeaemTw+l9LZapV/p4ou/nfbJYbxobdbRJJDXU45QWV+PF6UgASjAvABmXriElJoECROtN+UFnxlWzYa6BfYueoZAj2HRx91BNRNLWM+o8OxypUhJM2BZjlxwE0a+p5NKrFiyXbivfQNaXzNXGqoiGgCTiB8iIo93WITbkXiyHwENH5eLPTDFt+1hhk0ZCAa/srWMguZ8Xl1KTl40hvyxtmYVmZ9sLx2qyVauOrIFtm/+v428CkVL0d1zLaLkwWP13+QEaeodW7ibyX3FhSgHxbUnFL7UHrQAAAlo/zHGhVu4/gXeEWOSurZna2S1vYF4devDPK6p0AR6J1wplmWq0rniF1Qh8Akf9ZvFg1PjnWsjsGd1fdl43W6iCr55mWSTAzmi7hzy2aUj4bS0UU4KlMaI4nwDnXyUK1QGgRRfyGnj/25QE3AQ1oXMQkB3h4kPjwQ97rg9GTBgRrhKK0PhNcCQLtfOyc3q8lvCXTZ7c/RGqj2/KItb4Edj7SDOtRaA01WyrTyb19rD91v2lkPwnay7UIKmLenJM+jDk0MOZTDycMjLmU4unl5oFAsniIMP5eGdBtdiO3bzVj/0P9PffWO5Gal9uKkxf9F1qwMHOg955TcyUf5LrYsUsiLey7CfELAHGw0mYsdkGTCqEga4IdS0o9W/dSL6AIJ723xHWbUdONhMDe6Q0cwPsMBWEZARYquPrb0oDHx1DD5nnFpLHI4ER9rEQqp6IoCV/NHZsK+CBXr1IlYF29hdSmd9HAfzT9aBdJ3xs8V5JNOJYrdmd+66Sjh1XIs3agF4evMLh/u3CbSBENVORa9hDOCL42m1Fz5R96J/8k57QnF8RXaWgoSsURZ4rRrkTT+a4eDjQhVTfZpYfejONh7yOLLm2nd5uMoreWcaRF2LbWSCJAi1Y0UL9tZLHhKKLpfO1Wi34rJuBo/0swql5jvYz9PZPgZ10Cx5JnXreUIqyTdbBe58z/nMaPQR5DbCUVCBo/18aWrgt57pVIM8StGvj10aHNhZaGQGwWqKprKqIITsATtCjcq/FSPq5/4wb5lkf8xjgID4wxO2joUndanCk/h14qa07sT26tkl5fE6+LUE+SEQtVYLlUCD7zt9b4AlhHGzGQlWAAAAFF/UPZDEVLLs6w4WwSAJdgAAAawiFrYpEpXheCYAUG3gM0ylgcT3Lte1yulzlZv8eX+unSVQMTOM54KQBWasy1iSwp+Ms5KFyXcdSTQd2GBBEQildARJ8FOFe/H73HlFPLJx58GsWunElcMrUJIC2vylLOvI14ABu0CPXt0TsZXq9j3J8LHlcMdjacUcnEsiXKYg7AWGKm2A2T0GGQfQDaAnxysemXztpCkLaK6ck2Blaf63MMa69VLFt9OV4ZYip3YH1cPcrT7rIfzSDoVJqBVfcX7R3qVhDAHk2ixsthY/G+f2RiPB3yFFDtPdnNm1GnA0nnGaqZrW+A/zJSlZJmp+gzEsEue4ICJx/sHXdOtt87OAWzlkPhklzwYA06iNC+G6BES2vtuBv2XBaMTlLTIB2g16zVfaXyD2bsWDFl9tfr4HUc4HAIImi0pq0UgxsOm949KtTq/T9XEqlZNG3NXiehxLEUTS72F+VqZp5kIJzo8hGn1TZpwjbrIbCsNFvCrPikbwvhj7ztQLwn5Rr5LRyfXxY8oUDhCFeHI2iy79knS7PDH4QfnrJv+0kGru5IUxqJWvKr99h2X34H0ZgQOXWAzYQlbX59/xodTxm7Do8/T8SkOVCxDxBOrHI9wwhbU0nnvPCBkHANx32WapwxCVwqt18htI38gJA0O4GbdbeUYBlTz0Lcb2Qr0sccqNjVedtYqelRjkMoNS9IB+PdZtv20nWtLNGkuxlb166yAjaYVBa10No7/zKikOpP9hq5HGKJy3aRvJo8Y/c8jIXwU7ZiHtGFKdQL4EABc0z5jn+0Apnz3Lj8xLux6JCxlWNcqg8mKVUsQfwVgf/VcL6R0XBCfVHhWfSuplLxjuJFnTeiPJmRPPzAIL1P3y8m7NjJ5Ke805KpziN+/q1lT5so9ye2ptJ3evTLxmCdTEYRG76Qi9/RtBzP2SYM0dtF4B0XzBUfxfr87lUMygE8GAZLAYzYZyiShAAANxO9X6k3DQft4OLPIAJn6idqwO0j0p7LE/x/PLng7FQSY7DhGnvIpojB7W6J6xEZDw3bp3eSsCPnrHvUCWv/49O8rWqcemi/VxWhXebD+B4xI8YMOC7ALhzJ7lYPgEcp/CEectUvF0ASuV0wT51iq+bpxY2nYpiT+e50Ha4Mm34TTqYkGPg2LjUx7DbCSOPzk2JL4zgNRI9jwSZUp0PPQQdBBcUnc/4hOfQAAAAAADuBAIH9pAjq8KVgUIt9auuNyfuSmKodtgErak8OQBWoPZck7xQGfjaAAAAAQ+30vCtEhZNJiulJK9/8qxgoK9f+aOKZRDq96H7qfUGfGrO+KYHgtrm5HaQrUJIjozU+7aeB2hml0NdIHQmGeFg/6SrBTUJ1lSCldgMwtwJNqFwPEUvY9V1WtMZXD9NXM0z0y8UlH4SByUxg9Kmbh2Lksv0OG+dThuj0ba9gj9sDAQx8oLdoCYdSVLMgg8K1IG4Z/ufVHawHYmGQ0wVpcbgkNPaU6p/pVFDKHrI7rCJrmMT5+TmauG0h2MFpxrCqCXpUc1IRdc5Vt4tvpyvDLEW2LCMG4AtBaDpmDyBStM4SUWkHugWS6/Y4ud9WWTiCFrlV26AACtkO82FMSuOXukAfStUpPrannT9ekS1nGmhCBjual3OXqBQ2rxAVeczbOqSYrE2V+t3WdfHMpkPW05UQ6GM7l4fAqOR6aw4t1aNSbay4YbU4HN9ZUzSVrXEh5S6gFZeuwT60F3VRAXnsBen/UnMVkcumBXpIirSDbgF13qaC8eoWVIaCBhRrKeUogNdG000fZBbXYe/gG2l7t4e0v/lIBF/rdAuFUvv2w3RyiB3ELto7IeJOlBU8kjKL76A3EtGBAFHS2NV3IRnJCbjcpwof94xn6OAYPeelZxvxiqUdr2ldyldy64z8kq24UOX58gPPF4oONW4u1EXghWwSggRsLjsxCQdqzqnDZF8ioywnYb3KHi4Fx1oMJWXQN0EPctlKYQOZdjdH7oibTDK4+baLlxmW4N1mGpIk7gz5S78gTxFzO+E3qn0H/H7a0PeziNHUbgpeOU2MqJIUTQ25K+QbHZsem32sZIHgK3RzAQodit8o6PpHe2Rb7M23xk4yXIGDrgqomlxi5QXRyQhTFn5tsG+sdS3xz6o3O3JM0nsOzaQ19IoK7+83TwrOvpepa3eL/drt+WIhC4RhWzbMnCNUepIqq5dWY+rZJtC3faGeefi0IA7VkOijdOqkZxk9rj78nqkPAhv4EuyCa+XSz9x2x57a0OQPo+RecNM5IJbZVTJaLvX25kKEUOKM5z0cvH8fjSu2fP3j09IDvFmYjZhzf/VJI5kMLj2svEyWcEkEkFkvypTCcWPVIDtsxi47WVsDKbUHt+WF3VoIn4t2miw0cjTwAHQAAAPOafFd6J4psiN2eBXtqEHtaLDJCreieDdKGdhX1S8+pM2DZPUuPmq2bCkbUppwO3WRl/cEHbJ4p/bmAKeLQYwvCAKjOpYy8duagqCezCKVtzqKIbWbpRbiNxrxBdcagJavpVi1Ou2kTpGEipKYtVS389JGxijMsKBGf+6kP11mBm48hQoyupkcmsLZIFQ5fxx42q0MQOS+Cv1kHpFNnkt74v+4pxgKKL2tgxEdpn/YOQCmHrkmVUQAAAAAAdWakAKeXYYRkVMLeRwE60aEG5g1n5XowY44AMKtV0zCa4q75vmtQVflygW2oHwAAAAGSB0IOzWB1S7Iu8svHIfmK+PDX7+Lf7orFJW2n16Ts9/RssMobBYq4LjH9zQ5mnHp7mkIx5FNKyw8GylVHp9R3DldX2ANo+yAAAnwYTmiwKyTsto85Yj/j/O3z+yMR9JPnICJw7S5FVnx2lTBYk/j1fzo97xG8Onuzm7byHCch7SYRiwUMJM1qQX57a6pw0zL6yTatTvcdau0dsywi/HqmovoLoTKqmcQMhw4vQNpTqHAcYr040Bax5gJ6Iwlua0Kk1AqzRUujoIkR1p5gqjQISWYwl9dVKAKXKhxEZDRVbAAHTlaE1O+c42FD7SLrXo+Cal8uWsiO2+h6c4aPCSk+tiK18ccKs9j7pkBunhnx64F5UQcpx6znk5adRLMXVDMyjL9GIvHul1Xx49683B6x4d/FLZve5r/uFastORtfSlpuUeqB/Cu2CGKQMv2dxLLruv6myOvTFQzQFD1np9QIe5r/uH/5gku1LPaPdbMkvdQWQLdvOpPMRtaj7iWTwW6QoQlLnNLNBnjnyujCoImnKvHLBr7+SehIJqbpIhMADDQsjDyMzigyI3UxOI4Nmcm3+VGuI9QVhkqEpwcTlgkozFHcoCHSktBVPf6VnguxCoesOc5zQ8cKiigoY5oEs1TqmS9h767DNlYIc9MHdT9LYctQxO8MG9yTd4k+Mx0Oa4BEPXI5DWOXAd+Ds5gJZRpMoiBms3jtyJsQYbv5a/+LvniP9MB1RiS6aJat8QyPKnIMMJPUp3h+G9OKoBEL3I/YxD/Y3+QO6fpmvTLrVQZJ1gaPSri8LNlEnirJjN7nJ5zmrbF4WHH4M1eM/9J4D0Sk84NC4cpddtTUvHnK9vurG8wD6/H429KqXqRWKXrKzTsPPL5UprfeTiiOV4N/gfCgQ5eRJ9HDrw5YdxaMX8omh37aOrclft1eOV/oH0LGFGjTGz1W5VcuH2aVHryAClvoXcw17GwQq0Ij9rdo1ZySz9sDeHD+MUh9q04odQ01nQkxOm3t/bO3ET8+DuJ4ZKY4vpDRA7XW+9bTqI/77ZiKTVQ9Yc482tkw5ZTRUhSElEPWMNUbX+mwe3kHZO41H8DNiFuvOKRIxbbcI54nNR6F5Q4mPAACcxhY8ZeXRG4VCdAZbsaLZKxOXyYIdNv7CJBRfOlBcK5tck7qdLQvVanlyulxo/IDsedJEcNTnTUCs9BJvoQgxYuIheYZ26SXYzV8YHsE7W59Kbc0+LAbuHgnZmQkD6WfCRUUc9txG6ZtNi2+/oeaYtkxiYyosYiHlIhFJtu9L6rPCRrkrT1Q/0FFvgV2vEAWTWvtYDkzglYR8dDcE36VEA79JfuYhT2NyurJQBBu5m+NtAAAAAABdkUlbyOB4macWTb759m0yV1nD04KP6+InZB9UyDDAx5SGYxAOpGAEiMAAADgZ2TfViiA07cc96QoSR34Xi+URZKTSL68c2aRnAMYLhChNWHOWSyYNCq97vQQTA7IgM7g7pmgFoH7XuWgsf56yb9Wy7iyp5KksCW9aKtb39VeC7QpyA5qhtGG2/6suOeiCLEb8b77xBhiHo6GjIyJmjtwL2PfKZmp3f6NnU2Lk+wtYMJT7eGkAkamqfayYz40bSIlyzTmiSEYLh/sDBxtz+382Js6IUw4IdMWC6FJQ5r6F3D0NhBXmsmpn+qgl/QRC74XB4ZyV8rYAARPAz/OmTD6jUcKGweTbOohoCQ7LpvL2bl+OAptnge2lAQu4GZmxx9DhPYWa3yVomXiTqgne+hLhsocpMugTAMHPNdZMCY+Z1uO62dTlJUNARRKKt+B/l6OAkOivd1SjpsLbMvG489Zz2m5vgmpN7ADqyzXOsx3lntBUFJmLb3WIHOBXi6hfcR+WVNl6R5+HXGhpBDfi+/7iqARRpLO59UB4R6RvPM2Dr8aFRucpm94CSNqSlUH1k78oCfjWgwUXrUyV2smHQK2xqrDholeG700zbbAa4U1J7XX9BWDybeMypwu2LRT0G7Q+5+LJecJyN7XtP1aHlfD1+HTchT4vXI+K13/WED3po5LJBJgIcDJ6NuwN5geILYtgyNgsmmVr111Z32Eq3jLs0rqtqyw7SSQa1IQfFJDE/MznZy6jmnMnzwsNi0vbqAvlVKjaOtwDxEpIO5907uTezzbTDdZhPlLT/sUfAEYokqq38+OmAIvbShpxtPwlNh8556fjIwNPtgUQtMFDRRYusknWAc+6F2x/1Vq7mw3B7uXE8hJWS0qU223COeJzVa4koQJjAA2eKqKRoBqNKXXBPNRLHmFOilaQZhARCgiHfenjT+sJutoXOElcMuMra8tuqOFNeVeKoRg+sBGtvOISJsGk85vnr3Z4kosaugFkMLnDhtAIz8sVYNUB2bVjhAxfKOegt3bZ/CbHnqM63NiEXu4a2/RmIzqID+QAm6iSFx3uS42v18o/ZakQ00EyIY8k7wObtDUBajyGyyCvauW5ZZeahXY1ASVnZ2hMT70sI3jAkMYyO8fv8Of/LvJWKoo+FcSPv+NwQtNEH8Dochu1EC4wUUKXMTzJLIxpruvfqyiqVG1fTX38kkcqDBgWAR++Fw6+Ugb2wCYkxgAAAAABHJRLpFygvQAAAAAABLfJWjtEM0POuoRRE/6OE++1AAAAAAAAAOZDqu7L4vO75oSc6JEj/Lhq8tfMla0/hQdB2dSdclLP/gn0pC/nBLV7zBmdd+b0O/UnGYRnSPdl2bFd9MHPe+woDpyc2KdX9ftDxHbDQl8+Kuk3krr+eyWr5G+ww+nG2taA38Nbsdxyov+F/MwOPjTi+kbQ4xPUbVHOA3kuQ+OhXFQgK+d63XYp+lu+FuQBK6GQAW0rADMX+ZmgnbQcjKvvElM/FQKWdM2xq21AZq/Oxd9KbniLPAv9JHJ3OXu43UAjqJhKipiZ+My+UNC4+KJhJqZ4KNWnK1HyHeImWxgRHrYHd1jo40gnPweZgEy8HKTLKb2H05DKQfWnbRY/W63FNKeYGtB9PfyhwdCbvC/1jR24nFU2wshLnwgDdV5ezYDcJp2IcOpqE+3XKlTi9Mf5tQWc2JdRGwrjEsklZuquOHoHH5x0FFW4PDV8Vx6DenlUG9bEHtyfUoZsTyNBtZMuvXLsD18krlMPlxLturIKZyx8aQofV5UIxf/ww+dW8iay60jfwhxIGlRC6oJrFAr3ZkCHSKoB27AgjhEucPq6AAAAaRUMnHTuAViq8hmNVL0Le7jsRtqQa5wCEoevNPdwO5/dZah/BIqll40c5Kh+Pn8KeujOEMoR3NPhJcC6/DjF418mzt7NPKyJStHv0pU/FqzOKOB0l9qYVFZA58UpxFKD9BRMbZk6kzieRIN307e6+VT39FbxzTD7V6Z4GEpWj36Uqfi1kKFz8uS+c2W7FwQltS+X2WGYZ02UQ1HZmtpjjt+2G55ojfVSzMj8C6tnqrXrWH4VN073NZn0w0qPRYrinGXFggcpM+1ikq2XlrOv+W1r4Um1URmWaDg0lsiyhyLUBpu4d+jyfpqGrtWbarLdMHQ+GSXPBgDTqtIEcfcSQUn082Oh+ovKUX4BdyBJoCnaT7VeZp19QPo08w6HwyS54MAadVpAjkw8G07Uc8KQnEh4Yzra0ZrOgJVJZCwzmSA0qM4VhrQ0JGMna7oYeWebV9u/JTXedt6o4H93WX1R2T7AvIx7qTFndO02ZV5z+PMvPHczAVI1AA18FtgDQiPMCR2lXAPEXO7Uy7kYobVdQsYYYy2em5Fk88FhXIDy/doptT78kN9bh13zb73f6XdM4KSvIDKOwOfV9SVs6qFTtmqGQY7yyKdywjX/ELKVYWhfQyyuviKgfQ5hSSClnxhD4abPC6wNV26VDvlJCzqFB3MDOGW7oNTpWRDLVwu7u1c3QAfOhCiFKFg6aiDABzgzML8BDv98wXZEQDezXhmIPoZCflC+CBrQQFcuvn2BFqSYDs2cJ8Gem5B0Bf2ymlSsNUfXSjMLrGVZjgrP4XTQGxCANAlKZsR2aA4+jCv+YFBfMs50aT7HPHzgGK72Vhe2iE+z4epPXMGjUuL/WhOrkW1IaTkMLbrWeE3ABza73PnsPoTuoIYRvDFFZbG+B48sku7OZm9ymBg5USDAiL9POWS7Jz3+fanEVfjis7Mv7nZIqPDVMusrbmvhbXN79I9Ayzzbj+Z5e/u7YqlEwYqS4gr6AD5t5170FWiSOUt6qcHBSqNqyRFiArQClQbt9lXlquYmrWEnuZzNCVJ/gqyvyZ7ds3dF0GPDynSCIk1PNg1KllYHs2T2VuqeynBkFM4cKBNbPKzontO4xvCw/w4GTh63or1e1d2ZyCiMRV3xZ1IQAk/c8Tgx0NpAAmgCwwSvPaUuwFbztqQEA9YiKrY17IpSIo4vvSlIZUQQNf3Fp5YCPIX5u1iDf02NpofmSOZ1SxMoyTi4L/PbBmnVYPN0ufC1ORbKx81G+rlOXVNHcPwkG8gtLSMu8d7z88oCViNFDTQzTjjUV5QW17ZPA4Z4EUF2SJv2HGE/KsqgXPSFHdPHSYiVNJkzTIFezUMSR2hZUL15A57yosoIo+xUDyVZ6hPt6WSOs8IHvEptS2LVglfDv2LMH5RQEIpf/sf88xxLR0YbvEJENp91FDuYgoWboS0BFI0pCnJBYrerAy6sBny1rS0l/eEpYSON8FXOQ5WZoKpsrcK5chncbi5whyFTar9GOW4WCOghnJNssbfHsgduuMcezkYqQtOJjw9SXzGq9o3dDS0UpnCN8Ge4frvQlwgFUl8MkwAd45TYysezJJw4DL7yvBfgA+QPhSU+PxvIZ3sYym9ngVo/KFiXNENFm2+Tb6hILLoTyB/yNCW9M+6MS6QFfqF3TJJ9RQNQaWd1MIMeO+0LOCJq6Wt3jqq0PtKy2YItFQZ2ct6Rs6Hsc15iN9VLMyPNcTwyHvftWe17z29sCTC9sSsmzaUN/7VyEqRScfE2CZ8F1t1aAZ37PWTFg2g49Bg8ZzeMbQkK0Rt+9jQrByGlufSpy0qEVF8iER1WeBMsxdUMzKLQuDzSxyXWs/uAtm9T8lH4FNzrPxjxuSDG1dky2ArbG8gk/Z2cuQAWzBZ6d2Gv/2bbnAzCXcVEIB+2SJm6be4t2TM84RxodoYQcIbKFg0nALof8UTShbv0KLyebSRia7mSXIZr99+UUxeOERiywKszRtEaTigXv6vQKPrKZYopJyPasTNnSkexg6sEYX50OhZqrg5IaJnU41h+F+RHxs3sPZRF5i6lGAH9q7yXlYm52P1eyNPJS28qGs2Q01p8XnpSQG1vQmMhOrDlBmxztJ+aqWLZWppt52DXQVrgqDYu6SA3nMUIvs+IJfXLqjq1uaqtL94MHCondCXwm5j0uAlWlEEGzuKjMxRQcThMcNcy7FY8OfOQI5Xc65G0XizhT7O7oUbeRHUL2wEKvEIZFQSVhLTClJyChQtp4vOxivhmQfBWRp5KW3lQ1myGmtPi89KSA2t6FZI/rxdMk3BKue3bpHB7lWFLshgCNqUJ46mQtKWl3vStsIACJeV/JsG4qWd1olNd1ByAD/CXHOKQGCLcobFWbDQocOZzKz55yHezqmiqC21FQROC0x5aEpNSOlq4w9VPyG5dPere9L/ZL7BGP4XLky0lEKOagEeqy5Mb2G7X6QxoEuV0d3qtXhaEmFniMJDL3iSCQFtWSWBvi0u4DuhqbFwpHJFFmE/x4HheQ8YWGJ4DJap9EDnVqtF2ZMjDXoODPHfz/RG2AbvstRn4zsF+r7cXJC2l5DLcEHRogQMmTWX5GCfrCbLV5i6DUZhrMp3qaTXzG2szpkPffbVzsUp/RRE/DSFmXHalod1imbBo2a7JyWnYg2Yqium1vAx6pCP8ZzZ+ZkHNm5robDp0PInjrmHe16OHwH0fVhFZak75soIcubV2RIB5zztATR7jZeTASxm7p/S0frmD9+qS+jbOxRsMcTSOot/cCPLEFJkGxYaQF0gjtCaO6rOOa+2M2aL703ND4mjnUVdtwjnic1PAFYxtHhHPE5qBwc5IJvVEOpXd9CD3EFj+cBMeAzT7piXSfe7AIcFeIFyzYcYSn8B1ZfIQmYgf37Ob2huSMkyL7cyCFUxkmIdkzuToZ1oQSDiXAu8Qnz0QCRyEXUIlcbQnRpG3md0G1VoSO6r/O594YtX7b22QUe6hXRLYmPKuc5F9VS9g/e1vKY5Cq17gswps5g5IAsmo+p/66CsJQucDyl/ucfTCPmm0jO0yfqq1YcEjjmpdNpxR7z3REu0zpOBk/6rtKxLlZjPJI7OilK5ibD920OaPIxX2im/HsZkvlz20Jp4/P7m/ww/nAbrZc+NyGKbEmH1AgF5tUU0mYw8urxNsE2P4ucH/7hhi0LueIEG5YovJ5GoOOx47DxipDxATPFrkqZLr0xgWztPM7Z/gHkN2dPOUXjmXspwjf/Bsr8GNwK8ab9VIpPnSc49N+XVUBMADdSKKLRGWtaYUgAHpM/mhciRP5glyyKBwNYpMLqt74Nsw1EVZvr3qF1O/HVzErDgmvKbrnt5MRYKiNdcnF5JmFypRwntIKm1/jXTvcuGC34c6xItgZpaiAGV9oICvBOR7oqxni1zy5JFxaimzVAFnxIMscqf9diAHt8lKJ4X8/eHPr7vGBpy86tNPKFFO6wrF8fBdJjZdJgbHuV3tn25K4eaU+pU7lJT1xm1JVpWZo/S2aeyLnfL2532cK3qEXhe/O5SLeZECpHkMqXVsFc0VInzdb9BTwrVxv6NQzkrKowAMeGR40UNWXJoPnSvq5CdQHIA13EcZ/P74uXepWl0zf6i/bBc1aBLjAIgvHtKIoJ5xa57jKGq54JzYok49WlfoG+RwhoCY7NWBXNGHwJelA3BtqvzVNA5aAV8Vmnz0Z88cJ5hEMwqeIL0CGM23inCrUf6MHeHLDsI2O/kq0JcH79M7zg9QFieSyiCE5QbaDKwozz/9AI8em6ZByKNEoo3rPLNbmhCIRB3wFG5UAEJs+xiCvMbKb7fUs/QuifigHb1aY2ejNEJpF+w0E1pzYxjyv3ZIKcHbOVihYt4N38fTeRLYS9QpZb7g0n7MVifH5U1ibgjL5oocZe2dNxnCa+MFJsp2fjqgilH9D1YhhrkJKd+sjTcj+vMuni06zmQTV4rHpT2Em0u5dWOsmvAQ5Di7xa/CSXiZS4WRpcLAIWaHyn6fzqG5NdLs32MxT3KtGajC0Ccy2cAV8HP7KBVn8i3yeJCtObeFXBcAuIhx+mDuHi3JKFnHy9hzecARKg+0X5pFBBc1B+TWTXdTacpdLmwAXUmB31zsuQ/5y+J0aFErX3FWZfmwCMcXHB9bc0ahu+UuZiKoTb4+kNUP1oeU7ki8t2Yfn5/Pj+s+yRS1ImnayCcAR93VjUKTP2B0NY7FuRGHSgWcEoy/2aW2W3fU0LtZaIGt5nck+PIe77fryw2lGjnNzDHJ4AbiFxhYzj2VrpPrIL8bh1UgEQKKOWIoye3vw4wIljb4qX7OLFhQie4p72DLCb4wiiztJn87ecLDlBtLf6n25PCQdfEOFQJIP8x0pbvYGT+iCDhKH2QHcP0aFn4GlXKwg6W0wWnyR8YX2wLTcK2alg+wUovndBuHhnoxnSy1XLfsUEf9wMZq+u+fzPUniTzb8xIXw/CP0P2kLi6vebM9y/haIPP7xsR2lnJ8Dtf97TqblnDIvM9caMOe2wS0xxeMwxeXS/QyFWQw+r19cwwmhs6c5IcLmI6HvJ2Al6T1RhVWSHXvMLqcoy1GfVg82BEKg1M0XQI2yBfEuS415nL3SD4Ft3ysToGhvLE9/SRlUWpi1UnJ/Gq5qpltO4w36Yp5Wrorn40v6Xg0QAhhB7SeGNIi9NQ2FVRO8ljBd52HEHevmBhLjkS9KfukFAlP+jbzwh825t3U9xWxBqJ1azJqykRSShzicjT9nAx4JTY/S335urVVGzEl4z/HcD49g4N1oPwTghFKOjzBwd8iS3RvXaNci8Pbkcf6LaMPpnniOf0EV+yhhBtHX9Am6zLBJBeCKn0/ZkynLeMHPF03bshJQr22E044j+/RA43ReHr/9HEPYbkWu/edZY/1Sjs6tDRh88oDQae3ZOU1iVR0z8Ql4Sa4Sim+v/6M4ff31f851Lj4Gj08hhZx27rHd9KuVW41GpT4ODg5A3GZNEqBRKXxbVx0UNTbjQxBly78my9t/egc0TlYyGCgFARV6yG8VBL6r+QEm8JrXSp4jSmx5CKwrAap7uHv0VvSEd0trY9YAqXcMqGXyZ7CmUv05hSStKdc6wREXBFa9rBf4eFGbFRimR8N47X4lk8Szb2XUr4Hxh/rvYgjVrwKrcl1ggSPDuiiQk0hiinPJN49Fjn1CmcydPpTm8qtZAgF3rnYcQd60z+M5bs7RAjFX2Y7OMeSQ6QtGQGs5DccqlR7miaso2WKsaRLJXU4Fu04eaXlkcC0Vs+hsKEh+z+U5xBX5M0pRm/darnJknrCQC+O/pKdGCSCoo6QkKE7EuNs2QR0vZ2xtdeKYFxhZukgZXJeYCCur7xzZrbaolZFmuJezIIFBQxgI6cpg2pRKsFZK3qqfdFr10aPVSfl2/GsNR2V3Gd58TuhY/YvvbHFrjB+tDRPXzLqEaok2n3PHg+ourpFvLCTXx//aDAT5ORalP9KJJJoKLeonOfhsokn8CrPgBL6qmU1G29pGOEXtygmrrrb3+V6rqg6OYm4ywJQEmPn7Wvk6PqcI1F43q9tBXKz4JhBd5vbgFWpU3iYs1ERFutTMTbTKc1MYVz3uL5Xv6wpnL0LN9TqeS7e/DlfTwPbTiA8ytU9/esnmKGKNShDdtgwZrDXYN40kS8W/9aIpPJUXySj1hiB6SwSePczgKRwkpN//Fe1qTemH3G6Ue/tF9+0VOpEMv0i4qFpOK+ZI4cE6LGUSIPcxvi1bwSGPZ6588C5SbZhS40mXo1O2SEQLi0e08VZHwEBV/MIVb8xNndJWcoOHaTMce94teJuVVlV7Zotro9b3mIFVCUk9i3AHgAkTTi0PalF2YPbvdpdw6O6yBBXaUBzLW6wXj1eTNiHNGO7OZYgyh6kXjEQc2Pra6tSpQPXSg/3Cl8YfjP/pPuoncZlpF3gAAAAAAAAAFpq28AAAAAAAAzwCv1C7piXM9ZxroneZ8CPcWA14DGwzYrt01Ny2/liTTQ+p3oXCvKTRFvRFTHZa/6rJJrVkh7JUrletfVOGK/ue3czt8ceRW9eJT7KWyqWt/K0EsGayOKodgGUvo/fOpwgVAYi6hNN0yW5AUovLJOnKwwXIfKq/K1l/u2gdERss/SENrmI2chTvbouIoi8kYw3rOT5HEcPdSxhdhJ/RwwZvzGKlW715RqUs4RskZOYsQ5ZfFt0rPwghTFQxkOr3R/COk8kEoO1NgZ3lKl8V5HMzElC/SwVe/71fOHv73kHkFUD6QF08wnSoKI16NQciT+BhFIlZZ6FL3CU5EBNkohGgQWoUFMuBhNY6zu7uqZzvCtkZJxUlayGitOln7OkfoEe/L47vSb5v24IW33sck0TqNF/ci47n/+na4TT4G/KS19U4Yt/3VfFbIiKZ1mcUVJbgZnKeTs40ITB0fkBLKqANE09q038INpfp2l7k2YM9rpbDoOcjvtrWzjfUd9xboVCW2SRZsckkmonDf/OaOY8shUr6wl+cKh/f9MfOBRu3aYnf+uTnnA2ZcVMSyoLA995FFw7WsesIiDKp4YPuvn4sL7WO32gXuAIz7CU0xUqEHmwkLrzEVLXOI1oUzORghXUrVh1Us2kP8yWPuFy5MeYSdRWMZCt15/gNwwOrUVFXxtNdfF4uq7s9IDmh2mR64Oq5QAESNaeqUxRO9tkTbhXm4ervn4WCQ13c29iinlKgwnuh98DisWPdgBgIcoADfi9lm8SYaZkH8Me6vcJrwQAXRlDszzXsVnidT6CEfvAVeNPgTNXVlHdpgaBn4F0/L7C7yR+jLf0+LfvlQluaLd7T9t4t/2MXuIDjEuOW6oBfLUsQR+vHlA71SBQKz0Xt5GWbL2wS6bhN3H8x6sVSpj6KrG6QD6xoUqaC9RdQXdGzrlt8IsUkNTtjmFm7nlyLFZYbbE9KseBPa6+wU0e9p9RbvDI7MAzRSBtsUpZbOQ1Hnwtnt0xv71er9BxUNw/a+1vKYvZ4BeFI6V1aAiJR84uHWjaFXavTyb2qfkiU4Kxqzj206vQmUyrxdMk3BKuwPhmQfBoVdcoGX4UduxMRgdmkMkJkxJu0kEfcLdMunB2E7dG25wCdxXDq33EJAkhZ8spRC70YFMyUkRMfeOs6tBmxxB87X4FJL2wlAizbPWJNG+RJIjkcjy9+sz3gJREy8mbIvuwgsmUB2ZJDmDOKZq+ms/IxOjGhYN4dxnB+ctdXlMdf7r3wJvlTqiIGZB8TeeIpufM8waHXXMW2fTEFpbPwSgakdzikZGGwG8dAokZIUeciU1/wpthwnXwOaGkJg7ggl7vgdR6KzaE7zxR9FnxcfdzTSiFLmBoo9p/VAuRxRXCaxTl0s7AJmM+BkvZdjeINZGqphZLJDoXHHiFQY2wY9wWx30dkgABtIAZOmrqorxqeY+zn5AhNa4ooPXwi/8uzOB0KeIRJloI0fIM5G/S7ijifXBXU8tMoh3J65cvMZPfR+LVLO2liSm1qs3VxeJDQ0avhoMOr6LTFsK5KEMTL8eSegvDl/q29ETPYcrpFKpM3s/ubxpJc7RffrEcYfYUcXE/0c/hNmZWCHTqDc+ywHVoVLbulMcZuVX4SFSFeZMwnYESP1WsAGKU7OZ761S6AYYFnAT2yzLcG6zDSGUGsPlrjTJLCVD5CPPk52Q7E4fClNCX1ImP4rvOKMSGuyCkJVf1FD/5eB9m2DnYm5qmOQyhmyA9KxrSk/I6cjQj8Cbz3ESERwH+QJGh0z7t5rkvjInrG7l/66F6K/bDg8dXvVdYJcJbQ0tUSDvmBkJUyGK06k34YHUFat7m5EiI8uYUhjuLXMdEpYBY5gF21IlG20Xgx1m3oSfOeRbJA8lScvhP34orKE+LE0QXiV3Az7Ep8qLH1P5zBQVsTH5Hwio/cIvzl6yks9lGjUS5WFV6F4lsyau7m/sDiR5az7snVyJMMas20miXarWQzBnF6XotTJ8JAExw6BFpLpBLHWIZiEqc/fLgb4ybJyUlfFhktLmY28zEuptxxGBYQ6YtVZ3AhFVcXqJVJ928cAMko3Z/wOs4Ihq4kHMAN/iiGOk7ugABwlO3IDOj209ZmI8OukX4+Lse8/fjFErTNNzw6btDF++Bjsa4oC/qlukw2ZTXEYahqUFv2ryhM9FkX+YqjkPgN4FW2hQ1nYL4VeZu8b1iE5EcbnVTPSq5tiVUGfxuhHY92dLplN+a5O9lbfySpRk/JEfbaUQh4Xg6mbZSSYc7vjgHvO1sDiaSYDeUlkWRu72qrnxpQQ6Ati2+898vCK59JTWuH7IbjIk4WprLBWHJb4klQsRvl+xGwOtqKCwgNk1E5Vz0gQ6T6jCzxBFajXalF0VirLwIYVwD7ONxP2ucGrJ8sHfSSUoSmYWbhMfnZrc9fQjqslJfv0rqRdnlJi6fQkGngUQBokHmL2SIi8EoeWgLrjegS3n7Agt+zdezdN5Tm42+MnpChE4zpSjah4fiQ52mIPmWLkzjlLYLoxd21eSl0nyuJvSYaQ3pamlFt0oLDLzl82nk5QnNSbGjXySk9LVlOXj/HgVDYYXn4lFQgov1+1T3DNN4W/zV7xjHBypludpYVsddYkRxWqy5B6i9BDg3IEnNQWcHXt9pjPDe8Ji2s03YYmny5k5zkYeoEGqH3MJkT8anxG1U4dX/B55CbagH0C42pu2eoDP5RXCG26WaJ6V5kvVXYP0L8vjSlQBOMe7Ic6TbJmEJDIo5pBcjh76Zs+gKszXPvra9YM926x1WX/+rXn2IdhahKGRKjG7Z1bgJzE2ibpXC4+Eb2U1sUGMrxN8BCYqjL7ZghPuyRzg0+JDknMutUzeAxjnpTa7LHmsw+uTgOGmgIJcgGtcIpYn9u/OggPDMh1F1xWhhuVkg6QYvnjKoFLGWsEHZ6S65M/Ahw1nR8Kfca5dYdrL00uLoHqnmbScDkvdkIEcfrj2BCimiznIeFfWjMEAj/DT1dyGh9DeOFYWu05UsRnRiR9ulbpC2yjZ9f5ACiz72T/OeCLU2xf87lJGG6AAIyj0f8gQObeFCDzYfMxhK4FTV31hOqq49naGOSdOD1RFVlPoXjsZPqemMHaZLdjuPW+dqmJQMZXfQ1VLJnacGVVqNTkzGyjNyfOWTqHW8/pUbkAMQrmWzq6PKpvgZIjuV/1x3Z4LGeq7/Wl+KN8RsQ0MipKJ2UQP5xd2EEz2dap2+K2mARh1b3QwgErP9tEwF7kNudXEaMBNaaxiY4KfIvbPB1UntQ8W7jDEN3oUrzC+LDoJsv+kwcJtWGhd2TSOAT3QpBX/ixKM1RvQ7/TQ5MIVjKsgo2DwC74yKQYwheejE3tRmX7lxbV5+j5C0E8qF0mXa4RtdtG1VV8gkNXZD3p8Yom1HZSSpPZQ72E28xFkrYnOL01wvNM/dFkH/IhS79w5Vf0mzQEQecNJXzTdFwsQ8qWEqZuZqZYom/j4Ln5//j7lN1YM6tWyPjy4FYeK8ATu/4QfJ38/1GnpEG0dDMSbnG7aStbxUMSeX1vskPFauL+z6HAdhYwN899LQBM6enxbmVA3LQlcklHKjR5ULphNlmKCYvlqZBMyLXQBeZhQAfRf28/Kx+wC+uhu7QVCESNQCxQnBfrb6IYGa7YgNlEXy+63gcHg6X8mhtWAN3tPmfVUlstHNWYn+Do65KErpFennQvhwLeV/E5f8No2vFifKrgX9L3EyK1LX8en3rhMD2ceIxmrVm6w4idZm4e620NKK8dIbo9wcAUvmqvJEPqWqy65C0FiDnapMKQQ+Qg7bVrD0PacCrEPwoI/mYLIAdgtjBhiOV0cDC0ty7gr8hNDiRIHnQ6FGNHm/U/4/z2NLlAAoYQda8JtcXkcuXs2r0lyHlfclS0U7iCh53QjoFsK9/wiHEIQHbb9H8Mi241K4TqUuYDXiNZBRZmrH2wcy3nWlWSG/xbqPaLacnFCS2AYaLJoSYRgRyWrvZyt5ByipVAbJau8+j3S9WZqr/FkA06ygncDsM1TSOSql0qxyDORYEilNtPqOC161hTMYlKDNxj6wJhkUGcff/M3f+0IgoTigpBg/BQTTYINuYVxDIV/nJ09wHUAX3suaC/wYG2ILAutVTukVD8woI74sXJjUxFPB8dn+mE63as601JXUD0eqhq2bP/pgeD8mO/jzU8FYx/Dqz1yOYuD+5+7v3xFpIsAaknGMOKRndMhBbTosVdsdtzsvK2RdU4Dm3SHoO+u5VzcPLqNSRzB/exE14JAtvresYAqtxg1HPxiBgojHbY9SUIfysX/+plJ9xWIEOyuJioFNjj/2poGchV7+kXUPEc8WuR0kBhY7dXTjJf2P5aMNshE1dz2gmw+cIrrW5CKAAXe86f1JKapYf9KpVM00/fcxGm1Tt9rHm/xJARtCxt6zUXImSc/WrsGG8pHbmZxYbXQY1WfZBy2pjG0JFVDyMPo6vTI4d+84RhvECZ7/mUTIYR9g2afbR+ZFF3bAv3HIEWNMQuzrAkomh+VfE9lYUgU1NiMCg5e40y7C3VcvPTca3Ic3SQV9t1OF2NtaMqx+w1YFhciZ2Wtsyy4DGoAzhU1fX3KYgMQ/pDiT9uFkW6qZ+sBKt5lSRzYUJM0nq4GDzhfdqvxf1ftQsX+P7o1GZbYrAmG2rdlNjtDzYUD/sHcN1P0PdT3x9g6Igr+4r6nlQ/yMGcjVI16LPXpzRUInA/apF1JSVgeTeYc1F+mA5NVOniHQMju/O7pzrjnjcIlL/YcMNU0f0Qz4Mo38R0Yjdyj8+1lRFfHA1da4t0rLS5XGr8lJ1LDRytd7tl1+zumYiF30cPthsua22gpRG26WiS1Ppg8KPCIdDfs6prkBLQ3LeNx0XUrSlsxTOOxlXrtqizq8XBiaGH6/QCvcfNgrGhuvoeUShDq8VZYrEkzmsz2s92VppjQwo/Yl/eFGgZyB1aIEfC5YL6y2DOQgGI1a7Te6KMdHpBUw6BLjjZtuip3aS5xoQ40CIG6qfkdhOaq+ZNq3Ap+V6TAyYgxFvMjrJzZOUYr82vFMoifANEystGni7NEW+n4rbDQ5LTMShLZz253CF0tARvkDsW97aalowY43AoRS9+Ubc8B1D8kGd50u6M6WZbyMk3Co1C1eybfIcvTSFbe2/7Ul0U9+2vv+mHl1T//L4LGNvArwbunj6oZXfkEEnLetFFIZL+oe7VMp25TDAC+aFeCFM963cC601MbhOlg4GFUe1Om9zRDW65ygP0oPcH4c6J1krB1EBi6eWXFC5c7pg8KPCIwb3ntq27QjaiONaF610MuT7UUFt+QbXKnraAU3V7HmMxQll8ceehzdsPm+/kN9TlQ2XkoYJbOe3MKVYTS6AEo1LDPoORnE5opZ/I4izVL+8ZqN2B/yQWqHNelVxZ3uK+p5lr+TMerwFcocjVedseLCR0QxAiHonRHgDwDSdbepkku8QlzjacTHE4t1pJR7Fx90jHCBBrxhRyfkLvUzA6HaOuyKRzI6kf4qCZu8wo/Vr2XG/7jbWojc0ScmQ5P172zSzwTyq8+g4laHTd+4Zdy5rrWTlROh95++/JAUljrs1HjYbEkkW8F6q5c4sCngIMEQE4h19kO1ZxmwKKboNh/GnHksLvifyNxqOIYTYJ+NxMbyEXUEZVOLvJA4upR9Qpl205Kqycq2z+sNO0hjKuVyMLzV7GDu9R5nc2Ixmy/AxX8ZbFNZrhmOgXwswWFzA+FL5D556dIercBiRekLWbkUS2ZaCQht3cIdNSsE9kPk7wpEAQg28ezAFxon2zzXu/zd1XRQ5aFYWDZQ2QsDWYnGjwIYSb4AwTAVePaxdaa6W+xOcKwl4KOSihC+37i05q6UdEWjXw7ckWfCn43B9jAZeYQaLoBBObM9e25snZqrhLlXtYFbYcKhi+WPaVCYB1HeDBrFUT5QDZooZB3e6EIp6MsX5R9P6LMBxKYensl0lRcFYa32NIy0+mHedSrkG46i/0o2EHBgUqDbtkB+LFYpSniZa2VgU+Kqtbk3eA/V3l2CzlBPjFSDTWg9mgprFyib0DmKxR6kwc+msm747OpMZzZxW06DPvOJLCZH2TM8FAWdvMeVf1XGj91W1GhKpzMQiQ7kpKvgUzj3u12Aih/mXS9sUa6/6gEb94m+YBIYS2tljxqtSNWzA05MJiTOFuTWgB2hW3etpmBNpcRpWS6m5RV6yZ1y02cTb3UFVlcbtbO5uQ6howE4o9jz7SU9kHgE3WdEYrCVB4hVmx3CSLK0nJYHuAz5mxgXv7lWlpFTb08rvQnfw0VGkx/lyDmAe6E8pPjjTcOJJajtMrgARvLlcm1gand2EgXkryCnrg4sK+TP6Uljrw9KRNPAb0s7+0uGjFncfpVQQ4zg0umL+NQrZF5b+/jvcdRqie2fltMKzuCqNE0EFuCWuCTbGkczD+uRBCi4c4tCr3idHYTA4LJ8pEFeikrd76KCNYcyApGrd8lWO2u5R/TgC9/P6+Qw94Bfyy/0WU41S9Cv7NIq3eL9RKCj2ol0YHodCXcsFALUoHMyCNWH06tvYHTw0HKJQIXKblPv5Fdxh1wEiv1FkKbNGatxVuNZ69OALjwKoizEvCIKRndOVIy4crzicZcuXKVJu0mZYwGu+oZ2lY96EKyFlpzWPLzDIg2v2vDUhNRnwDaHDo+yyTYL+o4qoZWQOxPQ3pNZdjjlwPV62lXo/GNCOtnyBofmG7pYDolPR+GZVTKjdPVSMjvfYjlCLbzpJNCd5Bk+rJU/6ZLmtoi8BPm9vvGUXq5yoiprHNLGfCLd11JKW/blcLU5yFzysdmCGAAFtLTOJ/r5pQv1vL6mBczV27RFHDgq7LSrjJTrvCKUTMlVrQsGcY1yDMKoxtlph/5ItUXfkWgQRwyuFHpTr5lClMo4eT+B/lSFd3nHdEWA4BqjcKB7V8gU7mhSTVstYXL9hhPHs8U7X6AFaVzWvNY9Nd9ofFIlryEvdn+LJc0wddcZOBRpjIeSxPtrOnYZ6prmBP7jABwU9bb7Syv1TpBzmJirFy5MqrmlJZdbVjXSi3Qh1yds7LTeItq5yTpRezidt/fdsl11GHLg3rBBBW8p50VeIvjAfw7ZtC27CrN9DqLCVRLSm7w5lHrbjplViV1spzx/2YduEYqcD49hhhZg8LQxb2AVKT2QAAxi3Sx/skPHuZhuSwI282tWNCmTTot1e+WttPBoP5EdqeY9+ew5wtqXurVrKlqHyteS9S8Q+e2HKOJcYRmgsvIlXEpzJOdxV81yPplbGo5947TS0aFNY29yGgAc3ySmW4D/L415Os3j2Mz9ZS7DUjNC6UvmfMMyaY0UveZI4jcGp8BggSpKtsF6ceb0gJtrl9i29wMzX5upzDgYzaUr5IcbunlouXKqu+U/5EGHr6+aS/dn3Ps3z4yZz9JmCcXNOlo+iBZkv2En4bp3F77T4SmjjGYwQq2FcNhwN7Em4W00IXNaCZCS5zcFthtUSTGyGtxflP/iuWz+89b9+RzH4OAOs8C0DXya8h7ar6qKGu9a8fSpQ2Z/3J64D+x0om+aW09QbBb3j0n046vlZE+aTifvXrLHkZitWP0+gZSQTt6DtoOnYRTMtgp+XOeIZ1OX89x4hzZ5TixZD/aXhefOk1A2v6nuBvcjgbxElu7sItxU+LSKlt/yejxFWBgMARlRJr+O7E3qyB1HO3LfbCYnm6F26DHnKXZgzg/l1P2Q7cftMbbLvNDXKq1KjRu/je3Bsbt2scfUoFCix0k5jfvsU7Ng/mo1xuFbbZnSjPUVqed5duyazKZ6UlNlZaY22+l8IVB7Kb0dcwie4weoOoUWoU5p48Y/Cm9boLrj/RGntFEzb/GQ4r8XV1ANGbyEBql36AC4wi2cOuhXHmp03hBI2AYsdG7fnGPn/+d5C+svWZi72vcB6/xYzhptbrabbhw/1NF3N6ExtK7wFDLZQUutKFVfZynm/ABqQl8sN6yAQOXoQKduOetLmmhzGxV7bKrXtcVtEkUMY1XDiryKqVp74e6DSqXYnJIz165fNAtRoxC8+O0qgewmk3Rmhkz22xeiBdMx5ejVJ3macgELUkmgSxrsQxKte66jOOpyZHUMe3MnlYjASYPt7aNAjqaS2jU8rUX5sAM/sAqKgxOV/RMYVNDHSm2mKwDjQgv6fbE8VmfUlNDAbu3jP13keioxwdiisZZ3Bcxvh0rmgKixiqFRCW3ilZ9/liGeebAwkVZOR7XKUwt0NVjEoXvX5aoWpVtv5WRviY3lmli8nommlqdXue7Dej720nuPiSLLhg5yNsKzm7rliEnkwkd/X38nZTSQjet1BkuIUD9HPKG1I6Xu/KPExQfc20S8NgtLWC28Sv5bmXnEO0L/keBG6Wh2GPMbf2xHiMkgBJYrdjHU5CDKNJI+M8WygSLnamjs0kWapgODYFLungSoKSSxJgaq0P4mQvetuBFXAfEcEzvIuPHtUiltD3ymcC4NjBB5a1fZxGt+CpXVC0LXOJjHZ3kXHjvr6TWiQoczdCpt7+KZPKxQUosvqel0LxOxGBRlFyUX3tFCqYwt1I8GAv5xHTPB6ZPktuDu0io2M0xYeFN8sI2xzx8hXUrOTOhyKvq/qrnLmrq50FQ/nt2hrcJHat0qRMoenImOFnUxjQeyviQjhyPkQ4brw7XtD48RGYufRwlMz9IgpexjwIGLcUhspQxnDln1N/DMzPnalsiIaNXYWNYzFoHl5ww4L9rme32KwN/0cXKb6S9Be89rEwipKkgwJ6/BT3ls8WxC0wCIbRd2kA7NRj/vnvuiXJWAy2K51r1A90LwdLqD+qRB7TEhArElZEgXYiiO9yLPy2h4T3V9/z9hbeGplkGv1bAMQzvYc+uxQKQO93v27XHgPSW3LteDD2GTOYLvHBdzAAAA7H3+t6hlA9PBmomwPIvYvcvBJwoiSBJ5jeDH7rnHVmMpHj18ZrR/O2eqgnWEN5mFNOz0wjjNXnFHXz2fnJ36OWJ3SKT5Bkb39EQu4xBJUZBXQ4EcJGD9dK7CzwM/zpk1aAEEEjeYP5RkJnFuXJpHz0s6hprhgG7YBfVaZkZvGlrB1zRLjFNZowxxjbhQbdkgQa3A8xx3xINh0vfsKWqCC/8DjA1KQjudeVKVVoISyJR5d5NXh/FN1WlDh2yD48HACduL6CWtKc3EdcIboc0SqDkZb11NUqjnft5/fC7V96CzmAnOR6UqBIpTrYImkyT/8RbmWPtL3t0CFsdkrw2IzpEzJqrcKW5UoX4SueGiy4PeLZAHWlckMI0KUBA48XAhUC0peS34sjb6hDYeTluIZbtL66R2BSjbibMvAD6WazKeP/4Oi6VfdNv/j65BrC+Zqg3Eae7ZC4qSJsr2TPbS0M4dGTlZp1Akm5Q6bH95yacUv7B22wlFvFxPVpGXeO9+e9wEumOl7ifWda+musRSgSbWD2deIkTNVMdrvohqjeC25M93eGjUNqV3OykhZI41u6MBznAQ+G/twvJZAvfvS0nxVDpav8urXdCWSEr/lbyAUo3ctBYiGC1cGYwUEY12yWyHdvuqAVSSod1YzPSm9Alb7fjFldRrEKRE5JXxs8dKo5Rsf2tDGL5grWLNKSlIm0ULMVae0qdYxasgf9CXs1PASmU7wkK7KAu6M8/3YWnKm6SgaqJdwGV/wG7Zitc3gjCxUHwf1YlVIDFuq5PFncd2s4Rb8x8jbmjtgy49x8szagTXom3nmLWHhDu2pxrcWSTUNZQt85JWdLkqfQ8Sfg7vCcno0kzkpHmZumesfsNWvRQvoRC7O8tYbPlrVDRrLT3vcH55tRUYC2t7Uduc6DG924sxTOmsfs61BWwe2gJHKAKTLxQgRz0jfHwVlvjM+9b7BdNAGTdTpd9gFSlEaHZzNo0PgQcaC8I/EfgMwhT1GWFgEbGFKHjWweH3TxVRI0vsdqChEB+PsWKlr0mrBr5uo/u/KyhHshI42iuQCU0MZjQMTe5ZuIzosAlfe2sSL2xjchoyat1GAxMEeisWEkyBK7+5zOK1msavbzzPN6CYpkcys4nqCtGmDzRH2VbSp/o+yRb0Bf12CHxWO4mBWfKHY0/z4E6tDP+p+WQ42OLp5Eu+3TymDNRfY1FQOHQPtspDF/XhpQx8TET43O9NMlSxbXw4Xdp9pegwtoBb+9jjYTruvB/rV1Fy9qjPKmxd3FGnbkHnot/TiRz2dOEiDD+P+FfrWMDZ0teqkeKszKSiD1Rku4amcnb4FLfESBNB0dJ7F6mQ3BwnobLqeh36KKYVjYCWQUHgvrun3Pev/Hsv0vzMQGfBPxx3VI/kYTWdOJINkiSJkqPWb1LS9xEuA0mWPa2Jw4UZETHphT36QVP6L/KApnsmirTBAL1BfYXLObJVyhNzwA460AIZ3R4/82rW8JP3jiahEjLl3y/VM7VRx0dfiJ2QhyhzwS35IrRfXPlHs7SamIA3GrF0g1dEB7HzolNlUAStP9/OOzxrFOWdcPnYg5Xn2LdoAsIXSwvISxzmBq7vww24TVmXaD/7tqjcE3fBgj+8K9w6N/+QGZIll0SVOfj4kjG5VVAgcBjmOlB8qfBzKCmFJ5dpfvrT+yVl42TkJw+g+Qrx94NY4f2Arjp4M2RRKWCYYRIwo4GJ2ZpdT8YYsUSRGB5g5GaNL58SXPLIm/D3xxpEOZaFrzr1AU7Bnbqwd82/7sh71Q4Am4k+Ax+ACQt9yOk5EH6XVOIrBgExcsaVcV2X1MjlpZQB/BW6vWiM/OUjDrpfD+kUGOVY0kV+BmBt3aGLS2vt1Ey/kNFAj3A2Wi36c4ozYrRVflQOCThFP+Arb0upI2kTylaRoqgL7TessYRonwEnf0PQ6BpudIlD7UMgGpxwvDGYXBQWk3pAm9VNxKYpu/JM42d4dL0eMaZ7GE3HLjv6XJuN07E+lHzWp+HJ9XTBo2BFvGJa2cpqsWvWiyZsLBz585B0ovqw8xNctBqPZo9LsEvlvRjkQTm/tf9dvXNSQzpxE35/jjfKqKFCF4UIECSOI+OVo1IMCzhWkSJ8avvF6WMVx8wmxbkfUHRfUu11faSVAwa7IAJSQg2MbHS2OdtmW+aTrh+PNYhBgA/3DDvp1khiJ7I8YdmFtBUmlzTn54ZQjGdvbTnCpRzq2K3Ssxwd0Dze8NUkP4o/oeciwRb4Z4SHesAbtwEUjwxC/0LzYrPAL9Zw82yio1KWsgBuBS53A9a3VSRfFJ6ql1KPJKWWvv6SQbSqvhRNxsMwzZGafabi6KaefXQY35zmdvwj3WrnKaNHYPKHmL7wDAm2ocEKQd355b/D/LGBPcvqNaFIkeWYiGpNqpJpRazVsy9DEH5JE2LFI/5BlA1jkWBr8Q9VPJnUu4IjoMpAifTozcSrpSSazxPTmRmYp+UMWED2M8nOFyJ6bpE1fWEF+K0wPr3L3Mn4KDqTK4NRNOTD8vMIdW8if1bsYRfwwugx2EmEgRy+o1ajsHf6nRkmlw9cVmDPQoijoiYK5HKzcrtxwagcSxekPBhsnn7rXkXZgW/tvN+g8hETUSFMlylO8Wxr7azF8cXyQlnvGL8LUs75oSCg5IgD82omQyw7XAmQW+QF4zewWZp9M8jCwyJnWX1XJcPV1CzDsuVnVdtasysH4DFn9L/e1ulQ5sKGzMSBFCWZPlEu4PU+U9xMl5szgVukos8jlBSFQJ2dxUS40kjedXrFwTOL6+iIVAMKeWk/7kUvLSd/0Q7Ua436kJqloR2Dwe/6VM6aFWmJTr3YYXq0gZg9of21FxEKvg1lw7MYTJPkqvdIGb6Pr/eoUERvArKjvvJe2fwcheJlyUCToC3DSBSkJfGpxpH08R+UFZQwXWrothtqPcfhfCSGkQFXXnXLHp77qNUtt2euUdVfnWiVENbdXYH910HgBI2nf8hs6Z0aogLR0lepzCWzokAHHiqFAXx5Zaqo3gwnAqanyKwIO60A+VER3ZnSDfYejN0qXhiHou89t9uCkN1TYi2c3gLnwNg54hAndB6v+Nk3q6NXv1rNIvC7rEX61boGtF57q4xJVTyM1mW4+pxzFuI6qu5yktMck+KvauFeUCPqGrWLoDSyCRT/RUlvdVY87KK4AAvWAAMScuSWyGz8n2jj7ZyrsACKayHhGL8IbbAS/98HYjYObw0KyCCBHn3wFF0/z7CQu9nFcnvpYs4mAU6WAS2ngfebW9hzbJ4kj8d64M9tvuv3d/VTctpismOKEgwB5+Us5HLiuQq7Btopbu5ax0w/zNsaYQMbRtXnjKaYCFgNgoeAwIlbJd1aA8n4mCzlBZILUdiRDlJlN2Yp23tGrJAH8joCVkqF0/1v/viEIPbLLzOEvezg8VRqVSoS46e+eilYZRdwhmaU7cjwwpSM5lPd7kTXGI2Dm7SmPXi37yeg+jVAqz99dVHff721epS/9XZSXsVH8Zb9LF5PwmpwZehh35evgYyt3nRechmMyz/gS3l3lpBiNym4nLKlyilcsv3qmkw4BM5O4SBV1+I+haUwmThsQS+eOz/8l1GpO1xvDc28nNewSebm4prJiaPjjKYY0ERVLRawrFFmAobcq9NFlVltTE/XymRd9bWRCsXF1IhacXwzqFX2z+QFqizOIa1OG4IK2FDQ9vwJunzGXQdpYQSBKDa25VtCA6llufL6mOgnWG7MjHHw6VWOKhURb0R/jMPBnH+ie+lrVOVAGHek0gFtovhHlaiBNzYO6Pj3+eM9XiDUQDWF9x7N6C6M85q0J4v85sp0D7MVXG9WY7k9Z1gUTBPlft0LzKYdg9PIf0xaCQpL/sBvTAGfaLGEinOxAll80nJshkaGUHf4NZRWivpTPaubrvWSn7gd2euBYRtLvKxKQJgXxWjLY77iqJHaoO1XMl95D6pYiyUBVsh5+9iygPWViVzB+3C8+yHJWwn+5DGZZ7nGvyNIGaPVn5fH5MK2xPMs1VfTSggJ8n/WT4Jn5HFRrlRtXWS7YhvqtHYiz+tA+jGi3mduw8W8afemVeP/UwZ+yVI695H+a0VvMb7zrwJu2JffAi5GXMuQJwyRS+jIlOpnQOSqAqVYzJg5ZY7PDVDw66i2FwyE/OGtbC8g4/SzNUPYCxA6DO7sJYpz1XQerrmGCaY5r4hLr8ISthXPZkw3kOvnC6LbRK9B9/NoXWP1AqcgQUUp7Aluqe9TRJzAOPTyZVrZ3zDPYFHOsuPL3vT124xJeEY6gs05zSUg5Z2aCxxvnZSU2dmFhr0StG4PbmBy63alBg6BzFwLQqbU7yeqPxSGF0RTWxfWdgJuYcmIhxtzsDVhArTWSgFPFbwc05sBNC6WDhtl+dX2a5x+dg4CQoq3y8Rli7IIJlN4Nb7QoA18vmnh1a+SXQG+1QosCtm0zm2sgnv/zCUcoXZ+To6mr5mdn7MzDZB8dg/41dLRh9EyQNVKrGBnhNgdyh7nZD453rUTr8Yefmjzfr/BMMiUfQSKLgUoqiGj1NWoYCw3tstWnEHuHgWy7iEmIwevYNLAknafN5GVqsIvMEpRzNTF3sgSnMFPcsC1v2U2hNI/J5tNEFKM3Dnn3FabKD3aXZRslN9Jx9FLAvDTJpw6VE8MKCrqzQuk1V0L1/wj8VQuDoyiPqE977hYwR8deObs1Gd1NuNUt3UUtzqTKSA86L1qNe4zg/a+eIDP3TgyXPPSJfI0B+ImiXfCI8MmHZiW2/Y/2LUXDUEdBDq1+9W6LZZ3au4iIoHJ/XTh6LEtqsreislLNV6V1wssK3/gzinsQ9sEXAbHAPeRlvh6qxdoT9+vIWU+YNPm0vICJNl2ab8urBClfOeCFmhPrLPFcwyvol9FLz+O8RnHFE9J8EscoEtvshCR9LyiOMV7mwX73JlHYP2to7uMkt/jtfEiiVWau6MH5Z4EVEVtJGI56bCKCFWUFPRNieI94TgTXmGGyJfkWG7taXq8crREgDEZ2cTEKqy0El9FxY+IWZzdBtop75+gJaidSK3Atg3D+5/WhLa50VtawlQUGW8NNNKtStnL5I5PoHAH/MDJAkMd7XOkQVguuw92KLvuYMND4LXGEVJVE2NIYtTQ3xvx7nuRjcACss20mV9b9xiONK61Ah4+H/VkcV7dym+2VZKqtqtfTUBrNW+JlsH0k6MUWI4ZD4NjygEHpFHvOAEaj1L+VplQZFpALQYLHJSdyF3DyC6vco7yn5hsouFsv/kxv/izsINeqedYwxIHpHhEWH0YCleX8KuHiA9dHA5sdUbPCcpLa6CmLY0cuEwGnPpiLoNtGdVR+BD3ZgEgn5S0aGtT2U3z+4g3AcYAibvwWat15Nb118DJFRRa0uXXg+6OeUlIgkhvE+YBub0zOSKwFJhQKHfq5Rzoy82VljGuxl4rwp1TrCll+DQwvdizcRUmuXBFqPWfKlb12fz+kmHTTBpU4AvscdSPa8HnZFJtUOUf3A93HX3ZSB4rTiGP1QhULIaAVMkBXspdiRJQmu+mWj47LVtl6g/cyRQQaQlrvKKmrOmp2U+J572BBBYCbpLS6AWDoKQtkR11PuVOnlpcAzsxZi5lIgwpJiRpYfGHmPPRyDjFFCXXGGn9bYyFqsFTF8X/AV7mja8QtC6l2LzUbCLsis8mwg8FvLzCXKMSrTigu6c0aM34ZD9vLGRhMMqfxpvIRHm/FKnObio8zpsxQsGgumrqFtL++UcwJEhdBgBDau3ChxfGC8EgPIncdrJ3h7tosoCGoQSh6KRpsqecwY2acLvcOVLSbHJSHv5GpmR00ftsBefCuPofyvW1c1loSWJWuKbrpZXY7cZmCAGILoVYsv7XT+nbevvA9bKVVJVNoLsFA4afPk01fEejqpz1QtAKymddBOHRvFrphWq83nJUmZQWty9KYgjgsa00+UH03UlP12e5c6GmAonPMhU6Pbf2VDJFCNZMEYdABgv456gjC5QBY5nZLoM2ZqolvuXus6k9azed/LKvVGPNF1Pim6iHC7aAYGXkSvddFSi0sTC9LdawHF/z/fR1Jk3j7gWsoBil8dLpEBnaus6zUbTDkM2J/1quVsc9WEsmANsl4v7lcyVTKbhRGaJZ7gjQzUvc4pSnAiYGSDLq+4S6Jv6ZEpeCwP/k7VQTiooi0/idIKeVNOreEqE6ahMGgGAjoaUOji2eWHJkL2t9LZHgtO9uTp7QGbjdcN+oJIqhZPeKl5/LvA+EZpUYgks/iCziudxJfQCRAF/VjkzAuTJfrxSZEUSiZX0LMBgdjdkCUD89HwZ4rCrYPIpQpMRj1dvJT7xE3DbDiQ5h5atv8K+9jyJ8R2/Ug2oOkTgrKSh8nvkQczy+TNJgySM2ysYT3cq1c7XhBImJ0iKT1ti/8HbwUAEGAV0g1kwcO3EYy7zmLnmSONLSz4fSF5Iih0vFww/CMSC2vhwu7T7S9BhbPvUsn4ffq3C3QD4lbib8ZAOhTP5vHAEqi1hG7hthoOHJ6xZZOKUxbhc11QXNaBIPag7wzTVHY/rvQjf84NcpTBaVfPxqFYiWN6a23I2Nk37a01QvQxbQPN8z9YUg+uL0dxIR+EsU0BJgUjEJQRzoY33VdUTyRMlIUPcsCPmTPKO+3UT+pLBzSWSBO2MxQ3r4y3BxTU1y/tQUpINJLyeoKolNIkNhVECMuwG43V2Q4AAfEtcgPAlxgBkl1LS9nOtedq4l+QcGTbmlM0hOMUdR6hOd+QSztpsoN5F7q0jUZrGm7/5QFl2iHgi0QuTg7zU6mrkrrjDUCT7kjJqFGb2wknbAulqE9riTw9abTktUUngyIAJ0YenKt+WAtHS2/gDnMQFIfZQ+cgfReEemKm63Qv9tMNfKC+aCV/EDpEhXgQTK+z8zfYj0fDJm8afzyBhyVThm4mN09s19j5QRs7+MI7cw+iMUPiMw5bzEKU4BkoWqqZwcSBLMRrYRNfkxpiQQxPLTZK65wNqSvkVV8k7d9L6OXUa0ABujpqyG47FaT7VC9Dttw3zCJWMe+rI/rA94XlR2bNc9GUywjexE16HyAc3KyUvojLLlVBh0GVY9/m++fAfiH2/rlvbMfpk2l0i1hQom4lGKwwQQ6QAo9NACobrKzNZuTD3wbZL/I8WsWW+sc0csF75ZURytKdeQG/p4fSf67b8PHF0GPTDjQcWHg8/bx2E76yL5VO06CYTn+QXXxjSZtH3uVIYwidx3gHu4amV9ZTtDKOshqBomriP5khwTYJlJRRwE0edveOujvhEMgdRMY/NhUWSI+BUmKAT9YjnmnJWnBPBTZbNMluQG/GhcsJvERv6prStHtQvCxPzdIr+TmffvwVTAH6DBUet22POEBT4Bpq+0VqzEfMuVx6wtPowGJIRWPQQvH4u6qDhqd9PDLnAxN5tEcqMuMYHz/dfHyeijKWmeTgxds3w0oKNHIY9kIHgosmgr5AwfHTyOD5S78gUtfVOGImMPILPC4N4z6CUFEMu6uWNDT4D1Imrc1/N7asIiAvoIbDdfxf43AxlSLS5NbJU1DsPZWUoZfu6ig9JjxS3Y4txgbZlsw8I9LSkhCokpY3JjkXQuPpOdrkzLjMtwbrMNdZCdSe9CPx7Bd8w4XBxNimj5CdNQgPlYrJZSKZvjUyNB1xFgu6fy8ysCUiWwcqqiiv18coValS/fC9sfzvQDVDgXJgMhImo3R09GWn9lxOrhqY+jq1lgJWiXSPwOhdJwhbJwf77LBQ8ixzjqLc9N5VEVgO7kXK0FtvIu8eR1l8h7oIUSJCxBeB1aqiFc77B68KM0R17KoieaCAPV1Jv6bl/fkWckJjW27X20U20cmLjyWKXbadj55/fFzdDkwgU0XOrNeNq9EHOEpImquqN3I56w8Za3bxSRhe03uV4E1KI4tBDUqQI/ur/eRlrqIMNmjpCvbuSVI2XXUbG+KoVCsQv9PiYJgA8fEQtN6Js8zNo0k3R3AT5Qc/ZPKYOGLVSPD4x2oJXLnpm8v46ijD/5kIKY+G0o4jIG56blt8BxQmyyJ/t8Uimk3rZUm0awagR7pWAd/NuF7/UGyikbb5LVdiM/PFSxiSeUjQW/QccUaTmIcKunSrasXh8aWoYZ9IWZiZosGL7ZYyGA0n0HE2xJPeklQXMacGk35m7zuVyAm5UiK65hB3mxlK3+/E8/Gn6vYnJYmmhH+R5qQAxUSS9UE5HtPXpT9Qg2+D+qiqppISmbz3Poy4u1+qLeljUt7pjOAchK9QRkWPvS8l+hStrdjRkAJCzR/Qxatl7EpmEOO1okzBQQn22jhuO9EPawaRkAPVj3PPkFbOrYgmfBUWfwve40eYuj6FQKG2ZXICbfEXvDt+y/9S/6j5PeL1VWuVMUniCdy23+oG+9wR+yfUtbZrXNfayrv2WlW+7Dvu47AmupIy7X+h/pGw6o0ssQfVmFoQRU8PAdBKmOhT96bYT9SbK/1bN+sh1N155NGjuo02UZKl5/x9E9DVGuX9g72DqAonNqvVc6BHt/ToPRWS18uVEiDby2hUwYLF2MHQ04l4axB/o32a1c1PooOPOS1zz8g3Iq9Z/kcVAB+stQ4jKoskc+pbiq9O9pKF7L0woO+coXouln1Z9ycod2ideOV4i9745XHHkMmYcvoFvIQqrgWIgvs7BT6Aiq7P2r/RTliQuAwFtU0VZSpWkfuF48wAoF75jqt0qNKEY657J6MyR0okDLyxzXICblSIrrUYDsSuVOLAsV+m1rjA7sVi2jWq4o/vsDvDXegQfaeRDFHq519XXXEhoVJPA2Wo85cJ8fE7r65s4pjAIXCTz9VLuU+1KY3KWzUFWiH9r/H3Tfw+S0xAcRc65Nc7Cib4qVoqjD7+cJo7r65tENMZljLWKm5mhQgKYU9yl8eCzgsBgvQMApAxzCZoj9r/SP9sgTkDb+c+bUEyZ07M5hMcR/qmd/xMCZ2fiJF1v+wplymbhnYey3AHH9Wzc/Tt1UqxgQKI63qzqNNlGTRszajktZYwAiCBlKXB0ewmIBxZiHKJVxKmipTPxPKyovX2tmopWJQfUtvZBddp5/CWcDZKvm9RF4d/5ub6Vd9V59fJV0KtzuVcXtb829FQsqYIIL9JPhDchxEziuJEIofhJKuCtU34V7aMilMbU7kgwoeDPas6zaiLVfyuLvvPDnUMqaj3pNcNnB5Aw5GMfvws/sFYT+wWgof/HgdSgsWWGX9ARnH6Fq2FQwfA7NFg8aK6NAcwBsbsP5SNxvyi+Qf3lF+eFR2BqzF7II720pyEvAA3tz5X9FtFXeqx/LMO9pcolvszGBOJur3q/3gpk2aMlo4ZKUuAlaTaCzZbDWWVuKmIFAng4pmgO3bJju17pGkJhseYslTsd0TwQVjnVpCRT2hyGEy3SW/94cn7P7e1uYLeNlSzOFvdhKQ5W/9EEojyqOl1QOdiO0ctm96e2IqUZjevqUpnyOo47atPQWXwIu7KeKY7GFAGPkBNypEV1qMB2JXVAlsMJTNOvmdsXsTMe1fT4AnSbfCSVd8v3cROM+xihtWHGCCnGxx7WlgAa5oXGVAqjks9xqSlRSOTEFu9PCPyQEqs9d3iK7IRoA7ocdG4kZpN6Ws0dvHXGik/7qKiDRdHctCcOylO6Itc5g/e8sEqbTFe1n8xrgqdw9ijlYkhhOkAh+knwh0OfiB4sbiWWsjncktO2cF5UsRoQY9zoVtoyvThV54mKyYLb6iKv931vQp9xzysDXdvAT9+SD192hvM2dbUZIQ9ECmK8LC7Hp8PZ/WffEPp6zc+RXl9yUVFpwZ73uwM7AnAhY5xsMQfFoQ9DGAk1ruZXrpUmfDJrA/18TAdAUW3dMn7ZbiLc1y5hB9TT/iUac+CTxrNBEs+ehsJbfDXan7bj0wtDwWhOb/carN0kIdakeowTriJ0sYJ8NpDUbkfOmI84/CQm4Dn+rpSqmtjHlvuvWfFqo2PU81p9kPngicaOZXpP/HWIUHJXXzoMbW6mNN7xuDKgNh3urnwBUUT3YUfCHSRETk10pWlGKoZ1hwu5WpEat9zKg/ynv0iTeeJbcVYI4voLHetQsjwP5TSBXP3Tfv7fWlZx/2vPHw36Gs5LnjrFZCwhpNi+vHmMp2YgXxzFC+D22WBpEFFSeMS1iyAGJW7GhqiWCMp/I8LJu8BlcOfcf3X+a2/UYmcwCsIT9eA8JWQgKshI/2xN3jLJm5jx7rVo8p0pxm8rf+J/thChQ/wEqiGo4I6dx4bY5I3LHBTyDzqahNvPDqE5qihwJuJBh5yz28mY8hUJ+zndOQwkwt6FhWaB/N0vtXC9gNFOiNmf9e01SvQ8NUJU8awyvnF6OdCbegpiMSb7Vh+4jUH5j7Agh0qyyBMykCpnmAkkw6aYNQAttLp+o7SvtOhT3DFyMSdTLMnSjkZH8slZL4Ct62Hkr7/E+aQtYaCQPCP0iHfK/PrAg0G4t0NjKsrAyPSBB2V03Gdq9NLnUtv/rFVWX0PhLbXLQVYu4Fh26hkUyXrtotHrWyDCCr/pmvJGkRj0kwpUepHkuTNRzDxUlm6Q83r+EqQWM7n+gAAAVUOUMChm/QERau5u1x6c35+7y1wh4AEVOrAkCblsvEyIsPTIpYW22AEgQnOp6ZtPvnxIAHF5mmI4+yFjgIWKsvD7brsPJQU9CRKzd6MtOxXUUhDxivaNGgAb8DosJzBhjiIF0oun5F9AgB930jCUhROBZ9tAgqodEpuyfS9PggAQ1urxGLYqZZCaw96Xf66FO4D5YAdt9p1EM2YKKL5iDvFnxR+vU5Apscw8a56ei3dVspmvLPBa7iuRhqaFqmzF0WlD/KwWch8COEFWtuN3CfxK8SGg2FsGUiocCWHS8eMt2osdLxyOZLehud90ROlmQ76eTyjP20/lEeUo/Dq/0wwmAgrDACfxfGtYc9wjVfdiUEc3JmY8npfE3dfD2V5NhBvwEwKpxZcJ85fMBG6vrVVuB/UtXpzHUYRhxc442W3q/4tFhS6AU4FDUJXabjOdnLqrUwpZLzCZCVrWjk2n4mgbNyOoJTxfsKpibdDXEMYdwYCTKBLY1olTKCUpCFPs3zfdRqRN4szwOLQf6P7ZdYscoDcZRKfd4+5abEjhIs4FDAfg/AMDcXAaJ4gBd51SxV+Y+ftQ8cuVaC1R13jySm/pGYWqLL3BRzllzPEXebF1RC0n/oiwRypYUIx7wqGTq0veaJe1qHruK+o5DqQxPi7yyUt9ep3Qp41WZeAzuTHYSJ2FGPpTCO/dzbQKBSt4Crj8Yf1KsXOmcJrEfIhEucCMZuun4bHthzbQA79Vc6cVoF3zq2bRy7yu2kPHCvqUt2hOzTQNF6vrsIuXvqLghX4mIqdq2SLlv4vCq5ir1H7x7dNTo9WAQDU2RTO40Jz9AHSjzkXE4DIMMx45dxXTyG81Z+BA1xUUOahHcWbs36tUPV67Q9aVhlFfS9oGHjf5PNRTKOdbPbhwRhaY31SpAX2ij0VkM48+ZLCEYwufNOxvjUbCs8JpdPMgzbK00QQA0qjcY1uHP/eSZIXs7yizReZGkGKuOh3bnWqLFGH5ws+1q12YvEkhveCX6DCMQLO74QhdwkYwF1f2gJ9kXn8yyxhXAlaUygAF6Y26WFi/dFcEQr4IxSJJa1AAylZUXTBHl5Ev6/gDAt80a3eVuCg/twJ8ktgs5f9+gTDSrkKFwhorYfBrEgTeJWMGxtND8yN+5v8g/Cbj8j8vuUCBFNJehd0nZVEo9VTNNvKt2ctDAKbcHSdoshV+p0MPrJU3FSd/zgGeKMsivp1Uz8BbLuXbo93Q6fsuMrt4x23+TVjqGEg2C8mbICZHK2g3M0hWCkL82hUm/7+9nABmhhko6RXboHD6powY0w9HameawuL2t5On/Naql9Fq1UTWhU04HItLijdI/k7bodHs3+ig63tmfTts6g1W2oYdjQyCvuZoVmFXxIvJ4CoG2ymP0WRfBWaEF4F9I8Hf+Yd1GvuwpmXvMz0NLoWjG/qTjqzHivPenifbw9pqs4A3hjAypcZzxVRoVwmeIZebhsaRnT8TUkQyD9bxbeB+ZWUBnL/+fHzhhwN0nlsbAdXo8Spmir8xiK3OEoF+wuLArhgGcmtRtfh9926X4JJEovWRnADdkGeg0ygpzWnFXHTNfS7JnT+ErIccB4s7lcA8j67ke6ZXkvk222UuIB/m+iYav09Tb8WoveKNQSPf1RFkiNNsQ0JDOsTJyXekK/UDjLjqLL0Ikr5SjCQ/BXIV2Df5CQhue6H/INyTNS3uqWcIsXAYAvGa0OFu70tjuWf9QE3ygvRSv15fO21V6K5OY0rsSP+rZRGnEdEV+45LiOjmbs9E1G7sPT5Z1GOtQc8eCvUEKSBbp1/vbN83KkctPkJmE9VPybjhgA4tv3cQozbEzfukGe+sDpSj15VaWQPy+6xznzCx1Gmh8wKOC26YeJc8p7LMDlc/mt/DvYMIOJxswZijuIa3t9VPybj2EO4EeksFGyKsx0YHhZrWxnQOSM9sgtQWlsPQroB+Omgn8+44rqB8YcqiMFrwFS03EmOFBVpVcCDrb2xBvBL80IY8s1J2QC7eDQHYRMW9bYsTD8xsosluS05oe7KQd8mZsVD0VHlHjGOvfQlrI1/NqB8wfFcSgWCvzFnO7dR5tBGANQnHpwzHr+zSa1sbfsmCLFzWEa+9bjOSsOXlfjXOANfKhO/3IWzniczwolnrIzBODpItuSkXBl9QeNAhf8u77l6C5zBB3WOc20FOCG8Lu8Fcp6wCBCq6AmNHHhbzGRImx8LOBHUSCt+A7fOghBZ0yhea49L+4buOyM9X234RZSFStN91RkxhgWkVRIvQ5wjzh9a5I/vvLEhKP4i8s4EEzgXX0VEYXwD03MihtRDqiY1353elYrCIu+uKxjFPQjJVPw/9jVkKZWMWgtqaDgEHGAONCOaI9KHhTXQ8ev5P9k0Oq+8SIxWMyjl6Ztk/fCTykOAAyRpS5w5PWQ9RyqoxV7uLdKgTv0Ig/QR0coMIhEIhEIhEIhEIhEIhEIhEIhBlhxD5ik2iwloi0jKaE2lqqaaWjENaOxQWTUdW8tdX/uZpFdg6Yu9uzD+U4g0xlzeLAc0/QaknydvTcgRJYDq2Ohds5eXhbph02HCfmxcSTLqLYNm7QFMzWCnyKbXxzK9BCgK0/wOfk7kubiDnzlippRd6bkerbijTcEPJyU5dQ2mYGmYk2AYhPN5ty9EgkJpZU58dzuJiaisKLCalprRwcQlY00kDwrUL07vYMaCSYnQeDPdXDBwngKlrAFKqx/pbIqF2dcfismivxjLK57XfwYu6yfH+F6WvNNnll52qVR8l/0013j/lcyA9PvcFx4+ZlNhEwcZPHhF3zMbkbF66NZJLl4w3kG2h3lNM3LcP7RvAzr3uDcTIbFwtFDTbhEcFkkyVujKlg1T4FchP1/lkW/CVS7oDsAu3ACys6mqnGJ/GUbQfasVan1gylUztNnWxd/hMu14mauBM/LL3M8Zn5en9kzFXTtoKde6voT4T5DTUA2tUBm/1VoBZgPt29xYy/Eo+mWQBkRDoCaJ/uFO6yhF//DhXxUNCt2fZqlnAR7nD59dPlxMGyJCEP+6i3c2+l5eMRf8sRPVjqNYwFzcUC+xwp9Q4HAJdSOCTg1gbbf6fYF0pylDUq+KCOarLkhp7P23E6mYfsOKAfhlo9AhT+oi5EnNcs0Ai2U+9fxJWJorUzKhDWHGu43+PArbPBtm3kfLE6usK1VOyv3dRg1Ih1IVEYJFHoZZwhKe9Sx2maNG15lrTi7QkweSl51xihM0weiA7I1yn5R9w2+1qSBFOl+eQj3f4FXdRnMQ/D3hCDzxINURUOMJi+yQvBjd4Q83RF6DcguU5gyNcm28UD3EE1nKJKvXtpi1CIudKr9rF7mC2A9h52jng96r7SUoHkMBv576G/AzgcMhWy6woxGI4KitUw+i7RB1E0C9gTxO4Oda4AXVnKd1LMdD4RQfYFLKilV2kQE1m5FBu7epcvyMylKILV4jzox6Z4a/GQa9LYhZ62dA9UN4TAhfr4dSXpDyeqJCHv2va/dGJeyXKS/ysh1ZJ4qF8P/iK//DEU4G566MD8iOOJ6CyAtS5FrwzcF/Fa4QpsyZ+JZ/id1SCSOqykIhPOO7JaSul6YS4cij1EmEARdYEroUzZiwGskhustGgRQwgtrFy20k2YNgo5pIi3nlAhWOIGrX/9+RCnnJ+4hCeDp9x5lbW9olsvBY5q3bGolslrcPU974uQD8y5DQiUkmqSdoK3N7oyU5RHHFV4PVI28toqtcnyrnIrFoAcfzk4oAKtaaw6FuHErOmoMgl2w8nIv5TQxoXrkiT0yHepv+gC48uIJZJtRQpbf/L/ILfo/DDSXYyHC+ElF8CrtK1VQTLm3WjsMEeecoz4PcRMlo9rc0ADeQMCPg4AVpuFgm6v0p7Ksu9tbXG1R+UW3Y8HVN8uTCO+7b1Pn/B1OP8x6WM62O67m06UfsZx6c7G7ks2TErkS94clHQ/EjdSSpzidCoLk1pF46iUNFMLXOwIy6fmbCBfadvuxJFaSdH8sbaUcgEVs8BdPXgApuH1L/xscEIu2zvAdbpPa77Rxyhxh/yI411YGA9AtER4KYLq1tLzVZkd9D16oIEVlXUE45AL4Bv/yUy6Qcvp/untCJ/JpMC9Sn0NJ00CARARL0EhJKScZrDgVt1g6qsjaUobWX1TRiXKqdv0lYR0b97kfnFOWEJ5NbAferBG5wzcg0Itjua8J3jBXjQkxpuiwCfND44bINdT4BTbuRYvJq7bvtSSCCyyuCpEOBpGPQgN95UIsDqR4heXeORZxSOuUbd0wIjnCElK7BLHv+hMO5f9j8l0lx939ycOUPzXbL0fJlANCNzbo5G42W6zWGdUH6cgaspKU5XCxhlcWJlM+vP8EGMLbG4H1a2kqTSLRM+uSPI+bgNOh3vN/yLEPnpirjbo/yQZd3msv07RpMBX3dHGXR2JuLQVI5u+DdBOg8QNgS+j/HVQr1TvX4ZfqbILPmCy96BOb/39MH0/XEzWCPNs7/rQHF91wQPHpoZveZD6vbHYEOzlTn6UrNOK6ID1jXJuPT+T7l7A7ll7ea5+tBhLD2XhNAtUXxQlcWVlIRaoADiZZppDMhm2har4wUm8ttPdHnYcFiJxf5QOFSUehObO12xCnbwGIKjn7hdwURY5kaeSERw0bRoG7S/yz8BW5LRz5w5W/rJkpS5q001CkEflKhxNLbyQsWSKj+EAFRlLfzZxo015CeKD2eK698WI0/OXudrJmdOUJ/N5OpRFVGnaQPQtxRTTKKgAjbLcPkAh19gz1tNR1ADor8mZcyq6GFmTFEAia5R/CDP1XunGo8vJFoQn3amd/yyNU8PAOzGqvMP3IgY3eLjip9OrOvSnhjpS8DkobXgT8wKOYh5aSY/lbcYOPMoJf+5vLCP7h+eDaO92Iq3LrvEPipViLH4b3xmJS3mA2t37McMJasMqIQBqz9TmA8EaW03QmmPnYrDFzWjoMG8BAXc8ovW3f4Vd7KLAJ43xm2H8BUCD2QmW8+m0UDD+rUV8AebRDlNGWgahQNQoGgaBldUU1VIM3Aaa5uEQd8DPEmJrMRhO7Cjajuwo2sxKEISzxBr7BHwHZjl0puYF48Sa/w8Sa+TeJNf4cZNzCOEor9ds8G6R+HRF+tkWzwcLXXyoSplybnJvfhvG4dMhg77GtDfd69ajWcvVQxJkkx7rI/d7Nfovni+ExZOgp0M+9XjzhvRDMrzER23kWdvMsesh9/wXeTPHY0OX3YLZJ51ctuHrXNao7MZiQremzHF1Ic87FyAA4KCy79y5L2Jzquq8NZhixVHR70cncQtPZ9J5lYw7Zmzp1nDYbCWSMxSfvBkMdP1Vlhxp2GVbg95cA3NTfeH+sksfXUF13b1KWegO3LbnL492SDQEgEmxq7ZVQr9yGUTc5hP8wueWv2+jWAiDtlU1A/FtgBsI+NiA32yzHv6ye4FWJOmzjfCJuvHLl4qUuQhDBjLRvu1fR8cXuQIMy8xsJiYSJc2Xs5sQ0RaQWyX0cxbjNfPAKFlOVkSFVKMBUdg6qSeAEfw9bydUvrPMUoMmXjBPbFcwfxhQ0+QTPahE+Bkfjr5V+6qM+A+3GkMrBNAwV9NFy45tN09NOSAuQNEU5jzb8ZOnqW8I/+9aBVQ8xECKTva6XJpdHORGwD3qMtbu96z6W+u4QnoFUmovqq1+2fcQEQPLmfH8Gz/jZ7zmXWEhFsKDyTgJHS6oa9UEHAtN9BFfw15Wj03RxRmd+IwxBV2FO5AYc5n+BXwlNGDZZH+eDV1BPpmjwelMrkPOL6FP/kZeehNO5CSR+XlWa27Unuh0ZAvVU8gPrKl3s5SfnGVAMWS9+6VLS42uv/cIkax2k2FkNAkwcEWpYkkbHtkfscSRuW48RkItVf0yJDszqq5LXAjymj2xWsknFnR4SfxQv2WqbjYXAJfAlT53/SdCsVSZhiuzGzyPNpB3SE8Nf1uSEGvg8XiZsQQk+8FMGYh/Oaix7FUkyf/MEVkj9FJIsD4pWmUIJQYGfgwQPbdObKLhfDlpcPleyEh4CBAH8+iM0gboicGkfIpt/d9b3xlL/UkvMTXAgDrQjkRGmENk0FLs7sZmCJc9UUOo0s2JaUjq3ok/U0DS7RfYTTa1q31mUverA7+KcWqRa08UtLQBi2A+6KWop2LZGWT2ba/7/lAqFw2ot3Ugnxw7DXPA8p3/gKQtUZH8RGVf7TAFF/83lXSvwH0DfUin2GyJRo90xuXjOS6re+unC/SxSkEPxE51/L7uszvpZ4BOgpD14Je2GQnrTR9ph2SR0zhDlYL0/RgaiDmmD05HLXn/FktrKWZxBuFXVVcB8FRxefZUanbA95DpBxc6P4ekSbQIGrgw8U2yBeOdeB6jt5yg1RhhVIYIa8tt324U/vhj26fNAb6iPDskCfKcFDBMlyQTJckEyXJBMlyQTJcjkgmS5HJBFSKTT8jIuAm25pxtqEt9mx2vmXbjoXmXdmNCuZGyanC8CJ0PsZAk340MaS83OruNMZJIuChpGz9xTRm4S9xkMUNbAXYXmOoyHry9/1dRec+fReKi2TdJ6aFOaE+3JaFYDQSc/bqO632RwU30ml4zSucB1kEUQdtzeQTsiHbfU1G41AvhFi/yEpjrKFL1mDp5n1JCDEQ+Y3ijggp354Xzze03Hp+qpza3Awxh4Ycvz6OMx+EmgmTl/3vUlBoRfs87aObjoSrqP8CqdzUkuCYyuEqWpVTJwBNd3ZXh4j4SjPVsktfGuopdL9LarWlqfSJLf3VLlv23yTsspk54QGF6ijbTKtkBp8bf9SG9JFzs2ff3PD20xAlCae9tEkoV4PvWhaqWuj5vUpiyc+U8is9FJEr6b1dldcmRd4oKTR7DWRa9anBz7BM49B/LWiMy1j7027bHFu4xmEVm5qCG+bsKcXRdOQ2aZWLrjv0tUySUvqy5R6Valh3ZiPQyWnM3o4GOv08iqjL+SaWgOBUGnmAlgJ/o2rZ1by2i3DyG4LbHpLJ5ktdJatXwFd28jiU906Lu7k0pGFs5WtcFa7g5Hy+FW+6Ko5fpBOq4sKNTBWEle+ii3Q8xXKjAK2+Fv47bcJSmLE9THSSmBBMEZ5jDPESz7o7RJKY8bcQjKFeyP7QzMje2WG2H6F4I85edTj+0MzI3tlnxMB4tygFYvfhmyDuJYb4EKh5qDyXc6DoW4gms1FOMyahojN9y6WXyw+qQvC16mL9FnPKHjPxtPkrdVXjbNDlHDflT5oMUlIwwOVi6VEceseJ/WIFDpfFK2chrf3Gq2Zzifpm9dboNCgHtt0azJl3KLnGs8jfqPSuS3yykffNkNg0PchDDBTQT4IXmtbpA3b7cXTbPFZCtALVTH52MLEYJu+aHylTVeT8IaXhdTWEOhYrJgA9mxkHyr3jsN8eyGQiSwaIfC5do5fFW8716KzNfNvGrZl1rZZBLIkNMANbjfsdeFiJWxoNchC/MM/NVEUwcuilcG3mYlKVOumXQk66P2UlSbUmUhzD73t5ohBx4MQ84ghVS8Pw5WriMBtxB7x7kElwiP4KEOrC67O/utsUpdeslj+nfdjYa1fN4NoQVcXjJRIa6LmxGECaHOeSskZSfaEQkWJZVFsJeZg4+IC9cTJOJ9LS5izXLuHXJY0zkPd7Kf+7KPCAa/4FYodPkLSaKpjBvVMUblnY3ep0U/+dTlyMnBJ6YB/qugPbyVSium+HZ8ifOFQw8DJa0LGq8H0wk0tO9Cp2srrTuySiZji7fxQb6q5IuAx72g35Wl5yDxgfiozb4ApLQBepiOWbwgaRgkrwlWv5gdGnGpV3LacjkcjaCbnyUsVrrRES3JM5qNcF77hPfupaYdZ45asxlsaPMI/DxYXWPDsvwWVR2gHacenkTIDfMPHgKcrITLBAI836xbpt0q3d/g9Qh77qGYZV1DotU9ijhdHciIfHhnnTuAtVn7HbZULKETQ4VsE9WVeXRZGMkbd22j6YwnitSsGb8Nq38VG79dfamQy7pNZDcYR25iRJYLICoxEiBIvrNzmAOSw1higvVOO09TrL7RafMFCFPmWcCAJLlPQ/ysfo75RGA/3HDfwV5P2RnbUb581D6s4LqkU5+0mUJp23X6pZmR38LMqMifSavFjVomz1N7D7a00nqyry6LOt5++pOf/xpMsfUBePtXkkz7Q57GEw4X+pH89HsfyrYc1xa17o4n/fzHS5Zrbz4bEexgRVFJl/SQCnHsb63Po1JimaqE1OXRKl10CPGZaurYX9rtjiQW2YPA7pNs50Zl3MSef3lcvd/TpPGQUqH2HjB2TRqRI5TNRoopZzOtlAUCVFNeSaCStqcHlW4xVSanzONUaM/TY+omkonc9uTRYPwuUdWXhsVcYt2903GZbDB98JJUtf8E/Q0p9cyZ8b+AjWklR+wPLCWqKI0X+pYV6q8zUHBVbUERBjMWS+OGuK3DuNqF7N8SA3tOHf+7hR/5VLjKoz/iCTkXOd2RXmOenS5A/VmBhUmHGLQ/DwHjZ446lQZZ1Ez03XH1VIxb+EO1e+nnzLdTj4OlQZhpNEovb5An+SwSJZES8fcYU/k+LB5ASCHqIWmkIm8XzFSvCs4++j6rFTEX+mMOJrgyyNGWKkgCkR55eLZOe+o2QxqZdDqMikZhs++AGPeb2mQ47qLCipDbF3lTKpIz30TQbRH4pPSKZWD2OSdpfbbXlxrgmrKbsJH+uPhhE3cSSBJ/Co9UBNKO3UH9dxjtWV+3CXiBmx3RNSzYrIsslJQV+RhI2e4MXBq/3lS++Y0BOqkEthVQgLIF8xEx1/wm8D+OeH1CzVz8hbZfA8Ap2yCft1CVKPwsQvytLBUKdH7tuRXLKnuHnvh9EvTE+WlADUlEM47afUli94RlJsFBsJ2VGb2KocnmXOswztTKbWdnW7vS+4EtG2R9EQoXYhBAkS40mx7sPK78qmuLBZpzVZGlRz4zsuXGBNCdVEkgnhlhiyn0UHhKuj82+ROBtXJYuZ/6V61qPUbbDZaAgC6STTmsoQ4050BKWaUj5n2ErzfJ1YPWUSTE92gQeN0/jrBCYSTpmjSLjTEDpg6EROc15lPQLnu39ymwAKdzN5uwT7euFEDaqJ2sEvsWN7y9kZNi6bBHSBQO/feUXCrvA4mDkhfpoadHLpYiW2BrQYj/AxpRaTJ4gxcz6JTZ+fjnnZaLCiEOsX59fdPHr+WwiLuhWGmRmmgb4YgpNmAN5FGVed0WHgO3TFchnaEE9N7BMLel2HGIUp7JD8sHp1I5EspTY9X4zFziUqS2fk2OGP0TQDaIjqMLQlm+j4G4DmYghHSlKvY+6JALmf7wwRDSuqJlFjAFzNvBMacnfj3uWLo9su4/lBo4A0y80ExU84AlGCduTjEna/7d2mn2H2HvNhhTJx/rzZAnLENI6QbtK0PvogxeVmut2BOD5vnm0gm7oMHGhxtpOuh/T0CWd8i0gJgzS0Vgn/wlWrud3PCclKdzz9mN8m9nlKYk9GMFIpdpLVo1cpttXYggdppmg/BUe+Sw5Yd/RvxDJviWZUkw98Xh4SjYHLz7rJPh7INTC/ZXccXk1LWrAxuVTRqkP4IbeiuqO/UvO1ZkrW2r/TLyKvM6EdA+mthcIademhW+mh9miM7K7MSj/2plzic39FZQ7q/Donoi4oQtzJKLi9CBl88VrZ7Y7BHYfWOFdqW2ud7UhSbafB/JIWa1VtD9zmBHVkxw3DWjBCXQTFeeFwT5/T/Het9nmVHzfk8kFGlpGSn+OWYxuJ/xjbHBoP4DN/nPnS3/wx/djwKqV1uCF1lTOG26w3IjFlxMD0iU93J1cEWbnHr7lNprBN/kcIxMG4tmuEMkXgJe6YauPtlrQLQK0p/HJKgiyTZqEGwlswkpJqjAt159UZ/s/lETVAXCpwJ5oIfO86/OBfvGNBOf5aEl33PxQnGML1Jghgj/DMTAg/QGHGp+YG4PZw54zeZOCD/h9cc3IfwUTB5fnYkQ/lh2M9NtwBGdd9esTSie0n0yWKL2i8dKEge4nh6VAkgBHGJMgiNFg4C1OsQ/n1PXSSQDjOpHpWxzeEFTOd72//V2kkdtsoL1ef9KpvCzj6Wh30VPvgDyq5cg6Vnt5V2iMuymst/uxEcg4FIytAV/I/wB4XJ0NpIyH2Usw7vmP1P644SWnGKgT+PeoWf5us4UF53FippKIT4Cl2Axfpb/Tx4AeZttZ8EqPmgB6BP9rVyaOLbL9lqzmmJDTzu+Oba+oyCC16ljXGR1Jc8uVrwQ3Y3lCRLHUhnv6HyhfAhb454qbrMF4+F0/KDFfuiFB376cSXaZsUemC8dB2j/veWMEJxNaWe4bssRBJAHEnGCyayhlIkF6lh4HLgjG2BrQWGipoE6mJnHHaAGyjWV8KRfcECom6SIvudhQqIIibkmVOv3Lc9uC4/voBwvpsJfh6ADpDR1eJ1bMwHAm4PehxCA/7vACY+W55IAi7BFLgmSq3x4C6nClCAVvOjsTTEdt7w/CZ0Cjm/TaTKIlOQBkwAAJDxqAAAAAAA1SHtQ89hzdLgBmHHmff4u2sE9siPraZMtNljeUWFPbQG5bb4v0/50896wVdPWuX6YsuulsxA4gehBOOxqiSF1cXv6jpve5r/uHFdKgvN8WKOkD+2VyHcSyqunuX3Ar+S5zSzPIRS9toMeeubTyo7hKQmka2xLvUFZEbWs/9TVqS+4N9jKQn6uk3yAQoyBA+tIiY6yNoWKEboYzpz1h/rQP2C4jo5m5/pCI7rB1AAY+01E2ubrAOowKyJ+lnweKIXtfoB1a4iYUDXv1h2pcagZcAp1GVlz6xZcntdL7CWAe9hPytqpulwGqKJzU1tDa6j6Yv6q+bJD2oeew5ulqekZRNdXSbfuRaMZYhHrBvQ+HyQWHT3L7i8lmahCbu165KukBn7tGS24ll13XLJF7yWlTjiQXXi4FVYYTVzoD6hdd6mgvHqIEXHVS8cpsZWPZkk4cBl95XgvwAcLZiBxA87mO0ZZW2FeNiZ0ht+YbH6LRz+lMu55gi74QuNT41gGQrNcwaFR6Q70E5Fu+QAGqGnYLjL2pniY4dlRBPzCrIYZ0EBIHw/5b9vMOM1yz5RgNhrQYvQKOcDI5xhEaHFZf9IwIJUKniwr/bY+qm+q7Av1tGGkR32nXwdN40S+tzK6aNYPwXJ7kMr52/dXXNytvgEU5xlgztOOIWAMbHjeJpCjTgACa64ROEm5d3Bq7fjmb0l1L2Llx5KIp4ZXugKwPFpTqEw1aAPWhFhXIqSK25nj1F5RKbWTO7r0UU0EWKif/GFAsuKWX5IKPuN7yElwdhddnntbud0zJ+X7Bx9UpYEjTHyQF/UYMOJd+Mq+RuPfUIjgXpFyWLXhDIcVRgsZxDxTGKiE2SQ9zHw2ZJ7kZOgH0cvIYkqr9dpnc9j58/LncUB5RsDN3pw01x1lYlOK4/3AZtCLLJcPAEoHpiWYIAzYbhp8/N3OA0ZjEdZONN/lpqYJ4DoE5jjl7TB9bFM8/sw2RM9vEfaMWIiT9p//Yjd77KyWMyPym1HGp2WPz59HbItfO5z5sgJma65mKJBIty1CLnYisFgoVyI5tkUuq9aYijXoMI4zZQbog5OO9lpsK5oBUNBH3+8iK/gGjcGOw52bdRagSkexV+M5K/qOIga5RIXDjJefR12G5ZzTKAydNu4pgFFoV3H5WIlETAA85GvG72U4NS7KpFAGdnxBL68kfNysCs5tBEdRNaN/y7xVIMhG4d+tW/eU2ksmakz7/Hf5gQ/yPAFR4kZXaMkD9aXazjjUjxpYm3yp2WILpFbyqf7kd2xuIqKqkQwXw139mcgJTf9+Q8yUD+j/mixkUkZBMp4L/jf9xIo5t+4oQxj/iYQgnU7k3s821bLm+W3rsc6IISYQeMRF4P1UFU5NClNItJJ7NPMc0ykdcq0xv+otupCcukjq63eYqAZ0M7WAW9lZWTiQFGypI3rim3dWdeh/ai7trd+5TG+6sOOAHyHh6w5zkqVg6FFrYY08Cu0tuCjhUDF41VOYxI5idxJS0mN/b2DKjdtl8OJH7ig8MuLSPQAURJ5SFzTdXIYluxeL+zqp9AwxjbMhv5z46WrIIgLxyoLYF38AyJvcLMsp85RJFOiAcEMwYytpSBNOjq0F7hbrs6xzmLWjM4pVY3LsnW4djtj1sK9h0Tw0YD0PfVXLO8hAE8GTCuVnyVhLUlzvdFKCVSIVhRziopjPI+vRSj8cYh2Egh2huNvg0Ymxrk89qQkRP3xmllIuN9+eegPyXIbTr7NEnxhgFUUC1tXiAmqCrDtQ+JAbgiC2QOrT2y91ujMQwXTV6+LEEuX29qGe+BPBJkE0q6pVOAO0NgFJB4Sj76gez4VSC/H5/sawGc13EajTtMmbDoYiWSb3Vqx1x1ah2XU+Jwy0OwAba2ZUYiEEoU/N0kpnNYlDqlVTXVctvi0O+mpjxx1LliRDSxelZ+kJQV/7BreC8UtVMVp5C+/Pv2A2DRmT2++P4MFSCZ3OUfax9ivQNgIJpCeSN51E4F5heURh2gijZt6sZ2vLGkM0qV/UGEc6NQtdtLw+VOIqISNMOEERSF4OPhiRYPg/PWC9omv2g04jGvKcmRLbF7Y9tuO0r56sBE/eBs6LnviB3rvHrC96g2PMzaaDdj3MXtQpeceH7w79zNAvzWZ2RMPGRQb6Cuc6nl5IGxQAAUoanISNBiO3AxIdjS6W1D3QKcbGxbQZhn4STGcKIyNvRt7ZFEeAu3F9AqLMFJVWU0IWRxM9JSqimV8ehCsEl3ggXwBVOK/VzMoUe8l9ezgV03JmuhDLbODIScI4nHNJNMDZitKljm/5IURHgkf6adeb4Ds5c0bGQOIusxZxnXZoL9Q0tA02vOzmbmUAJcyRFdhDHotiIFss7EQAgeqRSPvsCGPWpN+dJRn0kZxP4j24/l300M8bW3MYNMMe1M2or3Lk0G1WOtIn6tcfIjuxW6Vpao9u8Dgxl/GmdQsqrGz4vrAGgHwUI6Tk8gtXCqavxq4u+Oknu6Rg6OwEUgSa4wV2Qg3C5NNiMBymWN8j4wF23lM9y1zlHXKe7SINaPiMG7qKeRsVdaV5/SpjoOiU57yns+CqRxQUO/z48gkEtIkbNY3ugU46DKQIsvp40sVEqrQdBRLKXYd7NPbeYClMM31zBhAnKKpq8KlNvjwq7EP2uMPRuXipVXSEEfum9b/zFjbmPNiCcc+WYVVYlnhFj4yRCeFpSShpGoG/S/0enXsP/eF7yqbToqAz9wYc2fB6UXSnnap7YCrkEOSMobkNoKkhVohV+5K1cshFWnkwy3KlFj0+Hs/rInPedyb3xmCcKajWJQUnpj9bEEAAReQ77BEBmsr46Ux8CloVdBq1fEY3+HQmYiSXdWw0T1u9Og76yaCdUsotsRZL/xh85grlc1OItYbPmFI06YgDc+1g6o4Y39uV0SRnG6U6XutvUDbMwCSIK6rxj06XjEKlQeN9L+W1Op1n2owU4M+c4ai+XnK2ow5KAdyU3it/mXCEXhh6LrwpHdKWz/rd3FLebtStsrcszPhRXS7uwlJXyr3tiB+wTshkQqPF5/mN6LmKGircdFyijmbQ+zZv8lApqBou9Aq9QwLZpGHA27x9kSPJ+33tIk20yxaKPdd9ye1hYThpNrUhYhcZdlDnFJ0QBPVXcI0VcBSyYzuIqOAX0vjZ4WlUwbchevB3wRH7NXCzVeV9TuPFE23k0ne8wJk7hB9xeqTxvK85tDQBR2Ukxk+mptysCkJoH1Dtv8/sjT6p7w7yZd8OyzG+zb+FJlKb36vFfJZ6jg07eet25V6mQUcRL1sUVWMNSAnZwPvRvnkJkd02kVXTsoMoDSxZ8aqX0Rur/GvRV1GD6IQnrQQU4JGZxBlLkEhxlH//IcZKCJ8latr+QCDQRZ68rOWfQXxqEj1ZtS1ZUZoWRs3pV40DQ7fSqguX/kTnt7LJ1LIowE3KdT0h4A6od2FP7WGXchLNsdcsWbU9gRSa0G4D5l2kPbFe0PUBhnuV3PUhgS4poPrzuZCwbfVcS1roH+6sDdmbkLVd0gG/y7A7KrGkKWBAcnlaVKBcyO7V1TudoKwOC5TTOx45lGNAgENCb/JQKaeTWe3yAMoDEzjKrhxWDrGat5ZAO6CWGTnnMj6nzstAxwWdS2A4m7Qx9aO2E5OnSydKZIYqoLXf72kFTtvzbFhkZczgEkaT2OfGo3r9/uSlJLKVL1V2Yee5ckF5UKEO1p2ysloT3obkoszd3kF9ZaWYsYwR0fkA0EFTGEcCAXTtIGp6IQWAAFkl/bs6m95thJMH749vjSANQbC0JQcRfzVILLqD50sbuMDWrhf8IzVQzLmeZt1n3WeDGxHHfWgi14lFQo8CxuXu/ig65PlBIeyXsQVKTWyiMzZ1jx87vYwBeGXTrKcRsu2KeYAgG4gEtOY8z1QW4CBn7FyQ68Go25kGQJkiuGUHmt92qmOj4DEKAxjrtYSx1O/clsSQ0OIKPxtHGQhbCQXu23+1L77gN2lXRe5I2e43h7j11dUGMomBAAAAAXIfw3xMic0CPK5YddnHwAoBRz2DQs9pH90N/5sU4QDs+HjdR/qpFhck5zSqZrZDLY4DJBqAnqeZ6SiO+QgLVJBsOZL50ImvZ979zUPGSrcRI/Cr8WmvqLxk+VDM79woHZ0igliMx5XPhrUj4e28LGJaVhs7PZxd1t7ecw5Ay85P1MzZe/zhABhH87krsNfroWr29RJPyagblZtVyMOeXmI05l02DMoaaMPrZSf6gxYR49qagczbCFUn5edVAdj2AkJBWEEDvMAeBtZdw3LwInO809wMtwPi7fH/VZ6+BzqLf1lrLOkcJRZreE0HTl8Pz4/nSrfqBRXOzfZ7IzFBsAo3E4OsA487y+6spWpgtXDF/U88J8sB0y/WxAsTNX0kWPL9N0B9wE+e2caN2daQx2xlQHuBJPBCAgCnzdebA1ZuytgiyaN+CL79jU1sOTPw0SS6V7QPjfgdS3DF4hD+cTwZgJwU82tKKPRdQhJlAYuzqZgh8fV4dPvOMoQxqv64yiGWBVq7KTK9DF1Lz8rBU8CqEaRb0fsCqzhZ0MhC28tmsENIXFnOnIo63ZCfV6bmUA3MqFW4qG8r5rYmpdU9eM1DlIONkJU92hBbZhARqw9eAnpjohgmjDezIIjtHjPwZ7JoqWyKHjJCPt3w0LZ0YAXIHvxSo3ULN0cs8u1Dg58eTtH5L8ok0h5MZRCCTizpndUkNNUFoIDzlR5wt7KziS1QkmeKOD58ffZukSUCHwKELrJSMyqy909qB/z9wak8lIVFQ6GgpoaYXCJxq5FZJ7UPPYc23wWZvwD6LDlHtJ4hq53G1lFBzlZ9B7NdUA36VLjp0GS9ydYSzKn+gxqMOfTSIedO5MF8xN4y3KW8lHXJi/tqKDxKNqbfNAZ8tjKhxkIbYobTI5+tmMhXZw8HA8Zf09LOrnFSE9Zl1M9y1TyTmOu2pOR/0iwozi6i+HphYuQtv8RnNSbUzrFdpbh/egR5TvKI4pjflFgkezUp5T4hkQZCuZKwSD9OMVtvuv51xeBEIa+r01yKGG9EHyBA0raiR+W1dJV97CGJpL6Pzfggm6dgzHW/seqc/ZWwgeN9BVQjYQllkpyBs19WRSCvPj72T1whTBNWpp8XNO06EauKOzFtJYiXjJNxzTK5rWdYmQVxCPWD4odVuERE8ENHIA7xjkgAzpOk5yqoWmXmZNihuqiFpPqhHnfQDsJ/FHvVdFofrbtvG1+kF7hRvpiH1Utb42wtNMta/1R7bbMIrYAdH8VPj71AvFpj6pKEjoNcMKd5+I27zKLhgg2m5N7PNtNuaVsTsRZ3QDhXkqjyTJ5n4T5TvS5zoEjYkiOhelpmIpNVD1hzmIzAFgQHzYKeq6IUiS2A3lnm5RxSdIpVQpqiZUY3/UkAEF3iX9A2a1CotTrfeeFtfabR6irnxTtNsPgaE5ZJo9y6uCe3jhZf+wXo0NDVGJJdzlB4WOzjkyh0DuIktobGiB8jD+IGEuMLBLJeibdoPoLHBlnRR7QIAFPE681DMW16uvG01AQHBDc/Lk1W9/m+MnNF6mis66xrde0CBOjmucjlXlWguh1kC4Mrzl/SHcPbH8PYStD7EWKbwWXkdk514O1+rbRxmU2d1kkk146JWQLqDA21S6XPBFGFMOkXIXzPKopRWbj6A6Cs7e9WI2NH+xo0QoQoC6LiSgugsKWVhhknfzmJmS5XbxHG9w6dRT4nRpuSUcdbjkEg2bDt1W4nKkiKZHr/iSD0BE6FRP8fujxl1wkhpWSX/FwmktWDnHOKo2cs+AEhMpJrXZmJIgcsvssqYluYM5t04/jHNbWer1E1cX2z7xl+xFUe5BFeUCeX83d86WZg46DcRAEipCozTtWtRKM2fdRiq53Qv9H5quLM+iI+25S+sBMD4W/foEqRZVfhKLxgPQ0gEHs37tmdsZsfPypNudcVh3UpkZf6BP9C7+fo/e1CEgRAH46XKCRt7mNYBbdkxJEEgynzSwlRAeuOX+eUcYyCQ1MYs5x7Qz/9EGL9m3dOIByQNtEgF81bUGqizzNcWZ2jg6CZfL3FKdh1hXtSI6qNKVx5PYT2ka295cSzz+O5Anokqd82qj62oVY/yCFVQCT07WCiYbLJaa2Xys/+877Ghb8VbhkHGa+qxXKRsJjHLbYaO217WvbhQThe3BEuDJbYrbQFK6+mTFQfdGcMJelP0A4Twqf32UMdMRC6HOh63XBDR+m9v8D3/SwM1WsV85ACirIxdApLNe0KRFf2zfu5MhIKBU2SiAHWbJ64Tq2DaYvb70xbuDzr6hCoQmb6jgj9pWufO8SjdJ07bxNoNJwC6T0uCeQCXPoQH45v0uppkhSK3uTq5URFyGvE633PkbMGTWiFtmKJQjyCjINDaM8QKpz3ezbiSMX3UFlLozAh9dwMDgg9J0LucY+qG7znzuiZrob0V/4ADy0h/XFYWNNF+CdWmDsNOY6S7vuMz69KONL6c3R8JH8ZhDX/z0VsdfA8j/qC5cR4HRcz3geOWtQVhU5uksc0sBB7kC+pXhu5qLKnUp6ZXmoLDeQ3ObSfn1pMC7AW70uB9+PUYGTBTKoDAUD8psE7f+K0tcqD+HmUgNJoHa/56IWqkNBw4vOiZMFc+Ju6+HsryY/QlodtxSOEhTg9pjaIz3zFCeAopnI6qPHkpstnkJ4bp1cDMwnqp+TceQYTuIdjYXH6GSMVQaX/4IWvsH1rkyfc81Nas3RXHUmxUjVvgBSnYF9Upejmc539tU7Zx5+68hprduF/4/k+bMRKvQu/vK3O7GGWYbHR/j/YHXqXLX7YGJ7PQiItfqrf2emywMnl34a3G0kB9Z32Fz6DaNj2YIuTVzPFaeBuixzWuR3wuyc+JIcu5SOzkcQFjC7iU55boiYwEKEGPCKy6OD/i7cL1xAUD6mABidOApwV8GLxiPJao3b0GUhTfWNZ9OWa5Kzp9vgH9+WpDhP3cjXGqq7GDfaMUAYTyeMEE4sNgmM+hojkdee8iVr7hePXkRoY4sXmIBiC/BC5Pk++iQXLGhcACITwjr3Q13eFJr0e7AQJcGpgL07EeZ25zn/pRNMIESGi7i5wcBStGaQ65Iik6kyWVhs3OuoVOR8rpThJTu8EIKO7tyrpa6rLhGyAr7Jf51in0M8LjmvyRb1D1kQeBLgcOwVX9Uxn0aFERecoGjKDE7m8azcm1fj97CoNgs+LrQZ8XFsyKXtSGMK7as7t0CzhO8zFnYIQVrhaJuTfaia6qmp1RH6vg+9OC1obgWrU3q3qZffCLqIPY013vfmVLsC7PfAHEHWIZpgUzp1EjtSisYL3cx5xLQkRHRNOMNGIF5vzwgufY6j9L/Uwr2b67yv4gXIw2lhc/H7cTYe5DN5dC7rJIqprlIi9BP+ZOJB2QuUPx1kSH7t/S0BAy5SnPV9sRF1ZOTvqAAAAAAx4+FGFY6PUnkcgp/FptypmyfOdSlgnQmkHEoxYLN+XJlUaGNm70OaNw4RSQA9jhB5nGNAo4HXbS7S2KBefScMxV/5xgl/CtI8vYLVA2yEQykbnGFAuDF+Mbfqkl3Vcvmc5xjAtHEI/YGCqiAvDEUqybkjXTa/mQCugV3eLN9nSZQNe6lK5P4RHN2Ai+OnlfgPmMy91OWZSkkT48j9SPc2eUD6yndIVbJQMK8BDVxuJJXIBjZbsUiMuXDHMucfXH985xSb3fIodnZrQPgwhKTIZdmwFiiX0x2EOpEsG4lBrzEtlkxwNbHVsNdS1Dy7kODC/h+zjz0SIUOArCjgsTxDFajmiox2RQZSVxDcTWMEEdGJhibakUZCUyw9qOMYLoTMA44nm/He04wpfrAlY8xCMI1xZbCEK8CpsfCjCtSOsi5V84PB9/H6ZgcerQp+KEQhCs+//UFl4lJS9yDGJrGF0QzG6slCfj7qJCKOjbjVAPUN1DaJJcF0LBlr9N5yuR5vPAeQRUgKhpJi4Z7pPwSkVl8DovdWlJAqzo/enGAMwHUbAyfSA53IfezYEGnIZKmjUnTa5DAvt7FtU5IRXH0FJKq1ITMG/NCtKjYLcPJBWD1pHmKcFm8Ba7elAe1a9xVd/KTaYCigiGhzkL2D8XvUiKGMQkEM/JXjj1/tCaCd2Yv6ssB3j56vXkWX3YYb4XEBSCuM2BZlNy726iogyhrzU6U8Tj4dNLPIiKL30CSyKgOHIL1UPMrsxR6B8oN1LSfCny2qMpsqX0EutA3sQiO5HfEVJjf684hFRdDbqFtg/zTXp0QKIwnTYEAU3ujbB7TOavmy6BcP2moj1kDml2QUj/jN3W4NRUVEt2aigI4nrAlUqQEMCgUsgwZalh1b3Dibi53RSX7l4QHO4/3NiCoJdB3Kg/BmV9My7Pxx7xwTui/SdcbaSmoHcRtteOcppsLd4q9kMUX3Ah4Nhy/j/G5wXktBHM4hUlYW41fGKYPrxxTFGT3xLp27eFzy76LTr2rCxD/kRxDXufDIlhHiBdATgJ97qFgCE+GmVoTQvyv4u3XJaeCNg8A1Op7iMsNI+wtXWwzH8WEVmK5VK8DlZNQpZ0VSZ4HkuatxTA6LI2naT9kdbicjUENZkpNfgqssrzQV1tg15v5XvGy4yipUKyqCu1xEKtj+U913BJOD019chtda1dnMJR9p3hTQllbN4hUlaPyVA19dfPvoUUBWSVb8oZNoYtdkLeKeQA/3cxFprv6gd5ayNrEPWbume0w1kVqHDXePlqrRGJnzEjzPWqEL8SDiBfzMss7+OPIjakLIN6kqlHfc1qMS6EhxPOE1G9IycaPSqzon9x1CBHDwPQbOivWgZgJVHb84b6bA+V8R92ge7t6jwqdOruxWETE6uBI8UI+Jh/emcDHCyClHmCZgGlvcfSabfFpWFu2SrykzjnoqvEuvKl8IZ8diuZtsdbdc2156pzYs2BY6b2vgbhJLLJJc5GU5hXojaWG+jvV2RYBIJ6PN+ej7m6TGVLlekPC4pbbcFBZv11Xq2Rv5HWLXT5vcyzCPtpuWpPlue12/SBzjFwilAKxWTcO7aytJ04UzaunItC/ezrxs3V/FPVhdnDzZaVubrDU5ZMe25A6LufHpStBl51F1wC4Bwa3PV3tMlzxG6Qf8minPtHoRQ/zPoOsNszdeWHJaS+k/wERCDR4GD39xM3JU8zwAbljdp3SaFr/CAoJP4ytlYhlYIey3fgKjag7lu+unkJu7QEWLZIlgGdjZYRQvWLadi95Nj/0LrBcR4UQ9lWXlNTgY1Pf149fvGXDI5Djp989cOB8YewVnoldMx/TN2XMDu43LKFtOwjQps6+kkUzt9J2kWbbfl+8b5joS55tI5bEBvy9hTe9yhYqJd6SNckc1E9bK8X/OT1g1cQOpl+EAp0rdREDyJydtSx8mVCRKtWwP1BCOldSO3MnrItA1U7iXM+0Fhqfb21joLOBQprXm/JgD0Bj/QtM9+9hQoTxoHeEythP6Jj5JuYnFit+l/wO+ydzaQtQhEbJVubMIIugZe1pTNt8668+8l+vip4p7Ocdp8Nwt5Qk2gjCFh3BSnEx2ohwZQIL66vV5Gs+QrwVHLnbTmm1KKPrYauROBO8ZdlYOLK7H7XVFzdmrzqCXkG7qjN5uIDWwwRyMHaIu/CkdLstNO8dSieH/KWI6TUKxMqtTn7dkwFb/AA+mGB3SHKUGvuaZVz7hyd6ZC6PX/6N9ioEExHSkvcAXMCSmDHNJLvKkO8gEMdauWftCh/ILwxkeO28VBAK9GP6O1i9R1zrpHJaNfDPVaMhDszDhQKO4YYPJEITkLlfGEjIun0SGRlWdYzOJeaI4r3fv2dqA00kOY7jWUynpTGRa2f1xFuGVKRK4I4uLvAYrMK1dBTEQNwZB+VDotBWApz/wF84MCcsad5iv9K9Rita7R1KycNWjLFXJunYoUncHnSr9Dw/96gM/icwLxR9F54YU4s5wC1tbbbHEe3Hx5OKJv1d51HBUlhk1ETvXywvXiplzLUF+FD6P6kh1Z8rOzWtTjJHgmrpVbyx2jfxeLpYe22cm2+dP1TTSx1jbqTeMpK/jAOr8OXZRUZp+3RrAQEa4LUIRc+8fI1Z39/ZjfxkGR1BlsFD5HX8kdZBM0JOYqCE9djKYoq2hqPeS+vZwK6cyU+zyrGBYHEzjKkWm9MsbZ2pDNdD+w+WPN5Tb8GxVMhaSKN24kHe3YQ3YFPQVAyCZlHqQJ6bkKtlScdScMVxeZxpNVmhxRkOn7RAYRXK3h7I6FeQwVPjjjOkutlBUIAVYuzT9JSGKG/BFcPScKgEwl7ruMja6JJy47+uccjviLEQL1lk573zkIDQ66EOXT6JDIjtDWdJOINBjYyqKS1wKwJfwGFVJpOZYc7gC8wMaBDpeSeNZiKPZQNNzhJLtnN6vpolKoWuK/48tRCnhYVFFOlQi3Rh8VKgQ4qZt2L7R0cZgCTm6o5hOzBIrhAOGXpUVY6U1XjkeR7b8T/+1EVJbesbzKez34r/0nE0xE7H4u3Nr/qYggB2SVrck/m58ixDJZHTdAqKDg5iUVKC0cBjXeZ6FM2YE+r1UBKSip1ISCQvJhToIFCIyc32yowXZTFA0mQlr2pFyrs9OarF8/MlAdRlxgkNRk15+XlGQSD7PKwSd4NozKf4vjFolapBq2eBXpG+PHIgvqj0u7ZSx0UyNvPqCz5dlV6op89+yxoZLsTWhA7CrFqbrjjX+FmO9NO/TKQKdQ07Ra932qODX5fagJNYr0+tYJglHbiz8PidtvtWogPU0RY8dIBkGHI8S/lKOd8FYEqnZl1eWDzm2Xo+FSry0gwIpSPGWu1+i3h46tmddTGirXfvuJWgtWcAdTIDthDyME4Sa/4RtYKk2k8l5esWI43IBhne56/04EF1LFbKLRd/eE9RPr5F1NoSURETlCnBqC2U5PHkewvaOhzBvnARQDl0ilP+cVcfP+vz3neVneESheIrfMEJ6ZQSUIkOYTq/kxm4bfO2j5xujqQ6E8vdMSDQL4ewSt7meGEdWtChKcwU9v9DW37cuUwRVQ96vHrod/2ib+xcQGDW9MP4jp1vvLhdtxhP7Ygk4bjCdH8ywa5EEnQS5eigrwuRFcmjfH1YrftT1WWJLl/hW4X5xqlAMOfvkG7RcVrYjLR5fzCxtgIoaOpPnlAhtnvHlLkHIR5zSPK1fLJE7NZ+dMOQrpjSNRNntMNWovxGibmrqYxgtC3YQrFL+Zg6UeeiSpNKHPvN6M2oEGIPnxgdEnyPBFQI4mhZrRqRVGdUHRlk7+rKHVIbuHoGVnFCYAbBA1gNJ1EbTsO4sP1no/8CrY1r3ZX7LED+kdJOJbkkoo+6cFAH2fuxVUsam0ZhbjnN3i5iv/OHtRslLZv10qmhhLT0CoZrzr2VAyPCoRFyFpEDu8/s9DveIIwamutuRXDPUC7Kt2Raiy5DRPFTRjJxhzoYmyP4Ki8uV3f8Y/uoBVA9FDx2f7dSau0geNcDZviQBeWm5XN87qYHiMc/XwOQbR0Xo1wZmF7420MaFa+Cx8IUh5dGM+fH/Kqu23sC0aHLIqkoapZsG1/Xhsj9RfAHtOgFIZPfy8AEEbBjKJvmA49iMzx+5NT/aztxp8yhSALrLIMkLkaE/W/DuroQzQJRtcRaXJEbtUmbyymq/7yDNTXRAVcVIbER3l9ca6jpl5qp1k0wR3McEPCeymdYqrMbM52k14pUkwfbqoIo4cEmTi1ngOQGtes1rVjeX5K0vIlONMHRHDZbW7C5VhaDLpwJxO+VzNccSqukwLFQbpsfvLpH5zCyYBZ91lwa2CBQHBnkOq7VHmkV5n7YprH/UJDH225hxrDvqG3+bZP61CEhkDxAY/0Zg9akPytuAC2rFl2GcueZMpkMvqZcM0xEf/ixm/+Wtdc4iL4vjwHH5EldkxomfC3/oMgK5aaryzV9UB47bxZxPoxN8X5VdIQR+6b1wAj29bXJdPG6diiSRFa4wGLVjvH/xm4dVFkrgOGu+yTb+Cye0yTo9gQS8da8lZi9mD8r1jU5N77gcR2ct/hkbimge0tFuHPj7jsWPDamYi0cAAAAAAAAAAAA6gjeXSZKWsbyENqz/1SSo5dF7hB11wtt0rnkvPlEZUOXbPlKvLKaHjtIAexP/U2ZcV6FT3jA4LO1ARG/7w2EUCkV93fqyIGHI0CUlLFytu2ayDJRIBZKEEjTPyodAc7SYIPDa/1OND63PB7Xvg00aKzGBoyKSfQWVbFbLo5Fen1Ldy8lYQYRDfWsi0HpvvqqyrJsDQ0B8u9WqOYVNuwxWihlmUURPu3x4Nx58dfgNZ19P2T+8n4z/jwPMP2g53myXF7LMbjL5p4Up+OjrWJr3LQzHfceL5ibfTR63vqAM1vB9t13YY6niccpR6ojQXEE95fcxtYXEve05l6T3N9u/enHXPMijU4duB3xOzPbJPjv95jsRAu1okbH/OZLYbUNAzGxb9sAp3NfrhAkgXvWCyVtSN9EtjoXhUHAhQpdaCqV5PeFbWo+ENY+zuFH4SJdVoa2OoGPjyF497+Bo4x5eITiEhwgF3kAY/dzOf44AgrGozaNzKN0oPH0hrhI/yN+b+dSvNsNYykZLhQA8oQKmGTNEyr88IPF6Q8FMa1J5jK7KAmfoY1DYl4da9OWYG/3lT3p0xCSDBlio4xShPxymQ8wv9RG8R1i9KFhX0ApQIB3/p1swON9uC1H5ngNjXGRRAMp3w7O3OPBGrPfitL3qGr8rT+V07IUyPHRmGUuFx8AJGgUeKYACALO3e2Vz2Lfuiajd4++Ct1DxK0qezIBKDgoG1oD5tEFs20m2nPE5B5Vl3rhMfPciKK34EhlQppfFUTtd5TcG+7uOwU+QqTuVlNGVR/NHFPavc7jorJpE0IIL5iF5hvkJnsQy/47HPu4tyQYErsgeq9FRZBg43pBkh/+RoC+Josn4Lhu15qEtxnFnSonj3TkNcPdOQBJW8IZLHsXQwajC89AHnAzHyjxGc73pvy+lDoAJmDYu18gsNQn9b04YDsvTC+y6w5yvrqX+2yFbeNalLT3q/+KYKzZscS6yWwKhMHAHnnTPbo8nk8s6CFCEYPuVLfy9vuck08CupPwjNPIVp8XqskEgB4hS492c+4DsoJyVKC9PiZkBBSEsadVkyjtf8lruYiMs3uRYAoYI4S4tnneLg1hZtOt4+FXzzRpopR6QDuHJQiwccRMzSFxhJAP5NJjiP0OxNygNy1XeZ9hWzIX20umBP1v3xswssqFuIJHI3Eu1u0Vx3aKSNodSPQpbh9PThipMwRB/4pW9B/s3wqXHj6VRrdiHzF7J/z7dDspWKRMp7leLnzbz5QKtB2uqq8CwCx1/luqdde65vpq7Ff2qTkkgjtSDNNCUxz4oyQySTOBdXqycAovbpA7172dFOLcclBGiBq7oR6N+Aex1frRDlXcoqmY8HDQm7QXYqcYGaxfnIuFXFsrDLrthsC6nQItFc+JfKmhsXPT0kLWGDc40M0LkvNgzDKhTS+KooFV9q0MnwErtqa/CAIE/Qetozwy6jZZlva6w8cwjdQvOqn5NyevdpO8iqW5D+mbhXqw0W1nEqceStYUIm3jsGaKcGSG8c0lJTqKTwVRW8necJVST2or7fhF8/DNnez/OaYe4hRNcwnLSNIWUPXsLa98Bd1VZkWP8LSrH7xGl7zIprtHbGIu54B0MsI9WC7DtCAijJRkqGoP1pGqU01xgIRDdyOK7zO5jTDtEcabT1puA1d72a5EVED6Bg/wk2TXl10ToDUHJ5IoKzh1W4CuAbJY3ffev8NPlQLEsQyOv7eDQkpSOJxKEIuciz60Vw35SRJVUHCsqfJbxkfcMIQHq/tG39cPFyp8ugMJ8j18Uds0rLo5Tl3zAW2+aBn5HmkBTs3uMk2+TMIGMzsys9WYIBxPASyQBjzbavzzIKLUtklmob0VyDfbILn2Ao8rsdPGYaP/mKIM7hoCRoKf8Hq+5ITzw0QlvSFr9IjEDGPUt3a708FTR9/P0IBTeznYXGzTUFRSvWbxCf/9vzMbCnb2YOuLvYjh8pjAojRQkuLEXHh91fUHa07gll9Sb1earrWkP319ahjAXF3PAOhjdm5wxiS6s9PI77CZ/wNeDX0ViTqfgOHEDvCdOIA+DPMoewJPVE97Tem2NJR25l33XuXjgPqonSYNYmBd1lW27PcT9axDeLH7asaGvCV+G6gJV3A2EX3md/qqoqUWOZ8zR/O5SUYsr2p3sDevZ9sEXb1IcZ73AKE8N+o7Yceaw+z8J3+7nftNnneU2Je68JtTrPfBegfhLmeiZs3nge6juWXZGDpu3XCP9J3xqziwmBS35yZhh1BEOzMlI05FSt0EjDhWfz3CyX4DGjgs/Xw9l0b1+GvM/Pc8b0Q3jK8rLHae/hNlSShLg71x85gzwAqNesrloHBOrlH7EUtBKROKh6Ya9i/31mv7Gw0QjFzhoXlPCGwnRN8Yp29VCD3PSRqTJbH/tOBWufZMoYwEHozT8mE7QEswLcJrKY5igajHIVKyL3QqPBKPv0IFbaHws5RZauHl7RR+QKxTIZ6kzP7PMvprCRLts1hktWQwMM9LviQONyeUjZI2eO0fOtdpiBFGMaX2HvB5EEP+HPVHw9KzXMF5DJ/PgiSvlKEmDW0pve24sUGAHCylC2cWZ0O7MGgIIIvG0Oimm2E+Tt71C3S7bAkIN4z93MnxCibmqaJbDel4b/UM3Ennxh0gc1Ps0DI+VtFtSoTiAbolNlSDojxUbfn3Uy1W3ZOZMbvCNRdXF14VRZwnUmTionHbqJserFlgc0zrl6VRV8bTPDQWJ8HpTsYdUQgXXhNMu4u2QOQbbcU9CCekYWgN2TY48W/U6w6EFadVxW5uqeItU4HRburMe4xlk87BhLTN2WR5LLTY4DzwEIWe4qyhNfMz9wh7LWL5ESJh2TAaLQeqYNoFuZHTWoma82LrtPe9oae/2Mwl5SKJiTS1XyWOiRUQjPdUjTgsU7AH46pxT1DC20qHTjRRDKuD7c9FP2H6qtPvmBmYxg4fDD/1UXolYhbtzzPGk99Cn393nKzVIKlfDBEf2WUwRbF9828UzrpPvAsTtdwVik9CG8BQVYjVD3pMAciv2L4SUws4DTeI/022uPJCEV8pA8eKf2IXu9ic+aK41o+JvBuMsoblYv3WKpLP1m1JKejbLEst+gXOcLRSDE8f5rRZ9oPQPoUWTwJu8MDDBlTVJIQRHIrdILLoMJkbzcDtZa+avMCEwc6de6rVZfpGk+VHBbD56DqmxGEUweLzpmfuAAACjSjIr4OHc3uRBQG+M0akM1swWPSF+EXHG13vXwJ4Lq4+HRuFPMXVTKnBrLJcLME2wCLuCPfbLsnwNUcfiWqy0/9tIjkogjB8pPzZkx8iBXYMW9NS9cvEdBT4gZ4asGJn1q/+1wSJ3keqO++ihd+b6LemtpNKY1ck5zHPMhZxwHnaDOvuoUxbNyu4h6Nblw5d8wlx/a1A9FpkYj7jvVyf7GCpNPo6Q4ueG2snWMQDEjX3zVcfzXrfibPsSgDWogmpHPAA36bU4QzRZlT3wUA3ECIxkm8kTA8l4tqw9h3wLFnQlaCwCIBBuvXRA1VR7Td2Ik+d1fk436RLR64PVYSf2QQahLxjC1ovCKM1RWQt8YRPX4B14z1aiuJ1h/8XjEFcPvHzi1QhG09tuykMLsb8WHwScQ1u7nEwZpUsw57G8x8EvdymAhmua57g3ZChZUsJLPfjVO5yw8CB1m2jT/u0m+U7hb0nINyGHbP6wwwms7RWrvVibM2RfF1P6Z6kSuigVYRk2vLipGV7qRihJPQ/iZzIF4wqzaPckCa9ouB3rtW5ffnFkBMoDmca723M6+kWtuyjO/Z8VWaTxifj85nEMZwlJ9MvGWJEptNHO6d9TbM4ut0qTxDMWpBoJrebsjrD9OPMQVM95T3UZZL1t8m781yfwLZNOs27h4Z3408bSwx6bpR+rb7UgKs1ZffvrFmelqs8ZxWQC9F6aAM+I0k8xkAOz6nVFvr6nS0OhiBY+MFm3+1kuPBu6nJqrYxdgb/rdfLRKSP2vGxBT60nAvwfu6xrFYkUSjmRvzo99fhBC4KliCgk/TnZgCiQgnPpwkMyo/s9Pp0irwmQRputbVliFqxvCES4UEFWzwbChtpr64dycNAxui3hap8+pT1ROU6Xhe/FMiGNEWJkPAaNbfJSO+j15N/66eAEdF+C6a1HZY4NIAGs9qx4+qFoz3YEHlNe/RSrvl+7iJxum8fPQfroRMk0PWYoZY8ODZ7lycnGZMDE/x/HIGnXaLU2+hC7cyYuROon/nR1HbQcj9i0BFozDoanOol8EsU6X7OLhpBxJ/4Mf6GY6thAqIDq8c8ZEum7Qwu4x/psLUwpx7JQ09QD9YjrbsVFD/QGN1XYgejudDfTVV/N3M38Hb6XuuC4ASX+QYXmPa9l+EAJHsGE2CRwBE0ye0F/liEoG8xK2S/SWExwfwocJUk26mqTGVjVouS2GxxGr0KGf5rale40ZO7jPSSin69/3hgf6Gb0jJDL1zY2stfkYzMzBX0KNSkfx4pAYSfJ1tOOM4w6M8QD0ZAP1QGLGRg1EYa4eVD/q83SqRy8f6wGBgye+G6/y4mTsG+lfDYL3xMWnzhpOfrkmmZtxg0bbPW5fx3fIKtP5hhJsMX3kZT7reAc1+SD192jVjGH4lDKe5Bv1xRgUZRchr6EOSesiBtzu3Bu3zesDAYhCSJl9vq5igspv+sT87yjm0M+cbd9YbBOKZOWUwjaunI2lxkMZ+P0sM2DKk7DDx6fTpMzkZzh03VkJZZSjPSiV+Xbafx+KApd1EwNiHMb/LfCrRh2OSWHG3VuxiRlWvaAfYnuSBuWGrhV2KVhaceITTQ2FNnFpUr5H4OD7k/8UxmxzhBe0OYclzQKZszzKsUIZLHTI0WRzT99VVbxjMPSX6XS7qMAGIGI/JIkI9UvrNKkaYaF0JTRYSwKCIGNi/msN2QXbirUXFNlD8cXhtZpKBwRzjKjbx3X10B9KMSiiwrtScOeaiVVkxY/mURLpSo0ai4FneStG6mB6ZM0ics6w6ibJP7/ZjIavqpLM36yQ+18TAreSR9XV7uECmUHw4tHiPVbmGCXfs3C48BWdx0dyY7Y+A7Cqn32TCNd3Kdy7R2C5XjCZFs7eoIEMRe4umMwsKRClArhO1SNBbSrEmmgf9BNxS6szjyWDwBPNxL0CF2K5Xxyx5H3/G1r11xRxYHNO5NHZBuMrpfl6fIiJXcU9pdSy+HSJq92ceOA33Mocs9bdDOpTRM8QFUvME9UJuxnGxXoBLJ6qn018qmQuG8dWsZwHZKxlF75PSOV51Q0R/H9DCk4MBeEwbSv20iTbM27GfPlB8gq6lzjib3P1Y05owlsysExWx2anK6/fRw1kVExi1ZxyLj8vEAxsV21UYTtTIyB2MMCirlckUzba7mE7U+vPVMi11kD65LTV/y/4hVdBZCzXUFjwmWPI1BnH5e7brqEq9IYHDXp6E1HNP619oFRh8B6b54dAsNkI5R2cwyAt9BMAMr2KCGBGr4ZzFNYx+Ow2BrR7Q6L32uF/qpgnfOG2YcY3z70nqHx9OPns+TmkMLOUC07eGm4eYxs0x5XfzQXZmdT/KaHia60oGXsrXGIjLRwuyORkXvHbxAjj7uyaWlfBkDPBEMEKgqsvpoAUJjVqDn+q57BQmA8nZNsmJPGDTXLn/ya4igvnwQEBtZ92DMKOd/E1XY4sVkAvRemgDI3nUsbo69BUbYGSbkYLluIIV5fmoVoV8jHmQIgpdvlkVo4Z6bNseYs2vxmoKBD4dVI2mz9vnK0gzEabrPNrHNn3SfRgU4Ec9BM/TQn29/0pCPs2q9av45jgJZal3SNP6zp5w91fO78aAZqxKoxHmcu388MM4yKJHdKVvGqPY8uLU/6AgH8+NTb2lAG67m3fzF3CUGAx/9bnXz3EXgUxShmHpEOh8GT00oJJthqjpf8VRwSD6OhoG46IMSXlJIM6iZMEW1fTmgFQPr5lcfIBMseRqD2m3tbOooTDGK20nhVPjZTAeFSmQy7BiEbyvnV24KBN+eGV87xxSdWtj3bBun0HmGlkgGof9BcyxkGS7BfC0JRTb9FApm5i78Mze+jbwTU3OlW7GxnGsWjhdzqOb7a2yxZ1/KrdPmy//e5PHxap36uoh4P+B2yXCZY/JlqpHil3HKPm2UgZBcBAvO6s22KvUWupTt7vysAUK6dEFLt8sibs7a+WaF0I2DmaHEpp4d9UnOtQat7LDJcc1TTm/mIpt47JghYaMBGiuXAaUOS1IhaH+kEyhObxItdv+2kh2DuIf6BogvAo9K8sWei9MpuhBhUy5q4lUXKobfQAKgCPeoUUSZQBsUwo8NXBAMD2PmSYkj5ZMJCn0zxtGaXdZ5cE67nkZh8bEzfX0vGZmecAAAAAAAACRnukt+F0xwPFfRJ33z7NpkrRGKDltIrseNgUMAYhvjSpaagHIArUHsPfEUhnNs/x4DXtIP0ZUJAAqlk14OTqjNfodLGGY5I5neBGkxHiWa0IeJiImkbOhB+sPvl5q2IzQNj/nRWtC+XOmZTx80kR2C/uCeLN8VLfHE/eNBDzrqFOZHjkg1Kt65dc/KKbk8zWERINWpu5XOvT4LtqGPEmtSG7zyCZ+ZOshvKSZCua7JDtLI7rCuIPR9JQx3cJphgA5+Z1u4qEF4fyUm71iGSeFnxYCWwnYxtxuw4W2fOYndByWsaStJ+ri2S14F+Ton8YfI+/WGVUtScAH8K8O4wCb3g98gK6x4Go+p3Ecoubzzugx/ELs0DCaAJACXlMh7/EFtgXg+BFv9Ofev2D0KekqYDCgR3xuErx53ezSCF48W0UgfH7+HcEiG6YwprCNeT5J5lAgJ73JlrjH9o4eXtuhA+U4p/fMi7W/p0iY3A9V3lf1AeYGt0al6fkEX8jdarMhjBw7tFAFVgmbfkJ4bp56DCYAO8cpsZUDblaC9Ib3FhDTt84ed6ueLNCZ9tuuPnuRFFbvWbe/wPh1CryJB62ANjj5H66QdxGkbmGoJAbUqSzKh3O+xyupH6dtzvbvb3DHmEOxyXy++Hs5zVLNdkYPFzxtjfI/BFTQklIRLgyVI/8lv/+qRfdPKODN+YxUqzo9tFB0FD//nZcH1vSba7KE6kUbg6vW0iLPN84ahpnqOZz/rMfhoKtbceYZUO4XzGRXj1xnOCyx1RRBg48sPZWEvXBDzDm59n2f0tbmvUYcizz0LJp+XRLgWcHbln2Ihky4b34TUfySy4I+c2nodWgg99ZIjc9qRno7WTtdeGF1n9K27qgiEIKfWjYroNmczcmmK7d8WPM+lj0iWULj7+hfDv1WdrORSj9nRhHPy4oR+on0y+yFUfKOXIkVjGS81j48qsOraaYSiPNXkFHROr5bSU1JhlWjt9prjzEE2+VvapaHQZtWpMw7Ck/ohKdAJvdb9VbEK6EgJ71elMyn7/McfLBdwJuDy/caQ+ZDkAqStasDtpXeNMs/LulrccKygdDVBnTQVjy8obB9vvPNLMteISQ91hcQjDC1i0XdQ6tkzWtHGgphZ0+m1zgNYTuFSom66eR6YHH2g7fog0FqiUEwWa34OTlqshlXh1zl5GhDCLZo91XKJvulh/ZazKGH1H+2GFGQ7+kIt+D8WXayLwOM91iNPD1Jw/3Ix6MHSO73srkTLIXIFGzqVR1Gl3aakJpHf9mTVoZPzPD/2+tjYqe8Wr0KIqaXagYx7QLut60VtSDSWo3ZnpBAJr97kuKXdvX8yZH+Tusi3+Rj0fsE7v6i5Of3Vn3YwsEpZL3bkZyt9AZZKgHIKIjwbFz7qA9X+o+NM4rdhGpfD1PABy5lEK6UeojkYOuStG/Jrs9p8sBG9DmgZumuqmIJNtL61U80H91TLiqAMkS+jBP0y5UfKPbW4ga2kpqRTGGZljt9prjy/GuyPfYEkyr72IA2gtdfI00Sgn7eLjYrhkyCDGvJrSrs8pfI377uH2GLPRppDDrMXchA5WPU/R38yrZRoHVKOgJ5236lcTFF5SgnRY+AD3ZCuu2Pe4YfvKxASrnJTZaEV5MbhLpJ7yF2my0zWEXN1m+WOhB4/vuFidk9K4YAKRuqN0lfKUOvdsOgc4shqeIWpI9+lD03qpBfCqgX5u/jmvibjfRKfcVgZwJ5C7prIaykIcrx1RVs3qY2zMP8aJE6forAtuLfhNtVYcSMmIcrcCeiBW8bgvYSkJpGtsKMQEQ/UII1gbr1Dvj5jn+iv2r2/pzz2P8qaQHxpwXGWWGDL5PhBqkSGRhY3q72FoGxcMglIJBREm8p/LnVuL9Dk7YCEPgaFPBvhhSrEk5fiAf4DUt/gYEmkYMwPRdnT82ylYjQ+Iahjys6iaItjOS4VOdzDTBOmRKY6ZD22WCdmWL8itpYtkt59Uh/bct11VF8miuAeGPViJ97I6Q+fnnQxwTwQXLyWWRulPlP167bINba/eKfbkrc2lw2tEhqNO4tQETpup3t9q1kFd6WTaIFDZjEI9mCqE5QHoooyoIyzvV878nXAG7n5xcUkAtM/4q5JyIz7qEJWv4pKhi+bchVmdgaUvdSL3ZScjRKPBDxaS8npIrd0x4UjEnwi4tE0JalkFh0pjeo+73OvA8MG7xGrEgO+NLr7+dQ5bvjj1BqWNY1RyGUm/kdwAgn+wQPIHy641YE/W2IkXqVfB8X8/FIHUHpOVwxdQf36kOvrUgB5Uui0ANh1lEejD56AJ9+sthmdAfEaorK/K7EDs3VUSS1HoaRK2HXkSkbWjyEglG+2wRAg5WSJqgqJyRkkVsifOeLIDmlhd+/mebUS6yCf0cDIdPOtu27ZVcABBt3sPK11prTdbiQdnvk7Dsc5A7m1ECo4gbKywva7LybO40LL1PuTzdz6K0xIigvrjKssTfbc8bGLP6ECTJCCNWYRRiIoFJQsXlsUiB+ANSspqGwJAGa3yVomXiTqgnezwN1m65gxq/DNSjxESPoFx9TQaMuik2CIktGg26zNhkCBIwju5iqmR977TwL47IAI/7ysxXxiAWWFRx9sJFsVMF4kP6ZKGI5Vd7owybhR+qz6Oi2fiVKJr46wuENfV6a5FDDeiK74ZFzPp1o+9cOb7n3PnEp3/Tw4+tkVS3IsZ5DuWNZaic8GzpejwFcE9oatfSeEehhK/GoeVYLc1LfGYVncIL4eBa+9ITZ4E5rpCbetM9xGHgzCkDkQ6PmRk9O+UDM8CDkY1rLLcWlZKqgYpJknnpggm3803Abd8lU5/8o8t2Ep7iUYVsFMuiYQAEmIXEMyxrDEi7jOYcaifrFGO1gL7rxO+WRFFHIoBgQFW6zmarQxrsIaHuBDRBMsu99QagR0Y5qnCIIM1nxaHKA7un68+36dhsR5Gm+sfQGhauzXQI7XZwjQJhNmkxnOCPj9+6rMDDt7e44zrsAbMP5eR4IxQAz9KKynvGF+j3WctzZbtj5NTZzWskg28qLOZxIXZ1ewBI4pjflFZKpTjNuv4AvT5pNSb2DxDOG2/IYJdQbEwnPX2yKkktyRc3KK9N50zvVDNC+4IEjMikfAz1DPByPqUyzJxPh6sRDEKJsU54J6DvpiE8m5GNJTDAck2WyhqJLU1ySmE2RiTKYlpiJ2BHQ59iO131U4C00366gGPP61fuSTIvtzIYVj7Y4vSfp6yp7gRLUDlZZf1u6rCvyvZBemuTswY2xUfxfqtPwFmjHjaCQkSBn4cMoUnm3wbgUs0Yr6kzMxv3mfHz7o52ywwQiWS45q6XybGsHYRA4V/ik2jc88QyIUzsA2plSaf9PYh9+3RDyKDyxCSqw/A10FnJHHAMzMJsB4yxlCD/6TDsog4D7rblgx72ZlDHx1BnSZcN78Jrg6AZJrIzqn4tud5mFO0eyLo/ZcCmWCPPPgyjFs7/a6w8dGM4Kp9HHc3qp+Tcno8sPZVxzfBMXyE8N1BzvSmuUXYj/bQVCed2FzwglD6ZGv07Xh5I71FM1WTde7I+5qmWK/whEZhe04M8oxqi6rC8DS3nrMx4D44qmI7eOwRPjtGzk0/Z2TTZeperixYm+PZc0o4Zw1FO5wCgwbmoBB+XCBoRkl5BIEmBJiGkXJ/XyrnXE5WG+Gc7P64l2YtbBUZjA35h2b9P0blwimOheCl9Prf4h5HwY5VIi0ByoLxzwDPgNbKGp3SwmJJqJbzhCODMIap4x+7Z33U8YyPGgKkt63FBu6+oncUAn0LUYx2hJy655/m4rDLAn8pcLiBYs8OW0nlpxcJthrl2tepCA9tNx2a3cAbS5qt8RptzZ4wlM0MmLTuAgl63U2eNHAv7KmVi0MQUxdIZIlv9dgxG/jpMRKuFEUO1GBEnHBYdSMBDkA3VZpdQsKx8IXBpbwjbcKvxavW3tCFdN9eEhC2L/5n/s6w5hdSPuX2ypK70awl03dsijMLqUVKcRZGzaAAAH85nVcHaLAAhTAkvlWJmffB9E1rkWEy0MVCpj4EoX3TjNJJUg1h4sxqV+D4b1G+XHfDLZGbB/Fmf47sUXc0gbm/HlOSEC1piMTQb0+IA7341f9BHnyfV6fjs+GSQb064cnHjhzgJOCtW/JUxCvyabJoA4kMs1Z0fMy8LLMSyB9R/BjVColofH2Rg3U2RXGWZjEiUw7A0aliwwkUCrhMTE07jnTCsaS0alCLf/ShoTmoyF8WmJIu5mxmttN4tHuh8eAetphLzrPfZ7Z/6x+cQLdbT1p9b37zGZCN3Nh4EicGM8rTYvdETPTcmAJ+5iahvkdcBeGt+rsKcXdIjihQXJ9BZeWx+4RA8o2IY/cYQ+KFcp6lRHTHbE7i5IMGrJmjnlEwa7HVTQluIP5I/WCb7FDLRCk/f3BO7A1+/LJ1GY+u8lysi0n3IloV6FZ8A1pxf+h/G1u8MF8QiMkYLgubeEDswmuq3c3CyBiefd4GZWbVghPUMJ0jauFRmCphNi9dtvWViZx4OopWZ+Q5NwwtQHC3jxUd9lFvBxGBCt/xZNMixiAjqYDv9gplDyOlDdxv7yrN5mEFgO6Q7Izx7rOfE9Sm2877O1lvaj4WGJkpQB7OArUnLOpUZMAdx6Lg1dxAbvWcCsUrAH8gSY+c1sqNR6sykgW5Jhq7lEqdO73cSmwozmiaYasSPGFBeZpP+fvGDsW87QQzATEE0h0qXeSUAHevox+OZ6EGujrDe785YRRYILmJDAneQfdup0Sgfru/UWS+qHjE8ToZ3UH/zxOAk3uyk/+/PYhu5HoXO3ZGPxxSP16YnjpR+lj54+UL31esuG3ZJ3qCrzsw/lMv7r6QVG2nVwmvxS5W3TQOm5L8MsZhG3Oa0z2hXeA0J+GoNzrzVLbOItxR/RJZa72g+ovEBnHF9YcZRbZPXTpdMcFf0HVnIl/KA9EEfTte0QRtZjgxlZZM05d1C4cW6jMTiy1Bc9Zz3Op/AcvYCXjX9Lqhk5FWJYkCX/qaqEHX6zR9Gxb9kbjpmFr5jpudwhvQtvaIpzXDoJg3rkBGpUxA6Of/6PPRDbVp0Nj2VZwrMiNiMGQeLtN5Zxy3c+EtCfFcPyI8QrKZ3bDZMVzuhsGLFaIrOPTn7IBjX/oKxs4vHthY70Fe2azcUwrd+jlNHo9GF3jvTxuniCvphh7TkAHnndmrCY6/X+HIyuO8RqiknOLlJJzmh01Wn8pOixV12zJmzPcA91RrF8tsYL+WqlT0g8Etcqfxpd9EKgva/lPJFLBWMC5HX2FT0L/C2dNy0Enk2iQQChqM7UDZoTKBjojEyoYB3ug/lm9+bsrDjMeoiUL2RoALRmJc61oGBY39uIjuXW7w5lB5XI45FgcA1PWc2dsRdHPFI5ao7ouOgI4NQ+wq4z2XGAjnKmKil3c42H/4dBsZ86Z8LZecxR5JOq6Pb089eG7Gdd6QCAnXXhk07gScMnOkrqCdwrKCGamPKVPW9bRBWdUMLu2pYXQlm5cvAcAR7D90cVa6QMNKK3VPp7bw809UJ0PX3bmeoYiaitUKsL1K39ZYxqp/XbXdIahbIkXrdaSzWFwA2hedFa+gpTCCCWG4dZx/hmm7PkwrLCq6PZDU3pLZW36UBShqxu2BcjdypAlu8unZqbqcVGuidd+/5+2G5vVJ+YTdtNQkdQIreIP8b+xDKIg/lVDTKDiCBHmxs22V+rM/x1YQwLNaREyhQUJVLnNruwG6MxndoTVurcU4zxyeg4D8KZtvQdwNdzv1DOiDih4mhDEBx3B415Tkrl61YBsM5Q5Fh9yjwWhFsBtg4FG1+GoKRfYl8XU5MjRg1oQI0TSQFI07/0RqgX3AidRHRZ8xhjC3lRInGwn5+rSDm6BSpbWbvxPE5NNzAZ7NfLdG0ZtOUipaTlS63WhDB6MUd0SnS3/UQ8I64kK9AyZVOwjIZY4EaeE/90tLjPHJ6Vi+m/KpMD2OfDrB62SdzG9KBH7pZ+WNsgekEO2RVwqyfbYiG16cKlKvdg//WPEEg8Vw2a0XgUth4YaWUZ4JlmO8Yv1fDwh790laKRdBdxJd+pc1Md+p82FJavwY4ZHZ/PL5UQamnhtxQ2+LqDpweApK6C9y4PGfID7qGwb1igBDJq7VPR5AYqaI7ZpI06h/o2UB1hlBLWkdEcZLBsIf+9gm7IeKuu55SfORpBaFd0RG03NWN5aG4EucZBdiRzOyXRuz5M3Cxe64aDgllPz15gSSCgdKDC8Z0EjYAcolIoyp4AGMPq24k5n1Mjc12eqfrlhyUmyog/Iqj9BPGTHT/ipShImBSzpudGsBNFFPGoFXtK8joCsni4oR9Nhx+PwD6Lke7O2srwms7xEWFevhHHWA3APk2jjxufzkAz+dqI9BPz8RCL1mh9tI1E2e0w1c4yMlPPUs8xODEU5KkdNlBkCccXO5n/5nVcvvSpcSXuJGgqeSYGuKWxkeJX78d0Jouom89Wd20E/+kZPMGi3fUWUUfFvRRJg1ZxR0LNOOkYq7VO4ViaLPGsK+/s7gFkfSQpVS6AGz4M3sg/g8Ih7F55bS14Fd8byyr6C+dHKZdTG93lVyc2QOI/MssUQCcV+liMkLG+3SBeZQEiM19oNU0Yr/kDo3wriAo9TOP9B95GRZi+K5bYlASpw+aYLlCEqQqu3TMUSp/qaMGnINNJbEN6bR8+l88nUGUGnPhKd4dHRtP+DLj7QpbDZJ70CWsaHQ1f5oORAsNsyjzOvV6EmB766wDqru2VSntzvBJDrXFT1jWr8AAAAAAAEhmPBLo7R0khBagiUtKH4FFCuYyYzIAAAAALA/2leOoNHQAgynHI4bdTVYzVTQX42aUnABfj8DrRhC0YAxtzIrb0XrpAxmhLuRtar7MzfUxSLnSxOhiUYukLmKjE6mKNHdPNp5LAFO9NDNWMsqqrOK59pR2f7ptxdWa6T69yvM+3zACAXQpjLpE8nVAFGRq+iQWBnydiai+8CfokfP/GuNzvAkQwmYaAUUpjzDV2u4oJcb+8yJE2ew470x4Pv4P0T+B5eyemjgX2SiFJKHP3MD3465eG/c775WoYbkuKFisL1mf91oKi80afJrHe8h11JPU9pA+ud8/VBOQFl++u43kAKXyT0XjadDlEbZEJ2eDqIPI1vPn3ZG9Mkua1ZIMqg1GT5XsqnHx7cN2FzenAS7vsX0Q4MATjKh1jymhpFAvilAAmMTVq/bC4xXZGfFYtd3swHh03TVyhnO3JP+KFVRdTUFgh8UPCypDAcqCcNdDk7gHvshAMpgaC9ZfgqAuriNorKNfP/VV+cGSXtL8mdtqRcHFm+iqwTkhWYPtjNoqjNSUfhC00c3UI7SH+ar6bhM3fCeD9sr4VulWfIsfOsBMg+ayd888gr5r0YbebFruUvbKy9wQOAv6hQpiuSEkPsP+YE3Nq2GRB+2IO8WCTbwJEMJmF4ZXZctrlUfb88By8rqqCK2XKSy+otD/HQXrqYijz7VzlYb++P4jd982+PpPIy/jVZM1tcyY5EJuVOqpc85rIcZ/RlXglL9cdhEvXmU/Xl0ZFUPTHHcd4Yc9UlurigW9z5/U0H4HQ36g/QVHGK6ClxKFnMpEx0LbENx2Uy/xeWFoQQ5ri+k+8zRFWoY4948IEGQ5PISMiNt7mynIv3X8sAgaKHAE8/URqeTefi36ckN6j3c+EZRFzFpUgpmHIBdpYa844ACY2kUXQ/EwpRPHd6IWmkelSdRFA227JCZfjv8MC6KvErZ3kslD7ECWSUwObhuqyTC9yA3pYsvsO9EUijFBi/K9iuCzAtNvpJmKccSLb+XtFS+UTI0IjH0RJwM1QuiZsZpq06++ShLpBVV+22+r0qXhwANa4NqJSmKNWL2DPB8AbKJT9ZkFh6gpSmcnIctS2vj0B5BXgN+K2zReKMfhjZal5uWShCUGINRexGmfVvJUNjyA2Hb+1Udf7dql/ZHKrljSLptoLDz219IsRCLCaffHgRr10TujGKkU94a4CP8sIHT8e8h4f1shTYQg7YON3RLd13eVEvmONpS2k8Z7tkpx+hoh1oUOOHu0f5CXdxIp8lFGMU1WBJKvcwPUCin0d3TToouIrlEqZiqS7Ln7eKdB4vnyqrWhM+fsnkBNF+qJTgoXNGis8yOhQUoYIHByH7qCMgkI49yof1CKqnOOXE9tfgxMKZCvqOWhSi6v+5r+nNfXOFe9othgxinGfzLfTOkvkm1kYdLynikjyoz3JkQnO1pA4fV5T0vtzCMuvozMStKdj+yzTHQg9dtfQT43+3YxFxUzI2QXILkA6c+9zAzpqF5qbbUh/uC6dGq8fpk4R8zdRvr84KJeA3r88Bt1e/V8vxCNHKZoCX2tl7M9QAAAAAAt9pdNZBgwfePpxgbc4EVooAAAAAAAAAAAAAAAAAACHTadff051kUOPTv9UzJA+CYW9Y5cCTwXL9Rn8znH43G4+bk3CLSBWJfjxyfKDfx47HtTW0qK7QrmyOTSgYzHf/DRYHEUUOoh3aOuGxMO7rn3V/hVeUcnC/fBCtv8/+ZwxQOclLZ5egwGz3lZZ6wfgCH8/8drzlF+OcHVBCDkIxVHEaqAB8NbljTbdmqF9FLUuZ/vHNUhf9sj3cq9uFrpRlQkx8ztVVBbUhHmCjVGFJxADufp5TdcQVQFShcYmp7S6NUFCKsOIB2ikJkLafoEhBc2Mv9Tv3s/drYsxJe8pBj3H7B/KPib8jE4LCn+4bt9ZJ+d02x/SouqHN6EFqeOdOvvwwYsQEVRme7hRO5PMe2ciegrCMQWaRykh1Pfm8mpQnhl3TLUIJV+Yx6oUV9Yzo9pnst+t8HQ3U4nepAlgN5tvQdSLGrwl6wuP7u9GGnZspH/jJpWy6SYJokypEE3eia3xmlUZZkzWUTtf8cVTjhAGma64aTU4GPCn+pn/zRo8qc8dBo/fBI1z6aptCo3cqkBP/x9dxdgedHUj7o2bqQlafdnd7db8ugJBM2YBbXDNN6N4zmvXnPRTNkRcanmUBubu8Rc7IUGyb8cD9GRi9AgukrVf8TX3sxUtT+J53llNFHwY8znO8FJ1EHOjSpjvItnIxPyFq9C8EuNfk9fJ182iljU0MpoEj8ufxAYdKePMZ3VczdImDg3L32mAtLif03a35OUc/CUVTKLVt7VRATyzCUIdmrwxa/lHwd5NsIYYcN3ffrmDPzlXyXeA87qUryRMgm2hUgAaF3I7+DEQ49Eo5AOT7jbrzcNZEHzgsyeeBJuZAGkTkxujQIJhIsp2p6N98br39vRBWWR9XXQUPrwEp40+IxepGY71NNy2tP6cbnfI8ZreeVzgcUeKXHvKBDRjA683+GjidGr7dejRf5zKB9JWqjpVPsYKy88dSIYwzJvvK8Bhuprbc5Rn07e5TplBrMpWrWAnVK8ps8euZMUVZl/Ks98Ip7nZLq5MQGcbs39x0ADzIR2v5k+nT10C7nMt2ADEFE2m+izpow9cqNWL355AAij6qGTc8c3cF+zJKki9DWqH58H3l4UWqHlu72bVKF0VsqJyoGqJT3g3nJkcO8kYvGud4Qyz7dIND3Lto3L+/4Ks8ZY4dEL0+P9XKZ9usjYkN7xNI7Y2EyHjXzZMOjlVP5OChxYfjMVOXR8irmR/aN8K9w/NqDe7XE+euTcxR8EHHww3XxRg4ZRq8JfLmP3bitASQ5+TH7S+adhB8DtAekQh8W5bySz9pmDvwszUns9HYGmdfXXcZre8TSUeWaoz1L2sxEk8vz3xtWa3dXLMLWpApq2X4nrKgF3cXOWfJk4VKD1m+onvZNUj8XbuebQ9ITe/VHiTPGcJMZ8XgP9mceITpOMx8Sr1JCJ2l3lunHbsOZjGs/MxKkP2LW7nXVge6wcwhrl3T5XMMpYeAH/JaEA4Ws/PwI/4gVyO2M8dMoCK+SwE9JxsU97UVpnvEnrh8GlUv1sSRz7o5nd0/54OSCiNLqp/FzQIQj0FvhZViwppyKg0TNN6aK1itHX/GpVMzPxk/vKSbCvVVCs5XS8AipHSV6IyamnsrkbJhd+iHWABlcujUHD4FaQFwzc0KUigjka4WAmjh9uGQTeV2ISOHNzEOLDyUqG/4JF63CSNW4S0ik/uyPm1rmX9DpLo35t98dvkenUpQ9/Fzab+i7+Fa6oXlAoySQHkgtq+FupHSCAvybpsB++WGKl3TOfFVEz5s4n9I9usPi3LeR7FsXXV5qv2lSq9XOyeZvdJYaHbp+NNge+Wn7b4LjhAor8e4mcKej4MeY4A7UhsCY/AKm2Lq/lqjD/+NpDmsnWl6BPFqjWWurileSJkE20KkADQvRO5PrZarBev8xcsbRV7MlDSHimvXhXQ/JyKEy5rVcsWTBTYEqOE72B9vvKc9cLG8eMIksJLpesgM5fVtC2/zLPatw2yw4omB+LSo1djJzLlFkpoKEhxcnpZkz5pw1sFhflCmh9dULyb/MOkL+gtkExVsmN5mFRDwjr5xkrj3kHuPigPFZr6mxFzKhnQwm8Plqjc/I229PSmnSUUsT4LgBTbFibcOVN+6iKU7a8QCY1ii/FYdPU24Ulk/9EgEUIri24ga/BJfQyj0/0srqDzQ6GsZmYFU3E8PQnQIDSx8EQkQdBP2KnaTcXvPNViANf8B+6YQyTloQQzQJuNNtUzPvvtJznY1um3koEQ5pOw+yy0r2X9mJsmvMfr4stAEulNUXrQ3k7oBabPQoVu8Sy8yUPFtJjp0YPtdEAAAAAP/8ed///ikf8nH99fmm/8iXhs6G8e3HDgn9mxvk12yapqbDGRHJm5gnJR0mzh6kz/ixYdq71v7h9c0GKGMMvZ49qUxw78tX/k5WOFh+TvV91I0EhVfOwXDPoQ6Th8wnQLk4BDJk44TPdofYJBx/OWxN6FeiaN8OuE8WUYDUin/o9CES/13gfEPJtTqMIaSqvNo7eJlSD6bx2pySabPztLDL4+ZRhsLhhy7C/QQJhutJetplKRyEP+f7btlRO/Hr0rgcTCTrB+xdcz7AGmcU7jv/qRPqIf93H++vzISV2lv+DfJIZkzTXDtPz/XGeBc8uwKtnAn1+KF893oj9uhriGMO4MBJlAlsa0SlaQVHdwEULu6V1FQPDT0Xr1ItGSbPGNTbhip1ikcsPxnbBFnSxpD4W7iHkoMrY4pBW6N11hX5U+GCWhYeTN7pdV8z+zJFQlMOJbByZfVOFKuPQbEQ1TdUkwwsv5e9i56Tj764YENPfzNp3I+m6Zxzw8AfokLTboUBYC9K+S7eqlWkWuG51IbF3v7U2F9ByY0pJhYSZj5HdDn7O8xylrKyRVDQ6f+IMKP1EgKcsH07GGwGIAce6KBdAKnfvVZTrdAA9V8Qg+RiUEzdhMDPpMzeEAqGnJBMgVakrm+sYE89Cutodnf4rl192iUQwOIMecRogUsQ25oSBuRmRWYcEnbYwDeT0P8oBdef6xIz0589RV5CsN7mSIa8aFJvp7VxpSFz/gIwoDKu3dAHh0vdYxeQUe//dszdEm4gjPfb/bAVQyD31q8MK33YjT2i/mYUcb9J9Ox2qDbrwCszZ1PYrKFeQ3qJNVtyDqo1BSHOELCpBv8WU1WVPnOnmc7YuYjpCmvlUzGNVyNq5icSIWcu7WG7L2NiCKtXdQlDxUgZZkN7yx3A6DtU3UzncZXRJuhhCRcbwidd+MJ8Hd3r+FbpXgg5xLlCCzkYKBpqDzo6/5Dvf+3fb/cJvI5Tb4iWpP2YixHehRtgEWouU1zBFQDm1ZEYQznYhcruQ+ePd9UkgeBIpwg+B/curqiQP7dYPvmNvdDuwF/IfkfryB4txVNpRTAKI4gI4DStBVEzWUGWktv3WNHK4TlLXgXPPFAvVL8wN6o+AexoE1d7u4+0vwq8hWG9zJEN4Nq5qNB5iKJQSsSbKQopUPueffA//h/AS4qwsuLt0ZW7R4OZOoKQBUeeF84CUcYvvfz7rOWYS+r2W6/hkBMGORhs0qi4XJzhOj76wx9UQA/3DUqpYIhlFAAAhpVDt5cVrHw3/397QUMTTNgUcFd7EwhPQgaqnE9H0jf2nhjJuty1blrHMwbIVlawMBS8AWWNPnf/Evx0ksYeXDJ8glFv+6C3n4eXYpW6yEkpt/qV5x3OZS+HmFhGnUwJgtt7bmJQB9s1i9/teUbyD88LEqDhYOZjTBuQDyaEmxHIE6BjnR9xuCSdH1wgduVldb0Plu0/BubnmsCK2tbujd/NsgCgv0ZD7S/G/qSHGB2HSA3jzCWgdUj9kgxz+3qGePy0dDXSPGnesJ3pr+sHEH1inxGh6fqRwTeFiYGLZSHVJcPa8HqA/7wKHgi0Ci7wPDEvomIanIp7+5A0R9OOW7ukt61ZkdLS/SDhR12/tttBJXzX1aaNx3HeXp8Qq5Q6ub8uebuXm2TZfUIIPykL58uKbjMoXgptVRUMbVZaRfov5qQbzgKU2bv0UBjqrtOBYujk1YqUovf7XlG8g/OCxE+hIAO7wqamRgAdcB9Ix77GyVx0uEMuyWvpvskqrxPBa7mu3bF0yHRWuzDb6tAvaR2nchHxZJaLHWpftMdIQQL8EVmbeyF9YRPmx5BkeyXzkC/gKsLnRPQHQEHUidJA5CbiMppPGRYCSb5N7lg9q7GgtJPkcWU5mQJ20gwaPcVFPPJ3YRv7ggNYDx0VtER285EJcxmXsTVGYmYOHcGwMTQ78OGC3lAx7ieH262frEMHvxggNdnbhMZYUdWg+w6GoirwWmKKyHjgK+/g6XNREzBx9csaWLA9DHrfUCTj08ED5q21Vnr3LCvl0UZmmCvZIoO4lwgSTsPn4rh88BRn6RJEXaLSzYJ2lvUkM0rBFxEInkZ8SKWYk0BDjdIu4vRgoKDEA2SSx/avaGJ1Lzmkzu+USWFt0lqR1fuM/T+kMcH4gV5KwsZIAfzXHTV5EoP9id3btygOJa07W7Y98nvcvxdmj9jkWagY3DBMjYj3glsJ/8h9AaS2uaKnK2fRcGgYMOQbkNvNlbxfw8AYI32k9HjaoBy/uxKXTzbN+hNirkX02AbSKJ2i3oNSk+NU38tsCAZnIndYY2wQZMesXGMJ1S62cK4ViY2p5GGCWCB69+ITFwwvAqN3f5hVzeM3K1BaEQB6T7jf38mxRm5UI60Q4X2icbcBfXmxrjlDRI2uNAaOIljCUgK98FSKM+DIHuRnBQuMa63z2q3rJWha9GeXzOovaUUfUy8buqO7HgWejLj7rMYVPpWYssAdfgSTR2ky0+0eztCpTcDV4N5AACcZ+yi1Ukt8xwdvXebARKVN1tP0/AvGH8j5jvwsTGVzmfri1o2PuV87OOG3gmoh9QvNlGSmroxYMOTp2nvS9428q3TTAzoqC+SO7cvYA/N3b2PAibPzSRqhzOW7Amo6StkNR1q60TYfqLordwUiySucKHxduZFKnvgAmk40eyJNCs9j3RJ+g0fVAfHHpTbKzPndl/xYjJ7FwrsgFUUY++yKv2s7pge/fY07PW/ahZK/dT8D/7wvIjzYFPnXKEsqMN1+U49/uGAp0PP9Io09kqr2BpgiU/DSJ31B7tGAqRkzawwGvPr2M0x6Vs6a0gRrdphwu1ZIbfD6yFFtULGI3bKLMq0RJUDKzqpYsAPKmlknD0LokX4KK5ORTXLwxpeSsJYCvvq359lPCWh2jDWHqIHXyqraAFjZ5Qua74WMjLX2avbrH/eO1Yvo/eifNjG0Yu5VHiTVyZAZ4bTdmcc5DPBw2lWBH6a2Ud9u5dpuJ/EaokILtN8kpHNJOBsLiDpcZpDA5GDDNK0gTjv0t+wjPfcRsu9RCY0ppgx8/u1QHGGK44lqAKxGVgM6KDHwqBJVdy0U1XPxwKJgVwm3vg3n8ak7cDRv07Zxlzw6TeUwZxouPTQTtQCjDvR1dARSsXxmJ9WntCAz1hjBVlGcp8djRlkkN+uiqyoFIBf/Hn7s4uWjGh0A0xv2E9CZ/DdmuxyCKmjeDTurMSSWedbgBh1vNXtlX4p/jXixwgBGlyTS0I9kytfLYMhczTCCpC5Oup3c4YbBZBv6i8Ze9Xv722r8NaN9lYyRieL4yhEBUSmO7OuK4WrmPKpB3GOSsiEkN2VahJRoL9HzOiUmTrEksW+4qXWsNHxLbiITOODw2gp0KFvMYh3pvEHOpI2nKvF2X8lmxbPxgiM1XeaNhGAfIR8qUKolV2gtGl3vH0BGnSbiw6shthvwahtVl58CGzql/wEe2jRT+CBR9cSatCD59zA9Yo9OwKT4QFCd8p1Me9dB48r2OPYGb4iLJEYhT4KilmOrRshnIL9vq3okBW0d3eVmj2gXRvtD26v7sqdMEUMFvIK4GJQ6rILtFWFVIm6XP1/LrrhE6I2qUUmAL+7ukAQhyAZFWv2WkVkey0TN2W803LAtn49JeAHl2c9tSRVooy9JoTp4+pdPv84/FXl9zpO0tueiup7ExKinzRfPQrtQIi/+PGaHDO/6q1AUo2JCIWkORJtjMg0K/stTm8Xg7L+RhDCcLv/cd3nMCKrUU8IMjZgPSPKol01NkcfuFGYzTgpjogPMFq8VzCsTDyWC2dq2/UM5HbTM9Crzr1NDzvED1r/M23PBMn7tulc6fWOhFS01pCGKGUeT6N5DQvlPgX/wjc4EfyUhIiJchAddkFPpisktMUMvTiLwiN600zGeSnXk8ulBdafwdvSyY9B79SWr4qA7Ul2VwPNySWbqY8H74TB2hhLsycZcXmqZyuCF7wws7Vt+nHfYGOEKGbognkxS8oVehi3nWMz+7jrk/MxolKGfFSHltq5+kCQ3u+Zx3ecwCfCcjXo2U1aK8vjE5PB+rtBY2+fpnJML39zgD/LWAL17RX2JGaDwzKLOgT2ylbCFNKjcPUm40ZBLGwEqOwekVzAQDlM3ToiprGeirUwOF948WbYyNIvi54q5S0zF6YrqoLUCKEY/+oc8LrwCkq1lWqFM1WRcpQgu9R0nfwZoUzVZFo+mlmSzYM/ctOUTd8/SDpzJ8vV3mO535X2jDuuOm7gRTCew4WxeAP8lBRGpVQdDfYd37jlUmqQN6TJ/4P5TWp/mgp5dO8ca+qhpWX5gVr0q5cNAE2xFddRBzUc3ZaQXJaOaYx6P9ZKMTMto/RdhZvSQa8cOXbYuj6Uc8CULpfnsi0iQv/iSTHfGtpNVsDqiLwzwLLg24XBow6AlWV9FRT209TICRDM8KeSFW7t6YgyFuvmaoouO341K1CH78EFhaoxaCLcUXeZ3w28bVIib1Vy4Z0Uv+Q4dPXuan3JsOOaw62iCia37fH10FqEP34VY3fGth8s6MY3k5zOl0vMmbOfwhoP6jtpSB0ZBph9kXJUCkqTXYhzRlxhSi+82kf9hVN8BjA5iwDob0UjUAvHEF/eMP5IJN8+focGEifDm1j6Zx7twdT/1+xIEuhYCIjnJPzOfRmx0Av4UdT+pDnpDYfWnOWPfQlG7UkB5TV3t9snHfM4crfSoBRpLK9MaBC5D+6kBwQuDhMcNNfSyKvpzD60bEXwYWKf+Z4K8Or3MCVUZAxYWRi5M3P3Fs435h2t63sEi0D768iJ73GR/HkYtdhDlwG82gkC9S4irYc8QCfL9Dnnfv6HL51mCNjy58U8qpIzGNk4VIBPR7OvNb+lw6veh7QaZYMMy661SP2WFQvh4Da90erKlITpPLDc5KWZC19nPcuyl9S+XOrSIIH9dCdIWN95rUq3q5pYP09c1uNNo3E2P81gIU7d7sJWkR8ZdplszIYnyxjjrx5k8WTQdjcsHCWYWx4nEp6zBGx5c+Ki8ZaQQUnDobuaDQ9bvNTBpYRcPxtAiYBKhmisotwRgMCSDhNlVKo2fnlbyuUGCqSeS8vcEo3QGXoj73HD0DtgUSYTDfQofODrn6kbl7Q2wqReyG642ZXN1cc9jn6DI13cWMbMhRhnHD6G+T9rkUIIzK7jdBods/wB6zBGx5c+KlN2N8JTWXIDvVqnqQCej2dea39LwXFJCFOgfFyPpXdpLOS8kx2PfItKz5Te2AOtkV5otLiqpKP+rzB2wzGNuSeh1W46bzu1cvuROeCxoev4GPNF0d5Kd4vVkti4BbgHFmOBfvxjX+I2+nJHwpjpBAF2ImoKAZ3gCqi/jG6AQredhqzDKuaSf0oiCmlFW3JX2NcQn1mV84Oj7EBm6hyqLqwPXY3r72d8CinfL6BYMQfqlwu5aWeHWEfc3Bd4Tm9Dn8c8C7lNEhlcnyNxsuMBAun4/8Ps920w7gpfPqrQrZQwveQyLuqFuOX4+Zc3Wfuy/b8jXShlrw984zlokncvFRh+XRcQigSLHRO9lL6YaQ+tftDH+T/ECamELocJF/DzrymxLybMaQx+VFEXGf9DEl5Z4NRJt83nnuT5sxeQvogQAQOKT9j0OWpmAAKL3tbdQG62LYyy45U3bXveFKG2kCBCyBQ5wVscZeBvPxvvwbiY/XJ/HROuuTZL7x4pvluVmVADpePJJMS++MZF5rTsotmdCj4GL+CJXDsuTq4Wn6LwMDhTNXnQdk5QVfffk7H7yLso6nmPBpCobOmxxv2WwC917SqLv14Q0pSNkw+tYJgfgwPFDGkQygtmdzOCysMf/ud/7Wf1GWcOFsOXM/4Ha4OILzEVxDTLBU/3kckKLlZhtBv/Agudp2FX89AoHdbV5kEB8aJRIwjCeT3aN9jrXzvsXDvDDGJEAyNvxT75z8SxfttcfyKn6zzrEmUtEnadPGs9V9YRGMGdnkehSY5bfvFsv/3x005dcAqFDK04cjxg/oGipModCdXmqUJ7FXaVSIsfSN3fVfH3XwXaXcYlm9T5HIjpO3kqLASJ/otFjr2qw91vkS2Wxq825TNLHwCtP+RIbJqNGPDlrW8Y5xgSJFdZFTNnehpw+CSljp8BjCyYMBgJAn2fukqZb+lz4f8y+8DWxOURxh3jd/Yw8sXx2ZkLaEAGsivyoAY46zdtqB4Uviq5IYUhsX22ZPuje6WLwHWplihHEBHro3/xM5wZ/G2lc3H31BuILEYStummLdbaQ/6sTysTMUXATQNov9urdCOY1BEzFRXgTUr1Um3YHn4ZKThnD9K3gmGjq8+2fKGXZwXCenAB7lR7BHIoEIRDE9crLn66msW2A4mJLNc8J6BQ0jcIw+OJpUqVK3YEHypK2EG0OGKbjdp0mFT4jp6dacdujyPWqnXR+6r9vvnBuGrHJOBVvZ6rELXoohPr8YpmZs4lBzZ/0Cob8MA1VhJef6xktPqv1VrRbGAKTmrAzzrVQW4igS0UY7h8xQg0IcZ87a1R/tGp8CKEgzJLVYsXG14RDXyG9BCgTScKKERI0cDtPDFbNy8F4CWp8SCvCJ2OyCmioOJ2nrNmoS1IYxqO/sPjoMQFz0dwxLZs8Z7h+rTgPf6nIL9EFb7RWpanPc/kj0sti3wKtD6xwKRlysyRGm/UxyYkEffOECuJGpM8lA1DcUkCHKTzr3H+CcT8bqYD7iMVtmqcZOmzjrJ33bjYh/L2PUMTiKT+0kg2CxuXlsRRCRarR6bpdNrQA/0CAAcr30WFykJ9fTuSafrSzR1Con0C0ta0dU+owb02OOI8tgEfkmObsWgOnYyT+YdNdGNACfyDCvoljRPMvBXWuR7JkfwoywQt0MmlfB4KagpbGq8na7O6uxzLDjyIa0wDdfSYRHgKkDr4PMQ3uLrLTgiGdXsDXFBBNFvSOBj5Rhy2u2uBhpg4w2MuEyCf7XxBDHBTbpLvdgigoXQyK4E3TL9Wx+plCID7NUmzARyB1eKfbXbDoPV/IDOndRZKlY4Go59US6l54J4gvX/IzEy5fNITscbqzWb/BP/734cmQCk6xPNt0kz73U9tta7uhsqG0SPthwuZ0zSb6pyyeZ4kBxpHYm0Jzz7ya0hVPslGEUHQk+/JsZ9Z6sdenN4NcZSVdsV/A0ugwkEy1QktmtClgmEytpjlTP/KVYeFC3UyUKYtL6j74IQjKkgnOpzcaVhvzeglBrKNE4rtVhqc1KTiNZH1Pe+KyY7Eu0cZYka+CviT1lCXqiA4U96QwqZPVGHRC2/Hzg5kskao/+XfPEhvhc2InCvzw7mtzZI9F1JsiSPsD7BUZ4QScDm6Qwl059yUA5TXA19xzms0V74frEGXcQNfj/aHw/LOxpsNMrtty8W0fOwzWKaqr2BoZ9vJcEZuXIxZD4MSP2hPDnd8wLd2RV3p6Ez7n8kcFNpYbAgQnT2zsiBLmMIHiE4xeUkIvo8arTkG501IKxE0+Rjv1TX0LOesHcMBhOPbT6ngE43KZ17T4tB5wbpVyuXcv0+Wil5FbVmM4nYX3wbF34LWShv5OOmI+hcPqXDwaNr5P8ils0s1SvNpIuxyvPYDg95hnn7x5R9n2wmdJEg1TTGFuPzp7sDLEZ+RI6pIS1VDEVZDiPOIffSOTRQHK/g36w0FJWtsBOzqr8n8YNhlh8GtJnpnDHLDqiOdsgfw2HqFpBQHhYDxxvQXCc4nIiX5zsQAH7gec5jycY5MwPArBMoJpbgt7H+Qj0ekB/kxFbM4GVW/xpcBQ9i4XoHFGzo6IvyWm2fkLUCrnYQ7xj5colMODITZv8cJxSw+h0jI+FuFZrCUqYN1CqIuBWnW5x+68yb17RtnY6nSaWktGMcOsHeKR9i7txlNaSJffCEdBqCth0ewmSSjSxZFsuZmLpgHe5sOysNrlSGD07q8ldlwSOGJw2GmPNLZ7PrXrXF/9ws8W2UIBgJ5pNpgQ02tsFRHT5ZecJ7n3vvcyUTR/jmrlc5dYiccpFpmyZoCSqjgOoO9oytEuH+UjmeukDDGG4gY+OlZ8i7bM8rR6mtuVKBEGjFfUuP26wSnxLA/YQ3Br2e87/RW9JMDw3be5XqWv6jojkGftYlYkQvSynLOrHO6kjV10WUEMQe9XS+6A0T6aIOj76x5hz83NKHirzHQS85I41YKp1LSI0I7JF2lbVdRsf3vxrrle1iLRAmQgvfO3I0E6JUqXel6hwx5rMPn5H/DOE8n7uVmr8G10zr9ZLszThyvJvHBRCixHe7AckdhIYfydlDEeKznjSQB/umfC6UgXM6YqA0hAxPl4ZQEBw4rV9OHr7+sGO/IkeaTWaNXQ9BHjtYAq52b/0xIy83MzUs3ilvPNDdH4G+YuTCyzzP3Tl+ts8BG6X4vDfItCXc+/VD6Hib/ooSgPMas+PxUYaVZeCHb9H0kosEicgFvzDn1xFulFLmM+3bNwqbu/9+FPXWEI0b0vGH/erVt6CYAxrV5U+jfj/EKS8czI86qd/bAFMBTgeuZJ7SHYnOtGrg9c59L1i9cW4R+ls+kTVNl4SrD6JQdwLMD3wEDMIV6yRoFGV1hgZCyjMGzsRnnv0lyOwVo6hanh6Mnv/4iWpTgp5EsdRwnRBZ7KNlpCwWyD7GmFMEftKHS2bk9asN4PEK9vw8ziTfe4JOhXHfKgwWk/RiQsXbh3EA0fwJm4LGc7QEPediZxRUk/g2nfcnwI4D8FTgnJEzPzJrRis+vaxVze9T+koQsHpzG58Qpp0n7kHI2W8yv6/XtJAOhXevQaCHkvKNfWzmbfgk+h+/3nzoFQupX2v/qP2beVs4unVAThkDm1c5eqGc9TEKABFPQzZRcjRRInvApDnxePfN0w7zibyq642ZUpNg91NvtZUigAACxnr86ZMAA+3SmwLtKuXMeAAIqH6FcAAAfLOMgkNTJFqhevuBZOiMfZ9Xzq4E2UQzoHXYPJ3x0ILXI+FolEPJy3I9Z0AiCnml/ELRyeDAWlSckhXU254nIOp8rvlsEp8iPPV/tmyTjfbc2RQiFpMBph2n4d7Mzq/CGYi0LvHzDf8oCrLFVWcdbtaLfkC/edIHdhmkrpioGiIiY9hR53YKz0SaD3Py2e9Aa7qF2kF4WEzR9Mq0pZmU2JTjGsJSg5k7XW8Yf45jMMcb351gJqfZs6lo0939w8FlL+WFUeNA0Vr2LqpNcRA36EMBJVVEicsgUC/2EP9XDgMZrrIzXbBjAj5y+70ybWzwsbDkMdTGT8XDLsAZdn0OmfhV0+JdeYC7OMEp6CXx+9ReLiaOGrFmi/y4vXVo9yq5wQqq93TJja7Y/9xTFwrVqVlw+V6D8PqymnigIAuklQjg2CGqCavR6bUpsYmpJoIcaSwEG3cMnv4Kre6QMSWT1RPXgD2lITbGko7vXnfxT4jImL7eOQEISg4jHMvCCZn/BmbIN0YJUI8g5ut03jWqOganxRJKwIsuOOHDVS5kIrbqzWZmCr3RpSckhXUxYf59XeaZelwhsrfbinzmquTHWJl4TzPgeiVLZIPcFva6nHxIuNYnCIEz2eP0JmCFLXP/zuOSO0bqHO/h09WAdNo58naBfAFfAWhe4CmETvU8RrmTC1g28jdEAZQWN6ZjZLiLgGqx/3Z/8oF4cR6dcDqAJ61T2nlXzGBOOD2BngGmeT6juUm/oAgFMVCHPlImNmYUS7XPEaC8FPDnthE2R5t8lDN00wlaN465RHAH+Q/CzkFQQbZdCKn/ykjJoqPfJNqbqf0BqTIKbQX9oaufoVE49/rpcr3+tVGQuhIhFw3P6EE7L6PS7aFuV4G7+yf2dr4TYmfj2s9hfeZZx3fLl4BfTgdivla9z4o8F4JlpAY8XZ8U0IKfxvJsXFTDDEK9uxoESNrWCrB/cgsEQaf3AnSzqqclkXZREbVPTKmhvvpRAr3d0i2WJ3HDJqx7j3ndOtT2reYZnneJ/z5AAAKNMi3GGpXFYjgZFXp+LB9/zqbKE3NCzlWbab09rNXIlQWb+LBNCreuFrIJjRk1EtM9RwRdn85BXKB1NMHmHoASELDyKzYvmIIA8ipUA1eLKtrYnrLeZw9et+Xs5qvLGrqY/sK14euapdr6QAu/dtIA+AGIFu64L9brFTQIsOS+7RZO3pOhKA6SjP3SmG0bIj9+w1EnYGH/e9V3lBZHiTXExaW3T+2NXn/L9GAkFuDAcJ+PVYgkvdkd2+jI2BJHoMqcoBBc3zXCRZrn/DWUoTnDK6NkvFMyiY3f/WglnKAwSDSI9Lykk9D90cEDwAFxH14w5HlJOgTq30ZYBwRrCGLuu+O3SZknEy7NY7T5tnbUU2e5LtntuNf0QxQ1MKZu39jfG2wxc5F/4xwThi9Ttuns8czFyVMIrXH5ohyLstJCpC8ONHTPCmxMOcK/E862hbCAOaqENLfpI7AkfKNBkuOxb5TZOyksQuFA4Y0bchBUq+QS1z2ql5jtuuvmIHO36W8keOqiaCZezBnWQ3Oe/olAXlsl+Z3cEuoFpyRGMsWEcvyKSx4ZCFJD1GgsBLz9t/pqehOh5uKF8Lm8mbfta92NDsGIQzmJPQQSOAZ3vvnNXaoyOBzVPFQsNYxwJEsJ+KZ5fpOjyKTEp3l96rqR9zxVmL9WVLa1QukYxPxs3bw6hyTrvJkyIaFmpnpUzVfglhng+1l/Pfei05mJ3pHceFvUh4Vm1JXjhcHNVLRVb0RJ+vw8dNv1Jxq6mfhOGAZG5q5kSGs1FZ2cL3V42lP1xViAfk5aSzpxu6JQC2COTleY47TVQpLK4Svet1+X6H7Rzpv19OYl5FH7CxNbxTdPEcy+p/Ed0X20ZLClfwxXhrFuVVgT/aUS7PSyG9lsAIgrqf7y5OWAxLsfI7Gbv+BghIBWeFph8ghIuiAFwt3dASSy/8KEPHr2Khzl2BTw4Kxd84SvDq7U03VugfKh+Gaaa1t0Ht6NxpZjLJkmISj2SjxdpH1Le2UWS6qOIzetQBlIe8WCfOJ7I3hqm5YdjXqh3LdRVGQc/GUzlJ9TDbCQKA5kYdVtaEta6suvltw/VhDGCI2QqCqKrQbW1K5hk0bRefxrF0i2ogRnxykp7C3ZLkU+Zr7s7pICABb359uaS4YM0MYLJ7Lnm2/hJYFLc6OHjd3ykgcDhtbNVwtZzcltdp+wfDY8yfQBL4/lFjLERdfGMnNH3O4cRR74Mxsyh23Cx89rzEfMm9n3TG5XunxSBP7d6MPI2zdrBmVFm3Kqtemnze0yAPWAqu/Jp1BP90nTPwNSdWOgOYBbgpMgKRRlRjhDbGVIYH4+xRSn0NyXJg+iTRvCdc+zeZ6bP9c8cUgaVmtYthwkWsKohZQfH2D2mYX+iP5/iOg3aSW28pUpQIDsaCbTcLYTUFCBzVk1wo4RPFmygNbuloOp7URArPfAnObKyLlw3Pku1Zryis/twu3DH7q0AczCToyMS4HLzkezeRUMA3ZptZUWwHoyi95zbS2kXGdBswYHYuo6Vv96eqasKZNQDxvc1CNlVAFw0pgMu/3anhZ55oxjyijdENFRbTYnO2TfYwAmb210RkGifmJaNel01C3zHcccDE5YdgH2xc0uiSCMcWtJHSszKw/DaCKBAsDmNF7Smb69TdFCJ2fJSNn0NIaHG8mB0t65ZHZtovRF6EvjORjCVLq/4pFydlbNJd31NIBC2l3ifnHpLON3bSN5RFb6E+hTwXPSkuBldQnAFL4IBBVI6/Qe4BSw8DxUeB3W7tgfxHZ2u3rqWM2DSAkR/a74TSOK9WJFH/D3KNsGQFrmlhw+krWf74xJBloPpH0EUrSfk9YEA6s3c3NA/LBWXvb2WPGa62dJTOWsppeb1A0DQnzCp+tHxUm0ziigXosGFqQRTw8g9ndbFsqO+wh1hUHHP0OaEFPe8p+GLaI2GurmZBYyugif9n509sUsvs0JCQn6PEUjBI8r8ERaHktFxZSxzUJ7EzHB5Uo1vJq0ApFgjl0oPxGqLXTuh9O/FbF6JuzxDMdoOAup01VCgXnRNxOl8mHfor9o4IKUcWo9NiVyx6rJVn3j/49eW1nFfBBKQNmhVDb5cDbOIFvGqQF4MMNS/pVJ5AzHsN7jay0Zs9Q7YgRTSmclP/A3QF7a6Sf73qu7LcuZmOpCXWaTml5sF+uL+jASC3BgCYAHvwPQl5vS08Abvc8EeY8Jo2gC87LivRjFc8gnepPDmCLVgrmTgp5AojE5nObfta92NK3V0bOURsmfgC7DGr9x8Gh02150Obz4esymuKqyWauM6qhXbFJn9KKznAS+oTL0/U4mROpcBZ7yqW5nND4i5RpKmT8Dz3WHsln9Du5CKKoDVkZHsUfs2wpS0dIIMe4C54yr0dNNIjBOddHwTX9kfKpPyKDjOH3KYG2RpJmxxjN93y2HPit/btwUbDvqFoLTSSfnCB+8JU3JHphbcAAXuduby+BzwC1/Ao9oGB/Noedx6TsitaDwU0M8OvjIqCQGmT5P7W3n1idpFcfcEPCj1ZNRHQnzWHI8IBgwYdWIc+VC7inOeukr5zCnRQgcF04GB5JCvfKn2k1uGfNICFe29GzNO2fPZ1k7w2OGHMmQHrT30hpo5rQLu03jup6NYQWuyh3n1ygGFqRiyPeo9CqOI23k4VTFSWdV6rzKwnnVf4SVkaMWyom7qFJkftMKSQhtfbcdGf7glv0MQ31PDmJNjLbQcvzDsP/C+a8dZy6LQ1PYJjSuTxmZ2kGaBmyYKU5m12lK3UFkJwy5soFt8NVv8vHsn84Hsa910WEqrAsN/K00rFJ7auR/zE2EczRqhEb8vTxSO01c4klVk8nLh31fKCa6mresGtm4xcelF10zrqSP3Rh2moGDY9awz0Fawyl4STXwgJv2dXuaTQt+nWdC65ul8enbWwJ/T4NpRvioTX1ND+DI7MzH2rJvagC11DItC5jTwcOHF8GEWN6lE/m2TLUYig0s9OYTHY1co1/tfhaGYM5dcXy5NLNLcGuIadou0RSDGKDy3xos35kCNb8I8q3mtyWG1uMxoDGwDpRQVuSnWhVCjOQ8UcGz/4m3fevdLfNrp1JZij8dAmjr52DRUPp+wAMz5kcrneWchDK2RZHBnfJDtGtVVKh2dH/uJ5tFAVZkqp2DEze9myAx2hkjtRfgnuulWkre3j7+c3JQt9AC5Itr9imnzZu/rfaiQ7UWrGO/tw0T55ifMM79d8yKL50N+BgUFk5pDXZTyD65gEih8pWA5+5GJ5F4TXYA5sPGZogD0H0LhCXA+ajn8+2GBY4PJQ7YEcRRsjiHKMIqImaiAJPq2XLaqbmu/tVQ9E93LlsOldrqUrAJtQKsv0zS3y7/z1bmLfTJhxjrLiw8ebSYLDSUwd0U78lfgQdK0uRk73LTjP4BcgNo48vOetWA4wVKhqPNftnqAmFZb+TSAz0G373kxFRv/PXAY81NVsxoX7mbsuXRP4HQjASauU8q5cfYN2T2g7iNLpDxQOzpvZO4CN6kBK5sVq+21bPFEr88Y+CiHOOYbKh8coHnpLiMTneai4LKfI9eDCdTecq+pwO8dvTk0leytIApvocFqXYET06g8ketPQDJYUznQCJQfCGz2Iom97AI/UK0GGBAbCvH/vazxCwig/Mftlc9nOqvgPfBQv8/9rziBQgxeifzCNuH98wr/faCj+Czkw65D6IzgzbKYjST+HXd7qgMIrxvc+knGSEEPHkrYRr8PQydSrq5XftwxpsiOptGxqXYE2wUGwvQtI4M9EprBc9T1HT4wCmmJkA/rIZLebxXvXimDCg31dh1L/pfmGNnAgRvyDSUYt6ZKi0tC448M/hRx52Ju/bzDl6hb81xtgbl5t/K061Qr/6h3roRAdymdAAaLOUH0GRfsSy50Q3GKcjhwi9XSU/QdJ46MHEPPZr7p0R5SHzqrISXzJAUvW7zWxQEtRdfd/f/vcukkEIzrNo9wDPfNdrJ1Tk3dTJfqICgH5oVq2djRSxT8QTOHuCdDywGMFVjxqmTDuKe0cNdcmI2dWr4iIFBqrNHHRRMM+E48vn/C2dNlBtMB36HzA6m62c49bZoDrXWwEg2FwHtwlKxo0dUIt3EeNQhpcSEV1CYkhEeww10C/ywiS2GizHrbQkQQhHDpTH2OSDOFXo+C8Gm/OiBkLCoXpWvsXXgl4sthADPzEQMhwt3VK6IWR19FQxg4Y9FWcFMJkridm69bufdHJkI9g5RSKfeRJwTRBDjRt4X4pXTGN16egsc4viPn0eNbSAZ5o6ezKeW2uO9Qx8AfSC4L/9A+CMSnw6SK3+/QO8zNC+jBFwwRaQjD0bcK5bPkfPZczs6dPYGaJl/CvotV06kJLQjbwCmP+IgKfBOfGF3mEP5i8l35yB2BW7u2GckFxis4F2JuEANlfLW89KZhRz+FoGLIL/XWAgTa6np+T1gLKs1S481tzZ8yfPtjsrtCCJFmtEOPeX2CP6iAKNTPoZb4Bmz959E7E+gLLNk//wL6I3YR8vcHLxeQAi0FYwF1c0wKktedym7Jjm2HkP7FcRh2BiExLRAc9APzkOsPFO+MUCJqp7Hdjok5TkK0d7Sd/y/uUl0HkWRADQlEsttyH+W7KbSzC4G0W3d81ROU743HfipmL08aLy5b0FZulnwxKA8R73hg1gtGbiy3IGoaCvsw2pEAPDX+PaabkvfZZtVfVKLdoO9hZQNdFX4d0cnDFx2lCmlLXOxFLfqYUsmuwYJPpCdKiZp7IaB3fMasjs2mt3H5M4aJ9WxHJl42cWXsT0BQA2VlyXZxTJTsBtrMv63O9sWaLr7jpa9U3eTmfBm1moUQ8/+hp2D/qGX5lY9zwKbeuYjKMGq3sdm7eUYh5rqHv7a7jAeCcjHPl3iU7DhRDsba6L8EXtBzQDyyeAAboYjvE03l7GAkeOIifIBf3hugTqP4osS1wgJFiMBG8UVaLCkOg9nbYRM5wPzhokSPhGWUNPvx7Fxn3b8cyA4KyJzXRjIHXT0hZZVDnzJe7HuLMMBMWabtNZMOABqXRAD4oVnfQH+Zdz95EbHezvy5j7PRRLwmFqqCi1rj4Nl+JkTPdx3OT42GbDkXJyPUGsCAJI70FAxlUNWcN6V8hGxXwJKIMv4y7MCeKV2MPIVC9jEVriHEVg3+7Zo7iCsujnIbh1JkfWjeHEPlCqvrxmLRZO3pNSfsEWnDEjgY3CpDqJOwL5tf3DU/okdvlxATyqW5nKwmeznkE9p49TktYvY9LnMq50R64t8CtN9HV2yNJM5artf5lug+8OASGaX+9oh7JAb+sbrlzGXV5b8HxKTY5kPdW/Ck6ckeo69w/fsrNYjGU3a0QCv8wPVZBQYBO2utXxWRUnFLdkqbojQf8Mt3JxGaSOQqlGEy9MGSKCjk/UD2tZYwDtoavdRE8gjOkVWkkqyP6Z7XcE0/P2SKgoZ5bKJCOHUdlaY/FXT9xI/qEJrNR8b5jVBM7izPfxtyXJIoIXjkAfjuu29AVsn19YjBXpV5Odu3R4Q4iW+qoKFMvrZxV7hYZ43xihaAfRlpaB4O5pk7bRfXuQAACDE2+WvjK57IPfXAhAJgPqElB2RAnlFcruKTZbLzbwolqK8fsCa0UsZ7ivzMztZTRGQini/8wAz/XaQH7h0K3iT8okByk002M64bl9lfR2Uu5iC7o0I56BvxgrOD/N1IR4Bl7LxJ5JAwmSwAII4KVOUoe/XpyO4wxs+wl1uX5EU6fmCPVSll+nHaRsnzkrUe4yDz0B/Sg+rPgLCCVkeMZGstFi5eZs8vpyvmN4oe87V3VwZu1Nz5W+a10N6eqTew8B+0HfYGpwo/gLqL03Ijqh47Nq+wBJWjcCBguXYHXAx5WERC1KF9L5qt/LVR1XTb0GPBApkzoDkTO24cDS/sm6efcZlZB3vSj5NdDUNKCUe/P4uuT7D95yD3Mz7SZW1pbmuE9zTK/7IsmmyjV2taddMryMhf+sYOCUzgnJAHOpuYU51yE23rujJJniO+LYEkW/dzEevirqr7rLY3r76JOyiK0ML45+QZV4FASlYToDiluHFFf4ny0TkACRdJwlnzL5tkIzMAQMVPbGs6Oy/1Xmvv/0RQecxwQwbNoVPJeSr1Z08lfuaPVmLlKPuxXK3pmI9aSa+ixl3bsOIX/UNAkMAMTQK+nvbri14TjlT4tbWQgif/5yFZvqu4v0f3cfwGbARucHx2qeSKqYEH+yEpj41lb71pq8JB+5SfpceZJZeebDl5CV5D1YxDbB8R9qBxVDTFF905b0dQTg5p9hQ6jVE6aPsuuF/DjD8TjS/PzTtsWustRqAEQjoSa2dcfVdG5q4nD4V6ecNSvsImAtL5IF7U66RUSE8GY5+YYNagvSmJYajTFrCFmRPDp3mTYagOD8Mpf68Gp/Yg+bN1h6TjuTD/gFCAhqhVlg7AvND6RT4fnhrYVZlQbVFy5ngbxM5I11ool6EI96NW7QJcPPo2Sbt0XnbQx+g0on4ATzQl+zQ67oGKb0dAoqPdz9eMRk3277+0AtRK7XZAIlPajDGPy6SWqNlCkKlTv8o0dIip/LRSK5J16GX/IlzZQyGSdaw3M+CTnskTnEIOM0kfiImbl5hpNk81YKyRByW64gP5eG/wN92fm/qpEgM7b3OzItdzPmWgGt+nzB3E2m9AMQvfVgjme8GEQhDEGjpQ61PVnmRNexNixLb0WhlgmDfAVha1EpudN6MyPeBS/WhBcENSaW8ot312E5Y6mddeviGHUKvAJHmg18DujJfED5kc3MM3PcpuZ9bw8NxkTpqySe5p2C59JBzzG4sU0B09FvuoVkZkIq6n6PGQF5aMmsvffo3DLf8LFaPEq1toZMEEWK0LUB+oyhFb7ZSQpzhxJsCAAAACZ3xPWxqDWCgAAAAAcLlNT+QnhuoN43w6C8C1HshSuCqANwJ9UEHpDuAysCnvXGcLv5M1D7WIOFjzZ8TjMAkjXdNJ8HqsGxjPkfMI1+pU7WOkoR+DE5IDqcUnFrFByvSMLBzATJ6VGDMwAdzUAQzv2CpVfH3ZQeqyQXxENMNeXt++95mgYuxij3AEunOXBs+t0GZfykoXbnNvZ5ChG2QafIDBngtaXwQRRGH5fqurbo9R7PpTR0UmQXsohX3XANESiPBwKZGVPB5nlzImcwLE6D569gIo2W8sFe2f172C0XCrEzk+W8aH+wez8X3lVb6YgtsdcksCEB+hGF0YL8N1bimsgBxtkbEeo3+/07vzpeV5gLXK2hT3fUqVwxBkOKfmjPVgpwntlQFcJj/bKxoNvIgLwq8/Qw3x5SLmmbzR/3U63MQUFJmpuqAcTEpTXx8HvhMCLVjn94KhhwU3ucZZfy+9CJ8xiz4QbnsUHcf7dK3ReOkxEqte0E8nlBpXvHdnyOgE3PH5p4a/2TuvCsdFiRxaW1w0b/3O61n4GkaNc9CNJd2dTXCP5q7+WDQCxSfWnnEowlZCM899YmGfc8AC9vEhdYMiitH8xQFwd4AzYOJvXb6hAJOCvuYgQd6VGFmwEn6VoYwRK6Jhf2Jyl+DHv1FmPyznEDeePXVeiRqQ8viFo0akbIroTjetx/jJ99ngYmMIB7UhOsneCwJPw3VbFib7nDIB8sDf3ythOuGVgkXj3S6r1dqVdnlOQauiw7HTtNH6MA+1ugOQExd4ksIpDTgNnA3UyJSc4acRD/+UR5SgVM0AD6YYH8n4f2n11dJt+5FoxliEhHgmZPGkLsSwqMs2xFzPjBg0mQRWwukuMGf1qZ2D13O6MnUIACHmszOPawbxx8g5Dl180+EkokQASL5OSPbfGLRc3eQRPR+hxJthsv7CNEzCXNcKN2nsHEhgNGof/5V/4sLm6NnOSG/AIlULyaLxVU48HiLLx3djy66LiInXhOKA8TevdHHEUluG/KARm4qyJGRP8kOS3hX9f+QXUSpx5apDhmUVsm/rZOUKpfyTrFKTsA8Zm+zFVnyHGfKTvY5ofXeoKyI2tZ/6kb13aJc8zXtETpZrops/iSv6fpqGx1t12fscM4gpH6MqSdG24VKShSN0ZwvhRz5F5Ok1MPgQibEsD/oPljdyJ58QtszrKBWnorTavt0ex/2dvPa0zIqt4E4S4KGzo/WVvmargW6W0eznVKF5cLo/8EIk8wQcIn0Am7DHdrJlgLB4ORktLvcHcQW79AsLD4Qj2sde5DMwtGWON77/idSs2ZODnKMgCK9sVzw8GEIztApPlPjcdtMXz3ewXfXvltB0Jea36yHDcQG/bKoo6DpYFAbBJIF3oopOYhBkoREJ6Mkuyf1wOCPZYK6x1ZBusduQ5Dfp06eSNwWGVb5FQVbqsvNe+uXGgo5G1t1tPyGqUwLqoCUdJiq3i6ZJuCVdXGbLst2t68oK4xXZmp8Tv6hy0Qq1787jhspKTPhzi0GXXXrrHSF5Oca92eZELWwEeluhFa3uYKxCnjj3BwcqcciCC4UHM5My0Mp7+EJ4p3ATm0wAd45TYyse5ROcgzu4I+roy7tgPikbZww+7vt+W7OWYW8cpsZUOJDUl1yeoCAhsOlo3iGO0deZo86V/JUBs0Qn7Z7X1LAkJYMIQyzJZfm/ZxXKO9fMUP+MwKysWh0/gQe4HaHqMV3wc8NH/wt6lD4V/IYI/jSg8iNDiwLwI7Z68hUmmnxR7WRv127KvYVEDzPG+WbcUfEMkAEh38xWNkxd4+2DmZM0DE8Em0qvTk3EqM4c1+g77iGNESIAXIt3WCyrm4V+o/75xKGm/4tST/0xInzsUej2VN2SqD29OILHhTY7i6ZpMsD2Ed1qIk5KKSKotl9Ct8C5O782w9HnQoC5XXv8FYL8skK3j0YY055blNXvsZVIBB+zzEbLhLhzt6+iIzTu+8ZObESwY9o8PYtBU8j6TYjSuvJmU3bDxm39ZHN+iBlmlztvgzQuxXId1aaPbt0KdtQl6jisEL/edwz7Etsx7Nq7S7d8RerhMjT+BJH+3FwDsz1hJSJxJeY4Xrp9LHh+cnzsv3eoQ3uYGt5L9OTW33wMHh2Q9XiiVgBju5ZHdbzDH4s4dFG+TIpS79uB4UlDx8795qbSQalbWpXuQ9YkawqN0hnZwCwpc/qCv2ieVCcH2bUVWIvyKNmnoMoFgjXEvimil2MXnMAbg2+MomtT4I+bbhHPE5qmcSTSJlSBecHlMXzn9do9S17sdTUJPhg/bnsiLqY8VontFOFHxbbh90R79MwU4o5OsQqxD5jmIhEvL4yc3v5+KTcLsGsmAuRgcAKXcbsBwqXNAuo08raLRrAI+bVY3SnLxf56AdcPWnOL7G7C/vB8R9GqcYqiTuRQncHubGc+jCSD1U5+O/Kod+nQPDAJshJxQu1IZm5VFmqnP6RZpj705ULUs2GQxe8jFUB3kbkmXkxlr8+fFHkAkWBbgUz1LvoeTIyq2XJ2+MiNvUE3agOT2vbTIEJbS/ka4gAIDGpGyCLSaT8bEoCVPwRqtgvpCyJp10qpG03hvFL8bltYteiRIYnlU40l4HUTgqMvdNmr6UtsMKajH6yRJnWINbcRlJTmrYkiMaf2MyZBS7yYhhJe5uRQ/0MQkFmkFstnMtGCwNkmIKZzpHbpj4lXjFvve8DS3ifTIN14BFXd9jfPWf7hb6fwhMYc+SlYqDG1MImiuI31inYMJA1TgjyyDNeGlvg6JEXahRabCO8Exmuqn+atXfYpU66fUVk/GaVglLZ/ItNdG0ws8awdn+/gt6nOVZISO2OkDCrKmeZtQ+TEFETU2J3vOY7eeTxEFZvM2IDqw8EsLrmimAcGAbW6Ui51lCMfRN7HBOKvJCAWArzw/rdjews826G2Gb7FQO00M00J752ieBG/pQaZfg62l4Ff3e8XHuKWXyXlpr2y8C52w8tAlYdR15VqBvvYA49kK7Gm415HBzrzpaQ1Lz/aRbE0DxOWNSbflsWxMYKOyJDC7pveonAZhiefSVHh3ibXmgCe77Y7Tmo/TYRL9o/eyIlbq6DAZGWoVMnmE9TLQE2CCBOEMQg8gM9sYHeQPBKK4YEe+jhzSPujKgjQ+GubOaDhv8uVFZSoO/A8f1wgtukM6gLI0ACUNyoYQ3k0YkSSlPTCmBxKzFQnf7GLQGqmDbh3e70d2hxOEYMoH8R7I9Z+apt0Lx7bIwYydOnzHUTSC3UWK5IqsjENRPo7LClpK2dBUBIphbQWQKxzh2KO8pmVYEE3UUbABiyhfBowjX9L9/GCZk6u23ElcLADz34IAQiDYKEx1RkxZk4o7ZmNR3+jDHEJNgScYhTiRM+t3EJvYTwrIlr0tVwNp3h1XqGFEJQasZT+rTcfjMl1yLoD2omRZLxX+y4hCs0oO0GlxcwkncxEM4O48ESRgoOaadwsyd38A5NDTMzCsX+E/aNjIso7s4dKZFIH22l0n4AWESV8pQT1XmRvz3BvzSimMhjuubahIyVR5BaCqkX1epEg0yypFVJt4iSNP6xdnUWWX7VYIO6aDIs+lqwkn0geAn0rjwabQkKKlUCEXNZUUHSX/FwsehNdWeBdNZBdiWO/jn9MVaCpRhNSyNfnBlS1UkMpmXhILmg8WGAOwLrmNRkBDmBfDasazfuwsA26QPzcRfuvDVuA21SyzoarSJqOTAcAkefFB+qdeEekCWTqGqekMyj/aRwf/iJ2Bn5P8sb2l/LLWiCekXmdmOwNc9Cw+PA47nJfze9atPTeAnTZUEel2omQwuz9nCaAEb/J0hmzUD3jx0NN3tfRPBpwODTRZ+vWvjv7vMZ0TyADSFNzUomMUibfLjRZx561I2MBa5P606kBTqsqE3dcWtYFbNQinWmZOKGvqOHz4IVl+BFmIjvjbrWIeO24PYpcQlTLL/oP4ljjkILzPalAhl2a3LS0Wkw4wuBpYtYhD8cPrEGW0kMwDz1ZSti3+Z7v+gL97d+lcYkJUbH3OPpm7OSc6QRQ+nYRJBNdJeBSCRtAkMmqPplytVwov3ogPYf7/geWBU6u31K7ErQAEB6JEjtMYfrzxb0WoO4EUxZ172w9JGW85Tv4ltZ69oTe1jmpDalprpobRQDTuAz9fbgLQ8P9W0SX9Tu5qxl4rUN8f9s1aNwdp+MIDOUYi81eOxbhlUd0UeUiT6/jvzMsBfScWyRadOwZq7mPddrd7/d7ROAK/72Qi+uIwLP1Q5yhIlycL7nHfMZNe28paVkWlbF53K5j7F6azeh/9oNjQKfLpJ1jrmdzTxYx3N6fjpFRqPKL5xBLQI84e33Zbvu9oVQ1o9pphYln6yJ2rkIqTL/3qeQgNY4eVFLoZXo6NV7udcJlmZJcWq63xMkAQ6LBmHsCsMqfqeIruh0HqI81zv2FDXHtVaUnkdNYypa8hwCCCLZZz91+cq1IPD4WWEJfBFfmKskf1kivR5fCSAXp4TOghSnS9zZGfYRiCAi1ygDXQTxkYQDfyuojctIy7x3vtsXXsRU3ZptYmsO25o8Pw2QzKvzFjOw3tz6c2+rzg+TgjkcHN3m9ZXLQdyrc9PGAxjuNDOzUlqZ+jKkpNvpjwF8JDqQlgOqePqYwGbSkVNUFSRQoPYWWAULdD40hhFovTIIunaXjy8oMnj4rTif3suu6IZ/SnFk+1W6aURLiw+Q1FJyn20zacgaImK+3iYFgRZoLnDvQjhwu8J8apburRipYMjBlS/avedp0BAr6AFAnPQIDTnSRn1EJNJPKUARgAnraN0NbTG1QxPUHnxpDlsKx5ZnZc2RTEWIXP9X2g6biNxPBsppts2aKyQ7tWdHyZv0ht88ZN3zTD80ZgJbcs8BozpQWgYbQ0/uRVCV5XxBnbc45sMfddlsgZX8T+ZMpmJWG8fISot6yzyG8IRGCBSzpfkTlv8hrmXEqfS7/UFYcumOFwv+h95GM1ykAxME6LePtYp1hzMg+sAvJ3HH7F9BLmVlw9Zr+nIK0eJv3EvQi0w1LnfhL3hc9A1TYUmIsNCHgtBYVRddBT4SVw0lUrzrfNVoT0aJdQ1zDUoBeDhmRGzkYO5iUx96lpwGNaGbROX2Cjs0GTtG1JZy24xz7GltUioMfZHRd3379wP/dHze7uQiWu9L0xHtGsaR0yxXV8SF3xs5z0y79e/7CxyYuSvTnS+7Y8yUb1MD2sOEg/nzJWgXiEc/Dd7k2X0yKAtyjVSgD8t5YzScVuqEeMlcNPm2A5WD2UqooNUoQZsSBVF7IsEnWOYaMawhpK/Hy+jWR3Ki5OogtwD0wI1cn6TpHGSw1IbXvyrx8QUWIPkNLUtO40IgtcjcQFHnR2MNHi6lQxraiPKAXxnQ834UnADs4dCChAJJJ0U7ZFjVm2lsT84FVzKAS2gA96NTENxt23v8NUWDW5cwlgwJZ58JzqsW/AehqGr4aPghkZm7/4nosybogkcj3ryD+XTlJOdtaZ169o0ZB9opWZMpq4LtEpofnFV62T7/dj9Fdi8N6Gr2bzBrToHtn2NfrxhMwswq3C4wHbLczi4TktaHJjE5SJfv9JYkUcOqYKky31kDEVwU0DhGYjahWbmY5lNWFwuDaR8AD8DVCxZtSCH5S0tnuQRDhZoqc9kmualq3wLJlx+6j+jIe6qjJv4L5Qi1u4kVVC1ZjoiCVN1XY4fLwQUVpJE9dCUk51jCjLwkaCvHxQamYoGGIArZz5Oin/AhSwX6Zt7SUJlzhTCoVIPF2gFtoPVlgIXYOWN6VQXWVRUDkXsXy6tri2iDjntw8Adr5pohmGVGdAdUZXEnqMNVOGtJm/GsoBPyBmhjd08ljP3IJhCEN/dfeJdkxrUUf+t/f9Cgcsr64UfeGUYv0K4e1KfABM1XVYtlKdszP66027En1i/5Y+Pxn36NPCvD91cVaQz50d5He3Lco6/mOXijyfqiOx/cYDFQQ2P8/aUWirwvLtSRneXLXMVyp8LE8TnsBorj+9B2qUSQR87cdNVTlrH9dQ8hf/IZ3G/V7yrEM6Qd7RpXS71F2lvbIZz615lFKltIQRqgd9MLSsVPpV+UqYipG01t2zDHw5y9TEVcpNkPUcoWylAmEqG0FeqCG/a+aapNwNF9iHzypNPURNEowxTT7dqVS5v/buXh/p1bxkSckpoGswJ5DaA55fBMOyBQQIbRfCT0nkoDSP71vIL8/1d5lVAfA7U/b44S1ivA9BXzRlBa6avvYKMkQKpphzWCI4hhVZ7UIw0fgVgJsymbgNZTU9P+L1hhvLIL+SbH2YARUYzTC6FPySrgzh8rbcdchGG5UzQShQP1PMvn9itCvBhmZe6dzWo2serqWNsiFyWOkLph/hS9+Evf56HZohbii2JxX2tffwm88QJqxzzj5i3X3Fu4iC7DiRNwxk0BaFODBUSg6CJe2A0Vh/dOz1/43vPiG3ti2TbBbgSM49JoTIJzxo2mTjsJNITJ8g9hazzVrwx4Sx74XwciBZ7QRRm5sNKC/o3mWzlk2QgzRl9HNKLEhkL9AT/m5wZKYAK6OZ9XthEaivmjay136q/cUennXHAH2dGZWqTqa+bw/dBcoJ43jjDHLAzzj624RZ4SiNz5TrXUBZ5ahh8RRr0nP1uTV4uCZRDL/X/OAghLPbzZIBsJrcPLwJ4y5syeBdlm50T0AB0xwW+EWyuhc5tdxINxGnMRwh5MlvBM9y8L5RD1hk95WF+wdDCDzerg5JpgOT7CzURlcaFAmqOlvLwPjFuigfywnHr2dc8cjMZeIfmO5hUSeAlTWtnDbQjqO7BlLSxgKaL6qCe+gOVLB2WZtR6B7O+tE6E/EdVXipEvmR1GqzWCfQLIvKGdIW0xWKNp+YSp0Wi8EKpj6ZvrVvX20SBPBf0jGbNsu3nYw3F1apQnmtlc20nZG6I326JYz5EDTzhKJlyrNq4NHHJsDHJ9H/UuRWr9fTxZZzuXTPOHgvgnBDtj05/Ubxbr7i8M35bw2mA/gjH4EUQ6AihA6P8KT0bkDzHqF9CdFnrP+CNMzd3mrruqD5R3i8rW/ZjiKaTWHNjk9p8JwZCtVDtQX0rkTIGbxTdpOMbkDrwX4aIKUznKQ2qce00icKqIkxW3EcwrVU5orj+9bogUG4AqCWO7Kklrri0a5d2j6uabwotu+zV3Fssslu/AJQA3PtrB8cg2lE07c7Y5/h56XYmYT3PTCLbDGrO+0Y+tqIz/tTBwiQPNu6ll4TSCOO6Gjnd7GRMf2BYwZ9+toEcyrkRAgSO2JZwObq2FEzkYWLot23ezryNrci+koj6TWMF55BOP0asWAtCbcPmK5UgfaqX9NAP+01A28dIVqFwRY32qlBWeQANF2jU5ZOqMAWVjh0IsDyeW1s/rqvutWd8CNA9LqqbRQDDUqffx2fDTJdo+jHQSSFC2Y+t5BfWlwweRGXj65C7vmK5V0jtLF1PX2M7LltD3tXkhVpY8VRU3FyMtdtpnAf0PHUebUFpTxTo9ZxysgL+5nAkUsjtxC4eYboBvU25ey8ghPxaZqOvQAgPB3v3uUUEtEEF2wN/kS6RcoIoefp0nYTyQAyTOaymtP0uRnvLGpUWwK/HPeVcSKup39sNTymOtejhFhNlxl4W5uyoOEdQwjwl+1ptSN3aLFAuzGFyqlT/qQbdi/zIzn9SWs19aQ7W5N7K/czsUCZVkjYLd8WJEVqHbPPEbPiNSvldZiMui82tYFeCsCuibrh6HnhsFB6OoR5FeEjva5nOdsMvnbS8KCYjivkonAAworX+hS/gWVMSysQU3DC2ZKkdeMQr55pO9U68ZQ+W2HxqahKp7rhaEMchrqabXP2cqQOaFdkure7KxhOy2tjtLpKwqJAXvHRs5jMIixjNMq9NJ55wFej74YV9kgIDwGK+87mbv2OZ3hgaI1mNRRRWC2wQpJ0vILsvIGSX6u6a4FhS41IWXkghduI7BqS51/yR7aCtLeoTzKYxtWT6f3J5blf7KfnFLoRZr9ce8c8nRRNJfXrrhPQkyexP4vL6Axqwn2BUd05Rg0ttP1xyfR9ovpR9F4Wg8uMr0DIzoykU31CbpjelSm7xyrx/mS0Z91mMx16iB50LOLVEg2O4fF3l7mpBjRSRXQ1NXy+7Ztfb3MpUxFOxPm1kqNuxuS59cMir6KWGIFQ63gBL0PDyaNmZHbosySrIgm2T5BCW5PWOeSh5VvxmaWu1rD0ict9mqSlu/LGmwzP1T3pdi/CDE8q9NLpzzejK2lw3mF/60DrXdtTKkQ0kh0cV1ioss/FrztZstqzFKnlMlHCv7fRpcCBrXRn3P7qURICwH8Z1X9sDIaVUX7ytXnclxrzMhaLOWoFRLUTzk4ZhF1R4nbeKw1KXQZlR6jcEmRT6wcaZ7I0KhFmMq/tE+p6I6YlTAY78s1ReIjHpuXScO2spbh/S31JGulGQgCO9kojS9Qy46XJRJgyVv5Fg2OfllqoIEYIML9s6sOIXh68Hu6a8MvdoSAQuqnC0IbM90Ve/g2QiG6tSYiKgQ3DRfTZaZnGpA+i9GnQtbmjnbYpHaNHWBlVbktBoprAQU5TqjJiur9SmG8WEfXLW5Pz6+VlCN39gishD+clWKzRAJmctXqwUq0Z1BLmcqzxuCTsIAAn8gcufZ1KU4E/7CfeGvzAU8/7gmkUKkVqH01Mbzbl5pHdX3i3KI0+Trv+enIpcNUK9ORH8xIzB+mwOnkBR7Tcn2Zs+nX4cGFWyrHeEqI9UaWgauWPyXHkgSNj0UmrgHp5LxEp1m7PsfcoGMOctkt9BJC1rCIUkRoElFackBguMVkTPqWkPEwQGlNxWWNdWKAdUZRfJDTdjbc2qAQWxgMlh2UcQuYLhFIpVYbLh5ceszf5lRB7kGmbal0Qd61klW4NSAw4y2QjABQVJyHE1oWwjPykmx0mrGgMep2y2orBKQoRo6QpNkabgFXEJyH18WQZQU+9hiZME0QktWaK2+a4bzWXY/8j+izBWLhBewrBlFchwTXM40qr/7yCc7KR/GTbqRjZ6Qn6N+pTDkTAXnw4bpYXPD2Nc7r7qYl4driMDnTe3lYAyaTD4ZT4RhBthK/IePHvt9TuEbknZGTJYkfZ1iX2yVi3L6KOlxS/M5MLcu+ZaK+56jLyxsvG22B44E/aK9JU4ECmTv1lskAZQ5qMDwbsS6Mtl4Utp2b1LNgqDLx9aGogA+ACdXYtZ5E+gTMrI3xMtVTfhSyM98PwwgGeXcTk/OCToPviBCiIspRhpVERryuschH9bhqaoyeyZ1t39JEBjdLXQL3chojCP2WEu4m3cJkuWEuhaBmcxxoEU4+un5fn2BVEWAl6W4q4RRXQJcLUrvfmdUbEHDdxmysQb2lwHvpuI4vz2JafXTt4fLG+azmhAZ07yAkAAAAAAAI+afZ/vP1vTowq9pWZvCpI3P978F6AWaSkzaQZu4FkYjoZAxZ5mZ8714ZlvphkXa8TsXXdIr6Kn1UGI0F2FiGajR8XXnv+nqE4DoEr6MPOlTDLVHOzdN97COd5njBdCEA4vDmd9hGBM0w0Fqrk8vpnLlXhlocPhoo0nR8sIpehuDT53Ru4A0KnPnp2z+G98aDdgLRT0woKW+KF7IgZTpG+Stqxdt/Tpci5Tm5B/0Wl5a4TT96dL23TZ7boohY9ryQvCn3KbU4Azs7AqGWe0aVCNQ+cwdvaJlDCRB2c6URya+YLHy22Fn88zlG4DeYsHcsoQ9IReSgTekRJmbXkE1zDy7nZgG/qBZT75LbMLsnOQFGs4ttlA2hMq56EnP3ZAbUt5QrRzZ/kWvQIUw6YTFl1s9xhkeQWhutgRregbtLQqWabW3+jlGaYQFFxS1KPZIIUwxoRC1bFk1UroEGmjuahQgTUNIR0QSbcdkUvs2Buanng35TwNM4MgyxjlTHVtZbMVLFzvJwdo+k9q01oLUJ5zei7qBiSDG0/JygfJktn3Bn14wE6hhMIHdKPtNl2Iey6zRDBXgt2GlDukUbCDFOfOFp4sHNvXuvVT7Fs0z1/u4DalvKFUSj+3pd1jcFfU78uAEevbom812m3wnZv2NJm7a3ACif2yzGvrXzF6EyrLd5x9rWvlCePvv+JuO4Wul3AHkub4m8C9bkR2AODqZlRj0SkIb+5apNU3Dwqt5XD5d2lR1qxMRs0eOyBvBOFAAbJlN0hEMxVoXF14UCEiQUAqgRcYTy0X4BWt2SeyhGSRT41ht7upo3LRAIMmmZiftTW5ZSAa3uZlktdkWcpDEl6xA2Bm/ULtj23cE6sZUj7YMG7RS7NB2Mvx5T3tUGAgfLUtZD6QzWQ+BtZD7UxN3s6rCA7yYzW7V1E8HFQYwr3NA4G/YRqLztM69QKjkSWYd2nJEsIzti66YpHM83A32HsvRDAk7sPWmSBMEgims3MHZVPxUzAKjj8uB1cBxgFW+6ei3aw673DoDfphQp88Iy6a+/eAbH/DOCQY4RMr+cS3L62eMDeEuD9jDKSujXCiecFs0Tx9yNBlbNlIMM7h2gsQnjatH7sOMV78WBh8fKUwzNMfTymWOqICcT71Am320rUpq/MqwonkN+3hpc+MzgYlk2EmQis+HgrI9qPiAKLhQsR8/r97R2s/j0pocVweRlqZQm6/HwEsC/nx2k5qIlPH4PaiTJSDdJ0w5D1zo9O9s+STtZdX/bbyf9ddKL9NcuBwHLmwI5TWHSyadK6o83S+oxjg+EvYE72P51Q8lTTe+ct823iwpWRO+/804GDwtuEzJ1pANXuXEtM6ycxjQcBK8Q45C93SJS135UmP6LVPQs3n4UAc6PXbc0FEr4lQAChE4zuMEYl+QbUPRoPmqS0ytLzAI7JhlZ2CiKGUJ9goQs7xldavms9//5CeTMxyK+aNxdm0KfIgpQU5Wh4tXEqQ3rAPhvEivGdTBHy1KROOc0EFsbc3LouifCbuwalwtG1ULB+0EDOtMTQpI8fGxvW7vUc1FeChIDUvBDt4HExgzqoDRXa6KIWOZkoIUQAYDXFaEJTHFCVRl49ISqMvL6EntMvkxRUhT0iYgisDxHSXVkCIZIEEpaNFXvST6BXXp0MqoZTplIHHknW/pkvl2VqbatxqMYfMugnUF8M3/rIuE2pSzqhOOmAAE/l1+cy1QQRt/9Nj60fJv1cOdx3XhAaCAvah38vSTWxQgRDlPRmZ72Hf8ucBVlaLnr+3IsvvlfTCDeQ8uXXYXkquqMU7HCUekZQMb7kcDgNy0YjMau8VnS2NQEPJ58y7wqfjL+Dcg/o/Pas3s2MfoDOtNy6diEK578S9Q+k/DUZQyb+zPpldbKI0dthH2iA/fZ9KPjLnb5qMylAbElG/N5eS86CI5lY4qo8a1N/JmPz1N/nupXMmoSmZiJaIeHAmf0W8XXUAoZ4jEZCMh7vPiDkex1AZ/tTBpXh8hZsDbufHdxRgtA0n8/HOBgjJSW/JFJnmvnGlQztmwnolIJn5yAwCGUbYsHsjPi0Y97gFm0edk+89/LX5rERiJI8CILGAseUGmri1r+wNJ06dyAuvYkr1NgSI+8zpDDMA9FaT4LK3laQ8qelW9QwXaLTYFF2VfyJrXDYDzJv1fj2hHQ+DtKJowNz+PE2CSWQVzMByiX6NtLNo/jAb4VnO6i7iEjtHXe8sgNgILmTX7OR4Fz2tUygjHMyDwZjNSZK9aKIHgzHAKfg9JA3UT/+DX3y1zsqxgkn6upOvRjTcg9Yrb5Y0CpqBXlmrssePxU+dCGV4DRG9P52qr4jYkVpTJIMdViB+dmGnyFlQV1AkPAEovJdwwkl2nKYOiPr1osGhzFe4y0qwrzbxlj8MReWcE9b3p+P+EksVVtuZcbPdAvH9jVagpGAiNh05x7kMsqpC7wO2WRpZfysEe9DWjbyfkBkHBgJP2OLWQBLryUKEtOsIHY2rkoeGVPAH7bOJ1jDoiS7QBPxXXdn1UWOHR4G0tSkEO0epCJo/xA5vSbjMB7dlXhA+Z4khb/7ZDJl4NVyMnL6pjH5dkHCnhKVsbRs+koCvUg+I3JjRfAsAwvRdWtYVx7PN54DIT3KRjnfL/yAxRg2pC93164DatxVwLJvK4vx4H1TCymezyF4Mg5Pzsk/2GGfDz1ze/IKXG5+LU7zJsUnl+I/7ZCGrNGU3VvHq3/KkJeuuEGVJC0gL6mFbY9gQdLUdgc+kmCogzR+PoMD5P1LwsHiI6ASuD7/IDrGEzsvgaJc7pJu+s96lfScdYi7gAAAAAacMK7LNYNgJBPk/ROB6REDAWMdwCIgKK4yKIfT3VmjZToXCeelwZHSrWYHZYJ42mdOcBLtCXcoloXzJLueKg7IvLS4In5keFm+nM3S7nP9bT5wN5ywFjML1sBDmvxcCLsJD3fvDGdn42FPodv08x6swS0yHgKrwmFslva8Ui90vnuYRQHi75gr/foHrjqm4cDORncfV89x822kwwz1WFVftP3y7zNKnGLEOuCvEruGokoF2vEM6TGYymfiMWXud6JivMQYsvuRFFbRaV+ZDki3Geskc3OMnY7HR93g6MxwAQx0MDQMaBo89/ZGlcXhhntGAYJtVEuqXEdp1d7dcWEnZX6fMHbrRZ984LHSgmZYdPedo4hsLo30Na9rSXMegts14wOLdagoIxKu7073X7Do1n4iSBNi0nORcdhi2HXMtCdGf7YiGsksxrgFMSyYJsXRJrUKjJn800agUoN11Rc4I5AXYYeAHgzcBR8pVaQeyiVN4Q5BUBdXD89v4h7a0rx/tXyT/70VMeNylVWjxOmGIajCA5If8UF0uqCN3RRiBzPeyUmIDAE4ZR6gvcOy3oDfWajIqxI8NNltWxTpstijnS+4vLi2M1bUCqg6iPgAITGrF28TaMU1sE5o93veWizZ9UTkavpjBBN0KbfoCgNRipL+pw6zHtfEClblAcp6GsWe1g+p46tY+kSz8a88SfWI1nVL31yYr+SRKBpE3q24byYwBeGHxvLvfYbgj2r8mZflBZlekXsIcAAZL7kMwTIrZMuOV9FElEaGqOAVdgLRNqYXAAwE16Yrzi5IrYg+KHlShatODOBZwMnc8OU9YgJXFkZ8tVEh5Oh8+lIms47kQt4X+eADwbnEtV440bFRn7o6gWCFpqIKnsS5brviKuIoaoMAy2BfmmWbXm8pRlurG2zGSrVuj7VrDckEu2hslHi8Cr3Q4vlmBrWlYr7P7HNDwM4vWW5NCd7gTbXm0ijm8thxV5w86+zDjp/luHqhKNKOKiY5Hvka+MLZrbqUD2F5rc+YACNB25xF7lw2G5FlniKeKp6YNv4BTRjA5O9BSwtPRpXrqDWAjAimSP6c4co7x1UafZBMs8PABbziodnSNfh9/RxuorzCawAcFn/0OgaC9mf8zLlmnin6P7NMYE5ttM7JxUUaPevoFq9cQr2XAUlCrZQ49E6rrKEQ+MIpRDuIFaJt5gAs8AnU9gaX+QBukWqyHY/vtf2Ke2yIkZkqmak15VXuizjq2TDueWcwhdBKNBZ+GJL0t/lc6RtpFT7D4cTgH5UTL0VYeVxPUch8Ny5nTkHNp1Wo5ApSfMWpuWaxUYlsnMz4aGRsguQXIB0597mBnTULzMnyTm1y6dG6/slpOiCpLj/vMSYUO3Bku8uWbXmDCJAACObokwH5PYELFUYNztQHegMhAucTFdMlrqZgL4wL/Xgsdd78JbMo1R5GcYankiuYK/tp49Fe1uIYDM9W3FLwexXESOUVmJ5lQD0oL59EIIrEimMIXSrQ+kW/8yL9NJ66h0qc9BQR6s5tQLM2+kgyWpmyeixayr4CtWnstu3nuhq+r9E1x0oIgct2fINvyDAENFdQExedeqArlexJqQteG1vCe7m9owaSoOI1aVwo/LNbc3J/JlndJsBqamp/zEcsuGWPf5xi2qrYXzdCUBe9zwvRjMT7yw6M5I8LhI9/iJ+Iz+dJuno0w5JJbpCVZSllGXVDv5zu+ROZNFe497QVSPKhU3lVqYD03C7CAk4Ad9qpKJsqw5G4wYYmJZvLESKbCLUISb0jOapuKhEzOsGSk3YVynU5Py0oTVmf6lxP1gp39kr/62k6V1S6aQMYcfhNXou/coLTOni558+eYEa/uWflRfhIkMLujO4neJQI+wnW+XpEKpHlPH7gsSQ3PNINgZp4y+TMPPjEpu4EgXHclwzrGZlNxRnC5lLWNomCvFd0kIn2cqklE8wg967pTCo22LZlMvEi880myA7LUVO4R744/rrKGW6Oo5R+lrmLgLfpmty3qgFoK8sOz2xZqxOYljCBWdxTOoExppIlqwOaJbxcQApSfpghXybEIwHFULURylrNxuBe9tc0RUAWMzo4G56A2OSmNvRODArD1XLnCpwvcuk9uzTzQ9iO1IHxKMhrqUm1zIbpECt7LldBIUl3YlKr6h4BtkTvqouQ0tY1h3uHrZYVS7yTPSaWb3QafGywSZ8tUjoH503C53T2uX5ZdfDebgw5c8pbq/VNmoydx/+InfTJuKnnPMwhdCF8miJuWfNnDaKKckrQeDI2IcrEjFscw7kS2qopA/70durhLEvvx8xKUkK0RrC+Ou1CWXibPMNLvKbMXGJOBNxNBMyNLyQNlRQQChog+yidoh9HiJM5nAsZGbz8TtzgNZwWzODpRWKoOUAkJLGk3+RW5qjvtJeDFyQKtKXolJox0MhxNtww+i+uDd9AaWsaw73D1ssLEnPj1aAn2ksZe5syp/Ifbl0U08VX4pOFjPdE34Ty5aNggrseQrapu7hsGag4ro2igKyFoDE3WD6ECu5k3zQ5tMoIbJ7RD447ELCr06avoLYIJ9mwtZfmbYxFXZIyOfm4raf0MJs0Wyx+G6yrUAwnp/+PEzi+05KkGbli5ttXBlWaPogIgURMSbiTfN3kYJ3+dvf5+JNvmhlhGAGrCbVOLGHispqyshk/AbKaYv5jPqA7o6hcsHtz+Nf9CXypeBAbKucZ7oVSXNDzfwFdLDafGISweTMPAjWakT9e4Ewf1+KEZmYQk+ElVv+W13KKqketAjz5W82qVBHxWE35VzZuEH3tAnEvMVrzAvo/gR81YScVsYLawNWyg0uBiP2nYp+a8KAtiFaeHoQbUkQFBS+1/mYXvE0ty+FigBpoVzCuNQurs2yzgZi15CGTmcVcvgYRgsbjMz/oOu0Y1miX3BJfHAYnLVLqy3Qqxczg0Qv8o0F0M5WCg4N0GZd9IN6KtCAv13Xz4gDRIk/OgOL0AdrcGFzddoaECEHBs4VeJ0HQHg0WhP8PJ0XP9El7I3ltd5T4xNJFZCtPWfYcTgokEAIrfUtGSQPYplZk7VMEOUauFP6bxOIErpvuHLGaWwD/9WPb9T+x6nw/YSrXD3kluVf1nDSoIjF5J782jAAAAAABWuPoOb/Ru38o2Fmv/lGuc359RF8olYh5xVJb19UlvX1SW9fVJb19UlvX1SW9fRICAAAAAAAAHTGZvh6WGJX26iGrbbC5yQ///x48fS5q7v/xN+W09jlIzlywuANN8zSZqMbtSleavS0KnHVA9gFPJdmUB63I4XBI7j6lXmJCmwzYjhQmcSPtgQlwqAwfb2jTcy3fpHlBfgOcmWGY3tpZHX287oN/r3KgT1zA48L4mrjL3ZWlsUGqsuBxUKmgBvgnujmSs3++KdfW7EO5TG0jyMzfwehh1fBhHRwPrQHB+Azn3+lo+4SXBQJebnN8aFJhPyW4bDglppUz09N4pgwQaa7q2aFBk3z2MX8zhQa8VeYwA68+dE/M81pmi1n6uBVYW5ymtxv7cW+Av1z4LzgtuU6166PnRRJSUCl2TFKf/nQxhzPQK7hdxuW2ZJtlQ9s8C0onfwOFZxG/hrwQHYvWlIPrYmFWkO2E0yXlsemGMJdo5HgV4eJ7pLp4LHYBo4qVueXU0UN1rhFkwPK+rsoHY3WF846De8AblKmlHGULrgRbDSAS8L4tcx21dqRJRVtWUortYpT5KIdH+5pDPH1skG+EeLMxhyTtqnlrXeLw8IBpEqmRe92kpWXGLa95p4OpfzPo8S8J/EIiOuoAVrWk7drrGl6q1tSGDXtAKrvr9BdvjXwgr9WqkTUTkxR/EiEAjrqYdQ4bb7ejrdYqqs0f/IaT7gaCTb2i1tYtt0xTDCmghNXAbUeTb/QYnOhVm4aKQWphb3TDuVpJtnan2lSD8+fGTaScMyG9GxlYjNp3j404wG/VNn5XQJufuQS1DTsCBLuDGuFa0BV0c6tTg2jFe9AiLGKYc3zkNReJAXvxxDXp94XVFQx3tlfgJtjvIT7/pqL0ScCoMEvaBq6ktvAYsBUsIjTcUUeMV1DZj7elG7Q+0xf1qsG1tsyPFVROIXb9mhpQb3gDdKE3CiHItqHqsX7pKM3AQWQixZ3U/XaO3FJM4vz8Tu/pa251qDw+MmtMxESliC2oVP2g7ZclIkyiY9P/tvysNyWV33bGGioFtBzMbR9bOS2KXRXpcsCVrQK7bw2OPoIg7XD/KtmJKhwKimf/yET6wv3x5291JRlKzbUKAeVMC80wXETQwCSIy5Co5Ql0oqqi4szkiHF7ex8JKlyVH5Ck+gQUUAAAADWDva9H1T+876ze5uDjkBYPjSTSHmtedqW2/GndO1zi0DfOoPFO2hd8tPTPP5wjKJuux1b9Ljs8iJEeoYvqxYUYTSpgKnFZeTkpMPgjaQ+7CZsjRr+zEiNiC4agRtIHh9Vh2gbayXcwgl8nFYB924Vji9b7YXh3+ql+yc9Ut5Han5mSxA1hjrUBnx8EavP/JEp0ZwSlPM/Lk9L0WBUVbouLNgqZdFs8IXN+Wi4IOlx2dykpTrv9F+e6sptqUqLfzpK7o82TSIbr1rBxzepdIG0Mty3glw6UWzN9XdNj+iTtdT3Q8RyeENEzs/H0/kMPkmvtsy+WClQjh8mQycd11aLDFBcsSm77yfeTvRZxOK90CqX1V19LZQXJqJTc6iQ0p/8RXs07cKzIFOzijuNEwYCUj8VNF+0cuDyImhwZqpigKlyeyecnZ7N98ONrzuLqLsN4aPogFMcePCOUFEPrSldLzgN/vHrYgAtEgckps6Cb24v5aqtaF85fmkL2joAbH4oYBF3G3ij/DLzqPP1vgKwQ/h4kIxpBP7c8enkU66vx5tjAh1KRM14lMMYKt5oOGwDpEYOXGNTjdPkquC28Z8U07eECwKWFU8u9RBAh746Hm/eDaFpP3FJG5NH/QcA1IEAkzWn6wCMTY5CIZ/zixVQ3eSZQnEYWkTwB9YHinb1rh3Uyj6G4j6rZni4jWFShcCnS7x0NNa30G+CTwDw7m479JabZu+jwbjBWTKxV9H7fO0pSSzlxT6I56FaLifLxW2NpASsUFEs6kdiLJ13V4zUpR6jF4K9PAjSB3rzDJVc1pLtFBVb8TWPt+jfO14oNFDkQyVScpKmmNgOMNRFy8Rg0rz2nYTTlE8mpBoML5AJkuAmeIRB6G6GfrRMoDf8t9bn1khf/M+CoSbkAzzp0N0E9rO6mPXzsl8f28/rs2n7qdGahsUtEBZ6bitM/+7MEJKWgQzypk7UKFGC/sHZj9k76Lof+Wlr4HzR+eL2zKOyJFZHxaJTyt3UJhbufer4Ukofk8sd0ZjnTrihyu54/LI1k0DVyDdyCcLG4ylYjzd4ULBb7GiOnRCi63TdQs6cneuMh6W05apxD/xy8IbbJzhFbJAL92yaPjUQzf3isSB3sPPiseXd+Ar1g24ZQB1xMkwLNE+Q6TsnwgcfUm+5eNOzVBt6CWgkMdeWxMQHB4RD5Q5/woUQk4Z83ucyIJI7Ju1UZ5iZfE6sOAvf8RhzMlISMNUoHAz5DOSZGSx6v3wa8hR52MzyZrriFAuQC7QMtg7vvttT1k0kQQW5Kuy+Dyh1LNud0BCQ9SQmidcE5xld7QjXFMas2UYCG/fERBO70qtVn9ZlxTO8rIS2ptT2rzdjZhPerTf5qUwH2ouL9sdldQ7Nxdtpke2O+CUJQuSMQnZM6rOFAo9um5Hr5pZ5xtUZiFgn95bL8ex6TVdVzy27k+1DDn9Hb27CQPt2+b0qDhazUO/wqv1mlUV4V0Y6S3u+dGtQvplA/QbVihpGQfsGM7k3aLX5otbGRNs7jnGWcPSlzYcteMZ67rB+ITCCQHlHZlVuWWa+QczztUq7qiAopX0hyGUl8/92EOc1wcv80Epuh2OOPhgdUkoxW9d2D2bce9SK0EQyRFgHK7U/2u+SNKhqF4gg3y3qjaAtv/PizJTSEoNYqv1faQy1a4e+nWQPVOaKgkdVR4PaasIswphctQpqage97FRtGvdJ/Yr606JcnMn3B/ehBiKtLFvI5COTVMW5uLv/IcscsI81KlrjruHoH1Zw1zatinH9HWpZaItUWHMIqMP98zxKo4VvA5GCLA3LiZ2o50CAvN0OouZM78H5sAAAAWVIxdoV//8MuP5Rc38/HWRUabllnIfVvt0ehQ0FsgAHEUBuKIoCWzE7bN7SMfts3tJtlAbiiKAlxcIzGR9GbXgRFo58tNG/8nQJTgtbd1iKz3U1+ChVWjicQ9Wi+hTElaT/l2p+IHl7HXenwgR5JNVyOULcbKgiQjx8bWjsNgiatJPJjsLcmdYrgRR17pXy3+gFraLl13WsRAZjg3ubdpEIDIp//2nFnQwApHgbSXn51IJ8Z7DksnxvQ21ZCKLU9AkZyZPPzotfTcRIGV7nZQx0KQ9vLxlef0jd0u9d2u+V4QHw/XkXnnwZjXwP2y/489dvMzSS3nXJ75qfgG5UcEnfJmlAYRaWrKGnE9i9r+62FHsmQ9RKdQUmzMTWJEsf867pH4LfGSbMcmradOpvHsBCfGRSnGyMErQnfEch6AD+/l0tc4rCGxJrDY9NmQSjJGwtRpWnQ+aNROXPLWMPmJxMh1cPAeIbUNGYKT5RQ8jX/ZlSYObN8+l+BTqKRN1zqV0nsescR89WaZf+4ekanjAtoRwbavWtRebdd8TeD7IkF80HSy/H2CF18xx1y4BZK8Puw5Q3q1VZGQ0YlOJR3o/x6N60RHvZIDb+DHqaTF/4SzT/uZLgBujhUur+g9YFniLxJFgxa7bxNQF2VBUq88vNFehQ03FAUzPQXMyZ2IR7FpLuTkv152ZgzR78zwaZ+xx80pfB2Z08L5o21D0Kzc5Iq3twWevODHq01uC1wIsq6Xo4aSTE9DBFXUkla66Y/ubyT47fR5I8EfC184Ya9jdAeqjv5TBcAIw6UUyznUv9H/bdFaveAUM+YFt1Qi1+1X7+OMv5rUAntuVTMOOZYt7rJxmY5Z0Tc02tH2NneNIc30T5uttqTsPU26ClJA0YnoQLb0gePkmtCyGX2K6yvZTR33DWms/SIAqvmD3oRVSRCimv7+tvAANWZiRd7AM+FdhMLpg6HEcp2b/t0LRRFMgnTplHXmqkM3iq0MEidUmn5uPrzES98UZImiysgOSfZVntyoaD5fyKwEOJ0pWLsRzFKccRcPmeB6e4EMX+9LIrYGvtDYwd1xBp1BozN9s2Lqo7BowJH+h9mOqgaEmUlWQGWPwC8fIfptnbTZcLDCgqCDo/OtK4mZ5ir2+0sf0+LGwMfAZKfLqhE0k/kAoY1kK/KjcniYuDcUqxsLHiPjT8z7FP+B56TGM2gsunmZx/lto1h04iHhoKfVjX/18Sa3usqz8psS0lKa4dNzRcxGQOGtjZ8BeR7Dg0J0IHzcDsZciCljSloeCjdBWS/4YeTRCJW48F8Y7Tf7ipX0QhYuVzP/XOVT3i1LqegsBgscwnd9mv/UwfBLQkugX5Oj7ugApzhwOjZJzwfwDbx1UMfUv5aNJIuZAaCW08coxtbmK2cfksmkbJJJ9cV5eCcvkvuSg6Eto0TR+4rFVL4T4AHWUBHGkRWKOOOfshTzGRDDYpPcwgeUR/mEGL+OTatl7ZW5TNUpyW/1UhLc5Lqyd7uvH5UGE9gQUqA1wQICCjb4CfB1Ox5fyII68IKN3dR7rV341ryJJxvEwQVaqxgOj1SEjrYSMsGQt/Z6A+wjhca/IJnosMVCJJnUVL6D1je30N/jrG0sbS+7n5sY7XvgUuV6gPOubLe2pVTTdVIyxWl21UKAyDjDkf9tPJGRJ3TBz8h2OyoamuFYm/2W+E0QqaoOqkE2v7KfAOQwlfFhshxPFj3hvwQxdfZC39pNdCVCX5sXnXgK21m9zEZCXdNRs/nx4HVqqyKydMkndWAzOco2Sc8H8A28dU+d4Yh4OtbzfsyKL7svtDzDzTQB8SDGgolsx2P6tMZ1khcboj7ngJKW9BL7KmIX9M8v8tFNmBq7t6WmQ3/fJecUcoF4mPpnWi2MpgCE8/zEer92xAagcrmU/svZzYcxzq4Dmx62j5OWJIrQUvheaQYJhpbzSw7sztRZFxzrrsogEAtKvmhrPupZSCbX9lPmSfdRq+A2rrNicQVb4jYuvshb+tZYM117ICJ9zRVtgDDwCKtIjQmuLTw+Qs4iMujSeIUETvFb7W0zeDVSGbxVaGZRkcenyE7ndsUoJrv78YRvoPkFSioz/baHzqUsHkOXe5e/cu3pOfS3mlNjZ3qYqnK/5TKtL4juYs+fCVnMPP8K9pwCHKTiMbFy6J3/L0vUIMqPGIznNRfj49ixkrwwEm+ZHyxzJ1hriVP73YppQj63Uet2AA5rcxE8v8YMvyB3s4ineLeBpou/bQSTQ7PrYKqjEzi5UgMvQz24cSUeEH/6B+2Aq8qnwglwWDLFSXEaq+sqtS/+PP5pKuK5HAWIapLvTalsj94tgh01I7RSZ5kLy8DBgFMHCnsG269QMjTY6Pi8KwkjaH30YZ0C5m/Izh4dVkQ8FAlGASl4UKGpMBXms83nuf5hyynPtRH/FH8FKhupIoKs+ECrZWJfmXzR5RPPkHI+AjYfKfYzEgKXQOG4LGnX5diuh8WtSP9PRhYRZeEsnScjzfSrETL2l8coqL5XCCOL0Gck8XQdmQ4SUOWNKUC6AhmLtilM/np0ERmBRFiQaOwsHWNwrjTcqn0QWmlAOovLuC4QLM6lA5Fh+kMiAQBXzBtJiOkFKV5NFh24oSRz4zg7m3DUpowSdEwECefWehiJlNmenGC+5o0VHVtAl7koroIHMNCrcZdJ7JCqMTOJ8HrW6KNCcreU+wWF1LQnHSeSydKkM1O7/yehyvi+HeoVhnZaYpbNOh+vh8qER4r2G8oER8cu+yDXOJDEPzrFficP4vhWpgv9SsMMMyrpTTb3929gKG+/p7A+xDurdiTKJJfyLZWkZcO4F0wdBbCCiF2peKNYOiK3z/wrkWHv17KBS4OOGpkI1kBZD7PfTQjbSx3gwJMQuCXXvDYT0FiBdpYiN+PFtf3iuK2hzn5XgORs9aiQKLfMepo4GWx1GGaZOyh1LM1pEbTYOpKKeRzzDNq0661DymiBlAC2yNTWtrMk8GICmRFpv9r3qxvdSU1vX6DkNJ0ghgESJK1f50uak9I7HUfCznobkYn2pKiROMJ7P2A18f18D0iVgiTJI2XJbk6XxlqFXmOQc6JoDeBV85GHM1fgpdu93XdRhQ7aJmyc9yp9hhpaBJyyO0gM9WlX33s7KrzPCf9hGAblbjrgWmfLDIVUdRkFqeAHCRb+ilrMSwQ4sIaWPYS0mTpCI0Q8oGoFXBWmivH4ov9SdVlFWHigubeUJq6+rqJeNrGiLlABYsupuGKH960pwemvh3E8tsnBv0oVzrRjmdKM6VyKvtE83iNiFZvTGEVLd/eQC5U3DVqFqGsX0AYVEB921ZzZienPpgVb2nCXnvP9PhKjOvUNs4vOSGN0uEZTJVmdpr/EdabsvU4qvOwvnJqLsdo+xQGoLZnQUMDvMQCAP8S1WpIwe6jm4ZhZCCrWbaqJhotbgilaJnnY33vaD4u3+hDe1fi8/1eQqFcaLC7DiEmFYzeMRxiU0J+oMaBjOSbKay0BVLSw0iYjUz0QbFcD6HiLtVuXZyOzp/j6P19U+aVS2bsiLoww6hm8JWt7A/vQ40YyNeIDoW2go5i6T1brPAvbv7qMo9heMl4Hd8DDUaiRXPseEFwfxMXJAcasQr87Jv1hMIprE9BEp8MI6Ez9OMk9/t9QqCOLXtRF5zsaDLaVaVV+1LfEzfb0dZYUuQ982tWcMc0HrNlvwMHgTwM0ThixmvS8TsJ196PDZ5pc9IVtqR7aAJScAsUiAzQLHeLb2jEJ+mxKZzrU9KRUKwQrLtkPnabrzbvlBYG1DG9gZGPL5T3eqQUn4PseH/0JsIAPviS0aIQbZUw+lNzFHZfc46WXGVrN6bOIWaPCqA7JgPBO2Re8xh8K7u8gHiKhZOa2/x8sCLjxL/1ZcfYexrTCPTGqViJHDyHsEDder49dItB4i110yCQl2YoTbhZrhoyI8n9jldu2RbVAMJpMCM7kD+d3orO/wvhErPJT2TZGpOMg7Rj5U3LnNd5viDPk+6A1gc1nIEp3VxQq/YWjZJY2K8AoGEN6M+Nvd7JJAF1ykEI15m0sxrWBJ7g+1rsB07jodS9buNs8gRosvygMPWqgH0M2uBYAboU4RGIkSZz1dkxc16mo+6/zBBQ4GrG1c3RmTQt+QEFzW1cpidaVsBDwyWyI1yvqIXNDUwGIAY12KDJwpwLP0c5VEcZC4CjoAoAoDYGJPQCIyCap6dNce87ca78jLZ9QbYkILo1XfpoDqK13Kkw3V5If/V4XsxGM83XM6WfZKK3NEOpGxLxQqFQqFQqEzb5NkTlXEZVe+vSEbD3wA+8A/wKWh2GQDmZpQ9JlMT/zF8iAX8DgVxIy2mpYcLTNl1V2surN3DJeOCfGo/yf4j7g0Sb6hJ/gQAAAAAa9vXn//8O7/hX/9qaFC1gJP6vc/ignP0vGMYcyu5YoJz9LxjGHMruWKCc/S8YxhzK7ligoDvwj2VTtTk8VOBYIFggWCHb5PwIAAB1siycEtdS9Lu+q0Qz8RqEwsOe/a62/U9x7VKjdI8rBb9dLkHpObziogVAUykYTi5c8u60XbPvOUfZnYlVYVIFaUPMp/YgST1SsRSTE+40y1uO2ccclvCLC0zy0xUwubHdxdGhF3fX+L/wBbqYqCBgd/sojea9LwJy+1PP7IEFFI84lI7PpFtctInWjmQBKOaPdzz08afBhiSnJhJO9oVuvYG9G5qG4FuOjDS60ngN0WGHuzQvyccvlEoQVTISArY1i99EKyUajsqPQtU8HWysZkWL/tHtXWC0FL3pk31F5mvIu3ou/gJLNbDLIc0u8rclWbQZ1orjgcTqp+DJzmEM/xibup7ECWSP7xG4kxqPZOsd7fhwYAp+fwEcDkxzqYNJp1DcDduLkuSF5lKwiPFz4DLxWg8NNT5TsHIOrDbjNl+ZJO9UT93y/av4iAJSo/lxxMMOZ8ziHh1EN80fflo8Hnd3A/eQxFVW4FPCK9KL2sADnTSHZORWKlRl6nGzfucY4hbGWYNvXtlezzQOODvI2/hztQ1yNldP6hf9pxwvAXMPcBESCdARypOeG/50PErG+B+PjhKI/OwraN1N+kR1RHR+Qkv8bhu7QGLE5bxO3dqt3HDcIPOfYib3yKGJljraUKAteFLgzxST8p7zR1635+hwz22SGdc+xEU+wH0UrY9YfaMABW2PKgiRxYcdgEjHdMImI1z9JVRe8A/PYAA9/dzf9eka+6TBbYyRFUFrKy8M4wwlvnDSkprAlgegr+7NlriJtSIOeGUBZb/0Lbtyz2I033OUbf12xczNOZM6KHa/zWeeM9h30hzsvyhZLl4mMRzletUIgmmWvy7U/991icmwlKJpRKYbS5PUasulYZa8/Z3UYXHzRDpDP8GdkM1cUN3a/dpcOKuu+ZsC5Qw/IKuqhSUxmEdRycJ5IAoAS3GbZgfPj0qR0LPtAdBkwkwZ3IgLpVCPqbDeTC34DYSxNSsjEB0uQM0E7tgGP+TllKOvnYVE1GGt4zX41eglWdprBGvfjKJwzRjCaRWW+9fv77vNR0jFLqQ3WdFASsjmqUxzrKokl5VNwq6jzqlfj070zX5bjmt+P7eJPxc8xqlKf0chRU4p6/UbeFY3wHqnBtrw4MXvvs+H7Nz4AKmqeK3o8W2LHOf60VBP5HyVz8hJVJ1nafaz7/YD4KmZ8qM27c7NuvStyfptnS/r8kRpNG97yvOIGZnQlC9iwF9StPZEXZCbFzmS4irBCXayAfIGwnSGqkRD/Uk0pkx1RUHN3/BWPbFCm3vTbJWtL5n7ER5MWJLZ0RG1W7Jft5tQnMTcUNdffnc3/w0bjsg83pugWN+B+6+1Fk7LQFIsAAkc0lDqO0cp9yX9BdE1+ekfNWDgMUJyaH6HZ7bxhAG0BvlWO4lH+tPbKTfy8N1KLUMKEpgAiZQ5nxjLgLnewAAHjkZtzMuGFtyKpir1actm+udEPjuwLquTRs8QCV9FX6CEAF3ar7RFy9NMeVtWestEIcUt0CyPtTL+yfSExyyQ4n7T/lJ5yQKg0G3QhVRjPjLL5gNYn+BOtWKC+HseR8rvBcDw8+Ubva7HgMDBtgDDgkbIQJX/GHRDUAdJMyw9+ixSMC9ignvE+rycTZMbliCiEjktlQ4AAc/XhQoJzBpoXNlKO9UevgQUa+DUseu6iMLcIIWOq7EW4fK932lrcZKXE9LLzpsZ+09tQDvyAHBiMhZUJlPbvTNxxddT4m08Tz3mLxZpoTo0sq/+I9Mt2ugJttSxoYO00U+IfiVK7tmWh3g2IUg3xwQNsMld9IFUEOr72YwgbsuaeWdf/V/+mBuBlCSenBMpiC7PluSSFmpE5aEq6P7qAzxmzOW5LKebrxz64L0nzPcVYv4xsjRBX2jTgcZ+QaEkKaLu4cI8DO0hev29b2JFVmwRvaSDl22eq0TE9t6Yle5R8nUOaTDuLxWes0ix6UlGMgb5glr0gU9uMT29oLusAJUohTHhluJB2RiQoAaPdc6sK2DCeKzSuUP8J13zyPbqD+gShCSQ2+EOWxVsBOOANPFEZGIIVThCGfQ9XjDu1ku5m9nN9C6W5SiMG/+7MTDrgmey2MRHdDYXGb8hVGRn5R00QHD6k0gW5mKFjRyDuCUceHbIDoBRdqVUQpVTezlrFKmUMjb0wdDsdNBcQsXU95Uo4gUtbRe/hEhkClGkyOgkJsDQJrj19xg7N2D8+0ObOR6XBSXgtY1XqUmzmmxEWvxeglsJkwu6Uu/D3IbAnAYlPGu/CBtI+QOLgJ12P41AuQjw8kHNJj9h6wQCmjgQhvwza6nHeMNJmCjc/S+/2LI80Uur2tsg/F9r5Q7mqPKqkzs0BI1749RxRVmvkqkAU2DAYZnirvSMT4SdFp61EGjMC41zBYtClpAQbbBPTntTsZi2WLDRoW40K/thuRW0GsziPC/KBSVW+D5nJE0OFpFfyJM76NPdJajnTJN6HMFqr73AAAAWUwQtuVxsGih1dMksqfwFGm1j2Fd6YvTTha5EkFId/3EIpRIG8DMIahxhu3ZGqtyK/as30imnvrERmxPvCCtzo5AephfN3t6pK85ENpSbmXdUvCCQX6tNTr/1M0JQ2EtpaQoKxci9eITXQfpwQyd031wy12ko/TnsGrkZQvohf661aiDrmi5a1mgbFqeGph8jJ87FxsObyTm418f5U1ULB0x2gHeMnJeawA7RwrkxoneKYaFZUOSXoaMbI7yMrVrbGra0R+qFElWGM8tD1qio6C/7wBrJ10AbCgn9eQHOeFQMhfa7hRt3B5KT5P/dEQoe62RbT6fx6V4Frhda6glRXEHkKozeKjBG7OXWjPcAa48IRMW2O8GsYhs/a0dapjvnGFc9rBp0CYpXuDT2oQ9HLToenOe1ySQWd/zmmVqRBTZiqa3fu1P1mikRKZ8cyOVopnWAsApF4m1/SILS3rz928pfI/TS4/DvsnlDSnZe9XwmQaS/2AeQuHEiu+PGIVE/IpEn7OX5OOHw+vz7m4CuBrhvxVBd4cD192nJai8KxpuEes3w7w9OKo6L8Ibgfql4gV3KPTg30S21ozQy073a6z3WdONgXV4ueTz97GCWhA4L1sTh/vmBGyyfZt7ky7x66dYAkR7w56N6kHU1eN3C7rk0sxr3Sth1V9wgyPdfdd2GVjOfxDILA9Xdp9J710OFC9zCggQthWpTkO3/I0SuNLKxZoBfkQ9ROCYgJxpOqSMTBIotUp+cNMEmBvgxDH3wosSJ9Fn30V0zsVVaotKrz7P4N4SDqWHvzb/JSwSjEqSh4EJ4AinAtRbYwQFxwP0aQxlo3hHjNXY8IbiXnuMh4ZM+YYNLVKXdAed+giBWcQckLbz5gtVE8NMQnKKTAX9mCooG0LViyYSTYk2WGo3D9tqUQugYtUFF1T8SVE1e+7wa1zk3UPHZuNd+0LRYWi4JI3EWzWSrhH4BKsv0CcAveku/sr6rMjZ6MtIqzZRcXtHo7w9/64JcaLkxj8cq3txR1XN3pJoxMNQj+4uEuo+MQDGQGHJhwcs73mSbiXwLtP8Epq/RhfROeJnKMroQahJEL8sCv0aK9yt3c4uBaW1c2w5fl6ndkSzpzV7rn/N8S2EgtoycMsGmwmEefDvMsKO7dphqEcRqZstqHbfYRlNXkikE/q4ussvGhyq83VJZ0qyMfPFHr8uWbnpFI9qjc/RjJHSOYOM+UCaeB4uA3Dtz/isNFJevurnAUQK6Bs2e2p9HY21fXNXgO1QtAmZCaW5WF7+ACBvtLu2+Jj8ZPFQ6BO5VQUINO9LqH7Y5CXHccOYsPIYqX9BnW1lDMlyzfHmU8UNyEAKpLrl/x3QHTwcdaaOaO7fkGblpCkq7wQBAp+6WSIgVqRab+CulAUq0l5G7rgk9qYeCYLGve9oMb7Z00pkGHZychK+VHljBZ93k/i56csZwcYoO+qVVOA+IlYSLME+tEbVAsDCkm/XK4423viKMpdXXPaIvRCPGbBwZHT0o44Mg0Fjx0z1fnlsNbxgyXXdQCnd++ZU3x1ptEnCK6eM2Qecw/tseBDPmq0ZxEyyx+CFppe42216mwhNytxXl8JTIAmOiToUEavlCYsKWoQfBRy2kKn/ivnzksnD+hcJVFtBZzO6a1Q+gX28hhAo8szn0czZ4J7rAyIqgiIbmPPEzB21Ex9xYy67AiAKh0KFOuhOgQAD88/k2IAObZwSnJLPGSlRLSptKkGh6dEXkH20n0md/8kZGAfU1IBw6AWlCCVDcEXBJ0ZLNMkIoigS9CHMQwn2bAqoKfvEfVIpIXgFhaSbD+EUSFZONOuzIu6nd8mPJIsh0a0l5NxC3czBDo+XKpnHJ/xfojR3ADUtFwzCBcEaWVRWaHfRlG6+iSFsVyxYqCGhsOYdyW4p8Tgfxn5IUcMwvTc9lZ1Jh/P7OLsE/KTZCFL+fnvFkqTlDOX6qcHv+0Xsamp4IXWpgMQhDA9plo40dX8BC1J4p0V1x1EAgzAUsell15QdiAPu01St+JNE7cFsZnghP94vfW7wPY+iKqwQGC+QJUka00m6un1o5g5QKs6CeSjsMpmUNaGVr8452fZmy8MPKinWcfow3RrPguQaCz8J+t5kyMLpZ1SMHd4K1DRHUN+1p4ykEh3yGsape4lSksowvtfXP8jJYaFUxIfGYc5klzgRQPhPo3Myjf72DozliereonCkafjRcGCWvcQkT3xCxAU+YrKo+5/shrjFK640en+GJ/bkU9miiP5IfGiQ/dwXzTmAGEignK2U3OhCdCF2r9Qam7t1tI0eo0YXGInSobmkgumP+all6Jz526oUqQVDRhU6AmbF9CG1wl4jy9Z4Z7BtRzBiV5PJNJQNZ5Hnxi4ZN2+Em6mP2nXEp3uV8hlZxdPN/G2a0wEZhA3dxcL6Sekk99zvEOS38MPJ02CUvyIpHXF3lNUaYVo1L/iD8ADScz9s1f4GkpjaZKOBkdfTAcu1BtAxAWJz+mwmLdoPxUbmVtkL2vMcW5omKViKJLhlverei1DtMiBgOhcv9JaH9AFuqaQ/x91KYVTzYfsC3NonHRKBarsvLl8YlTqRDiQdxJNxAQeYo7x9rjfpG200BBe/czLnJdQZOWiARWG1InbxqOcgZZDFYQmWUTfkunCZr4flDf+tyanfSlFq+doZK4ihz4gtAVYxVmUDdrJrSoIWuoia9iYF9uWx/73IlacsIXaJMrumamNBn1gVwCCamSi2F60gkjwyKIQTP13VQBFcsVewhKCQojFgvPCUXD8qoNmtMeZ1ypeE4UqjcfhviXZh3O5eOJMv024sEm0nCwi0/B1SfIBd9DOs9NeSK1Yz4XVnHg0scjMeYPwtxBj3Hhotiul3Cpc6O3EcKBYb5LbuaCA6xgiVk3PJSNP3J6RqbkC/KShzZtER405577hyenpYPoNuYPV5ONE4obfhy3eyxGE/pyGYThtSwnO/bhvd0/BnDiy4vxzkMrzvQYXf1CEP1x3IMbLUKwTkmOWjkAIlL3oalTJCD6XTIuPphbHJWdbg4r1miaSD32pSdnONwy3Ycflc88ZbVSDjDq5poLbSPegDvVzE7o+GNXXpSg9Uxgj+kQDMhFB8iqwDyEYM9UsJKeyDH3Jpn8keIslWM41Y2XhGW3KqdYn0+Z4vkDiXIjv0PE0GaOfnk+ANiNx2OVHJpo69N+Stw1k4QmxYeGE7AluBhGYgmETC0dk3E+nQAEGQtgq5owWyjPJJuJMVgW7iAhgQe8JDlpgq2Q6QTIAwb4E0LuHq9sWMaCopfT8d0Vv5m5TvIJcDraBKRbjKG9vhv5EdnDKw3kP21tZg4qDi2xSWAAAA="
+      },
+      "nodes": {
+        "1-35-IMG": {
+          "width": 101,
+          "height": 32,
+          "bottom": 1498,
+          "left": 5019,
+          "top": 1466,
+          "right": 5119
+        },
+        "page-0-IMG": {
+          "width": 59,
+          "right": 106,
+          "left": 48,
+          "top": 2026,
+          "height": 59,
+          "bottom": 2085
+        },
+        "1-47-IMG": {
+          "width": 96,
+          "right": 7177,
+          "left": 7081,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32
+        },
+        "1-50-IMG": {
+          "width": 59,
+          "height": 59,
+          "bottom": 2085,
+          "left": 48,
+          "top": 2026,
+          "right": 106
+        },
+        "1-63-IMG": {
+          "right": 389,
+          "bottom": 13048,
+          "height": 32,
+          "left": 359,
+          "top": 13016,
+          "width": 30,
+          "id": "open-path"
+        },
+        "page-15-IMG": {
+          "right": 5120,
+          "bottom": 1498,
+          "height": 32,
+          "left": 5020,
+          "top": 1466,
+          "width": 101
+        },
+        "page-57-IMG": {
+          "width": 96,
+          "right": 4624,
+          "bottom": 1498,
+          "height": 32,
+          "left": 4528,
+          "top": 1466
+        },
+        "page-19-BUTTON": {
+          "height": 40,
+          "bottom": 77,
+          "left": 348,
+          "top": 37,
+          "right": 388,
+          "width": 40,
+          "id": "dialog::R18j5::trigger"
+        },
+        "page-33-IMG": {
+          "right": 2210,
+          "height": 32,
+          "bottom": 1498,
+          "left": 2116,
+          "top": 1466,
+          "width": 94
+        },
+        "page-34-IMG": {
+          "width": 101,
+          "height": 32,
+          "bottom": 1498,
+          "left": 2290,
+          "top": 1466,
+          "right": 2391
+        },
+        "page-51-IMG": {
+          "width": 96,
+          "right": 4448,
+          "height": 32,
+          "bottom": 1498,
+          "left": 4352,
+          "top": 1466
+        },
+        "1-13-IMG": {
+          "left": 1322,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32,
+          "right": 1418,
+          "width": 96
+        },
+        "1-26-IMG": {
+          "right": 3577,
+          "top": 1466,
+          "left": 3500,
+          "bottom": 1498,
+          "height": 32,
+          "width": 78
+        },
+        "1-44-IMG": {
+          "right": 6702,
+          "top": 1466,
+          "left": 6601,
+          "height": 32,
+          "bottom": 1498,
+          "width": 101
+        },
+        "page-6-IMG": {
+          "right": 5648,
+          "top": 1466,
+          "left": 5549,
+          "bottom": 1498,
+          "height": 32,
+          "width": 99
+        },
+        "1-48-IMG": {
+          "right": 7353,
+          "left": 7257,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32,
+          "width": 96
+        },
+        "1-31-IMG": {
+          "height": 32,
+          "bottom": 1498,
+          "left": 4351,
+          "top": 1466,
+          "right": 4447,
+          "width": 96
+        },
+        "page-36-IMG": {
+          "right": 2918,
+          "bottom": 1498,
+          "height": 32,
+          "left": 2819,
+          "top": 1466,
+          "width": 99
+        },
+        "1-53-IMG": {
+          "width": 24,
+          "left": 239,
+          "top": 10869,
+          "height": 24,
+          "bottom": 10893,
+          "right": 263
+        },
+        "1-17-IMG": {
+          "top": 1466,
+          "left": 1973,
+          "bottom": 1498,
+          "height": 32,
+          "right": 2035,
+          "width": 62
+        },
+        "page-66-DIV": {
+          "width": 8189,
+          "right": 7536,
+          "bottom": 1498,
+          "height": 32,
+          "left": -654,
+          "top": 1466
+        },
+        "page-16-IMG": {
+          "width": 78,
+          "right": 6308,
+          "left": 6230,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32
+        },
+        "page-45-IMG": {
+          "width": 96,
+          "right": 1419,
+          "left": 1323,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32
+        },
+        "1-27-IMG": {
+          "left": 3657,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498,
+          "right": 3791,
+          "width": 134
+        },
+        "page-63-g": {
+          "width": 82,
+          "height": 133,
+          "bottom": 1040,
+          "left": 48,
+          "top": 907,
+          "right": 130
+        },
+        "page-32-IMG": {
+          "width": 101,
+          "right": 1243,
+          "top": 1466,
+          "left": 1143,
+          "height": 32,
+          "bottom": 1498
+        },
+        "page-7-IMG": {
+          "width": 90,
+          "right": 5290,
+          "left": 5200,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498
+        },
+        "1-59-IMG": {
+          "left": 239,
+          "top": 11049,
+          "bottom": 11073,
+          "height": 24,
+          "right": 263,
+          "width": 24
+        },
+        "1-61-IMG": {
+          "width": 24,
+          "right": 173,
+          "height": 24,
+          "bottom": 11163,
+          "left": 149,
+          "top": 11139
+        },
+        "page-53-IMG": {
+          "width": 43,
+          "right": 1542,
+          "top": 1466,
+          "left": 1499,
+          "bottom": 1498,
+          "height": 32
+        },
+        "1-8-IMG": {
+          "width": 101,
+          "left": 428,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498,
+          "right": 529
+        },
+        "1-1-IMG": {
+          "width": 0,
+          "right": 0,
+          "left": 0,
+          "top": 0,
+          "bottom": 0,
+          "height": 0
+        },
+        "1-14-IMG": {
+          "right": 1541,
+          "bottom": 1498,
+          "height": 32,
+          "left": 1498,
+          "top": 1466,
+          "width": 43
+        },
+        "page-38-IMG": {
+          "width": 101,
+          "height": 32,
+          "bottom": 1498,
+          "left": 3159,
+          "top": 1466,
+          "right": 3260
+        },
+        "page-31-IMG": {
+          "width": 134,
+          "top": 1466,
+          "left": 929,
+          "bottom": 1498,
+          "height": 32,
+          "right": 1063
+        },
+        "1-41-IMG": {
+          "right": 6149,
+          "left": 6069,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498,
+          "width": 81
+        },
+        "1-34-IMG": {
+          "right": 4939,
+          "top": 1466,
+          "left": 4845,
+          "height": 32,
+          "bottom": 1498,
+          "width": 94
+        },
+        "page-61-g": {
+          "width": 114,
+          "right": 352,
+          "left": 238,
+          "top": 781,
+          "height": 146,
+          "bottom": 927
+        },
+        "page-25-IMG": {
+          "width": 101,
+          "right": -339,
+          "height": 32,
+          "bottom": 1498,
+          "left": -440,
+          "top": 1466
+        },
+        "page-22-BODY": {
+          "width": 412,
+          "right": 412,
+          "left": 0,
+          "top": 0,
+          "height": 13078,
+          "bottom": 13078
+        },
+        "1-5-IMG": {
+          "width": 99,
+          "bottom": 1498,
+          "height": 32,
+          "left": -91,
+          "top": 1466,
+          "right": 8
+        },
+        "1-24-IMG": {
+          "width": 101,
+          "height": 32,
+          "bottom": 1498,
+          "left": 3158,
+          "top": 1466,
+          "right": 3259
+        },
+        "1-9-IMG": {
+          "width": 81,
+          "right": 690,
+          "left": 609,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32
+        },
+        "page-21-META": {
+          "width": 0,
+          "left": 0,
+          "top": 0,
+          "height": 0,
+          "bottom": 0,
+          "right": 0
+        },
+        "page-44-IMG": {
+          "width": 81,
+          "right": 691,
+          "bottom": 1498,
+          "height": 32,
+          "left": 610,
+          "top": 1466
+        },
+        "page-37-IMG": {
+          "bottom": 1498,
+          "height": 32,
+          "top": 1466,
+          "left": 2998,
+          "right": 3079,
+          "width": 81
+        },
+        "page-46-IMG": {
+          "width": 96,
+          "right": 1718,
+          "left": 1622,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498
+        },
+        "1-54-IMG": {
+          "width": 24,
+          "top": 10869,
+          "left": 329,
+          "bottom": 10893,
+          "height": 24,
+          "right": 353
+        },
+        "page-12-IMG": {
+          "right": 7354,
+          "left": 7258,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32,
+          "width": 96
+        },
+        "page-8-IMG": {
+          "height": 40,
+          "bottom": 77,
+          "left": 33,
+          "top": 37,
+          "right": 167,
+          "width": 134
+        },
+        "page-58-DIV": {
+          "id": "ago-prompt",
+          "width": 401,
+          "right": 401,
+          "left": 0,
+          "top": 12874,
+          "height": 125,
+          "bottom": 12999
+        },
+        "page-64-g": {
+          "height": 133,
+          "bottom": 1046,
+          "left": 143,
+          "top": 913,
+          "right": 225,
+          "width": 82
+        },
+        "page-49-IMG": {
+          "width": 81,
+          "left": 3340,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32,
+          "right": 3421
+        },
+        "page-30-IMG": {
+          "left": 771,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498,
+          "right": 849,
+          "width": 78
+        },
+        "1-29-IMG": {
+          "width": 96,
+          "left": 4052,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498,
+          "right": 4148
+        },
+        "page-29-IMG": {
+          "width": 101,
+          "bottom": 1498,
+          "height": 32,
+          "left": 429,
+          "top": 1466,
+          "right": 530
+        },
+        "1-4-IMG": {
+          "width": 90,
+          "right": -171,
+          "bottom": 1498,
+          "height": 32,
+          "left": -260,
+          "top": 1466
+        },
+        "1-21-IMG": {
+          "width": 99,
+          "right": 2738,
+          "height": 32,
+          "bottom": 1498,
+          "left": 2639,
+          "top": 1466
+        },
+        "1-23-IMG": {
+          "width": 81,
+          "right": 3078,
+          "height": 32,
+          "bottom": 1498,
+          "left": 2997,
+          "top": 1466
+        },
+        "page-27-IMG": {
+          "left": 89,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498,
+          "right": 188,
+          "width": 99
+        },
+        "page-11-IMG": {
+          "width": 101,
+          "right": 5990,
+          "height": 32,
+          "bottom": 1498,
+          "left": 5889,
+          "top": 1466
+        },
+        "page-67-g": {
+          "width": 177,
+          "height": 114,
+          "bottom": 895,
+          "left": 48,
+          "top": 781,
+          "right": 225
+        },
+        "page-1-IMG": {
+          "width": 134,
+          "right": 6522,
+          "height": 32,
+          "bottom": 1498,
+          "left": 6388,
+          "top": 1466
+        },
+        "1-64-IMG": {
+          "right": 0,
+          "left": 0,
+          "top": 0,
+          "bottom": 0,
+          "height": 0,
+          "width": 0
+        },
+        "1-49-IMG": {
+          "right": 7495,
+          "bottom": 1498,
+          "height": 32,
+          "top": 1466,
+          "left": 7433,
+          "width": 62
+        },
+        "page-68-DIV": {
+          "width": 380,
+          "right": 396,
+          "left": 16,
+          "top": 601,
+          "height": 55,
+          "bottom": 656
+        },
+        "1-33-IMG": {
+          "width": 62,
+          "bottom": 1498,
+          "height": 32,
+          "left": 4703,
+          "top": 1466,
+          "right": 4765
+        },
+        "1-58-IMG": {
+          "width": 24,
+          "right": 83,
+          "top": 11049,
+          "left": 59,
+          "bottom": 11073,
+          "height": 24
+        },
+        "page-18-DIV": {
+          "right": 396,
+          "top": 720,
+          "left": 16,
+          "bottom": 1100,
+          "height": 380,
+          "width": 380
+        },
+        "page-23-rect": {
+          "bottom": 833,
+          "height": 4,
+          "left": 70,
+          "top": 829,
+          "right": 197,
+          "width": 127
+        },
+        "page-28-IMG": {
+          "left": 268,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32,
+          "right": 349,
+          "width": 81
+        },
+        "page-50-IMG": {
+          "width": 96,
+          "right": 4149,
+          "left": 4053,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498
+        },
+        "1-11-IMG": {
+          "width": 134,
+          "top": 1466,
+          "left": 928,
+          "bottom": 1498,
+          "height": 32,
+          "right": 1061
+        },
+        "page-48-IMG": {
+          "width": 99,
+          "bottom": 1498,
+          "height": 32,
+          "left": 2640,
+          "top": 1466,
+          "right": 2739
+        },
+        "1-30-IMG": {
+          "width": 43,
+          "right": 4271,
+          "bottom": 1498,
+          "height": 32,
+          "left": 4228,
+          "top": 1466
+        },
+        "1-7-IMG": {
+          "width": 81,
+          "bottom": 1498,
+          "height": 32,
+          "left": 267,
+          "top": 1466,
+          "right": 348
+        },
+        "1-39-IMG": {
+          "right": 5808,
+          "top": 1466,
+          "left": 5727,
+          "height": 32,
+          "bottom": 1498,
+          "width": 81
+        },
+        "page-39-IMG": {
+          "right": 3578,
+          "left": 3501,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32,
+          "width": 78
+        },
+        "1-55-IMG": {
+          "width": 24,
+          "top": 10959,
+          "left": 59,
+          "bottom": 10983,
+          "height": 24,
+          "right": 83
+        },
+        "1-19-IMG": {
+          "width": 101,
+          "left": 2289,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498,
+          "right": 2390
+        },
+        "page-35-IMG": {
+          "width": 90,
+          "right": 2560,
+          "height": 32,
+          "bottom": 1498,
+          "left": 2471,
+          "top": 1466
+        },
+        "page-43-IMG": {
+          "width": 99,
+          "height": 32,
+          "bottom": 1498,
+          "top": 1466,
+          "left": -90,
+          "right": 9
+        },
+        "1-37-IMG": {
+          "left": 5369,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32,
+          "right": 5468,
+          "width": 99
+        },
+        "page-41-IMG": {
+          "width": 101,
+          "right": 3973,
+          "height": 32,
+          "bottom": 1498,
+          "left": 3872,
+          "top": 1466
+        },
+        "page-62-DIV": {
+          "width": 380,
+          "right": 396,
+          "bottom": 545,
+          "height": 57,
+          "top": 488,
+          "left": 16
+        },
+        "1-22-IMG": {
+          "width": 99,
+          "right": 2917,
+          "left": 2818,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32
+        },
+        "1-52-IMG": {
+          "width": 24,
+          "height": 24,
+          "bottom": 10893,
+          "left": 149,
+          "top": 10869,
+          "right": 173
+        },
+        "page-56-IMG": {
+          "right": 1894,
+          "left": 1798,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498,
+          "width": 96
+        },
+        "page-9-IMG": {
+          "width": 81,
+          "bottom": 1498,
+          "height": 32,
+          "top": 1466,
+          "left": 5728,
+          "right": 5809
+        },
+        "1-38-IMG": {
+          "left": 5548,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32,
+          "right": 5647,
+          "width": 99
+        },
+        "1-25-IMG": {
+          "width": 81,
+          "right": 3420,
+          "height": 32,
+          "bottom": 1498,
+          "top": 1466,
+          "left": 3339
+        },
+        "page-14-IMG": {
+          "width": 96,
+          "right": 6879,
+          "top": 1466,
+          "left": 6783,
+          "height": 32,
+          "bottom": 1498
+        },
+        "1-15-IMG": {
+          "right": 1717,
+          "bottom": 1498,
+          "height": 32,
+          "left": 1621,
+          "top": 1466,
+          "width": 96
+        },
+        "page-60-BUTTON": {
+          "right": 406,
+          "left": 386,
+          "top": 12889,
+          "bottom": 12915,
+          "height": 26,
+          "id": "ago-prompt-close",
+          "width": 20
+        },
+        "page-55-IMG": {
+          "left": 6959,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498,
+          "right": 7002,
+          "width": 43
+        },
+        "page-10-IMG": {
+          "width": 99,
+          "right": 5469,
+          "bottom": 1498,
+          "height": 32,
+          "left": 5370,
+          "top": 1466
+        },
+        "1-65-IMG": {
+          "right": 0,
+          "height": 0,
+          "bottom": 0,
+          "left": 0,
+          "top": 0,
+          "width": 0
+        },
+        "1-36-IMG": {
+          "bottom": 1498,
+          "height": 32,
+          "top": 1466,
+          "left": 5199,
+          "right": 5289,
+          "width": 90
+        },
+        "1-0-IMG": {
+          "width": 134,
+          "right": 167,
+          "left": 33,
+          "top": 37,
+          "height": 40,
+          "bottom": 77
+        },
+        "page-17-P": {
+          "width": 401,
+          "left": 0,
+          "top": 12900,
+          "height": 83,
+          "bottom": 12983,
+          "right": 401
+        },
+        "page-65-P": {
+          "width": 380,
+          "right": 396,
+          "height": 98,
+          "bottom": 448,
+          "left": 16,
+          "top": 350
+        },
+        "1-32-IMG": {
+          "width": 96,
+          "right": 4623,
+          "height": 32,
+          "bottom": 1498,
+          "left": 4527,
+          "top": 1466
+        },
+        "page-40-IMG": {
+          "left": 3658,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498,
+          "right": 3792,
+          "width": 134
+        },
+        "1-57-IMG": {
+          "width": 24,
+          "right": 353,
+          "left": 329,
+          "top": 10959,
+          "height": 24,
+          "bottom": 10983
+        },
+        "1-45-IMG": {
+          "width": 96,
+          "top": 1466,
+          "left": 6782,
+          "bottom": 1498,
+          "height": 32,
+          "right": 6878
+        },
+        "1-42-IMG": {
+          "width": 78,
+          "top": 1466,
+          "left": 6229,
+          "bottom": 1498,
+          "height": 32,
+          "right": 6307
+        },
+        "page-52-IMG": {
+          "height": 32,
+          "bottom": 1498,
+          "left": 4704,
+          "top": 1466,
+          "right": 4766,
+          "width": 62
+        },
+        "1-62-IMG": {
+          "right": 263,
+          "left": 239,
+          "top": 11139,
+          "height": 24,
+          "bottom": 11163,
+          "width": 24
+        },
+        "page-59-g": {
+          "right": 352,
+          "bottom": 1029,
+          "height": 95,
+          "left": 238,
+          "top": 934,
+          "width": 114
+        },
+        "1-43-IMG": {
+          "width": 134,
+          "right": 6521,
+          "height": 32,
+          "bottom": 1498,
+          "left": 6387,
+          "top": 1466
+        },
+        "1-16-IMG": {
+          "bottom": 1498,
+          "height": 32,
+          "top": 1466,
+          "left": 1797,
+          "right": 1893,
+          "width": 96
+        },
+        "page-13-IMG": {
+          "bottom": 1498,
+          "height": 32,
+          "left": 6602,
+          "top": 1466,
+          "right": 6703,
+          "width": 101
+        },
+        "page-4-IMG": {
+          "width": 62,
+          "right": 7496,
+          "bottom": 1498,
+          "height": 32,
+          "left": 7434,
+          "top": 1466
+        },
+        "page-47-IMG": {
+          "width": 62,
+          "height": 32,
+          "bottom": 1498,
+          "top": 1466,
+          "left": 1974,
+          "right": 2036
+        },
+        "page-24-IMG": {
+          "bottom": 1498,
+          "height": 32,
+          "top": 1466,
+          "left": -614,
+          "right": -520,
+          "width": 94
+        },
+        "1-12-IMG": {
+          "bottom": 1498,
+          "height": 32,
+          "left": 1141,
+          "top": 1466,
+          "right": 1242,
+          "width": 101
+        },
+        "1-18-IMG": {
+          "top": 1466,
+          "left": 2115,
+          "height": 32,
+          "bottom": 1498,
+          "right": 2209,
+          "width": 94
+        },
+        "1-2-IMG": {
+          "width": 94,
+          "left": -615,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32,
+          "right": -521
+        },
+        "1-40-IMG": {
+          "width": 101,
+          "bottom": 1498,
+          "height": 32,
+          "left": 5888,
+          "top": 1466,
+          "right": 5989
+        },
+        "page-20-LINK": {
+          "height": 0,
+          "bottom": 0,
+          "top": 0,
+          "left": 0,
+          "right": 0,
+          "width": 0
+        },
+        "page-54-IMG": {
+          "right": 4272,
+          "left": 4229,
+          "top": 1466,
+          "height": 32,
+          "bottom": 1498,
+          "width": 43
+        },
+        "1-10-IMG": {
+          "right": 848,
+          "height": 32,
+          "bottom": 1498,
+          "top": 1466,
+          "left": 770,
+          "width": 78
+        },
+        "page-3-IMG": {
+          "width": 81,
+          "right": 6150,
+          "left": 6070,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32
+        },
+        "1-46-IMG": {
+          "width": 43,
+          "right": 7001,
+          "height": 32,
+          "bottom": 1498,
+          "left": 6958,
+          "top": 1466
+        },
+        "1-28-IMG": {
+          "width": 101,
+          "right": 3972,
+          "bottom": 1498,
+          "height": 32,
+          "top": 1466,
+          "left": 3871
+        },
+        "page-2-IMG": {
+          "height": 32,
+          "bottom": 1498,
+          "left": 7082,
+          "top": 1466,
+          "right": 7178,
+          "width": 96
+        },
+        "page-5-IMG": {
+          "height": 32,
+          "bottom": 13048,
+          "left": 359,
+          "top": 13016,
+          "right": 389,
+          "width": 30,
+          "id": "open-path"
+        },
+        "page-42-IMG": {
+          "left": 4846,
+          "top": 1466,
+          "bottom": 1498,
+          "height": 32,
+          "right": 4940,
+          "width": 94
+        },
+        "page-26-IMG": {
+          "top": 1466,
+          "left": -259,
+          "bottom": 1498,
+          "height": 32,
+          "right": -170,
+          "width": 90
+        },
+        "1-60-IMG": {
+          "right": 353,
+          "top": 11049,
+          "left": 329,
+          "bottom": 11073,
+          "height": 24,
+          "width": 24
+        },
+        "1-6-IMG": {
+          "right": 187,
+          "top": 1466,
+          "left": 88,
+          "height": 32,
+          "bottom": 1498,
+          "width": 99
+        },
+        "1-3-IMG": {
+          "width": 101,
+          "top": 1466,
+          "left": -441,
+          "bottom": 1498,
+          "height": 32,
+          "right": -340
+        },
+        "1-56-IMG": {
+          "width": 24,
+          "right": 173,
+          "left": 149,
+          "top": 10959,
+          "height": 24,
+          "bottom": 10983
+        },
+        "1-20-IMG": {
+          "width": 90,
+          "right": 2559,
+          "height": 32,
+          "bottom": 1498,
+          "left": 2470,
+          "top": 1466
+        },
+        "1-51-IMG": {
+          "bottom": 10893,
+          "height": 24,
+          "top": 10869,
+          "left": 59,
+          "right": 83,
+          "width": 24
+        }
+      }
+    }
+  },
+  "analysisUTCTimestamp": "2026-05-15T09:28:01.261Z"
+}

--- a/tmp/perf-20260515/psi-jobs.json
+++ b/tmp/perf-20260515/psi-jobs.json
@@ -1,0 +1,6187 @@
+{
+  "captchaResult": "CAPTCHA_NOT_NEEDED",
+  "kind": "pagespeedonline#result",
+  "id": "https://www.ocobo.co/jobs",
+  "loadingExperience": {
+    "initial_url": "https://www.ocobo.co/jobs"
+  },
+  "lighthouseResult": {
+    "requestedUrl": "https://www.ocobo.co/jobs",
+    "finalUrl": "https://www.ocobo.co/jobs",
+    "mainDocumentUrl": "https://www.ocobo.co/jobs",
+    "finalDisplayedUrl": "https://www.ocobo.co/jobs",
+    "lighthouseVersion": "13.0.1",
+    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+    "fetchTime": "2026-05-15T09:29:48.373Z",
+    "environment": {
+      "networkUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36",
+      "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/146.0.7680.177 Safari/537.36",
+      "benchmarkIndex": 720.5
+    },
+    "runWarnings": [],
+    "configSettings": {
+      "emulatedFormFactor": "mobile",
+      "formFactor": "mobile",
+      "locale": "en-US",
+      "onlyCategories": [
+        "performance"
+      ],
+      "channel": "lr"
+    },
+    "audits": {
+      "legacy-javascript-insight": {
+        "id": "legacy-javascript-insight",
+        "title": "Legacy JavaScript",
+        "description": "Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile [Baseline](https://web.dev/articles/baseline-and-polyfills) features, unless you know you must support older browsers. [Learn why most sites can deploy ES6+ code without transpiling](https://developer.chrome.com/docs/performance/insights/legacy-javascript)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 14 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "type": "debugdata",
+            "wastedBytes": 13897
+          },
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "subItemsHeading": {
+                "valueType": "source-location",
+                "key": "location"
+              },
+              "label": "URL"
+            },
+            {
+              "valueType": "code",
+              "subItemsHeading": {
+                "key": "signal"
+              },
+              "key": null
+            },
+            {
+              "label": "Wasted bytes",
+              "key": "wastedBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "items": [
+            {
+              "wastedBytes": 13897,
+              "subItems": {
+                "items": [
+                  {
+                    "location": {
+                      "line": 1,
+                      "type": "source-location",
+                      "column": 6239,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "urlProvider": "network"
+                    },
+                    "signal": "Array.prototype.concat"
+                  },
+                  {
+                    "location": {
+                      "urlProvider": "network",
+                      "column": 12925,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "type": "source-location",
+                      "line": 1
+                    },
+                    "signal": "Array.prototype.slice"
+                  },
+                  {
+                    "location": {
+                      "line": 1,
+                      "column": 12813,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+                      "type": "source-location",
+                      "urlProvider": "network"
+                    },
+                    "signal": "Object.assign"
+                  },
+                  {
+                    "location": {
+                      "urlProvider": "network",
+                      "line": 1,
+                      "type": "source-location",
+                      "column": 10857,
+                      "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                    },
+                    "signal": "Object.create"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "unsized-images": {
+        "id": "unsized-images",
+        "title": "Image elements do not have explicit `width` and `height`",
+        "description": "Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [
+            {
+              "node": {
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                "path": "1,HTML,1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "lhId": "1-0-IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "nodeLabel": "Ocobo",
+                "boundingRect": {
+                  "left": 33,
+                  "top": 37,
+                  "bottom": 77,
+                  "width": 134,
+                  "right": 167,
+                  "height": 40
+                }
+              },
+              "url": "https://www.ocobo.co/logo-ocobo.png"
+            }
+          ],
+          "type": "table",
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            }
+          ]
+        }
+      },
+      "script-treemap-data": {
+        "id": "script-treemap-data",
+        "title": "Script Treemap Data",
+        "description": "Used for treemap app",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "type": "treemap-data",
+          "nodes": [
+            {
+              "name": "https://www.ocobo.co/jobs",
+              "encodedBytes": 9557,
+              "children": [
+                {
+                  "unusedBytes": 0,
+                  "name": "(inline) window.dataLaye…",
+                  "resourceBytes": 298
+                },
+                {
+                  "name": "(inline) window.AGO = {\n…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 631
+                },
+                {
+                  "resourceBytes": 592,
+                  "unusedBytes": 0,
+                  "name": "(inline) ((storageKey2, …"
+                },
+                {
+                  "resourceBytes": 520,
+                  "name": "(inline) window.__reactR…",
+                  "unusedBytes": 0
+                },
+                {
+                  "unusedBytes": 0,
+                  "name": "(inline) window.__reactR…",
+                  "resourceBytes": 42302
+                },
+                {
+                  "name": "(inline) window.__reactR…",
+                  "unusedBytes": 0,
+                  "resourceBytes": 53
+                },
+                {
+                  "resourceBytes": 6432,
+                  "unusedBytes": 0,
+                  "name": "(inline) ;\nimport * as r…"
+                }
+              ],
+              "resourceBytes": 50828
+            },
+            {
+              "resourceBytes": 9792,
+              "encodedBytes": 3946,
+              "unusedBytes": 749,
+              "name": "https://www.ocobo.co/assets/root-HtXVBFii.js"
+            },
+            {
+              "resourceBytes": 125385,
+              "encodedBytes": 43336,
+              "unusedBytes": 72349,
+              "name": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            },
+            {
+              "encodedBytes": 878,
+              "resourceBytes": 927,
+              "name": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "unusedBytes": 0
+            },
+            {
+              "name": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "unusedBytes": 1084,
+              "encodedBytes": 1562,
+              "resourceBytes": 3192
+            },
+            {
+              "unusedBytes": 89,
+              "name": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "resourceBytes": 983,
+              "encodedBytes": 929
+            },
+            {
+              "encodedBytes": 80,
+              "resourceBytes": 141,
+              "name": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "unusedBytes": 6
+            },
+            {
+              "encodedBytes": 683,
+              "resourceBytes": 1284,
+              "name": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "unusedBytes": 467
+            },
+            {
+              "resourceBytes": 15426,
+              "encodedBytes": 6232,
+              "unusedBytes": 1144,
+              "name": "https://www.ocobo.co/assets/cx-DiffRdtV.js"
+            },
+            {
+              "unusedBytes": 1545,
+              "name": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "resourceBytes": 17234,
+              "encodedBytes": 5641
+            },
+            {
+              "encodedBytes": 1271,
+              "resourceBytes": 3070,
+              "name": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "unusedBytes": 1266
+            },
+            {
+              "encodedBytes": 367,
+              "resourceBytes": 428,
+              "name": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "unusedBytes": 239
+            },
+            {
+              "encodedBytes": 349,
+              "resourceBytes": 410,
+              "name": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 65,
+              "name": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "resourceBytes": 525,
+              "encodedBytes": 463
+            },
+            {
+              "encodedBytes": 880,
+              "resourceBytes": 942,
+              "name": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "unusedBytes": 362
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "resourceBytes": 349,
+              "encodedBytes": 303
+            },
+            {
+              "name": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "unusedBytes": 0,
+              "encodedBytes": 779,
+              "resourceBytes": 1866
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "resourceBytes": 348,
+              "encodedBytes": 302
+            },
+            {
+              "unusedBytes": 32058,
+              "name": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "resourceBytes": 67398,
+              "encodedBytes": 20674
+            },
+            {
+              "resourceBytes": 165,
+              "encodedBytes": 119,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js"
+            },
+            {
+              "encodedBytes": 145,
+              "resourceBytes": 206,
+              "name": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "resourceBytes": 109016,
+              "encodedBytes": 33602
+            },
+            {
+              "encodedBytes": 558,
+              "resourceBytes": 605,
+              "name": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "unusedBytes": 0
+            },
+            {
+              "resourceBytes": 826,
+              "encodedBytes": 779,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js"
+            },
+            {
+              "resourceBytes": 404,
+              "encodedBytes": 343,
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "unusedBytes": 0,
+              "encodedBytes": 428,
+              "resourceBytes": 490
+            },
+            {
+              "unusedBytes": 337,
+              "name": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "resourceBytes": 835,
+              "encodedBytes": 788
+            },
+            {
+              "resourceBytes": 68826,
+              "encodedBytes": 25833,
+              "unusedBytes": 47522,
+              "name": "https://www.ocobo.co/assets/portal-Clm-6X_X.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "unusedBytes": 32198,
+              "encodedBytes": 44681,
+              "resourceBytes": 133936
+            },
+            {
+              "encodedBytes": 426,
+              "resourceBytes": 473,
+              "name": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "unusedBytes": 0
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "resourceBytes": 338,
+              "encodedBytes": 277
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "resourceBytes": 435,
+              "encodedBytes": 374
+            },
+            {
+              "encodedBytes": 251,
+              "resourceBytes": 312,
+              "name": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "unusedBytes": 0
+            },
+            {
+              "name": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "unusedBytes": 194,
+              "encodedBytes": 248,
+              "resourceBytes": 309
+            },
+            {
+              "name": "https://www.ocobo.co/assets/_main.(_lang).jobs._index-Djw8wGmL.js",
+              "unusedBytes": 0,
+              "encodedBytes": 4680,
+              "resourceBytes": 16557
+            },
+            {
+              "resourceBytes": 1208,
+              "encodedBytes": 552,
+              "unusedBytes": 4,
+              "name": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/badge-i9dgPBIb.js",
+              "unusedBytes": 65,
+              "encodedBytes": 422,
+              "resourceBytes": 495
+            },
+            {
+              "resourceBytes": 717,
+              "encodedBytes": 655,
+              "unusedBytes": 65,
+              "name": "https://www.ocobo.co/assets/text-DlkbtvSW.js"
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "resourceBytes": 549,
+              "encodedBytes": 487
+            },
+            {
+              "resourceBytes": 605,
+              "encodedBytes": 543,
+              "unusedBytes": 65,
+              "name": "https://www.ocobo.co/assets/card-C2t40nZ4.js"
+            },
+            {
+              "name": "https://www.ocobo.co/assets/map-pin-BFjzXly_.js",
+              "unusedBytes": 0,
+              "encodedBytes": 375,
+              "resourceBytes": 438
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/star-BI6vQnwF.js",
+              "resourceBytes": 656,
+              "encodedBytes": 607
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/sparkles-Cv6LQ7xb.js",
+              "resourceBytes": 678,
+              "encodedBytes": 629
+            },
+            {
+              "unusedBytes": 0,
+              "name": "https://www.ocobo.co/assets/shield-check-CXoajV1s.js",
+              "resourceBytes": 499,
+              "encodedBytes": 450
+            },
+            {
+              "name": "https://www.ocobo.co/assets/zap-C3uzvT7-.js",
+              "unusedBytes": 0,
+              "encodedBytes": 400,
+              "resourceBytes": 446
+            },
+            {
+              "name": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "unusedBytes": 28104,
+              "encodedBytes": 23529,
+              "resourceBytes": 69550
+            },
+            {
+              "resourceBytes": 17494,
+              "encodedBytes": 4218,
+              "unusedBytes": 12049,
+              "name": "https://useago.github.io/widgetjs/frame.js"
+            },
+            {
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "unusedBytes": 204200,
+              "encodedBytes": 156443,
+              "resourceBytes": 471691
+            },
+            {
+              "resourceBytes": 2125,
+              "encodedBytes": 580,
+              "unusedBytes": 0,
+              "name": "https://js-eu1.hs-scripts.com/27107933.js"
+            },
+            {
+              "unusedBytes": 6432,
+              "name": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "resourceBytes": 12567,
+              "encodedBytes": 4673
+            },
+            {
+              "name": "https://www.ocobo.co/_vercel/insights/script.js",
+              "unusedBytes": 682,
+              "encodedBytes": 1227,
+              "resourceBytes": 2495
+            },
+            {
+              "name": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "unusedBytes": 36142,
+              "encodedBytes": 25123,
+              "resourceBytes": 72608
+            },
+            {
+              "name": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "unusedBytes": 35974,
+              "encodedBytes": 26498,
+              "resourceBytes": 78059
+            },
+            {
+              "unusedBytes": 46367,
+              "name": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "resourceBytes": 108995,
+              "encodedBytes": 42586
+            },
+            {
+              "name": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "unusedBytes": 56996,
+              "encodedBytes": 27871,
+              "resourceBytes": 97992
+            },
+            {
+              "unusedBytes": 335744,
+              "name": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "resourceBytes": 471691,
+              "encodedBytes": 156443
+            },
+            {
+              "name": "https://js-eu1.hs-scripts.com/27107933.js",
+              "unusedBytes": 0,
+              "encodedBytes": 580,
+              "resourceBytes": 2125
+            },
+            {
+              "name": "https://useago.github.io/widgetjs/frame.js",
+              "encodedBytes": 4218,
+              "resourceBytes": 17494
+            },
+            {
+              "resourceBytes": 587832,
+              "encodedBytes": 202942,
+              "unusedBytes": 337253,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "resourceBytes": 587832,
+              "encodedBytes": 202942,
+              "unusedBytes": 248156,
+              "name": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            }
+          ]
+        }
+      },
+      "cache-insight": {
+        "id": "cache-insight",
+        "title": "Use efficient cache lifetimes",
+        "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more about caching](https://developer.chrome.com/docs/performance/insights/cache).",
+        "score": 0.5,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 319 KiB",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "debugData": {
+            "type": "debugdata",
+            "wastedBytes": 326734.79166666669
+          },
+          "headings": [
+            {
+              "key": "url",
+              "valueType": "url",
+              "label": "Request"
+            },
+            {
+              "displayUnit": "duration",
+              "label": "Cache TTL",
+              "valueType": "ms",
+              "key": "cacheLifetimeMs"
+            },
+            {
+              "label": "Transfer Size",
+              "key": "totalBytes",
+              "granularity": 1,
+              "displayUnit": "kb",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "table",
+          "skipSumming": [
+            "cacheLifetimeMs"
+          ],
+          "items": [
+            {
+              "wastedBytes": 196194.79166666669,
+              "totalBytes": 204725,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "wastedBytes": 41846.583333333336,
+              "totalBytes": 43666,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "wastedBytes": 27456,
+              "totalBytes": 29952,
+              "cacheLifetimeMs": 600000,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js"
+            },
+            {
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "wastedBytes": 27037.458333333336,
+              "totalBytes": 28213,
+              "cacheLifetimeMs": 300000
+            },
+            {
+              "wastedBytes": 26084.875,
+              "totalBytes": 27219,
+              "cacheLifetimeMs": 300000,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js"
+            },
+            {
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "wastedBytes": 4617.25,
+              "totalBytes": 5037,
+              "cacheLifetimeMs": 600000
+            },
+            {
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "wastedBytes": 1849.8333333333333,
+              "totalBytes": 2018,
+              "cacheLifetimeMs": 600000
+            },
+            {
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "wastedBytes": 1648,
+              "totalBytes": 1648,
+              "cacheLifetimeMs": 0
+            }
+          ]
+        }
+      },
+      "max-potential-fid": {
+        "id": "max-potential-fid",
+        "title": "Max Potential First Input Delay",
+        "description": "The maximum potential First Input Delay that your users could experience is the duration of the longest task. [Learn more about the Maximum Potential First Input Delay metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-max-potential-fid/).",
+        "score": 0.55,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "230 ms",
+        "numericValue": 232,
+        "numericUnit": "millisecond"
+      },
+      "unused-css-rules": {
+        "id": "unused-css-rules",
+        "title": "Reduce unused CSS",
+        "description": "Reduce unused rules from stylesheets and defer CSS not used for above-the-fold content to decrease bytes consumed by network activity. [Learn how to reduce unused CSS](https://developer.chrome.com/docs/lighthouse/performance/unused-css-rules/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "type": "opportunity",
+          "headings": [],
+          "debugData": {
+            "metricSavings": {
+              "FCP": 0,
+              "LCP": 0
+            },
+            "type": "debugdata"
+          },
+          "overallSavingsBytes": 0,
+          "items": [],
+          "overallSavingsMs": 0
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "dom-size-insight": {
+        "id": "dom-size-insight",
+        "title": "Optimize DOM size",
+        "description": "A large DOM can increase the duration of style calculations and layout reflows, impacting page responsiveness. A large DOM will also increase memory usage. [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/performance/insights/dom-size).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "value": {
+                "value": 594,
+                "granularity": 1,
+                "type": "numeric"
+              },
+              "statistic": "Total elements"
+            },
+            {
+              "statistic": "DOM depth",
+              "value": {
+                "type": "numeric",
+                "granularity": 1,
+                "value": 16
+              },
+              "node": {
+                "selector": "div.d_flex \u003e span.d_flex \u003e svg.lucide \u003e path",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,2,SECTION,0,DIV,1,UL,0,LI,0,A,0,DIV,1,DIV,1,DIV,0,SPAN,0,svg,0,path",
+                "lhId": "page-12-path",
+                "snippet": "\u003cpath d=\"M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 …\"\u003e",
+                "type": "node",
+                "nodeLabel": "div.d_flex \u003e span.d_flex \u003e svg.lucide \u003e path",
+                "boundingRect": {
+                  "bottom": 3521,
+                  "left": 52,
+                  "top": 3507,
+                  "width": 11,
+                  "height": 13,
+                  "right": 62
+                }
+              }
+            },
+            {
+              "statistic": "Most children",
+              "node": {
+                "selector": "body",
+                "path": "1,HTML,1,BODY",
+                "boundingRect": {
+                  "height": 8765,
+                  "right": 412,
+                  "width": 412,
+                  "top": 0,
+                  "left": 0,
+                  "bottom": 8765
+                },
+                "nodeLabel": "body",
+                "lhId": "page-11-BODY",
+                "snippet": "\u003cbody\u003e",
+                "type": "node"
+              },
+              "value": {
+                "value": 58,
+                "granularity": 1,
+                "type": "numeric"
+              }
+            }
+          ],
+          "type": "table",
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "statistic",
+              "label": "Statistic"
+            },
+            {
+              "label": "Element",
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "label": "Value",
+              "key": "value",
+              "valueType": "numeric"
+            }
+          ],
+          "debugData": {
+            "maxDepth": 16,
+            "type": "debugdata",
+            "maxChildren": 58,
+            "totalElements": 594
+          }
+        },
+        "numericValue": 594,
+        "numericUnit": "element"
+      },
+      "speed-index": {
+        "id": "speed-index",
+        "title": "Speed Index",
+        "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).",
+        "score": 0.68,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "4.7 s",
+        "numericValue": 4734.2322830500516,
+        "numericUnit": "millisecond"
+      },
+      "non-composited-animations": {
+        "id": "non-composited-animations",
+        "title": "Avoid non-composited animations",
+        "description": "Animations which are not composited can be janky and increase CLS. [Learn how to avoid non-composited animations](https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/)",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "Element",
+              "valueType": "node",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "failureReason"
+              },
+              "key": "node"
+            }
+          ],
+          "items": [],
+          "type": "table"
+        }
+      },
+      "lcp-discovery-insight": {
+        "id": "lcp-discovery-insight",
+        "title": "LCP request discovery",
+        "description": "[Optimize LCP](https://developer.chrome.com/docs/performance/insights/lcp-discovery) by making the LCP image discoverable from the HTML immediately, and avoiding lazy-loading",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "redirects": {
+        "id": "redirects",
+        "title": "Avoid multiple page redirects",
+        "description": "Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://developer.chrome.com/docs/lighthouse/performance/redirects/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 0,
+          "headings": [],
+          "items": [],
+          "type": "opportunity"
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "network-server-latency": {
+        "id": "network-server-latency",
+        "title": "Server Backend Latencies",
+        "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "sortedBy": [
+            "serverResponseTime"
+          ],
+          "items": [
+            {
+              "serverResponseTime": 7,
+              "origin": "https://www.googletagmanager.com"
+            },
+            {
+              "serverResponseTime": 4,
+              "origin": "https://tag.clearbitscripts.com"
+            },
+            {
+              "serverResponseTime": 3.5,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "serverResponseTime": 2,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "serverResponseTime": 1.5,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://useago.github.io"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "serverResponseTime": 1,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "origin": "https://perf-eu1.hsforms.com",
+              "serverResponseTime": 1
+            },
+            {
+              "origin": "https://fonts.googleapis.com",
+              "serverResponseTime": 1
+            },
+            {
+              "origin": "https://track-eu1.hubspot.com",
+              "serverResponseTime": 0.5
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "serverResponseTime": 0,
+              "origin": "https://fonts.gstatic.com"
+            }
+          ],
+          "type": "table",
+          "headings": [
+            {
+              "key": "origin",
+              "valueType": "text",
+              "label": "URL"
+            },
+            {
+              "key": "serverResponseTime",
+              "granularity": 1,
+              "valueType": "ms",
+              "label": "Time Spent"
+            }
+          ]
+        },
+        "numericValue": 7,
+        "numericUnit": "millisecond"
+      },
+      "viewport-insight": {
+        "id": "viewport-insight",
+        "title": "Optimize viewport for mobile",
+        "description": "Tap interactions may be [delayed by up to 300 ms](https://developer.chrome.com/docs/performance/insights/viewport) if the viewport is not optimized for mobile.",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "node": {
+                "path": "1,HTML,0,HEAD,2,META",
+                "selector": "head \u003e meta",
+                "type": "node",
+                "snippet": "\u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\"\u003e",
+                "lhId": "page-10-META",
+                "nodeLabel": "head \u003e meta",
+                "boundingRect": {
+                  "right": 0,
+                  "height": 0,
+                  "width": 0,
+                  "left": 0,
+                  "top": 0,
+                  "bottom": 0
+                }
+              }
+            }
+          ],
+          "type": "table",
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            }
+          ]
+        }
+      },
+      "first-contentful-paint": {
+        "id": "first-contentful-paint",
+        "title": "First Contentful Paint",
+        "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).",
+        "score": 0.49,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.0 s",
+        "numericValue": 3001.0460255528551,
+        "numericUnit": "millisecond"
+      },
+      "bootup-time": {
+        "id": "bootup-time",
+        "title": "Reduce JavaScript execution time",
+        "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to reduce Javascript execution time](https://developer.chrome.com/docs/lighthouse/performance/bootup-time/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "1.7 s",
+        "metricSavings": {
+          "TBT": 600
+        },
+        "details": {
+          "summary": {
+            "wastedMs": 1740.8975999999959
+          },
+          "items": [
+            {
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "scriptParseCompile": 17.6616,
+              "scripting": 360.90239999999977,
+              "total": 795.65519999999992
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "scriptParseCompile": 198.9756,
+              "scripting": 294.5123999999991,
+              "total": 550.22159999999917
+            },
+            {
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "scriptParseCompile": 10.9872,
+              "scripting": 397.35119999999762,
+              "total": 454.4363999999976
+            },
+            {
+              "scriptParseCompile": 136.82520000000002,
+              "scripting": 213.43919999999937,
+              "total": 353.2643999999994,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "scriptParseCompile": 0,
+              "scripting": 35.367600000000024,
+              "total": 229.62119999999868,
+              "url": "Unattributable"
+            },
+            {
+              "scriptParseCompile": 4.7639999999999993,
+              "scripting": 6.535199999999997,
+              "total": 200.3376,
+              "url": "https://www.ocobo.co/jobs"
+            },
+            {
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "scripting": 50.078399999999988,
+              "total": 67.109999999999971,
+              "scriptParseCompile": 13.497599999999998
+            }
+          ],
+          "sortedBy": [
+            "total"
+          ],
+          "type": "table",
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Total CPU Time",
+              "valueType": "ms",
+              "granularity": 1,
+              "key": "total"
+            },
+            {
+              "label": "Script Evaluation",
+              "key": "scripting",
+              "valueType": "ms",
+              "granularity": 1
+            },
+            {
+              "valueType": "ms",
+              "granularity": 1,
+              "key": "scriptParseCompile",
+              "label": "Script Parse"
+            }
+          ]
+        },
+        "numericValue": 1740.8975999999959,
+        "numericUnit": "millisecond"
+      },
+      "metrics": {
+        "id": "metrics",
+        "title": "Metrics",
+        "description": "Collects all available metrics.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "interactive": 11319,
+              "cumulativeLayoutShift": 0.002049,
+              "speedIndex": 4734,
+              "cumulativeLayoutShiftMainFrame": 0.002049,
+              "observedLargestContentfulPaintTs": 64858562991,
+              "observedCumulativeLayoutShiftMainFrame": 0.002049,
+              "observedCumulativeLayoutShift": 0.002049,
+              "totalBlockingTime": 646,
+              "observedLargestContentfulPaintAllFrames": 1017,
+              "observedFirstVisualChange": 380,
+              "observedFirstContentfulPaintTs": 64858562991,
+              "observedLargestContentfulPaintAllFramesTs": 64858562991,
+              "observedFirstPaintTs": 64858562991,
+              "observedFirstContentfulPaint": 1017,
+              "observedLoadTs": 64860492698,
+              "observedSpeedIndex": 1369,
+              "observedTraceEndTs": 64862856068,
+              "observedSpeedIndexTs": 64858915002,
+              "observedLoad": 2946,
+              "observedFirstContentfulPaintAllFramesTs": 64858562991,
+              "largestContentfulPaint": 3601,
+              "observedLargestContentfulPaint": 1017,
+              "observedTimeOriginTs": 64857546340,
+              "observedNavigationStart": 0,
+              "observedLastVisualChange": 3471,
+              "observedTimeOrigin": 0,
+              "maxPotentialFID": 232,
+              "observedFirstContentfulPaintAllFrames": 1017,
+              "timeToFirstByte": 601,
+              "observedDomContentLoaded": 1085,
+              "observedFirstPaint": 1017,
+              "observedLastVisualChangeTs": 64861017340,
+              "observedNavigationStartTs": 64857546340,
+              "observedDomContentLoadedTs": 64858631204,
+              "firstContentfulPaint": 3001,
+              "observedTraceEnd": 5310,
+              "observedFirstVisualChangeTs": 64857926340
+            },
+            {
+              "lcpInvalidated": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 11319,
+        "numericUnit": "millisecond"
+      },
+      "unminified-css": {
+        "id": "unminified-css",
+        "title": "Minify CSS",
+        "description": "Minifying CSS files can reduce network payload sizes. [Learn how to minify CSS](https://developer.chrome.com/docs/lighthouse/performance/unminified-css/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "overallSavingsMs": 0,
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "type": "opportunity",
+          "headings": [],
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "overallSavingsBytes": 0
+        },
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "forced-reflow-insight": {
+        "id": "forced-reflow-insight",
+        "title": "Forced reflow",
+        "description": "A forced reflow occurs when JavaScript queries geometric properties (such as offsetWidth) after styles have been invalidated by a change to the DOM state. This can result in poor performance. Learn more about [forced reflows](https://developer.chrome.com/docs/performance/insights/forced-reflow) and possible mitigations.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "details": {
+          "items": [
+            {
+              "headings": [
+                {
+                  "key": "source",
+                  "valueType": "source-location",
+                  "label": "Source"
+                },
+                {
+                  "label": "Total reflow time",
+                  "key": "reflowTime",
+                  "valueType": "ms",
+                  "granularity": 1
+                }
+              ],
+              "items": [
+                {
+                  "reflowTime": 0.75,
+                  "source": {
+                    "urlProvider": "network",
+                    "line": 19,
+                    "type": "source-location",
+                    "column": 85503,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+                  }
+                },
+                {
+                  "source": {
+                    "urlProvider": "network",
+                    "column": 100773,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+                    "type": "source-location",
+                    "line": 19
+                  },
+                  "reflowTime": 73.975
+                },
+                {
+                  "reflowTime": 0.19,
+                  "source": {
+                    "type": "text",
+                    "value": "[unattributed]"
+                  }
+                }
+              ],
+              "type": "table"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "lcp-breakdown-insight": {
+        "id": "lcp-breakdown-insight",
+        "title": "LCP breakdown",
+        "description": "Each [subpart has specific improvement strategies](https://developer.chrome.com/docs/performance/insights/lcp-breakdown). Ideally, most of the LCP time should be spent on loading the resources, not within delays.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "headings": [
+                {
+                  "label": "Subpart",
+                  "valueType": "text",
+                  "key": "label"
+                },
+                {
+                  "label": "Duration",
+                  "key": "duration",
+                  "valueType": "ms"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "duration": 0.431,
+                  "label": "Time to first byte",
+                  "subpart": "timeToFirstByte"
+                },
+                {
+                  "label": "Element render delay",
+                  "subpart": "elementRenderDelay",
+                  "duration": 1016.22
+                }
+              ]
+            },
+            {
+              "selector": "div.mx_auto \u003e div.d_flex \u003e div.lg:w_1/2 \u003e p.fs_xl",
+              "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,0,DIV,2,P",
+              "lhId": "page-7-P",
+              "snippet": "\u003cp class=\"fs_xl c_gray.700 mb_8 lh_relaxed fw_medium\"\u003e",
+              "type": "node",
+              "boundingRect": {
+                "height": 98,
+                "right": 396,
+                "width": 380,
+                "bottom": 520,
+                "top": 423,
+                "left": 16
+              },
+              "nodeLabel": "Rejoindre Ocobo, c'est intégrer une équipe d'experts issus des plus belles scal…"
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "cls-culprits-insight": {
+        "id": "cls-culprits-insight",
+        "title": "Layout shift culprits",
+        "description": "Layout shifts occur when elements move absent any user interaction. [Investigate the causes of layout shifts](https://developer.chrome.com/docs/performance/insights/cls-culprit), such as elements being added, removed, or their fonts changing as the page loads.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "metricSavings": {
+          "CLS": 0
+        },
+        "details": {
+          "items": [
+            {
+              "items": [
+                {
+                  "score": 0.002049,
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  }
+                },
+                {
+                  "subItems": {
+                    "items": [
+                      {
+                        "cause": "Unsized image element",
+                        "extra": {
+                          "path": "1,HTML,1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                          "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                          "nodeLabel": "Ocobo",
+                          "boundingRect": {
+                            "bottom": 77,
+                            "top": 37,
+                            "left": 33,
+                            "height": 40,
+                            "right": 167,
+                            "width": 134
+                          },
+                          "type": "node",
+                          "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                          "lhId": "page-6-IMG"
+                        }
+                      },
+                      {
+                        "extra": {
+                          "type": "url",
+                          "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "extra": {
+                          "type": "url",
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf"
+                        },
+                        "cause": "Web font"
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "type": "url",
+                          "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf"
+                        }
+                      }
+                    ],
+                    "type": "subitems"
+                  },
+                  "score": 0.002049,
+                  "node": {
+                    "lhId": "page-8-H1",
+                    "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark mb_10 white-space_pre-line\"\u003e",
+                    "type": "node",
+                    "nodeLabel": "Rejoignez les\narchitectes.",
+                    "boundingRect": {
+                      "height": 91,
+                      "right": 396,
+                      "width": 380,
+                      "bottom": 383,
+                      "top": 292,
+                      "left": 16
+                    },
+                    "selector": "div.mx_auto \u003e div.d_flex \u003e div.lg:w_1/2 \u003e h1.text",
+                    "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,0,DIV,1,H1"
+                  }
+                }
+              ],
+              "type": "table",
+              "headings": [
+                {
+                  "label": "Element",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "key": "node",
+                  "valueType": "node"
+                },
+                {
+                  "label": "Layout shift score",
+                  "key": "score",
+                  "granularity": 0.001,
+                  "subItemsHeading": {
+                    "key": "cause",
+                    "valueType": "text"
+                  },
+                  "valueType": "numeric"
+                }
+              ]
+            },
+            {
+              "headings": [
+                {
+                  "key": "node",
+                  "subItemsHeading": {
+                    "key": "extra"
+                  },
+                  "valueType": "node",
+                  "label": "Element"
+                },
+                {
+                  "valueType": "numeric",
+                  "subItemsHeading": {
+                    "valueType": "text",
+                    "key": "cause"
+                  },
+                  "granularity": 0.001,
+                  "key": "score",
+                  "label": "Layout shift score"
+                }
+              ],
+              "type": "table",
+              "items": [
+                {
+                  "score": 0,
+                  "node": {
+                    "value": "Total",
+                    "type": "text"
+                  }
+                },
+                {
+                  "subItems": {
+                    "items": [
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        }
+                      },
+                      {
+                        "cause": "Web font",
+                        "extra": {
+                          "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                          "type": "url"
+                        }
+                      }
+                    ],
+                    "type": "subitems"
+                  },
+                  "score": 0,
+                  "node": {
+                    "path": "0,HTML,1,BODY,1,DIV,0,FORM,1,DIV,1,DIV,0,INPUT",
+                    "selector": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "nodeLabel": "form#hsForm_386c07f1-1344-4019-afcb-39a8279db08c \u003e div.hs_submit \u003e div.actions \u003e input.hs-button",
+                    "boundingRect": {
+                      "right": 380,
+                      "height": 38,
+                      "width": 110,
+                      "left": 270,
+                      "top": 79,
+                      "bottom": 117
+                    },
+                    "type": "node",
+                    "snippet": "\u003cinput type=\"submit\" class=\"hs-button primary large\" value=\"S'inscrire\"\u003e",
+                    "lhId": "page-0-INPUT"
+                  }
+                }
+              ]
+            }
+          ],
+          "type": "list"
+        }
+      },
+      "image-delivery-insight": {
+        "id": "image-delivery-insight",
+        "title": "Improve image delivery",
+        "description": "Reducing the download time of images can improve the perceived load time of the page and LCP. [Learn more about optimizing image size](https://developer.chrome.com/docs/performance/insights/image-delivery)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 693 KiB",
+        "metricSavings": {
+          "LCP": 150,
+          "FCP": 0
+        },
+        "details": {
+          "items": [
+            {
+              "url": "https://www.ocobo.co/images/jobs/seminaire.jpeg",
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 115421,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 216682,
+                    "reason": "This image file is larger than it needs to be (902x900) for its displayed dimensions (354x312). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "totalBytes": 250772,
+              "node": {
+                "selector": "div.d_grid \u003e div.d_flex \u003e div.group \u003e img.w_full",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,1,DIV,0,DIV,0,DIV,1,DIV,0,IMG",
+                "lhId": "page-0-IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"/images/jobs/seminaire.jpeg\" alt=\"L'équipe Ocobo en séminaire\" width=\"1024\" height=\"900\" loading=\"eager\" decoding=\"async\" fetchpriority=\"high\" class=\"w_full asp_1 obj-f_cover bdr_3xl filter_grayscale(100%) trs_all_500ms grou…\"\u003e",
+                "boundingRect": {
+                  "bottom": 1322,
+                  "top": 1144,
+                  "left": 16,
+                  "width": 178,
+                  "height": 178,
+                  "right": 194
+                },
+                "nodeLabel": "L'équipe Ocobo en séminaire"
+              },
+              "wastedBytes": 232373
+            },
+            {
+              "wastedBytes": 119614,
+              "node": {
+                "nodeLabel": "Bureaux Ocobo — espace de travail",
+                "boundingRect": {
+                  "right": 132,
+                  "height": 87,
+                  "width": 116,
+                  "left": 16,
+                  "top": 7200,
+                  "bottom": 7287
+                },
+                "lhId": "page-1-IMG",
+                "snippet": "\u003cimg src=\"/images/jobs/bureau-1.jpeg\" alt=\"Bureaux Ocobo — espace de travail\" class=\"w_full asp_4/3 obj-f_cover bdr_2xl filter_grayscale(100%) trs_all_500ms gr…\"\u003e",
+                "type": "node",
+                "selector": "div.mx_auto \u003e div.d_grid \u003e div.group \u003e img.w_full",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,4,SECTION,0,DIV,1,DIV,0,DIV,0,IMG"
+              },
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 119614,
+                    "reason": "This image file is larger than it needs to be (1024x768) for its displayed dimensions (203x152). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "totalBytes": 124507,
+              "url": "https://www.ocobo.co/images/jobs/bureau-1.jpeg"
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 110903,
+                    "reason": "This image file is larger than it needs to be (1024x768) for its displayed dimensions (203x152). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "totalBytes": 115440,
+              "url": "https://www.ocobo.co/images/jobs/bureau-3.jpeg",
+              "wastedBytes": 110903,
+              "node": {
+                "snippet": "\u003cimg src=\"/images/jobs/bureau-3.jpeg\" alt=\"Bureaux Ocobo — espace commun\" class=\"w_full asp_4/3 obj-f_cover bdr_2xl filter_grayscale(100%) trs_all_500ms gr…\"\u003e",
+                "type": "node",
+                "lhId": "page-2-IMG",
+                "nodeLabel": "Bureaux Ocobo — espace commun",
+                "boundingRect": {
+                  "width": 116,
+                  "height": 87,
+                  "right": 396,
+                  "bottom": 7287,
+                  "left": 280,
+                  "top": 7200
+                },
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,4,SECTION,0,DIV,1,DIV,2,DIV,0,IMG",
+                "selector": "div.mx_auto \u003e div.d_grid \u003e div.group \u003e img.w_full"
+              }
+            },
+            {
+              "node": {
+                "selector": "div.d_grid \u003e div.d_flex \u003e div.group \u003e img.w_full",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,1,DIV,0,DIV,1,DIV,0,DIV,0,IMG",
+                "lhId": "page-3-IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"/images/jobs/cafet.jpeg\" alt=\"Les bureaux Ocobo\" width=\"1000\" height=\"667\" loading=\"eager\" decoding=\"async\" class=\"w_full asp_1 obj-f_cover bdr_3xl filter_grayscale(100%) trs_all_500ms grou…\"\u003e",
+                "nodeLabel": "Les bureaux Ocobo",
+                "boundingRect": {
+                  "top": 894,
+                  "left": 218,
+                  "bottom": 1072,
+                  "width": 178,
+                  "height": 178,
+                  "right": 396
+                }
+              },
+              "wastedBytes": 110433,
+              "url": "https://www.ocobo.co/images/jobs/cafet.jpeg",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 60288,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 90783,
+                    "reason": "This image file is larger than it needs to be (669x667) for its displayed dimensions (467x312). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "totalBytes": 134678
+            },
+            {
+              "wastedBytes": 110406,
+              "node": {
+                "lhId": "page-4-IMG",
+                "type": "node",
+                "snippet": "\u003cimg src=\"/images/jobs/bureau-2.jpeg\" alt=\"Bureaux Ocobo — salle de réunion\" class=\"w_full asp_4/3 obj-f_cover bdr_2xl filter_grayscale(100%) trs_all_500ms gr…\"\u003e",
+                "nodeLabel": "Bureaux Ocobo — salle de réunion",
+                "boundingRect": {
+                  "width": 116,
+                  "height": 87,
+                  "right": 264,
+                  "bottom": 7287,
+                  "top": 7200,
+                  "left": 148
+                },
+                "selector": "div.mx_auto \u003e div.d_grid \u003e div.group \u003e img.w_full",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,4,SECTION,0,DIV,1,DIV,1,DIV,0,IMG"
+              },
+              "totalBytes": 114922,
+              "subItems": {
+                "items": [
+                  {
+                    "reason": "This image file is larger than it needs to be (1024x768) for its displayed dimensions (203x152). Use responsive images to reduce the image download size.",
+                    "wastedBytes": 110406
+                  }
+                ],
+                "type": "subitems"
+              },
+              "url": "https://www.ocobo.co/images/jobs/bureau-2.jpeg"
+            },
+            {
+              "wastedBytes": 16208,
+              "node": {
+                "nodeLabel": "Chat",
+                "boundingRect": {
+                  "width": 30,
+                  "height": 32,
+                  "right": 380,
+                  "left": 350,
+                  "top": 760,
+                  "bottom": 792
+                },
+                "type": "node",
+                "snippet": "\u003cimg src=\"https://www.ocobo.co/android-chrome-192x192.png\" alt=\"Chat\" id=\"open-path\" style=\"width: 32px; height: 32px; object-fit: contain;\"\u003e",
+                "lhId": "page-5-IMG",
+                "path": "1,HTML,1,BODY,12,DIV,1,BUTTON,0,IMG",
+                "selector": "body \u003e div#ago-wrapper \u003e button#ago-chat-button \u003e img#open-path"
+              },
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "wastedBytes": 10523,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 15421,
+                    "reason": "This image file is larger than it needs to be (192x192) for its displayed dimensions (53x53). Use responsive images to reduce the image download size."
+                  }
+                ]
+              },
+              "totalBytes": 16667,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png"
+            },
+            {
+              "wastedBytes": 9533,
+              "node": {
+                "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                "type": "node",
+                "lhId": "page-6-IMG",
+                "boundingRect": {
+                  "width": 134,
+                  "height": 40,
+                  "right": 167,
+                  "top": 37,
+                  "left": 33,
+                  "bottom": 77
+                },
+                "nodeLabel": "Ocobo",
+                "path": "1,HTML,1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG",
+                "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all"
+              },
+              "subItems": {
+                "items": [
+                  {
+                    "wastedBytes": 6234,
+                    "reason": "Using a modern image format (WebP, AVIF) or increasing the image compression could improve this image's download size."
+                  },
+                  {
+                    "wastedBytes": 6709,
+                    "reason": "This image file is larger than it needs to be (348x104) for its displayed dimensions (234x70). Use responsive images to reduce the image download size."
+                  }
+                ],
+                "type": "subitems"
+              },
+              "totalBytes": 12266,
+              "url": "https://www.ocobo.co/logo-ocobo.png"
+            }
+          ],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 709470,
+            "type": "debugdata"
+          },
+          "headings": [
+            {
+              "valueType": "node",
+              "key": "node"
+            },
+            {
+              "label": "URL",
+              "subItemsHeading": {
+                "key": "reason",
+                "valueType": "text"
+              },
+              "key": "url",
+              "valueType": "url"
+            },
+            {
+              "label": "Resource Size",
+              "valueType": "bytes",
+              "key": "totalBytes"
+            },
+            {
+              "label": "Est Savings",
+              "valueType": "bytes",
+              "subItemsHeading": {
+                "valueType": "bytes",
+                "key": "wastedBytes"
+              },
+              "key": "wastedBytes"
+            }
+          ]
+        }
+      },
+      "screenshot-thumbnails": {
+        "id": "screenshot-thumbnails",
+        "title": "Screenshot Thumbnails",
+        "description": "This is what the load of your site looked like.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "timing": 434,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFwABAQEBAAAAAAAAAAAAAAAAAAIGCP/EABwQAQEAAwADAQAAAAAAAAAAAAACElKRAQMzcf/EABQBAQAAAAAAAAAAAAAAAAAAAAD/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwDqkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATnG09M42noKE5xtPTONp6ChOcbT0zjaegoTnG09M42noKE5xtPTONp6ChOcbT0zjaegoTnG09M42noKE5xtPTONp6ChOcbT0zjaegoTnG09M42noKE5xtPTONp6ChOcbT0zjaegoTnG09M42noKE5xtPTONp6ChOcbT0zjaegoTnO09UDNAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAr1/Sf3w0YA//9k=",
+              "timestamp": 64857980215
+            },
+            {
+              "timing": 868,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k=",
+              "timestamp": 64858414090
+            },
+            {
+              "timing": 1302,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAEkQAAEDAwMCBAQCBwcBBQcFAAECAwQABREGEiETMQcUQVEiMmFxgZEIFSNCU5KxFjM1UmJyoRckN0OCgxhzorKzwdEnNHR18f/EABkBAQEBAQEBAAAAAAAAAAAAAAABBAMCBf/EACcRAQACAQEHBQEBAQAAAAAAAAABEQIDBCEycXKywRIUMTNSQiIj/9oADAMBAAIRAxEAPwD1TSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSvilBKSpRASBkk9hVea1xpV64eRa1FaVy87Q0mUgkn279/pQWKlCQBknj3qunXGlkz/ACR1FaRLzt6Xm0bs+3fv9KCxUoCCAQcg+tRV51Da7KtCbrK8oheMPOtqDQ+7mNo/E0ErSqF41yv/ANJL/Jhv8GOlSHWl9wVJ5BFSx1fp6zRIEa73y3Q5SmW/2b8hKVcpHJBPFBZ6V1xpDMphD8Z1t5lwbkONqCkqHuCO9Qt31jpuzyxFut9tkSTnHSekoSofcE8fjQT1K6okliZHRIiPNvsODKHG1BSVD3BHeu2gUpSgUpSgUpSgUpSgUpSgUpXxatqSaAVBPcgV8DiD2UKi7lcYlvYMi4ymYzOQnqPLCE5PYZNYEPUtjmyUR4d4t78hw4Q23IQpSvsAaCy0rojrJ+E/hXfQKUpQKUpQa38cH3l2ex2hLy48S8XViDLcQdp6KiSpOfTOMVY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvr3rM1dp2DqqxP2u5pV0XMKStBwtpY5StJ9CDVPd0XrOTCNsla8Wq2qT01rRb0JkqR2I6m7vj1xmgohvtyf8D4cFU10ocvAsip6VYUuN1Snfn6pG3NbcRoHSqbH+qRYrf5LZswWU7u2M7u+765zXN7RNkd0SNKmMRaUtBpKQfiSQchYP8Am3c596rSdE60RE/Vydfu/q0J6YUbegydnbHVz3x64zQQ3iDKk6E8FDH07eHpZbdTDROUsKWy2pZBG4eqR8IPcVsXT+nLZb9OItzbQkR3mQl9bx6ipGRypZPzE5rrt2jbJC0enTIiJetPTLa23viLmTkqUf8AMTzn3rFVp66Wyyiz6YnpjRtnTRImrVIcjp7YQnjOPTco4oNKx33Y/hF4oWBLq3rdZpy48Najna31B8Gfpj/mtz6J0pZoek4jZixpypcdDkmS8gOKlKUkEqUT3BzwPQVHjwzgR/DWdpKBJcb86Cp+Y4netxwqBK1DjOcYo3o7UdpieQ0vqluFbQna2zKgiQqOPUNq3Dj2Cs4oKpp+W9pD/qjarISqBZ2vOQWvmDC1tKWpA+gIzirT4WaSsbOhrbJXDizpVxjpky5T7aXFvrcG5WSRyMntU1ovR0PTNnlRC65PkznFPTpUgArkrV3KvpjgCq7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNB0eHzLdg8T9WabtY2WZDLE5tgHKY7i8hSU+wPfFbQqs6I0ixpdmY4uW/cLpOc60yc/87yvQYHASBwAO1WagUpSgUpSgUpSgUpSgUpSgVwfGWjXOh5oK7qMSTbT5ITi9uH/AOy6PUx/6vw4/wCagrKm7/rRjzQ1F0cnd5oQen2PzdP4/wAquy2SD8PIriGlk/LQfWB+0FZVcGmwgfWudApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAoeO9KpWrrk6uYqI2opabA3AH5iRmjlrasaWPqlcDIZH/io/mp5ln+Kj+atGaq1XC009CbnMyXDL37CylJ27SkHOVA/vDtk1zuOpo0HUUKzGNKdlSmw6lTYRsSkq25O5QPHfABOKlskbZlO/wBLeHmWf4qP5qeZZ/io/mrQly1vbIGoTZ3Gpi5CVtoccbbBbbUsZSCc57c8A133fVkG16ih2aQzKVJlJQpC20pKBvUUjPxZ7pPYGlr7zP8ADenmWf4qP5qeZZ/io/mrR7Wp4TmojZktSPNBxbe4pTsyltCzznPZY9O+aW3UjU/UM20Jt9xZeiDct55pIaIyQkghROFYJHHIBpae8y/LeHmWf4qP5qeZZ/io/mrRlo1TFukm7Mx40pItq3G3nFhG1SkEghICifTjIFYml9d2nUlxbhW5MkPKjGSeolICQFbSk4Ufi9fbHrS193nv/wAfDf3mWf4qP5qeZZ/io/mrRVr1ZDuTd3cZjS0NWwuJdUsI+MozkJAUT+6e4FfdP6tgX+HMkW1mU4IraVqRsG5RUkq2pGfm4xjjmlk7ZnH8t6eZZ/io/mrsSpKxlJBHuK0fpfUDWoYrz7EKdFQ04Wj5ptKCpQODjBPYgg1aLTcXrfKQttR6efjRngilkbbWVZY02TSgOQCPWlVvKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKpWrra6iYqY2kqacA3EfukDFXWh570ctbSjVx9MtKXiw228ux3LlG6zkfd0lb1JKMkEkEEc/COfpXC4adtdwukS5TIvUmxNvRd6iht2q3DgHB555rdJjMHuy3/KKeVY/gt/yipTJGxZR8ZNJTdL2Wdd27pKt7Tk5BSoOknun5SRnBI+orum2C2zrqxcpMbfOYCUtvBaklISSQOD2yo/fPNbn8qx/Bb/lFPKsfwW/5RSj2WX7abRZLci8LuqYqRPWCC7k+oAJxnAOABnGcCshqDHZnyJrbeJMhKEOryfiCM7RjtxuP51tzyrH8Fv+UU8qx/Bb/lFKT2OU/wBNKwNN2mBNnS4kTpyJ27zCuoo79xyeCcDJ9sVxtel7Na5jUq3wUMSGmeglaVK+T2PPPYcnnit2eVY/gt/yinlWP4Lf8opS+yz/AG0nB0zaIK7guLE6argFCT+0WepuznueO57Yrvs9jt1mL5tkVMfrbeptUTu2jaO59q3L5Vj+C3/KKeVY/gt/yilE7FlPzm1Hb4Me3sKZht9NtTi3SMk5UpRUo8+5JqYtFueuEpCG0npg/Gv0ArYnlWP4Lf8AKK7EpSgYSAB7ClGOw77yyt9AwAB6UpSq+gUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVp3xH8cY2idWSbG7Y3pi2EIWXkyQgHckK7bT71uKvFn6TP/e9dP/csf/STQbNZ/SctxcSH9NS0N+qkSUqI/ApH9a3TovVVr1jYWrtZXVLjLJSpKxtW2od0qHoa8YviVraxadtGmdOOuTbSwtEp9hAKnytQKSrA7DHc+5q8zpWp/Bvwui2zemFeb5MdfJSQtUdpCEJIB7BRJHIzj79iPWVU3xXOrRpNf9g+n+tuondnbu6eDnZu+HdnHf0z6145Fx1kuALyL3PLalYCv1n+1Uc4yG9+8jPrjFbFm601bcvBK6N379YsSYkuN5eetC2VPIUVZTu43EY7/Xmg234Hq8R1Knf9QAfJbB5frhAe355+T93Gfm5zjFbYrwtobxJveljd5LU6RJmPxPLx/MuqcS2ouIJXtJxkJBx965RP+oupLVcNSxpl5lwYilGRJTLKQggblYTuBwAQeBwKD2Tro35OlLgdIpZVe9g8uHcYzkZ78ZxnGeM1qXwmPi9/bBr+1oe/UmFeY810v8p27NvOc47cVr/Svidfbz4a6vst2nPPyosFMmLM3EPBIdQlSSocn5hg9+9Qnghqy4QddCbcrhOlRIkGXJW04+pQUEMqV2Jx6UHtOleJ06o8RPEzVTn6llzlyUAvtxIkjotsIChjuQOCQMnk1B651Rqx7VU83qZNg3JBQ3IYafUhKVpQlJIAOBnGeOOaD3pSvAuqtQXlu6MhF3uCQYMNWBJWOTGaJPf1JJqZ8RZ2r4belpV4u69si1MOwhFfWC21tABV2+M4yTzknvQt7hpXj26eMupUeGdkt0a4OouTinkSJ2f2ym0kBACvQ8nKu/wjnk1S/P6zjRI91TergA8odMoue54k9iWwveB9SKK97UrxprnWer7toTT/AOuBdIc+PJfb8wELYMlspbKVHGMkHIz9veqLarhqm7XFmBbZ94kzHVbUMtyHCon7Zoj9Ba8leKnizrayeIV9ttrvamIUaQUNN+WZVtGBxkoJP4mvQvhLZLtp7QVut2oXy/c0b1uqLpcI3LKgCo98AgfhXkHxu/72NTf/AMo//KKD2to2Y/cNIWObMc6kmTBYedXgDctTaSTgcDkntUxXizXXiVqGSzaNPWafIg2+HAiMbY6y2p5zoo3FShzjJxjOOKiIl417pu8R/J3W4Oyz8aW48wTEq+ikoUofgeaD3VTIPY15C8btc6wnt2MSkXCywZEFDimUhbIceyQ5nseCOAfTB9apWlLfqu6ITJ0/ef8AtRUdsdN1S1IUR7IKwTQt7ypVf8Pv1l/Ymyi+9b9aCMgSev8APvxzu+tWCilKUoFKUoFKUoFeRf0h9K6hunincpVssV1mRVtMhL0eG44gkNpBwoAjvXrqlB4t1L4Zakg2DTd5s1nufWfibJbLDK+sy8lShkoA3AFO309D71KWrwx1TqjwzfW/Ent3m33BbjMa4JW2t5pTTYUE78eqRj04NevqUHh2LZPEyHbDY4lov7EMubyhqIpPOc/3gGcZ5xnFXDVGmNSad8ELi9rG4ynJc2ZHDEN+SXeilJUfUkBRzyB6Afh6yrRf6QHhtqTXWorU7YkRzFYjFtxbz4QkK3E9uSePpRGgvDHRT+un71b4K0JnsQfMxws4StQcQCkn0yFHn3xUlGsfifYbZO0/Dtd/Zt8skSGGI6ltryMH4gCOQADg8ivRfgh4U/8AT5qXMuEpuVd5aA2otA9NpAOdqSeTk4JOB2H4yHiF4u2DQl8atV4jXJ2Q4wmQFRmkKTtKlJHJWDnKT6UGltL+E1+svhrqy53KC9+tJsJMaLAaT1HtvVQpRITnk7Rx34Oah/BDQ17OvG2b7YrtDt0iHJjuvPxHG0gLZUn5lDGea9U6K1NC1hpuLe7Y2+3EklYQl9ISsbVlJyASO6T61heIWuLRoS0Nz70Xil1fTaaZRuW4rGcDOAOPUmg8iPaD1jp+8dbS4lzWVEpj3KzulSXEE9ypByn6g4xVR1RCft+oJ0SbLTMltObXn0r3hTmPi+L1wcjPripjS+l7pqy43FnS76VlhBkKS+6I6unnBUcnbxkZ+L1rYOhPAibcrtH/ALRXa2R4u7Ko8aUl590DkgbeB98n7UFI1BpDUs+ZFkwdP3eTGXAh7HWYTi0KxGaBwoJweQavXjLpbUE+06BRBsV1krjWCOy8lmI4stLCRlKsDhQ9jzXrKKw1FjNR46A2y0gIQgdkpAwBXZQp44j+Eeorx4ZRJ0W2SmbtClvpchSWy0460QghSQoDODu++eO1Q0ez+J/6uYsse1agZiMryhCIqmgDn1cAGRz6nFe4KUV5duUfxS0ToqLbon63uFxupW7IdZS7LXCQkAJbSoZCVHKiSPpjtmtX22xeIlrlvSrZatWQ5L3948xHkNrXznkgZNe6JVxhRHAiXMjMLI3BLjqUkj3wTXdHkMyWg7GdbebPAW2oKB/EUFV8JDdD4c2M3/zn6z6Suv53d1s71fNu5zjHevLfjDpDUs/xN1DKg6evEmM7JKkOswnFoWMDkEJwa9pUoPHev/CLUrDVpvVlt0mW1JgxlPMNIPWjPBlAUCjv3GeOxyDWDGsfixqS5xk+VvsdxADaXHEKhttj3PCR+Pc17SpQeX9eaf8AE7Ts1iPaVXG+W0RWQ6txCZiHHQn4yW17iOc447YrWK9Da41DeFOjSs5iQ6RnbA8m0D2zjalIr3dSgg9DW6fadH2e33iR5i4R4yG3nN27KgPf1x2z64qcpSgUpSgUpSgUpSgVrfxa8WLb4eqjRXIrk+5yEdRMdCwgIRnG5SsHGSDjj0NbIrxx+lNFks+KTj76VdCREaUwo9ikDaQP/MD+dBsJ79JSH/Z5qUxZN106/TdhrkEAIwSFpXtOe2CMDFco36RD72l7hd/7NtgxZceN0vOn4uqh5W7OzjHS7Y/e+laL1lqOx3uz2qPZtLR7O/ETtfktOlRfOPXgeoJycmum2/8Adjf/AP8AtYH/ANKXRG7W/wBJjqWuc4qwNszUbBGa8yVpcJJ3FR2jAAH4kipmT+kFFgaLtVylWsPXmf1FCG07tQhCVlO5SiCRkp4GD2NUX9FOy2y83jUCLtb4k1DbDRQJDSXAklSs4yOKhv0m7M3ZvEFlEOG3Et7kJssIZbCEDBVuAA4znk/egt0T9JyYJA85pqOpgns1KIUB+KcH/iqH+kBqeBq/VFnvNqK/Lv2psFCxhTag66Ck/UGsS9a607PstphNaEtbT0NIS891VpL2E4PKNp5PPJNVnVrseQ9b5MKzN2eM/FC0MoeW4F4cWkryskjJSRjtx9aDZGnfGC7aM8PtN2ywwmlhvrmS/KaUUKUXlKCEEEdkkE/7hWw9TeLNlv3hJFvly03FuijPTCk2+Q5hLLhbWrelW0nsnjgHk+1ax1akf+znoVWBnz8rn/1HP/xVPgKP/S69pydou8Egf+jK/wDxQbNteurVL8ONao07oiLa1+VQw6uO8XFFDu5JUTszhOM47fatY+F99k6b11a7tCt67lIjlzbFQSCvc2pJ7AngKJ7elXfwNaW9ozxObaSVrVZyAkdz8LlUzwo1JE0jr+1Xu5NvORIpd3pZAKzuaWgYBIHdQ9aD0n4jePVp0reX7Tbre5dZkdWx9QdDbaFDunOCSR68cVDaY/STts64sx77Znbcw4oJ8w2/1koJ9VDaDj6jP2rzvcJCGtbvy7mw4phcwyFtut7lKQtW4HbkA5BBxnB96mrjd9HSdQKeRYrjLjqCUpQ261CCj9Gm0KA/mNB6O8VvG636KugtVvg/rS4BCXHf2uxtoKGUgnBJJBBx7Ec1R7V+k275lIuunG/Lk8qjSDuSPsoYP5itR+J8R60+IMhM2C40kJjuJjPrKz0+kjCCr97AG0n6GpPVWu9NXmdEejaBtUVplvYttLziN5/9PYPzBNBk/pEala1RrtiZEZUmCiAwiM6c/t0KBc34xxguFOOeUn7VsrwC8QYunfDC4/r2I7GttqWFNSRlRlLdWs7EDAGQRjue/OK1V4vskRtGyWrV+qor9mBajBanEo/bvKwFK5PC0q57bq4zNTx7h4L2/TEViWZlumqmyV7B0umoqSOc57uJ7ig2nI/SdQJKhG0wpUfPCnJm1RH2CCP+avunPG7Tl30jdL063IivWxCVyIasKWdx2p2HsoEkDPGPXFeWNN3WwRdN3GLd4br010/sVNR2yojH8VZJbx/pSatWjpukk6Y1K87pe6KiNxWmpT/6xCjhb7YSEjYEhQI3DP8AlI9aC6S/0nJpkHyem46WM8B2SoqI/BIArZfg94tt+Ik6ZCVaVwJMZkPEh4OIUMgewOea8ryV6ftCm7lpm6yZMpKsCJcrY2oBJ75JUpBx9vyra3gx4jW2AxqW73DT0OPMgQA6uTbmuiH0lxKQhSAdoUVKTyAOM+1B6kpWlfC3xyb1rqtqxyrMYLshK1MOIe6gJSkqIUMDHAPP0rdVFKUpQKUpQKUpQKUpQKgtW6SserYSIuoLe1MbQdyCrKVoP+lQwRU7Sg1+94QaLdsDNmNqKYTb5kAIeWlal4IypWcng4wTxXQ14LaJatMm2otz4iSHm33E+acyVthYSc5z2cX+dbHpQVLRHh5p3RMiU9p6I5HckpSh0reW5kAkj5icd6lNUaXsuqoKYl/t7M1lJ3I3jCkH3Socj8DUzSg1pF8DtAR3w6LKXCDna5JcUn8t1SOqPCjSGppkeTdLaSuPHTFaSy8ppCG0kkJCUkD941eqUFGm+FelJul7fp6RBeVa4Di3WGxIWClSiSSVZyeVHvWC34LaJbtMi2otz4iPvNyHE+acyVtpWlJznPZxf51selBUtE+HmnNFOy3NPw3GFS0pQ7veW5uCc4+Yn3NQ1z8FtCXGe5LesgbdcVvUll5baCf9oOB+FbGpQUzUXhjpHULMRu6WdpZitJYacQtSFhCRgJKgQSAB65ro014TaM05PbnW2zN+bbOW3H3FOlB9wFEgH61eqUFc1dojTur0NjUFrZlrbGEO8ocSPYKSQcfTtVctfgroO3SkSGrIl1xCtyQ+8txOf9pOD+NbGpQQeqdJ2PVVuRBvtvZlR0HLYOUqbP8ApUMEfhUJpfws0hpmRJetdqAXJaUw6HnVOpU2cZSQokYOBV3pQazf8DdAPSC6bKpBJzsRJdSn8t1WmLofTUXTjthYs0RNpd5cjlGQs99yj3J4HOc8VY6UGsXvArQDrm/9TuI/0olOgf8AzVabNoTTNmssq02+zxWoMtOyQggqLw/1KPJ/Pj0qy0oKbpDwz0ppG5LuFjtgZmKSUh1bqnCgHuE7icfhVypSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVC3TUUW2zXY77EpSGWkPPPoQChpC1KSCrnPdJ7A4qaqq3zTj8+/OXBCgUBEZIZU6oNuhC3CtK0DgjCwRnPIFWElYfPw/PeS83H85t3dDqDqY99uc4rpN2iMxm3p7zMIOLLaQ+8gZIJGAQcEnHbOarKdPSo9yW64y07HTOXO8x11lYBUVYDYTyoZ298EDt6VxtVonoSzOTCYfLrLzZjTFFsthTy1g/Ke4UAoYzwKUXK2LnNtyXW3sNNoShXWW4kJJUSAO+R29QAc8Z5rj+trd5ETfPxPJk46/WT085xjdnHeqr/ZGWI6I63GX20s25olZPx9B5S18c8EHisqRYJbd7M+OzGeZTMU+mMtW0FKmENlQ4ICgUn8FHkUqC5TcO9QZKVHrtt/tlMoDi0jqFKtuU88gkj8xWTHnw5Mh5iPLjuvsnDjbbgUpH+4A5H41VbFpZ+NdI8qY1ESlrzikpaJIaU86hSduR6BKhniuWl9OS7bLt/mWGAmCypoPpkKWp0nAztwAAcbjknnH3pUFynJ97Ziy1Rmo0uW+2kLcTGa3dMHtkkgZ+gyfpXam9W0w48pc1hpmQcNKdWG9x/y4Vg59Md6wVxbnb7rcJFuYjSmZqkuqS68WlNuBCUeiVZSQlP1Bz3zUWzp6fBd8wliFcXXmHEOtPrKENrW6txRT8KspJXg+uEppQtL1whsymor0uO3Jd5baU4Atf2GcmsaNe4L8tyKX2mpKHVMpacWkLcKQCSkZyRzVfe07O6E6KliCpM3pEyAopMcpQhB2JIJONm5Pxdz+JP6emrcubQjQtk2ciUJW89RtKdnONvKhs45xz9OVQb1pbnw3ZjkRuXHXKbGVspcBWke5T3Fdsh9mMwt6S62yygZUtxQSlI9yT2qqwLBNYct7KmoqW4UpyT5pCz1Xt2/gjbwTv8AiOT2+vEhdYky62y2PmO03LYeblOQ3HMoUQkgoKgPQqyDjukUoSTdyiOuMhl5DqHm1OodQoKQUpIBO4cfvCvse5wJMVcmPNjOxkEhTqHUqQnHfJBxUJLskmfpy5RHGIcKRKWpSURySnGUnClYGd234iB2Pr3OCjTcl1ua5IhMtrdLG1tMxZUemSdxVtxkE8Dbzjk88C5TsvUtniSoUd+4xULmAqZJeSAoD1zn17D3NZz8xLElLbqdrXSU6p5S0hKAkjvk59e+McckcVWoljucc2t9SYj70Z94qS4oIPTX2O5CMFQ4/dGff1Pfq2xSrut8xi0Au2SoY3qI+Nwt7fTt8JzTcb0hP1JZ4MQyX7jE6IfTHKg8kgLUoDB54xnJ9gCa7nb3bm3YTYlsLXMP7AJdSd4xncOeR9qhrpp59x+W5BbipSW4ZabUdqVLZeUsg4BwCCBnB+1YV003PlzZzhjRnEz0tbsylpTHKUhJSAEgqAxuBBSck9u9KguVsducBmV5V6bGbk43dJTqQvHvjOcUXc4CEPKXNjJSyMukupAb5I+LnjkEc+1a91AlKJFwtcdy3SH5VwaeCFhXmgrcg42Y5SAOF5wE/app3Sz6ba2Gm2FSUXN6ctAcKA8lS3NoKsHkJWk9jyn8aUWtJuMERm5BmRhHc5Q71U7VfY5wa71PNJd6SnEBzbv2FQzt98e31qq23TbiXrc7KjRkhmU9JU0HFOhJUjaCCRyfU4AGSfvUjdoM1V3RNgoZdzEcjKS4so2kqSQrscjg5FBIqucBK2UKnRQt7HSSXU5cyMjbzzke1chPhqnGEJcczANxYDg6gHvtznFVJvSckWObHWmMZrsGNHbcz8q2kYznGQN3IrnD03LZuyC4yytlM5yZ5kyFbsKUpQAQB3+Lb82MD64pUFyudKUqKUpSgUpSgUpVD1VfrhHu81uOlLbVuQ28gLUhKXioH5iXEnb+6MJVyM88CrEWkzS+UqjXvUdxjM3mU1KhxxAeQwiI63lS9yUHcTkHJ3HGBj4fyzl354tQW1rZLsi5SIi0Y56aOtjj04Qjn6/WlFrXSte2u+TXI7DEeZbrYwzZo01KVtZG5QXkfMMIG0fXmh1bdnnVPIYRGQ15fMd3pjf1EIUQSpwKByspGEnlPr2Ci2wqVB6gnyWbha4UV9qKJanN0hxG4DaAQhIJA3HP5JNVqDcJcLTM28MvtyHRKejgI/usqlFJdwVAYAOeTjHrjmlFtg0qjf2juke2z3lBuS9DfaShoBHUkbhy1htSgF85Bz7ZAGTXem9T5Mm2RkXOAwJMFctb/S3AqCh8KQSOACc55+H09FFrlStcP6wuzjKnWksMhiG3JJIRsfKirnK3EkIO3jaCefwOZqKfd5Vp1StqWiHHgs7Ww23lzcWULOVZ4xuPYf0pRa90qmXK+zYSm3GZ8eTb22kuOSWm0Ok5WQdyQsEJwAAUg859sVK6ilLi3CIpluMp5MaS42t87QlSUpIyr0SfX6UotPUqkN367qjuMhTZnJdaCkLabQpKFpUfg/alCz8PA3A4BPPGe2NqZ8xJLzrzW1u3uPpWprp5dQtaVcbj22pzgkc8HBFKLXKlUyLqC4quMPzS2URHlMtgttJWFKW2k4UQvchW4nHwkYx+Gde7lLTeXoTE2LBaYh+aKn0buqSpQx3GEp2jOOfiHb1UWstK1dbtTXONZIaIyW22oduiOAOdPDxU0knJUtKgM/CNqTyD37VZ0XqenUaWJKmkQ3JBYaDbaXAr4N2CoL3JVkHunGB+NKLWrAznHPvSqneLvNRqGfBYuMKCzGgtygp9vcVKKnAc8j4RtGfXmsSyXiQuamStsRxPmMB5tz/wwqGF7fodwApRa70qiSNTXNbLr8ZyP5Zp2UFuIQlxQS25tSdpWnKcA5Iye1Z+rZKydMvMSGmFOzhh11J2gKYd9MjnngH1xSi1spVBe1LdRKFvbW04UyHmjOaQ2A4EIbUAAtaU7v2hB5P92rj2xrnPfuNsVKkdMPLtD24tEFKsOpG4YJHOM8E9+570otselUZ3UtzF7eQlDaI7U9EMML6Y3pJSN2SvfuOdwwnGMfcSFmvM96++WnraDbvW6KWm0qQoIVwQsLJzgjIUkc+1KLWmlKVFKUpQKx5EKLJeaekRmHXmjlta2wpSD9Ce1ZFYMi72+PNRDfmMIlLIAbUoZye32z6e9B032yxbtEfbcbaQ+430xI6YK0jPYHvWZ5CJ5lUjyrHmFEEu9MbjgYHPfsSKxmr5bHZbkZucwX2925O7tt+bnscevt61iv6kg+T8xBdRLw+wypKVYI6riUBXbtySPfFXem53GwW5U9cp2M06VNtNJbW2kobDZWUlIxwfjP5Cs12DEektyXYzC5DXyOqbBUj7HuKx0Xq2ruJgImMmWCU9MK53AZKfbIHOO9ZapDKZKY6nEh9SC4EepSCAT+ZH51FfJUWPMa6Uthp9rIOx1AUMjtwa+pjspZU0llsNKzuQEjac98j61GvakszIbLtxjp3tpeTlX7iuyj7J+p4rJ/XFu8+IPnWPNk4DW8ZzjOPvjnHfFB2x7fDjNttx4kdpttRWhKGwkJUeCQB2PJ/OsWRYrfImJfkRmnUhso6S20qb5VuKsEd8+v1Ndky49CWmIwwuRJU0p7YhQGEhQHJJ4znj7GolvVI8mzLkwXIsZySY/UedRwQVJJ4J9Ufjmqm5OvwIkhbK5EVh1bJy0pbYUUH/AE57fhXalptJcKUJBcOV4HzHGOffgAVHOahtLcRqUqcyGXVKSg5yVFPzDHfjBz7etdci9jzkePAirnF5gyUracQE7MgA5J5zn0qCQcgRHFsrcisKWz/dqU2CUf7fb8K7VtNrUlS0JUpIIBIyQD3rAVe4DctuJIktMzFbQWVKBKVK7JJHAJ9B6+ldMrUEJuQliM63IfEhEd1CF8tFSinJ/EHigzU2yAmMuMmFFEdZypoNJ2qPuRjBrk5b4bqGUOxI60s/3YU2CEenHHH4V2sSGZAWWHUOBCihRQc4UO4+4qFe1I2zcno7kN8MMym4apG5O0OLSlSeM5x8aRnH/FBLCDETIRITFYD6E7EuBsbkj2B7gV9kw40lTapMdl5TR3ILiAooPuM9qw49/tUlClsTmVpSUJJB4+NW1J+xPAPY1wuN7biymYsZlcyU470S22pI2HplfxEkD5R/yKDMXboS1sLXDjqXHGGVFpJLf+3jj8K5iHFEvzQjs+Zxt62wb8e27vUPc9SItUSTJuUYsoYZS6ptLgW7kqUANo4x8PBz7+1TUWQ1KjpeYUVNq7EpI/4PNFYT1kgyLm9OlMIkOuNto2uoStKNhWQUgjg/GeftWW/DjPtutvx2XG3SC4laAQvGMZB79h+VQ6tSpEdUxNvlqtaVEGYNm3aDgubd27Z9cducY5rPVercm4CCqYyJRIT0887iMhPtnHOO9Xem52uW2C4hCHIUZSEK3pSppJCVe444Nd78dmQkJkMtupGcBaQoDIIPf6Ej8ajhqG0qecZROZW63v3IScnKM7hx3IwcjvXRC1TapVojXBUjosvhO1LqSFZKd20DHJx7ZpUm5JO26C7ETFdhxlxU9mVNJKB/5cYrsVFjqTtUw0U7OngoHy/5ftx2rHZukd+VFaYUHUSWVPtPIIKFBJSDz/5hWdUVjqhRFTEy1RmDKSNqXi2N4HsFd6+tQ4rMhx9mOy2+587iUAKV9z3Nd9KBSlKBSlKBVduNklPXsTIjjccLcaW44hxxKlBBGUqRnYvIBGTggH1wKsVKCqx7FdY8JNuZlQm4jCHQw8Wd7uVJUEkg8DG7kj5semTWMjS9wVKdedfZ/beUKkl1xwpLD3U4Ku4UCfbBx96udKtpSoQtLSY91QS80uC3LcmJJedKyVKUrbs3bBgqPxew7c5qTmWqUi4xpludQpaGXGFiUtSuFlB3A8kkFHb1z3FTlKWUoVusV3hyJUOKIik/qyLCW9IbVtJSHAVJwPixn5TjuORUpE03JhXKMuI+lqM0pCnFJdXueCUBOFNn4MnA+Pvx2q00pZSJ6Djeq/MbFFl6GG9wHCVIWTg/cL/+E1jNWNxMGCwtbajHnLlng4IK1qAH1G4flU/SoUp07S0s3FyfEeaLxdeIbU86ynY4G/3myDkFvtyDmsqHpSMh6AZzMSW1GiFja41uG8qCioBWcDg+uas9KtlKxL0/LcXOjMvRk26c+h9wlJ6reAgFKccH5Bg+n1r7L0yuTbXIvX6JduJmLcZJSopK92Ae4VjAzVmpSykLYYE60sxbfmO7AYStCXOQ5tBT0wR2zjcCfXAPqa4M6faRcLxOLcbzst3exILQUtr9ihscn6pJx9anaVLKUo2CVHjynLipUht6F5VxEdbjrm4H4Voz25JOBgJwO/eu+3aadk2+0KviY8mUl9Uyal1sKStxTak4A5Hw5SB9E1bqVbKVu6aaEpNyairZisSYKIjSUI4bKVLVnaMDHxjj71Lwf1iHlIneWU0GkYcZBSSvKtw2knAxtxz6ms2lQpR5+nb83bm7Zb5cVdrQhUcoVuS4qOrAKPUbwOAvj6jmpBenZRU9EQ+wLa7NE5Sik9ZKgsObB6fMnv6DjHrVopVspXYen3WG4CS43mPcJExZAPxJc62B9x1R+RrHh2G5wWLUpqTDek21pcZsKbUhC2lBA55JC/gScjjuMetWqlLKVePbJcKRCYYKXH225UhTxQUtB1xQIT/typXGc4TVma39JHV29TA3be2fXFcqVFKUpQKUpQKUpQKUrpaktOvustry41jeMHjPavM544zETPz8LETLupSlekKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6UpW9yAQRkEEe4ri04h1tLjS0rQoZSpJyCPcGqxbrdcIyoqHWn1bQjatuVsQ0AfiCk5+Inn0Oc4ynGayJJuDekpTTiXW5rUTAdSvKlL28kEeoNBYaVUn4F0KViO3LQwt1OG1yypacIUCrdvHwk7eMntnHOK7rZGuyLpDckokFHTSHi48ChJDeDgJXydwzgpPcnd6UFlW4hspC1pTuO1OTjJ9hXKqtOttyeuKVth4rTKLofU/+yS3sISAjPcEj09zn0rK05DuEZEjzJfSVNpSkSHur+0GcqHJ4PHqM+w9QnXHENNqccUlCEjKlKOAB9a5VCzv1gzp6b1lqdmKQUtFhJUckYGMD39fx4HAjpUS9OIeYaD6cKklLwfA3Bastgc5+EHHIGMccUFpLiEuJbK0hagSlJPJA74H4j865VWHbbdUPyW4zr3ldy+lukEqKSlnjcSSCSHQD6Z+1fYduuC5iXHFTGIgDqm2VytykEhsJ3EE55CyBkgZ/Cgs1KgLTDnqtU2PJMhhxeUtOOOlSx8PzcLVjn2I+wrAlwL3IYYdcMgPOhxTjTEkJ6KzjZzkApAHOM8knBzQW6uKXEKcWhK0laMbkg8jPbNVh213UNuuNPv+ZcceSSZB2hsg7MDOAc7cEDIzXCJCuMW4OymYkvoLcT+xXJStzaG1J5JVjAUQcZPv9KC2Uqr2mHdmLjAVKD60BlAfUt/KEkNYOAFcncPVJ7k7vSuyRCua5EwM9dL6+qW5PmcNAFJCE9PnkHHoO2cntQWSlVZq1zpD6Avz0aESolpUwlwHZgEqCicE8gZ9M+uK4x7TdAxFbcelHe3HMo+ZOd4J6mDnjI/y8e1Ba6VUxabs1FIjyJPXUJCCXJJV8G/9ljJODtAGe/PNZcSFcU2Sc0FSW3nFZaS8+FOJTgZG4E7ScKx8RxnPHYBPpcQpa0JWkqRjcAeU5965VTV2u5dSQ40zNbjOPpV0RKHWKemE/Nv7BWTjd6/TFZtsh3Vi7x1Seu60GwHXHH8oB6YHwgEZO4eqPUnPpQWWlKUClKUClKUCoi1/43dfu3/Q1L1EWv8Axu6/dv8AoawbX92h1T2ZOunw58vMJelKHscVvcilUxFmuvQ6SlP9FLqFLHmMuugJWCMn4SMlBzhJODkdqymLLcGwhxTzqn21RthXIKsISodQHsDlJIzjnigs7a0uNpW2oKQoZBHYiuVVVm1XNJY6qlLfHRIkdc4aCUgLQU/vbiFc+u7n5RRFnnsJtQaLzi2kNh4rkkpKtwK1HkHPfGMj0IxQWquJWgLSgqSFqBITnkgd/wCorDfbnefS4y6jyqU8tHuo4V9OO6fX0rBu1rfuM2DKQRHejsOFC85LbpKCPuMBQPuDQTaFJWkKQoKSfUHNfaqTdoufl46XEjq9FKUlt8hMZ3epSlem4EFPp+7jsTX123XZ1tLSw6lLTK2ypuQApw9VCgR/5Ung47kcd6C2V1pfbVIcYSrLqEpUpOOwOcf0P5VCGDOVZYTTiNy2ndzzCXiOoj4sJ3EnnlJxnHGM4rHTZZXXEkBTbyRHCB5hStoS6pSwSe/wKxz9qCz11yHm4zDjzytrTaSpSsdgO9VKJYblsCJMiSVKLYkL8zgPYcBUpIABGRn1B5x6A1kS7RNebns9NSlupeCZBkkBSVAhCNnpjIH4Z7k0FppVYfs8tuQ4G0Lfg71FEcSVIOS2gBW7OeFBfH+rPcVwFkuQRvVIcXKKylbiZBTlHlynjuB+0we3fmgs7zrbLanHVpQhPdSjgCuSVJUMpIIzjINV2NbZytPzIjqcOrcBa3uZUU/D83JAOQe3HrwSa43Czyl3hDsZb6Y4KFI6b4SlB3lTmQQc7s+nfscDmgstKqbFpubbGJAW+jrh0siQQS1tUA1n/SSDn96vps9xVcGHS4+lKels2SspaCfmScpyrPPPrnnGAaCzR5LEkEx3m3AACdigeCMg/iK7apqbDcERWUErCE9EOIZdCVLCWikjJ4OFYOD7VkMWS4oR1DIdMpCmA2tT5VtSEgLz2B/e9OeKC1UqpLtFwXCbbQh1kJW2X0plb1PhIUFEFXAySk84zjBxVhs0d2LbWGX1rW4gYJWvee/AKsDOBxQZlKUoFKUoFKUoFRFr/wAbuv3b/oal6iLX/jd1+7f9DWDa/u0OqezJ10+HPl5hL0pQ8g1vciuK1obAK1BIJAGTjJPpVMfsc1mMwnppUreyh8tuqPmiFgqcXgfDwDnv82OwrnM01OeaQhtwNNJ6pbZbewlgqI2lJKD2we2CM4HFBcq61vtIUUqWncNuQOSNxwOPqarUnT8lcRxCem667KcdcU4snKTu2dwRxkcYwO45pHsMlt9uR0oolKajJdkBX7QltYK+duSFD6+lBaaVU29PSyltDnTSPgEhaXlZlkOJUVqGODgK45+bHYVy/s4+Q98SMtoWIn7RWGldVakEe2ElI/AjtQWd95thve8sIRkJyfcnA/5Iow82+2HGVhaCSMj6HB/5FVJGm54lPOqf3Fbm5RU4CHB1krGQEA8JSQMk47Dijmm5y5MdfXwlsfBscA6SuqpZUMoJ5SpI4I+XHY0FwrpXKYQwp5TqOkklJXnIBBwR+fFQV6skqdempTbyg0hLYRhYHTIWSogFB7ggcEZxg8V9j2JUeyTYMdiKyXX1uILfAUkubhuwOCAcevagsVKr1ptc6NfHZb3SDLodCwhedxKwUHtk4AxyTjPGBXQ5ZZvTkpbZjdV3IW8Xl5eSXAfiGMZCcgZyPTtmgtFKpDdinJWzFksNyUIakFAU6pKElTiSjkJwCkEgYAxjisl2xXVUtbiJLaHFNqaMgKwo5a2hRGM5CucZx+NBa3HUNlIcUE7s4z9BmnVb+D40/tPk5+bjPHvVdTY3XG0tGNGjRiVBxhLqnEqy2pOSCAO5B7emTzWIjTctMmEtsNRkMJaCUMOAJbKVkrIBRn4h3wRnsaC3b09TZuG/Gduece9cqr1ytc1+/MTWOkENLbwrfhRQM7h2Pv6EZ9a7Zdsfdu6pIbacBUgtvKdUlTKR8yUpHfPJ7855yBQTlKqTGnZJDCHktJaSW/MBLqleZKSdy1cdz7eucHsK6Zmn5MS0veUz1y2+2rprUVKSpwFoe/wpGPp6UFzpVajWFwTGVqbbYiIf63lm3VFIwjAPYd1YOO3Ge9YULTE1tO2TILm5TfXJdGH8OBRUQEg8gEck98ZxQW991thlbryghtCSpSj2AHc1zqmzdNTHYcljaw6FNOtRgt1SRHy4spIwP8ikD6bMdjWRN07IeYWAvKnJi33U9T+8b+Lan4kqHGQcYxxQWqlYlpjuRLZGjvuKcdbbCVKUrcSfvgZ++Ky6BSlKBURa/wDG7r92/wChqXqItf8Ajd1+7f8AQ1g2v7tDqnsyddPhz5eYS9KUre5OuM+1JYbeYWFtODclXuK7Kp7OmZiJEJanGVFhDQC953N7D8QT8OcK/wBye/IPas20WWZEt9wjFxqOX29jTjSt60qwRvKtqcnkd8njkmgsdcUuJUtaBnKMA5BA5+vrVUt+l1oU0mY1FMYOBbkdKtyF4QtOSNqQSSpPcenc8V0J0/cH4yWZAQtLKmklDzg2PbWgkqGUq/e5GU/l3oLpXVKkNxYzsh44aaSVqIGcADJqsx7DcGAlomM+z1W3lqccVlRSyGynG08EpBzn17VkRLFKY03cbct5t1+QhaUvFSudyMAKzk4T2HJ4A9c0FjByK4uLS22pas7Ugk4GT+QqsxrJNjSG5MdiExseSvyrbqg2cIcSpe7Z8x3jPH7o59ax29O3Bvo7VRt4i9FbpcJIV0in4RsyBnB+bHfjNBb0qCkgjsRkZGK+1VX9NSF9Rxp5tmYta8yEklaUGOWwAcei8Kx24z3rG/sxLTCLbbcRKisKDXVHTB243EdLBJ4/dB4+agudKgrZapUW+PSlhjouJUCoK3LJJBH7oIHB4KlemMVEtaelSGJBS0zGdcMpJe3qDjoWpYSlXHCRkEHJ7DAFBc6x4MtuawHmQvpq+UqTjcPcfSoOVp7fNBaZi9Dc2UuKJ3soTjc2hOMFKsHPI+Y5BrFOllNW6NGjR4OUsdLPKAy5/FRhPKu3seByKC3V1tvtuOutoUCtogLHsSMj/iq05pt3puqaU0JDqnuq5kguoUvclKiBnGOD7ZOKx3tNSi3I6EeC0HHg42wl09NA2BPYtkHkZ4A78Ec5C4LUlCFKUcJAyT9K4sOofZbdaVubcSFJPuCMg1DX60u3DokNxn9jK29ryilKFqxhxOAeRg+x571gW3TkqLc4sh1xlXSS2OoFfEAloIKANudpIJ+bHPbNBa6VW5+nnZEqTIZcQzJdeWRISTvQ2WC3gfZeFY7cZ71iSNOSVx1hmNBYypJEdt09LIBBWctnJOR+76Dmgt9dDMth51TbSypSSpJwk4BTjIz29RUVeLU/MMRXSiSek2pCmnypKAo7cOJwDyMHHY89xWFL0/NebkJbkNoDhcPCj8W5TZweDwQhQPf5vWgtNcUOIWVhC0qKDtUAc4OM4P5iqj/ZV1cVxC0xgei8GGwolLLitm1ScJAGCknISMZ4Hc12TdMqJlmJFggvyA/nIbKvgwQv4FA85Pb19DQWylY8FL6I6USg1vQAkFsnCuBk4PbnPHPGOayKBSlKBURa/wDG7r92/wChqXqItf8Ajd1+7f8AQ1g2v7tDqnsyddPhz5eYS9KUre5FKUoFKUoFKUoFKUoFKEhIySAPc0oFKUoFKAg9iD6cUoFKUyMkZGR6UClKUClKUClMjJGeR6UoFKAgjIIIpQKUpQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6+LBKFBJwrHBr7St7kqtnto6cdp+BIamlsomSt4AcVtwSTn48nkccfTtWP0r/vlKVJkpKt2QllJCf2idu34+Rs3DgA4/1Yq5V8WtKEFS1BKQMkk4AoK5Zo0wXKPKmNTAVMlslT+UpIUrBUMjukjHBPvzzXVKVelodZYTIQ4kyf2nw4wXQWsZ7/Bn8uasyHW1q2ocQpXPAOTwcH/mudBT7hHvqHnGY78oRW3HOk4EhxxWUNlGTuTxuLo544GeKk70i4FLHSVJJDCuY2B+242k5/d7/T3qdpQVcJvO2TuMrz2HOUFHQ2/ubAf3sY/HOeMVj3MXcwii2puIJDimlPLSVBQSnaD64yVHk44OcjAq4UoKnJF3ckS9iZDiXG8oSpKUpQcJ4wchXOfY9819lN3pSpAjrlJfKnApWU9MJ3/s9g9wn/759KtHVb63S3p6m3dtzzjtnFc6CBW3cmLfPbaU+6pqU2pgqUCtbP7NShn1/wDEHNYUhF5k+bcbVLZSlMhbCAUgqUNnSB+nzcfnVqCkqUoBQJTwQD2olSVFQSoEpOCAex70FUnKukePKWUyUIAkLbLAQPizlBV9MZ/5z6UD97ditiIl0vqKlpcXjpkGOdufp1COP/tVrWlKklKwCkjBB7EV8a2FpHR29PA27e2PTH0oivWtu7t2u4jrOuSC1mN5hsJIc2n/AFK4zj6d8cViswZYkXGUhE9a247ao3WWkLW4EOggZz/n9fU+1W2lFUpDl1RIjxpa5wZW+4R0jha2w0kjkkn58+ufsOK5sLu7ktTTjswyGkR9oSUBAUfn6noeO/445q5YpxmgqMuNfPKx9smUN63lPFCQpaTn9kAAU4TjPr3xnjNc3Gb+lKnm3XFyitSAhW0NhPlyQcf+9A/P2q10oKgzBuKrmpTLlwbjuGOlbrqk7ylIdKx9slP58cVm2du7C9PLmPOlgl3KFNgIA3fs9p3f5fYe+ecVYq+BaSsoCgVAAkZ5Ge39KCnLi3tt5tEdbrDIK1NhDYVlZfWTv+IcbSnvnufXFS9h8+JkwTS+ts8oW4AkdzwE89hjkHB44BqbpQKUpQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6UpW9yVFFpuoidQyZ5k+UK9pk8eYHy+uMemPlPrzzXF6Hf1S5yw46SrqhABHTKCD0wAV4BHw5O0evJq1xpLUlK1ML3pSooJAOMjv967aCnyLZdUGUuGgtuLLuFBQyUqkBRA+IclGccj7iiWL8xCkNpTKeU4yUMnqpCmlBZxuysnOD3yTxzVwpQVWdAu5jjpvSldSU6p1KXPiCNyumE4WnCcY4Bz2zmu21MXhu6sKml91stpDqipKUJPTGcAKO7Kh/lB5POMCrLXEOIU4pAWkrSAVJB5Ge2aCuKtU9+cHHpM5LTkl0OJRJKQGcEowAePiCeRzzg8VhpgX16bEXKW98KWhuSoAJGAHQohY+I/FyEn0wRVrlSWYqAt9e1JO0cEkn2AHeu4kAZPago7FhuEaEPKpmtSY0JaGiZZVvfGNvJUfhOPlOB7is1+LeS5ILJlJdUpzesvDYtsq+ENpz8KgnjOBznOe9WulBUGrfPbekno3Lybj24ITKAfIDaAkle7OAQrjdnt3HFfWoF2SFGYmS4HFBToiPJbWtfRbSFZyn4QUryOMnHGKtjbiHElTakqAJTlJzyDgj86BxBdLYWnqABRTnkD3x+BoKX157dzix5Ml9dy6zIWlp9Owt7Rvy3n3CiTt/HHFdzMO/iZFU448kIQyMII2AbR1AobwCc7v3T6YIq4V1okMuOFtDraljOUhQJ4ODx96Ir8CLcVWO5x5aH1vONKS2p5YytRSR23KCeceuPoKjUWW5Q4nQiJcbbL5U4I+1G5OwbSAlSMYPB55IzyKu1cWnEOtpW0tK0K7KScg0VVjBvrjK2HHl8x+r1eoBueKAjp8cgZClZ7ZIx2rFuMZ+M0p+129y0t7ENuJQW0qdWp1sDG0kZA3jJ/zVcW5DLqylt1tagMkJUCe5H9QR+FdlBUJMW8IZ/7KJ5bS6tTTK30le3ajG5e/PzBePmGDyO2MvUsa7vy2jbnHUtJaO3pHGHc91fGnIxjuFDvxVkpQV6DbpcKDeG4ofTLdLi2XHX1OIKjuKSApR24J54H41Fu227JfkKhpmtsOFhK+q+FuqSkO7gCHAR8SkH5hxnHtVzS62tRSlaVKHcA1yoMOzokt2yOiaorkBOFFXf6Z5POMeprMpSgUpSgUpSgVEWv/ABu6/dv+hqXqJtiVC83MlJAJRg478GsO1x/20OqezJ10+HPl5hLV8UNySDnBGODivtK3OSmyLTc4tvYYtyJO9IeXkSlHCyrKc5WOMfce4Heu9LdxclzWAJSZmFudUycN9NRVsSlOSAoAAZwMEZyc82ulBVGrZcH3sLVPjwsOFLSpZLiTtQE7lBRJ5CiBk4/HFcV26+FovNPvImrWtOVvZbQkxyAducf3u09s/hVtpQVa2225GRFMhc5qMl3etDknKjhB7kKUdpVjjPp2HNdl7gXFya+7DDvRWpneGnAhbiEpcyAdycYUpB7jIBqy0oIB21vyYVnRKLynY7wW4Q+pKgNqhyQRk8getYEi33Wc15eS1JS20ytJUZO0PLDiSkjarPyg8nGM1bqUFUkx7yW1R4zMptKVOKQ6ZIPwlhQSnJVuJCyO/qM5qSnw5KbZCZjqkupbcSZCUvkOuJwcgLJHO4pPccAipmlBSW7Vem0tpT5lCMuFCUSAC2svLUFOHcNw2lHorseOalb3DnLnPPRGnFoWy02S25sVwtRVj4k+hHqPx7VYaUFfTHuStPxWX0vmQ24A+lt4BxxAJ+Ve714PJBxmo9i23ZqK+lKZTaVFxaUpeSpzl4KSCdwyduQfiHrznmrhSgq8WLc+rFVJYlEhKAnZLwlrCzu6gKjuJTj/AD+2fWsNMW7OPqZUZfmUR2dikydrbTm5eVKGcKGAMjnOMYHerpSgqwttz3FsF1phToUrpu7TgyFqVyDkZQR//tdCrdexIbSXJSmUFSWimR8mHlkKcJV8QLfT7hR4ORzVwpQV69RLm9eGnIyn/LBCAjpO7EoWFEqKxuGQRt9FdjwO9c7LBnxZjDkhx9aHGXev1HisBe9PTwCePhKu341PUoKpCsEqPbNoffS+6+CtKC2gobL25WFpSFcp91E/jXXLiXvzswx0yUtrbeaQRIyMlP7NQyvjt32ggn15NW+onU16i6fsc26T17I0VouLPvjsB9ScAfegreppremo7su7TXm7QhZICpxQ4VFCMEKKgSAQv4c+vAOK1w745adiXkOmbdJaELSMspPTKOngjCikE7s87R3zn0rQPiBrS6a1vjs+6PK6QUehGCvgYR7Ae/ufWq0hDjgUUNqUEjJwM4oj3jo7xJ0vq5aWrPc21SinJjOgtufgk9/wzVyBzX5vxZDsaQ2/GdWy+2oKQ4hRSpJHYgjsa9hfo/eIzusrI7BuzgVeYAAWvsXmz2Xj39D+B9aK2/SgORSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgHtWmP0pZb0fw1LbJIRImtNOY/wAuFK/qkVuc9qoXjHppeqtC3K3RwDK2h5jPqtByB+PI/Gg8MsoDr7TalBCVKCSo9hk962J4o40Vrk2nTLf6vbtiWi3Jb/vn1KbCitS+5B3Ebfl+la7facZdW08hTbqFFKkqGCkjuCKm0amlPqh/rtpF2bhpCWG5PokdkqWnCykf5d2KIsnjLb4jFx0/dIsdqK9eLSxPksNJCUJdUCFFKR2BxnHvmpP9GmW9G8VIbTROyRHebcA/yhO4f8pFa+1JfZ+pLu7crq4FyFgJASkJShIGEpSkcAAelbu/RW0q+u5zNSyGymOhsxoxUPnUSCpQ+gAx+J9qK9QtHKRXOuDQwkVzoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFdLze4V3UIoNJeKngzA1VIduVrcTb7srlatuW3j/qA7H6j8Qa0pL8D9bMSC21CjSEZx1G5KAn/4iD/xXtRbYV3FdRjJ9hQeX9E/o+zHZbb+q5TbcdJBMaKoqUv6KVjAH2z+Fek7JaotqgMQ4LCGIrCQhttAwEgVIIZSn0rtAxQfQMClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUH/2Q==",
+              "timestamp": 64858847965
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAEkQAAEDAwMCBAQCBwcBBQcFAAECAwQABREGEiETMQcUQVEiMmFxgZEIFSNCU5KxFjM1UmJyoRckN0OCgxhzorKzwdEnNHR18f/EABkBAQEBAQEBAAAAAAAAAAAAAAABBAMCBf/EACcRAQACAQEHBQEBAQAAAAAAAAABEQIDBCEycXKywRIUMTNSQiIj/9oADAMBAAIRAxEAPwD1TSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSvilBKSpRASBkk9hVea1xpV64eRa1FaVy87Q0mUgkn279/pQWKlCQBknj3qunXGlkz/ACR1FaRLzt6Xm0bs+3fv9KCxUoCCAQcg+tRV51Da7KtCbrK8oheMPOtqDQ+7mNo/E0ErSqF41yv/ANJL/Jhv8GOlSHWl9wVJ5BFSx1fp6zRIEa73y3Q5SmW/2b8hKVcpHJBPFBZ6V1xpDMphD8Z1t5lwbkONqCkqHuCO9Qt31jpuzyxFut9tkSTnHSekoSofcE8fjQT1K6okliZHRIiPNvsODKHG1BSVD3BHeu2gUpSgUpSgUpSgUpSgUpSgUpXxatqSaAVBPcgV8DiD2UKi7lcYlvYMi4ymYzOQnqPLCE5PYZNYEPUtjmyUR4d4t78hw4Q23IQpSvsAaCy0rojrJ+E/hXfQKUpQKUpQa38cH3l2ex2hLy48S8XViDLcQdp6KiSpOfTOMVY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvr3rM1dp2DqqxP2u5pV0XMKStBwtpY5StJ9CDVPd0XrOTCNsla8Wq2qT01rRb0JkqR2I6m7vj1xmgohvtyf8D4cFU10ocvAsip6VYUuN1Snfn6pG3NbcRoHSqbH+qRYrf5LZswWU7u2M7u+765zXN7RNkd0SNKmMRaUtBpKQfiSQchYP8Am3c596rSdE60RE/Vydfu/q0J6YUbegydnbHVz3x64zQQ3iDKk6E8FDH07eHpZbdTDROUsKWy2pZBG4eqR8IPcVsXT+nLZb9OItzbQkR3mQl9bx6ipGRypZPzE5rrt2jbJC0enTIiJetPTLa23viLmTkqUf8AMTzn3rFVp66Wyyiz6YnpjRtnTRImrVIcjp7YQnjOPTco4oNKx33Y/hF4oWBLq3rdZpy48Najna31B8Gfpj/mtz6J0pZoek4jZixpypcdDkmS8gOKlKUkEqUT3BzwPQVHjwzgR/DWdpKBJcb86Cp+Y4netxwqBK1DjOcYo3o7UdpieQ0vqluFbQna2zKgiQqOPUNq3Dj2Cs4oKpp+W9pD/qjarISqBZ2vOQWvmDC1tKWpA+gIzirT4WaSsbOhrbJXDizpVxjpky5T7aXFvrcG5WSRyMntU1ovR0PTNnlRC65PkznFPTpUgArkrV3KvpjgCq7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNB0eHzLdg8T9WabtY2WZDLE5tgHKY7i8hSU+wPfFbQqs6I0ixpdmY4uW/cLpOc60yc/87yvQYHASBwAO1WagUpSgUpSgUpSgUpSgUpSgVwfGWjXOh5oK7qMSTbT5ITi9uH/AOy6PUx/6vw4/wCagrKm7/rRjzQ1F0cnd5oQen2PzdP4/wAquy2SD8PIriGlk/LQfWB+0FZVcGmwgfWudApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAoeO9KpWrrk6uYqI2opabA3AH5iRmjlrasaWPqlcDIZH/io/mp5ln+Kj+atGaq1XC009CbnMyXDL37CylJ27SkHOVA/vDtk1zuOpo0HUUKzGNKdlSmw6lTYRsSkq25O5QPHfABOKlskbZlO/wBLeHmWf4qP5qeZZ/io/mrQly1vbIGoTZ3Gpi5CVtoccbbBbbUsZSCc57c8A133fVkG16ih2aQzKVJlJQpC20pKBvUUjPxZ7pPYGlr7zP8ADenmWf4qP5qeZZ/io/mrR7Wp4TmojZktSPNBxbe4pTsyltCzznPZY9O+aW3UjU/UM20Jt9xZeiDct55pIaIyQkghROFYJHHIBpae8y/LeHmWf4qP5qeZZ/io/mrRlo1TFukm7Mx40pItq3G3nFhG1SkEghICifTjIFYml9d2nUlxbhW5MkPKjGSeolICQFbSk4Ufi9fbHrS193nv/wAfDf3mWf4qP5qeZZ/io/mrRVr1ZDuTd3cZjS0NWwuJdUsI+MozkJAUT+6e4FfdP6tgX+HMkW1mU4IraVqRsG5RUkq2pGfm4xjjmlk7ZnH8t6eZZ/io/mrsSpKxlJBHuK0fpfUDWoYrz7EKdFQ04Wj5ptKCpQODjBPYgg1aLTcXrfKQttR6efjRngilkbbWVZY02TSgOQCPWlVvKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKpWrra6iYqY2kqacA3EfukDFXWh570ctbSjVx9MtKXiw228ux3LlG6zkfd0lb1JKMkEkEEc/COfpXC4adtdwukS5TIvUmxNvRd6iht2q3DgHB555rdJjMHuy3/KKeVY/gt/yipTJGxZR8ZNJTdL2Wdd27pKt7Tk5BSoOknun5SRnBI+orum2C2zrqxcpMbfOYCUtvBaklISSQOD2yo/fPNbn8qx/Bb/lFPKsfwW/5RSj2WX7abRZLci8LuqYqRPWCC7k+oAJxnAOABnGcCshqDHZnyJrbeJMhKEOryfiCM7RjtxuP51tzyrH8Fv+UU8qx/Bb/lFKT2OU/wBNKwNN2mBNnS4kTpyJ27zCuoo79xyeCcDJ9sVxtel7Na5jUq3wUMSGmeglaVK+T2PPPYcnnit2eVY/gt/yinlWP4Lf8opS+yz/AG0nB0zaIK7guLE6argFCT+0WepuznueO57Yrvs9jt1mL5tkVMfrbeptUTu2jaO59q3L5Vj+C3/KKeVY/gt/yilE7FlPzm1Hb4Me3sKZht9NtTi3SMk5UpRUo8+5JqYtFueuEpCG0npg/Gv0ArYnlWP4Lf8AKK7EpSgYSAB7ClGOw77yyt9AwAB6UpSq+gUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVp3xH8cY2idWSbG7Y3pi2EIWXkyQgHckK7bT71uKvFn6TP/e9dP/csf/STQbNZ/SctxcSH9NS0N+qkSUqI/ApH9a3TovVVr1jYWrtZXVLjLJSpKxtW2od0qHoa8YviVraxadtGmdOOuTbSwtEp9hAKnytQKSrA7DHc+5q8zpWp/Bvwui2zemFeb5MdfJSQtUdpCEJIB7BRJHIzj79iPWVU3xXOrRpNf9g+n+tuondnbu6eDnZu+HdnHf0z6145Fx1kuALyL3PLalYCv1n+1Uc4yG9+8jPrjFbFm601bcvBK6N379YsSYkuN5eetC2VPIUVZTu43EY7/Xmg234Hq8R1Knf9QAfJbB5frhAe355+T93Gfm5zjFbYrwtobxJveljd5LU6RJmPxPLx/MuqcS2ouIJXtJxkJBx965RP+oupLVcNSxpl5lwYilGRJTLKQggblYTuBwAQeBwKD2Tro35OlLgdIpZVe9g8uHcYzkZ78ZxnGeM1qXwmPi9/bBr+1oe/UmFeY810v8p27NvOc47cVr/Svidfbz4a6vst2nPPyosFMmLM3EPBIdQlSSocn5hg9+9Qnghqy4QddCbcrhOlRIkGXJW04+pQUEMqV2Jx6UHtOleJ06o8RPEzVTn6llzlyUAvtxIkjotsIChjuQOCQMnk1B651Rqx7VU83qZNg3JBQ3IYafUhKVpQlJIAOBnGeOOaD3pSvAuqtQXlu6MhF3uCQYMNWBJWOTGaJPf1JJqZ8RZ2r4belpV4u69si1MOwhFfWC21tABV2+M4yTzknvQt7hpXj26eMupUeGdkt0a4OouTinkSJ2f2ym0kBACvQ8nKu/wjnk1S/P6zjRI91TergA8odMoue54k9iWwveB9SKK97UrxprnWer7toTT/AOuBdIc+PJfb8wELYMlspbKVHGMkHIz9veqLarhqm7XFmBbZ94kzHVbUMtyHCon7Zoj9Ba8leKnizrayeIV9ttrvamIUaQUNN+WZVtGBxkoJP4mvQvhLZLtp7QVut2oXy/c0b1uqLpcI3LKgCo98AgfhXkHxu/72NTf/AMo//KKD2to2Y/cNIWObMc6kmTBYedXgDctTaSTgcDkntUxXizXXiVqGSzaNPWafIg2+HAiMbY6y2p5zoo3FShzjJxjOOKiIl417pu8R/J3W4Oyz8aW48wTEq+ikoUofgeaD3VTIPY15C8btc6wnt2MSkXCywZEFDimUhbIceyQ5nseCOAfTB9apWlLfqu6ITJ0/ef8AtRUdsdN1S1IUR7IKwTQt7ypVf8Pv1l/Ymyi+9b9aCMgSev8APvxzu+tWCilKUoFKUoFKUoFeRf0h9K6hunincpVssV1mRVtMhL0eG44gkNpBwoAjvXrqlB4t1L4Zakg2DTd5s1nufWfibJbLDK+sy8lShkoA3AFO309D71KWrwx1TqjwzfW/Ent3m33BbjMa4JW2t5pTTYUE78eqRj04NevqUHh2LZPEyHbDY4lov7EMubyhqIpPOc/3gGcZ5xnFXDVGmNSad8ELi9rG4ynJc2ZHDEN+SXeilJUfUkBRzyB6Afh6yrRf6QHhtqTXWorU7YkRzFYjFtxbz4QkK3E9uSePpRGgvDHRT+un71b4K0JnsQfMxws4StQcQCkn0yFHn3xUlGsfifYbZO0/Dtd/Zt8skSGGI6ltryMH4gCOQADg8ivRfgh4U/8AT5qXMuEpuVd5aA2otA9NpAOdqSeTk4JOB2H4yHiF4u2DQl8atV4jXJ2Q4wmQFRmkKTtKlJHJWDnKT6UGltL+E1+svhrqy53KC9+tJsJMaLAaT1HtvVQpRITnk7Rx34Oah/BDQ17OvG2b7YrtDt0iHJjuvPxHG0gLZUn5lDGea9U6K1NC1hpuLe7Y2+3EklYQl9ISsbVlJyASO6T61heIWuLRoS0Nz70Xil1fTaaZRuW4rGcDOAOPUmg8iPaD1jp+8dbS4lzWVEpj3KzulSXEE9ypByn6g4xVR1RCft+oJ0SbLTMltObXn0r3hTmPi+L1wcjPripjS+l7pqy43FnS76VlhBkKS+6I6unnBUcnbxkZ+L1rYOhPAibcrtH/ALRXa2R4u7Ko8aUl590DkgbeB98n7UFI1BpDUs+ZFkwdP3eTGXAh7HWYTi0KxGaBwoJweQavXjLpbUE+06BRBsV1krjWCOy8lmI4stLCRlKsDhQ9jzXrKKw1FjNR46A2y0gIQgdkpAwBXZQp44j+Eeorx4ZRJ0W2SmbtClvpchSWy0460QghSQoDODu++eO1Q0ez+J/6uYsse1agZiMryhCIqmgDn1cAGRz6nFe4KUV5duUfxS0ToqLbon63uFxupW7IdZS7LXCQkAJbSoZCVHKiSPpjtmtX22xeIlrlvSrZatWQ5L3948xHkNrXznkgZNe6JVxhRHAiXMjMLI3BLjqUkj3wTXdHkMyWg7GdbebPAW2oKB/EUFV8JDdD4c2M3/zn6z6Suv53d1s71fNu5zjHevLfjDpDUs/xN1DKg6evEmM7JKkOswnFoWMDkEJwa9pUoPHev/CLUrDVpvVlt0mW1JgxlPMNIPWjPBlAUCjv3GeOxyDWDGsfixqS5xk+VvsdxADaXHEKhttj3PCR+Pc17SpQeX9eaf8AE7Ts1iPaVXG+W0RWQ6txCZiHHQn4yW17iOc447YrWK9Da41DeFOjSs5iQ6RnbA8m0D2zjalIr3dSgg9DW6fadH2e33iR5i4R4yG3nN27KgPf1x2z64qcpSgUpSgUpSgUpSgVrfxa8WLb4eqjRXIrk+5yEdRMdCwgIRnG5SsHGSDjj0NbIrxx+lNFks+KTj76VdCREaUwo9ikDaQP/MD+dBsJ79JSH/Z5qUxZN106/TdhrkEAIwSFpXtOe2CMDFco36RD72l7hd/7NtgxZceN0vOn4uqh5W7OzjHS7Y/e+laL1lqOx3uz2qPZtLR7O/ETtfktOlRfOPXgeoJycmum2/8Adjf/AP8AtYH/ANKXRG7W/wBJjqWuc4qwNszUbBGa8yVpcJJ3FR2jAAH4kipmT+kFFgaLtVylWsPXmf1FCG07tQhCVlO5SiCRkp4GD2NUX9FOy2y83jUCLtb4k1DbDRQJDSXAklSs4yOKhv0m7M3ZvEFlEOG3Et7kJssIZbCEDBVuAA4znk/egt0T9JyYJA85pqOpgns1KIUB+KcH/iqH+kBqeBq/VFnvNqK/Lv2psFCxhTag66Ck/UGsS9a607PstphNaEtbT0NIS891VpL2E4PKNp5PPJNVnVrseQ9b5MKzN2eM/FC0MoeW4F4cWkryskjJSRjtx9aDZGnfGC7aM8PtN2ywwmlhvrmS/KaUUKUXlKCEEEdkkE/7hWw9TeLNlv3hJFvly03FuijPTCk2+Q5hLLhbWrelW0nsnjgHk+1ax1akf+znoVWBnz8rn/1HP/xVPgKP/S69pydou8Egf+jK/wDxQbNteurVL8ONao07oiLa1+VQw6uO8XFFDu5JUTszhOM47fatY+F99k6b11a7tCt67lIjlzbFQSCvc2pJ7AngKJ7elXfwNaW9ozxObaSVrVZyAkdz8LlUzwo1JE0jr+1Xu5NvORIpd3pZAKzuaWgYBIHdQ9aD0n4jePVp0reX7Tbre5dZkdWx9QdDbaFDunOCSR68cVDaY/STts64sx77Znbcw4oJ8w2/1koJ9VDaDj6jP2rzvcJCGtbvy7mw4phcwyFtut7lKQtW4HbkA5BBxnB96mrjd9HSdQKeRYrjLjqCUpQ261CCj9Gm0KA/mNB6O8VvG636KugtVvg/rS4BCXHf2uxtoKGUgnBJJBBx7Ec1R7V+k275lIuunG/Lk8qjSDuSPsoYP5itR+J8R60+IMhM2C40kJjuJjPrKz0+kjCCr97AG0n6GpPVWu9NXmdEejaBtUVplvYttLziN5/9PYPzBNBk/pEala1RrtiZEZUmCiAwiM6c/t0KBc34xxguFOOeUn7VsrwC8QYunfDC4/r2I7GttqWFNSRlRlLdWs7EDAGQRjue/OK1V4vskRtGyWrV+qor9mBajBanEo/bvKwFK5PC0q57bq4zNTx7h4L2/TEViWZlumqmyV7B0umoqSOc57uJ7ig2nI/SdQJKhG0wpUfPCnJm1RH2CCP+avunPG7Tl30jdL063IivWxCVyIasKWdx2p2HsoEkDPGPXFeWNN3WwRdN3GLd4br010/sVNR2yojH8VZJbx/pSatWjpukk6Y1K87pe6KiNxWmpT/6xCjhb7YSEjYEhQI3DP8AlI9aC6S/0nJpkHyem46WM8B2SoqI/BIArZfg94tt+Ik6ZCVaVwJMZkPEh4OIUMgewOea8ryV6ftCm7lpm6yZMpKsCJcrY2oBJ75JUpBx9vyra3gx4jW2AxqW73DT0OPMgQA6uTbmuiH0lxKQhSAdoUVKTyAOM+1B6kpWlfC3xyb1rqtqxyrMYLshK1MOIe6gJSkqIUMDHAPP0rdVFKUpQKUpQKUpQKUpQKgtW6SserYSIuoLe1MbQdyCrKVoP+lQwRU7Sg1+94QaLdsDNmNqKYTb5kAIeWlal4IypWcng4wTxXQ14LaJatMm2otz4iSHm33E+acyVthYSc5z2cX+dbHpQVLRHh5p3RMiU9p6I5HckpSh0reW5kAkj5icd6lNUaXsuqoKYl/t7M1lJ3I3jCkH3Socj8DUzSg1pF8DtAR3w6LKXCDna5JcUn8t1SOqPCjSGppkeTdLaSuPHTFaSy8ppCG0kkJCUkD941eqUFGm+FelJul7fp6RBeVa4Di3WGxIWClSiSSVZyeVHvWC34LaJbtMi2otz4iPvNyHE+acyVtpWlJznPZxf51selBUtE+HmnNFOy3NPw3GFS0pQ7veW5uCc4+Yn3NQ1z8FtCXGe5LesgbdcVvUll5baCf9oOB+FbGpQUzUXhjpHULMRu6WdpZitJYacQtSFhCRgJKgQSAB65ro014TaM05PbnW2zN+bbOW3H3FOlB9wFEgH61eqUFc1dojTur0NjUFrZlrbGEO8ocSPYKSQcfTtVctfgroO3SkSGrIl1xCtyQ+8txOf9pOD+NbGpQQeqdJ2PVVuRBvtvZlR0HLYOUqbP8ApUMEfhUJpfws0hpmRJetdqAXJaUw6HnVOpU2cZSQokYOBV3pQazf8DdAPSC6bKpBJzsRJdSn8t1WmLofTUXTjthYs0RNpd5cjlGQs99yj3J4HOc8VY6UGsXvArQDrm/9TuI/0olOgf8AzVabNoTTNmssq02+zxWoMtOyQggqLw/1KPJ/Pj0qy0oKbpDwz0ppG5LuFjtgZmKSUh1bqnCgHuE7icfhVypSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVC3TUUW2zXY77EpSGWkPPPoQChpC1KSCrnPdJ7A4qaqq3zTj8+/OXBCgUBEZIZU6oNuhC3CtK0DgjCwRnPIFWElYfPw/PeS83H85t3dDqDqY99uc4rpN2iMxm3p7zMIOLLaQ+8gZIJGAQcEnHbOarKdPSo9yW64y07HTOXO8x11lYBUVYDYTyoZ298EDt6VxtVonoSzOTCYfLrLzZjTFFsthTy1g/Ke4UAoYzwKUXK2LnNtyXW3sNNoShXWW4kJJUSAO+R29QAc8Z5rj+trd5ETfPxPJk46/WT085xjdnHeqr/ZGWI6I63GX20s25olZPx9B5S18c8EHisqRYJbd7M+OzGeZTMU+mMtW0FKmENlQ4ICgUn8FHkUqC5TcO9QZKVHrtt/tlMoDi0jqFKtuU88gkj8xWTHnw5Mh5iPLjuvsnDjbbgUpH+4A5H41VbFpZ+NdI8qY1ESlrzikpaJIaU86hSduR6BKhniuWl9OS7bLt/mWGAmCypoPpkKWp0nAztwAAcbjknnH3pUFynJ97Ziy1Rmo0uW+2kLcTGa3dMHtkkgZ+gyfpXam9W0w48pc1hpmQcNKdWG9x/y4Vg59Md6wVxbnb7rcJFuYjSmZqkuqS68WlNuBCUeiVZSQlP1Bz3zUWzp6fBd8wliFcXXmHEOtPrKENrW6txRT8KspJXg+uEppQtL1whsymor0uO3Jd5baU4Atf2GcmsaNe4L8tyKX2mpKHVMpacWkLcKQCSkZyRzVfe07O6E6KliCpM3pEyAopMcpQhB2JIJONm5Pxdz+JP6emrcubQjQtk2ciUJW89RtKdnONvKhs45xz9OVQb1pbnw3ZjkRuXHXKbGVspcBWke5T3Fdsh9mMwt6S62yygZUtxQSlI9yT2qqwLBNYct7KmoqW4UpyT5pCz1Xt2/gjbwTv8AiOT2+vEhdYky62y2PmO03LYeblOQ3HMoUQkgoKgPQqyDjukUoSTdyiOuMhl5DqHm1OodQoKQUpIBO4cfvCvse5wJMVcmPNjOxkEhTqHUqQnHfJBxUJLskmfpy5RHGIcKRKWpSURySnGUnClYGd234iB2Pr3OCjTcl1ua5IhMtrdLG1tMxZUemSdxVtxkE8Dbzjk88C5TsvUtniSoUd+4xULmAqZJeSAoD1zn17D3NZz8xLElLbqdrXSU6p5S0hKAkjvk59e+McckcVWoljucc2t9SYj70Z94qS4oIPTX2O5CMFQ4/dGff1Pfq2xSrut8xi0Au2SoY3qI+Nwt7fTt8JzTcb0hP1JZ4MQyX7jE6IfTHKg8kgLUoDB54xnJ9gCa7nb3bm3YTYlsLXMP7AJdSd4xncOeR9qhrpp59x+W5BbipSW4ZabUdqVLZeUsg4BwCCBnB+1YV003PlzZzhjRnEz0tbsylpTHKUhJSAEgqAxuBBSck9u9KguVsducBmV5V6bGbk43dJTqQvHvjOcUXc4CEPKXNjJSyMukupAb5I+LnjkEc+1a91AlKJFwtcdy3SH5VwaeCFhXmgrcg42Y5SAOF5wE/app3Sz6ba2Gm2FSUXN6ctAcKA8lS3NoKsHkJWk9jyn8aUWtJuMERm5BmRhHc5Q71U7VfY5wa71PNJd6SnEBzbv2FQzt98e31qq23TbiXrc7KjRkhmU9JU0HFOhJUjaCCRyfU4AGSfvUjdoM1V3RNgoZdzEcjKS4so2kqSQrscjg5FBIqucBK2UKnRQt7HSSXU5cyMjbzzke1chPhqnGEJcczANxYDg6gHvtznFVJvSckWObHWmMZrsGNHbcz8q2kYznGQN3IrnD03LZuyC4yytlM5yZ5kyFbsKUpQAQB3+Lb82MD64pUFyudKUqKUpSgUpSgUpVD1VfrhHu81uOlLbVuQ28gLUhKXioH5iXEnb+6MJVyM88CrEWkzS+UqjXvUdxjM3mU1KhxxAeQwiI63lS9yUHcTkHJ3HGBj4fyzl354tQW1rZLsi5SIi0Y56aOtjj04Qjn6/WlFrXSte2u+TXI7DEeZbrYwzZo01KVtZG5QXkfMMIG0fXmh1bdnnVPIYRGQ15fMd3pjf1EIUQSpwKByspGEnlPr2Ci2wqVB6gnyWbha4UV9qKJanN0hxG4DaAQhIJA3HP5JNVqDcJcLTM28MvtyHRKejgI/usqlFJdwVAYAOeTjHrjmlFtg0qjf2juke2z3lBuS9DfaShoBHUkbhy1htSgF85Bz7ZAGTXem9T5Mm2RkXOAwJMFctb/S3AqCh8KQSOACc55+H09FFrlStcP6wuzjKnWksMhiG3JJIRsfKirnK3EkIO3jaCefwOZqKfd5Vp1StqWiHHgs7Ww23lzcWULOVZ4xuPYf0pRa90qmXK+zYSm3GZ8eTb22kuOSWm0Ok5WQdyQsEJwAAUg859sVK6ilLi3CIpluMp5MaS42t87QlSUpIyr0SfX6UotPUqkN367qjuMhTZnJdaCkLabQpKFpUfg/alCz8PA3A4BPPGe2NqZ8xJLzrzW1u3uPpWprp5dQtaVcbj22pzgkc8HBFKLXKlUyLqC4quMPzS2URHlMtgttJWFKW2k4UQvchW4nHwkYx+Gde7lLTeXoTE2LBaYh+aKn0buqSpQx3GEp2jOOfiHb1UWstK1dbtTXONZIaIyW22oduiOAOdPDxU0knJUtKgM/CNqTyD37VZ0XqenUaWJKmkQ3JBYaDbaXAr4N2CoL3JVkHunGB+NKLWrAznHPvSqneLvNRqGfBYuMKCzGgtygp9vcVKKnAc8j4RtGfXmsSyXiQuamStsRxPmMB5tz/wwqGF7fodwApRa70qiSNTXNbLr8ZyP5Zp2UFuIQlxQS25tSdpWnKcA5Iye1Z+rZKydMvMSGmFOzhh11J2gKYd9MjnngH1xSi1spVBe1LdRKFvbW04UyHmjOaQ2A4EIbUAAtaU7v2hB5P92rj2xrnPfuNsVKkdMPLtD24tEFKsOpG4YJHOM8E9+570otselUZ3UtzF7eQlDaI7U9EMML6Y3pJSN2SvfuOdwwnGMfcSFmvM96++WnraDbvW6KWm0qQoIVwQsLJzgjIUkc+1KLWmlKVFKUpQKx5EKLJeaekRmHXmjlta2wpSD9Ce1ZFYMi72+PNRDfmMIlLIAbUoZye32z6e9B032yxbtEfbcbaQ+430xI6YK0jPYHvWZ5CJ5lUjyrHmFEEu9MbjgYHPfsSKxmr5bHZbkZucwX2925O7tt+bnscevt61iv6kg+T8xBdRLw+wypKVYI6riUBXbtySPfFXem53GwW5U9cp2M06VNtNJbW2kobDZWUlIxwfjP5Cs12DEektyXYzC5DXyOqbBUj7HuKx0Xq2ruJgImMmWCU9MK53AZKfbIHOO9ZapDKZKY6nEh9SC4EepSCAT+ZH51FfJUWPMa6Uthp9rIOx1AUMjtwa+pjspZU0llsNKzuQEjac98j61GvakszIbLtxjp3tpeTlX7iuyj7J+p4rJ/XFu8+IPnWPNk4DW8ZzjOPvjnHfFB2x7fDjNttx4kdpttRWhKGwkJUeCQB2PJ/OsWRYrfImJfkRmnUhso6S20qb5VuKsEd8+v1Ndky49CWmIwwuRJU0p7YhQGEhQHJJ4znj7GolvVI8mzLkwXIsZySY/UedRwQVJJ4J9Ufjmqm5OvwIkhbK5EVh1bJy0pbYUUH/AE57fhXalptJcKUJBcOV4HzHGOffgAVHOahtLcRqUqcyGXVKSg5yVFPzDHfjBz7etdci9jzkePAirnF5gyUracQE7MgA5J5zn0qCQcgRHFsrcisKWz/dqU2CUf7fb8K7VtNrUlS0JUpIIBIyQD3rAVe4DctuJIktMzFbQWVKBKVK7JJHAJ9B6+ldMrUEJuQliM63IfEhEd1CF8tFSinJ/EHigzU2yAmMuMmFFEdZypoNJ2qPuRjBrk5b4bqGUOxI60s/3YU2CEenHHH4V2sSGZAWWHUOBCihRQc4UO4+4qFe1I2zcno7kN8MMym4apG5O0OLSlSeM5x8aRnH/FBLCDETIRITFYD6E7EuBsbkj2B7gV9kw40lTapMdl5TR3ILiAooPuM9qw49/tUlClsTmVpSUJJB4+NW1J+xPAPY1wuN7biymYsZlcyU470S22pI2HplfxEkD5R/yKDMXboS1sLXDjqXHGGVFpJLf+3jj8K5iHFEvzQjs+Zxt62wb8e27vUPc9SItUSTJuUYsoYZS6ptLgW7kqUANo4x8PBz7+1TUWQ1KjpeYUVNq7EpI/4PNFYT1kgyLm9OlMIkOuNto2uoStKNhWQUgjg/GeftWW/DjPtutvx2XG3SC4laAQvGMZB79h+VQ6tSpEdUxNvlqtaVEGYNm3aDgubd27Z9cducY5rPVercm4CCqYyJRIT0887iMhPtnHOO9Xem52uW2C4hCHIUZSEK3pSppJCVe444Nd78dmQkJkMtupGcBaQoDIIPf6Ej8ajhqG0qecZROZW63v3IScnKM7hx3IwcjvXRC1TapVojXBUjosvhO1LqSFZKd20DHJx7ZpUm5JO26C7ETFdhxlxU9mVNJKB/5cYrsVFjqTtUw0U7OngoHy/5ftx2rHZukd+VFaYUHUSWVPtPIIKFBJSDz/5hWdUVjqhRFTEy1RmDKSNqXi2N4HsFd6+tQ4rMhx9mOy2+587iUAKV9z3Nd9KBSlKBSlKBVduNklPXsTIjjccLcaW44hxxKlBBGUqRnYvIBGTggH1wKsVKCqx7FdY8JNuZlQm4jCHQw8Wd7uVJUEkg8DG7kj5semTWMjS9wVKdedfZ/beUKkl1xwpLD3U4Ku4UCfbBx96udKtpSoQtLSY91QS80uC3LcmJJedKyVKUrbs3bBgqPxew7c5qTmWqUi4xpludQpaGXGFiUtSuFlB3A8kkFHb1z3FTlKWUoVusV3hyJUOKIik/qyLCW9IbVtJSHAVJwPixn5TjuORUpE03JhXKMuI+lqM0pCnFJdXueCUBOFNn4MnA+Pvx2q00pZSJ6Djeq/MbFFl6GG9wHCVIWTg/cL/+E1jNWNxMGCwtbajHnLlng4IK1qAH1G4flU/SoUp07S0s3FyfEeaLxdeIbU86ynY4G/3myDkFvtyDmsqHpSMh6AZzMSW1GiFja41uG8qCioBWcDg+uas9KtlKxL0/LcXOjMvRk26c+h9wlJ6reAgFKccH5Bg+n1r7L0yuTbXIvX6JduJmLcZJSopK92Ae4VjAzVmpSykLYYE60sxbfmO7AYStCXOQ5tBT0wR2zjcCfXAPqa4M6faRcLxOLcbzst3exILQUtr9ihscn6pJx9anaVLKUo2CVHjynLipUht6F5VxEdbjrm4H4Voz25JOBgJwO/eu+3aadk2+0KviY8mUl9Uyal1sKStxTak4A5Hw5SB9E1bqVbKVu6aaEpNyairZisSYKIjSUI4bKVLVnaMDHxjj71Lwf1iHlIneWU0GkYcZBSSvKtw2knAxtxz6ms2lQpR5+nb83bm7Zb5cVdrQhUcoVuS4qOrAKPUbwOAvj6jmpBenZRU9EQ+wLa7NE5Sik9ZKgsObB6fMnv6DjHrVopVspXYen3WG4CS43mPcJExZAPxJc62B9x1R+RrHh2G5wWLUpqTDek21pcZsKbUhC2lBA55JC/gScjjuMetWqlLKVePbJcKRCYYKXH225UhTxQUtB1xQIT/typXGc4TVma39JHV29TA3be2fXFcqVFKUpQKUpQKUpQKUrpaktOvustry41jeMHjPavM544zETPz8LETLupSlekKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6UpW9yAQRkEEe4ri04h1tLjS0rQoZSpJyCPcGqxbrdcIyoqHWn1bQjatuVsQ0AfiCk5+Inn0Oc4ynGayJJuDekpTTiXW5rUTAdSvKlL28kEeoNBYaVUn4F0KViO3LQwt1OG1yypacIUCrdvHwk7eMntnHOK7rZGuyLpDckokFHTSHi48ChJDeDgJXydwzgpPcnd6UFlW4hspC1pTuO1OTjJ9hXKqtOttyeuKVth4rTKLofU/+yS3sISAjPcEj09zn0rK05DuEZEjzJfSVNpSkSHur+0GcqHJ4PHqM+w9QnXHENNqccUlCEjKlKOAB9a5VCzv1gzp6b1lqdmKQUtFhJUckYGMD39fx4HAjpUS9OIeYaD6cKklLwfA3Bastgc5+EHHIGMccUFpLiEuJbK0hagSlJPJA74H4j865VWHbbdUPyW4zr3ldy+lukEqKSlnjcSSCSHQD6Z+1fYduuC5iXHFTGIgDqm2VytykEhsJ3EE55CyBkgZ/Cgs1KgLTDnqtU2PJMhhxeUtOOOlSx8PzcLVjn2I+wrAlwL3IYYdcMgPOhxTjTEkJ6KzjZzkApAHOM8knBzQW6uKXEKcWhK0laMbkg8jPbNVh213UNuuNPv+ZcceSSZB2hsg7MDOAc7cEDIzXCJCuMW4OymYkvoLcT+xXJStzaG1J5JVjAUQcZPv9KC2Uqr2mHdmLjAVKD60BlAfUt/KEkNYOAFcncPVJ7k7vSuyRCua5EwM9dL6+qW5PmcNAFJCE9PnkHHoO2cntQWSlVZq1zpD6Avz0aESolpUwlwHZgEqCicE8gZ9M+uK4x7TdAxFbcelHe3HMo+ZOd4J6mDnjI/y8e1Ba6VUxabs1FIjyJPXUJCCXJJV8G/9ljJODtAGe/PNZcSFcU2Sc0FSW3nFZaS8+FOJTgZG4E7ScKx8RxnPHYBPpcQpa0JWkqRjcAeU5965VTV2u5dSQ40zNbjOPpV0RKHWKemE/Nv7BWTjd6/TFZtsh3Vi7x1Seu60GwHXHH8oB6YHwgEZO4eqPUnPpQWWlKUClKUClKUCoi1/43dfu3/Q1L1EWv8Axu6/dv8AoawbX92h1T2ZOunw58vMJelKHscVvcilUxFmuvQ6SlP9FLqFLHmMuugJWCMn4SMlBzhJODkdqymLLcGwhxTzqn21RthXIKsISodQHsDlJIzjnigs7a0uNpW2oKQoZBHYiuVVVm1XNJY6qlLfHRIkdc4aCUgLQU/vbiFc+u7n5RRFnnsJtQaLzi2kNh4rkkpKtwK1HkHPfGMj0IxQWquJWgLSgqSFqBITnkgd/wCorDfbnefS4y6jyqU8tHuo4V9OO6fX0rBu1rfuM2DKQRHejsOFC85LbpKCPuMBQPuDQTaFJWkKQoKSfUHNfaqTdoufl46XEjq9FKUlt8hMZ3epSlem4EFPp+7jsTX123XZ1tLSw6lLTK2ypuQApw9VCgR/5Ung47kcd6C2V1pfbVIcYSrLqEpUpOOwOcf0P5VCGDOVZYTTiNy2ndzzCXiOoj4sJ3EnnlJxnHGM4rHTZZXXEkBTbyRHCB5hStoS6pSwSe/wKxz9qCz11yHm4zDjzytrTaSpSsdgO9VKJYblsCJMiSVKLYkL8zgPYcBUpIABGRn1B5x6A1kS7RNebns9NSlupeCZBkkBSVAhCNnpjIH4Z7k0FppVYfs8tuQ4G0Lfg71FEcSVIOS2gBW7OeFBfH+rPcVwFkuQRvVIcXKKylbiZBTlHlynjuB+0we3fmgs7zrbLanHVpQhPdSjgCuSVJUMpIIzjINV2NbZytPzIjqcOrcBa3uZUU/D83JAOQe3HrwSa43Czyl3hDsZb6Y4KFI6b4SlB3lTmQQc7s+nfscDmgstKqbFpubbGJAW+jrh0siQQS1tUA1n/SSDn96vps9xVcGHS4+lKels2SspaCfmScpyrPPPrnnGAaCzR5LEkEx3m3AACdigeCMg/iK7apqbDcERWUErCE9EOIZdCVLCWikjJ4OFYOD7VkMWS4oR1DIdMpCmA2tT5VtSEgLz2B/e9OeKC1UqpLtFwXCbbQh1kJW2X0plb1PhIUFEFXAySk84zjBxVhs0d2LbWGX1rW4gYJWvee/AKsDOBxQZlKUoFKUoFKUoFRFr/wAbuv3b/oal6iLX/jd1+7f9DWDa/u0OqezJ10+HPl5hL0pQ8g1vciuK1obAK1BIJAGTjJPpVMfsc1mMwnppUreyh8tuqPmiFgqcXgfDwDnv82OwrnM01OeaQhtwNNJ6pbZbewlgqI2lJKD2we2CM4HFBcq61vtIUUqWncNuQOSNxwOPqarUnT8lcRxCem667KcdcU4snKTu2dwRxkcYwO45pHsMlt9uR0oolKajJdkBX7QltYK+duSFD6+lBaaVU29PSyltDnTSPgEhaXlZlkOJUVqGODgK45+bHYVy/s4+Q98SMtoWIn7RWGldVakEe2ElI/AjtQWd95thve8sIRkJyfcnA/5Iow82+2HGVhaCSMj6HB/5FVJGm54lPOqf3Fbm5RU4CHB1krGQEA8JSQMk47Dijmm5y5MdfXwlsfBscA6SuqpZUMoJ5SpI4I+XHY0FwrpXKYQwp5TqOkklJXnIBBwR+fFQV6skqdempTbyg0hLYRhYHTIWSogFB7ggcEZxg8V9j2JUeyTYMdiKyXX1uILfAUkubhuwOCAcevagsVKr1ptc6NfHZb3SDLodCwhedxKwUHtk4AxyTjPGBXQ5ZZvTkpbZjdV3IW8Xl5eSXAfiGMZCcgZyPTtmgtFKpDdinJWzFksNyUIakFAU6pKElTiSjkJwCkEgYAxjisl2xXVUtbiJLaHFNqaMgKwo5a2hRGM5CucZx+NBa3HUNlIcUE7s4z9BmnVb+D40/tPk5+bjPHvVdTY3XG0tGNGjRiVBxhLqnEqy2pOSCAO5B7emTzWIjTctMmEtsNRkMJaCUMOAJbKVkrIBRn4h3wRnsaC3b09TZuG/Gduece9cqr1ytc1+/MTWOkENLbwrfhRQM7h2Pv6EZ9a7Zdsfdu6pIbacBUgtvKdUlTKR8yUpHfPJ7855yBQTlKqTGnZJDCHktJaSW/MBLqleZKSdy1cdz7eucHsK6Zmn5MS0veUz1y2+2rprUVKSpwFoe/wpGPp6UFzpVajWFwTGVqbbYiIf63lm3VFIwjAPYd1YOO3Ge9YULTE1tO2TILm5TfXJdGH8OBRUQEg8gEck98ZxQW991thlbryghtCSpSj2AHc1zqmzdNTHYcljaw6FNOtRgt1SRHy4spIwP8ikD6bMdjWRN07IeYWAvKnJi33U9T+8b+Lan4kqHGQcYxxQWqlYlpjuRLZGjvuKcdbbCVKUrcSfvgZ++Ky6BSlKBURa/wDG7r92/wChqXqItf8Ajd1+7f8AQ1g2v7tDqnsyddPhz5eYS9KUre5OuM+1JYbeYWFtODclXuK7Kp7OmZiJEJanGVFhDQC953N7D8QT8OcK/wBye/IPas20WWZEt9wjFxqOX29jTjSt60qwRvKtqcnkd8njkmgsdcUuJUtaBnKMA5BA5+vrVUt+l1oU0mY1FMYOBbkdKtyF4QtOSNqQSSpPcenc8V0J0/cH4yWZAQtLKmklDzg2PbWgkqGUq/e5GU/l3oLpXVKkNxYzsh44aaSVqIGcADJqsx7DcGAlomM+z1W3lqccVlRSyGynG08EpBzn17VkRLFKY03cbct5t1+QhaUvFSudyMAKzk4T2HJ4A9c0FjByK4uLS22pas7Ugk4GT+QqsxrJNjSG5MdiExseSvyrbqg2cIcSpe7Z8x3jPH7o59ax29O3Bvo7VRt4i9FbpcJIV0in4RsyBnB+bHfjNBb0qCkgjsRkZGK+1VX9NSF9Rxp5tmYta8yEklaUGOWwAcei8Kx24z3rG/sxLTCLbbcRKisKDXVHTB243EdLBJ4/dB4+agudKgrZapUW+PSlhjouJUCoK3LJJBH7oIHB4KlemMVEtaelSGJBS0zGdcMpJe3qDjoWpYSlXHCRkEHJ7DAFBc6x4MtuawHmQvpq+UqTjcPcfSoOVp7fNBaZi9Dc2UuKJ3soTjc2hOMFKsHPI+Y5BrFOllNW6NGjR4OUsdLPKAy5/FRhPKu3seByKC3V1tvtuOutoUCtogLHsSMj/iq05pt3puqaU0JDqnuq5kguoUvclKiBnGOD7ZOKx3tNSi3I6EeC0HHg42wl09NA2BPYtkHkZ4A78Ec5C4LUlCFKUcJAyT9K4sOofZbdaVubcSFJPuCMg1DX60u3DokNxn9jK29ryilKFqxhxOAeRg+x571gW3TkqLc4sh1xlXSS2OoFfEAloIKANudpIJ+bHPbNBa6VW5+nnZEqTIZcQzJdeWRISTvQ2WC3gfZeFY7cZ71iSNOSVx1hmNBYypJEdt09LIBBWctnJOR+76Dmgt9dDMth51TbSypSSpJwk4BTjIz29RUVeLU/MMRXSiSek2pCmnypKAo7cOJwDyMHHY89xWFL0/NebkJbkNoDhcPCj8W5TZweDwQhQPf5vWgtNcUOIWVhC0qKDtUAc4OM4P5iqj/ZV1cVxC0xgei8GGwolLLitm1ScJAGCknISMZ4Hc12TdMqJlmJFggvyA/nIbKvgwQv4FA85Pb19DQWylY8FL6I6USg1vQAkFsnCuBk4PbnPHPGOayKBSlKBURa/wDG7r92/wChqXqItf8Ajd1+7f8AQ1g2v7tDqnsyddPhz5eYS9KUre5FKUoFKUoFKUoFKUoFKEhIySAPc0oFKUoFKAg9iD6cUoFKUyMkZGR6UClKUClKUClMjJGeR6UoFKAgjIIIpQKUpQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6+LBKFBJwrHBr7St7kqtnto6cdp+BIamlsomSt4AcVtwSTn48nkccfTtWP0r/vlKVJkpKt2QllJCf2idu34+Rs3DgA4/1Yq5V8WtKEFS1BKQMkk4AoK5Zo0wXKPKmNTAVMlslT+UpIUrBUMjukjHBPvzzXVKVelodZYTIQ4kyf2nw4wXQWsZ7/Bn8uasyHW1q2ocQpXPAOTwcH/mudBT7hHvqHnGY78oRW3HOk4EhxxWUNlGTuTxuLo544GeKk70i4FLHSVJJDCuY2B+242k5/d7/T3qdpQVcJvO2TuMrz2HOUFHQ2/ubAf3sY/HOeMVj3MXcwii2puIJDimlPLSVBQSnaD64yVHk44OcjAq4UoKnJF3ckS9iZDiXG8oSpKUpQcJ4wchXOfY9819lN3pSpAjrlJfKnApWU9MJ3/s9g9wn/759KtHVb63S3p6m3dtzzjtnFc6CBW3cmLfPbaU+6pqU2pgqUCtbP7NShn1/wDEHNYUhF5k+bcbVLZSlMhbCAUgqUNnSB+nzcfnVqCkqUoBQJTwQD2olSVFQSoEpOCAex70FUnKukePKWUyUIAkLbLAQPizlBV9MZ/5z6UD97ditiIl0vqKlpcXjpkGOdufp1COP/tVrWlKklKwCkjBB7EV8a2FpHR29PA27e2PTH0oivWtu7t2u4jrOuSC1mN5hsJIc2n/AFK4zj6d8cViswZYkXGUhE9a247ao3WWkLW4EOggZz/n9fU+1W2lFUpDl1RIjxpa5wZW+4R0jha2w0kjkkn58+ufsOK5sLu7ktTTjswyGkR9oSUBAUfn6noeO/445q5YpxmgqMuNfPKx9smUN63lPFCQpaTn9kAAU4TjPr3xnjNc3Gb+lKnm3XFyitSAhW0NhPlyQcf+9A/P2q10oKgzBuKrmpTLlwbjuGOlbrqk7ylIdKx9slP58cVm2du7C9PLmPOlgl3KFNgIA3fs9p3f5fYe+ecVYq+BaSsoCgVAAkZ5Ge39KCnLi3tt5tEdbrDIK1NhDYVlZfWTv+IcbSnvnufXFS9h8+JkwTS+ts8oW4AkdzwE89hjkHB44BqbpQKUpQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6UpW9yVFFpuoidQyZ5k+UK9pk8eYHy+uMemPlPrzzXF6Hf1S5yw46SrqhABHTKCD0wAV4BHw5O0evJq1xpLUlK1ML3pSooJAOMjv967aCnyLZdUGUuGgtuLLuFBQyUqkBRA+IclGccj7iiWL8xCkNpTKeU4yUMnqpCmlBZxuysnOD3yTxzVwpQVWdAu5jjpvSldSU6p1KXPiCNyumE4WnCcY4Bz2zmu21MXhu6sKml91stpDqipKUJPTGcAKO7Kh/lB5POMCrLXEOIU4pAWkrSAVJB5Ge2aCuKtU9+cHHpM5LTkl0OJRJKQGcEowAePiCeRzzg8VhpgX16bEXKW98KWhuSoAJGAHQohY+I/FyEn0wRVrlSWYqAt9e1JO0cEkn2AHeu4kAZPago7FhuEaEPKpmtSY0JaGiZZVvfGNvJUfhOPlOB7is1+LeS5ILJlJdUpzesvDYtsq+ENpz8KgnjOBznOe9WulBUGrfPbekno3Lybj24ITKAfIDaAkle7OAQrjdnt3HFfWoF2SFGYmS4HFBToiPJbWtfRbSFZyn4QUryOMnHGKtjbiHElTakqAJTlJzyDgj86BxBdLYWnqABRTnkD3x+BoKX157dzix5Ml9dy6zIWlp9Owt7Rvy3n3CiTt/HHFdzMO/iZFU448kIQyMII2AbR1AobwCc7v3T6YIq4V1okMuOFtDraljOUhQJ4ODx96Ir8CLcVWO5x5aH1vONKS2p5YytRSR23KCeceuPoKjUWW5Q4nQiJcbbL5U4I+1G5OwbSAlSMYPB55IzyKu1cWnEOtpW0tK0K7KScg0VVjBvrjK2HHl8x+r1eoBueKAjp8cgZClZ7ZIx2rFuMZ+M0p+129y0t7ENuJQW0qdWp1sDG0kZA3jJ/zVcW5DLqylt1tagMkJUCe5H9QR+FdlBUJMW8IZ/7KJ5bS6tTTK30le3ajG5e/PzBePmGDyO2MvUsa7vy2jbnHUtJaO3pHGHc91fGnIxjuFDvxVkpQV6DbpcKDeG4ofTLdLi2XHX1OIKjuKSApR24J54H41Fu227JfkKhpmtsOFhK+q+FuqSkO7gCHAR8SkH5hxnHtVzS62tRSlaVKHcA1yoMOzokt2yOiaorkBOFFXf6Z5POMeprMpSgUpSgUpSgVEWv/ABu6/dv+hqXqJtiVC83MlJAJRg478GsO1x/20OqezJ10+HPl5hLV8UNySDnBGODivtK3OSmyLTc4tvYYtyJO9IeXkSlHCyrKc5WOMfce4Heu9LdxclzWAJSZmFudUycN9NRVsSlOSAoAAZwMEZyc82ulBVGrZcH3sLVPjwsOFLSpZLiTtQE7lBRJ5CiBk4/HFcV26+FovNPvImrWtOVvZbQkxyAducf3u09s/hVtpQVa2225GRFMhc5qMl3etDknKjhB7kKUdpVjjPp2HNdl7gXFya+7DDvRWpneGnAhbiEpcyAdycYUpB7jIBqy0oIB21vyYVnRKLynY7wW4Q+pKgNqhyQRk8getYEi33Wc15eS1JS20ytJUZO0PLDiSkjarPyg8nGM1bqUFUkx7yW1R4zMptKVOKQ6ZIPwlhQSnJVuJCyO/qM5qSnw5KbZCZjqkupbcSZCUvkOuJwcgLJHO4pPccAipmlBSW7Vem0tpT5lCMuFCUSAC2svLUFOHcNw2lHorseOalb3DnLnPPRGnFoWy02S25sVwtRVj4k+hHqPx7VYaUFfTHuStPxWX0vmQ24A+lt4BxxAJ+Ve714PJBxmo9i23ZqK+lKZTaVFxaUpeSpzl4KSCdwyduQfiHrznmrhSgq8WLc+rFVJYlEhKAnZLwlrCzu6gKjuJTj/AD+2fWsNMW7OPqZUZfmUR2dikydrbTm5eVKGcKGAMjnOMYHerpSgqwttz3FsF1phToUrpu7TgyFqVyDkZQR//tdCrdexIbSXJSmUFSWimR8mHlkKcJV8QLfT7hR4ORzVwpQV69RLm9eGnIyn/LBCAjpO7EoWFEqKxuGQRt9FdjwO9c7LBnxZjDkhx9aHGXev1HisBe9PTwCePhKu341PUoKpCsEqPbNoffS+6+CtKC2gobL25WFpSFcp91E/jXXLiXvzswx0yUtrbeaQRIyMlP7NQyvjt32ggn15NW+onU16i6fsc26T17I0VouLPvjsB9ScAfegreppremo7su7TXm7QhZICpxQ4VFCMEKKgSAQv4c+vAOK1w745adiXkOmbdJaELSMspPTKOngjCikE7s87R3zn0rQPiBrS6a1vjs+6PK6QUehGCvgYR7Ae/ufWq0hDjgUUNqUEjJwM4oj3jo7xJ0vq5aWrPc21SinJjOgtufgk9/wzVyBzX5vxZDsaQ2/GdWy+2oKQ4hRSpJHYgjsa9hfo/eIzusrI7BuzgVeYAAWvsXmz2Xj39D+B9aK2/SgORSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgHtWmP0pZb0fw1LbJIRImtNOY/wAuFK/qkVuc9qoXjHppeqtC3K3RwDK2h5jPqtByB+PI/Gg8MsoDr7TalBCVKCSo9hk962J4o40Vrk2nTLf6vbtiWi3Jb/vn1KbCitS+5B3Ebfl+la7facZdW08hTbqFFKkqGCkjuCKm0amlPqh/rtpF2bhpCWG5PokdkqWnCykf5d2KIsnjLb4jFx0/dIsdqK9eLSxPksNJCUJdUCFFKR2BxnHvmpP9GmW9G8VIbTROyRHebcA/yhO4f8pFa+1JfZ+pLu7crq4FyFgJASkJShIGEpSkcAAelbu/RW0q+u5zNSyGymOhsxoxUPnUSCpQ+gAx+J9qK9QtHKRXOuDQwkVzoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFdLze4V3UIoNJeKngzA1VIduVrcTb7srlatuW3j/qA7H6j8Qa0pL8D9bMSC21CjSEZx1G5KAn/4iD/xXtRbYV3FdRjJ9hQeX9E/o+zHZbb+q5TbcdJBMaKoqUv6KVjAH2z+Fek7JaotqgMQ4LCGIrCQhttAwEgVIIZSn0rtAxQfQMClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUH/2Q==",
+              "timestamp": 64859281840,
+              "timing": 1736
+            },
+            {
+              "timing": 2169,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAUGBAcCAwgBCf/EAEkQAAEDAwMCBAQCBwcBBQcFAAECAwQABREGEiETMQcUQVEiMmFxgZEIFSNCU5KxFjM1UmJyoRckN0OCgxhzorKzwdEnNHR18f/EABkBAQEBAQEBAAAAAAAAAAAAAAABBAMCBf/EACcRAQACAQEHBQEBAQAAAAAAAAABEQIDBCEycXKywRIUMTNSQiIj/9oADAMBAAIRAxEAPwD1TSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSvilBKSpRASBkk9hVea1xpV64eRa1FaVy87Q0mUgkn279/pQWKlCQBknj3qunXGlkz/ACR1FaRLzt6Xm0bs+3fv9KCxUoCCAQcg+tRV51Da7KtCbrK8oheMPOtqDQ+7mNo/E0ErSqF41yv/ANJL/Jhv8GOlSHWl9wVJ5BFSx1fp6zRIEa73y3Q5SmW/2b8hKVcpHJBPFBZ6V1xpDMphD8Z1t5lwbkONqCkqHuCO9Qt31jpuzyxFut9tkSTnHSekoSofcE8fjQT1K6okliZHRIiPNvsODKHG1BSVD3BHeu2gUpSgUpSgUpSgUpSgUpSgUpXxatqSaAVBPcgV8DiD2UKi7lcYlvYMi4ymYzOQnqPLCE5PYZNYEPUtjmyUR4d4t78hw4Q23IQpSvsAaCy0rojrJ+E/hXfQKUpQKUpQa38cH3l2ex2hLy48S8XViDLcQdp6KiSpOfTOMVY5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvr3rM1dp2DqqxP2u5pV0XMKStBwtpY5StJ9CDVPd0XrOTCNsla8Wq2qT01rRb0JkqR2I6m7vj1xmgohvtyf8D4cFU10ocvAsip6VYUuN1Snfn6pG3NbcRoHSqbH+qRYrf5LZswWU7u2M7u+765zXN7RNkd0SNKmMRaUtBpKQfiSQchYP8Am3c596rSdE60RE/Vydfu/q0J6YUbegydnbHVz3x64zQQ3iDKk6E8FDH07eHpZbdTDROUsKWy2pZBG4eqR8IPcVsXT+nLZb9OItzbQkR3mQl9bx6ipGRypZPzE5rrt2jbJC0enTIiJetPTLa23viLmTkqUf8AMTzn3rFVp66Wyyiz6YnpjRtnTRImrVIcjp7YQnjOPTco4oNKx33Y/hF4oWBLq3rdZpy48Najna31B8Gfpj/mtz6J0pZoek4jZixpypcdDkmS8gOKlKUkEqUT3BzwPQVHjwzgR/DWdpKBJcb86Cp+Y4netxwqBK1DjOcYo3o7UdpieQ0vqluFbQna2zKgiQqOPUNq3Dj2Cs4oKpp+W9pD/qjarISqBZ2vOQWvmDC1tKWpA+gIzirT4WaSsbOhrbJXDizpVxjpky5T7aXFvrcG5WSRyMntU1ovR0PTNnlRC65PkznFPTpUgArkrV3KvpjgCq7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNB0eHzLdg8T9WabtY2WZDLE5tgHKY7i8hSU+wPfFbQqs6I0ixpdmY4uW/cLpOc60yc/87yvQYHASBwAO1WagUpSgUpSgUpSgUpSgUpSgVwfGWjXOh5oK7qMSTbT5ITi9uH/AOy6PUx/6vw4/wCagrKm7/rRjzQ1F0cnd5oQen2PzdP4/wAquy2SD8PIriGlk/LQfWB+0FZVcGmwgfWudApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAoeO9KpWrrk6uYqI2opabA3AH5iRmjlrasaWPqlcDIZH/io/mp5ln+Kj+atGaq1XC009CbnMyXDL37CylJ27SkHOVA/vDtk1zuOpo0HUUKzGNKdlSmw6lTYRsSkq25O5QPHfABOKlskbZlO/wBLeHmWf4qP5qeZZ/io/mrQly1vbIGoTZ3Gpi5CVtoccbbBbbUsZSCc57c8A133fVkG16ih2aQzKVJlJQpC20pKBvUUjPxZ7pPYGlr7zP8ADenmWf4qP5qeZZ/io/mrR7Wp4TmojZktSPNBxbe4pTsyltCzznPZY9O+aW3UjU/UM20Jt9xZeiDct55pIaIyQkghROFYJHHIBpae8y/LeHmWf4qP5qeZZ/io/mrRlo1TFukm7Mx40pItq3G3nFhG1SkEghICifTjIFYml9d2nUlxbhW5MkPKjGSeolICQFbSk4Ufi9fbHrS193nv/wAfDf3mWf4qP5qeZZ/io/mrRVr1ZDuTd3cZjS0NWwuJdUsI+MozkJAUT+6e4FfdP6tgX+HMkW1mU4IraVqRsG5RUkq2pGfm4xjjmlk7ZnH8t6eZZ/io/mrsSpKxlJBHuK0fpfUDWoYrz7EKdFQ04Wj5ptKCpQODjBPYgg1aLTcXrfKQttR6efjRngilkbbWVZY02TSgOQCPWlVvKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKpWrra6iYqY2kqacA3EfukDFXWh570ctbSjVx9MtKXiw228ux3LlG6zkfd0lb1JKMkEkEEc/COfpXC4adtdwukS5TIvUmxNvRd6iht2q3DgHB555rdJjMHuy3/KKeVY/gt/yipTJGxZR8ZNJTdL2Wdd27pKt7Tk5BSoOknun5SRnBI+orum2C2zrqxcpMbfOYCUtvBaklISSQOD2yo/fPNbn8qx/Bb/lFPKsfwW/5RSj2WX7abRZLci8LuqYqRPWCC7k+oAJxnAOABnGcCshqDHZnyJrbeJMhKEOryfiCM7RjtxuP51tzyrH8Fv+UU8qx/Bb/lFKT2OU/wBNKwNN2mBNnS4kTpyJ27zCuoo79xyeCcDJ9sVxtel7Na5jUq3wUMSGmeglaVK+T2PPPYcnnit2eVY/gt/yinlWP4Lf8opS+yz/AG0nB0zaIK7guLE6argFCT+0WepuznueO57Yrvs9jt1mL5tkVMfrbeptUTu2jaO59q3L5Vj+C3/KKeVY/gt/yilE7FlPzm1Hb4Me3sKZht9NtTi3SMk5UpRUo8+5JqYtFueuEpCG0npg/Gv0ArYnlWP4Lf8AKK7EpSgYSAB7ClGOw77yyt9AwAB6UpSq+gUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVp3xH8cY2idWSbG7Y3pi2EIWXkyQgHckK7bT71uKvFn6TP/e9dP/csf/STQbNZ/SctxcSH9NS0N+qkSUqI/ApH9a3TovVVr1jYWrtZXVLjLJSpKxtW2od0qHoa8YviVraxadtGmdOOuTbSwtEp9hAKnytQKSrA7DHc+5q8zpWp/Bvwui2zemFeb5MdfJSQtUdpCEJIB7BRJHIzj79iPWVU3xXOrRpNf9g+n+tuondnbu6eDnZu+HdnHf0z6145Fx1kuALyL3PLalYCv1n+1Uc4yG9+8jPrjFbFm601bcvBK6N379YsSYkuN5eetC2VPIUVZTu43EY7/Xmg234Hq8R1Knf9QAfJbB5frhAe355+T93Gfm5zjFbYrwtobxJveljd5LU6RJmPxPLx/MuqcS2ouIJXtJxkJBx965RP+oupLVcNSxpl5lwYilGRJTLKQggblYTuBwAQeBwKD2Tro35OlLgdIpZVe9g8uHcYzkZ78ZxnGeM1qXwmPi9/bBr+1oe/UmFeY810v8p27NvOc47cVr/Svidfbz4a6vst2nPPyosFMmLM3EPBIdQlSSocn5hg9+9Qnghqy4QddCbcrhOlRIkGXJW04+pQUEMqV2Jx6UHtOleJ06o8RPEzVTn6llzlyUAvtxIkjotsIChjuQOCQMnk1B651Rqx7VU83qZNg3JBQ3IYafUhKVpQlJIAOBnGeOOaD3pSvAuqtQXlu6MhF3uCQYMNWBJWOTGaJPf1JJqZ8RZ2r4belpV4u69si1MOwhFfWC21tABV2+M4yTzknvQt7hpXj26eMupUeGdkt0a4OouTinkSJ2f2ym0kBACvQ8nKu/wjnk1S/P6zjRI91TergA8odMoue54k9iWwveB9SKK97UrxprnWer7toTT/AOuBdIc+PJfb8wELYMlspbKVHGMkHIz9veqLarhqm7XFmBbZ94kzHVbUMtyHCon7Zoj9Ba8leKnizrayeIV9ttrvamIUaQUNN+WZVtGBxkoJP4mvQvhLZLtp7QVut2oXy/c0b1uqLpcI3LKgCo98AgfhXkHxu/72NTf/AMo//KKD2to2Y/cNIWObMc6kmTBYedXgDctTaSTgcDkntUxXizXXiVqGSzaNPWafIg2+HAiMbY6y2p5zoo3FShzjJxjOOKiIl417pu8R/J3W4Oyz8aW48wTEq+ikoUofgeaD3VTIPY15C8btc6wnt2MSkXCywZEFDimUhbIceyQ5nseCOAfTB9apWlLfqu6ITJ0/ef8AtRUdsdN1S1IUR7IKwTQt7ypVf8Pv1l/Ymyi+9b9aCMgSev8APvxzu+tWCilKUoFKUoFKUoFeRf0h9K6hunincpVssV1mRVtMhL0eG44gkNpBwoAjvXrqlB4t1L4Zakg2DTd5s1nufWfibJbLDK+sy8lShkoA3AFO309D71KWrwx1TqjwzfW/Ent3m33BbjMa4JW2t5pTTYUE78eqRj04NevqUHh2LZPEyHbDY4lov7EMubyhqIpPOc/3gGcZ5xnFXDVGmNSad8ELi9rG4ynJc2ZHDEN+SXeilJUfUkBRzyB6Afh6yrRf6QHhtqTXWorU7YkRzFYjFtxbz4QkK3E9uSePpRGgvDHRT+un71b4K0JnsQfMxws4StQcQCkn0yFHn3xUlGsfifYbZO0/Dtd/Zt8skSGGI6ltryMH4gCOQADg8ivRfgh4U/8AT5qXMuEpuVd5aA2otA9NpAOdqSeTk4JOB2H4yHiF4u2DQl8atV4jXJ2Q4wmQFRmkKTtKlJHJWDnKT6UGltL+E1+svhrqy53KC9+tJsJMaLAaT1HtvVQpRITnk7Rx34Oah/BDQ17OvG2b7YrtDt0iHJjuvPxHG0gLZUn5lDGea9U6K1NC1hpuLe7Y2+3EklYQl9ISsbVlJyASO6T61heIWuLRoS0Nz70Xil1fTaaZRuW4rGcDOAOPUmg8iPaD1jp+8dbS4lzWVEpj3KzulSXEE9ypByn6g4xVR1RCft+oJ0SbLTMltObXn0r3hTmPi+L1wcjPripjS+l7pqy43FnS76VlhBkKS+6I6unnBUcnbxkZ+L1rYOhPAibcrtH/ALRXa2R4u7Ko8aUl590DkgbeB98n7UFI1BpDUs+ZFkwdP3eTGXAh7HWYTi0KxGaBwoJweQavXjLpbUE+06BRBsV1krjWCOy8lmI4stLCRlKsDhQ9jzXrKKw1FjNR46A2y0gIQgdkpAwBXZQp44j+Eeorx4ZRJ0W2SmbtClvpchSWy0460QghSQoDODu++eO1Q0ez+J/6uYsse1agZiMryhCIqmgDn1cAGRz6nFe4KUV5duUfxS0ToqLbon63uFxupW7IdZS7LXCQkAJbSoZCVHKiSPpjtmtX22xeIlrlvSrZatWQ5L3948xHkNrXznkgZNe6JVxhRHAiXMjMLI3BLjqUkj3wTXdHkMyWg7GdbebPAW2oKB/EUFV8JDdD4c2M3/zn6z6Suv53d1s71fNu5zjHevLfjDpDUs/xN1DKg6evEmM7JKkOswnFoWMDkEJwa9pUoPHev/CLUrDVpvVlt0mW1JgxlPMNIPWjPBlAUCjv3GeOxyDWDGsfixqS5xk+VvsdxADaXHEKhttj3PCR+Pc17SpQeX9eaf8AE7Ts1iPaVXG+W0RWQ6txCZiHHQn4yW17iOc447YrWK9Da41DeFOjSs5iQ6RnbA8m0D2zjalIr3dSgg9DW6fadH2e33iR5i4R4yG3nN27KgPf1x2z64qcpSgUpSgUpSgUpSgVrfxa8WLb4eqjRXIrk+5yEdRMdCwgIRnG5SsHGSDjj0NbIrxx+lNFks+KTj76VdCREaUwo9ikDaQP/MD+dBsJ79JSH/Z5qUxZN106/TdhrkEAIwSFpXtOe2CMDFco36RD72l7hd/7NtgxZceN0vOn4uqh5W7OzjHS7Y/e+laL1lqOx3uz2qPZtLR7O/ETtfktOlRfOPXgeoJycmum2/8Adjf/AP8AtYH/ANKXRG7W/wBJjqWuc4qwNszUbBGa8yVpcJJ3FR2jAAH4kipmT+kFFgaLtVylWsPXmf1FCG07tQhCVlO5SiCRkp4GD2NUX9FOy2y83jUCLtb4k1DbDRQJDSXAklSs4yOKhv0m7M3ZvEFlEOG3Et7kJssIZbCEDBVuAA4znk/egt0T9JyYJA85pqOpgns1KIUB+KcH/iqH+kBqeBq/VFnvNqK/Lv2psFCxhTag66Ck/UGsS9a607PstphNaEtbT0NIS891VpL2E4PKNp5PPJNVnVrseQ9b5MKzN2eM/FC0MoeW4F4cWkryskjJSRjtx9aDZGnfGC7aM8PtN2ywwmlhvrmS/KaUUKUXlKCEEEdkkE/7hWw9TeLNlv3hJFvly03FuijPTCk2+Q5hLLhbWrelW0nsnjgHk+1ax1akf+znoVWBnz8rn/1HP/xVPgKP/S69pydou8Egf+jK/wDxQbNteurVL8ONao07oiLa1+VQw6uO8XFFDu5JUTszhOM47fatY+F99k6b11a7tCt67lIjlzbFQSCvc2pJ7AngKJ7elXfwNaW9ozxObaSVrVZyAkdz8LlUzwo1JE0jr+1Xu5NvORIpd3pZAKzuaWgYBIHdQ9aD0n4jePVp0reX7Tbre5dZkdWx9QdDbaFDunOCSR68cVDaY/STts64sx77Znbcw4oJ8w2/1koJ9VDaDj6jP2rzvcJCGtbvy7mw4phcwyFtut7lKQtW4HbkA5BBxnB96mrjd9HSdQKeRYrjLjqCUpQ261CCj9Gm0KA/mNB6O8VvG636KugtVvg/rS4BCXHf2uxtoKGUgnBJJBBx7Ec1R7V+k275lIuunG/Lk8qjSDuSPsoYP5itR+J8R60+IMhM2C40kJjuJjPrKz0+kjCCr97AG0n6GpPVWu9NXmdEejaBtUVplvYttLziN5/9PYPzBNBk/pEala1RrtiZEZUmCiAwiM6c/t0KBc34xxguFOOeUn7VsrwC8QYunfDC4/r2I7GttqWFNSRlRlLdWs7EDAGQRjue/OK1V4vskRtGyWrV+qor9mBajBanEo/bvKwFK5PC0q57bq4zNTx7h4L2/TEViWZlumqmyV7B0umoqSOc57uJ7ig2nI/SdQJKhG0wpUfPCnJm1RH2CCP+avunPG7Tl30jdL063IivWxCVyIasKWdx2p2HsoEkDPGPXFeWNN3WwRdN3GLd4br010/sVNR2yojH8VZJbx/pSatWjpukk6Y1K87pe6KiNxWmpT/6xCjhb7YSEjYEhQI3DP8AlI9aC6S/0nJpkHyem46WM8B2SoqI/BIArZfg94tt+Ik6ZCVaVwJMZkPEh4OIUMgewOea8ryV6ftCm7lpm6yZMpKsCJcrY2oBJ75JUpBx9vyra3gx4jW2AxqW73DT0OPMgQA6uTbmuiH0lxKQhSAdoUVKTyAOM+1B6kpWlfC3xyb1rqtqxyrMYLshK1MOIe6gJSkqIUMDHAPP0rdVFKUpQKUpQKUpQKUpQKgtW6SserYSIuoLe1MbQdyCrKVoP+lQwRU7Sg1+94QaLdsDNmNqKYTb5kAIeWlal4IypWcng4wTxXQ14LaJatMm2otz4iSHm33E+acyVthYSc5z2cX+dbHpQVLRHh5p3RMiU9p6I5HckpSh0reW5kAkj5icd6lNUaXsuqoKYl/t7M1lJ3I3jCkH3Socj8DUzSg1pF8DtAR3w6LKXCDna5JcUn8t1SOqPCjSGppkeTdLaSuPHTFaSy8ppCG0kkJCUkD941eqUFGm+FelJul7fp6RBeVa4Di3WGxIWClSiSSVZyeVHvWC34LaJbtMi2otz4iPvNyHE+acyVtpWlJznPZxf51selBUtE+HmnNFOy3NPw3GFS0pQ7veW5uCc4+Yn3NQ1z8FtCXGe5LesgbdcVvUll5baCf9oOB+FbGpQUzUXhjpHULMRu6WdpZitJYacQtSFhCRgJKgQSAB65ro014TaM05PbnW2zN+bbOW3H3FOlB9wFEgH61eqUFc1dojTur0NjUFrZlrbGEO8ocSPYKSQcfTtVctfgroO3SkSGrIl1xCtyQ+8txOf9pOD+NbGpQQeqdJ2PVVuRBvtvZlR0HLYOUqbP8ApUMEfhUJpfws0hpmRJetdqAXJaUw6HnVOpU2cZSQokYOBV3pQazf8DdAPSC6bKpBJzsRJdSn8t1WmLofTUXTjthYs0RNpd5cjlGQs99yj3J4HOc8VY6UGsXvArQDrm/9TuI/0olOgf8AzVabNoTTNmssq02+zxWoMtOyQggqLw/1KPJ/Pj0qy0oKbpDwz0ppG5LuFjtgZmKSUh1bqnCgHuE7icfhVypSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVC3TUUW2zXY77EpSGWkPPPoQChpC1KSCrnPdJ7A4qaqq3zTj8+/OXBCgUBEZIZU6oNuhC3CtK0DgjCwRnPIFWElYfPw/PeS83H85t3dDqDqY99uc4rpN2iMxm3p7zMIOLLaQ+8gZIJGAQcEnHbOarKdPSo9yW64y07HTOXO8x11lYBUVYDYTyoZ298EDt6VxtVonoSzOTCYfLrLzZjTFFsthTy1g/Ke4UAoYzwKUXK2LnNtyXW3sNNoShXWW4kJJUSAO+R29QAc8Z5rj+trd5ETfPxPJk46/WT085xjdnHeqr/ZGWI6I63GX20s25olZPx9B5S18c8EHisqRYJbd7M+OzGeZTMU+mMtW0FKmENlQ4ICgUn8FHkUqC5TcO9QZKVHrtt/tlMoDi0jqFKtuU88gkj8xWTHnw5Mh5iPLjuvsnDjbbgUpH+4A5H41VbFpZ+NdI8qY1ESlrzikpaJIaU86hSduR6BKhniuWl9OS7bLt/mWGAmCypoPpkKWp0nAztwAAcbjknnH3pUFynJ97Ziy1Rmo0uW+2kLcTGa3dMHtkkgZ+gyfpXam9W0w48pc1hpmQcNKdWG9x/y4Vg59Md6wVxbnb7rcJFuYjSmZqkuqS68WlNuBCUeiVZSQlP1Bz3zUWzp6fBd8wliFcXXmHEOtPrKENrW6txRT8KspJXg+uEppQtL1whsymor0uO3Jd5baU4Atf2GcmsaNe4L8tyKX2mpKHVMpacWkLcKQCSkZyRzVfe07O6E6KliCpM3pEyAopMcpQhB2JIJONm5Pxdz+JP6emrcubQjQtk2ciUJW89RtKdnONvKhs45xz9OVQb1pbnw3ZjkRuXHXKbGVspcBWke5T3Fdsh9mMwt6S62yygZUtxQSlI9yT2qqwLBNYct7KmoqW4UpyT5pCz1Xt2/gjbwTv8AiOT2+vEhdYky62y2PmO03LYeblOQ3HMoUQkgoKgPQqyDjukUoSTdyiOuMhl5DqHm1OodQoKQUpIBO4cfvCvse5wJMVcmPNjOxkEhTqHUqQnHfJBxUJLskmfpy5RHGIcKRKWpSURySnGUnClYGd234iB2Pr3OCjTcl1ua5IhMtrdLG1tMxZUemSdxVtxkE8Dbzjk88C5TsvUtniSoUd+4xULmAqZJeSAoD1zn17D3NZz8xLElLbqdrXSU6p5S0hKAkjvk59e+McckcVWoljucc2t9SYj70Z94qS4oIPTX2O5CMFQ4/dGff1Pfq2xSrut8xi0Au2SoY3qI+Nwt7fTt8JzTcb0hP1JZ4MQyX7jE6IfTHKg8kgLUoDB54xnJ9gCa7nb3bm3YTYlsLXMP7AJdSd4xncOeR9qhrpp59x+W5BbipSW4ZabUdqVLZeUsg4BwCCBnB+1YV003PlzZzhjRnEz0tbsylpTHKUhJSAEgqAxuBBSck9u9KguVsducBmV5V6bGbk43dJTqQvHvjOcUXc4CEPKXNjJSyMukupAb5I+LnjkEc+1a91AlKJFwtcdy3SH5VwaeCFhXmgrcg42Y5SAOF5wE/app3Sz6ba2Gm2FSUXN6ctAcKA8lS3NoKsHkJWk9jyn8aUWtJuMERm5BmRhHc5Q71U7VfY5wa71PNJd6SnEBzbv2FQzt98e31qq23TbiXrc7KjRkhmU9JU0HFOhJUjaCCRyfU4AGSfvUjdoM1V3RNgoZdzEcjKS4so2kqSQrscjg5FBIqucBK2UKnRQt7HSSXU5cyMjbzzke1chPhqnGEJcczANxYDg6gHvtznFVJvSckWObHWmMZrsGNHbcz8q2kYznGQN3IrnD03LZuyC4yytlM5yZ5kyFbsKUpQAQB3+Lb82MD64pUFyudKUqKUpSgUpSgUpVD1VfrhHu81uOlLbVuQ28gLUhKXioH5iXEnb+6MJVyM88CrEWkzS+UqjXvUdxjM3mU1KhxxAeQwiI63lS9yUHcTkHJ3HGBj4fyzl354tQW1rZLsi5SIi0Y56aOtjj04Qjn6/WlFrXSte2u+TXI7DEeZbrYwzZo01KVtZG5QXkfMMIG0fXmh1bdnnVPIYRGQ15fMd3pjf1EIUQSpwKByspGEnlPr2Ci2wqVB6gnyWbha4UV9qKJanN0hxG4DaAQhIJA3HP5JNVqDcJcLTM28MvtyHRKejgI/usqlFJdwVAYAOeTjHrjmlFtg0qjf2juke2z3lBuS9DfaShoBHUkbhy1htSgF85Bz7ZAGTXem9T5Mm2RkXOAwJMFctb/S3AqCh8KQSOACc55+H09FFrlStcP6wuzjKnWksMhiG3JJIRsfKirnK3EkIO3jaCefwOZqKfd5Vp1StqWiHHgs7Ww23lzcWULOVZ4xuPYf0pRa90qmXK+zYSm3GZ8eTb22kuOSWm0Ok5WQdyQsEJwAAUg859sVK6ilLi3CIpluMp5MaS42t87QlSUpIyr0SfX6UotPUqkN367qjuMhTZnJdaCkLabQpKFpUfg/alCz8PA3A4BPPGe2NqZ8xJLzrzW1u3uPpWprp5dQtaVcbj22pzgkc8HBFKLXKlUyLqC4quMPzS2URHlMtgttJWFKW2k4UQvchW4nHwkYx+Gde7lLTeXoTE2LBaYh+aKn0buqSpQx3GEp2jOOfiHb1UWstK1dbtTXONZIaIyW22oduiOAOdPDxU0knJUtKgM/CNqTyD37VZ0XqenUaWJKmkQ3JBYaDbaXAr4N2CoL3JVkHunGB+NKLWrAznHPvSqneLvNRqGfBYuMKCzGgtygp9vcVKKnAc8j4RtGfXmsSyXiQuamStsRxPmMB5tz/wwqGF7fodwApRa70qiSNTXNbLr8ZyP5Zp2UFuIQlxQS25tSdpWnKcA5Iye1Z+rZKydMvMSGmFOzhh11J2gKYd9MjnngH1xSi1spVBe1LdRKFvbW04UyHmjOaQ2A4EIbUAAtaU7v2hB5P92rj2xrnPfuNsVKkdMPLtD24tEFKsOpG4YJHOM8E9+570otselUZ3UtzF7eQlDaI7U9EMML6Y3pJSN2SvfuOdwwnGMfcSFmvM96++WnraDbvW6KWm0qQoIVwQsLJzgjIUkc+1KLWmlKVFKUpQKx5EKLJeaekRmHXmjlta2wpSD9Ce1ZFYMi72+PNRDfmMIlLIAbUoZye32z6e9B032yxbtEfbcbaQ+430xI6YK0jPYHvWZ5CJ5lUjyrHmFEEu9MbjgYHPfsSKxmr5bHZbkZucwX2925O7tt+bnscevt61iv6kg+T8xBdRLw+wypKVYI6riUBXbtySPfFXem53GwW5U9cp2M06VNtNJbW2kobDZWUlIxwfjP5Cs12DEektyXYzC5DXyOqbBUj7HuKx0Xq2ruJgImMmWCU9MK53AZKfbIHOO9ZapDKZKY6nEh9SC4EepSCAT+ZH51FfJUWPMa6Uthp9rIOx1AUMjtwa+pjspZU0llsNKzuQEjac98j61GvakszIbLtxjp3tpeTlX7iuyj7J+p4rJ/XFu8+IPnWPNk4DW8ZzjOPvjnHfFB2x7fDjNttx4kdpttRWhKGwkJUeCQB2PJ/OsWRYrfImJfkRmnUhso6S20qb5VuKsEd8+v1Ndky49CWmIwwuRJU0p7YhQGEhQHJJ4znj7GolvVI8mzLkwXIsZySY/UedRwQVJJ4J9Ufjmqm5OvwIkhbK5EVh1bJy0pbYUUH/AE57fhXalptJcKUJBcOV4HzHGOffgAVHOahtLcRqUqcyGXVKSg5yVFPzDHfjBz7etdci9jzkePAirnF5gyUracQE7MgA5J5zn0qCQcgRHFsrcisKWz/dqU2CUf7fb8K7VtNrUlS0JUpIIBIyQD3rAVe4DctuJIktMzFbQWVKBKVK7JJHAJ9B6+ldMrUEJuQliM63IfEhEd1CF8tFSinJ/EHigzU2yAmMuMmFFEdZypoNJ2qPuRjBrk5b4bqGUOxI60s/3YU2CEenHHH4V2sSGZAWWHUOBCihRQc4UO4+4qFe1I2zcno7kN8MMym4apG5O0OLSlSeM5x8aRnH/FBLCDETIRITFYD6E7EuBsbkj2B7gV9kw40lTapMdl5TR3ILiAooPuM9qw49/tUlClsTmVpSUJJB4+NW1J+xPAPY1wuN7biymYsZlcyU470S22pI2HplfxEkD5R/yKDMXboS1sLXDjqXHGGVFpJLf+3jj8K5iHFEvzQjs+Zxt62wb8e27vUPc9SItUSTJuUYsoYZS6ptLgW7kqUANo4x8PBz7+1TUWQ1KjpeYUVNq7EpI/4PNFYT1kgyLm9OlMIkOuNto2uoStKNhWQUgjg/GeftWW/DjPtutvx2XG3SC4laAQvGMZB79h+VQ6tSpEdUxNvlqtaVEGYNm3aDgubd27Z9cducY5rPVercm4CCqYyJRIT0887iMhPtnHOO9Xem52uW2C4hCHIUZSEK3pSppJCVe444Nd78dmQkJkMtupGcBaQoDIIPf6Ej8ajhqG0qecZROZW63v3IScnKM7hx3IwcjvXRC1TapVojXBUjosvhO1LqSFZKd20DHJx7ZpUm5JO26C7ETFdhxlxU9mVNJKB/5cYrsVFjqTtUw0U7OngoHy/5ftx2rHZukd+VFaYUHUSWVPtPIIKFBJSDz/5hWdUVjqhRFTEy1RmDKSNqXi2N4HsFd6+tQ4rMhx9mOy2+587iUAKV9z3Nd9KBSlKBSlKBVduNklPXsTIjjccLcaW44hxxKlBBGUqRnYvIBGTggH1wKsVKCqx7FdY8JNuZlQm4jCHQw8Wd7uVJUEkg8DG7kj5semTWMjS9wVKdedfZ/beUKkl1xwpLD3U4Ku4UCfbBx96udKtpSoQtLSY91QS80uC3LcmJJedKyVKUrbs3bBgqPxew7c5qTmWqUi4xpludQpaGXGFiUtSuFlB3A8kkFHb1z3FTlKWUoVusV3hyJUOKIik/qyLCW9IbVtJSHAVJwPixn5TjuORUpE03JhXKMuI+lqM0pCnFJdXueCUBOFNn4MnA+Pvx2q00pZSJ6Djeq/MbFFl6GG9wHCVIWTg/cL/+E1jNWNxMGCwtbajHnLlng4IK1qAH1G4flU/SoUp07S0s3FyfEeaLxdeIbU86ynY4G/3myDkFvtyDmsqHpSMh6AZzMSW1GiFja41uG8qCioBWcDg+uas9KtlKxL0/LcXOjMvRk26c+h9wlJ6reAgFKccH5Bg+n1r7L0yuTbXIvX6JduJmLcZJSopK92Ae4VjAzVmpSykLYYE60sxbfmO7AYStCXOQ5tBT0wR2zjcCfXAPqa4M6faRcLxOLcbzst3exILQUtr9ihscn6pJx9anaVLKUo2CVHjynLipUht6F5VxEdbjrm4H4Voz25JOBgJwO/eu+3aadk2+0KviY8mUl9Uyal1sKStxTak4A5Hw5SB9E1bqVbKVu6aaEpNyairZisSYKIjSUI4bKVLVnaMDHxjj71Lwf1iHlIneWU0GkYcZBSSvKtw2knAxtxz6ms2lQpR5+nb83bm7Zb5cVdrQhUcoVuS4qOrAKPUbwOAvj6jmpBenZRU9EQ+wLa7NE5Sik9ZKgsObB6fMnv6DjHrVopVspXYen3WG4CS43mPcJExZAPxJc62B9x1R+RrHh2G5wWLUpqTDek21pcZsKbUhC2lBA55JC/gScjjuMetWqlLKVePbJcKRCYYKXH225UhTxQUtB1xQIT/typXGc4TVma39JHV29TA3be2fXFcqVFKUpQKUpQKUpQKUrpaktOvustry41jeMHjPavM544zETPz8LETLupSlekKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6UpW9yAQRkEEe4ri04h1tLjS0rQoZSpJyCPcGqxbrdcIyoqHWn1bQjatuVsQ0AfiCk5+Inn0Oc4ynGayJJuDekpTTiXW5rUTAdSvKlL28kEeoNBYaVUn4F0KViO3LQwt1OG1yypacIUCrdvHwk7eMntnHOK7rZGuyLpDckokFHTSHi48ChJDeDgJXydwzgpPcnd6UFlW4hspC1pTuO1OTjJ9hXKqtOttyeuKVth4rTKLofU/+yS3sISAjPcEj09zn0rK05DuEZEjzJfSVNpSkSHur+0GcqHJ4PHqM+w9QnXHENNqccUlCEjKlKOAB9a5VCzv1gzp6b1lqdmKQUtFhJUckYGMD39fx4HAjpUS9OIeYaD6cKklLwfA3Bastgc5+EHHIGMccUFpLiEuJbK0hagSlJPJA74H4j865VWHbbdUPyW4zr3ldy+lukEqKSlnjcSSCSHQD6Z+1fYduuC5iXHFTGIgDqm2VytykEhsJ3EE55CyBkgZ/Cgs1KgLTDnqtU2PJMhhxeUtOOOlSx8PzcLVjn2I+wrAlwL3IYYdcMgPOhxTjTEkJ6KzjZzkApAHOM8knBzQW6uKXEKcWhK0laMbkg8jPbNVh213UNuuNPv+ZcceSSZB2hsg7MDOAc7cEDIzXCJCuMW4OymYkvoLcT+xXJStzaG1J5JVjAUQcZPv9KC2Uqr2mHdmLjAVKD60BlAfUt/KEkNYOAFcncPVJ7k7vSuyRCua5EwM9dL6+qW5PmcNAFJCE9PnkHHoO2cntQWSlVZq1zpD6Avz0aESolpUwlwHZgEqCicE8gZ9M+uK4x7TdAxFbcelHe3HMo+ZOd4J6mDnjI/y8e1Ba6VUxabs1FIjyJPXUJCCXJJV8G/9ljJODtAGe/PNZcSFcU2Sc0FSW3nFZaS8+FOJTgZG4E7ScKx8RxnPHYBPpcQpa0JWkqRjcAeU5965VTV2u5dSQ40zNbjOPpV0RKHWKemE/Nv7BWTjd6/TFZtsh3Vi7x1Seu60GwHXHH8oB6YHwgEZO4eqPUnPpQWWlKUClKUClKUCoi1/43dfu3/Q1L1EWv8Axu6/dv8AoawbX92h1T2ZOunw58vMJelKHscVvcilUxFmuvQ6SlP9FLqFLHmMuugJWCMn4SMlBzhJODkdqymLLcGwhxTzqn21RthXIKsISodQHsDlJIzjnigs7a0uNpW2oKQoZBHYiuVVVm1XNJY6qlLfHRIkdc4aCUgLQU/vbiFc+u7n5RRFnnsJtQaLzi2kNh4rkkpKtwK1HkHPfGMj0IxQWquJWgLSgqSFqBITnkgd/wCorDfbnefS4y6jyqU8tHuo4V9OO6fX0rBu1rfuM2DKQRHejsOFC85LbpKCPuMBQPuDQTaFJWkKQoKSfUHNfaqTdoufl46XEjq9FKUlt8hMZ3epSlem4EFPp+7jsTX123XZ1tLSw6lLTK2ypuQApw9VCgR/5Ung47kcd6C2V1pfbVIcYSrLqEpUpOOwOcf0P5VCGDOVZYTTiNy2ndzzCXiOoj4sJ3EnnlJxnHGM4rHTZZXXEkBTbyRHCB5hStoS6pSwSe/wKxz9qCz11yHm4zDjzytrTaSpSsdgO9VKJYblsCJMiSVKLYkL8zgPYcBUpIABGRn1B5x6A1kS7RNebns9NSlupeCZBkkBSVAhCNnpjIH4Z7k0FppVYfs8tuQ4G0Lfg71FEcSVIOS2gBW7OeFBfH+rPcVwFkuQRvVIcXKKylbiZBTlHlynjuB+0we3fmgs7zrbLanHVpQhPdSjgCuSVJUMpIIzjINV2NbZytPzIjqcOrcBa3uZUU/D83JAOQe3HrwSa43Czyl3hDsZb6Y4KFI6b4SlB3lTmQQc7s+nfscDmgstKqbFpubbGJAW+jrh0siQQS1tUA1n/SSDn96vps9xVcGHS4+lKels2SspaCfmScpyrPPPrnnGAaCzR5LEkEx3m3AACdigeCMg/iK7apqbDcERWUErCE9EOIZdCVLCWikjJ4OFYOD7VkMWS4oR1DIdMpCmA2tT5VtSEgLz2B/e9OeKC1UqpLtFwXCbbQh1kJW2X0plb1PhIUFEFXAySk84zjBxVhs0d2LbWGX1rW4gYJWvee/AKsDOBxQZlKUoFKUoFKUoFRFr/wAbuv3b/oal6iLX/jd1+7f9DWDa/u0OqezJ10+HPl5hL0pQ8g1vciuK1obAK1BIJAGTjJPpVMfsc1mMwnppUreyh8tuqPmiFgqcXgfDwDnv82OwrnM01OeaQhtwNNJ6pbZbewlgqI2lJKD2we2CM4HFBcq61vtIUUqWncNuQOSNxwOPqarUnT8lcRxCem667KcdcU4snKTu2dwRxkcYwO45pHsMlt9uR0oolKajJdkBX7QltYK+duSFD6+lBaaVU29PSyltDnTSPgEhaXlZlkOJUVqGODgK45+bHYVy/s4+Q98SMtoWIn7RWGldVakEe2ElI/AjtQWd95thve8sIRkJyfcnA/5Iow82+2HGVhaCSMj6HB/5FVJGm54lPOqf3Fbm5RU4CHB1krGQEA8JSQMk47Dijmm5y5MdfXwlsfBscA6SuqpZUMoJ5SpI4I+XHY0FwrpXKYQwp5TqOkklJXnIBBwR+fFQV6skqdempTbyg0hLYRhYHTIWSogFB7ggcEZxg8V9j2JUeyTYMdiKyXX1uILfAUkubhuwOCAcevagsVKr1ptc6NfHZb3SDLodCwhedxKwUHtk4AxyTjPGBXQ5ZZvTkpbZjdV3IW8Xl5eSXAfiGMZCcgZyPTtmgtFKpDdinJWzFksNyUIakFAU6pKElTiSjkJwCkEgYAxjisl2xXVUtbiJLaHFNqaMgKwo5a2hRGM5CucZx+NBa3HUNlIcUE7s4z9BmnVb+D40/tPk5+bjPHvVdTY3XG0tGNGjRiVBxhLqnEqy2pOSCAO5B7emTzWIjTctMmEtsNRkMJaCUMOAJbKVkrIBRn4h3wRnsaC3b09TZuG/Gduece9cqr1ytc1+/MTWOkENLbwrfhRQM7h2Pv6EZ9a7Zdsfdu6pIbacBUgtvKdUlTKR8yUpHfPJ7855yBQTlKqTGnZJDCHktJaSW/MBLqleZKSdy1cdz7eucHsK6Zmn5MS0veUz1y2+2rprUVKSpwFoe/wpGPp6UFzpVajWFwTGVqbbYiIf63lm3VFIwjAPYd1YOO3Ge9YULTE1tO2TILm5TfXJdGH8OBRUQEg8gEck98ZxQW991thlbryghtCSpSj2AHc1zqmzdNTHYcljaw6FNOtRgt1SRHy4spIwP8ikD6bMdjWRN07IeYWAvKnJi33U9T+8b+Lan4kqHGQcYxxQWqlYlpjuRLZGjvuKcdbbCVKUrcSfvgZ++Ky6BSlKBURa/wDG7r92/wChqXqItf8Ajd1+7f8AQ1g2v7tDqnsyddPhz5eYS9KUre5OuM+1JYbeYWFtODclXuK7Kp7OmZiJEJanGVFhDQC953N7D8QT8OcK/wBye/IPas20WWZEt9wjFxqOX29jTjSt60qwRvKtqcnkd8njkmgsdcUuJUtaBnKMA5BA5+vrVUt+l1oU0mY1FMYOBbkdKtyF4QtOSNqQSSpPcenc8V0J0/cH4yWZAQtLKmklDzg2PbWgkqGUq/e5GU/l3oLpXVKkNxYzsh44aaSVqIGcADJqsx7DcGAlomM+z1W3lqccVlRSyGynG08EpBzn17VkRLFKY03cbct5t1+QhaUvFSudyMAKzk4T2HJ4A9c0FjByK4uLS22pas7Ugk4GT+QqsxrJNjSG5MdiExseSvyrbqg2cIcSpe7Z8x3jPH7o59ax29O3Bvo7VRt4i9FbpcJIV0in4RsyBnB+bHfjNBb0qCkgjsRkZGK+1VX9NSF9Rxp5tmYta8yEklaUGOWwAcei8Kx24z3rG/sxLTCLbbcRKisKDXVHTB243EdLBJ4/dB4+agudKgrZapUW+PSlhjouJUCoK3LJJBH7oIHB4KlemMVEtaelSGJBS0zGdcMpJe3qDjoWpYSlXHCRkEHJ7DAFBc6x4MtuawHmQvpq+UqTjcPcfSoOVp7fNBaZi9Dc2UuKJ3soTjc2hOMFKsHPI+Y5BrFOllNW6NGjR4OUsdLPKAy5/FRhPKu3seByKC3V1tvtuOutoUCtogLHsSMj/iq05pt3puqaU0JDqnuq5kguoUvclKiBnGOD7ZOKx3tNSi3I6EeC0HHg42wl09NA2BPYtkHkZ4A78Ec5C4LUlCFKUcJAyT9K4sOofZbdaVubcSFJPuCMg1DX60u3DokNxn9jK29ryilKFqxhxOAeRg+x571gW3TkqLc4sh1xlXSS2OoFfEAloIKANudpIJ+bHPbNBa6VW5+nnZEqTIZcQzJdeWRISTvQ2WC3gfZeFY7cZ71iSNOSVx1hmNBYypJEdt09LIBBWctnJOR+76Dmgt9dDMth51TbSypSSpJwk4BTjIz29RUVeLU/MMRXSiSek2pCmnypKAo7cOJwDyMHHY89xWFL0/NebkJbkNoDhcPCj8W5TZweDwQhQPf5vWgtNcUOIWVhC0qKDtUAc4OM4P5iqj/ZV1cVxC0xgei8GGwolLLitm1ScJAGCknISMZ4Hc12TdMqJlmJFggvyA/nIbKvgwQv4FA85Pb19DQWylY8FL6I6USg1vQAkFsnCuBk4PbnPHPGOayKBSlKBURa/wDG7r92/wChqXqItf8Ajd1+7f8AQ1g2v7tDqnsyddPhz5eYS9KUre5FKUoFKUoFKUoFKUoFKEhIySAPc0oFKUoFKAg9iD6cUoFKUyMkZGR6UClKUClKUClMjJGeR6UoFKAgjIIIpQKUpQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6+LBKFBJwrHBr7St7kqtnto6cdp+BIamlsomSt4AcVtwSTn48nkccfTtWP0r/vlKVJkpKt2QllJCf2idu34+Rs3DgA4/1Yq5V8WtKEFS1BKQMkk4AoK5Zo0wXKPKmNTAVMlslT+UpIUrBUMjukjHBPvzzXVKVelodZYTIQ4kyf2nw4wXQWsZ7/Bn8uasyHW1q2ocQpXPAOTwcH/mudBT7hHvqHnGY78oRW3HOk4EhxxWUNlGTuTxuLo544GeKk70i4FLHSVJJDCuY2B+242k5/d7/T3qdpQVcJvO2TuMrz2HOUFHQ2/ubAf3sY/HOeMVj3MXcwii2puIJDimlPLSVBQSnaD64yVHk44OcjAq4UoKnJF3ckS9iZDiXG8oSpKUpQcJ4wchXOfY9819lN3pSpAjrlJfKnApWU9MJ3/s9g9wn/759KtHVb63S3p6m3dtzzjtnFc6CBW3cmLfPbaU+6pqU2pgqUCtbP7NShn1/wDEHNYUhF5k+bcbVLZSlMhbCAUgqUNnSB+nzcfnVqCkqUoBQJTwQD2olSVFQSoEpOCAex70FUnKukePKWUyUIAkLbLAQPizlBV9MZ/5z6UD97ditiIl0vqKlpcXjpkGOdufp1COP/tVrWlKklKwCkjBB7EV8a2FpHR29PA27e2PTH0oivWtu7t2u4jrOuSC1mN5hsJIc2n/AFK4zj6d8cViswZYkXGUhE9a247ao3WWkLW4EOggZz/n9fU+1W2lFUpDl1RIjxpa5wZW+4R0jha2w0kjkkn58+ufsOK5sLu7ktTTjswyGkR9oSUBAUfn6noeO/445q5YpxmgqMuNfPKx9smUN63lPFCQpaTn9kAAU4TjPr3xnjNc3Gb+lKnm3XFyitSAhW0NhPlyQcf+9A/P2q10oKgzBuKrmpTLlwbjuGOlbrqk7ylIdKx9slP58cVm2du7C9PLmPOlgl3KFNgIA3fs9p3f5fYe+ecVYq+BaSsoCgVAAkZ5Ge39KCnLi3tt5tEdbrDIK1NhDYVlZfWTv+IcbSnvnufXFS9h8+JkwTS+ts8oW4AkdzwE89hjkHB44BqbpQKUpQKUpQKiLX/jd1+7f9DUvURa/wDG7r92/wChrBtf3aHVPZk66fDny8wl6UpW9yVFFpuoidQyZ5k+UK9pk8eYHy+uMemPlPrzzXF6Hf1S5yw46SrqhABHTKCD0wAV4BHw5O0evJq1xpLUlK1ML3pSooJAOMjv967aCnyLZdUGUuGgtuLLuFBQyUqkBRA+IclGccj7iiWL8xCkNpTKeU4yUMnqpCmlBZxuysnOD3yTxzVwpQVWdAu5jjpvSldSU6p1KXPiCNyumE4WnCcY4Bz2zmu21MXhu6sKml91stpDqipKUJPTGcAKO7Kh/lB5POMCrLXEOIU4pAWkrSAVJB5Ge2aCuKtU9+cHHpM5LTkl0OJRJKQGcEowAePiCeRzzg8VhpgX16bEXKW98KWhuSoAJGAHQohY+I/FyEn0wRVrlSWYqAt9e1JO0cEkn2AHeu4kAZPago7FhuEaEPKpmtSY0JaGiZZVvfGNvJUfhOPlOB7is1+LeS5ILJlJdUpzesvDYtsq+ENpz8KgnjOBznOe9WulBUGrfPbekno3Lybj24ITKAfIDaAkle7OAQrjdnt3HFfWoF2SFGYmS4HFBToiPJbWtfRbSFZyn4QUryOMnHGKtjbiHElTakqAJTlJzyDgj86BxBdLYWnqABRTnkD3x+BoKX157dzix5Ml9dy6zIWlp9Owt7Rvy3n3CiTt/HHFdzMO/iZFU448kIQyMII2AbR1AobwCc7v3T6YIq4V1okMuOFtDraljOUhQJ4ODx96Ir8CLcVWO5x5aH1vONKS2p5YytRSR23KCeceuPoKjUWW5Q4nQiJcbbL5U4I+1G5OwbSAlSMYPB55IzyKu1cWnEOtpW0tK0K7KScg0VVjBvrjK2HHl8x+r1eoBueKAjp8cgZClZ7ZIx2rFuMZ+M0p+129y0t7ENuJQW0qdWp1sDG0kZA3jJ/zVcW5DLqylt1tagMkJUCe5H9QR+FdlBUJMW8IZ/7KJ5bS6tTTK30le3ajG5e/PzBePmGDyO2MvUsa7vy2jbnHUtJaO3pHGHc91fGnIxjuFDvxVkpQV6DbpcKDeG4ofTLdLi2XHX1OIKjuKSApR24J54H41Fu227JfkKhpmtsOFhK+q+FuqSkO7gCHAR8SkH5hxnHtVzS62tRSlaVKHcA1yoMOzokt2yOiaorkBOFFXf6Z5POMeprMpSgUpSgUpSgVEWv/ABu6/dv+hqXqJtiVC83MlJAJRg478GsO1x/20OqezJ10+HPl5hLV8UNySDnBGODivtK3OSmyLTc4tvYYtyJO9IeXkSlHCyrKc5WOMfce4Heu9LdxclzWAJSZmFudUycN9NRVsSlOSAoAAZwMEZyc82ulBVGrZcH3sLVPjwsOFLSpZLiTtQE7lBRJ5CiBk4/HFcV26+FovNPvImrWtOVvZbQkxyAducf3u09s/hVtpQVa2225GRFMhc5qMl3etDknKjhB7kKUdpVjjPp2HNdl7gXFya+7DDvRWpneGnAhbiEpcyAdycYUpB7jIBqy0oIB21vyYVnRKLynY7wW4Q+pKgNqhyQRk8getYEi33Wc15eS1JS20ytJUZO0PLDiSkjarPyg8nGM1bqUFUkx7yW1R4zMptKVOKQ6ZIPwlhQSnJVuJCyO/qM5qSnw5KbZCZjqkupbcSZCUvkOuJwcgLJHO4pPccAipmlBSW7Vem0tpT5lCMuFCUSAC2svLUFOHcNw2lHorseOalb3DnLnPPRGnFoWy02S25sVwtRVj4k+hHqPx7VYaUFfTHuStPxWX0vmQ24A+lt4BxxAJ+Ve714PJBxmo9i23ZqK+lKZTaVFxaUpeSpzl4KSCdwyduQfiHrznmrhSgq8WLc+rFVJYlEhKAnZLwlrCzu6gKjuJTj/AD+2fWsNMW7OPqZUZfmUR2dikydrbTm5eVKGcKGAMjnOMYHerpSgqwttz3FsF1phToUrpu7TgyFqVyDkZQR//tdCrdexIbSXJSmUFSWimR8mHlkKcJV8QLfT7hR4ORzVwpQV69RLm9eGnIyn/LBCAjpO7EoWFEqKxuGQRt9FdjwO9c7LBnxZjDkhx9aHGXev1HisBe9PTwCePhKu341PUoKpCsEqPbNoffS+6+CtKC2gobL25WFpSFcp91E/jXXLiXvzswx0yUtrbeaQRIyMlP7NQyvjt32ggn15NW+onU16i6fsc26T17I0VouLPvjsB9ScAfegreppremo7su7TXm7QhZICpxQ4VFCMEKKgSAQv4c+vAOK1w745adiXkOmbdJaELSMspPTKOngjCikE7s87R3zn0rQPiBrS6a1vjs+6PK6QUehGCvgYR7Ae/ufWq0hDjgUUNqUEjJwM4oj3jo7xJ0vq5aWrPc21SinJjOgtufgk9/wzVyBzX5vxZDsaQ2/GdWy+2oKQ4hRSpJHYgjsa9hfo/eIzusrI7BuzgVeYAAWvsXmz2Xj39D+B9aK2/SgORSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgHtWmP0pZb0fw1LbJIRImtNOY/wAuFK/qkVuc9qoXjHppeqtC3K3RwDK2h5jPqtByB+PI/Gg8MsoDr7TalBCVKCSo9hk962J4o40Vrk2nTLf6vbtiWi3Jb/vn1KbCitS+5B3Ebfl+la7facZdW08hTbqFFKkqGCkjuCKm0amlPqh/rtpF2bhpCWG5PokdkqWnCykf5d2KIsnjLb4jFx0/dIsdqK9eLSxPksNJCUJdUCFFKR2BxnHvmpP9GmW9G8VIbTROyRHebcA/yhO4f8pFa+1JfZ+pLu7crq4FyFgJASkJShIGEpSkcAAelbu/RW0q+u5zNSyGymOhsxoxUPnUSCpQ+gAx+J9qK9QtHKRXOuDQwkVzoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFdLze4V3UIoNJeKngzA1VIduVrcTb7srlatuW3j/qA7H6j8Qa0pL8D9bMSC21CjSEZx1G5KAn/4iD/xXtRbYV3FdRjJ9hQeX9E/o+zHZbb+q5TbcdJBMaKoqUv6KVjAH2z+Fek7JaotqgMQ4LCGIrCQhttAwEgVIIZSn0rtAxQfQMClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUClKUH/2Q==",
+              "timestamp": 64859715715
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAYCAwQFBwgBCf/EAEkQAAEDAwMCBAMEBwQGCQUAAAECAwQABREGEiETMQcUQVEiYXEVMoGRCCNCUlOSsRYzYqEXJTVygoMYJDQ3Q6Kys9Enc3R18f/EABkBAQEBAQEBAAAAAAAAAAAAAAABAwQCBf/EAC0RAQACAQICCQMFAQAAAAAAAAABEQIDIQQUEjEyM1JxcrLBEyJCQVFhkaGx/9oADAMBAAIRAxEAPwD1TSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSvilBKSpRASBkk9hUea1xpV64eRa1FaVy87Q0mUgkn279/lQSKlCQBknj3qOnXGlkz/ACR1FaRLzt6Xm0bs+3fv8qCRUoCCAQcg+taq86htdlWhN1leUQvGHnW1BofVzG0fiaDa0qBeNcr/AOkl/kw3+DHSpDrS+4Kk8gitsdX6es0SBGu98t0OUplv9W/ISlXKRyQTxQSelW40hmUwh+M628y4NyHG1BSVD3BHetLd9Y6bs8sRbrfbZEk5x0npKEqH1BPH40G+pVqJJYmR0SIjzb7DgyhxtQUlQ9wR3q7QKUpQKUpQKUpQKUpQKUpQKUr4tW1JNAKgnuQK+BxB7KFau5XGJb2DIuMpmMzkJ6jywhOT2GTWBD1LY5slEeHeLe/IcOENtyEKUr6AGgktKsR1k/Cfwq/QKUpQKUpQc38cH3l2ex2hLy48S8XViDLcQdp6KiSpOfTOMVI5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvn3rM1dp2DqqxP2u5pV0XMKStBwtpY5StJ9CDUPd0XrOTCNsla8Wq2qT01rRb0JkqR2I6m7vj1xmgghvtyf8D4cFU10ocvAsip6VYUuN1Snfn5pG3NdcRoHSqbH9kixW/yWzZgsp3dsZ3d93zzmq3tE2R3RI0qYxFpS0GkpB+JJByFg/vbuc+9RpOidaIifZydfu/ZoT0wo29Bk7O2Ornvj1xmg03iDKk6E8FDH07eHpZbdTDROUsKWy2pZBG4eqR8IPcV0XT+nLZb9OItzbQkR3mQl9bx6ipGRypZP3ic1bt2jbJC0enTIiJetPTLa23viLmTkqUf3iec+9YqtPXS2WUWfTE9MaNs6aJE1apDkdPbCE8Zx6blHFBxWO+7H8IvFCwJdW9brNOXHhrUc7W+oPgz8sf512fROlLND0nEbMWNOVLjockyXkBxUpSkglSie4OeB6CtePDOBH8NZ2koElxvzoKn5jid63HCoErUOM5xijejtR2mJ5DS+qW4VtCdrbMqCJCo49Q2rcOPYKzigimn5b2kP9KNqshKoFna85Ba+8GFraUtSB8gRnFSnws0lY2dDW2SuHFnSrjHTJlyn20uLfW4NyskjkZPat1ovR0PTNnlRC65PkznFPTpUgArkrV3KvljgCo7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNBY8PmW7B4n6s03axssyGWJzbAOUx3F5Ckp9ge+K6hUZ0RpFjS7Mxxct+4XSc51pk5/wC+8r0GBwEgcADtUmoFKUoFKUoFKUoFKUoFKUoFUPjLRquh5oI7qMSTbT5ITi9uH/Yuj1Mf834cf51orKm7/ajHmhqLo5O7zQg9PsfvdP4/yqbLZIPw8iqQ0sn7tB9YH6wVlVQ02ED51XQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKHjvSoVq65OrmKiNqKWmwNwB+8SM0Za2rGlj0pTAyGR/4qP5qeZZ/io/mrhmqtVwtNPQm5zMlwy9+wspSdu0pBzlQP7Q7ZNV3HU0aDqKFZjGlOypTYdSpsI2JSVbcncoHjvgAnFS3JHGZTv0XcPMs/wAVH81PMs/xUfzVwS5a3tkDUJs7jUxchK20OONtgttqWMpBOc9ueAav3fVkG16ih2aQzKVJlJQpC20pKBvUUjPxZ7pPYGlrzmfgd08yz/FR/NTzLP8AFR/NXD2tTwnNRGzJakeaDi29xSnZlLaFnnOeyx6d80tupGp+oZtoTb7iy9EG5bzzSQ0RkhJBCicKwSOOQDS05zLwu4eZZ/io/mp5ln+Kj+auGWjVMW6SbszHjSki2rcbecWEbVKQSCEgKJ9OMgViaX13adSXFuFbkyQ8qMZJ6iUgJAVtKThR+L19setLXm89/s6nfvMs/wAVH81PMs/xUfzVwq16sh3Ju7uMxpaGrYXEuqWEfGUZyEgKJ/ZPcCvun9WwL/DmSLazKcEVtK1I2DcoqSVbUjP3uMY45pZPGZx+LunmWf4qP5quJUlYykgj3FcP0vqBrUMV59iFOioacLR802lBUoHBxgnsQQalFpuL1vlIW2o9PPxozwRSyONrKssadJpQHIBHrSq7ylKUClKUClKUClKUClKUClKUClKUClKUCoVq62uomKmNpKmnANxH7JAxU1oee9GWtpRq49GXFLxYbbeXY7lyjdZyPu6St6klGSCSCCOfhHPyqi4adtdwukS5TIvUmxNvRd6iht2q3DgHB555rtJjMHuy3/KKeVY/gt/yipTkjgso6snEpul7LOu7d0lW9pycgpUHST3T90kZwSPmKvTbBbZ11YuUmNvnMBKW3gtSSkJJIHB7ZUfrnmuz+VY/gt/yinlWP4Lf8opRyWXjcbRZLci8LuqYqRPWCC7k+oAJxnAOABnGcCshqDHZnyJrbeJMhKEOryfiCM7RjtxuP511zyrH8Fv+UU8qx/Bb/lFKTkcp/JxWBpu0wJs6XEidORO3eYV1FHfuOTwTgZPtiqbXpezWuY1Kt8FDEhpnoJWlSvuex557Dk88V2zyrH8Fv+UU8qx/Bb/lFKXks/G4nB0zaIK7guLE6argFCT+sWepuznueO57Yq/Z7HbrMXzbIqY/W29TaondtG0dz7V2XyrH8Fv+UU8qx/Bb/lFKJ4LKevNyO3wY9vYUzDb6banFukZJypSipR59yTW4tFueuEpCG0npg/Gv0AronlWP4Lf8oq4lKUDCQAPYUox4He8srfQMAAelKUqvoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFcd8R/HGNonVkmxu2N6YthCFl5MkIB3JCu20+9dirxZ+kz/AN710/8Assf+0mg6az+k5bi4kP6alob9VIkpUR+BSP612nReqrXrGwtXayuqXGWSlSVjattQ7pUPQ14xfErW1i07aNM6cdcm2lhaJT7CAVPlagUlWB2GO59zU5nStT+DfhdFtm9MK83yY6+Skhao7SEISQD2CiSORnH17EesqhviudWjSa/7B9P7W6id2du7p4Odm74d2cd/TPrXjkXHWS4AvIvc8tqVgK+0/wBao5xkN795GfXGK6LN1pq25eCV0bv32ixJiS43l560LZU8hRVlO7jcRjv8+aDrfgerxHUqd/pAB8lsHl+uEB7fnn7n7OM/e5zjFdYrwtobxJveljd5LU6RJmPxPLx/MuqcS2ouIJXtJxkJBx9aqif6RdSWq4aljTLzLgxFKMiSmWUhBA3KwncDgAg8DgUHsnXRvydKXA6RSyq97B5cO4xnIz34zjOM8ZrkvhMfF7+2DX9rQ99iYV5jzXS/dO3Zt5znHbiuf6V8Tr7efDXV9lu055+VFgpkxZm4h4JDqEqSVDk/eGD371pPBDVlwg66E25XCdKiRIMuStpx9SgoIZUrsTj0oPadK8Tp1R4ieJmqnPsWXOXJQC+3EiSOi2wgKGO5A4JAyeTWj1zqjVj2qp5vUybBuSChuQw0+pCUrShKSQAcDOM8cc0HvSleBdVagvLd0ZCLvcEgwYasCSscmM0Se/qSTW58RZ2r4belpV4u69si1MOwhFfWC21tABV2+M4yTzknvQt7hpXj26eMupUeGdkt0a4OouTinkSJ2f1ym0kBACvQ8nKu/wAI55NQvz+s40SPdU3q4APKHTKLnueJPYlsL3gfMiive1K8aa51nq+7aE0/9sC6Q58eS+35gIWwZLZS2UqOMZIORn6e9QW1XDVN2uLMC2z7xJmOq2oZbkOFRP0zRH6C15K8VPFnW1k8Qr7bbXe1MQo0goab8syraMDjJQSfxNehfCWyXbT2grdbtQvl+5o3rdUXS4RuWVAFR74BA/CvIPjd/wB7Gpv/AMo/+kUHtbRsx+4aQsc2Y51JMmCw86vAG5am0knA4HJPatxXizXXiVqGSzaNPWafIg2+HAiMbY6y2p5zoo3FShzjJxjOOK1ES8a903eI/k7rcHZZ+NLceYJiVfJSUKUPwPNB7qpkHsa8heN2udYT27GJSLhZYMiChxTKQtkOPZIcz2PBHAPpg+tQrSlv1XdEJk6fvP8A1oqO2Om6pakKI9kFYJoW95UqP+H32l/Ymyi+9b7UEZAk9f7+/HO751IKKUpSgUpSgUpSgV5F/SH0rqG6eKdylWyxXWZFW0yEvR4bjiCQ2kHCgCO9euqUHi3UvhlqSDYNN3mzWe59Z+JslssMr6zLyVKGSgDcAU7fT0PvW0tXhjqnVHhm+t+JPbvNvuC3GY1wSttbzSmmwoJ349UjHpwa9fUoPDsWyeJkO2GxxLRf2IZc3lDURSec5/vAM4zzjOKmGqNMak074IXF7WNxlOS5syOGIb8ku9FKSo+pICjnkD0A/D1lXC/0gPDbUmutRWp2xIjmKxGLbi3nwhIVuJ7ck8fKiOBeGOin9dP3q3wVoTPYg+ZjhZwlag4gFJPpkKPPvitlGsfifYbZO0/Dtd/Zt8skSGGI6ltryMH4gCOQADg8ivRfgh4U/wCj5qXMuEpuVd5aA2otA9NpAOdqSeTk4JOB2H47DxC8XbBoS+NWq8Rrk7IcYTICozSFJ2lSkjkrBzlJ9KDi2l/Ca/WXw11Zc7lBe+1JsJMaLAaT1HtvVQpRITnk7Rx34Oa0/ghoa9nXjbN9sV2h26RDkx3Xn4jjaQFsqT95QxnmvVOitTQtYabi3u2NvtxJJWEJfSErG1ZScgEjuk+tYXiFri0aEtDc+9F4pdX02mmUbluKxnAzgDj1JoPIj2g9Y6fvHW0uJc1lRKY9ys7pUlxBPcqQcp+YOMVEdUQn7fqCdEmy0zJbTm159K94U5j4vi9cHIz64rcaX0vdNWXG4s6XfSssIMhSX3RHV084Kjk7eMjPxetdB0J4ETbldo/9ortbI8XdlUeNKS8+6ByQNvA+uT9KCEag0hqWfMiyYOn7vJjLgQ9jrMJxaFYjNA4UE4PINTrxl0tqCfadAog2K6yVxrBHZeSzEcWWlhIylWBwoex5r1lFYaixmo8dAbZaQEIQOyUgYAq5Qp44j+Eeorx4ZRJ0W2SmbtClvpchSWy0460QghSQoDODu+ueO1aaPZ/E/wCzmLLHtWoGYjK8oQiKpoA59XABkc+pxXuClFeXblH8UtE6Ki26J9r3C43UrdkOspdlrhISAEtpUMhKjlRJHyx2zXL7bYvES1y3pVstWrIcl7+8eYjyG1r5zyQMmvdEq4wojgRLmRmFkbglx1KSR74Jq9HkMyWg7GdbebPAW2oKB/EUEV8JDdD4c2M3/wA59p9JXX87u62d6vvbuc4x3ry34w6Q1LP8TdQyoOnrxJjOySpDrMJxaFjA5BCcGvaVKDx3r/wi1Kw1ab1ZbdJltSYMZTzDSD1ozwZQFAo79xnjscg1gxrH4sakucZPlb7HcQA2lxxCobbY9zwkfj3Ne0qUHl/Xmn/E7Ts1iPaVXG+W0RWQ6txCZiHHQn4yW17iOc447YrmK9Da41DeFOjSs5iQ6RnbA8m0D2zjalIr3dSg0ehrdPtOj7Pb7xI8xcI8ZDbzm7dlQHv647Z9cVvKUoFKUoFKUoFKUoFc38WvFi2+Hqo0VyK5PuchHUTHQsICEZxuUrBxkg449DXSK8cfpTRZLPik4++lXQkRGlMKPYpA2kD/AIgfzoOhPfpKQ/7PNSmLJuunX6bsNcggBGCQtK9pz2wRgYqqN+kQ+9pe4Xf+zbYMWXHjdLzp+LqoeVuzs4x0u2P2vlXC9Zajsd7s9qj2bS0ezvxE7X5LTpUXzj14HqCcnJqzbf8Auxv/AP8AtYH/ALUuiO2t/pMdS1znFWBtmajYIzXmStLhJO4qO0YAA/EkVuZP6QUWBou1XKVaw9eZ/UUIbTu1CEJWU7lKIJGSngYPY1Bf0U7LbLzeNQIu1viTUNsNFAkNJcCSVKzjI4rTfpN2ZuzeILKIcNuJb3ITZYQy2EIGCrcABxnPJ+tBLon6TkwSB5zTUdTBPZqUQoD8U4P+VQP9IDU8DV+qLPebUV+XftTYKFjCm1B10FJ+YNYl611p2fZbTCa0Ja2noaQl57qrSXsJweUbTyeeSajOrXY8h63yYVmbs8Z+KFoZQ8twLw4tJXlZJGSkjHbj50HSNO+MF20Z4fabtlhhNLDfXMl+U0ooUovKUEIII7JIJ/3hXQ9TeLNlv3hJFvly03FuijPTCk2+Q5hLLhbWrelW0nsnjgHk+1cx1akf9HPQqsDPn5XP/Mc/+Kh8BR/0XXtOTtF3gkD/AJMr/wCKDptr11apfhxrVGndERbWvyqGHVx3i4ood3JKidmcJxnHb6VzHwvvsnTeurXdoVvXcpEcubYqCQV7m1JPYE8BRPb0qb+BrS3tGeJzbSStarOQEjufhcqGeFGpImkdf2q93Jt5yJFLu9LIBWdzS0DAJA7qHrQek/Ebx6tOlby/abdb3LrMjq2PqDobbQod05wSSPXjitNpj9JO2zrizHvtmdtzDignzDb/AFkoJ9VDaDj5jP0rzvcJCGtbvy7mw4phcwyFtut7lKQtW4HbkA5BBxnB963Vxu+jpOoFPIsVxlx1BKUobdahBR+TTaFAfzGg9HeK3jdb9FXQWq3wftS4BCXHf1uxtoKGUgnBJJBBx7Ec1B7V+k275lIuunG/Lk8qjSDuSPooYP5iuR+J8R60+IMhM2C40kJjuJjPrKz0+kjCCr9rAG0n5GtnqrXemrzOiPRtA2qK0y3sW2l5xG8/8vYPzBNBk/pEala1RrtiZEZUmCiAwiM6c/r0KBc34xxguFOOeUn6V0rwC8QYunfDC4/bsR2NbbUsKakjKjKW6tZ2IGAMgjHc9+cVyrxfZIjaNktWr7Kiv2YFqMFqcSj9e8rAUrk8LSrntuqmZqePcPBe36YisSzMt01U2SvYOl01FSRznPdxPcUHU5H6TqBJUI2mFKj54U5M2qI+gQR/nU90543acu+kbpenW5EV62ISuRDVhSzuO1Ow9lAkgZ4x64ryxpu62CLpu4xbvDdemun9SpqO2VEY/irJLeP8KTUq0dN0knTGpXndL3RURuK01Kf+0Qo4W+2EhI2BIUCNwz+6R60E0l/pOTTIPk9Nx0sZ4DslRUR+CQBXS/B7xbb8RJ0yEq0rgSYzIeJDwcQoZA9gc815Xkr0/aFN3LTN1kyZSVYES5WxtQCT3ySpSDj6flXVvBjxGtsBjUt3uGnoceZAgB1cm3NdEPpLiUhCkA7QoqUnkAcZ9qD1JSuK+Fvjk3rXVbVjlWYwXZCVqYcQ91ASlJUQoYGOAeflXaqKUpSgUpSgUpSgUpSgVotW6SserYSIuoLe1MbQdyCrKVoP+FQwRW9pQc/e8INFu2BmzG1FMJt8yAEPLStS8EZUrOTwcYJ4qw14LaJatMm2otz4iSHm33E+acyVthYSc5z2cX+ddHpQRLRHh5p3RMiU9p6I5HckpSh0reW5kAkj7xOO9bTVGl7LqqCmJf7ezNZSdyN4wpB90qHI/A1uaUHNIvgdoCO+HRZS4Qc7XJLik/lurY6o8KNIammR5N0tpK48dMVpLLymkIbSSQkJSQP2jU6pQQab4V6Um6Xt+npEF5VrgOLdYbEhYKVKJJJVnJ5Ue9YLfgtolu0yLai3PiI+83IcT5pzJW2laUnOc9nF/nXR6UES0T4eac0U7Lc0/DcYVLSlDu95bm4Jzj7xPua01z8FtCXGe5LesgbdcVvUll5baCf90HA/CujUoIZqLwx0jqFmI3dLO0sxWksNOIWpCwhIwElQIJAA9c1Y014TaM05PbnW2zN+bbOW3H3FOlB9wFEgH51OqUEc1dojTur0NjUFrZlrbGEO8ocSPYKSQcfLtUctfgroO3SkSGrIl1xCtyQ+8txOf90nB/GujUoNHqnSdj1VbkQb7b2ZUdBy2DlKmz/hUMEfhWk0v4WaQ0zIkvWu1ALktKYdDzqnUqbOMpIUSMHAqb0oOZv+BugHpBdNlUgk52IkupT+W6pTF0PpqLpx2wsWaIm0u8uRyjIWe+5R7k8DnOeKkdKDmL3gVoB1zf8AY7iP8KJToH/qqU2bQmmbNZZVpt9nitQZadkhBBUXh/iUeT+fHpUlpQQ3SHhnpTSNyXcLHbAzMUkpDq3VOFAPcJ3E4/CplSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArS3TUUW2zXY77EpSGWkPPPoQChpC1KSCrnPdJ7A4rdVFb5px+ffnLghQKAiMkMqdUG3QhbhWlaBwRhYIznkCrCSkPn4fnvJebj+c27uh1B1Me+3OcVZN2iMxm3p7zMIOLLaQ+8gZIJGAQcEnHbOajKdPSo9yW64y07HTOXO8x11lYBUVYDYTyoZ298EDt6VTarRPQlmcmEw+XWXmzGmKLZbCnlrB+6e4UAoYzwKUXKWLnNtyXW3sNNoShXWW4kJJUSAO+R29QAc8Z5qn7Wt3kRN8/E8mTjr9ZPTznGN2cd6iv9kZYjojrcZfbSzbmiVk/H0HlLXxzwQeKypFglt3sz47MZ5lMxT6Yy1bQUqYQ2VDggKBSfwUeRSoLlu4d6gyUqPXbb/XKZQHFpHUKVbcp55BJH5ismPPhyZDzEeXHdfZOHG23ApSP94A5H41FbFpZ+NdI8qY1ESlrzikpaJIaU86hSduR6BKhniqtL6cl22Xb/MsMBMFlTQfTIUtTpOBnbgAA43HJPOPrSoLlvJ97Ziy1Rmo0uW+2kLcTGa3dMHtkkgZ+QyflV1N6tphx5S5rDTMg4aU6sN7j+7hWDn0x3rBXFudvutwkW5iNKZmqS6pLrxaU24EJR6JVlJCU/MHPfNatnT0+C75hLEK4uvMOIdafWUIbWt1biin4VZSSvB9cJTShKXrhDZlNRXpcduS7y20pwBa/oM5NY0a9wX5bkUvtNSUOqZS04tIW4UgElIzkjmo+9p2d0J0VLEFSZvSJkBRSY5ShCDsSQScbNyfi7n8Sf09NW5c2hGhbJs5EoSt56jaU7OcbeVDZxzjn5cqg3SlufDdmORG5cdcpsZWylwFaR7lPcVdkPsxmFvSXW2WUDKluKCUpHuSe1RWBYJrDlvZU1FS3ClOSfNIWeq9u38EbeCd/wARye3z42F1iTLrbLY+Y7Tcth5uU5DccyhRCSCgqA9CrIOO6RShsm7lEdcZDLyHUPNqdQ6hQUgpSQCdw4/aFfY9zgSYq5MebGdjIJCnUOpUhOO+SDitJLskmfpy5RHGIcKRKWpSURySnGUnClYGd234iB2Pr3OCjTcl1ua5IhMtrdLG1tMxZUemSdxVtxkE8Dbzjk88C5b2XqWzxJUKO/cYqFzAVMkvJAUB65z69h7ms5+YliSlt1O1rpKdU8paQlASR3yc+vfGOOSOKjUSx3OObW+pMR96M+8VJcUEHpr7HchGCocfsjPv6m/q2xSrut8xi0Au2SoY3qI+Nwt7fTt8JzTY3bCfqSzwYhkv3GJ0Q+mOVB5JAWpQGDzxjOT7AE1edvdubdhNiWwtcw/qAl1J3jGdw55H0rTXTTz7j8tyC3FSktwy02o7UqWy8pZBwDgEEDOD9KwrppufLmznDGjOJnpa3ZlLSmOUpCSkAJBUBjcCCk5J7d6VBcpY7c4DMryr02M3Jxu6SnUhePfGc4ou5wEIeUubGSlkZdJdSA3yR8XPHII59q57qBKUSLha47lukPyrg08ELCvNBW5BxsxykAcLzgJ+lbp3Sz6ba2Gm2FSUXN6ctAcKA8lS3NoKsHkJWk9jyn8aUWlJuMERm5BmRhHc5Q71U7VfQ5wavqeaS70lOIDm3fsKhnb749vnUVtum3EvW52VGjJDMp6SpoOKdCSpG0EEjk+pwAMk/WtjdoM1V3RNgoZdzEcjKS4so2kqSQrscjg5FBsVXOAlbKFTooW9jpJLqcuZGRt55yPaqhPhqnGEJcczANxYDg6gHvtznFRJvSckWObHWmMZrsGNHbcz91bSMZzjIG7kVXD03LZuyC4yytlM5yZ5kyFbsKUpQAQB3+Lb97GB88UqC5TOlKVFKUpQKUpQKUqB6qv1wj3ea3HSltq3IbeQFqQlLxUD94lxJ2/sjCVcjPPAqxFpM0nlKg171HcYzN5lNSoccQHkMIiOt5UvclB3E5BydxxgY+H8s5d+eLUFta2S7IuUiItGOemjrY49OEI5+fzpRaV0rntrvk1yOwxHmW62MM2aNNSlbWRuUF5H3hhA2j580Orbs86p5DCIyGvL5ju9Mb+ohCiCVOBQOVlIwk8p9ewUW6FStHqCfJZuFrhRX2oolqc3SHEbgNoBCEgkDcc/kk1GoNwlwtMzbwy+3IdEp6OAj+6yqUUl3BUBgA55OMeuOaUW6DSoN/aO6R7bPeUG5L0N9pKGgEdSRuHLWG1KAXzkHPtkAZNX03qfJk2yMi5wGBJgrlrf6W4FQUPhSCRwATnPPw+nootMqVzh/WF2cZU60lhkMQ25JJCNj5UVc5W4khB28bQTz+BzNRT7vKtOqVtS0Q48Fna2G28ubiyhZyrPGNx7D+lKLTulQy5X2bCU24zPjybe20lxyS02h0nKyDuSFghOAACkHnPtitrqKUuLcIimW4ynkxpLja3ztCVJSkjKvRJ9flSi2+pUIbv13VHcZCmzOS60FIW02hSULSo/B+tKFn4eBuBwCeeM3Y2pnzEkvOvNbW7e4+lamunl1C1pVxuPbanOCRzwcEUotMqVDIuoLiq4w/NLZREeUy2C20lYUpbaThRC9yFbicfCRjH4Z17uUtN5ehMTYsFpiH5oqfRu6pKlDHcYSnaM45+IdvVRaS0rl1u1Nc41khojJbbah26I4A508PFTSSclS0qAz8I2pPIPftUnRep6dRpYkqaRDckFhoNtpcCvg3YKgvclWQe6cYH40otKsDOcc+9Kid4u81GoZ8Fi4woLMaC3KCn29xUoqcBzyPhG0Z9eaxLJeJC5qZK2xHE+YwHm3P8AwwqGF7fkdwApRab0qCSNTXNbLr8ZyP5Zp2UFuIQlxQS25tSdpWnKcA5Iye1Z+rZKydMvMSGmFOzhh11J2gKYd9MjnngH1xSi0spUBe1LdRKFvbW04UyHmjOaQ2A4EIbUAAtaU7v1hB5P92rj2xrnPfuNsVKkdMPLtD24tEFKsOpG4YJHOM8E9+570ot0elQZ3UtzF7eQlDaI7U9EMML6Y3pJSN2SvfuOdwwnGMfUbCzXme9ffLT1tBt3rdFLTaVIUEK4IWFk5wRkKSOfalFpTSlKilKUoFY8iFFkvNPSIzDrzRy2tbYUpB+RPasisGRd7fHmohvzGESlkANqUM5Pb6Z9Pegs32yxbtEfbcbaQ+430xI6YK0jPYHvWZ5CJ5lUjyrHmFEEu9MbjgYHPfsSKxmr5bHZbkZucwX2925O7tt+9z2OPX29axX9SQfJ+Yguol4fYZUlKsEdVxKArt25JHvirumy8bBblT1ynYzTpU200ltbaShsNlZSUjHB+M/kKzXYMR6S3JdjMLkNfcdU2CpH0PcVjovVtXcTARMZMsEp6YVzuAyU+2QOcd6y1SGUyUx1OJD6kFwI9SkEAn8yPzqK+SoseY10pbDT7WQdjqAoZHbg19THZSyppLLYaVncgJG0575HzrWvakszIbLtxjp3tpeTlX7Cuyj7J+Z4rJ+2Ld58QfOsebJwGt4znGcfXHOO+KC7Ht8OM223HiR2m21FaEobCQlR4JAHY8n86xZFit8iYl+RGadSGyjpLbSpvlW4qwR3z6/M1cmXHoS0xGGFyJKmlPbEKAwkKA5JPGc8fQ1qW9UjybMuTBcixnJJj9R51HBBUkngn1R+OaqbN6/AiSFsrkRWHVsnLSlthRQf8Oe34VdS02kuFKEguHK8D7xxjn34AFa5zUNpbiNSlTmQy6pSUHOSop+8Md+MHPt61bkXsecjx4EVc4vMGSlbTiAnZkAHJPOc+lQbByBEcWytyKwpbP8AdqU2CUf7vt+FXVtNrUlS0JUpIIBIyQD3rAVe4DctuJIktMzFbQWVKBKVK7JJHAJ9B6+lWZWoITchLEZ1uQ+JCI7qEL5aKlFOT+IPFBmptkBMZcZMKKI6zlTQaTtUfcjGDVTlvhuoZQ7EjrSz/dhTYIR6cccfhV1iQzICyw6hwIUUKKDnCh3H1FaV7UjbNyejuQ3wwzKbhqkbk7Q4tKVJ4znHxpGcf5UG2EGImQiQmKwH0J2JcDY3JHsD3Ar7JhxpKm1SY7LymjuQXEBRQfcZ7Vhx7/apKFLYnMrSkoSSDx8atqT9CeAexqi43tuLKZixmVzJTjvRLbakjYemV/ESQPuj/MUGYu3QlrYWuHHUuOMMqLSSW/8Ad44/CqxDiiX5oR2fM429bYN+Pbd3rT3PUiLVEkyblGLKGGUuqbS4Fu5KlADaOMfDwc+/tW6iyGpUdLzCiptXYlJH+R5orCeskGRc3p0phEh1xttG11CVpRsKyCkEcH4zz9Ky34cZ9t1t+Oy426QXErQCF4xjIPfsPyrTq1KkR1TE2+Wq1pUQZg2bdoOC5t3btnzx25xjms9V6tybgIKpjIlEhPTzzuIyE+2cc471d02XXLbBcQhDkKMpCFb0pU0khKvcccGr78dmQkJkMtupGcBaQoDIIPf5Ej8a1w1DaVPOMonMrdb37kJOTlGdw47kYOR3qxC1TapVojXBUjosvhO1LqSFZKd20DHJx7ZpUmzZO26C7ETFdhxlxU9mVNJKB/w4xVxUWOpO1TDRTs6eCgfd/d+nHasdm6R35UVphQdRJZU+08ggoUElIPP/ABCs6orHVCiKmJlqjMGUkbUvFsbwPYK719ahxWZDj7Mdlt9z77iUAKV9T3NX6UClKUClKUCo7cbJKevYmRHG44W40txxDjiVKCCMpUjOxeQCMnBAPrgVIqUEVj2K6x4SbczKhNxGEOhh4s73cqSoJJB4GN3JH3semTWMjS9wVKdedfZ/XeUKkl1xwpLD3U4Ku4UCfbBx9amdKtpSIQtLSY91QS80uC3LcmJJedKyVKUrbs3bBgqPxew7c5rZzLVKRcY0y3OoUtDLjCxKWpXCyg7geSSCjt657it5SllIFbrFd4ciVDiiIpP2ZFhLekNq2kpDgKk4HxYz9047jkVtImm5MK5RlxH0tRmlIU4pLq9zwSgJwps/Bk4Hx9+O1SmlLKanoON6r8xsUWXoYb3AcJUhZOD9Qv8A8prGasbiYMFha21GPOXLPBwQVrUAPmNw/Kt/SoUh07S0s3FyfEeaLxdeIbU86ynY4G/2myDkFvtyDmsqHpSMh6AZzMSW1GiFja41uG8qCioBWcDg+uak9KtlIxL0/LcXOjMvRk26c+h9wlJ6reAgFKccH7gwfT519l6ZXJtrkXr9Eu3EzFuMkpUUle7APcKxgZqTUpZTS2GBOtLMW35juwGErQlzkObQU9MEds43An1wD6mqGdPtIuF4nFuN52W7vYkFoKW1+pQ2OT80k4+db2lSykKNglR48py4qVIbeheVcRHW465uB+FaM9uSTgYCcDv3q/btNOybfaFXxMeTKS+qZNS62FJW4ptScAcj4cpA+Sal1KtlI3dNNCUm5NRVsxWJMFERpKEcNlKlqztGBj4xx9a28H7RDykTvLKaDSMOMgpJXlW4bSTgY2459TWbSoUg8/Tt+btzdst8uKu1oQqOUK3JcVHVgFHqN4HAXx8xzWwXp2UVPREPsC2uzROUopPWSoLDmwen3k9/QcY9alFKtlI7D0+6w3ASXG8x7hImLIB+JLnWwPqOqPyNY8Ow3OCxalNSYb0m2tLjNhTakIW0oIHPJIX8CTkcdxj1qVUpZSLx7ZLhSITDBS4+23KkKeKCloOuKBCf93KlcZzhNSZrf0kdXb1MDdt7Z9cVVSopSlKBSlKBSlKBSlWWpLTr7rLa8uNY3jB4z2rzOeOMxEz19SxEyvUpSvSFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFai1/7buv1b/oa29ai1/7buv1b/oa4OL77Q9U+zJrp9nPy+YbelKV3sgEEZBBHuKpacQ62lxpaVoUMpUk5BHuDUYt1uuEZUVDrT6toRtW3K2IaAPxBSc/ETz6HOcZTjNZEk3BvSUppxLrc1qJgOpXlSl7eSCPUGgkNKiT8C6FKxHbloYW6nDa5ZUtOEKBVu3j4SdvGT2zjnFXrZGuyLpDckokFHTSHi48ChJDeDgJXydwzgpPcnd6UElW4hspC1pTuO1OTjJ9hVVRadbbk9cUrbDxWmUXQ+p/9UlvYQkBGe4JHp7nPpWVpyHcIyJHmS+kqbSlIkPdX9YM5UOTwePUZ9h6hvXHENNqccUlCEjKlKOAB86qrSzvtBnT03rLU7MUgpaLCSo5IwMYHv6/jwOBrpUS9OIeYaD6cKklLwfA3Bastgc5+EHHIGMccUEpLiEuJbK0hagSlJPJA74H4j86qqMO226ofktxnXvK7l9LdIJUUlLPG4kkEkOgH0z9K+w7dcFzEuOKmMRAHVNsrlblIJDYTuIJzyFkDJAz+FBJqVoLTDnqtU2PJMhhxeUtOOOlSx8P3uFqxz7EfQVgS4F7kMMOuGQHnQ4pxpiSE9FZxs5yAUgDnGeSTg5oJdVKXEKcWhK0laMbkg8jPbNRh213UNuuNPv+ZcceSSZB2hsg7MDOAc7cEDIzVESFcYtwdlMxJfQW4n9SuSlbm0NqTySrGAog4yff5UEspUXtMO7MXGAqUH1oDKA+pb+UJIawcAK5O4eqT3J3elXJEK5rkTAz10vr6pbk+Zw0AUkIT0+eQceg7Zye1BJKVFmrXOkPoC/PRoRKiWlTCXAdmASoKJwTyBn0z64qmPaboGIrbj0o7245lHzJzvBPUwc8ZH7vHtQSulRMWm7NRSI8iT11CQglySVfBv8A1WMk4O0AZ7881lxIVxTZJzQVJbecVlpLz4U4lOBkbgTtJwrHxHGc8dgG/S4hS1oStJUjG4A8pz71VUNXa7l1JDjTM1uM4+lXREodYp6YT97f2CsnG71+WKzbZDurF3jqk9d1oNgOuOP5QD0wPhAIydw9UepOfSgktKUoFKUoFKUoFai1/wC27r9W/wChrb1qLX/tu6/Vv+hrg4vvtD1T7Mmun2c/L5ht6UoexxXeyKVDEWa69DpKU/0UuoUseYy66AlYIyfhIyUHOEk4OR2rKYstwbCHFPOqfbVG2FcgqwhKh1AewOUkjOOeKCTtrS42lbagpChkEdiKqqKs2q5pLHVUpb46JEjrnDQSkBaCn9rcQrn13c/dFEWeewm1BovOLaQ2HiuSSkq3ArUeQc98YyPQjFBKqpK0BaUFSQtQJCc8kDv/AFFYb7c7z6XGXUeVSnlo91HCvlx3T6+lYN2tb9xmwZSCI70dhwoXnJbdJQR9RgKB9waDdoUlaQpCgpJ9Qc19qJN2i5+XjpcSOr0UpSW3yExnd6lKV6bgQU+n7OOxNfXbddnW0tLDqUtMrbKm5ACnD1UKBH/Ck8HHcjjvQSyraX21SHGEqy6hKVKTjsDnH9D+VaQwZyrLCacRuW07ueYS8R1EfFhO4k88pOM44xnFY6bLK64kgKbeSI4QPMKVtCXVKWCT3+BWOfpQSerch5uMw488ra02kqUrHYDvUSiWG5bAiTIklSi2JC/M4D2HAVKSAARkZ9QecegNZEu0TXm57PTUpbqXgmQZJAUlQIQjZ6YyB+Ge5NBKaVGH7PLbkOBtC34O9RRHElSDktoAVuznhQXx/iz3FUCyXII3qkOLlFZStxMgpyjy5Tx3A/WYPbvzQSd51tltTjq0oQnupRwBVSVJUMpIIzjINR2NbZytPzIjqcOrcBa3uZUU/D97kgHIPbj14JNU3Czyl3hDsZb6Y4KFI6b4SlB3lTmQQc7s+nfscDmgktKibFpubbGJAW+jrh0siQQS1tUA1n/CSDn9qvps9xVcGHS4+lKels2SspaCfvJOU5Vnnn1zzjANBJo8liSCY7zbgABOxQPBGQfxFXahqbDcERWUErCE9EOIZdCVLCWikjJ4OFYOD7VkMWS4oR1DIdMpCmA2tT5VtSEgLz2B/a9OeKCVUqJLtFwXCbbQh1kJW2X0plb1PhIUFEFXAySk84zjBxUhs0d2LbWGX1rW4gYJWvee/AKsDOBxQZlKUoFKUoFKUoPma09rP+u7r9W/6GtoVVprYr/Xd1+rf9DXBxffaHqn2ZNtPs5+XzDe5pmrG+hXwea72K/mqVuJQAVqCQSAMnHJ7CoM/ZprUZhPTSpW9pD5Q6o+aIWCpa+OOAc9/vY7Cqpmnpr7SENuBppPVLbLb2EsFRG0pJQe2D2wRnA4oJzmrS5DSFFKlp3DblOckbjgcfM1FJNjkriOIHTdddlOOuKcWTlJ3bO4I4yOMYHcc19j2SS0+iR04wlKajJdkBX6wltYK+cZIUPn6UEvzTNQxuwyiltDhbSBsEhaXVEyiHEqK1DHBwFcc/ex2FVf2ffIe+JGW0LET41YaV1VqQR7YSUj8x2oJa++2w31HlhCMhOT7k4H+ZFGH232w4ysLQSRkfI4P+YqGI0/OEp51T+4rc3KKnAQ4OslYyAgHhIIGScdhxX1zT85clhfXwlsfBscA6SuqpRUMoJ5SoDgjtjsaCbZqyuWwhhTynUdJJKSvOQCDgj8+Kjd6tEqdeWpTbyg0hLYRhYHTIWSogFJ7ggcEZxg8V9j2Ux7LNgx2IrJdfW4kt8BQLm4bsDggHHr2oJTmmai9pt02NfHpb3SDTocCwhedxKwUntk4AxyTjPGBVhy0zOnJS21H6ruQt5Ty8vAuA/EMY4TkDOQO3bNBL80zUCbs04KZiyWESUIakbAp1SUIKnAUchOAUgkDA4xxWS7ZbqqWp1ElCHFNqaMgKwo5a2hRGM5CucZx+NBMHHkNlIcUE7s4z8hmvvWb+D40/H9z4vvcZ496iybO640loxo8eMSoOMJdU4lWW1JyQQB3IPb0z3rERp6WmTDW304yGEtBKWHAEtlKiVkDZn4h3wRnsaCa9RPU2bhvxnbnnHvVWai9yt81+/MTGekENLRg78KKBncOx9/QjPrV6Vb33LuZIQ04CpBbeU6pKmUj7yUpHfPfvznnIFBIs0zUMYsEkhhDwaS0kt+YCXVK8yUk7lq47n29c4PYVYmWKTEtT3lM9ctvtq6a1FSkqcBaHv8KRj5elBOs0zUUjWVwTGVqbbYiIf63l23VFIwjAPYd1YOO3Ge9YMLTk1sbZMgublN9dRd4fw4FFRASDyARyT3x2oJq+8hhlbryghtCSpSj2AHc1XmoRM09LdhyWMMuhTTrUYLdUkR8uLKSOP3FIHy247GsmZYX3mFgLypyYt51PU/vG/i2p+JKhxkHGMcUEvzX3Na+0tORbbGjvuKccbbCVKUrcSR88DP1xWYFUFylU5qrNBjhC1DPasCJbn2bjNfUpGx4p2gHngVt6VnnpY55Y5ZdeM3H9TH/JeoymImI/Vi9Bz3FOg5+8PzrKpWjyxfLue6aeXc901lUoMXy7numnl3PdNZVKDF8u57pp5dz3TWVSgxfLue6aeXc901lUoMXy7numnl3PdNZVKDF8u57pp5dz3TWVSgxfLue6aeXc901lUoMXy7numnl3PdNZVKDF8u57pp5dz3TWVSgxfLue6aeXc901lUoMXy7numnQc9xWVSgxeg5+8KdBz3FZVKDHDKx6ivnKTg1k1bfGWyfUUHxKqrrHQqruaC7SlKBSlKDW3u4GCwkoxvUeM1YsN1M4qbX8TiRknGMVsJsJmY2pLyc5GM+orFtFoatqnFIWpal8ZIxgV8vUw4yONxywmPpTG/8OnGdH6MxMfcg9o8SnHpkpVwhtptzAf6jscOKU0W3NiUqynaSv0APets54j2dl2KzIYnMyHn1R1NOthKmVpKchWVY/aScJycGpD9gW37GftXlUmA8VlbRJOSpRUTnv3Oa1rmhrA5HbZchrWhCy4dzyyXFEgkrOfi7DvntX1HM16vEmy7bkppuW8mCCpwoSn4khRQpScqHAUMYODyMA1tp+rIFutsCdcG5MZiY2paeo3goIQV7VDPCiAcD3FWJOhNPSW5DbsFXTfcDqkJfcSAoKKuAFcfESePWtlL09bJtpYtsyOZENlSFoQ6tSzlJyCVE5P4mg0bviHaGVudVielpCVAu9DKS4lG9TQOfvhP4cHms2LrK2SdKrv6A/5NKtmwAKWVbgkJG0kEkkAc+tXX9IWR+4PzHYeXntxXhxQTuUnapQSDgKI43DmrkfS1oYssi1Nxf+pSFlx1JWoqUskHcVE5zkDnPoKDVDxBtIalLdZmsqitvuOtuNAKT0igLHfvlY+vNWZHiVYmHbk2RKUYOQopQCFkLCFAc8YUoAlWB3PYVci+HdkRHkMzG3JSHH3nQVOrCglzbuQSDlQykHn1rZK0fZFOS1iIpJlcubHlpGdwUSAD8JJAJIoNC94jMrfQmJBdMdbMd4PuEbf1rwa2/CTz355HFZa/EW0J6mGJ5GUhghn/ALSC4GtzfPI3kDnHes9rRNgaS0lEHCW0pQB1V8gOdUZ55O/nJ9zVTOi7Cy8txEL4lLS4MuKIQUr6gCRn4Ru5wOM0GBG8Q7O/cbdCDctD83ISFoSnYoLUgpOTydySPhzWXctVx7frCDZX0nEtO1K8dnDkpHfJBCVZOODjnmrqtG2NUiO8YZ3MOl5A6q9u/eV5Izg/ESeavydMWmTe0Xd6MTPSpCwsOKA3JBCTgHBIBI7etBHr7rG5W96/KjW5h6JaVhLjinSDy2hSePmVEfhWRbtcMTNeSNPhtoNISUNvBwFS3kpSpaNvoAFd/dKvat/JsFtkt3Jt6MFIuJSqUNx/WEAJHrxwB2qwxpSyMOMOM29pLzD6pKHRnqdRRJJKu5zuPBOOaC69qWxsPLaevFvbdQopUhUhAKSO4IzWDftRqZZtSbGIs1+5vlhhxTv6kYSpSlFSc5wEngetb9UZhRJUw0SeSSgVh3iyQLvDRFnMbmm1hxvYooU2odlJUkgg8ntQRu2a7Q46YU23yFXRp9xl9uEnrIQEKSC5ng7fjT6Z78cVZuviNBYiSVwosp1xtSS1vbKUSUdZLSy2fXBV64zx6VuP7FWEMxmhBwlgqKSHVhStygpW85yvJAJ3ZziqVaH0+rzW6DuEj76S4vCfjDmEjPwgqAJxjkUGC74i2htoKXHn70bzJbDOVRUoXsUpznAAPtmsq26xYk6el3iVCkxo0aUuOrICjhLmzfwe3qfbBq45oewOIZSuCSG92T1V5cClblBZz8YKhnCs1so9htzECbCbj/8AVJi3FvNFRKVFf3sZPGcntQaNzxBs6FoCW5jjZOVuoZyhpHULYcUc/dKknGMnAzjFJfiDZ4sESlolKbKHXAEtjOG3uir1wPi9Txjms53Rlid8luggJhtIZaSlagChJylKgD8QB55zzVH9ibDvfWIakqeCgSl5Y2hS96tvPw5UM8Y5oNtZLmxebVGuETd0H07k7sZH5Ej8qy3/AO5X9KxrPbIlntzUG3MhmM3nagEnkkknJ5JJJNZEj+4X9KDFbNX81jNVfzQZNKUoFKUoIHfb/fo2tRAjshu1htJ6hjqXuBSoqWFD1SQn4fX8RUaTrnUwgQ/PhMCa+t5JQbe4sgJZCmyE5yd5PPtnHcV2GrLsVh2Qy+40hTzOemsjJRkYOD6ZFBydd51QxKkTEwZKpJDroYUlxSEKERtQSADgjeVce4OOauxtc3zpy1AecaZXJYQ63BcSVOJYbW0CjkjKlL+uK6zVliKxHW8thpDa3l9RwpGCtWAMn3OAB+FBBdLah1HP1aqHcYiWoPTJKSwpJSAhBSsK7HJKhj/4NYcrUuq43mXUxUvtrEwNtiIrLIafShCjg/FlClKxxnbxXTKUHIJOpdVhTMtpbjraGZiWSIK0IlqRsLa1IzlOcqwPXacd6kFuvWpk63Ztc1DbkIJTudEZSA4kt7i4FZIGFfDgn096n9KDlWp9bX+2XK/CMwfJw2XS2p6IpIStGzad2fiByr2zjgCsSdrjUjLimWVIWSiSuK4bc5ullHT2J2ZykFSlJ3H2zXWpkVibGcjy2UPMODC21pylQ+YoqKwqU3JU0gyG0lCHCPiSk4yAfY4H5UHOpuodUNMPPvFESOueuMFiAt4x20pJCiAcr3KwnPAFYUjUmp5sCY1LZdgSVwFKbitQnFKUosFW8Og4SQvjHf0711ilByWdqbWFtiojIYDym3dnmzEWQR0G1pSUgnutSk7v8PvUzvl7ljSc+ZaEpNxjENqStpaglwEbhgDJxnvjFSeqUISjOxITkknA7n3oOWf2z1GU2HZDf6j+0yUrgqAUC8UEghRxhPPb2PriqXNU6wata3lstl1yM1ISTDWnpEuqQpHrk7Ug89s+1dXpQc/vWqbnH01pqXuMKRcVhEhTsNS1N/q1KJDQUTnKRxk1pGL1ql+4WyVIZkQy47FMhlLKylRVHWSnBPwjeEj5EjPauqvxWH3GVvNIcWyre2pQyUKwRkexwSKvUHJ4941PdjZlIlOtSQ8pT+Lc42hk+XcJbUCcLAUAAffHetxqK+33+y1jkMNqiPzoxXKWmKt0tOdHclAQORuVxk9se9dApQcy0TftTPXu2264RlJhiM2HC8yveodBKupv7Z3kpIP9avXzUWq4su8x4lvC028FxL/QKg6hxSOntGeShPUKgP3R710elBy1vU2rloYcDDfTbYbdXiIv9fmSpvHcbT0wFY59+1Ylu1Jq2M9CiqC5G6Y+l1x6Ir4sSNobyOw6Z3A/MexrrtKCxClNzYyX2d+xRIG9BSeCQeDz3FVyf7hf0q5VEj+5X9KDCaq/VloVfoLqHErGQR9Kq3JJIyMisBaK0luR/rq6fVH9DWGrrfTzwwrtTX+TPw9449KJn9kryPcUyPcVqC3Xzp1u8Nxke4pke4rRRnGpKVKYVvSlRQTg4yO/1q706DcZHuKZHuK0/Tp06DcZHuKZHuK0/TqkBClqQFJK04Kkg8jPbNBusj3FMj3FaGS61GQFvr2gnaOCST7ACrxRgZNBuMj3FMj3Fafp06dBuMj3FMj3FaVsIcTubUlQyRlJzyDgj86fAXC3uT1ANxTnkD3x+BoNxvRu27k59s1Vke4rT9OraFtLcKEOtqWM5SFAng4PH1oN5ke4pke4rT9OqW9jqAtpSVoPZSTkGg3WR7ivhUkdyPzrSNracUUtutrUOSEqBI5I/qCPwq506DcZHuKZHuK0/Tp06DcZHuKZHuK0qdilFKVpKh3ANVdOg3GR7ilagNkVmsyMN4XyR/nQZRIHc1jSHQobEHPuasLKnFZVVaEUH1sVexXxCauYoLRRWmtqP9d3X6t/0Nb/ABWotiFC9XQlJAJRg+/Brh4vvtD1T7cmun2c/L5hnbPlVKmwpJBHBGODisrbTbXcyQaRZ7nGgMMW9uTuSHV5EonCyrKc5WOMfUe4HerwYuDkqawBJTMwtfV8zhvYonYlKcnCgABnAwRnJzzM9tNtBDW7TcH3sLM6PDIcKWlSyXEnagJyoKJPIUQMnH44qldsvZaLzT7qJq1LTlb2W0pMcgHbnH97g9s/hU02020EOt1ruJfjF9U1qMl3etDknKjhB7kKUdpVjjPp2HNXL1bbg5Nedhpc6S1Nbw04ErcSlLmQDuTjCig9xkA1LdtNtBGXbQ/JhWhEkvKdjvBbhD6kkDaockEZPIHrWvkWy6TmvLyGZCW22VpKjJ2h1YcSUkbVZ5SD3xjNTbbTbQQ2REvBbUxGZktgKcUhwyQfhLCglOSrJIWR39RnNbGfAkptsNmOZLqW3El9KXyHXE4OQFkjncUnuOARUh2020ECbtF5bS0lPmUN5cKEokAFtReWoKWdw3DaUeiux45raXqBNXNdeiNOKQtppsltzarhairHxJ9x6j8e1SnbTbQRdMS5KsMVp5L5kNuAPJbeAccQCfurz68Hkg4zWAza7q1FfSlMlCVFxaUpeSpfLwUkE7hk7cg/EPr61N9tNtBEIsK59WKqSxKOEoCdkvCWsLO7eCo7iU4/e9s+tYaYd1cfUyoyzJQwzsUmRtQ0vcvKlDOFDAHHPbGB3qd7abaCHC1XLcWwXW2FOhSum7tODIWpXIORlBH/APasm13oPtpK5KmkFSWimR9zDyyFLO74gUdPuFHg5HNTfbTbQRa8wbk9eGnIyn/LBCAjpu7EoUFEqKxuGQRt9FdjwKrs1vnxZbC5C31oWy71w48VgL3p2YGePhKu341JttNtBDYWnpUe2FIefS+6+CtKC2goQXtysLSkK5T7qJ/GrcuDevOzDHTIS2tt5pBD+Ryn9WoZXx277QQT68mpttFanU14i2CyTbpPXsjRWi4s++OwHzJwB9aCKakkt6cYdl3WY83aELJAVNKFlRQjBCioEgEL+HPrwDiudOeNmnYl5DpmXOWhC0jLKT0yjp4IwopBO7PO0e+fSuE6/wBZ3TWl7dn3N5XSCj0IwV8DCPYD39z61GkIccCihtSgkZOBnFEe6tHeIumNWKS1aLm0qUU5MZ0Ftz8Ae/4ZqZoANfnLFkOxpDb8Z1bL7agpDiFFKkkdiCOxr2D+j94iu6xsjsG7OBV5gABa+xebPAXj39D+B9aK66BVVB2r7QKUpQKYpSgYpilKBimKUoGKYpSgYpilKBimKUoGKYpSgYpilKBimKUoGKYpSgYpilKD4e1cZ/SllvR/DUtskhEia005j93Clf1SK7Oe1QLxj00vVWhblbo4BlbQ8xn1Wg5A/HkfjQeGWUB19ptSghKlBJUewye9dE8UcaK1ybTplv7PbtiWi3Jb/vn1KbCitS+5B3Ebfu/KudvtOMuraeQpt1CilSVDBSR3BFbtGppT6of220i7Nw0hLDcn0SOyVLThZSP3d2KIknjLb4jFx0/dIsdqK9eLSxPksNJCUJdUCFFKR2BxnHvmtn+jTLejeKkNponZIjvNuAfuhO4f5pFc+1JfZ+pLu7crq4FyFgJASkJShIGEpSkcAAeldu/RW0q+u5zNSyGymOhsxoxUPvqJBUofIAY/E+1FeoWjlIquqGhhIqugUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVZeb3Cr1CKDiXip4MwNVSHbla3E2+7K5Wrblt4/4gOx+Y/EGuKS/A/WzEgttQo0hGcdRuSgJ/wDMQf8AKvai2wruKtGMn2FB5f0T+j7Mdltv6rlNtx0kExoqipS/kpWMAfTP4V6Tslqi2qAxDgsIYisJCG20DASBWwQylPpV0DFB9AwKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQKUpQf/9k=",
+              "timestamp": 64860149590,
+              "timing": 2603
+            },
+            {
+              "timing": 3037,
+              "timestamp": 64860583465,
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAYCAwQFBwgBCf/EAEsQAAEDAwMCBAQDBQYDBQUJAAECAwQABREGEiETMQcUQVEiYXGRMlKBCBUjU5IWM0JiobEXJXIkNTeCg0OisrPRGCc0VnN0dZTw/8QAGQEBAQEBAQEAAAAAAAAAAAAAAAEDBAIF/8QALBEBAAIBAgIJAwUAAAAAAAAAAAERAgMEEiEUMTIzUnFyssEFQlETIkGh0f/aAAwDAQACEQMRAD8A9U0pSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUr4pQSkqUQEgZJPYVHmtcaVeuHkWtRWlcvO0NJlIJJ9u/f5UEipQkAZJ496jp1xpZM/wAkdRWkS87el5tG7Pt37/KgkVKAggEHIPrWqvOobXZVoTdZXlELxh51tQaH1cxtH6mg2tKgXjXK/wDukv8AJhv8GOlSHWl9wVJ5BFbY6v09ZokCNd75bocpTLf8N+QlKuUjkgnigk9KtxpDMphD8Z1t5lwbkONqCkqHuCO9aW76x03Z5Yi3W+2yJJzjpPSUJUPqCeP1oN9SrUSSxMjokRHm32HBlDjagpKh7gjvV2gUpSgUpSgUpSgUpSgUpSgUpXxatqSaAVBPcgV8DiD2UK1dyuMS3sGRcZTMZnIT1HlhCcnsMmsCHqWxzZKI8O8W9+Q4cIbbkIUpX0ANBJaVYjrJ+E/pV+gUpSgUpSg5v44PvLs9jtCXlx4l4urEGW4g7T0VElSc+mcYqRy9C6YkWFVoXZYCYOwoCUspBTxjcFYyFfPvWZq7TsHVViftdzSrouYUlaDhbSxylaT6EGoe7ovWcmEbZK14tVtUnprWi3oTJUjsR1N3fHrjNBBDfbk/4Hw4KprpQ5eBZFT0qwpcbqlO/PzSNua64jQOlU2P90ixW/yWzZgsp3dsZ3d93zzmq3tE2R3RI0qYxFpS0GkpB+JJByFg/m3c596jSdE60RE/dydfu/u0J6YUbegydnbHVz3x64zQabxBlSdCeChj6dvD0stuphonKWFLZbUsgjcPVI+EHuK6Lp/Tlst+nEW5toSI7zIS+t49RUjI5Usn8ROat27RtkhaPTpkREvWnpltbb3xFzJyVKP5iec+9YqtPXS2WUWfTE9MaNs6aJE1apDkdPbCE8Zx6blHFBxWO+7H8IvFCwJdW9brNOXHhrUc7W+oPgz8sf612fROlLND0nEbMWNOVLjockyXkBxUpSkglSie4OeB6CtePDOBH8NZ2koElxvzoKn5jid63HCoErUOM5xijejtR2mJ5DS+qW4VtCdrbMqCJCo49Q2rcOPYKzigimn5b2kP+KNqshKoFna85Ba/EGFraUtSB8gRnFSnws0lY2dDW2SuHFnSrjHTJlyn20uLfW4NyskjkZPat1ovR0PTNnlRC65PkznFPTpUgArkrV3KvljgCo7C0FqHT6HIWkNW+Rs5UpTUSXCTJMfJyQhRIOPYHNBY8PmW7B4n6s03axssyGWJzbAOUx3F5Ckp9ge+K6hUZ0RpFjS7Mxxct+4XSc51pk5/8byvQYHASBwAO1SagUpSgUpSgUpSgUpSgUpSgVQ+MtGq6HmgjuoxJNtPkhOL24f/AILo9TH/AKvw4/1rRWVN3/ejHmhqLo5O7zQg9PsfxdP4/tU2WyQfh5FUhpZP4aD6wP4grKqhpsIHzqugUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUPHelQrV1ydXMVEbUUtNgbgD+IkZoy1tWNLHilMDIZH/ALVH9VPMs/zUf1VwzVWq4WmnoTc5mS4Ze/YWUpO3aUg5yoH/ABDtk1XcdTRoOooVmMaU7KlNh1KmwjYlJVtydygeO+ACcVLckbzKefC7h5ln+aj+qnmWf5qP6q4Jctb2yBqE2dxqYuQlbaHHG2wW21LGUgnOe3PANX7vqyDa9RQ7NIZlKkykoUhbaUlA3qKRn4s90nsDS16Zn4HdPMs/zUf1U8yz/NR/VXD2tTwnNRGzJakeaDi29xSnZlLaFnnOeyx6d80tupGp+oZtoTb7iy9EG5bzzSQ0RkhJBCicKwSOOQDS06Zl4XcPMs/zUf1U8yz/ADUf1Vwy0api3STdmY8aUkW1bjbziwjapSCQQkBRPpxkCsTS+u7TqS4twrcmSHlRjJPUSkBICtpScKPxevtj1pa9Lz5/s6nfvMs/zUf1U8yz/NR/VXCrXqyHcm7u4zGloathcS6pYR8ZRnISAon/AAnuBX3T+rYF/hzJFtZlOCK2lakbBuUVJKtqRn8XGMcc0sneZx9runmWf5qP6quJUlYykgj3FcP0vqBrUMV59iFOioacLR802lBUoHBxgnsQQalFpuL1vlIW2o9PPxozwRSyN7WVZY06TSgOQCPWlV3lKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFQrV1tdRMVMbSVNOAbiP8JAxU1oee9GWtpRq48MuKXiw228ux3LlG6zkfd0lb1JKMkEkEEc/COflVFw07a7hdIlymRepNibei71FDbtVuHAODzzzXaTGYPdlv+kU8qx/Jb/pFSnJGyyjqycSm6Xss67t3SVb2nJyClQdJPdP4SRnBI+Yq9NsFtnXVi5SY2+cwEpbeC1JKQkkgcHtlR+uea7P5Vj+S3/SKeVY/kt/0ilHQsvG42iyW5F4XdUxUiesEF3J9QATjOAcADOM4FZDUGOzPkTW28SZCUIdXk/EEZ2jHbjcfvXXPKsfyW/6RTyrH8lv+kUpOg5T9zisDTdpgTZ0uJE6cidu8wrqKO/ccngnAyfbFU2vS9mtcxqVb4KGJDTPQStKlfg9jzz2HJ54rtnlWP5Lf9Ip5Vj+S3/SKUvQs/G4nB0zaIK7guLE6argFCT/EWepuznueO57Yq/Z7HbrMXzbIqY/W29TaondtG0dz7V2XyrH8lv8ApFPKsfyW/wCkUonZZT15uR2+DHt7CmYbfTbU4t0jJOVKUVKPPuSa3Fotz1wlIQ2k9MH41+gFdE8qx/Jb/pFXEpSgYSAB7ClGOx53llb6BgAD0pSlV9ApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArjviP44xtE6sk2N2xvTFsIQsvJkhAO5IV22n3rsVeLP2mf/F66f8A6LH/AMpNB01n9py3FxIf01LQ36qRJSoj9Ckf712nReqrXrGwtXayuqXGWSlSVjattQ7pUPQ14xfErW1i07aNM6cdcm2lhaJT7CAVPlagUlWB2GO59zU5nStT+DfhdFtm9MK83yY6+Skhao7SEISQD2CiSORnH17EesqhviudWjSa/wCwfT/e3UTuzt3dPBzs3fDuzjv6Z9a8ci46yXAF5F7nltSsBX7z/iqOcZDe/eRn1xiuizdaatuXgldG79+8WJMSXG8vPWhbKnkKKsp3cbiMd/nzQdb8D1eI6lTv+IAPktg8v1wgPb88/g/w4z+LnOMV1ivC2hvEm96WN3ktTpEmY/E8vH8y6pxLai4gle0nGQkHH1qqJ/xF1JarhqWNMvMuDEUoyJKZZSEEDcrCdwOACDwOBQeyddG/J0pcDpFLKr3sHlw7jGcjPfjOM4zxmuS+Ex8Xv7YNf2tD37kwrzHmul+U7dm3nOcduK5/pXxOvt58NdX2W7Tnn5UWCmTFmbiHgkOoSpJUOT+IYPfvWk8ENWXCDroTblcJ0qJEgy5K2nH1KCghlSuxOPSg9p0rxOnVHiJ4maqc/csucuSgF9uJEkdFthAUMdyBwSBk8mtHrnVGrHtVTzepk2DckFDchhp9SEpWlCUkgA4GcZ445oPelK8C6q1BeW7oyEXe4JBgw1YElY5MZok9/Ukmtz4iztXw29LSrxd17ZFqYdhCK+sFtraACrt8ZxknnJPehb3DSvHt08ZdSo8M7Jbo1wdRcnFPIkTs/wAZTaSAgBXoeTlXf4Rzyahfn9Zxoke6pvVwAeUOmUXPc8SexLYXvA+ZFFe9qV401zrPV920Jp/98C6Q58eS+35gIWwZLZS2UqOMZIORn6e9QW1XDVN2uLMC2z7xJmOq2oZbkOFRP0zRH6C15K8VPFnW1k8Qr7bbXe1MQo0goab8syraMDjJQSf1NehfCWyXbT2grdbtQvl+5o3rdUXS4RuWVAFR74BA/SvIPjd/4sam/wD3R/8AhFB7W0bMfuGkLHNmOdSTJgsPOrwBuWptJJwOByT2rcV4s114lahks2jT1mnyINvhwIjG2Ostqec6KNxUoc4ycYzjitREvGvdN3iP5O63B2WfjS3HmCYlXyUlClD9DzQe6qZB7GvIXjdrnWE9uxiUi4WWDIgocUykLZDj2SHM9jwRwD6YPrUK0pb9V3RCZOn7z/2oqO2Om6pakKI9kFYJoW95UqP+H37y/sTZRfet+9BGQJPX/Hvxzu+dSCilKUoFKUoFKUoFeRf2h9K6hunincpVssV1mRVtMhL0eG44gkNpBwoAjvXrqlB4t1L4Zakg2DTd5s1nufWfibJbLDK+sy8lShkoA3AFO309D71tLV4Y6p1R4ZvrfiT27zb7gtxmNcErbW80ppsKCd+PVIx6cGvX1KDw7FsniZDthscS0X9iGXN5Q1EUnnOf7wDOM84ziphqjTGpNO+CFxe1jcZTkubMjhiG/JLvRSkqPqSAo55A9AP09ZVwv9oDw21JrrUVqdsSI5isRi24t58ISFbie3JPHyojgXhjop/XT96t8FaEz2IPmY4WcJWoOIBST6ZCjz74rZRrH4n2G2TtPw7Xf2bfLJEhhiOpba8jB+IAjkAA4PIr0X4IeFP/AA+alzLhKblXeWgNqLQPTaQDnaknk5OCTgdh+uw8QvF2waEvjVqvEa5OyHGEyAqM0hSdpUpI5Kwc5SfSg4tpfwmv1l8NdWXO5QXv3pNhJjRYDSeo9t6qFKJCc8naOO/BzWn8ENDXs68bZvtiu0O3SIcmO68/EcbSAtlSfxKGM816p0VqaFrDTcW92xt9uJJKwhL6QlY2rKTkAkd0n1rC8QtcWjQlobn3ovFLq+m00yjctxWM4GcAcepNB5Ee0HrHT9462lxLmsqJTHuVndKkuIJ7lSDlPzBxiojqiE/b9QTok2WmZLac2vPpXvCnMfF8Xrg5GfXFbjS+l7pqy43FnS76VlhBkKS+6I6unnBUcnbxkZ+L1roOhPAibcrtH/tFdrZHi7sqjxpSXn3QOSBt4H1yfpQQjUGkNSz5kWTB0/d5MZcCHsdZhOLQrEZoHCgnB5BqdeMultQT7ToFEGxXWSuNYI7LyWYjiy0sJGUqwOFD2PNesorDUWM1HjoDbLSAhCB2SkDAFXKFPHEfwj1FePDKJOi2yUzdoUt9LkKS2WnHWiEEKSFAZwd31zx2rTR7P4n/ALuYsse1agZiMryhCIqmgDn1cAGRz6nFe4KUV5duUfxS0ToqLbon73uFxupW7IdZS7LXCQkAJbSoZCVHKiSPljtmuX22xeIlrlvSrZatWQ5L3948xHkNrXznkgZNe6JVxhRHAiXMjMLI3BLjqUkj3wTV6PIZktB2M6282eAttQUD+ooIr4SG6Hw5sZv/AJz959JXX87u62d6vxbuc4x3ry34w6Q1LP8AE3UMqDp68SYzskqQ6zCcWhYwOQQnBr2lSg8d6/8ACLUrDVpvVlt0mW1JgxlPMNIPWjPBlAUCjv3GeOxyDWDGsfixqS5xk+VvsdxADaXHEKhttj3PCR+vc17SpQeX9eaf8TtOzWI9pVcb5bRFZDq3EJmIcdCfjJbXuI5zjjtiuYr0NrjUN4U6NKzmJDpGdsDybQPbONqUivd1KDR6Gt0+06Ps9vvEjzFwjxkNvObt2VAe/rjtn1xW8pSgUpSgUpSgUpSgVzfxa8WLb4eqjRXIrk+5yEdRMdCwgIRnG5SsHGSDjj0NdIrxx+1NFks+KTj76VdCREaUwo9ikDaQP/MD96DoT37SkP8As81KYsm66dfpuw1yCAEYJC0r2nPbBGBiqo37RD72l7hd/wCzbYMWXHjdLzp+LqoeVuzs4x0u2P8AF8q4XrLUdjvdntUezaWj2d+Ina/JadKi+cevA9QTk5NWbb/4Y3//APlYH/ypdEdtb/aY6lrnOKsDbM1GwRmvMlaXCSdxUdowAB+pIrcyf2gosDRdquUq1h68z+ooQ2ndqEISsp3KUQSMlPAwexqC/sp2W2Xm8agRdrfEmobYaKBIaS4EkqVnGRxWm/abszdm8QWUQ4bcS3uQmywhlsIQMFW4ADjOeT9aCXRP2nJgkDzmmo6mCezUohQH6pwf9Kgf7QGp4Gr9UWe82or8u/amwULGFNqDroKT8waxL1rrTs+y2mE1oS1tPQ0hLz3VWkvYTg8o2nk88k1GdWux5D1vkwrM3Z4z8ULQyh5bgXhxaSvKySMlJGO3HzoOkad8YLtozw+03bLDCaWG+uZL8ppRQpReUoIQQR2SQT/1Cuh6m8WbLfvCSLfLlpuLdFGemFJt8hzCWXC2tW9KtpPZPHAPJ9q5jq1I/wDs56FVgZ8/K5/9Rz/6VD4Cj/wuvacnaLvBIH/oyv8A6UHTbXrq1S/DjWqNO6Ii2tflUMOrjvFxRQ7uSVE7M4TjOO30rmPhffZOm9dWu7Qreu5SI5c2xUEgr3NqSewJ4Cie3pU38DWlvaM8Tm2kla1WcgJHc/C5UM8KNSRNI6/tV7uTbzkSKXd6WQCs7mloGASB3UPWg9J+I3j1adK3l+0263uXWZHVsfUHQ22hQ7pzgkkevHFabTH7SdtnXFmPfbM7bmHFBPmG3+slBPqobQcfMZ+led7hIQ1rd+Xc2HFMLmGQtt1vcpSFq3A7cgHIIOM4PvW6uN30dJ1Ap5FiuMuOoJSlDbrUIKPyabQoD+o0Ho7xW8brfoq6C1W+D+9LgEJcd/i7G2goZSCcEkkEHHsRzUHtX7TbvmUi66cb8uTyqNIO5I+ihg/cVyPxPiPWnxBkJmwXGkhMdxMZ9ZWen0kYQVf4sAbSfka2eqtd6avM6I9G0DaorTLexbaXnEbz/wCnsH3BNBk/tEala1RrtiZEZUmCiAwiM6c/x0KBc34xxguFOOeUn6V0rwC8QYunfDC4/v2I7GttqWFNSRlRlLdWs7EDAGQRjue/OK5V4vskRtGyWrV+6or9mBajBanEo/jvKwFK5PC0q57bqpmanj3DwXt+mIrEszLdNVNkr2DpdNRUkc5z3cT3FB1OR+06gSVCNphSo+eFOTNqiPoEEf61PdOeN2nLvpG6Xp1uRFetiErkQ1YUs7jtTsPZQJIGeMeuK8sabutgi6buMW7w3Xprp/gqajtlRGP5qyS3j/Kk1KtHTdJJ0xqV53S90VEbitNSn/3iFHC32wkJGwJCgRuGfyketBNJf7Tk0yD5PTcdLGeA7JUVEfokAV0vwe8W2/ESdMhKtK4EmMyHiQ8HEKGQPYHPNeV5K9P2hTdy0zdZMmUlWBEuVsbUAk98kqUg4+n2rq3gx4jW2AxqW73DT0OPMgQA6uTbmuiH0lxKQhSAdoUVKTyAOM+1B6kpXFfC3xyb1rqtqxyrMYLshK1MOIe6gJSkqIUMDHAPPyrtVFKUpQKUpQKUpQKUpQK0WrdJWPVsJEXUFvamNoO5BVlK0H/KoYIre0oOfveEGi3bAzZjaimE2+ZACHlpWpeCMqVnJ4OME8VYa8FtEtWmTbUW58RJDzb7ifNOZK2wsJOc57OL+9dHpQRLRHh5p3RMiU9p6I5HckpSh0reW5kAkj8ROO9bTVGl7LqqCmJf7ezNZSdyN4wpB90qHI/Q1uaUHNIvgdoCO+HRZS4Qc7XJLik/bdWx1R4UaQ1NMjybpbSVx46YrSWXlNIQ2kkhISkgf4jU6pQQab4V6Um6Xt+npEF5VrgOLdYbEhYKVKJJJVnJ5Ue9YLfgtolu0yLai3PiI+83IcT5pzJW2laUnOc9nF/euj0oIlonw805op2W5p+G4wqWlKHd7y3NwTnH4ifc1prn4LaEuM9yW9ZA264repLLy20E/wDSDgfpXRqUEM1F4Y6R1CzEbulnaWYrSWGnELUhYQkYCSoEEgAeuasaa8JtGacntzrbZm/NtnLbj7inSg+4CiQD86nVKCOau0Rp3V6GxqC1sy1tjCHeUOJHsFJIOPl2qOWvwV0HbpSJDVkS64hW5IfeW4nP/STg/rXRqUGj1TpOx6qtyIN9t7MqOg5bBylTZ/yqGCP0rSaX8LNIaZkSXrXagFyWlMOh51TqVNnGUkKJGDgVN6UHM3/A3QD0gumyqQSc7ESXUp+26pTF0PpqLpx2wsWaIm0u8uRyjIWe+5R7k8DnOeKkdKDmL3gVoB1zf+53Ef5USnQP/iqU2bQmmbNZZVpt9nitQZadkhBBUXh/mUeT9+PSpLSghukPDPSmkbku4WO2BmYpJSHVuqcKAe4TuJx+lTKlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBWlumoottmux32JSkMtIeefQgFDSFqUkFXOe6T2BxW6qK3zTj8+/OXBCgUBEZIZU6oNuhC3CtK0DgjCwRnPIFWElIfPw/PeS83H85t3dDqDqY99uc4qybtEZjNvT3mYQcWW0h95AyQSMAg4JOO2c1GU6elR7kt1xlp2Omcud5jrrKwCoqwGwnlQzt74IHb0qm1WiehLM5MJh8usvNmNMUWy2FPLWD+E9woBQxngUouUsXObbkutvYabQlCustxISSokAd8jt6gA54zzVP72t3kRN8/E8mTjr9ZPTznGN2cd6iv9kZYjojrcZfbSzbmiVk/H0HlLXxzwQeKypFglt3sz47MZ5lMxT6Yy1bQUqYQ2VDggKBSf0UeRSoLlu4d6gyUqPXbb/jKZQHFpHUKVbcp55BJH3FZMefDkyHmI8uO6+ycONtuBSkf9QByP1qK2LSz8a6R5UxqIlLXnFJS0SQ0p51Ck7cj0CVDPFVaX05Ltsu3+ZYYCYLKmg+mQpanScDO3AABxuOSecfWlQXLeT72zFlqjNRpct9tIW4mM1u6YPbJJAz8hk/Krqb1bTDjylzWGmZBw0p1Yb3H8uFYOfTHesFcW52+63CRbmI0pmapLqkuvFpTbgQlHolWUkJT8wc981q2dPT4LvmEsQri68w4h1p9ZQhta3VuKKfhVlJK8H1wlNKEpeuENmU1Felx25LvLbSnAFr+gzk1jRr3BfluRS+01JQ6plLTi0hbhSASUjOSOaj72nZ3QnRUsQVJm9ImQFFJjlKEIOxJBJxs3J+Luf1J/T01blzaEaFsmzkShK3nqNpTs5xt5UNnHOOflyqDmlLc+G7MciNy465TYytlLgK0j3Ke4q7IfZjMLekutssoGVLcUEpSPck9qisCwTWHLeypqKluFKck+aQs9V7dv4I28E7/iOT2+fGwusSZdbZbHzHablsPNynIbjmUKISQUFQHoVZBx3SKUNk3cojrjIZeQ6h5tTqHUKCkFKSATuHH+IV9j3OBJirkx5sZ2MgkKdQ6lSE475IOK0kuySZ+nLlEcYhwpEpalJRHJKcZScKVgZ3bfiIHY+vc4KNNyXW5rkiEy2t0sbW0zFlR6ZJ3FW3GQTwNvOOTzwLlvZepbPElQo79xioXMBUyS8kBQHrnPr2Huazn5iWJKW3U7Wukp1TylpCUBJHfJz698Y45I4qNRLHc45tb6kxH3oz7xUlxQQemvsdyEYKhx/hGff1N/VtilXdb5jFoBdslQxvUR8bhb2+nb4TmnI5thP1JZ4MQyX7jE6IfTHKg8kgLUoDB54xnJ9gCavO3u3NuwmxLYWuYf4AS6k7xjO4c8j6Vprpp59x+W5BbipSW4ZabUdqVLZeUsg4BwCCBnB+lYV003PlzZzhjRnEz0tbsylpTHKUhJSAEgqAxuBBSck9u9KguUsducBmV5V6bGbk43dJTqQvHvjOcUXc4CEPKXNjJSyMukupAb5I+LnjkEc+1c91AlKJFwtcdy3SH5VwaeCFhXmgrcg42Y5SAOF5wE/St07pZ9NtbDTbCpKLm9OWgOFAeSpbm0FWDyErSex5T+tKLSk3GCIzcgzIwjucod6qdqvoc4NX1PNJd6SnEBzbv2FQzt98e3zqK23TbiXrc7KjRkhmU9JU0HFOhJUjaCCRyfU4AGSfrWxu0Gaq7omwUMu5iORlJcWUbSVJIV2ORwcig2KrnAStlCp0ULex0kl1OXMjI2885HtVQnw1TjCEuOZgG4sBwdQD325ziok3pOSLHNjrTGM12DGjtuZ/CtpGM5xkDdyKrh6bls3ZBcZZWymc5M8yZCt2FKUoAIA7/Ft/FjA+eKVBcpnSlKilKUoFKUoFKVA9VX64R7vNbjpS21bkNvIC1ISl4qB/ES4k7f8IwlXIzzwKsRaTNJ5SoNe9R3GMzeZTUqHHEB5DCIjreVL3JQdxOQcnccYGPh+2cu/PFqC2tbJdkXKREWjHPTR1scenCEc/P50otK6Vz213ya5HYYjzLdbGGbNGmpStrI3KC8j8QwgbR8+aHVt2edU8hhEZDXl8x3emN/UQhRBKnAoHKykYSeU+vYKLdCpWj1BPks3C1wor7UUS1ObpDiNwG0AhCQSBuOfsk1GoNwlwtMzbwy+3IdEp6OAj+6yqUUl3BUBgA55OMeuOaUW6DSoN/aO6R7bPeUG5L0N9pKGgEdSRuHLWG1KAXzkHPtkAZNX03qfJk2yMi5wGBJgrlrf6W4FQUPhSCRwATnPPw+nootMqVzh/WF2cZU60lhkMQ25JJCNj5UVc5W4khB28bQTz+hzNRT7vKtOqVtS0Q48Fna2G28ubiyhZyrPGNx7D/alFp3SoZcr7NhKbcZnx5NvbaS45JabQ6TlZB3JCwQnAABSDzn2xW11FKXFuERTLcZTyY0lxtb52hKkpSRlXok+vypRbfUqEN367qjuMhTZnJdaCkLabQpKFpUfg/ilCz8PA3A4BPPGbsbUz5iSXnXmtrdvcfStTXTy6ha0q43HttTnBI54OCKUWmVKhkXUFxVcYfmlsoiPKZbBbaSsKUttJwohe5CtxOPhIxj9M693KWm8vQmJsWC0xD80VPo3dUlShjuMJTtGcc/EO3qotJaVy63amucayQ0RktttQ7dEcAc6eHippJOSpaVAZ+EbUnkHv2qTovU9Oo0sSVNIhuSCw0G20uBXwbsFQXuSrIPdOMD9aUWlWBnOOfelRO8XeajUM+CxcYUFmNBblBT7e4qUVOA55HwjaM+vNYlkvEhc1MlbYjifMYDzbn/ALMKhhe35HcAKUWm9KgkjU1zWy6/Gcj+WadlBbiEJcUEtubUnaVpynAOSMntWfq2SsnTLzEhphTs4YddSdoCmHfTI554B9cUotLKVAXtS3UShb21tOFMh5ozmkNgOBCG1AALWlO7+IQeT/dq49sa5z37jbFSpHTDy7Q9uLRBSrDqRuGCRzjPBPfue9KLdHpUGd1Lcxe3kJQ2iO1PRDDC+mN6SUjdkr37jncMJxjH1Gws15nvX3y09bQbd63RS02lSFBCuCFhZOcEZCkjn2pRaU0pSopSlKBWPIhRZLzT0iMw680ctrW2FKQfkT2rIrBkXe3x5qIb8xhEpZADalDOT2+mfT3oLN9ssW7RH23G2kPuN9MSOmCtIz2B71meQieZVI8qx5hRBLvTG44GBz37EisZq+Wx2W5GbnMF9vduTu7bfxc9jj19vWsV/UkHyfmILqJeH2GVJSrBHVcSgK7duSR74q805LxsFuVPXKdjNOlTbTSW1tpKGw2VlJSMcH4z9hWa7BiPSW5LsZhchr8DqmwVI+h7isdF6tq7iYCJjJlglPTCudwGSn2yBzjvWWqQymSmOpxIfUguBHqUggE/cj71FfJUWPMa6Uthp9rIOx1AUMjtwa+pjspZU0llsNKzuQEjac98j51rXtSWZkNl24x0720vJyr/AAK7KPsn5nisn98W7z4g+dY82TgNbxnOM4+uOcd8UF2Pb4cZttuPEjtNtqK0JQ2EhKjwSAOx5P3rFkWK3yJiX5EZp1IbKOkttKm+VbirBHfPr8zVyZcehLTEYYXIkqaU9sQoDCQoDkk8Zzx9DWpb1SPJsy5MFyLGckmP1HnUcEFSSeCfVH65qpyb1+BEkLZXIisOrZOWlLbCig/5c9v0q6lptJcKUJBcOV4H4jjHPvwAK1zmobS3EalKnMhl1SkoOclRT+IY78YOfb1q3IvY85HjwIq5xeYMlK2nEBOzIAOSec59Kg2DkCI4tlbkVhS2f7tSmwSj/p9v0q6tptakqWhKlJBAJGSAe9YCr3AbltxJElpmYraCypQJSpXZJI4BPoPX0qzK1BCbkJYjOtyHxIRHdQhfLRUopyf1B4oM1NsgJjLjJhRRHWcqaDSdqj7kYwaqct8N1DKHYkdaWf7sKbBCPTjjj9KusSGZAWWHUOBCihRQc4UO4+orSvakbZuT0dyG+GGZTcNUjcnaHFpSpPGc4+NIzj/Sg2wgxEyESExWA+hOxLgbG5I9ge4FfZMONJU2qTHZeU0dyC4gKKD7jPasOPf7VJQpbE5laUlCSQePjVtSfoTwD2NUXG9txZTMWMyuZKcd6JbbUkbD0yv4iSB+Ef6igzF26EtbC1w46lxxhlRaSS3/ANPHH6VWIcUS/NCOz5nG3rbBvx7bu9ae56kRaokmTcoxZQwyl1TaXAt3JUoAbRxj4eDn39q3UWQ1KjpeYUVNq7EpI/0PNFYT1kgyLm9OlMIkOuNto2uoStKNhWQUgjg/GefpWW/DjPtutvx2XG3SC4laAQvGMZB79h9q06tSpEdUxNvlqtaVEGYNm3aDgubd27Z88ducY5rPVercm4CCqYyJRIT0887iMhPtnHOO9XmnJdctsFxCEOQoykIVvSlTSSEq9xxwavvx2ZCQmQy26kZwFpCgMgg9/kSP1rXDUNpU84yicyt1vfuQk5OUZ3DjuRg5HerELVNqlWiNcFSOiy+E7UupIVkp3bQMcnHtmlScmydt0F2ImK7DjLip7MqaSUD/AMuMVcVFjqTtUw0U7OngoH4fy/TjtWOzdI78qK0woOoksqfaeQQUKCSkHn/zCs6orHVCiKmJlqjMGUkbUvFsbwPYK719ahxWZDj7Mdlt9z8biUAKV9T3NX6UClKUClKUCo7cbJKevYmRHG44W40txxDjiVKCCMpUjOxeQCMnBAPrgVIqUEVj2K6x4SbczKhNxGEOhh4s73cqSoJJB4GN3JH4semTWMjS9wVKdedfZ/jeUKkl1xwpLD3U4Ku4UCfbBx9amdKtpSIQtLSY91QS80uC3LcmJJedKyVKUrbs3bBgqPxew7c5rZzLVKRcY0y3OoUtDLjCxKWpXCyg7geSSCjt657it5SllIFbrFd4ciVDiiIpP7siwlvSG1bSUhwFScD4sZ/CcdxyK2kTTcmFcoy4j6WozSkKcUl1e54JQE4U2fgycD4+/HapTSllNT0HG9V+Y2KLL0MN7gOEqQsnB+oX/wC6axmrG4mDBYWttRjzlyzwcEFa1AD5jcPtW/pUKQ6dpaWbi5PiPNF4uvENqedZTscDf+Jsg5Bb7cg5rKh6UjIegGczEltRohY2uNbhvKgoqAVnA4PrmpPSrZSMS9Py3FzozL0ZNunPofcJSeq3gIBSnHB/AMH0+dfZemVyba5F6/RLtxMxbjJKVFJXuwD3CsYGak1KWU0thgTrSzFt+Y7sBhK0Jc5Dm0FPTBHbONwJ9cA+pqhnT7SLheJxbjedlu72JBaCltfwUNjk/NJOPnW9pUspCjYJUePKcuKlSG3oXlXER1uOubgfhWjPbkk4GAnA796v27TTsm32hV8THkykvqmTUuthSVuKbUnAHI+HKQPkmpdSrZSN3TTQlJuTUVbMViTBREaShHDZSpas7RgY+McfWtvB/eIeUid5ZTQaRhxkFJK8q3DaScDG3HPqazaVCkHn6dvzdubtlvlxV2tCFRyhW5Lio6sAo9RvA4C+PmOa2C9Oyip6Ih9gW12aJylFJ6yVBYc2D0/Env6DjHrUopVspHYen3WG4CS43mPcJExZAPxJc62B9R1R9jWPDsNzgsWpTUmG9JtrS4zYU2pCFtKCBzySF/Ak5HHcY9alVKWUi8e2S4UiEwwUuPttypCnigpaDrigQn/pypXGc4TUma39JHV29TA3be2fXFVUqKUpSgUpSgUpSgUpVlqS06+6y2vLjWN4weM9q8znjjMRM9fUsRMr1KUr0hSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBSlKBWotf8A33dfq3/sa29ai1/993X6t/7GuDd99oeqfZk10+zn5fMNvSlK72QCCMggj3FUtOIdbS40tK0KGUqScgj3BqMW63XCMqKh1p9W0I2rblbENAH4gpOfiJ59DnOMpxmsiSbg3pKU04l1ua1EwHUrypS9vJBHqDQSGlRJ+BdClYjty0MLdThtcsqWnCFAq3bx8JO3jJ7Zxzir1sjXZF0huSUSCjppDxceBQkhvBwEr5O4ZwUnuTu9KCSrcQ2Uha0p3HanJxk+wqqotOttyeuKVth4rTKLofU//CS3sISAjPcEj09zn0rK05DuEZEjzJfSVNpSkSHur/EGcqHJ4PHqM+w9Q3rjiGm1OOKShCRlSlHAA+dVVpZ37wZ09N6y1OzFIKWiwkqOSMDGB7+v68Dga6VEvTiHmGg+nCpJS8HwNwWrLYHOfhBxyBjHHFBKS4hLiWytIWoEpSTyQO+B+o+9VVGHbbdUPyW4zr3ldy+lukEqKSlnjcSSCSHQD6Z+lfYduuC5iXHFTGIgDqm2VytykEhsJ3EE55CyBkgZ/Sgk1K0Fphz1WqbHkmQw4vKWnHHSpY+H8XC1Y59iPoKwJcC9yGGHXDIDzocU40xJCeis42c5AKQBzjPJJwc0EuqlLiFOLQlaStGNyQeRntmow7a7qG3XGn3/ADLjjySTIO0NkHZgZwDnbggZGaoiQrjFuDspmJL6C3E/wVyUrc2htSeSVYwFEHGT7/KgllKi9ph3Zi4wFSg+tAZQH1LfyhJDWDgBXJ3D1Se5O70q5IhXNciYGeul9fVLcnzOGgCkhCenzyDj0HbOT2oJJSos1a50h9AX56NCJUS0qYS4DswCVBROCeQM+mfXFUx7TdAxFbcelHe3HMo+ZOd4J6mDnjI/Lx7UErpUTFpuzUUiPIk9dQkIJcklXwb/AOFjJODtAGe/PNZcSFcU2Sc0FSW3nFZaS8+FOJTgZG4E7ScKx8RxnPHYBv0uIUtaErSVIxuAPKc+9VVDV2u5dSQ40zNbjOPpV0RKHWKemE/i39grJxu9flis22Q7qxd46pPXdaDYDrjj+UA9MD4QCMncPVHqTn0oJLSlKBSlKBSlKBWotf8A33dfq3/sa2+a09rP/O7r9W/9jXBu++0PVPsya6fZz8vmG4pTNfCeDiu9k+0qFos916HSUp/opdQpY8xl10BKwRk/CRkoOcJJwcjtWUxZrg2EOKedU+2qNsK5BVhCVDqA9gcpJGcc8UEobWlxtK21BSFDII7EVVUVZtdzSWOqpS3wGSJHXOGglIC0FP8Ai3EK59d3P4RXxFonMJtQaLzi2kNh4rkkpKtwK1HkHPfGMj0IxQSuqStAWlBUkLUCQnPJA7/7isN9E3z6XGXUeVSn4mj3UcK+XHdPr6VgXa2P3GbBlIIjvR2XCheclt0lBH1GAoH3BoN4hSVpCkKCkn1BzX2oi3abn5eOHUjq9FKUlt8hMZ3epSlem4EFPp/hx2Jqp23XV1tLS+qlLTK2ypuQApw9VCgR/wCVJ4OO5HHegllW0vtqkOMJVl1CUqUnHYHOP9j9q0ZhTlWWE04jctp3c8wl4jqI+LCdxJ55ScZxxjOKxxZpXXEkBTbyRHCB5hStoS6pSwSe/wACsc/SglFW5DzcZhx55W1ptJUpWOwHeojEsVy2BEmRJKlFsSF+ZwHsOAqUkAAjIz6g849AayJdomvNz2dhUt1LwTIMkgKSoEIRs9MZA/TPcmglVKi79olNyHA2hb8ELUURxJUg5LaAFbs54UF8f5s9xVH7luIRvVIcXKKylbiZBTlvy5Tx3A/iYPb50EoedbZbU46tKEJ7qUcAVUlSVDKSCM4yDUcjW6crT8yI6nDq3AWt7mVFPw/i5IByD249eCTVNwtEpd4Q7GW+mOChSOm+EpQd5U5kEHO7Pp37HA5oJNSomxark2ziRvfR1w6WRIIJa2qAaz/lJBz/AIq+m0XFVwYdLj6Up6WzZKyloJ/Gk5TlWeefXPOMA0EmjyWJIJjvNuAAE7FA8EZB/UVdqGJsVwRFZQSoIT0Q4hl0JUsJaKSMng4Vg4PtWSxZbghHUVIdMpCmA2tT5VtSEgLz2B/xenPFBKqVEV2m4LhNtoQ6yErbL6Uyt6nwkKCiCrgZJSecZxg4qQ2dh2LbWGX1rW4gYJWvecZ4BVgZwOKDNpTNM0ClM0oFKUoLe4Vp7Yr/AJ3dfq3/ALGtgV/OtRbHP+d3X6t/7GuHd99oeqfZk20+zn5fMN9upurH6g96+FfHeu5iyd1UrdSgArUlIJAGTjk9hUGfs81qOwnppUre0h8odUfNELBUtfHw8A57/ix2FVTNPzXmkIbcDTSeqW2UPYSwVEbSCUHtg9sEZwOKCc7qtrktIUUqWncNuQOSNxwOPmaicmySFRXEAtuuuyXHXFOLJyk7tncEcZHGMD05oxZpDb6H+nGEpTUZLsgK/iEtrBXzjkKHz9KCYbqbqhjdilFKEOFtI+ASFpdVmUQ4lRWoY4OArjn8WOwr6bC/h74kZbQsRPjVhpXVWpBHthJSP0I7UEvfkNsN73lpQjIGT7k4H+pFGJDb7YcZWFoJIyPkcH/UVC0WCcJLzqn9xW5uUVOAhz+MlYyAgHhIIGScdhxRywTlSWFl/CWx8GxwDpq6qlFQygnlKgOCO2OxoJvuq0uYwhhTynUdJJKSvOQCDgj78VGb1aZU68tSW3lBpCWwjCwOmQslRAKT3BA4IzjB4r6xZjHss2DHYisl19TiVN8BQLm4bsDggHHr2oJVupuqL2q3zY18dluloMuhwLCF53ErBSe2TgDHJOM8YFY7lqmdOSlDUfqu5C3i8vLwLgPxDGOE5AzkenbNBMN1N1QJuzzQpqNJZRJQhqRsCnVJQkqcBRyE4BSCQMDjHGKyHbNdFS1OIktocU2poyAr4jlraFEYzkK5xnH60RMnH0NlIWoJ3Zxn5DNOu38Hxo+P8HP4uM8e9RZNoccbS0Y8ePGJUHGUuqcSrLZTkggDuQe3pk81iI0/KTIhrb6cdDCWglDDgCWylRKyBsz8Q74Iz2NFTbqp37Nyd+M7c8496+7qi9ygTX76xMZ6QQ0tGDvwooGdw7H39CM+tXZUF9y7mQENOAqQW3lOqSplI/EkJHfPJ7855yBQSPdTdULZsMkhhDwaS2C35gJdUrzJSTuWrjufb1zz2FWZljkxLU95XPWLb7aum4oqUlTgLQ9/hSMfL0oJ1upuqJx7M4JjK1NtsREP9Xy7bqikYRgHsO6sHHbjPesKFp2agbZMgublI65LvD+HAoqICQeQCOSe+O1BNn322GVuvKCG0JKlKPYAdzVzcKg03T8t2HJYwy6FNOtRgt1SRHy4spI4/IpA+W3HY1kTLE+8wsBeVOTFPOp6n42/i2p+JKhxkHGMcUEx3Cqga1dpaci22NHecLjrbYSpSlbiT9cDP1xWaFUGRmmatpVVWaB0kflH2qhEVhDi3ENIC143EDk4q9SpMRNTP8FqOk3+RP2p0m/yJ+1V18UtKPxKA+tW6FPSb/In7U6Tf5E/aqwQRkHIpQUdJv8AIn7U6Tf5E/aq6UFHSb/In7U6Tf5E/aq6UFHSb/In7U6Tf5E/aq6UFHSb/In7U6Tf5E/aq6UFHSb/ACJ+1Ok3+RP2qulBR0m/yJ+1Ok3+RP2qulBR0m/yJ+1Ok3+RP2qulBR0m/yJ+1Ok3+RP2qulBR0m/wAiftTpN/kT9qrpQUdJv8iftTpN/kT9qrpQUdJv8iftTpI/IPtVdKCnpo/KPtXxTSSOBg1XSgxeUqIPcVXmqJBw8PpXzNBl0pSgVENSvPea3EKDfZJ/3/8A99Kl9WpEdqQ3sfQFp9jXB9S2eW80J0sMuGW+31Y0c4ymLhGFSpL2ibw6grS8mM70unwQQg4xj1zUKtKNTabsCbq7I6bM1EVopdddl+Wz+N9QVgjggbRwK68yy2w2G2kBCB2AqzHnQ5S+nHksuqwVbULBOASkn7giuja6eelo44amXFlEc5/Ms9TKMs5nGKhywa31IiTYi602qNIcKHC3FVvkJ6xQFpSSMApwrAJIznGKx3Ne6jag3h+WhMdbJIaaEUrU051SlLZGeQUjJUcYwT2rsmB7UxW7whEy/wB0haFt17Qtq4ONlC5ojsKHUQSQrYk8ggkfXFaORqvVEWfBjyUMJlFEdXlBFWoyeofj2rBwnpjv9PnXU6pWpCCnepKSTgZOMn2oIH4calu95mXaPeEJUuPhTammShHJUNuSc54HBANRqPr+/lbgcWwtxEdEl5hMRSVRv+0oQtB5+Lagk5/Wux4FYxgRTcROLKfNhoshz12E5x96DlV011qTqg2+O2I6pclDTrkdWHUoWkNo9xuSSc9z6CrN91ZqdxWqYSFlhUdpxyOuPHJLSUOJGCScglJPpg8kHArsmKYHtQchf1ReoCZQafSyy5LdxOdjOOpVtZbUhIRnjeSfl+tZkXVeqXZjTr0dplkyGY64qo6ipO9jeVbs54Vx2rqRAPcVb67PmPL9RHX27+nn4tucZx7ZoIJ4d6out3td2cvKN0iIAoKaYIQrKScJ5yojHYgEcZrE8Or3cblar+1JCihlvrR3NhQr+IlSinuexHYHjtXSsAUAA7UHIWHptijaQu8iVcpCHozkmWypSlYKIXCcfNQzg/4jWw8K59/jz7hA1JHn9eU0LiyZBBG48ONpIJASDtwOO5rp1KCPfvi9f/ll/wD/ALbP/wBa0mvpL/U0+bmqbBszri/P+WWrchWz4EqUjnbu7kfKp5VlMqO44tpLzSnEq2KSFAkKxnGPfHNByW2akvcCNGaEl9m1rekLiypkVyQ4+2FpDbZAwrJBUQTyQBVF/wBWaiks3uK2ClXQlpMdmOtDsQNj+G5vz8W/2HvxXXnX2WltIdcQhbqtraVEAqOM4HucCruB3xQcjb1jf24XSXIaTEEpLP72VCXtQOhvKS3nJO/4M5/1rceHt3vl11BclXpxUcu2+I+1EU0UhtSgrcU5+fcd+R7VP477MpkOx3G3WlZwpBBBwcHn61dxQcsOrtTeRlrfYbiJiPtwJElUdSkpc3q3vhIPKAnZgf5u/FWla6vzNu6khhPVciLVGWIywJDiX9gUB6Ao+LFdYIB7iqd6OoEbk78ZCc8496CA6R1NeJ2trja7khBioC1NFpkgICVADconIJB9Rz6GugUwKUGHLP8AGH0qnNfZn9+PpVFBsKUpQUuBRbUEHCscH51x+LYdbi0XBrrzE3NxbYadMkdNLoWSp38ROzbgbcDPHHFdipQcYai6lfv7UFhF0blRosJSlKm5bZXvX1VL5wvcAff07VdTpjVMWMUxmX0N7FBxDL6ULWkzFLUlJzwotnvx7V2LAznAz70oOKwGtWy7RKXbkXF1Sk3GGlC5Y3sOdUdIqJPOACARmpPpq1amY1w/Kub0gwSVnPV3NLbKUhCdu7hQIPISPXk5roYAHYAUoOZybHqtNyly4MmSh52TMSjqSctpaLf8E7M4Hx/LIrVN6a1E+YL78a5iPHnMPJjvTgt0EIUHF7t2NpUQcZ9+Oa7DSg5DK01q5u32Xoybgp8oWqV/2rcpt8qG1RysApCR25HyOa3niPB1NMlW8WBt8hpvcXWZGzDgUnIKdwGCkHkg98YHeuhUoOFzzqVUDUNxiu3JpuMu4pW+qUShaQohpDaM5SUqGc47evNSG02HUcuXE8wu5RrUqaXVNLm7nUt+XwdygrJSp3kDP2rqW1OCMDB7jFfaDj7dk1qWpYCpyXS2RLUqaCJSusk5Y5/h/wAMKHp3A+dXpemL9IcVNiMXCJIZgFEULnhbgX19wStQPPw+hyPTJrrVKDmloY1PZ9Q3S5XNEuVGBcw2hwKQ8FOJ6YSkqOClOf8ACPXvWZ4gW/UUm/WiVYRJW01jqNpf2NZ3gkqwoHtnn4vbFT+lByCdaNbSLleVsImR230rSjZLyMh9BSpOV8fw93YJ9qqvtg1c0jp2tdwdbYnvqjIMvIU0Q2UbzvCsAheDk4yeDXXaUHNvEkXeRfLVDtqZy1uwZBLcST0QHRs2KUcjIBNax/S+pV3qNNdS64+1LWpLqHwlI3RUoDhGe3UByO+PSuuYGc4GfelByWJpa9Tm7Q1PjXJlMeUHJDjtw3qUeitKloIOUpKiOAfXsK3ku3ahd0PYI7/mnZrK2jcGmpAQ66kAggLz3ztJ55wan1KDjlg0zq6A/YWleZZjMBG5Lb4IaPXWpzeNwCtyCkZwr9Kl+pbTfZOqoSrZKdRaZIR53DuOkWiVJ2jP+PO049BU0pQcitGntYmOpq4SJwUuVH8wUycBYC1FxaDvJAKSOOPTjirMjS2q0u9djzZmiA/FbeVLyUjrlSQfi7lvgH3xnFdjpQRXQjV2g25qJdWJKtynHA484lRaTuG1s/Eongkjk9u9SqlKDCmf34+lUVcl8vj6VSE0GbuHuK+BaSSAoZHfmtWW61FtR/zq6fVH+xrDV1v088MK7U1/Uz8PeOPFEz+P9Szcn3H3puT7j71qOnTp1u8NvuT7j703J9x960cZxqSlSmFb0pUUE4OMjv8AWrvToNvuT7j703J9x961HTp06Db7k+4+9NyfcfetR06pAQpakBSStOCpIPIz2zQbncn3H3puT7j71opLrUZAW+vaCdo4JJPsAKvFGBk0G33J9x96bk+4+9ajp06dBt9yfcfem5PuPvWmbCHE7m1JUMkZSc8g4I+9PgLhb3J6gG4pzyB74/Q0G36re/bvTu9s81VuT7j71qOnVtC2luFCHW1LGcpCgTwcHj60G73J9x96bk+4+9ajp1S3sdQFtKStB7KScg0G53J9x96FaQMlQH61pG1tOKKW3W1qHJCVAkckf7gj9KudOg2+5PuPvTcn3H3rUdOnToNvuT7j703J9x960ydilFKVpKh3ANVdOg2+5PuPvX0c9q0/TrJjOKaO08pP+lBn1Qt1CByRn2FY0h0r+FP4f96tpRQfclxZUfWrmKITVzbQWyj5Vp7Yj/nV0+rf+xrf7RWptrZF6uiiCASjBI78GuHd99oeqfbk10+zn5fMM7ZXxTYUkg5wRjg4rJ2im0V3MkGfs9zjQGGLeiTvSHV5EonCyrKc5WOMfUe4Her4YuDkqawBJTMwtfV8zhvYonYlKckBQAAzgYIzk55mW0U2ighrdpuD72FmdHh4cKWlSyXEnagJyoKJPIUQMnH64qldsvZaLzT7qJq1rTlb2W0JMcgHbnH97g9s/pU02im0UEOttruJkRi+qa3GS7vWhyTlRwg9yFKO0qxxn07Dmrt6t1wcmvOww70Vqa3hpwIW4lKXMgHcnHxKQe44BqWbRTaKCMu2l+TCtCJJeU7HeC3CH1JIG1Q5IIyeQPWsCRbLpNZ8vIakJbaZWkqMnaHV9RJSRtVnlIPfGM1NdoptFBDZMS8KQpiMzJbSFOKS4ZIPwlghKclWSQsjv6jOa2M6BJTbYbMcyXEtuJL6UvkOuJwcgLJHO4pPccAipDtFNooIG3aLy2ltKfMpRlwoSiQAW1F5agpZ3fENpR6K7Hjmtne4E1c116I04pC2mmyW3NquFqKsfEn0I9R+vapTtFNooIumJcVWGK08l/rtuDrJbeAccQCfwrz68Hkg4zWAza7q1FfSlMlCVFxaUpeSV8vBSQTuGTtyD8Q+vrU32im0UEQiwrn1YqpLEr8KAnZLwlrCzu3gqO4lOPze2fWsNMO6uPrZUZZkoYZ2KTI2oaWVLypQzhQwBkc9sYHep3tFNooIeLVctxbBdbYU4CrpuhJwZC1K5ByMoIqwq2XoPtguSVNIKktFMj8GHlkKWd3xAo6fcKPByOam+0U2igi15g3J68NORlP+XCEBHTd2JQoKJUVjcMgjb6K7Hgd6rstvnRpbC5Dj60LZd6/Ue3gL3p2YGePh3dv1qTbRTaKCGwtPSo9r2h59L7r4K0oLaChBe3KwtKQrlPuon9atyoN687MLCJCW1tvNoIkZGSn+GoZXx277QQT68mpttFanU14i2CyTbpPXsjRWi4s++OwHzJwB9aCKakkt6bYdl3WY83aELJAVNKFlRQjBCioEgEL+HPrwDiudu+NmnYl5DpmXOWhC0jLKT0yjp4IwopBO7PO0d859K4Tr/Wd01pe3Z9zeV0go9CMFfAwj2A9/c+tRpCHHAoobUoJGTgZxRHujR3iJpjVi0tWi5tKlFOfLOgtufoD3/TNTNIBr8540h2NIbfjOrZfbUFIWhRSpJHYgjsa9gfs/eIrusbI7BuzgVeIAAWvsXmz2Xj39D+h9aK64lNV0HNVYoGKYpSgYpilKBimKUoGKYpSgYpilKBimKUoGKYpSgYpilKBimKUoGKYpSgYpilKBimKUoPhHFcZ/allvR/DUtskhEia005j8uFK/3SK7Oe1QLxj00vVWhblbo4BlbQ8xn1Wg5A/XkfrQeGWUB19ptSghKlBJUewye9dE8UcaK1ybTplv93t2xLRbkt/3z6lNhRWpfcg7iNv4flXO32nGXVtPIU26hRSpKhgpI7git2jU0p9UP99tIuzcNISw3J9EjslS04WUj8u7FESTxlt8Ri46fukWO1FevFpYnyWGkhKEuqBCilI7A4zj3zWz/ZplvRvFSG00TskR3m3APyhO4f6pFc+1JfZ+pLu7crq4FyFgJASkJShIGEpSkcAAeldu/ZW0q+u5zNSyGymOhsxoxUPxqJBUofIAY/U+1FeoWjlIquqGhhIqugUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVZeb3Cr1CKDiXip4MwNVSHbla3E2+7K5Wrblt4/wCYDsfmP1BrikvwP1sxILbUKNIRnHUbkoCf/eIP+le1FthXcVaMZPsKDy/on9n2Y7Lbf1XKbbjpIJjRVFSl/JSsYA+mf0r0nZLVFtUBiHBYQxFYSENtoGAkCtghlKfSroGKD6BgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSg/9k="
+            },
+            {
+              "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAYCAwQFBwgBCf/EAEsQAAEDAwMCBAMFBQUGAwYHAAECAwQABREGEiETMQcUQVEiYXEjMoGRoQgVQlOSFjNSYrEXJCU1coI0N4MYQ6Kys9Enc3R1wfDx/8QAGQEBAQEBAQEAAAAAAAAAAAAAAAEDBAIF/8QALREBAAIBAgELAwUAAAAAAAAAAAERAgMEIRIUMTIzQVJxcrLBEyJCUZGh0fD/2gAMAwEAAhEDEQA/APVNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFK+KUEpKlEBIGST2FR5rXGlXrh5FrUVpXLztDSZSCSfbv3+VBIqUJAGSePeo6dcaWTP8AJHUVpEvO3pebRuz7d+/yoJFSgIIBByD61qrzqG12VaE3WV5RC8YedbUGh9XMbR+JoNrSoF41yv8A8JL/ACYb/BjpUh1pfcFSeQRW2Or9PWaJAjXe+W6HKUy39m/ISlXKRyQTxQSelW40hmUwh+M628y4NyHG1BSVD3BHetLd9Y6bs8sRbrfbZEk5x0npKEqH1BPH40G+pVqJJYmR0SIjzb7DgyhxtQUlQ9wR3q7QKUpQKUpQKUpQKUpQKUpQKUr4tW1JNAKgnuQK+BxB7KFau5XGJb2DIuMpmMzkJ6jywhOT2GTWBD1LY5slEeHeLe/IcOENtyEKUr6AGgktKsR1k/Cfwq/QKUpQKUpQc38cH3l2ex2hLy48S8XViDLcQdp6KiSpOfTOMVI5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvn3rM1dp2DqqxP2u5pV0XMKStBwtpY5StJ9CDUPd0XrOTCNsla8Wq2qT01rRb0JkqR2I6m7vj1xmgghvtyf8D4cFU10ocvAsip6VYUuN1Snfn5pG3NdcRoHSqbH+6RYrf5LZswWU7u2M7u+755zVb2ibI7okaVMYi0paDSUg/Ekg5Cwf8AFu5z71Gk6J1oiJ+7k6/d/doT0wo29Bk7O2Ornvj1xmg03iDKk6E8FDH07eHpZbdTDROUsKWy2pZBG4eqR8IPcV0XT+nLZb9OItzbQkR3mQl9bx6ipGRypZP3ic1bt2jbJC0enTIiJetPTLa23viLmTkqUf8AETzn3rFVp66Wyyiz6YnpjRtnTRImrVIcjp7YQnjOPTco4oOKx33Y/hF4oWBLq3rdZpy48Najna31B8Gflj9a7PonSlmh6TiNmLGnKlx0OSZLyA4qUpSQSpRPcHPA9BWvHhnAj+Gs7SUCS4350FT8xxO9bjhUCVqHGc4xRvR2o7TE8hpfVLcK2hO1tmVBEhUceobVuHHsFZxQRTT8t7SH+1G1WQlUCztecgtfeDC1tKWpA+QIzipT4WaSsbOhrbJXDizpVxjpky5T7aXFvrcG5WSRyMntW60Xo6HpmzyohdcnyZzinp0qQAVyVq7lXyxwBUdhaC1Dp9DkLSGrfI2cqUpqJLhJkmPk5IQokHHsDmgseHzLdg8T9WabtY2WZDLE5tgHKY7i8hSU+wPfFdQqM6I0ixpdmY4uW/cLpOc60yc/995XoMDgJA4AHapNQKUpQKUpQKUpQKUpQKUpQKofGWjVdDzQR3UYkm2nyQnF7cP/AAXR6mP/AFfhx+taKypu/wC9GPNDUXRyd3mhB6fY/e6fx/lU2WyQfh5FUhpZP3aD6wPtBWVVDTYQPnVdApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAoeO9KhWrrk6uYqI2opabA3AH7xIzRlrasaWPKlMDIZH/vUf1U8yz/NR/VXDNVarhaaehNzmZLhl79hZSk7dpSDnKgf4h2yaruOpo0HUUKzGNKdlSmw6lTYRsSkq25O5QPHfABOKluSN5lPHku4eZZ/mo/qp5ln+aj+quCXLW9sgahNncamLkJW2hxxtsFttSxlIJzntzwDV+76sg2vUUOzSGZSpMpKFIW2lJQN6ikZ+LPdJ7A0teeZ+B3TzLP8ANR/VTzLP81H9VcPa1PCc1EbMlqR5oOLb3FKdmUtoWec57LHp3zS26kan6hm2hNvuLL0QblvPNJDRGSEkEKJwrBI45ANLTnmXhdw8yz/NR/VTzLP81H9VcMtGqYt0k3ZmPGlJFtW4284sI2qUgkEJAUT6cZArE0vru06kuLcK3Jkh5UYyT1EpASAraUnCj8Xr7Y9aWvO8+P2dDv3mWf5qP6qeZZ/mo/qrhVr1ZDuTd3cZjS0NWwuJdUsI+MozkJAUT/Ce4FfdP6tgX+HMkW1mU4IraVqRsG5RUkq2pGfvcYxxzSyd5nH4u6eZZ/mo/qq4lSVjKSCPcVw/S+oGtQxXn2IU6KhpwtHzTaUFSgcHGCexBBqUWm4vW+Uhbaj08/GjPBFLI3tZVljTpNKA5AI9aVXeUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVCtXW11ExUxtJU04BuI/hIGKmtDz3oy1tKNXHky4peLDbby7HcuUbrOR93SVvUkoyQSQQRz8I5+VUXDTtruF0iXKZF6k2Jt6LvUUNu1W4cA4PPPNdpMZg92W/wCkU8qx/Jb/AKRUpyRsso6MnEpul7LOu7d0lW9pycgpUHST3T90kZwSPmKvTbBbZ11YuUmNvnMBKW3gtSSkJJIHB7ZUfrnmuz+VY/kt/wBIp5Vj+S3/AEilHMsvG42iyW5F4XdUxUiesEF3J9QATjOAcADOM4FZDUGOzPkTW28SZCUIdXk/EEZ2jHbjcfzrrnlWP5Lf9Ip5Vj+S3/SKUnMcp/JxWBpu0wJs6XEidORO3eYV1FHfuOTwTgZPtiqbXpezWuY1Kt8FDEhpnoJWlSvuex557Dk88V2zyrH8lv8ApFPKsfyW/wCkUpeZZ+NxODpm0QV3BcWJ01XAKEn7RZ6m7Oe547ntir9nsdusxfNsipj9bb1Nqid20bR3PtXZfKsfyW/6RTyrH8lv+kUonZZT05uR2+DHt7CmYbfTbU4t0jJOVKUVKPPuSa3Fotz1wlIQ2k9MH41+gFdE8qx/Jb/pFXEpSgYSAB7ClGOx43llb6BgAD0pSlV9ApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArjviP44xtE6sk2N2xvTFsIQsvJkhAO5IV22n3rsVeLP2mf/ADeun/5LH/0k0HTWf2nLcXEh/TUtDfqpElKiPwKR/rXadF6qtesbC1drK6pcZZKVJWNq21DulQ9DXjF8StbWLTto0zpx1ybaWFolPsIBU+VqBSVYHYY7n3NTmdK1P4N+F0W2b0wrzfJjr5KSFqjtIQhJAPYKJI5GcfXsR6yqG+K51aNJr/sH0/3t1E7s7d3Twc7N3w7s47+mfWvHIuOslwBeRe55bUrAV+8/tVHOMhvfvIz64xXRZutNW3LwSujd+/eLEmJLjeXnrQtlTyFFWU7uNxGO/wA+aDrfgerxHUqd/tAB8lsHl+uEB7fnn7n8OM/e5zjFdYrwtobxJveljd5LU6RJmPxPLx/MuqcS2ouIJXtJxkJBx9aqif7RdSWq4aljTLzLgxFKMiSmWUhBA3KwncDgAg8DgUHsnXRvydKXA6RSyq97B5cO4xnIz34zjOM8ZrkvhMfF7+2DX9rQ9+5MK8x5rpf4Tt2bec5x24rn+lfE6+3nw11fZbtOeflRYKZMWZuIeCQ6hKklQ5P3hg9+9aTwQ1ZcIOuhNuVwnSokSDLkracfUoKCGVK7E49KD2nSvE6dUeIniZqpz9yy5y5KAX24kSR0W2EBQx3IHBIGTya0eudUase1VPN6mTYNyQUNyGGn1ISlaUJSSADgZxnjjmg96UrwLqrUF5bujIRd7gkGDDVgSVjkxmiT39SSa3PiLO1fDb0tKvF3XtkWph2EIr6wW2toAKu3xnGSeck96FvcNK8e3Txl1KjwzslujXB1FycU8iROz9sptJAQAr0PJyrv8I55NQvz+s40SPdU3q4APKHTKLnueJPYlsL3gfMiive1K8aa51nq+7aE0/8AvgXSHPjyX2/MBC2DJbKWylRxjJByM/T3qC2q4apu1xZgW2feJMx1W1DLchwqJ+maI/QWvJXip4s62sniFfbba72piFGkFDTflmVbRgcZKCT+Jr0L4S2S7ae0FbrdqF8v3NG9bqi6XCNyyoAqPfAIH4V5B8bv/NjU3/6o/wDyig9raNmP3DSFjmzHOpJkwWHnV4A3LU2kk4HA5J7VuK8Wa68StQyWbRp6zT5EG3w4ERjbHWW1POdFG4qUOcZOMZxxWoiXjXum7xH8ndbg7LPxpbjzBMSr5KShSh+B5oPdVMg9jXkLxu1zrCe3YxKRcLLBkQUOKZSFshx7JDmex4I4B9MH1qFaUt+q7ohMnT95/wB6KjtjpuqWpCiPZBWCaFveVKj/AIffvL+xNlF96370EZAk9f7+/HO751IKKUpSgUpSgUpSgV5F/aH0rqG6eKdylWyxXWZFW0yEvR4bjiCQ2kHCgCO9euqUHi3UvhlqSDYNN3mzWe59Z+JslssMr6zLyVKGSgDcAU7fT0PvW0tXhjqnVHhm+t+JPbvNvuC3GY1wSttbzSmmwoJ349UjHpwa9fUoPDsWyeJkO2GxxLRf2IZc3lDURSec5/vAM4zzjOKmGqNMak074IXF7WNxlOS5syOGIb8ku9FKSo+pICjnkD0A/D1lXC/2gPDbUmutRWp2xIjmKxGLbi3nwhIVuJ7ck8fKiOBeGOin9dP3q3wVoTPYg+ZjhZwlag4gFJPpkKPPvitlGsfifYbZO0/Dtd/Zt8skSGGI6ltryMH4gCOQADg8ivRfgh4U/wCz5qXMuEpuVd5aA2otA9NpAOdqSeTk4JOB2H47DxC8XbBoS+NWq8Rrk7IcYTICozSFJ2lSkjkrBzlJ9KDi2l/Ca/WXw11Zc7lBe/ek2EmNFgNJ6j23qoUokJzydo478HNafwQ0Nezrxtm+2K7Q7dIhyY7rz8RxtIC2VJ+8oYzzXqnRWpoWsNNxb3bG324kkrCEvpCVjaspOQCR3SfWsLxC1xaNCWhufei8Uur6bTTKNy3FYzgZwBx6k0HkR7QesdP3jraXEuayolMe5Wd0qS4gnuVIOU/MHGKiOqIT9v1BOiTZaZktpza8+le8Kcx8XxeuDkZ9cVuNL6XumrLjcWdLvpWWEGQpL7ojq6ecFRydvGRn4vWug6E8CJtyu0f+0V2tkeLuyqPGlJefdA5IG3gfXJ+lBCNQaQ1LPmRZMHT93kxlwIex1mE4tCsRmgcKCcHkGp14y6W1BPtOgUQbFdZK41gjsvJZiOLLSwkZSrA4UPY816yisNRYzUeOgNstICEIHZKQMAVcoU8cR/CPUV48Mok6LbJTN2hS30uQpLZacdaIQQpIUBnB3fXPHatNHs/if+7mLLHtWoGYjK8oQiKpoA59XABkc+pxXuClFeXblH8UtE6Ki26J+97hcbqVuyHWUuy1wkJACW0qGQlRyokj5Y7Zrl9tsXiJa5b0q2WrVkOS9/ePMR5Da1855IGTXuiVcYURwIlzIzCyNwS46lJI98E1ejyGZLQdjOtvNngLbUFA/iKCK+Ehuh8ObGb/AOc/efSV1/O7utner727nOMd68t+MOkNSz/E3UMqDp68SYzskqQ6zCcWhYwOQQnBr2lSg8d6/wDCLUrDVpvVlt0mW1JgxlPMNIPWjPBlAUCjv3GeOxyDWDGsfixqS5xk+VvsdxADaXHEKhttj3PCR+Pc17SpQeX9eaf8TtOzWI9pVcb5bRFZDq3EJmIcdCfjJbXuI5zjjtiuYr0NrjUN4U6NKzmJDpGdsDybQPbONqUivd1KDR6Gt0+06Ps9vvEjzFwjxkNvObt2VAe/rjtn1xW8pSgUpSgUpSgUpSgVzfxa8WLb4eqjRXIrk+5yEdRMdCwgIRnG5SsHGSDjj0NdIrxx+1NFks+KTj76VdCREaUwo9ikDaQP+4H86DoT37SkP+zzUpiybrp1+m7DXIIARgkLSvac9sEYGKqjftEPvaXuF3/s22DFlx43S86fi6qHlbs7OMdLtj+L5VwvWWo7He7Pao9m0tHs78RO1+S06VF849eB6gnJyas23/yxv/8A+6wP/pS6I7a3+0x1LXOcVYG2ZqNgjNeZK0uEk7io7RgAD8SRW5k/tBRYGi7VcpVrD15n9RQhtO7UIQlZTuUogkZKeBg9jUF/ZTstsvN41Ai7W+JNQ2w0UCQ0lwJJUrOMjitN+03Zm7N4gsohw24lvchNlhDLYQgYKtwAHGc8n60EuiftOTBIHnNNR1ME9mpRCgPxTg/pUD/aA1PA1fqiz3m1Ffl37U2ChYwptQddBSfmDWJetdadn2W0wmtCWtp6GkJee6q0l7CcHlG08nnkmozq12PIet8mFZm7PGfihaGUPLcC8OLSV5WSRkpIx24+dB0jTvjBdtGeH2m7ZYYTSw31zJflNKKFKLylBCCCOySCf+oV0PU3izZb94SRb5ctNxbooz0wpNvkOYSy4W1q3pVtJ7J44B5PtXMdWpH/ALOehVYGfPyuf/Uc/wDtUPgKP+y69pydou8Egf8Aoyv/ALUHTbXrq1S/DjWqNO6Ii2tflUMOrjvFxRQ7uSVE7M4TjOO30rmPhffZOm9dWu7Qreu5SI5c2xUEgr3NqSewJ4Cie3pU38DWlvaM8Tm2kla1WcgJHc/C5UM8KNSRNI6/tV7uTbzkSKXd6WQCs7mloGASB3UPWg9J+I3j1adK3l+0263uXWZHVsfUHQ22hQ7pzgkkevHFabTH7SdtnXFmPfbM7bmHFBPmG3+slBPqobQcfMZ+led7hIQ1rd+Xc2HFMLmGQtt1vcpSFq3A7cgHIIOM4PvW6uN30dJ1Ap5FiuMuOoJSlDbrUIKPyabQoD+o0Ho7xW8brfoq6C1W+D+9LgEJcd+12NtBQykE4JJIIOPYjmoPav2m3fMpF10435cnlUaQdyR9FDB/MVyPxPiPWnxBkJmwXGkhMdxMZ9ZWen0kYQVfxYA2k/I1s9Va701eZ0R6NoG1RWmW9i20vOI3n/09g/ME0GT+0RqVrVGu2JkRlSYKIDCIzpz9uhQLm/GOMFwpxzyk/SuleAXiDF074YXH9+xHY1ttSwpqSMqMpbq1nYgYAyCMdz35xXKvF9kiNo2S1av3VFfswLUYLU4lH27ysBSuTwtKue26qZmp49w8F7fpiKxLMy3TVTZK9g6XTUVJHOc93E9xQdTkftOoElQjaYUqPnhTkzaoj6BBH61PdOeN2nLvpG6Xp1uRFetiErkQ1YUs7jtTsPZQJIGeMeuK8sabutgi6buMW7w3Xprp+xU1HbKiMfzVklvH+VJqVaOm6STpjUrzul7oqI3FaalP/vEKOFvthISNgSFAjcM/4SPWgmkv9pyaZB8npuOljPAdkqKiPwSAK6X4PeLbfiJOmQlWlcCTGZDxIeDiFDIHsDnmvK8len7Qpu5aZusmTKSrAiXK2NqASe+SVKQcfT8q6t4MeI1tgMalu9w09DjzIEAOrk25roh9JcSkIUgHaFFSk8gDjPtQepKVxXwt8cm9a6rascqzGC7IStTDiHuoCUpKiFDAxwDz8q7VRSlKUClKUClKUClKUCtFq3SVj1bCRF1Bb2pjaDuQVZStB/yqGCK3tKDn73hBot2wM2Y2ophNvmQAh5aVqXgjKlZyeDjBPFWGvBbRLVpk21FufESQ82+4nzTmStsLCTnOezi/zro9KCJaI8PNO6JkSntPRHI7klKUOlby3MgEkfeJx3raao0vZdVQUxL/AG9mayk7kbxhSD7pUOR+Brc0oOaRfA7QEd8Oiylwg52uSXFJ/LdWx1R4UaQ1NMjybpbSVx46YrSWXlNIQ2kkhISkgfxGp1Sgg03wr0pN0vb9PSILyrXAcW6w2JCwUqUSSSrOTyo96wW/BbRLdpkW1FufER95uQ4nzTmSttK0pOc57OL/ADro9KCJaJ8PNOaKdluafhuMKlpSh3e8tzcE5x94n3Naa5+C2hLjPclvWQNuuK3qSy8ttBP/AEg4H4V0alBDNReGOkdQsxG7pZ2lmK0lhpxC1IWEJGAkqBBIAHrmrGmvCbRmnJ7c622ZvzbZy24+4p0oPuAokA/Op1SgjmrtEad1ehsagtbMtbYwh3lDiR7BSSDj5dqjlr8FdB26UiQ1ZEuuIVuSH3luJz/0k4P410alBo9U6TseqrciDfbezKjoOWwcpU2f8qhgj8K0ml/CzSGmZEl612oBclpTDoedU6lTZxlJCiRg4FTelBzN/wADdAPSC6bKpBJzsRJdSn8t1SmLofTUXTjthYs0RNpd5cjlGQs99yj3J4HOc8VI6UHMXvArQDrm/wDc7iP8qJToH/zVKbNoTTNmssq02+zxWoMtOyQggqLw/wAyjyfz49KktKCG6Q8M9KaRuS7hY7YGZiklIdW6pwoB7hO4nH4VMqUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFaW6aii22a7HfYlKQy0h559CAUNIWpSQVc57pPYHFbqorfNOPz785cEKBQERkhlTqg26ELcK0rQOCMLBGc8gVYSUh8/D895Lzcfzm3d0OoOpj325zirJu0RmM29PeZhBxZbSH3kDJBIwCDgk47ZzUZTp6VHuS3XGWnY6Zy53mOusrAKirAbCeVDO3vggdvSqbVaJ6EszkwmHy6y82Y0xRbLYU8tYP3T3CgFDGeBSi5Sxc5tuS629hptCUK6y3EhJKiQB3yO3qADnjPNU/va3eRE3z8TyZOOv1k9POcY3Zx3qK/2RliOiOtxl9tLNuaJWT8fQeUtfHPBB4rKkWCW3ezPjsxnmUzFPpjLVtBSphDZUOCAoFJ/BR5FKguW7h3qDJSo9dtv7ZTKA4tI6hSrblPPIJI/MVkx58OTIeYjy47r7Jw4224FKR/1AHI/GorYtLPxrpHlTGoiUtecUlLRJDSnnUKTtyPQJUM8VVpfTku2y7f5lhgJgsqaD6ZClqdJwM7cAAHG45J5x9aVBct5PvbMWWqM1Gly320hbiYzW7pg9skkDPyGT8qupvVtMOPKXNYaZkHDSnVhvcf8ADhWDn0x3rBXFudvutwkW5iNKZmqS6pLrxaU24EJR6JVlJCU/MHPfNatnT0+C75hLEK4uvMOIdafWUIbWt1biin4VZSSvB9cJTShKXrhDZlNRXpcduS7y20pwBa/oM5NY0a9wX5bkUvtNSUOqZS04tIW4UgElIzkjmo+9p2d0J0VLEFSZvSJkBRSY5ShCDsSQScbNyfi7n8Sf09NW5c2hGhbJs5EoSt56jaU7OcbeVDZxzjn5cqg4pS3PhuzHIjcuOuU2MrZS4CtI9ynuKuyH2YzC3pLrbLKBlS3FBKUj3JPaorAsE1hy3sqaipbhSnJPmkLPVe3b+CNvBO/4jk9vnxsLrEmXW2Wx8x2m5bDzcpyG45lCiEkFBUB6FWQcd0ilDZN3KI64yGXkOoebU6h1CgpBSkgE7hx/EK+x7nAkxVyY82M7GQSFOodSpCcd8kHFaSXZJM/TlyiOMQ4UiUtSkojklOMpOFKwM7tvxEDsfXucFGm5Lrc1yRCZbW6WNraZiyo9Mk7irbjIJ4G3nHJ54Fy3svUtniSoUd+4xULmAqZJeSAoD1zn17D3NZz8xLElLbqdrXSU6p5S0hKAkjvk59e+McckcVGoljucc2t9SYj70Z94qS4oIPTX2O5CMFQ4/hGff1N/VtilXdb5jFoBdslQxvUR8bhb2+nb4TmnA4thP1JZ4MQyX7jE6IfTHKg8kgLUoDB54xnJ9gCavO3u3NuwmxLYWuYfsAl1J3jGdw55H0rTXTTz7j8tyC3FSktwy02o7UqWy8pZBwDgEEDOD9KwrppufLmznDGjOJnpa3ZlLSmOUpCSkAJBUBjcCCk5J7d6VBcpY7c4DMryr02M3Jxu6SnUhePfGc4ou5wEIeUubGSlkZdJdSA3yR8XPHII59q57qBKUSLha47lukPyrg08ELCvNBW5BxsxykAcLzgJ+lbp3Sz6ba2Gm2FSUXN6ctAcKA8lS3NoKsHkJWk9jyn8aUWlJuMERm5BmRhHc5Q71U7VfQ5wavqeaS70lOIDm3fsKhnb749vnUVtum3EvW52VGjJDMp6SpoOKdCSpG0EEjk+pwAMk/WtjdoM1V3RNgoZdzEcjKS4so2kqSQrscjg5FBsVXOAlbKFTooW9jpJLqcuZGRt55yPaqhPhqnGEJcczANxYDg6gHvtznFRJvSckWObHWmMZrsGNHbcz91bSMZzjIG7kVXD03LZuyC4yytlM5yZ5kyFbsKUpQAQB3+Lb97GB88UqC5TOlKVFKUpQKUpQKUqB6qv1wj3ea3HSltq3IbeQFqQlLxUD94lxJ2/wjCVcjPPAqxFpM0nlKg171HcYzN5lNSoccQHkMIiOt5UvclB3E5BydxxgY+H8s5d+eLUFta2S7IuUiItGOemjrY49OEI5+fzpRaV0rntrvk1yOwxHmW62MM2aNNSlbWRuUF5H3hhA2j580Orbs86p5DCIyGvL5ju9Mb+ohCiCVOBQOVlIwk8p9ewUW6FStHqCfJZuFrhRX2oolqc3SHEbgNoBCEgkDcc/kk1GoNwlwtMzbwy+3IdEp6OAj+6yqUUl3BUBgA55OMeuOaUW6DSoN/aO6R7bPeUG5L0N9pKGgEdSRuHLWG1KAXzkHPtkAZNX03qfJk2yMi5wGBJgrlrf6W4FQUPhSCRwATnPPw+nootMqVzh/WF2cZU60lhkMQ25JJCNj5UVc5W4khB28bQTz+BzNRT7vKtOqVtS0Q48Fna2G28ubiyhZyrPGNx7D/SlFp3SoZcr7NhKbcZnx5NvbaS45JabQ6TlZB3JCwQnAABSDzn2xW11FKXFuERTLcZTyY0lxtb52hKkpSRlXok+vypRbfUqEN367qjuMhTZnJdaCkLabQpKFpUfg+1KFn4eBuBwCeeM3Y2pnzEkvOvNbW7e4+lamunl1C1pVxuPbanOCRzwcEUotMqVDIuoLiq4w/NLZREeUy2C20lYUpbaThRC9yFbicfCRjH4Z17uUtN5ehMTYsFpiH5oqfRu6pKlDHcYSnaM45+IdvVRaS0rl1u1Nc41khojJbbah26I4A508PFTSSclS0qAz8I2pPIPftUnRep6dRpYkqaRDckFhoNtpcCvg3YKgvclWQe6cYH40otKsDOcc+9Kid4u81GoZ8Fi4woLMaC3KCn29xUoqcBzyPhG0Z9eaxLJeJC5qZK2xHE+YwHm3P/AHYVDC9vyO4AUotN6VBJGprmtl1+M5H8s07KC3EIS4oJbc2pO0rTlOAckZPas/VslZOmXmJDTCnZww66k7QFMO+mRzzwD64pRaWUqAvaluolC3tracKZDzRnNIbAcCENqAAWtKd32hB5P92rj2xrnPfuNsVKkdMPLtD24tEFKsOpG4YJHOM8E9+570ot0elQZ3UtzF7eQlDaI7U9EMML6Y3pJSN2SvfuOdwwnGMfUbCzXme9ffLT1tBt3rdFLTaVIUEK4IWFk5wRkKSOfalFpTSlKilKUoFY8iFFkvNPSIzDrzRy2tbYUpB+RPasisGRd7fHmohvzGESlkANqUM5Pb6Z9Pegs32yxbtEfbcbaQ+430xI6YK0jPYHvWZ5CJ5lUjyrHmFEEu9MbjgYHPfsSKxmr5bHZbkZucwX2925O7tt+9z2OPX29axX9SQfJ+Yguol4fYZUlKsEdVxKArt25JHvirxTgvGwW5U9cp2M06VNtNJbW2kobDZWUlIxwfjP5Cs12DEektyXYzC5DX3HVNgqR9D3FY6L1bV3EwETGTLBKemFc7gMlPtkDnHestUhlMlMdTiQ+pBcCPUpBAJ/Mj86ivkqLHmNdKWw0+1kHY6gKGR24NfUx2UsqaSy2GlZ3ICRtOe+R861r2pLMyGy7cY6d7aXk5V/Arso+yfmeKyf3xbvPiD51jzZOA1vGc4zj645x3xQXY9vhxm2248SO022orQlDYSEqPBIA7Hk/nWLIsVvkTEvyIzTqQ2UdJbaVN8q3FWCO+fX5mrky49CWmIwwuRJU0p7YhQGEhQHJJ4znj6GtS3qkeTZlyYLkWM5JMfqPOo4IKkk8E+qPxzVTg3r8CJIWyuRFYdWyctKW2FFB/y57fhV1LTaS4UoSC4crwPvHGOffgAVrnNQ2luI1KVOZDLqlJQc5Kin7wx34wc+3rVuRex5yPHgRVzi8wZKVtOICdmQAck85z6VBsHIERxbK3IrCls/3alNglH/AE+34VdW02tSVLQlSkggEjJAPesBV7gNy24kiS0zMVtBZUoEpUrskkcAn0Hr6VZlaghNyEsRnW5D4kIjuoQvloqUU5P4g8UGam2QExlxkwoojrOVNBpO1R9yMYNVOW+G6hlDsSOtLP8AdhTYIR6cccfhV1iQzICyw6hwIUUKKDnCh3H1FaV7UjbNyejuQ3wwzKbhqkbk7Q4tKVJ4znHxpGcfpQbYQYiZCJCYrAfQnYlwNjckewPcCvsmHGkqbVJjsvKaO5BcQFFB9xntWHHv9qkoUticytKShJIPHxq2pP0J4B7GqLje24spmLGZXMlOO9EttqSNh6ZX8RJA+6P1FBmLt0Ja2Frhx1LjjDKi0klv/p44/CqxDiiX5oR2fM429bYN+Pbd3rT3PUiLVEkyblGLKGGUuqbS4Fu5KlADaOMfDwc+/tW6iyGpUdLzCiptXYlJH6HmisJ6yQZFzenSmESHXG20bXUJWlGwrIKQRwfjPP0rLfhxn23W347LjbpBcStAIXjGMg9+w/KtOrUqRHVMTb5arWlRBmDZt2g4Lm3du2fPHbnGOaz1Xq3JuAgqmMiUSE9PPO4jIT7ZxzjvV4pwXXLbBcQhDkKMpCFb0pU0khKvcccGr78dmQkJkMtupGcBaQoDIIPf5Ej8a1w1DaVPOMonMrdb37kJOTlGdw47kYOR3qxC1TapVojXBUjosvhO1LqSFZKd20DHJx7ZpUnBsnbdBdiJiuw4y4qezKmklA/7cYq4qLHUnaphop2dPBQPu/4fpx2rHZukd+VFaYUHUSWVPtPIIKFBJSDz/wBwrOqKx1QoipiZaozBlJG1LxbG8D2Cu9fWocVmQ4+zHZbfc++4lAClfU9zV+lApSlApSlAqO3GySnr2JkRxuOFuNLccQ44lSggjKVIzsXkAjJwQD64FSKlBFY9iuseEm3MyoTcRhDoYeLO93KkqCSQeBjdyR97Hpk1jI0vcFSnXnX2ftvKFSS644Ulh7qcFXcKBPtg4+tTOlW0pEIWlpMe6oJeaXBbluTEkvOlZKlKVt2btgwVH4vYduc1s5lqlIuMaZbnUKWhlxhYlLUrhZQdwPJJBR29c9xW8pSykCt1iu8ORKhxREUn92RYS3pDatpKQ4CpOB8WM/dOO45FbSJpuTCuUZcR9LUZpSFOKS6vc8EoCcKbPwZOB8ffjtUppSymp6Djeq/MbFFl6GG9wHCVIWTg/UL/APhNYzVjcTBgsLW2ox5y5Z4OCCtagB8xuH5Vv6VCkOnaWlm4uT4jzReLrxDannWU7HA3/E2Qcgt9uQc1lQ9KRkPQDOZiS2o0QsbXGtw3lQUVAKzgcH1zUnpVspGJen5bi50Zl6Mm3Tn0PuEpPVbwEApTjg/cGD6fOvsvTK5Ntci9fol24mYtxklKikr3YB7hWMDNSalLKaWwwJ1pZi2/Md2AwlaEuchzaCnpgjtnG4E+uAfU1Qzp9pFwvE4txvOy3d7EgtBS2vsUNjk/NJOPnW9pUspCjYJUePKcuKlSG3oXlXER1uOubgfhWjPbkk4GAnA796v27TTsm32hV8THkykvqmTUuthSVuKbUnAHI+HKQPkmpdSrZSN3TTQlJuTUVbMViTBREaShHDZSpas7RgY+McfWtvB/eIeUid5ZTQaRhxkFJK8q3DaScDG3HPqazaVCkHn6dvzdubtlvlxV2tCFRyhW5Lio6sAo9RvA4C+PmOa2C9Oyip6Ih9gW12aJylFJ6yVBYc2D0+8nv6DjHrUopVspHYen3WG4CS43mPcJExZAPxJc62B9R1R+RrHh2G5wWLUpqTDek21pcZsKbUhC2lBA55JC/gScjjuMetSqlLKRePbJcKRCYYKXH225UhTxQUtB1xQIT/05UrjOcJqTNb+kjq7epgbtvbPriqqVFKUpQKUpQKUpQKUqy1JadfdZbXlxrG8YPGe1eZzxxmImenoWImV6lKV6QpSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArUWv/nd1+rf+hrb1qLX/wA7uv1b/wBDXBu+20PVPsya6fVz8vmG3pSld7IBBGQQR7iqWnEOtpcaWlaFDKVJOQR7g1GLdbrhGVFQ60+raEbVtytiGgD8QUnPxE8+hznGU4zWRJNwb0lKacS63NaiYDqV5Upe3kgj1BoJDSok/AuhSsR25aGFupw2uWVLThCgVbt4+Enbxk9s45xV62Rrsi6Q3JKJBR00h4uPAoSQ3g4CV8ncM4KT3J3elBJVuIbKQtaU7jtTk4yfYVVUWnW25PXFK2w8VplF0Pqf+yS3sISAjPcEj09zn0rK05DuEZEjzJfSVNpSkSHur9oM5UOTwePUZ9h6hvXHENNqccUlCEjKlKOAB86qrSzv3gzp6b1lqdmKQUtFhJUckYGMD39fx4HA10qJenEPMNB9OFSSl4PgbgtWWwOc/CDjkDGOOKCUlxCXEtlaQtQJSknkgd8D8R+dVVGHbbdUPyW4zr3ldy+lukEqKSlnjcSSCSHQD6Z+lfYduuC5iXHFTGIgDqm2VytykEhsJ3EE55CyBkgZ/Cgk1K0Fphz1WqbHkmQw4vKWnHHSpY+H73C1Y59iPoKwJcC9yGGHXDIDzocU40xJCeis42c5AKQBzjPJJwc0EuqlLiFOLQlaStGNyQeRntmow7a7qG3XGn3/ADLjjySTIO0NkHZgZwDnbggZGaoiQrjFuDspmJL6C3E/YrkpW5tDak8kqxgKIOMn3+VBLKVF7TDuzFxgKlB9aAygPqW/lCSGsHACuTuHqk9yd3pVyRCua5EwM9dL6+qW5PmcNAFJCE9PnkHHoO2cntQSSlRZq1zpD6Avz0aESolpUwlwHZgEqCicE8gZ9M+uKpj2m6BiK249KO9uOZR8yc7wT1MHPGR/h49qCV0qJi03ZqKRHkSeuoSEEuSSr4N/2WMk4O0AZ7881lxIVxTZJzQVJbecVlpLz4U4lOBkbgTtJwrHxHGc8dgG/S4hS1oStJUjG4A8pz71VUNXa7l1JDjTM1uM4+lXREodYp6YT97f2CsnG71+WKzbZDurF3jqk9d1oNgOuOP5QD0wPhAIydw9UepOfSgktKUoFKUoFKUoFai1/wDO7r9W/wDQ1t61Fr/53dfq3/oa4N322h6p9mTXT6ufl8w29KUPY4rvZFKhiLNdeh0lKf6KXUKWPMZddASsEZPwkZKDnCScHI7VlMWW4NhDinnVPtqjbCuQVYQlQ6gPYHKSRnHPFBJ21pcbSttQUhQyCOxFVVFWbVc0ljqqUt8dEiR1zhoJSAtBT/FuIVz67ufuiiLPPYTag0XnFtIbDxXJJSVbgVqPIOe+MZHoRiglVUlaAtKCpIWoEhOeSB3/ANRWG+3O8+lxl1HlUp5aPdRwr5cd0+vpWDdrW/cZsGUgiO9HYcKF5yW3SUEfUYCgfcGg3aFJWkKQoKSfUHNfaiTdoufl46XEjq9FKUlt8hMZ3epSlem4EFPp/DjsTX123XZ1tLSw6lLTK2ypuQApw9VCgR/2pPBx3I470Esq2l9tUhxhKsuoSlSk47A5x/ofyrSGDOVZYTTiNy2ndzzCXiOoj4sJ3EnnlJxnHGM4rHTZZXXEkBTbyRHCB5hStoS6pSwSe/wKxz9KCT1bkPNxmHHnlbWm0lSlY7Ad6iUSw3LYESZEkqUWxIX5nAew4CpSQACMjPqDzj0BrIl2ia83PZ6alLdS8EyDJICkqBCEbPTGQPwz3JoJTSow/Z5bchwNoW/B3qKI4kqQcltACt2c8KC+P82e4qgWS5BG9UhxcorKVuJkFOUeXKeO4H2mD2780EnedbZbU46tKEJ7qUcAVUlSVDKSCM4yDUdjW2crT8yI6nDq3AWt7mVFPw/e5IByD249eCTVNws8pd4Q7GW+mOChSOm+EpQd5U5kEHO7Pp37HA5oJLSomxabm2xiQFvo64dLIkEEtbVANZ/ykg5/ir6bPcVXBh0uPpSnpbNkrKWgn7yTlOVZ559c84wDQSaPJYkgmO824AATsUDwRkH8RV2oamw3BEVlBKwhPRDiGXQlSwlopIyeDhWDg+1ZDFkuKEdQyHTKQpgNrU+VbUhIC89gf4vTniglVKiS7RcFwm20IdZCVtl9KZW9T4SFBRBVwMkpPOM4wcVIbNHdi21hl9a1uIGCVr3nvwCrAzgcUGZSlKBSlKBSlKD5mtPaz/xu6/Vv/Q1tSrFaa2K/43dfq3/oa4N322h6p9mTbT6ufl8w3maZqzvr4Vcd672K/mqVuJQAVqCQSAMnHJ7CoM/ZprUZhPTSpW9pD5Q6o+aIWCpa+OOAc9/vY7Cq5mnpr7SENuBppPVLTLb2EsFRG0pJQe2D2wRnA4oJxmrS5DSFFKlp3DblOckbjgcfM1FJNjkriOIHTdddlOOuKcWTlJ3bO4I4yOMYHcc19j2SQ0+3I6cYSlNRkuyAr7QltYK+cZIUPn6UEvzTNQxuwyiltDnTT9wSFpeUTKIcSorUMcHAVxz97HYVV/Z98h74kZbQsRPtFYaV1VqQR7YSUj8x2oJa++2w31HlhCMhOT7k4H6kUYfbfbDjKwtBJGR8jg/qKhqNPzhKedU/uK3NyipwEODrJWMgIB4SCBknHYcUc0/OVJYX18JbHwbHAOkrqqUVDKCeUqA4I+7jsaCbZqyuWwhhTynUdJJKSvOQCDgj8+Kjl6tEqdeWpTbyg0hLYRhYHTIWSogFJ7ggcEZxg8Uj2VUeyzYMdiKyXX1uJLfAUC5uG7A4IBx69qCU5pmoxardNjXx2W90g06HAsIXncSsFJ7ZOAMck4zxgVjuWmZ05KW2o/VdyFvKeXl4FwH4hjHCcgZyB27ZoJfmmagTdmnBTMWSw3JQhqRsCnVJQgqcBRyE4BSCQMDjHFZLtluipanUSUIcU2poyArCjlraFEYzkK5xnH40EwceQ2UhxQTuzjPyGa+9Zv4PjT8f3Pi+9xnj3qLpszrjaWjGjR4xKg4wl1TiVZbKckEAdyD29MnmsRGnpSZMNbfSjIYS0EoYcAS2UqJWQNmfiHfBGexoJp1E9TZuG/Gduece9VZqMXK3TX76xMZ6QQ0tvCt+FFIzuHY+/oRn1q7Kt77l3MkNtOAqQW3lOqSplI+8lKR3z37855yBQSLNM1DGLBJIYQ8GktJLfmAl1SvMlJO5auO59vXOD2FWZlikxLU95TPXLb7aumtRUpKnAWh7/CkY+XpQTnNM1FI1lcExlam22IiH+t5dt1RSMIwD2HdWDjtxnvWFC03NbG2TILm5TfXUXeH8OBRUQEg8gEck98dqCaPvIYZW68oIbQkqUo9gB3NXAag8zT0t2HJYww6FNOtRgt1SRHy4spI4/wACkD5bcdjWRMsL7rCwF5U5MW+6nqf3jfxbU/ElQ4yDjGMigmGaZrW2lpyJbYzDzinHG2wlSlK3En64GfriswOfOgvZr7mqAc19zQY/KjhIzWvhQZLVznvLQA26UbDuHOBzW4bTtSBVVZamjjqZY5T+M3H7THy9RlMRMR3sTpO+36186Tvt+tZlK1eWH0nvb9adJ72/WsylBh9J72/WnSe9v1rMpQYfSe9v1p0nvb9azKUGH0nvb9adJ72/WsylBh9J72/WnSe9v1rMpQYfSe9v1p0nvb9azKUGH0nvb9adJ72/WsylBh9J72/WnSe9v1rMpQYfSe9v1p0nvb9azKUGH0nvb9adJ72/WsylBh9J72/WnSe9v1rMpQYfSd9v1r4W3fb9azDVJ7UGM02rqALHH1rTWPUgvF+u1pEVLTlsO15fVCgSSdm0Dk5SMntg8c1vzkEEdxWEzb7dCcMiJCZafwpO9KMH41blZPrlXP1oMpCqu7qxWzV/NBfpSlApSlBZmPpjRlvK5CR2960tsvpkTEsvBOVcJCR+v/8Afet4+yh9GxwZTnOK1MPT7UW4JkpdUUpyUox2/GvmbyN79fTy29ci/u/v/d7p0Z0eRlGp09yO3jX6rfrRVhTBZd2vR2ifM4eUHR95Le3kJ7nkcCs9zxD043GW+5LdQ2NuwrjrT1UqUUhSMj4k5BGRx+YqQRrZFjXGdOabIkzdnXUVEhWwYTx2HFaROhLGhl1pDUlKVpCE4kufZoCioITzwjJJ29u3sK+m5lxWtbKJqYiXn1yVNBxLaY6ySS2XAjt98pBIT3quBrC1TbKi7NqkIgqkiKHHWVI+MrCPX+HccZ7VitaAsDJ/3ePIYBYEchqS4jKQgoBOD32nGfp7Cs+Lpa1x9OPWINvuWxxBbLTz61lKcYwkk5SBjjHb0oMRnXNiefYaRIePWKQHAwsoTvWUIKlYwkKKTtz34PqKzLHqm03yFKl2+SVxo2eq6ttSEgAEk5I+R+lWDoyyeYiupjLQI6GW0todUlCg0ct70g4VtPIzV606VtVrM8xmVqM5AbkF51ThWkZASST/AJj8+aDFt+uLLOkNMMOSQ66pKUJdjrbJ3NrcSfiA4KUKOfpVlHiFptaQrzqwgxhK3FleAnpdXGcfe2fFt71jwvDu1xpb7in5jjSiypgF9e9ktoUjAXuyQUrIx7VmRNCWKGvdFYkMjoJj7W5LiRtS2GweD97YAM/LPfmgwJ/iLbmmGXYbEiQ07DkS0vKbUhsBnbkE4Jwdw5AI7e4rPf13YY6pSXpDyRHC9y+gvYsoICwhWMKKSRkCrY8P7AI/RDD4QQ+leH1guB4JDgVg852J/IVee0PYn3ZK3Yzig/vJQX17EFZBWUJzhJUQMkf/AMmgob15YlyYsfryESZDy2EMrjrSsLQoBQIIyOVJ/PPvWXedSxbTfrZbpZKRNOxK9i+Fk4QMgY5OfUY496sTtE2Sa8XJDDx3SFSVJD6wlThKSSRnHdKfy+ZrIumlLVc70xdZbTipjPT2qS6pI+zUVIyAcHBUfzoNXqLWEq1S7w3HtXmmLZHEh93rhGElpxY4x6qQE/8Adn0q9E1mxI1imxeXKUqa4k7/AIS/tCyzjHfYoKz9RW2m2C3TBdRIZUr95spYlYWRvQAQAOeOFHtWCzonT7MtuW3b20zW5PmxKyetv57r7lODjbnGOMUG2du1uacU27PiIcScKSp5IIPzGa11/wBQeSatybWy1cJVxkGPGSHghskJUpSlLAOAAhXYE54rZOWu3uuKcdgxFrUclSmUkk/M4rHulht9yhMxXmS02w4HmVR1FpTSxn4klOCDyfzNBprVreHIKY05h9i6B51h2Mw2uRsLaglStyU/cypPxEDv8jVq4eIVoYjLcideQtDzTYT0Vp6iFPpZUts7fjCVK7Jznj3rNTomyo8sWmpLS2SvLiJLiVu71Baw4rOV5UATn2q2vQVhWh5Jjv7VkFIElwdHDodw3z8A3pCuMdqANeWE9L/eHxvzvzGc+w+0Lf2vHwfGCnnHIq9a9XQptgRd32ZESMqUYv2zZBCur0wT8icc+n4VaToSxJ6X+7vnZyvMhZ6/2hc+15+P4yVc55JrPb01bUWOZaC04u3y1OKcaW4o46hJUEnukZJIx2PagwG9c2J19ltEh4h0pAcDCy2nctSEFSsYSFKSdue/B7EVaka+0/HiNyXpTiWnWWn0HpK5S6paUencltX5VlnRlk60RxMZaBGbZbS2l1QQtLRy3vTnCtp5GaxkaCsbbDjTbcpKFoQ1/wCJc+FCFKUlA5+6CtXHbmgkUZ5EqM1IZ3Fp1AWkqSUnBGRkHkfjXySMMn8K+WyBHtlujQYSOnGjNpaaRknakDAGTzVcsfYK/D/Wgx2qyM1jtVkUGRSlKBSlKCHeIupLlp5u3/uyK275hSwtx1BUlJSnKUcEYKjwDz24BPFR6669vMKTe0mPGQxDCDGcWw4Q8VONpWnPqW95Bx944xjBFdSqzMisTY5YltIeZJBKFjIJBBH5EA/hQcqVqm+TZ0d0FamBhoLjoW20+BPjt9UAnIyhS/U8Z9KuRPES7LmPIfZihLQbceaDDgXGSZaWlhZJ5KWyVZAA+WO/V6seUj+d830Uea6fS6uPi2Zztz7Z5oOcwtd3qTe7bFTb2xGkvKTuU0oFxHmVt5SSeClCUrPBzn+Ec1tb5qS9wtSvR4kRl6Ay9Ga2dNXUc6qVkkKzgYKR6Hv6VOKUHJo+stQzza1LWxHYMuMJLzcRwJT1Eub2FBRzuSpKQVD1UO3Y5MPWmpQvTiJkKIVXNlqQvYytIwtaQWxlWQpKSVE4OeOAMmuoYpQc/wBW6zuNo1bHtsOMhyMUJLpcaOfiSs7kq3dgUgH4cc981oI3iRd3YMJ1xVubRIWyFSzFd6bRWy44psp3ZUpBQnJBx8Y7V11xCXG1IcSFIUClQPqD6VjC2wg3DQIrWyHgxxt4awkpG32+EkfSg52zrPUr0J6a7DiwoyTEbV1Y7iyyXW0LW4rCgSlOSMcHkZIwayIWs7vJmQGJTDMIPshQ3RnVKlEuLRlvH3BtSlfxA4CxnHeuj0oOPwtaamtun4KJjLUh5ceIsy1sK+zDjbhPUBWNx3NpGcp5X2954vUDzmkpk6M20LrGipcdjrSspbdLYXtOBkjkdqklUIabbU4ptCUqcO5ZAwVHAGT7nAA/Cg5S94j3dEG1uIhJU866pLwVGIQtIdSj4FBwjsonI3dvQA1fe1rqRmM+8uLCwppbjWWVp6e2T0iFEqwSU/EM7QPU45rqWKUEDuer5rGkNP3RIYivXCQhl5cmOspaBQslWwKzjKAe+MevrUea1ZqGRcLfKUlUNl12J1mS0tSVhbL52jJ+EKUhA98qTntg9XkRWJKmTIaQ4WV9VsqGdisEbh88Ej8avUHKUap1BdGbQ/DkRkyC6tTyExHg23/uziy04CRuKVADII5xkelbPWGqrrG0vaZERpEV24wnHXHVMrc6TnRCktpCeQpRJAJ7bexrodKDnmjtVXmdqJq1TYgTHQwnctaCHD9ihXVJzyFKURjaPqeRVq7ay1DCevLSbYjFscS2t8tKKFh11IbWn4hkJaJKue/qBXSKUHMmtY6kfcjKTEiNskROoCwtRX1nltlSTuwAAkLxz37+tYWmNbagXKskCY03KU8lPmHlMKQpZLi0rA+LgoCQTwc5/h4Ndapigsw5DUyIzJjK3sPIDiFYIykjIODyKS/7hX4f61eq1L/uFfh/rQYjVX8VaaFX8UH1h4KSEqOFD39avZHvWAtFaO3I/wCNXT6t/wChrDV1vp54YV1pr+Jn4e8ceVEz+iV5pmtQW6+dOt3huM0zWhjONSUqUwrelKignBxkd/rV7p0G4zTNafp06dBuM0zWn6dUgIUtSApJWnBUkHkZ7ZoN1mma0MlxqMgLfUEgnaOCST7ACrpbwMnFBuc0zWn6dOnQbjNM1pWwhxO5tSVDJGUnPIOCPzr5hBcLe5PUA3FOeQPfH4Gg3eaZrT9OrSFtLcKEOtqWM5SFAng4PH1oN7mma0/TqhsIdQFtKStB7KScg0G7zTNaJtbTiilt1tahyQlQJHJH+oI/CrvToNxmma0/Tp06DcZpmtInYpRSlSSodwDVfToNxmlacNkHI4NZzck9P4hlY/WgyiQO5xWJIdDmEp5A7mrJClqKlcmriEYoKmxV3FfEJq5igtqRWltqP+N3X6t/6Gt/itRbEEXq6EpIBKMH34NcO77bQ9U+3Jrp9XPy+YZpR8q+KaCkkHOCMcHFZW2vm0V3MkGfs1zjQGGLe3J3pDq8iUThZVlOcrHGPqPcDvV9LFwclTWAJKZmFr6vmcN7FE7EpTk4UAAM4GCM5OeZltFNooIc3abg+9hZnR4eHClpUslxJ2oCcqCiTyFEDJx+OKpXa72Wi60+6iatS05W9ltCTHIB25x/e4PbP4VM9optFBD7bariZEYvqmtxku71ock5UcIPchSjtKscZ9Ow5q5erbcHJrzsMO9Famt4acCFuJSlzIB3Jx8SkHuMgGpZtFNooIy5aH5MK0Ikl5Tsd4LcIfUkgbVDkgjJ5A9awJFruk1ny8hqQlttlaSoydodX1ElJG1WeUg98YzU12im0UENkw7wW1MRmZLaQpxSHDJB+EsEJTkqySFkd/UZzWxn2+Sm2w2Y5kupbcSX0pfIdcTg5AWSOdxSe44BFSHaKbRQQNuz3ltLaUiSlGXChKJABbUXlqClncNw2lHorseOa2l7gTnJrr0RpxSFtNNktubVcLUVY+JPoR6j8e1SjaKbRQRhMS5KsMVp5L5kNuDrJbeAccQCfurz68Hkg4zWvZtV1aivpSmShKi4tKUvJK+XgpIJ3DJ25B+IfX1qb7RTaKCIRYVz6sVUliUcJQE7JeEtYWd28FR3Epx/i9s+tYaYV1cfWyoyzJQwzsUmRtQ0sqXlShnChgDI57YwO9TvaKbRQQ8Wm5bi2C62wpwFXTdCTgyFqVyDkZQR/wD7VhVrvQfbSXJKmkFSWimR9zDyyFLO74gUdPuFHg5HNTfaKbRQRe8wLk9eGnIyn/LhCAjpu7EoUFEqKxuGQRt9FdjwKqs1unxZbC5C31oWy71+o9vAXvTswM8fDu7fjUm2im0UENhaelR7ZsDz6X3XwVpQW0FCC9uVhaUhXKfdRP41RKgXrzkwsIkJbW282giRkZKfs1DK+O3faCCfXk1NdorVamvEXT9km3SevZGitFxZ98dgPmTgD60ET1JJb02w7Lusx5u0IWSAqcULKihGCFFQJAIX8OfXgHFc7c8bNOxLyHTMuctCFpGWUnplHTwRhRSCd2edo98+lcJ1/rO6a0vbs+5vK6QUehGCvgYR7Ae/ufWo0hDjgUUNqUEjJwM4oj3Vo7xF0xqxaWrRc21SiNxjOgtufke/4ZqZoANfnLFkOxpDb8Z1bL7agpDiFFKkkdiCOxr2D+z94iu6xsjsG7OBV5gABa+xebPAXj39D+B9aK66BVWKDtX2gUpSgYpilKBimKUoGKYpSgYpilKBimKUoGKYpSgYpilKBimKUoGKYpSgYpilKBimKUoPhHFcZ/allvR/DUtskhEia005j/DhSv8AVIrs57VAvGPTS9VaFuVujgGVtDzGfVaDkD8eR+NB4ZZQHX2m1KCEqUElR7DJ710TxRxorXJtOmW/3e3bEtFuS3/fPqU2FFal9yDuI2/d+Vc7facZdW08hTbqFFKkqGCkjuCK3aNTSn1Q/wB9tIuzcNISw3J9EjslS04WUj/DuxREk8ZbfEYuOn7pFjtRXrxaWJ8lhpIShLqgQopSOwOM4981s/2aZb0bxUhtNE7JEd5twD/CE7h+qRXPtSX2fqS7u3K6uBchYCQEpCUoSBhKUpHAAHpXbv2VtKvruczUshspjobMaMVD76iQVKHyAGPxPtRXqFo5SKrqhoYSKroFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFWXm9wq9Qig4l4qeDMDVUh25WtxNvuyuVq25beP8AmA7H5j8Qa4pL8D9bMSC21CjSEZx1G5KAn/4iD+le1FthXcVaMZPsKDy/on9n2Y7Lbf1XKbbjpIJjRVFSl/JSsYA+mfwr0nZLVFtUBiHBYQxFYSENtoGAkCtghlKfSroGKD6BgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSg//Z",
+              "timestamp": 64861017340,
+              "timing": 3471
+            }
+          ],
+          "scale": 3471,
+          "type": "filmstrip"
+        }
+      },
+      "network-rtt": {
+        "id": "network-rtt",
+        "title": "Network Round Trip Times",
+        "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "10 ms",
+        "details": {
+          "sortedBy": [
+            "rtt"
+          ],
+          "type": "table",
+          "items": [
+            {
+              "origin": "https://tag.clearbitscripts.com",
+              "rtt": 9.182879999999999
+            },
+            {
+              "rtt": 8.010584999999999,
+              "origin": "https://track-eu1.hubspot.com"
+            },
+            {
+              "rtt": 4.038885,
+              "origin": "https://perf-eu1.hsforms.com"
+            },
+            {
+              "rtt": 1.8024749999999998,
+              "origin": "https://js-eu1.hs-scripts.com"
+            },
+            {
+              "rtt": 1.1826750000000004,
+              "origin": "https://cta-eu1.hubspot.com"
+            },
+            {
+              "rtt": 0.9844725,
+              "origin": "https://forms-eu1.hsforms.com"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://useago.github.io"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://www.google-analytics.com"
+            },
+            {
+              "rtt": 0.89999999999999991,
+              "origin": "https://forms-eu1.hscollectedforms.net"
+            },
+            {
+              "origin": "https://fonts.googleapis.com",
+              "rtt": 0.89999999999999991
+            },
+            {
+              "rtt": 0.005227560746269449,
+              "origin": "https://js-eu1.hs-analytics.net"
+            },
+            {
+              "origin": "https://js-eu1.hubspot.com",
+              "rtt": 0.0039510448388399028
+            },
+            {
+              "rtt": 0.0038920098978636472,
+              "origin": "https://js-eu1.hs-banner.com"
+            },
+            {
+              "rtt": 0.0035123242794845395,
+              "origin": "https://www.ocobo.co"
+            },
+            {
+              "rtt": 0.0030715126962786673,
+              "origin": "https://js-eu1.hscollectedforms.net"
+            },
+            {
+              "rtt": 0.001467130254700841,
+              "origin": "https://fonts.gstatic.com"
+            },
+            {
+              "rtt": 0.0010948987758418959,
+              "origin": "https://js-eu1.hsforms.net"
+            },
+            {
+              "rtt": 0.00095534912088473482,
+              "origin": "https://www.googletagmanager.com"
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "text",
+              "key": "origin"
+            },
+            {
+              "key": "rtt",
+              "granularity": 1,
+              "valueType": "ms",
+              "label": "Time Spent"
+            }
+          ]
+        },
+        "numericValue": 9.182879999999999,
+        "numericUnit": "millisecond"
+      },
+      "unminified-javascript": {
+        "id": "unminified-javascript",
+        "title": "Minify JavaScript",
+        "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn how to minify JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unminified-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "type": "opportunity",
+          "headings": [],
+          "debugData": {
+            "metricSavings": {
+              "LCP": 0,
+              "FCP": 0
+            },
+            "type": "debugdata"
+          },
+          "overallSavingsBytes": 0,
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "items": [],
+          "overallSavingsMs": 0
+        },
+        "warnings": [],
+        "numericValue": 0,
+        "numericUnit": "millisecond"
+      },
+      "network-requests": {
+        "id": "network-requests",
+        "title": "Network Requests",
+        "description": "Lists the network requests that were made during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "debugData": {
+            "initiators": [
+              {
+                "columnNumber": 1066,
+                "lineNumber": 0,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 668,
+                "lineNumber": 21
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 16766,
+                "lineNumber": 21
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 1748,
+                "lineNumber": 22
+              },
+              {
+                "columnNumber": 2076,
+                "lineNumber": 22,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 22201,
+                "lineNumber": 23
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 22433,
+                "lineNumber": 23
+              },
+              {
+                "columnNumber": 22662,
+                "lineNumber": 23,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 22956,
+                "lineNumber": 23
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 141,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 261,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 360,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 460,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 536,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 602,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 671,
+                "lineNumber": 39
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 731,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 795,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 857,
+                "lineNumber": 39
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 916,
+                "lineNumber": 39
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 985,
+                "lineNumber": 39
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 1052
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 1119,
+                "lineNumber": 39
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 1176,
+                "lineNumber": 39
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 1238,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 1297,
+                "lineNumber": 39,
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "lineNumber": 39,
+                "columnNumber": 1361,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1427,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 1488,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 1556,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1622,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 1693,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 1751,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 1811,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs",
+                "columnNumber": 1886,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 1947,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 2005,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 2069,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 2129,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 2188,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2250,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 2311,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 2374,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2430,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2498,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2565,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2626,
+                "lineNumber": 39,
+                "type": "parser",
+                "url": "https://www.ocobo.co/jobs"
+              },
+              {
+                "columnNumber": 2706,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 2769,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 2829,
+                "lineNumber": 39
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 2888,
+                "lineNumber": 39
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "lineNumber": 39,
+                "columnNumber": 2952
+              },
+              {
+                "columnNumber": 3011,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 3073,
+                "lineNumber": 39
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 3132,
+                "lineNumber": 39
+              },
+              {
+                "columnNumber": 3195,
+                "lineNumber": 39,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 3262,
+                "lineNumber": 39
+              },
+              {
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser",
+                "columnNumber": 3320,
+                "lineNumber": 39
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+                "type": "parser"
+              },
+              {
+                "columnNumber": 42490,
+                "lineNumber": 222,
+                "url": "https://www.ocobo.co/jobs",
+                "type": "parser"
+              },
+              {
+                "type": "parser",
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap"
+              },
+              {
+                "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                "type": "parser"
+              }
+            ],
+            "networkStartTimeTs": 64857546499,
+            "type": "debugdata"
+          },
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "text",
+              "key": "protocol",
+              "label": "Protocol"
+            },
+            {
+              "key": "networkRequestTime",
+              "granularity": 1,
+              "valueType": "ms",
+              "label": "Network Request Time"
+            },
+            {
+              "label": "Network End Time",
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "networkEndTime"
+            },
+            {
+              "label": "Transfer Size",
+              "key": "transferSize",
+              "granularity": 1,
+              "displayUnit": "kb",
+              "valueType": "bytes"
+            },
+            {
+              "displayUnit": "kb",
+              "valueType": "bytes",
+              "label": "Resource Size",
+              "granularity": 1,
+              "key": "resourceSize"
+            },
+            {
+              "label": "Status Code",
+              "valueType": "text",
+              "key": "statusCode"
+            },
+            {
+              "label": "MIME Type",
+              "key": "mimeType",
+              "valueType": "text"
+            },
+            {
+              "key": "resourceType",
+              "valueType": "text",
+              "label": "Resource Type"
+            }
+          ],
+          "items": [
+            {
+              "resourceType": "Document",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 120211,
+              "statusCode": 200,
+              "networkEndTime": 814.79999999701977,
+              "transferSize": 23021,
+              "rendererStartTime": 0,
+              "networkRequestTime": 1.2719999998807907,
+              "finished": true,
+              "url": "https://www.ocobo.co/jobs",
+              "mimeType": "text/html",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "VeryHigh",
+              "entity": "ocobo.co"
+            },
+            {
+              "priority": "VeryHigh",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "networkEndTime": 886.11599999666214,
+              "resourceType": "Stylesheet",
+              "resourceSize": 122090,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css",
+              "mimeType": "text/css",
+              "rendererStartTime": 830.77400000393391,
+              "transferSize": 24572,
+              "networkRequestTime": 831.81100000441074
+            },
+            {
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "priority": "Medium",
+              "protocol": "h2",
+              "rendererStartTime": 831.222999997437,
+              "transferSize": 12758,
+              "networkRequestTime": 831.94700000435114,
+              "url": "https://www.ocobo.co/logo-ocobo.png",
+              "finished": true,
+              "mimeType": "image/png",
+              "resourceType": "Image",
+              "statusCode": 200,
+              "resourceSize": 12266,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 866.609999999404
+            },
+            {
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "priority": "Medium",
+              "protocol": "h2",
+              "networkRequestTime": 832.05100000649691,
+              "rendererStartTime": 831.36900000274181,
+              "transferSize": 29546,
+              "mimeType": "image/png",
+              "url": "https://www.ocobo.co/images/partners/modern-revenue-club.png",
+              "finished": true,
+              "statusCode": 200,
+              "resourceSize": 29045,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "networkEndTime": 863.15799999982119
+            },
+            {
+              "entity": "ocobo.co",
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/images/jobs/seminaire.jpeg",
+              "finished": true,
+              "mimeType": "image/jpeg",
+              "rendererStartTime": 831.53200000524521,
+              "transferSize": 251265,
+              "networkRequestTime": 832.13500000536442,
+              "networkEndTime": 1194.5729999989271,
+              "resourceType": "Image",
+              "statusCode": 200,
+              "resourceSize": 250772,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "mimeType": "image/jpeg",
+              "finished": true,
+              "url": "https://www.ocobo.co/images/jobs/cafet.jpeg",
+              "networkRequestTime": 909.24700000137091,
+              "rendererStartTime": 831.64900000393391,
+              "transferSize": 135167,
+              "networkEndTime": 1223.4920000061393,
+              "statusCode": 200,
+              "resourceSize": 134678,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "entity": "ocobo.co",
+              "priority": "Low",
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "ocobo.co",
+              "priority": "Low",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "finished": true,
+              "url": "https://www.ocobo.co/images/jobs/bureau-1.jpeg",
+              "mimeType": "image/jpeg",
+              "rendererStartTime": 831.74500000476837,
+              "transferSize": 124999,
+              "networkRequestTime": 909.36999999731779,
+              "networkEndTime": 1198.0329999998212,
+              "resourceType": "Image",
+              "statusCode": 200,
+              "resourceSize": 124507,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "Low",
+              "entity": "ocobo.co",
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 114922,
+              "networkEndTime": 1176.1749999970198,
+              "transferSize": 115414,
+              "rendererStartTime": 831.8669999986887,
+              "networkRequestTime": 909.457999996841,
+              "url": "https://www.ocobo.co/images/jobs/bureau-2.jpeg",
+              "finished": true,
+              "mimeType": "image/jpeg"
+            },
+            {
+              "networkEndTime": 1211.7470000013709,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 115440,
+              "url": "https://www.ocobo.co/images/jobs/bureau-3.jpeg",
+              "finished": true,
+              "mimeType": "image/jpeg",
+              "transferSize": 115932,
+              "rendererStartTime": 831.972000002861,
+              "networkRequestTime": 909.56499999761581,
+              "protocol": "h2",
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co"
+            },
+            {
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 104549,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "networkEndTime": 1193.1200000047684,
+              "networkRequestTime": 909.65100000053644,
+              "rendererStartTime": 832.07800000160933,
+              "transferSize": 105040,
+              "mimeType": "image/jpeg",
+              "finished": true,
+              "url": "https://www.ocobo.co/images/jobs/rooftop.jpeg"
+            },
+            {
+              "mimeType": "application/javascript",
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "finished": true,
+              "networkRequestTime": 909.75200000405312,
+              "transferSize": 157129,
+              "rendererStartTime": 832.18800000101328,
+              "networkEndTime": 931.88500000536442,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 471691,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "entity": "Google Tag Manager",
+              "protocol": "h2",
+              "priority": "Low",
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "Clearbit",
+              "protocol": "h2",
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "finished": true,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "mimeType": "application/javascript",
+              "transferSize": 640,
+              "rendererStartTime": 832.35600000619888,
+              "networkRequestTime": 909.87200000137091,
+              "networkEndTime": 1127.6689999997616,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 404,
+              "resourceSize": 0
+            },
+            {
+              "networkRequestTime": 910.00900000333786,
+              "transferSize": 1648,
+              "rendererStartTime": 832.46700000017881,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://js-eu1.hs-scripts.com/27107933.js",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 2125,
+              "resourceType": "Script",
+              "networkEndTime": 950.07499999552965,
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "Low"
+            },
+            {
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "Low",
+              "entity": "GitHub",
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 17494,
+              "statusCode": 200,
+              "networkEndTime": 927.13900000602007,
+              "transferSize": 5037,
+              "rendererStartTime": 832.58700000494719,
+              "networkRequestTime": 910.11999999731779,
+              "finished": true,
+              "url": "https://useago.github.io/widgetjs/frame.js",
+              "mimeType": "application/javascript"
+            },
+            {
+              "networkEndTime": 868.09400000423193,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "resourceSize": 69556,
+              "experimentalFromMainFrame": true,
+              "url": "https://www.ocobo.co/assets/entry.client-CYoGBzBE.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 832.68400000035763,
+              "isLinkPreload": true,
+              "transferSize": 24117,
+              "networkRequestTime": 833.41399999707937,
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co"
+            },
+            {
+              "networkEndTime": 1050.8830000013113,
+              "resourceType": "Script",
+              "resourceSize": 927,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "url": "https://www.ocobo.co/assets/jsx-runtime-DwmtE_Ma.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "rendererStartTime": 832.82400000095367,
+              "transferSize": 1457,
+              "networkRequestTime": 833.68100000172853,
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co"
+            },
+            {
+              "networkEndTime": 878.82999999821186,
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 125397,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js",
+              "networkRequestTime": 833.86800000071526,
+              "transferSize": 43927,
+              "isLinkPreload": true,
+              "rendererStartTime": 833.00200000405312,
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co"
+            },
+            {
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "networkEndTime": 906.80900000035763,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 133936,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/index-CvLOWJXy.js",
+              "mimeType": "application/javascript",
+              "transferSize": 45263,
+              "rendererStartTime": 833.125,
+              "isLinkPreload": true,
+              "networkRequestTime": 834.222000002861
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 110060,
+              "resourceType": "Script",
+              "networkEndTime": 864.60099999606609,
+              "networkRequestTime": 834.40500000119209,
+              "transferSize": 34187,
+              "isLinkPreload": true,
+              "rendererStartTime": 833.23100000619888,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/resources-NaHgTejN.js",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co"
+            },
+            {
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 991,
+              "networkEndTime": 865.92000000178814,
+              "transferSize": 1517,
+              "rendererStartTime": 833.33500000089407,
+              "isLinkPreload": true,
+              "networkRequestTime": 834.71700000017881,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/context-HICI_8br.js",
+              "mimeType": "application/javascript"
+            },
+            {
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 9799,
+              "statusCode": 200,
+              "networkEndTime": 866.29100000113249,
+              "transferSize": 4525,
+              "rendererStartTime": 833.43699999898672,
+              "isLinkPreload": true,
+              "networkRequestTime": 834.88099999725819,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/root-HtXVBFii.js",
+              "mimeType": "application/javascript"
+            },
+            {
+              "entity": "ocobo.co",
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/useTranslation-gwnEmc4O.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 833.55099999904633,
+              "isLinkPreload": true,
+              "transferSize": 2151,
+              "networkRequestTime": 835.04800000041723,
+              "networkEndTime": 865.554000005126,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "resourceSize": 3192,
+              "experimentalFromMainFrame": true
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "url": "https://www.ocobo.co/assets/use-hydrated-CxzUb1z9.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "transferSize": 672,
+              "isLinkPreload": true,
+              "rendererStartTime": 833.64999999850988,
+              "networkRequestTime": 835.29900000244379,
+              "networkEndTime": 863.8910000026226,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 141
+            },
+            {
+              "url": "https://www.ocobo.co/assets/ErrorMessage-COLM78qB.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "rendererStartTime": 833.7660000026226,
+              "transferSize": 1272,
+              "networkRequestTime": 835.42200000584126,
+              "networkEndTime": 962.98300000280142,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "resourceSize": 1284,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "networkEndTime": 866.96299999952316,
+              "statusCode": 200,
+              "resourceSize": 15426,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/cx-DiffRdtV.js",
+              "networkRequestTime": 835.78400000184774,
+              "rendererStartTime": 833.95600000023842,
+              "isLinkPreload": true,
+              "transferSize": 6809,
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co"
+            },
+            {
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 17234,
+              "networkEndTime": 867.63499999791384,
+              "transferSize": 6208,
+              "rendererStartTime": 834.1059999987483,
+              "isLinkPreload": true,
+              "networkRequestTime": 835.89900000393391,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/factory-hx59odkt.js",
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co"
+            },
+            {
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 3070,
+              "networkEndTime": 867.28700000047684,
+              "transferSize": 1835,
+              "isLinkPreload": true,
+              "rendererStartTime": 834.28600000590086,
+              "networkRequestTime": 836.15900000184774,
+              "url": "https://www.ocobo.co/assets/grid-DIis54sB.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co"
+            },
+            {
+              "resourceType": "Script",
+              "statusCode": 200,
+              "resourceSize": 428,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 876.92600000649691,
+              "isLinkPreload": true,
+              "rendererStartTime": 834.40399999916553,
+              "transferSize": 956,
+              "networkRequestTime": 836.35200000554323,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/container-DmKIJmEK.js",
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "protocol": "h2",
+              "entity": "ocobo.co"
+            },
+            {
+              "networkRequestTime": 836.56300000101328,
+              "transferSize": 940,
+              "rendererStartTime": 834.53999999910593,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/button-link-DVE2Hbdl.js",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 410,
+              "resourceType": "Script",
+              "networkEndTime": 882.1169999986887,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High"
+            },
+            {
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 525,
+              "networkEndTime": 869.19200000166893,
+              "transferSize": 1050,
+              "isLinkPreload": true,
+              "rendererStartTime": 834.70100000500679,
+              "networkRequestTime": 836.78700000047684,
+              "url": "https://www.ocobo.co/assets/button-0H_j6y7x.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co"
+            },
+            {
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "networkEndTime": 871.89699999988079,
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 942,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/create-recipe-CoY0ArzD.js",
+              "networkRequestTime": 836.91500000655651,
+              "transferSize": 1474,
+              "isLinkPreload": true,
+              "rendererStartTime": 834.81400000303984
+            },
+            {
+              "networkRequestTime": 837.32200000435114,
+              "isLinkPreload": true,
+              "rendererStartTime": 834.95900000631809,
+              "transferSize": 879,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/arrow-right-Dg8DaGR8.js",
+              "resourceSize": 349,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "networkEndTime": 887.38899999856949,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "protocol": "h2"
+            },
+            {
+              "url": "https://www.ocobo.co/assets/createLucideIcon-AYdXNW8X.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "rendererStartTime": 835.10000000149012,
+              "isLinkPreload": true,
+              "transferSize": 1370,
+              "networkRequestTime": 837.43800000101328,
+              "networkEndTime": 892.31700000166893,
+              "resourceType": "Script",
+              "resourceSize": 1866,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "networkEndTime": 891.7850000038743,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 348,
+              "url": "https://www.ocobo.co/assets/url-Do_uLi_4.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "transferSize": 870,
+              "isLinkPreload": true,
+              "rendererStartTime": 835.24499999731779,
+              "networkRequestTime": 837.609999999404
+            },
+            {
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "networkEndTime": 878.09200000762939,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "resourceSize": 67398,
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/_main-9OzAywp_.js",
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "rendererStartTime": 835.60400000214577,
+              "transferSize": 21255,
+              "networkRequestTime": 838.1600000038743
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/useLocalizedPathname-BG6E6HZ-.js",
+              "networkRequestTime": 838.28000000119209,
+              "transferSize": 704,
+              "isLinkPreload": true,
+              "rendererStartTime": 835.74400000274181,
+              "networkEndTime": 885.4210000038147,
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 165,
+              "resourceType": "Script"
+            },
+            {
+              "networkEndTime": 875.42600000649691,
+              "resourceSize": 605,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/layers-CQ3InJLS.js",
+              "finished": true,
+              "networkRequestTime": 838.57299999892712,
+              "isLinkPreload": true,
+              "rendererStartTime": 835.89299999922514,
+              "transferSize": 1130,
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co"
+            },
+            {
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "networkEndTime": 889.52300000190735,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 826,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/cpu-DlfrcSl-.js",
+              "mimeType": "application/javascript",
+              "transferSize": 1348,
+              "rendererStartTime": 836.03400000929832,
+              "isLinkPreload": true,
+              "networkRequestTime": 838.6950000077486
+            },
+            {
+              "resourceType": "Script",
+              "resourceSize": 404,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 896.18600000441074,
+              "rendererStartTime": 836.167000003159,
+              "isLinkPreload": true,
+              "transferSize": 932,
+              "networkRequestTime": 838.7960000038147,
+              "url": "https://www.ocobo.co/assets/briefcase-D8kT73_s.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "priority": "High",
+              "protocol": "h2",
+              "entity": "ocobo.co"
+            },
+            {
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 490,
+              "statusCode": 200,
+              "networkEndTime": 890.83500000089407,
+              "transferSize": 1014,
+              "rendererStartTime": 836.32800000160933,
+              "isLinkPreload": true,
+              "networkRequestTime": 838.91600000113249,
+              "url": "https://www.ocobo.co/assets/users-Cf70nLSI.js",
+              "finished": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "sessionTargetType": "page",
+              "priority": "High",
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "statusCode": 200,
+              "resourceSize": 206,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 880.6169999986887,
+              "rendererStartTime": 836.52100000530481,
+              "isLinkPreload": true,
+              "transferSize": 729,
+              "networkRequestTime": 839.24800000339746,
+              "url": "https://www.ocobo.co/assets/lang-PH2TSE5M.js",
+              "finished": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/hubspot-CtaUYGpC.js",
+              "mimeType": "application/javascript",
+              "transferSize": 1361,
+              "rendererStartTime": 836.70199999958277,
+              "isLinkPreload": true,
+              "networkRequestTime": 839.707000002265,
+              "networkEndTime": 891.30600000172853,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 835,
+              "statusCode": 200
+            },
+            {
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/portal-Clm-6X_X.js",
+              "finished": true,
+              "networkRequestTime": 840.00900000333786,
+              "isLinkPreload": true,
+              "rendererStartTime": 836.93899999558926,
+              "transferSize": 26415,
+              "networkEndTime": 882.75899999588728,
+              "statusCode": 200,
+              "resourceSize": 68826,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/linkedin-CoMnw5qu.js",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 837.14700000733137,
+              "isLinkPreload": true,
+              "transferSize": 1000,
+              "networkRequestTime": 840.1330000013113,
+              "networkEndTime": 880.32800000160933,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "resourceSize": 473,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/x-B1I3g_bH.js",
+              "networkRequestTime": 840.22900000214577,
+              "transferSize": 858,
+              "isLinkPreload": true,
+              "rendererStartTime": 837.40900000184774,
+              "networkEndTime": 880.9130000025034,
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 338,
+              "resourceType": "Script"
+            },
+            {
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 435,
+              "networkEndTime": 893.762000001967,
+              "transferSize": 967,
+              "rendererStartTime": 837.59500000625849,
+              "isLinkPreload": true,
+              "networkRequestTime": 840.61000000685453,
+              "url": "https://www.ocobo.co/assets/external-link-CfD0dRGr.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co"
+            },
+            {
+              "networkEndTime": 893.18400000035763,
+              "resourceType": "Script",
+              "statusCode": 200,
+              "resourceSize": 312,
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/chevron-down-Dfq6Rhgn.js",
+              "mimeType": "application/javascript",
+              "rendererStartTime": 837.77100000530481,
+              "isLinkPreload": true,
+              "transferSize": 843,
+              "networkRequestTime": 840.75500000268221,
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co"
+            },
+            {
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "networkEndTime": 879.95900000631809,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 309,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/Loader-Cf_o9nzL.js",
+              "finished": true,
+              "networkRequestTime": 841.09499999880791,
+              "transferSize": 834,
+              "isLinkPreload": true,
+              "rendererStartTime": 837.97800000011921
+            },
+            {
+              "networkEndTime": 1058.1580000072718,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 16573,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/_main.(_lang).jobs._index-Djw8wGmL.js",
+              "networkRequestTime": 844.55800000578165,
+              "transferSize": 5264,
+              "rendererStartTime": 838.19900000095367,
+              "isLinkPreload": true,
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 1217,
+              "resourceType": "Script",
+              "networkEndTime": 895.29900000244379,
+              "networkRequestTime": 860.33600000292063,
+              "transferSize": 1135,
+              "isLinkPreload": true,
+              "rendererStartTime": 838.35400000214577,
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/metatags-vCrX9zEO.js",
+              "finished": true,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co"
+            },
+            {
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/badge-i9dgPBIb.js",
+              "mimeType": "application/javascript",
+              "transferSize": 1019,
+              "rendererStartTime": 838.5190000012517,
+              "isLinkPreload": true,
+              "networkRequestTime": 860.472999997437,
+              "networkEndTime": 959.10400000214577,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 495,
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page"
+            },
+            {
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "networkEndTime": 894.30000000447035,
+              "statusCode": 200,
+              "resourceSize": 717,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/text-DlkbtvSW.js",
+              "networkRequestTime": 860.68200000375509,
+              "rendererStartTime": 838.75600000470877,
+              "isLinkPreload": true,
+              "transferSize": 1240
+            },
+            {
+              "url": "https://www.ocobo.co/assets/Container-AZtpvsXO.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "isLinkPreload": true,
+              "rendererStartTime": 838.984999999404,
+              "transferSize": 1077,
+              "networkRequestTime": 860.85000000149012,
+              "networkEndTime": 883.25999999791384,
+              "resourceType": "Script",
+              "resourceSize": 549,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "networkRequestTime": 861.06300000101328,
+              "transferSize": 1128,
+              "rendererStartTime": 839.18600000441074,
+              "isLinkPreload": true,
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/card-C2t40nZ4.js",
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 605,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "networkEndTime": 905.71100000292063
+            },
+            {
+              "transferSize": 961,
+              "isLinkPreload": true,
+              "rendererStartTime": 839.34100000560284,
+              "networkRequestTime": 861.28300000727177,
+              "url": "https://www.ocobo.co/assets/map-pin-BFjzXly_.js",
+              "finished": true,
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 438,
+              "statusCode": 200,
+              "networkEndTime": 1043.5499999970198,
+              "entity": "ocobo.co",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High"
+            },
+            {
+              "networkEndTime": 1068.8709999993443,
+              "resourceSize": 656,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/star-BI6vQnwF.js",
+              "finished": true,
+              "networkRequestTime": 861.42300000041723,
+              "isLinkPreload": true,
+              "rendererStartTime": 839.60100000351667,
+              "transferSize": 1176,
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 678,
+              "resourceType": "Script",
+              "networkEndTime": 1039.3840000033379,
+              "networkRequestTime": 861.63399999588728,
+              "transferSize": 1202,
+              "isLinkPreload": true,
+              "rendererStartTime": 839.79000000655651,
+              "mimeType": "application/javascript",
+              "url": "https://www.ocobo.co/assets/sparkles-Cv6LQ7xb.js",
+              "finished": true,
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co"
+            },
+            {
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/shield-check-CXoajV1s.js",
+              "networkRequestTime": 861.75300000607967,
+              "rendererStartTime": 839.99400000274181,
+              "isLinkPreload": true,
+              "transferSize": 1027,
+              "networkEndTime": 1065.3540000021458,
+              "statusCode": 200,
+              "resourceSize": 499,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "resourceSize": 446,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "networkEndTime": 924.9210000038147,
+              "networkRequestTime": 861.85199999809265,
+              "transferSize": 968,
+              "isLinkPreload": true,
+              "rendererStartTime": 840.18200000375509,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/assets/zap-C3uzvT7-.js",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co"
+            },
+            {
+              "finished": true,
+              "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+              "mimeType": "font/woff",
+              "rendererStartTime": 940.30600000172853,
+              "transferSize": 31975,
+              "networkRequestTime": 941.31100000441074,
+              "networkEndTime": 971.84899999946356,
+              "resourceType": "Font",
+              "resourceSize": 31480,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "entity": "ocobo.co",
+              "priority": "VeryHigh",
+              "protocol": "h2",
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "mimeType": "font/otf",
+              "finished": true,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf",
+              "networkRequestTime": 941.444000005722,
+              "transferSize": 38779,
+              "rendererStartTime": 940.67400000244379,
+              "networkEndTime": 960.22900000214577,
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 57572,
+              "resourceType": "Font"
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 58256,
+              "resourceType": "Font",
+              "networkEndTime": 969.92300000041723,
+              "networkRequestTime": 941.72500000149012,
+              "transferSize": 39127,
+              "rendererStartTime": 941.04900000244379,
+              "mimeType": "font/otf",
+              "finished": true,
+              "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "VeryHigh",
+              "entity": "ocobo.co"
+            },
+            {
+              "entity": "GitHub",
+              "sessionTargetType": "page",
+              "priority": "VeryHigh",
+              "protocol": "h2",
+              "rendererStartTime": 1138.3790000006557,
+              "transferSize": 2018,
+              "networkRequestTime": 1139.4540000036359,
+              "finished": true,
+              "url": "https://useago.github.io/widgetjs/frame.css",
+              "mimeType": "text/css",
+              "resourceType": "Stylesheet",
+              "resourceSize": 4371,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1187.027000002563
+            },
+            {
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "protocol": "h2",
+              "entity": "ocobo.co",
+              "statusCode": 200,
+              "resourceSize": 16667,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "networkEndTime": 1159.7870000004768,
+              "networkRequestTime": 1141.0370000004768,
+              "rendererStartTime": 1139.7000000029802,
+              "transferSize": 17171,
+              "mimeType": "image/png",
+              "finished": true,
+              "url": "https://www.ocobo.co/android-chrome-192x192.png"
+            },
+            {
+              "sessionTargetType": "page",
+              "priority": "High",
+              "protocol": "h2",
+              "entity": "Google Analytics",
+              "resourceType": "Fetch",
+              "resourceSize": 0,
+              "statusCode": 204,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1363.5760000050068,
+              "rendererStartTime": 1349.6970000043511,
+              "transferSize": 796,
+              "networkRequestTime": 1354.8980000019073,
+              "finished": true,
+              "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65d0v9100339653za200zd9100339653&_p=1778837389409&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1596769434.1778837390&frm=0&pscdl=noapi&rcb=2&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616986~115938465~115938468&dp=%2Fjobs&sid=1778837389&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fjobs&dt=Ocobo%20%C2%B7%20Nous%20rejoindre%20%E2%80%94%20Ocobo&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1348",
+              "mimeType": "text/plain"
+            },
+            {
+              "protocol": "h2",
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "networkEndTime": 1423.1530000045896,
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 97992,
+              "resourceType": "Script",
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+              "networkRequestTime": 1360.8930000066757,
+              "transferSize": 29952,
+              "rendererStartTime": 1359.6260000020266
+            },
+            {
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "protocol": "h2",
+              "networkRequestTime": 1361.1700000017881,
+              "rendererStartTime": 1360.3530000001192,
+              "transferSize": 28213,
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://js-eu1.hscollectedforms.net/collectedforms.js",
+              "resourceSize": 78203,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "networkEndTime": 1388.097000002861
+            },
+            {
+              "networkEndTime": 1411.8409999981523,
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 109001,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "finished": true,
+              "mimeType": "text/javascript",
+              "transferSize": 43666,
+              "rendererStartTime": 1360.9270000010729,
+              "networkRequestTime": 1361.9930000007153,
+              "protocol": "h2",
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "entity": "Hubspot"
+            },
+            {
+              "resourceType": "Script",
+              "statusCode": 200,
+              "resourceSize": 72678,
+              "experimentalFromMainFrame": true,
+              "networkEndTime": 1382.8940000012517,
+              "rendererStartTime": 1361.4540000036359,
+              "transferSize": 27219,
+              "networkRequestTime": 1363.7350000068545,
+              "finished": true,
+              "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+              "mimeType": "text/javascript",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "protocol": "h2",
+              "entity": "Hubspot"
+            },
+            {
+              "transferSize": 640,
+              "rendererStartTime": 1557.2960000038147,
+              "networkRequestTime": 1559.0450000017881,
+              "finished": true,
+              "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js",
+              "mimeType": "application/javascript",
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 404,
+              "resourceSize": 0,
+              "networkEndTime": 1778.9130000025034,
+              "entity": "Clearbit",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "Low"
+            },
+            {
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "Low",
+              "entity": "ocobo.co",
+              "resourceType": "Script",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 2495,
+              "networkEndTime": 1604.3540000021458,
+              "transferSize": 1868,
+              "rendererStartTime": 1559.3600000068545,
+              "networkRequestTime": 1564.4589999988675,
+              "url": "https://www.ocobo.co/_vercel/insights/script.js",
+              "finished": true,
+              "mimeType": "application/javascript"
+            },
+            {
+              "mimeType": "application/javascript",
+              "finished": true,
+              "url": "https://www.ocobo.co/_vercel/speed-insights/script.js",
+              "networkRequestTime": 1564.6309999972582,
+              "transferSize": 5314,
+              "rendererStartTime": 1560.691000007093,
+              "networkEndTime": 1595.7390000000596,
+              "experimentalFromMainFrame": true,
+              "resourceSize": 12567,
+              "statusCode": 200,
+              "resourceType": "Script",
+              "entity": "ocobo.co",
+              "protocol": "h2",
+              "priority": "Low",
+              "sessionTargetType": "page"
+            },
+            {
+              "resourceType": "Fetch",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 16435,
+              "statusCode": 200,
+              "networkEndTime": 1659.7960000038147,
+              "transferSize": 2496,
+              "rendererStartTime": 1563.5560000017285,
+              "networkRequestTime": 1564.7170000001788,
+              "url": "https://www.ocobo.co/__manifest?paths=%2Fblog%2C%2Fclients%2C%2Ffr%2C%2Ffr%2Fabout-us%2C%2Ffr%2Fcontact%2C%2Ffr%2Fjobs%2C%2Ffr%2Fjobs%2Fmarketing-brand-communication%2C%2Ffr%2Fjobs%2Frevenue-operations-associate%2C%2Ffr%2Fjobs%2Frevenue-operations-manager%2C%2Ffr%2Flegal%2Fcgu%2C%2Ffr%2Flegal%2Fconfidentialite%2C%2Ffr%2Fmethod%2C%2Ffr%2Foffer%2C%2Ffr%2Fstudio%2C%2Ffr%2Ftechnology%2C%2Fjobs&version=ba6d9b28",
+              "finished": true,
+              "mimeType": "application/json",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "entity": "ocobo.co"
+            },
+            {
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "protocol": "h2",
+              "networkRequestTime": 1586.8350000008941,
+              "rendererStartTime": 1585.3670000061393,
+              "transferSize": 204725,
+              "mimeType": "application/javascript",
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "finished": true,
+              "statusCode": 200,
+              "resourceSize": 607831,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Script",
+              "networkEndTime": 1623.0000000074506
+            },
+            {
+              "protocol": "h2",
+              "priority": "High",
+              "sessionTargetType": "page",
+              "entity": "ocobo.co",
+              "networkEndTime": 1700.5310000032187,
+              "experimentalFromMainFrame": true,
+              "statusCode": 202,
+              "resourceSize": 48,
+              "resourceType": "Fetch",
+              "mimeType": "application/json",
+              "finished": true,
+              "url": "https://www.ocobo.co/_vercel/insights/view",
+              "networkRequestTime": 1638.0509999990463,
+              "transferSize": 473,
+              "rendererStartTime": 1635.7060000002384
+            },
+            {
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "Hubspot",
+              "networkEndTime": 1825.6280000060797,
+              "resourceType": "Fetch",
+              "statusCode": 200,
+              "resourceSize": 5,
+              "experimentalFromMainFrame": true,
+              "finished": true,
+              "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+              "mimeType": "text/plain",
+              "rendererStartTime": 1805.9079999998212,
+              "transferSize": 557,
+              "networkRequestTime": 1807.8500000014901
+            },
+            {
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "High",
+              "transferSize": 1094,
+              "rendererStartTime": 1860.2980000078678,
+              "networkRequestTime": 1862.0710000023246,
+              "finished": true,
+              "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk=",
+              "mimeType": "application/json",
+              "resourceType": "XHR",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 135,
+              "networkEndTime": 1926.8510000035167
+            },
+            {
+              "networkEndTime": 2607.125,
+              "resourceType": "Fetch",
+              "resourceSize": 61,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fjobs&isMobile=true",
+              "finished": true,
+              "mimeType": "application/json",
+              "rendererStartTime": 2447.972000002861,
+              "transferSize": 1712,
+              "networkRequestTime": 2449.4289999976754,
+              "priority": "High",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "Hubspot"
+            },
+            {
+              "transferSize": 4083,
+              "rendererStartTime": 2811.5769999995828,
+              "networkRequestTime": 2813.4380000010133,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953",
+              "finished": true,
+              "mimeType": "application/json",
+              "resourceType": "XHR",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 9346,
+              "statusCode": 200,
+              "networkEndTime": 2944.7120000049472,
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "protocol": "http/1.1",
+              "priority": "High"
+            },
+            {
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "protocol": "http/1.1",
+              "priority": "Low",
+              "networkRequestTime": 2816.6430000066757,
+              "transferSize": 1021,
+              "rendererStartTime": 2815.5439999997616,
+              "mimeType": "image/gif",
+              "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+              "finished": true,
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 35,
+              "resourceType": "Image",
+              "networkEndTime": 2906.4060000032187
+            },
+            {
+              "experimentalFromMainFrame": true,
+              "resourceSize": 45,
+              "statusCode": 200,
+              "resourceType": "Image",
+              "networkEndTime": 3124.8379999995232,
+              "networkRequestTime": 2946.8150000050664,
+              "transferSize": 1524,
+              "rendererStartTime": 2944.6970000043511,
+              "mimeType": "image/gif",
+              "finished": true,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fjobs&t=Ocobo+%C2%B7+Nous+rejoindre+%E2%80%94+Ocobo&cts=1778837391443&vi=99d0f3d0fcee250b399997518fd723e8&nc=true&u=242475741.99d0f3d0fcee250b399997518fd723e8.1778837391426.1778837391426.1778837391426.1&b=242475741.1.1778837391426&cc=15",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "Low",
+              "entity": "Hubspot"
+            },
+            {
+              "networkRequestTime": 2973.8889999985695,
+              "transferSize": 1659,
+              "rendererStartTime": 2969.7629999965429,
+              "mimeType": "application/javascript",
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "finished": true,
+              "resourceSize": 607831,
+              "statusCode": 304,
+              "resourceType": "Script",
+              "networkEndTime": 2994.7630000039935,
+              "entity": "Hubspot",
+              "sessionTargetType": "page",
+              "protocol": "h2",
+              "priority": "Low"
+            },
+            {
+              "sessionTargetType": "page",
+              "protocol": "http/1.1",
+              "priority": "Low",
+              "entity": "Hubspot",
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "statusCode": 200,
+              "resourceSize": 35,
+              "networkEndTime": 3326.8149999976158,
+              "transferSize": 1024,
+              "rendererStartTime": 3191.9549999982119,
+              "networkRequestTime": 3198.2919999957085,
+              "finished": true,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+              "mimeType": "image/gif"
+            },
+            {
+              "priority": "VeryHigh",
+              "protocol": "h2",
+              "sessionTargetType": "page",
+              "entity": "Google Fonts",
+              "networkEndTime": 3221.8290000036359,
+              "resourceType": "Stylesheet",
+              "statusCode": 200,
+              "resourceSize": 3792,
+              "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+              "finished": true,
+              "mimeType": "text/css",
+              "rendererStartTime": 3202.7110000029206,
+              "transferSize": 1259,
+              "networkRequestTime": 3205.8940000012517
+            },
+            {
+              "mimeType": "font/woff2",
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "finished": true,
+              "networkRequestTime": 3254.5209999978542,
+              "transferSize": 51336,
+              "rendererStartTime": 3252.917000003159,
+              "networkEndTime": 3258.9130000025034,
+              "statusCode": 200,
+              "resourceSize": 50524,
+              "resourceType": "Font",
+              "entity": "Google Fonts",
+              "protocol": "h2",
+              "priority": "VeryHigh",
+              "sessionTargetType": "page"
+            },
+            {
+              "entity": "Google Fonts",
+              "protocol": "h2",
+              "priority": "VeryHigh",
+              "sessionTargetType": "page",
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "finished": true,
+              "mimeType": "font/woff2",
+              "transferSize": 51336,
+              "rendererStartTime": 3261.4120000079274,
+              "networkRequestTime": 3262.5170000046492,
+              "networkEndTime": 3266.7370000034571,
+              "resourceType": "Font",
+              "resourceSize": 50524,
+              "statusCode": 200
+            },
+            {
+              "resourceSize": 45,
+              "statusCode": 200,
+              "experimentalFromMainFrame": true,
+              "resourceType": "Image",
+              "networkEndTime": 3422.4380000010133,
+              "networkRequestTime": 3320.015000000596,
+              "rendererStartTime": 3312.5649999976158,
+              "transferSize": 1024,
+              "mimeType": "image/gif",
+              "finished": true,
+              "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=02232c85-acc8-4742-bb77-2eca1ba0135c&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fjobs&t=Ocobo+%C2%B7+Nous+rejoindre+%E2%80%94+Ocobo&cts=1778837391803&vi=99d0f3d0fcee250b399997518fd723e8&nc=true&u=242475741.99d0f3d0fcee250b399997518fd723e8.1778837391426.1778837391426.1778837391426.1&b=242475741.1.1778837391426&cc=15",
+              "sessionTargetType": "page",
+              "priority": "Low",
+              "protocol": "h2",
+              "entity": "Hubspot"
+            },
+            {
+              "networkEndTime": 3447.0909999981523,
+              "resourceType": "Image",
+              "experimentalFromMainFrame": true,
+              "resourceSize": 35,
+              "statusCode": 200,
+              "finished": true,
+              "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1",
+              "mimeType": "image/gif",
+              "transferSize": 1024,
+              "rendererStartTime": 3313.1709999963641,
+              "networkRequestTime": 3324.6340000033379,
+              "protocol": "http/1.1",
+              "priority": "Low",
+              "sessionTargetType": "page",
+              "entity": "Hubspot"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "final-screenshot": {
+        "id": "final-screenshot",
+        "title": "Final Screenshot",
+        "description": "The last screenshot captured of the pageload.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "timestamp": 64861018150,
+          "type": "screenshot",
+          "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAHyAPoDASIAAhEBAxEB/8QAHQABAAEFAQEBAAAAAAAAAAAAAAYCAwQFBwgBCf/EAEsQAAEDAwMCBAMFBQUGAwYHAAECAwQABREGEiETMQcUQVEiYXEjMoGRoQgVQlOSFjNSYrEXJCU1coI0N4MYQ6Kys9Enc3R1wfDx/8QAGQEBAQEBAQEAAAAAAAAAAAAAAAEDBAIF/8QALREBAAIBAgELAwUAAAAAAAAAAAERAgMEIRIUMTIzQVJxcrLBEyJCUZGh0fD/2gAMAwEAAhEDEQA/APVNKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFK+KUEpKlEBIGST2FR5rXGlXrh5FrUVpXLztDSZSCSfbv3+VBIqUJAGSePeo6dcaWTP8AJHUVpEvO3pebRuz7d+/yoJFSgIIBByD61qrzqG12VaE3WV5RC8YedbUGh9XMbR+JoNrSoF41yv8A8JL/ACYb/BjpUh1pfcFSeQRW2Or9PWaJAjXe+W6HKUy39m/ISlXKRyQTxQSelW40hmUwh+M628y4NyHG1BSVD3BHetLd9Y6bs8sRbrfbZEk5x0npKEqH1BPH40G+pVqJJYmR0SIjzb7DgyhxtQUlQ9wR3q7QKUpQKUpQKUpQKUpQKUpQKUr4tW1JNAKgnuQK+BxB7KFau5XGJb2DIuMpmMzkJ6jywhOT2GTWBD1LY5slEeHeLe/IcOENtyEKUr6AGgktKsR1k/Cfwq/QKUpQKUpQc38cH3l2ex2hLy48S8XViDLcQdp6KiSpOfTOMVI5ehdMSLCq0LssBMHYUBKWUgp4xuCsZCvn3rM1dp2DqqxP2u5pV0XMKStBwtpY5StJ9CDUPd0XrOTCNsla8Wq2qT01rRb0JkqR2I6m7vj1xmgghvtyf8D4cFU10ocvAsip6VYUuN1Snfn5pG3NdcRoHSqbH+6RYrf5LZswWU7u2M7u+755zVb2ibI7okaVMYi0paDSUg/Ekg5Cwf8AFu5z71Gk6J1oiJ+7k6/d/doT0wo29Bk7O2Ornvj1xmg03iDKk6E8FDH07eHpZbdTDROUsKWy2pZBG4eqR8IPcV0XT+nLZb9OItzbQkR3mQl9bx6ipGRypZP3ic1bt2jbJC0enTIiJetPTLa23viLmTkqUf8AETzn3rFVp66Wyyiz6YnpjRtnTRImrVIcjp7YQnjOPTco4oOKx33Y/hF4oWBLq3rdZpy48Najna31B8Gflj9a7PonSlmh6TiNmLGnKlx0OSZLyA4qUpSQSpRPcHPA9BWvHhnAj+Gs7SUCS4350FT8xxO9bjhUCVqHGc4xRvR2o7TE8hpfVLcK2hO1tmVBEhUceobVuHHsFZxQRTT8t7SH+1G1WQlUCztecgtfeDC1tKWpA+QIzipT4WaSsbOhrbJXDizpVxjpky5T7aXFvrcG5WSRyMntW60Xo6HpmzyohdcnyZzinp0qQAVyVq7lXyxwBUdhaC1Dp9DkLSGrfI2cqUpqJLhJkmPk5IQokHHsDmgseHzLdg8T9WabtY2WZDLE5tgHKY7i8hSU+wPfFdQqM6I0ixpdmY4uW/cLpOc60yc/995XoMDgJA4AHapNQKUpQKUpQKUpQKUpQKUpQKofGWjVdDzQR3UYkm2nyQnF7cP/AAXR6mP/AFfhx+taKypu/wC9GPNDUXRyd3mhB6fY/e6fx/lU2WyQfh5FUhpZP3aD6wPtBWVVDTYQPnVdApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlAoeO9KhWrrk6uYqI2opabA3AH7xIzRlrasaWPKlMDIZH/vUf1U8yz/NR/VXDNVarhaaehNzmZLhl79hZSk7dpSDnKgf4h2yaruOpo0HUUKzGNKdlSmw6lTYRsSkq25O5QPHfABOKluSN5lPHku4eZZ/mo/qp5ln+aj+quCXLW9sgahNncamLkJW2hxxtsFttSxlIJzntzwDV+76sg2vUUOzSGZSpMpKFIW2lJQN6ikZ+LPdJ7A0teeZ+B3TzLP8ANR/VTzLP81H9VcPa1PCc1EbMlqR5oOLb3FKdmUtoWec57LHp3zS26kan6hm2hNvuLL0QblvPNJDRGSEkEKJwrBI45ANLTnmXhdw8yz/NR/VTzLP81H9VcMtGqYt0k3ZmPGlJFtW4284sI2qUgkEJAUT6cZArE0vru06kuLcK3Jkh5UYyT1EpASAraUnCj8Xr7Y9aWvO8+P2dDv3mWf5qP6qeZZ/mo/qrhVr1ZDuTd3cZjS0NWwuJdUsI+MozkJAUT/Ce4FfdP6tgX+HMkW1mU4IraVqRsG5RUkq2pGfvcYxxzSyd5nH4u6eZZ/mo/qq4lSVjKSCPcVw/S+oGtQxXn2IU6KhpwtHzTaUFSgcHGCexBBqUWm4vW+Uhbaj08/GjPBFLI3tZVljTpNKA5AI9aVXeUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgVCtXW11ExUxtJU04BuI/hIGKmtDz3oy1tKNXHky4peLDbby7HcuUbrOR93SVvUkoyQSQQRz8I5+VUXDTtruF0iXKZF6k2Jt6LvUUNu1W4cA4PPPNdpMZg92W/wCkU8qx/Jb/AKRUpyRsso6MnEpul7LOu7d0lW9pycgpUHST3T90kZwSPmKvTbBbZ11YuUmNvnMBKW3gtSSkJJIHB7ZUfrnmuz+VY/kt/wBIp5Vj+S3/AEilHMsvG42iyW5F4XdUxUiesEF3J9QATjOAcADOM4FZDUGOzPkTW28SZCUIdXk/EEZ2jHbjcfzrrnlWP5Lf9Ip5Vj+S3/SKUnMcp/JxWBpu0wJs6XEidORO3eYV1FHfuOTwTgZPtiqbXpezWuY1Kt8FDEhpnoJWlSvuex557Dk88V2zyrH8lv8ApFPKsfyW/wCkUpeZZ+NxODpm0QV3BcWJ01XAKEn7RZ6m7Oe547ntir9nsdusxfNsipj9bb1Nqid20bR3PtXZfKsfyW/6RTyrH8lv+kUonZZT05uR2+DHt7CmYbfTbU4t0jJOVKUVKPPuSa3Fotz1wlIQ2k9MH41+gFdE8qx/Jb/pFXEpSgYSAB7ClGOx43llb6BgAD0pSlV9ApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArjviP44xtE6sk2N2xvTFsIQsvJkhAO5IV22n3rsVeLP2mf/ADeun/5LH/0k0HTWf2nLcXEh/TUtDfqpElKiPwKR/rXadF6qtesbC1drK6pcZZKVJWNq21DulQ9DXjF8StbWLTto0zpx1ybaWFolPsIBU+VqBSVYHYY7n3NTmdK1P4N+F0W2b0wrzfJjr5KSFqjtIQhJAPYKJI5GcfXsR6yqG+K51aNJr/sH0/3t1E7s7d3Twc7N3w7s47+mfWvHIuOslwBeRe55bUrAV+8/tVHOMhvfvIz64xXRZutNW3LwSujd+/eLEmJLjeXnrQtlTyFFWU7uNxGO/wA+aDrfgerxHUqd/tAB8lsHl+uEB7fnn7n8OM/e5zjFdYrwtobxJveljd5LU6RJmPxPLx/MuqcS2ouIJXtJxkJBx9aqif7RdSWq4aljTLzLgxFKMiSmWUhBA3KwncDgAg8DgUHsnXRvydKXA6RSyq97B5cO4xnIz34zjOM8ZrkvhMfF7+2DX9rQ9+5MK8x5rpf4Tt2bec5x24rn+lfE6+3nw11fZbtOeflRYKZMWZuIeCQ6hKklQ5P3hg9+9aTwQ1ZcIOuhNuVwnSokSDLkracfUoKCGVK7E49KD2nSvE6dUeIniZqpz9yy5y5KAX24kSR0W2EBQx3IHBIGTya0eudUase1VPN6mTYNyQUNyGGn1ISlaUJSSADgZxnjjmg96UrwLqrUF5bujIRd7gkGDDVgSVjkxmiT39SSa3PiLO1fDb0tKvF3XtkWph2EIr6wW2toAKu3xnGSeck96FvcNK8e3Txl1KjwzslujXB1FycU8iROz9sptJAQAr0PJyrv8I55NQvz+s40SPdU3q4APKHTKLnueJPYlsL3gfMiive1K8aa51nq+7aE0/8AvgXSHPjyX2/MBC2DJbKWylRxjJByM/T3qC2q4apu1xZgW2feJMx1W1DLchwqJ+maI/QWvJXip4s62sniFfbba72piFGkFDTflmVbRgcZKCT+Jr0L4S2S7ae0FbrdqF8v3NG9bqi6XCNyyoAqPfAIH4V5B8bv/NjU3/6o/wDyig9raNmP3DSFjmzHOpJkwWHnV4A3LU2kk4HA5J7VuK8Wa68StQyWbRp6zT5EG3w4ERjbHWW1POdFG4qUOcZOMZxxWoiXjXum7xH8ndbg7LPxpbjzBMSr5KShSh+B5oPdVMg9jXkLxu1zrCe3YxKRcLLBkQUOKZSFshx7JDmex4I4B9MH1qFaUt+q7ohMnT95/wB6KjtjpuqWpCiPZBWCaFveVKj/AIffvL+xNlF96370EZAk9f7+/HO751IKKUpSgUpSgUpSgV5F/aH0rqG6eKdylWyxXWZFW0yEvR4bjiCQ2kHCgCO9euqUHi3UvhlqSDYNN3mzWe59Z+JslssMr6zLyVKGSgDcAU7fT0PvW0tXhjqnVHhm+t+JPbvNvuC3GY1wSttbzSmmwoJ349UjHpwa9fUoPDsWyeJkO2GxxLRf2IZc3lDURSec5/vAM4zzjOKmGqNMak074IXF7WNxlOS5syOGIb8ku9FKSo+pICjnkD0A/D1lXC/2gPDbUmutRWp2xIjmKxGLbi3nwhIVuJ7ck8fKiOBeGOin9dP3q3wVoTPYg+ZjhZwlag4gFJPpkKPPvitlGsfifYbZO0/Dtd/Zt8skSGGI6ltryMH4gCOQADg8ivRfgh4U/wCz5qXMuEpuVd5aA2otA9NpAOdqSeTk4JOB2H47DxC8XbBoS+NWq8Rrk7IcYTICozSFJ2lSkjkrBzlJ9KDi2l/Ca/WXw11Zc7lBe/ek2EmNFgNJ6j23qoUokJzydo478HNafwQ0Nezrxtm+2K7Q7dIhyY7rz8RxtIC2VJ+8oYzzXqnRWpoWsNNxb3bG324kkrCEvpCVjaspOQCR3SfWsLxC1xaNCWhufei8Uur6bTTKNy3FYzgZwBx6k0HkR7QesdP3jraXEuayolMe5Wd0qS4gnuVIOU/MHGKiOqIT9v1BOiTZaZktpza8+le8Kcx8XxeuDkZ9cVuNL6XumrLjcWdLvpWWEGQpL7ojq6ecFRydvGRn4vWug6E8CJtyu0f+0V2tkeLuyqPGlJefdA5IG3gfXJ+lBCNQaQ1LPmRZMHT93kxlwIex1mE4tCsRmgcKCcHkGp14y6W1BPtOgUQbFdZK41gjsvJZiOLLSwkZSrA4UPY816yisNRYzUeOgNstICEIHZKQMAVcoU8cR/CPUV48Mok6LbJTN2hS30uQpLZacdaIQQpIUBnB3fXPHatNHs/if+7mLLHtWoGYjK8oQiKpoA59XABkc+pxXuClFeXblH8UtE6Ki26J+97hcbqVuyHWUuy1wkJACW0qGQlRyokj5Y7Zrl9tsXiJa5b0q2WrVkOS9/ePMR5Da1855IGTXuiVcYURwIlzIzCyNwS46lJI98E1ejyGZLQdjOtvNngLbUFA/iKCK+Ehuh8ObGb/AOc/efSV1/O7utner727nOMd68t+MOkNSz/E3UMqDp68SYzskqQ6zCcWhYwOQQnBr2lSg8d6/wDCLUrDVpvVlt0mW1JgxlPMNIPWjPBlAUCjv3GeOxyDWDGsfixqS5xk+VvsdxADaXHEKhttj3PCR+Pc17SpQeX9eaf8TtOzWI9pVcb5bRFZDq3EJmIcdCfjJbXuI5zjjtiuYr0NrjUN4U6NKzmJDpGdsDybQPbONqUivd1KDR6Gt0+06Ps9vvEjzFwjxkNvObt2VAe/rjtn1xW8pSgUpSgUpSgUpSgVzfxa8WLb4eqjRXIrk+5yEdRMdCwgIRnG5SsHGSDjj0NdIrxx+1NFks+KTj76VdCREaUwo9ikDaQP+4H86DoT37SkP+zzUpiybrp1+m7DXIIARgkLSvac9sEYGKqjftEPvaXuF3/s22DFlx43S86fi6qHlbs7OMdLtj+L5VwvWWo7He7Pao9m0tHs78RO1+S06VF849eB6gnJyas23/yxv/8A+6wP/pS6I7a3+0x1LXOcVYG2ZqNgjNeZK0uEk7io7RgAD8SRW5k/tBRYGi7VcpVrD15n9RQhtO7UIQlZTuUogkZKeBg9jUF/ZTstsvN41Ai7W+JNQ2w0UCQ0lwJJUrOMjitN+03Zm7N4gsohw24lvchNlhDLYQgYKtwAHGc8n60EuiftOTBIHnNNR1ME9mpRCgPxTg/pUD/aA1PA1fqiz3m1Ffl37U2ChYwptQddBSfmDWJetdadn2W0wmtCWtp6GkJee6q0l7CcHlG08nnkmozq12PIet8mFZm7PGfihaGUPLcC8OLSV5WSRkpIx24+dB0jTvjBdtGeH2m7ZYYTSw31zJflNKKFKLylBCCCOySCf+oV0PU3izZb94SRb5ctNxbooz0wpNvkOYSy4W1q3pVtJ7J44B5PtXMdWpH/ALOehVYGfPyuf/Uc/wDtUPgKP+y69pydou8Egf8Aoyv/ALUHTbXrq1S/DjWqNO6Ii2tflUMOrjvFxRQ7uSVE7M4TjOO30rmPhffZOm9dWu7Qreu5SI5c2xUEgr3NqSewJ4Cie3pU38DWlvaM8Tm2kla1WcgJHc/C5UM8KNSRNI6/tV7uTbzkSKXd6WQCs7mloGASB3UPWg9J+I3j1adK3l+0263uXWZHVsfUHQ22hQ7pzgkkevHFabTH7SdtnXFmPfbM7bmHFBPmG3+slBPqobQcfMZ+led7hIQ1rd+Xc2HFMLmGQtt1vcpSFq3A7cgHIIOM4PvW6uN30dJ1Ap5FiuMuOoJSlDbrUIKPyabQoD+o0Ho7xW8brfoq6C1W+D+9LgEJcd+12NtBQykE4JJIIOPYjmoPav2m3fMpF10435cnlUaQdyR9FDB/MVyPxPiPWnxBkJmwXGkhMdxMZ9ZWen0kYQVfxYA2k/I1s9Va701eZ0R6NoG1RWmW9i20vOI3n/09g/ME0GT+0RqVrVGu2JkRlSYKIDCIzpz9uhQLm/GOMFwpxzyk/SuleAXiDF074YXH9+xHY1ttSwpqSMqMpbq1nYgYAyCMdz35xXKvF9kiNo2S1av3VFfswLUYLU4lH27ysBSuTwtKue26qZmp49w8F7fpiKxLMy3TVTZK9g6XTUVJHOc93E9xQdTkftOoElQjaYUqPnhTkzaoj6BBH61PdOeN2nLvpG6Xp1uRFetiErkQ1YUs7jtTsPZQJIGeMeuK8sabutgi6buMW7w3Xprp+xU1HbKiMfzVklvH+VJqVaOm6STpjUrzul7oqI3FaalP/vEKOFvthISNgSFAjcM/4SPWgmkv9pyaZB8npuOljPAdkqKiPwSAK6X4PeLbfiJOmQlWlcCTGZDxIeDiFDIHsDnmvK8len7Qpu5aZusmTKSrAiXK2NqASe+SVKQcfT8q6t4MeI1tgMalu9w09DjzIEAOrk25roh9JcSkIUgHaFFSk8gDjPtQepKVxXwt8cm9a6rascqzGC7IStTDiHuoCUpKiFDAxwDz8q7VRSlKUClKUClKUClKUCtFq3SVj1bCRF1Bb2pjaDuQVZStB/yqGCK3tKDn73hBot2wM2Y2ophNvmQAh5aVqXgjKlZyeDjBPFWGvBbRLVpk21FufESQ82+4nzTmStsLCTnOezi/zro9KCJaI8PNO6JkSntPRHI7klKUOlby3MgEkfeJx3raao0vZdVQUxL/AG9mayk7kbxhSD7pUOR+Brc0oOaRfA7QEd8Oiylwg52uSXFJ/LdWx1R4UaQ1NMjybpbSVx46YrSWXlNIQ2kkhISkgfxGp1Sgg03wr0pN0vb9PSILyrXAcW6w2JCwUqUSSSrOTyo96wW/BbRLdpkW1FufER95uQ4nzTmSttK0pOc57OL/ADro9KCJaJ8PNOaKdluafhuMKlpSh3e8tzcE5x94n3Naa5+C2hLjPclvWQNuuK3qSy8ttBP/AEg4H4V0alBDNReGOkdQsxG7pZ2lmK0lhpxC1IWEJGAkqBBIAHrmrGmvCbRmnJ7c622ZvzbZy24+4p0oPuAokA/Op1SgjmrtEad1ehsagtbMtbYwh3lDiR7BSSDj5dqjlr8FdB26UiQ1ZEuuIVuSH3luJz/0k4P410alBo9U6TseqrciDfbezKjoOWwcpU2f8qhgj8K0ml/CzSGmZEl612oBclpTDoedU6lTZxlJCiRg4FTelBzN/wADdAPSC6bKpBJzsRJdSn8t1SmLofTUXTjthYs0RNpd5cjlGQs99yj3J4HOc8VI6UHMXvArQDrm/wDc7iP8qJToH/zVKbNoTTNmssq02+zxWoMtOyQggqLw/wAyjyfz49KktKCG6Q8M9KaRuS7hY7YGZiklIdW6pwoB7hO4nH4VMqUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFaW6aii22a7HfYlKQy0h559CAUNIWpSQVc57pPYHFbqorfNOPz785cEKBQERkhlTqg26ELcK0rQOCMLBGc8gVYSUh8/D895Lzcfzm3d0OoOpj325zirJu0RmM29PeZhBxZbSH3kDJBIwCDgk47ZzUZTp6VHuS3XGWnY6Zy53mOusrAKirAbCeVDO3vggdvSqbVaJ6EszkwmHy6y82Y0xRbLYU8tYP3T3CgFDGeBSi5Sxc5tuS629hptCUK6y3EhJKiQB3yO3qADnjPNU/va3eRE3z8TyZOOv1k9POcY3Zx3qK/2RliOiOtxl9tLNuaJWT8fQeUtfHPBB4rKkWCW3ezPjsxnmUzFPpjLVtBSphDZUOCAoFJ/BR5FKguW7h3qDJSo9dtv7ZTKA4tI6hSrblPPIJI/MVkx58OTIeYjy47r7Jw4224FKR/1AHI/GorYtLPxrpHlTGoiUtecUlLRJDSnnUKTtyPQJUM8VVpfTku2y7f5lhgJgsqaD6ZClqdJwM7cAAHG45J5x9aVBct5PvbMWWqM1Gly320hbiYzW7pg9skkDPyGT8qupvVtMOPKXNYaZkHDSnVhvcf8ADhWDn0x3rBXFudvutwkW5iNKZmqS6pLrxaU24EJR6JVlJCU/MHPfNatnT0+C75hLEK4uvMOIdafWUIbWt1biin4VZSSvB9cJTShKXrhDZlNRXpcduS7y20pwBa/oM5NY0a9wX5bkUvtNSUOqZS04tIW4UgElIzkjmo+9p2d0J0VLEFSZvSJkBRSY5ShCDsSQScbNyfi7n8Sf09NW5c2hGhbJs5EoSt56jaU7OcbeVDZxzjn5cqg4pS3PhuzHIjcuOuU2MrZS4CtI9ynuKuyH2YzC3pLrbLKBlS3FBKUj3JPaorAsE1hy3sqaipbhSnJPmkLPVe3b+CNvBO/4jk9vnxsLrEmXW2Wx8x2m5bDzcpyG45lCiEkFBUB6FWQcd0ilDZN3KI64yGXkOoebU6h1CgpBSkgE7hx/EK+x7nAkxVyY82M7GQSFOodSpCcd8kHFaSXZJM/TlyiOMQ4UiUtSkojklOMpOFKwM7tvxEDsfXucFGm5Lrc1yRCZbW6WNraZiyo9Mk7irbjIJ4G3nHJ54Fy3svUtniSoUd+4xULmAqZJeSAoD1zn17D3NZz8xLElLbqdrXSU6p5S0hKAkjvk59e+McckcVGoljucc2t9SYj70Z94qS4oIPTX2O5CMFQ4/hGff1N/VtilXdb5jFoBdslQxvUR8bhb2+nb4TmnA4thP1JZ4MQyX7jE6IfTHKg8kgLUoDB54xnJ9gCavO3u3NuwmxLYWuYfsAl1J3jGdw55H0rTXTTz7j8tyC3FSktwy02o7UqWy8pZBwDgEEDOD9KwrppufLmznDGjOJnpa3ZlLSmOUpCSkAJBUBjcCCk5J7d6VBcpY7c4DMryr02M3Jxu6SnUhePfGc4ou5wEIeUubGSlkZdJdSA3yR8XPHII59q57qBKUSLha47lukPyrg08ELCvNBW5BxsxykAcLzgJ+lbp3Sz6ba2Gm2FSUXN6ctAcKA8lS3NoKsHkJWk9jyn8aUWlJuMERm5BmRhHc5Q71U7VfQ5wavqeaS70lOIDm3fsKhnb749vnUVtum3EvW52VGjJDMp6SpoOKdCSpG0EEjk+pwAMk/WtjdoM1V3RNgoZdzEcjKS4so2kqSQrscjg5FBsVXOAlbKFTooW9jpJLqcuZGRt55yPaqhPhqnGEJcczANxYDg6gHvtznFRJvSckWObHWmMZrsGNHbcz91bSMZzjIG7kVXD03LZuyC4yytlM5yZ5kyFbsKUpQAQB3+Lb97GB88UqC5TOlKVFKUpQKUpQKUqB6qv1wj3ea3HSltq3IbeQFqQlLxUD94lxJ2/wjCVcjPPAqxFpM0nlKg171HcYzN5lNSoccQHkMIiOt5UvclB3E5BydxxgY+H8s5d+eLUFta2S7IuUiItGOemjrY49OEI5+fzpRaV0rntrvk1yOwxHmW62MM2aNNSlbWRuUF5H3hhA2j580Orbs86p5DCIyGvL5ju9Mb+ohCiCVOBQOVlIwk8p9ewUW6FStHqCfJZuFrhRX2oolqc3SHEbgNoBCEgkDcc/kk1GoNwlwtMzbwy+3IdEp6OAj+6yqUUl3BUBgA55OMeuOaUW6DSoN/aO6R7bPeUG5L0N9pKGgEdSRuHLWG1KAXzkHPtkAZNX03qfJk2yMi5wGBJgrlrf6W4FQUPhSCRwATnPPw+nootMqVzh/WF2cZU60lhkMQ25JJCNj5UVc5W4khB28bQTz+BzNRT7vKtOqVtS0Q48Fna2G28ubiyhZyrPGNx7D/SlFp3SoZcr7NhKbcZnx5NvbaS45JabQ6TlZB3JCwQnAABSDzn2xW11FKXFuERTLcZTyY0lxtb52hKkpSRlXok+vypRbfUqEN367qjuMhTZnJdaCkLabQpKFpUfg+1KFn4eBuBwCeeM3Y2pnzEkvOvNbW7e4+lamunl1C1pVxuPbanOCRzwcEUotMqVDIuoLiq4w/NLZREeUy2C20lYUpbaThRC9yFbicfCRjH4Z17uUtN5ehMTYsFpiH5oqfRu6pKlDHcYSnaM45+IdvVRaS0rl1u1Nc41khojJbbah26I4A508PFTSSclS0qAz8I2pPIPftUnRep6dRpYkqaRDckFhoNtpcCvg3YKgvclWQe6cYH40otKsDOcc+9Kid4u81GoZ8Fi4woLMaC3KCn29xUoqcBzyPhG0Z9eaxLJeJC5qZK2xHE+YwHm3P/AHYVDC9vyO4AUotN6VBJGprmtl1+M5H8s07KC3EIS4oJbc2pO0rTlOAckZPas/VslZOmXmJDTCnZww66k7QFMO+mRzzwD64pRaWUqAvaluolC3tracKZDzRnNIbAcCENqAAWtKd32hB5P92rj2xrnPfuNsVKkdMPLtD24tEFKsOpG4YJHOM8E9+570ot0elQZ3UtzF7eQlDaI7U9EMML6Y3pJSN2SvfuOdwwnGMfUbCzXme9ffLT1tBt3rdFLTaVIUEK4IWFk5wRkKSOfalFpTSlKilKUoFY8iFFkvNPSIzDrzRy2tbYUpB+RPasisGRd7fHmohvzGESlkANqUM5Pb6Z9Pegs32yxbtEfbcbaQ+430xI6YK0jPYHvWZ5CJ5lUjyrHmFEEu9MbjgYHPfsSKxmr5bHZbkZucwX2925O7tt+9z2OPX29axX9SQfJ+Yguol4fYZUlKsEdVxKArt25JHvirxTgvGwW5U9cp2M06VNtNJbW2kobDZWUlIxwfjP5Cs12DEektyXYzC5DX3HVNgqR9D3FY6L1bV3EwETGTLBKemFc7gMlPtkDnHestUhlMlMdTiQ+pBcCPUpBAJ/Mj86ivkqLHmNdKWw0+1kHY6gKGR24NfUx2UsqaSy2GlZ3ICRtOe+R861r2pLMyGy7cY6d7aXk5V/Arso+yfmeKyf3xbvPiD51jzZOA1vGc4zj645x3xQXY9vhxm2248SO022orQlDYSEqPBIA7Hk/nWLIsVvkTEvyIzTqQ2UdJbaVN8q3FWCO+fX5mrky49CWmIwwuRJU0p7YhQGEhQHJJ4znj6GtS3qkeTZlyYLkWM5JMfqPOo4IKkk8E+qPxzVTg3r8CJIWyuRFYdWyctKW2FFB/y57fhV1LTaS4UoSC4crwPvHGOffgAVrnNQ2luI1KVOZDLqlJQc5Kin7wx34wc+3rVuRex5yPHgRVzi8wZKVtOICdmQAck85z6VBsHIERxbK3IrCls/3alNglH/AE+34VdW02tSVLQlSkggEjJAPesBV7gNy24kiS0zMVtBZUoEpUrskkcAn0Hr6VZlaghNyEsRnW5D4kIjuoQvloqUU5P4g8UGam2QExlxkwoojrOVNBpO1R9yMYNVOW+G6hlDsSOtLP8AdhTYIR6cccfhV1iQzICyw6hwIUUKKDnCh3H1FaV7UjbNyejuQ3wwzKbhqkbk7Q4tKVJ4znHxpGcfpQbYQYiZCJCYrAfQnYlwNjckewPcCvsmHGkqbVJjsvKaO5BcQFFB9xntWHHv9qkoUticytKShJIPHxq2pP0J4B7GqLje24spmLGZXMlOO9EttqSNh6ZX8RJA+6P1FBmLt0Ja2Frhx1LjjDKi0klv/p44/CqxDiiX5oR2fM429bYN+Pbd3rT3PUiLVEkyblGLKGGUuqbS4Fu5KlADaOMfDwc+/tW6iyGpUdLzCiptXYlJH6HmisJ6yQZFzenSmESHXG20bXUJWlGwrIKQRwfjPP0rLfhxn23W347LjbpBcStAIXjGMg9+w/KtOrUqRHVMTb5arWlRBmDZt2g4Lm3du2fPHbnGOaz1Xq3JuAgqmMiUSE9PPO4jIT7ZxzjvV4pwXXLbBcQhDkKMpCFb0pU0khKvcccGr78dmQkJkMtupGcBaQoDIIPf5Ej8a1w1DaVPOMonMrdb37kJOTlGdw47kYOR3qxC1TapVojXBUjosvhO1LqSFZKd20DHJx7ZpUnBsnbdBdiJiuw4y4qezKmklA/7cYq4qLHUnaphop2dPBQPu/4fpx2rHZukd+VFaYUHUSWVPtPIIKFBJSDz/wBwrOqKx1QoipiZaozBlJG1LxbG8D2Cu9fWocVmQ4+zHZbfc++4lAClfU9zV+lApSlApSlAqO3GySnr2JkRxuOFuNLccQ44lSggjKVIzsXkAjJwQD64FSKlBFY9iuseEm3MyoTcRhDoYeLO93KkqCSQeBjdyR97Hpk1jI0vcFSnXnX2ftvKFSS644Ulh7qcFXcKBPtg4+tTOlW0pEIWlpMe6oJeaXBbluTEkvOlZKlKVt2btgwVH4vYduc1s5lqlIuMaZbnUKWhlxhYlLUrhZQdwPJJBR29c9xW8pSykCt1iu8ORKhxREUn92RYS3pDatpKQ4CpOB8WM/dOO45FbSJpuTCuUZcR9LUZpSFOKS6vc8EoCcKbPwZOB8ffjtUppSymp6Djeq/MbFFl6GG9wHCVIWTg/UL/APhNYzVjcTBgsLW2ox5y5Z4OCCtagB8xuH5Vv6VCkOnaWlm4uT4jzReLrxDannWU7HA3/E2Qcgt9uQc1lQ9KRkPQDOZiS2o0QsbXGtw3lQUVAKzgcH1zUnpVspGJen5bi50Zl6Mm3Tn0PuEpPVbwEApTjg/cGD6fOvsvTK5Ntci9fol24mYtxklKikr3YB7hWMDNSalLKaWwwJ1pZi2/Md2AwlaEuchzaCnpgjtnG4E+uAfU1Qzp9pFwvE4txvOy3d7EgtBS2vsUNjk/NJOPnW9pUspCjYJUePKcuKlSG3oXlXER1uOubgfhWjPbkk4GAnA796v27TTsm32hV8THkykvqmTUuthSVuKbUnAHI+HKQPkmpdSrZSN3TTQlJuTUVbMViTBREaShHDZSpas7RgY+McfWtvB/eIeUid5ZTQaRhxkFJK8q3DaScDG3HPqazaVCkHn6dvzdubtlvlxV2tCFRyhW5Lio6sAo9RvA4C+PmOa2C9Oyip6Ih9gW12aJylFJ6yVBYc2D0+8nv6DjHrUopVspHYen3WG4CS43mPcJExZAPxJc62B9R1R+RrHh2G5wWLUpqTDek21pcZsKbUhC2lBA55JC/gScjjuMetSqlLKRePbJcKRCYYKXH225UhTxQUtB1xQIT/05UrjOcJqTNb+kjq7epgbtvbPriqqVFKUpQKUpQKUpQKUqy1JadfdZbXlxrG8YPGe1eZzxxmImenoWImV6lKV6QpSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlApSlArUWv/nd1+rf+hrb1qLX/wA7uv1b/wBDXBu+20PVPsya6fVz8vmG3pSld7IBBGQQR7iqWnEOtpcaWlaFDKVJOQR7g1GLdbrhGVFQ60+raEbVtytiGgD8QUnPxE8+hznGU4zWRJNwb0lKacS63NaiYDqV5Upe3kgj1BoJDSok/AuhSsR25aGFupw2uWVLThCgVbt4+Enbxk9s45xV62Rrsi6Q3JKJBR00h4uPAoSQ3g4CV8ncM4KT3J3elBJVuIbKQtaU7jtTk4yfYVVUWnW25PXFK2w8VplF0Pqf+yS3sISAjPcEj09zn0rK05DuEZEjzJfSVNpSkSHur9oM5UOTwePUZ9h6hvXHENNqccUlCEjKlKOAB86qrSzv3gzp6b1lqdmKQUtFhJUckYGMD39fx4HA10qJenEPMNB9OFSSl4PgbgtWWwOc/CDjkDGOOKCUlxCXEtlaQtQJSknkgd8D8R+dVVGHbbdUPyW4zr3ldy+lukEqKSlnjcSSCSHQD6Z+lfYduuC5iXHFTGIgDqm2VytykEhsJ3EE55CyBkgZ/Cgk1K0Fphz1WqbHkmQw4vKWnHHSpY+H73C1Y59iPoKwJcC9yGGHXDIDzocU40xJCeis42c5AKQBzjPJJwc0EuqlLiFOLQlaStGNyQeRntmow7a7qG3XGn3/ADLjjySTIO0NkHZgZwDnbggZGaoiQrjFuDspmJL6C3E/YrkpW5tDak8kqxgKIOMn3+VBLKVF7TDuzFxgKlB9aAygPqW/lCSGsHACuTuHqk9yd3pVyRCua5EwM9dL6+qW5PmcNAFJCE9PnkHHoO2cntQSSlRZq1zpD6Avz0aESolpUwlwHZgEqCicE8gZ9M+uKpj2m6BiK249KO9uOZR8yc7wT1MHPGR/h49qCV0qJi03ZqKRHkSeuoSEEuSSr4N/2WMk4O0AZ7881lxIVxTZJzQVJbecVlpLz4U4lOBkbgTtJwrHxHGc8dgG/S4hS1oStJUjG4A8pz71VUNXa7l1JDjTM1uM4+lXREodYp6YT97f2CsnG71+WKzbZDurF3jqk9d1oNgOuOP5QD0wPhAIydw9UepOfSgktKUoFKUoFKUoFai1/wDO7r9W/wDQ1t61Fr/53dfq3/oa4N322h6p9mTXT6ufl8w29KUPY4rvZFKhiLNdeh0lKf6KXUKWPMZddASsEZPwkZKDnCScHI7VlMWW4NhDinnVPtqjbCuQVYQlQ6gPYHKSRnHPFBJ21pcbSttQUhQyCOxFVVFWbVc0ljqqUt8dEiR1zhoJSAtBT/FuIVz67ufuiiLPPYTag0XnFtIbDxXJJSVbgVqPIOe+MZHoRiglVUlaAtKCpIWoEhOeSB3/ANRWG+3O8+lxl1HlUp5aPdRwr5cd0+vpWDdrW/cZsGUgiO9HYcKF5yW3SUEfUYCgfcGg3aFJWkKQoKSfUHNfaiTdoufl46XEjq9FKUlt8hMZ3epSlem4EFPp/DjsTX123XZ1tLSw6lLTK2ypuQApw9VCgR/2pPBx3I470Esq2l9tUhxhKsuoSlSk47A5x/ofyrSGDOVZYTTiNy2ndzzCXiOoj4sJ3EnnlJxnHGM4rHTZZXXEkBTbyRHCB5hStoS6pSwSe/wKxz9KCT1bkPNxmHHnlbWm0lSlY7Ad6iUSw3LYESZEkqUWxIX5nAew4CpSQACMjPqDzj0BrIl2ia83PZ6alLdS8EyDJICkqBCEbPTGQPwz3JoJTSow/Z5bchwNoW/B3qKI4kqQcltACt2c8KC+P82e4qgWS5BG9UhxcorKVuJkFOUeXKeO4H2mD2780EnedbZbU46tKEJ7qUcAVUlSVDKSCM4yDUdjW2crT8yI6nDq3AWt7mVFPw/e5IByD249eCTVNws8pd4Q7GW+mOChSOm+EpQd5U5kEHO7Pp37HA5oJLSomxabm2xiQFvo64dLIkEEtbVANZ/ykg5/ir6bPcVXBh0uPpSnpbNkrKWgn7yTlOVZ559c84wDQSaPJYkgmO824AATsUDwRkH8RV2oamw3BEVlBKwhPRDiGXQlSwlopIyeDhWDg+1ZDFkuKEdQyHTKQpgNrU+VbUhIC89gf4vTniglVKiS7RcFwm20IdZCVtl9KZW9T4SFBRBVwMkpPOM4wcVIbNHdi21hl9a1uIGCVr3nvwCrAzgcUGZSlKBSlKBSlKD5mtPaz/xu6/Vv/Q1tSrFaa2K/43dfq3/oa4N322h6p9mTbT6ufl8w3maZqzvr4Vcd672K/mqVuJQAVqCQSAMnHJ7CoM/ZprUZhPTSpW9pD5Q6o+aIWCpa+OOAc9/vY7Cq5mnpr7SENuBppPVLTLb2EsFRG0pJQe2D2wRnA4oJxmrS5DSFFKlp3DblOckbjgcfM1FJNjkriOIHTdddlOOuKcWTlJ3bO4I4yOMYHcc19j2SQ0+3I6cYSlNRkuyAr7QltYK+cZIUPn6UEvzTNQxuwyiltDnTT9wSFpeUTKIcSorUMcHAVxz97HYVV/Z98h74kZbQsRPtFYaV1VqQR7YSUj8x2oJa++2w31HlhCMhOT7k4H6kUYfbfbDjKwtBJGR8jg/qKhqNPzhKedU/uK3NyipwEODrJWMgIB4SCBknHYcUc0/OVJYX18JbHwbHAOkrqqUVDKCeUqA4I+7jsaCbZqyuWwhhTynUdJJKSvOQCDgj8+Kjl6tEqdeWpTbyg0hLYRhYHTIWSogFJ7ggcEZxg8Uj2VUeyzYMdiKyXX1uJLfAUC5uG7A4IBx69qCU5pmoxardNjXx2W90g06HAsIXncSsFJ7ZOAMck4zxgVjuWmZ05KW2o/VdyFvKeXl4FwH4hjHCcgZyB27ZoJfmmagTdmnBTMWSw3JQhqRsCnVJQgqcBRyE4BSCQMDjHFZLtluipanUSUIcU2poyArCjlraFEYzkK5xnH40EwceQ2UhxQTuzjPyGa+9Zv4PjT8f3Pi+9xnj3qLpszrjaWjGjR4xKg4wl1TiVZbKckEAdyD29MnmsRGnpSZMNbfSjIYS0EoYcAS2UqJWQNmfiHfBGexoJp1E9TZuG/Gduece9VZqMXK3TX76xMZ6QQ0tvCt+FFIzuHY+/oRn1q7Kt77l3MkNtOAqQW3lOqSplI+8lKR3z37855yBQSLNM1DGLBJIYQ8GktJLfmAl1SvMlJO5auO59vXOD2FWZlikxLU95TPXLb7aumtRUpKnAWh7/CkY+XpQTnNM1FI1lcExlam22IiH+t5dt1RSMIwD2HdWDjtxnvWFC03NbG2TILm5TfXUXeH8OBRUQEg8gEck98dqCaPvIYZW68oIbQkqUo9gB3NXAag8zT0t2HJYww6FNOtRgt1SRHy4spI4/wACkD5bcdjWRMsL7rCwF5U5MW+6nqf3jfxbU/ElQ4yDjGMigmGaZrW2lpyJbYzDzinHG2wlSlK3En64GfriswOfOgvZr7mqAc19zQY/KjhIzWvhQZLVznvLQA26UbDuHOBzW4bTtSBVVZamjjqZY5T+M3H7THy9RlMRMR3sTpO+36186Tvt+tZlK1eWH0nvb9adJ72/WsylBh9J72/WnSe9v1rMpQYfSe9v1p0nvb9azKUGH0nvb9adJ72/WsylBh9J72/WnSe9v1rMpQYfSe9v1p0nvb9azKUGH0nvb9adJ72/WsylBh9J72/WnSe9v1rMpQYfSe9v1p0nvb9azKUGH0nvb9adJ72/WsylBh9J72/WnSe9v1rMpQYfSd9v1r4W3fb9azDVJ7UGM02rqALHH1rTWPUgvF+u1pEVLTlsO15fVCgSSdm0Dk5SMntg8c1vzkEEdxWEzb7dCcMiJCZafwpO9KMH41blZPrlXP1oMpCqu7qxWzV/NBfpSlApSlBZmPpjRlvK5CR2960tsvpkTEsvBOVcJCR+v/8Afet4+yh9GxwZTnOK1MPT7UW4JkpdUUpyUox2/GvmbyN79fTy29ci/u/v/d7p0Z0eRlGp09yO3jX6rfrRVhTBZd2vR2ifM4eUHR95Le3kJ7nkcCs9zxD043GW+5LdQ2NuwrjrT1UqUUhSMj4k5BGRx+YqQRrZFjXGdOabIkzdnXUVEhWwYTx2HFaROhLGhl1pDUlKVpCE4kufZoCioITzwjJJ29u3sK+m5lxWtbKJqYiXn1yVNBxLaY6ySS2XAjt98pBIT3quBrC1TbKi7NqkIgqkiKHHWVI+MrCPX+HccZ7VitaAsDJ/3ePIYBYEchqS4jKQgoBOD32nGfp7Cs+Lpa1x9OPWINvuWxxBbLTz61lKcYwkk5SBjjHb0oMRnXNiefYaRIePWKQHAwsoTvWUIKlYwkKKTtz34PqKzLHqm03yFKl2+SVxo2eq6ttSEgAEk5I+R+lWDoyyeYiupjLQI6GW0todUlCg0ct70g4VtPIzV606VtVrM8xmVqM5AbkF51ThWkZASST/AJj8+aDFt+uLLOkNMMOSQ66pKUJdjrbJ3NrcSfiA4KUKOfpVlHiFptaQrzqwgxhK3FleAnpdXGcfe2fFt71jwvDu1xpb7in5jjSiypgF9e9ktoUjAXuyQUrIx7VmRNCWKGvdFYkMjoJj7W5LiRtS2GweD97YAM/LPfmgwJ/iLbmmGXYbEiQ07DkS0vKbUhsBnbkE4Jwdw5AI7e4rPf13YY6pSXpDyRHC9y+gvYsoICwhWMKKSRkCrY8P7AI/RDD4QQ+leH1guB4JDgVg852J/IVee0PYn3ZK3Yzig/vJQX17EFZBWUJzhJUQMkf/AMmgob15YlyYsfryESZDy2EMrjrSsLQoBQIIyOVJ/PPvWXedSxbTfrZbpZKRNOxK9i+Fk4QMgY5OfUY496sTtE2Sa8XJDDx3SFSVJD6wlThKSSRnHdKfy+ZrIumlLVc70xdZbTipjPT2qS6pI+zUVIyAcHBUfzoNXqLWEq1S7w3HtXmmLZHEh93rhGElpxY4x6qQE/8Adn0q9E1mxI1imxeXKUqa4k7/AIS/tCyzjHfYoKz9RW2m2C3TBdRIZUr95spYlYWRvQAQAOeOFHtWCzonT7MtuW3b20zW5PmxKyetv57r7lODjbnGOMUG2du1uacU27PiIcScKSp5IIPzGa11/wBQeSatybWy1cJVxkGPGSHghskJUpSlLAOAAhXYE54rZOWu3uuKcdgxFrUclSmUkk/M4rHulht9yhMxXmS02w4HmVR1FpTSxn4klOCDyfzNBprVreHIKY05h9i6B51h2Mw2uRsLaglStyU/cypPxEDv8jVq4eIVoYjLcideQtDzTYT0Vp6iFPpZUts7fjCVK7Jznj3rNTomyo8sWmpLS2SvLiJLiVu71Baw4rOV5UATn2q2vQVhWh5Jjv7VkFIElwdHDodw3z8A3pCuMdqANeWE9L/eHxvzvzGc+w+0Lf2vHwfGCnnHIq9a9XQptgRd32ZESMqUYv2zZBCur0wT8icc+n4VaToSxJ6X+7vnZyvMhZ6/2hc+15+P4yVc55JrPb01bUWOZaC04u3y1OKcaW4o46hJUEnukZJIx2PagwG9c2J19ltEh4h0pAcDCy2nctSEFSsYSFKSdue/B7EVaka+0/HiNyXpTiWnWWn0HpK5S6paUencltX5VlnRlk60RxMZaBGbZbS2l1QQtLRy3vTnCtp5GaxkaCsbbDjTbcpKFoQ1/wCJc+FCFKUlA5+6CtXHbmgkUZ5EqM1IZ3Fp1AWkqSUnBGRkHkfjXySMMn8K+WyBHtlujQYSOnGjNpaaRknakDAGTzVcsfYK/D/Wgx2qyM1jtVkUGRSlKBSlKCHeIupLlp5u3/uyK275hSwtx1BUlJSnKUcEYKjwDz24BPFR6669vMKTe0mPGQxDCDGcWw4Q8VONpWnPqW95Bx944xjBFdSqzMisTY5YltIeZJBKFjIJBBH5EA/hQcqVqm+TZ0d0FamBhoLjoW20+BPjt9UAnIyhS/U8Z9KuRPES7LmPIfZihLQbceaDDgXGSZaWlhZJ5KWyVZAA+WO/V6seUj+d830Uea6fS6uPi2Zztz7Z5oOcwtd3qTe7bFTb2xGkvKTuU0oFxHmVt5SSeClCUrPBzn+Ec1tb5qS9wtSvR4kRl6Ay9Ga2dNXUc6qVkkKzgYKR6Hv6VOKUHJo+stQzza1LWxHYMuMJLzcRwJT1Eub2FBRzuSpKQVD1UO3Y5MPWmpQvTiJkKIVXNlqQvYytIwtaQWxlWQpKSVE4OeOAMmuoYpQc/wBW6zuNo1bHtsOMhyMUJLpcaOfiSs7kq3dgUgH4cc981oI3iRd3YMJ1xVubRIWyFSzFd6bRWy44psp3ZUpBQnJBx8Y7V11xCXG1IcSFIUClQPqD6VjC2wg3DQIrWyHgxxt4awkpG32+EkfSg52zrPUr0J6a7DiwoyTEbV1Y7iyyXW0LW4rCgSlOSMcHkZIwayIWs7vJmQGJTDMIPshQ3RnVKlEuLRlvH3BtSlfxA4CxnHeuj0oOPwtaamtun4KJjLUh5ceIsy1sK+zDjbhPUBWNx3NpGcp5X2954vUDzmkpk6M20LrGipcdjrSspbdLYXtOBkjkdqklUIabbU4ptCUqcO5ZAwVHAGT7nAA/Cg5S94j3dEG1uIhJU866pLwVGIQtIdSj4FBwjsonI3dvQA1fe1rqRmM+8uLCwppbjWWVp6e2T0iFEqwSU/EM7QPU45rqWKUEDuer5rGkNP3RIYivXCQhl5cmOspaBQslWwKzjKAe+MevrUea1ZqGRcLfKUlUNl12J1mS0tSVhbL52jJ+EKUhA98qTntg9XkRWJKmTIaQ4WV9VsqGdisEbh88Ej8avUHKUap1BdGbQ/DkRkyC6tTyExHg23/uziy04CRuKVADII5xkelbPWGqrrG0vaZERpEV24wnHXHVMrc6TnRCktpCeQpRJAJ7bexrodKDnmjtVXmdqJq1TYgTHQwnctaCHD9ihXVJzyFKURjaPqeRVq7ay1DCevLSbYjFscS2t8tKKFh11IbWn4hkJaJKue/qBXSKUHMmtY6kfcjKTEiNskROoCwtRX1nltlSTuwAAkLxz37+tYWmNbagXKskCY03KU8lPmHlMKQpZLi0rA+LgoCQTwc5/h4Ndapigsw5DUyIzJjK3sPIDiFYIykjIODyKS/7hX4f61eq1L/uFfh/rQYjVX8VaaFX8UH1h4KSEqOFD39avZHvWAtFaO3I/wCNXT6t/wChrDV1vp54YV1pr+Jn4e8ceVEz+iV5pmtQW6+dOt3huM0zWhjONSUqUwrelKignBxkd/rV7p0G4zTNafp06dBuM0zWn6dUgIUtSApJWnBUkHkZ7ZoN1mma0MlxqMgLfUEgnaOCST7ACrpbwMnFBuc0zWn6dOnQbjNM1pWwhxO5tSVDJGUnPIOCPzr5hBcLe5PUA3FOeQPfH4Gg3eaZrT9OrSFtLcKEOtqWM5SFAng4PH1oN7mma0/TqhsIdQFtKStB7KScg0G7zTNaJtbTiilt1tahyQlQJHJH+oI/CrvToNxmma0/Tp06DcZpmtInYpRSlSSodwDVfToNxmlacNkHI4NZzck9P4hlY/WgyiQO5xWJIdDmEp5A7mrJClqKlcmriEYoKmxV3FfEJq5igtqRWltqP+N3X6t/6Gt/itRbEEXq6EpIBKMH34NcO77bQ9U+3Jrp9XPy+YZpR8q+KaCkkHOCMcHFZW2vm0V3MkGfs1zjQGGLe3J3pDq8iUThZVlOcrHGPqPcDvV9LFwclTWAJKZmFr6vmcN7FE7EpTk4UAAM4GCM5OeZltFNooIc3abg+9hZnR4eHClpUslxJ2oCcqCiTyFEDJx+OKpXa72Wi60+6iatS05W9ltCTHIB25x/e4PbP4VM9optFBD7bariZEYvqmtxku71ock5UcIPchSjtKscZ9Ow5q5erbcHJrzsMO9Famt4acCFuJSlzIB3Jx8SkHuMgGpZtFNooIy5aH5MK0Ikl5Tsd4LcIfUkgbVDkgjJ5A9awJFruk1ny8hqQlttlaSoydodX1ElJG1WeUg98YzU12im0UENkw7wW1MRmZLaQpxSHDJB+EsEJTkqySFkd/UZzWxn2+Sm2w2Y5kupbcSX0pfIdcTg5AWSOdxSe44BFSHaKbRQQNuz3ltLaUiSlGXChKJABbUXlqClncNw2lHorseOa2l7gTnJrr0RpxSFtNNktubVcLUVY+JPoR6j8e1SjaKbRQRhMS5KsMVp5L5kNuDrJbeAccQCfurz68Hkg4zWvZtV1aivpSmShKi4tKUvJK+XgpIJ3DJ25B+IfX1qb7RTaKCIRYVz6sVUliUcJQE7JeEtYWd28FR3Epx/i9s+tYaYV1cfWyoyzJQwzsUmRtQ0sqXlShnChgDI57YwO9TvaKbRQQ8Wm5bi2C62wpwFXTdCTgyFqVyDkZQR/wD7VhVrvQfbSXJKmkFSWimR9zDyyFLO74gUdPuFHg5HNTfaKbRQRe8wLk9eGnIyn/LhCAjpu7EoUFEqKxuGQRt9FdjwKqs1unxZbC5C31oWy71+o9vAXvTswM8fDu7fjUm2im0UENhaelR7ZsDz6X3XwVpQW0FCC9uVhaUhXKfdRP41RKgXrzkwsIkJbW282giRkZKfs1DK+O3faCCfXk1NdorVamvEXT9km3SevZGitFxZ98dgPmTgD60ET1JJb02w7Lusx5u0IWSAqcULKihGCFFQJAIX8OfXgHFc7c8bNOxLyHTMuctCFpGWUnplHTwRhRSCd2edo98+lcJ1/rO6a0vbs+5vK6QUehGCvgYR7Ae/ufWo0hDjgUUNqUEjJwM4oj3Vo7xF0xqxaWrRc21SiNxjOgtufke/4ZqZoANfnLFkOxpDb8Z1bL7agpDiFFKkkdiCOxr2D+z94iu6xsjsG7OBV5gABa+xebPAXj39D+B9aK66BVWKDtX2gUpSgYpilKBimKUoGKYpSgYpilKBimKUoGKYpSgYpilKBimKUoGKYpSgYpilKBimKUoPhHFcZ/allvR/DUtskhEia005j/DhSv8AVIrs57VAvGPTS9VaFuVujgGVtDzGfVaDkD8eR+NB4ZZQHX2m1KCEqUElR7DJ710TxRxorXJtOmW/3e3bEtFuS3/fPqU2FFal9yDuI2/d+Vc7facZdW08hTbqFFKkqGCkjuCK3aNTSn1Q/wB9tIuzcNISw3J9EjslS04WUj/DuxREk8ZbfEYuOn7pFjtRXrxaWJ8lhpIShLqgQopSOwOM4981s/2aZb0bxUhtNE7JEd5twD/CE7h+qRXPtSX2fqS7u3K6uBchYCQEpCUoSBhKUpHAAHpXbv2VtKvruczUshspjobMaMVD76iQVKHyAGPxPtRXqFo5SKrqhoYSKroFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFKUoFWXm9wq9Qig4l4qeDMDVUh25WtxNvuyuVq25beP8AmA7H5j8Qa4pL8D9bMSC21CjSEZx1G5KAn/4iD+le1FthXcVaMZPsKDy/on9n2Y7Lbf1XKbbjpIJjRVFSl/JSsYA+mfwr0nZLVFtUBiHBYQxFYSENtoGAkCtghlKfSroGKD6BgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSgUpSg//Z",
+          "timing": 3472
+        }
+      },
+      "inp-breakdown-insight": {
+        "id": "inp-breakdown-insight",
+        "title": "INP breakdown",
+        "description": "Start investigating [how to improve INP](https://developer.chrome.com/docs/performance/insights/inp-breakdown) by looking at the longest subpart.",
+        "score": null,
+        "scoreDisplayMode": "notApplicable"
+      },
+      "mainthread-work-breakdown": {
+        "id": "mainthread-work-breakdown",
+        "title": "Minimize main-thread work",
+        "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn how to minimize main-thread work](https://developer.chrome.com/docs/lighthouse/performance/mainthread-work-breakdown/)",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "2.9 s",
+        "metricSavings": {
+          "TBT": 650
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "group": "scriptEvaluation",
+              "groupLabel": "Script Evaluation",
+              "duration": 1450.2815999999859
+            },
+            {
+              "groupLabel": "Style & Layout",
+              "duration": 593.77800000000013,
+              "group": "styleLayout"
+            },
+            {
+              "group": "scriptParseCompile",
+              "groupLabel": "Script Parsing & Compilation",
+              "duration": 456.18720000000008
+            },
+            {
+              "group": "other",
+              "groupLabel": "Other",
+              "duration": 267.76559999999836
+            },
+            {
+              "groupLabel": "Parse HTML & CSS",
+              "duration": 45.932399999999973,
+              "group": "parseHTML"
+            },
+            {
+              "duration": 27.193200000000008,
+              "groupLabel": "Rendering",
+              "group": "paintCompositeRender"
+            },
+            {
+              "group": "garbageCollection",
+              "duration": 24.969600000000003,
+              "groupLabel": "Garbage Collection"
+            }
+          ],
+          "headings": [
+            {
+              "label": "Category",
+              "key": "groupLabel",
+              "valueType": "text"
+            },
+            {
+              "label": "Time Spent",
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "duration"
+            }
+          ],
+          "sortedBy": [
+            "duration"
+          ]
+        },
+        "numericValue": 2866.1075999999844,
+        "numericUnit": "millisecond"
+      },
+      "network-dependency-tree-insight": {
+        "id": "network-dependency-tree-insight",
+        "title": "Network dependency tree",
+        "description": "[Avoid chaining critical requests](https://developer.chrome.com/docs/performance/insights/network-dependency-tree) by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load.",
+        "score": 0,
+        "scoreDisplayMode": "numeric",
+        "metricSavings": {
+          "LCP": 0
+        },
+        "details": {
+          "type": "list",
+          "items": [
+            {
+              "value": {
+                "longestChain": {
+                  "duration": 1004
+                },
+                "type": "network-tree",
+                "chains": {
+                  "5261E9A4E2A747E17C223C45AA231D00": {
+                    "transferSize": 23021,
+                    "children": {
+                      "51.2": {
+                        "children": {
+                          "51.83": {
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf",
+                            "transferSize": 39127,
+                            "navStartToEndTime": 1004,
+                            "children": {}
+                          },
+                          "51.81": {
+                            "navStartToEndTime": 1003,
+                            "children": {},
+                            "transferSize": 38779,
+                            "url": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf"
+                          },
+                          "51.78": {
+                            "transferSize": 31975,
+                            "navStartToEndTime": 1004,
+                            "children": {},
+                            "url": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                            "isLongest": true
+                          }
+                        },
+                        "navStartToEndTime": 899,
+                        "transferSize": 24572,
+                        "isLongest": true,
+                        "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+                      }
+                    },
+                    "navStartToEndTime": 852,
+                    "isLongest": true,
+                    "url": "https://www.ocobo.co/jobs"
+                  }
+                }
+              },
+              "type": "list-section"
+            },
+            {
+              "value": {
+                "headings": [
+                  {
+                    "label": "Origin",
+                    "subItemsHeading": {
+                      "key": "warning"
+                    },
+                    "key": "origin",
+                    "valueType": "text"
+                  },
+                  {
+                    "label": "Source",
+                    "key": "source",
+                    "valueType": "node"
+                  }
+                ],
+                "items": [
+                  {
+                    "subItems": {
+                      "items": [
+                        {
+                          "warning": "Unused preconnect. Only use preconnect for origins that the page is likely to request."
+                        }
+                      ],
+                      "type": "subitems"
+                    },
+                    "origin": "https://raw.githubusercontent.com/",
+                    "source": {
+                      "selector": "head \u003e link",
+                      "path": "1,HTML,0,HEAD,3,LINK",
+                      "nodeLabel": "head \u003e link",
+                      "boundingRect": {
+                        "right": 0,
+                        "height": 0,
+                        "width": 0,
+                        "left": 0,
+                        "top": 0,
+                        "bottom": 0
+                      },
+                      "lhId": "page-9-LINK",
+                      "snippet": "\u003clink rel=\"preconnect\" href=\"https://raw.githubusercontent.com\" crossorigin=\"anonymous\"\u003e",
+                      "type": "node"
+                    }
+                  }
+                ],
+                "type": "table"
+              },
+              "title": "Preconnected origins",
+              "description": "[preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints help the browser establish a connection earlier in the page load, saving time when the first request for that origin is made. The following are the origins that the page preconnected to.",
+              "type": "list-section"
+            },
+            {
+              "value": {
+                "value": "No additional origins are good candidates for preconnecting",
+                "type": "text"
+              },
+              "title": "Preconnect candidates",
+              "description": "Add [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/) hints to your most important origins, but try to use no more than 4.",
+              "type": "list-section"
+            }
+          ]
+        }
+      },
+      "unused-javascript": {
+        "id": "unused-javascript",
+        "title": "Reduce unused JavaScript",
+        "description": "Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/).",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 390 KiB",
+        "metricSavings": {
+          "LCP": 150,
+          "FCP": 150
+        },
+        "details": {
+          "sortedBy": [
+            "wastedBytes"
+          ],
+          "debugData": {
+            "metricSavings": {
+              "LCP": 150,
+              "FCP": 150
+            },
+            "type": "debugdata"
+          },
+          "overallSavingsBytes": 399539,
+          "headings": [
+            {
+              "valueType": "url",
+              "subItemsHeading": {
+                "valueType": "code",
+                "key": "source"
+              },
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "subItemsHeading": {
+                "key": "sourceBytes"
+              }
+            },
+            {
+              "label": "Est Savings",
+              "subItemsHeading": {
+                "key": "sourceWastedBytes"
+              },
+              "key": "wastedBytes",
+              "valueType": "bytes"
+            }
+          ],
+          "type": "opportunity",
+          "overallSavingsMs": 150,
+          "items": [
+            {
+              "wastedPercent": 57.372344479375059,
+              "wastedBytes": 112602,
+              "totalBytes": 196265,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "wastedPercent": 71.178801376324756,
+              "wastedBytes": 111354,
+              "totalBytes": 156443,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "wastedBytes": 82854,
+              "totalBytes": 196265,
+              "wastedPercent": 42.2154629213789
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "wastedBytes": 67726,
+              "totalBytes": 156443,
+              "wastedPercent": 43.291052829076662
+            },
+            {
+              "wastedBytes": 25003,
+              "totalBytes": 43332,
+              "wastedPercent": 57.7014794433146,
+              "url": "https://www.ocobo.co/assets/chunk-JZWAC4HX-CCO50xey.js"
+            }
+          ]
+        },
+        "numericValue": 150,
+        "numericUnit": "millisecond"
+      },
+      "cumulative-layout-shift": {
+        "id": "cumulative-layout-shift",
+        "title": "Cumulative Layout Shift",
+        "description": "Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/articles/cls).",
+        "score": 1,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "0.002",
+        "details": {
+          "items": [
+            {
+              "cumulativeLayoutShiftMainFrame": 0.002049,
+              "newEngineResultDiffered": false
+            }
+          ],
+          "type": "debugdata"
+        },
+        "numericValue": 0.002049,
+        "numericUnit": "unitless"
+      },
+      "third-parties-insight": {
+        "id": "third-parties-insight",
+        "title": "3rd parties",
+        "description": "3rd party code can significantly impact load performance. [Reduce and defer loading of 3rd party code](https://developer.chrome.com/docs/performance/insights/third-parties) to prioritize your page's content.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "headings": [
+            {
+              "valueType": "text",
+              "subItemsHeading": {
+                "valueType": "url",
+                "key": "url"
+              },
+              "key": "entity",
+              "label": "3rd party"
+            },
+            {
+              "valueType": "bytes",
+              "subItemsHeading": {
+                "key": "transferSize"
+              },
+              "granularity": 1,
+              "key": "transferSize",
+              "label": "Transfer size"
+            },
+            {
+              "label": "Main thread time",
+              "granularity": 1,
+              "key": "mainThreadTime",
+              "valueType": "ms",
+              "subItemsHeading": {
+                "key": "mainThreadTime"
+              }
+            }
+          ],
+          "items": [
+            {
+              "transferSize": 350145,
+              "entity": "Hubspot",
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 206384,
+                    "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+                    "mainThreadTime": 379.87600000947714
+                  },
+                  {
+                    "transferSize": 43666,
+                    "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+                    "mainThreadTime": 52.981000028550625
+                  },
+                  {
+                    "mainThreadTime": 39.511999987065792,
+                    "transferSize": 28213,
+                    "url": "https://js-eu1.hscollectedforms.net/collectedforms.js"
+                  },
+                  {
+                    "transferSize": 29952,
+                    "url": "https://js-eu1.hubspot.com/web-interactives-embed.js",
+                    "mainThreadTime": 29.673000007867813
+                  },
+                  {
+                    "mainThreadTime": 21.259999968111515,
+                    "url": "https://js-eu1.hs-banner.com/v2/27107933/banner.js",
+                    "transferSize": 27219
+                  },
+                  {
+                    "mainThreadTime": 4.4300000071525574,
+                    "transferSize": 1648,
+                    "url": "https://js-eu1.hs-scripts.com/27107933.js"
+                  },
+                  {
+                    "mainThreadTime": 0.32400000095367432,
+                    "transferSize": 1094,
+                    "url": "https://forms-eu1.hscollectedforms.net/collected-forms/v1/config/json?portalId=27107933&utk="
+                  },
+                  {
+                    "transferSize": 4083,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/form/27107933/386c07f1-1344-4019-afcb-39a8279db08c/json?hs_static_app=forms-embed&hs_static_app_version=1.10953&X-HubSpot-Static-App-Info=forms-embed-1.10953",
+                    "mainThreadTime": 0.24000000208616257
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 1712,
+                    "url": "https://cta-eu1.hubspot.com/web-interactives/public/v1/embed/combinedConfigs?portalId=27107933&currentUrl=https%3A%2F%2Fwww.ocobo.co%2Fjobs&isMobile=true"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 1524,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=1&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fjobs&t=Ocobo+%C2%B7+Nous+rejoindre+%E2%80%94+Ocobo&cts=1778837391443&vi=99d0f3d0fcee250b399997518fd723e8&nc=true&u=242475741.99d0f3d0fcee250b399997518fd723e8.1778837391426.1778837391426.1778837391426.1&b=242475741.1.1778837391426&cc=15"
+                  },
+                  {
+                    "transferSize": 1024,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-DEFINITION_SUCCESS&count=1",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "transferSize": 1024,
+                    "url": "https://track-eu1.hubspot.com/__ptq.gif?k=15&fi=386c07f1-1344-4019-afcb-39a8279db08c&fci=02232c85-acc8-4742-bb77-2eca1ba0135c&ft=0&sd=412x823&cd=24-bit&cs=UTF-8&ln=en-us&bfp=a068bdda4b5d345c6aa30c73c343cc49&v=1.1&a=27107933&pu=https%3A%2F%2Fwww.ocobo.co%2Fjobs&t=Ocobo+%C2%B7+Nous+rejoindre+%E2%80%94+Ocobo&cts=1778837391803&vi=99d0f3d0fcee250b399997518fd723e8&nc=true&u=242475741.99d0f3d0fcee250b399997518fd723e8.1778837391426.1778837391426.1778837391426.1&b=242475741.1.1778837391426&cc=15",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 1024,
+                    "url": "https://forms-eu1.hsforms.com/embed/v3/counters.gif?key=forms-embed-v2-RENDER_SUCCESS&count=1"
+                  },
+                  {
+                    "transferSize": 1021,
+                    "url": "https://perf-eu1.hsforms.com/embed/v3/counters.gif?key=config-loaded-success&value=1",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "url": "https://js-eu1.hs-banner.com/v2/cf-location",
+                    "transferSize": 557,
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 528.29600001126528
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 157129,
+                    "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+                    "mainThreadTime": 293.1159999743104
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 293.1159999743104,
+              "entity": "Google Tag Manager",
+              "transferSize": 157129
+            },
+            {
+              "transferSize": 7055,
+              "entity": "GitHub",
+              "subItems": {
+                "type": "subitems",
+                "items": [
+                  {
+                    "mainThreadTime": 7.9519999995827675,
+                    "transferSize": 5037,
+                    "url": "https://useago.github.io/widgetjs/frame.js"
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 2018,
+                    "url": "https://useago.github.io/widgetjs/frame.css"
+                  }
+                ]
+              },
+              "mainThreadTime": 7.9519999995827675
+            },
+            {
+              "transferSize": 1280,
+              "entity": "Clearbit",
+              "subItems": {
+                "items": [
+                  {
+                    "mainThreadTime": 0,
+                    "transferSize": 1280,
+                    "url": "https://tag.clearbitscripts.com/v1/pk_38c2f75e7330f98606d3fda7c9686cc9/tags.js"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0
+            },
+            {
+              "transferSize": 796,
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 796,
+                    "url": "https://www.google-analytics.com/g/collect?v=2&tid=G-HTM5DK0W7S&gtm=45je65d0v9100339653za200zd9100339653&_p=1778837389409&gcd=13l3l3l3l1l1&npa=0&dma=0&are=1&cid=1596769434.1778837390&frm=0&pscdl=noapi&rcb=2&sr=412x823&uaa=&uab=64&uafvl=Chromium%3B146.0.7680.177%7CNot-A.Brand%3B24.0.0.0%7CHeadlessChrome%3B146.0.7680.177&uam=moto%20g%20power%20(2022)&uamb=1&uap=Android&uapv=11.0&uaw=0&ul=en-us&_s=1&tag_exp=0~115616986~115938465~115938468&dp=%2Fjobs&sid=1778837389&sct=1&seg=0&dl=https%3A%2F%2Fwww.ocobo.co%2Fjobs&dt=Ocobo%20%C2%B7%20Nous%20rejoindre%20%E2%80%94%20Ocobo&en=page_view&_fv=1&_nsi=1&_ss=1&_ee=1&tfd=1348",
+                    "mainThreadTime": 0
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0,
+              "entity": "Google Analytics"
+            },
+            {
+              "entity": "Google Fonts",
+              "subItems": {
+                "items": [
+                  {
+                    "transferSize": 102672,
+                    "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                    "mainThreadTime": 0
+                  },
+                  {
+                    "mainThreadTime": 0,
+                    "url": "https://fonts.googleapis.com/css2?family=Work%20Sans:wght@400;500;700&display=swap",
+                    "transferSize": 1259
+                  }
+                ],
+                "type": "subitems"
+              },
+              "mainThreadTime": 0,
+              "transferSize": 103931
+            }
+          ],
+          "type": "table",
+          "isEntityGrouped": true
+        }
+      },
+      "long-tasks": {
+        "id": "long-tasks",
+        "title": "Avoid long main-thread tasks",
+        "description": "Lists the longest tasks on the main thread, useful for identifying worst contributors to input delay. [Learn how to avoid long main-thread tasks](https://web.dev/articles/optimize-long-tasks)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "9 long tasks found",
+        "metricSavings": {
+          "TBT": 650
+        },
+        "details": {
+          "headings": [
+            {
+              "key": "url",
+              "valueType": "url",
+              "label": "URL"
+            },
+            {
+              "label": "Start Time",
+              "valueType": "ms",
+              "granularity": 1,
+              "key": "startTime"
+            },
+            {
+              "label": "Duration",
+              "key": "duration",
+              "granularity": 1,
+              "valueType": "ms"
+            }
+          ],
+          "debugData": {
+            "tasks": [
+              {
+                "duration": 232,
+                "scriptEvaluation": 0,
+                "other": 232,
+                "urlIndex": 0,
+                "startTime": 12250.6
+              },
+              {
+                "other": 172,
+                "urlIndex": 1,
+                "startTime": 7617.1,
+                "duration": 172,
+                "scriptEvaluation": 0
+              },
+              {
+                "startTime": 8412.1,
+                "urlIndex": 0,
+                "other": 164,
+                "scriptEvaluation": 0,
+                "duration": 164
+              },
+              {
+                "startTime": 3720.5,
+                "urlIndex": 1,
+                "other": 156,
+                "duration": 156
+              },
+              {
+                "duration": 121,
+                "scriptEvaluation": 0,
+                "urlIndex": 2,
+                "other": 121,
+                "startTime": 5211
+              },
+              {
+                "startTime": 5096,
+                "other": 115,
+                "urlIndex": 2,
+                "scriptEvaluation": 0,
+                "duration": 115
+              },
+              {
+                "duration": 108,
+                "scriptEvaluation": 0,
+                "urlIndex": 2,
+                "other": 108,
+                "startTime": 4988
+              },
+              {
+                "startTime": 6901.1,
+                "urlIndex": 1,
+                "other": 66,
+                "duration": 66
+              },
+              {
+                "other": 56,
+                "duration": 56,
+                "urlIndex": 0,
+                "startTime": 12482.6
+              }
+            ],
+            "urls": [
+              "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            ],
+            "type": "debugdata"
+          },
+          "type": "table",
+          "sortedBy": [
+            "duration"
+          ],
+          "skipSumming": [
+            "startTime"
+          ],
+          "items": [
+            {
+              "startTime": 12250.591000455337,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "duration": 232
+            },
+            {
+              "startTime": 7617.1201778324539,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "duration": 172
+            },
+            {
+              "duration": 164,
+              "startTime": 8412.1380766585644,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js"
+            },
+            {
+              "duration": 156,
+              "startTime": 3720.4617811811518,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js"
+            },
+            {
+              "startTime": 5211.0102279006342,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "duration": 121
+            },
+            {
+              "duration": 115,
+              "startTime": 5096.0102279006342,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S"
+            },
+            {
+              "startTime": 4988.0102279006342,
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "duration": 108
+            },
+            {
+              "startTime": 6901.1125069069785,
+              "url": "https://js-eu1.hs-analytics.net/analytics/1778837100000/27107933.js",
+              "duration": 66
+            },
+            {
+              "startTime": 12482.591000455337,
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "duration": 56
+            }
+          ]
+        }
+      },
+      "document-latency-insight": {
+        "id": "document-latency-insight",
+        "title": "Document request latency",
+        "description": "Your first network request is the most important. [Reduce its latency](https://developer.chrome.com/docs/performance/insights/document-latency) by avoiding redirects, ensuring a fast server response, and enabling text compression.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "debugData": {
+            "wastedBytes": 0,
+            "uncompressedResponseBytes": 0,
+            "serverResponseTime": 41,
+            "redirectDuration": 0,
+            "type": "debugdata"
+          },
+          "items": {
+            "usesCompression": {
+              "value": true,
+              "label": "Applies text compression"
+            },
+            "serverResponseIsFast": {
+              "label": "Server responds quickly (observed 41 ms)",
+              "value": true
+            },
+            "noRedirects": {
+              "value": true,
+              "label": "Avoids redirects"
+            }
+          },
+          "type": "checklist"
+        }
+      },
+      "render-blocking-insight": {
+        "id": "render-blocking-insight",
+        "title": "Render blocking requests",
+        "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
+        "score": 0,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Est savings of 750 ms",
+        "metricSavings": {
+          "LCP": 750,
+          "FCP": 750
+        },
+        "details": {
+          "type": "table",
+          "items": [
+            {
+              "totalBytes": 24572,
+              "wastedMs": 151,
+              "url": "https://www.ocobo.co/assets/index-BE7NgYT7.css"
+            }
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Transfer Size"
+            },
+            {
+              "key": "wastedMs",
+              "valueType": "timespanMs",
+              "label": "Duration"
+            }
+          ]
+        }
+      },
+      "total-byte-weight": {
+        "id": "total-byte-weight",
+        "title": "Avoids enormous network payloads",
+        "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn how to reduce payload sizes](https://developer.chrome.com/docs/lighthouse/performance/total-byte-weight/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Total size was 1,907 KiB",
+        "details": {
+          "sortedBy": [
+            "totalBytes"
+          ],
+          "headings": [
+            {
+              "key": "url",
+              "valueType": "url",
+              "label": "URL"
+            },
+            {
+              "valueType": "bytes",
+              "key": "totalBytes",
+              "label": "Transfer Size"
+            }
+          ],
+          "type": "table",
+          "items": [
+            {
+              "url": "https://www.ocobo.co/images/jobs/seminaire.jpeg",
+              "totalBytes": 251265
+            },
+            {
+              "url": "https://js-eu1.hsforms.net/forms/embed/v2.js",
+              "totalBytes": 204725
+            },
+            {
+              "url": "https://www.googletagmanager.com/gtag/js?id=G-HTM5DK0W7S",
+              "totalBytes": 157129
+            },
+            {
+              "url": "https://www.ocobo.co/images/jobs/cafet.jpeg",
+              "totalBytes": 135167
+            },
+            {
+              "url": "https://www.ocobo.co/images/jobs/bureau-1.jpeg",
+              "totalBytes": 124999
+            },
+            {
+              "url": "https://www.ocobo.co/images/jobs/bureau-3.jpeg",
+              "totalBytes": 115932
+            },
+            {
+              "url": "https://www.ocobo.co/images/jobs/bureau-2.jpeg",
+              "totalBytes": 115414
+            },
+            {
+              "url": "https://www.ocobo.co/images/jobs/rooftop.jpeg",
+              "totalBytes": 105040
+            },
+            {
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+              "totalBytes": 51336
+            },
+            {
+              "totalBytes": 51336,
+              "url": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2"
+            }
+          ]
+        },
+        "numericValue": 1952319,
+        "numericUnit": "byte"
+      },
+      "diagnostics": {
+        "id": "diagnostics",
+        "title": "Diagnostics",
+        "description": "Collection of useful page vitals.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "items": [
+            {
+              "maxRtt": 9.182879999999999,
+              "numTasksOver500ms": 0,
+              "numStylesheets": 3,
+              "totalByteWeight": 1952319,
+              "numRequests": 88,
+              "numTasksOver10ms": 39,
+              "numTasksOver100ms": 6,
+              "throughput": 23982571973.948235,
+              "numTasks": 1579,
+              "maxServerLatency": 7,
+              "numTasksOver50ms": 9,
+              "numScripts": 58,
+              "numFonts": 5,
+              "mainDocumentTransferSize": 23021,
+              "totalTaskTime": 2388.4230000000048,
+              "numTasksOver25ms": 19,
+              "rtt": 0.00095534912088473482
+            }
+          ],
+          "type": "debugdata"
+        }
+      },
+      "layout-shifts": {
+        "id": "layout-shifts",
+        "title": "Avoid large layout shifts",
+        "description": "These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "displayValue": "2 layout shifts found",
+        "metricSavings": {
+          "CLS": 0.002
+        },
+        "details": {
+          "headings": [
+            {
+              "label": "Element",
+              "subItemsHeading": {
+                "key": "extra"
+              },
+              "key": "node",
+              "valueType": "node"
+            },
+            {
+              "granularity": 0.001,
+              "key": "score",
+              "label": "Layout shift score",
+              "valueType": "numeric",
+              "subItemsHeading": {
+                "valueType": "text",
+                "key": "cause"
+              }
+            }
+          ],
+          "items": [
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "cause": "Media element lacking an explicit size",
+                    "extra": {
+                      "nodeLabel": "Ocobo",
+                      "boundingRect": {
+                        "left": 33,
+                        "top": 37,
+                        "bottom": 77,
+                        "height": 40,
+                        "right": 167,
+                        "width": 134
+                      },
+                      "lhId": "page-6-IMG",
+                      "type": "node",
+                      "snippet": "\u003cimg src=\"/logo-ocobo.png\" alt=\"Ocobo\" class=\"trs_all trs-dur_700ms h_40px w_auto lg:h_46px\"\u003e",
+                      "selector": "nav.pos_relative \u003e div.d_flex \u003e a.d_flex \u003e img.trs_all",
+                      "path": "1,HTML,1,BODY,1,DIV,0,DIV,0,NAV,0,DIV,0,A,0,IMG"
+                    }
+                  },
+                  {
+                    "extra": {
+                      "value": "https://www.ocobo.co/fonts/bermia/Bermia-Black.woff",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  },
+                  {
+                    "extra": {
+                      "type": "url",
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Regular.otf"
+                    },
+                    "cause": "Web font loaded"
+                  },
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "type": "url",
+                      "value": "https://www.ocobo.co/fonts/bornia/Bornia-Bold.otf"
+                    }
+                  }
+                ],
+                "type": "subitems"
+              },
+              "score": 0.002049,
+              "node": {
+                "selector": "div.mx_auto \u003e div.d_flex \u003e div.lg:w_1/2 \u003e h1.text",
+                "path": "1,HTML,1,BODY,1,DIV,1,DIV,1,DIV,0,DIV,0,SECTION,0,DIV,0,DIV,0,DIV,1,H1",
+                "nodeLabel": "Rejoignez les\narchitectes.",
+                "boundingRect": {
+                  "width": 380,
+                  "height": 91,
+                  "right": 396,
+                  "bottom": 383,
+                  "left": 16,
+                  "top": 292
+                },
+                "lhId": "page-8-H1",
+                "type": "node",
+                "snippet": "\u003ch1 class=\"text text--variant_display-xl text--color_dark mb_10 white-space_pre-line\"\u003e"
+              }
+            },
+            {
+              "subItems": {
+                "items": [
+                  {
+                    "cause": "Web font loaded",
+                    "extra": {
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                      "type": "url"
+                    }
+                  },
+                  {
+                    "extra": {
+                      "value": "https://fonts.gstatic.com/s/worksans/v24/QGYsz_wNahGAdqQ43Rh_fKDptfpA4Q.woff2",
+                      "type": "url"
+                    },
+                    "cause": "Web font loaded"
+                  }
+                ],
+                "type": "subitems"
+              },
+              "score": 0
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "font-display-insight": {
+        "id": "font-display-insight",
+        "title": "Font display",
+        "description": "Consider setting [font-display](https://developer.chrome.com/docs/performance/insights/font-display) to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with [font metric overrides](https://developer.chrome.com/blog/font-fallbacks).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "INP": 0
+        },
+        "details": {
+          "items": [],
+          "type": "table",
+          "skipSumming": [
+            "wastedMs"
+          ],
+          "headings": [
+            {
+              "label": "URL",
+              "valueType": "url",
+              "key": "url"
+            },
+            {
+              "label": "Est Savings",
+              "valueType": "ms",
+              "key": "wastedMs"
+            }
+          ]
+        }
+      },
+      "resource-summary": {
+        "id": "resource-summary",
+        "title": "Resources Summary",
+        "description": "Aggregates all network requests and groups them by type",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "headings": [
+            {
+              "label": "Resource Type",
+              "key": "label",
+              "valueType": "text"
+            },
+            {
+              "label": "Requests",
+              "key": "requestCount",
+              "valueType": "numeric"
+            },
+            {
+              "label": "Transfer Size",
+              "valueType": "bytes",
+              "key": "transferSize"
+            }
+          ],
+          "items": [
+            {
+              "requestCount": 88,
+              "label": "Total",
+              "resourceType": "total",
+              "transferSize": 1952319
+            },
+            {
+              "requestCount": 14,
+              "label": "Image",
+              "transferSize": 912909,
+              "resourceType": "image"
+            },
+            {
+              "requestCount": 58,
+              "label": "Script",
+              "resourceType": "script",
+              "transferSize": 764776
+            },
+            {
+              "requestCount": 5,
+              "label": "Font",
+              "resourceType": "font",
+              "transferSize": 212553
+            },
+            {
+              "resourceType": "stylesheet",
+              "transferSize": 27849,
+              "label": "Stylesheet",
+              "requestCount": 3
+            },
+            {
+              "requestCount": 1,
+              "label": "Document",
+              "transferSize": 23021,
+              "resourceType": "document"
+            },
+            {
+              "requestCount": 7,
+              "label": "Other",
+              "transferSize": 11211,
+              "resourceType": "other"
+            },
+            {
+              "transferSize": 0,
+              "resourceType": "media",
+              "requestCount": 0,
+              "label": "Media"
+            },
+            {
+              "requestCount": 25,
+              "label": "Third-party",
+              "transferSize": 620336,
+              "resourceType": "third-party"
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "main-thread-tasks": {
+        "id": "main-thread-tasks",
+        "title": "Tasks",
+        "description": "Lists the toplevel main thread tasks that executed during page load.",
+        "score": 1,
+        "scoreDisplayMode": "informative",
+        "details": {
+          "headings": [
+            {
+              "granularity": 1,
+              "valueType": "ms",
+              "key": "startTime",
+              "label": "Start Time"
+            },
+            {
+              "label": "End Time",
+              "key": "duration",
+              "granularity": 1,
+              "valueType": "ms"
+            }
+          ],
+          "items": [
+            {
+              "startTime": 818.614,
+              "duration": 25.258
+            },
+            {
+              "startTime": 889.711,
+              "duration": 9.77
+            },
+            {
+              "startTime": 908.301,
+              "duration": 14.376
+            },
+            {
+              "startTime": 922.693,
+              "duration": 79.513
+            },
+            {
+              "duration": 19.087,
+              "startTime": 1005.875
+            },
+            {
+              "startTime": 1029.364,
+              "duration": 15.68
+            },
+            {
+              "startTime": 1045.368,
+              "duration": 10.341
+            },
+            {
+              "duration": 12.636,
+              "startTime": 1058.898
+            },
+            {
+              "duration": 9.685,
+              "startTime": 1074.283
+            },
+            {
+              "startTime": 1085.438,
+              "duration": 23.468
+            },
+            {
+              "duration": 17.4,
+              "startTime": 1109.772
+            },
+            {
+              "duration": 6.403,
+              "startTime": 1128.882
+            },
+            {
+              "startTime": 1135.521,
+              "duration": 5.079
+            },
+            {
+              "startTime": 1142.582,
+              "duration": 89.82
+            },
+            {
+              "startTime": 1250.439,
+              "duration": 5.211
+            },
+            {
+              "startTime": 1257.216,
+              "duration": 96.119
+            },
+            {
+              "duration": 11.188,
+              "startTime": 1363.932
+            },
+            {
+              "startTime": 1375.159,
+              "duration": 15.177
+            },
+            {
+              "startTime": 1393.403,
+              "duration": 11.493
+            },
+            {
+              "duration": 5.36,
+              "startTime": 1405.068
+            },
+            {
+              "duration": 5.822,
+              "startTime": 1410.442
+            },
+            {
+              "startTime": 1418.659,
+              "duration": 5.509
+            },
+            {
+              "duration": 5.668,
+              "startTime": 1424.216
+            },
+            {
+              "duration": 21.137,
+              "startTime": 1432.047
+            },
+            {
+              "duration": 5.868,
+              "startTime": 1453.278
+            },
+            {
+              "duration": 8.338,
+              "startTime": 1459.215
+            },
+            {
+              "duration": 5.296,
+              "startTime": 1467.589
+            },
+            {
+              "duration": 5.62,
+              "startTime": 1472.9
+            },
+            {
+              "startTime": 1478.555,
+              "duration": 5.506
+            },
+            {
+              "duration": 5.395,
+              "startTime": 1484.082
+            },
+            {
+              "duration": 8.595,
+              "startTime": 1489.499
+            },
+            {
+              "startTime": 1498.145,
+              "duration": 5.2
+            },
+            {
+              "startTime": 1503.386,
+              "duration": 5.264
+            },
+            {
+              "duration": 5.305,
+              "startTime": 1508.67
+            },
+            {
+              "startTime": 1514.043,
+              "duration": 5.315
+            },
+            {
+              "duration": 11.264,
+              "startTime": 1519.376
+            },
+            {
+              "duration": 5.908,
+              "startTime": 1530.671
+            },
+            {
+              "duration": 5.459,
+              "startTime": 1536.593
+            },
+            {
+              "duration": 9.643,
+              "startTime": 1542.078
+            },
+            {
+              "duration": 35.798,
+              "startTime": 1551.75
+            },
+            {
+              "startTime": 1587.567,
+              "duration": 18.726
+            },
+            {
+              "duration": 9.625,
+              "startTime": 1610.12
+            },
+            {
+              "duration": 5.503,
+              "startTime": 1621.736
+            },
+            {
+              "startTime": 1627.274,
+              "duration": 6.073
+            },
+            {
+              "startTime": 1637.474,
+              "duration": 7.922
+            },
+            {
+              "startTime": 1647.582,
+              "duration": 6.346
+            },
+            {
+              "startTime": 1654.202,
+              "duration": 7.562
+            },
+            {
+              "duration": 6.918,
+              "startTime": 1663.152
+            },
+            {
+              "startTime": 1677.796,
+              "duration": 5.562
+            },
+            {
+              "duration": 5.815,
+              "startTime": 1683.378
+            },
+            {
+              "duration": 5.348,
+              "startTime": 1689.23
+            },
+            {
+              "startTime": 1695.167,
+              "duration": 6.384
+            },
+            {
+              "startTime": 1702.365,
+              "duration": 5.14
+            },
+            {
+              "duration": 5.184,
+              "startTime": 1707.723
+            },
+            {
+              "startTime": 1712.926,
+              "duration": 5.211
+            },
+            {
+              "startTime": 1718.151,
+              "duration": 5.603
+            },
+            {
+              "startTime": 1723.77,
+              "duration": 5.693
+            },
+            {
+              "startTime": 1729.475,
+              "duration": 7.439
+            },
+            {
+              "startTime": 1737.408,
+              "duration": 31.796
+            },
+            {
+              "duration": 8.791,
+              "startTime": 1769.322
+            },
+            {
+              "startTime": 1780.715,
+              "duration": 26.487
+            },
+            {
+              "startTime": 1807.251,
+              "duration": 39.916
+            },
+            {
+              "startTime": 1850.401,
+              "duration": 10.947
+            },
+            {
+              "startTime": 1864.407,
+              "duration": 24.272
+            },
+            {
+              "startTime": 1888.726,
+              "duration": 29.155
+            },
+            {
+              "startTime": 1924.098,
+              "duration": 101.025
+            },
+            {
+              "duration": 286.011,
+              "startTime": 2030.261
+            },
+            {
+              "startTime": 2324.689,
+              "duration": 110.267
+            },
+            {
+              "startTime": 2443.651,
+              "duration": 9.095
+            },
+            {
+              "duration": 17.511,
+              "startTime": 2452.828
+            },
+            {
+              "startTime": 2474.037,
+              "duration": 12.95
+            },
+            {
+              "duration": 32.493,
+              "startTime": 2489.78
+            },
+            {
+              "startTime": 2523.285,
+              "duration": 130.221
+            },
+            {
+              "startTime": 2654.811,
+              "duration": 16.268
+            },
+            {
+              "startTime": 2676.236,
+              "duration": 136.347
+            },
+            {
+              "startTime": 2909.936,
+              "duration": 38.376
+            },
+            {
+              "startTime": 2952.284,
+              "duration": 20.186
+            },
+            {
+              "startTime": 2999.834,
+              "duration": 193.284
+            },
+            {
+              "duration": 5.087,
+              "startTime": 3194.685
+            },
+            {
+              "startTime": 3201.487,
+              "duration": 46.947
+            },
+            {
+              "startTime": 3250.611,
+              "duration": 41.215
+            },
+            {
+              "duration": 17.235,
+              "startTime": 3296.837
+            }
+          ],
+          "type": "table"
+        }
+      },
+      "duplicated-javascript-insight": {
+        "id": "duplicated-javascript-insight",
+        "title": "Duplicated JavaScript",
+        "description": "Remove large, [duplicate JavaScript modules](https://developer.chrome.com/docs/performance/insights/duplicated-javascript) from bundles to reduce unnecessary bytes consumed by network activity.",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "items": [],
+          "type": "table",
+          "debugData": {
+            "wastedBytes": 0,
+            "type": "debugdata"
+          },
+          "headings": [
+            {
+              "subItemsHeading": {
+                "key": "url",
+                "valueType": "url"
+              },
+              "key": "source",
+              "valueType": "code",
+              "label": "Source"
+            },
+            {
+              "subItemsHeading": {
+                "key": "sourceTransferBytes"
+              },
+              "valueType": "bytes",
+              "label": "Duplicated bytes",
+              "key": "wastedBytes",
+              "granularity": 10
+            }
+          ]
+        }
+      },
+      "interactive": {
+        "id": "interactive",
+        "title": "Time to Interactive",
+        "description": "Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).",
+        "score": 0.19,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "11.3 s",
+        "numericValue": 11318.627903846889,
+        "numericUnit": "millisecond"
+      },
+      "user-timings": {
+        "id": "user-timings",
+        "title": "User Timing marks and measures",
+        "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more about User Timing marks](https://developer.chrome.com/docs/lighthouse/performance/user-timings/).",
+        "score": null,
+        "scoreDisplayMode": "notApplicable",
+        "details": {
+          "headings": [
+            {
+              "valueType": "text",
+              "key": "name",
+              "label": "Name"
+            },
+            {
+              "valueType": "text",
+              "key": "timingType",
+              "label": "Type"
+            },
+            {
+              "granularity": 0.01,
+              "valueType": "ms",
+              "key": "startTime",
+              "label": "Start Time"
+            },
+            {
+              "label": "Duration",
+              "key": "duration",
+              "granularity": 0.01,
+              "valueType": "ms"
+            }
+          ],
+          "type": "table",
+          "items": []
+        }
+      },
+      "server-response-time": {
+        "id": "server-response-time",
+        "title": "Initial server response time was short",
+        "description": "Keep the server response time for the main document short because all other requests depend on it. [Learn more about the Time to First Byte metric](https://developer.chrome.com/docs/lighthouse/performance/time-to-first-byte/).",
+        "score": 1,
+        "scoreDisplayMode": "metricSavings",
+        "displayValue": "Root document took 40 ms",
+        "metricSavings": {
+          "LCP": 0,
+          "FCP": 0
+        },
+        "details": {
+          "overallSavingsMs": 0,
+          "headings": [
+            {
+              "valueType": "url",
+              "key": "url",
+              "label": "URL"
+            },
+            {
+              "label": "Time Spent",
+              "key": "responseTime",
+              "valueType": "timespanMs"
+            }
+          ],
+          "items": [
+            {
+              "responseTime": 41,
+              "url": "https://www.ocobo.co/jobs"
+            }
+          ],
+          "type": "opportunity"
+        },
+        "numericValue": 41,
+        "numericUnit": "millisecond"
+      },
+      "largest-contentful-paint": {
+        "id": "largest-contentful-paint",
+        "title": "Largest Contentful Paint",
+        "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)",
+        "score": 0.61,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "3.6 s",
+        "numericValue": 3601.0562534534906,
+        "numericUnit": "millisecond"
+      },
+      "total-blocking-time": {
+        "id": "total-blocking-time",
+        "title": "Total Blocking Time",
+        "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).",
+        "score": 0.46,
+        "scoreDisplayMode": "numeric",
+        "displayValue": "650 ms",
+        "numericValue": 646,
+        "numericUnit": "millisecond"
+      }
+    },
+    "categories": {
+      "performance": {
+        "id": "performance",
+        "title": "Performance",
+        "score": 0.66,
+        "auditRefs": [
+          {
+            "id": "first-contentful-paint",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "FCP"
+          },
+          {
+            "id": "largest-contentful-paint",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "LCP"
+          },
+          {
+            "id": "total-blocking-time",
+            "weight": 30,
+            "group": "metrics",
+            "acronym": "TBT"
+          },
+          {
+            "id": "cumulative-layout-shift",
+            "weight": 25,
+            "group": "metrics",
+            "acronym": "CLS"
+          },
+          {
+            "id": "speed-index",
+            "weight": 10,
+            "group": "metrics",
+            "acronym": "SI"
+          },
+          {
+            "id": "cache-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "cls-culprits-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "document-latency-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "dom-size-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "duplicated-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "font-display-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "forced-reflow-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "image-delivery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "inp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-breakdown-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "lcp-discovery-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "legacy-javascript-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "network-dependency-tree-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "render-blocking-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "third-parties-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "viewport-insight",
+            "weight": 0,
+            "group": "insights"
+          },
+          {
+            "id": "interactive",
+            "weight": 0,
+            "group": "hidden",
+            "acronym": "TTI"
+          },
+          {
+            "id": "max-potential-fid",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "unminified-css",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unminified-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-css-rules",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unused-javascript",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "total-byte-weight",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "user-timings",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "bootup-time",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "mainthread-work-breakdown",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "long-tasks",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "non-composited-animations",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "unsized-images",
+            "weight": 0,
+            "group": "diagnostics"
+          },
+          {
+            "id": "network-requests",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-rtt",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "network-server-latency",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "main-thread-tasks",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "diagnostics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "metrics",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "screenshot-thumbnails",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "final-screenshot",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "script-treemap-data",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "resource-summary",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "redirects",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "server-response-time",
+            "weight": 0,
+            "group": "hidden"
+          },
+          {
+            "id": "layout-shifts",
+            "weight": 0,
+            "group": "hidden"
+          }
+        ]
+      }
+    },
+    "categoryGroups": {
+      "a11y-language": {
+        "title": "Internationalization and localization",
+        "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      },
+      "a11y-tables-lists": {
+        "title": "Tables and lists",
+        "description": "These are opportunities to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+      },
+      "metrics": {
+        "title": "Metrics"
+      },
+      "a11y-best-practices": {
+        "title": "Best practices",
+        "description": "These items highlight common accessibility best practices."
+      },
+      "a11y-color-contrast": {
+        "title": "Contrast",
+        "description": "These are opportunities to improve the legibility of your content."
+      },
+      "a11y-audio-video": {
+        "title": "Audio and video",
+        "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+      },
+      "seo-mobile": {
+        "title": "Mobile Friendly",
+        "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn how to make pages mobile-friendly](https://developers.google.com/search/mobile-sites/)."
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "description": "More information about the performance of your application. These numbers don't [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score."
+      },
+      "a11y-navigation": {
+        "title": "Navigation",
+        "description": "These are opportunities to improve keyboard navigation in your application."
+      },
+      "best-practices-ux": {
+        "title": "User Experience"
+      },
+      "best-practices-browser-compat": {
+        "title": "Browser Compatibility"
+      },
+      "seo-crawl": {
+        "title": "Crawling and Indexing",
+        "description": "To appear in search results, crawlers need access to your app."
+      },
+      "insights": {
+        "title": "Insights",
+        "description": "These insights are also available in the Chrome DevTools Performance Panel - [record a trace](https://developer.chrome.com/docs/devtools/performance/reference) to view more detailed information."
+      },
+      "seo-content": {
+        "title": "Content Best Practices",
+        "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+      },
+      "best-practices-general": {
+        "title": "General"
+      },
+      "best-practices-trust-safety": {
+        "title": "Trust and Safety"
+      },
+      "a11y-names-labels": {
+        "title": "Names and labels",
+        "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+      },
+      "a11y-aria": {
+        "title": "ARIA",
+        "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+      }
+    },
+    "timing": {
+      "total": 24418
+    },
+    "i18n": {
+      "rendererFormattedStrings": {
+        "varianceDisclaimer": "Values are estimated and may vary. The [performance score is calculated](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) directly from these metrics.",
+        "opportunityResourceColumnLabel": "Opportunity",
+        "opportunitySavingsColumnLabel": "Estimated Savings",
+        "errorMissingAuditInfo": "Report error: no audit information",
+        "errorLabel": "Error!",
+        "warningHeader": "Warnings: ",
+        "passedAuditsGroupTitle": "Passed audits",
+        "notApplicableAuditsGroupTitle": "Not applicable",
+        "manualAuditsGroupTitle": "Additional items to manually check",
+        "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+        "crcLongestDurationLabel": "Maximum critical path latency:",
+        "crcInitialNavigation": "Initial Navigation",
+        "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+        "labDataTitle": "Lab Data",
+        "warningAuditsGroupTitle": "Passed audits but with warnings",
+        "snippetExpandButtonLabel": "Expand snippet",
+        "snippetCollapseButtonLabel": "Collapse snippet",
+        "thirdPartyResourcesLabel": "Show 3rd-party resources",
+        "runtimeDesktopEmulation": "Emulated Desktop",
+        "runtimeMobileEmulation": "Emulated Moto G Power",
+        "runtimeNoEmulation": "No emulation",
+        "runtimeSettingsBenchmark": "Unthrottled CPU/Memory Power",
+        "runtimeSettingsCPUThrottling": "CPU throttling",
+        "runtimeSettingsDevice": "Device",
+        "runtimeSettingsNetworkThrottling": "Network throttling",
+        "runtimeSettingsUANetwork": "User agent (network)",
+        "runtimeUnknown": "Unknown",
+        "dropdownCopyJSON": "Copy JSON",
+        "dropdownDarkTheme": "Toggle Dark Theme",
+        "dropdownPrintExpanded": "Print Expanded",
+        "dropdownPrintSummary": "Print Summary",
+        "dropdownSaveGist": "Save as Gist",
+        "dropdownSaveHTML": "Save as HTML",
+        "dropdownSaveJSON": "Save as JSON",
+        "dropdownViewer": "Open in Viewer",
+        "footerIssue": "File an issue",
+        "throttlingProvided": "Provided by environment",
+        "calculatorLink": "See calculator.",
+        "runtimeSettingsAxeVersion": "Axe version",
+        "viewTreemapLabel": "View Treemap",
+        "showRelevantAudits": "Show audits relevant to:"
+      }
+    },
+    "entities": [
+      {
+        "name": "ocobo.co",
+        "isFirstParty": true,
+        "isUnrecognized": true,
+        "origins": [
+          "https://www.ocobo.co"
+        ]
+      },
+      {
+        "name": "Google Tag Manager",
+        "homepage": "https://marketingplatform.google.com/about/tag-manager/",
+        "category": "tag-manager",
+        "origins": [
+          "https://www.googletagmanager.com"
+        ]
+      },
+      {
+        "name": "Clearbit",
+        "homepage": "https://clearbit.com/",
+        "category": "analytics",
+        "origins": [
+          "https://tag.clearbitscripts.com"
+        ]
+      },
+      {
+        "name": "Hubspot",
+        "homepage": "https://hubspot.com/",
+        "category": "marketing",
+        "origins": [
+          "https://js-eu1.hs-scripts.com",
+          "https://js-eu1.hubspot.com",
+          "https://js-eu1.hscollectedforms.net",
+          "https://js-eu1.hs-analytics.net",
+          "https://js-eu1.hs-banner.com",
+          "https://js-eu1.hsforms.net",
+          "https://forms-eu1.hscollectedforms.net",
+          "https://cta-eu1.hubspot.com",
+          "https://forms-eu1.hsforms.com",
+          "https://perf-eu1.hsforms.com",
+          "https://track-eu1.hubspot.com"
+        ]
+      },
+      {
+        "name": "GitHub",
+        "category": "utility",
+        "origins": [
+          "https://useago.github.io"
+        ]
+      },
+      {
+        "name": "Google Analytics",
+        "homepage": "https://marketingplatform.google.com/about/analytics/",
+        "category": "analytics",
+        "origins": [
+          "https://www.google-analytics.com"
+        ]
+      },
+      {
+        "name": "Google Fonts",
+        "homepage": "https://fonts.google.com/",
+        "category": "cdn",
+        "origins": [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com"
+        ]
+      }
+    ],
+    "fullPageScreenshot": {
+      "nodes": {
+        "1-0-IMG": {
+          "width": 134,
+          "height": 40,
+          "right": 167,
+          "bottom": 77,
+          "top": 37,
+          "left": 33
+        },
+        "1-6-IMG": {
+          "left": 280,
+          "top": 7200,
+          "bottom": 7287,
+          "height": 87,
+          "right": 396,
+          "width": 116
+        },
+        "page-1-IMG": {
+          "width": 116,
+          "height": 87,
+          "right": 132,
+          "bottom": 7287,
+          "left": 16,
+          "top": 7200
+        },
+        "1-3-IMG": {
+          "height": 178,
+          "right": 396,
+          "width": 178,
+          "bottom": 1072,
+          "left": 218,
+          "top": 894
+        },
+        "page-5-IMG": {
+          "bottom": 8734,
+          "id": "open-path",
+          "left": 350,
+          "top": 8702,
+          "width": 30,
+          "height": 32,
+          "right": 380
+        },
+        "page-9-LINK": {
+          "left": 0,
+          "top": 0,
+          "bottom": 0,
+          "height": 0,
+          "right": 0,
+          "width": 0
+        },
+        "1-2-IMG": {
+          "width": 178,
+          "height": 178,
+          "right": 194,
+          "bottom": 1322,
+          "left": 16,
+          "top": 1144
+        },
+        "page-14-BUTTON": {
+          "height": 26,
+          "right": 397,
+          "width": 20,
+          "top": 8575,
+          "left": 377,
+          "bottom": 8601,
+          "id": "ago-prompt-close"
+        },
+        "1-8-IMG": {
+          "bottom": 8734,
+          "id": "open-path",
+          "left": 350,
+          "top": 8702,
+          "right": 380,
+          "height": 32,
+          "width": 30
+        },
+        "1-4-IMG": {
+          "height": 87,
+          "right": 132,
+          "width": 116,
+          "left": 16,
+          "top": 7200,
+          "bottom": 7287
+        },
+        "page-12-path": {
+          "width": 11,
+          "right": 62,
+          "height": 13,
+          "bottom": 3521,
+          "left": 52,
+          "top": 3507
+        },
+        "page-13-DIV": {
+          "height": 125,
+          "right": 392,
+          "width": 392,
+          "id": "ago-prompt",
+          "bottom": 8685,
+          "left": 0,
+          "top": 8560
+        },
+        "1-10-IMG": {
+          "height": 0,
+          "right": 0,
+          "width": 0,
+          "bottom": 0,
+          "left": 0,
+          "top": 0
+        },
+        "page-7-P": {
+          "top": 423,
+          "left": 16,
+          "bottom": 520,
+          "width": 380,
+          "height": 98,
+          "right": 396
+        },
+        "1-1-IMG": {
+          "bottom": 0,
+          "left": 0,
+          "top": 0,
+          "height": 0,
+          "right": 0,
+          "width": 0
+        },
+        "page-2-IMG": {
+          "height": 87,
+          "right": 396,
+          "width": 116,
+          "bottom": 7287,
+          "left": 280,
+          "top": 7200
+        },
+        "page-3-IMG": {
+          "width": 178,
+          "height": 178,
+          "right": 396,
+          "left": 218,
+          "top": 894,
+          "bottom": 1072
+        },
+        "page-11-BODY": {
+          "right": 412,
+          "height": 8765,
+          "width": 412,
+          "left": 0,
+          "top": 0,
+          "bottom": 8765
+        },
+        "page-0-IMG": {
+          "bottom": 1322,
+          "left": 16,
+          "top": 1144,
+          "width": 178,
+          "height": 178,
+          "right": 194
+        },
+        "1-7-IMG": {
+          "width": 0,
+          "right": 0,
+          "height": 0,
+          "bottom": 0,
+          "left": 0,
+          "top": 0
+        },
+        "page-6-IMG": {
+          "left": 33,
+          "top": 37,
+          "bottom": 77,
+          "width": 134,
+          "right": 167,
+          "height": 40
+        },
+        "1-5-IMG": {
+          "left": 148,
+          "top": 7200,
+          "bottom": 7287,
+          "height": 87,
+          "right": 264,
+          "width": 116
+        },
+        "page-8-H1": {
+          "top": 292,
+          "left": 16,
+          "bottom": 383,
+          "height": 91,
+          "right": 396,
+          "width": 380
+        },
+        "page-10-META": {
+          "height": 0,
+          "right": 0,
+          "width": 0,
+          "left": 0,
+          "top": 0,
+          "bottom": 0
+        },
+        "page-4-IMG": {
+          "height": 87,
+          "right": 264,
+          "width": 116,
+          "bottom": 7287,
+          "top": 7200,
+          "left": 148
+        },
+        "1-9-IMG": {
+          "bottom": 0,
+          "left": 0,
+          "top": 0,
+          "width": 0,
+          "height": 0,
+          "right": 0
+        }
+      },
+      "screenshot": {
+        "data": "data:image/webp;base64,UklGRgJwAQBXRUJQVlA4WAoAAAAgAAAAmwEAPCIASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZWUDggFG4BAHCLCJ0BKpwBPSI/EYa7WKw4Oi8iEjmrQCIJaW78RB+j+DyU6/xqvYXgCgPMizQeKxet33e7l3R+99OXMv7Qy27NPpR/uvqB8+jzI+b//4vV3/c/Sg9KX1ZP8H6kX7getJ6wn+SyYHzH/of7p/kvbt8y/cP9t/gv3P/y3p7+a/Y/8T/B+hP/2+D/1/+881/6F+WP7n+U/0X//+K38v/6f8R/tP2l9G/l3qEe5/RW+v/aDuxds/4X7Y+wL7/fi/L9+V/8n+Q/0n73fCP7n/pP/j7gP7C+n//O/bTyp/y3/U9gf+b/5b/6/6H/ffuj9Ov+v5G/2D/of/7/p/Av/Xv8///v+f/3e5n6VwufOyyo1jkVGscio1jkVGscio1jkVGscio1jkVF4/3DY+ORUaxyKf6ajM86OVhCF5G37lupoQazb423U+u+kSpMcySSRiqUQQN7LVOmLdqQIXuWVzvi6sn0mtOMft0kkcNZu6Iv7Ty/PfkLmyJWuoYxTZouo0O5598Qm06X5IW6xmffAh7UMjSzJ5Ecg1aiX3PlbOOyyoCG6uK6NY5rumxzXRrHIqNZBzvh2WVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGsceL/8YX55F0Iiola5UPiDf7kTZZLIJm+aOzXOlgBsHi+H34URsIVIcYoDXMn2rQA5cZysILKjWORUXrtbjv/aeSFuExzLLnPad873oZ3hRyrbL10LKIrqG6swthEEjNvfwvkgyxB2qNY5FRrHNttAiDSfn7EsBBZUaxyKjWORUaxybHt0kj9ukdoLKGNBMT3ovNE/9ICI7LIVXspmYofECQdRKDO8U/lLc/bpJHbRXcijL5f+rA2HVFAsk7hLfid+ArsrZOSkWo/DbSi71S2m5MZUsY9McFAGl705NQro81/NS26caSlJlL5OPZbDI0maep55BGj7/I9AT600Xn/8m5DpXkUH/ZwcPA+eoKVI/bj0C9OXsO+SdGsuDP3NaF5dTkRnlcKqSY/dbynAEMW3Vc0QC35lOnR+ACqQmHIwzF42vIoXrqBOLkVbueGAwyahNsgG/lNaMzyc4rNl3yvb0pd7XowK2gJRU9ySIvoWFWF7hJXzcFx6ciZ4RoiRoAHbfp/fU0BiO3UVzoyKjXu8yST2S5tknE1zKCbTkf2QAbf2VPKKYKaWEmObvyVDWWliJZrtFwmDA40SPaGapj+rpYEPugKlt1SNQwzztUF4ITptGRgI0thDYrdYM+LmFivw+RoxdqptYj3zsie73V3g5yylAIT0MVOj3Xh/RrHIlZsk4lFjyPtgrF0d7NeY/88o+c69sl0gISRtSaiSxrYWJ4KWaNTyEayc70Lrs6f81Fl4HAkvPRVZGFuMvjl6jo/bpJH8HvkU7461L1uNllRrHIqNY5FRrHIqNY5FRdZDqRusgbtz/zjssqNYUM245Rfp1d2Kj0K1uN66gA5py5XRfTMpg6PcNkjvANB4B61h2WTBi0yFHA4+GSGOT9tPKC25zrrcYgfRlxp8l61nEp1xmdwfiAwaMdOT+dFELhhY0z7CJd0ReQpPw7y9Ad4FinC/fPO8iHCHiUTAiSqqsvg2AQOaTDHHZdBTaD3i4l3m67RstdXt4kUm87QGaSkaEjGn+vxiRGGMg7xnGCP1PJE3W9SfjDtB9Hi/DTSCB7FnS9pV4hkOIwLa9J4tVRIQncNs0XoJireeU8KjS2ClVdHcPOasuk/f85w+7UT11rpbhVtYYDqsE2BjIJQZBRrxXMGRe/FQKjzyglnxgQ4weLcmE80VHVdVkodwd55h+1jiuMOWa0OJLPzt68KeUGbgRPyPgGA1RFBtqG8iM8v8ATEQMSuao+YgkYv2i1Jtxx13ArGh2xpiIucwL39YDZbal1LA028AHBvLhIcVY3uktXP4b7+PSx+CSd1pVBdXDZeI33xymGF0ZaHqfoaAVpzek2ct63aQZcwn75aWt10XUOcF0dw58Jfbrp4GcObj/t46G5J6EPY4zGdI9pYzpjABnOB4fNelARd7sU3prPzIeUCLhvigKnGYp1Rddv/rFqS6m9o1vxjNUhaNEiymo3Zhyzfs15dCekkhk1cbhseDCSP26XowhU1I18qNY5GNnhwBvT3ke49ojshY8lxGc9WvJytgdytmNrIooRM9lOHXc9zAd9kns59lDl1JCm4SmgLROZYH9Iw174lphbRibKTVr2qbwitREQVXY3gNetS/sCqiTwPHRoW2NUTN6CfKBB2XvhWXjvvzDgbCiGIlauPjYYGMJYCB5JsGW1/eodcZ2cxXYKVzjc4o4AT9a4NXXKa0z++cgMtnhBWulT/NviBwz9w51X0H+ENbHh5JEp4gRK1NKzg/pRVvEyyd2NP9fQPb5DpB2efRvfd9yc+3YXe4x60FOA2Er+zNZ7ItwXGKxzLmiMyYgwUexj/NrMj9LGiC37bNdDvcdPOPgGjZ2SYrYx7pjXFUiwF8FI8RFlKhKUibAIclxOCLeLdWwQEThodBggOf5kuJBNyV4MDXIBB6ODVyfPiDTmbre7AGbfJAcPxy1V5nKHSCFnZPGHKKYVQO09aIsc9SJ8+IwjGoBarS0HKCa3sLBSc0A+95fA2SkqweEKhQDW5Kn3+SkMbEtRS3T0U83MCyeQ+sRdgY60KfSS8LSt7OgHHpCiJeNojWvdW2At8g2vjZcs8uKBWvPoI2XLPV2dNum49AGyyo1OteJ+LWTPWagAtkROC7LG09A0aZz7kAWBWvMliW8HqvXLhEQU4JXRKCL6GOUmfggG27mOpJMSRkCzoGrUnQaRryJWQSlooB3e80n3ENAq3NuVuvlQjeAOqNYc0bXb41zIIkIfYhojRFE8sYYTkmc+xtrmDaV+KA8k1OacIHSOoJUho62PPcxSvRfKzug2hnmorWmNUmMkcfSoqjbMHexzGOL3HqhujS0igomSZyWpcCa8NFymhzwFu87vc2DINuOKlt9aCaFITE9keFqh9otQqSVDA0ArgM1ezYIX1eJ3CMHlAcgzEyfmPAZ8cwJdPb1SJFswsjSWv8DocbpXbPm3Q87Utmj7OtLvj6CrIkPPpiUdHYucI70dmG7Sg0uXCUb3FfYYvllgWeejI0Bvsec/93AaKV++YHHcBA8bIGdR66FMu7D1Vb82AyUxG0gouWLmMb74U9bq74tIQ10G3qRg7cv4io1jkVGscio1jkYxVLvh2WVGsyj52WVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGsLpy7gQjhFVxDCN6OmghRSxyKjWORJtNPjKJgQuXMQzkk/hQMdbvM5StSkC6Z6pipJH7dJI/JMfiRzX0mDGrxi7KHDXgoOATesVYIkKWhaONZtUlyweyr/7yBiOt728zSMwCfws8qJARFNpSFyEe7nP8PZfEyD7jIkADaz6NFxUag8JrIEYuhyTPJA86PvwV6ugFfdlyHvLVwtKZdovT2JGPOh64uZx5z8GaIIq8lG+KQZwYPysp0jVgT9k6qGwDL9Py0IhXbE8ehzpfyqVyjrWos+n/eTP0QM7Y85wMK8kj++QxmI4h5d0qoBlI8+fqcHrm1/DSALZS/qGshh5FiIX6gNPP8DRG7f3skPtvOKkNAHEtqvDfk9Rqd+qJpm6XISWwmmAwIi2mkgTCfKjUuivdNEWGiozgaaRfbYplYBEgbmgVaB6Z1yNjg/P81O8alq0Hb1ZrmRcIImBb9EgOJegujhVm1MBMiR+01IqMClUBheR448Hl/N5L8RH4yQIigceW7wZOAOxOjcl3TAdER61d160FGLec75y+V77OaD2/ARC9pskMar6xXJ2xMiAnwwciowKO+rFvy0sL5TVwsVnvCZIjuzqd2wGOPRg143GO6wE0NP2A3vVpMAD4PYjDYS0fC492YKJij/g3FTFaf/Kfp+3SSDJJddN0uJMKd8tXiWR6wWZGN89MXz2/LiTFmAJGIUjD/49vzqkzVhHu3UO2PeBYB0ZCCBJmLjN4fjxc4x38SO2MC90maZG/g63pGiuFLGdji/xnDiPebIbOquJd6qj/WjydTkzO0KlWzUv3mvLRzXq8TDniPAhho4rRgFxtz+zwaqXonlR2QdIuDyp2XnV0ToCKeOaTyowt3HGb3PRPuyGlLZqxC0P+IhYwCAcGG2YLKlHFqmFoeX42KLDCElLRfcW1j8ysqr+3CI3RPohQYhFFzbtEOTtBPKASFHAIBt5AJf8PBnskBNwbniCdxySLFQnjZNM8RwaMNKTvi4a2WOW/7XisOb4S6NhoZ0puwP/JjiYWAq7sH2It1vTYRhedooDWIjlLevBjlSxgIyATQ4Z38DhGWvwkruBg3kCNlyz1dnTbpndtdVvMD7o1Wo3i1fvXzTL0wM5y1fiKU8Bw4dXHutPxQbvJeg3JIKF63DssmRU/Bb8R8FbLQMitookExSxyQjTKhNqEv3gbnaNLNqBi0ddTApxzAOx+621xfYdqE+qese1eNMO43KpJsPVfUq2coMPah/O6DhtxsLYXLCE5L7KcaX9br49t0LV/ji6T9KSvymR3RX6pju3i+kzpGvJlIGoovbOJxM7rwekFgc9xawwrGNYuzG/dt37X141zDkSMEj9ukkf/ntxshfNfJ4Lqm3kkft0krSZ8DRw0zW4ASA24obmzcyDg6WdMeemNDvr1XLa79A0xLq844emaS45Bac9UNySP26SSO9HR+XaQpm0XlyfspR9uSZrPtwqdssGnGZBHK1SoRxzxIg7vHJPtd+45+CO5GLjtukkft0mOFJcU2wi7qVmVpABv7IAOaXmfh+TvE3gRORUaxyKtidGc5x25fUo3UhJxRN78Y/bpJHYLBPBY76t563a+jvA1a5GsNaq7PT9ukkftzWGPjLx1468ddU1ukkft0kjyEJJH6pmBG6SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+0oGtMrqQeWIAhOcNLnxEMAIEj9ukkft0WqIoOLBqKvZbhZq0agGR5KT2O5jm4IFySdUIpyZ/d9sR5/hCejPCNUuyADf2QAb8lQjqqWZkxpFNuPrBq0COnk0+ixI/bpJH7dJM6+wv7wOfxFRrHIp1y8SBuIok2HJiwfSHt8mPh0WCut6GALW9be2fLUsX7USRraZ45YJyv0okKzAc8bpF34n92+IBpL0A3yESyqdukkftNetwY12HFZYmX14N1A1+r0RFMLHXB99k0Y1KrHGrt9MUMIYr+V+b9v5yK+gNfqH6snpBq+Qr3SdIGDmMk8ttHiD0TBQf/DlOVXk95JH7dUV3Ca2bXw+qY+GNlyz1dnTbpnZUaxx2TzD3lp971JDBYKcoG5jhxzmqmqz8K77T3oJs7fytZB+iM+c/7Rzln7dJI7fyjXdyVCUgUB43ehGNkzTNQOgWFM9bT7AIHRjY+Ugp6oxzxVcVfHhB3o9oDZDfqIG0e+PuOaYpjIdsxSvmEB5Dzwgx9PifOx1bqwZetzKkrosjy/t0kj+DCga90DcfKe5x2WVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGsbt/ZhjwNWuRrEAQnOWr8RSngatcjWIAhLxLSuGCa4yX3360tMvHXjrx1468deOvHXjrx1zbA8eUJbBwX7NSR+qes4mF/eB/1Q/8BWp5ST+4IsJjw7cupd8Oyyo1jdJevNagvoFuS4866Nl9P3W4idpNrmvc/v2nIsfVdVfkkop52WVGsciowSUrxttVl0pRMuSbv6zVBmK6tKsqNY5FRrD6QS16ppoUxrdJI/bpJH5j012xHbwGPX5D2prtZcm38VN2hnHVz8THhtPEWQj+bHl8hEUyv1d2LM0M4dldaEdojdEJNCgxl+i6MsId+vIpv5O/6dZ3bz1IC5SfKbmKzfrjUzSIzXbNAj2sWFI7fZOehfGQVARlLjo7+QO43OvKXsfGCR+Y9NdtSLr6oWsQY2QHkkfmPTXbUio1jlLzKNY5FRgkpXjUSX7YKO04fRnKhuKzMMaUFfBpxV8xEJHga2FhR7dGlu5410QdmMHcRBrgKEXOHRF+uZtRb366hWSydcQCP9ts2IyML2XQfxlPTNLN16D1ecuEAut1ME4a8ChcET/67zvE4hb51u541R2BUkHO8sj/IbfK0v+OYSfP+MA0oyU9AgScdZqYVGX0i1ovIl6CXfF0yHeLcNBm6MA3ha+n/1aZTF+1NK+LTWp99yNebKL5/Xddx/TEVuQ/ccOIpfkmGsliRoMDRUSkcrMYa0OW0II/Bj1808ljzY0/76CAQRYVC39qXkbBZLPLaYMNK1goIv6xoEY5gBqnDtTDmIiyrYu948pVHlSKjBJSvHYo5VB0gYIMkZkFLf2PveRo3pnxG1gUaxyKjWORUanE05xFl0JvlPghOctX4ilPA1a5GsQBCc5avxFKeBElLmkzjssqNY5FRrHIqNY650vhVuzcWEdeOvHXjrx1468deOvHWo5+z+pVDhxMiDIsqNjA5urSve4dw7h3Alr9uHqdUXaFaLu+HZZUaxyK0KwhZVDqte9Kj6t6WmaNY5FRrHMKe97WrAWfTO5608tDWEXLWORUaxyK0KwhSk0EQ2pgo6ELatHKRmd/bpJH7dJw0QogPx+IOCTdsOhxUaxyKjWORWhWEM1fjH7dJIAgTOWGV+nZzTm3VyA5uHhzfg3Ap56getA1twRqDFjj0Ft3tawgRf9a4YwoQO4y+h7Aa9orzj3HRSBhcl1wcsF6r7kDPpgb5rfmXKo4QCFIXKV2BM500OnpFp3Ew2IrOBOPTMA5aKwuzptrcGK9YKCXc5Vlyz1dnf61dnTeEfIIVrbyXHem9N6b03pvTeZSQQrW3kkft0kj9ukkfvr74NlDiWOblU7IM4m2W3oaoOtBM13HpTRnDeSDJw9k+92N00+Oiz3HyAZAndlD7hYgiQU2+yqUrl4FC1fvCQMeY3qRfO1+I4OISDlN+qDvOaDFZb3HbrLkdpHkxg+2AswzBnHjCAoNMjZT9+x2K0KwhHxmFsvwDL2lcQO5KmHwaHrCNGNe2BPR4h7yRKlSEmNk2cSQowZNjzJbQtUclLCiU1MaZRr+Qe/wqbk5RKmAWtFxvWIGcV2CRespmmwF38HenZC/QM0g1WRH3JoSMSrdZoIS1bv2z6N3fDtfiOFOnoSSs29b6VsS74fCiBNl8BIkAs6iKjYss47LKdLXFQunrGF7hPIJkFJ+k/SfpP0n6T9J+k/RXVTOQvE7deHp7096e9PenvT3p7096etPtfctmv/Ww1YisRWIrEViKxFYisRTmKWXYE5jlXKUWXaAG/sgA39kAG/0BDIbj2+7EYjWORUaxyKjWORQgdKygOs/I317UnfkOyyo1jkVG2u0oMRAqM+/DDNTCCmbySP26SR++vvhHmYIwgMbB9CSLg4cio1jkVG2xi+in4yDMo/RxfkAzDmwPKfbpJH7dJJLkPUq8WKy3pd8Oyyo1jmExzBfcjTn6JLGg8mILmW4T4SOo88lh7MOzBTEUmEi5hqcr99LylpS1HVXzswJjmDvSd0jSz32Tf7BG/kE7T696W+DXuTDqqMj9qiJnyTpUX9tzFJ8KYwqPi0URS2naYOPpj3+7aC4nJEF+QfP9CtU1+xyK0GSA1rvCHgF/khjTM1Y5FaFYQzV+Mf64274dllRtsYvovlmD7Mr2eyqYyCqnFK4BeXmHRw41SbvcrBeytxzh5ZH/t8wAGs4wPalmNG7Q9OYVgSqb87v9Yru/5DTkUusA/wNNOHDhKQJW6Vfv6ckENiQjL+NwhZ78+w/ZXD9qYQ6/dJIR8v6LDv/rZ9OydgijiaqNlghO8AEmlvkkli2QcGiMbQxKS/UOOGLCa3fCRSESH6NP9oMB65Ek8xUyuxztIeGfAsKgkuHwAY4dW0u5GlE8noA/uZN+MQnKUvAchkSHg1SBu1lMuNEBKVPJNkpFFoNGP9dEOghCC6Ntfs3w09oYQ2BQHAkj9uk4aIUtGsckB9V7C74dlnNNYBpxya9vxj9ukkft0kjxF8zg1Bj1dIwJ0c5OcnOTnJzk5yc5OcnN5wObQROsqNY5FRrHIqNY5s+YzuH5QoFQtHeBq1yNYgCE5y1fiKU8DVrkaw4rJZmCy7KnuBBtudesRL+G5bctuW3Lblty25Y9eihoO0m87LKjWORUaxyKek8rZ30N1yzy030lMsqNY5FRrG6S9ea2/C357NQ3gAIcDBjlMft0kj9uke5K3DoZ85ShP2YucxJPATedllRrHIqMElK8fGs5rWZJ4ud9IBUAhEVGscio1jdJevNmJilIgO5xamCM6R7ShxEU7LKjBJSvHukeLREClInDJM5sqN5fQw0Mc/NPQA7I+YHh4Wia8Bjn35tTDtzbW7ZCUk0QdXAdw8D8oZViK6YcWfB+0f4gs0t6nnZZT0nlbQNyjuYT9KoxtAICcxagHxCsbEUw/GP2peRsGknNsL/MaMV68kj9uSHVdKlSMbPDf2QAb+x/6J5W0CH+Jj71jAfOyxhMNryPyNGpcxEuOeEeE+jLfsJlewZMr1xbc2s56oDkrdNuUebboEe493joC75i7fbXT2dYy2Z2jfiHC/vtc0sl+rtUhTv2BrRx0tIJa+5boJbyLUGNVTxQkBMPSU1BDfw9JF0G/GDr4d9DKerm/gkMG7AxFbkk3Ip+bCxk/kavhRKbZRhRSlmVOJMmJRmruIpyCA8ihaA3YCSJkRHOGDiBisaQ3a6x91XSl7sshRT1dOCHu0eeXdAC9p1IB/yXOTqRIbLWHRpCHc53sLuS3c8f2QDB+sHfDssqNYfSCOXPhwV3ZZUaxyKjWORUXX5klvpn0UWqafk/PCE5y1fiKU8DVrkaxAEJzlq/EUp4C4Jtx0l13A6LF+Y2le9w7h3DuHcPLCyo+cUhOJle8EY18mbvh2idj9ukqXw7LKjYss47LKjWPB2P26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSP26SR+3SSPyarYwxi1Ab4Lt8c580vrNXTwYZGNCvz6AdUGQWFGYOq1wTCixbu5zjIM8TFZvsxHU7ooQaMzSrMXjuarjBLNDjGQAb+qDbzFnIvWEM37twMMSTbzSk81lXg1SEL/nQoWPhLdC339Rq+Pl/Fz8cW5zWmwtBWtlkFnOwvSI6gpeyTbBgvtLAV5eusRP8E4P34QRCc0qq33l9U/imbSciEDAHXXxPP3SbeTABv7IAaptgwNxstIGYssqNY21N0rYHFL0mmyZnqlZM8bedjgnLAdzsEdLsYKfMbbKgWwNjXTJ7hYJuZaZJ3n/HSFTG1jc9GZB067yLeqo/vdVdU8Dk9jmpEe65daDeff98x+jdEyAYBHORxIZ+TkgQbDeHdYJW8ZTQTUXOvlqq57cxdrxu1YzIjIJDRXoY8k/m25w6xsj7ezTBbdz+eZcv6mnE1UaY3gtPlCK2jiscRBk9ppipgTSW2Z93mHUqaWORUnhCIJ+sWIIedllRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FQOIfh+4X94H/VPWcTC/vA4Edw/BjmHIqNY5FRrHIqMiDN9X9R4rCxgXnS2KO3ZabWCGN4HxhgfHml+ltPZqOSNtGG9DaSq9t2qlyp3YuZdYzh3w7L5FQkqV7hrCDoRD3hnCfDVmS7YY7J2DlCS+Eiw6WZkm1bwDwCCIY5X6cfRp3X0/nFe2/yNzn3ZFSOy3nKYemShWWzjsvkVCD1qj4WrLfTlVmAeqBPFML8zSX9IArgLJ3rmcjyQlJpy0AMzMM7uZTVx8wLGl3OHoeI0TfcFsKPljkbgLg823SmqVEIwzF0frpMAKwvGKTAzl0hItcOGiSa2/vrNsX5V5BOXcRavtHtfqI5Y5FYpVixzbC/vA/rOOyyo2oICpFRrHIp8NvOyypE9hq2q71SP5dKYBYivT/lwiL4OK6LsCDEj1zBvwVz/Vt0SHAa2M3tZ9V9ysqWDbNvD7Yr5fFSQ2ft0moJX3UaVsi8lD3CFze/t1Cujk/bpJH7dJI/bpJaN3qADf2QAb+x+OourtYfkj9ukkfm3wKGiXkzvMDJW47rbip7Dk/bpJH7TdphRSMDvuWXCWeDN5FL04uh33ls271ABv7IAN/Y/0eGN16v1xMMiotawdPLsQqNY5FRrHIqTe6a4Z9GJgW8mCf/mcJ8mjhyKjWORUaxx8NAzRUUo4qLwNKXIjuiv1T1nEwv7wKI9aZNObZuF/eB/1T1nEwv7wP6zW7PftPxj9ukkft0kj9BYQrWQoREkMn4VtPUOStsY7dJI/evVWwrLY6ZMokB4oszFV1h3uEkOuoW3Rd4VgBenCtjXC85CrX0x6NJvO/f3yzMmt7ZpjLJkaV3uBjmVSTwYVzMSK0uImeBJrMtsZc6MMDvAwyXoQO2PFpUTqeTsN+NI+Cusm149ceuB2T0tjH4wTPFFJA4hS74vRGru6QQ+3SvRUxnuCkwk9HXPz42aKOg7z/4DT2QyCf1/bqFdH6bLcr0gNwI0YMWIgUlDzJkpfISR1W5YGrgjG8eniQKuTNYztDiSRzqE4pN/IZXDkVGscjcBdY6LRrHIqNY5FRrQpLZ847LKjWORUaxyNwF0oCFqo3S7HyXJXvZQgxrZ1NHEGGG6zpwQN9rf9fNkfhkMkOF8vXLkWMOyysUq0NiisHXgcG9kiDuyJBqKwR8ZCqmfEpo7wqPgYBZIyikWVBURcaxy5FRr5C8DB+TvW42WVG1BAenfDssqNY5FRvoSB+sWLHIqNY5FRrHIqRPYgvijWORTrr/z8pfzUF+dX7zlrAkMG7jxZMRUDHCQoe/JH7dJI/bpIiikcvw5tAYWPNaXJ+3SSP26SRThJrpWkIgzYoadkMwQliw0UaxyKjWORUaxvBfwLzrudkwn4f9U9ZxML+8D/qnqW730uUG/9wkd0V+qes4mF/eB/1M3si8ctByI7or9U9ZxML+8D+syN0vs7KjWORUaxyKjWOXWyvwjirJxr6RXuV2JIvR1QmGlKVngmW/VriBjm2Npfv1iaYxgpw9z4208P9bVD2UfKnDFYlsn2rts1wVP2KLzuKhxcs+F9IcUV/dQQ4Ph2X1tMHvBZeaYPDduhQ6vFjqR187PQszYcH/izLBgBEM4F0SzcpbkEHfoEX+jYkdf2QECRZyZ9hmal9xvQOox7VgILiHjxZigkBb125sRA0Zlj5uxl/FjqHlswaQnmLroio1ogD1SNw0OJnMIio1jkVGscutpjzssqNY5FRrHIqRYtSo9hrHFGscixAd+74e1qwRZI38xgPnaX1G7RuQM51cMgPeFDx7cGY13JX6MKBvtZa/fq0Ho+j3BR2bLXfkigw02wFcevpPKkVG1V8wmO6p7s4uxBP6/t0mtMF8UaxyKjWORUaxy62mPOyyo1jkVGqa2/QkEzSJJH7dJI7Kf1njYbPfgsowz8biV5PzLhYuaQB8AVIqNY5FO7RUzQidgRH5q9MXaSaoRCGq2JepyKjWORUs1F4v3N3LpNvNeC4XKF2n2x7RT5IncqNY5FRrHIqNY3jeBQ/scQuWJMLCN90V+qes4mF/eB/1LCqdYcvSYbPQNH6p6ziYX94H/VPWb17h2WVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio1jkVGscio4EkfqnrOJhf3gf9U9YDjWORUaxyKjWORUaxyNvf2lA1mLc5avxFKeBq1v9x7Eo9o1jkbe/tPCtbkA6uTeaNGKBFK5IZp83DlJnyG0+rTIi7THXNsbTQHaYi3bOytEAz3hqNvGmTFXCcMho4mWbvqi4lLSTV5GgvZdEVigrZx0Go/5oPiLxLLsWBkfYxpFKSwq5krpZ7EEAhW0DzdJI/bpJH7eHiKxQVs1hZ5bFXMlM1qHFJwtK10UkCqNygYihOQzvpMIoThW/FiYacuPXm6NN0uyj+HU1VHqcBn9BouCguDmkVrCcKwRBjT+QFIssQDg2mStmH1afmTo9GyvmIdm3AjMRc0YP6+C+WeQHIvDJeLIon7TNoY/Ue+S+EvnrIyrh9oh/5bOO1bQPNJCIhFO8xiXCmjWJKqJI9NhIAbbpStSdjoFja11pioRpWYTfRwLL8/+9doTt6K4bOAKvPWH/hZOFk4QUPcUoJambgEkZMzo1jB8cYnUozS7HGHludm3xLjApjwZ+yTzzK3tmrEJgejo0SuuK9y90UAXZgs3n+xt9tPr9AevO2oPHiRr1mtQfbqSZ8bEqoWNBl3JIzdxtyWBDA042LYCQGwSWWnblKNX5z5b3wKkpfOrQRsuWers6bwdl8evN5JH7dJI/bpJH712g6CltnPn6QykxzzSSUdNrZPOXWkL5E67VPU5YN7OYNmX1xXBQ+lDSt1kBx3DJbrmyCvTdzv5+t9CyI2/wP/hPhT7kXOPAszXWyJbB6rbBMcVvC9VuWft6z4IP8gO7vzjalqPkhUCm906c0HI+NObXxzkB+NqS2ceXAuIb+XmHDt+Ps4gd0BHGq/nWIUryWio1kId0uPhvqC7NUHyi2cdllRrHIqNY5FYoK2cdllRrHIqNY5FYoK2cdllRrHIqNY5FYoK2cdllRrHIqNY5FYoK2cdllRrHIqNY5FYoK2cdllRrHIqNY5FYoK2DcYcN0kj9ukkft0mny3nECBkoQNeg4fIt6fqbKxpZ9q0E6EoW8mUYejDiMszDQERNWCrnfD2UDz1XdhyIg+n9CLBxFpZP+h+MND3tYsayVdl8evOGsOVtqxCCNoriy4FZK9z3RrHPtklaeFg9vwdGy2JPXyzMo+PShORR0h6z4hDpRnrEAhyjVdMO6FbBk7uDIva7QcCApo/HnrtCi+YbBJsBtf4tCqdB1i4+rQRsuWers69p18eu/wKeJgSILnWQaEoIcgVEPDN/j71oDI/bqFS49eche26Q3nryPh2WbfEuROsqNYXxU1IxgMF/U5J1dhcyWBA77EQWkW8tA89djkVF93RCQAKYBiKUrRMgPwL3pLrYBICO5RE3hGOKaJGEPhtqLzHUDs489doTvh2VumlfwIqxOIQ5VNNtjsN7O8DJ1BzAOVmd7VP6Ykg0Ha+HmfLQPPXY5FRguzS7OPRaP6XDmDaKxQVs47LJEIwC+bG4PNYZg+Cg9+ACKsha7YwBN8eutZai+6xfQPz3uspe1gei49ebySPx+c1YmwMIH5WOhu9xknNVn8Z/Hm6SR3OnhdR/Li66jYTtFAQ5FVdh1FnmCwDVZ/Gfx5ukkdVKqJNjyilipUdYknylADUcbloH8v0F/v5jRVs3h2VigraB5ukkfm/CKkLQCb1CpcevN5JH5TWhdNHn+zP1gfVvyiJs7/rrO/fngRNPSHMX8l3Pp7lfj+74YTBWd8evN5JH5HsdSVc5OVBX+nTjwmhyiqK5X0sIjcwtmmn8jklxrHIlZGDXKxYySS8mEuxsn9DFk2qXItUgfyOSXGsciuzjk2gYO1bQPPXY5FRrHIqNY5G3xLkTrKjWORUaxyKkTr49ebySP26SR+3SS0VigrZx2WVGscio1j5aB4gSov5sPm8BlLrV87sQ1/cvyyo1j5aB4blNXLFcsvM7HlMgIMXaisJhbWaF3LcMiEGSuV7GIGYTje/GF4tXV7jssrFBWyTxEUQ8zXnxAdhR61osJUxiMm3jzVsn0LJiJYiJXfkmHy0Dz22JtDNW5s8Gv7KJAHgL5osIgVpS4RQxEA6f+jf6SQOodQgcs3etUZMr8OUmeiwhs1n5y84an0f2U0UPd8ax9A9e81b20MDGjSyf1oQfb+MtFUXBIMP/1/b2p8tBSGwdJZfGBgtUss6iHJChJHAC8pH7dQqXHr+o4ciShOZJxLbVHDkbfEuRYT8Y/HKoIccifCEtW5Sc5N3tFPxkAfNP5LPijWOexxABv7NqLzhy/d8Og5aIXHV5Mppb5CjnuzknBcEqsHr3qx6y3bFlvqZEaLXqKVHMCJ9sFyl0xISjnrI7VLGItCeaQqNY2wMZ2bRlIoGHJHcD1ODL1ustA89s6yo1DNKpwMPlJi4OUf5qAJtZlUBe0yX9vany0FDjWOO3FNbNjs7k6ey2mIrEb8rNF78S5E6+scgA3EmxnSpxUU6xrqehMAwfRYD96V2B0HyOSde/t0WqYhjhKaI0u0Dee1olv4tYAirmM0Qnomb47KkFbMXfvCipnRDukAfNP5LPijWF95hpPrG3qSFEnXOXyA3ghW0Dz2zrKjUnGJEuwd8vt5tJCIx0/ZXxUFR/dPSPX5BS42ZZ9KkTr49f1HDkSGEzzK0zga5HW3U3EwadKwfAESyy+LJ64naWo483tT5aChxrHIkkPWmpKiI+1bQPPbOsqNQ0nQC7C0cGvBDM2dztryBYr0qpe9f83IZAJeu4NiEgUX2mnH+ncNIZfhryOlhQqXHr+o4ciTOqSEuzU1ZXTeLV9smK1dYgLH3m5CiirLn2P15TFC/Tr49f1HDkSodepWDBtNVkPVmA2R9GQZ0zXgMFxcfyy4KCtoKHGsciq2M7D3hveS0VjmV+Mft0kj9uk0+W+J17+3SSP26SR+9doTzSFRrHIqNY5FRtP5HJOvf26SR+3SSP3rtCbD1R9g1Bjt7LmvbHIp1WOfZACs745M8SnS24LG4pgP2ZlngCdUCqQQyRMzSQRTXCO25fbQdRDT6tGzjDp2trhNKSc2yE5dAs5wlSxLQkZZ2bfEuROuxOOnINfL5jU4e/nseNe2cVe20p0I/0W/GQB80/ktpD1ctjp5nwSBx+1Mdl41cpqRx5Fl7/QHsdPTgQpdaGHqts9/Og2XVuXpPThHMI5DuSTf/JbzGETsOUfakD+RyTteFZCAcmxZTy5qXQ+OW8VS4OP249Jg6UbL49ecOXnomcjIM1sgHMOQiAO64gzLfzLjQIshxh7YqROvj1/WDTsquP6ogfp+9doTzSFRrG22+7+SU22ideY0GqyZuPuf5wqaoIky7/OXytrZ/GfyhxrHHhhVEu0+f0InPiIKCNBm1zuC+avUlyJ19Y5ABuOEZWq55diemqdIQTI1Ldy17W/jQA/LQpC42aMflAZHJLkWE/GPyIowAECkYu/fWCJIJ6vw70zFLj15w5fu+HSG0MjPndaB2iclcxgwS8jWCslKkhRCXZx9wEdq2gee2dZUajW+lWdTiR2gxmHrXdMdqUY5iv4y3UudV+a20gNRPPXaH5I/bkCDAQ/4EuztIKW6PHbp+cliAPmn8lnxRrCufhyqjRsrTItNx1xMClXAYsZmTUQ4fJeABaXsovJYJLjcH4MrWe+9SXIsJ+Mfj8suLwWDdwnouLzhqfRyft0ZX5anbbKmart7F+AW4cfM/DyQei49f1HDkV3Fy5WWcdq2gee2dZUaxyKjWORWKCtoKHGscio1jkVGtCeZIExAsqNY5FRrHI2+Jciwn4x+3SSP26SWisTxzB4VSe/t0kj9ui+aWXWz+M7sbC5IDnX1iiOSKGSOXZxSXKFlhAa0eWOrBRo9aq2qc2I9mRP12SswE06kmCUwSeRqYJAa6cxbVQlJ/bFFhauG0VigsxDEVlfY6s8HOEP3eVx2eRoZoKNDKywO0Pn9pb3rtCeZM4DywpAyDSMsGqEKiIFwD6r1LBiNQfPYSPsm+bOHatoHnrGdzQINYQeh2yOkemuabausQolwCwM4ORt8S5E6StSCD1b/UcMVHimsvnC5zJHjdnwV4TThXNp18evOPn9i8OKaVgxXHQYsJgiEJ59FKqVWyCSm1nUAKit0xecNT5Zx2WSZkJ1jw3Lxt9zcq/BXtQP2pGApffZw6JN5CTT5b39ukd0wtb77fbkTxgsD31aE3VA9Fx52WU5rZj7GqaPSIZw7Rn1PCZjADDGp/I4kAjuKbNAKnMWeoBOdVgei49ebySPyRkEsZoMBeDNJquGjhEFWDz8/iy6evOGp8s47LJXB37Yxei9ibsjASsU2THZ+IRw8G+bx9kA/K2VkM/jz12ORUXI4biyNxDBqiNvlD5WcY+zFL2+Hw/j07EjAhwWu1XPirZz8Gq84anyzjssqT9uv5L/8HegbVigrZx2WSpjJFICPLIWEV9OEXg20B4UmUuivbpNqrYCYNbDAcDasUFbOOyyTqEofaUuB0hSGL6aMZ/W+9wow39m1F5w1ORUak5wOCSGA4gjeDR1jgCjU/G0VigrZx2WVGtdh3OO1bQPPXY5FRrHIqNY5G3xLkTrKjWORUaxyKkTr49ebySP26SR+3SS0VigrZx2WVGscio1j5aB4gSov5sPm8BlLrV4cAPQgUcae+SuGXHrzHEt4p+fDBDpe9zdWqees9bNF1KZLURQCN/P02TSTsdysZk5Ocr2NBMrXQ9unAk8eVU/5DHzMb70e7qqnefhX2p8s/iZyY2/pxkGU/Ap1ZTudF807o1ewu/HnrtEAcVkhrIuulOecPipV2lkYV9+sLADFnWeYrjss2+JcixOE4nIwhE1VANKgJQo8V4WbMWvMqNY+Wgee26pf/Z7A12krgme+Tcl/LHrvIyiKku6ySkTr49f1HDkSnx83dXySw9LM/me0JklfZpH6Oaru/rcQl0SpkckuRYT8Y/I4AlyLWnnYQ+YAhNHdI4FVjiWj7RYz7UuQHMUXE6bByGfx57Z1lRrWUBnRjdQ8QMEjEAUU+Pmn8lnxRrDaW6+Vn/J7/7vU0xeKpuJKk7uPHdhS76gyKSAQMaa/gqfMVgeH5iG1RAGw9FKvJa487LJMwDq7HzR22on82Jbf6l4kzMm1Fi/K10lg/4jrlzz12h+SP25BUxQiNrpfvQGx/Gumr/C7ZsihlVG6IC1I5Jciwn4x+NIYszo0FgqvAX8mXojpbHfPTh796Z86qozAJJ4KT82ovOHL93w6JA2oVuzbUm2+WmZDp+G6hUuPX9Rw5Ehca7ABAA2wCgwNXd4kkrV+gVPsAdW7xJaKxQWHJ+3RfOL9hh9wxHiOQ22ifB5Sbxreahi6d+2gwAMRUbfEuRYT8Y/Ms9XZmEA218pnEku3PMkB81VEkftGEK8mwSiTE2A0hPs7jozaGbap5U7x80n6CfUupVseIOcXX8fLQPPbOsqNRQ0Kfc+d3Bvrubf/i/lZRANbUXnDl+74dIhzaf/11QuI9MuPAEv+t5D9q8iC9YzcYTyMJ/iImn8jknXv7dFn6yMaUFlnseuKAgPyit2VaIUZ2W+Jciwn4x+3Vg6IqNaE8yQJiBZUaxyKjWORt8S5FhPxj9ukkft0ktFYoLDk/bpJH7dJI/eu0J5pCo1jkVGscio2n8jknXv7dJI/bpJH712hNh7AW8aPwA0Mq4K6NO0HRG+fzVoU+BAPZ2C6+PV+KB7dQqXHPV5/Qg8S6B70LzQmJ2BKnyiahsD0mtsKOjJ5lMCaqZGaPfkrPQdezkG+5i9ONoNNXs0fdPN5NPlvZz5YEjxLh/4uQxhFQjwkFewSqpzA1sDsZg2Mt/SDo8M7w/bseQt5cM+iKR8AMPZie+JcidfIi4mpX48Qm+lsjEJJWeGshQgL9EElopB4ZeNAIFmsGXPziAyl1AZ2K7HNqLzhnzkwqRMgz3X2Lzr3lhT34Hcw9njMmk6BPLz/Gfx5663DK2RwKwGMB64b93mrh4t7IAOBtWKCtnHbk74dllRrHy0Dz12ORUXMG54l+UEsIbZKP7wohj6GA/0p6SFG66B97YTglW3TYAcmF3FWZvUUcoJvCafyOSXGsciSbVceUmGHDBYzDVY+ebBetOUtFYoK2cdlkmOB7BGTEEklVl10BK0QzsUiD3FkIGoOGFWHfPW0Dz12ORUXinnZ+7kWssX4y5j4fZqv2Pv8/xn8eOYRDJ+MfljmEBL6oV1p78Tj8WQuXXOcpqfjaKxQLKjWORUnjqh3w9k+hbi7VSRPDnp9v7IAN/ZABv7IAN/ZFdhqSPWcdllRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrG4iAJrImUiuYRNXshXqJ6nJfq7MvQOL6LwC7p6qdB4otbRB+jCa24RYZkcVDwOvnNFHKYPZZUaxyKi9qdpAW8mYeEnXOjDwH8dukZunIQIYuPP2GX8SFVxrLRn480QX2im4g3ytK2GMu6IyY1jkVGsciTpqATF/VGJK2n4or33nkCAN/ZABv6pfgQvfBuicpIW53hIM/CqjF2EUqA4bN6kFfhDwgsKtbpYQWVq78PlWANeep8jzcIZ2GWkQDMLKnHfKzmyJTF1fJdqIu5HKg1fcn5vnXT2tIblhlOl8AL0RC3Yq11aRV7gKIAWcSWmebUtE2Qw7VNRFP9uc5Ggv0LleWU7HSrlKQn02MUVxoq9GcsPbxwFwplpd5w0aXopd/DAdLiM/s0g3tXqHnaQgpPqoCIXQasuwIw4lrVlcv5Ei+S9sXYw3qkWs9w/WXc54brvh2WVGscio1jkVGscio1jkVGsN7/8H/IhSlmw5p5EvREvLtgfmfvpeqf4WGdOU3e0FL3HszzsOZJY3vMsl+BQbi+BbZDuP7NSmhYgdZ356MODjVe8duiEa+j7ztdNVmIsF5hL8NRguNvv19Q55DF+pCh8qjfKxOvEU1KPRE3wvPY7tWKsDzvq5dqekyQ2u4qvHfyumFphn16Rn383O3GhMCosHr66Nq8iI/vk4/kmULAHfrqJiiayjb14oI1VkCwpcpXXPA1jaAKrif5mtwDSiSrcQToNJoIuycsH25F1I0GA7sM2LEKg7YTRXd1cCTdmknla7flQyy+UR+xHPIfgBYjMGB/4byGu2HsbGnAwLhPieqcbK9ETIa68kBQhifOwKA3IhRprywLVuC6C8gatS0294sbTcQvhfqFf4ah5UiHmolDjP3MpDBoB7xwMUWSnJX1PhROjx+2xgRnOkqDi78+NP5/2d17SFe7eLTkDsx2Pd9SXyhZXion1pRnjlIhHlRI2X3rlv9nCCQNfgiqiIeJz6zhUrEfjZo2ohsqJJ0WW5sBA1ulbFi0e/1zVdbavrtfVfubcWvoybdDKb/gClrwXXM6+7KbCT8xaakCQy4zkxHhVZcA8GXJZg17ZDb0xIAKeQNaWN9fWAVs464UEP3pfVv+Ilk2XLO75Ei4LeI/jSJgRZ6wpqZUNprqYZPJjMutY+s+mNlT2q2rMMLNgWJToeSRcKNMZL9hDqUJ8bqZz0YB0W5rEKLkaxAD+xjSKcUp4GrS4Bh+STi8m6WYDzwkQhpd8Oyyo1jkVGsMqFG73zm5JH7dJcd6b03pvTekJz/+ccEvxEsk9Obn7tIjE7ft+OS5d4EJYA7Afku5YJbD/ZNfm4dfrEkMu1jhzsF9lWfxRh2VKFsIjB2ZJHHcbWtckQuFJxZL4UhmJkEeO7IfvVmIA36YrDzRrS5a97VPQ3j2OZy9NESrsKRWgAldnt4Z5PMWRMGlNw3LuI/CTRmgDw1dA8UsWRXZ4esd6JgynHuuM3aBnZxBZLyQIAZViIl/RM6RiiVJGEX2E6m1CIcJ+jJWoGL5Xh1pAeQlgUa02WVJ4VEj8x84pJj8dbvZBMWM3vyF0MQrh+D0YN3pd0/KD+oTozBkD4wE4GeRHJxHtfASO/3Y+4Rp2VG6uRKztiXe4yywkd/bpJH9cCyo1jj1pQEiBFG6nIdFwmjpEg/PZ/OyJI9UOXiOAG0/uK4kNne4+5N6Ulhhx77bUeuztFj5VkPr3OISZ9NTMTelJI9q9dRqTuL6q/n6QHEGKBZ2s2/FjQhzyiqcwvAQxU2DMlgTOLbDiuIj0zlEsuAsPZGgurFsJSnjl0ovA0Gc+wwooknBTH/NTbUl8RVouMFRzutcmnSsfI8JHwwFysRdsLI/E0pE+XF7Y72itvHdDT2dzriNM1jsidbEaovJs4Zg9nWkuM/yE8Rq5L9ALVHQKoXXawBGWwi+3W1qYXgBhgh4ZC594T91v5KkSmKJdOZfuqZof1MpfoSo9OQJWzjwsoI88SpkDcBmyfGCv4dpi6NYbWNtz5SARPSSmZVnO6MbHnJa/UXfPbUD4yKasyj50tMYJrEVGscio1jkVGsPpaWQj4DtZ/0u+HZZUaxyKjUKPwfuiIC+xjq/EUp4GrXI1iAITnLV+IpTwNWuRrD0x8VGscio1jkVGsciumxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjWORUaxyKjUpE6sboQqLzNIzAKBi0ddU6TrqnSdeKAcmPkVVilaCrj7kx8iqsS74dllRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY5FRrHIqNY2zq1XTfSGyQZFRn9oJIhgZiRUSR+3SSP26RztRtzfuNMTaqLw7SnEhFOhoB6B46uK6JBdXSvD906XCfxt8zELDmX5qdOIoLfTuHO6tkKeMXfDssqNY5EpLicJDKEQos6YMiFweamc0MpvBHgzzOFSu7mpOyo1jkVGscio3ZDIJ/X9ukkft0kjsTmlEDctBZ0Hbd9wzNY5FRrHIqNYbjPy5bcsED3rnBHmhkdb07SADf2QAb+yADg/WJp01ukkft0kj9ukkJFm2V/eB+BM47LKjWORUaejkD7sEts1P+0vw2B4abaBN5/5pVFaejYLsivKaC0axyKjWORKbP2M6QoKNDNBQDNsSMVllRrHIqNTIJEChJf3gepk8+s/sgA39kAG/sgA39kAG/sgA39kAG/sgA39kAG/sgA39irT5gGt/NKc85CpKQbUdgrcTDxHstPh0g8e1jkVGscio1jkV9fKtcLKjWORUaxyKjWOTY9ukkft0kj9ukj9xLjxV+1gyBF0uR2mgQMwqgsPbCjUJyUmBO0m52vQddfz0oisRGyyo1jkVGsbYcXvDcIuft0kj9ukkftGhwpMU4302Pbbh4BikgcHKVRif3+hZmBhJH7dJI/bpJH7dVpnYo1jkVGscio1jkVHzbvh2WVGscio1jbELLOOyyo1jkVGsciUhoue5axD1yJZkYx4dLlQG4L96Lk5FRrHIqNY5FdroFPZABv7IAN/ZABuHkSd2YL9z0DAacYI+/6jp4X+OAWE5w5B37syU9xrHIqNYbBQYogPCmbzWwY6KASBMxiaIpCNs+0BUK+gY0fKOwiR2Y9ukkftKd91j5DyYnG1XVAGlTXaq/yLfb+yADf1Sn4YZOXtkgZZ1Snpqst8A/jzssqNY5FRrHHdULlO+6Ty22fbKrFMoVNgB8MHoWUANaq2ew74dllRrHIqMF2dLYikDEbLcQnpJH7dJI/bpJH7dJUvh2WVGscio1jlLzKNY5FRrHIqNY24BGl0yljpZY/K42EYnH6WcMmNFIofHYSYHUksuDQ1BDNUWn0iDkFYnI0zXbikjtXtz7VLt/kj9uOassgzG7oFYKhZcRkwJwDDWirceEiP8I6jknSFsQDfTFLQQqldOCtMdSKNqqcAGscio1rsV9kNO9PUtqW07U/t0kj9ukkft0kj9ukkftxtQW414BQMWjrqnSddU6TrqnSddUvmsyXNTvoOB9JdP2U2Hzx4ZO/2GlN5xPX7Kx4IEy8/oY1TWYIV+Y0NB4IBW5sgZ/cF8mMwyma2jU2BacT6KyqEm5RMLkQNXOPYNjk5Ct3efjI1DCJOgI3ZCYZgTsSQbzLUPd8LLeN/cyq0pxi6wzVoI2XLPV2dNugxGAUDFoCHNcxPI6SFEozJZksyWZLMlmSzGHdFfYeeR8Y/bpJH7VYYFV1KnrpOukFyIcUu4JyUiLHIqNY5FRrDZo90c3xUR6OUwNFCY5P4m23w9roT0zMl8TYt/Pq/GP26SR+3Ri/0ZLoGgfOlMDM9gQRHVBtbjpP/ZABv7IAN/ZAiOrArxJC/vA/6p6ziYX94H/VOGeEiiGzjNuS6TrqnSddU6TrqnSddU6TrqmY8MjBScL68rw+DixJ44Vc2dPVMqL8fKe/x1qOyO9R9uf7hO1ZAU51hLzz1KAtRcNs7hvK3/OXSmuZ47Njr7nqnV+PLPPqJhLyr87s/lpcsQ3GsYDvvLyLCU0xQVIkFcnK1YvxRuioHZO0xoA0pK0Fuj9d27v4LmNVC7dloui3H4vvnR3uprQ7BUluIJG4cjrP4USqVraGnKjH/H9MPTTwVElUC5V14zVUM6aM7jXWdYs4G0J6yFu68jGo+bPjZK8tnyhjplt7zoOZ/Lp9XZtHRUZzJM3HuYRkDROIVFWcOpEmhUAMeNYUbgvmtLVijU4hQXXI3mw0WGzyVc0rr1X64Ia6CFQ7tEgYvdXQYglhQL/Ik7/qa3zkcqeajZdMTjrl+GKzA5D1DS687X0n+XQUaImCjREwUaGaCjQyHIBb1ycGccZNTQ0NMfosb8ytOr+I3FbtJd45HRUfO8DsnDDZ0ogtwgPCYulc+DjzkW49orRkGOacXtssDMoewggUkCM8c7eyscOuyMINsSuS7osDJTXKUdusPwG9jzHcjR7aq8EI/L86rDevOBdOOb6h7ibPeZkVQ6S5CdhKv/PokJZbgQ0AtUPaXe6+wCX0A4Iqg1h4CupGGiFHwqiJJRb4o+Tq0qhngya+XzXe86Hdk9IZVx026CjQzQWAeCPqQBv8IGqMp7dcXn3zmWjWORUoJJA74dj9PxDzsqNY5FRrHIqNZCIJ+YAD++5WGBWgBqmrHoBP1nenx0C6gef3zcJq5cm2/+lDV5LPTXfz+QWmm3TbzensgPU6bKHLNrwDOnYaL7gXJ0avlVNstG3HTKfkr/9Sw4C5sn+bFlXWUz7vkncWGqYU+TG6IYiXxHHmiIbLC3vO3KrnH/w1BP45Zf2HLQsSphNlPdzVJHDybscFfHXgX1aSEopCi0jUWjfJHAlHGCgSU8A+/Kex6j3mp8b30kstJDUOdcM/obfTQHmk8f3/DNLv2McKRhLN+qqjlt1aWkkWHMld57p4tjc98HU2KsG8DazRN4m1MmuMMjVDn6tpiih+ANglpe8g8zTNL6W1aAWtYbyrGSZXvWs73aUSbIMsA14Zsta+vgAM4KHoNDg8iWSUs+Go+e6gZ8u9TCCQASLCcI2HsmTSmzmAoB/JOD5eh+51Dmw9f/jJkRwPrMZGguMCxo76vNDQffARGAwMxG1kcfyoUJU6J1paWVvnaxkU+2Mq57mfn1x40W0wE66/R/sY214Gaue0wvfHJTtiijA1AG3wBUkcabz2bUDZP+vI9FclLpqMl0QW9t59FpFMHUNYVjWQbclCR5kpm6uo3P/7LgI+/+2RK41Ifz4sTbxNmegBxo5vvlE3P1Kd8ztS/joNhWC19iXmpuhWtNtB5EU+qYh9A08H1DVSte+urzcAwmrttx+3QFkj9NQPN4FqSjoqTmwJWSkMaZjtirf124EDkwZo5DswS1U09Nuxglna+8QCGI13VHeDcSbMHxcWX2vc9Gf4nqTqWo/AJzowb5wAAAAAAAAAAAAnuLdLjh0i2MmCkX0J490Ugcr27pJZeKpLYW/zyWB41QD81zprimRfWv1ZftixhPw+PM7pndKokpIgLzp+y8fXNRvWmURi4oDIN7fEIvowG1pvp1039Ws6eaKDHvV3SK8b57faaKZ6RdwpXLr17Zq2FO3gbPh7bwXhic5hwM3AsowNdhvUnG+M93ldqJRoqk+1NyucvX4JFr/EguXZEhkM/NnS+6RXpeRJ7PhrkwabJvsGWgX8/YfMJRvXIS/HukibnHvJGHH4+cwWozEyTzAmRbPQd+gdlNZgJR4k4nOq/ha4u9T6DKTkiy6lSTMfg0zimROnxw3HPWSaRItHGcZdEPMDNmprzuQylanb33njKWqrE2GF639IekCu/I0vIr9XfC2YFzHoa9UH7mCGxL5MbIaPMuUAr7A9sD7T51kcgHoj3/nBA2nH69Rw9j9B9l+5At2W68iwAIsyukzjFBxc+MOYlu7KfNmGl7nnYJStXMA+rqSB1ymkJcV45LXfHCNEFEoRl+3qnCiyUd+/HUMHBhAsnUChIF+a27BxhkE47zUBxHT2A9Ch5BMB5x4ApCvUqaHHjnpZY+NbtScEsx8CrPqJmwhiFyreamSgzJlHoyff8otNy2zRrOZkDDK3vJv3VNCu9JifA+AyUIP/6VVS3FW0agc7YNs9vMSaLNLCAcLYkdyQtl1HpkMzbi9HPKbADEn5VDla1FhUjSTOl8ZoJhnMZDjNxx04hKaVkK229GNA9IFlbYik1YN5jn7fiejEZoW+0p6mgQDZY+TP/sKZ+WagWOZtWB+ak3NGao5uSEMU2wxyn6BS9i1eiNAcrAANom6fBudkU68D2KJwxOBfpVNodPd6PSi5EbBGZyfFG475oQGX5gLZSAMjuSdKbyM/8b8ZiwN4lzU9xEoTargYrOz8shlB6vo/tIs6qLiFt6tQ4eTPjy9IP7tZr5z2UTdil8nd+iWiSEmwHTHPstbmy7jIzROuEpEVhWMfZNXTO845WWgS6fXipH/pLZX+r3VjfnyM2Ue452t2bqr9ysamviDZkyd+nlKSxOfh/LzcKVpS6Q/sQ8SVKr3SiJCd7KURNn3U1Fphq4baLgPQ6Cho0Du4IpW/PvafqLR2sWHa2M+/3IlujecCEb0OsR/WIwcxxzMntwnb9d8lRmY0fq2knhBEv40aLLij+7Z1B16VRqO0+k/kD80qXUtjE3TRS5vflWrgXcmS2Oc4T5wbGvFva/S2zmI0LAlQWaCAS9EJKh6e80Fb0at2qnOgHr39NkysqWjxWjYQhhH2v7hxE7Vfzq8E5hMTUw9tBEgiaJwme56mwjcqr49+HFwzMesotF8/7zThVvm4EZASdy7S84jPfAG4yshkTvtfP8+a4R143ut9kbTbraRa0aAMr2/qfnLKn9Bx6U2yJYi5t1dklOZgzVmFyBCmyIwBOea9fU4NJfKw7aMPvZ3eBLHJujM/lVsmomRpvHGEK0qHA/RR/xIUE1Gw8KGJREYjvsx/8pb7UzWVADZ7hZR1UkxTJpFvMt/ak4ZASBf3txFBBd/Glf01TEMHzO9vgO9lEJjO8Yaq5OSlBSzPXlUZZViQJZqjr567x3/kkK3RMLVlyHlRVqrTjZ3A/lYZutz+knRKlYoZJjBG3jLaj45m4NOat9PzBYo49nLcaNGMBx5DUD6iu4iWa0LmQavU02t/aqx+2+HsQ0qFNCDN55plYRTyLFJM71mxRyPOpGKAzqca30syZp9XloJ/S47lZq+SBL9UI8xkDJa+bzbkBqbaztKojkFayeexgxyQ6oEvU7QvKZKzpKAsS0iXelpsKC5XPf0eXg/H8b66NlnrmUuhMmFx4UlhpdjpU8nz7G5JX+jdiJlHkO5OmKEz8c9na4100IcRPy1xu6SqIE3DT/fP763j0VpvokaT5rr3YyAunI/WGc5eIHK7aQFC7lJu462LuWXqdzfFWcO/Z6MQTyMPYcokM6FRUbzpksUfZhk5BDae83pafCDAlYv+K5l9S9N6ruQDz/2qFjPqDOlURoUf/P6C6XKMpiX4vNyMhOLavrclHAOF59lcyWYweU/zmgmUgPAKM4BPug7h1EahkI6HrYb05BtpXGYuFAg3rJ9U/3UwOD27Fa3btsP9dTOZfT44xLt+bG0c+rrnzTP71aa5doUeHRyTdSxbFHixlMGgJ7SU9H6cS33Bq2K50cAr197wtQGA8jtDQRCo+GVdrU+phHpIumdZRJxYAZTOX6UHn+hzseJhFhyDPLs4j13yu7uJbkgO5iR9saC0oIMvGGN6BjpmBd3sD7TOdH5Hm/3kcOb2aWqv8u0uhxsq7niZuaJlguVlhPzSAC7dSmdUh066ZcrteC2tw8qKIFi7F90xwuPhV8LHzAXYsnefI3VKq1ewAwOUBiMa0RgGOIEBjag75ujqBxvLSpF0XH7eTHMtyQFSLbfVNaujVCvWtWki87/4gC/M+KQdWJvt1B+2iAlpgAjbp7Pgcz1K1FZUIhvZo8diqr6YaDX72cWl2B1oH/hadDH9YViinPWGD7bN7n1XxtASwHKZdqWiAsfz+Fp5JcYcJfFlnV6kDFoQ4vok7pKYFJMoUW8fCy2QImCgEyz8CrxGuVLroU212topDAJV3RPvYyJrHRgkE8tYAGpgqIolUTd+NoJ96qba2a/9SD2e8lbFhikBgkdM1u5kbm/61HZmkn5wFifpZJVEW9hUhfX6CQNMm95K7SLWHiws0vQBLgnvbxPCOjMgAPbN3V1CMy3eYrg3mzztlnF0zZXRfA8ZKOOjGYOkJ3JNxtqeRoEdnGng6fXrPaXjajJr/Ex3RFzGXy4yJ3ChXRJV3ewGCVksibj9eqUviUbxUleLqf1HubBRSuJMAaZejTKfI4GX8TqWgcvUN+EM8MRyws/Q/6kjbQNHFtmyQqVzedyebYy66yqUB/gBmocNo0iQhSbyHDgu12YTh05qoxCBY2RzyodIfCtC08ZTEx1E/nDP3ai7StXelHw0iycE/K0txLC5WuWWdcNAM5k1NjAmtNbmR34hHCA+4RMpLLVGfRNMwGtJvRiJzCfkEiLeqnA3lwfMt0wPor4WI7NPQdZ+frD5Y5M+a8+Jtquh9m/J4FLeoUwGDX/+ZY0zg0t6PFUiACqREOpOi+gNRbMeOmcHS929eLB1CfXaZb8w1nj5fi5o9DcBFxzy/VqU/2UzTJFDTNBJnOMDyoTXMkbAfA+OFe3Pv1XHe6hw61im+bUmMM492UdDwIXPJADz4FnmAgv/U0Q7VbGiPVJTdZyby5U305uMw9bodez6eh5tDz1Uhiutb9H5WpyLmaOeNyr55G0RGqhOg/ls3hQbDT6iS5uxfi+FU1XQW62q7KonGApFm6CxCNlaj5FRAOlmi2EgKnA5tSyRPBYDP9zHCC6JyK9BqKCWZj0gKuh7kN0spkkBBuZ8FSTEMYnSxV9HJWPJK2hsfxo5y7tGUqLLtIkPwohNMbuhMiXmikOwdEzrsuZ/LRd2Z3QFhXNqGPHgR9SO0pn3suBvpeElLNDs40AAA401YSZiESIrU+f3P66hGdrmq34XlKhgemQd7iheDHfsCj0IoJ14ObyB1btA2h4CI6p1HMNC8GuS67Uv5TLyodUAEA4x4WH3w55pogUDyQfNTTSuCrFLooE0ymA40RM8dTIqN8NQtcM6IT4J2RN+ASxitthT9NT4e96LBjsbAU5f1Nsc6drT0UkVPTRfkOlmrlb+D3grHC9lI0CwybkYccR2J41wxBIPIKEQpVwOkSEFDQogzm1U7Lxr7ya19S6yYo2w97QeTBvczoNrzGO9tvlXW5HZVai2alK9RnD8Wd9rp85Wnca0KpbGW/ra/ZIGWYj/d5KTM3UsUw+H63dQCwYfDWbwxakpA6GxMlMaQYqbzlCFLA4jUH3gQsVihIPmpppXc5jSX20x5rc8uwidXxdrYHvd0PSWTj4zGqMsHxAb1NmRoUcMlAzN4rVtSrbDpd18AALSwKqVgSP3kYWMmlM0drqolfdI481SXPxk2RGXx1yxIjdGPrW5zOI76i39qNp6bgUwzhAYYJdUpfAUvgXDC+auOvcsO9NCwXFIxHBZMcyE6Fi8BIN4m4c7mzkRa5jj9PH9tppHvF1MjU+05J6Cz1lVHtwSSKnmgP6qUpofhHFXTu3qrq/XGs5xrHUMfPzbIt25HLQVobNKeFdme99rWGiSO5L420eRTl7U9hw6BFsmShJzjy9dhTLGigwhkZxu0tFA+R7a8oRoHxwBX+AlHdcXscIGqlJD/Smv+MsjtoYL9WHNl9vOYlrvO7l4OLEIWqvNIcZC9YFsfEuFBqQkwjK9H0x4YWC2gJ4VHwULewMUGckOV1WjNtm8wzJV4DiZkKTLswt7BV/ejUpcMt+zBk6C4c26KzXY7zTtKHAGM+4o6UfpMIC2q9h/jz1jtQ9gqQ5N5XAUoeoWptdXxNiE0S7fdjqL7bGY1zPGAAYkqyF7yuGNhL3PVraRdOKoSDCAnqf/Oim0DYWxnQYRYN1dANzejfa5/qv7l+Q99nfgtFa+/ZRvDHk1K2Km3e0d6BULuYue9wdaJJ7j3mZNWErzXAHwGLwVNgmi+yoMDBL+gtgB/3CB/MPnJJMe66a7S3MIOmxojNFZSxylQirXXl/nK/KbBNtgNgdMLGayij5H6OvMvkpLEae4j1wEHAARNrRx7MSoPt7flrLKazZjsgWKsWNgWyAANK0LBS0J1hYDjbU2EV3FnXM2+KEn3MWaGsWznsl77zO4ZnqXL98ac+p7r61OwOSSiHQaApEpFjmuNgKdiDhU6n1gQu9nPRGIpKEL4sAftquFn0+SnFA++FX2VtNaqp0k7ALz/eIaWl1xRA+YGFC5wm490Ox1/uJz9z9HMZ0SRYo8TXzrfhL4KFJJ42LsMg/VZ7IlJEXNTFLX8UVtJv+mz21PiW3KM3fCsnhllJMPrs2ApAMsIlnF6aLeiYzq8yfn4sbQFTIuIXKuwAPe6Ny95U0ymwlQXe6osJSyY30X6y3InOLGuQK2sKM8jKlvKMvbiPqYitHcZu9Hcm/wYL/JKfJHFxcSh0EixJ9/CmmZNc9kWF9QPUK4vzz7TMsiSC4kLb8qrBTgwalerZMWmFBzasxcT/lT4LRKs/KpimO32mP/hRBxxqKN4kwDhjBmyVL5JwB6KCc2h1Y+ChpSMR+wBYGUmYtJXdnRvPQfrPi3gPYWFSlGExsuvs4b70bTSOgmeRAG7fK7TPOJ9OU6RzY1tMF38G2Sv59UG7cfrrT0qomWNvqoltOqJRHpAGBCH7FZg9LBvVa6iRDw7fNA40kecV+zAulWnguEfoIYDC5hf+SFfJjBRHtC++rJJv3Er6h9gQVsIHJEzbkTe+zrgTFm8uUAxG1Dj3+hqHZYnnFIKUeuwgn8Nu+z2lWyLOMPY7e+pLTJqrplF8yem4QiIiVL0w45sjHTuzPzry85HAGpHnNxX1n1w7xbB5S/YfWMf0tU3wFEaXfgYxea+UhenzVdx6Cj3i4g+DcUPWQ3hrg3VwwzehFV+hRIJLmZ4FnzMm5SaoTNdTmbqZQ0gHBLja5jUCpvOUIUsHHjJUUy5/rs8BWOPrpfX4ysTr0EJzs6a0LaddpqygDP7EXAPmxZ+mVELUxoP4v+SPHdKgv4SVeJ16pNEZ3/08u+VqVk8nx85bLolViASJgHs4k9E/U11ueKgez4tmPiExhV0Gd6RpmpM+FitEtUwM7buunAU4kyitSQn6O+qtEQGMGSixvw2Z7M35enEBJurtoPYvJX9aVWYqH/jGOgvpiX/IbZ5DGfaAGeIi1fmoBqVWx/KkjcmBDFYnpuYmA/WRmol3cDj0bhrpRJvKd/WeeM7QCRbUdfgYt9VVjQu+LYbAc8gnPTvTxujNaMdK64O2AGJzm8WJxOXwmDAs9SaaDZHe8R6YWFAHvd6Tau74w4HXbu1P/va9oyGfTCdff0wNXqvZeEFpSnmG+6fOBHQm4rb9BTdddJp/KZLez7SbAji5ZezV/yB7PgKGYdHuwIrsRwyg9Am6lHZMWmFDHmlg1grL4Gsc8CAwDhE68FER/ja6ppt2HeSR0lhLSE3bx0Z99904iGgjH3VeroYomhv1hSxAsUJa7YCiDmSxhsgclWW57k0HuMxcrRyjNXfW/8h2ni7yBvZkdS7vAZtHqMlP+2IFVnOiwu+AxF7fXzC1RfICDlNlsKk4up5MO1HdnJDH6qGhsJ5beF8AzA7RfLu/SfMzFr8wGum0cuNQO+R+NwZGWjWyOMJgtq/6gOTtRi2eskIjul/6ImTvIICTzyL/tDEA3u7x900rOyxA4BymDl69uRmqZbtbyOvvWr3iF1rklpCOZ2fFzAndpWvdIPnXB4Veqap1k/7HhfJcx7zH+vU4D8vELA8I9jjFCQzX+YCghI6vFYqDFuF/eYyS7JtfbqsmH08JvwNWwC969xoXpoDS9h1iHglYSpkYz766W4ReroYIPcGFBIJs+XHmtz3wBSIsfzT+WGxFb4j8x8dWohZIW6Qea6FWcuPtvPUpdoVJ1Wua8OjfRqpgdmxb0RL7WqP6yxJFG40G2/z+/L+/nAEjIdrUgNXAy0TPSRhstamWJaNBpcocl6V6QOAsx5dT6fnfB73+NXFHps96FOJUdJHpL/6VJWlz0oBY5yeUsqiVZM8tL4GtDLDcuJVj4w3Cfqa4sKBVFct+YJaLBFf7/Yk7wOztRRKowBHehP8cgt9e88MuKVgM8DCy/2/3FAJMqvPqPpjn58WWALiMJFlabQ2n94NMvz8/FlgNxMbEQlKg1D0xiWfe4LQesblOMocxb9TBTzIzW33+74CeWLXwU6O2TSvFkDYYN5T0+cZ0Ys9qigbudfLsfvbOAwKwsmKmkF8SqH0of05+sJwHx4eazzMBfDkkTAyQa/OX15/0ntZuFiSbwYTchYplFevsmTJm4J+8mBpgGk/9JbLlJyOBDezVbh8AzjjgmahlVLJ/GMxLSj2tkbn+TM4kvm2kWkoTjx/zIS2wwKGXg72A6jc7o59IjNOfdMKmMMqDdb1xGPM2WRt43vIOdjq+py+GsN02ut6SG33CTs6PWs+OAzLePZF+82AoikO3rfCxFf/5LguemxtO1gxTOoO0z0bghSREN/T2cF2FD80C/PZGK1CUeXrQWr5Z0pgfEUwKaWqvr7OqFn7hTf/iphyea7+/ITccTsqCrJMAXxhsvuSOUibsYdt7osZFyeDiteVfrtHA65fcRQMGB/TKqfCSpwZ49SxacYdMX9cF4xmSSP4zZLVZg1lgYHRyJ2z4xJoqjE2YscJTScv2SZHPHq+AK1nLX1f16UHvp1VX1O0zDDiX4XYe2pSR4NAAPsfhwC+NXH5eDdoHGSLZc1+0fmjH9DtjQnXJ7vsfzd3EKS/lrStu4ZJQ5EBvyKshrrxlcfSgnaSJGvRVn06Sc3d6yYPmmXAkAVKpUD6CnIPWg7Docv/A4uDT9Bo0pB22V5vZYdOjF6MEshBE0y+JDx918gdGyNZGCsktoSQqShBYJ7yucD3ou24coMwFEDP9FLoqMTL9/BlAy581TkiNJestdSCNGr3m09UX020zFjT2ZGmYPLdfOqPeqex/eXLV9QN8XkY7CG15dPtXarnJQqx/LVRnFoFAJihIxRbQH7NJn0hl9Yv6t05Ji/KxxRYf0KcIYVodCuFPrkYyG0RIC1w/7Ik6Kv18HZAogYuBx+5SP/yzaBX84cwkw27mEonQAAt+zEGKTB/73k88FJ6v8+lF0z8+MmnmbClP2ZmPYO+bHF69b2HWULrznUzYaK5VoVQE1oXDfytEf/x7wcBUyKinWmo9tk0YEKRW4951m/dZdbeufU/KEyv0SFvPdR0zqngean7PBxlYTtN2ImwXpR/cYRrAUqtN1+Jbj68SfVz2U+tHaGvYgXVJzCiKa5ELmVRG9HraqBh486Uo5HmE+o19vv/We3jYYSQjqcKeQFH8gDFkMbv7AEw04Owg/XxISTodaN4TZJImzwLoAtm8c/tBc6b1joOvqg4CLRdG5bgqr8GhShTcbnavF5zzDlWWlgUhAv6Na6+bTZYy1lTWjQ3obxHbdAgv8MDkQ9Xj4NBe0yCpfdVlPxCscaNuKFYZT8mXhxqZQ90dMryTDS44H71UVgijrMvti/ecykf0RbPwzMyNCXTsvFBiqPYSZOyjAhzC+N7mCfJOevZJ1EY2e3EBLg1NXpDVMKUAdgt33DYY7AxBOU5l1lGJUCG6egqg9mh1r2LbLqoHfhr8UBZK3QwHrA0aeKwUtFjI66eAzqqgkqHqSvXrcuVe1zVUjNvyCGdZNIfXCDDp1w2Y6cai/D3diA2ZuBDMDyCdd1VSfrPEAzD+q0deNTdGbLrMneFupAakhunnQ22S4LJGAeeOsVqx1WWGmB9/8r0sBvLCXke3l2hjBRrnsFyk6l7+lSgko8665ELmT0Rq/1Rs5fEXZ0kHuejAoJ4xU0AHVYMEWm0dpVhVV9mFDgB/t1tsU3Vt2xufTKzmFV1FIG4QKruouzuU1dKq7ot79B82NHdUVA/+EF4+wfFl7DDW1SuxbD7fmadk4FH95hX1ToLf9kouRtO3wukczSu6d6FdI1ZqGdi2Qz9Ub7cDaKOSDiVC/pRqD1fioDaRb7cW+b7QhXhUAtxojKI9zrDG4nhV3PS4Cyb5EbenWXP+vVQ4u6YbySCcLZ7O+Jxk4cJe+nMuygbHQQkw06JOr8ODQ3+cCQsnSZNhQhlXKkftRDwRz1hcenpQxD/OG/Apb7Zgl37qixJiTM9UqDtVXutqtYCRAsKnrG+3yNLhNBJQU1VcZdvW6mVMnUp5DAK8bDIKtqM2Knz8K8L7S0NNeSEQtBDOBJfi/pSrykRkHOndBU+GZCKlX5Y4OelhuuZ+gBDaXty7PVK28lCeJiiIVoZ5ruWJO2xLt3p8iInl7QHabP+T8yggYshxaBCwH23QSDTCBsQllzq/juiHRXU5So/EVWajjS4ndo5tg4zkKlMEbE06hmrVqr2glvYB4fzIgWT23IykX5G+HeQ6HuGQbQxrD7GFRXLbc63lkcjbF2ej6nUXSxU+GhADhiBZqr8rzHPiAbXcFnhcCIez/+jAIo5NLKCHsj7Jx0e5+eDU7mrT7atP6cqhJlXjs4tQnSKFN8gy+ZVGF/TH0TmB9Vd7NxGIJ9cxmOS+A3rFYG30VLYYmRonO8ABidI7oHQVvi4rYgzHRXKrmChoWiWVWj1S6E0kAdN3mdEuGZTgzo6gywHahVcSmZJFVHZEE9VUXZo+p4QuZAHLdHh2C2yGcYD0dXbszBpqNJHTGA+XMYFTGNYjN0wVbAqg5C/hdJJxLitttEWvsni4GA0u/QccGgo2Nc38IMsXavXwqVN0qaSduMirHEkG43w5dIc/SMIAhy504+V2rFKn8McbgNxf2N5zHwJWcwIrbp0UAjwIhgNzCs+SKwoWbFZObLWpD/IwWD8flZI0vc9JSPKramnxYUSjkDClxYjpxrdaRf8tuC1dpORcep7eLlvU6gOycAz38rrA+qpwO0Uv2W0G2XBWQPk1FMzdDd7/I4SPLLiz8clGHSKo504L8xUF/T5EC/87uDCd5SGBEzIz5TuoXyZJQmnnrJSOECIRSX02+57y7yNnpE5i4obboU4yWV5IAQX+WEN+ONwvDIlTCPbRkNsx1GuHgBZxvv5HUOsn1A5EpRWldzV5JV6OsKIOFbHeADiI2nmENaMkyhaRiOgzbJ+ZHNOIyqxfglu7dIHV8HUR+9uaorj2aKA1tOpCCl1wJv6VNGBpsbjN1NpNcs1qMP4Y43AbgQvM9+9nRTqalAlmSoM0fXtiYplzHJZCg87qJEvhMabWpuZ9MrxJEaObYOVMUwTfR22Ta1NcyMvufS+yQBTFnpPeDTrBWJlf3wAF01POnhauUGeedmQctEfRTCyzOl7JD/7o+bUVQmzR3YAuMXWhk4VMmkAs/M2qqXwYWDRfHByBWJDVFB41+o4C1oAcmguhpUEmSzoDyuxbmIf14jKS8dQ+AGX3EaViRZrES84ylAksX08ZrQkKAyciYu+qJxpToraLp2qHzSvhrrOwr0gFn5a0c53VUL67wNEYmB0ZDN9yVh/wyVKCBXWAgGo+GC5/dZBuOAb1cBZTcsb6b4vTAXRHLDNGJdLutrVuXy3laDl0XX0GITBOnA+PWCoJmbNz/snP2WOQiGyMZB+4EryKL+NUpbGcTPCWxK0auqnjfnj6eBqffJPgusM/VBje+OrL5kHb8mdQcN3GUOJKTR88khqi9ibeO+CxwW84LIGuunIiUKqMFxJ/PC0N6yU3wZyX59FQ5DFP2PUPqn9s5REB2o+layCvSvCh4V6E3FPawf7MqUUl4mOtTKlJ6/mdLM9M5hdNiAchzCtbqPEhqCRQ7kLCTcT1M9GJVmLKcW6T1KINzLwmWiYsCl9EKHdy03gGMlR9G3WfXo2QxfcKrq3w7dpjcL/1xN3ypmyi8GzvQv4VYAnzLGcinBWZSHTKf3lcZIU/GwI8AsDHpB0o7m7bM3+P6ZZec2oXBU2/DoCzRFEkqGCyivn4V4Up1QfWtu2pempGd77d6laOdBPo2alogU0McNCtEVS90u4oepG0bVVpwnHwRAMNiPnF/TrJWyTcpn8r1WLzRMUTDroWYD5vTW+c3b7/1nt4x6p5yrWDPzcR/nFPsziU3w0xRVbKjmBK/p6vRyuJ3OGhW9gutXs+cwk1tvoAIL6xdS7rZXLtcgDrKtRo6Fzp5dhKXjtm1UMM/LuUWpqks2qNLmHdg/XaIaEqa/8WF8WptRZmwBAqIVGcnzsI6ApkyS7DWNP4wgMV424Yo1J8VkjmGFsF00RssgT2qkZhZtG2uEFKuGYjwS1SH+KjA5Dvwxxz7FL7KIgHygFvIhBEL4AZSHVvDbGuj62YlB1Xu/dJRmizUw5RQlZd9Ov2nhgR493W5JSXEB5v7H3TFmsptjv02MIEAPMS0tnrT8AMY1fK/fnbaxcX+hhDOcnkC73f99UoQ+0SRJoC4ANpY5TBnr/k5Z3cMoL/6dbEYh+QGBV5NI5Rq9KnFZIefQlgLhcGnC6VCVcTZK9RBgoNRJmHT/p5okl08m7bLkZcVAVHw6hCiFRbulJReD8Vx3OiDtgp+ivFyyLzJ1DzrBrwmnBsQ7X/jSvYkE+5S/l1ww53d2VDC9PbVWtXj8fgSh4rBO30s4+tkVZocfO7CC2CcVsaYtnZDZPClboNnrWd8XcT2V1KmtG6N++CKVdyA1zRK913Ms0vT9P0vidTpIKifuW8biv4oQ4okytNHGqv849yzwBhro24NyQWOpno+HqHN29ibFqyGyYR5idSNT7t+BBgsQdJxH0tUqcIZh1Arje5ngJkvFhmoKnnRM1OT5OLl4jB+8XMdxgYNFA9zlSWeZbTCBjNd0BJ8vk/Wj6QO+ri/7121WN6e2v4q6VkxZrzgIQbxIWKo2T87J92lhqrG3pOIg2OpXBC8CLX/jhnPuaFlLAGaaxKFTK0PXRL9zXAuiQQe66PsuTfNMCI8LDkcdnWMUsoHD2ndQ15bCl1n4KJ/NlcwaMvsJDokCV2NiHNW9zX7QmuqOmHoC3Xe5oqNiwctzY2rUjX9ylHyr91Z/GBXnf0a/zbz4aonyjBpA3cwQFnmKznSPXagHLfssWasp8BmlDYtM/3ftQE7wj/QSJBegwU940S5Hq2YLaM+YcsmH6QgqLKBrgslRfO4i01cosxf1bGWFTBZgFxxO10mrxVlwsgVyue4ivxrf+rCeI5uHIxg1vf8Koms0zG4OckXbAV331uaVhmYmTsbGLhoUYXXUnBduxGjHXC06YERdZ2IiL8YDDaBSppIohZ1tUgfr96uQCz/4zAnqdfvl2SpvmrnJ4bseN9hN4RRyaWYpbXYWN19ltF3CBvfifSzCw+eU4zuQxLk4YO+MhklXXpUQprpbROT/XmAs++X0C8Cnkhc5EbD/aiKrcRzrsU1fOETmprSVQZgKgXjRzoYyUlwr0OG+Dp12WkVn291cFDGWupqyW0MiAPQgDIgeSQq/3ubpmkNjJBjU+QpKqvFK1rLtQDlxJBTKFrPBtDCEJ8rvJZUOIfkDm3dsK/vVKnNUvU3TBVsCqDkL+F0lCNHVELaeLuuzJywoULoyDe+bDkoEhrqgTAJDadTu30C77MPM7itbFYHLyRpZBtolle8C9TpkyvVwTgtdvqAOI7WUdwA4FPGm99ttQZoalhf6IUKcBMgAuzYssN4JVS8m051CPR49ko7wgg6HgatLW84HWyghshGJGXtFMwOepQQoKnU+sBqFonpyKXqgk7J+7DFUc7uXxmdFbWNOGrNUymKhVj0LnQ3w6qJhRrjhLPkUa6HzG9Dkwij3P4hoZ2UeyRNyrKA6SQaBCRyTx6SsKimhBWQ27HooRSc7eET0LX28DZ/YHUFa6u5vwJdRoQdKnBk2H2/Xdle9M/2TeWNDtPC02QeqvZ2v9a8S6NrEOXJ+sYzogF1vLPjnd1dfwfC3lbLImegcnqv04cAlEJ3+tPDALSim+bzOSAp9s2foNT2dro3yi+QaL1IhdHLovrhcUFZUkmYK/qu0jOVBM7DiQuBcXFzVKyq+RIDHfXZw9ykanEFIRp5ZLDWM4jfXRcZsq6bhYJrKyZFo9O0oAE9xz5DLaEHqAIwWkkZ9xkw8Fm6+LFvL/8nw3UzJRNGCIS2zKWzHwGgt2awKGthFaScLwxvaiRon3ciPKm1vJ6WA22Kb8OR5hg8Km0+bH/2m4em/htdcSvqmDxPUn09JTxvAjManYIXuCx61ivt/zVZMNaYfIU4oIwHYoJ45BtuKsTAvoK8qYlIRiR8OxO6///exDrcCBACsBqjG+ACopaEuMPQEqeZ4Z/OH21kr7G+AOfdzVizH3i5VGfnrmPI/6jxW21VMaDOEuGb4A8KSCmGrSdtqLaZc4u62yB3xnNaAyUv/6NVCXIxgtJYWzRAmY+LpF/qPP3nPvAPGtnIgox2STzzotsTpVc+kDR/v1XPiQTK72T//XP59nQ7j6lAXiAv5zIzxz62zumzB5Ph1v0GrrNOE4UfcrBynqPTcY7CRL7mV9wn2nfrhLr4WMg4UpRDmTvaUxN2kd4v/jcNNoZGMSDZylBv+EE1EEFrddMWgzjFbHqaTuywTs0/vu3NC5JqEVS7VjmJSHgKHVqNSgwa27aZJbAvwzcf/dQEUNPHG1aNBEu+Gng0v3NCocf9wim9D6nWRMYwQJHa3wccuV2cLt6R0Wqm18xIpg9D+Z3gprPQZeh/4Y7GCzVH6zkDydAak3cenwkw94hVv7YL/rH95M9JIaP/X78psfXKCslvyG93SKD4ZXmOlO6GwQUEY0XMCqssNS4C4jMzSmZ7iFCgTbMSlpjyJKWLRlhClsXyxjbciZLzIpE5s4wurGNtrCQkGtJvyRYEN98u521gQD4hBonlKHshHi6FtjBOFIke9bkBDbjhFVoW6CvQBaMDQ4PVVv9VxpiwwHYRb9YiRL9zV0g6+ceqSLjAAHWbVIoel+0p6OHjsk7baCC3LGrcQYZrEo3v1FoSy51fx3RdxPZXUqaiEIT+NbPue+b/1wrZgIzGY96x7h4AXAxdxPZXUqcSLmUu84lTYFOSZdQu2coG1Ks1SI8twFjteg+gZEv7Z7QAkoTzkUSi+7mq7E7/vzkllwMaEl7bz+aX2mFABpb5zorbcxS6HN4ct+smI1xvJARZI6xPoIYQMvLCqyOlkhP69t4ZXVwXWrHXg2Z1Zm3jzkIdyrxYnjGkyBCrzQSy1BwcPIlXqQL57uuX0vsw6281N2TZHkjBUUI/ieYF6zQkmUt3oJZw/mZKpU4QzEXWsEKBwyTPiTPS0IsxrnaG1avovuO9mak9I+I2ZB7H+MFS8AZh4wSzcTdhWw31aE+/BwIfUcsIiJk4DckFk9RK1z2A8ICyL+lllOlcpYlVnYhhk+5AMluhDkCHaynILW+QE0kaeh+YcoBGU/AWaCv1Ewn+27k6F/F7JecmxoRCQljci6O2suxgSr4JhFgocXavXwqVOXgvbSPGtMb3IrEbnuwJj0/HesVnxTegiC81KFSmy496cFEOJPESB1e/3n/kJbWO4cbgoUbWsN+celiMthVlbYxrw+4APAxor7z0x+JcLxjHTWBjHEQX+/ABC+45BWEAWCdYUQcKif9puT15nqynZl5Gmfck6m0eCNz3sk6XCo9xkVY4kykKRN9Hhm3eF9iXDuAG41XJx6pCRzJRyrPMVXFV99ZYqv3eswMM7QqC6Esz47bEK+63XhtXtv+tMY2pPwm0kKa2BDwsOE5wjgwTyO/QziwXCB2UEqw5si6lC0GhZqKXr8YN9rIBXBL0jTpx5Plor6aut5GPPiELYsCjgiF9L1OdWIR2Sz8HglgSN/M/Ahqfdw35C06kUEmK19ZvRmvb9ZAULZjzQCTJ8f83AAGQDY8IUkEAQFaBj2o2iKrPvgIEx7q9BD9NHWNwkipC6BU4FBdHkIU2YvIn+8h0RllhE66EPBlJpxgl6roqWclNRiRKpAGzsN2wGGvC58NS9kOG3RjIAYbhfed9b5uIEzLUNhPm50TQAWVYQgx4ATL//NqSyLrlnUY0Zpr0khqXi/uO+0jVuGlZHhlHd2y2YE7YsAr0buJCzQBaIuIP6O3dJGeOtpTHN5/cSsuDylAbDaa2RRZ1W/2hvFU0wuJkJ5cZyKZD27JCwJO7Px6wKHIQb4wjx8ZdZS5e6NkZNYcddeIhHhlHckI6PJluF0EPVu3QzL3MX3Cq6t8QGN2tkPn+aOvg2nQ9aLqlHaFfK5tEU2Kfwc4ciCf9Hz8F13/DZyKk+M3koEmKddGcotDDkNPgFhPEraDDviWMMBEPz5pe0yqfHmsVyW2KRy3isk7k5uYvD8uckMfpA7hnygU98/T7wETwinDgdCtNef/J19YiuE1+FvB0xgJ231n4ThQjTiwXoNsyvJLf532NbAemcwrkpDkJhmxb+wcWdcekHnjkKo7MqgfHGo4Sbw4Vr9RUBbuonEhqV5lgJodrxMUqrLljEp2lMJtfHcCkyvqSu3o0cMUqL/K2tufxlhonPngQSxC7aBC1oHHfFs44BmPEDyf2x2tNtBFeoK+OHvrYdaT2z9yenK1+AfAJX/2eoa1ABLNXct4qOZv8tBw5ScZKVH6rPeOROfkpyZQ9s0obooNND+NGoXL9Yg2gTeEbamOXpMBxTSU+O2jUx4NPXcMxAKSjfj38NrS5/lbWHlJlRnIVzsaOofiLzCRuRFYcyr3bvs21TL83lzD83ECGMJPnST8Tr5RH2YlH4BtXb3FTwN6ZVIMDSeBvpM4y/gs8CFVuICrRg4kZ/gGxZ/RhjrNBFDF1q7w37hn3pW8FhScQ6ZttJdoCiI17nu+UtnNs+9hYtVl0QPFFbWyM9Ym2rVwpyPOmwNw5p5LfkN/NCK2yF+EPzT2dsEnO3UhcPcmKyQoiuTnDclACwKyq7B8VsRlJeLhSsN9hiJDncDAdVPGhM81afriumj57F70kP/1fgYtbJ3Nf+vKdgDvztWozFYqXfUHC6OCv6R3nRYq5ZGH/73+MIDGUSL2orIP6+o1q93+373250S3Qc5FlQmNLAkvX0JHDIsEtwLIO+M6EG3RMQdJ/MwREOGcRwLlO3AkjDcQ07PjmoHBCSMsOp0yOuuL4R6CHztbWlxXUHkPix8P3NZbmcq2+uHDejK3dSK72XxAZ1CAXZCf3hd4e2+TVA2YQAAAAAAAAAAsElbq6oaAs+Ut74mtwXIA/nAaqshsmle9K+J0qIHaDfqNZJu4NiYge8G5Rs/n09cW4hKJ6g/rJrbm0/xskIfGx631D9BBH7isxb6VD4Tkvjs4RBjP5+/N6MJugxLtI/ylSF1OL2RbmOLe1IQRbOm9/xtY8pVH6xv6sk9D+xAyYuzmA+fKhGHMM7U9OFb042HkcwnBuB/L7AG3JFU7vLVpr0ZPd1AvRAkD0KWwKYMoISfw/VaeaVffLSbShKZxN4yNE7bRoDghBPVQpbJ8jP4BRL0Z6vAExvz1LZwkng/0acP1kpbpml2KNMDZzQahOv6jziX2HuUdCvwmv6Y+baWOs/M/9ntERFTvHeG3OKOPi2VGmwusLGrPOh4CWlxHRV5v+DljX0ZdB8EC9yG2My7uqcYElUKAluHiwu6/NVJTLtDWGTRa2VSUgoZV8v0ceNi/5A5fwurZoePCJYwLodUh4gbiCHFXNcRwdsf0TbB8I/kEZPiIlxzDHO/qBfVm7uBNxG6UMPY+lown0hz2ddx1NZjFOqGilWsCHoOQc4z6semYZ6Kw+M5nUjb8nyzHC1631xoPp43oyJdZ2MpubtW35UYsL8UgUuZFp//FQbLJCw7m+tKLZP2doNXGGl9lj6i7Zh+OUAnVSxuDRPEQsdO3jRbBhS7HQW2Bo4T6AhYKI9vZGVYPyhq6wO7BNRXyO2etxIT0QYxrdrpRELBxnCIHxcEzVwjTTl+LVlwdV/lWAEpdimLgK0HMxCmKKwGF+7X3/Y4zmuhpLwIpDn9sR1N0UmEnGwpKLrh7oqNI9MkXT6RJtr7dl7IplmwRSrgbkaWDNteKP5NcndMpRkswPcLOkAyLJg76VP2OuQoDM2eaSJaZJWspIEUDgG9YYBX7LrvIKvGAqFz4wZ+crvBo0xiksnKaB6IB2DRgBghZoozW8H0m+9KC4pNCdd+cuFwXdg1Np7p2IzprEzF2K1WIOxxUK/GSFUfkw2XRXKyWYERLxETKfP2zLYFw0yXVGHJbC2oeRctT1ywFoWFTK2d4a+/7Tr0zetJXdg2bWd7SBu4yPeYWWN3DuVJQqvAbmyhJ/AH9TqSIY5DBpkOSnFU1o/MAxQJ1zZB9WhoSXGwZofYsEszQeMXmhyfqToojk1iUkDoKyM3MBFq/t40qxM561S1n5tM86FoKMw7bNadYlttjNa4IrnrouO9pCCGucqa1NLYdeB6Y5pLqxzk4wt3oY2l+za+fVBoRs+/f+p2VgSM5AAkojks8SSVGi31nZ5+btk+kooAplbhTJmFaTd2ok6BmBJhqlqhxmUC+EHc2EVNXRRHKDuIFiFHS/Mgi/w4mzUcPCeKmweO2S90pLJ+XFV4qqE4W4LhSaw4EN79polxLxhEH8b1/ypUa8lvpED2Pj5ZRqY6DMKUuQ+bmkdIhhKCE5WRdhymyWMjLu0A1rbeopbPeAXnCcCLCygjVDEqRn1q8gybx+lHNpIDDmfM3F+PE2EFX2z9p6Unm6C/CwYcPL/ndBIpfEZK6Cm7oOGMSF/fU7F+sqz5MAY5wiAdMmLICIN/j6fG9itVbep0V+MYsR49qHnsvm1jZfEfx3kUkTdcky8QIrJZINpTPVcAqPFblxTNWmrHmOKxLKRQYO3eHBocuFOe5GBn/bS0IJSviHYqi8oSpHumRu2JI4IanEFyC4n9dthSkh+eucKOIKizCwuNbei9aDt51D3y0F419bXEePjT5S9Czj5TPwNsYL+/ZmC4f3rsi5uatvxtENuER+SXtFvIiz9uQXuFfvXVYfhVIXSVLfA/x7yurm6hvPQDU3SMYHvNBmJG17HQP1/RiBuEtrgBBnJ6SUguMRpuD7u8YW0GzWZbdDzA6hU0xW+Oh4n2DZAhuNO8rUDBc1TR4aZVtdlHt/Af/8M/mldXFtls639izT80/MLfH7RPCp0JZ+HOlIsKZTNj04b92KJ9ooUv5YmpbRaxa4MWAS1yVNrHJP1qR2zgz4V48TKguPfOWe/LWZXx5kZRPY5o/pm3ZEoOJIBW/X6ADaYsIAQX5/ae5xlnhcQcO96LYTjgul8tpo9GyVZDnaf9OPuvCQW9e+ewbpH0zfwe2WEl1Z8AsMiN4SC+25NKHM9afjU9S0+zDb0XKPg/c4dsJ9yQhnqpCQvdCtl8M1+O0A7YF1VDL7oncogzJtkWWEyKTHoqQduCXEsww/D0MukAkHwSzC5R/5hDouTseBLzCQCGQH1PagG3767Y+Sk2tZfNxzA4BBSWtiNVQ6POkxetpxJCxu22oHpZXLwF36vq++hau/96dVI0DbZhojwafUVDr3x4QwJRPM3XDNIjCjxvUhJk5X2/5+ly2Ri9MR9iGkhYCQMg25Ii4ER9uqYOZF7z3BpRrbwR9NrbLHA082ZNRgoL1LpmUCmt7Gl5Ixxh3iL3GvNf1lp0Qc2ohfbNsiXAsQ0FxNP//N4FO5nF5L7hiddC7MSUyVYvqn5c9PfzSCHY3kS/Hwmc846bLQj5ZFEeAz2oeSPWXM1p1EAMnyzlMUEc2Q8Q1noe5Ume/9LUC8qIq/EWrFcBqrjKx1m67G7xP5tCU274jJlNyaPxehf/PpjuFvBNUNe6aEufx0u/IVo0t6pBTovcCrPRtdFhDNTIbIOfCjXJT83bQNuv3e25V81vRGVIRN3wZP8rhdAIpxHXLZyqustRZDFd9cZxAWnuYu2DNABaSi4doNAKvHG3oNixxY3icgfabuOnIAZE4vPkLVlnxyaPxCeyEOAPl1sRDXYKKOsFgPPdURm+xGGgggHFK3W0+urZ27xosWK/zQPEGX92xHEdOvygNrnck/ao6Q+56QRv4N4WwhFtoQyq95I3KlB1AeBNx4cXT7V1pelzHAjCXZtSn6606YNt2s+FRDVSb2Tr+V5ZHyri9XPpo0VM2JW9PPvlpQB/0noNyq4sem0TiZsqzsY+6UXW3/tiissCON0DXAD2U45T0qu4eONYolI5b2VScKwhrfBpPYLuahIFGfHPLLiDo/UfogBGhhrEh4eTM+V8OQQS8sLoE07UjTnBs9X3BKNgj2uLC2x1pwFx8SNHh8EKrBhkrDLQmG907DD/v6Ceonq40awFOUdG87yOoHTTj8TEjcmA8LgCwxinGgPWiyLDiRVcT4xNVzaA3dek/87jhb909FEVSXWdxkJGedQgyDoYqIzBWa+OFM6o+xLqxkwVYWUvEEW0GH+xLUjps+icnXycP7NcYFLnDEzpCLgsz4GINH52uyBCruG/W4oGeSxSKsxKZSvImXF5sygENQ/qK1ri/+lIZYQyKHm28xscs3aS+f82xmg68RsywoybVX+COYlJ+s/slpEJGLqeqmJJKWDCh/O6EPRNVwidlc74FE72a8lggrucZRUmQ90y8vgWkyhIxSWOdFTsB7FRvs6vCCZrAr5v4NruKaYFvLIS/d0+xiQzdt6uQXhaB+8EYa/d57RqINxlVGd5p5DGzKJW/KNWQ4DpgcR0dcupJfXlqp7XXKyh9glVeF9R8TwYAnJkFc8HW1y0yel7RuwdDNyV5Z0FtXQXLR58cpWjSbwPr/Meq286+BQfhtCZqhUukL4VcWP/GvITxq/EAQ/Ir0gotkHcGLHAefpmqW1ZAEnyQXVirDS8CQVrm3BqUcMRteKPWeJV9I19NqmdyOILXddpDkWVoDT14dVE6zTf8dIHd4K6EkttdiR12Ml7DD4AswwL4rgeQcxvMTl79UfdDI7r7kCqxa4MF4aJbmqJriQHX7WT5HYC1axS0d3US3q86Wx893CcpzJzeG0V4fGPlkURro5sm5wtMsFiMekw422erPSTgk7srR4brAVmyDIqLnwjV5AzsJvf6vQixLRB1xNjPXNrb+2Hr/sGau8Jgs4y7nogdmjUOOb0JznvWV+zPXyIPOX9jqZcWNBcRkKRQ5OsOAUXE7IOVy5ZDum66Pg1U5IsAityVVK70LYdtegV47B0e8fIyo31fO5X5a/XLkdoNzX/Hh+10wQPxEv/l+AUCBnmRfRD3q1K9aOaMcHxbFRA+EoPI1neJHnuNYvYtGYm6cjdjOPqd8X/59kE9B69ewBPnyktjDd0FaxBKzvLT64NeYn9Qnsr7CjOn5DrnYz9e046R4P1YuRfMc6sTNtOYaZc1Lwa1CikJKAn8iUZsQrjIHIhCJU6M53qqSMM9Ziz0hA9rLUWan0TYobZHejpUiqV/oeza1ohKTOaN94qTEdBJP3qCkouw17IMYxi6p0FMiJDk7FJhMGayGZW/tKyT75bcQfda3S223oVgNEAC8huR7yYYkir1xj++0Qnygn1o9L66TQypwJb7lmFkWrJFpKAvXR2x686qy+Z8jUDRuGFM/N/IZ04sIr8K6UHUkQLUt02EwIXpMRo4+StFp2EfllF3KmOtskzxaMha6h+iuOGxUyYXBPwwKM1v+GAOtwaP8kN663nH8cImAqVAA79hjrnP2pw/IOTTquGHTwEcnDalbXHTINtVDe/Pak8X/JMdAwF+NvT/dqPCfmyua2DGZG6tvkNdQKSe4MWOKx8DGbVx0WfnIkP2x3UEbhO6K/r0cMTilKxo2k1i2MhIm/lN1qSIPlIZQdr8NX/qxJfqXT2oeADouCtkOVIMVigtKgH+YgAPScEoeXBcRlWIOIQ4G7cAH87CnfGkN+c7IlmMaUGDvulS7UqEB2IUsVquXFO0K59FirXqMCoC0Mez9rlVtqcTtfaxQlAPkaMU1PKGfsf40Vz7hMB2BEBcX34ZHKiqvwKCUo74AoGwE962F+WDrvipj0kcEjId/gYOl8amrwfA7oA5cYr3HRvq1d3gttAoKAEra6llUBV3Ps7o7kktGno67En0Om9gJ/5EowSWxd288DFKu5adFqMJFAqq8QunJPxN6L7MKLQeSERBjvfxYU7YVXH7OIsbDTd++1WMAdDsfxHRIrO7k8syaA/h8CYKizeubCR8LlGV+njm/OSkTDRcgSI+7TS4V9ue9JglEWATzfE78GKvlAo7ywuahOv8Yiuw9PWVZ3hBZOjusDvl9D8XRBpMriFxR1V15gI+dqTh4SlKJNxYpqiJH0vNqrioPFySRAXh9StlaECU8ayLU4pCTvIGXFAswzPQOmG/PntvuSQFiwNJo9CpOYWzEJ7No1y8yFtOKYtzaBrEWgF7+tJ7L/fbdgElzxXxs5MPkgBnw0PDIDcC048FwFiQdMw7asPYtg/j8WX+7SRSc9iToGQFO0/egf8Yq0XZ2dnZ2dnPWGgWNwkhw5IQyp6cmVz5stUEwr0g4x8URLe2gJrQ+dxm6F0ZRuZPJ+/Z1a2YCA7LilgD3NGB+qE9gMYxoQKHX5A039Yez/gtuGIaL8s5vKc2DStX2cHVMSB0P3kBrDQZhUApvdPaiQsoLCsjR4hpAGgry/c4NnSH1uKGvoZFWwg5s7U79zggEV0bUuQBIpneuQ5h5BR5r13KNfw3erVipCWR3DffEliMo7JsoRFEZN/7VUY4FkKvc9yL9xsyDYzbBlK5wz4fS02MTG5B4rzEMLIJ3ZbAO63mlsBgSV51Szqt1Y4Sd+z5T/4GsbOatj8m97+L1zU/QLDUFIda24fI7VjkCVf9XFh9CRGsXucGyG+9yiFs3G40mWIJtYlDIEnSUFiTMAbFeehTcV1hnw7F5mCoA+KzNAOOPeDEwBX3pwKmd/yhuW7bFFInwrvqwDLkAAQ6Jn8OoXYtmCqOxiv2pMWIHLHEa3i4P7mMXRS7EzT+u3F37mHZNw9RR4qngfq+UZs8PQ2ciVVEeIFrHClyvCLF7iDb9DFDmquIgi68gFrlF6U7wvMWNKNiyAxu5n3L07+05mvawfWnvQJcRkPlk3wPm30RwZzujdtoBu1+hXNQ7UIRxD7RZ+gbgialJlyjC92WXPfGSN8wbnTDnD+aARPVDvguc6Zr+49yBb/q11vjdk6/15UG3roml3sIU/cS+fBfHPeZVBxsT6XOrVmEvTRTdMRv7clhhO2KwLqcCBm2r/+SQJcPeZ6L5KqxWCVHKC5N8U5ZmKcyl1344msQCBFMmUib8/urZyjQNg3vQDvbdTTdefD7vOQlOvbz+NsqHwYT1uHO2awztwtzbWKSAzWiPuVb8+ev6c7J9eLVULTpEUFJ3XDswtOMyCpDFOlDXSCNs79vQObkP5dU3LAnSSsD+reNfdWXutmEbTWq4wJ9DKXZAI26GGMQJpbQjDgSf/17QTSdRtC78yHf5Er1jh72iTPAPWZFNgQIibIbOY1onh17Jkqe9VtbBNf0G77fItqSgMX78PP6VMOb5YSWRlH0GOXeLqile4xVJNxBnnQwzvXKMBzm5DI6HcNXPxHUiTeL4oqkP4SFtihiy0vkmA1iF26VrmQUXjPE3PrEgKiRezfcG4uscTaYprprlpyF+ZJg3nXUuYQFO3KboeQPZPwKv7dX4uAOXDnvcqDf0d+Cb1h3LLu0exF7/ay35rUbimDls8P672ZRkC9s+hsJnRp9OB/+JtP5EwljfiS9Jtzr4FXjRWsxQ17WVHhbufiVKO4+lpd4Isqc5bxfeSeYD3hcpKKdaNhqjCvtpMotz0kokM+UBvOTp6EarGXwPxJdMPhn+EfWX7hITF/MUhHr81sLW/EXYh2/oVv1w5LufFk4DX7wBn1ns+/hRZ0orxmfvCbAN3MyOPq9iqEU9Qlj6X2E7IMhP/8Buivhdz8V0vyZEP4pjFA8Jq+ovLxTgvbQ49sxa/7XikjXhRE9GPa/UrPCZprvOLXqmT91IKy7nWDNFcGb3deFJVm+ejK1TQq+o+XIefFGoMYYUSnnKA0KJMB/u2SI59LlY9we0vfNPt/CGU/dVUvxK15/f2qZ6bk7egACdp53lr6soyX7kzH4RFHJSYW9Xjnqtx8T9+0UwK8EvbO9rhBjeWScfOgxQfStuS4Sv4MMSN8OcTeaLpSLIyEtCHysLGwvUz5b36HiWgRNZYQ1OaliXGDUz5thH/AKYp1C9a1+U35O1IRk4xKPnALzZMqfsX8gy4xouhVkIXwhCzhdX3iW6qVVAGIUftzA3JrU0gNT6JtjfI1vS3PymsJTc7DOUcvMMgKIrNLDrWmoNUULbocGWzyD2t9XC/rNEDyr3VMj6jVq43D4PqRF5SUKv31RUI2gPlUIpXkmAhapUorsUxIJyaWmOZTU+AAAAAAAAAAAAAAAAAAAFgf0t3E2tJr8Ail5+7mSSFTwo5dISCjw3S0iGdnZz1+enYDYYrC3Qgmt1eNgWNOUrU6+4BFl5YKtjHRJn2R2dm2GuPYEhMiOlCuC3ouknzv5b4l9MGfeeeodi5MIxGd/xuIYAJxjI8lN1NdhlkdF0Ibo2IDzfJFaok3+RVhtXGr8hAf+kDGJxliYpw6SJ3EL7iLDvJHQO0qayak7vZ4mX3mrKheOpWEc2+KIO4qmZrCETbaXMfGenS0wS6BCboIHRRbI4qdykwJSWzhsslgrJOz6Tjei/lOdxB2fwVvsz+jtYCASyb8PDUw2eLEnRHoFE3e83OBcnZ0LFYovDwfmlq4PzUHb+Sz20DIMDiEjGglh3OaXhAEnZ8n/SP1n63KyBvOqPUM+m3nR+Hg94P2ag+TBkm96X1ELryNRqB3NvfuzgHHTQcFkL3U0Ku6MADu/f5Ru5IQHop54xDxiBDb4ZysuovEwFKDgnf5W+M89h8IaQbk2agbIuXxVKIABxs3FvrEi2UqCo134HH6hPRGc+xjnEJbZ9jYFIKcBsEG4lYmXuD5MV1aiYtnikl9DOBIQ7QNM6Tb7zNbdoODRA4+ZG8mxcxBNCM/L3xCE7OkorEOnUOVTdW5eUi5K2K5fuASde1CQuRn/jfjZZNShx2usAWEz+UpOY06PIZAjqTFdPblaiuHN6d+rvZaScWXUart5z04gTB23h9nZ3ohiZDV+wUaQUblK5nA9U/3UwjIMmIP2wpEiTWt2B/9SC996Pdg5Yx2VuoGKi1XiXuf5W2BCk2wLJOwkd/hInuXTJN1AFe8tvtRg9ZGPhHoMPjK5TbQpWUqWNcH+IqxMeJ1BGRFCqwInTbVpqKKH4Ec8JBEKxp2AJg+RnPyg77H07oHRZ0ObZ8KNgwDFW1VwMQAHKMiz1nwanxPlNNJLsjKv5nCiGe4rdJpHi5cp58u5NdaDdnhhQecOSoIsKqkVTY9imXPJr6ia7SDLPlPrbMqVJ2SCXgh6zGuLwbGZGLdNTi8g3N2yJ4YHOKEER/nZatE4gSxvhAbvo8I348FOieig9O2Y2/Jrf0COO0aA1OeEH3u8AVG+P/H0QgNBGeQVQhwlKLbGurKiRf4h5JWz1zhGMtkYshuWbu+GlD1+G/m/NlwlUuRrCOhJJwptWdMBenLnK69m4xUENJ3dqVjlteeZVwbAf6G4XFFfPv5AkWjprphuUNzmuViirDPi6lqRz5SOLl8CIcJF1onovJnenDrwft4siKDK0ceyLyjPaspTzLd7qeaxzCmcdUYjReWXgA/FtANZD5EZFSnUeKIXuZ5ljAKTArfZzujLy6C2xFQDAz73tqwfL7yUif9LMOiuZioBs6BfMvaJq/21I++6mcsrMFou4QkHskLyZvcC1XiTJeBJWX9toR3HFdFyzCej9A5/JvWzD8Ptv1I3WBOso5v7FqXg98bZ0EueAZVt7xPgxjzHeidwYmYmNc5eUGARy5+wrKMyfwB9SC31OCln6suNf6Abp8QEnRmexqXoTxsRVkQ9GCrZ9ToDEJFA0bfXNu70YDHX8jYcf0+APoKhOyRRRd7uAxkJrOG13ngo3u2Aic/9jZxrudqdUao/xhtttUPqo7K5/4KZ2kmgXh0Dpln3xA/5cMceQLJEkBU7DhJiPofoPNrFHGGVu+6GM9famL91Fq7C0Urmz5PKE1ymjdDil68hreUUDWgAzF2maVRpoklqRLDE0jW3bBdqlftu8tSbjcWESYvdXeK5Fup43FtJYjViS8B6M4Yfwrz7S57+cqJQG0WgtWNiHqinlsr0ycwQ98pDaFy8zs8jKNOG07AVfwbHS9i/7K8qgMKIkS1yI/J5Qmu1T6RMMJqeZ+gddlwo8/66HcclaFU9Ii8ElOHrRxNM8l5lVA6qOCUZHdJSs9yLxj+IYeVA/UAUVyc+VioEa7h03HiZtKw0FMzNMAE6nA5D/GhkNGC8cHPNm3HAADVZ3NkAsNzoarEiEthdkcf4NozQsbmnOqlFe3TAWDYxVaeEHeI6pOMipoKP4gQ6z8qi1Ry+AQQMagzFfHzwmBkadogM3IPMLPYjwUUy8tVI8idgM6OdOKx9nS+WyP6mDnPFCCU5kZuJkoh8bL/KwVZIj2vTb+LO4gHlTXtpKJT6IpHwdBdtOoWPrAFXhR/k+0XLwBbqmk8xzpoZ6Yd7dLVFoSAFE5bHkzoH3Qnw3pMmZZMMZszAKrw86qO4acEOZ/ZJYvSVvlyn6u1bPNd1MZ3+QXlShsEyrggpVLkgT4sEZuLtWM75SW+dVqOpan4QphOHxBcoFQlSTM4FnO8KQMoZ4VnTWMJzDvTfBa1FoMCtsMM8XsW0KNkO0nJUPN4N0+5ncRH5MHvjVa5eaj+7k9nfcGwrhjW3zT1VNPbPckbrDYVM/rrNrdPoCDoAVM+cpMq1k5jOLSJWBzDPE37OQ3Z7MTa4EKqpks+x5xufINfLDMn6SyTZCy21mX5QXxtJsMX6EWGBuzqhVh6Ni4fAxwQvwAAAAAAAH26tPJk+N8fTv9Nw4knn83huqYMoZd15KebAb2woM7Ozs7Ozs7Ozs7Ozs7OzmErAhPv8FEIVV+6HJGsDZGiBisJQ7rNYQYshXcOIGdGz9PJUIWAL98X9jKwbtE3aJu0Tdom7RN2ibtEhrBf6wJpPXi9PhonPBOnZIOaBXFmPMU8Az1ok6TNTxZqs922s1We7bW03moC0xnA5MIBh49d/AXSSvCqZnsNoglZmwwKQmIXOy5WDLdxvquIr71yQ0WDX5VNWSlgS3r4i8H1A7MzFTQ4LRHoeLJfrjUlHG7YGlFHFIxDxjSoHuGMJqrJMD5Bw/ihxGYb2HEjyGETpbDAXgRUptEGET4rNejrPwXAMAX9YziWhpByKkIcccjeysLYheQlmbqsY9r4bnIyW/0UGzSM9xnO9cB9oRrA3KMvFHAAcx1ecEoX0IeQ4VvGP1WUlaeAPrgLqAz7Ekc+jJ1OwHBxSX4q9Z9aEFxDiPXN2/V9XfceGwczlJgpe6mVlFV9mRHxihWut5EayahDEM64z6+yOH8jGUVFT052DfHsdhJ+W6S5uoGuzWsPgTbt3Dl8H9ynQ5JFhP5A47u5QEgP0uhabVR/knS4pVa/T7fjVe5gjxnU371n8C2Q8oGHGT1QbuYtY3jgUiwwl2XOduyxCBcdSC06J+qjeP2TWM8Fw9nvArVTEXu8gtZuJeWUrCRa2jnfjOWXX56xEg4gNXgaQj2X4jMZN85IkZM3Ta9u5/ldReZEkTN20LVXf8T4yEDEDSdLxY96vNLZY7FO9o89utrwUUR5PfpatOvE4TVNwCXxXiTsPKHNVckarad07Vv4X07kJuRl3mZxJfs7umqWmbVpGljSyaPmNCPjlcn8Xi2LmnFQzlYTZJICSLgyZMOqSXsIfmhsqNGqoUCCzOXgy6F+u00I7Udh0ioikTbEpq9BnNhMk7qhCPFq6kC8jrkRWSnjessnlbZOCn8iU8Pht40nYaEUfkwBoE2MEoSh+1CN8K5ICaY9aN4OwuGlfvnLYW5u7DHVdF+NTe9vh+U26XHQM7fgs9fZjuv//qJV8gGGIZXmhLZFzGcjgyzQBpMmMERL80sJjHCkQ6J1uab7Vz/FSiV+hpZCOz4zWOZ/fyt4xt3KeNrPX2Y7r//6iVfKa0pnWmstxTJr8gLDHD87fSh+vJmUFWSBx0CF5u11dJ3zSF5gqTp4AslBJanSXqy19oetPLQqbd/O80B+agTIPPQeAmBbouqexegYLharaIxVBzn0NI0cVt+BI4T1jYZOkSGIPSFOCY7h0we8xwZbOpNUPj3V1ztguxTAMWJGWLIza2Hp2FWvmjuLmck/0wqdJI/3loWfR3JQ++DBqKGdjFbmJfRp0RTDV+t2INusZy6k6epT3Ho3zPi3hY1XVA1PDIqwXo+4USccoIv94TOxauVOJCxwenzjJol0OgZoZUdVka7dZnJLD07gbIPW5Do8ADYGS0XrvuS1VPpmyl/7Ez/EEAQJUk8KMyi3NfjxEvbuEmG35J8JjHgZYumwnj4MjYYrHxyxNnbmoh+qcOcH/YNVmovHwaKTp0CYxJ2i+wBxTc4YRBnrLLIVXDtRqNZhH9Q5x00HIG2puf+PwyZ8RgIjiVbb3pAoJAAoyMyoKwQ2U9ZyPXJ9pyUZvlG7BeeHPuqA70jfwnlWwVnpCidYz9o6Yf6TosAUm47DHpOKIpfAb2RpkvBue43p0La2p+QKdm33B8ecnjQgP32mxFsieV/0/cQSd1LvaFNLZ/cXc1Uziduo/A7BfNOmXRQSUh4pYLZz8N+efYzLLzoi+kSJr3fXS2HtzWNKx+XgAP3mf0lUAIsO1Ips8rdsQDQq2oX3+RYN8COumtwVy6uVBPjN+w2Ly33CmWk/247eEV/TUz26/7QFYY0bpaWVrQ68C8NOFfSH/7Hxm/Bf52gQHg7tUPOe21xxV71MAtGQaJR2M8UXQHQ69qeBB+SuFiDCLwgUqe8Kll5E+JyN+vrEVcYWo/8+Pkk0YE5e89VaIO3DIRsGESydSkokFu0tsPj5uY9M6btSxdCSQSk/LQVhgG/7OdxPAPDaun7PCw/D+MUlxuw5WhdiJq+yc3n1+jDraol2QlwhyB+FDpSN2Ad6MR7k/Q3uZfUMiojYexHaLHJRfU2CBkt5JjAUg3aal7hJN6t9r3y4OpeYx7RviaqZf5EJoS+tT4Uo6c720TwBKst3Z/OogV9lcpc3ImDQB/0m5WDO6pZwiV2AL/zQlFyWJXp41t61g8lYG3VqghxKSo1WcQTeOhwvostmY0pwj++uiFVKgLcV6rYFi7MFX3z6HC9dk/HHnY4CJw/ImQt59TQxtHPTvD1rHDrecCf3Ebey5QF+ngaIfEp051D6Tg90u+D+lFfFrqVaLw1PEkDuxtiBfv7VzLGtbwfpp6xAwFyq6O7jw2gmS47oTSg63/+xr6XXqLCBNCHYccvaZn6r7BRK1rOtScfG3tl1248Pj7VSGOiEAqEoAhzEBOAmK6gSUNmKOuRXpdQFiBUoM1RZiUI+aPWWvwN2wkYsQKJb33GDoveOE4PDaww3TUEICNgD6VTaWRB1ZUT8v+xTQ3dmvwxVj0U4yzIULFdhe0FVdJELTk0mali0wfwWP0TDEquAnRXu0QucVIRjkYLVp/iNrxsuG/HQjtGtUBki24xRpouVB4OdYMr3gXqgQ0/69Xnc6uIGsBwYw/KE/zFBb8lEvhJM1XhXPysfro1AehNDL9rP/a2Y+SdKq8QpB6sAhfoVNl6m/XMMO8KCMmh2/Q8FtrmOw2UFDcB9cXTke4dCzoUl47xqNSCkurYR1ulhona9uRwV4xoLfdCmWrTSak/4ZN/aktd7Y2SDc4R/Mcl4PIhV6yxFIagsjuMN9fMlhiSPB6Zl2V8fKK3Nw0y3BfC8DItVFF8Kz5BbPaWRzpHY9U+7VsJq/FOUAB6QDQHcU2L1DUAy9RA8QieXyg5NaBo/G8pbcRqTo4cRe0y9iZN/Rh/4hN9vSCsEP8SEZU48XqwEBIA0xVLKKXU8PQWTZtMF+9q2iArMBgAmFPDkXN9Yq8zGy6VyUDJJEzgDf1eDNILSOqd1d4wGPZ9o+aOrcAk2TSIGndutFAKY7CqTPBOx9v02bI2wtokeGG2CjBIPyfLZEbWa7QMAHy1Nh7UwZBH4Ir/+pJaX8VaylS9UaPOoRGH6zY7xWJ8vzPQWVQOfNoO2iuUH33//8PksAHoAJC9tTpXXMlj4oJEFmaqCm3hMkTAC+P6c6L4wl1Vi18L6lWbB3vY44lQIU71nQ8ugltwmiusUcNf0ouAcqE0yXbKlp6PnMLb1a9TNE+BN7PUkDHl+5QZII6p5Jqjj9WZAVlcIj1H9dHOS7tHlFr1W4PASQFSA1LxSZZKEB5Fee1rj3+kxHsyvCOfnWKXXrjQY5GT8Jg0O4dfJaJC7etAOiLcKBtrjGa6q8Dh+2nQ3gzBoKCehY9eozp93cwqXe4TiXY2vmCSUgn5PvV0V/DfE6Y1F1laqVD2PeTse4zm3ecWRjhgaRaYL5S0P82LJEpa3s/AfCDu/fLAKpKrqf0f3ffxacWh5FuZdWH3pJd2mgDHRxBWbBVesBChA66yCApankz/eJK+d2nqQMh1Hkx6Vstwb5YYwptNVYJFAn0ap0HfIif48VRD2O5s5U1vjGZDHFbY+diDFmYBx38efGonX3yydHCira7V2Ys8O4NowWjm5pwh4rrLk4wM4gOK1w0poZ4YFEAXg0hm1hSmvshecJkrhXDW5b6ilwHHCCpEETYN6hnKeg/IHUMsmbEN0gl02FJWoKjgGOI1TWhNeGVkBrFo3q69ZZMglHqjlRA4IGxihtfgjaApfhd/PGteAlswmbKlIPEwnc+PQHGHUAaIIO4gC3GRwBg9mNKgw4bAw7wS+YsmNLSxY8Khd1hz6ZQAFFJqW4YNY4hUZQDLb6yXSwMBP0hMNGyZMIcK/UXtxreHz8D/LrzqqJu0Tdom7RN2ibtE3aJu0Tdom7Vb4HCaSDPVkz8g5K847HsICQdrPEIZQ9r+LoD8SwKMCRmp7Rb9UA+l+6pehGULmw+eMR52hT/OrJoNQl/kPwJlMg2V7W26pNN8yvloGbVw78z3k6TwEBisfVMlnutPRd2vMG8PYoYdgRXHrWwV8UIqfgagtRDbyZuSuGDRPZX00TiAmkdnEzeDMHphY8yXGBlnY11bF8Fe5rwpWXSZlOzFRBVu4oCLDLD5LSq+qxt8DKDswepXZVdKg2LRU4TXCKqout2F3atkBe0UXXX4hAMQ0zLMpuJjR/IVhgiTnRQoBCtvM0V6fEeInbh/ptrQN3/DpBNwXhzNojq2YpBWooalOsU+jpIJe/fjUxyk4BC12OzWPqrB2eCkirH0zN0EocVAQUyIMzZ56QOE8hhjPX/GS4Xu5I/TUYkNk1DPOuX3letfM014eqj8qDlycCA7ZW4iqGL25dNbM2Pt8kNHW2eV3Ka6rbLFUN+ub76ARdysxgYN2rRrQZibER75P0k+XoofWO54tR6GgEv09d3MuLPCBBd8X3f+qlOMJvoBM1DBSBdVn4FAkLZBuRfK+Qd/lc04TR6povuR0XU8H6kneNmMBzvOV6E2T3d1w8ZSZyaeeIInOnASpaiHpye5rUdEniFA4rydtX9+jTDGLhYj77+WXqIQ+EV4OCGomSHolp90H7AbCGz95CR6JsvI51iBQih9bZmHvcNoYT9gJSxFI1K8lXtc9go6EOg65ptKqc6UqNJ+g4F8OQiFasn7vO15cHdt9793HC5N9qOUUJsHEDnV2UzYAl4qCStwsA+E4D0gpLmUCYhYK+WiBrh39ss8237sea+3pnVwv1Kd1VcUYA3KUeXp0hdcJWop9cxb+7zOgAf0S4lknSdv4+b/tSOwFmGXdG0Pp7YexWnboYYxAmmShRXNqsC3zmOwB/rznwjNXYHoBZRAt3v9wbTwmYriQfVEeXOwM0pkB5+EIFgW+tYmJaPPkayCTYb9uGrabMeQrs3kjZm9QIV/8g2Q7XL+TbFG4PdEg5OIDtEa8tPN8W1g/iTdNtQnslbxA+DQYWUcMcSDx4H8DifzKsYPRFvpKicG9D3wBTBzn8ZjYYzfEA1x6BMQsFmmhHIkD8nayalvp53IViwO2ItkgVi4cgwVJ7EGVH+nif7xni4ZRuYTdTXJMuERmBJb1W0TDUbxP/uNR2lgpZM28hgP6TYGTsLdw/Sb2sgYatfpEWQiz6JmxmJxe8IqKyZCWvWgugLIrk33a0qonoGd9/cfHxhwOh2cURWR2rJGa5cIujp7cAGr61WBALRYAFwHcKbtlBaUr9UoFMgcW4ebGkswtHcWP2jkFfKnWuPwNtt1dL36j9o9BEYsoetaqOM7Nx8xooHq+xKuL2qbZSNGRKhrKDWEAaE+tkzTgL917UC3267DdqVaJ9tVP7/1/mbqrJfsadqow325Qp3Wr6QZ/BsR7NTPsrkdNP5oCCxl1xFBJR5G5FwOYS7/Qjyek4eo0KTEI1I+fPGjysGqPS1MJIg1GtDv6pZ4nB+O12dxO/XJjBkl4IxMaHOewVrEcClCejMCv4budiVhLiH0jcrVpXp0LU3I12Fm4Vv2MY8keIlmDjxW6Twc1QUAWT9Yqt7H9vJWnqgw71gtdl9n2eC8NKj/QdI2wy6h2ZfwZ6Ofcgr398AHGsQqqTtSVoYCmoid8xRvQA76at4QyO53w/plDFcfzK2xA/bSuXPgUGN8CdGxwTlhW2hrbAHYeJETlgjzSulD5QiOgn+cqoJxHaNKAyP3mw9kV7GVGU8OZf7jKq7x7e3CnwU8i8r1lDBpmBntrcnYpCjdxBa4qodP2kLx9pXXHZ6s2/SVNOsSLp+lgIn6ARmpcipKIKoD4IPEoOkiVz1EF0+6yZ3ZPrBgOkLskaKmnHnBFlezvyUm8xS+mMQ00yj/fjc51ckeOdp8A5EaU77sRnR7tYDl95oIyyeXUUPh2O7pedo/oybKQpFDH0YBFB2TPx5VOLFL3USaJ0+XtrgTdBS78THy1gPxSqpFA8FXlg+mlfJN2fGMlsO+v84DduKa7lrD8n/UW9lz+m1v9nONtyG0Iv4U+2l5TeCqCg4AIlfEJkROLL5bk4kksDtd/opoKsmZPcNyp7EaM/VRFTzSP4yP3Io3JLUNdsKGbZP8tdUuDL+F+rWFJgg8wovPqdoIZ5v2OzYT6t/4z5XeVS4SeX56/C6VDgRi0A2KHti4Hn1ONu9cIy3PYcL79Zta/WfA4Z0I7q1Kb2sTARbTe/SyzC2/gY+zIiVhWdjg8M5b7XVWH0ifi2TTMOxQsv0pCOvUbxsFA5JDes9DYxUvxQJmzfcIot/L/4Kit1FJU9Uk7Eglf5B4/hew/msb7P594yy/n+/4qkfoYlvVY0aSz3Z6YddN2HcaipgVdOJXgX+aU1CuU3rW7t6p0I7q1IflkNb/srmqk4LL/tlDKoIyZ5iayThSqTGeqevduG8JgV0N/v5EDrLaYmO/kwovf2yhlUEZMsmO7hx7wlJs0J29bc58KpN07HMpHpU3z6CEIgmIPtKmnSqfKDPBx4muGq8n2PW+IAYPjAtCJMFDKZNJ4ERs6MPOxxdRu75tGcEVMAVYs5xNaDqq4mMJLb1f5VfJKhSY8NVC0by9z18AFxXrRS2egchAJ9L1ChSwu/P72fvM+YI/VCs7AfSQbN4RFrZwtnKUUi1Qv78xADnCwX5UUNB9IFYQ/w5+KrB+xygGACJHNJnWkExn8r4GTE3c36YZmIB35zDe+YQSQNbROhbDpU+oJgnZ+2qGvdX5joBrMJKGG6iUkwaoZrZ8gM2I6Gbispoau/+zMMpTXN/+Qd5k8Z4yFChHjsTh0+q1PUx0v+p1PTQLg5KdjZiIXaPzHRQc25SLuI6qNa0EmSO5K5xk5F9srUH58uiKNyDKX0OSBB7aBGKzsnvXjJ55QQKLkl1cUnmhqRUJMs4NdxzawCMEbzlyCNjx2+o+F8PrzAysgrqQnKdX/wyrIlo2spqDSCk+rynQYAwH7jIsNR63u3V6yI8gIWRIgqL+5xpB2sCc7R/8Fi0SB0WTHiGvj7P0pMEbrYAj6HdiBVnI5vLF1N0ddxkY9nlslrRYJLiYJeJLRzmJlj3AaLoQCC0DbeMRuaMZ7B0u4caU2+mB4mMP7batuI+O1x1RlW3LZlT10/9YKV5VNsXf7z8HqZjetmbViHe7vkn/7Q20GN69uAgg1XCwU+Q5x2YST19wKSi5v0ATf4Fok+Bwm+QCW7nnCEGLjli+rGDqFBL53dEmGW/o+bMpkrM1UBS5aOl7MNzlODrU1LvME26eh+tJ/+0P/sKD2PlauCJYDMAbe7J+nmbCAxNdbt67O10OaRKw+Hckbok8KssYgx0TGgHAkBVGwtOieWqQLiBj8WZ6mLHl8Yp5VnJMZsjTeLJnPSCgkLgoriXQsOcS+J3k7nOG/N9XMZicc7y0PaKrbLO9Jf+p45xp9U8jSm1Y2nAf02X28idbaUjIUv2FX/gIbKpd5IoRtRzf18hr+pGBY+V1sSVBJIjjBOMytRTL8vhsidLhw4aU+3CDrkH7h5ALooltTKSyfCMlku0N+ZX1JAkwaHcmxT9HMdUaM15jDmZDjasAl1kX4BrsOU+ekJoqPf27dbPw1KkaZLMiqYVZFztkOJM1zp9fDSVGvtUO4OZdwzn8pN1XlX+OrTTK46QcujKXUu5wevoc7RZyW5vAT3SZ7kSWiiRxKT/KSjIOeHCBVOtJ6xBol0f659R4HUlat46mc/dbiglzKR5+v4Bmcl7X55YnPNGNrRP0L1zsllFpmlvKmZqwc4WX5bzhzzzp4MUF8ooUODwTtGBOWwQXOMZ7TwBmFLpJFhgCIU5J/cflLCmfIsDfzXCqCcacKAoY1sZmXfTrMs1E6LmWaZZqKEQlLCWwBQ93uDju5z57x5O7qwRd6dZqUSDdom5RN2iblE3KJuUTcom5RN2iahD6hsWQ6ZkW3PKF4sikeqcogrHwABsleQQ85NzLVPYXqHZ4hQU+NINchBFvSjG4AM3JGk/FROvy/9mPT6pA7I07M8m8IMprtEctdouSGE0ibjOJKxQpkoZLxS4BD3xg4QofqxuTCcfCxA0zRZFODJ0TMnb0hzIEFuY4HiFVksMfguewXdIz6nzgbVDPhTSivbUaCevYkSAVVPY9K+3dqBdWZdJfFDaDR2QxugrTIyzJWvmI9K4QrA5ECio8cLx5K89pNiWsCW1vCZkGOLq57vphywo/nFL8VEjmRmR22CYntycIKtlyWd0/GpKPvUfK7TMWlzOHdq99fU5w6na0tzxl8LEffd4lL8C2Q8sUmUe6DrbA1aZIqqREHav8rztXdv3WxPFrYdn/R0jgVZ5P/mR190SL0YCwq4mXKyncv+djHFazFtdUe43KXHNtB0Vgu9g8q/tfWBwslN34xqnpeWgyFXS63moWVxkhynD+s9cY0p/dnJT2OX7zrYSUQiNFl2EYKPOxElw/YIfZk8LloCGiDh+rKJoJNJeJRFM81cb1iazJpfCx/V+/F16LByiGuJul+E1jRkyJVbqepavLsuezytzRXKKNdS0SnQJg1rMh5uRje33x0wAO7lLfIx3OTiLmvI9UX3FMPuBjbmxb6LUSB1tvjgM3F70tQRZ6F9orB8Wn24XMN2fflqha+/qLsNYaoSFKDxu4dBQUbzQHQl5cId52ZZHLXV/zqeayJZkZqWW20P2kna25A0ednQkh8hA+yq1FfxzuBZgRLUWGIqJMypPpkseYhMapQJPLfk+3devCErf8OSB0OTqQ6ZH9qBy8XVA7Pa8kAAUy2+dgQsqImKzqUwck0KFnh1COXcUmbOkdJ/XbT5JYjxdfgYJqjzDy7qZm1lZhQh5r2MswvVrgE55i+xA3ft5hBUVYAtQ4+SdO+lKiBP1482k8J4xi9+z7nE8U8IoRfevO26OC/yRosPKadgAsGwRMA16q3cfVVqYV0+YxZh+H9u/C7Ffo+eJcfCR9H7kfei9CTsn0ZX6bNe9k4cqDO9QRvCDTBpLkCg0qSjkoNchTA2P3+5j/jUtfJeI98l1FQfeI0FGaDveVs9OBR6aRZ29552WBlpTKUWynASIZd/tE9mcoA9nYVBEBHG9MItIdNnch3nRvwgBm9cB1wIlwUgNNDtx1qCRmixgonH3POcHbr0AjR95YxcXPFYF8bcfrduNJBIhMIqJ3V8jVlVRYsiHwefS/WiEcN/zQCs1IkOuFJNo7x4rxUhvnFar27PN14Nx3tdvyuk0s2TLe0evHHxWFOKfJmiqIEGVIRKl+i8imkGMxRC98EgCblJr0l9TbiAO9x47jtO8fAku4ukJ82IVm3/3kOTSgaxw65GTAj+x5E2OzuA+l9pvXSyYLa5g0FRtR6lHfUeq9B+6L3DHW/gxYipTDrmQ2K2xxVNcQErLkP3YwWY5UiXJY6zCm04PTMuE3WLZ4SxgsxypMaLA4jCH66vvvZA4jHDm1dDDFJK4W/imIkIIYWbb544aKEtkKxbdWfCLbahzurkrZjK5dwhe5CE6uBQbTWaGtRAKlqlpVUy/HveNTw8gz0kpYUGdpQkAOSCIqiUt+Kiu992YEYEm9IXflITaJtQVzYK8en5OOSJ6j0rvCcbsUDMNKMaGJEWyrhDtLPrzjJk6KGWfWYRvhHF+cjjHGSaHTKFuJ23hMmyhFg4y0fjmYjIn6mezvKMlpFjP97dDfXucmnFL+6l58S/hw8sahtW6v/OOArbCCZWaQgVTLPgkCeLty9Z9NTdM6myQ/FFWdM434BUsFtRmHABZxOff2m/JjowEOF4dH4CAAsr/CXO5xyDUZk2/k4CXLzBhnV9hHyxtTAW9M7RfuiNyOK6PlgdXu8wvjAST1zmiDiVCo/HB/OFtoZf6vKbtuhrfmfcfV61LF0Aomfd1JYdl15qO/YSLRdJO27RdoxCPYxp21H7uMkORA2rECgThQ7b7/QxyrQjKCzx9pOIfKp3zT9R1P/PxIcdPgdexZBrpjVedxiNOlN/oQshGaGyOA7i9NJSe/Nur4e+uGdd7jVTX/YLJOWYWF0mFWpy3iFtJ8lP5wJMXpsWS4OIRtMPHghl84aYhuzhm0Y3ld+qMaF3gxSZDqX0Rku9JEdPoIB6bB7iuiC2/PTre4ttqQq/rhrGDnDu1pYF0rQZZ5Wta0bJ0vr5o/G9uhqm8xVyk1VlaCZLImDWTJSt5NmPgQ9VS8sF9jDkhgO+yiT8jLkaFHkn3Y7H9nV0WR9GsvG26X9c6tzhTiU2JgzFSZek8aotvRxxAqnNHFJLDwTSLFZqrblVcduNe25ULKVtauudPD81qjXfklcpBqniSzip02kQIz0/FMa9UxhD/V7xbW9Cs2Q78Dnaalnhb44bTLjvIRh/HQxtY8u/XCO8UW/7mdJ9VCtdcP2FPK5v8Mi8PvDvPd3ieodinrt2Uw8/j7pOuVuWK1ix25HEOljR4gS4r5cXmtwDhmIMhIAz/iR8W94zVK0fyDtsnRfdmuBR8cyQI79cp2j3YrqizMVkZOmH9K3jfN9nPLFmSdbtfRiqpfhYsDz4n/j1498v1WGr2zXO/NkC5migG1RA/pMSOgKXxknurxYKJTxrKQeDVcPzic/Sa/+96c+VwVDfdXrj9fC/nlGSTw/e2ILZzAhB7mEydWg4emNeLsja8liOqy5/1sMNDvbGgCHMNvebrxiXR/ITq4OIceXnoAQlUkigWfHNwfJuRyrUw8grGo/yc7qXwAzJeJuVqV9Cfl32gebqYfFulfFrjsQiNGPn4Zr5OgDxLrm4tW1cQhwJjR2C36vmFWlYsLtGXG4/H+SjUmmUelrsKBZoxbvyKtGYF61Qqq7mSbDKLoo/AK+Wdia/G/eMwA3OTI0Tm9G6n8kSS7F/gzo3y5WmQrowTzouTks/W0AUYJ6Fj16jOfuJpXVL118yjkd0DJ86/wisDlsvK2alCwyuEGusVjpHBdp58I+J46TwNGKarit+N+8rKEWfrdqvJBzkQW9RGsiSNPUiKzkA2jlMmlyZ6OibM3J8N0cirLgJCqgF9MhdEgumUymozaTM61/ZxRWBNiwfaFfX7uzoi7ddduQSN/Mr3jy7y7lpSJszcjWZ6UrmOBMznNBIVLkJsRshdUrI2kxmgPaSETWAxY0s9rRhpvytpMNUgI1iOCoJZ6f8/6DqIenARdn4c6Y01J5v0xYBrD5XgpX5tZDrkLVqJIqvAofiJi9BBgxDS1RO/nOt6l2nWNLQw0AEmfGgXhhyvg+9+rTGI22TCR3i2oYrUbHaSZEn58O++0BXnz28TJitWMDXOpxLO2fVAH0CIddZoal/EhsVpPLMH0gDbwcZV9r1cNrJWNeQfvG4NPzugmnUqFup0If253yKBjYCCBHjJFfBu5ivglL/BigHx9OStriEBuDYh2u8jRmmvQ8euwVqpw2LRv59febmMglOlFDVpat1vSuc/iGkAO8Hv5AmQ7VEF+qlmuz1kAF/v8WGMKXE/dusryuufCKKf6EDxzeNH7xqqgBM6s2DslQcgAK1DuHw08rgIPFR/krtI0xbi+YnuzHNq+ABf8VsE1vVO7q1eHHRYNL5TsxjwMZUa/CIXwLikNjY2NjY2NjY2NjY2NjY2NjY+AH5IbCOaYlBWxbFsWxbEf1DYsh0zAu1kLYVN5Bc4K1O6g7Pc7hP3/jwxcHBAdb+unbIw5WlJT3nk+aOIFcjlGlGwt1IuP54HgANpACtnqQj/utrTXZeHDnieJm07gNSdLBWAU1b23CEg5BUP5XURLY4XygShNM6Tw/FOmj33aAnOZIiT7ckHeN/fpC3Im+1olmsY6MKz+k/LA18/NDYM0GzJ5jCsybWA1qtdEx8moeP9Va1sx0CSENqv6aG/PxTMAFpmlVdWifplqXNiXK7nI6uqAyQwCYnC/WWeDAGARqtMBVpsRXp0Q65qiGFrqhwrDBCsAI0gS2YU9o+Y2KLAQ3VU+WcPO369xrMmbLHoDmGEK9+Xq508UuxjdZw3fm3i6LIc/GQfMd8EAvB1M/HJvr6ywaXSGlur6p7lT2xgGV7pTZpLi1g2ttoVYmWt1l/Vth8LO1XpEUnakzOK++mDhtM7uRsIbTunocveXcwqL04ejt+nNTtXC2JxIhHQ1ZLlIvrYC5wHjOf2Y/DdLTwbzt1rvgXYT7ClLOEot4Wjc5WvpmkNyqPDGiGFmdj2Gs2kZ97gGss7kilAOeV2Dz6s3IizsS9nBZr9KZW4JG64LslF9YciHDsIxTVVjrv/kH/QtJ5Gie9RrT9HB3rby8dHl+vTDPxwpZM40ALHag1qZ8V8uMaGyvn0exfaWLGUMQuvzEReIg1IHc/IAmRMceGr2snhmvVSgG+SaNlQeNJKfndeomF3Er8AFMuPrSGGsWh0Esy6hhw8VmLFjMWdsUyXyChh8u+q9jpWn5o9+dyZFIpQz1WTWNxHBIgquwAA0S7ur1waoWJ53FZBe+2G4U49cMn/I8ok+87d3vI4YDer6nm/H12YkS+uxWXRjwMwBtNYqs7BcHnvv5Vi514Axi3MYl/oe55l5tO48IAdOyHQLXbniKQjbMclCZuw0fYUdop3MB5fqS3DqxkpPptq9/xd0ooUqbahEiUHHZo0MEN97U4hhLEyT5f42yDXshN0Hm1rGLClZS1P4iGYgi1H+CAVvRgTQPzAuX8pkkM3HZurcl+BxZU/DXvFjeqCWK7231ac7NbRFglK11wj+wet3bZKYLxJd1fnzo1/431uJjlmZSEY1n2YvkInnkcodSimBroxLOZ4P9NIg6FJiSI37WeB0TGLJCxiuDdDD23vdHHjuo8Z/2kliETQE89yVDvjZ9mck50lhhN4qmw3r/ikW22/nF1kcRmFwi5m07+jOz3URqaDlXKMdvyKEnTAWop939ZsiZ5nqmBzmdCpuiLSzkQMHlFevqIcFM2GGIWuK1wH6WBJ9QySZwRHpgPWgAvEJgrMZzU29uL+HSzFMXylsAv8loRKWv+KvrcfrduNK0xt2a3UGiB8lao2lZuDPZ20I+jFilc1lQqJmlD+okO/m+pkZNPsz4sjFeqi9giKs6PWVZH8hxj67N7YqG7cZQDu1eAiLmL74upPayXQQx2pWbk1oF7JS20w/iPMrblNpE5mI75hnQJia2HlEFeT53hfsVgbfRdJE/mxOt5b7zUmCuR6GMwemER9Aii+LmOw2UG5ZYnuSrDjvmkWy2ts5hQ9Rzh/AE6GbspKtzGFuNnTnWsIWf4HNJRz9SGFOYRN473Gkn7McgwS0KVrrk0ZGo7At9qu1oI+6kr7qnYq2+AEJhxeFuPYFOMsyFCnRAWuVzK+vVB4vhwi3DE1bu8KckTQtfv9jBSkoL0IEvpjA5udt07mGTBeJdpNy7m8JdVR4wd/SjowXLgMacTqdQpBPCHzN0LRmQ13hLyCNjHXnLfwYrd/MYc8Tu6uYFHwxzwopgcRi5dYvCSGJd02a0dh+O34HDtzLXmsDiwnfxEsD/WSMkXzOSknoM0QcSoU/oiLA4jCH66vvu/aKptXxbU3hYm8yTVWWEhvkMkbF6FUcJXwApv6tZ1X/6mNDWtYACfCBpgnc3ZOu0YRQG9KtMZVyGYZl1tTqm+S3bZqkhgqDbaoyfBH7qGqvRUagDyxXQ5zA3AUPes5J1+XOU6Ye20kH9SqjauRcK8RgCYo7bCTe0DMZW3XwyJmFp8GUKzvbhkulgy+ehX6i8gz0vGuThdzxRvzs4KuV1JNZ0MUd3XVH6w5HNDaYtIxrp/XLw8h/TqKHXkxD/SY53uD0tuvpScHgQRRgBxNjjGPQHDVL0cc4k20uVvkKYWFYRplKoPf6WTYKs+t76jl2ms8e8JSbNCdvXEaQu0gyc62jpiqkdJEaAcCz9FcNS1GgOn6RlYJCMXzfxZCcNZju/PqF1cjj9tmnXEazCWISKajfg/QMDt6Cey2wsb7hSpDXP+sUv8mPjGhvFPbBtkOPV+ZkmmggsI5ZWOCNQVOVb0DbEny42qlPUsKTXIqL5KBYW3FIbCicYna7aseSa7RMx98Pb5CmejIVLSQBAAcEmDQ0p8AJyn2ab2PFk1q0mC2MR1wT9zWq0k9glclwGQbUd5HuL9wzivRQ7Mo4uOs4w/eEyDeQqtHBXYt4Bx44g7Ep5qQguuAcEMAwx3D0SR1OvaOFRFqq0NRycPu91hQizr+RzI5SKlF2bVUcTseUhmxHaRMCg5+hg+2qOYLmo917rn3PV0XoybYKezB2HNTBmrMRnXbLuJGEiplR5+6G9cJeGhNIsit6YYhevYT2wKs26CcD2OoTYwIuynmmda4WQNj7jhi521J/8LVJW1QFii2zs1mAnHYCV0KYCrcS/aVGNXQ0dxvezz6zw/8iQiBRbpURhAbSAGmkXmbOYYKCO8OKRuuLOdp3fGh1kUdsjhegqCZ20VgNQxc903Th6dOyyRQMJq5Yqn21cj9HEtImroK/p0ybyqNvQ7vtgQepqioReYsiI4n0AWhm3X996otXUeTmf6iZU8/GXbuTRoWndP4uyJLaJeQyBW5D4f5OVEISwl8Z4BKll6v0C9N7SF+XmVfLEPoqGqJpwl30u/lFzezcz0ZSD3bhxwZaSky6ndrgypvXXCMDlOc1xEO2WSkM6ggNkdXVVcGZ8ua9oF08Rco1OSFIhAxApu1V0+4c7EHQ0OiEg3TS143IuZ1/JGqrS5cuM9JhPd2ce5ao1JwAnc4VBuWskepRAJNw+qeRsjwuBjjoYeyCeoOiXL0GLs5HN5YueLN3g9y5HJxPseJEuLmWm84zMXvS4CJGfaMgvBG5+SqumtrPDBBw1Y+u+j6qxW59+Gf/j7RVfG7qnaR6b/TaSL7CCQXM9zCMOW1A/FFhF3zWym331HbGQC03z9r4GALmM8C6oKitQ8VykD0VaFTvkGkGmMJZZ1paYl4XF7n290HRLuED3iR4XuY1ugcfG8i6PwaQ0PJsLzn+qm99hDZzA+BCrWKBm54U+qFQNU/318VxqTsUGseuAABDgT80HDhRGyiQydYDWHv9uJ81gZAXcpuGemkbB2S1lw4LciEkMBBUQTxC1BnEbOa0YQPFA8UDxQPFA8UDxQPFA8UDxQPFA8UDxQPFA8UDxQPFA8PyiCbTAJIK/RhhsYLR6h32W2+fJMsLzzfkB4uig2coA74K7B+ugSWXdUtyICquv0ik301dVK75/uY1ER/u/oTEVltpm20zHAAAAAAAAAABT82kdKcmgrvk/5Qm7ccWNbvwKe3MZ5IoOr3eRenEVjGz5P9MFKnYCq+ue1OCDf7fJsHRDTfUPEOJJss8DsT329XJtfqCzBstDveZvf6m4cbLe+94ECi0OInlJTEkf9/+eB2mIC3dXQPRwWSya6NMe1qyko6//o+wNipaEXoR7YZl3PnpHdCZN6+fslvBHMyKv0Iqlu8I4NY0NdaGF2J77erk9cCXbDWMbs/jDxdUdX17uyO7BAkuENQp11yZV6brTJv8OrFktG4F0AFrDF43purbH5zbQ+aNLLUYQbAu8l8YzC1gkIVcHBFS+ta4mOtDaDXM3NJ5mSjwYO82qQ7Z2B1DE2BAeF0tC5CdS5pCZ+q+T59C/jyeakH/Mr2MQegypY7WbjvLjU99vVye8IG142yg2ImlpgQ9O4prnY2DafNTWVUz8RGUCl1bfekkoUyI6aKlpvTPAa+rvu2EaJmSa+tCgI4q8rdNpcwbPaD+4bmU05W/JK/opFw3S0ovdOEDGpPx2wGLsE812JBjn7+MAiW7pK8QHokup6momP9xz+Y89504uiZHz5yCggqwQNcAD5zkzus8PzrJx+8RiyF7PdFsR6dbjDkK4ST6KFjzC+gZLUBj1zo/9H44AVhEnRhoAUcCHMhLIneZlJwt2YOKj9f6PJA5srGoEQJtctscC0LsMOvPIOg9uloxnoVdvKv94cjnAOqc8ZFg8I7ZYv0Sx5Q43Ng2fCx7M6hN9u0QI/WOE/kUnDmLzbi0gk2HxNS4GQwUdtrbfeI9hrDJv1JP7Qt/NWrE2P7zdani/rWJNEADqBvfGoy+lkqnnX1KD5eYMHYag/J4cMpNJIsVoef6LdVwzsiI7o2GsbxXLvWOk9wRa+Jw2zyWnyky3xLvxnE5h14zO1Y/f5dIHKTFq6FuaBrjnvyGuLJPiMo694k48a14fHc3BA8vzGSPqW10nnSBcg+EDg8FYhuugAK2mZ8g2eZe8Kb4Nw7RMhpYl9FQ+7LIvFmBQ2ODLGjspScyiYCnl2LlL26wUlCU4J5g8HAHr5HiAcmp0FWcswobFGSXJH2r6WjTHgTVKsg0qi30B6AdRi+DdrRHpVQymxGE071GdZSdoqrBX0y7uzZOz9gIWL5dfFOAxuMzp7iopx1LeA942flKXmMh7LypVTZ/phI7BiVtyG1lQeDxlAdaHDxBWT4mlrO2eL7/IwUGRYzxuqe123H6fjCAIeeLd1/du7/dRIUUR6mVN0cB2DXi3Kk60F8OZDFz+c0aQLPoGEn37pdFw+E8juBykUueEFAsKzTzFABWIu0FPt2d/DNG9BEVZ34WgmxBnoFcfHrZjBUHgqYQIATZCNR0mnRcDtRj2dEeX8kQWTlkIzqpzRXa931B4OdBAsN2teWSfZhWr0BWVEybb7tPUmlY81BAQvxMV6rcK4pEdgG2+daPbfekInXRL49fYfPmGLZGeuaVV85O5EYqs/nYh86MLtkT8fFI+dj+WrNdhHcUGhHpN88w5mFC1lgZvS8RbQtuH+m5uGulHunvbgcd7ySV+d/OBjpDmB6XJg6yQnsc/2IOuQoOY7w4j45RFeDld0WidAKV19ihAqyM4T3OqDGLhDYJJLlHF+eES3ikAmCSmZGekzKKjPv9Hs/YmjygcxBkCJlie0kxVxj0IGGTuo67jDnk2ENVeghfOPUydl/cQ7MzjNAlv0C5cIXZp9cA/N54spGsp5nWkRtw7xmc4jtcjDkhZNIQWZp8C47Jowu3LwHhg5WYzRe0WLLYHNHqsKcWslI5jc08m7hGtQc6XuPhJWk/pFACE82+nQ80h0CDhFbSFem62tCB7gsPLs+n5zb1GzFE6Y/vlbcPUVlzipcJxPzK0U5scD84DL7+PSIgF6xI/5w8q3mbFuOBKB1PEETmrHJ1E55vmRKMSGQ45llhCas+CFM22QDKiTinv4yU8nSulfIOkvE3gQ7hadtvnWjt77ELrFMtffG2COV1k0w/MBf03WSIm4osa5OoeZu4UlMiWePAm3bfCBqr0f6JYOMi69rRgRhr5QlYztl9KE3zVy7k/8m1wNDLYSJAeZTcv5s+bPCEP6NJ08qvD9UZt0+rozhjdfi2CKInqE7QvZvbV731GuonTrq5XUKTjUurDwtZYAfX9QQ8nmCP+tg/dn6gmVKgZXIffBr7QYCwUOwSQmvGjf35RcQ8iufS3hts9ZVn7y07xaJ6yrgVElv9eK36LyZucs7+b8sSkSPB8S4p5iOBceX3f+jc/hoJs280q/+JknIb/CQwrB6zuauxNIkoef3BH5vM6nKVHhXmzC2adKeAcHq3i9WTvUot5MYi6Dt7xuxQTAYrEPbHwo/HniIrzL8w/7Ge1cEN5Gz/k3Bc/VeGQ1PsYqg8mvHEX2uiZAMCDxYoCo8XA+MJOeulyG3s94sfvhBphsjGoCPU29LoicHNpT5zbcwJkGVcvfwKERSMK+bU0CvdbKYsKnTewIDyjz4CcxTf+Hm70yvthPU/Fw5Me8ZY0PcHdgJLGygIfEub2Ve7Sp7lob5SbdzolQEs/q3bhSbkDZGX0xlruwRHiLx4WYCTgeknInC2X7V8C3sZGE6a9p8zglYNVGLvVyMxvCLw5g2dykOUYqKLvb4+Erh8iAsHiANX264YVU4tTZXBVjWlCSEdBsBS4Wy/b4Q1tYrGiRbUtVXITFbHmBIQM4KmW5yTVVB/MS/WuZRc1fR47WH3aXQjt1NmIOgFFf1e1QoSpzIKr1rJPQ2kHhCcu9u+kAR5Zr64q2lRqxlWH3/qAdoIk+1tiB+tsL7csAntTfmIVFrTRL3S94UnJpmoYElw4axmonLNfYv6khjf1zGU0e1hAmfEP1qzcf4FzSz5EKEb0ScA7eosdBIxTfj/sTVsmczUfLwSDyL/fYoFbddc+oFlC1EQzlUeM1DAvOc1ukJe10APt8peavZR+68bCAo4NQWIJDuZHMCSmk/tu0TdJ8Pcvnb9qXqpxFacIxjXSgTP2+moG/3ELs8q+0pmvWvXPjfvG9zCox3JBKQfBMG3u5eOoB4AAAAAAZbJjsgbTPOlfnxQ07zhwb6p7JohbPib5BDrcv14OsX3UyjOnmyTYmc3ONBYmSgRw3kOrYtclZAB+t2vlRBp2MRJXyPCKs9mko03wcPybzzuAf8G1pnAtG2ZZPN+7OpXdGgVO8L6XhI6fCUIZ9r6ZBUYLiTvRpuul4O4WwH7aMHG/SY7b95q+wMefFGCx4DKih5gSUtKeVzc90vPb3qvmqJFst+S1aUibnpPs3yzb8Lhn6SX2p+XVgYtTx2w7Gx7UnRaK2ZUxirRl5HVHFEGocMbwVb6PMrhJMpvgVyxu7cFX9Og6W6Dzb4Nhm4xsjQoEJgX3cyEgpx3or3ZcNcJ9WEcVF7+mRPc15vzZhOgu5f52e6eOWwxF07A9zj5on25WC/6eKTyEEZwWBxKybbeFrDapWofvNbSaFcKOmQEsmp+Uh9aEvx5nBEavZQ8YLl20Lxuz8SVNvUO5WOEskOiqy+vl75iPloGs8eyoiGeimU6Udzp8MiQ7RhjMIN0H1HibdQIkghPqIJTvtAR7xR5KGQGDrseWPC+7MykEGZBtUsWwnS6urUsK+DovhprBN+F5iP+bR8hJAlgh1jbxxBLNM4g7v0qEMP/UMddVOkZSw3bd8Knp/txkJvp74ZaoTF/FKObtUB/eV6oPP0Ro/GfHYT1XGQFtoPNpL+UsdmcUz4QB70baAMi7AtgwFQQfIjr45dE8B6F7tYKpZgLE7cEGfGxKm8bQmFJL1Ehv61H6CEzUzleUwdoyM8b1N3m8b6L6dOIsFcxp1lsNLDqFuR98AusBe2JJJqZ5iE1FF4QwJujtpfzKivIkjgXzrGwlirkpRWajj5aE7GgfgzrkMk0lDDHScp7/YgOGA0lz4jmszsSgQWOn9SwG56uQNQ0sjY7SeDo96I69bqftNhI2w5OPJbUJm5wtcwePyrPfmgx4Gy9//kbqV3a6pv6iiZV6O/IF/apckiW5jqU2GV+t9X2GHhipRSmqLafebqAnuAvkCFJTdFGZoCG3Y21ih/w8KxamU+o7bQLbf2SfUstrXzXi4SXy14XqR9O4Zk231rACQ0m1biayGs6k77+dV/XAk9PKRdWk9zWAUphza9PTIaxhlUgzTq+vQ9L4vbSZdm8zSQxnesAZ5uRfxXY+2lD0maoXGZ++ohyGOrip3Vxfsj8uJi6kj3MfOWRma6wmpTRu11wf4QTUasALibSfW39ONu6bvB3iQI4qLvOApbbhJv32Z2Dxafbgzcn1m/SOljI91vnkl2SHEgUaMSqcLBKyoT1AVKrkm2FX66T8lbZEZF7rlBmH/TMkxhXCaQXdnXO3rdSFRwFX/baw6PM+3Xuziz3JQ5QfuJPPkAq+1O3qsuS50wriLsxvRXfk+6wNRiWu1Q2bU390G0RdPOWKb0U7dOcQi9Vbp7UWvwKQYY3Kt8x4AjepbDGx3DXzZ19eGg9dR2F5gS3RgEMYKVKmngHWdMT9/QCXAp7EMMOI0uZrVDtlXgFgzFE2R0QzIQfPlHbUir6sjMWTQlB+mNWwVOyU8uMx9sSNRaksHHt1r1nepVMXli+uETVoPot9cnFsx9ew+7yszgAAAAPWDm7iTW5rXrTNMOR6Fx0tmD1tzx125Y+dzsU8ejKMKXjzgmiP5jhQXowQYkIZgu08DvxUksynhMy1Ip6mO/pYAnpwgOROGHM9E+1oIFne9yiDMELzfCO4USoMumMzsh1o87dfTtRdQyyNaAX+NpAiZaJcfPmljk7jnBgwokrextohXHkgp3GYuOKUbv9yhKt6ViiZo6RPi2Cilf0K2MghM4yATXo+uHLUGQGXSqANhkSUVqKNpwMxlJQKet4xRz1RmmrTVsSzzPWC9SScf3prRNRXGU7sFSjDarWBIDJ0GdT580scvm3BA8lLI8HfW9OhSFOkaO/f/BgsHqq1E+32TWvD6Qzu77gypSGx5x1MkkMphh0RvH3j7JU75adph2rdJFVpi6mNlYY2ECPfyd6rOetHkm/cBaZXCF+PQJOqW0D9Eqleipyhi5qY6kR4wwgG7yQvmNZQ3y3GllKScpr5VXeMMXW5Muf4wWHHdLK11sY1aauHxNSkWnydWdS9sXEdlU4qFFum289SabTV3rcgApSDj0y15uNCNipAJY43WAAG0ZZYI2CAwc4Jc4TruwRjEnLxeyU7/PVXMHoejgEY1UWRMXClglWE9LzCHXiDaKJPDrPOGtxPRSHD69Kf3CJAhrgcN7O5Y3Cz7dgnIpuAgDHfKcJo69uH8U51SONtiMWByN2G9Sov61JPmIls9F88VnUONU4Oe+IfdJS+yQVhuSVABN8OQDrQzxw1wAHSScl3rAzAQV8Ws6NJ4cP8NSpoWku8eLgwKdQndQnVDQ4xp2YAMqAfQj+VDsC9qQlRQAMlyEi+cK8HV8LuAhfkGFpPzvpPyMXlBIgcLVprl1/NCXmcW/f1fXPxX5Uc9LLHxrdqT7aDSk/FfgWgib9rkcLD8a/HJT1ga8oD18e60hz0rmKXYcHTjGRyaCNTBP2nd1S0qTTlViURXQuvLDiM+8fvxIKai2QLyU+xY/ocLjc29S2AzdwS6cH4V8SCSmy4MtRfNB3kXQzt91aIrqn/sbH3kVdJVxnIwGkMj8XZfBVTCCRtpqHwQIwv2QjmIQbSNiDjQkbK9amBy2mB09bD3kW0HVjW20jQi+iooNNEtnCi/chh2x6m/rpsx9XtZWmIwD0Mtdjdt0T7F2PPZTCmEuOK/grPAU3x27rygWp+dnicT6qHiByvXMl7zm89AKT8XqEQcjjbwNfI54yz2VeNBluvjdLf+x61XxBR1ExVzsaDmZbQNczkxFMl2RKbPZ3X/ON8yk9thGgjHp2B6ypXyUmtpFqHrbl2wFQhfCoSerbjLp8kqZ7rarmXGcjuAQbfL7g9hIgdSfFClhW/eIEVeEYmeUEdT6XYWkyhnPJEwUhGA81qJOzoRjsfBnPOEVNRqwbcZ/5/33RFLF+hz+LDtSPp5eBsmPzi0isSUkb8uvxHp7rTlxbYid8Qht+2IPHzkZpwBLT315cChqMb26y9URCDBfpT7FkCMK/RNnAjfB4bFl1uU4atfZMCjC94gOM8mES8p54HkTamOYXFUqMSYhqs5eIHLPZqROLTjcvArynyf9wQjuN/1vLTAH27wFZXzytlkBoAzKSXGPE2DBAu0hlxLZ8Ebz0OjkATmF3PUJc3NUm2rgnMPet1I0xHh7VTHCW8EMogL5EjlOCkT5zYsV6n0ZTUjrL6nChQeI+c4dbu9+yT0KBp1h9pTbFjL+Er/AevnyQTQzYb0EQkohtvUPYrwuqcBcAPTN3E8AOYQ+DtlpgXpNM7TDyN+l7t3TwYRI0ppobSDi96xjsCBAw/HujAoHrYOi+q5IvCSxzf+AUfNpsMcIIPHMPY8WUx0s8SLi3YIBrRARLKn3u8Cjuh8xUHEliuQuEg/BcaY6oZDOksMhh8ZblAyHGf2maOpa3ouzCO3CPlh3DxI6/civt+KfjeqVTud41izlJz7TpAozNjVmBG5M2PwIeV0c3ueVF81YxrUuuRrjDgvVXk2i4JM77aSz7mq+Hjz6tsNKVfkf/goiNARtGxc7nRwCvX4iXPWEj+1N2+DxX8KdMrKT8ofBTcgq4//THEveIhnUE9go38ZGgWw9jK1hA3hGQDr8dWGZVaXcduAvYDl6ujVsIjBvKbYUC2bYmyMw6SKNTtdm5U/vxBFHc/FWtQhwJsvUFNzmwDBtq/xHmghmH7oxoLHyAISTM2l3X1xh9tgkgvK40S+5YeFg3yU1en1F1ldswyAccfU32vf1yoi+l2o79FsVF9qB7+jSRQdESo796DPQCMDkZm5vr5GzMpFsz/i3x8Y30kI3uOWauaCPyd1iMxTlxiFS/SRu00fGa4VkbqQvPa4/TDTZIqVotd2kvq6hSo0ZXtiOrTUNne0oVD6i32sypinmMa2k0LCt39NMuXmFQmbCdPe126PP2jwWc8xBZe5woeRfRlZQGRkxPE4LgyTmFbdOi/noEJ1JpwVIZULQLn9KNzaKqM2KTY1BVgSIW2U04hQ9zA3GREjKNNSiC9LoeH5Dg0URfdqhcpJOoiUOSaNsPJrDAwQdOuVe855zptemgzAAAAYYWAOBxIsZrGUtaae+eH0g6zGfEqMbPSP1aHJGufBg0UTbs9Syaqul4Y4E4Yj68Pqhp/SBMzDzffu47BCmLHuswOIWBXNVdr05L8nUSGGulsSvsszO6qYW6ufnXiVaKUjd1mSSKv+ux/bhZYGG7TJ07YyIUINitt60Bcexp0sptS3y1EIB5tOMK8ZyRZ6I8WxRCAtjM1unVZAVkq9wOig/rmxVx0hgQSRTYDP6n13rOMNoWBEXmYukbSF2c2iZJWNWs4xLZyYtXYyX22DVM9y1oLhjjovvxWeOpG7wQ413iF/fKoNqi4Q/z6L5aPm3mcGB2dF6pVQJWOIBkaZ87L2GQJNKkeB+fbfSpXTw/hvyi54/Cy0xHNTNEBiFd9n/7zkaBGva7ZgmSxkaHxB2OCRKsQNBgnwk2XSZ4HVAHFEfV3zJAKWbm/DzQ3DuWtCMaNLkfFbxgibZQXeK4jrz+NEh+xLBCfKavqKjtisLmfT7w+QEAiW22moocjVbn9aw7ps+xmRwiFL+PFoCZYXF2CHn1AwOU2lKpF6L2cVgrqzQ9AfR4T8UTOh+8woc2q1LfAhUSvd0VNYlf1hJGzXxUpX6xlH5bD/ZEF946gAANChLMBc5a6yV8ICc4hftocbk2y6DaeFabZi1msf0rIyagp8WxFhbYGLr30NDnsvUWVb1KA6VCazfxa9KHNFUi/fjc3WYTWEihrKayEtcCX++5mLZB6svT/LLjxpesu5TyRSATb/nQyMYNcZbpYnYOHHj6W1paiBx/y552XaBLqlCDUAmrBwR/iAIF85AVCHZ9PaN0cMgw5Rst+lfulPE0/jYgD8HtwXCzmg7HvYAz+dZ5fg7Yhi/7CAQPc1j2P435L6fXdN3HFGvFFOb8ZXSEObQoCM3cG3N3zlt4vy55/39RKmnmnQ5Rj1ZZ1BaRsJYTlRRQ9zviX+ybV0iNnrT+go+OOewvXtIm6q3qVy+6J5NCDw9Qj6MO6m/BPnJTkkSQj3tSl8IiVBDrtU0IWcgYahk9moC687CFPA2RnmQMq0m0UVvJ3thQymzuVAMooABxgthul31GnQdryEdclzdH7LyQzlKu7YKob1w7sIkwn5JMaVRhoIRBXikP9tsKcfEQivEwOJHEQQD4sfj9UIxCahjfEbO6UvO2KR/7Y7Q89gh1h8x/mSZXfDrhRXTRaFgKwyJZxJz0eycLWyYxdyKJN0lUtcDn104pJeWvqnIAz4eFsp7tSFOVft1/QH2of8WSoHdYFCOKX7M1IXbhwbzze5RMndv62hS+pPROc9Ihc/n2XzLP7ZVXQfpjUbzchPgG/aU6O+eJoDKYYscqrl7qB2tkMvlyLv5Q3JCtVYL+2O/nBx6UQni4gsp9VgJPbl07h+c87moSeqiQ7wUJVQzLQh7h1MUefLpfDnzH/RFKzT9gB/WS8pP3pdbTNzaCWXr7WMd4iIOeLynozaqXp2zieXLTxQ04yEEnIJ5+txIBcSLdzvY+O7CVt193akQoqO6UEw0RHgNXoAXFx5uXGMFaHdfk7L72jeCweumqja/XdyriBhtLC4gVStu+eOsQ+1OvxY+QSsphxVpz4p+zwQWX5/x1/HPS12IrKSiOp5u1Qbr/cHL7WT1Qan+iJQyw0fu55CpSZ9q3yC+yp6xLosE+QUHT5n5EszXkAklX+B1/+WVuax/tS29WwVmC0F5nCFaCLnZtPQZq9zpisYgkqj3iKanma2dSY8FI4QpgUkM0wCKNBzfvbC/Ll2EBU0/t05kh4BwS45MuiDqQiGPgE1s1D6kp6gvjl5MQ7IIDv8TYc6cLXnqb7Uwzc2JXRehiB5/4WtK8TNHckn+feQDbFXAiV5ilf68nMF3JKqqpXYJgnA6Ly0cEVuDsicHH2PJP3aSIi2rNTgKl+5wIbU3g7BtgXjmHhQQHCAHP6LwVO3sJCN5+LOy4FE0L0qSzfH7IV5D7bdpfxc9MVpoOoymOlRO9ym7VCytpEkuhNYA7Dgv42YDFx5gzxsnwC+lW3AJ06WeyCe7cBYeNVpx04iPam6Z2GE0zyXmVUDqo7N3s5dG9lPqsyWckLl4j41LbDXmxkuWcFfU9QJiVK15nh4d89a+2w5QgdcLpnZCBeq9t7tPXJ/LDIcvbABFdqleOryYRvuqpiDRPFRFqv/367wpYSfFLzKqJIrlWDaLAs7fP6v3ARcqJ5hLr7sOPm7bIZh0MgCFszldnC/r1/v6egOIZuaBA6n7UInRkvs5B+S60Y93M+PIfJ/sWcYYaDskMuEovuZUx3qTBpIKCEekBX/iiUnkYz7XVLerUta5KQtb8iIw+G8ezuvgCPUbgfQYQIKvJCPs0soq1YmfAkiTgbuBClsbZWJEIWAFmfk5Wt+eAAyvVL4b5V72392pmYl62G+G31NR+l9y268BROqo8uaBdSsmLEA39QwJ3ZttpULrj6IAEicmL3F3o5TsGWt7Ix5MJhnlKObAAV+xH9Vi69l50CSakRNeZTOQ5+QPxR8Nr2gKTWyBqWeiyojdeZfKovJE2+Vs11HhbgyTvE66VS6Hk0qEiH+wAEnJD/SWCfFnfPl28y6ReFepy6YJ0SOdLhStvr9uY6vDk0l1zhaUH6Y5IdK0jaBReXkvlBSNNnKLZWRBhdOAVDpTGQr3LfhmvONkuIX5xSgKlT4LBXE4yolHGXRdmQyyk57ItRp8tho++Ekq0N/oUA8p2FMzw8wdo1QlcA48ucB3eMvHHfwU8IkurFBMGppDelaJf0OrMl2BhmXhhTj1t9xAx1MkIO8z7pYhL3wl2T5b2zeC8frIs0SoVURioUIifMGkxq+uJypJqp2P+cegzK+jlXv6szGm+qiLZBVQ7RkhQFpFyLZdB3UdFyAHdk4VNr9q8Frf7HfdlT5QsB1ksUjvFFF4flesaiHtuiAkcfl/6HGbYl7mD6GvQY0+toBc9u0XnSI1KqyCWsU/5RrxGhJLgtsfg1vpsWBKiOIcKoZsZ0UuExTsMwAAABJt9zoTWnEn86WWgwg2QgbIdbCPlMyzizKRnRhHPhRnAzylUjElhmqLJSUomnOod7Tkt5JbAB3bKUNPITsAmKAWKvT+G7/MilZ4KLbWH2cXHnkFwOEkRX8KBlBztUqr3oeruWrd5r6uCbkbhS3bxGRUd2DUaYjR3C0Aik+KFwmxzYRiLqKDkTaYhNtjClFkGdNwI1vNvJ9DBoDOmKKuZdANbMgDfhkClPG1WaHRIjwA5bMtYE0XuAAAAAAAAAAAAAMHZhTbhbAKsBEtgPTSuQr4UFR2gCboKyMHNvsoZ31b/h6fvp//fm7plvWLYU72LsWfJpa/EKZQ5iXO0oIJqwEuyMoKLz/lHYfZH6XaPbxxjHHRNxiBqxayYhhT6i82LgEjzYMyzAuNtGTg+yQrdtL+pKjr9JtIu1BsUaXzTFgjytI5E3ZCKy9YDxZX2L5SzRsG+0tpTVQmTLCY32/Q34JbMyrwr6bygdXgISyTn/JaNLf9lCmFMj07RXysjBTyJ7GpcMYp0IrEYWUyMUMjLaMlbVeZFo29NlEg4fciRP3EZHl1PyhAlRfQmuH0IFSdtNDIhIJ0IuF5LH5/mg9FHQZ38MJhVJ3KVqGIxWFbCSRS8Irm8S+CgxkX7rm/IVauCizLC5oPRR0GgSL9ohFQIOpfzABdG4P2ynRiw80j+IHDP43T2gzRFPb+ZzdD46HewC1b0p4rCAFNt9gc/NX1wBPlG/ZJ/RiaKdhBdW4bun76GWKRRe+9GPIil3K2MBhzQTgu8U9gVzhTZ7MfMOICgRcY39L+7ri3bXomWe6HvnpeCMiNMrQwtIB09MYIDrstMWYJp47QPeCVb32BCdSDvi0K7lE+Yyx7BrjGi8QAHU7EvmtbIrt5cErooFU4AbaRAddHYCjDUtetkBC8kQZIKATDjVVhYaTmnHPvalqr75hAIxC88MCf0iD4UOFC7EfqaWP/XqGOvlCYNxl4tgX/M8SJ8tpT15VJatW4t2zXmw/u1ZYu2rsl+WAD9+LrojGl4ADEXac6Wnl//Aitvt5N4nz145b6vHeNkMMBvPqFGzpqXmdDaFRAp9LHf8QDbpuTziwlk2xb6fD8KOtrcuqgdukBkKLlSbnWxTyprxrDA4+xTM0HL9qmliYN0sD1NylZTwrwYjUJkyIUaLaWKPsqxz/ux1D80SPkqy8sSGsklY0ILxr3uYeWo6xTxaoO9RPYcpgVaSiworpJljy+e/eJh+XroRgWzFId54cKy4KUtTiwk4WX54YdAxzb81XysgqzfK1Ub0NNoloqG28ZC6x65glOweEr0WQpmJZcslDH+oNBCHt85M4lc0iACzAeQyzJnzGXy3qhlmgzkk9OhD/a1lHD1RqclNFeQv2MwGVdZro9CFDfSqpME3tnlr41MURScz16lVWH3D/7q49nh+wYgFsktH1Jq6asz3xlii2KFi4OovdWJUxTsUssWnD1bXEzTpRZUu4VB0X+gdJ4LR44cAUHp6Hov2TBaqVpaOaRilCmOKnlElVH5ru27VLwLLKL5J/RqiouCyqRVfFNW9Qs/S3A6Jl1R953ZV78V2+i1loZa8XHZ90Wh5grRFRPhN9xvl8Gcfwso9iFyzXZclEGveZEy8MV/F6B4keQiVdCn0X/EXQosLrComagQudADi22xgKXvhu8Daa3Vcoh5DF/yP0DWI9QffE+TjHkUQawGfW+N0y3smEMHDn1mgPRaIZEKT/x1+/E5vrxGzyE8zOtdaEIw2YRhUdYfbUHSWahfE+cR8rFiNoV3hUdgnvkhFvVMj1Vg7O9PTps7sIoAFaaaNyKoxQB0HOSAhmSbYYwBZZWpdqiYE/+gThQyybHDZFQIRk6Slq+qtBZa5DjLXt+/Chz1HLj+w9E0c/CH06pmEcTQNPl+I+Hn2CAIhCugUGs5SAa6FZPPHvf9MHNrPGGyqyOPxMSDxvvUs6ASqTgDCXIYLijR+m5CGs/FjpVzL7FXsUx0WhNmvwHUr4SGRmZwImr4Wl8C42cQQPaCIfjbxju7SZ0uB4VXTnSTfUA3TBei4GT329VOnYonAWYaiQVgjKk2riZ931NuaaDqQm3/22FWbLwA1d8KLcwuuwDEAbgpLCndSsVquK5znBk6/jG+T43+i09TCUFsLp63/IZ6b+4+9hM/BSrqh7mAo49KkB+IXdf94fz+1QcTgW3MoUYwINwVhJs2IrvZCfOcrjye8meTX+B8LPUXVPt67TFZRPLnwMKqZ+D8skXesUMsGVa5bMeuvkTTunRSk3DhiBikjJsIbCJElPhZ6x9c/K588CysIyH4Gqh2kFkF8NWmSKqkQGYdnQhxiXyrSYz9ZgJZeS7zt9uhrwnFHJa09tOBnsmXOgkkak6M0iqJ4W+R98fnUFTyUHWZ/RR/c4IHaN1XlAvWjakuHylOn6RYJesbJnSvSr556xQhRdjXeHdKQ7H+7Z029gLZkPM/mu60F7ZHFlMRwK05zAuXPaLbf2WhSmmBQyEC+5p67oweuXXFJeKVtKqpoT7Ss+NtwsEOa7Rs+hGmeNI+NmlrKlKDRgYVzK+vXXImJ/eyOLJyRfF87T67izgyhYhvi1xDIjJEKU5CWg3DS1pDHSyoqPYAhGybFXjTlHX2mv4rHhr+zc7s849s4UTdMUM9YN43USPhXeZIJcgXsjCxRcaPOJG5cbChthCoOztMyEbcvudjBf1k6cCtHICaKcWqP4rBJRYnr7Q6gwC6DVI21CxoGFnCfnWao7JI7MsyBgGO5hLTt++PEPnmENbsIQ1PgUiSJjOXnK7gjHAWzvVmf4RD39TDDGe7cWkEmw+Jba4Eq64pyv2IkUyRLsbnLZvCPUOpySfZwjKrreNn07IOIfHX5XQ9k0SZRwp+HB+dlWUyi7qDuHTfLBtYAMRHKnMxGGpZBrcbCFScZBu4d8zakGyfLkl3esJFZWAJ2skh0vrxpiGuAbK5BoF3gAACJclAyTlPtWwh0bkySItTxphGTAHct2b9/ELt1dA/bzIq8gtFnaZcP/ult1ph43QmUr1IyJ75+uVTo5yK6+WXYjhbB2PGzbTuXxTDseSkblzxphGTBo1oLNf9rnIxBYJ9ZNKB/djODasVLX257298qMVaLSCyocTbOBF1oucbDRQMwChuNm0D9NnpO7qzfcTM9ONKKF0P8yquhDnVdUXewai8G+TprnWYo2iwu9gCm0K+VfUr1aOhGIh7Y0zN8bwEGcX4jWig8Zpwnu8T7U/mV1ddLG7uWbbFwb04+9cPH5lNLk1uIgrlG7r2zcbDdzsndzAmEes2BeresP1yk7Tno6DYT1dPcp5Sd7yv8wSvc0JyGJbuMkQOG+OIaDHvVLWAfRDrcrbR5aXGNS5JRdMpnr2tcoZMV7zCbkQNJAzgrXUwgrQhh1N1WvBGCQoklxLpepkli9CILRUOxpNfF49XI0dEgt+d2J2eA4t9TwITI71bNlycYXBOcK9TW6ruPe+cXIkSLhsXMxTo5Mu3+xIs5CecHs00Ul7sDNC4Z+5LoMxR76/gKdzMrd/4JMf2jpdSHfDSoQclw5GhiC+9gX51IWlvVmvI8evZ1TKc5+v2a1oAMa+IJ5kGAzj5VhnS03t+It+9FEoP6J4r5cDTA0QgldPcAqKp17GsBviUqBi4yMnFB78fb552zFlBXzrPgQUBsaPjh09QMydKzGks9B44aq77BThfv2QhVmQfSQQHkx4rh78PXFbioIQyRzNQL+evDUkEGtqzYEwQEa2qErgCtnixK2a13AgLfc3wqbYrUHELUVC7wxEhY0ipcr4cBQwdFBd9ocxQ13wgDqw7lrGTo87YdkAywRK75pYNwWudLbKPVI0lERPIvaNPBmskKFxC1l2npafULfg0jMWhFQ/PjWvRdDp5Lf03ce5QWna4acFbSjyJh7mYhviEnnK/bBt50wN81xBNoRl4rGytAOllm1iGuEwK/LKkouT6InjupJH2wSLSDW4dfSXjt3LffDCFFkP0tsMdDsIPX/xNiMd1aW5CJG64f+I24/8TQqcNSrSy2x19EDLcv1kOv+tYYg22MqCAAAAAAAAAAKQTBUQJ4u/wjqi4+2tj/7v8LqWrXEBLQDuzgsxLd1vnqScQ/lDE+jN/SSzleq4t79w91bjYQBHNaaJwS8ur54yOALd8KnqUSPlGDVLGgfvW3tVSsW9TU6s86ooX3dXcQTsCVOPgpEBKrv3rLFKPym1nrfoiooTB8obu5sKkNdmcueieX7WSqRyHrE1q3nWmOGsJGUqsZd9yTsojeIWb53EOUcg9zjoDbD6UoIrPuJFBrfU1Rj3eVw7/2zVshTwDfo++5xU256RXZUmieBwBHYIet4YvhTH6J0kOn5BVm8OofMB/FptNOe7zhOn1hbWHXanx0+o52JyjE6o5mPftpjaEKz/NDqGX4/5Myf94I99GGuJDAaFNGs/3/TGqcBF16onfmvzlLiYdDOipgrQ0DUMHYD3zhdAHGVOPg/Q27rClBT30aSUHwHLhlXFbNL65I9XwJNNSDF1R/hKdtmDmvbj+s0CoDF9nKZxBNhP2qvrXvLekBUaW5wUNDaHJ4VBmJoamoc+Pqla40tepJHnzoTBk221oBTOIXvBhe8bkhjP7QAxQ0atjSY0bdaou2OlZKmmfjwV2dyUjQxaNV5TfOApMShgwnrywJDW0aHQRfPaYOR4PqESqWDMpDcb3dN9x/dGyPFy6fJzJNQ+ke1r1mTzlx3Uvsmt1+75Y2IPeaK+l3BKCkJuDXFignt+n4Cz8qMYVMIKmFPw1gDBgty2LkvN+EvJSaBAv8MEigxKMZwJaQP/Q3+sZn/FkDDDOisLUgHstGiaY0JZ3OZ/3g21FaGvZYL99fihyDfrCtezARag0PeEr4veLVyt2/hBLCzdaLgL9Tb7yYiPniOYR4H26fIbTM+LteBBbxMKOCOrg9O8MppzOFoqEN0WyQR+Pi5D+1+htOit0vL0paZgygTwxrqkwNs9J6Rt5GBQcyk5XN1lnuQFoxu3r1Z0dQJ2X4vdcq9UK4guqSp8nVnjTrPD4hzPFN8k7HM1HKhORp+rOb2ZMzD8YoBIhB0BQM6PR7w5rBfaeGWDNB/r6WlVrpR+9b4F4Fs/2g3xOYonf9Agl3E2c4SGfaz55lHgEO+Wilva1BxMAGldY4hAOHe55fDwzVoeXFd1u7rnx3Pvj51YytCHuB5Fv4q7cVDq0T/koWym+V7HGolBdGABpMMJ2FSgJGAdaQAAWREY1K4l2sC8jqV61+/2hc3zt5J9CTRXIptg2mGR0AwfMRI5J/2WdS0337XqXZtrPSIeBo6o8IHAZBrG/O5Gp0H2+GZn3w53rBF3Pq9U96QhBNzUdspDocIqCneHIe6SM22CAN10RwpKyds0EAAAxe0WyzaoQ7TrFVoS6bIS8CG+kHUwxpzPdaXRkAFQwkmugoY5L1M3y00rJXEJc2eJmnlAeb76jTcKRlx3SvGMHufUwraYgM5d1TL8EvSCVarB27NaCvuDQne7cizlUj7885UUSRVTwycIjqiqXTxK8ItV4Eg8yH73v7EOWlcnrBVaKlE/kwu2AKHPaT8tYzs8HNwL1M3xzLfVttO7XXyGTzsdlhwczgOsHxCuqMXDa+advhVHKAS+8dyXGGdDaZr7AzOtcePx3TACaUAmJRMAhc0uEzfSrsi93QhhqGvMqwp+tjMY+3zT2ZlxZ0GZbUiu/3arqB/RSjQI9+DSLx+s4xjb8CMktfPGP3H/8L5PJ55wqq3a+YMEHW/Qausy1YtufFq7RwPxpbwHx+HTI0XPKxblCyOYpZPps2mJv9HCawE1uwuF4yimuF/TYCxT5eI7kQtRHaVdGko5gF8tx2HLtbbCm6A+qMIDVlqNUplayQUkPRzPDxei18qkmmvrwTXRerVWLvCfQvkUTMdms/XYacC62iGW0A74ziQKZRnoU+gZNu3dOCow+6nlp2IdbgQH4JJN3CNaEtOMyn5+u6EZ4nlfC1JfswZLt99dmNYm5ugCr2v4YAWVLoRSU7MTxbYly6uR46wvwbhrYqRwdxpmue2fGpyTfUCx6p948n1xF7nfb79hhL4DI8I5hL+ywnd4mY21PZjr5SehiOWaCQp+EcM0unLNjjDBEgoGKPGUqi3MV3TI4eDgL0xTsWoMwQ+gjzUHlTrMxzdNWzuWzHBtVKvj50z9IEGUCNg+cqSqPz2iScV9vPP0hiYwa6bsfDof5bwyYywF7NGBwDuG/Mt5khFffCndjpJs4G8BCFnzfLlLqYRrTDTRjmHIT8YQrvbPcnBUVzW4dI8faPnDASch4WgFk1YEyKr9cnOpXI427XPdfeMPlPNClB56i5LqPIki+4JCEY7v6b1Rli0PTR0Z/VHspNLRsyhdXCn7OHlf/SEEMX+t9waVYOuok9YPnUOCmmBuKYEyWDRXqBl54FtI4d7FoXmRdeTUROVj2caign/7jTZUfy6ZO/0c/UW2nJKfr9Uoghc57hzrKITDbWR1ZN0qcAEKKGYsPbncNHtmSJZjtkpnnDuxkl1tf5NoYbyCQa5tXA+s1gGbIeO5BrmPBOdzq5lWNshe/iDeC1uorz4hGDLQ6r0NRginOsXG7+f3B/9lL3mxKOss36VYoby5NT329QtiXbfi/Ke8urMiSQIlac6Z2x+pfxvB5jeilii3CHqyf7d2nE9sU15MIJMqULvSaT0243PEc/BfiVQ6iHkWw/AE+RYb0+o5gNmHIkEmjDCGxZ5WYHwctjT+bKUWxFU3ZAAaK9hh/QY5aCog8x0NVAoK/TXs+jQp5FTepKTESK28omat81cvZdWcICDPhgOpVGzEcLO9QHFLYDK5bwj0UyH4zxTUU/5f/XpZD5OBIi3KC4f+sAQtEwWjG5ipIBQoqpkbXgnG893TA5jc3ZxzZjdwJXEu/2ycYLMhHDyX0Co3bE3fsfyXvSXPaQ5mONq/BnxwFtwjfRyYB1XXCHaB0w0DbFDGTMOafkYFqcAj0vi5NXca/ohAtENfrQXfh2kLJPbm8t2GSZIaLsHRi05uDcjiLVS9xgpPqxhm1Nb6GwUQmYw2Z/09Nr6bwwFEUe96BpQhvL5xH56Py7ARijk3Gh8O4GSsY/O3P0UOivD/RQAXne6mqp3in28JOe24jKGxniSbe9hfSlZUBhZ6+akrJCDfkZtpVUw6/gO65JMJnzaRbHknvtYdEjQa4by9+MyUa78HymLOiOEuKhEmnTw/6+kZy+x8oha1ZXW0RAkiAPI47+LVWvGXeomMTI1P0sIMDjrKt63sG9tTV5zCjBvgDAc40eaYLwWRbBZ5kSLK4O2mt/Xz0zJhjJbnepd40TYcM2nw01ZG0h0joecQ/8aS3hXscEqzOhjMAvHoSSZ7yqrfdtYtx9s37XCERKr8W7rnno3HGGls31h60/MnZx1vYVV8U5fpnQl12i9XOgIwNIqWOLwl0MU9Rivt/Fchapoxdsma3yIaDXbIGiwxn6hH+VtkWrZMBu8vpsknvf7+JBwdryVNZwRpPDBNZUpdvBtx1xEs3XxXczmW3/sijOwhkqTWOGKR1eG7mWfuOAGkGIS9cJCEeSciW5jrDb/Etu43WhuA30zPICsLjci6O2sw9AYts2QGX4IkiaU5XNELq9PYAi4nKJ6a40bWtAVpd6BfvzgMvwRs2UcBmVbN++24eWqZ0t0SJmiIQ3LoSdLbJ04nkKXMxkhhrt5vt9giNPiUkeW6GKl6WLNdOosBv1fBDxgyse/GaHAL8boQQpOqrT9i0F3OcYfNJBbwpGa1+Sxm1ezKBi46WVVbSOJi+KPPGliqacF9QB1P/A6BejOzTsfzdfKf/PegITmD6xBFlZJNt4gzngwXniFRdosOLdTNBfkNwS5y3m71Q7LQ8oN9RrqJ0Jg17uRgli8QlSefs8lkBqemc5Zt9WSpPjIvUzdRegYmEXEPIro3vF3R1iBwQ5ROLH8x819YagNk85r/0e44la+pYAwtZtpcyUv5F2pGj1bjxOdWPf3xyKkwOdInlRHqw9Jieg+wlm6h4TktPueM8VFJu7p1kTA4NxyQk8kMlird/jFqlW29cnMYLG0/+oBwdyyRfFVaqXcuDfBsD9hYwEvWdkOFfZLF+1LfmNfTLo4qKgLbp8k2/McjUyoSV7riT8xTUT4pBrJquYVXUUgbhA7i86BtCEjr7X1+0jREKg0ShQahbRmxNNaay9M8kTb9BrzNplkboRdwdXXHiVAdvRWpTBrrVnFN3VvjpNjpFTlbYyQY5sMWqMz/Hh2d9IhP6dAmHoB9MmSXYa/8/xG7vnSDmf7zVXqQDTNgEOWaqGaMExKv88WNZmZrgGq6lWlUEuPVAqUV71O1bgW8XbZamme5ObTbxp3pK7wtExOmlRhAx9wKQc1mwE1DwPz/1VqhXKSF5PEIx3Bk4Uy4uLnisx3CovhF/fC1rXXVcy3t0UBTHcrdJ1LAAAAAAAACdfqYjhX2mqjV5FGOwSerQiyjbzeP4RvKcCBxZzX8M3WD77Dv2Bir7pSGdh8LxMM1zADHwdZxkeBDYbpdnYEmk91ulNIzWxM5VDe+OfqwPuSZ7Z/aHJfZIxNHR6b7z5KdbPas6BpOknvFPuxkM6f6nsogrn2eHMgI+tH88dBH+H6IWF+Dv43KQQjqoO/ss7D3vudSeYZTxAu6wnsfC9L/570/slAu1MTPnDbvT4MzHU2zntyeP3GhIOJARoSj7XaJISFnp6Cj5hfZTNPrfs8VHj9WMopxJ+ogfiNUh32VPRJ5plQvQKwyEVVtqezASbQuqo3CwmPR2+1WdCKqM2za+DVz811ILNPQTqYFe4XSQ/RcwJKmMmzVf8iwZQa4O7IUjwWdpGlkBBRlJCn2i+HLHkI7+BaOfR3/zMeenk1G5aqJ2z3M5lpWOCCBQMLGXYOBlnL31eVsIeRHfyhvjm73Xeu0y97nnroeGpAI22MPw3nMW8jBIidVmEsuxjbSVilvHu2kTv+Aua6/CFIDVIefNf94fz+kJqOgw31bD990hp5qsJLMmGjvT8RGOowfK+5fc1EzUoTL3QTN9u4ZgGGSuAqtznEnBZu+z+tUpwuc8vUKivT4jxG6MCcpMUd9RVPAC5hf8hRkpt308fubid2DFHDl7247B20uC7HcUkhqAMDFX1ek7NJdlvFG9UBC/RiuQAiRimVAdMUwgKnCxXcYGumfhgUZrf73wZ/tVXbYZbc2I8eScbogZNehAyWdRWL8aEu1P1/wStxTmRZLtHPOBKeK0vE+0r5KD4NeTIdZKIf9sXAiVWlag3XMZ1UVJHem4+0vnlLsAMjwgCQhQw6gBOFn3aHxV5X3dcBHzZibHZoeNF2QOzu6nNnj+9wV8/tOpGJMFSfBqO7ZH8tB/MJ5ix8ykaAPY4/zN8PjzqOmSOz4JJi1djmFObiEixLjvBudkwFKOz/FqnoQbFIdTk5zqPaGnO2r2RECKO0Wl9AwxBRdJU6QUgJKfhmhbs9SvRdrgZhxXHdm22lXG1WQD8shUQ5B6sRChUR5EiJBBiQYPtakPppQNHbhikzxr4+4+GGtc5c57zCBzsZMBHmKV6lOWiBYo0d6fiJgVEpAxEA7Btp2N+Wr7TDgGeopxs7G2kJTF7t5Ucf4GAzQr5cI3oZucTdHnZgQg/IWuL8Kgyxq66rTPn3qiLO1A/LAlXE7VJCsizOSkQXGg/G1nNVWoxY38U1Nh2sp8hfRKWnwEl4mzMEM5pfzTIgttAPcMAB4uXPop23RFRaNmYnxRuLOQyslBIy6ToROAiVF9tRKhkJKccy/HqWE8lQ5ACbCzoavHv2j+8l0gjNEWNxh7SjBKB70joA754pxt7QaRm3W0UubmytyTb2LnOb2nKOZHSe5rX0+yKABqs+4Uop1KqjxyHvCC8oWCe6kASsynXtpI/bpPB8KPgyNGuSEPhnAUuFs6/yvpSE2JfGz9uuFtVvCSmwIRyOgY5/vAPxx0BZaxsbE3MnuVilvZZXMrK7Z/QQVuREs/5HY9YcuLrMzp2C7oKelQpY/giK0JP+AgcyAQW2v3DePmN4RdkIn/JmHf5uIzSEpEVp9vUss6wAr6HZ3V92AjNJWiduOGHP9JPB3kG34Fa4ZLjjbyGCnZB7L2i9pSVNwA3f1cAd5HrXjm4GFJByI2Tv/RF+afvFt6HhNZ4/hHBw9C5igL1EapYmkQw8ZNIhUbz92prYpKAwNCsbQnfxIUH2gdKBagejRYfDzLKzafAFS24+Ibfht4MzYC0MzjbmIK3z4oFkkA6Ir9/RjdyvmLKJE1a9uoY0TyCy1jXG63saDyQh8M4ClwtnX+V8Wf486FmFzqkdv2LBeuF3nT0ftzp2+Kf9Bxhb60tHaQmkOMdjGDA5sgm2ld3TqqMpfRHc09SHXybWDqIi0nLdEcIfD8OMRWwoovckmxVKHQKYwwkbTIyOYCKDov6oNajjtIDKL4UYqLbqLHgNW8w1gVR622E0/4orur9MW/ZtjyCm5C2JtMEnuBgCQ665G6Km55c+pWYej3AnRK0fHHHJkmgStQ7u6r0wzeGviRiEr6M9boEdNAYXveb1Kvm70lgsjWvNwpX1CNhA1dDHP6uXGJqIBH6EAOVgwVvZ9+NZ1GD/7NrSgvUmzEm3k1/aV3wi9qjZ4LBUyVP0H89F1fh/fvsSos6p+UXn2b1kDThumnDMQunoyfHhstK5aQEhWzPQQCWnmJmI5FfFDKTHRD0WTcQegISyY6/8yrPGPmWW1Ce0s9LgRqVCmpLqvolsnuGErW/Nd63LMQHTsO8tOGbwEFn9cXrOHyDgNXDOoZfAsGCFzUoA+QNp5uTOFFyRqOL9WbxoVyzeBMLmD/UxMy3inn/ZIQIjEfHzmR8mBv7UTdSgjOmY8D3u5aWEJ3z+3JDRYrPhs4QnzBY997I2VzAhUAqdo1f/ECcs8xbc8i2Ojwzkd5EnN565nMMNRmCl4JFzt+FRWEdTYF9PLn0ufXY3tQqK7KGNjl2eqNjZjDsb7nE2naiXaMsr3fVYBV0pLbnjTPPDc5UFUoZChsJgWoNZ3ikDgeVkFmw5sEltodK4u2cNvKJc3LRkat/o6AJIyYASlWRYVS5Jdjs130spx5BQ5HoWo/EOR8SUldTNuJB0M4PSTFPYrqocEe3+yZUsDRlkzQ6mT49KWj1mEzLK+jgGE/FlpF/yFMTdIq+wA7jsKKdZRn5mlxE/2AHlcaGNsiNaA+H/Bk/OVteCIigDL6FV77eUaqeYc0P7B3jWf2hay2y3znDAFjB+6a9gEJazDNopjCx75inBcgBzz/CbqDu1FzdH5rwkwr4kRpuMeMEoxHdJ/Bj9pSuQGkqhUg2tjucR6lMEAV8VQtWMvg9jHLWLM6ia6vsBenn99L9m2ZmTQQoqmwmqNrbMO8u8DHLolj1OfkOncckxdG0lodbXwX+2y46+vGXn5x+FO7uufHIla41t0PKekdwJBN18U2TxDC6Nzb09L3ECmrtJTyhyiedKXHgm96UuobOueBtrWylISIZ0QfByNZA2nfZn8zEC7YG3f7K5wNS67+0w6XXCwnFZ2fHI9ZwQuP3kWYVPgCOtyAdEdTspNwNuzUbu6zxlJJPX3thuLKOZidyNr8qeh0V2ABxw34dCjWzPLMFWGoJnNU33jMiX6c9MIYOFxIaFKkMhQ2EwLUGs7xcBRd0U+msSUw/OKi4KkfpWjKuaDSUzHmeToF4n6CZmYQpj7lmQQUgzAHbes43Xerg9t3NQkTmyPGalrC+WLmspkX8a57n3zIGtBFHHW9dU9gF+yTao2YNYaoMKaaiWyKgLITnHetI7fM/DuInUtzyCLTRnKDUcAbsKc70Chm2omnVYZ7wuWhnGcEgML3PsuHP2b6ZvPzQRq+pHMAFVwael1DVqhvSNC6dYPFYPnTM8J8FDbZyp3KPa5/qp3ouKNaGo8PlcNxx7Ft2ekxXlEbgRPYTTvSZxdKym5THjAvMPXfNGK41uV3/c8ISjCNrgUnIHoJxzaVb3BkUqgYwETPtXIQ5pr8fiv9itSRw3Jy8nIEErp/BDxIlw4F+mgVh9fu2uLhfghPeaLma3psCBrV3A27NSJmmrjiaXyBurtnotSb6pwK+xlWpRDlcs3lUoXNSu9o/X8akjU8042NYGxuYcnoWUYSwGcv25bOOgW6CRsP/2h/lzmlQrdkxjMGjqPYHMssdm4qgMDcQraSVgZPg6FXV4T5L/GAOQbCCO5M839j1d6u8+pgQziCV/Ma9obsbC+UhvolVMwpv8EzA54Buwn8LnhA7SEL+FgcmpRkBlOdvaAX+6402IXmSzgjodYMJ7iDRK4aC8oRfp4dP6a/sJFaEY3EAQpHt5Z833wzioZvQNpv5F4PP8eRELuF3080TR+qLJj8CNUPfXkUJXlhv8KkQxjh6Ho4AeLKASf43GjON9rFSIQFwLwDwvXD04SeOh4O0UHUhzhS6gFyEUJaS/1CYuNQGPBQOaJQ7OGbknmLazw/zeZMtNLrxZbAhW5HdnlVFebAOY2JUoE6eRpIK6SZkgKsde87nvxSdcGHLtd6YN4Z0AWJW7Ym6OmhTZENlvIG9hBAxVLRMSmTFyx3hUmwWFavwMIkiF0eaFDpvl34QmGbE9CS4ixjXbo1CXDQxt5cY6KrWh7RBVnUlri1ZPyY8gwwSyKvqjSs27TGborKXspKYKwKAfkup9IpkYc1LRK+ebS+pmIpfRe1lBGooXd9sdm0SGO9lkU6ODR1xsPeaJUXLcNsGQSfmUyvUlLw7IrZmjgSNFhz5wFR/lhPbDvE9pSeXNcLO6LEJXvPrN17KWIQ9+N5R+m9aHGx+fYh+bCUaTlWaZti00QEmfTikGgAZtgANPlNrB0gNaDOFmcN4tn1gc6I6BtP5BjYs2RaTlqYXuoLFqdU5oABDq189azS32IEcT5ifdhY3yzWgCLsVs6aPhtSpIAKM4bxDEm/Gcjc88gaHERhNr0FY1AF0ufvYzkwrQAqR4n7JFRVOOPhC9Z5KTEIx1axh2VZyHMh6ceVwKBUOAOB8Jt71SefFE0EwLYRmLAX7LHC87NMY0Yr7d0HinUZyc0017IXI7PX+4MF11NmbkyqtiApQC1k40SGRSPPi2icunRJq7CjRR666imAjaaJRX+v3tATLUYDEPGXxqhPxwe1Lq9UUuTLm86J9Q715Pf+AUnXXYfLSKA7ALQfOrjY2v6xqkUDBlJxjo70dMdjIcOXIgQiWFOmUqXSjH3EZh7cMqoRa7qHal5PPILJ6Td1ms6CH8LgHZ8Z+ugT3yQqbSM3spRUeI+QeqIe6RVpQQ4qk6NROlQ1qKjvmh+YlPxqzl+UCPh0AiRUfj3CEzgp/uUIMJW5B95j9+/GEOQNAoKZ/QONOleokwpv8E+fM7MHTC6abZyAAAAAAAI6vMKe1s9a9eW/bkfgCeJrkjiJViOFB8JIfksHjiQkTRhu841dNpQsEVAT6I9rg5qHUmqT6zo6mhDY3Ya0H/vH2se84FHJqYG0i/QhA/7LjBsJ0VqlVBL4cnASYLMV/3h/PqgLffXv4O9PYU/LqldXlTqddRq9NAXVSPFy4vXl0HkrXgwqjKPZlCCdy6Gwr0mzobbFh9RGL6/xNWLock75a0MH7/Tb0oa1xPIt4qODO+nZoW7Ol8oNpgox+z6fmsrg1cyBefbqcgI7T3TP8tnLQJIeRqlGw772wfTLTa4ljTnYXsCwezoZVftFjzZxPZqKQ6H+sKX+AjSOQZ+CiRDxY+AA2CkQxBHo/yKWZdOn+uxEagBCRr/Zj1DcGASbQh0jI/RScSL6O2+ynz6cLc64oBLEun7cXYWNh8iNIWh+n2JOE29TuiXoCJGlLUnofMopbG2ViRHIbrq45jUbOsTHCelhUAXRLOuNzcgbhLsmd0j1ZlRGpOitj7X3Sb+8sQi/up+5dKSoTi/plHw0l25XmKRICkVnGNsSYAl3/3Wf+uUIjkH1f91/0ZLElkYDOGVBpJZkui38pXhqwPRL+rRWXOkL1x2IGNpmRNWCfVhWTqpg/6nfcB6HqJULeNIpDJvTN1UEoWq0rEDDWWrm+gZtuEjh1QhWSRT0NXtug09XYPwF/H6rKStPZSHR+zuct428ioV7NtGEut9dNOAp1DEqUXhcL7su0bsVddGSm3fS7nmgAKNovtnQU0e9Ic1oI15qjE1KWey95gjrz55GYhEb8aZGsuNGPHJnLUqUjCK/yi1r2dhDlEBJ3xk9VYOzwUkVY90Lp+kgcKBmWayua4nWhNLrLIpvbKhwxxOGztLSxXwqep+w8cNk4S0yTUeFmy4o1L8eygkxegbkTmT/wljZWV7NINLGkkG657qTDs9nAUQ+uoXfqPOp5rH9hqR4arjFaY8A0/xePVt4Aly9sHfTGYA/BFXskClZRHQPusMXbjufDgrGbxxqvEHV291jWaSGWf0jt7uX4HiYTzZSQU791UN5zDYjNG0O5KnkAgDCVSjfwxWCSiKk9BTbtWexgM3DWG9AnTqLxUXoRm6nQhP2zOtlIHdAjD3hT95EyBIebPCZkETCOQyc0wPfcK4TEPY2abKn6+yHf25Y4hMKcCcCqcfCK60FITvjOW+FZKf3JzC5/jtzGn/WprDeqyMQkwscrpfYoNsSdpQpHG2c2UnPjETsSTY76Di4gEORhN1cvIzM4kHF3/YeSY0ORiVZn3mtKJxL2A84zbD1GnajlfNNr3HqLNFjAuXxR5p1FBz/XW8jCwqooVNTxCBPKNOWDImpmGD7OfHFphtOz1xcqeKlHOmyeUemtLhWyzwlp05+/KSZdj6n9P0hP7+MBWEskaTs1We0CkRnxyP3V4bzpytH0EwNT/dUWRQgzoIagGXfiWcFs3+VMy6jS2sFeb9AL4uwwcH6ZULuz0yprs8vuvsXxaJb6v6e6d3QQDHdDvL87x9oYpAI78rRDVU4R/Fkiv6POKgolxOy/6JsFGSPG2oBtNh8fm9SJzOCKPRHdQSHQ8gRNeLbyqJhBJkiRkWLDHgIsJfdT7ptULHK2zosH0hpRYNClX5Tu/9wtK88pp72nikkwi37fZKuJFFzhoESj0mlKtI2ebg51zQmproSdTXpz+qCeSyz390+ORVOfqLzoeuM1pvGSJrcqYK50L61W2uDpa3+k8C/lZhebQE1vs9+RWGGMcHjhmTQTkd0WpO+CrDWil8Eq4ef0GM3FMdroO5CnUclFJXcw9mWw1l6SAEk5iV74EkCE7uB03FvFlSGE8oiJPKCFFfhuA48iN7afC/oqmIxXtiw0PqF81DFpBWNFTqEyjJbGjjWYfV/F0ZswtV7v3QN2zIEVWNzC8qsxkQM2byt0KVAmirBfCbK4vW3wdco66ACYnJDdnSdPOGKQEOgdz4Kpm4MguxgV3pOGbVzzbCTVbR3G8Bu7xPtbuWfiC1QN9Pi2TtDQgrq07QhCpaj4O/0h3ZdliWOdnQyGaU0V7cVF8aOqFRUB3KjQFUPijyGJ0fBTcnaXOnWDtIDEnB7V8J09atJrXilWId+iaGtK5RBF3ZXLJpYE0fvPh6j3TLGiAba4oncgdSfmcqP/V6gu4Miq3FUfZDVt36f4ajK8CF/brZuwwvdm62vkEmdh3DPHC/Lt76gxj3kBDoHhxdY2M6stdaczlLsT54Lc3G77w5yt4bIQXiItna7NwC0SZZrKNCAIlNTGUhEYA0NV+gJSD1cJcQgaTd3m6RCXkLkTx7hMPKN4avVSsSS98QrqjlMnJ2z+BE8oomsOOrbX6LP9n3kNiVEo8/VmlV7O0seMaPSdph3Eekwg6hNGIOyo/nkE+CQSHtibEIhaX9yLGhTscZswafQvEn5imonuj9hii9c/r0bIYvuFV1b4dn7bkKpc5RNCA8hhh4Z26o+nZwbywqJvaLJ8pUxD/dF+Ez5GFNwgZKsk6ooGR9lAHnYDS1ZxovKDvK2uI647nvRwBYmKKbBxJyUPvU7ua1HIsVcWAqoLAUhMwE3gKxIqbOWGrC0NXxaP/LMZDG4Rqsl9s/DpPPirq42FCDYUjAa99tp2HMvcxfcKrq3w8VgsPkx6pmyiYK2tDURGUSJTcSkp0LVnS0WPgFSXegX784DL8EbNlHAZlWzfvtuHlqmdPAdpcx9CyF3R5QKNUGmevilUGydVjZG8attCDTaOIoi3nc9P8Rc8m95N9hZilG+kkyyVvO4Ek23iI/3BjFwhz9lozdwO5xbqC8sWmKYn5yndAEe64GzwSHuQScwthEdEq8xjjfxTQuVJCH4rxYP80XphS1oqT8Y783uPxQomxEVSvFxYaoRwhJhv/MWCh2B3qetGVqiLU7kaJrcObcPUVPdLbxx+m7Wz5yVeezcXlq2ZrPlw8C6on5N34cPbe6QS2F71OP0iDXHxBNiYCLbS+bFzN/FePqDqbkRUbz7CeLH1Yq/RaUYztZav9s5VnzVpGRj7kgh/wvy7e+oMZCt0J+MYxs5du5INkD4iOZjdOhBVzkKrGwxWJILxUHsOlV1gAu6xYQqQQl6l2yg/Gxif9QRqtmBb1ifv1EQ8cidi9sNE/kfcu1Ml6B7cA8SQBQzwZFAhJqhqO72/oyLMumEmZwFbMpNEZ1aoctdF3CqYsc9f1dSL2QfUocnDQEI/9vFh9xjqRkNgseBpBiEOAY7nKLXTMtYk1PDHPuRmPoNWhy+lYXHYz3yMlv+wEyrHIMP4PSSPlmz7CetaP5dGMtHEz2X0C5wAn80ICc0pgEbAGPgVdC/SrFDeXJhuplCWXOx75GF0CQAw/HGpgiv55ICfBDqrgkrFZHVOcgPSATQBOugw9N/Da7SnpkA6+KCTNMv6p6jECRNSjK9KR4zjZKOe1m6filOZoyw4KJR28qRQ1L+WVHGQCrIuzCFWr4UNEjm/8wf+g2STcXRH1oJn3kJ8pFuyKlN9/i7TADP3bfgRklwCdYltYz/sde8zM/UapTxSgaS0i1M8SlVCMHCmSpHCo1iDLgHVusf2v0hOUsZIYMknT8jN2zLBkloSEx2HiIy09YTkxPW11x6VYv+QbbLCNpcbaJRtFp823kAidFAU0WkXkhtLpcz2TUjRtAUzbpW+iZmrVCGuz+APdKOw9tWbsCeYwSMHmdwgz+vXYilMWbbbseupJ3AdobatavsWX95UGsS8i4oIwdMpb+2wIiDdbWfUZciBxKzMkaeR5sfliYtsjAPcMk7t6weAJH/VoI5jAjy6/jDz0Q0Bn/QPntJI9Dw0VHwDqQbK/75IofJ4mL29/wioraiCUwQ7LvpzA55p02GqIwIby9+Qjma1w+hf8IAAAAAADVcUo9HjBVgK45o4SpV0edtGrBE8PYPmiSBPvitwZXOGXvYE0HYGP3kHkkeXaBJzERyGTQlb9wfdipLdoxpNpjKHMuKFCHsfdnXxOI1Zl7rlNNkLcEvhycBJgsaceAYjQq/d+mrvwDZ/nTj4Hy6ISSIHoiT0Jy7oCQi2nlg/YUqQR6IXYarwAvRNZ7kHrNYVkCYjX5NuJmuzyE7VMK7gwcopCOwpQDbAUFTPVlTqDGh+9729VNBnU7GoWhn9qI2e/fsXgFtB+yBkE93klzninhM6mR6uGDIw42cAIQLso8i7QHITpdzixqVzGjXxR0SqHov9h1tFz5Ug0K1NT3R//rb6/oyv03GBb65U7aYxJPrEwzRRpECKZzpumSK5PASo2Ft6QxllSfxBDQ94tOqwvu/QjsnX653eqP25aHayIwYoZ8ACIme5wMHy5agnUOsBU9JU/Sw4kCjRrayoBsTAA1WsG7HR8mMdB3J9uwn9VbKMsN5T7C58J/t+4UAsO7xdCYDyofq0lz95XrXup4qkFbflMmvjzdn3gaTN9YXTvPnS+j8X/E3VnT9C2dPbvmGyKkW7sfofhLrBCEJeiBYqmHrtLCRtWVj099QBVgA0Oi0WoSbBXwZVrU+Nuh2PeZnYPQqbP+F+YtmTKPQzGm91dZBn1hcw6xTQs1R3Hr0SHjFykvxXIxe9EuXXgV0tSznFF8RiQ3FkzrNWys+gnCP+x3tHAf39PfRTcQFqmjUFhk8DmYvew4yZwokEYg8zNEK6Tut5EYXpW56LYyGVTAG8whYtFuFz7gf7pZtJGqHdhAvXp92+Be5Idr/fCSCpYKj2FFkKdfxZmCNeEzzqnIAqcZGACbFlz/M3fCF4r8d2vTyMxaipSft180ib0oPpbFPhEaoKS8sFo9K80HOgg8VlZ2WZlJqhi9THR2sQL/IHfBsBxnxJumzai6Kmz+3Xwm3vCiuSKbQpEL/yzK8b+dTCh3mJgEbjShO2GwjEUeJlAVkyVkk1TNjZb/IDbxwM4oiM91epo2czVtzKc8BiYTUqgzKbdvA9vtUjPDgAC6tmhTvYGqRqTQT2MfpPnihFKt5jXHPsOR3D3N9ipRER9UQ2KRprhHenut/LRyEXCZwwZ+Bx3ntRez7v+gur6rN/zQGRx4BZ8qXxM820WP6QGw5njvpaq0mZg30RkeCzdfFi3MAt4KhnVtuHQeY4obd+Vf9nmD4YviQ2S+Ff7Ep+KkUtCWTla/APgCljFFJu7p1sDEbPnLyDsam6M2oMKla+x2FbwQIxU6ipaRKm7csXC7Kg93ycBgjt1js6+FJi3gW6ZU5L2Hqz30FXrPEXBEL2IpXqptShAzpouKIjhe0j0W34kM5BQEsxe8LJtXZaBz6rGiEpqXLxPU3Tl60yrPv9vehj5CxwUW1et+ly9aYFI7Pi1OY/OY5snNux4Z24T/lyhbE/0ldqJzyy60ePTSVHDk5SwI3w026Q1RFfVz7ta/eO6VOCVMp+/7SoG/Jjg1HC7mZ5CYMvgBi2hV7sVT4JUQFAvJ+3Sf29GZf40kLHAVoj9DP+Txe0s3X+S0O6NrKA6jpgFkkknH61utL2VLJVhd4ZDAac/kbU1vobBRCZjDZnhldkjWcbxOcH39ytxwIfk9ZYp4ramiODVuwbj661XZHabrv+2T3mtNYzyynzCEhjQAFdiYK9Qa735eIHxflK++FTtggSjti2EGQApUdyCJwyk2wSe+Jx2OrbsurpuP9wsgaq47mj460rM1CYUjq3PFB4i7oE9MdyY//N0sxae9XQUKCzPjn8qTRy5XGCjkNQmminKMAo4aXWDE/+LL+VZwya2Hpc0qr53lGEeOBVahQgUSx9qYiNaVBW1sJxBYMONAjQbnc7uvr/yY4y2hRRzr34RBfPMm+6oa0LrNQXDKTErkYKBAFhXwdkolV8ujgnQS4vvQcGkBNjogTFE7MUX/5Td2RsXzpM4IB/5H5lujOVjJXPbyJo7z9W6fcyonyS8Ew2KLYhD4ZT58qkBlwFd6alf8iMYGpGQDwDdYDa++Lce3y323QSBGYfgZoP1BtdaUPTbiyvDCctSGERQEmJ+R2KYRiHeSVti+T/eRyGHbrHuGw9N4v4en7ZiAgJHw0Awaom7Y1IrgcZvCT6MMUWs7KKo2unL2qfjN9Pmh+1237+QhZWz31dW3cNl2iGDf0SUi58oNv2RPEZc2bFnmpveznxxUOZW/gDPOyc1iAxUC98sMip5cWVGBQh0WRfKHW66X8nRhwYGSqe+pAUDW16/jHuAyaixA+U3Cc0ZfU+PCuxWSrf+21PFzVnYqhBByfwkze9lldsvrfoQhE0OoO8V0MUrJl9iSMHsNQBrZINQOrVEJzvuEBCM8BwO1PHBlSLxhzGCxtOx5g0sfUGS8E/D0xd30I6orceSQEyLDFFeo/VEhG5fRyTe3mRrRq1LTyDFzQT+iKVFBt0s47KiQG2t+Qm6FLM4ple8C9TjXNrd9qirUldUWee19ejKcp+q+/VrlXZu5x1vnCZvi3IHAbGk7b64/MC35Ak8mRO5dnzawPiQVej1SRgnj+2Vr+9xXv9bznAxjV8nYHbPSpa6WxUgEIHTe+HzGEqjsMfv+DN9jatWZeLhvlyl1KyEFpMF8JCLDjl6jZ4KhlgBFUd6mMIFTuf4CwfyD+jEZ63Rwvx3heUyvfdPC/6ZxRYye4bN6CgLaxWelALNofTznWJfhjgVe4Jxed6yEU30w1Da+TSJAi9UTOS8OdMn4WNJhYKa5uJAyD82A+EPHFX0DGGyLiEQfEUYsgEcpjQMCsPzxX/oQN8wwLb05veySQGcAuOI0wvBQrXyqpnoTnrVAafk/hF+95pJ17cH6V9OnyOPtKwRdLX0agkHB2BKwFsC4lU5P2OgPM26DfE/aAYuA2kJy+x8oha1ZXW0MF/yVNo7siZDms57cHOYBhV6cyIx5Q2Lf2xx8oc8yzzXDXTD3pzvaUxJr7/DAkt5h9AcU92GWaDyHZRpMO8ACAVBXJkfilixMN0QY93YmgHHYJHoc4DetN0VrsalwGlWIGrVrwdD0MnIZGHpGUW9WuejMeAJtYbp8/2IGDGjkvKBCgQLEO0sgCrhn/rzzmfCNrpkMZNJItZO5frcanUmX2ij0C0aP1VXMQh280q7gxSlBscjF9MQBHZ+LzAoQNIr5WZz73X80KRvZqBNrlOGZXMTG4auN0aOArZhNSoYG7JssnsQeyRD5S89buCMcSrlXElvrjRVTNcARui+yvuoegCayGRMHq5yU0QkomFwpBVF8b5AVJaJXQAbcX8FZA/xD75UNE5Z6meH7v6TqbV/XD2pXOAE/mg+4lqTfJtLbth0FJ2x5dBRq3q9z2ZRJUy0VaQuRNbuvziFFh1QOmdcjlr2FECgqrHH2TuDwU2pegfPagWgNiTTJ5MiJI02l4A3/R6YsqiSG7Ok6ecMUgIdA7nwVTNwZBdjArvScDmV2ZJ2E5g+rmHe27xOLOb9CbzoIUEXUWbX3n0b+Wi6A9jJDjSLbua427QyWtjSybRP140ZEyO3zjXPY2daMlihW8slTEFFYlBQ9TQeSsRUsjsOzQrg6kQw0NaVMRoQmMHfdBArE/wyVveBBQ+ki3851lWhGlpeWPEJrLehtT9TACBbMls5ITmtapVgnaHmJaKBUMxLXWhXAofZ4Zn/w24s+tv4FDOOYyZIp9iGL6xXPwirQG9Jl6BiLnO7XYRGrI1A7XMcGPF4iLZ2uzcAtEmWa4GAMaQFZ3CXanjObOoOixtUy/BMJeIyjECWrycti+WMbb4PHdNmDnT1pOP35gi6xLcoCgM0Wi0xqXIqGduqPp2cG8sKib3lQk9XONrLblq+lRKiAuAEpi2f9D1sxgTuYWjfQEeyqqU6LGVnPe06P/QslIgNzDA5389nybLchxwnVoEfzQiuhOpg83rtZajQHSyQ80yyns9ycTiOOLx1SNHbvHOV1vExBkJ6CHBGQH85FAgefTM2Erp+QMm3bu2xfCdjO/nXP5puSMjG4Nhjr6JORShwu5mlIgl5Y85X7KYdERjh+bVpyZoTfoQB0bKSG8mA/6AWp4a7o3qmvrnSiU/Mr84qIAAAAAAAAnn6mI4V9pqo1eRRjsEnq0Iso283j+EbynAgcWc1/DN1g5g+pVpbaPl8C4QUe65gaWKq/OzpqbzLnDgAsJ1G6S3l41Xk3GbHWZZAyiKDoEy0ZbZtmxPTxtacQAPw7kKGuRczPCh8nzvSbZP5aAhobJTcGPQD8VALaHVKsoDzjlokEEc6G9BOIaY/0zXq4yXVHmJ7K/TeF/Z69eOMnuzvsMnEiOAZr0Cs+SslRf00TlT3DxS5xt3A291OYL2c7LgTJodCgCTUGCqYWzOFodfiyycfR3aTrM8ViiedDzFkiRymyl9xGH+jkoZTp58dXVIQKqpyiZzTWuRh28j+gcpBAt8p/VzdvIeLCqqxVcxtAjLc+N5tJTbMLtPCQb4fzwRprDrwygQbRC0EHG+l5sGAvnFyA9zBUTKLSc/NXMaAZs6v056m3ciGIfgK4xaHFKYT3Q/d7sbjVR6Zr5KycsxCqtAIObq5h813D4BjPkWU8awaUhdCzSz0BMmr3n6PfJbpze478Xx05CWm9aAUnqa7R/HPFS8Oyk1BJIqBGzgYuMVbgC34L8Pgrohn4AAAnincLRjh1EhgBjFMzWgFiQCD8mJ5NyJLstJ7rbwsugoUgu+noKN45rP5+BAiy4RGFs8+GwKLnon9HVvcZ3zZ55i13piEYqsRf9kx2POIqoaaLps3y4tM33TGtQjVbyLOIGfNuBvhBl73nfv8HwZTofLrQddsL3r/MwVTVgudLPMaQeJI1s9sK8jJl4x/LTqbIqdK96gv9Hb833XDC38/WnjXZQW4gWn7nqPggPpdq0QJfeKyL+2x58n4VMMht2dvb2q/YBa+DfPntV8swgmg9S/2dgWpl7YopWJgqzWIXXPskezCfqzWhA6+3ShGL70DxoAH6pk6Nj7Ll9vkuM4n2CulrkevsPhaIuK98ExA2+uBRkQDYMd9pVzRiY+mNvaCYYmUkG775yZT/ZeGitvxGb9MbhzcoWTpAJqIqnrIYszFlOb2ErEzIAKWQ/9bjQNur+xA9REkdejT131Aj2Jb4GtRsUP8ZAf6l0pJ0fhcfJPsjIGRa6JXPDmnLLfiTWFJhtVa3odtWG9scbxJsIeXoF+/OAy+7Y718F2mB3l9l59GMR6b1UujemmIdoHS0bxBLCpvSmmdGH/0WOFdW5IRa9N4YiI6GnZyfHDjMa03KSV3ZyT7JO+/YYcT4WWhsRR7yPz4crpkCdgMuoF2h2+XrTYiWmPutP5bbZajOTt6srQjhfBCU8MVAAUc9Zr+BFs9t+x5SEpMsLtffYhwbu16jWIp6w9RU9zLiy6ncQibX4qvRnAZMOrAljI4GX88tE20lLcPEaKNc5mC892X80gIwyW37wQKwwug3IoheM2PefKLQ6uVcNy6Pp16hSwflkdqYBPRmz2ddDEFESGofd06j0Jh6cET85KCjmoHBB26pm/fFgygwGbtUTQk1WTRbQQxYp3JoOUaFRcn95nuJmr3bXaKTJdkkAXfxnx0TIfpD50fSuOAc42yuarUvj9Uwcjbs6GvVubN8TMqBGb04Lja88/VbqcGforGZM/EKQLVlPfMkmPUjQkySNz39hr9a7khhJqTAH4Bl5/egr64PwugNOqiL6vMPoDjVVXMOUaS/zx6Q+4aRc1GQC8SrlwAM3B0J0zllGJniRUxZFGrYoJQt4JzKaIWnvRQ07pUJ3FcyJnmf2gjto+WSzRQugE2bMlWTCOkaUnq/F+AADal7vQHIkbJ141PHnChtJfVB3FODA+CWIZsZaVxjlB7TeuBS+jkm9/d16gqhraznXETVix8nbuSplpFapWl5loVswsVMtZaZt0qDQc5TcV6CqWBONJoar/ieJgoqIA7j67ZaPJ05TNKFzFrKKR/ndX5wS9GJttEDJXTLdio8SyaNDSW28yOAtOaiFd9oHiX5/YyQQ2D5NyNcqFnkZ9hh8hr6iIJWZTHPm1KqpatWWSJo3MaxVTZCY5ZxYEjPF9B/sVc1avgrlyw7wvtiyuXRZAixFfiszRDdNOjIAu2gE4xPn2aNkIiJGyedhAY4fmLGtcE4dbNJh9joImFT971gT2vpkvNAH0h+NLgMjwjmE9gppwM866a/5y6AH/U6e9GLuXKUfPCPbSakLx1iDFfaO5F7oFwEj5wT8ffnbU620hQt/Xlqwq+FxXYDlTwEThOwCmY1hrGfE4jtci/jVblUxEC8dKrqAyVMbrDySYJKZkVQA+MjQAAzXjTve7UespCxvHYMcRv3rAnwDQwDFCR00jSoIkUzuqiVyiL+4SLaSv4kNFdSzFszF86pfSxiaN3YdMlJCUuPpe8BERRx/Kxc0T6ajQUg+oBXoPj44RTPgRJdpoTXABVsdyhtkmT+KoJ9/fdfWbR8BhF1tqLTdB3tKYm7SPF8irRXgSh8aw4Tq0CP5oRVgxHAqVjRZAVBfddxi0YUH7xJ1tavqYNjMwVwSpRO3uWp0pms52Bmkx57U/40Z2yd6htjy9FrDpnWpqQbcbg35vSy2wQUEYzbyAtNwgApWWCgz+TeSJbkCxBXHotiIxr7Ne6fz4gTLXMQ+8zhpIdNZ141ITQ3sNO1OVE4wtBZH0yOjKoB/lUzs43mkU1jZcSwFJXG98hz3czSl7N3APVcCFXDw0yjIqtJ2T+/Fdn4TTFYvSNwR2vLoJguYJDBKPy/P0PcqjsdbaVH8Xcigi60Vao1meNx2OtkaNHPQlKYi76P1Wpz+KskUYkUqYlIAyFucnqBaBcxQio3MJEBLKG+2UEEiJ9r7aGlJThharyBcRhwJSA4GTt2q6lzmQ6HWQc3fRnpi6SD6LvTzT02ElBiFIAA6Lp4+jiCNojOrUCyNpALLyUW0Wv+B3ISuwYoMtwGZdOKqop9gvXXO7/xmh04cySe0HsSzbe2SWfhaQJyO3GxAcGi14t4p9HwaJaN3FmEcfPUSgS8WEeo61WEKZgqugl6D7ONSBTYtvty20uW/kduolbn3Et2Kf4ld3VQX44dhwLxszj0/gKBa9DXo4/ExFkiZWEN5BbIhcalEJBZW8WHEWpTyZEb5smgrh+x0mPrZb7lTqr5dTuwmgAJWhkX8kyXdeVFK/Vfqnkl9dnIHQJfVXV02M8uppkinQmxEVXqRYxKefiZomlJT8N1aqCaP5DkQy002Xzg9cbQ67UubdBviD4aTEDaSCpIDhjMqfP3/qzstxJi3+EWHkDzWasHDpCLbr55bSrCqr7C9r6ukPGTK61bwzkMXsklxuRM60RMYHQUz5eanx+QQofxR9Kw/1ppC0Ssc87Q0MNq+1kxZGx7XsPBoiik6AGVaJ+wDRk/sEgvXvCYyiFxcCjHjokNletjpUXBe/cn91333QuNvb8CMkvgkOb82UzvJQUI+Ycm7RwsAs4LFKyZfVSoppGAifv22EMcGkVtKtrApGZEaD+mq/4j8kPyf7jJPwIDoG4P8V4L7kTyCt6kugz4h8ITTtNBt3g6OYGEXo4rIj1kFrTnhkhBeY5vykTUuO7NIWXtgUIlNrzxwa9VQlElooKonPgH7JeQgawh50TSn90IoTKDOb0ktIvJ6ieQfs7sFQjwDF1K3qBffPmGLZIfobwbPuIpIxKocEIZHQyzRlYXMKq12X2sV5SqvMOapBwMashC8Ai/ylesw2AHpu5H7S9r2q0nxaisYgtp4yCZdg+qKTenGK8N9NKwQGSzUtdhf2phwPWhMupkDVkVXYoWHE1VKfGbgBiCNrQskCHemsj+Rcc5KNXlsyGBQImOWXFs8e0CqnfPx5v+kwHZg6ZkL/Uxa5U/zoL5oJ3rsVM0vRFRmdts5bbr1eZpI5LgOpj6WaU+QJlmy6etyejlqcWDRRr31xGX1L2F6VlQIunaDK0DWsX0ZF84Gua1WzI5Y4Z6FR2mNoAdSkRG4Q3nGue5zvux0ETCu8c8KJF7lhxzBx/FebOp7zOL1plxOryabrAFZZ9c1O5p8JOe3Z1/QhSzpY4by+QCyO1/K3/y4mmIRBUEWayAAzbltb3BNEjYF01eFOO5gADYf/duHkWu/mUrbrRqfdSX3RUVn5KbSo6v0kf02i1mDB6OFPOezaoWsMC7x5rUaQKtE9CttHlbkJFVbgNILn9aYDpOtsgiF5m6NJEOEwnqfLj95FANMuyJtvXyujOkIAlGRzdD5umsKMLIoTpGndwiVxI5RCB2cnQanxf3+3W1fkloEwU9N/YO1hBJOXT9Px3uFruWGA76stbe4EX3Rl258vXnepJD8B1SEe5+t+etkZ3MUErmIMOIrvSI9QFeYhjgxRX2+s0CjvSr7x0cBfYiexqPo3+KB+oMBK07QTAtGEelcmN7fsdeKj9BGmBQotZpgPXNhZqrkmj5250KVC2rs51JQ5kjc9OhCh9JoH01xszl+8fU8WUNeY28vZnBFFopFVEs8qXxM7uOwaZ9YdFZoLPdkvkQMgt7q+UK1EDwBUtIlB+wJSWJ/8Em4P2MRWpXIYKcygYmpW9QL758wxbJH5ZUsKDr7JVCJtlBdoroY1ZCF4BF/lK9Zhs8gHQInpwdqQ7nlMqU8KvfaXz+qXuY7e95NhuAib/ImAM8WOeI4pYDpW2svAax5LYatgLACKo71QYLpLXh6D8IGtFhU46uI7WWtMRubYCi6uHs6T1sMgIkmHwhYglVq0UlJVgQHG4GAYqtyFk0hBZYEi0fXa/2bCadkoxfmF/7shzpYkihfbP4pMZyuToabpykjLzOJtPCc1LhGnyKrQVe4+fSjFlq+u6qKkqUAd2YEwUvuhriq9SLLDwPDNAH88DgNHcq8//B4EvSNwDRo6o+DKLT1GBH/sLYIhCoIeS8QiWOCKSKTXHyqM6ZgLAsNlkdqx/dZrcTPmBROGigM/92xMjj7qxF4LRhHjgW640lNqcUob2ALUljgahAgf9JEnX2qr3Q/vx9C0aTbu7FWW3hiXgP3NSWG1VjY6ELTL+RwANAYtqYbXZTZfqG9fWLlyapPy20TKqmwLEyu+uemRlJpEm6ubZUMS99h9pNUjt2MQ9SNCBXQwpz1ZIAPgPmjKvc6MEAoZWYf+cR5efLuFBUMHLNVyz+wU1fYOB0VDTBWbssGvw+IQG5CZlTgznn39Nxvz75ZZ4aeyATMo+YfBlQFy0vtCzAAAAAAAAJKKNqy90gPAmr6PVNh9tWLVWt6u4FPhDXoa7eEKuVRJ74JF8L1aQ5o8wXBPlG+2fyyoCMC7/9Y60Fwn1iEoF6i3lTuHuUhXLrzjI1tzcR/lvNa15iL0PRdQyTRA34lczgeqf7qY9izydzP7Jd8vzQPqKLAhtGJQzwMaA3vmEOuoU5nwh/AAvuIc+8opVtgEJT+1e01VSk/G04ysV3okpj/EB2taC7qV/qfbLxF88oV0ChQqRuEnnQm2Llt/zn5Ie0fBpX8bCj5DktcHPZV2PO3GXCBmf8j9fSVl/+0RWbG0AZaXSGy39ACK4jONN9XPiU7X2eekev42Bqkyvl3PEPrBdBvfVrPHweEIUxz696AFP61HR5rxyuZmAVMgO33uqGFuY9wDnwAmz0eGyXoHEH3SE88ZqLoNfAwSU9JsMK8TpciSSy9e055blnUQE0UMGQwY5LH+y0dllRgOcqrI/N8y4VV6kKLgHqBVmo3DLmW3U7qvXWze9rWHuXac4OefI2PkmZT55VWiZijdjTOGTEum/TVmN7Z3tTnhqNYSTUurUqYxNf6+xRFqt7BcO3hN2KKpepdfrWEsXxOnlZapg5q+MkyIpldvnhUCBi0kLWvzPKACKeDFCFrcI2ayHb3yADWn65viVWD1+JL2m+9CfHcEgk3b1aFJZRNMMZaAcsLccZYzI3mACzz0ezmApeodZGi3oYqW1n+Z5qr8MNNsdvx0YCezKRCyRHVjior01ButJDZe/meIitzkhVumf5bgnlbjHoPYcE3IeNLtGZFpZ8xhFnkwMJLo7yhnJwE3Gu3aKz1JN+Cbpo8/wficDWMsfSm3jYDs3HlTWLjbrK+oCl3sah0E2ADgXtkBBF/wkqDXkx4O56HvuSwMURQQvQx/fXTTgT01oyCCgRVMHEa3G6qddvP33dgmw1hbyE50yLgld0fhd2+eWwxF8ykNxoC2oJ2BuTjMbAWiRWO+gHpzke0/6/oYVUIiTrbOq5Wv2Q2fZ7tkA/pt1DCc7MOd50Utb3bQjBgA9JYiXBJr9j/EWeTBIpf6aBAWcG7lIIiFqbIwjzuCcF8pjrAY5b1EEGgqVn/OAmkQATmHnMMNKQuzKfZqtn2unMP+Se/RsgMwxpOE6CVMdNnFrgdcGTdyCfZG9plDJzcX/BsMoL0QbCIfgeLRqutcpPC1qhwWedTRzGmHsB5PtH+q37BhajDkpxVqhj/GG5Z8aBcHiz7/2j62dPfMyd0UF4HXgIuVwseMfTlY2kqsUIZIWkKFGrZSzEIArMIRSTQ2duqrfUU7VwsSbWjXAbp/wcQYZFfmU73GP4Yml2839FM4MeJVO/du09euzetH1Og7AoKM+utr/+MsBzybVMQQnZyiURdM/rMKzUYDHpWbsBKViujdCXDFo1Yi/wp3mqCMIjqSRnCwher0lT+n0gA8VlLImITxOKIMOyVhDTsaNVCxKIBIyJ8EBGlTr16dzpfcJTGk3XW2Thckkf6yTr0DmanF08NYCxVg9sjxtMBOzxAB6/8EYoiBQj/ey9awAE32e1uklk/E/1mbu15K7js/neSyntF2fD/yVY4PPqGCN90tnkTh1MzCHnWrnjD1wvRI25gS40e1g7ZnS6zbyV16Qp85t+y4oEVd/PmaTt+GlrzyI3ebjMjtC9ufKf2mKqEtmoAn+1Jzsy6HRmDOLmp5azHyjJSMOcCJTTqyd7tL3aIcvbg3Y+2xUgTc7v7BNrgbRgiOhzulrSGSRZd8/wWVVD8h3yy39+h/wKDtOE48L96dx3bkxCsL0xlI/b/+dZ0ZxP8ZegD98gQ3t09f1JBuHaIgtS9aghFyGodDStgeg4Q0sxGtR99nAQgOaVwFF3wi14c5ihw1fQJxaM3kJadQgi+FpEUHDTA5S6mJv2T7IkzNMCrD83rcwxT0TW2gEqwrk955J5a6yfLcWgJlhOwECAScbsczvL0E79OdQ5jKgy9lDuX061GytnNsAl38+lR5DK7Mc8SQ25+UvppYsEDZej6svvNXB3Pe4oi3otTTd+udxQdS4RJdqS5gYQeOJ8XxqafF+JaSiMKpWixEKtAz6UadQ1o15cxtUxZBz8yBuH++MbGwFlmb6zkn4fRsVwElYSoIgFobjCDASm7RlqRfC3GAv8llvK2uMUGvpdAUt8quhdIrc1b/pbFRPCjAOuWcrbrzoSc0k/hwOvOLQw4qwthMrLQfmOLws7kVJLIn5sY+fkyNP6bvr02HyaKSYjIIl7tbpzJXbpN2KvYiJW42BYqZJWd7zWfqNcIim4nwpxLbxp41zYzXE/nAaHOgUsbVrBJUpUV5MjV/gPaoWakC/YU+wJMZhufUxXq9LWxjH3nm3blJVqo5GH4Rc0P8qSsx3a0iY3zNEF1TK/YSx7PyD6OFJA7ENEUA8Hvzt+0jfVZYfbDZsO6/0RYvCsTZzAeTn2nNGcz7mWYK1T+JL3ZZ3DQxK8AM5Y4fsvh9KEG+Tw8a3ELUoYwSSeg1f+/0TadQ7FrT4UzbhapC6xUcukRYMKY+nU8EHEVlXSiKPB7YUiFutBYeTq44ANKrCb30R1WL5iPf6uqujKOhDnUctDrLuQYU9KwvfMSjsddYJCHtBbeBLNJaoetCRA+UukGklMOkLsvAWoWzQ82l5oMLUCtt0JvA7Zayc7V34OAYmj0Pvvn2RAJkAcsFKds6PcS8BPbFEGV9w/pQ5CXCFTKG8NXdbaSgSL32VME/dq0QI4HpwFsYM8ePs4aI0PjkVGAKyp8XKFs6Qjvb1ihcCmH2qcPUwVgS3fyaGf9SIzha1fB+0AIMnAAAABINgAAAAAAAAAAAAFZPVUj0fradvQXxrh/PyeEnXaa+9lpeShKAOTOLl/tSBhrMy5PWDwU8/NKT8V97I5h1D1FTva1w/UUlBmxrAB8k9S8oX2Akpfb8X9ThAeISM3vqu5xTA2739rNrG/MeZpHClt5/+iQd7JLpkYkuu0br+bSOlOSVInfuqYbh6isuAgK/besieV9OyWXn9+PJDBzALPBd8/K5aep6GuDt+B3uQvae8GNCUnViO5DDsxRuizOJLDddk08n0zJpc22HneQYWk+A7Nwrt6p/upj9i/lI7QEomXqpIQ3n6BN1zX8NJTgNFi6rlxS3bLdn3cCvKhuUHMuO/+mrq5DXgF9KlVx66HMvI2sAN4lexE+kefsv5BcTmcEpJlKdgnAMeBhVU5gAtzSAAMd3H7yWpOymqcnRw7UE/ju1mkjAO0EhjFA9UR/jMHTjIcOtnmeYabK0Efz7GFoNk186xu3rYR6f2EStzLTzHXGWOP+h2fCDrw2nsy/8D99gE8VJ5uQN9HBwGaSXoXf8DyqHRLy7W6k2wSHqSf3Hyal4nbekl7Xxfvv40xmf3PhJYOMAr3UTDc6sTbyCsJoNSbtRECzplBYJwSxMltteUCAgrClJZ9mAIGrkws8lhiyWxhsCDX7E8x0Xa8NWfrmc+SXPxaZ6U4fo3kWh+unx4FEHaUY/Nh3GdeiB2E8LFcT2FnaakYeL+YnkPlJ7iAdgnm/BTkNhjDSaPQ5Agy0DuIu3DgFdgdRas+D3OEIefMTIiVMN3DJ3vzLGB2TI0vyzthXcO58VLOfqXAeWsJbxzAh7yXLG5H0sBBTmibgcVOa6HMlK2DU08kwLggQy6+Zeft875U/+HksoGlVM+Xx5W0453pughMdkRkh3ltN6/+4EWBgqcIbaFH8EjVqKA8bYtgAYYSQov0SVviSIi19KPT9y4KOuDwjlkJy+osRQyqn5yFPuDfrpS67mYNtjcdjg0/VRJavlFMyY+XqgkGr3z77MYMnBlUG3Bpo/PdftI9jM+hzLZ4jpjN6/cONR2EfdpbaqBdnDjvfNFCuiincJ6/BUFnVqjJgVQ7rDkKB0EUacWpFM3Foxys9lC9Wj06B/SgSuPHVQh8ZRYjLqkm2KG0FQzwC37xKAFZENVs0h6+gqlkU7jhWG4ntpN5u+xQRYeV/0VoN7lMcXX6RlQeSRFSUFwSH99wzwdCQaZYuX16JeaKI7rgUDBKk0JRfbRyJE2VQhrLc4leo//YGbXRoemXaVp0JYnvlC5AOgGaVCg2KfRr9iLLf1txpz9rz7r+ZbatPykfoEX/bjah87ibEgbs3hXaKhc6AAYj7MqsODyh4XlgqWHrMePoBCovwggCCIAb6nYAaSQqu2CAwhWMKQU9fvlQ3/z2qif6HzlzNHkVA46b2fbqep8K1iL0dzLLPcVgf7h7lNKJuisUb36MzlyBSbJ+LSbpA0JN9NGordI8ZqtNaUrNveL07J0gIRRJ/8AIKeOjbqt5ti7WfteKYzOd6rp+TAvIFK+gdmUYhN3tsYAP4g9rJ0MfuwDkL6IonohQCfVRCuo3c6MuKkPO4ZhAmuEZgwftFTnwtCSFoLTxi7oUPi7/FGRert04Mm+Oa7ILhDh/QHNLteA9rbFOKPoik69NTf6Cy2EPiiDbdB7z0SnmcofbpEFe52e2cipzfTtNVG9TroeHiMoqz7lY1EdGq1cReRR02lzbihF8JWCKVvqGUS8W+4/Ari0JEG/zssIWjQ7kk++CKYEheAYJoKxfBsr3Bpkt1He0qz/j/PrtPsjFRt/KVH9zmggwT6VKGkePvTrqXbP6b9zBkn4mZhzgWNYabHMg4To8cWT6rmfHiji0lOmaKWmnBSyZ8oH7Rqd8C/Pi5oUtktM28t+5PBtqr3mIHmmtzEZKQFriY4b0ekNC79q2qWXC7Zv55ddECjIcWXyiO2c5m7+q4rTkrP/+yUBeGOrVGiRurXWGxb2nTpqcVj8leqwxAMOoQ03UOz2SFh2xipVmIaNVam9fq8RtHm6ne7s4BTizRDzvi6dlkLO5xyHy4oZKkRuzsFn6MLkO2V8Zmzmf4mOQqmErHCmGHIShu7VcwBny0L5ViYvbxvz0EZrHaYsXXXMMAQQaRZVJLWimc9gnizZxhUslvdRmQefU93OK3Bco9nqzF30W5Kcw+uWKdXKLPp4dFEWvICa5xoKrnX4pOM4tNBx+Sf5b9HrpoQ0g+W4aIdq7zOTqiVAgepxsSxWXuEUM6r95kciZws0QyNA0w0s9hZ3pEpHSY0zNdsjqyadeiA6Nn6yT9Q/xJhW2+MgnqUvfSlCwVNmyqHYVKyI0eHvCmmI8HOjPNgszGgUXbMS2j1U1b9vk+6w/jlGYV7QW6Y3NxcrhtmdcBJqyRkJnV5wohJWYe++tQDIMz02rPV8UyO6SuHj1/Ys5xHsAjh+KYRzZktogjD7A2Ys+0UNISqqoY5SNCiVk4XiVXeRMghyZXEzwUcxt+XVnnkGT0cCHa8wo6+FtjfyJ8Gk88eD16i1AyyWr/KbTYdcYuRNOvg76sSnsgbJsqEPmVjAkL/D7uVfm47fR+KJonJeFFZHzlb24yo6IBBhbue4FWjyWcZX39aljqfy61nTH+hHCAFOz1UFpmxMWFK/t+CxhMyUhkAdEsrHSVMaM6IAMQoli5e1NX+mn5barFr5C3JAnnvRvUxoIvbl2yqacXMm2Ll5Fm+lYJXLwrc2DBxlrGcjw1yDhp2LHpPh/6aGEXXccg4IVYYdsn2mdPm+UDbZMJR0XyA5u8m3ser3w7pwZHtCtggPsA17Bq8c4c32hpLqjAuN6yKaMyEEvDpltHqTFA5B42MjmhpvMmFvFnljjQity/08idcQtzZBLEJ+rr3VuE8ABSRmuwxTalQiWyvRYnKOsDTcwU5b0Nco8EUGfT4uxw6G3Tcc/x8Pa3BE/eTnfzK5ip7HTSWVwk9GrjNoIgWgk9Hi7jveSL8Sr00KYMOgK0+aW7I8RB1eHI6KHbxd/3LgCmxuPa1mMUCGvyf8EtI/W9df7JiJVKf+OaiY0q23/LGf+dfkc386km5o2MexMVgyGTfDCI7gfrMpRs9NPoU8DkZdgPYZe4ak9T29KoGORexYnxWE5ob76FqtN/RvVJS2LgFGGU1IqqpcQsZxGXj2AwvgoxkXok3DojtcdFdLoDPsuLfkYxfThBP2Z8aR50Vvh6zdGjo1o4elVIaFVKkr/jnq2hK/fkHgiPGUnvR3kaMaXPPyAFe6m1aYIQg1149t5b5UqQVZgW2GKwvseEDcheNSKd5eDP+qxkIkIkcriw+BJg3+Uop9rX60fr/QPuFv1b1n7p8JH8cpJCdaEuNpSEpmF72Tl5GxUUosv4a011lsbxQ29eZthmMU3QcnrNz5I6xC+3JWBVr82o9uhBIQ6gc2Ss3gomjCvS00YxY4/IP0nG/YUlQrpUVxkVspAFxVVSB0/K/ok2pJIx/5t2CI53IlODco57d5hKv/Y7KvtdTzwrLe4K4lCjiAh1MhgAkZlNq0B4QAjKhe1MUfz6S6GjKSMyEgeo4cmLosZM6D+BHOHzVCtFD6K5PtmnOHV2ofgqJ3RogLNyIKnQM6dAaE2OEsKPEaB4UfrSvvnQAqW5fY91vmYQ9KX65rmmn8dk4hoMq1qnN4xwtzq1faiZTDjzn4RVn3YlW7/9gttbFGKpx0Itb0iZY/g5Cm7Zxw9it96Hc0gGnyQf37m6x4TUHKdWLoNY9eP6iSzBOQM1S4hDlM4Jkph1ehKqnJEry8le9XD+fZg7hxrQz1xU8DmiH7teT9sDqAD+63+cwh2z8bLTNw1vVrvx+S/+Dn00RtaMmAWWgL49Xt+EcW0vMerE5PmAU9REVruKUbJUwspOa8w85YSEJTkHWYdOf1Z2f9z5YCCQ1fDnBdAgSm34lws1KbyfDAJVwxLpNaXimfGROsNw5ZJp6vgTDr48kWeDXz+jNgvdWxmHnnl/WqG8iDzimqLX4pm0O3lA4+hveCCBXi4YgVXYBFwh9j3IkevPEVr8eqfStoLN0PHjcFe2jbZTdA306oKvVoSYRUj+ElbWZB10TR7BfHP8eLZbMEyHuWmXfkvW1sAD5NQ7YQhSthJWhMeuKu+xKYqw7WMnwd0difpZzNEvcCXlw//gM7Zhe52rUeBnRwm1/OaLH4G9qDfpYvFxElLtFh1dOBtPFK9GeCtIy2Pj++cUXuu9BQVWsAvuXnHeZHDBuvcEO1El1cXc+fxdADgVwaXQU1kIziBr5WtIBtxhKZtCET/6d0dI48q8+/Vg6LmedUOpzBfO+9A8nPP67zcI2WW8eIgnUk/XY+93S9g0rUjIxYOSYgCLMFb5vg6D20TN2Z8fec23dH+aVl3TUIB1SdNjSP7IfMJu55+FToPIGuL43DUY8LCnJTb1yUgBpzwsfojKgiSs6H6jlXsj1JttCuaJPk6ulxn69jcUWAt6KWZH6gK3OsEXoDkHWcI/zvaRE36lYnKL2kjPp6Gg4juZZiaDGPaLCKicSTXP3F1QfGTTYNVb3yoNewAeTYrrhGVG8WQI6R/Dkdfai90zCTN0QHsuLrwIqZ297ZGAgjxxA3T8fVwh3xrluGG5TX75Uds1G/35U3MN3mT3L5Hrbm7FzB7wyVq6+C3+C+sqFiNYFHP0jniZ3MkZpu9ai13wTLeJXZnxpkRKxjH0NxT+WNdIYEUTnzwRzhcFl8rRUq5UtfZMe1UZuT7aKjxH4fgm1eABPlLJvP2SR6bsDpPu5PL0OhkOSaE/mOLnCI9m6gdBzYRviV9lAGm7V1UkzPjD99nVaUDS4Xgw+8d+YtjmIEN3tyJyUjwf6Pf0IZr2027Xcz1syrXbkIUngyg8PqEQn5ZafcMzq9iTxRbfR+N+qv/Wr8PRJ0/J4Yr6+WIC1e1rSRkC6WzX/6k5YcW+oQookRBU6TUmLly5oRp8rdxwHXos6W0hknFKB6Y88clt7KTs+fV/k3A643N+I1769Dng5mynWdLLYqvUHW/Jwy76q48Pi36/oxWjsgZlN2GDFj1MHUWQ10AeLfkyM8N3aDei0UjmMbIl9kxYVhR/6VbPMBX/C7Pl6h2m1kDV749e/Cq4VhLkBVPexedYcCVmGdPxAw16pdIB4Or6OQ9HkEeJWDjVSHS1Jt4AUbmlA9H2pUtaFSRlg7uPlTm0gT4+t2NexbrJEZfaQZskzMktb3B8rsAEUn2u/+wBhvRn+V2JNamV+pRS98O/KWROFwjVzAuqQGxYcq4b6VSoUK465b5RlAuX6vsfK29GTWxGtMzZinOkw5MX7aChZBMmPfDqCoQ2XZq891CRk7SIYZtpLAKl7/Npo56UARJiFcwUl8pNjq2Ixn2VYKsoVzOxu9agC6EO2VoT/BevRj/3XvRaZ/sgKlX766Z1zW++IlDXlnb+lvaJXlcPevK10eF7mUo4dlZys5WcrOW1w7La4dlZy2uHZWcvFn/x2+lJf/28eVMIly/orQUYnVm9LXmOR8BxtjgBoX6mWNHnOjGPeOSwqQroryYHlAnwCAXi13KbWDpyqNucgJWyTYQe/+wadic7mLaZ6VQvcCFWTWgBDAWxtCmEWuHvqUOlnonw/XcWpWHNmTZ5z0KAVk+brJhwKv4GmHwVt/iCYFcQxLnKYNcFhtV9voA+sXBm4I5eO59Q75MzOHY8EdsG/zo0adAFIiOjHvDpbGGPG00+tjfhaWl8/8VBAHwHkyo6IqfVmlnjB+GkBYMiqk7bhgjVFSAwrTH4Ljc6IxoPnu80q8ipW5Xo9t87xP2deV+xoSe8535ccEW96f01/U0mgB74I0KuneYr5ARuKce+79VCDIaB17XPOGRgUNogDme4WeF/kZFRwMrCkkfXy78qZJq21qYBK9qydVuFo5P//z815FnlOAXM9TgrU7AMTK14aS9acBUSoWW/3Et56IxLuc5861QKkODf8MPbeguYFSyJemrFX1XXgr8OuGakKKE5OExvov5e9u8QkIwV4/X2u4keqkcUpuMt1M/DLGotP4bZVUnRYT7+cYEjMF1DTLTtuQkLNyYS4sJMx51zmfQOTGrgzcCRQxlBwv3eemQzsCPG8yTEUM2/N3FpFqTMhS6/heOpL0D/TrYNFTKSVyB8PyFVM69H27I+46wflz/lT4Dj5+t3Ehyl6q9ADGOcEgm4OkW0XsscNB2nXdH2LKo71Almr+6MRinkUKpQb38av640GCuxDSahsdDTDEdxDtrLa/6mD+3bAEZ1fpXngOTGUwZ23uQ1F9rMt2dyL4ZoCE8Bg1kAm7lfzw9HvZsSXCffAb6P0poM91CjNHnk8s9OaCmmfK/ZzthFY/t+b87myGgEGJO+Lt/nFJpHABq1DSt5dNCyImNh+xael3vLB+Iu8VEU9FpF8gaZ9jlXwhowR79br/vpsW5HcSxcZBt78+Vdyu8iOKOuEKQQeBWPgSYo6ajKsZCyw+11o2dfZnE2rgoMiXfLLP8E6uomGi6ZZVqMDhg61ZpbaKanZp2dmPFRIqIASdDyHvPViwQJjiLP+o7sLbBl51iDJ4Vud6t6IGQjN22N+bFnZ4luFrYApfGMNr8tgyCWOKRgDspzJZJqJ6sb1anvjOzt4gHfX+/f82cjLVMta2PkPXiE0WGUXVBHbo6NW8unSLdoM4RKGGaLEVpj/UwLnP7x3IVPI0ZBZi5ISURWypJEDbyM8rNYAljcGJ3TOOpqrqWa+fr8kfse0bWbtk1Chq4JFnDlbnYpYkrIWZ4xOKSYac1YsWKBeIcISylxKB1K9xM39TXgnqped3Q/IxSvKLPYG1Cud4BlU0AfxNFuEL3gPOGpwiE2IRjvxu41F1vYcO9vxRdcCS1D9bTUhJe+clpifbQDN8kJakVrRCt5MwhfMgwa9NjO0oxiOA+exvD4lbhDSRGNXMiI9qPnkbp6XGcHUOicXTTPgC/qJ4O+PI+5Kh7P4+epsKmvKGRlPcskDwVwbW/ji9ltM9c7rrQ1njyOsYv/kZIz6SzYW7r+cvpKMlfP+ZDqMUn9zvdXFe6nqg3xn9mzalDMhKgnGCA95rDQrvHzetEk/elxeY6dcWkM6ngflhoFGrdx3jZhNXkeKCH1ndZkEDd+24/fc+WBjx5v0+WT1a++Lks0YGBFEiOxLIgWqPXnK8lf5cebodWzyVNb0IovEAfqP2+AjOIZkzZQ2iTB38PP4Dgf9BVUCUf3QYMaD0ix+jqv56NdvaHwkUn88AUx12SAjFBHVDksqerZJA6GKEXbFsKZf+AwOCfFMLcb+vvqvb285zHAzWVaYGU8I+SsJzVd5uSkrivRCgM5CK/4bMW9CLkhYjwMb4vfRQWkFV+YohZmbA9OLcgWAO9HE7E5YXyCxJHD7Wn8leUvjosAk4qi+rTxN7wahbmzqMPGN3LwgnGnTk5MR0AWV3HC6aJfEVNfY5E+8JNrHNHMKIE6Xzs6n2M1bXl8ojxHAdE7AL6J4WoKRnngMOeBhNQvlBmfibn4ejX9qjvz+pX+15bUM2ijTAVA6kTe8TpuhOAFGr7if75uieXtK3P7FYXLJ5UTqUD4rXUL8fj8nVwT72bx6qEEi95N9g2r63djibyz/qW65exwiU6E2BbO/cbBPEDFzyrBFrpRMBBFuEAfA2BGN6AEZR7yzF9YeMsFGx/jCgodzb5jq+9Sw32bxtNPdnz0tKad6aZ2ai5Q96YOx0gXjDgj1HPdwpFyQEmtqgFeVSp0QTtpjZND71Ls9Knw1UgCeRAtSCNwzyt7jqWR0gU04v/a7gkYm7/vXEuHPB1JxX05THEVkuTWTF1ZzBvq3UPkQcIJ9DT0WiDPmBgfvP9B0CFz9MfDKfKAGmqUg0QWUy7BvIiVP+C1zcEp5MfUnO5gEBZp/PuWvCwZrdi1C1igYW0IEYSH0DUXvZHq05ZsW+rcTZ3qSrgXqLT0491vaT+xNcCC1hnbSqCPDdjzaHJ2VydMIjmboS9xBDCg5dlacxASHA1IKJ1avXBZ01OfK15N5Jifp4XCtTdzfvnc0sAZBShBjbYwMT4XgcGt6WKjCRiMpq6MkWwI6lxXVa36aZaWMpdL/sBNmXphtClapMHLQNseOtE7uOMicTIXQwCBXEd5M6CSmpIg0A/ZdxlUz96jcOGLyGI8PL2+UNpewOFwFvefkM6sVwDRTuhdNv7FCL4T9YemPJ0qCPydpPL/WGCEfMu2ZABkEBWFVHh7+bP5LNCELi4JpaFSUg7mKeMNIZ1kDJml3q5PrbtSbdNp9EUTShJIFpTSEil7qHF51Q3WFKt1ekpwES22B9mD+AL9wNJ4OIDcGluhqjKLbdu91gU7GIBJqLv/tZ1BJmR/jKOdCjLtWybazo9YFB4h1TwsbyrA1J7+Z6IrUasNxPXgSFPXE+QmqF4buZ2LGN1KULgmHBkXzQPIBDgSJ8Jqu7m+mTAAFBVVIC28RzJM6kCBUaTOmFZpFybdEIJmfBdw+TLOmVL30eno04xDMpNzY1Ni2F0ALd4jNdvRryIOgDjay2tEUyvyQp1KdNlmlhGaW16NMIFbaP8Z16YWWkuvSrysyvWt/bV6vmKYqKmOoYLBrM8mH4rOhpGuD1yBW+poTmRYbQeAPJJhjY5ftW4ewnoYpwT4b3ioZP2lDWMLgdTTlrsNlzFd38Xo2AmTk5d84Wh0VRTOozCSAegEHTh0JCKFXgFWsFuWzlNVKb0awkoOu0hqg/PoYCXvF44joE4Gbn5Ua5J1EaVD42P0z89V0ygI++6AVVMA3P1+kxHd5pM1p0OfLFX3P7YdWyfXo1ViEx3T1beWoM13bwiwAkLWdDOGyngR6fRoy1miQo5W++HfEbJ4FcRCq1wl9bG9nyPQmAZgcR1FmheBS1oINMzOFRIW8WJN+4lGwLzEE3r8wIqF73X8KfCMC6OKk4I4xCjniebpcs0+rCjbo+dYn1XI7/XYuXIRjNrr9hPZWNgoaAlE7IYIZ7VIMbo8Q5eaN+FyuGEHnuwoMpDSTrM5Br1c5O9MWaEMNYZcRqVEWhIuclzEXhARxv+2PXpr11giQj/VeOBDdNVmGibA0LYJiGrUhHL4mCN7Tacdrn0BLu7TjB2BdJYBKDuhY0LQrKGNl7b3jlmN6jsQJAhUOZwSMWITL9pZGNOcWDDkwFLFwKeBhOE82mwak6jv+UV6UvQJ2P3jAcUuWMtdChqyRtJY/k783+09/eL5kiG3MMRsUNhefdIFhBbJf89aekIPphCK9R8gP7vQ+lvfpZt6pWeKLTvJywgxbVbiBjQE5iDP0uHMUitZhbIFj7tq3AbgAqLNv5G5SQ3dGaj3rmmP/73xOx9exPaKdCxiiTMkEuRpt1JP/pu3BP8UgN0fMlO9ow+OQJWvzoOH4bU62iN4ayJdXmJJgqtOFAuQd2jXDufh4CXZCr1jqkvWHsWaWRCbFheRXQKlnjiBfyySEZQ5LCjTRDo6jrkQHD5+9gPjVAeY6mozakE3gBSMLSitOIT/jvJv4/NzAZnzBf2d78zoXc8RxFwF4yDxvAcLlo/x/x0Hh1YV54e+IpvO0oSM58ECeyBvx6T4ne2GePfIUH/x3k7NAAjotUACZbuBd4104z+n8P+ZjVFSl39Vt8Um1yd3sTbGTevaWgkMwQ9udRMCVKPrA2RuLAr/GBwSdbLLnVban+10IO3NcSQXP4OMBrVr68v33LtaUAckaAw8yxxJ0evydttx9Lq3TBky4vh+0o/MxDOaFLdFWhbrJclM7jyUG1DdQkw/Ptn2Efor1+OhSzQDaI9OyZkWhDtnzgbj3UpQsy7uGeAiPcLBm9UzU7QNCM+ltutob8eH7LIH5dsszmugQQJpSn7TwQPWeEvAslFi+efM36B7edm7iHUxCAAAAAAAAAAAAAAAARf9n3I+91ut1ur4hCAAgAAEMS5lEEAkdC1cOw/jaBrG0MWyGXOYloE0EbSH9terrRLOkMXHy22FTTnic7Equg/l19AxT8wXcPoIi+6mDajd2CzmFabpql+2wchzZdMHiyeljW+xLdGK3U+JguAunB2VpdawCoSaQpWvE+ntMBkODOzn6XuJa0liW3uMyTLu5kYy5Nf29kNJBLT2/CokAJu/vO3bDw0nVbRCg1BgfXuOA/mMLrNLh50EYEbAnMhNW6EzdHNyrNjdJxDczU/5bzkliB1CJcjSveijCBYd6UcHk8Nxhc4bNkBz5YDfEfGin4TTf2MUQk56CR72QJHydZ51MM4hSgeeSkYKjivEfypiw5xPKsvv/lGvOZnfQLPcKeTj+Xk5YUJWu5n7g5361qPnCLFclMfoiXrXAHv/N4N8zuf1eaTWvKlz+z8hUxE7hwBBFuYg10I7cVkehHkAZLYKil+HqNTiS8ZUDLqbDGYSIywUNR9s6K6PwKLDCyNYHisKG+gkkG+p+lDM4tvWcpQmh7ZuiEhaFwjL98isNL5NUDfD72vpa7LEdB0RqCjS4ZOMQNK5MCcxALnXUeOanDfwSmhehvCna6ddy0C0bEADs65Fi9lUOEUARQsX0ujNFdKCcOs1MvxBbIBiCXWaT+ydSM91d3oqUb5Wsc2CzbkDER5SQGBnhCXsynkQ+CY4MN6DRYpc4fxXbtcjYRFrz3IABI5itMhrBxywW6J4uSxtW1a7UR9OxL94wvLbVo25To0NlgPvjSXGs748+v3K0l9Ybm6SGYT2X3QSj47PCXnVug0ODsR9Trz6IjacsZInAHlox+SllxIPl3tK3TRR3+cJk1SZRgI3w3XDdSEip6fFVVfpoKXOizoUF9BM2m1up8hL7zqyWx55QiOlP7JGaOPnZOESdPgP8z2Za+11TvG4Au+CJlh7vgLtjgrcUSNwQwGJoM32vEtfvfsAATGynHtahFBJYzs7GPt1WLgRGvF2+RKu8NO4ijZpIt1p7saTEtJM4Ye72/GIDev/yKZbhRMTeBWhvjWZbPPcO60lOiCT4v6cQpXA1KXXLrZlXf6Gs/XfwBybpvXzKIguFvtLK2YHnK+gI+SJNGg2ztpr3My7ge2pjVDWs15N+rvUvxu+ravAOroco3J69dIMEm7j58zguOfh6q/uOzNrpTJMTzUtr6rJJuuT9cIC+cL0NZ+u/gDk3TevmPxQ/mGK+SGAw+5DhUN44yME1Z/4lJ9o5bvqK2z09J5CsoN6sfK8vGDtI01l3WIzjqlvy/3421s29WPfk2dWjBblzN0hlXOEe3sEhsUNDe3zion+21axqesLWFVjmkjFpNTrDJEfjUbbmDyA33VqCn8Eg6j2IwxOt8qFCQwzhepXFmL82Hk6BqSMglJksbWh2Lfd6AXIQnOeXwAL1M3hlZ4sa/3k8c469Eba0z9/xHpHlrgolQXJwkPttYPeGDn9GOrnJ1o3aLE33vdKAAAAAYLHV4dEWT4xpw0Ol/qrTs27xfrA97uktzOFdwSyMklFhNQIL8ORmp1Zr44BElZU/uK1lU38m8Kwk3cFgLAyYSnWMsPJ89f0vLdIljzPxmWM0rZmIhArEIQeO+CFmrTz9bOEyf2R1CPzZzyYZqhY8L/Kc+idX788eUAAAF2ejbvYlUxMJBuM8uKGyypQgBnZYq33aPTZZ+48vyf35u8YFfDiKuIkz60uLYkh+LnGXRdOHPb5dkvQltUelRUhqCqJJPD38FPU3PrG47Ib1i5lsunRh+6f0oZv1hLizX73KjphCnrqexOXTRGFWOrpLOaxxYYKv2KrhXI35Smqe0L1IlJNhXiqIYvBFQ4PjXfogHp+ElSrLvAPp/HhUgQYvsieqani4WGKg4q77AjsYEH0uzkLG05K1MZjMBnz9pdJLwLsuF8LN3UeQOeMrCSAzl41gJhQeYCePUgAj5CvgqQNwYrOwS8A7TvKFBUgUCQtBdregOxn7cvwXJ2D/aHgnuLlrcJEY9UeL6I/zhX+NDRLZZGzbvHycISlngtlbbv0Bic6tG8VWEB5WB0dO81PigRGDcI5BDYu9BsRDm42v1XXuAxx3empu3yajUCP/DSH7BH76GsdnqCBIh3rh9KwaEkdrpJNRIWX8m9uI1HTXB72YZI34vl++zuQy76PnU/TrH2jY4oe2KWsvlRGY3fbuXBrIjNV5VnnhWPKREU8vASh1SH1qrZY0GZ/nv85DrDltQvTwUNLiqVPI8hWYS+W5vpfKwVmKej9RZzXJiLMHQAhP6tE5YvbNbGc0HlwJXrlHGlMLf74G2SphESPM4C2oE2oJMSYeFhgSPeV0x1XNs+bCfzrtrXUv4HcU3/Tmf6XXvGTouiTvgJ6BWzo2hgaEIfN8v2SZoQEpg5rZTAnkP0G0VuViWt9GEI09eIlE+A+SaeIeH0sg2hHj4q+Uu7VZqVQH+JsM3ZV3iAEy9+zCACSuoKGKh4ekcjMmZKkKURyUEF/O94ZtPnuboUrE15Q9ZrDFX1JtLPsqTMXWnUZDMVO9ps4aueHy1H0EoxWPVRkY1ozKBoXAuovI9QTqNcTD0goYvWWpCJkKgzbMWlykj3lltMWmmFG5+z0+PnAljcuNwoJokxMq2J4cXwczwdwp6FiIIK1tYP92jtZ9Qvxjm4GdclAeWtupP8n88usKpKMh9S77ENrynX2rhI+zjGfl0DTlB0nPr+RUYYKQbLAmz/Zbv1ypGvoty3AA7IT2hh5XS3Bij+XbmKTub4nGJLLG36yl7MKjfoHP04XbDDEOVGEFCyff4w7GrChkHHscg3vK726TEqjHu/Uywrs/LO/W/rfCC7Jz1MJ5cd34qJgB0Q66kSggEbCIW2FYS50WFJXurxiQfDX69C2ZigAmWErC+GVP0CSMPMykF6tgZjZX54hD2nREz5FGSu+DlMQC+PWLh23MQHbz5em1VaMUVmw67jW9UhB3139N0hTeu5kxR165/rb5Nz8ByBkBY8/E9Pdw4jTr8uFcohzb+unWvP2b1V3BMtvtnxOuQtrgeCtZFUhDDMhZ8OJnBEEzk6SyNdZUS9Bbu/z2ulpEHrepc2rdk+cy+Hi1oh8hhaNfpvgFH+eU5RXcod3n0ouXMWa93TpxD3jIAaLXu+uONNjZNEjLKdErTqAm1uAsg1rmU1+oHQJZaIvwSiWME4I/JhgaaNuYTBYiyUSlGeEWEFIfru8TsmAPK2d8vL04idOKHcZSq9NeuWFUACSmBZBhqsvZaFCHCS6HoF1mFNcKiwfJS/L2OvAB6EVYXN7EZMhWp3I8MBBAqoZFO26SjbN/WRBV3Oe3PjXa9oaaj4idZEDlO9kyBKukhgde4WqiE4NW3wHFGt5xO3zIo1EzT1SR7AIGSbYDuL6kJRw8bvuSX6li3fgLoPgW/77/hyoW3+DonVi0KRLoOzJHXpRr2nL4rrhIRhq1yMQ/pQIg5oRjjgNpusY3NEVB4w+uvMM1dGGty8mkzwzEZxf5LkZ82dgLzMlB9HVP3JQ6K15r1uokXpxE6ZVFdUlsokEzI5+zSQLSs3DH+hFpqJRzAeDruWM17LXAeWIARKBWWXCjCrnJJLFLxYZjpbdIpy87JdvihMz4/amEHVOMzgg7VwrGNNz08TLyRVl9whwrAk6EIPpdjThDEnHzF93lX8rnxJMNDiqSRQX+pkk/6Rk/KdmnT5R/XOS29BLhrUKTb60RbpNF9lG9AC8g+WNgwli3lbJYZbusebVdGmypGLrsvqObDOXk+axsLV62QPwCoxO0dfYfRavTQJFki7dHNCqroR9mT6I7K0Ao7/Rj4BAN4VqbZd1NgIKAOJuPZ4qV0zpIlWeE4C5pa+WD2z4GUzf0N2flHW7tiro5BwJTSP4VYefMFyaMGHRqOsAzisMyMKL+OkvjxUlmJCS4+axHWmRY8DQVnGQiUc/loCm/XIJ8yuqXlEzNR/Sr2yvwq+DNahlDxQ/XYCcL+KN6A9jkmh2mp2Pdyed7PYOuMsHlCguk/ZPYEovC21O2fKOEUecnvaK5jVI4PKgCnxUO2ln5f4h8r6fsv+5OhvB79Bxyn1TMpTcv1qttoYq7HejSZy0uuqtIrdZXCIJS9LFRZ37Eze8gobHs32CD5CLDqK/ovHvsPY8gDNp9Ay6d4+0SO7d2Nm1Sqc7ardXB8RAPpdY+woMeto5CPVUb1rjpQEkWF7u83pL6Df8Cg3nY5aBegtrtriMbNNdP4ReGvaMRwNLe0QcF+Jxwcm1oTMn4GFfBbYBqpzwdzW5l/yW6xdfUIKNwsAzMb+Raq20FlPYD48V/+cz7TUYzCIWx4DAQBMtsKb8YhsI5rxnPsYgI0JhbDZ7Xlb61oV4qUW29IYUsyJa7fIqAsKL75tYCsp3HBT9qgBVfxobVSn4YMHvJ1u0OBSIOQ+F9UxhNzyNvtDqcY6iFe9h/Cu9gChkuJbms0qXbcl9fuCdiJNIAF7vY7NKF6SRvcOvmVY3Y9u0cKlCtXy4o37U167CONFafb1BndSnpbCmQL5lTQQwiSqL1g4i1JJuqa6TIrJjAKIUC69D4WirxRJNd+9QmkP7W90afAorOfb23A+ajg+lEB/nSkjMQJnKaHVvzdXoVPPI/aV2MPFZlSnNLpocjL0DA9G4lEUOXQxSjL6hhNdONBQPXfLP2ttXGNJCoRBqdopQauxiXr4LLXG4ooQsAHToAyfjs+NXBMQSVKbdzHE69szqYbO8e3UCXKtFr/EkVSiBZEkziO9mEu/p6ZUv4od5xOeJ/u3WNjZYd4Q3GeuOQxWtTsfNqmgTaUL5TaBYlO0giwGnP1UAGDAxbBoSYTxosPfMukFX5zn67OEv8y6n4EPdWpWpiwP2nBsI8Nd23ZLEpwTzInkGz+iwOsOk1RHUsQ+hU35157d6MiH0F0mCV+dzdoOHRN57KgDChRPKe26zt0S0Gcn2xAMzGKEu9KHR8CPmGNwPYAV2K012k59noeTq8z1EI3m6LmVSmVJ845/j7UhlkKB2Tj3qkfi5TeiHWLLdMUJF16RapHjWEgYr2q9+mEvIIt2hvmCz90GbY99b+Ctm/5pEquKW/mz+OQwXARBzcgX90EA1/kFfxkzJ+ftt89GFI4qStd8D3Mhpzw65aKbUp8CJVZYnmS4DsYe+DCDw/YgaZHUHRajyYrEgAvbnVYfjhR9tBJVPIm/xhqXX4kVRaFDE90opvzHyx57YmfDpIOPr2vZZxPFQ8eSsDlrXoeTNn/Ps0IsbeI9VxS382KWln5Jsn8CsBZhdvXVDgkIIBZ4eCgSQzDaBvCOh01K3XyZolYuCiTB8wc26wk4OABmxb30tjHCA26g520PeV2AEPJaofDLVbkspWG73mSpRpFXqha8oT+xNHsMVGiD/q6z1ITy/2yzDKVAeQRDIVU2n6CbTup4TMNwOKtXNu+SjKnUXoFxdr5uSCND/UHdGzxpf+bSXRyrN9wKubJWXfyiH2HNx3kZNnx0nN08IoFWJw3Pu97vLbGL/xHnod8FDDNSKqpxe0t+bL25XPcixtj6yVhnJsoOi3Lk+ILAYTKAHJzeADfTv8KpDgUTd0rFJE/jT93b7T2LnoxwfU77WypLQvkiWhX+LeoYqoVuzzVST9zmOG11HkLaGskT3aYu99wvJlW1Yt4/EZx+5Mbj66FORDfJYO6idPET+v0ghpmE+0+HNwzDntKCRSbMi9aMeZ75UMGO+CNWo1emh7Bp3KJRauaZT1zwLcYSUkqwUqN1MH6ri2mTttp5t30I0I2JQwP0A4AnZkI/aYlB8HcZM2ZotzeabLIGWYDzJMaLZ9Q87MHeURks0V7M7yZ1QucvrDcI7R0CxHxtn2oB3brsBCa0CL6eSOc3JBtIwoRIvORaAbljnMz8sB21ZzrU6h4c07kLPUr7z5Hg4sZNW2MK0XRGuDi2DNRT+TuXgZXvCL1ZPM7DlgEfQg+BwwnaeAgE4kLyBJtNep+YkV6XrnejYLgEdfMVoJkx8J7+kfp4HLUDAtUPYmLAxPxt53D9wHUUO6P+cym08ApoxA184M2Z+W9lCSj+x27cn/erhhD4wEaUlbVVpZ4dl+E2dqNl2iZduuyTCG53e5QVe9ry6sHDqAf1aU3tX6AWsM8c8ky/R85tRBQFLXoa4CMGyXNzMK2Mohe+XGTqbv6q84xgUBv3Xi/ZxgmCAbv5D7AzdaSofoxEbaSbXcezH7oa+NL4kMbfKamrrYQwogtlLUCrKhixBnUk4BWAFlgpPBhvKqNr22cCUnNLYkK5SfuE+iaUm3I4fis+GJ2xA+xA80UbWF1X6xfWxU/K3QYzZhXcAxIgGUXWC70cHH3FF29v1KdidBz6yK5+6ZTBIhhdm79pMX7DRUpyCkKUjIlKQa18hTjrW0Acyg0glylSpcTZ2awMg/2oSUh/ehakz7bMQmqXhyHItCIC4x7PLgXOCTKJwvLJeWS8sl5ZKgJ+X/PxlAd/gYM4qSHZbVNyTYbwiql/AkUcpv1FfbbIJxf3BXRg0ecbv58aj7qTLgTdkgNMDetqvtUoiKFnPdAVMHFWwTcal8jXtnsHAoH0akK9AgDlpTL/CjjXc0tFheYEa1U070A6E77zYAtHaU7/EwfSr0fHMFqrUxj9yI0TTV7kQDp3D90f82MeH+nvZaTTLxwNmoiylScxctGfPt1kBlI/3XeZmq4beNXuPvi8jtHPiFOUTki8T8/8I+Z0bGKPDc2AbSZo2HCyn6S7n04rVnMh8LbL4rjpLK9HGUULc71H6kdf1phAwl78ASJ7ZeJvtMjHehxfnxx2XwqfTnaHY4Sdi4Lrj4UOrdEHHSoCMnBD4LOaX06hTqcKGxHm98NT9hHUcRJX+gUf0olvlSMvzU3CDTnN3jG0eeic9VpyXYxy98cYncY+JGUmlZ3pW+Srh3wxap2p4V2BPPPZAqH9PpecbkdTplhoChOQVMuuJaCz3+7E1HKtyNARu1ureZqay0q8lcx5EZI3ECbh7ESSXLW2XcI6LR7zFRqC6HbSzLan+yzBEwGVgL7M5XbXmfUBKNE3aB6/ewdvqBaj/LHSikGa+cFkQ9wvKJs8BR/bjNv8Cs+zrHmioeJO2R6LDsZEfoENITg0UcMn8zcWHO8R1jqBFEyLriRWl2pAKs/ehKJ3AdSn0Qkejf/A1p2Ml5M5+kiaQCFQzWZpyJ1gSziywbA9gDo2/8zYnhQt5i+Mu4SVbuG1G9X5obLjCVO56o3VZE/kGGgI0j6rM5N7BBxqq4yT7I3pSAerbR5rp3aLO5m2dWpG4HWYXlbV0LPHzfIIJoG19x+xWWdTTfLgdlc92Yd8sUWOQMxVyKEmbsJ2XJwLKIjfbLkDqnDAWFdfSAujiXjGcvz8XiAhSR5BsZLijzYJ+KoROsDUQUNdj01AYhc8rUUXowCoVL8WMeig0mUz1BNKsjvJjJA7z7EREt4jI9Wjj1CR9r4tFxeF87ENTx5Z5clZVuQgaghli6Blwr/wQ2KhQMATATSL29JJ/yzjTarBkeENEWc/STzwZkXBPZAGAN1gjrE7VFFiPjBVY4n2L/trGsppgGyimmAOw8BWwT8BjieqVURX7nr30WJ+YeKSN1hYvKInVjV09FxwLFIuoN+R+Yp2OiGnqIOMsruF79Zwdrj5O1qXuNhevGfMXQ32bTlwPH2acdiBlz5/5Cxlv6JV3kZri3At+Z8SfdVvQ4WIGmt7E9cKMBlIk7FHWJ3IH/px/IvaNCfTxSMNJ2fZFQStKbx6zfZcjCkYBA+JG9EG9zVyYcRB61B0hrRuDR76dbciWPlyc2Rf0raG4Krfvx0VChApm2LVVz5U4QZfrnnLcsIuu0Kz2FCGu9c/n66fjfoHKKZlwuKvbAn9wqHUKqZwYuMO2RcfCPnd+zl3pG420eL6YvPT4PkOdO4wylPDzfYAPIE/WrXJnliOVY3hK3s5xWOkeMqz4Lpoc9RO/rwZs2qdC5QLheiALAgIrY96quFHYbfhHtexb0IYlWRejCQZGqG+mPmb72n+zbOb2rd3M6/gWQg2oaTF9Y+NUh5fcmg1Zkof6MLFlZR7xW/h241k3KdYgrnKzaAntfdHEvlALhDsLMwPJFu92zE/HlO2vCwnGFvNuAy38bWIFFd7/lnXSYB3STuvqFd+P2QwJEZsRmAeBev3cn3xFqSU2Dyq+7usMt9Cr11tf0ElhpPu/Pys7jSADVnJAxW14uecejrcvgi97VXUbknpg7AVqr2XYnG10YTmLZwQtQDpv6Xh1auw3x0B05DuzZ33Hn4zGTaTSWuU9Hr9jA3gS0IpmnHyfCSOdErdFDIEj55dfPZjQJmFJSRpX8siedRlZK9mfe+7s67/n/Kd2LRR9V5si/pX26BRlV2Hg/N9HsUFJsvwoFbeP0EE38ox2aU2Bc4sMC3mwFk0LePnzjC5pFVJnToRJLzR9sQLKfXuMDttr7FHPu3UHUASdaoYaOKENPVy2NN7HHVt5eNdjPf4NWN/ltldMmB3uwX0XrenAxLJ5FrXLa+BmmSSBJlRJ543YPRJmYXY01QI4kfYffW3ufujo0OcuvS6ubpgIEA9pmAImet5WCtcx612o9QiPPqFrh/M/AyB2HmFk1xAUB2hwyT7iCSKl/kHCtXNbGXtjBHMTITuBCN+rfkQNkun6xAMaw9wM+C73lipGimMbVBL9DSBR2MFn5FgE28bjVQAX3h1ztJ2yHuO2vH81hfWNV6vLSde8F36J4U+aQv5czoXuQISoxPsPPNwQVGOzu7xzgg0uVnrAKKpIbCiMVkB3iMj6Uc8msSovkybYcP8MmprIcePr78Zcw7Hmm696CuV1N5hAKIACt60ue6rRB6SbT1c6R0byveMdIMXLiA5Ock17J7EuSZ3hyf7UMlzSua48Fu7Tysd/vrwaYnz/CIa2Jb/MmjZCav97Km1MYhuy3PWFE1LVtx6a6CbuKYmNKKx8ZhXt05YSaqd6LoKpjgdqLrENoP+5SE+VrBAa70lZCNcA0Rt7z0ppykYMNsaiEU/AF5Q7DJCWSscD8mbsVOYvc7yRAb0dVKJENtEAcOWf/aA4akKj6vLTgj3nK7ohY4izyBgnfwtMWBt4/TonUyaqASIdiN0bQ1vwS17mbXKc7060p8Jz1o4eOacmr1fLiE5eW84kU5cUEVXUgNDi+EPfRfzulwkBBEy6x1y8jKAYKbFQOXjGxCrrTY56hWhj0ywB7Gx14BfT4dWy3UiF0358HxVhE+REMw3BBw8CQ/2sEG2ThS7J7+2VaFaT+l4u3r8k0pbHlGiNxnm2WU43sEMXhujySibzhWwBAiFXpZaXX2IY8cD1txWMaPWcHGv1lsdQzy92tGKHPNdbjuRvXs13+y8s9P3LixLYSsuEXYSTAhQxgXcuUT9hcXxF8bFFASkhCPntGzgl7o5Q0CqhSIPeQgEmTtweahnt9N2sI33/4LzeJm7Q3zoKJXhiO2jzBnonvbPq/WhyadV2N1iLiDDEq50Dw2bA2BPB5BqK7VjpbOh2l7jiBYXDP78+x4jP+vtEzqS2wLIVtvboYcp0R50S3DM+GWirDEnyFqkjKCiFjtoI3uNU7ErhTKviL43AP3gYjqZfr9KyY6o2aIFFFHj1yYZLgNofnYMkxHirzA0sjz8LtFZ/DYxmV9MrhsPcAYrmjJLMDKkb+ptM1xgz8Mk4Jp9a52OExu2us2gpNeF3d7+jxjjnH1jIhY7H0jYPHKL0dhu/nQKlAe0/i4vzvPCPziWh8hGXIb3WHLoA/MHnS5EU7sfSpWGf8ucrEIbEjQQptBzXQg7i0qPGH7RP7YcP1unIAA4rLgBR+ewh4w5ToReFLVOVOGaeCKtW3K6fZf90ZEaIExJUlyqxjrRAfBXQ12m6E4J8wOnOfUs5xkL++fgWryhcZqjChIf0rW9bje79Z7vYZcehvCT6q9ScYmYfUfFnl4KY89kzRw68aLdlKtRAVPn2H9zJNMUppbfAhS63gyZ54Qk6JyVOMPfJyhjvTl2wxLwpLtey8sT4lHDt8rZCi3N9b8CabfdhfQOsrc72FUwRv1pAc2pYZTJmEnV6qPDe98aD6hjfsMsRCRHpjWKvtho9oaMmA9KtTHqTA78S5WzLjBMiqENppdrpUmV14IdtsgVF5CzQG5QbfFepuA37OVlwjYZid6SU8hTvtYQKVhXFUj98TKdHwhAtlOuv1am/GL+gunbxLsigk3nW1VbSt2O66b8KEikVjKX+ERN9W6NNOd9I3DReo2pc+1yGYisHe9RUtG6tvjpoFGd4gdV9osQvMo4rH+O1s5ovsWxKTd7Sp2aB0TBecraDmto2zYeKBgp7v4JIpjDl1E0/u0oI9nowuPaymS2Jerdx98DBWP7DTwwjQdmIgXZfYybmCgV+ci6rqoeR4qIpnpwNz7Nq4pEwIkg55hR5LxvzGTITT56Gs/XfdkpKc9bsvc/HlRBRB8DPL9uXCHejDDHuXqMVAlgL3kdfnji9w4wNwCD7NmPL9ibtmZZJ4B39YuPjl3buq6YbEzl7eZUCo/TqPIupzee9GzbsKFRbsvlpL/kZZBUc8A+LoBNtVRvPsjEtK5AOE47zgsNJuJbXrqOb8zKlAI02fAYmPIJXIwe4XW5EfHVjgcoYEAAAA",
+        "height": 8765,
+        "width": 412
+      }
+    }
+  },
+  "analysisUTCTimestamp": "2026-05-15T09:29:48.373Z"
+}


### PR DESCRIPTION
## Summary

Captures lab-data PSI snapshots from `scripts/perf/baseline-run.sh` for the 2026-05-14 baseline and the 2026-05-15 post-#185 run on 6 prod routes (home, blog index, jobs index, one blog post, one job, one client).

## Why keep these

- Single-run PSI is noisy (±30-50% on LCP across re-runs) — not a credible regression signal on its own.
- Kept as trend reference: once we accumulate medians (or Vercel Speed Insights p75 RUM stabilizes), we can compare against these JSON dumps directly.
- The 2026-05-15 run is the first snapshot after PR #185 (deferred member/team resolution on detail loaders).

## Test plan

- [x] Files are extract-only JSON dumps — no runtime change.
- [x] `pnpm check && pnpm typecheck` green (no source touched).